### PR TITLE
Consume signed-in OAuth start bodies so e2e wrangler stays up

### DIFF
--- a/packages/worker/src/app/handlers/auth-provider.node.test.ts
+++ b/packages/worker/src/app/handlers/auth-provider.node.test.ts
@@ -861,10 +861,10 @@ test('JSON start mode returns the authorize URL for client-side navigation', asy
 	})
 })
 
-test('signed-out JSON start consumes the request body instead of abandoning a clone', async () => {
-	const { db } = createMigratedDb()
+test('JSON start consumes the request body for signed-out and signed-in requests', async () => {
+	const { sqlite, db } = createMigratedDb()
 	const env = createAppEnv(db)
-	const request = new Request('http://example.com/auth/github', {
+	const signedOutRequest = new Request('http://example.com/auth/github', {
 		method: 'POST',
 		headers: {
 			Accept: 'application/json',
@@ -873,14 +873,52 @@ test('signed-out JSON start consumes the request body instead of abandoning a cl
 		body: JSON.stringify({ website: '', turnstileToken: '' }),
 	})
 
-	expect(request.bodyUsed).toBe(false)
-	const response = await runHandler(
+	expect(signedOutRequest.bodyUsed).toBe(false)
+	const signedOutResponse = await runHandler(
 		createAuthProviderStartHandler(env),
-		request,
+		signedOutRequest,
 		{ provider: 'github' },
 	)
-	expect(response.status).toBe(200)
-	expect(request.bodyUsed).toBe(true)
+	expect(signedOutResponse.status).toBe(200)
+	expect(signedOutRequest.bodyUsed).toBe(true)
+
+	// Connect Google / Discord from /account posts the same JSON body while
+	// already signed in. Skipping the read left workerd with an unread body
+	// and killed wrangler mid social-login e2e (workers-sdk#14926).
+	await seedUser(sqlite, {
+		id: 21,
+		email: 'connector@example.com',
+		username: 'connector',
+	})
+	const sessionCookiePair = getCookiePair(
+		await createAuthCookie(
+			{
+				stableUserId: await createStableUserIdFromEmail(
+					'connector@example.com',
+				),
+				email: 'connector@example.com',
+				rememberMe: false,
+			},
+			false,
+		),
+	)
+	const signedInRequest = new Request('http://example.com/auth/google', {
+		method: 'POST',
+		headers: {
+			Accept: 'application/json',
+			'Content-Type': 'application/json',
+			Cookie: sessionCookiePair,
+		},
+		body: JSON.stringify({ website: '', turnstileToken: '' }),
+	})
+	expect(signedInRequest.bodyUsed).toBe(false)
+	const signedInResponse = await runHandler(
+		createAuthProviderStartHandler(env),
+		signedInRequest,
+		{ provider: 'google' },
+	)
+	expect(signedInResponse.status).toBe(200)
+	expect(signedInRequest.bodyUsed).toBe(true)
 })
 
 test('signed-in users link and disconnect providers from their account', async () => {

--- a/packages/worker/src/app/handlers/auth-provider.ts
+++ b/packages/worker/src/app/handlers/auth-provider.ts
@@ -208,16 +208,19 @@ export function createAuthProviderStartHandler(env: Env) {
 			const inviteCode = normalizeInviteCode(url.searchParams.get('inviteCode'))
 			const { session } = await readAuthSessionResult(request)
 
+			// Always consume the JSON start body. `request.clone().json()` tees
+			// it and leaves the original unread; workerd can then terminate
+			// the isolate ("Network connection lost"), and wrangler's
+			// ProxyController treats that as a fatal `wrangler dev` exit
+			// (workers-sdk#14926). Signed-in Connect-* from /account posts
+			// the same honeypot payload as signed-out Continue-with-*, so
+			// skipping the read here still leaked the unread body after
+			// oauth_connection_linked.
+			const body = (await request.json().catch(() => ({}))) as Record<
+				string,
+				unknown
+			>
 			if (!session) {
-				// Read this request once. `request.clone().json()` tees the
-				// body and leaves the original unread; workerd can then
-				// terminate the isolate ("Network connection lost"), and
-				// wrangler's ProxyController treats that as a fatal
-				// `wrangler dev` exit (workers-sdk#14926).
-				const body = (await request.json().catch(() => ({}))) as Record<
-					string,
-					unknown
-				>
 				const protection = await verifyPublicFormProtection({
 					env,
 					request,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop the daily social-login e2e flake where Playwright's webServer (`wrangler dev`) dies mid-suite with `Error inside ProxyWorker` / `Network connection lost` after a signed-in Connect Google or Connect Discord.

## Summary

#1655 already consumed the JSON body on **signed-out** `POST /auth/{provider}` so workerd would not kill the isolate over an unread teed body. The first-party UI still POSTs that same honeypot payload for **signed-in** Connect-* from `/account`, and the start handler skipped the read whenever a session existed.

Wrangler logs from [Validate #32593146372](https://github.com/kentcdodds/kody/actions/runs/32593146372/job/97079968932) (PR #1670 merge, which already contained #1655) show:

1. GitHub signup succeeds (`oauth_signup`).
2. Connect Google succeeds (`oauth_connection_linked`).
3. Immediately: `Network connection lost` → wrangler exits.
4. Playwright is then stuck on `/auth/discord/callback?...` until `toHaveURL` times out; remaining tests fail with `E2eWebServerDeadError`.
5. The CI one-retry also died the same way (after GitHub signup, before Google returned).

This PR always `request.json()`s the start body, and still runs Turnstile/honeypot only when signed out. A node-unit regression asserts `bodyUsed` for both signed-out Continue-with-* and signed-in Connect-*.

## Testing

- `npx vitest run --project node-unit packages/worker/src/app/handlers/auth-provider.node.test.ts` — 14 passed, including the new signed-in body consume case.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `768eabc7` · **Head:** `0448442e`

**Classification:** composes — no primitives added or changed; the start handler already consumed signed-out JSON bodies, and now consumes the same payload when a session is present.

### Primitives touched

| Primitive | Group | Impact |
| ------------ | -------- | --------------------------------------- |
| `app-sessions` | auth | composes — still skips Turnstile when signed in; only consumes the already-sent JSON start body |
| `app-ui` | surfaces | composes — node-unit regression only |

### Change flow

Signed-in Connect Google/Discord now drains the start POST body so workerd does not kill wrangler.

```mermaid
sequenceDiagram
	actor user as User
	participant appUi as app-ui
	participant appSessions as app-sessions
	user->>appUi: click Connect Google
	appUi->>appSessions: POST /auth/google JSON honeypot body
	appSessions->>appSessions: request.json() even when session exists
	appSessions-->>appUi: authorizeUrl
	appUi->>appSessions: GET /auth/google/callback
	appSessions-->>appUi: redirect /account?oauthLinked=google
```

### Invariants

Per-user isolation and session issuance are unchanged. Signed-in starts still skip public-form protection; they only consume the request body.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e3e25b2f-a79b-4957-a01e-c196c0b412ee?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e3e25b2f-a79b-4957-a01e-c196c0b412ee&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - OAuth sign-in and connection requests now consistently process submitted request data, whether or not the visitor is already signed in.
  - Improved reliability for authentication flows involving GitHub and Google providers.
- **Tests**
  - Expanded coverage for OAuth requests from both signed-out and signed-in states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->