### PR TITLE
Show memory one-liners in homepage search text, not a JSON copy

### DIFF
--- a/packages/worker/client/routes/interactive-guide-transcript.node.test.ts
+++ b/packages/worker/client/routes/interactive-guide-transcript.node.test.ts
@@ -1,0 +1,52 @@
+import { expect, test } from 'vitest'
+import { howKodyWorksTranscriptActs } from './how-kody-works-transcript.ts'
+import {
+	executeTextReturn,
+	searchTextReturn,
+} from './interactive-guide-transcript.ts'
+
+const sampleMemory = {
+	id: 'mem-watch-login',
+	subject: 'Favorite bot',
+	summary: 'kody-bot is the favorite bot to watch.',
+}
+
+test('search and execute text returns memories as one-liners, not structured JSON', () => {
+	const search = searchTextReturn({
+		conversationId: 'conv-1',
+		body: '# Search results\n\n1. **secret** `githubAccessToken`',
+		memories: [sampleMemory],
+	})
+	expect(search).toContain('## Relevant memories')
+	expect(search).toContain(
+		'- **Favorite bot** — kody-bot is the favorite bot to watch.',
+	)
+	expect(search).not.toContain('"surfaced"')
+	expect(search).not.toContain(sampleMemory.id)
+
+	const execute = executeTextReturn({
+		conversationId: 'conv-1',
+		value: [{ title: 'kody-bot/lantern v1.4.0' }],
+		memories: [sampleMemory],
+	})
+	expect(execute).toContain('## Relevant memories')
+	expect(execute).toContain(
+		'- **Favorite bot** — kody-bot is the favorite bot to watch.',
+	)
+	expect(execute).not.toContain('"surfaced"')
+	expect(execute).not.toContain(sampleMemory.id)
+})
+
+test('homepage factory-loop tool results do not dump memory structured content', () => {
+	const toolResults = howKodyWorksTranscriptActs.flatMap((act) =>
+		act.lines.flatMap((line) =>
+			line.role === 'tools' ? line.tools.map((tool) => tool.result) : [],
+		),
+	)
+	expect(
+		toolResults.some((result) => result.includes('## Relevant memories')),
+	).toBe(true)
+	expect(toolResults.every((result) => !result.includes('"surfaced"'))).toBe(
+		true,
+	)
+})

--- a/packages/worker/client/routes/interactive-guide-transcript.ts
+++ b/packages/worker/client/routes/interactive-guide-transcript.ts
@@ -85,18 +85,6 @@ function relevantMemoriesMarkdown(memories: Array<TranscriptMemory>) {
 	].join('\n')
 }
 
-function relevantMemoriesStructured(memories: Array<TranscriptMemory>) {
-	return jsonInput({
-		memories: {
-			surfaced: memories.map((memory) => ({
-				id: memory.id,
-				subject: memory.subject,
-				summary: memory.summary,
-			})),
-		},
-	})
-}
-
 export function searchTextReturn(input: {
 	conversationId: string
 	body: string
@@ -104,12 +92,7 @@ export function searchTextReturn(input: {
 }) {
 	const parts = [conversationIdReturn(input.conversationId), '', input.body]
 	if (input.memories && input.memories.length > 0) {
-		parts.push(
-			'',
-			relevantMemoriesMarkdown(input.memories),
-			'',
-			relevantMemoriesStructured(input.memories),
-		)
+		parts.push('', relevantMemoriesMarkdown(input.memories))
 	}
 	return parts.join('\n')
 }
@@ -125,12 +108,7 @@ export function executeTextReturn(input: {
 		jsonInput(input.value),
 	]
 	if (input.memories && input.memories.length > 0) {
-		parts.push(
-			'',
-			relevantMemoriesMarkdown(input.memories),
-			'',
-			relevantMemoriesStructured(input.memories),
-		)
+		parts.push('', relevantMemoriesMarkdown(input.memories))
 	}
 	return parts.join('\n')
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

The homepage factory-loop (and How Kody Works) was showing a search/execute result that appended a JSON `memories.surfaced` object after the Relevant memories markdown. That is not what the tool text looks like.

## Summary

- Search and execute return compact `## Relevant memories` subject — summary one-liners in the **text** content.
- Memory ids live in MCP **structured content**, not a second JSON dump in the visible result.
- Homepage / guide transcript helpers now match that text shape.

## Testing

- `vitest run --project node-unit packages/worker/client/routes/interactive-guide-transcript.node.test.ts packages/worker/client/routes/landing-loop-player.node.test.ts` (3 passed)

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `ba4b27f9` · **Head:** `a095326a`

**Classification:** composes — demo transcript text only; search/execute contracts are unchanged.

### Primitives touched

| Primitive | Group    | Impact                                                                 |
| --------- | -------- | ---------------------------------------------------------------------- |
| `app-ui`  | surfaces | composes — homepage/guide tool-result copy matches real search text    |

### Change flow

The landing loop still plays the factory conversation. Search/execute tool cards now show memory one-liners the way MCP text does.

```mermaid
sequenceDiagram
	actor visitor as visitor
	participant appUi as app-ui
	participant mcpServer as mcp-server
	visitor->>appUi: open homepage factory loop
	appUi-->>visitor: search/execute text with Relevant memories one-liners
	Note over mcpServer: structuredContent still holds memory ids
	mcpServer-->>appUi: text blocks only, no JSON copy of the same lines
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1eb915b2-7557-4672-98ac-efa185d98465?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1eb915b2-7557-4672-98ac-efa185d98465&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

