### PR TITLE
Point onboarding Automatic copy at Manual web-host setup

### DIFF
--- a/packages/worker/client/routes/onboarding-mcp-client-tabs.node.test.ts
+++ b/packages/worker/client/routes/onboarding-mcp-client-tabs.node.test.ts
@@ -31,6 +31,10 @@ test('onboarding Step 1 shows @kodycodes/cli first and collapses Manual', async 
 	expect(automaticBlock).toContain(
 		buildKodyCliInstallCommand(defaultKodyMcpUrl),
 	)
+	expect(automaticBlock).toContain(
+		'You can also manually connect web hosts such as ChatGPT, Claude.ai, and Grok below.',
+	)
+	expect(automaticBlock).not.toContain('stay under Manual')
 	expect(automaticBlock).not.toContain('Add to Cursor')
 	expect(automaticBlock).not.toContain('Choose your client')
 

--- a/packages/worker/client/routes/onboarding-mcp-client-tabs.tsx
+++ b/packages/worker/client/routes/onboarding-mcp-client-tabs.tsx
@@ -532,8 +532,8 @@ export function OnboardingMcpClientTabs(
 					<p>
 						Run this to add Kody to the local agents the CLI finds (Cursor,
 						Claude Desktop, VS Code, Claude Code, Codex, and others). Then
-						Authenticate in that client. Web hosts such as ChatGPT, Claude.ai,
-						and Grok stay under Manual.
+						Authenticate in that client. You can also manually connect web hosts
+						such as ChatGPT, Claude.ai, and Grok below.
 					</p>
 					<CopyCard
 						label="Install command"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Tell people on Get started that ChatGPT, Claude.ai, and Grok can be connected in Manual, not that those hosts are off-limits.

## Why

“Web hosts … stay under Manual” reads like a closed door. The Manual section is right below.

## Summary

- Automatic blurb now says: “You can also manually connect web hosts such as ChatGPT, Claude.ai, and Grok below.”

## Testing

- Node test for Step 1 Automatic copy.
- Pre-push `test:push`: 2054 node, 301 workers, 7 e2e passed.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `5245f95a` · **Head:** `4a2e6ba3`

**Classification:** composes — onboarding copy only.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | composes — Automatic blurb on `/onboarding` Step 1 |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d2e9331f-8e81-48a9-8bb2-55b7442a5065?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d2e9331f-8e81-48a9-8bb2-55b7442a5065&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated automatic installation instructions to clarify that the CLI supports manually connecting web hosts such as ChatGPT, Claude.ai, and Grok.
  * Removed outdated guidance directing users exclusively to the Manual section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->