### PR TITLE
Unstick the homepage code-runs ticker after a still bootstrap window

### DIFF
--- a/docs/contributing/architecture/usage-metering.md
+++ b/docs/contributing/architecture/usage-metering.md
@@ -342,7 +342,11 @@ Guarantees and rules:
   `prefers-reduced-motion` snaps and does not animate. A frozen tab (rAF gap,
   hidden, or a late timeout) snaps to the official count instead of rolling
   through every missed integer. Live leftover ticks in a busy second still step
-  +1; leftover catch-up delays stay under that freeze window.
+  +1; leftover catch-up delays stay under that freeze window. A still pair
+  (`previous === current`, used when KV is empty) does **not** hold for 24h once
+  the fleet execute total grows — the next `usage_aggregation` refresh rotates
+  it so the ticker can move. Live windows with a real delta still hold until
+  `windowEnd`.
 - **Fleet visibility** (`/admin/insights`, loader in
   `packages/worker/src/admin/fleet-usage-insights.ts`): bounded SQL over
   `usage_rollups` for the current UTC month — top-10 combined runtime duration

--- a/packages/worker/client/code-runs-ticker.tsx
+++ b/packages/worker/client/code-runs-ticker.tsx
@@ -17,6 +17,9 @@ import {
  * missed integer. Live leftover ticks in a busy second still step +1.
  * Mono digits plus a reserved width from `current` keep the label from
  * shifting as digits change. The line is sized larger than the hero subtitle.
+ * A still window (`previous === current`) has no next tick — that is a
+ * bootstrap pair, not a client bug. Refresh unsticks it when the fleet
+ * total grows.
  */
 export function CodeRunsTicker(
 	handle: Handle<{ window: PublicCodeRunsWindow }>,

--- a/packages/worker/src/usage/code-runs-window.node.test.ts
+++ b/packages/worker/src/usage/code-runs-window.node.test.ts
@@ -49,7 +49,7 @@ async function createEnv(input?: {
 	return { APP_DB: db, BUNDLE_ARTIFACTS_KV: kv }
 }
 
-test('refreshPublicCodeRunsWindow initializes a still pair, holds it for 24h, then rotates without going backwards', async () => {
+test('refreshPublicCodeRunsWindow initializes a still pair, unsticks when the fleet grows, and holds a live window for 24h', async () => {
 	const env = await createEnv({
 		rows: [
 			{ userId: 'a', month: '2026-07', eventCount: 40 },
@@ -69,30 +69,60 @@ test('refreshPublicCodeRunsWindow initializes a still pair, holds it for 24h, th
 		windowEnd: '2026-08-22T00:00:00.000Z',
 	})
 
+	await expect(
+		refreshPublicCodeRunsWindow({
+			env,
+			now: new Date('2026-08-21T12:00:00.000Z'),
+		}),
+	).resolves.toEqual({ status: 'held' })
+	expect(await loadPublicCodeRunsWindow(env, start)).toEqual(still)
+
 	await env.APP_DB.prepare(
 		`UPDATE usage_rollups SET event_count = 90 WHERE user_id = 'b'`,
 	).run()
 	await expect(
 		refreshPublicCodeRunsWindow({
 			env,
-			now: new Date('2026-08-21T23:59:00.000Z'),
+			now: new Date('2026-08-21T12:01:00.000Z'),
+		}),
+	).resolves.toEqual({ status: 'rotated' })
+	const live = await loadPublicCodeRunsWindow(
+		env,
+		new Date('2026-08-21T12:01:00.000Z'),
+	)
+	expect(live).toEqual({
+		previous: 100,
+		current: 130,
+		windowStart: '2026-08-21T12:01:00.000Z',
+		windowEnd: '2026-08-22T12:01:00.000Z',
+	})
+
+	await env.APP_DB.prepare(
+		`UPDATE usage_rollups SET event_count = 110 WHERE user_id = 'b'`,
+	).run()
+	await expect(
+		refreshPublicCodeRunsWindow({
+			env,
+			now: new Date('2026-08-21T18:00:00.000Z'),
 		}),
 	).resolves.toEqual({ status: 'held' })
-	expect(await loadPublicCodeRunsWindow(env, start)).toEqual(still)
+	expect(
+		await loadPublicCodeRunsWindow(env, new Date('2026-08-21T18:00:00.000Z')),
+	).toEqual(live)
 
 	await expect(
 		refreshPublicCodeRunsWindow({
 			env,
-			now: new Date('2026-08-22T00:00:00.000Z'),
+			now: new Date('2026-08-22T12:01:00.000Z'),
 		}),
 	).resolves.toEqual({ status: 'rotated' })
 	expect(
-		await loadPublicCodeRunsWindow(env, new Date('2026-08-22T00:00:00.000Z')),
+		await loadPublicCodeRunsWindow(env, new Date('2026-08-22T12:01:00.000Z')),
 	).toEqual({
-		previous: 100,
-		current: 130,
-		windowStart: '2026-08-22T00:00:00.000Z',
-		windowEnd: '2026-08-23T00:00:00.000Z',
+		previous: 130,
+		current: 150,
+		windowStart: '2026-08-22T12:01:00.000Z',
+		windowEnd: '2026-08-23T12:01:00.000Z',
 	})
 
 	await env.APP_DB.prepare(
@@ -101,16 +131,16 @@ test('refreshPublicCodeRunsWindow initializes a still pair, holds it for 24h, th
 	await expect(
 		refreshPublicCodeRunsWindow({
 			env,
-			now: new Date('2026-08-23T00:00:00.000Z'),
+			now: new Date('2026-08-23T12:01:00.000Z'),
 		}),
 	).resolves.toEqual({ status: 'rotated' })
 	expect(
-		await loadPublicCodeRunsWindow(env, new Date('2026-08-23T00:00:00.000Z')),
+		await loadPublicCodeRunsWindow(env, new Date('2026-08-23T12:01:00.000Z')),
 	).toEqual({
-		previous: 130,
-		current: 130,
-		windowStart: '2026-08-23T00:00:00.000Z',
-		windowEnd: '2026-08-24T00:00:00.000Z',
+		previous: 150,
+		current: 150,
+		windowStart: '2026-08-23T12:01:00.000Z',
+		windowEnd: '2026-08-24T12:01:00.000Z',
 	})
 })
 

--- a/packages/worker/src/usage/code-runs-window.ts
+++ b/packages/worker/src/usage/code-runs-window.ts
@@ -1,4 +1,5 @@
 import {
+	isStillPublicCodeRunsWindow,
 	parsePublicCodeRunsWindow,
 	publicCodeRunsWindowMs,
 	type PublicCodeRunsWindow,
@@ -52,7 +53,16 @@ export async function refreshPublicCodeRunsWindow(input: {
 		const existingWindow = existing.window
 
 		const windowEndMs = Date.parse(existingWindow.windowEnd)
-		if (Number.isFinite(windowEndMs) && now.getTime() < windowEndMs) {
+		const beforeEnd =
+			Number.isFinite(windowEndMs) && now.getTime() < windowEndMs
+		const stillGrowing =
+			isStillPublicCodeRunsWindow(existingWindow) &&
+			total > existingWindow.current
+		// A still pair is a bootstrap (KV miss or first write). Holding it
+		// for 24h freezes the homepage ticker even while executes accrue.
+		// Live windows still hold until windowEnd so interpolation stays
+		// deterministic for every visitor.
+		if (beforeEnd && !stillGrowing) {
 			return { status: 'held' }
 		}
 

--- a/packages/worker/universal/code-runs.node.test.ts
+++ b/packages/worker/universal/code-runs.node.test.ts
@@ -4,6 +4,7 @@ import {
 	codeRunsCatchUpSnapAfterMs,
 	formatCodeRunsCount,
 	interpolateCodeRunsCount,
+	isStillPublicCodeRunsWindow,
 	msUntilNextCodeRunsCount,
 	nextDisplayedCodeRunsCount,
 	parsePublicCodeRunsWindow,
@@ -134,6 +135,10 @@ test('interpolateCodeRunsCount wobbles +1 ticks without long idle when the pair 
 	expect(
 		msUntilNextCodeRunsCount({ ...window, previous: 80, current: 80 }, nowMs),
 	).toBeNull()
+	expect(
+		isStillPublicCodeRunsWindow({ ...window, previous: 80, current: 80 }),
+	).toBe(true)
+	expect(isStillPublicCodeRunsWindow(window)).toBe(false)
 })
 
 test('interpolateCodeRunsCount rolls every extra integer inside a second', () => {

--- a/packages/worker/universal/code-runs.ts
+++ b/packages/worker/universal/code-runs.ts
@@ -19,6 +19,10 @@ export type PublicCodeRunsWindow = {
 	windowEnd: string
 }
 
+export function isStillPublicCodeRunsWindow(window: PublicCodeRunsWindow) {
+	return window.previous === window.current
+}
+
 export function parsePublicCodeRunsWindow(
 	value: unknown,
 ): PublicCodeRunsWindow | null {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Keep the public homepage ticker moving after a KV miss or first write, instead of holding a still `{ previous, current }` pair for 24 hours while executes keep accruing.

## Why

Production `GET /code-runs.json` is currently a still pair (`previous === current === 257940`). The client correctly returns `msUntilNextCodeRunsCount === null` when `delta === 0`, so the number never ticks.

That looks like a client animation bug, and it has been chased that way every time the ticker UI changed. The freeze is a **bootstrap KV hold**: `refreshPublicCodeRunsWindow` initializes `previous === current` when the key is missing, then used to hold that pair until `windowEnd` even if the fleet execute total grew. Homepage GET does not write KV; only the hourly `usage_aggregation` lane does.

## Summary

- Treat a still pair as bootstrap, not a live 24h window.
- If the pair is still and `total > current`, the next hourly refresh rotates it (`previous = old current`, `current = new total`, new 24h window).
- Live windows with a real delta still hold until `windowEnd` so interpolation stays deterministic for every visitor.
- Lock the contract in unit tests and document it in usage metering so the next ticker UI change does not get blamed for a still KV pair.

After this ships, the ticker starts moving on the next `usage_aggregation` run once the fleet execute total is above the still value.

## Testing

- `npx vitest run --project node-unit packages/worker/src/usage/code-runs-window.node.test.ts packages/worker/universal/code-runs.node.test.ts` — 6 passed.
- Locked: initialize still → hold if the total is unchanged → rotate when the total grows → hold a live window mid-window → rotate at `windowEnd`.
- Production evidence of the still pair: `GET https://kody.codes/code-runs.json` returned `{ previous: 257940, current: 257940, ... }`.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `485311ef` · **Head:** `638cf9f4`

**Classification:** extends — `usage-metering` refresh no longer holds a still bootstrap pair for 24h when the fleet execute total has grown. `app-ui` only documents that a still pair is not a client bug.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `usage-metering` | storage | extends — still windows rotate on growth instead of holding until `windowEnd` |
| `app-ui` | surfaces | composes — ticker comment only; interpolation unchanged |

### Change flow

Hourly `usage_aggregation` reads the KV window and the D1 execute sum. A still pair plus a higher total now rotates instead of holding.

```mermaid
sequenceDiagram
	participant usageAggregation as usage-aggregation
	participant usageMetering as usage-metering
	participant d1AppDb as d1-app-db
	participant kv as kv-namespaces
	participant appUi as app-ui
	usageAggregation->>usageMetering: refreshPublicCodeRunsWindow
	usageMetering->>d1AppDb: SUM(event_count) WHERE metric = execute
	usageMetering->>kv: get public-code-runs:v1
	alt still pair and total greater than current
		usageMetering->>kv: put rotated previous/current and new 24h window
	else live delta and before windowEnd
		Note over usageMetering: hold — interpolation stays deterministic
	end
	appUi->>kv: GET /code-runs.json reads the pair
	Note over appUi: still pair means no tick; live delta interpolates
```

### Before / after

**Before:** missing KV → write `{ previous: total, current: total }` → hold until `windowEnd` even if the execute sum grew.

**After:** same still bootstrap on first write; the next refresh with `total > current` rotates. Live windows with `previous !== current` still hold until `windowEnd`.

### Invariants

Public ticker remains an anonymous `SUM(event_count)` of `execute` rows. Homepage GET still does not write the KV key. The payload still never includes per-user rows.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9463cdc8-e51e-49e0-b132-c0801db40024?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9463cdc8-e51e-49e0-b132-c0801db40024&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

