### PR TITLE
Overlap onboarding listings with one Mailbox count

### DIFF
--- a/docs/contributing/architecture/request-lifecycle.md
+++ b/docs/contributing/architecture/request-lifecycle.md
@@ -169,7 +169,15 @@ are:
 - `ssr` — route preload, stylesheet, and starting the HTML stream
 - `highlight` — token batch (`desc` is `hit`, `worker`, `miss`, or `fallback`)
 - `listings` — onboarding featured/chooser load
+- `mailbox` — signed-in onboarding Mailbox first-win probes (`desc` is `skip`
+  until an MCP host has authorized, otherwise `probe`)
 - `code-runs` — homepage public ticker window
+
+Signed-in `/onboarding` overlaps featured listings, MCP OAuth grant listing, and
+D1 checklist reads. It does not call Mailbox or UserMeter until `hasMcpClient`
+is true, so a first visit after login does not wake the platform worker. When it
+does probe, one unfiltered Mailbox count returns immediately for an empty
+mailbox.
 
 Durations use `Date.now()`, which Workers only advance across I/O. The weekly
 site-perf collector records these phases; it does not budget them.

--- a/docs/contributing/architecture/request-lifecycle.md
+++ b/docs/contributing/architecture/request-lifecycle.md
@@ -169,15 +169,13 @@ are:
 - `ssr` — route preload, stylesheet, and starting the HTML stream
 - `highlight` — token batch (`desc` is `hit`, `worker`, `miss`, or `fallback`)
 - `listings` — onboarding featured/chooser load
-- `mailbox` — signed-in onboarding Mailbox first-win probes (`desc` is `skip`
-  until an MCP host has authorized, otherwise `probe`)
+- `mailbox` — signed-in onboarding Mailbox first-win probes
 - `code-runs` — homepage public ticker window
 
 Signed-in `/onboarding` overlaps featured listings, MCP OAuth grant listing, and
-D1 checklist reads. It does not call Mailbox or UserMeter until `hasMcpClient`
-is true, so a first visit after login does not wake the platform worker. When it
-does probe, one unfiltered Mailbox count returns immediately for an empty
-mailbox.
+the Mailbox first-win read. That Mailbox read is one unfiltered count; search
+and list run only when the mailbox is not empty. `install-starter` reads saved
+packages from D1.
 
 Durations use `Date.now()`, which Workers only advance across I/O. The weekly
 site-perf collector records these phases; it does not budget them.

--- a/packages/worker/src/app/handlers/account.ts
+++ b/packages/worker/src/app/handlers/account.ts
@@ -35,7 +35,6 @@ export function createAccountHandler(env: Env) {
 					env,
 					user.mcpUser.userId,
 					onboarding.hasMcpClient,
-					{ probeMailbox: onboarding.hasMcpClient },
 				)
 			}
 			return renderAppPage({

--- a/packages/worker/src/app/handlers/account.ts
+++ b/packages/worker/src/app/handlers/account.ts
@@ -35,6 +35,7 @@ export function createAccountHandler(env: Env) {
 					env,
 					user.mcpUser.userId,
 					onboarding.hasMcpClient,
+					{ probeMailbox: onboarding.hasMcpClient },
 				)
 			}
 			return renderAppPage({

--- a/packages/worker/src/app/handlers/onboarding.node.test.ts
+++ b/packages/worker/src/app/handlers/onboarding.node.test.ts
@@ -313,6 +313,7 @@ test('onboarding persist next-steps use the newest saved-package kody id', async
 	mockModule.listOwnerEmailMessages.mockResolvedValue([])
 	mockModule.searchOwnerEmailMessages.mockResolvedValue([])
 	mockModule.countInternalUserEmailMessages.mockReset()
+	mockModule.countInternalUserEmailMessages.mockResolvedValue(0)
 
 	const response = await createOnboardingApiHandler(env).handler(
 		new RequestContext(new Request('https://example.com/onboarding.json')),
@@ -326,11 +327,12 @@ test('onboarding persist next-steps use the newest saved-package kody id', async
 		hasSentWelcomeEmail: false,
 		persistedPackageKodyId: 'morning-digest',
 	})
-	expect(mockModule.countInternalUserEmailMessages).not.toHaveBeenCalled()
+	expect(mockModule.countInternalUserEmailMessages).toHaveBeenCalledTimes(1)
 	expect(mockModule.searchOwnerEmailMessages).not.toHaveBeenCalled()
 	expect(response.headers.get('Server-Timing')).toContain('mailbox;dur=')
-	expect(response.headers.get('Server-Timing')).toContain('desc="skip"')
+	expect(response.headers.get('Server-Timing')).toContain('listings;dur=')
 
+	mockModule.countInternalUserEmailMessages.mockClear()
 	mockModule.countInternalUserEmailMessages.mockResolvedValue(0)
 	const connectedEnv = {
 		...env,
@@ -347,6 +349,32 @@ test('onboarding persist next-steps use the newest saved-package kody id', async
 		hasMcpClient: true,
 		hasSentWelcomeEmail: false,
 	})
-	expect(mockModule.countInternalUserEmailMessages).toHaveBeenCalled()
-	expect(connected.headers.get('Server-Timing')).toContain('desc="probe"')
+	expect(mockModule.countInternalUserEmailMessages).toHaveBeenCalledTimes(1)
+	expect(mockModule.searchOwnerEmailMessages).not.toHaveBeenCalled()
+
+	mockModule.countInternalUserEmailMessages.mockReset()
+	mockModule.countInternalUserEmailMessages
+		.mockResolvedValueOnce(2)
+		.mockResolvedValueOnce(1)
+		.mockResolvedValueOnce(1)
+	mockModule.searchOwnerEmailMessages.mockResolvedValue([
+		{
+			subject: 'Welcome to Kody — reply to introduce yourself',
+			fromAddress: 'kody@heykody.app',
+		},
+	])
+	const withMail = await createOnboardingApiHandler(connectedEnv).handler(
+		new RequestContext(new Request('https://example.com/onboarding.json')),
+	)
+	expect(withMail.status).toBe(200)
+	await expect(withMail.json()).resolves.toMatchObject({
+		ok: true,
+		hasSentWelcomeEmail: true,
+		welcomeEmail: {
+			subject: 'Welcome to Kody — reply to introduce yourself',
+			fromAddress: 'kody@heykody.app',
+		},
+	})
+	expect(mockModule.countInternalUserEmailMessages).toHaveBeenCalledTimes(3)
+	expect(mockModule.searchOwnerEmailMessages).toHaveBeenCalled()
 })

--- a/packages/worker/src/app/handlers/onboarding.node.test.ts
+++ b/packages/worker/src/app/handlers/onboarding.node.test.ts
@@ -26,6 +26,7 @@ const mockModule = vi.hoisted(() => ({
 	listMcpServerSettings: vi.fn(),
 	loadMcpClientHubSnapshotOrNull: vi.fn(),
 	listSavedPackagesByUserId: vi.fn(),
+	countInternalUserEmailMessages: vi.fn(),
 }))
 
 vi.mock('#app/ssr-render.tsx', () => ({
@@ -47,6 +48,11 @@ vi.mock('#worker/email/owner-email-reader.ts', () => ({
 		mockModule.listOwnerEmailMessages(...args),
 	searchOwnerEmailMessages: (...args: Array<unknown>) =>
 		mockModule.searchOwnerEmailMessages(...args),
+}))
+
+vi.mock('#worker/email/mailbox-internal-read.ts', () => ({
+	countInternalUserEmailMessages: (...args: Array<unknown>) =>
+		mockModule.countInternalUserEmailMessages(...args),
 }))
 
 vi.mock('#worker/mcp-client/settings-service.ts', () => ({
@@ -306,6 +312,7 @@ test('onboarding persist next-steps use the newest saved-package kody id', async
 	mockModule.listMcpServerSettings.mockResolvedValue([])
 	mockModule.listOwnerEmailMessages.mockResolvedValue([])
 	mockModule.searchOwnerEmailMessages.mockResolvedValue([])
+	mockModule.countInternalUserEmailMessages.mockReset()
 
 	const response = await createOnboardingApiHandler(env).handler(
 		new RequestContext(new Request('https://example.com/onboarding.json')),
@@ -315,6 +322,31 @@ test('onboarding persist next-steps use the newest saved-package kody id', async
 		ok: true,
 		loggedIn: true,
 		username: 'u-b',
+		hasMcpClient: false,
+		hasSentWelcomeEmail: false,
 		persistedPackageKodyId: 'morning-digest',
 	})
+	expect(mockModule.countInternalUserEmailMessages).not.toHaveBeenCalled()
+	expect(mockModule.searchOwnerEmailMessages).not.toHaveBeenCalled()
+	expect(response.headers.get('Server-Timing')).toContain('mailbox;dur=')
+	expect(response.headers.get('Server-Timing')).toContain('desc="skip"')
+
+	mockModule.countInternalUserEmailMessages.mockResolvedValue(0)
+	const connectedEnv = {
+		...env,
+		OAUTH_PROVIDER: {
+			listUserGrants: async () => ({ items: [{ id: 'grant-1' }] }),
+		},
+	} as Env
+	const connected = await createOnboardingApiHandler(connectedEnv).handler(
+		new RequestContext(new Request('https://example.com/onboarding.json')),
+	)
+	expect(connected.status).toBe(200)
+	await expect(connected.json()).resolves.toMatchObject({
+		ok: true,
+		hasMcpClient: true,
+		hasSentWelcomeEmail: false,
+	})
+	expect(mockModule.countInternalUserEmailMessages).toHaveBeenCalled()
+	expect(connected.headers.get('Server-Timing')).toContain('desc="probe"')
 })

--- a/packages/worker/src/app/handlers/onboarding.ts
+++ b/packages/worker/src/app/handlers/onboarding.ts
@@ -4,7 +4,6 @@ import {
 	deriveOnboardingChecklist,
 	dismissOnboardingChecklist,
 	readOnboardingChecklistDismissed,
-	userHasSentWelcomeEmail,
 } from '#mcp/onboarding-checklist.ts'
 import { normalizeRedirectTo } from '#app/auth-redirect.ts'
 import { readAuthenticatedAppUser } from '#app/authenticated-user.ts'
@@ -40,7 +39,9 @@ import {
 import {
 	loadOnboardingData,
 	loadPublicOnboardingData,
+	userHasMcpOAuthGrants,
 } from '#app/onboarding-data.ts'
+import { countInternalUserEmailMessages } from '#worker/email/mailbox-internal-read.ts'
 import { anonymousPersonalizedJsonCacheHeaders } from '#app/anonymous-html-cache.ts'
 import { renderAppPage } from '#app/ssr-render.tsx'
 import { type routes } from '#universal/routes.ts'
@@ -63,6 +64,7 @@ export async function loadChecklist(
 	env: Env,
 	userId: string,
 	hasMcpClient: boolean,
+	options?: { probeMailbox?: boolean },
 ): Promise<OnboardingChecklistLoaderData> {
 	const [checklist, dismissed] = await Promise.all([
 		deriveOnboardingChecklist({
@@ -70,21 +72,116 @@ export async function loadChecklist(
 			userId,
 			emailVerified: true,
 			hasMcpClient,
+			probeMailbox: options?.probeMailbox,
 		}),
 		readOnboardingChecklistDismissed({ env, userId }),
 	])
 	return { items: checklist.items, dismissed }
 }
 
+const emptyOnboardingMailboxSignals = {
+	inboundMail: 0,
+	hasSentWelcomeEmail: false,
+	welcomeEmail: null,
+}
+
 /**
- * First-win Send sub-step: successful `email_send` or stored outbound mail.
- * Fails open to false so a Mailbox or UserMeter blip never breaks the payload.
+ * Mailbox-backed first-win signals. One unfiltered count first: an empty
+ * mailbox (the usual first-visit case) returns without a second RPC. Search
+ * and list run only when something is stored.
  */
-async function loadHasSentWelcomeEmail(
+async function loadOnboardingMailboxSignals(
 	env: Env,
 	userId: string,
-): Promise<boolean> {
-	return await userHasSentWelcomeEmail({ env, userId })
+): Promise<{
+	inboundMail: number
+	hasSentWelcomeEmail: boolean
+	welcomeEmail: OnboardingWelcomeEmail | null
+}> {
+	try {
+		const total = await countInternalUserEmailMessages({
+			env,
+			ownerId: userId,
+		})
+		if (total === 0) return emptyOnboardingMailboxSignals
+		const [inboundMail, outboundMail, welcomeEmail] = await Promise.all([
+			countInternalUserEmailMessages({
+				env,
+				ownerId: userId,
+				filters: { direction: 'inbound' },
+			}),
+			countInternalUserEmailMessages({
+				env,
+				ownerId: userId,
+				filters: { direction: 'outbound' },
+			}),
+			loadWelcomeEmail(env, userId),
+		])
+		return {
+			inboundMail,
+			hasSentWelcomeEmail: outboundMail > 0,
+			welcomeEmail,
+		}
+	} catch {
+		return emptyOnboardingMailboxSignals
+	}
+}
+
+function withInboundMail(
+	checklist: OnboardingChecklistLoaderData,
+	inboundMail: number,
+): OnboardingChecklistLoaderData {
+	return {
+		...checklist,
+		items: checklist.items.map((item) =>
+			item.id === 'first-hello' ? { ...item, done: inboundMail > 0 } : item,
+		),
+	}
+}
+
+async function loadSignedInOnboardingD1Progress(env: Env, userId: string) {
+	const [checklist, persistedPackageKodyId] = await Promise.all([
+		loadChecklist(env, userId, false, { probeMailbox: false }),
+		loadPersistedPackageKodyId(env, userId),
+	])
+	return { checklist, persistedPackageKodyId }
+}
+
+async function loadSignedInOnboardingMailboxProgress(input: {
+	env: Env
+	userId: string
+	hasMcpClient: boolean
+	checklist: OnboardingChecklistLoaderData
+	serverTiming: Array<ServerTimingEntry>
+}): Promise<{
+	checklist: OnboardingChecklistLoaderData
+	hasSentWelcomeEmail: boolean
+	welcomeEmail: OnboardingWelcomeEmail | null
+}> {
+	const mailboxStartedAt = Date.now()
+	const mailbox = input.hasMcpClient
+		? await loadOnboardingMailboxSignals(input.env, input.userId)
+		: emptyOnboardingMailboxSignals
+	input.serverTiming.push({
+		name: 'mailbox',
+		durationMs: Date.now() - mailboxStartedAt,
+		desc: input.hasMcpClient ? 'probe' : 'skip',
+	})
+	return {
+		checklist: withInboundMail(
+			{
+				...input.checklist,
+				items: input.checklist.items.map((item) =>
+					item.id === 'connect-agent'
+						? { ...item, done: input.hasMcpClient }
+						: item,
+				),
+			},
+			mailbox.inboundMail,
+		),
+		hasSentWelcomeEmail: mailbox.hasSentWelcomeEmail,
+		welcomeEmail: mailbox.welcomeEmail,
+	}
 }
 
 /**
@@ -94,14 +191,6 @@ async function loadHasSentWelcomeEmail(
  */
 const welcomeEmailSubjectMatch = 'Welcome to Kody'
 
-/**
- * Subject and sender of the stored welcome email, so the Reply sub-step can
- * name exactly what to search a personal inbox for. Agents write their own
- * subject line, so a mailbox with no match falls back to the newest outbound
- * message — during the first win that is the mail to reply to. Fails open to
- * null: the sub-step reads fine without it, and a Mailbox blip must not break
- * the payload.
- */
 /**
  * Most recently updated saved-package kody id for Step 3 next-steps after
  * persist. The listing is `ORDER BY updated_at DESC`, so the first row is
@@ -120,6 +209,14 @@ export async function loadPersistedPackageKodyId(
 	}
 }
 
+/**
+ * Subject and sender of the stored welcome email, so the Reply sub-step can
+ * name exactly what to search a personal inbox for. Agents write their own
+ * subject line, so a mailbox with no match falls back to the newest outbound
+ * message — during the first win that is the mail to reply to. Fails open to
+ * null: the sub-step reads fine without it, and a Mailbox blip must not break
+ * the payload.
+ */
 export async function loadWelcomeEmail(
 	env: Env,
 	userId: string,
@@ -327,28 +424,31 @@ export function createOnboardingHandler(env: Env) {
 				return redirectUnverifiedToPending(request)
 			}
 
-			const chooser = await pushServerTiming(serverTiming, 'listings', () =>
-				loadOnboardingChooserFields(env, request, user.mcpUser.userId),
-			)
+			const [chooser, hasMcpClient, d1Progress] = await Promise.all([
+				pushServerTiming(serverTiming, 'listings', () =>
+					loadOnboardingChooserFields(env, request, user.mcpUser.userId),
+				),
+				userHasMcpOAuthGrants(env, user.mcpUser.userId),
+				loadSignedInOnboardingD1Progress(env, user.mcpUser.userId),
+			])
+			const mailboxProgress = await loadSignedInOnboardingMailboxProgress({
+				env,
+				userId: user.mcpUser.userId,
+				hasMcpClient,
+				checklist: d1Progress.checklist,
+				serverTiming,
+			})
 			const onboarding = await loadOnboardingData({
 				env,
 				requestUrl: request.url,
 				stableUserId: user.mcpUser.userId,
 				username: user.username,
 				emailVerified: user.emailVerified,
+				hasMcpClient,
 				...chooser,
+				persistedPackageKodyId: d1Progress.persistedPackageKodyId,
+				...mailboxProgress,
 			})
-			;[
-				onboarding.checklist,
-				onboarding.hasSentWelcomeEmail,
-				onboarding.welcomeEmail,
-				onboarding.persistedPackageKodyId,
-			] = await Promise.all([
-				loadChecklist(env, user.mcpUser.userId, onboarding.hasMcpClient),
-				loadHasSentWelcomeEmail(env, user.mcpUser.userId),
-				loadWelcomeEmail(env, user.mcpUser.userId),
-				loadPersistedPackageKodyId(env, user.mcpUser.userId),
-			])
 			return renderAppPage({
 				request,
 				env,
@@ -405,10 +505,23 @@ export function createOnboardingApiHandler(env: Env) {
 			// Unverified callers still get a payload so clients can detect the
 			// gate; MCP URL/setup and featured fields stay empty until
 			// verification succeeds.
-			const chooser = user.emailVerified
-				? await pushServerTiming(serverTiming, 'listings', () =>
-						loadOnboardingChooserFields(env, request, user.mcpUser.userId),
-					)
+			const [chooser, hasMcpClient, d1Progress] = user.emailVerified
+				? await Promise.all([
+						pushServerTiming(serverTiming, 'listings', () =>
+							loadOnboardingChooserFields(env, request, user.mcpUser.userId),
+						),
+						userHasMcpOAuthGrants(env, user.mcpUser.userId),
+						loadSignedInOnboardingD1Progress(env, user.mcpUser.userId),
+					])
+				: [null, false, null]
+			const mailboxProgress = d1Progress
+				? await loadSignedInOnboardingMailboxProgress({
+						env,
+						userId: user.mcpUser.userId,
+						hasMcpClient,
+						checklist: d1Progress.checklist,
+						serverTiming,
+					})
 				: null
 			const onboarding = await loadOnboardingData({
 				env,
@@ -416,21 +529,11 @@ export function createOnboardingApiHandler(env: Env) {
 				stableUserId: user.mcpUser.userId,
 				username: user.username,
 				emailVerified: user.emailVerified,
+				hasMcpClient,
 				...chooser,
+				persistedPackageKodyId: d1Progress?.persistedPackageKodyId,
+				...mailboxProgress,
 			})
-			if (user.emailVerified) {
-				;[
-					onboarding.checklist,
-					onboarding.hasSentWelcomeEmail,
-					onboarding.welcomeEmail,
-					onboarding.persistedPackageKodyId,
-				] = await Promise.all([
-					loadChecklist(env, user.mcpUser.userId, onboarding.hasMcpClient),
-					loadHasSentWelcomeEmail(env, user.mcpUser.userId),
-					loadWelcomeEmail(env, user.mcpUser.userId),
-					loadPersistedPackageKodyId(env, user.mcpUser.userId),
-				])
-			}
 			return jsonResponse(
 				await withOnboardingHighlights(env, onboarding, serverTiming),
 				{ serverTiming },

--- a/packages/worker/src/app/handlers/onboarding.ts
+++ b/packages/worker/src/app/handlers/onboarding.ts
@@ -6,7 +6,10 @@ import {
 	readOnboardingChecklistDismissed,
 } from '#mcp/onboarding-checklist.ts'
 import { normalizeRedirectTo } from '#app/auth-redirect.ts'
-import { readAuthenticatedAppUser } from '#app/authenticated-user.ts'
+import {
+	readAuthenticatedAppUser,
+	type AuthenticatedAppUser,
+} from '#app/authenticated-user.ts'
 import {
 	loadOnboardingFeaturedListings,
 	loadOnboardingMcpChooserListings,
@@ -64,7 +67,7 @@ export async function loadChecklist(
 	env: Env,
 	userId: string,
 	hasMcpClient: boolean,
-	options?: { probeMailbox?: boolean },
+	options?: { inboundMail?: number },
 ): Promise<OnboardingChecklistLoaderData> {
 	const [checklist, dismissed] = await Promise.all([
 		deriveOnboardingChecklist({
@@ -72,7 +75,7 @@ export async function loadChecklist(
 			userId,
 			emailVerified: true,
 			hasMcpClient,
-			probeMailbox: options?.probeMailbox,
+			inboundMail: options?.inboundMail,
 		}),
 		readOnboardingChecklistDismissed({ env, userId }),
 	])
@@ -87,8 +90,8 @@ const emptyOnboardingMailboxSignals = {
 
 /**
  * Mailbox-backed first-win signals. One unfiltered count first: an empty
- * mailbox (the usual first-visit case) returns without a second RPC. Search
- * and list run only when something is stored.
+ * mailbox returns without a second RPC. Search and list run only when
+ * something is stored.
  */
 async function loadOnboardingMailboxSignals(
 	env: Env,
@@ -127,61 +130,40 @@ async function loadOnboardingMailboxSignals(
 	}
 }
 
-function withInboundMail(
-	checklist: OnboardingChecklistLoaderData,
-	inboundMail: number,
-): OnboardingChecklistLoaderData {
-	return {
-		...checklist,
-		items: checklist.items.map((item) =>
-			item.id === 'first-hello' ? { ...item, done: inboundMail > 0 } : item,
-		),
-	}
-}
-
-async function loadSignedInOnboardingD1Progress(env: Env, userId: string) {
-	const [checklist, persistedPackageKodyId] = await Promise.all([
-		loadChecklist(env, userId, false, { probeMailbox: false }),
-		loadPersistedPackageKodyId(env, userId),
-	])
-	return { checklist, persistedPackageKodyId }
-}
-
-async function loadSignedInOnboardingMailboxProgress(input: {
+async function loadSignedInOnboardingPageData(input: {
 	env: Env
-	userId: string
-	hasMcpClient: boolean
-	checklist: OnboardingChecklistLoaderData
+	request: Request
+	user: AuthenticatedAppUser
 	serverTiming: Array<ServerTimingEntry>
-}): Promise<{
-	checklist: OnboardingChecklistLoaderData
-	hasSentWelcomeEmail: boolean
-	welcomeEmail: OnboardingWelcomeEmail | null
-}> {
-	const mailboxStartedAt = Date.now()
-	const mailbox = input.hasMcpClient
-		? await loadOnboardingMailboxSignals(input.env, input.userId)
-		: emptyOnboardingMailboxSignals
-	input.serverTiming.push({
-		name: 'mailbox',
-		durationMs: Date.now() - mailboxStartedAt,
-		desc: input.hasMcpClient ? 'probe' : 'skip',
+}) {
+	const userId = input.user.mcpUser.userId
+	const [chooser, hasMcpClient, mailbox, persistedPackageKodyId] =
+		await Promise.all([
+			pushServerTiming(input.serverTiming, 'listings', () =>
+				loadOnboardingChooserFields(input.env, input.request, userId),
+			),
+			userHasMcpOAuthGrants(input.env, userId),
+			pushServerTiming(input.serverTiming, 'mailbox', () =>
+				loadOnboardingMailboxSignals(input.env, userId),
+			),
+			loadPersistedPackageKodyId(input.env, userId),
+		])
+	const checklist = await loadChecklist(input.env, userId, hasMcpClient, {
+		inboundMail: mailbox.inboundMail,
 	})
-	return {
-		checklist: withInboundMail(
-			{
-				...input.checklist,
-				items: input.checklist.items.map((item) =>
-					item.id === 'connect-agent'
-						? { ...item, done: input.hasMcpClient }
-						: item,
-				),
-			},
-			mailbox.inboundMail,
-		),
+	return loadOnboardingData({
+		env: input.env,
+		requestUrl: input.request.url,
+		stableUserId: userId,
+		username: input.user.username,
+		emailVerified: input.user.emailVerified,
+		hasMcpClient,
+		...chooser,
+		persistedPackageKodyId,
+		checklist,
 		hasSentWelcomeEmail: mailbox.hasSentWelcomeEmail,
 		welcomeEmail: mailbox.welcomeEmail,
-	}
+	})
 }
 
 /**
@@ -424,30 +406,11 @@ export function createOnboardingHandler(env: Env) {
 				return redirectUnverifiedToPending(request)
 			}
 
-			const [chooser, hasMcpClient, d1Progress] = await Promise.all([
-				pushServerTiming(serverTiming, 'listings', () =>
-					loadOnboardingChooserFields(env, request, user.mcpUser.userId),
-				),
-				userHasMcpOAuthGrants(env, user.mcpUser.userId),
-				loadSignedInOnboardingD1Progress(env, user.mcpUser.userId),
-			])
-			const mailboxProgress = await loadSignedInOnboardingMailboxProgress({
+			const onboarding = await loadSignedInOnboardingPageData({
 				env,
-				userId: user.mcpUser.userId,
-				hasMcpClient,
-				checklist: d1Progress.checklist,
+				request,
+				user,
 				serverTiming,
-			})
-			const onboarding = await loadOnboardingData({
-				env,
-				requestUrl: request.url,
-				stableUserId: user.mcpUser.userId,
-				username: user.username,
-				emailVerified: user.emailVerified,
-				hasMcpClient,
-				...chooser,
-				persistedPackageKodyId: d1Progress.persistedPackageKodyId,
-				...mailboxProgress,
 			})
 			return renderAppPage({
 				request,
@@ -505,35 +468,20 @@ export function createOnboardingApiHandler(env: Env) {
 			// Unverified callers still get a payload so clients can detect the
 			// gate; MCP URL/setup and featured fields stay empty until
 			// verification succeeds.
-			const [chooser, hasMcpClient, d1Progress] = user.emailVerified
-				? await Promise.all([
-						pushServerTiming(serverTiming, 'listings', () =>
-							loadOnboardingChooserFields(env, request, user.mcpUser.userId),
-						),
-						userHasMcpOAuthGrants(env, user.mcpUser.userId),
-						loadSignedInOnboardingD1Progress(env, user.mcpUser.userId),
-					])
-				: [null, false, null]
-			const mailboxProgress = d1Progress
-				? await loadSignedInOnboardingMailboxProgress({
+			const onboarding = user.emailVerified
+				? await loadSignedInOnboardingPageData({
 						env,
-						userId: user.mcpUser.userId,
-						hasMcpClient,
-						checklist: d1Progress.checklist,
+						request,
+						user,
 						serverTiming,
 					})
-				: null
-			const onboarding = await loadOnboardingData({
-				env,
-				requestUrl: request.url,
-				stableUserId: user.mcpUser.userId,
-				username: user.username,
-				emailVerified: user.emailVerified,
-				hasMcpClient,
-				...chooser,
-				persistedPackageKodyId: d1Progress?.persistedPackageKodyId,
-				...mailboxProgress,
-			})
+				: await loadOnboardingData({
+						env,
+						requestUrl: request.url,
+						stableUserId: user.mcpUser.userId,
+						username: user.username,
+						emailVerified: user.emailVerified,
+					})
 			return jsonResponse(
 				await withOnboardingHighlights(env, onboarding, serverTiming),
 				{ serverTiming },

--- a/packages/worker/src/app/onboarding-data.ts
+++ b/packages/worker/src/app/onboarding-data.ts
@@ -116,11 +116,14 @@ export async function loadOnboardingData(input: {
 	checklist?: OnboardingChecklistLoaderData | null
 	/** Stored welcome email metadata, loaded by the handler. */
 	welcomeEmail?: OnboardingWelcomeEmail | null
+	/** Precomputed MCP OAuth grant signal so the handler can overlap listings. */
+	hasMcpClient?: boolean
+	/** First-win Send sub-step, loaded by the handler. */
+	hasSentWelcomeEmail?: boolean
 }): Promise<OnboardingLoaderData> {
-	const hasMcpClient = await userHasMcpOAuthGrants(
-		input.env,
-		input.stableUserId,
-	)
+	const hasMcpClient =
+		input.hasMcpClient ??
+		(await userHasMcpOAuthGrants(input.env, input.stableUserId))
 	// Incomplete setup means either the account email is still unverified or no
 	// MCP host has authorized yet. An unverified account with a leftover grant
 	// still needs onboarding until verification is finished.
@@ -170,8 +173,7 @@ export async function loadOnboardingData(input: {
 				listDisconnectedOnboardingFeaturedMcpServers())
 			: [],
 		customMcpServers: input.emailVerified ? (input.customMcpServers ?? []) : [],
-		// Computed by the handler alongside the checklist probes.
-		hasSentWelcomeEmail: false,
+		hasSentWelcomeEmail: input.hasSentWelcomeEmail ?? false,
 		welcomeEmail: input.welcomeEmail ?? null,
 		persistedPackageKodyId: input.emailVerified
 			? (input.persistedPackageKodyId ?? null)

--- a/packages/worker/src/mcp/onboarding-checklist.node.test.ts
+++ b/packages/worker/src/mcp/onboarding-checklist.node.test.ts
@@ -7,7 +7,9 @@ import { createInMemoryUserMeterEnv } from '#worker/test-support/user-meter.ts'
 import { upsertIntegration } from '#worker/integrations/service.ts'
 import { insertMemory } from '#mcp/memory/repo.ts'
 import { buildOnboardingSearchNotice } from '#mcp/tools/search-onboarding-notice.ts'
+import { insertSavedPackage } from '#worker/package-registry/repo.ts'
 import {
+	assembleOnboardingChecklist,
 	deriveOnboardingChecklist,
 	dismissOnboardingChecklist,
 	readOnboardingChecklistDismissed,
@@ -182,6 +184,50 @@ test('search onboarding notice points at /onboarding and goes quiet after dismis
 			baseUrl: 'https://kody.example',
 		}),
 	).toBe(null)
+})
+
+test('checklist install-starter reads saved packages from D1 and can skip Mailbox', async () => {
+	const { env } = createEnv()
+	await seedUser(env.APP_DB)
+	await insertSavedPackage(env.APP_DB, {
+		id: 'pkg-1',
+		user_id: userId,
+		name: '@user/starter',
+		kody_id: 'starter',
+		description: 'Starter',
+		tags_json: '[]',
+		source_id: 'src-1',
+		has_app: 0,
+	})
+
+	const skipped = await deriveOnboardingChecklist({
+		env,
+		userId,
+		emailVerified: true,
+		hasMcpClient: false,
+		probeMailbox: false,
+	})
+	expect(
+		Object.fromEntries(skipped.items.map((item) => [item.id, item.done])),
+	).toEqual({
+		'verify-email': true,
+		'connect-agent': false,
+		'first-hello': false,
+		'save-memory': false,
+		'connect-integration': false,
+		'install-starter': true,
+	})
+
+	expect(
+		assembleOnboardingChecklist({
+			emailVerified: true,
+			hasMcpClient: true,
+			inboundMail: 2,
+			hasMemory: true,
+			hasIntegrationOrMcp: true,
+			hasSavedPackage: true,
+		}).complete,
+	).toBe(true)
 })
 
 test('first-win Send is done when email_send meter counts even without mailbox', async () => {

--- a/packages/worker/src/mcp/onboarding-checklist.node.test.ts
+++ b/packages/worker/src/mcp/onboarding-checklist.node.test.ts
@@ -186,7 +186,7 @@ test('search onboarding notice points at /onboarding and goes quiet after dismis
 	).toBe(null)
 })
 
-test('checklist install-starter reads saved packages from D1 and can skip Mailbox', async () => {
+test('checklist install-starter reads saved packages from D1', async () => {
 	const { env } = createEnv()
 	await seedUser(env.APP_DB)
 	await insertSavedPackage(env.APP_DB, {
@@ -205,7 +205,7 @@ test('checklist install-starter reads saved packages from D1 and can skip Mailbo
 		userId,
 		emailVerified: true,
 		hasMcpClient: false,
-		probeMailbox: false,
+		inboundMail: 0,
 	})
 	expect(
 		Object.fromEntries(skipped.items.map((item) => [item.id, item.done])),

--- a/packages/worker/src/mcp/onboarding-checklist.ts
+++ b/packages/worker/src/mcp/onboarding-checklist.ts
@@ -5,6 +5,7 @@ import {
 } from '#worker/entitlements/service.ts'
 import { listIntegrations } from '#worker/integrations/service.ts'
 import { listMcpServerSettings } from '#worker/mcp-client/settings-service.ts'
+import { listSavedPackagesByUserId } from '#worker/package-registry/repo.ts'
 import { listMemoriesByUserId } from '#mcp/memory/repo.ts'
 import { getValue } from '#mcp/values/service.ts'
 import {
@@ -68,59 +69,82 @@ export async function userHasSentWelcomeEmail(input: {
 }
 
 /**
- * Compute the checklist from existing signals: one Mailbox DO count (stored
- * INBOUND mail — the welcome email alone is outbound, so "exchange a first
- * email" only completes once the user's reply lands), and three cheap D1
+ * Compute the checklist from existing signals: an optional Mailbox DO count
+ * (stored INBOUND mail — the welcome email alone is outbound, so "exchange
+ * a first email" only completes once the user's reply lands), and cheap D1
  * reads (active memories, saved integrations or MCP servers, saved
  * packages). Individual probe failures fail open to "not done" so a
  * storage blip never breaks onboarding surfaces.
  */
+export function assembleOnboardingChecklist(input: {
+	emailVerified: boolean
+	hasMcpClient: boolean
+	inboundMail: number
+	hasMemory: boolean
+	hasIntegrationOrMcp: boolean
+	hasSavedPackage: boolean
+}): OnboardingChecklist {
+	const items: Array<OnboardingChecklistItem> = [
+		{ id: 'verify-email', done: input.emailVerified },
+		{ id: 'connect-agent', done: input.hasMcpClient },
+		{ id: 'first-hello', done: input.inboundMail > 0 },
+		{ id: 'save-memory', done: input.hasMemory },
+		{ id: 'connect-integration', done: input.hasIntegrationOrMcp },
+		{ id: 'install-starter', done: input.hasSavedPackage },
+	]
+	return {
+		items,
+		complete: items.every((item) => item.done),
+	}
+}
+
 export async function deriveOnboardingChecklist(input: {
 	env: OnboardingChecklistEnv
 	userId: string
 	emailVerified: boolean
 	hasMcpClient: boolean
-	now?: Date
+	/**
+	 * When false, skip the Mailbox Durable Object. First-hello stays not-done
+	 * unless `inboundMail` is provided. Signed-in onboarding uses this until
+	 * an MCP host has authorized, so a first page load does not pay a cold
+	 * platform-worker Mailbox wake.
+	 */
+	probeMailbox?: boolean
+	/** Preloaded inbound count; skips the Mailbox inbound probe when set. */
+	inboundMail?: number
 }): Promise<OnboardingChecklist> {
 	const { env, userId } = input
-	const now = input.now ?? new Date()
+	const probeMailbox = input.probeMailbox ?? input.inboundMail === undefined
 	const [inboundMail, memories, integrations, mcpServers, savedPackages] =
 		await Promise.all([
-			countInternalUserEmailMessages({
-				env,
-				ownerId: userId,
-				filters: { direction: 'inbound' },
-			}).catch(() => 0),
+			input.inboundMail !== undefined
+				? Promise.resolve(input.inboundMail)
+				: probeMailbox
+					? countInternalUserEmailMessages({
+							env,
+							ownerId: userId,
+							filters: { direction: 'inbound' },
+						}).catch(() => 0)
+					: Promise.resolve(0),
 			listMemoriesByUserId(env.APP_DB, userId, {
 				limit: 1,
 				statuses: ['active'],
 			}).catch(() => []),
 			listIntegrations({ env, userId }).catch(() => [] as Array<unknown>),
 			listMcpServerSettings({ env, userId }).catch(() => [] as Array<unknown>),
-			readCurrentEntitlementResourceUsage({
-				db: env.APP_DB,
-				env,
-				userId,
-				resource: 'saved_packages',
-				now,
-			}).catch(() => 0),
+			listSavedPackagesByUserId(env.APP_DB, { userId }).catch(
+				() => [] as Array<unknown>,
+			),
 		])
 
-	const items: Array<OnboardingChecklistItem> = [
-		{ id: 'verify-email', done: input.emailVerified },
-		{ id: 'connect-agent', done: input.hasMcpClient },
-		{ id: 'first-hello', done: inboundMail > 0 },
-		{ id: 'save-memory', done: memories.length > 0 },
-		{
-			id: 'connect-integration',
-			done: integrations.length > 0 || mcpServers.length > 0,
-		},
-		{ id: 'install-starter', done: savedPackages > 0 },
-	]
-	return {
-		items,
-		complete: items.every((item) => item.done),
-	}
+	return assembleOnboardingChecklist({
+		emailVerified: input.emailVerified,
+		hasMcpClient: input.hasMcpClient,
+		inboundMail,
+		hasMemory: memories.length > 0,
+		hasIntegrationOrMcp: integrations.length > 0 || mcpServers.length > 0,
+		hasSavedPackage: savedPackages.length > 0,
+	})
 }
 
 export async function readOnboardingChecklistDismissed(input: {

--- a/packages/worker/src/mcp/onboarding-checklist.ts
+++ b/packages/worker/src/mcp/onboarding-checklist.ts
@@ -69,12 +69,12 @@ export async function userHasSentWelcomeEmail(input: {
 }
 
 /**
- * Compute the checklist from existing signals: an optional Mailbox DO count
- * (stored INBOUND mail — the welcome email alone is outbound, so "exchange
- * a first email" only completes once the user's reply lands), and cheap D1
- * reads (active memories, saved integrations or MCP servers, saved
- * packages). Individual probe failures fail open to "not done" so a
- * storage blip never breaks onboarding surfaces.
+ * Compute the checklist from existing signals: one Mailbox inbound count
+ * (the welcome email alone is outbound, so "exchange a first email" only
+ * completes once the user's reply lands), and cheap D1 reads (active
+ * memories, saved integrations or MCP servers, saved packages). Individual
+ * probe failures fail open to "not done" so a storage blip never breaks
+ * onboarding surfaces.
  */
 export function assembleOnboardingChecklist(input: {
 	emailVerified: boolean
@@ -103,29 +103,19 @@ export async function deriveOnboardingChecklist(input: {
 	userId: string
 	emailVerified: boolean
 	hasMcpClient: boolean
-	/**
-	 * When false, skip the Mailbox Durable Object. First-hello stays not-done
-	 * unless `inboundMail` is provided. Signed-in onboarding uses this until
-	 * an MCP host has authorized, so a first page load does not pay a cold
-	 * platform-worker Mailbox wake.
-	 */
-	probeMailbox?: boolean
-	/** Preloaded inbound count; skips the Mailbox inbound probe when set. */
+	/** Preloaded inbound count; skips a second Mailbox inbound probe. */
 	inboundMail?: number
 }): Promise<OnboardingChecklist> {
 	const { env, userId } = input
-	const probeMailbox = input.probeMailbox ?? input.inboundMail === undefined
 	const [inboundMail, memories, integrations, mcpServers, savedPackages] =
 		await Promise.all([
 			input.inboundMail !== undefined
 				? Promise.resolve(input.inboundMail)
-				: probeMailbox
-					? countInternalUserEmailMessages({
-							env,
-							ownerId: userId,
-							filters: { direction: 'inbound' },
-						}).catch(() => 0)
-					: Promise.resolve(0),
+				: countInternalUserEmailMessages({
+						env,
+						ownerId: userId,
+						filters: { direction: 'inbound' },
+					}).catch(() => 0),
 			listMemoriesByUserId(env.APP_DB, userId, {
 				limit: 1,
 				statuses: ['active'],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Fix the obvious waste on signed-in `/onboarding` without skipping work to dodge cold starts.

## Why

A first signed-in `/onboarding` was doing independent I/O in a waterfall, then up to four Mailbox RPCs plus a UserMeter read for data D1 already has. Cold isolates from low traffic are a separate problem.

## Summary

- Overlap featured listings, MCP OAuth grant listing, and the Mailbox first-win read.
- Mailbox first-win is one unfiltered count. Search and list run only when the mailbox is not empty.
- `install-starter` reads `saved_packages` from D1.
- `Server-Timing` includes a `mailbox` phase.

## Testing

- Node unit: onboarding handler, onboarding-data, onboarding-checklist, account
- Empty mailbox: one `countMessages`, no search. Non-empty: three counts plus welcome search.
- Typecheck on commit
- Preview bootstrap CPU-limit failure is unrelated to this request path

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `9b3dc221` · **Head:** `33d392a6`

**Classification:** extends — signed-in onboarding overlaps listings with one Mailbox count and reads packages from D1.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | extends — signed-in `/onboarding` overlaps listings with one Mailbox count |
| `mcp-server` | surfaces | extends — checklist `install-starter` reads D1 saved packages |
| `mailbox` | storage | composes — empty mailbox is one count; search/list only when stored |
| `app-sessions` | auth | composes — path overlap only (`onboarding-data.ts`) |

### Change flow

Signed-in onboarding runs listings, OAuth grants, and one Mailbox count together, then assembles the checklist from that inbound count.

```mermaid
sequenceDiagram
	actor User
	participant appUi as app-ui
	participant d1AppDb as d1-app-db
	participant mailbox as mailbox
	User->>appUi: GET /onboarding (kody_session)
	par listings and grants
		appUi->>d1AppDb: featured and chooser listings
		appUi->>appUi: listUserGrants
		appUi->>mailbox: countMessages
	end
	alt mailbox empty
		Note over mailbox: stop after one count
	else mailbox has mail
		appUi->>mailbox: inbound + outbound counts and welcome search
	end
	appUi->>d1AppDb: memories, integrations, saved packages
	appUi-->>User: HTML no-store
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8a9d9f31-2e4e-4b4b-8158-43ca59aaf9e0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8a9d9f31-2e4e-4b4b-8158-43ca59aaf9e0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved onboarding progress detection for signed-in users.
  * Welcome-email status now updates correctly when messages are present.
  * Empty mailboxes no longer trigger unnecessary message searches.
  * Saved starter packages now correctly complete the related onboarding step.

* **Documentation**
  * Updated Page Server-Timing and onboarding lifecycle documentation to reflect current mailbox and starter-package behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->