### PR TITLE
Cache anonymous onboarding and guide pages at the edge

### DIFF
--- a/docs/contributing/architecture/request-lifecycle.md
+++ b/docs/contributing/architecture/request-lifecycle.md
@@ -150,10 +150,13 @@ session, logout, password reset, health).
 
 `renderAppPage` sets
 `Cache-Control: public, max-age=60, stale-while-revalidate=300` and
-`Vary: Cookie` for anonymous `/`, `/pricing`, `/blog`, and `/community`. The
-response stays `no-store` when the request carries a `kody_session` cookie,
-`loadSessionInfo` resolves a session, or the response sets a cookie. Auth,
-OAuth, account, and every other HTML path stay `no-store`.
+`Vary: Cookie` for anonymous `/`, `/pricing`, `/blog`, `/community`,
+`/onboarding`, `/guides`, and `/guides/:slug`. Anonymous `/onboarding.json` uses
+that same short cache. `/guides/:slug.json` is publicly cacheable without a
+cookie vary (the payload is identical for every visitor). The response stays
+`no-store` when the request carries a `kody_session` cookie, `loadSessionInfo`
+resolves a session, or the response sets a cookie. Auth, OAuth, account, and
+every other HTML path stay `no-store`.
 
 ## Page Server-Timing
 

--- a/docs/contributing/weekly-site-perf.md
+++ b/docs/contributing/weekly-site-perf.md
@@ -63,10 +63,13 @@ returns an agent URL comments it on the open needs-fix issue.
 
 ## What the homepage already does
 
-Anonymous `/`, `/pricing`, `/blog`, and `/community` HTML is
-`public, max-age=60, stale-while-revalidate=300` with `Vary: Cookie`. Any
-`kody_session` cookie, a resolved session, or a `Set-Cookie` response stays
-`no-store`. Auth, OAuth, and account pages never use the short CDN cache.
+Anonymous `/`, `/pricing`, `/blog`, `/community`, `/onboarding`, `/guides`, and
+`/guides/:slug` HTML is `public, max-age=60, stale-while-revalidate=300` with
+`Vary: Cookie`. Anonymous `/onboarding.json` uses the same cache with
+`Vary: Cookie`. Guide JSON (`/guides/:slug.json`) is shared publicly without a
+cookie vary because the body is the same for every visitor. Any `kody_session`
+cookie, a resolved session, or a `Set-Cookie` response stays `no-store` on HTML.
+Auth, OAuth, and account pages never use the short CDN cache.
 
 Landing layout CSS lives in `packages/worker/public/styles.css` (`.landing-*`)
 so SSR does not emit a Remix style tag per marketing node. Hero and below-fold

--- a/packages/worker/src/app/anonymous-html-cache.node.test.ts
+++ b/packages/worker/src/app/anonymous-html-cache.node.test.ts
@@ -1,6 +1,9 @@
 import { expect, test } from 'vitest'
 import {
 	anonymousHtmlCacheControl,
+	anonymousPersonalizedJsonCacheHeaders,
+	isCacheableAnonymousPath,
+	publicSharedJsonCacheHeaders,
 	requestHasSessionCookie,
 	resolveAppPageCacheControl,
 } from '#app/anonymous-html-cache.ts'
@@ -53,6 +56,37 @@ test('anonymous marketing HTML is cacheable only without a session', () => {
 
 	expect(
 		resolveAppPageCacheControl({
+			pathname: '/onboarding',
+			session: null,
+			request: request('https://example.com/onboarding'),
+			responseSetsCookie: false,
+		}),
+	).toEqual({
+		cacheControl: anonymousHtmlCacheControl,
+		vary: 'Cookie',
+	})
+	expect(
+		resolveAppPageCacheControl({
+			pathname: '/guides',
+			session: null,
+			request: request('https://example.com/guides'),
+			responseSetsCookie: false,
+		}).cacheControl,
+	).toBe(anonymousHtmlCacheControl)
+	expect(
+		resolveAppPageCacheControl({
+			pathname: '/guides/how-kody-works',
+			session: null,
+			request: request('https://example.com/guides/how-kody-works'),
+			responseSetsCookie: false,
+		}).cacheControl,
+	).toBe(anonymousHtmlCacheControl)
+
+	expect(isCacheableAnonymousPath('/guides/how-kody-works.json')).toBe(true)
+	expect(isCacheableAnonymousPath('/guides/nested/path')).toBe(false)
+
+	expect(
+		resolveAppPageCacheControl({
 			pathname: '/account',
 			session: null,
 			request: request('https://example.com/account'),
@@ -86,4 +120,32 @@ test('anonymous marketing HTML is cacheable only without a session', () => {
 			responseSetsCookie: true,
 		}),
 	).toEqual({ cacheControl: 'no-store' })
+
+	expect(publicSharedJsonCacheHeaders()).toEqual({
+		'Cache-Control': anonymousHtmlCacheControl,
+	})
+	expect(
+		anonymousPersonalizedJsonCacheHeaders({
+			personalized: false,
+			request: request('https://example.com/onboarding.json'),
+		}),
+	).toEqual({
+		'Cache-Control': anonymousHtmlCacheControl,
+		Vary: 'Cookie',
+	})
+	expect(
+		anonymousPersonalizedJsonCacheHeaders({
+			personalized: true,
+			request: request('https://example.com/onboarding.json'),
+		}),
+	).toEqual({ 'Cache-Control': 'no-store' })
+	expect(
+		anonymousPersonalizedJsonCacheHeaders({
+			personalized: false,
+			request: request(
+				'https://example.com/onboarding.json',
+				'kody_session=stale',
+			),
+		}),
+	).toEqual({ 'Cache-Control': 'no-store' })
 })

--- a/packages/worker/src/app/anonymous-html-cache.ts
+++ b/packages/worker/src/app/anonymous-html-cache.ts
@@ -10,12 +10,21 @@ export const sessionCookieName = 'kody_session'
 export const anonymousHtmlCacheControl =
 	'public, max-age=60, stale-while-revalidate=300'
 
-const cacheableAnonymousPaths = new Set([
+const cacheableAnonymousExactPaths = new Set([
 	'/',
 	'/pricing',
 	'/blog',
 	'/community',
+	'/onboarding',
+	'/guides',
 ])
+
+export function isCacheableAnonymousPath(pathname: string) {
+	if (cacheableAnonymousExactPaths.has(pathname)) return true
+	if (!pathname.startsWith('/guides/')) return false
+	const rest = pathname.slice('/guides/'.length)
+	return rest.length > 0 && !rest.includes('/')
+}
 
 export function requestHasSessionCookie(request: Request): boolean {
 	const cookie = request.headers.get('Cookie') ?? ''
@@ -37,11 +46,28 @@ export function resolveAppPageCacheControl(input: {
 	if (requestHasSessionCookie(input.request)) {
 		return { cacheControl: 'no-store' }
 	}
-	if (!cacheableAnonymousPaths.has(input.pathname)) {
+	if (!isCacheableAnonymousPath(input.pathname)) {
 		return { cacheControl: 'no-store' }
 	}
 	return {
 		cacheControl: anonymousHtmlCacheControl,
 		vary: 'Cookie',
+	}
+}
+
+export function publicSharedJsonCacheHeaders(): HeadersInit {
+	return { 'Cache-Control': anonymousHtmlCacheControl }
+}
+
+export function anonymousPersonalizedJsonCacheHeaders(input: {
+	personalized: boolean
+	request: Request
+}): HeadersInit {
+	if (input.personalized || requestHasSessionCookie(input.request)) {
+		return { 'Cache-Control': 'no-store' }
+	}
+	return {
+		'Cache-Control': anonymousHtmlCacheControl,
+		Vary: 'Cookie',
 	}
 }

--- a/packages/worker/src/app/handlers/guides.node.test.ts
+++ b/packages/worker/src/app/handlers/guides.node.test.ts
@@ -186,6 +186,9 @@ test('interactive guide JSON includes walkthrough highlight tokens', async () =>
 		},
 	)
 	expect(howKodyWorksResponse.status).toBe(200)
+	expect(howKodyWorksResponse.headers.get('Cache-Control')).toBe(
+		'public, max-age=60, stale-while-revalidate=300',
+	)
 	expect(howKodyWorksResponse.headers.get('Server-Timing') ?? '').toContain(
 		'highlight;dur=',
 	)

--- a/packages/worker/src/app/handlers/guides.tsx
+++ b/packages/worker/src/app/handlers/guides.tsx
@@ -12,6 +12,7 @@ import {
 	withVaryAccept,
 } from '#app/markdown-negotiation.ts'
 import { type routes } from '#universal/routes.ts'
+import { publicSharedJsonCacheHeaders } from '#app/anonymous-html-cache.ts'
 import { renderAppPage } from '#app/ssr-render.tsx'
 import { jsonResponse } from '#worker/json-response.ts'
 import { parseOgTheme } from '#worker/og/palette.ts'
@@ -200,6 +201,7 @@ export function createGuideDetailApiHandler(env: Env) {
 			const serverTiming: Array<ServerTimingEntry> = []
 			return jsonResponse(await toGuideDetail(env, guide, serverTiming), {
 				serverTiming,
+				headers: publicSharedJsonCacheHeaders(),
 			})
 		},
 	} satisfies Action<typeof routes.guideDetailApi>

--- a/packages/worker/src/app/handlers/onboarding.node.test.ts
+++ b/packages/worker/src/app/handlers/onboarding.node.test.ts
@@ -85,6 +85,10 @@ test('onboarding serves public setup content to anonymous visitors', async () =>
 		new RequestContext(new Request('https://example.com/onboarding.json')),
 	)
 	expect(anonymousApiResponse.status).toBe(200)
+	expect(anonymousApiResponse.headers.get('Cache-Control')).toBe(
+		'public, max-age=60, stale-while-revalidate=300',
+	)
+	expect(anonymousApiResponse.headers.get('Vary')).toBe('Cookie')
 	const onboardingTiming =
 		anonymousApiResponse.headers.get('Server-Timing') ?? ''
 	expect(onboardingTiming).toContain('listings;dur=')
@@ -127,6 +131,7 @@ test('onboarding API includes the authenticated package-scope username', async (
 	)
 
 	expect(response.status).toBe(200)
+	expect(response.headers.get('Cache-Control')).toBe('no-store')
 	await expect(response.json()).resolves.toMatchObject({
 		ok: true,
 		loggedIn: true,

--- a/packages/worker/src/app/handlers/onboarding.ts
+++ b/packages/worker/src/app/handlers/onboarding.ts
@@ -41,6 +41,7 @@ import {
 	loadOnboardingData,
 	loadPublicOnboardingData,
 } from '#app/onboarding-data.ts'
+import { anonymousPersonalizedJsonCacheHeaders } from '#app/anonymous-html-cache.ts'
 import { renderAppPage } from '#app/ssr-render.tsx'
 import { type routes } from '#universal/routes.ts'
 import {
@@ -391,7 +392,13 @@ export function createOnboardingApiHandler(env: Env) {
 						},
 						serverTiming,
 					),
-					{ serverTiming },
+					{
+						serverTiming,
+						headers: anonymousPersonalizedJsonCacheHeaders({
+							personalized: false,
+							request,
+						}),
+					},
 				)
 			}
 

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -686,6 +686,20 @@ test('renderAppPage caches anonymous marketing HTML and keeps session pages priv
 		'public, max-age=60, stale-while-revalidate=300',
 	)
 	expect(anonymousHome.headers.get('Vary')).toBe('Cookie')
+	const anonymousOnboarding = await renderAppPage({
+		request: new Request('https://example.com/onboarding'),
+		env,
+	})
+	expect(anonymousOnboarding.headers.get('Cache-Control')).toBe(
+		'public, max-age=60, stale-while-revalidate=300',
+	)
+	const anonymousGuide = await renderAppPage({
+		request: new Request('https://example.com/guides/how-kody-works'),
+		env,
+	})
+	expect(anonymousGuide.headers.get('Cache-Control')).toBe(
+		'public, max-age=60, stale-while-revalidate=300',
+	)
 	const homeTiming = anonymousHome.headers.get('Server-Timing') ?? ''
 	expect(homeTiming).toContain('session;dur=')
 	expect(homeTiming).toContain('ssr;dur=')


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Cut anonymous page-load time on the paths production Server-Timing showed were still `no-store`.

## Why

After #1753, production `/health` is `1004a7dc`. Warm origin phases on those pages are already cheap: `highlight` cache hits are 4–11ms, `listings` / `session` / `ssr` often 0. The remaining cost is bytes plus `no-store`:

- `/` is already cached (78KB, `code-runs` 2–9ms)
- `/onboarding` is 167KB `no-store`
- `/guides/how-kody-works` is 449KB `no-store`
- `/guides/how-kody-works.json` is 175KB `no-store` — the homepage loop fetches this on every visit

Highlight is not the next cut. Caching the public documents is.

## Summary

- Anonymous `/onboarding`, `/guides`, and `/guides/:slug` HTML use the same `public, max-age=60, stale-while-revalidate=300` + `Vary: Cookie` cache as `/`.
- Anonymous `/onboarding.json` uses that cache with `Vary: Cookie` so a signed-in checklist payload cannot reuse it. Signed-in onboarding JSON stays `no-store`.
- `/guides/:slug.json` is publicly cacheable without a cookie vary. The body is identical for every visitor, including the homepage loop.
- Session cookie, resolved session, and `Set-Cookie` still force HTML `no-store`.

## Testing

- Node-unit: anonymous-html-cache path matching, `renderAppPage` onboarding/guide cache, anonymous vs signed-in onboarding JSON, guide JSON cache header.
- CI on `bc7a6869` is green (Node, Workers, E2E, Static, MCP, Validate). Bugbot found no issues. CodeRabbit was rate-limited on this PR.
- Preview https://kody-pr-1754.kody-a99.workers.dev: anonymous `/onboarding`, `/guides`, `/guides/how-kody-works`, and both JSON companions are `public, max-age=60, swr=300`. Signed-in HTML and `/onboarding.json` stay `no-store`. Guide JSON stays public when signed in. Seed login + GET `/onboarding.json` + GET `/guides/how-kody-works.json` succeeded.
- Preview UI: signed in as `user-me`; homepage, onboarding, and the guide render with highlighted code.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` · **Head:** `cursor/cache-anonymous-guides-f9e0`

**Classification:** extends — the anonymous HTML cache allowlist and public JSON cache contract grow to cover onboarding and guides.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | extends — cacheable anonymous paths include onboarding and guides; guide JSON is shared publicly |

### Change flow

Anonymous onboarding and guide responses can now be reused at the edge for 60s instead of regenerating `no-store` HTML and JSON on every visit.

```mermaid
sequenceDiagram
	actor Browser
	participant edge as CDN
	participant appUi as app-ui
	Browser->>edge: GET /onboarding /guides/:slug /guides/:slug.json
	alt anonymous cache hit
		edge-->>Browser: cached HTML/JSON (max-age 60)
	else miss or session cookie
		edge->>appUi: origin render
		appUi-->>edge: public cache or no-store
		edge-->>Browser: response
	end
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8a9d9f31-2e4e-4b4b-8158-43ca59aaf9e0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8a9d9f31-2e4e-4b4b-8158-43ca59aaf9e0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

