### PR TITLE
Add onboarding Step 2 exits: custom MCP, BYOK, Just-try-Kody

### DIFF
--- a/docs/contributing/community-packages.md
+++ b/docs/contributing/community-packages.md
@@ -117,16 +117,16 @@ badge on the detail page, the admin-only toggle
 (`POST /community/:listingId/feature.json`, audited), the admin-only
 `community_set_featured` capability, and onboarding Steps 2–3: Step 2 offers
 official workspace MCP servers (Notion, Linear, Atlassian, Stripe, Sentry,
-Canva) plus the matching `@kody/*-mcp` helper (or skip) as the quicker
-first-value path. Official non-MCP API packages (`@kody/notion`, `@kody/linear`,
-`@kody/jira`, `@kody/stripe`, `@kody/sentry`, `@kody/canva`) stay the long-term
-preferred helpers — do not convert them to MCP-first. Step 3 leads with an ad
-hoc execute → persist prompt, then keeps built-in service connects, featured
-zero-auth examples, and non-example featured starters under Advanced (Install
-then Copy prompt, with Choose your own adventure). Signed-in onboarding,
-`/community` cards, and listing detail overlay a per-request `viewerInstall`
-when the viewer already has a matching `kody_id` saved package or a
-`community_forks` row for that listing, so those surfaces show Copy prompt
+Canva) plus the matching `@kody/*-mcp` helper, a custom MCP URL, Just-try-Kody
+zero-auth examples, or skip as the quicker first-value path. Official non-MCP
+API packages (`@kody/notion`, `@kody/linear`, `@kody/jira`, `@kody/stripe`,
+`@kody/sentry`, `@kody/canva`) stay the long-term preferred helpers — do not
+convert them to MCP-first. Step 3 leads with an ad hoc execute → persist prompt,
+then keeps built-in service connects and non-example featured starters under
+Advanced (Install then Copy prompt, with Choose your own adventure). Signed-in
+onboarding, `/community` cards, and listing detail overlay a per-request
+`viewerInstall` when the viewer already has a matching `kody_id` saved package
+or a `community_forks` row for that listing, so those surfaces show Copy prompt
 instead of Install. Listing cards and detail place Trusted / Installed / Forked
 badges on a row under the title so wrapping `@scope/name` stays aligned.
 `community_get` exposes the effective `featured` flag. Onboarding loads up to 12

--- a/docs/guides/first-win.md
+++ b/docs/guides/first-win.md
@@ -16,7 +16,8 @@ category: platform
 <!--
 Agent notes — for AI agents driving the optional email loop from this page:
 
-- Onboarding Step 2 connects an official workspace MCP server. Step 3
+- Onboarding Step 2 connects a workspace MCP server (featured or custom) or a
+  Just-try-Kody example. Step 3
   climax is /guides/quick-example (ad hoc execute → persist → own). Use this
   guide only when the person wants the email-and-memories loop.
 - You drive the whole loop. The person stays in this chat; they should not need

--- a/docs/guides/quick-example.md
+++ b/docs/guides/quick-example.md
@@ -15,8 +15,8 @@ category: platform
 Agent notes — for AI agents driving onboarding Step 3 from this page:
 
 - The person already connected a workspace MCP server on /onboarding Step 2
-  (Notion, Linear, Atlassian, Stripe, Sentry, or Canva), or skipped so they could
-  try an ad hoc request first.
+  (featured official remotes, or a custom MCP URL), installed a Just-try-Kody
+  zero-auth example, or skipped so they could try an ad hoc request first.
 - Your job is one useful execute call, a short result, then persist that
   working code as a package they own. That owned package is the point of Kody.
 - Keep messages short — under roughly 120 words.
@@ -48,9 +48,10 @@ their agent as soon as they reach that step.
 ## Before you start
 
 The account needs a verified email and an authorized MCP host. If they connected
-a workspace MCP server on `/onboarding` Step 2, confirm the server is ready with
-`mcp_server_list` before calling its tools. If they skipped, ask what they want
-to try and use whatever tools are already available.
+a workspace MCP server on `/onboarding` Step 2 (featured or custom), confirm the
+server is ready with `mcp_server_list` before calling its tools. If they
+installed a Just-try-Kody example, invoke that owned package. If they skipped,
+ask what they want to try and use whatever tools are already available.
 
 ## Step 1 — Confirm the connection
 

--- a/docs/use/community-packages.md
+++ b/docs/use/community-packages.md
@@ -157,19 +157,19 @@ is ahead.
 
 Each listing detail page has an **Install** button for signed-in users. On
 `/onboarding`, Step 2 offers official workspace MCP servers and the matching
-`@kody` package. Step 3 leads with an ad hoc → persist prompt so your agent can
-save a first package you own. Featured zero-auth examples and built-in service
-connects stay under Advanced; after those installs, **Copy prompt** gives your
-agent a short setup prompt. If you already have a saved package with the same
-`kody_id`, or a fork of that listing, onboarding, listing cards, and the detail
-page show **Copy prompt** / **Installed** (or **Forked**) instead of Install.
-Listing cards and the detail page place **Trusted** / **Installed** (or
-**Forked**) badges on their own row under the package name. A trailing **Choose
-your own adventure** card copies an open-ended setup prompt when you want to
-explore or build something custom instead. Install forks the listing into your
-account and, when the fork passes the same publish checks a repo session would
-run, publishes it immediately as a live saved package. **Publishing activates
-the package right away** — declared jobs are scheduled.
+`@kody` package, a custom MCP URL, or Just-try-Kody zero-auth examples. Step 3
+leads with an ad hoc → persist prompt so your agent can save a first package you
+own. Built-in service connects stay under Advanced; after those installs, **Copy
+prompt** gives your agent a short setup prompt. If you already have a saved
+package with the same `kody_id`, or a fork of that listing, onboarding, listing
+cards, and the detail page show **Copy prompt** / **Installed** (or **Forked**)
+instead of Install. Listing cards and the detail page place **Trusted** /
+**Installed** (or **Forked**) badges on their own row under the package name. A
+trailing **Choose your own adventure** card copies an open-ended setup prompt
+when you want to explore or build something custom instead. Install forks the
+listing into your account and, when the fork passes the same publish checks a
+repo session would run, publishes it immediately as a live saved package.
+**Publishing activates the package right away** — declared jobs are scheduled.
 
 - **Untrusted listings** show a warning first: no admin has reviewed the code,
   and installing runs it in your account. You must explicitly confirm. Direct

--- a/docs/use/connect-your-agent.md
+++ b/docs/use/connect-your-agent.md
@@ -111,9 +111,9 @@ code more easily.
 
 After the connection works, Get started Step 2 offers official remote MCP
 servers for Notion, Linear, Atlassian, Stripe, Sentry, and Canva, plus the
-matching `@kody/*-mcp` helper. Connect one and authorize it, install the
-package, or skip. MCP is the quicker first-value path. The official non-MCP
-packages (`@kody/notion`, `@kody/linear`, `@kody/jira`, `@kody/stripe`,
+matching `@kody/*-mcp` helper. You can also add a custom MCP URL, try a
+zero-auth example, or skip. MCP is the quicker first-value path. The official
+non-MCP packages (`@kody/notion`, `@kody/linear`, `@kody/jira`, `@kody/stripe`,
 `@kody/sentry`, `@kody/canva`) stay the long-term API helpers.
 
 Step 3 copies a prompt that asks your agent to run one ad hoc request, then

--- a/packages/worker/client/routes/onboarding-custom-mcp-card.tsx
+++ b/packages/worker/client/routes/onboarding-custom-mcp-card.tsx
@@ -1,0 +1,444 @@
+import { type Handle, css } from 'remix/ui'
+import { on } from '#client/event-mixin.ts'
+import { readJson } from '#client/routes/account-approval-shared.ts'
+import { routes } from '#universal/routes.ts'
+import { type OnboardingCustomMcpServer } from '#universal/onboarding-mcp-chooser.ts'
+import { colors, typography } from '#universal/styles/tokens.ts'
+import {
+	getAuthInputCss,
+	getGhostButtonCss,
+	getPillButtonCss,
+} from '#universal/styles/style-primitives.ts'
+
+type AccountMcpServersAddPayload = {
+	ok?: boolean
+	error?: string
+	selectedServerId?: string
+	servers?: Array<{
+		id: string
+		name: string
+		state: string
+		authUrl: string | null
+	}>
+}
+
+type OnboardingCustomMcpCardProps = {
+	servers: Array<OnboardingCustomMcpServer>
+	loggedIn: boolean
+	onChanged: () => void
+}
+
+/**
+ * Step 2 "Custom" exit: add any remote MCP server with the same add/reconnect
+ * API as `/account/mcp-servers/new`. Counts as a workspace connect.
+ */
+export function OnboardingCustomMcpCard(
+	handle: Handle<OnboardingCustomMcpCardProps>,
+) {
+	let name = ''
+	let url = ''
+	let bearerToken = ''
+	let showBearer = false
+	let actionState: 'idle' | 'busy' = 'idle'
+	let reconnectingId: string | null = null
+	let error: string | null = null
+
+	function requireLogin() {
+		window.location.assign(
+			`/login?redirectTo=${encodeURIComponent(`${routes.onboarding.href()}#connect-mcp`)}`,
+		)
+	}
+
+	function openAuthUrl(authUrl: string) {
+		window.open(authUrl, '_blank', 'noopener,noreferrer')
+	}
+
+	async function postMcpServerAction(body: Record<string, unknown>) {
+		const response = await fetch(routes.accountMcpServersApi.href(), {
+			method: 'POST',
+			headers: {
+				Accept: 'application/json',
+				'Content-Type': 'application/json',
+			},
+			credentials: 'include',
+			body: JSON.stringify(body),
+		})
+		if (response.status === 401) {
+			requireLogin()
+			return null
+		}
+		const payload = await readJson<AccountMcpServersAddPayload>(response)
+		if (!response.ok || !payload?.ok) {
+			throw new Error(payload?.error || 'Unable to connect MCP server.')
+		}
+		return payload
+	}
+
+	function authUrlFromPayload(
+		payload: AccountMcpServersAddPayload,
+		fallbackName: string,
+	) {
+		const selected = payload.selectedServerId
+			? payload.servers?.find(
+					(server) => server.id === payload.selectedServerId,
+				)
+			: payload.servers?.find((server) => server.name === fallbackName)
+		return selected?.authUrl ?? null
+	}
+
+	async function addServer() {
+		if (actionState !== 'idle') return
+		if (!handle.props.loggedIn) {
+			requireLogin()
+			return
+		}
+		const trimmedName = name.trim()
+		const trimmedUrl = url.trim()
+		if (!trimmedName || !trimmedUrl) {
+			error = 'Name and URL are required.'
+			handle.update()
+			return
+		}
+		actionState = 'busy'
+		error = null
+		handle.update()
+		try {
+			const token = bearerToken.trim()
+			const payload = await postMcpServerAction({
+				action: 'add',
+				name: trimmedName,
+				url: trimmedUrl,
+				...(token ? { bearerToken: token } : {}),
+			})
+			if (!payload) return
+			const authUrl = authUrlFromPayload(payload, trimmedName)
+			if (authUrl) openAuthUrl(authUrl)
+			name = ''
+			url = ''
+			bearerToken = ''
+			handle.props.onChanged()
+		} catch (caught) {
+			error =
+				caught instanceof Error
+					? caught.message
+					: 'Unable to connect MCP server.'
+		} finally {
+			actionState = 'idle'
+			handle.update()
+		}
+	}
+
+	async function reconnect(server: OnboardingCustomMcpServer) {
+		if (reconnectingId != null) return
+		if (!handle.props.loggedIn) {
+			requireLogin()
+			return
+		}
+		if (server.connected) return
+		if (server.authUrl) {
+			openAuthUrl(server.authUrl)
+			return
+		}
+		reconnectingId = server.id
+		error = null
+		handle.update()
+		try {
+			const payload = await postMcpServerAction({
+				action: 'reconnect',
+				id: server.id,
+			})
+			if (!payload) return
+			const authUrl = authUrlFromPayload(payload, server.name)
+			if (authUrl) openAuthUrl(authUrl)
+			handle.props.onChanged()
+		} catch (caught) {
+			error =
+				caught instanceof Error
+					? caught.message
+					: 'Unable to reconnect MCP server.'
+		} finally {
+			reconnectingId = null
+			handle.update()
+		}
+	}
+
+	return () => {
+		const busy = actionState === 'busy'
+		return (
+			<div mix={css(cardCss)} data-testid="onboarding-custom-mcp">
+				<em mix={css(eyebrowCss)}>Custom</em>
+				<strong mix={css(titleCss)}>Add any remote MCP server</strong>
+				<p mix={css(copyCss)}>
+					Same easy login path — name plus URL. If the server returns an
+					authorize link, we open it. Used as{' '}
+					<code mix={css(codeCss)}>kody.mcp[&quot;name&quot;]</code>.
+				</p>
+				{handle.props.servers.length > 0 ? (
+					<ul mix={css(serverListCss)}>
+						{handle.props.servers.map((server) => (
+							<li
+								key={server.id}
+								mix={css(serverRowCss)}
+								data-connected={server.connected ? 'true' : undefined}
+								data-testid={`onboarding-custom-mcp-${server.id}`}
+							>
+								<span mix={css(serverMetaCss)}>
+									<strong mix={css(serverNameCss)}>{server.name}</strong>
+									<span mix={css(serverUrlCss)}>{server.url}</span>
+								</span>
+								<button
+									type="button"
+									disabled={server.connected || reconnectingId === server.id}
+									mix={[
+										css(
+											server.connected
+												? connectedButtonCss
+												: reconnectButtonCss,
+										),
+										on('click', () => void reconnect(server)),
+									]}
+									data-testid={`onboarding-custom-mcp-${server.id}-connect`}
+								>
+									{server.connected
+										? 'Connected'
+										: reconnectingId === server.id
+											? 'Connecting…'
+											: server.authUrl
+												? 'Authorize'
+												: 'Reconnect'}
+								</button>
+								{server.error && !server.connected ? (
+									<p mix={css(errorCss)} role="alert">
+										{server.error}
+									</p>
+								) : null}
+							</li>
+						))}
+					</ul>
+				) : null}
+				<form
+					mix={[
+						css(formCss),
+						on('submit', (event) => {
+							event.preventDefault()
+							void addServer()
+						}),
+					]}
+				>
+					<label mix={css(fieldCss)}>
+						<span mix={css(fieldLabelCss)}>Server name</span>
+						<input
+							data-field-ring
+							name="name"
+							type="text"
+							value={name}
+							placeholder="acme"
+							disabled={busy}
+							required
+							autocomplete="off"
+							mix={[
+								on('input', (event) => {
+									name = event.currentTarget.value
+									handle.update()
+								}),
+								css(inputCss),
+							]}
+						/>
+					</label>
+					<label mix={css(fieldCss)}>
+						<span mix={css(fieldLabelCss)}>Server URL</span>
+						<input
+							data-field-ring
+							name="url"
+							type="url"
+							value={url}
+							placeholder="https://mcp.example.com/mcp"
+							disabled={busy}
+							required
+							autocomplete="off"
+							mix={[
+								on('input', (event) => {
+									url = event.currentTarget.value
+									handle.update()
+								}),
+								css(inputCss),
+							]}
+						/>
+					</label>
+					{showBearer ? (
+						<label mix={css(fieldCss)}>
+							<span mix={css(fieldLabelCss)}>Bearer token (optional)</span>
+							<input
+								data-field-ring
+								name="bearerToken"
+								type="password"
+								value={bearerToken}
+								placeholder="Only if the server uses a static token"
+								disabled={busy}
+								autocomplete="off"
+								mix={[
+									on('input', (event) => {
+										bearerToken = event.currentTarget.value
+										handle.update()
+									}),
+									css(inputCss),
+								]}
+							/>
+						</label>
+					) : (
+						<button
+							type="button"
+							mix={[
+								css(tokenToggleCss),
+								on('click', () => {
+									showBearer = true
+									handle.update()
+								}),
+							]}
+						>
+							Uses a static bearer token?
+						</button>
+					)}
+					<button
+						type="submit"
+						disabled={busy}
+						mix={css(submitCss)}
+						data-testid="onboarding-custom-mcp-add"
+					>
+						{busy ? 'Connecting…' : 'Add custom MCP'}
+					</button>
+				</form>
+				{error ? (
+					<p mix={css(errorCss)} role="alert">
+						{error}
+					</p>
+				) : null}
+			</div>
+		)
+	}
+}
+
+const cardCss = {
+	display: 'grid',
+	gap: '0.7rem',
+	padding: '1.15rem 1.25rem',
+	border: `1.5px dashed ${colors.border}`,
+	borderRadius: '16px',
+	backgroundColor: `oklch(from ${colors.primary} l c h / 0.04)`,
+}
+
+const eyebrowCss = {
+	margin: 0,
+	font: `700 0.75rem/1 ${typography.fontFamilyDisplay}`,
+	letterSpacing: '0.08em',
+	textTransform: 'uppercase' as const,
+	color: colors.primaryText,
+}
+
+const titleCss = {
+	margin: 0,
+	font: `720 1.1rem/1.25 ${typography.fontFamilyDisplay}`,
+	color: colors.text,
+}
+
+const copyCss = {
+	margin: 0,
+	color: colors.textMuted,
+	fontSize: '0.92rem',
+	lineHeight: 1.5,
+	maxWidth: '68ch',
+}
+
+const codeCss = {
+	fontSize: '0.85em',
+}
+
+const serverListCss = {
+	listStyle: 'none',
+	margin: 0,
+	padding: 0,
+	display: 'grid',
+	gap: '0.55rem',
+}
+
+const serverRowCss = {
+	display: 'grid',
+	gap: '0.4rem',
+	gridTemplateColumns: 'minmax(0, 1fr) auto',
+	alignItems: 'center',
+	padding: '0.65rem 0.75rem',
+	border: `1px solid ${colors.border}`,
+	borderRadius: '12px',
+	backgroundColor: colors.surface,
+}
+
+const serverMetaCss = {
+	display: 'grid',
+	gap: '0.15rem',
+	minWidth: 0,
+}
+
+const serverNameCss = {
+	fontWeight: 650,
+	color: colors.text,
+}
+
+const serverUrlCss = {
+	color: colors.textMuted,
+	fontSize: '0.82rem',
+	overflow: 'hidden',
+	textOverflow: 'ellipsis',
+	whiteSpace: 'nowrap' as const,
+}
+
+const formCss = {
+	display: 'grid',
+	gap: '0.7rem',
+}
+
+const fieldCss = {
+	display: 'grid',
+	gap: '0.3rem',
+}
+
+const fieldLabelCss = {
+	font: `650 0.82rem/1.3 ${typography.fontFamilyBody}`,
+	color: colors.text,
+}
+
+const inputCss = {
+	...getAuthInputCss(),
+}
+
+const tokenToggleCss = {
+	...getGhostButtonCss(),
+	width: 'fit-content',
+	fontSize: '0.85rem',
+	justifySelf: 'start',
+}
+
+const submitCss = {
+	...getPillButtonCss(),
+	width: 'fit-content',
+}
+
+const reconnectButtonCss = {
+	...getGhostButtonCss(),
+	fontSize: '0.85rem',
+}
+
+const connectedButtonCss = {
+	...getGhostButtonCss(),
+	fontSize: '0.85rem',
+	color: colors.primaryText,
+	borderColor: `oklch(from ${colors.primary} l c h / 0.45)`,
+	backgroundColor: `oklch(from ${colors.primary} l c h / 0.08)`,
+	cursor: 'default',
+}
+
+const errorCss = {
+	margin: 0,
+	gridColumn: '1 / -1',
+	color: colors.error,
+	font: `550 0.82rem/1.4 ${typography.fontFamilyBody}`,
+}

--- a/packages/worker/client/routes/onboarding-payload.ts
+++ b/packages/worker/client/routes/onboarding-payload.ts
@@ -2,6 +2,7 @@ import { type OnboardingFeaturedListing } from '#universal/community-public-type
 import {
 	type OnboardingBuiltInProvider,
 	type OnboardingChecklistLoaderData,
+	type OnboardingCustomMcpServer,
 	type OnboardingFeaturedMcpServer,
 	type OnboardingWelcomeEmail,
 } from '#universal/loader-data.ts'
@@ -29,6 +30,7 @@ export type OnboardingPayload = {
 	featuredListings: Array<OnboardingFeaturedListing>
 	builtInProviders: Array<OnboardingBuiltInProvider>
 	featuredMcpServers: Array<OnboardingFeaturedMcpServer>
+	customMcpServers: Array<OnboardingCustomMcpServer>
 	/**
 	 * Most recently updated saved-package kody id after persist. Null when
 	 * logged out, unverified, or the listing fails open.

--- a/packages/worker/client/routes/onboarding-persist-card.tsx
+++ b/packages/worker/client/routes/onboarding-persist-card.tsx
@@ -10,11 +10,12 @@ import {
 type OnboardingPersistCardProps = {
 	persistPrompt: string
 	connectedServerLabel: string | null
+	installedExampleName: string | null
 }
 
 /**
  * Step 3 lead: copy the ad hoc → persist prompt after the person connected
- * (or skipped) a featured MCP server.
+ * a workspace MCP, installed a Just-try-Kody example, or skipped.
  */
 export function OnboardingPersistCard(
 	handle: Handle<OnboardingPersistCardProps>,
@@ -41,18 +42,20 @@ export function OnboardingPersistCard(
 
 	return () => {
 		const connectedLabel = handle.props.connectedServerLabel
+		const exampleName = handle.props.installedExampleName
+		const targetLabel = connectedLabel ?? exampleName
 		return (
 			<div mix={css(cardCss)} data-testid="onboarding-persist-card">
 				<p mix={css(kickerCss)}>Paste this next</p>
 				<h3 mix={css(titleCss)}>
-					{connectedLabel
-						? `Ask your agent to use ${connectedLabel}, then save the result`
+					{targetLabel
+						? `Ask your agent to use ${targetLabel}, then save the result`
 						: 'Ask your agent to try something, then save the result'}
 				</h3>
 				<p mix={css(copyCss)}>
 					The prompt tells your agent to run one ad hoc request
-					{connectedLabel ? ` against ${connectedLabel}` : ''}, show you the
-					result, and persist that working code as a package you own.
+					{targetLabel ? ` against ${targetLabel}` : ''}, show you the result,
+					and persist that working code as a package you own.
 				</p>
 				<button
 					type="button"

--- a/packages/worker/client/routes/onboarding.tsx
+++ b/packages/worker/client/routes/onboarding.tsx
@@ -17,19 +17,26 @@ import {
 import {
 	type OnboardingBuiltInProvider,
 	type OnboardingChecklistLoaderData,
+	type OnboardingCustomMcpServer,
 	type OnboardingFeaturedMcpServer,
 } from '#universal/loader-data.ts'
 import { type OnboardingFeaturedListing } from '#universal/community-public-types.ts'
 import { landingArtAttrs } from '#universal/landing-images.ts'
 import { routes } from '#universal/routes.ts'
 import {
+	firstInstalledOnboardingExampleName,
+	hasInstalledOnboardingExample,
+	onboardingExampleInstallFingerprint,
 	selectOnboardingExampleListings,
 	selectOnboardingServiceStarterListings,
 } from '#universal/onboarding-examples.ts'
 import {
+	customOnboardingMcpFingerprint,
 	featuredOnboardingMcpFingerprint,
+	firstConnectedOnboardingWorkspaceLabel,
 	formatOnboardingFeaturedMcpChoice,
-	hasConnectedOnboardingFeaturedMcpServer,
+	hasConnectedOnboardingWorkspaceMcp,
+	hasPendingOnboardingCustomMcpAuth,
 	hasPendingOnboardingFeaturedMcpAuth,
 } from '#universal/onboarding-mcp-chooser.ts'
 import {
@@ -44,6 +51,7 @@ import {
 	shouldShowOnboardingChecklist,
 } from '#client/routes/onboarding-checklist.tsx'
 import { OnboardingMcpClientTabs } from '#client/routes/onboarding-mcp-client-tabs.tsx'
+import { OnboardingCustomMcpCard } from '#client/routes/onboarding-custom-mcp-card.tsx'
 import { OnboardingMcpChooserCard } from '#client/routes/onboarding-mcp-chooser-card.tsx'
 import { OnboardingExampleCard } from '#client/routes/onboarding-example-card.tsx'
 import { OnboardingPersistCard } from '#client/routes/onboarding-persist-card.tsx'
@@ -82,12 +90,12 @@ import {
  * behind a disclosure. Server state (prompts, MCP URL, featured MCP
  * servers, hasMcpClient / OAuth polling) stays in the route state.
  *
- * Step 2 adds an official workspace MCP server (or skip) — the quicker
- * first-value path, paired with `@kody/*-mcp` helpers. Official non-MCP
- * API packages stay the long-term preferred path. Step 3 is the permanence
- * lesson: copy a prompt that runs one ad hoc execute, then persist that
- * working code as a package. Built-in platform OAuth and featured starters
- * stay available under Advanced.
+ * Step 2 ranks exits: featured official MCP, custom MCP, BYOK explanation
+ * (not a connect step), then Just-try-Kody zero-auth examples, then skip.
+ * Official non-MCP API packages stay the long-term preferred path. Step 3
+ * is the permanence lesson: copy a prompt that runs one ad hoc execute,
+ * then persist that working code as a package. Built-in platform OAuth and
+ * featured starters stay available under Advanced.
  */
 
 type OnboardingStep = 1 | 2 | 3
@@ -171,7 +179,7 @@ export function OnboardingRoute(handle: Handle) {
 	let setupPrompt = ''
 	let persistPrompt = ''
 	let hasMcpClient = false
-	let hasFeaturedMcp = false
+	let hasStep2Win = false
 	let hasPersistedPackage = false
 	let persistedPackageKodyId: string | null = null
 	let featuredListings: Array<OnboardingFeaturedListing> = []
@@ -179,6 +187,7 @@ export function OnboardingRoute(handle: Handle) {
 	let serviceStarterListings: Array<OnboardingFeaturedListing> = []
 	let builtInProviders: Array<OnboardingBuiltInProvider> = []
 	let featuredMcpServers: Array<OnboardingFeaturedMcpServer> = []
+	let customMcpServers: Array<OnboardingCustomMcpServer> = []
 	let checklist: OnboardingChecklistLoaderData | null = null
 	let checklistHidden = false
 	let activeStep: OnboardingStep = 1
@@ -202,7 +211,12 @@ export function OnboardingRoute(handle: Handle) {
 		serviceStarterListings =
 			selectOnboardingServiceStarterListings(featuredListings)
 		featuredMcpServers = payload.featuredMcpServers ?? []
-		hasFeaturedMcp = hasConnectedOnboardingFeaturedMcpServer(featuredMcpServers)
+		customMcpServers = payload.customMcpServers ?? []
+		hasStep2Win =
+			hasConnectedOnboardingWorkspaceMcp({
+				featuredMcpServers,
+				customMcpServers,
+			}) || hasInstalledOnboardingExample(exampleListings)
 		builtInProviders = payload.builtInProviders ?? []
 		checklist = payload.checklist
 		hasPersistedPackage = isOnboardingChecklistItemDone(
@@ -214,16 +228,16 @@ export function OnboardingRoute(handle: Handle) {
 		status = 'ready'
 		message = null
 		if (!initializedStep) {
-			activeStep = hasFeaturedMcp ? 3 : payload.hasMcpClient ? 2 : 1
+			activeStep = hasStep2Win ? 3 : payload.hasMcpClient ? 2 : 1
 			initializedStep = true
-		} else if (!wasConnected && payload.hasMcpClient && !hasFeaturedMcp) {
+		} else if (!wasConnected && payload.hasMcpClient && !hasStep2Win) {
 			panelAnimationArmed = true
 			activeStep = 2
 			updateStepHash(2)
 			scrollToNav('onboarding-steps-nav')
 		}
-		// Stay on Step 2 when a featured MCP finishes so the Connected
-		// state is visible; wizard nav advances to the persist prompt.
+		// Stay on Step 2 when a workspace MCP or example finishes so the
+		// Connected/Installed state is visible; wizard nav advances.
 	}
 
 	/**
@@ -372,6 +386,7 @@ export function OnboardingRoute(handle: Handle) {
 		if (
 			hasMcpClient &&
 			!hasPendingOnboardingFeaturedMcpAuth(featuredMcpServers) &&
+			!hasPendingOnboardingCustomMcpAuth(customMcpServers) &&
 			hasPersistedPackage &&
 			persistedPackageKodyId != null
 		) {
@@ -384,6 +399,8 @@ export function OnboardingRoute(handle: Handle) {
 			const payload = await fetchOnboardingPayload(handle.signal)
 			if (handle.signal.aborted || !payload) return
 			const nextServers = payload.featuredMcpServers ?? []
+			const nextCustomServers = payload.customMcpServers ?? []
+			const nextListings = payload.featuredListings ?? []
 			const nextHasPersistedPackage = isOnboardingChecklistItemDone(
 				payload.checklist,
 				'install-starter',
@@ -392,6 +409,10 @@ export function OnboardingRoute(handle: Handle) {
 				payload.hasMcpClient === hasMcpClient &&
 				featuredOnboardingMcpFingerprint(nextServers) ===
 					featuredOnboardingMcpFingerprint(featuredMcpServers) &&
+				customOnboardingMcpFingerprint(nextCustomServers) ===
+					customOnboardingMcpFingerprint(customMcpServers) &&
+				onboardingExampleInstallFingerprint(nextListings) ===
+					onboardingExampleInstallFingerprint(featuredListings) &&
 				nextHasPersistedPackage === hasPersistedPackage &&
 				payload.persistedPackageKodyId === persistedPackageKodyId
 			) {
@@ -470,6 +491,13 @@ export function OnboardingRoute(handle: Handle) {
 			})
 		}
 
+		const workspaceLabel = firstConnectedOnboardingWorkspaceLabel({
+			featuredMcpServers,
+			customMcpServers,
+		})
+		const exampleName = firstInstalledOnboardingExampleName(exampleListings)
+		const persistTargetLabel = workspaceLabel ?? exampleName
+
 		return (
 			<section mix={css(onboardCss)}>
 				<header mix={css(onboardHeadCss)}>
@@ -526,7 +554,7 @@ export function OnboardingRoute(handle: Handle) {
 								const isActive = activeStep === step.number
 								const isComplete =
 									(step.number === 1 && hasMcpClient) ||
-									(step.number === 2 && hasFeaturedMcp)
+									(step.number === 2 && hasStep2Win)
 								return (
 									<button
 										key={step.number}
@@ -663,11 +691,11 @@ export function OnboardingRoute(handle: Handle) {
 									/>
 								</div>
 								<p mix={css(panelLedeCss)}>
-									Give your agent a live workspace: add{' '}
-									{formatOnboardingFeaturedMcpChoice()} as a remote MCP server,
+									Give your agent a live workspace. Official MCP is the easy
+									login path: add {formatOnboardingFeaturedMcpChoice()},
 									authorize it, and install the matching official{' '}
-									<em>@kody/*-mcp</em> helper — or skip if you would rather try
-									an ad hoc request first.
+									<em>@kody/*-mcp</em> helper. None of these? Add a custom
+									server, or just try Kody without a third-party login.
 								</p>
 								<ul
 									mix={css(starterGridCss)}
@@ -684,13 +712,24 @@ export function OnboardingRoute(handle: Handle) {
 										/>
 									))}
 								</ul>
-								{hasFeaturedMcp ? (
+								{hasConnectedOnboardingWorkspaceMcp({
+									featuredMcpServers,
+									customMcpServers,
+								}) ? (
 									<p
 										mix={css(quickExampleDoneCss)}
 										data-testid="onboarding-mcp-chooser-done"
 									>
 										Connected — continue to run one useful request and persist
 										it as a package you own.
+									</p>
+								) : hasInstalledOnboardingExample(exampleListings) ? (
+									<p
+										mix={css(quickExampleDoneCss)}
+										data-testid="onboarding-example-done"
+									>
+										Installed — continue to try it and persist a package you
+										own.
 									</p>
 								) : null}
 								<aside
@@ -709,10 +748,71 @@ export function OnboardingRoute(handle: Handle) {
 										this list — it does not return an authorization link.
 									</p>
 								</aside>
+								<div
+									mix={css(step2ExitCss)}
+									data-testid="onboarding-none-of-these"
+								>
+									<p mix={css(step2ExitLabelCss)}>None of these?</p>
+									<p mix={css(step2ExitLedeCss)}>
+										Add any remote MCP server. Same easy authorize path — just
+										not a vendor we featured.
+									</p>
+									<OnboardingCustomMcpCard
+										servers={customMcpServers}
+										loggedIn={loggedIn}
+										onChanged={() => {
+											void refreshOnboardingAfterInstall()
+										}}
+									/>
+								</div>
+								<div mix={css(step2ExitCss)} data-testid="onboarding-no-mcp">
+									<p mix={css(step2ExitLabelCss)}>No MCP for that service?</p>
+									<p mix={css(step2ExitLedeCss)}>
+										Bring-your-own-key is the durable path when a tool has no
+										remote MCP — you create the app, your agent walks you
+										through it. That is harder. Finish this first build first,
+										then connect from Advanced or{' '}
+										<a href="/account/secrets/new" mix={css(primaryLinkCss)}>
+											Account → Secrets
+										</a>
+										.{' '}
+										<a href="#byok" mix={css(primaryLinkCss)}>
+											Why bring your own keys?
+										</a>
+									</p>
+								</div>
+								{exampleListings.length > 0 ? (
+									<div
+										mix={css(step2ExitCss)}
+										data-testid="onboarding-just-try"
+									>
+										<p mix={css(step2ExitLabelCss)}>Just try Kody</p>
+										<p mix={css(step2ExitLedeCss)}>
+											No third-party login. Install an example, then persist it
+											as a package you own.
+										</p>
+										<ul
+											mix={css(starterGridCss)}
+											data-testid="onboarding-example-packages"
+										>
+											{exampleListings.map((listing) => (
+												<OnboardingExampleCard
+													key={listing.id}
+													listing={listing}
+													loggedIn={loggedIn}
+													username={username}
+													onInstalled={() => {
+														void refreshOnboardingAfterInstall()
+													}}
+												/>
+											))}
+										</ul>
+									</div>
+								) : null}
 								<WizardNavigation
 									activeStep={activeStep}
 									onSelectStep={selectStep}
-									confirmUnconnectedNext={!hasFeaturedMcp}
+									confirmUnconnectedNext={!hasStep2Win}
 									skipLabel="Skip for now"
 									onSkip={() => selectStep(3)}
 								/>
@@ -749,17 +849,13 @@ export function OnboardingRoute(handle: Handle) {
 								</div>
 								<p mix={css(panelLedeCss)}>
 									This is the permanence lesson: run one useful ad hoc request
-									{featuredMcpServers.find((server) => server.connected)
-										? ` against ${featuredMcpServers.find((server) => server.connected)?.label}`
-										: ''}
-									, then save that working code as a package you own.
+									{persistTargetLabel ? ` against ${persistTargetLabel}` : ''},
+									then save that working code as a package you own.
 								</p>
 								<OnboardingPersistCard
 									persistPrompt={persistPrompt}
-									connectedServerLabel={
-										featuredMcpServers.find((server) => server.connected)
-											?.label ?? null
-									}
+									connectedServerLabel={workspaceLabel}
+									installedExampleName={exampleName}
 								/>
 								{hasPersistedPackage ? (
 									<>
@@ -858,24 +954,6 @@ export function OnboardingRoute(handle: Handle) {
 													</li>
 												)
 											})}
-										</ul>
-									) : null}
-									{exampleListings.length > 0 ? (
-										<ul
-											mix={css(starterGridCss)}
-											data-testid="onboarding-example-packages"
-										>
-											{exampleListings.map((listing) => (
-												<OnboardingExampleCard
-													key={listing.id}
-													listing={listing}
-													loggedIn={loggedIn}
-													username={username}
-													onInstalled={() => {
-														void refreshOnboardingAfterInstall()
-													}}
-												/>
-											))}
 										</ul>
 									) : null}
 									<ul mix={css(starterListCss)}>
@@ -1486,6 +1564,30 @@ const providerConnectedPillCss = {
 	borderColor: `oklch(from ${colors.primary} l c h / 0.45)`,
 	backgroundColor: `oklch(from ${colors.primary} l c h / 0.08)`,
 	cursor: 'pointer',
+}
+
+const step2ExitCss = {
+	display: 'grid',
+	gap: '0.45rem',
+	marginTop: '0.35rem',
+	paddingTop: '1rem',
+	borderTop: `1px solid ${colors.border}`,
+}
+
+const step2ExitLabelCss = {
+	margin: 0,
+	font: `700 0.78rem/1 ${typography.fontFamilyBody}`,
+	letterSpacing: '0.06em',
+	textTransform: 'uppercase' as const,
+	color: colors.textMuted,
+}
+
+const step2ExitLedeCss = {
+	margin: 0,
+	color: colors.textMuted,
+	fontSize: '0.92rem',
+	lineHeight: 1.55,
+	maxWidth: '68ch',
 }
 
 /* Built-in OAuth and featured starters demote to Advanced under the persist lead. */

--- a/packages/worker/src/app/handlers/onboarding.node.test.ts
+++ b/packages/worker/src/app/handlers/onboarding.node.test.ts
@@ -5,6 +5,7 @@ import {
 	createOnboardingApiHandler,
 	createOnboardingHandler,
 	loadOnboardingBuiltInProviders,
+	loadOnboardingCustomMcpServers,
 	loadOnboardingFeaturedMcpServers,
 	loadPersistedPackageKodyId,
 	loadWelcomeEmail,
@@ -330,6 +331,54 @@ test('onboarding featured MCP servers overlay Notion and Linear connection state
 	await expect(
 		loadOnboardingFeaturedMcpServers(env, 'viewer-1'),
 	).resolves.toEqual(listDisconnectedOnboardingFeaturedMcpServers())
+})
+
+test('onboarding custom MCP servers exclude featured remotes', async () => {
+	const env = {} as Env
+	mockModule.listMcpServerSettings.mockResolvedValue([
+		{
+			id: 'srv-linear',
+			name: 'linear',
+			url: 'https://mcp.linear.app/mcp',
+			enabled: true,
+			createdAt: '2026-08-01T00:00:00.000Z',
+			updatedAt: '2026-08-01T00:00:00.000Z',
+		},
+		{
+			id: 'srv-acme',
+			name: 'acme',
+			url: 'https://mcp.acme.example/mcp',
+			enabled: true,
+			createdAt: '2026-08-01T00:00:00.000Z',
+			updatedAt: '2026-08-01T00:00:00.000Z',
+		},
+	])
+	mockModule.loadMcpClientHubSnapshotOrNull.mockResolvedValue({
+		servers: [
+			{
+				serverId: 'srv-acme',
+				state: 'ready',
+				authUrl: null,
+				error: null,
+				tools: [{ name: 'ping' }],
+			},
+		],
+	})
+
+	await expect(loadOnboardingCustomMcpServers(env)).resolves.toEqual([])
+	await expect(
+		loadOnboardingCustomMcpServers(env, 'viewer-1'),
+	).resolves.toEqual([
+		{
+			id: 'srv-acme',
+			name: 'acme',
+			url: 'https://mcp.acme.example/mcp',
+			connected: true,
+			authUrl: null,
+			state: 'ready',
+			error: null,
+		},
+	])
 })
 
 test('onboarding persist next-steps use the newest saved-package kody id', async () => {

--- a/packages/worker/src/app/handlers/onboarding.ts
+++ b/packages/worker/src/app/handlers/onboarding.ts
@@ -27,12 +27,16 @@ import { listMcpServerSettings } from '#worker/mcp-client/settings-service.ts'
 import { listSavedPackagesByUserId } from '#worker/package-registry/repo.ts'
 import {
 	attachOnboardingMcpPackageListings,
+	firstConnectedOnboardingWorkspaceLabel,
 	listDisconnectedOnboardingFeaturedMcpServers,
+	listOnboardingCustomMcpServers,
 	overlayOnboardingFeaturedMcpServers,
 } from '#universal/onboarding-mcp-chooser.ts'
+import { firstInstalledOnboardingExampleName } from '#universal/onboarding-examples.ts'
 import {
 	type OnboardingBuiltInProvider,
 	type OnboardingChecklistLoaderData,
+	type OnboardingCustomMcpServer,
 	type OnboardingFeaturedMcpServer,
 	type OnboardingWelcomeEmail,
 } from '#universal/loader-data.ts'
@@ -193,15 +197,15 @@ export async function loadOnboardingBuiltInProviders(
  * overlays saved MCP servers and hub connection state. Fails open to the
  * disconnected catalog so a hub or D1 blip never breaks the payload.
  */
-export async function loadOnboardingFeaturedMcpServers(
+async function loadOnboardingMcpChooserOverlay(
 	env: Env,
 	userId?: string | null,
-): Promise<Array<OnboardingFeaturedMcpServer>> {
-	if (!userId) return listDisconnectedOnboardingFeaturedMcpServers()
+) {
+	if (!userId) return { settings: [], statusByServerId: undefined }
 	try {
 		const settings = await listMcpServerSettings({ env, userId })
 		if (settings.length === 0) {
-			return listDisconnectedOnboardingFeaturedMcpServers()
+			return { settings: [], statusByServerId: undefined }
 		}
 		const snapshot = await loadMcpClientHubSnapshotOrNull({ env, userId })
 		const statusByServerId = new Map(
@@ -224,25 +228,86 @@ export async function loadOnboardingFeaturedMcpServers(
 				] as const
 			}),
 		)
-		return overlayOnboardingFeaturedMcpServers({
-			settings,
-			statusByServerId,
-		})
+		return { settings, statusByServerId }
+	} catch {
+		return { settings: [], statusByServerId: undefined }
+	}
+}
+
+export async function loadOnboardingFeaturedMcpServers(
+	env: Env,
+	userId?: string | null,
+): Promise<Array<OnboardingFeaturedMcpServer>> {
+	if (!userId) return listDisconnectedOnboardingFeaturedMcpServers()
+	try {
+		const overlay = await loadOnboardingMcpChooserOverlay(env, userId)
+		if (overlay.settings.length === 0) {
+			return listDisconnectedOnboardingFeaturedMcpServers()
+		}
+		return overlayOnboardingFeaturedMcpServers(overlay)
 	} catch {
 		return listDisconnectedOnboardingFeaturedMcpServers()
 	}
 }
 
-async function loadOnboardingChooserMcpServers(
+export async function loadOnboardingCustomMcpServers(
+	env: Env,
+	userId?: string | null,
+): Promise<Array<OnboardingCustomMcpServer>> {
+	if (!userId) return []
+	const overlay = await loadOnboardingMcpChooserOverlay(env, userId)
+	return listOnboardingCustomMcpServers(overlay)
+}
+
+async function loadOnboardingChooserMcpState(
 	env: Env,
 	request: Request,
 	userId?: string | null,
-): Promise<Array<OnboardingFeaturedMcpServer>> {
-	const [servers, listings] = await Promise.all([
-		loadOnboardingFeaturedMcpServers(env, userId),
+): Promise<{
+	featuredMcpServers: Array<OnboardingFeaturedMcpServer>
+	customMcpServers: Array<OnboardingCustomMcpServer>
+}> {
+	const [overlay, listings] = await Promise.all([
+		loadOnboardingMcpChooserOverlay(env, userId),
 		loadOnboardingMcpChooserListings(env, request),
 	])
-	return attachOnboardingMcpPackageListings(servers, listings)
+	const featuredBase =
+		overlay.settings.length === 0
+			? listDisconnectedOnboardingFeaturedMcpServers()
+			: overlayOnboardingFeaturedMcpServers(overlay)
+	return {
+		featuredMcpServers: attachOnboardingMcpPackageListings(
+			featuredBase,
+			listings,
+		),
+		customMcpServers: listOnboardingCustomMcpServers(overlay),
+	}
+}
+
+async function loadOnboardingChooserFields(
+	env: Env,
+	request: Request,
+	userId?: string | null,
+) {
+	const [featuredListings, builtInProviders, chooser] = await Promise.all([
+		loadOnboardingFeaturedListings(env, request),
+		loadOnboardingBuiltInProviders(env, userId),
+		loadOnboardingChooserMcpState(env, request, userId),
+	])
+	return {
+		featuredListings,
+		builtInProviders,
+		featuredMcpServers: chooser.featuredMcpServers,
+		customMcpServers: chooser.customMcpServers,
+		persistContext: {
+			connectedWorkspaceLabel: firstConnectedOnboardingWorkspaceLabel({
+				featuredMcpServers: chooser.featuredMcpServers,
+				customMcpServers: chooser.customMcpServers,
+			}),
+			installedExampleName:
+				firstInstalledOnboardingExampleName(featuredListings),
+		},
+	}
 }
 
 function redirectUnverifiedToPending(request: Request) {
@@ -263,17 +328,14 @@ export function createOnboardingHandler(env: Env) {
 		async handler({ request }) {
 			const user = await readAuthenticatedAppUser(request, env)
 			if (!user) {
+				const { persistContext: _persistContext, ...chooser } =
+					await loadOnboardingChooserFields(env, request)
 				const onboarding = {
 					...loadPublicOnboardingData({
 						env,
 						requestUrl: request.url,
 					}),
-					featuredListings: await loadOnboardingFeaturedListings(env, request),
-					builtInProviders: await loadOnboardingBuiltInProviders(env),
-					featuredMcpServers: await loadOnboardingChooserMcpServers(
-						env,
-						request,
-					),
+					...chooser,
 				}
 				return renderAppPage({
 					request,
@@ -286,22 +348,18 @@ export function createOnboardingHandler(env: Env) {
 				return redirectUnverifiedToPending(request)
 			}
 
+			const chooser = await loadOnboardingChooserFields(
+				env,
+				request,
+				user.mcpUser.userId,
+			)
 			const onboarding = await loadOnboardingData({
 				env,
 				requestUrl: request.url,
 				stableUserId: user.mcpUser.userId,
 				username: user.username,
 				emailVerified: user.emailVerified,
-				featuredListings: await loadOnboardingFeaturedListings(env, request),
-				builtInProviders: await loadOnboardingBuiltInProviders(
-					env,
-					user.mcpUser.userId,
-				),
-				featuredMcpServers: await loadOnboardingChooserMcpServers(
-					env,
-					request,
-					user.mcpUser.userId,
-				),
+				...chooser,
 			})
 			;[
 				onboarding.checklist,
@@ -333,42 +391,30 @@ export function createOnboardingApiHandler(env: Env) {
 
 			const user = await readAuthenticatedAppUser(request, env)
 			if (!user) {
+				const { persistContext: _persistContext, ...chooser } =
+					await loadOnboardingChooserFields(env, request)
 				return jsonResponse({
 					...loadPublicOnboardingData({
 						env,
 						requestUrl: request.url,
 					}),
-					featuredListings: await loadOnboardingFeaturedListings(env, request),
-					builtInProviders: await loadOnboardingBuiltInProviders(env),
-					featuredMcpServers: await loadOnboardingChooserMcpServers(
-						env,
-						request,
-					),
+					...chooser,
 				})
 			}
 
 			// Unverified callers still get a payload so clients can detect the
 			// gate; MCP URL/setup and featured fields stay empty until
 			// verification succeeds.
+			const chooser = user.emailVerified
+				? await loadOnboardingChooserFields(env, request, user.mcpUser.userId)
+				: null
 			const onboarding = await loadOnboardingData({
 				env,
 				requestUrl: request.url,
 				stableUserId: user.mcpUser.userId,
 				username: user.username,
 				emailVerified: user.emailVerified,
-				featuredListings: user.emailVerified
-					? await loadOnboardingFeaturedListings(env, request)
-					: [],
-				builtInProviders: user.emailVerified
-					? await loadOnboardingBuiltInProviders(env, user.mcpUser.userId)
-					: [],
-				featuredMcpServers: user.emailVerified
-					? await loadOnboardingChooserMcpServers(
-							env,
-							request,
-							user.mcpUser.userId,
-						)
-					: [],
+				...chooser,
 			})
 			if (user.emailVerified) {
 				;[

--- a/packages/worker/src/app/onboarding-data.node.test.ts
+++ b/packages/worker/src/app/onboarding-data.node.test.ts
@@ -70,6 +70,7 @@ test('onboarding data builds the MCP URL and derives incomplete setup from verif
 		featuredListings: [],
 		builtInProviders: [],
 		featuredMcpServers: listDisconnectedOnboardingFeaturedMcpServers(),
+		customMcpServers: [],
 		persistedPackageKodyId: null,
 		checklist: null,
 	})
@@ -111,6 +112,7 @@ test('onboarding data builds the MCP URL and derives incomplete setup from verif
 		featuredListings: [],
 		builtInProviders: [],
 		featuredMcpServers: listDisconnectedOnboardingFeaturedMcpServers(),
+		customMcpServers: [],
 		persistedPackageKodyId: null,
 		checklist: null,
 	})
@@ -196,4 +198,37 @@ test('onboarding data builds the MCP URL and derives incomplete setup from verif
 	})
 	expect(whenProviderListingFails.hasMcpClient).toBe(false)
 	expect(whenProviderListingFails.needsOnboarding).toBe(true)
+
+	const withCustomPersist = await loadOnboardingData({
+		env: {
+			OAUTH_PROVIDER: {
+				listUserGrants: vi.fn(async () => ({ items: [] })),
+			},
+		},
+		requestUrl: 'https://heykody.dev/onboarding',
+		stableUserId: 'user-1',
+		username: 'u-b',
+		emailVerified: true,
+		persistContext: { connectedWorkspaceLabel: 'acme' },
+	})
+	expect(withCustomPersist.persistPrompt).toContain(
+		'I connected acme as a remote MCP server',
+	)
+	expect(withCustomPersist.customMcpServers).toEqual([])
+
+	const withExamplePersist = await loadOnboardingData({
+		env: {
+			OAUTH_PROVIDER: {
+				listUserGrants: vi.fn(async () => ({ items: [] })),
+			},
+		},
+		requestUrl: 'https://heykody.dev/onboarding',
+		stableUserId: 'user-1',
+		username: 'u-b',
+		emailVerified: true,
+		persistContext: { installedExampleName: '@kody/hn-pulse' },
+	})
+	expect(withExamplePersist.persistPrompt).toContain(
+		'I installed @kody/hn-pulse from /onboarding Step 2 Just try Kody',
+	)
 })

--- a/packages/worker/src/app/onboarding-data.ts
+++ b/packages/worker/src/app/onboarding-data.ts
@@ -10,6 +10,7 @@ import { listDisconnectedOnboardingFeaturedMcpServers } from '#universal/onboard
 import {
 	type OnboardingBuiltInProvider,
 	type OnboardingChecklistLoaderData,
+	type OnboardingCustomMcpServer,
 	type OnboardingFeaturedMcpServer,
 	type OnboardingLoaderData,
 	type OnboardingWelcomeEmail,
@@ -85,6 +86,7 @@ export function loadPublicOnboardingData(input: {
 		featuredListings: [],
 		builtInProviders: [],
 		featuredMcpServers: listDisconnectedOnboardingFeaturedMcpServers(),
+		customMcpServers: [],
 		persistedPackageKodyId: null,
 		checklist: null,
 	}
@@ -105,6 +107,13 @@ export async function loadOnboardingData(input: {
 	builtInProviders?: Array<OnboardingBuiltInProvider>
 	/** Official workspace MCP chooser cards, loaded by the handler. */
 	featuredMcpServers?: Array<OnboardingFeaturedMcpServer>
+	/** Non-featured MCP servers the viewer added, loaded by the handler. */
+	customMcpServers?: Array<OnboardingCustomMcpServer>
+	/** Contextual Step 3 persist prompt, computed by the handler. */
+	persistContext?: {
+		connectedWorkspaceLabel?: string | null
+		installedExampleName?: string | null
+	}
 	/** Most recently updated saved-package kody id, loaded by the handler. */
 	persistedPackageKodyId?: string | null
 	/** Derived progress checklist, computed by the handler. */
@@ -151,6 +160,9 @@ export async function loadOnboardingData(input: {
 			? buildPersistFirstPackagePrompt({
 					env: input.env,
 					requestUrl: input.requestUrl,
+					connectedWorkspaceLabel:
+						input.persistContext?.connectedWorkspaceLabel,
+					installedExampleName: input.persistContext?.installedExampleName,
 				})
 			: '',
 		hasMcpClient,
@@ -162,6 +174,7 @@ export async function loadOnboardingData(input: {
 			? (input.featuredMcpServers ??
 				listDisconnectedOnboardingFeaturedMcpServers())
 			: [],
+		customMcpServers: input.emailVerified ? (input.customMcpServers ?? []) : [],
 		// Computed by the handler alongside the checklist probes.
 		hasSentWelcomeEmail: false,
 		welcomeEmail: input.welcomeEmail ?? null,

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -379,6 +379,7 @@ test('SSR HTML routes render page content and embedded loader data', async () =>
 		featuredListings: [],
 		builtInProviders: [],
 		featuredMcpServers: [],
+		customMcpServers: [],
 		persistedPackageKodyId: null,
 		checklist: null,
 	})

--- a/packages/worker/src/onboarding-prompts.ts
+++ b/packages/worker/src/onboarding-prompts.ts
@@ -29,6 +29,8 @@ export function buildOnboardingSetupPrompt() {
 		'Help me get started with Kody.',
 		'First, briefly explain what Kody can do for me in plain language.',
 		`Then help me connect ${formatOnboardingFeaturedMcpChoice()} as a remote MCP server: call mcp_server_add with one of ${formatOnboardingFeaturedMcpAddHint()}. If I already connected one on /onboarding, skip add and use mcp_server_list. When the result includes an authUrl, ask me to open it and authorize Kody, then check mcp_server_list.`,
+		'If none of those services are useful, add a custom remote MCP server with mcp_server_add (name + URL), or skip to a zero-auth example / ad hoc request.',
+		'Do not start a bring-your-own-key OAuth-app walkthrough unless I ask — that path is harder and belongs after the first package.',
 		'Do not offer GitHub official MCP as the first option — it does not return an authorization URL.',
 		'Do not create any packages until one connected server works — start with a small ad hoc execute smoke test against its tools (for example search Notion, list Linear issues, or list Stripe customers).',
 		'Once that ad hoc call works, persist the working code as a package I own with package_save, or community_fork the matching official @kody/*-mcp listing if one is closer. Only create a new package if nothing suitable exists.',
@@ -89,15 +91,27 @@ export function buildFirstWinPrompt(input: {
 export function buildPersistFirstPackagePrompt(input: {
 	env: OnboardingPromptEnv
 	requestUrl: string | URL
+	connectedWorkspaceLabel?: string | null
+	installedExampleName?: string | null
 }) {
 	const origin = getAppBaseUrl({
 		env: input.env,
 		requestUrl: input.requestUrl,
 	})
+	const step2Context = input.connectedWorkspaceLabel
+		? `I connected ${input.connectedWorkspaceLabel} as a remote MCP server from /onboarding Step 2.`
+		: input.installedExampleName
+			? `I installed ${input.installedExampleName} from /onboarding Step 2 Just try Kody.`
+			: `I may have connected ${formatOnboardingFeaturedMcpChoice()} or a custom MCP server on /onboarding Step 2, installed a zero-auth example, or skipped so I could try an ad hoc request first.`
+	const executeHint = input.connectedWorkspaceLabel
+		? `Use execute for one useful ad hoc call against ${input.connectedWorkspaceLabel}.`
+		: input.installedExampleName
+			? `Use execute or packages.invoke for one useful call against ${input.installedExampleName}.`
+			: 'Use execute for one useful ad hoc call (search Notion, list Linear issues, list Stripe customers, invoke a Just-try-Kody example, or ask me what I want if I skipped).'
 	return [
 		`Ask the connected Kody server to read ${origin}/guides/quick-example and help me with my first build on Kody.`,
-		`I connected ${formatOnboardingFeaturedMcpChoice()} as a remote MCP server from /onboarding Step 2, or skipped so I could try an ad hoc request first.`,
-		'Use execute for one useful ad hoc call (search Notion, list Linear issues, list Stripe customers, or ask me what I want if I skipped). Show the result, then persist that working code as a package I own with package_save — or community_fork the matching official @kody/*-mcp listing if one is closer.',
+		step2Context,
+		`${executeHint} Show the result, then persist that working code as a package I own with package_save — or community_fork the matching official @kody/*-mcp listing if one is closer.`,
 		'Explain that I own the package. Ask if I want a trigger (webhook, Kody app, cron, or skip) without recommending one.',
 		'Keep messages short. Do not poll.',
 	].join(' ')

--- a/packages/worker/universal/loader-data.ts
+++ b/packages/worker/universal/loader-data.ts
@@ -12,6 +12,7 @@ import { type PermissionString, type RoleName } from '#universal/permissions.ts'
 import { type AdminFeatureFlag } from '#universal/feature-flags/types.ts'
 import { type OnboardingChecklistItemId } from '#universal/onboarding-checklist-types.ts'
 import {
+	type OnboardingCustomMcpServer,
 	type OnboardingFeaturedMcpServer,
 	type OnboardingFeaturedMcpServerId,
 } from '#universal/onboarding-mcp-chooser.ts'
@@ -26,7 +27,11 @@ import { type PublicCodeRunsWindow } from '#universal/code-runs.ts'
 export type { ProfileVisibility }
 export type { AdminFeatureFlag }
 export type { OnboardingChecklistItemId }
-export type { OnboardingFeaturedMcpServer, OnboardingFeaturedMcpServerId }
+export type {
+	OnboardingCustomMcpServer,
+	OnboardingFeaturedMcpServer,
+	OnboardingFeaturedMcpServerId,
+}
 
 export type BlogPostSummaryLoaderData = {
 	slug: string
@@ -846,6 +851,8 @@ export type OnboardingLoaderData = {
 	builtInProviders: Array<OnboardingBuiltInProvider>
 	/** Official workspace MCP chooser cards, with viewer connection overlay. */
 	featuredMcpServers: Array<OnboardingFeaturedMcpServer>
+	/** Non-featured MCP servers the viewer added themselves. */
+	customMcpServers: Array<OnboardingCustomMcpServer>
 	/**
 	 * Most recently updated saved-package kody id for this account, used by
 	 * Step 3 next-steps after persist. Null when logged out, unverified, or

--- a/packages/worker/universal/onboarding-examples.node.test.ts
+++ b/packages/worker/universal/onboarding-examples.node.test.ts
@@ -2,7 +2,10 @@ import { expect, test } from 'vitest'
 import {
 	buildOnboardingExamplePrompt,
 	buildOnboardingPackageAuthoringPrompt,
+	firstInstalledOnboardingExampleName,
+	hasInstalledOnboardingExample,
 	isOnboardingExampleListing,
+	onboardingExampleInstallFingerprint,
 	onboardingExampleListingIds,
 	selectOnboardingExampleListings,
 	selectOnboardingServiceStarterListings,
@@ -56,6 +59,52 @@ test('selects zero-auth examples in the known production order', () => {
 			tags: [],
 		}),
 	).toBe(true)
+	expect(hasInstalledOnboardingExample(featured)).toBe(false)
+	expect(
+		hasInstalledOnboardingExample([
+			{
+				...featured[2]!,
+				viewerInstall: {
+					status: 'installed',
+					targetName: '@me/local-conditions',
+					agentPrompt: 'Use it',
+					packageId: 'pkg-1',
+					listingAhead: false,
+					listingAheadPrompt: null,
+				},
+			},
+		]),
+	).toBe(true)
+	expect(
+		firstInstalledOnboardingExampleName([
+			{
+				...featured[2]!,
+				viewerInstall: {
+					status: 'installed',
+					targetName: '@me/local-conditions',
+					agentPrompt: 'Use it',
+					packageId: 'pkg-1',
+					listingAhead: false,
+					listingAheadPrompt: null,
+				},
+			},
+		]),
+	).toBe('@kody/local-conditions')
+	expect(
+		onboardingExampleInstallFingerprint([
+			{
+				...featured[2]!,
+				viewerInstall: {
+					status: 'installed',
+					targetName: '@me/local-conditions',
+					agentPrompt: 'Use it',
+					packageId: 'pkg-1',
+					listingAhead: false,
+					listingAheadPrompt: null,
+				},
+			},
+		]),
+	).toContain('installed')
 })
 
 test('example prompt searches the user-owned scoped package and invokes in user scope', () => {

--- a/packages/worker/universal/onboarding-examples.node.test.ts
+++ b/packages/worker/universal/onboarding-examples.node.test.ts
@@ -89,7 +89,7 @@ test('selects zero-auth examples in the known production order', () => {
 				},
 			},
 		]),
-	).toBe('@kody/local-conditions')
+	).toBe('@me/local-conditions')
 	expect(
 		onboardingExampleInstallFingerprint([
 			{

--- a/packages/worker/universal/onboarding-examples.ts
+++ b/packages/worker/universal/onboarding-examples.ts
@@ -56,11 +56,10 @@ export function hasInstalledOnboardingExample(
 export function firstInstalledOnboardingExampleName(
 	listings: Array<OnboardingFeaturedListing>,
 ): string | null {
-	return (
-		selectOnboardingExampleListings(listings).find(
-			(listing) => listing.viewerInstall != null,
-		)?.name ?? null
+	const installed = selectOnboardingExampleListings(listings).find(
+		(listing) => listing.viewerInstall != null,
 	)
+	return installed?.viewerInstall?.targetName ?? installed?.name ?? null
 }
 
 /** Poll skip key for Just-try-Kody installs. */

--- a/packages/worker/universal/onboarding-examples.ts
+++ b/packages/worker/universal/onboarding-examples.ts
@@ -26,7 +26,7 @@ export function isOnboardingExampleListing(listing: {
 }
 
 /**
- * Featured zero-auth examples shown under onboarding Step 3 Advanced.
+ * Featured zero-auth examples shown under onboarding Step 2 "Just try Kody".
  * Ordered like the known production set when present. Returns whatever the
  * featured payload includes; callers should tolerate an empty list when
  * curation has not landed yet.
@@ -43,6 +43,33 @@ export function selectOnboardingExampleListings(
 		const rightRank = rightIndex === -1 ? Number.MAX_SAFE_INTEGER : rightIndex
 		return leftRank - rightRank
 	})
+}
+
+export function hasInstalledOnboardingExample(
+	listings: Array<OnboardingFeaturedListing>,
+): boolean {
+	return selectOnboardingExampleListings(listings).some(
+		(listing) => listing.viewerInstall != null,
+	)
+}
+
+export function firstInstalledOnboardingExampleName(
+	listings: Array<OnboardingFeaturedListing>,
+): string | null {
+	return (
+		selectOnboardingExampleListings(listings).find(
+			(listing) => listing.viewerInstall != null,
+		)?.name ?? null
+	)
+}
+
+/** Poll skip key for Just-try-Kody installs. */
+export function onboardingExampleInstallFingerprint(
+	listings: Array<OnboardingFeaturedListing>,
+): string {
+	return selectOnboardingExampleListings(listings)
+		.map((listing) => `${listing.id}:${listing.viewerInstall?.status ?? ''}`)
+		.join('|')
 }
 
 /** Featured starters under Step 3 Advanced: everything that is not a zero-auth example. */
@@ -70,7 +97,7 @@ function exampleInvokeHint(scopedName: string, kodyId: string): string {
 }
 
 /**
- * Agent paste after the user picks an Advanced example. Safe to show while
+ * Agent paste after the user picks a Just-try-Kody example. Safe to show while
  * one-click install is still in flight — the agent is told to wait/retry once
  * if the fork is not searchable yet.
  */

--- a/packages/worker/universal/onboarding-mcp-chooser.node.test.ts
+++ b/packages/worker/universal/onboarding-mcp-chooser.node.test.ts
@@ -75,10 +75,16 @@ test('featured MCP chooser ships six official OAuth servers with packages', () =
 	).toBe(true)
 	expect(
 		matchOnboardingFeaturedMcpServer(
-			{ name: 'linear', url: 'https://example.test/other' },
+			{ name: 'linear', url: 'https://mcp.linear.app/sse' },
 			onboardingFeaturedMcpServers[1],
 		),
 	).toBe(true)
+	expect(
+		matchOnboardingFeaturedMcpServer(
+			{ name: 'linear', url: 'https://example.test/other' },
+			onboardingFeaturedMcpServers[1],
+		),
+	).toBe(false)
 
 	const disconnected = listDisconnectedOnboardingFeaturedMcpServers()
 	expect(disconnected).toHaveLength(6)
@@ -209,6 +215,11 @@ test('custom MCP servers exclude featured remotes and count as a workspace conne
 				name: 'acme',
 				url: 'https://mcp.acme.example/mcp',
 			},
+			{
+				id: 'srv-other-linear',
+				name: 'linear',
+				url: 'https://mcp.other.example/mcp',
+			},
 		],
 		statusByServerId: new Map([
 			[
@@ -232,9 +243,31 @@ test('custom MCP servers exclude featured remotes and count as a workspace conne
 			state: 'ready',
 			error: null,
 		},
+		{
+			id: 'srv-other-linear',
+			name: 'linear',
+			url: 'https://mcp.other.example/mcp',
+			connected: false,
+			authUrl: null,
+			state: null,
+			error: null,
+		},
 	])
 	expect(hasConnectedOnboardingCustomMcpServer(custom)).toBe(true)
 	expect(hasPendingOnboardingCustomMcpAuth(custom)).toBe(false)
+	expect(
+		hasPendingOnboardingCustomMcpAuth([
+			{
+				id: 'srv-pending',
+				name: 'acme',
+				url: 'https://mcp.acme.example/mcp',
+				connected: false,
+				authUrl: 'https://auth.acme.example/authorize',
+				state: 'authenticating',
+				error: null,
+			},
+		]),
+	).toBe(true)
 	expect(
 		hasConnectedOnboardingWorkspaceMcp({
 			featuredMcpServers: listDisconnectedOnboardingFeaturedMcpServers(),
@@ -247,7 +280,9 @@ test('custom MCP servers exclude featured remotes and count as a workspace conne
 			customMcpServers: custom,
 		}),
 	).toBe('acme')
-	expect(customOnboardingMcpFingerprint(custom)).toBe('srv-acme:ready:1')
+	expect(customOnboardingMcpFingerprint(custom)).toBe(
+		'srv-acme:ready:1|srv-other-linear::0',
+	)
 	expect(
 		hasConnectedOnboardingWorkspaceMcp({
 			featuredMcpServers: listDisconnectedOnboardingFeaturedMcpServers(),

--- a/packages/worker/universal/onboarding-mcp-chooser.node.test.ts
+++ b/packages/worker/universal/onboarding-mcp-chooser.node.test.ts
@@ -4,8 +4,14 @@ import {
 	featuredOnboardingMcpFingerprint,
 	formatOnboardingFeaturedMcpAddHint,
 	formatOnboardingFeaturedMcpChoice,
+	customOnboardingMcpFingerprint,
+	hasConnectedOnboardingCustomMcpServer,
 	hasConnectedOnboardingFeaturedMcpServer,
+	firstConnectedOnboardingWorkspaceLabel,
+	hasConnectedOnboardingWorkspaceMcp,
+	hasPendingOnboardingCustomMcpAuth,
 	hasPendingOnboardingFeaturedMcpAuth,
+	listOnboardingCustomMcpServers,
 	listDisconnectedOnboardingFeaturedMcpServers,
 	listOnboardingFeaturedMcpListingIds,
 	matchOnboardingFeaturedMcpServer,
@@ -188,4 +194,64 @@ test('featured MCP poll fingerprint changes when a listing appears after a miss'
 			attachOnboardingMcpPackageListings(withoutListing, [notionListing]),
 		),
 	)
+})
+
+test('custom MCP servers exclude featured remotes and count as a workspace connect', () => {
+	const custom = listOnboardingCustomMcpServers({
+		settings: [
+			{
+				id: 'srv-linear',
+				name: 'linear',
+				url: 'https://mcp.linear.app/mcp',
+			},
+			{
+				id: 'srv-acme',
+				name: 'acme',
+				url: 'https://mcp.acme.example/mcp',
+			},
+		],
+		statusByServerId: new Map([
+			[
+				'srv-acme',
+				{
+					connected: true,
+					authUrl: null,
+					state: 'ready',
+					error: null,
+				},
+			],
+		]),
+	})
+	expect(custom).toEqual([
+		{
+			id: 'srv-acme',
+			name: 'acme',
+			url: 'https://mcp.acme.example/mcp',
+			connected: true,
+			authUrl: null,
+			state: 'ready',
+			error: null,
+		},
+	])
+	expect(hasConnectedOnboardingCustomMcpServer(custom)).toBe(true)
+	expect(hasPendingOnboardingCustomMcpAuth(custom)).toBe(false)
+	expect(
+		hasConnectedOnboardingWorkspaceMcp({
+			featuredMcpServers: listDisconnectedOnboardingFeaturedMcpServers(),
+			customMcpServers: custom,
+		}),
+	).toBe(true)
+	expect(
+		firstConnectedOnboardingWorkspaceLabel({
+			featuredMcpServers: listDisconnectedOnboardingFeaturedMcpServers(),
+			customMcpServers: custom,
+		}),
+	).toBe('acme')
+	expect(customOnboardingMcpFingerprint(custom)).toBe('srv-acme:ready:1')
+	expect(
+		hasConnectedOnboardingWorkspaceMcp({
+			featuredMcpServers: listDisconnectedOnboardingFeaturedMcpServers(),
+			customMcpServers: [],
+		}),
+	).toBe(false)
 })

--- a/packages/worker/universal/onboarding-mcp-chooser.ts
+++ b/packages/worker/universal/onboarding-mcp-chooser.ts
@@ -258,3 +258,100 @@ export function hasPendingOnboardingFeaturedMcpAuth(
 ): boolean {
 	return servers.some((server) => server.serverId != null && !server.connected)
 }
+
+/**
+ * A remote MCP server the person added themselves — not one of the featured
+ * official remotes. Same add/reconnect API as `/account/mcp-servers/new`.
+ */
+export type OnboardingCustomMcpServer = {
+	id: string
+	name: string
+	url: string
+	connected: boolean
+	authUrl: string | null
+	state: string | null
+	error: string | null
+}
+
+export type OnboardingMcpChooserOverlay = {
+	settings: Array<{
+		id: string
+		name: string
+		url: string
+	}>
+	statusByServerId?: Map<
+		string,
+		{
+			connected: boolean
+			authUrl: string | null
+			state: string
+			error: string | null
+		}
+	>
+}
+
+export function listOnboardingCustomMcpServers(
+	input: OnboardingMcpChooserOverlay,
+): Array<OnboardingCustomMcpServer> {
+	return input.settings
+		.filter(
+			(setting) =>
+				!onboardingFeaturedMcpServers.some((option) =>
+					matchOnboardingFeaturedMcpServer(setting, option),
+				),
+		)
+		.map((setting) => {
+			const status = input.statusByServerId?.get(setting.id)
+			return {
+				id: setting.id,
+				name: setting.name,
+				url: setting.url,
+				connected: status?.connected ?? false,
+				authUrl: status?.authUrl ?? null,
+				state: status?.state ?? null,
+				error: status?.error ?? null,
+			}
+		})
+}
+
+export function customOnboardingMcpFingerprint(
+	servers: Array<OnboardingCustomMcpServer>,
+): string {
+	return servers
+		.map((server) =>
+			[server.id, server.state ?? '', server.connected ? '1' : '0'].join(':'),
+		)
+		.join('|')
+}
+
+export function hasConnectedOnboardingCustomMcpServer(
+	servers: Array<OnboardingCustomMcpServer>,
+): boolean {
+	return servers.some((server) => server.connected)
+}
+
+export function hasPendingOnboardingCustomMcpAuth(
+	servers: Array<OnboardingCustomMcpServer>,
+): boolean {
+	return servers.some((server) => !server.connected)
+}
+
+export function hasConnectedOnboardingWorkspaceMcp(input: {
+	featuredMcpServers: Array<OnboardingFeaturedMcpServer>
+	customMcpServers: Array<OnboardingCustomMcpServer>
+}): boolean {
+	return (
+		hasConnectedOnboardingFeaturedMcpServer(input.featuredMcpServers) ||
+		hasConnectedOnboardingCustomMcpServer(input.customMcpServers)
+	)
+}
+
+export function firstConnectedOnboardingWorkspaceLabel(input: {
+	featuredMcpServers: Array<OnboardingFeaturedMcpServer>
+	customMcpServers: Array<OnboardingCustomMcpServer>
+}): string | null {
+	const featured = input.featuredMcpServers.find((server) => server.connected)
+	if (featured) return featured.label
+	const custom = input.customMcpServers.find((server) => server.connected)
+	return custom?.name ?? null
+}

--- a/packages/worker/universal/onboarding-mcp-chooser.ts
+++ b/packages/worker/universal/onboarding-mcp-chooser.ts
@@ -137,14 +137,29 @@ export function normalizeOnboardingMcpServerUrl(url: string): string {
 	}
 }
 
+function onboardingMcpServerHostsMatch(left: string, right: string): boolean {
+	try {
+		return new URL(left).hostname === new URL(right).hostname
+	} catch {
+		return false
+	}
+}
+
 export function matchOnboardingFeaturedMcpServer(
 	setting: { name: string; url: string },
 	option: Pick<OnboardingFeaturedMcpServerOption, 'name' | 'url'>,
 ): boolean {
-	return (
-		setting.name === option.name ||
+	if (
 		normalizeOnboardingMcpServerUrl(setting.url) ===
-			normalizeOnboardingMcpServerUrl(option.url)
+		normalizeOnboardingMcpServerUrl(option.url)
+	) {
+		return true
+	}
+	// Name alone is not enough: a custom server named "linear" with some
+	// other host must stay on the custom list, not overlay the official card.
+	return (
+		setting.name === option.name &&
+		onboardingMcpServerHostsMatch(setting.url, option.url)
 	)
 }
 
@@ -333,7 +348,19 @@ export function hasConnectedOnboardingCustomMcpServer(
 export function hasPendingOnboardingCustomMcpAuth(
 	servers: Array<OnboardingCustomMcpServer>,
 ): boolean {
-	return servers.some((server) => !server.connected)
+	return servers.some((server) => {
+		if (server.connected) return false
+		if (server.authUrl != null) return true
+		switch (server.state) {
+			case 'authenticating':
+			case 'connecting':
+			case 'connected':
+			case 'discovering':
+				return true
+			default:
+				return false
+		}
+	})
 }
 
 export function hasConnectedOnboardingWorkspaceMcp(input: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Give people a way off the featured-MCP hero on `/onboarding` Step 2 without starting a 20-minute BYOK ceremony or pretending the six official remotes are the only first win.

## Why

Featured official MCP (Notion, Linear, Atlassian, Stripe, Sentry, Canva) is the easy login path, but it is not everyone. Custom MCP is the same add/reconnect API as Account → MCP servers. BYOK is the documented drop-off — explain it, do not start OAuth-app setup here. Just-try-Kody brings the three zero-auth examples back as the last on-ramp so people can still persist a package they own.

## Summary

- Featured official MCP stays the hero row.
- **Custom MCP** card: name + URL, optional bearer, counts as Step 2 complete when connected.
- **No MCP** copy explains BYOK and links to `#byok` / Account → Secrets. Does not start OAuth-app setup.
- **Just try Kody** moves the three zero-auth examples (`local-conditions`, `hn-pulse`, `personal-capture`) onto Step 2.
- Skip stays.
- Step 3 persist prompt names the connected workspace or installed example. Advanced keeps built-ins + non-example starters.
- Guides and community-package docs match the ranked exits.

## Testing

- Focused node-unit: onboarding chooser, examples, data, handler — passing after review fixes.
- CI green on `cf0d55fb` (Static, Node, Workers, E2E, MCP, Validate). Local full `validate` flakes on Cloud Agent wrangler (e2e webServer timeout); CI is the gate.
- Addressed Bugbot + CodeRabbit: featured match requires host, leftover custom MCPs do not block poll stop, persist prompt uses installed `targetName`. Follow-up Bugbot passed; CodeRabbit rate-limited on the fix commit.
- Preview as seeded user `user-me`: added custom MCP `acme-preview` via `/account/mcp-servers.json`, confirmed it on `/onboarding.json`, then UI pass of `/onboarding#connect-mcp` (featured, custom, BYOK, skip → Step 3 persist). Just-try-Kody listings are empty on this preview (no featured zero-auth curation).

Preview: https://kody-pr-1706.kody-a99.workers.dev

![Step 2 custom MCP and BYOK](https://cursor.com/artifacts/c/art-f178d8f7-401d-416b-af49-a071980d1789)
![Step 3 persist card](https://cursor.com/artifacts/c/art-8f886492-08e4-414a-9d96-885dff1eafbb)
<a href="https://cursor.com/agents/bc-a2f0e222-acf4-43dd-9845-23ecdb38dfd7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fonboarding_step2_exits_preview.mp4"><img src="https://cursor.com/artifacts/c/art-3b423f8a-5cc8-473f-a735-7e04780ce111" alt="onboarding_step2_exits_preview.mp4" /></a>

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `7477e4ac` · **Head:** `cf0d55fb`

**Classification:** extends — Step 2 wizard contract and onboarding payload grow a custom-MCP list and ranked exits; persist prompt is contextual.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | extends — Step 2 ranked exits, custom MCP card, payload `customMcpServers`, persist prompt context |
| `app-sessions` | auth | composes — `onboarding-data` still builds the signed-in payload; persist context is extra input |
| `mcp-server` | surfaces | extends — setup/persist prompt text (via `onboarding-prompts.ts`) names custom MCP / Just-try-Kody and refuses BYOK unless asked |

### Change flow

Step 2 completion now includes a custom remote MCP or a Just-try-Kody install, then Step 3 persist names that win.

```mermaid
sequenceDiagram
	actor user as User
	participant appUi as app-ui
	participant mcpClient as Account MCP API
	participant mcpServer as mcp-server
	user->>appUi: Open /onboarding#connect-mcp
	appUi-->>user: Featured official MCP hero
	alt Featured official MCP
		user->>appUi: Connect featured remote
		appUi->>mcpClient: add/reconnect featured URL
	else Custom MCP
		user->>appUi: Name + URL (optional bearer)
		appUi->>mcpClient: add/reconnect custom URL
	else Just try Kody
		user->>appUi: Install zero-auth example
	else No MCP / skip
		appUi-->>user: BYOK explanation or skip to Step 3
	end
	appUi-->>user: Step 2 complete when featured/custom connected or example installed
	user->>appUi: Copy Step 3 persist prompt
	appUi-->>mcpServer: Contextual persist prompt (workspace or example)
	mcpServer-->>user: Ad hoc execute, then package_save
```

### Before / after

| Surface | Before | After |
| --- | --- | --- |
| Step 2 | Featured MCP or skip | Featured → custom MCP → BYOK copy → Just-try-Kody → skip |
| Step 2 complete | Featured connected | Featured connected **or** custom connected **or** example installed |
| Step 3 prompt | Generic featured/skip | Names connected workspace or installed example |
| Step 3 Advanced | Built-ins + examples + starters | Built-ins + non-example starters (examples moved to Step 2) |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a2f0e222-acf4-43dd-9845-23ecdb38dfd7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a2f0e222-acf4-43dd-9845-23ecdb38dfd7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Onboarding now supports adding and reconnecting custom remote MCP servers, including authentication, validation, and connection status.
  * Step 2 offers custom server connections, BYOK options, and zero-auth “Just try Kody” examples.
  * Onboarding progress and prompts now reflect connected workspaces or installed examples.

* **Documentation**
  * Updated onboarding guides to describe the expanded connection and example options.
  * Clarified the distinction between Step 2 setup choices and Advanced options.

* **Bug Fixes**
  * Improved onboarding status tracking and persistence context for custom connections and installed examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->