### PR TITLE
Garden leftover cutover wording in worker and values runbooks

### DIFF
--- a/.agents/skills/preview-manual-test/SKILL.md
+++ b/.agents/skills/preview-manual-test/SKILL.md
@@ -26,9 +26,9 @@ the assertions as the same logged-in user:
 
 ```bash
 npm run preview:manual-test -- \
-  --request 'POST /account/values.json {"action":"save","name":"preview-locale","value":"en-US"}' \
-  --request 'GET /account/values.json' \
-  --check /account/values
+  --request 'POST /onboarding/checklist-dismiss.json {}' \
+  --request 'GET /onboarding.json' \
+  --check /onboarding
 ```
 
 `--request` spec: `METHOD /path [status] [json-body]` (default success: 2xx).

--- a/docs/contributing/architecture/jobs-worker-migration-runbook.md
+++ b/docs/contributing/architecture/jobs-worker-migration-runbook.md
@@ -1,172 +1,109 @@
 # Jobs worker migration runbook
 
-Production already owns `JobManager`, `JOBS_DB`, and the five-minute cron on
+Production owns `JobManager`, `JOBS_DB`, and the five-minute cron on
 `kody-jobs`. `transferred_classes` is a one-shot cutover; do not invent a second
-transfer or add `deleted_classes` for `JobManager`. This page records ownership,
-the cutover order that landed, and rollback constraints.
+transfer or add `deleted_classes` for `JobManager`.
 
-Operational runbook for the dedicated jobs worker (`packages/jobs-worker`, ADR
+This page records current ownership and the invariants later deploys must keep.
+The cutover that landed is in the
+[historical appendix](#historical-appendix-2026-jobs-cutover). Do not follow
+that appendix as a live playbook.
+
+Operational notes for the dedicated jobs worker (`packages/jobs-worker`, ADR
 [0016 — Mono-worker extraction](../decisions/0016-mono-worker-extraction.md)).
-It covers two coordinated moves that already landed:
+Later deploys follow `.github/workflows/deploy.yml`. Do not re-run the Durable
+Object transfer or a bounded D1 copy against live production.
 
-1. **Durable Object transfer** — the `JobManager` class moves from the deployed
-   `kody-production` script to the `kody-jobs` script via a Wrangler
-   `transferred_classes` script migration, keeping every existing per-user DO's
-   storage and alarm.
-2. **Bounded D1 data migration** — the `jobs` and `archived_job_artifacts` rows
-   move from `APP_DB` (`kody-db`) into the dedicated `kody-jobs` D1 database.
+## Ownership
 
-The cutover already landed. Later deploys follow `.github/workflows/deploy.yml`.
-Keep the invariants below when changing jobs bindings or `JOBS_DB`. Do not
-re-run the transfer or the bounded D1 copy against live production.
+| Concern                                                          | Owner                                                              |
+| ---------------------------------------------------------------- | ------------------------------------------------------------------ |
+| `JobManager` Durable Object (per-user scheduling state + alarms) | `kody-jobs`                                                        |
+| `jobs` / `archived_job_artifacts` tables                         | `JOBS_DB` on `kody-jobs`                                           |
+| Five-minute cron and `kody-scheduled-dispatch` queues            | `kody-jobs`                                                        |
+| Job execution / scheduled lanes (`JobsHost`)                     | `kody` (origin); `kody-jobs` calls back through the `HOST` binding |
+| Job reads and writes from origin / MCP / dashboards              | `JOBS` service binding (`JobsService`) on origin                   |
+
+`APP_DB` has no `jobs` or `archived_job_artifacts` tables. The schema change is
+`packages/worker/migrations/0010-drop-jobs-tables.sql`. Live authority is
+`JOBS_DB`. Do not query those names on `APP_DB`, do not copy them "one more
+time," and do not treat 0010 as a waiting follow-up.
 
 ## Invariants
 
-- `JobManager` DO storage (per-user scheduling state and alarms) must survive
-  the move byte-for-byte. `transferred_classes` guarantees this: the namespace
-  and all object storage move to the receiving script; object IDs derived from
-  user IDs stay valid.
-- The `jobs` / `archived_job_artifacts` tables must not take writes while rows
-  are copied (brief write pause; the pause window only blocks job
-  create/update/delete and job finalization, not the rest of the app).
-- After the read/write flip, `APP_DB` retains a cold copy of those tables only
-  until migration `packages/worker/migrations/0010-drop-jobs-tables.sql` drops
-  them (step 8). Live authority is `JOBS_DB` on the jobs worker.
-
-## Cloudflare mechanics (why the order below)
-
-- A `transferred_classes` migration lives in the **receiving** worker's config
-  (`packages/jobs-worker/wrangler.jsonc`, tag `v1`,
+- Do not add another `transferred_classes` row for `JobManager`. The `v1`
+  transfer already applied on production `kody-jobs`
+  (`packages/jobs-worker/wrangler.jsonc`,
   `{ from: "JobManager", from_script: "kody-production", to: "JobManager" }`).
-  It is applied when the receiving worker (`kody-jobs`) is deployed.
-- At the moment the transfer is applied, the source script (`kody-production`)
-  must still have the `JobManager` class deployed and no in-flight deploy
-  removing it. After the transfer, the namespace belongs to `kody-jobs`; a
-  subsequent deploy of `kody-production` without the class (and without its DO
-  binding) is valid and must **not** include a `deleted_classes` migration for
-  `JobManager` (that would destroy the transferred data; the deploy-guardrails
-  check enforces an allowlist for any `deleted_classes`).
+- Never add `deleted_classes` for `JobManager`. That destroys transferred
+  per-user DO storage. Deploy guardrails allowlist any `deleted_classes` edit.
+- Object IDs derived from user IDs stay valid because the namespace moved with
+  the class. Do not recreate `JobManager` on origin.
 - Service bindings are by deployed worker name (wrangler appends the
   environment, so the production main worker script is `kody-production`):
-  `kody-production` reaches the jobs worker through the `JOBS` binding
-  (`JobsService` entrypoint) and `kody-jobs` calls back into `kody-production`
-  through the `HOST` binding (`JobsHost` entrypoint). The jobs worker must exist
-  before a main-worker deploy that declares the `JOBS` binding can validate,
-  hence the deploy ordering in `.github/workflows/deploy.yml` (jobs worker
-  deploys first).
+  origin reaches the jobs worker through `JOBS` (`JobsService`) and `kody-jobs`
+  calls back through `HOST` (`JobsHost`). The jobs worker must exist before a
+  main-worker deploy that declares the `JOBS` binding can validate, which is why
+  `.github/workflows/deploy.yml` deploys the jobs worker first when jobs sources
+  change.
+- Shared D1 besides `JOBS_DB` is unchanged: jobs data does not live on `APP_DB`.
 
-## Cutover steps (production)
+## Later deploys
 
-Prerequisites: Cloudflare API token with D1 + Workers permissions, `jq`,
-repository checkout at the release SHA.
+The merged main-branch deploy workflow encodes deploy order. Merge and watch; do
+not pause job writes, export `APP_DB`, or apply a jobs-table drop by hand.
 
-### 1. Provision resources (idempotent)
+When jobs sources change, the workflow deploys `kody-jobs` before origin so the
+`JOBS` binding validates. That order is binding hygiene. It does not re-apply
+the `v1` transfer and it does not copy rows.
 
-```sh
-node tools/ci/jobs-worker-resources.ts ensure --env production \
-	--out-config packages/jobs-worker/wrangler-production.generated.json
-```
+Remix/blog/UI-only uploads skip jobs.
 
-Creates (when missing) the `kody-jobs` D1 database and the
-`kody-scheduled-dispatch` / `kody-scheduled-dispatch-dlq` queues, and writes the
-generated deploy config. The deploy workflow runs the same command.
+Verify cron ticks (jobs-worker logs show `scheduled` invocations every 5 minutes
+and queue consumption on `kody-scheduled-dispatch`), a due job running
+end-to-end (`JobManager` alarm → `HOST.runDueJobsForUser` → a run in the user's
+activity), and dashboards (`/account/jobs`) plus MCP `jobs_*` listing `JOBS_DB`
+rows.
 
-### 2. Apply the jobs D1 schema
+## Historical appendix: 2026 jobs cutover
 
-```sh
-node ./wrangler-env.ts d1 migrations apply JOBS_DB --remote \
-	--config packages/jobs-worker/wrangler-production.generated.json
-```
+**Do not re-run these steps.** They describe the one-shot Durable Object
+transfer and bounded D1 copy that already landed. Re-exporting `jobs` /
+`archived_job_artifacts` from `APP_DB` fails: those tables are gone. Re-issuing
+`transferred_classes` or adding `deleted_classes` for `JobManager` destroys or
+orphans production scheduling state.
 
-### 3. Pause job writes briefly
+Two coordinated moves landed:
 
-Enable the platform kill switch for job mutation surfaces (or schedule the
-window during a quiet period). The copy in step 4 is bounded: both tables are
-small (thousands of rows, not millions), so the pause is minutes. Dual-write is
-intentionally not used — the tables have single-writer semantics through the
-jobs service and a short pause is simpler and safer than reconciling concurrent
-writers.
+1. **Durable Object transfer** — `JobManager` moved from the deployed
+   `kody-production` script to the `kody-jobs` script via `transferred_classes`,
+   keeping every existing per-user DO's storage and alarm.
+2. **Bounded D1 data migration** — `jobs` and `archived_job_artifacts` rows
+   copied from `APP_DB` (`kody-db`) into `JOBS_DB` during a brief write pause
+   (job create/update/delete and finalization only). Dual-write was not used.
+   After the read/write flip, `APP_DB` held a cold copy until
+   `packages/worker/migrations/0010-drop-jobs-tables.sql` removed those tables.
 
-### 4. Copy `jobs` and `archived_job_artifacts` from `APP_DB`
+Coordinated order that landed:
 
-Export via the Cloudflare D1 export API (SQL dump limited to the two tables),
-then import into `kody-jobs`:
+1. Provision `kody-jobs` D1 and the `kody-scheduled-dispatch` /
+   `kody-scheduled-dispatch-dlq` queues (`tools/ci/jobs-worker-resources.ts`).
+2. Apply the jobs D1 schema on `JOBS_DB`.
+3. Pause job mutation surfaces (or wait for a quiet window).
+4. Export the two tables from `APP_DB` and import into `JOBS_DB`; verify row
+   counts.
+5. Deploy `kody-jobs` (applied `v1` `transferred_classes`).
+6. Deploy origin without a `JobManager` export, jobs cron, or scheduled-queue
+   consumer — the read/write flip onto the `JOBS` binding.
+7. Unpause; confirm cron, a due job, and dashboard/MCP lists.
+8. After every remaining `APP_DB` reader of those tables was ported to the JOBS
+   service contract, apply 0010. That migration is in the schema. There is no
+   cold copy left on `APP_DB`.
 
-```sh
-# Export from APP_DB (kody-db)
-curl -sX POST \
-	"https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/d1/database/$APP_DB_ID/export" \
-	-H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
-	-H 'Content-Type: application/json' \
-	-d '{"output_format":"polling","dump_options":{"tables":["jobs","archived_job_artifacts"],"no_schema":true}}' \
-	| jq -r '.result.at_bookmark' # poll until signed_url is returned, then download
-
-# Import into kody-jobs (schema already applied in step 2)
-npx wrangler d1 execute kody-jobs --remote --file ./jobs-export.sql
-```
-
-Verify row counts match on both sides:
-
-```sh
-npx wrangler d1 execute kody-db --remote \
-	--command 'SELECT COUNT(*) FROM jobs; SELECT COUNT(*) FROM archived_job_artifacts;'
-npx wrangler d1 execute kody-jobs --remote \
-	--command 'SELECT COUNT(*) FROM jobs; SELECT COUNT(*) FROM archived_job_artifacts;'
-```
-
-### 5. Deploy the jobs worker (applies the DO transfer)
-
-Deploy `kody-jobs` **before** deploying a main-worker build that removes the
-`JobManager` class:
-
-```sh
-npm run build # not required for the jobs worker; it deploys from source
-npx wrangler deploy --config packages/jobs-worker/wrangler-production.generated.json --env production
-```
-
-This deploy applies migration tag `v1` (`transferred_classes`), taking ownership
-of every existing `JobManager` object and its storage. Healthcheck:
-`curl https://<jobs-worker-host>/health`.
-
-### 6. Deploy the main worker (flips reads/writes to the jobs worker)
-
-Deploy the main-worker (`kody-production`) build from this PR. Its config has no
-`JobManager` class export, no jobs cron, and no scheduled-queue consumer; all
-job reads and writes go through the `JOBS` service binding, so this deploy is
-the read/write flip. The regular deploy workflow performs steps 1, 2, 5, and 6
-in this order automatically.
-
-### 7. Unpause and verify
-
-- Clear the kill switch from step 3.
-- Confirm cron ticks: jobs-worker logs show `scheduled` invocations every 5
-  minutes and queue consumption on `kody-scheduled-dispatch`.
-- Confirm a due job runs end-to-end (JobManager alarm → `HOST.runDueJobsForUser`
-  → run recorded in the user's activity).
-- Confirm dashboards (`/account/jobs`) and MCP `jobs_*` capabilities list the
-  copied rows.
-
-### 8. Drop the old tables from `APP_DB`
-
-After every main-worker surface that still read the old `APP_DB` copies
-(entitlement counts and storage bytes, DR exporter inventory, admin insights,
-account export / user-inventory storage ids, account data targets) is ported to
-the JOBS service contract, migration
-`packages/worker/migrations/0010-drop-jobs-tables.sql` drops `jobs` and
-`archived_job_artifacts` from `APP_DB` (applied by the regular deploy pipeline's
-D1 migration step).
-
-## Rollback
-
-- Before step 5: nothing to roll back (resources are additive).
-- After step 5 but before step 6: redeploy the previous main-worker build; the
-  DO namespace already belongs to `kody-jobs`, and the previous build reaches it
-  only if it still has a `JOB_MANAGER` binding — so prefer rolling forward. A
-  reverse `transferred_classes` migration (`from_script: "kody-jobs"`) is the
-  escape hatch to hand the namespace back.
-- After step 6: roll forward. The old `APP_DB` tables still hold the pre-pause
-  rows as a cold copy until step 8, so data loss is bounded to the cutover
-  window in the worst case.
+Recovery after the transfer applied: roll _forward_ on `kody-jobs`. A reverse
+`transferred_classes` migration (`from_script: "kody-jobs"`) was the escape
+hatch to hand the namespace back; do not use it under incident pressure. There
+is no `APP_DB` rollback copy.
 
 Leftovers that wait on a later drop follow
 [Cleanup after migrations](../cleanup-after-migrations.md).

--- a/docs/contributing/architecture/platform-worker-migration-runbook.md
+++ b/docs/contributing/architecture/platform-worker-migration-runbook.md
@@ -1,22 +1,21 @@
 # Platform worker migration runbook
 
-Production already owns the platform Durable Object classes on `kody-platform`.
+Production owns the platform Durable Object classes on `kody-platform`.
 `transferred_classes` is a one-shot cutover; do not invent a second transfer or
-add `deleted_classes` for those names. This page records ownership, the cutover
-order that landed, and rollback constraints.
+add `deleted_classes` for those names.
 
-How the remaining platform Durable Objects moved from the origin `kody` Worker
-into the `kody-platform` Worker (`packages/platform-worker/`), per
-[ADR 0034](../decisions/0034-origin-owns-no-durable-objects.md). The risky step
-was the Durable Object **script migration**: the storage of `MCP`,
-`McpClientHub`, `OAuthPurgeCoordinator`, `UserMeter`, `Mailbox`, `RepoSession`,
-`RepoSessionIndex`, and `StripePlanRefresh` moved from the `kody` script to the
-`kody-platform` script via a Wrangler `transferred_classes` migration.
+This page records current ownership and the invariants later deploys must keep.
+The cutover that landed is in the
+[historical appendix](#historical-appendix-2026-platform-cutover). Do not follow
+that appendix as a live playbook.
 
-Later deploys follow `.github/workflows/deploy.yml`. Remix/blog/UI-only uploads
-skip platform. Official guide markdown uploads origin and platform.
+How the remaining platform Durable Objects live on the `kody-platform` Worker
+(`packages/platform-worker/`), per
+[ADR 0034](../decisions/0034-origin-owns-no-durable-objects.md). Later deploys
+follow `.github/workflows/deploy.yml`. Remix/blog/UI-only uploads skip platform.
+Official guide markdown uploads origin and platform.
 
-## Ownership after the split
+## Ownership
 
 | Concern                                                                                                                        | Owner                                                       |
 | ------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------- |
@@ -27,69 +26,71 @@ skip platform. Official guide markdown uploads origin and platform.
 | `JobManager`                                                                                                                   | `kody-jobs`                                                 |
 | `APP_DB` / `AUDIT_DB` / KV / R2 / queues / Vectorize / AI                                                                      | Shared resources; each worker binds directly                |
 
-## Migration configuration
+## Invariants
 
-Committed in `packages/platform-worker/wrangler.jsonc` (production applies it on
-the first `kody-platform` deploy; the exact transfer set is protected by
-`tools/ci/durable-object-baseline.json`). The committed `from_script: "kody"` is
-rewritten by `tools/ci/platform-worker-config.ts` to the actual deployed origin
-script name (`kody-production` — wrangler appends the environment to the
-top-level name) at deploy time.
-
-Cloudflare requirements for a `transferred_classes` migration:
-
-- The source script (`kody-production`) must still exist and must still contain
-  the migration history that created the classes; the transfer removes them from
-  the source script's Durable Object namespace registry.
-- The destination script must export classes under the `to` names.
-- The source script must stop exporting/serving the classes in the **same
-  coordinated deploy window** — after the transfer, DO requests routed through
-  the old script's namespaces fail.
-- Existing DO ids, storage, and alarms move with the class. In-flight requests
-  against the old namespace during the switch can error; run at a quiet time.
+- Do not add another `transferred_classes` row for `MCP`, `McpClientHub`,
+  `OAuthPurgeCoordinator`, `UserMeter`, `Mailbox`, `RepoSession`,
+  `RepoSessionIndex`, or `StripePlanRefresh`. The `v1` transfer already applied
+  on production `kody-platform`. The exact set is protected by
+  `tools/ci/durable-object-baseline.json`.
 - Never add `deleted_classes` for a transferred class. That destroys data.
+- The committed `from_script: "kody"` in
+  `packages/platform-worker/wrangler.jsonc` is rewritten by
+  `tools/ci/platform-worker-config.ts` to the deployed origin script name
+  (`kody-production`) at deploy time. Leave that rewrite in place; do not point
+  production at a second source script.
+- Preview worker sets (`kody-pr-<n>-platform`) are created fresh with
+  `new_sqlite_classes`. Preview cannot rehearse a `transferred_classes`
+  migration.
+- Cloudflare rules that made the original transfer valid still apply to any
+  future class move: the source script must still exist and still contain the
+  migration history that created the class; the destination must export the `to`
+  names; existing ids, storage, and alarms move with the class. Those rules are
+  why a second transfer or a `deleted_classes` tag for these names is forbidden.
 
-## Coordinated production deploy order
+## Later deploys
 
-The merged main-branch deploy workflow (`.github/workflows/deploy.yml`) encodes
-this order; the operator's job is to merge and watch, not to run wrangler by
-hand.
+The merged main-branch deploy workflow encodes deploy order. Merge and watch; do
+not run wrangler by hand to "finish" a transfer.
 
-1. **Preview verification (before merging).** The PR's preview deploy creates a
-   fresh worker set (`kody-pr-<n>`, `kody-pr-<n>-platform`,
-   `kody-pr-<n>-runtime`). Verify:
-   - healthchecks passed (`/health` on origin, `/__platform/health` on platform,
-     `/__runtime/health` on runtime);
-   - sign-in works and account/mailbox/session surfaces that hit transferred
-     Durable Objects load;
-   - `GET /mcp` still challenges unauthenticated clients (401). Preview cannot
-     rehearse a `transferred_classes` migration (preview sets are created fresh
-     with `new_sqlite_classes`). The production transfer already landed; later
-     deploys must not invent a second transfer.
-2. **Merge the PR.** The production deploy workflow then:
-   1. generates the runtime and platform configs from the provisioned origin
-      config;
-   2. syncs secrets to origin, platform, and runtime;
-   3. applies D1 migrations (shared databases, applied once);
-   4. **deploys `kody-platform` first** — this applies the `v1`
-      `transferred_classes` migration, moving the active classes' storage out of
-      `kody`. From this moment the still-running old `kody` deployment serves
-      those objects against namespaces that have moved; the window until the
-      origin deploy completes must be short. Alarms on `Mailbox`,
-      `RepoSessionIndex`, and `StripePlanRefresh` move with the classes;
-   5. **deploys `kody-runtime`** with platform bindings retargeted to
-      `kody-platform`;
-   6. **deploys `kody`** with `script_name: "kody-platform"` on those eight
-      classes;
-   7. healthchecks origin (`/health`), platform (`/__platform/health`), and
-      runtime (`/__runtime/health`), then runs the execute smoke check.
-3. **Post-deploy verification.**
-   - Sign in and load account, mailbox, and a repo session that existed before
-     the cutover (proves old DO storage moved).
-   - Hit `/mcp` (OAuth challenge) and confirm an existing MCP session still
-     resumes.
-   - Check Sentry for origin, platform, and runtime.
+When platform sources change, the workflow deploys `kody-platform` before origin
+so cross-script bindings stay valid. That order is binding and healthcheck
+hygiene. It does not re-apply the `v1` transfer.
 
-Remix/blog/UI-only later deploys upload origin only and skip platform, runtime,
-and jobs. Official guide markdown deploys origin and platform (MCP bundles those
-files) and still skips runtime and jobs, so those Durable Objects are not reset.
+Remix/blog/UI-only uploads skip platform, runtime, and jobs. Official guide
+markdown deploys origin and platform (MCP bundles those files) and still skips
+runtime and jobs, so those Durable Objects are not reset.
+
+Healthchecks: origin `/health`, platform `/__platform/health`, runtime
+`/__runtime/health`.
+
+## Historical appendix: 2026 platform cutover
+
+**Do not re-run these steps.** They describe the one-shot script migration that
+already landed. Re-issuing `transferred_classes` or adding `deleted_classes` for
+the names above destroys or orphans production Durable Object storage.
+
+The storage of `MCP`, `McpClientHub`, `OAuthPurgeCoordinator`, `UserMeter`,
+`Mailbox`, `RepoSession`, `RepoSessionIndex`, and `StripePlanRefresh` moved from
+the `kody` script to the `kody-platform` script via a Wrangler
+`transferred_classes` migration.
+
+Coordinated order that landed (encoded in `.github/workflows/deploy.yml`):
+
+1. Preview verification on a fresh `kody-pr-<n>` set (healthchecks, sign-in,
+   account/mailbox/session surfaces, unauthenticated `GET /mcp` → 401). Preview
+   used `new_sqlite_classes`, so it did not rehearse the transfer.
+2. Deploy `kody-platform` first — this applied the `v1` `transferred_classes`
+   migration. From that moment the still-running old `kody` deployment served
+   those objects against namespaces that had moved. Alarms on `Mailbox`,
+   `RepoSessionIndex`, and `StripePlanRefresh` moved with the classes.
+3. Deploy `kody-runtime` with platform bindings retargeted to `kody-platform`.
+4. Deploy `kody` with `script_name: "kody-platform"` on those eight classes.
+5. Healthchecks, then execute smoke. Post-deploy checks loaded pre-cutover
+   account, mailbox, and repo-session objects and confirmed an existing MCP
+   session still resumed.
+
+After the transfer applied, the recovery path was roll _forward_ on
+`kody-platform`. A reverse `transferred_classes` migration is a second risky
+migration and needs its own reviewed config change; deploy guardrails refuse
+unreviewed migration edits.

--- a/docs/contributing/architecture/runtime-worker-migration-runbook.md
+++ b/docs/contributing/architecture/runtime-worker-migration-runbook.md
@@ -1,26 +1,25 @@
 # Runtime worker migration runbook
 
-Production already owns the package-runtime Durable Object classes and
-package-app zone routes on `kody-runtime`. `transferred_classes` is a one-shot
-cutover; do not invent a second transfer or add `deleted_classes` for those
-names. This page records ownership, the cutover order that landed, and rollback
-constraints.
+Production owns the package-runtime Durable Object classes and package-app zone
+routes on `kody-runtime`. `transferred_classes` is a one-shot cutover; do not
+invent a second transfer or add `deleted_classes` for those names.
 
-How the package runtime lane moved from the origin `kody` Worker into the
-`kody-runtime` Worker (`packages/runtime-worker/`), per
-[ADR 0016](../decisions/0016-mono-worker-extraction.md). The risky step was the
-Durable Object **script migration**: the storage of `StorageRunner`, `RunLog`,
-and `PackageRealtimeSession` moved from the `kody` script to the `kody-runtime`
-script via a Wrangler `transferred_classes` migration.
+This page records current ownership and the invariants later deploys must keep.
+The cutover that landed is in the
+[historical appendix](#historical-appendix-2026-runtime-cutover). Do not follow
+that appendix as a live playbook.
 
-Later deploys follow `.github/workflows/deploy.yml`. Remix/blog/UI-only uploads
-skip runtime.
+How the package runtime lane lives on the `kody-runtime` Worker
+(`packages/runtime-worker/`), per
+[ADR 0016](../decisions/0016-mono-worker-extraction.md). Later deploys follow
+`.github/workflows/deploy.yml`. Remix/blog/UI-only uploads skip runtime.
 
-## Ownership after the split
+## Ownership
 
 | Concern                                                             | Owner                                                                       |
 | ------------------------------------------------------------------- | --------------------------------------------------------------------------- |
 | Package-app origin (`PACKAGE_APP_BASE_URL`, `kody.run`) zone routes | `kody-runtime`                                                              |
+| Dual-served legacy package-app zone (`kodyapps.dev`)                | `kody-runtime` (same zone-route shape as `kody.run`)                        |
 | Inline package-app serving (`/apps/...` on the app origin)          | `kody-runtime` (forwarded by main via the `RUNTIME_WORKER` service binding) |
 | Package invocation API                                              | `kody-runtime` (forwarded by main)                                          |
 | `DynamicCallableWorkflow` (Cloudflare Workflow)                     | `kody-runtime` (main binds it cross-script)                                 |
@@ -28,147 +27,52 @@ skip runtime.
 | Remaining platform Durable Objects (`UserMeter`, `MCP`, …)          | `kody-platform` (runtime binds them cross-script)                           |
 | `APP_DB` / `AUDIT_DB` / KV / R2 / queues / Vectorize / AI           | Shared resources; each worker binds directly (no RPC proxying)              |
 
-## Migration configuration
+Production serves `kody.run` (and dual-served `kodyapps.dev`) via **zone
+routes** on the runtime Worker (apex + `*.kody.run/*` / `*.kodyapps.dev/*`),
+never a Workers custom domain in those zones. Leave those routes on
+`kody-runtime`. Do not detach them from the main worker "so the first runtime
+deploy can publish" — that first publish already happened.
 
-Committed in `packages/runtime-worker/wrangler.jsonc` (production applies it on
-the first `kody-runtime` deploy; the exact transfer set is protected by
-`tools/ci/durable-object-baseline.json`). The committed `from_script: "kody"` is
-rewritten by `tools/ci/runtime-worker-config.ts` to the actual deployed main
-script name (`kody-production` — wrangler appends the environment to the
-top-level name) at deploy time:
+## Invariants
 
-```jsonc
-"migrations": [
-	{
-		"tag": "v1",
-		"transferred_classes": [
-			{ "from": "StorageRunner", "from_script": "kody", "to": "StorageRunner" },
-			{ "from": "RunLog", "from_script": "kody", "to": "RunLog" },
-			{ "from": "PackageRealtimeSession", "from_script": "kody", "to": "PackageRealtimeSession" }
-		]
-	}
-]
-```
+- Do not add another `transferred_classes` row for `StorageRunner`, `RunLog`, or
+  `PackageRealtimeSession`. The `v1` transfer already applied on production
+  `kody-runtime`. The exact set is protected by
+  `tools/ci/durable-object-baseline.json`.
+- Never add `deleted_classes` for a class that still has live objects unless you
+  are following [Deleting a transferred class](#deleting-a-transferred-class).
+  Do not add `deleted_classes` for `StorageRunner`, `RunLog`, or
+  `PackageRealtimeSession`.
+- The committed `from_script: "kody"` in
+  `packages/runtime-worker/wrangler.jsonc` is rewritten by
+  `tools/ci/runtime-worker-config.ts` to the deployed main script name
+  (`kody-production`) at deploy time.
+- Preview worker sets are created fresh with `new_sqlite_classes`. Preview
+  cannot rehearse a `transferred_classes` migration.
+- `DynamicCallableWorkflow` is a **new** Cloudflare Workflow on `kody-runtime`
+  (`kody-runtime-dynamic-callable-workflows`). Workflows cannot be transferred
+  between scripts. Do not try to move that workflow back onto origin.
+- Cloudflare transfer rules that made the original move valid still apply to any
+  future class move: the source script must still exist and still contain the
+  migration history that created the class; the destination must export the `to`
+  names; existing ids, storage, and alarms move with the class.
 
-Cloudflare requirements for a `transferred_classes` migration:
+## Later deploys
 
-- The source script (`kody-production`) must still exist and must still contain
-  the migration history that created the classes; the transfer removes them from
-  the source script's Durable Object namespace registry.
-- The destination script must export classes under the `to` names.
-- The source script must stop exporting/serving the classes in the **same
-  coordinated deploy window** — after the transfer, DO requests routed through
-  the old script's namespaces fail.
-- Existing DO ids, storage, and alarms move with the class. In-flight requests
-  against the old namespace during the switch can error; run at a quiet time.
+The merged main-branch deploy workflow encodes deploy order. Merge and watch; do
+not run wrangler by hand to "finish" a transfer or to free the package-app zone.
 
-## Workflow cutover caveat
+When runtime sources change, the workflow deploys `kody-runtime` before origin
+so cross-script bindings stay valid. That order is binding and healthcheck
+hygiene. It does not re-apply the `v1` transfer and it does not republish
+package-app zone routes as a first-time attach.
 
-`DynamicCallableWorkflow` moves to `kody-runtime` as a **new** Cloudflare
-Workflow (`kody-runtime-dynamic-callable-workflows`) — Workflows cannot be
-transferred between scripts. Any workflow instances still running on the old
-`kody`-owned workflow at cutover are orphaned once the main worker stops
-exporting a workflow binding for them; deploy at a quiet time and treat
-in-flight dynamic callable runs at the cutover moment as lost (they surface as
-failed runs).
+Remix/blog/UI-only uploads skip runtime. Official guide markdown still skips
+runtime.
 
-## Coordinated production deploy order
-
-The merged main-branch deploy workflow (`.github/workflows/deploy.yml`) encodes
-this order; the operator's job is to merge and watch, not to run wrangler by
-hand.
-
-1. **Preview verification (before merging).** The PR's preview deploy creates a
-   fresh worker set (`kody-pr-<n>`, `kody-pr-<n>-platform`,
-   `kody-pr-<n>-runtime`, `kody-pr-<n>-jobs`). Verify:
-   - healthchecks passed in the preview workflow (`/health` on origin,
-     `/__platform/health` on platform, `/__runtime/health` on runtime);
-   - a package app loads on the preview origin (`/apps/<user>/<package>`);
-   - a package invocation runs end to end (create a run, watch its RunLog stream
-     complete). Preview cannot rehearse a `transferred_classes` migration
-     (preview sets are created fresh with `new_sqlite_classes`). The production
-     transfer already landed; later deploys must not invent a second transfer.
-2. **Ensure the package-app zone is free for `kody-runtime` (one-time, just
-   before merging).** Production serves `kody.run` (and dual-served
-   `kodyapps.dev`) via **zone routes** on the runtime Worker (apex +
-   `*.kody.run/*` / `*.kodyapps.dev/*`), never a Workers custom domain in those
-   zones — publishing a zone's route table detaches any custom domain there. If
-   the main worker still owns a leftover `kody.run` or `kodyapps.dev` custom
-   domain or zone routes from before the split, remove them in the Cloudflare
-   dashboard (Workers & Pages → `kody` → Settings → Domains & Routes) so the
-   first `kody-runtime` deploy can publish the package-app routes. Between that
-   detach and the runtime deploy, package-app traffic on those hosts is unserved
-   — merge promptly. Later deploys find the zone routes already on
-   `kody-runtime`.
-3. **Merge the PR.** The production deploy workflow then:
-   1. generates the runtime config from the provisioned main config
-      (`tools/ci/runtime-worker-config.ts`);
-   2. syncs secrets to both workers;
-   3. applies D1 migrations (shared databases, applied once);
-   4. **deploys `kody-runtime` first** — this applies the `v1`
-      `transferred_classes` migration, moving the active classes' storage out of
-      `kody`. From this moment the still-running old `kody` deployment serves
-      runtime traffic against namespaces that have moved; the window until step
-      5 completes must be short and is why the two deploys are consecutive steps
-      in one job. There is deliberately no maintenance-mode traffic gate: the
-      accepted risk (per ADR 0016) is that runtime requests hitting the old
-      `kody` deployment during this seconds-long window error and surface as
-      failed runs/invocations, which is why the deploy runs at a quiet time;
-   5. **deploys `kody` second** with the config that binds the three classes
-      cross-script (`script_name: "kody-runtime"`) plus the `RUNTIME_WORKER`
-      service binding, and stops routing runtime requests in-process;
-   6. healthchecks `kody` (`/health`) and `kody-runtime` (`/__runtime/health`),
-      then runs the execute smoke check.
-4. **Post-deploy verification.**
-   - Load a production package app on
-     `https://{username}.kody.run/packages/{kodyId}/...` (the apex only
-     redirects; it does not serve package code).
-   - Run a package invocation; confirm the run appears with streaming logs
-     (proves RunLog storage transferred, not recreated empty).
-   - Open an existing pre-migration run's logs (proves old DO storage moved).
-   - Check Sentry for both workers.
-
-## Manual execution (only if the workflow cannot run)
-
-From a checkout of the merged commit, with `CLOUDFLARE_API_TOKEN` set (plus the
-secret values used below — mirror the `🔐 Sync Cloudflare Secrets` steps in
-`.github/workflows/deploy.yml`, which are the source of truth for the exact
-secret lists). The steps mirror the workflow order: generate configs, sync
-secrets to both workers, apply D1 migrations, then deploy runtime → main.
-
-```sh
-node tools/ci/production-resources.ts ensure --out-config packages/worker/wrangler-production.generated.json
-node tools/ci/runtime-worker-config.ts generate \
-  --env production \
-  --main-config packages/worker/wrangler-production.generated.json \
-  --worker-name kody-runtime \
-  --main-worker-name kody \
-  --out-config packages/runtime-worker/wrangler-production.generated.json
-
-# Sync secrets to both workers (full secret set to main; runtime-lane
-# allowlist to kody-runtime — see deploy.yml for the current lists).
-# Runtime uses --env "" --name so wrangler does not write
-# kody-runtime-production (secret bulk still suffixes -<env> even with
-# --name; deploy uses --name to override).
-node tools/ci/sync-worker-secrets.ts --env production \
-  --config packages/worker/wrangler-production.generated.json \
-  --set-from-env COOKIE_SECRET ... # copy the main-worker flag list from deploy.yml
-node tools/ci/sync-worker-secrets.ts --env "" \
-  --name kody-runtime \
-  --config packages/runtime-worker/wrangler-production.generated.json \
-  --set-from-env COOKIE_SECRET \
-  --set-from-env-optional SECRET_STORE_KEY \
-  --set-from-env-optional AI_GATEWAY_ID \
-  --set-from-env-optional SENTRY_DSN \
-  --set-from-env-optional CLOUDFLARE_API_TOKEN
-
-# Apply shared D1 migrations once (both workers bind the same databases):
-node ./wrangler-env.ts d1 migrations apply APP_DB --remote --config packages/worker/wrangler-production.generated.json
-node ./wrangler-env.ts d1 migrations apply AUDIT_DB --remote --config packages/worker/wrangler-production.generated.json
-
-npm run deploy -- --config packages/runtime-worker/wrangler-production.generated.json
-npm run deploy -- --config packages/worker/wrangler-production.generated.json
-```
+Healthchecks: origin `/health`, runtime `/__runtime/health`. Package apps load
+on `https://{username}.kody.run/packages/{kodyId}/...` (the apex only redirects;
+it does not serve package code).
 
 ## Deleting a transferred class
 
@@ -187,18 +91,44 @@ together so they elide.
 stub export). Preview applies `v1` `new_sqlite_classes` then `v2`
 `deleted_classes` on first deploy so create and delete elide.
 
-## Rollback
+## Historical appendix: 2026 runtime cutover
 
-- **Runtime deploy failed before the migration applied:** nothing moved; the old
-  `kody` deployment still owns the classes. Fix and retry.
-- **After the transfer applied:** roll _forward_ on the runtime worker (redeploy
-  a fixed `kody-runtime`). Do not attempt to transfer the classes back to `kody`
-  under incident pressure — a reverse `transferred_classes` migration is
-  possible but is a second risky migration; it needs its own reviewed config
-  change (the deploy guardrails intentionally refuse unreviewed migration
-  edits).
-- The main worker can always be rolled back independently as long as its config
-  keeps the cross-script bindings.
+**Do not re-run these steps.** They describe the one-shot script migration that
+already landed. Re-issuing `transferred_classes`, detaching `kody.run` /
+`kodyapps.dev` zone routes, or adding `deleted_classes` for the live runtime
+classes destroys or orphans production storage and unserves package-app traffic.
+
+The storage of `StorageRunner`, `RunLog`, and `PackageRealtimeSession` moved
+from the `kody` script to the `kody-runtime` script via a Wrangler
+`transferred_classes` migration. `PackageServiceInstance` transferred in the
+same `v1` tag and was later removed with tag `v2`.
+
+`DynamicCallableWorkflow` was created on `kody-runtime` as a new workflow.
+Instances still running on the old `kody`-owned workflow at cutover were
+orphaned once origin stopped exporting that binding.
+
+Coordinated order that landed:
+
+1. Preview verification on a fresh worker set (healthchecks, `/apps/...` package
+   app, an end-to-end invocation). Preview used `new_sqlite_classes`.
+2. One-time detach of leftover `kody.run` / `kodyapps.dev` custom domains or
+   zone routes from the main worker so the first `kody-runtime` deploy could
+   publish those zone routes. That detach window is closed; the routes belong to
+   `kody-runtime`.
+3. Deploy `kody-runtime` first — this applied the `v1` `transferred_classes`
+   migration. There was no maintenance-mode traffic gate (ADR 0016): requests
+   that hit the old `kody` deployment in that seconds-long window failed.
+4. Deploy `kody` with `script_name: "kody-runtime"` on the three classes plus
+   the `RUNTIME_WORKER` service binding.
+5. Healthchecks and execute smoke. Post-deploy checks loaded a production
+   package app on `{username}.kody.run`, ran an invocation (RunLog storage
+   transferred, not recreated empty), and opened a pre-migration run's logs.
+
+After the transfer applied, the recovery path was roll _forward_ on
+`kody-runtime`. A reverse `transferred_classes` migration is a second risky
+migration and needs its own reviewed config change; deploy guardrails refuse
+unreviewed migration edits. The main worker can roll back independently as long
+as its config keeps the cross-script bindings.
 
 Leftovers that wait on a later tag or deploy follow
 [Cleanup after migrations](../cleanup-after-migrations.md).

--- a/docs/contributing/architecture/values-retirement-runbook.md
+++ b/docs/contributing/architecture/values-retirement-runbook.md
@@ -1,8 +1,30 @@
 # Values retirement runbook
 
 Executable plan for retiring the values primitive (ADR
-[0022](../decisions/0022-retire-values-primitive.md)). Landing this document
-does **not** change production behavior.
+[0022](../decisions/0022-retire-values-primitive.md)).
+
+## Status
+
+Phase 0 is in the repo: ADR 0022, this runbook, the per-affected-user
+retiring-primitives notice, and the `values` coding guide. `value_set` still
+writes. `primitives.yaml` still lists `values` until the removal PR.
+
+Phase 1 already has the onboarding dismiss column
+(`users.onboarding_checklist_dismissed_at`, migration `0015`) and the
+`retiringPrimitiveNotices` registry
+(`packages/worker/src/mcp/instructions/retiring-primitives.ts`). Agents for
+users who still have at least one non-expired stored value get a one-line notice
+that points at `coding_guide_get({ guide: "values" })`. Users with no value rows
+(or only an empty / expired bucket) do not see the section. The
+preview-manual-test worked example writes that onboarding column
+([preview-manual-testing.md](../preview-manual-testing.md)), not
+`/account/values.json`.
+
+There is no `values-writes` feature flag.
+`packages/worker/universal/feature-flags/registry.ts` does not define that key.
+Do not describe or flip a registry flag that is not there. A later write freeze
+adds a flag to that registry (or another explicit gate) in the same change that
+starts rejecting writes.
 
 Intended cadence is about thirty days. Removal waits for the gates in
 [Retirement criterion](#retirement-criterion), the same metrics-then-cut pattern
@@ -29,19 +51,13 @@ the unused buckets with the tables.
 
 ## Agent channel
 
-Do not dump this runbook into always-on MCP instructions. Agents for users who
-still have at least one non-expired stored value get a one-line notice from
-`retiringPrimitiveNotices`
-(`packages/worker/src/mcp/instructions/retiring-primitives.ts`) that points at
-`coding_guide_get({ guide: "values" })`. Users with no value rows (or only an
-empty / expired bucket) do not see the section. The destination map and steps
-live in `docs/guides/values.md`. An empty active-notice set omits the section,
-so later retirements reuse the same slot: add a notice plus a coding guide and a
-cheap EXISTS gate, then delete both when the primitive is gone.
+Do not dump this runbook into always-on MCP instructions. The destination map
+and steps live in `docs/guides/values.md`. An empty active-notice set omits the
+section, so later retirements reuse the same slot: add a notice plus a coding
+guide and a cheap EXISTS gate, then delete both when the primitive is gone.
 
-This PR ships that per-affected-user notice and guide. Later phase-1 work still
-moves onboarding dismiss, bearer-token-like rows, write-result hints, and
-insights counts.
+Remaining phase-1 work still moves bearer-token-like rows, write-result hints,
+and insights counts.
 
 ## Production inventory (baseline, 2026-08-19)
 
@@ -72,34 +88,32 @@ GROUP BY vb.scope;
 
 ## Phases
 
-### Phase 0 — Record the decision and tell agents (this change)
+### Phase 0 — Record the decision and tell agents
 
-Ship ADR 0022, this runbook, the per-affected-user retiring-primitives
+In the repo: ADR 0022, this runbook, the per-affected-user retiring-primitives
 instruction notice, and the `values` coding guide. `value_set` still writes.
 `primitives.yaml` still lists `values` until the removal PR.
 
-### Phase 1 — Stop the bleeding (week 1)
+### Phase 1 — Stop the bleeding
 
 Goal: the platform stops _creating_ reasons to use values, and the one security
 smell leaves the readable store.
 
-1. **Move onboarding dismiss off values.** Add
-   `users.onboarding_checklist_dismissed_at` (nullable ISO timestamp). Migration
-   `0015` backfills from `onboardingChecklistDismissed` and deletes those rows.
-   Reads copy any leftover value onto the column; writes go to the column only.
-   The operator account plus six others drop off values without a user action.
+1. **Onboarding dismiss lives on the users column.**
+   `users.onboarding_checklist_dismissed_at` is a nullable ISO timestamp.
+   Migration `0015` backfills from `onboardingChecklistDismissed` and deletes
+   those rows. Reads copy any leftover value onto the column; writes go to the
+   column only. `POST /onboarding/checklist-dismiss.json` is the account JSON
+   route (`packages/worker/universal/routes.ts`).
 2. **Move bearer-token-like rows to a secret** (operator). Values entity detail
    prints the stored string; bearer tokens must not live there.
-3. **Tell agents in server instructions.** Keep a `retiringPrimitiveNotices`
-   registry (`packages/worker/src/mcp/instructions/retiring-primitives.ts`).
-   Each notice is one line plus `coding_guide_get({ guide })`, and
+3. **Tell agents in server instructions.** Keep the `retiringPrimitiveNotices`
+   registry. Each notice is one line plus `coding_guide_get({ guide })`, and
    `loadActiveRetiringNoticeIds` includes the values notice only when that user
    still has a live stored value. The destination map lives in
    `docs/guides/values.md` (id `values`), not in the always-on instruction
-   string. An empty active set omits the section. Future retirements add a
-   notice + guide + EXISTS gate the same way. Also stop recommending values in
-   execute tool text, capability descriptions, usage docs, and project-intent's
-   isolation list.
+   string. Also stop recommending values in execute tool text, capability
+   descriptions, usage docs, and project-intent's isolation list.
 4. **Deprecate writes in place.** `value_set` and `POST /account/values.json`
    still succeed. Responses and the account UI include a deprecation notice and
    a destination hint (table above). Do not add a new MCP capability for this —
@@ -108,9 +122,10 @@ smell leaves the readable store.
 5. **Watch the fleet.** Admin insights totals gain `value_entries` and
    `users_with_value_rows` (counts only, no names or contents). That is the
    phase dashboard; remove the counters with the primitive.
-6. **Retire values as the preview-manual-test example.** Point
-   `docs/contributing/preview-manual-testing.md` and the skill at a surface that
-   will survive (memories, secrets metadata, or the new onboarding column).
+6. **Preview-manual-test uses a surviving surface.**
+   `docs/contributing/preview-manual-testing.md` and the skill post
+   `/onboarding/checklist-dismiss.json` (the onboarding column), not
+   `/account/values.json`.
 
 Do **not** auto-upsert memories from values (verify-first). Do **not** hide
 `value_get` / `value_list` / search-entity `value` yet — agents need them to
@@ -141,7 +156,7 @@ rows.
 | Package detector / setting keys     | 1 (5 rows)   | owning package storage or repo               |
 | OAuth client ids and leftover URLs  | 9 (1–5 each) | integrations; leftover URLs → owning package |
 | Profile blob                        | 1            | memory                                       |
-| Only `onboardingChecklistDismissed` | 5            | done in phase 1 after onboarding backfill    |
+| Only `onboardingChecklistDismissed` | 5            | onboarding column (`0015`)                   |
 | Empty bucket                        | 1            | dropped with the tables                      |
 
 Outreach is a short Discord note plus the account-page banner: values go away;
@@ -155,16 +170,21 @@ a new domain.
 
 ### Phase 3 — Write freeze (week 4)
 
-Add registry flag `values-writes` (default enabled). When disabled:
+The feature-flag registry has no `values-writes` key. When this phase starts,
+add an explicit gate in the same PR — a new registry flag or an equivalent
+code-reviewed switch — then use it to reject writes. Until that change lands,
+`value_set` and account save keep succeeding.
+
+Once a gate exists and is disabled:
 
 - `value_set` and account save reject **new names** with a destination hint
 - updates to existing names stay allowed for a few days, then reject too
 - `value_get` / `value_list` / `value_delete` / search / account read stay
 - hide `/account/values/new`
 
-Flip the flag globally when phase 2 outreach has landed and insights show
+Flip the gate globally when phase 2 outreach has landed and insights show
 new-name writes near zero. Per-user override on if someone still needs a last
-update. Rollback is re-enabling the flag.
+update. Rollback is re-enabling the gate.
 
 ### Phase 4 — Remove the primitive
 
@@ -189,11 +209,12 @@ Re-run the inventory queries. Remove the primitive when **all** hold for the
 2. `onboardingChecklistDismissed` has **zero** rows (backfill + cutoff done).
 3. Admin insights `value_entries` is **unchanged or falling**, and `value_set` /
    account-save writes are **near zero** (no new names; leftover updates only
-   from the freeze overrides).
+   from freeze overrides).
 4. Every remaining row has a recorded destination (migrated, exported, or owner
    notified). Empty buckets do not block.
-5. `values-writes` has been globally off for those seven days without a
-   rollback.
+5. Writes have been rejected by an explicit gate (see Phase 3) for those seven
+   days without a rollback. Do not treat a non-existent `values-writes` registry
+   flag as that gate.
 
 If (3) or (5) fails, keep reads and reset the seven-day window. Do not delete on
 day 30 because the calendar said so.
@@ -208,6 +229,8 @@ day 30 because the calendar said so.
   `packageStorage().get` / `set`, or a package export.
 - Do not query other users' stored contents during this migration. Counts,
   names, and scopes are enough.
+- Do not document a `values-writes` feature flag unless it is in
+  `packages/worker/universal/feature-flags/registry.ts`.
 
 ## Related
 

--- a/docs/contributing/decisions/0004-status-page-separate-worker.md
+++ b/docs/contributing/decisions/0004-status-page-separate-worker.md
@@ -42,6 +42,7 @@ top; do not move the status page into the main worker. The status worker
 duplicates a small amount of email-sending code rather than importing from
 `packages/worker` (import boundaries keep it dependency-free). Incident records
 are probe-derived only; manually posted incident narratives are a possible later
-addition, not built now. `status.heykody.dev` stays a worker custom domain for
-legacy links and 308s to `status.kody.codes` except `/health`, which remains
-reachable on the legacy host if the canonical hostname is not attached yet.
+addition, not built now. `status.kody.codes` is the attached canonical hostname.
+`status.heykody.dev` is a legacy worker custom domain: GET/HEAD other than
+`/health` 308 to `status.kody.codes`. `/health` stays reachable on the legacy
+host as a fallback when the canonical hostname returns Cloudflare 1016.

--- a/docs/contributing/decisions/0017-per-user-package-app-subdomains.md
+++ b/docs/contributing/decisions/0017-per-user-package-app-subdomains.md
@@ -78,3 +78,13 @@ package-app apex:
   owner's hosted app.
 - Revisit per-package subdomains only if same-owner isolation becomes a reported
   abuse vector or a product requirement.
+
+## Later update (2026-08-24)
+
+The 2026-08-11 decision above used `kodyapps.dev` as the package-app apex. That
+hostname is not rewritten here. The canonical package-app apex is `kody.run`
+(`PACKAGE_APP_BASE_URL`). Production public URL shape is
+`https://{username}.kody.run/packages/{kodyId}/{path}`. `kodyapps.dev` is
+dual-served as a legacy package-app zone (apex + `*.kodyapps.dev`) pending
+[#1428](https://github.com/kentcdodds/kody/issues/1428). See
+[`setup-manifest.md`](../setup-manifest.md) and [`security.md`](../security.md).

--- a/docs/contributing/preview-manual-testing.md
+++ b/docs/contributing/preview-manual-testing.md
@@ -26,9 +26,9 @@ as the same user:
 
 ```bash
 npm run preview:manual-test -- \
-  --request 'POST /account/values.json {"action":"save","name":"preview-locale","value":"en-US"}' \
-  --request 'GET /account/values.json' \
-  --check /account/values
+  --request 'POST /onboarding/checklist-dismiss.json {}' \
+  --request 'GET /onboarding.json' \
+  --check /onboarding
 ```
 
 `--request` is authenticated HTTP as the seed user. Spec:
@@ -41,7 +41,7 @@ session. `--cookie-file .tmp/preview-cookie` writes that header value:
 ```bash
 COOKIE=$(cat .tmp/preview-cookie)
 curl -sS -H "Cookie: $COOKIE" -H 'Accept: application/json' \
-  "$PREVIEW_URL/account/values.json"
+  "$PREVIEW_URL/onboarding.json"
 ```
 
 `--no-wait` fails immediately if the preview is not up. `--url` skips GitHub


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Keep contributor runbooks and ADRs describing the system as it works today so an on-call does not re-run a one-shot Durable Object transfer, copy dropped `APP_DB` jobs tables, or treat a non-existent `values-writes` flag as live.

## Why

Track A of the 2026-08-24 Legacy Reaper fleet. These pages already said the cutovers landed, but the live sections still read as pre-merge playbooks. ADR 0017 still implied `kodyapps.dev` was the canonical apex. ADR 0004 still treated `status.kody.codes` as a pending attach. The preview-manual-test example POSTed `/account/values.json`.

## Summary

- ADR 0017: leave the 2026-08-11 decision on `kodyapps.dev`; add a later note that the canonical package-app apex is `kody.run` and `kodyapps.dev` is dual-served legacy pending #1428.
- ADR 0004: `status.kody.codes` is attached; `status.heykody.dev` is a legacy redirect/fallback (including `/health` when the canonical host returns 1016). `setup-manifest.md` already said this, so it is unchanged.
- Platform / runtime / jobs runbooks: live sections are current ownership + invariants + do-not-repeat `transferred_classes` / `deleted_classes`. Imperative cutover steps moved into labeled historical appendices. Jobs runbook states `APP_DB` has no jobs tables (0010 is in the schema).
- Values retirement runbook: present-tense status. Phase 0 is in the repo. Phase 1 onboarding column + retiring notice exist. No `values-writes` registry flag.
- Preview-manual-test example writes `POST /onboarding/checklist-dismiss.json` (route in `packages/worker/universal/routes.ts`).

Docs and contributor-skill wording only. No production mutations.

## Testing

- `npm run validate` green locally
- PR CI green: https://github.com/kentcdodds/kody/actions/runs/32705602277
- Production deploy success: https://github.com/kentcdodds/kody/actions/runs/32706543323 (origin/platform/runtime/jobs health + execute smoke)

## Conductor report

- **Track:** A (legacy-docs-garden)
- **Status:** DONE
- **Shipped:** https://github.com/kentcdodds/kody/pull/1715 squash-merged as `7c07668`
- **Evidence:** local validate; PR CI 20/20; deploy success
- **Remains:** none. No soak/calendar gate. `setup-manifest.md` already had `status.kody.codes` attached.
- **Gate times:** docs-temporal + decisions immediate; local validate minutes; PR CI ~3m; main validate ~1m; deploy ~3m

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `67738208` · **Head:** `c2eabf27`

**Classification:** composes — no primitives added or changed; this PR gardens contributor docs and a skill. Classifier matched zero `code` roots.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| _(none)_ | — | docs/skill wording only; no `packages/**` or workflow changes |

Unmatched paths: the four worker/values runbooks, ADRs 0004 and 0017, `preview-manual-testing.md`, and `.agents/skills/preview-manual-test/SKILL.md`.

### Change flow

An on-call reading the gardened runbooks is pointed at current ownership and told not to replay the one-shot cutover.

```mermaid
sequenceDiagram
	actor OnCall
	participant platformRunbook as platform-worker runbook
	participant jobsRunbook as jobs-worker runbook
	participant valuesRunbook as values runbook
	participant previewSkill as preview-manual-test skill
	OnCall->>platformRunbook: open live section
	platformRunbook-->>OnCall: ownership + do not re-run transferred_classes
	OnCall->>jobsRunbook: open live section
	jobsRunbook-->>OnCall: JOBS_DB is live authority; APP_DB has no jobs tables
	OnCall->>valuesRunbook: open status
	valuesRunbook-->>OnCall: phase 0/1 exist; no values-writes registry flag
	OnCall->>previewSkill: copy worked example
	previewSkill-->>OnCall: POST /onboarding/checklist-dismiss.json
```

### Before / after

| Topic | Before | After |
| ----- | ------ | ----- |
| ADR 0017 apex | Decision text used `kodyapps.dev` only | Same 2026-08-11 text + later note: canonical apex is `kody.run` |
| ADR 0004 status host | `/health` on legacy host "if canonical is not attached yet" | `status.kody.codes` attached; `status.heykody.dev` is legacy fallback |
| Worker runbooks | Pre-merge playbooks (apply `v1` transfer, copy `APP_DB` jobs) | Live ownership/invariants; cutover steps in historical appendix |
| Preview example | `POST /account/values.json` | `POST /onboarding/checklist-dismiss.json` |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-085094a4-0577-4c2d-959c-071510683285?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-085094a4-0577-4c2d-959c-071510683285&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated manual preview-testing guidance to use onboarding checklist dismissal and onboarding endpoints.
  - Reworked migration runbooks to document current ownership, deployment invariants, verification steps, and historical cutover details.
  - Clarified values retirement phases, remaining migration requirements, and preview-testing procedures.
  - Documented legacy status-page redirects and health-check behavior.
  - Updated hosted-app URL guidance to reflect the canonical package-app domain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->