### PR TITLE
Wobble homepage code-runs ticks without skipping or sitting still

### DIFF
--- a/docs/contributing/architecture/usage-metering.md
+++ b/docs/contributing/architecture/usage-metering.md
@@ -331,12 +331,13 @@ Guarantees and rules:
   platform KV pair (or a still D1 sum when KV is empty) and interpolates
   `previous → current` across the 24-hour window. The payload is the window pair
   only — never per-user rows. Interpolation is deterministic from the window so
-  every visitor at a given second sees the same number (`nowMs` is floored to
-  whole seconds before endpoint checks and progress). Official `current` appears
-  at the first whole second on or after `windowEnd`. When the pair has at least
-  one tick per three seconds, a backbone tick lands every three seconds and
-  leftover count is warped into larger steps so the cadence stays frequent with
-  varying amounts; it never passes `current`.
+  every visitor at a given clock time sees the same integer. Official `current`
+  appears at `windowEnd`. Each displayed step is +1: when the pair has at least
+  one tick per second, a tick lands every second at a hashed time so the
+  cadence wobbles instead of marching on the clock, and leftover count rolls
+  through that second without skipping. It never passes `current`. The client
+  schedules the next integer (`msUntilNextCodeRunsCount`) rather than polling
+  once a second; `prefers-reduced-motion` snaps and does not animate.
 - **Fleet visibility** (`/admin/insights`, loader in
   `packages/worker/src/admin/fleet-usage-insights.ts`): bounded SQL over
   `usage_rollups` for the current UTC month — top-10 combined runtime duration

--- a/docs/contributing/architecture/usage-metering.md
+++ b/docs/contributing/architecture/usage-metering.md
@@ -333,11 +333,11 @@ Guarantees and rules:
   only — never per-user rows. Interpolation is deterministic from the window so
   every visitor at a given clock time sees the same integer. Official `current`
   appears at `windowEnd`. Each displayed step is +1: when the pair has at least
-  one tick per second, a tick lands every second at a hashed time so the
-  cadence wobbles instead of marching on the clock, and leftover count rolls
-  through that second without skipping. It never passes `current`. The client
-  schedules the next integer (`msUntilNextCodeRunsCount`) rather than polling
-  once a second; `prefers-reduced-motion` snaps and does not animate.
+  one tick per second, a tick lands every second at a hashed time so the cadence
+  wobbles instead of marching on the clock, and leftover count rolls through
+  that second without skipping. It never passes `current`. The client schedules
+  the next integer (`msUntilNextCodeRunsCount`) rather than polling once a
+  second; `prefers-reduced-motion` snaps and does not animate.
 - **Fleet visibility** (`/admin/insights`, loader in
   `packages/worker/src/admin/fleet-usage-insights.ts`): bounded SQL over
   `usage_rollups` for the current UTC month — top-10 combined runtime duration

--- a/docs/contributing/architecture/usage-metering.md
+++ b/docs/contributing/architecture/usage-metering.md
@@ -333,11 +333,13 @@ Guarantees and rules:
   only — never per-user rows. Interpolation is deterministic from the window so
   every visitor at a given clock time sees the same integer. Official `current`
   appears at `windowEnd`. Each displayed step is +1: when the pair has at least
-  one tick per second, a tick lands every second at a hashed time so the cadence
-  wobbles instead of marching on the clock, and leftover count rolls through
-  that second without skipping. It never passes `current`. The client schedules
-  the next integer (`msUntilNextCodeRunsCount`) rather than polling once a
-  second; `prefers-reduced-motion` snaps and does not animate.
+  one tick per second, that tick lands at a hashed time inside the second so the
+  cadence wobbles instead of marching on the clock. Leftover count (more than
+  one tick in a second) rolls through from the start of that second without
+  skipping. It never passes `current`. The client schedules the next integer
+  (`msUntilNextCodeRunsCount`) rather than polling once a second;
+  `prefers-reduced-motion` snaps and does not animate. A tab that wakes more
+  than sixty integers behind snaps instead of replaying every missed tick.
 - **Fleet visibility** (`/admin/insights`, loader in
   `packages/worker/src/admin/fleet-usage-insights.ts`): bounded SQL over
   `usage_rollups` for the current UTC month — top-10 combined runtime duration

--- a/packages/worker/client/code-runs-ticker.tsx
+++ b/packages/worker/client/code-runs-ticker.tsx
@@ -10,7 +10,8 @@ import {
  * 24-hour delayed fleet execute count. SSR paints the interpolated value;
  * the client advances one integer at a time, scheduled to the next hashed
  * fire so the cadence wobbles. If the tab sleeps and the official count
- * jumps, leftover integers roll through one second. Mono digits plus a
+ * jumps, leftover integers roll through one second unless more than
+ * sixty are owed, in which case the display snaps. Mono digits plus a
  * reserved width from `current` keep the label from shifting as digits
  * change. The line is sized larger than the hero subtitle.
  */
@@ -25,9 +26,16 @@ export function CodeRunsTicker(
 	if (typeof document !== 'undefined' && !prefersReducedMotion) {
 		let timeoutId: ReturnType<typeof setTimeout> | undefined
 		function scheduleNext() {
+			if (handle.signal.aborted) return
 			const official = interpolateCodeRunsCount(handle.props.window, Date.now())
 			if (displayed < official) {
 				const behind = official - displayed
+				if (behind > 60) {
+					displayed = official
+					handle.update()
+					scheduleNext()
+					return
+				}
 				const slotMs = Math.max(16, Math.floor(1000 / behind))
 				timeoutId = setTimeout(() => {
 					displayed += 1

--- a/packages/worker/client/code-runs-ticker.tsx
+++ b/packages/worker/client/code-runs-ticker.tsx
@@ -2,43 +2,66 @@ import { type Handle } from 'remix/ui'
 import {
 	formatCodeRunsCount,
 	interpolateCodeRunsCount,
+	msUntilNextCodeRunsCount,
 	type PublicCodeRunsWindow,
 } from '#universal/code-runs.ts'
 
 /**
  * 24-hour delayed fleet execute count. SSR paints the interpolated value;
- * the client advances it only when the displayed integer changes.
- * Mono digits plus a reserved width from `current` keep the label from
- * shifting as digits change. The line is sized larger than the hero subtitle.
+ * the client advances one integer at a time, scheduled to the next hashed
+ * fire so the cadence wobbles. If the tab sleeps and the official count
+ * jumps, leftover integers roll through one second. Mono digits plus a
+ * reserved width from `current` keep the label from shifting as digits
+ * change. The line is sized larger than the hero subtitle.
  */
 export function CodeRunsTicker(
 	handle: Handle<{ window: PublicCodeRunsWindow }>,
 ) {
-	let nowMs = Date.now()
+	let displayed = interpolateCodeRunsCount(handle.props.window, Date.now())
 	const prefersReducedMotion =
 		typeof matchMedia === 'function' &&
 		matchMedia('(prefers-reduced-motion: reduce)').matches
 
 	if (typeof document !== 'undefined' && !prefersReducedMotion) {
-		const interval = setInterval(() => {
-			const nextMs = Date.now()
-			const previousCount = interpolateCodeRunsCount(handle.props.window, nowMs)
-			const nextCount = interpolateCodeRunsCount(handle.props.window, nextMs)
-			nowMs = nextMs
-			if (nextCount === previousCount) return
-			handle.update()
-		}, 1000)
+		let timeoutId: ReturnType<typeof setTimeout> | undefined
+		function scheduleNext() {
+			const official = interpolateCodeRunsCount(
+				handle.props.window,
+				Date.now(),
+			)
+			if (displayed < official) {
+				const behind = official - displayed
+				const slotMs = Math.max(16, Math.floor(1000 / behind))
+				timeoutId = setTimeout(() => {
+					displayed += 1
+					handle.update()
+					scheduleNext()
+				}, slotMs)
+				return
+			}
+			const delay = msUntilNextCodeRunsCount(handle.props.window, Date.now())
+			if (delay === null) return
+			timeoutId = setTimeout(() => {
+				const nextOfficial = interpolateCodeRunsCount(
+					handle.props.window,
+					Date.now(),
+				)
+				if (displayed < nextOfficial) displayed += 1
+				handle.update()
+				scheduleNext()
+			}, Math.max(16, delay))
+		}
+		scheduleNext()
 		handle.signal.addEventListener(
 			'abort',
 			() => {
-				clearInterval(interval)
+				if (timeoutId !== undefined) clearTimeout(timeoutId)
 			},
 			{ once: true },
 		)
 	}
 
 	return () => {
-		const count = interpolateCodeRunsCount(handle.props.window, nowMs)
 		const reserved = formatCodeRunsCount(handle.props.window.current)
 		return (
 			<p data-rise style={{ '--rise': '1.5' }} class="landing-hero-runs">
@@ -46,7 +69,7 @@ export function CodeRunsTicker(
 					class="landing-hero-runs-count"
 					style={{ '--runs-ch': `${reserved.length}ch` }}
 				>
-					{formatCodeRunsCount(count)}
+					{formatCodeRunsCount(displayed)}
 				</span>
 				<span class="landing-hero-runs-label">code runs</span>
 			</p>

--- a/packages/worker/client/code-runs-ticker.tsx
+++ b/packages/worker/client/code-runs-ticker.tsx
@@ -25,10 +25,7 @@ export function CodeRunsTicker(
 	if (typeof document !== 'undefined' && !prefersReducedMotion) {
 		let timeoutId: ReturnType<typeof setTimeout> | undefined
 		function scheduleNext() {
-			const official = interpolateCodeRunsCount(
-				handle.props.window,
-				Date.now(),
-			)
+			const official = interpolateCodeRunsCount(handle.props.window, Date.now())
 			if (displayed < official) {
 				const behind = official - displayed
 				const slotMs = Math.max(16, Math.floor(1000 / behind))
@@ -41,15 +38,18 @@ export function CodeRunsTicker(
 			}
 			const delay = msUntilNextCodeRunsCount(handle.props.window, Date.now())
 			if (delay === null) return
-			timeoutId = setTimeout(() => {
-				const nextOfficial = interpolateCodeRunsCount(
-					handle.props.window,
-					Date.now(),
-				)
-				if (displayed < nextOfficial) displayed += 1
-				handle.update()
-				scheduleNext()
-			}, Math.max(16, delay))
+			timeoutId = setTimeout(
+				() => {
+					const nextOfficial = interpolateCodeRunsCount(
+						handle.props.window,
+						Date.now(),
+					)
+					if (displayed < nextOfficial) displayed += 1
+					handle.update()
+					scheduleNext()
+				},
+				Math.max(16, delay),
+			)
 		}
 		scheduleNext()
 		handle.signal.addEventListener(

--- a/packages/worker/client/code-runs-ticker.tsx
+++ b/packages/worker/client/code-runs-ticker.tsx
@@ -36,12 +36,18 @@ export function CodeRunsTicker(
 					scheduleNext()
 					return
 				}
-				const slotMs = Math.max(16, Math.floor(1000 / behind))
-				timeoutId = setTimeout(() => {
-					displayed += 1
-					handle.update()
+				displayed += 1
+				handle.update()
+				if (behind === 1) {
 					scheduleNext()
-				}, slotMs)
+					return
+				}
+				timeoutId = setTimeout(
+					() => {
+						scheduleNext()
+					},
+					Math.max(16, Math.floor(1000 / behind)),
+				)
 				return
 			}
 			const delay = msUntilNextCodeRunsCount(handle.props.window, Date.now())

--- a/packages/worker/universal/code-runs.node.test.ts
+++ b/packages/worker/universal/code-runs.node.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from 'vitest'
 import {
 	formatCodeRunsCount,
 	interpolateCodeRunsCount,
+	msUntilNextCodeRunsCount,
 	parsePublicCodeRunsWindow,
 } from './code-runs.ts'
 
@@ -17,7 +18,7 @@ const window = {
 	windowEnd,
 }
 
-test('interpolateCodeRunsCount stays monotonic, bursty, and inside the pair', () => {
+test('interpolateCodeRunsCount stays monotonic, warped, and inside the pair', () => {
 	expect(interpolateCodeRunsCount(window, startMs - 1)).toBe(1000)
 	expect(interpolateCodeRunsCount(window, startMs)).toBe(1000)
 	expect(interpolateCodeRunsCount(window, startMs + 24 * hourMs)).toBe(1240)
@@ -52,45 +53,69 @@ test('interpolateCodeRunsCount stays monotonic, bursty, and inside the pair', ()
 	)
 })
 
-test('interpolateCodeRunsCount advances at least every 3s with mixed step sizes', () => {
+test('interpolateCodeRunsCount wobbles +1 ticks without long idle when the pair is dense', () => {
 	const busy = { ...window, previous: 0, current: 86_400 }
+	const gaps: Array<number> = []
 	let previous = interpolateCodeRunsCount(busy, startMs)
-	let lastAdvanceAt = 0
-	let maxGap = 0
-	let skippedSeconds = 0
-	let multiStepSeconds = 0
-	const stepSizes = new Set<number>()
-	for (let second = 1; second < 86_400; second += 1) {
-		const count = interpolateCodeRunsCount(busy, startMs + second * 1000)
-		const step = count - previous
-		expect(step).toBeGreaterThanOrEqual(0)
+	let at = startMs
+	for (let step = 0; step < 2_400; step += 1) {
+		const wait = msUntilNextCodeRunsCount(busy, at)
+		expect(wait).not.toBeNull()
+		expect(wait!).toBeGreaterThan(0)
+		at += wait!
+		const count = interpolateCodeRunsCount(busy, at)
+		expect(count).toBe(previous + 1)
 		expect(count).toBeLessThan(86_400)
-		if (step === 0) skippedSeconds += 1
-		if (step > 1) multiStepSeconds += 1
-		if (step > 0) {
-			stepSizes.add(step)
-			maxGap = Math.max(maxGap, second - lastAdvanceAt)
-			lastAdvanceAt = second
-		}
+		gaps.push(wait!)
 		previous = count
 	}
-	expect(previous).toBeLessThan(86_400)
 	expect(interpolateCodeRunsCount(busy, startMs + 86_400 * 1000)).toBe(86_400)
-	expect(maxGap).toBeLessThanOrEqual(3)
-	expect(skippedSeconds).toBeGreaterThan(0)
-	expect(multiStepSeconds).toBeGreaterThan(0)
-	expect(stepSizes.size).toBeGreaterThan(1)
+
+	const minGap = Math.min(...gaps)
+	const maxGap = Math.max(...gaps)
+	expect(maxGap).toBeLessThanOrEqual(2_000)
+	expect(minGap).toBeLessThan(800)
+	expect(maxGap).toBeGreaterThan(1_100)
+	expect(new Set(gaps).size).toBeGreaterThan(10)
+
+	let densePrevious = interpolateCodeRunsCount(busy, startMs + 6 * hourMs)
+	for (let offset = 10; offset <= 120_000; offset += 10) {
+		const count = interpolateCodeRunsCount(busy, startMs + 6 * hourMs + offset)
+		expect(count - densePrevious).toBeGreaterThanOrEqual(0)
+		expect(count - densePrevious).toBeLessThanOrEqual(1)
+		densePrevious = count
+	}
 })
 
-test('interpolateCodeRunsCount is stable across milliseconds in the same second', () => {
-	const wide = { ...window, previous: 0, current: 1_000_000_000 }
-	const midSecond = startMs + 6 * hourMs + 100
-	expect(interpolateCodeRunsCount(wide, midSecond)).toBe(
-		interpolateCodeRunsCount(wide, midSecond + 800),
-	)
+test('interpolateCodeRunsCount rolls every extra integer inside a second', () => {
+	const packed = { ...window, previous: 0, current: 86_400 * 5 }
+	const midSecond = startMs + 6 * hourMs
+	const seen = new Set<number>()
+	for (let offset = 0; offset < 1000; offset += 1) {
+		seen.add(interpolateCodeRunsCount(packed, midSecond + offset))
+	}
+	const values = [...seen].sort((left, right) => left - right)
+	expect(values.length).toBeGreaterThan(1)
+	for (let index = 1; index < values.length; index += 1) {
+		expect(values[index]).toBe(values[index - 1]! + 1)
+	}
 })
 
-test('interpolateCodeRunsCount stays one integer through a non-aligned window end', () => {
+test('msUntilNextCodeRunsCount lands on the next integer and then is still', () => {
+	const busy = { ...window, previous: 0, current: 86_400 }
+	const nowMs = startMs + 3 * hourMs + 250
+	const here = interpolateCodeRunsCount(busy, nowMs)
+	const wait = msUntilNextCodeRunsCount(busy, nowMs)
+	expect(wait).not.toBeNull()
+	expect(interpolateCodeRunsCount(busy, nowMs + wait! - 1)).toBe(here)
+	expect(interpolateCodeRunsCount(busy, nowMs + wait!)).toBe(here + 1)
+	expect(msUntilNextCodeRunsCount(busy, startMs + 24 * hourMs)).toBeNull()
+	expect(
+		msUntilNextCodeRunsCount({ ...window, previous: 80, current: 80 }, nowMs),
+	).toBeNull()
+})
+
+test('interpolateCodeRunsCount holds current from the exact window end', () => {
 	const offset = {
 		...window,
 		previous: 171540,
@@ -99,14 +124,8 @@ test('interpolateCodeRunsCount stays one integer through a non-aligned window en
 		windowEnd: '2026-08-23T15:47:07.637Z',
 	}
 	const endMs = Date.parse(offset.windowEnd)
-	const endSecondMs = Math.floor(endMs / 1000) * 1000
-	expect(interpolateCodeRunsCount(offset, endSecondMs + 100)).toBe(
-		interpolateCodeRunsCount(offset, endSecondMs + 900),
-	)
-	expect(interpolateCodeRunsCount(offset, endSecondMs + 100)).toBeLessThan(
-		257940,
-	)
-	expect(interpolateCodeRunsCount(offset, endSecondMs + 1000)).toBe(257940)
+	expect(interpolateCodeRunsCount(offset, endMs - 1)).toBeLessThan(257940)
+	expect(interpolateCodeRunsCount(offset, endMs)).toBe(257940)
 	expect(interpolateCodeRunsCount(offset, endMs + 1000)).toBe(257940)
 })
 

--- a/packages/worker/universal/code-runs.ts
+++ b/packages/worker/universal/code-runs.ts
@@ -1,10 +1,11 @@
 /**
  * Public homepage “code runs” ticker: a 24-hour delayed replay of fleet
- * `execute` event counts. Interpolation is deterministic from the window
- * so every visitor at a given second sees the same number. Ticks land at
- * least every three seconds when the pair has enough count, with hashed
- * leftover bursts so steps vary in size. The count stays monotonic between
- * `previous` and `current`.
+ * `execute` event counts. Interpolation is deterministic from the window so
+ * every visitor at a given clock time sees the same integer. Each displayed
+ * step is +1. When the pair has at least one tick per second, a tick lands
+ * every second at a hashed time so the cadence wobbles instead of marching
+ * on the clock. Extra count rolls through the second without skipping.
+ * The count stays monotonic between `previous` and `current`.
  */
 
 export const publicCodeRunsWindowMs = 24 * 60 * 60 * 1000
@@ -42,6 +43,54 @@ export function interpolateCodeRunsCount(
 	window: PublicCodeRunsWindow,
 	nowMs: number,
 ): number {
+	const bounds = windowBounds(window)
+	if (!bounds) return Math.max(window.current, window.previous)
+	if (nowMs <= bounds.startMs) return bounds.previous
+	if (nowMs >= bounds.endMs) return bounds.current
+	if (bounds.delta === 0) return bounds.previous
+	const ticks = ticksAfterElapsed({
+		elapsedMs: nowMs - bounds.startMs,
+		totalMs: bounds.totalMs,
+		delta: bounds.delta,
+		seed: bounds.seed,
+	})
+	if (ticks >= bounds.delta) return bounds.current - 1
+	return bounds.previous + ticks
+}
+
+export function msUntilNextCodeRunsCount(
+	window: PublicCodeRunsWindow,
+	nowMs: number,
+): number | null {
+	const bounds = windowBounds(window)
+	if (!bounds || bounds.delta === 0) return null
+	if (nowMs >= bounds.endMs) return null
+	const here = interpolateCodeRunsCount(window, nowMs)
+	if (interpolateCodeRunsCount(window, bounds.endMs) <= here) return null
+	let lo = nowMs + 1
+	let hi = bounds.endMs
+	while (lo < hi) {
+		const mid = lo + Math.floor((hi - lo) / 2)
+		if (interpolateCodeRunsCount(window, mid) > here) hi = mid
+		else lo = mid + 1
+	}
+	return lo - nowMs
+}
+
+const coarseSegmentCount = 72
+const fineSegmentCount = 8
+
+type WindowBounds = {
+	previous: number
+	current: number
+	delta: number
+	startMs: number
+	endMs: number
+	totalMs: number
+	seed: number
+}
+
+function windowBounds(window: PublicCodeRunsWindow): WindowBounds | null {
 	const previous = window.previous
 	const current = Math.max(window.current, previous)
 	const startMs = Date.parse(window.windowStart)
@@ -51,28 +100,18 @@ export function interpolateCodeRunsCount(
 		!Number.isFinite(endMs) ||
 		endMs <= startMs
 	) {
-		return current
+		return null
 	}
-	const secondMs = Math.floor(nowMs / 1000) * 1000
-	if (secondMs <= startMs) return previous
-	if (secondMs >= endMs) return current
-	const delta = current - previous
-	if (delta === 0) return previous
-	const ticks = ticksAfterElapsed({
-		elapsedMs: secondMs - startMs,
+	return {
+		previous,
+		current,
+		delta: current - previous,
+		startMs,
+		endMs,
 		totalMs: endMs - startMs,
-		delta,
 		seed: windowSeed(window),
-	})
-	if (ticks >= delta) return current - 1
-	return previous + ticks
+	}
 }
-
-const maxIdleSeconds = 3
-const secondsPerCell = maxIdleSeconds
-const cellMs = maxIdleSeconds * 1000
-const coarseSegmentCount = 72
-const fineSegmentCount = 8
 
 function ticksAfterElapsed(input: {
 	elapsedMs: number
@@ -80,81 +119,75 @@ function ticksAfterElapsed(input: {
 	delta: number
 	seed: number
 }): number {
-	const totalCells = Math.floor(input.totalMs / cellMs)
-	if (totalCells <= 0) {
+	const totalSeconds = Math.floor(input.totalMs / 1000)
+	if (totalSeconds <= 0) {
 		return Math.floor(input.delta * (input.elapsedMs / input.totalMs))
 	}
-	const rawCell = Math.floor(input.elapsedMs / cellMs)
-	if (rawCell >= totalCells) return input.delta
-	const useBackbone = input.delta >= totalCells
-	const extra = useBackbone ? input.delta - totalCells : input.delta
-	const before =
-		extraBeforeCell(rawCell, extra, totalCells, input.seed) +
-		(useBackbone ? rawCell : 0)
-	const inCell =
-		extraBeforeCell(rawCell + 1, extra, totalCells, input.seed) -
-		extraBeforeCell(rawCell, extra, totalCells, input.seed) +
-		(useBackbone ? 1 : 0)
-	const offset = Math.min(
-		Math.floor((input.elapsedMs % cellMs) / 1000),
-		secondsPerCell - 1,
+	const secondIndex = Math.min(
+		Math.floor(input.elapsedMs / 1000),
+		totalSeconds - 1,
 	)
-	const split = splitCellTicks(inCell, input.seed, rawCell)
-	let partial = 0
-	for (let index = 0; index <= offset; index += 1) {
-		partial += split[index] ?? 0
-	}
-	return before + partial
+	const fracMs = input.elapsedMs - secondIndex * 1000
+	const before = officialTicksAtSecond(
+		secondIndex,
+		totalSeconds,
+		input.delta,
+		input.seed,
+	)
+	const after = officialTicksAtSecond(
+		secondIndex + 1,
+		totalSeconds,
+		input.delta,
+		input.seed,
+	)
+	return (
+		before + ticksFiredInSecond(after - before, fracMs, input.seed, secondIndex)
+	)
 }
 
-function extraBeforeCell(
-	cellIndex: number,
+function officialTicksAtSecond(
+	secondIndex: number,
+	totalSeconds: number,
+	delta: number,
+	seed: number,
+): number {
+	if (secondIndex <= 0) return 0
+	if (secondIndex >= totalSeconds) return delta
+	const useBackbone = delta >= totalSeconds
+	const extra = useBackbone ? delta - totalSeconds : delta
+	const extras = extraBeforeSecond(secondIndex, extra, totalSeconds, seed)
+	return extras + (useBackbone ? secondIndex : 0)
+}
+
+function extraBeforeSecond(
+	secondIndex: number,
 	extra: number,
-	totalCells: number,
+	totalSeconds: number,
 	seed: number,
 ): number {
-	if (extra <= 0 || cellIndex <= 0) return 0
-	if (cellIndex >= totalCells) return extra
-	return Math.floor(extra * warpCodeRunsProgress(cellIndex / totalCells, seed))
+	if (extra <= 0 || secondIndex <= 0) return 0
+	if (secondIndex >= totalSeconds) return extra
+	return Math.floor(
+		extra * warpCodeRunsProgress(secondIndex / totalSeconds, seed),
+	)
 }
 
-function splitCellTicks(
-	ticks: number,
+function ticksFiredInSecond(
+	gain: number,
+	fracMs: number,
 	seed: number,
-	cellIndex: number,
-): Array<number> {
-	const split = Array.from({ length: secondsPerCell }, () => 0)
-	if (ticks <= 0) return split
-	split[secondsPerCell - 1] = 1
-	const leftover = ticks - 1
-	if (leftover <= 0) return split
-	let weightPrefix = 0
-	let tickPrefix = 0
-	let total = 0
-	const weights = Array.from({ length: secondsPerCell }, (_, index) => {
-		const weight = cellSecondWeight(seed, cellIndex, index)
-		total += weight
-		return weight
-	})
-	for (let index = 0; index < secondsPerCell; index += 1) {
-		weightPrefix += weights[index] ?? 0
-		const next =
-			index === secondsPerCell - 1
-				? leftover
-				: Math.floor((weightPrefix / total) * leftover)
-		split[index] = (split[index] ?? 0) + (next - tickPrefix)
-		tickPrefix = next
+	secondIndex: number,
+): number {
+	if (gain <= 0) return 0
+	if (gain === 1) {
+		return fracMs >= singleTickFireMs(seed, secondIndex) ? 1 : 0
 	}
-	return split
+	const slot = 1000 / gain
+	return Math.min(gain, Math.floor(fracMs / slot) + 1)
 }
 
-function cellSecondWeight(
-	seed: number,
-	cellIndex: number,
-	index: number,
-): number {
-	const unit = hashUnit(seed, Math.imul(cellIndex + 1, 29) + index + 5)
-	return 0.4 + unit * unit * 4
+function singleTickFireMs(seed: number, secondIndex: number): number {
+	return Math.floor(hashUnit(seed, secondIndex + 11) * 1000)
 }
 
 function windowSeed(window: PublicCodeRunsWindow): number {
@@ -205,12 +238,12 @@ function warpFineProgress(
 
 function coarseWeight(seed: number, index: number): number {
 	const unit = hashUnit(seed, index + 1)
-	return 0.03 + unit * unit * unit * 7
+	return 0.75 + unit * 0.5
 }
 
 function fineWeight(seed: number, coarseIndex: number, index: number): number {
 	const unit = hashUnit(seed, Math.imul(coarseIndex + 1, 17) + index + 3)
-	return 0.2 + unit * unit * 3
+	return 0.65 + unit * 0.7
 }
 
 function hashUnit(seed: number, salt: number): number {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

The homepage code-runs ticker should feel like real events arriving — a little jitter, never a metronome, and never a multi-second pause — without skipping integers or inventing counts past the official pair.

## Summary

- Drop the three-second mixed-step backbone that jumped `+2`…`+7` and could sit idle for 1–3s.
- When the pair has at least one tick per second, land exactly one `+1` each second at a hashed time so gaps wobble (~0–2s) instead of marching on the clock.
- Extra count (above one per second) rolls through that second without skipping.
- Client schedules the next integer via `msUntilNextCodeRunsCount`. One owed tick applies immediately (a late timer no longer locks a 1 Hz lag). More than one leftover rolls through about a second; more than sixty snaps. `prefers-reduced-motion` still snaps.
- Official `current` appears at exact `windowEnd`. Same `nowMs` still yields the same integer for every visitor.

## Testing

- `npx vitest run packages/worker/universal/code-runs.node.test.ts` (pass)
- `npx vitest run packages/worker/src/app/ssr-render.node.test.ts -t 'tabular homepage code-runs'` (pass)
- Local production-window sample: 40 consecutive `+1` ticks, gaps 93–1652ms (mean 993ms)
- Preview `https://kody-pr-1667.kody-a99.workers.dev/` with a seeded 24h pair (`100000 → 186400`): Playwright polled `.landing-hero-runs-count` every 80ms for 12s and saw **12 consecutive +1 steps**, gaps 165–1566ms (165, 1404, 409, 1566, 906, 412, 1401, 907, 1483, 165, 1319, 1071)
- `npm run preview:manual-test -- --pr 1667 --request 'GET /code-runs.json' --check /`
- GitHub Validate on `69d9893f` was green; `401ecb40` is the Bugbot catch-up fix (one owed tick applies immediately)

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `235a4e5a` · **Head:** `401ecb40`

**Classification:** extends — homepage ticker interpolation and client scheduling change so visitors see wobbling `+1` ticks instead of mixed-size 3s-backbone steps.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | extends — interpolator and ticker client cadence |

### Change flow

Homepage SSR and the ticker client both read the same official pair; this PR changes when the displayed integer advances.

```mermaid
sequenceDiagram
	actor Visitor
	participant appUi as app-ui
	participant kv as kv-storage
	Visitor->>appUi: GET /
	appUi->>kv: read public-code-runs:v1
	appUi-->>Visitor: SSR count at nowMs
	Note over appUi: hashed +1 fire times, no skipped integers
	Visitor->>appUi: client schedule msUntilNextCodeRunsCount
	appUi-->>Visitor: +1 at hashed offset; one owed tick is immediate
```

### Before / after

```text
before: floor(nowMs) → 3s backbone + leftover bursts (steps +1…+7, idle ≤3s)
after:  nowMs → +1 at hashed second offset; extras divide the second evenly
```

### Invariants

Anonymous fleet `execute` SUM exception is unchanged: homepage GET still does not write `public-code-runs:v1`, and the public payload still has no user ids.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c8c17c2f-384e-4efd-ad81-13cc125f46ab?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c8c17c2f-384e-4efd-ad81-13cc125f46ab&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The homepage code-runs ticker now updates in smooth, single-count increments with more natural timing.
  * Ticker updates use precise scheduling, catch up when delayed, and stop cleanly when no longer needed.
  * Reduced-motion settings now display stable count values without animated transitions.

* **Documentation**
  * Updated ticker documentation to explain the revised timing, progression, rollover, and catch-up behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->