### PR TITLE
Skip Vectorize embeds when embed-text fingerprints match

### DIFF
--- a/docs/contributing/adding-capabilities.md
+++ b/docs/contributing/adding-capabilities.md
@@ -400,12 +400,13 @@ the domain modules.
    keywords, or schemas, production deploy refreshes builtin capability vectors
    via the guarded `POST /__maintenance/reindex-capabilities` endpoint with
    `{ "phases": ["capabilities"] }`. User-owned memory, job, and saved-package
-   vectors upsert on write. Unchanged embed text (same model, dimensions, and
-   fingerprint version) skips embed and Vectorize upsert. For a full rebuild
-   (embedding model, pooling, Vectorize index dimensions, or disaster recovery),
-   POST without `phases` (or with every kind). After Vectorize data loss,
-   include `{ "force": true }` so D1 fingerprints do not skip upserts. Each POST
-   is time-budgeted; if the JSON response has `complete: false`, POST again with
+   vectors upsert on write. Unchanged embed text and Vectorize metadata (same
+   model, dimensions, and fingerprint version) skip embed and Vectorize upsert.
+   For a full rebuild (embedding model, pooling, Vectorize index dimensions, or
+   disaster recovery), POST `{ "force": true }` without `phases` (or with every
+   kind). Pooling-only changes and Vectorize data loss both need `force` so
+   matching fingerprints do not skip upserts. Each POST is time-budgeted; if the
+   JSON response has `complete: false`, POST again with
    `{ "cursor": <response.cursor> }` (and the same `phases` / `force` when you
    set them) until `complete` is true.
 

--- a/docs/contributing/adding-capabilities.md
+++ b/docs/contributing/adding-capabilities.md
@@ -400,11 +400,14 @@ the domain modules.
    keywords, or schemas, production deploy refreshes builtin capability vectors
    via the guarded `POST /__maintenance/reindex-capabilities` endpoint with
    `{ "phases": ["capabilities"] }`. User-owned memory, job, and saved-package
-   vectors upsert on write. For a full rebuild (embedding model, pooling,
-   Vectorize index dimensions, or disaster recovery), POST without `phases` (or
-   with every kind). Each POST is time-budgeted; if the JSON response has
-   `complete: false`, POST again with `{ "cursor": <response.cursor> }` (and the
-   same `phases` when you set them) until `complete` is true.
+   vectors upsert on write. Unchanged embed text (same model, dimensions, and
+   fingerprint version) skips embed and Vectorize upsert. For a full rebuild
+   (embedding model, pooling, Vectorize index dimensions, or disaster recovery),
+   POST without `phases` (or with every kind). After Vectorize data loss,
+   include `{ "force": true }` so D1 fingerprints do not skip upserts. Each POST
+   is time-budgeted; if the JSON response has `complete: false`, POST again with
+   `{ "cursor": <response.cursor> }` (and the same `phases` / `force` when you
+   set them) until `complete` is true.
 
 Example (assuming `example` exists in `capabilityDomainNames`):
 

--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -1353,12 +1353,14 @@ namespace. Vector rows are derived from D1. User-owned memory, job, and
 saved-package vectors upsert on write; saved packages also mark
 `saved_package_search_index_debt` and reconcile after the response. Each upsert
 (write-time or reindex) records a SHA-256 of embedding model, dimensions,
-`vectorEmbedFingerprintVersion`, and truncated embed text in
-`vector_embed_fingerprints` (`user_id` is the Vectorize namespace: the account
-id, or `__kody_builtin__` for builtins). A later upsert with the same hash skips
-Workers AI and Vectorize. `force: true` on the maintenance body ignores
-fingerprints and rewrites Vectorize — required after Vectorize data loss,
-because a D1 restore still has the skip rows. Bump
+`vectorEmbedFingerprintVersion`, truncated embed text, and canonical Vectorize
+metadata in `vector_embed_fingerprints` (`user_id` is the Vectorize namespace:
+the account id, or `__kody_builtin__` for builtins). A later upsert with the
+same hash skips Workers AI and Vectorize. Metadata is part of the hash so a
+memory status or category change still rewrites the vector. `force: true` on the
+maintenance body ignores fingerprints and rewrites Vectorize — required after
+Vectorize data loss, because a D1 restore still has the skip rows, and after a
+pooling-only embedding change (pooling is not in the hash). Bump
 `vectorEmbedFingerprintVersion` when the metadata contract changes so hashes
 invalidate even if embed text is unchanged. The bounded
 `POST /__maintenance/reindex-capabilities` sweep rebuilds requested kinds

--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -91,7 +91,9 @@ Deletion must cover these user-owned surfaces:
   conversation state, raw-fetch state, and transport storage before revoking
   OAuth grants.
 - **Vectorize:** memory, job, and saved-package vector ids are derived from D1
-  rows and removed with `deleteByIds`.
+  rows and removed with `deleteByIds`. Matching `vector_embed_fingerprints` rows
+  are deleted by `vector_id` on those writes; account deletion clears remaining
+  rows for that `user_id`.
 - **R2:** raw USER email MIME and attachment blobs in `EMAIL_BLOBS` are
   inventoried by `Mailbox.listBlobReferences`; the Mailbox store derives raw
   keys from owner/message ids and emits only canonical external-attachment keys.
@@ -248,7 +250,8 @@ Durable Object export behavior:
 
 Vectorize entries are intentionally excluded. Memory text and metadata, job
 metadata, and package projections are exported from D1; vectors are derived and
-should be rebuilt by reindexing after import.
+should be rebuilt by reindexing after import. `vector_embed_fingerprints` is the
+same class of derived skip cache and is omitted from portable export.
 
 Cloudflare Artifacts repo contents are not inlined in the JSON export. D1 stores
 metadata/projections, while canonical package, job, and app source lives in the
@@ -1348,7 +1351,16 @@ deterministic so upserts and deletes target the same vector.
 Search paths query only per-account namespaces plus the reserved builtin
 namespace. Vector rows are derived from D1. User-owned memory, job, and
 saved-package vectors upsert on write; saved packages also mark
-`saved_package_search_index_debt` and reconcile after the response. The bounded
+`saved_package_search_index_debt` and reconcile after the response. Each upsert
+(write-time or reindex) records a SHA-256 of embedding model, dimensions,
+`vectorEmbedFingerprintVersion`, and truncated embed text in
+`vector_embed_fingerprints` (`user_id` is the Vectorize namespace: the account
+id, or `__kody_builtin__` for builtins). A later upsert with the same hash skips
+Workers AI and Vectorize. `force: true` on the maintenance body ignores
+fingerprints and rewrites Vectorize — required after Vectorize data loss,
+because a D1 restore still has the skip rows. Bump
+`vectorEmbedFingerprintVersion` when the metadata contract changes so hashes
+invalidate even if embed text is unchanged. The bounded
 `POST /__maintenance/reindex-capabilities` sweep rebuilds requested kinds
 (`phases`; omit the field to rebuild every kind), keyset-pages memory, job, and
 saved-package rows, rebuilds builtins in their reserved namespace, and returns
@@ -1357,7 +1369,8 @@ a `cursor` so the caller can POST again until `complete` is true. Production
 deploy CI loops that endpoint with `{ "phases": ["capabilities"] }` after each
 production ship so only builtin capability vectors refresh. A full sweep
 (embedding-model change, metadata-contract change, or disaster recovery) omits
-`phases` or lists every kind.
+`phases` or lists every kind. Disaster recovery POSTs `{ "force": true }` so
+restored fingerprints cannot skip an empty index.
 
 ### `entity_sources` and package import contracts
 

--- a/docs/contributing/disaster-recovery.md
+++ b/docs/contributing/disaster-recovery.md
@@ -238,7 +238,11 @@ node -e "const fs=require('node:fs'),{createHash}=require('node:crypto');console
 
 Restore rebuilds the derived stores below; do not treat them as recovery media:
 
-- Vectorize (`CAPABILITY_VECTOR_INDEX`) — reindex
+- Vectorize (`CAPABILITY_VECTOR_INDEX`) — reindex with
+  `POST /__maintenance/reindex-capabilities` `{ "force": true }` (omit `phases`
+  so every kind rebuilds; follow `cursor` until `complete`). D1 restore includes
+  `vector_embed_fingerprints`; without `force`, matching hashes skip Vectorize
+  upserts.
 - OAuth KV / browser sessions / provider tokens — users reconnect
 - Queues, Workflow instances, Durable Object alarms — recreate from config + D1
 - Derived community icons and ordinary KV caches
@@ -419,8 +423,10 @@ import init/ingest etag. Without that prelude, drills fail with errors like
    unless its final response has both `"done": true` and `"verified": true`.
 
 Disable ingress / put the app in maintenance before execute. After restore:
-reindex Vectorize, re-arm jobs/alarms from D1, recreate queues from Wrangler
-config, and expect users to reauthorize OAuth and reconnect MCP servers.
+reindex Vectorize (`POST /__maintenance/reindex-capabilities` with
+`{ "force": true }`, omit `phases`, follow `cursor` until `complete`), re-arm
+jobs/alarms from D1, recreate queues from Wrangler config, and expect users to
+reauthorize OAuth and reconnect MCP servers.
 
 ### Durable Object point-in-time recovery
 

--- a/docs/contributing/environment-variables.md
+++ b/docs/contributing/environment-variables.md
@@ -284,12 +284,12 @@ Worker secrets:
   saved-package vectors upsert on write. Omit `phases` (or list every kind)
   after changing the embedding model, pooling, or Vectorize index dimensions to
   rebuild those rows too, with per-user `userId` metadata on user-owned rows.
-  Unchanged embed text skips embed and Vectorize upsert; after Vectorize data
-  loss, POST `{ "force": true }` (and omit `phases` for every kind) so restored
-  D1 fingerprints cannot skip an empty index. Each call is time-budgeted and may
-  return `complete: false` plus a `cursor` to resume. Use the re-encrypt
-  endpoint to rewrite remaining pre-AAD (2-part) secret ciphertexts to v2
-  without rotating `SECRET_STORE_KEY` (see
+  Unchanged embed text and Vectorize metadata skip embed and Vectorize upsert;
+  after Vectorize data loss or a pooling-only change, POST `{ "force": true }`
+  (and omit `phases` for every kind) so matching fingerprints cannot skip
+  upserts. Each call is time-budgeted and may return `complete: false` plus a
+  `cursor` to resume. Use the re-encrypt endpoint to rewrite remaining pre-AAD
+  (2-part) secret ciphertexts to v2 without rotating `SECRET_STORE_KEY` (see
   [Secret rotation](./secret-rotation.md)). Local dev uses offline search while
   `WRANGLER_IS_LOCAL_DEV` is set or the binding is missing.
 - **`JOB_REINDEX_SECRET`** — optional Worker secret; bearer token for

--- a/docs/contributing/environment-variables.md
+++ b/docs/contributing/environment-variables.md
@@ -284,9 +284,12 @@ Worker secrets:
   saved-package vectors upsert on write. Omit `phases` (or list every kind)
   after changing the embedding model, pooling, or Vectorize index dimensions to
   rebuild those rows too, with per-user `userId` metadata on user-owned rows.
-  Each call is time-budgeted and may return `complete: false` plus a `cursor` to
-  resume. Use the re-encrypt endpoint to rewrite remaining pre-AAD (2-part)
-  secret ciphertexts to v2 without rotating `SECRET_STORE_KEY` (see
+  Unchanged embed text skips embed and Vectorize upsert; after Vectorize data
+  loss, POST `{ "force": true }` (and omit `phases` for every kind) so restored
+  D1 fingerprints cannot skip an empty index. Each call is time-budgeted and may
+  return `complete: false` plus a `cursor` to resume. Use the re-encrypt
+  endpoint to rewrite remaining pre-AAD (2-part) secret ciphertexts to v2
+  without rotating `SECRET_STORE_KEY` (see
   [Secret rotation](./secret-rotation.md)). Local dev uses offline search while
   `WRANGLER_IS_LOCAL_DEV` is set or the binding is missing.
 - **`JOB_REINDEX_SECRET`** — optional Worker secret; bearer token for
@@ -294,7 +297,10 @@ Worker secrets:
   (without a full capability/memory/package reindex). When unset, the jobs-only
   endpoint returns not-configured. Production deploys do not refresh job
   vectors; those upsert on write. Use this secret or a full capability reindex
-  when you need a jobs rebuild.
+  when you need a jobs rebuild. After Vectorize data loss, use
+  `POST /__maintenance/reindex-capabilities` with `{ "force": true }` rather
+  than the jobs-only endpoint so restored D1 fingerprints cannot skip an empty
+  index.
 - **`STATUS_INCIDENT_EVENT_SECRET`** — optional Worker secret shared with the
   status worker. Bearer token for `POST /__maintenance/status-incidents`, which
   fans `status.incident.opened` / `status.incident.resolved` to admin package

--- a/docs/contributing/setup-manifest.md
+++ b/docs/contributing/setup-manifest.md
@@ -685,13 +685,15 @@ How to get/set each value:
     `complete` is true (each POST is bounded to about 70 seconds; CI follows the
     cursor for up to 8 sweeps), refreshing builtin capability embeddings.
     User-owned memory, job, and saved-package vectors upsert on write. Unchanged
-    embed text (same model, dimensions, and fingerprint version) skips embed and
-    Vectorize upsert. For a full rebuild after changing the embedding model,
-    pooling, or Vectorize index dimensions, POST without `phases` and follow the
-    same cursor loop so existing rows are rebuilt with compatible vectors. After
-    Vectorize data loss, include `{ "force": true }` so restored D1 fingerprints
-    cannot skip an empty index. The same bearer authenticates
-    `POST /__maintenance/reencrypt-secrets` (see
+    embed text and Vectorize metadata (same model, dimensions, and fingerprint
+    version) skip embed and Vectorize upsert. For a full rebuild after changing
+    the embedding model, pooling, or Vectorize index dimensions, POST
+    `{ "force": true }` without `phases` and follow the same cursor loop so
+    existing rows are rebuilt with compatible vectors. Pooling is not part of
+    the fingerprint, so a pooling-only change also needs `force` (or a
+    `vectorEmbedFingerprintVersion` bump). After Vectorize data loss, `force` is
+    required so restored D1 fingerprints cannot skip an empty index. The same
+    bearer authenticates `POST /__maintenance/reencrypt-secrets` (see
     [Secret rotation](./secret-rotation.md)). Local and preview environments can
     omit it; CI skips reindex and execute-smoke when the secret is unset.
 - `JOB_REINDEX_SECRET` (optional; jobs-only reindex)

--- a/docs/contributing/setup-manifest.md
+++ b/docs/contributing/setup-manifest.md
@@ -684,11 +684,14 @@ How to get/set each value:
     with `Authorization: Bearer …` and loops on the returned `cursor` until
     `complete` is true (each POST is bounded to about 70 seconds; CI follows the
     cursor for up to 8 sweeps), refreshing builtin capability embeddings.
-    User-owned memory, job, and saved-package vectors upsert on write. For a
-    full rebuild after changing the embedding model, pooling, or Vectorize index
-    dimensions, POST without `phases` and follow the same cursor loop so
-    existing rows are rebuilt with compatible vectors. The same bearer
-    authenticates `POST /__maintenance/reencrypt-secrets` (see
+    User-owned memory, job, and saved-package vectors upsert on write. Unchanged
+    embed text (same model, dimensions, and fingerprint version) skips embed and
+    Vectorize upsert. For a full rebuild after changing the embedding model,
+    pooling, or Vectorize index dimensions, POST without `phases` and follow the
+    same cursor loop so existing rows are rebuilt with compatible vectors. After
+    Vectorize data loss, include `{ "force": true }` so restored D1 fingerprints
+    cannot skip an empty index. The same bearer authenticates
+    `POST /__maintenance/reencrypt-secrets` (see
     [Secret rotation](./secret-rotation.md)). Local and preview environments can
     omit it; CI skips reindex and execute-smoke when the secret is unset.
 - `JOB_REINDEX_SECRET` (optional; jobs-only reindex)

--- a/packages/worker/migrations/0021-vector-embed-fingerprints.sql
+++ b/packages/worker/migrations/0021-vector-embed-fingerprints.sql
@@ -1,6 +1,7 @@
 -- Derived skip cache for Vectorize embeddings. A row means this vector id in
 -- this owner namespace was last upserted from embed text that hashes to
--- content_hash (model + dimensions + fingerprint version + truncated text).
+-- content_hash (model + dimensions + fingerprint version + truncated text +
+-- canonical Vectorize metadata).
 -- User-owned rows use the account stable user id; builtin capability vectors
 -- use the reserved __kody_builtin__ namespace as user_id. Account deletion
 -- removes user-owned rows. A force reindex ignores these hashes.

--- a/packages/worker/migrations/0021-vector-embed-fingerprints.sql
+++ b/packages/worker/migrations/0021-vector-embed-fingerprints.sql
@@ -1,0 +1,16 @@
+-- Derived skip cache for Vectorize embeddings. A row means this vector id in
+-- this owner namespace was last upserted from embed text that hashes to
+-- content_hash (model + dimensions + fingerprint version + truncated text).
+-- User-owned rows use the account stable user id; builtin capability vectors
+-- use the reserved __kody_builtin__ namespace as user_id. Account deletion
+-- removes user-owned rows. A force reindex ignores these hashes.
+CREATE TABLE vector_embed_fingerprints (
+	user_id TEXT NOT NULL,
+	vector_id TEXT NOT NULL,
+	content_hash TEXT NOT NULL,
+	updated_at TEXT NOT NULL,
+	PRIMARY KEY (user_id, vector_id)
+);
+
+CREATE INDEX idx_vector_embed_fingerprints_vector_id
+ON vector_embed_fingerprints(vector_id);

--- a/packages/worker/src/account/data-targets.ts
+++ b/packages/worker/src/account/data-targets.ts
@@ -268,6 +268,14 @@ export const accountUserDataTargets: ReadonlyArray<UserScopedDataTarget> = [
 		reason:
 			'Operational search-index reconcile debt omitted from portable export; account deletion removes outstanding debt rows.',
 	},
+	{
+		kind: 'user_id',
+		table: 'vector_embed_fingerprints',
+		includeInExport: false,
+		surface: 'vector_embed_fingerprints',
+		reason:
+			'Derived Vectorize embed-text skip cache omitted from portable export; account deletion removes user-owned fingerprint rows. Builtin rows use the reserved __kody_builtin__ owner id.',
+	},
 	{ kind: 'user_id', table: 'entity_source_artifacts_push_subscriptions' },
 	{ kind: 'user_id', table: 'entity_sources' },
 	{

--- a/packages/worker/src/capability-maintenance.node.test.ts
+++ b/packages/worker/src/capability-maintenance.node.test.ts
@@ -104,20 +104,24 @@ test('capability reindex maintenance route rebuilds every vector kind and resume
 		{
 			afterId: null,
 			deadlineMs: expect.any(Number),
+			force: false,
 		},
 	)
 	expect(mockModule.reindexMemoryVectors).toHaveBeenCalledWith(env, {
 		afterId: null,
 		deadlineMs: expect.any(Number),
+		force: false,
 	})
 	expect(mockModule.reindexJobVectors).toHaveBeenCalledWith(env, {
 		afterId: null,
 		deadlineMs: expect.any(Number),
+		force: false,
 	})
 	expect(mockModule.reindexSavedPackageVectors).toHaveBeenCalledWith(env, {
 		baseUrl: 'https://kody.example.com',
 		afterId: null,
 		deadlineMs: expect.any(Number),
+		force: false,
 	})
 
 	resetMocks()
@@ -169,6 +173,7 @@ test('capability reindex maintenance route rebuilds every vector kind and resume
 	expect(mockModule.reindexMemoryVectors).toHaveBeenCalledWith(env, {
 		afterId: 'memory-8',
 		deadlineMs: expect.any(Number),
+		force: false,
 	})
 
 	const invalidCursorResponse = await handleCapabilityReindexRequest(
@@ -323,4 +328,65 @@ test('capability reindex can limit work to builtin capabilities for production d
 	)
 	expect(workflow).toContain('payload=\'{"phases":["capabilities"]}\'')
 	expect(workflow).toContain('{phases:["capabilities"],cursor:$cursor}')
+})
+
+test('capability reindex force ignores fingerprints and rejects a non-boolean force', async () => {
+	resetMocks()
+	mockModule.reindexCapabilityVectors.mockResolvedValue(completeStep(3))
+	mockModule.reindexMemoryVectors.mockResolvedValue(completeStep(2))
+	mockModule.reindexJobVectors.mockResolvedValue(completeStep(1))
+	mockModule.reindexSavedPackageVectors.mockResolvedValue(completeStep(4))
+	const env = {
+		CAPABILITY_REINDEX_SECRET: 'secret',
+	} as Env
+
+	const response = await handleCapabilityReindexRequest(
+		createReindexRequest({ force: true }),
+		env,
+	)
+	expect(response.status).toBe(200)
+	await expect(response.json()).resolves.toEqual({
+		ok: true,
+		complete: true,
+		phases: ['capabilities', 'memories', 'jobs', 'packages'],
+		capabilities: completeStep(3),
+		memories: completeStep(2),
+		jobs: completeStep(1),
+		packages: completeStep(4),
+	})
+	expect(mockModule.reindexCapabilityVectors).toHaveBeenCalledWith(
+		env,
+		expect.any(Object),
+		{
+			afterId: null,
+			deadlineMs: expect.any(Number),
+			force: true,
+		},
+	)
+	expect(mockModule.reindexMemoryVectors).toHaveBeenCalledWith(env, {
+		afterId: null,
+		deadlineMs: expect.any(Number),
+		force: true,
+	})
+	expect(mockModule.reindexJobVectors).toHaveBeenCalledWith(env, {
+		afterId: null,
+		deadlineMs: expect.any(Number),
+		force: true,
+	})
+	expect(mockModule.reindexSavedPackageVectors).toHaveBeenCalledWith(env, {
+		baseUrl: 'https://kody.example.com',
+		afterId: null,
+		deadlineMs: expect.any(Number),
+		force: true,
+	})
+
+	const invalidForce = await handleCapabilityReindexRequest(
+		createReindexRequest({ force: 'yes' }),
+		env,
+	)
+	expect(invalidForce.status).toBe(400)
+	await expect(invalidForce.json()).resolves.toEqual({
+		ok: false,
+		error: 'force must be a boolean.',
+	})
 })

--- a/packages/worker/src/capability-maintenance.ts
+++ b/packages/worker/src/capability-maintenance.ts
@@ -65,6 +65,7 @@ function parseCapabilityReindexBody(body: unknown):
 			cursor: CapabilityReindexCursor | null
 			phases: ReadonlyArray<CapabilityReindexPhase>
 			timeBudgetMs: number
+			force: boolean
 	  }
 	| { ok: false; error: string } {
 	if (body == null) {
@@ -73,6 +74,7 @@ function parseCapabilityReindexBody(body: unknown):
 			cursor: null,
 			phases: capabilityReindexPhases,
 			timeBudgetMs: capabilityReindexTimeBudgetMs,
+			force: false,
 		}
 	}
 	if (typeof body !== 'object' || Array.isArray(body)) {
@@ -82,6 +84,13 @@ function parseCapabilityReindexBody(body: unknown):
 	const phases = resolveCapabilityReindexPhases(record.phases)
 	if (!phases.ok) {
 		return phases
+	}
+	let force = false
+	if (record.force !== undefined) {
+		if (typeof record.force !== 'boolean') {
+			return { ok: false, error: 'force must be a boolean.' }
+		}
+		force = record.force
 	}
 	let timeBudgetMs = capabilityReindexTimeBudgetMs
 	if (record.timeBudgetMs !== undefined) {
@@ -98,7 +107,13 @@ function parseCapabilityReindexBody(body: unknown):
 		timeBudgetMs = record.timeBudgetMs
 	}
 	if (record.cursor === undefined || record.cursor === null) {
-		return { ok: true, cursor: null, phases: phases.phases, timeBudgetMs }
+		return {
+			ok: true,
+			cursor: null,
+			phases: phases.phases,
+			timeBudgetMs,
+			force,
+		}
 	}
 	if (typeof record.cursor !== 'object' || Array.isArray(record.cursor)) {
 		return { ok: false, error: 'cursor must be an object.' }
@@ -124,6 +139,7 @@ function parseCapabilityReindexBody(body: unknown):
 		cursor: { phase: cursor.phase, afterId: cursor.afterId },
 		phases: phases.phases,
 		timeBudgetMs,
+		force,
 	}
 }
 
@@ -134,6 +150,7 @@ async function runReindexPhase(
 		phase: CapabilityReindexPhase
 		afterId: string | null
 		deadlineMs: number
+		force: boolean
 	},
 ): Promise<ReindexStepResult> {
 	switch (input.phase) {
@@ -142,6 +159,7 @@ async function runReindexPhase(
 				reindexCapabilityVectors(env, getStaticRegistry().capabilitySpecs, {
 					afterId: input.afterId,
 					deadlineMs: input.deadlineMs,
+					force: input.force,
 				}),
 			)
 		case 'memories':
@@ -149,6 +167,7 @@ async function runReindexPhase(
 				reindexMemoryVectors(env, {
 					afterId: input.afterId,
 					deadlineMs: input.deadlineMs,
+					force: input.force,
 				}),
 			)
 		case 'jobs':
@@ -156,6 +175,7 @@ async function runReindexPhase(
 				reindexJobVectors(env, {
 					afterId: input.afterId,
 					deadlineMs: input.deadlineMs,
+					force: input.force,
 				}),
 			)
 		case 'packages':
@@ -164,6 +184,7 @@ async function runReindexPhase(
 					baseUrl: input.baseUrl,
 					afterId: input.afterId,
 					deadlineMs: input.deadlineMs,
+					force: input.force,
 				}),
 			)
 		default: {
@@ -180,6 +201,7 @@ async function reindexAllCapabilitySearchVectors(
 		cursor: CapabilityReindexCursor | null
 		phases: ReadonlyArray<CapabilityReindexPhase>
 		deadlineMs: number
+		force: boolean
 	},
 ) {
 	const result: CapabilityReindexKinds = {
@@ -212,6 +234,7 @@ async function reindexAllCapabilitySearchVectors(
 			phase,
 			afterId,
 			deadlineMs: input.deadlineMs,
+			force: input.force,
 		})
 		result[phase] = step
 		if (step.error) continue
@@ -251,6 +274,7 @@ export async function handleCapabilityReindexRequest(
 				cursor: parsed.cursor,
 				phases: parsed.phases,
 				deadlineMs: Date.now() + parsed.timeBudgetMs,
+				force: parsed.force,
 			})
 			const kindResults = (
 				['capabilities', 'memories', 'jobs', 'packages'] as const

--- a/packages/worker/src/jobs/job-reindex.ts
+++ b/packages/worker/src/jobs/job-reindex.ts
@@ -37,6 +37,7 @@ export async function reindexJobVectors(
 		pageSize: reindexPageSize,
 		afterId: options?.afterId,
 		deadlineMs: options?.deadlineMs,
+		force: options?.force,
 		listPage: ({ afterId, limit }) =>
 			runD1WithRetry(() =>
 				jobsData(env).listJobsPage({

--- a/packages/worker/src/mcp/capabilities/capability-reindex.ts
+++ b/packages/worker/src/mcp/capabilities/capability-reindex.ts
@@ -35,5 +35,6 @@ export async function reindexCapabilityVectors(
 		candidates,
 		afterId: options?.afterId,
 		deadlineMs: options?.deadlineMs,
+		force: options?.force,
 	})
 }

--- a/packages/worker/src/mcp/jobs-vectorize.ts
+++ b/packages/worker/src/mcp/jobs-vectorize.ts
@@ -3,6 +3,11 @@ import {
 	getCapabilityVectorIndex,
 	isCapabilitySearchOffline,
 } from '#worker/vectorize/embedding.ts'
+import {
+	recordVectorEmbedFingerprint,
+	shouldSkipVectorEmbed,
+	tryDeleteVectorEmbedFingerprint,
+} from '#worker/vectorize/embed-fingerprints.ts'
 import { userVectorNamespace } from '#worker/vectorize/vector-namespaces.ts'
 import { buildLengthSafeVectorId } from '#worker/vectorize/vector-ids.ts'
 
@@ -20,19 +25,39 @@ export async function upsertJobVector(
 ): Promise<void> {
 	const index = getCapabilityVectorIndex(env)
 	if (!index || isCapabilitySearchOffline(env)) return
+	const vectorId = jobVectorId(input.jobId)
+	const namespace = userVectorNamespace(input.userId)
+	if (
+		await shouldSkipVectorEmbed({
+			env,
+			userId: namespace,
+			vectorId,
+			text: input.embedText,
+		})
+	) {
+		return
+	}
 	const values = await embedTextForVectorize(env, input.embedText)
 	await index.upsert([
 		{
-			id: jobVectorId(input.jobId),
+			id: vectorId,
 			values,
-			namespace: userVectorNamespace(input.userId),
+			namespace,
 			metadata: { kind: 'job', userId: input.userId },
 		},
 	])
+	await recordVectorEmbedFingerprint({
+		env,
+		userId: namespace,
+		vectorId,
+		text: input.embedText,
+	})
 }
 
 export async function deleteJobVector(env: Env, jobId: string): Promise<void> {
+	const vectorId = jobVectorId(jobId)
+	await tryDeleteVectorEmbedFingerprint({ env, vectorId })
 	const index = getCapabilityVectorIndex(env)
 	if (!index || isCapabilitySearchOffline(env)) return
-	await index.deleteByIds([jobVectorId(jobId)])
+	await index.deleteByIds([vectorId])
 }

--- a/packages/worker/src/mcp/jobs-vectorize.ts
+++ b/packages/worker/src/mcp/jobs-vectorize.ts
@@ -27,12 +27,14 @@ export async function upsertJobVector(
 	if (!index || isCapabilitySearchOffline(env)) return
 	const vectorId = jobVectorId(input.jobId)
 	const namespace = userVectorNamespace(input.userId)
+	const metadata = { kind: 'job', userId: input.userId }
 	if (
 		await shouldSkipVectorEmbed({
 			env,
 			userId: namespace,
 			vectorId,
 			text: input.embedText,
+			metadata,
 		})
 	) {
 		return
@@ -43,7 +45,7 @@ export async function upsertJobVector(
 			id: vectorId,
 			values,
 			namespace,
-			metadata: { kind: 'job', userId: input.userId },
+			metadata,
 		},
 	])
 	await recordVectorEmbedFingerprint({
@@ -51,6 +53,7 @@ export async function upsertJobVector(
 		userId: namespace,
 		vectorId,
 		text: input.embedText,
+		metadata,
 	})
 }
 

--- a/packages/worker/src/mcp/memory/memory-reindex.ts
+++ b/packages/worker/src/mcp/memory/memory-reindex.ts
@@ -36,6 +36,7 @@ export async function reindexMemoryVectors(
 		pageSize: reindexPageSize,
 		afterId: options?.afterId,
 		deadlineMs: options?.deadlineMs,
+		force: options?.force,
 		listPage: ({ afterId, limit }) =>
 			runD1WithRetry(() =>
 				listMemoriesPage({

--- a/packages/worker/src/mcp/memory/memory-vectorize.ts
+++ b/packages/worker/src/mcp/memory/memory-vectorize.ts
@@ -30,12 +30,19 @@ export async function upsertMemoryVector(
 	if (!index || isCapabilitySearchOffline(env)) return
 	const vectorId = memoryVectorId(input.memoryId)
 	const namespace = userVectorNamespace(input.userId)
+	const metadata = {
+		kind: 'memory',
+		userId: input.userId,
+		status: input.status,
+		...(input.category ? { category: input.category } : {}),
+	}
 	if (
 		await shouldSkipVectorEmbed({
 			env,
 			userId: namespace,
 			vectorId,
 			text: input.embedText,
+			metadata,
 		})
 	) {
 		return
@@ -46,12 +53,7 @@ export async function upsertMemoryVector(
 			id: vectorId,
 			values,
 			namespace,
-			metadata: {
-				kind: 'memory',
-				userId: input.userId,
-				status: input.status,
-				...(input.category ? { category: input.category } : {}),
-			},
+			metadata,
 		},
 	])
 	await recordVectorEmbedFingerprint({
@@ -59,6 +61,7 @@ export async function upsertMemoryVector(
 		userId: namespace,
 		vectorId,
 		text: input.embedText,
+		metadata,
 	})
 }
 

--- a/packages/worker/src/mcp/memory/memory-vectorize.ts
+++ b/packages/worker/src/mcp/memory/memory-vectorize.ts
@@ -3,6 +3,11 @@ import {
 	getCapabilityVectorIndex,
 	isCapabilitySearchOffline,
 } from '#worker/vectorize/embedding.ts'
+import {
+	recordVectorEmbedFingerprint,
+	shouldSkipVectorEmbed,
+	tryDeleteVectorEmbedFingerprint,
+} from '#worker/vectorize/embed-fingerprints.ts'
 import { userVectorNamespace } from '#worker/vectorize/vector-namespaces.ts'
 import { buildLengthSafeVectorId } from '#worker/vectorize/vector-ids.ts'
 import { type MemoryStatus } from './types.ts'
@@ -23,12 +28,24 @@ export async function upsertMemoryVector(
 ): Promise<void> {
 	const index = getCapabilityVectorIndex(env)
 	if (!index || isCapabilitySearchOffline(env)) return
+	const vectorId = memoryVectorId(input.memoryId)
+	const namespace = userVectorNamespace(input.userId)
+	if (
+		await shouldSkipVectorEmbed({
+			env,
+			userId: namespace,
+			vectorId,
+			text: input.embedText,
+		})
+	) {
+		return
+	}
 	const values = await embedTextForVectorize(env, input.embedText)
 	await index.upsert([
 		{
-			id: memoryVectorId(input.memoryId),
+			id: vectorId,
 			values,
-			namespace: userVectorNamespace(input.userId),
+			namespace,
 			metadata: {
 				kind: 'memory',
 				userId: input.userId,
@@ -37,13 +54,21 @@ export async function upsertMemoryVector(
 			},
 		},
 	])
+	await recordVectorEmbedFingerprint({
+		env,
+		userId: namespace,
+		vectorId,
+		text: input.embedText,
+	})
 }
 
 export async function deleteMemoryVector(
 	env: Env,
 	memoryId: string,
 ): Promise<void> {
+	const vectorId = memoryVectorId(memoryId)
+	await tryDeleteVectorEmbedFingerprint({ env, vectorId })
 	const index = getCapabilityVectorIndex(env)
 	if (!index || isCapabilitySearchOffline(env)) return
-	await index.deleteByIds([memoryVectorId(memoryId)])
+	await index.deleteByIds([vectorId])
 }

--- a/packages/worker/src/package-registry/package-reindex.ts
+++ b/packages/worker/src/package-registry/package-reindex.ts
@@ -80,6 +80,7 @@ export async function reindexSavedPackageVectors(
 			index: vectorIndex,
 			kind: 'saved package',
 			candidates: chunk.candidates,
+			force: input.force,
 		})
 		pageResults.push(pageResult)
 		// Prefer uncapped failedIds (failures is a capped sample for messages).

--- a/packages/worker/src/package-registry/vectorize.ts
+++ b/packages/worker/src/package-registry/vectorize.ts
@@ -23,12 +23,17 @@ export async function upsertSavedPackageVector(
 	if (!index || isCapabilitySearchOffline(env)) return
 	const vectorId = savedPackageVectorId(input.packageId)
 	const namespace = userVectorNamespace(input.userId)
+	const metadata = {
+		kind: 'package',
+		userId: input.userId,
+	}
 	if (
 		await shouldSkipVectorEmbed({
 			env,
 			userId: namespace,
 			vectorId,
 			text: input.embedText,
+			metadata,
 		})
 	) {
 		return
@@ -39,10 +44,7 @@ export async function upsertSavedPackageVector(
 			id: vectorId,
 			values,
 			namespace,
-			metadata: {
-				kind: 'package',
-				userId: input.userId,
-			},
+			metadata,
 		},
 	])
 	await recordVectorEmbedFingerprint({
@@ -50,6 +52,7 @@ export async function upsertSavedPackageVector(
 		userId: namespace,
 		vectorId,
 		text: input.embedText,
+		metadata,
 	})
 }
 

--- a/packages/worker/src/package-registry/vectorize.ts
+++ b/packages/worker/src/package-registry/vectorize.ts
@@ -3,6 +3,11 @@ import {
 	getCapabilityVectorIndex,
 	isCapabilitySearchOffline,
 } from '#worker/vectorize/embedding.ts'
+import {
+	recordVectorEmbedFingerprint,
+	shouldSkipVectorEmbed,
+	tryDeleteVectorEmbedFingerprint,
+} from '#worker/vectorize/embed-fingerprints.ts'
 import { userVectorNamespace } from '#worker/vectorize/vector-namespaces.ts'
 import { savedPackageVectorId } from './repo.ts'
 
@@ -16,22 +21,42 @@ export async function upsertSavedPackageVector(
 ) {
 	const index = getCapabilityVectorIndex(env)
 	if (!index || isCapabilitySearchOffline(env)) return
+	const vectorId = savedPackageVectorId(input.packageId)
+	const namespace = userVectorNamespace(input.userId)
+	if (
+		await shouldSkipVectorEmbed({
+			env,
+			userId: namespace,
+			vectorId,
+			text: input.embedText,
+		})
+	) {
+		return
+	}
 	const values = await embedTextForVectorize(env, input.embedText)
 	await index.upsert([
 		{
-			id: savedPackageVectorId(input.packageId),
+			id: vectorId,
 			values,
-			namespace: userVectorNamespace(input.userId),
+			namespace,
 			metadata: {
 				kind: 'package',
 				userId: input.userId,
 			},
 		},
 	])
+	await recordVectorEmbedFingerprint({
+		env,
+		userId: namespace,
+		vectorId,
+		text: input.embedText,
+	})
 }
 
 export async function deleteSavedPackageVector(env: Env, packageId: string) {
+	const vectorId = savedPackageVectorId(packageId)
+	await tryDeleteVectorEmbedFingerprint({ env, vectorId })
 	const index = getCapabilityVectorIndex(env)
 	if (!index || isCapabilitySearchOffline(env)) return
-	await index.deleteByIds([savedPackageVectorId(packageId)])
+	await index.deleteByIds([vectorId])
 }

--- a/packages/worker/src/vectorize/embed-fingerprints.node.test.ts
+++ b/packages/worker/src/vectorize/embed-fingerprints.node.test.ts
@@ -7,6 +7,8 @@ import {
 	recordVectorEmbedFingerprint,
 	shouldSkipVectorEmbed,
 	tryDeleteVectorEmbedFingerprint,
+	tryReadVectorEmbedFingerprints,
+	tryWriteVectorEmbedFingerprints,
 	vectorEmbedContentHash,
 	vectorEmbedFingerprintVersion,
 } from './embed-fingerprints.ts'
@@ -157,6 +159,30 @@ test('vector embed fingerprints skip unchanged text and force rebuilds Vectorize
 				text: 'remember a different locale',
 			}),
 		).resolves.toBe(false)
+
+		const unmigratedEnv = {
+			APP_DB: createD1FromSqlite(new DatabaseSync(':memory:')),
+		} as Env
+		await expect(
+			tryReadVectorEmbedFingerprints({
+				env: unmigratedEnv,
+				keys: [{ userId: 'user-me', vectorId: 'memory-1' }],
+			}),
+		).resolves.toBeNull()
+		await tryWriteVectorEmbedFingerprints({
+			env: unmigratedEnv,
+			rows: [
+				{
+					userId: 'user-me',
+					vectorId: 'memory-1',
+					contentHash: 'abc',
+				},
+			],
+		})
+		await tryDeleteVectorEmbedFingerprint({
+			env: unmigratedEnv,
+			vectorId: 'memory-1',
+		})
 	} finally {
 		embedSpy.mockRestore()
 	}

--- a/packages/worker/src/vectorize/embed-fingerprints.node.test.ts
+++ b/packages/worker/src/vectorize/embed-fingerprints.node.test.ts
@@ -4,6 +4,7 @@ import { expect, test, vi } from 'vitest'
 import { applyAllMigrations } from '#worker/test-support/apply-all-migrations.ts'
 import { createD1FromSqlite } from '#worker/test-support/create-d1-from-sqlite.ts'
 import {
+	canonicalizeVectorEmbedMetadata,
 	recordVectorEmbedFingerprint,
 	shouldSkipVectorEmbed,
 	tryDeleteVectorEmbedFingerprint,
@@ -47,7 +48,10 @@ test('vector embed fingerprints skip unchanged text and force rebuilds Vectorize
 			},
 		]
 
-		const hash = await vectorEmbedContentHash(candidates[0]!.text)
+		const hash = await vectorEmbedContentHash({
+			text: candidates[0]!.text,
+			metadata: candidates[0]!.metadata,
+		})
 		await expect(
 			sha256Hex(
 				[
@@ -55,6 +59,7 @@ test('vector embed fingerprints skip unchanged text and force rebuilds Vectorize
 					String(embedding.CAPABILITY_EMBEDDING_DIMENSIONS),
 					String(vectorEmbedFingerprintVersion),
 					candidates[0]!.text,
+					canonicalizeVectorEmbedMetadata(candidates[0]!.metadata),
 				].join('\0'),
 			),
 		).resolves.toBe(hash)
@@ -62,8 +67,10 @@ test('vector embed fingerprints skip unchanged text and force rebuilds Vectorize
 		const longPrefix = 'x'.repeat(
 			embedding.CAPABILITY_EMBEDDING_MAX_INPUT_CHARS,
 		)
-		await expect(vectorEmbedContentHash(`${longPrefix}tail-a`)).resolves.toBe(
-			await vectorEmbedContentHash(`${longPrefix}tail-b`),
+		await expect(
+			vectorEmbedContentHash({ text: `${longPrefix}tail-a` }),
+		).resolves.toBe(
+			await vectorEmbedContentHash({ text: `${longPrefix}tail-b` }),
 		)
 
 		const first = await reindexVectorCandidates({
@@ -94,14 +101,25 @@ test('vector embed fingerprints skip unchanged text and force rebuilds Vectorize
 				userId: 'user-me',
 				vectorId: 'memory-1',
 				text: 'remember the preview locale',
+				metadata: { kind: 'memory' },
 			}),
 		).resolves.toBe(true)
+		await expect(
+			shouldSkipVectorEmbed({
+				env,
+				userId: 'user-me',
+				vectorId: 'memory-1',
+				text: 'remember the preview locale',
+				metadata: { kind: 'memory', status: 'deleted' },
+			}),
+		).resolves.toBe(false)
 		await expect(
 			shouldSkipVectorEmbed({
 				env: {} as Env,
 				userId: 'user-me',
 				vectorId: 'memory-1',
 				text: 'remember the preview locale',
+				metadata: { kind: 'memory' },
 			}),
 		).resolves.toBe(false)
 
@@ -133,6 +151,30 @@ test('vector embed fingerprints skip unchanged text and force rebuilds Vectorize
 			expect.objectContaining({
 				id: 'memory-1',
 				namespace: 'user-me',
+			}),
+		])
+
+		embedSpy.mockClear()
+		upsert.mockClear()
+		const metadataChanged = await reindexVectorCandidates({
+			env,
+			index: { upsert } as unknown as VectorizeIndex,
+			kind: 'test',
+			candidates: [
+				candidates[0]!,
+				{
+					...candidates[1]!,
+					text: 'remember a different locale',
+					metadata: { kind: 'memory', status: 'deleted' },
+				},
+			],
+		})
+		expect(metadataChanged).toEqual({ upserted: 1, skipped: 1 })
+		expect(embedSpy).toHaveBeenCalledTimes(1)
+		expect(upsert).toHaveBeenCalledWith([
+			expect.objectContaining({
+				id: 'memory-1',
+				metadata: { kind: 'memory', status: 'deleted' },
 			}),
 		])
 

--- a/packages/worker/src/vectorize/embed-fingerprints.node.test.ts
+++ b/packages/worker/src/vectorize/embed-fingerprints.node.test.ts
@@ -1,0 +1,163 @@
+import { sha256Hex } from '@kody-internal/shared/sha256.ts'
+import { DatabaseSync } from 'node:sqlite'
+import { expect, test, vi } from 'vitest'
+import { applyAllMigrations } from '#worker/test-support/apply-all-migrations.ts'
+import { createD1FromSqlite } from '#worker/test-support/create-d1-from-sqlite.ts'
+import {
+	recordVectorEmbedFingerprint,
+	shouldSkipVectorEmbed,
+	tryDeleteVectorEmbedFingerprint,
+	vectorEmbedContentHash,
+	vectorEmbedFingerprintVersion,
+} from './embed-fingerprints.ts'
+import * as embedding from './embedding.ts'
+import { reindexVectorCandidates } from './reindex-batches.ts'
+import { BUILTIN_VECTOR_NAMESPACE } from './vector-namespaces.ts'
+
+function createMigratedDb() {
+	const sqlite = new DatabaseSync(':memory:')
+	applyAllMigrations(sqlite, new URL('../../migrations/', import.meta.url))
+	return createD1FromSqlite(sqlite)
+}
+
+test('vector embed fingerprints skip unchanged text and force rebuilds Vectorize', async () => {
+	const env = { APP_DB: createMigratedDb() } as Env
+	const upsert = vi.fn(async () => {})
+	const embedSpy = vi
+		.spyOn(embedding, 'embedTextsForVectorize')
+		.mockImplementation(async (_env, texts) =>
+			texts.map((text) => [text.length]),
+		)
+
+	try {
+		const candidates = [
+			{
+				id: 'search_memories',
+				text: 'search memories capability',
+				namespace: BUILTIN_VECTOR_NAMESPACE,
+				metadata: { kind: 'builtin' as const },
+			},
+			{
+				id: 'memory-1',
+				text: 'remember the preview locale',
+				namespace: 'user-me',
+				metadata: { kind: 'memory' as const },
+			},
+		]
+
+		const hash = await vectorEmbedContentHash(candidates[0]!.text)
+		await expect(
+			sha256Hex(
+				[
+					embedding.CAPABILITY_EMBEDDING_MODEL,
+					String(embedding.CAPABILITY_EMBEDDING_DIMENSIONS),
+					String(vectorEmbedFingerprintVersion),
+					candidates[0]!.text,
+				].join('\0'),
+			),
+		).resolves.toBe(hash)
+
+		const longPrefix = 'x'.repeat(
+			embedding.CAPABILITY_EMBEDDING_MAX_INPUT_CHARS,
+		)
+		await expect(vectorEmbedContentHash(`${longPrefix}tail-a`)).resolves.toBe(
+			await vectorEmbedContentHash(`${longPrefix}tail-b`),
+		)
+
+		const first = await reindexVectorCandidates({
+			env,
+			index: { upsert } as unknown as VectorizeIndex,
+			kind: 'test',
+			candidates,
+		})
+		expect(first).toEqual({ upserted: 2 })
+		expect(embedSpy).toHaveBeenCalledTimes(1)
+		expect(upsert).toHaveBeenCalledTimes(1)
+
+		embedSpy.mockClear()
+		upsert.mockClear()
+		const skipped = await reindexVectorCandidates({
+			env,
+			index: { upsert } as unknown as VectorizeIndex,
+			kind: 'test',
+			candidates,
+		})
+		expect(skipped).toEqual({ upserted: 0, skipped: 2 })
+		expect(embedSpy).not.toHaveBeenCalled()
+		expect(upsert).not.toHaveBeenCalled()
+
+		await expect(
+			shouldSkipVectorEmbed({
+				env,
+				userId: 'user-me',
+				vectorId: 'memory-1',
+				text: 'remember the preview locale',
+			}),
+		).resolves.toBe(true)
+		await expect(
+			shouldSkipVectorEmbed({
+				env: {} as Env,
+				userId: 'user-me',
+				vectorId: 'memory-1',
+				text: 'remember the preview locale',
+			}),
+		).resolves.toBe(false)
+
+		const forced = await reindexVectorCandidates({
+			env,
+			index: { upsert } as unknown as VectorizeIndex,
+			kind: 'test',
+			candidates,
+			force: true,
+		})
+		expect(forced).toEqual({ upserted: 2 })
+		expect(embedSpy).toHaveBeenCalledTimes(1)
+		expect(upsert).toHaveBeenCalledTimes(1)
+
+		embedSpy.mockClear()
+		upsert.mockClear()
+		const changed = await reindexVectorCandidates({
+			env,
+			index: { upsert } as unknown as VectorizeIndex,
+			kind: 'test',
+			candidates: [
+				candidates[0]!,
+				{ ...candidates[1]!, text: 'remember a different locale' },
+			],
+		})
+		expect(changed).toEqual({ upserted: 1, skipped: 1 })
+		expect(embedSpy).toHaveBeenCalledTimes(1)
+		expect(upsert).toHaveBeenCalledWith([
+			expect.objectContaining({
+				id: 'memory-1',
+				namespace: 'user-me',
+			}),
+		])
+
+		await recordVectorEmbedFingerprint({
+			env,
+			userId: 'user-me',
+			vectorId: 'memory-1',
+			text: 'remember a different locale',
+		})
+		await expect(
+			shouldSkipVectorEmbed({
+				env,
+				userId: 'user-me',
+				vectorId: 'memory-1',
+				text: 'remember a different locale',
+			}),
+		).resolves.toBe(true)
+		await tryDeleteVectorEmbedFingerprint({ env, vectorId: 'memory-1' })
+		await expect(
+			shouldSkipVectorEmbed({
+				env,
+				userId: 'user-me',
+				vectorId: 'memory-1',
+				text: 'remember a different locale',
+			}),
+		).resolves.toBe(false)
+	} finally {
+		embedSpy.mockRestore()
+	}
+})

--- a/packages/worker/src/vectorize/embed-fingerprints.ts
+++ b/packages/worker/src/vectorize/embed-fingerprints.ts
@@ -1,5 +1,4 @@
 import { sha256Hex } from '@kody-internal/shared/sha256.ts'
-import { getErrorMessage } from '@kody-internal/shared/error-message.ts'
 import {
 	CAPABILITY_EMBEDDING_DIMENSIONS,
 	CAPABILITY_EMBEDDING_MODEL,
@@ -108,13 +107,7 @@ export async function tryReadVectorEmbedFingerprints(input: {
 			db: input.env.APP_DB,
 			keys: input.keys,
 		})
-	} catch (error) {
-		console.error(
-			JSON.stringify({
-				message: 'vector embed fingerprint read failed',
-				error: getErrorMessage(error),
-			}),
-		)
+	} catch {
 		return null
 	}
 }
@@ -133,13 +126,8 @@ export async function tryWriteVectorEmbedFingerprints(input: {
 			db: input.env.APP_DB,
 			rows: input.rows,
 		})
-	} catch (error) {
-		console.error(
-			JSON.stringify({
-				message: 'vector embed fingerprint write failed',
-				error: getErrorMessage(error),
-			}),
-		)
+	} catch {
+		// Fail-open: a derived skip cache must not break upsert or delete.
 	}
 }
 
@@ -153,13 +141,8 @@ export async function tryDeleteVectorEmbedFingerprint(input: {
 			db: input.env.APP_DB,
 			vectorId: input.vectorId,
 		})
-	} catch (error) {
-		console.error(
-			JSON.stringify({
-				message: 'vector embed fingerprint delete failed',
-				error: getErrorMessage(error),
-			}),
-		)
+	} catch {
+		// Fail-open: a derived skip cache must not break upsert or delete.
 	}
 }
 

--- a/packages/worker/src/vectorize/embed-fingerprints.ts
+++ b/packages/worker/src/vectorize/embed-fingerprints.ts
@@ -21,12 +21,29 @@ export function vectorEmbedFingerprintKey(userId: string, vectorId: string) {
 	return `${userId}\0${vectorId}`
 }
 
-export async function vectorEmbedContentHash(text: string) {
+export function canonicalizeVectorEmbedMetadata(
+	metadata: Record<string, VectorizeVectorMetadata> | undefined,
+) {
+	if (!metadata) return ''
+	return JSON.stringify(
+		Object.fromEntries(
+			Object.keys(metadata)
+				.sort()
+				.map((key) => [key, metadata[key]]),
+		),
+	)
+}
+
+export async function vectorEmbedContentHash(input: {
+	text: string
+	metadata?: Record<string, VectorizeVectorMetadata>
+}) {
 	const material = [
 		CAPABILITY_EMBEDDING_MODEL,
 		String(CAPABILITY_EMBEDDING_DIMENSIONS),
 		String(vectorEmbedFingerprintVersion),
-		truncateEmbeddingInput(text),
+		truncateEmbeddingInput(input.text),
+		canonicalizeVectorEmbedMetadata(input.metadata),
 	].join('\0')
 	return sha256Hex(material)
 }
@@ -151,13 +168,17 @@ export async function shouldSkipVectorEmbed(input: {
 	userId: string
 	vectorId: string
 	text: string
+	metadata?: Record<string, VectorizeVectorMetadata>
 }): Promise<boolean> {
 	const existing = await tryReadVectorEmbedFingerprints({
 		env: input.env,
 		keys: [{ userId: input.userId, vectorId: input.vectorId }],
 	})
 	if (!existing) return false
-	const hash = await vectorEmbedContentHash(input.text)
+	const hash = await vectorEmbedContentHash({
+		text: input.text,
+		metadata: input.metadata,
+	})
 	return (
 		existing.get(vectorEmbedFingerprintKey(input.userId, input.vectorId)) ===
 		hash
@@ -169,6 +190,7 @@ export async function recordVectorEmbedFingerprint(input: {
 	userId: string
 	vectorId: string
 	text: string
+	metadata?: Record<string, VectorizeVectorMetadata>
 }) {
 	if (!hasVectorEmbedFingerprintDb(input.env)) return
 	await tryWriteVectorEmbedFingerprints({
@@ -177,7 +199,10 @@ export async function recordVectorEmbedFingerprint(input: {
 			{
 				userId: input.userId,
 				vectorId: input.vectorId,
-				contentHash: await vectorEmbedContentHash(input.text),
+				contentHash: await vectorEmbedContentHash({
+					text: input.text,
+					metadata: input.metadata,
+				}),
 			},
 		],
 	})

--- a/packages/worker/src/vectorize/embed-fingerprints.ts
+++ b/packages/worker/src/vectorize/embed-fingerprints.ts
@@ -1,0 +1,201 @@
+import { sha256Hex } from '@kody-internal/shared/sha256.ts'
+import { getErrorMessage } from '@kody-internal/shared/error-message.ts'
+import {
+	CAPABILITY_EMBEDDING_DIMENSIONS,
+	CAPABILITY_EMBEDDING_MODEL,
+	truncateEmbeddingInput,
+} from './embedding.ts'
+
+/**
+ * Bump when the Vectorize metadata contract changes in a way that requires
+ * every stored vector to be rewritten even if embed text is unchanged.
+ */
+export const vectorEmbedFingerprintVersion = 1
+
+export function hasVectorEmbedFingerprintDb(
+	env: Env,
+): env is Env & { APP_DB: D1Database } {
+	return typeof env.APP_DB?.prepare === 'function'
+}
+
+export function vectorEmbedFingerprintKey(userId: string, vectorId: string) {
+	return `${userId}\0${vectorId}`
+}
+
+export async function vectorEmbedContentHash(text: string) {
+	const material = [
+		CAPABILITY_EMBEDDING_MODEL,
+		String(CAPABILITY_EMBEDDING_DIMENSIONS),
+		String(vectorEmbedFingerprintVersion),
+		truncateEmbeddingInput(text),
+	].join('\0')
+	return sha256Hex(material)
+}
+
+export async function readVectorEmbedFingerprints(input: {
+	db: D1Database
+	keys: ReadonlyArray<{ userId: string; vectorId: string }>
+}): Promise<Map<string, string>> {
+	const found = new Map<string, string>()
+	if (input.keys.length === 0) return found
+	const chunkSize = 32
+	for (let offset = 0; offset < input.keys.length; offset += chunkSize) {
+		const chunk = input.keys.slice(offset, offset + chunkSize)
+		const placeholders = chunk.map(() => '(?, ?)').join(', ')
+		const rows = await input.db
+			.prepare(
+				`SELECT user_id, vector_id, content_hash
+				FROM vector_embed_fingerprints
+				WHERE (user_id, vector_id) IN (${placeholders})`,
+			)
+			.bind(...chunk.flatMap((key) => [key.userId, key.vectorId]))
+			.all<{
+				user_id: string
+				vector_id: string
+				content_hash: string
+			}>()
+		for (const row of rows.results ?? []) {
+			found.set(
+				vectorEmbedFingerprintKey(row.user_id, row.vector_id),
+				row.content_hash,
+			)
+		}
+	}
+	return found
+}
+
+export async function writeVectorEmbedFingerprints(input: {
+	db: D1Database
+	rows: ReadonlyArray<{
+		userId: string
+		vectorId: string
+		contentHash: string
+	}>
+}) {
+	const now = new Date().toISOString()
+	for (const row of input.rows) {
+		await input.db
+			.prepare(
+				`INSERT INTO vector_embed_fingerprints (
+					user_id, vector_id, content_hash, updated_at
+				) VALUES (?, ?, ?, ?)
+				ON CONFLICT(user_id, vector_id) DO UPDATE SET
+					content_hash = excluded.content_hash,
+					updated_at = excluded.updated_at`,
+			)
+			.bind(row.userId, row.vectorId, row.contentHash, now)
+			.run()
+	}
+}
+
+export async function deleteVectorEmbedFingerprint(input: {
+	db: D1Database
+	vectorId: string
+}) {
+	await input.db
+		.prepare(`DELETE FROM vector_embed_fingerprints WHERE vector_id = ?`)
+		.bind(input.vectorId)
+		.run()
+}
+
+export async function tryReadVectorEmbedFingerprints(input: {
+	env: Env
+	keys: ReadonlyArray<{ userId: string; vectorId: string }>
+}): Promise<Map<string, string> | null> {
+	if (!hasVectorEmbedFingerprintDb(input.env)) return null
+	try {
+		return await readVectorEmbedFingerprints({
+			db: input.env.APP_DB,
+			keys: input.keys,
+		})
+	} catch (error) {
+		console.error(
+			JSON.stringify({
+				message: 'vector embed fingerprint read failed',
+				error: getErrorMessage(error),
+			}),
+		)
+		return null
+	}
+}
+
+export async function tryWriteVectorEmbedFingerprints(input: {
+	env: Env
+	rows: ReadonlyArray<{
+		userId: string
+		vectorId: string
+		contentHash: string
+	}>
+}) {
+	if (!hasVectorEmbedFingerprintDb(input.env) || input.rows.length === 0) return
+	try {
+		await writeVectorEmbedFingerprints({
+			db: input.env.APP_DB,
+			rows: input.rows,
+		})
+	} catch (error) {
+		console.error(
+			JSON.stringify({
+				message: 'vector embed fingerprint write failed',
+				error: getErrorMessage(error),
+			}),
+		)
+	}
+}
+
+export async function tryDeleteVectorEmbedFingerprint(input: {
+	env: Env
+	vectorId: string
+}) {
+	if (!hasVectorEmbedFingerprintDb(input.env)) return
+	try {
+		await deleteVectorEmbedFingerprint({
+			db: input.env.APP_DB,
+			vectorId: input.vectorId,
+		})
+	} catch (error) {
+		console.error(
+			JSON.stringify({
+				message: 'vector embed fingerprint delete failed',
+				error: getErrorMessage(error),
+			}),
+		)
+	}
+}
+
+export async function shouldSkipVectorEmbed(input: {
+	env: Env
+	userId: string
+	vectorId: string
+	text: string
+}): Promise<boolean> {
+	const existing = await tryReadVectorEmbedFingerprints({
+		env: input.env,
+		keys: [{ userId: input.userId, vectorId: input.vectorId }],
+	})
+	if (!existing) return false
+	const hash = await vectorEmbedContentHash(input.text)
+	return (
+		existing.get(vectorEmbedFingerprintKey(input.userId, input.vectorId)) ===
+		hash
+	)
+}
+
+export async function recordVectorEmbedFingerprint(input: {
+	env: Env
+	userId: string
+	vectorId: string
+	text: string
+}) {
+	if (!hasVectorEmbedFingerprintDb(input.env)) return
+	await tryWriteVectorEmbedFingerprints({
+		env: input.env,
+		rows: [
+			{
+				userId: input.userId,
+				vectorId: input.vectorId,
+				contentHash: await vectorEmbedContentHash(input.text),
+			},
+		],
+	})
+}

--- a/packages/worker/src/vectorize/embedding.ts
+++ b/packages/worker/src/vectorize/embedding.ts
@@ -36,7 +36,7 @@ export const CAPABILITY_EMBEDDING_MODEL = '@cf/baai/bge-small-en-v1.5'
 export const CAPABILITY_EMBEDDING_BATCH_SIZE = 8
 export const CAPABILITY_EMBEDDING_MAX_INPUT_CHARS = 2_000
 
-function truncateEmbeddingInput(text: string) {
+export function truncateEmbeddingInput(text: string) {
 	if (text.length <= CAPABILITY_EMBEDDING_MAX_INPUT_CHARS) return text
 	return text.slice(0, CAPABILITY_EMBEDDING_MAX_INPUT_CHARS)
 }

--- a/packages/worker/src/vectorize/reindex-batches.ts
+++ b/packages/worker/src/vectorize/reindex-batches.ts
@@ -1,5 +1,12 @@
 import { getErrorMessage } from '@kody-internal/shared/error-message.ts'
 import { embedTextsForVectorize } from './embedding.ts'
+import {
+	hasVectorEmbedFingerprintDb,
+	tryReadVectorEmbedFingerprints,
+	tryWriteVectorEmbedFingerprints,
+	vectorEmbedContentHash,
+	vectorEmbedFingerprintKey,
+} from './embed-fingerprints.ts'
 
 export type VectorReindexFailurePhase = 'load' | 'embed' | 'upsert'
 
@@ -18,6 +25,7 @@ export type VectorReindexCandidate = {
 
 export type VectorReindexResult = {
 	upserted: number
+	skipped?: number
 	failed?: number
 	warning?: string
 	error?: string
@@ -37,12 +45,14 @@ export function mergeVectorReindexResults(
 	results: ReadonlyArray<VectorReindexResult>,
 ): VectorReindexResult {
 	let upserted = 0
+	let skipped = 0
 	let failed = 0
 	const failures: Array<VectorReindexFailure> = []
 	const failedIds: Array<string> = []
 	const seenFailedIds = new Set<string>()
 	for (const result of results) {
 		upserted += result.upserted
+		skipped += result.skipped ?? 0
 		failed += result.failed ?? 0
 		for (const failure of result.failures ?? []) {
 			if (failures.length < maxReportedFailures) failures.push(failure)
@@ -53,10 +63,13 @@ export function mergeVectorReindexResults(
 			failedIds.push(failedId)
 		}
 	}
-	if (failed === 0) return { upserted }
+	if (failed === 0) {
+		return skipped > 0 ? { upserted, skipped } : { upserted }
+	}
 	const message = `${failed} ${kind} vector(s) failed to reindex`
 	return {
 		upserted,
+		...(skipped > 0 ? { skipped } : {}),
 		failed,
 		failures,
 		...(failedIds.length > 0 ? { failedIds } : {}),
@@ -69,8 +82,10 @@ export async function reindexVectorCandidates(input: {
 	index: VectorizeIndex
 	kind: string
 	candidates: ReadonlyArray<VectorReindexCandidate>
+	force?: boolean
 }): Promise<VectorReindexResult> {
 	let upserted = 0
+	let skipped = 0
 	let failed = 0
 	const failures: Array<VectorReindexFailure> = []
 	const failedIds: Array<string> = []
@@ -114,29 +129,81 @@ export async function reindexVectorCandidates(input: {
 	}
 
 	async function processBatch(batch: ReadonlyArray<VectorReindexCandidate>) {
+		let pending = batch
+		let pendingHashes: Array<string> | null = null
+		if (!input.force && hasVectorEmbedFingerprintDb(input.env)) {
+			const hashed = await Promise.all(
+				batch.map(async (candidate) => ({
+					candidate,
+					contentHash: await vectorEmbedContentHash(candidate.text),
+				})),
+			)
+			const existing = await tryReadVectorEmbedFingerprints({
+				env: input.env,
+				keys: hashed.map((item) => ({
+					userId: item.candidate.namespace,
+					vectorId: item.candidate.id,
+				})),
+			})
+			if (existing) {
+				const changed: typeof hashed = []
+				for (const item of hashed) {
+					const key = vectorEmbedFingerprintKey(
+						item.candidate.namespace,
+						item.candidate.id,
+					)
+					if (existing.get(key) === item.contentHash) {
+						skipped += 1
+						continue
+					}
+					changed.push(item)
+				}
+				pending = changed.map((item) => item.candidate)
+				pendingHashes = changed.map((item) => item.contentHash)
+			} else {
+				pendingHashes = hashed.map((item) => item.contentHash)
+			}
+		}
+		if (pending.length === 0) return
+
 		let embeddings: Array<Array<number>>
 		try {
 			embeddings = await embedTextsForVectorize(
 				input.env,
-				batch.map((candidate) => candidate.text),
+				pending.map((candidate) => candidate.text),
 			)
 		} catch (error) {
-			await splitOrRecord(batch, 'embed', error)
+			await splitOrRecord(pending, 'embed', error)
 			return
 		}
 
 		try {
 			await input.index.upsert(
-				batch.map((candidate, index_) => ({
+				pending.map((candidate, index_) => ({
 					id: candidate.id,
 					values: embeddings[index_]!,
 					namespace: candidate.namespace,
 					metadata: candidate.metadata,
 				})),
 			)
-			upserted += batch.length
+			upserted += pending.length
+			if (hasVectorEmbedFingerprintDb(input.env)) {
+				const hashes =
+					pendingHashes ??
+					(await Promise.all(
+						pending.map((candidate) => vectorEmbedContentHash(candidate.text)),
+					))
+				await tryWriteVectorEmbedFingerprints({
+					env: input.env,
+					rows: pending.map((candidate, index_) => ({
+						userId: candidate.namespace,
+						vectorId: candidate.id,
+						contentHash: hashes[index_]!,
+					})),
+				})
+			}
 		} catch (error) {
-			await splitOrRecord(batch, 'upsert', error)
+			await splitOrRecord(pending, 'upsert', error)
 		}
 	}
 
@@ -150,10 +217,13 @@ export async function reindexVectorCandidates(input: {
 		)
 	}
 
-	if (failed === 0) return { upserted }
+	if (failed === 0) {
+		return skipped > 0 ? { upserted, skipped } : { upserted }
+	}
 
 	const result: VectorReindexResult = {
 		upserted,
+		...(skipped > 0 ? { skipped } : {}),
 		failed,
 		failures,
 		failedIds,

--- a/packages/worker/src/vectorize/reindex-batches.ts
+++ b/packages/worker/src/vectorize/reindex-batches.ts
@@ -135,7 +135,10 @@ export async function reindexVectorCandidates(input: {
 			const hashed = await Promise.all(
 				batch.map(async (candidate) => ({
 					candidate,
-					contentHash: await vectorEmbedContentHash(candidate.text),
+					contentHash: await vectorEmbedContentHash({
+						text: candidate.text,
+						metadata: candidate.metadata,
+					}),
 				})),
 			)
 			const existing = await tryReadVectorEmbedFingerprints({
@@ -191,7 +194,12 @@ export async function reindexVectorCandidates(input: {
 				const hashes =
 					pendingHashes ??
 					(await Promise.all(
-						pending.map((candidate) => vectorEmbedContentHash(candidate.text)),
+						pending.map((candidate) =>
+							vectorEmbedContentHash({
+								text: candidate.text,
+								metadata: candidate.metadata,
+							}),
+						),
 					))
 				await tryWriteVectorEmbedFingerprints({
 					env: input.env,

--- a/packages/worker/src/vectorize/reindex-sweep.ts
+++ b/packages/worker/src/vectorize/reindex-sweep.ts
@@ -23,6 +23,7 @@ export type CapabilityReindexCursor = {
 export type VectorReindexSweepOptions = {
 	afterId?: string | null
 	deadlineMs?: number
+	force?: boolean
 }
 
 export type VectorReindexSweepResult = VectorReindexResult & {
@@ -104,6 +105,7 @@ export async function reindexVectorCandidateList(input: {
 	candidates: ReadonlyArray<VectorReindexCandidate>
 	afterId?: string | null
 	deadlineMs?: number
+	force?: boolean
 }): Promise<VectorReindexSweepResult> {
 	const startIndex = findResumeIndex(input.candidates, input.afterId)
 	const pageResults: Array<VectorReindexResult> = []
@@ -130,6 +132,7 @@ export async function reindexVectorCandidateList(input: {
 				index: input.index,
 				kind: input.kind,
 				candidates: batch,
+				force: input.force,
 			}),
 		)
 		afterId = batch[batch.length - 1]!.id
@@ -148,6 +151,7 @@ export async function reindexPagedVectorRows<Row>(input: {
 	pageSize: number
 	afterId?: string | null
 	deadlineMs?: number
+	force?: boolean
 	listPage: (input: {
 		afterId: string | null
 		limit: number
@@ -203,6 +207,7 @@ export async function reindexPagedVectorRows<Row>(input: {
 						index: input.index,
 						kind: input.kind,
 						candidates,
+						force: input.force,
 					}),
 				)
 			} else {

--- a/tools/migration-ledger.json
+++ b/tools/migration-ledger.json
@@ -83,6 +83,10 @@
 		{
 			"filename": "0020-user-mcp-oauth-clients.sql",
 			"sha256": "6b60b6a0387fac63ac58f584adfab068cf2541d925ebd2734d04dabbe2672112"
+		},
+		{
+			"filename": "0021-vector-embed-fingerprints.sql",
+			"sha256": "3ddb28704d61caeba6a28b669c4636a9aec2954e66997e1df67d60c68c0ef4e0"
 		}
 	]
 }

--- a/tools/migration-ledger.json
+++ b/tools/migration-ledger.json
@@ -86,7 +86,7 @@
 		},
 		{
 			"filename": "0021-vector-embed-fingerprints.sql",
-			"sha256": "3ddb28704d61caeba6a28b669c4636a9aec2954e66997e1df67d60c68c0ef4e0"
+			"sha256": "5b082b0055c753ecd6e75373ed1aa848ad61862d281f7a1214aa2466f5dafd25"
 		}
 	]
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Full Vectorize rebuilds should not re-embed text that has not changed. Write-time upserts and operator reindex already share one embed-text contract; this PR records that contract in D1 so unchanged rows skip Workers AI and Vectorize. `force: true` exists so a D1 restore cannot skip an empty index after Vectorize data loss.

## Summary

- Add `vector_embed_fingerprints` (`user_id` + `vector_id`) with a SHA-256 of embedding model, dimensions, `vectorEmbedFingerprintVersion`, truncated embed text, and canonical Vectorize metadata.
- Reindex and write-time memory/job/package upserts skip when the hash matches; they record the hash after a successful upsert.
- Memory `status` / `category` are part of the hash so soft-delete, archive, and restore still rewrite Vectorize.
- `POST /__maintenance/reindex-capabilities` accepts `{ "force": true }` to ignore fingerprints (required after Vectorize data loss and after pooling-only embedding changes).
- Account deletion clears user-owned fingerprint rows; portable export omits the table.
- Builtin rows use the reserved `__kody_builtin__` owner id.
- Fingerprint D1 helpers fail open silently so stub/unmigrated `APP_DB` bindings cannot break job delete.

Production deploy CI is unchanged: it still POSTs `{ "phases": ["capabilities"] }` and follows the cursor. Fingerprints make that sweep cheap when builtin embed text and metadata have not changed.

## Testing

- `npx vitest run --project node-unit` on fingerprint, reindex, jobs-vectorize, jobs/service, and run-kody-registry suites.
- `npm run migrations:check` (ledger 0021).
- Preview `kody-pr-1658`: signed in as `user-me`, saved value `preview-fingerprint`, memories/packages APIs 200, export lists `vector_embed_fingerprints` as excluded, maintenance reindex 503 without secret.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `22054b15` · **Head:** `4ada5172`

**Classification:** extends — new D1 skip-cache table and a skip/force contract on Vectorize upserts.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `vectorize-search` | storage | extends — skip unchanged embed text + metadata; `force` rebuilds |
| `d1-app-db` | storage | extends — `vector_embed_fingerprints` + deletion target |
| `mcp-server` | surfaces | extends — memory/job write-time upserts honor the skip cache |
| `saved-packages` | assistant | extends — package write-time upserts honor the skip cache |
| `capability-registry` | assistant | composes — threads `force` into builtin reindex |
| `jobs` | assistant | composes — threads `force` into job reindex |

### Change flow

Write-time upserts and maintenance reindex hash embed text and Vectorize metadata against D1 before calling Workers AI or Vectorize; `force: true` skips that check so a restored fingerprint table cannot leave Vectorize empty.

```mermaid
sequenceDiagram
	actor Operator
	participant capabilityRegistry as capability-registry
	participant vectorizeSearch as vectorize-search
	participant d1AppDb as d1-app-db
	Operator->>capabilityRegistry: POST /__maintenance/reindex-capabilities
	capabilityRegistry->>vectorizeSearch: reindex phase with force
	vectorizeSearch->>d1AppDb: read vector_embed_fingerprints
	alt hash matches and force is false
		vectorizeSearch-->>Operator: skipped (no embed, no Vectorize upsert)
	else miss or force true
		vectorizeSearch->>vectorizeSearch: embed + Vectorize upsert
		vectorizeSearch->>d1AppDb: write content_hash
	end
```

### Before / after

**Reindex body**

```json
{ "phases": ["capabilities"] }
```

```json
{ "phases": ["capabilities"], "force": true }
```

**Disaster recovery:** omit `phases` and POST `{ "force": true }`, then follow `cursor` until `complete`.

### Invariants

Per-user isolation: fingerprint `user_id` is the Vectorize namespace (account stable id, or `__kody_builtin__`). Account deletion deletes `WHERE user_id = ?`. Export omits the derived skip cache. Memory `status` is in the hash so search filters cannot stay stale after soft-delete.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1374096b-5a6f-4674-86f1-b0bdb9100b6a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1374096b-5a6f-4674-86f1-b0bdb9100b6a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reindexing now skips unchanged embeddings and reports skipped items.
  * Added a `force` option to rebuild vectors after data loss or embedding configuration changes.
  * Reindexing supports resumable, cursor-based processing across all phases.

* **Bug Fixes**
  * Removed embedding tracking data when vectors or accounts are deleted.
  * Improved recovery handling for restored vector data.

* **Documentation**
  * Updated setup, maintenance, storage, and disaster-recovery guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->