### PR TITLE
fix(client): harden optional Shiki chunk load (KODY-CLOUDFLARE-5W)

### DIFF
--- a/packages/worker/client/lazy-route.tsx
+++ b/packages/worker/client/lazy-route.tsx
@@ -425,7 +425,15 @@ export async function preloadClientRouteModules(
 	const match = preloadMatcher.match(url)
 	if (!match) return
 	if (syntaxHighlightAreaNameSet.has(match.data.name)) {
-		await Promise.all([match.data.load(), loadSyntaxHighlight()])
+		// Route chunk failure must still reject (boot reloads on stale hashes).
+		// Highlight is optional — plaintext fences hydrate fine — so a flaky
+		// Shiki fetch must not fail the whole preload (KODY-CLOUDFLARE-5W).
+		await match.data.load()
+		try {
+			await loadSyntaxHighlight()
+		} catch {
+			// Leave fences as escaped plaintext until a later load succeeds.
+		}
 		return
 	}
 	await match.data.load()

--- a/packages/worker/client/lazy-route.tsx
+++ b/packages/worker/client/lazy-route.tsx
@@ -425,15 +425,11 @@ export async function preloadClientRouteModules(
 	const match = preloadMatcher.match(url)
 	if (!match) return
 	if (syntaxHighlightAreaNameSet.has(match.data.name)) {
-		// Route chunk failure must still reject (boot reloads on stale hashes).
-		// Highlight is optional — plaintext fences hydrate fine — so a flaky
-		// Shiki fetch must not fail the whole preload (KODY-CLOUDFLARE-5W).
-		await match.data.load()
-		try {
-			await loadSyntaxHighlight()
-		} catch {
-			// Leave fences as escaped plaintext until a later load succeeds.
-		}
+		// Keep highlight in this await: SSR already rendered Shiki fences for
+		// these areas, so a client miss would hydrate plaintext against
+		// highlighted markup. Boot reload (entry.tsx) recovers stale hashes;
+		// optional homepage prefetch catches separately (landing-loop-player).
+		await Promise.all([match.data.load(), loadSyntaxHighlight()])
 		return
 	}
 	await match.data.load()

--- a/packages/worker/client/routes/landing-loop-player.tsx
+++ b/packages/worker/client/routes/landing-loop-player.tsx
@@ -172,9 +172,16 @@ export function LandingLoopPlayer(handle: Handle) {
 	}
 
 	whenWindowLoaded(() => {
-		void loadSyntaxHighlight().then(() => {
-			if (!handle.signal.aborted) handle.update()
-		})
+		// Best-effort: plaintext fences already render until Shiki loads.
+		// An uncaught rejection here was KODY-CLOUDFLARE-5W (Mobile Safari
+		// "Failed to fetch dynamically imported module" for the highlight chunk).
+		void loadSyntaxHighlight()
+			.then(() => {
+				if (!handle.signal.aborted) handle.update()
+			})
+			.catch(() => {
+				// Keep playing with plaintext; a later navigation may retry.
+			})
 	}, handle.signal)
 
 	return () => {

--- a/packages/worker/client/sentry-browser-filters.node.test.ts
+++ b/packages/worker/client/sentry-browser-filters.node.test.ts
@@ -483,3 +483,44 @@ test('browser Sentry filters drop WorkerGlobalScope blob importScripts NetworkEr
 		}),
 	).not.toBeNull()
 })
+
+test('browser Sentry filters drop syntax-highlight-core dynamic import fetch failures (KODY-CLOUDFLARE-5W)', () => {
+	const highlightChunkMessage =
+		'Failed to fetch dynamically imported module: https://kody.codes/assets/syntax-highlight-core-VCFYP6MU.js'
+	expect(
+		filterBrowserSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'TypeError',
+						value: highlightChunkMessage,
+					},
+				],
+			},
+		}),
+	).toBeNull()
+	expect(
+		filterBrowserSentryEvent(
+			{
+				exception: {
+					values: [{ type: 'TypeError', value: 'something else' }],
+				},
+			},
+			new TypeError(highlightChunkMessage),
+		),
+	).toBeNull()
+	// Other hashed asset chunk misses must stay visible (boot reload path).
+	expect(
+		filterBrowserSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'TypeError',
+						value:
+							'Failed to fetch dynamically imported module: https://kody.codes/assets/blog-area-ABC123.js',
+					},
+				],
+			},
+		}),
+	).not.toBeNull()
+})

--- a/packages/worker/client/sentry-browser-filters.ts
+++ b/packages/worker/client/sentry-browser-filters.ts
@@ -731,6 +731,62 @@ export function filterBrowserBlobImportScriptsNetworkSentryEvent<
 	return event
 }
 
+/**
+ * Optional Shiki chunk failed to load (`import('./syntax-highlight-core')`).
+ * Observed as an unhandledrejection on `/` when the homepage landing loop
+ * fire-and-forgot the preload without a catch (KODY-CLOUDFLARE-5W, Mobile
+ * Safari). Fences already render as escaped plaintext until the chunk
+ * resolves, so this is expected degradation — not an app defect. Match only
+ * the browser "Failed to fetch dynamically imported module" signature with
+ * `syntax-highlight-core` in the URL so other chunk-load failures stay
+ * Sentry-visible (route boot still reloads on stale area hashes).
+ */
+const syntaxHighlightCoreDynamicImportFailureMessage =
+	/Failed to fetch dynamically imported module:\s*\S*syntax-highlight-core[^/\s]*\.js/i
+
+export function isSyntaxHighlightCoreDynamicImportFailureMessage(
+	message: string,
+) {
+	return syntaxHighlightCoreDynamicImportFailureMessage.test(message.trim())
+}
+
+export function isSyntaxHighlightCoreDynamicImportFailureError(error: unknown) {
+	if (typeof error === 'string') {
+		return isSyntaxHighlightCoreDynamicImportFailureMessage(error)
+	}
+	if (typeof error !== 'object' || error === null) return false
+	if (!('message' in error) || typeof error.message !== 'string') return false
+	return isSyntaxHighlightCoreDynamicImportFailureMessage(error.message)
+}
+
+export function isSyntaxHighlightCoreDynamicImportFailureSentryEvent(
+	event: SentryErrorEventLike,
+	originalException?: unknown,
+) {
+	if (isSyntaxHighlightCoreDynamicImportFailureError(originalException)) {
+		return true
+	}
+	return sentryEventMessages(event).some(
+		(message) =>
+			typeof message === 'string' &&
+			isSyntaxHighlightCoreDynamicImportFailureMessage(message),
+	)
+}
+
+export function filterSyntaxHighlightCoreDynamicImportFailureSentryEvent<
+	T extends SentryErrorEventLike,
+>(event: T, originalException?: unknown): T | null {
+	if (
+		isSyntaxHighlightCoreDynamicImportFailureSentryEvent(
+			event,
+			originalException,
+		)
+	) {
+		return null
+	}
+	return event
+}
+
 /** Combined browser beforeSend / capture gate used by the client SDK. */
 export function filterBrowserSentryEvent<T extends SentryErrorEventLike>(
 	event: T,
@@ -803,6 +859,14 @@ export function filterBrowserSentryEvent<T extends SentryErrorEventLike>(
 	}
 	if (
 		filterBrowserBlobImportScriptsNetworkSentryEvent(
+			event,
+			originalException,
+		) === null
+	) {
+		return null
+	}
+	if (
+		filterSyntaxHighlightCoreDynamicImportFailureSentryEvent(
 			event,
 			originalException,
 		) === null

--- a/packages/worker/client/sentry-client.ts
+++ b/packages/worker/client/sentry-client.ts
@@ -2,6 +2,7 @@ import {
 	isBrowserAbortError,
 	isBrowserInjectedGlobalNoiseError,
 	isFirefoxDomPermissionDeniedError,
+	isSyntaxHighlightCoreDynamicImportFailureError,
 } from '#client/sentry-browser-filters.ts'
 import {
 	parseSentryClientConfig,
@@ -49,7 +50,8 @@ function shouldIgnoreBufferedError(error: unknown) {
 	return (
 		isBrowserAbortError(error) ||
 		isFirefoxDomPermissionDeniedError(error) ||
-		isBrowserInjectedGlobalNoiseError(error)
+		isBrowserInjectedGlobalNoiseError(error) ||
+		isSyntaxHighlightCoreDynamicImportFailureError(error)
 	)
 }
 

--- a/packages/worker/client/sentry-init.ts
+++ b/packages/worker/client/sentry-init.ts
@@ -36,15 +36,17 @@ export function initBrowserSentry(config: SentryClientConfig) {
 		// exist", MetaMask inpage connect failures, Chrome extension
 		// "Client has been destroyed" with exclusively chrome-extension
 		// frames, Twitter/X in-app browser chrome `CONFIG` ReferenceErrors /
-		// `sendScrollEvent`→ `window.webkit.messageHandlers` TypeErrors, and
+		// `sendScrollEvent`→ `window.webkit.messageHandlers` TypeErrors,
 		// injected unguarded `meta[property='og:type']` probes from
-		// `global code`) — see filterBrowserSentryEvent /
+		// `global code`, and optional Shiki `syntax-highlight-core` dynamic
+		// import fetch failures) — see filterBrowserSentryEvent /
 		// KODY-CLOUDFLARE-23 / KODY-CLOUDFLARE-3Q / KODY-CLOUDFLARE-3S /
 		// KODY-CLOUDFLARE-3X / KODY-CLOUDFLARE-43 / KODY-CLOUDFLARE-46 /
 		// KODY-CLOUDFLARE-4F / KODY-CLOUDFLARE-5C / KODY-CLOUDFLARE-5K /
+		// KODY-CLOUDFLARE-5W /
 		// issues 7639685398, 7648833360, 7648833403, 7653117289, 7655189301,
 		// 7658961865, 7659616372, 7660258027, 7662064169, 7677729361,
-		// 7682968915.
+		// 7682968915, 7687920474.
 		beforeSend(event, hint) {
 			return filterBrowserSentryEvent(event, hint.originalException)
 		},

--- a/packages/worker/client/syntax-highlight.node.test.ts
+++ b/packages/worker/client/syntax-highlight.node.test.ts
@@ -6,6 +6,7 @@ import {
 	loadSyntaxHighlight,
 	renderHighlightedCode,
 	resetSyntaxHighlightLoadForTests,
+	setHighlightCoreImporterForTests,
 } from '#client/syntax-highlight.tsx'
 
 test('highlights known languages with dual-theme token styles and escapes content', async () => {
@@ -65,4 +66,54 @@ test('public API falls back to plaintext until the core chunk loads', async () =
 	)
 	expect(loadedHtml).toContain('--shiki-dark:')
 	expect(loadedHtml).toContain('const')
+})
+
+test('loadSyntaxHighlight retries once after a transient core import failure', async () => {
+	resetSyntaxHighlightLoadForTests()
+	let attempts = 0
+	const module = {
+		renderHighlightedCode: renderHighlightedCodeCore,
+	}
+	setHighlightCoreImporterForTests(async () => {
+		attempts += 1
+		if (attempts === 1) {
+			throw new TypeError(
+				'Failed to fetch dynamically imported module: https://kody.codes/assets/syntax-highlight-core-VCFYP6MU.js',
+			)
+		}
+		return module
+	})
+	try {
+		await loadSyntaxHighlight()
+		expect(attempts).toBe(2)
+		const loadedHtml = await renderToString(
+			jsx('div', {
+				children: renderHighlightedCode('const x = 1', 'ts'),
+			}),
+		)
+		expect(loadedHtml).toContain('--shiki-dark:')
+	} finally {
+		setHighlightCoreImporterForTests(null)
+		resetSyntaxHighlightLoadForTests()
+	}
+})
+
+test('loadSyntaxHighlight rejects after a second core import failure', async () => {
+	resetSyntaxHighlightLoadForTests()
+	let attempts = 0
+	setHighlightCoreImporterForTests(async () => {
+		attempts += 1
+		throw new TypeError(
+			'Failed to fetch dynamically imported module: https://kody.codes/assets/syntax-highlight-core-VCFYP6MU.js',
+		)
+	})
+	try {
+		await expect(loadSyntaxHighlight()).rejects.toThrow(
+			/Failed to fetch dynamically imported module/,
+		)
+		expect(attempts).toBe(2)
+	} finally {
+		setHighlightCoreImporterForTests(null)
+		resetSyntaxHighlightLoadForTests()
+	}
 })

--- a/packages/worker/client/syntax-highlight.tsx
+++ b/packages/worker/client/syntax-highlight.tsx
@@ -12,8 +12,9 @@ import { type RemixNode } from 'remix/ui'
  * so hydration has a safe fallback.
  *
  * Import failures (stale deploy hashes, Mobile Safari flakes) reject after
- * one retry. Callers that treat highlighting as optional must catch — the
- * homepage landing loop and route preload already do.
+ * one retry. Optional post-load callers (homepage landing loop) must catch —
+ * fences stay plaintext until a later load succeeds. Route preload must
+ * still await a successful load so SSR-highlighted fences hydrate cleanly.
  */
 type HighlightModule = {
 	renderHighlightedCode: (

--- a/packages/worker/client/syntax-highlight.tsx
+++ b/packages/worker/client/syntax-highlight.tsx
@@ -10,6 +10,10 @@ import { type RemixNode } from 'remix/ui'
  * hydration, and SPA preload already do this for those areas). Until the
  * chunk resolves, fences render as escaped plaintext in the same wrapper
  * so hydration has a safe fallback.
+ *
+ * Import failures (stale deploy hashes, Mobile Safari flakes) reject after
+ * one retry. Callers that treat highlighting as optional must catch — the
+ * homepage landing loop and route preload already do.
  */
 type HighlightModule = {
 	renderHighlightedCode: (
@@ -19,22 +23,35 @@ type HighlightModule = {
 	) => RemixNode
 }
 
+type HighlightCoreImporter = () => Promise<HighlightModule>
+
 let highlightModule: HighlightModule | null = null
 let highlightPending: Promise<HighlightModule> | null = null
+// Dynamic import is intentional so Shiki is an async chunk (sanctioned
+// exception to the no-inline-imports rule). Swappable in tests.
+let importHighlightCore: HighlightCoreImporter = () =>
+	import('./syntax-highlight-core.tsx')
+
+async function loadHighlightCoreWithRetry(): Promise<HighlightModule> {
+	try {
+		const module = await importHighlightCore()
+		highlightModule = module
+		return module
+	} catch {
+		// One retry covers transient network / Mobile Safari module-fetch
+		// flakes (KODY-CLOUDFLARE-5W). A second failure propagates.
+		const module = await importHighlightCore()
+		highlightModule = module
+		return module
+	}
+}
 
 export function loadSyntaxHighlight(): Promise<HighlightModule> {
 	if (highlightModule) return Promise.resolve(highlightModule)
 	if (!highlightPending) {
-		// Dynamic import is intentional so Shiki is an async chunk
-		// (sanctioned exception to the no-inline-imports rule).
-		highlightPending = import('./syntax-highlight-core.tsx')
-			.then((module) => {
-				highlightModule = module
-				return module
-			})
-			.finally(() => {
-				if (!highlightModule) highlightPending = null
-			})
+		highlightPending = loadHighlightCoreWithRetry().finally(() => {
+			if (!highlightModule) highlightPending = null
+		})
 	}
 	return highlightPending
 }
@@ -43,6 +60,14 @@ export function loadSyntaxHighlight(): Promise<HighlightModule> {
 export function resetSyntaxHighlightLoadForTests() {
 	highlightModule = null
 	highlightPending = null
+}
+
+/** Test hook: replace the core chunk importer (retry / failure coverage). */
+export function setHighlightCoreImporterForTests(
+	importer: HighlightCoreImporter | null,
+) {
+	importHighlightCore =
+		importer ?? (() => import('./syntax-highlight-core.tsx'))
 }
 
 /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop optional homepage Shiki chunk-load flakes from opening Sentry issues, while keeping plaintext code fences as the safe fallback.

## Summary

- Catch `loadSyntaxHighlight()` failures in the homepage landing-loop player (root cause of the unhandledrejection)
- Retry the `syntax-highlight-core` dynamic import once before rejecting
- Keep highlight required in route preload so SSR Shiki fences hydrate cleanly (Bugbot feedback addressed)
- Narrow browser Sentry filter for `Failed to fetch dynamically imported module` only when the URL contains `syntax-highlight-core`

Siblings `KODY-CLOUDFLARE-3W` / `4W` / `4X` do not share this root cause.

## Testing

- Focused node-unit suites for syntax-highlight, sentry-browser-filters, lazy-route — passed
- CI Validate (Node/Workers/MCP/E2E/Static) — green
- CodeRabbit: no actionable comments; Bugbot hydration note fixed
- Preview manual test on https://kody-pr-1697.kody-a99.workers.dev — health/login + `/` + `/guides` OK; UI pass confirmed Shiki on a guide page with no dynamic-import console errors

![Preview homepage](https://cursor.com/artifacts/c/art-73665021-228f-4079-a414-307d173f1b28)
![Preview guides](https://cursor.com/artifacts/c/art-3e7dcb38-36b5-4c07-abbd-f7ae67bbc8ba)
![Shiki highlighting on guide](https://cursor.com/artifacts/c/art-546779b5-390b-40a0-b860-2db26f19e6ea)

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `47c3b8d6` · **Head:** `b5d614dc`

**Classification:** extends — changes optional Shiki load failure handling and browser Sentry filtering on `app-ui`; no primitive added.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | extends — resilient optional highlight load + narrow Sentry drop |

### Change flow

Homepage Shiki preload fails softly instead of reporting to Sentry.

```mermaid
sequenceDiagram
	actor Browser
	participant appUi as app-ui
	participant Sentry as browser-sentry
	Browser->>appUi: window load → loadSyntaxHighlight()
	appUi->>appUi: dynamic import syntax-highlight-core (retry once)
	alt import succeeds
		appUi->>appUi: re-render fences with Shiki
	else import still fails
		appUi->>appUi: keep plaintext fences (caught)
		Note over Sentry: beforeSend drops syntax-highlight-core fetch signature only
	end
```

### Invariants

None from `primitives.yaml` (no auth, isolation, billing, migrations, or DR surface).

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fd152708-6f77-4660-9130-8e2e6791d16f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fd152708-6f77-4660-9130-8e2e6791d16f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Route preloading now waits for syntax highlighting where required and reports failures instead of silently falling back.
  - Syntax highlighting retries once after a transient loading failure.
  - Failed highlighting loads retain plaintext rendering and can retry during later navigation.
  - Route loading failures continue to be reported normally.

- **Monitoring**
  - Known optional syntax-highlighting chunk failures are filtered from error reporting, while unrelated asset failures remain visible.

- **Tests**
  - Added coverage for retry behavior, fallback handling, and error filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->