### PR TITLE
fix(client): stub Navigation API so Remix boots on Safari < 26.2

### DIFF
--- a/packages/worker/client/ensure-navigation-api.node.test.ts
+++ b/packages/worker/client/ensure-navigation-api.node.test.ts
@@ -1,0 +1,59 @@
+import { expect, test } from 'vitest'
+import { ensureNavigationApi } from './ensure-navigation-api.ts'
+
+test('ensureNavigationApi stubs a missing Navigation API so Remix boot can call updateCurrentEntry and leaves a real implementation alone', async () => {
+	const assigns: Array<string> = []
+	const replaces: Array<string> = []
+	const hostWithoutNavigation = {
+		location: {
+			href: 'https://kody.codes/account',
+			assign(url: string | URL) {
+				assigns.push(String(url))
+			},
+			replace(url: string | URL) {
+				replaces.push(String(url))
+			},
+		},
+	}
+
+	ensureNavigationApi(hostWithoutNavigation)
+
+	const navigation = hostWithoutNavigation.navigation
+	expect(typeof navigation?.updateCurrentEntry).toBe('function')
+	expect(() => {
+		navigation?.updateCurrentEntry({
+			state: { target: undefined, src: 'https://kody.codes/account' },
+		})
+	}).not.toThrow()
+	expect(navigation?.currentEntry?.url).toBe('https://kody.codes/account')
+	expect(navigation?.currentEntry?.getState()).toEqual({
+		target: undefined,
+		src: 'https://kody.codes/account',
+	})
+	expect(navigation?.entries()).toHaveLength(1)
+
+	const replaceResult = navigation?.navigate('https://kody.codes/login', {
+		history: 'replace',
+	})
+	expect(replaces).toEqual(['https://kody.codes/login'])
+	expect(assigns).toEqual([])
+	await expect(replaceResult?.finished).resolves.toMatchObject({
+		url: 'https://kody.codes/login',
+	})
+
+	const pushResult = navigation?.navigate('https://kody.codes/pricing')
+	expect(assigns).toEqual(['https://kody.codes/pricing'])
+	await expect(pushResult?.finished).resolves.toMatchObject({
+		url: 'https://kody.codes/pricing',
+	})
+
+	const existingUpdate = () => {
+		throw new Error('should not replace a real Navigation API')
+	}
+	const hostWithNavigation = {
+		navigation: { updateCurrentEntry: existingUpdate },
+		location: hostWithoutNavigation.location,
+	}
+	ensureNavigationApi(hostWithNavigation)
+	expect(hostWithNavigation.navigation.updateCurrentEntry).toBe(existingUpdate)
+})

--- a/packages/worker/client/ensure-navigation-api.ts
+++ b/packages/worker/client/ensure-navigation-api.ts
@@ -1,0 +1,115 @@
+/**
+ * Remix 3 `run()` calls `window.navigation.updateCurrentEntry` during boot.
+ * The Navigation API is missing on Safari < 26.2, every iOS Chrome / Twitter
+ * WKWebView, and Firefox < 147. Kody's client router already owns SPA
+ * navigation via `history.pushState`, so a stub is enough to let hydration
+ * start. This is not a full Navigation API polyfill.
+ */
+export type NavigationApiHost = {
+	navigation?: {
+		updateCurrentEntry?: (options?: { state?: unknown }) => void
+	} | null
+	location?: {
+		href: string
+		assign: (url: string | URL) => void
+		replace: (url: string | URL) => void
+	}
+}
+
+type NavigationHistoryEntryLike = {
+	key: string
+	id: string
+	url: string
+	index: number
+	sameDocument: boolean
+	getState: () => unknown
+}
+
+type NavigationResultLike = {
+	committed: Promise<NavigationHistoryEntryLike>
+	finished: Promise<NavigationHistoryEntryLike>
+}
+
+function createSettledResult(
+	entry: NavigationHistoryEntryLike,
+): NavigationResultLike {
+	const committed = Promise.resolve(entry)
+	return { committed, finished: committed }
+}
+
+function createHistoryEntry(
+	url: string,
+	state: unknown = null,
+): NavigationHistoryEntryLike {
+	return {
+		key: 'kody-navigation-stub',
+		id: 'kody-navigation-stub',
+		url,
+		index: 0,
+		sameDocument: true,
+		getState: () => state,
+	}
+}
+
+export function ensureNavigationApi(
+	host: NavigationApiHost | undefined = typeof window === 'undefined'
+		? undefined
+		: (window as NavigationApiHost),
+): void {
+	if (!host) return
+	if (typeof host.navigation?.updateCurrentEntry === 'function') return
+
+	const locationApi = host.location
+	let currentState: unknown = null
+
+	const readUrl = () => locationApi?.href ?? ''
+
+	const currentEntry = (): NavigationHistoryEntryLike =>
+		createHistoryEntry(readUrl(), currentState)
+
+	const navigate = (
+		url: string | URL,
+		options?: { history?: 'auto' | 'push' | 'replace'; state?: unknown },
+	): NavigationResultLike => {
+		currentState = options?.state ?? null
+		const href = typeof url === 'string' ? url : url.toString()
+		if (options?.history === 'replace') {
+			locationApi?.replace(href)
+		} else {
+			locationApi?.assign(href)
+		}
+		return createSettledResult(createHistoryEntry(href, currentState))
+	}
+
+	const stub = {
+		get currentEntry() {
+			return currentEntry()
+		},
+		addEventListener() {},
+		removeEventListener() {},
+		updateCurrentEntry(options?: { state?: unknown }) {
+			if (options && 'state' in options) {
+				currentState = options.state
+			}
+		},
+		entries() {
+			return [currentEntry()]
+		},
+		navigate,
+	}
+
+	try {
+		Object.defineProperty(host, 'navigation', {
+			configurable: true,
+			enumerable: true,
+			writable: true,
+			value: stub,
+		})
+	} catch {
+		try {
+			host.navigation = stub
+		} catch {
+			// Leave the host unchanged; Remix will still throw if it calls navigation.
+		}
+	}
+}

--- a/packages/worker/client/entry.tsx
+++ b/packages/worker/client/entry.tsx
@@ -11,9 +11,13 @@ import {
 } from '#client/sentry-client.ts'
 import { AppRoot, APP_ROOT_ENTRY_ID } from './app-root.tsx'
 import { ensureCryptoRandomUUID } from './ensure-crypto-random-uuid.ts'
+import { ensureNavigationApi } from './ensure-navigation-api.ts'
 
 // Remix frame ids call crypto.randomUUID(); some in-app browsers omit it.
 ensureCryptoRandomUUID()
+// Remix `run()` calls window.navigation.updateCurrentEntry; Safari < 26.2 and
+// iOS in-app browsers omit the Navigation API entirely.
+ensureNavigationApi()
 initSentryClient(document)
 
 const clientRegistry: Record<string, typeof AppRoot> = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop Kody's Remix 3 client from throwing on boot in browsers that do not implement the Navigation API (KODY-CLOUDFLARE-3W).

## Why

`run()` calls `window.navigation.updateCurrentEntry` before hydration. That API is missing on Safari < 26.2, every iOS Chrome / Twitter WKWebView, and Firefox < 147. Latest production event is 2026-08-24 on `/account` (release `d30791020d44`) — still live after the 2026-08-22 reliability work. ~150 events; sibling KODY-CLOUDFLARE-17 is the same crash on an older chunk.

Kody already owns SPA routing via `history.pushState`. A boot stub is enough; this is not a full Navigation API polyfill.

## Summary

- Install `ensureNavigationApi()` next to the existing `randomUUID` polyfill, before `run()`.
- Stub only the methods Remix boot uses (`updateCurrentEntry`, `currentEntry`, `entries`, `navigate`, event listener no-ops).
- Leave a real `window.navigation` alone.

## Testing

- `npx vitest run packages/worker/client/ensure-navigation-api.node.test.ts` — pass
- `npx tsc -b packages/worker/tsconfig-client.json --noEmit` — pass
- `npm run build:client:web` — pass
- `npm run validate`: format, lint, typecheck, primitives, docs green. Parallel jobs flaked on wrangler/mock startup (email mock, mcp-e2e, e2e webServer, one workers-unit timeout); `cloudflare-email.node.test.ts` passed when re-run alone.

Skip preview: no logged-in UI or data-shape change.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `52ca69fa` · **Head:** `492a60db`

**Classification:** composes — no primitives added or changed; this PR fills a missing browser API so existing Remix boot can hydrate.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `app-ui` | surfaces | composes — boot stub only |

### Change flow

Client boot installs a Navigation API stub when `window.navigation` is missing, then Remix `run()` can call `updateCurrentEntry` without throwing.

```mermaid
sequenceDiagram
	actor Browser
	participant appUi as app-ui
	Browser->>appUi: load client-entry
	appUi->>appUi: ensureNavigationApi() when window.navigation is missing
	appUi->>appUi: run() calls navigation.updateCurrentEntry
	Note over appUi: SPA clicks still go through history.pushState client-router
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1690051a-fbc7-4efb-982f-cdb88aa5e296?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1690051a-fbc7-4efb-982f-cdb88aa5e296&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

