### PR TITLE
Make the homepage code-runs ticker burst and slow down

### DIFF
--- a/docs/contributing/architecture/usage-metering.md
+++ b/docs/contributing/architecture/usage-metering.md
@@ -331,7 +331,8 @@ Guarantees and rules:
   `previous → current` across the 24-hour window. The payload is the window pair
   only — never per-user rows. Interpolation is deterministic from the window so
   every visitor at a given second sees the same number (`nowMs` is floored to
-  whole seconds before progress is computed). Elapsed time is warped
+  whole seconds before endpoint checks and progress). Official `current` appears
+  at the first whole second on or after `windowEnd`. Elapsed time is warped
   through hashed bursty weights (quiet stretches and rapid spikes) and stays
   monotonic; it never passes `current`.
 - **Fleet visibility** (`/admin/insights`, loader in

--- a/docs/contributing/architecture/usage-metering.md
+++ b/docs/contributing/architecture/usage-metering.md
@@ -330,7 +330,8 @@ Guarantees and rules:
   platform KV pair (or a still D1 sum when KV is empty) and interpolates
   `previous → current` across the 24-hour window. The payload is the window pair
   only — never per-user rows. Interpolation is deterministic from the window so
-  every visitor at a given second sees the same number. Elapsed time is warped
+  every visitor at a given second sees the same number (`nowMs` is floored to
+  whole seconds before progress is computed). Elapsed time is warped
   through hashed bursty weights (quiet stretches and rapid spikes) and stays
   monotonic; it never passes `current`.
 - **Fleet visibility** (`/admin/insights`, loader in

--- a/docs/contributing/architecture/usage-metering.md
+++ b/docs/contributing/architecture/usage-metering.md
@@ -329,8 +329,10 @@ Guarantees and rules:
 - **Public homepage ticker** (`GET /code-runs.json`, SSR on `/`): reads the
   platform KV pair (or a still D1 sum when KV is empty) and interpolates
   `previous → current` across the 24-hour window. The payload is the window pair
-  only — never per-user rows. Interpolation is deterministic from the timestamps
-  so every visitor at a given second sees the same number.
+  only — never per-user rows. Interpolation is deterministic from the window so
+  every visitor at a given second sees the same number. Elapsed time is warped
+  through hashed bursty weights (quiet stretches and rapid spikes) and stays
+  monotonic; it never passes `current`.
 - **Fleet visibility** (`/admin/insights`, loader in
   `packages/worker/src/admin/fleet-usage-insights.ts`): bounded SQL over
   `usage_rollups` for the current UTC month — top-10 combined runtime duration

--- a/packages/worker/client/code-runs-ticker.tsx
+++ b/packages/worker/client/code-runs-ticker.tsx
@@ -6,10 +6,10 @@ import {
 } from '#universal/code-runs.ts'
 
 /**
- * 24-hour delayed fleet execute count. SSR paints the interpolated value;
- * the client advances it only when the displayed integer changes. Mono
- * digits plus a reserved width from `current` keep the label from shifting
- * as digits change. The line is sized larger than the hero subtitle.
+ * 24-hour delayed fleet execute count. SSR paints the bursty interpolated
+ * value; the client advances it only when the displayed integer changes.
+ * Mono digits plus a reserved width from `current` keep the label from
+ * shifting as digits change. The line is sized larger than the hero subtitle.
  */
 export function CodeRunsTicker(
 	handle: Handle<{ window: PublicCodeRunsWindow }>,

--- a/packages/worker/universal/code-runs.node.test.ts
+++ b/packages/worker/universal/code-runs.node.test.ts
@@ -60,7 +60,7 @@ test('interpolateCodeRunsCount is stable across milliseconds in the same second'
 	)
 })
 
-test('interpolateCodeRunsCount hits current at a non-aligned window end', () => {
+test('interpolateCodeRunsCount stays one integer through a non-aligned window end', () => {
 	const offset = {
 		...window,
 		previous: 171540,
@@ -69,9 +69,15 @@ test('interpolateCodeRunsCount hits current at a non-aligned window end', () => 
 		windowEnd: '2026-08-23T15:47:07.637Z',
 	}
 	const endMs = Date.parse(offset.windowEnd)
-	expect(interpolateCodeRunsCount(offset, endMs)).toBe(257940)
-	expect(interpolateCodeRunsCount(offset, endMs + 1)).toBe(257940)
-	expect(interpolateCodeRunsCount(offset, endMs - 1)).toBeLessThan(257940)
+	const endSecondMs = Math.floor(endMs / 1000) * 1000
+	expect(interpolateCodeRunsCount(offset, endSecondMs + 100)).toBe(
+		interpolateCodeRunsCount(offset, endSecondMs + 900),
+	)
+	expect(interpolateCodeRunsCount(offset, endSecondMs + 100)).toBeLessThan(
+		257940,
+	)
+	expect(interpolateCodeRunsCount(offset, endSecondMs + 1000)).toBe(257940)
+	expect(interpolateCodeRunsCount(offset, endMs + 1000)).toBe(257940)
 })
 
 test('interpolateCodeRunsCount sits still when the pair has not moved', () => {

--- a/packages/worker/universal/code-runs.node.test.ts
+++ b/packages/worker/universal/code-runs.node.test.ts
@@ -60,6 +60,20 @@ test('interpolateCodeRunsCount is stable across milliseconds in the same second'
 	)
 })
 
+test('interpolateCodeRunsCount hits current at a non-aligned window end', () => {
+	const offset = {
+		...window,
+		previous: 171540,
+		current: 257940,
+		windowStart: '2026-08-22T15:47:07.637Z',
+		windowEnd: '2026-08-23T15:47:07.637Z',
+	}
+	const endMs = Date.parse(offset.windowEnd)
+	expect(interpolateCodeRunsCount(offset, endMs)).toBe(257940)
+	expect(interpolateCodeRunsCount(offset, endMs + 1)).toBe(257940)
+	expect(interpolateCodeRunsCount(offset, endMs - 1)).toBeLessThan(257940)
+})
+
 test('interpolateCodeRunsCount sits still when the pair has not moved', () => {
 	const still = { ...window, previous: 80, current: 80 }
 	expect(interpolateCodeRunsCount(still, startMs + 6 * hourMs)).toBe(80)

--- a/packages/worker/universal/code-runs.node.test.ts
+++ b/packages/worker/universal/code-runs.node.test.ts
@@ -17,13 +17,37 @@ const window = {
 	windowEnd,
 }
 
-test('interpolateCodeRunsCount spreads yesterday’s delta across 24 hours and never overshoots', () => {
+test('interpolateCodeRunsCount stays monotonic, bursty, and inside the pair', () => {
 	expect(interpolateCodeRunsCount(window, startMs - 1)).toBe(1000)
 	expect(interpolateCodeRunsCount(window, startMs)).toBe(1000)
-	expect(interpolateCodeRunsCount(window, startMs + 12 * hourMs)).toBe(1120)
-	expect(interpolateCodeRunsCount(window, startMs + 24 * hourMs - 1)).toBe(1239)
 	expect(interpolateCodeRunsCount(window, startMs + 24 * hourMs)).toBe(1240)
 	expect(interpolateCodeRunsCount(window, startMs + 30 * hourMs)).toBe(1240)
+	expect(
+		interpolateCodeRunsCount(window, startMs + 24 * hourMs - 1),
+	).toBeLessThan(1240)
+
+	const hourly = Array.from({ length: 25 }, (_, hour) =>
+		interpolateCodeRunsCount(window, startMs + hour * hourMs),
+	)
+	for (let index = 1; index < hourly.length; index += 1) {
+		expect(hourly[index]!).toBeGreaterThanOrEqual(hourly[index - 1]!)
+	}
+	expect(hourly[0]).toBe(1000)
+	expect(hourly[24]).toBe(1240)
+
+	const hourlyDeltas = hourly
+		.slice(1)
+		.map((count, index) => count - hourly[index]!)
+	const quietest = Math.min(...hourlyDeltas)
+	const busiest = Math.max(...hourlyDeltas)
+	expect(busiest).toBeGreaterThan(quietest * 3)
+	expect(interpolateCodeRunsCount(window, startMs + 12 * hourMs)).not.toBe(1120)
+	expect(interpolateCodeRunsCount(window, startMs + 6 * hourMs)).not.toBe(
+		interpolateCodeRunsCount(
+			{ ...window, previous: 900, current: 1140 },
+			startMs + 6 * hourMs,
+		),
+	)
 })
 
 test('interpolateCodeRunsCount sits still when the pair has not moved', () => {

--- a/packages/worker/universal/code-runs.node.test.ts
+++ b/packages/worker/universal/code-runs.node.test.ts
@@ -42,11 +42,21 @@ test('interpolateCodeRunsCount stays monotonic, bursty, and inside the pair', ()
 	const busiest = Math.max(...hourlyDeltas)
 	expect(busiest).toBeGreaterThan(quietest * 3)
 	expect(interpolateCodeRunsCount(window, startMs + 12 * hourMs)).not.toBe(1120)
-	expect(interpolateCodeRunsCount(window, startMs + 6 * hourMs)).not.toBe(
-		interpolateCodeRunsCount(
-			{ ...window, previous: 900, current: 1140 },
-			startMs + 6 * hourMs,
-		),
+	const firstPair = { ...window, previous: 0, current: 1_000_000 }
+	const secondPair = { ...firstPair, previous: 100, current: 1_000_100 }
+	const sampleMs = startMs + 6 * hourMs
+	expect(
+		interpolateCodeRunsCount(firstPair, sampleMs) - firstPair.previous,
+	).not.toBe(
+		interpolateCodeRunsCount(secondPair, sampleMs) - secondPair.previous,
+	)
+})
+
+test('interpolateCodeRunsCount is stable across milliseconds in the same second', () => {
+	const wide = { ...window, previous: 0, current: 1_000_000_000 }
+	const midSecond = startMs + 6 * hourMs + 100
+	expect(interpolateCodeRunsCount(wide, midSecond)).toBe(
+		interpolateCodeRunsCount(wide, midSecond + 800),
 	)
 })
 

--- a/packages/worker/universal/code-runs.ts
+++ b/packages/worker/universal/code-runs.ts
@@ -52,10 +52,9 @@ export function interpolateCodeRunsCount(
 	) {
 		return current
 	}
-	if (nowMs <= startMs) return previous
-	if (nowMs >= endMs) return current
 	const secondMs = Math.floor(nowMs / 1000) * 1000
 	if (secondMs <= startMs) return previous
+	if (secondMs >= endMs) return current
 	const progress = (secondMs - startMs) / (endMs - startMs)
 	const warped = warpCodeRunsProgress(progress, windowSeed(window))
 	return previous + Math.floor((current - previous) * warped)

--- a/packages/worker/universal/code-runs.ts
+++ b/packages/worker/universal/code-runs.ts
@@ -52,9 +52,10 @@ export function interpolateCodeRunsCount(
 	) {
 		return current
 	}
+	if (nowMs <= startMs) return previous
+	if (nowMs >= endMs) return current
 	const secondMs = Math.floor(nowMs / 1000) * 1000
 	if (secondMs <= startMs) return previous
-	if (secondMs >= endMs) return current
 	const progress = (secondMs - startMs) / (endMs - startMs)
 	const warped = warpCodeRunsProgress(progress, windowSeed(window))
 	return previous + Math.floor((current - previous) * warped)

--- a/packages/worker/universal/code-runs.ts
+++ b/packages/worker/universal/code-runs.ts
@@ -52,9 +52,10 @@ export function interpolateCodeRunsCount(
 	) {
 		return current
 	}
-	if (nowMs <= startMs) return previous
-	if (nowMs >= endMs) return current
-	const progress = (nowMs - startMs) / (endMs - startMs)
+	const secondMs = Math.floor(nowMs / 1000) * 1000
+	if (secondMs <= startMs) return previous
+	if (secondMs >= endMs) return current
+	const progress = (secondMs - startMs) / (endMs - startMs)
 	const warped = warpCodeRunsProgress(progress, windowSeed(window))
 	return previous + Math.floor((current - previous) * warped)
 }

--- a/packages/worker/universal/code-runs.ts
+++ b/packages/worker/universal/code-runs.ts
@@ -1,7 +1,9 @@
 /**
  * Public homepage “code runs” ticker: a 24-hour delayed replay of fleet
  * `execute` event counts. Interpolation is deterministic from the window
- * timestamps so every visitor at a given second sees the same number.
+ * so every visitor at a given second sees the same number. Elapsed time is
+ * warped through hashed bursty weights (quiet stretches and rapid spikes)
+ * and stays monotonic between `previous` and `current`.
  */
 
 export const publicCodeRunsWindowMs = 24 * 60 * 60 * 1000
@@ -53,7 +55,78 @@ export function interpolateCodeRunsCount(
 	if (nowMs <= startMs) return previous
 	if (nowMs >= endMs) return current
 	const progress = (nowMs - startMs) / (endMs - startMs)
-	return previous + Math.floor((current - previous) * progress)
+	const warped = warpCodeRunsProgress(progress, windowSeed(window))
+	return previous + Math.floor((current - previous) * warped)
+}
+
+const coarseSegmentCount = 72
+const fineSegmentCount = 8
+
+function windowSeed(window: PublicCodeRunsWindow): number {
+	return hash32(
+		hash32(Date.parse(window.windowStart)) ^
+			hash32(window.previous) ^
+			Math.imul(hash32(window.current), 3),
+	)
+}
+
+function warpCodeRunsProgress(progress: number, seed: number): number {
+	if (progress <= 0) return 0
+	if (progress >= 1) return 1
+	const position = progress * coarseSegmentCount
+	const coarseIndex = Math.min(Math.floor(position), coarseSegmentCount - 1)
+	const coarseFrac = position - coarseIndex
+	let prefix = 0
+	let total = 0
+	for (let index = 0; index < coarseSegmentCount; index += 1) {
+		const weight = coarseWeight(seed, index)
+		total += weight
+		if (index < coarseIndex) prefix += weight
+	}
+	const currentWeight = coarseWeight(seed, coarseIndex)
+	const fine = warpFineProgress(coarseFrac, seed, coarseIndex)
+	return (prefix + currentWeight * fine) / total
+}
+
+function warpFineProgress(
+	frac: number,
+	seed: number,
+	coarseIndex: number,
+): number {
+	if (frac <= 0) return 0
+	if (frac >= 1) return 1
+	const position = frac * fineSegmentCount
+	const fineIndex = Math.min(Math.floor(position), fineSegmentCount - 1)
+	const inner = position - fineIndex
+	let prefix = 0
+	let total = 0
+	for (let index = 0; index < fineSegmentCount; index += 1) {
+		const weight = fineWeight(seed, coarseIndex, index)
+		total += weight
+		if (index < fineIndex) prefix += weight
+	}
+	return (prefix + fineWeight(seed, coarseIndex, fineIndex) * inner) / total
+}
+
+function coarseWeight(seed: number, index: number): number {
+	const unit = hashUnit(seed, index + 1)
+	return 0.03 + unit * unit * unit * 7
+}
+
+function fineWeight(seed: number, coarseIndex: number, index: number): number {
+	const unit = hashUnit(seed, Math.imul(coarseIndex + 1, 17) + index + 3)
+	return 0.2 + unit * unit * 3
+}
+
+function hashUnit(seed: number, salt: number): number {
+	return hash32(seed ^ Math.imul(salt, 0x9e3779b9)) / 0x1_0000_0000
+}
+
+function hash32(value: number): number {
+	let n = value | 0
+	n = Math.imul(n ^ (n >>> 16), 0x7feb352d)
+	n = Math.imul(n ^ (n >>> 15), 0x846ca68b)
+	return (n ^ (n >>> 16)) >>> 0
 }
 
 export function formatCodeRunsCount(count: number): string {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

The production ticker is moving, but a constant 24h lerp looks mechanical. Warp elapsed time so the same official `previous → current` pair has quiet stretches and rapid spikes — still deterministic, monotonic, and never past `current`.

## Summary

- `interpolateCodeRunsCount` hashes the window into 72 coarse × 8 fine positive weights (heavy-tailed, so most slices are quiet and a few spike).
- Every visitor at a given second still sees the same integer: `nowMs` is floored to whole seconds before endpoint checks and progress. Official `current` appears at the first whole second on or after `windowEnd` (so a `.637Z` end cannot split that UTC second). `prefers-reduced-motion` still snaps.
- Homepage GET still does not write KV.

## Review

CodeRabbit (first commit) and Bugbot (`4633289f`) comments are addressed:

- Seed-sensitivity compares normalized displacement on equal-sized high-resolution pairs.
- Interpolation quantizes `nowMs` before boundary checks so large deltas cannot diverge within a second, including the last second of a non-aligned window.

## Testing

- `npx vitest run packages/worker/universal/code-runs.node.test.ts`
- `npx vitest run packages/worker/src/app/ssr-render.node.test.ts -t "tabular homepage code-runs"`

Preview `GET /code-runs.json` stays `{ window: null }` on an empty preview D1, so the ticker stays hidden there. Wobble is covered by the unit tests; production already has a moving official pair.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `cea53d58` · **Head:** `2cc77678`

**Classification:** extends — the public ticker interpolation contract changes from a constant rate to a bursty monotonic warp, and clocks are quantized to whole seconds.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | extends — homepage code-runs interpolation is bursty and second-stable |

### Change flow

SSR and the client still read the same official window pair; only the elapsed-time warp and second quantization change.

```mermaid
sequenceDiagram
	participant appUi as app-ui
	participant usageMetering as usage-metering
	appUi->>usageMetering: GET /code-runs.json official pair
	usageMetering-->>appUi: previous, current, window timestamps
	appUi->>appUi: floor nowMs to the current second
	appUi->>appUi: warp elapsed time through hashed burst weights
	appUi->>appUi: paint the same integer for every visitor at that second
```

### Before / after

```
before: count = previous + floor(delta * t)
after:  count = previous + floor(delta * warp(floorSecond(now), seed(window)))
```

`warp` is monotonic in `[0, 1]` and `seed` is derived from the window so two visitors agree. Endpoint checks use the floored second so a non-aligned `windowEnd` cannot split.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c8c17c2f-384e-4efd-ad81-13cc125f46ab?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c8c17c2f-384e-4efd-ad81-13cc125f46ab&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Updated the code-runs ticker to display more natural, deterministic bursty activity patterns instead of steady linear progress.
  * Preserved accurate start and end values while ensuring displayed totals remain monotonic and within expected bounds.
  * Improved server-rendered and client-side ticker behavior, including integer updates, stable timing, and consistent sizing.

* **Documentation**
  * Clarified ticker interpolation, rendering behavior, timestamp handling, and usage-metering calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->