### PR TITLE
Label execute-smoke origin-only and teach canonical kody.codes / kody.run hosts

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -831,7 +831,7 @@ jobs:
           fi
           exit 1
 
-      - name: 🧪 Execute smoke check (production)
+      - name: 🧪 Origin-only execute smoke check (production)
         if: needs.sha-guard.outputs.deploy_main == 'true'
         shell: bash
         env:

--- a/docs/contributing/architecture/index.md
+++ b/docs/contributing/architecture/index.md
@@ -13,15 +13,15 @@ Production is four product scripts plus independent ops workers. Origin owns
 **zero** Durable Object classes
 ([ADR 0034](../decisions/0034-origin-owns-no-durable-objects.md)).
 
-| Script                       | Public surface                                      | Owns                                                                                                                                               | Binds                                                           |
-| ---------------------------- | --------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
-| `kody-production` (origin)   | `kody.codes` (legacy `heykody.app` / `heykody.dev`) | Remix, MCP HTTP, OAuth, inbound email, queue consumers, `JobsHost`                                                                                 | Platform DOs, runtime DOs / workflows, `RUNTIME_WORKER`, `JOBS` |
-| `kody-platform`              | `/__platform/health` only                           | `MCP`, `McpClientHub`, `OAuthPurgeCoordinator`, `UserMeter`, `Mailbox`, `RepoSession`, `RepoSessionIndex`, `StripePlanRefresh`, `KodyFetchGateway` | Shared D1/KV/R2/AI; runtime DOs for package work                |
-| `kody-runtime`               | `kody.run` / `kodyapps.dev`; `/__runtime/health`    | `StorageRunner`, `RunLog`, `PackageRealtimeSession`, `DynamicCallableWorkflow`, `KodyFetchGateway`, `PackageAppRuntimeBridge`                      | Platform DOs, `JOBS`                                            |
-| `kody-jobs`                  | no public hostname                                  | `JobManager`, `JOBS_DB`, `kody-scheduled-dispatch`                                                                                                 | `HOST` → origin `JobsHost`                                      |
-| `kody-status`                | `status.kody.codes`                                 | `StatusStore`                                                                                                                                      | HTTP probes + `JOBS` service                                    |
-| `kody-nx-cache`              | `nx-cache.kody.codes`                               | R2 `kody-nx-cache`                                                                                                                                 | —                                                               |
-| `kody-production-d1-backups` | operator-only                                       | D1 backup / DR workflows                                                                                                                           | R2 `kody-production-backups`                                    |
+| Script                       | Public surface                                                                               | Owns                                                                                                                                               | Binds                                                           |
+| ---------------------------- | -------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| `kody-production` (origin)   | `kody.codes` (legacy hosts dual-served until #1300/#1428)                                    | Remix, MCP HTTP, OAuth, inbound email, queue consumers, `JobsHost`                                                                                 | Platform DOs, runtime DOs / workflows, `RUNTIME_WORKER`, `JOBS` |
+| `kody-platform`              | `/__platform/health` only                                                                    | `MCP`, `McpClientHub`, `OAuthPurgeCoordinator`, `UserMeter`, `Mailbox`, `RepoSession`, `RepoSessionIndex`, `StripePlanRefresh`, `KodyFetchGateway` | Shared D1/KV/R2/AI; runtime DOs for package work                |
+| `kody-runtime`               | `{user}.kody.run` (legacy `kodyapps.dev` dual-served until #1300/#1428); `/__runtime/health` | `StorageRunner`, `RunLog`, `PackageRealtimeSession`, `DynamicCallableWorkflow`, `KodyFetchGateway`, `PackageAppRuntimeBridge`                      | Platform DOs, `JOBS`                                            |
+| `kody-jobs`                  | no public hostname                                                                           | `JobManager`, `JOBS_DB`, `kody-scheduled-dispatch`                                                                                                 | `HOST` → origin `JobsHost`                                      |
+| `kody-status`                | `status.kody.codes`                                                                          | `StatusStore`                                                                                                                                      | HTTP probes + `JOBS` service                                    |
+| `kody-nx-cache`              | `nx-cache.kody.codes`                                                                        | R2 `kody-nx-cache`                                                                                                                                 | —                                                               |
+| `kody-production-d1-backups` | operator-only                                                                                | D1 backup / DR workflows                                                                                                                           | R2 `kody-production-backups`                                    |
 
 Local `npm run dev` attaches origin, platform, runtime, and jobs in one
 Miniflare. Playwright `CLOUDFLARE_ENV=test` is the exception: Durable Object
@@ -33,8 +33,10 @@ origin and platform because MCP `coding_guide_get` bundles those files.
 
 MCP `execute` resolves `KodyFetchGateway` from `ctx.exports` on the script that
 owns the `MCP` Durable Object (`kody-platform`). Origin
-`/__maintenance/execute-smoke` uses origin `ctx.exports` and can pass while MCP
-execute is broken.
+`POST /__maintenance/execute-smoke` is **origin-only**: it uses origin
+`ctx.exports` and returns `scope: "origin-only"`,
+`proves: "origin-kody-fetch-gateway"`, and `notMcpExecute: true`. A passing
+smoke does not prove MCP execute health.
 
 ## Core docs
 

--- a/docs/contributing/architecture/request-lifecycle.md
+++ b/docs/contributing/architecture/request-lifecycle.md
@@ -12,9 +12,8 @@ Production has two public HTTP entrypoints:
   package-invocation API, inline `/apps`) forward over the `RUNTIME_WORKER`
   service binding to `kody-runtime`.
 - **Package-app origin** (`kody.run`; legacy `kodyapps.dev` dual-served until
-  #1300/#1428) —
-  `packages/worker/src/runtime-worker.ts`. Zone routes on that script; the
-  origin handler does not see this host in production.
+  #1300/#1428) — `packages/worker/src/runtime-worker.ts`. Zone routes on that
+  script; the origin handler does not see this host in production.
 
 The routing order below is the **app-origin** handler.
 

--- a/docs/contributing/architecture/request-lifecycle.md
+++ b/docs/contributing/architecture/request-lifecycle.md
@@ -12,8 +12,8 @@ Production has two public HTTP entrypoints:
   package-invocation API, inline `/apps`) forward over the `RUNTIME_WORKER`
   service binding to `kody-runtime`.
 - **Package-app origin** (`kody.run`; legacy `kodyapps.dev` dual-served until
-  #1300/#1428) — `packages/worker/src/runtime-worker.ts`. Zone routes on that
-  script; the origin handler does not see this host in production.
+  issues 1300 and 1428) — `packages/worker/src/runtime-worker.ts`. Zone routes
+  on that script; the origin handler does not see this host in production.
 
 The routing order below is the **app-origin** handler.
 

--- a/docs/contributing/architecture/request-lifecycle.md
+++ b/docs/contributing/architecture/request-lifecycle.md
@@ -11,7 +11,8 @@ Production has two public HTTP entrypoints:
   email, and queue consumers. Runtime-owned paths (`/@{username}/packages/…`,
   package-invocation API, inline `/apps`) forward over the `RUNTIME_WORKER`
   service binding to `kody-runtime`.
-- **Package-app origin** (`kody.run` / `kodyapps.dev`) —
+- **Package-app origin** (`kody.run`; legacy `kodyapps.dev` dual-served until
+  #1300/#1428) —
   `packages/worker/src/runtime-worker.ts`. Zone routes on that script; the
   origin handler does not see this host in production.
 
@@ -87,8 +88,10 @@ Requests are handled in this order:
      ([ADR 0034](../decisions/0034-origin-owns-no-durable-objects.md)). MCP
      `execute` looks up `KodyFetchGateway` on `ctx.exports` of the script that
      **owns** `MCP` — that is `kody-platform`. Origin
-     `/__maintenance/execute-smoke` uses origin `ctx.exports` and can pass while
-     MCP execute is broken if platform does not export the gateway.
+     `POST /__maintenance/execute-smoke` is **origin-only**: it uses origin
+     `ctx.exports` and returns `scope: "origin-only"`,
+     `proves: "origin-kody-fetch-gateway"`, and `notMcpExecute: true`. A passing
+     smoke does not prove MCP execute health.
 6. Public `@username` ingress handled in `packages/worker/src/index.ts` before
    the OAuth provider / app router (needs `ExecutionContext` for background
    work). Production forwards package-invocation and package-app paths to

--- a/docs/contributing/environment-variables.md
+++ b/docs/contributing/environment-variables.md
@@ -280,8 +280,9 @@ Worker secrets:
   logged/routed through AI Gateway. When unset, the Worker calls Workers AI
   directly.
 - **`CAPABILITY_REINDEX_SECRET`** — strongly recommended for production (CI
-  skips the post-deploy capability reindex and execute smoke check when it is
-  unset); bearer token for `POST /__maintenance/reindex-capabilities`,
+  skips the post-deploy capability reindex and origin-only execute smoke check
+  when it is unset); bearer token for
+  `POST /__maintenance/reindex-capabilities`,
   `POST /__maintenance/reencrypt-secrets`, and other secret-gated maintenance
   endpoints. Production deploy POSTs `{ "phases": ["capabilities"] }` so only
   builtin capability vectors refresh after a ship. User-owned memory, job, and

--- a/docs/contributing/remix.md
+++ b/docs/contributing/remix.md
@@ -28,8 +28,8 @@ origin request path is:
 `packages/worker/src/index.ts` -> `packages/worker/src/app/handler.ts` ->
 `packages/worker/src/app/router.ts`
 
-Package-app hosts (`kody.run`; legacy `kodyapps.dev` dual-served until
-#1300/#1428) and the invocation API live on `kody-runtime`. Platform Durable
+Package-app hosts (`kody.run`; legacy `kodyapps.dev` dual-served until issues
+1300 and 1428) and the invocation API live on `kody-runtime`. Platform Durable
 Objects and scheduled jobs live on `kody-platform` and `kody-jobs`. See
 [architecture](architecture/index.md#production-worker-fleet).
 

--- a/docs/contributing/remix.md
+++ b/docs/contributing/remix.md
@@ -28,9 +28,9 @@ origin request path is:
 `packages/worker/src/index.ts` -> `packages/worker/src/app/handler.ts` ->
 `packages/worker/src/app/router.ts`
 
-Package-app hosts (`kody.run` / `kodyapps.dev`) and the invocation API live on
-`kody-runtime`. Platform Durable Objects and scheduled jobs live on
-`kody-platform` and `kody-jobs`. See
+Package-app hosts (`kody.run`; legacy `kodyapps.dev` dual-served until
+#1300/#1428) and the invocation API live on `kody-runtime`. Platform Durable
+Objects and scheduled jobs live on `kody-platform` and `kody-jobs`. See
 [architecture](architecture/index.md#production-worker-fleet).
 
 Keep these Worker-specific differences when comparing Kody with the default

--- a/docs/contributing/setup-manifest.md
+++ b/docs/contributing/setup-manifest.md
@@ -429,7 +429,7 @@ automatically:
 - `AI_GATEWAY_ID` (optional Worker secret; routes Workers AI embedding calls
   through the configured Cloudflare AI Gateway when set)
 - `CAPABILITY_REINDEX_SECRET` (strongly recommended for production — CI skips
-  the post-deploy reindex and execute smoke check when unset; optional locally
+  the post-deploy reindex and origin-only execute smoke check when unset; optional locally
   and for previews; bearer auth for `POST /__maintenance/reindex-capabilities`.
   Production deploy refreshes builtin capability vectors only
   (`{ "phases": ["capabilities"] }`). Omit `phases` to rebuild memories, jobs,
@@ -697,7 +697,7 @@ How to get/set each value:
     required so restored D1 fingerprints cannot skip an empty index. The same
     bearer authenticates `POST /__maintenance/reencrypt-secrets` (see
     [Secret rotation](./secret-rotation.md)). Local and preview environments can
-    omit it; CI skips reindex and execute-smoke when the secret is unset.
+    omit it; CI skips reindex and origin-only execute-smoke when the secret is unset.
 - `JOB_REINDEX_SECRET` (optional; jobs-only reindex)
   - Bearer token for `POST /__maintenance/reindex-jobs`. Generate and sync the
     same way as `CAPABILITY_REINDEX_SECRET` only if you want the jobs-only

--- a/docs/contributing/setup-manifest.md
+++ b/docs/contributing/setup-manifest.md
@@ -429,13 +429,13 @@ automatically:
 - `AI_GATEWAY_ID` (optional Worker secret; routes Workers AI embedding calls
   through the configured Cloudflare AI Gateway when set)
 - `CAPABILITY_REINDEX_SECRET` (strongly recommended for production — CI skips
-  the post-deploy reindex and origin-only execute smoke check when unset; optional locally
-  and for previews; bearer auth for `POST /__maintenance/reindex-capabilities`.
-  Production deploy refreshes builtin capability vectors only
-  (`{ "phases": ["capabilities"] }`). Omit `phases` to rebuild memories, jobs,
-  and saved packages too. Saved package projections also refresh when packages
-  are saved or published. Same bearer authenticates
-  `POST /__maintenance/reencrypt-secrets` — see
+  the post-deploy reindex and origin-only execute smoke check when unset;
+  optional locally and for previews; bearer auth for
+  `POST /__maintenance/reindex-capabilities`. Production deploy refreshes
+  builtin capability vectors only (`{ "phases": ["capabilities"] }`). Omit
+  `phases` to rebuild memories, jobs, and saved packages too. Saved package
+  projections also refresh when packages are saved or published. Same bearer
+  authenticates `POST /__maintenance/reencrypt-secrets` — see
   [Secret rotation](./secret-rotation.md).)
 - `JOB_REINDEX_SECRET` (optional Worker secret; bearer auth for
   `POST /__maintenance/reindex-jobs` for a jobs-only Vectorize rebuild. Not
@@ -697,7 +697,8 @@ How to get/set each value:
     required so restored D1 fingerprints cannot skip an empty index. The same
     bearer authenticates `POST /__maintenance/reencrypt-secrets` (see
     [Secret rotation](./secret-rotation.md)). Local and preview environments can
-    omit it; CI skips reindex and origin-only execute-smoke when the secret is unset.
+    omit it; CI skips reindex and origin-only execute-smoke when the secret is
+    unset.
 - `JOB_REINDEX_SECRET` (optional; jobs-only reindex)
   - Bearer token for `POST /__maintenance/reindex-jobs`. Generate and sync the
     same way as `CAPABILITY_REINDEX_SECRET` only if you want the jobs-only

--- a/packages/runtime-worker/readme.md
+++ b/packages/runtime-worker/readme.md
@@ -2,7 +2,8 @@
 
 The package runtime lane extracted from the main `kody` Worker per
 [ADR 0016](../../docs/contributing/decisions/0016-mono-worker-extraction.md):
-the package-app origin (`kody.run` / `kodyapps.dev`), inline package-app serving
+the package-app origin (`kody.run`; legacy `kodyapps.dev` dual-served until
+#1300/#1428), inline package-app serving
 forwarded from origin, the package invocation API, dynamic callable workflows
 (`DynamicCallableWorkflow`), `PackageAppRuntimeBridge`, `KodyFetchGateway`, and
 the runtime Durable Objects (`StorageRunner`, `RunLog`, and

--- a/packages/runtime-worker/readme.md
+++ b/packages/runtime-worker/readme.md
@@ -3,11 +3,10 @@
 The package runtime lane extracted from the main `kody` Worker per
 [ADR 0016](../../docs/contributing/decisions/0016-mono-worker-extraction.md):
 the package-app origin (`kody.run`; legacy `kodyapps.dev` dual-served until
-#1300/#1428), inline package-app serving
-forwarded from origin, the package invocation API, dynamic callable workflows
-(`DynamicCallableWorkflow`), `PackageAppRuntimeBridge`, `KodyFetchGateway`, and
-the runtime Durable Objects (`StorageRunner`, `RunLog`, and
-`PackageRealtimeSession`).
+#1300/#1428), inline package-app serving forwarded from origin, the package
+invocation API, dynamic callable workflows (`DynamicCallableWorkflow`),
+`PackageAppRuntimeBridge`, `KodyFetchGateway`, and the runtime Durable Objects
+(`StorageRunner`, `RunLog`, and `PackageRealtimeSession`).
 
 The Worker entry module is
 [`packages/worker/src/runtime-worker.ts`](../worker/src/runtime-worker.ts): the

--- a/packages/runtime-worker/readme.md
+++ b/packages/runtime-worker/readme.md
@@ -3,8 +3,8 @@
 The package runtime lane extracted from the main `kody` Worker per
 [ADR 0016](../../docs/contributing/decisions/0016-mono-worker-extraction.md):
 the package-app origin (`kody.run`; legacy `kodyapps.dev` dual-served until
-#1300/#1428), inline package-app serving forwarded from origin, the package
-invocation API, dynamic callable workflows (`DynamicCallableWorkflow`),
+issues 1300 and 1428), inline package-app serving forwarded from origin, the
+package invocation API, dynamic callable workflows (`DynamicCallableWorkflow`),
 `PackageAppRuntimeBridge`, `KodyFetchGateway`, and the runtime Durable Objects
 (`StorageRunner`, `RunLog`, and `PackageRealtimeSession`).
 

--- a/packages/worker/src/execute-maintenance.node.test.ts
+++ b/packages/worker/src/execute-maintenance.node.test.ts
@@ -13,10 +13,14 @@ vi.mock('#mcp/executor.ts', () => ({
 		createExecuteExecutorMock(...args),
 }))
 
-const { handleExecuteSmokeRequest, runExecuteSmokeCheck } =
-	await import('./execute-maintenance.ts')
+const {
+	executeSmokeProves,
+	executeSmokeScope,
+	handleExecuteSmokeRequest,
+	runExecuteSmokeCheck,
+} = await import('./execute-maintenance.ts')
 
-test('runExecuteSmokeCheck executes trivial code through the dynamic worker path', async () => {
+test('runExecuteSmokeCheck executes trivial code through the origin gateway and labels the result origin-only', async () => {
 	const execute = vi.fn(async () => ({ result: 42, logs: [] }))
 	createExecuteExecutorMock.mockReturnValue({ execute })
 
@@ -25,7 +29,14 @@ test('runExecuteSmokeCheck executes trivial code through the dynamic worker path
 		LOADER: {},
 	} as Env
 
-	await expect(runExecuteSmokeCheck(env)).resolves.toEqual({ result: 42 })
+	await expect(runExecuteSmokeCheck(env)).resolves.toEqual({
+		result: 42,
+		scope: executeSmokeScope,
+		proves: executeSmokeProves,
+		notMcpExecute: true,
+	})
+	expect(executeSmokeScope).toBe('origin-only')
+	expect(executeSmokeProves).toBe('origin-kody-fetch-gateway')
 	expect(createExecuteExecutorMock).toHaveBeenCalledWith(
 		expect.objectContaining({
 			timeoutMs: 10_000,
@@ -46,7 +57,7 @@ test('runExecuteSmokeCheck executes trivial code through the dynamic worker path
 	])
 })
 
-test('handleExecuteSmokeRequest enforces auth and reports smoke results', async () => {
+test('handleExecuteSmokeRequest enforces auth and reports origin-only smoke results', async () => {
 	const execute = vi.fn(async () => ({ result: 42, logs: [] }))
 	createExecuteExecutorMock.mockReturnValue({ execute })
 
@@ -77,5 +88,8 @@ test('handleExecuteSmokeRequest enforces auth and reports smoke results', async 
 	await expect(success.json()).resolves.toEqual({
 		ok: true,
 		result: 42,
+		scope: 'origin-only',
+		proves: 'origin-kody-fetch-gateway',
+		notMcpExecute: true,
 	})
 })

--- a/packages/worker/src/execute-maintenance.ts
+++ b/packages/worker/src/execute-maintenance.ts
@@ -13,6 +13,15 @@ const executeSmokeProviders = [
 	},
 ] as const
 
+/**
+ * Origin `/__maintenance/execute-smoke` proves this script's
+ * `ctx.exports.KodyFetchGateway` only. MCP `execute` looks up the gateway on
+ * `kody-platform` (the script that owns the `MCP` Durable Object). A passing
+ * origin smoke is not MCP execute health.
+ */
+export const executeSmokeScope = 'origin-only' as const
+export const executeSmokeProves = 'origin-kody-fetch-gateway' as const
+
 export async function runExecuteSmokeCheck(env: Env) {
 	if (!env.LOADER) {
 		throw new Error('Execute smoke check requires the LOADER binding.')
@@ -46,7 +55,12 @@ export async function runExecuteSmokeCheck(env: Env) {
 			`Execute smoke check returned unexpected result: ${getErrorMessage(result.result)}`,
 		)
 	}
-	return { result: result.result }
+	return {
+		result: result.result,
+		scope: executeSmokeScope,
+		proves: executeSmokeProves,
+		notMcpExecute: true,
+	}
 }
 
 export async function handleExecuteSmokeRequest(
@@ -56,7 +70,7 @@ export async function handleExecuteSmokeRequest(
 	return handleSecretMaintenanceRequest({
 		request,
 		secret: env.CAPABILITY_REINDEX_SECRET,
-		notConfiguredMessage: 'Execute smoke check is not configured',
+		notConfiguredMessage: 'Origin-only execute smoke check is not configured',
 		run: async () => await runExecuteSmokeCheck(env),
 	})
 }

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -238,6 +238,8 @@ const appHandler = withCors({
 		}
 
 		if (url.pathname === '/__maintenance/execute-smoke') {
+			// Origin-only: proves this script's ctx.exports.KodyFetchGateway.
+			// MCP execute looks up the gateway on kody-platform.
 			return handleExecuteSmokeRequest(request, env)
 		}
 

--- a/packages/worker/src/security/public-route-hardening.workers.test.ts
+++ b/packages/worker/src/security/public-route-hardening.workers.test.ts
@@ -89,7 +89,7 @@ test('public route hardening rejects retired connector paths, unknown paths, and
 		{
 			path: '/__maintenance/execute-smoke',
 			secret: env.CAPABILITY_REINDEX_SECRET,
-			notConfiguredMessage: 'Execute smoke check is not configured',
+			notConfiguredMessage: 'Origin-only execute smoke check is not configured',
 		},
 		{
 			path: '/__maintenance/reindex-memories',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
<!-- visual-recap -->
## System recap

```mermaid
sequenceDiagram
  participant CI as Deploy workflow
  participant Origin as Origin kody worker
  participant Gateway as Origin KodyFetchGateway
  participant MCP as MCP execute path
  participant Platform as kody-platform gateway
  CI->>Origin: POST /__maintenance/execute-smoke
  Origin->>Gateway: ctx.exports.KodyFetchGateway
  Gateway-->>CI: 42 (origin-only)
  Note over CI,Gateway: scope origin-only; does not prove MCP execute
  MCP->>Platform: getAgentByName(kody-platform, KodyFetchGateway)
```

| Field | Value |
| --- | --- |
| Risk | Medium |
| Touches | request-lifecycle, mcp-server, docs-usage, docs-contributing, ci-cd |
| Surfaces | `/__maintenance/execute-smoke` (origin-only), `/mcp` execute (unchanged), `kody.codes` / `{user}.kody.run` docs |
| Persistence | none |
| Rollback | revert this PR; smoke JSON and docs return to unlabeled / `heykody.dev`-first wording |

## Conductor report

- **Status:** DONE
- **PR:** https://github.com/kentcdodds/kody/pull/1724 **MERGED** squash `04bd609a484fe8afa486cc18b871c1dd86306a55`
- **CI:** https://github.com/kentcdodds/kody/actions/runs/32752470968 green (Static, Node, Workers, MCP, E2E)
- **Preview:** https://github.com/kentcdodds/kody/actions/runs/32752471054 → https://kody-pr-1724.kody-a99.workers.dev
- **Main Validate:** https://github.com/kentcdodds/kody/actions/runs/32753635838 green
- **Production deploy:** https://github.com/kentcdodds/kody/actions/runs/32753800119 — origin + platform + runtime deployed; `🧪 Origin-only execute smoke check (production)` **success**. Production JSON: `ok: true`, `result: 42`, `scope: origin-only`, `notMcpExecute: true`.
- **Discord:** posted to channel `1491568683737157683` (message `1541493030047977544`)
- **Chosen contract:** label origin-only (do not route smoke through platform). Success JSON includes `scope: origin-only`, `proves: origin-kody-fetch-gateway`, `notMcpExecute: true`. 503 copy: `Origin-only execute smoke check is not configured`.
- **Docs:** `kody.codes` / `{user}.kody.run` first; dual-serve until issues 1300 and 1428; ADR 0017 untouched; production `APP_LEGACY_*` / `PACKAGE_APP_LEGACY_*` / `LEGACY_*_EMAIL` unchanged.
- **Falsifiable-after-merge:** agent-facing examples owned by C emit only `kody.codes` / `{user}.kody.run`; execute-smoke cannot be mistaken for MCP execute health; CI/deploy green.
- **Conductor createRun:** retries still return Cursor API 409 (conductor likely already running a follow-up). Durable report is this PR body.

## Summary

- **Execute-smoke contract:** origin `/__maintenance/execute-smoke` is labeled origin-only. It still calls origin `ctx.exports.KodyFetchGateway`. MCP execute still looks up the gateway on `kody-platform`. The smoke JSON and 503 copy cannot be mistaken for MCP execute health.
- **Host vocabulary:** contributing architecture, remix, environment-variables, setup-manifest, and runtime-worker readme lead with `kody.codes` and `{username}.kody.run`. Dual-serve (`heykody.dev`, `*.heykody.app`) is documented as remaining until issues 1300 and 1428. ADR 0017 is unchanged.
- **Deploy step:** production smoke job title is now `🧪 Origin-only execute smoke check (production)` and passed on this SHA with the labeled JSON.
- **Not in this PR:** Track A values search/docs, Track B `jobs/createJob` `createdAt`.

## Test plan

- [x] `execute-maintenance.node.test.ts` asserts `scope`, `proves`, `notMcpExecute`
- [x] Hardening test expects the new 503 copy
- [x] Preview signed in as `me@kentcdodds.com` (`ilikecode` / `user-me`): POST execute-smoke returns labeled 503; GET 405; `/guides/package-authoring` uses `{username}.kody.run`; `/guides/salesforce` uses `https://kody.codes/connect/oauth`
- [x] CodeRabbit + Bugbot
- [x] CI validate + preview workflows
- [x] Production deploy + origin-only smoke on main (`04bd609a`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium risk.** Origin `/__maintenance/execute-smoke` is labeled origin-only (`scope`, `proves`, `notMcpExecute`) so it cannot be mistaken for MCP execute health. Agent-facing contributing docs lead with `kody.codes` and `{username}.kody.run`; dual-serve stays until issues 1300 and 1428. ADR 0017 and production `APP_LEGACY_*` vars are untouched.
>
> <sup>Reviewed 3 files, 199 lines. Used skills: remix, visual-recap, preview-manual-test, ship-pr, testing-principles, end-to-end-testing, code-style, documentation, architecture.</sup>
>
> Written by Cursor [Background Agent for Cloud Agents](https://cursor.com/dashboard?product=cloud-agents) (support: [cursor.com/dashboard](https://cursor.com/dashboard?product=cloud-agents))
<!-- /CURSOR_SUMMARY -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6e4a564a-99c4-46a4-9f72-4e94e0da306f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6e4a564a-99c4-46a4-9f72-4e94e0da306f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified production worker hosts, package-app domains, and legacy dual-serving behavior.
  - Documented that the execute smoke check validates the origin gateway only, not MCP execution.
  - Updated configuration guidance for post-deploy reindexing and smoke checks.

- **Enhancements**
  - Execute smoke-check responses now identify their validation scope and proof details.
  - Updated maintenance messaging to clearly describe origin-only validation.

- **Tests**
  - Expanded coverage for origin-only smoke execution and its response metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->