### PR TITLE
Show @kodycodes/cli first on onboarding Step 1

### DIFF
--- a/docs/use/connect-your-agent.md
+++ b/docs/use/connect-your-agent.md
@@ -10,19 +10,24 @@ block and MCP URL, and `/.well-known/mcp/server-card.json` for the server card.
 People following a host-specific walkthrough can stay on this page or use Get
 started (`/onboarding`).
 
-The in-app Get started page (`/onboarding`) has tabs with client-specific
-instructions. Step 1 shows a copyable Automatic install command first.
-Deeplinks, the MCP URL, and JSON/TOML merge stay under Manual.
+The in-app Get started page (`/onboarding`) shows one Automatic command first:
+`npx @kodycodes/cli install`. That CLI detects running local agents and writes
+each host's remote MCP entry for this deployment. Host-specific deeplinks,
+vendor CLIs, the MCP URL, and JSON/TOML merge stay under Manual.
 
 ## Add the MCP server
 
-1. Open Get started (`/onboarding`) and choose your client tab, or follow the
-   short notes below.
-2. Run the Automatic install command for your client. It already includes this
-   deployment’s MCP URL (`https://<this-host>/mcp`). Hosts without a CLI copy
-   that URL instead.
+1. Open Get started (`/onboarding`).
+2. Copy and run the Automatic command. On [kody.codes](https://kody.codes) that
+   is `npx @kodycodes/cli install` (the CLI default MCP URL is
+   `https://kody.codes/mcp`). Preview and local origins add `--mcp-url` with
+   that deployment's MCP URL (`https://<this-host>/mcp`).
 3. Complete the OAuth flow when the host opens it. Sign in to Kody if needed,
    then approve access.
+
+The CLI configures local agents it finds (Cursor, Claude Desktop, VS Code,
+Claude Code, Codex, and similar). It does not configure web hosts such as
+ChatGPT, Claude.ai, or Grok — those stay under Manual.
 
 Your account email must be verified before authorize can finish or MCP can run.
 If authorize asks you to verify, keep that tab open, finish verification (from
@@ -33,10 +38,12 @@ MCP URL and setup prompt.
 
 ### Client notes
 
-- **Cursor** — Run the Automatic Node command to merge `mcpServers.kody.url`
-  into `~/.cursor/mcp.json` without replacing other servers, then Authenticate
-  in the Cursor MCP list. Manual includes Add to Cursor, the MCP URL, and JSON
-  merge for `~/.cursor/mcp.json` / `.cursor/mcp.json`.
+Manual on Get started has one tab per host. Use those when you are not running
+`@kodycodes/cli`, or when the host is web-only.
+
+- **Cursor** — After the CLI writes `~/.cursor/mcp.json`, Authenticate in the
+  Cursor MCP list. Manual includes Add to Cursor, the MCP URL, and JSON merge
+  for `~/.cursor/mcp.json` / `.cursor/mcp.json`.
 - **Claude Desktop** — Copy the MCP URL into Settings → Connectors (custom
   connector). Remote servers are not configured through
   `claude_desktop_config.json`. After connecting, start a new chat and ask
@@ -48,8 +55,10 @@ MCP URL and setup prompt.
   custom MCP server in the cloud console; members can then connect it from the
   Grok connectors page. See xAI's
   [custom MCP connector docs](https://docs.x.ai/grok/connectors).
-- **Claude Code** — `claude mcp add --transport http -s user kody <url>`, or a
-  `.mcp.json` entry with `"type": "http"`.
+- **Claude Code** — After the CLI writes the remote entry, enter `/mcp` → Kody →
+  Authenticate. Manual includes
+  `claude mcp add --transport http -s user kody <url>`, or a `.mcp.json` entry
+  with `"type": "http"`.
 - **ChatGPT** — On an
   [eligible paid plan (Plus, Pro, Business, Enterprise, or Education)](https://developers.openai.com/api/docs/guides/developer-mode),
   turn on Developer mode on the web (Settings → Security and login), then create
@@ -58,18 +67,19 @@ MCP URL and setup prompt.
   Plugins UI is missing. You can use the site favicon (`/apple-touch-icon.png`)
   for the app icon; the owner can edit a developer-mode app's name and logo
   later from Manage in Apps settings.
-- **Codex** — `codex mcp add kody --url <url>`, then `codex mcp login kody` if
-  OAuth does not start. Manual includes the shared `~/.codex/config.toml`
-  `[mcp_servers.kody]` `url` entry.
-- **OpenCode** — `opencode mcp add kody --url <url>`, then
-  `opencode mcp auth kody` if prompted. Manual includes a `mcp.kody` remote
-  entry in `opencode.json` (`"type": "remote"`).
-- **Copilot** — In Copilot CLI, run
-  `copilot mcp add --transport http kody <url>`. In VS Code Copilot Chat, use
-  Add to VS Code or `.vscode/mcp.json` with root key `servers` (not
-  `mcpServers`) and `"type": "http"`, then Agent mode. You can also merge a
-  `mcpServers` entry into `~/.copilot/mcp-config.json` (CLI does not read
-  `.vscode/mcp.json`).
+- **Codex** — After the CLI writes the shared config, run `codex mcp login kody`
+  if OAuth does not start. Manual includes `codex mcp add kody --url <url>` and
+  the shared `~/.codex/config.toml` `[mcp_servers.kody]` `url` entry.
+- **OpenCode** — After the CLI writes the remote entry, run
+  `opencode mcp auth kody` if prompted. Manual includes
+  `opencode mcp add kody --url <url>` and a `mcp.kody` remote entry in
+  `opencode.json` (`"type": "remote"`).
+- **Copilot** — After the CLI writes the remote entry, complete OAuth in that
+  host. Manual includes `copilot mcp add --transport http kody <url>`. In VS
+  Code Copilot Chat, use Add to VS Code or `.vscode/mcp.json` with root key
+  `servers` (not `mcpServers`) and `"type": "http"`, then Agent mode. You can
+  also merge a `mcpServers` entry into `~/.copilot/mcp-config.json` (CLI does
+  not read `.vscode/mcp.json`).
 - **Copilot App** — In the GitHub Copilot app, open settings → **MCP Servers**
   and add a custom remote HTTP server with the MCP URL. Servers from Copilot CLI
   or repository MCP config are also available in the app.

--- a/docs/use/connect-your-agent.md
+++ b/docs/use/connect-your-agent.md
@@ -11,13 +11,16 @@ People following a host-specific walkthrough can stay on this page or use Get
 started (`/onboarding`).
 
 The in-app Get started page (`/onboarding`) has tabs with client-specific
-instructions and copyable config snippets for the host you are on.
+instructions. Step 1 shows a copyable Automatic install command first. Deeplinks,
+the MCP URL, and JSON/TOML merge stay under Manual.
 
 ## Add the MCP server
 
 1. Open Get started (`/onboarding`) and choose your client tab, or follow the
    short notes below.
-2. Use this deployment’s MCP URL: `https://<this-host>/mcp`.
+2. Run the Automatic install command for your client. It already includes this
+   deployment’s MCP URL (`https://<this-host>/mcp`). Hosts without a CLI copy
+   that URL instead.
 3. Complete the OAuth flow when the host opens it. Sign in to Kody if needed,
    then approve access.
 
@@ -30,13 +33,15 @@ MCP URL and setup prompt.
 
 ### Client notes
 
-- **Cursor** — Add a remote MCP server from Customize, or merge a
-  `mcpServers.kody.url` entry into `~/.cursor/mcp.json` / `.cursor/mcp.json`.
-- **Claude Desktop** — Use Settings → Connectors (custom connector + MCP URL).
-  Remote servers are not configured through `claude_desktop_config.json`. After
-  connecting, start a new chat and ask Claude to list Kody tools before the
-  first task — Claude Desktop often does not bind MCP tools until that next
-  turn.
+- **Cursor** — Run the Automatic Node command to merge `mcpServers.kody.url`
+  into `~/.cursor/mcp.json` without replacing other servers, then Authenticate
+  in the Cursor MCP list. Manual includes Add to Cursor, the MCP URL, and JSON
+  merge for `~/.cursor/mcp.json` / `.cursor/mcp.json`.
+- **Claude Desktop** — Copy the MCP URL into Settings → Connectors (custom
+  connector). Remote servers are not configured through
+  `claude_desktop_config.json`. After connecting, start a new chat and ask
+  Claude to list Kody tools before the first task — Claude Desktop often does
+  not bind MCP tools until that next turn.
 - **Grok** — On [grok.com/connectors](https://grok.com/connectors), click **New
   Connector**, select **Custom**, and paste the MCP URL. Complete OAuth when
   prompted. For Grok Business and Enterprise, a team admin must first add this
@@ -53,13 +58,16 @@ MCP URL and setup prompt.
   Plugins UI is missing. You can use the site favicon (`/apple-touch-icon.png`)
   for the app icon; the owner can edit a developer-mode app's name and logo
   later from Manage in Apps settings.
-- **Codex** — Codex (ChatGPT desktop, CLI, IDE) shares `~/.codex/config.toml`
-  with an `[mcp_servers.kody]` `url` entry.
-- **OpenCode** — Add a `mcp.kody` remote entry in `opencode.json`
-  (`"type": "remote"`).
-- **Copilot** — In VS Code, use `.vscode/mcp.json` with root key `servers` (not
-  `mcpServers`) and `"type": "http"`, then Agent mode in Copilot Chat. In
-  Copilot CLI, run `copilot mcp add --transport http kody <url>` or merge a
+- **Codex** — `codex mcp add kody --url <url>`, then `codex mcp login kody` if
+  OAuth does not start. Manual includes the shared `~/.codex/config.toml`
+  `[mcp_servers.kody]` `url` entry.
+- **OpenCode** — `opencode mcp add kody --url <url>`, then
+  `opencode mcp auth kody` if prompted. Manual includes a `mcp.kody` remote
+  entry in `opencode.json` (`"type": "remote"`).
+- **Copilot** — In Copilot CLI, run
+  `copilot mcp add --transport http kody <url>`. In VS Code Copilot Chat, use
+  Add to VS Code or `.vscode/mcp.json` with root key `servers` (not
+  `mcpServers`) and `"type": "http"`, then Agent mode. You can also merge a
   `mcpServers` entry into `~/.copilot/mcp-config.json` (CLI does not read
   `.vscode/mcp.json`).
 - **Copilot App** — In the GitHub Copilot app, open settings → **MCP Servers**

--- a/docs/use/connect-your-agent.md
+++ b/docs/use/connect-your-agent.md
@@ -11,8 +11,8 @@ People following a host-specific walkthrough can stay on this page or use Get
 started (`/onboarding`).
 
 The in-app Get started page (`/onboarding`) has tabs with client-specific
-instructions. Step 1 shows a copyable Automatic install command first. Deeplinks,
-the MCP URL, and JSON/TOML merge stay under Manual.
+instructions. Step 1 shows a copyable Automatic install command first.
+Deeplinks, the MCP URL, and JSON/TOML merge stay under Manual.
 
 ## Add the MCP server
 

--- a/docs/use/index.md
+++ b/docs/use/index.md
@@ -28,9 +28,9 @@ Read in order for a full tour, or jump to a topic.
   process (vault, CLI, or home devices), publish it with Tunnel and Access, and
   connect it to Kody. Starter:
   [home-mcp-starter](https://github.com/kody-bot/home-mcp-starter)
-- [Connect your agent](./connect-your-agent.md) — add `{origin}/mcp`, complete
-  OAuth, and use the setup prompt. Machine-readable twin:
-  [`/auth.md`](https://kody.codes/auth.md)
+- [Connect your agent](./connect-your-agent.md) — run
+  `npx @kodycodes/cli install`, complete OAuth, and use the setup prompt.
+  Machine-readable twin: [`/auth.md`](https://kody.codes/auth.md)
 - [Connect remote MCP servers](./mcp-client-servers.md) — add external MCP
   servers so Kody can call their tools (`kody.mcp[...]`)
 - [First steps — what to ask Kody to do](./first-steps.md)

--- a/packages/worker/client/routes/onboarding-mcp-client-tabs.node.test.ts
+++ b/packages/worker/client/routes/onboarding-mcp-client-tabs.node.test.ts
@@ -6,14 +6,14 @@ import {
 	buildClaudeCodeAddCommand,
 	buildCodexMcpAddCommand,
 	buildCopilotCliAddCommand,
+	buildKodyCliInstallCommand,
 	buildOpenCodeMcpAddCommand,
+	defaultKodyMcpUrl,
 } from './onboarding-mcp-clients.ts'
 
-const mcpServerUrl = 'https://heykody.dev/mcp'
-
-test('onboarding MCP tabs show Automatic first and collapse Manual', async () => {
+test('onboarding Step 1 shows @kodycodes/cli first and collapses Manual', async () => {
 	const html = await renderToString(
-		jsx(OnboardingMcpClientTabs, { mcpServerUrl }),
+		jsx(OnboardingMcpClientTabs, { mcpServerUrl: defaultKodyMcpUrl }),
 	)
 
 	expect(html).toContain('data-testid="onboarding-mcp-automatic"')
@@ -22,14 +22,40 @@ test('onboarding MCP tabs show Automatic first and collapse Manual', async () =>
 	)
 	expect(html).toContain('>Automatic<')
 	expect(html).toContain('>Manual<')
+	expect(html).toContain('npx @kodycodes/cli install')
+	expect(html).not.toContain('--mcp-url')
+	expect(html).not.toMatch(/heykody\.(?:app|dev)/)
 	expect(html).toMatch(/aria-selected="true"[^>]*>Cursor</)
 
-	expect(html).toContain(mcpServerUrl)
-	expect(html).toContain('~/.cursor/mcp.json')
-	expect(html).toContain(buildClaudeCodeAddCommand(mcpServerUrl))
-	expect(html).toContain(buildCodexMcpAddCommand(mcpServerUrl))
-	expect(html).toContain(buildOpenCodeMcpAddCommand(mcpServerUrl))
-	expect(html).toContain(buildCopilotCliAddCommand(mcpServerUrl))
-	expect(html).toContain('Add to Cursor')
-	expect(html).toContain('Add to VS Code')
+	const automaticBlock = html.slice(
+		html.indexOf('data-testid="onboarding-mcp-automatic"'),
+		html.indexOf('data-testid="onboarding-mcp-manual"'),
+	)
+	expect(automaticBlock).toContain(
+		buildKodyCliInstallCommand(defaultKodyMcpUrl),
+	)
+	expect(automaticBlock).not.toContain('Add to Cursor')
+	expect(automaticBlock).not.toContain('Choose your client')
+
+	const manualBlock = html.slice(
+		html.indexOf('data-testid="onboarding-mcp-manual"'),
+	)
+	expect(manualBlock).toContain('Choose your client')
+	expect(manualBlock).toContain(defaultKodyMcpUrl)
+	expect(manualBlock).toContain('~/.cursor/mcp.json')
+	expect(manualBlock).toContain(buildClaudeCodeAddCommand(defaultKodyMcpUrl))
+	expect(manualBlock).toContain(buildCodexMcpAddCommand(defaultKodyMcpUrl))
+	expect(manualBlock).toContain(buildOpenCodeMcpAddCommand(defaultKodyMcpUrl))
+	expect(manualBlock).toContain(buildCopilotCliAddCommand(defaultKodyMcpUrl))
+	expect(manualBlock).toContain('Add to Cursor')
+	expect(manualBlock).toContain('Add to VS Code')
+
+	const previewHtml = await renderToString(
+		jsx(OnboardingMcpClientTabs, {
+			mcpServerUrl: 'http://localhost:3742/mcp',
+		}),
+	)
+	expect(previewHtml).toContain(
+		'npx @kodycodes/cli install --mcp-url http://localhost:3742/mcp',
+	)
 })

--- a/packages/worker/client/routes/onboarding-mcp-client-tabs.node.test.ts
+++ b/packages/worker/client/routes/onboarding-mcp-client-tabs.node.test.ts
@@ -1,0 +1,35 @@
+import { jsx } from 'remix/ui/jsx-runtime'
+import { renderToString } from 'remix/ui/server'
+import { expect, test } from 'vitest'
+import { OnboardingMcpClientTabs } from './onboarding-mcp-client-tabs.tsx'
+import {
+	buildClaudeCodeAddCommand,
+	buildCodexMcpAddCommand,
+	buildCopilotCliAddCommand,
+	buildOpenCodeMcpAddCommand,
+} from './onboarding-mcp-clients.ts'
+
+const mcpServerUrl = 'https://heykody.dev/mcp'
+
+test('onboarding MCP tabs show Automatic first and collapse Manual', async () => {
+	const html = await renderToString(
+		jsx(OnboardingMcpClientTabs, { mcpServerUrl }),
+	)
+
+	expect(html).toContain('data-testid="onboarding-mcp-automatic"')
+	expect(html).toMatch(
+		/<details(?![^>]*\bopen\b)[^>]*data-testid="onboarding-mcp-manual"/,
+	)
+	expect(html).toContain('>Automatic<')
+	expect(html).toContain('>Manual<')
+	expect(html).toContain('name="cursor"')
+
+	expect(html).toContain(mcpServerUrl)
+	expect(html).toContain('~/.cursor/mcp.json')
+	expect(html).toContain(buildClaudeCodeAddCommand(mcpServerUrl))
+	expect(html).toContain(buildCodexMcpAddCommand(mcpServerUrl))
+	expect(html).toContain(buildOpenCodeMcpAddCommand(mcpServerUrl))
+	expect(html).toContain(buildCopilotCliAddCommand(mcpServerUrl))
+	expect(html).toContain('Add to Cursor')
+	expect(html).toContain('Add to VS Code')
+})

--- a/packages/worker/client/routes/onboarding-mcp-client-tabs.node.test.ts
+++ b/packages/worker/client/routes/onboarding-mcp-client-tabs.node.test.ts
@@ -22,7 +22,7 @@ test('onboarding MCP tabs show Automatic first and collapse Manual', async () =>
 	)
 	expect(html).toContain('>Automatic<')
 	expect(html).toContain('>Manual<')
-	expect(html).toContain('name="cursor"')
+	expect(html).toMatch(/aria-selected="true"[^>]*>Cursor</)
 
 	expect(html).toContain(mcpServerUrl)
 	expect(html).toContain('~/.cursor/mcp.json')

--- a/packages/worker/client/routes/onboarding-mcp-client-tabs.tsx
+++ b/packages/worker/client/routes/onboarding-mcp-client-tabs.tsx
@@ -193,8 +193,9 @@ function renderPanelContent(kind: McpClientKind, mcpServerUrl: string) {
 						</a>
 						. In a managed workspace, ask an admin to enable access if the
 						setting or Plugins UI is missing. Then open{' '}
-						<strong>Settings → Plugins → Browse plugins → Create app</strong> and
-						paste the MCP URL as the server URL. Complete OAuth when prompted.
+						<strong>Settings → Plugins → Browse plugins → Create app</strong>{' '}
+						and paste the MCP URL as the server URL. Complete OAuth when
+						prompted.
 					</p>
 					<AutomaticPath>
 						<CopyCard
@@ -474,8 +475,8 @@ function renderPanelContent(kind: McpClientKind, mcpServerUrl: string) {
 					<ManualPath>
 						<p>
 							Servers you already configured for Copilot CLI (or in a
-							repository) are also available in the app. You can merge this
-							into <code>~/.copilot/mcp-config.json</code> instead:
+							repository) are also available in the app. You can merge this into{' '}
+							<code>~/.copilot/mcp-config.json</code> instead:
 						</p>
 						<CopyCard
 							label="~/.copilot/mcp-config.json"

--- a/packages/worker/client/routes/onboarding-mcp-client-tabs.tsx
+++ b/packages/worker/client/routes/onboarding-mcp-client-tabs.tsx
@@ -10,8 +10,8 @@ import {
 	buildCopilotCliMcpJson,
 	buildCursorInstallUrl,
 	buildCursorMcpJson,
-	buildCursorMcpMergeCommand,
 	buildKodyAppIconUrl,
+	buildKodyCliInstallCommand,
 	buildOpenCodeMcpAddCommand,
 	buildOpenCodeMcpJson,
 	buildVsCodeInstallUrl,
@@ -129,49 +129,32 @@ function ManualPath(handle: Handle<{ children?: RemixNode }>) {
 function renderPanelContent(kind: McpClientKind, mcpServerUrl: string) {
 	switch (kind) {
 		case 'cursor': {
-			const cursorCommand = buildCursorMcpMergeCommand(mcpServerUrl)
 			const cursorJson = buildCursorMcpJson(mcpServerUrl)
 			const installUrl = buildCursorInstallUrl(mcpServerUrl)
 			return (
 				<>
 					<p>
-						Copy and run this to add Kody to your user-global{' '}
-						<code>~/.cursor/mcp.json</code> without replacing other servers.
-						Then Authenticate in Cursor&apos;s MCP list.
+						Install with the deeplink, open <strong>Customize</strong> and add a
+						remote MCP server with the URL, or merge the JSON into{' '}
+						<code>~/.cursor/mcp.json</code> (global) or{' '}
+						<code>.cursor/mcp.json</code> (project).
 					</p>
-					<AutomaticPath>
-						<CopyCard
-							label="Install command"
-							value={cursorCommand}
-							copyLabel="Copy command"
-							variant="pill"
-							lang="sh"
-						/>
-					</AutomaticPath>
-					<ManualPath>
-						<p>
-							Install with the deeplink, open <strong>Customize</strong> and add
-							a remote MCP server with the URL, or merge the JSON into{' '}
-							<code>~/.cursor/mcp.json</code> (global) or{' '}
-							<code>.cursor/mcp.json</code> (project).
-						</p>
-						<InstallDeepLink href={installUrl} label="Add to Cursor" />
-						<CopyCard
-							label="MCP URL"
-							value={mcpServerUrl}
-							copyLabel="Copy MCP URL"
-						/>
-						<p>
-							JSON config (merge under your existing <code>mcpServers</code> if
-							you already have one):
-						</p>
-						<CopyCard
-							label="mcp.json"
-							value={cursorJson}
-							copyLabel="Copy JSON"
-							lang="json"
-						/>
-					</ManualPath>
+					<InstallDeepLink href={installUrl} label="Add to Cursor" />
+					<CopyCard
+						label="MCP URL"
+						value={mcpServerUrl}
+						copyLabel="Copy MCP URL"
+					/>
+					<p>
+						JSON config (merge under your existing <code>mcpServers</code> if
+						you already have one):
+					</p>
+					<CopyCard
+						label="mcp.json"
+						value={cursorJson}
+						copyLabel="Copy JSON"
+						lang="json"
+					/>
 					<ClientNote>{codingAgentPackageHint}</ClientNote>
 				</>
 			)
@@ -197,26 +180,21 @@ function renderPanelContent(kind: McpClientKind, mcpServerUrl: string) {
 						and paste the MCP URL as the server URL. Complete OAuth when
 						prompted.
 					</p>
-					<AutomaticPath>
-						<CopyCard
-							label="MCP URL"
-							value={mcpServerUrl}
-							copyLabel="Copy MCP URL"
-							variant="pill"
-						/>
-					</AutomaticPath>
-					<ManualPath>
-						<p>
-							For the app icon, download Kody&apos;s favicon from the URL below.
-							Owners can edit a developer-mode app&apos;s name and logo later
-							from its <strong>Manage</strong> menu in Apps settings.
-						</p>
-						<CopyCard
-							label="App icon (favicon)"
-							value={appIconUrl}
-							copyLabel="Copy icon URL"
-						/>
-					</ManualPath>
+					<CopyCard
+						label="MCP URL"
+						value={mcpServerUrl}
+						copyLabel="Copy MCP URL"
+					/>
+					<p>
+						For the app icon, download Kody&apos;s favicon from the URL below.
+						Owners can edit a developer-mode app&apos;s name and logo later from
+						its <strong>Manage</strong> menu in Apps settings.
+					</p>
+					<CopyCard
+						label="App icon (favicon)"
+						value={appIconUrl}
+						copyLabel="Copy icon URL"
+					/>
 					<ClientNote>{nonCodingAgentNote}</ClientNote>
 				</>
 			)
@@ -228,28 +206,22 @@ function renderPanelContent(kind: McpClientKind, mcpServerUrl: string) {
 				<>
 					<p>
 						Codex (ChatGPT desktop, Codex CLI, and the IDE extension) shares{' '}
-						<code>~/.codex/config.toml</code>. Copy and run this, then{' '}
+						<code>~/.codex/config.toml</code>. Run the Codex CLI, then{' '}
 						<code>{codexMcpLoginCommand}</code> if OAuth does not start
-						automatically:
+						automatically, or add the streamable HTTP entry yourself:
 					</p>
-					<AutomaticPath>
-						<CopyCard
-							label="codex CLI"
-							value={codexCommand}
-							copyLabel="Copy command"
-							variant="pill"
-							lang="sh"
-						/>
-					</AutomaticPath>
-					<ManualPath>
-						<p>Or add this streamable HTTP entry yourself:</p>
-						<CopyCard
-							label="config.toml"
-							value={codexToml}
-							copyLabel="Copy TOML"
-							lang="toml"
-						/>
-					</ManualPath>
+					<CopyCard
+						label="codex CLI"
+						value={codexCommand}
+						copyLabel="Copy command"
+						lang="sh"
+					/>
+					<CopyCard
+						label="config.toml"
+						value={codexToml}
+						copyLabel="Copy TOML"
+						lang="toml"
+					/>
 					<ClientNote>{codingAgentPackageHint}</ClientNote>
 				</>
 			)
@@ -262,21 +234,16 @@ function renderPanelContent(kind: McpClientKind, mcpServerUrl: string) {
 						Customize → Connectors), add a custom connector, and paste this MCP
 						URL. Claude Desktop handles remote OAuth through that UI.
 					</p>
-					<AutomaticPath>
-						<CopyCard
-							label="MCP URL"
-							value={mcpServerUrl}
-							copyLabel="Copy MCP URL"
-							variant="pill"
-						/>
-					</AutomaticPath>
-					<ManualPath>
-						<p>
-							Do not put the remote URL into{' '}
-							<code>claude_desktop_config.json</code>. After connecting, start a
-							new chat and ask Claude to list Kody tools before the first task.
-						</p>
-					</ManualPath>
+					<CopyCard
+						label="MCP URL"
+						value={mcpServerUrl}
+						copyLabel="Copy MCP URL"
+					/>
+					<p>
+						Do not put the remote URL into{' '}
+						<code>claude_desktop_config.json</code>. After connecting, start a
+						new chat and ask Claude to list Kody tools before the first task.
+					</p>
 					<ClientNote>{claudeDesktopToolHint}</ClientNote>
 					<ClientNote>{nonCodingAgentNote}</ClientNote>
 				</>
@@ -297,29 +264,24 @@ function renderPanelContent(kind: McpClientKind, mcpServerUrl: string) {
 						<strong>Custom</strong>, and paste this MCP URL. Complete OAuth when
 						Grok prompts you.
 					</p>
-					<AutomaticPath>
-						<CopyCard
-							label="MCP URL"
-							value={mcpServerUrl}
-							copyLabel="Copy MCP URL"
-							variant="pill"
-						/>
-					</AutomaticPath>
-					<ManualPath>
-						<p>
-							For Grok Business and Enterprise, a team admin must first add this
-							custom MCP server in the cloud console. Members can then connect
-							it from the Grok connectors page. See xAI&apos;s{' '}
-							<a
-								href={grokCustomMcpGuideUrl}
-								target="_blank"
-								rel="noreferrer noopener"
-							>
-								custom MCP connector docs
-							</a>{' '}
-							for details.
-						</p>
-					</ManualPath>
+					<CopyCard
+						label="MCP URL"
+						value={mcpServerUrl}
+						copyLabel="Copy MCP URL"
+					/>
+					<p>
+						For Grok Business and Enterprise, a team admin must first add this
+						custom MCP server in the cloud console. Members can then connect it
+						from the Grok connectors page. See xAI&apos;s{' '}
+						<a
+							href={grokCustomMcpGuideUrl}
+							target="_blank"
+							rel="noreferrer noopener"
+						>
+							custom MCP connector docs
+						</a>{' '}
+						for details.
+					</p>
 					<ClientNote>{nonCodingAgentNote}</ClientNote>
 				</>
 			)
@@ -328,29 +290,24 @@ function renderPanelContent(kind: McpClientKind, mcpServerUrl: string) {
 			const claudeCodeJson = buildClaudeCodeMcpJson(mcpServerUrl)
 			return (
 				<>
-					<p>Copy and run this (user scope, all projects):</p>
-					<AutomaticPath>
-						<CopyCard
-							label="claude CLI"
-							value={claudeCodeCommand}
-							copyLabel="Copy command"
-							variant="pill"
-							lang="sh"
-						/>
-					</AutomaticPath>
-					<ManualPath>
-						<p>
-							Or merge this into a project <code>.mcp.json</code> (or the
-							user-scoped <code>mcpServers</code> block). Claude Code requires{' '}
-							<code>type: &quot;http&quot;</code> for remote servers:
-						</p>
-						<CopyCard
-							label=".mcp.json"
-							value={claudeCodeJson}
-							copyLabel="Copy JSON"
-							lang="json"
-						/>
-					</ManualPath>
+					<p>
+						Run this (user scope, all projects), or merge the JSON into a
+						project <code>.mcp.json</code> (or the user-scoped{' '}
+						<code>mcpServers</code> block). Claude Code requires{' '}
+						<code>type: &quot;http&quot;</code> for remote servers:
+					</p>
+					<CopyCard
+						label="claude CLI"
+						value={claudeCodeCommand}
+						copyLabel="Copy command"
+						lang="sh"
+					/>
+					<CopyCard
+						label=".mcp.json"
+						value={claudeCodeJson}
+						copyLabel="Copy JSON"
+						lang="json"
+					/>
 					<ClientNote>{codingAgentPackageHint}</ClientNote>
 				</>
 			)
@@ -361,31 +318,24 @@ function renderPanelContent(kind: McpClientKind, mcpServerUrl: string) {
 			return (
 				<>
 					<p>
-						Copy and run this to add Kody as a remote MCP server. Then{' '}
-						<code>{openCodeMcpAuthCommand}</code> if prompted:
+						Run this to add Kody as a remote MCP server, then{' '}
+						<code>{openCodeMcpAuthCommand}</code> if prompted. Or add the remote
+						entry to your OpenCode config (<code>opencode.json</code> in the
+						project, or your global OpenCode config). OpenCode uses{' '}
+						<code>type: &quot;remote&quot;</code>:
 					</p>
-					<AutomaticPath>
-						<CopyCard
-							label="opencode CLI"
-							value={openCodeCommand}
-							copyLabel="Copy command"
-							variant="pill"
-							lang="sh"
-						/>
-					</AutomaticPath>
-					<ManualPath>
-						<p>
-							Or add this to your OpenCode config (<code>opencode.json</code> in
-							the project, or your global OpenCode config). OpenCode uses{' '}
-							<code>type: &quot;remote&quot;</code>:
-						</p>
-						<CopyCard
-							label="opencode.json"
-							value={openCodeJson}
-							copyLabel="Copy JSON"
-							lang="json"
-						/>
-					</ManualPath>
+					<CopyCard
+						label="opencode CLI"
+						value={openCodeCommand}
+						copyLabel="Copy command"
+						lang="sh"
+					/>
+					<CopyCard
+						label="opencode.json"
+						value={openCodeJson}
+						copyLabel="Copy JSON"
+						lang="json"
+					/>
 					<ClientNote>{codingAgentPackageHint}</ClientNote>
 				</>
 			)
@@ -398,59 +348,54 @@ function renderPanelContent(kind: McpClientKind, mcpServerUrl: string) {
 			return (
 				<>
 					<p>
-						Copy and run this to add a remote HTTP server for Copilot CLI
-						(writes <code>~/.copilot/mcp-config.json</code>). Copilot CLI does
-						not read <code>.vscode/mcp.json</code>:
+						Run this to add a remote HTTP server for Copilot CLI (writes{' '}
+						<code>~/.copilot/mcp-config.json</code>). Copilot CLI does not read{' '}
+						<code>.vscode/mcp.json</code>:
 					</p>
-					<AutomaticPath>
-						<CopyCard
-							label="copilot CLI"
-							value={copilotCliCommand}
-							copyLabel="Copy command"
-							variant="pill"
-							lang="sh"
-						/>
-					</AutomaticPath>
-					<ManualPath>
-						<p>
-							<strong>In VS Code (Copilot Chat):</strong> install Kody directly,
-							create or edit <code>.vscode/mcp.json</code> in your workspace, or
-							open user MCP config via the{' '}
-							<strong>MCP: Open User Configuration</strong> command. VS Code
-							uses the root key <code>servers</code>, not{' '}
-							<code>mcpServers</code>. Use Agent mode in Copilot Chat so MCP
-							tools are available, then complete OAuth when VS Code opens it.
-						</p>
-						<InstallDeepLink href={installUrl} label="Add to VS Code" />
-						<CopyCard
-							label=".vscode/mcp.json"
-							value={vsCodeJson}
-							copyLabel="Copy JSON"
-							lang="json"
-						/>
-						<p>
-							Or merge this into <code>~/.copilot/mcp-config.json</code> (root
-							key <code>mcpServers</code>):
-						</p>
-						<CopyCard
-							label="~/.copilot/mcp-config.json"
-							value={copilotCliJson}
-							copyLabel="Copy JSON"
-							lang="json"
-						/>
-						<p>
-							See GitHub&apos;s{' '}
-							<a
-								href={copilotCliMcpGuideUrl}
-								target="_blank"
-								rel="noreferrer noopener"
-							>
-								Copilot CLI MCP docs
-							</a>{' '}
-							for details. For the desktop GitHub Copilot app, use the{' '}
-							<strong>Copilot App</strong> tab.
-						</p>
-					</ManualPath>
+					<CopyCard
+						label="copilot CLI"
+						value={copilotCliCommand}
+						copyLabel="Copy command"
+						lang="sh"
+					/>
+					<p>
+						<strong>In VS Code (Copilot Chat):</strong> install Kody directly,
+						create or edit <code>.vscode/mcp.json</code> in your workspace, or
+						open user MCP config via the{' '}
+						<strong>MCP: Open User Configuration</strong> command. VS Code uses
+						the root key <code>servers</code>, not <code>mcpServers</code>. Use
+						Agent mode in Copilot Chat so MCP tools are available, then complete
+						OAuth when VS Code opens it.
+					</p>
+					<InstallDeepLink href={installUrl} label="Add to VS Code" />
+					<CopyCard
+						label=".vscode/mcp.json"
+						value={vsCodeJson}
+						copyLabel="Copy JSON"
+						lang="json"
+					/>
+					<p>
+						Or merge this into <code>~/.copilot/mcp-config.json</code> (root key{' '}
+						<code>mcpServers</code>):
+					</p>
+					<CopyCard
+						label="~/.copilot/mcp-config.json"
+						value={copilotCliJson}
+						copyLabel="Copy JSON"
+						lang="json"
+					/>
+					<p>
+						See GitHub&apos;s{' '}
+						<a
+							href={copilotCliMcpGuideUrl}
+							target="_blank"
+							rel="noreferrer noopener"
+						>
+							Copilot CLI MCP docs
+						</a>{' '}
+						for details. For the desktop GitHub Copilot app, use the{' '}
+						<strong>Copilot App</strong> tab.
+					</p>
 					<ClientNote>{codingAgentPackageHint}</ClientNote>
 				</>
 			)
@@ -464,38 +409,33 @@ function renderPanelContent(kind: McpClientKind, mcpServerUrl: string) {
 						<strong>MCP Servers</strong>. Add a custom remote HTTP server with
 						this MCP URL, then complete OAuth when the app opens it:
 					</p>
-					<AutomaticPath>
-						<CopyCard
-							label="MCP URL"
-							value={mcpServerUrl}
-							copyLabel="Copy MCP URL"
-							variant="pill"
-						/>
-					</AutomaticPath>
-					<ManualPath>
-						<p>
-							Servers you already configured for Copilot CLI (or in a
-							repository) are also available in the app. You can merge this into{' '}
-							<code>~/.copilot/mcp-config.json</code> instead:
-						</p>
-						<CopyCard
-							label="~/.copilot/mcp-config.json"
-							value={copilotCliJson}
-							copyLabel="Copy JSON"
-							lang="json"
-						/>
-						<p>
-							See GitHub&apos;s{' '}
-							<a
-								href={copilotAppCustomizeGuideUrl}
-								target="_blank"
-								rel="noreferrer noopener"
-							>
-								Copilot app customization docs
-							</a>{' '}
-							for MCP Servers, skills, and plugins.
-						</p>
-					</ManualPath>
+					<CopyCard
+						label="MCP URL"
+						value={mcpServerUrl}
+						copyLabel="Copy MCP URL"
+					/>
+					<p>
+						Servers you already configured for Copilot CLI (or in a repository)
+						are also available in the app. You can merge this into{' '}
+						<code>~/.copilot/mcp-config.json</code> instead:
+					</p>
+					<CopyCard
+						label="~/.copilot/mcp-config.json"
+						value={copilotCliJson}
+						copyLabel="Copy JSON"
+						lang="json"
+					/>
+					<p>
+						See GitHub&apos;s{' '}
+						<a
+							href={copilotAppCustomizeGuideUrl}
+							target="_blank"
+							rel="noreferrer noopener"
+						>
+							Copilot app customization docs
+						</a>{' '}
+						for MCP Servers, skills, and plugins.
+					</p>
 					<ClientNote>{nonCodingAgentNote}</ClientNote>
 				</>
 			)
@@ -508,23 +448,18 @@ function renderPanelContent(kind: McpClientKind, mcpServerUrl: string) {
 						can connect to Kody. Add a remote MCP server pointed at this URL and
 						complete the OAuth flow when the host opens it:
 					</p>
-					<AutomaticPath>
-						<CopyCard
-							label="MCP URL"
-							value={mcpServerUrl}
-							copyLabel="Copy MCP URL"
-							variant="pill"
-						/>
-					</AutomaticPath>
-					<ManualPath>
-						<p>
-							Config file shapes differ by host. If your client expects a JSON{' '}
-							<code>mcpServers</code> map with a <code>url</code> field, start
-							from the Cursor or Copilot CLI snippet; if it uses{' '}
-							<code>servers</code> with <code>type: &quot;http&quot;</code>, use
-							the Copilot (VS Code) snippet.
-						</p>
-					</ManualPath>
+					<CopyCard
+						label="MCP URL"
+						value={mcpServerUrl}
+						copyLabel="Copy MCP URL"
+					/>
+					<p>
+						Config file shapes differ by host. If your client expects a JSON{' '}
+						<code>mcpServers</code> map with a <code>url</code> field, start
+						from the Cursor or Copilot CLI snippet; if it uses{' '}
+						<code>servers</code> with <code>type: &quot;http&quot;</code>, use
+						the Copilot (VS Code) snippet.
+					</p>
 				</>
 			)
 		default: {
@@ -535,38 +470,69 @@ function renderPanelContent(kind: McpClientKind, mcpServerUrl: string) {
 }
 
 /**
- * Client picker (step 2): host chips in the same grammar as the landing host
- * cloud, one panel of setup instructions per host. Roving tabindex and arrow
- * keys come from `remix/ui/tabs`.
+ * Step 1 install: one Automatic `@kodycodes/cli` command for every client,
+ * then a collapsed Manual section with host chips and deeplink / vendor CLI
+ * / JSON-TOML fallbacks. Roving tabindex and arrow keys come from
+ * `remix/ui/tabs`.
  */
 export function OnboardingMcpClientTabs(
 	handle: Handle<OnboardingMcpClientTabsProps>,
 ) {
-	return () => (
-		<Tabs defaultActiveTab="cursor" mix={css(tabsRootCss)}>
-			<div mix={css(tabPickerCss)}>
-				<p mix={css(tabKickerCss)} id="onboarding-client-label">
-					Choose your client
-				</p>
-				<TabList
-					aria-labelledby="onboarding-client-label"
-					mix={css(tabListCss)}
-				>
-					{mcpClientTabs.map((tab) => (
-						<Tab key={tab.id} name={tab.id} mix={css(tabPillCss)}>
-							{tab.label}
-						</Tab>
-					))}
-				</TabList>
-			</div>
+	return () => {
+		const installCommand = buildKodyCliInstallCommand(handle.props.mcpServerUrl)
+		return (
+			<div mix={css(installLayoutCss)}>
+				<AutomaticPath>
+					<p>
+						Run this to add Kody to the local agents the CLI finds (Cursor,
+						Claude Desktop, VS Code, Claude Code, Codex, and others). Then
+						Authenticate in that client. Web hosts such as ChatGPT, Claude.ai,
+						and Grok stay under Manual.
+					</p>
+					<CopyCard
+						label="Install command"
+						value={installCommand}
+						copyLabel="Copy command"
+						variant="pill"
+						lang="sh"
+					/>
+				</AutomaticPath>
+				<ManualPath>
+					<p>
+						Use a host-specific deeplink, vendor CLI, or config snippet instead.
+					</p>
+					<Tabs defaultActiveTab="cursor" mix={css(tabsRootCss)}>
+						<div mix={css(tabPickerCss)}>
+							<p mix={css(tabKickerCss)} id="onboarding-client-label">
+								Choose your client
+							</p>
+							<TabList
+								aria-labelledby="onboarding-client-label"
+								mix={css(tabListCss)}
+							>
+								{mcpClientTabs.map((tab) => (
+									<Tab key={tab.id} name={tab.id} mix={css(tabPillCss)}>
+										{tab.label}
+									</Tab>
+								))}
+							</TabList>
+						</div>
 
-			{mcpClientTabs.map((tab) => (
-				<TabPanel key={tab.id} name={tab.id} mix={css(tabPanelCss)}>
-					{renderPanelContent(tab.id, handle.props.mcpServerUrl)}
-				</TabPanel>
-			))}
-		</Tabs>
-	)
+						{mcpClientTabs.map((tab) => (
+							<TabPanel key={tab.id} name={tab.id} mix={css(tabPanelCss)}>
+								{renderPanelContent(tab.id, handle.props.mcpServerUrl)}
+							</TabPanel>
+						))}
+					</Tabs>
+				</ManualPath>
+			</div>
+		)
+	}
+}
+
+const installLayoutCss = {
+	display: 'grid',
+	gap: '1.15rem',
 }
 
 const tabsRootCss = {
@@ -681,6 +647,11 @@ const tabPanelCss = {
 const installPathCss = {
 	display: 'grid',
 	gap: '0.75rem',
+	'& > p': {
+		margin: 0,
+		color: colors.textMuted,
+		maxWidth: '72ch',
+	},
 }
 
 const pathLabelCss = {

--- a/packages/worker/client/routes/onboarding-mcp-client-tabs.tsx
+++ b/packages/worker/client/routes/onboarding-mcp-client-tabs.tsx
@@ -1,20 +1,24 @@
-import { type Handle, css } from 'remix/ui'
+import { type Handle, type RemixNode, css } from 'remix/ui'
 import { Tab, TabList, TabPanel, Tabs } from 'remix/ui/tabs'
 import { CopyTextButton } from '#client/copy-text-button.tsx'
 import {
 	buildClaudeCodeAddCommand,
 	buildClaudeCodeMcpJson,
+	buildCodexMcpAddCommand,
 	buildCodexMcpToml,
 	buildCopilotCliAddCommand,
 	buildCopilotCliMcpJson,
 	buildCursorInstallUrl,
 	buildCursorMcpJson,
+	buildCursorMcpMergeCommand,
 	buildKodyAppIconUrl,
+	buildOpenCodeMcpAddCommand,
 	buildOpenCodeMcpJson,
 	buildVsCodeInstallUrl,
 	buildVsCodeMcpJson,
 	chatGptDeveloperModeGuideUrl,
 	claudeDesktopToolHint,
+	codexMcpLoginCommand,
 	codingAgentPackageHint,
 	copilotAppCustomizeGuideUrl,
 	copilotCliMcpGuideUrl,
@@ -23,6 +27,7 @@ import {
 	type McpClientKind,
 	mcpClientTabs,
 	nonCodingAgentNote,
+	openCodeMcpAuthCommand,
 } from '#client/routes/onboarding-mcp-clients.ts'
 import {
 	colors,
@@ -103,36 +108,70 @@ function InstallDeepLink(
 	)
 }
 
+function AutomaticPath(handle: Handle<{ children?: RemixNode }>) {
+	return () => (
+		<div data-testid="onboarding-mcp-automatic" mix={css(installPathCss)}>
+			<p mix={css(pathLabelCss)}>Automatic</p>
+			{handle.props.children}
+		</div>
+	)
+}
+
+function ManualPath(handle: Handle<{ children?: RemixNode }>) {
+	return () => (
+		<details data-testid="onboarding-mcp-manual" mix={css(manualDetailsCss)}>
+			<summary mix={css(manualSummaryCss)}>Manual</summary>
+			<div mix={css(manualBodyCss)}>{handle.props.children}</div>
+		</details>
+	)
+}
+
 function renderPanelContent(kind: McpClientKind, mcpServerUrl: string) {
 	switch (kind) {
 		case 'cursor': {
+			const cursorCommand = buildCursorMcpMergeCommand(mcpServerUrl)
 			const cursorJson = buildCursorMcpJson(mcpServerUrl)
 			const installUrl = buildCursorInstallUrl(mcpServerUrl)
 			return (
 				<>
 					<p>
-						Install Kody directly, or open <strong>Customize</strong> and add a
-						remote MCP server with the URL below. You can also merge the JSON
-						into <code>~/.cursor/mcp.json</code> (global) or{' '}
-						<code>.cursor/mcp.json</code> (project).
+						Copy and run this to add Kody to your user-global{' '}
+						<code>~/.cursor/mcp.json</code> without replacing other servers.
+						Then Authenticate in Cursor&apos;s MCP list.
 					</p>
-					<InstallDeepLink href={installUrl} label="Add to Cursor" />
-					<CopyCard
-						label="MCP URL"
-						value={mcpServerUrl}
-						copyLabel="Copy MCP URL"
-						variant="pill"
-					/>
-					<p>
-						JSON config (merge under your existing <code>mcpServers</code> if
-						you already have one):
-					</p>
-					<CopyCard
-						label="mcp.json"
-						value={cursorJson}
-						copyLabel="Copy JSON"
-						lang="json"
-					/>
+					<AutomaticPath>
+						<CopyCard
+							label="Install command"
+							value={cursorCommand}
+							copyLabel="Copy command"
+							variant="pill"
+							lang="sh"
+						/>
+					</AutomaticPath>
+					<ManualPath>
+						<p>
+							Install with the deeplink, open <strong>Customize</strong> and add
+							a remote MCP server with the URL, or merge the JSON into{' '}
+							<code>~/.cursor/mcp.json</code> (global) or{' '}
+							<code>.cursor/mcp.json</code> (project).
+						</p>
+						<InstallDeepLink href={installUrl} label="Add to Cursor" />
+						<CopyCard
+							label="MCP URL"
+							value={mcpServerUrl}
+							copyLabel="Copy MCP URL"
+						/>
+						<p>
+							JSON config (merge under your existing <code>mcpServers</code> if
+							you already have one):
+						</p>
+						<CopyCard
+							label="mcp.json"
+							value={cursorJson}
+							copyLabel="Copy JSON"
+							lang="json"
+						/>
+					</ManualPath>
 					<ClientNote>{codingAgentPackageHint}</ClientNote>
 				</>
 			)
@@ -154,45 +193,62 @@ function renderPanelContent(kind: McpClientKind, mcpServerUrl: string) {
 						</a>
 						. In a managed workspace, ask an admin to enable access if the
 						setting or Plugins UI is missing. Then open{' '}
-						<strong>Settings → Plugins → Browse plugins → Create app</strong>.
-						Paste the MCP URL below as the server URL. For the app icon,
-						download Kody&apos;s favicon from the link below. Owners can edit a
-						developer-mode app&apos;s name and logo later from its{' '}
-						<strong>Manage</strong> menu in Apps settings. Complete OAuth when
-						prompted.
+						<strong>Settings → Plugins → Browse plugins → Create app</strong> and
+						paste the MCP URL as the server URL. Complete OAuth when prompted.
 					</p>
-					<CopyCard
-						label="MCP URL"
-						value={mcpServerUrl}
-						copyLabel="Copy MCP URL"
-						variant="pill"
-					/>
-					<CopyCard
-						label="App icon (favicon)"
-						value={appIconUrl}
-						copyLabel="Copy icon URL"
-					/>
+					<AutomaticPath>
+						<CopyCard
+							label="MCP URL"
+							value={mcpServerUrl}
+							copyLabel="Copy MCP URL"
+							variant="pill"
+						/>
+					</AutomaticPath>
+					<ManualPath>
+						<p>
+							For the app icon, download Kody&apos;s favicon from the URL below.
+							Owners can edit a developer-mode app&apos;s name and logo later
+							from its <strong>Manage</strong> menu in Apps settings.
+						</p>
+						<CopyCard
+							label="App icon (favicon)"
+							value={appIconUrl}
+							copyLabel="Copy icon URL"
+						/>
+					</ManualPath>
 					<ClientNote>{nonCodingAgentNote}</ClientNote>
 				</>
 			)
 		}
 		case 'codex': {
+			const codexCommand = buildCodexMcpAddCommand(mcpServerUrl)
 			const codexToml = buildCodexMcpToml(mcpServerUrl)
 			return (
 				<>
 					<p>
 						Codex (ChatGPT desktop, Codex CLI, and the IDE extension) shares{' '}
-						<code>~/.codex/config.toml</code>. Add this streamable HTTP entry,
-						then run <code>codex mcp login kody</code> if OAuth does not start
+						<code>~/.codex/config.toml</code>. Copy and run this, then{' '}
+						<code>{codexMcpLoginCommand}</code> if OAuth does not start
 						automatically:
 					</p>
-					<CopyCard
-						label="config.toml"
-						value={codexToml}
-						copyLabel="Copy TOML"
-						variant="pill"
-						lang="toml"
-					/>
+					<AutomaticPath>
+						<CopyCard
+							label="codex CLI"
+							value={codexCommand}
+							copyLabel="Copy command"
+							variant="pill"
+							lang="sh"
+						/>
+					</AutomaticPath>
+					<ManualPath>
+						<p>Or add this streamable HTTP entry yourself:</p>
+						<CopyCard
+							label="config.toml"
+							value={codexToml}
+							copyLabel="Copy TOML"
+							lang="toml"
+						/>
+					</ManualPath>
 					<ClientNote>{codingAgentPackageHint}</ClientNote>
 				</>
 			)
@@ -203,15 +259,23 @@ function renderPanelContent(kind: McpClientKind, mcpServerUrl: string) {
 					<p>
 						In Claude Desktop, open <strong>Settings → Connectors</strong> (or
 						Customize → Connectors), add a custom connector, and paste this MCP
-						URL. Claude Desktop handles remote OAuth through that UI — do not
-						put the remote URL into <code>claude_desktop_config.json</code>.
+						URL. Claude Desktop handles remote OAuth through that UI.
 					</p>
-					<CopyCard
-						label="MCP URL"
-						value={mcpServerUrl}
-						copyLabel="Copy MCP URL"
-						variant="pill"
-					/>
+					<AutomaticPath>
+						<CopyCard
+							label="MCP URL"
+							value={mcpServerUrl}
+							copyLabel="Copy MCP URL"
+							variant="pill"
+						/>
+					</AutomaticPath>
+					<ManualPath>
+						<p>
+							Do not put the remote URL into{' '}
+							<code>claude_desktop_config.json</code>. After connecting, start a
+							new chat and ask Claude to list Kody tools before the first task.
+						</p>
+					</ManualPath>
 					<ClientNote>{claudeDesktopToolHint}</ClientNote>
 					<ClientNote>{nonCodingAgentNote}</ClientNote>
 				</>
@@ -230,24 +294,31 @@ function renderPanelContent(kind: McpClientKind, mcpServerUrl: string) {
 						</a>
 						, click <strong>New Connector</strong>, select{' '}
 						<strong>Custom</strong>, and paste this MCP URL. Complete OAuth when
-						Grok prompts you. For Grok Business and Enterprise, a team admin
-						must first add this custom MCP server in the cloud console. Members
-						can then connect it from the Grok connectors page. See xAI&apos;s{' '}
-						<a
-							href={grokCustomMcpGuideUrl}
-							target="_blank"
-							rel="noreferrer noopener"
-						>
-							custom MCP connector docs
-						</a>{' '}
-						for details.
+						Grok prompts you.
 					</p>
-					<CopyCard
-						label="MCP URL"
-						value={mcpServerUrl}
-						copyLabel="Copy MCP URL"
-						variant="pill"
-					/>
+					<AutomaticPath>
+						<CopyCard
+							label="MCP URL"
+							value={mcpServerUrl}
+							copyLabel="Copy MCP URL"
+							variant="pill"
+						/>
+					</AutomaticPath>
+					<ManualPath>
+						<p>
+							For Grok Business and Enterprise, a team admin must first add this
+							custom MCP server in the cloud console. Members can then connect
+							it from the Grok connectors page. See xAI&apos;s{' '}
+							<a
+								href={grokCustomMcpGuideUrl}
+								target="_blank"
+								rel="noreferrer noopener"
+							>
+								custom MCP connector docs
+							</a>{' '}
+							for details.
+						</p>
+					</ManualPath>
 					<ClientNote>{nonCodingAgentNote}</ClientNote>
 				</>
 			)
@@ -256,50 +327,64 @@ function renderPanelContent(kind: McpClientKind, mcpServerUrl: string) {
 			const claudeCodeJson = buildClaudeCodeMcpJson(mcpServerUrl)
 			return (
 				<>
-					<p>Prefer the CLI (user scope, all projects):</p>
-					<CopyCard
-						label="claude CLI"
-						value={claudeCodeCommand}
-						copyLabel="Copy command"
-						variant="pill"
-						lang="sh"
-					/>
-					<p>
-						Or merge this into a project <code>.mcp.json</code> (or the
-						user-scoped <code>mcpServers</code> block). Claude Code requires{' '}
-						<code>type: &quot;http&quot;</code> for remote servers:
-					</p>
-					<CopyCard
-						label=".mcp.json"
-						value={claudeCodeJson}
-						copyLabel="Copy JSON"
-						lang="json"
-					/>
+					<p>Copy and run this (user scope, all projects):</p>
+					<AutomaticPath>
+						<CopyCard
+							label="claude CLI"
+							value={claudeCodeCommand}
+							copyLabel="Copy command"
+							variant="pill"
+							lang="sh"
+						/>
+					</AutomaticPath>
+					<ManualPath>
+						<p>
+							Or merge this into a project <code>.mcp.json</code> (or the
+							user-scoped <code>mcpServers</code> block). Claude Code requires{' '}
+							<code>type: &quot;http&quot;</code> for remote servers:
+						</p>
+						<CopyCard
+							label=".mcp.json"
+							value={claudeCodeJson}
+							copyLabel="Copy JSON"
+							lang="json"
+						/>
+					</ManualPath>
 					<ClientNote>{codingAgentPackageHint}</ClientNote>
 				</>
 			)
 		}
 		case 'opencode': {
+			const openCodeCommand = buildOpenCodeMcpAddCommand(mcpServerUrl)
 			const openCodeJson = buildOpenCodeMcpJson(mcpServerUrl)
 			return (
 				<>
 					<p>
-						Add this to your OpenCode config (<code>opencode.json</code> in the
-						project, or your global OpenCode config). OpenCode uses{' '}
-						<code>type: &quot;remote&quot;</code> and will start OAuth when
-						needed:
+						Copy and run this to add Kody as a remote MCP server. Then{' '}
+						<code>{openCodeMcpAuthCommand}</code> if prompted:
 					</p>
-					<CopyCard
-						label="opencode.json"
-						value={openCodeJson}
-						copyLabel="Copy JSON"
-						variant="pill"
-						lang="json"
-					/>
-					<p>
-						You can also run <code>opencode mcp add</code> and paste the URL
-						interactively, then <code>opencode mcp auth kody</code> if prompted.
-					</p>
+					<AutomaticPath>
+						<CopyCard
+							label="opencode CLI"
+							value={openCodeCommand}
+							copyLabel="Copy command"
+							variant="pill"
+							lang="sh"
+						/>
+					</AutomaticPath>
+					<ManualPath>
+						<p>
+							Or add this to your OpenCode config (<code>opencode.json</code> in
+							the project, or your global OpenCode config). OpenCode uses{' '}
+							<code>type: &quot;remote&quot;</code>:
+						</p>
+						<CopyCard
+							label="opencode.json"
+							value={openCodeJson}
+							copyLabel="Copy JSON"
+							lang="json"
+						/>
+					</ManualPath>
 					<ClientNote>{codingAgentPackageHint}</ClientNote>
 				</>
 			)
@@ -312,58 +397,59 @@ function renderPanelContent(kind: McpClientKind, mcpServerUrl: string) {
 			return (
 				<>
 					<p>
-						<strong>In VS Code (Copilot Chat):</strong> install Kody directly,
-						create or edit <code>.vscode/mcp.json</code> in your workspace, or
-						open user MCP config via the{' '}
-						<strong>MCP: Open User Configuration</strong> command. VS Code uses
-						the root key <code>servers</code>, not <code>mcpServers</code>:
+						Copy and run this to add a remote HTTP server for Copilot CLI
+						(writes <code>~/.copilot/mcp-config.json</code>). Copilot CLI does
+						not read <code>.vscode/mcp.json</code>:
 					</p>
-					<InstallDeepLink href={installUrl} label="Add to VS Code" />
-					<CopyCard
-						label=".vscode/mcp.json"
-						value={vsCodeJson}
-						copyLabel="Copy JSON"
-						variant="pill"
-						lang="json"
-					/>
-					<p>
-						Use Agent mode in Copilot Chat so MCP tools are available, then
-						complete OAuth when VS Code opens it.
-					</p>
-					<p>
-						<strong>In Copilot CLI:</strong> add a remote HTTP server (writes{' '}
-						<code>~/.copilot/mcp-config.json</code>). Copilot CLI does not read{' '}
-						<code>.vscode/mcp.json</code>:
-					</p>
-					<CopyCard
-						label="copilot CLI"
-						value={copilotCliCommand}
-						copyLabel="Copy command"
-						variant="pill"
-						lang="sh"
-					/>
-					<p>
-						Or merge this into <code>~/.copilot/mcp-config.json</code> (root key{' '}
-						<code>mcpServers</code>):
-					</p>
-					<CopyCard
-						label="~/.copilot/mcp-config.json"
-						value={copilotCliJson}
-						copyLabel="Copy JSON"
-						lang="json"
-					/>
-					<p>
-						See GitHub&apos;s{' '}
-						<a
-							href={copilotCliMcpGuideUrl}
-							target="_blank"
-							rel="noreferrer noopener"
-						>
-							Copilot CLI MCP docs
-						</a>{' '}
-						for details. For the desktop GitHub Copilot app, use the{' '}
-						<strong>Copilot App</strong> tab.
-					</p>
+					<AutomaticPath>
+						<CopyCard
+							label="copilot CLI"
+							value={copilotCliCommand}
+							copyLabel="Copy command"
+							variant="pill"
+							lang="sh"
+						/>
+					</AutomaticPath>
+					<ManualPath>
+						<p>
+							<strong>In VS Code (Copilot Chat):</strong> install Kody directly,
+							create or edit <code>.vscode/mcp.json</code> in your workspace, or
+							open user MCP config via the{' '}
+							<strong>MCP: Open User Configuration</strong> command. VS Code
+							uses the root key <code>servers</code>, not{' '}
+							<code>mcpServers</code>. Use Agent mode in Copilot Chat so MCP
+							tools are available, then complete OAuth when VS Code opens it.
+						</p>
+						<InstallDeepLink href={installUrl} label="Add to VS Code" />
+						<CopyCard
+							label=".vscode/mcp.json"
+							value={vsCodeJson}
+							copyLabel="Copy JSON"
+							lang="json"
+						/>
+						<p>
+							Or merge this into <code>~/.copilot/mcp-config.json</code> (root
+							key <code>mcpServers</code>):
+						</p>
+						<CopyCard
+							label="~/.copilot/mcp-config.json"
+							value={copilotCliJson}
+							copyLabel="Copy JSON"
+							lang="json"
+						/>
+						<p>
+							See GitHub&apos;s{' '}
+							<a
+								href={copilotCliMcpGuideUrl}
+								target="_blank"
+								rel="noreferrer noopener"
+							>
+								Copilot CLI MCP docs
+							</a>{' '}
+							for details. For the desktop GitHub Copilot app, use the{' '}
+							<strong>Copilot App</strong> tab.
+						</p>
+					</ManualPath>
 					<ClientNote>{codingAgentPackageHint}</ClientNote>
 				</>
 			)
@@ -377,34 +463,38 @@ function renderPanelContent(kind: McpClientKind, mcpServerUrl: string) {
 						<strong>MCP Servers</strong>. Add a custom remote HTTP server with
 						this MCP URL, then complete OAuth when the app opens it:
 					</p>
-					<CopyCard
-						label="MCP URL"
-						value={mcpServerUrl}
-						copyLabel="Copy MCP URL"
-						variant="pill"
-					/>
-					<p>
-						Servers you already configured for Copilot CLI (or in a repository)
-						are also available in the app. You can merge this into{' '}
-						<code>~/.copilot/mcp-config.json</code> instead:
-					</p>
-					<CopyCard
-						label="~/.copilot/mcp-config.json"
-						value={copilotCliJson}
-						copyLabel="Copy JSON"
-						lang="json"
-					/>
-					<p>
-						See GitHub&apos;s{' '}
-						<a
-							href={copilotAppCustomizeGuideUrl}
-							target="_blank"
-							rel="noreferrer noopener"
-						>
-							Copilot app customization docs
-						</a>{' '}
-						for MCP Servers, skills, and plugins.
-					</p>
+					<AutomaticPath>
+						<CopyCard
+							label="MCP URL"
+							value={mcpServerUrl}
+							copyLabel="Copy MCP URL"
+							variant="pill"
+						/>
+					</AutomaticPath>
+					<ManualPath>
+						<p>
+							Servers you already configured for Copilot CLI (or in a
+							repository) are also available in the app. You can merge this
+							into <code>~/.copilot/mcp-config.json</code> instead:
+						</p>
+						<CopyCard
+							label="~/.copilot/mcp-config.json"
+							value={copilotCliJson}
+							copyLabel="Copy JSON"
+							lang="json"
+						/>
+						<p>
+							See GitHub&apos;s{' '}
+							<a
+								href={copilotAppCustomizeGuideUrl}
+								target="_blank"
+								rel="noreferrer noopener"
+							>
+								Copilot app customization docs
+							</a>{' '}
+							for MCP Servers, skills, and plugins.
+						</p>
+					</ManualPath>
 					<ClientNote>{nonCodingAgentNote}</ClientNote>
 				</>
 			)
@@ -417,19 +507,23 @@ function renderPanelContent(kind: McpClientKind, mcpServerUrl: string) {
 						can connect to Kody. Add a remote MCP server pointed at this URL and
 						complete the OAuth flow when the host opens it:
 					</p>
-					<CopyCard
-						label="MCP URL"
-						value={mcpServerUrl}
-						copyLabel="Copy MCP URL"
-						variant="pill"
-					/>
-					<p>
-						Config file shapes differ by host. If your client expects a JSON{' '}
-						<code>mcpServers</code> map with a <code>url</code> field, start
-						from the Cursor or Copilot CLI snippet; if it uses{' '}
-						<code>servers</code> with <code>type: &quot;http&quot;</code>, use
-						the Copilot (VS Code) snippet.
-					</p>
+					<AutomaticPath>
+						<CopyCard
+							label="MCP URL"
+							value={mcpServerUrl}
+							copyLabel="Copy MCP URL"
+							variant="pill"
+						/>
+					</AutomaticPath>
+					<ManualPath>
+						<p>
+							Config file shapes differ by host. If your client expects a JSON{' '}
+							<code>mcpServers</code> map with a <code>url</code> field, start
+							from the Cursor or Copilot CLI snippet; if it uses{' '}
+							<code>servers</code> with <code>type: &quot;http&quot;</code>, use
+							the Copilot (VS Code) snippet.
+						</p>
+					</ManualPath>
 				</>
 			)
 		default: {
@@ -574,6 +668,60 @@ const tabPanelCss = {
 	},
 	// Enters via @starting-style so a fast host-switch retargets the
 	// in-flight transition instead of restarting keyframes from zero.
+	'@media (prefers-reduced-motion: no-preference)': {
+		transition: `opacity 240ms ${transitions.easeOut}, translate 240ms ${transitions.easeOut}`,
+	},
+	'@starting-style': {
+		opacity: 0,
+		translate: '0 6px',
+	},
+}
+
+const installPathCss = {
+	display: 'grid',
+	gap: '0.75rem',
+}
+
+const pathLabelCss = {
+	margin: 0,
+	font: `700 1.05rem/1.3 ${typography.fontFamilyDisplay}`,
+	color: colors.text,
+}
+
+const manualDetailsCss = {
+	display: 'grid',
+	gap: '0.4rem',
+	'&[open] > summary': {
+		marginBottom: '0.15rem',
+	},
+}
+
+const manualSummaryCss = {
+	cursor: 'pointer',
+	width: 'fit-content',
+	padding: '0.3rem 0',
+	font: `700 1.05rem/1.3 ${typography.fontFamilyDisplay}`,
+	color: colors.text,
+	transition: `color ${transitions.fast}`,
+	[hoverMq]: {
+		'&:hover': {
+			color: colors.primaryText,
+		},
+	},
+}
+
+const manualBodyCss = {
+	display: 'grid',
+	gap: '0.9rem',
+	marginTop: '0.6rem',
+	'& > p': {
+		margin: 0,
+		color: colors.textMuted,
+		maxWidth: '72ch',
+	},
+	'& > p a': {
+		color: colors.primaryText,
+	},
 	'@media (prefers-reduced-motion: no-preference)': {
 		transition: `opacity 240ms ${transitions.easeOut}, translate 240ms ${transitions.easeOut}`,
 	},

--- a/packages/worker/client/routes/onboarding-mcp-clients.node.test.ts
+++ b/packages/worker/client/routes/onboarding-mcp-clients.node.test.ts
@@ -1,17 +1,27 @@
+import { execSync } from 'node:child_process'
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { expect, test } from 'vitest'
 import {
 	buildClaudeCodeAddCommand,
 	buildClaudeCodeMcpJson,
+	buildCodexMcpAddCommand,
 	buildCodexMcpToml,
 	buildCopilotCliAddCommand,
 	buildCopilotCliMcpJson,
 	buildCursorInstallUrl,
 	buildCursorMcpJson,
+	buildCursorMcpMergeCommand,
 	buildKodyAppIconUrl,
+	buildOpenCodeMcpAddCommand,
 	buildOpenCodeMcpJson,
 	buildVsCodeInstallUrl,
 	buildVsCodeMcpJson,
+	codexMcpLoginCommand,
 	mcpClientTabs,
+	mergeCursorUserMcpConfig,
+	openCodeMcpAuthCommand,
 } from './onboarding-mcp-clients.ts'
 
 const mcpServerUrl = 'https://heykody.dev/mcp'
@@ -54,7 +64,17 @@ test('onboarding MCP client builders emit the structured configs each host expec
 			},
 		},
 	})
-	expect(buildClaudeCodeAddCommand(mcpServerUrl)).toContain(mcpServerUrl)
+	expect(buildClaudeCodeAddCommand(mcpServerUrl)).toBe(
+		`claude mcp add --transport http -s user kody ${mcpServerUrl}`,
+	)
+	expect(buildCodexMcpAddCommand(mcpServerUrl)).toBe(
+		`codex mcp add kody --url ${mcpServerUrl}`,
+	)
+	expect(codexMcpLoginCommand).toBe('codex mcp login kody')
+	expect(buildOpenCodeMcpAddCommand(mcpServerUrl)).toBe(
+		`opencode mcp add kody --url ${mcpServerUrl}`,
+	)
+	expect(openCodeMcpAuthCommand).toBe('opencode mcp auth kody')
 	expect(JSON.parse(buildVsCodeMcpJson(mcpServerUrl))).toEqual({
 		servers: {
 			kody: {
@@ -119,4 +139,88 @@ test('onboarding MCP client builders emit the structured configs each host expec
 		type: 'http',
 		url: mcpServerUrl,
 	})
+
+	expect(mergeCursorUserMcpConfig(null, mcpServerUrl)).toEqual({
+		mcpServers: { kody: { url: mcpServerUrl } },
+	})
+	expect(
+		mergeCursorUserMcpConfig(
+			{
+				mcpServers: {
+					other: { command: 'npx' },
+					kody: { url: 'https://old.example/mcp', headers: { X: '1' } },
+				},
+				theme: 'dark',
+			},
+			mcpServerUrl,
+		),
+	).toEqual({
+		mcpServers: {
+			other: { command: 'npx' },
+			kody: { url: mcpServerUrl },
+		},
+		theme: 'dark',
+	})
+	expect(() => mergeCursorUserMcpConfig([], mcpServerUrl)).toThrow(
+		/must be a JSON object/u,
+	)
+	expect(() =>
+		mergeCursorUserMcpConfig({ mcpServers: [] }, mcpServerUrl),
+	).toThrow(/mcpServers must be an object/u)
+
+	const cursorCommand = buildCursorMcpMergeCommand(mcpServerUrl)
+	expect(cursorCommand).toContain(mcpServerUrl)
+	expect(cursorCommand).toContain("node <<'EOF'")
+	expect(cursorCommand).not.toMatch(/cursor mcp add|agent mcp add/u)
+
+	const home = mkdtempSync(join(tmpdir(), 'kody-cursor-mcp-'))
+	execSync(cursorCommand, {
+		env: { ...process.env, HOME: home },
+		shell: '/bin/bash',
+	})
+	expect(
+		JSON.parse(readFileSync(join(home, '.cursor', 'mcp.json'), 'utf8')),
+	).toEqual({
+		mcpServers: { kody: { url: mcpServerUrl } },
+	})
+
+	mkdirSync(join(home, 'existing', '.cursor'), { recursive: true })
+	const existingHome = join(home, 'existing')
+	writeFileSync(
+		join(existingHome, '.cursor', 'mcp.json'),
+		JSON.stringify(
+			{
+				mcpServers: { notes: { command: 'notes' } },
+				extra: true,
+			},
+			null,
+			2,
+		),
+	)
+	execSync(buildCursorMcpMergeCommand(mcpServerUrl), {
+		env: { ...process.env, HOME: existingHome },
+		shell: '/bin/bash',
+	})
+	expect(
+		JSON.parse(readFileSync(join(existingHome, '.cursor', 'mcp.json'), 'utf8')),
+	).toEqual({
+		mcpServers: {
+			notes: { command: 'notes' },
+			kody: { url: mcpServerUrl },
+		},
+		extra: true,
+	})
+
+	const invalidHome = join(home, 'invalid')
+	mkdirSync(join(invalidHome, '.cursor'), { recursive: true })
+	writeFileSync(join(invalidHome, '.cursor', 'mcp.json'), '{not-json')
+	expect(() =>
+		execSync(buildCursorMcpMergeCommand(mcpServerUrl), {
+			env: { ...process.env, HOME: invalidHome },
+			shell: '/bin/bash',
+		}),
+	).toThrow()
+	expect(readFileSync(join(invalidHome, '.cursor', 'mcp.json'), 'utf8')).toBe(
+		'{not-json',
+	)
 })

--- a/packages/worker/client/routes/onboarding-mcp-clients.node.test.ts
+++ b/packages/worker/client/routes/onboarding-mcp-clients.node.test.ts
@@ -1,7 +1,3 @@
-import { execSync } from 'node:child_process'
-import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
-import { join } from 'node:path'
 import { expect, test } from 'vitest'
 import {
 	buildClaudeCodeAddCommand,
@@ -12,19 +8,19 @@ import {
 	buildCopilotCliMcpJson,
 	buildCursorInstallUrl,
 	buildCursorMcpJson,
-	buildCursorMcpMergeCommand,
 	buildKodyAppIconUrl,
+	buildKodyCliInstallCommand,
 	buildOpenCodeMcpAddCommand,
 	buildOpenCodeMcpJson,
 	buildVsCodeInstallUrl,
 	buildVsCodeMcpJson,
 	codexMcpLoginCommand,
+	defaultKodyMcpUrl,
 	mcpClientTabs,
-	mergeCursorUserMcpConfig,
 	openCodeMcpAuthCommand,
 } from './onboarding-mcp-clients.ts'
 
-const mcpServerUrl = 'https://heykody.dev/mcp'
+const mcpServerUrl = defaultKodyMcpUrl
 
 test('onboarding MCP client builders emit the structured configs each host expects', () => {
 	expect(mcpClientTabs.map((tab) => tab.id)).toEqual([
@@ -47,6 +43,16 @@ test('onboarding MCP client builders emit the structured configs each host expec
 	)
 	expect(mcpClientTabs.find((tab) => tab.id === 'copilot-app')?.label).toBe(
 		'Copilot App',
+	)
+
+	expect(buildKodyCliInstallCommand(mcpServerUrl)).toBe(
+		'npx @kodycodes/cli install',
+	)
+	expect(buildKodyCliInstallCommand(`${mcpServerUrl}/`)).toBe(
+		'npx @kodycodes/cli install',
+	)
+	expect(buildKodyCliInstallCommand('http://localhost:3742/mcp')).toBe(
+		'npx @kodycodes/cli install --mcp-url http://localhost:3742/mcp',
 	)
 
 	expect(JSON.parse(buildCursorMcpJson(mcpServerUrl))).toEqual({
@@ -107,7 +113,7 @@ test('onboarding MCP client builders emit the structured configs each host expec
 		['[mcp_servers.kody]', `url = "${mcpServerUrl}"`, ''].join('\n'),
 	)
 	expect(buildKodyAppIconUrl(mcpServerUrl)).toBe(
-		'https://heykody.dev/apple-touch-icon.png',
+		'https://kody.codes/apple-touch-icon.png',
 	)
 
 	const cursorInstallUrl = new URL(buildCursorInstallUrl(mcpServerUrl))
@@ -139,89 +145,4 @@ test('onboarding MCP client builders emit the structured configs each host expec
 		type: 'http',
 		url: mcpServerUrl,
 	})
-
-	expect(mergeCursorUserMcpConfig(null, mcpServerUrl)).toEqual({
-		mcpServers: { kody: { url: mcpServerUrl } },
-	})
-	expect(
-		mergeCursorUserMcpConfig(
-			{
-				mcpServers: {
-					other: { command: 'npx' },
-					kody: { url: 'https://old.example/mcp', headers: { X: '1' } },
-				},
-				theme: 'dark',
-			},
-			mcpServerUrl,
-		),
-	).toEqual({
-		mcpServers: {
-			other: { command: 'npx' },
-			kody: { url: mcpServerUrl },
-		},
-		theme: 'dark',
-	})
-	expect(() => mergeCursorUserMcpConfig([], mcpServerUrl)).toThrow(
-		/must be a JSON object/u,
-	)
-	expect(() =>
-		mergeCursorUserMcpConfig({ mcpServers: [] }, mcpServerUrl),
-	).toThrow(/mcpServers must be an object/u)
-
-	const cursorCommand = buildCursorMcpMergeCommand(mcpServerUrl)
-	expect(cursorCommand).toContain(mcpServerUrl)
-	expect(cursorCommand).toContain("node <<'EOF'")
-	expect(cursorCommand).not.toMatch(/cursor mcp add|agent mcp add/u)
-
-	const home = mkdtempSync(join(tmpdir(), 'kody-cursor-mcp-'))
-	execSync(cursorCommand, {
-		env: { ...process.env, HOME: home },
-		shell: '/bin/bash',
-	})
-	expect(
-		JSON.parse(readFileSync(join(home, '.cursor', 'mcp.json'), 'utf8')),
-	).toEqual({
-		mcpServers: { kody: { url: mcpServerUrl } },
-	})
-
-	mkdirSync(join(home, 'existing', '.cursor'), { recursive: true })
-	const existingHome = join(home, 'existing')
-	writeFileSync(
-		join(existingHome, '.cursor', 'mcp.json'),
-		JSON.stringify(
-			{
-				mcpServers: { notes: { command: 'notes' } },
-				extra: true,
-			},
-			null,
-			2,
-		),
-	)
-	execSync(buildCursorMcpMergeCommand(mcpServerUrl), {
-		env: { ...process.env, HOME: existingHome },
-		shell: '/bin/bash',
-	})
-	expect(
-		JSON.parse(readFileSync(join(existingHome, '.cursor', 'mcp.json'), 'utf8')),
-	).toEqual({
-		mcpServers: {
-			notes: { command: 'notes' },
-			kody: { url: mcpServerUrl },
-		},
-		extra: true,
-	})
-
-	const invalidHome = join(home, 'invalid')
-	mkdirSync(join(invalidHome, '.cursor'), { recursive: true })
-	writeFileSync(join(invalidHome, '.cursor', 'mcp.json'), '{not-json')
-	expect(() =>
-		execSync(buildCursorMcpMergeCommand(mcpServerUrl), {
-			env: { ...process.env, HOME: invalidHome },
-			shell: '/bin/bash',
-			stdio: 'pipe',
-		}),
-	).toThrow()
-	expect(readFileSync(join(invalidHome, '.cursor', 'mcp.json'), 'utf8')).toBe(
-		'{not-json',
-	)
 })

--- a/packages/worker/client/routes/onboarding-mcp-clients.node.test.ts
+++ b/packages/worker/client/routes/onboarding-mcp-clients.node.test.ts
@@ -218,6 +218,7 @@ test('onboarding MCP client builders emit the structured configs each host expec
 		execSync(buildCursorMcpMergeCommand(mcpServerUrl), {
 			env: { ...process.env, HOME: invalidHome },
 			shell: '/bin/bash',
+			stdio: 'pipe',
 		}),
 	).toThrow()
 	expect(readFileSync(join(invalidHome, '.cursor', 'mcp.json'), 'utf8')).toBe(

--- a/packages/worker/client/routes/onboarding-mcp-clients.ts
+++ b/packages/worker/client/routes/onboarding-mcp-clients.ts
@@ -122,6 +122,91 @@ export function buildClaudeCodeAddCommand(mcpServerUrl: string) {
 	return `claude mcp add --transport http -s user kody ${mcpServerUrl}`
 }
 
+/** Codex CLI streamable HTTP add. OAuth may need `codex mcp login kody`. */
+export function buildCodexMcpAddCommand(mcpServerUrl: string) {
+	return `codex mcp add kody --url ${mcpServerUrl}`
+}
+
+export const codexMcpLoginCommand = 'codex mcp login kody'
+
+/**
+ * OpenCode non-interactive remote add (`opencode mcp add <name> --url`).
+ * OAuth may need `opencode mcp auth kody`.
+ */
+export function buildOpenCodeMcpAddCommand(mcpServerUrl: string) {
+	return `opencode mcp add kody --url ${mcpServerUrl}`
+}
+
+export const openCodeMcpAuthCommand = 'opencode mcp auth kody'
+
+/**
+ * Merge `mcpServers.kody.url` into a Cursor user-global `mcp.json` object
+ * without replacing other top-level keys or other servers.
+ */
+export function mergeCursorUserMcpConfig(
+	existing: unknown,
+	mcpServerUrl: string,
+) {
+	if (
+		existing != null &&
+		(typeof existing !== 'object' || Array.isArray(existing))
+	) {
+		throw new Error('Cursor mcp.json must be a JSON object')
+	}
+	const config =
+		existing == null ? {} : { ...(existing as Record<string, unknown>) }
+	const existingServers = config.mcpServers
+	if (
+		existingServers != null &&
+		(typeof existingServers !== 'object' || Array.isArray(existingServers))
+	) {
+		throw new Error('Cursor mcp.json mcpServers must be an object')
+	}
+	const servers =
+		existingServers == null
+			? {}
+			: { ...(existingServers as Record<string, unknown>) }
+	config.mcpServers = {
+		...servers,
+		kody: { url: mcpServerUrl },
+	}
+	return config
+}
+
+/**
+ * Copyable Node heredoc that writes `~/.cursor/mcp.json`. Cursor has no
+ * official `mcp add` CLI (agent mcp only lists, enables, and logs in).
+ */
+export function buildCursorMcpMergeCommand(mcpServerUrl: string) {
+	const urlLiteral = JSON.stringify(mcpServerUrl)
+	return [
+		'# Adds Kody to ~/.cursor/mcp.json without replacing other servers',
+		"node <<'EOF'",
+		"const fs = require('node:fs')",
+		"const path = require('node:path')",
+		"const os = require('node:os')",
+		"const file = path.join(os.homedir(), '.cursor', 'mcp.json')",
+		`const url = ${urlLiteral}`,
+		'let config = {}',
+		'try {',
+		"  config = JSON.parse(fs.readFileSync(file, 'utf8'))",
+		'} catch (error) {',
+		"  if (error.code !== 'ENOENT') throw error",
+		'}',
+		'if (!config || typeof config !== "object" || Array.isArray(config)) {',
+		"  throw new Error('~/.cursor/mcp.json must be a JSON object')",
+		'}',
+		'const servers = config.mcpServers',
+		'if (servers != null && (typeof servers !== "object" || Array.isArray(servers))) {',
+		"  throw new Error('~/.cursor/mcp.json mcpServers must be an object')",
+		'}',
+		'config.mcpServers = { ...servers, kody: { url } }',
+		"fs.mkdirSync(path.dirname(file), { recursive: true })",
+		"fs.writeFileSync(file, JSON.stringify(config, null, 2) + '\\n')",
+		'EOF',
+	].join('\n')
+}
+
 /** VS Code Copilot `.vscode/mcp.json` (root key is `servers`, not `mcpServers`). */
 export function buildVsCodeMcpJson(mcpServerUrl: string) {
 	return prettyJson({

--- a/packages/worker/client/routes/onboarding-mcp-clients.ts
+++ b/packages/worker/client/routes/onboarding-mcp-clients.ts
@@ -201,7 +201,7 @@ export function buildCursorMcpMergeCommand(mcpServerUrl: string) {
 		"  throw new Error('~/.cursor/mcp.json mcpServers must be an object')",
 		'}',
 		'config.mcpServers = { ...servers, kody: { url } }',
-		"fs.mkdirSync(path.dirname(file), { recursive: true })",
+		'fs.mkdirSync(path.dirname(file), { recursive: true })',
 		"fs.writeFileSync(file, JSON.stringify(config, null, 2) + '\\n')",
 		'EOF',
 	].join('\n')

--- a/packages/worker/client/routes/onboarding-mcp-clients.ts
+++ b/packages/worker/client/routes/onboarding-mcp-clients.ts
@@ -66,6 +66,25 @@ export const claudeDesktopToolHint =
 export const codingAgentPackageHint =
 	'Coding agents are the best fit when you want to create or edit Kody packages. Once a package exists, non-coding agents can use it just fine.'
 
+/** Production MCP URL. `@kodycodes/cli install` uses this when `--mcp-url` is omitted. */
+export const defaultKodyMcpUrl = 'https://kody.codes/mcp'
+
+/**
+ * Copyable Automatic command for every client. Production uses the CLI
+ * default; preview and local origins pass `--mcp-url` so install writes
+ * this deployment's MCP endpoint.
+ */
+export function buildKodyCliInstallCommand(mcpServerUrl: string) {
+	if (normalizeMcpUrl(mcpServerUrl) === defaultKodyMcpUrl) {
+		return 'npx @kodycodes/cli install'
+	}
+	return `npx @kodycodes/cli install --mcp-url ${mcpServerUrl}`
+}
+
+function normalizeMcpUrl(mcpServerUrl: string) {
+	return mcpServerUrl.replace(/\/+$/u, '')
+}
+
 function prettyJson(value: unknown) {
 	return `${JSON.stringify(value, null, 2)}\n`
 }
@@ -138,74 +157,6 @@ export function buildOpenCodeMcpAddCommand(mcpServerUrl: string) {
 }
 
 export const openCodeMcpAuthCommand = 'opencode mcp auth kody'
-
-/**
- * Merge `mcpServers.kody.url` into a Cursor user-global `mcp.json` object
- * without replacing other top-level keys or other servers.
- */
-export function mergeCursorUserMcpConfig(
-	existing: unknown,
-	mcpServerUrl: string,
-) {
-	if (
-		existing != null &&
-		(typeof existing !== 'object' || Array.isArray(existing))
-	) {
-		throw new Error('Cursor mcp.json must be a JSON object')
-	}
-	const config =
-		existing == null ? {} : { ...(existing as Record<string, unknown>) }
-	const existingServers = config.mcpServers
-	if (
-		existingServers != null &&
-		(typeof existingServers !== 'object' || Array.isArray(existingServers))
-	) {
-		throw new Error('Cursor mcp.json mcpServers must be an object')
-	}
-	const servers =
-		existingServers == null
-			? {}
-			: { ...(existingServers as Record<string, unknown>) }
-	config.mcpServers = {
-		...servers,
-		kody: { url: mcpServerUrl },
-	}
-	return config
-}
-
-/**
- * Copyable Node heredoc that writes `~/.cursor/mcp.json`. Cursor has no
- * official `mcp add` CLI (agent mcp only lists, enables, and logs in).
- */
-export function buildCursorMcpMergeCommand(mcpServerUrl: string) {
-	const urlLiteral = JSON.stringify(mcpServerUrl)
-	return [
-		'# Adds Kody to ~/.cursor/mcp.json without replacing other servers',
-		"node <<'EOF'",
-		"const fs = require('node:fs')",
-		"const path = require('node:path')",
-		"const os = require('node:os')",
-		"const file = path.join(os.homedir(), '.cursor', 'mcp.json')",
-		`const url = ${urlLiteral}`,
-		'let config = {}',
-		'try {',
-		"  config = JSON.parse(fs.readFileSync(file, 'utf8'))",
-		'} catch (error) {',
-		"  if (error.code !== 'ENOENT') throw error",
-		'}',
-		'if (!config || typeof config !== "object" || Array.isArray(config)) {',
-		"  throw new Error('~/.cursor/mcp.json must be a JSON object')",
-		'}',
-		'const servers = config.mcpServers',
-		'if (servers != null && (typeof servers !== "object" || Array.isArray(servers))) {',
-		"  throw new Error('~/.cursor/mcp.json mcpServers must be an object')",
-		'}',
-		'config.mcpServers = { ...servers, kody: { url } }',
-		'fs.mkdirSync(path.dirname(file), { recursive: true })',
-		"fs.writeFileSync(file, JSON.stringify(config, null, 2) + '\\n')",
-		'EOF',
-	].join('\n')
-}
 
 /** VS Code Copilot `.vscode/mcp.json` (root key is `servers`, not `mcpServers`). */
 export function buildVsCodeMcpJson(mcpServerUrl: string) {

--- a/packages/worker/client/routes/onboarding.tsx
+++ b/packages/worker/client/routes/onboarding.tsx
@@ -613,9 +613,8 @@ export function OnboardingRoute(handle: Handle) {
 										list and click <strong>Authenticate</strong>.
 									</span>
 									<span>
-										<strong>Claude Code:</strong> after copying and running the
-										command, enter <code>/mcp</code> → Kody →{' '}
-										<strong>Authenticate</strong>.
+										<strong>Claude Code:</strong> after install, enter{' '}
+										<code>/mcp</code> → Kody → <strong>Authenticate</strong>.
 									</span>
 									<span>
 										Approve the <strong>kody.codes</strong> OAuth window. This

--- a/packages/worker/client/routes/onboarding.tsx
+++ b/packages/worker/client/routes/onboarding.tsx
@@ -609,8 +609,8 @@ export function OnboardingRoute(handle: Handle) {
 								>
 									<strong>Authenticate Kody before you continue</strong>
 									<span>
-										<strong>Cursor:</strong> after Add to Cursor, open the
-										Cursor MCP list and click <strong>Authenticate</strong>.
+										<strong>Cursor:</strong> after install, open the Cursor MCP
+										list and click <strong>Authenticate</strong>.
 									</span>
 									<span>
 										<strong>Claude Code:</strong> after copying and running the


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Get started Step 1 should start everyone on one official install: `@kodycodes/cli`. Host-specific deeplinks, vendor CLIs, and JSON/TOML stay as Manual fallbacks. Official non-MCP API packages stay the long-term preferred invoke path and are not rewritten here.

## Summary

- Automatic is one command for every client: `npx @kodycodes/cli install`.
- Production (`https://kody.codes/mcp`) omits `--mcp-url` because that is the CLI default. Preview and local origins add `--mcp-url` with the live `mcpServerUrl`.
- Client tabs move under a collapsed **Manual** section (still defaults to Cursor). Deeplinks, vendor CLIs, MCP URL, and JSON/TOML stay there.
- The CLI configures running local agents. Web hosts (ChatGPT, Claude.ai, Grok) stay under Manual.
- Authenticate callout stays (Cursor MCP list; Claude Code `/mcp` → Kody → Authenticate).
- Usage docs match this path. Fixtures and examples use `kody.codes`, not `heykody.*`.

## Testing

- `npx vitest run --project node-unit packages/worker/client/routes/onboarding-mcp-clients.node.test.ts packages/worker/client/routes/onboarding-mcp-client-tabs.node.test.ts` — 2 files, 2 tests passed.
- `npx nx run worker:typecheck` — passed.
- Manual: signed in as `kody@example.com` on the running app (`http://127.0.0.1:3848/onboarding`) and captured Automatic + expanded Manual from the live page.

![Logged-in Get started Step 1 with Automatic @kodycodes/cli install](https://cursor.com/artifacts/c/art-fb944d9a-6eb2-4722-9ec8-ad68cf027c1e)

![Same live page with Manual expanded, Cursor tab, Add to Cursor](https://cursor.com/artifacts/c/art-cb196972-e9ca-4f52-b947-4d901667c9be)

<a href="https://cursor.com/agents/bc-8705b828-83b5-48b5-ad54-312b87c53c29/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fonboarding_step1_cli_install.mp4"><img src="https://cursor.com/artifacts/c/art-26574997-e9ee-4fb3-a7bc-1a9d06065544" alt="onboarding_step1_cli_install.mp4" /></a>

The local screenshot command includes `--mcp-url http://127.0.0.1:3848/mcp` because Automatic uses the live request origin. On kody.codes the same UI shows `npx @kodycodes/cli install` with no override.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `8dc01e6f` · **Head:** `7f378216`

**Classification:** composes — no primitives added or changed; this PR rearranges onboarding Step 1 copy around the existing MCP URL and the official CLI.

### Primitives touched

| Primitive | Group    | Impact   |
| --------- | -------- | -------- |
| `app-ui`  | surfaces | composes |

Unmatched paths: `docs/use/connect-your-agent.md`, `docs/use/index.md` (usage docs only).

### Change flow

Get started Step 1 shows one `@kodycodes/cli install` command first. Host-specific install options stay under Manual.

```mermaid
sequenceDiagram
	actor User
	participant appUi as app-ui
	User->>appUi: open /onboarding#connect-agent
	appUi->>User: Automatic npx @kodycodes/cli install
	opt Manual disclosure
		appUi->>User: client tabs, deeplink, vendor CLI, JSON/TOML
	end
	User->>appUi: Authenticate in host MCP list
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8705b828-83b5-48b5-ad54-312b87c53c29?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8705b828-83b5-48b5-ad54-312b87c53c29&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

