### PR TITLE
Add Cursor plugin manifest

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "kody",
+  "version": "1.0.2",
+  "description": "Personal assistant MCP server with search, execute, packages, jobs, secrets, and integrations.",
+  "author": { "name": "Kent C. Dodds" },
+  "homepage": "https://kody.codes",
+  "repository": "https://github.com/kentcdodds/kody",
+  "mcpServers": {
+    "kody": { "url": "https://kody.codes/mcp" }
+  }
+}


### PR DESCRIPTION
Adds a plugin manifest at `.cursor-plugin/plugin.json` so this repo can be installed as an agent plugin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for discovering and connecting to the Kody personal assistant MCP server through Cursor.
  - Included plugin metadata such as version, homepage, and repository information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->