### PR TITLE
Fix official platform packages failing user-secret access

### DIFF
--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -328,13 +328,12 @@ The schema is defined by migrations in `packages/worker/migrations/`:
   are derived at read time from `community_forks` / `community_stars`
 - `secret_buckets`: encrypted-secret ownership buckets scoped to `user`,
   `package`, or `session`. Package buckets bind directly to `saved_packages.id`;
-  package runtimes may use their own package secrets.   User secrets are
+  package runtimes may use their own package secrets. User secrets are
   auto-granted for read/use to self-authored packages (no `community_forks` row
   for that `saved_packages.id` + `userId`), live official platform packages
-  (caller-owned `saved_packages` miss falls back to
-  `findPlatformPackageByRef`; decision
-  [0014](../decisions/0014-platform-live-packages.md)), and adopted forks
-  (`community_forks.adopted_at` set via `community_fork_adopt`). Unadopted
+  (caller-owned `saved_packages` miss falls back to `findPlatformPackageByRef`;
+  decision [0014](../decisions/0014-platform-live-packages.md)), and adopted
+  forks (`community_forks.adopted_at` set via `community_fork_adopt`). Unadopted
   community forks (`community_forks.forked_package_id`, indexed in the squashed
   baseline) still require an explicit `allowed_packages` grant on every package
   read path. Updating or deleting a user secret from package code (`secret_set`

--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -328,9 +328,12 @@ The schema is defined by migrations in `packages/worker/migrations/`:
   are derived at read time from `community_forks` / `community_stars`
 - `secret_buckets`: encrypted-secret ownership buckets scoped to `user`,
   `package`, or `session`. Package buckets bind directly to `saved_packages.id`;
-  package runtimes may use their own package secrets. User secrets are
+  package runtimes may use their own package secrets.   User secrets are
   auto-granted for read/use to self-authored packages (no `community_forks` row
-  for that `saved_packages.id` + `userId`) and to adopted forks
+  for that `saved_packages.id` + `userId`), live official platform packages
+  (caller-owned `saved_packages` miss falls back to
+  `findPlatformPackageByRef`; decision
+  [0014](../decisions/0014-platform-live-packages.md)), and adopted forks
   (`community_forks.adopted_at` set via `community_fork_adopt`). Unadopted
   community forks (`community_forks.forked_package_id`, indexed in the squashed
   baseline) still require an explicit `allowed_packages` grant on every package

--- a/docs/guides/account-secret-setup.md
+++ b/docs/guides/account-secret-setup.md
@@ -60,9 +60,10 @@ so the user can paste immediately.
 
 ## Package approval URLs (after a package exists)
 
-Self-authored packages and adopted community forks (`community_fork_adopt`) can
-read and use the user's secrets without an `allowed_packages` grant; updating or
-deleting a user secret from package code still requires that grant. When an
+Self-authored packages, live official platform packages, and adopted community
+forks (`community_fork_adopt`) can read and use the user's secrets without an
+`allowed_packages` grant; updating or deleting a user secret from package code
+still requires that grant. When an
 **unadopted community-forked** package needs access to one or more **existing**
 user secrets, either adopt it after reviewing the source or send the user an
 approval link — do not ask them to recreate the secrets.

--- a/docs/guides/account-secret-setup.md
+++ b/docs/guides/account-secret-setup.md
@@ -63,10 +63,10 @@ so the user can paste immediately.
 Self-authored packages, live official platform packages, and adopted community
 forks (`community_fork_adopt`) can read and use the user's secrets without an
 `allowed_packages` grant; updating or deleting a user secret from package code
-still requires that grant. When an
-**unadopted community-forked** package needs access to one or more **existing**
-user secrets, either adopt it after reviewing the source or send the user an
-approval link — do not ask them to recreate the secrets.
+still requires that grant. When an **unadopted community-forked** package needs
+access to one or more **existing** user secrets, either adopt it after reviewing
+the source or send the user an approval link — do not ask them to recreate the
+secrets.
 
 - Single secret:
   `/account/secrets/user/{secretName}?package_id={savedPackageId}&package={kodyId}`

--- a/docs/guides/package-authoring.md
+++ b/docs/guides/package-authoring.md
@@ -147,9 +147,9 @@ When a package will use user-scoped secrets (`{{secret:name}}` placeholders or
 
 1. Ensure each secret exists (see `guide: "connect_secret"` /
    `guide: "secret_backed_integration"`).
-2. Self-authored packages (and community forks adopted with
-   `community_fork_adopt` after a real source review) get automatic read/use
-   access to user secrets (host approval still applies; `secret_set` /
+2. Self-authored packages, live official platform packages, and community forks
+   adopted with `community_fork_adopt` after a real source review get automatic
+   read/use access to user secrets (host approval still applies; `secret_set` /
    `secret_delete` still need an `allowed_packages` grant). After save/publish,
    read `pending_secret_package_approvals` from the tool result — it is non-null
    only for unadopted community forks.

--- a/docs/guides/providers/github.md
+++ b/docs/guides/providers/github.md
@@ -75,8 +75,8 @@ https://kody.codes/account/secrets/new?name=githubAccessToken&description=GitHub
 ```
 
 Approve the `api.github.com` host on the same page after saving. The name
-`githubAccessToken` is exactly what the official `@kody/github` community
-package reads by default, so a fork of it works without renaming anything.
+`githubAccessToken` is exactly what live `kody:@kody/github` reads by default,
+so no rename is needed.
 
 ## Lane C: bring-your-own OAuth App
 
@@ -185,27 +185,24 @@ per-capability.
 - Token exchange fails in Lane C: the client secret is required even with PKCE.
   Regenerate the secret and reconnect.
 
-## Fork the official package and verify
+## Use the official package and verify
 
-A saved token or integration is credentials only. Finish by forking the trusted
-official package so day-to-day work goes through maintained helpers instead of
-hand-rolled API calls:
+A saved token or integration is credentials only. Finish by calling the live
+official helpers so day-to-day work goes through maintained code instead of
+hand-rolled API calls. Official `@kody/*` packages resolve in the caller runtime
+against the caller's secrets — do **not** fork them just to use them. Fork only
+when you need to customize the source.
 
-1. Find the listing with `community_search({ query: 'github' })` — the trusted
-   `@kody/github` listing wraps REST, GraphQL, pagination, and PR helpers.
-2. Fork it with `community_fork` (or click **Install** on the listing page). The
-   fork lands in your account under your own scope.
-3. Check the fork's README **Required setup**: its default `bot` account reads
-   the `githubAccessToken` secret — the exact name Lane B saved, so no
-   adaptation is needed for the PAT lane. For OAuth (Lane A/C), remap the
-   account to the `github` integration name when the package supports that.
-   Remove or remap the extra `kent`/`explicit-only` account aliases if you do
-   not want them.
-4. Verify the package against your credentials by running its identity smoke
-   test from `execute`:
+1. Search for `@kody/github` (or import `kody:@kody/github` directly). It wraps
+   REST, GraphQL, pagination, and PR helpers.
+2. Check its README **Required setup**: the default `bot` account reads the
+   `githubAccessToken` secret — the exact name Lane B saved, so no adaptation is
+   needed for the PAT lane. For OAuth (Lane A/C), remap the account to the
+   `github` integration name when the package supports that.
+3. Verify the live package against your credentials from `execute`:
 
 ```ts
-import getViewer from 'kody:@<your-username>/github/get-viewer'
+import getViewer from 'kody:@kody/github/get-viewer'
 
 export default async function main() {
 	return getViewer({ account: 'bot' })
@@ -213,4 +210,4 @@ export default async function main() {
 ```
 
 A successful response returns the GitHub login your token resolves to — proving
-the fork, the secret, and the host approval all line up.
+the live package, the secret, and the host approval all line up.

--- a/docs/guides/providers/google.md
+++ b/docs/guides/providers/google.md
@@ -193,24 +193,24 @@ reconnects use `/connect/oauth?provider=google` and the connect UI scope menu.
 - `403` from Gmail with a Calendar-only token: scopes are per-connection.
   Reconnect with the needed Gmail scope (BYO for inbox read).
 
-## Fork the official package and verify
+## Use the official package and verify
 
-A saved integration is auth credentials only. Finish by forking the trusted
-official package so day-to-day work goes through maintained Gmail, Calendar, and
-Drive helpers instead of raw `createAuthenticatedFetch` calls:
+A saved integration is auth credentials only. Finish by calling the live
+official helpers so day-to-day work goes through maintained Gmail, Calendar, and
+Drive helpers instead of raw `createAuthenticatedFetch` calls. Official
+`@kody/*` packages resolve in the caller runtime against the caller's secrets —
+do **not** fork them just to use them. Fork only when you need to customize the
+source.
 
-1. Find the listing with `community_search({ query: 'google' })` — the trusted
-   `@kody/google` listing covers Gmail, Calendar, Drive, People, and YouTube.
-2. Fork it with `community_fork` (or click **Install** on the listing page).
-3. Check the fork's README **Required setup**: the `personal` account alias maps
-   to an integration named `google` — the default name this guide's connect link
-   uses, so the primary lane needs no adaptation. Trim the other account aliases
-   (`business`, `youtube-*`) unless you connect those too.
-4. Verify the package against your integration with its built-in smoke test from
-   `execute`:
+1. Search for `@kody/google` (or import `kody:@kody/google` directly). It covers
+   Gmail, Calendar, Drive, People, and YouTube.
+2. Check its README **Required setup**: the `personal` account alias maps to an
+   integration named `google` — the default name this guide's connect link uses,
+   so the primary lane needs no adaptation.
+3. Verify the live package against your integration from `execute`:
 
 ```ts
-import { smokeTest } from 'kody:@<your-username>/google'
+import { smokeTest } from 'kody:@kody/google'
 
 export default async function main() {
 	return smokeTest({ account: 'personal' })
@@ -218,4 +218,4 @@ export default async function main() {
 ```
 
 A successful response returns the Google profile your integration resolves to —
-proving the fork, the OAuth tokens, and the host approvals all line up.
+proving the live package, the OAuth tokens, and the host approvals all line up.

--- a/docs/guides/providers/notion.md
+++ b/docs/guides/providers/notion.md
@@ -158,24 +158,23 @@ internal connection, edit the page's **Connections** menu.
 - Installation scope wrong on a public connection: it cannot be edited after
   creation; create a new public connection instead.
 
-## Fork the official package and verify
+## Use the official package and verify
 
-A saved integration is auth credentials only. Finish by forking the trusted
-official package so day-to-day work goes through maintained search, read, query,
-and confirmed-write helpers:
+A saved integration is auth credentials only. Finish by calling the live
+official helpers so day-to-day work goes through maintained search, read, query,
+and confirmed-write helpers. Official `@kody/*` packages resolve in the caller
+runtime against the caller's secrets — do **not** fork them just to use them.
+Fork only when you need to customize the source.
 
-1. Find the listing with `community_search({ query: 'notion' })` — the trusted
-   `@kody/notion` listing wraps pages, databases, and a generic request escape
-   hatch.
-2. Fork it with `community_fork` (or click **Install** on the listing page).
-3. Check the fork's README **Required setup**: it expects an OAuth integration
-   named `notion` — the default name this guide's connect link uses, so no
-   adaptation is needed.
-4. Verify the package against your integration with its built-in smoke test from
-   `execute`:
+1. Search for `@kody/notion` (or import `kody:@kody/notion` directly). It wraps
+   pages, databases, and a generic request escape hatch.
+2. Check its README **Required setup**: it expects an OAuth integration named
+   `notion` — the default name this guide's connect link uses, so no adaptation
+   is needed.
+3. Verify the live package against your integration from `execute`:
 
 ```ts
-import smokeTest from 'kody:@<your-username>/notion/smoke-test'
+import smokeTest from 'kody:@kody/notion/smoke-test'
 
 export default async function main() {
 	return smokeTest()
@@ -183,5 +182,5 @@ export default async function main() {
 ```
 
 A successful response confirms OAuth access without returning workspace PII —
-proving the fork, the tokens, and the page grants all line up. Remember the
-package only sees pages you shared on Notion's consent screen.
+proving the live package, the tokens, and the page grants all line up. Remember
+the package only sees pages you shared on Notion's consent screen.

--- a/docs/guides/providers/notion.md
+++ b/docs/guides/providers/notion.md
@@ -158,20 +158,20 @@ internal connection, edit the page's **Connections** menu.
 - Installation scope wrong on a public connection: it cannot be edited after
   creation; create a new public connection instead.
 
-## Use the official package and verify
+## Use the official package and verify (Lane B / OAuth)
 
-A saved integration is auth credentials only. Finish by calling the live
-official helpers so day-to-day work goes through maintained search, read, query,
-and confirmed-write helpers. Official `@kody/*` packages resolve in the caller
-runtime against the caller's secrets — do **not** fork them just to use them.
-Fork only when you need to customize the source.
+Lane A stays on the raw `notionToken` fetch above. The live official package is
+the Lane B finish: it uses the saved `notion` OAuth integration and does not
+read `notionToken`. Official `@kody/*` packages resolve in the caller runtime
+against the caller's secrets — do **not** fork them just to use them. Fork only
+when you need to customize the source.
 
 1. Search for `@kody/notion` (or import `kody:@kody/notion` directly). It wraps
    pages, databases, and a generic request escape hatch.
 2. Check its README **Required setup**: it expects an OAuth integration named
-   `notion` — the default name this guide's connect link uses, so no adaptation
-   is needed.
-3. Verify the live package against your integration from `execute`:
+   `notion` — the default name this guide's Lane B connect link uses, so no
+   adaptation is needed.
+3. Verify the live package against the OAuth integration from `execute`:
 
 ```ts
 import smokeTest from 'kody:@kody/notion/smoke-test'

--- a/docs/guides/providers/spotify.md
+++ b/docs/guides/providers/spotify.md
@@ -141,10 +141,12 @@ Changing scopes means reconnecting: `/connect/oauth?provider=spotify` with a new
   authorization, not the last refresh). Reconnect at
   `/connect/oauth?provider=spotify` to start a fresh six-month window.
 
-## Fork the official package and verify
+## Use a helper package and verify
 
-A saved integration is auth credentials only. Finish by forking the community
-package so playback, playlist, and library work goes through maintained helpers:
+A saved integration is auth credentials only. Finish by putting maintained
+helpers in front of it. There is no live official `@kody/spotify` package, so
+this path is a person-account community listing — review the source, then fork
+only because it is not an official `@kody/*` helper.
 
 1. Find the listing with `community_search({ query: 'spotify' })` — the
    `@kentcdodds/spotify` listing wraps playback, playlists, search, library, and

--- a/docs/guides/secret-backed-integration.md
+++ b/docs/guides/secret-backed-integration.md
@@ -72,10 +72,11 @@ smoke-test path is unclear.
      browser-side forms, or hosted callbacks.
 8. After the package is saved or published, finish package secret approval when
    needed.
-   - Self-authored packages and adopted forks (`community_fork_adopt`) get
-     automatic read/use access to user secrets (mutations still need an
-     `allowed_packages` grant); unadopted community forks still need explicit
-     package approval for read/use, or adoption after review.
+   - Self-authored packages, live official platform packages, and adopted forks
+     (`community_fork_adopt`) get automatic read/use access to user secrets
+     (mutations still need an `allowed_packages` grant); unadopted community
+     forks still need explicit package approval for read/use, or adoption after
+     review.
    - An ad hoc `execute` smoke test does **not** grant package secret access for
      community forks.
    - Read `pending_secret_package_approvals` from `package_save` or

--- a/docs/use/secrets-and-values.md
+++ b/docs/use/secrets-and-values.md
@@ -120,11 +120,12 @@ does not by itself approve new hosts.
 
 User-scoped secrets are available automatically for **reading and using**
 (mounts, fetch placeholders, capability inputs) to packages the user authored
-themselves, and to adopted community forks (`community_fork_adopt` after a real
-source review). Unadopted community-forked packages need explicit **package**
-approval (`allowed_packages`) before those read/use paths. Updating or deleting
-a user secret from package code (`secret_set`, `secret_delete`) always needs the
-grant, including for self-authored and adopted packages. Official OAuth token
+themselves, live official platform packages, and adopted community forks
+(`community_fork_adopt` after a real source review). Unadopted community-forked
+packages need explicit **package** approval (`allowed_packages`) before those
+read/use paths. Updating or deleting a user secret from package code
+(`secret_set`, `secret_delete`) always needs the grant, including for
+self-authored, official platform, and adopted packages. Official OAuth token
 rotation (`createAuthenticatedFetch`, `refreshAccessToken`, OpenAPI integration
 401 retry) persists host-side and does not need that write grant. Saving a
 secret, approving a host, or succeeding in an ad hoc execute smoke test does not

--- a/packages/worker/src/mcp/secrets/package-access.node.test.ts
+++ b/packages/worker/src/mcp/secrets/package-access.node.test.ts
@@ -255,12 +255,12 @@ test('package secret access resolves live platform packages the caller does not 
 	).rejects.toSatisfy((error: unknown) => {
 		expect(error).toBeInstanceOf(PackageSecretAccessDeniedError)
 		expect(error).toBeInstanceOf(McpCallerError)
-		expect(
-			parsePackageAccessRequiredMessage((error as Error).message),
-		).toEqual({
-			secretName: 'userToken',
-			packageName: 'notion',
-		})
+		expect(parsePackageAccessRequiredMessage((error as Error).message)).toEqual(
+			{
+				secretName: 'userToken',
+				packageName: 'notion',
+			},
+		)
 		return true
 	})
 	expect(mockModule.getCommunityForkByForkedPackageId).not.toHaveBeenCalled()

--- a/packages/worker/src/mcp/secrets/package-access.node.test.ts
+++ b/packages/worker/src/mcp/secrets/package-access.node.test.ts
@@ -7,6 +7,7 @@ import {
 
 const mockModule = vi.hoisted(() => ({
 	getSavedPackageById: vi.fn(),
+	findPlatformPackageByRef: vi.fn(),
 	getCommunityForkByForkedPackageId: vi.fn(),
 	loadPackageManifestBySourceId: vi.fn(),
 	resolveSecret: vi.fn(),
@@ -15,6 +16,11 @@ const mockModule = vi.hoisted(() => ({
 vi.mock('#worker/package-registry/repo.ts', () => ({
 	getSavedPackageById: (...args: Array<unknown>) =>
 		mockModule.getSavedPackageById(...args),
+}))
+
+vi.mock('#worker/package-registry/platform-packages.ts', () => ({
+	findPlatformPackageByRef: (...args: Array<unknown>) =>
+		mockModule.findPlatformPackageByRef(...args),
 }))
 
 vi.mock('#worker/community/repo.ts', () => ({
@@ -185,7 +191,102 @@ test('package secret access grants cover owned, self-authored, forked, adopted, 
 	).resolves.toBeUndefined()
 	// Grant short-circuits before package/fork lookups.
 	expect(mockModule.getSavedPackageById).not.toHaveBeenCalled()
+	expect(mockModule.findPlatformPackageByRef).not.toHaveBeenCalled()
 	expect(mockModule.getCommunityForkByForkedPackageId).not.toHaveBeenCalled()
+})
+
+test('package secret access resolves live platform packages the caller does not own', async () => {
+	const platformPackage = {
+		...savedPackage,
+		id: '91d7d9e4-6b88-44da-ab19-01fe26845ac5',
+		kodyId: 'notion',
+		name: '@kody/notion',
+	}
+	const platformAccess = accessInput({
+		storageContext: {
+			sessionId: null,
+			packageId: platformPackage.id,
+		},
+	})
+
+	mockModule.getSavedPackageById.mockResolvedValueOnce(null)
+	mockModule.findPlatformPackageByRef.mockResolvedValueOnce({
+		record: platformPackage,
+		platformScope: 'kody',
+		ownerUserId: 'platform-user',
+	})
+	mockModule.getCommunityForkByForkedPackageId.mockResolvedValueOnce(null)
+	await expect(
+		assertPackageCanAccessResolvedSecret(platformAccess),
+	).resolves.toBeUndefined()
+	expect(mockModule.getSavedPackageById).toHaveBeenCalledWith(
+		expect.anything(),
+		{ userId: 'user-1', packageId: platformPackage.id },
+	)
+	expect(mockModule.findPlatformPackageByRef).toHaveBeenCalledWith(
+		expect.anything(),
+		{ idOrKodyId: platformPackage.id },
+	)
+	expect(mockModule.getCommunityForkByForkedPackageId).toHaveBeenCalledWith(
+		expect.anything(),
+		{ forkerUserId: 'user-1', forkedPackageId: platformPackage.id },
+	)
+
+	// Mutate still needs an allowed-packages grant after the platform lookup.
+	mockModule.getSavedPackageById.mockClear()
+	mockModule.findPlatformPackageByRef.mockClear()
+	mockModule.getCommunityForkByForkedPackageId.mockClear()
+	mockModule.getSavedPackageById.mockResolvedValueOnce(null)
+	mockModule.findPlatformPackageByRef.mockResolvedValueOnce({
+		record: platformPackage,
+		platformScope: 'kody',
+		ownerUserId: 'platform-user',
+	})
+	await expect(
+		assertPackageCanAccessResolvedSecret(
+			accessInput({
+				intent: 'mutate',
+				storageContext: {
+					sessionId: null,
+					packageId: platformPackage.id,
+				},
+			}),
+		),
+	).rejects.toSatisfy((error: unknown) => {
+		expect(error).toBeInstanceOf(PackageSecretAccessDeniedError)
+		expect(error).toBeInstanceOf(McpCallerError)
+		expect(
+			parsePackageAccessRequiredMessage((error as Error).message),
+		).toEqual({
+			secretName: 'userToken',
+			packageName: 'notion',
+		})
+		return true
+	})
+	expect(mockModule.getCommunityForkByForkedPackageId).not.toHaveBeenCalled()
+
+	mockModule.getSavedPackageById.mockReset()
+	mockModule.findPlatformPackageByRef.mockReset()
+	mockModule.getSavedPackageById.mockResolvedValueOnce(null)
+	mockModule.findPlatformPackageByRef.mockResolvedValueOnce(null)
+	await expect(
+		assertPackageCanAccessResolvedSecret(platformAccess),
+	).rejects.toSatisfy((error: unknown) => {
+		expect(error).toBeInstanceOf(PackageSecretAccessDeniedError)
+		expect((error as Error).message).toBe(
+			`Package "${platformPackage.id}" was not found for secret access.`,
+		)
+		return true
+	})
+
+	mockModule.getSavedPackageById.mockReset()
+	mockModule.findPlatformPackageByRef.mockReset()
+	mockModule.getSavedPackageById.mockResolvedValueOnce(savedPackage)
+	mockModule.getCommunityForkByForkedPackageId.mockResolvedValueOnce(null)
+	await expect(
+		assertPackageCanAccessResolvedSecret(accessInput()),
+	).resolves.toBeUndefined()
+	expect(mockModule.findPlatformPackageByRef).not.toHaveBeenCalled()
 })
 
 test('assertCanSetSecrets fails closed for mutate grants before any provider work', async () => {

--- a/packages/worker/src/mcp/secrets/package-access.ts
+++ b/packages/worker/src/mcp/secrets/package-access.ts
@@ -13,11 +13,13 @@ import { resolveSecret, type ResolvedSecret } from './service.ts'
 import { type SecretScope } from './types.ts'
 import { type StorageContext } from '#mcp/storage.ts'
 import { getCommunityForkByForkedPackageId } from '#worker/community/repo.ts'
+import { findPlatformPackageByRef } from '#worker/package-registry/platform-packages.ts'
+import { getSavedPackageById } from '#worker/package-registry/repo.ts'
 import {
 	loadPackageManifestBySourceId,
 	type LoadedPackageManifest,
 } from '#worker/package-registry/source.ts'
-import { getSavedPackageById } from '#worker/package-registry/repo.ts'
+import { type SavedPackageRecord } from '#worker/package-registry/types.ts'
 
 type SecretMountDefinition = {
 	name: string
@@ -57,6 +59,30 @@ export function isPackageSecretAccessUnavailableError(error: unknown) {
 	)
 }
 
+/**
+ * Resolve the package whose runtime is asking for a user secret.
+ *
+ * The caller's own copy always wins. Live official platform packages
+ * (decision 0014) are not owned by the caller, so a miss falls back to
+ * {@link findPlatformPackageByRef} — the same widening search already uses
+ * for entity detail. Hidden and private platform packages stay unresolvable.
+ */
+async function resolvePackageRecordForSecretAccess(input: {
+	db: D1Database
+	userId: string
+	packageId: string
+}): Promise<SavedPackageRecord | null> {
+	const owned = await getSavedPackageById(input.db, {
+		userId: input.userId,
+		packageId: input.packageId,
+	})
+	if (owned) return owned
+	const platform = await findPlatformPackageByRef(input.db, {
+		idOrKodyId: input.packageId,
+	})
+	return platform?.record ?? null
+}
+
 export async function assertPackageCanAccessResolvedSecret(input: {
 	env: Pick<Env, 'APP_DB'>
 	baseUrl: string
@@ -79,7 +105,8 @@ export async function assertPackageCanAccessResolvedSecret(input: {
 	if (!packageId || input.resolved.scope !== 'user') return
 	if (input.resolved.allowedPackages.includes(packageId)) return
 
-	const savedPackage = await getSavedPackageById(input.env.APP_DB, {
+	const savedPackage = await resolvePackageRecordForSecretAccess({
+		db: input.env.APP_DB,
 		userId: input.userId,
 		packageId,
 	})
@@ -97,10 +124,11 @@ export async function assertPackageCanAccessResolvedSecret(input: {
 				forkedPackageId: savedPackage.id,
 			},
 		)
-		// Self-authored packages (no community fork row) and adopted community
-		// forks may read/use user secrets without an explicit allowed_packages
-		// grant. Unadopted community forks still require approval. Mutations
-		// never take this path.
+		// Self-authored packages (no community fork row), live official
+		// platform packages, and adopted community forks may read/use user
+		// secrets without an explicit allowed_packages grant. Unadopted
+		// community forks still require approval. Mutations never take this
+		// path.
 		if (!communityFork || communityFork.adoptedAt) return
 	}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Let official `@kody/*` packages use the calling user's secrets the same way a caller-owned package already can. Live platform helpers (for example `@kody/notion` `./smoke-test` falling back to `createAuthenticatedFetch("notion")`) were dying with `Package "…" was not found for secret access` even though decision 0014 already says those modules run in the caller runtime against the caller's secrets.

Kent confirmed the product decision: official `@kody/*` packages are meant to be used without forking. This PR finishes the secret-access half of that policy and stops provider guides from steering agents to `community_fork` official helpers.

## Summary

- `assertPackageCanAccessResolvedSecret` now resolves the runtime package as **caller-owned first**, then `findPlatformPackageByRef` — the same widening search already uses for entity detail.
- A live, non-hidden, non-private platform package is treated like a self-authored package for **read/use** (no `allowed_packages` grant). **Mutate** still requires that grant.
- Hidden/private platform packages stay unresolvable.
- Docs that list the auto-grant policy now include live official platform packages.
- Provider guides for GitHub, Notion, and Google tell agents to import/invoke `kody:@kody/…` live and fork only to customize. Spotify stays a reviewed community fork because it is `@kentcdodds/spotify`, not an official `@kody/*` package.
- CodeRabbit: Notion's official-package section is labeled Lane B / OAuth-only (`notion` integration, not `notionToken`). Lane A keeps the raw-fetch verify.

## Testing

- `npx vitest run --project node-unit` on `package-access.node.test.ts`, `fetch-gateway.node.test.ts`, and `integration-refresh-access-token.node.test.ts`: **18 passed**.
- New coverage: live platform package use-grant, mutate still denied, unknown package still `"was not found for secret access"`, caller-owned lookup still wins.
- `oxlint` on the changed TypeScript, `oxfmt --check` on the changed files, and `npm run docs:check-temporal` passed.
- CI on `7e678b9f` is green (Validate + Preview + Bugbot + CodeRabbit).
- Medium-risk preview as seeded user `user-me` on https://kody-pr-1691.kody-a99.workers.dev (merge commit of `7e678b9f`):
  - **Could:** sign in; create user secret `previewPlatformSecretAccess` (`allowedHosts: api.notion.com`); see it on `/account/secrets`; confirm `/account/packages` is empty (no official `@kody/notion`); load `/account/integrations`; `/admin` 403; `/mcp` 401.
  - **Could not replay:** official `@kody/notion` `./smoke-test` / `createAuthenticatedFetch("notion")`. Preview has no platform-account `@kody/notion` row and the seed user has no Notion OAuth secret. The lookup regression stays pinned by the node suite.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `5adbb44c` · **Head:** `7e678b9f`

**Classification:** extends — secret-access authorization now admits live official platform packages; no new primitive.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `mcp-server` | surfaces | extends — `assertPackageCanAccessResolvedSecret` falls back to `findPlatformPackageByRef` after a caller-owned miss |

Unmatched paths are policy and provider docs that now name live official platform packages in the auto-grant list and tell agents to import `kody:@kody/…` instead of forking official helpers.

### Change flow

User-secret reads from a live `@kody/*` export resolve the platform package after the caller-owned lookup misses, then reuse the existing no-fork read/use grant.

```mermaid
sequenceDiagram
	actor User
	participant mcpServer as mcp-server
	participant d1AppDb as d1-app-db
	User->>mcpServer: invoke official @kody package export
	mcpServer->>mcpServer: createAuthenticatedFetch / secret placeholder
	mcpServer->>d1AppDb: getSavedPackageById caller userId plus packageId
	d1AppDb-->>mcpServer: miss owned row
	mcpServer->>d1AppDb: findPlatformPackageByRef packageId
	d1AppDb-->>mcpServer: public platform package record
	Note over mcpServer: use granted when no unadopted community fork; mutate still needs allowed_packages
```

### Before / after

| Check | Before | After |
| --- | --- | --- |
| Caller-owned package | `getSavedPackageById` | unchanged (still wins) |
| Live official platform package | `"Package … was not found for secret access"` | resolve via `findPlatformPackageByRef`, then existing use/mutate rules |
| Unknown / hidden / private platform package | not found | still not found |
| Provider guides (GitHub / Notion / Google) | `community_fork` official `@kody/*` | import or invoke `kody:@kody/…` live; fork only to customize |

### Invariants

Per-user isolation is unchanged: platform resolution only widens *which published package record* the grant check may see. The secret still belongs to the caller, hidden/private platform packages stay owner-only, and person-account packages never resolve cross-user.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7c4891fa-2555-4543-9f17-1bed0be01192?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7c4891fa-2555-4543-9f17-1bed0be01192&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Live official platform packages can automatically read and use user secrets without an explicit package grant.
  * Secret updates and deletions still require explicit approval; OAuth token rotation remains exempt.

* **Bug Fixes**
  * Improved secret-access resolution when packages are not caller-owned.

* **Tests**
  * Added coverage for platform access, mutation permissions, missing packages, and fallback behavior.

* **Documentation**
  * Updated secret-management and package-authoring guidance.
  * Simplified provider setup by directing users to official packages where available and clarifying community-package requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->