### PR TITLE
Compose same-path repo_edit_files edits instead of last-write-wins

### DIFF
--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -1056,13 +1056,13 @@ Operational notes:
   batch edits (`repo_edit_files`: write/replace/writeJson/delete/move; same-path
   content edits compose in order), unified diff apply (`repo_apply_patch`), git
   inspection (`repo_status`, `repo_diff`, `repo_log`), commit (`repo_commit`),
-  and restore (`repo_restore`). There is no
-  git-command parser channel; branch/checkout/remote operations require the
-  Artifacts git lane via `package_get_git_remote`. Package runtime bundles are
-  loaded from published artifacts rather than a mounted checkout. The session
-  Workspace spills objects above the inline threshold to `REPO_SESSION_BLOBS` so
-  clone and checkout can honor the 10 MiB per-file policy without hitting the
-  Durable Object SQLite 2 MiB row limit.
+  and restore (`repo_restore`). There is no git-command parser channel;
+  branch/checkout/remote operations require the Artifacts git lane via
+  `package_get_git_remote`. Package runtime bundles are loaded from published
+  artifacts rather than a mounted checkout. The session Workspace spills objects
+  above the inline threshold to `REPO_SESSION_BLOBS` so clone and checkout can
+  honor the 10 MiB per-file policy without hitting the Durable Object SQLite 2
+  MiB row limit.
 - `repo_write_file` exposes the same Durable Object's `applyEdits` write path as
   a first-class MCP capability for whole-file overwrites. Prefer it over
   `repo_apply_patch` when the agent is replacing an entire file (for example, a

--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -1053,9 +1053,10 @@ Operational notes:
   projections of that repo-backed source rather than a competing second source
   of truth.
 - Repo sessions expose a file-level API inside the RepoSession Durable Object:
-  batch edits (`repo_edit_files`: write/replace/writeJson/delete/move), unified
-  diff apply (`repo_apply_patch`), git inspection (`repo_status`, `repo_diff`,
-  `repo_log`), commit (`repo_commit`), and restore (`repo_restore`). There is no
+  batch edits (`repo_edit_files`: write/replace/writeJson/delete/move; same-path
+  content edits compose in order), unified diff apply (`repo_apply_patch`), git
+  inspection (`repo_status`, `repo_diff`, `repo_log`), commit (`repo_commit`),
+  and restore (`repo_restore`). There is no
   git-command parser channel; branch/checkout/remote operations require the
   Artifacts git lane via `package_get_git_remote`. Package runtime bundles are
   loaded from published artifacts rather than a mounted checkout. The session

--- a/docs/use/repo-sessions.md
+++ b/docs/use/repo-sessions.md
@@ -178,5 +178,9 @@ await kody.repo_run_checks({ session_id: session.id })
 await kody.repo_publish_session({ session_id: session.id })
 ```
 
+Same-path `write`, `replace`, and `writeJson` edits in one `repo_edit_files`
+call compose in order: each instruction sees the file as left by the previous
+one. The last same-path edit's `content` is the file after the whole batch.
+
 Each step returns structured JSON so agents can inspect diffs, check outcomes,
 and publish results without shell parsing.

--- a/packages/worker/src/mcp/capabilities/repo/repo-edit-files.ts
+++ b/packages/worker/src/mcp/capabilities/repo/repo-edit-files.ts
@@ -16,7 +16,7 @@ export const repoEditFilesCapability = defineDomainCapability(
 	{
 		name: 'repo_edit_files',
 		description: [
-			'Apply a batch of file-level edits in an active repo session: write, replace, writeJson, delete, or move.',
+			'Apply a batch of file-level edits in an active repo session: write, replace, writeJson, delete, or move. Same-path write/replace/writeJson edits in one call compose in order against each prior result.',
 			fileLevelApiNote,
 			'Each content-changing edit is subject to a 10 MiB per-file size limit on the planned result.',
 			'Edits mutate the live session overlay only; pair with `repo_commit`, `repo_run_checks`, and `repo_publish_session` to validate and publish.',

--- a/packages/worker/src/mcp/capabilities/repo/repo-shared.ts
+++ b/packages/worker/src/mcp/capabilities/repo/repo-shared.ts
@@ -355,7 +355,7 @@ export const repoEditFilesInputSchema = repoSessionIdSchema.extend({
 		.array(repoSessionEditSchema)
 		.min(1)
 		.describe(
-			'Batch of file-level edits: write, replace, writeJson, delete, or move.',
+			'Batch of file-level edits: write, replace, writeJson, delete, or move. Multiple content edits to the same path compose sequentially.',
 		),
 	dry_run: z
 		.boolean()

--- a/packages/worker/src/repo/plan-repo-session-content-edits.node.test.ts
+++ b/packages/worker/src/repo/plan-repo-session-content-edits.node.test.ts
@@ -1,0 +1,228 @@
+import { expect, test } from 'vitest'
+import { planRepoSessionContentEdits } from './plan-repo-session-content-edits.ts'
+
+test('same-path replace and write instructions compose in order instead of keeping only the last edit', async () => {
+	const files = new Map<string, string>([
+		[
+			'/session/src/ci-secrets.ts',
+			[
+				'const accountId = status.accountId',
+				'const value = status.accountId',
+				'const extra = status.accountId',
+				'',
+			].join('\n'),
+		],
+		['/session/src/other.ts', 'export const flag = "todo"\n'],
+	])
+	const reads: Array<string> = []
+
+	const plan = await planRepoSessionContentEdits(
+		[
+			{
+				kind: 'replace',
+				path: '/session/src/ci-secrets.ts',
+				search: 'const accountId = status.accountId',
+				replacement: 'const accountId = accountId',
+			},
+			{
+				kind: 'replace',
+				path: '/session/src/ci-secrets.ts',
+				search: 'const value = status.accountId',
+				replacement: 'const value = accountId',
+			},
+			{
+				kind: 'replace',
+				path: '/session/src/other.ts',
+				search: '"todo"',
+				replacement: '"done"',
+			},
+			{
+				kind: 'replace',
+				path: '/session/src/ci-secrets.ts',
+				search: 'const extra = status.accountId',
+				replacement: 'const extra = accountId',
+			},
+			{
+				kind: 'write',
+				path: '/session/src/other.ts',
+				content: 'export const flag = "written"\n',
+			},
+		],
+		async (path) => {
+			reads.push(path)
+			return files.get(path) ?? null
+		},
+	)
+
+	expect(reads).toEqual([
+		'/session/src/ci-secrets.ts',
+		'/session/src/other.ts',
+	])
+	expect(plan.totalChanged).toBe(5)
+	expect(plan.edits.map((edit) => edit.changed)).toEqual([
+		true,
+		true,
+		true,
+		true,
+		true,
+	])
+	expect(plan.edits[0]?.content).toBe(
+		[
+			'const accountId = accountId',
+			'const value = status.accountId',
+			'const extra = status.accountId',
+			'',
+		].join('\n'),
+	)
+	expect(plan.edits[1]?.content).toBe(
+		[
+			'const accountId = accountId',
+			'const value = accountId',
+			'const extra = status.accountId',
+			'',
+		].join('\n'),
+	)
+	expect(plan.edits[3]?.content).toBe(
+		[
+			'const accountId = accountId',
+			'const value = accountId',
+			'const extra = accountId',
+			'',
+		].join('\n'),
+	)
+	expect(plan.edits[2]?.content).toBe('export const flag = "done"\n')
+	expect(plan.edits[4]?.content).toBe('export const flag = "written"\n')
+})
+
+test('replace options, missing files, and no-op searches keep the shell contract', async () => {
+	const files = new Map<string, string>([
+		['/session/src/note.ts', 'Foo foo FOO\n'],
+	])
+
+	const caseSensitive = await planRepoSessionContentEdits(
+		[
+			{
+				kind: 'replace',
+				path: '/session/src/note.ts',
+				search: 'foo',
+				replacement: 'bar',
+			},
+		],
+		async (path) => files.get(path) ?? null,
+	)
+	expect(caseSensitive.edits[0]?.content).toBe('Foo bar FOO\n')
+
+	const caseInsensitive = await planRepoSessionContentEdits(
+		[
+			{
+				kind: 'replace',
+				path: '/session/src/note.ts',
+				search: 'foo',
+				replacement: 'bar',
+				options: { caseSensitive: false },
+			},
+		],
+		async (path) => files.get(path) ?? null,
+	)
+	expect(caseInsensitive.edits[0]?.content).toBe('bar bar bar\n')
+
+	const wholeWord = await planRepoSessionContentEdits(
+		[
+			{
+				kind: 'replace',
+				path: '/session/src/note.ts',
+				search: 'Foo',
+				replacement: 'Ok',
+				options: { wholeWord: true },
+			},
+		],
+		async (path) => files.get(path) ?? null,
+	)
+	expect(wholeWord.edits[0]?.content).toBe('Ok foo FOO\n')
+
+	const regex = await planRepoSessionContentEdits(
+		[
+			{
+				kind: 'replace',
+				path: '/session/src/note.ts',
+				search: 'F[oO]o',
+				replacement: 'X',
+				options: { regex: true },
+			},
+		],
+		async (path) => files.get(path) ?? null,
+	)
+	expect(regex.edits[0]?.content).toBe('X foo FOO\n')
+
+	const noOp = await planRepoSessionContentEdits(
+		[
+			{
+				kind: 'replace',
+				path: '/session/src/note.ts',
+				search: 'missing',
+				replacement: 'nope',
+			},
+		],
+		async (path) => files.get(path) ?? null,
+	)
+	expect(noOp.totalChanged).toBe(0)
+	expect(noOp.edits[0]).toMatchObject({
+		changed: false,
+		content: 'Foo foo FOO\n',
+	})
+
+	const writeJson = await planRepoSessionContentEdits(
+		[
+			{
+				kind: 'writeJson',
+				path: '/session/src/config.json',
+				value: { enabled: true },
+			},
+		],
+		async () => null,
+	)
+	expect(writeJson.edits[0]?.content).toBe('{\n  "enabled": true\n}\n')
+
+	await expect(
+		planRepoSessionContentEdits(
+			[
+				{
+					kind: 'replace',
+					path: '/session/src/missing.ts',
+					search: 'x',
+					replacement: 'y',
+				},
+			],
+			async () => null,
+		),
+	).rejects.toThrow('ENOENT: no such file: /session/src/missing.ts')
+
+	await expect(
+		planRepoSessionContentEdits(
+			[
+				{
+					kind: 'replace',
+					path: '/session/src/note.ts',
+					search: '',
+					replacement: 'y',
+				},
+			],
+			async (path) => files.get(path) ?? null,
+		),
+	).rejects.toThrow('Search query must not be empty')
+
+	await expect(
+		planRepoSessionContentEdits(
+			[
+				{
+					kind: 'replace',
+					path: '/session/src/note.ts',
+					search: '(',
+					replacement: 'y',
+					options: { regex: true },
+				},
+			],
+			async (path) => files.get(path) ?? null,
+		),
+	).rejects.toThrow(/Invalid search pattern/)
+})

--- a/packages/worker/src/repo/plan-repo-session-content-edits.node.test.ts
+++ b/packages/worker/src/repo/plan-repo-session-content-edits.node.test.ts
@@ -54,10 +54,7 @@ test('same-path replace and write instructions compose in order instead of keepi
 		},
 	)
 
-	expect(reads).toEqual([
-		'/session/src/ci-secrets.ts',
-		'/session/src/other.ts',
-	])
+	expect(reads).toEqual(['/session/src/ci-secrets.ts', '/session/src/other.ts'])
 	expect(plan.totalChanged).toBe(5)
 	expect(plan.edits.map((edit) => edit.changed)).toEqual([
 		true,
@@ -139,6 +136,19 @@ test('replace options, missing files, and no-op searches keep the shell contract
 		async (path) => files.get(path) ?? null,
 	)
 	expect(wholeWord.edits[0]?.content).toBe('Ok foo FOO\n')
+
+	const dollarLiteral = await planRepoSessionContentEdits(
+		[
+			{
+				kind: 'replace',
+				path: '/session/src/note.ts',
+				search: 'FOO',
+				replacement: '$PRICE $$ $&',
+			},
+		],
+		async (path) => files.get(path) ?? null,
+	)
+	expect(dollarLiteral.edits[0]?.content).toBe('Foo foo $PRICE $$ $&\n')
 
 	const regex = await planRepoSessionContentEdits(
 		[

--- a/packages/worker/src/repo/plan-repo-session-content-edits.ts
+++ b/packages/worker/src/repo/plan-repo-session-content-edits.ts
@@ -106,11 +106,7 @@ function plannedContentForInstruction(
 	}
 }
 
-function stringifyJsonFileContent(
-	value: unknown,
-	path: string,
-	spaces = 2,
-) {
+function stringifyJsonFileContent(value: unknown, path: string, spaces = 2) {
 	const serialized = JSON.stringify(value, null, spaces)
 	if (serialized === undefined) {
 		throw new Error(`Unable to serialize JSON for ${path}`)
@@ -129,7 +125,9 @@ function replaceTextContent(
 	},
 ) {
 	const matcher = createTextMatcher(search, options ?? {})
-	return content.replace(matcher, replacement)
+	// Replacer function keeps `$`, `$&`, and `$$` literal, matching
+	// `@cloudflare/shell` replaceTextContent.
+	return content.replace(matcher, () => replacement)
 }
 
 function createTextMatcher(

--- a/packages/worker/src/repo/plan-repo-session-content-edits.ts
+++ b/packages/worker/src/repo/plan-repo-session-content-edits.ts
@@ -1,0 +1,160 @@
+export type RepoSessionContentEditInstruction =
+	| {
+			kind: 'write'
+			path: string
+			content: string
+	  }
+	| {
+			kind: 'replace'
+			path: string
+			search: string
+			replacement: string
+			options?: {
+				caseSensitive?: boolean
+				regex?: boolean
+				wholeWord?: boolean
+			}
+	  }
+	| {
+			kind: 'writeJson'
+			path: string
+			value: unknown
+			options?: {
+				spaces?: number
+			}
+	  }
+
+export type RepoSessionPlannedContentEdit = {
+	instruction: RepoSessionContentEditInstruction
+	path: string
+	changed: boolean
+	content: string
+	diff: string
+}
+
+export type RepoSessionContentEditPlan = {
+	edits: Array<RepoSessionPlannedContentEdit>
+	totalChanged: number
+	totalInstructions: number
+}
+
+/**
+ * Plan write/replace/writeJson instructions against a staged overlay so
+ * same-path edits compose in order.
+ *
+ * `@cloudflare/shell` `planEdits` reads each instruction against the file
+ * state at batch start, so a batch of replaces on one path all derive from
+ * the original contents and `applyEditPlan` keeps only the last write.
+ */
+export async function planRepoSessionContentEdits(
+	instructions: ReadonlyArray<RepoSessionContentEditInstruction>,
+	readFileIfExists: (path: string) => Promise<string | null>,
+): Promise<RepoSessionContentEditPlan> {
+	const overlay = new Map<string, string | null>()
+	const edits: Array<RepoSessionPlannedContentEdit> = []
+	let totalChanged = 0
+	for (const instruction of instructions) {
+		const previous = overlay.has(instruction.path)
+			? (overlay.get(instruction.path) ?? null)
+			: await readFileIfExists(instruction.path)
+		const content = plannedContentForInstruction(instruction, previous)
+		const changed = previous !== content
+		overlay.set(instruction.path, content)
+		edits.push({
+			instruction,
+			path: instruction.path,
+			changed,
+			content,
+			diff: '',
+		})
+		if (changed) totalChanged += 1
+	}
+	return {
+		edits,
+		totalChanged,
+		totalInstructions: instructions.length,
+	}
+}
+
+function plannedContentForInstruction(
+	instruction: RepoSessionContentEditInstruction,
+	previous: string | null,
+) {
+	switch (instruction.kind) {
+		case 'write':
+			return instruction.content
+		case 'writeJson':
+			return stringifyJsonFileContent(
+				instruction.value,
+				instruction.path,
+				instruction.options?.spaces,
+			)
+		case 'replace':
+			if (previous === null) {
+				throw new Error(`ENOENT: no such file: ${instruction.path}`)
+			}
+			return replaceTextContent(
+				previous,
+				instruction.search,
+				instruction.replacement,
+				instruction.options,
+			)
+		default: {
+			const exhaustive: never = instruction
+			return exhaustive
+		}
+	}
+}
+
+function stringifyJsonFileContent(
+	value: unknown,
+	path: string,
+	spaces = 2,
+) {
+	const serialized = JSON.stringify(value, null, spaces)
+	if (serialized === undefined) {
+		throw new Error(`Unable to serialize JSON for ${path}`)
+	}
+	return `${serialized}\n`
+}
+
+function replaceTextContent(
+	content: string,
+	search: string,
+	replacement: string,
+	options?: {
+		caseSensitive?: boolean
+		regex?: boolean
+		wholeWord?: boolean
+	},
+) {
+	const matcher = createTextMatcher(search, options ?? {})
+	return content.replace(matcher, replacement)
+}
+
+function createTextMatcher(
+	query: string,
+	options: {
+		caseSensitive?: boolean
+		regex?: boolean
+		wholeWord?: boolean
+	},
+) {
+	if (query.length === 0) {
+		throw new Error('Search query must not be empty')
+	}
+	let source = options.regex ? query : escapeRegExp(query)
+	if (options.wholeWord) {
+		source = `\\b(?:${source})\\b`
+	}
+	try {
+		return new RegExp(source, options.caseSensitive === false ? 'gi' : 'g')
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error)
+		throw new Error(`Invalid search pattern: ${message}`)
+	}
+}
+
+function escapeRegExp(value: string) {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}

--- a/packages/worker/src/repo/repo-session-do.node.test.ts
+++ b/packages/worker/src/repo/repo-session-do.node.test.ts
@@ -1,4 +1,5 @@
 import { expect, test, vi } from 'vitest'
+import { createWorkspaceStateBackend } from '@cloudflare/shell'
 import { consoleWarn } from '#worker/test-support/console-spies.ts'
 import type * as CloudflareWorkers from 'cloudflare:workers'
 import type * as Artifacts from './artifacts.ts'
@@ -396,8 +397,8 @@ vi.mock('@cloudflare/shell', () => ({
 		constructor(_workspace: unknown) {}
 	},
 	createWorkspaceStateBackend: vi.fn(() => ({
-		// Mirror the real backend closely enough for the applyEdits size gate:
-		// planned edits carry the resulting content per instruction.
+		// applyEditPlan persists caller-planned contents. Sequential same-path
+		// composition is planned in Kody before this backend sees the batch.
 		planEdits: vi.fn(
 			async (
 				instructions: Array<{ kind: string; path: string; content?: string }>,
@@ -1314,6 +1315,97 @@ test('applyEdits rejects a write over the per-file repo size limit with hosting 
 		}),
 	).rejects.toThrow(/"assets\/dataset\.csv".*per-file limit.*Cloudflare R2/s)
 	expect(mockModule.workspaceWriteFile).not.toHaveBeenCalled()
+})
+
+test('applyEdits composes multiple replace edits to the same file instead of keeping only the last', async () => {
+	setCommonSessionFixtures()
+	mockModule.workspaceReadFile.mockImplementation(async (path: string) => {
+		if (path === '/session/src/ci-secrets.ts') {
+			return [
+				'const accountId = status.accountId',
+				'const value = status.accountId',
+				'const extra = status.accountId',
+				'',
+			].join('\n')
+		}
+		return ''
+	})
+	const repoSession = new RepoSession(createDurableObjectState(), createEnv())
+
+	const result = await repoSession.applyEdits({
+		sessionId: 'session-1',
+		userId: 'user-1',
+		edits: [
+			{
+				kind: 'replace',
+				path: 'src/ci-secrets.ts',
+				search: 'const accountId = status.accountId',
+				replacement: 'const accountId = accountId',
+			},
+			{
+				kind: 'replace',
+				path: 'src/ci-secrets.ts',
+				search: 'const value = status.accountId',
+				replacement: 'const value = accountId',
+			},
+			{
+				kind: 'replace',
+				path: 'src/ci-secrets.ts',
+				search: 'const extra = status.accountId',
+				replacement: 'const extra = accountId',
+			},
+		],
+	})
+
+	const backend = vi.mocked(createWorkspaceStateBackend).mock.results.at(-1)
+		?.value as {
+		applyEditPlan: ReturnType<typeof vi.fn>
+	}
+	expect(backend.applyEditPlan).toHaveBeenCalledWith(
+		expect.objectContaining({
+			totalChanged: 3,
+			edits: [
+				expect.objectContaining({
+					changed: true,
+					content: [
+						'const accountId = accountId',
+						'const value = status.accountId',
+						'const extra = status.accountId',
+						'',
+					].join('\n'),
+				}),
+				expect.objectContaining({
+					changed: true,
+					content: [
+						'const accountId = accountId',
+						'const value = accountId',
+						'const extra = status.accountId',
+						'',
+					].join('\n'),
+				}),
+				expect.objectContaining({
+					changed: true,
+					content: [
+						'const accountId = accountId',
+						'const value = accountId',
+						'const extra = accountId',
+						'',
+					].join('\n'),
+				}),
+			],
+		}),
+		expect.objectContaining({ dryRun: undefined }),
+	)
+	expect(result.totalChanged).toBe(3)
+	expect(result.edits.map((edit) => edit.changed)).toEqual([true, true, true])
+	expect(result.edits.at(-1)?.content).toBe(
+		[
+			'const accountId = accountId',
+			'const value = accountId',
+			'const extra = accountId',
+			'',
+		].join('\n'),
+	)
 })
 
 test('publishSession persists the workspace snapshot to BUNDLE_ARTIFACTS_KV so downstream readers find the freshly published commit', async () => {

--- a/packages/worker/src/repo/repo-session-do.ts
+++ b/packages/worker/src/repo/repo-session-do.ts
@@ -45,6 +45,7 @@ import {
 	loadPublishedSourceSnapshot,
 	writePublishedSourceSnapshot,
 } from '#worker/package-runtime/published-runtime-artifacts.ts'
+import { planRepoSessionContentEdits } from './plan-repo-session-content-edits.ts'
 import { searchRepoWorkspace } from './repo-session-search.ts'
 import { repoSessionRpc as createRepoSessionRpc } from './repo-session-rpc.ts'
 import {
@@ -1103,7 +1104,11 @@ class RepoSessionBase extends DurableObject<Env> {
 			edits: [],
 		}
 		if (contentEdits.length > 0) {
-			const plan = await this.state.planEdits(
+			// @cloudflare/shell planEdits reads every instruction against the
+			// file at batch start, so same-path writes overwrite one another.
+			// Plan through a staged overlay so sequential edits observe prior
+			// results, matching applyUnifiedDiff and the batch contract.
+			const plan = await planRepoSessionContentEdits(
 				contentEdits.map((edit) => {
 					const path = resolveRepoWorkspacePath(
 						edit.path,
@@ -1149,6 +1154,7 @@ class RepoSessionBase extends DurableObject<Env> {
 						}
 					}
 				}),
+				async (path) => (await this.workspace.readFile(path)) ?? null,
 			)
 			for (const plannedEdit of plan.edits) {
 				if (!plannedEdit.changed) continue


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop `repo_edit_files` from silently discarding all but the last edit when a batch targets the same file.

## Why

`@cloudflare/shell` `planEdits` computes every instruction against the file state at batch start. A batch of independent `replace` edits on one path therefore all derive from the original contents, and `applyEditPlan` writes them in order so only the last write survives. The response still reports `changed: true` for every edit (and `dry_run` does too), so callers get a silently broken file.

This is a broken runtime contract with data loss: the batch API reads as sequential composition, and `repo_apply_patch` already uses a staged overlay for the same reason.

## Summary

- Plan `write` / `replace` / `writeJson` through a staged overlay so same-path edits compose in order.
- Keep `applyEditPlan` for persistence, per-edit diffs, and the existing per-file size gate.
- Apply replacements through a function so `$` sequences stay literal (same as `@cloudflare/shell`).
- Document the compose contract on the capability, schema, and repo-session usage docs.
- Cover the overlay planner and the `applyEdits` same-file replace batch.

## Testing

- Focused `node-unit`: `plan-repo-session-content-edits.node.test.ts` and `repo-session-do.node.test.ts` — 2 files, 31 tests passed (includes `$PRICE $$ $&` literal replacement).
- Preview (`kody-pr-1759`, head `4b6d94c8`): signed in as `user-me`, `/account/packages.json` 200 (empty seed list), `/mcp` 401 without OAuth, `/admin` 403. UI pass on `/account/packages` on the preview origin.
- `repo_edit_files` itself is MCP-only; composition is covered by the node tests, not the cookie HTTP surface.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `e9326fc6` · **Head:** `4b6d94c8`

**Classification:** extends — `repo_edit_files` same-path batches compose sequentially instead of last-write-wins.

### Primitives touched

| Primitive              | Group      | Impact                                                                                 |
| ---------------------- | ---------- | -------------------------------------------------------------------------------------- |
| `repo-sessions`        | runtime    | extends — same-path write/replace/writeJson edits compose through a staged overlay     |
| `capability-registry`  | assistant  | composes — capability and schema copy names the sequential-compose contract            |

### Change flow

`repo_edit_files` plans each same-path instruction against the prior planned result, then the session workspace applies that composed plan.

```mermaid
sequenceDiagram
	actor Caller
	participant capabilityRegistry as capability-registry
	participant repoSessions as repo-sessions
	Caller->>capabilityRegistry: repo_edit_files batch
	capabilityRegistry->>repoSessions: applyEdits
	Note over repoSessions: planRepoSessionContentEdits overlay composes same-path edits
	repoSessions->>repoSessions: applyEditPlan writes composed contents
	repoSessions-->>Caller: per-edit changed plus last same-path content
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0dc2f7d8-ab53-4cf6-831b-722013147782?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0dc2f7d8-ab53-4cf6-831b-722013147782&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Multiple edits to the same file now apply sequentially within a single edit operation.
  - Supports composing writes, replacements, and JSON updates while preserving prior changes.
  - Replacement options include case sensitivity, regular expressions, and whole-word matching.

- **Bug Fixes**
  - Prevented earlier edits from being overwritten by later changes.
  - Added validation for missing files, empty searches, invalid patterns, and unsupported JSON values.

- **Documentation**
  - Clarified sequential edit behavior in repository session and data storage documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->