### PR TITLE
Keep the homepage code-runs ticker moving when rollups grow

### DIFF
--- a/docs/contributing/architecture/usage-metering.md
+++ b/docs/contributing/architecture/usage-metering.md
@@ -346,9 +346,13 @@ Guarantees and rules:
   through every missed integer. Live leftover ticks in a busy second still step
   +1; leftover catch-up delays stay under that freeze window. Homepage GET
   continues an expired or still pair in memory when the fleet total has grown;
-  it does not write KV. The hourly `usage_aggregation` refresh still persists
-  the next official pair. Live windows with a real delta still hold until
-  `windowEnd`.
+  it does not write KV. The D1 `SUM(event_count)` for `metric = 'execute'` is
+  coerced with `Number()` the same way other rollup readers do — a
+  `typeof === 'number'` check treated D1 numeric strings as zero and froze the
+  ticker on a still pair. A tab that cannot paint a next tick refetches
+  `/code-runs.json` (cache bypass) instead of stopping for the rest of the
+  session. The hourly `usage_aggregation` refresh still persists the next
+  official pair. Live windows with a real delta still hold until `windowEnd`.
 - **Fleet visibility** (`/admin/insights`, loader in
   `packages/worker/src/admin/fleet-usage-insights.ts`): bounded SQL over
   `usage_rollups` for the current UTC month — top-10 combined runtime duration

--- a/packages/worker/client/code-runs-ticker.tsx
+++ b/packages/worker/client/code-runs-ticker.tsx
@@ -1,5 +1,9 @@
 import { type Handle } from 'remix/ui'
 import {
+	codeRunsStillWindowRefreshMs,
+	fetchCodeRunsPayload,
+} from '#client/routes/code-runs-payload.ts'
+import {
 	codeRunsCatchUpDelayMs,
 	codeRunsCatchUpSnapAfterMs,
 	codeRunsProgressToNext,
@@ -7,6 +11,7 @@ import {
 	interpolateCodeRunsCount,
 	msUntilNextCodeRunsPaint,
 	nextDisplayedCodeRunsCount,
+	publicCodeRunsWindowsEqual,
 	type PublicCodeRunsWindow,
 } from '#universal/code-runs.ts'
 
@@ -17,14 +22,17 @@ import {
  * longest the official integer may sit when budget allows; thinner windows
  * move the progress underline instead of inventing +1s. A frozen tab (rAF
  * gap, hidden, or a late timeout) snaps to the official count instead of
- * rolling through every missed integer. Mono digits plus a reserved width
- * from `current` keep the label from shifting as digits change.
+ * rolling through every missed integer. A still or ended window refetches
+ * `/code-runs.json` instead of stopping for the rest of the tab. Mono
+ * digits plus a reserved width from `current` keep the label from shifting
+ * as digits change.
  */
 export function CodeRunsTicker(
 	handle: Handle<{ window: PublicCodeRunsWindow }>,
 ) {
-	let displayed = interpolateCodeRunsCount(handle.props.window, Date.now())
-	let progress = codeRunsProgressToNext(handle.props.window, Date.now())
+	let activeWindow = handle.props.window
+	let displayed = interpolateCodeRunsCount(activeWindow, Date.now())
+	let progress = codeRunsProgressToNext(activeWindow, Date.now())
 	let lastDisplayAt = Date.now()
 	const prefersReducedMotion =
 		typeof matchMedia === 'function' &&
@@ -36,7 +44,21 @@ export function CodeRunsTicker(
 		let lastFrameAt = performance.now()
 
 		function officialAt(now: number) {
-			return interpolateCodeRunsCount(handle.props.window, now)
+			return interpolateCodeRunsCount(activeWindow, now)
+		}
+
+		function progressAt(now: number) {
+			return codeRunsProgressToNext(activeWindow, now)
+		}
+
+		async function refreshStuckWindow() {
+			const payload = await fetchCodeRunsPayload(handle.signal, {
+				cache: 'no-store',
+			})
+			if (handle.signal.aborted) return
+			const next = payload?.window
+			if (!next || publicCodeRunsWindowsEqual(next, activeWindow)) return
+			activeWindow = next
 		}
 
 		function clearTimer() {
@@ -54,11 +76,7 @@ export function CodeRunsTicker(
 		}
 
 		function snapToOfficial(now = Date.now()) {
-			show(
-				officialAt(now),
-				codeRunsProgressToNext(handle.props.window, now),
-				now,
-			)
+			show(officialAt(now), progressAt(now), now)
 		}
 
 		function scheduleNext() {
@@ -74,7 +92,7 @@ export function CodeRunsTicker(
 					official,
 					elapsedMsSinceDisplay: now - lastDisplayAt,
 				})
-				show(next, codeRunsProgressToNext(handle.props.window, now), now)
+				show(next, progressAt(now), now)
 				if (next < official) {
 					timeoutId = setTimeout(() => {
 						scheduleNext()
@@ -83,13 +101,17 @@ export function CodeRunsTicker(
 				}
 			}
 			const nowAfter = Date.now()
-			show(
-				officialAt(nowAfter),
-				codeRunsProgressToNext(handle.props.window, nowAfter),
-				nowAfter,
-			)
-			const delay = msUntilNextCodeRunsPaint(handle.props.window, nowAfter)
-			if (delay === null) return
+			show(officialAt(nowAfter), progressAt(nowAfter), nowAfter)
+			const delay = msUntilNextCodeRunsPaint(activeWindow, nowAfter)
+			if (delay === null) {
+				timeoutId = setTimeout(() => {
+					void refreshStuckWindow().finally(() => {
+						if (handle.signal.aborted) return
+						scheduleNext()
+					})
+				}, codeRunsStillWindowRefreshMs)
+				return
+			}
 			timeoutId = setTimeout(
 				() => {
 					scheduleNext()
@@ -146,7 +168,7 @@ export function CodeRunsTicker(
 	}
 
 	return () => {
-		const reserved = formatCodeRunsCount(handle.props.window.current)
+		const reserved = formatCodeRunsCount(activeWindow.current)
 		return (
 			<p data-rise style={{ '--rise': '1.5' }} class="landing-hero-runs">
 				<span class="landing-hero-runs-line">

--- a/packages/worker/client/routes/code-runs-payload.ts
+++ b/packages/worker/client/routes/code-runs-payload.ts
@@ -5,11 +5,18 @@ import { readJson } from '#client/routes/account-approval-shared.ts'
 
 export const codeRunsApiPath = routes.codeRunsApi.href()
 
-export async function fetchCodeRunsPayload(signal?: AbortSignal) {
+/** How long a stuck ticker waits before asking origin for a newer window. */
+export const codeRunsStillWindowRefreshMs = 60_000
+
+export async function fetchCodeRunsPayload(
+	signal?: AbortSignal,
+	init?: { cache?: RequestCache },
+) {
 	try {
 		const response = await fetch(codeRunsApiPath, {
 			headers: { Accept: 'application/json' },
 			signal,
+			cache: init?.cache,
 		})
 		const payload = await readJson<CodeRunsLoaderData>(response)
 		if (!response.ok || payload?.ok !== true) return null

--- a/packages/worker/src/usage/code-runs-window.node.test.ts
+++ b/packages/worker/src/usage/code-runs-window.node.test.ts
@@ -49,6 +49,25 @@ async function createEnv(input?: {
 	return { APP_DB: db, BUNDLE_ARTIFACTS_KV: kv }
 }
 
+function withCoercedExecuteSum(
+	env: { APP_DB: D1Database },
+	coerce: (total: unknown) => unknown,
+) {
+	const prepare = env.APP_DB.prepare.bind(env.APP_DB)
+	env.APP_DB.prepare = ((sql: string) => {
+		const statement = prepare(sql)
+		if (!sql.includes('SUM(event_count)')) return statement
+		const first = statement.first.bind(statement)
+		return Object.assign(statement, {
+			async first() {
+				const row = await first<{ total?: unknown }>()
+				if (row == null || row.total == null) return row
+				return { total: coerce(row.total) }
+			},
+		})
+	}) as D1Database['prepare']
+}
+
 test('refreshPublicCodeRunsWindow initializes a still pair, unsticks when the fleet grows, and holds a live window for 24h', async () => {
 	const env = await createEnv({
 		rows: [
@@ -209,4 +228,49 @@ test('public code-runs load continues an expired window without writing KV', asy
 			windowEnd: '2026-08-22T00:00:00.000Z',
 		}),
 	)
+})
+
+test('public code-runs load continues a still pair from a D1 SUM number, string, or bigint without writing KV', async () => {
+	const stored = {
+		previous: 257940,
+		current: 257940,
+		windowStart: '2026-08-24T17:00:18.000Z',
+		windowEnd: '2026-08-25T17:00:18.000Z',
+	}
+	const now = new Date('2026-08-24T19:26:00.000Z')
+	const continued = {
+		previous: 257940,
+		current: 257941,
+		windowStart: '2026-08-24T19:26:00.000Z',
+		windowEnd: '2026-08-25T19:26:00.000Z',
+	}
+
+	const numeric = await createEnv({
+		rows: [{ userId: 'a', month: '2026-08', eventCount: 257941 }],
+		window: stored,
+	})
+	expect(await loadPublicCodeRunsWindow(numeric, now)).toEqual(continued)
+	expect(numeric.BUNDLE_ARTIFACTS_KV.store.get(publicCodeRunsKvKey)).toBe(
+		JSON.stringify(stored),
+	)
+
+	const stringSum = await createEnv({
+		rows: [{ userId: 'a', month: '2026-08', eventCount: 257941 }],
+		window: stored,
+	})
+	withCoercedExecuteSum(stringSum, String)
+	expect(await loadPublicCodeRunsWindow(stringSum, now)).toEqual(continued)
+	await expect(
+		refreshPublicCodeRunsWindow({ env: stringSum, now }),
+	).resolves.toEqual({ status: 'rotated' })
+	expect(stringSum.BUNDLE_ARTIFACTS_KV.store.get(publicCodeRunsKvKey)).toBe(
+		JSON.stringify(continued),
+	)
+
+	const bigintSum = await createEnv({
+		rows: [{ userId: 'a', month: '2026-08', eventCount: 257941 }],
+		window: stored,
+	})
+	withCoercedExecuteSum(bigintSum, (total) => BigInt(Number(total)))
+	expect(await loadPublicCodeRunsWindow(bigintSum, now)).toEqual(continued)
 })

--- a/packages/worker/src/usage/code-runs-window.ts
+++ b/packages/worker/src/usage/code-runs-window.ts
@@ -137,14 +137,26 @@ async function sumExecuteEventCount(
 			`SELECT COALESCE(SUM(event_count), 0) AS total
 			 FROM usage_rollups
 			 WHERE metric = 'execute'`,
-		).first<{ total: number }>()
-		const total = row?.total
-		if (typeof total !== 'number' || !Number.isFinite(total) || total < 0) {
-			return 0
-		}
-		return Math.floor(total)
+		).first<{ total: unknown }>()
+		return toNonNegativeCount(row?.total)
 	} catch (error) {
 		console.debug('public-code-runs-sum-failed', error)
 		return null
 	}
+}
+
+/**
+ * D1 `SUM` / `COALESCE` can arrive as a number, numeric string, or bigint.
+ * Treating anything but `typeof === 'number'` as zero froze the homepage
+ * ticker on a still pair even while execute rollups existed.
+ */
+function toNonNegativeCount(value: unknown): number {
+	if (typeof value === 'bigint') {
+		if (value < 0n) return 0
+		const parsed = Number(value)
+		return Number.isFinite(parsed) ? Math.floor(parsed) : 0
+	}
+	const parsed = Number(value)
+	if (!Number.isFinite(parsed) || parsed < 0) return 0
+	return Math.floor(parsed)
 }

--- a/packages/worker/universal/code-runs.node.test.ts
+++ b/packages/worker/universal/code-runs.node.test.ts
@@ -12,6 +12,7 @@ import {
 	msUntilNextCodeRunsPaint,
 	nextDisplayedCodeRunsCount,
 	parsePublicCodeRunsWindow,
+	publicCodeRunsWindowsEqual,
 } from './code-runs.ts'
 
 const windowStart = '2026-08-21T00:00:00.000Z'
@@ -296,6 +297,10 @@ test('continuePublicCodeRunsWindow unsticks still and expired pairs without writ
 		windowStart: '2026-08-21T00:00:00.000Z',
 		windowEnd: '2026-08-22T00:00:00.000Z',
 	}
+	expect(publicCodeRunsWindowsEqual(still, still)).toBe(true)
+	expect(publicCodeRunsWindowsEqual(still, { ...still, current: 101 })).toBe(
+		false,
+	)
 	expect(
 		continuePublicCodeRunsWindow({ stored: still, total: 100, now }),
 	).toBeNull()

--- a/packages/worker/universal/code-runs.ts
+++ b/packages/worker/universal/code-runs.ts
@@ -12,6 +12,8 @@
  * integer backbone, the client moves honest progress toward the next tick
  * instead of inventing +1s. Homepage GET may continue an expired or still
  * pair in memory when the fleet total has grown; it does not write KV.
+ * A client that cannot paint a next tick refetches `/code-runs.json`
+ * instead of giving up for the rest of the tab.
  */
 
 export const publicCodeRunsWindowMs = 24 * 60 * 60 * 1000
@@ -26,6 +28,18 @@ export type PublicCodeRunsWindow = {
 
 export function isStillPublicCodeRunsWindow(window: PublicCodeRunsWindow) {
 	return window.previous === window.current
+}
+
+export function publicCodeRunsWindowsEqual(
+	left: PublicCodeRunsWindow,
+	right: PublicCodeRunsWindow,
+) {
+	return (
+		left.previous === right.previous &&
+		left.current === right.current &&
+		left.windowStart === right.windowStart &&
+		left.windowEnd === right.windowEnd
+	)
 }
 
 export function parsePublicCodeRunsWindow(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Keep the public homepage code-runs ticker moving whenever fleet `execute` rollups have actually grown — and only freeze when they have not.

## Why

Production `GET /code-runs.json` has been a still pair since 2026-08-24T17:00:18Z:

```json
{"previous":257940,"current":257940,"windowStart":"2026-08-24T17:00:18.000Z","windowEnd":"2026-08-25T17:00:18.000Z"}
```

That is not “no code runs.” Kent’s account alone has hundreds of retained runs after that timestamp. A still pair is only valid when the D1 `execute` SUM has not grown. `sumExecuteEventCount` treated anything but a JS `number` as `0`, which matches D1 returning `SUM` as a numeric string and would freeze both homepage GET continue and the hourly KV refresh.

## Summary

- Coerce the D1 `SUM(event_count)` with `Number()` / bigint, the same way other rollup readers do
- Homepage GET still continues a grown still pair in memory and does not write KV
- A tab that cannot paint a next tick refetches `/code-runs.json` (`cache: 'no-store'`) instead of giving up for the rest of the session
- Do not invent +1s when the fleet total has not grown

## Testing

- `vitest` node-unit: `code-runs-window` (string / bigint SUM + still-pair continue) and `code-runs`
- Pre-push `test:push` passed (node-unit, workers-unit, Playwright)
- Production evidence above; after deploy, `/code-runs.json` should show `current > previous` if D1’s execute SUM is above 257940

## System recap

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `52ca69fa` · **Head:** `0d2e3179`

**Classification:** extends — usage-metering SUM coercion and app-ui ticker refresh change behavior; no new primitives.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `usage-metering` | storage | extends — D1 execute SUM accepts numeric strings and bigint |
| `app-ui` | surfaces | extends — stuck ticker refetches `/code-runs.json` |

### Change flow

Homepage GET and the hourly refresh now treat a D1 numeric-string SUM as a real count so a still pair can unstick; an open tab asks origin again when it cannot paint.

```mermaid
sequenceDiagram
	actor visitor as visitor
	participant appUi as app-ui
	participant usageMetering as usage-metering
	participant d1AppDb as d1-app-db
	visitor->>appUi: GET / or /code-runs.json
	appUi->>usageMetering: loadPublicCodeRunsWindow
	usageMetering->>d1AppDb: SUM(event_count) where metric=execute
	d1AppDb-->>usageMetering: total as number, string, or bigint
	usageMetering-->>appUi: continue still pair when total is greater
	opt tab cannot paint a next tick
		appUi->>appUi: refetch /code-runs.json cache no-store
	end
```

### Before / after

| Path | Before | After |
| --- | --- | --- |
| D1 `SUM` type | non-number → `0` → still pair held | `Number()` / bigint → continue or rotate when total grew |
| Stuck tab | `msUntilNextCodeRunsPaint` is null → stop | refetch every 60s; still no invented +1s |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d2e9331f-8e81-48a9-8bb2-55b7442a5065?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d2e9331f-8e81-48a9-8bb2-55b7442a5065&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

