### PR TITLE
Recommend the latest Grok model in agent skills

### DIFF
--- a/.agents/skills/conduct/SKILL.md
+++ b/.agents/skills/conduct/SKILL.md
@@ -25,6 +25,7 @@ Do not spawn a one-agent "fleet."
 
 ## Defaults (override only if the user says so)
 
+- **Model.** Use the latest Grok model unless the user requests another.
 - **Escalate before fleet.** Analysis → multi-track program needs explicit
   approve: tracks, wall-clock, stop criteria, out-of-scope.
 - **Tracks implement by default.** Hand `orchestrate` only for clear parallel
@@ -113,11 +114,14 @@ review-only.
 
 ```javascript
 import { createAgent } from 'kody:@kentcdodds/cursor/agents'
+import { listModels } from 'kody:@kentcdodds/cursor/models'
 import { createRun } from 'kody:@kentcdodds/cursor/runs'
 
 export default async function main() {
+	const { items } = await listModels()
+	const latestGrok = items.find((item) => item.id.startsWith('grok-'))
 	const { agent } = await createAgent({
-		model: 'gpt-5.6-sol',
+		model: latestGrok.id,
 		repository: 'https://github.com/owner/repo',
 		ref: 'main',
 		name: 'track-short-name',

--- a/.agents/skills/orchestrate/SKILL.md
+++ b/.agents/skills/orchestrate/SKILL.md
@@ -18,6 +18,7 @@ optimized for cheap/fast execution.
 
 ## Defaults (override only if the user says so)
 
+- **Model.** Use the latest Grok model unless the user requests another.
 - **Prefer implement.** Fan out only when non-conflicting workstreams clearly
   beat one implementer. Sequential slices → implement (or one implementer).
 - **No orchestration theater.** Ban review → recheck → final → CI-watch chains
@@ -29,8 +30,8 @@ optimized for cheap/fast execution.
 ## Role
 
 1. Plan, delegate, integrate, ship. Bulk-code only when fan-out costs more.
-2. Frontier model orchestrates; cheap/fast models implement (prefer Grok 4.5 /
-   `composer-2.5-fast` for mechanical work).
+2. Frontier model orchestrates; cheap/fast models implement (prefer the latest
+   Grok model for mechanical work).
 3. Critical path first; parallelize non-conflicting files; serialize shared
    ones.
 4. **You do final QA.** Never declare done from sub-agent claims.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Default spawned Cursor Cloud agents and in-repo orchestrators to the latest Grok model instead of Fable or GPT, without pinning a version number that will go stale.

## Summary

- `conduct` and `orchestrate` skills now say **use the latest Grok model** unless the user requests another.
- The conduct spawn sketch resolves the current Grok id via `listModels` instead of pinning `gpt-5.6-sol`.
- The same wording is already saved in the `@kentcdodds/skills` package (`conduct`, `orchestrate`). That live-registry update is not in this git diff.

## Testing

- Confirmed the repo skills no longer mention `gpt-5.6-sol`, `Grok 4.5`, Fable, or `composer-2.5-fast`.
- Confirmed `@kentcdodds/skills` `conduct` / `orchestrate` now include "the latest Grok model" and no longer pin GPT.
- Local `npm run validate` passed (format, lint, typecheck, node/workers/mcp/e2e, docs, and dry-run builds).

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `67e068cf` · **Head:** `807dada6`

**Classification:** composes — no primitives added or changed; this PR only updates contributor skill markdown.

### Primitives touched

_None._ Classifier unmatched paths: `.agents/skills/conduct/SKILL.md`, `.agents/skills/orchestrate/SKILL.md`.

### Change flow

Conduct spawn sketches resolve a Grok model id at launch time instead of pinning GPT.

```mermaid
sequenceDiagram
	actor Conductor
	participant listModels as cursor/models
	participant createAgent as cursor/agents
	Conductor->>listModels: listModels()
	listModels-->>Conductor: first grok- id
	Conductor->>createAgent: createAgent({ model: latestGrok.id })
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5b4d41a5-045a-4e8e-8c4f-9ef28a71f4f4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5b4d41a5-045a-4e8e-8c4f-9ef28a71f4f4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated agent guidance to prefer the latest Grok model by default.
  * Added dynamic model resolution to the conduct workflow example.
  * Updated orchestration guidance for mechanical implementation tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->