### PR TITLE
Allow safe platform-doc invoke codemods

### DIFF
--- a/docs/contributing/package-codemods.md
+++ b/docs/contributing/package-codemods.md
@@ -223,9 +223,9 @@ API to an explicit owner-scoped specifier:
   The owner scope comes from the invoking package's `package.json.name`, which
   preserves the old API's caller-owned lookup.
 - Handles direct and optional `packages?.invoke` calls and preserves option
-  expressions and keyless/exactly-once behavior. Calls with only `kodyId`
-  become one-argument specifier calls; calls may omit `exportName` while
-  retaining any supported options.
+  expressions and keyless/exactly-once behavior. Calls with only `kodyId` become
+  one-argument specifier calls; calls may omit `exportName` while retaining any
+  supported options.
 - Rewrites complete examples in JavaScript/TypeScript Markdown fences and inline
   code spans. Untyped/unsupported fences, partial snippets, and matching prose
   remain unchanged with `needsManual`.

--- a/docs/contributing/package-codemods.md
+++ b/docs/contributing/package-codemods.md
@@ -223,17 +223,21 @@ API to an explicit owner-scoped specifier:
   The owner scope comes from the invoking package's `package.json.name`, which
   preserves the old API's caller-owned lookup.
 - Handles direct and optional `packages?.invoke` calls and preserves option
-  expressions and keyless/exactly-once behavior.
+  expressions and keyless/exactly-once behavior. Calls with only `kodyId`
+  become one-argument specifier calls; calls may omit `exportName` while
+  retaining any supported options.
 - Rewrites complete examples in JavaScript/TypeScript Markdown fences and inline
   code spans. Untyped/unsupported fences, partial snippets, and matching prose
   remain unchanged with `needsManual`.
+- Applies those safe Markdown rewrites to platform-owned package documentation,
+  using the package's explicit platform scope.
 - Leaves already string-first calls unchanged and is idempotent.
 - Emits `needsManual` for immutable `packageId` targets, dynamic or indirect
   input objects, computed properties, spreads, comments in the removed field,
   parse failures, and manifests without a valid scoped package name.
-- Emits `needsManual` for platform-owned package source: its old bare-id lookup
-  follows the runtime caller, which cannot be replaced by the source package's
-  platform scope without changing behavior.
+- Emits file-level `needsManual` findings for platform-owned runtime source: its
+  old bare-id lookup follows the runtime caller, which cannot be replaced by the
+  source package's platform scope without changing behavior.
 - Does not enforce removal of the object overload; that API remains supported
   for compatibility after fleet migration.
 

--- a/docs/contributing/package-codemods.md
+++ b/docs/contributing/package-codemods.md
@@ -223,18 +223,20 @@ API to an explicit owner-scoped specifier:
   The owner scope comes from the invoking package's `package.json.name`, which
   preserves the old API's caller-owned lookup.
 - Handles direct and optional `packages?.invoke` calls and preserves option
-  expressions and keyless/exactly-once behavior. Calls with only `kodyId` become
-  one-argument specifier calls; calls may omit `exportName` while retaining any
-  supported options.
+  expressions and keyless/exactly-once behavior.
 - Rewrites complete examples in JavaScript/TypeScript Markdown fences and inline
   code spans. Untyped/unsupported fences, partial snippets, and matching prose
   remain unchanged with `needsManual`.
 - Applies those safe Markdown rewrites to platform-owned package documentation,
-  using the package's explicit platform scope.
+  using the package's explicit platform scope. Documentation for `@kody/notify`,
+  `@kody/stash`, and `@kody/personal-capture` remains manual because examples
+  must use the installed user-fork owner to preserve `packageStorage()`
+  semantics.
 - Leaves already string-first calls unchanged and is idempotent.
 - Emits `needsManual` for immutable `packageId` targets, dynamic or indirect
-  input objects, computed properties, spreads, comments in the removed field,
-  parse failures, and manifests without a valid scoped package name.
+  input objects, calls without `exportName`, computed properties, spreads,
+  comments in the removed field, parse failures, and manifests without a valid
+  scoped package name.
 - Emits file-level `needsManual` findings for platform-owned runtime source: its
   old bare-id lookup follows the runtime caller, which cannot be replaced by the
   source package's platform scope without changing behavior.

--- a/packages/worker/src/package-codemods/codemods/0006-invoke-object-to-specifier.node.test.ts
+++ b/packages/worker/src/package-codemods/codemods/0006-invoke-object-to-specifier.node.test.ts
@@ -29,7 +29,9 @@ test('0006 rewrites safe object-only invokes to owner-scoped string-first calls'
 			'export default async function run(event) {',
 			"\tconst direct = await packages.invoke({ kodyId: 'github', exportName: './request', params: { event } })",
 			"\tconst optional = await packages?.invoke({ exportName: '.', idempotencyKey: event.id, kodyId: 'inbox' })",
-			'\treturn { direct, optional }',
+			"\tconst defaultExport = await packages.invoke({ kodyId: 'calendar' })",
+			"\tconst paramsOnly = await packages.invoke({ params: { event }, kodyId: 'notify' })",
+			'\treturn { direct, optional, defaultExport, paramsOnly }',
 			'}',
 			'',
 		].join('\n'),
@@ -57,6 +59,12 @@ test('0006 rewrites safe object-only invokes to owner-scoped string-first calls'
 	)
 	expect(result.files['index.ts']).toContain(
 		'packages?.invoke("kody:@kentcdodds/inbox", { exportName:',
+	)
+	expect(result.files['index.ts']).toContain(
+		'packages.invoke("kody:@kentcdodds/calendar")',
+	)
+	expect(result.files['index.ts']).toContain(
+		'packages.invoke("kody:@kentcdodds/notify", { params:',
 	)
 	expect(result.files['index.ts']).not.toContain("kodyId: '")
 	expect(result.files['already-migrated.ts']).toBe(files['already-migrated.ts'])
@@ -216,13 +224,35 @@ test('0006 requires a scoped manifest and is registered for admin runs', () => {
 		'package.json': manifest('@kody/demo'),
 		'index.ts':
 			"await packages.invoke({ kodyId: 'worker', exportName: './run' })\n",
+		'README.md': [
+			'# Usage',
+			'',
+			'```ts',
+			"await packages.invoke({ kodyId: 'github', params: {} })",
+			'```',
+			'',
+		].join('\n'),
 	}
+	expect(invokeObjectToSpecifierCodemod.detect(platformFiles)).toEqual([
+		{
+			path: 'index.ts',
+			message: expect.stringContaining('runtime caller'),
+		},
+		{
+			path: 'README.md',
+			message: expect.stringContaining('deprecated object-only'),
+		},
+	])
 	const platformResult = invokeObjectToSpecifierCodemod.transform(platformFiles)
-	expect(platformResult.changed).toBe(false)
-	expect(platformResult.files).toEqual(platformFiles)
+	expect(platformResult.changed).toBe(true)
+	expect(platformResult.changedPaths).toEqual(['README.md'])
+	expect(platformResult.files['index.ts']).toBe(platformFiles['index.ts'])
+	expect(platformResult.files['README.md']).toContain(
+		'packages.invoke("kody:@kody/github", { params: {} })',
+	)
 	expect(platformResult.needsManual).toEqual([
 		{
-			path: 'package.json',
+			path: 'index.ts',
 			message: expect.stringContaining('runtime caller'),
 		},
 	])

--- a/packages/worker/src/package-codemods/codemods/0006-invoke-object-to-specifier.node.test.ts
+++ b/packages/worker/src/package-codemods/codemods/0006-invoke-object-to-specifier.node.test.ts
@@ -29,9 +29,7 @@ test('0006 rewrites safe object-only invokes to owner-scoped string-first calls'
 			'export default async function run(event) {',
 			"\tconst direct = await packages.invoke({ kodyId: 'github', exportName: './request', params: { event } })",
 			"\tconst optional = await packages?.invoke({ exportName: '.', idempotencyKey: event.id, kodyId: 'inbox' })",
-			"\tconst defaultExport = await packages.invoke({ kodyId: 'calendar' })",
-			"\tconst paramsOnly = await packages.invoke({ params: { event }, kodyId: 'notify' })",
-			'\treturn { direct, optional, defaultExport, paramsOnly }',
+			'\treturn { direct, optional }',
 			'}',
 			'',
 		].join('\n'),
@@ -60,12 +58,6 @@ test('0006 rewrites safe object-only invokes to owner-scoped string-first calls'
 	expect(result.files['index.ts']).toContain(
 		'packages?.invoke("kody:@kentcdodds/inbox", { exportName:',
 	)
-	expect(result.files['index.ts']).toContain(
-		'packages.invoke("kody:@kentcdodds/calendar")',
-	)
-	expect(result.files['index.ts']).toContain(
-		'packages.invoke("kody:@kentcdodds/notify", { params:',
-	)
 	expect(result.files['index.ts']).not.toContain("kodyId: '")
 	expect(result.files['already-migrated.ts']).toBe(files['already-migrated.ts'])
 
@@ -85,6 +77,9 @@ test('0006 partially migrates safe files and reports ambiguous calls for review'
 			"await packages.invoke({ packageId: 'pkg-123', exportName: './run' })\n",
 		'dynamic.ts':
 			'await packages.invoke({ kodyId: targetId, exportName: exportName })\n',
+		'missing-export.ts': "await packages.invoke({ kodyId: 'worker' })\n",
+		'missing-export-options.ts':
+			"await packages.invoke({ kodyId: 'worker', params: {} })\n",
 		'variable.ts': 'await packages.invoke(input)\n',
 		'spread.ts':
 			"await packages.invoke({ kodyId: 'worker', exportName: './run', ...options })\n",
@@ -114,6 +109,14 @@ test('0006 partially migrates safe files and reports ambiguous calls for review'
 			message: expect.stringContaining('cannot be migrated safely'),
 		},
 		{
+			path: 'missing-export-options.ts',
+			message: expect.stringContaining('cannot be migrated safely'),
+		},
+		{
+			path: 'missing-export.ts',
+			message: expect.stringContaining('cannot be migrated safely'),
+		},
+		{
 			path: 'package-id.ts',
 			message: expect.stringContaining('cannot be migrated safely'),
 		},
@@ -128,6 +131,10 @@ test('0006 partially migrates safe files and reports ambiguous calls for review'
 	])
 	expect(result.files['package-id.ts']).toBe(files['package-id.ts'])
 	expect(result.files['dynamic.ts']).toBe(files['dynamic.ts'])
+	expect(result.files['missing-export.ts']).toBe(files['missing-export.ts'])
+	expect(result.files['missing-export-options.ts']).toBe(
+		files['missing-export-options.ts'],
+	)
 	expect(result.files['variable.ts']).toBe(files['variable.ts'])
 	expect(result.files['spread.ts']).toBe(files['spread.ts'])
 	expect(result.files['commented.ts']).toBe(files['commented.ts'])
@@ -256,6 +263,40 @@ test('0006 requires a scoped manifest and is registered for admin runs', () => {
 			message: expect.stringContaining('runtime caller'),
 		},
 	])
+
+	for (const packageName of [
+		'@kody/notify',
+		'@kody/personal-capture',
+		'@kody/stash',
+	]) {
+		const forkOwnedDocs = {
+			'package.json': manifest(packageName),
+			'README.md': [
+				'# Usage',
+				'',
+				'```ts',
+				"await packages.invoke({ kodyId: 'helper', exportName: './run', params: {} })",
+				'```',
+				'',
+			].join('\n'),
+		}
+		expect(invokeObjectToSpecifierCodemod.detect(forkOwnedDocs)).toEqual([
+			{
+				path: 'README.md',
+				message: expect.stringContaining('user-fork owner'),
+			},
+		])
+		const forkOwnedDocsResult =
+			invokeObjectToSpecifierCodemod.transform(forkOwnedDocs)
+		expect(forkOwnedDocsResult.changed).toBe(false)
+		expect(forkOwnedDocsResult.files).toEqual(forkOwnedDocs)
+		expect(forkOwnedDocsResult.needsManual).toEqual([
+			{
+				path: 'README.md',
+				message: expect.stringContaining('user-fork owner'),
+			},
+		])
+	}
 
 	const unrelated = {
 		'package.json': manifest(),

--- a/packages/worker/src/package-codemods/codemods/0006-invoke-object-to-specifier.node.test.ts
+++ b/packages/worker/src/package-codemods/codemods/0006-invoke-object-to-specifier.node.test.ts
@@ -235,7 +235,7 @@ test('0006 requires a scoped manifest and is registered for admin runs', () => {
 			'# Usage',
 			'',
 			'```ts',
-			"await packages.invoke({ kodyId: 'github', params: {} })",
+			"await packages.invoke({ kodyId: 'github', exportName: './request', params: {} })",
 			'```',
 			'',
 		].join('\n'),
@@ -255,7 +255,7 @@ test('0006 requires a scoped manifest and is registered for admin runs', () => {
 	expect(platformResult.changedPaths).toEqual(['README.md'])
 	expect(platformResult.files['index.ts']).toBe(platformFiles['index.ts'])
 	expect(platformResult.files['README.md']).toContain(
-		'packages.invoke("kody:@kody/github", { params: {} })',
+		'packages.invoke("kody:@kody/github", { exportName:',
 	)
 	expect(platformResult.needsManual).toEqual([
 		{

--- a/packages/worker/src/package-codemods/codemods/0006-invoke-object-to-specifier.ts
+++ b/packages/worker/src/package-codemods/codemods/0006-invoke-object-to-specifier.ts
@@ -17,6 +17,8 @@ const manifestScopeMessage =
 	'Package scope could not be read from package.json; migrate deprecated object-only `packages.invoke` calls manually.'
 const platformScopeMessage =
 	'Platform-owned runtime source uses deprecated object-only `packages.invoke`, whose target resolves against the runtime caller; migrate this call manually.'
+const platformForkDocsMessage =
+	'Platform-owned package documentation requires the installed user-fork owner to preserve packageStorage semantics; migrate this example manually.'
 const parseFailureMessage =
 	'File references `packages.invoke` but could not be parsed; migrate any deprecated object-only calls manually.'
 
@@ -40,6 +42,11 @@ const supportedOptionKeys = new Set([
 	'params',
 	'idempotencyKey',
 	'topic',
+])
+const platformForkDocumentationPackages = new Set([
+	'@kody/notify',
+	'@kody/personal-capture',
+	'@kody/stash',
 ])
 
 type AstNode = ModuleAstNode & {
@@ -90,7 +97,7 @@ function parseProgram(source: string): AstNode | null {
 	}
 }
 
-function readPackageScope(files: Record<string, string>): string | null {
+function readPackageName(files: Record<string, string>): string | null {
 	const source = files[packageManifestPath]
 	if (typeof source !== 'string') return null
 	try {
@@ -100,11 +107,18 @@ function readPackageScope(files: Record<string, string>): string | null {
 		}
 		const name = (parsed as Record<string, unknown>)['name']
 		if (typeof name !== 'string') return null
-		const match = /^@([^/\s]+)\/[^/\s]+$/.exec(name.trim())
-		return match?.[1] ? `@${match[1]}` : null
+		const trimmedName = name.trim()
+		return /^@[^/\s]+\/[^/\s]+$/.test(trimmedName) ? trimmedName : null
 	} catch {
 		return null
 	}
+}
+
+function readPackageScope(files: Record<string, string>): string | null {
+	const packageName = readPackageName(files)
+	if (!packageName) return null
+	const match = /^@([^/\s]+)\/[^/\s]+$/.exec(packageName)
+	return match?.[1] ? `@${match[1]}` : null
 }
 
 function isPlatformPackageScope(scope: string) {
@@ -237,24 +251,7 @@ function classifyObjectCall(input: {
 	) {
 		return null
 	}
-	if (properties.length === 1) {
-		if (
-			typeof input.objectNode.start !== 'number' ||
-			typeof input.objectNode.end !== 'number'
-		) {
-			return null
-		}
-		const objectSource = input.source.slice(
-			input.objectNode.start,
-			input.objectNode.end,
-		)
-		if (objectSource.includes('//') || objectSource.includes('/*')) return null
-		return {
-			start: input.objectNode.start,
-			end: input.objectNode.end,
-			replacement: JSON.stringify(`kody:${input.scope}/${kodyId}`),
-		}
-	}
+	if (!namedProperties.some((entry) => entry.name === 'exportName')) return null
 	const optionsSource = buildOptionsSource({
 		source: input.source,
 		objectNode: input.objectNode,
@@ -515,10 +512,15 @@ function detect(files: Record<string, string>): Array<PackageCodemodFinding> {
 	}
 	const scope = readPackageScope(files)
 	if (scope && isPlatformPackageScope(scope)) {
+		const packageNeedsForkOwner = platformForkDocumentationPackages.has(
+			readPackageName(files) ?? '',
+		)
 		return classifications.map((classification) => ({
 			path: classification.path,
 			message: markdownFilePattern.test(classification.path)
-				? (classification.manualMessage ?? rewriteDetectMessage)
+				? packageNeedsForkOwner
+					? platformForkDocsMessage
+					: (classification.manualMessage ?? rewriteDetectMessage)
 				: platformScopeMessage,
 		}))
 	}
@@ -565,10 +567,24 @@ function transform(
 	}
 	const scope = readPackageScope(files)
 	const platformScope = scope != null && isPlatformPackageScope(scope)
+	const packageNeedsForkOwner = platformForkDocumentationPackages.has(
+		readPackageName(files) ?? '',
+	)
 	const nextFiles = { ...files }
 	const changedPaths: Array<string> = []
 	const needsManual: Array<PackageCodemodFinding> = []
 	for (const classification of classifications) {
+		if (
+			platformScope &&
+			packageNeedsForkOwner &&
+			markdownFilePattern.test(classification.path)
+		) {
+			needsManual.push({
+				path: classification.path,
+				message: platformForkDocsMessage,
+			})
+			continue
+		}
 		if (platformScope && !markdownFilePattern.test(classification.path)) {
 			needsManual.push({
 				path: classification.path,

--- a/packages/worker/src/package-codemods/codemods/0006-invoke-object-to-specifier.ts
+++ b/packages/worker/src/package-codemods/codemods/0006-invoke-object-to-specifier.ts
@@ -16,7 +16,7 @@ const manualRewriteMessage =
 const manifestScopeMessage =
 	'Package scope could not be read from package.json; migrate deprecated object-only `packages.invoke` calls manually.'
 const platformScopeMessage =
-	'Package is owned by a platform scope; deprecated object-only `packages.invoke` resolves against the runtime caller, so its target owner must be migrated manually.'
+	'Platform-owned runtime source uses deprecated object-only `packages.invoke`, whose target resolves against the runtime caller; migrate this call manually.'
 const parseFailureMessage =
 	'File references `packages.invoke` but could not be parsed; migrate any deprecated object-only calls manually.'
 
@@ -225,7 +225,6 @@ function classifyObjectCall(input: {
 	) {
 		return null
 	}
-	if (!namedProperties.some((entry) => entry.name === 'exportName')) return null
 	const kodyIdProperty = kodyIdEntries[0]?.property
 	if (!kodyIdProperty) return null
 	const kodyId = readStringLiteral(
@@ -237,6 +236,24 @@ function classifyObjectCall(input: {
 		Array.from(kodyId).some((character) => /\s/.test(character))
 	) {
 		return null
+	}
+	if (properties.length === 1) {
+		if (
+			typeof input.objectNode.start !== 'number' ||
+			typeof input.objectNode.end !== 'number'
+		) {
+			return null
+		}
+		const objectSource = input.source.slice(
+			input.objectNode.start,
+			input.objectNode.end,
+		)
+		if (objectSource.includes('//') || objectSource.includes('/*')) return null
+		return {
+			start: input.objectNode.start,
+			end: input.objectNode.end,
+			replacement: JSON.stringify(`kody:${input.scope}/${kodyId}`),
+		}
 	}
 	const optionsSource = buildOptionsSource({
 		source: input.source,
@@ -498,7 +515,12 @@ function detect(files: Record<string, string>): Array<PackageCodemodFinding> {
 	}
 	const scope = readPackageScope(files)
 	if (scope && isPlatformPackageScope(scope)) {
-		return [{ path: packageManifestPath, message: platformScopeMessage }]
+		return classifications.map((classification) => ({
+			path: classification.path,
+			message: markdownFilePattern.test(classification.path)
+				? (classification.manualMessage ?? rewriteDetectMessage)
+				: platformScopeMessage,
+		}))
 	}
 	return classifications.map((classification) => ({
 		path: classification.path,
@@ -542,20 +564,21 @@ function transform(
 		}
 	}
 	const scope = readPackageScope(files)
-	if (scope && isPlatformPackageScope(scope)) {
-		return {
-			files: { ...files },
-			changed: false,
-			changedPaths: [],
-			needsManual: [
-				{ path: packageManifestPath, message: platformScopeMessage },
-			],
-		}
-	}
+	const platformScope = scope != null && isPlatformPackageScope(scope)
 	const nextFiles = { ...files }
 	const changedPaths: Array<string> = []
 	const needsManual: Array<PackageCodemodFinding> = []
 	for (const classification of classifications) {
+		if (
+			platformScope &&
+			!markdownFilePattern.test(classification.path)
+		) {
+			needsManual.push({
+				path: classification.path,
+				message: platformScopeMessage,
+			})
+			continue
+		}
 		if (classification.manualMessage) {
 			needsManual.push({
 				path: classification.path,

--- a/packages/worker/src/package-codemods/codemods/0006-invoke-object-to-specifier.ts
+++ b/packages/worker/src/package-codemods/codemods/0006-invoke-object-to-specifier.ts
@@ -569,10 +569,7 @@ function transform(
 	const changedPaths: Array<string> = []
 	const needsManual: Array<PackageCodemodFinding> = []
 	for (const classification of classifications) {
-		if (
-			platformScope &&
-			!markdownFilePattern.test(classification.path)
-		) {
+		if (platformScope && !markdownFilePattern.test(classification.path)) {
 			needsManual.push({
 				path: classification.path,
 				message: platformScopeMessage,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Let operators safely rescan legacy `packages.invoke` documentation in platform-owned packages without changing runtime lookup or caller-owned `packageStorage()` semantics.

## Summary

- Rewrites safe JavaScript/TypeScript examples in ordinary platform-owned Markdown using the package's explicit platform scope.
- Continues to refuse all platform-owned runtime source because its legacy bare-id target follows the runtime caller.
- Conservatively leaves `@kody/notify`, `@kody/stash`, and `@kody/personal-capture` documentation manual because those examples require the installed user-fork owner.
- Continues to refuse calls without `exportName`, matching both deployed legacy and package-only string parsers.
- Reports platform findings at affected files and documents the narrowed safety boundary.

## Testing

- Focused codemod fixture suite: 4/4 passed, covering ordinary platform Markdown, all three user-fork-owned documentation exceptions, platform runtime refusal, missing-`exportName` refusal, and idempotence.
- `npm run format:check`: passed; `npm run lint`: passed with four unrelated existing warnings.
- `npm run validate`: run twice locally. Both attempts completed but unrelated local Cloudflare mock/MCP/E2E startup contention timed out under the concurrent gate; GitHub's isolated validation jobs all passed.
- PR CI: 12 terminal checks, 10 passed and 2 intentionally skipped; Static, Node, Workers, MCP, E2E, CodeRabbit, and Cursor Bugbot passed.
- Seeded preview at head `9f7c59e0`: origin/runtime/platform health passed; authenticated `/account/packages` rendered; `/admin/codemods` returned the expected non-admin `Forbidden` boundary. Preview intentionally has no seeded admin, so a live codemod operation was unavailable and no data was modified.
- Preview walkthrough: <a href="https://cursor.com/agents/bc-758c53d6-84bd-4b0f-a4c0-b13747dfda64/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpr_1681_preview_auth_boundaries.mp4"><img src="https://cursor.com/artifacts/c/art-4cfda76c-d559-4fcc-9366-e34a8285bad2" alt="pr_1681_preview_auth_boundaries.mp4" /></a>
- Production evidence (read-only): scan `77541f96-283d-4a3e-9e2d-acf6d36844bc` covered 295 published packages: 240 clean, 54 detected, 1 drift-skipped. It found 24 mechanically migratable person-owned packages, 3 ambiguous runtime source files, and 27 platform-owned packages hidden behind the prior package-level refusal. Follow-up audit identified `notify`, `stash`, and `personal-capture` as caller-fork-owned documentation. No production mutation was performed by this track.

## Conductor report

**STATUS:** shipped — squash-merged as `7759a72f`; [production deploy passed](https://github.com/kentcdodds/kody/actions/runs/32616925899).

- Production evidence: scan `77541f96-283d-4a3e-9e2d-acf6d36844bc`; 295 total / 240 clean / 54 detected / 1 drift-skipped. Audit proved three platform doc packages require user-fork ownership.
- Shipped support: safe Markdown code examples in ordinary platform-owned packages.
- Explicitly manual: all platform runtime source; `@kody/notify`, `@kody/stash`, and `@kody/personal-capture` docs; calls without `exportName`; `packageId`; dynamic/indirect inputs; computed properties; spreads; comments whose removal is ambiguous; parse failures; invalid manifest scope.
- Cleared gates: focused fixtures, authoritative CI, CodeRabbit and Cursor Bugbot review, seeded preview, merge, and production deploy.
- Remains: production operator may rescan with codemod `0006`; production operation is intentionally outside this code track.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `67e068cf` · **Head:** `9f7c59e0`

**Classification:** extends — opens a file-level platform documentation lane in the existing codemod while preserving runtime and caller-fork ownership boundaries.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `package-codemods` | assistant | extends — rewrites safe ordinary platform documentation while retaining explicit semantic refusals |

### Change flow

Codemod 0006 separates platform documentation from executable source, then excludes docs whose examples require the installed user fork.

```mermaid
flowchart TD
	Scan["package-codemods<br/>scan object-only invoke"] -->|"classify file and manifest owner"| Markdown{"Platform Markdown?"}
	Markdown -->|"no: platform runtime source"| ManualRuntime["Keep unchanged; file-level needsManual"]
	Markdown -->|"yes: notify, stash, or personal-capture"| ManualFork["Keep unchanged; require installed user-fork owner"]
	Markdown -->|"yes: ordinary platform docs with literal kodyId + exportName"| RewriteDocs["Rewrite explicit platform specifier"]
	Markdown -->|"ambiguous or missing exportName"| ManualShape["Keep unchanged; needsManual"]
```

### Before / after

| Before | After |
| --- | --- |
| Every platform-owned finding collapsed to `package.json` | Safe ordinary Markdown rewrites proceed; semantic exceptions stay manual at file paths |
| Runtime and docs shared one blanket refusal | Runtime remains fully refused; docs get a narrowly proven lane |

### Invariants

- Platform runtime source is not rewritten because legacy lookup follows the runtime caller.
- Fork-owned storage examples never point at the live platform package.
- Both input forms still require `exportName`; the runtime object overload remains available.
- No publication failure, telemetry, or production operation is introduced.

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-758c53d6-84bd-4b0f-a4c0-b13747dfda64?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-758c53d6-84bd-4b0f-a4c0-b13747dfda64&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Codemod transformations now support object-only calls containing a `kodyId`, including default-export and params-only cases.
  * Markdown examples in platform-owned packages can be updated automatically.
* **Bug Fixes**
  * Platform-owned runtime files are now identified individually for manual review instead of blocking processing for the entire package.
* **Documentation**
  * Updated guidance explains supported call patterns, safe Markdown rewrites, and runtime files requiring review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->