### PR TITLE
Reveal copy-pill tooltips on hover

### DIFF
--- a/packages/worker/client/routes/account-integrations.tsx
+++ b/packages/worker/client/routes/account-integrations.tsx
@@ -615,9 +615,11 @@ const builtInIndicatorCss = {
 		border: '6px solid transparent',
 		borderTopColor: colors.surface,
 	},
-	[`${hoverMq} &:hover [role="tooltip"]`]: {
-		opacity: 1,
-		visibility: 'visible' as const,
+	[hoverMq]: {
+		'&:hover [role="tooltip"]': {
+			opacity: 1,
+			visibility: 'visible' as const,
+		},
 	},
 	'&:focus-visible [role="tooltip"]': {
 		opacity: 1,

--- a/packages/worker/client/routes/onboarding-diy-card.tsx
+++ b/packages/worker/client/routes/onboarding-diy-card.tsx
@@ -2,6 +2,7 @@ import { type Handle, css } from 'remix/ui'
 import { writeClipboardText } from '#client/clipboard.ts'
 import { on } from '#client/event-mixin.ts'
 import { colors, typography } from '#universal/styles/tokens.ts'
+import { mergeCss } from '#universal/styles/style-primitives.ts'
 import {
 	starterCardCss,
 	starterCopyPromptTooltipCss,
@@ -117,10 +118,10 @@ const diyDescriptionCss = {
 	lineHeight: 1.45,
 }
 
-const diyCopyButtonCss = {
-	...starterGhostButtonCss,
-	...starterCopyPromptTooltipCss,
-}
+const diyCopyButtonCss = mergeCss(
+	starterGhostButtonCss,
+	starterCopyPromptTooltipCss,
+)
 
 const diyRowCss = {
 	...starterRowCss,
@@ -137,10 +138,12 @@ const diyRowBodyCss = {
 	justifyItems: 'start',
 }
 
-const diyRowCopyButtonCss = {
-	...starterGhostButtonCss,
-	...starterCopyPromptTooltipCss,
-	width: 'auto',
-	flex: 'none',
-	fontSize: '0.9rem',
-}
+const diyRowCopyButtonCss = mergeCss(
+	starterGhostButtonCss,
+	starterCopyPromptTooltipCss,
+	{
+		width: 'auto',
+		flex: 'none',
+		fontSize: '0.9rem',
+	},
+)

--- a/packages/worker/client/routes/onboarding-example-card.tsx
+++ b/packages/worker/client/routes/onboarding-example-card.tsx
@@ -15,6 +15,7 @@ import { colors, radius, transitions } from '#universal/styles/tokens.ts'
 import {
 	getPillButtonCss,
 	hoverMq,
+	mergeCss,
 	primaryLinkCss,
 } from '#universal/styles/style-primitives.ts'
 import {
@@ -345,16 +346,18 @@ const exampleTryButtonCss = {
 	fontSize: '0.95rem',
 }
 
-const exampleCopyButtonCss = {
-	...getPillButtonCss(),
-	width: '100%',
-	fontSize: '0.95rem',
-	...starterCopyPromptTooltipCss,
-	'[data-selected] &': {
-		width: 'auto',
-		justifySelf: 'start',
+const exampleCopyButtonCss = mergeCss(
+	getPillButtonCss(),
+	starterCopyPromptTooltipCss,
+	{
+		width: '100%',
+		fontSize: '0.95rem',
+		'[data-selected] &': {
+			width: 'auto',
+			justifySelf: 'start',
+		},
 	},
-}
+)
 
 const examplePromptBlockCss = {
 	margin: 0,

--- a/packages/worker/client/routes/onboarding-starter-card.node.test.ts
+++ b/packages/worker/client/routes/onboarding-starter-card.node.test.ts
@@ -1,0 +1,34 @@
+import { jsx } from 'remix/ui/jsx-runtime'
+import { renderToString } from 'remix/ui/server'
+import { expect, test } from 'vitest'
+import { OnboardingStarterCard } from './onboarding-starter-card.tsx'
+
+test('advanced-row Copy prompt keeps pill hover lift and reveals its tooltip', async () => {
+	const html = await renderToString(
+		jsx(OnboardingStarterCard, {
+			loggedIn: true,
+			variant: 'row',
+			listing: {
+				id: 'listing-1',
+				kodyId: 'demo',
+				name: 'Demo',
+				description: 'A demo package',
+				iconUrl: '/icon.png',
+				tags: [],
+				viewerInstall: {
+					status: 'installed',
+					targetName: '@me/demo',
+					agentPrompt: 'Finish setup for this package.',
+					packageId: 'pkg-1',
+					listingAhead: false,
+					listingAheadPrompt: null,
+				},
+			},
+		}),
+	)
+
+	expect(html).toContain('data-testid="onboarding-starter-copy-listing-1"')
+	expect(html).toMatch(
+		/@media \(hover: hover\) and \(pointer: fine\) \{[\s\S]*&:not\(:disabled\):hover \{[\s\S]*translateY\(-1px\)[\s\S]*&:hover \[role="tooltip"\] \{\s*opacity: 1;\s*visibility: visible;/,
+	)
+})

--- a/packages/worker/client/routes/onboarding-starter-card.tsx
+++ b/packages/worker/client/routes/onboarding-starter-card.tsx
@@ -462,11 +462,11 @@ const starterErrorCss = {
 	textWrap: 'pretty' as const,
 }
 
-const rowCopyPromptButtonCss = {
-	...getPillButtonCss(),
-	...rowActionButtonSizeCss,
-	...starterCopyPromptTooltipCss,
-}
+const rowCopyPromptButtonCss = mergeCss(
+	getPillButtonCss(),
+	rowActionButtonSizeCss,
+	starterCopyPromptTooltipCss,
+)
 
 const starterRowStatusCss = {
 	...starterStatusCss,

--- a/packages/worker/client/routes/onboarding-starter-card.tsx
+++ b/packages/worker/client/routes/onboarding-starter-card.tsx
@@ -22,6 +22,7 @@ import {
 	getGhostButtonCss,
 	getPillButtonCss,
 	hoverMq,
+	mergeCss,
 } from '#universal/styles/style-primitives.ts'
 
 type OnboardingStarterCardProps = {
@@ -375,9 +376,11 @@ export const starterCopyPromptTooltipCss = {
 		border: '6px solid transparent',
 		borderTopColor: colors.surface,
 	},
-	[`${hoverMq} &:hover [role="tooltip"]`]: {
-		opacity: 1,
-		visibility: 'visible' as const,
+	[hoverMq]: {
+		'&:hover [role="tooltip"]': {
+			opacity: 1,
+			visibility: 'visible' as const,
+		},
 	},
 	'&:focus-visible [role="tooltip"]': {
 		opacity: 1,
@@ -385,11 +388,11 @@ export const starterCopyPromptTooltipCss = {
 	},
 }
 
-const copyPromptButtonCss = {
-	...getPillButtonCss(),
-	...starterActionButtonSizeCss,
-	...starterCopyPromptTooltipCss,
-}
+const copyPromptButtonCss = mergeCss(
+	getPillButtonCss(),
+	starterActionButtonSizeCss,
+	starterCopyPromptTooltipCss,
+)
 
 /* Compact "Advanced" list row: icon + text left, action right, status wraps
    to a full-width line beneath. */

--- a/packages/worker/universal/fork-outdated-copy-button.node.test.ts
+++ b/packages/worker/universal/fork-outdated-copy-button.node.test.ts
@@ -1,0 +1,23 @@
+import { renderToString } from 'remix/ui/server'
+import { expect, test } from 'vitest'
+import {
+	FORK_OUTDATED_COPY_TOOLTIP,
+	renderCopyPromptPill,
+} from '#universal/fork-outdated-copy-button.tsx'
+
+test('fork outdated copy pill reveals its tooltip on hover devices', async () => {
+	const html = await renderToString(
+		renderCopyPromptPill({
+			label: 'Fork outdated',
+			prompt: 'Compare the listing and absorb updates.',
+			testId: 'community-detail-listing-ahead-badge',
+			tooltip: FORK_OUTDATED_COPY_TOOLTIP,
+			tone: 'outdated',
+		}),
+	)
+
+	expect(html).toMatch(
+		/@media \(hover: hover\) and \(pointer: fine\) \{[\s\S]*&:hover \[role="tooltip"\] \{\s*opacity: 1;\s*visibility: visible;/,
+	)
+	expect(html).toContain(FORK_OUTDATED_COPY_TOOLTIP)
+})

--- a/packages/worker/universal/fork-outdated-copy-button.tsx
+++ b/packages/worker/universal/fork-outdated-copy-button.tsx
@@ -2,7 +2,7 @@
 /** @jsxRuntime automatic */
 import { type Handle, css } from 'remix/ui'
 import { communityStatusPillBoxCss } from '#universal/community-status-pill.ts'
-import { hoverMq } from '#universal/styles/style-primitives.ts'
+import { hoverMq, mergeCss } from '#universal/styles/style-primitives.ts'
 import {
 	colors,
 	radius,
@@ -109,9 +109,11 @@ const copyPromptTooltipCss = {
 		border: '6px solid transparent',
 		borderTopColor: colors.surface,
 	},
-	[`${hoverMq} &:hover [role="tooltip"]`]: {
-		opacity: 1,
-		visibility: 'visible' as const,
+	[hoverMq]: {
+		'&:hover [role="tooltip"]': {
+			opacity: 1,
+			visibility: 'visible' as const,
+		},
 	},
 	'&:focus-visible [role="tooltip"]': {
 		opacity: 1,
@@ -135,8 +137,7 @@ const copyPromptButtonBaseCss = {
  * `z-index` lifts the control above a listing card's stretched name-link
  * overlay so the click hits the button instead of the card.
  */
-const forkOutdatedCopyButtonCss = {
-	...copyPromptButtonBaseCss,
+const forkOutdatedCopyButtonCss = mergeCss(copyPromptButtonBaseCss, {
 	color: 'oklch(0.48 0.12 85)',
 	backgroundColor: 'oklch(0.88 0.12 95 / 0.92)',
 	[hoverMq]: {
@@ -148,10 +149,9 @@ const forkOutdatedCopyButtonCss = {
 		outline: `2px solid oklch(0.7 0.14 90)`,
 		outlineOffset: '2px',
 	},
-}
+})
 
-const badgeCopyPromptButtonCss = {
-	...copyPromptButtonBaseCss,
+const badgeCopyPromptButtonCss = mergeCss(copyPromptButtonBaseCss, {
 	color: colors.primaryText,
 	backgroundColor: `oklch(from ${colors.primary} l c h / 0.13)`,
 	[hoverMq]: {
@@ -163,4 +163,4 @@ const badgeCopyPromptButtonCss = {
 		outline: `2px solid ${colors.primary}`,
 		outlineOffset: '2px',
 	},
-}
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

The Fork outdated (and other copy-prompt) tooltips should appear on mouse hover the same way they already appear on keyboard focus.

## Why

The hover rule was written as one concatenated key (`@media … &:hover [role="tooltip"]`). Remix does not emit that as a media query, so only `:focus-visible` worked. Nesting the hover rule under `hoverMq` emits a real `@media (hover: hover) and (pointer: fine)` block.

## Summary

- Nested the tooltip hover reveal under `hoverMq` on the Fork outdated / Installed / Forked pills, onboarding Copy prompt buttons, and the built-in integration indicator.
- Used `mergeCss` so the hover media block keeps both the tooltip reveal and the pill background / lift.
- Follow-up: Advanced-row Copy prompt was still spreading tooltip CSS over `getPillButtonCss()`, which clobbered the pill hover lift. It now uses `mergeCss` too.
- Node tests lock the hover media query on the community pill and on the Advanced-row Copy prompt (tooltip reveal plus `translateY(-1px)` lift).

## Testing

- Node-unit: hover media query emits `&:hover [role="tooltip"] { visibility: visible }`.
- Advanced-row Copy prompt render test: same hover media block also keeps the pill lift.
- Chromium hover on the real rendered Fork outdated pill: tooltip `visibility` goes `hidden` → `visible`, opacity `1`. Focus still shows it.
- Pre-push `test:push`: node-unit 2079, workers-unit 301, Playwright 7 — all passed.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `b109b3cd` · **Head:** `13c12bab`

**Classification:** composes — CSS selector nesting only; no new primitives or product contract.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `app-ui` | surfaces | composes — hover tooltip CSS now nests under `hoverMq` |

### Change flow

Hover on a fine pointer reveals the copy-pill tooltip; focus-visible is unchanged. Advanced-row Copy prompt keeps the pill lift in the same hover media block.

```mermaid
sequenceDiagram
	actor User
	participant appUi as app-ui
	User->>appUi: hover Fork outdated pill
	appUi-->>User: tooltip visible via hoverMq
	User->>appUi: hover Advanced-row Copy prompt
	appUi-->>User: tooltip plus pill lift via mergeCss
	User->>appUi: keyboard focus
	appUi-->>User: tooltip visible via focus-visible
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d2e9331f-8e81-48a9-8bb2-55b7442a5065?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d2e9331f-8e81-48a9-8bb2-55b7442a5065&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

