### PR TITLE
Filter resolveFrame fetch network TypeErrors (KODY-CLOUDFLARE-5Y)

### DIFF
--- a/packages/worker/client/browser-fetch-network-error.ts
+++ b/packages/worker/client/browser-fetch-network-error.ts
@@ -25,9 +25,13 @@ export function isBrowserFetchNetworkError(error: unknown): boolean {
 	return isBrowserFetchNetworkErrorMessage(error.message)
 }
 
-/** True when a thrown Error's stack names Remix `resolveFrame` (KODY-CLOUDFLARE-5Y). */
+/**
+ * True when a thrown Error's stack names Remix `resolveFrame` or the
+ * `fetchFrameResolve` helper that owns the `fetch` (KODY-CLOUDFLARE-5Y).
+ * Mobile Safari often keeps only the immediate caller on `Error.stack`.
+ */
 export function errorStackMentionsResolveFrame(error: unknown) {
 	if (typeof error !== 'object' || error === null) return false
 	if (!('stack' in error) || typeof error.stack !== 'string') return false
-	return /\bresolveFrame\b/.test(error.stack)
+	return /\b(?:resolveFrame|fetchFrameResolve)\b/.test(error.stack)
 }

--- a/packages/worker/client/browser-fetch-network-error.ts
+++ b/packages/worker/client/browser-fetch-network-error.ts
@@ -1,0 +1,33 @@
+/**
+ * Browser `fetch()` network failures that reject as TypeError. Exact strings
+ * only — Firefox (KODY-CLOUDFLARE-3P), Chromium, and WebKit — so unrelated
+ * TypeErrors still surface their own message.
+ */
+
+const browserFetchNetworkErrorMessages = new Set([
+	'NetworkError when attempting to fetch resource.',
+	'Failed to fetch',
+	'Load failed',
+])
+
+export function normalizeBrowserFetchNetworkErrorMessage(message: string) {
+	return message.trim().replace(/^TypeError:\s*/i, '')
+}
+
+export function isBrowserFetchNetworkErrorMessage(message: string) {
+	return browserFetchNetworkErrorMessages.has(
+		normalizeBrowserFetchNetworkErrorMessage(message),
+	)
+}
+
+export function isBrowserFetchNetworkError(error: unknown): boolean {
+	if (!(error instanceof TypeError)) return false
+	return isBrowserFetchNetworkErrorMessage(error.message)
+}
+
+/** True when a thrown Error's stack names Remix `resolveFrame` (KODY-CLOUDFLARE-5Y). */
+export function errorStackMentionsResolveFrame(error: unknown) {
+	if (typeof error !== 'object' || error === null) return false
+	if (!('stack' in error) || typeof error.stack !== 'string') return false
+	return /\bresolveFrame\b/.test(error.stack)
+}

--- a/packages/worker/client/entry.tsx
+++ b/packages/worker/client/entry.tsx
@@ -1,7 +1,7 @@
 import { run } from 'remix/ui'
 import { consumePrefetchedFrame } from '#client/frame-prefetch.ts'
 import {
-	createFrameResolveInit,
+	fetchFrameResolve,
 	prefetchedFrameResponse,
 } from '#client/frame-resolve.ts'
 import { preloadClientRouteModules } from '#client/lazy-route.tsx'
@@ -74,7 +74,7 @@ async function boot() {
 			if (cached !== undefined) {
 				return prefetchedFrameResponse(cached)
 			}
-			const response = await fetch(src, createFrameResolveInit(options))
+			const response = await fetchFrameResolve(src, options)
 			if (!response.ok) {
 				throw new Error(
 					`Frame resolve failed (${response.status}) for ${src}${target ? ` target=${target}` : ''}`,

--- a/packages/worker/client/frame-resolve.node.test.ts
+++ b/packages/worker/client/frame-resolve.node.test.ts
@@ -1,6 +1,6 @@
-import { expect, test } from 'vitest'
+import { expect, test, vi } from 'vitest'
 import { REMIX_FRAME_TARGET_HEADER } from '#universal/frame-constants.ts'
-import { createFrameResolveInit } from './frame-resolve.ts'
+import { createFrameResolveInit, fetchFrameResolve } from './frame-resolve.ts'
 
 test('frame resolve never attaches a body to GET or HEAD, including lowercase methods', () => {
 	const formData = new FormData()
@@ -33,4 +33,56 @@ test('frame resolve never attaches a body to GET or HEAD, including lowercase me
 	expect(postInit.method).toBe('post')
 	expect(postInit.body).toBeInstanceOf(URLSearchParams)
 	expect(String(postInit.body)).toBe('q=remix')
+})
+
+test('fetchFrameResolve retries once on GET network TypeError (KODY-CLOUDFLARE-5Y)', async () => {
+	const ok = new Response('<html></html>', { status: 200 })
+	const fetchMock = vi
+		.fn()
+		.mockRejectedValueOnce(new TypeError('Load failed'))
+		.mockResolvedValueOnce(ok)
+	vi.stubGlobal('fetch', fetchMock)
+
+	try {
+		const response = await fetchFrameResolve('/@kody/planetscale')
+		expect(response).toBe(ok)
+		expect(fetchMock).toHaveBeenCalledTimes(2)
+	} finally {
+		vi.unstubAllGlobals()
+	}
+})
+
+test('fetchFrameResolve does not retry POST network TypeErrors', async () => {
+	const fetchMock = vi
+		.fn()
+		.mockRejectedValueOnce(new TypeError('Failed to fetch'))
+	vi.stubGlobal('fetch', fetchMock)
+
+	try {
+		await expect(
+			fetchFrameResolve('/action', {
+				method: 'post',
+				formData: new FormData(),
+			}),
+		).rejects.toThrow('Failed to fetch')
+		expect(fetchMock).toHaveBeenCalledTimes(1)
+	} finally {
+		vi.unstubAllGlobals()
+	}
+})
+
+test('fetchFrameResolve does not retry non-network TypeErrors', async () => {
+	const fetchMock = vi
+		.fn()
+		.mockRejectedValueOnce(new TypeError('null is not an object'))
+	vi.stubGlobal('fetch', fetchMock)
+
+	try {
+		await expect(fetchFrameResolve('/@kody/planetscale')).rejects.toThrow(
+			'null is not an object',
+		)
+		expect(fetchMock).toHaveBeenCalledTimes(1)
+	} finally {
+		vi.unstubAllGlobals()
+	}
 })

--- a/packages/worker/client/frame-resolve.ts
+++ b/packages/worker/client/frame-resolve.ts
@@ -1,4 +1,5 @@
 import { type ResolveFrameOptions } from 'remix/ui'
+import { isBrowserFetchNetworkError } from '#client/browser-fetch-network-error.ts'
 import { REMIX_FRAME_TARGET_HEADER } from '#universal/frame-constants.ts'
 
 const safeFrameMethods = new Set(['GET', 'HEAD'])
@@ -29,6 +30,30 @@ export function createFrameResolveInit(options?: ResolveFrameOptions) {
 		init.body = encodeFrameFormBody(formData, options?.encType)
 	}
 	return init
+}
+
+/**
+ * Fetch a Remix frame document. Idempotent GET/HEAD retries once on browser
+ * `fetch` network TypeErrors (WebKit "Load failed", Chromium "Failed to
+ * fetch", Firefox NetworkError) — KODY-CLOUDFLARE-5Y Mobile Safari blips after
+ * the same URL already succeeded.
+ */
+export async function fetchFrameResolve(
+	src: string,
+	options?: ResolveFrameOptions,
+) {
+	const init = createFrameResolveInit(options)
+	try {
+		return await fetch(src, init)
+	} catch (error: unknown) {
+		if (
+			!isBrowserFetchNetworkError(error) ||
+			!isSafeFrameMethod(init.method ?? 'GET')
+		) {
+			throw error
+		}
+		return await fetch(src, init)
+	}
 }
 
 function isSafeFrameMethod(method: string) {

--- a/packages/worker/client/routes/connect-oauth-config.ts
+++ b/packages/worker/client/routes/connect-oauth-config.ts
@@ -6,7 +6,10 @@ import {
 	normalizeProviderKey,
 	safeParseHost,
 } from '@kody-internal/shared/url-hosts.ts'
+import { isBrowserFetchNetworkError } from '#client/browser-fetch-network-error.ts'
 import { type AccountIntegrationListItem } from '#universal/loader-data.ts'
+
+export { isBrowserFetchNetworkError }
 
 export type OAuthFlow = 'pkce' | 'confidential'
 export type TokenExchangeStyle = 'form' | 'basic-json' | 'basic-form'
@@ -576,21 +579,6 @@ export function summarizeStoredSetupState(input: {
 		missingFields,
 		isReady: missingFields.length === 0,
 	}
-}
-
-/**
- * Browser `fetch()` network failures that reject as TypeError. Exact strings
- * only — Firefox (KODY-CLOUDFLARE-3P), Chromium, and WebKit — so unrelated
- * TypeErrors still surface their own message.
- */
-export function isBrowserFetchNetworkError(error: unknown): boolean {
-	if (!(error instanceof TypeError)) return false
-	const message = error.message.trim().replace(/^TypeError:\s*/i, '')
-	return (
-		message === 'NetworkError when attempting to fetch resource.' ||
-		message === 'Failed to fetch' ||
-		message === 'Load failed'
-	)
 }
 
 /**

--- a/packages/worker/client/sentry-browser-filters.node.test.ts
+++ b/packages/worker/client/sentry-browser-filters.node.test.ts
@@ -572,3 +572,61 @@ test('browser Sentry filters drop syntax-highlight-core dynamic import fetch fai
 		}),
 	).not.toBeNull()
 })
+
+test('browser Sentry filters drop resolveFrame fetch network TypeErrors (KODY-CLOUDFLARE-5Y)', () => {
+	expect(
+		filterBrowserSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'TypeError',
+						value: 'Load failed',
+						stacktrace: {
+							frames: [
+								{
+									function: 'app.resolveFrame',
+									filename: '../client/entry.tsx',
+								},
+							],
+						},
+					},
+				],
+			},
+		}),
+	).toBeNull()
+	expect(
+		filterBrowserSentryEvent(
+			{
+				exception: {
+					values: [{ type: 'TypeError', value: 'Failed to fetch' }],
+				},
+			},
+			Object.assign(new TypeError('Failed to fetch'), {
+				stack: 'resolveFrame@https://kody.codes/client-entry.js:3:61347',
+			}),
+		),
+	).toBeNull()
+	// Generic fetch TypeErrors without resolveFrame must stay visible.
+	expect(
+		filterBrowserSentryEvent({
+			exception: {
+				values: [{ type: 'TypeError', value: 'TypeError: Failed to fetch' }],
+			},
+		}),
+	).not.toBeNull()
+	expect(
+		filterBrowserSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'TypeError',
+						value: 'Load failed',
+						stacktrace: {
+							frames: [{ function: 'someOtherFetch', filename: 'app.js' }],
+						},
+					},
+				],
+			},
+		}),
+	).not.toBeNull()
+})

--- a/packages/worker/client/sentry-browser-filters.node.test.ts
+++ b/packages/worker/client/sentry-browser-filters.node.test.ts
@@ -606,6 +606,39 @@ test('browser Sentry filters drop resolveFrame fetch network TypeErrors (KODY-CL
 			}),
 		),
 	).toBeNull()
+	// Safari often keeps only the immediate fetchFrameResolve caller.
+	expect(
+		filterBrowserSentryEvent(
+			{
+				exception: {
+					values: [{ type: 'TypeError', value: 'Load failed' }],
+				},
+			},
+			Object.assign(new TypeError('Load failed'), {
+				stack: 'fetchFrameResolve@https://kody.codes/client-entry.js:3:61000',
+			}),
+		),
+	).toBeNull()
+	expect(
+		filterBrowserSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'TypeError',
+						value: 'Load failed',
+						stacktrace: {
+							frames: [
+								{
+									function: 'fetchFrameResolve',
+									filename: '../client/frame-resolve.ts',
+								},
+							],
+						},
+					},
+				],
+			},
+		}),
+	).toBeNull()
 	// Generic fetch TypeErrors without resolveFrame must stay visible.
 	expect(
 		filterBrowserSentryEvent({

--- a/packages/worker/client/sentry-browser-filters.ts
+++ b/packages/worker/client/sentry-browser-filters.ts
@@ -1000,8 +1000,7 @@ export function filterBrowserSentryEvent<T extends SentryErrorEventLike>(
 		return null
 	}
 	if (
-		filterResolveFrameFetchNetworkSentryEvent(event, originalException) ===
-		null
+		filterResolveFrameFetchNetworkSentryEvent(event, originalException) === null
 	) {
 		return null
 	}

--- a/packages/worker/client/sentry-browser-filters.ts
+++ b/packages/worker/client/sentry-browser-filters.ts
@@ -3,6 +3,12 @@
  * tests can exercise the predicates with plain event shapes.
  */
 
+import {
+	errorStackMentionsResolveFrame,
+	isBrowserFetchNetworkError,
+	isBrowserFetchNetworkErrorMessage,
+} from '#client/browser-fetch-network-error.ts'
+
 type SentryStackFrame = {
 	filename?: string
 	abs_path?: string
@@ -845,6 +851,60 @@ export function filterSyntaxHighlightCoreDynamicImportFailureSentryEvent<
 	return event
 }
 
+/**
+ * Remix `resolveFrame` `fetch()` network TypeErrors (WebKit "Load failed",
+ * Chromium "Failed to fetch", Firefox NetworkError). Observed as a handled
+ * client hydration error after a successful GET of the same frame URL
+ * (KODY-CLOUDFLARE-5Y, Mobile Safari on `/@kody/planetscale`). External
+ * connectivity blips — not an app defect. Match only when a stack frame names
+ * `resolveFrame` so other fetch TypeErrors stay Sentry-visible.
+ */
+export function isResolveFrameFetchNetworkSentryEvent(
+	event: SentryErrorEventLike,
+	originalException?: unknown,
+) {
+	const networkFromException =
+		isBrowserFetchNetworkError(originalException) ||
+		(typeof originalException === 'object' &&
+			originalException !== null &&
+			'message' in originalException &&
+			typeof originalException.message === 'string' &&
+			isBrowserFetchNetworkErrorMessage(originalException.message) &&
+			'name' in originalException &&
+			originalException.name === 'TypeError')
+
+	const networkFromEvent =
+		event.exception?.values?.some(
+			(value) =>
+				value.type === 'TypeError' &&
+				typeof value.value === 'string' &&
+				isBrowserFetchNetworkErrorMessage(value.value),
+		) ?? false
+
+	if (!networkFromException && !networkFromEvent) return false
+
+	if (errorStackMentionsResolveFrame(originalException)) return true
+	return sentryEventStackFrameFunctions(event).some((name) =>
+		name.includes('resolveFrame'),
+	)
+}
+
+/** Pre-SDK buffer gate: network TypeError whose stack names `resolveFrame`. */
+export function isResolveFrameFetchNetworkError(error: unknown) {
+	return (
+		isBrowserFetchNetworkError(error) && errorStackMentionsResolveFrame(error)
+	)
+}
+
+export function filterResolveFrameFetchNetworkSentryEvent<
+	T extends SentryErrorEventLike,
+>(event: T, originalException?: unknown): T | null {
+	if (isResolveFrameFetchNetworkSentryEvent(event, originalException)) {
+		return null
+	}
+	return event
+}
+
 /** Combined browser beforeSend / capture gate used by the client SDK. */
 export function filterBrowserSentryEvent<T extends SentryErrorEventLike>(
 	event: T,
@@ -936,6 +996,12 @@ export function filterBrowserSentryEvent<T extends SentryErrorEventLike>(
 			event,
 			originalException,
 		) === null
+	) {
+		return null
+	}
+	if (
+		filterResolveFrameFetchNetworkSentryEvent(event, originalException) ===
+		null
 	) {
 		return null
 	}

--- a/packages/worker/client/sentry-browser-filters.ts
+++ b/packages/worker/client/sentry-browser-filters.ts
@@ -857,7 +857,8 @@ export function filterSyntaxHighlightCoreDynamicImportFailureSentryEvent<
  * client hydration error after a successful GET of the same frame URL
  * (KODY-CLOUDFLARE-5Y, Mobile Safari on `/@kody/planetscale`). External
  * connectivity blips — not an app defect. Match only when a stack frame names
- * `resolveFrame` so other fetch TypeErrors stay Sentry-visible.
+ * `resolveFrame` or `fetchFrameResolve` so other fetch TypeErrors stay
+ * Sentry-visible.
  */
 export function isResolveFrameFetchNetworkSentryEvent(
 	event: SentryErrorEventLike,
@@ -884,12 +885,13 @@ export function isResolveFrameFetchNetworkSentryEvent(
 	if (!networkFromException && !networkFromEvent) return false
 
 	if (errorStackMentionsResolveFrame(originalException)) return true
-	return sentryEventStackFrameFunctions(event).some((name) =>
-		name.includes('resolveFrame'),
+	return sentryEventStackFrameFunctions(event).some(
+		(name) =>
+			name.includes('resolveFrame') || name.includes('fetchFrameResolve'),
 	)
 }
 
-/** Pre-SDK buffer gate: network TypeError whose stack names `resolveFrame`. */
+/** Pre-SDK buffer gate: network TypeError from resolveFrame / fetchFrameResolve. */
 export function isResolveFrameFetchNetworkError(error: unknown) {
 	return (
 		isBrowserFetchNetworkError(error) && errorStackMentionsResolveFrame(error)

--- a/packages/worker/client/sentry-client.ts
+++ b/packages/worker/client/sentry-client.ts
@@ -2,6 +2,7 @@ import {
 	isBrowserAbortError,
 	isBrowserInjectedGlobalNoiseError,
 	isFirefoxDomPermissionDeniedError,
+	isResolveFrameFetchNetworkError,
 	isSyntaxHighlightCoreDynamicImportFailureError,
 } from '#client/sentry-browser-filters.ts'
 import {
@@ -51,7 +52,8 @@ function shouldIgnoreBufferedError(error: unknown) {
 		isBrowserAbortError(error) ||
 		isFirefoxDomPermissionDeniedError(error) ||
 		isBrowserInjectedGlobalNoiseError(error) ||
-		isSyntaxHighlightCoreDynamicImportFailureError(error)
+		isSyntaxHighlightCoreDynamicImportFailureError(error) ||
+		isResolveFrameFetchNetworkError(error)
 	)
 }
 

--- a/packages/worker/client/sentry-init.ts
+++ b/packages/worker/client/sentry-init.ts
@@ -40,14 +40,15 @@ export function initBrowserSentry(config: SentryClientConfig) {
 		// `sendScrollEvent`→ `window.webkit.messageHandlers` TypeErrors,
 		// injected unguarded `meta[property='og:type']` probes from
 		// `global code`, and optional Shiki `syntax-highlight-core` dynamic
-		// import fetch failures) — see filterBrowserSentryEvent /
+		// import fetch failures, and resolveFrame fetch network TypeErrors) —
+		// see filterBrowserSentryEvent /
 		// KODY-CLOUDFLARE-23 / KODY-CLOUDFLARE-3Q / KODY-CLOUDFLARE-3S /
 		// KODY-CLOUDFLARE-3X / KODY-CLOUDFLARE-43 / KODY-CLOUDFLARE-46 /
 		// KODY-CLOUDFLARE-4F / KODY-CLOUDFLARE-5C / KODY-CLOUDFLARE-5K /
-		// KODY-CLOUDFLARE-5W / KODY-CLOUDFLARE-5X /
+		// KODY-CLOUDFLARE-5W / KODY-CLOUDFLARE-5X / KODY-CLOUDFLARE-5Y /
 		// issues 7639685398, 7648833360, 7648833403, 7653117289, 7655189301,
 		// 7658961865, 7659616372, 7660258027, 7662064169, 7677729361,
-		// 7682968915, 7687920474, 7689579030.
+		// 7682968915, 7687920474, 7689579030, 7690163947.
 		beforeSend(event, hint) {
 			return filterBrowserSentryEvent(event, hint.originalException)
 		},


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop Mobile Safari `TypeError: Load failed` from Remix `resolveFrame` paging Sentry when the failure is a transient browser `fetch` blip (KODY-CLOUDFLARE-5Y).

## Why

Production event on `/@kody/planetscale` (Mobile Safari 26.6 / iPhone): several GETs of the same frame URL succeeded, then one `fetch` rejected as WebKit `Load failed`. That rejection bubbled through `app.resolveFrame` and was captured as a handled hydration error. External connectivity noise — not an app defect — and it will recur on flaky mobile networks if we only ignore once.

## Summary

- Share `isBrowserFetchNetworkError` (Firefox / Chromium / WebKit exact TypeError strings) for frame resolve + OAuth UX.
- Retry idempotent GET/HEAD once in `fetchFrameResolve` on those network TypeErrors.
- Drop remaining `resolveFrame` / `fetchFrameResolve`-scoped fetch network TypeErrors in the browser Sentry `beforeSend` gate (and the pre-SDK buffer when the stack names those frames).
- Leave generic `Failed to fetch` without those frames Sentry-visible.

## Testing

- `npx vitest run packages/worker/client/frame-resolve.node.test.ts packages/worker/client/sentry-browser-filters.node.test.ts` — pass (includes Safari `fetchFrameResolve`-only stack case from Bugbot)
- CI Validate on prior head was green; retriggering after Bugbot stack-match fix

Skip preview: no logged-in UI or data-shape change; filter + GET retry only.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `ceb46260` · **Head:** `1f3c669e`

**Classification:** composes — no primitives added or changed; narrow client noise filter plus one idempotent frame-fetch retry.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `app-ui` | surfaces | composes — browser Sentry beforeSend + resolveFrame fetch helper |

### Change flow

`resolveFrame` retries a flaky GET once; if it still fails (or an older client reports), Sentry drops only network TypeErrors whose stack names `resolveFrame` or `fetchFrameResolve`.

```mermaid
sequenceDiagram
	actor Browser
	participant appUi as app-ui
	participant Sentry
	Browser->>appUi: resolveFrame fetch (GET)
	appUi->>appUi: network TypeError (Load failed)
	appUi->>appUi: retry GET once
	alt retry succeeds
		appUi-->>Browser: frame Response
	else still fails
		appUi->>Sentry: captureException
		Sentry-->>Sentry: beforeSend drops resolveFrame/fetchFrameResolve network TypeError
	end
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c435df90-b8cc-42f2-9dae-b4491c88561a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c435df90-b8cc-42f2-9dae-b4491c88561a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Frame resolution now automatically retries eligible GET requests once after certain browser network failures.
  - Prevented transient browser fetch errors from interrupting frame loading when a retry succeeds.
  - Known frame-resolution network errors are no longer surfaced as unnecessary Sentry reports.
  - Other request types and unrelated fetch errors continue to follow existing handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->