### PR TITLE
Send entitlement warning emails once per crossing, not daily

### DIFF
--- a/docs/contributing/architecture/entitlements.md
+++ b/docs/contributing/architecture/entitlements.md
@@ -188,11 +188,13 @@ the same cold zero-init path):
   not mail again the next UTC day. Dropping below that threshold and climbing
   back over it is a new instance. Same-hour crossings of the same kind still
   batch into one mail. KV prefix `entitlement-warning-user:v3` stores
-  `{prefix}:{userId}:{kind}:{resource}`. A remaining `v2` daily key for the
-  same user and kind counts as a claim for every resource currently in that
-  bucket. Candidate selection is the top ~80 accounts by current-month event
-  count plus high package/secret stock, capped at 100. Operator fleet mail is
-  unchanged and still runs if user warning sends fail.
+  `{prefix}:{userId}:{kind}:{resource}` for stock limits, and appends the UTC
+  day for `*_per_day` counters so a midnight reset is a new instance. A
+  remaining `v2` daily key for the same user and kind from the last 36 hours
+  counts as a claim for every resource currently in that bucket. Candidate
+  selection is the top ~80 accounts by current-month event count plus high
+  package/secret stock, capped at 100. Operator fleet mail is unchanged and
+  still runs if user warning sends fail.
 
 `readEntitlementResourceUsage` counts only APP_DB-backed row resources (`repos`,
 `saved_packages`, `secrets`). Resources whose authority is elsewhere

--- a/docs/contributing/architecture/entitlements.md
+++ b/docs/contributing/architecture/entitlements.md
@@ -189,13 +189,16 @@ the same cold zero-init path):
   back over it is a new instance. Same-hour crossings of the same kind still
   batch into one mail. KV prefix `entitlement-warning-user:v3` stores
   `{prefix}:{userId}:{kind}:{resource}` for stock limits, and appends the UTC
-  day for `*_per_day` counters so a midnight reset is a new instance. A
-  remaining same-day `v2` daily key for the same user and kind counts as a claim
-  for every resource currently in that bucket. A leftover `v2` key from an
-  earlier UTC day claims stock limits only, so a `*_per_day` midnight reset can
-  still mail. Candidate selection is the top ~80 accounts by current-month event
-  count plus high package/secret stock, capped at 100. Operator fleet mail is
-  unchanged and still runs if user warning sends fail.
+  day for `*_per_day` counters so a midnight reset is a new instance. Stock
+  claims use a 30-day TTL that the hourly sweep refreshes while the user is
+  still over, so sitting at a cap stays silent and a later drop out of the
+  candidate set can rematch after the claim expires. Daily claims keep a 36-hour
+  TTL. A remaining same-day `v2` daily key for the same user and kind counts as
+  a claim for every resource currently in that bucket. A leftover `v2` key from
+  an earlier UTC day claims stock limits only, so a `*_per_day` midnight reset
+  can still mail. Candidate selection is the top ~80 accounts by current-month
+  event count plus high package/secret stock, capped at 100. Operator fleet mail
+  is unchanged and still runs if user warning sends fail.
 
 `readEntitlementResourceUsage` counts only APP_DB-backed row resources (`repos`,
 `saved_packages`, `secrets`). Resources whose authority is elsewhere

--- a/docs/contributing/architecture/entitlements.md
+++ b/docs/contributing/architecture/entitlements.md
@@ -190,11 +190,12 @@ the same cold zero-init path):
   batch into one mail. KV prefix `entitlement-warning-user:v3` stores
   `{prefix}:{userId}:{kind}:{resource}` for stock limits, and appends the UTC
   day for `*_per_day` counters so a midnight reset is a new instance. A
-  remaining `v2` daily key for the same user and kind from the last 36 hours
-  counts as a claim for every resource currently in that bucket. Candidate
-  selection is the top ~80 accounts by current-month event count plus high
-  package/secret stock, capped at 100. Operator fleet mail is unchanged and
-  still runs if user warning sends fail.
+  remaining same-day `v2` daily key for the same user and kind counts as a claim
+  for every resource currently in that bucket. A leftover `v2` key from an
+  earlier UTC day claims stock limits only, so a `*_per_day` midnight reset can
+  still mail. Candidate selection is the top ~80 accounts by current-month event
+  count plus high package/secret stock, capped at 100. Operator fleet mail is
+  unchanged and still runs if user warning sends fail.
 
 `readEntitlementResourceUsage` counts only APP_DB-backed row resources (`repos`,
 `saved_packages`, `secrets`). Resources whose authority is elsewhere

--- a/docs/contributing/architecture/entitlements.md
+++ b/docs/contributing/architecture/entitlements.md
@@ -183,12 +183,16 @@ the same cold zero-init path):
   same `readAdminEntitlementConsumption` helper over a bounded sweep of the top
   ~15 active users by current-month event count. The same hourly lane also
   emails verified person accounts when usage crosses 80% or 100% of their
-  effective plan (transactional template). Throttle is one approaching email and
-  one reached email per user per UTC day, listing every resource currently in
-  that bucket — not one mail per entitlement. Candidate selection is the top ~80
-  accounts by current-month event count plus high package/secret stock, capped
-  at 100. Operator fleet mail is unchanged and still runs if user warning sends
-  fail.
+  effective plan (transactional template). Throttle is one mail per crossing of
+  a given percentage on a specific entitlement: staying at 10/10 packages does
+  not mail again the next UTC day. Dropping below that threshold and climbing
+  back over it is a new instance. Same-hour crossings of the same kind still
+  batch into one mail. KV prefix `entitlement-warning-user:v3` stores
+  `{prefix}:{userId}:{kind}:{resource}`. A remaining `v2` daily key for the
+  same user and kind counts as a claim for every resource currently in that
+  bucket. Candidate selection is the top ~80 accounts by current-month event
+  count plus high package/secret stock, capped at 100. Operator fleet mail is
+  unchanged and still runs if user warning sends fail.
 
 `readEntitlementResourceUsage` counts only APP_DB-backed row resources (`repos`,
 `saved_packages`, `secrets`). Resources whose authority is elsewhere

--- a/packages/worker/src/app/user-entitlement-warning-emails.node.test.ts
+++ b/packages/worker/src/app/user-entitlement-warning-emails.node.test.ts
@@ -1,6 +1,7 @@
 import { expect, test, vi } from 'vitest'
 import { utcDayKey } from '@kody-internal/shared/date-keys.ts'
 import type { EntitlementResource } from '#universal/plans.ts'
+import { consoleWarn } from '#worker/test-support/console-spies.ts'
 
 const readAdminEntitlementConsumption = vi.fn()
 
@@ -19,8 +20,10 @@ vi.mock('#app/email/cloudflare-email.ts', () => ({
 
 const {
 	sendUserEntitlementWarningEmails,
+	userEntitlementWarningDailyClaimTtlSeconds,
 	userEntitlementWarningDailyKvKey,
 	userEntitlementWarningKvKey,
+	userEntitlementWarningStockClaimTtlSeconds,
 } = await import('#app/user-entitlement-warning-emails.ts')
 
 const stableUserId = 'a'.repeat(64)
@@ -40,13 +43,24 @@ function consumptionRow(input: {
 
 function createKv() {
 	const store = new Map<string, string>()
+	const puts: Array<{
+		key: string
+		value: string
+		options?: { expirationTtl?: number }
+	}> = []
 	return {
 		store,
+		puts,
 		kv: {
 			async get(key: string) {
 				return store.get(key) ?? null
 			},
-			async put(key: string, value: string) {
+			async put(
+				key: string,
+				value: string,
+				options?: { expirationTtl?: number },
+			) {
+				puts.push({ key, value, options })
 				store.set(key, value)
 			},
 			async delete(key: string) {
@@ -115,7 +129,7 @@ function instanceKey(
 
 test('user entitlement warnings mail once per entitlement crossing, not once per day', async () => {
 	const now = new Date('2026-07-25T12:00:00.000Z')
-	const { kv, store } = createKv()
+	const { kv, store, puts } = createKv()
 	readAdminEntitlementConsumption.mockResolvedValue([
 		consumptionRow({
 			resource: 'execute_calls_per_day',
@@ -376,6 +390,16 @@ test('user entitlement warnings mail once per entitlement crossing, not once per
 	expect(store.get(instanceKey('approaching', 'saved_packages'))).toBe(
 		String(jumpedToLimit.getTime()),
 	)
+	expect(
+		puts.find((put) => put.key === instanceKey('reached', 'saved_packages'))
+			?.options?.expirationTtl,
+	).toBe(userEntitlementWarningStockClaimTtlSeconds)
+	expect(
+		puts.find(
+			(put) =>
+				put.key === instanceKey('approaching', 'execute_calls_per_day', now),
+		)?.options?.expirationTtl,
+	).toBe(userEntitlementWarningDailyClaimTtlSeconds)
 
 	readAdminEntitlementConsumption.mockResolvedValue([
 		consumptionRow({
@@ -478,6 +502,150 @@ test('user entitlement warnings absorb leftover daily claims without mailing aga
 	})
 	expect(nextDay).toEqual({ status: 'no_warnings' })
 	expect(sendCloudflareEmail).not.toHaveBeenCalled()
+})
+
+test('stock entitlement warning claims refresh TTL while the user stays over', async () => {
+	const now = new Date('2026-08-24T02:00:00.000Z')
+	const { kv, store, puts } = createKv()
+	readAdminEntitlementConsumption.mockResolvedValue([
+		consumptionRow({
+			resource: 'saved_packages',
+			label: 'saved packages',
+			current: 10,
+			limit: 10,
+		}),
+		consumptionRow({
+			resource: 'execute_calls_per_day',
+			label: 'execute calls per day',
+			current: 250,
+			limit: 250,
+		}),
+	])
+	sendCloudflareEmail.mockClear()
+	const env = createEnv({
+		users: [
+			{
+				stable_user_id: stableUserId,
+				email: 'maciek@example.com',
+				plan: 'free',
+				stripe_plan: null,
+			},
+		],
+		kv,
+	})
+
+	const first = await sendUserEntitlementWarningEmails({ env, now })
+	expect(first).toEqual({
+		status: 'notified',
+		emailedUsers: 1,
+		emailsSent: 1,
+		warnedResources: 2,
+	})
+	expect(store.get(instanceKey('reached', 'saved_packages'))).toBe(
+		String(now.getTime()),
+	)
+
+	sendCloudflareEmail.mockClear()
+	puts.length = 0
+	const later = new Date('2026-08-24T03:00:00.000Z')
+	const stillOver = await sendUserEntitlementWarningEmails({
+		env,
+		now: later,
+	})
+	expect(stillOver).toEqual({ status: 'no_warnings' })
+	expect(sendCloudflareEmail).not.toHaveBeenCalled()
+	expect(store.get(instanceKey('reached', 'saved_packages'))).toBe(
+		String(later.getTime()),
+	)
+	expect(store.get(instanceKey('approaching', 'saved_packages'))).toBe(
+		String(later.getTime()),
+	)
+	expect(
+		puts.filter((put) => put.key === instanceKey('reached', 'saved_packages')),
+	).toEqual([
+		{
+			key: instanceKey('reached', 'saved_packages'),
+			value: String(later.getTime()),
+			options: {
+				expirationTtl: userEntitlementWarningStockClaimTtlSeconds,
+			},
+		},
+	])
+	expect(puts.some((put) => put.key.includes('execute_calls_per_day'))).toBe(
+		false,
+	)
+})
+
+test('user entitlement warning claim write failures do not abort the sweep', async () => {
+	consoleWarn.mockImplementation(() => {})
+	const otherUserId = 'b'.repeat(64)
+	const { kv, store } = createKv()
+	const originalPut = kv.put.bind(kv)
+	kv.put = async (
+		key: string,
+		value: string,
+		options?: { expirationTtl?: number },
+	) => {
+		if (key.includes(stableUserId) && key.includes('saved_packages')) {
+			throw new Error('kv write failed')
+		}
+		return originalPut(key, value, options)
+	}
+	readAdminEntitlementConsumption.mockResolvedValue([
+		consumptionRow({
+			resource: 'saved_packages',
+			label: 'saved packages',
+			current: 10,
+			limit: 10,
+		}),
+	])
+	sendCloudflareEmail.mockClear()
+	const env = createEnv({
+		users: [
+			{
+				stable_user_id: stableUserId,
+				email: 'first@example.com',
+				plan: 'free',
+				stripe_plan: null,
+			},
+			{
+				stable_user_id: otherUserId,
+				email: 'second@example.com',
+				plan: 'free',
+				stripe_plan: null,
+			},
+		],
+		kv,
+	})
+
+	const result = await sendUserEntitlementWarningEmails({
+		env,
+		now: new Date('2026-08-24T04:00:00.000Z'),
+	})
+	expect(result).toEqual({
+		status: 'notified',
+		emailedUsers: 2,
+		emailsSent: 2,
+		warnedResources: 2,
+	})
+	expect(sendCloudflareEmail).toHaveBeenCalledTimes(2)
+	expect(store.get(instanceKey('reached', 'saved_packages'))).toBeUndefined()
+	expect(
+		store.get(
+			userEntitlementWarningKvKey({
+				userId: otherUserId,
+				kind: 'reached',
+				resource: 'saved_packages',
+			}),
+		),
+	).toBe(String(new Date('2026-08-24T04:00:00.000Z').getTime()))
+	expect(consoleWarn).toHaveBeenCalledWith(
+		'user-entitlement-warning-claim-failed',
+		expect.objectContaining({
+			kind: 'reached',
+			resource: 'saved_packages',
+		}),
+	)
 })
 
 test('user entitlement warnings skip when KV or transactional email is missing', async () => {

--- a/packages/worker/src/app/user-entitlement-warning-emails.node.test.ts
+++ b/packages/worker/src/app/user-entitlement-warning-emails.node.test.ts
@@ -1,456 +1,482 @@
-import { expect, test, vi } from "vitest";
-import { utcDayKey } from "@kody-internal/shared/date-keys.ts";
-import type { EntitlementResource } from "#universal/plans.ts";
+import { expect, test, vi } from 'vitest'
+import { utcDayKey } from '@kody-internal/shared/date-keys.ts'
+import type { EntitlementResource } from '#universal/plans.ts'
 
-const readAdminEntitlementConsumption = vi.fn();
+const readAdminEntitlementConsumption = vi.fn()
 
-vi.mock("#worker/admin/entitlement-consumption.ts", () => ({
-  readAdminEntitlementConsumption: (...args: Array<unknown>) =>
-    readAdminEntitlementConsumption(...args),
-  entitlementWarningThreshold: 0.8,
-}));
+vi.mock('#worker/admin/entitlement-consumption.ts', () => ({
+	readAdminEntitlementConsumption: (...args: Array<unknown>) =>
+		readAdminEntitlementConsumption(...args),
+	entitlementWarningThreshold: 0.8,
+}))
 
-const sendCloudflareEmail = vi.fn(async () => ({ ok: true }));
+const sendCloudflareEmail = vi.fn(async () => ({ ok: true }))
 
-vi.mock("#app/email/cloudflare-email.ts", () => ({
-  sendCloudflareEmail: (...args: Array<unknown>) =>
-    sendCloudflareEmail(...args),
-}));
+vi.mock('#app/email/cloudflare-email.ts', () => ({
+	sendCloudflareEmail: (...args: Array<unknown>) =>
+		sendCloudflareEmail(...args),
+}))
 
 const {
-  sendUserEntitlementWarningEmails,
-  userEntitlementWarningDailyKvKey,
-  userEntitlementWarningKvKey,
-} = await import("#app/user-entitlement-warning-emails.ts");
+	sendUserEntitlementWarningEmails,
+	userEntitlementWarningDailyKvKey,
+	userEntitlementWarningKvKey,
+} = await import('#app/user-entitlement-warning-emails.ts')
 
-const stableUserId = "a".repeat(64);
+const stableUserId = 'a'.repeat(64)
 
 function consumptionRow(input: {
-  resource: EntitlementResource;
-  label: string;
-  current: number;
-  limit: number;
+	resource: EntitlementResource
+	label: string
+	current: number
+	limit: number
 }) {
-  return {
-    ...input,
-    percentOfLimit: input.current / input.limit,
-    overEightyPercent: input.current / input.limit > 0.8,
-  };
+	return {
+		...input,
+		percentOfLimit: input.current / input.limit,
+		overEightyPercent: input.current / input.limit > 0.8,
+	}
 }
 
 function createKv() {
-  const store = new Map<string, string>();
-  return {
-    store,
-    kv: {
-      async get(key: string) {
-        return store.get(key) ?? null;
-      },
-      async put(key: string, value: string) {
-        store.set(key, value);
-      },
-      async delete(key: string) {
-        store.delete(key);
-      },
-    } as unknown as KVNamespace,
-  };
+	const store = new Map<string, string>()
+	return {
+		store,
+		kv: {
+			async get(key: string) {
+				return store.get(key) ?? null
+			},
+			async put(key: string, value: string) {
+				store.set(key, value)
+			},
+			async delete(key: string) {
+				store.delete(key)
+			},
+		} as unknown as KVNamespace,
+	}
 }
 
 function createDb(
-  users: Array<{
-    stable_user_id: string;
-    email: string;
-    plan: string;
-    stripe_plan: string | null;
-  }>,
+	users: Array<{
+		stable_user_id: string
+		email: string
+		plan: string
+		stripe_plan: string | null
+	}>,
 ) {
-  return {
-    prepare(query: string) {
-      const normalized = query.replace(/\s+/g, " ").trim().toLowerCase();
-      return {
-        bind(..._params: Array<unknown>) {
-          return this;
-        },
-        async all<T>() {
-          if (normalized.includes("from usage_rollups")) {
-            return { results: users as Array<T> };
-          }
-          return { results: [] };
-        },
-      };
-    },
-  } as unknown as D1Database;
+	return {
+		prepare(query: string) {
+			const normalized = query.replace(/\s+/g, ' ').trim().toLowerCase()
+			return {
+				bind(..._params: Array<unknown>) {
+					return this
+				},
+				async all<T>() {
+					if (normalized.includes('from usage_rollups')) {
+						return { results: users as Array<T> }
+					}
+					return { results: [] }
+				},
+			}
+		},
+	} as unknown as D1Database
 }
 
 function createEnv(input: {
-  users: Array<{
-    stable_user_id: string;
-    email: string;
-    plan: string;
-    stripe_plan: string | null;
-  }>;
-  kv?: KVNamespace;
+	users: Array<{
+		stable_user_id: string
+		email: string
+		plan: string
+		stripe_plan: string | null
+	}>
+	kv?: KVNamespace
 }) {
-  return {
-    APP_DB: createDb(input.users),
-    APP_BASE_URL: "https://kody.codes/",
-    CLOUDFLARE_ACCOUNT_ID: "acct",
-    CLOUDFLARE_API_TOKEN: "token",
-    BUNDLE_ARTIFACTS_KV: input.kv,
-  } as unknown as Env;
+	return {
+		APP_DB: createDb(input.users),
+		APP_BASE_URL: 'https://kody.codes/',
+		CLOUDFLARE_ACCOUNT_ID: 'acct',
+		CLOUDFLARE_API_TOKEN: 'token',
+		BUNDLE_ARTIFACTS_KV: input.kv,
+	} as unknown as Env
 }
 
 function instanceKey(
-  kind: "approaching" | "reached",
-  resource: EntitlementResource,
+	kind: 'approaching' | 'reached',
+	resource: EntitlementResource,
+	now?: Date,
 ) {
-  return userEntitlementWarningKvKey({
-    userId: stableUserId,
-    kind,
-    resource,
-  });
+	return userEntitlementWarningKvKey({
+		userId: stableUserId,
+		kind,
+		resource,
+		day: now ? utcDayKey(now) : undefined,
+	})
 }
 
-test("user entitlement warnings mail once per entitlement crossing, not once per day", async () => {
-  const now = new Date("2026-07-25T12:00:00.000Z");
-  const { kv, store } = createKv();
-  readAdminEntitlementConsumption.mockResolvedValue([
-    consumptionRow({
-      resource: "execute_calls_per_day",
-      label: "execute calls per day",
-      current: 200,
-      limit: 250,
-    }),
-    consumptionRow({
-      resource: "saved_packages",
-      label: "saved packages",
-      current: 9,
-      limit: 10,
-    }),
-    consumptionRow({
-      resource: "secrets",
-      label: "secrets",
-      current: 4,
-      limit: 25,
-    }),
-  ]);
-  const env = createEnv({
-    users: [
-      {
-        stable_user_id: stableUserId,
-        email: "jelias@example.com",
-        plan: "free",
-        stripe_plan: null,
-      },
-    ],
-    kv,
-  });
+test('user entitlement warnings mail once per entitlement crossing, not once per day', async () => {
+	const now = new Date('2026-07-25T12:00:00.000Z')
+	const { kv, store } = createKv()
+	readAdminEntitlementConsumption.mockResolvedValue([
+		consumptionRow({
+			resource: 'execute_calls_per_day',
+			label: 'execute calls per day',
+			current: 200,
+			limit: 250,
+		}),
+		consumptionRow({
+			resource: 'saved_packages',
+			label: 'saved packages',
+			current: 9,
+			limit: 10,
+		}),
+		consumptionRow({
+			resource: 'secrets',
+			label: 'secrets',
+			current: 4,
+			limit: 25,
+		}),
+	])
+	const env = createEnv({
+		users: [
+			{
+				stable_user_id: stableUserId,
+				email: 'jelias@example.com',
+				plan: 'free',
+				stripe_plan: null,
+			},
+		],
+		kv,
+	})
 
-  const first = await sendUserEntitlementWarningEmails({ env, now });
-  expect(first).toEqual({
-    status: "notified",
-    emailedUsers: 1,
-    emailsSent: 1,
-    warnedResources: 2,
-  });
-  expect(sendCloudflareEmail).toHaveBeenCalledTimes(1);
-  const approachingPayload = sendCloudflareEmail.mock.calls[0]?.[1] as {
-    to: string;
-    from: string;
-    subject: string;
-    html: string;
-    text: string;
-  };
-  expect(approachingPayload.to).toBe("jelias@example.com");
-  expect(approachingPayload.from).toBe("kody@kody.codes");
-  expect(approachingPayload.subject).toContain("approaching");
-  expect(approachingPayload.html).toContain(
-    "https://kody.codes/account/billing",
-  );
-  expect(approachingPayload.text).toContain("https://kody.codes/account/usage");
-  expect(approachingPayload.html).toContain("execute calls per day");
-  expect(approachingPayload.html).toContain("saved packages");
-  expect(approachingPayload.html).not.toContain("secrets");
-  expect(store.get(instanceKey("approaching", "execute_calls_per_day"))).toBe(
-    String(now.getTime()),
-  );
-  expect(store.get(instanceKey("approaching", "saved_packages"))).toBe(
-    String(now.getTime()),
-  );
-  expect(
-    store.get(instanceKey("reached", "execute_calls_per_day")),
-  ).toBeUndefined();
+	const first = await sendUserEntitlementWarningEmails({ env, now })
+	expect(first).toEqual({
+		status: 'notified',
+		emailedUsers: 1,
+		emailsSent: 1,
+		warnedResources: 2,
+	})
+	expect(sendCloudflareEmail).toHaveBeenCalledTimes(1)
+	const approachingPayload = sendCloudflareEmail.mock.calls[0]?.[1] as {
+		to: string
+		from: string
+		subject: string
+		html: string
+		text: string
+	}
+	expect(approachingPayload.to).toBe('jelias@example.com')
+	expect(approachingPayload.from).toBe('kody@kody.codes')
+	expect(approachingPayload.subject).toContain('approaching')
+	expect(approachingPayload.html).toContain(
+		'https://kody.codes/account/billing',
+	)
+	expect(approachingPayload.text).toContain('https://kody.codes/account/usage')
+	expect(approachingPayload.html).toContain('execute calls per day')
+	expect(approachingPayload.html).toContain('saved packages')
+	expect(approachingPayload.html).not.toContain('secrets')
+	expect(
+		store.get(instanceKey('approaching', 'execute_calls_per_day', now)),
+	).toBe(String(now.getTime()))
+	expect(store.get(instanceKey('approaching', 'saved_packages'))).toBe(
+		String(now.getTime()),
+	)
+	expect(
+		store.get(instanceKey('reached', 'execute_calls_per_day', now)),
+	).toBeUndefined()
 
-  sendCloudflareEmail.mockClear();
-  const stillApproaching = await sendUserEntitlementWarningEmails({
-    env,
-    now: new Date(now.getTime() + 60 * 60 * 1000),
-  });
-  expect(stillApproaching).toEqual({ status: "no_warnings" });
-  expect(sendCloudflareEmail).not.toHaveBeenCalled();
+	sendCloudflareEmail.mockClear()
+	const stillApproaching = await sendUserEntitlementWarningEmails({
+		env,
+		now: new Date(now.getTime() + 60 * 60 * 1000),
+	})
+	expect(stillApproaching).toEqual({ status: 'no_warnings' })
+	expect(sendCloudflareEmail).not.toHaveBeenCalled()
 
-  sendCloudflareEmail.mockClear();
-  const nextDayStillApproaching = await sendUserEntitlementWarningEmails({
-    env,
-    now: new Date("2026-07-26T01:00:00.000Z"),
-  });
-  expect(nextDayStillApproaching).toEqual({ status: "no_warnings" });
-  expect(sendCloudflareEmail).not.toHaveBeenCalled();
+	sendCloudflareEmail.mockClear()
+	readAdminEntitlementConsumption.mockResolvedValue([
+		consumptionRow({
+			resource: 'execute_calls_per_day',
+			label: 'execute calls per day',
+			current: 10,
+			limit: 250,
+		}),
+		consumptionRow({
+			resource: 'saved_packages',
+			label: 'saved packages',
+			current: 9,
+			limit: 10,
+		}),
+	])
+	const nextDayStillApproaching = await sendUserEntitlementWarningEmails({
+		env,
+		now: new Date('2026-07-26T01:00:00.000Z'),
+	})
+	expect(nextDayStillApproaching).toEqual({ status: 'no_warnings' })
+	expect(sendCloudflareEmail).not.toHaveBeenCalled()
 
-  readAdminEntitlementConsumption.mockResolvedValue([
-    consumptionRow({
-      resource: "execute_calls_per_day",
-      label: "execute calls per day",
-      current: 250,
-      limit: 250,
-    }),
-    consumptionRow({
-      resource: "outbound_fetches_per_day",
-      label: "outbound fetches per day",
-      current: 500,
-      limit: 500,
-    }),
-    consumptionRow({
-      resource: "saved_packages",
-      label: "saved packages",
-      current: 9,
-      limit: 10,
-    }),
-  ]);
-  const reachedAt = new Date("2026-07-26T03:00:00.000Z");
-  const reached = await sendUserEntitlementWarningEmails({
-    env,
-    now: reachedAt,
-  });
-  expect(reached).toEqual({
-    status: "notified",
-    emailedUsers: 1,
-    emailsSent: 1,
-    warnedResources: 2,
-  });
-  expect(sendCloudflareEmail).toHaveBeenCalledTimes(1);
-  const reachedPayload = sendCloudflareEmail.mock.calls[0]?.[1] as {
-    subject: string;
-    html: string;
-  };
-  expect(reachedPayload.subject).toContain("reached");
-  expect(reachedPayload.html).toContain("execute calls per day");
-  expect(reachedPayload.html).toContain("outbound fetches per day");
-  expect(reachedPayload.html).not.toContain("saved packages");
-  expect(store.get(instanceKey("reached", "execute_calls_per_day"))).toBe(
-    String(reachedAt.getTime()),
-  );
-  expect(store.get(instanceKey("approaching", "execute_calls_per_day"))).toBe(
-    String(reachedAt.getTime()),
-  );
-  expect(store.get(instanceKey("reached", "outbound_fetches_per_day"))).toBe(
-    String(reachedAt.getTime()),
-  );
+	readAdminEntitlementConsumption.mockResolvedValue([
+		consumptionRow({
+			resource: 'execute_calls_per_day',
+			label: 'execute calls per day',
+			current: 250,
+			limit: 250,
+		}),
+		consumptionRow({
+			resource: 'outbound_fetches_per_day',
+			label: 'outbound fetches per day',
+			current: 500,
+			limit: 500,
+		}),
+		consumptionRow({
+			resource: 'saved_packages',
+			label: 'saved packages',
+			current: 9,
+			limit: 10,
+		}),
+	])
+	const reachedAt = new Date('2026-07-26T03:00:00.000Z')
+	const reached = await sendUserEntitlementWarningEmails({
+		env,
+		now: reachedAt,
+	})
+	expect(reached).toEqual({
+		status: 'notified',
+		emailedUsers: 1,
+		emailsSent: 1,
+		warnedResources: 2,
+	})
+	expect(sendCloudflareEmail).toHaveBeenCalledTimes(1)
+	const reachedPayload = sendCloudflareEmail.mock.calls[0]?.[1] as {
+		subject: string
+		html: string
+	}
+	expect(reachedPayload.subject).toContain('reached')
+	expect(reachedPayload.html).toContain('execute calls per day')
+	expect(reachedPayload.html).toContain('outbound fetches per day')
+	expect(reachedPayload.html).not.toContain('saved packages')
+	expect(
+		store.get(instanceKey('reached', 'execute_calls_per_day', reachedAt)),
+	).toBe(String(reachedAt.getTime()))
+	expect(
+		store.get(instanceKey('approaching', 'execute_calls_per_day', reachedAt)),
+	).toBe(String(reachedAt.getTime()))
+	expect(
+		store.get(instanceKey('reached', 'outbound_fetches_per_day', reachedAt)),
+	).toBe(String(reachedAt.getTime()))
 
-  sendCloudflareEmail.mockClear();
-  const stillReachedNextDay = await sendUserEntitlementWarningEmails({
-    env,
-    now: new Date("2026-07-27T01:00:00.000Z"),
-  });
-  expect(stillReachedNextDay).toEqual({ status: "no_warnings" });
-  expect(sendCloudflareEmail).not.toHaveBeenCalled();
+	sendCloudflareEmail.mockClear()
+	const stillReachedSameDay = await sendUserEntitlementWarningEmails({
+		env,
+		now: new Date('2026-07-26T04:00:00.000Z'),
+	})
+	expect(stillReachedSameDay).toEqual({ status: 'no_warnings' })
+	expect(sendCloudflareEmail).not.toHaveBeenCalled()
 
-  readAdminEntitlementConsumption.mockResolvedValue([
-    consumptionRow({
-      resource: "execute_calls_per_day",
-      label: "execute calls per day",
-      current: 200,
-      limit: 250,
-    }),
-    consumptionRow({
-      resource: "outbound_fetches_per_day",
-      label: "outbound fetches per day",
-      current: 500,
-      limit: 500,
-    }),
-    consumptionRow({
-      resource: "saved_packages",
-      label: "saved packages",
-      current: 9,
-      limit: 10,
-    }),
-  ]);
-  sendCloudflareEmail.mockClear();
-  const droppedToApproaching = await sendUserEntitlementWarningEmails({
-    env,
-    now: new Date("2026-07-27T02:00:00.000Z"),
-  });
-  expect(droppedToApproaching).toEqual({ status: "no_warnings" });
-  expect(sendCloudflareEmail).not.toHaveBeenCalled();
-  expect(
-    store.get(instanceKey("reached", "execute_calls_per_day")),
-  ).toBeUndefined();
-  expect(store.get(instanceKey("approaching", "execute_calls_per_day"))).toBe(
-    String(reachedAt.getTime()),
-  );
+	readAdminEntitlementConsumption.mockResolvedValue([
+		consumptionRow({
+			resource: 'execute_calls_per_day',
+			label: 'execute calls per day',
+			current: 200,
+			limit: 250,
+		}),
+		consumptionRow({
+			resource: 'outbound_fetches_per_day',
+			label: 'outbound fetches per day',
+			current: 500,
+			limit: 500,
+		}),
+		consumptionRow({
+			resource: 'saved_packages',
+			label: 'saved packages',
+			current: 9,
+			limit: 10,
+		}),
+	])
+	sendCloudflareEmail.mockClear()
+	const nextUtcDay = new Date('2026-07-27T02:00:00.000Z')
+	const droppedToApproaching = await sendUserEntitlementWarningEmails({
+		env,
+		now: nextUtcDay,
+	})
+	expect(droppedToApproaching).toEqual({
+		status: 'notified',
+		emailedUsers: 1,
+		emailsSent: 2,
+		warnedResources: 2,
+	})
+	expect(sendCloudflareEmail).toHaveBeenCalledTimes(2)
+	expect(
+		store.get(instanceKey('reached', 'outbound_fetches_per_day', nextUtcDay)),
+	).toBe(String(nextUtcDay.getTime()))
+	expect(
+		store.get(instanceKey('approaching', 'execute_calls_per_day', nextUtcDay)),
+	).toBe(String(nextUtcDay.getTime()))
+	expect(
+		store.get(instanceKey('reached', 'execute_calls_per_day', nextUtcDay)),
+	).toBeUndefined()
 
-  readAdminEntitlementConsumption.mockResolvedValue([
-    consumptionRow({
-      resource: "execute_calls_per_day",
-      label: "execute calls per day",
-      current: 10,
-      limit: 250,
-    }),
-    consumptionRow({
-      resource: "outbound_fetches_per_day",
-      label: "outbound fetches per day",
-      current: 0,
-      limit: 500,
-    }),
-    consumptionRow({
-      resource: "saved_packages",
-      label: "saved packages",
-      current: 2,
-      limit: 10,
-    }),
-  ]);
-  const clearedAt = new Date("2026-07-27T04:00:00.000Z");
-  await sendUserEntitlementWarningEmails({ env, now: clearedAt });
-  expect(
-    store.get(instanceKey("approaching", "execute_calls_per_day")),
-  ).toBeUndefined();
-  expect(
-    store.get(instanceKey("approaching", "saved_packages")),
-  ).toBeUndefined();
-  expect(
-    store.get(instanceKey("reached", "outbound_fetches_per_day")),
-  ).toBeUndefined();
+	readAdminEntitlementConsumption.mockResolvedValue([
+		consumptionRow({
+			resource: 'execute_calls_per_day',
+			label: 'execute calls per day',
+			current: 10,
+			limit: 250,
+		}),
+		consumptionRow({
+			resource: 'outbound_fetches_per_day',
+			label: 'outbound fetches per day',
+			current: 0,
+			limit: 500,
+		}),
+		consumptionRow({
+			resource: 'saved_packages',
+			label: 'saved packages',
+			current: 2,
+			limit: 10,
+		}),
+	])
+	const clearedAt = new Date('2026-07-27T04:00:00.000Z')
+	await sendUserEntitlementWarningEmails({ env, now: clearedAt })
+	expect(
+		store.get(instanceKey('approaching', 'execute_calls_per_day', clearedAt)),
+	).toBeUndefined()
+	expect(
+		store.get(instanceKey('approaching', 'saved_packages')),
+	).toBeUndefined()
+	expect(
+		store.get(instanceKey('reached', 'outbound_fetches_per_day', clearedAt)),
+	).toBeUndefined()
 
-  readAdminEntitlementConsumption.mockResolvedValue([
-    consumptionRow({
-      resource: "saved_packages",
-      label: "saved packages",
-      current: 10,
-      limit: 10,
-    }),
-  ]);
-  sendCloudflareEmail.mockClear();
-  const jumpedToLimit = new Date("2026-07-27T05:00:00.000Z");
-  const jumped = await sendUserEntitlementWarningEmails({
-    env,
-    now: jumpedToLimit,
-  });
-  expect(jumped).toEqual({
-    status: "notified",
-    emailedUsers: 1,
-    emailsSent: 1,
-    warnedResources: 1,
-  });
-  expect(sendCloudflareEmail).toHaveBeenCalledTimes(1);
-  expect(
-    (sendCloudflareEmail.mock.calls[0]?.[1] as { subject: string }).subject,
-  ).toContain("reached");
-  expect(store.get(instanceKey("reached", "saved_packages"))).toBe(
-    String(jumpedToLimit.getTime()),
-  );
-  expect(store.get(instanceKey("approaching", "saved_packages"))).toBe(
-    String(jumpedToLimit.getTime()),
-  );
+	readAdminEntitlementConsumption.mockResolvedValue([
+		consumptionRow({
+			resource: 'saved_packages',
+			label: 'saved packages',
+			current: 10,
+			limit: 10,
+		}),
+	])
+	sendCloudflareEmail.mockClear()
+	const jumpedToLimit = new Date('2026-07-27T05:00:00.000Z')
+	const jumped = await sendUserEntitlementWarningEmails({
+		env,
+		now: jumpedToLimit,
+	})
+	expect(jumped).toEqual({
+		status: 'notified',
+		emailedUsers: 1,
+		emailsSent: 1,
+		warnedResources: 1,
+	})
+	expect(sendCloudflareEmail).toHaveBeenCalledTimes(1)
+	expect(
+		(sendCloudflareEmail.mock.calls[0]?.[1] as { subject: string }).subject,
+	).toContain('reached')
+	expect(store.get(instanceKey('reached', 'saved_packages'))).toBe(
+		String(jumpedToLimit.getTime()),
+	)
+	expect(store.get(instanceKey('approaching', 'saved_packages'))).toBe(
+		String(jumpedToLimit.getTime()),
+	)
 
-  readAdminEntitlementConsumption.mockResolvedValue([
-    consumptionRow({
-      resource: "saved_packages",
-      label: "saved packages",
-      current: 9,
-      limit: 10,
-    }),
-  ]);
-  sendCloudflareEmail.mockClear();
-  const afterDropFromLimit = await sendUserEntitlementWarningEmails({
-    env,
-    now: new Date("2026-07-27T06:00:00.000Z"),
-  });
-  expect(afterDropFromLimit).toEqual({ status: "no_warnings" });
-  expect(sendCloudflareEmail).not.toHaveBeenCalled();
-});
+	readAdminEntitlementConsumption.mockResolvedValue([
+		consumptionRow({
+			resource: 'saved_packages',
+			label: 'saved packages',
+			current: 9,
+			limit: 10,
+		}),
+	])
+	sendCloudflareEmail.mockClear()
+	const afterDropFromLimit = await sendUserEntitlementWarningEmails({
+		env,
+		now: new Date('2026-07-27T06:00:00.000Z'),
+	})
+	expect(afterDropFromLimit).toEqual({ status: 'no_warnings' })
+	expect(sendCloudflareEmail).not.toHaveBeenCalled()
+})
 
-test("user entitlement warnings absorb leftover daily claims without mailing again", async () => {
-  const now = new Date("2026-08-24T03:00:00.000Z");
-  const { kv, store } = createKv();
-  store.set(
-    userEntitlementWarningDailyKvKey({
-      userId: stableUserId,
-      kind: "reached",
-      day: utcDayKey(now),
-    }),
-    String(now.getTime() - 60 * 60 * 1000),
-  );
-  readAdminEntitlementConsumption.mockResolvedValue([
-    consumptionRow({
-      resource: "saved_packages",
-      label: "saved packages",
-      current: 10,
-      limit: 10,
-    }),
-  ]);
-  sendCloudflareEmail.mockClear();
-  const env = createEnv({
-    users: [
-      {
-        stable_user_id: stableUserId,
-        email: "maciek@example.com",
-        plan: "free",
-        stripe_plan: null,
-      },
-    ],
-    kv,
-  });
+test('user entitlement warnings absorb leftover daily claims without mailing again', async () => {
+	const now = new Date('2026-08-24T03:00:00.000Z')
+	const twoDaysAgo = new Date(now.getTime() - 2 * 24 * 60 * 60 * 1000)
+	const { kv, store } = createKv()
+	store.set(
+		userEntitlementWarningDailyKvKey({
+			userId: stableUserId,
+			kind: 'reached',
+			day: utcDayKey(twoDaysAgo),
+		}),
+		String(twoDaysAgo.getTime()),
+	)
+	readAdminEntitlementConsumption.mockResolvedValue([
+		consumptionRow({
+			resource: 'saved_packages',
+			label: 'saved packages',
+			current: 10,
+			limit: 10,
+		}),
+	])
+	sendCloudflareEmail.mockClear()
+	const env = createEnv({
+		users: [
+			{
+				stable_user_id: stableUserId,
+				email: 'maciek@example.com',
+				plan: 'free',
+				stripe_plan: null,
+			},
+		],
+		kv,
+	})
 
-  const absorbed = await sendUserEntitlementWarningEmails({ env, now });
-  expect(absorbed).toEqual({ status: "no_warnings" });
-  expect(sendCloudflareEmail).not.toHaveBeenCalled();
-  expect(store.get(instanceKey("reached", "saved_packages"))).toBe(
-    String(now.getTime()),
-  );
-  expect(store.get(instanceKey("approaching", "saved_packages"))).toBe(
-    String(now.getTime()),
-  );
+	const absorbed = await sendUserEntitlementWarningEmails({ env, now })
+	expect(absorbed).toEqual({ status: 'no_warnings' })
+	expect(sendCloudflareEmail).not.toHaveBeenCalled()
+	expect(store.get(instanceKey('reached', 'saved_packages'))).toBe(
+		String(now.getTime()),
+	)
+	expect(store.get(instanceKey('approaching', 'saved_packages'))).toBe(
+		String(now.getTime()),
+	)
 
-  sendCloudflareEmail.mockClear();
-  const nextDay = await sendUserEntitlementWarningEmails({
-    env,
-    now: new Date("2026-08-25T01:00:00.000Z"),
-  });
-  expect(nextDay).toEqual({ status: "no_warnings" });
-  expect(sendCloudflareEmail).not.toHaveBeenCalled();
-});
+	sendCloudflareEmail.mockClear()
+	const nextDay = await sendUserEntitlementWarningEmails({
+		env,
+		now: new Date('2026-08-25T01:00:00.000Z'),
+	})
+	expect(nextDay).toEqual({ status: 'no_warnings' })
+	expect(sendCloudflareEmail).not.toHaveBeenCalled()
+})
 
-test("user entitlement warnings skip when KV or transactional email is missing", async () => {
-  readAdminEntitlementConsumption.mockResolvedValue([
-    consumptionRow({
-      resource: "execute_calls_per_day",
-      label: "execute calls per day",
-      current: 200,
-      limit: 250,
-    }),
-  ]);
-  sendCloudflareEmail.mockClear();
-  const noKv = await sendUserEntitlementWarningEmails({
-    env: createEnv({
-      users: [
-        {
-          stable_user_id: stableUserId,
-          email: "user@example.com",
-          plan: "free",
-          stripe_plan: null,
-        },
-      ],
-    }),
-  });
-  expect(noKv).toEqual({ status: "skipped", reason: "no_kv" });
-  expect(sendCloudflareEmail).not.toHaveBeenCalled();
+test('user entitlement warnings skip when KV or transactional email is missing', async () => {
+	readAdminEntitlementConsumption.mockResolvedValue([
+		consumptionRow({
+			resource: 'execute_calls_per_day',
+			label: 'execute calls per day',
+			current: 200,
+			limit: 250,
+		}),
+	])
+	sendCloudflareEmail.mockClear()
+	const noKv = await sendUserEntitlementWarningEmails({
+		env: createEnv({
+			users: [
+				{
+					stable_user_id: stableUserId,
+					email: 'user@example.com',
+					plan: 'free',
+					stripe_plan: null,
+				},
+			],
+		}),
+	})
+	expect(noKv).toEqual({ status: 'skipped', reason: 'no_kv' })
+	expect(sendCloudflareEmail).not.toHaveBeenCalled()
 
-  const { kv } = createKv();
-  const noConfig = await sendUserEntitlementWarningEmails({
-    env: {
-      APP_DB: createDb([]),
-      BUNDLE_ARTIFACTS_KV: kv,
-    } as unknown as Env,
-  });
-  expect(noConfig).toEqual({ status: "skipped", reason: "no_email_config" });
-});
+	const { kv } = createKv()
+	const noConfig = await sendUserEntitlementWarningEmails({
+		env: {
+			APP_DB: createDb([]),
+			BUNDLE_ARTIFACTS_KV: kv,
+		} as unknown as Env,
+	})
+	expect(noConfig).toEqual({ status: 'skipped', reason: 'no_email_config' })
+})

--- a/packages/worker/src/app/user-entitlement-warning-emails.node.test.ts
+++ b/packages/worker/src/app/user-entitlement-warning-emails.node.test.ts
@@ -413,6 +413,12 @@ test('user entitlement warnings absorb leftover daily claims without mailing aga
 			current: 10,
 			limit: 10,
 		}),
+		consumptionRow({
+			resource: 'execute_calls_per_day',
+			label: 'execute calls per day',
+			current: 250,
+			limit: 250,
+		}),
 	])
 	sendCloudflareEmail.mockClear()
 	const env = createEnv({
@@ -428,15 +434,43 @@ test('user entitlement warnings absorb leftover daily claims without mailing aga
 	})
 
 	const absorbed = await sendUserEntitlementWarningEmails({ env, now })
-	expect(absorbed).toEqual({ status: 'no_warnings' })
-	expect(sendCloudflareEmail).not.toHaveBeenCalled()
+	expect(absorbed).toEqual({
+		status: 'notified',
+		emailedUsers: 1,
+		emailsSent: 1,
+		warnedResources: 1,
+	})
+	expect(sendCloudflareEmail).toHaveBeenCalledTimes(1)
+	expect(
+		(sendCloudflareEmail.mock.calls[0]?.[1] as { html: string }).html,
+	).toContain('execute calls per day')
+	expect(
+		(sendCloudflareEmail.mock.calls[0]?.[1] as { html: string }).html,
+	).not.toContain('saved packages')
 	expect(store.get(instanceKey('reached', 'saved_packages'))).toBe(
 		String(now.getTime()),
 	)
 	expect(store.get(instanceKey('approaching', 'saved_packages'))).toBe(
 		String(now.getTime()),
 	)
+	expect(store.get(instanceKey('reached', 'execute_calls_per_day', now))).toBe(
+		String(now.getTime()),
+	)
 
+	readAdminEntitlementConsumption.mockResolvedValue([
+		consumptionRow({
+			resource: 'saved_packages',
+			label: 'saved packages',
+			current: 10,
+			limit: 10,
+		}),
+		consumptionRow({
+			resource: 'execute_calls_per_day',
+			label: 'execute calls per day',
+			current: 0,
+			limit: 250,
+		}),
+	])
 	sendCloudflareEmail.mockClear()
 	const nextDay = await sendUserEntitlementWarningEmails({
 		env,

--- a/packages/worker/src/app/user-entitlement-warning-emails.node.test.ts
+++ b/packages/worker/src/app/user-entitlement-warning-emails.node.test.ts
@@ -1,295 +1,456 @@
-import { expect, test, vi } from 'vitest'
-import { utcDayKey } from '@kody-internal/shared/date-keys.ts'
+import { expect, test, vi } from "vitest";
+import { utcDayKey } from "@kody-internal/shared/date-keys.ts";
+import type { EntitlementResource } from "#universal/plans.ts";
 
-const readAdminEntitlementConsumption = vi.fn()
+const readAdminEntitlementConsumption = vi.fn();
 
-vi.mock('#worker/admin/entitlement-consumption.ts', () => ({
-	readAdminEntitlementConsumption: (...args: Array<unknown>) =>
-		readAdminEntitlementConsumption(...args),
-	entitlementWarningThreshold: 0.8,
-}))
+vi.mock("#worker/admin/entitlement-consumption.ts", () => ({
+  readAdminEntitlementConsumption: (...args: Array<unknown>) =>
+    readAdminEntitlementConsumption(...args),
+  entitlementWarningThreshold: 0.8,
+}));
 
-const sendCloudflareEmail = vi.fn(async () => ({ ok: true }))
+const sendCloudflareEmail = vi.fn(async () => ({ ok: true }));
 
-vi.mock('#app/email/cloudflare-email.ts', () => ({
-	sendCloudflareEmail: (...args: Array<unknown>) =>
-		sendCloudflareEmail(...args),
-}))
+vi.mock("#app/email/cloudflare-email.ts", () => ({
+  sendCloudflareEmail: (...args: Array<unknown>) =>
+    sendCloudflareEmail(...args),
+}));
 
-const { sendUserEntitlementWarningEmails, userEntitlementWarningKvKey } =
-	await import('#app/user-entitlement-warning-emails.ts')
+const {
+  sendUserEntitlementWarningEmails,
+  userEntitlementWarningDailyKvKey,
+  userEntitlementWarningKvKey,
+} = await import("#app/user-entitlement-warning-emails.ts");
 
-const stableUserId = 'a'.repeat(64)
+const stableUserId = "a".repeat(64);
 
 function consumptionRow(input: {
-	resource: string
-	label: string
-	current: number
-	limit: number
+  resource: EntitlementResource;
+  label: string;
+  current: number;
+  limit: number;
 }) {
-	return {
-		...input,
-		percentOfLimit: input.current / input.limit,
-		overEightyPercent: input.current / input.limit > 0.8,
-	}
+  return {
+    ...input,
+    percentOfLimit: input.current / input.limit,
+    overEightyPercent: input.current / input.limit > 0.8,
+  };
 }
 
 function createKv() {
-	const store = new Map<string, string>()
-	return {
-		store,
-		kv: {
-			async get(key: string) {
-				return store.get(key) ?? null
-			},
-			async put(key: string, value: string) {
-				store.set(key, value)
-			},
-		} as unknown as KVNamespace,
-	}
+  const store = new Map<string, string>();
+  return {
+    store,
+    kv: {
+      async get(key: string) {
+        return store.get(key) ?? null;
+      },
+      async put(key: string, value: string) {
+        store.set(key, value);
+      },
+      async delete(key: string) {
+        store.delete(key);
+      },
+    } as unknown as KVNamespace,
+  };
 }
 
 function createDb(
-	users: Array<{
-		stable_user_id: string
-		email: string
-		plan: string
-		stripe_plan: string | null
-	}>,
+  users: Array<{
+    stable_user_id: string;
+    email: string;
+    plan: string;
+    stripe_plan: string | null;
+  }>,
 ) {
-	return {
-		prepare(query: string) {
-			const normalized = query.replace(/\s+/g, ' ').trim().toLowerCase()
-			return {
-				bind(..._params: Array<unknown>) {
-					return this
-				},
-				async all<T>() {
-					if (normalized.includes('from usage_rollups')) {
-						return { results: users as Array<T> }
-					}
-					return { results: [] }
-				},
-			}
-		},
-	} as unknown as D1Database
+  return {
+    prepare(query: string) {
+      const normalized = query.replace(/\s+/g, " ").trim().toLowerCase();
+      return {
+        bind(..._params: Array<unknown>) {
+          return this;
+        },
+        async all<T>() {
+          if (normalized.includes("from usage_rollups")) {
+            return { results: users as Array<T> };
+          }
+          return { results: [] };
+        },
+      };
+    },
+  } as unknown as D1Database;
 }
 
 function createEnv(input: {
-	users: Array<{
-		stable_user_id: string
-		email: string
-		plan: string
-		stripe_plan: string | null
-	}>
-	kv?: KVNamespace
+  users: Array<{
+    stable_user_id: string;
+    email: string;
+    plan: string;
+    stripe_plan: string | null;
+  }>;
+  kv?: KVNamespace;
 }) {
-	return {
-		APP_DB: createDb(input.users),
-		APP_BASE_URL: 'https://heykody.dev/',
-		CLOUDFLARE_ACCOUNT_ID: 'acct',
-		CLOUDFLARE_API_TOKEN: 'token',
-		BUNDLE_ARTIFACTS_KV: input.kv,
-	} as unknown as Env
+  return {
+    APP_DB: createDb(input.users),
+    APP_BASE_URL: "https://kody.codes/",
+    CLOUDFLARE_ACCOUNT_ID: "acct",
+    CLOUDFLARE_API_TOKEN: "token",
+    BUNDLE_ARTIFACTS_KV: input.kv,
+  } as unknown as Env;
 }
 
-test('user entitlement warnings send one 80% email and one 100% email per UTC day regardless of resource', async () => {
-	const now = new Date('2026-07-25T12:00:00.000Z')
-	const { kv, store } = createKv()
-	readAdminEntitlementConsumption.mockResolvedValue([
-		consumptionRow({
-			resource: 'execute_calls_per_day',
-			label: 'execute calls per day',
-			current: 200,
-			limit: 250,
-		}),
-		consumptionRow({
-			resource: 'saved_packages',
-			label: 'saved packages',
-			current: 9,
-			limit: 10,
-		}),
-		consumptionRow({
-			resource: 'secrets',
-			label: 'secrets',
-			current: 4,
-			limit: 25,
-		}),
-	])
-	const env = createEnv({
-		users: [
-			{
-				stable_user_id: stableUserId,
-				email: 'jelias@example.com',
-				plan: 'free',
-				stripe_plan: null,
-			},
-		],
-		kv,
-	})
+function instanceKey(
+  kind: "approaching" | "reached",
+  resource: EntitlementResource,
+) {
+  return userEntitlementWarningKvKey({
+    userId: stableUserId,
+    kind,
+    resource,
+  });
+}
 
-	const first = await sendUserEntitlementWarningEmails({ env, now })
-	expect(first).toEqual({
-		status: 'notified',
-		emailedUsers: 1,
-		emailsSent: 1,
-		warnedResources: 2,
-	})
-	expect(sendCloudflareEmail).toHaveBeenCalledTimes(1)
-	const approachingPayload = sendCloudflareEmail.mock.calls[0]?.[1] as {
-		to: string
-		from: string
-		subject: string
-		html: string
-		text: string
-	}
-	expect(approachingPayload.to).toBe('jelias@example.com')
-	expect(approachingPayload.from).toBe('kody@heykody.dev')
-	expect(approachingPayload.subject).toContain('approaching')
-	expect(approachingPayload.html).toContain(
-		'https://heykody.dev/account/billing',
-	)
-	expect(approachingPayload.text).toContain('https://heykody.dev/account/usage')
-	expect(approachingPayload.html).toContain('execute calls per day')
-	expect(approachingPayload.html).toContain('saved packages')
-	expect(approachingPayload.html).not.toContain('secrets')
-	expect(approachingPayload.html).toContain(
-		'https://heykody.dev/images/kody-lantern.png',
-	)
+test("user entitlement warnings mail once per entitlement crossing, not once per day", async () => {
+  const now = new Date("2026-07-25T12:00:00.000Z");
+  const { kv, store } = createKv();
+  readAdminEntitlementConsumption.mockResolvedValue([
+    consumptionRow({
+      resource: "execute_calls_per_day",
+      label: "execute calls per day",
+      current: 200,
+      limit: 250,
+    }),
+    consumptionRow({
+      resource: "saved_packages",
+      label: "saved packages",
+      current: 9,
+      limit: 10,
+    }),
+    consumptionRow({
+      resource: "secrets",
+      label: "secrets",
+      current: 4,
+      limit: 25,
+    }),
+  ]);
+  const env = createEnv({
+    users: [
+      {
+        stable_user_id: stableUserId,
+        email: "jelias@example.com",
+        plan: "free",
+        stripe_plan: null,
+      },
+    ],
+    kv,
+  });
 
-	const approachingKey = userEntitlementWarningKvKey({
-		userId: stableUserId,
-		kind: 'approaching',
-		day: utcDayKey(now),
-	})
-	expect(store.get(approachingKey)).toBe(String(now.getTime()))
-	expect(
-		store.get(
-			userEntitlementWarningKvKey({
-				userId: stableUserId,
-				kind: 'reached',
-				day: utcDayKey(now),
-			}),
-		),
-	).toBeUndefined()
+  const first = await sendUserEntitlementWarningEmails({ env, now });
+  expect(first).toEqual({
+    status: "notified",
+    emailedUsers: 1,
+    emailsSent: 1,
+    warnedResources: 2,
+  });
+  expect(sendCloudflareEmail).toHaveBeenCalledTimes(1);
+  const approachingPayload = sendCloudflareEmail.mock.calls[0]?.[1] as {
+    to: string;
+    from: string;
+    subject: string;
+    html: string;
+    text: string;
+  };
+  expect(approachingPayload.to).toBe("jelias@example.com");
+  expect(approachingPayload.from).toBe("kody@kody.codes");
+  expect(approachingPayload.subject).toContain("approaching");
+  expect(approachingPayload.html).toContain(
+    "https://kody.codes/account/billing",
+  );
+  expect(approachingPayload.text).toContain("https://kody.codes/account/usage");
+  expect(approachingPayload.html).toContain("execute calls per day");
+  expect(approachingPayload.html).toContain("saved packages");
+  expect(approachingPayload.html).not.toContain("secrets");
+  expect(store.get(instanceKey("approaching", "execute_calls_per_day"))).toBe(
+    String(now.getTime()),
+  );
+  expect(store.get(instanceKey("approaching", "saved_packages"))).toBe(
+    String(now.getTime()),
+  );
+  expect(
+    store.get(instanceKey("reached", "execute_calls_per_day")),
+  ).toBeUndefined();
 
-	sendCloudflareEmail.mockClear()
-	const stillApproaching = await sendUserEntitlementWarningEmails({
-		env,
-		now: new Date(now.getTime() + 60 * 60 * 1000),
-	})
-	expect(stillApproaching).toEqual({ status: 'no_warnings' })
-	expect(sendCloudflareEmail).not.toHaveBeenCalled()
+  sendCloudflareEmail.mockClear();
+  const stillApproaching = await sendUserEntitlementWarningEmails({
+    env,
+    now: new Date(now.getTime() + 60 * 60 * 1000),
+  });
+  expect(stillApproaching).toEqual({ status: "no_warnings" });
+  expect(sendCloudflareEmail).not.toHaveBeenCalled();
 
-	readAdminEntitlementConsumption.mockResolvedValue([
-		consumptionRow({
-			resource: 'execute_calls_per_day',
-			label: 'execute calls per day',
-			current: 250,
-			limit: 250,
-		}),
-		consumptionRow({
-			resource: 'outbound_fetches_per_day',
-			label: 'outbound fetches per day',
-			current: 500,
-			limit: 500,
-		}),
-		consumptionRow({
-			resource: 'saved_packages',
-			label: 'saved packages',
-			current: 9,
-			limit: 10,
-		}),
-	])
-	const reached = await sendUserEntitlementWarningEmails({
-		env,
-		now: new Date(now.getTime() + 2 * 60 * 60 * 1000),
-	})
-	expect(reached).toEqual({
-		status: 'notified',
-		emailedUsers: 1,
-		emailsSent: 1,
-		warnedResources: 2,
-	})
-	expect(sendCloudflareEmail).toHaveBeenCalledTimes(1)
-	const reachedPayload = sendCloudflareEmail.mock.calls[0]?.[1] as {
-		subject: string
-		html: string
-	}
-	expect(reachedPayload.subject).toContain('reached')
-	expect(reachedPayload.html).toContain('execute calls per day')
-	expect(reachedPayload.html).toContain('outbound fetches per day')
-	expect(reachedPayload.html).not.toContain('saved packages')
-	expect(
-		store.get(
-			userEntitlementWarningKvKey({
-				userId: stableUserId,
-				kind: 'reached',
-				day: utcDayKey(now),
-			}),
-		),
-	).toBe(String(now.getTime() + 2 * 60 * 60 * 1000))
+  sendCloudflareEmail.mockClear();
+  const nextDayStillApproaching = await sendUserEntitlementWarningEmails({
+    env,
+    now: new Date("2026-07-26T01:00:00.000Z"),
+  });
+  expect(nextDayStillApproaching).toEqual({ status: "no_warnings" });
+  expect(sendCloudflareEmail).not.toHaveBeenCalled();
 
-	sendCloudflareEmail.mockClear()
-	const sameDay = await sendUserEntitlementWarningEmails({
-		env,
-		now: new Date(now.getTime() + 3 * 60 * 60 * 1000),
-	})
-	expect(sameDay).toEqual({ status: 'no_warnings' })
-	expect(sendCloudflareEmail).not.toHaveBeenCalled()
+  readAdminEntitlementConsumption.mockResolvedValue([
+    consumptionRow({
+      resource: "execute_calls_per_day",
+      label: "execute calls per day",
+      current: 250,
+      limit: 250,
+    }),
+    consumptionRow({
+      resource: "outbound_fetches_per_day",
+      label: "outbound fetches per day",
+      current: 500,
+      limit: 500,
+    }),
+    consumptionRow({
+      resource: "saved_packages",
+      label: "saved packages",
+      current: 9,
+      limit: 10,
+    }),
+  ]);
+  const reachedAt = new Date("2026-07-26T03:00:00.000Z");
+  const reached = await sendUserEntitlementWarningEmails({
+    env,
+    now: reachedAt,
+  });
+  expect(reached).toEqual({
+    status: "notified",
+    emailedUsers: 1,
+    emailsSent: 1,
+    warnedResources: 2,
+  });
+  expect(sendCloudflareEmail).toHaveBeenCalledTimes(1);
+  const reachedPayload = sendCloudflareEmail.mock.calls[0]?.[1] as {
+    subject: string;
+    html: string;
+  };
+  expect(reachedPayload.subject).toContain("reached");
+  expect(reachedPayload.html).toContain("execute calls per day");
+  expect(reachedPayload.html).toContain("outbound fetches per day");
+  expect(reachedPayload.html).not.toContain("saved packages");
+  expect(store.get(instanceKey("reached", "execute_calls_per_day"))).toBe(
+    String(reachedAt.getTime()),
+  );
+  expect(store.get(instanceKey("approaching", "execute_calls_per_day"))).toBe(
+    String(reachedAt.getTime()),
+  );
+  expect(store.get(instanceKey("reached", "outbound_fetches_per_day"))).toBe(
+    String(reachedAt.getTime()),
+  );
 
-	const nextDay = new Date('2026-07-26T01:00:00.000Z')
-	const nextDayResult = await sendUserEntitlementWarningEmails({
-		env,
-		now: nextDay,
-	})
-	expect(nextDayResult).toEqual({
-		status: 'notified',
-		emailedUsers: 1,
-		emailsSent: 2,
-		warnedResources: 3,
-	})
-	expect(sendCloudflareEmail).toHaveBeenCalledTimes(2)
-	const nextSubjects = sendCloudflareEmail.mock.calls.map(
-		(call) => (call[1] as { subject: string }).subject,
-	)
-	expect(nextSubjects).toEqual([
-		"You've reached a Kody plan limit",
-		"You're approaching a Kody plan limit",
-	])
-})
+  sendCloudflareEmail.mockClear();
+  const stillReachedNextDay = await sendUserEntitlementWarningEmails({
+    env,
+    now: new Date("2026-07-27T01:00:00.000Z"),
+  });
+  expect(stillReachedNextDay).toEqual({ status: "no_warnings" });
+  expect(sendCloudflareEmail).not.toHaveBeenCalled();
 
-test('user entitlement warnings skip when KV or transactional email is missing', async () => {
-	readAdminEntitlementConsumption.mockResolvedValue([
-		consumptionRow({
-			resource: 'execute_calls_per_day',
-			label: 'execute calls per day',
-			current: 200,
-			limit: 250,
-		}),
-	])
-	sendCloudflareEmail.mockClear()
-	const noKv = await sendUserEntitlementWarningEmails({
-		env: createEnv({
-			users: [
-				{
-					stable_user_id: stableUserId,
-					email: 'user@example.com',
-					plan: 'free',
-					stripe_plan: null,
-				},
-			],
-		}),
-	})
-	expect(noKv).toEqual({ status: 'skipped', reason: 'no_kv' })
-	expect(sendCloudflareEmail).not.toHaveBeenCalled()
+  readAdminEntitlementConsumption.mockResolvedValue([
+    consumptionRow({
+      resource: "execute_calls_per_day",
+      label: "execute calls per day",
+      current: 200,
+      limit: 250,
+    }),
+    consumptionRow({
+      resource: "outbound_fetches_per_day",
+      label: "outbound fetches per day",
+      current: 500,
+      limit: 500,
+    }),
+    consumptionRow({
+      resource: "saved_packages",
+      label: "saved packages",
+      current: 9,
+      limit: 10,
+    }),
+  ]);
+  sendCloudflareEmail.mockClear();
+  const droppedToApproaching = await sendUserEntitlementWarningEmails({
+    env,
+    now: new Date("2026-07-27T02:00:00.000Z"),
+  });
+  expect(droppedToApproaching).toEqual({ status: "no_warnings" });
+  expect(sendCloudflareEmail).not.toHaveBeenCalled();
+  expect(
+    store.get(instanceKey("reached", "execute_calls_per_day")),
+  ).toBeUndefined();
+  expect(store.get(instanceKey("approaching", "execute_calls_per_day"))).toBe(
+    String(reachedAt.getTime()),
+  );
 
-	const { kv } = createKv()
-	const noConfig = await sendUserEntitlementWarningEmails({
-		env: {
-			APP_DB: createDb([]),
-			BUNDLE_ARTIFACTS_KV: kv,
-		} as unknown as Env,
-	})
-	expect(noConfig).toEqual({ status: 'skipped', reason: 'no_email_config' })
-})
+  readAdminEntitlementConsumption.mockResolvedValue([
+    consumptionRow({
+      resource: "execute_calls_per_day",
+      label: "execute calls per day",
+      current: 10,
+      limit: 250,
+    }),
+    consumptionRow({
+      resource: "outbound_fetches_per_day",
+      label: "outbound fetches per day",
+      current: 0,
+      limit: 500,
+    }),
+    consumptionRow({
+      resource: "saved_packages",
+      label: "saved packages",
+      current: 2,
+      limit: 10,
+    }),
+  ]);
+  const clearedAt = new Date("2026-07-27T04:00:00.000Z");
+  await sendUserEntitlementWarningEmails({ env, now: clearedAt });
+  expect(
+    store.get(instanceKey("approaching", "execute_calls_per_day")),
+  ).toBeUndefined();
+  expect(
+    store.get(instanceKey("approaching", "saved_packages")),
+  ).toBeUndefined();
+  expect(
+    store.get(instanceKey("reached", "outbound_fetches_per_day")),
+  ).toBeUndefined();
+
+  readAdminEntitlementConsumption.mockResolvedValue([
+    consumptionRow({
+      resource: "saved_packages",
+      label: "saved packages",
+      current: 10,
+      limit: 10,
+    }),
+  ]);
+  sendCloudflareEmail.mockClear();
+  const jumpedToLimit = new Date("2026-07-27T05:00:00.000Z");
+  const jumped = await sendUserEntitlementWarningEmails({
+    env,
+    now: jumpedToLimit,
+  });
+  expect(jumped).toEqual({
+    status: "notified",
+    emailedUsers: 1,
+    emailsSent: 1,
+    warnedResources: 1,
+  });
+  expect(sendCloudflareEmail).toHaveBeenCalledTimes(1);
+  expect(
+    (sendCloudflareEmail.mock.calls[0]?.[1] as { subject: string }).subject,
+  ).toContain("reached");
+  expect(store.get(instanceKey("reached", "saved_packages"))).toBe(
+    String(jumpedToLimit.getTime()),
+  );
+  expect(store.get(instanceKey("approaching", "saved_packages"))).toBe(
+    String(jumpedToLimit.getTime()),
+  );
+
+  readAdminEntitlementConsumption.mockResolvedValue([
+    consumptionRow({
+      resource: "saved_packages",
+      label: "saved packages",
+      current: 9,
+      limit: 10,
+    }),
+  ]);
+  sendCloudflareEmail.mockClear();
+  const afterDropFromLimit = await sendUserEntitlementWarningEmails({
+    env,
+    now: new Date("2026-07-27T06:00:00.000Z"),
+  });
+  expect(afterDropFromLimit).toEqual({ status: "no_warnings" });
+  expect(sendCloudflareEmail).not.toHaveBeenCalled();
+});
+
+test("user entitlement warnings absorb leftover daily claims without mailing again", async () => {
+  const now = new Date("2026-08-24T03:00:00.000Z");
+  const { kv, store } = createKv();
+  store.set(
+    userEntitlementWarningDailyKvKey({
+      userId: stableUserId,
+      kind: "reached",
+      day: utcDayKey(now),
+    }),
+    String(now.getTime() - 60 * 60 * 1000),
+  );
+  readAdminEntitlementConsumption.mockResolvedValue([
+    consumptionRow({
+      resource: "saved_packages",
+      label: "saved packages",
+      current: 10,
+      limit: 10,
+    }),
+  ]);
+  sendCloudflareEmail.mockClear();
+  const env = createEnv({
+    users: [
+      {
+        stable_user_id: stableUserId,
+        email: "maciek@example.com",
+        plan: "free",
+        stripe_plan: null,
+      },
+    ],
+    kv,
+  });
+
+  const absorbed = await sendUserEntitlementWarningEmails({ env, now });
+  expect(absorbed).toEqual({ status: "no_warnings" });
+  expect(sendCloudflareEmail).not.toHaveBeenCalled();
+  expect(store.get(instanceKey("reached", "saved_packages"))).toBe(
+    String(now.getTime()),
+  );
+  expect(store.get(instanceKey("approaching", "saved_packages"))).toBe(
+    String(now.getTime()),
+  );
+
+  sendCloudflareEmail.mockClear();
+  const nextDay = await sendUserEntitlementWarningEmails({
+    env,
+    now: new Date("2026-08-25T01:00:00.000Z"),
+  });
+  expect(nextDay).toEqual({ status: "no_warnings" });
+  expect(sendCloudflareEmail).not.toHaveBeenCalled();
+});
+
+test("user entitlement warnings skip when KV or transactional email is missing", async () => {
+  readAdminEntitlementConsumption.mockResolvedValue([
+    consumptionRow({
+      resource: "execute_calls_per_day",
+      label: "execute calls per day",
+      current: 200,
+      limit: 250,
+    }),
+  ]);
+  sendCloudflareEmail.mockClear();
+  const noKv = await sendUserEntitlementWarningEmails({
+    env: createEnv({
+      users: [
+        {
+          stable_user_id: stableUserId,
+          email: "user@example.com",
+          plan: "free",
+          stripe_plan: null,
+        },
+      ],
+    }),
+  });
+  expect(noKv).toEqual({ status: "skipped", reason: "no_kv" });
+  expect(sendCloudflareEmail).not.toHaveBeenCalled();
+
+  const { kv } = createKv();
+  const noConfig = await sendUserEntitlementWarningEmails({
+    env: {
+      APP_DB: createDb([]),
+      BUNDLE_ARTIFACTS_KV: kv,
+    } as unknown as Env,
+  });
+  expect(noConfig).toEqual({ status: "skipped", reason: "no_email_config" });
+});

--- a/packages/worker/src/app/user-entitlement-warning-emails.ts
+++ b/packages/worker/src/app/user-entitlement-warning-emails.ts
@@ -22,7 +22,9 @@ import {
  * One email per crossing of 80% or 100% on a specific entitlement. Staying
  * over the same threshold does not mail again. A later drop below that
  * threshold, then a climb back over it, is a new instance. Same-hour
- * crossings of the same kind still batch into one mail.
+ * crossings of the same kind still batch into one mail. Stock claims expire
+ * after 30 days unless an hourly sweep still sees the user over and refreshes
+ * the TTL; daily `*_per_day` claims stay scoped to the UTC day.
  */
 
 export const userEntitlementWarningKvKeyPrefix = 'entitlement-warning-user:v3'
@@ -36,6 +38,7 @@ export const userEntitlementReachedThreshold = 1
 const warningSweepConcurrency = 4
 const dailyClaimLookbackDays = 3
 export const userEntitlementWarningDailyClaimTtlSeconds = 36 * 60 * 60
+export const userEntitlementWarningStockClaimTtlSeconds = 30 * 24 * 60 * 60
 
 const stockPackageThreshold = Math.ceil(planLimits.free.maxSavedPackages * 0.8)
 const stockSecretThreshold = Math.ceil(planLimits.free.maxSecrets * 0.8)
@@ -232,6 +235,15 @@ async function warnOneUserIfNeeded(input: {
 		kind: 'approaching',
 		warnings: approaching,
 		now: input.now,
+	})
+	await refreshStillOverStockClaims({
+		kv,
+		userId: input.user.stable_user_id,
+		now: input.now,
+		reached,
+		approaching,
+		newReached,
+		newApproaching,
 	})
 	if (newApproaching.length === 0 && newReached.length === 0) return null
 
@@ -433,6 +445,59 @@ async function claimWarningInstance(input: {
 	}
 }
 
+async function refreshStillOverStockClaims(input: {
+	kv: KVNamespace
+	userId: string
+	now: Date
+	reached: Array<WarningResource>
+	approaching: Array<WarningResource>
+	newReached: Array<WarningResource>
+	newApproaching: Array<WarningResource>
+}) {
+	const claimedAt = String(input.now.getTime())
+	const newReachedResources = new Set(
+		input.newReached.map((warning) => warning.resource),
+	)
+	const newApproachingResources = new Set(
+		input.newApproaching.map((warning) => warning.resource),
+	)
+	for (const warning of input.reached) {
+		if (isDailyEntitlementResource(warning.resource)) continue
+		if (newReachedResources.has(warning.resource)) continue
+		await putWarningClaim({
+			kv: input.kv,
+			userId: input.userId,
+			kind: 'reached',
+			resource: warning.resource,
+			now: input.now,
+			claimedAt,
+		})
+		// Keep the paired approaching claim alive so sitting at a cap does
+		// not let the 80% claim expire and rematch on a later drop to 80–99%.
+		if (newApproachingResources.has(warning.resource)) continue
+		await putWarningClaim({
+			kv: input.kv,
+			userId: input.userId,
+			kind: 'approaching',
+			resource: warning.resource,
+			now: input.now,
+			claimedAt,
+		})
+	}
+	for (const warning of input.approaching) {
+		if (isDailyEntitlementResource(warning.resource)) continue
+		if (newApproachingResources.has(warning.resource)) continue
+		await putWarningClaim({
+			kv: input.kv,
+			userId: input.userId,
+			kind: 'approaching',
+			resource: warning.resource,
+			now: input.now,
+			claimedAt,
+		})
+	}
+}
+
 function warningInstanceKey(input: {
 	userId: string
 	kind: UserEntitlementWarningKind
@@ -458,13 +523,18 @@ async function putWarningClaim(input: {
 	claimedAt: string
 }) {
 	const key = warningInstanceKey(input)
-	if (isDailyEntitlementResource(input.resource)) {
-		await input.kv.put(key, input.claimedAt, {
-			expirationTtl: userEntitlementWarningDailyClaimTtlSeconds,
+	const expirationTtl = isDailyEntitlementResource(input.resource)
+		? userEntitlementWarningDailyClaimTtlSeconds
+		: userEntitlementWarningStockClaimTtlSeconds
+	try {
+		await input.kv.put(key, input.claimedAt, { expirationTtl })
+	} catch (error) {
+		console.warn('user-entitlement-warning-claim-failed', {
+			kind: input.kind,
+			resource: input.resource,
+			error,
 		})
-		return
 	}
-	await input.kv.put(key, input.claimedAt)
 }
 
 async function deleteWarningClaims(input: {

--- a/packages/worker/src/app/user-entitlement-warning-emails.ts
+++ b/packages/worker/src/app/user-entitlement-warning-emails.ts
@@ -1,16 +1,17 @@
-import { utcDayKey, utcMonthKey } from '@kody-internal/shared/date-keys.ts'
-import { sendCloudflareEmail } from '#app/email/cloudflare-email.ts'
+import { utcDayKey, utcMonthKey } from "@kody-internal/shared/date-keys.ts";
+import { sendCloudflareEmail } from "#app/email/cloudflare-email.ts";
 import {
-	buildUserEntitlementWarningEmail,
-	type UserEntitlementWarningKind,
-} from '#app/email/messages.ts'
-import { resolveTransactionalEmailConfig } from '#app/email/sender-config.ts'
-import { readAdminEntitlementConsumption } from '#worker/admin/entitlement-consumption.ts'
+  buildUserEntitlementWarningEmail,
+  type UserEntitlementWarningKind,
+} from "#app/email/messages.ts";
+import { resolveTransactionalEmailConfig } from "#app/email/sender-config.ts";
+import { readAdminEntitlementConsumption } from "#worker/admin/entitlement-consumption.ts";
 import {
-	parseStoredPlanName,
-	planLimits,
-	resolveEffectivePlan,
-} from '#universal/plans.ts'
+  parseStoredPlanName,
+  planLimits,
+  resolveEffectivePlan,
+  type EntitlementResource,
+} from "#universal/plans.ts";
 
 /**
  * Hourly user-facing entitlement warnings. Shares the
@@ -18,242 +19,390 @@ import {
  * both stay on the same UTC-hour cadence. Failures here must not block
  * the operator alert.
  *
- * Throttle is one approaching (80%) email and one reached (100%) email per
- * verified person per UTC day, listing every resource currently in that
- * bucket. It is not per-resource.
+ * One email per crossing of 80% or 100% on a specific entitlement. Staying
+ * over the same threshold does not mail again. A later drop below that
+ * threshold, then a climb back over it, is a new instance. Same-hour
+ * crossings of the same kind still batch into one mail.
  */
 
-export const userEntitlementWarningKvKeyPrefix = 'entitlement-warning-user:v2'
-export const userEntitlementWarningSweepLimit = 100
-export const userEntitlementWarningActiveSweepLimit = 80
-export const userEntitlementWarningStockSweepLimit = 40
-export const userEntitlementWarningDailyTtlSeconds = 36 * 60 * 60
-export const userEntitlementApproachingThreshold = 0.8
-export const userEntitlementReachedThreshold = 1
-const warningSweepConcurrency = 4
+export const userEntitlementWarningKvKeyPrefix = "entitlement-warning-user:v3";
+export const userEntitlementWarningDailyKvKeyPrefix =
+  "entitlement-warning-user:v2";
+export const userEntitlementWarningSweepLimit = 100;
+export const userEntitlementWarningActiveSweepLimit = 80;
+export const userEntitlementWarningStockSweepLimit = 40;
+export const userEntitlementApproachingThreshold = 0.8;
+export const userEntitlementReachedThreshold = 1;
+const warningSweepConcurrency = 4;
+const dailyClaimLookbackDays = 2;
 
-const stockPackageThreshold = Math.ceil(planLimits.free.maxSavedPackages * 0.8)
-const stockSecretThreshold = Math.ceil(planLimits.free.maxSecrets * 0.8)
+const stockPackageThreshold = Math.ceil(planLimits.free.maxSavedPackages * 0.8);
+const stockSecretThreshold = Math.ceil(planLimits.free.maxSecrets * 0.8);
 
 type WarningCandidate = {
-	stable_user_id: string
-	email: string
-	plan: string
-	stripe_plan: string | null
-}
+  stable_user_id: string;
+  email: string;
+  plan: string;
+  stripe_plan: string | null;
+};
 
 type WarningResource = {
-	label: string
-	current: number
-	limit: number
-	percentOfLimit: number
-}
+  resource: EntitlementResource;
+  label: string;
+  current: number;
+  limit: number;
+  percentOfLimit: number;
+};
 
 export type UserEntitlementWarningEmailResult =
-	| { status: 'skipped'; reason: 'no_kv' | 'no_email_config' }
-	| { status: 'no_warnings' }
-	| {
-			status: 'notified'
-			emailedUsers: number
-			emailsSent: number
-			warnedResources: number
-	  }
+  | { status: "skipped"; reason: "no_kv" | "no_email_config" }
+  | { status: "no_warnings" }
+  | {
+      status: "notified";
+      emailedUsers: number;
+      emailsSent: number;
+      warnedResources: number;
+    };
 
 export function userEntitlementWarningKvKey(input: {
-	userId: string
-	kind: UserEntitlementWarningKind
-	day: string
+  userId: string;
+  kind: UserEntitlementWarningKind;
+  resource: EntitlementResource;
 }) {
-	return `${userEntitlementWarningKvKeyPrefix}:${input.userId}:${input.kind}:${input.day}`
+  return `${userEntitlementWarningKvKeyPrefix}:${input.userId}:${input.kind}:${input.resource}`;
+}
+
+export function userEntitlementWarningDailyKvKey(input: {
+  userId: string;
+  kind: UserEntitlementWarningKind;
+  day: string;
+}) {
+  return `${userEntitlementWarningDailyKvKeyPrefix}:${input.userId}:${input.kind}:${input.day}`;
 }
 
 export async function sendUserEntitlementWarningEmails(input: {
-	env: Env
-	now?: Date
+  env: Env;
+  now?: Date;
 }): Promise<UserEntitlementWarningEmailResult> {
-	const now = input.now ?? new Date()
-	if (!input.env.BUNDLE_ARTIFACTS_KV) {
-		return { status: 'skipped', reason: 'no_kv' }
-	}
-	const emailConfig = resolveTransactionalEmailConfig({ env: input.env })
-	if (!emailConfig) {
-		return { status: 'skipped', reason: 'no_email_config' }
-	}
+  const now = input.now ?? new Date();
+  if (!input.env.BUNDLE_ARTIFACTS_KV) {
+    return { status: "skipped", reason: "no_kv" };
+  }
+  const emailConfig = resolveTransactionalEmailConfig({ env: input.env });
+  if (!emailConfig) {
+    return { status: "skipped", reason: "no_email_config" };
+  }
 
-	const candidates = await listUsersForEntitlementWarningSweep(
-		input.env.APP_DB,
-		now,
-	)
-	if (candidates.length === 0) return { status: 'no_warnings' }
+  const candidates = await listUsersForEntitlementWarningSweep(
+    input.env.APP_DB,
+    now,
+  );
+  if (candidates.length === 0) return { status: "no_warnings" };
 
-	let emailedUsers = 0
-	let emailsSent = 0
-	let warnedResources = 0
-	await mapWithConcurrency(
-		candidates,
-		warningSweepConcurrency,
-		async (user) => {
-			const sent = await warnOneUserIfNeeded({
-				env: input.env,
-				emailConfig,
-				user,
-				now,
-			})
-			if (!sent) return
-			emailedUsers += 1
-			emailsSent += sent.emailsSent
-			warnedResources += sent.warnedResources
-		},
-	)
+  let emailedUsers = 0;
+  let emailsSent = 0;
+  let warnedResources = 0;
+  await mapWithConcurrency(
+    candidates,
+    warningSweepConcurrency,
+    async (user) => {
+      const sent = await warnOneUserIfNeeded({
+        env: input.env,
+        emailConfig,
+        user,
+        now,
+      });
+      if (!sent) return;
+      emailedUsers += 1;
+      emailsSent += sent.emailsSent;
+      warnedResources += sent.warnedResources;
+    },
+  );
 
-	if (emailedUsers === 0) return { status: 'no_warnings' }
-	console.info('user-entitlement-warning-emailed', {
-		emailedUsers,
-		emailsSent,
-		warnedResources,
-	})
-	return { status: 'notified', emailedUsers, emailsSent, warnedResources }
+  if (emailedUsers === 0) return { status: "no_warnings" };
+  console.info("user-entitlement-warning-emailed", {
+    emailedUsers,
+    emailsSent,
+    warnedResources,
+  });
+  return { status: "notified", emailedUsers, emailsSent, warnedResources };
 }
 
 async function warnOneUserIfNeeded(input: {
-	env: Env
-	emailConfig: { appBaseUrl: string; fromEmail: string }
-	user: WarningCandidate
-	now: Date
+  env: Env;
+  emailConfig: { appBaseUrl: string; fromEmail: string };
+  user: WarningCandidate;
+  now: Date;
 }): Promise<{ emailsSent: number; warnedResources: number } | null> {
-	const kv = input.env.BUNDLE_ARTIFACTS_KV
-	if (!kv) return null
+  const kv = input.env.BUNDLE_ARTIFACTS_KV;
+  if (!kv) return null;
 
-	const plan = resolveEffectivePlan(
-		parseStoredPlanName(input.user.plan),
-		input.user.stripe_plan,
-	)
-	const consumption = await readAdminEntitlementConsumption({
-		env: input.env,
-		usageUserId: input.user.stable_user_id,
-		plan,
-		now: input.now,
-	})
-	const approaching: Array<WarningResource> = []
-	const reached: Array<WarningResource> = []
-	for (const item of consumption) {
-		if (item.percentOfLimit == null) continue
-		const warning = {
-			label: item.label,
-			current: item.current,
-			limit: item.limit,
-			percentOfLimit: item.percentOfLimit,
-		}
-		if (item.percentOfLimit >= userEntitlementReachedThreshold) {
-			reached.push(warning)
-			continue
-		}
-		if (item.percentOfLimit >= userEntitlementApproachingThreshold) {
-			approaching.push(warning)
-		}
-	}
-	if (approaching.length === 0 && reached.length === 0) return null
+  const plan = resolveEffectivePlan(
+    parseStoredPlanName(input.user.plan),
+    input.user.stripe_plan,
+  );
+  const consumption = await readAdminEntitlementConsumption({
+    env: input.env,
+    usageUserId: input.user.stable_user_id,
+    plan,
+    now: input.now,
+  });
+  const approaching: Array<WarningResource> = [];
+  const reached: Array<WarningResource> = [];
+  for (const item of consumption) {
+    if (item.percentOfLimit == null) continue;
+    const warning = {
+      resource: item.resource,
+      label: item.label,
+      current: item.current,
+      limit: item.limit,
+      percentOfLimit: item.percentOfLimit,
+    };
+    if (item.percentOfLimit >= userEntitlementReachedThreshold) {
+      reached.push(warning);
+      continue;
+    }
+    if (item.percentOfLimit >= userEntitlementApproachingThreshold) {
+      approaching.push(warning);
+      await kv.delete(
+        userEntitlementWarningKvKey({
+          userId: input.user.stable_user_id,
+          kind: "reached",
+          resource: item.resource,
+        }),
+      );
+      continue;
+    }
+    await Promise.all([
+      kv.delete(
+        userEntitlementWarningKvKey({
+          userId: input.user.stable_user_id,
+          kind: "approaching",
+          resource: item.resource,
+        }),
+      ),
+      kv.delete(
+        userEntitlementWarningKvKey({
+          userId: input.user.stable_user_id,
+          kind: "reached",
+          resource: item.resource,
+        }),
+      ),
+    ]);
+  }
 
-	const day = utcDayKey(input.now)
-	let emailsSent = 0
-	let warnedResources = 0
-	// Reached first so a same-hour jump to 100% sends the limit mail
-	// even when an 80% send is also due.
-	for (const [kind, warnings] of [
-		['reached', reached],
-		['approaching', approaching],
-	] as const) {
-		const sent = await sendThresholdEmailIfNeeded({
-			env: input.env,
-			kv,
-			emailConfig: input.emailConfig,
-			user: input.user,
-			kind,
-			warnings,
-			day,
-			now: input.now,
-		})
-		if (!sent) continue
-		emailsSent += 1
-		warnedResources += warnings.length
-	}
-	if (emailsSent === 0) return null
-	return { emailsSent, warnedResources }
+  await absorbDailyClaims({
+    kv,
+    userId: input.user.stable_user_id,
+    kind: "reached",
+    warnings: reached,
+    now: input.now,
+  });
+  await absorbDailyClaims({
+    kv,
+    userId: input.user.stable_user_id,
+    kind: "approaching",
+    warnings: approaching,
+    now: input.now,
+  });
+
+  const newReached = await unclaimedWarnings({
+    kv,
+    userId: input.user.stable_user_id,
+    kind: "reached",
+    warnings: reached,
+  });
+  const newApproaching = await unclaimedWarnings({
+    kv,
+    userId: input.user.stable_user_id,
+    kind: "approaching",
+    warnings: approaching,
+  });
+  if (newApproaching.length === 0 && newReached.length === 0) return null;
+
+  let emailsSent = 0;
+  let warnedResources = 0;
+  // Reached first so a same-hour jump to 100% sends the limit mail
+  // even when an 80% send is also due.
+  for (const [kind, warnings] of [
+    ["reached", newReached],
+    ["approaching", newApproaching],
+  ] as const) {
+    const sent = await sendThresholdEmailIfNeeded({
+      env: input.env,
+      kv,
+      emailConfig: input.emailConfig,
+      user: input.user,
+      kind,
+      warnings,
+      now: input.now,
+    });
+    if (!sent) continue;
+    emailsSent += 1;
+    warnedResources += warnings.length;
+  }
+  if (emailsSent === 0) return null;
+  return { emailsSent, warnedResources };
 }
 
 async function sendThresholdEmailIfNeeded(input: {
-	env: Env
-	kv: KVNamespace
-	emailConfig: { appBaseUrl: string; fromEmail: string }
-	user: WarningCandidate
-	kind: UserEntitlementWarningKind
-	warnings: Array<WarningResource>
-	day: string
-	now: Date
+  env: Env;
+  kv: KVNamespace;
+  emailConfig: { appBaseUrl: string; fromEmail: string };
+  user: WarningCandidate;
+  kind: UserEntitlementWarningKind;
+  warnings: Array<WarningResource>;
+  now: Date;
 }): Promise<boolean> {
-	if (input.warnings.length === 0) return false
-	const key = userEntitlementWarningKvKey({
-		userId: input.user.stable_user_id,
-		kind: input.kind,
-		day: input.day,
-	})
-	if (await input.kv.get(key)) return false
+  if (input.warnings.length === 0) return false;
 
-	const billingUrl = new URL(
-		'/account/billing',
-		input.emailConfig.appBaseUrl,
-	).toString()
-	const usageUrl = new URL(
-		'/account/usage',
-		input.emailConfig.appBaseUrl,
-	).toString()
-	const email = buildUserEntitlementWarningEmail({
-		appBaseUrl: input.emailConfig.appBaseUrl,
-		billingUrl,
-		usageUrl,
-		kind: input.kind,
-		warnings: input.warnings,
-	})
+  const billingUrl = new URL(
+    "/account/billing",
+    input.emailConfig.appBaseUrl,
+  ).toString();
+  const usageUrl = new URL(
+    "/account/usage",
+    input.emailConfig.appBaseUrl,
+  ).toString();
+  const email = buildUserEntitlementWarningEmail({
+    appBaseUrl: input.emailConfig.appBaseUrl,
+    billingUrl,
+    usageUrl,
+    kind: input.kind,
+    warnings: input.warnings,
+  });
 
-	let sendResult: Awaited<ReturnType<typeof sendCloudflareEmail>>
-	try {
-		sendResult = await sendCloudflareEmail(
-			{
-				accountId: input.env.CLOUDFLARE_ACCOUNT_ID,
-				apiBaseUrl: input.env.CLOUDFLARE_API_BASE_URL,
-				apiToken: input.env.CLOUDFLARE_API_TOKEN,
-			},
-			{
-				to: input.user.email,
-				from: input.emailConfig.fromEmail,
-				subject: email.subject,
-				html: email.html,
-				text: email.text,
-			},
-		)
-	} catch (error) {
-		console.warn('user-entitlement-warning-send-failed', error)
-		return false
-	}
-	if (!sendResult.ok) {
-		console.warn('user-entitlement-warning-send-skipped', {
-			reason: sendResult.error ?? 'unconfigured',
-		})
-		return false
-	}
+  let sendResult: Awaited<ReturnType<typeof sendCloudflareEmail>>;
+  try {
+    sendResult = await sendCloudflareEmail(
+      {
+        accountId: input.env.CLOUDFLARE_ACCOUNT_ID,
+        apiBaseUrl: input.env.CLOUDFLARE_API_BASE_URL,
+        apiToken: input.env.CLOUDFLARE_API_TOKEN,
+      },
+      {
+        to: input.user.email,
+        from: input.emailConfig.fromEmail,
+        subject: email.subject,
+        html: email.html,
+        text: email.text,
+      },
+    );
+  } catch (error) {
+    console.warn("user-entitlement-warning-send-failed", error);
+    return false;
+  }
+  if (!sendResult.ok) {
+    console.warn("user-entitlement-warning-send-skipped", {
+      reason: sendResult.error ?? "unconfigured",
+    });
+    return false;
+  }
 
-	await input.kv.put(key, String(input.now.getTime()), {
-		expirationTtl: userEntitlementWarningDailyTtlSeconds,
-	})
-	return true
+  await claimWarningInstance({
+    kv: input.kv,
+    userId: input.user.stable_user_id,
+    kind: input.kind,
+    warnings: input.warnings,
+    now: input.now,
+  });
+  return true;
+}
+
+async function absorbDailyClaims(input: {
+  kv: KVNamespace;
+  userId: string;
+  kind: UserEntitlementWarningKind;
+  warnings: Array<WarningResource>;
+  now: Date;
+}) {
+  if (input.warnings.length === 0) return;
+  for (const day of recentUtcDayKeys(input.now)) {
+    const dailyKey = userEntitlementWarningDailyKvKey({
+      userId: input.userId,
+      kind: input.kind,
+      day,
+    });
+    if (!(await input.kv.get(dailyKey))) continue;
+    await claimWarningInstance({
+      kv: input.kv,
+      userId: input.userId,
+      kind: input.kind,
+      warnings: input.warnings,
+      now: input.now,
+    });
+    return;
+  }
+}
+
+async function unclaimedWarnings(input: {
+  kv: KVNamespace;
+  userId: string;
+  kind: UserEntitlementWarningKind;
+  warnings: Array<WarningResource>;
+}) {
+  const next: Array<WarningResource> = [];
+  for (const warning of input.warnings) {
+    const claimed = await input.kv.get(
+      userEntitlementWarningKvKey({
+        userId: input.userId,
+        kind: input.kind,
+        resource: warning.resource,
+      }),
+    );
+    if (claimed) continue;
+    next.push(warning);
+  }
+  return next;
+}
+
+async function claimWarningInstance(input: {
+  kv: KVNamespace;
+  userId: string;
+  kind: UserEntitlementWarningKind;
+  warnings: Array<WarningResource>;
+  now: Date;
+}) {
+  const claimedAt = String(input.now.getTime());
+  for (const warning of input.warnings) {
+    await input.kv.put(
+      userEntitlementWarningKvKey({
+        userId: input.userId,
+        kind: input.kind,
+        resource: warning.resource,
+      }),
+      claimedAt,
+    );
+    if (input.kind !== "reached") continue;
+    // Same climb already passed 80%. Claiming approaching here keeps a
+    // later drop into the 80–99% band from sending a second mail.
+    await input.kv.put(
+      userEntitlementWarningKvKey({
+        userId: input.userId,
+        kind: "approaching",
+        resource: warning.resource,
+      }),
+      claimedAt,
+    );
+  }
+}
+
+function recentUtcDayKeys(now: Date) {
+  const keys: Array<string> = [];
+  for (let daysAgo = 0; daysAgo < dailyClaimLookbackDays; daysAgo += 1) {
+    keys.push(
+      utcDayKey(new Date(now.getTime() - daysAgo * 24 * 60 * 60 * 1000)),
+    );
+  }
+  return keys;
 }
 
 async function listUsersForEntitlementWarningSweep(db: D1Database, now: Date) {
-	const currentMonth = utcMonthKey(now)
-	const [active, packages, secrets] = await Promise.all([
-		db
-			.prepare(
-				`SELECT u.stable_user_id, u.email, u.plan, u.stripe_plan
+  const currentMonth = utcMonthKey(now);
+  const [active, packages, secrets] = await Promise.all([
+    db
+      .prepare(
+        `SELECT u.stable_user_id, u.email, u.plan, u.stripe_plan
 				 FROM (
 					SELECT user_id, SUM(event_count) AS event_count
 					FROM usage_rollups
@@ -267,12 +416,12 @@ async function listUsersForEntitlementWarningSweep(db: D1Database, now: Date) {
 					AND u.account_type = 'person'
 					AND u.email_verified_at IS NOT NULL
 				 ORDER BY ranked.event_count DESC`,
-			)
-			.bind(currentMonth, userEntitlementWarningActiveSweepLimit)
-			.all<WarningCandidate>(),
-		db
-			.prepare(
-				`SELECT u.stable_user_id, u.email, u.plan, u.stripe_plan
+      )
+      .bind(currentMonth, userEntitlementWarningActiveSweepLimit)
+      .all<WarningCandidate>(),
+    db
+      .prepare(
+        `SELECT u.stable_user_id, u.email, u.plan, u.stripe_plan
 				 FROM (
 					SELECT user_id, COUNT(*) AS stock_count
 					FROM saved_packages
@@ -285,12 +434,12 @@ async function listUsersForEntitlementWarningSweep(db: D1Database, now: Date) {
 				 WHERE u.deleting_at IS NULL
 					AND u.account_type = 'person'
 					AND u.email_verified_at IS NOT NULL`,
-			)
-			.bind(stockPackageThreshold, userEntitlementWarningStockSweepLimit)
-			.all<WarningCandidate>(),
-		db
-			.prepare(
-				`SELECT u.stable_user_id, u.email, u.plan, u.stripe_plan
+      )
+      .bind(stockPackageThreshold, userEntitlementWarningStockSweepLimit)
+      .all<WarningCandidate>(),
+    db
+      .prepare(
+        `SELECT u.stable_user_id, u.email, u.plan, u.stripe_plan
 				 FROM (
 					SELECT sb.user_id, COUNT(*) AS stock_count
 					FROM secret_entries se
@@ -305,45 +454,45 @@ async function listUsersForEntitlementWarningSweep(db: D1Database, now: Date) {
 				 WHERE u.deleting_at IS NULL
 					AND u.account_type = 'person'
 					AND u.email_verified_at IS NOT NULL`,
-			)
-			.bind(
-				now.toISOString(),
-				stockSecretThreshold,
-				userEntitlementWarningStockSweepLimit,
-			)
-			.all<WarningCandidate>(),
-	])
+      )
+      .bind(
+        now.toISOString(),
+        stockSecretThreshold,
+        userEntitlementWarningStockSweepLimit,
+      )
+      .all<WarningCandidate>(),
+  ]);
 
-	const byUserId = new Map<string, WarningCandidate>()
-	for (const row of [
-		...(active.results ?? []),
-		...(packages.results ?? []),
-		...(secrets.results ?? []),
-	]) {
-		if (byUserId.has(row.stable_user_id)) continue
-		byUserId.set(row.stable_user_id, row)
-		if (byUserId.size >= userEntitlementWarningSweepLimit) break
-	}
-	return [...byUserId.values()]
+  const byUserId = new Map<string, WarningCandidate>();
+  for (const row of [
+    ...(active.results ?? []),
+    ...(packages.results ?? []),
+    ...(secrets.results ?? []),
+  ]) {
+    if (byUserId.has(row.stable_user_id)) continue;
+    byUserId.set(row.stable_user_id, row);
+    if (byUserId.size >= userEntitlementWarningSweepLimit) break;
+  }
+  return [...byUserId.values()];
 }
 
 async function mapWithConcurrency<T>(
-	items: ReadonlyArray<T>,
-	concurrency: number,
-	mapper: (item: T) => Promise<void>,
+  items: ReadonlyArray<T>,
+  concurrency: number,
+  mapper: (item: T) => Promise<void>,
 ): Promise<void> {
-	if (items.length === 0) return
-	const limit = Math.max(1, Math.min(concurrency, items.length))
-	let nextIndex = 0
-	await Promise.all(
-		Array.from({ length: limit }, async () => {
-			while (nextIndex < items.length) {
-				const index = nextIndex
-				nextIndex += 1
-				const item = items[index]
-				if (item === undefined) return
-				await mapper(item)
-			}
-		}),
-	)
+  if (items.length === 0) return;
+  const limit = Math.max(1, Math.min(concurrency, items.length));
+  let nextIndex = 0;
+  await Promise.all(
+    Array.from({ length: limit }, async () => {
+      while (nextIndex < items.length) {
+        const index = nextIndex;
+        nextIndex += 1;
+        const item = items[index];
+        if (item === undefined) return;
+        await mapper(item);
+      }
+    }),
+  );
 }

--- a/packages/worker/src/app/user-entitlement-warning-emails.ts
+++ b/packages/worker/src/app/user-entitlement-warning-emails.ts
@@ -1,17 +1,17 @@
-import { utcDayKey, utcMonthKey } from "@kody-internal/shared/date-keys.ts";
-import { sendCloudflareEmail } from "#app/email/cloudflare-email.ts";
+import { utcDayKey, utcMonthKey } from '@kody-internal/shared/date-keys.ts'
+import { sendCloudflareEmail } from '#app/email/cloudflare-email.ts'
 import {
-  buildUserEntitlementWarningEmail,
-  type UserEntitlementWarningKind,
-} from "#app/email/messages.ts";
-import { resolveTransactionalEmailConfig } from "#app/email/sender-config.ts";
-import { readAdminEntitlementConsumption } from "#worker/admin/entitlement-consumption.ts";
+	buildUserEntitlementWarningEmail,
+	type UserEntitlementWarningKind,
+} from '#app/email/messages.ts'
+import { resolveTransactionalEmailConfig } from '#app/email/sender-config.ts'
+import { readAdminEntitlementConsumption } from '#worker/admin/entitlement-consumption.ts'
 import {
-  parseStoredPlanName,
-  planLimits,
-  resolveEffectivePlan,
-  type EntitlementResource,
-} from "#universal/plans.ts";
+	parseStoredPlanName,
+	planLimits,
+	resolveEffectivePlan,
+	type EntitlementResource,
+} from '#universal/plans.ts'
 
 /**
  * Hourly user-facing entitlement warnings. Shares the
@@ -25,384 +25,466 @@ import {
  * crossings of the same kind still batch into one mail.
  */
 
-export const userEntitlementWarningKvKeyPrefix = "entitlement-warning-user:v3";
+export const userEntitlementWarningKvKeyPrefix = 'entitlement-warning-user:v3'
 export const userEntitlementWarningDailyKvKeyPrefix =
-  "entitlement-warning-user:v2";
-export const userEntitlementWarningSweepLimit = 100;
-export const userEntitlementWarningActiveSweepLimit = 80;
-export const userEntitlementWarningStockSweepLimit = 40;
-export const userEntitlementApproachingThreshold = 0.8;
-export const userEntitlementReachedThreshold = 1;
-const warningSweepConcurrency = 4;
-const dailyClaimLookbackDays = 2;
+	'entitlement-warning-user:v2'
+export const userEntitlementWarningSweepLimit = 100
+export const userEntitlementWarningActiveSweepLimit = 80
+export const userEntitlementWarningStockSweepLimit = 40
+export const userEntitlementApproachingThreshold = 0.8
+export const userEntitlementReachedThreshold = 1
+const warningSweepConcurrency = 4
+const dailyClaimLookbackDays = 3
+export const userEntitlementWarningDailyClaimTtlSeconds = 36 * 60 * 60
 
-const stockPackageThreshold = Math.ceil(planLimits.free.maxSavedPackages * 0.8);
-const stockSecretThreshold = Math.ceil(planLimits.free.maxSecrets * 0.8);
+const stockPackageThreshold = Math.ceil(planLimits.free.maxSavedPackages * 0.8)
+const stockSecretThreshold = Math.ceil(planLimits.free.maxSecrets * 0.8)
 
 type WarningCandidate = {
-  stable_user_id: string;
-  email: string;
-  plan: string;
-  stripe_plan: string | null;
-};
+	stable_user_id: string
+	email: string
+	plan: string
+	stripe_plan: string | null
+}
 
 type WarningResource = {
-  resource: EntitlementResource;
-  label: string;
-  current: number;
-  limit: number;
-  percentOfLimit: number;
-};
+	resource: EntitlementResource
+	label: string
+	current: number
+	limit: number
+	percentOfLimit: number
+}
 
 export type UserEntitlementWarningEmailResult =
-  | { status: "skipped"; reason: "no_kv" | "no_email_config" }
-  | { status: "no_warnings" }
-  | {
-      status: "notified";
-      emailedUsers: number;
-      emailsSent: number;
-      warnedResources: number;
-    };
+	| { status: 'skipped'; reason: 'no_kv' | 'no_email_config' }
+	| { status: 'no_warnings' }
+	| {
+			status: 'notified'
+			emailedUsers: number
+			emailsSent: number
+			warnedResources: number
+	  }
+
+export function isDailyEntitlementResource(resource: EntitlementResource) {
+	return resource.endsWith('_per_day')
+}
 
 export function userEntitlementWarningKvKey(input: {
-  userId: string;
-  kind: UserEntitlementWarningKind;
-  resource: EntitlementResource;
+	userId: string
+	kind: UserEntitlementWarningKind
+	resource: EntitlementResource
+	day?: string
 }) {
-  return `${userEntitlementWarningKvKeyPrefix}:${input.userId}:${input.kind}:${input.resource}`;
+	const base = `${userEntitlementWarningKvKeyPrefix}:${input.userId}:${input.kind}:${input.resource}`
+	if (!isDailyEntitlementResource(input.resource)) return base
+	if (!input.day) {
+		throw new Error(
+			`Daily entitlement warning key for ${input.resource} requires a UTC day`,
+		)
+	}
+	return `${base}:${input.day}`
 }
 
 export function userEntitlementWarningDailyKvKey(input: {
-  userId: string;
-  kind: UserEntitlementWarningKind;
-  day: string;
+	userId: string
+	kind: UserEntitlementWarningKind
+	day: string
 }) {
-  return `${userEntitlementWarningDailyKvKeyPrefix}:${input.userId}:${input.kind}:${input.day}`;
+	return `${userEntitlementWarningDailyKvKeyPrefix}:${input.userId}:${input.kind}:${input.day}`
 }
 
 export async function sendUserEntitlementWarningEmails(input: {
-  env: Env;
-  now?: Date;
+	env: Env
+	now?: Date
 }): Promise<UserEntitlementWarningEmailResult> {
-  const now = input.now ?? new Date();
-  if (!input.env.BUNDLE_ARTIFACTS_KV) {
-    return { status: "skipped", reason: "no_kv" };
-  }
-  const emailConfig = resolveTransactionalEmailConfig({ env: input.env });
-  if (!emailConfig) {
-    return { status: "skipped", reason: "no_email_config" };
-  }
+	const now = input.now ?? new Date()
+	if (!input.env.BUNDLE_ARTIFACTS_KV) {
+		return { status: 'skipped', reason: 'no_kv' }
+	}
+	const emailConfig = resolveTransactionalEmailConfig({ env: input.env })
+	if (!emailConfig) {
+		return { status: 'skipped', reason: 'no_email_config' }
+	}
 
-  const candidates = await listUsersForEntitlementWarningSweep(
-    input.env.APP_DB,
-    now,
-  );
-  if (candidates.length === 0) return { status: "no_warnings" };
+	const candidates = await listUsersForEntitlementWarningSweep(
+		input.env.APP_DB,
+		now,
+	)
+	if (candidates.length === 0) return { status: 'no_warnings' }
 
-  let emailedUsers = 0;
-  let emailsSent = 0;
-  let warnedResources = 0;
-  await mapWithConcurrency(
-    candidates,
-    warningSweepConcurrency,
-    async (user) => {
-      const sent = await warnOneUserIfNeeded({
-        env: input.env,
-        emailConfig,
-        user,
-        now,
-      });
-      if (!sent) return;
-      emailedUsers += 1;
-      emailsSent += sent.emailsSent;
-      warnedResources += sent.warnedResources;
-    },
-  );
+	let emailedUsers = 0
+	let emailsSent = 0
+	let warnedResources = 0
+	await mapWithConcurrency(
+		candidates,
+		warningSweepConcurrency,
+		async (user) => {
+			const sent = await warnOneUserIfNeeded({
+				env: input.env,
+				emailConfig,
+				user,
+				now,
+			})
+			if (!sent) return
+			emailedUsers += 1
+			emailsSent += sent.emailsSent
+			warnedResources += sent.warnedResources
+		},
+	)
 
-  if (emailedUsers === 0) return { status: "no_warnings" };
-  console.info("user-entitlement-warning-emailed", {
-    emailedUsers,
-    emailsSent,
-    warnedResources,
-  });
-  return { status: "notified", emailedUsers, emailsSent, warnedResources };
+	if (emailedUsers === 0) return { status: 'no_warnings' }
+	console.info('user-entitlement-warning-emailed', {
+		emailedUsers,
+		emailsSent,
+		warnedResources,
+	})
+	return { status: 'notified', emailedUsers, emailsSent, warnedResources }
 }
 
 async function warnOneUserIfNeeded(input: {
-  env: Env;
-  emailConfig: { appBaseUrl: string; fromEmail: string };
-  user: WarningCandidate;
-  now: Date;
+	env: Env
+	emailConfig: { appBaseUrl: string; fromEmail: string }
+	user: WarningCandidate
+	now: Date
 }): Promise<{ emailsSent: number; warnedResources: number } | null> {
-  const kv = input.env.BUNDLE_ARTIFACTS_KV;
-  if (!kv) return null;
+	const kv = input.env.BUNDLE_ARTIFACTS_KV
+	if (!kv) return null
 
-  const plan = resolveEffectivePlan(
-    parseStoredPlanName(input.user.plan),
-    input.user.stripe_plan,
-  );
-  const consumption = await readAdminEntitlementConsumption({
-    env: input.env,
-    usageUserId: input.user.stable_user_id,
-    plan,
-    now: input.now,
-  });
-  const approaching: Array<WarningResource> = [];
-  const reached: Array<WarningResource> = [];
-  for (const item of consumption) {
-    if (item.percentOfLimit == null) continue;
-    const warning = {
-      resource: item.resource,
-      label: item.label,
-      current: item.current,
-      limit: item.limit,
-      percentOfLimit: item.percentOfLimit,
-    };
-    if (item.percentOfLimit >= userEntitlementReachedThreshold) {
-      reached.push(warning);
-      continue;
-    }
-    if (item.percentOfLimit >= userEntitlementApproachingThreshold) {
-      approaching.push(warning);
-      await kv.delete(
-        userEntitlementWarningKvKey({
-          userId: input.user.stable_user_id,
-          kind: "reached",
-          resource: item.resource,
-        }),
-      );
-      continue;
-    }
-    await Promise.all([
-      kv.delete(
-        userEntitlementWarningKvKey({
-          userId: input.user.stable_user_id,
-          kind: "approaching",
-          resource: item.resource,
-        }),
-      ),
-      kv.delete(
-        userEntitlementWarningKvKey({
-          userId: input.user.stable_user_id,
-          kind: "reached",
-          resource: item.resource,
-        }),
-      ),
-    ]);
-  }
+	const plan = resolveEffectivePlan(
+		parseStoredPlanName(input.user.plan),
+		input.user.stripe_plan,
+	)
+	const consumption = await readAdminEntitlementConsumption({
+		env: input.env,
+		usageUserId: input.user.stable_user_id,
+		plan,
+		now: input.now,
+	})
+	const approaching: Array<WarningResource> = []
+	const reached: Array<WarningResource> = []
+	for (const item of consumption) {
+		if (item.percentOfLimit == null) continue
+		const warning = {
+			resource: item.resource,
+			label: item.label,
+			current: item.current,
+			limit: item.limit,
+			percentOfLimit: item.percentOfLimit,
+		}
+		if (item.percentOfLimit >= userEntitlementReachedThreshold) {
+			reached.push(warning)
+			continue
+		}
+		if (item.percentOfLimit >= userEntitlementApproachingThreshold) {
+			approaching.push(warning)
+			await deleteWarningClaims({
+				kv,
+				userId: input.user.stable_user_id,
+				kind: 'reached',
+				resource: item.resource,
+				now: input.now,
+			})
+			continue
+		}
+		await Promise.all([
+			deleteWarningClaims({
+				kv,
+				userId: input.user.stable_user_id,
+				kind: 'approaching',
+				resource: item.resource,
+				now: input.now,
+			}),
+			deleteWarningClaims({
+				kv,
+				userId: input.user.stable_user_id,
+				kind: 'reached',
+				resource: item.resource,
+				now: input.now,
+			}),
+		])
+	}
 
-  await absorbDailyClaims({
-    kv,
-    userId: input.user.stable_user_id,
-    kind: "reached",
-    warnings: reached,
-    now: input.now,
-  });
-  await absorbDailyClaims({
-    kv,
-    userId: input.user.stable_user_id,
-    kind: "approaching",
-    warnings: approaching,
-    now: input.now,
-  });
+	await absorbDailyClaims({
+		kv,
+		userId: input.user.stable_user_id,
+		kind: 'reached',
+		warnings: reached,
+		now: input.now,
+	})
+	await absorbDailyClaims({
+		kv,
+		userId: input.user.stable_user_id,
+		kind: 'approaching',
+		warnings: approaching,
+		now: input.now,
+	})
 
-  const newReached = await unclaimedWarnings({
-    kv,
-    userId: input.user.stable_user_id,
-    kind: "reached",
-    warnings: reached,
-  });
-  const newApproaching = await unclaimedWarnings({
-    kv,
-    userId: input.user.stable_user_id,
-    kind: "approaching",
-    warnings: approaching,
-  });
-  if (newApproaching.length === 0 && newReached.length === 0) return null;
+	const newReached = await unclaimedWarnings({
+		kv,
+		userId: input.user.stable_user_id,
+		kind: 'reached',
+		warnings: reached,
+		now: input.now,
+	})
+	const newApproaching = await unclaimedWarnings({
+		kv,
+		userId: input.user.stable_user_id,
+		kind: 'approaching',
+		warnings: approaching,
+		now: input.now,
+	})
+	if (newApproaching.length === 0 && newReached.length === 0) return null
 
-  let emailsSent = 0;
-  let warnedResources = 0;
-  // Reached first so a same-hour jump to 100% sends the limit mail
-  // even when an 80% send is also due.
-  for (const [kind, warnings] of [
-    ["reached", newReached],
-    ["approaching", newApproaching],
-  ] as const) {
-    const sent = await sendThresholdEmailIfNeeded({
-      env: input.env,
-      kv,
-      emailConfig: input.emailConfig,
-      user: input.user,
-      kind,
-      warnings,
-      now: input.now,
-    });
-    if (!sent) continue;
-    emailsSent += 1;
-    warnedResources += warnings.length;
-  }
-  if (emailsSent === 0) return null;
-  return { emailsSent, warnedResources };
+	let emailsSent = 0
+	let warnedResources = 0
+	// Reached first so a same-hour jump to 100% sends the limit mail
+	// even when an 80% send is also due.
+	for (const [kind, warnings] of [
+		['reached', newReached],
+		['approaching', newApproaching],
+	] as const) {
+		const sent = await sendThresholdEmailIfNeeded({
+			env: input.env,
+			kv,
+			emailConfig: input.emailConfig,
+			user: input.user,
+			kind,
+			warnings,
+			now: input.now,
+		})
+		if (!sent) continue
+		emailsSent += 1
+		warnedResources += warnings.length
+	}
+	if (emailsSent === 0) return null
+	return { emailsSent, warnedResources }
 }
 
 async function sendThresholdEmailIfNeeded(input: {
-  env: Env;
-  kv: KVNamespace;
-  emailConfig: { appBaseUrl: string; fromEmail: string };
-  user: WarningCandidate;
-  kind: UserEntitlementWarningKind;
-  warnings: Array<WarningResource>;
-  now: Date;
+	env: Env
+	kv: KVNamespace
+	emailConfig: { appBaseUrl: string; fromEmail: string }
+	user: WarningCandidate
+	kind: UserEntitlementWarningKind
+	warnings: Array<WarningResource>
+	now: Date
 }): Promise<boolean> {
-  if (input.warnings.length === 0) return false;
+	if (input.warnings.length === 0) return false
 
-  const billingUrl = new URL(
-    "/account/billing",
-    input.emailConfig.appBaseUrl,
-  ).toString();
-  const usageUrl = new URL(
-    "/account/usage",
-    input.emailConfig.appBaseUrl,
-  ).toString();
-  const email = buildUserEntitlementWarningEmail({
-    appBaseUrl: input.emailConfig.appBaseUrl,
-    billingUrl,
-    usageUrl,
-    kind: input.kind,
-    warnings: input.warnings,
-  });
+	const billingUrl = new URL(
+		'/account/billing',
+		input.emailConfig.appBaseUrl,
+	).toString()
+	const usageUrl = new URL(
+		'/account/usage',
+		input.emailConfig.appBaseUrl,
+	).toString()
+	const email = buildUserEntitlementWarningEmail({
+		appBaseUrl: input.emailConfig.appBaseUrl,
+		billingUrl,
+		usageUrl,
+		kind: input.kind,
+		warnings: input.warnings,
+	})
 
-  let sendResult: Awaited<ReturnType<typeof sendCloudflareEmail>>;
-  try {
-    sendResult = await sendCloudflareEmail(
-      {
-        accountId: input.env.CLOUDFLARE_ACCOUNT_ID,
-        apiBaseUrl: input.env.CLOUDFLARE_API_BASE_URL,
-        apiToken: input.env.CLOUDFLARE_API_TOKEN,
-      },
-      {
-        to: input.user.email,
-        from: input.emailConfig.fromEmail,
-        subject: email.subject,
-        html: email.html,
-        text: email.text,
-      },
-    );
-  } catch (error) {
-    console.warn("user-entitlement-warning-send-failed", error);
-    return false;
-  }
-  if (!sendResult.ok) {
-    console.warn("user-entitlement-warning-send-skipped", {
-      reason: sendResult.error ?? "unconfigured",
-    });
-    return false;
-  }
+	let sendResult: Awaited<ReturnType<typeof sendCloudflareEmail>>
+	try {
+		sendResult = await sendCloudflareEmail(
+			{
+				accountId: input.env.CLOUDFLARE_ACCOUNT_ID,
+				apiBaseUrl: input.env.CLOUDFLARE_API_BASE_URL,
+				apiToken: input.env.CLOUDFLARE_API_TOKEN,
+			},
+			{
+				to: input.user.email,
+				from: input.emailConfig.fromEmail,
+				subject: email.subject,
+				html: email.html,
+				text: email.text,
+			},
+		)
+	} catch (error) {
+		console.warn('user-entitlement-warning-send-failed', error)
+		return false
+	}
+	if (!sendResult.ok) {
+		console.warn('user-entitlement-warning-send-skipped', {
+			reason: sendResult.error ?? 'unconfigured',
+		})
+		return false
+	}
 
-  await claimWarningInstance({
-    kv: input.kv,
-    userId: input.user.stable_user_id,
-    kind: input.kind,
-    warnings: input.warnings,
-    now: input.now,
-  });
-  return true;
+	await claimWarningInstance({
+		kv: input.kv,
+		userId: input.user.stable_user_id,
+		kind: input.kind,
+		warnings: input.warnings,
+		now: input.now,
+	})
+	return true
 }
 
 async function absorbDailyClaims(input: {
-  kv: KVNamespace;
-  userId: string;
-  kind: UserEntitlementWarningKind;
-  warnings: Array<WarningResource>;
-  now: Date;
+	kv: KVNamespace
+	userId: string
+	kind: UserEntitlementWarningKind
+	warnings: Array<WarningResource>
+	now: Date
 }) {
-  if (input.warnings.length === 0) return;
-  for (const day of recentUtcDayKeys(input.now)) {
-    const dailyKey = userEntitlementWarningDailyKvKey({
-      userId: input.userId,
-      kind: input.kind,
-      day,
-    });
-    if (!(await input.kv.get(dailyKey))) continue;
-    await claimWarningInstance({
-      kv: input.kv,
-      userId: input.userId,
-      kind: input.kind,
-      warnings: input.warnings,
-      now: input.now,
-    });
-    return;
-  }
+	if (input.warnings.length === 0) return
+	for (const day of recentUtcDayKeys(input.now)) {
+		const dailyKey = userEntitlementWarningDailyKvKey({
+			userId: input.userId,
+			kind: input.kind,
+			day,
+		})
+		if (!(await input.kv.get(dailyKey))) continue
+		await claimWarningInstance({
+			kv: input.kv,
+			userId: input.userId,
+			kind: input.kind,
+			warnings: input.warnings,
+			now: input.now,
+		})
+		return
+	}
 }
 
 async function unclaimedWarnings(input: {
-  kv: KVNamespace;
-  userId: string;
-  kind: UserEntitlementWarningKind;
-  warnings: Array<WarningResource>;
+	kv: KVNamespace
+	userId: string
+	kind: UserEntitlementWarningKind
+	warnings: Array<WarningResource>
+	now: Date
 }) {
-  const next: Array<WarningResource> = [];
-  for (const warning of input.warnings) {
-    const claimed = await input.kv.get(
-      userEntitlementWarningKvKey({
-        userId: input.userId,
-        kind: input.kind,
-        resource: warning.resource,
-      }),
-    );
-    if (claimed) continue;
-    next.push(warning);
-  }
-  return next;
+	const next: Array<WarningResource> = []
+	for (const warning of input.warnings) {
+		const claimed = await input.kv.get(
+			warningInstanceKey({
+				userId: input.userId,
+				kind: input.kind,
+				resource: warning.resource,
+				now: input.now,
+			}),
+		)
+		if (claimed) continue
+		next.push(warning)
+	}
+	return next
 }
 
 async function claimWarningInstance(input: {
-  kv: KVNamespace;
-  userId: string;
-  kind: UserEntitlementWarningKind;
-  warnings: Array<WarningResource>;
-  now: Date;
+	kv: KVNamespace
+	userId: string
+	kind: UserEntitlementWarningKind
+	warnings: Array<WarningResource>
+	now: Date
 }) {
-  const claimedAt = String(input.now.getTime());
-  for (const warning of input.warnings) {
-    await input.kv.put(
-      userEntitlementWarningKvKey({
-        userId: input.userId,
-        kind: input.kind,
-        resource: warning.resource,
-      }),
-      claimedAt,
-    );
-    if (input.kind !== "reached") continue;
-    // Same climb already passed 80%. Claiming approaching here keeps a
-    // later drop into the 80–99% band from sending a second mail.
-    await input.kv.put(
-      userEntitlementWarningKvKey({
-        userId: input.userId,
-        kind: "approaching",
-        resource: warning.resource,
-      }),
-      claimedAt,
-    );
-  }
+	const claimedAt = String(input.now.getTime())
+	for (const warning of input.warnings) {
+		await putWarningClaim({
+			kv: input.kv,
+			userId: input.userId,
+			kind: input.kind,
+			resource: warning.resource,
+			now: input.now,
+			claimedAt,
+		})
+		if (input.kind !== 'reached') continue
+		// Same climb already passed 80%. Claiming approaching here keeps a
+		// later drop into the 80–99% band from sending a second mail.
+		await putWarningClaim({
+			kv: input.kv,
+			userId: input.userId,
+			kind: 'approaching',
+			resource: warning.resource,
+			now: input.now,
+			claimedAt,
+		})
+	}
+}
+
+function warningInstanceKey(input: {
+	userId: string
+	kind: UserEntitlementWarningKind
+	resource: EntitlementResource
+	now: Date
+}) {
+	return userEntitlementWarningKvKey({
+		userId: input.userId,
+		kind: input.kind,
+		resource: input.resource,
+		day: isDailyEntitlementResource(input.resource)
+			? utcDayKey(input.now)
+			: undefined,
+	})
+}
+
+async function putWarningClaim(input: {
+	kv: KVNamespace
+	userId: string
+	kind: UserEntitlementWarningKind
+	resource: EntitlementResource
+	now: Date
+	claimedAt: string
+}) {
+	const key = warningInstanceKey(input)
+	if (isDailyEntitlementResource(input.resource)) {
+		await input.kv.put(key, input.claimedAt, {
+			expirationTtl: userEntitlementWarningDailyClaimTtlSeconds,
+		})
+		return
+	}
+	await input.kv.put(key, input.claimedAt)
+}
+
+async function deleteWarningClaims(input: {
+	kv: KVNamespace
+	userId: string
+	kind: UserEntitlementWarningKind
+	resource: EntitlementResource
+	now: Date
+}) {
+	if (!isDailyEntitlementResource(input.resource)) {
+		await input.kv.delete(
+			userEntitlementWarningKvKey({
+				userId: input.userId,
+				kind: input.kind,
+				resource: input.resource,
+			}),
+		)
+		return
+	}
+	await Promise.all(
+		recentUtcDayKeys(input.now).map((day) =>
+			input.kv.delete(
+				userEntitlementWarningKvKey({
+					userId: input.userId,
+					kind: input.kind,
+					resource: input.resource,
+					day,
+				}),
+			),
+		),
+	)
 }
 
 function recentUtcDayKeys(now: Date) {
-  const keys: Array<string> = [];
-  for (let daysAgo = 0; daysAgo < dailyClaimLookbackDays; daysAgo += 1) {
-    keys.push(
-      utcDayKey(new Date(now.getTime() - daysAgo * 24 * 60 * 60 * 1000)),
-    );
-  }
-  return keys;
+	const keys: Array<string> = []
+	for (let daysAgo = 0; daysAgo < dailyClaimLookbackDays; daysAgo += 1) {
+		keys.push(
+			utcDayKey(new Date(now.getTime() - daysAgo * 24 * 60 * 60 * 1000)),
+		)
+	}
+	return keys
 }
 
 async function listUsersForEntitlementWarningSweep(db: D1Database, now: Date) {
-  const currentMonth = utcMonthKey(now);
-  const [active, packages, secrets] = await Promise.all([
-    db
-      .prepare(
-        `SELECT u.stable_user_id, u.email, u.plan, u.stripe_plan
+	const currentMonth = utcMonthKey(now)
+	const [active, packages, secrets] = await Promise.all([
+		db
+			.prepare(
+				`SELECT u.stable_user_id, u.email, u.plan, u.stripe_plan
 				 FROM (
 					SELECT user_id, SUM(event_count) AS event_count
 					FROM usage_rollups
@@ -416,12 +498,12 @@ async function listUsersForEntitlementWarningSweep(db: D1Database, now: Date) {
 					AND u.account_type = 'person'
 					AND u.email_verified_at IS NOT NULL
 				 ORDER BY ranked.event_count DESC`,
-      )
-      .bind(currentMonth, userEntitlementWarningActiveSweepLimit)
-      .all<WarningCandidate>(),
-    db
-      .prepare(
-        `SELECT u.stable_user_id, u.email, u.plan, u.stripe_plan
+			)
+			.bind(currentMonth, userEntitlementWarningActiveSweepLimit)
+			.all<WarningCandidate>(),
+		db
+			.prepare(
+				`SELECT u.stable_user_id, u.email, u.plan, u.stripe_plan
 				 FROM (
 					SELECT user_id, COUNT(*) AS stock_count
 					FROM saved_packages
@@ -434,12 +516,12 @@ async function listUsersForEntitlementWarningSweep(db: D1Database, now: Date) {
 				 WHERE u.deleting_at IS NULL
 					AND u.account_type = 'person'
 					AND u.email_verified_at IS NOT NULL`,
-      )
-      .bind(stockPackageThreshold, userEntitlementWarningStockSweepLimit)
-      .all<WarningCandidate>(),
-    db
-      .prepare(
-        `SELECT u.stable_user_id, u.email, u.plan, u.stripe_plan
+			)
+			.bind(stockPackageThreshold, userEntitlementWarningStockSweepLimit)
+			.all<WarningCandidate>(),
+		db
+			.prepare(
+				`SELECT u.stable_user_id, u.email, u.plan, u.stripe_plan
 				 FROM (
 					SELECT sb.user_id, COUNT(*) AS stock_count
 					FROM secret_entries se
@@ -454,45 +536,45 @@ async function listUsersForEntitlementWarningSweep(db: D1Database, now: Date) {
 				 WHERE u.deleting_at IS NULL
 					AND u.account_type = 'person'
 					AND u.email_verified_at IS NOT NULL`,
-      )
-      .bind(
-        now.toISOString(),
-        stockSecretThreshold,
-        userEntitlementWarningStockSweepLimit,
-      )
-      .all<WarningCandidate>(),
-  ]);
+			)
+			.bind(
+				now.toISOString(),
+				stockSecretThreshold,
+				userEntitlementWarningStockSweepLimit,
+			)
+			.all<WarningCandidate>(),
+	])
 
-  const byUserId = new Map<string, WarningCandidate>();
-  for (const row of [
-    ...(active.results ?? []),
-    ...(packages.results ?? []),
-    ...(secrets.results ?? []),
-  ]) {
-    if (byUserId.has(row.stable_user_id)) continue;
-    byUserId.set(row.stable_user_id, row);
-    if (byUserId.size >= userEntitlementWarningSweepLimit) break;
-  }
-  return [...byUserId.values()];
+	const byUserId = new Map<string, WarningCandidate>()
+	for (const row of [
+		...(active.results ?? []),
+		...(packages.results ?? []),
+		...(secrets.results ?? []),
+	]) {
+		if (byUserId.has(row.stable_user_id)) continue
+		byUserId.set(row.stable_user_id, row)
+		if (byUserId.size >= userEntitlementWarningSweepLimit) break
+	}
+	return [...byUserId.values()]
 }
 
 async function mapWithConcurrency<T>(
-  items: ReadonlyArray<T>,
-  concurrency: number,
-  mapper: (item: T) => Promise<void>,
+	items: ReadonlyArray<T>,
+	concurrency: number,
+	mapper: (item: T) => Promise<void>,
 ): Promise<void> {
-  if (items.length === 0) return;
-  const limit = Math.max(1, Math.min(concurrency, items.length));
-  let nextIndex = 0;
-  await Promise.all(
-    Array.from({ length: limit }, async () => {
-      while (nextIndex < items.length) {
-        const index = nextIndex;
-        nextIndex += 1;
-        const item = items[index];
-        if (item === undefined) return;
-        await mapper(item);
-      }
-    }),
-  );
+	if (items.length === 0) return
+	const limit = Math.max(1, Math.min(concurrency, items.length))
+	let nextIndex = 0
+	await Promise.all(
+		Array.from({ length: limit }, async () => {
+			while (nextIndex < items.length) {
+				const index = nextIndex
+				nextIndex += 1
+				const item = items[index]
+				if (item === undefined) return
+				await mapper(item)
+			}
+		}),
+	)
 }

--- a/packages/worker/src/app/user-entitlement-warning-emails.ts
+++ b/packages/worker/src/app/user-entitlement-warning-emails.ts
@@ -332,13 +332,15 @@ async function absorbDailyClaims(input: {
 	now: Date
 }) {
 	if (input.warnings.length === 0) return
-	for (const day of recentUtcDayKeys(input.now)) {
-		const dailyKey = userEntitlementWarningDailyKvKey({
+	const today = utcDayKey(input.now)
+	const todayClaimed = await input.kv.get(
+		userEntitlementWarningDailyKvKey({
 			userId: input.userId,
 			kind: input.kind,
-			day,
-		})
-		if (!(await input.kv.get(dailyKey))) continue
+			day: today,
+		}),
+	)
+	if (todayClaimed) {
 		await claimWarningInstance({
 			kv: input.kv,
 			userId: input.userId,
@@ -348,6 +350,33 @@ async function absorbDailyClaims(input: {
 		})
 		return
 	}
+
+	let priorDayClaimed = false
+	for (const day of recentUtcDayKeys(input.now)) {
+		if (day === today) continue
+		const dailyKey = userEntitlementWarningDailyKvKey({
+			userId: input.userId,
+			kind: input.kind,
+			day,
+		})
+		if (await input.kv.get(dailyKey)) {
+			priorDayClaimed = true
+			break
+		}
+	}
+	if (!priorDayClaimed) return
+
+	const stockWarnings = input.warnings.filter(
+		(warning) => !isDailyEntitlementResource(warning.resource),
+	)
+	if (stockWarnings.length === 0) return
+	await claimWarningInstance({
+		kv: input.kv,
+		userId: input.userId,
+		kind: input.kind,
+		warnings: stockWarnings,
+		now: input.now,
+	})
 }
 
 async function unclaimedWarnings(input: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop nagging people who stay over a plan limit. One email per time they cross 80% or 100% of a specific entitlement.

## Why

The first hourly sweep after the 80%/100% warning lane shipped mailed `maciek` for 10/10 saved packages. The throttle was one approaching mail and one reached mail **per user per UTC day**. Sitting at the same cap would have mailed them again at the next midnight.

That is the wrong unit. People should get one email per *instance* of hitting a given percentage of a given entitlement.

## Summary

- KV claim is now `{prefix}:{userId}:{kind}:{resource}` (`entitlement-warning-user:v3`) for stock limits.
- `*_per_day` counters append the UTC day so a midnight reset is a new instance, even if the user was off the sweep while the counter sat at zero.
- Staying at 80% or 100% of the same stock resource does not mail again, including the next UTC day.
- Dropping below that threshold clears the claim. Climbing back over it is a new instance and mails once.
- Hitting 100% also claims 80% for that resource, so a later drop into the 80–99% band does not send a second mail.
- Same-hour crossings of the same kind still batch into one mail.
- A same-day leftover `v2` key still claims every resource currently in that bucket. A leftover `v2` key from an earlier UTC day claims stock limits only.
- Stock claims use a 30-day TTL. The hourly sweep refreshes that TTL while the user is still over, so sitting at a cap stays silent. If they drop out of the candidate set, the claim can expire and a later climb rematches.
- One failed KV claim write no longer aborts the rest of the sweep.

## Testing

- `npx vitest run packages/worker/src/app/user-entitlement-warning-emails.node.test.ts` (5 passing)
- `oxfmt` on the touched files
- Preview `kody-pr-1714`: seed login, `GET /account/usage.json` and `/account/billing.json` 200 (email CTA pages). Re-run against this head after preview redeploys.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `b26b0ffb` · **Head:** `bf315349`

**Classification:** extends — the hourly entitlement-warning mailer changes from a per-user-per-UTC-day throttle to a per-entitlement crossing claim, and stock claims now expire unless the sweep refreshes them.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `app-ui` | surfaces | extends — `sendUserEntitlementWarningEmails` claims per resource (and per UTC day for daily counters), refreshes stock claim TTLs while still over, and deletes the claim when usage drops below the threshold |
| `entitlements` | auth | extends — warning policy in `entitlements.md` is one mail per crossing, not one mail per UTC day |
| `bundle-artifacts-kv` | storage | composes — v3 claim keys plus 30-day stock / 36-hour daily `expirationTtl` |

### Change flow

The hourly sweep still reads consumption, then claims, refreshes, or clears per-resource KV keys before it sends.

```mermaid
sequenceDiagram
	actor User
	participant scheduledCron as scheduled-cron
	participant appUi as app-ui
	participant entitlements as entitlements
	participant bundleArtifactsKv as bundle-artifacts-kv
	participant email as email
	scheduledCron->>appUi: usage_entitlement_alert lane
	appUi->>entitlements: readAdminEntitlementConsumption
	appUi->>bundleArtifactsKv: get v3 user/kind/resource and leftover v2 daily keys
	alt new crossing
		appUi->>email: send approaching or reached mail
		appUi->>bundleArtifactsKv: put v3 claim with stock or daily TTL
	else still over a claimed stock threshold
		appUi->>bundleArtifactsKv: refresh 30-day stock claim TTL
		appUi-->>User: no mail
	else dropped below the threshold
		appUi->>bundleArtifactsKv: delete v3 claim
	end
```

### Before / after

| | Before | After |
| --- | --- | --- |
| KV key | `v2:{userId}:{kind}:{utcDay}` | `v3:{userId}:{kind}:{resource}` (plus UTC day for `*_per_day`) |
| Still at 100% packages next UTC day | mails again | silent |
| Daily counter resets, then crosses again | next UTC day only if still over | new instance, one mail |
| Drop below, leave the sweep, climb back later | forever silent (no stock TTL) | rematch after the 30-day claim expires |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3309b591-bf0e-47db-a850-1e0b3cacebce?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3309b591-bf0e-47db-a850-1e0b3cacebce&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved entitlement warning emails to track usage thresholds separately for each resource.
  * Warnings can be sent again when usage drops below a threshold and later crosses it again.
  * Daily resource warnings now account for the UTC calendar day.
  * Prevented duplicate warnings from recent legacy records and grouped crossings within the same hour.
  * Warning records are now saved only after successful email delivery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->