### PR TITLE
Show Grok.com and Grok CLI as peer onboarding options

### DIFF
--- a/docs/use/connect-your-agent.md
+++ b/docs/use/connect-your-agent.md
@@ -13,7 +13,9 @@ started (`/onboarding`).
 The in-app Get started page (`/onboarding`) shows one Automatic command first:
 `npx @kodycodes/cli install`. That CLI detects running local agents and writes
 each host's remote MCP entry for this deployment. Host-specific deeplinks,
-vendor CLIs, the MCP URL, and JSON/TOML merge stay under Manual.
+vendor CLIs, the MCP URL, and JSON/TOML merge stay under Manual. A second
+client is worth it when you want the same [memories](./memory.md) and packages
+from another agent — you do not need every Manual tab.
 
 ## Add the MCP server
 
@@ -49,12 +51,17 @@ Manual on Get started has one tab per host. Use those when you are not running
   `claude_desktop_config.json`. After connecting, start a new chat and ask
   Claude to list Kody tools before the first task — Claude Desktop often does
   not bind MCP tools until that next turn.
-- **Grok** — On [grok.com/connectors](https://grok.com/connectors), click **New
-  Connector**, select **Custom**, and paste the MCP URL. Complete OAuth when
-  prompted. For Grok Business and Enterprise, a team admin must first add this
-  custom MCP server in the cloud console; members can then connect it from the
-  Grok connectors page. See xAI's
+- **Grok.com** — On [grok.com/connectors](https://grok.com/connectors), click
+  **New Connector**, select **Custom**, and paste the MCP URL. Complete OAuth
+  when prompted. For Grok Business and Enterprise, a team admin must first add
+  this custom MCP server in the cloud console; members can then connect it from
+  the Grok connectors page. See xAI's
   [custom MCP connector docs](https://docs.x.ai/grok/connectors).
+- **Grok CLI** — `grok mcp add --transport http --scope user kody <url>`. That
+  writes `~/.grok/config.toml`. OAuth opens a browser on first use; in the TUI,
+  `/mcps` then `i` authenticates. `grok mcp doctor kody` checks the
+  connection. See xAI's
+  [Grok CLI MCP docs](https://docs.x.ai/build/features/mcp-servers).
 - **Claude Code** — After the CLI writes the remote entry, enter `/mcp` → Kody →
   Authenticate. Manual includes
   `claude mcp add --transport http -s user kody <url>`, or a `.mcp.json` entry
@@ -96,10 +103,10 @@ Manual on Get started has one tab per host. Use those when you are not running
 ### Coding vs non-coding agents
 
 Using Kody packages works great with non-coding agents such as Claude Desktop,
-ChatGPT, Grok, and the GitHub Copilot app. For creating or editing packages, a
-coding agent (Cursor, Claude Code, Codex, Copilot, OpenCode, and similar) is
-usually smoother because those hosts can edit files and iterate on code more
-easily.
+ChatGPT, Grok.com, and the GitHub Copilot app. For creating or editing packages,
+a coding agent (Cursor, Claude Code, Codex, Grok CLI, Copilot, OpenCode, and
+similar) is usually smoother because those hosts can edit files and iterate on
+code more easily.
 
 ## Connect Notion or Linear, then persist a first build
 

--- a/docs/use/connect-your-agent.md
+++ b/docs/use/connect-your-agent.md
@@ -1,9 +1,9 @@
 # Connect your agent
 
 Kody is an MCP server. You use it from Cursor, ChatGPT, Codex, Claude Desktop,
-Grok, Claude Code, OpenCode, GitHub Copilot (VS Code or CLI), the GitHub Copilot
-app, or any other AI agent that supports MCP — not from a separate Kody chat
-app.
+Grok.com, Grok CLI, Claude Code, OpenCode, GitHub Copilot (VS Code or CLI), the
+GitHub Copilot app, or any other AI agent that supports MCP — not from a
+separate Kody chat app.
 
 Agents discovering this host can read `/auth.md` for the OAuth registration
 block and MCP URL, and `/.well-known/mcp/server-card.json` for the server card.

--- a/docs/use/connect-your-agent.md
+++ b/docs/use/connect-your-agent.md
@@ -13,9 +13,9 @@ started (`/onboarding`).
 The in-app Get started page (`/onboarding`) shows one Automatic command first:
 `npx @kodycodes/cli install`. That CLI detects running local agents and writes
 each host's remote MCP entry for this deployment. Host-specific deeplinks,
-vendor CLIs, the MCP URL, and JSON/TOML merge stay under Manual. A second
-client is worth it when you want the same [memories](./memory.md) and packages
-from another agent — you do not need every Manual tab.
+vendor CLIs, the MCP URL, and JSON/TOML merge stay under Manual. A second client
+is worth it when you want the same [memories](./memory.md) and packages from
+another agent — you do not need every Manual tab.
 
 ## Add the MCP server
 
@@ -59,9 +59,8 @@ Manual on Get started has one tab per host. Use those when you are not running
   [custom MCP connector docs](https://docs.x.ai/grok/connectors).
 - **Grok CLI** — `grok mcp add --transport http --scope user kody <url>`. That
   writes `~/.grok/config.toml`. OAuth opens a browser on first use; in the TUI,
-  `/mcps` then `i` authenticates. `grok mcp doctor kody` checks the
-  connection. See xAI's
-  [Grok CLI MCP docs](https://docs.x.ai/build/features/mcp-servers).
+  `/mcps` then `i` authenticates. `grok mcp doctor kody` checks the connection.
+  See xAI's [Grok CLI MCP docs](https://docs.x.ai/build/features/mcp-servers).
 - **Claude Code** — After the CLI writes the remote entry, enter `/mcp` → Kody →
   Authenticate. Manual includes
   `claude mcp add --transport http -s user kody <url>`, or a `.mcp.json` entry

--- a/docs/use/memory.md
+++ b/docs/use/memory.md
@@ -1,7 +1,8 @@
 # Memory and conversation context
 
 Kody is the system of record for the signed-in user's durable assistant state.
-Long-term memories are the primary store for facts and preferences. Facts saved
+Long-term memories are the primary store for facts and preferences. Memories
+saved in Kody are available from every connected host for that user. Facts saved
 only in the host (Claude memory, Codex notes, Cursor rules that are not also
 Kody memories) are invisible to the user's other agents.
 

--- a/packages/worker/client/routes/onboarding-mcp-client-tabs.tsx
+++ b/packages/worker/client/routes/onboarding-mcp-client-tabs.tsx
@@ -10,6 +10,8 @@ import {
 	buildCopilotCliMcpJson,
 	buildCursorInstallUrl,
 	buildCursorMcpJson,
+	buildGrokCliAddCommand,
+	buildGrokCliMcpToml,
 	buildKodyAppIconUrl,
 	buildKodyCliInstallCommand,
 	buildOpenCodeMcpAddCommand,
@@ -22,6 +24,7 @@ import {
 	codingAgentPackageHint,
 	copilotAppCustomizeGuideUrl,
 	copilotCliMcpGuideUrl,
+	grokCliMcpGuideUrl,
 	grokConnectorsUrl,
 	grokCustomMcpGuideUrl,
 	type McpClientKind,
@@ -248,17 +251,54 @@ function renderPanelContent(kind: McpClientKind, mcpServerUrl: string) {
 					<ClientNote>{nonCodingAgentNote}</ClientNote>
 				</>
 			)
-		case 'grok':
+		case 'grok': {
+			const grokCliCommand = buildGrokCliAddCommand(mcpServerUrl)
+			const grokCliToml = buildGrokCliMcpToml(mcpServerUrl)
 			return (
 				<>
 					<p>
-						In{' '}
+						<strong>In Grok CLI:</strong> add a remote HTTP server (writes{' '}
+						<code>~/.grok/config.toml</code>). OAuth opens a browser on first
+						use; in the TUI, <code>/mcps</code> then <strong>i</strong>{' '}
+						authenticates:
+					</p>
+					<CopyCard
+						label="grok CLI"
+						value={grokCliCommand}
+						copyLabel="Copy command"
+						variant="pill"
+						lang="sh"
+					/>
+					<p>
+						Or merge this into <code>~/.grok/config.toml</code>:
+					</p>
+					<CopyCard
+						label="~/.grok/config.toml"
+						value={grokCliToml}
+						copyLabel="Copy TOML"
+						lang="toml"
+					/>
+					<p>
+						See xAI&apos;s{' '}
+						<a
+							href={grokCliMcpGuideUrl}
+							target="_blank"
+							rel="noreferrer noopener"
+						>
+							Grok CLI MCP docs
+						</a>{' '}
+						for <code>grok mcp list</code>, <code>grok mcp doctor</code>, and
+						project scope.
+					</p>
+					<ClientNote>{codingAgentPackageHint}</ClientNote>
+					<p>
+						<strong>On Grok.com:</strong> open{' '}
 						<a
 							href={grokConnectorsUrl}
 							target="_blank"
 							rel="noreferrer noopener"
 						>
-							Grok.com → Connectors
+							Connectors
 						</a>
 						, click <strong>New Connector</strong>, select{' '}
 						<strong>Custom</strong>, and paste this MCP URL. Complete OAuth when
@@ -279,12 +319,13 @@ function renderPanelContent(kind: McpClientKind, mcpServerUrl: string) {
 							rel="noreferrer noopener"
 						>
 							custom MCP connector docs
-						</a>{' '}
-						for details.
+						</a>
+						.
 					</p>
 					<ClientNote>{nonCodingAgentNote}</ClientNote>
 				</>
 			)
+		}
 		case 'claude-code': {
 			const claudeCodeCommand = buildClaudeCodeAddCommand(mcpServerUrl)
 			const claudeCodeJson = buildClaudeCodeMcpJson(mcpServerUrl)
@@ -553,6 +594,12 @@ const tabKickerCss = {
 	textTransform: 'uppercase' as const,
 	letterSpacing: '0.09em',
 	color: colors.primaryText,
+}
+
+const tabLeadCss = {
+	margin: 0,
+	font: `400 0.95rem/1.45 ${typography.fontFamilyBody}`,
+	color: colors.textMuted,
 }
 
 const tabListCss = {

--- a/packages/worker/client/routes/onboarding-mcp-client-tabs.tsx
+++ b/packages/worker/client/routes/onboarding-mcp-client-tabs.tsx
@@ -251,16 +251,53 @@ function renderPanelContent(kind: McpClientKind, mcpServerUrl: string) {
 					<ClientNote>{nonCodingAgentNote}</ClientNote>
 				</>
 			)
-		case 'grok': {
+		case 'grok':
+			return (
+				<>
+					<p>
+						In{' '}
+						<a
+							href={grokConnectorsUrl}
+							target="_blank"
+							rel="noreferrer noopener"
+						>
+							Grok.com → Connectors
+						</a>
+						, click <strong>New Connector</strong>, select{' '}
+						<strong>Custom</strong>, and paste this MCP URL. Complete OAuth when
+						Grok prompts you. For Grok Business and Enterprise, a team admin
+						must first add this custom MCP server in the cloud console. Members
+						can then connect it from the Grok connectors page. See xAI&apos;s{' '}
+						<a
+							href={grokCustomMcpGuideUrl}
+							target="_blank"
+							rel="noreferrer noopener"
+						>
+							custom MCP connector docs
+						</a>{' '}
+						for details.
+					</p>
+					<CopyCard
+						label="MCP URL"
+						value={mcpServerUrl}
+						copyLabel="Copy MCP URL"
+						variant="pill"
+					/>
+					<p>
+						For the Grok CLI, use the <strong>Grok CLI</strong> tab.
+					</p>
+					<ClientNote>{nonCodingAgentNote}</ClientNote>
+				</>
+			)
+		case 'grok-cli': {
 			const grokCliCommand = buildGrokCliAddCommand(mcpServerUrl)
 			const grokCliToml = buildGrokCliMcpToml(mcpServerUrl)
 			return (
 				<>
 					<p>
-						<strong>In Grok CLI:</strong> add a remote HTTP server (writes{' '}
-						<code>~/.grok/config.toml</code>). OAuth opens a browser on first
-						use; in the TUI, <code>/mcps</code> then <strong>i</strong>{' '}
-						authenticates:
+						Add a remote HTTP server (writes <code>~/.grok/config.toml</code>).
+						OAuth opens a browser on first use; in the TUI, <code>/mcps</code>{' '}
+						then <strong>i</strong> authenticates:
 					</p>
 					<CopyCard
 						label="grok CLI"
@@ -288,41 +325,9 @@ function renderPanelContent(kind: McpClientKind, mcpServerUrl: string) {
 							Grok CLI MCP docs
 						</a>{' '}
 						for <code>grok mcp list</code>, <code>grok mcp doctor</code>, and
-						project scope.
+						project scope. For grok.com, use the <strong>Grok.com</strong> tab.
 					</p>
 					<ClientNote>{codingAgentPackageHint}</ClientNote>
-					<p>
-						<strong>On Grok.com:</strong> open{' '}
-						<a
-							href={grokConnectorsUrl}
-							target="_blank"
-							rel="noreferrer noopener"
-						>
-							Connectors
-						</a>
-						, click <strong>New Connector</strong>, select{' '}
-						<strong>Custom</strong>, and paste this MCP URL. Complete OAuth when
-						Grok prompts you.
-					</p>
-					<CopyCard
-						label="MCP URL"
-						value={mcpServerUrl}
-						copyLabel="Copy MCP URL"
-					/>
-					<p>
-						For Grok Business and Enterprise, a team admin must first add this
-						custom MCP server in the cloud console. Members can then connect it
-						from the Grok connectors page. See xAI&apos;s{' '}
-						<a
-							href={grokCustomMcpGuideUrl}
-							target="_blank"
-							rel="noreferrer noopener"
-						>
-							custom MCP connector docs
-						</a>
-						.
-					</p>
-					<ClientNote>{nonCodingAgentNote}</ClientNote>
 				</>
 			)
 		}
@@ -594,12 +599,6 @@ const tabKickerCss = {
 	textTransform: 'uppercase' as const,
 	letterSpacing: '0.09em',
 	color: colors.primaryText,
-}
-
-const tabLeadCss = {
-	margin: 0,
-	font: `400 0.95rem/1.45 ${typography.fontFamilyBody}`,
-	color: colors.textMuted,
 }
 
 const tabListCss = {

--- a/packages/worker/client/routes/onboarding-mcp-clients.node.test.ts
+++ b/packages/worker/client/routes/onboarding-mcp-clients.node.test.ts
@@ -8,6 +8,8 @@ import {
 	buildCopilotCliMcpJson,
 	buildCursorInstallUrl,
 	buildCursorMcpJson,
+	buildGrokCliAddCommand,
+	buildGrokCliMcpToml,
 	buildKodyAppIconUrl,
 	buildKodyCliInstallCommand,
 	buildOpenCodeMcpAddCommand,
@@ -110,6 +112,12 @@ test('onboarding MCP client builders emit the structured configs each host expec
 		},
 	})
 	expect(buildCodexMcpToml(mcpServerUrl)).toBe(
+		['[mcp_servers.kody]', `url = "${mcpServerUrl}"`, ''].join('\n'),
+	)
+	expect(buildGrokCliAddCommand(mcpServerUrl)).toBe(
+		`grok mcp add --transport http --scope user kody ${mcpServerUrl}`,
+	)
+	expect(buildGrokCliMcpToml(mcpServerUrl)).toBe(
 		['[mcp_servers.kody]', `url = "${mcpServerUrl}"`, ''].join('\n'),
 	)
 	expect(buildKodyAppIconUrl(mcpServerUrl)).toBe(

--- a/packages/worker/client/routes/onboarding-mcp-clients.node.test.ts
+++ b/packages/worker/client/routes/onboarding-mcp-clients.node.test.ts
@@ -31,6 +31,7 @@ test('onboarding MCP client builders emit the structured configs each host expec
 		'codex',
 		'claude-desktop',
 		'grok',
+		'grok-cli',
 		'claude-code',
 		'opencode',
 		'copilot',
@@ -40,6 +41,10 @@ test('onboarding MCP client builders emit the structured configs each host expec
 	expect(
 		mcpClientTabs.filter((tab) => tab.isNonCodingAgent).map((tab) => tab.id),
 	).toEqual(['chatgpt', 'claude-desktop', 'grok', 'copilot-app'])
+	expect(mcpClientTabs.find((tab) => tab.id === 'grok')?.label).toBe('Grok.com')
+	expect(mcpClientTabs.find((tab) => tab.id === 'grok-cli')?.label).toBe(
+		'Grok CLI',
+	)
 	expect(mcpClientTabs.find((tab) => tab.id === 'copilot')?.label).toBe(
 		'Copilot',
 	)

--- a/packages/worker/client/routes/onboarding-mcp-clients.ts
+++ b/packages/worker/client/routes/onboarding-mcp-clients.ts
@@ -9,6 +9,7 @@ export type McpClientKind =
 	| 'codex'
 	| 'claude-desktop'
 	| 'grok'
+	| 'grok-cli'
 	| 'claude-code'
 	| 'opencode'
 	| 'copilot'
@@ -27,7 +28,8 @@ export const mcpClientTabs = [
 	{ id: 'chatgpt', label: 'ChatGPT', isNonCodingAgent: true },
 	{ id: 'codex', label: 'Codex', isNonCodingAgent: false },
 	{ id: 'claude-desktop', label: 'Claude Desktop', isNonCodingAgent: true },
-	{ id: 'grok', label: 'Grok', isNonCodingAgent: true },
+	{ id: 'grok', label: 'Grok.com', isNonCodingAgent: true },
+	{ id: 'grok-cli', label: 'Grok CLI', isNonCodingAgent: false },
 	{ id: 'claude-code', label: 'Claude Code', isNonCodingAgent: false },
 	{ id: 'opencode', label: 'OpenCode', isNonCodingAgent: false },
 	{ id: 'copilot', label: 'Copilot', isNonCodingAgent: false },

--- a/packages/worker/client/routes/onboarding-mcp-clients.ts
+++ b/packages/worker/client/routes/onboarding-mcp-clients.ts
@@ -51,13 +51,16 @@ export const grokConnectorsUrl = 'https://grok.com/connectors'
 
 export const grokCustomMcpGuideUrl = 'https://docs.x.ai/grok/connectors'
 
+/** Grok CLI (`grok`) MCP add / config.toml docs. */
+export const grokCliMcpGuideUrl = 'https://docs.x.ai/build/features/mcp-servers'
+
 /** Square favicon suitable for ChatGPT plugin / connector app icons. */
 export function buildKodyAppIconUrl(mcpServerUrl: string) {
 	return new URL('/apple-touch-icon.png', mcpServerUrl).href
 }
 
 export const nonCodingAgentNote =
-	'Using Kody packages works great with non-coding agents. For creating or editing packages, a coding agent such as Cursor, Claude Code, Codex, Copilot, or OpenCode is usually smoother — those hosts can edit files and iterate on code more easily.'
+	'Using Kody packages works great with non-coding agents. For creating or editing packages, a coding agent such as Cursor, Claude Code, Codex, Grok CLI, Copilot, or OpenCode is usually smoother — those hosts can edit files and iterate on code more easily.'
 
 /** Claude Desktop often does not bind MCP tools until the next turn. */
 export const claudeDesktopToolHint =
@@ -205,6 +208,20 @@ export function buildOpenCodeMcpJson(mcpServerUrl: string) {
 
 /** Codex shared `~/.codex/config.toml` streamable HTTP entry. */
 export function buildCodexMcpToml(mcpServerUrl: string) {
+	return [
+		'[mcp_servers.kody]',
+		`url = ${JSON.stringify(mcpServerUrl)}`,
+		'',
+	].join('\n')
+}
+
+/** Grok CLI one-shot remote HTTP add (writes `~/.grok/config.toml`). */
+export function buildGrokCliAddCommand(mcpServerUrl: string) {
+	return `grok mcp add --transport http --scope user kody ${mcpServerUrl}`
+}
+
+/** Grok CLI user config (`~/.grok/config.toml`) streamable HTTP entry. */
+export function buildGrokCliMcpToml(mcpServerUrl: string) {
 	return [
 		'[mcp_servers.kody]',
 		`url = ${JSON.stringify(mcpServerUrl)}`,

--- a/packages/worker/client/routes/onboarding.tsx
+++ b/packages/worker/client/routes/onboarding.tsx
@@ -617,6 +617,10 @@ export function OnboardingRoute(handle: Handle) {
 										<code>/mcp</code> → Kody → <strong>Authenticate</strong>.
 									</span>
 									<span>
+										<strong>Grok.com:</strong> after adding the custom
+										connector, complete OAuth when Grok prompts you.
+									</span>
+									<span>
 										<strong>Grok CLI:</strong> after adding the server, OAuth
 										opens on first use. In the TUI, <code>/mcps</code> then{' '}
 										<strong>i</strong> authenticates.{' '}

--- a/packages/worker/client/routes/onboarding.tsx
+++ b/packages/worker/client/routes/onboarding.tsx
@@ -617,6 +617,12 @@ export function OnboardingRoute(handle: Handle) {
 										<code>/mcp</code> → Kody → <strong>Authenticate</strong>.
 									</span>
 									<span>
+										<strong>Grok CLI:</strong> after adding the server, OAuth
+										opens on first use. In the TUI, <code>/mcps</code> then{' '}
+										<strong>i</strong> authenticates.{' '}
+										<code>grok mcp doctor kody</code> checks the connection.
+									</span>
+									<span>
 										Approve the <strong>kody.codes</strong> OAuth window. This
 										is the step that connects your agent to your factory.
 									</span>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Make Get started and the connect-your-agent docs show both Grok paths as first-class options: Grok.com and Grok CLI.

## Why

Tyler Laprade's #ideas notes called out omitted Grok CLI docs while grok.com was documented. The first revision preferred the CLI and treated grok.com as leftover. Both hosts are real options — same pattern as Copilot and Copilot App.

`kody connect --all` still belongs in `@kodycodes/cli` (`kody-bot/cli`). This change only ships the website/docs side.

## Summary

- Adjacent **Grok.com** and **Grok CLI** tabs on Get started, with matching authenticate callouts.
- connect-your-agent lists both paths as peer client notes.
- Step 1 still says connect one client first; a second host is for shared memories and packages.
- Memory usage docs state Kody memories are available from every connected host.

Thread: https://kody.exchange/t/kx_view_affd1c27b0ce97b9cf6cec55c9e856b92aae96d09d1ae109
Discord: https://discord.com/channels/1539764478470656101/1540387666175201361

## Testing

- `npm run test:node -- packages/worker/client/routes/onboarding-mcp-clients.node.test.ts` — pass
- `oxfmt` on the edited client files
- `npm run docs:check-temporal` — pass
- Tab ids now include `grok` (Grok.com) and `grok-cli` (Grok CLI)

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `f5330831` · **Head:** `7d3b3b71`

**Classification:** composes — onboarding copy and snippet builders; no MCP, auth, or storage contract change.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `app-ui` | surfaces | composes — peer Grok.com and Grok CLI tabs |

Unmatched: `docs/use/connect-your-agent.md`, `docs/use/memory.md` (usage docs only).

### Change flow

Get started Step 1 and the connect-your-agent docs present Grok.com and Grok CLI as adjacent peer options.

```mermaid
sequenceDiagram
	actor User
	participant appUi as app-ui
	User->>appUi: open /onboarding#connect-agent
	appUi->>User: Grok.com and Grok CLI tabs
	alt Grok.com
		User->>appUi: open Grok.com tab
		appUi->>User: Connectors MCP URL + OAuth
	else Grok CLI
		User->>appUi: open Grok CLI tab
		appUi->>User: grok mcp add --scope user
	end
	Note over appUi: Authenticate callout covers both hosts
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4abae925-0f7f-4d3e-b661-dfc15fc58695?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4abae925-0f7f-4d3e-b661-dfc15fc58695&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Grok CLI as a supported connection option with dedicated setup instructions.
  * Added commands and configuration guidance for connecting Grok CLI.
  * Clarified onboarding steps, authentication, diagnostics, and when to connect additional clients.

* **Documentation**
  * Updated connection examples to include Grok.com and Grok CLI.
  * Clarified that long-term memories are available across connected hosts, while host-only memories remain private.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->