### PR TITLE
Prefer auto-favicons over catalog SVGs on saved integrations

### DIFF
--- a/docs/contributing/architecture/integrations.md
+++ b/docs/contributing/architecture/integrations.md
@@ -172,8 +172,8 @@ active image format is never stored or served. Assets live in the
 `platform_oauth_apps.logo_key` / `logo_content_type` point at the current asset.
 Serving is the public `/integrations/logos/:integrationSlug` route with
 immutable caching; projections expose the relative `logoPath`. The connect page
-and account integration views render it, falling back to the built-in
-`ProviderIcon` set.
+and account integration views render it, falling back to the auto-favicon and
+then the letter.
 
 User-lane OAuth apps have the same asset pipeline on `user_oauth_apps`
 (`logo_key`, `logo_content_type`, `logo_source`, `favicon_source_host`).
@@ -183,9 +183,8 @@ registrable-domain favicon of `authorizeUrl` (then `apiBaseUrl` / `tokenUrl`)
 over HTTPS with manual redirects, prefer `apple-touch-icon` then `rel=icon`,
 accept `/favicon.ico` only when it embeds a PNG, and store a raster under
 `user-oauth-app-logos/{userId}/{slug}/`. Display order is explicit upload,
-official `ProviderIcon` catalog, auto-favicon, then the letter fallback. The
-same `/integrations/logos/:slug` route serves user assets only to the signed-in
-owner after a platform miss.
+auto-favicon, then the letter fallback. The same `/integrations/logos/:slug`
+route serves user assets only to the signed-in owner after a platform miss.
 
 ### Admin provisioning
 

--- a/packages/worker/client/provider-icons.node.test.ts
+++ b/packages/worker/client/provider-icons.node.test.ts
@@ -35,31 +35,22 @@ test('resolveProviderIconId matches exact keys, families, and authorize hosts', 
 	).toBeNull()
 })
 
-test('resolveProviderMarkSource prefers upload, then catalog, then favicon', () => {
+test('resolveProviderMarkSource prefers upload, then favicon, then letter', () => {
 	expect(
 		resolveProviderMarkSource({
-			providerKey: 'dropbox',
 			logoPath: '/integrations/logos/dropbox?v=1',
 			autoLogoPath: '/integrations/logos/dropbox?v=2',
 		}),
 	).toBe('upload')
 	expect(
 		resolveProviderMarkSource({
-			providerKey: 'dropbox',
 			autoLogoPath: '/integrations/logos/dropbox?v=2',
-		}),
-	).toBe('catalog')
-	expect(
-		resolveProviderMarkSource({
-			providerKey: 'obscure-crm',
-			host: 'login.unknown.test',
-			autoLogoPath: '/integrations/logos/obscure-crm?v=2',
 		}),
 	).toBe('favicon')
 	expect(
 		resolveProviderMarkSource({
-			providerKey: 'obscure-crm',
-			host: 'login.unknown.test',
+			autoLogoPath: '/integrations/logos/obscure-crm?v=2',
 		}),
-	).toBe('letter')
+	).toBe('favicon')
+	expect(resolveProviderMarkSource({})).toBe('letter')
 })

--- a/packages/worker/client/provider-icons.tsx
+++ b/packages/worker/client/provider-icons.tsx
@@ -477,25 +477,23 @@ export function ProviderIcon(
 }
 
 /**
- * Display priority for a provider mark: explicit upload, official catalog
- * SVG, auto-fetched favicon, then the letter fallback.
+ * Display priority for a provider mark: explicit upload, auto-fetched
+ * favicon, then the letter fallback. Saved integrations do not use the
+ * official catalog SVGs — those stay on login and onboarding.
  */
 export function resolveProviderMarkSource(input: {
-	providerKey: string
-	host?: string | null
 	logoPath?: string | null
 	autoLogoPath?: string | null
-}): 'upload' | 'catalog' | 'favicon' | 'letter' {
+}): 'upload' | 'favicon' | 'letter' {
 	if (input.logoPath?.trim()) return 'upload'
-	if (resolveProviderIconId(input)) return 'catalog'
 	if (input.autoLogoPath?.trim()) return 'favicon'
 	return 'letter'
 }
 
 /**
- * Provider identity for connect / integration headers: uploaded logo, known
- * brand SVG, auto-favicon, or a letter fallback. Always sits on the white
- * logo well so dark marks stay readable in dark mode.
+ * Provider identity for connect / integration headers: uploaded logo,
+ * auto-favicon, or a letter fallback. Always sits on the white logo well
+ * so dark marks stay readable in dark mode.
  */
 export function ProviderMark(
 	handle: Handle<{
@@ -508,18 +506,13 @@ export function ProviderMark(
 	}>,
 ) {
 	return () => {
-		const { providerKey, label, logoPath, autoLogoPath, host } = handle.props
+		const { label, logoPath, autoLogoPath } = handle.props
 		const wellSize = handle.props.size ?? '3rem'
 		const source = resolveProviderMarkSource({
-			providerKey,
-			host,
 			logoPath,
 			autoLogoPath,
 		})
 		const letter = label.trim().charAt(0).toUpperCase() || '?'
-		const iconSize =
-			wellSize === '3rem' ? '1.65rem' : `calc(${wellSize} * 0.62)`
-		const iconId = resolveProviderIconId({ providerKey, host })
 		const imagePath = source === 'upload' ? logoPath : autoLogoPath
 		return (
 			<span
@@ -549,8 +542,6 @@ export function ProviderMark(
 							objectFit: 'contain' as const,
 						})}
 					/>
-				) : source === 'catalog' && iconId ? (
-					<ProviderIcon providerId={iconId} size={iconSize} />
 				) : (
 					letter
 				)}

--- a/packages/worker/client/routes/connect-oauth-config.ts
+++ b/packages/worker/client/routes/connect-oauth-config.ts
@@ -67,9 +67,9 @@ export type ConnectOauthConfig = {
 	platformAppSlug: string | null
 	/** Relative path of the operator-uploaded provider logo, when present. */
 	platformLogoPath: string | null
-	/** Explicit user-uploaded OAuth app logo (beats the catalog SVG). */
+	/** Explicit user-uploaded OAuth app logo (beats the auto-favicon). */
 	logoPath?: string | null
-	/** Auto-fetched favicon (loses to the catalog SVG). */
+	/** Auto-fetched favicon (loses to an explicit upload). */
 	autoLogoPath?: string | null
 	/** Operator-authored provider note (limitations, caveats), when present. */
 	platformDescription: string | null

--- a/packages/worker/universal/loader-data.ts
+++ b/packages/worker/universal/loader-data.ts
@@ -948,9 +948,9 @@ export type AccountIntegrationListItem = {
 	platformAllowedScopes?: Array<string>
 	/** Relative serving path of the operator-uploaded provider logo. */
 	platformLogoPath?: string | null
-	/** Explicit user-uploaded OAuth app logo (beats the catalog SVG). */
+	/** Explicit user-uploaded OAuth app logo (beats the auto-favicon). */
 	logoPath?: string | null
-	/** Auto-fetched favicon (loses to the catalog SVG). */
+	/** Auto-fetched favicon (loses to an explicit upload). */
 	autoLogoPath?: string | null
 	/** Operator-authored provider note for platform apps (limitations, caveats). */
 	platformDescription?: string | null
@@ -993,9 +993,9 @@ export type AccountOauthAppListItem = {
 	platform?: boolean
 	/** Relative serving path of the operator-uploaded provider logo. */
 	platformLogoPath?: string | null
-	/** Explicit user-uploaded OAuth app logo (beats the catalog SVG). */
+	/** Explicit user-uploaded OAuth app logo (beats the auto-favicon). */
 	logoPath?: string | null
-	/** Auto-fetched favicon (loses to the catalog SVG). */
+	/** Auto-fetched favicon (loses to an explicit upload). */
 	autoLogoPath?: string | null
 	createdAt: string
 	updatedAt: string


### PR DESCRIPTION
## Summary
- Saved integration marks no longer fall back to the official `ProviderIcon` catalog.
- Display order is now explicit upload, auto-favicon, then letter. Login and onboarding still use the catalog SVGs.

## Test plan
- [ ] Open https://kody.codes/account/integrations with no uploaded logo and confirm a stored favicon shows (or a letter if none exists).
- [ ] Confirm Dropbox/GitHub/Google no longer show the catalog SVG when only a favicon or letter is available.
- [ ] Confirm login and onboarding provider buttons still show official brand marks.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Provider logos now use uploaded images first, followed by automatically fetched favicons.
  * When no image is available, providers display a letter-based fallback.
  * User-uploaded assets remain access-controlled when automatic logo retrieval is unavailable.
* **Documentation**
  * Updated logo behavior guidance to reflect the new upload and favicon precedence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->