### PR TITLE
Pause the homepage loop at the end and stop mobile re-pauses

### DIFF
--- a/packages/worker/client/routes/landing-loop-player.node.test.ts
+++ b/packages/worker/client/routes/landing-loop-player.node.test.ts
@@ -3,13 +3,14 @@ import { howKodyWorksTranscriptActs } from './how-kody-works-transcript.ts'
 import {
 	createLandingLoopPlayer,
 	flattenTranscriptActs,
+	landingLoopChatScrollShouldExplore,
 	landingLoopHoldMs,
 	landingLoopTeaser,
 	landingLoopTeaserBeatCount,
 	waitLandingLoopHold,
 } from './landing-loop-state.ts'
 
-test('homepage loop player pauses for hover and explore, then play resumes and loops', async () => {
+test('homepage loop player pauses for hover and explore, then play resumes and restarts at the end', async () => {
 	const beats = flattenTranscriptActs(howKodyWorksTranscriptActs)
 	expect(beats[0]).toMatchObject({
 		kind: 'act',
@@ -29,6 +30,35 @@ test('homepage loop player pauses for hover and explore, then play resumes and l
 		beats.some((beat) => beat.kind === 'line' && beat.line.role === 'tools'),
 	).toBe(true)
 
+	expect(
+		landingLoopChatScrollShouldExplore({
+			autoScrolling: true,
+			userDriven: true,
+			atBottom: false,
+		}),
+	).toBe(false)
+	expect(
+		landingLoopChatScrollShouldExplore({
+			autoScrolling: false,
+			userDriven: false,
+			atBottom: false,
+		}),
+	).toBe(false)
+	expect(
+		landingLoopChatScrollShouldExplore({
+			autoScrolling: false,
+			userDriven: true,
+			atBottom: true,
+		}),
+	).toBe(false)
+	expect(
+		landingLoopChatScrollShouldExplore({
+			autoScrolling: false,
+			userDriven: true,
+			atBottom: false,
+		}),
+	).toBe(true)
+
 	const player = createLandingLoopPlayer({
 		beatCount: beats.length,
 		reducedMotion: false,
@@ -36,11 +66,10 @@ test('homepage loop player pauses for hover and explore, then play resumes and l
 	expect(player.revealedCount).toBe(landingLoopTeaserBeatCount)
 	expect(player.isPaused()).toBe(false)
 	expect(landingLoopHoldMs(beats[0]!)).toBe(1100)
-	expect(landingLoopHoldMs('loop')).toBe(4000)
 
 	player.setHover(true)
 	expect(player.isPaused()).toBe(true)
-	expect(player.advance()).toEqual({ didAdvance: false, looped: false })
+	expect(player.advance()).toEqual({ didAdvance: false, ended: false })
 
 	player.setExplore(true)
 	player.setHover(false)
@@ -49,7 +78,7 @@ test('homepage loop player pauses for hover and explore, then play resumes and l
 
 	player.play()
 	expect(player.isPaused()).toBe(false)
-	expect(player.advance()).toEqual({ didAdvance: true, looped: false })
+	expect(player.advance()).toEqual({ didAdvance: true, ended: false })
 	expect(player.revealedCount).toBe(landingLoopTeaserBeatCount + 1)
 
 	player.setHover(true)
@@ -71,23 +100,43 @@ test('homepage loop player pauses for hover and explore, then play resumes and l
 	expect(player.isPaused()).toBe(true)
 	player.play()
 
+	player.pause()
+	expect(player.isPaused()).toBe(true)
+	player.play()
+	player.setFocus(true)
+	expect(player.isPaused()).toBe(false)
+	player.setExplore(true)
+	expect(player.pauseReasons()).toEqual(['explore'])
+	player.play()
+	expect(player.isPaused()).toBe(false)
+
 	const still = createLandingLoopPlayer({
 		beatCount: beats.length,
 		reducedMotion: true,
 	})
 	expect(still.revealedCount).toBe(beats.length)
 	expect(still.isPaused()).toBe(true)
-	expect(still.advance()).toEqual({ didAdvance: false, looped: false })
+	expect(still.advance()).toEqual({ didAdvance: false, ended: false })
 
-	const looper = createLandingLoopPlayer({
+	const finisher = createLandingLoopPlayer({
 		beatCount: 3,
 		reducedMotion: false,
 	})
-	expect(looper.revealedCount).toBe(landingLoopTeaserBeatCount)
-	expect(looper.advance()).toEqual({ didAdvance: true, looped: false })
-	expect(looper.revealedCount).toBe(3)
-	expect(looper.advance()).toEqual({ didAdvance: true, looped: true })
-	expect(looper.revealedCount).toBe(landingLoopTeaserBeatCount)
+	expect(finisher.revealedCount).toBe(landingLoopTeaserBeatCount)
+	expect(finisher.advance()).toEqual({ didAdvance: true, ended: false })
+	expect(finisher.revealedCount).toBe(3)
+	expect(finisher.advance()).toEqual({ didAdvance: false, ended: true })
+	expect(finisher.revealedCount).toBe(3)
+	expect(finisher.isEnded()).toBe(true)
+	expect(finisher.isPaused()).toBe(true)
+	finisher.play()
+	expect(finisher.isEnded()).toBe(true)
+	expect(finisher.isPaused()).toBe(true)
+	finisher.restart()
+	expect(finisher.isEnded()).toBe(false)
+	expect(finisher.isPaused()).toBe(false)
+	expect(finisher.revealedCount).toBe(landingLoopTeaserBeatCount)
+	expect(finisher.advance()).toEqual({ didAdvance: true, ended: false })
 
 	vi.useFakeTimers()
 	try {

--- a/packages/worker/client/routes/landing-loop-player.tsx
+++ b/packages/worker/client/routes/landing-loop-player.tsx
@@ -11,6 +11,7 @@ import { type TranscriptLine } from './interactive-guide-transcript.ts'
 import {
 	createLandingLoopPlayer,
 	flattenTranscriptActs,
+	landingLoopChatScrollShouldExplore,
 	landingLoopHoldMs,
 	landingLoopTeaser,
 	waitLandingLoopHold,
@@ -25,16 +26,18 @@ type LoopLineRenderer = (line: TranscriptLine) => RemixNode
  * out of the marketing entry. Shiki prefetches after window `load` so
  * it does not block first paint or the first beats. Hover/focus (fine
  * pointers) and explore (scroll up or open a tool) pause the autoplay;
- * Play scrolls to the latest beat and continues.
+ * Play scrolls to the latest beat and continues. The last beat pauses
+ * and offers Restart instead of looping.
  */
 export function LandingLoopPlayer(handle: Handle) {
 	let beats: Array<LandingLoopBeat> | null = null
 	let renderLine: LoopLineRenderer | null = null
 	let player = createLandingLoopPlayer({ beatCount: 1, reducedMotion: false })
 	let reducedMotion = false
-	let hoverPauses = false
+	let finePointerPauses = false
 	let chatEl: HTMLElement | null = null
 	let autoScrolling = false
+	let chatUserDriven = false
 	let playGeneration = 0
 	let loadStarted = false
 	let loopEl: HTMLElement | null = null
@@ -47,7 +50,7 @@ export function LandingLoopPlayer(handle: Handle) {
 		)
 	}
 
-	function canHoverPause() {
+	function canFinePointerPause() {
 		return (
 			typeof matchMedia === 'function' &&
 			matchMedia('(hover: hover) and (pointer: fine)').matches
@@ -81,7 +84,7 @@ export function LandingLoopPlayer(handle: Handle) {
 			beats = flattenTranscriptActs(transcript.howKodyWorksTranscriptActs)
 			renderLine = walkthrough.renderInteractiveGuideLine
 			reducedMotion = prefersReducedMotion()
-			hoverPauses = canHoverPause()
+			finePointerPauses = canFinePointerPause()
 			player = createLandingLoopPlayer({
 				beatCount: beats.length,
 				reducedMotion,
@@ -95,18 +98,22 @@ export function LandingLoopPlayer(handle: Handle) {
 		}
 	}
 
+	function markAutoScroll() {
+		autoScrolling = true
+		const done = () => {
+			autoScrolling = false
+		}
+		chatEl?.addEventListener('scrollend', done, { once: true })
+		window.setTimeout(done, 800)
+	}
+
 	function scrollChatToBottom() {
 		if (!chatEl) return
-		autoScrolling = true
+		markAutoScroll()
 		chatEl.scrollTo({
 			top: chatEl.scrollHeight,
 			behavior: reducedMotion ? 'auto' : 'smooth',
 		})
-		const done = () => {
-			autoScrolling = false
-		}
-		chatEl.addEventListener('scrollend', done, { once: true })
-		window.setTimeout(done, 480)
 	}
 
 	function startPlayLoop() {
@@ -120,12 +127,8 @@ export function LandingLoopPlayer(handle: Handle) {
 				if (!currentBeats || currentBeats.length === 0) return
 				const current = currentBeats[player.revealedCount - 1]
 				if (!current) return
-				const hold =
-					player.revealedCount >= currentBeats.length
-						? landingLoopHoldMs('loop')
-						: landingLoopHoldMs(current)
 				const finished = await waitLandingLoopHold({
-					ms: hold,
+					ms: landingLoopHoldMs(current),
 					isPaused: () => player.isPaused(),
 					subscribe: player.subscribe,
 					signal,
@@ -134,19 +137,37 @@ export function LandingLoopPlayer(handle: Handle) {
 					return
 				}
 				if (player.isPaused()) continue
-				player.advance()
+				const step = player.advance()
 				await handle.update()
 				if (signal.aborted || generation !== playGeneration) return
+				if (step.ended) continue
 				scrollChatToBottom()
 			}
 		})()
 	}
 
 	function playFromHere() {
+		chatUserDriven = false
 		player.play()
 		handle.update()
+		startPlayLoop()
 		handle.queueTask(() => {
 			scrollChatToBottom()
+		})
+	}
+
+	function restartFromStart() {
+		chatUserDriven = false
+		player.restart()
+		handle.update()
+		startPlayLoop()
+		handle.queueTask(() => {
+			if (!chatEl) return
+			markAutoScroll()
+			chatEl.scrollTo({
+				top: 0,
+				behavior: reducedMotion ? 'auto' : 'smooth',
+			})
 		})
 	}
 
@@ -160,6 +181,7 @@ export function LandingLoopPlayer(handle: Handle) {
 		const visibleBeats = beats?.slice(0, player.revealedCount) ?? null
 		const lineRenderer = renderLine
 		const loaded = visibleBeats != null && lineRenderer != null
+		const ended = loaded && player.isEnded() && !reducedMotion
 		const userPaused =
 			loaded && player.pauseReasons().some((reason) => reason !== 'offscreen')
 		const paused = userPaused && !reducedMotion
@@ -170,15 +192,16 @@ export function LandingLoopPlayer(handle: Handle) {
 				class="landing-loop"
 				data-paused={paused ? 'true' : undefined}
 				data-playing={playing ? 'true' : undefined}
+				data-ended={ended ? 'true' : undefined}
 				aria-label="Factory loop conversation"
 				mix={[
 					on('pointerenter', () => {
-						if (!hoverPauses) return
+						if (!finePointerPauses) return
 						player.setHover(true)
 						handle.update()
 					}),
 					on('pointerleave', () => {
-						if (!hoverPauses) return
+						if (!finePointerPauses) return
 						player.setHover(false)
 						handle.update()
 					}),
@@ -224,36 +247,47 @@ export function LandingLoopPlayer(handle: Handle) {
 						<span class="landing-loop-status-dot"></span>
 						{reducedMotion
 							? 'The loop'
-							: paused
-								? 'Paused'
-								: loaded
-									? 'Playing'
-									: 'The loop'}
+							: ended
+								? 'The loop'
+								: paused
+									? 'Paused'
+									: loaded
+										? 'Playing'
+										: 'The loop'}
 					</p>
 					{reducedMotion || !loaded || !(playing || paused) ? null : (
 						<button
 							type="button"
 							class="landing-loop-toggle"
 							mix={on('click', () => {
-								if (player.isPaused()) playFromHere()
+								if (player.isEnded()) restartFromStart()
+								else if (player.isPaused()) playFromHere()
 								else {
 									player.pause()
 									handle.update()
 								}
 							})}
 						>
-							{paused ? 'Play' : 'Pause'}
+							{ended ? 'Restart' : paused ? 'Play' : 'Pause'}
 						</button>
 					)}
 				</div>
 				<div
 					class="landing-loop-chat"
 					mix={[
+						on('pointerdown', () => {
+							chatUserDriven = true
+						}),
+						on('wheel', () => {
+							chatUserDriven = true
+						}),
 						on('focusin', () => {
+							if (!finePointerPauses) return
 							player.setFocus(true)
 							handle.update()
 						}),
 						on('focusout', (event) => {
+							if (!finePointerPauses) return
 							const next = event.relatedTarget
 							if (
 								next instanceof Node &&
@@ -266,12 +300,20 @@ export function LandingLoopPlayer(handle: Handle) {
 							handle.update()
 						}),
 						on('scroll', () => {
-							if (!chatEl || autoScrolling) return
+							if (!chatEl) return
 							const slack = 28
 							const atBottom =
 								chatEl.scrollHeight - chatEl.scrollTop - chatEl.clientHeight <=
 								slack
-							if (atBottom) return
+							if (
+								!landingLoopChatScrollShouldExplore({
+									autoScrolling,
+									userDriven: chatUserDriven,
+									atBottom,
+								})
+							) {
+								return
+							}
 							player.setExplore(true)
 							handle.update()
 						}),

--- a/packages/worker/client/routes/landing-loop-state.ts
+++ b/packages/worker/client/routes/landing-loop-state.ts
@@ -18,6 +18,7 @@ export type LandingLoopPauseReason =
 	| 'explore'
 	| 'offscreen'
 	| 'manual'
+	| 'ended'
 
 export type LandingLoopBeat =
 	| {
@@ -34,7 +35,7 @@ export type LandingLoopBeat =
 
 export type LandingLoopAdvance = {
 	didAdvance: boolean
-	looped: boolean
+	ended: boolean
 }
 
 export function flattenTranscriptActs(
@@ -55,8 +56,15 @@ export function flattenTranscriptActs(
 	return beats
 }
 
-export function landingLoopHoldMs(beat: LandingLoopBeat | 'loop'): number {
-	if (beat === 'loop') return 4000
+export function landingLoopChatScrollShouldExplore(input: {
+	autoScrolling: boolean
+	userDriven: boolean
+	atBottom: boolean
+}) {
+	return !input.autoScrolling && input.userDriven && !input.atBottom
+}
+
+export function landingLoopHoldMs(beat: LandingLoopBeat): number {
 	if (beat.kind === 'act') return 1100
 	switch (beat.line.role) {
 		case 'user':
@@ -97,6 +105,14 @@ export function createLandingLoopPlayer(input: {
 		else reasons.delete(reason)
 		if (had === on) return
 		emit()
+	}
+
+	function clearPlayableReasons() {
+		ignorePointerPause = true
+		reasons.delete('explore')
+		reasons.delete('manual')
+		reasons.delete('hover')
+		reasons.delete('focus')
 	}
 
 	return {
@@ -141,27 +157,37 @@ export function createLandingLoopPlayer(input: {
 			ignorePointerPause = false
 			setReason('manual', true)
 		},
+		end() {
+			setReason('ended', true)
+		},
+		isEnded() {
+			return reasons.has('ended')
+		},
 		play() {
-			const wasPointerPaused = reasons.has('hover') || reasons.has('focus')
-			if (wasPointerPaused) ignorePointerPause = true
-			reasons.delete('explore')
-			reasons.delete('manual')
-			reasons.delete('hover')
-			reasons.delete('focus')
+			// Always ignore the hover/focus that follows a Play tap. Mobile
+			// often focuses the scrollable chat right after that click.
+			clearPlayableReasons()
+			emit()
+		},
+		restart() {
+			revealedCount = input.reducedMotion
+				? input.beatCount
+				: Math.min(landingLoopTeaserBeatCount, input.beatCount)
+			clearPlayableReasons()
+			reasons.delete('ended')
 			emit()
 		},
 		advance(): LandingLoopAdvance {
 			if (isPaused() || input.beatCount === 0) {
-				return { didAdvance: false, looped: false }
+				return { didAdvance: false, ended: reasons.has('ended') }
 			}
 			if (revealedCount >= input.beatCount) {
-				revealedCount = Math.min(landingLoopTeaserBeatCount, input.beatCount)
-				emit()
-				return { didAdvance: true, looped: true }
+				setReason('ended', true)
+				return { didAdvance: false, ended: true }
 			}
 			revealedCount += 1
 			emit()
-			return { didAdvance: true, looped: false }
+			return { didAdvance: true, ended: false }
 		},
 	}
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Keep the homepage factory conversation from immediately pausing again after Play on mobile, and stop at the last beat with a Restart control instead of looping.

## Summary

- Play always ignores leftover hover/focus, and chat scroll only pauses when the user is actually dragging or wheeling the pane — not after the programmatic scroll-to-bottom that follows Play.
- Fine-pointer hover/focus pause stays desktop-only. Coarse pointers no longer treat tap-focus as a pause.
- After the last beat’s hold, autoplay ends. The toggle becomes **Restart** and resets to the teaser.
- Unit coverage for the scroll gate, post-play focus ignore, end, and restart.

## Testing

- `npx vitest run packages/worker/client/routes/landing-loop-player.node.test.ts`

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `b50239a8` · **Head:** `53ce38b3`

**Classification:** composes — no primitives added or changed; this PR adjusts homepage player pause/end behavior inside existing `app-ui`.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `app-ui` | surfaces | composes — homepage loop pause, end, and restart |

### Change flow

Play ignores leftover mobile focus/scroll; the last beat ends autoplay and offers Restart.

```mermaid
stateDiagram-v2
	[*] --> Playing: load near viewport
	Playing --> Paused: Pause or user-driven chat explore
	Paused --> Playing: Play ignores leftover focus and programmatic scroll
	Playing --> Ended: last beat hold then end
	Ended --> Playing: Restart resets to teaser
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-04fe5c14-799f-46f2-8fb4-bfaf4693532e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-04fe5c14-799f-46f2-8fb4-bfaf4693532e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Landing animations now stop at the final beat instead of looping indefinitely.
  * Added clear ended-state behavior with Restart, Play, and Pause controls.
  * Restarting returns the animation to the beginning and resets chat scrolling.
  * Improved chat-scroll handling to distinguish automatic scrolling from user exploration.
  * Added pause behavior for pointer hover, focus, and user-driven scrolling.

* **Accessibility**
  * Updated status and accessibility information to reflect when the animation has ended.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->