### PR TITLE
Put the package README first and fold install into a Trusted-adjacent pill

### DIFF
--- a/docs/use/community-packages.md
+++ b/docs/use/community-packages.md
@@ -99,8 +99,9 @@ image (1200×630). When the owner keeps a
 shows a follow control next to the username. Private owners show as `@username`
 with a lock that explains the profile is private.
 
-Each detail page includes a **copyable prompt** you can hand to your agent to
-start a fork. You can also ask your agent to use `community_search` or
+The detail page opens with the README. Next to **Trusted** (and **Featured**,
+when present) a pill says **Install**, **Installed**, **Forked**, or **Fork
+outdated**. You can also ask your agent to use `community_search` or
 `community_get` from the `community` domain.
 
 ## Forking a listing
@@ -155,21 +156,20 @@ is ahead.
 
 ## One-click install
 
-Each listing detail page has an **Install** button for signed-in users. Get
+Each listing detail page has an **Install** pill next to **Trusted** for
+signed-in users. Logged-out visitors get the same pill as a login link. Get
 started Step 2–3 follow
 [Connect your agent](./connect-your-agent.md#connect-a-workspace-mcp-then-persist-a-first-build)
-(workspace MCP or Just-try-Kody, then ad hoc → persist). Built-in service
-connects live under Advanced; after those installs, **Copy prompt** gives your
-agent a short setup prompt. If you already have a saved package with the same
-`kody_id`, or a fork of that listing, onboarding, listing cards, and the detail
-page show **Copy prompt** / **Installed** (or **Forked**) instead of Install.
-Listing cards and the detail page place **Trusted** / **Installed** (or
-**Forked**) badges on their own row under the package name. A trailing **Choose
-your own adventure** card copies an open-ended setup prompt when you want to
-explore or build something custom instead. Install forks the listing into your
-account and, when the fork passes the same publish checks a repo session would
-run, publishes it immediately as a live saved package. **Publishing activates
-the package right away** — declared jobs are scheduled.
+(workspace MCP or Just-try-Kody, then ad hoc → persist). If you already have a
+saved package with the same `kody_id`, or a fork of that listing, listing cards
+and the detail page show **Installed** or **Forked** instead of Install.
+Clicking that pill copies a prompt so your agent can look up the installed
+package and adapt it. Listing cards and the detail page place **Trusted** /
+**Installed** (or **Forked**) pills on their own row under the package name.
+Install forks the listing into your account and, when the fork passes the same
+publish checks a repo session would run, publishes it immediately as a live
+saved package. **Publishing activates the package right away** — declared jobs
+are scheduled.
 
 - **Untrusted listings** show a warning first: no admin has reviewed the code,
   and installing runs it in your account. You must explicitly confirm. Direct
@@ -179,13 +179,12 @@ the package right away** — declared jobs are scheduled.
 
 When checks fail — most commonly because the package imports code from the
 original author's scope (`kody:@originuser/...`) — nothing is published. The
-fork stays **inert** exactly as a manual `community_fork` would, and the page
-gives you a copyable prompt so your agent can review, adapt, and publish it
+fork stays **inert** exactly as a manual `community_fork` would, and the
+**Forked** pill copies a prompt so your agent can review, adapt, and publish it
 through a repo session.
 
-After a successful install the page shows a copyable prompt for your agent to
-finish setup: required secrets, OAuth connections, package secret-access
-approval, and a first test run.
+After a successful install the **Installed** pill copies a prompt so your agent
+can look up that package and adapt it to your needs.
 
 One-click install is deliberately a **UI-only** flow. Agents use
 `community_fork` plus a repo session instead, which keeps a human review step

--- a/packages/worker/client/fork-outdated-copy.node.test.ts
+++ b/packages/worker/client/fork-outdated-copy.node.test.ts
@@ -10,7 +10,10 @@ test('fork outdated click copies the prompt and swaps the tooltip to Copied', as
 
 	const tooltip = { textContent: 'Click to copy an update prompt' }
 	const button = {
-		dataset: { copyText: 'absorb these listing changes' },
+		dataset: {
+			copyText: 'absorb these listing changes',
+			copyTooltip: 'Click to copy an update prompt',
+		},
 		querySelector: (selector: string) =>
 			selector === '[role="tooltip"]' ? tooltip : null,
 		contains: () => false,
@@ -18,7 +21,7 @@ test('fork outdated click copies the prompt and swaps the tooltip to Copied', as
 	const event = {
 		target: {
 			closest: (selector: string) =>
-				selector === '[data-fork-outdated-copy]' ? button : null,
+				selector === '[data-copy-prompt]' ? button : null,
 		},
 		preventDefault: vi.fn(),
 		stopPropagation: vi.fn(),

--- a/packages/worker/client/fork-outdated-copy.ts
+++ b/packages/worker/client/fork-outdated-copy.ts
@@ -1,47 +1,40 @@
 import { writeClipboardText } from '#client/clipboard.ts'
 import {
-	FORK_OUTDATED_COPIED_TOOLTIP,
-	FORK_OUTDATED_COPY_TOOLTIP,
+	COPY_PROMPT_COPIED_TOOLTIP,
+	COPY_PROMPT_SELECTOR,
 } from '#universal/fork-outdated-copy-button.tsx'
 
-export const FORK_OUTDATED_COPY_BUTTON_SELECTOR = '[data-fork-outdated-copy]'
+export const FORK_OUTDATED_COPY_BUTTON_SELECTOR = COPY_PROMPT_SELECTOR
 
-type ForkOutdatedCopyButtonEl = {
-	dataset: { copyText?: string }
+type CopyPromptButtonEl = {
+	dataset: { copyText?: string; copyTooltip?: string }
 	querySelector: (selector: string) => { textContent: string | null } | null
 	contains: (node: Node) => boolean
 }
 
-function asForkOutdatedCopyButton(
-	value: unknown,
-): ForkOutdatedCopyButtonEl | null {
+function asCopyPromptButton(value: unknown): CopyPromptButtonEl | null {
 	if (value == null || typeof value !== 'object') return null
 	if (!('dataset' in value) || !('querySelector' in value)) return null
-	return value as ForkOutdatedCopyButtonEl
+	return value as CopyPromptButtonEl
 }
 
-function findForkOutdatedCopyButton(event: Event) {
+function findCopyPromptButton(event: Event) {
 	const target = event.target
 	if (target == null || typeof target !== 'object' || !('closest' in target)) {
 		return null
 	}
 	const closest = target.closest
 	if (typeof closest !== 'function') return null
-	return asForkOutdatedCopyButton(
-		closest.call(target, FORK_OUTDATED_COPY_BUTTON_SELECTOR),
-	)
+	return asCopyPromptButton(closest.call(target, COPY_PROMPT_SELECTOR))
 }
 
-function setForkOutdatedTooltip(
-	button: ForkOutdatedCopyButtonEl,
-	text: string,
-) {
+function setCopyPromptTooltip(button: CopyPromptButtonEl, text: string) {
 	const tooltip = button.querySelector('[role="tooltip"]')
 	if (tooltip) tooltip.textContent = text
 }
 
 export async function handleForkOutdatedCopyClick(event: Event) {
-	const button = findForkOutdatedCopyButton(event)
+	const button = findCopyPromptButton(event)
 	if (!button) return
 	const text = button.dataset.copyText
 	if (!text) return
@@ -49,14 +42,14 @@ export async function handleForkOutdatedCopyClick(event: Event) {
 	event.stopPropagation()
 	try {
 		await writeClipboardText(text)
-		setForkOutdatedTooltip(button, FORK_OUTDATED_COPIED_TOOLTIP)
+		setCopyPromptTooltip(button, COPY_PROMPT_COPIED_TOOLTIP)
 	} catch {
-		setForkOutdatedTooltip(button, 'Copy failed')
+		setCopyPromptTooltip(button, 'Copy failed')
 	}
 }
 
 export function handleForkOutdatedCopyPointerOut(event: Event) {
-	const button = findForkOutdatedCopyButton(event)
+	const button = findCopyPromptButton(event)
 	if (!button) return
 	const related = 'relatedTarget' in event ? event.relatedTarget : null
 	if (
@@ -66,5 +59,8 @@ export function handleForkOutdatedCopyPointerOut(event: Event) {
 	) {
 		return
 	}
-	setForkOutdatedTooltip(button, FORK_OUTDATED_COPY_TOOLTIP)
+	setCopyPromptTooltip(
+		button,
+		button.dataset.copyTooltip ?? COPY_PROMPT_COPIED_TOOLTIP,
+	)
 }

--- a/packages/worker/client/routes/community-detail-install.ts
+++ b/packages/worker/client/routes/community-detail-install.ts
@@ -1,0 +1,33 @@
+export type CommunityInstallUiState =
+	| 'idle'
+	| 'confirming'
+	| 'submitting'
+	| 'error'
+
+export type CommunityInstallClickDecision = 'ignore' | 'submit' | 'confirm'
+
+/**
+ * The Install pill lives in the server frame, so it stays clickable while
+ * the client is submitting, confirming, or waiting for a reload. Ignore
+ * those clicks; use the in-memory trust flag (updated on 409) rather than
+ * the frame's stale `data-trusted`.
+ */
+export function decideCommunityInstallClick(input: {
+	installState: CommunityInstallUiState
+	alreadyInstalled: boolean
+	listingTrusted: boolean
+}): CommunityInstallClickDecision {
+	if (input.alreadyInstalled) return 'ignore'
+	switch (input.installState) {
+		case 'submitting':
+		case 'confirming':
+			return 'ignore'
+		case 'idle':
+		case 'error':
+			return input.listingTrusted ? 'submit' : 'confirm'
+		default: {
+			const exhaustive: never = input.installState
+			throw new Error(`Unhandled install state: ${String(exhaustive)}`)
+		}
+	}
+}

--- a/packages/worker/client/routes/community-detail.node.test.ts
+++ b/packages/worker/client/routes/community-detail.node.test.ts
@@ -1,0 +1,63 @@
+import { expect, test } from 'vitest'
+import { decideCommunityInstallClick } from './community-detail-install.ts'
+
+test('trusted idle install submits immediately', () => {
+	expect(
+		decideCommunityInstallClick({
+			installState: 'idle',
+			alreadyInstalled: false,
+			listingTrusted: true,
+		}),
+	).toBe('submit')
+})
+
+test('untrusted idle install asks for confirmation even if the frame still says trusted', () => {
+	expect(
+		decideCommunityInstallClick({
+			installState: 'idle',
+			alreadyInstalled: false,
+			listingTrusted: false,
+		}),
+	).toBe('confirm')
+})
+
+test('install clicks are ignored while submitting, confirming, or already installed', () => {
+	expect(
+		decideCommunityInstallClick({
+			installState: 'submitting',
+			alreadyInstalled: false,
+			listingTrusted: true,
+		}),
+	).toBe('ignore')
+	expect(
+		decideCommunityInstallClick({
+			installState: 'confirming',
+			alreadyInstalled: false,
+			listingTrusted: false,
+		}),
+	).toBe('ignore')
+	expect(
+		decideCommunityInstallClick({
+			installState: 'idle',
+			alreadyInstalled: true,
+			listingTrusted: true,
+		}),
+	).toBe('ignore')
+})
+
+test('a failed install can be retried', () => {
+	expect(
+		decideCommunityInstallClick({
+			installState: 'error',
+			alreadyInstalled: false,
+			listingTrusted: true,
+		}),
+	).toBe('submit')
+	expect(
+		decideCommunityInstallClick({
+			installState: 'error',
+			alreadyInstalled: false,
+			listingTrusted: false,
+		}),
+	).toBe('confirm')
+})

--- a/packages/worker/client/routes/community-detail.tsx
+++ b/packages/worker/client/routes/community-detail.tsx
@@ -19,15 +19,9 @@ import {
 	ActionButtonLoader,
 	installProgressWords,
 } from '#client/action-button-loader.tsx'
-import { CopyTextButton } from '#client/copy-text-button.tsx'
 import { renderMarkdownNodes } from '#client/markdown-view.tsx'
 import { readJson } from '#client/routes/account-approval-shared.ts'
-import {
-	colors,
-	radius,
-	transitions,
-	typography,
-} from '#universal/styles/tokens.ts'
+import { colors, transitions, typography } from '#universal/styles/tokens.ts'
 import {
 	getGhostButtonCss,
 	getPillButtonCss,
@@ -56,8 +50,9 @@ import { UserAvatar } from '#universal/user-avatar.tsx'
  * post: the listing head (back link, icon + name + author + badges, tags,
  * quiet meta row) stays server-rendered in the `community-detail` frame —
  * see `src/app/community-detail-content.tsx` — while this shell renders the
- * interactive sections around it: one-click install, the fork prompt block,
- * the README as `.prose`, stars, admin tools, and the report disclosure.
+ * interactive sections around it: the README as `.prose`, stars, admin
+ * tools, and the report disclosure. Install / Installed / Fork outdated
+ * live in the frame next to Trusted.
  */
 
 type CommunityDetailApiPayload = {
@@ -255,7 +250,6 @@ function buildReportApiPath(listingId: string) {
 }
 
 export function CommunityDetailRoute(handle: Handle) {
-	let forkPrompt = ''
 	let loggedIn = false
 	let viewerIsAdmin = false
 	let trusted = false
@@ -267,7 +261,6 @@ export function CommunityDetailRoute(handle: Handle) {
 	let installState: 'idle' | 'confirming' | 'submitting' | 'error' = 'idle'
 	let installMessage: string | null = null
 	let installOutcome: CommunityInstallOutcome | null = null
-	let existingInstall: ViewerListingInstall | null = null
 	let readmeContent: string | null = null
 	let shellStatus: 'loading' | 'ready' | 'error' = 'loading'
 	let shellLoadRequestId = 0
@@ -341,7 +334,6 @@ export function CommunityDetailRoute(handle: Handle) {
 				throw new Error('Unable to load community package.')
 			}
 			rememberListingId(ref.pathname, payload.listing.id)
-			forkPrompt = payload.forkPrompt
 			loggedIn = payload.loggedIn
 			viewerIsAdmin = payload.viewerIsAdmin
 			trusted = payload.listing.trusted
@@ -353,7 +345,6 @@ export function CommunityDetailRoute(handle: Handle) {
 			installState = 'idle'
 			installMessage = null
 			installOutcome = null
-			existingInstall = payload.viewerInstall
 			readmeContent = payload.listing.readmeContent
 			starCount = payload.listing.starCount
 			starredByViewer = payload.starredByViewer
@@ -639,6 +630,8 @@ export function CommunityDetailRoute(handle: Handle) {
 			}
 			installState = 'idle'
 			handle.update()
+			const frame = handle.frames.get(COMMUNITY_DETAIL_TARGET)
+			if (frame) void frame.reload()
 		} catch (error) {
 			if (getCurrentListingId(handle) !== listingId) return
 			installState = 'error'
@@ -648,6 +641,21 @@ export function CommunityDetailRoute(handle: Handle) {
 					: 'Unable to install this community package.'
 			handle.update()
 		}
+	}
+
+	function handleCommunityInstallClick(event: Event) {
+		const target = event.target
+		if (!(target instanceof Element)) return
+		const control = target.closest('[data-community-install]')
+		if (!control || control instanceof HTMLAnchorElement) return
+		event.preventDefault()
+		if (control.getAttribute('data-trusted') === 'true') {
+			void submitInstall()
+			return
+		}
+		installState = 'confirming'
+		installMessage = null
+		handle.update()
 	}
 
 	listenToRouterNavigation(handle, () => {
@@ -671,7 +679,6 @@ export function CommunityDetailRoute(handle: Handle) {
 		if (!routeData || !listingId || routeData.listingId !== listingId) {
 			return false
 		}
-		forkPrompt = routeData.forkPrompt
 		loggedIn = routeData.loggedIn
 		viewerIsAdmin = routeData.viewerIsAdmin
 		trusted = routeData.trusted
@@ -683,7 +690,6 @@ export function CommunityDetailRoute(handle: Handle) {
 		installState = 'idle'
 		installMessage = null
 		installOutcome = null
-		existingInstall = routeData.viewerInstall
 		readmeContent = routeData.readmeContent
 		starCount = routeData.starCount
 		starredByViewer = routeData.starredByViewer
@@ -771,24 +777,19 @@ export function CommunityDetailRoute(handle: Handle) {
 			: showShellReady
 				? ''
 				: 'Loading community package details…'
-		const shownInstall = installOutcome
-			? {
-					...installOutcome,
-					existing: false,
-				}
-			: existingInstall
-				? {
-						status: existingInstall.status,
-						targetName: existingInstall.targetName,
-						agentPrompt: existingInstall.agentPrompt,
-						packageId: existingInstall.packageId,
-						failedChecks: [] as Array<{ kind: string; message: string }>,
-						existing: true,
-					}
-				: null
+		const installAnnouncement = installOutcome
+			? installOutcome.status === 'installed'
+				? `Installed as ${installOutcome.targetName}.`
+				: `Forked as ${installOutcome.targetName}; it needs adaptation before it can run.`
+			: ''
 
 		return (
-			<article mix={css(detailArticleCss)}>
+			<article
+				mix={[
+					css(detailArticleCss),
+					on('click', (event) => handleCommunityInstallClick(event)),
+				]}
+			>
 				<Frame name={COMMUNITY_DETAIL_TARGET} src={frameSrc} />
 
 				{/*
@@ -817,200 +818,59 @@ export function CommunityDetailRoute(handle: Handle) {
 
 				{showShellReady ? (
 					<>
-						<section
-							aria-labelledby="install-title"
-							mix={css(detailSectionCss)}
-							data-testid="community-install"
-						>
-							<h2 id="install-title">One-click install</h2>
-							{shownInstall ? (
-								shownInstall.status === 'installed' ? (
-									<>
-										<p data-testid="community-install-success" role="status">
-											{shownInstall.existing
-												? 'Already installed as'
-												: 'Installed as'}{' '}
-											{shownInstall.targetName}.
-											{shownInstall.existing
-												? ''
-												: ' Any jobs the package declares are now scheduled.'}
-										</p>
-										<p>
-											<a
-												href={
-													shownInstall.packageId
-														? routes.accountPackageDetail.href({
-																packageId: shownInstall.packageId,
-															})
-														: routes.accountPackages.href()
-												}
-												mix={css(inlineLinkCss)}
-												data-testid="community-install-open-package"
-											>
-												{shownInstall.packageId
-													? 'Open in your packages'
-													: 'View it in your packages'}
-											</a>
-										</p>
-										<p>
-											Give this prompt to your agent to finish any remaining
-											setup (secrets, connections, a first test run):
-										</p>
-										<div mix={css(promptGroupCss)}>
-											<blockquote mix={css(promptBlockCss)}>
-												{shownInstall.agentPrompt}
-											</blockquote>
-											<CopyTextButton
-												value={shownInstall.agentPrompt}
-												idleLabel="Copy prompt"
-												variant="pill"
-											/>
-										</div>
-									</>
-								) : (
-									<>
-										<p data-testid="community-install-adaptation" role="status">
-											{shownInstall.existing
-												? 'Already forked as'
-												: 'Forked as'}{' '}
-											{shownInstall.targetName}, but it needs adaptation before
-											it can run in your account.
-										</p>
-										{shownInstall.failedChecks.length > 0 ? (
-											<ul mix={css(checkListCss)}>
-												{shownInstall.failedChecks.map((check) => (
-													<li key={check.kind}>
-														{check.kind}: {check.message}
-													</li>
-												))}
-											</ul>
-										) : null}
-										<p>
-											Give this prompt to your agent to adapt and publish it:
-										</p>
-										<div mix={css(promptGroupCss)}>
-											<blockquote mix={css(promptBlockCss)}>
-												{shownInstall.agentPrompt}
-											</blockquote>
-											<CopyTextButton
-												value={shownInstall.agentPrompt}
-												idleLabel="Copy prompt"
-												variant="pill"
-											/>
-										</div>
-									</>
-								)
-							) : (
-								<>
-									<p>
-										Install forks this package into your account and publishes
-										it right away when it passes the standard package checks.
-										{trusted
-											? ' An admin reviewed and trusted this exact version.'
-											: ' This listing has not been reviewed by an admin.'}
-									</p>
-									{loggedIn ? (
-										installState === 'confirming' ? (
-											<div
-												mix={css(warningCardCss)}
-												data-testid="community-install-warning"
-												role="alert"
-											>
-												<p mix={css({ margin: 0 })}>
-													This package is not trusted: no admin has reviewed its
-													code, and it was written by another user. Installing
-													publishes it into your account and can activate its
-													scheduled jobs immediately. Only continue if you
-													accept that risk.
-												</p>
-												<div mix={css(buttonRowCss)}>
-													<button
-														mix={[
-															on('click', () => void submitInstall()),
-															css(dangerPillButtonCss),
-														]}
-													>
-														Install anyway
-													</button>
-													<button
-														mix={[
-															on('click', () => {
-																installState = 'idle'
-																handle.update()
-															}),
-															css(smallGhostButtonCss),
-														]}
-													>
-														Cancel
-													</button>
-												</div>
-											</div>
-										) : (
-											<div mix={css(sectionActionCss)}>
-												<button
-													disabled={installState === 'submitting'}
-													aria-busy={
-														installState === 'submitting' ? 'true' : undefined
-													}
-													mix={[
-														on('click', () => {
-															if (trusted) {
-																void submitInstall()
-																return
-															}
-															installState = 'confirming'
-															installMessage = null
-															handle.update()
-														}),
-														css(pillButtonCss),
-													]}
-												>
-													{installState === 'submitting' ? (
-														<ActionButtonLoader
-															label="Installing"
-															words={installProgressWords}
-														/>
-													) : (
-														'Install'
-													)}
-												</button>
-											</div>
-										)
-									) : (
-										<p>
-											<a href="/login" mix={css(inlineLinkCss)}>
-												Log in
-											</a>{' '}
-											to install this package.
-										</p>
-									)}
-									{installMessage ? (
-										<p mix={css(errorTextCss)} role="alert">
-											{installMessage}
-										</p>
-									) : null}
-								</>
-							)}
-						</section>
-
-						<section aria-labelledby="fork-title" mix={css(detailSectionCss)}>
-							<h2 id="fork-title">Fork with your agent</h2>
-							<p>
-								Copy this prompt into your MCP-capable agent to fork and adapt
-								the package safely. Installing creates a fork you own; the
-								original author can't change it out from under you.
+						<div data-testid="community-install" mix={css(installStripCss)}>
+							<p role="status" mix={css(visuallyHiddenCss)}>
+								{installAnnouncement}
 							</p>
-							<div mix={css(promptGroupCss)}>
-								<blockquote id="fork-prompt" mix={css(promptBlockCss)}>
-									{forkPrompt}
-								</blockquote>
-								<CopyTextButton
-									value={forkPrompt}
-									idleLabel="Copy prompt"
-									variant="pill"
-								/>
-							</div>
-						</section>
+							{installState === 'submitting' ? (
+								<p mix={css(installProgressCss)} role="status">
+									<ActionButtonLoader
+										label="Installing"
+										words={installProgressWords}
+									/>
+								</p>
+							) : null}
+							{installState === 'confirming' ? (
+								<div
+									mix={css(warningCardCss)}
+									data-testid="community-install-warning"
+									role="alert"
+								>
+									<p mix={css({ margin: 0 })}>
+										This package is not trusted: no admin has reviewed its code,
+										and it was written by another user. Installing publishes it
+										into your account and can activate its scheduled jobs
+										immediately. Only continue if you accept that risk.
+									</p>
+									<div mix={css(buttonRowCss)}>
+										<button
+											mix={[
+												on('click', () => void submitInstall()),
+												css(dangerPillButtonCss),
+											]}
+										>
+											Install anyway
+										</button>
+										<button
+											mix={[
+												on('click', () => {
+													installState = 'idle'
+													handle.update()
+												}),
+												css(smallGhostButtonCss),
+											]}
+										>
+											Cancel
+										</button>
+									</div>
+								</div>
+							) : null}
+							{installMessage ? (
+								<p mix={css(errorTextCss)} role="alert">
+									{installMessage}
+								</p>
+							) : null}
+						</div>
 
 						{readmeContent ? (
 							<section
@@ -1343,24 +1203,15 @@ const sectionActionCss = {
 	marginTop: '1.1rem',
 }
 
-const promptGroupCss = {
-	marginTop: '1.2rem',
-	'& > button': {
-		marginTop: '0.8rem',
-	},
+const installStripCss = {
+	display: 'grid',
+	gap: '0.75rem',
 }
 
-const promptBlockCss = {
-	margin: 0,
-	fontSize: '0.98rem',
-	lineHeight: 1.6,
-	color: colors.text,
-	backgroundColor: colors.surface,
-	border: `1.5px solid ${colors.border}`,
-	borderRadius: radius.card,
-	padding: '1.1rem 1.3rem',
-	whiteSpace: 'pre-wrap' as const,
-	overflowWrap: 'break-word' as const,
+const installProgressCss = {
+	margin: '1.2rem 0 0',
+	color: colors.textMuted,
+	fontSize: '0.95rem',
 }
 
 const pillButtonCss = getPillButtonCss()
@@ -1399,15 +1250,6 @@ const buttonRowCss = {
 	display: 'flex',
 	gap: '0.5rem',
 	flexWrap: 'wrap' as const,
-}
-
-const checkListCss = {
-	margin: '0.8rem 0 0',
-	paddingLeft: '1.25rem',
-	color: colors.textMuted,
-	fontSize: '0.92rem',
-	display: 'grid',
-	gap: '0.35rem',
 }
 
 const inlineLinkCss = {

--- a/packages/worker/client/routes/community-detail.tsx
+++ b/packages/worker/client/routes/community-detail.tsx
@@ -21,6 +21,7 @@ import {
 } from '#client/action-button-loader.tsx'
 import { renderMarkdownNodes } from '#client/markdown-view.tsx'
 import { readJson } from '#client/routes/account-approval-shared.ts'
+import { decideCommunityInstallClick } from '#client/routes/community-detail-install.ts'
 import { colors, transitions, typography } from '#universal/styles/tokens.ts'
 import {
 	getGhostButtonCss,
@@ -649,13 +650,27 @@ export function CommunityDetailRoute(handle: Handle) {
 		const control = target.closest('[data-community-install]')
 		if (!control || control instanceof HTMLAnchorElement) return
 		event.preventDefault()
-		if (control.getAttribute('data-trusted') === 'true') {
-			void submitInstall()
-			return
+		const decision = decideCommunityInstallClick({
+			installState,
+			alreadyInstalled: installOutcome != null,
+			listingTrusted: trusted,
+		})
+		switch (decision) {
+			case 'ignore':
+				return
+			case 'submit':
+				void submitInstall()
+				return
+			case 'confirm':
+				installState = 'confirming'
+				installMessage = null
+				handle.update()
+				return
+			default: {
+				const exhaustive: never = decision
+				throw new Error(`Unhandled install click: ${String(exhaustive)}`)
+			}
 		}
-		installState = 'confirming'
-		installMessage = null
-		handle.update()
 	}
 
 	listenToRouterNavigation(handle, () => {

--- a/packages/worker/src/app/community-detail-content.node.test.ts
+++ b/packages/worker/src/app/community-detail-content.node.test.ts
@@ -53,4 +53,54 @@ test('community detail head replaces Installed with Fork outdated when the listi
 	expect(html).not.toContain(
 		'data-testid="community-detail-viewer-install-badge"',
 	)
+	expect(html).not.toContain('data-testid="community-detail-install"')
+})
+
+test('community detail head shows an Install pill when the viewer has not forked it', async () => {
+	const html = await renderCommunityDetailContentHtml({
+		listing: sampleListing,
+		ownerProfilePublic: true,
+		loggedIn: true,
+		viewerFollowsOwner: false,
+		viewerIsOwner: false,
+		returnTo: '/@kentcdodds/github-triage',
+		followError: null,
+	})
+
+	expect(html).toContain('data-testid="community-detail-install"')
+	expect(html).toContain('data-community-install')
+	expect(html).toContain('data-trusted="false"')
+	expect(html).not.toContain('One-click install')
+	expect(html).not.toContain('Fork with your agent')
+})
+
+test('community detail Installed pill copies an adapt prompt', async () => {
+	const agentPrompt =
+		'Call package_get for @me/github-triage and adapt it to my needs.'
+	const html = await renderCommunityDetailContentHtml({
+		listing: {
+			...sampleListing,
+			trusted: true,
+			viewerInstall: {
+				status: 'installed',
+				targetName: '@me/github-triage',
+				agentPrompt,
+				packageId: 'pkg-1',
+				listingAhead: false,
+				listingAheadPrompt: null,
+			},
+		},
+		ownerProfilePublic: true,
+		loggedIn: true,
+		viewerFollowsOwner: false,
+		viewerIsOwner: false,
+		returnTo: '/@kentcdodds/github-triage',
+		followError: null,
+	})
+
+	expect(html).toContain('data-testid="community-detail-trusted-badge"')
+	expect(html).toContain('data-testid="community-detail-viewer-install-badge"')
+	expect(html).toContain('data-copy-prompt')
+	expect(html).toContain(agentPrompt)
+	expect(html).not.toContain('data-testid="community-detail-install"')
 })

--- a/packages/worker/src/app/community-detail-content.tsx
+++ b/packages/worker/src/app/community-detail-content.tsx
@@ -73,32 +73,32 @@ export function CommunityDetailContent(
 				<CommunityListingIcon listing={listing} size="detail" />
 				<div mix={css(headTextCss)}>
 					<h1>{renderCommunityListingName(listing.name)}</h1>
-					{listing.trusted || listing.featured || listing.viewerInstall ? (
-						<span mix={css(detailBadgeGroupCss)}>
-							{listing.trusted ? (
-								<span
-									data-testid="community-detail-trusted-badge"
-									title="An admin reviewed this exact version and marked it trusted."
-									mix={css(badgeCss)}
-								>
-									Trusted
-								</span>
-							) : null}
-							{listing.featured ? (
-								<span
-									data-testid="community-detail-featured-badge"
-									title="An admin featured this package as an onboarding starter install."
-									mix={css(badgeCss)}
-								>
-									Featured
-								</span>
-							) : null}
-							{renderCommunityViewerInstallBadge({
-								listing,
-								variant: 'detail',
-							})}
-						</span>
-					) : null}
+					<span mix={css(detailBadgeGroupCss)}>
+						{listing.trusted ? (
+							<span
+								data-testid="community-detail-trusted-badge"
+								title="An admin reviewed this exact version and marked it trusted."
+								mix={css(badgeCss)}
+							>
+								Trusted
+							</span>
+						) : null}
+						{listing.featured ? (
+							<span
+								data-testid="community-detail-featured-badge"
+								title="An admin featured this package as an onboarding starter install."
+								mix={css(badgeCss)}
+							>
+								Featured
+							</span>
+						) : null}
+						{renderCommunityViewerInstallBadge({
+							listing,
+							variant: 'detail',
+							loggedIn,
+							returnTo,
+						})}
+					</span>
 					{/* A div, not a p: the signed-in follow control is a form, and
 					    browsers close a p before a form, which drops the glyph
 					    onto the next line. Separate flex items (not nested flex +

--- a/packages/worker/src/app/community-listings-content.node.test.ts
+++ b/packages/worker/src/app/community-listings-content.node.test.ts
@@ -150,9 +150,11 @@ test('community listings render sort controls, categories, empty states, and for
 	expect(installedHtml).toContain(
 		'data-testid="community-listing-viewer-install-listing-1"',
 	)
+	expect(installedHtml).toContain('data-copy-prompt')
 	expect(installedHtml).not.toContain(
 		'data-testid="community-listing-ahead-listing-1"',
 	)
+	expect(installedHtml).not.toContain('data-testid="community-detail-install"')
 
 	const aheadPrompt =
 		'Compare the current listing snapshot, keep local customizations, then call community_fork_absorb.'

--- a/packages/worker/src/app/community-listings-content.tsx
+++ b/packages/worker/src/app/community-listings-content.tsx
@@ -16,7 +16,13 @@ import {
 } from '#universal/community-display.ts'
 import { renderCommunityEmptyState } from '#universal/community-empty-state.tsx'
 import { CommunityListingIcon } from '#universal/community-listing-icon.tsx'
-import { ForkOutdatedCopyButton } from '#universal/fork-outdated-copy-button.tsx'
+import {
+	FORKED_COPY_TOOLTIP,
+	FORK_OUTDATED_COPY_TOOLTIP,
+	INSTALLED_COPY_TOOLTIP,
+	renderCopyPromptPill,
+} from '#universal/fork-outdated-copy-button.tsx'
+import { routes } from '#universal/routes.ts'
 import { renderCommunityListingName } from '#universal/community-listing-name.tsx'
 import { getCommunityListingHref } from '#universal/community-links.ts'
 import {
@@ -28,6 +34,7 @@ import { type CommunityIndexGroup } from '#universal/loader-data.ts'
 import { colors, transitions } from '#universal/styles/tokens.ts'
 import {
 	getSurfaceCardCss,
+	hoverMq,
 	mergeCss,
 	visuallyHiddenCss,
 } from '#universal/styles/style-primitives.ts'
@@ -286,37 +293,61 @@ function renderCommunityListingGrid(
 export function renderCommunityViewerInstallBadge(input: {
 	listing: PublicCommunityListing
 	variant: 'card' | 'detail'
+	loggedIn?: boolean
+	returnTo?: string
 }) {
 	const install = input.listing.viewerInstall
-	if (!install) return null
-	if (install.listingAhead && install.listingAheadPrompt) {
+	if (install?.listingAhead && install.listingAheadPrompt) {
+		return renderCopyPromptPill({
+			label: 'Fork outdated',
+			prompt: install.listingAheadPrompt,
+			testId:
+				input.variant === 'card'
+					? `community-listing-ahead-${input.listing.id}`
+					: 'community-detail-listing-ahead-badge',
+			tooltip: FORK_OUTDATED_COPY_TOOLTIP,
+			tone: 'outdated',
+		})
+	}
+	if (install) {
+		const installed = install.status === 'installed'
+		return renderCopyPromptPill({
+			label: installed ? 'Installed' : 'Forked',
+			prompt: install.agentPrompt,
+			testId:
+				input.variant === 'card'
+					? `community-listing-viewer-install-${input.listing.id}`
+					: 'community-detail-viewer-install-badge',
+			tooltip: installed ? INSTALLED_COPY_TOOLTIP : FORKED_COPY_TOOLTIP,
+			tone: 'badge',
+		})
+	}
+	if (input.variant !== 'detail') return null
+	const loginHref = routes.login.href(null, {
+		searchParams: { redirectTo: input.returnTo ?? routes.community.href() },
+	})
+	if (!input.loggedIn) {
 		return (
-			<ForkOutdatedCopyButton
-				prompt={install.listingAheadPrompt}
-				testId={
-					input.variant === 'card'
-						? `community-listing-ahead-${input.listing.id}`
-						: 'community-detail-listing-ahead-badge'
-				}
-			/>
+			<a
+				href={loginHref}
+				data-testid="community-detail-install"
+				data-community-install=""
+				mix={css(communityInstallPillCss)}
+			>
+				Install
+			</a>
 		)
 	}
 	return (
-		<span
-			data-testid={
-				input.variant === 'card'
-					? `community-listing-viewer-install-${input.listing.id}`
-					: 'community-detail-viewer-install-badge'
-			}
-			title={
-				install.status === 'installed'
-					? `Installed in your account as ${install.targetName}.`
-					: `Forked in your account as ${install.targetName}; still needs adaptation.`
-			}
-			mix={css(communityBadgePillCss)}
+		<button
+			type="button"
+			data-testid="community-detail-install"
+			data-community-install=""
+			data-trusted={input.listing.trusted ? 'true' : 'false'}
+			mix={css(communityInstallPillCss)}
 		>
-			{install.status === 'installed' ? 'Installed' : 'Forked'}
-		</span>
+			Install
+		</button>
 	)
 }
 
@@ -589,6 +620,27 @@ export const communityBadgePillCss = {
 	padding: '0.15rem 0.6rem',
 	whiteSpace: 'nowrap' as const,
 	cursor: 'help',
+}
+
+export const communityInstallPillCss = {
+	...communityBadgePillCss,
+	appearance: 'none' as const,
+	margin: 0,
+	border: 'none',
+	fontFamily: 'inherit',
+	lineHeight: 1.2,
+	textDecoration: 'none',
+	cursor: 'pointer',
+	[hoverMq]: {
+		'&:hover': {
+			backgroundColor: `oklch(from ${colors.primary} l c h / 0.2)`,
+			color: colors.primaryText,
+		},
+	},
+	'&:focus-visible': {
+		outline: `2px solid ${colors.primary}`,
+		outlineOffset: '2px',
+	},
 }
 
 const listingBadgeGroupCss = {

--- a/packages/worker/src/app/community-public.ts
+++ b/packages/worker/src/app/community-public.ts
@@ -178,7 +178,7 @@ export function buildInstallAdaptPrompt(input: {
 }
 
 export function buildExistingInstallPrompt(input: { targetName: string }) {
-	return `I already have the community package "${input.targetName}" in my Kody account. Call package_get for it and read its README, then walk me through any remaining setup: create required secrets or OAuth connections, approve package secret access if prompted, and run a quick test to confirm it works.`
+	return `I have the community package "${input.targetName}" installed in my Kody account. Call package_get for it and read its README, then adapt it to my needs: update the README Intent section, change behavior if needed, and publish the result.`
 }
 
 export function buildExistingAdaptPrompt(input: {

--- a/packages/worker/src/app/profile-content.node.test.ts
+++ b/packages/worker/src/app/profile-content.node.test.ts
@@ -54,7 +54,6 @@ test('profile packages link listings, prefer listing kody ids, and separate publ
 	})
 
 	expect(guestHtml).toContain('href="/@kody/fathom-analytics"')
-	expect(guestHtml).toContain('href="/@kody/fathom-analytics#fork-title"')
 	// Listed packages get one fork control; unpublished packages do not.
 	expect(guestHtml.match(/aria-label="fork"/g)).toHaveLength(1)
 	expect(guestHtml).toContain('notes')

--- a/packages/worker/src/app/profile-content.tsx
+++ b/packages/worker/src/app/profile-content.tsx
@@ -191,7 +191,7 @@ export function ProfileContent(handle: Handle<ProfileContentProps>) {
 										<div mix={css(packageTitleGroupCss)}>
 											{listingHref ? (
 												<a
-													href={`${listingHref}#fork-title`}
+													href={listingHref}
 													title="fork"
 													aria-label="fork"
 													mix={css(forkButtonCss)}

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -1643,6 +1643,9 @@ test('canonical package URL SSR renders the redesigned article', async () => {
 	expect(html).toContain('/community/listing-detail-1/icon/abc1234567890')
 	expect(html).toContain('data-testid="community-detail-trusted-badge"')
 	expect(html).toContain('data-testid="community-readme"')
+	expect(html).toContain('data-testid="community-detail-install"')
+	expect(html).not.toContain('One-click install')
+	expect(html).not.toContain('Fork with your agent')
 	const props = readAppRootProps(html)
 	expect(props.loaderData?.communityDetailShell).toMatchObject({
 		ok: true,

--- a/packages/worker/universal/fork-outdated-copy-button.tsx
+++ b/packages/worker/universal/fork-outdated-copy-button.tsx
@@ -10,8 +10,23 @@ import {
 } from '#universal/styles/tokens.ts'
 import { hoverMq } from '#universal/styles/style-primitives.ts'
 
+export const COPY_PROMPT_ATTRIBUTE = 'data-copy-prompt'
+export const COPY_PROMPT_SELECTOR = '[data-copy-prompt]'
 export const FORK_OUTDATED_COPY_TOOLTIP = 'Click to copy an update prompt'
-export const FORK_OUTDATED_COPIED_TOOLTIP = 'Copied'
+export const INSTALLED_COPY_TOOLTIP =
+	'Click to copy a prompt to look up this package and adapt it'
+export const FORKED_COPY_TOOLTIP =
+	'Click to copy a prompt to finish adapting this fork'
+export const COPY_PROMPT_COPIED_TOOLTIP = 'Copied'
+export const FORK_OUTDATED_COPIED_TOOLTIP = COPY_PROMPT_COPIED_TOOLTIP
+
+type CopyPromptPillInput = {
+	label: string
+	prompt: string
+	testId: string
+	tooltip: string
+	tone: 'badge' | 'outdated'
+}
 
 type ForkOutdatedCopyButtonProps = {
 	prompt: string
@@ -19,60 +34,48 @@ type ForkOutdatedCopyButtonProps = {
 }
 
 /**
- * Yellow pill that stands in for Installed/Forked when a community listing
- * has been republished ahead of this fork. Frames render this as static HTML;
- * the hydrated app copies `data-copy-text` on click and swaps the tooltip.
+ * Static HTML copy pill. Frames render it without hydration; the app copies
+ * `data-copy-text` on click and swaps the tooltip.
  */
-export function ForkOutdatedCopyButton(
-	handle: Handle<ForkOutdatedCopyButtonProps>,
-) {
-	return () => (
+export function renderCopyPromptPill(input: CopyPromptPillInput) {
+	return (
 		<button
 			type="button"
-			data-testid={handle.props.testId}
-			data-fork-outdated-copy=""
-			data-copy-text={handle.props.prompt}
-			mix={css(forkOutdatedCopyButtonCss)}
+			data-testid={input.testId}
+			data-copy-prompt=""
+			data-copy-text={input.prompt}
+			data-copy-tooltip={input.tooltip}
+			{...(input.tone === 'outdated' ? { 'data-fork-outdated-copy': '' } : {})}
+			mix={css(
+				input.tone === 'outdated'
+					? forkOutdatedCopyButtonCss
+					: badgeCopyPromptButtonCss,
+			)}
 		>
-			Fork outdated
-			<span role="tooltip">{FORK_OUTDATED_COPY_TOOLTIP}</span>
+			{input.label}
+			<span role="tooltip">{input.tooltip}</span>
 		</button>
 	)
 }
 
-/*
- * CSS hover/focus tooltip (same grammar as onboarding Copy prompt): a
- * top-layer popover would steal pointer events from neighboring pills.
- * `pointer-events: none` keeps the tip from becoming a hover target.
- * `z-index` lifts the control above a listing card's stretched name-link
- * overlay so the click hits the button instead of the card.
+/**
+ * Yellow pill that stands in for Installed/Forked when a community listing
+ * has been republished ahead of this fork.
  */
-const forkOutdatedCopyButtonCss = {
-	position: 'relative' as const,
-	zIndex: 1,
-	flex: 'none',
-	appearance: 'none' as const,
-	margin: 0,
-	border: 'none',
-	fontFamily: 'inherit',
-	fontSize: '0.78rem',
-	fontWeight: 650,
-	lineHeight: 1.2,
-	color: 'oklch(0.48 0.12 85)',
-	backgroundColor: 'oklch(0.88 0.12 95 / 0.92)',
-	borderRadius: '999px',
-	padding: '0.15rem 0.6rem',
-	whiteSpace: 'nowrap' as const,
-	cursor: 'pointer',
-	[hoverMq]: {
-		'&:hover': {
-			backgroundColor: 'oklch(0.84 0.13 95)',
-		},
-	},
-	'&:focus-visible': {
-		outline: `2px solid oklch(0.7 0.14 90)`,
-		outlineOffset: '2px',
-	},
+export function ForkOutdatedCopyButton(
+	handle: Handle<ForkOutdatedCopyButtonProps>,
+) {
+	return () =>
+		renderCopyPromptPill({
+			label: 'Fork outdated',
+			prompt: handle.props.prompt,
+			testId: handle.props.testId,
+			tooltip: FORK_OUTDATED_COPY_TOOLTIP,
+			tone: 'outdated',
+		})
+}
+
+const copyPromptTooltipCss = {
 	'& [role="tooltip"]': {
 		position: 'absolute' as const,
 		left: '50%',
@@ -112,5 +115,60 @@ const forkOutdatedCopyButtonCss = {
 	'&:focus-visible [role="tooltip"]': {
 		opacity: 1,
 		visibility: 'visible' as const,
+	},
+}
+
+const copyPromptButtonBaseCss = {
+	position: 'relative' as const,
+	zIndex: 1,
+	flex: 'none',
+	appearance: 'none' as const,
+	margin: 0,
+	border: 'none',
+	fontFamily: 'inherit',
+	fontSize: '0.78rem',
+	fontWeight: 650,
+	lineHeight: 1.2,
+	borderRadius: '999px',
+	padding: '0.15rem 0.6rem',
+	whiteSpace: 'nowrap' as const,
+	cursor: 'pointer',
+	...copyPromptTooltipCss,
+}
+
+/*
+ * CSS hover/focus tooltip (same grammar as onboarding Copy prompt): a
+ * top-layer popover would steal pointer events from neighboring pills.
+ * `pointer-events: none` keeps the tip from becoming a hover target.
+ * `z-index` lifts the control above a listing card's stretched name-link
+ * overlay so the click hits the button instead of the card.
+ */
+const forkOutdatedCopyButtonCss = {
+	...copyPromptButtonBaseCss,
+	color: 'oklch(0.48 0.12 85)',
+	backgroundColor: 'oklch(0.88 0.12 95 / 0.92)',
+	[hoverMq]: {
+		'&:hover': {
+			backgroundColor: 'oklch(0.84 0.13 95)',
+		},
+	},
+	'&:focus-visible': {
+		outline: `2px solid oklch(0.7 0.14 90)`,
+		outlineOffset: '2px',
+	},
+}
+
+const badgeCopyPromptButtonCss = {
+	...copyPromptButtonBaseCss,
+	color: colors.primaryText,
+	backgroundColor: `oklch(from ${colors.primary} l c h / 0.13)`,
+	[hoverMq]: {
+		'&:hover': {
+			backgroundColor: `oklch(from ${colors.primary} l c h / 0.2)`,
+		},
+	},
+	'&:focus-visible': {
+		outline: `2px solid ${colors.primary}`,
+		outlineOffset: '2px',
 	},
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Make the community package page lead with the README and keep install/adapt actions as compact pills next to Trusted, instead of two full-page sections.

## Why

The listing page spent most of its first screen on "One-click install" and "Fork with your agent" before anyone could read the package. Install, already-installed, and "fallen behind" already exist as pills on listing cards; the detail header should use that same grammar.

## Summary

- README is the first body section after the listing header.
- Removed the dedicated one-click install and fork-prompt sections.
- Detail header always shows an **Install** / **Installed** / **Forked** / **Fork outdated** pill next to Trusted (and Featured when present).
- Logged-out Install is a login link. Trusted Install posts immediately; untrusted still shows the compact confirm under the header.
- Installed and Forked pills copy an adapt prompt (`package_get` + README + Intent). Fork outdated stays the yellow copy pill.
- Listing cards still only show install-state pills (no Install on cards).
- Profile fork icon now links to the listing URL (the old `#fork-title` target is gone).
- Install clicks ignore the frame pill while submitting, confirming, or after a successful install, and use the in-memory trust flag so a 409 cannot skip the untrusted warning.

## Testing

- Local `npm run validate` / pre-push (node-unit 2034, workers-unit, e2e 7).
- Added / updated node tests for the detail Install pill, Installed copy pill, copy-prompt hydrator, profile link, SSR (README first; no install/fork sections), and Install click decisions.
- Preview UI pass after deploy. Preview catalogs start empty, so the listing-page pills were verified via SSR/node tests plus the preview community index.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `70c01cbd` · **Head:** `29aad8ae`

**Classification:** composes — no primitives added or changed; this PR rewires community detail UI around the existing install API and copy-prompt hydrator.

### Primitives touched

| Primitive | Group | Impact |
| ------------ | -------- | --------------------------------------- |
| `app-ui` | surfaces | composes — Trusted-adjacent install/copy pills, README first, generalized copy-prompt hydrator, install-click guard |
| `community-listings` | assistant | composes — detail shell drops install/fork sections; install POST and untrusted ack are unchanged |

### Change flow

The listing header frame renders the install-state pill; the client shell handles Install clicks and reloads the frame after a successful POST.

```mermaid
sequenceDiagram
	actor User
	participant appUi as app-ui
	participant communityListings as community-listings
	User->>appUi: open /@owner/kody-id
	appUi->>communityListings: community-detail frame (Trusted + install pill)
	Note over appUi: README is the first body section
	alt not installed
		User->>appUi: click Install
		appUi->>appUi: ignore if submitting, confirming, or already installed
		appUi->>communityListings: POST community install (ack if untrusted)
		communityListings-->>appUi: installed or adaptation_required
		appUi->>communityListings: reload frame to Installed or Forked
	else already installed
		User->>appUi: click Installed or Forked or Fork outdated
		Note over appUi: copy adapt / finish-adapt / update prompt
	end
```

### Before / after

| Before | After |
| --- | --- |
| One-click install + fork-prompt sections above README | README first; Install/Installed/Forked/Fork outdated pill next to Trusted |
| Visible fork prompt box + Copy prompt | Installed-state pills copy the prompt from a tooltip |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d2e9331f-8e81-48a9-8bb2-55b7442a5065?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d2e9331f-8e81-48a9-8bb2-55b7442a5065&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Community package pages now use compact status pills for **Install**, **Installed**, **Forked**, and **Fork outdated** states.
  - Signed-in visitors can install trusted packages directly; other installations request confirmation.
  - Signed-out visitors can sign in through the Install pill.
  - Install progress, completion announcements, and automatic page refreshes improve installation feedback.
  - Status pills can copy prompts for adapting installed or forked packages.

- **Improvements**
  - Community detail pages now open directly with the README and remove legacy setup prompts.
  - Profile package links now navigate directly to listing pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->