### PR TITLE
Make official @kody packages execute-only

### DIFF
--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -332,9 +332,8 @@ The schema is defined by migrations in `packages/worker/migrations/`:
   auto-granted for read/use to self-authored packages (no `community_forks` row
   for that `saved_packages.id` + `userId`), live official platform packages
   (caller-owned `saved_packages` miss falls back to `findPlatformPackageByRef`;
-  execute-live half of
-  [0014](../decisions/0014-platform-live-packages.md); saved person packages
-  must fork per
+  execute-live half of [0014](../decisions/0014-platform-live-packages.md);
+  saved person packages must fork per
   [0035](../decisions/0035-platform-packages-execute-only.md)), and adopted
   forks (`community_forks.adopted_at` set via `community_fork_adopt`). Unadopted
   community forks (`community_forks.forked_package_id`, indexed in the squashed

--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -332,7 +332,10 @@ The schema is defined by migrations in `packages/worker/migrations/`:
   auto-granted for read/use to self-authored packages (no `community_forks` row
   for that `saved_packages.id` + `userId`), live official platform packages
   (caller-owned `saved_packages` miss falls back to `findPlatformPackageByRef`;
-  decision [0014](../decisions/0014-platform-live-packages.md)), and adopted
+  execute-live half of
+  [0014](../decisions/0014-platform-live-packages.md); saved person packages
+  must fork per
+  [0035](../decisions/0035-platform-packages-execute-only.md)), and adopted
   forks (`community_forks.adopted_at` set via `community_fork_adopt`). Unadopted
   community forks (`community_forks.forked_package_id`, indexed in the squashed
   baseline) still require an explicit `allowed_packages` grant on every package
@@ -1414,13 +1417,18 @@ Saved package imports in user code use `kody:@scope/name/export` specifiers:
 1. `packages/worker/src/package-runtime/package-import-resolution.ts` parses the
    `kody:@` prefix, the `@scope/name` package name, and an optional export
    subpath (default `.`).
-2. Resolution is scoped to the caller's `userId`, with one structural exception:
-   scopes whose username belongs to a **platform account**
-   (`users.account_type = 'platform'`, e.g. `@kody`) resolve live from the
-   platform account's current published version when the caller has no copy of
-   their own (see decision record
-   [0014 — Platform scopes resolve live](../decisions/0014-platform-live-packages.md)).
-   Person-account and community package scopes never grant cross-user imports.
+2. Resolution is scoped to the caller's `userId`, with one structural exception
+   for **ad hoc execute**: scopes whose username belongs to a **platform
+   account** (`users.account_type = 'platform'`, e.g. `@kody`) resolve live from
+   the platform account's current published version when the caller has no copy
+   of their own. Saved person-account packages must `community_fork` that
+   official package into the caller's scope before importing or invoking it
+   (decision
+   [0035 — Platform packages are execute-only](../decisions/0035-platform-packages-execute-only.md);
+   supersedes the package-import half of
+   [0014](../decisions/0014-platform-live-packages.md)). Person-account and
+   community package scopes never grant cross-user imports. Platform-account
+   packages may still compose with each other.
 3. `packages/worker/src/package-registry/manifest.ts` normalizes export keys and
    resolves them through `package.json#exports`.
 4. Static imports are pinned into bundle dependencies at publish time. Literal

--- a/docs/contributing/decisions/0014-platform-live-packages.md
+++ b/docs/contributing/decisions/0014-platform-live-packages.md
@@ -2,7 +2,9 @@
 
 ## Status
 
-Accepted.
+Superseded by [0035](./0035-platform-packages-execute-only.md) for saved
+person-account packages. Ad hoc execute may still resolve platform scopes live
+as described here.
 
 ## Context
 

--- a/docs/contributing/decisions/0035-platform-packages-execute-only.md
+++ b/docs/contributing/decisions/0035-platform-packages-execute-only.md
@@ -1,0 +1,44 @@
+# 0035 — Platform packages are execute-only
+
+- **Status:** accepted
+- **Date:** 2026-08-23
+
+## Context
+
+[0014](./0014-platform-live-packages.md) let every caller resolve public
+`@kody/*` (and other platform-account) packages live, including saved packages
+that statically imported or `packages.invoke`d them. That made official package
+exports a public API the operator had to keep stable: no semver
+([0001](./0001-no-package-versioning.md)), no pins
+([0031](./0031-kody-dependencies-wildcard-map.md)), and `packages.invoke` of a
+platform target is live on every job run.
+
+Ad hoc execute is ephemeral. Agents rewrite. Saved packages, jobs, and apps are
+durable products.
+
+## Decision
+
+Official platform packages are **execute-only**.
+
+- Ad hoc `execute` may statically import or `packages.invoke` a public platform
+  scope. The modules still run in the caller's runtime against the caller's
+  secrets.
+- Saved **person-account** packages must not statically import, declare, or
+  `packages.invoke` a platform scope. Publish checks fail. Package, job, and app
+  runtimes fail closed. Already-published person-package artifacts that recorded
+  `platformOwned` dependencies fail at run time. No compatibility lane.
+- To use official helpers in a durable package, `community_fork` into the
+  caller's scope and depend on that copy. Fork rewrite maps same-package
+  `@kody/name` self-imports onto the new owner; remaining `@kody/other`
+  references stay foreign and must be forked too.
+- Platform-account packages may still compose with each other when the operator
+  publishes them.
+
+## Consequences
+
+The operator can change official package exports without a fleet of user-package
+republishes. Agents still get live helpers in execute. Users who want insulation
+or durability own a fork.
+
+Revisit only if official packages grow a real versioning contract that 0001 and
+0031 still refuse.

--- a/docs/contributing/decisions/index.md
+++ b/docs/contributing/decisions/index.md
@@ -53,7 +53,9 @@ Open these before proposing a new primitive, surface, or storage home.
 - [0008 — No traces, previews, browser-run, gradual deploys, or session mining](./0008-declined-adlc-primitives.md)
 - [0011 — Keep workers-unit per-file isolation; do not warm DOs to "fix" slowness](./0011-workers-unit-pool-harness.md)
 - [0013 — Post-publish checks stay on MCP; no signed app URLs or inbox injection](./0013-synthetic-package-requests.md)
-- [0014 — Platform scopes resolve live; person-account imports stay caller-owned](./0014-platform-live-packages.md)
+- [0035 — Platform packages are execute-only; person packages must fork](./0035-platform-packages-execute-only.md)
+  — supersedes the saved-package half of 0014; ad hoc execute may still resolve
+  platform scopes live
 - [0015 — Wait on Skills over MCP; serve skill content via packages](./0015-skills-over-mcp-wait.md)
 - [0017 — Hosted package apps use per-user subdomains; same-owner isolation deferred](./0017-per-user-package-app-subdomains.md)
 - [0020 — Repo sessions spill Workspace objects to R2; do not adopt `@cloudflare/computer`](./0020-repo-session-workspace-r2-not-computer.md)
@@ -76,6 +78,9 @@ Open these before proposing a new primitive, surface, or storage home.
 Accepted or superseded records that do **not** change the next product proposal.
 Do not treat this list as homework. History stays; it is not silently deleted.
 
+- [0014 — Platform scopes resolve live; person-account imports stay caller-owned](./0014-platform-live-packages.md)
+  — superseded by 0035 for saved person-account packages; execute-live half
+  remains
 - [0009 — Shiki for in-app syntax highlighting](./0009-shiki-syntax-highlighting.md)
   — library pick; the highlighter is already in the app
 - [0010 — One RecordTable for account and admin list/detail screens](./0010-account-record-table.md)

--- a/docs/contributing/packages-and-manifests.md
+++ b/docs/contributing/packages-and-manifests.md
@@ -245,8 +245,9 @@ the underlying bracketed code, for example `[invocation_failed] ...`.
 Security and loop safeguards:
 
 - Person-scope resolution is same-user only; package code cannot invoke another
-  person's saved package. Public platform scopes use the existing live platform
-  package resolution.
+  person's saved package. Public platform scopes resolve live from **ad hoc
+  execute** only. Person-owned packages must fork an official package into the
+  caller's scope before importing or invoking it (decision 0035).
 - `packages.invoke` requires package runtime context or authenticated execute
   context. Static `kody:@...` imports remain library imports in the caller's
   runtime; use keyless `packages.invoke` when execute or a package job needs to

--- a/docs/contributing/packages-and-manifests.md
+++ b/docs/contributing/packages-and-manifests.md
@@ -246,8 +246,9 @@ Security and loop safeguards:
 
 - Person-scope resolution is same-user only; package code cannot invoke another
   person's saved package. Public platform scopes resolve live from **ad hoc
-  execute** only. Person-owned packages must fork an official package into the
-  caller's scope before importing or invoking it (decision 0035).
+  execute** and from other platform-account packages. Person-owned packages
+  must fork an official package into the caller's scope before importing or
+  invoking it (decision 0035).
 - `packages.invoke` requires package runtime context or authenticated execute
   context. Static `kody:@...` imports remain library imports in the caller's
   runtime; use keyless `packages.invoke` when execute or a package job needs to

--- a/docs/contributing/packages-and-manifests.md
+++ b/docs/contributing/packages-and-manifests.md
@@ -246,9 +246,9 @@ Security and loop safeguards:
 
 - Person-scope resolution is same-user only; package code cannot invoke another
   person's saved package. Public platform scopes resolve live from **ad hoc
-  execute** and from other platform-account packages. Person-owned packages
-  must fork an official package into the caller's scope before importing or
-  invoking it (decision 0035).
+  execute** and from other platform-account packages. Person-owned packages must
+  fork an official package into the caller's scope before importing or invoking
+  it (decision 0035).
 - `packages.invoke` requires package runtime context or authenticated execute
   context. Static `kody:@...` imports remain library imports in the caller's
   runtime; use keyless `packages.invoke` when execute or a package job needs to

--- a/docs/guides/providers/github.md
+++ b/docs/guides/providers/github.md
@@ -187,11 +187,13 @@ per-capability.
 
 ## Use the official package and verify
 
-A saved token or integration is credentials only. Finish by calling the live
+Ad hoc `execute` may import or `packages.invoke` `kody:@kody/github` live. A
+saved token or integration is credentials only. Finish by calling the live
 official helpers so day-to-day work goes through maintained code instead of
-hand-rolled API calls. Official `@kody/*` packages resolve in the caller runtime
-against the caller's secrets — do **not** fork them just to use them. Fork only
-when you need to customize the source.
+hand-rolled API calls. Official `@kody/*` packages resolve in the execute
+caller runtime against the caller's secrets. Saved person-account packages
+cannot import or invoke a platform scope — `community_fork` into the caller's
+scope first, or fork when you need to customize the source.
 
 1. Search for `@kody/github` (or import `kody:@kody/github` directly). It wraps
    REST, GraphQL, pagination, and PR helpers.

--- a/docs/guides/providers/github.md
+++ b/docs/guides/providers/github.md
@@ -190,10 +190,10 @@ per-capability.
 Ad hoc `execute` may import or `packages.invoke` `kody:@kody/github` live. A
 saved token or integration is credentials only. Finish by calling the live
 official helpers so day-to-day work goes through maintained code instead of
-hand-rolled API calls. Official `@kody/*` packages resolve in the execute
-caller runtime against the caller's secrets. Saved person-account packages
-cannot import or invoke a platform scope — `community_fork` into the caller's
-scope first, or fork when you need to customize the source.
+hand-rolled API calls. Official `@kody/*` packages resolve in the execute caller
+runtime against the caller's secrets. Saved person-account packages cannot
+import or invoke a platform scope — `community_fork` into the caller's scope
+first, or fork when you need to customize the source.
 
 1. Search for `@kody/github` (or import `kody:@kody/github` directly). It wraps
    REST, GraphQL, pagination, and PR helpers.

--- a/docs/guides/providers/google.md
+++ b/docs/guides/providers/google.md
@@ -195,12 +195,14 @@ reconnects use `/connect/oauth?provider=google` and the connect UI scope menu.
 
 ## Use the official package and verify
 
-A saved integration is auth credentials only. Finish by calling the live
-official helpers so day-to-day work goes through maintained Gmail, Calendar, and
-Drive helpers instead of raw `createAuthenticatedFetch` calls. Official
-`@kody/*` packages resolve in the caller runtime against the caller's secrets —
-do **not** fork them just to use them. Fork only when you need to customize the
-source.
+Ad hoc `execute` may import or `packages.invoke` `kody:@kody/google` live. A
+saved integration is auth credentials only. Finish by calling the live official
+helpers so day-to-day work goes through maintained Gmail, Calendar, and Drive
+helpers instead of raw `createAuthenticatedFetch` calls. Official `@kody/*`
+packages resolve in the execute caller runtime against the caller's secrets.
+Saved person-account packages cannot import or invoke a platform scope —
+`community_fork` into the caller's scope first, or fork when you need to
+customize the source.
 
 1. Search for `@kody/google` (or import `kody:@kody/google` directly). It covers
    Gmail, Calendar, Drive, People, and YouTube.

--- a/docs/guides/providers/notion.md
+++ b/docs/guides/providers/notion.md
@@ -160,11 +160,13 @@ internal connection, edit the page's **Connections** menu.
 
 ## Use the official package and verify (Lane B / OAuth)
 
-Lane A stays on the raw `notionToken` fetch above. The live official package is
-the Lane B finish: it uses the saved `notion` OAuth integration and does not
-read `notionToken`. Official `@kody/*` packages resolve in the caller runtime
-against the caller's secrets — do **not** fork them just to use them. Fork only
-when you need to customize the source.
+Lane A stays on the raw `notionToken` fetch above. Ad hoc `execute` may import
+or `packages.invoke` `kody:@kody/notion` live. The live official package is the
+Lane B finish: it uses the saved `notion` OAuth integration and does not read
+`notionToken`. Official `@kody/*` packages resolve in the execute caller
+runtime against the caller's secrets. Saved person-account packages cannot
+import or invoke a platform scope — `community_fork` into the caller's scope
+first, or fork when you need to customize the source.
 
 1. Search for `@kody/notion` (or import `kody:@kody/notion` directly). It wraps
    pages, databases, and a generic request escape hatch.

--- a/docs/guides/providers/notion.md
+++ b/docs/guides/providers/notion.md
@@ -163,10 +163,10 @@ internal connection, edit the page's **Connections** menu.
 Lane A stays on the raw `notionToken` fetch above. Ad hoc `execute` may import
 or `packages.invoke` `kody:@kody/notion` live. The live official package is the
 Lane B finish: it uses the saved `notion` OAuth integration and does not read
-`notionToken`. Official `@kody/*` packages resolve in the execute caller
-runtime against the caller's secrets. Saved person-account packages cannot
-import or invoke a platform scope — `community_fork` into the caller's scope
-first, or fork when you need to customize the source.
+`notionToken`. Official `@kody/*` packages resolve in the execute caller runtime
+against the caller's secrets. Saved person-account packages cannot import or
+invoke a platform scope — `community_fork` into the caller's scope first, or
+fork when you need to customize the source.
 
 1. Search for `@kody/notion` (or import `kody:@kody/notion` directly). It wraps
    pages, databases, and a generic request escape hatch.

--- a/docs/use/packages.md
+++ b/docs/use/packages.md
@@ -146,8 +146,8 @@ exhaustive.
   example `import gh from 'kody:@kody/github/issues'`. A static import runs in
   **your** execute runtime against your secrets and grants. `packages.invoke`
   enters the target package runtime (still your secrets). **Saved person-owned
-  packages must not depend on a platform scope.** Official `@kody` packages
-  may still compose with each other. Publish checks reject `kody:@kody/…` static
+  packages must not depend on a platform scope.** Official `@kody` packages may
+  still compose with each other. Publish checks reject `kody:@kody/…` static
   imports, `kody.dependencies` entries, and `packages.invoke('kody:@kody/…')` in
   person-owned package source. Fork the official package into your scope
   (`community_fork`) and depend on that copy. Platform package code cannot use

--- a/docs/use/packages.md
+++ b/docs/use/packages.md
@@ -140,16 +140,19 @@ exhaustive.
   package's name is known when the code is written. Static imports are typed,
   publish-verified, dependency-graph-visible, and add zero per-call platform
   cost.
-- **Platform (built-in) scopes resolve live without forking.** When a scope's
-  username belongs to a platform account (for example `@kody`), a static import
-  such as `import gh from 'kody:@kody/github/issues'` resolves the platform
-  account's current published version even though you do not own a copy. The
-  code runs in **your** runtime against your secrets and grants; your own copy
-  of the same name always wins when you fork to customize. Platform package code
-  cannot use `packageStorage()` in your account, and dynamic
-  `import("kody:@kody/…")` is unsupported — use the static form. Platform
-  packages appear in `search` results alongside your own (marked with their
-  platform scope), so agents discover them without knowing the name in advance.
+- **Platform (built-in) scopes are execute-only.** When a scope's username
+  belongs to a platform account (for example `@kody`), ad hoc `execute` may
+  statically import or `packages.invoke` the current published version — for
+  example `import gh from 'kody:@kody/github/issues'`. That code runs in
+  **your** runtime against your secrets and grants. **Saved packages must not
+  depend on a platform scope.** Publish checks reject `kody:@kody/…` static
+  imports, `kody.dependencies` entries, and `packages.invoke('kody:@kody/…')` in
+  person-owned package source. Fork the official package into your scope
+  (`community_fork`) and depend on that copy. Platform package code cannot use
+  `packageStorage()` in your account, and dynamic `import("kody:@kody/…")` is
+  unsupported. Platform packages appear in `search` results (marked with their
+  platform scope) so agents discover them for execute; the detail text says to
+  fork before using them in a saved package.
 - Static `kody:@...` imports in saved package code are bundled into published
   runtime artifacts as snapshots of the imported package's published bundle.
   Republishing the imported package does not change already-published
@@ -267,10 +270,12 @@ object-only JavaScript and TypeScript call sites; the permanent
 
 Package runtime contexts, authenticated ad hoc MCP `execute` calls, and package
 job runtimes can call `packages.invoke`. Person-scoped targets resolve only from
-packages owned by the current authenticated user; public platform-scoped targets
-resolve live from the named platform account. Package code does not need to mint
-or pass package-invocation bearer tokens. Nested package invocations are
-depth-limited to prevent runaway loops.
+packages owned by the current authenticated user. Public platform-scoped targets
+resolve live only from **ad hoc execute** (and from official platform packages
+composing with each other). A person-owned package, job, or app that invokes
+`kody:@kody/…` fails closed: fork the official package into your scope first.
+Package code does not need to mint or pass package-invocation bearer tokens.
+Nested package invocations are depth-limited to prevent runaway loops.
 
 External trusted clients that must call package exports over HTTP use package
 invocation tokens instead. Before sending a user to create one, agents should
@@ -286,11 +291,11 @@ reaches the declaring package's own storage bucket (see
 platform (built-in) dependencies receive no `packageStorage()` grant and the
 call fails closed inside live platform code. `{{secret:...}}` placeholders for
 user-scope secrets still resolve at the fetch gateway under the calling user —
-so secret-backed packages such as `github` work fully via plain static import.
-Use keyless `packages.invoke` from execute or a package job runtime when you
-need to enter a saved package as that package so it receives `packageContext`,
-package-owned storage, package-mounted secrets (`kody.secretMounts`), and its
-own `packages` helper.
+so official helpers such as `@kody/github` work from execute via plain static
+import. Saved person-owned packages cannot take that shortcut; they must fork
+first. Use keyless `packages.invoke` from execute when you need to enter an
+official package as that package so it receives `packageContext`. Use
+`packages.invoke` from a package job runtime only for **your** packages.
 
 **Unsupported helpers:** `packages.invokeChecked`, `packages.check`, and literal
 dynamic `import("kody:@...")` are not available. Package publish checks reject

--- a/docs/use/packages.md
+++ b/docs/use/packages.md
@@ -143,16 +143,18 @@ exhaustive.
 - **Platform (built-in) scopes are execute-only.** When a scope's username
   belongs to a platform account (for example `@kody`), ad hoc `execute` may
   statically import or `packages.invoke` the current published version — for
-  example `import gh from 'kody:@kody/github/issues'`. That code runs in
-  **your** runtime against your secrets and grants. **Saved packages must not
-  depend on a platform scope.** Publish checks reject `kody:@kody/…` static
+  example `import gh from 'kody:@kody/github/issues'`. A static import runs in
+  **your** execute runtime against your secrets and grants. `packages.invoke`
+  enters the target package runtime (still your secrets). **Saved person-owned
+  packages must not depend on a platform scope.** Official `@kody` packages
+  may still compose with each other. Publish checks reject `kody:@kody/…` static
   imports, `kody.dependencies` entries, and `packages.invoke('kody:@kody/…')` in
   person-owned package source. Fork the official package into your scope
   (`community_fork`) and depend on that copy. Platform package code cannot use
   `packageStorage()` in your account, and dynamic `import("kody:@kody/…")` is
   unsupported. Platform packages appear in `search` results (marked with their
   platform scope) so agents discover them for execute; the detail text says to
-  fork before using them in a saved package.
+  fork before using them in a saved person-account package.
 - Static `kody:@...` imports in saved package code are bundled into published
   runtime artifacts as snapshots of the imported package's published bundle.
   Republishing the imported package does not change already-published

--- a/packages/worker/src/community/fork-scan.node.test.ts
+++ b/packages/worker/src/community/fork-scan.node.test.ts
@@ -132,7 +132,7 @@ import 'kody:@owner/a/y'`,
 	])
 })
 
-test('scanCrossScopeReferences allows platform scopes to remain in forked packages', () => {
+test('scanCrossScopeReferences treats platform scopes as foreign without an allowlist', () => {
 	const files = {
 		'package.json': `{
 	"name": "@jane/pkg",

--- a/packages/worker/src/community/fork-scan.ts
+++ b/packages/worker/src/community/fork-scan.ts
@@ -53,9 +53,9 @@ export function scanCrossScopeReferences(input: {
 	files: Record<string, string>
 	expectedPackageScope: string
 	/**
-	 * Scopes that remain valid in any account — platform (built-in) scopes
-	 * such as `@kody`, whose packages resolve live for every caller — so
-	 * forks keep referencing them instead of being told to rewrite.
+	 * Extra scopes treated as same-account. Unused for official platform
+	 * scopes: person-owned forks must not keep `kody:@kody/…` references
+	 * (decision 0035).
 	 */
 	allowedForeignScopes?: ReadonlyArray<string>
 }): Array<CrossScopeReference> {

--- a/packages/worker/src/community/service.ts
+++ b/packages/worker/src/community/service.ts
@@ -25,10 +25,8 @@ import {
 	getSavedPackageByKodyId,
 	getSavedPackageByName,
 } from '#worker/package-registry/repo.ts'
-import {
-	isPlatformAccountStableUserId,
-	listPlatformAccountUsernames,
-} from '#worker/package-registry/scope-grants.ts'
+import { rewriteForkedPackageSelfReferences } from '#worker/package-registry/platform-package-policy.ts'
+import { isPlatformAccountStableUserId } from '#worker/package-registry/scope-grants.ts'
 import { loadPackageSourceBySourceId } from '#worker/package-registry/source.ts'
 import { cleanupArtifactReposForPackage } from '#worker/repo/artifact-repo-cleanup.ts'
 import { deleteEntitySource } from '#worker/repo/entity-sources.ts'
@@ -1386,22 +1384,20 @@ export async function prepareCommunityFork(
 	} catch (error) {
 		throw new CommunityActionError(getErrorMessage(error))
 	}
-	const [existingByKody, existingByName, existingForks, platformUsernames] =
-		await Promise.all([
-			getSavedPackageByKodyId(input.env.APP_DB, {
-				userId: input.userId,
-				kodyId: targetKodyId,
-			}),
-			getSavedPackageByName(input.env.APP_DB, {
-				userId: input.userId,
-				name: rewrittenManifest.targetName,
-			}),
-			listCommunityForksByListingAndUser(input.env.APP_DB, {
-				listingId: input.listingId,
-				userId: input.userId,
-			}),
-			listPlatformAccountUsernames(input.env.APP_DB),
-		])
+	const [existingByKody, existingByName, existingForks] = await Promise.all([
+		getSavedPackageByKodyId(input.env.APP_DB, {
+			userId: input.userId,
+			kodyId: targetKodyId,
+		}),
+		getSavedPackageByName(input.env.APP_DB, {
+			userId: input.userId,
+			name: rewrittenManifest.targetName,
+		}),
+		listCommunityForksByListingAndUser(input.env.APP_DB, {
+			listingId: input.listingId,
+			userId: input.userId,
+		}),
+	])
 	if (existingByKody || existingByName) {
 		throw new CommunityActionError(
 			`You already have a saved package with kody id "${targetKodyId}". Pass a different kody_id to fork this listing.`,
@@ -1421,16 +1417,17 @@ export async function prepareCommunityFork(
 		)
 	}
 
-	const rewrittenFiles = {
-		...snapshot.files,
-		'package.json': rewrittenManifest.content,
-	}
+	const rewrittenFiles = rewriteForkedPackageSelfReferences({
+		files: {
+			...snapshot.files,
+			'package.json': rewrittenManifest.content,
+		},
+		originPackageName: listing.name,
+		nextPackageName: rewrittenManifest.targetName,
+	})
 	const crossScopeReferences = scanCrossScopeReferences({
 		files: rewrittenFiles,
 		expectedPackageScope: input.expectedPackageScope,
-		// Platform scopes (e.g. @kody) resolve live for every caller; forks
-		// keep those references instead of rewriting them.
-		allowedForeignScopes: platformUsernames,
 	})
 
 	return {

--- a/packages/worker/src/mcp/run-kody-registry.ts
+++ b/packages/worker/src/mcp/run-kody-registry.ts
@@ -43,6 +43,8 @@ import {
 	type KodyOpenApiProviderMetadata,
 	type KodyResolvedProvider,
 } from '#mcp/kody-remote-types.ts'
+import { personPackagePlatformDependencyMessage } from '#worker/package-registry/platform-package-policy.ts'
+import { getSavedPackageById } from '#worker/package-registry/repo.ts'
 import { openApiProviderKodyName } from '#worker/openapi/openapi-domain-id.ts'
 import {
 	createRuntimeHelperExtraProviders,
@@ -889,6 +891,23 @@ export async function runBundledModuleWithRegistry(
 		}
 		await reportExecutePhaseProgress(reportProgress, 'provider-assembly')
 		const providerAssemblyStartedAtMs = Date.now()
+		const runningPackageId = options?.packageContext?.packageId?.trim()
+		const runningUserId = callerContext.user?.userId
+		if (
+			runningPackageId &&
+			runningUserId &&
+			(bundle.dependencies ?? []).some(
+				(dependency) => dependency.platformOwned === true,
+			)
+		) {
+			const callerOwned = await getSavedPackageById(env.APP_DB, {
+				userId: runningUserId,
+				packageId: runningPackageId,
+			})
+			if (callerOwned) {
+				throw new Error(personPackagePlatformDependencyMessage)
+			}
+		}
 		const grantedPackageStorageIds = collectPackageStorageGrantIds({
 			packageContext: options?.packageContext ?? null,
 			dependencies: bundle.dependencies ?? [],

--- a/packages/worker/src/mcp/run-kody-registry.ts
+++ b/packages/worker/src/mcp/run-kody-registry.ts
@@ -43,8 +43,7 @@ import {
 	type KodyOpenApiProviderMetadata,
 	type KodyResolvedProvider,
 } from '#mcp/kody-remote-types.ts'
-import { personPackagePlatformDependencyMessage } from '#worker/package-registry/platform-package-policy.ts'
-import { getSavedPackageById } from '#worker/package-registry/repo.ts'
+import { assertPersonOwnedPackageMayNotRunPlatformDependencies } from '#worker/package-registry/platform-package-policy.ts'
 import { openApiProviderKodyName } from '#worker/openapi/openapi-domain-id.ts'
 import {
 	createRuntimeHelperExtraProviders,
@@ -893,20 +892,13 @@ export async function runBundledModuleWithRegistry(
 		const providerAssemblyStartedAtMs = Date.now()
 		const runningPackageId = options?.packageContext?.packageId?.trim()
 		const runningUserId = callerContext.user?.userId
-		if (
-			runningPackageId &&
-			runningUserId &&
-			(bundle.dependencies ?? []).some(
-				(dependency) => dependency.platformOwned === true,
-			)
-		) {
-			const callerOwned = await getSavedPackageById(env.APP_DB, {
+		if (runningPackageId && runningUserId) {
+			await assertPersonOwnedPackageMayNotRunPlatformDependencies({
+				db: env.APP_DB,
 				userId: runningUserId,
 				packageId: runningPackageId,
+				dependencies: bundle.dependencies ?? [],
 			})
-			if (callerOwned) {
-				throw new Error(personPackagePlatformDependencyMessage)
-			}
 		}
 		const grantedPackageStorageIds = collectPackageStorageGrantIds({
 			packageContext: options?.packageContext ?? null,

--- a/packages/worker/src/mcp/tools/search-entity-plugins/package.ts
+++ b/packages/worker/src/mcp/tools/search-entity-plugins/package.ts
@@ -219,8 +219,7 @@ export const packageSearchEntityPlugin = {
 		const vectorEligibleRows = rows.filter((row) => !row.platformScope)
 		// Fail closed in every mode: no userId, and foreign rows never enter
 		// ranking unless the loader explicitly marked them as platform
-		// (built-in) scope rows — the one lane that resolves live for every
-		// caller (decision record 0014).
+		// (built-in) scope rows — execute-only live resolution (decision 0035).
 		if (!input.userId) return []
 		if (
 			rows.some(
@@ -438,7 +437,7 @@ export const packageSearchEntityPlugin = {
 			? getPrimaryPackageActionFunction(primaryAction)
 			: null
 		const platformSuffix = match.platformScope
-			? ` This is a platform (built-in) package: the import resolves live from @${match.platformScope} — no fork needed, and it runs in your runtime against your secrets.`
+			? ` This is a platform (built-in) package: ad hoc execute may import or packages.invoke it live from @${match.platformScope}. Saved packages must community_fork it into your scope before depending on it.`
 			: ''
 		const listingAheadSuffix =
 			match.listingAhead === true ? ` ${listingAheadSearchNotice}` : ''

--- a/packages/worker/src/mcp/tools/search-entity-plugins/package.ts
+++ b/packages/worker/src/mcp/tools/search-entity-plugins/package.ts
@@ -437,7 +437,7 @@ export const packageSearchEntityPlugin = {
 			? getPrimaryPackageActionFunction(primaryAction)
 			: null
 		const platformSuffix = match.platformScope
-			? ` This is a platform (built-in) package: ad hoc execute may import or packages.invoke it live from @${match.platformScope}. Saved packages must community_fork it into your scope before depending on it.`
+			? ` This is a platform (built-in) package: ad hoc execute may import or packages.invoke it live from @${match.platformScope}. Saved person-account packages must community_fork it into your scope before depending on it.`
 			: ''
 		const listingAheadSuffix =
 			match.listingAhead === true ? ` ${listingAheadSearchNotice}` : ''

--- a/packages/worker/src/mcp/tools/search-format-types.ts
+++ b/packages/worker/src/mcp/tools/search-format-types.ts
@@ -172,7 +172,7 @@ export type SlimSearchMatch =
 			tags: Array<string>
 			hasApp: boolean
 			hidden: boolean
-			/** Platform (built-in) scope username; import without forking. */
+			/** Platform (built-in) scope username; execute-only without forking. */
 			platformScope?: string | null
 			hostedUrl: string | null
 			readmeSnippet: {
@@ -286,7 +286,7 @@ export type SearchEntityDetailStructured =
 			tags: Array<string>
 			hasApp: boolean
 			hidden: boolean
-			/** Platform (built-in) scope username; import without forking. */
+			/** Platform (built-in) scope username; execute-only without forking. */
 			platformScope?: string | null
 			hostedUrl: string | null
 			appEntry: string | null

--- a/packages/worker/src/mcp/tools/search-format-types.ts
+++ b/packages/worker/src/mcp/tools/search-format-types.ts
@@ -172,7 +172,7 @@ export type SlimSearchMatch =
 			tags: Array<string>
 			hasApp: boolean
 			hidden: boolean
-			/** Platform (built-in) scope username; execute-only without forking. */
+			/** Platform (built-in) scope username; live for execute and platform-account packages. Person-account saved packages must fork. */
 			platformScope?: string | null
 			hostedUrl: string | null
 			readmeSnippet: {
@@ -286,7 +286,7 @@ export type SearchEntityDetailStructured =
 			tags: Array<string>
 			hasApp: boolean
 			hidden: boolean
-			/** Platform (built-in) scope username; execute-only without forking. */
+			/** Platform (built-in) scope username; live for execute and platform-account packages. Person-account saved packages must fork. */
 			platformScope?: string | null
 			hostedUrl: string | null
 			appEntry: string | null

--- a/packages/worker/src/package-invocations/invoke-check.ts
+++ b/packages/worker/src/package-invocations/invoke-check.ts
@@ -121,6 +121,10 @@ export async function checkPackageInvokeForRuntimeWithPreloads(input: {
 		})
 		if (
 			callingOwned &&
+			!(await isPlatformAccountStableUserId(
+				input.env.APP_DB,
+				callingOwned.userId,
+			)) &&
 			(await isPlatformAccountStableUserId(
 				input.env.APP_DB,
 				savedPackage.userId,

--- a/packages/worker/src/package-invocations/invoke-check.ts
+++ b/packages/worker/src/package-invocations/invoke-check.ts
@@ -4,6 +4,9 @@ import {
 	type PackageInvokeContract,
 	type PackageInvokeInput,
 } from '#mcp/run-kody-registry.ts'
+import { formatPersonPackagePlatformDependencyMessage } from '#worker/package-registry/platform-package-policy.ts'
+import { getSavedPackageById } from '#worker/package-registry/repo.ts'
+import { isPlatformAccountStableUserId } from '#worker/package-registry/scope-grants.ts'
 import { type PackageExportProjection } from '#worker/package-registry/manifest.ts'
 import { normalizeExportName } from './common.ts'
 import {
@@ -77,6 +80,8 @@ export async function checkPackageInvokeForRuntimeWithPreloads(input: {
 	operationName: PackageInvokeCheckOperationName
 	userId: string
 	rawInput: PackageInvokeInput
+	callerKind?: 'package' | 'execute'
+	callingPackageId?: string | null
 }): Promise<PackageInvokeCheckOutcome> {
 	let request: ReturnType<typeof parsePackageInvokeInput>
 	try {
@@ -107,6 +112,31 @@ export async function checkPackageInvokeForRuntimeWithPreloads(input: {
 				contract: { exportName },
 			}),
 			preloads: null,
+		}
+	}
+	if (input.callerKind === 'package' && input.callingPackageId) {
+		const callingOwned = await getSavedPackageById(input.env.APP_DB, {
+			userId: input.userId,
+			packageId: input.callingPackageId,
+		})
+		if (
+			callingOwned &&
+			(await isPlatformAccountStableUserId(
+				input.env.APP_DB,
+				savedPackage.userId,
+			))
+		) {
+			const message = formatPersonPackagePlatformDependencyMessage(
+				savedPackage.name,
+			)
+			return {
+				result: createPackageInvokeCheckFailure({
+					message,
+					problems: [message],
+					contract: { exportName },
+				}),
+				preloads: null,
+			}
 		}
 	}
 	const sourceOwnerUserId = savedPackage.userId

--- a/packages/worker/src/package-invocations/invoke-contract-cache.node.test.ts
+++ b/packages/worker/src/package-invocations/invoke-contract-cache.node.test.ts
@@ -15,6 +15,7 @@ const mockModule = vi.hoisted(() => ({
 	getSavedPackageByKodyId: vi.fn(),
 	getSavedPackageByName: vi.fn(),
 	getPlatformAccountByUsername: vi.fn(),
+	isPlatformAccountStableUserId: vi.fn(),
 	getEntitySourceById: vi.fn(),
 	loadPublishedEntityManifest: vi.fn(),
 	loadPublishedEntitySource: vi.fn(),
@@ -36,6 +37,8 @@ vi.mock('#worker/package-registry/repo.ts', () => ({
 vi.mock('#worker/package-registry/scope-grants.ts', () => ({
 	getPlatformAccountByUsername: (...args: Array<unknown>) =>
 		mockModule.getPlatformAccountByUsername(...args),
+	isPlatformAccountStableUserId: (...args: Array<unknown>) =>
+		mockModule.isPlatformAccountStableUserId(...args),
 }))
 
 vi.mock('#worker/repo/entity-sources.ts', () => ({
@@ -207,6 +210,10 @@ function seedFixtures(fixturesByUserId: Record<string, Fixture>) {
 					}
 				: null,
 	)
+	mockModule.isPlatformAccountStableUserId.mockImplementation(
+		async (_db: unknown, stableUserId: string) =>
+			stableUserId === 'platform-owner',
+	)
 	mockModule.getEntitySourceById.mockImplementation(
 		async (_db: unknown, sourceId: string) =>
 			Object.values(fixturesByUserId).find(
@@ -259,6 +266,58 @@ async function runContractCheck(input: { userId: string; specifier?: string }) {
 		},
 	})
 }
+
+test('person package runtimes cannot invoke official platform packages', async () => {
+	seedFixtures({
+		'user-1': createFixture({ userId: 'user-1', publishedCommit: 'commit-1' }),
+		'platform-owner': createFixture({
+			userId: 'platform-owner',
+			publishedCommit: 'commit-1',
+			packageName: '@kody/github',
+			kodyId: 'github',
+		}),
+	})
+	mockModule.getSavedPackageById.mockImplementation(
+		async (_db: unknown, input: { userId: string; packageId: string }) =>
+			input.userId === 'user-1' && input.packageId === 'pkg-user-1'
+				? {
+						id: 'pkg-user-1',
+						userId: 'user-1',
+						name: '@kentcdodds/sentry-triage',
+						kodyId: 'sentry-triage',
+					}
+				: null,
+	)
+
+	const denied = await checkPackageInvokeForRuntimeWithPreloads({
+		env: createEnv(),
+		baseUrl: 'https://kody.dev',
+		operationName: 'packages.invoke',
+		userId: 'user-1',
+		rawInput: {
+			specifier: 'kody:@kody/github/get-issue-state',
+			options: { params: {} },
+		},
+		callerKind: 'package',
+		callingPackageId: 'pkg-user-1',
+	})
+	expect(denied.result.ok).toBe(false)
+	expect(denied.result.message).toContain('execute-only')
+	expect(denied.preloads).toBeNull()
+
+	const fromExecute = await checkPackageInvokeForRuntimeWithPreloads({
+		env: createEnv(),
+		baseUrl: 'https://kody.dev',
+		operationName: 'packages.invoke',
+		userId: 'user-1',
+		rawInput: {
+			specifier: 'kody:@kody/github/get-issue-state',
+			options: { params: {} },
+		},
+		callerKind: 'execute',
+	})
+	expect(fromExecute.result.ok).toBe(true)
+})
 
 test('a warm keyless invoke contract check performs zero D1/KV loads', async () => {
 	seedFixtures({

--- a/packages/worker/src/package-invocations/invoke-contract-cache.node.test.ts
+++ b/packages/worker/src/package-invocations/invoke-contract-cache.node.test.ts
@@ -317,6 +317,31 @@ test('person package runtimes cannot invoke official platform packages', async (
 		callerKind: 'execute',
 	})
 	expect(fromExecute.result.ok).toBe(true)
+
+	mockModule.getSavedPackageById.mockImplementation(
+		async (_db: unknown, input: { userId: string; packageId: string }) =>
+			input.userId === 'platform-owner' && input.packageId === 'pkg-kody-github'
+				? {
+						id: 'pkg-kody-github',
+						userId: 'platform-owner',
+						name: '@kody/github',
+						kodyId: 'github',
+					}
+				: null,
+	)
+	const fromPlatformPackage = await checkPackageInvokeForRuntimeWithPreloads({
+		env: createEnv(),
+		baseUrl: 'https://kody.dev',
+		operationName: 'packages.invoke',
+		userId: 'platform-owner',
+		rawInput: {
+			specifier: 'kody:@kody/github/get-issue-state',
+			options: { params: {} },
+		},
+		callerKind: 'package',
+		callingPackageId: 'pkg-kody-github',
+	})
+	expect(fromPlatformPackage.result.ok).toBe(true)
 })
 
 test('a warm keyless invoke contract check performs zero D1/KV loads', async () => {

--- a/packages/worker/src/package-invocations/runtime-tool-factories.ts
+++ b/packages/worker/src/package-invocations/runtime-tool-factories.ts
@@ -114,6 +114,8 @@ function createPackageInvokeTools(input: {
 			operationName: 'packages.invoke',
 			userId: user.userId,
 			rawInput,
+			callerKind: input.callerKind,
+			callingPackageId: packageContext?.packageId ?? null,
 		})
 		throwIfPackageInvokeAborted(signal)
 		if (!check.result.ok || !check.preloads) {

--- a/packages/worker/src/package-registry/platform-package-policy.node.test.ts
+++ b/packages/worker/src/package-registry/platform-package-policy.node.test.ts
@@ -97,4 +97,13 @@ import shared from 'kody:@kody/shared/util'
 	expect(files['index.ts']).toContain('kody:@kody/shared/util')
 	expect(files['package.json']).toContain('"@alice/github"')
 	expect(files['package.json']).toContain('"@kody/shared"')
+
+	const templateLiteral = rewriteForkedPackageSelfReferences({
+		files: {
+			'job.ts': 'await packages.invoke(`kody:@kody/github/issues`)\n',
+		},
+		originPackageName: '@kody/github',
+		nextPackageName: '@alice/github',
+	})
+	expect(templateLiteral['job.ts']).toContain('kody:@alice/github/issues')
 })

--- a/packages/worker/src/package-registry/platform-package-policy.node.test.ts
+++ b/packages/worker/src/package-registry/platform-package-policy.node.test.ts
@@ -1,0 +1,87 @@
+import { DatabaseSync } from 'node:sqlite'
+import { expect, test } from 'vitest'
+import { createPlatformAccount } from '#worker/identity/platform-account-creation.ts'
+import { applyAllMigrations as applyRepositoryMigrations } from '#worker/test-support/apply-all-migrations.ts'
+import { createD1FromSqlite } from '#worker/test-support/create-d1-from-sqlite.ts'
+import {
+	collectScopedPackageNamesFromSource,
+	findPersonPackagePlatformReference,
+	formatPersonPackagePlatformDependencyMessage,
+	personPackagePlatformDependencyMessage,
+	rewriteForkedPackageSelfReferences,
+} from './platform-package-policy.ts'
+
+const migrationsDirectory = new URL('../../migrations/', import.meta.url)
+
+async function createHarness() {
+	const sqlite = new DatabaseSync(':memory:')
+	applyRepositoryMigrations(sqlite, migrationsDirectory)
+	const db = createD1FromSqlite(sqlite)
+	await createPlatformAccount({
+		db,
+		email: 'kody@example.com',
+		username: 'kody',
+	})
+	return { db }
+}
+
+test('collectScopedPackageNamesFromSource reads imports, deps, and invoke specifiers', () => {
+	expect(
+		collectScopedPackageNamesFromSource({
+			manifestDependencies: { '@kody/github': '*', '@alice/helper': '*' },
+			sourceFiles: {
+				'index.ts': `
+import gh from 'kody:@kody/github/issues'
+import helper from 'kody:@alice/helper'
+await packages.invoke('kody:@kody/notion/smoke-test', { params: {} })
+await packages.invoke('@kody/google/profile', { params: {} })
+`,
+			},
+		}),
+	).toEqual(['@alice/helper', '@kody/github', '@kody/google', '@kody/notion'])
+})
+
+test('findPersonPackagePlatformReference names the official package and ignores person scopes', async () => {
+	const { db } = await createHarness()
+	await expect(
+		findPersonPackagePlatformReference({
+			db,
+			manifestDependencies: { '@alice/helper': '*' },
+			sourceFiles: {
+				'index.ts': `import helper from 'kody:@alice/helper'\n`,
+			},
+		}),
+	).resolves.toBeNull()
+	await expect(
+		findPersonPackagePlatformReference({
+			db,
+			sourceFiles: {
+				'job.ts': `await packages.invoke('kody:@kody/notion/smoke-test')\n`,
+			},
+		}),
+	).resolves.toBe('@kody/notion')
+	expect(
+		formatPersonPackagePlatformDependencyMessage('@kody/notion'),
+	).toContain(personPackagePlatformDependencyMessage)
+	expect(
+		formatPersonPackagePlatformDependencyMessage('@kody/notion'),
+	).toContain('@kody/notion')
+})
+
+test('rewriteForkedPackageSelfReferences rewrites only the forked package name', () => {
+	const files = rewriteForkedPackageSelfReferences({
+		files: {
+			'package.json':
+				'{"dependencies":{"@kody/github":"*","@kody/shared":"*"}}',
+			'index.ts': `import gh from 'kody:@kody/github/issues'
+import shared from 'kody:@kody/shared/util'
+`,
+		},
+		originPackageName: '@kody/github',
+		nextPackageName: '@alice/github',
+	})
+	expect(files['index.ts']).toContain('kody:@alice/github/issues')
+	expect(files['index.ts']).toContain('kody:@kody/shared/util')
+	expect(files['package.json']).toContain('"@alice/github"')
+	expect(files['package.json']).toContain('"@kody/shared"')
+})

--- a/packages/worker/src/package-registry/platform-package-policy.node.test.ts
+++ b/packages/worker/src/package-registry/platform-package-policy.node.test.ts
@@ -13,6 +13,11 @@ import {
 	rewriteForkedPackageSelfReferences,
 	throwIfPersonPackagePlatformReference,
 } from './platform-package-policy.ts'
+import {
+	getPlatformAccountByUsername,
+	isPlatformAccountStableUserId,
+	listPlatformAccountUsernames,
+} from './scope-grants.ts'
 
 const migrationsDirectory = new URL('../../migrations/', import.meta.url)
 
@@ -184,4 +189,27 @@ test('already-published person artifacts with platformOwned deps fail closed; pl
 			dependencies: platformOwned,
 		}),
 	).resolves.toBeUndefined()
+})
+
+test('platform-account lookups treat query-allowlist D1 mocks as person accounts', async () => {
+	const db = {
+		prepare(query: string) {
+			const statement = {
+				bind() {
+					return statement
+				},
+				async first() {
+					throw new Error(`Unsupported first query: ${query}`)
+				},
+				async all() {
+					throw new Error(`Unsupported first query: ${query}`)
+				},
+			}
+			return statement
+		},
+	} as unknown as D1Database
+
+	await expect(isPlatformAccountStableUserId(db, 'user-1')).resolves.toBe(false)
+	await expect(getPlatformAccountByUsername(db, 'kody')).resolves.toBeNull()
+	await expect(listPlatformAccountUsernames(db)).resolves.toEqual([])
 })

--- a/packages/worker/src/package-registry/platform-package-policy.node.test.ts
+++ b/packages/worker/src/package-registry/platform-package-policy.node.test.ts
@@ -1,9 +1,11 @@
 import { DatabaseSync } from 'node:sqlite'
 import { expect, test } from 'vitest'
 import { createPlatformAccount } from '#worker/identity/platform-account-creation.ts'
+import { insertSavedPackage } from '#worker/package-registry/repo.ts'
 import { applyAllMigrations as applyRepositoryMigrations } from '#worker/test-support/apply-all-migrations.ts'
 import { createD1FromSqlite } from '#worker/test-support/create-d1-from-sqlite.ts'
 import {
+	assertPersonOwnedPackageMayNotRunPlatformDependencies,
 	collectScopedPackageNamesFromSource,
 	findPersonPackagePlatformReference,
 	formatPersonPackagePlatformDependencyMessage,
@@ -18,12 +20,33 @@ async function createHarness() {
 	const sqlite = new DatabaseSync(':memory:')
 	applyRepositoryMigrations(sqlite, migrationsDirectory)
 	const db = createD1FromSqlite(sqlite)
-	await createPlatformAccount({
+	const platform = await createPlatformAccount({
 		db,
 		email: 'kody@example.com',
 		username: 'kody',
 	})
-	return { db }
+	return { db, platformUserId: platform.stableUserId }
+}
+
+async function seedPackage(
+	db: D1Database,
+	input: { userId: string; name: string; kodyId: string },
+) {
+	const id = crypto.randomUUID()
+	await insertSavedPackage(db, {
+		id,
+		user_id: input.userId,
+		name: input.name,
+		kody_id: input.kodyId,
+		description: `${input.name} test package`,
+		tags_json: '[]',
+		search_text: null,
+		source_id: `source-${id}`,
+		has_app: 0,
+		hidden: 0,
+		is_private: 0,
+	})
+	return id
 }
 
 test('collectScopedPackageNamesFromSource reads imports, deps, and invoke specifiers', () => {
@@ -106,4 +129,59 @@ import shared from 'kody:@kody/shared/util'
 		nextPackageName: '@alice/github',
 	})
 	expect(templateLiteral['job.ts']).toContain('kody:@alice/github/issues')
+})
+
+test('already-published person artifacts with platformOwned deps fail closed; platform composers do not', async () => {
+	const { db, platformUserId } = await createHarness()
+	await db
+		.prepare(
+			`INSERT INTO users (username, email, password_hash, email_verified_at, stable_user_id, plan)
+			VALUES (?, ?, 'x', CURRENT_TIMESTAMP, ?, 'free')`,
+		)
+		.bind('alice', 'alice@example.com', 'person-alice')
+		.run()
+	const personPackageId = await seedPackage(db, {
+		userId: 'person-alice',
+		name: '@alice/helper',
+		kodyId: 'helper',
+	})
+	const platformPackageId = await seedPackage(db, {
+		userId: platformUserId,
+		name: '@kody/github',
+		kodyId: 'github',
+	})
+	const platformOwned = [{ platformOwned: true }]
+
+	await expect(
+		assertPersonOwnedPackageMayNotRunPlatformDependencies({
+			db,
+			userId: 'person-alice',
+			packageId: personPackageId,
+			dependencies: platformOwned,
+		}),
+	).rejects.toThrow(personPackagePlatformDependencyMessage)
+	await expect(
+		assertPersonOwnedPackageMayNotRunPlatformDependencies({
+			db,
+			userId: platformUserId,
+			packageId: platformPackageId,
+			dependencies: platformOwned,
+		}),
+	).resolves.toBeUndefined()
+	await expect(
+		assertPersonOwnedPackageMayNotRunPlatformDependencies({
+			db,
+			userId: 'person-alice',
+			packageId: personPackageId,
+			dependencies: [{ platformOwned: false }],
+		}),
+	).resolves.toBeUndefined()
+	await expect(
+		assertPersonOwnedPackageMayNotRunPlatformDependencies({
+			db,
+			userId: 'person-alice',
+			packageId: platformPackageId,
+			dependencies: platformOwned,
+		}),
+	).resolves.toBeUndefined()
 })

--- a/packages/worker/src/package-registry/platform-package-policy.node.test.ts
+++ b/packages/worker/src/package-registry/platform-package-policy.node.test.ts
@@ -9,6 +9,7 @@ import {
 	formatPersonPackagePlatformDependencyMessage,
 	personPackagePlatformDependencyMessage,
 	rewriteForkedPackageSelfReferences,
+	throwIfPersonPackagePlatformReference,
 } from './platform-package-policy.ts'
 
 const migrationsDirectory = new URL('../../migrations/', import.meta.url)
@@ -66,6 +67,18 @@ test('findPersonPackagePlatformReference names the official package and ignores 
 	expect(
 		formatPersonPackagePlatformDependencyMessage('@kody/notion'),
 	).toContain('@kody/notion')
+	await expect(
+		throwIfPersonPackagePlatformReference({
+			db,
+			packageName: '@alice/helper',
+		}),
+	).resolves.toBeUndefined()
+	await expect(
+		throwIfPersonPackagePlatformReference({
+			db,
+			packageName: '@kody/notion',
+		}),
+	).rejects.toThrow(personPackagePlatformDependencyMessage)
 })
 
 test('rewriteForkedPackageSelfReferences rewrites only the forked package name', () => {

--- a/packages/worker/src/package-registry/platform-package-policy.ts
+++ b/packages/worker/src/package-registry/platform-package-policy.ts
@@ -80,6 +80,20 @@ export async function findPersonPackagePlatformReference(input: {
 	})
 }
 
+/** Fail closed only when the missing name is a platform-account scope. */
+export async function throwIfPersonPackagePlatformReference(input: {
+	db: D1Database
+	packageName: string
+}): Promise<void> {
+	const platformName = await findPlatformScopedPackageName({
+		db: input.db,
+		packageNames: [input.packageName],
+	})
+	if (platformName) {
+		throw new Error(formatPersonPackagePlatformDependencyMessage(platformName))
+	}
+}
+
 export function rewriteForkedPackageSelfReferences(input: {
 	files: Record<string, string>
 	originPackageName: string

--- a/packages/worker/src/package-registry/platform-package-policy.ts
+++ b/packages/worker/src/package-registry/platform-package-policy.ts
@@ -1,0 +1,102 @@
+import { collectStaticKodyPackageImportsFromFiles } from '#worker/package-runtime/static-kody-imports.ts'
+import { getPlatformAccountByUsername } from './scope-grants.ts'
+import { listKodyPackageDependencyNames } from './types.ts'
+
+/**
+ * Official `@kody/*` (and any other platform-account scope) packages are
+ * execute-only. Ad hoc execute may import or `packages.invoke` them live.
+ * Saved person-account packages must fork into the caller's scope. Decision
+ * 0035; this supersedes the package-import half of 0014.
+ */
+export const personPackagePlatformDependencyMessage =
+	'Official platform packages are execute-only. Ad hoc execute may import or packages.invoke them live. Saved packages must community_fork the official package into your scope and depend on that copy — platform APIs are not a stable package dependency.'
+
+export function formatPersonPackagePlatformDependencyMessage(
+	packageName: string,
+) {
+	return `${personPackagePlatformDependencyMessage} Offending reference: ${packageName}.`
+}
+
+const invokeSpecifierPattern =
+	/packages\.invoke\s*\(\s*(['"`])((?:kody:)?@[a-z0-9][a-z0-9._-]*\/[^'"`]+)\1/g
+
+function packageNameFromInvokeSpecifier(raw: string): string | null {
+	const trimmed = raw.startsWith('kody:') ? raw.slice('kody:'.length) : raw
+	const match = /^@([^/]+)\/([^/]+)/.exec(trimmed)
+	return match?.[1] && match[2] ? `@${match[1]}/${match[2]}` : null
+}
+
+function packageScopeUsername(packageName: string): string | null {
+	const match = /^@([^/]+)\//.exec(packageName)
+	return match?.[1] ?? null
+}
+
+export function collectScopedPackageNamesFromSource(input: {
+	manifestDependencies?: Array<string> | Record<string, string> | null
+	sourceFiles: Record<string, string>
+}): Array<string> {
+	const names = new Set<string>()
+	for (const dependency of listKodyPackageDependencyNames(
+		input.manifestDependencies,
+	)) {
+		names.add(dependency)
+	}
+	for (const imported of collectStaticKodyPackageImportsFromFiles(
+		input.sourceFiles,
+	)) {
+		names.add(imported.packageName)
+	}
+	for (const content of Object.values(input.sourceFiles)) {
+		for (const match of content.matchAll(invokeSpecifierPattern)) {
+			const packageName = packageNameFromInvokeSpecifier(match[2] ?? '')
+			if (packageName) names.add(packageName)
+		}
+	}
+	return [...names].sort((left, right) => left.localeCompare(right))
+}
+
+export async function findPlatformScopedPackageName(input: {
+	db: D1Database
+	packageNames: ReadonlyArray<string>
+}): Promise<string | null> {
+	for (const packageName of input.packageNames) {
+		const scope = packageScopeUsername(packageName)
+		if (!scope) continue
+		if (await getPlatformAccountByUsername(input.db, scope)) {
+			return packageName
+		}
+	}
+	return null
+}
+
+export async function findPersonPackagePlatformReference(input: {
+	db: D1Database
+	manifestDependencies?: Array<string> | Record<string, string> | null
+	sourceFiles: Record<string, string>
+}): Promise<string | null> {
+	return await findPlatformScopedPackageName({
+		db: input.db,
+		packageNames: collectScopedPackageNamesFromSource(input),
+	})
+}
+
+export function rewriteForkedPackageSelfReferences(input: {
+	files: Record<string, string>
+	originPackageName: string
+	nextPackageName: string
+}): Record<string, string> {
+	const origin = input.originPackageName.trim()
+	const next = input.nextPackageName.trim()
+	if (!origin || origin === next) {
+		return { ...input.files }
+	}
+	const escaped = origin.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+	const pattern = new RegExp(`${escaped}(?=/|["'\\s,]|$)`, 'g')
+	const files: Record<string, string> = {}
+	for (const [path, content] of Object.entries(input.files)) {
+		files[path] = content.includes(origin)
+			? content.replace(pattern, next)
+			: content
+	}
+	return files
+}

--- a/packages/worker/src/package-registry/platform-package-policy.ts
+++ b/packages/worker/src/package-registry/platform-package-policy.ts
@@ -1,5 +1,9 @@
 import { collectStaticKodyPackageImportsFromFiles } from '#worker/package-runtime/static-kody-imports.ts'
-import { getPlatformAccountByUsername } from './scope-grants.ts'
+import { getSavedPackageById } from './repo.ts'
+import {
+	getPlatformAccountByUsername,
+	isPlatformAccountStableUserId,
+} from './scope-grants.ts'
 import { listKodyPackageDependencyNames } from './types.ts'
 
 /**
@@ -78,6 +82,33 @@ export async function findPersonPackagePlatformReference(input: {
 		db: input.db,
 		packageNames: collectScopedPackageNamesFromSource(input),
 	})
+}
+
+/**
+ * Already-published person-package artifacts (modules, jobs, and apps) that
+ * recorded `platformOwned` dependencies fail closed. Platform-account
+ * packages may still compose with each other.
+ */
+export async function assertPersonOwnedPackageMayNotRunPlatformDependencies(input: {
+	db: D1Database
+	userId: string
+	packageId: string
+	dependencies: ReadonlyArray<{ platformOwned?: boolean }>
+}): Promise<void> {
+	if (
+		!input.dependencies.some((dependency) => dependency.platformOwned === true)
+	) {
+		return
+	}
+	const callerOwned = await getSavedPackageById(input.db, {
+		userId: input.userId,
+		packageId: input.packageId,
+	})
+	if (!callerOwned) return
+	if (await isPlatformAccountStableUserId(input.db, callerOwned.userId)) {
+		return
+	}
+	throw new Error(personPackagePlatformDependencyMessage)
 }
 
 /** Fail closed only when the missing name is a platform-account scope. */

--- a/packages/worker/src/package-registry/platform-package-policy.ts
+++ b/packages/worker/src/package-registry/platform-package-policy.ts
@@ -9,7 +9,7 @@ import { listKodyPackageDependencyNames } from './types.ts'
  * 0035; this supersedes the package-import half of 0014.
  */
 export const personPackagePlatformDependencyMessage =
-	'Official platform packages are execute-only. Ad hoc execute may import or packages.invoke them live. Saved packages must community_fork the official package into your scope and depend on that copy — platform APIs are not a stable package dependency.'
+	'Official platform packages are execute-only. Ad hoc execute may import or packages.invoke them live. Saved person-account packages must community_fork the official package into your scope and depend on that copy — platform APIs are not a stable package dependency.'
 
 export function formatPersonPackagePlatformDependencyMessage(
 	packageName: string,
@@ -105,7 +105,7 @@ export function rewriteForkedPackageSelfReferences(input: {
 		return { ...input.files }
 	}
 	const escaped = origin.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-	const pattern = new RegExp(`${escaped}(?=/|["'\\s,]|$)`, 'g')
+	const pattern = new RegExp(`${escaped}(?=/|["'\`\\s,]|$)`, 'g')
 	const files: Record<string, string> = {}
 	for (const [path, content] of Object.entries(input.files)) {
 		files[path] = content.includes(origin)

--- a/packages/worker/src/package-registry/platform-packages.ts
+++ b/packages/worker/src/package-registry/platform-packages.ts
@@ -12,9 +12,9 @@ type PlatformAccountRef = {
 
 /**
  * Platform (built-in) packages: packages owned by platform accounts
- * (`users.account_type = 'platform'`), which resolve live in `kody:@scope/…`
- * imports for every caller (decision record 0014). These helpers surface them
- * for discovery; hidden and private packages stay owner-only.
+ * (`users.account_type = 'platform'`). Ad hoc execute may resolve them live;
+ * saved person-account packages must fork (decision 0035). These helpers
+ * surface them for discovery; hidden and private packages stay owner-only.
  */
 async function listPlatformAccounts(
 	db: D1Database,

--- a/packages/worker/src/package-registry/scope-grants.ts
+++ b/packages/worker/src/package-registry/scope-grants.ts
@@ -5,7 +5,10 @@ function isUsersPlatformSchemaUnavailable(error: unknown) {
 	const message = getErrorMessage(error)
 	return (
 		message.includes('no such column: account_type') ||
-		message.includes('no such table: users')
+		message.includes('no such table: users') ||
+		// Node-unit D1 allowlist mocks reject unknown SQL instead of applying
+		// migrations. Same fail-closed outcome as an unmigrated `users` table.
+		message.includes('Unsupported first query')
 	)
 }
 

--- a/packages/worker/src/package-registry/scope-grants.ts
+++ b/packages/worker/src/package-registry/scope-grants.ts
@@ -32,9 +32,8 @@ export type PlatformAccountRow = {
 }
 
 /**
- * Usernames of every platform account. Platform scopes resolve live in
- * `kody:@scope/...` imports for all callers, so cross-scope policy checks
- * treat them as always-valid references.
+ * Usernames of every platform account. Ad hoc execute may resolve those
+ * scopes live; saved person-account packages must not (decision 0035).
  */
 export async function listPlatformAccountUsernames(
 	db: D1Database,

--- a/packages/worker/src/package-registry/scope-grants.ts
+++ b/packages/worker/src/package-registry/scope-grants.ts
@@ -1,4 +1,13 @@
+import { getErrorMessage } from '@kody-internal/shared/error-message.ts'
 import { normalizeStableUserId, resolveUserStableId } from '#worker/user-id.ts'
+
+function isUsersPlatformSchemaUnavailable(error: unknown) {
+	const message = getErrorMessage(error)
+	return (
+		message.includes('no such column: account_type') ||
+		message.includes('no such table: users')
+	)
+}
 
 /**
  * Package scope grants: explicit rows that let a person account act inside a
@@ -38,39 +47,51 @@ export type PlatformAccountRow = {
 export async function listPlatformAccountUsernames(
 	db: D1Database,
 ): Promise<Array<string>> {
-	const result = await db
-		.prepare(
-			`SELECT username FROM users WHERE account_type = 'platform' ORDER BY username ASC`,
-		)
-		.all<{ username: string }>()
-	return (result.results ?? []).map((row) => row.username)
+	try {
+		const result = await db
+			.prepare(
+				`SELECT username FROM users WHERE account_type = 'platform' ORDER BY username ASC`,
+			)
+			.all<{ username: string }>()
+		return (result.results ?? []).map((row) => row.username)
+	} catch (error) {
+		// Workers-unit suites often share a `users` table provisioned before
+		// migration 0072. Treat that as "no platform accounts".
+		if (isUsersPlatformSchemaUnavailable(error)) return []
+		throw error
+	}
 }
 
 export async function getPlatformAccountByUsername(
 	db: D1Database,
 	username: string,
 ): Promise<PlatformAccountRow | null> {
-	const row = await db
-		.prepare(
-			`SELECT id, username, email, account_type, stable_user_id
+	try {
+		const row = await db
+			.prepare(
+				`SELECT id, username, email, account_type, stable_user_id
 			FROM users
 			WHERE username = ?
 			LIMIT 1`,
-		)
-		.bind(username)
-		.first<{
-			id: number
-			username: string
-			email: string
-			account_type: string
-			stable_user_id: string
-		}>()
-	if (!row || row.account_type !== 'platform') return null
-	return {
-		id: row.id,
-		username: row.username,
-		email: row.email,
-		stableUserId: resolveUserStableId(row),
+			)
+			.bind(username)
+			.first<{
+				id: number
+				username: string
+				email: string
+				account_type: string
+				stable_user_id: string
+			}>()
+		if (!row || row.account_type !== 'platform') return null
+		return {
+			id: row.id,
+			username: row.username,
+			email: row.email,
+			stableUserId: resolveUserStableId(row),
+		}
+	} catch (error) {
+		if (isUsersPlatformSchemaUnavailable(error)) return null
+		throw error
 	}
 }
 
@@ -80,11 +101,16 @@ export async function isPlatformAccountStableUserId(
 ) {
 	const trimmed = normalizeStableUserId(stableUserId)
 	if (!trimmed) return false
-	const row = await db
-		.prepare(`SELECT account_type FROM users WHERE stable_user_id = ?`)
-		.bind(trimmed)
-		.first<{ account_type: string }>()
-	return row?.account_type === 'platform'
+	try {
+		const row = await db
+			.prepare(`SELECT account_type FROM users WHERE stable_user_id = ?`)
+			.bind(trimmed)
+			.first<{ account_type: string }>()
+		return row?.account_type === 'platform'
+	} catch (error) {
+		if (isUsersPlatformSchemaUnavailable(error)) return false
+		throw error
+	}
 }
 
 export async function hasPackageScopeGrant(

--- a/packages/worker/src/package-runtime/module-graph-bundle-builders.ts
+++ b/packages/worker/src/package-runtime/module-graph-bundle-builders.ts
@@ -1,5 +1,6 @@
 import { sha256Base64Url } from '@kody-internal/shared/sha256.ts'
 import { normalizePackageWorkspacePath } from '#worker/package-registry/manifest.ts'
+import { isPlatformAccountStableUserId } from '#worker/package-registry/scope-grants.ts'
 import {
 	createPublishedPackageCacheKey,
 	createPublishedPackagePromiseCache,
@@ -71,6 +72,15 @@ async function createModuleBundleCacheKey(input: {
 	])
 }
 
+async function resolveAllowPlatformScopes(input: {
+	env: Env
+	userId: string
+	bundleContext?: 'ad-hoc-execute' | 'saved-package-module'
+}) {
+	if (input.bundleContext === 'ad-hoc-execute') return true
+	return await isPlatformAccountStableUserId(input.env.APP_DB, input.userId)
+}
+
 function cloneRuntimeBundle(bundle: RuntimeBundle): RuntimeBundle {
 	return {
 		mainModule: bundle.mainModule,
@@ -95,6 +105,7 @@ export async function buildKodyModuleBundle(input: {
 	reuseCachedBundle?: boolean
 	bundleContext?: 'ad-hoc-execute' | 'saved-package-module'
 }) {
+	const allowPlatformScopes = await resolveAllowPlatformScopes(input)
 	const { files, packages } = await prepareKodyGraphFiles({
 		env: input.env,
 		baseUrl: input.baseUrl,
@@ -102,6 +113,7 @@ export async function buildKodyModuleBundle(input: {
 		sourceFiles: input.sourceFiles,
 		entryPoint: input.entryPoint,
 		rootPackageId: input.rootPackageId,
+		allowPlatformScopes,
 	})
 	const entryPoint =
 		resolveWorkspaceSourceFilePath({
@@ -147,6 +159,7 @@ export async function buildKodyModuleBundle(input: {
 			dependencies: await resolveDirectKodyDependenciesForEntryPoint({
 				...input,
 				loadedPackages: packages,
+				allowPlatformScopes,
 			}),
 			...includeDynamicDependenciesWhenPresent(modules),
 		}
@@ -178,6 +191,7 @@ export async function buildKodyImportableModuleBundle(input: {
 	// stamps root modules with package provenance (see RewriteState).
 	rootPackageId?: string | null
 }) {
+	const allowPlatformScopes = await resolveAllowPlatformScopes(input)
 	const { files, packages } = await prepareKodyGraphFiles({
 		env: input.env,
 		baseUrl: input.baseUrl,
@@ -185,6 +199,7 @@ export async function buildKodyImportableModuleBundle(input: {
 		sourceFiles: input.sourceFiles,
 		entryPoint: input.entryPoint,
 		rootPackageId: input.rootPackageId,
+		allowPlatformScopes,
 	})
 	const entryPoint =
 		resolveWorkspaceSourceFilePath({
@@ -220,6 +235,7 @@ export async function buildKodyImportableModuleBundle(input: {
 		dependencies: await resolveDirectKodyDependenciesForEntryPoint({
 			...input,
 			loadedPackages: packages,
+			allowPlatformScopes,
 		}),
 		...includeDynamicDependenciesWhenPresent(modules),
 	}
@@ -237,6 +253,7 @@ export async function buildKodyAppBundle(input: {
 	cacheKey?: string | null
 }) {
 	const buildBundle = async () => {
+		const allowPlatformScopes = await resolveAllowPlatformScopes(input)
 		const { files, packages } = await prepareKodyGraphFiles({
 			env: input.env,
 			baseUrl: input.baseUrl,
@@ -244,6 +261,7 @@ export async function buildKodyAppBundle(input: {
 			sourceFiles: input.sourceFiles,
 			entryPoint: input.entryPoint,
 			rootPackageId: input.rootPackageId,
+			allowPlatformScopes,
 		})
 		const entryPoint =
 			resolveWorkspaceSourceFilePath({
@@ -279,6 +297,7 @@ export async function buildKodyAppBundle(input: {
 			dependencies: await resolveDirectKodyDependenciesForEntryPoint({
 				...input,
 				loadedPackages: packages,
+				allowPlatformScopes,
 			}),
 			...includeDynamicDependenciesWhenPresent(modules),
 		}

--- a/packages/worker/src/package-runtime/module-graph-hydration.ts
+++ b/packages/worker/src/package-runtime/module-graph-hydration.ts
@@ -56,7 +56,7 @@ async function resolveCurrentDynamicPackageArtifact(input: {
 		})
 		throw new Error(
 			platformResolution?.platformScope
-				? `Dynamic import of platform package "${parsed.packageName}" is unsupported. Use a static import (import x from "${input.specifier}") — it resolves live from the platform scope.`
+				? `Dynamic import of platform package "${parsed.packageName}" is unsupported. From ad hoc execute, use a static import (import x from "${input.specifier}"). Saved packages must community_fork the official package into your scope.`
 				: `Dynamic Kody package import "${input.specifier}" could not find saved package "${parsed.packageName}" for this user.`,
 		)
 	}

--- a/packages/worker/src/package-runtime/module-graph-hydration.ts
+++ b/packages/worker/src/package-runtime/module-graph-hydration.ts
@@ -56,7 +56,7 @@ async function resolveCurrentDynamicPackageArtifact(input: {
 		})
 		throw new Error(
 			platformResolution?.platformScope
-				? `Dynamic import of platform package "${parsed.packageName}" is unsupported. From ad hoc execute, use a static import (import x from "${input.specifier}"). Saved packages must community_fork the official package into your scope.`
+				? `Dynamic import of platform package "${parsed.packageName}" is unsupported. From ad hoc execute, use a static import (import x from "${input.specifier}"). Saved person-account packages must community_fork the official package into your scope.`
 				: `Dynamic Kody package import "${input.specifier}" could not find saved package "${parsed.packageName}" for this user.`,
 		)
 	}

--- a/packages/worker/src/package-runtime/module-graph-import-rewriting.ts
+++ b/packages/worker/src/package-runtime/module-graph-import-rewriting.ts
@@ -7,6 +7,7 @@ import {
 	normalizePackageWorkspacePath,
 	resolvePackageExportPath,
 } from '#worker/package-registry/manifest.ts'
+import { formatPersonPackagePlatformDependencyMessage } from '#worker/package-registry/platform-package-policy.ts'
 import {
 	type AuthoredPackageJson,
 	type SavedPackageRecord,
@@ -97,6 +98,11 @@ type RewriteState = {
 	 * artifacts that later get composed into foreign bundles.
 	 */
 	rootPackageId: string | null
+	/**
+	 * Ad hoc execute and platform-owned package graphs may resolve live
+	 * `@kody/*` imports. Person-owned saved package graphs must not.
+	 */
+	allowPlatformScopes: boolean
 	proxies: Map<string, string>
 	dynamicPackageImports: Map<string, string>
 	packages: LoadedKodyGraphPackages
@@ -186,8 +192,14 @@ async function ensurePackageLoaded(
 		db: state.env.APP_DB,
 		userId: state.userId,
 		specifier: parsed,
+		allowPlatformScopes: state.allowPlatformScopes,
 	})
 	if (!resolution) {
+		if (!state.allowPlatformScopes) {
+			throw new Error(
+				formatPersonPackagePlatformDependencyMessage(parsed.packageName),
+			)
+		}
 		throw new Error(
 			`Saved package "${parsed.packageName}" was not found for this user.`,
 		)
@@ -470,6 +482,7 @@ export async function prepareKodyGraphFiles(input: {
 	sourceFiles: Record<string, string>
 	entryPoint: string
 	rootPackageId?: string | null
+	allowPlatformScopes?: boolean
 }) {
 	const files: Record<string, string> = {
 		[runtimeModulePath]: createRuntimeModuleSource(),
@@ -493,6 +506,7 @@ export async function prepareKodyGraphFiles(input: {
 		sourceFiles: input.sourceFiles,
 		rootPackage,
 		rootPackageId: input.rootPackageId?.trim() || null,
+		allowPlatformScopes: input.allowPlatformScopes !== false,
 		proxies: new Map(),
 		dynamicPackageImports: new Map(),
 		packages: new Map(),

--- a/packages/worker/src/package-runtime/module-graph-import-rewriting.ts
+++ b/packages/worker/src/package-runtime/module-graph-import-rewriting.ts
@@ -7,7 +7,7 @@ import {
 	normalizePackageWorkspacePath,
 	resolvePackageExportPath,
 } from '#worker/package-registry/manifest.ts'
-import { formatPersonPackagePlatformDependencyMessage } from '#worker/package-registry/platform-package-policy.ts'
+import { throwIfPersonPackagePlatformReference } from '#worker/package-registry/platform-package-policy.ts'
 import {
 	type AuthoredPackageJson,
 	type SavedPackageRecord,
@@ -196,9 +196,10 @@ async function ensurePackageLoaded(
 	})
 	if (!resolution) {
 		if (!state.allowPlatformScopes) {
-			throw new Error(
-				formatPersonPackagePlatformDependencyMessage(parsed.packageName),
-			)
+			await throwIfPersonPackagePlatformReference({
+				db: state.env.APP_DB,
+				packageName: parsed.packageName,
+			})
 		}
 		throw new Error(
 			`Saved package "${parsed.packageName}" was not found for this user.`,

--- a/packages/worker/src/package-runtime/module-graph-workspace.ts
+++ b/packages/worker/src/package-runtime/module-graph-workspace.ts
@@ -7,6 +7,7 @@ import {
 	parseAuthoredPackageJson,
 	resolvePackageExportPath,
 } from '#worker/package-registry/manifest.ts'
+import { formatPersonPackagePlatformDependencyMessage } from '#worker/package-registry/platform-package-policy.ts'
 import {
 	type AuthoredPackageJson,
 	type SavedPackageRecord,
@@ -161,6 +162,7 @@ export async function resolveDirectKodyDependenciesForEntryPoint(input: {
 			platformScope: string | null
 		}
 	>
+	allowPlatformScopes?: boolean
 }) {
 	const rootPackage = readRootPackage(input.sourceFiles)
 	const entryPoint =
@@ -202,8 +204,14 @@ export async function resolveDirectKodyDependenciesForEntryPoint(input: {
 						db: input.env.APP_DB,
 						userId: input.userId,
 						specifier: parsed,
+						allowPlatformScopes: input.allowPlatformScopes,
 					})
 			if (!resolution) {
+				if (input.allowPlatformScopes === false) {
+					throw new Error(
+						formatPersonPackagePlatformDependencyMessage(parsed.packageName),
+					)
+				}
 				const plainRepo = await findPlainRepoPromotionHint(input.env.APP_DB, {
 					userId: input.userId,
 					packageIdOrKodyId: parsed.packageName,

--- a/packages/worker/src/package-runtime/module-graph-workspace.ts
+++ b/packages/worker/src/package-runtime/module-graph-workspace.ts
@@ -7,7 +7,7 @@ import {
 	parseAuthoredPackageJson,
 	resolvePackageExportPath,
 } from '#worker/package-registry/manifest.ts'
-import { formatPersonPackagePlatformDependencyMessage } from '#worker/package-registry/platform-package-policy.ts'
+import { throwIfPersonPackagePlatformReference } from '#worker/package-registry/platform-package-policy.ts'
 import {
 	type AuthoredPackageJson,
 	type SavedPackageRecord,
@@ -208,9 +208,10 @@ export async function resolveDirectKodyDependenciesForEntryPoint(input: {
 					})
 			if (!resolution) {
 				if (input.allowPlatformScopes === false) {
-					throw new Error(
-						formatPersonPackagePlatformDependencyMessage(parsed.packageName),
-					)
+					await throwIfPersonPackagePlatformReference({
+						db: input.env.APP_DB,
+						packageName: parsed.packageName,
+					})
 				}
 				const plainRepo = await findPlainRepoPromotionHint(input.env.APP_DB, {
 					userId: input.userId,

--- a/packages/worker/src/package-runtime/module-graph.node.test.ts
+++ b/packages/worker/src/package-runtime/module-graph.node.test.ts
@@ -2672,9 +2672,8 @@ test('buildKodyModuleBundle rejects person-package imports of platform scopes', 
 
 	try {
 		const { buildKodyModuleBundle } = await import('./module-graph.ts')
-		const { personPackagePlatformDependencyMessage } = await import(
-			'#worker/package-registry/platform-package-policy.ts'
-		)
+		const { personPackagePlatformDependencyMessage } =
+			await import('#worker/package-registry/platform-package-policy.ts')
 
 		await expect(
 			buildKodyModuleBundle({

--- a/packages/worker/src/package-runtime/module-graph.node.test.ts
+++ b/packages/worker/src/package-runtime/module-graph.node.test.ts
@@ -10,6 +10,7 @@ const mockModule = vi.hoisted(() => ({
 	createWorker: vi.fn(),
 	getSavedPackageByKodyId: vi.fn(),
 	getSavedPackageByName: vi.fn(),
+	getPlatformAccountByUsername: vi.fn(async () => null),
 	loadPackageSourceBySourceId: vi.fn(),
 	loadPublishedBundleArtifactByIdentity: vi.fn(),
 }))
@@ -21,7 +22,8 @@ vi.mock('#worker/worker-bundler-modules.ts', () => ({
 }))
 
 vi.mock('#worker/package-registry/scope-grants.ts', () => ({
-	getPlatformAccountByUsername: async () => null,
+	getPlatformAccountByUsername: (...args: Array<unknown>) =>
+		mockModule.getPlatformAccountByUsername(...args),
 	isPlatformAccountStableUserId: async () => false,
 	listPlatformAccountUsernames: async () => [],
 }))
@@ -2652,6 +2654,56 @@ test('buildKodyModuleBundle rejects kody id shorthand imports', async () => {
 		},
 	)
 	expect(mockModule.getSavedPackageByKodyId).not.toHaveBeenCalled()
+})
+
+test('buildKodyModuleBundle rejects person-package imports of platform scopes', async () => {
+	mockModule.getPlatformAccountByUsername.mockImplementation(
+		async (_db: unknown, username: unknown) =>
+			username === 'kody'
+				? {
+						id: 1,
+						username: 'kody',
+						email: 'kody@example.com',
+						stableUserId: 'platform-kody',
+					}
+				: null,
+	)
+	mockModule.getSavedPackageByName.mockResolvedValue(null)
+
+	try {
+		const { buildKodyModuleBundle } = await import('./module-graph.ts')
+		const { personPackagePlatformDependencyMessage } = await import(
+			'#worker/package-registry/platform-package-policy.ts'
+		)
+
+		await expect(
+			buildKodyModuleBundle({
+				env: {
+					APP_DB: {},
+					REPO_SESSION: {},
+				} as Env,
+				baseUrl: 'https://heykody.dev',
+				userId: 'user-1',
+				sourceFiles: {
+					'package.json': JSON.stringify({
+						name: '@alice/local-package',
+						exports: {
+							'.': './index.js',
+						},
+						kody: {
+							id: 'local-package',
+							description: 'Local package',
+						},
+					}),
+					'index.js':
+						'import github from "kody:@kody/github"\nexport default github\n',
+				},
+				entryPoint: 'index.js',
+			}),
+		).rejects.toThrow(personPackagePlatformDependencyMessage)
+	} finally {
+		mockModule.getPlatformAccountByUsername.mockResolvedValue(null)
+	}
 })
 
 test('buildKodyAppBundle rewrites static and dynamic kody runtime imports inside TypeScript package apps', async () => {

--- a/packages/worker/src/package-runtime/module-graph.node.test.ts
+++ b/packages/worker/src/package-runtime/module-graph.node.test.ts
@@ -22,6 +22,7 @@ vi.mock('#worker/worker-bundler-modules.ts', () => ({
 
 vi.mock('#worker/package-registry/scope-grants.ts', () => ({
 	getPlatformAccountByUsername: async () => null,
+	isPlatformAccountStableUserId: async () => false,
 	listPlatformAccountUsernames: async () => [],
 }))
 

--- a/packages/worker/src/package-runtime/module-graph.workers.test.ts
+++ b/packages/worker/src/package-runtime/module-graph.workers.test.ts
@@ -255,6 +255,7 @@ test('ad hoc execute runtime exposes only packages.invoke', async () => {
 		env,
 		baseUrl: 'https://kody.dev',
 		userId: 'user-workers-test',
+		bundleContext: 'ad-hoc-execute',
 		sourceFiles: {
 			'entry.ts': [
 				"import { kody, packageContext, packages } from 'kody:runtime'",
@@ -439,6 +440,7 @@ test(
 			env,
 			baseUrl: 'https://kody.dev',
 			userId,
+			bundleContext: 'ad-hoc-execute',
 			sourceFiles: {
 				'entry.ts': [
 					"import { packages } from 'kody:runtime'",

--- a/packages/worker/src/package-runtime/package-app.ts
+++ b/packages/worker/src/package-runtime/package-app.ts
@@ -4,6 +4,7 @@ import {
 	getPackageAppEntryPath,
 	parseAuthoredPackageJson,
 } from '#worker/package-registry/manifest.ts'
+import { assertPersonOwnedPackageMayNotRunPlatformDependencies } from '#worker/package-registry/platform-package-policy.ts'
 import { type AuthoredPackageJson } from '#worker/package-registry/types.ts'
 import { type EntitySourceRow } from '#worker/repo/types.ts'
 import {
@@ -1769,6 +1770,12 @@ async function buildPackageAppWorkerOptionsUncached(input: {
 		savedPackage: input.savedPackage,
 		loadSourceFiles: input.loadSourceFiles,
 		sourceFiles: input.sourceFiles,
+	})
+	await assertPersonOwnedPackageMayNotRunPlatformDependencies({
+		db: input.env.APP_DB,
+		userId: input.userId,
+		packageId: input.savedPackage.id,
+		dependencies: bundled.dependencies ?? [],
 	})
 	const mainModule = 'package-app-entry.js'
 	const { modules: hydratedModules, dynamicDependencyPackageIds } =

--- a/packages/worker/src/package-runtime/package-import-resolution.ts
+++ b/packages/worker/src/package-runtime/package-import-resolution.ts
@@ -21,10 +21,10 @@ export type KodyPackageSpecifier = {
  * `platformScope` carries the scope username.
  *
  * Isolation invariant: platform resolution only widens *which published
- * source the bundler may read*. The resolved modules always execute in the
- * calling user's runtime against the caller's secrets, storage, and
- * entitlements — exactly like a fork would — and the caller's own copy
- * always wins, so forking a platform package to customize it keeps working.
+ * source the bundler may read*, and only for ad hoc execute (decision 0035).
+ * Saved person-account packages must not resolve platform scopes; they fork
+ * into the caller's scope instead. Platform-account packages may still
+ * compose with each other. The caller's own copy always wins.
  */
 export type ResolvedPackageImport = {
 	row: SavedPackageRecord

--- a/packages/worker/src/repo/checks.ts
+++ b/packages/worker/src/repo/checks.ts
@@ -12,6 +12,11 @@ import {
 	loadReachableStaticKodyDependencyEdges,
 } from '#worker/package-registry/static-dependency-cycles.ts'
 import {
+	findPersonPackagePlatformReference,
+	formatPersonPackagePlatformDependencyMessage,
+} from '#worker/package-registry/platform-package-policy.ts'
+import { isPlatformAccountStableUserId } from '#worker/package-registry/scope-grants.ts'
+import {
 	assertKodyDescriptionLength,
 	listKodyPackageDependencyNames,
 	type AuthoredPackageJson,
@@ -1258,6 +1263,32 @@ export async function runRepoChecks(input: {
 
 	const packageJson = snapshot.read('package.json')
 	const declaredNpmDependencies = parseDeclaredNpmDependencies(packageJson)
+	if (input.env?.APP_DB && input.userId) {
+		const publisherIsPlatform = await isPlatformAccountStableUserId(
+			input.env.APP_DB,
+			input.userId,
+		)
+		if (!publisherIsPlatform) {
+			const platformReference = await findPersonPackagePlatformReference({
+				db: input.env.APP_DB,
+				manifestDependencies: manifest.kody.dependencies,
+				sourceFiles,
+			})
+			if (platformReference) {
+				results.push({
+					kind: 'dependencies',
+					ok: false,
+					message:
+						formatPersonPackagePlatformDependencyMessage(platformReference),
+				})
+				return toRepoCheckRunResult({
+					results,
+					manifest,
+					sourceFiles,
+				})
+			}
+		}
+	}
 	const staticKodyDependencyCheck =
 		validateStaticKodyPackageDependencyDeclarations({
 			manifest,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop saved person-owned packages from depending on official `@kody/*` (and any other platform-account) packages, so official exports are not a public API we have to keep stable. Ad hoc execute can still import and invoke them live.

## Why

Decision 0014 let every caller resolve platform packages live, including durable packages and jobs. There is no semver and `packages.invoke` of a platform target is live on every run. That is the wrong contract for a product we intend to reshape. Execute is ephemeral; agents rewrite. Packages are products.

Decision [0035](https://github.com/kentcdodds/kody/blob/cursor/platform-packages-execute-only-b479/docs/contributing/decisions/0035-platform-packages-execute-only.md) supersedes the saved-package half of 0014. Hard cut, no compatibility lane.

## Summary

- Person-owned package publish checks reject `kody:@kody/…` static imports, `kody.dependencies` entries, and `packages.invoke('kody:@kody/…')`.
- Person package / job / **app** runtimes cannot run artifacts that recorded `platformOwned` dependencies. Execute still can. Official platform packages may still compose with each other.
- Community forks rewrite same-package `@kody/name` self-imports onto the new owner (including template-literal references); remaining `@kody/other` references stay foreign and must be forked too.
- Search and provider guides say execute-only; person-account packages fork before using official helpers.
- Rebased onto `main` after #1691 landed. Provider guides keep live-execute verify (`kody:@kody/…`) and say saved person-account packages must fork.
- Node-unit D1 allowlist mocks that reject the `account_type` lookup fail closed as person accounts (same as an unmigrated `users` table).

Related: secret-access for execute → invoke `@kody/…` shipped in #1691.

## Testing

- Node-unit: policy, jobs/service, invoke-contract-cache, package-app, run-kody-registry, package-registry/service **passed**.
- CI: 🧪 Node, 🎭 E2E, 🔌 MCP passed on `295aefe2`; 🧹 Static failed oxfmt (fixed in `79cad563`).
- Review: addressed valid Bugbot findings (apps skipped the fail-closed gate; platform composers were blocked at runtime). Stale comments on missing-import teaching and mock stubs are already fixed on this branch. Ignored 0014-fork-supersede (0035 restores fork) and `packages . invoke` whitespace member access.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `0130885a` · **Head:** `79cad563`

**Classification:** extends — person-owned package graphs and invoke may no longer resolve platform scopes; execute-live resolution stays.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `saved-packages` | assistant | extends — person packages cannot depend on platform scopes |
| `package-runtime` | runtime | extends — bundler `allowPlatformScopes` is execute/platform-owner only; person apps fail closed on `platformOwned` deps |
| `package-apps` | assistant | extends — person apps fail closed on `platformOwned` deps |
| `capabilities-execute` | runtime | extends — person-package artifacts with `platformOwned` deps fail closed; platform composers exempt |
| `community-listings` | assistant | extends — fork rewrite of same-package self-refs; no `@kody` allowlist |
| `mcp-server` | surfaces | extends — search copy says execute-only, fork for person-account packages |
| `repo-sessions` | runtime | extends — publish checks reject platform references in person packages |

### Change flow

Person-owned package publish, invoke, jobs, and apps fail closed on platform scopes; ad hoc execute and official packages still resolve them live.

```mermaid
sequenceDiagram
	actor User
	participant mcpServer as mcp-server
	participant packageRuntime as package-runtime
	participant savedPackages as saved-packages
	participant communityListings as community-listings
	User->>mcpServer: execute import kody:@kody/github
	mcpServer->>packageRuntime: bundleContext ad-hoc-execute
	packageRuntime->>savedPackages: resolvePlatformScopedPackageImport
	savedPackages-->>packageRuntime: live official package
	User->>mcpServer: publish or run person package/app with platformOwned deps
	mcpServer->>savedPackages: assertPersonOwnedPackageMayNotRunPlatformDependencies
	savedPackages-->>mcpServer: reject execute-only teaching error
	User->>communityListings: community_fork @kody/github
	communityListings->>communityListings: rewrite @kody/github self-refs to @user/github
```

### Before / after

| Caller | Before | After |
| --- | --- | --- |
| Ad hoc execute import/invoke `@kody/*` | live | unchanged |
| Person package static import / invoke | snapshotted live resolve | publish + runtime fail |
| Person package **app** with `platformOwned` deps | served | fail closed at serve |
| Official package composing with `@kody/*` | live | unchanged |

### Invariants

Per-user isolation is unchanged. Platform resolution still only widens which published source execute may read. Person-to-person imports stay unrepresentable. Official packages remain caller-secrets when execute uses them.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-404ba68c-58e1-4054-9579-96b85026b479?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-404ba68c-58e1-4054-9579-96b85026b479&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Official platform packages are now execute-only for saved person-owned packages.
  - Ad hoc executions can continue using live platform packages.
  - Saved packages must fork official packages before importing or invoking them.
  - Package publication, dependency checks, and runtime execution now enforce these rules.

- **Documentation**
  - Updated package, provider, architecture, and decision guidance to explain platform-package access, forking, and scope isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->