### PR TITLE
Reset the homepage ticker when the fleet execute SUM drops

### DIFF
--- a/docs/contributing/architecture/usage-metering.md
+++ b/docs/contributing/architecture/usage-metering.md
@@ -345,14 +345,17 @@ Guarantees and rules:
   hidden, or a late timeout) snaps to the official count instead of rolling
   through every missed integer. Live leftover ticks in a busy second still step
   +1; leftover catch-up delays stay under that freeze window. Homepage GET
-  continues an expired or still pair in memory when the fleet total has grown;
-  it does not write KV. The D1 `SUM(event_count)` for `metric = 'execute'` is
-  coerced with `Number()` the same way other rollup readers do — a
-  `typeof === 'number'` check treated D1 numeric strings as zero and froze the
-  ticker on a still pair. A tab that cannot paint a next tick refetches
-  `/code-runs.json` (cache bypass) instead of stopping for the rest of the
-  session. The hourly `usage_aggregation` refresh still persists the next
-  official pair. Live windows with a real delta still hold until `windowEnd`.
+  continues an expired or still pair in memory when the fleet total has grown,
+  and resets a still or expired pair to a new still window when the fleet total
+  has dropped (an authoritative rollup recompute can land below a latched
+  high-water mark; `max(total, previous)` would freeze the ticker). It does not
+  write KV. The D1 `SUM(event_count)` for `metric = 'execute'` is coerced with
+  `Number()` the same way other rollup readers do — a `typeof === 'number'`
+  check treated D1 numeric strings as zero and froze the ticker on a still pair.
+  A tab that cannot paint a next tick refetches `/code-runs.json` (cache bypass)
+  instead of stopping for the rest of the session. The hourly
+  `usage_aggregation` refresh still persists the next official pair. Live
+  windows with a real delta still hold until `windowEnd`.
 - **Fleet visibility** (`/admin/insights`, loader in
   `packages/worker/src/admin/fleet-usage-insights.ts`): bounded SQL over
   `usage_rollups` for the current UTC month — top-10 combined runtime duration

--- a/packages/worker/src/usage/code-runs-window.node.test.ts
+++ b/packages/worker/src/usage/code-runs-window.node.test.ts
@@ -156,8 +156,8 @@ test('refreshPublicCodeRunsWindow initializes a still pair, unsticks when the fl
 	expect(
 		await loadPublicCodeRunsWindow(env, new Date('2026-08-23T12:01:00.000Z')),
 	).toEqual({
-		previous: 150,
-		current: 150,
+		previous: 50,
+		current: 50,
 		windowStart: '2026-08-23T12:01:00.000Z',
 		windowEnd: '2026-08-24T12:01:00.000Z',
 	})
@@ -273,4 +273,34 @@ test('public code-runs load continues a still pair from a D1 SUM number, string,
 	})
 	withCoercedExecuteSum(bigintSum, (total) => BigInt(Number(total)))
 	expect(await loadPublicCodeRunsWindow(bigintSum, now)).toEqual(continued)
+})
+
+test('public code-runs load and refresh reset a still pair when the fleet SUM drops', async () => {
+	const stored = {
+		previous: 257940,
+		current: 257940,
+		windowStart: '2026-08-24T17:00:18.000Z',
+		windowEnd: '2026-08-25T17:00:18.000Z',
+	}
+	const now = new Date('2026-08-24T20:15:00.000Z')
+	const reset = {
+		previous: 190213,
+		current: 190213,
+		windowStart: '2026-08-24T20:15:00.000Z',
+		windowEnd: '2026-08-25T20:15:00.000Z',
+	}
+	const env = await createEnv({
+		rows: [{ userId: 'a', month: '2026-08', eventCount: 190213 }],
+		window: stored,
+	})
+	expect(await loadPublicCodeRunsWindow(env, now)).toEqual(reset)
+	expect(env.BUNDLE_ARTIFACTS_KV.store.get(publicCodeRunsKvKey)).toBe(
+		JSON.stringify(stored),
+	)
+	await expect(refreshPublicCodeRunsWindow({ env, now })).resolves.toEqual({
+		status: 'rotated',
+	})
+	expect(env.BUNDLE_ARTIFACTS_KV.store.get(publicCodeRunsKvKey)).toBe(
+		JSON.stringify(reset),
+	)
 })

--- a/packages/worker/src/usage/code-runs-window.ts
+++ b/packages/worker/src/usage/code-runs-window.ts
@@ -3,6 +3,7 @@ import {
 	isStillPublicCodeRunsWindow,
 	parsePublicCodeRunsWindow,
 	publicCodeRunsWindowMs,
+	stillPublicCodeRunsWindow,
 	type PublicCodeRunsWindow,
 } from '#universal/code-runs.ts'
 
@@ -32,7 +33,7 @@ export async function loadPublicCodeRunsWindow(
 	}
 	const total = await sumExecuteEventCount(env)
 	if (total === null || total <= 0) return null
-	return stillWindow(total, now)
+	return stillPublicCodeRunsWindow(total, now)
 }
 
 export async function refreshPublicCodeRunsWindow(input: {
@@ -58,30 +59,33 @@ export async function refreshPublicCodeRunsWindow(input: {
 			return { status: 'skipped', reason: 'kv_read_failed' }
 		}
 		if (existing.status === 'missing') {
-			await writeStoredWindow(kv, stillWindow(total, now))
+			await writeStoredWindow(kv, stillPublicCodeRunsWindow(total, now))
 			return { status: 'initialized' }
 		}
 		const existingWindow = existing.window
-
+		const still = isStillPublicCodeRunsWindow(existingWindow)
 		const windowEndMs = Date.parse(existingWindow.windowEnd)
 		const beforeEnd =
 			Number.isFinite(windowEndMs) && now.getTime() < windowEndMs
-		const stillGrowing =
-			isStillPublicCodeRunsWindow(existingWindow) &&
-			total > existingWindow.current
+		const stillGrowing = still && total > existingWindow.current
+		const stillRegressed = still && total < existingWindow.current
 		// A still pair is a bootstrap (KV miss or first write). Holding it
-		// for 24h freezes the homepage ticker even while executes accrue.
+		// for 24h freezes the homepage ticker even while executes accrue,
+		// and `current = max(total, previous)` latches a stale high-water
+		// mark when the fleet SUM later drops (authoritative AE recompute).
 		// Live windows still hold until windowEnd so interpolation stays
 		// deterministic for every visitor.
-		if (beforeEnd && !stillGrowing) {
+		if (beforeEnd && !stillGrowing && !stillRegressed) {
 			return { status: 'held' }
 		}
+		if (total <= existingWindow.current) {
+			await writeStoredWindow(kv, stillPublicCodeRunsWindow(total, now))
+			return { status: 'rotated' }
+		}
 
-		const previous = existingWindow.current
-		const current = Math.max(total, previous)
 		await writeStoredWindow(kv, {
-			previous,
-			current,
+			previous: existingWindow.current,
+			current: total,
 			windowStart: now.toISOString(),
 			windowEnd: new Date(now.getTime() + publicCodeRunsWindowMs).toISOString(),
 		})
@@ -117,15 +121,6 @@ async function writeStoredWindow(
 	window: PublicCodeRunsWindow,
 ) {
 	await kv.put(publicCodeRunsKvKey, JSON.stringify(window))
-}
-
-function stillWindow(total: number, now: Date): PublicCodeRunsWindow {
-	return {
-		previous: total,
-		current: total,
-		windowStart: now.toISOString(),
-		windowEnd: new Date(now.getTime() + publicCodeRunsWindowMs).toISOString(),
-	}
 }
 
 async function sumExecuteEventCount(

--- a/packages/worker/universal/code-runs.node.test.ts
+++ b/packages/worker/universal/code-runs.node.test.ts
@@ -313,6 +313,14 @@ test('continuePublicCodeRunsWindow unsticks still and expired pairs without writ
 		windowEnd: '2026-08-22T12:00:00.000Z',
 	})
 	expect(
+		continuePublicCodeRunsWindow({ stored: still, total: 80, now }),
+	).toEqual({
+		previous: 80,
+		current: 80,
+		windowStart: '2026-08-21T12:00:00.000Z',
+		windowEnd: '2026-08-22T12:00:00.000Z',
+	})
+	expect(
 		continuePublicCodeRunsWindow({
 			stored: window,
 			total: 2000,
@@ -330,5 +338,17 @@ test('continuePublicCodeRunsWindow unsticks still and expired pairs without writ
 		current: 2000,
 		windowStart: '2026-08-22T00:00:00.000Z',
 		windowEnd: '2026-08-23T00:00:00.000Z',
+	})
+	expect(
+		continuePublicCodeRunsWindow({
+			stored: window,
+			total: 900,
+			now: new Date('2026-08-22T01:00:00.000Z'),
+		}),
+	).toEqual({
+		previous: 900,
+		current: 900,
+		windowStart: '2026-08-22T01:00:00.000Z',
+		windowEnd: '2026-08-23T01:00:00.000Z',
 	})
 })

--- a/packages/worker/universal/code-runs.ts
+++ b/packages/worker/universal/code-runs.ts
@@ -11,7 +11,8 @@
  * replaying missed steps. When leftover budget cannot support a 3-second
  * integer backbone, the client moves honest progress toward the next tick
  * instead of inventing +1s. Homepage GET may continue an expired or still
- * pair in memory when the fleet total has grown; it does not write KV.
+ * pair in memory when the fleet total has grown, or reset one to a new
+ * still window when the fleet total has dropped; it does not write KV.
  * A client that cannot paint a next tick refetches `/code-runs.json`
  * instead of giving up for the rest of the tab.
  */
@@ -28,6 +29,19 @@ export type PublicCodeRunsWindow = {
 
 export function isStillPublicCodeRunsWindow(window: PublicCodeRunsWindow) {
 	return window.previous === window.current
+}
+
+export function stillPublicCodeRunsWindow(
+	total: number,
+	now: Date,
+): PublicCodeRunsWindow {
+	const nowMs = now.getTime()
+	return {
+		previous: total,
+		current: total,
+		windowStart: now.toISOString(),
+		windowEnd: new Date(nowMs + publicCodeRunsWindowMs).toISOString(),
+	}
 }
 
 export function publicCodeRunsWindowsEqual(
@@ -142,19 +156,25 @@ export function msUntilNextCodeRunsPaint(
 
 /**
  * In-memory continuation when KV still holds a pair that cannot tick.
- * Homepage GET uses this instead of writing. Null means keep `stored`.
+ * Grows a still / expired pair when the fleet total is higher. Resets to a
+ * new still window when the fleet total dropped (a latched high-water mark
+ * would otherwise freeze the ticker). Null means keep `stored`.
  */
 export function continuePublicCodeRunsWindow(input: {
 	stored: PublicCodeRunsWindow
 	total: number
 	now: Date
 }): PublicCodeRunsWindow | null {
-	if (input.total <= input.stored.current) return null
+	if (input.total <= 0) return null
 	const nowMs = input.now.getTime()
 	const endMs = Date.parse(input.stored.windowEnd)
 	const expired = Number.isFinite(endMs) && nowMs >= endMs
 	const still = isStillPublicCodeRunsWindow(input.stored)
 	if (!expired && !still) return null
+	if (input.total < input.stored.current) {
+		return stillPublicCodeRunsWindow(input.total, input.now)
+	}
+	if (input.total === input.stored.current) return null
 	if (still && !expired) {
 		return {
 			previous: input.stored.current,
@@ -166,7 +186,7 @@ export function continuePublicCodeRunsWindow(input: {
 	const startMs = Number.isFinite(endMs) ? endMs : nowMs
 	return {
 		previous: input.stored.current,
-		current: Math.max(input.total, input.stored.current),
+		current: input.total,
 		windowStart: new Date(startMs).toISOString(),
 		windowEnd: new Date(startMs + publicCodeRunsWindowMs).toISOString(),
 	}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Keep the homepage code-runs ticker honest when the official window is a still pair (or an expired live window) and the fleet `execute` rollup total is no longer at the latched high-water mark.

## Why

Production `GET /code-runs.json` has been stuck at `{ previous: 257940, current: 257940 }` since `2026-08-24T17:00:18Z`.

That is not “no executes.” Hourly `usage_aggregation` is running (`usage_rollups.updated_at` is `2026-08-24T20:00:18Z`). Production D1 `SUM(event_count) WHERE metric = 'execute'` is **190213** (July 75515 + August 114698), an integer. GET and the hourly refresh both refuse to move a still pair unless `total > current`, and refresh then writes `current = max(total, previous)`. After the 20:00 recompute landed below 257940, the ticker could not recover — not even at tomorrow’s `windowEnd`.

This PR does not invent ticks. It resets a still or expired pair to a new still window at the actual fleet total so the next real SUM increase can move the integer and the honesty underline.

The visible homepage number will drop once from 257940 to the current D1 total (~190213), then move again when rollups grow.

## Summary

- `continuePublicCodeRunsWindow` resets a still / expired pair in memory when D1 SUM is lower than `current` (GET still does not write KV).
- Hourly `refreshPublicCodeRunsWindow` persists that reset instead of holding the stale still pair or ratcheting `max(total, previous)`.
- Live windows with a real delta still hold until `windowEnd`.
- Tests cover the production still-pair shape (257940 latched, 190213 in D1) plus expired-window regression.

## Testing

- `vitest` on `code-runs.node.test.ts` and `code-runs-window.node.test.ts`
- Pre-push `test:push` (node, workers, e2e) passed on this branch
- Production evidence (read-only D1 + `/code-runs.json`) captured before this change

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends usage-metering</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `82ce41d2` · **Head:** `3cad7f51`

**Classification:** extends — the public ticker window now resets when the fleet execute SUM drops below a latched still / expired `current`, instead of holding the high-water mark forever.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `usage-metering` | storage | extends — still / expired public-code-runs window reset on SUM regression |
| `app-ui` | surfaces | composes — homepage `/code-runs.json` continue path uses the same helper |

### Change flow

Homepage GET and the hourly aggregation refresh now reset a stuck still pair to the actual D1 execute SUM instead of waiting for a total that may never exceed the old high-water mark.

```mermaid
sequenceDiagram
	actor Visitor
	participant appUi as app-ui
	participant usageMetering as usage-metering
	participant d1AppDb as d1-app-db
	Visitor->>appUi: GET / and /code-runs.json
	appUi->>usageMetering: loadPublicCodeRunsWindow
	usageMetering->>d1AppDb: SUM execute event_count
	alt still or expired and total below current
		usageMetering-->>appUi: in-memory still window at total
	else live window before windowEnd
		usageMetering-->>appUi: hold stored pair
	end
	Note over usageMetering: hourly refresh writes the reset to KV
```

### Before / after

| Case | Before | After |
| --- | --- | --- |
| Still pair, SUM higher | continue / rotate up | unchanged |
| Still pair, SUM equal | hold | unchanged |
| Still pair, SUM lower | hold forever | reset still window at total |
| Live window, before end | hold | unchanged |
| Expired live, SUM lower | still pair at old `current` | still pair at total |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d2e9331f-8e81-48a9-8bb2-55b7442a5065?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d2e9331f-8e81-48a9-8bb2-55b7442a5065&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the homepage code-runs ticker to accurately reflect decreases in fleet-wide totals.
  - Reset ticker windows when authoritative totals drop, preventing stale or inflated counts.
  - Ensured refreshed windows display the latest total consistently.

- **Documentation**
  - Clarified ticker behavior when totals decrease, including reset timing and high-water mark handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->