### PR TITLE
Polyfill constructable stylesheets for Safari < 16.4 (KODY-CLOUDFLARE-63)

### DIFF
--- a/packages/worker/client/ensure-constructable-stylesheets.node.test.ts
+++ b/packages/worker/client/ensure-constructable-stylesheets.node.test.ts
@@ -1,0 +1,125 @@
+import { expect, test } from 'vitest'
+import { ensureConstructableStylesheets } from './ensure-constructable-stylesheets.ts'
+
+type FakeRuleList = { length: number; rules: Array<string> }
+
+function createFakeDocument() {
+	const headChildren: Array<{ remove: () => void; isConnected: boolean }> = []
+	const head = {
+		appendChild(node: { isConnected: boolean }) {
+			node.isConnected = true
+			headChildren.push(node as { remove: () => void; isConnected: boolean })
+			return node
+		},
+	}
+
+	const doc = {
+		head,
+		documentElement: head,
+		createTextNode(data: string) {
+			return { data }
+		},
+		createElement(tagName: string) {
+			if (tagName !== 'style') {
+				throw new Error(`unexpected element: ${tagName}`)
+			}
+			const rules: Array<string> = []
+			const cssRules: FakeRuleList = {
+				get length() {
+					return rules.length
+				},
+				rules,
+			}
+			const sheet = {
+				cssRules,
+				insertRule(rule: string, index = 0) {
+					rules.splice(index, 0, rule)
+					return index
+				},
+				deleteRule(index: number) {
+					rules.splice(index, 1)
+				},
+			}
+			const style = {
+				isConnected: false,
+				appendChild(node: unknown) {
+					return node
+				},
+				remove() {
+					this.isConnected = false
+					const index = headChildren.indexOf(this)
+					if (index >= 0) headChildren.splice(index, 1)
+				},
+				get sheet() {
+					// Expose `.sheet` only while connected — same as real browsers.
+					return this.isConnected ? sheet : null
+				},
+			}
+			return style
+		},
+	}
+
+	return { doc, headChildren }
+}
+
+test('ensureConstructableStylesheets polyfills Illegal constructor hosts so Remix StyleManager construct + push + insertRule works', () => {
+	const { doc, headChildren } = createFakeDocument()
+	function NonConstructableCSSStyleSheet() {
+		throw new TypeError('Illegal constructor')
+	}
+	const host = {
+		CSSStyleSheet: NonConstructableCSSStyleSheet,
+		document: doc,
+	}
+
+	ensureConstructableStylesheets(host)
+
+	expect(typeof host.CSSStyleSheet).toBe('function')
+	expect(() => new (host.CSSStyleSheet as new () => object)()).not.toThrow()
+
+	const sheet = new (host.CSSStyleSheet as new () => {
+		cssRules: { length: number }
+		insertRule: (rule: string, index?: number) => number
+		deleteRule: (index: number) => void
+	})()
+
+	doc.adoptedStyleSheets!.push(sheet as never)
+	expect(headChildren).toHaveLength(1)
+	expect(sheet.insertRule('.rmxc-x { color: red }', 0)).toBe(0)
+	expect(sheet.cssRules.length).toBe(1)
+
+	sheet.deleteRule(0)
+	expect(sheet.cssRules.length).toBe(0)
+
+	doc.adoptedStyleSheets = Array.from(doc.adoptedStyleSheets!).filter(
+		(entry) => entry !== (sheet as never),
+	)
+	expect(headChildren).toHaveLength(0)
+})
+
+test('ensureConstructableStylesheets leaves a real Constructable Stylesheets implementation alone', () => {
+	const existingSheet = { cssRules: { length: 0 } }
+	function NativeCSSStyleSheet() {
+		return existingSheet
+	}
+	const existingAdopted: Array<object> = []
+	const doc = {
+		createElement() {
+			throw new Error('should not polyfill')
+		},
+		createTextNode() {
+			throw new Error('should not polyfill')
+		},
+		adoptedStyleSheets: existingAdopted,
+	}
+	const host = {
+		CSSStyleSheet: NativeCSSStyleSheet,
+		document: doc,
+	}
+
+	ensureConstructableStylesheets(host)
+
+	expect(host.CSSStyleSheet).toBe(NativeCSSStyleSheet)
+	expect(doc.adoptedStyleSheets).toBe(existingAdopted)
+	expect(new (host.CSSStyleSheet as new () => object)()).toBe(existingSheet)
+})

--- a/packages/worker/client/ensure-constructable-stylesheets.node.test.ts
+++ b/packages/worker/client/ensure-constructable-stylesheets.node.test.ts
@@ -7,6 +7,12 @@ function createFakeDocument() {
 	const headChildren: Array<{ remove: () => void; isConnected: boolean }> = []
 	const head = {
 		appendChild(node: { isConnected: boolean }) {
+			// Mirror DOM move semantics: re-appending a connected node relocates
+			// it without disconnecting (CSSOM rules must survive).
+			const existing = headChildren.indexOf(
+				node as { remove: () => void; isConnected: boolean },
+			)
+			if (existing >= 0) headChildren.splice(existing, 1)
 			node.isConnected = true
 			headChildren.push(node as { remove: () => void; isConnected: boolean })
 			return node
@@ -47,6 +53,9 @@ function createFakeDocument() {
 				},
 				remove() {
 					this.isConnected = false
+					// Real browsers drop CSSOM mutations on disconnect and reparse
+					// empty textContent on reconnect.
+					rules.length = 0
 					const index = headChildren.indexOf(this)
 					if (index >= 0) headChildren.splice(index, 1)
 				},
@@ -62,7 +71,13 @@ function createFakeDocument() {
 	return { doc, headChildren }
 }
 
-test('ensureConstructableStylesheets polyfills Illegal constructor hosts so Remix StyleManager construct + push + insertRule works', () => {
+type PolyfilledSheet = {
+	cssRules: { length: number }
+	insertRule: (rule: string, index?: number) => number
+	deleteRule: (index: number) => void
+}
+
+function installOnFakeHost() {
 	const { doc, headChildren } = createFakeDocument()
 	function NonConstructableCSSStyleSheet() {
 		throw new TypeError('Illegal constructor')
@@ -71,17 +86,18 @@ test('ensureConstructableStylesheets polyfills Illegal constructor hosts so Remi
 		CSSStyleSheet: NonConstructableCSSStyleSheet,
 		document: doc,
 	}
-
 	ensureConstructableStylesheets(host)
+	const Ctor = host.CSSStyleSheet as new () => PolyfilledSheet
+	return { doc, headChildren, Ctor }
+}
 
-	expect(typeof host.CSSStyleSheet).toBe('function')
-	expect(() => new (host.CSSStyleSheet as new () => object)()).not.toThrow()
+test('ensureConstructableStylesheets polyfills Illegal constructor hosts so Remix StyleManager construct + push + insertRule works', () => {
+	const { doc, headChildren, Ctor } = installOnFakeHost()
 
-	const sheet = new (host.CSSStyleSheet as new () => {
-		cssRules: { length: number }
-		insertRule: (rule: string, index?: number) => number
-		deleteRule: (index: number) => void
-	})()
+	expect(typeof Ctor).toBe('function')
+	expect(() => new Ctor()).not.toThrow()
+
+	const sheet = new Ctor()
 
 	doc.adoptedStyleSheets!.push(sheet as never)
 	expect(headChildren).toHaveLength(1)
@@ -98,18 +114,8 @@ test('ensureConstructableStylesheets polyfills Illegal constructor hosts so Remi
 })
 
 test('ensureConstructableStylesheets reorders connected style elements when adoptedStyleSheets is reassigned', () => {
-	const { doc, headChildren } = createFakeDocument()
-	function NonConstructableCSSStyleSheet() {
-		throw new TypeError('Illegal constructor')
-	}
-	const host = {
-		CSSStyleSheet: NonConstructableCSSStyleSheet,
-		document: doc,
-	}
+	const { doc, headChildren, Ctor } = installOnFakeHost()
 
-	ensureConstructableStylesheets(host)
-
-	const Ctor = host.CSSStyleSheet as new () => object
 	const first = new Ctor()
 	const second = new Ctor()
 	doc.adoptedStyleSheets!.push(first as never, second as never)
@@ -119,6 +125,22 @@ test('ensureConstructableStylesheets reorders connected style elements when adop
 
 	doc.adoptedStyleSheets = [second as never, first as never]
 	expect(headChildren).toEqual([secondStyle, firstStyle])
+})
+
+test('ensureConstructableStylesheets keeps insertRule CSSOM across reorder without disconnecting', () => {
+	const { doc, headChildren, Ctor } = installOnFakeHost()
+
+	const first = new Ctor()
+	const second = new Ctor()
+	doc.adoptedStyleSheets!.push(first as never, second as never)
+	first.insertRule('.rmxc-a { color: red }', 0)
+	second.insertRule('.rmxc-b { color: blue }', 0)
+
+	doc.adoptedStyleSheets = [second as never, first as never]
+
+	expect(headChildren).toHaveLength(2)
+	expect(first.cssRules.length).toBe(1)
+	expect(second.cssRules.length).toBe(1)
 })
 
 test('ensureConstructableStylesheets leaves a real Constructable Stylesheets implementation alone', () => {

--- a/packages/worker/client/ensure-constructable-stylesheets.node.test.ts
+++ b/packages/worker/client/ensure-constructable-stylesheets.node.test.ts
@@ -97,6 +97,30 @@ test('ensureConstructableStylesheets polyfills Illegal constructor hosts so Remi
 	expect(headChildren).toHaveLength(0)
 })
 
+test('ensureConstructableStylesheets reorders connected style elements when adoptedStyleSheets is reassigned', () => {
+	const { doc, headChildren } = createFakeDocument()
+	function NonConstructableCSSStyleSheet() {
+		throw new TypeError('Illegal constructor')
+	}
+	const host = {
+		CSSStyleSheet: NonConstructableCSSStyleSheet,
+		document: doc,
+	}
+
+	ensureConstructableStylesheets(host)
+
+	const Ctor = host.CSSStyleSheet as new () => object
+	const first = new Ctor()
+	const second = new Ctor()
+	doc.adoptedStyleSheets!.push(first as never, second as never)
+	expect(headChildren).toHaveLength(2)
+	const firstStyle = headChildren[0]
+	const secondStyle = headChildren[1]
+
+	doc.adoptedStyleSheets = [second as never, first as never]
+	expect(headChildren).toEqual([secondStyle, firstStyle])
+})
+
 test('ensureConstructableStylesheets leaves a real Constructable Stylesheets implementation alone', () => {
 	const existingSheet = { cssRules: { length: 0 } }
 	function NativeCSSStyleSheet() {

--- a/packages/worker/client/ensure-constructable-stylesheets.ts
+++ b/packages/worker/client/ensure-constructable-stylesheets.ts
@@ -69,8 +69,9 @@ function appendStyleElement(
 	doc: ConstructableStylesheetsDocument,
 	style: PolyfilledStyleElement,
 ): void {
-	if (style.isConnected) return
 	const parent = doc.head ?? doc.documentElement
+	// Always appendChild: a connected node is moved without disconnecting, so
+	// CSSOM rules from insertRule survive reorder (unlike remove + reinsert).
 	parent?.appendChild(style)
 }
 
@@ -119,11 +120,12 @@ function syncAdoptedStyleSheets(
 	previous: Array<PolyfilledStyleSheet>,
 	next: Array<PolyfilledStyleSheet>,
 ): void {
-	// Detach everything first, then append `next` in order. Skipping detach for
-	// retained sheets would keep the old DOM order when assignment only
-	// reorders (e.g. `[a, b]` → `[b, a]`), which would ignore cascade order.
+	// Drop sheets that left the list. Retained sheets stay connected so
+	// insertRule CSSOM state survives; appendChild below only moves them.
 	for (const sheet of previous) {
-		sheet._detach()
+		if (!next.includes(sheet)) {
+			sheet._detach()
+		}
 	}
 	for (const sheet of next) {
 		sheet._attach(doc)

--- a/packages/worker/client/ensure-constructable-stylesheets.ts
+++ b/packages/worker/client/ensure-constructable-stylesheets.ts
@@ -60,7 +60,9 @@ function supportsConstructableStylesheets(
 ): boolean {
 	const doc = host.document
 	if (!doc) return false
-	return canConstructStyleSheet(host.CSSStyleSheet) && 'adoptedStyleSheets' in doc
+	return (
+		canConstructStyleSheet(host.CSSStyleSheet) && 'adoptedStyleSheets' in doc
+	)
 }
 
 function appendStyleElement(
@@ -179,9 +181,7 @@ function installCssStyleSheetConstructor(
 	host: ConstructableStylesheetsHost,
 	doc: ConstructableStylesheetsDocument,
 ): void {
-	function PolyfilledCSSStyleSheet(
-		this: unknown,
-	): PolyfilledStyleSheet {
+	function PolyfilledCSSStyleSheet(this: unknown): PolyfilledStyleSheet {
 		// Returning an object from `new` replaces the constructed instance.
 		return createPolyfilledStyleSheet(doc)
 	}

--- a/packages/worker/client/ensure-constructable-stylesheets.ts
+++ b/packages/worker/client/ensure-constructable-stylesheets.ts
@@ -1,0 +1,217 @@
+/**
+ * Remix UI's `createStyleManager` calls `new CSSStyleSheet()` and pushes onto
+ * `document.adoptedStyleSheets`. Constructable stylesheets shipped in Safari
+ * 16.4 / iOS 16.4; older WebKit throws `TypeError: Illegal constructor`
+ * (KODY-CLOUDFLARE-63 on `/guides/how-kody-works`). Install a `<style>`-backed
+ * polyfill before `run()` so client css-mixin inserts still apply.
+ *
+ * This is not a full Constructable Stylesheets polyfill (no ShadowRoot
+ * adoption, no `replace` / `replaceSync`). It covers the Remix StyleManager
+ * surface: construct, `adoptedStyleSheets.push` / assign, `insertRule`,
+ * `deleteRule`, and `cssRules`.
+ */
+
+export type ConstructableStyleSheetLike = {
+	readonly cssRules: { readonly length: number }
+	insertRule: (rule: string, index?: number) => number
+	deleteRule: (index: number) => void
+}
+
+export type ConstructableStylesheetsDocument = {
+	createElement: (tagName: string) => {
+		sheet: ConstructableStyleSheetLike | null
+		appendChild: (node: unknown) => unknown
+		remove: () => void
+		readonly isConnected: boolean
+	}
+	createTextNode: (data: string) => unknown
+	head?: { appendChild: (node: unknown) => unknown } | null
+	documentElement?: { appendChild: (node: unknown) => unknown } | null
+	adoptedStyleSheets?: Array<ConstructableStyleSheetLike>
+}
+
+export type ConstructableStylesheetsHost = {
+	CSSStyleSheet?: unknown
+	document?: ConstructableStylesheetsDocument | null
+}
+
+type PolyfilledStyleElement = ReturnType<
+	ConstructableStylesheetsDocument['createElement']
+>
+
+type PolyfilledStyleSheet = ConstructableStyleSheetLike & {
+	_style: PolyfilledStyleElement
+	_attach: (doc: ConstructableStylesheetsDocument) => void
+	_detach: () => void
+}
+
+function canConstructStyleSheet(Ctor: unknown): boolean {
+	if (typeof Ctor !== 'function') return false
+	try {
+		Reflect.construct(Ctor as new () => unknown, [])
+		return true
+	} catch {
+		return false
+	}
+}
+
+function supportsConstructableStylesheets(
+	host: ConstructableStylesheetsHost,
+): boolean {
+	const doc = host.document
+	if (!doc) return false
+	return canConstructStyleSheet(host.CSSStyleSheet) && 'adoptedStyleSheets' in doc
+}
+
+function appendStyleElement(
+	doc: ConstructableStylesheetsDocument,
+	style: PolyfilledStyleElement,
+): void {
+	if (style.isConnected) return
+	const parent = doc.head ?? doc.documentElement
+	parent?.appendChild(style)
+}
+
+function requireLiveSheet(
+	style: PolyfilledStyleElement,
+	operation: string,
+): ConstructableStyleSheetLike {
+	const live = style.sheet
+	if (!live) {
+		throw new TypeError(
+			`CSSStyleSheet ${operation} is unavailable until the sheet is adopted`,
+		)
+	}
+	return live
+}
+
+function createPolyfilledStyleSheet(
+	doc: ConstructableStylesheetsDocument,
+): PolyfilledStyleSheet {
+	const style = doc.createElement('style')
+	// Non-empty text node so older engines expose `.sheet` once connected.
+	style.appendChild(doc.createTextNode(''))
+
+	return {
+		_style: style,
+		_attach(ownerDoc) {
+			appendStyleElement(ownerDoc, style)
+		},
+		_detach() {
+			style.remove()
+		},
+		get cssRules() {
+			return requireLiveSheet(style, 'cssRules').cssRules
+		},
+		insertRule(rule, index = 0) {
+			return requireLiveSheet(style, 'insertRule').insertRule(rule, index)
+		},
+		deleteRule(index) {
+			requireLiveSheet(style, 'deleteRule').deleteRule(index)
+		},
+	}
+}
+
+function syncAdoptedStyleSheets(
+	doc: ConstructableStylesheetsDocument,
+	previous: Array<PolyfilledStyleSheet>,
+	next: Array<PolyfilledStyleSheet>,
+): void {
+	for (const sheet of previous) {
+		if (!next.includes(sheet)) {
+			sheet._detach()
+		}
+	}
+	for (const sheet of next) {
+		sheet._attach(doc)
+	}
+}
+
+function wirePush(
+	sheets: Array<PolyfilledStyleSheet>,
+	onMutate: () => void,
+): void {
+	sheets.push = (...items: Array<PolyfilledStyleSheet>) => {
+		const length = Array.prototype.push.apply(sheets, items)
+		onMutate()
+		return length
+	}
+}
+
+function installAdoptedStyleSheets(
+	doc: ConstructableStylesheetsDocument,
+): void {
+	let sheets: Array<PolyfilledStyleSheet> = []
+	let previous: Array<PolyfilledStyleSheet> = []
+
+	const apply = (next: Array<PolyfilledStyleSheet>) => {
+		syncAdoptedStyleSheets(doc, previous, next)
+		previous = next.slice()
+		sheets = next
+		wirePush(sheets, () => {
+			apply(sheets.slice())
+		})
+	}
+
+	apply([])
+
+	try {
+		Object.defineProperty(doc, 'adoptedStyleSheets', {
+			configurable: true,
+			enumerable: true,
+			get() {
+				return sheets
+			},
+			set(value: ArrayLike<PolyfilledStyleSheet>) {
+				apply(Array.from(value))
+			},
+		})
+	} catch {
+		try {
+			doc.adoptedStyleSheets = sheets
+		} catch {
+			// Leave the document unchanged; Remix will still throw without adoption.
+		}
+	}
+}
+
+function installCssStyleSheetConstructor(
+	host: ConstructableStylesheetsHost,
+	doc: ConstructableStylesheetsDocument,
+): void {
+	function PolyfilledCSSStyleSheet(
+		this: unknown,
+	): PolyfilledStyleSheet {
+		// Returning an object from `new` replaces the constructed instance.
+		return createPolyfilledStyleSheet(doc)
+	}
+
+	try {
+		Object.defineProperty(host, 'CSSStyleSheet', {
+			configurable: true,
+			enumerable: false,
+			writable: true,
+			value: PolyfilledCSSStyleSheet,
+		})
+	} catch {
+		try {
+			;(host as { CSSStyleSheet: unknown }).CSSStyleSheet =
+				PolyfilledCSSStyleSheet
+		} catch {
+			// Leave the host unchanged; Remix will still throw on construct.
+		}
+	}
+}
+
+export function ensureConstructableStylesheets(
+	host: ConstructableStylesheetsHost | undefined = typeof globalThis ===
+	'undefined'
+		? undefined
+		: (globalThis as ConstructableStylesheetsHost),
+): void {
+	if (!host?.document) return
+	if (supportsConstructableStylesheets(host)) return
+
+	installAdoptedStyleSheets(host.document)
+	installCssStyleSheetConstructor(host, host.document)
+}

--- a/packages/worker/client/ensure-constructable-stylesheets.ts
+++ b/packages/worker/client/ensure-constructable-stylesheets.ts
@@ -119,10 +119,11 @@ function syncAdoptedStyleSheets(
 	previous: Array<PolyfilledStyleSheet>,
 	next: Array<PolyfilledStyleSheet>,
 ): void {
+	// Detach everything first, then append `next` in order. Skipping detach for
+	// retained sheets would keep the old DOM order when assignment only
+	// reorders (e.g. `[a, b]` → `[b, a]`), which would ignore cascade order.
 	for (const sheet of previous) {
-		if (!next.includes(sheet)) {
-			sheet._detach()
-		}
+		sheet._detach()
 	}
 	for (const sheet of next) {
 		sheet._attach(doc)

--- a/packages/worker/client/entry.tsx
+++ b/packages/worker/client/entry.tsx
@@ -10,6 +10,7 @@ import {
 	initSentryClient,
 } from '#client/sentry-client.ts'
 import { AppRoot, APP_ROOT_ENTRY_ID } from './app-root.tsx'
+import { ensureConstructableStylesheets } from './ensure-constructable-stylesheets.ts'
 import { ensureCryptoRandomUUID } from './ensure-crypto-random-uuid.ts'
 import { ensureNavigationApi } from './ensure-navigation-api.ts'
 
@@ -18,6 +19,9 @@ ensureCryptoRandomUUID()
 // Remix `run()` calls window.navigation.updateCurrentEntry; Safari < 26.2 and
 // iOS in-app browsers omit the Navigation API entirely.
 ensureNavigationApi()
+// Remix StyleManager uses `new CSSStyleSheet()` + adoptedStyleSheets; Safari
+// / iOS before 16.4 throw TypeError: Illegal constructor (KODY-CLOUDFLARE-63).
+ensureConstructableStylesheets()
 initSentryClient(document)
 
 const clientRegistry: Record<string, typeof AppRoot> = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop Remix client hydration from throwing `TypeError: Illegal constructor` on Safari / iOS before 16.4 when StyleManager constructs a CSSStyleSheet.

## Why

Sentry [KODY-CLOUDFLARE-63](https://sentry.io/organizations/kent-c-dodds-tech-llc/issues/7690896449/) (`TypeError: Illegal constructor`) on `https://kody.codes/guides/how-kody-works` with Mobile Safari 16.0 / iPad. Stack is Remix UI `createStyleManager` → `new CSSStyleSheet()` → native Illegal constructor. Constructable stylesheets shipped in Safari 16.4; older WebKit cannot construct them. Same class of boot gap as the existing Navigation API and `crypto.randomUUID` ensure-* guards.

## Summary

- Add `ensureConstructableStylesheets()` — `<style>`-backed polyfill for `CSSStyleSheet` construct + `document.adoptedStyleSheets` push/assign, covering the Remix StyleManager surface.
- Call it from `client/entry.tsx` before `run()`.
- Reorder via `appendChild` move (no disconnect) so cascade order updates without wiping `insertRule` CSSOM.
- Unit tests for Illegal-constructor hosts, reorder, CSSOM survival across reorder, and leaving a real implementation alone.

## Testing

- `npx vitest run packages/worker/client/ensure-constructable-stylesheets.node.test.ts` (pass)
- Preview: https://kody-pr-1755.kody-a99.workers.dev
- CI re-running on `40fd1b48` after Bugbot CSSOM feedback

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `d55b2c40` · **Head:** `40fd1b48`

**Classification:** composes — client boot wiring only; no new primitive, no auth/isolation/billing/migration surface.

### Primitives touched

| Primitive | Group    | Impact                                                                 |
| --------- | -------- | ---------------------------------------------------------------------- |
| `app-ui`  | surfaces | composes — boot-time polyfill before Remix `run()`, same pattern as Navigation API / randomUUID guards |

### What changed

```mermaid
sequenceDiagram
  participant Browser as Mobile Safari < 16.4
  participant Entry as client/entry.tsx
  participant Ensure as ensureConstructableStylesheets
  participant Remix as Remix StyleManager

  Browser->>Entry: load client bundle
  Entry->>Ensure: ensureConstructableStylesheets()
  Note over Ensure: Illegal constructor on native CSSStyleSheet
  Ensure->>Ensure: install style-backed CSSStyleSheet + adoptedStyleSheets
  Entry->>Remix: run()
  Remix->>Remix: new CSSStyleSheet() + adoptedStyleSheets.push
  Note over Remix: insertRule / deleteRule work via connected style.sheet
```

### Risk notes

- Low: isolated client boot polyfill with unit tests; no server, auth, or data-path changes.
- Does not claim full Constructable Stylesheets coverage (no ShadowRoot / replaceSync); only Remix StyleManager usage.
- Sibling Sentry issues (Navigation API / scheduleUpdate) do not share this root cause and are left alone.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-44966337-9c30-4d57-a7a2-9b7acebf6e33?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-44966337-9c30-4d57-a7a2-9b7acebf6e33&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added constructable stylesheet support for older Safari and iOS versions.
  * Stylesheets can be created, adopted, updated, reordered, and removed consistently across supported browsers.
  * Reordering adopted stylesheets now preserves their existing CSS rules.

* **Bug Fixes**
  * Prevented stylesheet construction failures when native browser support is unavailable.
  * Preserved native browser behavior on browsers with built-in constructable stylesheet support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->