### PR TITLE
Add a delayed homepage ticker for fleet code runs

### DIFF
--- a/docs/contributing/architecture/authorization.md
+++ b/docs/contributing/architecture/authorization.md
@@ -19,6 +19,13 @@ forked or rated a deliberately public community listing and when, plus rating
 scores. This boundary never exposes forked package source, rating notes,
 secrets, or unrelated account content.
 
+The homepage code-runs ticker is a fifth narrow exception. Anonymous visitors
+and signed-in users see the same delayed fleet total: a `SUM(event_count)` of
+`execute` rows from `usage_rollups` with no user ids. The official
+`{ previous, current, windowStart, windowEnd }` pair lives at the platform KV
+key `public-code-runs:v1`. Homepage GET does not write that key. See
+[Usage metering](./usage-metering.md).
+
 For browser and MCP authentication mechanics, see
 [Authentication](./authentication.md).
 

--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -447,7 +447,8 @@ Two D1 reporting projections deliberately remain:
 OAuth provider state is stored in `OAUTH_KV` through the
 `@cloudflare/workers-oauth-provider` integration. Published package/job source
 snapshots, bundle artifacts, package retriever caches, and community listing
-snapshots are stored in `BUNDLE_ARTIFACTS_KV`.
+snapshots are stored in `BUNDLE_ARTIFACTS_KV`. That binding also holds the
+platform-owned `public-code-runs:v1` window for the homepage ticker.
 
 - Bindings are configured in `packages/worker/wrangler.jsonc` (remote KV IDs are
   supplied at deploy time via generated Wrangler configs, not committed in the
@@ -1276,6 +1277,10 @@ app-owned keys in it. App-owned `BUNDLE_ARTIFACTS_KV` keys are:
   serialized queue message would exceed 120 KB. Immediate account-deletion
   cleanup is not required because KV enforces the TTL; the queue consumer
   deletes the key after a terminal delivery.
+- `public-code-runs:v1` — platform-owned 24-hour delayed fleet `execute` window
+  for the homepage ticker (`{ previous, current, windowStart, windowEnd }`). Not
+  scoped by user id; account deletion must not remove it. Homepage GET is
+  read-only; the `usage_aggregation` lane writes it.
 
 Account deletion derives these keys from D1 rows and package ids before deleting
 D1 projections. New KV prefixes must add corresponding account-deletion coverage
@@ -1443,7 +1448,10 @@ Current retention policies:
   (`userMeterDailyCounterRetentionDays`); `admin_user_meter_parity` reports
   meter-only daily counts.
 - `usage_rollups`: per user/metric/month rollups keep 24 months by `month` key;
-  raw Analytics Engine usage events follow platform retention.
+  raw Analytics Engine usage events follow platform retention. The homepage
+  ticker reads an anonymous `SUM(event_count)` of `execute` rows from this
+  table; the official replay pair is the platform KV key `public-code-runs:v1`
+  and is independent of account deletion/export.
 - `feature_flag_exposure_rollups`: local-dev/test flag exposure rollups keep 90
   days by `day` key, matching Analytics Engine retention for the production
   `FLAG_EXPOSURES` exposure stream; the admin metric readout window is the

--- a/docs/contributing/architecture/usage-metering.md
+++ b/docs/contributing/architecture/usage-metering.md
@@ -13,7 +13,15 @@ document covers event capture and rollups only.
 
 Usage metering follows the repo-wide isolation invariant: every event carries a
 required `userId`, the Analytics Engine index is the `userId`, and the D1 rollup
-table is keyed by `user_id`. There is no cross-user read or write path.
+table is keyed by `user_id`. Admin and account reads stay scoped to one user.
+
+The homepage code-runs ticker is a documented exception: an anonymous
+`SUM(event_count)` of `execute` rows (no user ids) is replayed 24 hours delayed.
+The official `{ previous, current, windowStart, windowEnd }` pair lives at the
+platform KV key `public-code-runs:v1` on `BUNDLE_ARTIFACTS_KV`. Homepage GET
+does not write that key; the hourly `usage_aggregation` lane rotates it. The
+public payload never includes per-user rows. See
+[Authorization](./authorization.md).
 
 ## The event schema
 
@@ -318,6 +326,11 @@ Guarantees and rules:
   `derived-cache:v1:`), keyed by user id + current month, falling through to
   direct D1 queries when KV is unavailable. Usage is loaded for one selected
   account at a time, so admin reads stay O(1) per view as the user base grows.
+- **Public homepage ticker** (`GET /code-runs.json`, SSR on `/`): reads the
+  platform KV pair (or a still D1 sum when KV is empty) and interpolates
+  `previous → current` across the 24-hour window. The payload is the window pair
+  only — never per-user rows. Interpolation is deterministic from the timestamps
+  so every visitor at a given second sees the same number.
 - **Fleet visibility** (`/admin/insights`, loader in
   `packages/worker/src/admin/fleet-usage-insights.ts`): bounded SQL over
   `usage_rollups` for the current UTC month — top-10 combined runtime duration

--- a/docs/contributing/project-intent.md
+++ b/docs/contributing/project-intent.md
@@ -44,14 +44,16 @@ between users.
 Optimize for:
 
 - Per-user isolation as a first-class invariant, enforced at the storage,
-  durable-object, vectorize, and runtime layers. Four narrow, documented
+  durable-object, vectorize, and runtime layers. Five narrow, documented
   exceptions exist: RBAC account administration (`access = 'any'`, limited to
   `user` and `role` entities), operator-owned system email for reserved platform
-  addresses stored under `system:email`, and attributed platform feedback that a
-  user explicitly approved for role-gated admin review, plus role-gated metadata
-  about activity on deliberately public community listings. The community
-  exception covers who forked or rated which listing and when, including rating
-  scores, but never package source, rating notes, or unrelated user content. See
+  addresses stored under `system:email`, attributed platform feedback that a
+  user explicitly approved for role-gated admin review, role-gated metadata
+  about activity on deliberately public community listings, and an anonymous
+  public SUM of fleet `execute` counts (no user ids) that drives the homepage
+  code-runs ticker. The community exception covers who forked or rated which
+  listing and when, including rating scores, but never package source, rating
+  notes, or unrelated user content. See
   [Authorization](./architecture/authorization.md).
 - Fast iteration on the personal-assistant experience
 - Interoperability across MCP-capable hosts
@@ -90,9 +92,10 @@ When working in this repo, do not assume:
   (or that shares a Durable Object id across users) as a bug. The intentional
   cross-user boundaries are RBAC account administration (`:any` on `user`/`role`
   only, behind explicit guards), operator-owned system email for reserved
-  platform addresses, and explicitly approved, attributed platform feedback
-  exposed through role-gated admin review capabilities, plus role-gated
-  community activity metadata for public listings — see
+  platform addresses, explicitly approved, attributed platform feedback exposed
+  through role-gated admin review capabilities, role-gated community activity
+  metadata for public listings, and the anonymous public fleet `execute` SUM
+  behind the homepage code-runs ticker — see
   [Authorization](./architecture/authorization.md).
 - One conversation or one agent per signed-in user. Concurrent chats and
   completely separate agents for the same user are expected. Do not key
@@ -126,9 +129,10 @@ If you are an agent working in this repo:
   be scoped by `userId` at the data layer, by user-namespaced Durable Object ids
   at the runtime layer, and by user-aware filters at the search/vector layer.
   Cross-user access requires an explicit guard and one of the documented narrow
-  boundaries: account administration, operator-owned system email, or
-  user-approved platform feedback, or public-listing community activity metadata
-  — see [Authorization](./architecture/authorization.md).
+  boundaries: account administration, operator-owned system email, user-approved
+  platform feedback, public-listing community activity metadata, or the
+  anonymous public fleet `execute` SUM behind the homepage code-runs ticker —
+  see [Authorization](./architecture/authorization.md).
 - Isolation between users is not the same as one conversation per user. The same
   signed-in user can run concurrent chats and completely separate agents at
   once. Do not hide or bind conversation-scoped context (memories, nudges,

--- a/packages/worker/client/code-runs-ticker.tsx
+++ b/packages/worker/client/code-runs-ticker.tsx
@@ -7,9 +7,9 @@ import {
 
 /**
  * 24-hour delayed fleet execute count. SSR paints the interpolated value;
- * the client advances it only when the displayed integer changes. Tabular
- * numerals plus a reserved width from `current` keep the label from shifting
- * as digits change.
+ * the client advances it only when the displayed integer changes. Mono
+ * digits plus a reserved width from `current` keep the label from shifting
+ * as digits change. The line is sized larger than the hero subtitle.
  */
 export function CodeRunsTicker(
 	handle: Handle<{ window: PublicCodeRunsWindow }>,

--- a/packages/worker/client/code-runs-ticker.tsx
+++ b/packages/worker/client/code-runs-ticker.tsx
@@ -1,0 +1,55 @@
+import { type Handle } from 'remix/ui'
+import {
+	formatCodeRunsCount,
+	interpolateCodeRunsCount,
+	type PublicCodeRunsWindow,
+} from '#universal/code-runs.ts'
+
+/**
+ * 24-hour delayed fleet execute count. SSR paints the interpolated value;
+ * the client advances it only when the displayed integer changes. Tabular
+ * numerals plus a reserved width from `current` keep the label from shifting
+ * as digits change.
+ */
+export function CodeRunsTicker(
+	handle: Handle<{ window: PublicCodeRunsWindow }>,
+) {
+	let nowMs = Date.now()
+	const prefersReducedMotion =
+		typeof matchMedia === 'function' &&
+		matchMedia('(prefers-reduced-motion: reduce)').matches
+
+	if (typeof document !== 'undefined' && !prefersReducedMotion) {
+		const interval = setInterval(() => {
+			const nextMs = Date.now()
+			const previousCount = interpolateCodeRunsCount(handle.props.window, nowMs)
+			const nextCount = interpolateCodeRunsCount(handle.props.window, nextMs)
+			nowMs = nextMs
+			if (nextCount === previousCount) return
+			handle.update()
+		}, 1000)
+		handle.signal.addEventListener(
+			'abort',
+			() => {
+				clearInterval(interval)
+			},
+			{ once: true },
+		)
+	}
+
+	return () => {
+		const count = interpolateCodeRunsCount(handle.props.window, nowMs)
+		const reserved = formatCodeRunsCount(handle.props.window.current)
+		return (
+			<p data-rise style={{ '--rise': '1.5' }} class="landing-hero-runs">
+				<span
+					class="landing-hero-runs-count"
+					style={{ '--runs-ch': `${reserved.length}ch` }}
+				>
+					{formatCodeRunsCount(count)}
+				</span>
+				<span class="landing-hero-runs-label">code runs</span>
+			</p>
+		)
+	}
+}

--- a/packages/worker/client/routes/code-runs-payload.ts
+++ b/packages/worker/client/routes/code-runs-payload.ts
@@ -1,0 +1,23 @@
+import { parsePublicCodeRunsWindow } from '#universal/code-runs.ts'
+import { type CodeRunsLoaderData } from '#universal/loader-data.ts'
+import { routes } from '#universal/routes.ts'
+import { readJson } from '#client/routes/account-approval-shared.ts'
+
+export const codeRunsApiPath = routes.codeRunsApi.href()
+
+export async function fetchCodeRunsPayload(signal?: AbortSignal) {
+	try {
+		const response = await fetch(codeRunsApiPath, {
+			headers: { Accept: 'application/json' },
+			signal,
+		})
+		const payload = await readJson<CodeRunsLoaderData>(response)
+		if (!response.ok || payload?.ok !== true) return null
+		return {
+			ok: true as const,
+			window: parsePublicCodeRunsWindow(payload.window),
+		}
+	} catch {
+		return null
+	}
+}

--- a/packages/worker/client/routes/home.tsx
+++ b/packages/worker/client/routes/home.tsx
@@ -14,6 +14,9 @@ import {
 import { onboardingPath } from '#client/routes/onboarding-redirect.ts'
 import { pendingVerificationPath } from '#client/routes/pending-verification-path.ts'
 import { type RouteLoaderResult } from '#client/route-loader.ts'
+import { CodeRunsTicker } from '#client/code-runs-ticker.tsx'
+import { fetchCodeRunsPayload } from '#client/routes/code-runs-payload.ts'
+import { type PublicCodeRunsWindow } from '#universal/code-runs.ts'
 import { reveal, revealPop } from '#client/reveal.ts'
 import { fetchPublicAuthConfig } from '#client/social-sign-in.ts'
 import {
@@ -117,9 +120,14 @@ export async function homeRouteLoader(
 	_url: URL,
 	signal: AbortSignal,
 ): Promise<RouteLoaderResult> {
-	const onboarding = await fetchOnboardingPayload(signal)
-	if (!onboarding) return {}
-	return { onboarding }
+	const [onboarding, codeRuns] = await Promise.all([
+		fetchOnboardingPayload(signal),
+		fetchCodeRunsPayload(signal),
+	])
+	const result: RouteLoaderResult = {}
+	if (onboarding) result.onboarding = onboarding
+	if (codeRuns) result.codeRuns = codeRuns
+	return result
 }
 
 export function HomeRoute(handle: Handle) {
@@ -127,6 +135,7 @@ export function HomeRoute(handle: Handle) {
 	let emailVerified = false
 	let loggedIn = false
 	let discoveryPrompt = ''
+	let codeRunsWindow: PublicCodeRunsWindow | null = null
 	let onboardingStatus: 'idle' | 'loading' | 'ready' = 'idle'
 	const loadLatch = createRouteLoadLatch()
 
@@ -138,12 +147,22 @@ export function HomeRoute(handle: Handle) {
 		onboardingStatus = 'ready'
 	}
 
-	async function loadOnboarding(signal: AbortSignal) {
+	function applyCodeRunsPayload(
+		payload: { window: PublicCodeRunsWindow | null } | null,
+	) {
+		codeRunsWindow = payload?.window ?? null
+	}
+
+	async function loadHomePayload(signal: AbortSignal) {
 		const href = readCurrentRouterHref(handle)
 		try {
-			const payload = await fetchOnboardingPayload(signal)
+			const [payload, codeRuns] = await Promise.all([
+				fetchOnboardingPayload(signal),
+				fetchCodeRunsPayload(signal),
+			])
 			if (signal.aborted) return
 			applyOnboardingPayload(payload)
+			applyCodeRunsPayload(codeRuns)
 			loadLatch.markLoaded(href)
 			handle.update()
 		} catch {
@@ -157,9 +176,11 @@ export function HomeRoute(handle: Handle) {
 
 	function applyRouteLoaderData(href: string) {
 		if (!isHomePath(href)) return false
-		const routeData = tryConsumeRouteLoaderData(handle, 'onboarding', href)
-		if (!routeData) return false
-		applyOnboardingPayload(routeData)
+		const onboardingData = tryConsumeRouteLoaderData(handle, 'onboarding', href)
+		const codeRunsData = tryConsumeRouteLoaderData(handle, 'codeRuns', href)
+		if (codeRunsData) applyCodeRunsPayload(codeRunsData)
+		if (!onboardingData) return false
+		applyOnboardingPayload(onboardingData)
 		loadLatch.markLoaded(href)
 		return true
 	}
@@ -176,7 +197,7 @@ export function HomeRoute(handle: Handle) {
 		})
 		if (needsLoad && typeof document !== 'undefined') {
 			onboardingStatus = 'loading'
-			handle.queueTask(loadOnboarding)
+			handle.queueTask(loadHomePayload)
 		}
 
 		const isSignedIn = onboardingStatus === 'ready' && loggedIn
@@ -200,6 +221,7 @@ export function HomeRoute(handle: Handle) {
 						work into deterministic code you can run on a trigger or save tokens
 						with your agent.
 					</p>
+					{codeRunsWindow ? <CodeRunsTicker window={codeRunsWindow} /> : null}
 					<div data-rise style={{ '--rise': '2' }} class="landing-hero-actions">
 						{isSignedIn ? (
 							<>

--- a/packages/worker/client/routes/home.tsx
+++ b/packages/worker/client/routes/home.tsx
@@ -150,7 +150,8 @@ export function HomeRoute(handle: Handle) {
 	function applyCodeRunsPayload(
 		payload: { window: PublicCodeRunsWindow | null } | null,
 	) {
-		codeRunsWindow = payload?.window ?? null
+		if (!payload) return
+		codeRunsWindow = payload.window
 	}
 
 	async function loadHomePayload(signal: AbortSignal) {

--- a/packages/worker/public/styles.css
+++ b/packages/worker/public/styles.css
@@ -838,14 +838,10 @@ html.is-settled {
 	display: flex;
 	align-items: baseline;
 	justify-content: center;
-	column-gap: 0.4em;
-	font-size: 0.95rem;
+	column-gap: 0.45em;
+	font-size: clamp(1.3rem, 2.2vw, 1.65rem);
 	color: var(--color-text-muted);
 	white-space: nowrap;
-	font-variant-numeric: tabular-nums lining-nums;
-	font-feature-settings:
-		'tnum' 1,
-		'lnum' 1;
 }
 
 .landing-hero-runs-count {
@@ -853,8 +849,8 @@ html.is-settled {
 	box-sizing: content-box;
 	min-width: var(--runs-ch, 1ch);
 	text-align: end;
-	font-family: var(--font-body);
-	font-weight: 650;
+	font-family: var(--font-mono);
+	font-weight: 600;
 	font-variant-numeric: tabular-nums lining-nums;
 	font-feature-settings:
 		'tnum' 1,

--- a/packages/worker/public/styles.css
+++ b/packages/worker/public/styles.css
@@ -833,6 +833,39 @@ html.is-settled {
 	color: var(--color-text);
 }
 
+.landing-hero-runs {
+	margin: 0.85rem auto 0;
+	display: flex;
+	align-items: baseline;
+	justify-content: center;
+	column-gap: 0.4em;
+	font-size: 0.95rem;
+	color: var(--color-text-muted);
+	white-space: nowrap;
+	font-variant-numeric: tabular-nums lining-nums;
+	font-feature-settings:
+		'tnum' 1,
+		'lnum' 1;
+}
+
+.landing-hero-runs-count {
+	display: inline-block;
+	box-sizing: content-box;
+	min-width: var(--runs-ch, 1ch);
+	text-align: end;
+	font-family: var(--font-body);
+	font-weight: 650;
+	font-variant-numeric: tabular-nums lining-nums;
+	font-feature-settings:
+		'tnum' 1,
+		'lnum' 1;
+	color: var(--color-text);
+}
+
+.landing-hero-runs-label {
+	font-weight: 500;
+}
+
 .landing-hero-actions {
 	margin-top: 2.2rem;
 	display: flex;

--- a/packages/worker/src/app/handlers/code-runs.node.test.ts
+++ b/packages/worker/src/app/handlers/code-runs.node.test.ts
@@ -1,0 +1,34 @@
+import { expect, test } from 'vitest'
+import { createCodeRunsApiHandler } from './code-runs.ts'
+
+test('code-runs.json returns a public window when KV has a pair', async () => {
+	const window = {
+		previous: 1000,
+		current: 1240,
+		windowStart: '2026-08-21T00:00:00.000Z',
+		windowEnd: '2026-08-22T00:00:00.000Z',
+	}
+	const env = {
+		BUNDLE_ARTIFACTS_KV: {
+			async get(_key: string, type?: string) {
+				return type === 'json' ? window : JSON.stringify(window)
+			},
+		},
+	} as Env
+	const response = await createCodeRunsApiHandler(env).handler()
+	expect(response.status).toBe(200)
+	expect(response.headers.get('cache-control')).toContain('max-age=60')
+	await expect(response.json()).resolves.toEqual({ ok: true, window })
+})
+
+test('code-runs.json returns a null window when nothing is stored', async () => {
+	const env = {
+		BUNDLE_ARTIFACTS_KV: {
+			async get() {
+				return null
+			},
+		},
+	} as Env
+	const response = await createCodeRunsApiHandler(env).handler()
+	await expect(response.json()).resolves.toEqual({ ok: true, window: null })
+})

--- a/packages/worker/src/app/handlers/code-runs.ts
+++ b/packages/worker/src/app/handlers/code-runs.ts
@@ -1,0 +1,21 @@
+import { jsonResponse } from '#worker/json-response.ts'
+import { loadPublicCodeRunsWindow } from '#worker/usage/code-runs-window.ts'
+import { type routes } from '#universal/routes.ts'
+import { type Action } from 'remix/router'
+
+export function createCodeRunsApiHandler(env: Env) {
+	return {
+		middleware: [],
+		async handler() {
+			const window = await loadPublicCodeRunsWindow(env)
+			return jsonResponse(
+				{ ok: true, window },
+				{
+					headers: {
+						'Cache-Control': 'public, max-age=60, stale-while-revalidate=300',
+					},
+				},
+			)
+		},
+	} satisfies Action<typeof routes.codeRunsApi>
+}

--- a/packages/worker/src/app/handlers/home.ts
+++ b/packages/worker/src/app/handlers/home.ts
@@ -15,6 +15,7 @@ import {
 	loadPublicOnboardingData,
 } from '#app/onboarding-data.ts'
 import { renderAppPage } from '#app/ssr-render.tsx'
+import { loadPublicCodeRunsWindow } from '#worker/usage/code-runs-window.ts'
 import { type routes } from '#universal/routes.ts'
 
 export function createHomeHandler(env: Env) {
@@ -28,6 +29,9 @@ export function createHomeHandler(env: Env) {
 					origin,
 				)
 			}
+
+			const codeRunsWindow = await loadPublicCodeRunsWindow(env)
+			const codeRuns = { ok: true as const, window: codeRunsWindow }
 
 			const user = await readAuthenticatedAppUser(request, env)
 			if (!user) {
@@ -44,6 +48,7 @@ export function createHomeHandler(env: Env) {
 									env,
 									requestUrl: request.url,
 								}),
+								codeRuns,
 							},
 						}),
 					),
@@ -63,7 +68,7 @@ export function createHomeHandler(env: Env) {
 					await renderAppPage({
 						request,
 						env,
-						loaderData: { onboarding },
+						loaderData: { onboarding, codeRuns },
 					}),
 				),
 				origin,

--- a/packages/worker/src/app/router.ts
+++ b/packages/worker/src/app/router.ts
@@ -200,6 +200,7 @@ import {
 	createSecurityTxtHandler,
 	createSitemapHandler,
 } from '#app/handlers/agent-discovery.ts'
+import { createCodeRunsApiHandler } from '#app/handlers/code-runs.ts'
 import { createHomeHandler } from '#app/handlers/home.ts'
 import { createLoginHandler } from '#app/handlers/login.ts'
 import { createOgPageImageHandler } from '#app/handlers/og-page-image.ts'
@@ -258,6 +259,7 @@ export function createAppRouter(env: Env) {
 	router.map(routes, {
 		actions: {
 			home: createHomeHandler(env),
+			codeRunsApi: createCodeRunsApiHandler(env),
 			robotsTxt: createRobotsTxtHandler(env),
 			sitemap: createSitemapHandler(env),
 			authMarkdown: createAuthMarkdownHandler(env),

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -29,6 +29,10 @@ import { resetDataCacheForTests } from '#app/data-cache.ts'
 import { firstPartySecurityHeaders } from '#app/security-headers.ts'
 import { testStableUserIdFromEmail } from '#worker/test-support/stable-user-id.ts'
 import { BLOG_PLACEHOLDER_CALLOUT } from '#universal/blog-display.ts'
+import {
+	formatCodeRunsCount,
+	interpolateCodeRunsCount,
+} from '#universal/code-runs.ts'
 import { planLimits } from '#universal/plans.ts'
 import { getScrollRestorationInlineScript } from '#universal/router-scroll-restoration.ts'
 import type * as CommunitySocialRepo from '#worker/community/social-repo.ts'
@@ -682,6 +686,35 @@ test('renderAppPage caches anonymous marketing HTML and keeps session pages priv
 		env,
 	})
 	expect(login.headers.get('Cache-Control')).toBe('no-store')
+})
+
+test('renderAppPage embeds a tabular homepage code-runs ticker', async () => {
+	resetDataCacheForTests()
+	setAuthSessionSecret(testCookieSecret)
+	const env = createTestEnv(createUserTestDb([]))
+	const window = {
+		previous: 128447,
+		current: 151203,
+		windowStart: '2026-08-22T00:00:00.000Z',
+		windowEnd: '2026-08-23T00:00:00.000Z',
+	}
+	const response = await renderAppPage({
+		request: new Request('https://example.com/'),
+		env,
+		loaderData: { codeRuns: { ok: true, window } },
+	})
+	expect(response.status).toBe(200)
+	const html = await readResponseText(response)
+	const count = interpolateCodeRunsCount(window, Date.now())
+	const ticker = html.match(
+		/<p[^>]*class="landing-hero-runs"[\s\S]*?<\/p>/,
+	)?.[0]
+	expect(ticker).toBeTruthy()
+	expect(ticker).toContain('landing-hero-runs-count')
+	expect(ticker).toMatch(/--runs-ch:\s*7ch/)
+	expect(ticker).toContain(formatCodeRunsCount(count))
+	expect(ticker).toContain('code runs')
+	expect(html).not.toContain('aria-live')
 })
 
 test('signup social buttons are icon-only with accessible names', async () => {

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -698,14 +698,22 @@ test('renderAppPage embeds a tabular homepage code-runs ticker', async () => {
 		windowStart: '2026-08-22T00:00:00.000Z',
 		windowEnd: '2026-08-23T00:00:00.000Z',
 	}
-	const response = await renderAppPage({
-		request: new Request('https://example.com/'),
-		env,
-		loaderData: { codeRuns: { ok: true, window } },
-	})
-	expect(response.status).toBe(200)
-	const html = await readResponseText(response)
-	const count = interpolateCodeRunsCount(window, Date.now())
+	const nowMs = Date.parse('2026-08-22T12:00:00.000Z')
+	vi.useFakeTimers()
+	vi.setSystemTime(nowMs)
+	let html: string
+	try {
+		const response = await renderAppPage({
+			request: new Request('https://example.com/'),
+			env,
+			loaderData: { codeRuns: { ok: true, window } },
+		})
+		expect(response.status).toBe(200)
+		html = await readResponseText(response)
+	} finally {
+		vi.useRealTimers()
+	}
+	const count = interpolateCodeRunsCount(window, nowMs)
 	const ticker = html.match(
 		/<p[^>]*class="landing-hero-runs"[\s\S]*?<\/p>/,
 	)?.[0]

--- a/packages/worker/src/scheduled/scheduled-lanes.ts
+++ b/packages/worker/src/scheduled/scheduled-lanes.ts
@@ -17,6 +17,7 @@ import { reconcileArtifactsPushes } from '#worker/jobs/reconcile-artifacts-pushe
 import { cleanupRepoSessionBranches } from '#worker/repo/repo-session-cleanup.ts'
 import { backfillStorageBucketEstimates } from '#worker/storage-buckets/estimate-backfill.ts'
 import { aggregateUsageRollups } from '#worker/usage/aggregate-rollups.ts'
+import { refreshPublicCodeRunsWindow } from '#worker/usage/code-runs-window.ts'
 
 export {
 	isScheduledLaneName,
@@ -97,8 +98,14 @@ export async function runScheduledLane(input: {
 			return pruneRetention({ env: input.env, now: input.scheduledAt })
 		case 'job_retention':
 			return pruneJobRetention({ env: input.env, now: input.scheduledAt })
-		case 'usage_aggregation':
-			return aggregateUsageRollups(input.env, input.scheduledAt)
+		case 'usage_aggregation': {
+			const result = await aggregateUsageRollups(input.env, input.scheduledAt)
+			await refreshPublicCodeRunsWindow({
+				env: input.env,
+				now: input.scheduledAt,
+			})
+			return result
+		}
 		case 'auth_denial_alert':
 			return checkAuthDenialBurstAndNotify({
 				env: input.env,

--- a/packages/worker/src/usage/code-runs-window.node.test.ts
+++ b/packages/worker/src/usage/code-runs-window.node.test.ts
@@ -1,0 +1,136 @@
+import { DatabaseSync } from 'node:sqlite'
+import { expect, test } from 'vitest'
+import { createD1FromSqlite } from '#worker/test-support/create-d1-from-sqlite.ts'
+import { ensureUsageRollupsTestSchema } from '#worker/usage/test-schema.ts'
+import {
+	loadPublicCodeRunsWindow,
+	publicCodeRunsKvKey,
+	refreshPublicCodeRunsWindow,
+} from './code-runs-window.ts'
+
+function createMemoryKv(initial?: Record<string, string>) {
+	const store = new Map<string, string>(Object.entries(initial ?? {}))
+	return {
+		async get(key: string, type?: string) {
+			const raw = store.get(key)
+			if (raw === undefined) return null
+			return type === 'json' ? JSON.parse(raw) : raw
+		},
+		async put(key: string, value: string) {
+			store.set(key, value)
+		},
+		store,
+	} as unknown as KVNamespace & { store: Map<string, string> }
+}
+
+async function createEnv(input?: {
+	rows?: Array<{ userId: string; month: string; eventCount: number }>
+	window?: unknown
+}) {
+	const sqlite = new DatabaseSync(':memory:')
+	const db = createD1FromSqlite(sqlite)
+	await ensureUsageRollupsTestSchema(db)
+	for (const row of input?.rows ?? []) {
+		await db
+			.prepare(
+				`INSERT INTO usage_rollups (
+					user_id, metric, month, event_count, error_count,
+					total_duration_ms, total_cpu_ms, total_bytes
+				) VALUES (?, 'execute', ?, ?, 0, 0, 0, 0)`,
+			)
+			.bind(row.userId, row.month, row.eventCount)
+			.run()
+	}
+	const kv = createMemoryKv(
+		input?.window
+			? { [publicCodeRunsKvKey]: JSON.stringify(input.window) }
+			: undefined,
+	)
+	return { APP_DB: db, BUNDLE_ARTIFACTS_KV: kv }
+}
+
+test('refreshPublicCodeRunsWindow initializes a still pair, holds it for 24h, then rotates without going backwards', async () => {
+	const env = await createEnv({
+		rows: [
+			{ userId: 'a', month: '2026-07', eventCount: 40 },
+			{ userId: 'b', month: '2026-08', eventCount: 60 },
+		],
+	})
+	const start = new Date('2026-08-21T00:00:00.000Z')
+	await expect(
+		refreshPublicCodeRunsWindow({ env, now: start }),
+	).resolves.toEqual({ status: 'initialized' })
+
+	const still = await loadPublicCodeRunsWindow(env, start)
+	expect(still).toEqual({
+		previous: 100,
+		current: 100,
+		windowStart: '2026-08-21T00:00:00.000Z',
+		windowEnd: '2026-08-22T00:00:00.000Z',
+	})
+
+	await env.APP_DB.prepare(
+		`UPDATE usage_rollups SET event_count = 90 WHERE user_id = 'b'`,
+	).run()
+	await expect(
+		refreshPublicCodeRunsWindow({
+			env,
+			now: new Date('2026-08-21T23:59:00.000Z'),
+		}),
+	).resolves.toEqual({ status: 'held' })
+	expect(await loadPublicCodeRunsWindow(env, start)).toEqual(still)
+
+	await expect(
+		refreshPublicCodeRunsWindow({
+			env,
+			now: new Date('2026-08-22T00:00:00.000Z'),
+		}),
+	).resolves.toEqual({ status: 'rotated' })
+	expect(
+		await loadPublicCodeRunsWindow(env, new Date('2026-08-22T00:00:00.000Z')),
+	).toEqual({
+		previous: 100,
+		current: 130,
+		windowStart: '2026-08-22T00:00:00.000Z',
+		windowEnd: '2026-08-23T00:00:00.000Z',
+	})
+
+	await env.APP_DB.prepare(
+		`UPDATE usage_rollups SET event_count = 10 WHERE user_id = 'b'`,
+	).run()
+	await expect(
+		refreshPublicCodeRunsWindow({
+			env,
+			now: new Date('2026-08-23T00:00:00.000Z'),
+		}),
+	).resolves.toEqual({ status: 'rotated' })
+	expect(
+		await loadPublicCodeRunsWindow(env, new Date('2026-08-23T00:00:00.000Z')),
+	).toEqual({
+		previous: 130,
+		current: 130,
+		windowStart: '2026-08-23T00:00:00.000Z',
+		windowEnd: '2026-08-24T00:00:00.000Z',
+	})
+})
+
+test('loadPublicCodeRunsWindow falls back to a still D1 sum when KV is empty', async () => {
+	const env = await createEnv({
+		rows: [{ userId: 'a', month: '2026-08', eventCount: 12 }],
+	})
+	env.BUNDLE_ARTIFACTS_KV.store.clear()
+	expect(
+		await loadPublicCodeRunsWindow(env, new Date('2026-08-22T12:00:00.000Z')),
+	).toMatchObject({ previous: 12, current: 12 })
+})
+
+test('refreshPublicCodeRunsWindow skips when there are no execute events', async () => {
+	const env = await createEnv()
+	await expect(
+		refreshPublicCodeRunsWindow({
+			env,
+			now: new Date('2026-08-22T00:00:00.000Z'),
+		}),
+	).resolves.toEqual({ status: 'skipped', reason: 'no_runs' })
+	expect(await loadPublicCodeRunsWindow(env)).toBeNull()
+})

--- a/packages/worker/src/usage/code-runs-window.node.test.ts
+++ b/packages/worker/src/usage/code-runs-window.node.test.ts
@@ -124,6 +124,23 @@ test('loadPublicCodeRunsWindow falls back to a still D1 sum when KV is empty', a
 	).toMatchObject({ previous: 12, current: 12 })
 })
 
+test('refreshPublicCodeRunsWindow skips and load hides when KV get fails', async () => {
+	const env = await createEnv({
+		rows: [{ userId: 'a', month: '2026-08', eventCount: 12 }],
+	})
+	env.BUNDLE_ARTIFACTS_KV.get = async () => {
+		throw new Error('kv down')
+	}
+	await expect(
+		refreshPublicCodeRunsWindow({
+			env,
+			now: new Date('2026-08-22T00:00:00.000Z'),
+		}),
+	).resolves.toEqual({ status: 'skipped', reason: 'kv_read_failed' })
+	expect(env.BUNDLE_ARTIFACTS_KV.store.size).toBe(0)
+	expect(await loadPublicCodeRunsWindow(env)).toBeNull()
+})
+
 test('refreshPublicCodeRunsWindow skips when there are no execute events', async () => {
 	const env = await createEnv()
 	await expect(

--- a/packages/worker/src/usage/code-runs-window.ts
+++ b/packages/worker/src/usage/code-runs-window.ts
@@ -1,0 +1,114 @@
+import {
+	parsePublicCodeRunsWindow,
+	publicCodeRunsWindowMs,
+	type PublicCodeRunsWindow,
+} from '#universal/code-runs.ts'
+
+export const publicCodeRunsKvKey = 'public-code-runs:v1'
+
+type CodeRunsWindowEnv = {
+	APP_DB?: D1Database
+	BUNDLE_ARTIFACTS_KV?: KVNamespace
+}
+
+export async function loadPublicCodeRunsWindow(
+	env: CodeRunsWindowEnv,
+	now: Date = new Date(),
+): Promise<PublicCodeRunsWindow | null> {
+	const stored = await readStoredWindow(env)
+	if (stored) return stored
+	const total = await sumExecuteEventCount(env)
+	if (total === null || total <= 0) return null
+	return stillWindow(total, now)
+}
+
+export async function refreshPublicCodeRunsWindow(input: {
+	env: CodeRunsWindowEnv
+	now?: Date
+}): Promise<
+	| { status: 'initialized' | 'rotated' | 'held' }
+	| { status: 'skipped'; reason: 'no_kv' | 'no_runs' | 'query_failed' }
+> {
+	const kv = input.env.BUNDLE_ARTIFACTS_KV
+	if (!kv) return { status: 'skipped', reason: 'no_kv' }
+	const now = input.now ?? new Date()
+	try {
+		const total = await sumExecuteEventCount(input.env)
+		if (total === null) return { status: 'skipped', reason: 'query_failed' }
+		if (total <= 0) return { status: 'skipped', reason: 'no_runs' }
+
+		const existing = await readStoredWindow(input.env)
+		if (!existing) {
+			await writeStoredWindow(kv, stillWindow(total, now))
+			return { status: 'initialized' }
+		}
+
+		const windowEndMs = Date.parse(existing.windowEnd)
+		if (Number.isFinite(windowEndMs) && now.getTime() < windowEndMs) {
+			return { status: 'held' }
+		}
+
+		const previous = existing.current
+		const current = Math.max(total, previous)
+		await writeStoredWindow(kv, {
+			previous,
+			current,
+			windowStart: now.toISOString(),
+			windowEnd: new Date(now.getTime() + publicCodeRunsWindowMs).toISOString(),
+		})
+		return { status: 'rotated' }
+	} catch (error) {
+		console.warn('public-code-runs-window-refresh-failed', error)
+		return { status: 'skipped', reason: 'query_failed' }
+	}
+}
+
+async function readStoredWindow(
+	env: CodeRunsWindowEnv,
+): Promise<PublicCodeRunsWindow | null> {
+	const kv = env.BUNDLE_ARTIFACTS_KV
+	if (!kv) return null
+	try {
+		return parsePublicCodeRunsWindow(await kv.get(publicCodeRunsKvKey, 'json'))
+	} catch (error) {
+		console.debug('public-code-runs-window-read-failed', error)
+		return null
+	}
+}
+
+async function writeStoredWindow(
+	kv: KVNamespace,
+	window: PublicCodeRunsWindow,
+) {
+	await kv.put(publicCodeRunsKvKey, JSON.stringify(window))
+}
+
+function stillWindow(total: number, now: Date): PublicCodeRunsWindow {
+	return {
+		previous: total,
+		current: total,
+		windowStart: now.toISOString(),
+		windowEnd: new Date(now.getTime() + publicCodeRunsWindowMs).toISOString(),
+	}
+}
+
+async function sumExecuteEventCount(
+	env: CodeRunsWindowEnv,
+): Promise<number | null> {
+	if (!env.APP_DB) return null
+	try {
+		const row = await env.APP_DB.prepare(
+			`SELECT COALESCE(SUM(event_count), 0) AS total
+			 FROM usage_rollups
+			 WHERE metric = 'execute'`,
+		).first<{ total: number }>()
+		const total = row?.total
+		if (typeof total !== 'number' || !Number.isFinite(total) || total < 0) {
+			return 0
+		}
+		return Math.floor(total)
+	} catch (error) {
+		console.debug('public-code-runs-sum-failed', error)
+		return null
+	}
+}

--- a/packages/worker/src/usage/code-runs-window.ts
+++ b/packages/worker/src/usage/code-runs-window.ts
@@ -16,7 +16,8 @@ export async function loadPublicCodeRunsWindow(
 	now: Date = new Date(),
 ): Promise<PublicCodeRunsWindow | null> {
 	const stored = await readStoredWindow(env)
-	if (stored) return stored
+	if (stored.status === 'failed') return null
+	if (stored.status === 'found') return stored.window
 	const total = await sumExecuteEventCount(env)
 	if (total === null || total <= 0) return null
 	return stillWindow(total, now)
@@ -27,7 +28,10 @@ export async function refreshPublicCodeRunsWindow(input: {
 	now?: Date
 }): Promise<
 	| { status: 'initialized' | 'rotated' | 'held' }
-	| { status: 'skipped'; reason: 'no_kv' | 'no_runs' | 'query_failed' }
+	| {
+			status: 'skipped'
+			reason: 'no_kv' | 'no_runs' | 'query_failed' | 'kv_read_failed'
+	  }
 > {
 	const kv = input.env.BUNDLE_ARTIFACTS_KV
 	if (!kv) return { status: 'skipped', reason: 'no_kv' }
@@ -38,17 +42,21 @@ export async function refreshPublicCodeRunsWindow(input: {
 		if (total <= 0) return { status: 'skipped', reason: 'no_runs' }
 
 		const existing = await readStoredWindow(input.env)
-		if (!existing) {
+		if (existing.status === 'failed') {
+			return { status: 'skipped', reason: 'kv_read_failed' }
+		}
+		if (existing.status === 'missing') {
 			await writeStoredWindow(kv, stillWindow(total, now))
 			return { status: 'initialized' }
 		}
+		const existingWindow = existing.window
 
-		const windowEndMs = Date.parse(existing.windowEnd)
+		const windowEndMs = Date.parse(existingWindow.windowEnd)
 		if (Number.isFinite(windowEndMs) && now.getTime() < windowEndMs) {
 			return { status: 'held' }
 		}
 
-		const previous = existing.current
+		const previous = existingWindow.current
 		const current = Math.max(total, previous)
 		await writeStoredWindow(kv, {
 			previous,
@@ -65,14 +73,21 @@ export async function refreshPublicCodeRunsWindow(input: {
 
 async function readStoredWindow(
 	env: CodeRunsWindowEnv,
-): Promise<PublicCodeRunsWindow | null> {
+): Promise<
+	| { status: 'found'; window: PublicCodeRunsWindow }
+	| { status: 'missing' }
+	| { status: 'failed' }
+> {
 	const kv = env.BUNDLE_ARTIFACTS_KV
-	if (!kv) return null
+	if (!kv) return { status: 'missing' }
 	try {
-		return parsePublicCodeRunsWindow(await kv.get(publicCodeRunsKvKey, 'json'))
+		const window = parsePublicCodeRunsWindow(
+			await kv.get(publicCodeRunsKvKey, 'json'),
+		)
+		return window ? { status: 'found', window } : { status: 'missing' }
 	} catch (error) {
 		console.debug('public-code-runs-window-read-failed', error)
-		return null
+		return { status: 'failed' }
 	}
 }
 

--- a/packages/worker/universal/code-runs.node.test.ts
+++ b/packages/worker/universal/code-runs.node.test.ts
@@ -1,0 +1,50 @@
+import { expect, test } from 'vitest'
+import {
+	formatCodeRunsCount,
+	interpolateCodeRunsCount,
+	parsePublicCodeRunsWindow,
+} from './code-runs.ts'
+
+const windowStart = '2026-08-21T00:00:00.000Z'
+const windowEnd = '2026-08-22T00:00:00.000Z'
+const startMs = Date.parse(windowStart)
+const hourMs = 60 * 60 * 1000
+
+const window = {
+	previous: 1000,
+	current: 1240,
+	windowStart,
+	windowEnd,
+}
+
+test('interpolateCodeRunsCount spreads yesterday’s delta across 24 hours and never overshoots', () => {
+	expect(interpolateCodeRunsCount(window, startMs - 1)).toBe(1000)
+	expect(interpolateCodeRunsCount(window, startMs)).toBe(1000)
+	expect(interpolateCodeRunsCount(window, startMs + 12 * hourMs)).toBe(1120)
+	expect(interpolateCodeRunsCount(window, startMs + 24 * hourMs - 1)).toBe(1239)
+	expect(interpolateCodeRunsCount(window, startMs + 24 * hourMs)).toBe(1240)
+	expect(interpolateCodeRunsCount(window, startMs + 30 * hourMs)).toBe(1240)
+})
+
+test('interpolateCodeRunsCount sits still when the pair has not moved', () => {
+	const still = { ...window, previous: 80, current: 80 }
+	expect(interpolateCodeRunsCount(still, startMs + 6 * hourMs)).toBe(80)
+})
+
+test('parsePublicCodeRunsWindow accepts a valid pair and rejects junk', () => {
+	expect(parsePublicCodeRunsWindow(window)).toEqual(window)
+	expect(parsePublicCodeRunsWindow({ ...window, current: 900 })).toEqual({
+		...window,
+		current: 1000,
+	})
+	expect(parsePublicCodeRunsWindow({ ...window, previous: -1 })).toBeNull()
+	expect(parsePublicCodeRunsWindow({ ...window, windowEnd: windowStart })).toBe(
+		null,
+	)
+	expect(parsePublicCodeRunsWindow(null)).toBeNull()
+})
+
+test('formatCodeRunsCount uses grouping so reserved width stays stable', () => {
+	expect(formatCodeRunsCount(128447)).toBe('128,447')
+	expect(formatCodeRunsCount(0)).toBe('0')
+})

--- a/packages/worker/universal/code-runs.node.test.ts
+++ b/packages/worker/universal/code-runs.node.test.ts
@@ -41,6 +41,12 @@ test('parsePublicCodeRunsWindow accepts a valid pair and rejects junk', () => {
 	expect(parsePublicCodeRunsWindow({ ...window, windowEnd: windowStart })).toBe(
 		null,
 	)
+	expect(
+		parsePublicCodeRunsWindow({
+			...window,
+			windowEnd: '2026-08-21T12:00:00.000Z',
+		}),
+	).toBeNull()
 	expect(parsePublicCodeRunsWindow(null)).toBeNull()
 })
 

--- a/packages/worker/universal/code-runs.ts
+++ b/packages/worker/universal/code-runs.ts
@@ -1,0 +1,67 @@
+/**
+ * Public homepage “code runs” ticker: a 24-hour delayed replay of fleet
+ * `execute` event counts. Interpolation is deterministic from the window
+ * timestamps so every visitor at a given second sees the same number.
+ */
+
+export const publicCodeRunsWindowMs = 24 * 60 * 60 * 1000
+
+export type PublicCodeRunsWindow = {
+	previous: number
+	current: number
+	windowStart: string
+	windowEnd: string
+}
+
+export function parsePublicCodeRunsWindow(
+	value: unknown,
+): PublicCodeRunsWindow | null {
+	if (!value || typeof value !== 'object') return null
+	const record = value as Record<string, unknown>
+	const previous = readNonNegativeInt(record.previous)
+	const current = readNonNegativeInt(record.current)
+	if (previous === null || current === null) return null
+	if (typeof record.windowStart !== 'string') return null
+	if (typeof record.windowEnd !== 'string') return null
+	const startMs = Date.parse(record.windowStart)
+	const endMs = Date.parse(record.windowEnd)
+	if (!Number.isFinite(startMs) || !Number.isFinite(endMs)) return null
+	if (endMs <= startMs) return null
+	return {
+		previous,
+		current: Math.max(current, previous),
+		windowStart: record.windowStart,
+		windowEnd: record.windowEnd,
+	}
+}
+
+export function interpolateCodeRunsCount(
+	window: PublicCodeRunsWindow,
+	nowMs: number,
+): number {
+	const previous = window.previous
+	const current = Math.max(window.current, previous)
+	const startMs = Date.parse(window.windowStart)
+	const endMs = Date.parse(window.windowEnd)
+	if (
+		!Number.isFinite(startMs) ||
+		!Number.isFinite(endMs) ||
+		endMs <= startMs
+	) {
+		return current
+	}
+	if (nowMs <= startMs) return previous
+	if (nowMs >= endMs) return current
+	const progress = (nowMs - startMs) / (endMs - startMs)
+	return previous + Math.floor((current - previous) * progress)
+}
+
+export function formatCodeRunsCount(count: number): string {
+	return new Intl.NumberFormat('en-US').format(count)
+}
+
+function readNonNegativeInt(value: unknown): number | null {
+	if (typeof value !== 'number' || !Number.isFinite(value)) return null
+	if (value < 0) return null
+	return Math.floor(value)
+}

--- a/packages/worker/universal/code-runs.ts
+++ b/packages/worker/universal/code-runs.ts
@@ -26,7 +26,7 @@ export function parsePublicCodeRunsWindow(
 	const startMs = Date.parse(record.windowStart)
 	const endMs = Date.parse(record.windowEnd)
 	if (!Number.isFinite(startMs) || !Number.isFinite(endMs)) return null
-	if (endMs <= startMs) return null
+	if (endMs - startMs !== publicCodeRunsWindowMs) return null
 	return {
 		previous,
 		current: Math.max(current, previous),

--- a/packages/worker/universal/loader-data.ts
+++ b/packages/worker/universal/loader-data.ts
@@ -13,6 +13,7 @@ import { type AdminFeatureFlag } from '#universal/feature-flags/types.ts'
 import { type OnboardingChecklistItemId } from '#universal/onboarding-checklist-types.ts'
 import { type SignupMode } from '#universal/signup-mode.ts'
 import { type CommunityListingSort } from '#universal/community-search.ts'
+import { type PublicCodeRunsWindow } from '#universal/code-runs.ts'
 
 export type { ProfileVisibility }
 export type { AdminFeatureFlag }
@@ -1578,6 +1579,12 @@ export type AppLoaderData = {
 	accountBilling?: AccountBillingLoaderData
 	accountUsage?: AccountUsageLoaderData
 	discord?: DiscordPageLoaderData
+	codeRuns?: CodeRunsLoaderData
+}
+
+export type CodeRunsLoaderData = {
+	ok: true
+	window: PublicCodeRunsWindow | null
 }
 
 export type AccountBillingLoaderData = {

--- a/packages/worker/universal/routes.ts
+++ b/packages/worker/universal/routes.ts
@@ -172,6 +172,7 @@ export const routes = route({
 	timelineApi: '/timeline.json',
 	health: '/health',
 	healthComponents: '/health/components',
+	codeRunsApi: '/code-runs.json',
 	sentryTunnel: post('/sentry-tunnel'),
 	login: '/login',
 	ogPageImage: '/og/:page.png',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Show a quiet, above-the-fold homepage number that makes fleet usage feel real: yesterday’s `execute` totals, replayed over the next 24 hours, without inventing ticks or exposing any user id.

## Summary

- Persist a platform KV pair `{ previous, current, windowStart, windowEnd }` at `public-code-runs:v1`.
- The hourly `usage_aggregation` lane initializes, holds, or rotates that pair. Homepage GET is read-only.
- Interpolate `previous → current` across the 24-hour window. Every visitor at a given second sees the same integer. If the next snapshot is late, freeze on `current`. Never go backwards.
- First window is still (`previous === current`) until the next 24-hour rotation.
- Hero copy: **“N code runs”**. Mono digits plus a reserved width from `current` keep the label from shifting as digits change. The ticker line is larger than the hero subtitle.
- `prefers-reduced-motion` paints the interpolated value and skips the 1s interval.
- Hide the ticker when there is no window (no execute events yet).
- Documented as a fifth isolation exception: anonymous `SUM(event_count)` of `execute` from `usage_rollups`, no user ids.

## Testing

- Node unit: interpolation/window/handler tests, plus SSR assertion that the hero paints `landing-hero-runs-count` with `--runs-ch` and the interpolated count.
- Isolated re-runs of the two mock-cloudflare node tests and `observability.workers.test.ts` passed.
- Local SSR screenshot with a seeded mid-window pair (`128,447 → 151,203`) and larger mono digits.
- Preview `kody-pr-1659`: `GET /code-runs.json` returned `{ ok: true, window: null }` (no execute events on preview). Homepage 200 for anonymous and signed-in seed user. Ticker correctly hidden in both states.
- Review follow-ups: KV get failures skip refresh writes; parser requires an exact 24-hour interval; SSR ticker test freezes the clock; client fetch failures keep the last painted window.

![Larger mono code-runs ticker on the local homepage hero](https://cursor.com/artifacts/c/art-6008b8a2-4c31-4c89-ac05-e8695510ad9a)
![Preview homepage anonymous hero with ticker hidden](https://cursor.com/artifacts/c/art-ac4a7350-1985-426d-8f4f-be7d1813b04b)
![Preview homepage signed-in hero with ticker hidden](https://cursor.com/artifacts/c/art-7630edda-932d-412d-ab83-ef5588466c37)

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends usage-metering</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `c60231b6` · **Head:** `0479e65b`

**Classification:** extends — usage-metering gains a public delayed aggregate and a platform KV window. app-ui and scheduled-cron compose that pair.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `usage-metering` | storage | extends — anonymous `SUM(execute)` plus `public-code-runs:v1` replay pair |
| `app-ui` | surfaces | composes — homepage ticker, `/code-runs.json`, larger mono digits |
| `scheduled-cron` | surfaces | composes — `usage_aggregation` refreshes the pair |

### Change flow

The hourly lane writes the official pair; homepage GET only reads it and interpolates.

```mermaid
sequenceDiagram
	actor Visitor
	participant scheduledCron as scheduled-cron
	participant usageMetering as usage-metering
	participant appUi as app-ui
	scheduledCron->>usageMetering: usage_aggregation calls refreshPublicCodeRunsWindow
	usageMetering->>usageMetering: SUM execute from usage_rollups
	usageMetering->>usageMetering: write public-code-runs:v1 (init, hold, or rotate)
	Visitor->>appUi: GET / or GET /code-runs.json
	appUi->>usageMetering: loadPublicCodeRunsWindow (no KV write)
	usageMetering-->>appUi: window pair or still D1 fallback
	appUi-->>Visitor: interpolate previous to current with mono tabular-nums
```

### Before / after

```
GET / hero: subtitle then CTAs
GET / hero: subtitle then larger mono “N code runs” then CTAs
```

### Invariants

`per-user-isolation` — fifth documented exception: anonymous fleet `execute` SUM with no user ids. Homepage GET never writes the KV pair. A KV read failure skips refresh writes so the official pair is not reset.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c8c17c2f-384e-4efd-ad81-13cc125f46ab?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c8c17c2f-384e-4efd-ad81-13cc125f46ab&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a homepage ticker showing aggregate code-run counts over a rolling 24-hour window.
  * Counts update smoothly, use localized formatting, and respect reduced-motion preferences.
  * Added a publicly cacheable endpoint to provide ticker data for anonymous and signed-in visitors.
  * Added fallback handling when current ticker data is unavailable.

* **Documentation**
  * Documented the ticker’s aggregate data handling, storage, authorization boundaries, and retention.

* **Tests**
  * Added coverage for ticker calculations, rotation, formatting, API responses, and homepage rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->