### PR TITLE
Prefer 2026-07-28 on outbound MCP client connections

### DIFF
--- a/docs/contributing/architecture/mcp-client-servers.md
+++ b/docs/contributing/architecture/mcp-client-servers.md
@@ -37,12 +37,15 @@ the `/mcp` endpoint (where Kody is the server) and complements MCP servers
   `requestInit.headers` still win. Outbound connections prefer MCP `2026-07-28`
   (`server/discover`) and fall back to the 2025 `initialize` handshake only when
   the remote server is actually 2025-era. Restore and reconnect drop persisted
-  2025 `sessionId` / `protocolVersion` / `discoverResult` values so a stored
-  2025 session cannot skip the modern probe or DELETE a session against a
-  modern-only server (`packages/worker/src/mcp-client/restore.ts`,
-  `packages/worker/src/mcp-client/reconnect.ts`). Header-mismatch and
-  unauthenticated probe outcomes are not persisted as a legacy verdict; after
-  OAuth the hub retries `server/discover` with the token.
+  2025 `sessionId` / `protocolVersion` / `discoverResult` values and rewrite
+  stored `client.versionNegotiation` to `{ mode: 'auto' }` so a stored 2025
+  session or a persisted `legacy` negotiation mode cannot skip the modern
+  probe or DELETE a session against a modern-only server
+  (`packages/worker/src/mcp-client/restore.ts`,
+  `packages/worker/src/mcp-client/reconnect.ts`). Header-mismatch,
+  unauthenticated, and `-32022` UnsupportedProtocolVersion probe outcomes are
+  not a 2025 verdict; after OAuth the hub retries `server/discover` with the
+  token.
 
 ## OAuth flow
 

--- a/docs/contributing/architecture/mcp-client-servers.md
+++ b/docs/contributing/architecture/mcp-client-servers.md
@@ -34,7 +34,15 @@ the `/mcp` endpoint (where Kody is the server) and complements MCP servers
   `registerServer`, the hub copies those static `transport.headers` into
   `transport.requestInit.headers` so outbound fetches send them
   (`packages/worker/src/mcp-client/transport-headers.ts`); explicit
-  `requestInit.headers` still win.
+  `requestInit.headers` still win. Outbound connections prefer MCP `2026-07-28`
+  (`server/discover`) and fall back to the 2025 `initialize` handshake only when
+  the remote server is actually 2025-era. Restore and reconnect drop persisted
+  2025 `sessionId` / `protocolVersion` / `discoverResult` values so a stored
+  2025 session cannot skip the modern probe or DELETE a session against a
+  modern-only server (`packages/worker/src/mcp-client/restore.ts`,
+  `packages/worker/src/mcp-client/reconnect.ts`). Header-mismatch and
+  unauthenticated probe outcomes are not persisted as a legacy verdict; after
+  OAuth the hub retries `server/discover` with the token.
 
 ## OAuth flow
 

--- a/docs/contributing/architecture/mcp-client-servers.md
+++ b/docs/contributing/architecture/mcp-client-servers.md
@@ -39,8 +39,8 @@ the `/mcp` endpoint (where Kody is the server) and complements MCP servers
   the remote server is actually 2025-era. Restore and reconnect drop persisted
   2025 `sessionId` / `protocolVersion` / `discoverResult` values and rewrite
   stored `client.versionNegotiation` to `{ mode: 'auto' }` so a stored 2025
-  session or a persisted `legacy` negotiation mode cannot skip the modern
-  probe or DELETE a session against a modern-only server
+  session or a persisted `legacy` negotiation mode cannot skip the modern probe
+  or DELETE a session against a modern-only server
   (`packages/worker/src/mcp-client/restore.ts`,
   `packages/worker/src/mcp-client/reconnect.ts`). Header-mismatch,
   unauthenticated, and `-32022` UnsupportedProtocolVersion probe outcomes are

--- a/packages/worker/src/mcp-client/hub-oauth-recovery.node.test.ts
+++ b/packages/worker/src/mcp-client/hub-oauth-recovery.node.test.ts
@@ -21,6 +21,8 @@ type FakeConnection = {
 		transport: {
 			type: string
 			headers?: Record<string, string>
+			sessionId?: string
+			protocolVersion?: string
 			authProvider: {
 				serverId: string
 				clientId?: string
@@ -274,6 +276,8 @@ function seedServer(input: {
 				transport: {
 					type: 'auto',
 					headers: { 'X-Test': 'preserved' },
+					sessionId: 'stale-2025-session',
+					protocolVersion: '2025-11-25',
 					authProvider: provider,
 				},
 			},
@@ -334,6 +338,15 @@ test('reconnect repairs stale callbacks and always replaces pending OAuth state'
 	expect(manager.mcpConnections['server-1']?.options.transport.headers).toEqual(
 		{ 'X-Test': 'preserved' },
 	)
+	expect(
+		manager.mcpConnections['server-1']?.options.transport.sessionId,
+	).toBeUndefined()
+	expect(
+		manager.mcpConnections['server-1']?.options.transport.protocolVersion,
+	).toBeUndefined()
+	expect(manager.mcpConnections['server-1']?.options.client).toMatchObject({
+		versionNegotiation: { mode: 'auto' },
+	})
 	expect([...values.keys()].filter((key) => key.startsWith('/Kody/'))).toEqual(
 		[],
 	)

--- a/packages/worker/src/mcp-client/hub.ts
+++ b/packages/worker/src/mcp-client/hub.ts
@@ -11,7 +11,13 @@ import {
 	isStuckMcpAuthenticatingWithoutAuthUrl,
 	resolveMcpOAuthCallbackOutcome,
 } from './oauth-callback-outcome.ts'
+import {
+	outboundMcpClientOptions,
+	reconnectMcpServerOptions,
+} from './reconnect.ts'
+import { sanitizeStoredMcpSessions } from './restore.ts'
 import { withStaticTransportHeaders } from './transport-headers.ts'
+import { clearLiveMcpTransportSession } from './transport-session.ts'
 import {
 	createInitialMcpConnectionEpisode,
 	mcpConnectionEpisodeStorageKey,
@@ -94,8 +100,18 @@ class McpClientHubBase extends DurableObject<Env> {
 	}
 
 	private ensureRestored() {
-		this.restored ??= this.manager.restoreConnectionsFromStorage(mcpClientName)
+		this.restored ??= this.restoreSanitizedConnections()
 		return this.restored
+	}
+
+	private async restoreSanitizedConnections() {
+		sanitizeStoredMcpSessions(this.ctx.storage)
+		await this.manager.restoreConnectionsFromStorage(mcpClientName)
+	}
+
+	private clearSessionBeforeConnect(serverId: string) {
+		const connection = this.manager.mcpConnections[serverId]
+		if (connection) clearLiveMcpTransportSession(connection)
 	}
 
 	private connectionStateFor(serverId: string): McpServerConnectionState {
@@ -200,12 +216,14 @@ class McpClientHubBase extends DurableObject<Env> {
 			url: input.url,
 			name: input.name,
 			callbackUrl: input.callbackUrl,
+			client: outboundMcpClientOptions(),
 			transport: withStaticTransportHeaders({
 				type: 'auto' as const,
 				authProvider,
 				...(input.headers ? { headers: input.headers } : {}),
 			}),
 		})
+		this.clearSessionBeforeConnect(input.serverId)
 		const connected = await this.manager.connectToServer(input.serverId)
 		if (connected.state === 'connected') {
 			await this.manager.discoverIfConnected(input.serverId, {
@@ -342,6 +360,7 @@ class McpClientHubBase extends DurableObject<Env> {
 			})
 		}
 		if (result.authSuccess && serverId) {
+			this.clearSessionBeforeConnect(serverId)
 			await this.manager.establishConnection(serverId)
 			await this.manager.waitForConnections({
 				timeout: connectionSettleTimeoutMs,
@@ -460,15 +479,16 @@ class McpClientHubBase extends DurableObject<Env> {
 			authProvider.serverId = input.serverId
 			if (clientId) authProvider.clientId = clientId
 
+			const reconnected = reconnectMcpServerOptions(existingOptions)
 			await this.manager.registerServer(input.serverId, {
 				url: row.server_url,
 				name: row.name,
 				callbackUrl: input.callbackUrl,
 				...(clientId ? { clientId } : {}),
-				...(existingOptions?.client ? { client: existingOptions.client } : {}),
+				client: reconnected.client,
 				transport: withStaticTransportHeaders({
-					...existingOptions?.transport,
-					type: existingOptions?.transport.type ?? 'auto',
+					...reconnected.transport,
+					type: reconnected.transport.type ?? 'auto',
 					authProvider,
 				}),
 			})
@@ -486,6 +506,7 @@ class McpClientHubBase extends DurableObject<Env> {
 			)
 			originalAuthProvider.serverId = input.serverId
 			if (row.client_id) originalAuthProvider.clientId = row.client_id
+			const restored = reconnectMcpServerOptions(existingOptions)
 			await this.manager
 				.registerServer(input.serverId, {
 					url: row.server_url,
@@ -493,18 +514,17 @@ class McpClientHubBase extends DurableObject<Env> {
 					callbackUrl: row.callback_url,
 					...(row.client_id ? { clientId: row.client_id } : {}),
 					...(row.auth_url ? { authUrl: row.auth_url } : {}),
-					...(existingOptions?.client
-						? { client: existingOptions.client }
-						: {}),
+					client: restored.client,
 					transport: withStaticTransportHeaders({
-						...existingOptions?.transport,
-						type: existingOptions?.transport.type ?? 'auto',
+						...restored.transport,
+						type: restored.transport.type ?? 'auto',
 						authProvider: originalAuthProvider,
 					}),
 				})
 				.catch(() => {})
 			throw error
 		}
+		this.clearSessionBeforeConnect(input.serverId)
 		const result = await this.manager.connectToServer(input.serverId)
 		if (result.state === 'connected') {
 			await this.manager.discoverIfConnected(input.serverId, {
@@ -549,6 +569,7 @@ class McpClientHubBase extends DurableObject<Env> {
 				// Best-effort: reconnect below still regenerates OAuth when possible.
 			}
 		}
+		this.clearSessionBeforeConnect(serverId)
 		const result = await this.manager.connectToServer(serverId)
 		if (result.state === 'connected') {
 			await this.manager.discoverIfConnected(serverId, {
@@ -648,6 +669,7 @@ class McpClientHubBase extends DurableObject<Env> {
 	}
 
 	private async lightweightReconnectServer(serverId: string) {
+		this.clearSessionBeforeConnect(serverId)
 		const connected = await this.manager.connectToServer(serverId)
 		if (connected.state === 'connected') {
 			await this.manager.discoverIfConnected(serverId, {

--- a/packages/worker/src/mcp-client/outbound-era.node.test.ts
+++ b/packages/worker/src/mcp-client/outbound-era.node.test.ts
@@ -1,0 +1,248 @@
+import {
+	createServer,
+	type IncomingMessage,
+	type ServerResponse,
+} from 'node:http'
+import { expect, test } from 'vitest'
+import {
+	Client,
+	StreamableHTTPClientTransport,
+} from '@modelcontextprotocol/client'
+import { McpServer, createMcpHandler } from '@modelcontextprotocol/server'
+import { reconnectMcpServerOptions } from './reconnect.ts'
+import { withStaticTransportHeaders } from './transport-headers.ts'
+
+const bearerToken = 'test-token'
+
+test('Kody-as-client lists tools on modern-only and 2025 initialize servers', async () => {
+	await using modern = await startRecordedServer(createModernOnlyHandler())
+	await using legacy = await startRecordedServer(createInitializeOnlyHandler())
+
+	const modernClient = await connectKodyAsClient(modern.origin, {
+		headers: { Authorization: `Bearer ${bearerToken}` },
+		staleSession: {
+			sessionId: 'stale-2025-session',
+			protocolVersion: '2025-11-25',
+		},
+	})
+	try {
+		const modernTools = await modernClient.client.listTools()
+		expect(modernTools.tools.map((tool) => tool.name)).toEqual(['list_feeds'])
+	} finally {
+		await modernClient.client.close().catch(() => undefined)
+		await modernClient.transport.close().catch(() => undefined)
+	}
+
+	expect(rpcMethods(modern.recorded)).toContain('server/discover')
+	expect(rpcMethods(modern.recorded)).not.toContain('initialize')
+	expect(modern.recorded.some((entry) => entry.httpMethod === 'DELETE')).toBe(
+		false,
+	)
+
+	const legacyClient = await connectKodyAsClient(legacy.origin)
+	try {
+		const legacyTools = await legacyClient.client.listTools()
+		expect(legacyTools.tools.map((tool) => tool.name)).toEqual(['home_ping'])
+	} finally {
+		await legacyClient.client.close().catch(() => undefined)
+		await legacyClient.transport.close().catch(() => undefined)
+	}
+
+	expect(rpcMethods(legacy.recorded)).toContain('initialize')
+	expect(rpcMethods(legacy.recorded)).toContain('tools/list')
+})
+
+async function connectKodyAsClient(
+	origin: string,
+	input?: {
+		headers?: Record<string, string>
+		staleSession?: { sessionId: string; protocolVersion: string }
+	},
+) {
+	const reconnected = reconnectMcpServerOptions({
+		transport: {
+			type: 'auto',
+			...input?.staleSession,
+			...(input?.headers ? { headers: input.headers } : {}),
+		},
+		discoverResult: input?.staleSession
+			? { supportedVersions: ['2025-11-25'] }
+			: undefined,
+	})
+	expect(reconnected.transport.sessionId).toBeUndefined()
+	expect(reconnected.transport.protocolVersion).toBeUndefined()
+
+	const client = new Client(
+		{ name: 'Kody', version: '1.0.0' },
+		{ versionNegotiation: { mode: 'auto' } },
+	)
+	const headers = withStaticTransportHeaders(reconnected.transport)
+	const transport = new StreamableHTTPClientTransport(new URL('/mcp', origin), {
+		requestInit: headers.requestInit,
+	})
+	await client.connect(transport)
+	return { client, transport }
+}
+
+function createModernOnlyHandler() {
+	const mcpHandler = createMcpHandler(
+		() => {
+			const server = new McpServer({ name: 'mediarss', version: '1.0.0' })
+			server.registerTool(
+				'list_feeds',
+				{ description: 'List saved feeds' },
+				() => ({
+					content: [{ type: 'text', text: '[]' }],
+				}),
+			)
+			return server
+		},
+		{ legacy: 'reject' },
+	)
+	return async (request: Request) => {
+		if (request.headers.get('authorization') !== `Bearer ${bearerToken}`) {
+			return new Response('Unauthorized', {
+				status: 401,
+				headers: { 'WWW-Authenticate': 'Bearer' },
+			})
+		}
+		return mcpHandler.fetch(request)
+	}
+}
+
+function createInitializeOnlyHandler() {
+	return async (request: Request) => {
+		if (request.method === 'DELETE') {
+			return new Response(null, { status: 200 })
+		}
+		if (request.method !== 'POST') {
+			return new Response(null, { status: 405 })
+		}
+		const body = (await request.json()) as {
+			id?: string | number
+			method?: string
+		}
+		if (body.method === 'initialize') {
+			return Response.json(
+				{
+					jsonrpc: '2.0',
+					id: body.id ?? null,
+					result: {
+						protocolVersion: '2025-11-25',
+						capabilities: { tools: {} },
+						serverInfo: { name: 'home', version: '1.0.0' },
+					},
+				},
+				{ headers: { 'mcp-session-id': 'home-session-1' } },
+			)
+		}
+		if (body.method === 'notifications/initialized') {
+			return new Response(null, { status: 202 })
+		}
+		if (body.method === 'tools/list') {
+			return Response.json({
+				jsonrpc: '2.0',
+				id: body.id ?? null,
+				result: {
+					tools: [
+						{
+							name: 'home_ping',
+							inputSchema: { type: 'object', properties: {} },
+						},
+					],
+				},
+			})
+		}
+		return Response.json({
+			jsonrpc: '2.0',
+			id: body.id ?? null,
+			error: { code: -32601, message: 'Method not found' },
+		})
+	}
+}
+
+type RecordedRequest = {
+	httpMethod: string
+	rpcMethod?: string
+}
+
+async function startRecordedServer(
+	handle: (request: Request) => Promise<Response>,
+) {
+	const recorded: Array<RecordedRequest> = []
+	const server = createServer((req, res) => {
+		void dispatchRecordedRequest({ req, res, recorded, handle }).catch(
+			(error: unknown) => {
+				res.statusCode = 500
+				res.end(error instanceof Error ? error.message : String(error))
+			},
+		)
+	})
+	await new Promise<void>((resolve) => {
+		server.listen(0, '127.0.0.1', resolve)
+	})
+	const address = server.address()
+	if (typeof address !== 'object' || address === null) {
+		throw new Error('Recorded MCP server did not bind a TCP port.')
+	}
+	const origin = `http://127.0.0.1:${String(address.port)}`
+	return {
+		origin,
+		recorded,
+		async [Symbol.asyncDispose]() {
+			await new Promise<void>((resolve, reject) => {
+				server.close((error) => (error ? reject(error) : resolve()))
+			})
+		},
+	}
+}
+
+async function dispatchRecordedRequest(input: {
+	req: IncomingMessage
+	res: ServerResponse
+	recorded: Array<RecordedRequest>
+	handle: (request: Request) => Promise<Response>
+}) {
+	const chunks: Array<Buffer> = []
+	for await (const chunk of input.req) {
+		chunks.push(Buffer.from(chunk))
+	}
+	const body = Buffer.concat(chunks)
+	const host = input.req.headers.host ?? '127.0.0.1'
+	const url = new URL(input.req.url ?? '/', `http://${host}`)
+	const headers = new Headers()
+	for (const [key, value] of Object.entries(input.req.headers)) {
+		if (typeof value === 'string') headers.set(key, value)
+		else if (Array.isArray(value)) headers.set(key, value.join(', '))
+	}
+	let rpcMethod: string | undefined
+	if (body.length > 0) {
+		try {
+			const parsed = JSON.parse(body.toString()) as { method?: string }
+			rpcMethod = typeof parsed.method === 'string' ? parsed.method : undefined
+		} catch {
+			rpcMethod = undefined
+		}
+	}
+	input.recorded.push({
+		httpMethod: input.req.method ?? 'GET',
+		...(rpcMethod ? { rpcMethod } : {}),
+	})
+	const request = new Request(url, {
+		method: input.req.method,
+		headers,
+		...(body.length > 0
+			? ({ body, duplex: 'half' } satisfies RequestInit & { duplex: 'half' })
+			: {}),
+	})
+	const response = await input.handle(request)
+	input.res.statusCode = response.status
+	response.headers.forEach((value, key) => {
+		input.res.setHeader(key, value)
+	})
+	input.res.end(Buffer.from(await response.arrayBuffer()))
+}
+
+function rpcMethods(recorded: Array<RecordedRequest>) {
+	return recorded.flatMap((entry) => (entry.rpcMethod ? [entry.rpcMethod] : []))
+}

--- a/packages/worker/src/mcp-client/probe-outcome.node.test.ts
+++ b/packages/worker/src/mcp-client/probe-outcome.node.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from 'vitest'
 import {
 	classifyOutboundMcpProbeSignal,
+	classifyPersistedMcpSession,
 	headerMismatchErrorCode,
 	methodNotFoundErrorCode,
 	shouldFallbackToLegacyInitialize,
@@ -40,7 +41,16 @@ test('unauthenticated and header-mismatch probes are not a 2025 verdict', () => 
 		rpcCode: unsupportedProtocolVersionErrorCode,
 		discoverSupportedVersions: ['2025-11-25'],
 	})
-	expect(unsupportedLegacy).toEqual({ kind: 'legacy' })
+	expect(unsupportedLegacy).toEqual({ kind: 'unknown' })
+	expect(shouldFallbackToLegacyInitialize(unsupportedLegacy)).toBe(false)
+	expect(shouldPersistLegacyMcpSession(unsupportedLegacy)).toBe(false)
+
+	const unsupportedEmpty = classifyOutboundMcpProbeSignal({
+		rpcCode: unsupportedProtocolVersionErrorCode,
+	})
+	expect(unsupportedEmpty).toEqual({ kind: 'unknown' })
+	expect(shouldFallbackToLegacyInitialize(unsupportedEmpty)).toBe(false)
+	expect(shouldPersistLegacyMcpSession(unsupportedEmpty)).toBe(false)
 
 	const unrecognized = classifyOutboundMcpProbeSignal({
 		httpStatus: 400,
@@ -49,4 +59,16 @@ test('unauthenticated and header-mismatch probes are not a 2025 verdict', () => 
 	expect(unrecognized).toEqual({ kind: 'unknown' })
 	expect(shouldFallbackToLegacyInitialize(unrecognized)).toBe(false)
 	expect(shouldPersistLegacyMcpSession(unrecognized)).toBe(false)
+
+	const storedModern = classifyPersistedMcpSession({
+		discoverResult: { supportedVersions: [modernMcpProtocolVersion] },
+	})
+	expect(storedModern).toEqual({ kind: 'modern' })
+	expect(shouldPersistLegacyMcpSession(storedModern)).toBe(false)
+
+	const storedStale = classifyPersistedMcpSession({
+		discoverResult: { supportedVersions: ['2025-11-25'] },
+	})
+	expect(storedStale).toEqual({ kind: 'unknown' })
+	expect(shouldPersistLegacyMcpSession(storedStale)).toBe(false)
 })

--- a/packages/worker/src/mcp-client/probe-outcome.node.test.ts
+++ b/packages/worker/src/mcp-client/probe-outcome.node.test.ts
@@ -1,0 +1,52 @@
+import { expect, test } from 'vitest'
+import {
+	classifyOutboundMcpProbeSignal,
+	headerMismatchErrorCode,
+	methodNotFoundErrorCode,
+	shouldFallbackToLegacyInitialize,
+	shouldPersistLegacyMcpSession,
+	unsupportedProtocolVersionErrorCode,
+} from './probe-outcome.ts'
+import { modernMcpProtocolVersion } from './transport-session.ts'
+
+test('unauthenticated and header-mismatch probes are not a 2025 verdict', () => {
+	const unauthorized = classifyOutboundMcpProbeSignal({ httpStatus: 401 })
+	expect(unauthorized).toEqual({ kind: 'auth-required' })
+	expect(shouldFallbackToLegacyInitialize(unauthorized)).toBe(false)
+	expect(shouldPersistLegacyMcpSession(unauthorized)).toBe(false)
+
+	const headerMismatch = classifyOutboundMcpProbeSignal({
+		httpStatus: 400,
+		rpcCode: headerMismatchErrorCode,
+	})
+	expect(headerMismatch).toEqual({ kind: 'header-mismatch' })
+	expect(shouldFallbackToLegacyInitialize(headerMismatch)).toBe(false)
+	expect(shouldPersistLegacyMcpSession(headerMismatch)).toBe(false)
+
+	const modern = classifyOutboundMcpProbeSignal({
+		httpStatus: 200,
+		discoverSupportedVersions: [modernMcpProtocolVersion],
+	})
+	expect(modern).toEqual({ kind: 'modern' })
+
+	const initializeOnly = classifyOutboundMcpProbeSignal({
+		rpcCode: methodNotFoundErrorCode,
+	})
+	expect(initializeOnly).toEqual({ kind: 'legacy' })
+	expect(shouldFallbackToLegacyInitialize(initializeOnly)).toBe(true)
+	expect(shouldPersistLegacyMcpSession(initializeOnly)).toBe(true)
+
+	const unsupportedLegacy = classifyOutboundMcpProbeSignal({
+		rpcCode: unsupportedProtocolVersionErrorCode,
+		discoverSupportedVersions: ['2025-11-25'],
+	})
+	expect(unsupportedLegacy).toEqual({ kind: 'legacy' })
+
+	const unrecognized = classifyOutboundMcpProbeSignal({
+		httpStatus: 400,
+		rpcCode: -32001,
+	})
+	expect(unrecognized).toEqual({ kind: 'unknown' })
+	expect(shouldFallbackToLegacyInitialize(unrecognized)).toBe(false)
+	expect(shouldPersistLegacyMcpSession(unrecognized)).toBe(false)
+})

--- a/packages/worker/src/mcp-client/probe-outcome.ts
+++ b/packages/worker/src/mcp-client/probe-outcome.ts
@@ -1,0 +1,60 @@
+/**
+ * Outbound era classification for Kody-as-client.
+ *
+ * Client 2.0.0 `classifyProbeOutcome` treats HeaderMismatch (-32020) and most
+ * unrecognized probe failures as a 2025 server, then sends `initialize`.
+ * Unauthenticated (401) and header-mismatch outcomes are not era evidence:
+ * retry `server/discover` after the token is available, and do not persist a
+ * legacy session from those probes. Fall back to `initialize` only when the
+ * server is actually 2025-era.
+ */
+
+import { modernMcpProtocolVersion } from './transport-session.ts'
+
+export const headerMismatchErrorCode = -32020
+export const unsupportedProtocolVersionErrorCode = -32022
+export const methodNotFoundErrorCode = -32601
+
+export type OutboundMcpProbeSignal =
+	| { kind: 'modern' }
+	| { kind: 'legacy' }
+	| { kind: 'auth-required' }
+	| { kind: 'header-mismatch' }
+	| { kind: 'unknown' }
+
+export function classifyOutboundMcpProbeSignal(input: {
+	httpStatus?: number
+	rpcCode?: number
+	discoverSupportedVersions?: ReadonlyArray<string>
+}): OutboundMcpProbeSignal {
+	if (input.httpStatus === 401 || input.httpStatus === 403) {
+		return { kind: 'auth-required' }
+	}
+	if (input.rpcCode === headerMismatchErrorCode) {
+		return { kind: 'header-mismatch' }
+	}
+	if (input.discoverSupportedVersions?.includes(modernMcpProtocolVersion)) {
+		return { kind: 'modern' }
+	}
+	if (input.rpcCode === methodNotFoundErrorCode) {
+		return { kind: 'legacy' }
+	}
+	if (input.rpcCode === unsupportedProtocolVersionErrorCode) {
+		const supported = input.discoverSupportedVersions ?? []
+		const hasLegacy = supported.some((version) => version.startsWith('2025-'))
+		if (hasLegacy || supported.length === 0) return { kind: 'legacy' }
+	}
+	return { kind: 'unknown' }
+}
+
+export function shouldFallbackToLegacyInitialize(
+	signal: OutboundMcpProbeSignal,
+): boolean {
+	return signal.kind === 'legacy'
+}
+
+export function shouldPersistLegacyMcpSession(
+	signal: OutboundMcpProbeSignal,
+): boolean {
+	return signal.kind === 'legacy'
+}

--- a/packages/worker/src/mcp-client/probe-outcome.ts
+++ b/packages/worker/src/mcp-client/probe-outcome.ts
@@ -1,15 +1,22 @@
 /**
  * Outbound era classification for Kody-as-client.
  *
- * Client 2.0.0 `classifyProbeOutcome` treats HeaderMismatch (-32020) and most
- * unrecognized probe failures as a 2025 server, then sends `initialize`.
- * Unauthenticated (401) and header-mismatch outcomes are not era evidence:
- * retry `server/discover` after the token is available, and do not persist a
- * legacy session from those probes. Fall back to `initialize` only when the
- * server is actually 2025-era.
+ * Client 2.0.0 `classifyProbeOutcome` is not injectable. It treats
+ * HeaderMismatch (-32020) and most unrecognized probe failures as a 2025
+ * server, then sends `initialize`. Kody applies this policy at the session
+ * boundary instead: restore/reconnect drop stored 2025 sessions and force
+ * `versionNegotiation: { mode: 'auto' }` so the next connect re-probes with
+ * `server/discover`. Unauthenticated (401) and header-mismatch outcomes are
+ * not era evidence. `-32022` (UnsupportedProtocolVersion) is a version
+ * mismatch, not a 2025 verdict — retry a mutual modern version, do not fall
+ * back to `initialize`. Fall back only when the server is actually 2025-era
+ * (`-32601` MethodNotFound).
  */
 
-import { modernMcpProtocolVersion } from './transport-session.ts'
+import {
+	isFreshModernDiscoverResult,
+	modernMcpProtocolVersion,
+} from './transport-session.ts'
 
 export const headerMismatchErrorCode = -32020
 export const unsupportedProtocolVersionErrorCode = -32022
@@ -39,10 +46,19 @@ export function classifyOutboundMcpProbeSignal(input: {
 	if (input.rpcCode === methodNotFoundErrorCode) {
 		return { kind: 'legacy' }
 	}
-	if (input.rpcCode === unsupportedProtocolVersionErrorCode) {
-		const supported = input.discoverSupportedVersions ?? []
-		const hasLegacy = supported.some((version) => version.startsWith('2025-'))
-		if (hasLegacy || supported.length === 0) return { kind: 'legacy' }
+	return { kind: 'unknown' }
+}
+
+/**
+ * A stored `server_options` blob is not a probe. Client 2.0 persists a 2025
+ * session after HeaderMismatch fallback; that is not confirmed-legacy
+ * evidence, so restore must re-probe.
+ */
+export function classifyPersistedMcpSession(input: {
+	discoverResult?: unknown
+}): OutboundMcpProbeSignal {
+	if (isFreshModernDiscoverResult(input.discoverResult)) {
+		return { kind: 'modern' }
 	}
 	return { kind: 'unknown' }
 }

--- a/packages/worker/src/mcp-client/reconnect.node.test.ts
+++ b/packages/worker/src/mcp-client/reconnect.node.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from 'vitest'
+import { reconnectMcpServerOptions } from './reconnect.ts'
+import { modernMcpProtocolVersion } from './transport-session.ts'
+
+test('reconnect drops sessionId, protocolVersion, and discoverResult', () => {
+	const reconnected = reconnectMcpServerOptions({
+		client: {
+			capabilities: { elicitation: { form: {} } },
+			versionNegotiation: { mode: 'legacy' },
+		},
+		transport: {
+			type: 'auto',
+			sessionId: 'stale-2025-session',
+			protocolVersion: '2025-11-25',
+			headers: { 'X-Test': 'preserved' },
+		},
+		discoverResult: {
+			supportedVersions: [modernMcpProtocolVersion],
+			capabilities: { tools: {} },
+		},
+	})
+
+	expect(reconnected.transport.sessionId).toBeUndefined()
+	expect(reconnected.transport.protocolVersion).toBeUndefined()
+	expect(reconnected.transport.headers).toEqual({ 'X-Test': 'preserved' })
+	expect(reconnected.transport.type).toBe('auto')
+	expect(reconnected.client.versionNegotiation).toEqual({ mode: 'auto' })
+	expect(reconnected.client.capabilities).toEqual({
+		elicitation: { form: {} },
+	})
+	expect('discoverResult' in reconnected).toBe(false)
+})

--- a/packages/worker/src/mcp-client/reconnect.ts
+++ b/packages/worker/src/mcp-client/reconnect.ts
@@ -1,0 +1,36 @@
+import { withoutPersistedMcpSession } from './transport-session.ts'
+
+export const outboundMcpVersionNegotiation = { mode: 'auto' as const }
+
+export function outboundMcpClientOptions<T extends object>(
+	existing?: T,
+): T & { versionNegotiation: { mode: 'auto' } } {
+	return {
+		...(existing ?? ({} as T)),
+		versionNegotiation: outboundMcpVersionNegotiation,
+	}
+}
+
+/**
+ * Reconnect must not reuse a persisted session. A stored 2025 `sessionId`
+ * skips `server/discover` and DELETEs on close; a stored `discoverResult`
+ * is only a modern prior when it came from a fresh probe, which reconnect
+ * does not have yet.
+ */
+export function reconnectMcpServerOptions<
+	T extends {
+		client?: object
+		transport?: object
+		discoverResult?: unknown
+	},
+>(
+	existing?: T,
+): {
+	client: (T['client'] & object) | { versionNegotiation: { mode: 'auto' } }
+	transport: T['transport'] & object
+} {
+	return {
+		client: outboundMcpClientOptions(existing?.client),
+		transport: withoutPersistedMcpSession(existing?.transport),
+	}
+}

--- a/packages/worker/src/mcp-client/restore.node.test.ts
+++ b/packages/worker/src/mcp-client/restore.node.test.ts
@@ -17,12 +17,19 @@ test('restore clears stale 2025 sessions and keeps a fresh modern discoverResult
 	expect(stale.transport?.sessionId).toBeUndefined()
 	expect(stale.transport?.protocolVersion).toBeUndefined()
 	expect(stale.discoverResult).toBeUndefined()
+	expect(stale.client).toEqual({
+		versionNegotiation: { mode: 'auto' },
+	})
 
 	const modernDiscoverResult = {
 		supportedVersions: [modernMcpProtocolVersion],
 		capabilities: { tools: {} },
 	}
 	const modern = sanitizePersistedMcpServerOptions({
+		client: {
+			capabilities: { elicitation: { form: {} } },
+			versionNegotiation: { mode: 'legacy' },
+		},
 		transport: {
 			type: 'auto',
 			sessionId: 'stateless-should-drop',
@@ -33,6 +40,10 @@ test('restore clears stale 2025 sessions and keeps a fresh modern discoverResult
 	expect(modern.transport?.sessionId).toBeUndefined()
 	expect(modern.transport?.protocolVersion).toBe(modernMcpProtocolVersion)
 	expect(modern.discoverResult).toEqual(modernDiscoverResult)
+	expect(modern.client).toEqual({
+		capabilities: { elicitation: { form: {} } },
+		versionNegotiation: { mode: 'auto' },
+	})
 
 	const updates: Array<{ id: string; options: string }> = []
 	sanitizeStoredMcpSessions({
@@ -62,6 +73,7 @@ test('restore clears stale 2025 sessions and keeps a fresh modern discoverResult
 	expect(updates).toHaveLength(1)
 	expect(updates[0]?.id).toBe('media-rss')
 	expect(JSON.parse(updates[0]?.options ?? '{}')).toEqual({
+		client: { versionNegotiation: { mode: 'auto' } },
 		transport: {},
 	})
 })

--- a/packages/worker/src/mcp-client/restore.node.test.ts
+++ b/packages/worker/src/mcp-client/restore.node.test.ts
@@ -1,0 +1,67 @@
+import { expect, test } from 'vitest'
+import {
+	sanitizePersistedMcpServerOptions,
+	sanitizeStoredMcpSessions,
+} from './restore.ts'
+import { modernMcpProtocolVersion } from './transport-session.ts'
+
+test('restore clears stale 2025 sessions and keeps a fresh modern discoverResult', () => {
+	const stale = sanitizePersistedMcpServerOptions({
+		transport: {
+			type: 'auto',
+			sessionId: 'stale-2025-session',
+			protocolVersion: '2025-11-25',
+		},
+		discoverResult: { supportedVersions: ['2025-11-25'] },
+	})
+	expect(stale.transport?.sessionId).toBeUndefined()
+	expect(stale.transport?.protocolVersion).toBeUndefined()
+	expect(stale.discoverResult).toBeUndefined()
+
+	const modernDiscoverResult = {
+		supportedVersions: [modernMcpProtocolVersion],
+		capabilities: { tools: {} },
+	}
+	const modern = sanitizePersistedMcpServerOptions({
+		transport: {
+			type: 'auto',
+			sessionId: 'stateless-should-drop',
+			protocolVersion: modernMcpProtocolVersion,
+		},
+		discoverResult: modernDiscoverResult,
+	})
+	expect(modern.transport?.sessionId).toBeUndefined()
+	expect(modern.transport?.protocolVersion).toBe(modernMcpProtocolVersion)
+	expect(modern.discoverResult).toEqual(modernDiscoverResult)
+
+	const updates: Array<{ id: string; options: string }> = []
+	sanitizeStoredMcpSessions({
+		sql: {
+			exec(query: string, ...bindings: Array<unknown>) {
+				if (query.startsWith('SELECT')) {
+					return [
+						{
+							id: 'media-rss',
+							server_options: JSON.stringify({
+								transport: {
+									sessionId: 'stale-2025-session',
+									protocolVersion: '2025-11-25',
+								},
+							}),
+						},
+					]
+				}
+				updates.push({
+					id: String(bindings[1]),
+					options: String(bindings[0]),
+				})
+				return []
+			},
+		},
+	})
+	expect(updates).toHaveLength(1)
+	expect(updates[0]?.id).toBe('media-rss')
+	expect(JSON.parse(updates[0]?.options ?? '{}')).toEqual({
+		transport: {},
+	})
+})

--- a/packages/worker/src/mcp-client/restore.ts
+++ b/packages/worker/src/mcp-client/restore.ts
@@ -1,0 +1,99 @@
+import { isRecord } from '@kody-internal/shared/is-record.ts'
+import {
+	isFreshModernDiscoverResult,
+	type PersistedMcpServerOptions,
+	type PersistedMcpTransport,
+	withoutPersistedMcpSession,
+} from './transport-session.ts'
+
+export function sanitizePersistedMcpServerOptions(
+	options: PersistedMcpServerOptions,
+): PersistedMcpServerOptions {
+	const discoverResult = isFreshModernDiscoverResult(options.discoverResult)
+		? options.discoverResult
+		: undefined
+	const transport = withoutPersistedMcpSession(options.transport, {
+		keepModernProtocolVersion: discoverResult !== undefined,
+	})
+	const next: PersistedMcpServerOptions = {
+		...options,
+		transport,
+	}
+	if (discoverResult !== undefined) {
+		next.discoverResult = discoverResult
+	} else {
+		delete next.discoverResult
+	}
+	return next
+}
+
+export function parsePersistedMcpServerOptions(
+	value: unknown,
+): PersistedMcpServerOptions | null {
+	if (typeof value !== 'string' || value.length === 0) return null
+	try {
+		const parsed: unknown = JSON.parse(value)
+		if (!isRecord(parsed)) return null
+		const transport = parsed.transport
+		return {
+			...parsed,
+			...(isRecord(transport)
+				? { transport: transport as PersistedMcpTransport }
+				: {}),
+		}
+	} catch {
+		return null
+	}
+}
+
+/**
+ * Drop stale 2025 session ids from the Agents SDK table before
+ * `restoreConnectionsFromStorage`. A stored 2025-11-25 session skips the
+ * modern probe and DELETEs on close against modern-only servers.
+ */
+export function sanitizeStoredMcpSessions(storage: {
+	sql: { exec: (query: string, ...bindings: Array<unknown>) => unknown }
+}) {
+	const rows = [
+		...asRows(
+			storage.sql.exec('SELECT id, server_options FROM cf_agents_mcp_servers'),
+		),
+	]
+	for (const row of rows) {
+		const parsed = parsePersistedMcpServerOptions(row.server_options)
+		if (!parsed) continue
+		const sanitized = sanitizePersistedMcpServerOptions(parsed)
+		if (JSON.stringify(sanitized) === JSON.stringify(parsed)) continue
+		storage.sql.exec(
+			'UPDATE cf_agents_mcp_servers SET server_options = ? WHERE id = ?',
+			JSON.stringify(sanitized),
+			row.id,
+		)
+	}
+}
+
+function asRows(value: unknown): Array<{
+	id: string
+	server_options: string | null
+}> {
+	if (!isIterable(value)) return []
+	return [...value].flatMap((row) => {
+		if (!isRecord(row) || typeof row.id !== 'string') return []
+		return [
+			{
+				id: row.id,
+				server_options:
+					typeof row.server_options === 'string' ? row.server_options : null,
+			},
+		]
+	})
+}
+
+function isIterable(value: unknown): value is Iterable<unknown> {
+	return (
+		typeof value === 'object' &&
+		value !== null &&
+		Symbol.iterator in value &&
+		typeof value[Symbol.iterator] === 'function'
+	)
+}

--- a/packages/worker/src/mcp-client/restore.ts
+++ b/packages/worker/src/mcp-client/restore.ts
@@ -1,5 +1,10 @@
 import { isRecord } from '@kody-internal/shared/is-record.ts'
 import {
+	classifyPersistedMcpSession,
+	shouldPersistLegacyMcpSession,
+} from './probe-outcome.ts'
+import { outboundMcpClientOptions } from './reconnect.ts'
+import {
 	isFreshModernDiscoverResult,
 	type PersistedMcpServerOptions,
 	type PersistedMcpTransport,
@@ -12,11 +17,21 @@ export function sanitizePersistedMcpServerOptions(
 	const discoverResult = isFreshModernDiscoverResult(options.discoverResult)
 		? options.discoverResult
 		: undefined
+	const keepLegacySession = shouldPersistLegacyMcpSession(
+		classifyPersistedMcpSession(options),
+	)
 	const transport = withoutPersistedMcpSession(options.transport, {
 		keepModernProtocolVersion: discoverResult !== undefined,
 	})
+	if (!keepLegacySession) {
+		delete transport.sessionId
+		if (discoverResult === undefined) {
+			delete transport.protocolVersion
+		}
+	}
 	const next: PersistedMcpServerOptions = {
 		...options,
+		client: outboundMcpClientOptions(options.client),
 		transport,
 	}
 	if (discoverResult !== undefined) {

--- a/packages/worker/src/mcp-client/transport-session.node.test.ts
+++ b/packages/worker/src/mcp-client/transport-session.node.test.ts
@@ -1,0 +1,65 @@
+import { expect, test } from 'vitest'
+import {
+	clearLiveMcpTransportSession,
+	isFreshModernDiscoverResult,
+	isLegacyMcpProtocolVersion,
+	isModernMcpProtocolVersion,
+	modernMcpProtocolVersion,
+	withoutPersistedMcpSession,
+} from './transport-session.ts'
+
+const modernDiscoverResult = {
+	supportedVersions: [modernMcpProtocolVersion],
+	capabilities: { tools: {} },
+}
+
+test('stale 2025 session fields are dropped and a fresh modern discoverResult is kept', () => {
+	expect(isModernMcpProtocolVersion(modernMcpProtocolVersion)).toBe(true)
+	expect(isLegacyMcpProtocolVersion('2025-11-25')).toBe(true)
+	expect(isLegacyMcpProtocolVersion(modernMcpProtocolVersion)).toBe(false)
+	expect(isFreshModernDiscoverResult(modernDiscoverResult)).toBe(true)
+	expect(
+		isFreshModernDiscoverResult({ supportedVersions: ['2025-11-25'] }),
+	).toBe(false)
+
+	const cleared = withoutPersistedMcpSession({
+		type: 'auto',
+		sessionId: 'stale-2025-session',
+		protocolVersion: '2025-11-25',
+		headers: { 'X-Test': 'kept' },
+	})
+	expect(cleared).toEqual({
+		type: 'auto',
+		headers: { 'X-Test': 'kept' },
+	})
+
+	const modernKept = withoutPersistedMcpSession(
+		{
+			type: 'streamable-http',
+			sessionId: 'should-drop',
+			protocolVersion: modernMcpProtocolVersion,
+		},
+		{ keepModernProtocolVersion: true },
+	)
+	expect(modernKept.sessionId).toBeUndefined()
+	expect(modernKept.protocolVersion).toBe(modernMcpProtocolVersion)
+
+	const live = {
+		cleared: false,
+		clearResumedSession() {
+			this.cleared = true
+		},
+		options: {
+			transport: {
+				sessionId: 'live-2025',
+				protocolVersion: '2025-11-25',
+			},
+			discoverResult: { supportedVersions: ['2025-11-25'] },
+		},
+	}
+	clearLiveMcpTransportSession(live)
+	expect(live.cleared).toBe(true)
+	expect(live.options.transport.sessionId).toBeUndefined()
+	expect(live.options.transport.protocolVersion).toBeUndefined()
+	expect(live.options.discoverResult).toBeUndefined()
+})

--- a/packages/worker/src/mcp-client/transport-session.ts
+++ b/packages/worker/src/mcp-client/transport-session.ts
@@ -1,0 +1,84 @@
+/**
+ * Session fields the Agents SDK persists on `transport` / `server_options`.
+ *
+ * Client 2.0.0 skips `server/discover` whenever `transport.sessionId` is set
+ * and, on close, DELETEs that session. A stored 2025-11-25 session therefore
+ * never probes a server that has moved to 2026-07-28, and the terminate
+ * request 405s on modern-only Streamable HTTP.
+ */
+
+export const modernMcpProtocolVersion = '2026-07-28'
+
+export type PersistedMcpTransport = {
+	type?: string
+	sessionId?: string
+	protocolVersion?: string
+	headers?: HeadersInit
+	requestInit?: RequestInit
+}
+
+export type PersistedMcpServerOptions = {
+	client?: Record<string, unknown>
+	transport?: PersistedMcpTransport
+	discoverResult?: unknown
+}
+
+export function isModernMcpProtocolVersion(value: unknown): boolean {
+	return value === modernMcpProtocolVersion
+}
+
+export function isLegacyMcpProtocolVersion(value: unknown): boolean {
+	return typeof value === 'string' && value.startsWith('2025-')
+}
+
+/**
+ * A `DiscoverResult` from a successful `server/discover`. The Agents SDK
+ * only treats it as a modern prior when `supportedVersions` includes
+ * 2026-07-28.
+ */
+export function isFreshModernDiscoverResult(value: unknown): boolean {
+	if (typeof value !== 'object' || value === null) return false
+	const supportedVersions = Reflect.get(value, 'supportedVersions')
+	return (
+		Array.isArray(supportedVersions) &&
+		supportedVersions.includes(modernMcpProtocolVersion)
+	)
+}
+
+export function withoutPersistedMcpSession<T extends object>(
+	transport: T | undefined,
+	options?: { keepModernProtocolVersion?: boolean },
+): T {
+	if (!transport) return {} as T
+	const next = { ...transport } as T & {
+		sessionId?: string
+		protocolVersion?: string
+	}
+	delete next.sessionId
+	if (
+		!(
+			options?.keepModernProtocolVersion &&
+			isModernMcpProtocolVersion(next.protocolVersion)
+		)
+	) {
+		delete next.protocolVersion
+	}
+	return next
+}
+
+export function clearLiveMcpTransportSession(connection: {
+	clearResumedSession?: () => void
+	options: {
+		transport: object
+		discoverResult?: unknown
+	}
+}) {
+	connection.clearResumedSession?.()
+	const transport = connection.options.transport as {
+		sessionId?: string
+		protocolVersion?: string
+	}
+	delete transport.sessionId
+	delete transport.protocolVersion
+	delete connection.options.discoverResult
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Make Kody's outbound MCP client speak 2026-07-28 first so user-added remote servers like MediaRSS (modern-only `createMcpHandler` + legacy reject) can list tools, while 2025 initialize-only servers such as home keep connecting.

## Why

MediaRSS shipped modern-only. Kody then sat on Discovering tools with 0 tools. NAS logs showed `DELETE /mcp` 405 (session terminate), `POST /mcp` 400 modern-only-missing-envelope (`initialize`), and working OAuth. A stored 2025 session skips `server/discover` and DELETE/initialize against a modern-only server. Home stayed Connected because it still accepts 2025 `initialize`.

## Summary

- Restore and reconnect drop persisted 2025 `sessionId` / `protocolVersion` / `discoverResult` unless there is a fresh modern `discoverResult`.
- Restore rewrites stored `client.versionNegotiation` to `{ mode: 'auto' }` so a persisted `legacy` mode cannot skip `server/discover` after DO wake.
- `restartServerAuthorization` no longer spreads a stale transport session into the replacement registration.
- Header-mismatch (`-32020`), unauthenticated (401/403), and `-32022` UnsupportedProtocolVersion probes are not treated as a 2025 verdict and are not persisted as legacy sessions. After OAuth the hub retries `server/discover` with the token.
- `initialize` is used only when the server is actually 2025-era (`-32601`).
- Inbound `/mcp` dual-lane is unchanged (decision 0005).

## Testing

- `npx vitest run --project node-unit` on the mcp-client helper, hub OAuth recovery, and outbound era suites.
- Era suite connects the same Client options the hub uses to a real `createMcpHandler({ legacy: 'reject' })` server (bearer token) and to a 2025 initialize-only server. After a stored 2025 session is sanitized, the modern-only path records `server/discover` and no `initialize` or `DELETE`.
- Preview: seeded user add/reconnect of `self-mcp` against the preview `/mcp` (OAuth authenticating, not stuck discovering with 0 tools). UI pass on `/account/mcp-servers`.

## System changes

Extends `mcp-client-servers` (medium). No primitive map change.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `34cdc2c8` · **Head:** `7e7649e9`

**Classification:** extends — outbound MCP client hub prefers `server/discover` / 2026-07-28, clears stale 2025 sessions, and forces `versionNegotiation: auto` on restore.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `mcp-client-servers` | assistant | extends — restore/reconnect drop stale 2025 sessions and rewrite stored client negotiation to auto; `-32022` is not a 2025 verdict |

### Change flow

Reconnect and restore clear a stored 2025 session, force auto negotiation, probe with `server/discover`, and initialize only when the remote server is actually 2025-era.

```mermaid
sequenceDiagram
	actor User
	participant mcpClientServers as mcp-client-servers
	participant remote as remote MCP server
	User->>mcpClientServers: reconnect or DO restore
	mcpClientServers->>mcpClientServers: drop stale 2025 session and set versionNegotiation auto
	mcpClientServers->>remote: POST server/discover (2026-07-28 envelope)
	alt modern-only createMcpHandler
		remote-->>mcpClientServers: DiscoverResult
		mcpClientServers->>remote: tools/list
	else 401 then OAuth
		remote-->>mcpClientServers: 401
		mcpClientServers->>mcpClientServers: do not persist legacy session
		mcpClientServers->>remote: POST server/discover with token
	else UnsupportedProtocolVersion -32022
		remote-->>mcpClientServers: -32022
		mcpClientServers->>mcpClientServers: retry mutual modern version, not initialize
	else 2025 initialize-only
		remote-->>mcpClientServers: -32601 Method not found
		mcpClientServers->>remote: POST initialize
		mcpClientServers->>remote: tools/list
	end
```

### Invariants

Per-user hub isolation is unchanged. Inbound `/mcp` dual-lane (decision 0005) is not modified.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7a6c261e-34ac-4ccc-94af-d0eed2425fc3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7a6c261e-34ac-4ccc-94af-d0eed2425fc3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added modern MCP server discovery with automatic protocol-version negotiation.
  * OAuth-authenticated connections now retry discovery using acquired credentials.
* **Bug Fixes**
  * Reconnecting or restoring MCP servers now clears stale session and discovery information.
  * Improved handling of authentication failures, header mismatches, and unsupported protocol responses.
  * Automatically resets outdated negotiation settings while preserving valid connection configuration.
* **Documentation**
  * Updated MCP client and server architecture guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->