### PR TITLE
Restore official-package fork guides after #1691

### DIFF
--- a/docs/guides/providers/github.md
+++ b/docs/guides/providers/github.md
@@ -75,8 +75,8 @@ https://kody.codes/account/secrets/new?name=githubAccessToken&description=GitHub
 ```
 
 Approve the `api.github.com` host on the same page after saving. The name
-`githubAccessToken` is exactly what live `kody:@kody/github` reads by default,
-so no rename is needed.
+`githubAccessToken` is exactly what the official `@kody/github` community
+package reads by default, so a fork of it works without renaming anything.
 
 ## Lane C: bring-your-own OAuth App
 
@@ -185,24 +185,27 @@ per-capability.
 - Token exchange fails in Lane C: the client secret is required even with PKCE.
   Regenerate the secret and reconnect.
 
-## Use the official package and verify
+## Fork the official package and verify
 
-A saved token or integration is credentials only. Finish by calling the live
-official helpers so day-to-day work goes through maintained code instead of
-hand-rolled API calls. Official `@kody/*` packages resolve in the caller runtime
-against the caller's secrets — do **not** fork them just to use them. Fork only
-when you need to customize the source.
+A saved token or integration is credentials only. Finish by forking the trusted
+official package so day-to-day work goes through maintained helpers instead of
+hand-rolled API calls:
 
-1. Search for `@kody/github` (or import `kody:@kody/github` directly). It wraps
-   REST, GraphQL, pagination, and PR helpers.
-2. Check its README **Required setup**: the default `bot` account reads the
-   `githubAccessToken` secret — the exact name Lane B saved, so no adaptation is
-   needed for the PAT lane. For OAuth (Lane A/C), remap the account to the
-   `github` integration name when the package supports that.
-3. Verify the live package against your credentials from `execute`:
+1. Find the listing with `community_search({ query: 'github' })` — the trusted
+   `@kody/github` listing wraps REST, GraphQL, pagination, and PR helpers.
+2. Fork it with `community_fork` (or click **Install** on the listing page). The
+   fork lands in your account under your own scope.
+3. Check the fork's README **Required setup**: its default `bot` account reads
+   the `githubAccessToken` secret — the exact name Lane B saved, so no
+   adaptation is needed for the PAT lane. For OAuth (Lane A/C), remap the
+   account to the `github` integration name when the package supports that.
+   Remove or remap the extra `kent`/`explicit-only` account aliases if you do
+   not want them.
+4. Verify the package against your credentials by running its identity smoke
+   test from `execute`:
 
 ```ts
-import getViewer from 'kody:@kody/github/get-viewer'
+import getViewer from 'kody:@<your-username>/github/get-viewer'
 
 export default async function main() {
 	return getViewer({ account: 'bot' })
@@ -210,4 +213,4 @@ export default async function main() {
 ```
 
 A successful response returns the GitHub login your token resolves to — proving
-the live package, the secret, and the host approval all line up.
+the fork, the secret, and the host approval all line up.

--- a/docs/guides/providers/google.md
+++ b/docs/guides/providers/google.md
@@ -193,24 +193,24 @@ reconnects use `/connect/oauth?provider=google` and the connect UI scope menu.
 - `403` from Gmail with a Calendar-only token: scopes are per-connection.
   Reconnect with the needed Gmail scope (BYO for inbox read).
 
-## Use the official package and verify
+## Fork the official package and verify
 
-A saved integration is auth credentials only. Finish by calling the live
-official helpers so day-to-day work goes through maintained Gmail, Calendar, and
-Drive helpers instead of raw `createAuthenticatedFetch` calls. Official
-`@kody/*` packages resolve in the caller runtime against the caller's secrets —
-do **not** fork them just to use them. Fork only when you need to customize the
-source.
+A saved integration is auth credentials only. Finish by forking the trusted
+official package so day-to-day work goes through maintained Gmail, Calendar, and
+Drive helpers instead of raw `createAuthenticatedFetch` calls:
 
-1. Search for `@kody/google` (or import `kody:@kody/google` directly). It covers
-   Gmail, Calendar, Drive, People, and YouTube.
-2. Check its README **Required setup**: the `personal` account alias maps to an
-   integration named `google` — the default name this guide's connect link uses,
-   so the primary lane needs no adaptation.
-3. Verify the live package against your integration from `execute`:
+1. Find the listing with `community_search({ query: 'google' })` — the trusted
+   `@kody/google` listing covers Gmail, Calendar, Drive, People, and YouTube.
+2. Fork it with `community_fork` (or click **Install** on the listing page).
+3. Check the fork's README **Required setup**: the `personal` account alias maps
+   to an integration named `google` — the default name this guide's connect link
+   uses, so the primary lane needs no adaptation. Trim the other account aliases
+   (`business`, `youtube-*`) unless you connect those too.
+4. Verify the package against your integration with its built-in smoke test from
+   `execute`:
 
 ```ts
-import { smokeTest } from 'kody:@kody/google'
+import { smokeTest } from 'kody:@<your-username>/google'
 
 export default async function main() {
 	return smokeTest({ account: 'personal' })
@@ -218,4 +218,4 @@ export default async function main() {
 ```
 
 A successful response returns the Google profile your integration resolves to —
-proving the live package, the OAuth tokens, and the host approvals all line up.
+proving the fork, the OAuth tokens, and the host approvals all line up.

--- a/docs/guides/providers/notion.md
+++ b/docs/guides/providers/notion.md
@@ -158,23 +158,24 @@ internal connection, edit the page's **Connections** menu.
 - Installation scope wrong on a public connection: it cannot be edited after
   creation; create a new public connection instead.
 
-## Use the official package and verify (Lane B / OAuth)
+## Fork the official package and verify
 
-Lane A stays on the raw `notionToken` fetch above. The live official package is
-the Lane B finish: it uses the saved `notion` OAuth integration and does not
-read `notionToken`. Official `@kody/*` packages resolve in the caller runtime
-against the caller's secrets — do **not** fork them just to use them. Fork only
-when you need to customize the source.
+A saved integration is auth credentials only. Finish by forking the trusted
+official package so day-to-day work goes through maintained search, read, query,
+and confirmed-write helpers:
 
-1. Search for `@kody/notion` (or import `kody:@kody/notion` directly). It wraps
-   pages, databases, and a generic request escape hatch.
-2. Check its README **Required setup**: it expects an OAuth integration named
-   `notion` — the default name this guide's Lane B connect link uses, so no
+1. Find the listing with `community_search({ query: 'notion' })` — the trusted
+   `@kody/notion` listing wraps pages, databases, and a generic request escape
+   hatch.
+2. Fork it with `community_fork` (or click **Install** on the listing page).
+3. Check the fork's README **Required setup**: it expects an OAuth integration
+   named `notion` — the default name this guide's connect link uses, so no
    adaptation is needed.
-3. Verify the live package against the OAuth integration from `execute`:
+4. Verify the package against your integration with its built-in smoke test from
+   `execute`:
 
 ```ts
-import smokeTest from 'kody:@kody/notion/smoke-test'
+import smokeTest from 'kody:@<your-username>/notion/smoke-test'
 
 export default async function main() {
 	return smokeTest()
@@ -182,5 +183,5 @@ export default async function main() {
 ```
 
 A successful response confirms OAuth access without returning workspace PII —
-proving the live package, the tokens, and the page grants all line up. Remember
-the package only sees pages you shared on Notion's consent screen.
+proving the fork, the tokens, and the page grants all line up. Remember the
+package only sees pages you shared on Notion's consent screen.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Keep #1691 scoped to secret access for ad hoc execute → invoke live `@kody/*`. Stop those merged provider-guide rewrites from telling agents official helpers need no fork in a saved package.

## Why

Decision [0035](https://github.com/kentcdodds/kody/blob/cursor/platform-packages-execute-only-b479/docs/contributing/decisions/0035-platform-packages-execute-only.md) / #1699 is the hard cut: person-owned saved packages cannot import, declare, or `packages.invoke` platform scopes. Ad hoc execute still can.

#1691 correctly fixed `Package was not found for secret access` for live official packages. A follow-up commit on that same PR also rewrote GitHub / Notion / Google guides toward “use live `kody:@kody/…`; do not fork just to use them.” That fights #1699 and left it `CONFLICTING` with `main`.

## Summary

- Restore `docs/guides/providers/{github,notion,google}.md` “Fork the official package and verify” sections to their pre-#1691 wording (`f5330831`).
- Leave #1691 secret-access code and secret-policy auto-grant docs alone.
- Leave `docs/guides/providers/spotify.md` alone (honest community-listing fork; not official `@kody/spotify`).
- Do not invent 0035 policy here. #1699 still owns the execute-only sentences (ad hoc execute may use live `@kody/*`; fork before putting helpers in a saved person-account package).

Related: #1691 (secret-access, merged), #1699 (execute-only policy).

## Testing

- `git diff f5330831 HEAD --` the three provider files is empty (exact restore).
- `git apply --check` of #1699’s hunks for those three files against this branch: **OK**.
- No runtime or secret-access change. Docs-only.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `3bd2133b` · **Head:** `fa076679`

**Classification:** composes — no primitives added or changed; this PR restores provider-guide wording only.

### Primitives touched

None. Classifier unmatched paths are usage guides:

| Path | Impact |
| --- | --- |
| `docs/guides/providers/github.md` | restore pre-#1691 fork section |
| `docs/guides/providers/notion.md` | restore pre-#1691 fork section |
| `docs/guides/providers/google.md` | restore pre-#1691 fork section |

### Change flow

#1691 secret-access stays; provider guides stop claiming saved packages can skip a fork.

```mermaid
flowchart LR
	execute["ad hoc execute"]:::untouched
	secrets["user secrets"]:::untouched
	official["live @kody/*"]:::untouched
	guides["provider guides"]:::touched
	saved["saved person package"]:::untouched
	execute -->|"#1691: secret access still works"| official
	official -->|"caller secrets"| secrets
	guides -->|"restore: fork official helpers"| saved
	execute -->|"#1699 later: live import/invoke OK"| official
	saved -->|"#1699 later: cannot import/invoke platform scopes"| official
	classDef touched fill:#1a7f37,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

| Surface | After #1691 on main | This PR |
| --- | --- | --- |
| Secret access for execute → invoke `@kody/*` | live official package can read/use caller secrets | unchanged |
| GitHub / Notion / Google guides | “use live `kody:@kody/…`; do not fork just to use them” | “Fork the official package and verify” (pre-#1691) |
| #1699 provider-guide hunks | conflicting | apply cleanly |

### Invariants

No runtime, secret, or isolation change. Saved-package live-use of platform scopes is still #1699 / 0035, not this PR.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7c4891fa-2555-4543-9f17-1bed0be01192?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7c4891fa-2555-4543-9f17-1bed0be01192&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated GitHub, Google, and Notion provider guides with revised community package setup and verification instructions.
  * Added guidance for finding and forking trusted packages before installation.
  * Clarified required account aliases, token configuration, setup requirements, and smoke-test verification steps.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->