### PR TITLE
Replay the homepage ticker from delayed daily execute totals

### DIFF
--- a/docs/contributing/architecture/authorization.md
+++ b/docs/contributing/architecture/authorization.md
@@ -20,10 +20,11 @@ scores. This boundary never exposes forked package source, rating notes,
 secrets, or unrelated account content.
 
 The homepage code-runs ticker is a fifth narrow exception. Anonymous visitors
-and signed-in users see the same delayed fleet total: a `SUM(event_count)` of
-`execute` rows from `usage_rollups` with no user ids. The official
-`{ previous, current, windowStart, windowEnd }` pair lives at the platform KV
-key `public-code-runs:v1`. Homepage GET does not write that key. See
+and signed-in users see the same delayed fleet total: cumulative `execute`
+counts through completed UTC days, with no user ids. The official
+`{ start, end, updateAt }` triple lives at the platform KV key
+`public-code-runs:v2`. Homepage GET may fill that cache from D1 when the key is
+missing or `updateAt` has passed; it does not persist a high-water mark. See
 [Usage metering](./usage-metering.md).
 
 For browser and MCP authentication mechanics, see

--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -443,6 +443,12 @@ Two D1 reporting projections deliberately remain:
   Engine's account retention is approximately 90 days, so it cannot safely serve
   the 12-month admin trend or preserve the 24-month read model. The hourly
   Analytics Engine recompute and D1 table remain unchanged.
+- `fleet_execute_days` keeps platform-owned UTC-day fleet `execute` totals for
+  the homepage ticker (no `user_id`; not an account export/deletion target). The
+  hourly `usage_aggregation` lane rewrites the current and previous UTC months
+  from Analytics Engine. Public reads use only completed days (through
+  yesterday); older monthly `usage_rollups` fill months before the daily series
+  starts.
 - `agent_package_conversation_uses` is read while building MCP server
   instructions to provide popular-package hints. That request path is
   latency-sensitive, so Analytics Engine SQL is not a suitable replacement. A
@@ -455,7 +461,8 @@ OAuth provider state is stored in `OAUTH_KV` through the
 `@cloudflare/workers-oauth-provider` integration. Published package/job source
 snapshots, bundle artifacts, package retriever caches, and community listing
 snapshots are stored in `BUNDLE_ARTIFACTS_KV`. That binding also holds the
-platform-owned `public-code-runs:v1` window for the homepage ticker.
+platform-owned `public-code-runs:v2` delayed daily window for the homepage
+ticker.
 
 - Bindings are configured in `packages/worker/wrangler.jsonc` (remote KV IDs are
   supplied at deploy time via generated Wrangler configs, not committed in the
@@ -1307,10 +1314,11 @@ app-owned keys in it. App-owned `BUNDLE_ARTIFACTS_KV` keys are:
   serialized queue message would exceed 120 KB. Immediate account-deletion
   cleanup is not required because KV enforces the TTL; the queue consumer
   deletes the key after a terminal delivery.
-- `public-code-runs:v1` — platform-owned 24-hour delayed fleet `execute` window
-  for the homepage ticker (`{ previous, current, windowStart, windowEnd }`). Not
-  scoped by user id; account deletion must not remove it. Homepage GET is
-  read-only; the `usage_aggregation` lane writes it.
+- `public-code-runs:v2` — platform-owned delayed fleet `execute` window for the
+  homepage ticker (`{ start, end, updateAt }`). Not scoped by user id; account
+  deletion must not remove it. Homepage GET fills the cache from D1 when the key
+  is missing or `updateAt` has passed; the `usage_aggregation` lane syncs daily
+  D1 rows and refreshes the triple.
 
 Account deletion derives these keys from D1 rows and package ids before deleting
 D1 projections. New KV prefixes must add corresponding account-deletion coverage
@@ -1495,10 +1503,13 @@ Current retention policies:
   (`userMeterDailyCounterRetentionDays`); `admin_user_meter_parity` reports
   meter-only daily counts.
 - `usage_rollups`: per user/metric/month rollups keep 24 months by `month` key;
-  raw Analytics Engine usage events follow platform retention. The homepage
-  ticker reads an anonymous `SUM(event_count)` of `execute` rows from this
-  table; the official replay pair is the platform KV key `public-code-runs:v1`
-  and is independent of account deletion/export.
+  raw Analytics Engine usage events follow platform retention. Months before the
+  earliest `fleet_execute_days` row still feed the homepage ticker prefix.
+- `fleet_execute_days`: platform-owned UTC-day fleet `execute` totals (no
+  `user_id`). Rows are rewritten hourly for the current and previous UTC months;
+  older days remain so the delayed lifetime total can climb. The official replay
+  triple is the platform KV key `public-code-runs:v2` and is independent of
+  account deletion/export.
 - `feature_flag_exposure_rollups`: local-dev/test flag exposure rollups keep 90
   days by `day` key, matching Analytics Engine retention for the production
   `FLAG_EXPOSURES` exposure stream; the admin metric readout window is the

--- a/docs/contributing/architecture/usage-metering.md
+++ b/docs/contributing/architecture/usage-metering.md
@@ -15,12 +15,14 @@ Usage metering follows the repo-wide isolation invariant: every event carries a
 required `userId`, the Analytics Engine index is the `userId`, and the D1 rollup
 table is keyed by `user_id`. Admin and account reads stay scoped to one user.
 
-The homepage code-runs ticker is a documented exception: an anonymous
-`SUM(event_count)` of `execute` rows (no user ids) is replayed 24 hours delayed.
-The official `{ previous, current, windowStart, windowEnd }` pair lives at the
-platform KV key `public-code-runs:v1` on `BUNDLE_ARTIFACTS_KV`. Homepage GET
-does not write that key; the hourly `usage_aggregation` lane rotates it. The
-public payload never includes per-user rows. See
+The homepage code-runs ticker is a documented exception: an anonymous delayed
+lifetime total of fleet `execute` events (no user ids) is replayed across the
+current UTC day. Daily counts live in platform-owned `fleet_execute_days`. The
+official `{ start, end, updateAt }` triple — cumulative through the day before
+yesterday, cumulative through yesterday, and the next UTC midnight — is cached
+at `public-code-runs:v2` on `BUNDLE_ARTIFACTS_KV`. Homepage GET fills that cache
+from D1 when the key is missing or `updateAt` has passed; it does not latch a
+high-water mark. The public payload never includes per-user rows. See
 [Authorization](./authorization.md).
 
 ## The event schema
@@ -185,6 +187,8 @@ each chokepoint records exactly one event per metered unit, so sums are safe.
    **Local-dev direct fallback:** when `USAGE_EVENTS` is absent (local dev,
    tests), `recordUsage` upserts `usage_rollups` directly per event, so local
    admin pages and workers-unit tests work without Analytics Engine access.
+   `execute` events also increment today's `fleet_execute_days` row so the
+   homepage ticker has daily facts without Analytics Engine.
 
    The rollup is the cheap read path for month-to-date admin and cohort views:
    one point lookup per user, metric, and month.
@@ -247,9 +251,10 @@ Guarantees and rules:
 - If `userId` is empty, the event is skipped entirely. Callers on paths that can
   run without a user (for example anonymous gateway fetches) must guard with
   `if (userId)` and not invent placeholder ids.
-- The returned promise resolves quickly (one `writeDataPoint`, or one D1 upsert
-  in local dev). `await` it inline, or pass it to `ctx.waitUntil(...)` inside
-  Durable Objects when the caller must not block.
+- The returned promise resolves quickly (one `writeDataPoint`, or one or two D1
+  upserts in local dev — rollup plus `fleet_execute_days` for `execute`).
+  `await` it inline, or pass it to `ctx.waitUntil(...)` inside Durable Objects
+  when the caller must not block.
 
 ## Recipe: instrumenting a new chokepoint
 
@@ -328,34 +333,35 @@ Guarantees and rules:
   direct D1 queries when KV is unavailable. Usage is loaded for one selected
   account at a time, so admin reads stay O(1) per view as the user base grows.
 - **Public homepage ticker** (`GET /code-runs.json`, SSR on `/`): reads the
-  platform KV pair (or a still D1 sum when KV is empty) and interpolates
-  `previous → current` across the 24-hour window. The payload is the window pair
-  only — never per-user rows. Interpolation is deterministic from the window so
-  every visitor at a given clock time sees the same integer. Official `current`
-  appears at `windowEnd`. Each displayed step is +1. When the pair has at least
-  one tick per 3-second honesty slot, a backbone tick lands every slot at a
-  hashed phase so the cadence does not march on the clock. Leftover count (more
-  than the backbone) still warps into busy seconds and rolls through those
-  seconds without skipping, with hashed gaps so a busy second does not march on
-  even slots. It never passes `current`. When leftover budget cannot support a
+  cached `{ start, end, updateAt }` triple (or recomputes it from D1 when the
+  cache is missing or `now >= updateAt`) and interpolates `start → end` across
+  today (`[updateAt - 24h, updateAt)`). `end` is the cumulative fleet `execute`
+  total through yesterday; `start` is the same total through the day before
+  yesterday. Monthly `usage_rollups` fill only months **before** the earliest
+  `fleet_execute_days` row; today is stored hourly but never used in the public
+  payload. The payload is the triple only — never per-user rows. Interpolation
+  is deterministic from the triple so every visitor at a given clock time sees
+  the same integer. Official `end` appears at `updateAt`. Each displayed step is
+  +1. When the pair has at least one tick per 3-second honesty slot, a backbone
+  tick lands every slot at a hashed phase so the cadence does not march on the
+  clock. Leftover count (more than the backbone) still warps into busy seconds
+  and rolls through those seconds without skipping, with hashed gaps so a busy
+  second does not march on even slots. It never passes `end`. If `end < start`
+  (an Analytics Engine regression), the ticker shows `end` immediately — wobble
+  math cannot use a negative delta. When leftover budget cannot support a
   3-second integer backbone, the client moves honest progress toward the next
   tick instead of inventing +1s. The client schedules the next paint
   (`msUntilNextCodeRunsPaint`) rather than polling once a second;
   `prefers-reduced-motion` snaps and does not animate. A frozen tab (rAF gap,
   hidden, or a late timeout) snaps to the official count instead of rolling
   through every missed integer. Live leftover ticks in a busy second still step
-  +1; leftover catch-up delays stay under that freeze window. Homepage GET
-  continues an expired or still pair in memory when the fleet total has grown,
-  and resets a still or expired pair to a new still window when the fleet total
-  has dropped (an authoritative rollup recompute can land below a latched
-  high-water mark; `max(total, previous)` would freeze the ticker). It does not
-  write KV. The D1 `SUM(event_count)` for `metric = 'execute'` is coerced with
-  `Number()` the same way other rollup readers do — a `typeof === 'number'`
-  check treated D1 numeric strings as zero and froze the ticker on a still pair.
-  A tab that cannot paint a next tick refetches `/code-runs.json` (cache bypass)
-  instead of stopping for the rest of the session. The hourly
-  `usage_aggregation` refresh still persists the next official pair. Live
-  windows with a real delta still hold until `windowEnd`.
+  +1; leftover catch-up delays stay under that freeze window. A tab that cannot
+  paint a next tick waits until `updateAt` and refetches `/code-runs.json`
+  (cache bypass). If that fetch still returns the same triple (cron lag at
+  midnight), it retries about once a minute. The hourly `usage_aggregation` lane
+  syncs `fleet_execute_days` from Analytics Engine, then refreshes the cached
+  triple. Empty D1 (no daily rows, or no completed-day total) hides the ticker
+  (`window: null`).
 - **Fleet visibility** (`/admin/insights`, loader in
   `packages/worker/src/admin/fleet-usage-insights.ts`): bounded SQL over
   `usage_rollups` for the current UTC month — top-10 combined runtime duration

--- a/docs/contributing/architecture/usage-metering.md
+++ b/docs/contributing/architecture/usage-metering.md
@@ -22,7 +22,9 @@ official `{ start, end, updateAt }` triple — cumulative through the day before
 yesterday, cumulative through yesterday, and the next UTC midnight — is cached
 at `public-code-runs:v2` on `BUNDLE_ARTIFACTS_KV`. Homepage GET fills that cache
 from D1 when the key is missing or `updateAt` has passed; it does not latch a
-high-water mark. The public payload never includes per-user rows. See
+high-water mark. A D1 read failure is not an empty series: GET serves the last
+cached triple when one exists, and hourly refresh does not delete the key. The
+public payload never includes per-user rows. See
 [Authorization](./authorization.md).
 
 ## The event schema

--- a/packages/worker/client/code-runs-ticker.tsx
+++ b/packages/worker/client/code-runs-ticker.tsx
@@ -1,6 +1,6 @@
 import { type Handle } from 'remix/ui'
 import {
-	codeRunsStillWindowRefreshMs,
+	codeRunsWindowRefreshRetryMs,
 	fetchCodeRunsPayload,
 } from '#client/routes/code-runs-payload.ts'
 import {
@@ -9,6 +9,7 @@ import {
 	codeRunsProgressToNext,
 	formatCodeRunsCount,
 	interpolateCodeRunsCount,
+	msUntilCodeRunsWindowRefresh,
 	msUntilNextCodeRunsPaint,
 	nextDisplayedCodeRunsCount,
 	publicCodeRunsWindowsEqual,
@@ -22,9 +23,9 @@ import {
  * longest the official integer may sit when budget allows; thinner windows
  * move the progress underline instead of inventing +1s. A frozen tab (rAF
  * gap, hidden, or a late timeout) snaps to the official count instead of
- * rolling through every missed integer. A still or ended window refetches
- * `/code-runs.json` instead of stopping for the rest of the tab. Mono
- * digits plus a reserved width from `current` keep the label from shifting
+ * rolling through every missed integer. When no next integer can paint, the
+ * ticker waits until `updateAt` then refetches `/code-runs.json`. Mono
+ * digits plus a reserved width from `end` keep the label from shifting
  * as digits change.
  */
 export function CodeRunsTicker(
@@ -104,12 +105,16 @@ export function CodeRunsTicker(
 			show(officialAt(nowAfter), progressAt(nowAfter), nowAfter)
 			const delay = msUntilNextCodeRunsPaint(activeWindow, nowAfter)
 			if (delay === null) {
-				timeoutId = setTimeout(() => {
-					void refreshStuckWindow().finally(() => {
-						if (handle.signal.aborted) return
-						scheduleNext()
-					})
-				}, codeRunsStillWindowRefreshMs)
+				const refreshIn = msUntilCodeRunsWindowRefresh(activeWindow, nowAfter)
+				timeoutId = setTimeout(
+					() => {
+						void refreshStuckWindow().finally(() => {
+							if (handle.signal.aborted) return
+							scheduleNext()
+						})
+					},
+					refreshIn > 0 ? refreshIn : codeRunsWindowRefreshRetryMs,
+				)
 				return
 			}
 			timeoutId = setTimeout(
@@ -168,7 +173,7 @@ export function CodeRunsTicker(
 	}
 
 	return () => {
-		const reserved = formatCodeRunsCount(activeWindow.current)
+		const reserved = formatCodeRunsCount(activeWindow.end)
 		return (
 			<p data-rise style={{ '--rise': '1.5' }} class="landing-hero-runs">
 				<span class="landing-hero-runs-line">

--- a/packages/worker/client/routes/code-runs-payload.ts
+++ b/packages/worker/client/routes/code-runs-payload.ts
@@ -5,8 +5,8 @@ import { readJson } from '#client/routes/account-approval-shared.ts'
 
 export const codeRunsApiPath = routes.codeRunsApi.href()
 
-/** How long a stuck ticker waits before asking origin for a newer window. */
-export const codeRunsStillWindowRefreshMs = 60_000
+/** Retry after `updateAt` when origin still returns the same cached triple. */
+export const codeRunsWindowRefreshRetryMs = 60_000
 
 export async function fetchCodeRunsPayload(
 	signal?: AbortSignal,

--- a/packages/worker/migrations/0024-fleet-execute-days.sql
+++ b/packages/worker/migrations/0024-fleet-execute-days.sql
@@ -1,0 +1,9 @@
+-- Fleet-wide UTC-day execute counts for the homepage ticker.
+-- Platform-owned (no user_id): not an account export/deletion target.
+-- Hourly AE sync rewrites days in the current and previous UTC months;
+-- the public payload uses only completed days (through yesterday).
+CREATE TABLE fleet_execute_days (
+	day TEXT PRIMARY KEY NOT NULL,
+	event_count INTEGER NOT NULL,
+	updated_at TEXT NOT NULL
+);

--- a/packages/worker/src/account/data-targets.node.test.ts
+++ b/packages/worker/src/account/data-targets.node.test.ts
@@ -208,6 +208,7 @@ test('operator-owned tables are explicit deletion/export exclusions', () => {
 	using db = new DatabaseSync(':memory:')
 	applyMigrations(db)
 	const expectedTables = [
+		'fleet_execute_days',
 		'platform_oauth_apps',
 		'repo_session_storage_bucket_cursor',
 		'system_email_attachments',
@@ -237,7 +238,8 @@ test('operator-owned tables are explicit deletion/export exclusions', () => {
 					reason: expect.stringContaining(
 						table === 'platform_oauth_apps'
 							? 'Operator-provisioned built-in OAuth app'
-							: table.startsWith('repo_session_')
+							: table.startsWith('repo_session_') ||
+								  table === 'fleet_execute_days'
 								? 'Platform-owned'
 								: 'operator-owned system email',
 					),

--- a/packages/worker/src/account/data-targets.ts
+++ b/packages/worker/src/account/data-targets.ts
@@ -113,6 +113,12 @@ export const accountOperatorOwnedD1Surfaces = [
 		reason:
 			'Platform-owned storage-bucket inventory cursor across RepoSessionIndex owners (one singleton row). Not user data; account deletion does not touch it.',
 	},
+	{
+		table: 'fleet_execute_days',
+		surface: 'fleet_execute_days',
+		reason:
+			'Platform-owned UTC-day fleet execute totals for the homepage ticker. No user_id; account deletion and export must not touch it.',
+	},
 ] as const
 
 /** Targets that account export should skip (deletion still covers them). */

--- a/packages/worker/src/app/handlers/code-runs.node.test.ts
+++ b/packages/worker/src/app/handlers/code-runs.node.test.ts
@@ -3,10 +3,9 @@ import { createCodeRunsApiHandler } from './code-runs.ts'
 
 test('code-runs.json returns the stored public window or null', async () => {
 	const window = {
-		previous: 1000,
-		current: 1240,
-		windowStart: '2026-08-21T00:00:00.000Z',
-		windowEnd: '2026-08-22T00:00:00.000Z',
+		start: 1000,
+		end: 1240,
+		updateAt: '2099-01-01T00:00:00.000Z',
 	}
 	const present = await createCodeRunsApiHandler({
 		BUNDLE_ARTIFACTS_KV: {

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -723,10 +723,9 @@ test('renderAppPage embeds a tabular homepage code-runs ticker', async () => {
 	setAuthSessionSecret(testCookieSecret)
 	const env = createTestEnv(createUserTestDb([]))
 	const window = {
-		previous: 128447,
-		current: 151203,
-		windowStart: '2026-08-22T00:00:00.000Z',
-		windowEnd: '2026-08-23T00:00:00.000Z',
+		start: 128447,
+		end: 151203,
+		updateAt: '2026-08-23T00:00:00.000Z',
 	}
 	const nowMs = Date.parse('2026-08-22T12:00:00.000Z')
 	vi.useFakeTimers()

--- a/packages/worker/src/index.workers.test.ts
+++ b/packages/worker/src/index.workers.test.ts
@@ -20,6 +20,8 @@ const mocks = vi.hoisted(() => ({
 		count: 0,
 	})),
 	aggregateUsageRollups: vi.fn(async () => ({ skipped: true })),
+	syncFleetExecuteDays: vi.fn(async () => ({ skipped: true })),
+	refreshPublicCodeRunsWindow: vi.fn(async () => ({ status: 'skipped' })),
 	backfillStorageBucketEstimates: vi.fn(async () => ({
 		scanned: 0,
 		updated: 0,
@@ -63,6 +65,14 @@ vi.mock('#app/auth-denial-alerts.ts', () => ({
 
 vi.mock('#worker/usage/aggregate-rollups.ts', () => ({
 	aggregateUsageRollups: mocks.aggregateUsageRollups,
+}))
+
+vi.mock('#worker/usage/fleet-execute-days.ts', () => ({
+	syncFleetExecuteDays: mocks.syncFleetExecuteDays,
+}))
+
+vi.mock('#worker/usage/code-runs-window.ts', () => ({
+	refreshPublicCodeRunsWindow: mocks.refreshPublicCodeRunsWindow,
 }))
 
 vi.mock('#worker/storage-buckets/estimate-backfill.ts', () => ({
@@ -123,6 +133,11 @@ test('platform lanes execute with their expected inputs and jobs-owned lanes are
 		expect.objectContaining({ blobs: env.EMAIL_BLOBS }),
 	)
 	expect(mocks.aggregateUsageRollups).toHaveBeenCalledWith(env, scheduledAt)
+	expect(mocks.syncFleetExecuteDays).toHaveBeenCalledWith(env, scheduledAt)
+	expect(mocks.refreshPublicCodeRunsWindow).toHaveBeenCalledWith({
+		env,
+		now: scheduledAt,
+	})
 	expect(mocks.checkAuthDenialBurstAndNotify).toHaveBeenCalledWith(
 		expect.objectContaining({ now: scheduledAt }),
 	)

--- a/packages/worker/src/scheduled/scheduled-lanes.ts
+++ b/packages/worker/src/scheduled/scheduled-lanes.ts
@@ -20,6 +20,7 @@ import { cleanupRepoSessionBranches } from '#worker/repo/repo-session-cleanup.ts
 import { backfillStorageBucketEstimates } from '#worker/storage-buckets/estimate-backfill.ts'
 import { aggregateUsageRollups } from '#worker/usage/aggregate-rollups.ts'
 import { refreshPublicCodeRunsWindow } from '#worker/usage/code-runs-window.ts'
+import { syncFleetExecuteDays } from '#worker/usage/fleet-execute-days.ts'
 
 export {
 	isScheduledLaneName,
@@ -102,6 +103,7 @@ export async function runScheduledLane(input: {
 			return pruneJobRetention({ env: input.env, now: input.scheduledAt })
 		case 'usage_aggregation': {
 			const result = await aggregateUsageRollups(input.env, input.scheduledAt)
+			await syncFleetExecuteDays(input.env, input.scheduledAt)
 			await refreshPublicCodeRunsWindow({
 				env: input.env,
 				now: input.scheduledAt,

--- a/packages/worker/src/usage/aggregate-rollups.ts
+++ b/packages/worker/src/usage/aggregate-rollups.ts
@@ -241,9 +241,9 @@ function toCount(value: number | string) {
 	return Number.isFinite(parsed) ? Math.round(parsed) : 0
 }
 
-async function filterLiveUsageRows(
+export async function filterLiveUsageRows<T extends { user_id: string }>(
 	db: D1Database,
-	rows: Array<AnalyticsEngineSqlRow>,
+	rows: Array<T>,
 ) {
 	const systemRows = rows.filter((row) => row.user_id === 'system:email')
 	const userIds = [

--- a/packages/worker/src/usage/code-runs-window.node.test.ts
+++ b/packages/worker/src/usage/code-runs-window.node.test.ts
@@ -19,11 +19,15 @@ function createMemoryKv(initial?: Record<string, string>) {
 		async put(key: string, value: string) {
 			store.set(key, value)
 		},
+		async delete(key: string) {
+			store.delete(key)
+		},
 		store,
 	} as unknown as KVNamespace & { store: Map<string, string> }
 }
 
 async function createEnv(input?: {
+	days?: Array<{ day: string; eventCount: number }>
 	rows?: Array<{ userId: string; month: string; eventCount: number }>
 	window?: unknown
 }) {
@@ -41,6 +45,15 @@ async function createEnv(input?: {
 			.bind(row.userId, row.month, row.eventCount)
 			.run()
 	}
+	for (const day of input?.days ?? []) {
+		await db
+			.prepare(
+				`INSERT INTO fleet_execute_days (day, event_count, updated_at)
+				VALUES (?, ?, '2026-08-24T12:00:00.000Z')`,
+			)
+			.bind(day.day, day.eventCount)
+			.run()
+	}
 	const kv = createMemoryKv(
 		input?.window
 			? { [publicCodeRunsKvKey]: JSON.stringify(input.window) }
@@ -49,258 +62,133 @@ async function createEnv(input?: {
 	return { APP_DB: db, BUNDLE_ARTIFACTS_KV: kv }
 }
 
-function withCoercedExecuteSum(
-	env: { APP_DB: D1Database },
-	coerce: (total: unknown) => unknown,
-) {
-	const prepare = env.APP_DB.prepare.bind(env.APP_DB)
-	env.APP_DB.prepare = ((sql: string) => {
-		const statement = prepare(sql)
-		if (!sql.includes('SUM(event_count)')) return statement
-		const first = statement.first.bind(statement)
-		return Object.assign(statement, {
-			async first() {
-				const row = await first<{ total?: unknown }>()
-				if (row == null || row.total == null) return row
-				return { total: coerce(row.total) }
-			},
-		})
-	}) as D1Database['prepare']
+const midday = new Date('2026-08-24T15:00:00.000Z')
+const expectedWindow = {
+	start: 1030,
+	end: 1060,
+	updateAt: '2026-08-25T00:00:00.000Z',
 }
 
-test('refreshPublicCodeRunsWindow initializes a still pair, unsticks when the fleet grows, and holds a live window for 24h', async () => {
-	const env = await createEnv({
-		rows: [
-			{ userId: 'a', month: '2026-07', eventCount: 40 },
-			{ userId: 'b', month: '2026-08', eventCount: 60 },
+async function seededEnv(window?: unknown) {
+	return createEnv({
+		rows: [{ userId: 'a', month: '2026-07', eventCount: 1000 }],
+		days: [
+			{ day: '2026-08-21', eventCount: 10 },
+			{ day: '2026-08-22', eventCount: 20 },
+			{ day: '2026-08-23', eventCount: 30 },
+			{ day: '2026-08-24', eventCount: 99 },
 		],
+		window,
 	})
-	const start = new Date('2026-08-21T00:00:00.000Z')
+}
+
+test('load and refresh derive start/end from completed days and ignore today', async () => {
+	const env = await seededEnv()
 	await expect(
-		refreshPublicCodeRunsWindow({ env, now: start }),
+		refreshPublicCodeRunsWindow({ env, now: midday }),
 	).resolves.toEqual({ status: 'initialized' })
-
-	const still = await loadPublicCodeRunsWindow(env, start)
-	expect(still).toEqual({
-		previous: 100,
-		current: 100,
-		windowStart: '2026-08-21T00:00:00.000Z',
-		windowEnd: '2026-08-22T00:00:00.000Z',
-	})
-
-	await expect(
-		refreshPublicCodeRunsWindow({
-			env,
-			now: new Date('2026-08-21T12:00:00.000Z'),
-		}),
-	).resolves.toEqual({ status: 'held' })
-	expect(await loadPublicCodeRunsWindow(env, start)).toEqual(still)
-
-	await env.APP_DB.prepare(
-		`UPDATE usage_rollups SET event_count = 90 WHERE user_id = 'b'`,
-	).run()
-	await expect(
-		refreshPublicCodeRunsWindow({
-			env,
-			now: new Date('2026-08-21T12:01:00.000Z'),
-		}),
-	).resolves.toEqual({ status: 'rotated' })
-	const live = await loadPublicCodeRunsWindow(
-		env,
-		new Date('2026-08-21T12:01:00.000Z'),
+	expect(await loadPublicCodeRunsWindow(env, midday)).toEqual(expectedWindow)
+	expect(env.BUNDLE_ARTIFACTS_KV.store.get(publicCodeRunsKvKey)).toBe(
+		JSON.stringify(expectedWindow),
 	)
-	expect(live).toEqual({
-		previous: 100,
-		current: 130,
-		windowStart: '2026-08-21T12:01:00.000Z',
-		windowEnd: '2026-08-22T12:01:00.000Z',
-	})
 
-	await env.APP_DB.prepare(
-		`UPDATE usage_rollups SET event_count = 110 WHERE user_id = 'b'`,
-	).run()
 	await expect(
-		refreshPublicCodeRunsWindow({
-			env,
-			now: new Date('2026-08-21T18:00:00.000Z'),
-		}),
+		refreshPublicCodeRunsWindow({ env, now: midday }),
 	).resolves.toEqual({ status: 'held' })
-	expect(
-		await loadPublicCodeRunsWindow(env, new Date('2026-08-21T18:00:00.000Z')),
-	).toEqual(live)
+	expect(await loadPublicCodeRunsWindow(env, midday)).toEqual(expectedWindow)
+})
 
-	await expect(
-		refreshPublicCodeRunsWindow({
-			env,
-			now: new Date('2026-08-22T12:01:00.000Z'),
-		}),
-	).resolves.toEqual({ status: 'rotated' })
-	expect(
-		await loadPublicCodeRunsWindow(env, new Date('2026-08-22T12:01:00.000Z')),
-	).toEqual({
-		previous: 130,
-		current: 150,
-		windowStart: '2026-08-22T12:01:00.000Z',
-		windowEnd: '2026-08-23T12:01:00.000Z',
+test('load recomputes after updateAt and fills KV without latching a high-water mark', async () => {
+	const stale = {
+		start: 257940,
+		end: 257940,
+		updateAt: '2026-08-24T00:00:00.000Z',
+	}
+	const env = await seededEnv(stale)
+	const loaded = await loadPublicCodeRunsWindow(env, midday)
+	expect(loaded).toEqual(expectedWindow)
+	expect(env.BUNDLE_ARTIFACTS_KV.store.get(publicCodeRunsKvKey)).toBe(
+		JSON.stringify(expectedWindow),
+	)
+})
+
+test('load returns a valid cached triple without writing and ignores v1 JSON', async () => {
+	const cached = {
+		start: 10,
+		end: 20,
+		updateAt: '2026-08-25T00:00:00.000Z',
+	}
+	const cachedEnv = await seededEnv(cached)
+	expect(await loadPublicCodeRunsWindow(cachedEnv, midday)).toEqual(cached)
+	expect(cachedEnv.BUNDLE_ARTIFACTS_KV.store.get(publicCodeRunsKvKey)).toBe(
+		JSON.stringify(cached),
+	)
+
+	const v1 = await createEnv({
+		days: [{ day: '2026-08-23', eventCount: 12 }],
+		window: {
+			previous: 12,
+			current: 12,
+			windowStart: '2026-08-24T00:00:00.000Z',
+			windowEnd: '2026-08-25T00:00:00.000Z',
+		},
 	})
-
-	await env.APP_DB.prepare(
-		`UPDATE usage_rollups SET event_count = 10 WHERE user_id = 'b'`,
-	).run()
-	await expect(
-		refreshPublicCodeRunsWindow({
-			env,
-			now: new Date('2026-08-23T12:01:00.000Z'),
-		}),
-	).resolves.toEqual({ status: 'rotated' })
-	expect(
-		await loadPublicCodeRunsWindow(env, new Date('2026-08-23T12:01:00.000Z')),
-	).toEqual({
-		previous: 50,
-		current: 50,
-		windowStart: '2026-08-23T12:01:00.000Z',
-		windowEnd: '2026-08-24T12:01:00.000Z',
+	expect(await loadPublicCodeRunsWindow(v1, midday)).toEqual({
+		start: 0,
+		end: 12,
+		updateAt: '2026-08-25T00:00:00.000Z',
 	})
 })
 
-test('public code-runs load falls back to D1 and hides when KV fails or there are no runs', async () => {
-	const fallback = await createEnv({
-		rows: [{ userId: 'a', month: '2026-08', eventCount: 12 }],
-	})
-	fallback.BUNDLE_ARTIFACTS_KV.store.clear()
-	expect(
-		await loadPublicCodeRunsWindow(
-			fallback,
-			new Date('2026-08-22T12:00:00.000Z'),
-		),
-	).toMatchObject({ previous: 12, current: 12 })
-
-	const kvDown = await createEnv({
-		rows: [{ userId: 'a', month: '2026-08', eventCount: 12 }],
-	})
+test('public code-runs load hides when KV fails or there are no completed days', async () => {
+	const kvDown = await seededEnv()
 	kvDown.BUNDLE_ARTIFACTS_KV.get = async () => {
 		throw new Error('kv down')
 	}
 	await expect(
-		refreshPublicCodeRunsWindow({
-			env: kvDown,
-			now: new Date('2026-08-22T00:00:00.000Z'),
-		}),
+		refreshPublicCodeRunsWindow({ env: kvDown, now: midday }),
 	).resolves.toEqual({ status: 'skipped', reason: 'kv_read_failed' })
 	expect(kvDown.BUNDLE_ARTIFACTS_KV.store.size).toBe(0)
-	expect(await loadPublicCodeRunsWindow(kvDown)).toBeNull()
+	expect(await loadPublicCodeRunsWindow(kvDown, midday)).toBeNull()
 
 	const empty = await createEnv()
 	await expect(
-		refreshPublicCodeRunsWindow({
-			env: empty,
-			now: new Date('2026-08-22T00:00:00.000Z'),
-		}),
+		refreshPublicCodeRunsWindow({ env: empty, now: midday }),
 	).resolves.toEqual({ status: 'skipped', reason: 'no_runs' })
-	expect(await loadPublicCodeRunsWindow(empty)).toBeNull()
+	expect(await loadPublicCodeRunsWindow(empty, midday)).toBeNull()
+
+	const todayOnly = await createEnv({
+		days: [{ day: '2026-08-24', eventCount: 99 }],
+	})
+	expect(await loadPublicCodeRunsWindow(todayOnly, midday)).toBeNull()
 })
 
-test('public code-runs load continues an expired window without writing KV', async () => {
-	const env = await createEnv({
-		rows: [{ userId: 'a', month: '2026-08', eventCount: 200 }],
-		window: {
-			previous: 100,
-			current: 150,
-			windowStart: '2026-08-21T00:00:00.000Z',
-			windowEnd: '2026-08-22T00:00:00.000Z',
-		},
+test('refresh replaces yesterday’s triple at the next UTC midnight without waiting for cron', async () => {
+	const env = await seededEnv({
+		start: 1030,
+		end: 1060,
+		updateAt: '2026-08-25T00:00:00.000Z',
 	})
-	const loaded = await loadPublicCodeRunsWindow(
-		env,
-		new Date('2026-08-22T02:00:00.000Z'),
-	)
-	expect(loaded).toEqual({
-		previous: 150,
-		current: 200,
-		windowStart: '2026-08-22T00:00:00.000Z',
-		windowEnd: '2026-08-23T00:00:00.000Z',
-	})
-	expect(env.BUNDLE_ARTIFACTS_KV.store.get(publicCodeRunsKvKey)).toBe(
-		JSON.stringify({
-			previous: 100,
-			current: 150,
-			windowStart: '2026-08-21T00:00:00.000Z',
-			windowEnd: '2026-08-22T00:00:00.000Z',
-		}),
-	)
-})
-
-test('public code-runs load continues a still pair from a D1 SUM number, string, or bigint without writing KV', async () => {
-	const stored = {
-		previous: 257940,
-		current: 257940,
-		windowStart: '2026-08-24T17:00:18.000Z',
-		windowEnd: '2026-08-25T17:00:18.000Z',
-	}
-	const now = new Date('2026-08-24T19:26:00.000Z')
-	const continued = {
-		previous: 257940,
-		current: 257941,
-		windowStart: '2026-08-24T19:26:00.000Z',
-		windowEnd: '2026-08-25T19:26:00.000Z',
-	}
-
-	const numeric = await createEnv({
-		rows: [{ userId: 'a', month: '2026-08', eventCount: 257941 }],
-		window: stored,
-	})
-	expect(await loadPublicCodeRunsWindow(numeric, now)).toEqual(continued)
-	expect(numeric.BUNDLE_ARTIFACTS_KV.store.get(publicCodeRunsKvKey)).toBe(
-		JSON.stringify(stored),
-	)
-
-	const stringSum = await createEnv({
-		rows: [{ userId: 'a', month: '2026-08', eventCount: 257941 }],
-		window: stored,
-	})
-	withCoercedExecuteSum(stringSum, String)
-	expect(await loadPublicCodeRunsWindow(stringSum, now)).toEqual(continued)
+	const midnight = new Date('2026-08-25T00:00:00.000Z')
 	await expect(
-		refreshPublicCodeRunsWindow({ env: stringSum, now }),
+		refreshPublicCodeRunsWindow({ env, now: midnight }),
 	).resolves.toEqual({ status: 'rotated' })
-	expect(stringSum.BUNDLE_ARTIFACTS_KV.store.get(publicCodeRunsKvKey)).toBe(
-		JSON.stringify(continued),
-	)
-
-	const bigintSum = await createEnv({
-		rows: [{ userId: 'a', month: '2026-08', eventCount: 257941 }],
-		window: stored,
+	expect(await loadPublicCodeRunsWindow(env, midnight)).toEqual({
+		start: 1060,
+		end: 1159,
+		updateAt: '2026-08-26T00:00:00.000Z',
 	})
-	withCoercedExecuteSum(bigintSum, (total) => BigInt(Number(total)))
-	expect(await loadPublicCodeRunsWindow(bigintSum, now)).toEqual(continued)
 })
 
-test('public code-runs load and refresh reset a still pair when the fleet SUM drops', async () => {
-	const stored = {
-		previous: 257940,
-		current: 257940,
-		windowStart: '2026-08-24T17:00:18.000Z',
-		windowEnd: '2026-08-25T17:00:18.000Z',
+test('a cached regressing triple is served until updateAt', async () => {
+	const regression = {
+		start: 200,
+		end: 150,
+		updateAt: '2026-08-25T00:00:00.000Z',
 	}
-	const now = new Date('2026-08-24T20:15:00.000Z')
-	const reset = {
-		previous: 190213,
-		current: 190213,
-		windowStart: '2026-08-24T20:15:00.000Z',
-		windowEnd: '2026-08-25T20:15:00.000Z',
-	}
-	const env = await createEnv({
-		rows: [{ userId: 'a', month: '2026-08', eventCount: 190213 }],
-		window: stored,
-	})
-	expect(await loadPublicCodeRunsWindow(env, now)).toEqual(reset)
+	const env = await seededEnv(regression)
+	expect(await loadPublicCodeRunsWindow(env, midday)).toEqual(regression)
 	expect(env.BUNDLE_ARTIFACTS_KV.store.get(publicCodeRunsKvKey)).toBe(
-		JSON.stringify(stored),
-	)
-	await expect(refreshPublicCodeRunsWindow({ env, now })).resolves.toEqual({
-		status: 'rotated',
-	})
-	expect(env.BUNDLE_ARTIFACTS_KV.store.get(publicCodeRunsKvKey)).toBe(
-		JSON.stringify(reset),
+		JSON.stringify(regression),
 	)
 })

--- a/packages/worker/src/usage/code-runs-window.node.test.ts
+++ b/packages/worker/src/usage/code-runs-window.node.test.ts
@@ -192,3 +192,27 @@ test('a cached regressing triple is served until updateAt', async () => {
 		JSON.stringify(regression),
 	)
 })
+
+test('a D1 query failure keeps the cached window instead of treating it as empty', async () => {
+	const stale = {
+		start: 90_000,
+		end: 100_000,
+		updateAt: '2026-08-24T00:00:00.000Z',
+	}
+	const env = await seededEnv(stale)
+	env.APP_DB = {
+		prepare() {
+			throw new Error('D1 unavailable')
+		},
+	} as unknown as D1Database
+	await expect(
+		refreshPublicCodeRunsWindow({ env, now: midday }),
+	).resolves.toEqual({
+		status: 'skipped',
+		reason: 'query_failed',
+	})
+	expect(env.BUNDLE_ARTIFACTS_KV.store.get(publicCodeRunsKvKey)).toBe(
+		JSON.stringify(stale),
+	)
+	expect(await loadPublicCodeRunsWindow(env, midday)).toEqual(stale)
+})

--- a/packages/worker/src/usage/code-runs-window.ts
+++ b/packages/worker/src/usage/code-runs-window.ts
@@ -1,13 +1,11 @@
 import {
-	continuePublicCodeRunsWindow,
-	isStillPublicCodeRunsWindow,
 	parsePublicCodeRunsWindow,
-	publicCodeRunsWindowMs,
-	stillPublicCodeRunsWindow,
+	publicCodeRunsWindowsEqual,
 	type PublicCodeRunsWindow,
 } from '#universal/code-runs.ts'
+import { computeDelayedExecuteWindow } from './fleet-execute-days.ts'
 
-export const publicCodeRunsKvKey = 'public-code-runs:v1'
+export const publicCodeRunsKvKey = 'public-code-runs:v2'
 
 type CodeRunsWindowEnv = {
 	APP_DB?: D1Database
@@ -20,20 +18,20 @@ export async function loadPublicCodeRunsWindow(
 ): Promise<PublicCodeRunsWindow | null> {
 	const stored = await readStoredWindow(env)
 	if (stored.status === 'failed') return null
-	if (stored.status === 'found') {
-		const window = stored.window
-		const endMs = Date.parse(window.windowEnd)
-		const expired = Number.isFinite(endMs) && now.getTime() >= endMs
-		if (!expired && !isStillPublicCodeRunsWindow(window)) return window
-		const total = await sumExecuteEventCount(env)
-		if (total === null || total <= 0) return window
-		return (
-			continuePublicCodeRunsWindow({ stored: window, total, now }) ?? window
-		)
+	const cachedUntil =
+		stored.status === 'found' ? Date.parse(stored.window.updateAt) : NaN
+	if (stored.status === 'found' && now.getTime() < cachedUntil) {
+		return stored.window
 	}
-	const total = await sumExecuteEventCount(env)
-	if (total === null || total <= 0) return null
-	return stillPublicCodeRunsWindow(total, now)
+	const computed = await computeWindow(env, now)
+	if (computed && env.BUNDLE_ARTIFACTS_KV) {
+		try {
+			await writeStoredWindow(env.BUNDLE_ARTIFACTS_KV, computed)
+		} catch (error) {
+			console.debug('public-code-runs-window-write-failed', error)
+		}
+	}
+	return computed
 }
 
 export async function refreshPublicCodeRunsWindow(input: {
@@ -50,50 +48,45 @@ export async function refreshPublicCodeRunsWindow(input: {
 	if (!kv) return { status: 'skipped', reason: 'no_kv' }
 	const now = input.now ?? new Date()
 	try {
-		const total = await sumExecuteEventCount(input.env)
-		if (total === null) return { status: 'skipped', reason: 'query_failed' }
-		if (total <= 0) return { status: 'skipped', reason: 'no_runs' }
-
+		if (!input.env.APP_DB) return { status: 'skipped', reason: 'query_failed' }
+		const computed = await computeDelayedExecuteWindow(input.env.APP_DB, now)
 		const existing = await readStoredWindow(input.env)
 		if (existing.status === 'failed') {
 			return { status: 'skipped', reason: 'kv_read_failed' }
 		}
-		if (existing.status === 'missing') {
-			await writeStoredWindow(kv, stillPublicCodeRunsWindow(total, now))
-			return { status: 'initialized' }
+		if (!computed) {
+			if (existing.status === 'found') {
+				try {
+					await kv.delete(publicCodeRunsKvKey)
+				} catch (error) {
+					console.debug('public-code-runs-window-delete-failed', error)
+				}
+			}
+			return { status: 'skipped', reason: 'no_runs' }
 		}
-		const existingWindow = existing.window
-		const still = isStillPublicCodeRunsWindow(existingWindow)
-		const windowEndMs = Date.parse(existingWindow.windowEnd)
-		const beforeEnd =
-			Number.isFinite(windowEndMs) && now.getTime() < windowEndMs
-		const stillGrowing = still && total > existingWindow.current
-		const stillRegressed = still && total < existingWindow.current
-		// A still pair is a bootstrap (KV miss or first write). Holding it
-		// for 24h freezes the homepage ticker even while executes accrue,
-		// and `current = max(total, previous)` latches a stale high-water
-		// mark when the fleet SUM later drops (authoritative AE recompute).
-		// Live windows still hold until windowEnd so interpolation stays
-		// deterministic for every visitor.
-		if (beforeEnd && !stillGrowing && !stillRegressed) {
+		if (
+			existing.status === 'found' &&
+			publicCodeRunsWindowsEqual(existing.window, computed) &&
+			now.getTime() < Date.parse(computed.updateAt)
+		) {
 			return { status: 'held' }
 		}
-		if (total <= existingWindow.current) {
-			await writeStoredWindow(kv, stillPublicCodeRunsWindow(total, now))
-			return { status: 'rotated' }
+		await writeStoredWindow(kv, computed)
+		return {
+			status: existing.status === 'missing' ? 'initialized' : 'rotated',
 		}
-
-		await writeStoredWindow(kv, {
-			previous: existingWindow.current,
-			current: total,
-			windowStart: now.toISOString(),
-			windowEnd: new Date(now.getTime() + publicCodeRunsWindowMs).toISOString(),
-		})
-		return { status: 'rotated' }
 	} catch (error) {
 		console.warn('public-code-runs-window-refresh-failed', error)
 		return { status: 'skipped', reason: 'query_failed' }
 	}
+}
+
+async function computeWindow(
+	env: CodeRunsWindowEnv,
+	now: Date,
+): Promise<PublicCodeRunsWindow | null> {
+	if (!env.APP_DB) return null
+	return computeDelayedExecuteWindow(env.APP_DB, now)
 }
 
 async function readStoredWindow(
@@ -121,37 +114,4 @@ async function writeStoredWindow(
 	window: PublicCodeRunsWindow,
 ) {
 	await kv.put(publicCodeRunsKvKey, JSON.stringify(window))
-}
-
-async function sumExecuteEventCount(
-	env: CodeRunsWindowEnv,
-): Promise<number | null> {
-	if (!env.APP_DB) return null
-	try {
-		const row = await env.APP_DB.prepare(
-			`SELECT COALESCE(SUM(event_count), 0) AS total
-			 FROM usage_rollups
-			 WHERE metric = 'execute'`,
-		).first<{ total: unknown }>()
-		return toNonNegativeCount(row?.total)
-	} catch (error) {
-		console.debug('public-code-runs-sum-failed', error)
-		return null
-	}
-}
-
-/**
- * D1 `SUM` / `COALESCE` can arrive as a number, numeric string, or bigint.
- * Treating anything but `typeof === 'number'` as zero froze the homepage
- * ticker on a still pair even while execute rollups existed.
- */
-function toNonNegativeCount(value: unknown): number {
-	if (typeof value === 'bigint') {
-		if (value < 0n) return 0
-		const parsed = Number(value)
-		return Number.isFinite(parsed) ? Math.floor(parsed) : 0
-	}
-	const parsed = Number(value)
-	if (!Number.isFinite(parsed) || parsed < 0) return 0
-	return Math.floor(parsed)
 }

--- a/packages/worker/src/usage/code-runs-window.ts
+++ b/packages/worker/src/usage/code-runs-window.ts
@@ -24,14 +24,18 @@ export async function loadPublicCodeRunsWindow(
 		return stored.window
 	}
 	const computed = await computeWindow(env, now)
-	if (computed && env.BUNDLE_ARTIFACTS_KV) {
+	if (computed.status === 'failed') {
+		return stored.status === 'found' ? stored.window : null
+	}
+	if (computed.status === 'empty') return null
+	if (env.BUNDLE_ARTIFACTS_KV) {
 		try {
-			await writeStoredWindow(env.BUNDLE_ARTIFACTS_KV, computed)
+			await writeStoredWindow(env.BUNDLE_ARTIFACTS_KV, computed.window)
 		} catch (error) {
 			console.debug('public-code-runs-window-write-failed', error)
 		}
 	}
-	return computed
+	return computed.window
 }
 
 export async function refreshPublicCodeRunsWindow(input: {
@@ -54,7 +58,10 @@ export async function refreshPublicCodeRunsWindow(input: {
 		if (existing.status === 'failed') {
 			return { status: 'skipped', reason: 'kv_read_failed' }
 		}
-		if (!computed) {
+		if (computed.status === 'failed') {
+			return { status: 'skipped', reason: 'query_failed' }
+		}
+		if (computed.status === 'empty') {
 			if (existing.status === 'found') {
 				try {
 					await kv.delete(publicCodeRunsKvKey)
@@ -66,12 +73,12 @@ export async function refreshPublicCodeRunsWindow(input: {
 		}
 		if (
 			existing.status === 'found' &&
-			publicCodeRunsWindowsEqual(existing.window, computed) &&
-			now.getTime() < Date.parse(computed.updateAt)
+			publicCodeRunsWindowsEqual(existing.window, computed.window) &&
+			now.getTime() < Date.parse(computed.window.updateAt)
 		) {
 			return { status: 'held' }
 		}
-		await writeStoredWindow(kv, computed)
+		await writeStoredWindow(kv, computed.window)
 		return {
 			status: existing.status === 'missing' ? 'initialized' : 'rotated',
 		}
@@ -81,11 +88,8 @@ export async function refreshPublicCodeRunsWindow(input: {
 	}
 }
 
-async function computeWindow(
-	env: CodeRunsWindowEnv,
-	now: Date,
-): Promise<PublicCodeRunsWindow | null> {
-	if (!env.APP_DB) return null
+async function computeWindow(env: CodeRunsWindowEnv, now: Date) {
+	if (!env.APP_DB) return { status: 'failed' as const }
 	return computeDelayedExecuteWindow(env.APP_DB, now)
 }
 

--- a/packages/worker/src/usage/fleet-execute-days.node.test.ts
+++ b/packages/worker/src/usage/fleet-execute-days.node.test.ts
@@ -1,0 +1,227 @@
+import { DatabaseSync } from 'node:sqlite'
+import { expect, test, vi } from 'vitest'
+import { createD1FromSqlite } from '#worker/test-support/create-d1-from-sqlite.ts'
+import { ensureUsageRollupsTestSchema } from '#worker/usage/test-schema.ts'
+import {
+	computeDelayedExecuteWindow,
+	syncFleetExecuteDays,
+} from './fleet-execute-days.ts'
+
+async function createDb(input?: {
+	liveUserIds?: Array<string>
+	days?: Array<{ day: string; eventCount: number }>
+	rollups?: Array<{ userId: string; month: string; eventCount: number }>
+}) {
+	const sqlite = new DatabaseSync(':memory:')
+	const db = createD1FromSqlite(sqlite)
+	await ensureUsageRollupsTestSchema(db)
+	await db
+		.prepare(
+			`CREATE TABLE users (
+				stable_user_id TEXT PRIMARY KEY,
+				deleting_at TEXT
+			)`,
+		)
+		.run()
+	for (const userId of input?.liveUserIds ?? []) {
+		await db
+			.prepare(
+				`INSERT INTO users (stable_user_id, deleting_at) VALUES (?, NULL)`,
+			)
+			.bind(userId)
+			.run()
+	}
+	for (const day of input?.days ?? []) {
+		await db
+			.prepare(
+				`INSERT INTO fleet_execute_days (day, event_count, updated_at)
+				VALUES (?, ?, '2026-08-01T00:00:00.000Z')`,
+			)
+			.bind(day.day, day.eventCount)
+			.run()
+	}
+	for (const row of input?.rollups ?? []) {
+		await db
+			.prepare(
+				`INSERT INTO usage_rollups (
+					user_id, metric, month, event_count, error_count,
+					total_duration_ms, total_cpu_ms, total_bytes
+				) VALUES (?, 'execute', ?, ?, 0, 0, 0, 0)`,
+			)
+			.bind(row.userId, row.month, row.eventCount)
+			.run()
+	}
+	return db
+}
+
+function createEnv(db: D1Database) {
+	return {
+		USAGE_EVENTS: { writeDataPoint() {} },
+		APP_DB: db,
+		CLOUDFLARE_ACCOUNT_ID: 'account-1',
+		CLOUDFLARE_API_TOKEN: 'token-1',
+	}
+}
+
+function stubFetchByQuery(
+	handlers: Array<{ test: (query: string) => boolean; body: unknown }>,
+) {
+	const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+		const query = String(init?.body ?? '')
+		const match = handlers.find((handler) => handler.test(query))
+		return new Response(JSON.stringify(match?.body ?? { data: [] }), {
+			status: 200,
+		})
+	})
+	vi.stubGlobal('fetch', fetchMock)
+	return Object.assign(fetchMock, {
+		[Symbol.dispose]() {
+			vi.unstubAllGlobals()
+		},
+	})
+}
+
+function augustAndJulyBodies(input: { august?: unknown; july?: unknown }) {
+	return stubFetchByQuery([
+		{
+			test: (query) => query.includes("toDateTime('2026-09-01 00:00:00')"),
+			body: input.august ?? { data: [] },
+		},
+		{
+			test: (query) => query.includes("toDateTime('2026-07-01 00:00:00')"),
+			body: input.july ?? { data: [] },
+		},
+	])
+}
+
+async function listDays(db: D1Database) {
+	const { results } = await db
+		.prepare(`SELECT day, event_count FROM fleet_execute_days ORDER BY day`)
+		.all<{ day: string; event_count: number }>()
+	return results
+}
+
+test('syncFleetExecuteDays no-ops without Analytics Engine credentials', async () => {
+	using fetchMock = stubFetchByQuery([])
+	const db = await createDb()
+	await expect(
+		syncFleetExecuteDays({ APP_DB: db }, new Date('2026-08-24T20:00:00.000Z')),
+	).resolves.toEqual({ skipped: true, reason: 'missing-analytics-config' })
+	expect(fetchMock).not.toHaveBeenCalled()
+	expect(await listDays(db)).toEqual([])
+})
+
+test('syncFleetExecuteDays upserts live execute days and ignores deleted users', async () => {
+	using fetchMock = augustAndJulyBodies({
+		august: {
+			data: [
+				{ user_id: 'user-live', day: '2026-08-23', event_count: 10 },
+				{ user_id: 'user-live', day: '2026-08-24', event_count: 4 },
+				{ user_id: 'user-gone', day: '2026-08-23', event_count: 99 },
+			],
+		},
+		july: {
+			data: [{ user_id: 'user-live', day: '2026-07-31', event_count: 7 }],
+		},
+	})
+	const db = await createDb({ liveUserIds: ['user-live'] })
+	await expect(
+		syncFleetExecuteDays(createEnv(db), new Date('2026-08-24T20:00:00.000Z')),
+	).resolves.toEqual({ skipped: false, upsertedDays: 3, deletedDays: 0 })
+	expect(fetchMock).toHaveBeenCalledTimes(2)
+	expect(String(fetchMock.mock.calls[0]?.[1]?.body)).toContain(
+		"blob2 = 'execute'",
+	)
+	expect(await listDays(db)).toEqual([
+		{ day: '2026-07-31', event_count: 7 },
+		{ day: '2026-08-23', event_count: 10 },
+		{ day: '2026-08-24', event_count: 4 },
+	])
+})
+
+test('syncFleetExecuteDays does not wipe a month when Analytics Engine returns nothing', async () => {
+	using _fetchMock = augustAndJulyBodies({})
+	const db = await createDb({
+		liveUserIds: ['user-live'],
+		days: [
+			{ day: '2026-08-22', eventCount: 12 },
+			{ day: '2026-07-30', eventCount: 3 },
+		],
+	})
+	await expect(
+		syncFleetExecuteDays(createEnv(db), new Date('2026-08-24T20:00:00.000Z')),
+	).resolves.toEqual({ skipped: false, upsertedDays: 0, deletedDays: 0 })
+	expect(await listDays(db)).toEqual([
+		{ day: '2026-07-30', event_count: 3 },
+		{ day: '2026-08-22', event_count: 12 },
+	])
+})
+
+test('syncFleetExecuteDays deletes days absent from a non-empty month result', async () => {
+	using _fetchMock = augustAndJulyBodies({
+		august: {
+			data: [{ user_id: 'user-live', day: '2026-08-23', event_count: 8 }],
+		},
+	})
+	const db = await createDb({
+		liveUserIds: ['user-live'],
+		days: [
+			{ day: '2026-08-22', eventCount: 12 },
+			{ day: '2026-08-23', eventCount: 1 },
+			{ day: '2026-07-30', eventCount: 3 },
+		],
+	})
+	await expect(
+		syncFleetExecuteDays(createEnv(db), new Date('2026-08-24T20:00:00.000Z')),
+	).resolves.toEqual({ skipped: false, upsertedDays: 1, deletedDays: 1 })
+	expect(await listDays(db)).toEqual([
+		{ day: '2026-07-30', event_count: 3 },
+		{ day: '2026-08-23', event_count: 8 },
+	])
+})
+
+test('computeDelayedExecuteWindow sums older monthly rollups plus completed days', async () => {
+	const db = await createDb({
+		rollups: [
+			{ userId: 'a', month: '2026-06', eventCount: 100 },
+			{ userId: 'a', month: '2026-07', eventCount: 40 },
+			{ userId: 'a', month: '2026-08', eventCount: 999 },
+		],
+		days: [
+			{ day: '2026-07-31', eventCount: 5 },
+			{ day: '2026-08-22', eventCount: 20 },
+			{ day: '2026-08-23', eventCount: 30 },
+			{ day: '2026-08-24', eventCount: 99 },
+		],
+	})
+	expect(
+		await computeDelayedExecuteWindow(db, new Date('2026-08-24T15:00:00.000Z')),
+	).toEqual({
+		start: 125,
+		end: 155,
+		updateAt: '2026-08-25T00:00:00.000Z',
+	})
+	expect(
+		await computeDelayedExecuteWindow(db, new Date('2026-08-25T00:00:00.000Z')),
+	).toEqual({
+		start: 155,
+		end: 254,
+		updateAt: '2026-08-26T00:00:00.000Z',
+	})
+	expect(
+		await computeDelayedExecuteWindow(db, new Date('2026-08-24T15:00:00.000Z')),
+	).toEqual({
+		start: 125,
+		end: 155,
+		updateAt: '2026-08-25T00:00:00.000Z',
+	})
+})
+
+test('computeDelayedExecuteWindow hides when the daily table is empty', async () => {
+	const db = await createDb({
+		rollups: [{ userId: 'a', month: '2026-07', eventCount: 40 }],
+	})
+	expect(
+		await computeDelayedExecuteWindow(db, new Date('2026-08-24T15:00:00.000Z')),
+	).toBeNull()
+})

--- a/packages/worker/src/usage/fleet-execute-days.node.test.ts
+++ b/packages/worker/src/usage/fleet-execute-days.node.test.ts
@@ -197,23 +197,32 @@ test('computeDelayedExecuteWindow sums older monthly rollups plus completed days
 	expect(
 		await computeDelayedExecuteWindow(db, new Date('2026-08-24T15:00:00.000Z')),
 	).toEqual({
-		start: 125,
-		end: 155,
-		updateAt: '2026-08-25T00:00:00.000Z',
+		status: 'ready',
+		window: {
+			start: 125,
+			end: 155,
+			updateAt: '2026-08-25T00:00:00.000Z',
+		},
 	})
 	expect(
 		await computeDelayedExecuteWindow(db, new Date('2026-08-25T00:00:00.000Z')),
 	).toEqual({
-		start: 155,
-		end: 254,
-		updateAt: '2026-08-26T00:00:00.000Z',
+		status: 'ready',
+		window: {
+			start: 155,
+			end: 254,
+			updateAt: '2026-08-26T00:00:00.000Z',
+		},
 	})
 	expect(
 		await computeDelayedExecuteWindow(db, new Date('2026-08-24T15:00:00.000Z')),
 	).toEqual({
-		start: 125,
-		end: 155,
-		updateAt: '2026-08-25T00:00:00.000Z',
+		status: 'ready',
+		window: {
+			start: 125,
+			end: 155,
+			updateAt: '2026-08-25T00:00:00.000Z',
+		},
 	})
 })
 
@@ -223,5 +232,16 @@ test('computeDelayedExecuteWindow hides when the daily table is empty', async ()
 	})
 	expect(
 		await computeDelayedExecuteWindow(db, new Date('2026-08-24T15:00:00.000Z')),
-	).toBeNull()
+	).toEqual({ status: 'empty' })
+})
+
+test('computeDelayedExecuteWindow reports failed when D1 throws instead of empty', async () => {
+	const db = {
+		prepare() {
+			throw new Error('D1 unavailable')
+		},
+	} as unknown as D1Database
+	expect(
+		await computeDelayedExecuteWindow(db, new Date('2026-08-24T15:00:00.000Z')),
+	).toEqual({ status: 'failed' })
 })

--- a/packages/worker/src/usage/fleet-execute-days.ts
+++ b/packages/worker/src/usage/fleet-execute-days.ts
@@ -1,0 +1,313 @@
+/**
+ * Fleet-wide UTC-day `execute` counts for the homepage ticker.
+ *
+ * Production/preview: the hourly `usage_aggregation` lane queries Analytics
+ * Engine for the current and previous UTC months and upserts absolute daily
+ * totals after the same live-user filter as monthly rollups. An empty month
+ * result does not wipe existing days (ingestion lag). A non-empty result is
+ * authoritative for that month.
+ *
+ * Local dev / tests (no `USAGE_EVENTS`): `recordUsage` increments today's
+ * row per execute event. This module is a no-op without AE credentials.
+ *
+ * The public ticker never reads today — only completed UTC days.
+ */
+
+import { runD1WithRetry } from '#worker/d1-retry.ts'
+import {
+	filterLiveUsageRows,
+	queryAnalyticsEngineSql,
+	resolveUsageEventsDataset,
+	type UsageAggregationEnv,
+} from './aggregate-rollups.ts'
+import {
+	parsePublicCodeRunsWindow,
+	type PublicCodeRunsWindow,
+} from '#universal/code-runs.ts'
+
+const upsertBatchSize = 50
+const deleteStatementDayLimit = 80
+
+const fleetExecuteDayUpsertStatement = `
+INSERT INTO fleet_execute_days (day, event_count, updated_at)
+VALUES (?1, ?2, ?3)
+ON CONFLICT (day) DO UPDATE SET
+	event_count = excluded.event_count,
+	updated_at = excluded.updated_at
+`.trim()
+
+type FleetExecuteDayRow = {
+	user_id: string
+	day: string
+	event_count: number | string
+}
+
+export type FleetExecuteDaysSyncResult =
+	| { skipped: true; reason: string }
+	| {
+			skipped: false
+			upsertedDays: number
+			deletedDays: number
+	  }
+
+export async function syncFleetExecuteDays(
+	env: UsageAggregationEnv,
+	now: Date = new Date(),
+): Promise<FleetExecuteDaysSyncResult> {
+	const accountId = env.CLOUDFLARE_ACCOUNT_ID?.trim()
+	const apiToken = env.CLOUDFLARE_API_TOKEN?.trim()
+	if (!env.USAGE_EVENTS || !accountId || !apiToken) {
+		console.debug(
+			'fleet-execute-days-sync-skipped',
+			'missing USAGE_EVENTS binding or Cloudflare REST credentials',
+		)
+		return { skipped: true, reason: 'missing-analytics-config' }
+	}
+
+	const baseUrl =
+		env.CLOUDFLARE_API_BASE_URL?.trim() || 'https://api.cloudflare.com'
+	const dataset = resolveUsageEventsDataset(env)
+	const currentMonth = utcMonthStart(now)
+	const priorMonth = utcMonthStart(
+		new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - 1, 15)),
+	)
+	const [currentRows, previousRows] = await Promise.all([
+		queryAnalyticsEngineSql<FleetExecuteDayRow>({
+			accountId,
+			apiToken,
+			baseUrl,
+			query: buildMonthExecuteDaysQuery(dataset, utcMonthBounds(now)),
+		}),
+		queryAnalyticsEngineSql<FleetExecuteDayRow>({
+			accountId,
+			apiToken,
+			baseUrl,
+			query: buildMonthExecuteDaysQuery(dataset, utcMonthBounds(priorMonth)),
+		}),
+	])
+
+	const updatedAt = now.toISOString()
+	let upsertedDays = 0
+	let deletedDays = 0
+	for (const [monthStart, rows] of [
+		[currentMonth, currentRows],
+		[priorMonth, previousRows],
+	] as const) {
+		if (rows.length === 0) continue
+		const monthPrefix = utcDayString(monthStart).slice(0, 7)
+		const liveRows = await filterLiveUsageRows(env.APP_DB, rows)
+		const byDay = new Map<string, number>()
+		for (const row of liveRows) {
+			const day = normalizeUtcDay(row.day)
+			if (!day || !day.startsWith(monthPrefix)) continue
+			byDay.set(
+				day,
+				(byDay.get(day) ?? 0) + toNonNegativeCount(row.event_count),
+			)
+		}
+		upsertedDays += await upsertFleetExecuteDays({
+			db: env.APP_DB,
+			byDay,
+			updatedAt,
+		})
+		deletedDays += await deleteStaleFleetExecuteDays({
+			db: env.APP_DB,
+			monthStart,
+			presentDays: new Set(byDay.keys()),
+		})
+	}
+
+	const result = {
+		skipped: false as const,
+		upsertedDays,
+		deletedDays,
+	}
+	console.info('fleet-execute-days-sync', JSON.stringify(result))
+	return result
+}
+
+export async function computeDelayedExecuteWindow(
+	db: D1Database,
+	now: Date,
+): Promise<PublicCodeRunsWindow | null> {
+	try {
+		const oldest = await db
+			.prepare(`SELECT MIN(day) AS oldest FROM fleet_execute_days`)
+			.first<{ oldest: string | null }>()
+		const oldestDay = normalizeUtcDay(oldest?.oldest)
+		if (!oldestDay) return null
+
+		const today = utcDayString(now)
+		const yesterday = addUtcDays(today, -1)
+		const dayBeforeYesterday = addUtcDays(today, -2)
+		const prefixMonth = oldestDay.slice(0, 7)
+		const prefix = await sumExecuteRollupsBeforeMonth(db, prefixMonth)
+		const start =
+			prefix + (await sumFleetExecuteDaysThrough(db, dayBeforeYesterday))
+		const end = prefix + (await sumFleetExecuteDaysThrough(db, yesterday))
+		if (start === 0 && end === 0) return null
+		return parsePublicCodeRunsWindow({
+			start,
+			end,
+			updateAt: nextUtcMidnight(now).toISOString(),
+		})
+	} catch (error) {
+		console.debug('fleet-execute-days-window-failed', error)
+		return null
+	}
+}
+
+async function upsertFleetExecuteDays(input: {
+	db: D1Database
+	byDay: Map<string, number>
+	updatedAt: string
+}) {
+	const statements = [...input.byDay.entries()].map(([day, eventCount]) =>
+		input.db
+			.prepare(fleetExecuteDayUpsertStatement)
+			.bind(day, eventCount, input.updatedAt),
+	)
+	for (let index = 0; index < statements.length; index += upsertBatchSize) {
+		await runD1WithRetry(() =>
+			input.db.batch(statements.slice(index, index + upsertBatchSize)),
+		)
+	}
+	return statements.length
+}
+
+async function deleteStaleFleetExecuteDays(input: {
+	db: D1Database
+	monthStart: Date
+	presentDays: ReadonlySet<string>
+}) {
+	const monthEnd = new Date(
+		Date.UTC(
+			input.monthStart.getUTCFullYear(),
+			input.monthStart.getUTCMonth() + 1,
+			1,
+		),
+	)
+	const { results } = await runD1WithRetry(() =>
+		input.db
+			.prepare(
+				`SELECT day FROM fleet_execute_days
+				WHERE day >= ?1 AND day < ?2`,
+			)
+			.bind(utcDayString(input.monthStart), utcDayString(monthEnd))
+			.all<{ day: string }>(),
+	)
+	const staleDays = (results ?? [])
+		.map((row) => normalizeUtcDay(row.day))
+		.filter((day): day is string => day !== null && !input.presentDays.has(day))
+	let deleted = 0
+	for (
+		let index = 0;
+		index < staleDays.length;
+		index += deleteStatementDayLimit
+	) {
+		const chunk = staleDays.slice(index, index + deleteStatementDayLimit)
+		const placeholders = chunk.map(() => '?').join(', ')
+		const result = await runD1WithRetry(() =>
+			input.db
+				.prepare(
+					`DELETE FROM fleet_execute_days WHERE day IN (${placeholders})`,
+				)
+				.bind(...chunk)
+				.run(),
+		)
+		deleted += result.meta.changes ?? 0
+	}
+	return deleted
+}
+
+async function sumExecuteRollupsBeforeMonth(db: D1Database, month: string) {
+	const row = await db
+		.prepare(
+			`SELECT COALESCE(SUM(event_count), 0) AS total
+			 FROM usage_rollups
+			 WHERE metric = 'execute' AND month < ?1`,
+		)
+		.bind(month)
+		.first<{ total: unknown }>()
+	return toNonNegativeCount(row?.total)
+}
+
+async function sumFleetExecuteDaysThrough(db: D1Database, day: string) {
+	const row = await db
+		.prepare(
+			`SELECT COALESCE(SUM(event_count), 0) AS total
+			 FROM fleet_execute_days
+			 WHERE day <= ?1`,
+		)
+		.bind(day)
+		.first<{ total: unknown }>()
+	return toNonNegativeCount(row?.total)
+}
+
+function buildMonthExecuteDaysQuery(
+	dataset: string,
+	bounds: { monthStart: string; nextMonthStart: string },
+) {
+	return `
+SELECT
+	blob1 AS user_id,
+	toDate(timestamp) AS day,
+	sum(_sample_interval) AS event_count
+FROM ${dataset}
+WHERE blob2 = 'execute'
+	AND timestamp >= toDateTime('${bounds.monthStart}')
+	AND timestamp < toDateTime('${bounds.nextMonthStart}')
+GROUP BY blob1, day
+FORMAT JSON
+`.trim()
+}
+
+function utcMonthBounds(now: Date) {
+	const toDateTimeArgument = (date: Date) =>
+		`${date.toISOString().slice(0, 'YYYY-MM-DD'.length)} 00:00:00`
+	return {
+		monthStart: toDateTimeArgument(utcMonthStart(now)),
+		nextMonthStart: toDateTimeArgument(
+			new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1)),
+		),
+	}
+}
+
+function utcMonthStart(now: Date) {
+	return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1))
+}
+
+function utcDayString(date: Date) {
+	return date.toISOString().slice(0, 'YYYY-MM-DD'.length)
+}
+
+function addUtcDays(day: string, delta: number) {
+	const [year, month, date] = day.split('-').map(Number)
+	return new Date(Date.UTC(year ?? 1970, (month ?? 1) - 1, (date ?? 1) + delta))
+		.toISOString()
+		.slice(0, 'YYYY-MM-DD'.length)
+}
+
+function nextUtcMidnight(now: Date) {
+	return new Date(
+		Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + 1),
+	)
+}
+
+function normalizeUtcDay(value: unknown): string | null {
+	if (typeof value !== 'string') return null
+	const day = value.slice(0, 'YYYY-MM-DD'.length)
+	if (!/^\d{4}-\d{2}-\d{2}$/.test(day)) return null
+	return day
+}
+
+export function toNonNegativeCount(value: unknown): number {
+	if (typeof value === 'bigint') {
+		if (value < 0n) return 0
+		const parsed = Number(value)
+		return Number.isFinite(parsed) ? Math.floor(parsed) : 0
+	}
+	const parsed = Number(value)
+	if (!Number.isFinite(parsed) || parsed < 0) return 0
+	return Math.floor(parsed)
+}

--- a/packages/worker/src/usage/fleet-execute-days.ts
+++ b/packages/worker/src/usage/fleet-execute-days.ts
@@ -126,16 +126,21 @@ export async function syncFleetExecuteDays(
 	return result
 }
 
+export type DelayedExecuteWindowResult =
+	| { status: 'ready'; window: PublicCodeRunsWindow }
+	| { status: 'empty' }
+	| { status: 'failed' }
+
 export async function computeDelayedExecuteWindow(
 	db: D1Database,
 	now: Date,
-): Promise<PublicCodeRunsWindow | null> {
+): Promise<DelayedExecuteWindowResult> {
 	try {
 		const oldest = await db
 			.prepare(`SELECT MIN(day) AS oldest FROM fleet_execute_days`)
 			.first<{ oldest: string | null }>()
 		const oldestDay = normalizeUtcDay(oldest?.oldest)
-		if (!oldestDay) return null
+		if (!oldestDay) return { status: 'empty' }
 
 		const today = utcDayString(now)
 		const yesterday = addUtcDays(today, -1)
@@ -145,15 +150,16 @@ export async function computeDelayedExecuteWindow(
 		const start =
 			prefix + (await sumFleetExecuteDaysThrough(db, dayBeforeYesterday))
 		const end = prefix + (await sumFleetExecuteDaysThrough(db, yesterday))
-		if (start === 0 && end === 0) return null
-		return parsePublicCodeRunsWindow({
+		if (start === 0 && end === 0) return { status: 'empty' }
+		const window = parsePublicCodeRunsWindow({
 			start,
 			end,
 			updateAt: nextUtcMidnight(now).toISOString(),
 		})
+		return window ? { status: 'ready', window } : { status: 'failed' }
 	} catch (error) {
 		console.debug('fleet-execute-days-window-failed', error)
-		return null
+		return { status: 'failed' }
 	}
 }
 

--- a/packages/worker/src/usage/record-usage.ts
+++ b/packages/worker/src/usage/record-usage.ts
@@ -16,7 +16,9 @@
  *   would serialize every metered request on D1's single writer.
  * - When `USAGE_EVENTS` is absent (local dev, tests), the event is upserted
  *   directly into `usage_rollups` so local admin pages and tests work without
- *   Analytics Engine access.
+ *   Analytics Engine access. `execute` events also increment today's
+ *   `fleet_execute_days` row for the homepage ticker. `execute` events also increment today's
+ *   `fleet_execute_days` row for the homepage ticker.
  *
  * `recordUsage` never throws and never rejects; metering must not break the
  * paths it observes. In local dev and tests where a binding is missing it
@@ -87,6 +89,14 @@ ON CONFLICT (user_id, metric, month) DO UPDATE SET
 	updated_at = excluded.updated_at
 `.trim()
 
+const fleetExecuteDayUpsertStatement = `
+INSERT INTO fleet_execute_days (day, event_count, updated_at)
+VALUES (?1, 1, ?2)
+ON CONFLICT (day) DO UPDATE SET
+	event_count = event_count + 1,
+	updated_at = excluded.updated_at
+`.trim()
+
 /**
  * Record one usage event.
  *
@@ -120,6 +130,7 @@ export async function recordUsage(
 		}
 		console.debug('usage-event-local', JSON.stringify({ ...event, timestamp }))
 		await writeUsageRollup(env, event, timestamp)
+		await writeLocalFleetExecuteDay(env, event, timestamp)
 	} catch (error) {
 		console.warn('usage-event-record-failed', error)
 	}
@@ -196,5 +207,21 @@ async function writeUsageRollup(
 			.run()
 	} catch (error) {
 		console.warn('usage-rollup-failed', error)
+	}
+}
+
+async function writeLocalFleetExecuteDay(
+	env: UsageEnv,
+	event: UsageEvent,
+	timestamp: string,
+) {
+	if (event.eventType !== 'execute') return
+	if (!env.APP_DB) return
+	try {
+		await env.APP_DB.prepare(fleetExecuteDayUpsertStatement)
+			.bind(timestamp.slice(0, 10), timestamp)
+			.run()
+	} catch (error) {
+		console.warn('usage-fleet-execute-day-failed', error)
 	}
 }

--- a/packages/worker/src/usage/record-usage.workers.test.ts
+++ b/packages/worker/src/usage/record-usage.workers.test.ts
@@ -4,6 +4,13 @@ import { recordUsage } from './record-usage.ts'
 import { ensureUsageRollupsTestSchema } from './test-schema.ts'
 import { consoleWarn } from '#worker/test-support/console-spies.ts'
 
+async function listFleetDays(db: D1Database) {
+	const { results } = await db
+		.prepare(`SELECT day, event_count FROM fleet_execute_days ORDER BY day`)
+		.all()
+	return results
+}
+
 async function listRollups(db: D1Database, userId: string) {
 	const { results } = await db
 		.prepare(
@@ -72,6 +79,7 @@ test('recordUsage writes only Analytics Engine data points when USAGE_EVENTS is 
 	// hourly aggregation cron, never written per event.
 	expect(await listRollups(env.APP_DB, userA)).toEqual([])
 	expect(await listRollups(env.APP_DB, userB)).toEqual([])
+	expect(await listFleetDays(env.APP_DB)).toEqual([])
 })
 
 test('recordUsage accumulates per-user monthly rollups without USAGE_EVENTS (local dev)', async () => {
@@ -146,6 +154,9 @@ test('recordUsage accumulates per-user monthly rollups without USAGE_EVENTS (loc
 			total_cpu_ms: 0,
 			total_bytes: 0,
 		},
+	])
+	expect(await listFleetDays(env.APP_DB)).toEqual([
+		{ day: '2026-07-05', event_count: 3 },
 	])
 })
 

--- a/packages/worker/src/usage/test-schema.ts
+++ b/packages/worker/src/usage/test-schema.ts
@@ -1,6 +1,5 @@
 /**
- * Mirrors the `usage_rollups` schema in
- * `packages/worker/migrations/0001-squashed-init.sql` for
+ * Mirrors the `usage_rollups` and `fleet_execute_days` schemas for
  * `*.workers.test.ts` suites, which run against a local D1 database without
  * applying migrations.
  */
@@ -21,6 +20,12 @@ export async function ensureUsageRollupsTestSchema(db: D1Database) {
 );`,
 		`CREATE INDEX idx_usage_rollups_user_month
 ON usage_rollups(user_id, month);`,
+		`DROP TABLE IF EXISTS fleet_execute_days;`,
+		`CREATE TABLE fleet_execute_days (
+	day TEXT PRIMARY KEY NOT NULL,
+	event_count INTEGER NOT NULL,
+	updated_at TEXT NOT NULL
+);`,
 	]
 	for (const statement of statements) {
 		await db.prepare(statement).run()

--- a/packages/worker/universal/code-runs.node.test.ts
+++ b/packages/worker/universal/code-runs.node.test.ts
@@ -4,10 +4,10 @@ import {
 	codeRunsCatchUpSnapAfterMs,
 	codeRunsHonestySlotMs,
 	codeRunsProgressToNext,
-	continuePublicCodeRunsWindow,
 	formatCodeRunsCount,
 	interpolateCodeRunsCount,
 	isStillPublicCodeRunsWindow,
+	msUntilCodeRunsWindowRefresh,
 	msUntilNextCodeRunsCount,
 	msUntilNextCodeRunsPaint,
 	nextDisplayedCodeRunsCount,
@@ -15,16 +15,14 @@ import {
 	publicCodeRunsWindowsEqual,
 } from './code-runs.ts'
 
-const windowStart = '2026-08-21T00:00:00.000Z'
-const windowEnd = '2026-08-22T00:00:00.000Z'
-const startMs = Date.parse(windowStart)
+const updateAt = '2026-08-22T00:00:00.000Z'
+const startMs = Date.parse(updateAt) - 24 * 60 * 60 * 1000
 const hourMs = 60 * 60 * 1000
 
 const window = {
-	previous: 1000,
-	current: 1240,
-	windowStart,
-	windowEnd,
+	start: 1000,
+	end: 1240,
+	updateAt,
 }
 
 test('interpolateCodeRunsCount stays monotonic, warped, and holds at bounds', () => {
@@ -52,53 +50,52 @@ test('interpolateCodeRunsCount stays monotonic, warped, and holds at bounds', ()
 	const busiest = Math.max(...hourlyDeltas)
 	expect(busiest).toBeGreaterThan(quietest)
 	expect(interpolateCodeRunsCount(window, startMs + 12 * hourMs)).not.toBe(1120)
-	const firstPair = { ...window, previous: 0, current: 1_000_000 }
-	const secondPair = { ...firstPair, previous: 100, current: 1_000_100 }
+	const firstPair = { ...window, start: 0, end: 1_000_000 }
+	const secondPair = { ...firstPair, start: 100, end: 1_000_100 }
 	const sampleMs = startMs + 6 * hourMs
 	expect(
-		interpolateCodeRunsCount(firstPair, sampleMs) - firstPair.previous,
-	).not.toBe(
-		interpolateCodeRunsCount(secondPair, sampleMs) - secondPair.previous,
-	)
+		interpolateCodeRunsCount(firstPair, sampleMs) - firstPair.start,
+	).not.toBe(interpolateCodeRunsCount(secondPair, sampleMs) - secondPair.start)
 
 	const offset = {
 		...window,
-		previous: 171540,
-		current: 257940,
-		windowStart: '2026-08-22T15:47:07.637Z',
-		windowEnd: '2026-08-23T15:47:07.637Z',
+		start: 171540,
+		end: 257940,
+		updateAt: '2026-08-23T15:47:07.637Z',
 	}
-	const endMs = Date.parse(offset.windowEnd)
+	const endMs = Date.parse(offset.updateAt)
 	expect(interpolateCodeRunsCount(offset, endMs - 1)).toBeLessThan(257940)
 	expect(interpolateCodeRunsCount(offset, endMs)).toBe(257940)
 	expect(interpolateCodeRunsCount(offset, endMs + 1000)).toBe(257940)
 	expect(
 		interpolateCodeRunsCount(
-			{ ...window, previous: 80, current: 80 },
+			{ ...window, start: 80, end: 80 },
 			startMs + 6 * hourMs,
 		),
 	).toBe(80)
 
 	expect(parsePublicCodeRunsWindow(window)).toEqual(window)
-	expect(parsePublicCodeRunsWindow({ ...window, current: 900 })).toEqual({
+	expect(parsePublicCodeRunsWindow({ ...window, end: 900 })).toEqual({
 		...window,
-		current: 1000,
+		end: 900,
 	})
-	expect(parsePublicCodeRunsWindow({ ...window, previous: -1 })).toBeNull()
-	expect(parsePublicCodeRunsWindow({ ...window, windowEnd: windowStart })).toBe(
-		null,
-	)
+	expect(parsePublicCodeRunsWindow({ ...window, start: -1 })).toBeNull()
+	expect(
+		parsePublicCodeRunsWindow({ ...window, updateAt: 'not-a-date' }),
+	).toBeNull()
 	expect(
 		parsePublicCodeRunsWindow({
-			...window,
-			windowEnd: '2026-08-21T12:00:00.000Z',
+			previous: 1000,
+			current: 1240,
+			windowStart: '2026-08-21T00:00:00.000Z',
+			windowEnd: '2026-08-22T00:00:00.000Z',
 		}),
 	).toBeNull()
 	expect(parsePublicCodeRunsWindow(null)).toBeNull()
 })
 
 test('interpolateCodeRunsCount wobbles +1 ticks without long idle when the pair is dense', () => {
-	const busy = { ...window, previous: 0, current: 86_400 }
+	const busy = { ...window, start: 0, end: 86_400 }
 	const gaps: Array<number> = []
 	let previous = interpolateCodeRunsCount(busy, startMs)
 	let at = startMs
@@ -138,16 +135,16 @@ test('interpolateCodeRunsCount wobbles +1 ticks without long idle when the pair 
 	expect(interpolateCodeRunsCount(busy, nowMs + wait!)).toBe(here + 1)
 	expect(msUntilNextCodeRunsCount(busy, startMs + 24 * hourMs)).toBeNull()
 	expect(
-		msUntilNextCodeRunsCount({ ...window, previous: 80, current: 80 }, nowMs),
+		msUntilNextCodeRunsCount({ ...window, start: 80, end: 80 }, nowMs),
 	).toBeNull()
-	expect(
-		isStillPublicCodeRunsWindow({ ...window, previous: 80, current: 80 }),
-	).toBe(true)
+	expect(isStillPublicCodeRunsWindow({ ...window, start: 80, end: 80 })).toBe(
+		true,
+	)
 	expect(isStillPublicCodeRunsWindow(window)).toBe(false)
 })
 
 test('interpolateCodeRunsCount rolls every extra integer inside a second', () => {
-	const packed = { ...window, previous: 0, current: 86_400 * 5 }
+	const packed = { ...window, start: 0, end: 86_400 * 5 }
 	const midSecond = startMs + 6 * hourMs
 	const seen = new Set<number>()
 	const offsets: Array<number> = []
@@ -172,7 +169,7 @@ test('interpolateCodeRunsCount rolls every extra integer inside a second', () =>
 	const even = 1000 / offsets.length
 	expect(gaps.some((gap) => Math.abs(gap - even) > 30)).toBe(true)
 
-	const dense = { ...window, previous: 0, current: 86_400 * 50 }
+	const dense = { ...window, start: 0, end: 86_400 * 50 }
 	const denseStart = startMs + 6 * hourMs
 	let densePrevious = interpolateCodeRunsCount(dense, denseStart - 1)
 	for (let offset = 0; offset < 30_000; offset += 1) {
@@ -249,7 +246,7 @@ test('displayed code-runs catch-up snaps after a freeze and stays under the snap
 
 test('a 3-second backbone never waits longer than the honesty slot when budget allows', () => {
 	const slots = (24 * 60 * 60 * 1000) / codeRunsHonestySlotMs
-	const honest = { ...window, previous: 0, current: slots }
+	const honest = { ...window, start: 0, end: slots }
 	const gaps: Array<number> = []
 	let at = startMs
 	let previous = interpolateCodeRunsCount(honest, at)
@@ -274,7 +271,7 @@ test('a 3-second backbone never waits longer than the honesty slot when budget a
 })
 
 test('thin windows move progress instead of inventing integers', () => {
-	const thin = { ...window, previous: 10, current: 20 }
+	const thin = { ...window, start: 10, end: 20 }
 	const nowMs = startMs + 6 * hourMs
 	const wait = msUntilNextCodeRunsCount(thin, nowMs)
 	expect(wait).not.toBeNull()
@@ -284,71 +281,33 @@ test('thin windows move progress instead of inventing integers', () => {
 	expect(frac).toBeGreaterThan(0)
 	expect(frac).toBeLessThan(1)
 	expect(codeRunsProgressToNext(thin, nowMs + 3_000)).toBeGreaterThan(frac)
-	expect(
-		codeRunsProgressToNext({ ...window, previous: 80, current: 80 }, nowMs),
-	).toBe(0)
+	expect(codeRunsProgressToNext({ ...window, start: 80, end: 80 }, nowMs)).toBe(
+		0,
+	)
 })
 
-test('continuePublicCodeRunsWindow unsticks still and expired pairs without writing', () => {
-	const now = new Date('2026-08-21T12:00:00.000Z')
-	const still = {
-		previous: 100,
-		current: 100,
-		windowStart: '2026-08-21T00:00:00.000Z',
-		windowEnd: '2026-08-22T00:00:00.000Z',
-	}
+test('a regressing end shows immediately and refresh waits until updateAt', () => {
+	const still = { start: 100, end: 100, updateAt }
 	expect(publicCodeRunsWindowsEqual(still, still)).toBe(true)
-	expect(publicCodeRunsWindowsEqual(still, { ...still, current: 101 })).toBe(
-		false,
+	expect(publicCodeRunsWindowsEqual(still, { ...still, end: 101 })).toBe(false)
+	expect(isStillPublicCodeRunsWindow({ start: 200, end: 150, updateAt })).toBe(
+		true,
 	)
 	expect(
-		continuePublicCodeRunsWindow({ stored: still, total: 100, now }),
+		interpolateCodeRunsCount(
+			{ start: 200, end: 150, updateAt },
+			startMs + 6 * hourMs,
+		),
+	).toBe(150)
+	expect(
+		msUntilNextCodeRunsCount(
+			{ start: 200, end: 150, updateAt },
+			startMs + 6 * hourMs,
+		),
 	).toBeNull()
+	expect(msUntilCodeRunsWindowRefresh(window, startMs)).toBe(24 * hourMs)
+	expect(msUntilCodeRunsWindowRefresh(window, Date.parse(updateAt))).toBe(0)
 	expect(
-		continuePublicCodeRunsWindow({ stored: still, total: 140, now }),
-	).toEqual({
-		previous: 100,
-		current: 140,
-		windowStart: '2026-08-21T12:00:00.000Z',
-		windowEnd: '2026-08-22T12:00:00.000Z',
-	})
-	expect(
-		continuePublicCodeRunsWindow({ stored: still, total: 80, now }),
-	).toEqual({
-		previous: 80,
-		current: 80,
-		windowStart: '2026-08-21T12:00:00.000Z',
-		windowEnd: '2026-08-22T12:00:00.000Z',
-	})
-	expect(
-		continuePublicCodeRunsWindow({
-			stored: window,
-			total: 2000,
-			now: new Date('2026-08-21T12:00:00.000Z'),
-		}),
-	).toBeNull()
-	expect(
-		continuePublicCodeRunsWindow({
-			stored: window,
-			total: 2000,
-			now: new Date('2026-08-22T01:00:00.000Z'),
-		}),
-	).toEqual({
-		previous: 1240,
-		current: 2000,
-		windowStart: '2026-08-22T00:00:00.000Z',
-		windowEnd: '2026-08-23T00:00:00.000Z',
-	})
-	expect(
-		continuePublicCodeRunsWindow({
-			stored: window,
-			total: 900,
-			now: new Date('2026-08-22T01:00:00.000Z'),
-		}),
-	).toEqual({
-		previous: 900,
-		current: 900,
-		windowStart: '2026-08-22T01:00:00.000Z',
-		windowEnd: '2026-08-23T01:00:00.000Z',
-	})
+		msUntilCodeRunsWindowRefresh(window, Date.parse(updateAt) + 1_000),
+	).toBe(0)
 })

--- a/packages/worker/universal/code-runs.ts
+++ b/packages/worker/universal/code-runs.ts
@@ -1,47 +1,35 @@
 /**
  * Public homepage “code runs” ticker: a 24-hour delayed replay of fleet
- * `execute` event counts. Interpolation is deterministic from the window so
- * every visitor at a given clock time sees the same integer. Each displayed
- * step is +1. When the pair has at least one tick per 3-second honesty
- * slot, a backbone tick lands every slot at a hashed phase so the cadence
- * does not march on the clock. Extra count still warps into busy seconds
- * and rolls through those seconds without skipping, with hashed gaps so a
- * busy second does not march. The count stays monotonic between `previous`
- * and `current`. A frozen client snaps to the official integer instead of
- * replaying missed steps. When leftover budget cannot support a 3-second
- * integer backbone, the client moves honest progress toward the next tick
- * instead of inventing +1s. Homepage GET may continue an expired or still
- * pair in memory when the fleet total has grown, or reset one to a new
- * still window when the fleet total has dropped; it does not write KV.
- * A client that cannot paint a next tick refetches `/code-runs.json`
- * instead of giving up for the rest of the tab.
+ * `execute` event counts. The official payload is the cached triple
+ * `{ start, end, updateAt }` — cumulative totals through the day before
+ * yesterday and through yesterday, plus the next UTC midnight. Interpolation
+ * is deterministic from that triple so every visitor at a given clock time
+ * sees the same integer. Playback is `[updateAt - 24h, updateAt)`. Each
+ * displayed step is +1. When the pair has at least one tick per 3-second
+ * honesty slot, a backbone tick lands every slot at a hashed phase so the
+ * cadence does not march on the clock. Extra count still warps into busy
+ * seconds and rolls through those seconds without skipping, with hashed gaps
+ * so a busy second does not march. The count stays monotonic between `start`
+ * and `end` when `end >= start`. If `end < start` (an AE regression), the
+ * ticker shows `end` immediately — wobble math cannot use a negative delta.
+ * A frozen client snaps to the official integer instead of replaying missed
+ * steps. When leftover budget cannot support a 3-second integer backbone,
+ * the client moves honest progress toward the next tick instead of inventing
+ * +1s. A client that cannot paint a next tick waits until `updateAt`, then
+ * refetches `/code-runs.json` instead of polling a still pair.
  */
 
 export const publicCodeRunsWindowMs = 24 * 60 * 60 * 1000
 export const codeRunsHonestySlotMs = 3000
 
 export type PublicCodeRunsWindow = {
-	previous: number
-	current: number
-	windowStart: string
-	windowEnd: string
+	start: number
+	end: number
+	updateAt: string
 }
 
 export function isStillPublicCodeRunsWindow(window: PublicCodeRunsWindow) {
-	return window.previous === window.current
-}
-
-export function stillPublicCodeRunsWindow(
-	total: number,
-	now: Date,
-): PublicCodeRunsWindow {
-	const nowMs = now.getTime()
-	return {
-		previous: total,
-		current: total,
-		windowStart: now.toISOString(),
-		windowEnd: new Date(nowMs + publicCodeRunsWindowMs).toISOString(),
-	}
+	return window.end <= window.start
 }
 
 export function publicCodeRunsWindowsEqual(
@@ -49,10 +37,9 @@ export function publicCodeRunsWindowsEqual(
 	right: PublicCodeRunsWindow,
 ) {
 	return (
-		left.previous === right.previous &&
-		left.current === right.current &&
-		left.windowStart === right.windowStart &&
-		left.windowEnd === right.windowEnd
+		left.start === right.start &&
+		left.end === right.end &&
+		left.updateAt === right.updateAt
 	)
 }
 
@@ -61,20 +48,16 @@ export function parsePublicCodeRunsWindow(
 ): PublicCodeRunsWindow | null {
 	if (!value || typeof value !== 'object') return null
 	const record = value as Record<string, unknown>
-	const previous = readNonNegativeInt(record.previous)
-	const current = readNonNegativeInt(record.current)
-	if (previous === null || current === null) return null
-	if (typeof record.windowStart !== 'string') return null
-	if (typeof record.windowEnd !== 'string') return null
-	const startMs = Date.parse(record.windowStart)
-	const endMs = Date.parse(record.windowEnd)
-	if (!Number.isFinite(startMs) || !Number.isFinite(endMs)) return null
-	if (endMs - startMs !== publicCodeRunsWindowMs) return null
+	const start = readNonNegativeInt(record.start)
+	const end = readNonNegativeInt(record.end)
+	if (start === null || end === null) return null
+	if (typeof record.updateAt !== 'string') return null
+	const updateAtMs = Date.parse(record.updateAt)
+	if (!Number.isFinite(updateAtMs)) return null
 	return {
-		previous,
-		current: Math.max(current, previous),
-		windowStart: record.windowStart,
-		windowEnd: record.windowEnd,
+		start,
+		end,
+		updateAt: record.updateAt,
 	}
 }
 
@@ -83,10 +66,10 @@ export function interpolateCodeRunsCount(
 	nowMs: number,
 ): number {
 	const bounds = windowBounds(window)
-	if (!bounds) return Math.max(window.current, window.previous)
+	if (!bounds) return window.end
+	if (bounds.delta === 0) return bounds.current
 	if (nowMs <= bounds.startMs) return bounds.previous
 	if (nowMs >= bounds.endMs) return bounds.current
-	if (bounds.delta === 0) return bounds.previous
 	const ticks = ticksAfterElapsed({
 		elapsedMs: nowMs - bounds.startMs,
 		totalMs: bounds.totalMs,
@@ -118,7 +101,7 @@ export function msUntilNextCodeRunsCount(
 
 /**
  * Honest 0–1 progress from the last integer to the next. Zero when there is
- * no next tick (still pair, window ended, or already at current).
+ * no next tick (still pair, window ended, regression, or already at end).
  */
 export function codeRunsProgressToNext(
 	window: PublicCodeRunsWindow,
@@ -154,42 +137,14 @@ export function msUntilNextCodeRunsPaint(
 	return Math.min(wait, codeRunsHonestySlotMs)
 }
 
-/**
- * In-memory continuation when KV still holds a pair that cannot tick.
- * Grows a still / expired pair when the fleet total is higher. Resets to a
- * new still window when the fleet total dropped (a latched high-water mark
- * would otherwise freeze the ticker). Null means keep `stored`.
- */
-export function continuePublicCodeRunsWindow(input: {
-	stored: PublicCodeRunsWindow
-	total: number
-	now: Date
-}): PublicCodeRunsWindow | null {
-	if (input.total <= 0) return null
-	const nowMs = input.now.getTime()
-	const endMs = Date.parse(input.stored.windowEnd)
-	const expired = Number.isFinite(endMs) && nowMs >= endMs
-	const still = isStillPublicCodeRunsWindow(input.stored)
-	if (!expired && !still) return null
-	if (input.total < input.stored.current) {
-		return stillPublicCodeRunsWindow(input.total, input.now)
-	}
-	if (input.total === input.stored.current) return null
-	if (still && !expired) {
-		return {
-			previous: input.stored.current,
-			current: input.total,
-			windowStart: input.now.toISOString(),
-			windowEnd: new Date(nowMs + publicCodeRunsWindowMs).toISOString(),
-		}
-	}
-	const startMs = Number.isFinite(endMs) ? endMs : nowMs
-	return {
-		previous: input.stored.current,
-		current: input.total,
-		windowStart: new Date(startMs).toISOString(),
-		windowEnd: new Date(startMs + publicCodeRunsWindowMs).toISOString(),
-	}
+/** Milliseconds until the cached triple should be replaced. */
+export function msUntilCodeRunsWindowRefresh(
+	window: PublicCodeRunsWindow,
+	nowMs: number,
+): number {
+	const updateAtMs = Date.parse(window.updateAt)
+	if (!Number.isFinite(updateAtMs)) return 0
+	return Math.max(0, updateAtMs - nowMs)
 }
 
 export const codeRunsCatchUpSnapAfterMs = 1000
@@ -240,24 +195,19 @@ type WindowBounds = {
 }
 
 function windowBounds(window: PublicCodeRunsWindow): WindowBounds | null {
-	const previous = window.previous
-	const current = Math.max(window.current, previous)
-	const startMs = Date.parse(window.windowStart)
-	const endMs = Date.parse(window.windowEnd)
-	if (
-		!Number.isFinite(startMs) ||
-		!Number.isFinite(endMs) ||
-		endMs <= startMs
-	) {
-		return null
-	}
+	const endMs = Date.parse(window.updateAt)
+	if (!Number.isFinite(endMs)) return null
+	const startMs = endMs - publicCodeRunsWindowMs
+	const previous = window.start
+	const current = window.end
+	const delta = Math.max(0, window.end - window.start)
 	return {
 		previous,
 		current,
-		delta: current - previous,
+		delta,
 		startMs,
 		endMs,
-		totalMs: endMs - startMs,
+		totalMs: publicCodeRunsWindowMs,
 		seed: windowSeed(window),
 	}
 }
@@ -395,9 +345,9 @@ function singleTickFireMs(seed: number, secondIndex: number): number {
 
 function windowSeed(window: PublicCodeRunsWindow): number {
 	return hash32(
-		hash32(Date.parse(window.windowStart)) ^
-			hash32(window.previous) ^
-			Math.imul(hash32(window.current), 3),
+		hash32(Date.parse(window.updateAt) - publicCodeRunsWindowMs) ^
+			hash32(window.start) ^
+			Math.imul(hash32(window.end), 3),
 	)
 }
 

--- a/tools/migration-ledger.json
+++ b/tools/migration-ledger.json
@@ -95,6 +95,10 @@
 		{
 			"filename": "0023-secret-entry-expires-at.sql",
 			"sha256": "a8fff9cfb73ea4b6a741e0a2e61f95417d11927a46b6055a362a27b8a1b0abca"
+		},
+		{
+			"filename": "0024-fleet-execute-days.sql",
+			"sha256": "05a0061079a3988b424a0b63646510857ceec11197128e63735ff6b30b46ef8b"
 		}
 	]
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Keep the homepage code-runs ticker a 24-hour delayed, deterministic replay of real fleet `execute` counts — without a KV high-water mark that can freeze or refuse to recover.

## Why

The `{ previous, current }` pair at `public-code-runs:v1` interpolated a still lifetime SUM. When Analytics Engine recomputed below a latched `current`, or when refresh wrote a new still pair at the new total, the ticker stopped moving. Patches that coerced D1 `SUM` and reset still pairs when the SUM dropped treated symptoms of that state machine.

## Summary

- New platform table `fleet_execute_days` (no `user_id`) holds UTC-day fleet `execute` totals. Hourly `usage_aggregation` syncs the current and previous UTC months from Analytics Engine after the same live-user filter as monthly rollups. An empty month does not wipe days.
- Public payload is now `{ start, end, updateAt }` at `public-code-runs:v2`. `end` is cumulative through yesterday; `start` is cumulative through the day before yesterday; `updateAt` is the next UTC midnight. Today is stored hourly but never used in the public triple.
- Cumulative = older monthly `usage_rollups` (months before the earliest daily row) + daily sums through that completed day. Missing days count as 0. No daily rows → `window: null`.
- KV is a cache of the derived triple, not a latch. GET fills it from D1 when the key is missing or `now >= updateAt`. Old v1 JSON fails parse and falls through.
- A D1 query failure is not an empty series: GET serves the last cached triple when one exists, and hourly refresh does not delete the key.
- Client interpolates `start → end` across today with the existing hashed cadence. If `end < start`, it shows `end` immediately. When no next integer can paint, it waits until `updateAt` instead of polling a still pair every 60s.
- Local `recordUsage` increments today's daily row when Analytics Engine is absent.
- `fleet_execute_days` is documented as operator/platform-owned so account export/deletion do not touch it.

## Testing

- Focused node tests: interpolation, delayed-window load/refresh, daily AE sync (live-user filter, empty-month lag, stale-day delete), `/code-runs.json`, SSR reserved width from `end`, account operator-owned coverage, D1-throw keeps the cached triple (`query_failed`, no KV delete).
- Workers: `recordUsage` daily increment (local only) and scheduled-lane wiring.
- Pre-push `test:push`: 2049 node, 301 workers, 7 e2e passed.
- `migrations:check` and worker typecheck passed.
- Preview empty D1 should keep `GET /code-runs.json` as `{ window: null }`. Production proof is after deploy + first successful daily sync: the triple should climb `start → end` across the day, not a still lifetime SUM.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `a30b863f` · **Head:** `f0c60e1d`

**Classification:** extends — usage-metering and D1 gain a daily fleet execute series; the public ticker contract changes from a latched pair to a delayed daily triple.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `usage-metering` | storage | extends — daily AE→D1 sync, `{ start, end, updateAt }` cache, no still-pair latch |
| `d1-app-db` | storage | extends — new `fleet_execute_days` table |
| `app-ui` | surfaces | extends — ticker interpolates the new triple and refreshes at `updateAt` |
| `scheduled-cron` | surfaces | composes — `usage_aggregation` syncs days then refreshes the cache |
| `account-export` | storage | extends — `fleet_execute_days` listed as platform-owned, not a user target |
| `bundle-artifacts-kv` | storage | composes — new `public-code-runs:v2` cache key |

### Change flow

Hourly aggregation writes completed-day facts; homepage GET only caches and interpolates them.

```mermaid
sequenceDiagram
	participant scheduledCron as scheduled-cron
	participant usageMetering as usage-metering
	participant d1AppDb as d1-app-db
	participant bundleArtifactsKv as bundle-artifacts-kv
	participant appUi as app-ui
	scheduledCron->>usageMetering: usage_aggregation after monthly rollups
	usageMetering->>d1AppDb: upsert fleet_execute_days for current and prior UTC months
	usageMetering->>bundleArtifactsKv: cache start, end, updateAt at public-code-runs:v2
	appUi->>bundleArtifactsKv: GET /code-runs.json reads cached triple
	appUi->>d1AppDb: recompute and fill cache when missing or past updateAt
	Note over appUi: interpolate start to end across today; refetch at updateAt
```

### Before / after

```
before: { previous, current, windowStart, windowEnd }  // latched lifetime SUM pair
after:  { start, end, updateAt }                      // delayed daily lifetime totals
```

### Invariants

Per-user isolation: `fleet_execute_days` has no `user_id`. Public payload stays an anonymous fleet total. Account export/deletion must not remove the table or `public-code-runs:v2`. A D1 read failure is not an empty series and must not delete a usable cached triple.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d2e9331f-8e81-48a9-8bb2-55b7442a5065?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d2e9331f-8e81-48a9-8bb2-55b7442a5065&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the homepage code-runs ticker to display cumulative execution totals through completed UTC days.
  * Improved ticker playback and refresh timing across UTC day boundaries.
  * Added resilient handling for missing, stale, unavailable, or regressing data.

* **Bug Fixes**
  * Corrected ticker behavior for zero-change, thin, and regressing count windows.
  * Local development execution tracking now updates daily totals consistently.
  * Preserved the last known ticker data when refreshed data is temporarily unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->