### PR TITLE
Remove unused connector-kit and pin DR escrow CI actions

### DIFF
--- a/.github/workflows/dr-escrow.yml
+++ b/.github/workflows/dr-escrow.yml
@@ -10,12 +10,12 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
         with:
           persist-credentials: false
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 26
           cache: npm

--- a/package-lock.json
+++ b/package-lock.json
@@ -1843,13 +1843,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
-    "node_modules/@kody-bot/connector-kit": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=24"
-      }
-    },
     "node_modules/@kody-internal/shared": {
       "resolved": "packages/shared",
       "link": true
@@ -11107,7 +11100,6 @@
         "@epic-web/cachified": "^5.6.3",
         "@epic-web/invariant": "^1.0.0",
         "@epic-web/totp": "^4.0.1",
-        "@kody-bot/connector-kit": "^2.0.1",
         "@kody-internal/shared": "file:../shared",
         "@modelcontextprotocol/sdk": "1.30.0",
         "@modelcontextprotocol/server": "2.0.0",

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -14,7 +14,6 @@
     "@epic-web/cachified": "^5.6.3",
     "@epic-web/invariant": "^1.0.0",
     "@epic-web/totp": "^4.0.1",
-    "@kody-bot/connector-kit": "^2.0.1",
     "@kody-internal/shared": "file:../shared",
     "@modelcontextprotocol/sdk": "1.30.0",
     "@modelcontextprotocol/server": "2.0.0",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Drop a leftover unused worker dependency and stop the dispatch-only DR escrow workflow from drifting off the rest of CI's GitHub Action pins.

## Why

`@kody-bot/connector-kit` is confirmed unused (package.json + lockfile only; zero source imports). `dr-escrow.yml` was still on `actions/checkout@v4` and `actions/setup-node@v4` while validate/deploy use `checkout@v6.0.2` and `setup-node@v6`.

## Summary

- Remove `@kody-bot/connector-kit` from `packages/worker/package.json` and refresh `package-lock.json` via `npm install`
- Pin `.github/workflows/dr-escrow.yml` to `actions/checkout@v6.0.2` and `actions/setup-node@v6`
- Escrow secrets, seal script, and dispatch-only trigger are unchanged
- No other equally dead workspace dep found at high confidence

## Testing

- Ripgrep: zero `connector-kit` / `@kody-bot` source imports after removal
- `npm install` at repo root (removed 1 package; lockfile updated)
- GitHub CI green: Static, Node, Workers, MCP, E2E, aggregate Validate, CodeRabbit, Bugbot
- Local `npm run validate` on the Cloud Agent VM failed E2E/MCP on `webServer` timeout / workerd hang; same suites passed in CI
- Production `GET /health` after deploy: `{"ok":true,"commitSha":"01673f66db0b4766ae63f271ad1865fd0ac98d21"}`

## System changes

Low-risk hygiene. No runtime, schema, or primitive contract changes.

## Conductor report

Track B (`legacy-deps-ci`) of the 2026-08-24 Legacy Reaper fleet.

- **Conductor agent:** `bc-333418d7-300b-4b4d-9e9c-c9f6a0a08896`
- **Status:** DONE — squash-merged as `01673f66`, production deploy watched, Discord posted, conductor woken
- **PR:** https://github.com/kentcdodds/kody/pull/1716
- **PR CI:** https://github.com/kentcdodds/kody/actions/runs/32706825477
- **main Validate:** https://github.com/kentcdodds/kody/actions/runs/32707533488
- **Deploy:** https://github.com/kentcdodds/kody/actions/runs/32707631227 (origin + jobs worker)
- **Owned files:** `packages/worker/package.json`, `package-lock.json`, `.github/workflows/dr-escrow.yml`
- **Optional extra:** skipped (no other equally dead workspace dep at high confidence)
- **CodeRabbit nit ignored:** add `permissions: contents: read` to escrow (pre-existing; out of scope — do not rewrite CI jobs beyond action pins)
- **Gates:** none
- **Remains:** none

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `67738208` · **Head:** `2703f16a`

**Classification:** composes — no primitives added or changed; this PR only drops an unused worker dependency and aligns a dispatch-only GitHub Actions pin.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| _(none matched)_ | — | `packages/worker/package.json`, `package-lock.json`, and `.github/workflows/dr-escrow.yml` are unmatched by the taxonomy. The escrow workflow still calls the existing `tools/disaster-recovery/seal-escrow.ts` path owned by `backup-control-plane`; that script is unchanged. |

### Change flow

CI checkout/setup pins on the dispatch-only DR escrow workflow move to the same versions as validate/deploy. The unused `@kody-bot/connector-kit` dependency is removed from the worker package and lockfile.

```mermaid
sequenceDiagram
	actor Operator
	participant backupControlPlane as backup-control-plane
	Operator->>backupControlPlane: workflow_dispatch DR secret escrow
	Note over backupControlPlane: actions/checkout@v6.0.2 and actions/setup-node@v6 only
	backupControlPlane->>backupControlPlane: npm ci then unchanged seal-escrow.ts
	Note over backupControlPlane: @kody-bot/connector-kit removed; zero source imports
```

### Before / after

| Surface | Before | After |
| ------- | ------ | ----- |
| `@kody/worker` deps | `@kody-bot/connector-kit` ^2.0.1 (unused) | omitted |
| `dr-escrow.yml` checkout | `actions/checkout@v4` | `actions/checkout@v6.0.2` |
| `dr-escrow.yml` node | `actions/setup-node@v4` | `actions/setup-node@v6` |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-05933094-aeeb-47a6-8593-4acbf640db1c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-05933094-aeeb-47a6-8593-4acbf640db1c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automation tooling to use newer supported versions, improving reliability and maintainability.
  * Removed an unused internal package reference from the worker component.

* **Impact**
  * No changes to user-facing features or application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->