### PR TITLE
Filter chrome-extension call-stack Sentry noise; lock CodeRunsTicker deferral

### DIFF
--- a/packages/worker/client/code-runs-ticker.node.test.ts
+++ b/packages/worker/client/code-runs-ticker.node.test.ts
@@ -1,0 +1,74 @@
+import { expect, test, vi } from 'vitest'
+import { CodeRunsTicker } from '#client/code-runs-ticker.tsx'
+import { type PublicCodeRunsWindow } from '#universal/code-runs.ts'
+
+test('CodeRunsTicker defers scheduleNext through queueTask so setup never calls handle.update synchronously', () => {
+	const previousDocument = globalThis.document
+	const previousWindow = globalThis.window
+	const previousMatchMedia = globalThis.matchMedia
+	const previousRequestAnimationFrame = globalThis.requestAnimationFrame
+	const previousCancelAnimationFrame = globalThis.cancelAnimationFrame
+	const previousPerformance = globalThis.performance
+	const previousSetTimeout = globalThis.setTimeout
+	const previousClearTimeout = globalThis.clearTimeout
+
+	const addEventListener = vi.fn()
+	globalThis.document = {
+		visibilityState: 'visible',
+		addEventListener,
+	} as unknown as Document
+	globalThis.window = {
+		addEventListener,
+	} as unknown as Window & typeof globalThis
+	globalThis.matchMedia = vi.fn(() => ({
+		matches: false,
+	})) as unknown as typeof matchMedia
+	globalThis.requestAnimationFrame = vi.fn(
+		() => 1,
+	) as typeof requestAnimationFrame
+	globalThis.cancelAnimationFrame = vi.fn() as typeof cancelAnimationFrame
+	globalThis.performance = { now: () => 0 } as Performance
+	globalThis.setTimeout = vi.fn(() => 1) as unknown as typeof setTimeout
+	globalThis.clearTimeout = vi.fn() as unknown as typeof clearTimeout
+
+	const updateAt = new Date(Date.now() + 60_000).toISOString()
+	const codeRunsWindow: PublicCodeRunsWindow = {
+		start: 100,
+		end: 200,
+		updateAt,
+	}
+
+	let queuedTask: ((signal?: AbortSignal) => unknown) | undefined
+	const update = vi.fn()
+	const abort = new AbortController()
+
+	try {
+		CodeRunsTicker({
+			props: { window: codeRunsWindow },
+			signal: abort.signal,
+			queueTask(task) {
+				queuedTask = task
+			},
+			update,
+		} as never)
+
+		expect(queuedTask).toBeTypeOf('function')
+		expect(update).not.toHaveBeenCalled()
+		expect(globalThis.requestAnimationFrame).not.toHaveBeenCalled()
+		expect(globalThis.setTimeout).not.toHaveBeenCalled()
+
+		queuedTask?.(abort.signal)
+
+		expect(globalThis.requestAnimationFrame).toHaveBeenCalled()
+	} finally {
+		abort.abort()
+		globalThis.document = previousDocument
+		globalThis.window = previousWindow
+		globalThis.matchMedia = previousMatchMedia
+		globalThis.requestAnimationFrame = previousRequestAnimationFrame
+		globalThis.cancelAnimationFrame = previousCancelAnimationFrame
+		globalThis.performance = previousPerformance
+		globalThis.setTimeout = previousSetTimeout
+		globalThis.clearTimeout = previousClearTimeout
+	}
+})

--- a/packages/worker/client/code-runs-ticker.node.test.ts
+++ b/packages/worker/client/code-runs-ticker.node.test.ts
@@ -60,6 +60,7 @@ test('CodeRunsTicker defers scheduleNext through queueTask so setup never calls 
 		queuedTask?.(abort.signal)
 
 		expect(globalThis.requestAnimationFrame).toHaveBeenCalled()
+		expect(globalThis.setTimeout).toHaveBeenCalled()
 	} finally {
 		abort.abort()
 		globalThis.document = previousDocument

--- a/packages/worker/client/sentry-browser-filters.node.test.ts
+++ b/packages/worker/client/sentry-browser-filters.node.test.ts
@@ -372,6 +372,77 @@ test('browser Sentry filters drop AbortError and Firefox Xray noise and keep rea
 			exception: {
 				values: [
 					{
+						type: 'RangeError',
+						value: 'Maximum call stack size exceeded',
+						stacktrace: {
+							frames: [
+								{
+									function: 'Performance.get',
+									filename:
+										'chrome-extension://nmpbkbkalejlobohneicicgoojjokopi/data/content_script/page_context/inject.js',
+								},
+								{
+									function: 'Reflect.get',
+									filename: '<anonymous>',
+								},
+							],
+						},
+					},
+				],
+			},
+		}),
+	).toBeNull()
+	expect(
+		filterBrowserSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'RangeError',
+						value: 'Maximum call stack size exceeded',
+						stacktrace: {
+							frames: [
+								{
+									function: 'Performance.get',
+									filename:
+										'chrome-extension://nmpbkbkalejlobohneicicgoojjokopi/data/content_script/page_context/inject.js',
+								},
+								{
+									function: 'boot',
+									filename: 'https://kody.codes/assets/entry.js',
+								},
+							],
+						},
+					},
+				],
+			},
+		}),
+	).not.toBeNull()
+	expect(
+		filterBrowserSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'RangeError',
+						value: 'Maximum call stack size exceeded',
+						stacktrace: {
+							frames: [
+								{
+									function: 'scheduleNext',
+									filename: '../client/code-runs-ticker.tsx',
+								},
+							],
+						},
+					},
+				],
+			},
+		}),
+	).not.toBeNull()
+
+	expect(
+		filterBrowserSentryEvent({
+			exception: {
+				values: [
+					{
 						type: 'ReferenceError',
 						value: 'CONFIG is not defined',
 						stacktrace: {

--- a/packages/worker/client/sentry-browser-filters.ts
+++ b/packages/worker/client/sentry-browser-filters.ts
@@ -566,6 +566,85 @@ export function filterChromeExtensionClientDestroyedSentryEvent<
 }
 
 /**
+ * Some Chrome extensions wrap `performance` accessors in a recursive
+ * `Performance.get` proxy and blow the call stack on the host page. Sentry
+ * attributes the RangeError to the document because the promise rejects in
+ * page context, but every real frame is `chrome-extension://…` (plus
+ * engine-native `<anonymous>` / `[native code]` frames). Signature from
+ * production issues 7690314544 / 7690316805 (`chrome-extension://nmpbkb…
+ * /data/content_script/page_context/inject.js`).
+ *
+ * Match is intentionally narrow: Maximum call stack size exceeded wording,
+ * at least one `chrome-extension:` frame, and every reported frame URL is
+ * either `chrome-extension:` or anonymous/native. Never blanket-drop stack
+ * overflows that include first-party or http(s) frames.
+ */
+const chromeExtensionCallStackExceededMessage =
+	/^(?:(?:RangeError|Error):\s*)?Maximum call stack size exceeded\.?$/i
+
+export function isChromeExtensionCallStackExceededMessage(message: string) {
+	return chromeExtensionCallStackExceededMessage.test(message.trim())
+}
+
+export function isAnonymousOrNativeStackFrameUrl(url: string) {
+	const trimmed = url.trim()
+	return (
+		trimmed.length === 0 ||
+		trimmed === '<anonymous>' ||
+		trimmed === '[native code]' ||
+		trimmed === 'native'
+	)
+}
+
+export function isChromeExtensionOrAnonymousStackFrameUrl(url: string) {
+	return (
+		isAnonymousOrNativeStackFrameUrl(url) || isChromeExtensionStackFrameUrl(url)
+	)
+}
+
+export function isChromeExtensionCallStackExceededError(error: unknown) {
+	if (typeof error === 'string') {
+		return isChromeExtensionCallStackExceededMessage(error)
+	}
+	if (typeof error !== 'object' || error === null) return false
+	if (!('message' in error) || typeof error.message !== 'string') return false
+	return isChromeExtensionCallStackExceededMessage(error.message)
+}
+
+export function isChromeExtensionCallStackExceededSentryEvent(
+	event: SentryErrorEventLike,
+	originalException?: unknown,
+) {
+	const hasCallStackMessage =
+		isChromeExtensionCallStackExceededError(originalException) ||
+		event.exception?.values?.some(
+			(value) =>
+				value.type === 'RangeError' &&
+				typeof value.value === 'string' &&
+				isChromeExtensionCallStackExceededMessage(value.value),
+		) ||
+		sentryEventMessages(event).some(
+			(message) =>
+				typeof message === 'string' &&
+				isChromeExtensionCallStackExceededMessage(message),
+		)
+	if (!hasCallStackMessage) return false
+	const frameUrls = sentryEventStackFrameUrls(event)
+	if (frameUrls.length === 0) return false
+	if (!frameUrls.some(isChromeExtensionStackFrameUrl)) return false
+	return frameUrls.every(isChromeExtensionOrAnonymousStackFrameUrl)
+}
+
+export function filterChromeExtensionCallStackExceededSentryEvent<
+	T extends SentryErrorEventLike,
+>(event: T, originalException?: unknown): T | null {
+	if (isChromeExtensionCallStackExceededSentryEvent(event, originalException)) {
+		return null
+	}
+	return event
+}
+
+/**
  * Twitter/X iOS in-app browser chrome (`updateFooterPositions` /
  * `updateGapFiller`) references a host-page `CONFIG` global that Kody never
  * defines. WebKit reports it as an unhandled `ReferenceError` attributed to
@@ -895,6 +974,14 @@ export function filterBrowserSentryEvent<T extends SentryErrorEventLike>(
 	}
 	if (
 		filterChromeExtensionClientDestroyedSentryEvent(
+			event,
+			originalException,
+		) === null
+	) {
+		return null
+	}
+	if (
+		filterChromeExtensionCallStackExceededSentryEvent(
 			event,
 			originalException,
 		) === null


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Finish Sentry triage for `scheduleUpdate not implemented` (KODY-CLOUDFLARE-60) and the deploy-burst `Maximum call stack size exceeded` siblings (KODY-CLOUDFLARE-5Z / 61).

## Why

- Root cause for `scheduleUpdate not implemented` was synchronous `handle.update()` during `CodeRunsTicker` setup. Seer already shipped and deployed that fix in #1748 (`e1ee15a3`); both open scheduleUpdate events were on pre-fix releases (including one stale-client hit after deploy). Those Sentry issues are resolved in that commit.
- The backfill RangeErrors are chrome-extension `Performance.get` recursion (`chrome-extension://nmpbkb…/inject.js`), not Kody code — they need a narrow browser `beforeSend` filter, matching existing extension-noise filters.

## Summary

- Add `filterChromeExtensionCallStackExceededSentryEvent`: drop `Maximum call stack size exceeded` only when at least one frame is `chrome-extension:` and every frame URL is extension or anonymous/native.
- Wire it into `filterBrowserSentryEvent`.
- Add a regression test that `CodeRunsTicker` queues `scheduleNext` / rAF via `handle.queueTask` and does not call `handle.update` synchronously during setup.

## Testing

- `npx vitest run packages/worker/client/sentry-browser-filters.node.test.ts packages/worker/client/code-runs-ticker.node.test.ts` (pass)
- Full local `npm run validate` hit unrelated parallel-resource timeouts (mock Cloudflare / Playwright webServer / MCP worker ready); CI is the authoritative gate for this PR.

## System changes

Browser Sentry beforeSend only; no auth / isolation / billing / migration surface.

After merge: ignore filtered RangeError issues in Sentry. ScheduleUpdate issues already resolved in `e1ee15a3` (#1748).

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `e1ee15a3` · **Head:** `7688b084`

**Classification:** composes — narrow browser beforeSend filter plus a regression test; no primitive contracts changed.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `app-ui` | surfaces | composes — client Sentry filter + CodeRunsTicker deferral regression test |

### Change flow

Browser exceptions hit the client beforeSend gate; extension-only call-stack RangeErrors are dropped before Sentry ingest.

```mermaid
sequenceDiagram
	actor browser as Browser
	participant appUi as app-ui
	participant sentry as Sentry
	browser->>appUi: RangeError Maximum call stack size exceeded
	appUi->>appUi: filterChromeExtensionCallStackExceededSentryEvent
	alt chrome-extension frames only
		appUi-->>sentry: drop event
	else first-party or http(s) frames present
		appUi->>sentry: forward event
	end
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e0414f37-a07c-4fdd-96c8-8cd4c27c7e97?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e0414f37-a07c-4fdd-96c8-8cd4c27c7e97&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Reduced noise in error monitoring by filtering out browser errors caused by certain Chrome extensions.
  - Preserved reporting for genuine “Maximum call stack size exceeded” errors from the application and other sources.
  - Improved background code-run scheduling so updates begin asynchronously without unnecessary immediate work.

- **Tests**
  - Added regression coverage for deferred scheduling and error-filtering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->