### PR TITLE
Snap homepage code-runs when a tab wakes up

### DIFF
--- a/docs/contributing/architecture/usage-metering.md
+++ b/docs/contributing/architecture/usage-metering.md
@@ -341,8 +341,8 @@ Guarantees and rules:
   (`msUntilNextCodeRunsCount`) rather than polling once a second;
   `prefers-reduced-motion` snaps and does not animate. A frozen tab (rAF gap,
   hidden, or a late timeout) snaps to the official count instead of rolling
-  through every missed integer. Live leftover ticks in a busy second still
-  step +1.
+  through every missed integer. Live leftover ticks in a busy second still step
+  +1.
 - **Fleet visibility** (`/admin/insights`, loader in
   `packages/worker/src/admin/fleet-usage-insights.ts`): bounded SQL over
   `usage_rollups` for the current UTC month — top-10 combined runtime duration

--- a/docs/contributing/architecture/usage-metering.md
+++ b/docs/contributing/architecture/usage-metering.md
@@ -339,8 +339,10 @@ Guarantees and rules:
   gaps between those ticks so a busy second does not march on even slots. It
   never passes `current`. The client schedules the next integer
   (`msUntilNextCodeRunsCount`) rather than polling once a second;
-  `prefers-reduced-motion` snaps and does not animate. A tab that wakes more
-  than sixty integers behind snaps instead of replaying every missed tick.
+  `prefers-reduced-motion` snaps and does not animate. A frozen tab (rAF gap,
+  hidden, or a late timeout) snaps to the official count instead of rolling
+  through every missed integer. Live leftover ticks in a busy second still
+  step +1.
 - **Fleet visibility** (`/admin/insights`, loader in
   `packages/worker/src/admin/fleet-usage-insights.ts`): bounded SQL over
   `usage_rollups` for the current UTC month — top-10 combined runtime duration

--- a/packages/worker/client/code-runs-ticker.tsx
+++ b/packages/worker/client/code-runs-ticker.tsx
@@ -1,75 +1,133 @@
 import { type Handle } from 'remix/ui'
 import {
+	codeRunsCatchUpSnapAfterMs,
 	formatCodeRunsCount,
 	interpolateCodeRunsCount,
 	msUntilNextCodeRunsCount,
+	nextDisplayedCodeRunsCount,
 	type PublicCodeRunsWindow,
 } from '#universal/code-runs.ts'
 
 /**
  * 24-hour delayed fleet execute count. SSR paints the interpolated value;
  * the client advances one integer at a time, scheduled to the next hashed
- * fire so the cadence wobbles. If the tab sleeps and the official count
- * jumps, leftover integers roll through one second unless more than
- * sixty are owed, in which case the display snaps. Mono digits plus a
- * reserved width from `current` keep the label from shifting as digits
- * change. The line is sized larger than the hero subtitle.
+ * fire so the cadence wobbles. A frozen tab (rAF gap, hidden, or a late
+ * timeout) snaps to the official count instead of rolling through every
+ * missed integer. Live leftover ticks in a busy second still step +1.
+ * Mono digits plus a reserved width from `current` keep the label from
+ * shifting as digits change. The line is sized larger than the hero subtitle.
  */
 export function CodeRunsTicker(
 	handle: Handle<{ window: PublicCodeRunsWindow }>,
 ) {
 	let displayed = interpolateCodeRunsCount(handle.props.window, Date.now())
+	let lastDisplayAt = Date.now()
 	const prefersReducedMotion =
 		typeof matchMedia === 'function' &&
 		matchMedia('(prefers-reduced-motion: reduce)').matches
 
 	if (typeof document !== 'undefined' && !prefersReducedMotion) {
 		let timeoutId: ReturnType<typeof setTimeout> | undefined
+		let rafId: number | undefined
+		let lastFrameAt = performance.now()
+
+		function officialAt(now: number) {
+			return interpolateCodeRunsCount(handle.props.window, now)
+		}
+
+		function clearTimer() {
+			if (timeoutId === undefined) return
+			clearTimeout(timeoutId)
+			timeoutId = undefined
+		}
+
+		function show(count: number, now: number) {
+			if (count === displayed) return
+			displayed = count
+			lastDisplayAt = now
+			handle.update()
+		}
+
+		function snapToOfficial(now = Date.now()) {
+			show(officialAt(now), now)
+		}
+
 		function scheduleNext() {
 			if (handle.signal.aborted) return
-			const official = interpolateCodeRunsCount(handle.props.window, Date.now())
+			clearTimer()
+			if (document.visibilityState === 'hidden') return
+			const now = Date.now()
+			const official = officialAt(now)
 			if (displayed < official) {
-				const behind = official - displayed
-				if (behind > 60) {
-					displayed = official
-					handle.update()
-					scheduleNext()
+				const next = nextDisplayedCodeRunsCount({
+					displayed,
+					official,
+					elapsedMsSinceDisplay: now - lastDisplayAt,
+				})
+				show(next, now)
+				if (next < official) {
+					const behind = official - next
+					timeoutId = setTimeout(
+						() => {
+							scheduleNext()
+						},
+						Math.max(16, Math.floor(1000 / behind)),
+					)
 					return
 				}
-				displayed += 1
-				handle.update()
-				if (behind === 1) {
-					scheduleNext()
-					return
-				}
-				timeoutId = setTimeout(
-					() => {
-						scheduleNext()
-					},
-					Math.max(16, Math.floor(1000 / behind)),
-				)
-				return
 			}
 			const delay = msUntilNextCodeRunsCount(handle.props.window, Date.now())
 			if (delay === null) return
 			timeoutId = setTimeout(
 				() => {
-					const nextOfficial = interpolateCodeRunsCount(
-						handle.props.window,
-						Date.now(),
-					)
-					if (displayed < nextOfficial) displayed += 1
-					handle.update()
 					scheduleNext()
 				},
 				Math.max(16, delay),
 			)
 		}
+
+		function onFrame(timestamp: number) {
+			if (handle.signal.aborted) return
+			const gap = timestamp - lastFrameAt
+			lastFrameAt = timestamp
+			if (gap >= codeRunsCatchUpSnapAfterMs) {
+				snapToOfficial()
+				scheduleNext()
+			}
+			rafId = requestAnimationFrame(onFrame)
+		}
+
+		document.addEventListener(
+			'visibilitychange',
+			() => {
+				if (document.visibilityState === 'hidden') {
+					clearTimer()
+					snapToOfficial()
+					return
+				}
+				lastFrameAt = performance.now()
+				snapToOfficial()
+				scheduleNext()
+			},
+			{ signal: handle.signal },
+		)
+		window.addEventListener(
+			'pageshow',
+			(event) => {
+				if (!event.persisted) return
+				lastFrameAt = performance.now()
+				snapToOfficial()
+				scheduleNext()
+			},
+			{ signal: handle.signal },
+		)
 		scheduleNext()
+		rafId = requestAnimationFrame(onFrame)
 		handle.signal.addEventListener(
 			'abort',
 			() => {
-				if (timeoutId !== undefined) clearTimeout(timeoutId)
+				clearTimer()
+				if (rafId !== undefined) cancelAnimationFrame(rafId)
 			},
 			{ once: true },
 		)

--- a/packages/worker/universal/code-runs.node.test.ts
+++ b/packages/worker/universal/code-runs.node.test.ts
@@ -1,8 +1,10 @@
 import { expect, test } from 'vitest'
 import {
+	codeRunsCatchUpSnapAfterMs,
 	formatCodeRunsCount,
 	interpolateCodeRunsCount,
 	msUntilNextCodeRunsCount,
+	nextDisplayedCodeRunsCount,
 	parsePublicCodeRunsWindow,
 } from './code-runs.ts'
 
@@ -179,4 +181,49 @@ test('parsePublicCodeRunsWindow accepts a valid pair and rejects junk', () => {
 test('formatCodeRunsCount uses grouping so reserved width stays stable', () => {
 	expect(formatCodeRunsCount(128447)).toBe('128,447')
 	expect(formatCodeRunsCount(0)).toBe('0')
+})
+
+test('nextDisplayedCodeRunsCount snaps after a freeze and steps while live', () => {
+	expect(
+		nextDisplayedCodeRunsCount({
+			displayed: 100,
+			official: 100,
+			elapsedMsSinceDisplay: 16,
+		}),
+	).toBe(100)
+	expect(
+		nextDisplayedCodeRunsCount({
+			displayed: 100,
+			official: 101,
+			elapsedMsSinceDisplay: 16,
+		}),
+	).toBe(101)
+	expect(
+		nextDisplayedCodeRunsCount({
+			displayed: 100,
+			official: 108,
+			elapsedMsSinceDisplay: 40,
+		}),
+	).toBe(101)
+	expect(
+		nextDisplayedCodeRunsCount({
+			displayed: 100,
+			official: 108,
+			elapsedMsSinceDisplay: codeRunsCatchUpSnapAfterMs,
+		}),
+	).toBe(108)
+	expect(
+		nextDisplayedCodeRunsCount({
+			displayed: 100,
+			official: 102,
+			elapsedMsSinceDisplay: 8_000,
+		}),
+	).toBe(102)
+	expect(
+		nextDisplayedCodeRunsCount({
+			displayed: 100,
+			official: 161,
+			elapsedMsSinceDisplay: 16,
+		}),
+	).toBe(161)
 })

--- a/packages/worker/universal/code-runs.ts
+++ b/packages/worker/universal/code-runs.ts
@@ -6,7 +6,8 @@
  * every second at a hashed time so the cadence wobbles instead of marching
  * on the clock. Extra count rolls through the second without skipping, with
  * hashed gaps between those leftover ticks so a busy second does not march.
- * The count stays monotonic between `previous` and `current`.
+ * The count stays monotonic between `previous` and `current`. A frozen
+ * client snaps to the official integer instead of replaying missed steps.
  */
 
 export const publicCodeRunsWindowMs = 24 * 60 * 60 * 1000
@@ -76,6 +77,30 @@ export function msUntilNextCodeRunsCount(
 		else lo = mid + 1
 	}
 	return lo - nowMs
+}
+
+export const codeRunsCatchUpSnapAfterMs = 1000
+export const codeRunsCatchUpSnapBehind = 60
+
+/**
+ * Advance the on-screen ticker by one integer while the tab is live.
+ * After a freeze (or when more than sixty integers are already owed),
+ * jump to the official count instead of replaying the missed steps.
+ */
+export function nextDisplayedCodeRunsCount(input: {
+	displayed: number
+	official: number
+	elapsedMsSinceDisplay: number
+}): number {
+	if (input.official <= input.displayed) return input.displayed
+	const behind = input.official - input.displayed
+	if (
+		input.elapsedMsSinceDisplay >= codeRunsCatchUpSnapAfterMs ||
+		behind > codeRunsCatchUpSnapBehind
+	) {
+		return input.official
+	}
+	return input.displayed + 1
 }
 
 const coarseSegmentCount = 72
@@ -218,7 +243,7 @@ function busySecondFireMs(
 		prefix += weights[index] ?? 0
 	}
 	// More than 1000 ticks cannot get unique milliseconds; extras share 999
-	// and the client rolls through them.
+	// and a visible client rolls through them. A tab that froze snaps.
 	while (fires.length < gain) fires.push(999)
 	return fires
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Leaving the homepage and coming back should not replay every missed code-runs tick. The ticker should jump to the current official count, then resume the live wobble.

## Summary

- The client no longer rolls through owed integers at `1000 / behind` after a freeze.
- A requestAnimationFrame watchdog snaps when the frame gap is at least 1s (tab freeze / sleep).
- `visibilitychange` and bfcache `pageshow` also snap, and the pending timeout is cleared while hidden.
- Live leftover ticks in a busy second still step `+1`. More than sixty owed integers still snap even while live.
- `nextDisplayedCodeRunsCount` owns the snap-vs-step decision so the behavior is unit-tested.

## Testing

- `npx vitest run packages/worker/universal/code-runs.node.test.ts`
- `npm run preview:manual-test -- --pr 1676 --request 'GET /code-runs.json' --check /`
- Preview seeded (preview KV only) with a busy pair `100000 → 532000`
- Tab-hide walkthrough: left at **212,119**, returned after ~7s at **212,332** in one jump (no catch-up spin), then resumed live `+1`

![Ticker before leaving the tab](https://cursor.com/artifacts/c/art-716dd475-16b5-46c5-bc4f-cfdf0f618d2a)
![Ticker immediately after returning](https://cursor.com/artifacts/c/art-5f7e87d4-d471-4d5c-b705-5210a4513fcc)
<a href="https://cursor.com/agents/bc-c8c17c2f-384e-4efd-ad81-13cc125f46ab/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpreview_1676_ticker_snap_on_wake.mp4"><img src="https://cursor.com/artifacts/c/art-042b6eb3-3291-4c17-b84e-15c5e634d2ac" alt="preview_1676_ticker_snap_on_wake.mp4" /></a>

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `02116aa3` · **Head:** `8e09d442`

**Classification:** extends — homepage ticker catch-up after a freeze snaps instead of replaying missed integers.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | extends — frozen-tab ticker snap |

### Change flow

The official pair is unchanged. This PR only changes how the hydrated ticker treats a large clock gap.

```mermaid
sequenceDiagram
	actor Visitor
	participant appUi as app-ui
	Visitor->>appUi: watch live leftover +1
	Note over appUi: tab hidden or rAF gap >= 1s
	Visitor->>appUi: return to homepage
	appUi-->>Visitor: snap to official count
	Visitor->>appUi: next hashed fire
	appUi-->>Visitor: resume +1 wobble
```

### Before / after

```text
before: wake behind N → roll +1 at 1000/N ms (looks like a catch-up spin)
after:  wake after >=1s (or N>60) → jump to official, then wait for the next fire
```

### Invariants

Anonymous fleet `execute` SUM exception is unchanged. Homepage GET still does not write `public-code-runs:v1`. Every visitor at a given clock time still sees the same official integer.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c8c17c2f-384e-4efd-ad81-13cc125f46ab?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c8c17c2f-384e-4efd-ad81-13cc125f46ab&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the homepage code-runs ticker so it stays aligned with the official count after delayed updates, frozen tabs, hidden pages, or animation interruptions.
  - The ticker now gradually catches up during normal operation and snaps to the official count after extended delays or significant differences.
  - Reduced-motion mode continues to display the latest official count immediately.
  - Added coverage for delayed updates, large count differences, and incremental catch-up behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->