### PR TITLE
Play the factory-loop conversation on the homepage

### DIFF
--- a/docs/guides/how-kody-works.md
+++ b/docs/guides/how-kody-works.md
@@ -13,8 +13,10 @@ category: platform
 <!--
 Agent notes — for AI agents explaining or recreating this loop:
 
-- The web page at /guides/how-kody-works is an interactive transcript of the
-  same story. This markdown is the playbook.
+- The homepage plays this same transcript in a pause-on-explore player
+  (hover or focus pauses so a person can open tool calls).
+- The web page at /guides/how-kody-works is the full interactive transcript of
+  the same story. This markdown is the playbook.
 - Do not create the example package unless the person asks you to build it
   for them. If they do, follow package_authoring and package_lifecycle.
 - Search for GitHub activity ranks the saved `githubAccessToken` secret —

--- a/packages/worker/client/deferred-turnstile.node.test.ts
+++ b/packages/worker/client/deferred-turnstile.node.test.ts
@@ -42,3 +42,56 @@ test('observeNearViewport arms immediately without IntersectionObserver and wait
 	expect(disconnect).toHaveBeenCalledTimes(1)
 	vi.unstubAllGlobals()
 })
+
+test('observeNearViewport arms immediately when the node is already near', () => {
+	const observe = vi.fn()
+	class FakeObserver {
+		observe = observe
+		disconnect() {}
+	}
+	vi.stubGlobal('IntersectionObserver', FakeObserver)
+	vi.stubGlobal('window', { innerHeight: 800 })
+
+	const onNear = vi.fn()
+	const element = {
+		getBoundingClientRect: () => ({
+			top: 640,
+			bottom: 900,
+			left: 0,
+			right: 0,
+			width: 0,
+			height: 260,
+			x: 0,
+			y: 640,
+			toJSON() {
+				return this
+			},
+		}),
+	} as Element
+
+	const stop = observeNearViewport(element, onNear, '400px')
+	expect(onNear).toHaveBeenCalledTimes(1)
+	expect(observe).not.toHaveBeenCalled()
+	stop()
+
+	const far = {
+		getBoundingClientRect: () => ({
+			top: 1600,
+			bottom: 1900,
+			left: 0,
+			right: 0,
+			width: 0,
+			height: 300,
+			x: 0,
+			y: 1600,
+			toJSON() {
+				return this
+			},
+		}),
+	} as Element
+	const later = vi.fn()
+	observeNearViewport(far, later, '400px')
+	expect(later).not.toHaveBeenCalled()
+	expect(observe).toHaveBeenCalledWith(far)
+	vi.unstubAllGlobals()
+})

--- a/packages/worker/client/deferred-turnstile.ts
+++ b/packages/worker/client/deferred-turnstile.ts
@@ -1,6 +1,10 @@
 /**
  * Arm a below-fold widget once it is near the viewport so third-party
  * scripts stay off the first paint.
+ *
+ * IntersectionObserver can miss the initial callback on some mobile
+ * browsers when the node is already on screen at `observe()` time, so
+ * already-near elements arm synchronously from their box.
  */
 export function observeNearViewport(
 	element: Element,
@@ -8,6 +12,11 @@ export function observeNearViewport(
 	rootMargin = '400px',
 ): () => void {
 	if (typeof IntersectionObserver === 'undefined') {
+		onNear()
+		return () => {}
+	}
+
+	if (isElementNearViewport(element, rootMargin)) {
 		onNear()
 		return () => {}
 	}
@@ -26,4 +35,16 @@ export function observeNearViewport(
 	return () => {
 		observer.disconnect()
 	}
+}
+
+export function isElementNearViewport(
+	element: Element,
+	rootMargin = '400px',
+): boolean {
+	if (typeof window === 'undefined') return false
+	if (typeof element.getBoundingClientRect !== 'function') return false
+	const margin = Number.parseInt(rootMargin, 10)
+	const inset = Number.isFinite(margin) ? margin : 0
+	const rect = element.getBoundingClientRect()
+	return rect.top < window.innerHeight + inset && rect.bottom > -inset
 }

--- a/packages/worker/client/routes/home.tsx
+++ b/packages/worker/client/routes/home.tsx
@@ -27,7 +27,7 @@ import {
 	turnstileWidgetClassName,
 } from '#client/public-form-protection.ts'
 import { landingArtAttrs } from '#universal/landing-images.ts'
-import { routes } from '#universal/routes.ts'
+import { LandingLoopPlayer } from './landing-loop-player.tsx'
 
 /**
  * heykody.app landing page, ported from the redesign prototype
@@ -359,11 +359,7 @@ export function HomeRoute(handle: Handle) {
 						<strong>pretty much anything</strong>. What will{' '}
 						<strong>you</strong> build?
 					</p>
-					<p class="landing-factory-walkthrough">
-						<a href={routes.guideDetail.href({ slug: 'how-kody-works' })}>
-							See the whole loop
-						</a>
-					</p>
+					<LandingLoopPlayer />
 				</section>
 
 				{/* ============ honest runtime ============ */}

--- a/packages/worker/client/routes/interactive-guide-walkthrough.tsx
+++ b/packages/worker/client/routes/interactive-guide-walkthrough.tsx
@@ -49,7 +49,9 @@ export function renderInteractiveGuideWalkthrough(input: {
 					<h2 id={`${act.id}-title`}>{act.title}</h2>
 					<ol mix={css(threadCss)}>
 						{act.lines.map((line, index) => (
-							<li key={`${act.id}-${index}`}>{renderLine(line)}</li>
+							<li key={`${act.id}-${index}`}>
+								{renderInteractiveGuideLine(line)}
+							</li>
 						))}
 					</ol>
 				</section>
@@ -60,7 +62,7 @@ export function renderInteractiveGuideWalkthrough(input: {
 	)
 }
 
-function renderLine(line: TranscriptLine) {
+export function renderInteractiveGuideLine(line: TranscriptLine) {
 	switch (line.role) {
 		case 'user':
 			return (

--- a/packages/worker/client/routes/landing-loop-player.node.test.ts
+++ b/packages/worker/client/routes/landing-loop-player.node.test.ts
@@ -1,0 +1,121 @@
+import { expect, test, vi } from 'vitest'
+import { howKodyWorksTranscriptActs } from './how-kody-works-transcript.ts'
+import {
+	createLandingLoopPlayer,
+	flattenTranscriptActs,
+	landingLoopHoldMs,
+	landingLoopTeaser,
+	waitLandingLoopHold,
+} from './landing-loop-player.ts'
+
+test('homepage loop player pauses for hover and explore, then play resumes and loops', async () => {
+	const beats = flattenTranscriptActs(howKodyWorksTranscriptActs)
+	expect(beats[0]).toMatchObject({
+		kind: 'act',
+		id: 'ask',
+		kicker: landingLoopTeaser.kicker,
+		title: landingLoopTeaser.title,
+	})
+	expect(beats[1]).toMatchObject({
+		kind: 'line',
+		actId: 'ask',
+		line: { role: 'user', text: landingLoopTeaser.user },
+	})
+	expect(
+		beats.some((beat) => beat.kind === 'act' && beat.id === 'invoke'),
+	).toBe(true)
+	expect(
+		beats.some((beat) => beat.kind === 'line' && beat.line.role === 'tools'),
+	).toBe(true)
+
+	const player = createLandingLoopPlayer({
+		beatCount: beats.length,
+		reducedMotion: false,
+	})
+	expect(player.revealedCount).toBe(1)
+	expect(player.isPaused()).toBe(false)
+	expect(landingLoopHoldMs(beats[0]!)).toBe(1100)
+	expect(landingLoopHoldMs('loop')).toBe(4000)
+
+	player.setHover(true)
+	expect(player.isPaused()).toBe(true)
+	expect(player.advance()).toEqual({ didAdvance: false, looped: false })
+
+	player.setExplore(true)
+	player.setHover(false)
+	expect(player.isPaused()).toBe(true)
+	expect(player.pauseReasons()).toEqual(['explore'])
+
+	player.play()
+	expect(player.isPaused()).toBe(false)
+	expect(player.advance()).toEqual({ didAdvance: true, looped: false })
+	expect(player.revealedCount).toBe(2)
+
+	player.play()
+	player.setHover(true)
+	expect(player.isPaused()).toBe(false)
+	player.setHover(false)
+	player.setHover(true)
+	expect(player.isPaused()).toBe(true)
+
+	player.setFocus(true)
+	player.setHover(false)
+	expect(player.isPaused()).toBe(true)
+	player.play()
+	expect(player.isPaused()).toBe(false)
+	player.setFocus(false)
+	player.setFocus(true)
+	expect(player.isPaused()).toBe(true)
+	player.play()
+
+	const still = createLandingLoopPlayer({
+		beatCount: beats.length,
+		reducedMotion: true,
+	})
+	expect(still.revealedCount).toBe(beats.length)
+	expect(still.isPaused()).toBe(true)
+	expect(still.advance()).toEqual({ didAdvance: false, looped: false })
+
+	const looper = createLandingLoopPlayer({
+		beatCount: 2,
+		reducedMotion: false,
+	})
+	expect(looper.advance()).toEqual({ didAdvance: true, looped: false })
+	expect(looper.revealedCount).toBe(2)
+	expect(looper.advance()).toEqual({ didAdvance: true, looped: true })
+	expect(looper.revealedCount).toBe(1)
+
+	vi.useFakeTimers()
+	try {
+		const controller = new AbortController()
+		let paused = true
+		const listeners = new Set<() => void>()
+		const hold = waitLandingLoopHold({
+			ms: 400,
+			isPaused: () => paused,
+			subscribe: (listener) => {
+				listeners.add(listener)
+				return () => {
+					listeners.delete(listener)
+				}
+			},
+			signal: controller.signal,
+		})
+		await vi.advanceTimersByTimeAsync(400)
+		paused = false
+		for (const listener of [...listeners]) listener()
+		await vi.advanceTimersByTimeAsync(400)
+		await expect(hold).resolves.toBe(true)
+
+		const aborted = waitLandingLoopHold({
+			ms: 800,
+			isPaused: () => false,
+			subscribe: () => () => {},
+			signal: controller.signal,
+		})
+		controller.abort()
+		await expect(aborted).resolves.toBe(false)
+	} finally {
+		vi.useRealTimers()
+	}
+})

--- a/packages/worker/client/routes/landing-loop-player.node.test.ts
+++ b/packages/worker/client/routes/landing-loop-player.node.test.ts
@@ -5,6 +5,7 @@ import {
 	flattenTranscriptActs,
 	landingLoopHoldMs,
 	landingLoopTeaser,
+	landingLoopTeaserBeatCount,
 	waitLandingLoopHold,
 } from './landing-loop-state.ts'
 
@@ -32,7 +33,7 @@ test('homepage loop player pauses for hover and explore, then play resumes and l
 		beatCount: beats.length,
 		reducedMotion: false,
 	})
-	expect(player.revealedCount).toBe(1)
+	expect(player.revealedCount).toBe(landingLoopTeaserBeatCount)
 	expect(player.isPaused()).toBe(false)
 	expect(landingLoopHoldMs(beats[0]!)).toBe(1100)
 	expect(landingLoopHoldMs('loop')).toBe(4000)
@@ -49,7 +50,7 @@ test('homepage loop player pauses for hover and explore, then play resumes and l
 	player.play()
 	expect(player.isPaused()).toBe(false)
 	expect(player.advance()).toEqual({ didAdvance: true, looped: false })
-	expect(player.revealedCount).toBe(2)
+	expect(player.revealedCount).toBe(landingLoopTeaserBeatCount + 1)
 
 	player.setHover(true)
 	player.play()
@@ -79,13 +80,14 @@ test('homepage loop player pauses for hover and explore, then play resumes and l
 	expect(still.advance()).toEqual({ didAdvance: false, looped: false })
 
 	const looper = createLandingLoopPlayer({
-		beatCount: 2,
+		beatCount: 3,
 		reducedMotion: false,
 	})
+	expect(looper.revealedCount).toBe(landingLoopTeaserBeatCount)
 	expect(looper.advance()).toEqual({ didAdvance: true, looped: false })
-	expect(looper.revealedCount).toBe(2)
+	expect(looper.revealedCount).toBe(3)
 	expect(looper.advance()).toEqual({ didAdvance: true, looped: true })
-	expect(looper.revealedCount).toBe(1)
+	expect(looper.revealedCount).toBe(landingLoopTeaserBeatCount)
 
 	vi.useFakeTimers()
 	try {

--- a/packages/worker/client/routes/landing-loop-player.node.test.ts
+++ b/packages/worker/client/routes/landing-loop-player.node.test.ts
@@ -6,7 +6,7 @@ import {
 	landingLoopHoldMs,
 	landingLoopTeaser,
 	waitLandingLoopHold,
-} from './landing-loop-player.ts'
+} from './landing-loop-state.ts'
 
 test('homepage loop player pauses for hover and explore, then play resumes and loops', async () => {
 	const beats = flattenTranscriptActs(howKodyWorksTranscriptActs)
@@ -51,7 +51,9 @@ test('homepage loop player pauses for hover and explore, then play resumes and l
 	expect(player.advance()).toEqual({ didAdvance: true, looped: false })
 	expect(player.revealedCount).toBe(2)
 
+	player.setHover(true)
 	player.play()
+	expect(player.isPaused()).toBe(false)
 	player.setHover(true)
 	expect(player.isPaused()).toBe(false)
 	player.setHover(false)
@@ -103,7 +105,7 @@ test('homepage loop player pauses for hover and explore, then play resumes and l
 		})
 		await vi.advanceTimersByTimeAsync(400)
 		paused = false
-		for (const listener of [...listeners]) listener()
+		for (const listener of listeners) listener()
 		await vi.advanceTimersByTimeAsync(400)
 		await expect(hold).resolves.toBe(true)
 

--- a/packages/worker/client/routes/landing-loop-player.ts
+++ b/packages/worker/client/routes/landing-loop-player.ts
@@ -1,0 +1,214 @@
+import {
+	type TranscriptAct,
+	type TranscriptLine,
+} from './interactive-guide-transcript.ts'
+
+export const landingLoopTeaser = {
+	kicker: 'Example of a conversation you might have with your agent.',
+	title: 'Ask once',
+	user: 'What did my favorite bot ship recently on GitHub?',
+} as const
+
+export type LandingLoopPauseReason =
+	| 'hover'
+	| 'focus'
+	| 'explore'
+	| 'offscreen'
+	| 'manual'
+
+export type LandingLoopBeat =
+	| {
+			kind: 'act'
+			id: string
+			kicker: string
+			title: string
+	  }
+	| {
+			kind: 'line'
+			actId: string
+			line: TranscriptLine
+	  }
+
+export type LandingLoopAdvance = {
+	didAdvance: boolean
+	looped: boolean
+}
+
+export function flattenTranscriptActs(
+	acts: ReadonlyArray<TranscriptAct>,
+): Array<LandingLoopBeat> {
+	const beats: Array<LandingLoopBeat> = []
+	for (const act of acts) {
+		beats.push({
+			kind: 'act',
+			id: act.id,
+			kicker: act.kicker,
+			title: act.title,
+		})
+		for (const line of act.lines) {
+			beats.push({ kind: 'line', actId: act.id, line })
+		}
+	}
+	return beats
+}
+
+export function landingLoopHoldMs(beat: LandingLoopBeat | 'loop'): number {
+	if (beat === 'loop') return 4000
+	if (beat.kind === 'act') return 1100
+	switch (beat.line.role) {
+		case 'user':
+		case 'agent':
+			return Math.min(2200, 500 + beat.line.text.length * 4) + 700
+		case 'tools':
+		case 'files':
+			return 1500
+		default: {
+			const exhaustive: never = beat.line
+			return exhaustive
+		}
+	}
+}
+
+export function createLandingLoopPlayer(input: {
+	beatCount: number
+	reducedMotion: boolean
+}) {
+	const listeners = new Set<() => void>()
+	const reasons = new Set<LandingLoopPauseReason>()
+	let revealedCount = input.reducedMotion
+		? input.beatCount
+		: Math.min(1, input.beatCount)
+	let ignorePointerPause = false
+
+	function emit() {
+		for (const listener of [...listeners]) listener()
+	}
+
+	function isPaused() {
+		return input.reducedMotion || reasons.size > 0
+	}
+
+	function setReason(reason: LandingLoopPauseReason, on: boolean) {
+		const had = reasons.has(reason)
+		if (on) reasons.add(reason)
+		else reasons.delete(reason)
+		if (had === on) return
+		emit()
+	}
+
+	return {
+		get revealedCount() {
+			return revealedCount
+		},
+		isPaused,
+		pauseReasons(): Array<LandingLoopPauseReason> {
+			return [...reasons]
+		},
+		subscribe(listener: () => void) {
+			listeners.add(listener)
+			return () => {
+				listeners.delete(listener)
+			}
+		},
+		setHover(on: boolean) {
+			if (!on) {
+				ignorePointerPause = false
+				setReason('hover', false)
+				return
+			}
+			if (ignorePointerPause) return
+			setReason('hover', true)
+		},
+		setFocus(on: boolean) {
+			if (!on) {
+				setReason('focus', false)
+				return
+			}
+			if (ignorePointerPause) return
+			setReason('focus', true)
+		},
+		setExplore(on: boolean) {
+			setReason('explore', on)
+		},
+		setOffscreen(on: boolean) {
+			setReason('offscreen', on)
+		},
+		pause() {
+			ignorePointerPause = false
+			setReason('manual', true)
+		},
+		play() {
+			const wasPointerPaused = reasons.has('hover') || reasons.has('focus')
+			if (wasPointerPaused) ignorePointerPause = true
+			reasons.delete('explore')
+			reasons.delete('manual')
+			reasons.delete('hover')
+			reasons.delete('focus')
+			emit()
+		},
+		advance(): LandingLoopAdvance {
+			if (isPaused() || input.beatCount === 0) {
+				return { didAdvance: false, looped: false }
+			}
+			if (revealedCount >= input.beatCount) {
+				revealedCount = Math.min(1, input.beatCount)
+				emit()
+				return { didAdvance: true, looped: true }
+			}
+			revealedCount += 1
+			emit()
+			return { didAdvance: true, looped: false }
+		},
+	}
+}
+
+export async function waitLandingLoopHold(input: {
+	ms: number
+	isPaused: () => boolean
+	subscribe: (listener: () => void) => () => void
+	signal: AbortSignal
+}): Promise<boolean> {
+	let remaining = input.ms
+
+	function waitFor(kind: 'slice' | 'resume', ms?: number) {
+		return new Promise<'sleep' | 'abort' | 'change'>((resolve) => {
+			const timer =
+				kind === 'slice' && ms != null
+					? setTimeout(() => finish('sleep'), ms)
+					: null
+			function finish(event: 'sleep' | 'abort' | 'change') {
+				if (timer != null) clearTimeout(timer)
+				input.signal.removeEventListener('abort', onAbort)
+				unsubscribe()
+				resolve(event)
+			}
+			function onAbort() {
+				finish('abort')
+			}
+			const unsubscribe = input.subscribe(() => {
+				finish('change')
+			})
+			input.signal.addEventListener('abort', onAbort, { once: true })
+			if (input.signal.aborted) finish('abort')
+		})
+	}
+
+	while (remaining > 0) {
+		if (input.signal.aborted) return false
+		if (input.isPaused()) {
+			const event = await waitFor('resume')
+			if (event === 'abort') return false
+			continue
+		}
+		const slice = Math.min(remaining, 200)
+		const started = Date.now()
+		const event = await waitFor('slice', slice)
+		if (event === 'abort') return false
+		if (event === 'change') {
+			remaining -= Date.now() - started
+			continue
+		}
+		remaining -= slice
+	}
+	return !input.signal.aborted
+}

--- a/packages/worker/client/routes/landing-loop-player.tsx
+++ b/packages/worker/client/routes/landing-loop-player.tsx
@@ -11,7 +11,7 @@ import {
 	landingLoopTeaser,
 	waitLandingLoopHold,
 	type LandingLoopBeat,
-} from './landing-loop-player.ts'
+} from './landing-loop-state.ts'
 
 type LoopLineRenderer = (line: TranscriptLine) => RemixNode
 
@@ -133,7 +133,8 @@ export function LandingLoopPlayer(handle: Handle) {
 
 	return () => {
 		const visibleBeats = beats?.slice(0, player.revealedCount) ?? null
-		const loaded = visibleBeats != null && renderLine != null
+		const lineRenderer = renderLine
+		const loaded = visibleBeats != null && lineRenderer != null
 		const userPaused =
 			loaded && player.pauseReasons().some((reason) => reason !== 'offscreen')
 		const paused = userPaused && !reducedMotion
@@ -224,7 +225,6 @@ export function LandingLoopPlayer(handle: Handle) {
 				</div>
 				<div
 					class="landing-loop-chat"
-					tabIndex={0}
 					mix={[
 						on('focusin', () => {
 							player.setFocus(true)
@@ -274,11 +274,11 @@ export function LandingLoopPlayer(handle: Handle) {
 						}),
 					]}
 				>
-					{loaded
+					{visibleBeats && lineRenderer
 						? visibleBeats.map((beat, index) =>
 								renderBeat(
 									beat,
-									renderLine,
+									lineRenderer,
 									`${beatKey(beat)}-${index}`,
 									index === visibleBeats.length - 1,
 								),

--- a/packages/worker/client/routes/landing-loop-player.tsx
+++ b/packages/worker/client/routes/landing-loop-player.tsx
@@ -1,5 +1,8 @@
 import { type Handle, type RemixNode, ref } from 'remix/ui'
-import { observeNearViewport } from '#client/deferred-turnstile.ts'
+import {
+	isElementNearViewport,
+	observeNearViewport,
+} from '#client/deferred-turnstile.ts'
 import { on } from '#client/event-mixin.ts'
 import { loadSyntaxHighlight } from '#client/syntax-highlight.tsx'
 import { routes } from '#universal/routes.ts'
@@ -17,10 +20,11 @@ type LoopLineRenderer = (line: TranscriptLine) => RemixNode
 
 /**
  * Homepage factory-loop player. SSR paints the first user turn; the
- * transcript chunk and syntax highlighter load once the card is near the
- * viewport so they stay out of the marketing entry. Hover/focus (fine
- * pointers) and explore (scroll up or open a tool) pause the autoplay;
- * Play scrolls to the latest beat and continues.
+ * transcript chunk loads once the card is near the viewport so it stays
+ * out of the marketing entry. Shiki waits until a tool or file beat is
+ * on screen. Hover/focus (fine pointers) and explore (scroll up or open
+ * a tool) pause the autoplay; Play scrolls to the latest beat and
+ * continues.
  */
 export function LandingLoopPlayer(handle: Handle) {
 	let beats: Array<LandingLoopBeat> | null = null
@@ -32,7 +36,8 @@ export function LandingLoopPlayer(handle: Handle) {
 	let autoScrolling = false
 	let playGeneration = 0
 	let loadStarted = false
-	let visibleInViewport = false
+	let loopEl: HTMLElement | null = null
+	let visibleInViewport = true
 
 	function prefersReducedMotion() {
 		return (
@@ -48,16 +53,44 @@ export function LandingLoopPlayer(handle: Handle) {
 		)
 	}
 
-	async function loadLoop(signal: AbortSignal) {
+	function armLoad() {
+		if (loadStarted || handle.signal.aborted) return
+		loadStarted = true
+		void loadLoop()
+	}
+
+	function syncVisibility() {
+		visibleInViewport = loopEl ? isElementNearViewport(loopEl, '0px') : true
+		if (!beats || reducedMotion) return
+		const wasPaused = player.isPaused()
+		player.setOffscreen(!visibleInViewport)
+		if (wasPaused && !player.isPaused()) startPlayLoop()
+	}
+
+	function needsHighlight(visible: ReadonlyArray<LandingLoopBeat>) {
+		return visible.some(
+			(beat) =>
+				beat.kind === 'line' &&
+				(beat.line.role === 'tools' || beat.line.role === 'files'),
+		)
+	}
+
+	function prefetchHighlight() {
+		void loadSyntaxHighlight().then(() => {
+			if (!handle.signal.aborted) handle.update()
+		})
+	}
+
+	async function loadLoop() {
 		try {
 			const [transcript, walkthrough] = await Promise.all([
 				// Dynamic import is intentional so the factory transcript and
-				// tool-call renderer stay out of the homepage chunk.
+				// tool-call renderer stay out of the homepage chunk. Shiki
+				// stays off this path — plaintext fences are enough to start.
 				import('./how-kody-works-transcript.ts'),
 				import('./interactive-guide-walkthrough.tsx'),
-				loadSyntaxHighlight(),
 			])
-			if (signal.aborted) return
+			if (handle.signal.aborted) return
 			beats = flattenTranscriptActs(transcript.howKodyWorksTranscriptActs)
 			renderLine = walkthrough.renderInteractiveGuideLine
 			reducedMotion = prefersReducedMotion()
@@ -66,13 +99,15 @@ export function LandingLoopPlayer(handle: Handle) {
 				beatCount: beats.length,
 				reducedMotion,
 			})
-			if (!reducedMotion) {
-				player.setOffscreen(!visibleInViewport)
-				if (visibleInViewport) startPlayLoop()
+			syncVisibility()
+			if (needsHighlight(beats.slice(0, player.revealedCount))) {
+				prefetchHighlight()
 			}
+			if (!reducedMotion && !player.isPaused()) startPlayLoop()
 			handle.update()
 		} catch {
-			// Leave the SSR teaser in place if the transcript chunk fails.
+			// Leave the SSR teaser in place and let a later arm retry.
+			loadStarted = false
 		}
 	}
 
@@ -116,6 +151,9 @@ export function LandingLoopPlayer(handle: Handle) {
 				}
 				if (player.isPaused()) continue
 				player.advance()
+				if (beats && needsHighlight(beats.slice(0, player.revealedCount))) {
+					prefetchHighlight()
+				}
 				await handle.update()
 				if (signal.aborted || generation !== playGeneration) return
 				scrollChatToBottom()
@@ -158,36 +196,34 @@ export function LandingLoopPlayer(handle: Handle) {
 						handle.update()
 					}),
 					ref((node, signal) => {
-						if (typeof IntersectionObserver === 'undefined') {
-							visibleInViewport = true
+						loopEl = node
+						const stopNear = observeNearViewport(node, armLoad)
+						const onVisibility = () => {
+							if (isElementNearViewport(node)) armLoad()
+							syncVisibility()
+							if (beats) handle.update()
 						}
-						const stopNear = observeNearViewport(node, () => {
-							if (loadStarted) return
-							loadStarted = true
-							void loadLoop(handle.signal)
-						})
 						const visibilityObserver =
 							typeof IntersectionObserver === 'undefined'
 								? null
-								: new IntersectionObserver(
-										(entries) => {
-											visibleInViewport = entries.some(
-												(entry) => entry.isIntersecting,
-											)
-											if (!beats) return
-											const wasPaused = player.isPaused()
-											player.setOffscreen(!visibleInViewport)
-											if (!reducedMotion && wasPaused && !player.isPaused()) {
-												startPlayLoop()
-											}
-											handle.update()
-										},
-										{ threshold: 0.35 },
-									)
+								: new IntersectionObserver(onVisibility, { threshold: 0 })
 						visibilityObserver?.observe(node)
+						window.addEventListener('scroll', onVisibility, {
+							passive: true,
+							signal,
+						})
+						window.addEventListener('resize', onVisibility, {
+							passive: true,
+							signal,
+						})
+						const raf = requestAnimationFrame(() => {
+							if (isElementNearViewport(node)) armLoad()
+						})
 						signal.addEventListener(
 							'abort',
 							() => {
+								if (loopEl === node) loopEl = null
+								cancelAnimationFrame(raf)
 								stopNear()
 								visibilityObserver?.disconnect()
 							},

--- a/packages/worker/client/routes/landing-loop-player.tsx
+++ b/packages/worker/client/routes/landing-loop-player.tsx
@@ -94,7 +94,8 @@ export function LandingLoopPlayer(handle: Handle) {
 		if (reducedMotion || !beats) return
 		playGeneration += 1
 		const generation = playGeneration
-		handle.queueTask(async (signal) => {
+		const signal = handle.signal
+		void (async () => {
 			while (!signal.aborted && generation === playGeneration) {
 				const currentBeats = beats
 				if (!currentBeats || currentBeats.length === 0) return
@@ -115,12 +116,11 @@ export function LandingLoopPlayer(handle: Handle) {
 				}
 				if (player.isPaused()) continue
 				player.advance()
-				handle.update()
-				handle.queueTask(() => {
-					scrollChatToBottom()
-				})
+				await handle.update()
+				if (signal.aborted || generation !== playGeneration) return
+				scrollChatToBottom()
 			}
-		})
+		})()
 	}
 
 	function playFromHere() {
@@ -164,7 +164,7 @@ export function LandingLoopPlayer(handle: Handle) {
 						const stopNear = observeNearViewport(node, () => {
 							if (loadStarted) return
 							loadStarted = true
-							handle.queueTask(loadLoop)
+							void loadLoop(handle.signal)
 						})
 						const visibilityObserver =
 							typeof IntersectionObserver === 'undefined'

--- a/packages/worker/client/routes/landing-loop-player.tsx
+++ b/packages/worker/client/routes/landing-loop-player.tsx
@@ -5,6 +5,7 @@ import {
 } from '#client/deferred-turnstile.ts'
 import { on } from '#client/event-mixin.ts'
 import { loadSyntaxHighlight } from '#client/syntax-highlight.tsx'
+import { whenWindowLoaded } from '#client/when-window-loaded.ts'
 import { routes } from '#universal/routes.ts'
 import { type TranscriptLine } from './interactive-guide-transcript.ts'
 import {
@@ -21,10 +22,10 @@ type LoopLineRenderer = (line: TranscriptLine) => RemixNode
 /**
  * Homepage factory-loop player. SSR paints the first user turn; the
  * transcript chunk loads once the card is near the viewport so it stays
- * out of the marketing entry. Shiki waits until a tool or file beat is
- * on screen. Hover/focus (fine pointers) and explore (scroll up or open
- * a tool) pause the autoplay; Play scrolls to the latest beat and
- * continues.
+ * out of the marketing entry. Shiki prefetches after window `load` so
+ * it does not block first paint or the first beats. Hover/focus (fine
+ * pointers) and explore (scroll up or open a tool) pause the autoplay;
+ * Play scrolls to the latest beat and continues.
  */
 export function LandingLoopPlayer(handle: Handle) {
 	let beats: Array<LandingLoopBeat> | null = null
@@ -67,20 +68,6 @@ export function LandingLoopPlayer(handle: Handle) {
 		if (wasPaused && !player.isPaused()) startPlayLoop()
 	}
 
-	function needsHighlight(visible: ReadonlyArray<LandingLoopBeat>) {
-		return visible.some(
-			(beat) =>
-				beat.kind === 'line' &&
-				(beat.line.role === 'tools' || beat.line.role === 'files'),
-		)
-	}
-
-	function prefetchHighlight() {
-		void loadSyntaxHighlight().then(() => {
-			if (!handle.signal.aborted) handle.update()
-		})
-	}
-
 	async function loadLoop() {
 		try {
 			const [transcript, walkthrough] = await Promise.all([
@@ -100,9 +87,6 @@ export function LandingLoopPlayer(handle: Handle) {
 				reducedMotion,
 			})
 			syncVisibility()
-			if (needsHighlight(beats.slice(0, player.revealedCount))) {
-				prefetchHighlight()
-			}
 			if (!reducedMotion && !player.isPaused()) startPlayLoop()
 			handle.update()
 		} catch {
@@ -151,9 +135,6 @@ export function LandingLoopPlayer(handle: Handle) {
 				}
 				if (player.isPaused()) continue
 				player.advance()
-				if (beats && needsHighlight(beats.slice(0, player.revealedCount))) {
-					prefetchHighlight()
-				}
 				await handle.update()
 				if (signal.aborted || generation !== playGeneration) return
 				scrollChatToBottom()
@@ -168,6 +149,12 @@ export function LandingLoopPlayer(handle: Handle) {
 			scrollChatToBottom()
 		})
 	}
+
+	whenWindowLoaded(() => {
+		void loadSyntaxHighlight().then(() => {
+			if (!handle.signal.aborted) handle.update()
+		})
+	}, handle.signal)
 
 	return () => {
 		const visibleBeats = beats?.slice(0, player.revealedCount) ?? null

--- a/packages/worker/client/routes/landing-loop-player.tsx
+++ b/packages/worker/client/routes/landing-loop-player.tsx
@@ -1,0 +1,347 @@
+import { type Handle, type RemixNode, ref } from 'remix/ui'
+import { observeNearViewport } from '#client/deferred-turnstile.ts'
+import { on } from '#client/event-mixin.ts'
+import { loadSyntaxHighlight } from '#client/syntax-highlight.tsx'
+import { routes } from '#universal/routes.ts'
+import { type TranscriptLine } from './interactive-guide-transcript.ts'
+import {
+	createLandingLoopPlayer,
+	flattenTranscriptActs,
+	landingLoopHoldMs,
+	landingLoopTeaser,
+	waitLandingLoopHold,
+	type LandingLoopBeat,
+} from './landing-loop-player.ts'
+
+type LoopLineRenderer = (line: TranscriptLine) => RemixNode
+
+/**
+ * Homepage factory-loop player. SSR paints the first user turn; the
+ * transcript chunk and syntax highlighter load once the card is near the
+ * viewport so they stay out of the marketing entry. Hover/focus (fine
+ * pointers) and explore (scroll up or open a tool) pause the autoplay;
+ * Play scrolls to the latest beat and continues.
+ */
+export function LandingLoopPlayer(handle: Handle) {
+	let beats: Array<LandingLoopBeat> | null = null
+	let renderLine: LoopLineRenderer | null = null
+	let player = createLandingLoopPlayer({ beatCount: 1, reducedMotion: false })
+	let reducedMotion = false
+	let hoverPauses = false
+	let chatEl: HTMLElement | null = null
+	let autoScrolling = false
+	let playGeneration = 0
+	let loadStarted = false
+	let visibleInViewport = false
+
+	function prefersReducedMotion() {
+		return (
+			typeof matchMedia === 'function' &&
+			matchMedia('(prefers-reduced-motion: reduce)').matches
+		)
+	}
+
+	function canHoverPause() {
+		return (
+			typeof matchMedia === 'function' &&
+			matchMedia('(hover: hover) and (pointer: fine)').matches
+		)
+	}
+
+	async function loadLoop(signal: AbortSignal) {
+		try {
+			const [transcript, walkthrough] = await Promise.all([
+				// Dynamic import is intentional so the factory transcript and
+				// tool-call renderer stay out of the homepage chunk.
+				import('./how-kody-works-transcript.ts'),
+				import('./interactive-guide-walkthrough.tsx'),
+				loadSyntaxHighlight(),
+			])
+			if (signal.aborted) return
+			beats = flattenTranscriptActs(transcript.howKodyWorksTranscriptActs)
+			renderLine = walkthrough.renderInteractiveGuideLine
+			reducedMotion = prefersReducedMotion()
+			hoverPauses = canHoverPause()
+			player = createLandingLoopPlayer({
+				beatCount: beats.length,
+				reducedMotion,
+			})
+			if (!reducedMotion) {
+				player.setOffscreen(!visibleInViewport)
+				if (visibleInViewport) startPlayLoop()
+			}
+			handle.update()
+		} catch {
+			// Leave the SSR teaser in place if the transcript chunk fails.
+		}
+	}
+
+	function scrollChatToBottom() {
+		if (!chatEl) return
+		autoScrolling = true
+		chatEl.scrollTo({
+			top: chatEl.scrollHeight,
+			behavior: reducedMotion ? 'auto' : 'smooth',
+		})
+		const done = () => {
+			autoScrolling = false
+		}
+		chatEl.addEventListener('scrollend', done, { once: true })
+		window.setTimeout(done, 480)
+	}
+
+	function startPlayLoop() {
+		if (reducedMotion || !beats) return
+		playGeneration += 1
+		const generation = playGeneration
+		handle.queueTask(async (signal) => {
+			while (!signal.aborted && generation === playGeneration) {
+				const currentBeats = beats
+				if (!currentBeats || currentBeats.length === 0) return
+				const current = currentBeats[player.revealedCount - 1]
+				if (!current) return
+				const hold =
+					player.revealedCount >= currentBeats.length
+						? landingLoopHoldMs('loop')
+						: landingLoopHoldMs(current)
+				const finished = await waitLandingLoopHold({
+					ms: hold,
+					isPaused: () => player.isPaused(),
+					subscribe: player.subscribe,
+					signal,
+				})
+				if (!finished || signal.aborted || generation !== playGeneration) {
+					return
+				}
+				if (player.isPaused()) continue
+				player.advance()
+				handle.update()
+				handle.queueTask(() => {
+					scrollChatToBottom()
+				})
+			}
+		})
+	}
+
+	function playFromHere() {
+		player.play()
+		handle.update()
+		handle.queueTask(() => {
+			scrollChatToBottom()
+		})
+	}
+
+	return () => {
+		const visibleBeats = beats?.slice(0, player.revealedCount) ?? null
+		const loaded = visibleBeats != null && renderLine != null
+		const userPaused =
+			loaded && player.pauseReasons().some((reason) => reason !== 'offscreen')
+		const paused = userPaused && !reducedMotion
+		const playing = loaded && !player.isPaused() && !reducedMotion
+
+		return (
+			<div
+				class="landing-loop"
+				data-paused={paused ? 'true' : undefined}
+				data-playing={playing ? 'true' : undefined}
+				aria-label="Factory loop conversation"
+				mix={[
+					on('pointerenter', () => {
+						if (!hoverPauses) return
+						player.setHover(true)
+						handle.update()
+					}),
+					on('pointerleave', () => {
+						if (!hoverPauses) return
+						player.setHover(false)
+						handle.update()
+					}),
+					ref((node, signal) => {
+						if (typeof IntersectionObserver === 'undefined') {
+							visibleInViewport = true
+						}
+						const stopNear = observeNearViewport(node, () => {
+							if (loadStarted) return
+							loadStarted = true
+							handle.queueTask(loadLoop)
+						})
+						const visibilityObserver =
+							typeof IntersectionObserver === 'undefined'
+								? null
+								: new IntersectionObserver(
+										(entries) => {
+											visibleInViewport = entries.some(
+												(entry) => entry.isIntersecting,
+											)
+											if (!beats) return
+											const wasPaused = player.isPaused()
+											player.setOffscreen(!visibleInViewport)
+											if (!reducedMotion && wasPaused && !player.isPaused()) {
+												startPlayLoop()
+											}
+											handle.update()
+										},
+										{ threshold: 0.35 },
+									)
+						visibilityObserver?.observe(node)
+						signal.addEventListener(
+							'abort',
+							() => {
+								stopNear()
+								visibilityObserver?.disconnect()
+							},
+							{ once: true },
+						)
+					}),
+				]}
+			>
+				<div class="landing-loop-head">
+					<p class="landing-loop-status" aria-hidden="true">
+						<span class="landing-loop-status-dot"></span>
+						{reducedMotion
+							? 'The loop'
+							: paused
+								? 'Paused'
+								: loaded
+									? 'Playing'
+									: 'The loop'}
+					</p>
+					{reducedMotion || !loaded || !(playing || paused) ? null : (
+						<button
+							type="button"
+							class="landing-loop-toggle"
+							mix={on('click', () => {
+								if (player.isPaused()) playFromHere()
+								else {
+									player.pause()
+									handle.update()
+								}
+							})}
+						>
+							{paused ? 'Play' : 'Pause'}
+						</button>
+					)}
+				</div>
+				<div
+					class="landing-loop-chat"
+					tabIndex={0}
+					mix={[
+						on('focusin', () => {
+							player.setFocus(true)
+							handle.update()
+						}),
+						on('focusout', (event) => {
+							const next = event.relatedTarget
+							if (
+								next instanceof Node &&
+								event.currentTarget instanceof Node &&
+								event.currentTarget.contains(next)
+							) {
+								return
+							}
+							player.setFocus(false)
+							handle.update()
+						}),
+						on('scroll', () => {
+							if (!chatEl || autoScrolling) return
+							const slack = 28
+							const atBottom =
+								chatEl.scrollHeight - chatEl.scrollTop - chatEl.clientHeight <=
+								slack
+							if (atBottom) return
+							player.setExplore(true)
+							handle.update()
+						}),
+						ref((node, signal) => {
+							chatEl = node
+							const onToggle = (event: Event) => {
+								if (!(event.target instanceof HTMLDetailsElement)) return
+								if (!event.target.open) return
+								player.setExplore(true)
+								handle.update()
+							}
+							node.addEventListener('toggle', onToggle, {
+								capture: true,
+								signal,
+							})
+							signal.addEventListener(
+								'abort',
+								() => {
+									if (chatEl === node) chatEl = null
+								},
+								{ once: true },
+							)
+						}),
+					]}
+				>
+					{loaded
+						? visibleBeats.map((beat, index) =>
+								renderBeat(
+									beat,
+									renderLine,
+									`${beatKey(beat)}-${index}`,
+									index === visibleBeats.length - 1,
+								),
+							)
+						: renderTeaser()}
+				</div>
+				<p class="landing-loop-foot">
+					<a href={routes.guideDetail.href({ slug: 'how-kody-works' })}>
+						Read the walkthrough
+					</a>
+				</p>
+			</div>
+		)
+	}
+}
+
+function beatKey(beat: LandingLoopBeat) {
+	if (beat.kind === 'act') return `act-${beat.id}`
+	return `line-${beat.actId}-${beat.line.role}`
+}
+
+function renderBeat(
+	beat: LandingLoopBeat,
+	renderLine: LoopLineRenderer,
+	key: string,
+	newest: boolean,
+) {
+	if (beat.kind === 'act') {
+		return (
+			<header
+				key={key}
+				class="landing-loop-act"
+				data-newest={newest ? 'true' : undefined}
+			>
+				<p class="landing-loop-kicker">{beat.kicker}</p>
+				<h3>{beat.title}</h3>
+			</header>
+		)
+	}
+	return (
+		<div
+			key={key}
+			class="landing-loop-line"
+			data-newest={newest ? 'true' : undefined}
+		>
+			{renderLine(beat.line)}
+		</div>
+	)
+}
+
+function renderTeaser() {
+	return (
+		<>
+			<header class="landing-loop-act">
+				<p class="landing-loop-kicker">{landingLoopTeaser.kicker}</p>
+				<h3>{landingLoopTeaser.title}</h3>
+			</header>
+			<figure class="landing-loop-you">
+				<figcaption>You</figcaption>
+				<blockquote>
+					<p>{landingLoopTeaser.user}</p>
+				</blockquote>
+			</figure>
+		</>
+	)
+}

--- a/packages/worker/client/routes/landing-loop-state.ts
+++ b/packages/worker/client/routes/landing-loop-state.ts
@@ -81,7 +81,7 @@ export function createLandingLoopPlayer(input: {
 	let ignorePointerPause = false
 
 	function emit() {
-		for (const listener of [...listeners]) listener()
+		for (const listener of Array.from(listeners)) listener()
 	}
 
 	function isPaused() {
@@ -121,6 +121,7 @@ export function createLandingLoopPlayer(input: {
 		},
 		setFocus(on: boolean) {
 			if (!on) {
+				ignorePointerPause = false
 				setReason('focus', false)
 				return
 			}

--- a/packages/worker/client/routes/landing-loop-state.ts
+++ b/packages/worker/client/routes/landing-loop-state.ts
@@ -9,6 +9,9 @@ export const landingLoopTeaser = {
 	user: 'What did my favorite bot ship recently on GitHub?',
 } as const
 
+/** Act header plus the first user turn — matches the SSR teaser. */
+export const landingLoopTeaserBeatCount = 2
+
 export type LandingLoopPauseReason =
 	| 'hover'
 	| 'focus'
@@ -77,7 +80,7 @@ export function createLandingLoopPlayer(input: {
 	const reasons = new Set<LandingLoopPauseReason>()
 	let revealedCount = input.reducedMotion
 		? input.beatCount
-		: Math.min(1, input.beatCount)
+		: Math.min(landingLoopTeaserBeatCount, input.beatCount)
 	let ignorePointerPause = false
 
 	function emit() {
@@ -152,7 +155,7 @@ export function createLandingLoopPlayer(input: {
 				return { didAdvance: false, looped: false }
 			}
 			if (revealedCount >= input.beatCount) {
-				revealedCount = Math.min(1, input.beatCount)
+				revealedCount = Math.min(landingLoopTeaserBeatCount, input.beatCount)
 				emit()
 				return { didAdvance: true, looped: true }
 			}

--- a/packages/worker/client/when-window-loaded.node.test.ts
+++ b/packages/worker/client/when-window-loaded.node.test.ts
@@ -1,0 +1,34 @@
+import { expect, test, vi } from 'vitest'
+import { whenWindowLoaded } from './when-window-loaded.ts'
+
+test('whenWindowLoaded runs now if the document is already complete, otherwise waits for load', () => {
+	const onLoad = vi.fn()
+	vi.stubGlobal('document', { readyState: 'complete' })
+	const stopComplete = whenWindowLoaded(onLoad)
+	expect(onLoad).toHaveBeenCalledTimes(1)
+	stopComplete()
+
+	const listeners = new Map<string, () => void>()
+	const addEventListener = vi.fn((type: string, listener: () => void) => {
+		listeners.set(type, listener)
+	})
+	const removeEventListener = vi.fn()
+	vi.stubGlobal('document', { readyState: 'interactive' })
+	vi.stubGlobal('window', { addEventListener, removeEventListener })
+
+	const later = vi.fn()
+	const stop = whenWindowLoaded(later)
+	expect(later).not.toHaveBeenCalled()
+	expect(addEventListener).toHaveBeenCalledWith('load', later, { once: true })
+	listeners.get('load')?.()
+	expect(later).toHaveBeenCalledTimes(1)
+	stop()
+	expect(removeEventListener).toHaveBeenCalledWith('load', later)
+
+	const aborted = vi.fn()
+	const controller = new AbortController()
+	controller.abort()
+	whenWindowLoaded(aborted, controller.signal)
+	expect(aborted).not.toHaveBeenCalled()
+	vi.unstubAllGlobals()
+})

--- a/packages/worker/client/when-window-loaded.ts
+++ b/packages/worker/client/when-window-loaded.ts
@@ -1,0 +1,24 @@
+/**
+ * Run work after the window `load` event so it does not contend with
+ * first paint. Already-complete documents run the callback immediately.
+ */
+export function whenWindowLoaded(
+	onLoad: () => void,
+	signal?: AbortSignal,
+): () => void {
+	if (typeof document === 'undefined' || signal?.aborted) {
+		return () => {}
+	}
+	if (document.readyState === 'complete') {
+		onLoad()
+		return () => {}
+	}
+	window.addEventListener(
+		'load',
+		onLoad,
+		signal ? { once: true, signal } : { once: true },
+	)
+	return () => {
+		window.removeEventListener('load', onLoad)
+	}
+}

--- a/packages/worker/public/styles.css
+++ b/packages/worker/public/styles.css
@@ -1265,7 +1265,7 @@ html.is-settled {
 	text-wrap: pretty;
 }
 
-.landing-loop-line > * {
+.landing-loop-line * {
 	min-width: 0;
 }
 

--- a/packages/worker/public/styles.css
+++ b/packages/worker/public/styles.css
@@ -1211,11 +1211,6 @@ html.is-settled {
 	padding: 1rem 1.05rem;
 }
 
-.landing-loop-chat:focus-visible {
-	outline: 2px solid var(--color-primary-text);
-	outline-offset: -2px;
-}
-
 .landing-loop-act {
 	display: grid;
 	gap: 0.2rem;

--- a/packages/worker/public/styles.css
+++ b/packages/worker/public/styles.css
@@ -1116,18 +1116,185 @@ html.is-settled {
 	font-weight: 650;
 }
 
-.landing-factory-walkthrough {
-	margin: 0.85rem 0 0;
+.landing-loop {
+	margin: clamp(1.75rem, 4vw, 2.5rem) auto 0;
+	max-width: 40rem;
+	text-align: left;
+	background: var(--color-surface);
+	border: 1px solid var(--color-border);
+	border-radius: 16px;
+	overflow: hidden;
 }
 
-.landing-factory-walkthrough a {
-	color: var(--color-primary-text);
+.landing-loop-head,
+.landing-loop-foot {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	gap: 0.8rem;
+	padding: 0.75rem 1.05rem;
+	font-size: 0.75rem;
 	font-weight: 600;
+	letter-spacing: 0.06em;
+	text-transform: uppercase;
+	color: var(--color-text-muted);
+}
+
+.landing-loop-head {
+	border-bottom: 1px solid var(--color-border);
+}
+
+.landing-loop-foot {
+	border-top: 1px solid var(--color-border);
+	justify-content: flex-end;
+	text-transform: none;
+	letter-spacing: 0;
+	font-size: 0.92rem;
+	font-weight: 600;
+}
+
+.landing-loop-status {
+	display: flex;
+	align-items: center;
+	gap: 0.45rem;
+	margin: 0;
+}
+
+.landing-loop-status-dot {
+	width: 0.5rem;
+	height: 0.5rem;
+	border-radius: 50%;
+	background: var(--color-text-muted);
+	box-shadow: 0 0 0 3px
+		color-mix(in oklch, var(--color-text-muted) 18%, transparent);
+}
+
+.landing-loop[data-playing] .landing-loop-status-dot {
+	background: var(--color-primary-text);
+	box-shadow: 0 0 0 3px
+		color-mix(in oklch, var(--color-primary) 22%, transparent);
+}
+
+.landing-loop[data-paused] .landing-loop-status-dot {
+	background: var(--color-text-muted);
+	box-shadow: none;
+}
+
+.landing-loop-toggle {
+	margin: 0;
+	padding: 0;
+	border: 0;
+	background: none;
+	color: var(--color-primary-text);
+	font: inherit;
+	font-size: 0.75rem;
+	font-weight: 700;
+	letter-spacing: 0.06em;
+	text-transform: uppercase;
+	cursor: pointer;
+}
+
+.landing-loop-toggle:hover,
+.landing-loop-toggle:focus-visible {
+	text-decoration: underline;
+}
+
+.landing-loop-chat {
+	display: flex;
+	flex-direction: column;
+	gap: 0.9rem;
+	min-height: 14rem;
+	max-height: min(32rem, 70vh);
+	overflow-x: hidden;
+	overflow-y: auto;
+	overflow-anchor: none;
+	padding: 1rem 1.05rem;
+}
+
+.landing-loop-chat:focus-visible {
+	outline: 2px solid var(--color-primary-text);
+	outline-offset: -2px;
+}
+
+.landing-loop-act {
+	display: grid;
+	gap: 0.2rem;
+}
+
+.landing-loop-kicker {
+	margin: 0;
+	font-size: 0.95rem;
+	font-weight: 600;
+	color: var(--color-primary-text);
+	text-wrap: pretty;
+}
+
+.landing-loop-act h3 {
+	margin: 0;
+	font-size: 1.2rem;
+	font-weight: 720;
+	letter-spacing: -0.02em;
+	color: var(--color-text);
+}
+
+.landing-loop-you {
+	margin: 0;
+}
+
+.landing-loop-you figcaption {
+	margin: 0;
+	font-size: 0.75rem;
+	font-weight: 650;
+	letter-spacing: 0.06em;
+	text-transform: uppercase;
+	color: var(--color-text-muted);
+	text-align: right;
+}
+
+.landing-loop-you blockquote {
+	margin: 0.35rem 0 0 auto;
+	max-width: min(36rem, 100%);
+	padding: 0.5rem 1rem;
+	border: 1px solid
+		color-mix(in oklch, var(--color-primary) 28%, var(--color-border));
+	border-radius: 12px;
+	background: color-mix(
+		in oklch,
+		var(--color-primary) 8%,
+		var(--color-surface)
+	);
+}
+
+.landing-loop-you p {
+	margin: 0;
+	text-wrap: pretty;
+}
+
+.landing-loop-line > * {
+	min-width: 0;
+}
+
+.landing-loop-foot a {
+	color: var(--color-primary-text);
 	text-decoration: none;
 }
 
-.landing-factory-walkthrough a:hover {
+.landing-loop-foot a:hover {
 	text-decoration: underline;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+	.landing-loop-line[data-newest],
+	.landing-loop-act[data-newest] {
+		animation: landing-loop-in 280ms ease-out;
+	}
+
+	@keyframes landing-loop-in {
+		from {
+			opacity: 0;
+			transform: translateY(0.35rem);
+		}
+	}
 }
 
 .landing-honest {
@@ -1462,6 +1629,11 @@ html.is-settled {
 
 	.landing-factory-art {
 		width: min(60%, 300px);
+	}
+
+	.landing-loop-chat {
+		min-height: 12rem;
+		max-height: min(26rem, 65vh);
 	}
 
 	.landing-factory-beats {

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -725,6 +725,24 @@ test('renderAppPage embeds a tabular homepage code-runs ticker', async () => {
 	expect(html).not.toContain('aria-live')
 })
 
+test('renderAppPage embeds the homepage factory-loop conversation teaser', async () => {
+	resetDataCacheForTests()
+	setAuthSessionSecret(testCookieSecret)
+	const env = createTestEnv(createUserTestDb([]))
+	const response = await renderAppPage({
+		request: new Request('https://example.com/'),
+		env,
+	})
+	expect(response.status).toBe(200)
+	const html = await readResponseText(response)
+	expect(html).toContain('class="landing-loop"')
+	expect(html).toContain('Factory loop conversation')
+	expect(html).toContain('What did my favorite bot ship recently on GitHub?')
+	expect(html).toContain('/guides/how-kody-works')
+	expect(html).toContain('Read the walkthrough')
+	expect(html).not.toContain('See the whole loop')
+})
+
 test('signup social buttons are icon-only with accessible names', async () => {
 	resetDataCacheForTests()
 	setAuthSessionSecret(testCookieSecret)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Show how Kody works on the homepage the way kody.exchange shows an agentic conversation: an auto-progressing thread people can pause and inspect, instead of a link away to the walkthrough.

## Summary

- Replaces the factory-section “See the whole loop” link with a conversation player that uses the existing how-kody-works transcript.
- SSR paints the first user turn plus a walkthrough link so the page still works without JavaScript.
- The transcript and tool-call renderer load once the card is near the viewport, so they stay out of the marketing chunk.
- Playback does not wait for Shiki. After `window` `load`, the homepage prefetches the highlighter in the background so tool fences are ready without blocking first paint or the first beats.
- Autoplay starts when the card is on screen. Hover or focus (fine pointers) shows a paused indicator so people can scroll and open tool calls. Opening a tool or scrolling up keeps it paused; Play scrolls to the latest beat and continues.
- `prefers-reduced-motion` shows the full transcript and does not autoplay.

## Testing

- Unit test covers pause/play/loop and the teaser matching the real transcript.
- Near-viewport helper arms immediately when the node is already on screen.
- `whenWindowLoaded` runs immediately for a complete document and otherwise waits for `load`.
- Homepage SSR test asserts the teaser conversation and walkthrough link.
- Landing-loop CSS uses a descendant selector so production `styles.css` stays escape-safe for homepage inlining.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `cea53d58` · **Head:** `f295d921`

**Classification:** composes — no primitives added or changed; this PR wires the existing factory-loop transcript into the homepage.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `app-ui` | surfaces | composes — homepage player, near-viewport arming, post-load Shiki prefetch |

### Change flow

The homepage factory section plays the existing how-kody-works transcript. The loop starts from the transcript chunk; Shiki prefetches after the window finishes loading.

```mermaid
sequenceDiagram
	actor Visitor
	participant appUi as app-ui
	Visitor->>appUi: GET /
	appUi->>appUi: SSR first user turn + walkthrough link
	appUi->>appUi: window load, prefetch Shiki
	appUi->>appUi: card already near, arm transcript load
	appUi->>appUi: auto-advance ask / invoke beats
	Visitor->>appUi: hover, focus, scroll, or open a tool
	appUi->>appUi: pause and show Paused
	Visitor->>appUi: Play
	appUi->>appUi: scroll to latest beat and continue
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-04fe5c14-799f-46f2-8fb4-bfaf4693532e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-04fe5c14-799f-46f2-8fb4-bfaf4693532e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an interactive factory-loop transcript player to the homepage.
  - Transcript content progressively appears with play/pause controls, automatic scrolling, and looping playback.
  - Playback pauses during hover, focus, manual exploration, offscreen viewing, or reduced-motion settings.
  - Added a responsive chat-style presentation with status indicators and accessible interactions.
  - The full interactive transcript is available through the guide.

- **Documentation**
  - Updated the guide to describe the homepage’s pause-on-explore transcript player.

- **Tests**
  - Added coverage for playback, pausing, looping, reduced motion, loading, and homepage rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->