### PR TITLE
Wobble leftover code-runs ticks inside a busy second

### DIFF
--- a/docs/contributing/architecture/usage-metering.md
+++ b/docs/contributing/architecture/usage-metering.md
@@ -335,8 +335,9 @@ Guarantees and rules:
   appears at `windowEnd`. Each displayed step is +1: when the pair has at least
   one tick per second, that tick lands at a hashed time inside the second so the
   cadence wobbles instead of marching on the clock. Leftover count (more than
-  one tick in a second) rolls through from the start of that second without
-  skipping. It never passes `current`. The client schedules the next integer
+  one tick in a second) rolls through that second without skipping, with hashed
+  gaps between those ticks so a busy second does not march on even slots. It
+  never passes `current`. The client schedules the next integer
   (`msUntilNextCodeRunsCount`) rather than polling once a second;
   `prefers-reduced-motion` snaps and does not animate. A tab that wakes more
   than sixty integers behind snaps instead of replaying every missed tick.

--- a/packages/worker/universal/code-runs.node.test.ts
+++ b/packages/worker/universal/code-runs.node.test.ts
@@ -96,6 +96,7 @@ test('interpolateCodeRunsCount rolls every extra integer inside a second', () =>
 	for (let offset = 0; offset < 1000; offset += 1) {
 		const count = interpolateCodeRunsCount(packed, midSecond + offset)
 		seen.add(count)
+		expect(count).toBeGreaterThanOrEqual(previous)
 		if (count > previous) {
 			expect(count).toBe(previous + 1)
 			offsets.push(offset)

--- a/packages/worker/universal/code-runs.node.test.ts
+++ b/packages/worker/universal/code-runs.node.test.ts
@@ -91,14 +91,28 @@ test('interpolateCodeRunsCount rolls every extra integer inside a second', () =>
 	const packed = { ...window, previous: 0, current: 86_400 * 5 }
 	const midSecond = startMs + 6 * hourMs
 	const seen = new Set<number>()
+	const gaps: Array<number> = []
+	let previous = interpolateCodeRunsCount(packed, midSecond)
+	let lastAt = 0
 	for (let offset = 0; offset < 1000; offset += 1) {
-		seen.add(interpolateCodeRunsCount(packed, midSecond + offset))
+		const count = interpolateCodeRunsCount(packed, midSecond + offset)
+		seen.add(count)
+		if (count > previous) {
+			expect(count).toBe(previous + 1)
+			gaps.push(offset - lastAt)
+			lastAt = offset
+			previous = count
+		}
 	}
 	const values = [...seen].sort((left, right) => left - right)
 	expect(values.length).toBeGreaterThan(1)
 	for (let index = 1; index < values.length; index += 1) {
 		expect(values[index]).toBe(values[index - 1]! + 1)
 	}
+	expect(gaps.length).toBeGreaterThan(1)
+	expect(new Set(gaps).size).toBeGreaterThan(1)
+	const even = 1000 / (gaps.length + 1)
+	expect(gaps.some((gap) => Math.abs(gap - even) > 30)).toBe(true)
 })
 
 test('msUntilNextCodeRunsCount lands on the next integer and then is still', () => {

--- a/packages/worker/universal/code-runs.node.test.ts
+++ b/packages/worker/universal/code-runs.node.test.ts
@@ -111,6 +111,16 @@ test('interpolateCodeRunsCount rolls every extra integer inside a second', () =>
 	expect(new Set(gaps).size).toBeGreaterThan(1)
 	const even = 1000 / offsets.length
 	expect(gaps.some((gap) => Math.abs(gap - even) > 30)).toBe(true)
+
+	const dense = { ...window, previous: 0, current: 86_400 * 50 }
+	const denseStart = startMs + 6 * hourMs
+	let densePrevious = interpolateCodeRunsCount(dense, denseStart - 1)
+	for (let offset = 0; offset < 30_000; offset += 1) {
+		const count = interpolateCodeRunsCount(dense, denseStart + offset)
+		expect(count - densePrevious).toBeGreaterThanOrEqual(0)
+		expect(count - densePrevious).toBeLessThanOrEqual(1)
+		densePrevious = count
+	}
 })
 
 test('msUntilNextCodeRunsCount lands on the next integer and then is still', () => {

--- a/packages/worker/universal/code-runs.node.test.ts
+++ b/packages/worker/universal/code-runs.node.test.ts
@@ -91,27 +91,25 @@ test('interpolateCodeRunsCount rolls every extra integer inside a second', () =>
 	const packed = { ...window, previous: 0, current: 86_400 * 5 }
 	const midSecond = startMs + 6 * hourMs
 	const seen = new Set<number>()
-	const gaps: Array<number> = []
-	let previous = interpolateCodeRunsCount(packed, midSecond)
-	let lastAt = 0
+	const offsets: Array<number> = []
+	let previous = interpolateCodeRunsCount(packed, midSecond - 1)
 	for (let offset = 0; offset < 1000; offset += 1) {
 		const count = interpolateCodeRunsCount(packed, midSecond + offset)
 		seen.add(count)
 		if (count > previous) {
 			expect(count).toBe(previous + 1)
-			gaps.push(offset - lastAt)
-			lastAt = offset
+			offsets.push(offset)
 			previous = count
 		}
 	}
 	const values = [...seen].sort((left, right) => left - right)
-	expect(values.length).toBeGreaterThan(1)
+	expect(offsets.length).toBeGreaterThanOrEqual(3)
 	for (let index = 1; index < values.length; index += 1) {
 		expect(values[index]).toBe(values[index - 1]! + 1)
 	}
-	expect(gaps.length).toBeGreaterThan(1)
+	const gaps = offsets.slice(1).map((offset, index) => offset - offsets[index]!)
 	expect(new Set(gaps).size).toBeGreaterThan(1)
-	const even = 1000 / (gaps.length + 1)
+	const even = 1000 / offsets.length
 	expect(gaps.some((gap) => Math.abs(gap - even) > 30)).toBe(true)
 })
 

--- a/packages/worker/universal/code-runs.ts
+++ b/packages/worker/universal/code-runs.ts
@@ -211,6 +211,8 @@ function busySecondFireMs(
 		fires[index] = Math.min(999, lead + Math.floor((prefix / total) * span))
 		prefix += weights[index] ?? 0
 	}
+	// A second cannot hold more than 1000 distinct millisecond fires; extras
+	// share the last millisecond and the client rolls through them.
 	const minGap = Math.max(1, Math.min(16, Math.floor(1000 / gain) - 1))
 	for (let index = 1; index < gain; index += 1) {
 		const floorAt = (fires[index - 1] ?? 0) + minGap

--- a/packages/worker/universal/code-runs.ts
+++ b/packages/worker/universal/code-runs.ts
@@ -4,7 +4,8 @@
  * every visitor at a given clock time sees the same integer. Each displayed
  * step is +1. When the pair has at least one tick per second, a tick lands
  * every second at a hashed time so the cadence wobbles instead of marching
- * on the clock. Extra count rolls through the second without skipping.
+ * on the clock. Extra count rolls through the second without skipping, with
+ * hashed gaps between those leftover ticks so a busy second does not march.
  * The count stays monotonic between `previous` and `current`.
  */
 
@@ -182,8 +183,51 @@ function ticksFiredInSecond(
 	if (gain === 1) {
 		return fracMs >= singleTickFireMs(seed, secondIndex) ? 1 : 0
 	}
-	const slot = 1000 / gain
-	return Math.min(gain, Math.floor(fracMs / slot) + 1)
+	const fires = busySecondFireMs(gain, seed, secondIndex)
+	let fired = 0
+	for (const fireAt of fires) {
+		if (fracMs < fireAt) break
+		fired += 1
+	}
+	return fired
+}
+
+function busySecondFireMs(
+	gain: number,
+	seed: number,
+	secondIndex: number,
+): Array<number> {
+	const weights = Array.from({ length: gain }, (_, index) =>
+		busySecondGapWeight(seed, secondIndex, index),
+	)
+	let total = 0
+	for (const weight of weights) total += weight
+	const maxLead = Math.min(180, Math.max(0, Math.floor(1000 / gain / 2)))
+	const lead = Math.floor(hashUnit(seed, secondIndex + 41) * (maxLead + 1))
+	const span = 1000 - lead
+	const fires = Array.from({ length: gain }, () => 0)
+	let prefix = 0
+	for (let index = 0; index < gain; index += 1) {
+		fires[index] = Math.min(999, lead + Math.floor((prefix / total) * span))
+		prefix += weights[index] ?? 0
+	}
+	const minGap = Math.max(1, Math.min(16, Math.floor(1000 / gain) - 1))
+	for (let index = 1; index < gain; index += 1) {
+		const floorAt = (fires[index - 1] ?? 0) + minGap
+		if ((fires[index] ?? 0) < floorAt) {
+			fires[index] = Math.min(999, floorAt)
+		}
+	}
+	return fires
+}
+
+function busySecondGapWeight(
+	seed: number,
+	secondIndex: number,
+	index: number,
+): number {
+	const unit = hashUnit(seed, Math.imul(secondIndex + 1, 31) + index + 19)
+	return 0.2 + unit * unit * 2.3
 }
 
 function singleTickFireMs(seed: number, secondIndex: number): number {

--- a/packages/worker/universal/code-runs.ts
+++ b/packages/worker/universal/code-runs.ts
@@ -197,29 +197,29 @@ function busySecondFireMs(
 	seed: number,
 	secondIndex: number,
 ): Array<number> {
-	const weights = Array.from({ length: gain }, (_, index) =>
+	const unique = Math.min(gain, 1000)
+	const minGap =
+		unique <= 1 ? 1 : Math.max(1, Math.min(16, Math.floor(999 / (unique - 1))))
+	const weights = Array.from({ length: unique }, (_, index) =>
 		busySecondGapWeight(seed, secondIndex, index),
 	)
 	let total = 0
 	for (const weight of weights) total += weight
-	const maxLead = Math.min(180, Math.max(0, Math.floor(1000 / gain / 2)))
+	const maxLead = Math.min(180, Math.max(0, 999 - (unique - 1) * minGap))
 	const lead = Math.floor(hashUnit(seed, secondIndex + 41) * (maxLead + 1))
-	const span = 1000 - lead
-	const fires = Array.from({ length: gain }, () => 0)
+	const span = Math.max(0, 999 - lead)
+	const fires = Array.from({ length: unique }, () => 0)
 	let prefix = 0
-	for (let index = 0; index < gain; index += 1) {
-		fires[index] = Math.min(999, lead + Math.floor((prefix / total) * span))
+	for (let index = 0; index < unique; index += 1) {
+		const desired = lead + Math.floor((prefix / total) * span)
+		const earliest = index === 0 ? 0 : (fires[index - 1] ?? 0) + minGap
+		const latest = 999 - (unique - 1 - index) * minGap
+		fires[index] = Math.min(latest, Math.max(earliest, desired))
 		prefix += weights[index] ?? 0
 	}
-	// A second cannot hold more than 1000 distinct millisecond fires; extras
-	// share the last millisecond and the client rolls through them.
-	const minGap = Math.max(1, Math.min(16, Math.floor(1000 / gain) - 1))
-	for (let index = 1; index < gain; index += 1) {
-		const floorAt = (fires[index - 1] ?? 0) + minGap
-		if ((fires[index] ?? 0) < floorAt) {
-			fires[index] = Math.min(999, floorAt)
-		}
-	}
+	// More than 1000 ticks cannot get unique milliseconds; extras share 999
+	// and the client rolls through them.
+	while (fires.length < gain) fires.push(999)
 	return fires
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

When a delayed window has more than one tick in a second, those leftover `+1` steps should wobble like the rest of the ticker — not land on even 200ms slots.

## Summary

- Busy seconds (`gain >= 2`) no longer divide 1000ms evenly.
- Hashed weights space leftover ticks inside the second (short lead, uneven gaps, still every integer).
- Fire times stay unique for up to 1000 ticks in a second by reserving tail room, so a late cascade cannot pin several ticks on `999ms` and skip integers.
- Single-tick seconds are unchanged (hashed fire time).
- More than 1000 ticks in one second cannot get unique milliseconds; extras share `999` and the client rolls through them.

## Testing

- `npx vitest run packages/worker/universal/code-runs.node.test.ts` (includes a 50× window scanned every ms for 30s: steps only `0` or `1`)
- `npx vitest run packages/worker/src/app/ssr-render.node.test.ts -t 'tabular homepage code-runs'`
- `npm run preview:manual-test -- --pr 1671 --request 'GET /code-runs.json' --check /`
- Preview seeded with a busy pair (`100000 → 532000`). Playwright polled `.landing-hero-runs-count` every 40ms for 8s: **31 consecutive +1 steps**, 21 distinct gaps, **41–675ms** (`209,669` → `209,700`)

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `d4582614` · **Head:** `ea6bb446`

**Classification:** extends — interpolator spacing for leftover ticks in a busy second changes from even slots to hashed gaps.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | extends — busy-second leftover cadence |

### Change flow

Homepage interpolation still reads the official pair; this PR only changes when leftover integers fire inside a second that has more than one tick.

```mermaid
sequenceDiagram
	actor Visitor
	participant appUi as app-ui
	participant kv as kv-storage
	Visitor->>appUi: GET /
	appUi->>kv: read public-code-runs:v1
	appUi-->>Visitor: SSR count at nowMs
	Note over appUi: hashed leftover gaps; unique fires through 1000 ticks
	Visitor->>appUi: client schedule msUntilNextCodeRunsCount
	appUi-->>Visitor: next integer at hashed intra-second gap
```

### Before / after

```text
before: gain >= 2 → ticks at 0, 1000/G, 2*1000/G, …
after:  gain >= 2 → hashed lead + uneven unique gaps, still +1 through every integer
```

### Invariants

Anonymous fleet `execute` SUM exception is unchanged. Homepage GET still does not write `public-code-runs:v1`.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c8c17c2f-384e-4efd-ad81-13cc125f46ab?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c8c17c2f-384e-4efd-ad81-13cc125f46ab&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Updated the homepage code-runs ticker to display multiple increments per second with more natural, varied timing.
  * Preserved sequential count increases and ensured the displayed total never exceeds the current count.
  * Improved behavior during periods of high activity with smoother update distribution, reduced uniform spacing, and more consistent handling of rapid successive increments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->