### PR TITLE
Emit page Server-Timing phases so we can see where load time goes

### DIFF
--- a/docs/contributing/architecture/request-lifecycle.md
+++ b/docs/contributing/architecture/request-lifecycle.md
@@ -155,6 +155,22 @@ response stays `no-store` when the request carries a `kody_session` cookie,
 `loadSessionInfo` resolves a session, or the response sets a cookie. Auth,
 OAuth, account, and every other HTML path stay `no-store`.
 
+## Page Server-Timing
+
+`renderAppPage` and page JSON companions emit an HTTP `Server-Timing` header
+with request-scoped phases (`{ name, durationMs, desc? }`, same helper as
+execute). Cloudflare may append `cfEdge` / `cfOrigin` / `cfWorker`. App phases
+are:
+
+- `session` — `loadSessionInfo`
+- `ssr` — route preload, stylesheet, and starting the HTML stream
+- `highlight` — token batch (`desc` is `hit`, `worker`, `miss`, or `fallback`)
+- `listings` — onboarding featured/chooser load
+- `code-runs` — homepage public ticker window
+
+Durations use `Date.now()`, which Workers only advance across I/O. The weekly
+site-perf collector records these phases; it does not budget them.
+
 ## Syntax highlighting
 
 Browser pages that show code — markdown bodies on guides, blog posts, and

--- a/docs/contributing/weekly-site-perf.md
+++ b/docs/contributing/weekly-site-perf.md
@@ -21,7 +21,12 @@ npm run site-perf -- --url https://kody.codes/ --json
 
 [`tools/site-perf/collect.ts`](../../tools/site-perf/collect.ts) fetches the
 homepage, records HTML weight, `Cache-Control`, the largest same-origin JS
-payload, and the preloaded LCP image, then classifies against
+payload, the preloaded LCP image, TTFB, and `Server-Timing` phases (`session`,
+`ssr`, plus loader phases such as `code-runs`). When the primary URL is `/`, it
+also probes `/onboarding` and `/guides/how-kody-works` for the same timing
+snapshot. Those extra pages are observational and do not change the verdict.
+Homepage HTML that lacks an app `ssr` phase is a finding. The collector then
+classifies against
 [`tools/site-perf/budget.json`](../../tools/site-perf/budget.json).
 
 [`.github/workflows/weekly-site-perf.yml`](../../.github/workflows/weekly-site-perf.yml)

--- a/docs/contributing/weekly-site-perf.md
+++ b/docs/contributing/weekly-site-perf.md
@@ -24,10 +24,10 @@ homepage, records HTML weight, `Cache-Control`, the largest same-origin JS
 payload, the preloaded LCP image, TTFB, and `Server-Timing` phases (`session`,
 `ssr`, plus loader phases such as `code-runs`). When the primary URL is `/`, it
 also probes `/onboarding` and `/guides/how-kody-works` for the same timing
-snapshot. Those extra pages are observational and do not change the verdict.
-Homepage HTML that lacks an app `ssr` phase is a finding. The collector then
-classifies against
-[`tools/site-perf/budget.json`](../../tools/site-perf/budget.json).
+snapshot. Those extra pages are observational and do not change the verdict. A
+failed extra probe is omitted so homepage classify still runs. Homepage HTML
+that lacks an app `ssr` phase is a finding. The collector then classifies
+against [`tools/site-perf/budget.json`](../../tools/site-perf/budget.json).
 
 [`.github/workflows/weekly-site-perf.yml`](../../.github/workflows/weekly-site-perf.yml)
 runs that collector on Mondays at 14:17 UTC and on `workflow_dispatch`.

--- a/packages/highlight-worker/readme.md
+++ b/packages/highlight-worker/readme.md
@@ -6,6 +6,8 @@ receives serializable token trees. There is no public hostname; health is
 `GET /health` on the workers.dev URL the deploy workflow records.
 
 The browser never talks to this worker. Highlighted code is loader/API data.
+Successful `/highlight` responses include `x-kody-highlight-cache: hit|miss` so
+origin can attribute `Server-Timing` `highlight` as `worker` vs `miss`.
 
 - `wrangler.jsonc` — committed config (script name `kody-highlight`).
 - Build check: `npm run highlight:build` (part of `npm run validate`).

--- a/packages/highlight-worker/src/index.node.test.ts
+++ b/packages/highlight-worker/src/index.node.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from 'vitest'
+import { highlightCacheHeaderName } from '../../worker/universal/highlight-cache-header.ts'
+import handler from './index.ts'
+
+test('highlight worker returns tokens and a cache header', async () => {
+	const response = await handler.fetch(
+		new Request('https://highlight.internal/highlight', {
+			method: 'POST',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify({
+				snippets: [{ code: 'const x = 1', lang: 'ts' }],
+			}),
+		}),
+		{},
+	)
+	expect(response.status).toBe(200)
+	const body = (await response.json()) as {
+		results: Array<{ code: string; plain: boolean }>
+	}
+	expect(body.results).toHaveLength(1)
+	expect(body.results[0]?.code).toBe('const x = 1')
+	expect(body.results[0]?.plain).toBe(false)
+	expect(response.headers.get(highlightCacheHeaderName)).toBe('miss')
+})

--- a/packages/highlight-worker/src/index.ts
+++ b/packages/highlight-worker/src/index.ts
@@ -1,3 +1,4 @@
+import { highlightCacheHeaderName } from '../../worker/universal/highlight-cache-header.ts'
 import {
 	type HighlightedCode,
 	type HighlightSnippet,
@@ -90,12 +91,22 @@ const handler = {
 		}
 
 		const cached = await readCachedResults(snippets)
-		if (cached) return Response.json({ results: cached })
+		if (cached) return highlightJsonResponse(cached, 'hit')
 
 		const results = tokenizeSnippets(snippets)
 		await writeCachedResults(snippets, results)
-		return Response.json({ results })
+		return highlightJsonResponse(results, 'miss')
 	},
 } satisfies ExportedHandler<HighlightWorkerEnv>
+
+function highlightJsonResponse(
+	results: Array<HighlightedCode>,
+	cache: 'hit' | 'miss',
+) {
+	return Response.json(
+		{ results },
+		{ headers: { [highlightCacheHeaderName]: cache } },
+	)
+}
 
 export default handler

--- a/packages/highlight-worker/tsconfig.json
+++ b/packages/highlight-worker/tsconfig.json
@@ -13,6 +13,7 @@
 	"include": [
 		"src/**/*.ts",
 		"../worker/universal/highlighted-code.ts",
+		"../worker/universal/highlight-cache-header.ts",
 		"../worker/universal/highlight-cache-request.ts"
 	]
 }

--- a/packages/worker/src/app/account-activity-data.ts
+++ b/packages/worker/src/app/account-activity-data.ts
@@ -1,5 +1,6 @@
 import { type readAuthenticatedAppUser } from '#app/authenticated-user.ts'
 import { highlightJsonValue } from '#app/highlight-code.ts'
+import { type ServerTimingEntry } from '#worker/server-timing.ts'
 import { type HighlightedCode } from '#universal/highlighted-code.ts'
 import {
 	getRunRecord,
@@ -231,6 +232,7 @@ async function toDetail(
 	env: Env,
 	run: RunRecord,
 	logs: Array<RunRecordLog>,
+	serverTiming?: Array<ServerTimingEntry>,
 ): Promise<AccountActivityRunDetail> {
 	return {
 		...toListItem(run),
@@ -247,7 +249,9 @@ async function toDetail(
 		triagedAt: run.triagedAt,
 		triagedBy: run.triagedBy,
 		metadata: run.metadata,
-		metadataHighlighted: await highlightJsonValue(env, run.metadata),
+		metadataHighlighted: await highlightJsonValue(env, run.metadata, {
+			serverTiming,
+		}),
 		logs: logs
 			.slice()
 			.sort((a, b) => a.sequence - b.sequence)
@@ -270,6 +274,7 @@ export async function loadAccountActivityData(input: {
 	user: AuthenticatedUser
 	pathRunId?: string
 	now?: Date
+	serverTiming?: Array<ServerTimingEntry>
 }): Promise<AccountActivityLoaderData> {
 	const userId = input.user.mcpUser.userId
 	const now = input.now ?? new Date()
@@ -324,7 +329,12 @@ export async function loadAccountActivityData(input: {
 		runs: page.runs.map(toListItem),
 		nextCursor: page.nextCursor,
 		selectedRun: selectedRecord
-			? await toDetail(input.env, selectedRecord.run, selectedRecord.logs)
+			? await toDetail(
+					input.env,
+					selectedRecord.run,
+					selectedRecord.logs,
+					input.serverTiming,
+				)
 			: null,
 		selectedRunId,
 		retentionDays: runRecordRetentionDays,

--- a/packages/worker/src/app/account-jobs-data.ts
+++ b/packages/worker/src/app/account-jobs-data.ts
@@ -15,6 +15,7 @@ import { listSavedPackagesByUserId } from '#worker/package-registry/repo.ts'
 import { listRunRecords } from '#worker/run-records/service.ts'
 import { type HighlightedCode } from '#universal/highlighted-code.ts'
 import { highlightJsonValue } from '#app/highlight-code.ts'
+import { type ServerTimingEntry } from '#worker/server-timing.ts'
 
 type AuthenticatedUser = NonNullable<
 	Awaited<ReturnType<typeof readAuthenticatedAppUser>>
@@ -196,6 +197,7 @@ async function toDetail(input: {
 	userId: string
 	job: JobView
 	packageNamesById: ReadonlyMap<string, string>
+	serverTiming?: Array<ServerTimingEntry>
 }): Promise<AccountJobDetail> {
 	const inspection = buildJobInspectionOutput(input.job)
 	const recentRuns = await loadRecentRunsForJob({
@@ -209,6 +211,7 @@ async function toDetail(input: {
 		paramsHighlighted: await highlightJsonValue(
 			input.env,
 			input.job.params ?? {},
+			{ serverTiming: input.serverTiming },
 		),
 		schedule: input.job.schedule,
 		lastRunError: input.job.lastRunError ?? null,
@@ -240,6 +243,7 @@ export async function loadAccountJobsData(input: {
 	request: Request
 	user: AuthenticatedUser
 	pathJobId?: string
+	serverTiming?: Array<ServerTimingEntry>
 }): Promise<AccountJobsLoaderData> {
 	const userId = input.user.mcpUser.userId
 	const selectedJobId = readAccountJobsSelectedJobId(
@@ -273,6 +277,7 @@ export async function loadAccountJobsData(input: {
 					userId,
 					job: selectedRecord,
 					packageNamesById,
+					serverTiming: input.serverTiming,
 				})
 			: null,
 		selectedJobId,

--- a/packages/worker/src/app/handlers/account-activity.ts
+++ b/packages/worker/src/app/handlers/account-activity.ts
@@ -6,6 +6,7 @@ import { type AccountActivityLoaderData as AppAccountActivityLoaderData } from '
 import { requireAuthenticatedPageUser } from '#app/page-auth.ts'
 import { type routes } from '#universal/routes.ts'
 import { renderAppPage } from '#app/ssr-render.tsx'
+import { type ServerTimingEntry } from '#worker/server-timing.ts'
 
 function readPathRunId(params: unknown) {
 	if (
@@ -31,11 +32,13 @@ export function createAccountActivityHandler(env: Env) {
 				return user
 			}
 
+			const serverTiming: Array<ServerTimingEntry> = []
 			const accountActivity = await loadAccountActivityData({
 				env,
 				request,
 				user,
 				pathRunId: readPathRunId(params),
+				serverTiming,
 			})
 			return renderAppPage({
 				request,
@@ -44,6 +47,7 @@ export function createAccountActivityHandler(env: Env) {
 				loaderData: {
 					accountActivity: accountActivity as AppAccountActivityLoaderData,
 				},
+				serverTiming,
 			})
 		},
 	} satisfies Action<
@@ -67,12 +71,15 @@ export function createAccountActivityApiHandler(env: Env) {
 				return jsonResponse({ ok: false, error: 'Method not allowed.' }, 405)
 			}
 
+			const serverTiming: Array<ServerTimingEntry> = []
 			return jsonResponse(
 				await loadAccountActivityData({
 					env,
 					request,
 					user,
+					serverTiming,
 				}),
+				{ serverTiming },
 			)
 		},
 	} satisfies Action<typeof routes.accountActivityApi>

--- a/packages/worker/src/app/handlers/account-jobs.ts
+++ b/packages/worker/src/app/handlers/account-jobs.ts
@@ -12,6 +12,7 @@ import { requireAuthenticatedPageUser } from '#app/page-auth.ts'
 import { readTrimmedStringOrEmpty } from '#app/request-body.ts'
 import { type routes } from '#universal/routes.ts'
 import { renderAppPage } from '#app/ssr-render.tsx'
+import { type ServerTimingEntry } from '#worker/server-timing.ts'
 import { createMcpCallerContext } from '#mcp/context.ts'
 import { runJobNowViaManager } from '#worker/jobs/manager-client.ts'
 import { updateJobRetentionPreferencesForUser } from '#worker/jobs/job-retention-cleanup.ts'
@@ -45,11 +46,13 @@ export function createAccountJobsHandler(env: Env) {
 				return user
 			}
 
+			const serverTiming: Array<ServerTimingEntry> = []
 			const accountJobs = await loadAccountJobsData({
 				env,
 				request,
 				user,
 				pathJobId: readPathJobId(params),
+				serverTiming,
 			})
 			return renderAppPage({
 				request,
@@ -58,6 +61,7 @@ export function createAccountJobsHandler(env: Env) {
 				loaderData: {
 					accountJobs: accountJobs as AppAccountJobsLoaderData,
 				},
+				serverTiming,
 			})
 		},
 	} satisfies Action<typeof routes.accountJobs | typeof routes.accountJobDetail>
@@ -76,12 +80,15 @@ export function createAccountJobsApiHandler(env: Env) {
 			}
 
 			if (request.method === 'GET') {
+				const serverTiming: Array<ServerTimingEntry> = []
 				return jsonResponse(
 					await loadAccountJobsData({
 						env,
 						request,
 						user,
+						serverTiming,
 					}),
+					{ serverTiming },
 				)
 			}
 

--- a/packages/worker/src/app/handlers/blog.tsx
+++ b/packages/worker/src/app/handlers/blog.tsx
@@ -19,6 +19,7 @@ import {
 } from '#app/markdown-negotiation.ts'
 import { parseOgTheme } from '#worker/og/palette.ts'
 import { highlightMarkdownFences } from '#app/highlight-code.ts'
+import { type ServerTimingEntry } from '#worker/server-timing.ts'
 
 export function createBlogHandler(env: Env) {
 	return {
@@ -50,7 +51,11 @@ export function createBlogApiHandler(_env: Env) {
 }
 
 /** Loader payload shared by the SSR page and the JSON API. */
-async function toBlogPostLoaderData(env: Env, post: BlogPost) {
+async function toBlogPostLoaderData(
+	env: Env,
+	post: BlogPost,
+	serverTiming?: Array<ServerTimingEntry>,
+) {
 	return {
 		ok: true as const,
 		slug: post.slug,
@@ -62,7 +67,7 @@ async function toBlogPostLoaderData(env: Env, post: BlogPost) {
 		imageAlt: post.imageAlt,
 		ogImage: post.ogImage,
 		body: post.body,
-		bodyFences: await highlightMarkdownFences(env, post.body),
+		bodyFences: await highlightMarkdownFences(env, post.body, { serverTiming }),
 		readNext: getReadNextBlogPost(post.slug),
 	}
 }
@@ -90,13 +95,15 @@ export function createBlogPostHandler(env: Env) {
 				return markdownResponse(post.body)
 			}
 
+			const serverTiming: Array<ServerTimingEntry> = []
 			return withVaryAccept(
 				await renderAppPage({
 					request,
 					env,
 					loaderData: {
-						blogPost: await toBlogPostLoaderData(env, post),
+						blogPost: await toBlogPostLoaderData(env, post, serverTiming),
 					},
+					serverTiming,
 				}),
 			)
 		},
@@ -112,7 +119,10 @@ export function createBlogPostApiHandler(env: Env) {
 				return jsonResponse({ ok: false, error: 'Blog post not found.' }, 404)
 			}
 
-			return jsonResponse(await toBlogPostLoaderData(env, post))
+			const serverTiming: Array<ServerTimingEntry> = []
+			return jsonResponse(await toBlogPostLoaderData(env, post, serverTiming), {
+				serverTiming,
+			})
 		},
 	} satisfies Action<typeof routes.blogPostApi>
 }

--- a/packages/worker/src/app/handlers/community-detail.tsx
+++ b/packages/worker/src/app/handlers/community-detail.tsx
@@ -32,6 +32,7 @@ import { type CommunityListingRecord } from '#worker/community/types.ts'
 import { parseOgTheme } from '#worker/og/palette.ts'
 import { highlightMarkdownFences } from '#app/highlight-code.ts'
 import { type HighlightedCode } from '#universal/highlighted-code.ts'
+import { type ServerTimingEntry } from '#worker/server-timing.ts'
 
 const reportReasonSchema = z
 	.string()
@@ -79,14 +80,17 @@ async function renderCommunityListingPage(input: {
 		})
 	}
 
+	const serverTiming: Array<ServerTimingEntry> = []
 	const readmeFences = await highlightReadmeFences(
 		input.env,
 		detail.listing.readmeContent,
+		serverTiming,
 	)
 
 	return renderAppPage({
 		request: input.request,
 		env: input.env,
+		serverTiming,
 		loaderData: {
 			communityDetailShell: {
 				ok: true,
@@ -111,9 +115,10 @@ async function renderCommunityListingPage(input: {
 async function highlightReadmeFences(
 	env: Env,
 	readmeContent: string | null,
+	serverTiming?: Array<ServerTimingEntry>,
 ): Promise<Array<HighlightedCode>> {
 	if (!readmeContent) return []
-	return highlightMarkdownFences(env, readmeContent)
+	return highlightMarkdownFences(env, readmeContent, { serverTiming })
 }
 
 /**
@@ -187,13 +192,20 @@ export function createCommunityDetailApiHandler(env: Env) {
 				)
 			}
 
-			return jsonResponse(request, {
-				...detail,
-				readmeFences: await highlightReadmeFences(
-					env,
-					detail.listing.readmeContent,
-				),
-			})
+			const serverTiming: Array<ServerTimingEntry> = []
+			return jsonResponse(
+				request,
+				{
+					...detail,
+					readmeFences: await highlightReadmeFences(
+						env,
+						detail.listing.readmeContent,
+						serverTiming,
+					),
+				},
+				200,
+				serverTiming,
+			)
 		},
 	} satisfies Action<typeof routes.communityDetailApi>
 }
@@ -233,13 +245,20 @@ export function createCommunityPackageApiHandler(env: Env) {
 				)
 			}
 
-			return jsonResponse(request, {
-				...detail,
-				readmeFences: await highlightReadmeFences(
-					env,
-					detail.listing.readmeContent,
-				),
-			})
+			const serverTiming: Array<ServerTimingEntry> = []
+			return jsonResponse(
+				request,
+				{
+					...detail,
+					readmeFences: await highlightReadmeFences(
+						env,
+						detail.listing.readmeContent,
+						serverTiming,
+					),
+				},
+				200,
+				serverTiming,
+			)
 		},
 	} satisfies Action<typeof routes.communityPackageApi>
 }
@@ -392,10 +411,12 @@ function jsonResponse(
 	request: Request,
 	body: Record<string, unknown>,
 	status = 200,
+	serverTiming?: Array<ServerTimingEntry>,
 ) {
 	const cacheLookup = getRequestDataCacheLookup(request)
 	return buildJsonResponse(body, {
 		status,
 		headers: cacheLookup ? { 'X-Kody-Cache': cacheLookup } : undefined,
+		serverTiming,
 	})
 }

--- a/packages/worker/src/app/handlers/guides.node.test.ts
+++ b/packages/worker/src/app/handlers/guides.node.test.ts
@@ -186,6 +186,9 @@ test('interactive guide JSON includes walkthrough highlight tokens', async () =>
 		},
 	)
 	expect(howKodyWorksResponse.status).toBe(200)
+	expect(howKodyWorksResponse.headers.get('Server-Timing') ?? '').toContain(
+		'highlight;dur=',
+	)
 	const howKodyWorksPayload = (await howKodyWorksResponse.json()) as {
 		ok: boolean
 		walkthroughHighlights?: Record<

--- a/packages/worker/src/app/handlers/guides.tsx
+++ b/packages/worker/src/app/handlers/guides.tsx
@@ -25,6 +25,7 @@ import { collectGoogleOauthSnippets } from '#universal/google-oauth-transcript.t
 import { collectHowKodyWorksSnippets } from '#universal/how-kody-works-transcript.ts'
 import { type GuideDetailLoaderData } from '#universal/loader-data.ts'
 import { type Guide } from '#worker/guides/parse-frontmatter.ts'
+import { type ServerTimingEntry } from '#worker/server-timing.ts'
 
 function buildGuidesIndexMarkdown(baseUrl: string): string {
 	const lines = [
@@ -67,19 +68,27 @@ function collectWalkthroughSnippets(slug: string) {
 	}
 }
 
-async function highlightWalkthrough(env: Env, slug: string) {
+async function highlightWalkthrough(
+	env: Env,
+	slug: string,
+	serverTiming?: Array<ServerTimingEntry>,
+) {
 	const snippets = uniqueHighlightSnippets(collectWalkthroughSnippets(slug))
 	if (snippets.length === 0) return undefined
-	return highlightResultsByKey(snippets, await highlightSnippets(env, snippets))
+	return highlightResultsByKey(
+		snippets,
+		await highlightSnippets(env, snippets, { serverTiming }),
+	)
 }
 
 async function toGuideDetail(
 	env: Env,
 	guide: Guide,
+	serverTiming?: Array<ServerTimingEntry>,
 ): Promise<GuideDetailLoaderData> {
 	const [bodyFences, walkthroughHighlights] = await Promise.all([
-		highlightMarkdownFences(env, guide.body),
-		highlightWalkthrough(env, guide.slug),
+		highlightMarkdownFences(env, guide.body, { serverTiming }),
+		highlightWalkthrough(env, guide.slug, serverTiming),
 	])
 	return {
 		ok: true,
@@ -165,13 +174,15 @@ export function createGuideDetailHandler(env: Env) {
 			if (prefersMarkdown(request)) {
 				return markdownResponse(guide.body)
 			}
+			const serverTiming: Array<ServerTimingEntry> = []
 			return withVaryAccept(
 				await renderAppPage({
 					request,
 					env,
 					loaderData: {
-						guideDetail: await toGuideDetail(env, guide),
+						guideDetail: await toGuideDetail(env, guide, serverTiming),
 					},
+					serverTiming,
 				}),
 			)
 		},
@@ -186,7 +197,10 @@ export function createGuideDetailApiHandler(env: Env) {
 			if (!guide) {
 				return jsonResponse({ ok: false, error: 'Guide not found.' }, 404)
 			}
-			return jsonResponse(await toGuideDetail(env, guide))
+			const serverTiming: Array<ServerTimingEntry> = []
+			return jsonResponse(await toGuideDetail(env, guide, serverTiming), {
+				serverTiming,
+			})
 		},
 	} satisfies Action<typeof routes.guideDetailApi>
 }

--- a/packages/worker/src/app/handlers/home.ts
+++ b/packages/worker/src/app/handlers/home.ts
@@ -17,6 +17,10 @@ import {
 import { renderAppPage } from '#app/ssr-render.tsx'
 import { loadPublicCodeRunsWindow } from '#worker/usage/code-runs-window.ts'
 import { type routes } from '#universal/routes.ts'
+import {
+	pushServerTiming,
+	type ServerTimingEntry,
+} from '#worker/server-timing.ts'
 
 export function createHomeHandler(env: Env) {
 	return {
@@ -30,7 +34,12 @@ export function createHomeHandler(env: Env) {
 				)
 			}
 
-			const codeRunsWindow = await loadPublicCodeRunsWindow(env)
+			const serverTiming: Array<ServerTimingEntry> = []
+			const codeRunsWindow = await pushServerTiming(
+				serverTiming,
+				'code-runs',
+				() => loadPublicCodeRunsWindow(env),
+			)
 			const codeRuns = { ok: true as const, window: codeRunsWindow }
 
 			const user = await readAuthenticatedAppUser(request, env)
@@ -50,6 +59,7 @@ export function createHomeHandler(env: Env) {
 								}),
 								codeRuns,
 							},
+							serverTiming,
 						}),
 					),
 					origin,
@@ -69,6 +79,7 @@ export function createHomeHandler(env: Env) {
 						request,
 						env,
 						loaderData: { onboarding, codeRuns },
+						serverTiming,
 					}),
 				),
 				origin,

--- a/packages/worker/src/app/handlers/onboarding.node.test.ts
+++ b/packages/worker/src/app/handlers/onboarding.node.test.ts
@@ -85,6 +85,10 @@ test('onboarding serves public setup content to anonymous visitors', async () =>
 		new RequestContext(new Request('https://example.com/onboarding.json')),
 	)
 	expect(anonymousApiResponse.status).toBe(200)
+	const onboardingTiming =
+		anonymousApiResponse.headers.get('Server-Timing') ?? ''
+	expect(onboardingTiming).toContain('listings;dur=')
+	expect(onboardingTiming).toContain('highlight;dur=')
 	// Payload shape belongs to onboarding-data; the handler just serves it.
 	await expect(anonymousApiResponse.json()).resolves.toMatchObject({
 		ok: true,

--- a/packages/worker/src/app/handlers/onboarding.ts
+++ b/packages/worker/src/app/handlers/onboarding.ts
@@ -48,6 +48,10 @@ import {
 	highlightSnippets,
 } from '#app/highlight-code.ts'
 import { collectOnboardingMcpSnippets } from '#universal/onboarding-mcp-clients.ts'
+import {
+	pushServerTiming,
+	type ServerTimingEntry,
+} from '#worker/server-timing.ts'
 
 /**
  * The checklist derives from existing signals (mailbox, memories,
@@ -275,12 +279,13 @@ function redirectUnverifiedToPending(request: Request) {
 async function withOnboardingHighlights(
 	env: Env,
 	data: OnboardingLoaderData,
+	serverTiming?: Array<ServerTimingEntry>,
 ): Promise<OnboardingLoaderData> {
 	if (!data.mcpServerUrl) {
 		return { ...data, mcpHighlights: {} }
 	}
 	const snippets = collectOnboardingMcpSnippets(data.mcpServerUrl)
-	const results = await highlightSnippets(env, snippets)
+	const results = await highlightSnippets(env, snippets, { serverTiming })
 	return {
 		...data,
 		mcpHighlights: highlightResultsByKey(snippets, results),
@@ -291,21 +296,29 @@ export function createOnboardingHandler(env: Env) {
 	return {
 		middleware: [],
 		async handler({ request }) {
+			const serverTiming: Array<ServerTimingEntry> = []
 			const user = await readAuthenticatedAppUser(request, env)
 			if (!user) {
 				const { persistContext: _persistContext, ...chooser } =
-					await loadOnboardingChooserFields(env, request)
-				const onboarding = await withOnboardingHighlights(env, {
-					...loadPublicOnboardingData({
-						env,
-						requestUrl: request.url,
-					}),
-					...chooser,
-				})
+					await pushServerTiming(serverTiming, 'listings', () =>
+						loadOnboardingChooserFields(env, request),
+					)
+				const onboarding = await withOnboardingHighlights(
+					env,
+					{
+						...loadPublicOnboardingData({
+							env,
+							requestUrl: request.url,
+						}),
+						...chooser,
+					},
+					serverTiming,
+				)
 				return renderAppPage({
 					request,
 					env,
 					loaderData: { onboarding },
+					serverTiming,
 				})
 			}
 
@@ -313,10 +326,8 @@ export function createOnboardingHandler(env: Env) {
 				return redirectUnverifiedToPending(request)
 			}
 
-			const chooser = await loadOnboardingChooserFields(
-				env,
-				request,
-				user.mcpUser.userId,
+			const chooser = await pushServerTiming(serverTiming, 'listings', () =>
+				loadOnboardingChooserFields(env, request, user.mcpUser.userId),
 			)
 			const onboarding = await loadOnboardingData({
 				env,
@@ -341,8 +352,13 @@ export function createOnboardingHandler(env: Env) {
 				request,
 				env,
 				loaderData: {
-					onboarding: await withOnboardingHighlights(env, onboarding),
+					onboarding: await withOnboardingHighlights(
+						env,
+						onboarding,
+						serverTiming,
+					),
 				},
+				serverTiming,
 			})
 		},
 	} satisfies Action<typeof routes.onboarding>
@@ -356,18 +372,26 @@ export function createOnboardingApiHandler(env: Env) {
 				return jsonResponse({ ok: false, error: 'Method not allowed.' }, 405)
 			}
 
+			const serverTiming: Array<ServerTimingEntry> = []
 			const user = await readAuthenticatedAppUser(request, env)
 			if (!user) {
 				const { persistContext: _persistContext, ...chooser } =
-					await loadOnboardingChooserFields(env, request)
+					await pushServerTiming(serverTiming, 'listings', () =>
+						loadOnboardingChooserFields(env, request),
+					)
 				return jsonResponse(
-					await withOnboardingHighlights(env, {
-						...loadPublicOnboardingData({
-							env,
-							requestUrl: request.url,
-						}),
-						...chooser,
-					}),
+					await withOnboardingHighlights(
+						env,
+						{
+							...loadPublicOnboardingData({
+								env,
+								requestUrl: request.url,
+							}),
+							...chooser,
+						},
+						serverTiming,
+					),
+					{ serverTiming },
 				)
 			}
 
@@ -375,7 +399,9 @@ export function createOnboardingApiHandler(env: Env) {
 			// gate; MCP URL/setup and featured fields stay empty until
 			// verification succeeds.
 			const chooser = user.emailVerified
-				? await loadOnboardingChooserFields(env, request, user.mcpUser.userId)
+				? await pushServerTiming(serverTiming, 'listings', () =>
+						loadOnboardingChooserFields(env, request, user.mcpUser.userId),
+					)
 				: null
 			const onboarding = await loadOnboardingData({
 				env,
@@ -398,7 +424,10 @@ export function createOnboardingApiHandler(env: Env) {
 					loadPersistedPackageKodyId(env, user.mcpUser.userId),
 				])
 			}
-			return jsonResponse(await withOnboardingHighlights(env, onboarding))
+			return jsonResponse(
+				await withOnboardingHighlights(env, onboarding, serverTiming),
+				{ serverTiming },
+			)
 		},
 	} satisfies Action<typeof routes.onboardingApi>
 }

--- a/packages/worker/src/app/handlers/package-files.node.test.ts
+++ b/packages/worker/src/app/handlers/package-files.node.test.ts
@@ -90,6 +90,7 @@ test('community files API resolves the listing, rejects traversal, and 404s miss
 		env: {},
 		listingId: 'listing-1',
 		selectedPath: 'src/index.ts',
+		serverTiming: expect.any(Array),
 	})
 
 	const invalid = await handler.handler({
@@ -147,5 +148,6 @@ test('account files API requires the owner session and does not leak other users
 		userId: 'stable-user-1',
 		packageId: 'pkg-1',
 		selectedPath: 'src/index.ts',
+		serverTiming: expect.any(Array),
 	})
 })

--- a/packages/worker/src/app/handlers/package-files.ts
+++ b/packages/worker/src/app/handlers/package-files.ts
@@ -22,6 +22,7 @@ import {
 	normalizePackageFilesPath,
 } from '#universal/package-files.ts'
 import { type routes } from '#universal/routes.ts'
+import { type ServerTimingEntry } from '#worker/server-timing.ts'
 
 function redirectToCanonicalPath(input: { path: string; url: URL }) {
 	const destination = new URL(input.path, input.url)
@@ -41,11 +42,13 @@ async function renderCommunityFilesPage(input: {
 	listingId: string | null
 	selectedPath: string
 }) {
+	const serverTiming: Array<ServerTimingEntry> = []
 	const data = input.listingId
 		? await loadCommunityPackageFilesData({
 				env: input.env,
 				listingId: input.listingId,
 				selectedPath: input.selectedPath,
+				serverTiming,
 			})
 		: null
 	if (!data) {
@@ -55,6 +58,7 @@ async function renderCommunityFilesPage(input: {
 			title: 'Package files not found',
 			notFound: true,
 			status: 404,
+			serverTiming,
 		})
 	}
 	return renderAppPage({
@@ -62,6 +66,7 @@ async function renderCommunityFilesPage(input: {
 		env: input.env,
 		title: `${data.title} files`,
 		loaderData: { packageFiles: data },
+		serverTiming,
 	})
 }
 
@@ -172,11 +177,13 @@ export function createCommunityPackageFilesApiHandler(env: Env) {
 					404,
 				)
 			}
+			const serverTiming: Array<ServerTimingEntry> = []
 			const data = target
 				? await loadCommunityPackageFilesData({
 						env,
 						listingId: target.listingId,
 						selectedPath,
+						serverTiming,
 					})
 				: null
 			if (!data) {
@@ -185,7 +192,7 @@ export function createCommunityPackageFilesApiHandler(env: Env) {
 					404,
 				)
 			}
-			return jsonResponse(data)
+			return jsonResponse(data, { serverTiming })
 		},
 	} satisfies Action<typeof routes.communityPackageFilesApi>
 }
@@ -201,10 +208,12 @@ export function createCommunityDetailFilesApiHandler(env: Env) {
 					400,
 				)
 			}
+			const serverTiming: Array<ServerTimingEntry> = []
 			const data = await loadCommunityPackageFilesData({
 				env,
 				listingId: params.listingId,
 				selectedPath,
+				serverTiming,
 			})
 			if (!data) {
 				return jsonResponse(
@@ -212,7 +221,7 @@ export function createCommunityDetailFilesApiHandler(env: Env) {
 					404,
 				)
 			}
-			return jsonResponse(data)
+			return jsonResponse(data, { serverTiming })
 		},
 	} satisfies Action<typeof routes.communityDetailFilesApi>
 }
@@ -237,12 +246,14 @@ export function createAccountPackageFilesHandler(env: Env) {
 				})
 			}
 
+			const serverTiming: Array<ServerTimingEntry> = []
 			const data = await loadAccountPackageFilesData({
 				env,
 				request,
 				userId: user.mcpUser.userId,
 				packageId: params.packageId,
 				selectedPath,
+				serverTiming,
 			})
 			if (!data) {
 				return renderAppPage({
@@ -251,6 +262,7 @@ export function createAccountPackageFilesHandler(env: Env) {
 					title: 'Package files not found',
 					notFound: true,
 					status: 404,
+					serverTiming,
 				})
 			}
 			return renderAppPage({
@@ -258,6 +270,7 @@ export function createAccountPackageFilesHandler(env: Env) {
 				env,
 				title: `${data.title} files`,
 				loaderData: { packageFiles: data },
+				serverTiming,
 			})
 		},
 	} satisfies Action<typeof routes.accountPackageFiles>
@@ -281,12 +294,14 @@ export function createAccountPackageFilesApiHandler(env: Env) {
 					400,
 				)
 			}
+			const serverTiming: Array<ServerTimingEntry> = []
 			const data = await loadAccountPackageFilesData({
 				env,
 				request,
 				userId: user.mcpUser.userId,
 				packageId: params.packageId,
 				selectedPath,
+				serverTiming,
 			})
 			if (!data) {
 				return jsonResponse(
@@ -294,7 +309,7 @@ export function createAccountPackageFilesApiHandler(env: Env) {
 					404,
 				)
 			}
-			return jsonResponse(data)
+			return jsonResponse(data, { serverTiming })
 		},
 	} satisfies Action<typeof routes.accountPackageFilesApi>
 }

--- a/packages/worker/src/app/highlight-code.node.test.ts
+++ b/packages/worker/src/app/highlight-code.node.test.ts
@@ -7,11 +7,13 @@ import {
 	highlightSnippets,
 	uniqueHighlightSnippets,
 } from '#app/highlight-code.ts'
+import { highlightCacheHeaderName } from '#universal/highlight-cache-header.ts'
 import {
 	highlightSnippetKey,
 	plainHighlightedCode,
 	type HighlightedCode,
 } from '#universal/highlighted-code.ts'
+import { type ServerTimingEntry } from '#worker/server-timing.ts'
 
 function highlightedFixture(
 	code: string,
@@ -43,11 +45,55 @@ test('collectMarkdownFences walks top-level and nested code tokens', () => {
 	).toEqual([{ code: '{"ok": true}', lang: 'json' }])
 })
 
-test('highlightSnippets falls back to plaintext when HIGHLIGHT is missing', async () => {
-	const results = await highlightSnippets({}, [
-		{ code: 'const x = 1', lang: 'ts' },
+test('highlightSnippets records fallback, worker, miss, and origin-hit timings', async () => {
+	const fallbackTiming: Array<ServerTimingEntry> = []
+	const fallback = await highlightSnippets(
+		{},
+		[{ code: 'const x = 1', lang: 'ts' }],
+		{ serverTiming: fallbackTiming },
+	)
+	expect(fallback).toEqual([plainHighlightedCode('const x = 1', 'ts')])
+	expect(fallbackTiming).toEqual([
+		expect.objectContaining({ name: 'highlight', desc: 'fallback' }),
 	])
-	expect(results).toEqual([plainHighlightedCode('const x = 1', 'ts')])
+
+	const snippet = { code: 'const x = 1', lang: 'ts' as const }
+	const fixture = highlightedFixture(snippet.code)
+	const workerTiming: Array<ServerTimingEntry> = []
+	const workerEnv = {
+		HIGHLIGHT: {
+			fetch: async () =>
+				Response.json(
+					{ results: [fixture] },
+					{ headers: { [highlightCacheHeaderName]: 'hit' } },
+				),
+		} as unknown as Fetcher,
+	}
+	expect(
+		await highlightSnippets(workerEnv, [snippet], {
+			serverTiming: workerTiming,
+		}),
+	).toEqual([fixture])
+	expect(workerTiming).toEqual([
+		expect.objectContaining({ name: 'highlight', desc: 'worker' }),
+	])
+
+	const missTiming: Array<ServerTimingEntry> = []
+	const missEnv = {
+		HIGHLIGHT: {
+			fetch: async () =>
+				Response.json(
+					{ results: [fixture] },
+					{ headers: { [highlightCacheHeaderName]: 'miss' } },
+				),
+		} as unknown as Fetcher,
+	}
+	expect(
+		await highlightSnippets(missEnv, [snippet], { serverTiming: missTiming }),
+	).toEqual([fixture])
+	expect(missTiming).toEqual([
+		expect.objectContaining({ name: 'highlight', desc: 'miss' }),
+	])
 })
 
 test('highlightSnippets returns worker tokens and maps them by snippet key', async () => {

--- a/packages/worker/src/app/highlight-code.ts
+++ b/packages/worker/src/app/highlight-code.ts
@@ -1,4 +1,5 @@
 import { lexer, type Token, type Tokens } from 'marked'
+import { highlightCacheHeaderName } from '#universal/highlight-cache-header.ts'
 import { highlightBatchCacheRequest } from '#universal/highlight-cache-request.ts'
 import {
 	highlightSnippetKey,
@@ -6,9 +7,29 @@ import {
 	type HighlightedCode,
 	type HighlightSnippet,
 } from '#universal/highlighted-code.ts'
+import { type ServerTimingEntry } from '#worker/server-timing.ts'
 
 export type HighlightEnv = {
 	HIGHLIGHT?: Fetcher
+}
+
+export type HighlightOptions = {
+	serverTiming?: Array<ServerTimingEntry>
+}
+
+type HighlightCacheDesc = 'hit' | 'worker' | 'miss' | 'fallback'
+
+function recordHighlight(
+	serverTiming: Array<ServerTimingEntry> | undefined,
+	startedAt: number,
+	desc: HighlightCacheDesc,
+) {
+	if (!serverTiming) return
+	serverTiming.push({
+		name: 'highlight',
+		durationMs: Date.now() - startedAt,
+		desc,
+	})
 }
 
 const highlightOrigin = 'https://highlight.internal'
@@ -75,14 +96,20 @@ async function writeOriginCache(
 export async function highlightSnippets(
 	env: HighlightEnv,
 	snippets: Array<HighlightSnippet>,
+	options?: HighlightOptions,
 ): Promise<Array<HighlightedCode>> {
 	if (snippets.length === 0) return []
 
+	const startedAt = Date.now()
 	const cached = await readOriginCache(snippets)
-	if (cached) return cached
+	if (cached) {
+		recordHighlight(options?.serverTiming, startedAt, 'hit')
+		return cached
+	}
 
 	const highlight = env.HIGHLIGHT
 	if (!highlight) {
+		recordHighlight(options?.serverTiming, startedAt, 'fallback')
 		return snippets.map((snippet) =>
 			plainHighlightedCode(snippet.code, snippet.lang),
 		)
@@ -108,9 +135,17 @@ export async function highlightSnippets(
 			throw new Error('highlight worker returned unexpected results')
 		}
 		await writeOriginCache(snippets, body.results)
+		recordHighlight(
+			options?.serverTiming,
+			startedAt,
+			response.headers.get(highlightCacheHeaderName) === 'hit'
+				? 'worker'
+				: 'miss',
+		)
 		return body.results
 	} catch (error) {
 		console.debug('highlight-binding-failed', error)
+		recordHighlight(options?.serverTiming, startedAt, 'fallback')
 		return snippets.map((snippet) =>
 			plainHighlightedCode(snippet.code, snippet.lang),
 		)
@@ -151,16 +186,22 @@ export function collectMarkdownFences(
 export async function highlightMarkdownFences(
 	env: HighlightEnv,
 	markdown: string,
+	options?: HighlightOptions,
 ): Promise<Array<HighlightedCode>> {
-	return highlightSnippets(env, collectMarkdownFences(markdown))
+	return highlightSnippets(env, collectMarkdownFences(markdown), options)
 }
 
 export async function highlightJsonValue(
 	env: HighlightEnv,
 	value: unknown,
+	options?: HighlightOptions,
 ): Promise<HighlightedCode> {
 	const code = JSON.stringify(value, null, 2) ?? 'null'
-	const [result] = await highlightSnippets(env, [{ code, lang: 'json' }])
+	const [result] = await highlightSnippets(
+		env,
+		[{ code, lang: 'json' }],
+		options,
+	)
 	return result ?? plainHighlightedCode(code, 'json')
 }
 

--- a/packages/worker/src/app/package-files-data.ts
+++ b/packages/worker/src/app/package-files-data.ts
@@ -19,6 +19,7 @@ import {
 	highlightSnippets,
 } from '#app/highlight-code.ts'
 import { plainHighlightedCode } from '#universal/highlighted-code.ts'
+import { type ServerTimingEntry } from '#worker/server-timing.ts'
 
 export function readPackageFilesSelectedPath(requestUrl: string) {
 	const url = new URL(requestUrl, 'http://localhost')
@@ -32,20 +33,24 @@ async function toLoaderData(input: {
 	backLabel: string
 	filesBasePath: string
 	view: PackageFilesView
+	serverTiming?: Array<ServerTimingEntry>
 }): Promise<PackageFilesLoaderData> {
 	const content = input.view.content
 	const language = input.view.language
 	const contentKind = input.view.contentKind
+	const highlightOptions = { serverTiming: input.serverTiming }
 	const contentFences =
 		contentKind === 'markdown' && content
-			? await highlightMarkdownFences(input.env, content)
+			? await highlightMarkdownFences(input.env, content, highlightOptions)
 			: []
 	const contentHighlighted =
 		contentKind === 'code' && content
 			? ((
-					await highlightSnippets(input.env, [
-						{ code: content, lang: language ?? 'plaintext' },
-					])
+					await highlightSnippets(
+						input.env,
+						[{ code: content, lang: language ?? 'plaintext' }],
+						highlightOptions,
+					)
 				)[0] ?? plainHighlightedCode(content, language))
 			: content
 				? plainHighlightedCode(content, language)
@@ -73,6 +78,7 @@ export async function loadCommunityPackageFilesData(input: {
 	env: Env
 	listingId: string
 	selectedPath: string
+	serverTiming?: Array<ServerTimingEntry>
 }): Promise<PackageFilesLoaderData | null> {
 	const listing = await getCommunityListingById(input.env.APP_DB, {
 		listingId: input.listingId,
@@ -106,6 +112,7 @@ export async function loadCommunityPackageFilesData(input: {
 		backLabel: 'Package listing',
 		filesBasePath,
 		view,
+		serverTiming: input.serverTiming,
 	})
 }
 
@@ -115,6 +122,7 @@ export async function loadAccountPackageFilesData(input: {
 	userId: string
 	packageId: string
 	selectedPath: string
+	serverTiming?: Array<ServerTimingEntry>
 }): Promise<PackageFilesLoaderData | null> {
 	const record = await getSavedPackageById(input.env.APP_DB, {
 		userId: input.userId,
@@ -148,5 +156,6 @@ export async function loadAccountPackageFilesData(input: {
 		backLabel: 'Package',
 		filesBasePath: getAccountPackageFilesHref({ packageId: record.id }),
 		view,
+		serverTiming: input.serverTiming,
 	})
 }

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -686,6 +686,9 @@ test('renderAppPage caches anonymous marketing HTML and keeps session pages priv
 		'public, max-age=60, stale-while-revalidate=300',
 	)
 	expect(anonymousHome.headers.get('Vary')).toBe('Cookie')
+	const homeTiming = anonymousHome.headers.get('Server-Timing') ?? ''
+	expect(homeTiming).toContain('session;dur=')
+	expect(homeTiming).toContain('ssr;dur=')
 
 	const staleCookieHome = await renderAppPage({
 		request: new Request('https://example.com/', {

--- a/packages/worker/src/app/ssr-render.tsx
+++ b/packages/worker/src/app/ssr-render.tsx
@@ -29,6 +29,11 @@ import {
 } from '#universal/sentry-config.ts'
 import '#app/frame-registrations.ts'
 import { resolveRegisteredFrameHtml } from '#app/frame-registry.ts'
+import {
+	applyServerTimingHeader,
+	pushServerTiming,
+	type ServerTimingEntry,
+} from '#worker/server-timing.ts'
 
 /**
  * The remix/ui stream renderer emits markup starting at `<html>`; without a
@@ -68,15 +73,22 @@ export type RenderAppPageInput = {
 	notFound?: boolean
 	status?: number
 	extraSetCookies?: Array<string>
+	/** Loader phases already recorded for this request; session + ssr append. */
+	serverTiming?: Array<ServerTimingEntry>
 }
 
 export async function renderAppPage(input: RenderAppPageInput) {
 	const { request, env, title, loaderData, notFound, status, extraSetCookies } =
 		input
+	const serverTiming = input.serverTiming ?? []
 	// OAuth authorize (and any SSR entry) can run outside appHandler, so configure
 	// the session cookie before reading request cookies.
 	setAuthSessionSecret(getEnv(env).COOKIE_SECRET)
-	const { session, setCookie } = await loadSessionInfo(request, env)
+	const { session, setCookie } = await pushServerTiming(
+		serverTiming,
+		'session',
+		() => loadSessionInfo(request, env),
+	)
 	const requestUrl = new URL(request.url)
 	const url = `${requestUrl.pathname}${requestUrl.search}${requestUrl.hash}`
 	const clientEntryHref = buildClientEntryHref(getClientBuildId(getEnv(env)))
@@ -104,88 +116,92 @@ export async function renderAppPage(input: RenderAppPageInput) {
 		: null
 	const fathomSiteId = parsedEnv.FATHOM_SITE_ID?.trim() || null
 
-	// Warm lazy route chunks before streaming so SSR HTML includes the real
-	// route tree (dynamic import resolves in the worker bundle), and resolve
-	// the modulepreload hints and inline stylesheet in parallel.
-	const [, modulePreloadHrefs, inlineStylesheet] = await Promise.all([
-		preloadClientRouteModules(`${requestUrl.pathname}${requestUrl.search}`),
-		getClientModulePreloadHrefs({
-			assets: env.ASSETS,
-			buildId: getClientBuildId(parsedEnv),
+	const response = await pushServerTiming(serverTiming, 'ssr', async () => {
+		// Warm lazy route chunks before streaming so SSR HTML includes the real
+		// route tree (dynamic import resolves in the worker bundle), and resolve
+		// the modulepreload hints and inline stylesheet in parallel.
+		const [, modulePreloadHrefs, inlineStylesheet] = await Promise.all([
+			preloadClientRouteModules(`${requestUrl.pathname}${requestUrl.search}`),
+			getClientModulePreloadHrefs({
+				assets: env.ASSETS,
+				buildId: getClientBuildId(parsedEnv),
+				pathname: requestUrl.pathname,
+			}),
+			getInlineStylesheet({
+				assets: env.ASSETS,
+				buildId: getClientBuildId(parsedEnv),
+			}),
+		])
+
+		const stream = renderToStream(
+			// Remix server components accept props via handle.props; JSX typing is loose here.
+			(
+				<SsrDocument
+					documentHead={documentHead}
+					canonicalOrigin={origin}
+					url={url}
+					session={session}
+					loaderData={loaderData}
+					notFound={notFound}
+					clientEntryHref={clientEntryHref}
+					stylesheetHref={stylesheetHref}
+					modulePreloadHrefs={modulePreloadHrefs}
+					inlineStylesheet={inlineStylesheet}
+					sentryConfig={sentryConfig}
+					fathomSiteId={fathomSiteId}
+				/>
+			) as RemixNode,
+			{
+				frameSrc: request.url,
+				resolveFrame(src, target, context) {
+					return resolveRegisteredFrameHtml({
+						src,
+						target,
+						request,
+						env,
+						pageUrl: requestUrl,
+						currentFrameSrc: context?.currentFrameSrc,
+					})
+				},
+				onError(error) {
+					console.error('SSR render error:', error)
+				},
+			},
+		)
+
+		const responseSetsCookie =
+			Boolean(setCookie) || (extraSetCookies?.length ?? 0) > 0
+		const pageCache = resolveAppPageCacheControl({
 			pathname: requestUrl.pathname,
-		}),
-		getInlineStylesheet({
-			assets: env.ASSETS,
-			buildId: getClientBuildId(parsedEnv),
-		}),
-	])
+			session,
+			request,
+			responseSetsCookie,
+		})
+		const headers = new Headers({
+			'Cache-Control': pageCache.cacheControl,
+			'Content-Type': 'text/html; charset=utf-8',
+		})
+		if (pageCache.vary) {
+			headers.set('Vary', pageCache.vary)
+		}
+		if (setCookie) {
+			headers.append('Set-Cookie', setCookie)
+		}
+		for (const cookie of extraSetCookies ?? []) {
+			headers.append('Set-Cookie', cookie)
+		}
+		const cacheLookup = getRequestDataCacheLookup(request)
+		if (cacheLookup) {
+			headers.set('X-Kody-Cache', cacheLookup)
+		}
 
-	const stream = renderToStream(
-		// Remix server components accept props via handle.props; JSX typing is loose here.
-		(
-			<SsrDocument
-				documentHead={documentHead}
-				canonicalOrigin={origin}
-				url={url}
-				session={session}
-				loaderData={loaderData}
-				notFound={notFound}
-				clientEntryHref={clientEntryHref}
-				stylesheetHref={stylesheetHref}
-				modulePreloadHrefs={modulePreloadHrefs}
-				inlineStylesheet={inlineStylesheet}
-				sentryConfig={sentryConfig}
-				fathomSiteId={fathomSiteId}
-			/>
-		) as RemixNode,
-		{
-			frameSrc: request.url,
-			resolveFrame(src, target, context) {
-				return resolveRegisteredFrameHtml({
-					src,
-					target,
-					request,
-					env,
-					pageUrl: requestUrl,
-					currentFrameSrc: context?.currentFrameSrc,
-				})
-			},
-			onError(error) {
-				console.error('SSR render error:', error)
-			},
-		},
-	)
-
-	const responseSetsCookie =
-		Boolean(setCookie) || (extraSetCookies?.length ?? 0) > 0
-	const pageCache = resolveAppPageCacheControl({
-		pathname: requestUrl.pathname,
-		session,
-		request,
-		responseSetsCookie,
+		return applyFirstPartySecurityHeaders(
+			new Response(prependDoctype(stream), {
+				status: status ?? 200,
+				headers,
+			}),
+		)
 	})
-	const headers = new Headers({
-		'Cache-Control': pageCache.cacheControl,
-		'Content-Type': 'text/html; charset=utf-8',
-	})
-	if (pageCache.vary) {
-		headers.set('Vary', pageCache.vary)
-	}
-	if (setCookie) {
-		headers.append('Set-Cookie', setCookie)
-	}
-	for (const cookie of extraSetCookies ?? []) {
-		headers.append('Set-Cookie', cookie)
-	}
-	const cacheLookup = getRequestDataCacheLookup(request)
-	if (cacheLookup) {
-		headers.set('X-Kody-Cache', cacheLookup)
-	}
-
-	return applyFirstPartySecurityHeaders(
-		new Response(prependDoctype(stream), {
-			status: status ?? 200,
-			headers,
-		}),
-	)
+	applyServerTimingHeader(response.headers, serverTiming)
+	return response
 }

--- a/packages/worker/src/json-response.ts
+++ b/packages/worker/src/json-response.ts
@@ -1,16 +1,31 @@
+import {
+	applyServerTimingHeader,
+	type ServerTimingEntry,
+} from '#worker/server-timing.ts'
+
+type JsonResponseInit = ResponseInit & {
+	serverTiming?: Array<ServerTimingEntry>
+}
+
 /**
  * Serialize a JSON API response. Accepts either a bare status code or a full
  * ResponseInit; Content-Type and Cache-Control get sensible defaults that
  * individual headers can override.
  */
-export function jsonResponse(body: unknown, init: number | ResponseInit = 200) {
-	const responseInit = typeof init === 'number' ? { status: init } : init
-	const headers = new Headers(responseInit.headers)
+export function jsonResponse(
+	body: unknown,
+	init: number | JsonResponseInit = 200,
+) {
+	const responseInit: JsonResponseInit =
+		typeof init === 'number' ? { status: init } : init
+	const { serverTiming, ...rest } = responseInit
+	const headers = new Headers(rest.headers)
 	if (!headers.has('Content-Type')) {
 		headers.set('Content-Type', 'application/json; charset=utf-8')
 	}
 	if (!headers.has('Cache-Control')) {
 		headers.set('Cache-Control', 'no-store')
 	}
-	return new Response(JSON.stringify(body), { ...responseInit, headers })
+	applyServerTimingHeader(headers, serverTiming)
+	return new Response(JSON.stringify(body), { ...rest, headers })
 }

--- a/packages/worker/src/server-timing.node.test.ts
+++ b/packages/worker/src/server-timing.node.test.ts
@@ -31,6 +31,15 @@ test('format and parse Server-Timing keep page phases and quoted desc', () => {
 		{ name: 'highlight', durationMs: 20, desc: 'worker' },
 	])
 	expect(parseServerTimingHeader(null)).toEqual([])
+	expect(
+		parseServerTimingHeader('highlight;dur=20;desc="hit;miss", session;dur=1'),
+	).toEqual([
+		{ name: 'highlight', durationMs: 20, desc: 'hit;miss' },
+		{ name: 'session', durationMs: 1 },
+	])
+	expect(
+		parseServerTimingHeader('highlight;dur=20;desc="say \\"hi\\""'),
+	).toEqual([{ name: 'highlight', durationMs: 20, desc: 'say "hi"' }])
 })
 
 test('applyServerTimingHeader appends to an existing header', () => {

--- a/packages/worker/src/server-timing.node.test.ts
+++ b/packages/worker/src/server-timing.node.test.ts
@@ -1,0 +1,63 @@
+import { expect, test } from 'vitest'
+import {
+	applyServerTimingHeader,
+	formatServerTimingHeader,
+	parseServerTimingHeader,
+	pushServerTiming,
+	type ServerTimingEntry,
+} from './server-timing.ts'
+
+test('format and parse Server-Timing keep page phases and quoted desc', () => {
+	const header = formatServerTimingHeader([
+		{ name: 'session', durationMs: 12.4 },
+		{ name: 'highlight', durationMs: 45.6, desc: 'hit' },
+		{ name: 'code-runs', durationMs: 3 },
+		{ name: 'not a token', durationMs: 1 },
+		{ name: 'ssr', durationMs: -2 },
+	])
+	expect(header).toBe(
+		'session;dur=12, highlight;dur=46;desc="hit", code-runs;dur=3, ssr;dur=0',
+	)
+	expect(parseServerTimingHeader(header)).toEqual([
+		{ name: 'session', durationMs: 12 },
+		{ name: 'highlight', durationMs: 46, desc: 'hit' },
+		{ name: 'code-runs', durationMs: 3 },
+		{ name: 'ssr', durationMs: 0 },
+	])
+	expect(
+		parseServerTimingHeader('cfEdge;dur=9, highlight;dur=20;desc=worker'),
+	).toEqual([
+		{ name: 'cfEdge', durationMs: 9 },
+		{ name: 'highlight', durationMs: 20, desc: 'worker' },
+	])
+	expect(parseServerTimingHeader(null)).toEqual([])
+})
+
+test('applyServerTimingHeader appends to an existing header', () => {
+	const headers = new Headers({ 'Server-Timing': 'cfEdge;dur=4' })
+	applyServerTimingHeader(headers, [
+		{ name: 'session', durationMs: 8 },
+		{ name: 'ssr', durationMs: 11 },
+	])
+	expect(headers.get('Server-Timing')).toBe(
+		'cfEdge;dur=4, session;dur=8, ssr;dur=11',
+	)
+	applyServerTimingHeader(headers, [])
+	expect(headers.get('Server-Timing')).toBe(
+		'cfEdge;dur=4, session;dur=8, ssr;dur=11',
+	)
+})
+
+test('pushServerTiming records I/O-bounded durations when a bag is present', async () => {
+	const timings: Array<ServerTimingEntry> = []
+	const value = await pushServerTiming(timings, 'listings', async () => {
+		await new Promise((resolve) => setTimeout(resolve, 5))
+		return 7
+	})
+	expect(value).toBe(7)
+	expect(timings).toHaveLength(1)
+	expect(timings[0]?.name).toBe('listings')
+	expect(timings[0]?.durationMs).toBeGreaterThanOrEqual(5)
+
+	expect(await pushServerTiming(undefined, 'skip', async () => 'ok')).toBe('ok')
+})

--- a/packages/worker/src/server-timing.ts
+++ b/packages/worker/src/server-timing.ts
@@ -53,14 +53,25 @@ export function formatServerTimingHeader(
 		.join(', ')
 }
 
-function splitServerTimingParts(header: string) {
+function splitServerTimingParts(header: string, delimiter = ',') {
 	const parts: Array<string> = []
 	let current = ''
 	let inQuotes = false
+	let escaped = false
 	for (const char of header) {
+		if (escaped) {
+			current += char
+			escaped = false
+			continue
+		}
+		if (inQuotes && char === '\\') {
+			current += char
+			escaped = true
+			continue
+		}
 		if (char === '"' && !inQuotes) inQuotes = true
 		else if (char === '"' && inQuotes) inQuotes = false
-		else if (char === ',' && !inQuotes) {
+		else if (char === delimiter && !inQuotes) {
 			parts.push(current)
 			current = ''
 			continue
@@ -77,8 +88,7 @@ export function parseServerTimingHeader(
 	if (!header) return []
 	const entries: Array<ServerTimingEntry> = []
 	for (const part of splitServerTimingParts(header)) {
-		const tokens = part
-			.split(';')
+		const tokens = splitServerTimingParts(part, ';')
 			.map((token) => token.trim())
 			.filter(Boolean)
 		const name = tokens[0]

--- a/packages/worker/src/server-timing.ts
+++ b/packages/worker/src/server-timing.ts
@@ -1,7 +1,10 @@
 export type ServerTimingEntry = {
 	name: string
 	durationMs: number
+	desc?: string
 }
+
+const tokenPattern = /^[A-Za-z0-9_-]+$/
 
 /**
  * Request-scoped Server-Timing style phase measurement. Same shape as execute
@@ -21,4 +24,93 @@ export async function pushServerTiming<T>(
 	} finally {
 		timings.push({ name, durationMs: Date.now() - startedAt })
 	}
+}
+
+function quoteDesc(value: string) {
+	return `"${value.replaceAll('\\', '\\\\').replaceAll('"', '\\"')}"`
+}
+
+function unquoteDesc(value: string) {
+	if (value.startsWith('"') && value.endsWith('"') && value.length >= 2) {
+		return value.slice(1, -1).replaceAll('\\"', '"').replaceAll('\\\\', '\\')
+	}
+	return value
+}
+
+export function formatServerTimingHeader(
+	entries: Array<ServerTimingEntry>,
+): string {
+	return entries
+		.filter((entry) => tokenPattern.test(entry.name))
+		.map((entry) => {
+			const dur = Math.max(0, Math.round(entry.durationMs))
+			const desc =
+				entry.desc && tokenPattern.test(entry.desc)
+					? `;desc=${quoteDesc(entry.desc)}`
+					: ''
+			return `${entry.name};dur=${dur}${desc}`
+		})
+		.join(', ')
+}
+
+function splitServerTimingParts(header: string) {
+	const parts: Array<string> = []
+	let current = ''
+	let inQuotes = false
+	for (const char of header) {
+		if (char === '"' && !inQuotes) inQuotes = true
+		else if (char === '"' && inQuotes) inQuotes = false
+		else if (char === ',' && !inQuotes) {
+			parts.push(current)
+			current = ''
+			continue
+		}
+		current += char
+	}
+	if (current) parts.push(current)
+	return parts
+}
+
+export function parseServerTimingHeader(
+	header: string | null | undefined,
+): Array<ServerTimingEntry> {
+	if (!header) return []
+	const entries: Array<ServerTimingEntry> = []
+	for (const part of splitServerTimingParts(header)) {
+		const tokens = part
+			.split(';')
+			.map((token) => token.trim())
+			.filter(Boolean)
+		const name = tokens[0]
+		if (!name) continue
+		let durationMs = 0
+		let desc: string | undefined
+		for (const token of tokens.slice(1)) {
+			const separator = token.indexOf('=')
+			if (separator === -1) continue
+			const key = token.slice(0, separator).trim().toLowerCase()
+			const raw = token.slice(separator + 1).trim()
+			if (key === 'dur') {
+				const parsed = Number(raw)
+				if (Number.isFinite(parsed)) durationMs = parsed
+			}
+			if (key === 'desc') desc = unquoteDesc(raw)
+		}
+		entries.push(desc ? { name, durationMs, desc } : { name, durationMs })
+	}
+	return entries
+}
+
+export function applyServerTimingHeader(
+	headers: Headers,
+	entries: Array<ServerTimingEntry> | undefined,
+) {
+	if (!entries || entries.length === 0) return
+	const formatted = formatServerTimingHeader(entries)
+	if (!formatted) return
+	const existing = headers.get('Server-Timing')
+	headers.set(
+		'Server-Timing',
+		existing ? `${existing}, ${formatted}` : formatted,
+	)
 }

--- a/packages/worker/universal/highlight-cache-header.ts
+++ b/packages/worker/universal/highlight-cache-header.ts
@@ -1,0 +1,3 @@
+export const highlightCacheHeaderName = 'x-kody-highlight-cache'
+
+export type HighlightCacheHeader = 'hit' | 'miss'

--- a/tools/site-perf/collect.node.test.ts
+++ b/tools/site-perf/collect.node.test.ts
@@ -97,12 +97,21 @@ test('classifySitePerf scores healthy landing signals and flags cache, LCP, Shik
 test('collectSitePerf keeps homepage classify when extra landing probes fail', async () => {
 	const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
 		const url = String(input)
-		if (new URL(url).pathname === '/') {
+		const pathname = new URL(url).pathname
+		if (pathname === '/') {
 			return new Response(healthyHtml, {
 				headers: {
 					'Cache-Control': 'public, max-age=60, stale-while-revalidate=300',
 					Vary: 'Cookie',
 					'Server-Timing': 'session;dur=1, ssr;dur=4',
+				},
+			})
+		}
+		if (pathname === '/guides/how-kody-works') {
+			return new Response('<html></html>', {
+				headers: {
+					'Cache-Control': 'no-store',
+					'Server-Timing': 'highlight;dur=7;desc="hit"',
 				},
 			})
 		}
@@ -114,7 +123,15 @@ test('collectSitePerf keeps homepage classify when extra landing probes fail', a
 			url: 'https://kody.codes/',
 			budget,
 		})
-		expect(report.pages).toEqual([])
+		expect(report.pages).toEqual([
+			{
+				url: 'https://kody.codes/guides/how-kody-works',
+				htmlBytes: new TextEncoder().encode('<html></html>').byteLength,
+				cacheControl: 'no-store',
+				ttfbMs: expect.any(Number),
+				serverTiming: [{ name: 'highlight', durationMs: 7, desc: 'hit' }],
+			},
+		])
 		expect(report.verdict).toBe('ok')
 		expect(report.findings).toEqual([])
 	} finally {

--- a/tools/site-perf/collect.node.test.ts
+++ b/tools/site-perf/collect.node.test.ts
@@ -57,4 +57,35 @@ test('classifySitePerf scores healthy landing signals and flags cache, LCP, Shik
 		'shiki-on-home',
 		'js-over-budget',
 	])
+
+	const missingTiming = classifySitePerf({
+		url: 'https://kody.codes/',
+		html: healthyHtml,
+		cacheControl: 'public, max-age=60, stale-while-revalidate=300',
+		vary: 'Cookie',
+		htmlBytes: 800,
+		largestSameOriginJsBytes: 800,
+		lcpImageBytes: 800,
+		budget,
+		serverTiming: [{ name: 'cfEdge', durationMs: 9 }],
+	})
+	expect(missingTiming.findings.map((finding) => finding.id)).toContain(
+		'missing-app-timing',
+	)
+	expect(
+		classifySitePerf({
+			url: 'https://kody.codes/',
+			html: healthyHtml,
+			cacheControl: 'public, max-age=60, stale-while-revalidate=300',
+			vary: 'Cookie',
+			htmlBytes: 800,
+			largestSameOriginJsBytes: 800,
+			lcpImageBytes: 800,
+			budget,
+			serverTiming: [
+				{ name: 'session', durationMs: 4 },
+				{ name: 'ssr', durationMs: 20 },
+			],
+		}).verdict,
+	).toBe('ok')
 })

--- a/tools/site-perf/collect.node.test.ts
+++ b/tools/site-perf/collect.node.test.ts
@@ -1,5 +1,9 @@
-import { expect, test } from 'vitest'
-import { classifySitePerf, type SitePerfBudget } from './collect.ts'
+import { expect, test, vi } from 'vitest'
+import {
+	classifySitePerf,
+	collectSitePerf,
+	type SitePerfBudget,
+} from './collect.ts'
 
 const budget: SitePerfBudget = {
 	htmlBytes: 1000,
@@ -88,4 +92,32 @@ test('classifySitePerf scores healthy landing signals and flags cache, LCP, Shik
 			],
 		}).verdict,
 	).toBe('ok')
+})
+
+test('collectSitePerf keeps homepage classify when extra landing probes fail', async () => {
+	const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+		const url = String(input)
+		if (new URL(url).pathname === '/') {
+			return new Response(healthyHtml, {
+				headers: {
+					'Cache-Control': 'public, max-age=60, stale-while-revalidate=300',
+					Vary: 'Cookie',
+					'Server-Timing': 'session;dur=1, ssr;dur=4',
+				},
+			})
+		}
+		throw new Error(`extra landing probe failed: ${url}`)
+	})
+	vi.stubGlobal('fetch', fetchMock)
+	try {
+		const report = await collectSitePerf({
+			url: 'https://kody.codes/',
+			budget,
+		})
+		expect(report.pages).toEqual([])
+		expect(report.verdict).toBe('ok')
+		expect(report.findings).toEqual([])
+	} finally {
+		vi.unstubAllGlobals()
+	}
 })

--- a/tools/site-perf/collect.ts
+++ b/tools/site-perf/collect.ts
@@ -1,6 +1,10 @@
 import { readFile } from 'node:fs/promises'
 import path from 'node:path'
 import { isExecutedDirectly } from '../node-runtime.ts'
+import {
+	parseServerTimingHeader,
+	type ServerTimingEntry,
+} from '#worker/server-timing.ts'
 
 export type SitePerfVerdict = 'ok' | 'needs-fix'
 
@@ -15,6 +19,14 @@ export type SitePerfFinding = {
 	message: string
 }
 
+export type SitePerfPageProbe = {
+	url: string
+	htmlBytes: number
+	cacheControl: string | null
+	ttfbMs: number | null
+	serverTiming: Array<ServerTimingEntry>
+}
+
 export type SitePerfReport = {
 	url: string
 	fetchedAt: string
@@ -23,6 +35,9 @@ export type SitePerfReport = {
 	vary: string | null
 	largestSameOriginJsBytes: number | null
 	lcpImageBytes: number | null
+	ttfbMs: number | null
+	serverTiming: Array<ServerTimingEntry>
+	pages: Array<SitePerfPageProbe>
 	findings: Array<SitePerfFinding>
 	verdict: SitePerfVerdict
 }
@@ -58,6 +73,9 @@ export function classifySitePerf(input: {
 	largestSameOriginJsBytes: number | null
 	lcpImageBytes: number | null
 	budget: SitePerfBudget
+	ttfbMs?: number | null
+	serverTiming?: Array<ServerTimingEntry>
+	pages?: Array<SitePerfPageProbe>
 }): SitePerfReport {
 	const findings: Array<SitePerfFinding> = []
 	const { html, budget } = input
@@ -128,6 +146,18 @@ export function classifySitePerf(input: {
 		})
 	}
 
+	if (
+		new URL(input.url).pathname === '/' &&
+		input.serverTiming &&
+		!input.serverTiming.some((entry) => entry.name === 'ssr')
+	) {
+		findings.push({
+			id: 'missing-app-timing',
+			message:
+				'Homepage Server-Timing is missing the app ssr phase (session/ssr).',
+		})
+	}
+
 	return {
 		url: input.url,
 		fetchedAt: new Date(0).toISOString(),
@@ -136,6 +166,9 @@ export function classifySitePerf(input: {
 		vary: input.vary,
 		largestSameOriginJsBytes: input.largestSameOriginJsBytes,
 		lcpImageBytes: input.lcpImageBytes,
+		ttfbMs: input.ttfbMs ?? null,
+		serverTiming: input.serverTiming ?? [],
+		pages: input.pages ?? [],
 		findings,
 		verdict: findings.length > 0 ? 'needs-fix' : 'ok',
 	}
@@ -155,18 +188,53 @@ async function byteLengthOf(url: string): Promise<number | null> {
 	}
 }
 
+const extraLandingPaths = ['/onboarding', '/guides/how-kody-works'] as const
+
+async function probePage(url: string): Promise<SitePerfPageProbe> {
+	const startedAt = performance.now()
+	const response = await fetch(url, {
+		headers: { Accept: 'text/html' },
+		redirect: 'follow',
+	})
+	const ttfbMs = Math.round(performance.now() - startedAt)
+	const html = await response.text()
+	return {
+		url: response.url || url,
+		htmlBytes: new TextEncoder().encode(html).byteLength,
+		cacheControl: response.headers.get('Cache-Control'),
+		ttfbMs,
+		serverTiming: parseServerTimingHeader(
+			response.headers.get('Server-Timing'),
+		),
+	}
+}
+
 export async function collectSitePerf(input: {
 	url: string
 	budget?: SitePerfBudget
 	now?: Date
 }): Promise<SitePerfReport> {
 	const budget = input.budget ?? (await loadSitePerfBudget())
+	const startedAt = performance.now()
 	const response = await fetch(input.url, {
 		headers: { Accept: 'text/html' },
 		redirect: 'follow',
 	})
+	const ttfbMs = Math.round(performance.now() - startedAt)
 	const html = await response.text()
 	const htmlBytes = new TextEncoder().encode(html).byteLength
+	const serverTiming = parseServerTimingHeader(
+		response.headers.get('Server-Timing'),
+	)
+	const resolvedUrl = response.url || input.url
+	const extraPages =
+		new URL(resolvedUrl).pathname === '/'
+			? await Promise.all(
+					extraLandingPaths.map((pathname) =>
+						probePage(new URL(pathname, resolvedUrl).href),
+					),
+				)
+			: []
 	const scriptHrefs = hrefsMatching(html, /<script[^>]+src=["']([^"']+)["']/gi)
 	const preloadHrefs = hrefsMatching(
 		html,
@@ -197,7 +265,7 @@ export async function collectSitePerf(input: {
 		: null
 
 	const report = classifySitePerf({
-		url: response.url || input.url,
+		url: resolvedUrl,
 		html,
 		cacheControl: response.headers.get('Cache-Control'),
 		vary: response.headers.get('Vary'),
@@ -205,6 +273,9 @@ export async function collectSitePerf(input: {
 		largestSameOriginJsBytes,
 		lcpImageBytes,
 		budget,
+		ttfbMs,
+		serverTiming,
+		pages: extraPages,
 	})
 	report.fetchedAt = (input.now ?? new Date()).toISOString()
 	return report
@@ -235,7 +306,7 @@ export async function main(argv = process.argv.slice(2)) {
 		process.stdout.write(`${JSON.stringify(report, null, 2)}\n`)
 	} else {
 		process.stdout.write(
-			`${report.verdict} ${report.url} html=${report.htmlBytes} js=${report.largestSameOriginJsBytes ?? 'n/a'} lcp=${report.lcpImageBytes ?? 'n/a'}\n`,
+			`${report.verdict} ${report.url} html=${report.htmlBytes} js=${report.largestSameOriginJsBytes ?? 'n/a'} lcp=${report.lcpImageBytes ?? 'n/a'} ttfb=${report.ttfbMs ?? 'n/a'}\n`,
 		)
 		for (const finding of report.findings) {
 			process.stdout.write(`- ${finding.message}\n`)

--- a/tools/site-perf/collect.ts
+++ b/tools/site-perf/collect.ts
@@ -190,22 +190,26 @@ async function byteLengthOf(url: string): Promise<number | null> {
 
 const extraLandingPaths = ['/onboarding', '/guides/how-kody-works'] as const
 
-async function probePage(url: string): Promise<SitePerfPageProbe> {
-	const startedAt = performance.now()
-	const response = await fetch(url, {
-		headers: { Accept: 'text/html' },
-		redirect: 'follow',
-	})
-	const ttfbMs = Math.round(performance.now() - startedAt)
-	const html = await response.text()
-	return {
-		url: response.url || url,
-		htmlBytes: new TextEncoder().encode(html).byteLength,
-		cacheControl: response.headers.get('Cache-Control'),
-		ttfbMs,
-		serverTiming: parseServerTimingHeader(
-			response.headers.get('Server-Timing'),
-		),
+async function probePage(url: string): Promise<SitePerfPageProbe | null> {
+	try {
+		const startedAt = performance.now()
+		const response = await fetch(url, {
+			headers: { Accept: 'text/html' },
+			redirect: 'follow',
+		})
+		const ttfbMs = Math.round(performance.now() - startedAt)
+		const html = await response.text()
+		return {
+			url: response.url || url,
+			htmlBytes: new TextEncoder().encode(html).byteLength,
+			cacheControl: response.headers.get('Cache-Control'),
+			ttfbMs,
+			serverTiming: parseServerTimingHeader(
+				response.headers.get('Server-Timing'),
+			),
+		}
+	} catch {
+		return null
 	}
 }
 
@@ -229,11 +233,13 @@ export async function collectSitePerf(input: {
 	const resolvedUrl = response.url || input.url
 	const extraPages =
 		new URL(resolvedUrl).pathname === '/'
-			? await Promise.all(
-					extraLandingPaths.map((pathname) =>
-						probePage(new URL(pathname, resolvedUrl).href),
-					),
-				)
+			? (
+					await Promise.all(
+						extraLandingPaths.map((pathname) =>
+							probePage(new URL(pathname, resolvedUrl).href),
+						),
+					)
+				).filter((page): page is SitePerfPageProbe => page !== null)
 			: []
 	const scriptHrefs = hrefsMatching(html, /<script[^>]+src=["']([^"']+)["']/gi)
 	const preloadHrefs = hrefsMatching(

--- a/tools/site-perf/invoke-site-perf-package.node.test.ts
+++ b/tools/site-perf/invoke-site-perf-package.node.test.ts
@@ -16,6 +16,9 @@ const needsFixReport: SitePerfReport = {
 	vary: null,
 	largestSameOriginJsBytes: 800,
 	lcpImageBytes: 800,
+	ttfbMs: 80,
+	serverTiming: [{ name: 'ssr', durationMs: 20 }],
+	pages: [],
 	findings: [
 		{
 			id: 'home-no-store',

--- a/tools/site-perf/upsert-github-issue.ts
+++ b/tools/site-perf/upsert-github-issue.ts
@@ -35,6 +35,18 @@ function issueBody(report: SitePerfReport) {
 		`HTML: ${report.htmlBytes} bytes`,
 		`Largest same-origin JS: ${report.largestSameOriginJsBytes ?? 'n/a'} bytes`,
 		`LCP image: ${report.lcpImageBytes ?? 'n/a'} bytes`,
+		`TTFB: ${report.ttfbMs ?? 'n/a'} ms`,
+		`Server-Timing: ${
+			report.serverTiming.length === 0
+				? 'n/a'
+				: report.serverTiming
+						.map((entry) =>
+							entry.desc
+								? `${entry.name}=${entry.durationMs}ms (${entry.desc})`
+								: `${entry.name}=${entry.durationMs}ms`,
+						)
+						.join(', ')
+		}`,
 		`Cache-Control: ${report.cacheControl ?? 'n/a'}`,
 		'',
 		'Findings:',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Make page-load time attributable. After moving Shiki off the homepage, we still could not tell whether remaining origin time was session, highlight, listings, ticker, or SSR.

## Why

Cloudflare already emits `cfEdge` / `cfOrigin` / `cfWorker`. App-level `serverTiming` existed only as JSON on execute / community-fork / repo bootstrap. Weekly site-perf only watched bytes and cache. That is not enough to pick the next cut.

## Summary

- `renderAppPage` records `session` and `ssr` on every HTML response.
- Homepage records `code-runs`. Onboarding records `listings`. Highlight call sites record `highlight` with `desc=hit|worker|miss|fallback`.
- Highlight worker labels `x-kody-highlight-cache: hit|miss`.
- Page JSON companions carry the same header.
- `npm run site-perf` records TTFB and Server-Timing on `/`, and observational probes for `/onboarding` and `/guides/how-kody-works`. Homepage HTML missing an `ssr` phase is a finding.
- Extra landing probes fail open so a dead `/onboarding` or guide fetch cannot abort homepage classify.
- The Server-Timing parser keeps quoted `desc` values intact (commas, semicolons, escaped quotes).

No TTFB budgets yet. After this is in production we will read the phases and cut the actual hot path.

## Testing

- Node-unit: server-timing (including quoted `desc`), highlight-code, ssr-render, onboarding, guides, package-files, site-perf classify + fail-open extra probes.
- Typecheck: origin worker + highlight worker.
- Preview https://kody-pr-1753.kody-a99.workers.dev headers: anonymous `/` emits `code-runs` + `session` + `ssr`; `/onboarding` emits `listings` + `highlight;desc="hit"`; guide HTML/JSON emit `highlight`.
- Preview UI: signed in as `user-me`; `/`, `/onboarding`, and `/guides/how-kody-works` render; guide TypeScript/JSON blocks are token-colored.
- CI on `3c6911b6` is green (Node, Workers, E2E, Static, MCP, Validate, Bugbot, CodeRabbit).

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` · **Head:** `cursor/page-server-timing-f9e0`

**Classification:** extends — HTML/JSON page responses gain Server-Timing phases; highlight worker responses gain a cache-status header.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | extends — `renderAppPage` / page JSON emit `Server-Timing` |
| `highlight-worker` | surfaces | extends — `x-kody-highlight-cache: hit\|miss` |
| `community-listings` | assistant | composes — detail/files highlight records `highlight` |

### Change flow

Origin HTML and page JSON now carry request-scoped phases so DevTools, curl, and weekly site-perf can split `cfWorker`.

```mermaid
sequenceDiagram
	actor Browser
	participant appUi as app-ui
	participant highlightWorker as highlight-worker
	Browser->>appUi: GET / /onboarding /guides/:slug
	appUi->>appUi: session + listings + code-runs
	appUi->>highlightWorker: POST /highlight
	highlightWorker-->>appUi: tokens + x-kody-highlight-cache
	appUi-->>Browser: HTML + Server-Timing session/ssr/highlight
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8a9d9f31-2e4e-4b4b-8158-43ca59aaf9e0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8a9d9f31-2e4e-4b4b-8158-43ca59aaf9e0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Server-Timing metrics to HTML and JSON responses for sessions, rendering, listings, code execution, and syntax highlighting.
  * Highlighting responses now indicate cache hits or misses.
  * Site-performance reports now include TTFB, timing phases, and additional landing-page checks.

* **Bug Fixes**
  * Performance checks flag missing timing data while retaining homepage results when supplementary probes fail.

* **Documentation**
  * Documented timing metrics, cache indicators, and performance measurement behavior.

* **Tests**
  * Added coverage for timing headers, highlighting, cache status, and performance classification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->