### PR TITLE
Filter post-OAuth package suggestions to the connected provider

### DIFF
--- a/docs/guides/integration-bootstrap.md
+++ b/docs/guides/integration-bootstrap.md
@@ -121,8 +121,8 @@ If those conditions are not met, stop and fix the integration first.
      integration record itself.
    - If the user just finished `/connect/oauth`, read `nextSteps` from the
      connect success payload/UI first: it already includes same-provider
-     trusted-first community helpers suggestions (listing name, kody id, or
-     tags must mention the connected provider) and a create-helpers prompt.
+     trusted-first community helpers suggestions (listing name, kody id, or tags
+     must mention the connected provider) and a create-helpers prompt.
    - `search({ entity: "<provider>:integration" })` may already surface a small
      same-provider package suggestion set (user packages first, else
      trusted-first community listings). Use those when present.

--- a/docs/guides/integration-bootstrap.md
+++ b/docs/guides/integration-bootstrap.md
@@ -120,8 +120,9 @@ If those conditions are not met, stop and fix the integration first.
      agent-facing surface is a helpers package (or package app), not the
      integration record itself.
    - If the user just finished `/connect/oauth`, read `nextSteps` from the
-     connect success payload/UI first: it already includes trusted-first
-     community helpers suggestions and a create-helpers prompt.
+     connect success payload/UI first: it already includes same-provider
+     trusted-first community helpers suggestions (listing name, kody id, or
+     tags must mention the connected provider) and a create-helpers prompt.
    - `search({ entity: "<provider>:integration" })` may already surface a small
      same-provider package suggestion set (user packages first, else
      trusted-first community listings). Use those when present.

--- a/docs/guides/oauth.md
+++ b/docs/guides/oauth.md
@@ -223,10 +223,10 @@ The `/connect/oauth` success response (and success UI) includes `nextSteps`:
 
 - clear guidance that the integration stores credentials, while a helpers
   package is the durable agent-facing surface
-- up to three community package suggestions that mention the connected
-  provider in their listing name, kody id, or tags (trusted listings ranked
-  first), plus fork prompts / listing links. Listings that only mention the
-  provider in README or description prose are omitted
+- up to three community package suggestions that mention the connected provider
+  in their listing name, kody id, or tags (trusted listings ranked first), plus
+  fork prompts / listing links. Listings that only mention the provider in
+  README or description prose are omitted
 - a create-helpers CTA/prompt when no suitable listing exists (and as a fallback
   when suggestions do not fit)
 

--- a/docs/guides/oauth.md
+++ b/docs/guides/oauth.md
@@ -223,8 +223,10 @@ The `/connect/oauth` success response (and success UI) includes `nextSteps`:
 
 - clear guidance that the integration stores credentials, while a helpers
   package is the durable agent-facing surface
-- up to three community package suggestions for the provider, with trusted
-  listings ranked first, plus fork prompts / listing links
+- up to three community package suggestions that mention the connected
+  provider in their listing name, kody id, or tags (trusted listings ranked
+  first), plus fork prompts / listing links. Listings that only mention the
+  provider in README or description prose are omitted
 - a create-helpers CTA/prompt when no suitable listing exists (and as a fallback
   when suggestions do not fit)
 

--- a/docs/use/search.md
+++ b/docs/use/search.md
@@ -129,8 +129,9 @@ servers), capability detail reports the **related operation count**. Use
 
 Integration entity detail may include a small set of **related package
 suggestions** for the same provider (the user's packages first; otherwise
-trusted-first community listings, capped). Ranked query results stay lean and do
-not run community lookup or expand those suggestions.
+trusted-first community listings whose name, kody id, or tags mention that
+provider, capped). Ranked query results stay lean and do not run community
+lookup or expand those suggestions.
 
 Package entity detail is a slim index: summary, export subpaths with one-line
 purposes, job and retriever names, and the README `Intent` section. Structured

--- a/packages/worker/src/app/connect-oauth-next-steps.node.test.ts
+++ b/packages/worker/src/app/connect-oauth-next-steps.node.test.ts
@@ -7,6 +7,7 @@ import {
 	buildConnectOauthNextSteps,
 	buildConnectOauthNextStepsGuidance,
 	buildConnectOauthPackageSuggestion,
+	communityListingUsesProvider,
 	connectOauthCommunitySearchCandidateLimit,
 	connectOauthPackageSuggestionLimit,
 	loadConnectOauthNextSteps,
@@ -57,6 +58,19 @@ function listing(
 		...overrides,
 		kodyId,
 		name,
+	}
+}
+
+function githubIntegration() {
+	return {
+		name: 'github',
+		tokenUrl: 'https://github.com/login/oauth/access_token',
+		apiBaseUrl: 'https://api.github.com',
+		requiredHosts: ['api.github.com'],
+		authorization: {
+			authorizeUrl: 'https://github.com/login/oauth/authorize',
+			scopes: ['repo'],
+		},
 	}
 }
 
@@ -178,6 +192,135 @@ test('buildConnectOauthNextSteps ranks trusted-first, caps suggestions, and vari
 	)
 })
 
+test('post-OAuth suggestions keep only listings that use the connected provider', () => {
+	expect(
+		communityListingUsesProvider(
+			{
+				kodyId: 'github',
+				name: '@kody/github',
+				tags: ['github', 'oauth'],
+			},
+			'github',
+		),
+	).toBe(true)
+	expect(
+		communityListingUsesProvider(
+			{
+				kodyId: 'cursor',
+				name: '@kody/cursor',
+				tags: ['cursor', 'cloud-agents'],
+			},
+			'github',
+		),
+	).toBe(false)
+	expect(
+		communityListingUsesProvider(
+			{
+				kodyId: 'morning-briefing',
+				name: '@kody/morning-briefing',
+				tags: ['morning', 'calendar', 'weather'],
+			},
+			'google',
+		),
+	).toBe(false)
+	expect(
+		communityListingUsesProvider(
+			{
+				kodyId: 'cal-com',
+				name: '@kody/cal-com',
+				tags: ['cal-com', 'calendar', 'oauth'],
+			},
+			'google',
+		),
+	).toBe(false)
+
+	const nextSteps = buildConnectOauthNextSteps({
+		integrationName: 'github',
+		providerName: 'github',
+		baseUrl: 'https://example.com',
+		listings: [
+			listing({
+				id: 'trusted-cursor',
+				name: 'cursor',
+				trusted: true,
+				description: 'Cursor API SDK for cloud agents and repositories.',
+				tags: ['cursor', 'cloud-agents', 'api'],
+			}),
+			listing({
+				id: 'raycast-pouch',
+				name: 'raycast-kodys-pouch',
+				trusted: false,
+				description: 'Your Kody Skills and Tools, one command away.',
+				tags: ['raycast', 'pouch'],
+			}),
+			listing({
+				id: 'morning-briefing',
+				name: 'morning-briefing',
+				trusted: false,
+				description: 'Daily briefing from calendar and weather.',
+				tags: ['morning', 'calendar', 'weather'],
+			}),
+			listing({
+				id: 'github-helpers',
+				name: 'github',
+				trusted: false,
+				description: 'Call GitHub REST through saved GitHub OAuth.',
+				tags: ['github', 'api', 'oauth'],
+			}),
+			listing({
+				id: 'github-untrusted',
+				name: 'github-extra',
+				trusted: false,
+				tags: ['github'],
+			}),
+		],
+	})
+
+	expect(nextSteps.suggestions.map((entry) => entry.listingId)).toEqual([
+		'github-helpers',
+		'github-untrusted',
+	])
+	expect(nextSteps.guidance).toBe(
+		buildConnectOauthNextStepsGuidance({
+			integrationName: 'github',
+			suggestionCount: 2,
+			trustedSuggestionCount: 0,
+		}),
+	)
+
+	const googleNextSteps = buildConnectOauthNextSteps({
+		integrationName: 'google-business',
+		providerName: 'google',
+		baseUrl: 'https://example.com',
+		listings: [
+			listing({
+				id: 'morning-briefing',
+				name: 'morning-briefing',
+				trusted: true,
+				description: 'Composable daily briefing from calendar and weather.',
+				tags: ['morning', 'briefing', 'calendar'],
+			}),
+			listing({
+				id: 'cal-com',
+				name: 'cal-com',
+				trusted: false,
+				description: 'Cal.com booking pages and event types.',
+				tags: ['cal-com', 'calendar', 'oauth'],
+			}),
+			listing({
+				id: 'google-helpers',
+				name: 'google',
+				trusted: false,
+				description: 'Call Gmail and Calendar through saved Google OAuth.',
+				tags: ['google', 'gmail', 'oauth'],
+			}),
+		],
+	})
+	expect(googleNextSteps.suggestions.map((entry) => entry.listingId)).toEqual([
+		'google-helpers',
+	])
+})
+
 test('loadConnectOauthNextSteps searches with bounded limit and fails open', async () => {
 	mockModule.searchCommunityListings.mockResolvedValueOnce([
 		listing({
@@ -198,6 +341,7 @@ test('loadConnectOauthNextSteps searches with bounded limit and fails open', asy
 		integrationName: 'github',
 		providerQuery: 'GitHub',
 		baseUrl: 'https://example.com',
+		integration: githubIntegration(),
 	})
 
 	expect(mockModule.searchCommunityListings).toHaveBeenCalledWith({
@@ -205,6 +349,7 @@ test('loadConnectOauthNextSteps searches with bounded limit and fails open', asy
 		query: 'GitHub',
 		limit: connectOauthCommunitySearchCandidateLimit,
 		trustedFirst: true,
+		resultFilter: expect.any(Function),
 	})
 	expect(nextSteps.suggestions.map((entry) => entry.listingId)).toEqual([
 		'trusted',
@@ -217,6 +362,7 @@ test('loadConnectOauthNextSteps searches with bounded limit and fails open', asy
 		env,
 		integrationName: 'github',
 		baseUrl: 'https://example.com',
+		integration: githubIntegration(),
 	})
 	expect(failedOpen.suggestions).toEqual([])
 	expect(failedOpen.guidance).toBe(
@@ -236,4 +382,82 @@ test('loadConnectOauthNextSteps searches with bounded limit and fails open', asy
 			query: 'github',
 		}),
 	)
+})
+
+test('loadConnectOauthNextSteps resolves the stable provider and drops unrelated listings', async () => {
+	const googleCandidates = [
+		listing({
+			id: 'morning-briefing',
+			name: 'morning-briefing',
+			trusted: true,
+			tags: ['morning', 'calendar'],
+		}),
+		listing({
+			id: 'cal-com',
+			name: 'cal-com',
+			trusted: false,
+			tags: ['cal-com', 'calendar', 'oauth'],
+		}),
+		listing({
+			id: 'google-helpers',
+			name: 'google',
+			trusted: false,
+			tags: ['google', 'gmail', 'oauth'],
+		}),
+	]
+	mockModule.searchCommunityListings.mockImplementationOnce(
+		async (input: {
+			query: string
+			resultFilter?: (entry: ReturnType<typeof listing>) => boolean
+		}) => {
+			expect(input.query).toBe('google')
+			return googleCandidates.filter((entry) =>
+				input.resultFilter ? input.resultFilter(entry) : true,
+			)
+		},
+	)
+
+	const env = { APP_DB: {} } as Env
+	const googleBusiness = await loadConnectOauthNextSteps({
+		env,
+		integrationName: 'google-business',
+		baseUrl: 'https://example.com',
+		integration: {
+			name: 'google-business',
+			tokenUrl: 'https://oauth2.googleapis.com/token',
+			apiBaseUrl: 'https://www.googleapis.com/calendar/v3',
+			requiredHosts: ['www.googleapis.com'],
+			authorization: {
+				authorizeUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
+				scopes: ['https://www.googleapis.com/auth/calendar'],
+			},
+		},
+	})
+	expect(googleBusiness.suggestions.map((entry) => entry.listingId)).toEqual([
+		'google-helpers',
+	])
+
+	mockModule.searchCommunityListings.mockResolvedValueOnce([
+		listing({
+			id: 'trusted-cursor',
+			name: 'cursor',
+			trusted: true,
+			tags: ['cursor'],
+		}),
+		listing({
+			id: 'github-helpers',
+			name: 'github',
+			trusted: false,
+			tags: ['github', 'oauth'],
+		}),
+	])
+	const githubNextSteps = await loadConnectOauthNextSteps({
+		env,
+		integrationName: 'github',
+		baseUrl: 'https://example.com',
+		integration: githubIntegration(),
+	})
+	expect(githubNextSteps.suggestions.map((entry) => entry.listingId)).toEqual([
+		'github-helpers',
+	])
 })

--- a/packages/worker/src/app/connect-oauth-next-steps.ts
+++ b/packages/worker/src/app/connect-oauth-next-steps.ts
@@ -2,6 +2,19 @@ import { buildForkPrompt } from '#app/community-public.ts'
 import { searchCommunityListings } from '#worker/community/service.ts'
 import { type CommunityListingWithAggregates } from '#worker/community/types.ts'
 import { buildCommunityPublicUrl } from '#mcp/capabilities/community/shared.ts'
+import {
+	packageIdentityMentionsProvider,
+	resolveIntegrationProviderName,
+} from '#mcp/tools/integration-package-suggestions.ts'
+
+type ConnectOauthSuggestionProvider = Parameters<
+	typeof resolveIntegrationProviderName
+>[0]
+
+type CommunityListingProviderIdentity = Pick<
+	CommunityListingWithAggregates,
+	'kodyId' | 'name' | 'tags'
+>
 
 export const connectOauthPackageSuggestionLimit = 3
 export const connectOauthCommunitySearchCandidateLimit = 12
@@ -66,6 +79,26 @@ export function buildConnectOauthNextStepsGuidance(input: {
 	return `${base} Community listings below may help, but none are trusted yet — review carefully before forking, or create a thin helpers package.`
 }
 
+/**
+ * Same-provider gate used by MCP integration detail: a listing is related
+ * only when its kody id, name, or tags mention the connected provider.
+ * Description/README prose is ignored so a trusted Cursor SDK does not
+ * surface after a GitHub connect.
+ */
+export function communityListingUsesProvider(
+	listing: CommunityListingProviderIdentity,
+	providerName: string,
+): boolean {
+	return packageIdentityMentionsProvider(
+		{
+			kodyId: listing.kodyId,
+			name: listing.name,
+			tags: listing.tags,
+		},
+		providerName,
+	)
+}
+
 export function buildConnectOauthPackageSuggestion(input: {
 	listing: Pick<
 		CommunityListingWithAggregates,
@@ -93,10 +126,15 @@ export function buildConnectOauthPackageSuggestion(input: {
 
 export function buildConnectOauthNextSteps(input: {
 	integrationName: string
+	providerName?: string
 	baseUrl: string
 	listings: ReadonlyArray<CommunityListingWithAggregates>
 }): ConnectOauthNextSteps {
-	const ranked = rankTrustedFirstCommunityListings(input.listings).slice(
+	const providerName = input.providerName ?? input.integrationName
+	const related = input.listings.filter((listing) =>
+		communityListingUsesProvider(listing, providerName),
+	)
+	const ranked = rankTrustedFirstCommunityListings(related).slice(
 		0,
 		connectOauthPackageSuggestionLimit,
 	)
@@ -126,14 +164,21 @@ export function buildConnectOauthNextSteps(input: {
 /**
  * Bounded community search for post-connect suggestions. Fails open to an empty
  * suggestion list so OAuth connect never blocks on marketplace availability.
+ * Search is scoped to the resolved provider and filtered to listings that
+ * actually mention that provider in identity fields.
  */
 export async function loadConnectOauthNextSteps(input: {
 	env: Env
 	integrationName: string
 	baseUrl: string
+	integration: ConnectOauthSuggestionProvider
 	providerQuery?: string
 }): Promise<ConnectOauthNextSteps> {
-	const query = (input.providerQuery ?? input.integrationName).trim()
+	const providerName = resolveIntegrationProviderName({
+		...input.integration,
+		name: input.integration.name || input.integrationName,
+	})
+	const query = (input.providerQuery ?? providerName).trim()
 	let listings: Array<CommunityListingWithAggregates> = []
 	if (query) {
 		try {
@@ -142,6 +187,8 @@ export async function loadConnectOauthNextSteps(input: {
 				query,
 				limit: connectOauthCommunitySearchCandidateLimit,
 				trustedFirst: true,
+				resultFilter: (listing) =>
+					communityListingUsesProvider(listing, providerName),
 			})
 		} catch (error) {
 			console.error(
@@ -157,6 +204,7 @@ export async function loadConnectOauthNextSteps(input: {
 	}
 	return buildConnectOauthNextSteps({
 		integrationName: input.integrationName,
+		providerName,
 		baseUrl: input.baseUrl,
 		listings,
 	})

--- a/packages/worker/src/app/handlers/account-secrets.node.test.ts
+++ b/packages/worker/src/app/handlers/account-secrets.node.test.ts
@@ -1523,6 +1523,35 @@ test('connect oauth persists usePkce for confidential + PKCE providers like Canv
 	mockModule.searchCommunityListings.mockClear()
 	mockModule.searchCommunityListings.mockResolvedValueOnce([
 		{
+			id: 'unrelated-cursor',
+			ownerUserId: 'owner',
+			packageId: 'pkg-cursor',
+			sourceId: 'src-cursor',
+			kodyId: 'cursor',
+			name: '@kody/cursor',
+			description: 'Cursor API SDK for cloud agents.',
+			tags: ['cursor', 'cloud-agents'],
+			searchText: null,
+			readmeContent: null,
+			license: 'MIT',
+			pinnedCommit: 'aaa',
+			iconCommit: 'aaa',
+			status: 'active',
+			trustedCommit: 'aaa',
+			trustedAt: '2026-01-01T00:00:00.000Z',
+			trusted: true,
+			featuredAt: null,
+			featured: false,
+			createdAt: '2026-01-01T00:00:00.000Z',
+			updatedAt: '2026-01-01T00:00:00.000Z',
+			publishedAt: '2026-01-01T00:00:00.000Z',
+			averageStars: 5,
+			ratingCount: 1,
+			averageAdaptationEffort: 1,
+			forkCount: 9,
+			starCount: 2,
+		},
+		{
 			id: 'canva-untrusted',
 			ownerUserId: 'owner',
 			packageId: 'pkg',
@@ -1646,6 +1675,7 @@ test('connect oauth persists usePkce for confidential + PKCE providers like Canv
 		query: 'canva',
 		limit: 12,
 		trustedFirst: true,
+		resultFilter: expect.any(Function),
 	})
 	expect(mockModule.upsertIntegration).toHaveBeenCalledWith(
 		expect.objectContaining({

--- a/packages/worker/src/app/handlers/account-secrets.ts
+++ b/packages/worker/src/app/handlers/account-secrets.ts
@@ -526,11 +526,22 @@ async function handleConnectOauthAction(input: {
 	const nextSteps = await loadConnectOauthNextSteps({
 		env: input.env,
 		integrationName,
-		providerQuery: provider,
 		baseUrl: getAppBaseUrl({
 			env: input.env,
 			requestUrl: input.request.url,
 		}),
+		integration: {
+			name: integrationName,
+			tokenUrl,
+			apiBaseUrl: apiBaseUrl ?? null,
+			requiredHosts: allowedHosts,
+			authorization: authorizeUrl
+				? {
+						authorizeUrl,
+						scopes,
+					}
+				: null,
+		},
 	})
 
 	await emitConnectOauthAuthSucceeded({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

After connecting an OAuth integration, the success page should only recommend community packages that actually use that provider — not trusted-but-unrelated listings that happen to mention the provider in README prose.

## Summary

- Reproduced on live `community_search`: a GitHub connect ranked `@kody/cursor` (trusted) and Raycast above GitHub helpers; a Google connect ranked `@kody/morning-briefing` and Cal.com beside `@kody/google`.
- Post-connect `nextSteps` now resolves the stable provider from integration endpoints and keeps listings whose **name, kody id, or tags** mention that provider — the same identity gate MCP integration detail already uses.
- Trusted-first ranking still applies, but only after the provider filter, so a trusted Cursor SDK cannot fill the three-slot cap on a GitHub connect.
- Docs for `/connect/oauth` next steps, integration bootstrap, and search entity detail describe the same-provider rule.

## Testing

- `npx vitest run --project node-unit` on `connect-oauth-next-steps`, `account-secrets`, and `integration-package-suggestions` (20 passed).
- Live production `community_search` for `github`, `google`, and `discord` used as the before/after fixture in the new unit tests.
- Formatter wrap on the OAuth docs after the first Static check.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `db76bc78` · **Head:** `789a35df`

**Classification:** extends — the OAuth success `nextSteps` contract on `app-ui` now drops listings that do not mention the connected provider.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `app-ui` | surfaces | extends — post-connect suggestions filter to the resolved provider |

### Change flow

After token persist, connect success searches community listings for the resolved provider and keeps only identity matches before the trusted-first cap.

```mermaid
sequenceDiagram
	actor User
	participant appUi as app-ui
	participant communityListings as community-listings
	User->>appUi: finish /connect/oauth
	appUi->>appUi: resolve provider from token/API hosts
	appUi->>communityListings: searchCommunityListings(query, resultFilter)
	Note over communityListings: keep listings whose name, kody id, or tags mention the provider
	communityListings-->>appUi: same-provider listings
	appUi-->>User: nextSteps.suggestions (trusted-first, cap 3)
```

### Before / after

```
GitHub connect suggestions
before: @kody/cursor (trusted), @kody/github, @cameronpak/raycast-kodys-pouch
after:  @kody/github, @kentcdodds/github
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0f373f32-0f50-488f-a33e-2c271cd94ceb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0f373f32-0f50-488f-a33e-2c271cd94ceb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * OAuth connection suggestions now show only trusted-first community listings that clearly match the connected provider by name, identifier, or tags.
  * Provider matching is applied consistently across OAuth success, integration details, and community search results.
  * Unrelated listings are excluded, while existing suggestion limits and ranked-result behavior remain unchanged.

* **Documentation**
  * Updated integration, OAuth, and search guidance to describe provider-filtered community suggestions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->