### PR TITLE
Keep wrangler request-body draining so e2e POST /auth stays up

### DIFF
--- a/docs/contributing/end-to-end-testing.md
+++ b/docs/contributing/end-to-end-testing.md
@@ -80,8 +80,10 @@ Avoid `page.locator('css')` unless no accessible alternative exists.
   exited mid-suite (avoids burning retries on `ECONNREFUSED`). That error names
   the unread `request.clone()` tee fix (`discardUnreadRequestBody` in
   `#worker/request-body.ts`) when logs show `Network connection lost` /
-  `Error inside ProxyWorker`. On CI, the `🎭 E2E` job uploads `logs.local/` as
-  the `e2e-wrangler-logs` artifact when the suite fails.
+  `Error inside ProxyWorker`. Playwright keeps wrangler's default incoming-body
+  drain enabled so unused proxy tees do not kill `wrangler dev` mid-suite. On
+  CI, the `🎭 E2E` job uploads `logs.local/` as the `e2e-wrangler-logs` artifact
+  when the suite fails.
 - Ensure the `env.test` section in `packages/worker/wrangler.jsonc` includes
   assets, KV, and durable objects since these are not inherited from top-level
   Wrangler config.

--- a/e2e/playwright-config.node.test.ts
+++ b/e2e/playwright-config.node.test.ts
@@ -1,0 +1,11 @@
+import { readFileSync } from 'node:fs'
+import { expect, test } from 'vitest'
+
+test('e2e wrangler keeps incoming request-body draining enabled', () => {
+	const source = readFileSync(
+		new URL('../playwright.config.ts', import.meta.url),
+		'utf8',
+	)
+
+	expect(source).not.toMatch(/WRANGLER_DISABLE_REQUEST_BODY_DRAINING\s*:/)
+})

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -40,7 +40,11 @@ export default defineConfig({
 			// Fatal wrangler exits land here; CI uploads this directory on E2E
 			// failure (see validate.yml + e2e/web-server-liveness.ts).
 			WRANGLER_LOG_PATH: './logs.local',
-			WRANGLER_DISABLE_REQUEST_BODY_DRAINING: 'true',
+			// Keep wrangler's default incoming-body drain. Setting
+			// WRANGLER_DISABLE_REQUEST_BODY_DRAINING=true recreates the
+			// workers-sdk#5106 ProxyWorker "Network connection lost" race on
+			// POST /auth and other JSON posts; wrangler 4.114+ then exits
+			// instead of recovering (workers-sdk#14926).
 			// Wrangler 4.118+ enables local observability capture by default in
 			// `wrangler dev`. The extra collector/tail services have crashed the
 			// Playwright webServer mid-suite here; opt out for e2e stability.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop the daily e2e flake where Playwright's webServer (`wrangler dev`) dies mid-suite with `Error inside ProxyWorker` / `Network connection lost` right after a successful JSON `POST /auth`.

## Why

[Validate #32684221474](https://github.com/kentcdodds/kody/actions/runs/32684221474) (`cursor/transactional-email-worker-domain-ebce`, which already contained #1655 and #1689) failed 🎭 E2E on both the first attempt and the CI retry:

1. `POST /auth` login succeeds (`audit-event` `action=login` `result=success`).
2. ~130–180ms later: `Error inside ProxyWorker` / `Network connection lost`.
3. Playwright then hits `ERR_CONNECTION_REFUSED` on `/admin/users`; remaining tests fail fast with `E2eWebServerDeadError`.

`createAuthHandler` already consumes `request.json()`. The remaining hole was the e2e harness: `playwright.config.ts` set `WRANGLER_DISABLE_REQUEST_BODY_DRAINING=true` (present since repo init). That turns off wrangler's incoming-body drain workaround ([workers-sdk#5106](https://github.com/cloudflare/workers-sdk/pull/5106)), which exists specifically to stop unused proxy tees from killing workerd. Wrangler 4.114+ then exits instead of recovering ([workers-sdk#14926](https://github.com/cloudflare/workers-sdk/issues/14926)).

No other open PR or live Cloud Agent is fixing this flake. Main e2e was green all day; this is the same wrangler-dev race, not a product regression on the closed email-domain PR.

## Summary

- Leave wrangler's default request-body drain enabled in the Playwright webServer env.
- Lock that harness choice with a node-unit source check.
- Document the drain requirement next to the existing unread-clone remediation note.

App-level `discardUnreadRequestBody` / signed-in OAuth start consumption from #1655 and #1689 stay in place. This only undoes the local-dev workaround disable.

## Testing

- `npx vitest run --project node-unit e2e/playwright-config.node.test.ts` — passed
- `npx vitest run --project node-unit e2e/web-server-liveness.node.test.ts` — passed
- `npm run docs:check-temporal` — passed

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `9b144f33` · **Head:** `a35fcc98`

**Classification:** composes — no primitives added or changed; this is an e2e harness env-var fix. Classifier matched no `primitives.yaml` roots (`playwright.config.ts`, `e2e/playwright-config.node.test.ts`, `docs/contributing/end-to-end-testing.md`).

### Primitives touched

_None. Unmatched paths are the Playwright webServer env and its checker/docs._

### Change flow

Playwright starts wrangler with the default incoming-body drain so a JSON login POST cannot leave an unused proxy tee.

```mermaid
sequenceDiagram
	actor spec as Playwright spec
	participant harness as e2e harness
	participant wrangler as wrangler dev
	spec->>harness: login via POST /auth JSON
	harness->>wrangler: start without WRANGLER_DISABLE_REQUEST_BODY_DRAINING
	wrangler->>wrangler: drain unused incoming body tee
	wrangler-->>spec: login 200, webServer stays up
```

### Invariants

Per-user isolation, session issuance, and `/auth` handler body consumption are unchanged.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0c1f1974-f929-4d26-877e-1f55abb7e809?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0c1f1974-f929-4d26-877e-1f55abb7e809&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved end-to-end test server stability by restoring standard request-body handling.
  - Reduced the risk of development sessions stopping unexpectedly during browser tests.

- **Documentation**
  - Updated troubleshooting guidance for end-to-end test server issues.
  - Added information about accessing uploaded Wrangler logs when CI test runs fail.

- **Tests**
  - Added coverage to ensure the test environment retains the expected request-handling configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->