### PR TITLE
Give community package OG logos a white well

### DIFF
--- a/packages/worker/src/community/og-image.node.test.ts
+++ b/packages/worker/src/community/og-image.node.test.ts
@@ -1,7 +1,9 @@
 import { bytesToBase64 } from '@kody-internal/shared/base64.ts'
 import { expect, test } from 'vitest'
+import { colors } from '#universal/styles/tokens.ts'
+import { type SatoriChild, type SatoriElement } from '#worker/og/render.ts'
 import { renderCommunityIconFallbackPng } from './community-icon.ts'
-import { renderCommunityOgImage } from './og-image.ts'
+import { createCommunityOgMarkup, renderCommunityOgImage } from './og-image.ts'
 
 const PNG_MAGIC = [0x89, 0x50, 0x4e, 0x47] as const
 
@@ -15,6 +17,31 @@ function expectPngBytes(png: Uint8Array) {
 async function sampleIconDataUri(name: string) {
 	const png = await renderCommunityIconFallbackPng(name)
 	return `data:image/png;base64,${bytesToBase64(png)}`
+}
+
+function walkSatori(
+	node: SatoriChild | Array<SatoriChild> | undefined,
+	visit: (element: SatoriElement) => void,
+) {
+	if (node == null) return
+	if (typeof node === 'string') return
+	if (Array.isArray(node)) {
+		for (const child of node) walkSatori(child, visit)
+		return
+	}
+	visit(node)
+	walkSatori(node.props.children, visit)
+}
+
+function findPackageIconWell(markup: SatoriElement) {
+	const wells: Array<SatoriElement> = []
+	walkSatori(markup, (element) => {
+		if (element.props.style?.backgroundColor === colors.logoWell) {
+			wells.push(element)
+		}
+	})
+	expect(wells).toHaveLength(1)
+	return wells[0]!
 }
 
 test('renderCommunityOgImage returns valid PNG bytes with and without ratings', async () => {
@@ -32,7 +59,7 @@ test('renderCommunityOgImage returns valid PNG bytes with and without ratings', 
 	})
 	expectPngBytes(withRatings)
 
-	const withoutRatings = await renderCommunityOgImage({
+	const withoutRatingsInput = {
 		name: '@kody/new-package',
 		description: 'summarize your inbox every morning',
 		ownerUsername: 'jane',
@@ -41,6 +68,18 @@ test('renderCommunityOgImage returns valid PNG bytes with and without ratings', 
 		forkCount: 2,
 		starCount: 1,
 		iconDataUri: await sampleIconDataUri('@kody/new-package'),
-	})
+	}
+	const withoutRatings = await renderCommunityOgImage(withoutRatingsInput)
 	expectPngBytes(withoutRatings)
+
+	for (const theme of ['dark', 'light'] as const) {
+		const well = findPackageIconWell(
+			createCommunityOgMarkup({ ...withoutRatingsInput, theme }),
+		)
+		expect(well.props.style).toMatchObject({
+			backgroundColor: colors.logoWell,
+			overflow: 'hidden',
+		})
+		expect(well.props.style?.backgroundColor).toBe('#ffffff')
+	}
 })

--- a/packages/worker/src/community/og-image.ts
+++ b/packages/worker/src/community/og-image.ts
@@ -1,3 +1,4 @@
+import { colors } from '#universal/styles/tokens.ts'
 import {
 	getOgPalette,
 	OG_DEFAULT_THEME,
@@ -24,6 +25,8 @@ const DESCRIPTION_MAX_HEIGHT = Math.round(
 const PACKAGE_ICON_SIZE = 96
 /** Matches `--radius-lg` (0.75rem) at OG canvas scale (~1.5× UI). */
 const PACKAGE_ICON_RADIUS = 18
+/** Matches `getLogoWellCss` border at OG canvas scale (~1.5× UI). */
+const PACKAGE_ICON_WELL_BORDER = 2
 
 /**
  * Amber for filled star icons, per theme. The dark value is 2.6:1 on the pale
@@ -129,17 +132,36 @@ function createPackageIdentityRow(input: CommunityOgImageInput): SatoriElement {
 			},
 			children: [
 				{
-					type: 'img',
+					type: 'div',
 					props: {
-						src: input.iconDataUri,
-						width: PACKAGE_ICON_SIZE,
-						height: PACKAGE_ICON_SIZE,
+						// Same white plate as `CommunityListingIcon` / `getLogoWellCss`
+						// so transparent third-party marks stay readable on the dark card.
 						style: {
+							display: 'flex',
+							alignItems: 'center',
+							justifyContent: 'center',
 							width: PACKAGE_ICON_SIZE,
 							height: PACKAGE_ICON_SIZE,
 							borderRadius: PACKAGE_ICON_RADIUS,
 							marginRight: 24,
-							objectFit: 'contain',
+							backgroundColor: colors.logoWell,
+							borderWidth: PACKAGE_ICON_WELL_BORDER,
+							borderStyle: 'solid',
+							borderColor: palette.border,
+							overflow: 'hidden',
+						},
+						children: {
+							type: 'img',
+							props: {
+								src: input.iconDataUri,
+								width: PACKAGE_ICON_SIZE,
+								height: PACKAGE_ICON_SIZE,
+								style: {
+									width: PACKAGE_ICON_SIZE,
+									height: PACKAGE_ICON_SIZE,
+									objectFit: 'contain',
+								},
+							},
 						},
 					},
 				},
@@ -184,7 +206,9 @@ function createPackageIdentityRow(input: CommunityOgImageInput): SatoriElement {
 	}
 }
 
-function createOgMarkup(input: CommunityOgImageInput): SatoriElement {
+export function createCommunityOgMarkup(
+	input: CommunityOgImageInput,
+): SatoriElement {
 	const palette = getOgPalette(input.theme)
 	const description = truncateOgText(input.description, DESCRIPTION_MAX_LENGTH)
 	const starRow = createStarRow(input)
@@ -279,5 +303,7 @@ export async function renderCommunityOgImage(
 	input: CommunityOgImageInput & { assets?: OgAssetsFetcher },
 ): Promise<Uint8Array<ArrayBuffer>> {
 	await ensureRenderPipelineReady({ assets: input.assets })
-	return renderOgImage(createOgMarkup(input), { assets: input.assets })
+	return renderOgImage(createCommunityOgMarkup(input), {
+		assets: input.assets,
+	})
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Transparent community package marks were sitting directly on the dark OG card, so logos like AWS and Zendesk disappeared into the graphite pattern. Give those icons the same solid white plate the listing UI already uses.

## Summary

- Wrap the package icon in a rounded white well (`colors.logoWell`) with the listing-icon border treatment.
- Keep the well white in both dark and light OG themes.
- Assert the well is present and `#ffffff` on both themes.

![Community package OG card with the logo on a solid white well](https://cursor.com/artifacts/c/art-6651640b-304a-4b18-9923-5802f2bcfb1a)

## Testing

- `npx vitest run --project node-unit packages/worker/src/community/og-image.node.test.ts`
- Rendered a transparent orange mark through `renderCommunityOgImage` and confirmed the white plate behind it.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `00f36f00` · **Head:** `dceaa915`

**Classification:** composes — no primitives added or changed; this PR sits community package OG icons on the existing listing logo well.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `community-listings` | assistant | composes — OG cards reuse `colors.logoWell` |

### Change flow

Social crawlers still hit the listing OG route; this PR only wraps the package icon in the existing white well before satori paints the PNG.

```mermaid
sequenceDiagram
	actor Crawler
	participant communityListings as community-listings
	Crawler->>communityListings: GET /community/:listingId/og.png
	communityListings-->>Crawler: PNG with icon on colors.logoWell
```

### Before / after

| Before | After |
| --- | --- |
| Icon `<img>` sits on the dark card | Icon sits in a `#ffffff` well (`colors.logoWell`) |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bb52bc0a-5efa-4f07-81a9-b1e98b1dcb6c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bb52bc0a-5efa-4f07-81a9-b1e98b1dcb6c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

