### PR TITLE
Keep the homepage loop at a reserved height

### DIFF
--- a/packages/worker/public/styles.css
+++ b/packages/worker/public/styles.css
@@ -1203,8 +1203,7 @@ html.is-settled {
 	display: flex;
 	flex-direction: column;
 	gap: 0.9rem;
-	min-height: 14rem;
-	max-height: min(32rem, 70vh);
+	height: min(32rem, 70vh);
 	overflow-x: hidden;
 	overflow-y: auto;
 	overflow-anchor: none;
@@ -1627,8 +1626,7 @@ html.is-settled {
 	}
 
 	.landing-loop-chat {
-		min-height: 12rem;
-		max-height: min(26rem, 65vh);
+		height: min(26rem, 65vh);
 	}
 
 	.landing-factory-beats {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Keep the homepage factory-loop card from growing as beats appear. The conversation pane should already be the height it uses for the rest of the playback.

## Summary

- `.landing-loop-chat` no longer starts at `14rem` / `12rem` and expands.
- Desktop and narrow layouts pin the pane to the existing scrolling viewport (`min(32rem, 70vh)` and `min(26rem, 65vh)`).
- New beats fill that reserved height, then scroll, instead of stretching the factory card.

## Testing

- `vitest` `inline-stylesheet.node.test.ts` still passes (no `<>&` in the CSS).
- Headed capture on the live homepage: teaser pane is `224px` before and `512px` after applying the reserved height.

![Homepage loop chat growing from a short teaser](https://cursor.com/artifacts/c/art-54d3644a-f771-4ef6-b65f-2094e978c91a)
![Homepage loop chat reserved at final viewport height](https://cursor.com/artifacts/c/art-f95c44d7-d4f9-4ecc-9c9b-9923885f1325)

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `ba4b27f9` · **Head:** `448222c2`

**Classification:** composes — no primitives added or changed; this PR only reserves height on the existing homepage loop pane.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `app-ui` | surfaces | composes — homepage loop CSS in `packages/worker/public/styles.css` (unmatched by the classifier roots; still the Remix homepage surface) |

### Change flow

The factory-loop chat pane keeps one reserved height for the whole playback instead of growing from a short teaser.

```mermaid
sequenceDiagram
	actor Visitor
	participant appUi as app-ui
	Visitor->>appUi: GET /
	appUi->>appUi: SSR teaser in reserved chat height
	appUi->>appUi: reveal beats inside the same pane
	appUi->>appUi: scroll when content exceeds the reserved height
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-04fe5c14-799f-46f2-8fb4-bfaf4693532e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-04fe5c14-799f-46f2-8fb4-bfaf4693532e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the chat panel’s height behavior for a more consistent responsive layout.
  * Improved sizing on mobile and default screen layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->