### PR TITLE
Give adjacent community status pills one shared box

### DIFF
--- a/packages/worker/src/app/community-listings-content.node.test.ts
+++ b/packages/worker/src/app/community-listings-content.node.test.ts
@@ -1,6 +1,11 @@
 import { expect, test } from 'vitest'
-import { renderCommunityListingsContentHtml } from '#app/community-listings-content.tsx'
+import {
+	communityBadgePillCss,
+	communityInstallPillCss,
+	renderCommunityListingsContentHtml,
+} from '#app/community-listings-content.tsx'
 import { type PublicCommunityListing } from '#universal/community-public-types.ts'
+import { communityStatusPillBoxCss } from '#universal/community-status-pill.ts'
 
 const sampleListing = {
 	id: 'listing-1',
@@ -177,4 +182,19 @@ test('community listings render sort controls, categories, empty states, and for
 	expect(aheadHtml).not.toContain(
 		'data-testid="community-listing-viewer-install-listing-1"',
 	)
+})
+
+test('Trusted and Install pills share one box so they match when adjacent', () => {
+	for (const key of [
+		'display',
+		'alignItems',
+		'boxSizing',
+		'fontSize',
+		'lineHeight',
+		'padding',
+		'border',
+	] as const) {
+		expect(communityBadgePillCss[key]).toBe(communityStatusPillBoxCss[key])
+		expect(communityInstallPillCss[key]).toBe(communityStatusPillBoxCss[key])
+	}
 })

--- a/packages/worker/src/app/community-listings-content.tsx
+++ b/packages/worker/src/app/community-listings-content.tsx
@@ -23,8 +23,9 @@ import {
 	renderCopyPromptPill,
 } from '#universal/fork-outdated-copy-button.tsx'
 import { routes } from '#universal/routes.ts'
-import { renderCommunityListingName } from '#universal/community-listing-name.tsx'
 import { getCommunityListingHref } from '#universal/community-links.ts'
+import { renderCommunityListingName } from '#universal/community-listing-name.tsx'
+import { communityStatusPillBoxCss } from '#universal/community-status-pill.ts'
 import {
 	buildCommunityIndexHref,
 	defaultCommunityListingSort,
@@ -609,26 +610,17 @@ const listingLinkCss = {
 }
 
 /* The prototype's `.badge-trusted` pill; the detail head reuses it without
-   the card's trailing-edge push. */
+   the card's trailing-edge push. Same box as Install / Installed. */
 export const communityBadgePillCss = {
-	flex: 'none',
-	fontSize: '0.78rem',
-	fontWeight: 650,
+	...communityStatusPillBoxCss,
 	color: colors.primaryText,
 	backgroundColor: `oklch(from ${colors.primary} l c h / 0.13)`,
-	borderRadius: '999px',
-	padding: '0.15rem 0.6rem',
-	whiteSpace: 'nowrap' as const,
 	cursor: 'help',
 }
 
 export const communityInstallPillCss = {
 	...communityBadgePillCss,
 	appearance: 'none' as const,
-	margin: 0,
-	border: 'none',
-	fontFamily: 'inherit',
-	lineHeight: 1.2,
 	textDecoration: 'none',
 	cursor: 'pointer',
 	[hoverMq]: {

--- a/packages/worker/universal/community-status-pill.ts
+++ b/packages/worker/universal/community-status-pill.ts
@@ -1,0 +1,21 @@
+/**
+ * Shared box for Trusted / Featured / Install / Installed / Fork outdated.
+ * Spans inherit a taller line-height than reset buttons, so adjacent pills
+ * mismatch unless every variant uses the same flex box.
+ */
+export const communityStatusPillBoxCss = {
+	display: 'inline-flex' as const,
+	alignItems: 'center' as const,
+	justifyContent: 'center' as const,
+	boxSizing: 'border-box' as const,
+	flex: 'none' as const,
+	margin: 0,
+	fontFamily: 'inherit',
+	fontSize: '0.78rem',
+	fontWeight: 650,
+	lineHeight: 1.2,
+	borderRadius: '999px',
+	padding: '0.15rem 0.6rem',
+	border: '1px solid transparent',
+	whiteSpace: 'nowrap' as const,
+}

--- a/packages/worker/universal/fork-outdated-copy-button.tsx
+++ b/packages/worker/universal/fork-outdated-copy-button.tsx
@@ -8,6 +8,7 @@ import {
 	spacing,
 	typography,
 } from '#universal/styles/tokens.ts'
+import { communityStatusPillBoxCss } from '#universal/community-status-pill.ts'
 import { hoverMq } from '#universal/styles/style-primitives.ts'
 
 export const COPY_PROMPT_ATTRIBUTE = 'data-copy-prompt'
@@ -119,19 +120,10 @@ const copyPromptTooltipCss = {
 }
 
 const copyPromptButtonBaseCss = {
+	...communityStatusPillBoxCss,
 	position: 'relative' as const,
 	zIndex: 1,
-	flex: 'none',
 	appearance: 'none' as const,
-	margin: 0,
-	border: 'none',
-	fontFamily: 'inherit',
-	fontSize: '0.78rem',
-	fontWeight: 650,
-	lineHeight: 1.2,
-	borderRadius: '999px',
-	padding: '0.15rem 0.6rem',
-	whiteSpace: 'nowrap' as const,
 	cursor: 'pointer',
 	...copyPromptTooltipCss,
 }

--- a/packages/worker/universal/fork-outdated-copy-button.tsx
+++ b/packages/worker/universal/fork-outdated-copy-button.tsx
@@ -1,6 +1,8 @@
 /** @jsxImportSource remix/ui */
 /** @jsxRuntime automatic */
 import { type Handle, css } from 'remix/ui'
+import { communityStatusPillBoxCss } from '#universal/community-status-pill.ts'
+import { hoverMq } from '#universal/styles/style-primitives.ts'
 import {
 	colors,
 	radius,
@@ -8,8 +10,6 @@ import {
 	spacing,
 	typography,
 } from '#universal/styles/tokens.ts'
-import { communityStatusPillBoxCss } from '#universal/community-status-pill.ts'
-import { hoverMq } from '#universal/styles/style-primitives.ts'
 
 export const COPY_PROMPT_ATTRIBUTE = 'data-copy-prompt'
 export const COPY_PROMPT_SELECTOR = '[data-copy-prompt]'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Make Trusted, Featured, Install, Installed, and Fork outdated the same size — especially when they sit next to each other on a listing.

## Why

On the package detail head, Trusted is a `<span>` that inherited a taller line-height than the Install `<button>`, which used `line-height: 1.2`. The pair looked like two different pills.

## Summary

- Shared `communityStatusPillBoxCss` (`inline-flex`, same font, line-height, padding, transparent border)
- Trusted / Featured / Install / Installed / Fork outdated all use that box
- Tag chips stay the hairline chip grammar

## Testing

- Node-unit: listings/detail plus a box-metric assertion on Trusted vs Install
- Pre-push `test:push` passed

## System recap

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `82ce41d2` · **Head:** `678b10c3`

**Classification:** composes — one shared box used by existing community status pills; no new primitives.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | composes — shared status-pill box |

### Change flow

Listing and detail heads draw Trusted / Install / copy pills from one box so a span and a button match.

```mermaid
sequenceDiagram
	actor visitor as visitor
	participant appUi as app-ui
	visitor->>appUi: GET listing or package page
	appUi->>appUi: Trusted/Featured span uses communityStatusPillBoxCss
	appUi->>appUi: Install/Installed/Fork outdated use the same box
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d2e9331f-8e81-48a9-8bb2-55b7442a5065?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d2e9331f-8e81-48a9-8bb2-55b7442a5065&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

