### PR TITLE
Keep leftover code-runs catch-up under the freeze snap

### DIFF
--- a/docs/contributing/architecture/usage-metering.md
+++ b/docs/contributing/architecture/usage-metering.md
@@ -342,7 +342,7 @@ Guarantees and rules:
   `prefers-reduced-motion` snaps and does not animate. A frozen tab (rAF gap,
   hidden, or a late timeout) snaps to the official count instead of rolling
   through every missed integer. Live leftover ticks in a busy second still step
-  +1.
+  +1; leftover catch-up delays stay under that freeze window.
 - **Fleet visibility** (`/admin/insights`, loader in
   `packages/worker/src/admin/fleet-usage-insights.ts`): bounded SQL over
   `usage_rollups` for the current UTC month — top-10 combined runtime duration

--- a/packages/worker/client/code-runs-ticker.tsx
+++ b/packages/worker/client/code-runs-ticker.tsx
@@ -1,5 +1,6 @@
 import { type Handle } from 'remix/ui'
 import {
+	codeRunsCatchUpDelayMs,
 	codeRunsCatchUpSnapAfterMs,
 	formatCodeRunsCount,
 	interpolateCodeRunsCount,
@@ -59,6 +60,7 @@ export function CodeRunsTicker(
 			const now = Date.now()
 			const official = officialAt(now)
 			if (displayed < official) {
+				const behind = official - displayed
 				const next = nextDisplayedCodeRunsCount({
 					displayed,
 					official,
@@ -66,13 +68,9 @@ export function CodeRunsTicker(
 				})
 				show(next, now)
 				if (next < official) {
-					const behind = official - next
-					timeoutId = setTimeout(
-						() => {
-							scheduleNext()
-						},
-						Math.max(16, Math.floor(1000 / behind)),
-					)
+					timeoutId = setTimeout(() => {
+						scheduleNext()
+					}, codeRunsCatchUpDelayMs(behind))
 					return
 				}
 			}

--- a/packages/worker/client/code-runs-ticker.tsx
+++ b/packages/worker/client/code-runs-ticker.tsx
@@ -88,7 +88,7 @@ export function CodeRunsTicker(
 			if (handle.signal.aborted) return
 			const gap = timestamp - lastFrameAt
 			lastFrameAt = timestamp
-			if (gap >= codeRunsCatchUpSnapAfterMs) {
+			if (gap > codeRunsCatchUpSnapAfterMs) {
 				snapToOfficial()
 				scheduleNext()
 			}

--- a/packages/worker/universal/code-runs.node.test.ts
+++ b/packages/worker/universal/code-runs.node.test.ts
@@ -238,7 +238,8 @@ test('nextDisplayedCodeRunsCount snaps after a freeze and steps while live', () 
 
 test('codeRunsCatchUpDelayMs stays under the freeze snap for live leftover rolls', () => {
 	expect(codeRunsCatchUpDelayMs(1)).toBe(16)
-	expect(codeRunsCatchUpDelayMs(2)).toBe(500)
+	expect(codeRunsCatchUpDelayMs(102 - 100)).toBe(500)
+	expect(codeRunsCatchUpDelayMs(102 - 101)).toBe(16)
 	for (let behind = 1; behind <= 60; behind += 1) {
 		expect(codeRunsCatchUpDelayMs(behind)).toBeLessThan(
 			codeRunsCatchUpSnapAfterMs,

--- a/packages/worker/universal/code-runs.node.test.ts
+++ b/packages/worker/universal/code-runs.node.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from 'vitest'
 import {
+	codeRunsCatchUpDelayMs,
 	codeRunsCatchUpSnapAfterMs,
 	formatCodeRunsCount,
 	interpolateCodeRunsCount,
@@ -211,6 +212,13 @@ test('nextDisplayedCodeRunsCount snaps after a freeze and steps while live', () 
 			official: 108,
 			elapsedMsSinceDisplay: codeRunsCatchUpSnapAfterMs,
 		}),
+	).toBe(101)
+	expect(
+		nextDisplayedCodeRunsCount({
+			displayed: 100,
+			official: 108,
+			elapsedMsSinceDisplay: codeRunsCatchUpSnapAfterMs + 1,
+		}),
 	).toBe(108)
 	expect(
 		nextDisplayedCodeRunsCount({
@@ -226,4 +234,14 @@ test('nextDisplayedCodeRunsCount snaps after a freeze and steps while live', () 
 			elapsedMsSinceDisplay: 16,
 		}),
 	).toBe(161)
+})
+
+test('codeRunsCatchUpDelayMs stays under the freeze snap for live leftover rolls', () => {
+	expect(codeRunsCatchUpDelayMs(1)).toBe(16)
+	expect(codeRunsCatchUpDelayMs(2)).toBe(500)
+	for (let behind = 1; behind <= 60; behind += 1) {
+		expect(codeRunsCatchUpDelayMs(behind)).toBeLessThan(
+			codeRunsCatchUpSnapAfterMs,
+		)
+	}
 })

--- a/packages/worker/universal/code-runs.ts
+++ b/packages/worker/universal/code-runs.ts
@@ -95,12 +95,22 @@ export function nextDisplayedCodeRunsCount(input: {
 	if (input.official <= input.displayed) return input.displayed
 	const behind = input.official - input.displayed
 	if (
-		input.elapsedMsSinceDisplay >= codeRunsCatchUpSnapAfterMs ||
+		input.elapsedMsSinceDisplay > codeRunsCatchUpSnapAfterMs ||
 		behind > codeRunsCatchUpSnapBehind
 	) {
 		return input.official
 	}
 	return input.displayed + 1
+}
+
+/**
+ * Delay before the next live leftover +1. Uses the owed count from
+ * before the step so a single remaining integer cannot wait a full
+ * second and trip the freeze snap.
+ */
+export function codeRunsCatchUpDelayMs(behindBeforeStep: number): number {
+	if (behindBeforeStep <= 1) return 16
+	return Math.max(16, Math.floor(1000 / behindBeforeStep))
 }
 
 const coarseSegmentCount = 72


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

A live leftover `+1` in a busy second should not trip the freeze snap just because the last owed integer waited a second.

## Summary

Bugbot on #1676: catch-up used `1000 / remaining` *after* stepping, so one leftover slept 1000ms and the next `scheduleNext` always snapped.

- `codeRunsCatchUpDelayMs` uses the owed count from *before* the step (same as the old ticker).
- Live leftover delays stay under `codeRunsCatchUpSnapAfterMs` (max 500ms when two are owed).
- Freeze snap now requires elapsed **greater than** 1s in both `nextDisplayedCodeRunsCount` and the rAF watchdog.

## Testing

- `npx vitest run packages/worker/universal/code-runs.node.test.ts`
- `npm run preview:manual-test -- --pr 1677 --request 'GET /code-runs.json' --check /` (after this push)

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `06876647` · **Head:** `41f952d7`

**Classification:** extends — leftover catch-up delay no longer equals the freeze-snap window.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | extends — leftover catch-up delay |

### Change flow

The official pair is unchanged. This PR only fixes how long a visible leftover `+1` waits.

```mermaid
sequenceDiagram
	actor Visitor
	participant appUi as app-ui
	Visitor->>appUi: live leftover behind 2
	appUi-->>Visitor: +1
	Note over appUi: wait 500ms (pre-step behind), not 1000ms
	appUi-->>Visitor: next leftover +1
```

### Before / after

```text
before: +1 then wait 1000/(official-displayed) → last leftover waits 1s → snap
after:  +1 then wait 1000/behindBeforeStep → last leftover waits 500ms → stay +1
```

### Invariants

Anonymous fleet `execute` SUM exception is unchanged. Homepage GET still does not write `public-code-runs:v1`. Frozen tabs still snap after a gap greater than 1s.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c8c17c2f-384e-4efd-ad81-13cc125f46ab?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c8c17c2f-384e-4efd-ad81-13cc125f46ab&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved live ticker catch-up behavior so updates progress smoothly in smaller increments.
  - Refined timing when the ticker falls behind, including smoother recovery for larger gaps.
  - Updated snap-forward behavior so displayed values change only after the catch-up threshold is exceeded.
  - Preserved catch-up delays within the freeze window.

- **Tests**
  - Added coverage for ticker timing, stepping, snap behavior, and catch-up delays.

- **Documentation**
  - Clarified ticker catch-up and live update behavior in the architecture documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->