### PR TITLE
fix(client): filter extension runtime.sendMessage Tab not found Sentry noise (KODY-CLOUDFLARE-5X)

### DIFF
--- a/packages/worker/client/sentry-browser-filters.node.test.ts
+++ b/packages/worker/client/sentry-browser-filters.node.test.ts
@@ -223,8 +223,48 @@ test('browser Sentry filters drop AbortError and Firefox Xray noise and keep rea
 				values: [
 					{
 						type: 'Error',
-						value: 'MetaMask extension not found',
-						stacktrace: {
+						value: 'Invalid call to runtime.sendMessage(). Tab not found.',
+					},
+				],
+			},
+		}),
+	).toBeNull()
+	expect(
+		filterBrowserSentryEvent(
+			{
+				exception: {
+					values: [
+						{
+							type: 'Error',
+							value:
+								'Error: Invalid call to runtime.sendMessage(). Tab not found.',
+						},
+					],
+				},
+			},
+			new Error('Invalid call to runtime.sendMessage(). Tab not found.'),
+		),
+	).toBeNull()
+	expect(
+		filterBrowserSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'Error',
+						value: 'Invalid call to runtime.sendMessage(). Extension gone.',
+					},
+				],
+			},
+		}),
+	).not.toBeNull()
+
+	expect(
+		filterBrowserSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'Error',
+						value: 'MetaMask extension not found',						stacktrace: {
 							frames: [
 								{
 									filename:

--- a/packages/worker/client/sentry-browser-filters.node.test.ts
+++ b/packages/worker/client/sentry-browser-filters.node.test.ts
@@ -264,7 +264,8 @@ test('browser Sentry filters drop AbortError and Firefox Xray noise and keep rea
 				values: [
 					{
 						type: 'Error',
-						value: 'MetaMask extension not found',						stacktrace: {
+						value: 'MetaMask extension not found',
+						stacktrace: {
 							frames: [
 								{
 									filename:

--- a/packages/worker/client/sentry-browser-filters.node.test.ts
+++ b/packages/worker/client/sentry-browser-filters.node.test.ts
@@ -230,16 +230,23 @@ test('browser Sentry filters drop AbortError and Firefox Xray noise and keep rea
 		}),
 	).toBeNull()
 	expect(
+		filterBrowserSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'Error',
+						value:
+							'Error: Invalid call to runtime.sendMessage(). Tab not found.',
+					},
+				],
+			},
+		}),
+	).toBeNull()
+	expect(
 		filterBrowserSentryEvent(
 			{
 				exception: {
-					values: [
-						{
-							type: 'Error',
-							value:
-								'Error: Invalid call to runtime.sendMessage(). Tab not found.',
-						},
-					],
+					values: [{ type: 'Error', value: 'something else' }],
 				},
 			},
 			new Error('Invalid call to runtime.sendMessage(). Tab not found.'),

--- a/packages/worker/client/sentry-browser-filters.ts
+++ b/packages/worker/client/sentry-browser-filters.ts
@@ -427,10 +427,7 @@ export function filterChromeExtensionSendMessageTabNotFoundSentryEvent<
 	T extends SentryErrorEventLike,
 >(event: T, originalException?: unknown): T | null {
 	if (
-		isChromeExtensionSendMessageTabNotFoundSentryEvent(
-			event,
-			originalException,
-		)
+		isChromeExtensionSendMessageTabNotFoundSentryEvent(event, originalException)
 	) {
 		return null
 	}

--- a/packages/worker/client/sentry-browser-filters.ts
+++ b/packages/worker/client/sentry-browser-filters.ts
@@ -377,6 +377,67 @@ export function filterChromeExtensionReceivingEndMissingSentryEvent<
 }
 
 /**
+ * Browser-extension messaging noise: content scripts / page-injected extension
+ * code call `runtime.sendMessage` against a tab id that no longer exists
+ * (closed, navigated away, or never created). Chromium (and Safari Web
+ * Extensions that surface the same IPC wording) reject with this exact
+ * message. The promise often surfaces on the host page via
+ * `onunhandledrejection` with no app stack frames (Sentry attributes the
+ * culprit to the document URL).
+ *
+ * Signature from production issue 7689579030 / KODY-CLOUDFLARE-5X (Mobile
+ * Safari on https://kody.codes/, zero frames). Kody never uses
+ * `chrome.runtime` / `browser.runtime`. Match is intentionally narrow: only
+ * this exact "Invalid call to runtime.sendMessage(). Tab not found" wording
+ * (optional `Error:` preface). Never blanket-drop sendMessage or tab errors.
+ */
+const chromeExtensionSendMessageTabNotFoundMessage =
+	/^(?:Error:\s*)?Invalid call to runtime\.sendMessage\(\)\. Tab not found\.?$/
+
+export function isChromeExtensionSendMessageTabNotFoundMessage(
+	message: string,
+) {
+	return chromeExtensionSendMessageTabNotFoundMessage.test(message.trim())
+}
+
+export function isChromeExtensionSendMessageTabNotFoundError(error: unknown) {
+	if (typeof error === 'string') {
+		return isChromeExtensionSendMessageTabNotFoundMessage(error)
+	}
+	if (typeof error !== 'object' || error === null) return false
+	if (!('message' in error) || typeof error.message !== 'string') return false
+	return isChromeExtensionSendMessageTabNotFoundMessage(error.message)
+}
+
+export function isChromeExtensionSendMessageTabNotFoundSentryEvent(
+	event: SentryErrorEventLike,
+	originalException?: unknown,
+) {
+	if (isChromeExtensionSendMessageTabNotFoundError(originalException)) {
+		return true
+	}
+	return sentryEventMessages(event).some(
+		(message) =>
+			typeof message === 'string' &&
+			isChromeExtensionSendMessageTabNotFoundMessage(message),
+	)
+}
+
+export function filterChromeExtensionSendMessageTabNotFoundSentryEvent<
+	T extends SentryErrorEventLike,
+>(event: T, originalException?: unknown): T | null {
+	if (
+		isChromeExtensionSendMessageTabNotFoundSentryEvent(
+			event,
+			originalException,
+		)
+	) {
+		return null
+	}
+	return event
+}
+
+/**
  * MetaMask (`chrome-extension://nkbihfbeogaeaoehlefnkodbefgpgknn/…`) injects
  * `inpage.js` into every page and tries to restore a wallet session on load.
  * When the extension's background/service worker is unavailable it rejects
@@ -818,6 +879,14 @@ export function filterBrowserSentryEvent<T extends SentryErrorEventLike>(
 	}
 	if (
 		filterChromeExtensionReceivingEndMissingSentryEvent(
+			event,
+			originalException,
+		) === null
+	) {
+		return null
+	}
+	if (
+		filterChromeExtensionSendMessageTabNotFoundSentryEvent(
 			event,
 			originalException,
 		) === null

--- a/packages/worker/client/sentry-init.ts
+++ b/packages/worker/client/sentry-init.ts
@@ -33,7 +33,8 @@ export function initBrowserSentry(config: SentryClientConfig) {
 		// injected wallet/`__firefox__` globals, Fathom beacon
 		// removeChild-on-null, Chrome extension IPC "Object Not Found
 		// Matching Id…", Chrome/Firefox extension "Receiving end does not
-		// exist", MetaMask inpage connect failures, Chrome extension
+		// exist", extension "Invalid call to runtime.sendMessage(). Tab not
+		// found", MetaMask inpage connect failures, Chrome extension
 		// "Client has been destroyed" with exclusively chrome-extension
 		// frames, Twitter/X in-app browser chrome `CONFIG` ReferenceErrors /
 		// `sendScrollEvent`→ `window.webkit.messageHandlers` TypeErrors,
@@ -43,10 +44,10 @@ export function initBrowserSentry(config: SentryClientConfig) {
 		// KODY-CLOUDFLARE-23 / KODY-CLOUDFLARE-3Q / KODY-CLOUDFLARE-3S /
 		// KODY-CLOUDFLARE-3X / KODY-CLOUDFLARE-43 / KODY-CLOUDFLARE-46 /
 		// KODY-CLOUDFLARE-4F / KODY-CLOUDFLARE-5C / KODY-CLOUDFLARE-5K /
-		// KODY-CLOUDFLARE-5W /
+		// KODY-CLOUDFLARE-5W / KODY-CLOUDFLARE-5X /
 		// issues 7639685398, 7648833360, 7648833403, 7653117289, 7655189301,
 		// 7658961865, 7659616372, 7660258027, 7662064169, 7677729361,
-		// 7682968915, 7687920474.
+		// 7682968915, 7687920474, 7689579030.
 		beforeSend(event, hint) {
 			return filterBrowserSentryEvent(event, hint.originalException)
 		},


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop reporting browser-extension `runtime.sendMessage` “Tab not found” noise in client Sentry (KODY-CLOUDFLARE-5X).

## Why

Production issue [7689579030](https://sentry.io/organizations/kent-c-dodds-tech-llc/issues/7689579030/) (`KODY-CLOUDFLARE-5X`) captured an unhandledrejection on `https://kody.codes/` with:

- Message: `Invalid call to runtime.sendMessage(). Tab not found.`
- Mechanism: `auto.browser.global_handlers.onunhandledrejection`
- Zero stack frames; culprit is the document URL
- Kody never calls `chrome.runtime` / `browser.runtime`

Same class as existing extension IPC filters (receiving-end missing, Object Not Found, Client destroyed): injected extension messaging rejects on the host page and is not an app defect. Without a filter, recurrence would keep opening triage noise.

## Summary

- Add a narrow client `beforeSend` filter for the exact `Invalid call to runtime.sendMessage(). Tab not found` wording (optional `Error:` preface)
- Wire it into `filterBrowserSentryEvent`
- Unit-test drop + non-match keep path
- Update `sentry-init` noise inventory comment

Siblings (`updateCurrentEntry`, `scheduleUpdate not implemented`) do **not** share this root cause and are left alone.

## Testing

- `npm run test -- packages/worker/client/sentry-browser-filters.node.test.ts` (pass)
- Full `npm run validate` hit unrelated MCP e2e / workers timeout flakes on this VM; CI is the authoritative gate for those suites

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `589240c4` · **Head:** `0a8296e8`

**Classification:** composes — no primitives added or changed; this PR wires another narrow signature into the existing browser Sentry `beforeSend` filter chain.

### Primitives touched

| Primitive | Group    | Impact   |
| --------- | -------- | -------- |
| `app-ui`  | surfaces | composes |

### Change flow

Client Sentry drops this extension IPC rejection before the envelope is sent.

```mermaid
sequenceDiagram
	actor browser as browser page
	participant appUi as app-ui
	participant sentry as Sentry
	browser->>appUi: unhandledrejection (runtime.sendMessage Tab not found)
	appUi->>appUi: filterBrowserSentryEvent drops exact signature
	Note over appUi,sentry: no envelope sent for this noise
	appUi--xsentry: beforeSend returns null
```

### Before / after

**Before:** extension `runtime.sendMessage` tab-gone rejections open client Sentry issues with no app frames.

**After:** only the exact `Invalid call to runtime.sendMessage(). Tab not found` signature is dropped; other sendMessage/tab wording stays visible.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fd887cc9-9ca6-4958-9df7-fd355988eb8f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fd887cc9-9ca6-4958-9df7-fd355988eb8f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced error-reporting noise by filtering browser-extension “Tab not found” messaging errors from monitoring.
  * Preserved visibility for related extension errors that may indicate genuine issues.
  * Improved handling across both event-only reports and reports containing the original error.
  * Updated monitoring documentation for the filtered error scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->