### PR TITLE
Export KodyFetchGateway from kody-platform so MCP execute works

### DIFF
--- a/docs/contributing/decisions/0034-origin-owns-no-durable-objects.md
+++ b/docs/contributing/decisions/0034-origin-owns-no-durable-objects.md
@@ -53,5 +53,8 @@ Remix/blog/UI-only production deploys no longer reset platform or runtime
 Durable Objects. Official guide deploys reset platform objects because MCP
 bundles that markdown, and still skip runtime and jobs. Cost: another wrangler
 config, preview bootstrap ordering, and a one-shot production transfer with a
-short in-flight RPC error window. See the
+short in-flight RPC error window. The platform script must also export
+`KodyFetchGateway` (a WorkerEntrypoint, not a Durable Object) so MCP `execute`
+can loopback outbound fetch from `ctx.exports` on the script that owns `MCP`.
+See the
 [platform worker migration runbook](../architecture/platform-worker-migration-runbook.md).

--- a/packages/platform-worker/readme.md
+++ b/packages/platform-worker/readme.md
@@ -10,7 +10,8 @@ The Worker entry module is
 the platform lane shares the origin Worker's source tree, import maps, and
 pre-bundled `src/generated/` modules, so this package holds only the deploy
 configuration. The entry module is typechecked and tested through the `worker`
-Nx project.
+Nx project. It also exports `KodyFetchGateway` so MCP `execute` can loopback
+outbound fetch from the platform-owned `MCP` Durable Object.
 
 - `wrangler.jsonc` — the committed base config (script name `kody-platform`).
   Deployable configs are generated from it plus the origin Worker's generated

--- a/packages/worker/src/platform-worker.node.test.ts
+++ b/packages/worker/src/platform-worker.node.test.ts
@@ -1,0 +1,18 @@
+import { readFile } from 'node:fs/promises'
+import { expect, test } from 'vitest'
+
+test('platform worker exports KodyFetchGateway for MCP execute loopback', async () => {
+	const source = await readFile(
+		new URL('./platform-worker.ts', import.meta.url),
+		'utf8',
+	)
+	const exportBlock = source.match(/export \{([^}]+)\}/)?.[1] ?? ''
+	const names = exportBlock
+		.split(',')
+		.map((name) => name.trim())
+		.filter(Boolean)
+	expect(names).toContain('KodyFetchGateway')
+	expect(source).toMatch(
+		/import \{ KodyFetchGateway \} from '#mcp\/fetch-gateway\.ts'/,
+	)
+})

--- a/packages/worker/src/platform-worker.ts
+++ b/packages/worker/src/platform-worker.ts
@@ -3,6 +3,7 @@ import {
 	buildPlatformWorkerHealth,
 	platformWorkerHealthPath,
 } from '@kody-internal/shared/platform-worker.ts'
+import { KodyFetchGateway } from '#mcp/fetch-gateway.ts'
 import { McpClientHub } from './mcp-client/hub.ts'
 import { MCP } from './mcp/index.ts'
 import { UserMeter } from './entitlements/user-meter-do.ts'
@@ -20,8 +21,14 @@ import { getWorkerSentryOptions } from './sentry-options.ts'
  * Owns the remaining platform Durable Objects extracted from the origin
  * `kody` Worker per ADR 0034 so content/UI deploys of the origin script do
  * not reset those objects. HTTP on this script is the deploy healthcheck
- * only; MCP, OAuth, email, and the Remix app stay on the origin and reach
- * these classes through cross-script bindings.
+ * only; MCP HTTP, OAuth, email, and the Remix app stay on the origin and
+ * reach these classes through cross-script bindings.
+ *
+ * `KodyFetchGateway` is a loopback `ctx.exports` WorkerEntrypoint. MCP
+ * `execute` (and the search/execute graph that fans into it) runs inside
+ * the platform-owned `MCP` Durable Object and looks up that export on
+ * **this** script, the same way `kody-runtime` exports its own gateway
+ * instead of calling back into origin.
  */
 export {
 	MCP,
@@ -32,6 +39,7 @@ export {
 	RepoSession,
 	RepoSessionIndex,
 	StripePlanRefresh,
+	KodyFetchGateway,
 }
 
 const platformWorkerHandler = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Restore MCP `execute` after the `kody-platform` cutover. Production origin, platform, and runtime healthchecks are green on `cea53d58`, but MCP `execute` fails immediately because the platform-owned `MCP` Durable Object looks up `KodyFetchGateway` on its own script's `ctx.exports`.

## Summary

- Export `KodyFetchGateway` from `packages/worker/src/platform-worker.ts` (same loopback pattern as `kody-runtime`).
- Add a unit test that the platform entry exports that WorkerEntrypoint.
- Document the requirement in ADR 0034 and the platform worker readme.

This is a WorkerEntrypoint, not a Durable Object — no migration, no `transferred_classes` change.

## Testing

- `npx vitest run packages/worker/src/platform-worker.node.test.ts --project node-unit`
- Production evidence of the bug: Kody MCP `execute` after the #1660 deploy returned `KodyFetchGateway export is required for execute-time fetch.` Origin `/__maintenance/execute-smoke` still passed because that path uses origin `ctx.exports`.
- After merge: MCP `execute` ping + Discord post-message, plus origin/platform/runtime health on `kody.codes`.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `cea53d58` · **Head:** `ef453285`

**Classification:** extends — platform worker now exports the execute fetch gateway that MCP already requires on the owning script.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `platform-worker` | surfaces | extends — export `KodyFetchGateway` so MCP execute can loopback outbound fetch |

### Change flow

MCP `execute` on the platform-owned Durable Object resolves the fetch gateway from this script's `ctx.exports`.

```mermaid
sequenceDiagram
	actor host as MCP host
	participant mcpServer as mcp-server
	participant platformWorker as platform-worker
	host->>mcpServer: execute
	mcpServer->>platformWorker: ctx.exports.KodyFetchGateway
	Note over platformWorker: this PR adds the missing export
	platformWorker-->>mcpServer: WorkerEntrypoint for sandbox fetch
	mcpServer-->>host: evaluation result
```

### Before / after

**Before:** `kody-platform` exported only the eight transferred Durable Object classes. MCP `execute` threw `KodyFetchGateway export is required for execute-time fetch.`

**After:** the same script also exports `KodyFetchGateway`, matching `kody-runtime`.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-abe71c19-e4c8-4053-9eb6-64c48e4d7547?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-abe71c19-e4c8-4053-9eb6-64c48e4d7547&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

