### PR TITLE
fix(mcp): keep missing repo session ids off Sentry (KODY-CLOUDFLARE-5V)

### DIFF
--- a/packages/worker/src/mcp/capabilities/repo/repo-shared.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/repo/repo-shared.node.test.ts
@@ -1,0 +1,26 @@
+import { expect, test } from 'vitest'
+import { repoSessionIdSchema } from './repo-shared.ts'
+
+test('repoSessionIdSchema accepts real session ids', () => {
+	expect(
+		repoSessionIdSchema.parse({
+			session_id: 'de72ddd6-e277-4f69-a5db-3d6ece06ca6b',
+		}),
+	).toEqual({
+		session_id: 'de72ddd6-e277-4f69-a5db-3d6ece06ca6b',
+	})
+	expect(repoSessionIdSchema.parse({ session_id: 'session-1' })).toEqual({
+		session_id: 'session-1',
+	})
+})
+
+test('repoSessionIdSchema rejects placeholder session ids', () => {
+	for (const session_id of ['none', 'None', 'null', 'undefined', 'n/a']) {
+		const result = repoSessionIdSchema.safeParse({ session_id })
+		expect(result.success).toBe(false)
+		if (result.success) continue
+		expect(result.error.issues[0]?.message).toContain(
+			'not a placeholder like "none"',
+		)
+	}
+})

--- a/packages/worker/src/mcp/capabilities/repo/repo-shared.ts
+++ b/packages/worker/src/mcp/capabilities/repo/repo-shared.ts
@@ -94,8 +94,36 @@ export const repoResolvedTargetSchema = z.union([
 	}),
 ])
 
+/**
+ * Agents sometimes pass literal placeholders (`none`, `null`, …) when they do
+ * not have a session id yet. Reject those at the schema boundary with guidance
+ * so the mistake never reaches the RepoSession DO or Sentry (KODY-CLOUDFLARE-5V).
+ */
+const repoSessionIdPlaceholderValues = new Set([
+	'none',
+	'null',
+	'undefined',
+	'nil',
+	'n/a',
+	'na',
+])
+
+export const repoSessionIdFieldSchema = z
+	.string()
+	.min(1)
+	.refine(
+		(value) => !repoSessionIdPlaceholderValues.has(value.trim().toLowerCase()),
+		{
+			message:
+				'session_id must be a real id from repo_open_session or repo_list_sessions, not a placeholder like "none".',
+		},
+	)
+	.describe(
+		'Active repo session id from repo_open_session or repo_list_sessions.',
+	)
+
 export const repoSessionIdSchema = z.object({
-	session_id: z.string().min(1).describe('Active repo session id.'),
+	session_id: repoSessionIdFieldSchema,
 })
 
 export const repoPublishSessionInputSchema = repoSessionIdSchema.extend({

--- a/packages/worker/src/mcp/observability.node.test.ts
+++ b/packages/worker/src/mcp/observability.node.test.ts
@@ -275,6 +275,18 @@ test('logMcpEvent keeps sandbox and caller failures off Sentry and still reports
 			),
 		})
 
+		// Missing / placeholder repo session id (KODY-CLOUDFLARE-5V).
+		logMcpEvent({
+			...callerFailureBase,
+			capabilityName: 'repo_read_file',
+			domain: 'repo',
+			capabilitySource: 'builtin',
+			failurePhase: 'handler',
+			errorName: 'Error',
+			errorMessage: 'Repo session "none" was not found.',
+			cause: new Error('Repo session "none" was not found.'),
+		})
+
 		// Invalid repo_search regex (KODY-CLOUDFLARE-49). Plain Error from DO RPC.
 		logMcpEvent({
 			...callerFailureBase,
@@ -352,7 +364,7 @@ test('logMcpEvent keeps sandbox and caller failures off Sentry and still reports
 		})
 	})
 
-	expect(payloads).toHaveLength(20)
+	expect(payloads).toHaveLength(21)
 	expect(JSON.parse(payloads[0]!)).toMatchObject({
 		tool: 'execute',
 		outcome: 'failure',

--- a/packages/worker/src/mcp/observability.ts
+++ b/packages/worker/src/mcp/observability.ts
@@ -9,6 +9,7 @@ import {
 	isGitPushNotFastForwardMessage,
 	isRepoSearchInvalidRegexMessage,
 	isRepoSessionInactiveMessage,
+	isRepoSessionNotFoundMessage,
 } from '#worker/repo/repo-session-caller-error.ts'
 import {
 	isDestructiveOverwriteConfirmationMessage,
@@ -147,15 +148,16 @@ function isCallerFailure(payload: McpObservabilityPayload, cause?: unknown) {
 	) {
 		return true
 	}
-	// Published / inactive repo sessions and invalid repo_search regexes are
-	// thrown inside the RepoSession Durable Object as plain Errors. Match the
-	// stable phrases so they stay out of Sentry even when a capability forgets
-	// to re-wrap as McpCallerError.
+	// Published / inactive / missing repo sessions and invalid repo_search
+	// regexes are thrown inside the RepoSession Durable Object as plain Errors.
+	// Match the stable phrases so they stay out of Sentry even when a
+	// capability forgets to re-wrap as McpCallerError.
 	if (
 		getErrorCauseChain(cause).some(
 			(entry) =>
 				entry instanceof Error &&
 				(isRepoSessionInactiveMessage(entry.message) ||
+					isRepoSessionNotFoundMessage(entry.message) ||
 					isRepoSearchInvalidRegexMessage(entry.message)),
 		)
 	) {

--- a/packages/worker/src/repo/repo-session-caller-error.node.test.ts
+++ b/packages/worker/src/repo/repo-session-caller-error.node.test.ts
@@ -2,6 +2,8 @@ import { expect, test } from 'vitest'
 import {
 	isGitPushNotFastForwardError,
 	isGitPushNotFastForwardMessage,
+	isRepoSessionInactiveMessage,
+	isRepoSessionNotFoundMessage,
 } from './repo-session-caller-error.ts'
 
 test('isGitPushNotFastForwardError matches isomorphic-git PushRejected non-FF only', () => {
@@ -31,4 +33,33 @@ test('isGitPushNotFastForwardError matches isomorphic-git PushRejected non-FF on
 	expect(isGitPushNotFastForwardError(new Error('D1 write failed.'))).toBe(
 		false,
 	)
+})
+
+test('isRepoSessionNotFoundMessage matches missing and wrong-user phrases only', () => {
+	expect(
+		isRepoSessionNotFoundMessage('Repo session "none" was not found.'),
+	).toBe(true)
+	expect(
+		isRepoSessionNotFoundMessage(
+			'Repo session "none" was not found. Use repo_list_sessions or repo_open_session to obtain a valid session_id.',
+		),
+	).toBe(true)
+	expect(
+		isRepoSessionNotFoundMessage(
+			'Repo session "de72ddd6-e277-4f69-a5db-3d6ece06ca6b" was not found for this user.',
+		),
+	).toBe(true)
+	expect(
+		isRepoSessionNotFoundMessage(
+			'Repo session "de72ddd6-e277-4f69-a5db-3d6ece06ca6b" is published; open a new session before continuing.',
+		),
+	).toBe(false)
+	expect(isRepoSessionNotFoundMessage('Source "abc" was not found.')).toBe(
+		false,
+	)
+	expect(
+		isRepoSessionInactiveMessage(
+			'Repo session "de72ddd6-e277-4f69-a5db-3d6ece06ca6b" is published; open a new session before continuing.',
+		),
+	).toBe(true)
 })

--- a/packages/worker/src/repo/repo-session-caller-error.ts
+++ b/packages/worker/src/repo/repo-session-caller-error.ts
@@ -15,6 +15,32 @@ export function isRepoSessionInactiveMessage(message: string) {
 }
 
 /**
+ * Stable phrases from RepoSession DO `getSessionState` when the catalog has no
+ * row for the given id (or the row belongs to another user). Agents often pass
+ * placeholders (`none`, `null`) or stale ids; treat those as caller-correctable
+ * so they stay on `mcp-event` and out of Sentry. KODY-CLOUDFLARE-5V.
+ *
+ * Match allows an optional trailing guidance sentence after the period.
+ */
+export function isRepoSessionNotFoundMessage(message: string) {
+	return (
+		message.startsWith('Repo session "') &&
+		/" was not found(\.| for this user\.)/.test(message)
+	)
+}
+
+export const repoSessionNotFoundGuidance =
+	'Use repo_list_sessions or repo_open_session to obtain a valid session_id.'
+
+export function buildRepoSessionNotFoundMessage(sessionId: string) {
+	return `Repo session "${sessionId}" was not found. ${repoSessionNotFoundGuidance}`
+}
+
+export function buildRepoSessionNotFoundForUserMessage(sessionId: string) {
+	return `Repo session "${sessionId}" was not found for this user. ${repoSessionNotFoundGuidance}`
+}
+
+/**
  * isomorphic-git `PushRejectedError` for non-fast-forward pushes. Publish maps
  * these to `base_moved` so agents rebase; when a plain Error still escapes DO
  * RPC (subclass identity lost), MCP observability matches this phrase.

--- a/packages/worker/src/repo/repo-session-do.ts
+++ b/packages/worker/src/repo/repo-session-do.ts
@@ -1332,9 +1332,7 @@ class RepoSessionBase extends DurableObject<Env> {
 			}
 		} else {
 			if (sessionRow.user_id !== input.userId) {
-				throw new Error(
-					buildRepoSessionNotFoundForUserMessage(input.sessionId),
-				)
+				throw new Error(buildRepoSessionNotFoundForUserMessage(input.sessionId))
 			}
 			if (sessionRow.status !== 'active') {
 				throw new Error(
@@ -1563,9 +1561,7 @@ class RepoSessionBase extends DurableObject<Env> {
 			}
 		}
 		if (sessionRow.user_id !== input.userId) {
-			throw new Error(
-				buildRepoSessionNotFoundForUserMessage(input.sessionId),
-			)
+			throw new Error(buildRepoSessionNotFoundForUserMessage(input.sessionId))
 		}
 		await updateRepoSession(this.env, {
 			id: sessionRow.id,
@@ -1591,9 +1587,7 @@ class RepoSessionBase extends DurableObject<Env> {
 			sessionId: input.sessionId,
 		})
 		if (sessionRow && sessionRow.user_id !== input.userId) {
-			throw new Error(
-				buildRepoSessionNotFoundForUserMessage(input.sessionId),
-			)
+			throw new Error(buildRepoSessionNotFoundForUserMessage(input.sessionId))
 		}
 		await this.clearCachedSessionState(input.sessionId)
 		await this.resetWorkspace().catch(() => {
@@ -1630,9 +1624,7 @@ class RepoSessionBase extends DurableObject<Env> {
 			}
 		}
 		if (sessionRow.user_id !== input.userId) {
-			throw new Error(
-				buildRepoSessionNotFoundForUserMessage(input.sessionId),
-			)
+			throw new Error(buildRepoSessionNotFoundForUserMessage(input.sessionId))
 		}
 		const sessionBranch = sessionRow.session_branch
 		// Remote branch delete is best-effort. Cron selects the same expired

--- a/packages/worker/src/repo/repo-session-do.ts
+++ b/packages/worker/src/repo/repo-session-do.ts
@@ -105,7 +105,11 @@ import {
 	measureRepoSessionWorkspaceBlobBytes,
 	purgeRepoSessionWorkspaceBlobs,
 } from './repo-session-blobs.ts'
-import { isGitPushNotFastForwardError } from './repo-session-caller-error.ts'
+import {
+	buildRepoSessionNotFoundForUserMessage,
+	buildRepoSessionNotFoundMessage,
+	isGitPushNotFastForwardError,
+} from './repo-session-caller-error.ts'
 import {
 	assertPackagePrivateVisibilityChangeAllowed,
 	assertPackageSourceOverwriteAllowed,
@@ -456,12 +460,10 @@ class RepoSessionBase extends DurableObject<Env> {
 			cachedState?.sessionRow ??
 			null
 		if (!sessionRow) {
-			throw new Error(`Repo session "${sessionId}" was not found.`)
+			throw new Error(buildRepoSessionNotFoundMessage(sessionId))
 		}
 		if (sessionRow.user_id !== userId) {
-			throw new Error(
-				`Repo session "${sessionId}" was not found for this user.`,
-			)
+			throw new Error(buildRepoSessionNotFoundForUserMessage(sessionId))
 		}
 		const allowedStatuses = options.allowedStatuses ?? ['active']
 		if (!allowedStatuses.includes(sessionRow.status)) {
@@ -1331,7 +1333,7 @@ class RepoSessionBase extends DurableObject<Env> {
 		} else {
 			if (sessionRow.user_id !== input.userId) {
 				throw new Error(
-					`Repo session "${input.sessionId}" was not found for this user.`,
+					buildRepoSessionNotFoundForUserMessage(input.sessionId),
 				)
 			}
 			if (sessionRow.status !== 'active') {
@@ -1562,7 +1564,7 @@ class RepoSessionBase extends DurableObject<Env> {
 		}
 		if (sessionRow.user_id !== input.userId) {
 			throw new Error(
-				`Repo session "${input.sessionId}" was not found for this user.`,
+				buildRepoSessionNotFoundForUserMessage(input.sessionId),
 			)
 		}
 		await updateRepoSession(this.env, {
@@ -1590,7 +1592,7 @@ class RepoSessionBase extends DurableObject<Env> {
 		})
 		if (sessionRow && sessionRow.user_id !== input.userId) {
 			throw new Error(
-				`Repo session "${input.sessionId}" was not found for this user.`,
+				buildRepoSessionNotFoundForUserMessage(input.sessionId),
 			)
 		}
 		await this.clearCachedSessionState(input.sessionId)
@@ -1629,7 +1631,7 @@ class RepoSessionBase extends DurableObject<Env> {
 		}
 		if (sessionRow.user_id !== input.userId) {
 			throw new Error(
-				`Repo session "${input.sessionId}" was not found for this user.`,
+				buildRepoSessionNotFoundForUserMessage(input.sessionId),
 			)
 		}
 		const sessionBranch = sessionRow.session_branch


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop agents passing placeholder or missing `session_id` values (e.g. `"none"`) from opening Sentry platform-bug issues during repo workflows.

## Summary

- **KODY-CLOUDFLARE-5V**: `repo_read_file` with `session_id: "none"` threw a plain DO `Error` that was captured as a platform bug.
- Reject common placeholder ids (`none`, `null`, `undefined`, …) at the `session_id` schema boundary with guidance to use `repo_open_session` / `repo_list_sessions` (parse_input already stays off Sentry).
- Classify `Repo session "…" was not found` / `… for this user` messages as caller failures in MCP observability (same pattern as inactive sessions / invalid regex).
- Point DO not-found errors at list/open session capabilities.

Fixes https://kent-c-dodds-tech-llc.sentry.io/issues/7686873204/

Siblings (client `scheduleUpdate` / `updateCurrentEntry`) do **not** share this root cause and are left unresolved.

## Testing

- [x] Focused unit tests: `repo-session-caller-error`, `observability`, `repo-shared` (5/5 pass)
- [x] `format` / `lint` / `typecheck` green locally
- [ ] Full local `validate` hit env timeouts (mock Cloudflare / mcp-e2e / playwright webServer) under parallel load — relying on CI Validate workflow
- [ ] CI in progress on ready-for-review PR

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` · **Head:** this branch

**Classification:** composes — wires existing `isCallerFailure` / schema-boundary validation into missing-session handling; no new primitives or schema migrations.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `capability-registry` | assistant | composes — reject placeholder `session_id` values |
| `mcp-server` | surfaces | composes — not-found phrase match skips Sentry |
| `repo-sessions` | runtime | composes — clearer not-found guidance from DO |

### Change sequence

```mermaid
sequenceDiagram
	participant Agent
	participant MCP as MCP capability
	participant Obs as mcp observability
	participant DO as RepoSession DO
	participant Sentry
	Agent->>MCP: repo_read_file({ session_id: "none" })
	alt placeholder id
		MCP-->>Agent: parse_input McpCallerError (no Sentry)
	else unknown / stale id
		MCP->>DO: readFile
		DO-->>MCP: Repo session "…" was not found
		MCP->>Obs: logMcpEvent(failure)
		Obs-->>Sentry: skipped (caller failure)
		MCP-->>Agent: error with list/open guidance
	end
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0f5b0431-021b-4bd5-a873-173e113e5e48?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0f5b0431-021b-4bd5-a873-173e113e5e48&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

