### PR TITLE
Remove the homepage ticker progress underline

### DIFF
--- a/docs/contributing/architecture/usage-metering.md
+++ b/docs/contributing/architecture/usage-metering.md
@@ -351,19 +351,18 @@ Guarantees and rules:
   second does not march on even slots. It never passes `end`. If `end < start`
   (an Analytics Engine regression), the ticker shows `end` immediately — wobble
   math cannot use a negative delta. When leftover budget cannot support a
-  3-second integer backbone, the client moves honest progress toward the next
-  tick instead of inventing +1s. The client schedules the next paint
-  (`msUntilNextCodeRunsPaint`) rather than polling once a second;
-  `prefers-reduced-motion` snaps and does not animate. A frozen tab (rAF gap,
-  hidden, or a late timeout) snaps to the official count instead of rolling
-  through every missed integer. Live leftover ticks in a busy second still step
-  +1; leftover catch-up delays stay under that freeze window. A tab that cannot
-  paint a next tick waits until `updateAt` and refetches `/code-runs.json`
-  (cache bypass). If that fetch still returns the same triple (cron lag at
-  midnight), it retries about once a minute. The hourly `usage_aggregation` lane
-  syncs `fleet_execute_days` from Analytics Engine, then refreshes the cached
-  triple. Empty D1 (no daily rows, or no completed-day total) hides the ticker
-  (`window: null`).
+  3-second integer backbone, the displayed integer sits until the next real +1.
+  The client schedules the next integer (`msUntilNextCodeRunsCount`) rather than
+  polling once a second; `prefers-reduced-motion` snaps and does not animate. A
+  frozen tab (rAF gap, hidden, or a late timeout) snaps to the official count
+  instead of rolling through every missed integer. Live leftover ticks in a busy
+  second still step +1; leftover catch-up delays stay under that freeze window.
+  A tab that cannot paint a next tick waits until `updateAt` and refetches
+  `/code-runs.json` (cache bypass). If that fetch still returns the same triple
+  (cron lag at midnight), it retries about once a minute. The hourly
+  `usage_aggregation` lane syncs `fleet_execute_days` from Analytics Engine,
+  then refreshes the cached triple. Empty D1 (no daily rows, or no completed-day
+  total) hides the ticker (`window: null`).
 - **Fleet visibility** (`/admin/insights`, loader in
   `packages/worker/src/admin/fleet-usage-insights.ts`): bounded SQL over
   `usage_rollups` for the current UTC month — top-10 combined runtime duration

--- a/packages/worker/client/code-runs-ticker.tsx
+++ b/packages/worker/client/code-runs-ticker.tsx
@@ -6,11 +6,10 @@ import {
 import {
 	codeRunsCatchUpDelayMs,
 	codeRunsCatchUpSnapAfterMs,
-	codeRunsProgressToNext,
 	formatCodeRunsCount,
 	interpolateCodeRunsCount,
 	msUntilCodeRunsWindowRefresh,
-	msUntilNextCodeRunsPaint,
+	msUntilNextCodeRunsCount,
 	nextDisplayedCodeRunsCount,
 	publicCodeRunsWindowsEqual,
 	type PublicCodeRunsWindow,
@@ -21,7 +20,7 @@ import {
  * the client advances one integer at a time, scheduled to the next hashed
  * fire so leftover ticks still wobble. A 3-second honesty slot is the
  * longest the official integer may sit when budget allows; thinner windows
- * move the progress underline instead of inventing +1s. A frozen tab (rAF
+ * wait for the next real +1 instead of inventing ticks. A frozen tab (rAF
  * gap, hidden, or a late timeout) snaps to the official count instead of
  * rolling through every missed integer. When no next integer can paint, the
  * ticker waits until `updateAt` then refetches `/code-runs.json`. Mono
@@ -33,7 +32,6 @@ export function CodeRunsTicker(
 ) {
 	let activeWindow = handle.props.window
 	let displayed = interpolateCodeRunsCount(activeWindow, Date.now())
-	let progress = codeRunsProgressToNext(activeWindow, Date.now())
 	let lastDisplayAt = Date.now()
 	const prefersReducedMotion =
 		typeof matchMedia === 'function' &&
@@ -46,10 +44,6 @@ export function CodeRunsTicker(
 
 		function officialAt(now: number) {
 			return interpolateCodeRunsCount(activeWindow, now)
-		}
-
-		function progressAt(now: number) {
-			return codeRunsProgressToNext(activeWindow, now)
 		}
 
 		async function refreshStuckWindow() {
@@ -68,16 +62,15 @@ export function CodeRunsTicker(
 			timeoutId = undefined
 		}
 
-		function show(count: number, nextProgress: number, now: number) {
-			if (count === displayed && nextProgress === progress) return
-			if (count !== displayed) lastDisplayAt = now
+		function show(count: number, now: number) {
+			if (count === displayed) return
+			lastDisplayAt = now
 			displayed = count
-			progress = nextProgress
 			handle.update()
 		}
 
 		function snapToOfficial(now = Date.now()) {
-			show(officialAt(now), progressAt(now), now)
+			show(officialAt(now), now)
 		}
 
 		function scheduleNext() {
@@ -93,7 +86,7 @@ export function CodeRunsTicker(
 					official,
 					elapsedMsSinceDisplay: now - lastDisplayAt,
 				})
-				show(next, progressAt(now), now)
+				show(next, now)
 				if (next < official) {
 					timeoutId = setTimeout(() => {
 						scheduleNext()
@@ -102,8 +95,8 @@ export function CodeRunsTicker(
 				}
 			}
 			const nowAfter = Date.now()
-			show(officialAt(nowAfter), progressAt(nowAfter), nowAfter)
-			const delay = msUntilNextCodeRunsPaint(activeWindow, nowAfter)
+			show(officialAt(nowAfter), nowAfter)
+			const delay = msUntilNextCodeRunsCount(activeWindow, nowAfter)
 			if (delay === null) {
 				const refreshIn = msUntilCodeRunsWindowRefresh(activeWindow, nowAfter)
 				timeoutId = setTimeout(
@@ -182,14 +175,6 @@ export function CodeRunsTicker(
 						style={{ '--runs-ch': `${reserved.length}ch` }}
 					>
 						{formatCodeRunsCount(displayed)}
-						{progress > 0 ? (
-							<span
-								class="landing-hero-runs-progress"
-								style={{
-									transform: `scaleX(${progress})`,
-								}}
-							/>
-						) : null}
 					</span>
 					<span class="landing-hero-runs-label">code runs</span>
 				</span>

--- a/packages/worker/public/styles.css
+++ b/packages/worker/public/styles.css
@@ -847,7 +847,6 @@ html.is-settled {
 }
 
 .landing-hero-runs-count {
-	position: relative;
 	display: inline-block;
 	box-sizing: content-box;
 	min-width: var(--runs-ch, 1ch);
@@ -859,19 +858,6 @@ html.is-settled {
 		'tnum' 1,
 		'lnum' 1;
 	color: var(--color-text);
-}
-
-.landing-hero-runs-progress {
-	position: absolute;
-	left: 0;
-	right: 0;
-	bottom: -0.18em;
-	height: 2px;
-	border-radius: 999px;
-	background: currentColor;
-	opacity: 0.4;
-	transform-origin: left center;
-	pointer-events: none;
 }
 
 .landing-hero-runs-label {

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -748,6 +748,7 @@ test('renderAppPage embeds a tabular homepage code-runs ticker', async () => {
 	)?.[0]
 	expect(ticker).toBeTruthy()
 	expect(ticker).toContain('landing-hero-runs-count')
+	expect(ticker).not.toContain('landing-hero-runs-progress')
 	expect(ticker).toMatch(/--runs-ch:\s*7ch/)
 	expect(ticker).toContain(formatCodeRunsCount(count))
 	expect(ticker).toContain('code runs')

--- a/packages/worker/universal/code-runs.node.test.ts
+++ b/packages/worker/universal/code-runs.node.test.ts
@@ -3,13 +3,11 @@ import {
 	codeRunsCatchUpDelayMs,
 	codeRunsCatchUpSnapAfterMs,
 	codeRunsHonestySlotMs,
-	codeRunsProgressToNext,
 	formatCodeRunsCount,
 	interpolateCodeRunsCount,
 	isStillPublicCodeRunsWindow,
 	msUntilCodeRunsWindowRefresh,
 	msUntilNextCodeRunsCount,
-	msUntilNextCodeRunsPaint,
 	nextDisplayedCodeRunsCount,
 	parsePublicCodeRunsWindow,
 	publicCodeRunsWindowsEqual,
@@ -265,25 +263,19 @@ test('a 3-second backbone never waits longer than the honesty slot when budget a
 	// backbone is a fixed 3-second cadence.
 	expect(new Set(gaps.slice(1)).size).toBe(1)
 	expect(gaps[1]).toBe(codeRunsHonestySlotMs)
-	expect(msUntilNextCodeRunsPaint(honest, startMs + 10)).toBeLessThanOrEqual(
-		codeRunsHonestySlotMs,
-	)
 })
 
-test('thin windows move progress instead of inventing integers', () => {
+test('thin windows sit on the integer until the next real +1', () => {
 	const thin = { ...window, start: 10, end: 20 }
 	const nowMs = startMs + 6 * hourMs
 	const wait = msUntilNextCodeRunsCount(thin, nowMs)
 	expect(wait).not.toBeNull()
 	expect(wait!).toBeGreaterThan(codeRunsHonestySlotMs)
-	expect(msUntilNextCodeRunsPaint(thin, nowMs)).toBe(codeRunsHonestySlotMs)
-	const frac = codeRunsProgressToNext(thin, nowMs)
-	expect(frac).toBeGreaterThan(0)
-	expect(frac).toBeLessThan(1)
-	expect(codeRunsProgressToNext(thin, nowMs + 3_000)).toBeGreaterThan(frac)
-	expect(codeRunsProgressToNext({ ...window, start: 80, end: 80 }, nowMs)).toBe(
-		0,
+	const here = interpolateCodeRunsCount(thin, nowMs)
+	expect(interpolateCodeRunsCount(thin, nowMs + codeRunsHonestySlotMs)).toBe(
+		here,
 	)
+	expect(interpolateCodeRunsCount(thin, nowMs + wait!)).toBe(here + 1)
 })
 
 test('a regressing end shows immediately and refresh waits until updateAt', () => {

--- a/packages/worker/universal/code-runs.ts
+++ b/packages/worker/universal/code-runs.ts
@@ -14,9 +14,9 @@
  * ticker shows `end` immediately — wobble math cannot use a negative delta.
  * A frozen client snaps to the official integer instead of replaying missed
  * steps. When leftover budget cannot support a 3-second integer backbone,
- * the client moves honest progress toward the next tick instead of inventing
- * +1s. A client that cannot paint a next tick waits until `updateAt`, then
- * refetches `/code-runs.json` instead of polling a still pair.
+ * the displayed integer sits until the next real +1. A client that cannot
+ * paint a next tick waits until `updateAt`, then refetches
+ * `/code-runs.json` instead of polling a still pair.
  */
 
 export const publicCodeRunsWindowMs = 24 * 60 * 60 * 1000
@@ -97,44 +97,6 @@ export function msUntilNextCodeRunsCount(
 		else lo = mid + 1
 	}
 	return lo - nowMs
-}
-
-/**
- * Honest 0–1 progress from the last integer to the next. Zero when there is
- * no next tick (still pair, window ended, regression, or already at end).
- */
-export function codeRunsProgressToNext(
-	window: PublicCodeRunsWindow,
-	nowMs: number,
-): number {
-	const wait = msUntilNextCodeRunsCount(window, nowMs)
-	if (wait == null || wait <= 0) return 0
-	const bounds = windowBounds(window)
-	if (!bounds || nowMs <= bounds.startMs) return 0
-	const here = interpolateCodeRunsCount(window, nowMs)
-	let lo = bounds.startMs
-	let hi = nowMs
-	while (lo < hi) {
-		const mid = lo + Math.floor((hi - lo) / 2)
-		if (interpolateCodeRunsCount(window, mid) < here) lo = mid + 1
-		else hi = mid
-	}
-	const gap = nowMs - lo + wait
-	if (gap <= 0) return 0
-	return Math.min(1, (nowMs - lo) / gap)
-}
-
-/**
- * When to repaint so something honest moves at least every honesty slot.
- * Integer cadence wins when the next +1 is sooner than that.
- */
-export function msUntilNextCodeRunsPaint(
-	window: PublicCodeRunsWindow,
-	nowMs: number,
-): number | null {
-	const wait = msUntilNextCodeRunsCount(window, nowMs)
-	if (wait == null) return null
-	return Math.min(wait, codeRunsHonestySlotMs)
 }
 
 /** Milliseconds until the cached triple should be replaced. */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Keep the homepage code-runs ticker as a count and caption — no progress bar under the digits.

## Why

The `scaleX` underline (`.landing-hero-runs-progress`) was there so thin windows still “moved” between integers. It looks like leftover chrome under the number.

## Summary

- Delete the `.landing-hero-runs-progress` element and CSS.
- Drop `codeRunsProgressToNext` / `msUntilNextCodeRunsPaint`. The ticker now waits for the next real +1 (`msUntilNextCodeRunsCount`).
- Thin windows sit on the current integer instead of inventing motion.

## Testing

- Focused node tests: interpolation + SSR ticker HTML has no `landing-hero-runs-progress`.
- Pre-push `test:push`: 2051 node, 301 workers, 7 e2e passed.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `fff763bb` · **Head:** `f06a1b33`

**Classification:** composes — homepage ticker markup only; the delayed `{ start, end, updateAt }` contract is unchanged.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | composes — remove the progress underline under the code-runs count |

### Change flow

```mermaid
sequenceDiagram
	participant appUi as app-ui
	participant usageMetering as usage-metering
	appUi->>usageMetering: GET /code-runs.json
	usageMetering-->>appUi: start, end, updateAt
	Note over appUi: interpolate integer only; no scaleX bar
```

### Before / after

| Before | After |
| --- | --- |
| Count plus a fading underline that scales toward the next +1 | Count and caption only |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d2e9331f-8e81-48a9-8bb2-55b7442a5065?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d2e9331f-8e81-48a9-8bb2-55b7442a5065&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated the homepage code-runs ticker to display only genuine count increases.
  * Removed the progress underline indicator from the ticker for a cleaner presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->