### PR TITLE
Raise homepage HTML budget for inlined styles.css

### DIFF
--- a/docs/contributing/weekly-site-perf.md
+++ b/docs/contributing/weekly-site-perf.md
@@ -74,3 +74,11 @@ immediately.
 Edit [`tools/site-perf/budget.json`](../../tools/site-perf/budget.json) when the
 live site has a new honest baseline. Bump a threshold only after the change is
 on production and the collector agrees.
+
+`htmlBytes` counts the full anonymous document, including the intentionally
+inlined `styles.css` `<style>` block (see
+[`inline-stylesheet.ts`](../../packages/worker/src/app/inline-stylesheet.ts)).
+That trade removes a render-blocking stylesheet round trip; do not "fix" an
+`html-over-budget` finding by switching back to a `<link rel="stylesheet">`
+without a product call. When landing CSS grows for real product work, raise
+`htmlBytes` to the new honest production size instead.

--- a/tools/site-perf/budget.json
+++ b/tools/site-perf/budget.json
@@ -1,5 +1,5 @@
 {
-	"htmlBytes": 45000,
+	"htmlBytes": 85000,
 	"sameOriginJsBytes": 450000,
 	"lcpImageBytes": 40000
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Keep the weekly site-perf collector honest about production homepage HTML after intentional stylesheet inlining.

## Why

Weekly production measurement flagged `html-over-budget` (79521 vs 45000). Breakdown of the live document: ~35KB is the intentionally inlined `styles.css` `<style>` block (#1535 removed a render-blocking round trip), plus Remix chrome style tags and markup. With that architecture, a 45KB HTML budget is structurally unreachable without undoing the inline trade or splitting critical CSS (a product call / redesign).

Per `docs/contributing/weekly-site-perf.md`, bump the threshold to the new honest production baseline.

## Summary

- Raise `tools/site-perf/budget.json` `htmlBytes` from 45000 → 85000 (live ~79.5KB, modest headroom).
- Document that `htmlBytes` includes the inlined stylesheet and must not be "fixed" by reverting to `<link rel="stylesheet">` without a product call.
- Closes the path for [#1721](https://github.com/kentcdodds/kody/issues/1721) once this reaches `main` and the next collector run sees `ok`.

Not in this PR: CSS splitting, stopping inlining, converting `kody-mark.png` to SVG, or Worker/cache/auth changes.

## Testing

- `npm run site-perf -- --url https://kody.codes/ --json` → `verdict: "ok"`, `htmlBytes: 79521`, no findings.
- `vitest run` `tools/site-perf/collect.node.test.ts` + `invoke-site-perf-package.node.test.ts` + `inline-stylesheet.node.test.ts` — 4 passed.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `180c2386` · **Head:** `aa684623`

**Classification:** composes — no app primitives added or changed; budget + docs only for the weekly collector.

### Primitives touched

_None. Diff is `tools/site-perf/budget.json` and `docs/contributing/weekly-site-perf.md` only._

### Change flow

Weekly collector compares live HTML (with inlined `styles.css`) against the raised budget.

```mermaid
sequenceDiagram
	actor Cron
	participant Collect as tools/site-perf
	participant Prod as kody.codes /
	Cron->>Collect: weekly-site-perf workflow
	Collect->>Prod: GET /
	Note over Prod: HTML includes inlined styles.css
	Collect->>Collect: classify vs htmlBytes 85000
	Note over Collect: verdict ok when under 85KB
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-91eff154-3e9d-41ea-9a65-b16be29cfb00?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-91eff154-3e9d-41ea-9a65-b16be29cfb00&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that the HTML size budget includes the intentionally inlined landing-page stylesheet.
  * Documented the performance tradeoff and guidance for handling legitimate CSS growth.

* **Chores**
  * Increased the HTML size budget from 45,000 to 85,000 bytes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->