### PR TITLE
Leave claimed job runs running on transient D1 blips

### DIFF
--- a/packages/worker/src/mcp/run-kody-registry.node.test.ts
+++ b/packages/worker/src/mcp/run-kody-registry.node.test.ts
@@ -2653,7 +2653,7 @@ test('runBundledModuleWithRegistry finishes execute run records on failure only'
 	}
 })
 
-test('runBundledModuleWithRegistry leaves claimed job storage-estimate failures running', async () => {
+test('runBundledModuleWithRegistry leaves claimed job transient failures running', async () => {
 	silenceIncidentalRuntimeWarnings()
 	const env = {} as Env
 	const callerContext = createMcpCallerContext({
@@ -2688,25 +2688,91 @@ test('runBundledModuleWithRegistry leaves claimed job storage-estimate failures 
 		.mockResolvedValue(true)
 	const { createStorageEstimateReadError } =
 		await import('#worker/storage-estimate-error.ts')
+	const { d1NetworkConnectionLostMessage } =
+		await import('#worker/d1-retry.ts')
 	const estimateError = createStorageEstimateReadError({
 		storageId: 'package:estimate-target',
 		attempts: 4,
 		cause: new Error('Storage estimate read timed out after 2000ms.'),
 	})
+	const transientErrors = [
+		estimateError.message,
+		`${d1NetworkConnectionLostMessage}.`,
+		`D1_ERROR: ${d1NetworkConnectionLostMessage}.`,
+	]
+	let executeError: unknown = transientErrors[0]
 	const createExecuteExecutorSpy = vi
 		.spyOn(await import('#mcp/executor.ts'), 'createExecuteExecutor')
 		.mockReturnValue({
 			async execute() {
+				if (executeError instanceof Error) {
+					throw executeError
+				}
 				return {
 					result: undefined,
-					error: estimateError.message,
+					error: executeError,
 					logs: [],
 				}
 			},
 		} as never)
+	const claimedJobOptions = {
+		skipCapabilityRegistry: true,
+		runRecord: {
+			surface: 'job' as const,
+			name: 'sweep',
+			jobId: 'package-job:estimate:sweep',
+		},
+		runRecordHandle: handle,
+	}
 
 	try {
-		const claimed = await runBundledModuleWithRegistry(
+		for (const error of transientErrors) {
+			executeError = error
+			finishSpy.mockClear()
+			const claimed = await runBundledModuleWithRegistry(
+				env,
+				callerContext,
+				bundle,
+				undefined,
+				claimedJobOptions,
+			)
+			expect(claimed.error).toBe(error)
+			expect(finishSpy).not.toHaveBeenCalled()
+		}
+
+		executeError = new Error(`${d1NetworkConnectionLostMessage}.`)
+		finishSpy.mockClear()
+		await expect(
+			runBundledModuleWithRegistry(
+				env,
+				callerContext,
+				bundle,
+				undefined,
+				claimedJobOptions,
+			),
+		).rejects.toThrow(`${d1NetworkConnectionLostMessage}.`)
+		expect(finishSpy).not.toHaveBeenCalled()
+
+		executeError = 'user code failed'
+		finishSpy.mockClear()
+		const userCode = await runBundledModuleWithRegistry(
+			env,
+			callerContext,
+			bundle,
+			undefined,
+			claimedJobOptions,
+		)
+		expect(userCode.error).toBe('user code failed')
+		expect(finishSpy).toHaveBeenCalledWith(
+			expect.objectContaining({
+				handle,
+				status: 'error',
+			}),
+		)
+
+		executeError = `${d1NetworkConnectionLostMessage}.`
+		finishSpy.mockClear()
+		const executeFailure = await runBundledModuleWithRegistry(
 			env,
 			callerContext,
 			bundle,
@@ -2714,15 +2780,27 @@ test('runBundledModuleWithRegistry leaves claimed job storage-estimate failures 
 			{
 				skipCapabilityRegistry: true,
 				runRecord: {
-					surface: 'job',
-					name: 'sweep',
-					jobId: 'package-job:estimate:sweep',
+					surface: 'execute',
+					name: null,
+					storageId: 'storage-1',
 				},
-				runRecordHandle: handle,
+				runRecordHandle: {
+					...handle,
+					context: {
+						surface: 'execute',
+						name: null,
+						storageId: 'storage-1',
+						metadata: {},
+					},
+				},
 			},
 		)
-		expect(claimed.error).toBe(estimateError.message)
-		expect(finishSpy).not.toHaveBeenCalled()
+		expect(executeFailure.error).toBe(`${d1NetworkConnectionLostMessage}.`)
+		expect(finishSpy).toHaveBeenCalledWith(
+			expect.objectContaining({
+				status: 'error',
+			}),
+		)
 	} finally {
 		finishSpy.mockRestore()
 		createExecuteExecutorSpy.mockRestore()

--- a/packages/worker/src/mcp/run-kody-registry.node.test.ts
+++ b/packages/worker/src/mcp/run-kody-registry.node.test.ts
@@ -2688,8 +2688,7 @@ test('runBundledModuleWithRegistry leaves claimed job transient failures running
 		.mockResolvedValue(true)
 	const { createStorageEstimateReadError } =
 		await import('#worker/storage-estimate-error.ts')
-	const { d1NetworkConnectionLostMessage } =
-		await import('#worker/d1-retry.ts')
+	const { d1NetworkConnectionLostMessage } = await import('#worker/d1-retry.ts')
 	const estimateError = createStorageEstimateReadError({
 		storageId: 'package:estimate-target',
 		attempts: 4,

--- a/packages/worker/src/mcp/run-kody-registry.ts
+++ b/packages/worker/src/mcp/run-kody-registry.ts
@@ -75,8 +75,8 @@ import {
 } from '#worker/package-runtime/unbound-runtime-helpers.ts'
 import { runWithTransientDurableObjectResetRetry } from '#worker/durable-object-reset-retry.ts'
 import { evaluationHasHostMediatedSideEffects } from '#mcp/evaluation-side-effects.ts'
+import { isTransientJobExecutionError } from '#worker/jobs/execution-safety.ts'
 import { beginRunRecord, finishRunRecord } from '#worker/run-records/service.ts'
-import { isStorageEstimateReadError } from '#worker/storage-estimate-error.ts'
 import {
 	type RunRecordContext,
 	type RunRecordHandle,
@@ -814,6 +814,10 @@ export async function runBundledModuleWithRegistry(
 			waitUntil,
 		})
 	let runRecordFinished = false
+	const callerOwnsScheduledJobRun =
+		options?.runRecordHandle != null &&
+		(options.runRecord?.surface === 'job' ||
+			options.runRecordHandle.context.surface === 'job')
 	let exposeRunId = runRecordHandle?.persistence === 'eager'
 	let capturedLogs: Array<string> | undefined
 	// The metering span covers the whole bundled run (module hydration,
@@ -1128,17 +1132,16 @@ ${runtimeHelperRuntimePropertySource}
 						error: secretRedactor.redactErrorMessage(rewrittenMessage),
 					}
 				: sanitizedResult
-			const callerOwnsScheduledJobRun =
-				options?.runRecordHandle != null &&
-				(options.runRecord?.surface === 'job' ||
-					options.runRecordHandle.context.surface === 'job')
 			if (
 				callerOwnsScheduledJobRun &&
-				isStorageEstimateReadError(finalResult.error)
+				isTransientJobExecutionError(finalResult.error)
 			) {
 				// Leave the claimed run `running` so the job scheduler can
 				// abandon it and retry the same scheduledFor. Finishing as
-				// error would make the idempotency replay permanent.
+				// error would make the idempotency replay permanent — the
+				// next claim would replay the terminal row instead of
+				// retrying the occurrence (D1 blips, DO isolate resets,
+				// storage-estimate misses).
 				return withRunId(finalResult)
 			}
 			await finishObservedRun({
@@ -1149,6 +1152,13 @@ ${runtimeHelperRuntimePropertySource}
 			await recordPackageExportUsage('error')
 			return withRunId(finalResult)
 		} catch (error) {
+			if (
+				!runRecordFinished &&
+				callerOwnsScheduledJobRun &&
+				isTransientJobExecutionError(error)
+			) {
+				throw error
+			}
 			if (!runRecordFinished) {
 				await finishObservedRun({
 					status: 'error',
@@ -1159,6 +1169,13 @@ ${runtimeHelperRuntimePropertySource}
 			throw error
 		}
 	} catch (error) {
+		if (
+			!runRecordFinished &&
+			callerOwnsScheduledJobRun &&
+			isTransientJobExecutionError(error)
+		) {
+			throw error
+		}
 		if (!runRecordFinished) {
 			await finishObservedRun({
 				status: 'error',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop Cloudflare D1 transport blips (`Network connection lost.`) from finalizing a claimed scheduled job as a permanent error.

## Why

`kody-codes-social` poll `7b8fa3fe-1ef9-4a97-b634-4bb51512366b` finished as a hard job error with the exact D1 binding string that `isRetryableD1LockError` / `isTransientJobExecutionError` already treat as retryable. The package never constructs that message.

`executeJobOnce` would have promoted the sandbox `result.error` and asked JobManager to retry the same `scheduledFor`. Sandbox execute finished the claimed run as `error` first. `abandonRunRecord` only deletes `running` rows, so the next idempotency claim replayed the terminal failure and `run.error.recorded` opened this fingerprint.

The same hole was already patched for storage-estimate misses in `runBundledModuleWithRegistry`. This change uses that leave-running gate for every transient job-execution error, including thrown D1 blips.

## Summary

- Claimed scheduled-job sandbox failures that `isTransientJobExecutionError` matches (D1 blips, DO isolate resets, storage-estimate misses) no longer call `finishRunRecord`.
- The claimed row stays `running` so the scheduler can abandon it and retry the occurrence.
- Ad-hoc execute and user-code job failures still finish as error.
- Node coverage now includes the production `Network connection lost.` string, prefixed D1 form, thrown D1 blips, user-code finish, and execute-surface contrast.

## Testing

- `npm run test:node -- packages/worker/src/mcp/run-kody-registry.node.test.ts` — 17 passed, including the claimed-job transient leave-running workflow.
- `npm run test:node -- packages/worker/src/jobs/execution-safety.node.test.ts` — 4 passed.
- `nx run worker:typecheck` — passed.
- Preview cannot induce a Cloudflare D1 binding drop, so this path is covered by the node workflow above rather than `preview:manual-test`.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `70c01cbd` · **Head:** `d779f0d4`

**Classification:** extends — claimed scheduled-job execute no longer persists retryable D1/DO/storage-estimate failures as terminal run rows.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `capabilities-execute` | runtime | extends — leave claimed job runs `running` on `isTransientJobExecutionError` |
| `mcp-server` | surfaces | composes — registry node test only |

### Change flow

A claimed job sandbox D1 blip stays `running` so JobManager can abandon the row and retry the same `scheduledFor` instead of replaying a finished error.

```mermaid
sequenceDiagram
	participant jobs as jobs
	participant capabilitiesExecute as capabilities-execute
	participant runRecords as run-records
	jobs->>capabilitiesExecute: claimed scheduled job handle
	capabilitiesExecute->>capabilitiesExecute: sandbox returns Network connection lost
	alt transient job error
		capabilitiesExecute-->>jobs: result.error, run still running
		jobs->>runRecords: abandonRunRecord (delete if running)
		jobs->>jobs: retryClaimedJob same scheduledFor
	else user-code or execute-surface error
		capabilitiesExecute->>runRecords: finishRunRecord status error
		capabilitiesExecute-->>jobs: terminal error outcome
	end
```

### Invariants

Scheduled-job idempotency keys must not become permanent failures for retryable platform blips. User-authored job errors and ad-hoc execute failures still record as error.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-be2c5f58-ac37-45c9-8793-76b198dc06a9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-be2c5f58-ac37-45c9-8793-76b198dc06a9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of temporary job execution and network errors.
  * Scheduled jobs affected by transient failures can now retry instead of being permanently marked as failed.
  * User-code and execution-surface failures continue to be recorded as errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->