### PR TITLE
Prepare avatar uploads in the browser

### DIFF
--- a/docs/contributing/code-style.md
+++ b/docs/contributing/code-style.md
@@ -85,6 +85,11 @@ file style first, then run the formatter.
   during the undo window — remount commits immediately and loader data can
   restore the optimistic removal. Navigate after `onCommit` if the selection is
   gone.
+- For non-undo flash messages (save/upload success, or errors that should not
+  shift page layout), use `toast` from `packages/worker/client/toast.ts`. The
+  app shell already mounts `<Toaster />`. `toast.success` and `toast.info`
+  auto-dismiss; `toast.error` stays until dismissed. Pass `duration: null` (or
+  `Infinity`) to persist any tone, or `action: { label, onClick }` for a button.
 
 ## Absence values
 

--- a/docs/use/community-profiles.md
+++ b/docs/use/community-profiles.md
@@ -25,10 +25,13 @@ avatar, join date, follower and following counts, the user's **public packages**
 ### Avatars
 
 Upload or remove an avatar from **Account → Profile** in the web UI (MCP does
-not accept avatar uploads). Accepted formats are PNG, JPEG, and WebP, up to 1
-MB, with each side between 64px and 4096px and an aspect ratio of at most 3:1.
-Avatars appear on the public profile and in timeline and profile activity rows.
-Private profiles still keep the avatar for the owner; other users do not see it.
+not accept avatar uploads). The browser converts HEIC, AVIF, and other photos to
+PNG, JPEG, or WebP and resizes large images before upload. Stored avatars are
+PNG, JPEG, or WebP, up to 1 MB, with each side between 64px and 4096px and an
+aspect ratio of at most 3:1. Dropping a photo on the account page sets it as the
+avatar; dropping a file elsewhere in the app does not navigate away. Avatars
+appear on the public profile and in timeline and profile activity rows. Private
+profiles still keep the avatar for the owner; other users do not see it.
 
 Package privacy follows `package.json#private` (projected onto
 `saved_packages.is_private`):

--- a/docs/use/community-profiles.md
+++ b/docs/use/community-profiles.md
@@ -25,15 +25,16 @@ avatar, join date, follower and following counts, the user's **public packages**
 ### Avatars
 
 Upload or remove an avatar from **Account → Profile** in the web UI (MCP does
-not accept avatar uploads). Choosing or dropping a photo opens a crop and zoom
-editor (drag, pinch, scroll, or the slider) so you can frame a square that
-matches the circular avatar. The browser converts HEIC, AVIF, and other photos
-to PNG, JPEG, or WebP and resizes large images before upload. Stored avatars are
-PNG, JPEG, or WebP, up to 1 MB, with each side between 64px and 4096px and an
-aspect ratio of at most 3:1. Dropping a photo on the account page opens that
-editor; dropping a file elsewhere in the app does not navigate away. Avatars
-appear on the public profile and in timeline and profile activity rows. Private
-profiles still keep the avatar for the owner; other users do not see it.
+not accept avatar uploads). Click the avatar, or drop a photo anywhere on the
+account page, to open a crop and zoom editor (drag, pinch, scroll, or the
+slider) so you can frame a square that matches the circular avatar. The browser
+converts HEIC, AVIF, and other photos to PNG, JPEG, or WebP and resizes large
+images before upload. Stored avatars are PNG, JPEG, or WebP, up to 1 MB, with
+each side between 64px and 4096px and an aspect ratio of at most 3:1. Dropping a
+photo on the account page opens that editor; dropping a file elsewhere in the
+app does not navigate away. Avatars appear on the public profile and in timeline
+and profile activity rows. Private profiles still keep the avatar for the owner;
+other users do not see it.
 
 Package privacy follows `package.json#private` (projected onto
 `saved_packages.is_private`):

--- a/docs/use/community-profiles.md
+++ b/docs/use/community-profiles.md
@@ -25,11 +25,13 @@ avatar, join date, follower and following counts, the user's **public packages**
 ### Avatars
 
 Upload or remove an avatar from **Account → Profile** in the web UI (MCP does
-not accept avatar uploads). The browser converts HEIC, AVIF, and other photos to
-PNG, JPEG, or WebP and resizes large images before upload. Stored avatars are
+not accept avatar uploads). Choosing or dropping a photo opens a crop and zoom
+editor (drag, pinch, scroll, or the slider) so you can frame a square that
+matches the circular avatar. The browser converts HEIC, AVIF, and other photos
+to PNG, JPEG, or WebP and resizes large images before upload. Stored avatars are
 PNG, JPEG, or WebP, up to 1 MB, with each side between 64px and 4096px and an
-aspect ratio of at most 3:1. Dropping a photo on the account page sets it as the
-avatar; dropping a file elsewhere in the app does not navigate away. Avatars
+aspect ratio of at most 3:1. Dropping a photo on the account page opens that
+editor; dropping a file elsewhere in the app does not navigate away. Avatars
 appear on the public profile and in timeline and profile activity rows. Private
 profiles still keep the avatar for the owner; other users do not see it.
 

--- a/packages/worker/client/app.tsx
+++ b/packages/worker/client/app.tsx
@@ -32,6 +32,7 @@ import {
 import { visuallyHiddenUntilFocusedCss } from '#universal/styles/style-primitives.ts'
 import { SiteFooter } from './site-footer.tsx'
 import { SiteHeader } from './site-header.tsx'
+import { Toaster } from './toaster.tsx'
 import { type AppLoaderData } from '#universal/loader-data.ts'
 import { isPackageFilesPathname } from '#universal/package-files.ts'
 import { userHasRole } from '#universal/permissions.ts'
@@ -311,6 +312,7 @@ export function App(handle: Handle<AppProps>) {
 						{isAuthShellPath ? null : (
 							<SiteFooter loggedIn={isLoggedIn} loginHref={loginHref} />
 						)}
+						<Toaster />
 					</div>
 				</AppSessionProvider>
 			</AppLoaderDataProvider>

--- a/packages/worker/client/avatar-crop.node.test.ts
+++ b/packages/worker/client/avatar-crop.node.test.ts
@@ -1,0 +1,88 @@
+import { expect, test } from 'vitest'
+import {
+	clampTransform,
+	coverScale,
+	cropRectFromTransform,
+	initialCoverTransform,
+	maxScale,
+	panBy,
+	resizeTransform,
+	userAvatarCropMaxZoom,
+	zoomAtPoint,
+} from './avatar-crop.ts'
+import { userAvatarMinDimension } from '#universal/user-avatar-limits.ts'
+
+test('avatar crop math covers, pans, zooms, and stays a square in-bounds crop', () => {
+	const viewportSize = 280
+	const landscape = {
+		imageWidth: 2400,
+		imageHeight: 400,
+		viewportSize,
+	}
+	expect(coverScale(landscape)).toBe(viewportSize / 400)
+	const start = initialCoverTransform(landscape)
+	expect(start.offsetY).toBe(0)
+	expect(start.offsetX).toBe((viewportSize - 2400 * start.scale) / 2)
+
+	const coverCrop = cropRectFromTransform(landscape, start)
+	expect(coverCrop).toEqual({
+		sourceX: 1000,
+		sourceY: 0,
+		sourceWidth: 400,
+		sourceHeight: 400,
+	})
+
+	const pannedOffTheEdge = panBy(landscape, start, 4000, 4000)
+	expect(pannedOffTheEdge.offsetX).toBe(0)
+	expect(pannedOffTheEdge.offsetY).toBe(0)
+	expect(cropRectFromTransform(landscape, pannedOffTheEdge).sourceX).toBe(0)
+
+	const zoomed = zoomAtPoint(
+		landscape,
+		start,
+		start.scale * userAvatarCropMaxZoom,
+		viewportSize / 2,
+		viewportSize / 2,
+	)
+	expect(zoomed.scale).toBe(maxScale(landscape))
+	const zoomedCrop = cropRectFromTransform(landscape, zoomed)
+	expect(zoomedCrop.sourceWidth).toBe(zoomedCrop.sourceHeight)
+	expect(zoomedCrop.sourceWidth).toBeGreaterThanOrEqual(userAvatarMinDimension)
+	expect(zoomedCrop.sourceX).toBeGreaterThanOrEqual(0)
+	expect(zoomedCrop.sourceX + zoomedCrop.sourceWidth).toBeLessThanOrEqual(2400)
+
+	const rotated = {
+		imageWidth: 2400,
+		imageHeight: 400,
+		viewportSize: 160,
+	}
+	const resized = resizeTransform(landscape, rotated, zoomed)
+	const resizedCrop = cropRectFromTransform(rotated, resized)
+	expect(resizedCrop.sourceWidth).toBe(resizedCrop.sourceHeight)
+	expect(resizedCrop.sourceWidth).toBe(zoomedCrop.sourceWidth)
+	expect(resizedCrop.sourceX).toBe(zoomedCrop.sourceX)
+
+	const tiny = {
+		imageWidth: 80,
+		imageHeight: 80,
+		viewportSize,
+	}
+	expect(maxScale(tiny)).toBe(viewportSize / userAvatarMinDimension)
+	expect(
+		cropRectFromTransform(tiny, initialCoverTransform(tiny)).sourceWidth,
+	).toBe(80)
+
+	const square = {
+		imageWidth: 800,
+		imageHeight: 800,
+		viewportSize,
+	}
+	const clamped = clampTransform(square, {
+		scale: 0.01,
+		offsetX: 50,
+		offsetY: -900,
+	})
+	expect(clamped.scale).toBe(coverScale(square))
+	expect(clamped.offsetX).toBe(0)
+	expect(clamped.offsetY).toBe(0)
+})

--- a/packages/worker/client/avatar-crop.ts
+++ b/packages/worker/client/avatar-crop.ts
@@ -1,0 +1,152 @@
+/**
+ * Pure crop/zoom helpers for the account avatar editor. Kept free of DOM
+ * and framework imports so they can be unit tested directly.
+ */
+
+import { userAvatarMinDimension } from '#universal/user-avatar-limits.ts'
+
+/** How far the user can zoom in relative to the cover (fit) scale. */
+export const userAvatarCropMaxZoom = 4
+
+export type AvatarCropRect = {
+	sourceX: number
+	sourceY: number
+	sourceWidth: number
+	sourceHeight: number
+}
+
+export type AvatarCropBounds = {
+	imageWidth: number
+	imageHeight: number
+	viewportSize: number
+}
+
+export type AvatarCropTransform = {
+	scale: number
+	offsetX: number
+	offsetY: number
+}
+
+export function coverScale(bounds: AvatarCropBounds): number {
+	const shortest = Math.min(bounds.imageWidth, bounds.imageHeight)
+	if (shortest <= 0 || bounds.viewportSize <= 0) return 1
+	return bounds.viewportSize / shortest
+}
+
+export function maxScale(bounds: AvatarCropBounds): number {
+	const cover = coverScale(bounds)
+	if (bounds.viewportSize <= 0) return cover
+	const minCropScale = bounds.viewportSize / userAvatarMinDimension
+	return Math.max(cover, Math.min(cover * userAvatarCropMaxZoom, minCropScale))
+}
+
+export function initialCoverTransform(
+	bounds: AvatarCropBounds,
+): AvatarCropTransform {
+	const scale = coverScale(bounds)
+	return clampTransform(bounds, {
+		scale,
+		offsetX: (bounds.viewportSize - bounds.imageWidth * scale) / 2,
+		offsetY: (bounds.viewportSize - bounds.imageHeight * scale) / 2,
+	})
+}
+
+export function clampTransform(
+	bounds: AvatarCropBounds,
+	transform: AvatarCropTransform,
+): AvatarCropTransform {
+	const scale = clampNumber(
+		transform.scale,
+		coverScale(bounds),
+		maxScale(bounds),
+	)
+	const minX = bounds.viewportSize - bounds.imageWidth * scale
+	const minY = bounds.viewportSize - bounds.imageHeight * scale
+	return {
+		scale,
+		offsetX: clampNumber(transform.offsetX, Math.min(0, minX), 0),
+		offsetY: clampNumber(transform.offsetY, Math.min(0, minY), 0),
+	}
+}
+
+export function panBy(
+	bounds: AvatarCropBounds,
+	transform: AvatarCropTransform,
+	deltaX: number,
+	deltaY: number,
+): AvatarCropTransform {
+	return clampTransform(bounds, {
+		scale: transform.scale,
+		offsetX: transform.offsetX + deltaX,
+		offsetY: transform.offsetY + deltaY,
+	})
+}
+
+export function zoomAtPoint(
+	bounds: AvatarCropBounds,
+	transform: AvatarCropTransform,
+	nextScale: number,
+	originX: number,
+	originY: number,
+): AvatarCropTransform {
+	if (transform.scale <= 0) return initialCoverTransform(bounds)
+	const imageX = (originX - transform.offsetX) / transform.scale
+	const imageY = (originY - transform.offsetY) / transform.scale
+	return clampTransform(bounds, {
+		scale: nextScale,
+		offsetX: originX - imageX * nextScale,
+		offsetY: originY - imageY * nextScale,
+	})
+}
+
+/**
+ * Keep the same source crop when the on-screen viewport is measured or
+ * rotates. Scale and offsets are multiplied by the viewport size ratio.
+ */
+export function resizeTransform(
+	previous: AvatarCropBounds,
+	next: AvatarCropBounds,
+	transform: AvatarCropTransform,
+): AvatarCropTransform {
+	if (previous.viewportSize <= 0) return initialCoverTransform(next)
+	const factor = next.viewportSize / previous.viewportSize
+	return clampTransform(next, {
+		scale: transform.scale * factor,
+		offsetX: transform.offsetX * factor,
+		offsetY: transform.offsetY * factor,
+	})
+}
+
+export function cropRectFromTransform(
+	bounds: AvatarCropBounds,
+	transform: AvatarCropTransform,
+): AvatarCropRect {
+	const shortest = Math.min(bounds.imageWidth, bounds.imageHeight)
+	const rawSize =
+		transform.scale <= 0 ? shortest : bounds.viewportSize / transform.scale
+	const size = clampNumber(
+		Math.round(rawSize),
+		Math.min(userAvatarMinDimension, shortest),
+		shortest,
+	)
+	const sourceX = clampNumber(
+		Math.round(-transform.offsetX / transform.scale),
+		0,
+		Math.max(0, bounds.imageWidth - size),
+	)
+	const sourceY = clampNumber(
+		Math.round(-transform.offsetY / transform.scale),
+		0,
+		Math.max(0, bounds.imageHeight - size),
+	)
+	return {
+		sourceX,
+		sourceY,
+		sourceWidth: size,
+		sourceHeight: size,
+	}
+}
+
+function clampNumber(value: number, min: number, max: number) {
+	return Math.min(max, Math.max(min, value))
+}

--- a/packages/worker/client/client-router.tsx
+++ b/packages/worker/client/client-router.tsx
@@ -2,6 +2,7 @@ import { addEventListeners, type Handle } from 'remix/ui'
 import { createMultiMatcher } from 'remix/route-pattern/match'
 import { type AppLoaderData } from '#universal/loader-data.ts'
 import { applyDocumentHead } from './document-head.ts'
+import { installFileDropNavigationGuard } from './file-drop-navigation.ts'
 import {
 	abortIntentPrefetch,
 	prefetchRouteOnIntent,
@@ -964,6 +965,7 @@ function ensureRouter() {
 	document.addEventListener('touchstart', handleImmediateIntent, {
 		passive: true,
 	})
+	installFileDropNavigationGuard()
 }
 
 export function listenToRouterNavigation(

--- a/packages/worker/client/file-drop-navigation.node.test.ts
+++ b/packages/worker/client/file-drop-navigation.node.test.ts
@@ -1,0 +1,180 @@
+import { expect, test, vi } from 'vitest'
+import {
+	eventHasFileDrag,
+	installFileDropNavigationGuard,
+	isFileInputDropTarget,
+	isLikelyImageFile,
+	preventFileDropNavigation,
+	readDroppedImageFile,
+} from './file-drop-navigation.ts'
+import { listenForAvatarFileDrop } from './listen-for-avatar-file-drop.ts'
+
+function createDragEvent(input: {
+	type: string
+	types?: Array<string>
+	files?: Array<File>
+	target?: EventTarget | null
+	dropEffect?: string
+}): DragEvent {
+	const dataTransfer = {
+		types: input.types ?? [],
+		files: input.files ?? [],
+		dropEffect: input.dropEffect ?? 'none',
+	}
+	return {
+		type: input.type,
+		dataTransfer,
+		target: input.target ?? null,
+		preventDefault: vi.fn(),
+	} as unknown as DragEvent
+}
+
+function createFileInputTarget(): EventTarget {
+	return {
+		tagName: 'INPUT',
+		type: 'file',
+		closest: (selector: string) =>
+			selector === 'input[type="file"]' ? createFileInputTarget() : null,
+	} as unknown as EventTarget
+}
+
+test('file-drop helpers keep the page from navigating and route images to avatar upload', () => {
+	expect(
+		eventHasFileDrag(
+			createDragEvent({ type: 'dragover', types: ['text/plain'] }),
+		),
+	).toBe(false)
+	expect(
+		eventHasFileDrag(createDragEvent({ type: 'dragover', types: ['Files'] })),
+	).toBe(true)
+	expect(
+		eventHasFileDrag(
+			createDragEvent({
+				type: 'dragover',
+				types: ['application/x-moz-file'],
+			}),
+		),
+	).toBe(true)
+
+	const textDrag = createDragEvent({
+		type: 'drop',
+		types: ['text/plain'],
+	})
+	expect(preventFileDropNavigation(textDrag)).toBe(false)
+	expect(textDrag.preventDefault).not.toHaveBeenCalled()
+
+	const pageDrop = createDragEvent({
+		type: 'drop',
+		types: ['Files'],
+		target: { tagName: 'DIV', closest: () => null } as unknown as EventTarget,
+	})
+	expect(preventFileDropNavigation(pageDrop)).toBe(true)
+	expect(pageDrop.preventDefault).toHaveBeenCalledOnce()
+
+	const fileInputDrop = createDragEvent({
+		type: 'drop',
+		types: ['Files'],
+		target: createFileInputTarget(),
+	})
+	expect(isFileInputDropTarget(fileInputDrop.target)).toBe(true)
+	expect(preventFileDropNavigation(fileInputDrop)).toBe(false)
+	expect(fileInputDrop.preventDefault).not.toHaveBeenCalled()
+
+	const labeledInput = {
+		tagName: 'INPUT',
+		type: 'file',
+	}
+	const labelTarget = {
+		tagName: 'SPAN',
+		closest: (selector: string) => (selector === 'label' ? labelTarget : null),
+		control: labeledInput,
+		querySelector: () => labeledInput,
+	} as unknown as EventTarget
+	expect(isFileInputDropTarget(labelTarget)).toBe(true)
+
+	const photo = new File([Uint8Array.from([1, 2, 3])], 'photo.heic', {
+		type: '',
+	})
+	const notes = new File(['todo'], 'notes.txt', { type: 'text/plain' })
+	expect(isLikelyImageFile(photo)).toBe(true)
+	expect(isLikelyImageFile(notes)).toBe(false)
+	expect(
+		readDroppedImageFile({
+			files: [notes, photo],
+		} as unknown as DataTransfer),
+	).toBe(photo)
+
+	const listeners = new Map<string, (event: Event) => void>()
+	const target = {
+		addEventListener: vi.fn(
+			(type: string, listener: (event: Event) => void) => {
+				listeners.set(type, listener)
+			},
+		),
+		removeEventListener: vi.fn(),
+	}
+	const stop = installFileDropNavigationGuard(target)
+	expect(listeners.has('dragover')).toBe(true)
+	expect(listeners.has('drop')).toBe(true)
+	const guardedDrop = createDragEvent({
+		type: 'drop',
+		types: ['Files'],
+		target: { tagName: 'MAIN', closest: () => null } as unknown as EventTarget,
+	})
+	listeners.get('drop')?.(guardedDrop)
+	expect(guardedDrop.preventDefault).toHaveBeenCalledOnce()
+	stop()
+	expect(target.removeEventListener).toHaveBeenCalledTimes(2)
+
+	const controller = new AbortController()
+	const received: Array<File> = []
+	const dragStates: Array<boolean> = []
+	const avatarListeners = new Map<string, (event: Event) => void>()
+	listenForAvatarFileDrop({
+		target: {
+			addEventListener: (type, listener) => {
+				avatarListeners.set(type, listener as (event: Event) => void)
+			},
+			removeEventListener: vi.fn(),
+		},
+		signal: controller.signal,
+		onDragActiveChange: (active) => {
+			dragStates.push(active)
+		},
+		onImageFile: (file) => {
+			received.push(file)
+		},
+	})
+
+	const enter = createDragEvent({ type: 'dragenter', types: ['Files'] })
+	avatarListeners.get('dragenter')?.(enter)
+	avatarListeners.get('dragenter')?.(enter)
+	expect(dragStates).toEqual([true])
+	avatarListeners.get('dragleave')?.(enter)
+	expect(dragStates).toEqual([true])
+	avatarListeners.get('dragleave')?.(enter)
+	expect(dragStates).toEqual([true, false])
+
+	const droppedPhoto = new File([Uint8Array.from([9])], 'face.avif', {
+		type: 'image/avif',
+	})
+	const avatarDrop = createDragEvent({
+		type: 'drop',
+		types: ['Files'],
+		files: [droppedPhoto],
+		target: { tagName: 'MAIN', closest: () => null } as unknown as EventTarget,
+	})
+	avatarListeners.get('drop')?.(avatarDrop)
+	expect(avatarDrop.preventDefault).toHaveBeenCalledOnce()
+	expect(received).toEqual([droppedPhoto])
+	expect(dragStates.at(-1)).toBe(false)
+
+	const ignoredInputDrop = createDragEvent({
+		type: 'drop',
+		types: ['Files'],
+		files: [droppedPhoto],
+		target: createFileInputTarget(),
+	})
+	avatarListeners.get('drop')?.(ignoredInputDrop)
+	expect(received).toHaveLength(1)
+})

--- a/packages/worker/client/file-drop-navigation.node.test.ts
+++ b/packages/worker/client/file-drop-navigation.node.test.ts
@@ -90,7 +90,14 @@ test('file-drop helpers keep the page from navigating and route images to avatar
 		control: labeledInput,
 		querySelector: () => labeledInput,
 	} as unknown as EventTarget
-	expect(isFileInputDropTarget(labelTarget)).toBe(true)
+	expect(isFileInputDropTarget(labelTarget)).toBe(false)
+	const labelDrop = createDragEvent({
+		type: 'drop',
+		types: ['Files'],
+		target: labelTarget,
+	})
+	expect(preventFileDropNavigation(labelDrop)).toBe(true)
+	expect(labelDrop.preventDefault).toHaveBeenCalledOnce()
 
 	const photo = new File([Uint8Array.from([1, 2, 3])], 'photo.heic', {
 		type: '',
@@ -177,4 +184,14 @@ test('file-drop helpers keep the page from navigating and route images to avatar
 	})
 	avatarListeners.get('drop')?.(ignoredInputDrop)
 	expect(received).toHaveLength(1)
+
+	const labeledAvatarDrop = createDragEvent({
+		type: 'drop',
+		types: ['Files'],
+		files: [droppedPhoto],
+		target: labelTarget,
+	})
+	avatarListeners.get('drop')?.(labeledAvatarDrop)
+	expect(labeledAvatarDrop.preventDefault).toHaveBeenCalledOnce()
+	expect(received).toEqual([droppedPhoto, droppedPhoto])
 })

--- a/packages/worker/client/file-drop-navigation.ts
+++ b/packages/worker/client/file-drop-navigation.ts
@@ -1,7 +1,8 @@
 /**
  * File drags onto a page otherwise navigate the browser to that file. Guard
- * dragover/drop so the app stays put, while native file inputs still receive
- * their own drops.
+ * dragover/drop so the app stays put. Only a real `input[type=file]` assigns
+ * dropped files natively — labels wrapping those inputs do not, so those
+ * drops still need preventDefault.
  */
 
 export function eventHasFileDrag(
@@ -18,22 +19,14 @@ export function eventHasFileDrag(
 type ClosestElement = {
 	tagName?: string
 	type?: string
-	control?: EventTarget | null
 	closest?: (selector: string) => EventTarget | null
-	querySelector?: (selector: string) => EventTarget | null
 }
 
 export function isFileInputDropTarget(target: EventTarget | null): boolean {
 	const element = asClosestElement(target)
 	if (!element) return false
 	if (isFileInputElement(element)) return true
-	if (isFileInputElement(element.closest?.('input[type="file"]') ?? null)) {
-		return true
-	}
-	const label = asClosestElement(element.closest?.('label') ?? null)
-	if (!label) return false
-	if (isFileInputElement(label.control ?? null)) return true
-	return isFileInputElement(label.querySelector?.('input[type="file"]') ?? null)
+	return isFileInputElement(element.closest?.('input[type="file"]') ?? null)
 }
 
 function asClosestElement(target: unknown): ClosestElement | null {

--- a/packages/worker/client/file-drop-navigation.ts
+++ b/packages/worker/client/file-drop-navigation.ts
@@ -1,0 +1,86 @@
+/**
+ * File drags onto a page otherwise navigate the browser to that file. Guard
+ * dragover/drop so the app stays put, while native file inputs still receive
+ * their own drops.
+ */
+
+export function eventHasFileDrag(
+	event: Pick<DragEvent, 'dataTransfer'>,
+): boolean {
+	const types = event.dataTransfer?.types
+	if (!types) return false
+	return (
+		Array.from(types).includes('Files') ||
+		Array.from(types).includes('application/x-moz-file')
+	)
+}
+
+type ClosestElement = {
+	tagName?: string
+	type?: string
+	control?: EventTarget | null
+	closest?: (selector: string) => EventTarget | null
+	querySelector?: (selector: string) => EventTarget | null
+}
+
+export function isFileInputDropTarget(target: EventTarget | null): boolean {
+	const element = asClosestElement(target)
+	if (!element) return false
+	if (isFileInputElement(element)) return true
+	if (isFileInputElement(element.closest?.('input[type="file"]') ?? null)) {
+		return true
+	}
+	const label = asClosestElement(element.closest?.('label') ?? null)
+	if (!label) return false
+	if (isFileInputElement(label.control ?? null)) return true
+	return isFileInputElement(label.querySelector?.('input[type="file"]') ?? null)
+}
+
+function asClosestElement(target: unknown): ClosestElement | null {
+	if (target == null || typeof target !== 'object') return null
+	return target as ClosestElement
+}
+
+function isFileInputElement(target: unknown): boolean {
+	const element = asClosestElement(target)
+	return element?.tagName === 'INPUT' && element.type === 'file'
+}
+
+export function isLikelyImageFile(file: File): boolean {
+	if (file.type.startsWith('image/')) return true
+	return /\.(avif|bmp|gif|heic|heif|jpe?g|png|svg|tif{1,2}|webp)$/i.test(
+		file.name,
+	)
+}
+
+export function readDroppedImageFile(
+	dataTransfer: DataTransfer | null,
+): File | null {
+	return Array.from(dataTransfer?.files ?? []).find(isLikelyImageFile) ?? null
+}
+
+export function preventFileDropNavigation(event: DragEvent): boolean {
+	if (!eventHasFileDrag(event)) return false
+	if (event.type === 'drop' && isFileInputDropTarget(event.target)) {
+		return false
+	}
+	event.preventDefault()
+	if (event.type === 'dragover' && event.dataTransfer) {
+		event.dataTransfer.dropEffect = 'copy'
+	}
+	return true
+}
+
+export function installFileDropNavigationGuard(
+	target: Pick<Document, 'addEventListener' | 'removeEventListener'> = document,
+): () => void {
+	const handleDragEvent = (event: Event) => {
+		preventFileDropNavigation(event as DragEvent)
+	}
+	target.addEventListener('dragover', handleDragEvent)
+	target.addEventListener('drop', handleDragEvent)
+	return () => {
+		target.removeEventListener('dragover', handleDragEvent)
+		target.removeEventListener('drop', handleDragEvent)
+	}
+}

--- a/packages/worker/client/listen-for-avatar-file-drop.ts
+++ b/packages/worker/client/listen-for-avatar-file-drop.ts
@@ -1,0 +1,66 @@
+import {
+	eventHasFileDrag,
+	isFileInputDropTarget,
+	preventFileDropNavigation,
+	readDroppedImageFile,
+} from './file-drop-navigation.ts'
+
+export function listenForAvatarFileDrop(input: {
+	target?: Pick<Document, 'addEventListener' | 'removeEventListener'>
+	signal: AbortSignal
+	onDragActiveChange: (active: boolean) => void
+	onImageFile: (file: File) => void
+}): void {
+	if (input.signal.aborted) return
+	const target = input.target ?? document
+	let dragDepth = 0
+	let dragActive = false
+
+	function setDragActive(next: boolean) {
+		if (dragActive === next) return
+		dragActive = next
+		input.onDragActiveChange(next)
+	}
+
+	function handleDragEnter(event: Event) {
+		if (!eventHasFileDrag(event as DragEvent)) return
+		dragDepth += 1
+		setDragActive(true)
+	}
+
+	function handleDragLeave(event: Event) {
+		if (!eventHasFileDrag(event as DragEvent)) return
+		dragDepth = Math.max(0, dragDepth - 1)
+		if (dragDepth === 0) setDragActive(false)
+	}
+
+	function handleDragOver(event: Event) {
+		preventFileDropNavigation(event as DragEvent)
+	}
+
+	function handleDrop(event: Event) {
+		const dragEvent = event as DragEvent
+		dragDepth = 0
+		setDragActive(false)
+		if (isFileInputDropTarget(dragEvent.target)) return
+		if (!preventFileDropNavigation(dragEvent)) return
+		const file = readDroppedImageFile(dragEvent.dataTransfer)
+		if (!file) return
+		input.onImageFile(file)
+	}
+
+	target.addEventListener('dragenter', handleDragEnter)
+	target.addEventListener('dragleave', handleDragLeave)
+	target.addEventListener('dragover', handleDragOver)
+	target.addEventListener('drop', handleDrop)
+	input.signal.addEventListener(
+		'abort',
+		() => {
+			target.removeEventListener('dragenter', handleDragEnter)
+			target.removeEventListener('dragleave', handleDragLeave)
+			target.removeEventListener('dragover', handleDragOver)
+			target.removeEventListener('drop', handleDrop)
+		},
+		{ once: true },
+	)
+}

--- a/packages/worker/client/prepare-avatar-image.node.test.ts
+++ b/packages/worker/client/prepare-avatar-image.node.test.ts
@@ -1,7 +1,9 @@
 import { expect, test } from 'vitest'
 import {
+	clampEncodedAspect,
 	cropToMaxAspect,
 	prepareAvatarImage,
+	prepareDecodedAvatarImage,
 	scaleToMaxDimension,
 	userAvatarBrowserEncodeMaxDimension,
 	type EncodeAvatarImageInput,
@@ -38,6 +40,14 @@ test('prepareAvatarImage converts, resizes, crops, and rejects unusable photos',
 		width: 1024,
 		height: 512,
 	})
+	expect(scaleToMaxDimension(1200, 400, 1024)).toEqual({
+		width: 1024,
+		height: 342,
+	})
+	expect(clampEncodedAspect(1024, 341)).toEqual({ width: 1024, height: 342 })
+	expect(
+		1024 / scaleToMaxDimension(1200, 400, 1024).height,
+	).toBeLessThanOrEqual(3)
 
 	const readyJpeg = new File([Uint8Array.from([1, 2, 3, 4])], 'ready.jpg', {
 		type: 'image/jpeg',
@@ -113,6 +123,58 @@ test('prepareAvatarImage converts, resizes, crops, and rejects unusable photos',
 		sourceHeight: 100,
 		width: 300,
 		height: 100,
+	})
+
+	const banner = new File([new Uint8Array(2000)], 'wide-banner.png', {
+		type: 'image/png',
+	})
+	const bannerCalls: Array<EncodeAvatarImageInput> = []
+	await prepareAvatarImage(
+		banner,
+		createHost({
+			width: 2400,
+			height: 400,
+			encode: (request) => {
+				bannerCalls.push(request)
+				return new Blob([Uint8Array.from([1])], { type: 'image/png' })
+			},
+		}),
+	)
+	expect(bannerCalls[0]).toMatchObject({
+		sourceX: 600,
+		sourceY: 0,
+		sourceWidth: 1200,
+		sourceHeight: 400,
+		width: 1024,
+		height: 342,
+	})
+	expect(
+		Math.max(bannerCalls[0]?.width ?? 0, bannerCalls[0]?.height ?? 0) /
+			Math.min(bannerCalls[0]?.width ?? 1, bannerCalls[0]?.height ?? 1),
+	).toBeLessThanOrEqual(3)
+
+	const squareCropCalls: Array<EncodeAvatarImageInput> = []
+	await prepareDecodedAvatarImage(
+		banner,
+		{ width: 2400, height: 400 },
+		{
+			async decodeImage() {
+				throw new Error('decoded bitmaps should not be decoded again')
+			},
+			async encodeImage(request) {
+				squareCropCalls.push(request)
+				return new Blob([Uint8Array.from([1])], { type: 'image/jpeg' })
+			},
+		},
+		{ sourceX: 1000, sourceY: 0, sourceWidth: 400, sourceHeight: 400 },
+	)
+	expect(squareCropCalls[0]).toMatchObject({
+		sourceX: 1000,
+		sourceY: 0,
+		sourceWidth: 400,
+		sourceHeight: 400,
+		width: 400,
+		height: 400,
 	})
 
 	const tiny = new File([Uint8Array.from([1])], 'tiny.png', {

--- a/packages/worker/client/prepare-avatar-image.node.test.ts
+++ b/packages/worker/client/prepare-avatar-image.node.test.ts
@@ -1,0 +1,150 @@
+import { expect, test } from 'vitest'
+import {
+	cropToMaxAspect,
+	prepareAvatarImage,
+	scaleToMaxDimension,
+	userAvatarBrowserEncodeMaxDimension,
+	type EncodeAvatarImageInput,
+	type PrepareAvatarImageHost,
+} from './prepare-avatar-image.ts'
+import { userAvatarMaxSourceBytes } from '#universal/user-avatar-limits.ts'
+
+function createHost(input: {
+	width: number
+	height: number
+	encode?: (request: EncodeAvatarImageInput) => Blob
+}): PrepareAvatarImageHost {
+	return {
+		async decodeImage() {
+			return { width: input.width, height: input.height }
+		},
+		async encodeImage(request) {
+			if (input.encode) return input.encode(request)
+			return new Blob([Uint8Array.from([1, 2, 3])], {
+				type: request.contentType,
+			})
+		},
+	}
+}
+
+test('prepareAvatarImage converts, resizes, crops, and rejects unusable photos', async () => {
+	expect(cropToMaxAspect(900, 100)).toEqual({
+		sourceX: 300,
+		sourceY: 0,
+		sourceWidth: 300,
+		sourceHeight: 100,
+	})
+	expect(scaleToMaxDimension(4000, 2000, 1024)).toEqual({
+		width: 1024,
+		height: 512,
+	})
+
+	const readyJpeg = new File([Uint8Array.from([1, 2, 3, 4])], 'ready.jpg', {
+		type: 'image/jpeg',
+	})
+	await expect(
+		prepareAvatarImage(
+			readyJpeg,
+			createHost({
+				width: 128,
+				height: 128,
+				encode: () => {
+					throw new Error('ready images should not be re-encoded')
+				},
+			}),
+		),
+	).resolves.toBe(readyJpeg)
+
+	const heic = new File([Uint8Array.from([9, 9, 9])], 'photo.heic', {
+		type: 'image/heic',
+	})
+	const converted = await prepareAvatarImage(
+		heic,
+		createHost({
+			width: 800,
+			height: 600,
+			encode: (request) =>
+				new Blob([Uint8Array.from([5, 6, 7])], { type: request.contentType }),
+		}),
+	)
+	expect(converted).not.toBe(heic)
+	expect(converted.type).toBe('image/webp')
+	expect(converted.name).toBe('photo.webp')
+	expect(converted.size).toBe(3)
+
+	const oversized = new File([new Uint8Array(2000)], 'huge.jpg', {
+		type: 'image/jpeg',
+	})
+	const encodeCalls: Array<EncodeAvatarImageInput> = []
+	await prepareAvatarImage(
+		oversized,
+		createHost({
+			width: 8000,
+			height: 8000,
+			encode: (request) => {
+				encodeCalls.push(request)
+				return new Blob([Uint8Array.from([1])], { type: 'image/webp' })
+			},
+		}),
+	)
+	expect(encodeCalls[0]?.width).toBe(userAvatarBrowserEncodeMaxDimension)
+	expect(encodeCalls[0]?.height).toBe(userAvatarBrowserEncodeMaxDimension)
+	expect(encodeCalls[0]?.sourceWidth).toBe(8000)
+
+	const panorama = new File([new Uint8Array(2000)], 'wide.jpg', {
+		type: 'image/jpeg',
+	})
+	const cropCalls: Array<EncodeAvatarImageInput> = []
+	await prepareAvatarImage(
+		panorama,
+		createHost({
+			width: 900,
+			height: 100,
+			encode: (request) => {
+				cropCalls.push(request)
+				return new Blob([Uint8Array.from([1])], { type: 'image/jpeg' })
+			},
+		}),
+	)
+	expect(cropCalls[0]).toMatchObject({
+		sourceX: 300,
+		sourceY: 0,
+		sourceWidth: 300,
+		sourceHeight: 100,
+		width: 300,
+		height: 100,
+	})
+
+	const tiny = new File([Uint8Array.from([1])], 'tiny.png', {
+		type: 'image/png',
+	})
+	await expect(
+		prepareAvatarImage(tiny, createHost({ width: 32, height: 32 })),
+	).rejects.toThrow('between 64px and 4096px')
+
+	const unreadHeic = new File([Uint8Array.from([1])], 'iphone.heic', {
+		type: '',
+	})
+	await expect(prepareAvatarImage(unreadHeic)).rejects.toThrow(
+		'cannot convert HEIC',
+	)
+
+	const tooHeavy = new File(
+		[new Uint8Array(userAvatarMaxSourceBytes + 1)],
+		'heavy.avif',
+		{ type: 'image/avif' },
+	)
+	await expect(
+		prepareAvatarImage(
+			tooHeavy,
+			createHost({
+				width: 512,
+				height: 512,
+				encode: () =>
+					new Blob([new Uint8Array(userAvatarMaxSourceBytes + 1)], {
+						type: 'image/webp',
+					}),
+			}),
+		),
+	).rejects.toThrow(`${userAvatarMaxSourceBytes} bytes`)
+})

--- a/packages/worker/client/prepare-avatar-image.node.test.ts
+++ b/packages/worker/client/prepare-avatar-image.node.test.ts
@@ -147,4 +147,31 @@ test('prepareAvatarImage converts, resizes, crops, and rejects unusable photos',
 			}),
 		),
 	).rejects.toThrow(`${userAvatarMaxSourceBytes} bytes`)
+
+	const stubborn = new File(
+		[new Uint8Array(userAvatarMaxSourceBytes + 1)],
+		'huge.avif',
+		{ type: 'image/avif' },
+	)
+	const stubbornWidths: Array<number> = []
+	const prepared = await prepareAvatarImage(
+		stubborn,
+		createHost({
+			width: 8000,
+			height: 8000,
+			encode: (request) => {
+				stubbornWidths.push(request.width)
+				const stillTooBig = request.width >= userAvatarBrowserEncodeMaxDimension
+				return new Blob(
+					[new Uint8Array(stillTooBig ? userAvatarMaxSourceBytes + 1 : 12)],
+					{ type: 'image/webp' },
+				)
+			},
+		}),
+	)
+	expect(prepared.size).toBe(12)
+	expect(stubbornWidths[0]).toBe(userAvatarBrowserEncodeMaxDimension)
+	expect(stubbornWidths.at(-1)).toBeLessThan(
+		userAvatarBrowserEncodeMaxDimension,
+	)
 })

--- a/packages/worker/client/prepare-avatar-image.ts
+++ b/packages/worker/client/prepare-avatar-image.ts
@@ -8,7 +8,7 @@ import {
 	type UserAvatarOutputContentType,
 } from '#universal/user-avatar-limits.ts'
 
-/** Longest side written by the browser encoder. Server still allows 4096. */
+/** Longest side the browser encoder writes. Server still allows 4096. */
 export const userAvatarBrowserEncodeMaxDimension = 1024
 
 export type AvatarImageBitmap = {

--- a/packages/worker/client/prepare-avatar-image.ts
+++ b/packages/worker/client/prepare-avatar-image.ts
@@ -1,0 +1,368 @@
+import {
+	isUserAvatarOutputContentType,
+	normalizeUserAvatarContentType,
+	userAvatarMaxAspectRatio,
+	userAvatarMaxDimension,
+	userAvatarMaxSourceBytes,
+	userAvatarMinDimension,
+	type UserAvatarOutputContentType,
+} from '#universal/user-avatar-limits.ts'
+
+/** Longest side written by the browser encoder. Server still allows 4096. */
+export const userAvatarBrowserEncodeMaxDimension = 1024
+
+export type AvatarImageBitmap = {
+	width: number
+	height: number
+	close?: () => void
+}
+
+export type EncodeAvatarImageInput = {
+	source: AvatarImageBitmap
+	sourceX: number
+	sourceY: number
+	sourceWidth: number
+	sourceHeight: number
+	width: number
+	height: number
+	contentType: UserAvatarOutputContentType
+	quality: number
+}
+
+export type PrepareAvatarImageHost = {
+	decodeImage: (file: File) => Promise<AvatarImageBitmap>
+	encodeImage: (input: EncodeAvatarImageInput) => Promise<Blob>
+}
+
+type CropRect = {
+	sourceX: number
+	sourceY: number
+	sourceWidth: number
+	sourceHeight: number
+}
+
+const defaultHost: PrepareAvatarImageHost = {
+	decodeImage: decodeImageWithBrowser,
+	encodeImage: encodeImageWithBrowser,
+}
+
+export async function prepareAvatarImage(
+	file: File,
+	host: PrepareAvatarImageHost = defaultHost,
+): Promise<File> {
+	if (file.size === 0) {
+		throw new Error('Avatar file is required.')
+	}
+
+	let bitmap: AvatarImageBitmap
+	try {
+		bitmap = await host.decodeImage(file)
+	} catch (error) {
+		if (error instanceof Error) throw error
+		throw createDecodeError(file)
+	}
+
+	try {
+		return await prepareDecodedAvatarImage(file, bitmap, host)
+	} finally {
+		bitmap.close?.()
+	}
+}
+
+async function prepareDecodedAvatarImage(
+	file: File,
+	bitmap: AvatarImageBitmap,
+	host: PrepareAvatarImageHost,
+): Promise<File> {
+	if (
+		!Number.isFinite(bitmap.width) ||
+		!Number.isFinite(bitmap.height) ||
+		bitmap.width < userAvatarMinDimension ||
+		bitmap.height < userAvatarMinDimension
+	) {
+		throw new Error(
+			`Avatars must be between ${userAvatarMinDimension}px and ${userAvatarMaxDimension}px on each side.`,
+		)
+	}
+
+	const crop = cropToMaxAspect(bitmap.width, bitmap.height)
+	const needsCrop =
+		crop.sourceX !== 0 ||
+		crop.sourceY !== 0 ||
+		crop.sourceWidth !== bitmap.width ||
+		crop.sourceHeight !== bitmap.height
+	const acceptedType = normalizeUserAvatarContentType(file.type)
+	const alreadyFitsServer =
+		acceptedType !== null &&
+		file.size <= userAvatarMaxSourceBytes &&
+		bitmap.width <= userAvatarMaxDimension &&
+		bitmap.height <= userAvatarMaxDimension &&
+		!needsCrop
+
+	if (alreadyFitsServer) return file
+
+	let longest = Math.max(crop.sourceWidth, crop.sourceHeight)
+	let quality = 0.86
+	const preferredTypes = preferredOutputTypes(file)
+
+	for (let attempt = 0; attempt < 12; attempt++) {
+		const scaled = scaleToMaxDimension(
+			crop.sourceWidth,
+			crop.sourceHeight,
+			Math.min(longest, userAvatarBrowserEncodeMaxDimension),
+		)
+		if (
+			scaled.width < userAvatarMinDimension ||
+			scaled.height < userAvatarMinDimension
+		) {
+			throw new Error(
+				`Avatars must be between ${userAvatarMinDimension}px and ${userAvatarMaxDimension}px on each side.`,
+			)
+		}
+
+		const blob = await encodeWithFallback(host, {
+			source: bitmap,
+			...crop,
+			width: scaled.width,
+			height: scaled.height,
+			contentType: preferredTypes[0] ?? 'image/jpeg',
+			quality,
+		})
+		if (blob.size <= userAvatarMaxSourceBytes) {
+			const contentType =
+				normalizeUserAvatarContentType(blob.type) ??
+				preferredTypes[0] ??
+				'image/jpeg'
+			return new File([blob], fileNameForContentType(file.name, contentType), {
+				type: contentType,
+				lastModified: file.lastModified,
+			})
+		}
+
+		if (quality > 0.55) {
+			quality = Math.max(0.5, quality - 0.12)
+			continue
+		}
+		if (longest > 256) {
+			longest = Math.max(256, Math.floor(longest * 0.75))
+			quality = 0.86
+			continue
+		}
+
+		throw new Error(
+			`Avatars must be between 1 byte and ${userAvatarMaxSourceBytes} bytes.`,
+		)
+	}
+
+	throw new Error(
+		`Avatars must be between 1 byte and ${userAvatarMaxSourceBytes} bytes.`,
+	)
+}
+
+function preferredOutputTypes(file: File): Array<UserAvatarOutputContentType> {
+	if (file.type === 'image/png')
+		return ['image/png', 'image/webp', 'image/jpeg']
+	return ['image/webp', 'image/jpeg']
+}
+
+async function encodeWithFallback(
+	host: PrepareAvatarImageHost,
+	input: EncodeAvatarImageInput,
+): Promise<Blob> {
+	const requested = [input.contentType, 'image/jpeg', 'image/png'] as const
+	const seen = new Set<UserAvatarOutputContentType>()
+	for (const contentType of requested) {
+		if (seen.has(contentType)) continue
+		seen.add(contentType)
+		const blob = await host.encodeImage({ ...input, contentType })
+		if (blob.size === 0) continue
+		if (
+			blob.type === '' ||
+			isUserAvatarOutputContentType(blob.type) ||
+			blob.type === contentType
+		) {
+			return blob
+		}
+	}
+	throw new Error('Unable to convert that image in the browser.')
+}
+
+export function cropToMaxAspect(
+	width: number,
+	height: number,
+	maxAspect = userAvatarMaxAspectRatio,
+): CropRect {
+	const longer = Math.max(width, height)
+	const shorter = Math.min(width, height)
+	if (shorter <= 0 || longer / shorter <= maxAspect) {
+		return {
+			sourceX: 0,
+			sourceY: 0,
+			sourceWidth: width,
+			sourceHeight: height,
+		}
+	}
+	if (width >= height) {
+		const sourceWidth = Math.floor(height * maxAspect)
+		return {
+			sourceX: Math.floor((width - sourceWidth) / 2),
+			sourceY: 0,
+			sourceWidth,
+			sourceHeight: height,
+		}
+	}
+	const sourceHeight = Math.floor(width * maxAspect)
+	return {
+		sourceX: 0,
+		sourceY: Math.floor((height - sourceHeight) / 2),
+		sourceWidth: width,
+		sourceHeight,
+	}
+}
+
+export function scaleToMaxDimension(
+	width: number,
+	height: number,
+	maxDimension: number,
+): { width: number; height: number } {
+	const longest = Math.max(width, height)
+	if (longest <= maxDimension) return { width, height }
+	const scale = maxDimension / longest
+	return {
+		width: Math.max(1, Math.round(width * scale)),
+		height: Math.max(1, Math.round(height * scale)),
+	}
+}
+
+export function isHeicLikeFile(file: File): boolean {
+	const type = file.type.toLowerCase()
+	const name = file.name.toLowerCase()
+	return (
+		type === 'image/heic' ||
+		type === 'image/heif' ||
+		name.endsWith('.heic') ||
+		name.endsWith('.heif')
+	)
+}
+
+function fileNameForContentType(
+	originalName: string,
+	contentType: UserAvatarOutputContentType,
+): string {
+	const trimmed = originalName.trim()
+	const base = trimmed.replace(/\.[^.]+$/, '') || 'avatar'
+	switch (contentType) {
+		case 'image/png':
+			return `${base}.png`
+		case 'image/jpeg':
+			return `${base}.jpg`
+		case 'image/webp':
+			return `${base}.webp`
+		default: {
+			const unreachable: never = contentType
+			throw new Error(`Unsupported avatar content type: ${unreachable}`)
+		}
+	}
+}
+
+function createDecodeError(file: File): Error {
+	if (isHeicLikeFile(file)) {
+		return new Error(
+			'This browser cannot convert HEIC photos. Open this page in Safari, or export the photo as JPEG.',
+		)
+	}
+	return new Error(
+		'Could not read that image in the browser. Try a PNG, JPEG, WebP, AVIF, or HEIC photo.',
+	)
+}
+
+async function decodeImageWithBrowser(file: File): Promise<AvatarImageBitmap> {
+	if (typeof createImageBitmap === 'function') {
+		try {
+			return await createImageBitmap(file, { imageOrientation: 'from-image' })
+		} catch {
+			// Some browsers expose HEIC/AVIF only through HTMLImageElement.
+		}
+	}
+	if (typeof Image === 'undefined' || typeof URL === 'undefined') {
+		throw createDecodeError(file)
+	}
+
+	const objectUrl = URL.createObjectURL(file)
+	try {
+		const image = new Image()
+		image.src = objectUrl
+		await image.decode()
+		if (typeof createImageBitmap === 'function') {
+			return await createImageBitmap(image, { imageOrientation: 'from-image' })
+		}
+		return image
+	} catch {
+		throw createDecodeError(file)
+	} finally {
+		URL.revokeObjectURL(objectUrl)
+	}
+}
+
+async function encodeImageWithBrowser(
+	input: EncodeAvatarImageInput,
+): Promise<Blob> {
+	const source = input.source as CanvasImageSource
+	if (typeof OffscreenCanvas === 'function') {
+		const canvas = new OffscreenCanvas(input.width, input.height)
+		const context = canvas.getContext('2d')
+		if (context) {
+			context.drawImage(
+				source,
+				input.sourceX,
+				input.sourceY,
+				input.sourceWidth,
+				input.sourceHeight,
+				0,
+				0,
+				input.width,
+				input.height,
+			)
+			if (typeof canvas.convertToBlob === 'function') {
+				return await canvas.convertToBlob({
+					type: input.contentType,
+					quality: input.quality,
+				})
+			}
+		}
+	}
+
+	if (typeof document === 'undefined') {
+		throw new Error('Unable to convert that image in the browser.')
+	}
+
+	const canvas = document.createElement('canvas')
+	canvas.width = input.width
+	canvas.height = input.height
+	const context = canvas.getContext('2d')
+	if (!context) {
+		throw new Error('Unable to convert that image in the browser.')
+	}
+	context.drawImage(
+		source,
+		input.sourceX,
+		input.sourceY,
+		input.sourceWidth,
+		input.sourceHeight,
+		0,
+		0,
+		input.width,
+		input.height,
+	)
+	const blob = await new Promise<Blob | null>((resolve, reject) => {
+		try {
+			canvas.toBlob(resolve, input.contentType, input.quality)
+		} catch (error) {
+			reject(error)
+		}
+	})
+	if (!blob) {
+		throw new Error('Unable to convert that image in the browser.')
+	}
+	return blob
+}

--- a/packages/worker/client/prepare-avatar-image.ts
+++ b/packages/worker/client/prepare-avatar-image.ts
@@ -34,7 +34,7 @@ export type PrepareAvatarImageHost = {
 	encodeImage: (input: EncodeAvatarImageInput) => Promise<Blob>
 }
 
-type CropRect = {
+export type AvatarCropRect = {
 	sourceX: number
 	sourceY: number
 	sourceWidth: number
@@ -46,22 +46,26 @@ const defaultHost: PrepareAvatarImageHost = {
 	encodeImage: encodeImageWithBrowser,
 }
 
-export async function prepareAvatarImage(
+export async function decodeAvatarImage(
 	file: File,
 	host: PrepareAvatarImageHost = defaultHost,
-): Promise<File> {
+): Promise<AvatarImageBitmap> {
 	if (file.size === 0) {
 		throw new Error('Avatar file is required.')
 	}
-
-	let bitmap: AvatarImageBitmap
 	try {
-		bitmap = await host.decodeImage(file)
+		return await host.decodeImage(file)
 	} catch (error) {
 		if (error instanceof Error) throw error
 		throw createDecodeError(file)
 	}
+}
 
+export async function prepareAvatarImage(
+	file: File,
+	host: PrepareAvatarImageHost = defaultHost,
+): Promise<File> {
+	const bitmap = await decodeAvatarImage(file, host)
 	try {
 		return await prepareDecodedAvatarImage(file, bitmap, host)
 	} finally {
@@ -69,10 +73,11 @@ export async function prepareAvatarImage(
 	}
 }
 
-async function prepareDecodedAvatarImage(
+export async function prepareDecodedAvatarImage(
 	file: File,
 	bitmap: AvatarImageBitmap,
-	host: PrepareAvatarImageHost,
+	host: PrepareAvatarImageHost = defaultHost,
+	requestedCrop?: AvatarCropRect,
 ): Promise<File> {
 	if (
 		!Number.isFinite(bitmap.width) ||
@@ -85,7 +90,8 @@ async function prepareDecodedAvatarImage(
 		)
 	}
 
-	const crop = cropToMaxAspect(bitmap.width, bitmap.height)
+	const crop = requestedCrop ?? cropToMaxAspect(bitmap.width, bitmap.height)
+	assertCropFitsBitmap(bitmap, crop)
 	const needsCrop =
 		crop.sourceX !== 0 ||
 		crop.sourceY !== 0 ||
@@ -162,6 +168,25 @@ async function prepareDecodedAvatarImage(
 	)
 }
 
+function assertCropFitsBitmap(bitmap: AvatarImageBitmap, crop: AvatarCropRect) {
+	if (
+		!Number.isFinite(crop.sourceX) ||
+		!Number.isFinite(crop.sourceY) ||
+		!Number.isFinite(crop.sourceWidth) ||
+		!Number.isFinite(crop.sourceHeight) ||
+		crop.sourceX < 0 ||
+		crop.sourceY < 0 ||
+		crop.sourceWidth < userAvatarMinDimension ||
+		crop.sourceHeight < userAvatarMinDimension ||
+		crop.sourceX + crop.sourceWidth > bitmap.width ||
+		crop.sourceY + crop.sourceHeight > bitmap.height
+	) {
+		throw new Error(
+			`Avatars must be between ${userAvatarMinDimension}px and ${userAvatarMaxDimension}px on each side.`,
+		)
+	}
+}
+
 function preferredOutputTypes(file: File): Array<UserAvatarOutputContentType> {
 	if (file.type === 'image/png')
 		return ['image/png', 'image/webp', 'image/jpeg']
@@ -194,7 +219,7 @@ export function cropToMaxAspect(
 	width: number,
 	height: number,
 	maxAspect = userAvatarMaxAspectRatio,
-): CropRect {
+): AvatarCropRect {
 	const longer = Math.max(width, height)
 	const shorter = Math.min(width, height)
 	if (shorter <= 0 || longer / shorter <= maxAspect) {
@@ -229,12 +254,36 @@ export function scaleToMaxDimension(
 	maxDimension: number,
 ): { width: number; height: number } {
 	const longest = Math.max(width, height)
-	if (longest <= maxDimension) return { width, height }
-	const scale = maxDimension / longest
-	return {
-		width: Math.max(1, Math.round(width * scale)),
-		height: Math.max(1, Math.round(height * scale)),
+	const scaled =
+		longest <= maxDimension
+			? { width, height }
+			: {
+					width: Math.max(1, Math.round(width * (maxDimension / longest))),
+					height: Math.max(1, Math.round(height * (maxDimension / longest))),
+				}
+	return clampEncodedAspect(scaled.width, scaled.height)
+}
+
+/**
+ * Rounding after a max-dimension scale can push a 3:1 crop just over the
+ * server's `longer / shorter > 3` check (1200×400 → 1024×341). Grow the
+ * shorter side so the encoded canvas stays within the stored-avatar limit.
+ */
+export function clampEncodedAspect(
+	width: number,
+	height: number,
+	maxAspect = userAvatarMaxAspectRatio,
+): { width: number; height: number } {
+	const longer = Math.max(width, height)
+	const shorter = Math.min(width, height)
+	if (shorter <= 0 || longer / shorter <= maxAspect) {
+		return { width, height }
 	}
+	const minShorter = Math.ceil(longer / maxAspect)
+	if (width >= height) {
+		return { width, height: minShorter }
+	}
+	return { width: minShorter, height }
 }
 
 export function isHeicLikeFile(file: File): boolean {

--- a/packages/worker/client/prepare-avatar-image.ts
+++ b/packages/worker/client/prepare-avatar-image.ts
@@ -101,7 +101,10 @@ async function prepareDecodedAvatarImage(
 
 	if (alreadyFitsServer) return file
 
-	let longest = Math.max(crop.sourceWidth, crop.sourceHeight)
+	let longest = Math.min(
+		Math.max(crop.sourceWidth, crop.sourceHeight),
+		userAvatarBrowserEncodeMaxDimension,
+	)
 	let quality = 0.86
 	const preferredTypes = preferredOutputTypes(file)
 

--- a/packages/worker/client/routes/account-avatar-editor.tsx
+++ b/packages/worker/client/routes/account-avatar-editor.tsx
@@ -1,0 +1,770 @@
+import { css, ref, type Handle } from 'remix/ui'
+import { on } from '#client/event-mixin.ts'
+import {
+	clampTransform,
+	coverScale,
+	cropRectFromTransform,
+	initialCoverTransform,
+	maxScale,
+	panBy,
+	resizeTransform,
+	zoomAtPoint,
+	type AvatarCropBounds,
+	type AvatarCropTransform,
+} from '#client/avatar-crop.ts'
+import {
+	decodeAvatarImage,
+	prepareDecodedAvatarImage,
+	scaleToMaxDimension,
+	type AvatarImageBitmap,
+} from '#client/prepare-avatar-image.ts'
+import {
+	userAvatarMaxDimension,
+	userAvatarMinDimension,
+} from '#universal/user-avatar-limits.ts'
+import {
+	getGhostButtonCss,
+	getPillButtonCss,
+	mergeCss,
+} from '#universal/styles/style-primitives.ts'
+import {
+	colors,
+	mq,
+	radius,
+	shadows,
+	spacing,
+	typography,
+} from '#universal/styles/tokens.ts'
+import { accountFieldNoteCss } from '#client/routes/account-management-components.tsx'
+
+const previewMaxDimension = 1600
+const zoomStep = 1.15
+const panStep = 16
+
+type EditorStatus = 'idle' | 'decoding' | 'ready' | 'applying'
+
+export function AccountAvatarEditor(
+	handle: Handle<{
+		file: File | null
+		onCancel: () => void
+		onApply: (prepared: File) => void
+	}>,
+) {
+	let dialogNode: HTMLDialogElement | null = null
+	let stageNode: HTMLElement | null = null
+	let imageNode: HTMLImageElement | null = null
+	let zoomInputNode: HTMLInputElement | null = null
+	let status: EditorStatus = 'idle'
+	let error: string | null = null
+	let bitmap: AvatarImageBitmap | null = null
+	let previewUrl: string | null = null
+	let viewportSize = 280
+	let transform: AvatarCropTransform = { scale: 1, offsetX: 0, offsetY: 0 }
+	let activeFile: File | null = null
+	let loadGeneration = 0
+
+	function currentBounds(): AvatarCropBounds | null {
+		if (!bitmap) return null
+		return {
+			imageWidth: bitmap.width,
+			imageHeight: bitmap.height,
+			viewportSize,
+		}
+	}
+
+	function releasePreview() {
+		if (previewUrl) URL.revokeObjectURL(previewUrl)
+		previewUrl = null
+	}
+
+	function releaseBitmap() {
+		bitmap?.close?.()
+		bitmap = null
+		releasePreview()
+	}
+
+	function applyVisuals() {
+		const bounds = currentBounds()
+		if (!imageNode || !bounds) return
+		imageNode.style.width = `${bounds.imageWidth * transform.scale}px`
+		imageNode.style.height = `${bounds.imageHeight * transform.scale}px`
+		imageNode.style.transform = `translate(${transform.offsetX}px, ${transform.offsetY}px)`
+		if (zoomInputNode) {
+			zoomInputNode.value = String(transform.scale)
+		}
+	}
+
+	function setTransform(next: AvatarCropTransform) {
+		const bounds = currentBounds()
+		transform = bounds ? clampTransform(bounds, next) : next
+		applyVisuals()
+	}
+
+	function zoomFromCenter(nextScale: number) {
+		const bounds = currentBounds()
+		if (!bounds) return
+		setTransform(
+			zoomAtPoint(
+				bounds,
+				transform,
+				nextScale,
+				bounds.viewportSize / 2,
+				bounds.viewportSize / 2,
+			),
+		)
+	}
+
+	function unlockScroll() {
+		if (typeof document === 'undefined') return
+		document.body.style.overflow = ''
+	}
+
+	function lockScroll() {
+		if (typeof document === 'undefined') return
+		document.body.style.overflow = 'hidden'
+	}
+
+	function closeEditor() {
+		loadGeneration += 1
+		releaseBitmap()
+		status = 'idle'
+		error = null
+		activeFile = null
+		unlockScroll()
+		dialogNode?.close()
+		handle.props.onCancel()
+	}
+
+	async function applyCrop() {
+		const file = handle.props.file
+		const bounds = currentBounds()
+		if (!file || !bitmap || !bounds || status !== 'ready') return
+		status = 'applying'
+		error = null
+		handle.update()
+		try {
+			const prepared = await prepareDecodedAvatarImage(
+				file,
+				bitmap,
+				undefined,
+				cropRectFromTransform(bounds, transform),
+			)
+			releaseBitmap()
+			status = 'idle'
+			activeFile = null
+			unlockScroll()
+			dialogNode?.close()
+			handle.props.onApply(prepared)
+		} catch (caught) {
+			error =
+				caught instanceof Error
+					? caught.message
+					: 'Unable to prepare that avatar.'
+			status = 'ready'
+			handle.update()
+		}
+	}
+
+	function startLoad(file: File | null) {
+		const generation = ++loadGeneration
+		void (async () => {
+			releaseBitmap()
+			error = null
+			if (!file) {
+				unlockScroll()
+				dialogNode?.close()
+				if (generation !== loadGeneration) return
+				status = 'idle'
+				handle.update()
+				return
+			}
+			lockScroll()
+			dialogNode?.showModal()
+			try {
+				const nextBitmap = await decodeAvatarImage(file)
+				if (generation !== loadGeneration) {
+					nextBitmap.close?.()
+					return
+				}
+				if (
+					nextBitmap.width < userAvatarMinDimension ||
+					nextBitmap.height < userAvatarMinDimension
+				) {
+					nextBitmap.close?.()
+					throw new Error(
+						`Avatars must be between ${userAvatarMinDimension}px and ${userAvatarMaxDimension}px on each side.`,
+					)
+				}
+				bitmap = nextBitmap
+				previewUrl = await createPreviewObjectUrl(nextBitmap, file)
+				if (generation !== loadGeneration) {
+					releaseBitmap()
+					return
+				}
+				const measured = stageNode?.clientWidth
+				if (measured && measured > 0) viewportSize = measured
+				transform = initialCoverTransform({
+					imageWidth: nextBitmap.width,
+					imageHeight: nextBitmap.height,
+					viewportSize,
+				})
+				status = 'ready'
+			} catch (caught) {
+				if (generation !== loadGeneration) return
+				releaseBitmap()
+				error =
+					caught instanceof Error
+						? caught.message
+						: 'Could not read that image in the browser.'
+				status = 'idle'
+			}
+			handle.update()
+		})()
+	}
+
+	function attachStage(node: HTMLElement, signal: AbortSignal) {
+		stageNode = node
+		const pointers = new Map<number, { x: number; y: number }>()
+		let pinchDistance = 0
+		let lastX = 0
+		let lastY = 0
+
+		const observer = new ResizeObserver(() => {
+			const nextSize = node.clientWidth
+			const bounds = currentBounds()
+			if (!bounds || nextSize <= 0 || nextSize === viewportSize) return
+			transform = resizeTransform(
+				bounds,
+				{ ...bounds, viewportSize: nextSize },
+				transform,
+			)
+			viewportSize = nextSize
+			applyVisuals()
+		})
+		observer.observe(node)
+
+		function handlePointerDown(event: PointerEvent) {
+			if (event.button !== 0) return
+			event.preventDefault()
+			node.setPointerCapture(event.pointerId)
+			pointers.set(event.pointerId, { x: event.clientX, y: event.clientY })
+			lastX = event.clientX
+			lastY = event.clientY
+			if (pointers.size === 2) {
+				const [first, second] = Array.from(pointers.values())
+				if (!first || !second) return
+				pinchDistance = Math.hypot(first.x - second.x, first.y - second.y)
+			}
+		}
+
+		function handlePointerMove(event: PointerEvent) {
+			if (!pointers.has(event.pointerId)) return
+			event.preventDefault()
+			pointers.set(event.pointerId, { x: event.clientX, y: event.clientY })
+			const bounds = currentBounds()
+			if (!bounds) return
+			if (pointers.size >= 2) {
+				const [first, second] = Array.from(pointers.values())
+				if (!first || !second || pinchDistance <= 0) return
+				const nextDistance = Math.hypot(first.x - second.x, first.y - second.y)
+				const midpoint = {
+					x: (first.x + second.x) / 2,
+					y: (first.y + second.y) / 2,
+				}
+				const rect = node.getBoundingClientRect()
+				setTransform(
+					zoomAtPoint(
+						bounds,
+						transform,
+						transform.scale * (nextDistance / pinchDistance),
+						midpoint.x - rect.left,
+						midpoint.y - rect.top,
+					),
+				)
+				pinchDistance = nextDistance
+				return
+			}
+			setTransform(
+				panBy(bounds, transform, event.clientX - lastX, event.clientY - lastY),
+			)
+			lastX = event.clientX
+			lastY = event.clientY
+		}
+
+		function handlePointerUp(event: PointerEvent) {
+			if (!pointers.has(event.pointerId)) return
+			pointers.delete(event.pointerId)
+			if (pointers.size === 1) {
+				const remaining = Array.from(pointers.values())[0]
+				if (remaining) {
+					lastX = remaining.x
+					lastY = remaining.y
+				}
+				pinchDistance = 0
+			}
+			if (pointers.size === 0) handle.update()
+		}
+
+		function handleWheel(event: WheelEvent) {
+			event.preventDefault()
+			const bounds = currentBounds()
+			if (!bounds) return
+			const point = {
+				x: event.clientX - node.getBoundingClientRect().left,
+				y: event.clientY - node.getBoundingClientRect().top,
+			}
+			setTransform(
+				zoomAtPoint(
+					bounds,
+					transform,
+					transform.scale * Math.exp(-event.deltaY * 0.002),
+					point.x,
+					point.y,
+				),
+			)
+		}
+
+		node.addEventListener('pointerdown', handlePointerDown)
+		node.addEventListener('pointermove', handlePointerMove)
+		node.addEventListener('pointerup', handlePointerUp)
+		node.addEventListener('pointercancel', handlePointerUp)
+		node.addEventListener('wheel', handleWheel, { passive: false })
+		signal.addEventListener('abort', () => {
+			observer.disconnect()
+			node.removeEventListener('pointerdown', handlePointerDown)
+			node.removeEventListener('pointermove', handlePointerMove)
+			node.removeEventListener('pointerup', handlePointerUp)
+			node.removeEventListener('pointercancel', handlePointerUp)
+			node.removeEventListener('wheel', handleWheel)
+			if (stageNode === node) stageNode = null
+		})
+		const measured = node.clientWidth
+		const bounds = currentBounds()
+		if (measured > 0 && bounds && measured !== viewportSize) {
+			transform = resizeTransform(
+				bounds,
+				{ ...bounds, viewportSize: measured },
+				transform,
+			)
+			viewportSize = measured
+		}
+		applyVisuals()
+	}
+
+	return () => {
+		const file = handle.props.file
+		if (file !== activeFile && status !== 'applying') {
+			activeFile = file
+			status = file ? 'decoding' : 'idle'
+			error = file ? null : error
+			handle.queueTask(() => {
+				startLoad(file)
+			})
+		}
+
+		const bounds = currentBounds()
+		const cover = bounds ? coverScale(bounds) : 1
+		const zoomMax = bounds ? maxScale(bounds) : 1
+		const canZoom = zoomMax - cover > 0.001
+		const busy = status === 'decoding' || status === 'applying'
+		const canApply = status === 'ready' && Boolean(bitmap) && !error
+
+		return (
+			<dialog
+				aria-labelledby="avatar-editor-title"
+				data-testid="account-avatar-editor"
+				mix={[
+					css(editorDialogCss),
+					ref((node, signal) => {
+						if (!(node instanceof HTMLDialogElement)) return
+						dialogNode = node
+						if (handle.props.file && !node.open) node.showModal()
+						signal.addEventListener('abort', () => {
+							if (dialogNode === node) dialogNode = null
+						})
+					}),
+					on('cancel', (event) => {
+						event.preventDefault()
+						if (status === 'applying') return
+						closeEditor()
+					}),
+					on('keydown', (event) => {
+						if (!(event instanceof KeyboardEvent) || status !== 'ready') return
+						const key = event.key
+						if (key === 'ArrowLeft') {
+							event.preventDefault()
+							const next = currentBounds()
+							if (next) setTransform(panBy(next, transform, panStep, 0))
+							return
+						}
+						if (key === 'ArrowRight') {
+							event.preventDefault()
+							const next = currentBounds()
+							if (next) setTransform(panBy(next, transform, -panStep, 0))
+							return
+						}
+						if (key === 'ArrowUp') {
+							event.preventDefault()
+							const next = currentBounds()
+							if (next) setTransform(panBy(next, transform, 0, panStep))
+							return
+						}
+						if (key === 'ArrowDown') {
+							event.preventDefault()
+							const next = currentBounds()
+							if (next) setTransform(panBy(next, transform, 0, -panStep))
+							return
+						}
+						if (key === '+' || key === '=') {
+							event.preventDefault()
+							zoomFromCenter(transform.scale * zoomStep)
+							return
+						}
+						if (key === '-' || key === '_') {
+							event.preventDefault()
+							zoomFromCenter(transform.scale / zoomStep)
+						}
+					}),
+				]}
+			>
+				<div mix={css(editorShellCss)}>
+					<div mix={css(editorCopyCss)}>
+						<h3 id="avatar-editor-title" mix={css(editorTitleCss)}>
+							Crop your avatar
+						</h3>
+						<p mix={css(accountFieldNoteCss)}>
+							Drag to reposition. Pinch, scroll, or use the slider to zoom. The
+							circle is how your avatar will look.
+						</p>
+					</div>
+					{status === 'decoding' ? (
+						<p mix={css(accountFieldNoteCss)}>Reading photo…</p>
+					) : null}
+					{status === 'ready' && previewUrl ? (
+						<div
+							data-testid="account-avatar-editor-stage"
+							role="img"
+							aria-label="Avatar crop preview"
+							mix={[
+								css(editorStageCss),
+								ref((node, signal) => {
+									if (!(node instanceof HTMLElement)) return
+									attachStage(node, signal)
+								}),
+							]}
+						>
+							<img
+								src={previewUrl}
+								alt=""
+								draggable={false}
+								mix={[
+									css(editorImageCss),
+									ref((node) => {
+										if (!(node instanceof HTMLImageElement)) return
+										imageNode = node
+										applyVisuals()
+									}),
+								]}
+							/>
+							<div mix={css(editorCircleMaskCss)} />
+						</div>
+					) : null}
+					{status === 'ready' ? (
+						<div mix={css(editorZoomRowCss)}>
+							<button
+								type="button"
+								aria-label="Zoom out"
+								disabled={!canZoom || transform.scale <= cover}
+								mix={[
+									css(editorZoomButtonCss),
+									on('click', () => {
+										zoomFromCenter(transform.scale / zoomStep)
+										handle.update()
+									}),
+								]}
+							>
+								−
+							</button>
+							<input
+								type="range"
+								min={cover}
+								max={zoomMax}
+								step="any"
+								value={transform.scale}
+								disabled={!canZoom}
+								aria-label="Zoom"
+								data-testid="account-avatar-editor-zoom"
+								mix={[
+									css(editorZoomSliderCss),
+									ref((node) => {
+										zoomInputNode =
+											node instanceof HTMLInputElement ? node : null
+									}),
+									on('input', (event) => {
+										if (!(event.currentTarget instanceof HTMLInputElement)) {
+											return
+										}
+										zoomFromCenter(Number(event.currentTarget.value))
+									}),
+								]}
+							/>
+							<button
+								type="button"
+								aria-label="Zoom in"
+								disabled={!canZoom || transform.scale >= zoomMax}
+								mix={[
+									css(editorZoomButtonCss),
+									on('click', () => {
+										zoomFromCenter(transform.scale * zoomStep)
+										handle.update()
+									}),
+								]}
+							>
+								+
+							</button>
+						</div>
+					) : null}
+					{error ? (
+						<p
+							role="alert"
+							mix={css({
+								margin: 0,
+								color: colors.error,
+								fontSize: typography.fontSize.sm,
+							})}
+						>
+							{error}
+						</p>
+					) : null}
+					<div mix={css(editorActionsCss)}>
+						<button
+							type="button"
+							disabled={status === 'applying'}
+							data-testid="account-avatar-editor-cancel"
+							mix={[
+								css(editorGhostButtonCss),
+								on('click', () => {
+									if (status === 'applying') return
+									closeEditor()
+								}),
+							]}
+						>
+							Cancel
+						</button>
+						<button
+							type="button"
+							disabled={!canApply || busy}
+							data-testid="account-avatar-editor-apply"
+							mix={[
+								css(editorApplyButtonCss),
+								on('click', () => {
+									void applyCrop()
+								}),
+							]}
+						>
+							{status === 'applying' ? 'Preparing…' : 'Use photo'}
+						</button>
+					</div>
+				</div>
+			</dialog>
+		)
+	}
+}
+
+async function createPreviewObjectUrl(
+	bitmap: AvatarImageBitmap,
+	file: File,
+): Promise<string> {
+	try {
+		const scaled = scaleToMaxDimension(
+			bitmap.width,
+			bitmap.height,
+			previewMaxDimension,
+		)
+		const canvas = document.createElement('canvas')
+		canvas.width = scaled.width
+		canvas.height = scaled.height
+		const context = canvas.getContext('2d')
+		if (!context)
+			throw new Error('Unable to convert that image in the browser.')
+		context.drawImage(
+			bitmap as CanvasImageSource,
+			0,
+			0,
+			bitmap.width,
+			bitmap.height,
+			0,
+			0,
+			scaled.width,
+			scaled.height,
+		)
+		const blob = await new Promise<Blob | null>((resolve, reject) => {
+			try {
+				canvas.toBlob(resolve, 'image/jpeg', 0.82)
+			} catch (caught) {
+				reject(caught)
+			}
+		})
+		if (!blob) throw new Error('Unable to convert that image in the browser.')
+		return URL.createObjectURL(blob)
+	} catch {
+		return URL.createObjectURL(file)
+	}
+}
+
+const editorDialogCss = {
+	width: 'min(28rem, calc(100vw - 1.5rem))',
+	maxWidth: '100vw',
+	maxHeight: '100dvh',
+	margin: 'auto',
+	padding: 0,
+	border: `1px solid ${colors.border}`,
+	borderRadius: radius.lg,
+	boxShadow: shadows.md,
+	backgroundColor: colors.surface,
+	color: colors.text,
+	overflow: 'auto',
+	overscrollBehavior: 'contain',
+	'&::backdrop': {
+		backgroundColor: 'oklch(0 0 0 / 0.55)',
+	},
+	[mq.mobile]: {
+		width: '100vw',
+		height: '100dvh',
+		maxHeight: '100dvh',
+		margin: 0,
+		border: 'none',
+		borderRadius: 0,
+	},
+}
+
+const editorShellCss = {
+	display: 'grid',
+	gap: spacing.md,
+	minHeight: 0,
+	padding: spacing.lg,
+	paddingBottom: `max(${spacing.lg}, env(safe-area-inset-bottom))`,
+	paddingLeft: `max(${spacing.md}, env(safe-area-inset-left))`,
+	paddingRight: `max(${spacing.md}, env(safe-area-inset-right))`,
+	[mq.mobile]: {
+		minHeight: '100dvh',
+		gridTemplateRows: 'auto auto 1fr auto auto',
+		alignContent: 'start',
+	},
+}
+
+const editorCopyCss = {
+	display: 'grid',
+	gap: spacing.sm,
+}
+
+const editorTitleCss = {
+	margin: 0,
+	fontSize: '1.2rem',
+	fontWeight: 720,
+	letterSpacing: '-0.014em',
+	lineHeight: 1.2,
+}
+
+const editorStageCss = {
+	position: 'relative' as const,
+	width: 'min(22rem, 100%)',
+	aspectRatio: '1',
+	marginInline: 'auto',
+	overflow: 'hidden',
+	borderRadius: radius.md,
+	backgroundColor: colors.background,
+	touchAction: 'none',
+	cursor: 'grab',
+	userSelect: 'none',
+	outline: 'none',
+	'&:focus-visible': {
+		boxShadow: `0 0 0 3px ${colors.primarySoft}`,
+	},
+	[mq.mobile]: {
+		width: 'min(22rem, calc(100vw - 2rem))',
+		maxHeight: 'min(22rem, calc(100dvh - 16rem))',
+	},
+}
+
+const editorImageCss = {
+	position: 'absolute' as const,
+	top: 0,
+	left: 0,
+	maxWidth: 'none',
+	maxHeight: 'none',
+	pointerEvents: 'none',
+	userSelect: 'none',
+}
+
+const editorCircleMaskCss = {
+	position: 'absolute' as const,
+	inset: 0,
+	borderRadius: '50%',
+	border: `2px solid ${colors.onPrimary}`,
+	boxShadow: `0 0 0 999px color-mix(in srgb, ${colors.background} 58%, transparent)`,
+	pointerEvents: 'none',
+}
+
+const editorZoomRowCss = {
+	display: 'grid',
+	gridTemplateColumns: 'auto 1fr auto',
+	alignItems: 'center',
+	gap: spacing.sm,
+}
+
+const editorZoomButtonCss = mergeCss(getGhostButtonCss({ size: 'sm' }), {
+	minWidth: '2.75rem',
+	minHeight: '2.75rem',
+	padding: 0,
+	fontSize: '1.25rem',
+	lineHeight: 1,
+	touchAction: 'manipulation',
+})
+
+const editorZoomSliderCss = {
+	width: '100%',
+	height: '2.75rem',
+	margin: 0,
+	accentColor: colors.primary,
+	touchAction: 'none',
+	'&::-webkit-slider-thumb': {
+		width: '1.5rem',
+		height: '1.5rem',
+	},
+	'&::-moz-range-thumb': {
+		width: '1.5rem',
+		height: '1.5rem',
+	},
+}
+
+const editorActionsCss = {
+	display: 'flex',
+	justifyContent: 'flex-end',
+	flexWrap: 'wrap' as const,
+	gap: spacing.sm,
+	[mq.mobile]: {
+		display: 'grid',
+		gridTemplateColumns: '1fr 1fr',
+		position: 'sticky' as const,
+		bottom: 0,
+		paddingTop: spacing.sm,
+		backgroundColor: colors.surface,
+	},
+}
+
+const editorGhostButtonCss = mergeCss(getGhostButtonCss({ size: 'sm' }), {
+	touchAction: 'manipulation',
+	[mq.mobile]: {
+		minHeight: '2.75rem',
+		width: '100%',
+	},
+})
+
+const editorApplyButtonCss = mergeCss(getPillButtonCss({ size: 'sm' }), {
+	touchAction: 'manipulation',
+	[mq.mobile]: {
+		minHeight: '2.75rem',
+		width: '100%',
+	},
+})

--- a/packages/worker/client/routes/account-avatar-editor.tsx
+++ b/packages/worker/client/routes/account-avatar-editor.tsx
@@ -48,6 +48,7 @@ export function AccountAvatarEditor(
 		file: File | null
 		onCancel: () => void
 		onApply: (prepared: File) => void
+		onBusyChange: (busy: boolean) => void
 	}>,
 ) {
 	let dialogNode: HTMLDialogElement | null = null
@@ -141,6 +142,7 @@ export function AccountAvatarEditor(
 		if (!file || !bitmap || !bounds || status !== 'ready') return
 		status = 'applying'
 		error = null
+		handle.props.onBusyChange(true)
 		handle.update()
 		try {
 			const prepared = await prepareDecodedAvatarImage(
@@ -161,6 +163,7 @@ export function AccountAvatarEditor(
 					? caught.message
 					: 'Unable to prepare that avatar.'
 			status = 'ready'
+			handle.props.onBusyChange(false)
 			handle.update()
 		}
 	}
@@ -351,6 +354,16 @@ export function AccountAvatarEditor(
 		applyVisuals()
 	}
 
+	handle.signal.addEventListener(
+		'abort',
+		() => {
+			loadGeneration += 1
+			releaseBitmap()
+			unlockScroll()
+		},
+		{ once: true },
+	)
+
 	return () => {
 		const file = handle.props.file
 		if (file !== activeFile && status !== 'applying') {
@@ -390,6 +403,13 @@ export function AccountAvatarEditor(
 					}),
 					on('keydown', (event) => {
 						if (!(event instanceof KeyboardEvent) || status !== 'ready') return
+						if (
+							event.target === zoomInputNode ||
+							(event.target instanceof HTMLInputElement &&
+								event.target.type === 'range')
+						) {
+							return
+						}
 						const key = event.key
 						if (key === 'ArrowLeft') {
 							event.preventDefault()

--- a/packages/worker/client/routes/account-avatar-editor.tsx
+++ b/packages/worker/client/routes/account-avatar-editor.tsx
@@ -97,8 +97,15 @@ export function AccountAvatarEditor(
 
 	function setTransform(next: AvatarCropTransform) {
 		const bounds = currentBounds()
+		const previousScale = transform.scale
 		transform = bounds ? clampTransform(bounds, next) : next
 		applyVisuals()
+		// Wheel and pinch update the image immediately. Remix still owns the
+		// slider `value` and zoom-button disabled state, so a scale change
+		// without `handle.update()` leaves those controls on the last render.
+		if (Math.abs(transform.scale - previousScale) > 0.0001) {
+			handle.update()
+		}
 	}
 
 	function zoomFromCenter(nextScale: number) {

--- a/packages/worker/client/routes/account.tsx
+++ b/packages/worker/client/routes/account.tsx
@@ -2,7 +2,7 @@ import { type Handle, css } from 'remix/ui'
 import { getOauthLoginErrorMessage } from '#universal/oauth-login-errors.ts'
 import { on } from '#client/event-mixin.ts'
 import { listenForAvatarFileDrop } from '#client/listen-for-avatar-file-drop.ts'
-import { prepareAvatarImage } from '#client/prepare-avatar-image.ts'
+import { AccountAvatarEditor } from '#client/routes/account-avatar-editor.tsx'
 import { passwordManagerIgnoreProps } from '#client/password-manager-ignore.ts'
 import { readCurrentRouterHref } from '#client/client-router.tsx'
 import { ProviderIcon } from '#client/provider-icons.tsx'
@@ -155,7 +155,8 @@ export function AccountRoute(handle: Handle) {
 	let savedBio = ''
 	let savedProfileVisibility: ProfileVisibility = 'public'
 	let avatarUrl: string | null = null
-	let avatarStatus: 'idle' | 'preparing' | 'uploading' | 'removing' = 'idle'
+	let avatarStatus: 'idle' | 'editing' | 'uploading' | 'removing' = 'idle'
+	let editorFile: File | null = null
 	let avatarDropActive = false
 	let draftEmail = ''
 	let emailChangePassword = ''
@@ -391,22 +392,34 @@ export function AccountRoute(handle: Handle) {
 				handle.update()
 			},
 			onImageFile(file) {
-				void uploadAvatarFile(file)
+				openAvatarEditor(file)
 			},
 		})
 	}
 
-	async function uploadAvatarFile(file: File) {
-		if (avatarStatus !== 'idle') return
-		avatarStatus = 'preparing'
+	function openAvatarEditor(file: File) {
+		if (avatarStatus !== 'idle' && avatarStatus !== 'editing') return
+		editorFile = file
+		avatarStatus = 'editing'
+		message = null
+		messageTone = 'info'
+		handle.update()
+	}
+
+	function closeAvatarEditor() {
+		editorFile = null
+		if (avatarStatus === 'editing') avatarStatus = 'idle'
+		handle.update()
+	}
+
+	async function uploadPreparedAvatar(prepared: File) {
+		editorFile = null
+		avatarStatus = 'uploading'
 		message = null
 		messageTone = 'info'
 		handle.update()
 
 		try {
-			const prepared = await prepareAvatarImage(file)
-			avatarStatus = 'uploading'
-			handle.update()
 			const body = new FormData()
 			body.set('avatar', prepared)
 			const response = await fetch(accountAvatarApiPath, {
@@ -438,11 +451,11 @@ export function AccountRoute(handle: Handle) {
 		}
 	}
 
-	async function handleAvatarSelected(event: Event) {
+	function handleAvatarSelected(event: Event) {
 		const input = event.currentTarget
 		if (!(input instanceof HTMLInputElement) || !input.files?.[0]) return
 		try {
-			await uploadAvatarFile(input.files[0])
+			openAvatarEditor(input.files[0])
 		} finally {
 			input.value = ''
 		}
@@ -808,9 +821,9 @@ export function AccountRoute(handle: Handle) {
 											/>
 										</label>
 										<p mix={css(accountFieldNoteCss)}>
-											HEIC, AVIF, and large photos are converted and resized in
-											the browser. You can also drop a photo anywhere on this
-											page.
+											Choose a photo, then crop and zoom. HEIC, AVIF, and other
+											formats are converted to PNG, JPEG, or WebP in the
+											browser. You can also drop a photo anywhere on this page.
 										</p>
 										{avatarUrl ? (
 											<button
@@ -827,9 +840,6 @@ export function AccountRoute(handle: Handle) {
 													? 'Removing...'
 													: 'Remove avatar'}
 											</button>
-										) : null}
-										{avatarStatus === 'preparing' ? (
-											<p mix={css(accountFieldNoteCss)}>Preparing avatar…</p>
 										) : null}
 										{avatarStatus === 'uploading' ? (
 											<p mix={css(accountFieldNoteCss)}>Uploading avatar…</p>
@@ -1259,6 +1269,13 @@ export function AccountRoute(handle: Handle) {
 					</>
 				) : null}
 
+				<AccountAvatarEditor
+					file={editorFile}
+					onCancel={closeAvatarEditor}
+					onApply={(prepared) => {
+						void uploadPreparedAvatar(prepared)
+					}}
+				/>
 				{avatarDropActive ? (
 					<div
 						role="status"

--- a/packages/worker/client/routes/account.tsx
+++ b/packages/worker/client/routes/account.tsx
@@ -23,6 +23,7 @@ import { UserAvatar } from '#universal/user-avatar.tsx'
 import {
 	colors,
 	radius,
+	shadows,
 	spacing,
 	typography,
 } from '#universal/styles/tokens.ts'
@@ -30,9 +31,12 @@ import {
 	getDangerPillCss,
 	getGhostButtonCss,
 	getPillButtonCss,
+	hoverMq,
 	mutedLinkCss,
+	visuallyHiddenCss,
 } from '#universal/styles/style-primitives.ts'
 import { queueSessionRefresh } from '#client/session.ts'
+import { toast } from '#client/toast.ts'
 import {
 	type AccountStatus,
 	accountProfileApiPath,
@@ -155,6 +159,7 @@ export function AccountRoute(handle: Handle) {
 	let savedBio = ''
 	let savedProfileVisibility: ProfileVisibility = 'public'
 	let avatarUrl: string | null = null
+	let optimisticAvatarObjectUrl: string | null = null
 	let avatarStatus: 'idle' | 'editing' | 'uploading' | 'removing' = 'idle'
 	let editorFile: File | null = null
 	let avatarDropActive = false
@@ -381,7 +386,13 @@ export function AccountRoute(handle: Handle) {
 		draftDisplayName = payload.displayName
 		draftBio = payload.bio ?? ''
 		draftProfileVisibility = payload.profileVisibility
-		avatarUrl = payload.avatarUrl
+		if (!optimisticAvatarObjectUrl) avatarUrl = payload.avatarUrl
+	}
+
+	function releaseOptimisticAvatar() {
+		if (!optimisticAvatarObjectUrl) return
+		URL.revokeObjectURL(optimisticAvatarObjectUrl)
+		optimisticAvatarObjectUrl = null
 	}
 
 	if (typeof document !== 'undefined') {
@@ -396,6 +407,14 @@ export function AccountRoute(handle: Handle) {
 			},
 		})
 	}
+
+	handle.signal.addEventListener(
+		'abort',
+		() => {
+			releaseOptimisticAvatar()
+		},
+		{ once: true },
+	)
 
 	function openAvatarEditor(file: File) {
 		if (avatarStatus !== 'idle' && avatarStatus !== 'editing') return
@@ -423,9 +442,11 @@ export function AccountRoute(handle: Handle) {
 
 	async function uploadPreparedAvatar(prepared: File) {
 		editorFile = null
+		const previousAvatarUrl = avatarUrl
+		releaseOptimisticAvatar()
+		optimisticAvatarObjectUrl = URL.createObjectURL(prepared)
+		avatarUrl = optimisticAvatarObjectUrl
 		avatarStatus = 'uploading'
-		message = null
-		messageTone = 'info'
 		handle.update()
 
 		try {
@@ -447,13 +468,15 @@ export function AccountRoute(handle: Handle) {
 			if (!response.ok || !payload?.ok) {
 				throw new Error(payload?.error || 'Unable to upload avatar.')
 			}
+			releaseOptimisticAvatar()
 			applyProfileFields(payload)
-			message = 'Avatar updated.'
-			messageTone = 'info'
+			toast.success('Avatar updated.')
 		} catch (error) {
-			message =
-				error instanceof Error ? error.message : 'Unable to upload avatar.'
-			messageTone = 'error'
+			releaseOptimisticAvatar()
+			avatarUrl = previousAvatarUrl
+			toast.error(
+				error instanceof Error ? error.message : 'Unable to upload avatar.',
+			)
 		} finally {
 			avatarStatus = 'idle'
 			handle.update()
@@ -471,9 +494,10 @@ export function AccountRoute(handle: Handle) {
 	}
 
 	async function handleRemoveAvatar() {
+		const previousAvatarUrl = avatarUrl
+		releaseOptimisticAvatar()
+		avatarUrl = null
 		avatarStatus = 'removing'
-		message = null
-		messageTone = 'info'
 		handle.update()
 
 		try {
@@ -497,12 +521,12 @@ export function AccountRoute(handle: Handle) {
 				throw new Error(payload?.error || 'Unable to remove avatar.')
 			}
 			applyProfileFields(payload)
-			message = 'Avatar removed.'
-			messageTone = 'info'
+			toast.success('Avatar removed.')
 		} catch (error) {
-			message =
-				error instanceof Error ? error.message : 'Unable to remove avatar.'
-			messageTone = 'error'
+			avatarUrl = previousAvatarUrl
+			toast.error(
+				error instanceof Error ? error.message : 'Unable to remove avatar.',
+			)
 		} finally {
 			avatarStatus = 'idle'
 			handle.update()
@@ -806,54 +830,59 @@ export function AccountRoute(handle: Handle) {
 								]}
 							>
 								<div mix={css(avatarSectionCss)} data-testid="account-avatar">
-									<UserAvatar
-										displayName={draftDisplayName || username}
-										avatarUrl={avatarUrl}
-										size={72}
-										testId="account-avatar-image"
-									/>
-									<div mix={css({ display: 'grid', gap: spacing.sm })}>
-										<label mix={css(accountFieldCss)}>
-											<span mix={css(accountFieldLabelCss)}>Avatar</span>
-											<input
-												type="file"
-												name="avatar"
-												data-field-ring
-												accept="image/*,.heic,.heif"
-												disabled={avatarStatus !== 'idle' || isSaving}
-												mix={[
-													css(accountInputCss),
-													on('change', (event) => {
-														void handleAvatarSelected(event)
-													}),
-												]}
-											/>
-										</label>
-										<p mix={css(accountFieldNoteCss)}>
-											Choose a photo, then crop and zoom. HEIC, AVIF, and other
-											formats are converted to PNG, JPEG, or WebP in the
-											browser. You can also drop a photo anywhere on this page.
-										</p>
-										{avatarUrl ? (
-											<button
-												type="button"
-												disabled={avatarStatus !== 'idle' || isSaving}
-												mix={[
-													css(compactGhostButtonCss),
-													on('click', () => {
-														void handleRemoveAvatar()
-													}),
-												]}
-											>
-												{avatarStatus === 'removing'
-													? 'Removing...'
-													: 'Remove avatar'}
-											</button>
-										) : null}
-										{avatarStatus === 'uploading' ? (
-											<p mix={css(accountFieldNoteCss)}>Uploading avatar…</p>
-										) : null}
-									</div>
+									<label
+										mix={css({
+											...avatarEditCss,
+											cursor:
+												avatarStatus !== 'idle' || isSaving
+													? 'not-allowed'
+													: 'pointer',
+											opacity: avatarStatus !== 'idle' || isSaving ? 0.7 : 1,
+										})}
+									>
+										<UserAvatar
+											displayName={draftDisplayName || username}
+											avatarUrl={avatarUrl}
+											size={accountAvatarSize}
+											testId="account-avatar-image"
+										/>
+										<input
+											type="file"
+											name="avatar"
+											accept="image/*,.heic,.heif"
+											disabled={avatarStatus !== 'idle' || isSaving}
+											data-testid="account-avatar-file"
+											mix={[
+												css(visuallyHiddenCss),
+												on('change', (event) => {
+													void handleAvatarSelected(event)
+												}),
+											]}
+										/>
+										<span
+											data-avatar-edit-affordance
+											mix={css(avatarEditAffordanceCss)}
+										>
+											{avatarEditIcon()}
+										</span>
+										<span mix={css(visuallyHiddenCss)}>Change avatar</span>
+									</label>
+									{avatarUrl ? (
+										<button
+											type="button"
+											disabled={avatarStatus !== 'idle' || isSaving}
+											mix={[
+												css(compactGhostButtonCss),
+												on('click', () => {
+													void handleRemoveAvatar()
+												}),
+											]}
+										>
+											{avatarStatus === 'removing'
+												? 'Removing...'
+												: 'Remove avatar'}
+										</button>
+									) : null}
 								</div>
 								<label mix={css(accountFieldCss)}>
 									<span mix={css(accountFieldLabelCss)}>Username</span>
@@ -1338,9 +1367,64 @@ const compactGhostButtonCss = getGhostButtonCss({ size: 'sm' })
 
 const dangerButtonCss = getDangerPillCss({ size: 'sm' })
 
+const accountAvatarSize = 128
+
 const avatarSectionCss = {
-	display: 'flex',
-	alignItems: 'flex-start',
-	gap: spacing.md,
-	flexWrap: 'wrap' as const,
+	display: 'grid',
+	gap: spacing.sm,
+	justifyItems: 'start' as const,
+}
+
+const avatarEditCss = {
+	position: 'relative' as const,
+	display: 'inline-block',
+	width: `${accountAvatarSize}px`,
+	height: `${accountAvatarSize}px`,
+	borderRadius: radius.full,
+	[hoverMq]: {
+		'& [data-avatar-edit-affordance]': {
+			opacity: 0,
+		},
+		'&:hover [data-avatar-edit-affordance], &:focus-within [data-avatar-edit-affordance]':
+			{
+				opacity: 1,
+			},
+	},
+}
+
+const avatarEditAffordanceCss = {
+	position: 'absolute' as const,
+	right: '0.15rem',
+	bottom: '0.15rem',
+	display: 'inline-flex',
+	alignItems: 'center',
+	justifyContent: 'center',
+	width: '2.25rem',
+	height: '2.25rem',
+	borderRadius: radius.full,
+	backgroundColor: colors.surface,
+	color: colors.text,
+	border: `1px solid ${colors.border}`,
+	boxShadow: shadows.md,
+	opacity: 1,
+	pointerEvents: 'none' as const,
+}
+
+function avatarEditIcon() {
+	return (
+		<svg
+			viewBox="0 0 24 24"
+			width="16"
+			height="16"
+			fill="none"
+			stroke="currentColor"
+			stroke-width="2"
+			stroke-linecap="round"
+			stroke-linejoin="round"
+			aria-hidden="true"
+		>
+			<path d="M12 20h9" />
+			<path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z" />
+		</svg>
+	)
 }

--- a/packages/worker/client/routes/account.tsx
+++ b/packages/worker/client/routes/account.tsx
@@ -412,6 +412,15 @@ export function AccountRoute(handle: Handle) {
 		handle.update()
 	}
 
+	function setAvatarEditorBusy(busy: boolean) {
+		if (busy) {
+			avatarStatus = 'uploading'
+		} else if (editorFile) {
+			avatarStatus = 'editing'
+		}
+		handle.update()
+	}
+
 	async function uploadPreparedAvatar(prepared: File) {
 		editorFile = null
 		avatarStatus = 'uploading'
@@ -1272,6 +1281,7 @@ export function AccountRoute(handle: Handle) {
 				<AccountAvatarEditor
 					file={editorFile}
 					onCancel={closeAvatarEditor}
+					onBusyChange={setAvatarEditorBusy}
 					onApply={(prepared) => {
 						void uploadPreparedAvatar(prepared)
 					}}

--- a/packages/worker/client/routes/account.tsx
+++ b/packages/worker/client/routes/account.tsx
@@ -1,6 +1,8 @@
 import { type Handle, css } from 'remix/ui'
 import { getOauthLoginErrorMessage } from '#universal/oauth-login-errors.ts'
 import { on } from '#client/event-mixin.ts'
+import { listenForAvatarFileDrop } from '#client/listen-for-avatar-file-drop.ts'
+import { prepareAvatarImage } from '#client/prepare-avatar-image.ts'
 import { passwordManagerIgnoreProps } from '#client/password-manager-ignore.ts'
 import { readCurrentRouterHref } from '#client/client-router.tsx'
 import { ProviderIcon } from '#client/provider-icons.tsx'
@@ -18,7 +20,12 @@ import {
 import { kodyDiscordInviteUrl } from '#universal/community-links.ts'
 import { routes } from '#universal/routes.ts'
 import { UserAvatar } from '#universal/user-avatar.tsx'
-import { colors, spacing, typography } from '#universal/styles/tokens.ts'
+import {
+	colors,
+	radius,
+	spacing,
+	typography,
+} from '#universal/styles/tokens.ts'
 import {
 	getDangerPillCss,
 	getGhostButtonCss,
@@ -148,7 +155,8 @@ export function AccountRoute(handle: Handle) {
 	let savedBio = ''
 	let savedProfileVisibility: ProfileVisibility = 'public'
 	let avatarUrl: string | null = null
-	let avatarStatus: 'idle' | 'uploading' | 'removing' = 'idle'
+	let avatarStatus: 'idle' | 'preparing' | 'uploading' | 'removing' = 'idle'
+	let avatarDropActive = false
 	let draftEmail = ''
 	let emailChangePassword = ''
 	let message: string | null = null
@@ -375,18 +383,32 @@ export function AccountRoute(handle: Handle) {
 		avatarUrl = payload.avatarUrl
 	}
 
-	async function handleAvatarSelected(event: Event) {
-		const input = event.currentTarget
-		if (!(input instanceof HTMLInputElement) || !input.files?.[0]) return
-		const file = input.files[0]
-		avatarStatus = 'uploading'
+	if (typeof document !== 'undefined') {
+		listenForAvatarFileDrop({
+			signal: handle.signal,
+			onDragActiveChange(active) {
+				avatarDropActive = active
+				handle.update()
+			},
+			onImageFile(file) {
+				void uploadAvatarFile(file)
+			},
+		})
+	}
+
+	async function uploadAvatarFile(file: File) {
+		if (avatarStatus !== 'idle') return
+		avatarStatus = 'preparing'
 		message = null
 		messageTone = 'info'
 		handle.update()
 
 		try {
+			const prepared = await prepareAvatarImage(file)
+			avatarStatus = 'uploading'
+			handle.update()
 			const body = new FormData()
-			body.set('avatar', file)
+			body.set('avatar', prepared)
 			const response = await fetch(accountAvatarApiPath, {
 				method: 'POST',
 				headers: { Accept: 'application/json' },
@@ -412,8 +434,17 @@ export function AccountRoute(handle: Handle) {
 			messageTone = 'error'
 		} finally {
 			avatarStatus = 'idle'
-			input.value = ''
 			handle.update()
+		}
+	}
+
+	async function handleAvatarSelected(event: Event) {
+		const input = event.currentTarget
+		if (!(input instanceof HTMLInputElement) || !input.files?.[0]) return
+		try {
+			await uploadAvatarFile(input.files[0])
+		} finally {
+			input.value = ''
 		}
 	}
 
@@ -766,7 +797,7 @@ export function AccountRoute(handle: Handle) {
 												type="file"
 												name="avatar"
 												data-field-ring
-												accept="image/png,image/jpeg,image/webp"
+												accept="image/*,.heic,.heif"
 												disabled={avatarStatus !== 'idle' || isSaving}
 												mix={[
 													css(accountInputCss),
@@ -776,6 +807,11 @@ export function AccountRoute(handle: Handle) {
 												]}
 											/>
 										</label>
+										<p mix={css(accountFieldNoteCss)}>
+											HEIC, AVIF, and large photos are converted and resized in
+											the browser. You can also drop a photo anywhere on this
+											page.
+										</p>
 										{avatarUrl ? (
 											<button
 												type="button"
@@ -791,6 +827,9 @@ export function AccountRoute(handle: Handle) {
 													? 'Removing...'
 													: 'Remove avatar'}
 											</button>
+										) : null}
+										{avatarStatus === 'preparing' ? (
+											<p mix={css(accountFieldNoteCss)}>Preparing avatar…</p>
 										) : null}
 										{avatarStatus === 'uploading' ? (
 											<p mix={css(accountFieldNoteCss)}>Uploading avatar…</p>
@@ -1220,6 +1259,36 @@ export function AccountRoute(handle: Handle) {
 					</>
 				) : null}
 
+				{avatarDropActive ? (
+					<div
+						role="status"
+						data-testid="account-avatar-drop-overlay"
+						mix={css({
+							position: 'fixed',
+							inset: 0,
+							zIndex: 2000,
+							display: 'grid',
+							placeItems: 'center',
+							backgroundColor:
+								'color-mix(in srgb, var(--color-background) 72%, transparent)',
+							pointerEvents: 'none',
+						})}
+					>
+						<p
+							mix={css({
+								margin: 0,
+								padding: `${spacing.md} ${spacing.lg}`,
+								border: `2px dashed ${colors.primary}`,
+								borderRadius: radius.lg,
+								backgroundColor: colors.surface,
+								color: colors.text,
+								fontWeight: typography.fontWeight.semibold,
+							})}
+						>
+							Drop to set your avatar
+						</p>
+					</div>
+				) : null}
 				<p mix={css({ margin: 0 })}>
 					<a href="/privacy" mix={css(mutedLinkCss)}>
 						Privacy

--- a/packages/worker/client/toast.node.test.ts
+++ b/packages/worker/client/toast.node.test.ts
@@ -1,0 +1,73 @@
+import { expect, test, vi } from 'vitest'
+import { createToastStore } from './toast.ts'
+
+test('toast store auto-dismisses timed toasts, keeps persistent ones, replaces ids, and supports actions', () => {
+	vi.useFakeTimers()
+	try {
+		const store = createToastStore()
+		const listener = vi.fn()
+		const unsubscribe = store.subscribe(listener)
+
+		const successId = store.show('Avatar updated.', { tone: 'success' })
+		expect(store.list()).toEqual([
+			{
+				id: successId,
+				message: 'Avatar updated.',
+				tone: 'success',
+				duration: 4_000,
+				dismissible: true,
+			},
+		])
+		expect(listener).toHaveBeenCalledTimes(1)
+
+		const errorId = store.show('Unable to upload avatar.', { tone: 'error' })
+		expect(store.list().map((item) => item.id)).toEqual([successId, errorId])
+		expect(store.list()[1]).toMatchObject({
+			id: errorId,
+			tone: 'error',
+			duration: null,
+			dismissible: true,
+		})
+
+		vi.advanceTimersByTime(4_000)
+		expect(store.list().map((item) => item.id)).toEqual([errorId])
+		expect(listener).toHaveBeenCalledTimes(3)
+
+		store.show('Unable to upload avatar.', {
+			id: errorId,
+			tone: 'error',
+			description: 'Try a smaller photo.',
+		})
+		expect(store.list()).toHaveLength(1)
+		expect(store.list()[0]).toMatchObject({
+			id: errorId,
+			description: 'Try a smaller photo.',
+		})
+
+		const action = vi.fn()
+		const undoId = store.show('Disconnected Personal.', {
+			tone: 'info',
+			duration: null,
+			action: { label: 'Undo', onClick: action },
+		})
+		expect(store.list().at(-1)).toMatchObject({
+			id: undoId,
+			duration: null,
+			action: { label: 'Undo', onClick: action },
+		})
+
+		store.dismiss(errorId)
+		expect(store.list().map((item) => item.id)).toEqual([undoId])
+		store.list()[0]?.action?.onClick()
+		expect(action).toHaveBeenCalledTimes(1)
+
+		store.dismiss()
+		expect(store.list()).toEqual([])
+		const callsAfterDismissAll = listener.mock.calls.length
+		unsubscribe()
+		store.show('Ignored after unsubscribe.', { duration: 1 })
+		expect(listener).toHaveBeenCalledTimes(callsAfterDismissAll)
+	} finally {
+		vi.useRealTimers()
+	}
+})

--- a/packages/worker/client/toast.ts
+++ b/packages/worker/client/toast.ts
@@ -1,0 +1,157 @@
+export type ToastTone = 'info' | 'success' | 'error'
+
+export type ToastAction = {
+	label: string
+	onClick: () => void
+}
+
+export type ShowToastOptions = {
+	id?: string
+	description?: string
+	tone?: ToastTone
+	/**
+	 * Auto-dismiss delay in milliseconds. `null` or `Infinity` keeps the toast
+	 * until the user dismisses it (or `toast.dismiss` runs).
+	 */
+	duration?: number | null
+	dismissible?: boolean
+	action?: ToastAction
+}
+
+export type ToastRecord = {
+	id: string
+	message: string
+	description?: string
+	tone: ToastTone
+	duration: number | null
+	dismissible: boolean
+	action?: ToastAction
+}
+
+export const defaultToastDurationMs = {
+	info: 4_000,
+	success: 4_000,
+	error: null,
+} as const
+
+let nextToastId = 0
+
+function createToastId() {
+	if (
+		typeof crypto !== 'undefined' &&
+		typeof crypto.randomUUID === 'function'
+	) {
+		return crypto.randomUUID()
+	}
+	nextToastId += 1
+	return `toast-${nextToastId}`
+}
+
+function resolveDuration(
+	tone: ToastTone,
+	duration: number | null | undefined,
+): number | null {
+	if (duration === undefined) return defaultToastDurationMs[tone]
+	if (duration === Infinity) return null
+	if (typeof duration === 'number' && duration <= 0) return null
+	return duration
+}
+
+export function createToastStore() {
+	let items: Array<ToastRecord> = []
+	const timers = new Map<string, ReturnType<typeof setTimeout>>()
+	const listeners = new Set<() => void>()
+
+	function emit() {
+		for (const listener of listeners) listener()
+	}
+
+	function clearTimer(id: string) {
+		const timer = timers.get(id)
+		if (timer === undefined) return
+		clearTimeout(timer)
+		timers.delete(id)
+	}
+
+	function subscribe(listener: () => void) {
+		listeners.add(listener)
+		return () => {
+			listeners.delete(listener)
+		}
+	}
+
+	function list() {
+		return items
+	}
+
+	function dismiss(id?: string) {
+		if (id === undefined) {
+			if (items.length === 0) return
+			for (const item of items) clearTimer(item.id)
+			items = []
+			emit()
+			return
+		}
+		clearTimer(id)
+		const next = items.filter((item) => item.id !== id)
+		if (next.length === items.length) return
+		items = next
+		emit()
+	}
+
+	function show(message: string, options: ShowToastOptions = {}) {
+		const tone = options.tone ?? 'info'
+		const duration = resolveDuration(tone, options.duration)
+		const id = options.id ?? createToastId()
+		const record: ToastRecord = {
+			id,
+			message,
+			tone,
+			duration,
+			dismissible: options.dismissible ?? true,
+		}
+		if (options.description) record.description = options.description
+		if (options.action) record.action = options.action
+		items = [...items.filter((item) => item.id !== id), record]
+		clearTimer(id)
+		if (duration !== null) {
+			timers.set(
+				id,
+				setTimeout(() => {
+					dismiss(id)
+				}, duration),
+			)
+		}
+		emit()
+		return id
+	}
+
+	return { subscribe, list, show, dismiss }
+}
+
+const toastStore = createToastStore()
+
+function showToast(message: string, options?: ShowToastOptions) {
+	return toastStore.show(message, options)
+}
+
+export const toast = Object.assign(showToast, {
+	info(message: string, options?: Omit<ShowToastOptions, 'tone'>) {
+		return toastStore.show(message, { ...options, tone: 'info' })
+	},
+	success(message: string, options?: Omit<ShowToastOptions, 'tone'>) {
+		return toastStore.show(message, { ...options, tone: 'success' })
+	},
+	error(message: string, options?: Omit<ShowToastOptions, 'tone'>) {
+		return toastStore.show(message, { ...options, tone: 'error' })
+	},
+	dismiss: toastStore.dismiss,
+})
+
+export function subscribeToasts(listener: () => void) {
+	return toastStore.subscribe(listener)
+}
+
+export function listToasts() {
+	return toastStore.list()
+}

--- a/packages/worker/client/toaster.tsx
+++ b/packages/worker/client/toaster.tsx
@@ -1,0 +1,182 @@
+import { type Handle, css } from 'remix/ui'
+import { on } from '#client/event-mixin.ts'
+import {
+	listToasts,
+	subscribeToasts,
+	toast,
+	type ToastRecord,
+	type ToastTone,
+} from '#client/toast.ts'
+import {
+	getGhostButtonCss,
+	getPillButtonCss,
+	mergeCss,
+} from '#universal/styles/style-primitives.ts'
+import {
+	colors,
+	radius,
+	shadows,
+	spacing,
+	typography,
+} from '#universal/styles/tokens.ts'
+
+export function Toaster(handle: Handle) {
+	const unsubscribe = subscribeToasts(() => {
+		handle.update()
+	})
+	handle.signal.addEventListener('abort', unsubscribe, { once: true })
+
+	return () => {
+		const toasts = listToasts()
+		if (toasts.length === 0) return null
+
+		return (
+			<ol
+				data-testid="toaster"
+				aria-label="Notifications"
+				mix={css(toasterListCss)}
+			>
+				{toasts.map((item) => (
+					<li key={item.id} mix={css(toastItemCss)}>
+						<ToastCard item={item} />
+					</li>
+				))}
+			</ol>
+		)
+	}
+}
+
+function ToastCard(handle: Handle<{ item: ToastRecord }>) {
+	return () => {
+		const item = handle.props.item
+		const live = item.tone === 'error' ? 'assertive' : 'polite'
+		const role = item.tone === 'error' ? 'alert' : 'status'
+
+		return (
+			<div
+				role={role}
+				aria-live={live}
+				aria-atomic="true"
+				data-testid="toast"
+				data-toast-tone={item.tone}
+				mix={css(toastCardCss(item.tone))}
+			>
+				<div mix={css(toastCopyCss)}>
+					<p mix={css(toastMessageCss)}>{item.message}</p>
+					{item.description ? (
+						<p mix={css(toastDescriptionCss)}>{item.description}</p>
+					) : null}
+				</div>
+				{item.action ? (
+					<button
+						type="button"
+						data-testid="toast-action"
+						mix={[
+							css(toastActionButtonCss),
+							on('click', () => {
+								item.action?.onClick()
+							}),
+						]}
+					>
+						{item.action.label}
+					</button>
+				) : null}
+				{item.dismissible ? (
+					<button
+						type="button"
+						aria-label="Dismiss notification"
+						data-testid="toast-dismiss"
+						mix={[
+							css(toastDismissButtonCss),
+							on('click', () => {
+								toast.dismiss(item.id)
+							}),
+						]}
+					>
+						×
+					</button>
+				) : null}
+			</div>
+		)
+	}
+}
+
+function toastAccent(tone: ToastTone) {
+	switch (tone) {
+		case 'success':
+			return colors.primary
+		case 'error':
+			return colors.error
+		case 'info':
+			return colors.textMuted
+		default: {
+			const exhaustive: never = tone
+			return exhaustive
+		}
+	}
+}
+
+const toasterListCss = {
+	position: 'fixed' as const,
+	left: '50%',
+	bottom: `max(${spacing.xl}, env(safe-area-inset-bottom))`,
+	transform: 'translateX(-50%)',
+	zIndex: 1100,
+	display: 'grid',
+	gap: spacing.sm,
+	margin: 0,
+	padding: 0,
+	listStyle: 'none',
+	width: 'min(36rem, calc(100vw - 2rem))',
+	pointerEvents: 'none' as const,
+}
+
+const toastItemCss = {
+	pointerEvents: 'auto' as const,
+}
+
+function toastCardCss(tone: ToastTone) {
+	return {
+		display: 'flex',
+		alignItems: 'center',
+		gap: spacing.md,
+		padding: `${spacing.sm} ${spacing.md}`,
+		backgroundColor: colors.surface,
+		color: colors.text,
+		boxShadow: shadows.md,
+		borderRadius: radius.lg,
+		border: `1px solid ${colors.border}`,
+		borderLeft: `3px solid ${toastAccent(tone)}`,
+		borderTopLeftRadius: 0,
+		borderBottomLeftRadius: 0,
+	}
+}
+
+const toastCopyCss = {
+	display: 'grid',
+	gap: '0.15rem',
+	minWidth: 0,
+	flex: 1,
+}
+
+const toastMessageCss = {
+	margin: 0,
+	fontSize: typography.fontSize.sm,
+	fontWeight: typography.fontWeight.medium,
+}
+
+const toastDescriptionCss = {
+	margin: 0,
+	fontSize: typography.fontSize.sm,
+	color: colors.textMuted,
+}
+
+const toastActionButtonCss = getPillButtonCss({ size: 'sm' })
+
+const toastDismissButtonCss = mergeCss(getGhostButtonCss({ size: 'sm' }), {
+	minWidth: '2.25rem',
+	minHeight: '2.25rem',
+	padding: 0,
+	fontSize: '1.25rem',
+	lineHeight: 1,
+})

--- a/packages/worker/src/community/avatar.ts
+++ b/packages/worker/src/community/avatar.ts
@@ -1,6 +1,14 @@
 import { toHex } from '@kody-internal/shared/hex.ts'
 import { utcSqliteTimestamp } from '@kody-internal/shared/date-keys.ts'
 import {
+	normalizeUserAvatarContentType,
+	userAvatarMaxAspectRatio,
+	userAvatarMaxDimension,
+	userAvatarMaxSourceBytes,
+	userAvatarMinDimension,
+	type UserAvatarOutputContentType,
+} from '#universal/user-avatar-limits.ts'
+import {
 	assertAccountWritableDb,
 	withAccountWriteLease,
 } from '#worker/account/deletion-state.ts'
@@ -11,14 +19,10 @@ import {
 	readWebpDimensions,
 } from './community-icon.ts'
 
-const maxUserAvatarSourceBytes = 1_000_000
-const minUserAvatarDimension = 64
-const maxUserAvatarDimension = 4096
-const maxUserAvatarAspectRatio = 3
 const userAvatarR2KeyPrefix = 'user-avatars/'
 const userAvatarCacheControl = 'public, max-age=31536000, immutable'
 
-export type UserAvatarContentType = 'image/png' | 'image/jpeg' | 'image/webp'
+export type UserAvatarContentType = UserAvatarOutputContentType
 
 type ProcessedUserAvatar = {
 	bytes: Uint8Array
@@ -37,23 +41,6 @@ function extensionForContentType(contentType: UserAvatarContentType) {
 			const unreachable: never = contentType
 			throw new Error(`Unsupported avatar content type: ${unreachable}`)
 		}
-	}
-}
-
-function normalizeAvatarContentType(
-	contentType: string,
-): UserAvatarContentType | null {
-	const normalized = contentType.trim().toLowerCase()
-	switch (normalized) {
-		case 'image/png':
-			return 'image/png'
-		case 'image/jpeg':
-		case 'image/jpg':
-			return 'image/jpeg'
-		case 'image/webp':
-			return 'image/webp'
-		default:
-			return null
 	}
 }
 
@@ -83,9 +70,9 @@ export function splitUserAvatarCacheKey(
 }
 
 function assertUserAvatarSourceSize(bytes: Uint8Array) {
-	if (bytes.byteLength === 0 || bytes.byteLength > maxUserAvatarSourceBytes) {
+	if (bytes.byteLength === 0 || bytes.byteLength > userAvatarMaxSourceBytes) {
 		throw new Error(
-			`Avatars must be between 1 byte and ${maxUserAvatarSourceBytes} bytes.`,
+			`Avatars must be between 1 byte and ${userAvatarMaxSourceBytes} bytes.`,
 		)
 	}
 }
@@ -97,20 +84,20 @@ function assertUserAvatarDimensions(dimensions: {
 	if (
 		!Number.isInteger(dimensions.width) ||
 		!Number.isInteger(dimensions.height) ||
-		dimensions.width < minUserAvatarDimension ||
-		dimensions.height < minUserAvatarDimension ||
-		dimensions.width > maxUserAvatarDimension ||
-		dimensions.height > maxUserAvatarDimension
+		dimensions.width < userAvatarMinDimension ||
+		dimensions.height < userAvatarMinDimension ||
+		dimensions.width > userAvatarMaxDimension ||
+		dimensions.height > userAvatarMaxDimension
 	) {
 		throw new Error(
-			`Avatars must be between ${minUserAvatarDimension}px and ${maxUserAvatarDimension}px on each side.`,
+			`Avatars must be between ${userAvatarMinDimension}px and ${userAvatarMaxDimension}px on each side.`,
 		)
 	}
 	const longer = Math.max(dimensions.width, dimensions.height)
 	const shorter = Math.min(dimensions.width, dimensions.height)
-	if (longer / shorter > maxUserAvatarAspectRatio) {
+	if (longer / shorter > userAvatarMaxAspectRatio) {
 		throw new Error(
-			`Avatars must have an aspect ratio of at most ${maxUserAvatarAspectRatio}:1.`,
+			`Avatars must have an aspect ratio of at most ${userAvatarMaxAspectRatio}:1.`,
 		)
 	}
 }
@@ -137,7 +124,7 @@ export function processUserAvatar(input: {
 	contentType: string
 	sourceBytes: Uint8Array
 }): ProcessedUserAvatar {
-	const contentType = normalizeAvatarContentType(input.contentType)
+	const contentType = normalizeUserAvatarContentType(input.contentType)
 	if (!contentType) {
 		throw new Error('Avatars must be PNG, JPEG, or WebP images.')
 	}

--- a/packages/worker/universal/user-avatar-limits.ts
+++ b/packages/worker/universal/user-avatar-limits.ts
@@ -1,0 +1,35 @@
+export const userAvatarMaxSourceBytes = 1_000_000
+export const userAvatarMinDimension = 64
+export const userAvatarMaxDimension = 4096
+export const userAvatarMaxAspectRatio = 3
+export const userAvatarOutputContentTypes = [
+	'image/png',
+	'image/jpeg',
+	'image/webp',
+] as const
+
+export type UserAvatarOutputContentType =
+	(typeof userAvatarOutputContentTypes)[number]
+
+export function normalizeUserAvatarContentType(
+	contentType: string,
+): UserAvatarOutputContentType | null {
+	const normalized = contentType.trim().toLowerCase()
+	switch (normalized) {
+		case 'image/png':
+			return 'image/png'
+		case 'image/jpeg':
+		case 'image/jpg':
+			return 'image/jpeg'
+		case 'image/webp':
+			return 'image/webp'
+		default:
+			return null
+	}
+}
+
+export function isUserAvatarOutputContentType(
+	contentType: string,
+): contentType is UserAvatarOutputContentType {
+	return normalizeUserAvatarContentType(contentType) !== null
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Make avatar upload work the way people expect: convert phone photos in the browser, let you crop and zoom (including on a phone), shrink oversized images before they hit the 1 MB server limit, and stop dragged files from navigating the app away.

## Why

iPhone photos are often HEIC (or huge JPEGs). The account page only accepted PNG/JPEG/WebP and posted the raw file, so those uploads failed or refreshed the tab when dropped anywhere on the page. Auto-crop plus scale could also round a 3:1 banner just past the server aspect check (`1024×341`). Avatars render as circles, so people need to frame the photo themselves.

## Summary

- Click the avatar (pencil on hover/focus; always visible on coarse pointers) or drop a photo on `/account` to open a square crop/zoom editor (drag, pinch, wheel, and a large slider). On small screens it is a full-viewport sheet with 44px controls and safe-area padding.
- `Use photo` shows the cropped file on the profile avatar immediately, then encodes PNG/JPEG/WebP under 1 MB and POSTs to the existing avatar API. A failure restores the previous photo.
- Flash copy such as **Avatar updated.** is a fixed, accessible Remix toast (sonner-shaped API, not the React package) so the page does not shift. Success auto-dismisses; errors persist until dismissed.
- Zoom from wheel or pinch now calls `handle.update()` so the slider and ± buttons stay in sync with the image.
- Browser-side `prepareAvatarImage` still decodes HEIC/AVIF when the browser can, and encode retries start from a 1024px cap so large photos actually shrink.
- Scaled 3:1 crops grow the shorter side after rounding so `longer / shorter` never exceeds 3.
- Already-valid small PNG/JPEG/WebP files pass through unchanged when no crop is needed.
- Document-level drag/drop still prevents navigation; only a real `input[type=file]` stays native.

## Why not mediabunny

[Mediabunny](https://mediabunny.dev/guide/introduction) is a video/audio container toolkit (MP4, WebM, HLS, WebCodecs). Resize/crop there is for video tracks, not still photos. It does not read HEIF image items, JPEG, PNG, WebP, or AVIF stills. Using it would add a dependency and still leave us writing `createImageBitmap` + canvas for avatars, so this PR stays on the browser image APIs.

## Testing

- `npx vitest run --project node-unit` on `prepare-avatar-image`, `avatar-crop`, and `toast`
- `npx tsc -b packages/worker/tsconfig-client.json --noEmit`
- Local origin worker on `localhost:3742` as `kody@example.com`: pencil picker, crop/zoom slider stays in sync, Use photo updates the avatar immediately, **Avatar updated.** toast does not shift the form
- Preview `https://kody-pr-1768.kody-a99.workers.dev` as `me@kentcdodds.com` / `user-me`: same UI pass on `wide-banner.png`
- CI on `13b0040e` is green (Static, Node, Workers, MCP, E2E, Validate, Preview deploy)
- Holding merge until you say so.

![Account avatar with pencil, no Choose file](https://cursor.com/artifacts/c/art-fd788ed2-431c-409f-9767-9aca1fc0b863)
![Crop editor with zoom slider](https://cursor.com/artifacts/c/art-d3db0fc8-2d3d-4a65-8e10-42daf5cde0f8)
![Avatar updated toast after Use photo](https://cursor.com/artifacts/c/art-d89da830-2c8a-48d8-886c-a77b017b6b20)
<a href="https://cursor.com/agents/bc-c8691215-669a-44fe-9e6d-03d873e81fcd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Favatar_crop_wes_bos_portrait_demo.mp4"><img src="https://cursor.com/artifacts/c/art-b06fd262-7660-40bf-a4f7-df062b337a22" alt="avatar_crop_wes_bos_portrait_demo.mp4" /></a>
![Preview avatar toast after Use photo](https://cursor.com/artifacts/c/art-58a584f2-f6fc-4a99-a1a2-26d40c7ccab4)

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `ad258e99` · **Head:** `13b0040e`

**Classification:** extends — client avatar upload now converts, crops/zooms, resizes, and accepts page-wide drops; a Remix toast primitive carries flash messages; server stored-avatar contract is unchanged.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | extends — crop/zoom editor, optimistic avatar preview, hover pencil picker, Remix toast primitive, document file-drop guard |
| `community-listings` | assistant | composes — `processUserAvatar` still validates PNG/JPEG/WebP, 1 MB, 64–4096px, 3:1; limits live in `#universal` |

### Change flow

A selected or dropped photo opens a square crop editor; Use photo shows the cropped file immediately and posts it to the existing avatar API. Success and errors land in a fixed toast so the page does not shift.

```mermaid
sequenceDiagram
	actor User
	participant appUi as app-ui
	participant communityListings as community-listings
	User->>appUi: click avatar or drop a photo on /account
	Note over appUi: square crop/zoom editor (drag, pinch, slider)
	appUi->>appUi: encode crop to PNG/JPEG/WebP, clamp 3:1 rounding
	appUi->>appUi: show cropped object URL on the profile avatar
	appUi->>communityListings: POST /account/profile/avatar.json
	alt upload succeeds
		communityListings-->>appUi: profile JSON with avatarUrl
		appUi->>appUi: toast.success Avatar updated (auto-dismiss)
	else upload fails
		appUi->>appUi: restore previous avatar, toast.error (persists)
	end
	Note over appUi: preventDefault on page and label drops; only input[type=file] stays native
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c8691215-669a-44fe-9e6d-03d873e81fcd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c8691215-669a-44fe-9e6d-03d873e81fcd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an avatar crop-and-zoom editor with pan, zoom, and keyboard controls.
  * Added drag-and-drop avatar uploads with image preparation, resizing, conversion, validation, and HEIC support.
  * Added toast notifications for success, errors, and other status updates.
* **Bug Fixes**
  * Prevented accidental navigation when files are dropped outside upload areas.
  * Preserved native file-input behavior during drag-and-drop.
  * Added rollback when avatar updates or removals fail.
* **Documentation**
  * Clarified avatar editing and drag-and-drop behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->