### PR TITLE
Clarify homepage factory loop and code-runs ticker

### DIFF
--- a/packages/worker/client/code-runs-ticker.tsx
+++ b/packages/worker/client/code-runs-ticker.tsx
@@ -135,13 +135,18 @@ export function CodeRunsTicker(
 		const reserved = formatCodeRunsCount(handle.props.window.current)
 		return (
 			<p data-rise style={{ '--rise': '1.5' }} class="landing-hero-runs">
-				<span
-					class="landing-hero-runs-count"
-					style={{ '--runs-ch': `${reserved.length}ch` }}
-				>
-					{formatCodeRunsCount(displayed)}
+				<span class="landing-hero-runs-line">
+					<span
+						class="landing-hero-runs-count"
+						style={{ '--runs-ch': `${reserved.length}ch` }}
+					>
+						{formatCodeRunsCount(displayed)}
+					</span>
+					<span class="landing-hero-runs-label">code runs</span>
 				</span>
-				<span class="landing-hero-runs-label">code runs</span>
+				<span class="landing-hero-runs-caption">
+					Sandboxed executes across Kody accounts
+				</span>
 			</p>
 		)
 	}

--- a/packages/worker/client/routes/how-kody-works-transcript.node.test.ts
+++ b/packages/worker/client/routes/how-kody-works-transcript.node.test.ts
@@ -9,6 +9,8 @@ test('factory transcript covers ask, invoke, and a quiet daily email', () => {
 		'ask',
 		'invoke',
 	])
+	expect(howKodyWorksTranscriptActs[0]?.scene).toBeUndefined()
+	expect(howKodyWorksTranscriptActs[1]?.scene).toBe('phone')
 
 	const tools = howKodyWorksTranscriptActs.flatMap((act) =>
 		act.lines.flatMap((line) => (line.role === 'tools' ? line.tools : [])),
@@ -72,5 +74,23 @@ test('factory transcript covers ask, invoke, and a quiet daily email', () => {
 	)
 	expect(
 		agentLines.some((text) => /webhook/i.test(text) && /cron/i.test(text)),
+	).toBe(true)
+	expect(
+		agentLines.some((text) =>
+			text.includes('Favorite bot is the GitHub account kody-bot'),
+		),
+	).toBe(true)
+	expect(
+		agentLines.some((text) =>
+			text.includes('I will search for a package that already answers this.'),
+		),
+	).toBe(true)
+	expect(
+		agentLines.every(
+			(text) => !text.includes('Same question in different words'),
+		),
+	).toBe(true)
+	expect(
+		agentLines.every((text) => !text.includes('New agent, same ask')),
 	).toBe(true)
 })

--- a/packages/worker/client/routes/how-kody-works-transcript.ts
+++ b/packages/worker/client/routes/how-kody-works-transcript.ts
@@ -529,7 +529,7 @@ export const howKodyWorksTranscriptActs: Array<TranscriptAct> = [
 			{
 				role: 'agent',
 				tone: 'reasoning',
-				text: 'Favorite bot is kody-bot. I will fetch public events with the saved token.',
+				text: 'Favorite bot is the GitHub account kody-bot. I will fetch its public events with the saved token.',
 			},
 			{
 				role: 'tools',
@@ -752,6 +752,7 @@ export const howKodyWorksTranscriptActs: Array<TranscriptAct> = [
 	},
 	{
 		id: 'invoke',
+		scene: 'phone',
 		kicker:
 			'Later, on your phone with a completely different Kody-connected agent',
 		title: 'Ask again. Now safer, cheaper, and more reliable.',
@@ -763,7 +764,7 @@ export const howKodyWorksTranscriptActs: Array<TranscriptAct> = [
 			{
 				role: 'agent',
 				tone: 'reasoning',
-				text: 'Same question in different words. I will search for a package that already answers this.',
+				text: 'I will search for a package that already answers this.',
 			},
 			{
 				role: 'tools',

--- a/packages/worker/client/routes/interactive-guide-transcript.ts
+++ b/packages/worker/client/routes/interactive-guide-transcript.ts
@@ -32,10 +32,14 @@ export type TranscriptLine =
 			files: Array<TranscriptFile>
 	  }
 
+export type TranscriptScene = 'phone'
+
 export type TranscriptAct = {
 	id: string
 	kicker: string
 	title: string
+	/** Homepage loop only: start a new surface after this act header. */
+	scene?: TranscriptScene
 	lines: Array<TranscriptLine>
 }
 

--- a/packages/worker/client/routes/landing-loop-player.node.test.ts
+++ b/packages/worker/client/routes/landing-loop-player.node.test.ts
@@ -3,6 +3,7 @@ import { howKodyWorksTranscriptActs } from './how-kody-works-transcript.ts'
 import {
 	createLandingLoopPlayer,
 	flattenTranscriptActs,
+	groupLandingLoopScenes,
 	landingLoopChatScrollShouldExplore,
 	landingLoopHoldMs,
 	landingLoopTeaser,
@@ -17,15 +18,27 @@ test('homepage loop player pauses for hover and explore, then play resumes and r
 		id: 'ask',
 		kicker: landingLoopTeaser.kicker,
 		title: landingLoopTeaser.title,
+		scene: 'desk',
 	})
 	expect(beats[1]).toMatchObject({
 		kind: 'line',
 		actId: 'ask',
+		scene: 'desk',
 		line: { role: 'user', text: landingLoopTeaser.user },
 	})
 	expect(
 		beats.some((beat) => beat.kind === 'act' && beat.id === 'invoke'),
 	).toBe(true)
+	expect(
+		beats.some(
+			(beat) =>
+				beat.kind === 'act' && beat.id === 'invoke' && beat.scene === 'phone',
+		),
+	).toBe(true)
+	expect(groupLandingLoopScenes(beats).map((group) => group.scene)).toEqual([
+		'desk',
+		'phone',
+	])
 	expect(
 		beats.some((beat) => beat.kind === 'line' && beat.line.role === 'tools'),
 	).toBe(true)

--- a/packages/worker/client/routes/landing-loop-player.tsx
+++ b/packages/worker/client/routes/landing-loop-player.tsx
@@ -11,11 +11,13 @@ import { type TranscriptLine } from './interactive-guide-transcript.ts'
 import {
 	createLandingLoopPlayer,
 	flattenTranscriptActs,
+	groupLandingLoopScenes,
 	landingLoopChatScrollShouldExplore,
 	landingLoopHoldMs,
 	landingLoopTeaser,
 	waitLandingLoopHold,
 	type LandingLoopBeat,
+	type LandingLoopSceneGroup,
 } from './landing-loop-state.ts'
 
 type LoopLineRenderer = (line: TranscriptLine) => RemixNode
@@ -27,7 +29,8 @@ type LoopLineRenderer = (line: TranscriptLine) => RemixNode
  * it does not block first paint or the first beats. Hover/focus (fine
  * pointers) and explore (scroll up or open a tool) pause the autoplay;
  * Play scrolls to the latest beat and continues. The last beat pauses
- * and offers Restart instead of looping.
+ * and offers Restart instead of looping. The phone act is a later scene
+ * in the same card — a time skip plus device chrome, not a reset.
  */
 export function LandingLoopPlayer(handle: Handle) {
 	let beats: Array<LandingLoopBeat> | null = null
@@ -186,6 +189,7 @@ export function LandingLoopPlayer(handle: Handle) {
 
 	return () => {
 		const visibleBeats = beats?.slice(0, player.revealedCount) ?? null
+		const sceneGroups = visibleBeats ? groupLandingLoopScenes(visibleBeats) : []
 		const lineRenderer = renderLine
 		const loaded = visibleBeats != null && lineRenderer != null
 		const ended = loaded && player.isEnded() && !reducedMotion
@@ -347,12 +351,12 @@ export function LandingLoopPlayer(handle: Handle) {
 					]}
 				>
 					{visibleBeats && lineRenderer
-						? visibleBeats.map((beat, index) =>
-								renderBeat(
-									beat,
+						? sceneGroups.map((group, groupIndex) =>
+								renderSceneGroup(
+									group,
+									groupIndex,
 									lineRenderer,
-									`${beatKey(beat)}-${index}`,
-									index === visibleBeats.length - 1,
+									groupIndex === sceneGroups.length - 1,
 								),
 							)
 						: renderTeaser()}
@@ -364,6 +368,49 @@ export function LandingLoopPlayer(handle: Handle) {
 				</p>
 			</div>
 		)
+	}
+}
+
+function renderSceneGroup(
+	group: LandingLoopSceneGroup,
+	groupIndex: number,
+	lineRenderer: LoopLineRenderer,
+	newestGroup: boolean,
+) {
+	const lines = group.beats.map((beat, index) =>
+		renderBeat(
+			beat,
+			lineRenderer,
+			`${beatKey(beat)}-${index}`,
+			newestGroup && index === group.beats.length - 1,
+		),
+	)
+	switch (group.scene) {
+		case 'desk':
+			return (
+				<div
+					key={`scene-${group.scene}-${groupIndex}`}
+					class="landing-loop-scene"
+				>
+					{lines}
+				</div>
+			)
+		case 'phone':
+			return (
+				<div
+					key={`scene-${group.scene}-${groupIndex}`}
+					class="landing-loop-scene landing-loop-scene-phone"
+				>
+					<p class="landing-loop-later" aria-hidden="true">
+						Later
+					</p>
+					<div class="landing-loop-scene-frame">{lines}</div>
+				</div>
+			)
+		default: {
+			const exhaustive: never = group.scene
+			return exhaustive
+		}
 	}
 }
 

--- a/packages/worker/client/routes/landing-loop-state.ts
+++ b/packages/worker/client/routes/landing-loop-state.ts
@@ -1,6 +1,7 @@
 import {
 	type TranscriptAct,
 	type TranscriptLine,
+	type TranscriptScene,
 } from './interactive-guide-transcript.ts'
 
 export const landingLoopTeaser = {
@@ -20,18 +21,31 @@ export type LandingLoopPauseReason =
 	| 'manual'
 	| 'ended'
 
+export type LandingLoopScene = TranscriptScene | 'desk'
+
 export type LandingLoopBeat =
 	| {
 			kind: 'act'
 			id: string
 			kicker: string
 			title: string
+			scene: LandingLoopScene
 	  }
 	| {
 			kind: 'line'
 			actId: string
+			scene: LandingLoopScene
 			line: TranscriptLine
 	  }
+
+export type LandingLoopSceneGroup = {
+	scene: LandingLoopScene
+	beats: Array<LandingLoopBeat>
+}
+
+function actScene(act: TranscriptAct): LandingLoopScene {
+	return act.scene === 'phone' ? 'phone' : 'desk'
+}
 
 export type LandingLoopAdvance = {
 	didAdvance: boolean
@@ -43,17 +57,34 @@ export function flattenTranscriptActs(
 ): Array<LandingLoopBeat> {
 	const beats: Array<LandingLoopBeat> = []
 	for (const act of acts) {
+		const scene = actScene(act)
 		beats.push({
 			kind: 'act',
 			id: act.id,
 			kicker: act.kicker,
 			title: act.title,
+			scene,
 		})
 		for (const line of act.lines) {
-			beats.push({ kind: 'line', actId: act.id, line })
+			beats.push({ kind: 'line', actId: act.id, scene, line })
 		}
 	}
 	return beats
+}
+
+export function groupLandingLoopScenes(
+	beats: ReadonlyArray<LandingLoopBeat>,
+): Array<LandingLoopSceneGroup> {
+	const groups: Array<LandingLoopSceneGroup> = []
+	for (const beat of beats) {
+		const last = groups.at(-1)
+		if (last?.scene === beat.scene) {
+			last.beats.push(beat)
+			continue
+		}
+		groups.push({ scene: beat.scene, beats: [beat] })
+	}
+	return groups
 }
 
 export function landingLoopChatScrollShouldExplore(input: {

--- a/packages/worker/public/styles.css
+++ b/packages/worker/public/styles.css
@@ -835,12 +835,18 @@ html.is-settled {
 
 .landing-hero-runs {
 	margin: 0.85rem auto 0;
+	display: grid;
+	justify-items: center;
+	row-gap: 0.28rem;
+	font-size: clamp(1.3rem, 2.2vw, 1.65rem);
+	color: var(--color-text-muted);
+}
+
+.landing-hero-runs-line {
 	display: flex;
 	align-items: baseline;
 	justify-content: center;
 	column-gap: 0.45em;
-	font-size: clamp(1.3rem, 2.2vw, 1.65rem);
-	color: var(--color-text-muted);
 	white-space: nowrap;
 }
 
@@ -860,6 +866,16 @@ html.is-settled {
 
 .landing-hero-runs-label {
 	font-weight: 500;
+}
+
+.landing-hero-runs-caption {
+	max-width: 28ch;
+	font-size: 0.82rem;
+	font-weight: 500;
+	line-height: 1.35;
+	text-wrap: pretty;
+	text-align: center;
+	color: var(--color-text-muted);
 }
 
 .landing-hero-actions {
@@ -1182,21 +1198,33 @@ html.is-settled {
 
 .landing-loop-toggle {
 	margin: 0;
-	padding: 0;
-	border: 0;
-	background: none;
-	color: var(--color-primary-text);
-	font: inherit;
-	font-size: 0.75rem;
-	font-weight: 700;
-	letter-spacing: 0.06em;
+	padding: 0.45rem 0.9rem;
+	min-height: 2.25rem;
+	min-width: 4.75rem;
+	border: 1px solid var(--color-border);
+	border-radius: var(--radius-full);
+	background: var(--color-surface);
+	color: var(--color-text);
+	font: 650 0.78rem/1 var(--font-display);
+	letter-spacing: 0.04em;
 	text-transform: uppercase;
 	cursor: pointer;
 }
 
 .landing-loop-toggle:hover,
 .landing-loop-toggle:focus-visible {
-	text-decoration: underline;
+	border-color: color-mix(
+		in oklch,
+		var(--color-primary) 45%,
+		var(--color-border)
+	);
+	background: color-mix(
+		in oklch,
+		var(--color-primary) 10%,
+		var(--color-surface)
+	);
+	color: var(--color-primary-text);
+	text-decoration: none;
 }
 
 .landing-loop-chat {
@@ -1208,6 +1236,59 @@ html.is-settled {
 	overflow-y: auto;
 	overflow-anchor: none;
 	padding: 1rem 1.05rem;
+}
+
+.landing-loop-scene {
+	display: flex;
+	flex-direction: column;
+	gap: 0.9rem;
+}
+
+.landing-loop-scene-phone {
+	margin-top: 0.65rem;
+	gap: 0.7rem;
+}
+
+.landing-loop-later {
+	margin: 0.4rem 0 0;
+	text-align: center;
+	font-size: 0.72rem;
+	font-weight: 700;
+	letter-spacing: 0.14em;
+	text-transform: uppercase;
+	color: var(--color-text-muted);
+}
+
+.landing-loop-later::before,
+.landing-loop-later::after {
+	content: '';
+	display: inline-block;
+	width: 2.4rem;
+	height: 1px;
+	margin: 0 0.7rem;
+	vertical-align: middle;
+	background: var(--color-border);
+}
+
+.landing-loop-scene-frame {
+	display: flex;
+	flex-direction: column;
+	gap: 0.9rem;
+	margin-inline: 0.35rem;
+	padding: 1.15rem 0.75rem 0.95rem;
+	border: 1px solid var(--color-border);
+	border-radius: 22px;
+	background: color-mix(in oklch, var(--color-text) 3.5%, var(--color-surface));
+}
+
+.landing-loop-scene-frame::before {
+	content: '';
+	display: block;
+	width: 2.5rem;
+	height: 0.28rem;
+	margin: 0 auto 0.15rem;
+	border-radius: 999px;
+	background: color-mix(in oklch, var(--color-text) 16%, transparent);
 }
 
 .landing-loop-act {

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -748,6 +748,7 @@ test('renderAppPage embeds a tabular homepage code-runs ticker', async () => {
 	expect(ticker).toMatch(/--runs-ch:\s*7ch/)
 	expect(ticker).toContain(formatCodeRunsCount(count))
 	expect(ticker).toContain('code runs')
+	expect(ticker).toContain('Sandboxed executes across Kody accounts')
 	expect(html).not.toContain('aria-live')
 })
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Make the homepage factory-loop demo and code-runs ticker easier to read the first time, without putting narrator voice in a new agent's mouth.

## Why

Cameron's homepage feedback (and a follow-up here) pointed at four real gaps: the phone beat still looks like the same chat, Play/Pause looks like a link, `kody-bot` reads like the product, and the ticker number is fun but unmoored from "safer / cheaper / reliable." A brand-new phone agent also cannot know there was a previous ask.

## Summary

- Phone act is a later scene in the same card: a "Later" time skip plus device chrome. The desktop convo stays on screen.
- Phone reasoning is in-character: `I will search for a package that already answers this.`
- First reasoning names `kody-bot` as a GitHub account. The example package id `kody-bot-shipped` is unchanged — that is only the demo package the walkthrough saves after "Want this as a package…?"
- Play / Pause / Restart is a real button.
- Ticker keeps `code runs` and adds `Sandboxed executes across Kody accounts.` No "safe" prefix, no tokens-saved metric.

## Testing

- `npx vitest run --project node-unit` on the landing-loop, transcript, interactive-guide, and homepage SSR tests (21 passed)
- Screenshots of the new ticker caption, Pause button, and phone scene (real SSR renderer + landing CSS / transcript). Local `npm run dev` / `preview:e2e` did not stay healthy in this Cloud VM (Wrangler DO migration / reload loop), so these are renderer screenshots rather than a live hydrated player.

![Homepage hero with sandboxed code-runs caption](https://cursor.com/artifacts/c/art-c357cc3e-7fbe-40fc-aba3-ee8655e3a9ef)
![Factory loop with Pause button, Later skip, and phone scene](https://cursor.com/artifacts/c/art-c6ced289-7d02-4dfe-a5fd-a90472a7d857)
![Phone scene close-up with in-character search reasoning](https://cursor.com/artifacts/c/art-d69d7ed3-5c35-4565-81cf-b91bf1c8a5b6)

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `12835b44` · **Head:** `959200e3`

**Classification:** composes — homepage copy and landing CSS only; no primitive contracts change.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `app-ui` | surfaces | composes — landing ticker caption, loop scene chrome, transcript copy |

### Change flow

The homepage still SSRs the factory-loop teaser and hydrates the same transcript; this PR only changes how later acts are grouped and labeled.

```mermaid
sequenceDiagram
	actor Visitor
	participant appUi as app-ui
	Visitor->>appUi: GET /
	appUi-->>Visitor: hero ticker plus factory-loop teaser
	Note over appUi: caption under code runs
	appUi->>appUi: hydrate transcript near viewport
	appUi-->>Visitor: desk scene then Later plus phone frame
	Note over appUi: phone agent searches; no prior-ask voice
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9463cdc8-e51e-49e0-b132-c0801db40024?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9463cdc8-e51e-49e0-b132-c0801db40024&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added phone-style scenes to the landing-page interactive guide, including device framing and “Later” labeling.
  * Improved transitions between desk and phone scenes as the guide progresses.
  * Redesigned the landing-loop toggle with a clearer pill-style control and enhanced focus/hover states.

* **Content Updates**
  * Clarified GitHub account and package-search wording in the interactive transcript.
  * Added explanatory messaging for sandboxed executions across accounts.

* **Bug Fixes**
  * Improved ticker and landing-loop layout consistency across rendered views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->