### PR TITLE
Highlight homepage factory-loop code as it loads

### DIFF
--- a/packages/worker/client/routes/landing-loop-highlights.node.test.ts
+++ b/packages/worker/client/routes/landing-loop-highlights.node.test.ts
@@ -1,0 +1,43 @@
+import { expect, test, vi } from 'vitest'
+import { highlightSnippetKey } from '#universal/highlighted-code.ts'
+import { routes } from '#universal/routes.ts'
+import { fetchLandingLoopHighlights } from './landing-loop-highlights.ts'
+
+test('landing loop highlight fetch reads walkthrough tokens from the guide JSON', async () => {
+	const snippet = { code: 'const x = 1', lang: 'ts' }
+	const key = highlightSnippetKey(snippet)
+	const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+		expect(String(input)).toBe(
+			routes.guideDetailApi.href({ slug: 'how-kody-works' }),
+		)
+		return Response.json({
+			ok: true,
+			walkthroughHighlights: {
+				[key]: {
+					code: snippet.code,
+					lang: snippet.lang,
+					plain: false,
+					lines: [[{ content: 'const', style: { color: '#d73a49' } }]],
+				},
+			},
+		})
+	})
+	const originalFetch = globalThis.fetch
+	globalThis.fetch = fetchMock as typeof fetch
+	try {
+		const highlights = await fetchLandingLoopHighlights()
+		expect(highlights[key]?.plain).toBe(false)
+		expect(highlights[key]?.lines[0]?.[0]?.style?.color).toBe('#d73a49')
+	} finally {
+		globalThis.fetch = originalFetch
+	}
+
+	globalThis.fetch = (async () => {
+		throw new Error('offline')
+	}) as typeof fetch
+	try {
+		expect(await fetchLandingLoopHighlights()).toEqual({})
+	} finally {
+		globalThis.fetch = originalFetch
+	}
+})

--- a/packages/worker/client/routes/landing-loop-highlights.ts
+++ b/packages/worker/client/routes/landing-loop-highlights.ts
@@ -1,0 +1,26 @@
+import { type HighlightedCode } from '#universal/highlighted-code.ts'
+import { routes } from '#universal/routes.ts'
+import { readJson } from '#client/routes/account-approval-shared.ts'
+
+/**
+ * Homepage loop reuses the How Kody works walkthrough tokens. Fetch them
+ * with the transcript chunk so code beats paint highlighted, not plaintext.
+ */
+export async function fetchLandingLoopHighlights(signal?: AbortSignal) {
+	try {
+		const response = await fetch(
+			routes.guideDetailApi.href({ slug: 'how-kody-works' }),
+			{
+				headers: { Accept: 'application/json' },
+				signal,
+			},
+		)
+		const payload = await readJson<{
+			walkthroughHighlights?: Record<string, HighlightedCode>
+		}>(response)
+		if (!response.ok) return {}
+		return payload?.walkthroughHighlights ?? {}
+	} catch {
+		return {}
+	}
+}

--- a/packages/worker/client/routes/landing-loop-player.tsx
+++ b/packages/worker/client/routes/landing-loop-player.tsx
@@ -4,8 +4,10 @@ import {
 	observeNearViewport,
 } from '#client/deferred-turnstile.ts'
 import { on } from '#client/event-mixin.ts'
+import { type HighlightedCode } from '#universal/highlighted-code.ts'
 import { routes } from '#universal/routes.ts'
 import { type TranscriptLine } from './interactive-guide-transcript.ts'
+import { fetchLandingLoopHighlights } from './landing-loop-highlights.ts'
 import {
 	createLandingLoopPlayer,
 	flattenTranscriptActs,
@@ -25,20 +27,21 @@ type LoopLineRenderer = (line: TranscriptLine) => RemixNode
 /**
  * Homepage factory-loop player. SSR paints the first user turn; the
  * transcript chunk loads once the card is near the viewport so it stays
- * out of the marketing entry. Shiki prefetches after window `load` so
- * it does not block first paint or the first beats. Hover/focus (fine
- * pointers) and explore (scroll up or open a tool) pause the autoplay;
- * Play scrolls to the latest beat and continues. The last beat pauses
- * and offers Restart instead of looping. One header control is both
- * the playing indicator and play/pause (icons, not words). SSR paints
- * Pause so the header does not shift when the transcript chunk loads.
- * A reserved slot keeps that size if reduced-motion later hides it.
- * The phone act is a later scene in the same card — a time skip plus
- * device chrome, not a reset.
+ * out of the marketing entry. Walkthrough highlight tokens fetch in
+ * parallel so tool/file beats paint colored spans instead of plaintext.
+ * Hover/focus (fine pointers) and explore (scroll up or open a tool)
+ * pause the autoplay; Play scrolls to the latest beat and continues.
+ * The last beat pauses and offers Restart instead of looping. One
+ * header control is both the playing indicator and play/pause (icons,
+ * not words). SSR paints Pause so the header does not shift when the
+ * transcript chunk loads. A reserved slot keeps that size if
+ * reduced-motion later hides it. The phone act is a later scene in the
+ * same card — a time skip plus device chrome, not a reset.
  */
 export function LandingLoopPlayer(handle: Handle) {
 	let beats: Array<LandingLoopBeat> | null = null
 	let renderLine: LoopLineRenderer | null = null
+	let highlightsPromise: Promise<Record<string, HighlightedCode>> | null = null
 	let player = createLandingLoopPlayer({ beatCount: 1, reducedMotion: false })
 	let reducedMotion = false
 	let finePointerPauses = false
@@ -65,9 +68,15 @@ export function LandingLoopPlayer(handle: Handle) {
 		)
 	}
 
+	function startHighlightsFetch() {
+		if (highlightsPromise || handle.signal.aborted) return
+		highlightsPromise = fetchLandingLoopHighlights(handle.signal)
+	}
+
 	function armLoad() {
 		if (loadStarted || handle.signal.aborted) return
 		loadStarted = true
+		startHighlightsFetch()
 		void loadLoop()
 	}
 
@@ -81,16 +90,18 @@ export function LandingLoopPlayer(handle: Handle) {
 
 	async function loadLoop() {
 		try {
-			const [transcript, walkthrough] = await Promise.all([
+			const [transcript, walkthrough, highlights] = await Promise.all([
 				// Dynamic import is intentional so the factory transcript and
-				// tool-call renderer stay out of the homepage chunk. Shiki
-				// stays off this path — plaintext fences are enough to start.
+				// tool-call renderer stay out of the homepage chunk. Tokens
+				// come from the How Kody works guide JSON, not client Shiki.
 				import('./how-kody-works-transcript.ts'),
 				import('./interactive-guide-walkthrough.tsx'),
+				highlightsPromise ?? fetchLandingLoopHighlights(handle.signal),
 			])
 			if (handle.signal.aborted) return
 			beats = flattenTranscriptActs(transcript.howKodyWorksTranscriptActs)
-			renderLine = walkthrough.renderInteractiveGuideLine
+			renderLine = (line) =>
+				walkthrough.renderInteractiveGuideLine(line, highlights)
 			reducedMotion = prefersReducedMotion()
 			finePointerPauses = canFinePointerPause()
 			player = createLandingLoopPlayer({
@@ -183,6 +194,7 @@ export function LandingLoopPlayer(handle: Handle) {
 	}
 
 	return () => {
+		if (typeof document !== 'undefined') startHighlightsFetch()
 		const visibleBeats = beats?.slice(0, player.revealedCount) ?? null
 		const sceneGroups = visibleBeats ? groupLandingLoopScenes(visibleBeats) : []
 		const lineRenderer = renderLine


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Paint syntax-highlighted tokens on the homepage factory-loop as tool and file beats appear, using the same highlight-worker data path as `/guides/how-kody-works`.

## Why

The landing loop already reused that transcript, but `CopyCodeBlock`s fell back to plaintext because the player never fetched walkthrough tokens.

## Summary

- Fetch `/guides/how-kody-works.json` `walkthroughHighlights` in parallel with the transcript chunk.
- Start the fetch as soon as the player hydrates so tokens are ready when code beats reveal.
- Pass those tokens into `renderInteractiveGuideLine`. Shiki stays off the homepage bundle.

## Testing

- Node-unit: landing-loop highlight fetch maps guide JSON tokens; existing loop player tests still pass
- Preview: expand a tool/file beat on `/` and confirm colored spans

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `7dda595b` · **Head:** `aff52e87`

**Classification:** composes — homepage player reads existing walkthrough tokens; no highlight-worker or loader contract change.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | composes — landing loop paints `walkthroughHighlights` |

### Change flow

The homepage factory loop loads the How Kody works transcript and its already-highlighted tokens together, then paints each revealed beat.

```mermaid
sequenceDiagram
	actor User
	participant appUi as app-ui
	User->>appUi: GET /
	appUi-->>User: SSR teaser (no code)
	appUi->>appUi: fetch /guides/how-kody-works.json walkthroughHighlights
	appUi->>appUi: dynamic import transcript + line renderer
	appUi-->>User: revealed tool/file beats paint HighlightedCode spans
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8a9d9f31-2e4e-4b4b-8158-43ca59aaf9e0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8a9d9f31-2e4e-4b4b-8158-43ca59aaf9e0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added highlighted code spans to the landing-page walkthrough player for clearer tool and file references.
  * Walkthrough highlight data now loads alongside the transcript and interactive content.

* **Bug Fixes**
  * Added graceful fallback behavior so walkthrough content remains available when highlight data cannot be loaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->