### PR TITLE
Combine homepage loop play/pause into one icon control

### DIFF
--- a/packages/worker/client/routes/how-kody-works-transcript.node.test.ts
+++ b/packages/worker/client/routes/how-kody-works-transcript.node.test.ts
@@ -93,4 +93,11 @@ test('factory transcript covers ask, invoke, and a quiet daily email', () => {
 	expect(
 		agentLines.every((text) => !text.includes('New agent, same ask')),
 	).toBe(true)
+	expect(
+		agentLines.some((text) =>
+			text.includes(
+				'You now have `@you/kody-bot-shipped`. Ask again from any agent and I will invoke the export instead of walking GitHub by hand.',
+			),
+		),
+	).toBe(true)
 })

--- a/packages/worker/client/routes/how-kody-works-transcript.ts
+++ b/packages/worker/client/routes/how-kody-works-transcript.ts
@@ -746,7 +746,7 @@ export const howKodyWorksTranscriptActs: Array<TranscriptAct> = [
 			},
 			{
 				role: 'agent',
-				text: 'You now have `kody-bot-shipped`. Ask again from any agent and I will invoke the export instead of walking GitHub by hand.',
+				text: 'You now have `@you/kody-bot-shipped`. Ask again from any agent and I will invoke the export instead of walking GitHub by hand.',
 			},
 		],
 	},

--- a/packages/worker/client/routes/landing-loop-player.node.test.ts
+++ b/packages/worker/client/routes/landing-loop-player.node.test.ts
@@ -187,7 +187,7 @@ test('homepage loop player pauses for hover and explore, then play resumes and r
 	}
 })
 
-test('homepage loop toggle keeps Pause on the teaser so first paint does not shift', () => {
+test('homepage loop toggle defaults to Pause so the combined icon control can paint on the teaser', () => {
 	expect(
 		landingLoopToggleLabel({
 			reducedMotion: false,

--- a/packages/worker/client/routes/landing-loop-player.node.test.ts
+++ b/packages/worker/client/routes/landing-loop-player.node.test.ts
@@ -8,6 +8,7 @@ import {
 	landingLoopHoldMs,
 	landingLoopTeaser,
 	landingLoopTeaserBeatCount,
+	landingLoopToggleLabel,
 	waitLandingLoopHold,
 } from './landing-loop-state.ts'
 
@@ -184,4 +185,35 @@ test('homepage loop player pauses for hover and explore, then play resumes and r
 	} finally {
 		vi.useRealTimers()
 	}
+})
+
+test('homepage loop toggle keeps Pause on the teaser so first paint does not shift', () => {
+	expect(
+		landingLoopToggleLabel({
+			reducedMotion: false,
+			ended: false,
+			paused: false,
+		}),
+	).toBe('Pause')
+	expect(
+		landingLoopToggleLabel({
+			reducedMotion: false,
+			ended: false,
+			paused: true,
+		}),
+	).toBe('Play')
+	expect(
+		landingLoopToggleLabel({
+			reducedMotion: false,
+			ended: true,
+			paused: true,
+		}),
+	).toBe('Restart')
+	expect(
+		landingLoopToggleLabel({
+			reducedMotion: true,
+			ended: false,
+			paused: false,
+		}),
+	).toBeNull()
 })

--- a/packages/worker/client/routes/landing-loop-player.tsx
+++ b/packages/worker/client/routes/landing-loop-player.tsx
@@ -19,6 +19,7 @@ import {
 	waitLandingLoopHold,
 	type LandingLoopBeat,
 	type LandingLoopSceneGroup,
+	type LandingLoopToggleLabel,
 } from './landing-loop-state.ts'
 
 type LoopLineRenderer = (line: TranscriptLine) => RemixNode
@@ -30,11 +31,12 @@ type LoopLineRenderer = (line: TranscriptLine) => RemixNode
  * it does not block first paint or the first beats. Hover/focus (fine
  * pointers) and explore (scroll up or open a tool) pause the autoplay;
  * Play scrolls to the latest beat and continues. The last beat pauses
- * and offers Restart instead of looping. Pause is painted on the SSR
- * teaser so the header does not shift when the transcript chunk loads.
- * A reserved toggle slot keeps that height if reduced-motion later
- * hides the button. The phone act is a later scene in the same card
- * — a time skip plus device chrome, not a reset.
+ * and offers Restart instead of looping. One header control is both
+ * the playing indicator and play/pause (icons, not words). SSR paints
+ * Pause so the header does not shift when the transcript chunk loads.
+ * A reserved slot keeps that size if reduced-motion later hides it.
+ * The phone act is a later scene in the same card — a time skip plus
+ * device chrome, not a reset.
  */
 export function LandingLoopPlayer(handle: Handle) {
 	let beats: Array<LandingLoopBeat> | null = null
@@ -268,23 +270,12 @@ export function LandingLoopPlayer(handle: Handle) {
 				]}
 			>
 				<div class="landing-loop-head">
-					<p class="landing-loop-status" aria-hidden="true">
-						<span class="landing-loop-status-dot"></span>
-						{reducedMotion
-							? 'The loop'
-							: ended
-								? 'The loop'
-								: paused
-									? 'Paused'
-									: loaded
-										? 'Playing'
-										: 'The loop'}
-					</p>
 					<span class="landing-loop-toggle-slot">
 						{toggleLabel ? (
 							<button
 								type="button"
 								class="landing-loop-toggle"
+								aria-label={toggleLabel}
 								mix={on('click', () => {
 									if (player.isEnded()) restartFromStart()
 									else if (player.isPaused() || heldPause) playFromHere()
@@ -295,7 +286,8 @@ export function LandingLoopPlayer(handle: Handle) {
 									}
 								})}
 							>
-								{toggleLabel}
+								<span class="landing-loop-status-dot"></span>
+								{renderLoopToggleIcon(toggleLabel)}
 							</button>
 						) : null}
 					</span>
@@ -480,4 +472,55 @@ function renderTeaser() {
 			</figure>
 		</>
 	)
+}
+
+function renderLoopToggleIcon(label: LandingLoopToggleLabel) {
+	switch (label) {
+		case 'Pause':
+			return (
+				<svg
+					viewBox="0 0 24 24"
+					width="1em"
+					height="1em"
+					aria-hidden="true"
+					fill="currentColor"
+				>
+					<rect x="6" y="5" width="4.5" height="14" rx="1" />
+					<rect x="13.5" y="5" width="4.5" height="14" rx="1" />
+				</svg>
+			)
+		case 'Play':
+			return (
+				<svg
+					viewBox="0 0 24 24"
+					width="1em"
+					height="1em"
+					aria-hidden="true"
+					fill="currentColor"
+				>
+					<path d="M8 5.5v13l11-6.5-11-6.5Z" />
+				</svg>
+			)
+		case 'Restart':
+			return (
+				<svg
+					viewBox="0 0 24 24"
+					width="1em"
+					height="1em"
+					aria-hidden="true"
+					fill="none"
+					stroke="currentColor"
+					stroke-width="2"
+					stroke-linecap="round"
+					stroke-linejoin="round"
+				>
+					<path d="M4.5 12a7.5 7.5 0 1 0 2.2-5.3" />
+					<path d="M4.5 4.5v5h5" />
+				</svg>
+			)
+		default: {
+			const exhaustive: never = label
+			return exhaustive
+		}
+	}
 }

--- a/packages/worker/client/routes/landing-loop-player.tsx
+++ b/packages/worker/client/routes/landing-loop-player.tsx
@@ -15,6 +15,7 @@ import {
 	landingLoopChatScrollShouldExplore,
 	landingLoopHoldMs,
 	landingLoopTeaser,
+	landingLoopToggleLabel,
 	waitLandingLoopHold,
 	type LandingLoopBeat,
 	type LandingLoopSceneGroup,
@@ -29,8 +30,10 @@ type LoopLineRenderer = (line: TranscriptLine) => RemixNode
  * it does not block first paint or the first beats. Hover/focus (fine
  * pointers) and explore (scroll up or open a tool) pause the autoplay;
  * Play scrolls to the latest beat and continues. The last beat pauses
- * and offers Restart instead of looping. The phone act is a later scene
- * in the same card — a time skip plus device chrome, not a reset.
+ * and offers Restart instead of looping. Pause is painted on the SSR
+ * teaser so the header does not shift when the transcript chunk loads.
+ * The phone act is a later scene in the same card — a time skip plus
+ * device chrome, not a reset.
  */
 export function LandingLoopPlayer(handle: Handle) {
 	let beats: Array<LandingLoopBeat> | null = null
@@ -43,6 +46,7 @@ export function LandingLoopPlayer(handle: Handle) {
 	let chatUserDriven = false
 	let playGeneration = 0
 	let loadStarted = false
+	let heldPause = false
 	let loopEl: HTMLElement | null = null
 	let visibleInViewport = true
 
@@ -92,6 +96,7 @@ export function LandingLoopPlayer(handle: Handle) {
 				beatCount: beats.length,
 				reducedMotion,
 			})
+			if (heldPause) player.pause()
 			syncVisibility()
 			if (!reducedMotion && !player.isPaused()) startPlayLoop()
 			handle.update()
@@ -150,6 +155,7 @@ export function LandingLoopPlayer(handle: Handle) {
 	}
 
 	function playFromHere() {
+		heldPause = false
 		chatUserDriven = false
 		player.play()
 		handle.update()
@@ -160,6 +166,7 @@ export function LandingLoopPlayer(handle: Handle) {
 	}
 
 	function restartFromStart() {
+		heldPause = false
 		chatUserDriven = false
 		player.restart()
 		handle.update()
@@ -194,9 +201,15 @@ export function LandingLoopPlayer(handle: Handle) {
 		const loaded = visibleBeats != null && lineRenderer != null
 		const ended = loaded && player.isEnded() && !reducedMotion
 		const userPaused =
-			loaded && player.pauseReasons().some((reason) => reason !== 'offscreen')
+			heldPause ||
+			player.pauseReasons().some((reason) => reason !== 'offscreen')
 		const paused = userPaused && !reducedMotion
-		const playing = loaded && !player.isPaused() && !reducedMotion
+		const playing = loaded && !player.isPaused() && !reducedMotion && !heldPause
+		const toggleLabel = landingLoopToggleLabel({
+			reducedMotion,
+			ended,
+			paused,
+		})
 
 		return (
 			<div
@@ -266,22 +279,23 @@ export function LandingLoopPlayer(handle: Handle) {
 										? 'Playing'
 										: 'The loop'}
 					</p>
-					{reducedMotion || !loaded || !(playing || paused) ? null : (
+					{toggleLabel ? (
 						<button
 							type="button"
 							class="landing-loop-toggle"
 							mix={on('click', () => {
 								if (player.isEnded()) restartFromStart()
-								else if (player.isPaused()) playFromHere()
+								else if (player.isPaused() || heldPause) playFromHere()
 								else {
+									heldPause = true
 									player.pause()
 									handle.update()
 								}
 							})}
 						>
-							{ended ? 'Restart' : paused ? 'Play' : 'Pause'}
+							{toggleLabel}
 						</button>
-					)}
+					) : null}
 				</div>
 				<div
 					class="landing-loop-chat"

--- a/packages/worker/client/routes/landing-loop-player.tsx
+++ b/packages/worker/client/routes/landing-loop-player.tsx
@@ -32,8 +32,9 @@ type LoopLineRenderer = (line: TranscriptLine) => RemixNode
  * Play scrolls to the latest beat and continues. The last beat pauses
  * and offers Restart instead of looping. Pause is painted on the SSR
  * teaser so the header does not shift when the transcript chunk loads.
- * The phone act is a later scene in the same card — a time skip plus
- * device chrome, not a reset.
+ * A reserved toggle slot keeps that height if reduced-motion later
+ * hides the button. The phone act is a later scene in the same card
+ * — a time skip plus device chrome, not a reset.
  */
 export function LandingLoopPlayer(handle: Handle) {
 	let beats: Array<LandingLoopBeat> | null = null
@@ -279,23 +280,25 @@ export function LandingLoopPlayer(handle: Handle) {
 										? 'Playing'
 										: 'The loop'}
 					</p>
-					{toggleLabel ? (
-						<button
-							type="button"
-							class="landing-loop-toggle"
-							mix={on('click', () => {
-								if (player.isEnded()) restartFromStart()
-								else if (player.isPaused() || heldPause) playFromHere()
-								else {
-									heldPause = true
-									player.pause()
-									handle.update()
-								}
-							})}
-						>
-							{toggleLabel}
-						</button>
-					) : null}
+					<span class="landing-loop-toggle-slot">
+						{toggleLabel ? (
+							<button
+								type="button"
+								class="landing-loop-toggle"
+								mix={on('click', () => {
+									if (player.isEnded()) restartFromStart()
+									else if (player.isPaused() || heldPause) playFromHere()
+									else {
+										heldPause = true
+										player.pause()
+										handle.update()
+									}
+								})}
+							>
+								{toggleLabel}
+							</button>
+						) : null}
+					</span>
 				</div>
 				<div
 					class="landing-loop-chat"

--- a/packages/worker/client/routes/landing-loop-state.ts
+++ b/packages/worker/client/routes/landing-loop-state.ts
@@ -13,6 +13,24 @@ export const landingLoopTeaser = {
 /** Act header plus the first user turn — matches the SSR teaser. */
 export const landingLoopTeaserBeatCount = 2
 
+export type LandingLoopToggleLabel = 'Restart' | 'Play' | 'Pause'
+
+/**
+ * Header control for the factory loop. Pause is the default — including
+ * before the transcript chunk loads — so SSR reserves the button and
+ * first paint does not shift when playback starts.
+ */
+export function landingLoopToggleLabel(input: {
+	reducedMotion: boolean
+	ended: boolean
+	paused: boolean
+}): LandingLoopToggleLabel | null {
+	if (input.reducedMotion) return null
+	if (input.ended) return 'Restart'
+	if (input.paused) return 'Play'
+	return 'Pause'
+}
+
 export type LandingLoopPauseReason =
 	| 'hover'
 	| 'focus'

--- a/packages/worker/client/routes/landing-loop-state.ts
+++ b/packages/worker/client/routes/landing-loop-state.ts
@@ -17,8 +17,8 @@ export type LandingLoopToggleLabel = 'Restart' | 'Play' | 'Pause'
 
 /**
  * Header control for the factory loop. Pause is the default — including
- * before the transcript chunk loads — so SSR reserves the button and
- * first paint does not shift when playback starts.
+ * before the transcript chunk loads — so SSR reserves the combined
+ * playing/pause control and first paint does not shift.
  */
 export function landingLoopToggleLabel(input: {
 	reducedMotion: boolean

--- a/packages/worker/public/styles.css
+++ b/packages/worker/public/styles.css
@@ -1157,6 +1157,7 @@ html.is-settled {
 }
 
 .landing-loop-head {
+	justify-content: flex-end;
 	border-bottom: 1px solid var(--color-border);
 }
 
@@ -1169,16 +1170,10 @@ html.is-settled {
 	font-weight: 600;
 }
 
-.landing-loop-status {
-	display: flex;
-	align-items: center;
-	gap: 0.45rem;
-	margin: 0;
-}
-
 .landing-loop-status-dot {
 	width: 0.5rem;
 	height: 0.5rem;
+	flex: 0 0 auto;
 	border-radius: 50%;
 	background: var(--color-text-muted);
 	box-shadow: 0 0 0 3px
@@ -1191,23 +1186,27 @@ html.is-settled {
 		color-mix(in oklch, var(--color-primary) 22%, transparent);
 }
 
-.landing-loop[data-paused] .landing-loop-status-dot {
+.landing-loop[data-paused] .landing-loop-status-dot,
+.landing-loop[data-ended] .landing-loop-status-dot {
 	background: var(--color-text-muted);
 	box-shadow: none;
 }
 
 .landing-loop-toggle {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	gap: 0.45rem;
 	margin: 0;
-	padding: 0.45rem 0.9rem;
+	padding: 0.45rem 0.7rem;
 	min-height: 2.25rem;
-	min-width: 4.75rem;
+	min-width: 3.5rem;
 	border: 1px solid var(--color-border);
 	border-radius: var(--radius-full);
 	background: var(--color-surface);
 	color: var(--color-text);
-	font: 650 0.78rem/1 var(--font-display);
-	letter-spacing: 0.04em;
-	text-transform: uppercase;
+	font-size: 0.95rem;
+	line-height: 1;
 	cursor: pointer;
 }
 
@@ -1218,7 +1217,7 @@ html.is-settled {
 	align-items: center;
 	justify-content: center;
 	min-height: 2.25rem;
-	min-width: 4.75rem;
+	min-width: 3.5rem;
 	flex: 0 0 auto;
 }
 

--- a/packages/worker/public/styles.css
+++ b/packages/worker/public/styles.css
@@ -1211,6 +1211,17 @@ html.is-settled {
 	cursor: pointer;
 }
 
+/* Same box as the control so reduced-motion can drop the button
+   without shrinking the header. */
+.landing-loop-toggle-slot {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	min-height: 2.25rem;
+	min-width: 4.75rem;
+	flex: 0 0 auto;
+}
+
 .landing-loop-toggle:hover,
 .landing-loop-toggle:focus-visible {
 	border-color: color-mix(

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -768,13 +768,14 @@ test('renderAppPage embeds the homepage factory-loop conversation teaser', async
 	expect(html).toContain('/guides/how-kody-works')
 	expect(html).toContain('Read the walkthrough')
 	expect(html).not.toContain('See the whole loop')
-	// Pause is on the teaser so the header does not shift when playback starts.
-	// The slot stays even if reduced-motion later hides the button.
+	// Combined playing/pause control is on the teaser so the header does
+	// not shift when playback starts. Icons, not the word Pause.
 	expect(html).toContain('class="landing-loop-toggle-slot"')
 	expect(html).toContain('class="landing-loop-toggle"')
-	expect(html).toMatch(
-		/<button[^>]*class="landing-loop-toggle"[^>]*>\s*Pause\s*<\/button>/,
-	)
+	expect(html).toContain('aria-label="Pause"')
+	expect(html).toContain('class="landing-loop-status-dot"')
+	expect(html).not.toContain('>Playing<')
+	expect(html).not.toContain('>Pause<')
 })
 
 test('signup social buttons are icon-only with accessible names', async () => {

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -768,6 +768,11 @@ test('renderAppPage embeds the homepage factory-loop conversation teaser', async
 	expect(html).toContain('/guides/how-kody-works')
 	expect(html).toContain('Read the walkthrough')
 	expect(html).not.toContain('See the whole loop')
+	// Pause is on the teaser so the header does not shift when playback starts.
+	expect(html).toContain('class="landing-loop-toggle"')
+	expect(html).toMatch(
+		/<button[^>]*class="landing-loop-toggle"[^>]*>\s*Pause\s*<\/button>/,
+	)
 })
 
 test('signup social buttons are icon-only with accessible names', async () => {

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -769,6 +769,8 @@ test('renderAppPage embeds the homepage factory-loop conversation teaser', async
 	expect(html).toContain('Read the walkthrough')
 	expect(html).not.toContain('See the whole loop')
 	// Pause is on the teaser so the header does not shift when playback starts.
+	// The slot stays even if reduced-motion later hides the button.
+	expect(html).toContain('class="landing-loop-toggle-slot"')
 	expect(html).toContain('class="landing-loop-toggle"')
 	expect(html).toMatch(
 		/<button[^>]*class="landing-loop-toggle"[^>]*>\s*Pause\s*<\/button>/,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Keep the homepage factory-loop header stable, and make play/pause one control instead of a status label plus a separate button.

## Why

Pause appeared only after the transcript chunk loaded, so the header shifted (CLS). A later Playing label plus Pause pill still read as two controls. Reduced-motion then hid the button after load and shrank the header again. The closing agent line also omitted the `@you/` prefix.

## Summary

- One reserved header button is both the playing indicator (status dot) and the action (pause / play / restart icons).
- SSR paints that Pause control on the teaser so the header does not wait for the transcript chunk.
- A same-size slot stays if reduced-motion later hides the button.
- A Pause tap before load is kept when the chunk arrives.
- Closing copy uses `` `@you/kody-bot-shipped` ``.

## Testing

- Unit + SSR teaser tests: combined control has `aria-label="Pause"`, the status dot, and no Playing / Pause text.
- Preview first paint previously had no Pause; this branch paints the icon control in a reserved slot.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `485311ef` · **Head:** `256f5020`

**Classification:** composes — no primitive behavior or contract change. The factory-loop header is one reserved icon control, and walkthrough copy matches `@you/kody-bot-shipped`.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | composes — combined loop control, reserved slot, transcript copy |

### Change flow

SSR paints a Pause icon button with a status dot. The transcript chunk can still load later; a pre-load pause is applied to the real player.

```mermaid
sequenceDiagram
	actor Visitor
	participant appUi as app-ui
	Visitor->>appUi: GET /
	appUi-->>Visitor: teaser HTML with Pause icon in a reserved slot
	Note over appUi: landingLoopToggleLabel defaults to Pause
	appUi->>appUi: near-viewport loads transcript chunk
	alt visitor already tapped Pause
		appUi->>appUi: heldPause applied; Play icon
	else prefers-reduced-motion
		appUi->>appUi: hide the button, keep the slot
	else autoplay
		appUi->>appUi: playing dot plus Pause icon
	end
```

### Before / after

**Before:** status text on the left (`Playing`) and a labeled Pause / Play / Restart pill on the right.

**After:** one right-aligned button with the status dot and an icon. Reduced-motion keeps the empty slot. Closing agent line uses `` `@you/kody-bot-shipped` ``.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9463cdc8-e51e-49e0-b132-c0801db40024?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9463cdc8-e51e-49e0-b132-c0801db40024&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved landing-page playback controls with clearer Play, Pause, and Restart states.
  * Playback pauses persist while transcript content loads and can be resumed or restarted.
  * Reduced-motion settings preserve page layout while hiding playback controls.
  * Updated playback controls with accessible labels, status indicators, and icons.
  * Updated transcript messaging to reference the scoped package name.

* **Tests**
  * Added coverage for playback states, transcript messaging, and homepage rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->