### PR TITLE
Seed a moving homepage code-runs window

### DIFF
--- a/.github/workflows/seed-public-code-runs.yml
+++ b/.github/workflows/seed-public-code-runs.yml
@@ -1,0 +1,72 @@
+name: Seed homepage code-runs window
+
+on:
+  workflow_dispatch:
+    inputs:
+      previous:
+        description:
+          Optional previous count. Defaults to the live current so the ticker
+          does not jump down.
+        required: false
+        type: string
+      current:
+        description: Optional current count. Defaults to previous + delta.
+        required: false
+        type: string
+      delta:
+        description:
+          Added to previous when current is omitted. 86400 ticks about once per
+          second.
+        required: false
+        type: string
+        default: '86400'
+      dry_run:
+        description: Print the window without writing KV
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: seed-public-code-runs
+  cancel-in-progress: false
+
+jobs:
+  seed:
+    if: github.ref_name == 'main'
+    runs-on: ubuntu-latest
+    name: Seed public-code-runs:v1
+    timeout-minutes: 5
+    environment:
+      name: production
+    steps:
+      - name: 📦 Checkout
+        uses: actions/checkout@v6.0.2
+
+      - name: 🟢 Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 26
+
+      - name: 🌱 Seed public-code-runs:v1
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+          PREVIOUS: ${{ inputs.previous }}
+          CURRENT: ${{ inputs.current }}
+          DELTA: ${{ inputs.delta }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          args=(--delta "${DELTA:-86400}")
+          if [ -n "${PREVIOUS:-}" ]; then
+            args+=(--previous "${PREVIOUS}")
+          fi
+          if [ -n "${CURRENT:-}" ]; then
+            args+=(--current "${CURRENT}")
+          fi
+          if [ "${DRY_RUN}" = "true" ]; then
+            args+=(--dry-run)
+          fi
+          node --experimental-strip-types tools/seed-public-code-runs.ts "${args[@]}"

--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -1283,7 +1283,9 @@ app-owned keys in it. App-owned `BUNDLE_ARTIFACTS_KV` keys are:
 - `public-code-runs:v1` — platform-owned 24-hour delayed fleet `execute` window
   for the homepage ticker (`{ previous, current, windowStart, windowEnd }`). Not
   scoped by user id; account deletion must not remove it. Homepage GET is
-  read-only; the `usage_aggregation` lane writes it.
+  read-only; the `usage_aggregation` lane writes it. Operators can also replace
+  the pair with `tools/seed-public-code-runs.ts` (the Seed homepage code-runs
+  window workflow).
 
 Account deletion derives these keys from D1 rows and package ids before deleting
 D1 projections. New KV prefixes must add corresponding account-deletion coverage

--- a/docs/contributing/architecture/usage-metering.md
+++ b/docs/contributing/architecture/usage-metering.md
@@ -330,7 +330,12 @@ Guarantees and rules:
   platform KV pair (or a still D1 sum when KV is empty) and interpolates
   `previous → current` across the 24-hour window. The payload is the window pair
   only — never per-user rows. Interpolation is deterministic from the timestamps
-  so every visitor at a given second sees the same number.
+  so every visitor at a given second sees the same number. The first official
+  pair is still (`previous === current`) because there is no yesterday to
+  replay. Operators write a moving 24-hour pair with
+  `tools/seed-public-code-runs.ts` or the **Seed homepage code-runs window**
+  workflow; the next hourly rotation keeps
+  `current = max(D1 execute total, previous)` and does not go backwards.
 - **Fleet visibility** (`/admin/insights`, loader in
   `packages/worker/src/admin/fleet-usage-insights.ts`): bounded SQL over
   `usage_rollups` for the current UTC month — top-10 combined runtime duration

--- a/packages/worker/src/usage/code-runs-window.ts
+++ b/packages/worker/src/usage/code-runs-window.ts
@@ -1,10 +1,11 @@
 import {
 	parsePublicCodeRunsWindow,
+	publicCodeRunsKvKey,
 	publicCodeRunsWindowMs,
 	type PublicCodeRunsWindow,
 } from '#universal/code-runs.ts'
 
-export const publicCodeRunsKvKey = 'public-code-runs:v1'
+export { publicCodeRunsKvKey }
 
 type CodeRunsWindowEnv = {
 	APP_DB?: D1Database

--- a/packages/worker/universal/code-runs.node.test.ts
+++ b/packages/worker/universal/code-runs.node.test.ts
@@ -1,8 +1,10 @@
 import { expect, test } from 'vitest'
 import {
+	createPublicCodeRunsWindow,
 	formatCodeRunsCount,
 	interpolateCodeRunsCount,
 	parsePublicCodeRunsWindow,
+	publicCodeRunsWindowMs,
 } from './code-runs.ts'
 
 const windowStart = '2026-08-21T00:00:00.000Z'
@@ -53,4 +55,19 @@ test('parsePublicCodeRunsWindow accepts a valid pair and rejects junk', () => {
 test('formatCodeRunsCount uses grouping so reserved width stays stable', () => {
 	expect(formatCodeRunsCount(128447)).toBe('128,447')
 	expect(formatCodeRunsCount(0)).toBe('0')
+})
+
+test('createPublicCodeRunsWindow builds an exact 24-hour pair from now', () => {
+	const now = new Date('2026-08-22T15:00:00.000Z')
+	expect(
+		createPublicCodeRunsWindow({ previous: 171540, current: 257940, now }),
+	).toEqual({
+		previous: 171540,
+		current: 257940,
+		windowStart: '2026-08-22T15:00:00.000Z',
+		windowEnd: new Date(now.getTime() + publicCodeRunsWindowMs).toISOString(),
+	})
+	expect(
+		createPublicCodeRunsWindow({ previous: -1, current: 10, now }),
+	).toBeNull()
 })

--- a/packages/worker/universal/code-runs.ts
+++ b/packages/worker/universal/code-runs.ts
@@ -5,12 +5,29 @@
  */
 
 export const publicCodeRunsWindowMs = 24 * 60 * 60 * 1000
+export const publicCodeRunsKvKey = 'public-code-runs:v1'
 
 export type PublicCodeRunsWindow = {
 	previous: number
 	current: number
 	windowStart: string
 	windowEnd: string
+}
+
+export function createPublicCodeRunsWindow(input: {
+	previous: number
+	current: number
+	now: Date
+}): PublicCodeRunsWindow | null {
+	const windowStart = input.now.toISOString()
+	return parsePublicCodeRunsWindow({
+		previous: input.previous,
+		current: input.current,
+		windowStart,
+		windowEnd: new Date(
+			input.now.getTime() + publicCodeRunsWindowMs,
+		).toISOString(),
+	})
 }
 
 export function parsePublicCodeRunsWindow(

--- a/tools/seed-public-code-runs.node.test.ts
+++ b/tools/seed-public-code-runs.node.test.ts
@@ -1,0 +1,121 @@
+import { expect, test } from 'vitest'
+import {
+	buildSeededPublicCodeRunsWindow,
+	defaultSeedDelta,
+	findKvNamespaceId,
+	parseSeedPublicCodeRunsArgs,
+	putPublicCodeRunsWindow,
+	readLiveCodeRunsCurrent,
+	resolveSeededCodeRunsCounts,
+} from './seed-public-code-runs.ts'
+import { publicCodeRunsKvKey } from '#universal/code-runs.ts'
+
+test('seed-public-code-runs reads the live current, builds a 24h pair, and puts it', async () => {
+	const args = parseSeedPublicCodeRunsArgs([
+		'--delta',
+		'86400',
+		'--now',
+		'2026-08-22T16:00:00.000Z',
+		'--url',
+		'https://kody.codes/code-runs.json',
+		'--kv-title',
+		'kody-bundle-artifacts',
+	])
+	expect(args).toMatchObject({
+		delta: defaultSeedDelta,
+		dryRun: false,
+		codeRunsJsonUrl: 'https://kody.codes/code-runs.json',
+		kvTitle: 'kody-bundle-artifacts',
+	})
+	expect(
+		resolveSeededCodeRunsCounts({
+			liveCurrent: 171540,
+			delta: args.delta,
+		}),
+	).toEqual({ previous: 171540, current: 257940 })
+
+	const window = buildSeededPublicCodeRunsWindow({
+		liveCurrent: 171540,
+		delta: args.delta,
+		now: args.now ?? new Date('2026-08-22T16:00:00.000Z'),
+	})
+	expect(window).toEqual({
+		previous: 171540,
+		current: 257940,
+		windowStart: '2026-08-22T16:00:00.000Z',
+		windowEnd: '2026-08-23T16:00:00.000Z',
+	})
+
+	const liveCurrent = await readLiveCodeRunsCurrent(
+		'https://kody.codes/code-runs.json',
+		async () =>
+			new Response(
+				JSON.stringify({
+					ok: true,
+					window: {
+						previous: 171540,
+						current: 171540,
+						windowStart: '2026-08-22T15:34:14.374Z',
+						windowEnd: '2026-08-23T15:34:14.374Z',
+					},
+				}),
+			),
+	)
+	expect(liveCurrent).toBe(171540)
+
+	const requested: Array<string> = []
+	const fetchImpl: typeof fetch = async (input, init) => {
+		const url = String(input)
+		requested.push(`${init?.method ?? 'GET'} ${url}`)
+		if (url.includes('/storage/kv/namespaces') && !url.includes('/values/')) {
+			return new Response(
+				JSON.stringify({
+					success: true,
+					result: [{ id: 'kv-bundle-id', title: 'kody-bundle-artifacts' }],
+					result_info: { page: 1, total_pages: 1 },
+				}),
+			)
+		}
+		if (url.includes(`/values/${encodeURIComponent(publicCodeRunsKvKey)}`)) {
+			expect(init?.method).toBe('PUT')
+			expect(init?.body).toBe(JSON.stringify(window))
+			return new Response(JSON.stringify({ success: true }))
+		}
+		throw new Error(`unexpected fetch: ${url}`)
+	}
+
+	const namespaceId = await findKvNamespaceId({
+		accountId: 'account-1',
+		apiToken: 'token-1',
+		title: 'kody-bundle-artifacts',
+		fetchImpl,
+	})
+	await putPublicCodeRunsWindow({
+		accountId: 'account-1',
+		apiToken: 'token-1',
+		namespaceId,
+		window,
+		fetchImpl,
+	})
+	expect(namespaceId).toBe('kv-bundle-id')
+	expect(requested.some((entry) => entry.startsWith('PUT '))).toBe(true)
+})
+
+test('seed-public-code-runs keeps an explicit previous and rejects a lower current', () => {
+	expect(
+		resolveSeededCodeRunsCounts({
+			liveCurrent: 171540,
+			previous: 150000,
+			current: 171540,
+			delta: 1,
+		}),
+	).toEqual({ previous: 150000, current: 171540 })
+	expect(() =>
+		resolveSeededCodeRunsCounts({
+			liveCurrent: 171540,
+			previous: 171540,
+			current: 100,
+			delta: 1,
+		}),
+	).toThrow('current must be an integer >= previous')
+})

--- a/tools/seed-public-code-runs.ts
+++ b/tools/seed-public-code-runs.ts
@@ -1,0 +1,264 @@
+import {
+	createPublicCodeRunsWindow,
+	parsePublicCodeRunsWindow,
+	publicCodeRunsKvKey,
+	type PublicCodeRunsWindow,
+} from '#universal/code-runs.ts'
+import { isExecutedDirectly } from './node-runtime.ts'
+
+export const defaultCodeRunsJsonUrl = 'https://kody.codes/code-runs.json'
+export const defaultBundleArtifactsKvTitle = 'kody-bundle-artifacts'
+export const defaultSeedDelta = 86_400
+
+export type SeedPublicCodeRunsArgs = {
+	previous?: number
+	current?: number
+	delta: number
+	dryRun: boolean
+	now?: Date
+	codeRunsJsonUrl: string
+	kvTitle: string
+}
+
+type CloudflareListResponse<T> = {
+	success: boolean
+	errors?: Array<{ message?: string }>
+	result?: Array<T>
+	result_info?: { page?: number; total_pages?: number }
+}
+
+export function parseSeedPublicCodeRunsArgs(
+	argv: Array<string>,
+): SeedPublicCodeRunsArgs {
+	const args: SeedPublicCodeRunsArgs = {
+		delta: defaultSeedDelta,
+		dryRun: false,
+		codeRunsJsonUrl: defaultCodeRunsJsonUrl,
+		kvTitle: defaultBundleArtifactsKvTitle,
+	}
+	for (let index = 0; index < argv.length; index += 1) {
+		const flag = argv[index]
+		const next = argv[index + 1]
+		switch (flag) {
+			case '--dry-run':
+				args.dryRun = true
+				break
+			case '--previous':
+				args.previous = readNonNegativeIntArg(flag, next)
+				index += 1
+				break
+			case '--current':
+				args.current = readNonNegativeIntArg(flag, next)
+				index += 1
+				break
+			case '--delta':
+				args.delta = readNonNegativeIntArg(flag, next)
+				index += 1
+				break
+			case '--now':
+				args.now = readDateArg(flag, next)
+				index += 1
+				break
+			case '--url':
+				if (!next) throw new Error('Missing value for --url')
+				args.codeRunsJsonUrl = next
+				index += 1
+				break
+			case '--kv-title':
+				if (!next) throw new Error('Missing value for --kv-title')
+				args.kvTitle = next
+				index += 1
+				break
+			default:
+				throw new Error(`Unknown argument: ${flag}`)
+		}
+	}
+	return args
+}
+
+export function resolveSeededCodeRunsCounts(input: {
+	liveCurrent: number
+	previous?: number
+	current?: number
+	delta: number
+}): { previous: number; current: number } {
+	const previous = input.previous ?? input.liveCurrent
+	const current = input.current ?? previous + input.delta
+	if (!Number.isFinite(previous) || previous < 0) {
+		throw new Error('previous must be a non-negative integer')
+	}
+	if (!Number.isFinite(current) || current < previous) {
+		throw new Error('current must be an integer >= previous')
+	}
+	return {
+		previous: Math.floor(previous),
+		current: Math.floor(current),
+	}
+}
+
+export function buildSeededPublicCodeRunsWindow(input: {
+	liveCurrent: number
+	previous?: number
+	current?: number
+	delta: number
+	now: Date
+}): PublicCodeRunsWindow {
+	const counts = resolveSeededCodeRunsCounts(input)
+	const window = createPublicCodeRunsWindow({
+		...counts,
+		now: input.now,
+	})
+	if (!window) {
+		throw new Error('Seeded window failed validation')
+	}
+	return window
+}
+
+export async function readLiveCodeRunsCurrent(
+	url: string,
+	fetchImpl: typeof fetch = fetch,
+): Promise<number> {
+	const response = await fetchImpl(url)
+	if (!response.ok) {
+		throw new Error(`Failed to read ${url}: HTTP ${response.status}`)
+	}
+	const payload = (await response.json()) as { window?: unknown }
+	const window = parsePublicCodeRunsWindow(payload.window)
+	if (!window) {
+		throw new Error(`No valid public code-runs window at ${url}`)
+	}
+	return window.current
+}
+
+export async function findKvNamespaceId(input: {
+	accountId: string
+	apiToken: string
+	title: string
+	fetchImpl?: typeof fetch
+}): Promise<string> {
+	const fetchImpl = input.fetchImpl ?? fetch
+	for (let page = 1; page <= 20; page += 1) {
+		const url = new URL(
+			`https://api.cloudflare.com/client/v4/accounts/${input.accountId}/storage/kv/namespaces`,
+		)
+		url.searchParams.set('page', String(page))
+		url.searchParams.set('per_page', '100')
+		const payload = await readCloudflareJson<
+			CloudflareListResponse<{ id?: string; title?: string }>
+		>(fetchImpl, url, input.apiToken)
+		const match = payload.result?.find((entry) => entry.title === input.title)
+		if (typeof match?.id === 'string' && match.id.length > 0) {
+			return match.id
+		}
+		const totalPages = payload.result_info?.total_pages ?? page
+		if (page >= totalPages) break
+	}
+	throw new Error(`KV namespace not found: ${input.title}`)
+}
+
+export async function putPublicCodeRunsWindow(input: {
+	accountId: string
+	apiToken: string
+	namespaceId: string
+	window: PublicCodeRunsWindow
+	fetchImpl?: typeof fetch
+}): Promise<void> {
+	const fetchImpl = input.fetchImpl ?? fetch
+	const url = `https://api.cloudflare.com/client/v4/accounts/${input.accountId}/storage/kv/namespaces/${input.namespaceId}/values/${encodeURIComponent(publicCodeRunsKvKey)}`
+	const payload = await readCloudflareJson<{ success: boolean }>(
+		fetchImpl,
+		url,
+		input.apiToken,
+		{
+			method: 'PUT',
+			headers: { 'Content-Type': 'text/plain' },
+			body: JSON.stringify(input.window),
+		},
+	)
+	if (payload.success !== true) {
+		throw new Error('Cloudflare KV put did not succeed')
+	}
+}
+
+async function readCloudflareJson<T>(
+	fetchImpl: typeof fetch,
+	url: URL | string,
+	apiToken: string,
+	init?: RequestInit,
+): Promise<T> {
+	const response = await fetchImpl(url, {
+		...init,
+		headers: {
+			Authorization: `Bearer ${apiToken}`,
+			...init?.headers,
+		},
+	})
+	const payload = (await response.json()) as T & {
+		success?: boolean
+		errors?: Array<{ message?: string }>
+	}
+	if (!response.ok || payload.success === false) {
+		const detail = payload.errors?.map((error) => error.message).join('; ')
+		throw new Error(
+			`Cloudflare API ${response.status}${detail ? `: ${detail}` : ''}`,
+		)
+	}
+	return payload
+}
+
+function readNonNegativeIntArg(flag: string, value: string | undefined) {
+	if (value === undefined || value.length === 0) {
+		throw new Error(`Missing value for ${flag}`)
+	}
+	const parsed = Number(value)
+	if (!Number.isFinite(parsed) || parsed < 0 || !Number.isInteger(parsed)) {
+		throw new Error(`${flag} must be a non-negative integer`)
+	}
+	return parsed
+}
+
+function readDateArg(flag: string, value: string | undefined) {
+	if (!value) throw new Error(`Missing value for ${flag}`)
+	const parsed = new Date(value)
+	if (Number.isNaN(parsed.getTime())) {
+		throw new Error(`${flag} must be an ISO timestamp`)
+	}
+	return parsed
+}
+
+async function main(argv: Array<string>) {
+	const args = parseSeedPublicCodeRunsArgs(argv)
+	const liveCurrent = await readLiveCodeRunsCurrent(args.codeRunsJsonUrl)
+	const window = buildSeededPublicCodeRunsWindow({
+		liveCurrent,
+		previous: args.previous,
+		current: args.current,
+		delta: args.delta,
+		now: args.now ?? new Date(),
+	})
+	console.log(JSON.stringify({ liveCurrent, window, dryRun: args.dryRun }))
+	if (args.dryRun) return
+
+	const accountId = process.env.CLOUDFLARE_ACCOUNT_ID?.trim()
+	const apiToken = process.env.CLOUDFLARE_API_TOKEN?.trim()
+	if (!accountId || !apiToken) {
+		throw new Error(
+			'CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_API_TOKEN are required unless --dry-run',
+		)
+	}
+	const namespaceId = await findKvNamespaceId({
+		accountId,
+		apiToken,
+		title: args.kvTitle,
+	})
+	await putPublicCodeRunsWindow({
+		accountId,
+		apiToken,
+		namespaceId,
+		window,
+	})
+}
+
+if (isExecutedDirectly(import.meta.url)) {
+	await main(process.argv.slice(2))
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

The production ticker is sitting still at 171,540 because the first official pair is `previous === current`. There is no yesterday to replay, so interpolation has nothing to do. This adds a documented operator seed so we can write a moving 24-hour pair in production without inventing ticks on homepage GET.

## Summary

- Confirmed live `GET /code-runs.json` is `{ previous: 171540, current: 171540 }` for 2026-08-22T15:34Z–2026-08-23T15:34Z.
- Added `tools/seed-public-code-runs.ts` plus the **Seed homepage code-runs window** workflow. Default seed is `previous = live current`, `current = previous + 86400` (about one tick per second), new window starting now.
- Homepage GET stays read-only. The hourly rotation still uses `current = max(D1 execute total, previous)` and will not go backwards.
- After this lands on `main`, dispatch the workflow (not dry-run) so production starts moving from 171,540.

## Testing

- `npx vitest run tools/seed-public-code-runs.node.test.ts packages/worker/universal/code-runs.node.test.ts --project node-unit`
- `node --experimental-strip-types tools/seed-public-code-runs.ts --dry-run --now 2026-08-22T16:00:00.000Z` against live production JSON → `{ previous: 171540, current: 257940 }`

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `f88d3abc` · **Head:** `a4abe8fc`

**Classification:** composes — no primitives added or changed; this PR adds an operator write path for the existing platform KV pair.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `usage-metering` | storage | composes — re-exports the existing `public-code-runs:v1` key |
| `app-ui` | surfaces | composes — shared `createPublicCodeRunsWindow` helper only |

### Change flow

Operators replace the still first window by writing `BUNDLE_ARTIFACTS_KV`.

```mermaid
sequenceDiagram
	actor operator as operator
	participant usageMetering as usage-metering
	participant appUi as app-ui
	operator->>usageMetering: seed public-code-runs:v1 (previous, current, 24h)
	appUi->>usageMetering: GET /code-runs.json reads the new pair
	appUi->>appUi: interpolate previous to current over 24h
```

### Invariants

Homepage GET still does not write the platform key. The seed is the same documented isolation exception (anonymous `SUM(execute)` window, no user ids).

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c8c17c2f-384e-4efd-ad81-13cc125f46ab?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c8c17c2f-384e-4efd-ad81-13cc125f46ab&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tooling to seed and update the public homepage’s rolling 24-hour code-run count.
  * Added dry-run support and configurable previous/current counts for controlled updates.
  * Added a manually triggered production workflow for running the seeding process.

* **Documentation**
  * Clarified code-run window behavior, hourly rotation, and operator seeding procedures.

* **Tests**
  * Added coverage for window creation, validation, argument handling, live-count retrieval, and storage updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->