### PR TITLE
Store OAuth tokens on integrations with any/packages grants

### DIFF
--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -1238,12 +1238,15 @@ on write unless a migration backfills existing rows.
   persists host-side and does not use that write grant. Package-scoped secrets
   are owned exclusively by the package id in their bucket binding.
 - `user_oauth_apps.extra_authorize_params_json`,
-  `user_integrations.scopes_json`, and `user_integrations.required_hosts_json`
-  (`0001-squashed-init.sql`, `packages/worker/src/integrations/`) store a
-  string→string object, a scope string list, and a host string list
-  respectively. Parsers in the integrations data-access layer own the shapes;
-  credential values are never stored in these columns (only secret names and the
-  inline non-secret `client_id`).
+  `user_integrations.scopes_json`, `user_integrations.required_hosts_json`, and
+  `user_integrations.allowed_packages_json` (`0001-squashed-init.sql` /
+  `0026-integration-owned-credentials.sql`, `packages/worker/src/integrations/`)
+  store a string→string object, a scope string list, a host string list, and a
+  saved-package-id list respectively. Parsers in the integrations data-access
+  layer own the shapes. Access and refresh token ciphertexts live on
+  `user_integrations`; the user-lane client secret ciphertext lives on
+  `user_oauth_apps`. Account export redacts those columns. `*_secret_name`
+  columns remain for dual-write soak.
 - `user_openapi_bindings.auth_json`, `user_openapi_bindings.selection_json`, and
   `user_openapi_binding_operations.operation_json` (`0001-squashed-init.sql`,
   `packages/worker/src/openapi/`) store the auth discriminant, selection object,

--- a/docs/contributing/architecture/integrations.md
+++ b/docs/contributing/architecture/integrations.md
@@ -152,8 +152,10 @@ query-param tokens). It also refreshes host-side
 (`integration_refresh_access_token` → `refreshIntegrationTokens`) so token
 rotation does not need an `allowed_packages` write grant, then materializes the
 new access token for user-lane integrations and throws for platform ones
-(`integration_get` carries `platform: true`). Unadopted community forks still
-need a read/use grant before the helper will return a raw token. Token-exchange
+(`integration_get` carries `platform: true`). The integration usage grant
+(`any`, or `packages` that includes that package) decides whether a package —
+including an unadopted community fork — can refresh or materialize tokens.
+Token-exchange
 request building is shared:
 `packages/worker/src/integrations/oauth-token-exchange.ts` lives in the
 shared-primitive layer so both the `/connect/oauth` handlers and the MCP refresh

--- a/docs/contributing/architecture/integrations.md
+++ b/docs/contributing/architecture/integrations.md
@@ -155,8 +155,7 @@ new access token for user-lane integrations and throws for platform ones
 (`integration_get` carries `platform: true`). The integration usage grant
 (`any`, or `packages` that includes that package) decides whether a package —
 including an unadopted community fork — can refresh or materialize tokens.
-Token-exchange
-request building is shared:
+Token-exchange request building is shared:
 `packages/worker/src/integrations/oauth-token-exchange.ts` lives in the
 shared-primitive layer so both the `/connect/oauth` handlers and the MCP refresh
 capability use it within the import boundaries.

--- a/docs/contributing/architecture/integrations.md
+++ b/docs/contributing/architecture/integrations.md
@@ -118,10 +118,11 @@ tokens on the connection (and dual-writes the secret-store names during soak),
 and returns only `{ ok, refreshedAt, refreshTokenRotated }` — never token
 values. Platform connections require this path — the shared client secret has no
 user-facing secret name by design. User-lane connections may also refresh
-through it; because their `tokenUrl` is user-configurable, the user lane
-enforces each materialized secret's `allowed_hosts` against the token host
-before the request — the same containment the fetch gateway applied when refresh
-ran in-sandbox via placeholder resolution. Platform-lane destinations are
+through it. Ciphertext-backed refresh enforces the connection's `requiredHosts`
+against the token host. The secret-store fallback (soak / pre-migration rows)
+still enforces that secret's `allowed_hosts`. `integration_save` cannot add new
+hosts or retarget `tokenUrl` to an unapproved host; reconnect at
+`/connect/oauth` to approve a new destination. Platform-lane destinations are
 operator-pinned rows, so no user-secret allowlist applies.
 
 Reconnectable caller-errors (`IntegrationTokenRefreshCallerError`: missing

--- a/docs/contributing/architecture/integrations.md
+++ b/docs/contributing/architecture/integrations.md
@@ -7,8 +7,12 @@ two lanes: **user lane** — a per-user `user_oauth_apps` row the user registere
 with the provider — or **platform lane** — an operator-provisioned built-in
 `platform_oauth_apps` row every user can connect to (see
 [Platform (built-in) OAuth apps](#platform-built-in-oauth-apps)). Per-user
-credential _values_ never enter these tables — they live in the secret store and
-are referenced by name.
+access and refresh tokens live encrypted on the connection
+(`access_token_encrypted` / `refresh_token_encrypted`). User-lane client secrets
+live encrypted on the app (`client_secret_encrypted`). During soak those values
+are dual-written to `secret_entries` under the `*_secret_name` columns so
+placeholder resolution and reconnect still work; those names stay hidden from
+`/account/secrets`, `secret_list`, and search.
 
 Data access lives under `packages/worker/src/integrations/`. MCP capabilities
 live under `packages/worker/src/mcp/capabilities/integrations/`. The hosted
@@ -20,7 +24,10 @@ An **OAuth app** (`user_oauth_apps`) holds the provider client identity and
 endpoint config that many connections can share:
 
 - `client_id` (inline non-secret identifier)
-- `client_secret_secret_name` (secret-store name, or null for public PKCE apps)
+- `client_secret_encrypted` (user-lane AES-GCM ciphertext; purpose
+  `user-oauth-client-secret`)
+- `client_secret_secret_name` (soak dual-write name, or null for public PKCE
+  apps)
 - `token_url`, optional `authorize_url` / `api_base_url`
 - `flow` (`pkce` | `confidential`), optional `use_pkce`, `token_exchange_style`,
   `scope_separator`, and `extra_authorize_params_json`
@@ -33,7 +40,13 @@ either lane:
   `platform_app_slug` (FK to `platform_oauth_apps(slug)`), enforced by a `CHECK`
   constraint
 - `scopes_json`, `required_hosts_json`
-- `access_token_secret_name` and optional `refresh_token_secret_name`
+- `access_token_encrypted` / optional `refresh_token_encrypted` (AES-GCM;
+  purposes `user-oauth-access-token` / `user-oauth-refresh-token`)
+- `access_token_secret_name` and optional `refresh_token_secret_name` (soak
+  dual-write names)
+- `usage_mode` (`any` | `packages`) and `allowed_packages_json` (user-gated
+  grant: `any` is execute plus every package; `packages` is only the listed
+  saved package ids, and execute is denied)
 - optional `account_label` / `description`, plus connect/refresh timestamps
 
 `JoinedIntegration` (`packages/worker/src/integrations/types.ts`) joins a
@@ -52,7 +65,9 @@ isolation structural. Both connection FKs use `ON DELETE RESTRICT`, so
 connections must be removed before their app (user lane) and a platform app
 cannot be deleted while any user's connection references it. Platform-lane
 connections point at a global app row, but the connection itself and its token
-secrets stay scoped by `user_id`, so per-user isolation is unaffected.
+ciphertexts stay scoped by `user_id`, so per-user isolation is unaffected.
+Disconnect deletes that connection's token secrets, not a sibling connection's
+shared user-lane client secret. Deleting the app removes the client secret.
 
 ## Platform (built-in) OAuth apps
 
@@ -99,15 +114,15 @@ Both lanes refresh host-side by default through `createAuthenticatedFetch`.
 `integration_token_refresh` (implemented by `refreshIntegrationTokens` in
 `packages/worker/src/integrations/token-refresh.ts`) resolves the refresh token
 and client secret server-side, POSTs to the provider token URL, persists rotated
-tokens back to the user secret store, and returns only
-`{ ok, refreshedAt, refreshTokenRotated }` — never token values. Platform
-connections require this path — the shared client secret has no user-facing
-secret name by design. User-lane connections may also refresh through it;
-because their `tokenUrl` is user-configurable, the user lane enforces each
-materialized secret's `allowed_hosts` against the token host before the request
-— the same containment the fetch gateway applied when refresh ran in-sandbox via
-placeholder resolution. Platform-lane destinations are operator-pinned rows, so
-no user-secret allowlist applies.
+tokens on the connection (and dual-writes the secret-store names during soak),
+and returns only `{ ok, refreshedAt, refreshTokenRotated }` — never token
+values. Platform connections require this path — the shared client secret has no
+user-facing secret name by design. User-lane connections may also refresh
+through it; because their `tokenUrl` is user-configurable, the user lane
+enforces each materialized secret's `allowed_hosts` against the token host
+before the request — the same containment the fetch gateway applied when refresh
+ran in-sandbox via placeholder resolution. Platform-lane destinations are
+operator-pinned rows, so no user-secret allowlist applies.
 
 Reconnectable caller-errors (`IntegrationTokenRefreshCallerError`: missing
 refresh token, provider HTTP 4xx / `invalid_grant`, missing secrets,
@@ -271,16 +286,21 @@ highlight that connection. User-registered integrations also have
 `/account/integrations/apps/:appSlug` (a connection named `apps` resolves at
 `/account/integrations/apps`). Endpoints, secret names, host allowlists, flow /
 PKCE / exchange style, and credential rotation stay behind an advanced
-disclosure. The rotate form posts to `/account/integrations.json` with
-`action: "rotate_oauth_app_credentials"`: it stores a new client-secret value in
-the secret store (when provided), then calls `rotateOauthAppClientCredentials`
-so every sibling connection picks up the new client id / secret name on the next
-join. Each connection has a double-checked Disconnect control; user-registered
-integrations also have Delete integration. Both are delayed-commit undoable
-actions (`createUndoableAction`): the UI updates immediately, and
-`/account/integrations.json` receives `disconnect_connection` or
-`delete_oauth_app` only after the undo window (or when the user leaves).
-Built-in apps cannot be deleted; disconnect their connections instead.
+disclosure. Each connection also shows a usage grant: **any context** (execute
+and every package) or **specific packages** only. One-click approval lives at
+`/account/integrations/approve?name=&package_id=`; approving a package while the
+connection is still `any` leaves it `any` so execute stays usable. The rotate
+form posts to `/account/integrations.json` with
+`action: "rotate_oauth_app_credentials"`: it stores a new client-secret value on
+the app (and dual-writes the secret store during soak), then calls
+`rotateOauthAppClientCredentials` so every sibling connection picks up the new
+client id / secret name on the next join. Each connection has a double-checked
+Disconnect control; user-registered integrations also have Delete integration.
+Both are delayed-commit undoable actions (`createUndoableAction`): the UI
+updates immediately, and `/account/integrations.json` receives
+`disconnect_connection` or `delete_oauth_app` only after the undo window (or
+when the user leaves). Built-in apps cannot be deleted; disconnect their
+connections instead.
 
 ## Capability surface
 

--- a/docs/contributing/architecture/primitives.yaml
+++ b/docs/contributing/architecture/primitives.yaml
@@ -330,7 +330,8 @@ primitives:
     name: OAuth integrations
     summary:
       Per-user connections over user-owned or platform (built-in) OAuth apps;
-      token secrets stay in the user secret store.
+      access/refresh tokens and user-lane client secrets live encrypted on the
+      connection/app, with a user-gated any/packages grant.
     code:
       - packages/worker/src/integrations/
       - packages/worker/src/mcp/capabilities/integrations/

--- a/docs/use/privacy.md
+++ b/docs/use/privacy.md
@@ -36,10 +36,12 @@ user-owned rows and objects.
 
 When you connect a third-party service — an OAuth app or API key you register
 yourself — Kody stores that connection in your account only: tokens, the scopes
-you granted, and host allowlists. Those credentials stay in the encrypted secret
-store. Your agent and package code refer to them by name; Kody substitutes them
-at the network boundary and never returns the raw value to chat, search, or
-capability output.
+you granted, and host allowlists. OAuth access and refresh tokens, and a
+user-lane app client secret, are stored encrypted on that connection or app.
+Standalone credentials (PATs and API keys) stay in the encrypted secret store.
+Your agent and package code refer to them by name; Kody substitutes them at the
+network boundary and never returns the raw value to chat, search, or capability
+output.
 
 Kody fetches data from a connected service only to fulfill a request you, or a
 job you saved, just made. Content a package or job persists (for example a saved

--- a/docs/use/privacy.md
+++ b/docs/use/privacy.md
@@ -64,10 +64,10 @@ Kody and revoke it at the provider.
 When you connect Google, the rules above apply to Google user data — Calendar,
 Docs, Sheets, Gmail send, Contacts, Tasks, YouTube, and any other Google scopes
 you grant. Kody uses Google user data only to fulfill your request or saved job.
-Kody stores Google OAuth tokens in your encrypted secret store and does not use
-Google user data for advertising. Kody shares, transfers, or discloses Google
-user data only with Cloudflare (hosting), the MCP host you connected when it
-asks Kody to act, Google when Kody calls Google APIs on your behalf, and when
+Kody stores Google OAuth tokens encrypted on that Google connection and does not
+use Google user data for advertising. Kody shares, transfers, or discloses
+Google user data only with Cloudflare (hosting), the MCP host you connected when
+it asks Kody to act, Google when Kody calls Google APIs on your behalf, and when
 required by law.
 
 ## What a deployment admin can see

--- a/docs/use/secrets-and-values.md
+++ b/docs/use/secrets-and-values.md
@@ -152,4 +152,7 @@ storage bucket via `packageStorage()`. See
 
 Durable facts and preferences belong in memories. Package runtime state and
 knobs belong in `packageStorage()`. Versioned config belongs in a repo.
-Credentials belong in secrets. OAuth client ids belong in integrations.
+Credentials belong in secrets. OAuth client ids belong in integrations. OAuth
+access and refresh tokens, and a user-registered app's client secret, live on
+the integration — they do not appear in the Secrets list. PATs, API keys, and
+webhook HMAC secrets stay in the secret store.

--- a/packages/worker/client/lazy-route.tsx
+++ b/packages/worker/client/lazy-route.tsx
@@ -249,6 +249,7 @@ registerPreloadPatterns(
 		routePattern(routes.accountUsage),
 		routePattern(routes.accountIntegrations),
 		routePattern(routes.accountOauthAppDetail),
+		routePattern(routes.accountIntegrationsApprove),
 		routePattern(routes.accountIntegrationDetail),
 		routePattern(routes.accountMcpServers),
 		routePattern(routes.accountMcpServerNew),

--- a/packages/worker/client/routes/account-integrations.tsx
+++ b/packages/worker/client/routes/account-integrations.tsx
@@ -85,7 +85,18 @@ import {
 } from '#universal/styles/style-primitives.ts'
 
 const accountIntegrationsApiPath = routes.accountIntegrationsApi.href()
-const integrationsRoute = createListDetailRoute('/account/integrations')
+const integrationsRoute = createListDetailRoute('/account/integrations', {
+	parseDetailId(pathname) {
+		const prefix = `${routes.accountIntegrations.href()}/`
+		if (!pathname.startsWith(prefix)) return null
+		const segment = pathname.slice(prefix.length)
+		if (!segment || segment.includes('/') || segment === 'approve') {
+			return null
+		}
+		return decodePathSegment(segment)
+	},
+})
+
 const oauthAppsPathPrefix = `${routes.accountIntegrations.href()}/apps/`
 
 function decodePathSegment(value: string) {
@@ -249,8 +260,24 @@ const clampedCellCss = css(recordCellClamp(26))
  * filter do not change the GET response, so keying the latch on the base path
  * avoids spurious refetches when only those URL parts change.
  */
-function getDataLatchKey(_href: string) {
+function getDataLatchKey(href: string) {
+	const url = new URL(href, 'http://localhost')
+	if (url.pathname === routes.accountIntegrationsApprove.href()) {
+		return `${url.pathname}?${url.searchParams.get('name') ?? ''}&${url.searchParams.get('package_id') ?? ''}`
+	}
 	return '/account/integrations'
+}
+
+function buildIntegrationsApiHref(href: string) {
+	const url = new URL(href, 'http://localhost')
+	const requestUrl = new URL(accountIntegrationsApiPath, url.origin)
+	if (url.pathname === routes.accountIntegrationsApprove.href()) {
+		const name = url.searchParams.get('name')
+		const packageId = url.searchParams.get('package_id')
+		if (name) requestUrl.searchParams.set('name', name)
+		if (packageId) requestUrl.searchParams.set('package_id', packageId)
+	}
+	return `${requestUrl.pathname}${requestUrl.search}`
 }
 
 function readSearchFilter(href: string) {
@@ -258,10 +285,10 @@ function readSearchFilter(href: string) {
 }
 
 export async function accountIntegrationsRouteLoader(
-	_url: URL,
+	url: URL,
 	signal: AbortSignal,
 ): Promise<RouteLoaderResult> {
-	const response = await fetch(accountIntegrationsApiPath, {
+	const response = await fetch(buildIntegrationsApiHref(url.toString()), {
 		headers: { Accept: 'application/json' },
 		credentials: 'include',
 		signal,
@@ -639,10 +666,156 @@ const highlightedConnectionCardCss = {
 	borderRadius: `0 ${radius.lg} ${radius.lg} 0`,
 }
 
+function ConnectionUsageForm(
+	handle: Handle<{
+		connection: AccountIntegrationListItem
+		savedPackages: ReadonlyArray<{ id: string; kodyId: string }>
+		draft: { usageMode: 'any' | 'packages'; allowedPackageIds: Array<string> }
+		saving: boolean
+		onDraftChange: (draft: {
+			usageMode: 'any' | 'packages'
+			allowedPackageIds: Array<string>
+		}) => void
+		onSave: () => void
+	}>,
+) {
+	return () => {
+		const { connection, savedPackages, draft, saving, onDraftChange, onSave } =
+			handle.props
+		return (
+			<section
+				data-testid="integration-usage"
+				mix={css({ display: 'grid', gap: spacing.xs })}
+			>
+				<p
+					mix={css({
+						...fieldLabelCss,
+						margin: 0,
+					})}
+				>
+					Usage
+				</p>
+				<label
+					mix={css({
+						display: 'flex',
+						gap: spacing.xs,
+						alignItems: 'flex-start',
+						color: colors.text,
+						fontSize: typography.fontSize.sm,
+					})}
+				>
+					<input
+						type="radio"
+						name={`usage-mode-${connection.name}`}
+						checked={draft.usageMode === 'any'}
+						disabled={saving}
+						mix={[
+							on('change', () =>
+								onDraftChange({
+									usageMode: 'any',
+									allowedPackageIds: [],
+								}),
+							),
+						]}
+					/>
+					<span>Any context (execute and every package)</span>
+				</label>
+				<label
+					mix={css({
+						display: 'flex',
+						gap: spacing.xs,
+						alignItems: 'flex-start',
+						color: colors.text,
+						fontSize: typography.fontSize.sm,
+					})}
+				>
+					<input
+						type="radio"
+						name={`usage-mode-${connection.name}`}
+						checked={draft.usageMode === 'packages'}
+						disabled={saving}
+						mix={[
+							on('change', () =>
+								onDraftChange({
+									usageMode: 'packages',
+									allowedPackageIds: draft.allowedPackageIds,
+								}),
+							),
+						]}
+					/>
+					<span>Specific packages only</span>
+				</label>
+				{draft.usageMode === 'packages' ? (
+					savedPackages.length === 0 ? (
+						<p mix={css({ ...descriptionCss, margin: 0 })}>
+							Save a package first, then approve it here. Execute cannot use
+							this connection while it is limited to specific packages.
+						</p>
+					) : (
+						<div mix={css({ display: 'grid', gap: spacing.xs })}>
+							{savedPackages.map((savedPackage) => {
+								const checked = draft.allowedPackageIds.includes(
+									savedPackage.id,
+								)
+								return (
+									<label
+										key={savedPackage.id}
+										mix={css({
+											display: 'flex',
+											gap: spacing.xs,
+											alignItems: 'center',
+											fontSize: typography.fontSize.sm,
+										})}
+									>
+										<input
+											type="checkbox"
+											checked={checked}
+											disabled={saving}
+											mix={[
+												on('change', () =>
+													onDraftChange({
+														usageMode: 'packages',
+														allowedPackageIds: checked
+															? draft.allowedPackageIds.filter(
+																	(id) => id !== savedPackage.id,
+																)
+															: [...draft.allowedPackageIds, savedPackage.id],
+													}),
+												),
+											]}
+										/>
+										<span>{savedPackage.kodyId}</span>
+									</label>
+								)
+							})}
+						</div>
+					)
+				) : null}
+				<button
+					type="button"
+					data-testid="save-integration-usage"
+					disabled={saving}
+					mix={[css(getPillButtonCss({ size: 'sm' })), on('click', onSave)]}
+				>
+					{saving ? 'Saving…' : 'Save usage'}
+				</button>
+			</section>
+		)
+	}
+}
+
 export function AccountIntegrationsRoute(handle: Handle) {
 	let status: AccountStatus = 'loading'
 	let integrations: Array<AccountIntegrationListItem> = []
 	let apps: Array<AccountOauthAppListItem> = []
+	let savedPackages: Array<{ id: string; kodyId: string }> = []
+	let approval: AccountIntegrationsLoaderData['approval'] = null
+	let usageDrafts = new Map<
+		string,
+		{ usageMode: 'any' | 'packages'; allowedPackageIds: Array<string> }
+	>()
+	let usageSavingName: string | null = null
+	let approvalSubmitting = false
 	let message: string | null = null
 	let rotateClientId = ''
 	let rotateClientSecret = ''
@@ -741,6 +914,95 @@ export function AccountIntegrationsRoute(handle: Handle) {
 		apps = apps.filter(
 			(entry) => integrationListId(entry) !== integrationListId(app),
 		)
+	}
+
+	function usageDraftFor(connection: AccountIntegrationListItem) {
+		return (
+			usageDrafts.get(connection.name) ?? {
+				usageMode: connection.usageMode === 'packages' ? 'packages' : 'any',
+				allowedPackageIds: [...(connection.allowedPackageIds ?? [])],
+			}
+		)
+	}
+
+	function setUsageDraft(
+		name: string,
+		draft: { usageMode: 'any' | 'packages'; allowedPackageIds: Array<string> },
+	) {
+		usageDrafts = new Map(usageDrafts)
+		usageDrafts.set(name, draft)
+		handle.update()
+	}
+
+	async function submitUsage(connection: AccountIntegrationListItem) {
+		if (usageSavingName) return
+		const draft = usageDraftFor(connection)
+		usageSavingName = connection.name
+		handle.update()
+		try {
+			await postIntegrationsMutation({
+				action: 'set_usage',
+				name: connection.name,
+				usageMode: draft.usageMode,
+				allowedPackageIds:
+					draft.usageMode === 'packages' ? draft.allowedPackageIds : [],
+			})
+			integrations = integrations.map((entry) =>
+				entry.name === connection.name
+					? {
+							...entry,
+							usageMode: draft.usageMode,
+							allowedPackageIds:
+								draft.usageMode === 'packages' ? draft.allowedPackageIds : [],
+						}
+					: entry,
+			)
+			usageDrafts = new Map(usageDrafts)
+			usageDrafts.delete(connection.name)
+			message = `Updated usage for ${connectionLabel(connection)}.`
+		} catch (error) {
+			message =
+				error instanceof Error
+					? error.message
+					: 'Unable to update integration usage.'
+		} finally {
+			usageSavingName = null
+			handle.update()
+		}
+	}
+
+	async function submitApproval() {
+		if (!approval || approvalSubmitting) return
+		approvalSubmitting = true
+		handle.update()
+		try {
+			await postIntegrationsMutation({
+				action: 'approve_package',
+				name: approval.name,
+				packageId: approval.packageId,
+			})
+			integrations = integrations.map((entry) => {
+				if (entry.name !== approval?.name) return entry
+				if (entry.usageMode === 'any' || !entry.usageMode) return entry
+				const allowed = new Set(entry.allowedPackageIds ?? [])
+				allowed.add(approval.packageId)
+				return {
+					...entry,
+					usageMode: 'packages',
+					allowedPackageIds: Array.from(allowed),
+				}
+			})
+			approval = approval ? { ...approval, alreadyGranted: true } : approval
+			navigate(routes.accountIntegrations.href())
+		} catch (error) {
+			message =
+				error instanceof Error
+					? error.message
+					: 'Unable to approve that package.'
+		} finally {
+			approvalSubmitting = false
+			handle.update()
+		}
 	}
 
 	async function postIntegrationsMutation(body: Record<string, unknown>) {
@@ -863,7 +1125,7 @@ export function AccountIntegrationsRoute(handle: Handle) {
 		const href = getCurrentHref()
 		const latchKey = getDataLatchKey(href)
 		try {
-			const response = await fetch(accountIntegrationsApiPath, {
+			const response = await fetch(buildIntegrationsApiHref(href), {
 				headers: { Accept: 'application/json' },
 				credentials: 'include',
 				signal,
@@ -880,6 +1142,8 @@ export function AccountIntegrationsRoute(handle: Handle) {
 			if (getDataLatchKey(getCurrentHref()) !== latchKey) return
 			integrations = payload.integrations
 			apps = payload.apps ?? []
+			savedPackages = payload.savedPackages ?? []
+			approval = payload.approval ?? null
 			status = 'ready'
 			message = null
 			loadLatch.markLoaded(latchKey)
@@ -905,6 +1169,8 @@ export function AccountIntegrationsRoute(handle: Handle) {
 		if (!routeData) return false
 		integrations = routeData.integrations
 		apps = routeData.apps ?? []
+		savedPackages = routeData.savedPackages ?? []
+		approval = routeData.approval ?? null
 		status = 'ready'
 		message = null
 		loadLatch.markLoaded(getDataLatchKey(href))
@@ -1063,6 +1329,98 @@ export function AccountIntegrationsRoute(handle: Handle) {
 					>
 						{message}
 					</AccountManagementMessage>
+				) : null}
+
+				{status === 'ready' && approval ? (
+					<section
+						data-testid="integration-approval-card"
+						mix={css({
+							display: 'grid',
+							gap: spacing.md,
+							padding: spacing.lg,
+							borderRadius: radius.lg,
+							border: `1px solid ${colors.primary}`,
+							backgroundColor: colors.primarySoftest,
+							marginBlockEnd: spacing.lg,
+						})}
+					>
+						<div mix={css({ display: 'grid', gap: spacing.xs })}>
+							<h2
+								mix={css({
+									margin: 0,
+									fontSize: typography.fontSize.lg,
+									fontWeight: typography.fontWeight.semibold,
+									color: colors.text,
+								})}
+							>
+								Approve integration access
+							</h2>
+							<p mix={css({ margin: 0, color: colors.textMuted })}>
+								{approval.alreadyGranted ? (
+									<>
+										Package{' '}
+										<strong mix={css({ color: colors.text })}>
+											{approval.packageKodyId ?? approval.packageId}
+										</strong>{' '}
+										can already use integration <code>{approval.name}</code>
+										{approval.usageMode === 'any' ? ' from any context.' : '.'}
+									</>
+								) : (
+									<>
+										Allow package{' '}
+										<strong mix={css({ color: colors.text })}>
+											{approval.packageKodyId ?? approval.packageId}
+										</strong>{' '}
+										to use integration <code>{approval.name}</code>.
+									</>
+								)}
+							</p>
+						</div>
+						<div
+							mix={css({
+								display: 'flex',
+								flexWrap: 'wrap',
+								gap: spacing.xs,
+							})}
+						>
+							{approval.alreadyGranted ? (
+								<a
+									href={routes.accountIntegrations.href()}
+									mix={css({
+										...getPillButtonCss({ size: 'sm' }),
+										display: 'inline-flex',
+										textDecoration: 'none',
+									})}
+								>
+									Back to integrations
+								</a>
+							) : (
+								<>
+									<button
+										type="button"
+										data-testid="approve-integration-package"
+										disabled={approvalSubmitting}
+										mix={[
+											css(getPillButtonCss({ size: 'sm' })),
+											on('click', () => void submitApproval()),
+										]}
+									>
+										{approvalSubmitting ? 'Approving…' : 'Approve'}
+									</button>
+									<a
+										href={routes.accountIntegrations.href()}
+										mix={css({
+											...getPillButtonCss({ size: 'sm' }),
+											display: 'inline-flex',
+											textDecoration: 'none',
+										})}
+									>
+										Cancel
+									</a>
+								</>
+							)}
+						</div>
+					</section>
 				) : null}
 
 				{status === 'ready' ? (
@@ -1298,8 +1656,27 @@ export function AccountIntegrationsRoute(handle: Handle) {
 																					}).length,
 																				})}`
 																			: ''}
+																		{connection
+																			? ` · ${
+																					connection.usageMode === 'packages'
+																						? 'Specific packages'
+																						: 'Any context'
+																				}`
+																			: ''}
 																	</p>
 																</div>
+																{connection ? (
+																	<ConnectionUsageForm
+																		connection={connection}
+																		savedPackages={savedPackages}
+																		draft={usageDraftFor(connection)}
+																		saving={usageSavingName === connection.name}
+																		onDraftChange={(draft) =>
+																			setUsageDraft(connection.name, draft)
+																		}
+																		onSave={() => void submitUsage(connection)}
+																	/>
+																) : null}
 																<div
 																	mix={css({
 																		display: 'flex',

--- a/packages/worker/client/routes/index.tsx
+++ b/packages/worker/client/routes/index.tsx
@@ -46,6 +46,10 @@ export const clientRouteLoaders: Record<string, RouteLoader> = {
 		accountArea,
 		(m) => m.accountIntegrationsRouteLoader,
 	),
+	[routePattern(routes.accountIntegrationsApprove)]: lazyRouteLoader(
+		accountArea,
+		(m) => m.accountIntegrationsRouteLoader,
+	),
 	[routePattern(routes.accountIntegrationDetail)]: lazyRouteLoader(
 		accountArea,
 		(m) => m.accountIntegrationsRouteLoader,
@@ -311,6 +315,9 @@ export const clientRoutes = {
 		<LazyAccountRoute render={(m) => <m.AccountIntegrationsRoute />} />
 	),
 	[routePattern(routes.accountOauthAppDetail)]: (
+		<LazyAccountRoute render={(m) => <m.AccountIntegrationsRoute />} />
+	),
+	[routePattern(routes.accountIntegrationsApprove)]: (
 		<LazyAccountRoute render={(m) => <m.AccountIntegrationsRoute />} />
 	),
 	[routePattern(routes.accountIntegrationDetail)]: (

--- a/packages/worker/migrations/0026-integration-owned-credentials.sql
+++ b/packages/worker/migrations/0026-integration-owned-credentials.sql
@@ -1,0 +1,15 @@
+-- OAuth access/refresh tokens and user-lane client secrets move onto the
+-- integration/app rows (encrypted at rest). usage_mode + allowed_packages_json
+-- are the user-gated grant: 'any' is execute plus every package; 'packages'
+-- is only the listed saved package ids. New connections default to 'any'.
+-- *_secret_name columns stay for dual-write soak and placeholder resolution.
+ALTER TABLE user_integrations ADD COLUMN access_token_encrypted TEXT;
+
+ALTER TABLE user_integrations ADD COLUMN refresh_token_encrypted TEXT;
+
+ALTER TABLE user_integrations ADD COLUMN usage_mode TEXT NOT NULL DEFAULT 'any'
+	CHECK (usage_mode IN ('any', 'packages'));
+
+ALTER TABLE user_integrations ADD COLUMN allowed_packages_json TEXT NOT NULL DEFAULT '[]';
+
+ALTER TABLE user_oauth_apps ADD COLUMN client_secret_encrypted TEXT;

--- a/packages/worker/src/account/data-targets.node.test.ts
+++ b/packages/worker/src/account/data-targets.node.test.ts
@@ -185,6 +185,15 @@ test('every accountUserDataTargets kind has a shared match builder and export gu
 	expect(accountExportRedactedColumnsByTable.secret_entries).toEqual(
 		expect.arrayContaining(['encrypted_value', 'lookup_hash']),
 	)
+	expect(accountExportRedactedColumnsByTable.user_integrations).toEqual(
+		expect.arrayContaining([
+			'access_token_encrypted',
+			'refresh_token_encrypted',
+		]),
+	)
+	expect(accountExportRedactedColumnsByTable.user_oauth_apps).toEqual(
+		expect.arrayContaining(['client_secret_encrypted']),
+	)
 	expect(accountExportForeignUserIdColumnsByTable.user_follows).toEqual(
 		expect.arrayContaining(['follower_user_id', 'followee_user_id']),
 	)

--- a/packages/worker/src/account/data-targets.ts
+++ b/packages/worker/src/account/data-targets.ts
@@ -243,8 +243,8 @@ export const accountUserDataTargets: ReadonlyArray<UserScopedDataTarget> = [
 	},
 	{ kind: 'user_id', table: 'secret_buckets' },
 	// Connections reference OAuth apps with ON DELETE RESTRICT, so delete
-	// user_integrations before user_oauth_apps. Neither table stores credential
-	// values (only secret names + the non-secret OAuth client id).
+	// user_integrations before user_oauth_apps. Ciphertext columns are redacted
+	// on export; secret-name placeholders stay for soak compatibility.
 	{ kind: 'user_id', table: 'user_integrations' },
 	{ kind: 'user_id', table: 'user_oauth_apps' },
 	// OpenAPI binding operations before bindings (composite FK child).
@@ -762,6 +762,8 @@ export const accountExportRedactedColumnsByTable: Readonly<
 	pending_email_changes: ['token_hash'],
 	platform_feedback: ['reviewed_by_user_id', 'reviewed_at', 'admin_note'],
 	secret_entries: ['encrypted_value', 'lookup_hash'],
+	user_integrations: ['access_token_encrypted', 'refresh_token_encrypted'],
+	user_oauth_apps: ['client_secret_encrypted'],
 	users: ['password_hash'],
 	verifications: ['secret'],
 	webhook_endpoints: ['url_secret_hash'],

--- a/packages/worker/src/app/account-integrations-data.ts
+++ b/packages/worker/src/app/account-integrations-data.ts
@@ -24,6 +24,8 @@ import { buildPlatformOauthAppLogoPath } from '#worker/integrations/platform-app
 import { buildUserOauthAppLogoPaths } from '#worker/integrations/user-oauth-app-logo.ts'
 import { backfillMissingUserOauthAppFavicons } from '#worker/integrations/user-oauth-app-favicon.ts'
 import { type JoinedIntegration } from '#worker/integrations/types.ts'
+import { getOauthAppClientSecretCiphertext } from '#worker/integrations/repo.ts'
+import { listSavedPackagesByUserId } from '#worker/package-registry/repo.ts'
 
 type AuthenticatedUser = NonNullable<
 	Awaited<ReturnType<typeof readAuthenticatedAppUser>>
@@ -51,6 +53,8 @@ function toAccountIntegrationRecord(
 			: buildUserOauthAppLogoPaths(entry.app)),
 		createdAt: entry.connection.createdAt,
 		updatedAt: entry.connection.updatedAt,
+		usageMode: entry.connection.usageMode,
+		allowedPackageIds: entry.connection.allowedPackageIds,
 	}
 }
 
@@ -238,18 +242,30 @@ function buildOauthAppRecords(
 export async function loadAccountIntegrationsData(
 	env: Env,
 	user: AuthenticatedUser,
-	options?: { waitUntil?: (promise: Promise<unknown>) => void },
+	options?: {
+		waitUntil?: (promise: Promise<unknown>) => void
+		searchParams?: URLSearchParams
+	},
 ): Promise<{
 	ok: true
 	email: string
 	username: string
 	integrations: Array<AccountIntegrationRecord>
 	apps: Array<AccountOauthAppRecord>
+	savedPackages: Array<{ id: string; kodyId: string }>
+	approval: {
+		name: string
+		packageId: string
+		packageKodyId: string | null
+		usageMode: 'any' | 'packages'
+		alreadyGranted: boolean
+	} | null
 }> {
 	const userId = user.mcpUser.userId
-	const [joined, apps] = await Promise.all([
+	const [joined, apps, savedPackages] = await Promise.all([
 		listJoinedIntegrations({ env, userId }),
 		listOauthApps({ env, userId }),
+		listSavedPackagesByUserId(env.APP_DB, { userId }),
 	])
 	const integrations = joined
 		.map((entry) => toAccountIntegrationRecord(entry))
@@ -267,12 +283,47 @@ export async function loadAccountIntegrationsData(
 		waitUntil: options?.waitUntil,
 	})
 
+	const packageRecords = savedPackages.map((entry) => ({
+		id: entry.id,
+		kodyId: entry.kodyId,
+	}))
+	const approvalName = options?.searchParams?.get('name')?.trim() ?? ''
+	const approvalPackageId =
+		options?.searchParams?.get('package_id')?.trim() ?? ''
+	let approval: {
+		name: string
+		packageId: string
+		packageKodyId: string | null
+		usageMode: 'any' | 'packages'
+		alreadyGranted: boolean
+	} | null = null
+	if (approvalName && approvalPackageId) {
+		const connection = integrations.find((entry) => entry.name === approvalName)
+		if (connection) {
+			const savedPackage = packageRecords.find(
+				(entry) => entry.id === approvalPackageId,
+			)
+			const usageMode = connection.usageMode === 'packages' ? 'packages' : 'any'
+			approval = {
+				name: approvalName,
+				packageId: approvalPackageId,
+				packageKodyId: savedPackage?.kodyId ?? null,
+				usageMode,
+				alreadyGranted:
+					usageMode === 'any' ||
+					(connection.allowedPackageIds ?? []).includes(approvalPackageId),
+			}
+		}
+	}
+
 	return {
 		ok: true,
 		email: user.email,
 		username: user.username,
 		integrations,
 		apps: buildOauthAppRecords(apps, joined),
+		savedPackages: packageRecords,
+		approval,
 	}
 }
 
@@ -452,11 +503,22 @@ export async function hasStoredConnectClientSecret(
 	const secretName =
 		record?.clientSecretSecretName?.trim() ||
 		`${normalizeProviderKey(name)}ClientSecret`
-	const secrets = await listSecrets({
-		env,
-		userId: user.mcpUser.userId,
-		scope: 'user',
-	})
+	const [secrets, storedCiphertext] = await Promise.all([
+		listSecrets({
+			env,
+			userId: user.mcpUser.userId,
+			scope: 'user',
+			includeIntegrationOwned: true,
+		}),
+		record?.appSlug && !record.platform
+			? getOauthAppClientSecretCiphertext({
+					db: env.APP_DB,
+					userId: user.mcpUser.userId,
+					slug: record.appSlug,
+				})
+			: Promise.resolve(null),
+	])
+	if (storedCiphertext) return true
 	return secrets.some(
 		(secret) => secret.scope === 'user' && secret.name === secretName,
 	)

--- a/packages/worker/src/app/account-secrets-data.ts
+++ b/packages/worker/src/app/account-secrets-data.ts
@@ -358,6 +358,7 @@ async function resolveSecretApprovalView(input: {
 			env: input.env,
 			userId: input.userId,
 			scope: 'user',
+			includeIntegrationOwned: true,
 		})
 		const byName = new Map(
 			secrets
@@ -409,6 +410,7 @@ async function resolveSecretApprovalView(input: {
 		userId: input.userId,
 		scope: approval.scope,
 		storageContext: approval.storageContext,
+		includeIntegrationOwned: true,
 	})
 	const secret = secrets.find(
 		(item) => item.name === approval.name && item.scope === approval.scope,

--- a/packages/worker/src/app/handlers/account-integrations.node.test.ts
+++ b/packages/worker/src/app/handlers/account-integrations.node.test.ts
@@ -1,5 +1,8 @@
 import { beforeEach, expect, test, vi } from 'vitest'
 import type * as IntegrationsService from '#worker/integrations/service.ts'
+import type * as IntegrationsRepo from '#worker/integrations/repo.ts'
+import type * as IntegrationsCredentials from '#worker/integrations/credentials.ts'
+import type * as PackageRegistryRepo from '#worker/package-registry/repo.ts'
 
 const createdAt = '1970-01-01T00:00:00.000Z'
 const updatedAt = '1970-01-01T00:00:00.001Z'
@@ -52,6 +55,8 @@ const mockModule = vi.hoisted(() => ({
 				requiredHosts: ['www.googleapis.com'],
 				accessTokenSecretName: 'googleAccessToken',
 				refreshTokenSecretName: 'googleRefreshToken',
+				usageMode: 'any',
+				allowedPackageIds: [],
 				connectedAt: null,
 				tokenRefreshedAt: null,
 				createdAt: '1970-01-01T00:00:00.000Z',
@@ -265,6 +270,19 @@ const mockModule = vi.hoisted(() => ({
 		deleted: true,
 		connectionNames: ['google', 'google-calendar'],
 	})),
+	listSavedPackagesByUserId: vi.fn(async () => []),
+	getOauthAppClientSecretCiphertext: vi.fn(async () => null),
+	persistUserOauthAppClientSecret: vi.fn(async () => undefined),
+	setIntegrationUsage: vi.fn(async () => ({
+		name: 'google',
+		usageMode: 'packages' as const,
+		allowedPackageIds: ['pkg-mail'],
+	})),
+	grantIntegrationPackage: vi.fn(async () => ({
+		name: 'google',
+		usageMode: 'packages' as const,
+		allowedPackageIds: ['pkg-mail'],
+	})),
 }))
 
 vi.mock('#app/authenticated-user.ts', () => ({
@@ -315,6 +333,37 @@ vi.mock('#worker/integrations/service.ts', async (importOriginal) => {
 			mockModule.getAvailablePlatformApp(...args),
 		listAvailablePlatformApps: (...args: Array<unknown>) =>
 			mockModule.listAvailablePlatformApps(...args),
+		setIntegrationUsage: (...args: Array<unknown>) =>
+			mockModule.setIntegrationUsage(...args),
+		grantIntegrationPackage: (...args: Array<unknown>) =>
+			mockModule.grantIntegrationPackage(...args),
+	}
+})
+
+vi.mock('#worker/package-registry/repo.ts', async (importOriginal) => {
+	const actual = await importOriginal<typeof PackageRegistryRepo>()
+	return {
+		...actual,
+		listSavedPackagesByUserId: (...args: Array<unknown>) =>
+			mockModule.listSavedPackagesByUserId(...args),
+	}
+})
+
+vi.mock('#worker/integrations/repo.ts', async (importOriginal) => {
+	const actual = await importOriginal<typeof IntegrationsRepo>()
+	return {
+		...actual,
+		getOauthAppClientSecretCiphertext: (...args: Array<unknown>) =>
+			mockModule.getOauthAppClientSecretCiphertext(...args),
+	}
+})
+
+vi.mock('#worker/integrations/credentials.ts', async (importOriginal) => {
+	const actual = await importOriginal<typeof IntegrationsCredentials>()
+	return {
+		...actual,
+		persistUserOauthAppClientSecret: (...args: Array<unknown>) =>
+			mockModule.persistUserOauthAppClientSecret(...args),
 	}
 })
 
@@ -377,6 +426,8 @@ test('integrations API lists connections with app grouping metadata and never ex
 		ok: true,
 		email: 'user@example.com',
 		username: 'test-user',
+		savedPackages: [],
+		approval: null,
 		apps: [
 			{
 				slug: 'github',
@@ -474,6 +525,8 @@ test('integrations API lists connections with app grouping metadata and never ex
 				autoLogoPath: null,
 				createdAt,
 				updatedAt,
+				usageMode: 'any',
+				allowedPackageIds: [],
 			},
 			{
 				name: 'google-calendar',
@@ -715,13 +768,14 @@ test('integrations API rotates OAuth app credentials for the authenticated user'
 		userId: 'stable-user-1',
 		scope: 'user',
 		storageContext: { sessionId: null, appId: null, packageId: null },
+		includeIntegrationOwned: true,
 	})
-	expect(mockModule.saveSecret).toHaveBeenCalledWith(
+	expect(mockModule.persistUserOauthAppClientSecret).toHaveBeenCalledWith(
 		expect.objectContaining({
 			userId: 'stable-user-1',
-			name: 'googleClientSecret',
+			slug: 'google',
 			value: 'new-google-client-secret',
-			scope: 'user',
+			secretName: 'googleClientSecret',
 		}),
 	)
 	expect(mockModule.setSecretAllowedHosts).toHaveBeenCalledWith({
@@ -922,7 +976,7 @@ test('integrations API scopes rotate actions to the authenticated user', async (
 			slug: 'google',
 		}),
 	)
-	expect(mockModule.saveSecret).toHaveBeenCalledWith(
+	expect(mockModule.persistUserOauthAppClientSecret).toHaveBeenCalledWith(
 		expect.objectContaining({
 			userId: 'stable-user-other',
 		}),
@@ -1008,4 +1062,111 @@ test('integrations API disconnects a connection and deletes a user-lane OAuth ap
 		params: {},
 	} as never)
 	expect(missingApp.status).toBe(404)
+})
+
+test('integrations API sets usage, returns approval payload, and grants a package without widening any', async () => {
+	const handler = createAccountIntegrationsApiHandler(createEnv())
+	mockModule.listSavedPackagesByUserId.mockResolvedValue([
+		{
+			id: 'pkg-mail',
+			userId: 'stable-user-1',
+			name: 'mail',
+			kodyId: 'mail',
+			description: '',
+			tags: [],
+			searchText: null,
+			sourceId: 'source-mail',
+			hasApp: false,
+			hidden: false,
+			isPrivate: false,
+			createdAt: createdAt,
+			updatedAt: updatedAt,
+		},
+	])
+
+	const usageResponse = await handler.handler({
+		request: new Request('https://example.com/account/integrations.json', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				action: 'set_usage',
+				name: 'google',
+				usageMode: 'packages',
+				allowedPackageIds: ['pkg-mail'],
+			}),
+		}),
+		params: {},
+	} as never)
+	expect(usageResponse.status).toBe(200)
+	expect(mockModule.setIntegrationUsage).toHaveBeenCalledWith({
+		env: expect.any(Object),
+		userId: 'stable-user-1',
+		name: 'google',
+		usageMode: 'packages',
+		allowedPackageIds: ['pkg-mail'],
+	})
+	await expect(usageResponse.json()).resolves.toEqual({
+		ok: true,
+		usageMode: 'packages',
+		allowedPackageIds: ['pkg-mail'],
+	})
+
+	const approvalGet = await handler.handler({
+		request: new Request(
+			'https://example.com/account/integrations.json?name=google&package_id=pkg-mail',
+		),
+		params: {},
+	} as never)
+	expect(approvalGet.status).toBe(200)
+	const approvalPayload = await approvalGet.json()
+	expect(approvalPayload).toMatchObject({
+		ok: true,
+		approval: {
+			name: 'google',
+			packageId: 'pkg-mail',
+			packageKodyId: 'mail',
+			usageMode: 'any',
+			alreadyGranted: true,
+		},
+	})
+	expect(approvalPayload.integration).toBeUndefined()
+
+	mockModule.grantIntegrationPackage.mockResolvedValueOnce({
+		name: 'google',
+		usageMode: 'any',
+		allowedPackageIds: [],
+	})
+	const approveAny = await handler.handler({
+		request: new Request('https://example.com/account/integrations.json', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				action: 'approve_package',
+				name: 'google',
+				packageId: 'pkg-mail',
+			}),
+		}),
+		params: {},
+	} as never)
+	expect(approveAny.status).toBe(200)
+	await expect(approveAny.json()).resolves.toEqual({
+		ok: true,
+		alreadyGranted: true,
+		usageMode: 'any',
+		allowedPackageIds: [],
+	})
+
+	const missingPackage = await handler.handler({
+		request: new Request('https://example.com/account/integrations.json', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				action: 'approve_package',
+				name: 'google',
+				packageId: 'pkg-missing',
+			}),
+		}),
+		params: {},
+	} as never)
+	expect(missingPackage.status).toBe(400)
 })

--- a/packages/worker/src/app/handlers/account-integrations.ts
+++ b/packages/worker/src/app/handlers/account-integrations.ts
@@ -19,18 +19,18 @@ import { renderAppPage } from '#app/ssr-render.tsx'
 import { toOauthAppPublic } from '#mcp/capabilities/integrations/oauth-app-shared.ts'
 import { canonicalIntegrationName } from '#mcp/capabilities/integrations/integration-shared.ts'
 import { normalizeAllowedHosts } from '#mcp/secrets/allowed-hosts.ts'
-import {
-	listSecrets,
-	saveSecret,
-	setSecretAllowedHosts,
-} from '#mcp/secrets/service.ts'
+import { listSecrets, setSecretAllowedHosts } from '#mcp/secrets/service.ts'
 import {
 	deleteIntegration,
 	deleteOauthAppWithConnections,
 	getOauthApp,
 	listJoinedIntegrations,
+	grantIntegrationPackage,
 	rotateOauthAppClientCredentials,
+	setIntegrationUsage,
 } from '#worker/integrations/service.ts'
+import { persistUserOauthAppClientSecret } from '#worker/integrations/credentials.ts'
+import { listSavedPackagesByUserId } from '#worker/package-registry/repo.ts'
 import { type routes } from '#universal/routes.ts'
 
 const rotateOauthAppCredentialsSchema = z
@@ -60,12 +60,31 @@ const deleteOauthAppSchema = z
 	})
 	.strict()
 
+const setUsageSchema = z
+	.object({
+		action: z.literal('set_usage'),
+		name: z.string().min(1),
+		usageMode: z.enum(['any', 'packages']),
+		allowedPackageIds: z.array(z.string()).optional(),
+	})
+	.strict()
+
+const approvePackageSchema = z
+	.object({
+		action: z.literal('approve_package'),
+		name: z.string().min(1),
+		packageId: z.string().min(1),
+	})
+	.strict()
+
 const accountIntegrationsActionSchema = z
 	.object({
 		action: z.enum([
 			'rotate_oauth_app_credentials',
 			'disconnect_connection',
 			'delete_oauth_app',
+			'set_usage',
+			'approve_package',
 		]),
 	})
 	.passthrough()
@@ -81,6 +100,7 @@ export function createAccountIntegrationsHandler(env: Env) {
 
 			const accountIntegrations = await loadAccountIntegrationsData(env, user, {
 				waitUntil,
+				searchParams: new URL(request.url).searchParams,
 			})
 			return renderAppPage({
 				request,
@@ -92,6 +112,7 @@ export function createAccountIntegrationsHandler(env: Env) {
 	} satisfies Action<
 		| typeof routes.accountIntegrations
 		| typeof routes.accountOauthAppDetail
+		| typeof routes.accountIntegrationsApprove
 		| typeof routes.accountIntegrationDetail
 	>
 }
@@ -117,7 +138,8 @@ export function createAccountIntegrationsApiHandler(env: Env) {
 					})
 				}
 				const name = searchParams.get('name')?.trim()
-				if (name) {
+				const approvalPackageId = searchParams.get('package_id')?.trim()
+				if (name && !approvalPackageId) {
 					// `platform=1` forces the built-in of the same name;
 					// `platform=<slug>` connects that built-in under a
 					// different connection name (rename-instead-of-replace).
@@ -154,7 +176,10 @@ export function createAccountIntegrationsApiHandler(env: Env) {
 					return jsonResponse({ ok: true, app })
 				}
 				return jsonResponse(
-					await loadAccountIntegrationsData(env, user, { waitUntil }),
+					await loadAccountIntegrationsData(env, user, {
+						waitUntil,
+						searchParams: new URL(request.url).searchParams,
+					}),
 				)
 			}
 
@@ -211,6 +236,34 @@ export function createAccountIntegrationsApiHandler(env: Env) {
 						appSlug: parsed.data.appSlug,
 					})
 				}
+				case 'set_usage': {
+					const parsed = setUsageSchema.safeParse(body)
+					if (!parsed.success) {
+						return jsonResponse(
+							{ ok: false, error: 'Invalid request body.' },
+							400,
+						)
+					}
+					return handleSetUsage({
+						env,
+						user,
+						body: parsed.data,
+					})
+				}
+				case 'approve_package': {
+					const parsed = approvePackageSchema.safeParse(body)
+					if (!parsed.success) {
+						return jsonResponse(
+							{ ok: false, error: 'Invalid request body.' },
+							400,
+						)
+					}
+					return handleApprovePackage({
+						env,
+						user,
+						body: parsed.data,
+					})
+				}
 				default: {
 					const _exhaustive: never = actionParsed.data.action
 					return _exhaustive
@@ -221,6 +274,68 @@ export function createAccountIntegrationsApiHandler(env: Env) {
 		| typeof routes.accountIntegrationsApi
 		| typeof routes.accountIntegrationsApiPost
 	>
+}
+
+async function handleSetUsage(input: {
+	env: Env
+	user: NonNullable<Awaited<ReturnType<typeof readAuthenticatedAppUser>>>
+	body: z.infer<typeof setUsageSchema>
+}) {
+	const allowedPackageIds =
+		input.body.usageMode === 'packages'
+			? (input.body.allowedPackageIds ?? [])
+			: []
+	const updated = await setIntegrationUsage({
+		env: input.env,
+		userId: input.user.mcpUser.userId,
+		name: input.body.name,
+		usageMode: input.body.usageMode,
+		allowedPackageIds,
+	})
+	if (!updated) {
+		return jsonResponse({ ok: false, error: 'Connection not found.' }, 404)
+	}
+	return jsonResponse({
+		ok: true,
+		usageMode: updated.usageMode,
+		allowedPackageIds: updated.allowedPackageIds,
+	})
+}
+
+async function handleApprovePackage(input: {
+	env: Env
+	user: NonNullable<Awaited<ReturnType<typeof readAuthenticatedAppUser>>>
+	body: z.infer<typeof approvePackageSchema>
+}) {
+	const userId = input.user.mcpUser.userId
+	const savedPackage = (
+		await listSavedPackagesByUserId(input.env.APP_DB, {
+			userId,
+		})
+	).find((entry) => entry.id === input.body.packageId)
+	if (!savedPackage) {
+		return jsonResponse(
+			{ ok: false, error: 'That package is not on this account.' },
+			400,
+		)
+	}
+	const updated = await grantIntegrationPackage({
+		env: input.env,
+		userId,
+		name: input.body.name,
+		packageId: input.body.packageId,
+	})
+	if (!updated) {
+		return jsonResponse({ ok: false, error: 'Connection not found.' }, 404)
+	}
+	return jsonResponse({
+		ok: true,
+		alreadyGranted:
+			updated.usageMode === 'any' ||
+			updated.allowedPackageIds.includes(input.body.packageId),
+		usageMode: updated.usageMode,
+		allowedPackageIds: updated.allowedPackageIds,
+	})
 }
 
 async function handleDisconnectConnection(input: {
@@ -303,6 +418,7 @@ async function handleRotateOauthAppCredentials(input: {
 				userId,
 				scope: 'user',
 				storageContext,
+				includeIntegrationOwned: true,
 			})
 			const existingSecret = currentSecrets.find(
 				(secret) => secret.name === secretName && secret.scope === 'user',
@@ -311,15 +427,14 @@ async function handleRotateOauthAppCredentials(input: {
 				...(existingSecret?.allowedHosts ?? []),
 				...oauthAppSecretAllowedHosts(existing),
 			])
-			await saveSecret({
+			await persistUserOauthAppClientSecret({
 				env: input.env,
 				userId,
 				userEmail: input.user.mcpUser.email,
-				name: secretName,
+				slug: existing.slug,
 				value: input.body.clientSecret,
-				scope: 'user',
+				secretName,
 				description: `${existing.provider} OAuth client secret`,
-				storageContext,
 			})
 			await setSecretAllowedHosts({
 				env: input.env,

--- a/packages/worker/src/app/handlers/account-secrets.node.test.ts
+++ b/packages/worker/src/app/handlers/account-secrets.node.test.ts
@@ -2,6 +2,7 @@ import { expect, test, vi } from 'vitest'
 import type * as AllowedCapabilities from '#mcp/secrets/allowed-capabilities.ts'
 import type * as AllowedHosts from '#mcp/secrets/allowed-hosts.ts'
 import type * as IntegrationsService from '#worker/integrations/service.ts'
+import type * as IntegrationsCredentials from '#worker/integrations/credentials.ts'
 
 const mockModule = vi.hoisted(() => ({
 	readAuthenticatedAppUser: vi.fn(async () => ({
@@ -92,6 +93,13 @@ const mockModule = vi.hoisted(() => ({
 	),
 	getPlatformOauthAppClientSecret: vi.fn(async () => null),
 	dispatchIntegrationAuthSucceededSubscriptionEvents: vi.fn(async () => []),
+	persistIntegrationTokens: vi.fn(async () => undefined),
+	persistUserOauthAppClientSecret: vi.fn(async () => undefined),
+	getJoinedIntegration: vi.fn(async (input: { name: string }) => ({
+		lane: 'user' as const,
+		app: { slug: String(input.name).toLowerCase() },
+		connection: { name: String(input.name).toLowerCase() },
+	})),
 }))
 
 vi.mock('#app/authenticated-user.ts', () => ({
@@ -173,6 +181,8 @@ vi.mock('#worker/integrations/service.ts', async (importOriginal) => {
 			mockModule.getAvailablePlatformApp(...args),
 		upsertPlatformIntegration: (...args: Array<unknown>) =>
 			mockModule.upsertPlatformIntegration(...args),
+		getJoinedIntegration: (...args: Array<unknown>) =>
+			mockModule.getJoinedIntegration(...args),
 		// Real scope validation so handler ordering tests exercise the actual
 		// allowlist semantics.
 		assertScopesAllowedForPlatformApp: actual.assertScopesAllowedForPlatformApp,
@@ -192,6 +202,17 @@ vi.mock('#worker/integrations/platform-apps.ts', () => ({
 	getPlatformOauthAppClientSecret: (...args: Array<unknown>) =>
 		mockModule.getPlatformOauthAppClientSecret(...args),
 }))
+
+vi.mock('#worker/integrations/credentials.ts', async (importOriginal) => {
+	const actual = await importOriginal<typeof IntegrationsCredentials>()
+	return {
+		...actual,
+		persistIntegrationTokens: (...args: Array<unknown>) =>
+			mockModule.persistIntegrationTokens(...args),
+		persistUserOauthAppClientSecret: (...args: Array<unknown>) =>
+			mockModule.persistUserOauthAppClientSecret(...args),
+	}
+})
 
 vi.mock('#worker/package-registry/repo.ts', () => ({
 	listSavedPackagesByUserId: (...args: Array<unknown>) =>

--- a/packages/worker/src/app/handlers/account-secrets.ts
+++ b/packages/worker/src/app/handlers/account-secrets.ts
@@ -1030,6 +1030,7 @@ async function handleApprovalAction(input: {
 					env: input.env,
 					userId: input.user.mcpUser.userId,
 					scope: 'user',
+					includeIntegrationOwned: true,
 				})
 				const byName = new Map(
 					current
@@ -1090,6 +1091,7 @@ async function handleApprovalAction(input: {
 					userId: input.user.mcpUser.userId,
 					scope: approval.scope,
 					storageContext: approval.storageContext,
+					includeIntegrationOwned: true,
 				})
 				const secret = current.find(
 					(item) =>
@@ -1125,6 +1127,7 @@ async function handleApprovalAction(input: {
 					userId: input.user.mcpUser.userId,
 					scope: approval.scope,
 					storageContext: approval.storageContext,
+					includeIntegrationOwned: true,
 				})
 				const secret = current.find(
 					(item) =>
@@ -1160,6 +1163,7 @@ async function handleApprovalAction(input: {
 					userId: input.user.mcpUser.userId,
 					scope: approval.scope,
 					storageContext: approval.storageContext,
+					includeIntegrationOwned: true,
 				})
 				const secret = current.find(
 					(item) =>

--- a/packages/worker/src/app/handlers/account-secrets.ts
+++ b/packages/worker/src/app/handlers/account-secrets.ts
@@ -43,10 +43,15 @@ import {
 import {
 	assertScopesAllowedForPlatformApp,
 	getAvailablePlatformApp,
+	getJoinedIntegration,
 	upsertIntegration,
 	upsertOauthAppWithoutConnection,
 	upsertPlatformIntegration,
 } from '#worker/integrations/service.ts'
+import {
+	persistIntegrationTokens,
+	persistUserOauthAppClientSecret,
+} from '#worker/integrations/credentials.ts'
 import { getPlatformOauthAppClientSecret } from '#worker/integrations/platform-apps.ts'
 import { dispatchIntegrationAuthSucceededSubscriptionEvents } from '#worker/integrations/package-subscriptions.ts'
 import { requireAuthenticatedPageUser } from '#app/page-auth.ts'
@@ -427,6 +432,7 @@ async function handleConnectOauthAction(input: {
 				userId: input.user.mcpUser.userId,
 				scope: 'user',
 				storageContext: null,
+				includeIntegrationOwned: true,
 			})
 		).map((secret) => [secret.name, new Set(secret.allowedHosts)]),
 	)
@@ -503,6 +509,47 @@ async function handleConnectOauthAction(input: {
 					}
 				: null,
 		})
+	}
+	await persistIntegrationTokens({
+		env: input.env,
+		userId: input.user.mcpUser.userId,
+		userEmail: input.user.mcpUser.email,
+		name: integrationName,
+		accessToken,
+		refreshToken:
+			refreshToken && persistRefreshTokenSecretName ? refreshToken : null,
+		accessTokenSecretName,
+		refreshTokenSecretName: persistRefreshTokenSecretName,
+		descriptionPrefix: provider,
+	})
+	if (!platformApp && clientSecretSecretName) {
+		const resolvedClientSecret = await resolveSecret({
+			env: input.env,
+			userId: input.user.mcpUser.userId,
+			name: clientSecretSecretName,
+			scope: 'user',
+			storageContext: { sessionId: null, appId: null, packageId: null },
+		})
+		const saved = await getJoinedIntegration({
+			env: input.env,
+			userId: input.user.mcpUser.userId,
+			name: integrationName,
+		})
+		if (
+			resolvedClientSecret.found &&
+			resolvedClientSecret.value &&
+			saved?.lane === 'user'
+		) {
+			await persistUserOauthAppClientSecret({
+				env: input.env,
+				userId: input.user.mcpUser.userId,
+				userEmail: input.user.mcpUser.email,
+				slug: saved.app.slug,
+				value: resolvedClientSecret.value,
+				secretName: clientSecretSecretName,
+				description: `${provider} OAuth client secret`,
+			})
+		}
 	}
 	const approvalSecretNames = [
 		accessTokenSecretName,

--- a/packages/worker/src/app/router.ts
+++ b/packages/worker/src/app/router.ts
@@ -307,6 +307,7 @@ export function createAppRouter(env: Env) {
 			accountExport: createAccountExportHandler(env),
 			accountIntegrations: createAccountIntegrationsHandler(env),
 			accountOauthAppDetail: createAccountIntegrationsHandler(env),
+			accountIntegrationsApprove: createAccountIntegrationsHandler(env),
 			accountIntegrationDetail: createAccountIntegrationsHandler(env),
 			accountIntegrationsApi: createAccountIntegrationsApiHandler(env),
 			accountIntegrationsApiPost: createAccountIntegrationsApiHandler(env),

--- a/packages/worker/src/integrations/credentials.ts
+++ b/packages/worker/src/integrations/credentials.ts
@@ -1,0 +1,242 @@
+import {
+	decryptUserOauthAccessToken,
+	decryptUserOauthClientSecret,
+	decryptUserOauthRefreshToken,
+	encryptUserOauthAccessToken,
+	encryptUserOauthClientSecret,
+	encryptUserOauthRefreshToken,
+	userIntegrationCredentialContext,
+	userOauthAppCredentialContext,
+} from '#mcp/secrets/crypto.ts'
+import {
+	deleteSecret,
+	resolveSecret,
+	saveSecret,
+} from '#mcp/secrets/service.ts'
+import {
+	getIntegrationCredentialCiphertexts,
+	getOauthAppClientSecretCiphertext,
+	updateIntegrationCredentialCiphertexts,
+	updateOauthAppClientSecretCiphertext,
+} from './repo.ts'
+
+type CredentialEnv = Pick<Env, 'APP_DB' | 'SECRET_STORE_KEY'>
+
+export async function persistIntegrationTokens(input: {
+	env: CredentialEnv
+	userId: string
+	userEmail?: string | null
+	name: string
+	accessToken: string
+	refreshToken?: string | null
+	accessTokenSecretName: string
+	refreshTokenSecretName?: string | null
+	descriptionPrefix: string
+}): Promise<void> {
+	const context = userIntegrationCredentialContext(input.userId, input.name)
+	const accessTokenEncrypted = await encryptUserOauthAccessToken(
+		input.env,
+		input.accessToken,
+		context,
+	)
+	const refreshToken = input.refreshToken?.trim() || null
+	const refreshTokenEncrypted = refreshToken
+		? await encryptUserOauthRefreshToken(input.env, refreshToken, context)
+		: null
+	await updateIntegrationCredentialCiphertexts({
+		db: input.env.APP_DB,
+		userId: input.userId,
+		name: input.name,
+		accessTokenEncrypted,
+		refreshTokenEncrypted,
+	})
+
+	const storageContext = { sessionId: null, appId: null, packageId: null }
+	await saveSecret({
+		env: input.env,
+		userId: input.userId,
+		userEmail: input.userEmail,
+		name: input.accessTokenSecretName,
+		value: input.accessToken,
+		scope: 'user',
+		description: `${input.descriptionPrefix} OAuth access token`,
+		storageContext,
+	})
+	if (refreshToken && input.refreshTokenSecretName) {
+		await saveSecret({
+			env: input.env,
+			userId: input.userId,
+			userEmail: input.userEmail,
+			name: input.refreshTokenSecretName,
+			value: refreshToken,
+			scope: 'user',
+			description: `${input.descriptionPrefix} OAuth refresh token`,
+			storageContext,
+		})
+	}
+}
+
+export async function persistUserOauthAppClientSecret(input: {
+	env: CredentialEnv
+	userId: string
+	userEmail?: string | null
+	slug: string
+	value: string
+	secretName: string
+	description: string
+}): Promise<void> {
+	const encrypted = await encryptUserOauthClientSecret(
+		input.env,
+		input.value,
+		userOauthAppCredentialContext(input.userId, input.slug),
+	)
+	await updateOauthAppClientSecretCiphertext({
+		db: input.env.APP_DB,
+		userId: input.userId,
+		slug: input.slug,
+		clientSecretEncrypted: encrypted,
+	})
+	await saveSecret({
+		env: input.env,
+		userId: input.userId,
+		userEmail: input.userEmail,
+		name: input.secretName,
+		value: input.value,
+		scope: 'user',
+		description: input.description,
+		storageContext: { sessionId: null, appId: null, packageId: null },
+	})
+}
+
+export async function resolveIntegrationAccessToken(input: {
+	env: CredentialEnv
+	userId: string
+	name: string
+	secretName: string
+}): Promise<string | null> {
+	const ciphertexts = await getIntegrationCredentialCiphertexts({
+		db: input.env.APP_DB,
+		userId: input.userId,
+		name: input.name,
+	})
+	if (ciphertexts?.accessTokenEncrypted) {
+		return decryptUserOauthAccessToken(
+			input.env,
+			ciphertexts.accessTokenEncrypted,
+			userIntegrationCredentialContext(input.userId, input.name),
+		)
+	}
+	const resolved = await resolveSecret({
+		env: input.env,
+		userId: input.userId,
+		name: input.secretName,
+		scope: 'user',
+		storageContext: { sessionId: null, appId: null, packageId: null },
+	})
+	return resolved.found ? (resolved.value ?? null) : null
+}
+
+export async function resolveIntegrationRefreshToken(input: {
+	env: CredentialEnv
+	userId: string
+	name: string
+	secretName: string
+}): Promise<{
+	value: string | null
+	allowedHosts: Array<string>
+	source: 'integration' | 'secret'
+}> {
+	const ciphertexts = await getIntegrationCredentialCiphertexts({
+		db: input.env.APP_DB,
+		userId: input.userId,
+		name: input.name,
+	})
+	if (ciphertexts?.refreshTokenEncrypted) {
+		return {
+			value: await decryptUserOauthRefreshToken(
+				input.env,
+				ciphertexts.refreshTokenEncrypted,
+				userIntegrationCredentialContext(input.userId, input.name),
+			),
+			allowedHosts: [],
+			source: 'integration',
+		}
+	}
+	const resolved = await resolveSecret({
+		env: input.env,
+		userId: input.userId,
+		name: input.secretName,
+		scope: 'user',
+		storageContext: { sessionId: null, appId: null, packageId: null },
+	})
+	return {
+		value: resolved.found ? (resolved.value ?? null) : null,
+		allowedHosts: resolved.allowedHosts,
+		source: 'secret',
+	}
+}
+
+export async function resolveUserOauthAppClientSecret(input: {
+	env: CredentialEnv
+	userId: string
+	slug: string
+	secretName: string
+}): Promise<{
+	value: string | null
+	allowedHosts: Array<string>
+	source: 'integration' | 'secret'
+}> {
+	const encrypted = await getOauthAppClientSecretCiphertext({
+		db: input.env.APP_DB,
+		userId: input.userId,
+		slug: input.slug,
+	})
+	if (encrypted) {
+		return {
+			value: await decryptUserOauthClientSecret(
+				input.env,
+				encrypted,
+				userOauthAppCredentialContext(input.userId, input.slug),
+			),
+			allowedHosts: [],
+			source: 'integration',
+		}
+	}
+	const resolved = await resolveSecret({
+		env: input.env,
+		userId: input.userId,
+		name: input.secretName,
+		scope: 'user',
+		storageContext: { sessionId: null, appId: null, packageId: null },
+	})
+	return {
+		value: resolved.found ? (resolved.value ?? null) : null,
+		allowedHosts: resolved.allowedHosts,
+		source: 'secret',
+	}
+}
+
+export async function deleteIntegrationOwnedSecrets(input: {
+	env: Pick<Env, 'APP_DB'>
+	userId: string
+	secretNames: Array<string | null | undefined>
+}): Promise<void> {
+	const names = Array.from(
+		new Set(
+			input.secretNames
+				.map((name) => name?.trim())
+				.filter((name): name is string => Boolean(name)),
+		),
+	)
+	await Promise.all(
+		names.map((name) =>
+			deleteSecret({
+				env: input.env,
+				userId: input.userId,
+				name,
+				scope: 'user',
+				storageContext: { sessionId: null, appId: null, packageId: null },
+			}),
+		),
+	)
+}

--- a/packages/worker/src/integrations/owned-credentials.node.test.ts
+++ b/packages/worker/src/integrations/owned-credentials.node.test.ts
@@ -342,3 +342,59 @@ test('integration-owned credentials persist, hide, grant, approve, and disconnec
 		}),
 	).toMatchObject({ found: false })
 })
+
+test('disconnecting the last user-lane connection deletes the leftover client secret', async () => {
+	const { env } = createHarness()
+	const userId = 'user-last-disconnect'
+	const userEmail = 'user@example.com'
+
+	await upsertIntegration({ env, userId, config: googleConfig })
+	await persistIntegrationTokens({
+		env,
+		userId,
+		userEmail,
+		name: 'google',
+		accessToken: 'access-live',
+		refreshToken: 'refresh-live',
+		accessTokenSecretName: 'googleAccessToken',
+		refreshTokenSecretName: 'googleRefreshToken',
+		descriptionPrefix: 'google',
+	})
+	await persistUserOauthAppClientSecret({
+		env,
+		userId,
+		userEmail,
+		slug: 'google',
+		value: 'client-secret-live',
+		secretName: 'googleClientSecret',
+		description: 'google OAuth client secret',
+	})
+
+	expect(await deleteIntegration({ env, userId, name: 'google' })).toBe(true)
+	expect(
+		await resolveSecret({
+			env,
+			userId,
+			name: 'googleAccessToken',
+			scope: 'user',
+			storageContext,
+		}),
+	).toMatchObject({ found: false })
+	expect(
+		await resolveSecret({
+			env,
+			userId,
+			name: 'googleClientSecret',
+			scope: 'user',
+			storageContext,
+		}),
+	).toMatchObject({ found: false })
+	expect(
+		await listSecrets({
+			env,
+			userId,
+			scope: 'user',
+			includeIntegrationOwned: true,
+		}),
+	).toEqual([])
+})

--- a/packages/worker/src/integrations/owned-credentials.node.test.ts
+++ b/packages/worker/src/integrations/owned-credentials.node.test.ts
@@ -1,0 +1,344 @@
+import { DatabaseSync } from 'node:sqlite'
+import { expect, test } from 'vitest'
+import {
+	listSecrets,
+	listUserSecretsForSearch,
+	resolveSecret,
+} from '#mcp/secrets/service.ts'
+import { applyAllMigrations as applyRepositoryMigrations } from '#worker/test-support/apply-all-migrations.ts'
+import { createD1FromSqlite } from '#worker/test-support/create-d1-from-sqlite.ts'
+import { createInMemoryUserMeterEnv } from '#worker/test-support/user-meter.ts'
+import {
+	deleteIntegrationOwnedSecrets,
+	persistIntegrationTokens,
+	persistUserOauthAppClientSecret,
+	resolveIntegrationAccessToken,
+	resolveIntegrationRefreshToken,
+	resolveUserOauthAppClientSecret,
+} from './credentials.ts'
+import {
+	assertCanUseIntegration,
+	buildIntegrationPackageApprovalUrl,
+	IntegrationPackageAccessDeniedError,
+} from './package-access.ts'
+import {
+	deleteIntegration,
+	deleteOauthAppWithConnections,
+	grantIntegrationPackage,
+	setIntegrationUsage,
+	upsertIntegration,
+} from './service.ts'
+
+const migrationsDirectory = new URL('../../migrations/', import.meta.url)
+const storageContext = { sessionId: null, appId: null, packageId: null }
+
+function createHarness() {
+	const sqlite = new DatabaseSync(':memory:')
+	applyRepositoryMigrations(sqlite, migrationsDirectory)
+	const env = {
+		APP_DB: createD1FromSqlite(sqlite),
+		SECRET_STORE_KEY: 'test-secret-store-key-32-chars-minimum',
+		...createInMemoryUserMeterEnv().env,
+	} as Env
+	return { sqlite, env }
+}
+
+function seedPackage(
+	sqlite: DatabaseSync,
+	input: { id: string; userId: string; kodyId: string },
+) {
+	sqlite
+		.prepare(
+			`INSERT INTO saved_packages (
+				id, user_id, name, kody_id, description, source_id
+			) VALUES (?, ?, ?, ?, ?, ?)`,
+		)
+		.run(
+			input.id,
+			input.userId,
+			input.kodyId,
+			input.kodyId,
+			'',
+			`source-${input.id}`,
+		)
+}
+
+const googleConfig = {
+	name: 'google',
+	tokenUrl: 'https://oauth2.googleapis.com/token',
+	apiBaseUrl: 'https://www.googleapis.com',
+	flow: 'confidential' as const,
+	clientId: 'google-client-id',
+	clientSecretSecretName: 'googleClientSecret',
+	accessTokenSecretName: 'googleAccessToken',
+	refreshTokenSecretName: 'googleRefreshToken',
+	requiredHosts: ['www.googleapis.com', 'oauth2.googleapis.com'],
+	authorization: {
+		authorizeUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
+		scopes: ['openid', 'email'],
+		scopeSeparator: null,
+		extraAuthorizeParams: { access_type: 'offline' },
+	},
+}
+
+test('integration-owned credentials persist, hide, grant, approve, and disconnect without dropping the shared client secret', async () => {
+	const { sqlite, env } = createHarness()
+	const userId = 'user-owned-creds'
+	const userEmail = 'user@example.com'
+	seedPackage(sqlite, { id: 'pkg-mail', userId, kodyId: 'mail' })
+	seedPackage(sqlite, { id: 'pkg-docs', userId, kodyId: 'docs' })
+
+	await upsertIntegration({ env, userId, config: googleConfig })
+	await persistIntegrationTokens({
+		env,
+		userId,
+		userEmail,
+		name: 'google',
+		accessToken: 'access-live',
+		refreshToken: 'refresh-live',
+		accessTokenSecretName: 'googleAccessToken',
+		refreshTokenSecretName: 'googleRefreshToken',
+		descriptionPrefix: 'google',
+	})
+	await persistUserOauthAppClientSecret({
+		env,
+		userId,
+		userEmail,
+		slug: 'google',
+		value: 'client-secret-live',
+		secretName: 'googleClientSecret',
+		description: 'google OAuth client secret',
+	})
+
+	const ciphertexts = sqlite
+		.prepare(
+			`SELECT access_token_encrypted, refresh_token_encrypted
+			FROM user_integrations
+			WHERE user_id = ? AND name = ?`,
+		)
+		.get(userId, 'google') as {
+		access_token_encrypted: string
+		refresh_token_encrypted: string
+	}
+	expect(ciphertexts.access_token_encrypted.startsWith('v2.')).toBe(true)
+	expect(ciphertexts.refresh_token_encrypted.startsWith('v2.')).toBe(true)
+	expect(
+		(
+			sqlite
+				.prepare(
+					`SELECT client_secret_encrypted
+					FROM user_oauth_apps
+					WHERE user_id = ? AND slug = ?`,
+				)
+				.get(userId, 'google') as { client_secret_encrypted: string }
+		).client_secret_encrypted.startsWith('v2.'),
+	).toBe(true)
+
+	expect(
+		await resolveIntegrationAccessToken({
+			env,
+			userId,
+			name: 'google',
+			secretName: 'googleAccessToken',
+		}),
+	).toBe('access-live')
+	expect(
+		await resolveIntegrationRefreshToken({
+			env,
+			userId,
+			name: 'google',
+			secretName: 'googleRefreshToken',
+		}),
+	).toMatchObject({ value: 'refresh-live', source: 'integration' })
+	expect(
+		await resolveUserOauthAppClientSecret({
+			env,
+			userId,
+			slug: 'google',
+			secretName: 'googleClientSecret',
+		}),
+	).toMatchObject({ value: 'client-secret-live', source: 'integration' })
+
+	sqlite
+		.prepare(
+			`UPDATE user_integrations
+			SET access_token_encrypted = NULL, refresh_token_encrypted = NULL
+			WHERE user_id = ? AND name = ?`,
+		)
+		.run(userId, 'google')
+	expect(
+		await resolveIntegrationAccessToken({
+			env,
+			userId,
+			name: 'google',
+			secretName: 'googleAccessToken',
+		}),
+	).toBe('access-live')
+
+	const listed = await listSecrets({ env, userId, scope: 'user' })
+	expect(listed.map((secret) => secret.name)).toEqual([])
+	const listedOwned = await listSecrets({
+		env,
+		userId,
+		scope: 'user',
+		includeIntegrationOwned: true,
+	})
+	expect(listedOwned.map((secret) => secret.name).sort()).toEqual([
+		'googleAccessToken',
+		'googleClientSecret',
+		'googleRefreshToken',
+	])
+	expect(await listUserSecretsForSearch({ env, userId })).toEqual([])
+
+	await assertCanUseIntegration({
+		env,
+		baseUrl: 'https://kody.codes',
+		userId,
+		name: 'google',
+	})
+	await assertCanUseIntegration({
+		env,
+		baseUrl: 'https://kody.codes',
+		userId,
+		name: 'google',
+		packageId: 'pkg-mail',
+		packageKodyId: 'mail',
+	})
+
+	const grantedAny = await grantIntegrationPackage({
+		env,
+		userId,
+		name: 'google',
+		packageId: 'pkg-mail',
+	})
+	expect(grantedAny).toMatchObject({
+		usageMode: 'any',
+		allowedPackageIds: [],
+	})
+
+	await setIntegrationUsage({
+		env,
+		userId,
+		name: 'google',
+		usageMode: 'packages',
+		allowedPackageIds: ['pkg-mail'],
+	})
+	await expect(
+		assertCanUseIntegration({
+			env,
+			baseUrl: 'https://kody.codes',
+			userId,
+			name: 'google',
+		}),
+	).rejects.toBeInstanceOf(IntegrationPackageAccessDeniedError)
+	await assertCanUseIntegration({
+		env,
+		baseUrl: 'https://kody.codes',
+		userId,
+		name: 'google',
+		packageId: 'pkg-mail',
+		packageKodyId: 'mail',
+	})
+	await expect(
+		assertCanUseIntegration({
+			env,
+			baseUrl: 'https://kody.codes',
+			userId,
+			name: 'google',
+			packageId: 'pkg-docs',
+			packageKodyId: 'docs',
+		}),
+	).rejects.toThrow(
+		buildIntegrationPackageApprovalUrl({
+			baseUrl: 'https://kody.codes',
+			name: 'google',
+			packageId: 'pkg-docs',
+			kodyId: 'docs',
+		}),
+	)
+
+	const grantedDocs = await grantIntegrationPackage({
+		env,
+		userId,
+		name: 'google',
+		packageId: 'pkg-docs',
+	})
+	expect(grantedDocs).toMatchObject({
+		usageMode: 'packages',
+		allowedPackageIds: ['pkg-docs', 'pkg-mail'],
+	})
+	await assertCanUseIntegration({
+		env,
+		baseUrl: 'https://kody.codes',
+		userId,
+		name: 'google',
+		packageId: 'pkg-docs',
+	})
+
+	await upsertIntegration({
+		env,
+		userId,
+		config: {
+			...googleConfig,
+			name: 'google-work',
+			accessTokenSecretName: 'googleWorkAccessToken',
+			refreshTokenSecretName: 'googleWorkRefreshToken',
+		},
+	})
+	await persistIntegrationTokens({
+		env,
+		userId,
+		userEmail,
+		name: 'google-work',
+		accessToken: 'work-access',
+		refreshToken: 'work-refresh',
+		accessTokenSecretName: 'googleWorkAccessToken',
+		refreshTokenSecretName: 'googleWorkRefreshToken',
+		descriptionPrefix: 'google-work',
+	})
+
+	expect(await deleteIntegration({ env, userId, name: 'google-work' })).toBe(
+		true,
+	)
+	expect(
+		await resolveSecret({
+			env,
+			userId,
+			name: 'googleWorkAccessToken',
+			scope: 'user',
+			storageContext,
+		}),
+	).toMatchObject({ found: false })
+	expect(
+		await resolveUserOauthAppClientSecret({
+			env,
+			userId,
+			slug: 'google',
+			secretName: 'googleClientSecret',
+		}),
+	).toMatchObject({ value: 'client-secret-live', source: 'integration' })
+
+	await deleteIntegrationOwnedSecrets({
+		env,
+		userId,
+		secretNames: ['googleAccessToken', 'googleRefreshToken'],
+	})
+	const deletedApp = await deleteOauthAppWithConnections({
+		env,
+		userId,
+		slug: 'google',
+	})
+	expect(deletedApp).toEqual({
+		deleted: true,
+		connectionNames: ['google'],
+	})
+	expect(
+		await resolveSecret({
+			env,
+			userId,
+			name: 'googleClientSecret',
+			scope: 'user',
+			storageContext,
+		}),
+	).toMatchObject({ found: false })
+})

--- a/packages/worker/src/integrations/owned-secret-names.ts
+++ b/packages/worker/src/integrations/owned-secret-names.ts
@@ -1,0 +1,78 @@
+/**
+ * Secret-store names that exist only because an OAuth integration or user-lane
+ * app referenced them. Used to hide those rows from standalone secret lists
+ * during the dual-write soak.
+ */
+export async function listReferencedIntegrationSecretNames(input: {
+	db: D1Database
+	userId: string
+}): Promise<Set<string>> {
+	const [connectionResult, appResult] = await Promise.all([
+		input.db
+			.prepare(
+				`SELECT access_token_secret_name, refresh_token_secret_name
+				FROM user_integrations
+				WHERE user_id = ?`,
+			)
+			.bind(input.userId)
+			.all<{
+				access_token_secret_name: string
+				refresh_token_secret_name: string | null
+			}>(),
+		input.db
+			.prepare(
+				`SELECT client_secret_secret_name
+				FROM user_oauth_apps
+				WHERE user_id = ? AND client_secret_secret_name IS NOT NULL`,
+			)
+			.bind(input.userId)
+			.all<{ client_secret_secret_name: string | null }>(),
+	])
+	const names = new Set<string>()
+	for (const row of connectionResult.results ?? []) {
+		const access = row.access_token_secret_name.trim()
+		if (access) names.add(access)
+		const refresh = row.refresh_token_secret_name?.trim()
+		if (refresh) names.add(refresh)
+	}
+	for (const row of appResult.results ?? []) {
+		const clientSecret = row.client_secret_secret_name?.trim()
+		if (clientSecret) names.add(clientSecret)
+	}
+	return names
+}
+
+export async function findIntegrationOwningSecretName(input: {
+	db: D1Database
+	userId: string
+	secretName: string
+}): Promise<{ name: string } | null> {
+	const name = input.secretName.trim()
+	if (!name) return null
+	const connection = await input.db
+		.prepare(
+			`SELECT name
+			FROM user_integrations
+			WHERE user_id = ?
+				AND (
+					access_token_secret_name = ?
+					OR refresh_token_secret_name = ?
+				)
+			LIMIT 1`,
+		)
+		.bind(input.userId, name, name)
+		.first<{ name: string }>()
+	if (connection) return { name: connection.name }
+	const app = await input.db
+		.prepare(
+			`SELECT i.name AS name
+			FROM user_oauth_apps a
+			JOIN user_integrations i
+				ON i.user_id = a.user_id AND i.app_slug = a.slug
+			WHERE a.user_id = ? AND a.client_secret_secret_name = ?
+			LIMIT 1`,
+		)
+		.bind(input.userId, name)
+		.first<{ name: string }>()
+	return app ? { name: app.name } : null
+}

--- a/packages/worker/src/integrations/package-access.ts
+++ b/packages/worker/src/integrations/package-access.ts
@@ -1,0 +1,84 @@
+import { McpCallerError } from '#mcp/caller-error.ts'
+import { getJoinedIntegrationByName } from './repo.ts'
+import { normalizeIntegrationUsageMode } from './usage-mode.ts'
+
+export class IntegrationPackageAccessDeniedError extends McpCallerError {
+	constructor(message: string, options?: ErrorOptions) {
+		super(message, options)
+		this.name = 'IntegrationPackageAccessDeniedError'
+	}
+}
+
+export function buildIntegrationPackageApprovalUrl(input: {
+	baseUrl: string
+	name: string
+	packageId: string
+	kodyId?: string | null
+}) {
+	const url = new URL('/account/integrations/approve', input.baseUrl)
+	url.searchParams.set('name', input.name)
+	url.searchParams.set('package_id', input.packageId)
+	if (input.kodyId) {
+		url.searchParams.set('package', input.kodyId)
+	}
+	return url.toString()
+}
+
+export function createIntegrationPackageAccessDeniedMessage(input: {
+	integrationName: string
+	packageName: string
+	approvalUrl: string
+}) {
+	return `Package "${input.packageName}" is not approved to use integration "${input.integrationName}". Approve it at ${input.approvalUrl}.`
+}
+
+export function createIntegrationExecuteAccessDeniedMessage(input: {
+	integrationName: string
+}) {
+	return `Integration "${input.integrationName}" is limited to specific packages and cannot be used from execute. Approve a package from the account integrations page, or switch the integration back to any context.`
+}
+
+/**
+ * `any` is execute plus every package. `packages` is only the listed ids —
+ * execute (no packageId) is denied. Unlike user secrets, self-authored
+ * packages do not auto-pass.
+ */
+export async function assertCanUseIntegration(input: {
+	env: Pick<Env, 'APP_DB'>
+	baseUrl: string
+	userId: string
+	name: string
+	packageId?: string | null
+	packageKodyId?: string | null
+}): Promise<void> {
+	const joined = await getJoinedIntegrationByName({
+		db: input.env.APP_DB,
+		userId: input.userId,
+		name: input.name,
+	})
+	if (!joined) return
+	const usageMode = normalizeIntegrationUsageMode(joined.connection.usageMode)
+	if (usageMode === 'any') return
+	const packageId = input.packageId?.trim() ?? ''
+	if (!packageId) {
+		throw new IntegrationPackageAccessDeniedError(
+			createIntegrationExecuteAccessDeniedMessage({
+				integrationName: joined.connection.name,
+			}),
+		)
+	}
+	if (joined.connection.allowedPackageIds.includes(packageId)) return
+	const approvalUrl = buildIntegrationPackageApprovalUrl({
+		baseUrl: input.baseUrl,
+		name: joined.connection.name,
+		packageId,
+		kodyId: input.packageKodyId,
+	})
+	throw new IntegrationPackageAccessDeniedError(
+		createIntegrationPackageAccessDeniedMessage({
+			integrationName: joined.connection.name,
+			packageName: input.packageKodyId?.trim() || packageId,
+			approvalUrl,
+		}),
+	)
+}

--- a/packages/worker/src/integrations/repo.ts
+++ b/packages/worker/src/integrations/repo.ts
@@ -1,5 +1,13 @@
 import { parseJsonStringArray } from '@kody-internal/shared/json-parsing.ts'
 import {
+	parseAllowedPackages,
+	stringifyAllowedPackages,
+} from '#mcp/secrets/allowed-packages.ts'
+import {
+	normalizeIntegrationUsageMode,
+	type IntegrationUsageMode,
+} from './usage-mode.ts'
+import {
 	mapPlatformOauthAppRow,
 	type PlatformOauthAppRow,
 } from './platform-apps.ts'
@@ -28,6 +36,8 @@ type JoinedIntegrationRow = NullablePrefixed<UserOauthAppRow, 'a_'> &
 		required_hosts_json: string
 		access_token_secret_name: string
 		refresh_token_secret_name: string | null
+		usage_mode: string | null
+		allowed_packages_json: string | null
 		connected_at: string | null
 		token_refreshed_at: string | null
 		connection_created_at: string
@@ -98,6 +108,8 @@ const joinedSelectColumns = `
 	i.required_hosts_json AS required_hosts_json,
 	i.access_token_secret_name AS access_token_secret_name,
 	i.refresh_token_secret_name AS refresh_token_secret_name,
+	i.usage_mode AS usage_mode,
+	i.allowed_packages_json AS allowed_packages_json,
 	i.connected_at AS connected_at,
 	i.token_refreshed_at AS token_refreshed_at,
 	i.created_at AS connection_created_at,
@@ -500,6 +512,120 @@ export async function deleteIntegrationConnection(input: {
 	return (result.meta.changes ?? 0) > 0
 }
 
+export async function getIntegrationCredentialCiphertexts(input: {
+	db: D1Database
+	userId: string
+	name: string
+}): Promise<{
+	accessTokenEncrypted: string | null
+	refreshTokenEncrypted: string | null
+} | null> {
+	const row = await input.db
+		.prepare(
+			`SELECT access_token_encrypted, refresh_token_encrypted
+			FROM user_integrations
+			WHERE user_id = ? AND name = ?
+			LIMIT 1`,
+		)
+		.bind(input.userId, input.name)
+		.first<{
+			access_token_encrypted: string | null
+			refresh_token_encrypted: string | null
+		}>()
+	if (!row) return null
+	return {
+		accessTokenEncrypted: row.access_token_encrypted,
+		refreshTokenEncrypted: row.refresh_token_encrypted,
+	}
+}
+
+export async function updateIntegrationCredentialCiphertexts(input: {
+	db: D1Database
+	userId: string
+	name: string
+	accessTokenEncrypted: string
+	refreshTokenEncrypted: string | null
+}): Promise<void> {
+	const now = new Date().toISOString()
+	await input.db
+		.prepare(
+			`UPDATE user_integrations
+			SET access_token_encrypted = ?,
+				refresh_token_encrypted = COALESCE(?, refresh_token_encrypted),
+				updated_at = ?
+			WHERE user_id = ? AND name = ?`,
+		)
+		.bind(
+			input.accessTokenEncrypted,
+			input.refreshTokenEncrypted,
+			now,
+			input.userId,
+			input.name,
+		)
+		.run()
+}
+
+export async function getOauthAppClientSecretCiphertext(input: {
+	db: D1Database
+	userId: string
+	slug: string
+}): Promise<string | null> {
+	const row = await input.db
+		.prepare(
+			`SELECT client_secret_encrypted
+			FROM user_oauth_apps
+			WHERE user_id = ? AND slug = ?
+			LIMIT 1`,
+		)
+		.bind(input.userId, input.slug)
+		.first<{ client_secret_encrypted: string | null }>()
+	return row?.client_secret_encrypted ?? null
+}
+
+export async function updateOauthAppClientSecretCiphertext(input: {
+	db: D1Database
+	userId: string
+	slug: string
+	clientSecretEncrypted: string
+}): Promise<void> {
+	const now = new Date().toISOString()
+	await input.db
+		.prepare(
+			`UPDATE user_oauth_apps
+			SET client_secret_encrypted = ?, updated_at = ?
+			WHERE user_id = ? AND slug = ?`,
+		)
+		.bind(input.clientSecretEncrypted, now, input.userId, input.slug)
+		.run()
+}
+
+export async function updateIntegrationUsage(input: {
+	db: D1Database
+	userId: string
+	name: string
+	usageMode: IntegrationUsageMode
+	allowedPackageIds: Array<string>
+}): Promise<boolean> {
+	const now = new Date().toISOString()
+	const result = await input.db
+		.prepare(
+			`UPDATE user_integrations
+			SET usage_mode = ?,
+				allowed_packages_json = ?,
+				updated_at = ?
+			WHERE user_id = ? AND name = ?`,
+		)
+		.bind(
+			input.usageMode,
+			stringifyAllowedPackages(input.allowedPackageIds),
+			now,
+			input.userId,
+			input.name,
+		)
+		.run()
+	return (result.meta.changes ?? 0) > 0
+}
+
 export function mapOauthAppRow(row: UserOauthAppRow): UserOauthApp {
 	return {
 		userId: row.user_id,
@@ -539,6 +665,8 @@ export function mapIntegrationRow(
 		requiredHosts: parseJsonStringArray(row.required_hosts_json),
 		accessTokenSecretName: row.access_token_secret_name,
 		refreshTokenSecretName: row.refresh_token_secret_name,
+		usageMode: normalizeIntegrationUsageMode(row.usage_mode),
+		allowedPackageIds: parseAllowedPackages(row.allowed_packages_json),
 		connectedAt: row.connected_at,
 		tokenRefreshedAt: row.token_refreshed_at,
 		createdAt: row.created_at,
@@ -558,6 +686,8 @@ function mapJoinedRow(row: JoinedIntegrationRow): JoinedIntegration {
 		required_hosts_json: row.required_hosts_json,
 		access_token_secret_name: row.access_token_secret_name,
 		refresh_token_secret_name: row.refresh_token_secret_name,
+		usage_mode: normalizeIntegrationUsageMode(row.usage_mode),
+		allowed_packages_json: row.allowed_packages_json ?? '[]',
 		connected_at: row.connected_at,
 		token_refreshed_at: row.token_refreshed_at,
 		created_at: row.connection_created_at,

--- a/packages/worker/src/integrations/repo.ts
+++ b/packages/worker/src/integrations/repo.ts
@@ -422,6 +422,24 @@ export async function deleteOauthApp(input: {
 	return (result.meta.changes ?? 0) > 0
 }
 
+export async function countOauthAppsByClientSecretName(input: {
+	db: D1Database
+	userId: string
+	secretName: string
+}): Promise<number> {
+	const name = input.secretName.trim()
+	if (!name) return 0
+	const row = await input.db
+		.prepare(
+			`SELECT COUNT(*) AS count
+			FROM user_oauth_apps
+			WHERE user_id = ? AND client_secret_secret_name = ?`,
+		)
+		.bind(input.userId, name)
+		.first<{ count: number }>()
+	return row?.count ?? 0
+}
+
 export async function upsertIntegrationConnection(input: {
 	db: D1Database
 	row: Omit<UserIntegrationRow, 'created_at' | 'updated_at'> & {

--- a/packages/worker/src/integrations/service.ts
+++ b/packages/worker/src/integrations/service.ts
@@ -51,7 +51,7 @@ import {
 export type { IntegrationConfig, PlatformOauthApp }
 
 type IntegrationWriteEnv = Pick<Env, 'APP_DB'> &
-	Partial<Pick<Env, 'COMMUNITY_ASSETS'>>
+	Partial<Pick<Env, 'COMMUNITY_ASSETS' | 'SECRET_STORE_KEY'>>
 
 type LogoWriteInput = {
 	logoBase64?: string | null
@@ -319,8 +319,7 @@ export async function upsertIntegration(
 
 	if (existing && existing.lane === 'user' && existing.app.slug !== appSlug) {
 		await deleteOauthAppIfNoConnections({
-			db: input.env.APP_DB,
-			communityAssets: input.env.COMMUNITY_ASSETS,
+			env: input.env,
 			userId: input.userId,
 			appSlug: existing.app.slug,
 		})
@@ -417,8 +416,7 @@ export async function deleteIntegration(input: {
 	// cleans up the shared app row.
 	if (existing.lane === 'user') {
 		await deleteOauthAppIfNoConnections({
-			db: input.env.APP_DB,
-			communityAssets: input.env.COMMUNITY_ASSETS,
+			env: input.env,
 			userId: input.userId,
 			appSlug: existing.app.slug,
 		})
@@ -432,7 +430,7 @@ export async function deleteIntegration(input: {
  * secret) is operator-owned.
  */
 export async function upsertPlatformIntegration(input: {
-	env: Pick<Env, 'APP_DB'>
+	env: IntegrationWriteEnv
 	userId: string
 	platformAppSlug: string
 	name?: string | null
@@ -504,7 +502,7 @@ export async function upsertPlatformIntegration(input: {
 	// same way a user-lane app switch does.
 	if (existing?.lane === 'user') {
 		await deleteOauthAppIfNoConnections({
-			db: input.env.APP_DB,
+			env: input.env,
 			userId: input.userId,
 			appSlug: existing.app.slug,
 		})
@@ -561,30 +559,35 @@ export async function getAvailablePlatformApp(input: {
 }
 
 async function deleteOauthAppIfNoConnections(input: {
-	db: D1Database
-	communityAssets?: Env['COMMUNITY_ASSETS']
+	env: IntegrationWriteEnv
 	userId: string
 	appSlug: string
 }): Promise<void> {
 	const remaining = await countConnectionsForApp({
-		db: input.db,
+		db: input.env.APP_DB,
 		userId: input.userId,
 		appSlug: input.appSlug,
 	})
 	if (remaining !== 0) return
 	const existing = await getOauthAppBySlug({
-		db: input.db,
+		db: input.env.APP_DB,
 		userId: input.userId,
 		slug: input.appSlug,
 	})
 	await deleteOauthApp({
-		db: input.db,
+		db: input.env.APP_DB,
 		userId: input.userId,
 		slug: input.appSlug,
 	})
-	if (existing && input.communityAssets) {
+	if (!existing) return
+	await deleteIntegrationOwnedSecrets({
+		env: input.env,
+		userId: input.userId,
+		secretNames: [existing.clientSecretSecretName],
+	})
+	if (input.env.COMMUNITY_ASSETS) {
 		await deleteUserOauthAppLogoAsset({
-			env: { COMMUNITY_ASSETS: input.communityAssets },
+			env: { COMMUNITY_ASSETS: input.env.COMMUNITY_ASSETS },
 			logoKey: existing.logoKey ?? null,
 		})
 	}

--- a/packages/worker/src/integrations/service.ts
+++ b/packages/worker/src/integrations/service.ts
@@ -18,6 +18,7 @@ import { deleteIntegrationOwnedSecrets } from './credentials.ts'
 import {
 	addPlatformIntegrationRequiredHosts,
 	countConnectionsForApp,
+	countOauthAppsByClientSecretName,
 	deleteIntegrationConnection,
 	deleteOauthApp,
 	findOauthAppByAppTuple,
@@ -574,17 +575,27 @@ async function deleteOauthAppIfNoConnections(input: {
 		userId: input.userId,
 		slug: input.appSlug,
 	})
-	await deleteOauthApp({
+	const deleted = await deleteOauthApp({
 		db: input.env.APP_DB,
 		userId: input.userId,
 		slug: input.appSlug,
 	})
-	if (!existing) return
-	await deleteIntegrationOwnedSecrets({
-		env: input.env,
-		userId: input.userId,
-		secretNames: [existing.clientSecretSecretName],
-	})
+	if (!deleted || !existing) return
+	const clientSecretName = existing.clientSecretSecretName?.trim() ?? ''
+	if (clientSecretName) {
+		const stillReferenced = await countOauthAppsByClientSecretName({
+			db: input.env.APP_DB,
+			userId: input.userId,
+			secretName: clientSecretName,
+		})
+		if (stillReferenced === 0) {
+			await deleteIntegrationOwnedSecrets({
+				env: input.env,
+				userId: input.userId,
+				secretNames: [clientSecretName],
+			})
+		}
+	}
 	if (input.env.COMMUNITY_ASSETS) {
 		await deleteUserOauthAppLogoAsset({
 			env: { COMMUNITY_ASSETS: input.env.COMMUNITY_ASSETS },

--- a/packages/worker/src/integrations/service.ts
+++ b/packages/worker/src/integrations/service.ts
@@ -8,11 +8,13 @@ import {
 	type IntegrationConfig,
 } from '#mcp/capabilities/integrations/integration-shared.ts'
 import { normalizeAllowedHosts } from '#mcp/secrets/allowed-hosts.ts'
+import { normalizeAllowedPackages } from '#mcp/secrets/allowed-packages.ts'
 import {
 	getPlatformOauthAppBySlug,
 	listPlatformOauthApps,
 	type PlatformOauthApp,
 } from './platform-apps.ts'
+import { deleteIntegrationOwnedSecrets } from './credentials.ts'
 import {
 	addPlatformIntegrationRequiredHosts,
 	countConnectionsForApp,
@@ -25,10 +27,15 @@ import {
 	listJoinedIntegrationsForUser,
 	listOauthAppsByProvider,
 	listOauthAppsWithConnectionCounts,
+	updateIntegrationUsage,
 	updateOauthAppClientCredentials,
 	upsertIntegrationConnection,
 	upsertOauthApp,
 } from './repo.ts'
+import {
+	normalizeIntegrationUsageMode,
+	type IntegrationUsageMode,
+} from './usage-mode.ts'
 import {
 	deleteUserOauthAppLogoAsset,
 	setUserOauthAppLogo,
@@ -110,6 +117,7 @@ export function toIntegrationConfig(
 		requiredHosts: connection.requiredHosts,
 		tokenExchangeStyle: app.tokenExchangeStyle,
 		authorization,
+		...usageFields(connection),
 	})
 }
 
@@ -142,8 +150,17 @@ export function toPlatformIntegrationConfig(
 				scopeSeparator: app.scopeSeparator,
 				extraAuthorizeParams: app.extraAuthorizeParams,
 			},
+			...usageFields(connection),
 		}),
 		platform: true,
+	}
+}
+
+function usageFields(connection: UserIntegrationConnection) {
+	if (connection.usageMode !== 'packages') return {}
+	return {
+		usageMode: 'packages' as const,
+		allowedPackageIds: connection.allowedPackageIds,
 	}
 }
 
@@ -382,6 +399,14 @@ export async function deleteIntegration(input: {
 		name,
 	})
 	if (!existing) return false
+	await deleteIntegrationOwnedSecrets({
+		env: input.env,
+		userId: input.userId,
+		secretNames: [
+			existing.connection.accessTokenSecretName,
+			existing.connection.refreshTokenSecretName,
+		],
+	})
 	const deleted = await deleteIntegrationConnection({
 		db: input.env.APP_DB,
 		userId: input.userId,
@@ -839,6 +864,14 @@ export async function deleteOauthAppWithConnections(input: {
 	const connectionNames: Array<string> = []
 	for (const entry of joined) {
 		if (entry.lane !== 'user' || entry.app.slug !== existing.slug) continue
+		await deleteIntegrationOwnedSecrets({
+			env: input.env,
+			userId: input.userId,
+			secretNames: [
+				entry.connection.accessTokenSecretName,
+				entry.connection.refreshTokenSecretName,
+			],
+		})
 		const deleted = await deleteIntegrationConnection({
 			db: input.env.APP_DB,
 			userId: input.userId,
@@ -852,6 +885,13 @@ export async function deleteOauthAppWithConnections(input: {
 		userId: input.userId,
 		slug: existing.slug,
 	})
+	if (deleted) {
+		await deleteIntegrationOwnedSecrets({
+			env: input.env,
+			userId: input.userId,
+			secretNames: [existing.clientSecretSecretName],
+		})
+	}
 	if (deleted && input.env.COMMUNITY_ASSETS) {
 		await deleteUserOauthAppLogoAsset({
 			env: { COMMUNITY_ASSETS: input.env.COMMUNITY_ASSETS },
@@ -1187,4 +1227,79 @@ async function allocateAppSlug(input: {
 	throw new Error(
 		`Unable to allocate an OAuth app slug for "${input.preferredSlug}".`,
 	)
+}
+
+export async function setIntegrationUsage(input: {
+	env: Pick<Env, 'APP_DB'>
+	userId: string
+	name: string
+	usageMode: IntegrationUsageMode
+	allowedPackageIds?: Array<string>
+}): Promise<UserIntegrationConnection | null> {
+	const name = canonicalIntegrationName(input.name)
+	if (!name) return null
+	const existing = await getJoinedIntegrationByName({
+		db: input.env.APP_DB,
+		userId: input.userId,
+		name,
+	})
+	if (!existing) return null
+	const usageMode = normalizeIntegrationUsageMode(input.usageMode)
+	const allowedPackageIds =
+		usageMode === 'packages'
+			? normalizeAllowedPackages(input.allowedPackageIds ?? [])
+			: []
+	const updated = await updateIntegrationUsage({
+		db: input.env.APP_DB,
+		userId: input.userId,
+		name,
+		usageMode,
+		allowedPackageIds,
+	})
+	if (!updated) return null
+	const saved = await getJoinedIntegrationByName({
+		db: input.env.APP_DB,
+		userId: input.userId,
+		name,
+	})
+	return saved?.connection ?? null
+}
+
+export async function grantIntegrationPackage(input: {
+	env: Pick<Env, 'APP_DB'>
+	userId: string
+	name: string
+	packageId: string
+}): Promise<UserIntegrationConnection | null> {
+	const name = canonicalIntegrationName(input.name)
+	const packageId = input.packageId.trim()
+	if (!name || !packageId) return null
+	const existing = await getJoinedIntegrationByName({
+		db: input.env.APP_DB,
+		userId: input.userId,
+		name,
+	})
+	if (!existing) return null
+	if (existing.connection.usageMode === 'any') return existing.connection
+	if (existing.connection.allowedPackageIds.includes(packageId)) {
+		return existing.connection
+	}
+	const allowedPackageIds = normalizeAllowedPackages([
+		...existing.connection.allowedPackageIds,
+		packageId,
+	])
+	const updated = await updateIntegrationUsage({
+		db: input.env.APP_DB,
+		userId: input.userId,
+		name,
+		usageMode: 'packages',
+		allowedPackageIds,
+	})
+	if (!updated) return null
+	const saved = await getJoinedIntegrationByName({
+		db: input.env.APP_DB,
+		userId: input.userId,
+		name,
+	})
+	return saved?.connection ?? null
 }

--- a/packages/worker/src/integrations/service.ts
+++ b/packages/worker/src/integrations/service.ts
@@ -559,6 +559,26 @@ export async function getAvailablePlatformApp(input: {
 	})
 }
 
+async function deleteUnreferencedClientSecret(input: {
+	env: IntegrationWriteEnv
+	userId: string
+	secretName: string | null | undefined
+}): Promise<void> {
+	const secretName = input.secretName?.trim() ?? ''
+	if (!secretName) return
+	const stillReferenced = await countOauthAppsByClientSecretName({
+		db: input.env.APP_DB,
+		userId: input.userId,
+		secretName,
+	})
+	if (stillReferenced !== 0) return
+	await deleteIntegrationOwnedSecrets({
+		env: input.env,
+		userId: input.userId,
+		secretNames: [secretName],
+	})
+}
+
 async function deleteOauthAppIfNoConnections(input: {
 	env: IntegrationWriteEnv
 	userId: string
@@ -581,21 +601,11 @@ async function deleteOauthAppIfNoConnections(input: {
 		slug: input.appSlug,
 	})
 	if (!deleted || !existing) return
-	const clientSecretName = existing.clientSecretSecretName?.trim() ?? ''
-	if (clientSecretName) {
-		const stillReferenced = await countOauthAppsByClientSecretName({
-			db: input.env.APP_DB,
-			userId: input.userId,
-			secretName: clientSecretName,
-		})
-		if (stillReferenced === 0) {
-			await deleteIntegrationOwnedSecrets({
-				env: input.env,
-				userId: input.userId,
-				secretNames: [clientSecretName],
-			})
-		}
-	}
+	await deleteUnreferencedClientSecret({
+		env: input.env,
+		userId: input.userId,
+		secretName: existing.clientSecretSecretName,
+	})
 	if (input.env.COMMUNITY_ASSETS) {
 		await deleteUserOauthAppLogoAsset({
 			env: { COMMUNITY_ASSETS: input.env.COMMUNITY_ASSETS },
@@ -900,10 +910,10 @@ export async function deleteOauthAppWithConnections(input: {
 		slug: existing.slug,
 	})
 	if (deleted) {
-		await deleteIntegrationOwnedSecrets({
+		await deleteUnreferencedClientSecret({
 			env: input.env,
 			userId: input.userId,
-			secretNames: [existing.clientSecretSecretName],
+			secretName: existing.clientSecretSecretName,
 		})
 	}
 	if (deleted && input.env.COMMUNITY_ASSETS) {

--- a/packages/worker/src/integrations/token-refresh.ts
+++ b/packages/worker/src/integrations/token-refresh.ts
@@ -1,5 +1,11 @@
 import { safeParseHost } from '@kody-internal/shared/url-hosts.ts'
-import { resolveSecret, saveSecret } from '#mcp/secrets/service.ts'
+import {
+	persistIntegrationTokens,
+	resolveIntegrationAccessToken,
+	resolveIntegrationRefreshToken,
+	resolveUserOauthAppClientSecret,
+} from './credentials.ts'
+import { assertCanUseIntegration } from './package-access.ts'
 import {
 	buildOAuthTokenExchangeRequest,
 	resolveTokenExchangeStyle,
@@ -308,6 +314,9 @@ export async function refreshIntegrationTokens(input: {
 	userId: string
 	userEmail?: string | undefined
 	name: string
+	baseUrl?: string
+	packageId?: string | null
+	packageKodyId?: string | null
 	waitUntil?: (promise: Promise<unknown>) => void
 }): Promise<IntegrationTokenRefreshResult> {
 	try {
@@ -331,8 +340,21 @@ async function refreshIntegrationTokensOrThrow(input: {
 	userId: string
 	userEmail?: string | undefined
 	name: string
+	baseUrl?: string
+	packageId?: string | null
+	packageKodyId?: string | null
 	waitUntil?: (promise: Promise<unknown>) => void
 }): Promise<IntegrationTokenRefreshResult> {
+	if (input.baseUrl) {
+		await assertCanUseIntegration({
+			env: input.env,
+			baseUrl: input.baseUrl,
+			userId: input.userId,
+			name: input.name,
+			packageId: input.packageId,
+			packageKodyId: input.packageKodyId,
+		})
+	}
 	const joined = await getJoinedIntegration({
 		env: input.env,
 		userId: input.userId,
@@ -381,7 +403,6 @@ async function refreshIntegrationTokensOrThrow(input: {
 		)
 	}
 
-	const storageContext = { sessionId: null, appId: null, packageId: null }
 	// User-lane destinations are user-configurable (integration_save can point
 	// tokenUrl anywhere), so materializing user secrets here must honor the
 	// same per-secret host allowlist the fetch gateway enforces for
@@ -405,23 +426,32 @@ async function refreshIntegrationTokensOrThrow(input: {
 		)
 	}
 
-	const refreshTokenSecret = await resolveSecret({
+	const refreshTokenSecret = await resolveIntegrationRefreshToken({
 		env: input.env,
 		userId: input.userId,
-		name: refreshTokenSecretName,
-		scope: 'user',
-		storageContext,
+		name: connection.name,
+		secretName: refreshTokenSecretName,
 	})
-	if (!refreshTokenSecret.found || !refreshTokenSecret.value) {
+	if (!refreshTokenSecret.value) {
 		throw fail(
 			`Refresh token secret "${refreshTokenSecretName}" was not found. Reconnect at ${reconnectPath}.`,
 			{ reason: 'missing_refresh_token' },
 		)
 	}
-	assertUserSecretAllowedForTokenHost(
-		refreshTokenSecretName,
-		refreshTokenSecret.allowedHosts,
-	)
+	if (refreshTokenSecret.source === 'secret') {
+		assertUserSecretAllowedForTokenHost(
+			refreshTokenSecretName,
+			refreshTokenSecret.allowedHosts,
+		)
+	} else if (
+		joined.lane === 'user' &&
+		!connection.requiredHosts.includes(tokenHost)
+	) {
+		throw fail(
+			`Integration "${connection.name}" is not approved for host "${tokenHost}".`,
+			{ reason: 'host_not_approved' },
+		)
+	}
 
 	let clientSecret: string | null = null
 	if (app.flow === 'confidential') {
@@ -443,20 +473,27 @@ async function refreshIntegrationTokensOrThrow(input: {
 						{ reason: 'missing_secret' },
 					)
 				}
-				const resolved = await resolveSecret({
+				const resolved = await resolveUserOauthAppClientSecret({
 					env: input.env,
 					userId: input.userId,
-					name: clientSecretSecretName,
-					scope: 'user',
-					storageContext,
+					slug: joined.app.slug,
+					secretName: clientSecretSecretName,
 				})
-				if (resolved.found) {
+				if (resolved.source === 'secret') {
 					assertUserSecretAllowedForTokenHost(
 						clientSecretSecretName,
 						resolved.allowedHosts,
 					)
+				} else if (
+					joined.lane === 'user' &&
+					!connection.requiredHosts.includes(tokenHost)
+				) {
+					throw fail(
+						`Integration "${connection.name}" is not approved for host "${tokenHost}".`,
+						{ reason: 'host_not_approved' },
+					)
 				}
-				clientSecret = resolved.found ? (resolved.value ?? null) : null
+				clientSecret = resolved.value
 				break
 			}
 			default: {
@@ -541,27 +578,18 @@ async function refreshIntegrationTokensOrThrow(input: {
 	const refreshTokenRotated =
 		typeof payload.refresh_token === 'string' &&
 		payload.refresh_token.length > 0
-	if (refreshTokenRotated) {
-		await saveSecret({
-			env: input.env,
-			userId: input.userId,
-			userEmail: input.userEmail,
-			name: refreshTokenSecretName,
-			value: payload.refresh_token as string,
-			scope: 'user',
-			description: `${connection.name} OAuth refresh token`,
-			storageContext,
-		})
-	}
-	await saveSecret({
+	await persistIntegrationTokens({
 		env: input.env,
 		userId: input.userId,
 		userEmail: input.userEmail,
-		name: accessTokenSecretName,
-		value: payload.access_token,
-		scope: 'user',
-		description: `${connection.name} OAuth access token`,
-		storageContext,
+		name: connection.name,
+		accessToken: payload.access_token,
+		refreshToken: refreshTokenRotated
+			? (payload.refresh_token as string)
+			: null,
+		accessTokenSecretName,
+		refreshTokenSecretName,
+		descriptionPrefix: connection.name,
 	})
 
 	const refreshedAt = new Date().toISOString()
@@ -621,6 +649,9 @@ export async function refreshAndMaterializeUserLaneAccessToken(input: {
 	userId: string
 	userEmail?: string | undefined
 	name: string
+	baseUrl?: string
+	packageId?: string | null
+	packageKodyId?: string | null
 	waitUntil?: (promise: Promise<unknown>) => void
 }): Promise<IntegrationRefreshAccessTokenResult> {
 	const joined = await getJoinedIntegration({
@@ -639,14 +670,13 @@ export async function refreshAndMaterializeUserLaneAccessToken(input: {
 
 	const result = await refreshIntegrationTokens(input)
 	const accessTokenSecretName = joined.connection.accessTokenSecretName.trim()
-	const accessTokenSecret = await resolveSecret({
+	const accessToken = await resolveIntegrationAccessToken({
 		env: input.env,
 		userId: input.userId,
-		name: accessTokenSecretName,
-		scope: 'user',
-		storageContext: { sessionId: null, appId: null, packageId: null },
+		name: joined.connection.name,
+		secretName: accessTokenSecretName,
 	})
-	if (!accessTokenSecret.found || !accessTokenSecret.value) {
+	if (!accessToken) {
 		throw callerRefreshError(
 			`Access token secret "${accessTokenSecretName}" was not found after refreshing integration "${joined.connection.name}".`,
 			{
@@ -657,6 +687,6 @@ export async function refreshAndMaterializeUserLaneAccessToken(input: {
 	}
 	return {
 		...result,
-		accessToken: accessTokenSecret.value,
+		accessToken,
 	}
 }

--- a/packages/worker/src/integrations/types.ts
+++ b/packages/worker/src/integrations/types.ts
@@ -4,6 +4,7 @@ import {
 	tokenExchangeStyleValues,
 } from '#mcp/capabilities/integrations/integration-shared.ts'
 import { type PlatformOauthApp } from './platform-apps.ts'
+import { integrationUsageModeValues } from './usage-mode.ts'
 export const oauthAppFlowSchema = z.enum(integrationFlowValues)
 export const oauthTokenExchangeStyleSchema = z.enum(tokenExchangeStyleValues)
 
@@ -45,6 +46,8 @@ export const userIntegrationConnectionSchema = z.object({
 	requiredHosts: z.array(z.string()),
 	accessTokenSecretName: z.string().min(1),
 	refreshTokenSecretName: z.string().min(1).nullable(),
+	usageMode: z.enum(integrationUsageModeValues),
+	allowedPackageIds: z.array(z.string()),
 	connectedAt: z.string().min(1).nullable(),
 	tokenRefreshedAt: z.string().min(1).nullable(),
 	createdAt: z.string().min(1),
@@ -110,6 +113,10 @@ export type UserIntegrationRow = {
 	required_hosts_json: string
 	access_token_secret_name: string
 	refresh_token_secret_name: string | null
+	access_token_encrypted?: string | null
+	refresh_token_encrypted?: string | null
+	usage_mode?: (typeof integrationUsageModeValues)[number]
+	allowed_packages_json?: string
 	connected_at: string | null
 	token_refreshed_at: string | null
 	created_at: string

--- a/packages/worker/src/integrations/usage-mode.ts
+++ b/packages/worker/src/integrations/usage-mode.ts
@@ -1,0 +1,15 @@
+export const integrationUsageModeValues = ['any', 'packages'] as const
+
+export type IntegrationUsageMode = (typeof integrationUsageModeValues)[number]
+
+export function isIntegrationUsageMode(
+	value: string | null | undefined,
+): value is IntegrationUsageMode {
+	return value === 'any' || value === 'packages'
+}
+
+export function normalizeIntegrationUsageMode(
+	value: string | null | undefined,
+): IntegrationUsageMode {
+	return isIntegrationUsageMode(value) ? value : 'any'
+}

--- a/packages/worker/src/mcp/capabilities/integrations/integration-refresh-access-token.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/integrations/integration-refresh-access-token.node.test.ts
@@ -13,11 +13,12 @@ vi.mock('#worker/integrations/package-subscriptions.ts', () => ({
 }))
 import { McpCallerError } from '#mcp/caller-error.ts'
 import { createMcpCallerContext } from '#mcp/context.ts'
-import { PackageSecretAccessDeniedError } from '#mcp/secrets/package-access.ts'
 import { saveSecret, setSecretAllowedHosts } from '#mcp/secrets/service.ts'
 import { insertCommunityFork } from '#worker/community/repo.ts'
 import { upsertPlatformOauthApp } from '#worker/integrations/platform-apps.ts'
+import { IntegrationPackageAccessDeniedError } from '#worker/integrations/package-access.ts'
 import {
+	setIntegrationUsage,
 	upsertIntegration,
 	upsertPlatformIntegration,
 } from '#worker/integrations/service.ts'
@@ -157,6 +158,14 @@ test('self-authored packages can materialize a refreshed access token without an
 		})
 		expect(fetchMock).toHaveBeenCalledTimes(1)
 
+		await setIntegrationUsage({
+			env,
+			userId,
+			name: 'x-kodykoala',
+			usageMode: 'packages',
+			allowedPackageIds: [packageId],
+		})
+
 		const forkPackageId = 'fork-pkg-1'
 		await insertPackage(env, userId, forkPackageId, {
 			name: '@someone/x',
@@ -196,10 +205,10 @@ test('self-authored packages can materialize a refreshed access token without an
 				},
 			),
 		).rejects.toSatisfy((error: unknown) => {
-			expect(error).toBeInstanceOf(PackageSecretAccessDeniedError)
+			expect(error).toBeInstanceOf(IntegrationPackageAccessDeniedError)
 			expect(error).toBeInstanceOf(McpCallerError)
 			expect((error as Error).message).toContain(
-				'is not allowed for package "x-fork"',
+				'is not approved to use integration "x-kodykoala"',
 			)
 			return true
 		})

--- a/packages/worker/src/mcp/capabilities/integrations/integration-refresh-access-token.ts
+++ b/packages/worker/src/mcp/capabilities/integrations/integration-refresh-access-token.ts
@@ -4,8 +4,6 @@ import { defineDomainCapability } from '#mcp/capabilities/define-domain-capabili
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
 import { type CapabilityContext } from '#mcp/capabilities/types.ts'
-import { assertPackageCanAccessResolvedSecret } from '#mcp/secrets/package-access.ts'
-import { resolveSecret } from '#mcp/secrets/service.ts'
 import { getJoinedIntegration } from '#worker/integrations/service.ts'
 import {
 	createPlatformRawTokenRefusedMessage,
@@ -29,40 +27,6 @@ const outputSchema = z.object({
 	refreshTokenRotated: z.boolean(),
 })
 
-async function assertCallerCanUseIntegrationTokenSecrets(input: {
-	env: Env
-	baseUrl: string
-	userId: string
-	storageContext: {
-		sessionId: string | null
-		appId: string | null
-		packageId: string | null
-		storageId: string | null
-	}
-	secretNames: Array<string>
-}) {
-	if (!input.storageContext.packageId) return
-	for (const secretName of input.secretNames) {
-		const resolved = await resolveSecret({
-			env: input.env,
-			userId: input.userId,
-			name: secretName,
-			scope: 'user',
-			storageContext: input.storageContext,
-		})
-		if (!resolved.found) continue
-		await assertPackageCanAccessResolvedSecret({
-			env: input.env,
-			baseUrl: input.baseUrl,
-			userId: input.userId,
-			storageContext: input.storageContext,
-			secretName,
-			resolved,
-			intent: 'use',
-		})
-	}
-}
-
 export const integrationRefreshAccessTokenCapability = defineDomainCapability(
 	capabilityDomainNames.integrations,
 	{
@@ -85,12 +49,6 @@ export const integrationRefreshAccessTokenCapability = defineDomainCapability(
 		outputSchema,
 		async handler(args, ctx: CapabilityContext) {
 			const user = requireMcpUser(ctx.callerContext)
-			const storageContext = {
-				sessionId: ctx.callerContext.storageContext?.sessionId ?? null,
-				appId: ctx.callerContext.storageContext?.appId ?? null,
-				packageId: ctx.callerContext.storageContext?.packageId ?? null,
-				storageId: ctx.callerContext.storageContext?.storageId ?? null,
-			}
 			const joined = await getJoinedIntegration({
 				env: ctx.env,
 				userId: user.userId,
@@ -101,25 +59,14 @@ export const integrationRefreshAccessTokenCapability = defineDomainCapability(
 					createPlatformRawTokenRefusedMessage(joined.connection.name),
 				)
 			}
-			if (joined) {
-				const secretNames = [
-					joined.connection.refreshTokenSecretName,
-					joined.connection.accessTokenSecretName,
-				].filter((name): name is string => Boolean(name?.trim()))
-				await assertCallerCanUseIntegrationTokenSecrets({
-					env: ctx.env,
-					baseUrl: ctx.callerContext.baseUrl,
-					userId: user.userId,
-					storageContext,
-					secretNames,
-				})
-			}
 			try {
 				return await refreshAndMaterializeUserLaneAccessToken({
 					env: ctx.env,
 					userId: user.userId,
 					userEmail: user.email,
 					name: args.name,
+					baseUrl: ctx.callerContext.baseUrl,
+					packageId: ctx.callerContext.storageContext?.packageId ?? null,
 					waitUntil: ctx.waitUntil,
 				})
 			} catch (error) {

--- a/packages/worker/src/mcp/capabilities/integrations/integration-save.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/integrations/integration-save.node.test.ts
@@ -338,6 +338,16 @@ test('integration_save reuses an existing app when credentials match and preserv
 				'Cannot point tokenUrl at host "attacker.example"',
 			),
 	)
+	const sameHost = await integrationSaveCapability.handler(
+		{
+			name: 'google',
+			tokenUrl: 'https://oauth2.googleapis.com/oauth/token',
+		},
+		{ env, callerContext: caller(userId) },
+	)
+	expect(sameHost.integration.tokenUrl).toBe(
+		'https://oauth2.googleapis.com/oauth/token',
+	)
 })
 
 test('integration_delete and credential rotation return the expected MCP response shapes', async () => {

--- a/packages/worker/src/mcp/capabilities/integrations/integration-save.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/integrations/integration-save.node.test.ts
@@ -334,7 +334,9 @@ test('integration_save reuses an existing app when credentials match and preserv
 	).rejects.toSatisfy(
 		(error: unknown) =>
 			error instanceof McpCallerError &&
-			error.message.includes('Cannot point tokenUrl at host "attacker.example"'),
+			error.message.includes(
+				'Cannot point tokenUrl at host "attacker.example"',
+			),
 	)
 })
 

--- a/packages/worker/src/mcp/capabilities/integrations/integration-save.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/integrations/integration-save.node.test.ts
@@ -32,7 +32,10 @@ function createEnv() {
 	applyAllMigrations(sqlite)
 	return {
 		sqlite,
-		env: { APP_DB: createD1FromSqlite(sqlite) } as unknown as Env,
+		env: {
+			APP_DB: createD1FromSqlite(sqlite),
+			SECRET_STORE_KEY: 'test-secret-store-key-32-chars-minimum',
+		} as unknown as Env,
 	}
 }
 
@@ -302,6 +305,37 @@ test('integration_save reuses an existing app when credentials match and preserv
 			extraAuthorizeParams: { access_type: 'offline' },
 		},
 	})
+
+	await expect(
+		integrationSaveCapability.handler(
+			{
+				name: 'google',
+				requiredHosts: [
+					'accounts.google.com',
+					'www.googleapis.com',
+					'attacker.example',
+				],
+			},
+			{ env, callerContext: caller(userId) },
+		),
+	).rejects.toSatisfy(
+		(error: unknown) =>
+			error instanceof McpCallerError &&
+			error.message.includes('Cannot add required hosts (attacker.example)'),
+	)
+	await expect(
+		integrationSaveCapability.handler(
+			{
+				name: 'google',
+				tokenUrl: 'https://attacker.example/token',
+			},
+			{ env, callerContext: caller(userId) },
+		),
+	).rejects.toSatisfy(
+		(error: unknown) =>
+			error instanceof McpCallerError &&
+			error.message.includes('Cannot point tokenUrl at host "attacker.example"'),
+	)
 })
 
 test('integration_delete and credential rotation return the expected MCP response shapes', async () => {

--- a/packages/worker/src/mcp/capabilities/integrations/integration-save.ts
+++ b/packages/worker/src/mcp/capabilities/integrations/integration-save.ts
@@ -128,7 +128,11 @@ function assertIntegrationSaveKeepsApprovedHosts(input: {
 	current: IntegrationConfig
 	next: IntegrationConfig
 }) {
-	const approved = new Set(input.current.requiredHosts ?? [])
+	const currentTokenHost = safeParseHost(input.current.tokenUrl)
+	const approved = new Set([
+		...(input.current.requiredHosts ?? []),
+		...(currentTokenHost ? [currentTokenHost] : []),
+	])
 	const addedHosts = (input.next.requiredHosts ?? []).filter(
 		(host) => !approved.has(host),
 	)

--- a/packages/worker/src/mcp/capabilities/integrations/integration-save.ts
+++ b/packages/worker/src/mcp/capabilities/integrations/integration-save.ts
@@ -128,8 +128,8 @@ function assertIntegrationSaveKeepsApprovedHosts(input: {
 	current: IntegrationConfig
 	next: IntegrationConfig
 }) {
-	const approved = new Set(input.current.requiredHosts)
-	const addedHosts = input.next.requiredHosts.filter(
+	const approved = new Set(input.current.requiredHosts ?? [])
+	const addedHosts = (input.next.requiredHosts ?? []).filter(
 		(host) => !approved.has(host),
 	)
 	if (addedHosts.length > 0) {

--- a/packages/worker/src/mcp/capabilities/integrations/integration-save.ts
+++ b/packages/worker/src/mcp/capabilities/integrations/integration-save.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { safeParseHost } from '@kody-internal/shared/url-hosts.ts'
 import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
@@ -61,6 +62,13 @@ export const integrationSaveCapability = defineDomainCapability(
 			const config = existing
 				? mergeIntegrationConfig(existing, args)
 				: createNewIntegrationConfig(args)
+			if (existing) {
+				assertIntegrationSaveKeepsApprovedHosts({
+					name: existing.name,
+					current: existing,
+					next: config,
+				})
+			}
 			const integration = await upsertIntegration({
 				env: ctx.env,
 				userId: user.userId,
@@ -113,4 +121,27 @@ function createNewIntegrationConfig(
 		)
 	}
 	return normalizeIntegrationConfig(parsed.data)
+}
+
+function assertIntegrationSaveKeepsApprovedHosts(input: {
+	name: string
+	current: IntegrationConfig
+	next: IntegrationConfig
+}) {
+	const approved = new Set(input.current.requiredHosts)
+	const addedHosts = input.next.requiredHosts.filter(
+		(host) => !approved.has(host),
+	)
+	if (addedHosts.length > 0) {
+		throw new McpCallerError(
+			`Cannot add required hosts (${addedHosts.join(', ')}) on "${input.name}" via integration_save. Reconnect at /connect/oauth?provider=${encodeURIComponent(input.name)} so the user can approve new destinations.`,
+		)
+	}
+	if (input.next.tokenUrl === input.current.tokenUrl) return
+	const tokenHost = safeParseHost(input.next.tokenUrl)
+	if (tokenHost && !approved.has(tokenHost)) {
+		throw new McpCallerError(
+			`Cannot point tokenUrl at host "${tokenHost}" on "${input.name}" via integration_save. Reconnect at /connect/oauth?provider=${encodeURIComponent(input.name)} to approve that token endpoint.`,
+		)
+	}
 }

--- a/packages/worker/src/mcp/capabilities/integrations/integration-shared.ts
+++ b/packages/worker/src/mcp/capabilities/integrations/integration-shared.ts
@@ -72,6 +72,12 @@ export const integrationConfigSchema = z.object({
 	 * host-side (`integration_token_refresh`).
 	 */
 	platform: z.boolean().optional(),
+	/**
+	 * Omitted means `any` (execute plus every package). `packages` is only
+	 * the listed saved package ids — execute is denied.
+	 */
+	usageMode: z.enum(['any', 'packages']).optional(),
+	allowedPackageIds: z.array(z.string()).optional(),
 })
 
 export type IntegrationConfig = z.infer<typeof integrationConfigSchema>
@@ -128,6 +134,8 @@ function normalizeIntegrationConfigFields(
 		| 'requiredHosts'
 		| 'tokenExchangeStyle'
 		| 'authorization'
+		| 'usageMode'
+		| 'allowedPackageIds'
 	>,
 ) {
 	const authorization = value.authorization
@@ -153,6 +161,18 @@ function normalizeIntegrationConfigFields(
 		requiredHosts: normalizeAllowedHosts(value.requiredHosts ?? []),
 		...(tokenExchangeStyle ? { tokenExchangeStyle } : {}),
 		...(authorization ? { authorization } : {}),
+		...(value.usageMode === 'packages'
+			? {
+					usageMode: 'packages' as const,
+					allowedPackageIds: Array.from(
+						new Set(
+							(value.allowedPackageIds ?? [])
+								.map((id) => id.trim())
+								.filter(Boolean),
+						),
+					).sort((left, right) => left.localeCompare(right)),
+				}
+			: {}),
 	}
 }
 

--- a/packages/worker/src/mcp/capabilities/integrations/integration-token-refresh.ts
+++ b/packages/worker/src/mcp/capabilities/integrations/integration-token-refresh.ts
@@ -27,7 +27,7 @@ export const integrationTokenRefreshCapability = defineDomainCapability(
 	{
 		name: 'integration_token_refresh',
 		description:
-			'Refresh the OAuth access token for a saved integration host-side and persist the new tokens to the user secret store. Returns metadata only — token values never appear in the output. createAuthenticatedFetch refreshes through this path for every integration; it is the only refresh path for platform (built-in) integrations, whose shared client secret stays server-side.',
+			'Refresh the OAuth access token for a saved integration host-side and persist the new tokens on the connection. Returns metadata only — token values never appear in the output. createAuthenticatedFetch refreshes through this path for every integration; it is the only refresh path for platform (built-in) integrations, whose shared client secret stays server-side.',
 		keywords: [
 			'integration',
 			'oauth',
@@ -53,6 +53,8 @@ export const integrationTokenRefreshCapability = defineDomainCapability(
 					userId: user.userId,
 					userEmail: user.email,
 					name: args.name,
+					baseUrl: ctx.callerContext.baseUrl,
+					packageId: ctx.callerContext.storageContext?.packageId ?? null,
 					waitUntil: ctx.waitUntil,
 				})
 				return {

--- a/packages/worker/src/mcp/fetch-gateway.node.test.ts
+++ b/packages/worker/src/mcp/fetch-gateway.node.test.ts
@@ -14,6 +14,8 @@ import * as secretService from '#mcp/secrets/service.ts'
 import * as communityRepo from '#worker/community/repo.ts'
 import { createInMemoryUserMeterEnv } from '#worker/test-support/user-meter.ts'
 import * as packageRepo from '#worker/package-registry/repo.ts'
+import * as ownedSecretNames from '#worker/integrations/owned-secret-names.ts'
+import * as integrationPackageAccess from '#worker/integrations/package-access.ts'
 
 const userMeter = createInMemoryUserMeterEnv()
 const env = {
@@ -209,6 +211,92 @@ test('fetch gateway requires package approval before resolving user secrets', as
 		packageSpy.mockRestore()
 		forkSpy.mockRestore()
 		resolveSpy.mockRestore()
+	}
+})
+
+test('fetch gateway gates integration-owned token names by the connection grant, not secret allowed_packages', async () => {
+	const request = () =>
+		new Request('https://example.com/api', {
+			headers: {
+				Authorization: 'Bearer {{secret:googleAccessToken|scope=user}}',
+			},
+		})
+	const packageProps = {
+		...props,
+		storageContext: {
+			sessionId: null,
+			appId: 'pkg-1',
+			packageId: 'pkg-1',
+			storageId: 'pkg-1',
+		},
+	}
+	const packageSpy = vi
+		.spyOn(packageRepo, 'getSavedPackageById')
+		.mockResolvedValue({
+			id: 'pkg-1',
+			userId: 'user-123',
+			kodyId: 'example-package',
+			name: '@user/example-package',
+			description: '',
+			tags: [],
+			searchText: null,
+			hasApp: false,
+			hidden: false,
+			isPrivate: false,
+			sourceId: 'source-1',
+			createdAt: '2026-01-01T00:00:00.000Z',
+			updatedAt: '2026-01-01T00:00:00.000Z',
+		})
+	const forkSpy = vi
+		.spyOn(communityRepo, 'getCommunityForkByForkedPackageId')
+		.mockResolvedValue({
+			id: 'fork-1',
+			listingId: 'listing-1',
+			forkerUserId: 'user-123',
+			originCommit: 'abc123',
+			forkedPackageId: 'pkg-1',
+			forkedSourceId: 'source-1',
+			targetKodyId: 'example-package',
+			createdAt: '2026-01-01T00:00:00.000Z',
+			adoptedAt: null,
+			adoptionNote: null,
+		})
+	const resolveSpy = vi.spyOn(secretService, 'resolveSecret').mockResolvedValue({
+		found: true,
+		value: 'oauth-access',
+		scope: 'user',
+		allowedHosts: ['example.com'],
+		allowedCapabilities: [],
+		allowedPackages: [],
+	})
+	const ownerSpy = vi
+		.spyOn(ownedSecretNames, 'findIntegrationOwningSecretName')
+		.mockResolvedValue({ name: 'google' })
+	const grantSpy = vi
+		.spyOn(integrationPackageAccess, 'assertCanUseIntegration')
+		.mockResolvedValue(undefined)
+
+	try {
+		const transformed = await expandSecretPlaceholders({
+			request: request(),
+			props: packageProps,
+			env,
+		})
+		expect(transformed.headers.get('Authorization')).toBe('Bearer oauth-access')
+		expect(grantSpy).toHaveBeenCalledWith(
+			expect.objectContaining({
+				name: 'google',
+				packageId: 'pkg-1',
+			}),
+		)
+		expect(packageSpy).not.toHaveBeenCalled()
+		expect(forkSpy).not.toHaveBeenCalled()
+	} finally {
+		packageSpy.mockRestore()
+		forkSpy.mockRestore()
+		resolveSpy.mockRestore()
+		ownerSpy.mockRestore()
+		grantSpy.mockRestore()
 	}
 })
 

--- a/packages/worker/src/mcp/fetch-gateway.node.test.ts
+++ b/packages/worker/src/mcp/fetch-gateway.node.test.ts
@@ -261,14 +261,16 @@ test('fetch gateway gates integration-owned token names by the connection grant,
 			adoptedAt: null,
 			adoptionNote: null,
 		})
-	const resolveSpy = vi.spyOn(secretService, 'resolveSecret').mockResolvedValue({
-		found: true,
-		value: 'oauth-access',
-		scope: 'user',
-		allowedHosts: ['example.com'],
-		allowedCapabilities: [],
-		allowedPackages: [],
-	})
+	const resolveSpy = vi
+		.spyOn(secretService, 'resolveSecret')
+		.mockResolvedValue({
+			found: true,
+			value: 'oauth-access',
+			scope: 'user',
+			allowedHosts: ['example.com'],
+			allowedCapabilities: [],
+			allowedPackages: [],
+		})
 	const ownerSpy = vi
 		.spyOn(ownedSecretNames, 'findIntegrationOwningSecretName')
 		.mockResolvedValue({ name: 'google' })

--- a/packages/worker/src/mcp/fetch-gateway.ts
+++ b/packages/worker/src/mcp/fetch-gateway.ts
@@ -352,19 +352,14 @@ export async function expandSecretPlaceholders(input: {
 			if (!resolved.found || typeof resolved.value !== 'string') {
 				throw new Error(createMissingSecretMessage(referenced.name))
 			}
-			await assertPackageCanAccessResolvedSecret({
-				env: input.env,
-				baseUrl: input.props.baseUrl,
-				userId: input.props.userId!,
-				storageContext: input.props.storageContext,
-				secretName: referenced.name,
-				resolved,
-			})
 			const owningIntegration = await findIntegrationOwningSecretName({
 				db: input.env.APP_DB,
 				userId: input.props.userId!,
 				secretName: referenced.name,
 			})
+			// Dual-written OAuth names are hidden from /account/secrets, so
+			// secret allowed_packages is not a grant the user can manage.
+			// The connection's any/packages grant is the only package gate.
 			if (owningIntegration) {
 				await assertCanUseIntegration({
 					env: input.env,
@@ -372,6 +367,15 @@ export async function expandSecretPlaceholders(input: {
 					userId: input.props.userId!,
 					name: owningIntegration.name,
 					packageId: input.props.storageContext?.packageId ?? null,
+				})
+			} else {
+				await assertPackageCanAccessResolvedSecret({
+					env: input.env,
+					baseUrl: input.props.baseUrl,
+					userId: input.props.userId!,
+					storageContext: input.props.storageContext,
+					secretName: referenced.name,
+					resolved,
 				})
 			}
 			return { referenced, resolved, value: resolved.value }

--- a/packages/worker/src/mcp/fetch-gateway.ts
+++ b/packages/worker/src/mcp/fetch-gateway.ts
@@ -352,11 +352,14 @@ export async function expandSecretPlaceholders(input: {
 			if (!resolved.found || typeof resolved.value !== 'string') {
 				throw new Error(createMissingSecretMessage(referenced.name))
 			}
-			const owningIntegration = await findIntegrationOwningSecretName({
-				db: input.env.APP_DB,
-				userId: input.props.userId!,
-				secretName: referenced.name,
-			})
+			const owningIntegration =
+				resolved.scope === 'user'
+					? await findIntegrationOwningSecretName({
+							db: input.env.APP_DB,
+							userId: input.props.userId!,
+							secretName: referenced.name,
+						})
+					: null
 			// Dual-written OAuth names are hidden from /account/secrets, so
 			// secret allowed_packages is not a grant the user can manage.
 			// The connection's any/packages grant is the only package gate.

--- a/packages/worker/src/mcp/fetch-gateway.ts
+++ b/packages/worker/src/mcp/fetch-gateway.ts
@@ -21,6 +21,8 @@ import {
 import { normalizeHost } from '#mcp/secrets/allowed-hosts.ts'
 import { resolveSecret, type ResolvedSecret } from '#mcp/secrets/service.ts'
 import { assertPackageCanAccessResolvedSecret } from '#mcp/secrets/package-access.ts'
+import { findIntegrationOwningSecretName } from '#worker/integrations/owned-secret-names.ts'
+import { assertCanUseIntegration } from '#worker/integrations/package-access.ts'
 import { type StorageContext } from '#mcp/storage.ts'
 import {
 	consumeDailyEntitlement,
@@ -358,6 +360,20 @@ export async function expandSecretPlaceholders(input: {
 				secretName: referenced.name,
 				resolved,
 			})
+			const owningIntegration = await findIntegrationOwningSecretName({
+				db: input.env.APP_DB,
+				userId: input.props.userId!,
+				secretName: referenced.name,
+			})
+			if (owningIntegration) {
+				await assertCanUseIntegration({
+					env: input.env,
+					baseUrl: input.props.baseUrl,
+					userId: input.props.userId!,
+					name: owningIntegration.name,
+					packageId: input.props.storageContext?.packageId ?? null,
+				})
+			}
 			return { referenced, resolved, value: resolved.value }
 		}),
 	)

--- a/packages/worker/src/mcp/secrets/crypto.ts
+++ b/packages/worker/src/mcp/secrets/crypto.ts
@@ -144,6 +144,9 @@ const secretStorePurpose = 'mcp-secret-store'
  * them, so sandboxed code has no resolution path to the shared credential.
  */
 const platformOauthClientSecretPurpose = 'platform-oauth-client-secret'
+const userOauthAccessTokenPurpose = 'user-oauth-access-token'
+const userOauthRefreshTokenPurpose = 'user-oauth-refresh-token'
+const userOauthClientSecretPurpose = 'user-oauth-client-secret'
 
 /** AAD context for a user-owned secret ciphertext. */
 export function userSecretContext(userId: string) {
@@ -153,6 +156,19 @@ export function userSecretContext(userId: string) {
 /** AAD context for a platform OAuth app client secret ciphertext. */
 export function platformOauthAppContext(slug: string) {
 	return `app:${slug}`
+}
+
+/** AAD context for a user-lane OAuth connection token ciphertext. */
+export function userIntegrationCredentialContext(
+	userId: string,
+	integrationName: string,
+) {
+	return `user:${userId}:integration:${integrationName}`
+}
+
+/** AAD context for a user-lane OAuth app client secret ciphertext. */
+export function userOauthAppCredentialContext(userId: string, slug: string) {
+	return `user:${userId}:oauth-app:${slug}`
 }
 
 export async function encryptPlatformOauthClientSecret(
@@ -182,6 +198,96 @@ export async function decryptPlatformOauthClientSecret(
 		)
 	} catch {
 		throw new Error('Unable to decrypt platform client secret.')
+	}
+}
+
+export async function encryptUserOauthAccessToken(
+	env: Pick<Env, 'SECRET_STORE_KEY'>,
+	value: string,
+	context: string,
+) {
+	return encryptWithKey(
+		env.SECRET_STORE_KEY,
+		userOauthAccessTokenPurpose,
+		context,
+		value,
+	)
+}
+
+export async function decryptUserOauthAccessToken(
+	env: Pick<Env, 'SECRET_STORE_KEY'>,
+	payload: string,
+	context: string,
+) {
+	try {
+		return await decryptWithKey(
+			env.SECRET_STORE_KEY,
+			userOauthAccessTokenPurpose,
+			context,
+			payload,
+		)
+	} catch {
+		throw new Error('Unable to decrypt integration access token.')
+	}
+}
+
+export async function encryptUserOauthRefreshToken(
+	env: Pick<Env, 'SECRET_STORE_KEY'>,
+	value: string,
+	context: string,
+) {
+	return encryptWithKey(
+		env.SECRET_STORE_KEY,
+		userOauthRefreshTokenPurpose,
+		context,
+		value,
+	)
+}
+
+export async function decryptUserOauthRefreshToken(
+	env: Pick<Env, 'SECRET_STORE_KEY'>,
+	payload: string,
+	context: string,
+) {
+	try {
+		return await decryptWithKey(
+			env.SECRET_STORE_KEY,
+			userOauthRefreshTokenPurpose,
+			context,
+			payload,
+		)
+	} catch {
+		throw new Error('Unable to decrypt integration refresh token.')
+	}
+}
+
+export async function encryptUserOauthClientSecret(
+	env: Pick<Env, 'SECRET_STORE_KEY'>,
+	value: string,
+	context: string,
+) {
+	return encryptWithKey(
+		env.SECRET_STORE_KEY,
+		userOauthClientSecretPurpose,
+		context,
+		value,
+	)
+}
+
+export async function decryptUserOauthClientSecret(
+	env: Pick<Env, 'SECRET_STORE_KEY'>,
+	payload: string,
+	context: string,
+) {
+	try {
+		return await decryptWithKey(
+			env.SECRET_STORE_KEY,
+			userOauthClientSecretPurpose,
+			context,
+			payload,
+		)
+	} catch {
+		throw new Error('Unable to decrypt OAuth app client secret.')
 	}
 }
 

--- a/packages/worker/src/mcp/secrets/reencrypt.node.test.ts
+++ b/packages/worker/src/mcp/secrets/reencrypt.node.test.ts
@@ -5,9 +5,13 @@ import { createD1FromSqlite } from '#worker/test-support/create-d1-from-sqlite.t
 import {
 	decryptPlatformOauthClientSecret,
 	decryptSecretValue,
+	decryptUserOauthAccessToken,
+	decryptUserOauthClientSecret,
 	encryptPlatformOauthClientSecret,
 	encryptSecretValue,
 	platformOauthAppContext,
+	userIntegrationCredentialContext,
+	userOauthAppCredentialContext,
 	userSecretContext,
 } from './crypto.ts'
 import { reencryptLegacySecretCiphertexts } from './reencrypt.ts'
@@ -102,6 +106,60 @@ async function insertPlatformApp(
 		.run(input.slug, input.encryptedSecret)
 }
 
+function insertUserOauthApp(
+	sqlite: DatabaseSync,
+	input: {
+		userId: string
+		slug: string
+		encryptedSecret: string
+	},
+) {
+	sqlite
+		.prepare(
+			`INSERT INTO user_oauth_apps (
+				user_id, slug, provider, label, client_id,
+				token_url, flow, extra_authorize_params_json,
+				client_secret_encrypted
+			) VALUES (
+				?, ?, 'google', NULL, 'client-id',
+				'https://example.com/token', 'confidential', '{}',
+				?
+			)`,
+		)
+		.run(input.userId, input.slug, input.encryptedSecret)
+}
+
+function insertUserIntegration(
+	sqlite: DatabaseSync,
+	input: {
+		userId: string
+		name: string
+		appSlug: string
+		accessTokenEncrypted: string
+		refreshTokenEncrypted: string
+	},
+) {
+	sqlite
+		.prepare(
+			`INSERT INTO user_integrations (
+				user_id, name, app_slug, platform_app_slug,
+				description, scopes_json, required_hosts_json,
+				access_token_secret_name, refresh_token_secret_name,
+				access_token_encrypted, refresh_token_encrypted
+			) VALUES (
+				?, ?, ?, NULL, '', '[]', '[]',
+				'access', 'refresh', ?, ?
+			)`,
+		)
+		.run(
+			input.userId,
+			input.name,
+			input.appSlug,
+			input.accessTokenEncrypted,
+			input.refreshTokenEncrypted,
+		)
+}
+
 function readSecretPayload(
 	sqlite: DatabaseSync,
 	bucketId: string,
@@ -188,6 +246,30 @@ test('legacy secret re-encryption upgrades 2-part payloads, leaves v2 and corrup
 		slug: 'corrupt-app',
 		encryptedSecret: 'totally-broken',
 	})
+	const userAccessLegacy = await encryptLegacyPayload({
+		purpose: 'user-oauth-access-token',
+		plaintext: 'user-access-legacy',
+	})
+	const userRefreshLegacy = await encryptLegacyPayload({
+		purpose: 'user-oauth-refresh-token',
+		plaintext: 'user-refresh-legacy',
+	})
+	const userClientSecretLegacy = await encryptLegacyPayload({
+		purpose: 'user-oauth-client-secret',
+		plaintext: 'user-client-secret-legacy',
+	})
+	insertUserOauthApp(sqlite, {
+		userId: 'user-a',
+		slug: 'google',
+		encryptedSecret: userClientSecretLegacy,
+	})
+	insertUserIntegration(sqlite, {
+		userId: 'user-a',
+		name: 'google',
+		appSlug: 'google',
+		accessTokenEncrypted: userAccessLegacy,
+		refreshTokenEncrypted: userRefreshLegacy,
+	})
 
 	const dryRun = await reencryptLegacySecretCiphertexts({
 		env,
@@ -208,6 +290,20 @@ test('legacy secret re-encryption upgrades 2-part payloads, leaves v2 and corrup
 		decryptFailed: 1,
 		remaining: 2,
 	})
+	expect(dryRun.userIntegrations).toEqual({
+		scanned: 2,
+		rewritten: 2,
+		skippedConcurrent: 0,
+		decryptFailed: 0,
+		remaining: 2,
+	})
+	expect(dryRun.userOauthApps).toEqual({
+		scanned: 1,
+		rewritten: 1,
+		skippedConcurrent: 0,
+		decryptFailed: 0,
+		remaining: 1,
+	})
 	expect(dryRun.decryptFailures).toEqual([
 		{ table: 'secret_entries', key: 'bucket-a/z-corrupt' },
 		{ table: 'platform_oauth_apps', key: 'corrupt-app' },
@@ -227,6 +323,8 @@ test('legacy secret re-encryption upgrades 2-part payloads, leaves v2 and corrup
 	expect(bounded.secretEntries.rewritten).toBe(2)
 	expect(bounded.secretEntries.remaining).toBe(2)
 	expect(bounded.platformOauthApps.scanned).toBe(0)
+	expect(bounded.userIntegrations.scanned).toBe(0)
+	expect(bounded.userOauthApps.scanned).toBe(0)
 
 	const finish = await reencryptLegacySecretCiphertexts({ env, pageSize: 1 })
 	expect(finish.secretEntries).toEqual({
@@ -243,6 +341,47 @@ test('legacy secret re-encryption upgrades 2-part payloads, leaves v2 and corrup
 		decryptFailed: 1,
 		remaining: 1,
 	})
+	expect(finish.userIntegrations).toEqual({
+		scanned: 2,
+		rewritten: 2,
+		skippedConcurrent: 0,
+		decryptFailed: 0,
+		remaining: 0,
+	})
+	expect(finish.userOauthApps).toEqual({
+		scanned: 1,
+		rewritten: 1,
+		skippedConcurrent: 0,
+		decryptFailed: 0,
+		remaining: 0,
+	})
+	const upgradedAccess = sqlite
+		.prepare(
+			`SELECT access_token_encrypted FROM user_integrations
+			WHERE user_id = ? AND name = ?`,
+		)
+		.get('user-a', 'google') as { access_token_encrypted: string }
+	expect(upgradedAccess.access_token_encrypted.startsWith('v2.')).toBe(true)
+	expect(
+		await decryptUserOauthAccessToken(
+			env,
+			upgradedAccess.access_token_encrypted,
+			userIntegrationCredentialContext('user-a', 'google'),
+		),
+	).toBe('user-access-legacy')
+	const upgradedUserClient = sqlite
+		.prepare(
+			`SELECT client_secret_encrypted FROM user_oauth_apps
+			WHERE user_id = ? AND slug = ?`,
+		)
+		.get('user-a', 'google') as { client_secret_encrypted: string }
+	expect(
+		await decryptUserOauthClientSecret(
+			env,
+			upgradedUserClient.client_secret_encrypted,
+			userOauthAppCredentialContext('user-a', 'google'),
+		),
+	).toBe('user-client-secret-legacy')
 
 	const upgradedUserA = readSecretPayload(sqlite, 'bucket-a', 'a-legacy')
 	expect(upgradedUserA.encrypted_value.startsWith('v2.')).toBe(true)

--- a/packages/worker/src/mcp/secrets/reencrypt.ts
+++ b/packages/worker/src/mcp/secrets/reencrypt.ts
@@ -2,15 +2,25 @@ import { runD1WithRetry } from '#worker/d1-retry.ts'
 import {
 	decryptPlatformOauthClientSecret,
 	decryptSecretValue,
+	decryptUserOauthAccessToken,
+	decryptUserOauthClientSecret,
+	decryptUserOauthRefreshToken,
 	encryptPlatformOauthClientSecret,
 	encryptSecretValue,
+	encryptUserOauthAccessToken,
+	encryptUserOauthClientSecret,
+	encryptUserOauthRefreshToken,
 	platformOauthAppContext,
+	userIntegrationCredentialContext,
+	userOauthAppCredentialContext,
 	userSecretContext,
 } from './crypto.ts'
 
 export const secretCiphertextTables = [
 	'secret_entries',
 	'platform_oauth_apps',
+	'user_integrations',
+	'user_oauth_apps',
 ] as const
 
 export type SecretCiphertextTable = (typeof secretCiphertextTables)[number]
@@ -39,6 +49,8 @@ export type ReencryptLegacySecretCiphertextsResult = {
 	dryRun: boolean
 	secretEntries: SecretReencryptTableResult
 	platformOauthApps: SecretReencryptTableResult
+	userIntegrations: SecretReencryptTableResult
+	userOauthApps: SecretReencryptTableResult
 	decryptFailures: Array<SecretReencryptDecryptFailure>
 }
 
@@ -55,6 +67,19 @@ type SecretEntryLegacyRow = {
 }
 
 type PlatformOauthLegacyRow = {
+	slug: string
+	client_secret_encrypted: string
+}
+
+type UserIntegrationLegacyRow = {
+	user_id: string
+	name: string
+	access_token_encrypted: string | null
+	refresh_token_encrypted: string | null
+}
+
+type UserOauthAppLegacyRow = {
+	user_id: string
 	slug: string
 	client_secret_encrypted: string
 }
@@ -115,11 +140,12 @@ function recordDecryptFailure(
 async function countRemaining(input: {
 	db: D1Database
 	sql: string
+	bindings?: Array<string>
 }): Promise<number> {
 	const row = await runD1WithRetry(() =>
 		input.db
 			.prepare(input.sql)
-			.bind(versionedCiphertextPrefix)
+			.bind(...(input.bindings ?? [versionedCiphertextPrefix]))
 			.first<Record<string, unknown>>(),
 	)
 	return readCount(row, 'remaining')
@@ -250,6 +276,141 @@ async function updatePlatformOauthApp(input: {
 	return Number(result.meta.changes ?? 0)
 }
 
+async function listUserIntegrationPage(input: {
+	db: D1Database
+	afterUserId: string
+	afterName: string
+	limit: number
+}): Promise<Array<UserIntegrationLegacyRow>> {
+	const { results } = await runD1WithRetry(() =>
+		input.db
+			.prepare(
+				`SELECT user_id, name, access_token_encrypted, refresh_token_encrypted
+				FROM user_integrations
+				WHERE (
+					(access_token_encrypted IS NOT NULL AND access_token_encrypted NOT LIKE ?)
+					OR (refresh_token_encrypted IS NOT NULL AND refresh_token_encrypted NOT LIKE ?)
+				)
+					AND (user_id > ? OR (user_id = ? AND name > ?))
+				ORDER BY user_id, name
+				LIMIT ?`,
+			)
+			.bind(
+				versionedCiphertextPrefix,
+				versionedCiphertextPrefix,
+				input.afterUserId,
+				input.afterUserId,
+				input.afterName,
+				input.limit,
+			)
+			.all<Record<string, unknown>>(),
+	)
+	return (results ?? []).map((row) => ({
+		user_id: String(row['user_id'] ?? ''),
+		name: String(row['name'] ?? ''),
+		access_token_encrypted:
+			typeof row['access_token_encrypted'] === 'string'
+				? row['access_token_encrypted']
+				: null,
+		refresh_token_encrypted:
+			typeof row['refresh_token_encrypted'] === 'string'
+				? row['refresh_token_encrypted']
+				: null,
+	}))
+}
+
+async function listUserOauthAppPage(input: {
+	db: D1Database
+	afterUserId: string
+	afterSlug: string
+	limit: number
+}): Promise<Array<UserOauthAppLegacyRow>> {
+	const { results } = await runD1WithRetry(() =>
+		input.db
+			.prepare(
+				`SELECT user_id, slug, client_secret_encrypted
+				FROM user_oauth_apps
+				WHERE client_secret_encrypted IS NOT NULL
+					AND client_secret_encrypted NOT LIKE ?
+					AND (user_id > ? OR (user_id = ? AND slug > ?))
+				ORDER BY user_id, slug
+				LIMIT ?`,
+			)
+			.bind(
+				versionedCiphertextPrefix,
+				input.afterUserId,
+				input.afterUserId,
+				input.afterSlug,
+				input.limit,
+			)
+			.all<Record<string, unknown>>(),
+	)
+	return (results ?? []).map((row) => ({
+		user_id: String(row['user_id'] ?? ''),
+		slug: String(row['slug'] ?? ''),
+		client_secret_encrypted: String(row['client_secret_encrypted'] ?? ''),
+	}))
+}
+
+function isLegacyCiphertext(payload: string | null): payload is string {
+	return payload != null && !payload.startsWith('v2.')
+}
+
+async function updateUserIntegrationCiphertext(input: {
+	db: D1Database
+	userId: string
+	name: string
+	column: 'access_token_encrypted' | 'refresh_token_encrypted'
+	nextPayload: string
+	previousPayload: string
+}): Promise<number> {
+	const now = new Date().toISOString()
+	const result = await runD1WithRetry(() =>
+		input.db
+			.prepare(
+				`UPDATE user_integrations
+				SET ${input.column} = ?, updated_at = ?
+				WHERE user_id = ? AND name = ? AND ${input.column} = ?`,
+			)
+			.bind(
+				input.nextPayload,
+				now,
+				input.userId,
+				input.name,
+				input.previousPayload,
+			)
+			.run(),
+	)
+	return Number(result.meta.changes ?? 0)
+}
+
+async function updateUserOauthApp(input: {
+	db: D1Database
+	userId: string
+	slug: string
+	nextPayload: string
+	previousPayload: string
+}): Promise<number> {
+	const now = new Date().toISOString()
+	const result = await runD1WithRetry(() =>
+		input.db
+			.prepare(
+				`UPDATE user_oauth_apps
+				SET client_secret_encrypted = ?, updated_at = ?
+				WHERE user_id = ? AND slug = ? AND client_secret_encrypted = ?`,
+			)
+			.bind(
+				input.nextPayload,
+				now,
+				input.userId,
+				input.slug,
+				input.previousPayload,
+			)
+			.run(),
+	)
+	return Number(result.meta.changes ?? 0)
+}
+
 /**
  * Format-upgrade pass for pre-AAD (2-part) secret ciphertexts. Decrypts via
  * the existing dual-read, re-encrypts as v2 with the owning identity AAD, and
@@ -265,6 +426,8 @@ export async function reencryptLegacySecretCiphertexts(
 	const decryptFailures: Array<SecretReencryptDecryptFailure> = []
 	const secretEntries = emptyTableResult()
 	const platformOauthApps = emptyTableResult()
+	const userIntegrations = emptyTableResult()
+	const userOauthApps = emptyTableResult()
 	const db = input.env.APP_DB
 
 	let afterBucketId = ''
@@ -376,10 +539,146 @@ export async function reencryptLegacySecretCiphertexts(
 				AND client_secret_encrypted NOT LIKE ?`,
 	})
 
+	let afterIntegrationUserId = ''
+	let afterIntegrationName = ''
+	while (remainingBudget > 0) {
+		const rows = await listUserIntegrationPage({
+			db,
+			afterUserId: afterIntegrationUserId,
+			afterName: afterIntegrationName,
+			limit: Math.min(pageSize, remainingBudget),
+		})
+		if (rows.length === 0) break
+		for (const row of rows) {
+			const context = userIntegrationCredentialContext(row.user_id, row.name)
+			const columns = [
+				{
+					column: 'access_token_encrypted' as const,
+					payload: row.access_token_encrypted,
+					decrypt: decryptUserOauthAccessToken,
+					encrypt: encryptUserOauthAccessToken,
+				},
+				{
+					column: 'refresh_token_encrypted' as const,
+					payload: row.refresh_token_encrypted,
+					decrypt: decryptUserOauthRefreshToken,
+					encrypt: encryptUserOauthRefreshToken,
+				},
+			]
+			for (const column of columns) {
+				if (!isLegacyCiphertext(column.payload) || remainingBudget <= 0) {
+					continue
+				}
+				const previousPayload = column.payload!
+				const outcome = await rewritePayload({
+					dryRun,
+					previousPayload,
+					decrypt: () => column.decrypt(input.env, previousPayload, context),
+					encrypt: (plaintext) => column.encrypt(input.env, plaintext, context),
+					write: (nextPayload, previous) =>
+						updateUserIntegrationCiphertext({
+							db,
+							userId: row.user_id,
+							name: row.name,
+							column: column.column,
+							nextPayload,
+							previousPayload: previous,
+						}),
+				})
+				recordOutcome(userIntegrations, outcome)
+				if (outcome === 'decryptFailed') {
+					recordDecryptFailure(decryptFailures, {
+						table: 'user_integrations',
+						key: `${row.user_id}/${row.name}/${column.column}`,
+					})
+				}
+				remainingBudget -= 1
+			}
+		}
+		if (rows.length < pageSize) break
+		const last = rows[rows.length - 1]!
+		afterIntegrationUserId = last.user_id
+		afterIntegrationName = last.name
+	}
+	userIntegrations.remaining = await countRemaining({
+		db,
+		sql: `SELECT (
+				SUM(CASE
+					WHEN access_token_encrypted IS NOT NULL
+						AND access_token_encrypted NOT LIKE ?
+					THEN 1 ELSE 0 END)
+				+ SUM(CASE
+					WHEN refresh_token_encrypted IS NOT NULL
+						AND refresh_token_encrypted NOT LIKE ?
+					THEN 1 ELSE 0 END)
+			) AS remaining
+			FROM user_integrations`,
+		bindings: [versionedCiphertextPrefix, versionedCiphertextPrefix],
+	})
+
+	let afterUserOauthUserId = ''
+	let afterUserOauthSlug = ''
+	while (remainingBudget > 0) {
+		const rows = await listUserOauthAppPage({
+			db,
+			afterUserId: afterUserOauthUserId,
+			afterSlug: afterUserOauthSlug,
+			limit: Math.min(pageSize, remainingBudget),
+		})
+		if (rows.length === 0) break
+		for (const row of rows) {
+			const outcome = await rewritePayload({
+				dryRun,
+				previousPayload: row.client_secret_encrypted,
+				decrypt: () =>
+					decryptUserOauthClientSecret(
+						input.env,
+						row.client_secret_encrypted,
+						userOauthAppCredentialContext(row.user_id, row.slug),
+					),
+				encrypt: (plaintext) =>
+					encryptUserOauthClientSecret(
+						input.env,
+						plaintext,
+						userOauthAppCredentialContext(row.user_id, row.slug),
+					),
+				write: (nextPayload, previousPayload) =>
+					updateUserOauthApp({
+						db,
+						userId: row.user_id,
+						slug: row.slug,
+						nextPayload,
+						previousPayload,
+					}),
+			})
+			recordOutcome(userOauthApps, outcome)
+			if (outcome === 'decryptFailed') {
+				recordDecryptFailure(decryptFailures, {
+					table: 'user_oauth_apps',
+					key: `${row.user_id}/${row.slug}`,
+				})
+			}
+			remainingBudget -= 1
+		}
+		if (rows.length < pageSize) break
+		const last = rows[rows.length - 1]!
+		afterUserOauthUserId = last.user_id
+		afterUserOauthSlug = last.slug
+	}
+	userOauthApps.remaining = await countRemaining({
+		db,
+		sql: `SELECT COUNT(*) AS remaining
+			FROM user_oauth_apps
+			WHERE client_secret_encrypted IS NOT NULL
+				AND client_secret_encrypted NOT LIKE ?`,
+	})
+
 	return {
 		dryRun,
 		secretEntries,
 		platformOauthApps,
+		userIntegrations,
+		userOauthApps,
 		decryptFailures,
 	}
 }

--- a/packages/worker/src/mcp/secrets/service.ts
+++ b/packages/worker/src/mcp/secrets/service.ts
@@ -51,6 +51,7 @@ import {
 } from '#worker/entitlements/service.ts'
 import { type UserMeterEnv } from '#worker/entitlements/user-meter-client.ts'
 import { type SecretMetadata, type SecretScope } from './types.ts'
+import { listReferencedIntegrationSecretNames } from '#worker/integrations/owned-secret-names.ts'
 
 type SecretOwnerContext = {
 	userId: string
@@ -74,6 +75,7 @@ type SaveSecretInput = SecretOwnerContext & {
 type ListSecretsInput = SecretOwnerContext & {
 	env: Pick<Env, 'APP_DB'>
 	scope?: SecretScope | null
+	includeIntegrationOwned?: boolean
 }
 
 type ResolveSecretInput = SecretOwnerContext & {
@@ -627,7 +629,7 @@ export async function listSecrets(
 			}),
 		),
 	)
-	return results
+	const listed = results
 		.flat()
 		.filter((row) => !isReservedSecretName(row.name))
 		.map((row) =>
@@ -644,6 +646,14 @@ export async function listSecrets(
 				expiresAt: row.expires_at,
 			}),
 		)
+	if (input.includeIntegrationOwned) return listed
+	const ownedNames = await listReferencedIntegrationSecretNames({
+		db: input.env.APP_DB,
+		userId: input.userId,
+	})
+	return listed.filter(
+		(row) => row.scope !== 'user' || !ownedNames.has(row.name),
+	)
 }
 
 export async function resolveSecret(
@@ -814,8 +824,14 @@ export async function listUserSecretsForSearch(input: {
 		db: input.env.APP_DB,
 		userId: input.userId,
 	})
+	const ownedNames = await listReferencedIntegrationSecretNames({
+		db: input.env.APP_DB,
+		userId: input.userId,
+	})
 	return rows
-		.filter((row) => !isReservedSecretName(row.name))
+		.filter(
+			(row) => !isReservedSecretName(row.name) && !ownedNames.has(row.name),
+		)
 		.map((row) => ({
 			name: row.name,
 			scope: row.scope,

--- a/packages/worker/src/secret-reencrypt-maintenance.node.test.ts
+++ b/packages/worker/src/secret-reencrypt-maintenance.node.test.ts
@@ -93,6 +93,20 @@ test('secret re-encrypt maintenance route enforces auth and returns counts witho
 			decryptFailed: 0,
 			remaining: 0,
 		},
+		userIntegrations: {
+			scanned: 0,
+			rewritten: 0,
+			skippedConcurrent: 0,
+			decryptFailed: 0,
+			remaining: 0,
+		},
+		userOauthApps: {
+			scanned: 0,
+			rewritten: 0,
+			skippedConcurrent: 0,
+			decryptFailed: 0,
+			remaining: 0,
+		},
 		decryptFailures: [],
 	})
 	expect(JSON.stringify(payload)).not.toMatch(/encrypted/i)

--- a/packages/worker/universal/document-head.ts
+++ b/packages/worker/universal/document-head.ts
@@ -137,6 +137,7 @@ const routeDocumentHeads = {
 	[routePattern(routes.accountUsage)]: titleOnly('Usage'),
 	[routePattern(routes.accountIntegrations)]: titleOnly('Integrations'),
 	[routePattern(routes.accountOauthAppDetail)]: titleOnly('Integrations'),
+	[routePattern(routes.accountIntegrationsApprove)]: titleOnly('Integrations'),
 	[routePattern(routes.accountIntegrationDetail)]: titleOnly('Integrations'),
 	[routePattern(routes.accountMcpServers)]: titleOnly('MCP servers'),
 	[routePattern(routes.accountMcpServerNew)]: titleOnly('MCP servers'),

--- a/packages/worker/universal/loader-data.ts
+++ b/packages/worker/universal/loader-data.ts
@@ -956,6 +956,9 @@ export type AccountIntegrationListItem = {
 	platformDescription?: string | null
 	createdAt: string
 	updatedAt: string
+	/** Omitted or `any` is execute plus every package. */
+	usageMode?: 'any' | 'packages'
+	allowedPackageIds?: Array<string>
 }
 
 export type AccountOauthAppConnectionRef = {
@@ -1004,6 +1007,14 @@ export type AccountIntegrationsLoaderData = {
 	username: string
 	integrations: Array<AccountIntegrationListItem>
 	apps: Array<AccountOauthAppListItem>
+	savedPackages?: Array<{ id: string; kodyId: string }>
+	approval?: {
+		name: string
+		packageId: string
+		packageKodyId: string | null
+		usageMode: 'any' | 'packages'
+		alreadyGranted: boolean
+	} | null
 }
 
 export type AccountIntegrationDetailLoaderData = {

--- a/packages/worker/universal/routes.ts
+++ b/packages/worker/universal/routes.ts
@@ -17,6 +17,9 @@ export const routes = route({
 	// resolves at `/account/integrations/apps` while OAuth apps live under
 	// `/account/integrations/apps/:appSlug`.
 	accountOauthAppDetail: '/account/integrations/apps/:appSlug',
+	// Static `/approve` must win over `:integrationName` so a connection named
+	// `approve` is not required to claim the one-click grant URL.
+	accountIntegrationsApprove: '/account/integrations/approve',
 	accountIntegrationDetail: '/account/integrations/:integrationName',
 	accountIntegrationsApi: '/account/integrations.json',
 	accountIntegrationsApiPost: post('/account/integrations.json'),

--- a/tools/migration-ledger.json
+++ b/tools/migration-ledger.json
@@ -103,6 +103,10 @@
 		{
 			"filename": "0025-user-oauth-app-logos.sql",
 			"sha256": "f3eac0872fcf55ebf9e1821591a0cc4d8ceb3f06033646925899f3f2ea8233c8"
+		},
+		{
+			"filename": "0026-integration-owned-credentials.sql",
+			"sha256": "cedea1c9d99566ef07cc1f942037c3a7f9045ae594ff3165eafd3adb208a08fb"
 		}
 	]
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Keep OAuth connection credentials on the integration, not as standalone secret-store entries the user has to manage. Let execute use a connection immediately, and give the user a grant that can later limit that connection to specific packages.

## Why

OAuth access/refresh tokens and a user-lane client secret only exist because a connection exists. Listing them next to PATs and API keys is the wrong IA and makes package grants a secret-store problem. Secrets stay the home for standalone credentials.

## Summary

- Migration `0026` adds encrypted token/client-secret columns plus `usage_mode` (`any` | `packages`) and `allowed_packages_json`.
- Connect, rotate, and token refresh persist ciphertext on the connection/app and dual-write `secret_entries` for soak.
- Integration-owned secret names are hidden from `/account/secrets`, `secret_list`, and search.
- `any` is execute plus every package. `packages` is only the listed ids; execute is denied. Approving a package never switches `any` → `packages`.
- One-click `/account/integrations/approve?name=&package_id=` plus visible usage controls on each connection.
- Account export redacts the new ciphertext columns.
- Dual-write / `*_secret_name` drop waits on soak: [#1773](https://github.com/kentcdodds/kody/issues/1773).

## Review follow-ups

Addressed Cursor Bugbot and valid CodeRabbit notes:

- Fetch gateway uses the connection grant for user-scoped integration-owned token names.
- Last-connection disconnect and explicit app delete delete the leftover client secret only when no other app still names it.
- `integration_save` cannot add new required hosts or retarget `tokenUrl` to an unapproved host; the current token host counts as approved.
- Secret approval lookups include integration-owned rows so soak dual-write approval links still work. The list page still hides those names.
- Docs now distinguish connection ciphertext from standalone secret-store credentials, and ciphertext refresh uses `requiredHosts`.

Skipped as nits: disable every Save usage button while one save is in flight; hide the approve card for an unknown package id; skip owned-name lookup on non-user secret lists; drop the extra `saveSecret` before `persistIntegrationTokens`.

## Testing

- Focused node-unit: owned-credentials, fetch-gateway, integration-save, token-refresh, account-secrets, service
- Worker typecheck
- Preview-manual-test as `me@kentcdodds.com` on https://kody-pr-1771.kody-a99.workers.dev: connected `preview-ship`, hid those names from `/account/secrets.json` (only `githubPat` listed), toggled usage, approve URL rendered. UI pass confirmed usage radios and the approve card.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `b109b3c` · **Head:** `4f245e6`

**Classification:** extends — integrations now own encrypted OAuth credentials and a user-gated any/packages grant; secret list/search hide those dual-write names; D1 and account export grow ciphertext columns.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `integrations` | assistant | extends — tokens/client secret live encrypted on the connection/app; `usage_mode` + allowed packages; primitives.yaml summary updated |
| `mcp-server` | surfaces | extends — fetch gateway checks the integration grant; secret list/search hide owned names; new AAD purposes + reencrypt tables |
| `app-ui` | surfaces | extends — usage controls, `/account/integrations/approve`, connect persist/rotate write ciphertext |
| `d1-app-db` | storage | extends — `0026` ciphertext + grant columns |
| `account-export` | assistant | extends — redacts `access_token_encrypted`, `refresh_token_encrypted`, `client_secret_encrypted` |

### Change flow

Connect, refresh, and package fetch persist or read integration-owned credentials and enforce the user-gated grant.

```mermaid
sequenceDiagram
	actor User
	participant appUi as app-ui
	participant mcpServer as mcp-server
	participant integrations as integrations
	participant d1AppDb as d1-app-db
	User->>appUi: finish /connect/oauth or rotate
	appUi->>integrations: persistIntegrationTokens / persistUserOauthAppClientSecret
	integrations->>d1AppDb: write ciphertext + dual-write secret_entries
	mcpServer->>integrations: refreshIntegrationTokens / fetch placeholder
	integrations->>integrations: assertCanUseIntegration any vs packages
	integrations->>d1AppDb: read ciphertext then secret-store fallback
	opt packages mode and package not listed
		integrations-->>User: /account/integrations/approve?name=&package_id=
		User->>appUi: Approve
		appUi->>integrations: grantIntegrationPackage keeps any if already any
	end
```

### Before / after

| Surface | Before | After |
| --- | --- | --- |
| Token storage | `secret_entries` only | ciphertext on `user_integrations` / `user_oauth_apps` + soak dual-write |
| Secret list | OAuth token names visible | those names hidden unless `includeIntegrationOwned` |
| Execute / package use | no integration grant | `any` allows both; `packages` allows listed ids only |
| Account export | names only | ciphertext columns redacted |

### Invariants

Per-user isolation stays on `(user_id, name)` / `(user_id, slug)`. Agents cannot set `usageMode` via `integration_save`. Approving a package must not lock execute out of an `any` connection. `integration_save` cannot add required hosts or retarget `tokenUrl` to an unapproved host.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fa394a15-0a40-43d3-b71c-2a848fece0f9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fa394a15-0a40-43d3-b71c-2a848fece0f9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Manage integration usage for all contexts or selected saved packages.
  * Review and approve package access from a dedicated integrations page.
  * Integration OAuth credentials are securely stored and reused during token refresh.
  * Integration-owned credentials are separated from regular secret listings.
  * Integration updates now validate approved hosts and token URLs.

* **Bug Fixes**
  * Improved package and fork access enforcement for integrations.
  * Account exports redact encrypted integration credentials.
  * Added support for safely re-encrypting legacy integration credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->