### PR TITLE
Lead Cursor and Grok Bot onboarding with marketplace plugin install

### DIFF
--- a/docs/use/connect-your-agent.md
+++ b/docs/use/connect-your-agent.md
@@ -45,11 +45,7 @@ Manual on Get started has one tab per host. Use those when you are not running
 
 - **Cursor** — Install the official
   [Kody plugin](https://cursor.com/marketplace/kody), or in Cursor chat run
-  `/add-plugin kody`. After install, Authenticate in the Cursor MCP list. The
-  marketplace plugin targets production [kody.codes](https://kody.codes).
-  Preview and local origins still need a raw MCP server: Manual / fallback
-  includes Add to Cursor (MCP deeplink), the MCP URL, and JSON merge for
-  `~/.cursor/mcp.json` / `.cursor/mcp.json`.
+  `/add-plugin kody`. After install, Authenticate in the Cursor MCP list.
 - **Claude Desktop** — Copy the MCP URL into Settings → Connectors (custom
   connector). Remote servers are not configured through
   `claude_desktop_config.json`. After connecting, start a new chat and ask
@@ -69,9 +65,7 @@ Manual on Get started has one tab per host. Use those when you are not running
   official Kody plugin with
   [`grokbot://app/v1/plugin/add?id=56286216`](grokbot://app/v1/plugin/add?id=56286216),
   or open **Plugins** in the Grok Bot sidebar and add Kody. See Cursor's
-  [Grok Bot plugin help](https://cursor.com/help/grok-bot/connect-plugins). The
-  marketplace plugin targets production kody.codes. Manual / fallback is the MCP
-  URL for a custom connector (preview and local origins need this).
+  [Grok Bot plugin help](https://cursor.com/help/grok-bot/connect-plugins).
 - **Claude Code** — After the CLI writes the remote entry, enter `/mcp` → Kody →
   Authenticate. Manual includes
   `claude mcp add --transport http -s user kody <url>`, or a `.mcp.json` entry

--- a/docs/use/connect-your-agent.md
+++ b/docs/use/connect-your-agent.md
@@ -1,9 +1,9 @@
 # Connect your agent
 
 Kody is an MCP server. You use it from Cursor, ChatGPT, Codex, Claude Desktop,
-Grok.com, Grok CLI, Claude Code, OpenCode, GitHub Copilot (VS Code or CLI), the
-GitHub Copilot app, or any other AI agent that supports MCP — not from a
-separate Kody chat app.
+Grok.com, Grok CLI, Grok Bot, Claude Code, OpenCode, GitHub Copilot (VS Code or
+CLI), the GitHub Copilot app, or any other AI agent that supports MCP — not from
+a separate Kody chat app.
 
 Agents discovering this host can read `/auth.md` for the OAuth registration
 block and MCP URL, and `/.well-known/mcp/server-card.json` for the server card.
@@ -43,9 +43,13 @@ MCP URL and setup prompt.
 Manual on Get started has one tab per host. Use those when you are not running
 `@kodycodes/cli`, or when the host is web-only.
 
-- **Cursor** — After the CLI writes `~/.cursor/mcp.json`, Authenticate in the
-  Cursor MCP list. Manual includes Add to Cursor, the MCP URL, and JSON merge
-  for `~/.cursor/mcp.json` / `.cursor/mcp.json`.
+- **Cursor** — Install the official
+  [Kody plugin](https://cursor.com/marketplace/kody), or in Cursor chat run
+  `/add-plugin kody`. After install, Authenticate in the Cursor MCP list. The
+  marketplace plugin targets production [kody.codes](https://kody.codes).
+  Preview and local origins still need a raw MCP server: Manual / fallback
+  includes Add to Cursor (MCP deeplink), the MCP URL, and JSON merge for
+  `~/.cursor/mcp.json` / `.cursor/mcp.json`.
 - **Claude Desktop** — Copy the MCP URL into Settings → Connectors (custom
   connector). Remote servers are not configured through
   `claude_desktop_config.json`. After connecting, start a new chat and ask
@@ -61,6 +65,13 @@ Manual on Get started has one tab per host. Use those when you are not running
   writes `~/.grok/config.toml`. OAuth opens a browser on first use; in the TUI,
   `/mcps` then `i` authenticates. `grok mcp doctor kody` checks the connection.
   See xAI's [Grok CLI MCP docs](https://docs.x.ai/build/features/mcp-servers).
+- **Grok Bot** — Grok Bot is Cursor's desktop assistant, not grok.com. Add the
+  official Kody plugin with
+  [`grokbot://app/v1/plugin/add?id=56286216`](grokbot://app/v1/plugin/add?id=56286216),
+  or open **Plugins** in the Grok Bot sidebar and add Kody. See Cursor's
+  [Grok Bot plugin help](https://cursor.com/help/grok-bot/connect-plugins). The
+  marketplace plugin targets production kody.codes. Manual / fallback is the MCP
+  URL for a custom connector (preview and local origins need this).
 - **Claude Code** — After the CLI writes the remote entry, enter `/mcp` → Kody →
   Authenticate. Manual includes
   `claude mcp add --transport http -s user kody <url>`, or a `.mcp.json` entry
@@ -103,10 +114,10 @@ Manual on Get started has one tab per host. Use those when you are not running
 ### Coding vs non-coding agents
 
 Using Kody packages works great with non-coding agents such as Claude Desktop,
-ChatGPT.com, Grok.com, and the GitHub Copilot app. For creating or editing
-packages, a coding agent (Cursor, Claude Code, Codex / ChatGPT desktop, Grok
-CLI, Copilot, OpenCode, and similar) is usually smoother because those hosts can
-edit files and iterate on code more easily.
+ChatGPT.com, Grok.com, Grok Bot, and the GitHub Copilot app. For creating or
+editing packages, a coding agent (Cursor, Claude Code, Codex / ChatGPT desktop,
+Grok CLI, Copilot, OpenCode, and similar) is usually smoother because those
+hosts can edit files and iterate on code more easily.
 
 ## Give Kody Access, then persist a first build
 

--- a/packages/worker/client/routes/onboarding-mcp-client-tabs.node.test.ts
+++ b/packages/worker/client/routes/onboarding-mcp-client-tabs.node.test.ts
@@ -61,6 +61,14 @@ test('onboarding Step 1 shows @kodycodes/cli first and collapses Manual', async 
 	expect(manualBlock).toContain(kodyCursorMarketplaceUrl)
 	expect(manualBlock).toContain(kodyCursorAddPluginCommand)
 	expect(manualBlock).toContain(grokBotInstallUrl)
+	expect(manualBlock).toContain('Or do this:')
+	expect(manualBlock).toContain('data-testid="onboarding-mcp-plugin-primary"')
+	expect(manualBlock).toContain(
+		'data-testid="onboarding-mcp-plugin-alternative"',
+	)
+	expect(manualBlock).not.toContain('Cursor&apos;s')
+	expect(manualBlock).not.toContain("Cursor's")
+	expect(manualBlock).toContain('>Grok Bot plugin help<')
 	expect(manualBlock).toContain(
 		buildCursorInstallUrl(defaultKodyMcpUrl).replaceAll('&', '&amp;'),
 	)
@@ -74,6 +82,27 @@ test('onboarding Step 1 shows @kodycodes/cli first and collapses Manual', async 
 	expect(manualBlock).toContain(
 		'https://cursor.com/help/grok-bot/connect-plugins',
 	)
+
+	const cursorPrimary = manualBlock.slice(
+		manualBlock.indexOf('onboarding-mcp-plugin-primary'),
+		manualBlock.indexOf('onboarding-mcp-cursor-fallback'),
+	)
+	expect(
+		cursorPrimary.indexOf(`href="${kodyCursorMarketplaceUrl}"`),
+	).toBeLessThan(cursorPrimary.indexOf('onboarding-mcp-plugin-alternative'))
+	expect(
+		cursorPrimary.indexOf('onboarding-mcp-plugin-alternative'),
+	).toBeLessThan(cursorPrimary.indexOf(kodyCursorAddPluginCommand))
+	expect(cursorPrimary).not.toContain('Copy command')
+
+	const grokBotPrimary = manualBlock.slice(
+		manualBlock.lastIndexOf('onboarding-mcp-plugin-primary'),
+		manualBlock.indexOf('onboarding-mcp-grok-bot-fallback'),
+	)
+	expect(grokBotPrimary.indexOf(`href="${grokBotInstallUrl}"`)).toBeLessThan(
+		grokBotPrimary.indexOf('onboarding-mcp-plugin-alternative'),
+	)
+	expect(grokBotPrimary).not.toContain('Copy link')
 
 	const previewHtml = await renderToString(
 		jsx(OnboardingMcpClientTabs, {

--- a/packages/worker/client/routes/onboarding-mcp-client-tabs.node.test.ts
+++ b/packages/worker/client/routes/onboarding-mcp-client-tabs.node.test.ts
@@ -6,7 +6,6 @@ import {
 	buildClaudeCodeAddCommand,
 	buildCodexMcpAddCommand,
 	buildCopilotCliAddCommand,
-	buildCursorInstallUrl,
 	buildKodyCliInstallCommand,
 	buildOpenCodeMcpAddCommand,
 	defaultKodyMcpUrl,
@@ -48,7 +47,6 @@ test('onboarding Step 1 shows @kodycodes/cli first and collapses Manual', async 
 	)
 	expect(manualBlock).toContain('Choose your client')
 	expect(manualBlock).toContain(defaultKodyMcpUrl)
-	expect(manualBlock).toContain('~/.cursor/mcp.json')
 	expect(manualBlock).toContain(buildClaudeCodeAddCommand(defaultKodyMcpUrl))
 	expect(manualBlock).toContain(buildCodexMcpAddCommand(defaultKodyMcpUrl))
 	expect(manualBlock).toContain(buildOpenCodeMcpAddCommand(defaultKodyMcpUrl))
@@ -68,25 +66,20 @@ test('onboarding Step 1 shows @kodycodes/cli first and collapses Manual', async 
 	)
 	expect(manualBlock).not.toContain('Cursor&apos;s')
 	expect(manualBlock).not.toContain("Cursor's")
+	expect(manualBlock).not.toContain('~/.cursor/mcp.json')
+	expect(manualBlock).not.toContain('cursor://anysphere.cursor-deeplink')
+	expect(manualBlock).not.toContain('onboarding-mcp-cursor-fallback')
+	expect(manualBlock).not.toContain('onboarding-mcp-grok-bot-fallback')
+	expect(manualBlock).not.toContain('This origin is not production')
+	expect(manualBlock).not.toContain('targets production')
 	expect(manualBlock).toContain('>Grok Bot plugin help<')
-	expect(manualBlock).toContain(
-		buildCursorInstallUrl(defaultKodyMcpUrl).replaceAll('&', '&amp;'),
-	)
-	expect(manualBlock).toContain('data-testid="onboarding-mcp-cursor-fallback"')
-	expect(manualBlock).toContain(
-		'data-testid="onboarding-mcp-grok-bot-fallback"',
-	)
-	expect(manualBlock).not.toMatch(
-		/<details[^>]*\bopen\b[^>]*data-testid="onboarding-mcp-cursor-fallback"/,
-	)
 	expect(manualBlock).toContain(
 		'https://cursor.com/help/grok-bot/connect-plugins',
 	)
 
-	const cursorPrimary = manualBlock.slice(
-		manualBlock.indexOf('onboarding-mcp-plugin-primary'),
-		manualBlock.indexOf('onboarding-mcp-cursor-fallback'),
-	)
+	const firstPrimary = manualBlock.indexOf('onboarding-mcp-plugin-primary')
+	const secondPrimary = manualBlock.lastIndexOf('onboarding-mcp-plugin-primary')
+	const cursorPrimary = manualBlock.slice(firstPrimary, secondPrimary)
 	expect(
 		cursorPrimary.indexOf(`href="${kodyCursorMarketplaceUrl}"`),
 	).toBeLessThan(cursorPrimary.indexOf('onboarding-mcp-plugin-alternative'))
@@ -94,15 +87,14 @@ test('onboarding Step 1 shows @kodycodes/cli first and collapses Manual', async 
 		cursorPrimary.indexOf('onboarding-mcp-plugin-alternative'),
 	).toBeLessThan(cursorPrimary.indexOf(kodyCursorAddPluginCommand))
 	expect(cursorPrimary).not.toContain('Copy command')
+	expect(cursorPrimary).not.toContain('Manual / fallback')
 
-	const grokBotPrimary = manualBlock.slice(
-		manualBlock.lastIndexOf('onboarding-mcp-plugin-primary'),
-		manualBlock.indexOf('onboarding-mcp-grok-bot-fallback'),
-	)
+	const grokBotPrimary = manualBlock.slice(secondPrimary)
 	expect(grokBotPrimary.indexOf(`href="${grokBotInstallUrl}"`)).toBeLessThan(
 		grokBotPrimary.indexOf('onboarding-mcp-plugin-alternative'),
 	)
 	expect(grokBotPrimary).not.toContain('Copy link')
+	expect(grokBotPrimary).not.toContain('Manual / fallback')
 
 	const previewHtml = await renderToString(
 		jsx(OnboardingMcpClientTabs, {
@@ -112,10 +104,10 @@ test('onboarding Step 1 shows @kodycodes/cli first and collapses Manual', async 
 	expect(previewHtml).toContain(
 		'npx @kodycodes/cli install --mcp-url http://localhost:3742/mcp',
 	)
-	expect(previewHtml).toContain(
-		'This origin is not production <code>kody.codes</code>',
-	)
-	expect(previewHtml).toMatch(
-		/<details[^>]*\bopen\b[^>]*data-testid="onboarding-mcp-cursor-fallback"|<details[^>]*data-testid="onboarding-mcp-cursor-fallback"[^>]*\bopen\b/,
-	)
+	expect(previewHtml).toContain(kodyCursorMarketplaceUrl)
+	expect(previewHtml).toContain(grokBotInstallUrl)
+	expect(previewHtml).not.toContain('This origin is not production')
+	expect(previewHtml).not.toContain('onboarding-mcp-cursor-fallback')
+	expect(previewHtml).not.toContain('onboarding-mcp-grok-bot-fallback')
+	expect(previewHtml).not.toContain('cursor://anysphere.cursor-deeplink')
 })

--- a/packages/worker/client/routes/onboarding-mcp-client-tabs.node.test.ts
+++ b/packages/worker/client/routes/onboarding-mcp-client-tabs.node.test.ts
@@ -6,9 +6,13 @@ import {
 	buildClaudeCodeAddCommand,
 	buildCodexMcpAddCommand,
 	buildCopilotCliAddCommand,
+	buildCursorInstallUrl,
 	buildKodyCliInstallCommand,
 	buildOpenCodeMcpAddCommand,
 	defaultKodyMcpUrl,
+	grokBotInstallUrl,
+	kodyCursorAddPluginCommand,
+	kodyCursorMarketplaceUrl,
 } from './onboarding-mcp-clients.ts'
 
 test('onboarding Step 1 shows @kodycodes/cli first and collapses Manual', async () => {
@@ -51,7 +55,25 @@ test('onboarding Step 1 shows @kodycodes/cli first and collapses Manual', async 
 	expect(manualBlock).toContain(buildCopilotCliAddCommand(defaultKodyMcpUrl))
 	expect(manualBlock).toContain('Add to Cursor')
 	expect(manualBlock).toContain('Add to VS Code')
+	expect(manualBlock).toContain('Add to Grok Bot')
 	expect(manualBlock).toContain('chatgpt.com')
+	expect(manualBlock).toContain('>Grok Bot<')
+	expect(manualBlock).toContain(kodyCursorMarketplaceUrl)
+	expect(manualBlock).toContain(kodyCursorAddPluginCommand)
+	expect(manualBlock).toContain(grokBotInstallUrl)
+	expect(manualBlock).toContain(
+		buildCursorInstallUrl(defaultKodyMcpUrl).replaceAll('&', '&amp;'),
+	)
+	expect(manualBlock).toContain('data-testid="onboarding-mcp-cursor-fallback"')
+	expect(manualBlock).toContain(
+		'data-testid="onboarding-mcp-grok-bot-fallback"',
+	)
+	expect(manualBlock).not.toMatch(
+		/<details[^>]*\bopen\b[^>]*data-testid="onboarding-mcp-cursor-fallback"/,
+	)
+	expect(manualBlock).toContain(
+		'https://cursor.com/help/grok-bot/connect-plugins',
+	)
 
 	const previewHtml = await renderToString(
 		jsx(OnboardingMcpClientTabs, {
@@ -60,5 +82,11 @@ test('onboarding Step 1 shows @kodycodes/cli first and collapses Manual', async 
 	)
 	expect(previewHtml).toContain(
 		'npx @kodycodes/cli install --mcp-url http://localhost:3742/mcp',
+	)
+	expect(previewHtml).toContain(
+		'This origin is not production <code>kody.codes</code>',
+	)
+	expect(previewHtml).toMatch(
+		/<details[^>]*\bopen\b[^>]*data-testid="onboarding-mcp-cursor-fallback"|<details[^>]*data-testid="onboarding-mcp-cursor-fallback"[^>]*\bopen\b/,
 	)
 })

--- a/packages/worker/client/routes/onboarding-mcp-client-tabs.node.test.ts
+++ b/packages/worker/client/routes/onboarding-mcp-client-tabs.node.test.ts
@@ -77,9 +77,13 @@ test('onboarding Step 1 shows @kodycodes/cli first and collapses Manual', async 
 		'https://cursor.com/help/grok-bot/connect-plugins',
 	)
 
-	const firstPrimary = manualBlock.indexOf('onboarding-mcp-plugin-primary')
-	const secondPrimary = manualBlock.lastIndexOf('onboarding-mcp-plugin-primary')
-	const cursorPrimary = manualBlock.slice(firstPrimary, secondPrimary)
+	const pluginBlocks = [
+		...manualBlock.matchAll(
+			/<div data-testid="onboarding-mcp-plugin-primary"[\s\S]*?<\/small><\/div>/g,
+		),
+	].map((match) => match[0])
+	expect(pluginBlocks).toHaveLength(2)
+	const [cursorPrimary, grokBotPrimary] = pluginBlocks
 	expect(
 		cursorPrimary.indexOf(`href="${kodyCursorMarketplaceUrl}"`),
 	).toBeLessThan(cursorPrimary.indexOf('onboarding-mcp-plugin-alternative'))
@@ -88,8 +92,6 @@ test('onboarding Step 1 shows @kodycodes/cli first and collapses Manual', async 
 	).toBeLessThan(cursorPrimary.indexOf(kodyCursorAddPluginCommand))
 	expect(cursorPrimary).not.toContain('Copy command')
 	expect(cursorPrimary).not.toContain('Manual / fallback')
-
-	const grokBotPrimary = manualBlock.slice(secondPrimary)
 	expect(grokBotPrimary.indexOf(`href="${grokBotInstallUrl}"`)).toBeLessThan(
 		grokBotPrimary.indexOf('onboarding-mcp-plugin-alternative'),
 	)

--- a/packages/worker/client/routes/onboarding-mcp-client-tabs.tsx
+++ b/packages/worker/client/routes/onboarding-mcp-client-tabs.tsx
@@ -118,7 +118,7 @@ function ClientNote(handle: Handle<ClientNoteProps>) {
 function InstallDeepLink(
 	handle: Handle<{
 		href: string
-		label: 'Add to Cursor' | 'Add to Grok Bot' | 'Add to VS Code'
+		label: 'Add to Cursor' | 'Add to VS Code'
 	}>,
 ) {
 	return () => (
@@ -126,6 +126,38 @@ function InstallDeepLink(
 			<a href={handle.props.href} mix={css(deepLinkButtonCss)}>
 				{handle.props.label}
 			</a>
+			<small mix={css(deepLinkNoteCss)}>
+				Your client will still ask you to authorize access afterwards.
+			</small>
+		</div>
+	)
+}
+
+function PluginPrimaryInstall(
+	handle: Handle<{
+		href: string
+		label: 'Add to Cursor' | 'Add to Grok Bot'
+		alternativeValue: string
+		alternativeCopyLabel: string
+	}>,
+) {
+	return () => (
+		<div data-testid="onboarding-mcp-plugin-primary" mix={css(deepLinkCss)}>
+			<a href={handle.props.href} mix={css(deepLinkButtonCss)}>
+				{handle.props.label}
+			</a>
+			<p
+				data-testid="onboarding-mcp-plugin-alternative"
+				mix={css(pluginAlternativeCss)}
+			>
+				Or do this: <code>{handle.props.alternativeValue}</code>
+				<CopyTextButton
+					value={handle.props.alternativeValue}
+					idleLabel="Copy"
+					variant="chip"
+					ariaLabel={handle.props.alternativeCopyLabel}
+				/>
+			</p>
 			<small mix={css(deepLinkNoteCss)}>
 				Your client will still ask you to authorize access afterwards.
 			</small>
@@ -191,19 +223,14 @@ function renderPanelContent(
 						>
 							Kody plugin
 						</a>{' '}
-						from the Cursor Marketplace, or in Cursor chat run{' '}
-						<code>{kodyCursorAddPluginCommand}</code>. The marketplace listing
-						targets production <code>kody.codes</code>.
+						from the Cursor Marketplace. The marketplace listing targets
+						production <code>kody.codes</code>.
 					</p>
-					<InstallDeepLink
+					<PluginPrimaryInstall
 						href={kodyCursorMarketplaceUrl}
 						label="Add to Cursor"
-					/>
-					<CopyCard
-						highlights={highlights}
-						label="/add-plugin"
-						value={kodyCursorAddPluginCommand}
-						copyLabel="Copy command"
+						alternativeValue={kodyCursorAddPluginCommand}
+						alternativeCopyLabel="Copy /add-plugin kody"
 					/>
 					{isProduction ? null : (
 						<p>
@@ -434,7 +461,7 @@ function renderPanelContent(
 					<p>
 						Install the official Kody plugin in Grok Bot. Click{' '}
 						<strong>Add to Grok Bot</strong>, or open <strong>Plugins</strong>{' '}
-						in the Grok Bot sidebar and add Kody. See Cursor&apos;s{' '}
+						in the Grok Bot sidebar and add Kody. See{' '}
 						<a
 							href={grokBotConnectPluginsUrl}
 							target="_blank"
@@ -444,12 +471,11 @@ function renderPanelContent(
 						</a>
 						. The marketplace plugin targets production <code>kody.codes</code>.
 					</p>
-					<InstallDeepLink href={grokBotInstallUrl} label="Add to Grok Bot" />
-					<CopyCard
-						highlights={highlights}
-						label="Grok Bot plugin"
-						value={grokBotInstallUrl}
-						copyLabel="Copy link"
+					<PluginPrimaryInstall
+						href={grokBotInstallUrl}
+						label="Add to Grok Bot"
+						alternativeValue={grokBotInstallUrl}
+						alternativeCopyLabel="Copy Grok Bot plugin link"
 					/>
 					{isProduction ? null : (
 						<p>
@@ -924,6 +950,20 @@ const deepLinkButtonCss = getPillButtonCss()
 const deepLinkNoteCss = {
 	color: colors.textMuted,
 	fontSize: '0.88rem',
+}
+
+const pluginAlternativeCss = {
+	display: 'flex',
+	flexWrap: 'wrap' as const,
+	alignItems: 'center',
+	gap: '0.35rem 0.5rem',
+	margin: 0,
+	color: colors.textMuted,
+	fontSize: '0.88rem',
+	maxWidth: '72ch',
+	'& code': {
+		overflowWrap: 'anywhere' as const,
+	},
 }
 
 /* Config snippets: labeled wells with their copy button in the header. */

--- a/packages/worker/client/routes/onboarding-mcp-client-tabs.tsx
+++ b/packages/worker/client/routes/onboarding-mcp-client-tabs.tsx
@@ -24,9 +24,14 @@ import {
 	codingAgentPackageHint,
 	copilotAppCustomizeGuideUrl,
 	copilotCliMcpGuideUrl,
+	grokBotConnectPluginsUrl,
+	grokBotInstallUrl,
 	grokCliMcpGuideUrl,
 	grokConnectorsUrl,
 	grokCustomMcpGuideUrl,
+	isDefaultKodyMcpUrl,
+	kodyCursorAddPluginCommand,
+	kodyCursorMarketplaceUrl,
 	type McpClientKind,
 	mcpClientTabs,
 	nonCodingAgentNote,
@@ -111,7 +116,10 @@ function ClientNote(handle: Handle<ClientNoteProps>) {
 }
 
 function InstallDeepLink(
-	handle: Handle<{ href: string; label: 'Add to Cursor' | 'Add to VS Code' }>,
+	handle: Handle<{
+		href: string
+		label: 'Add to Cursor' | 'Add to Grok Bot' | 'Add to VS Code'
+	}>,
 ) {
 	return () => (
 		<div mix={css(deepLinkCss)}>
@@ -143,6 +151,25 @@ function ManualPath(handle: Handle<{ children?: RemixNode }>) {
 	)
 }
 
+function ClientFallbackPath(
+	handle: Handle<{
+		children?: RemixNode
+		testId: string
+		open?: boolean
+	}>,
+) {
+	return () => (
+		<details
+			data-testid={handle.props.testId}
+			open={handle.props.open ? true : undefined}
+			mix={css(manualDetailsCss)}
+		>
+			<summary mix={css(manualSummaryCss)}>Manual / fallback</summary>
+			<div mix={css(manualBodyCss)}>{handle.props.children}</div>
+		</details>
+	)
+}
+
 function renderPanelContent(
 	kind: McpClientKind,
 	mcpServerUrl: string,
@@ -151,33 +178,69 @@ function renderPanelContent(
 	switch (kind) {
 		case 'cursor': {
 			const cursorJson = buildCursorMcpJson(mcpServerUrl)
-			const installUrl = buildCursorInstallUrl(mcpServerUrl)
+			const mcpInstallUrl = buildCursorInstallUrl(mcpServerUrl)
+			const isProduction = isDefaultKodyMcpUrl(mcpServerUrl)
 			return (
 				<>
 					<p>
-						Install with the deeplink, open <strong>Customize</strong> and add a
-						remote MCP server with the URL, or merge the JSON into{' '}
-						<code>~/.cursor/mcp.json</code> (global) or{' '}
-						<code>.cursor/mcp.json</code> (project).
+						Install the official{' '}
+						<a
+							href={kodyCursorMarketplaceUrl}
+							target="_blank"
+							rel="noreferrer noopener"
+						>
+							Kody plugin
+						</a>{' '}
+						from the Cursor Marketplace, or in Cursor chat run{' '}
+						<code>{kodyCursorAddPluginCommand}</code>. The marketplace listing
+						targets production <code>kody.codes</code>.
 					</p>
-					<InstallDeepLink href={installUrl} label="Add to Cursor" />
+					<InstallDeepLink
+						href={kodyCursorMarketplaceUrl}
+						label="Add to Cursor"
+					/>
 					<CopyCard
 						highlights={highlights}
-						label="MCP URL"
-						value={mcpServerUrl}
-						copyLabel="Copy MCP URL"
+						label="/add-plugin"
+						value={kodyCursorAddPluginCommand}
+						copyLabel="Copy command"
 					/>
-					<p>
-						JSON config (merge under your existing <code>mcpServers</code> if
-						you already have one):
-					</p>
-					<CopyCard
-						highlights={highlights}
-						label="mcp.json"
-						value={cursorJson}
-						copyLabel="Copy JSON"
-						lang="json"
-					/>
+					{isProduction ? null : (
+						<p>
+							This origin is not production <code>kody.codes</code>. Use Manual
+							/ fallback so Cursor talks to this deployment&apos;s MCP URL.
+						</p>
+					)}
+					<ClientFallbackPath
+						testId="onboarding-mcp-cursor-fallback"
+						open={!isProduction}
+					>
+						<p>
+							Preview and local origins, or a raw MCP server: install with the
+							deeplink, open <strong>Customize</strong> and add a remote MCP
+							server with the URL, or merge the JSON into{' '}
+							<code>~/.cursor/mcp.json</code> (global) or{' '}
+							<code>.cursor/mcp.json</code> (project).
+						</p>
+						<InstallDeepLink href={mcpInstallUrl} label="Add to Cursor" />
+						<CopyCard
+							highlights={highlights}
+							label="MCP URL"
+							value={mcpServerUrl}
+							copyLabel="Copy MCP URL"
+						/>
+						<p>
+							JSON config (merge under your existing <code>mcpServers</code> if
+							you already have one):
+						</p>
+						<CopyCard
+							highlights={highlights}
+							label="mcp.json"
+							value={cursorJson}
+							copyLabel="Copy JSON"
+							lang="json"
+						/>
+					</ClientFallbackPath>
 					<ClientNote>{codingAgentPackageHint}</ClientNote>
 				</>
 			)
@@ -313,7 +376,8 @@ function renderPanelContent(
 						variant="pill"
 					/>
 					<p>
-						For the Grok CLI, use the <strong>Grok CLI</strong> tab.
+						For the Grok CLI, use the <strong>Grok CLI</strong> tab. For Grok
+						Bot (Cursor desktop), use the <strong>Grok Bot</strong> tab.
 					</p>
 					<ClientNote>{nonCodingAgentNote}</ClientNote>
 				</>
@@ -357,8 +421,62 @@ function renderPanelContent(
 						</a>{' '}
 						for <code>grok mcp list</code>, <code>grok mcp doctor</code>, and
 						project scope. For grok.com, use the <strong>Grok.com</strong> tab.
+						For Grok Bot, use the <strong>Grok Bot</strong> tab.
 					</p>
 					<ClientNote>{codingAgentPackageHint}</ClientNote>
+				</>
+			)
+		}
+		case 'grok-bot': {
+			const isProduction = isDefaultKodyMcpUrl(mcpServerUrl)
+			return (
+				<>
+					<p>
+						Install the official Kody plugin in Grok Bot. Click{' '}
+						<strong>Add to Grok Bot</strong>, or open <strong>Plugins</strong>{' '}
+						in the Grok Bot sidebar and add Kody. See Cursor&apos;s{' '}
+						<a
+							href={grokBotConnectPluginsUrl}
+							target="_blank"
+							rel="noreferrer noopener"
+						>
+							Grok Bot plugin help
+						</a>
+						. The marketplace plugin targets production <code>kody.codes</code>.
+					</p>
+					<InstallDeepLink href={grokBotInstallUrl} label="Add to Grok Bot" />
+					<CopyCard
+						highlights={highlights}
+						label="Grok Bot plugin"
+						value={grokBotInstallUrl}
+						copyLabel="Copy link"
+					/>
+					{isProduction ? null : (
+						<p>
+							This origin is not production <code>kody.codes</code>. Use Manual
+							/ fallback so Grok Bot talks to this deployment&apos;s MCP URL.
+						</p>
+					)}
+					<ClientFallbackPath
+						testId="onboarding-mcp-grok-bot-fallback"
+						open={!isProduction}
+					>
+						<p>
+							You can also add a custom connector with this MCP URL (preview and
+							local origins need this):
+						</p>
+						<CopyCard
+							highlights={highlights}
+							label="MCP URL"
+							value={mcpServerUrl}
+							copyLabel="Copy MCP URL"
+						/>
+					</ClientFallbackPath>
+					<p>
+						Grok.com (xAI web connectors) and Grok CLI are separate products.
+						Use those tabs when you are not installing the Grok Bot plugin.
+					</p>
+					<ClientNote>{nonCodingAgentNote}</ClientNote>
 				</>
 			)
 		}

--- a/packages/worker/client/routes/onboarding-mcp-client-tabs.tsx
+++ b/packages/worker/client/routes/onboarding-mcp-client-tabs.tsx
@@ -8,8 +8,6 @@ import {
 	buildCodexMcpToml,
 	buildCopilotCliAddCommand,
 	buildCopilotCliMcpJson,
-	buildCursorInstallUrl,
-	buildCursorMcpJson,
 	buildGrokCliAddCommand,
 	buildGrokCliMcpToml,
 	buildKodyAppIconUrl,
@@ -29,7 +27,6 @@ import {
 	grokCliMcpGuideUrl,
 	grokConnectorsUrl,
 	grokCustomMcpGuideUrl,
-	isDefaultKodyMcpUrl,
 	kodyCursorAddPluginCommand,
 	kodyCursorMarketplaceUrl,
 	type McpClientKind,
@@ -183,35 +180,13 @@ function ManualPath(handle: Handle<{ children?: RemixNode }>) {
 	)
 }
 
-function ClientFallbackPath(
-	handle: Handle<{
-		children?: RemixNode
-		testId: string
-		open?: boolean
-	}>,
-) {
-	return () => (
-		<details
-			data-testid={handle.props.testId}
-			open={handle.props.open ? true : undefined}
-			mix={css(manualDetailsCss)}
-		>
-			<summary mix={css(manualSummaryCss)}>Manual / fallback</summary>
-			<div mix={css(manualBodyCss)}>{handle.props.children}</div>
-		</details>
-	)
-}
-
 function renderPanelContent(
 	kind: McpClientKind,
 	mcpServerUrl: string,
 	highlights?: Record<string, HighlightedCode>,
 ) {
 	switch (kind) {
-		case 'cursor': {
-			const cursorJson = buildCursorMcpJson(mcpServerUrl)
-			const mcpInstallUrl = buildCursorInstallUrl(mcpServerUrl)
-			const isProduction = isDefaultKodyMcpUrl(mcpServerUrl)
+		case 'cursor':
 			return (
 				<>
 					<p>
@@ -223,8 +198,7 @@ function renderPanelContent(
 						>
 							Kody plugin
 						</a>{' '}
-						from the Cursor Marketplace. The marketplace listing targets
-						production <code>kody.codes</code>.
+						from the Cursor Marketplace.
 					</p>
 					<PluginPrimaryInstall
 						href={kodyCursorMarketplaceUrl}
@@ -232,46 +206,9 @@ function renderPanelContent(
 						alternativeValue={kodyCursorAddPluginCommand}
 						alternativeCopyLabel="Copy /add-plugin kody"
 					/>
-					{isProduction ? null : (
-						<p>
-							This origin is not production <code>kody.codes</code>. Use Manual
-							/ fallback so Cursor talks to this deployment&apos;s MCP URL.
-						</p>
-					)}
-					<ClientFallbackPath
-						testId="onboarding-mcp-cursor-fallback"
-						open={!isProduction}
-					>
-						<p>
-							Preview and local origins, or a raw MCP server: install with the
-							deeplink, open <strong>Customize</strong> and add a remote MCP
-							server with the URL, or merge the JSON into{' '}
-							<code>~/.cursor/mcp.json</code> (global) or{' '}
-							<code>.cursor/mcp.json</code> (project).
-						</p>
-						<InstallDeepLink href={mcpInstallUrl} label="Add to Cursor" />
-						<CopyCard
-							highlights={highlights}
-							label="MCP URL"
-							value={mcpServerUrl}
-							copyLabel="Copy MCP URL"
-						/>
-						<p>
-							JSON config (merge under your existing <code>mcpServers</code> if
-							you already have one):
-						</p>
-						<CopyCard
-							highlights={highlights}
-							label="mcp.json"
-							value={cursorJson}
-							copyLabel="Copy JSON"
-							lang="json"
-						/>
-					</ClientFallbackPath>
 					<ClientNote>{codingAgentPackageHint}</ClientNote>
 				</>
 			)
-		}
 		case 'chatgpt': {
 			const appIconUrl = buildKodyAppIconUrl(mcpServerUrl)
 			return (
@@ -454,8 +391,7 @@ function renderPanelContent(
 				</>
 			)
 		}
-		case 'grok-bot': {
-			const isProduction = isDefaultKodyMcpUrl(mcpServerUrl)
+		case 'grok-bot':
 			return (
 				<>
 					<p>
@@ -469,7 +405,7 @@ function renderPanelContent(
 						>
 							Grok Bot plugin help
 						</a>
-						. The marketplace plugin targets production <code>kody.codes</code>.
+						.
 					</p>
 					<PluginPrimaryInstall
 						href={grokBotInstallUrl}
@@ -477,27 +413,6 @@ function renderPanelContent(
 						alternativeValue={grokBotInstallUrl}
 						alternativeCopyLabel="Copy Grok Bot plugin link"
 					/>
-					{isProduction ? null : (
-						<p>
-							This origin is not production <code>kody.codes</code>. Use Manual
-							/ fallback so Grok Bot talks to this deployment&apos;s MCP URL.
-						</p>
-					)}
-					<ClientFallbackPath
-						testId="onboarding-mcp-grok-bot-fallback"
-						open={!isProduction}
-					>
-						<p>
-							You can also add a custom connector with this MCP URL (preview and
-							local origins need this):
-						</p>
-						<CopyCard
-							highlights={highlights}
-							label="MCP URL"
-							value={mcpServerUrl}
-							copyLabel="Copy MCP URL"
-						/>
-					</ClientFallbackPath>
 					<p>
 						Grok.com (xAI web connectors) and Grok CLI are separate products.
 						Use those tabs when you are not installing the Grok Bot plugin.
@@ -505,7 +420,6 @@ function renderPanelContent(
 					<ClientNote>{nonCodingAgentNote}</ClientNote>
 				</>
 			)
-		}
 		case 'claude-code': {
 			const claudeCodeCommand = buildClaudeCodeAddCommand(mcpServerUrl)
 			const claudeCodeJson = buildClaudeCodeMcpJson(mcpServerUrl)
@@ -687,9 +601,9 @@ function renderPanelContent(
 					<p>
 						Config file shapes differ by host. If your client expects a JSON{' '}
 						<code>mcpServers</code> map with a <code>url</code> field, start
-						from the Cursor or Copilot CLI snippet; if it uses{' '}
-						<code>servers</code> with <code>type: &quot;http&quot;</code>, use
-						the Copilot (VS Code) snippet.
+						from the Copilot CLI snippet; if it uses <code>servers</code> with{' '}
+						<code>type: &quot;http&quot;</code>, use the Copilot (VS Code)
+						snippet.
 					</p>
 				</>
 			)

--- a/packages/worker/client/routes/onboarding-mcp-clients.node.test.ts
+++ b/packages/worker/client/routes/onboarding-mcp-clients.node.test.ts
@@ -6,8 +6,6 @@ import {
 	buildCodexMcpToml,
 	buildCopilotCliAddCommand,
 	buildCopilotCliMcpJson,
-	buildCursorInstallUrl,
-	buildCursorMcpJson,
 	buildGrokCliAddCommand,
 	buildGrokCliMcpToml,
 	buildKodyAppIconUrl,
@@ -68,13 +66,6 @@ test('onboarding MCP client builders emit the structured configs each host expec
 		'npx @kodycodes/cli install --mcp-url http://localhost:3742/mcp',
 	)
 
-	expect(JSON.parse(buildCursorMcpJson(mcpServerUrl))).toEqual({
-		mcpServers: {
-			kody: {
-				url: mcpServerUrl,
-			},
-		},
-	})
 	expect(JSON.parse(buildClaudeCodeMcpJson(mcpServerUrl))).toEqual({
 		mcpServers: {
 			kody: {
@@ -147,24 +138,6 @@ test('onboarding MCP client builders emit the structured configs each host expec
 			mcpServerUrl,
 		]),
 	)
-
-	const cursorInstallUrl = new URL(buildCursorInstallUrl(mcpServerUrl))
-	expect(cursorInstallUrl.protocol).toBe('cursor:')
-	expect(cursorInstallUrl.hostname).toBe('anysphere.cursor-deeplink')
-	expect(cursorInstallUrl.pathname).toBe('/mcp/install')
-	expect(cursorInstallUrl.searchParams.get('name')).toBe('kody')
-	const cursorConfig = cursorInstallUrl.searchParams.get('config')
-	expect(cursorConfig).toMatch(/^[\w-]+$/u)
-	expect(
-		JSON.parse(
-			atob(
-				cursorConfig!
-					.replaceAll('-', '+')
-					.replaceAll('_', '/')
-					.padEnd(Math.ceil(cursorConfig!.length / 4) * 4, '='),
-			),
-		),
-	).toEqual({ url: mcpServerUrl })
 
 	const vsCodeInstallUrl = buildVsCodeInstallUrl(mcpServerUrl)
 	expect(vsCodeInstallUrl.startsWith('vscode:mcp/install?')).toBe(true)

--- a/packages/worker/client/routes/onboarding-mcp-clients.node.test.ts
+++ b/packages/worker/client/routes/onboarding-mcp-clients.node.test.ts
@@ -17,7 +17,13 @@ import {
 	buildVsCodeInstallUrl,
 	buildVsCodeMcpJson,
 	codexMcpLoginCommand,
+	collectOnboardingMcpSnippets,
 	defaultKodyMcpUrl,
+	grokBotInstallUrl,
+	isDefaultKodyMcpUrl,
+	kodyCursorAddPluginCommand,
+	kodyCursorMarketplaceUrl,
+	kodyMarketplacePluginId,
 	mcpClientTabs,
 	openCodeMcpAuthCommand,
 } from './onboarding-mcp-clients.ts'
@@ -32,6 +38,7 @@ test('onboarding MCP client builders emit the structured configs each host expec
 		'claude-desktop',
 		'grok',
 		'grok-cli',
+		'grok-bot',
 		'claude-code',
 		'opencode',
 		'copilot',
@@ -40,11 +47,17 @@ test('onboarding MCP client builders emit the structured configs each host expec
 	])
 	expect(
 		mcpClientTabs.filter((tab) => tab.isNonCodingAgent).map((tab) => tab.id),
-	).toEqual(['chatgpt', 'claude-desktop', 'grok', 'copilot-app'])
+	).toEqual(['chatgpt', 'claude-desktop', 'grok', 'grok-bot', 'copilot-app'])
+	expect(mcpClientTabs.find((tab) => tab.id === 'grok-bot')?.label).toBe(
+		'Grok Bot',
+	)
 	expect(
 		mcpClientTabs.every((tab) => typeof tab.label === 'string' && tab.label),
 	).toBe(true)
 
+	expect(isDefaultKodyMcpUrl(mcpServerUrl)).toBe(true)
+	expect(isDefaultKodyMcpUrl(`${mcpServerUrl}/`)).toBe(true)
+	expect(isDefaultKodyMcpUrl('http://localhost:3742/mcp')).toBe(false)
 	expect(buildKodyCliInstallCommand(mcpServerUrl)).toBe(
 		'npx @kodycodes/cli install',
 	)
@@ -120,6 +133,19 @@ test('onboarding MCP client builders emit the structured configs each host expec
 	)
 	expect(buildKodyAppIconUrl(mcpServerUrl)).toBe(
 		'https://kody.codes/apple-touch-icon.png',
+	)
+	expect(kodyCursorMarketplaceUrl).toBe('https://cursor.com/marketplace/kody')
+	expect(kodyCursorAddPluginCommand).toBe('/add-plugin kody')
+	expect(kodyMarketplacePluginId).toBe('56286216')
+	expect(grokBotInstallUrl).toBe('grokbot://app/v1/plugin/add?id=56286216')
+	expect(
+		collectOnboardingMcpSnippets(mcpServerUrl).map((snippet) => snippet.code),
+	).toEqual(
+		expect.arrayContaining([
+			kodyCursorAddPluginCommand,
+			grokBotInstallUrl,
+			mcpServerUrl,
+		]),
 	)
 
 	const cursorInstallUrl = new URL(buildCursorInstallUrl(mcpServerUrl))

--- a/packages/worker/client/routes/onboarding.tsx
+++ b/packages/worker/client/routes/onboarding.tsx
@@ -649,8 +649,7 @@ export function OnboardingRoute(handle: Handle) {
 									<strong>Authenticate Kody before you continue</strong>
 									<span>
 										<strong>Cursor:</strong> after installing the plugin, open
-										the Cursor MCP list and click{' '}
-										<strong>Authenticate</strong>.
+										the Cursor MCP list and click <strong>Authenticate</strong>.
 									</span>
 									<span>
 										<strong>Claude Code:</strong> after install, enter{' '}

--- a/packages/worker/client/routes/onboarding.tsx
+++ b/packages/worker/client/routes/onboarding.tsx
@@ -648,8 +648,9 @@ export function OnboardingRoute(handle: Handle) {
 								>
 									<strong>Authenticate Kody before you continue</strong>
 									<span>
-										<strong>Cursor:</strong> after install, open the Cursor MCP
-										list and click <strong>Authenticate</strong>.
+										<strong>Cursor:</strong> after installing the plugin (or raw
+										MCP), open the Cursor MCP list and click{' '}
+										<strong>Authenticate</strong>.
 									</span>
 									<span>
 										<strong>Claude Code:</strong> after install, enter{' '}
@@ -658,6 +659,10 @@ export function OnboardingRoute(handle: Handle) {
 									<span>
 										<strong>Grok.com:</strong> after adding the custom
 										connector, complete OAuth when Grok prompts you.
+									</span>
+									<span>
+										<strong>Grok Bot:</strong> after adding the plugin, complete{' '}
+										<strong>Authorize</strong> when Grok Bot prompts you.
 									</span>
 									<span>
 										<strong>Grok CLI:</strong> after adding the server, OAuth

--- a/packages/worker/client/routes/onboarding.tsx
+++ b/packages/worker/client/routes/onboarding.tsx
@@ -648,8 +648,8 @@ export function OnboardingRoute(handle: Handle) {
 								>
 									<strong>Authenticate Kody before you continue</strong>
 									<span>
-										<strong>Cursor:</strong> after installing the plugin (or raw
-										MCP), open the Cursor MCP list and click{' '}
+										<strong>Cursor:</strong> after installing the plugin, open
+										the Cursor MCP list and click{' '}
 										<strong>Authenticate</strong>.
 									</span>
 									<span>

--- a/packages/worker/universal/onboarding-mcp-clients.ts
+++ b/packages/worker/universal/onboarding-mcp-clients.ts
@@ -117,19 +117,6 @@ function prettyJson(value: unknown) {
 	return `${JSON.stringify(value, null, 2)}\n`
 }
 
-function encodeBase64Url(value: string) {
-	return btoa(value)
-		.replaceAll('+', '-')
-		.replaceAll('/', '_')
-		.replace(/=+$/u, '')
-}
-
-/** Cursor protocol handler for installing a remote MCP server. */
-export function buildCursorInstallUrl(mcpServerUrl: string) {
-	const config = encodeBase64Url(JSON.stringify({ url: mcpServerUrl }))
-	return `cursor://anysphere.cursor-deeplink/mcp/install?name=kody&config=${config}`
-}
-
 /** VS Code protocol handler for installing a remote MCP server. */
 export function buildVsCodeInstallUrl(mcpServerUrl: string) {
 	const config = encodeURIComponent(
@@ -140,17 +127,6 @@ export function buildVsCodeInstallUrl(mcpServerUrl: string) {
 		}),
 	)
 	return `vscode:mcp/install?${config}`
-}
-
-/** Cursor `~/.cursor/mcp.json` or `.cursor/mcp.json` remote server entry. */
-export function buildCursorMcpJson(mcpServerUrl: string) {
-	return prettyJson({
-		mcpServers: {
-			kody: {
-				url: mcpServerUrl,
-			},
-		},
-	})
 }
 
 /** Claude Code project `.mcp.json` or user-scoped `mcpServers` entry. */
@@ -264,7 +240,6 @@ export function collectOnboardingMcpSnippets(mcpServerUrl: string) {
 		{ code: buildKodyAppIconUrl(mcpServerUrl) },
 		{ code: kodyCursorAddPluginCommand },
 		{ code: grokBotInstallUrl },
-		{ code: buildCursorMcpJson(mcpServerUrl), lang: 'json' },
 		{ code: buildCodexMcpAddCommand(mcpServerUrl), lang: 'sh' },
 		{ code: buildCodexMcpToml(mcpServerUrl), lang: 'toml' },
 		{ code: buildGrokCliAddCommand(mcpServerUrl), lang: 'sh' },

--- a/packages/worker/universal/onboarding-mcp-clients.ts
+++ b/packages/worker/universal/onboarding-mcp-clients.ts
@@ -11,6 +11,7 @@ export type McpClientKind =
 	| 'claude-desktop'
 	| 'grok'
 	| 'grok-cli'
+	| 'grok-bot'
 	| 'claude-code'
 	| 'opencode'
 	| 'copilot'
@@ -31,6 +32,7 @@ export const mcpClientTabs = [
 	{ id: 'claude-desktop', label: 'Claude Desktop', isNonCodingAgent: true },
 	{ id: 'grok', label: 'Grok.com', isNonCodingAgent: true },
 	{ id: 'grok-cli', label: 'Grok CLI', isNonCodingAgent: false },
+	{ id: 'grok-bot', label: 'Grok Bot', isNonCodingAgent: true },
 	{ id: 'claude-code', label: 'Claude Code', isNonCodingAgent: false },
 	{ id: 'opencode', label: 'OpenCode', isNonCodingAgent: false },
 	{ id: 'copilot', label: 'Copilot', isNonCodingAgent: false },
@@ -57,6 +59,22 @@ export const grokCustomMcpGuideUrl = 'https://docs.x.ai/grok/connectors'
 /** Grok CLI (`grok`) MCP add / config.toml docs. */
 export const grokCliMcpGuideUrl = 'https://docs.x.ai/build/features/mcp-servers'
 
+/** Cursor Marketplace listing for the official Kody plugin (production). */
+export const kodyCursorMarketplaceUrl = 'https://cursor.com/marketplace/kody'
+
+/** Cursor chat command shown on the marketplace listing. */
+export const kodyCursorAddPluginCommand = '/add-plugin kody'
+
+/** Confirmed Cursor Marketplace plugin id for Kody. */
+export const kodyMarketplacePluginId = '56286216'
+
+/** Confirmed Grok Bot one-click add for the official Kody plugin. */
+export const grokBotInstallUrl = `grokbot://app/v1/plugin/add?id=${kodyMarketplacePluginId}`
+
+/** Grok Bot sidebar plugin help. */
+export const grokBotConnectPluginsUrl =
+	'https://cursor.com/help/grok-bot/connect-plugins'
+
 /** Square favicon suitable for ChatGPT plugin / connector app icons. */
 export function buildKodyAppIconUrl(mcpServerUrl: string) {
 	return new URL('/apple-touch-icon.png', mcpServerUrl).href
@@ -80,8 +98,12 @@ export const defaultKodyMcpUrl = 'https://kody.codes/mcp'
  * default; preview and local origins pass `--mcp-url` so install writes
  * this deployment's MCP endpoint.
  */
+export function isDefaultKodyMcpUrl(mcpServerUrl: string) {
+	return normalizeMcpUrl(mcpServerUrl) === defaultKodyMcpUrl
+}
+
 export function buildKodyCliInstallCommand(mcpServerUrl: string) {
-	if (normalizeMcpUrl(mcpServerUrl) === defaultKodyMcpUrl) {
+	if (isDefaultKodyMcpUrl(mcpServerUrl)) {
 		return 'npx @kodycodes/cli install'
 	}
 	return `npx @kodycodes/cli install --mcp-url ${mcpServerUrl}`
@@ -240,6 +262,8 @@ export function collectOnboardingMcpSnippets(mcpServerUrl: string) {
 	return [
 		{ code: mcpServerUrl },
 		{ code: buildKodyAppIconUrl(mcpServerUrl) },
+		{ code: kodyCursorAddPluginCommand },
+		{ code: grokBotInstallUrl },
 		{ code: buildCursorMcpJson(mcpServerUrl), lang: 'json' },
 		{ code: buildCodexMcpAddCommand(mcpServerUrl), lang: 'sh' },
 		{ code: buildCodexMcpToml(mcpServerUrl), lang: 'toml' },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Update Get started / connect-your-agent so Cursor and Grok Bot install Kody as the official marketplace plugin, not as a raw custom MCP server.

## Why

Kody is listed on the Cursor Marketplace (`https://cursor.com/marketplace/kody`, plugin id `56286216`). Grok Bot has a confirmed one-click add: `grokbot://app/v1/plugin/add?id=56286216`. The marketplace page also shows `/add-plugin kody`. Production onboarding should lead with that plugin path only. Preview and local origins can still use the production plugin.

## Summary

- **Cursor** tab is plugin-only: green **Add to Cursor** (`https://cursor.com/marketplace/kody`) plus quiet **Or do this:** `/add-plugin kody` and the authorize-afterwards note. Removed the "This origin is not production kody.codes" warning and the entire **Manual / fallback** raw-MCP block (deeplink, MCP URL, `mcp.json`).
- **Grok Bot** tab is plugin-only: green **Add to Grok Bot** (`grokbot://app/v1/plugin/add?id=56286216`) plus the same URL as **Or do this:**. Removed the origin warning and **Manual / fallback** MCP URL. Help link label is **Grok Bot plugin help**.
- Other clients (ChatGPT, Claude Desktop, Grok.com, Grok CLI, Claude Code, Copilot, Other) still keep raw MCP / vendor CLI / JSON-TOML.
- Dropped leftover "targets production kody.codes" copy and unused Cursor MCP deeplink / `mcp.json` builders.
- Docs and the authenticate callout now say plugin, not "plugin (or raw MCP)".

## Testing

- `npx vitest run --project node-unit` on `onboarding-mcp-clients.node.test.ts` and `onboarding-mcp-client-tabs.node.test.ts` (pass)
- Rendered HTML: no origin warning and no fallback testids on production or preview origins; plugin buttons remain

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `b0e0d623` · **Head:** `9c504cfe`

**Classification:** composes — no primitives added or changed; this PR wires marketplace plugin install into existing onboarding UI.

### Primitives touched

| Primitive | Group    | Impact   |
| --------- | -------- | -------- |
| `app-ui`  | surfaces | composes |

Unmatched path: `docs/use/connect-your-agent.md` (usage copy for the same onboarding change).

### Change flow

Get started Manual tabs install Cursor and Grok Bot only through the official plugin. Other clients keep raw MCP.

```mermaid
sequenceDiagram
	actor User
	participant appUi as app-ui
	User->>appUi: open Manual → Cursor
	appUi->>User: Add to Cursor marketplace button, then Or do this /add-plugin kody
	Note over appUi: no origin warning, no Manual/fallback
	User->>appUi: open Manual → Grok Bot
	appUi->>User: Add to Grok Bot deeplink, then Or do this grokbot URL
	User->>appUi: open Manual → ChatGPT / Claude / Grok.com / Grok CLI
	appUi->>User: keep raw MCP URL, vendor CLI, or JSON/TOML
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-53838108-4f48-4e7f-8234-24f52dabb621?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-53838108-4f48-4e7f-8234-24f52dabb621&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Grok Bot as a supported connection option with one-click installation and authorization guidance.
  * Added Cursor Marketplace plugin installation for production deployments.
  * Retained manual MCP setup instructions for local and preview deployments.
  * Improved onboarding guidance for connecting coding and AI agents.

* **Documentation**
  * Updated connection guides and agent comparisons to include Grok Bot and Cursor setup options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->