### PR TITLE
Use the worker domain for transactional email From and links

### DIFF
--- a/docs/contributing/environment-variables.md
+++ b/docs/contributing/environment-variables.md
@@ -350,9 +350,12 @@ Optional Worker secrets/vars (see `packages/worker/src/env-schema.ts` and
 - `SYSTEM_EMAIL_DOMAIN` — optional override for the system email domain (the
   `kody@<domain>` transactional sender and operator system inboxes). Defaults to
   the `APP_BASE_URL` hostname. Production commits
-  `SYSTEM_EMAIL_DOMAIN=kody.codes`. Signup, email-change, and password-reset
-  messages also put this host on their action and asset links. Local
-  `npm run dev` keeps those links on the request origin so they stay clickable.
+  `SYSTEM_EMAIL_DOMAIN=kody.codes`. Signup, email-change, password-reset, and
+  entitlement-warning messages send from that host and put action and asset
+  links on the worker origin (`APP_BASE_URL`). A leftover `heykody.app` /
+  `heykody.dev` worker origin remaps both From and links to this override (or
+  `kody.codes` when the override is also retired). Local `npm run dev` keeps
+  those links on the request origin so they stay clickable.
 - `LEGACY_USER_EMAIL_DOMAINS` / `LEGACY_SYSTEM_EMAIL_DOMAINS` — optional
   comma-separated additional email domains that inbound mail is accepted on
   alongside the canonical domains (see

--- a/docs/contributing/setup.md
+++ b/docs/contributing/setup.md
@@ -46,11 +46,12 @@ Quick notes for getting a local kody environment running.
   clone/pull/push flows need a real Git-capable Artifacts remote and are not
   fully simulated by the local mock. Password reset and email-verification
   messages send through the same Cloudflare Email API helper. Both send from
-  `kody@<SYSTEM_EMAIL_DOMAIN>` (falling back to the `APP_BASE_URL` hostname) and
-  put that same sending domain on action and asset links, so a legacy
-  `APP_BASE_URL` cannot pin `heykody.dev` into the message. Local `npm run dev`
-  keeps those action and asset links on the request origin so they stay
-  clickable. Set `SKIP_CLOUDFLARE_MOCK=1` to skip the local Cloudflare mock
+  `kody@<SYSTEM_EMAIL_DOMAIN>` (falling back to the worker's `APP_BASE_URL`
+  hostname) and put action and asset links on that worker origin. A leftover
+  `heykody.app` / `heykody.dev` origin remaps to `SYSTEM_EMAIL_DOMAIN` when set,
+  otherwise `kody.codes`, so live mail cannot keep the retired hosts. Local
+  `npm run dev` keeps those action and asset links on the request origin so they
+  stay clickable. Set `SKIP_CLOUDFLARE_MOCK=1` to skip the local Cloudflare mock
   entirely. The main worker streams logs live; the client bundle and background
   mock workers buffer logs and only print them if that child process exits with
   an error.

--- a/packages/worker/src/app/email/sender-config.node.test.ts
+++ b/packages/worker/src/app/email/sender-config.node.test.ts
@@ -1,7 +1,28 @@
 import { expect, test } from 'vitest'
 import { resolveTransactionalEmailConfig } from './sender-config.ts'
 
-test('resolveTransactionalEmailConfig derives link hosts from the sending domain', () => {
+test('resolveTransactionalEmailConfig follows the worker origin and remaps leftover heykody hosts', () => {
+	expect(
+		resolveTransactionalEmailConfig({
+			env: {
+				APP_BASE_URL: 'https://kody.codes',
+				SYSTEM_EMAIL_DOMAIN: 'kody.codes',
+			},
+		}),
+	).toEqual({
+		appBaseUrl: 'https://kody.codes',
+		fromEmail: 'kody@kody.codes',
+	})
+
+	expect(
+		resolveTransactionalEmailConfig({
+			env: { APP_BASE_URL: 'https://heykody.app/' },
+		}),
+	).toEqual({
+		appBaseUrl: 'https://kody.codes',
+		fromEmail: 'kody@kody.codes',
+	})
+
 	expect(
 		resolveTransactionalEmailConfig({
 			env: {
@@ -17,23 +38,23 @@ test('resolveTransactionalEmailConfig derives link hosts from the sending domain
 
 	expect(
 		resolveTransactionalEmailConfig({
+			env: {
+				APP_BASE_URL: 'https://kody-pr-1708.example.workers.dev',
+				SYSTEM_EMAIL_DOMAIN: 'kody.codes',
+			},
+		}),
+	).toEqual({
+		appBaseUrl: 'https://kody-pr-1708.example.workers.dev',
+		fromEmail: 'kody@kody.codes',
+	})
+
+	expect(
+		resolveTransactionalEmailConfig({
 			env: { APP_BASE_URL: 'https://app.example.com/path' },
 		}),
 	).toEqual({
 		appBaseUrl: 'https://app.example.com',
 		fromEmail: 'kody@app.example.com',
-	})
-
-	expect(
-		resolveTransactionalEmailConfig({
-			env: {
-				APP_BASE_URL: 'https://kody.codes',
-				SYSTEM_EMAIL_DOMAIN: 'kody.codes',
-			},
-		}),
-	).toEqual({
-		appBaseUrl: 'https://kody.codes',
-		fromEmail: 'kody@kody.codes',
 	})
 
 	expect(

--- a/packages/worker/src/app/email/sender-config.ts
+++ b/packages/worker/src/app/email/sender-config.ts
@@ -1,8 +1,11 @@
+import { getCanonicalAppBaseUrl } from '#worker/app-base-url.ts'
+import { parseLegacyHosts } from '#worker/app-legacy-redirect.ts'
 import { getSystemEmailDomain } from '#worker/email/platform-address.ts'
 
 export type TransactionalEmailEnv = {
 	APP_BASE_URL?: string | null
 	SYSTEM_EMAIL_DOMAIN?: string | null
+	LEGACY_SYSTEM_EMAIL_DOMAINS?: string | null
 	WRANGLER_IS_LOCAL_DEV?: string
 }
 
@@ -13,6 +16,12 @@ export type TransactionalEmailConfig = {
 	fromEmail: string
 }
 
+const canonicalPublicOrigin = 'https://kody.codes'
+const bakedInLegacyOutboundHosts: ReadonlyArray<string> = [
+	'heykody.app',
+	'heykody.dev',
+]
+
 function tryOrigin(value: string | URL | null | undefined) {
 	if (value == null || value === '') return null
 	try {
@@ -22,38 +31,59 @@ function tryOrigin(value: string | URL | null | undefined) {
 	}
 }
 
+function isLegacyOutboundHost(hostname: string, env: TransactionalEmailEnv) {
+	const host = hostname.toLowerCase()
+	if (bakedInLegacyOutboundHosts.includes(host)) {
+		return true
+	}
+	return parseLegacyHosts(env.LEGACY_SYSTEM_EMAIL_DOMAINS).includes(host)
+}
+
+function remapOutboundHost(hostname: string, env: TransactionalEmailEnv) {
+	if (!isLegacyOutboundHost(hostname, env)) return hostname
+	const systemDomain = getSystemEmailDomain(env)
+	if (systemDomain && !isLegacyOutboundHost(systemDomain, env)) {
+		return systemDomain
+	}
+	return new URL(canonicalPublicOrigin).hostname
+}
+
 /**
- * Resolve the From address and link origin for signup, email-change, and
- * password-reset mail.
+ * Resolve the From address and link origin for signup, email-change,
+ * password-reset, and entitlement-warning mail.
  *
- * From always follows the sending domain (`SYSTEM_EMAIL_DOMAIN`, else the
- * `APP_BASE_URL` hostname). Link hosts follow that same domain so a legacy
- * `APP_BASE_URL` or dual-served host cannot pin `heykody.dev` into the
- * message. Local `npm run dev` keeps clickable links on the request origin
- * so signup still works against localhost.
+ * From follows `SYSTEM_EMAIL_DOMAIN` when set, otherwise the worker hostname
+ * (`APP_BASE_URL`, else the request host). Links follow that worker origin
+ * so preview mail points at the preview worker. A leftover `heykody.app` /
+ * `heykody.dev` origin — or any `LEGACY_SYSTEM_EMAIL_DOMAINS` host — remaps
+ * both From and links to `SYSTEM_EMAIL_DOMAIN` when that override is a
+ * current host, otherwise `kody.codes`. Local `npm run dev` keeps clickable
+ * links on the request origin so signup still works against localhost.
  */
 export function resolveTransactionalEmailConfig(input: {
 	env: TransactionalEmailEnv
 	requestUrl?: string | URL | null
 }): TransactionalEmailConfig | null {
-	const systemDomain = getSystemEmailDomain(input.env)
 	const requestOrigin = tryOrigin(input.requestUrl)
 	const configuredOrigin = tryOrigin(input.env.APP_BASE_URL?.trim())
-	const fallbackOrigin = configuredOrigin ?? requestOrigin
-	const fromHost =
-		systemDomain ?? (fallbackOrigin ? new URL(fallbackOrigin).hostname : null)
-	if (!fromHost) return null
+	const systemDomain = getSystemEmailDomain(input.env)
+	if (!configuredOrigin && !requestOrigin && !systemDomain) return null
+
+	const workerOrigin = getCanonicalAppBaseUrl({
+		env: input.env,
+		requestUrl: input.requestUrl,
+	})
+	const workerHost = new URL(workerOrigin).hostname
+	const fromHost = remapOutboundHost(systemDomain ?? workerHost, input.env)
 
 	const fromEmail = `kody@${fromHost}`
 	if (input.env.WRANGLER_IS_LOCAL_DEV === 'true') {
 		const localOrigin = requestOrigin ?? configuredOrigin
 		if (localOrigin) return { appBaseUrl: localOrigin, fromEmail }
 	}
-	if (fallbackOrigin && new URL(fallbackOrigin).hostname === fromHost) {
-		return { appBaseUrl: fallbackOrigin, fromEmail }
-	}
-	if (systemDomain) {
-		return { appBaseUrl: `https://${systemDomain}`, fromEmail }
-	}
-	return fallbackOrigin ? { appBaseUrl: fallbackOrigin, fromEmail } : null
+
+	const linkHost = remapOutboundHost(workerHost, input.env)
+	const appBaseUrl =
+		linkHost === workerHost ? workerOrigin : `https://${linkHost}`
+	return { appBaseUrl, fromEmail }
 }

--- a/packages/worker/src/app/user-entitlement-warning-emails.node.test.ts
+++ b/packages/worker/src/app/user-entitlement-warning-emails.node.test.ts
@@ -86,7 +86,7 @@ function createEnv(input: {
 }) {
 	return {
 		APP_DB: createDb(input.users),
-		APP_BASE_URL: 'https://heykody.dev/',
+		APP_BASE_URL: 'https://kody.codes/',
 		CLOUDFLARE_ACCOUNT_ID: 'acct',
 		CLOUDFLARE_API_TOKEN: 'token',
 		BUNDLE_ARTIFACTS_KV: input.kv,
@@ -144,17 +144,17 @@ test('user entitlement warnings send one 80% email and one 100% email per UTC da
 		text: string
 	}
 	expect(approachingPayload.to).toBe('jelias@example.com')
-	expect(approachingPayload.from).toBe('kody@heykody.dev')
+	expect(approachingPayload.from).toBe('kody@kody.codes')
 	expect(approachingPayload.subject).toContain('approaching')
 	expect(approachingPayload.html).toContain(
-		'https://heykody.dev/account/billing',
+		'https://kody.codes/account/billing',
 	)
-	expect(approachingPayload.text).toContain('https://heykody.dev/account/usage')
+	expect(approachingPayload.text).toContain('https://kody.codes/account/usage')
 	expect(approachingPayload.html).toContain('execute calls per day')
 	expect(approachingPayload.html).toContain('saved packages')
 	expect(approachingPayload.html).not.toContain('secrets')
 	expect(approachingPayload.html).toContain(
-		'https://heykody.dev/images/kody-lantern.png',
+		'https://kody.codes/images/kody-lantern.png',
 	)
 
 	const approachingKey = userEntitlementWarningKvKey({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Live entitlement and auth mail should come from the worker's public origin, not a leftover `heykody.app` / `heykody.dev` `APP_BASE_URL`.

## Why

A stale worker origin still leaked into From and action/asset links when `SYSTEM_EMAIL_DOMAIN` was unset. Production should send `kody@kody.codes` with `https://kody.codes/…` links. Preview should keep links on the preview worker.

## Summary

- `resolveTransactionalEmailConfig` follows `APP_BASE_URL` (the worker origin) for links
- From stays `kody@SYSTEM_EMAIL_DOMAIN` when that override is set
- `heykody.app` / `heykody.dev` (and `LEGACY_SYSTEM_EMAIL_DOMAINS`) remap both From and links to `SYSTEM_EMAIL_DOMAIN`, or `kody.codes`
- Entitlement-warning tests now assert `kody.codes`

## Testing

Focused node-unit: sender-config, entitlement-warning emails, password-reset, email template (8 passed).

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `34cdc2c8` · **Head:** `e0930a08`

**Classification:** extends — transactional From and link hosts change when the worker origin is a retired heykody host.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | extends — `resolveTransactionalEmailConfig` remaps leftover heykody hosts |

### Change flow

Scheduled entitlement warnings and request-scoped auth mail resolve From and links from the worker origin, remapping retired heykody hosts to `kody.codes`.

```mermaid
sequenceDiagram
	participant scheduledCron as scheduled-cron
	participant appUi as app-ui
	scheduledCron->>appUi: usage_entitlement_alert send
	appUi->>appUi: resolveTransactionalEmailConfig from APP_BASE_URL
	Note over appUi: heykody.app/dev remap to kody.codes
	appUi->>appUi: From kody@worker-or-system host plus matching links
```

### Before / after

```text
APP_BASE_URL=https://heykody.app (no SYSTEM_EMAIL_DOMAIN)
  From/links: kody@heykody.app / https://heykody.app/…
  → kody@kody.codes / https://kody.codes/…

APP_BASE_URL=https://kody-pr-N.example.workers.dev SYSTEM_EMAIL_DOMAIN=kody.codes
  From: kody@kody.codes
  Links: preview worker origin
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3309b591-bf0e-47db-a850-1e0b3cacebce?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3309b591-bf0e-47db-a850-1e0b3cacebce&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated transactional and entitlement-warning emails to use the canonical system domain.
  * Ensured email action, billing, usage, and asset links point to the correct application URL.
  * Remapped legacy application domains while preserving local-development request links.
  * Removed URL paths when deriving application hosts for email links.

* **Documentation**
  * Clarified email-domain, link-generation, and local-development behavior in setup and contribution guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->