### PR TITLE
Auto-trust platform-owned community listings on publish

### DIFF
--- a/docs/contributing/community-packages.md
+++ b/docs/contributing/community-packages.md
@@ -78,11 +78,15 @@ KV snapshot, and ratings.
 
 Admin **trust** marks live in `trusted_commit` / `trusted_by_user_id` /
 `trusted_at`. A listing is effectively trusted only while
-`trusted_commit = pinned_commit`, so an owner republish (which moves the pinned
-commit) drops the effective mark without an explicit revoke.
-`setCommunityListingTrusted` in `service.ts` sets or clears the mark; delisted
-listings cannot be trusted. Surfaces: the `Trusted` badge on `/community` cards
-and detail pages, the admin-only toggle on the detail page
+`trusted_commit = pinned_commit`. `publishCommunityListing` automatically pins
+trust after a successful snapshot write when `owner_user_id` belongs to a
+platform account (`users.account_type = 'platform'`), including republishes.
+Person-owned listings are never auto-trusted, regardless of username, so their
+republishes move `pinned_commit` and drop the effective mark without an explicit
+revoke. `setCommunityListingTrusted` in `service.ts` sets or clears the mark;
+delisted listings cannot be trusted, and admins can revoke trust from
+platform-owned listings between publishes. Surfaces: the `Trusted` badge on
+`/community` cards and detail pages, the admin-only toggle on the detail page
 (`POST /community/:listingId/trust.json`, audited), and the admin-only
 `community_set_trusted` capability. `community_search` and `community_get`
 expose the effective `trusted` flag.
@@ -94,8 +98,9 @@ a package scope grant; see
 [Platform accounts](./architecture/platform-accounts.md).
 `setCommunityListingFeatured` in `service.ts` requires the listing to be
 effectively trusted before featuring; the effective `featured` flag
-(`featured_at IS NOT NULL AND trusted`) is computed in `repo.ts`, so an owner
-republish that drops trust also pulls the listing from onboarding while keeping
+(`featured_at IS NOT NULL AND trusted`) is computed in `repo.ts`. A platform
+republish re-pins trust and leaves an official listing effectively featured. A
+person republish drops trust and pulls the listing from onboarding while keeping
 the stored mark. `listFeaturedCommunityListings` feeds the onboarding page (slim
 `OnboardingFeaturedListing` shapes, capped at 12). Surfaces: the `Featured`
 badge on the detail page, the admin-only toggle

--- a/docs/use/community-packages.md
+++ b/docs/use/community-packages.md
@@ -182,14 +182,20 @@ between community content and live code.
 
 ## Trusted listings
 
-Admins can mark a listing as **trusted** after reviewing its content. Trusted
-listings show a **Trusted** badge on `/community` cards and detail pages, and
-`community_search` / `community_get` include a `trusted` field.
+Admins can mark a person-owned listing as **trusted** after reviewing its
+content. Listings owned by an official platform account such as `@kody` are
+trusted automatically whenever they are published successfully. A username alone
+does not grant this behavior: person accounts, including `@kentcdodds`, still
+require review. Trusted listings show a **Trusted** badge on `/community` cards
+and detail pages, and `community_search` / `community_get` include a `trusted`
+field.
 
-Trust is pinned to the **exact reviewed commit**. When the owner republishes the
-listing with new content, the badge disappears until an admin reviews the new
-version and re-trusts it. A trusted badge means an admin reviewed that version —
-it is still your responsibility (and your agent's) to review forked code before
+Trust is pinned to the **exact trusted commit**. For person-owned listings, that
+is the commit an admin reviewed. When the owner republishes with new content,
+the badge disappears until an admin reviews the new version and re-trusts it. A
+platform-owned listing instead re-pins trust to the newly published commit
+automatically. Admins can still revoke trust from either kind of listing. It is
+still your responsibility (and your agent's) to review forked code before
 publishing it into your account.
 
 Admins toggle trust from the listing detail page or with the
@@ -203,9 +209,10 @@ one-click install. Official starter packages are published under platform scopes
 such as `@kody` by operators who hold a package scope grant on that account —
 they show up like any other community listing, owned by `@kody/...` rather than
 a personal username. Only trusted listings can be featured, and a listing is
-only _shown_ in onboarding while it remains effectively trusted: when the owner
-republishes, it silently drops out of onboarding until an admin re-trusts the
-new version (the featured mark itself is kept, so re-trusting restores it).
+only _shown_ in onboarding while it remains effectively trusted. Platform-owned
+listings re-pin trust on republish, so official featured listings stay in
+onboarding. A person-owned listing silently drops out until an admin re-trusts
+the new version (the featured mark itself is kept, so re-trusting restores it).
 
 Featured listings show a **Featured** badge on their detail page. Admins toggle
 featuring from the listing detail page or with the `community_set_featured`

--- a/packages/worker/src/community/community-flow.workers.test.ts
+++ b/packages/worker/src/community/community-flow.workers.test.ts
@@ -59,17 +59,20 @@ async function ensureUsersTable() {
 async function insertTestUser(input: {
 	email: string
 	username: string
+	accountType?: 'person' | 'platform'
 }): Promise<TestUser> {
 	await ensureUsersTable()
 	const userId = await createStableUserIdFromEmail(input.email)
 	await runSql(
-		`INSERT INTO users (username, email, stable_user_id, password_hash, plan)
-			VALUES (?, ?, ?, ?, ?)`,
+		`INSERT INTO users
+			(username, email, stable_user_id, password_hash, plan, account_type)
+			VALUES (?, ?, ?, ?, ?, ?)`,
 		input.username,
 		input.email,
 		userId,
 		'test-password-hash',
 		'max',
+		input.accountType ?? 'person',
 	)
 	return {
 		userId,
@@ -615,6 +618,112 @@ test('community package flow works end-to-end through capability handlers', asyn
 			reporterCtx,
 		),
 	).rejects.toThrow('banned from community participation')
+}, 120_000)
+
+test('platform-owned listing stays trusted and featured through republish', async () => {
+	silenceIncidentalRuntimeWarnings()
+	using _artifactsMock = createMswNodeServer(
+		createArtifactsMswHandlers({
+			accountId: mockAccountId,
+			apiBaseUrl: artifactsApiBaseUrl,
+		}),
+		{ onUnhandledRequest: 'bypass' },
+	)
+	const testEnv = {
+		...env,
+		CLOUDFLARE_ACCOUNT_ID: mockAccountId,
+		CLOUDFLARE_API_TOKEN: 'artifacts-test-token',
+		CLOUDFLARE_API_BASE_URL: artifactsApiBaseUrl,
+		COMMUNITY_ACTIVITY_DISPATCH_QUEUE: {
+			async send() {},
+		},
+		COMMUNITY_LISTING_PUBLISHED_DISPATCH_QUEUE: {
+			async send() {},
+		},
+	} as Env
+	const unique = crypto.randomUUID()
+	const owner = await insertTestUser({
+		email: `platform-owner-${unique}@example.com`,
+		username: `kody-${unique.slice(0, 8)}`,
+		accountType: 'platform',
+	})
+	const packageId = `platform-package-${unique}`
+	const sourceId = `platform-source-${unique}`
+	const kodyId = `platform-listing-${unique}`
+	const publishedCommit = `platform-commit-${unique}`
+	const seeded = await seedOwnerPackage({
+		testEnv,
+		owner,
+		packageId,
+		sourceId,
+		kodyId,
+		publishedCommit,
+	})
+	const ownerCtx = createCapabilityContext(testEnv, owner)
+
+	const published = await communityPublishCapability.handler(
+		{ package_id: packageId },
+		ownerCtx,
+	)
+	const publishedDetail = await communityGetCapability.handler(
+		{ listing_id: published.listing_id },
+		ownerCtx,
+	)
+	expect(publishedDetail).toMatchObject({
+		pinned_commit: publishedCommit,
+		trusted: true,
+	})
+
+	await setCommunityListingFeatured({
+		env: testEnv,
+		listingId: published.listing_id,
+		featured: true,
+	})
+	const republishedCommit = `platform-republished-${unique}`
+	await writePublishedSourceSnapshot({
+		env: testEnv,
+		source: { ...seeded.entitySource, published_commit: republishedCommit },
+		files: seeded.files,
+	})
+	await runSql(
+		`UPDATE entity_sources SET published_commit = ? WHERE id = ?`,
+		republishedCommit,
+		sourceId,
+	)
+
+	await communityPublishCapability.handler({ package_id: packageId }, ownerCtx)
+
+	const republishedDetail = await communityGetCapability.handler(
+		{ listing_id: published.listing_id },
+		ownerCtx,
+	)
+	expect(republishedDetail).toMatchObject({
+		pinned_commit: republishedCommit,
+		trusted: true,
+		featured: true,
+	})
+	const featuredListings = await listFeaturedCommunityListingsWithAggregates({
+		env: testEnv,
+		limit: 10,
+	})
+	expect(
+		featuredListings.some((listing) => listing.id === published.listing_id),
+	).toBe(true)
+
+	const trustRow = await env.APP_DB.prepare(
+		`SELECT trusted_commit, trusted_by_user_id
+			FROM community_listings
+			WHERE id = ?`,
+	)
+		.bind(published.listing_id)
+		.first<{
+			trusted_commit: string | null
+			trusted_by_user_id: string | null
+		}>()
+	expect(trustRow).toEqual({
+		trusted_commit: republishedCommit,
+		trusted_by_user_id: owner.userId,
+	})
 }, 120_000)
 
 test('one-click install publishes clean listings and keeps unresolvable forks inert', async () => {

--- a/packages/worker/src/community/community-service.node.test.ts
+++ b/packages/worker/src/community/community-service.node.test.ts
@@ -483,6 +483,106 @@ test('publishCommunityListing pins platform trust on publish and republish but n
 	expect(mockModule.setCommunityListingTrustedCommit).toHaveBeenCalledTimes(2)
 })
 
+test('publishCommunityListing restores listing snapshots when platform trust pinning fails', async () => {
+	mockModule.getCommunityBan.mockResolvedValue(null)
+	mockModule.getSavedPackageById.mockResolvedValue(validSavedPackage())
+	mockModule.loadPackageSourceBySourceId.mockResolvedValue(validPublishSource())
+	mockModule.getCommunityListingByOwnerAndPackage.mockResolvedValue(null)
+	mockModule.insertCommunityListing.mockResolvedValue(undefined)
+	mockModule.writeCommunitySnapshot.mockResolvedValue(undefined)
+	mockModule.isPlatformAccountStableUserId.mockResolvedValue(true)
+	mockModule.setCommunityListingTrustedCommit.mockRejectedValue(
+		new Error('trust unavailable'),
+	)
+	mockModule.deleteCommunityListing.mockResolvedValue(true)
+	mockModule.deleteCommunitySnapshot.mockResolvedValue(undefined)
+
+	await expect(
+		publishCommunityListing({
+			env: createEnv(),
+			baseUrl: 'https://heykody.dev',
+			userId: 'platform-owner-1',
+			packageId: 'package-1',
+		}),
+	).rejects.toThrow('trust unavailable')
+
+	const firstListingId = mockModule.insertCommunityListing.mock.calls[0]?.[1]
+		?.id as string
+	expect(mockModule.deleteCommunityListing).toHaveBeenCalledWith(
+		expect.anything(),
+		{
+			listingId: firstListingId,
+			ownerUserId: 'platform-owner-1',
+		},
+	)
+	expect(mockModule.deleteCommunitySnapshot).toHaveBeenCalledWith(
+		expect.anything(),
+		firstListingId,
+	)
+	expect(mockModule.insertCommunityActivityEvent).not.toHaveBeenCalled()
+
+	mockModule.updateCommunityListing.mockClear()
+	mockModule.writeCommunitySnapshot.mockClear()
+	mockModule.deleteCommunityListing.mockClear()
+	mockModule.deleteCommunitySnapshot.mockClear()
+	const existingListing = sampleListing({
+		ownerUserId: 'platform-owner-1',
+		trustedCommit: 'commit-1',
+		trusted: true,
+		featuredAt: '2026-07-02T00:00:00.000Z',
+		featured: true,
+	})
+	const previousSnapshot = {
+		version: 1 as const,
+		listingId: existingListing.id,
+		pinnedCommit: existingListing.pinnedCommit,
+		files: {
+			'package.json': '{"name":"@owner/discord-gateway"}',
+			'README.md': existingListing.readmeContent ?? '',
+		},
+		createdAt: existingListing.publishedAt,
+	}
+	mockModule.getCommunityListingByOwnerAndPackage.mockResolvedValue(
+		existingListing,
+	)
+	mockModule.readCommunitySnapshot.mockResolvedValue(previousSnapshot)
+	mockModule.updateCommunityListing.mockResolvedValue(true)
+	const republishedSource = validPublishSource()
+	republishedSource.source.published_commit = 'commit-2'
+	mockModule.loadPackageSourceBySourceId.mockResolvedValue(republishedSource)
+
+	await expect(
+		publishCommunityListing({
+			env: createEnv(),
+			baseUrl: 'https://heykody.dev',
+			userId: 'platform-owner-1',
+			actorUserId: 'operator-1',
+			packageId: 'package-1',
+		}),
+	).rejects.toThrow('trust unavailable')
+
+	expect(mockModule.readCommunitySnapshot).toHaveBeenCalledWith(
+		expect.anything(),
+		existingListing.id,
+	)
+	expect(mockModule.updateCommunityListing).toHaveBeenLastCalledWith(
+		expect.anything(),
+		expect.objectContaining({
+			listingId: existingListing.id,
+			ownerUserId: 'platform-owner-1',
+			pinnedCommit: 'commit-1',
+			publishedAt: existingListing.publishedAt,
+		}),
+	)
+	expect(mockModule.writeCommunitySnapshot).toHaveBeenLastCalledWith(
+		expect.anything(),
+		previousSnapshot,
+	)
+	expect(mockModule.deleteCommunityListing).not.toHaveBeenCalled()
+	expect(mockModule.deleteCommunitySnapshot).not.toHaveBeenCalled()
+	expect(mockModule.insertCommunityActivityEvent).not.toHaveBeenCalled()
+})
+
 test('publishCommunityListing rolls back D1 when KV snapshot write fails', async () => {
 	mockModule.getCommunityBan.mockResolvedValue(null)
 	mockModule.getSavedPackageById.mockResolvedValue(validSavedPackage())

--- a/packages/worker/src/community/community-service.node.test.ts
+++ b/packages/worker/src/community/community-service.node.test.ts
@@ -45,7 +45,9 @@ const mockModule = vi.hoisted(() => ({
 	deleteCommunityRatingsByListingId: vi.fn(),
 	deleteCommunitySnapshot: vi.fn(),
 	setCommunityListingStatus: vi.fn(),
+	setCommunityListingTrustedCommit: vi.fn(),
 	resolveCommunityReportRow: vi.fn(),
+	isPlatformAccountStableUserId: vi.fn(),
 }))
 
 vi.mock('./activity-dispatch-queue-producer.ts', () => ({
@@ -60,6 +62,8 @@ vi.mock('./listing-published-dispatch-queue-producer.ts', () => ({
 
 vi.mock('#worker/package-registry/scope-grants.ts', () => ({
 	getPlatformAccountByUsername: async () => null,
+	isPlatformAccountStableUserId: (...args: Array<unknown>) =>
+		mockModule.isPlatformAccountStableUserId(...args),
 	listPlatformAccountUsernames: async () => [],
 }))
 
@@ -149,6 +153,8 @@ vi.mock('./repo.ts', async (importOriginal) => {
 			mockModule.resolveCommunityReportRow(...args),
 		setCommunityListingStatus: (...args: Array<unknown>) =>
 			mockModule.setCommunityListingStatus(...args),
+		setCommunityListingTrustedCommit: (...args: Array<unknown>) =>
+			mockModule.setCommunityListingTrustedCommit(...args),
 	}
 })
 
@@ -355,6 +361,127 @@ function validSavedPackage() {
 		updatedAt: '2026-07-01T00:00:00.000Z',
 	}
 }
+
+test('publishCommunityListing pins platform trust on publish and republish but not for people', async () => {
+	mockModule.getCommunityBan.mockResolvedValue(null)
+	mockModule.getSavedPackageById.mockResolvedValue(validSavedPackage())
+	const firstSource = validPublishSource()
+	mockModule.loadPackageSourceBySourceId.mockResolvedValue(firstSource)
+	mockModule.getCommunityListingByOwnerAndPackage.mockResolvedValue(null)
+	mockModule.insertCommunityListing.mockResolvedValue(undefined)
+	mockModule.writeCommunitySnapshot.mockResolvedValue(undefined)
+	mockModule.isPlatformAccountStableUserId.mockImplementation(
+		async (_db: unknown, userId: string) => userId === 'platform-owner-1',
+	)
+	mockModule.setCommunityListingTrustedCommit.mockResolvedValue(true)
+	mockModule.getCommunityListingById.mockImplementation(
+		async (_db: unknown, input: { listingId: string }) =>
+			sampleListing({
+				id: input.listingId,
+				ownerUserId: 'platform-owner-1',
+				trustedCommit: firstSource.source.published_commit,
+				trusted: true,
+			}),
+	)
+	mockModule.insertCommunityActivityEvent.mockResolvedValue(undefined)
+
+	await publishCommunityListing({
+		env: createEnv(),
+		baseUrl: 'https://heykody.dev',
+		userId: 'platform-owner-1',
+		packageId: 'package-1',
+	})
+
+	const listingId = mockModule.insertCommunityListing.mock.calls[0]?.[1]
+		?.id as string
+	expect(mockModule.setCommunityListingTrustedCommit).toHaveBeenNthCalledWith(
+		1,
+		expect.anything(),
+		{
+			listingId,
+			trustedCommit: 'commit-1',
+			trustedByUserId: 'platform-owner-1',
+		},
+	)
+	expect(
+		mockModule.writeCommunitySnapshot.mock.invocationCallOrder[0],
+	).toBeLessThan(
+		mockModule.setCommunityListingTrustedCommit.mock.invocationCallOrder[0] ??
+			0,
+	)
+	expect(
+		mockModule.setCommunityListingTrustedCommit.mock.invocationCallOrder[0],
+	).toBeLessThan(
+		mockModule.insertCommunityActivityEvent.mock.invocationCallOrder[0] ?? 0,
+	)
+
+	mockModule.getCommunityListingByOwnerAndPackage.mockResolvedValue(
+		sampleListing({
+			id: listingId,
+			ownerUserId: 'platform-owner-1',
+			trustedCommit: 'commit-1',
+			trusted: true,
+		}),
+	)
+	mockModule.updateCommunityListing.mockResolvedValue(true)
+	const republishedSource = validPublishSource()
+	republishedSource.source.published_commit = 'commit-2'
+	mockModule.loadPackageSourceBySourceId.mockResolvedValue(republishedSource)
+	mockModule.getCommunityListingById.mockResolvedValue(
+		sampleListing({
+			id: listingId,
+			ownerUserId: 'platform-owner-1',
+			pinnedCommit: 'commit-2',
+			trustedCommit: 'commit-2',
+			trusted: true,
+		}),
+	)
+
+	await publishCommunityListing({
+		env: createEnv(),
+		baseUrl: 'https://heykody.dev',
+		userId: 'platform-owner-1',
+		actorUserId: 'operator-1',
+		packageId: 'package-1',
+	})
+
+	expect(mockModule.setCommunityListingTrustedCommit).toHaveBeenNthCalledWith(
+		2,
+		expect.anything(),
+		{
+			listingId,
+			trustedCommit: 'commit-2',
+			trustedByUserId: 'operator-1',
+		},
+	)
+	expect(
+		mockModule.writeCommunitySnapshot.mock.invocationCallOrder[1],
+	).toBeLessThan(
+		mockModule.setCommunityListingTrustedCommit.mock.invocationCallOrder[1] ??
+			0,
+	)
+	expect(
+		mockModule.setCommunityListingTrustedCommit.mock.invocationCallOrder[1],
+	).toBeLessThan(
+		mockModule.insertCommunityActivityEvent.mock.invocationCallOrder[1] ?? 0,
+	)
+
+	mockModule.getCommunityListingByOwnerAndPackage.mockResolvedValue(null)
+	mockModule.loadPackageSourceBySourceId.mockResolvedValue(validPublishSource())
+	mockModule.getCommunityListingById.mockImplementation(
+		async (_db: unknown, input: { listingId: string }) =>
+			sampleListing({ id: input.listingId, ownerUserId: 'person-1' }),
+	)
+
+	await publishCommunityListing({
+		env: createEnv(),
+		baseUrl: 'https://heykody.dev',
+		userId: 'person-1',
+		packageId: 'package-1',
+	})
+
+	expect(mockModule.setCommunityListingTrustedCommit).toHaveBeenCalledTimes(2)
+})
 
 test('publishCommunityListing rolls back D1 when KV snapshot write fails', async () => {
 	mockModule.getCommunityBan.mockResolvedValue(null)

--- a/packages/worker/src/community/service.ts
+++ b/packages/worker/src/community/service.ts
@@ -481,6 +481,43 @@ async function restoreReleasedCommunityPackageUrl(input: {
 	}
 }
 
+async function restoreCommunityListingAfterPublishFailure(input: {
+	env: Env
+	ownerUserId: string
+	listingId: string
+	existingListing: CommunityListingRecord | null
+}) {
+	try {
+		if (input.existingListing) {
+			await updateCommunityListing(input.env.APP_DB, {
+				listingId: input.listingId,
+				ownerUserId: input.ownerUserId,
+				sourceId: input.existingListing.sourceId,
+				kodyId: input.existingListing.kodyId,
+				name: input.existingListing.name,
+				description: input.existingListing.description,
+				tagsJson: JSON.stringify(input.existingListing.tags),
+				category: input.existingListing.category,
+				searchText: input.existingListing.searchText,
+				readmeContent: input.existingListing.readmeContent,
+				license: input.existingListing.license,
+				pinnedCommit: input.existingListing.pinnedCommit,
+				publishedAt: input.existingListing.publishedAt,
+			})
+		} else {
+			await deleteCommunityListing(input.env.APP_DB, {
+				listingId: input.listingId,
+				ownerUserId: input.ownerUserId,
+			})
+		}
+	} catch (revertError) {
+		console.error(
+			'Failed to revert community listing after publish failure:',
+			revertError,
+		)
+	}
+}
+
 export async function publishCommunityListing(input: {
 	env: Env
 	baseUrl: string
@@ -571,6 +608,18 @@ export async function publishCommunityListing(input: {
 		)
 	}
 
+	const platformOwner = await isPlatformAccountStableUserId(
+		input.env.APP_DB,
+		input.userId,
+	)
+	const listingId = existingListing?.id ?? crypto.randomUUID()
+	const previousSnapshot =
+		platformOwner && existingListing
+			? await readCommunitySnapshot(
+					input.env.BUNDLE_ARTIFACTS_KV,
+					existingListing.id,
+				)
+			: null
 	const releasedListingId = await releaseContestedCommunityPackageUrl({
 		env: input.env,
 		ownerUserId: input.userId,
@@ -579,7 +628,6 @@ export async function publishCommunityListing(input: {
 	})
 
 	const now = new Date().toISOString()
-	const listingId = existingListing?.id ?? crypto.randomUUID()
 	const tagsJson = JSON.stringify(savedPackage.tags)
 	const category = resolveCommunityListingCategory({
 		category: loadedSource.manifest.kody.category,
@@ -661,36 +709,56 @@ export async function publishCommunityListing(input: {
 		try {
 			await writeCommunitySnapshot(input.env.BUNDLE_ARTIFACTS_KV, snapshot)
 		} catch (snapshotError) {
-			try {
-				if (existingListing) {
-					await updateCommunityListing(input.env.APP_DB, {
-						listingId,
-						ownerUserId: input.userId,
-						sourceId: existingListing.sourceId,
-						kodyId: existingListing.kodyId,
-						name: existingListing.name,
-						description: existingListing.description,
-						tagsJson: JSON.stringify(existingListing.tags),
-						category: existingListing.category,
-						searchText: existingListing.searchText,
-						readmeContent: existingListing.readmeContent,
-						license: existingListing.license,
-						pinnedCommit: existingListing.pinnedCommit,
-						publishedAt: existingListing.publishedAt,
-					})
-				} else {
-					await deleteCommunityListing(input.env.APP_DB, {
-						listingId,
-						ownerUserId: input.userId,
-					})
-				}
-			} catch (revertError) {
-				console.error(
-					'Failed to revert community listing after snapshot failure:',
-					revertError,
-				)
-			}
+			await restoreCommunityListingAfterPublishFailure({
+				env: input.env,
+				ownerUserId: input.userId,
+				listingId,
+				existingListing,
+			})
 			throw snapshotError
+		}
+		if (platformOwner) {
+			try {
+				const trusted = await setCommunityListingTrustedCommit(
+					input.env.APP_DB,
+					{
+						listingId,
+						trustedCommit: publishedCommit,
+						trustedByUserId: input.actorUserId ?? input.userId,
+					},
+				)
+				if (!trusted) {
+					throw new Error(
+						`Community listing "${listingId}" could not be marked trusted.`,
+					)
+				}
+			} catch (trustError) {
+				await restoreCommunityListingAfterPublishFailure({
+					env: input.env,
+					ownerUserId: input.userId,
+					listingId,
+					existingListing,
+				})
+				try {
+					if (previousSnapshot) {
+						await writeCommunitySnapshot(
+							input.env.BUNDLE_ARTIFACTS_KV,
+							previousSnapshot,
+						)
+					} else {
+						await deleteCommunitySnapshot(
+							input.env.BUNDLE_ARTIFACTS_KV,
+							listingId,
+						)
+					}
+				} catch (revertError) {
+					console.error(
+						'Failed to revert community snapshot after trust failure:',
+						revertError,
+					)
+				}
+				throw trustError
+			}
 		}
 	} catch (publishError) {
 		await restoreReleasedCommunityPackageUrl({
@@ -699,13 +767,6 @@ export async function publishCommunityListing(input: {
 			listingId: releasedListingId,
 		})
 		throw publishError
-	}
-	if (await isPlatformAccountStableUserId(input.env.APP_DB, input.userId)) {
-		await setCommunityListingTrustedCommit(input.env.APP_DB, {
-			listingId,
-			trustedCommit: publishedCommit,
-			trustedByUserId: input.actorUserId ?? input.userId,
-		})
 	}
 	if (existingListing) {
 		// Drop all cached icon revisions (including a reused commit id) so the

--- a/packages/worker/src/community/service.ts
+++ b/packages/worker/src/community/service.ts
@@ -25,6 +25,10 @@ import {
 	getSavedPackageByKodyId,
 	getSavedPackageByName,
 } from '#worker/package-registry/repo.ts'
+import {
+	isPlatformAccountStableUserId,
+	listPlatformAccountUsernames,
+} from '#worker/package-registry/scope-grants.ts'
 import { loadPackageSourceBySourceId } from '#worker/package-registry/source.ts'
 import { cleanupArtifactReposForPackage } from '#worker/repo/artifact-repo-cleanup.ts'
 import { deleteEntitySource } from '#worker/repo/entity-sources.ts'
@@ -85,7 +89,6 @@ import {
 	deleteCommunityStarsByListingId,
 	insertCommunityActivityEvent,
 } from './social-repo.ts'
-import { listPlatformAccountUsernames } from '#worker/package-registry/scope-grants.ts'
 import {
 	rewritePackageManifestForFork,
 	scanCrossScopeReferences,
@@ -696,6 +699,13 @@ export async function publishCommunityListing(input: {
 			listingId: releasedListingId,
 		})
 		throw publishError
+	}
+	if (await isPlatformAccountStableUserId(input.env.APP_DB, input.userId)) {
+		await setCommunityListingTrustedCommit(input.env.APP_DB, {
+			listingId,
+			trustedCommit: publishedCommit,
+			trustedByUserId: input.actorUserId ?? input.userId,
+		})
 	}
 	if (existingListing) {
 		// Drop all cached icon revisions (including a reused commit id) so the

--- a/packages/worker/src/community/types.ts
+++ b/packages/worker/src/community/types.ts
@@ -56,10 +56,12 @@ export type CommunityListingRecord = {
 	iconCommit: string
 	status: CommunityListingStatus
 	/**
-	 * Commit an admin reviewed when marking this listing trusted, or null when
-	 * never trusted (or trust was revoked). Trust follows the reviewed
-	 * content: `trusted` is true only while this matches `pinnedCommit`, so an
-	 * owner republish drops the effective mark until an admin re-reviews.
+	 * Commit trusted for this listing, or null when never trusted (or trust was
+	 * revoked). Admin trust records the reviewed commit. Platform-owned
+	 * listings automatically trust each successfully published commit. Trust
+	 * follows the pinned content: `trusted` is true only while this matches
+	 * `pinnedCommit`, so a person-owned republish drops the effective mark
+	 * until an admin re-reviews.
 	 */
 	trustedCommit: string | null
 	trustedAt: string | null

--- a/packages/worker/src/mcp/capabilities/community/publish.ts
+++ b/packages/worker/src/mcp/capabilities/community/publish.ts
@@ -17,7 +17,7 @@ export const communityPublishCapability = defineDomainCapability(
 	{
 		name: 'community_publish',
 		description:
-			'Publish a saved package as a public community listing on this deployment. Requires MIT license in package.json `license`, `"private"` not set to true, a root README with a `## Intent` section, and a published commit. Set `package.json#kody.category` to integrations, examples, productivity, apps, or utilities so `/community` can group the listing; omitted categories infer from well-known tags. Publishing shares the pinned snapshot publicly with all users on this deployment. Re-publishing the same package updates the listing to the current published commit.',
+			'Publish a saved package as a public community listing on this deployment. Requires MIT license in package.json `license`, `"private"` not set to true, a root README with a `## Intent` section, and a published commit. Set `package.json#kody.category` to integrations, examples, productivity, apps, or utilities so `/community` can group the listing; omitted categories infer from well-known tags. Publishing shares the pinned snapshot publicly with all users on this deployment. Re-publishing the same package updates the listing to the current published commit. Listings owned by a platform account are automatically trusted at each successfully published commit; person-owned listings require admin review.',
 		keywords: [
 			'community',
 			'publish',

--- a/packages/worker/src/mcp/capabilities/community/set-featured.ts
+++ b/packages/worker/src/mcp/capabilities/community/set-featured.ts
@@ -11,7 +11,7 @@ export const communitySetFeaturedCapability = defineDomainCapability(
 	{
 		name: 'community_set_featured',
 		description:
-			'Admin-only curation: mark a trusted community listing as an onboarding starter package, or remove the mark. Featured listings are offered for one-click install during onboarding, so featuring requires the listing to be trusted at its current commit; an owner republish drops the listing from onboarding until an admin re-trusts it.',
+			'Admin-only curation: mark a trusted community listing as an onboarding starter package, or remove the mark. Featured listings are offered for one-click install during onboarding, so featuring requires the listing to be trusted at its current commit. A person-owned republish drops the listing from onboarding until an admin re-trusts it; a platform-owned republish re-pins trust automatically so the listing stays featured.',
 		keywords: [
 			'community',
 			'featured',

--- a/packages/worker/src/mcp/capabilities/community/set-trusted.ts
+++ b/packages/worker/src/mcp/capabilities/community/set-trusted.ts
@@ -11,7 +11,7 @@ export const communitySetTrustedCapability = defineDomainCapability(
 	{
 		name: 'community_set_trusted',
 		description:
-			'Admin-only curation: mark a community listing as trusted at its current pinned commit, or revoke the mark. Trust is pinned to the reviewed commit, so an owner republish automatically drops the effective trusted state until an admin re-reviews.',
+			'Admin-only curation: mark a community listing as trusted at its current pinned commit, or revoke the mark. Trust is pinned to the reviewed commit, so a person-owned republish drops the effective trusted state until an admin re-reviews. Platform-owned listings are automatically re-trusted when successfully republished; admins can still revoke trust between publishes.',
 		keywords: ['community', 'trusted', 'curate', 'admin', 'review', 'listing'],
 		readOnly: false,
 		idempotent: true,

--- a/packages/worker/src/mcp/capabilities/community/shared.ts
+++ b/packages/worker/src/mcp/capabilities/community/shared.ts
@@ -80,7 +80,7 @@ export const communityListingAggregatesSchema = z.object({
 export const communityTrustedFieldSchema = z
 	.boolean()
 	.describe(
-		'True when an admin reviewed and trusted the exact pinned commit of this listing.',
+		'True when the exact pinned commit is trusted, either by admin review or automatic platform-account trust.',
 	)
 
 export const communityFeaturedFieldSchema = z

--- a/packages/worker/src/package-registry/scope-grants.ts
+++ b/packages/worker/src/package-registry/scope-grants.ts
@@ -75,7 +75,7 @@ export async function getPlatformAccountByUsername(
 	}
 }
 
-async function isPlatformAccountStableUserId(
+export async function isPlatformAccountStableUserId(
 	db: D1Database,
 	stableUserId: string,
 ) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Keep official platform-owned community listings trusted at their current published commit without requiring an admin to re-trust every README or icon republish, while preserving person-owned trust semantics.

## Summary

- Detect platform ownership by `users.account_type = 'platform'` after validating a community publish.
- Pin platform listing trust to the published commit and attribute it to the acting user (or owner fallback) before activity events.
- Compensate a failed trust write by restoring the prior listing and KV snapshot (or deleting a failed first publish), so rejected publishes do not leave partial public state.
- Preserve person-owned republish, delisting, manual revoke, and effective-featured behavior.
- Cover first publish, republish, person ownership, trust-write rollback, and featured onboarding behavior; update capability and community documentation.

## Testing

- `npm run validate` at `c977e92c` — passed: Node 1,982; Workers 301; MCP 5; Playwright 7, plus format, lint, typecheck, builds, and repository checks.
- Preview deployed at https://kody-pr-1678.kody-a99.workers.dev and authenticated seed-user smoke passed. The preview seed has no platform account, package-scope grant, admin user, or community data, so the operator-only platform publish path cannot be created through its product JSON APIs without prohibited raw D1 seeding; the focused Workers test exercises that exact data path instead.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `d0c97dfc` · **Head:** `c977e92c`

**Classification:** extends — changes the trust and compensation lifecycle of existing community listings without adding a primitive or schema.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `community-listings` | assistant | extends — platform publishes re-pin trust; trust failures restore listing and snapshot state before rejection |
| `saved-packages` | assistant | composes — exposes and reuses the existing stable-user platform-account check |

### Change flow

A successful community snapshot gates the platform-owner trust pin; failed trust writes compensate both D1 and KV before the publish rejects.

```mermaid
sequenceDiagram
	actor Publisher
	participant communityListings as community-listings
	participant savedPackages as saved-packages
	participant bundleArtifactsKv as bundle-artifacts-kv
	participant d1AppDb as d1-app-db
	Publisher->>communityListings: community_publish saved package
	communityListings->>savedPackages: load package commit and check owner account_type
	communityListings->>d1AppDb: insert or update pinned_commit
	communityListings->>bundleArtifactsKv: write public listing snapshot
	alt platform account
		communityListings->>d1AppDb: set trusted_commit and trusted_by_user_id
		alt trust write fails
			communityListings->>d1AppDb: restore previous listing or delete first publish
			communityListings->>bundleArtifactsKv: restore previous snapshot or delete first snapshot
		end
	else person account
		communityListings->>d1AppDb: preserve existing trust pin semantics
	end
	communityListings->>d1AppDb: insert activity event after successful trust decision
```

### Invariants

- Person accounts, including `@kentcdodds`, are never auto-trusted by username.
- Delisted listings remain unpublishable and therefore cannot enter the auto-trust path.
- Effective featured state remains `featured_at IS NOT NULL AND trusted`.
- Admin trust revocation remains available between platform publishes.
- Rejected platform publishes restore the prior public listing/snapshot state best-effort.

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-47663096-0b59-4bd6-bb5c-2edc1b9e9e69?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-47663096-0b59-4bd6-bb5c-2edc1b9e9e69&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Platform-owned community listings are automatically trusted after successful publication and republishing.
  - Featured platform listings remain visible in onboarding after republishing.
  - Administrators can revoke trust for any listing.

- **Bug Fixes**
  - Person-owned listings lose effective trust after republishing and require renewed admin review.
  - Featured person-owned listings leave onboarding until re-trusted.
  - Failed publications now roll back listing changes to prevent inconsistent states.

- **Documentation**
  - Updated publishing, trust, and featuring guidance to explain these behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->