### PR TITLE
Move the listing star next to the package name

### DIFF
--- a/docs/use/community-packages.md
+++ b/docs/use/community-packages.md
@@ -99,9 +99,10 @@ image (1200×630). When the owner keeps a
 shows a follow control next to the username. Private owners show as `@username`
 with a lock that explains the profile is private.
 
-The detail page opens with the README. Next to **Trusted** (and **Featured**,
-when present) a pill says **Install**, **Installed**, **Forked**, or **Fork
-outdated**. You can also ask your agent to use `community_search` or
+The detail page opens with the README. A star control sits next to the package
+name — filled when you have starred the listing. Next to **Trusted** (and
+**Featured**, when present) a pill says **Install**, **Installed**, **Forked**,
+or **Fork outdated**. You can also ask your agent to use `community_search` or
 `community_get` from the `community` domain.
 
 ## Forking a listing
@@ -231,9 +232,10 @@ capability.
 ## Stars (stargazers)
 
 Anyone signed in can **star** a listing as a public bookmark (`community_star` /
-`community_unstar`). Star counts appear on search and detail outputs; stargazer
-lists include only users with public profiles. Stars are separate from the 1–5
-**ratings** below — see
+`community_unstar`). The listing page puts that control next to the package
+name. Star counts appear on search cards and in the detail meta row. Stargazer
+lists from `community_get` include only users with public profiles. Stars are
+separate from the 1–5 **ratings** below — see
 [Community profiles](./community-profiles.md#stars-vs-ratings).
 
 ## Ratings

--- a/docs/use/community-profiles.md
+++ b/docs/use/community-profiles.md
@@ -27,9 +27,8 @@ avatar, join date, follower and following counts, the user's **public packages**
 Upload or remove an avatar from **Account → Profile** in the web UI (MCP does
 not accept avatar uploads). Accepted formats are PNG, JPEG, and WebP, up to 1
 MB, with each side between 64px and 4096px and an aspect ratio of at most 3:1.
-Avatars appear on the public profile, in timeline and profile activity rows, and
-next to public stargazers on listing pages. Private profiles still keep the
-avatar for the owner; other users do not see it.
+Avatars appear on the public profile and in timeline and profile activity rows.
+Private profiles still keep the avatar for the owner; other users do not see it.
 
 Package privacy follows `package.json#private` (projected onto
 `saved_packages.is_private`):

--- a/packages/worker/client/routes/community-detail.tsx
+++ b/packages/worker/client/routes/community-detail.tsx
@@ -35,15 +35,9 @@ import {
 } from '#universal/styles/style-primitives.ts'
 import {
 	type PublicCommunityListing,
-	type PublicCommunityStargazer,
 	type ViewerListingInstall,
 } from '#universal/community-public-types.ts'
-import {
-	type AppLoaderData,
-	type CommunityStargazersLoaderData,
-} from '#universal/loader-data.ts'
-import { formatCommunityPublishedDate } from '#universal/community-display.ts'
-import { UserAvatar } from '#universal/user-avatar.tsx'
+import { type AppLoaderData } from '#universal/loader-data.ts'
 
 /**
  * Community detail, ported from the redesign prototype
@@ -51,9 +45,9 @@ import { UserAvatar } from '#universal/user-avatar.tsx'
  * post: the listing head (back link, icon + name + author + badges, tags,
  * quiet meta row) stays server-rendered in the `community-detail` frame —
  * see `src/app/community-detail-content.tsx` — while this shell renders the
- * interactive sections around it: the README as `.prose`, stars, admin
- * tools, and the report disclosure. Install / Installed / Fork outdated
- * live in the frame next to Trusted.
+ * interactive sections around it: the README as `.prose`, admin tools, and
+ * the report disclosure. Install / Installed / Fork outdated live in the
+ * frame next to Trusted. The title star lives there too.
  */
 
 type CommunityDetailApiPayload = {
@@ -273,14 +267,9 @@ export function CommunityDetailRoute(handle: Handle) {
 	// way.
 	let shellLoadedForPathname: string | null = null
 	let shellRequestedForPathname: string | null = null
-	let starCount = 0
 	let starredByViewer = false
 	let starState: 'idle' | 'submitting' | 'error' = 'idle'
 	let starMessage: string | null = null
-	let stargazers: Array<PublicCommunityStargazer> = []
-	let stargazersTotal = 0
-	let stargazersStatus: 'idle' | 'loading' | 'ready' | 'error' = 'idle'
-	let stargazersLoadedForListingId: string | null = null
 
 	// Re-lexing markdown on every handle.update() would be wasted work; cache
 	// the rendered README per markdown string (same policy as MarkdownView).
@@ -347,7 +336,6 @@ export function CommunityDetailRoute(handle: Handle) {
 			installMessage = null
 			installOutcome = null
 			readmeContent = payload.listing.readmeContent
-			starCount = payload.listing.starCount
 			starredByViewer = payload.starredByViewer
 			starState = 'idle'
 			starMessage = null
@@ -356,36 +344,12 @@ export function CommunityDetailRoute(handle: Handle) {
 			shellLoadedForPathname = ref.pathname
 			shellStatus = 'ready'
 			handle.update()
-			void loadStargazers(payload.listing.id)
 		} catch {
 			if (requestId !== shellLoadRequestId) return
 			// Mark the listing as attempted so renders do not requeue the load
 			// in a loop; the user can recover via navigation or reload.
 			shellLoadedForPathname = ref.pathname
 			shellStatus = 'error'
-			handle.update()
-		}
-	}
-
-	async function loadStargazers(listingId: string) {
-		stargazersStatus = 'loading'
-		handle.update()
-		try {
-			const response = await fetch(
-				routes.communityStargazersApi.href({ listingId }),
-				{ headers: { Accept: 'application/json' } },
-			)
-			const payload = await readJson<CommunityStargazersLoaderData>(response)
-			if (!response.ok || !payload?.ok) {
-				throw new Error('Unable to load stargazers.')
-			}
-			stargazers = payload.stargazers
-			stargazersTotal = payload.totalStars
-			stargazersLoadedForListingId = listingId
-			stargazersStatus = 'ready'
-			handle.update()
-		} catch {
-			stargazersStatus = 'error'
 			handle.update()
 		}
 	}
@@ -425,10 +389,8 @@ export function CommunityDetailRoute(handle: Handle) {
 				throw new Error(payload?.error ?? 'Unable to update star status.')
 			}
 			starredByViewer = payload.starred ?? nextStarred
-			starCount = payload.starCount ?? starCount
 			starState = 'idle'
 			handle.update()
-			void loadStargazers(listingId)
 			const frame = handle.frames.get(COMMUNITY_DETAIL_TARGET)
 			if (frame) void frame.reload()
 		} catch (error) {
@@ -673,6 +635,16 @@ export function CommunityDetailRoute(handle: Handle) {
 		}
 	}
 
+	function handleCommunityStarClick(event: Event) {
+		const target = event.target
+		if (!(target instanceof Element)) return
+		const control = target.closest('[data-community-star]')
+		if (!control || control instanceof HTMLAnchorElement) return
+		event.preventDefault()
+		if (starState === 'submitting') return
+		void submitStar(!starredByViewer)
+	}
+
 	listenToRouterNavigation(handle, () => {
 		if (!getListingPageRef(readRouterPathname(handle))) return
 
@@ -706,7 +678,6 @@ export function CommunityDetailRoute(handle: Handle) {
 		installMessage = null
 		installOutcome = null
 		readmeContent = routeData.readmeContent
-		starCount = routeData.starCount
 		starredByViewer = routeData.starredByViewer
 		starState = 'idle'
 		starMessage = null
@@ -714,14 +685,6 @@ export function CommunityDetailRoute(handle: Handle) {
 		reportMessage = null
 		shellLoadedForPathname = pathname
 		shellStatus = 'ready'
-		if (stargazersLoadedForListingId !== listingId) {
-			// This runs during render, and `loadStargazers` calls
-			// `handle.update()` before its first await. The runtime only wires
-			// up a component's update scheduler after its first render
-			// returns, so calling it inline throws instead of scheduling:
-			// https://github.com/remix-run/remix/issues/11642
-			handle.queueTask(() => void loadStargazers(listingId))
-		}
 		return true
 	}
 
@@ -802,7 +765,10 @@ export function CommunityDetailRoute(handle: Handle) {
 			<article
 				mix={[
 					css(detailArticleCss),
-					on('click', (event) => handleCommunityInstallClick(event)),
+					on('click', (event) => {
+						handleCommunityInstallClick(event)
+						handleCommunityStarClick(event)
+					}),
 				]}
 			>
 				<Frame name={COMMUNITY_DETAIL_TARGET} src={frameSrc} />
@@ -885,6 +851,11 @@ export function CommunityDetailRoute(handle: Handle) {
 									{installMessage}
 								</p>
 							) : null}
+							{starMessage ? (
+								<p mix={css(errorTextCss)} role="alert">
+									{starMessage}
+								</p>
+							) : null}
 						</div>
 
 						{readmeContent ? (
@@ -898,99 +869,6 @@ export function CommunityDetailRoute(handle: Handle) {
 								</div>
 							</section>
 						) : null}
-
-						<section
-							aria-labelledby="stars-title"
-							mix={css(detailSectionCss)}
-							data-testid="community-star"
-						>
-							<h2 id="stars-title">Stars</h2>
-							<p data-testid="community-star-count">
-								{starCount} {starCount === 1 ? 'star' : 'stars'}
-							</p>
-							{loggedIn ? (
-								<div mix={css(sectionActionCss)}>
-									<button
-										type="button"
-										disabled={starState === 'submitting'}
-										mix={[
-											on('click', () => void submitStar(!starredByViewer)),
-											css(
-												starredByViewer ? smallGhostButtonCss : pillButtonCss,
-											),
-										]}
-									>
-										{starState === 'submitting'
-											? 'Saving…'
-											: starredByViewer
-												? 'Unstar'
-												: 'Star'}
-									</button>
-								</div>
-							) : (
-								<p>
-									<a href="/login" mix={css(inlineLinkCss)}>
-										Log in
-									</a>{' '}
-									to star this package.
-								</p>
-							)}
-							{starMessage ? (
-								<p mix={css(errorTextCss)} role="alert">
-									{starMessage}
-								</p>
-							) : null}
-							{/*
-							 * Only once the fetch resolved. `stargazersTotal` starts
-							 * at 0, so rendering it unconditionally put a second,
-							 * contradictory number next to the shell's own
-							 * `starCount` ("5 stars" above "0 stargazers") for the
-							 * length of the request — and left it there for good if
-							 * the request failed.
-							 */}
-							{stargazersStatus === 'ready' ? (
-								<p data-testid="community-stargazers-total">
-									{stargazersTotal}{' '}
-									{stargazersTotal === 1 ? 'stargazer' : 'stargazers'}
-								</p>
-							) : null}
-							{stargazersStatus === 'loading' ? (
-								<p>Loading stargazers…</p>
-							) : null}
-							{stargazersStatus === 'error' ? (
-								<p>Unable to load the stargazer list.</p>
-							) : null}
-							{stargazersStatus === 'ready' && stargazers.length > 0 ? (
-								<ul
-									mix={css(stargazerListCss)}
-									data-testid="community-stargazers"
-								>
-									{stargazers.map((stargazer) => (
-										<li key={stargazer.username}>
-											<UserAvatar
-												displayName={stargazer.displayName}
-												avatarUrl={stargazer.avatarUrl}
-												size={32}
-											/>
-											<span>
-												<a
-													href={routes.profile.href({
-														username: stargazer.username,
-													})}
-													mix={css(stargazerLinkCss)}
-												>
-													{stargazer.displayName}
-												</a>{' '}
-												<span mix={css({ color: colors.textMuted })}>
-													starred{' '}
-													{formatCommunityPublishedDate(stargazer.starredAt)}
-												</span>
-											</span>
-										</li>
-									))}
-								</ul>
-							) : null}
-						</section>
 
 						{viewerIsAdmin ? (
 							<section
@@ -1229,8 +1107,6 @@ const installProgressCss = {
 	fontSize: '0.95rem',
 }
 
-const pillButtonCss = getPillButtonCss()
-
 /* The prototype's smaller `.account-form .button` sizing. */
 const smallGhostButtonCss = mergeCss(getGhostButtonCss(), {
 	fontSize: '0.95rem',
@@ -1307,30 +1183,6 @@ const readmeProseCss = mergeCss(proseCss, {
 		letterSpacing: '-0.01em',
 	},
 })
-
-const stargazerListCss = {
-	listStyle: 'none',
-	margin: '1.1rem 0 0',
-	padding: 0,
-	display: 'grid',
-	gap: '0.45rem',
-	fontSize: '0.92rem',
-	'& > li': {
-		display: 'flex',
-		alignItems: 'center',
-		gap: '0.5rem',
-	},
-}
-
-const stargazerLinkCss = {
-	color: colors.text,
-	fontWeight: 550,
-	textDecoration: 'none',
-	transition: `color ${transitions.fast}`,
-	'&:hover': {
-		color: colors.primaryText,
-	},
-}
 
 /* "Report this listing" tucked in a details disclosure. */
 const reportDisclosureCss = {

--- a/packages/worker/src/app/community-detail-content.node.test.ts
+++ b/packages/worker/src/app/community-detail-content.node.test.ts
@@ -41,6 +41,7 @@ test('community detail head replaces Installed with Fork outdated when the listi
 		},
 		ownerProfilePublic: true,
 		loggedIn: true,
+		starredByViewer: false,
 		viewerFollowsOwner: false,
 		viewerIsOwner: false,
 		returnTo: '/community',
@@ -61,6 +62,7 @@ test('community detail head shows an Install pill when the viewer has not forked
 		listing: sampleListing,
 		ownerProfilePublic: true,
 		loggedIn: true,
+		starredByViewer: false,
 		viewerFollowsOwner: false,
 		viewerIsOwner: false,
 		returnTo: '/@kentcdodds/github-triage',
@@ -92,6 +94,7 @@ test('community detail Installed pill copies an adapt prompt', async () => {
 		},
 		ownerProfilePublic: true,
 		loggedIn: true,
+		starredByViewer: false,
 		viewerFollowsOwner: false,
 		viewerIsOwner: false,
 		returnTo: '/@kentcdodds/github-triage',
@@ -103,4 +106,59 @@ test('community detail Installed pill copies an adapt prompt', async () => {
 	expect(html).toContain('data-copy-prompt')
 	expect(html).toContain(agentPrompt)
 	expect(html).not.toContain('data-testid="community-detail-install"')
+})
+
+test('community detail title row shows an empty star next to the name', async () => {
+	const html = await renderCommunityDetailContentHtml({
+		listing: sampleListing,
+		ownerProfilePublic: true,
+		loggedIn: true,
+		starredByViewer: false,
+		viewerFollowsOwner: false,
+		viewerIsOwner: false,
+		returnTo: '/@kentcdodds/github-triage',
+		followError: null,
+	})
+
+	expect(html).toContain('data-testid="community-detail-star"')
+	expect(html).toContain('data-community-star')
+	expect(html).toContain('data-starred="false"')
+	expect(html).toContain('title="Star"')
+	expect(html.indexOf('data-testid="community-detail-star"')).toBeGreaterThan(
+		html.indexOf('<h1'),
+	)
+})
+
+test('community detail title star is filled when the viewer already starred', async () => {
+	const html = await renderCommunityDetailContentHtml({
+		listing: sampleListing,
+		ownerProfilePublic: true,
+		loggedIn: true,
+		starredByViewer: true,
+		viewerFollowsOwner: false,
+		viewerIsOwner: false,
+		returnTo: '/@kentcdodds/github-triage',
+		followError: null,
+	})
+
+	expect(html).toContain('data-starred="true"')
+	expect(html).toContain('title="Unstar"')
+	expect(html).toContain('fill="currentColor"')
+})
+
+test('logged-out title star is a login link', async () => {
+	const html = await renderCommunityDetailContentHtml({
+		listing: sampleListing,
+		ownerProfilePublic: true,
+		loggedIn: false,
+		starredByViewer: false,
+		viewerFollowsOwner: false,
+		viewerIsOwner: false,
+		returnTo: '/@kentcdodds/github-triage',
+		followError: null,
+	})
+
+	expect(html).toContain('data-testid="community-detail-star"')
+	expect(html).toContain('/login?redirectTo=%2F%40kentcdodds%2Fgithub-triage')
+	expect(html).not.toContain('data-starred=')
 })

--- a/packages/worker/src/app/community-detail-content.tsx
+++ b/packages/worker/src/app/community-detail-content.tsx
@@ -39,6 +39,7 @@ export type CommunityDetailContentProps = {
 	listing: PublicCommunityListing
 	ownerProfilePublic: boolean
 	loggedIn: boolean
+	starredByViewer: boolean
 	viewerFollowsOwner: boolean
 	viewerIsOwner: boolean
 	returnTo: string
@@ -52,6 +53,7 @@ export function CommunityDetailContent(
 		listing,
 		ownerProfilePublic,
 		loggedIn,
+		starredByViewer,
 		viewerFollowsOwner,
 		viewerIsOwner,
 		returnTo,
@@ -72,7 +74,15 @@ export function CommunityDetailContent(
 			<header data-rise style={{ '--rise': '1' }} mix={css(detailHeadCss)}>
 				<CommunityListingIcon listing={listing} size="detail" />
 				<div mix={css(headTextCss)}>
-					<h1>{renderCommunityListingName(listing.name)}</h1>
+					<div mix={css(titleRowCss)}>
+						<h1>{renderCommunityListingName(listing.name)}</h1>
+						{renderCommunityDetailStarControl({
+							listingName: listing.name,
+							loggedIn,
+							starred: starredByViewer,
+							returnTo,
+						})}
+					</div>
 					<span mix={css(detailBadgeGroupCss)}>
 						{listing.trusted ? (
 							<span
@@ -247,6 +257,66 @@ export async function renderCommunityDetailContentHtml(
 	return renderToString(<CommunityDetailContent {...props} />)
 }
 
+function renderCommunityDetailStarControl(input: {
+	listingName: string
+	loggedIn: boolean
+	starred: boolean
+	returnTo: string
+}) {
+	const label = input.starred
+		? `Unstar ${input.listingName}`
+		: `Star ${input.listingName}`
+	const glyph = renderCommunityStarGlyph(input.starred)
+	if (!input.loggedIn) {
+		const loginHref = routes.login.href(null, {
+			searchParams: { redirectTo: input.returnTo },
+		})
+		return (
+			<a
+				href={loginHref}
+				title="Star"
+				data-testid="community-detail-star"
+				data-community-star=""
+				mix={css(starButtonCss)}
+			>
+				{glyph}
+				<span mix={css(visuallyHiddenCss)}>{label}</span>
+			</a>
+		)
+	}
+	return (
+		<button
+			type="button"
+			title={input.starred ? 'Unstar' : 'Star'}
+			data-testid="community-detail-star"
+			data-community-star=""
+			data-starred={input.starred ? 'true' : 'false'}
+			mix={css(input.starred ? starredButtonCss : starButtonCss)}
+		>
+			{glyph}
+			<span mix={css(visuallyHiddenCss)}>{label}</span>
+		</button>
+	)
+}
+
+function renderCommunityStarGlyph(starred: boolean) {
+	return (
+		<svg
+			viewBox="0 0 16 16"
+			width="1em"
+			height="1em"
+			aria-hidden="true"
+			focusable={false}
+			fill={starred ? 'currentColor' : 'none'}
+			stroke="currentColor"
+			strokeWidth={starred ? 0 : 1.4}
+			strokeLinejoin="round"
+		>
+			<path d="M8 1.7 9.9 6.1l4.7.4-3.6 3.1 1.1 4.6L8 11.8l-4.1 2.4 1.1-4.6-3.6-3.1 4.7-.4z" />
+		</svg>
+	)
+}
+
 /* ---------- styles (prototype: `.pkg-detail` in landing/styles.css) ---------- */
 
 const backLinkCss = {
@@ -282,6 +352,54 @@ const headTextCss = {
 		letterSpacing: '-0.024em',
 		lineHeight: 1.05,
 		overflowWrap: 'anywhere' as const,
+	},
+}
+
+const titleRowCss = {
+	display: 'flex',
+	alignItems: 'center',
+	flexWrap: 'wrap' as const,
+	gap: '0.5rem',
+	minWidth: 0,
+	'& h1': {
+		flex: '0 1 auto',
+		minWidth: 0,
+	},
+}
+
+const starButtonCss = {
+	display: 'inline-flex',
+	alignItems: 'center',
+	justifyContent: 'center',
+	width: '1.85rem',
+	height: '1.85rem',
+	padding: 0,
+	border: `1px solid ${colors.border}`,
+	borderRadius: '999px',
+	backgroundColor: 'transparent',
+	color: colors.textMuted,
+	textDecoration: 'none',
+	cursor: 'pointer',
+	flexShrink: 0,
+	'&:hover': {
+		color: colors.primaryText,
+		borderColor: colors.primaryText,
+	},
+	'&:focus-visible': {
+		outline: `2px solid ${colors.primary}`,
+		outlineOffset: '2px',
+	},
+}
+
+const starredButtonCss = {
+	...starButtonCss,
+	color: colors.primary,
+	borderColor: colors.primary,
+	backgroundColor: `oklch(from ${colors.primary} l c h / 0.13)`,
+	'&:hover': {
+		color: colors.primaryText,
+		borderColor: colors.primaryText,
+		backgroundColor: `oklch(from ${colors.primary} l c h / 0.2)`,
 	},
 }
 

--- a/packages/worker/src/app/frames/community-detail.ts
+++ b/packages/worker/src/app/frames/community-detail.ts
@@ -22,6 +22,7 @@ registerFrame(COMMUNITY_DETAIL_TARGET, {
 			listing: detail.listing,
 			ownerProfilePublic: detail.ownerProfilePublic,
 			loggedIn: detail.loggedIn,
+			starredByViewer: detail.starredByViewer,
 			viewerFollowsOwner: detail.viewerFollowsOwner,
 			viewerIsOwner: detail.viewerIsOwner,
 			returnTo: url.pathname,

--- a/packages/worker/src/app/handlers/community-detail.frame.node.test.ts
+++ b/packages/worker/src/app/handlers/community-detail.frame.node.test.ts
@@ -121,6 +121,8 @@ test('community detail handler returns bare detail frame HTML for target header'
 	expect(publicHtml).not.toContain(
 		'data-testid="community-detail-owner-private"',
 	)
+	expect(publicHtml).toContain('data-testid="community-detail-star"')
+	expect(publicHtml).toContain('title="Star"')
 	expect(publicHtml).toContain('data-testid="community-detail-forks"')
 	expect(publicHtml).toContain('data-testid="community-browse-files"')
 	expect(publicHtml).toContain('href="/@kentcdodds/github-triage/files"')
@@ -178,6 +180,8 @@ test('community detail handler returns bare detail frame HTML for target header'
 	expect(signedInHtml).not.toMatch(
 		/<p[^>]*data-testid="community-detail-owner-line"/,
 	)
+	expect(signedInHtml).toContain('data-testid="community-detail-star"')
+	expect(signedInHtml).toContain('data-starred="false"')
 	expect(signedInHtml).toContain('data-testid="community-detail-owner-follow"')
 	expect(signedInHtml).toContain(
 		'data-testid="community-detail-viewer-install-badge"',

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -1644,8 +1644,10 @@ test('canonical package URL SSR renders the redesigned article', async () => {
 	expect(html).toContain('data-testid="community-detail-trusted-badge"')
 	expect(html).toContain('data-testid="community-readme"')
 	expect(html).toContain('data-testid="community-detail-install"')
+	expect(html).toContain('data-testid="community-detail-star"')
 	expect(html).not.toContain('One-click install')
 	expect(html).not.toContain('Fork with your agent')
+	expect(html).not.toContain('id="stars-title"')
 	const props = readAppRootProps(html)
 	expect(props.loaderData?.communityDetailShell).toMatchObject({
 		ok: true,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Let people star a community package from the title, and stop spending a whole page section on stars and the stargazer list.

## Why

The listing page already shows the star count in the meta row. The dedicated Stars block (count, Star/Unstar pill, stargazer list) was leftover chrome after the README moved to the top.

## Summary

- Compact star icon sits next to the package name in the listing header.
- Outline when not starred; filled green when starred.
- Logged-out visitors get the same icon as a login link.
- Clicking the signed-in icon stars or unstars and reloads the header (count + fill).
- Removed the Stars section and the listing-page stargazer list. MCP `community_get` still returns stargazers.

## Testing

- Local pre-push (node-unit, workers-unit, e2e).
- Node tests for empty / filled / login-link star next to the title, plus frame and SSR assertions that the Stars section is gone.
- Preview catalogs start empty, so listing-page starring is covered by those HTML tests.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `52ca69fa` · **Head:** `c1a4a050`

**Classification:** composes — no primitives added or changed; this PR moves the existing star POST onto a header icon.

### Primitives touched

| Primitive | Group | Impact |
| ------------ | -------- | --------------------------------------- |
| `app-ui` | surfaces | composes — title-adjacent star icon in the community-detail frame |
| `community-listings` | assistant | composes — detail shell drops the Stars section; star POST is unchanged |

### Change flow

The header frame renders the star next to the name; the client shell handles clicks and reloads the frame after a successful POST.

```mermaid
sequenceDiagram
	actor User
	participant appUi as app-ui
	participant communityListings as community-listings
	User->>appUi: open /@owner/kody-id
	appUi->>communityListings: community-detail frame (name + star icon)
	alt logged out
		User->>appUi: click star
		appUi->>appUi: login redirect
	else signed in
		User->>appUi: click star
		appUi->>communityListings: POST community star toggle
		communityListings-->>appUi: starred + starCount
		appUi->>communityListings: reload frame (filled or outline)
	end
```

### Before / after

| Before | After |
| --- | --- |
| Stars section with count, Star/Unstar pill, and stargazer list | Star icon next to the title; count stays in the meta row |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d2e9331f-8e81-48a9-8bb2-55b7442a5065?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d2e9331f-8e81-48a9-8bb2-55b7442a5065&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a star/unstar control beside community package names.
  * Logged-out visitors are prompted to sign in before starring.
  * Star state updates directly within the package detail header.

* **Documentation**
  * Clarified star counts, install-status badges, and star-control placement.
  * Updated avatar visibility guidance for community profiles.

* **Tests**
  * Added coverage for starred, unstarred, and logged-out states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->