### PR TITLE
Ignore keyed export platform interrupts as retryable weather

### DIFF
--- a/docs/contributing/architecture/run-records.md
+++ b/docs/contributing/architecture/run-records.md
@@ -215,9 +215,9 @@ Interrupted scheduled-job occurrences (`idempotency_key` beginning
 `scheduled-job:`), keyed subscription deliveries, and keyed package-export
 invocations are retained with `error_triage=ignored` because their scheduler,
 delivery queue, or invocation-token caller retries the same idempotent unit.
-Manual jobs, keyed execute calls, and other surfaces stay open: their caller
-may need to recover or act on the unknown outcome. A later terminal finish
-still replaces the reconciled row when the outcome becomes known.
+Manual jobs, keyed execute calls, and other surfaces stay open: their caller may
+need to recover or act on the unknown outcome. A later terminal finish still
+replaces the reconciled row when the outcome becomes known.
 
 ## Keyed package-invocation idempotency ledger
 

--- a/docs/contributing/architecture/run-records.md
+++ b/docs/contributing/architecture/run-records.md
@@ -212,12 +212,12 @@ retention passes, and **on read** (`getRun`, keyed lookup, `listRuns`,
 `summarize`) so Activity and keyed-execute recovery do not wait for an alarm.
 
 Interrupted scheduled-job occurrences (`idempotency_key` beginning
-`scheduled-job:`) and keyed subscription deliveries are retained with
-`error_triage=ignored` because their scheduler or delivery queue retries the
-same idempotent unit. Manual jobs, keyed execute calls, and other surfaces stay
-open: their caller may need to recover or act on the unknown outcome. A later
-terminal finish still replaces the reconciled row when the outcome becomes
-known.
+`scheduled-job:`), keyed subscription deliveries, and keyed package-export
+invocations are retained with `error_triage=ignored` because their scheduler,
+delivery queue, or invocation-token caller retries the same idempotent unit.
+Manual jobs, keyed execute calls, and other surfaces stay open: their caller
+may need to recover or act on the unknown outcome. A later terminal finish
+still replaces the reconciled row when the outcome becomes known.
 
 ## Keyed package-invocation idempotency ledger
 

--- a/packages/worker/src/run-records/run-records.workers.test.ts
+++ b/packages/worker/src/run-records/run-records.workers.test.ts
@@ -987,6 +987,13 @@ test('cap and stale retention journey', async () => {
 				surface: 'subscription',
 				idempotencyKey: 'delivery-123',
 			})
+			insertRunRow(state, {
+				id: 'stale-keyed-export',
+				status: 'running',
+				startedAt: staleSubscriptionStartedAt,
+				surface: 'export',
+				idempotencyKey: 'youtube:websub:video-1:2026-08-25T13:41:52.301Z',
+			})
 		})
 
 		const summary = await summarizeRunRecords({
@@ -996,7 +1003,7 @@ test('cap and stale retention journey', async () => {
 		})
 		expect(summary).toMatchObject({
 			errors: 0,
-			ignored: 2,
+			ignored: 3,
 			running: 0,
 		})
 		const page = await listRunRecords({
@@ -1004,7 +1011,7 @@ test('cap and stale retention journey', async () => {
 			userId,
 			filter: { errorTriage: 'ignored' },
 		})
-		expect(page.runs).toHaveLength(2)
+		expect(page.runs).toHaveLength(3)
 		for (const run of page.runs) {
 			expect(run).toMatchObject({
 				status: 'error',
@@ -1049,6 +1056,18 @@ test('cap and stale retention journey', async () => {
 					env,
 					userId,
 					runId: 'stale-subscription-delivery',
+				})
+			)?.run,
+		).toMatchObject({
+			errorName: runRecordPlatformInterruptedErrorName,
+			errorTriage: 'ignored',
+		})
+		expect(
+			(
+				await getRunRecord({
+					env,
+					userId,
+					runId: 'stale-keyed-export',
 				})
 			)?.run,
 		).toMatchObject({

--- a/packages/worker/src/run-records/stale-running-interrupt.node.test.ts
+++ b/packages/worker/src/run-records/stale-running-interrupt.node.test.ts
@@ -32,6 +32,12 @@ test('platform interrupt has a stable error contract and only auto-ignores retry
 			idempotencyKey: 'delivery-123',
 		}),
 	).toBe('ignored')
+	expect(
+		platformInterruptTriage({
+			surface: 'export',
+			idempotencyKey: 'youtube:websub:video-1:2026-08-25T13:41:52.301Z',
+		}),
+	).toBe('ignored')
 
 	expect(
 		platformInterruptTriage({
@@ -42,6 +48,12 @@ test('platform interrupt has a stable error contract and only auto-ignores retry
 	expect(
 		platformInterruptTriage({
 			surface: 'subscription',
+			idempotencyKey: ' ',
+		}),
+	).toBeNull()
+	expect(
+		platformInterruptTriage({
+			surface: 'export',
 			idempotencyKey: ' ',
 		}),
 	).toBeNull()

--- a/packages/worker/src/run-records/types.ts
+++ b/packages/worker/src/run-records/types.ts
@@ -71,9 +71,10 @@ export const runRecordPlatformInterruptedErrorMessage =
 	'The platform interrupted this run before completion; outcome unknown.'
 
 /**
- * Idempotent unattended deliveries are retried by their owning scheduler or
- * queue, so retain their interrupted attempt as ignored history instead of an
- * open user-facing failure. Interactive and non-idempotent attempts stay open.
+ * Idempotent unattended deliveries are retried by their owning scheduler,
+ * queue, or invocation token, so retain their interrupted attempt as ignored
+ * history instead of an open user-facing failure. Interactive and
+ * non-idempotent attempts stay open.
  */
 export function runErrorTriageForPlatformInterrupt(
 	context: Pick<RunRecordContext, 'surface' | 'idempotencyKey'>,
@@ -83,9 +84,9 @@ export function runErrorTriageForPlatformInterrupt(
 		case 'job':
 			return idempotencyKey?.startsWith('scheduled-job:') ? 'ignored' : null
 		case 'subscription':
+		case 'export':
 			return idempotencyKey ? 'ignored' : null
 		case 'execute':
-		case 'export':
 		case 'app_fetch':
 		case 'app_realtime':
 		case 'workflow':


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop Activity and issue-triage from paging a successful keyed HTTP package handoff when the parent export isolate dies before the terminal RunLog write.

## Why

Fingerprint `export:youtube-livestream-vod-manager:the-platform-interrupted-this-run-before-completion-outcome-unknown` (sample [12df821d](https://kody.codes/account/activity/12df821d-2b37-4bb4-a148-69ddcc695b7a)): `./process-video` created workflow `pkgwf-vxP1pM2CpxyzpoZhPPzp-WkBkWOUMsU7KIAYNIzCiYQ`, `./process-video-work` succeeded in 2546ms, then the parent keyed export was stamped `platform_interrupted` at the 3-minute stale-running TTL. That is designed platform weather (isolate reset / lost finish), not a package bug. Keyed HTTP exports already retry the same idempotency unit — the same reason scheduled jobs and keyed subscriptions auto-ignore this error.

## Summary

- Auto-ignore `platform_interrupted` on keyed `export` runs (`idempotencyKey` present), matching keyed `subscription`.
- Key-less exports, keyed `execute`, and other surfaces stay open.
- A later real `finishRun` still replaces the reconciled row.
- Docs and tests follow the policy.

This does **not** investigate the `kody-runtime` isolate reset itself. Do that from CF/runtime logs for 12df821d only if this class keeps appearing after the noise is gone.

## Testing

- `npx vitest run packages/worker/src/run-records/stale-running-interrupt.node.test.ts packages/worker/src/run-records/run-records.workers.test.ts` — 18 passed.
- Preview [kody-pr-1762](https://kody-pr-1762.kody-a99.workers.dev) at merge commit of `4478c8f8`:
  - Seed login `me@kentcdodds.com` succeeded.
  - `GET /account/activity.json` default `triageFilter=open`.
  - `GET /account/activity.json?error_triage=ignored` → `triageFilter=ignored`.
  - `GET /account/activity.json?error_triage=all&status=all` → both filters `all`.
  - UI pass on `/account/activity`: empty seed account, Open / Ignored / All triage filters load without errors.

![Activity default open filter](https://cursor.com/artifacts/c/art-8a783290-1d7e-42e1-ac9e-df16fc2b627a)
![Activity ignored triage filter](https://cursor.com/artifacts/c/art-070f34ae-5089-42c8-9d14-170bb0bebed4)

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `9b3dc221` · **Head:** `4478c8f8`

**Classification:** extends — `runErrorTriageForPlatformInterrupt` now ignores keyed export interrupts; history rows and `run_get` still keep the original error.

### Primitives touched

| Primitive     | Group   | Impact                                                                 |
| ------------- | ------- | ---------------------------------------------------------------------- |
| `run-records` | storage | extends — keyed export `platform_interrupted` auto-triages `ignored` |

### Change flow

Stale-running reconciliation still writes `platform_interrupted`; keyed exports now land as ignored history instead of open Activity errors.

```mermaid
sequenceDiagram
	actor TokenCaller
	participant packageRuntime as package-runtime
	participant runRecords as run-records
	TokenCaller->>packageRuntime: keyed HTTP export invoke
	packageRuntime->>runRecords: claim + running row
	Note over packageRuntime: isolate reset or lost finish
	runRecords->>runRecords: reconcile stale running after 3m
	runRecords-->>runRecords: error_triage=ignored when export has idempotencyKey
```

### Invariants

Per-user isolation is unchanged. Soft triage only hides Activity noise; `error_name` / `error_message` stay on the row.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9ea57f71-d5d3-4ed8-9b60-f57a13526fdc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9ea57f71-d5d3-4ed8-9b60-f57a13526fdc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Interrupted retryable export deliveries are now correctly classified as ignored during retention reconciliation.
  * Export runs without an idempotency key are not automatically marked as ignored.

* **Tests**
  * Added coverage for interrupted export deliveries and stale idempotent runs.
  * Updated reconciliation checks to verify the expected ignored-run classifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->