### PR TITLE
Show auto-fetched favicons beside MCP servers

### DIFF
--- a/docs/contributing/architecture/mcp-client-servers.md
+++ b/docs/contributing/architecture/mcp-client-servers.md
@@ -19,8 +19,12 @@ the `/mcp` endpoint (where Kody is the server) and complements MCP servers
   `purgeForAccountDeletion`.
 - **D1 `mcp_server_settings` table**
   (`packages/worker/migrations/0001-squashed-init.sql`) — user-scoped metadata
-  (id, name, url, enabled). D1 answers "which servers does this user have
-  enabled" without waking the DO; the DO owns live connection state and tokens.
+  (id, name, url, enabled, plus optional favicon columns). D1 answers "which
+  servers does this user have enabled" without waking the DO; the DO owns live
+  connection state and tokens. Account-page loads fetch the registrable-domain
+  favicon of `url` with the same HTTPS pipeline as user-lane OAuth apps and
+  store a raster under `user-mcp-server-logos/{userId}/{id}/`. The signed-in
+  owner loads it from `/account/mcp-servers/logos/:serverId`.
 - **Hub client with snapshot cache**
   (`packages/worker/src/mcp-client/hub-client.ts`) — worker-side facade over the
   DO stub. Snapshots are cached per user for 30 seconds and invalidated on every
@@ -118,8 +122,8 @@ fetch `{canonical-app-origin}/oauth/client-metadata.json`; that document's
 ## Management surfaces
 
 - **UI**: `/account/mcp-servers` (add with optional bearer token, authorize,
-  reconnect, refresh tools, enable/disable, remove; shows live state and
-  discovered tools).
+  reconnect, refresh tools, enable/disable, remove; shows live state, discovered
+  tools, and the auto-fetched server favicon next to the name).
 - **Capabilities**: the `mcp_servers` domain (`mcp_server_add`,
   `mcp_server_list`, `mcp_server_reconnect`, `mcp_server_refresh`,
   `mcp_server_remove`, `mcp_server_set_enabled`). `mcp_server_add` accepts

--- a/packages/worker/client/routes/account-mcp-servers.tsx
+++ b/packages/worker/client/routes/account-mcp-servers.tsx
@@ -8,6 +8,7 @@ import { createRouteLoadLatch } from '#client/route-load-latch.ts'
 import { replaceLocation } from '#client/replace-location.ts'
 import { matchesSearchQuery } from '#client/search-filter.ts'
 import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
+import { ProviderMark } from '#client/provider-icons.tsx'
 import { consumeStaleNavigationData } from '#client/navigation-data.ts'
 import {
 	type AccountStatus,
@@ -54,6 +55,41 @@ import {
 
 const clampedCellCss = css(recordCellClamp(26))
 
+function hostFromUrl(url: string | null | undefined) {
+	if (!url) return null
+	try {
+		return new URL(url).hostname || null
+	} catch {
+		return null
+	}
+}
+
+function renderNamedServer(input: {
+	name: string
+	url: string
+	autoLogoPath?: string | null
+}) {
+	return (
+		<span
+			mix={css({
+				display: 'inline-flex',
+				alignItems: 'center',
+				gap: spacing.sm,
+				minWidth: 0,
+			})}
+		>
+			<ProviderMark
+				providerKey={input.name}
+				label={input.name}
+				autoLogoPath={input.autoLogoPath}
+				host={hostFromUrl(input.url)}
+				size="1.75rem"
+			/>
+			<span mix={clampedCellCss}>{input.name}</span>
+		</span>
+	)
+}
+
 type McpServerListItem = {
 	id: string
 	name: string
@@ -67,6 +103,7 @@ type McpServerListItem = {
 	tools: Array<string>
 	createdAt: string
 	updatedAt: string
+	autoLogoPath: string | null
 }
 
 type AccountMcpServersPayload = {
@@ -607,7 +644,7 @@ export function AccountMcpServersRoute(handle: Handle) {
 								? undefined
 								: mcpServersRoute.buildDetailHref(item.id, getCurrentSearch()),
 							cells: {
-								name: item.name,
+								name: renderNamedServer(item),
 								state: (
 									<span mix={css({ color: stateColor(item) })}>
 										{stateLabel(item)}
@@ -739,12 +776,26 @@ export function AccountMcpServersRoute(handle: Handle) {
 								</form>
 							) : server ? (
 								<section mix={css(recordBodyCss)}>
-									<div mix={css({ display: 'grid', gap: spacing.xs })}>
-										<h2 mix={css(cardTitleCss)}>{server.name}</h2>
-										<p mix={css(descriptionCss)}>
-											Saved MCP server connection. Kody keeps OAuth tokens and
-											connection state isolated to your account.
-										</p>
+									<div
+										mix={css({
+											display: 'flex',
+											alignItems: 'flex-start',
+											gap: spacing.md,
+										})}
+									>
+										<ProviderMark
+											providerKey={server.name}
+											label={server.name}
+											autoLogoPath={server.autoLogoPath}
+											host={hostFromUrl(server.url)}
+										/>
+										<div mix={css({ display: 'grid', gap: spacing.xs })}>
+											<h2 mix={css(cardTitleCss)}>{server.name}</h2>
+											<p mix={css(descriptionCss)}>
+												Saved MCP server connection. Kody keeps OAuth tokens and
+												connection state isolated to your account.
+											</p>
+										</div>
 									</div>
 
 									<MetadataGrid

--- a/packages/worker/migrations/0027-mcp-server-logos.sql
+++ b/packages/worker/migrations/0027-mcp-server-logos.sql
@@ -1,0 +1,12 @@
+-- Auto-fetched favicons for user-added MCP servers. Assets live in
+-- COMMUNITY_ASSETS under content-hashed keys. SVG is rasterized; ICO
+-- is accepted only when it embeds a PNG. favicon_source_host records
+-- the registrable domain last used so a changed server URL can re-fetch.
+ALTER TABLE mcp_server_settings ADD COLUMN logo_key TEXT;
+
+ALTER TABLE mcp_server_settings ADD COLUMN logo_content_type TEXT;
+
+ALTER TABLE mcp_server_settings ADD COLUMN logo_source TEXT
+	CHECK (logo_source IN ('favicon'));
+
+ALTER TABLE mcp_server_settings ADD COLUMN favicon_source_host TEXT;

--- a/packages/worker/src/app/account-mcp-servers-data.ts
+++ b/packages/worker/src/app/account-mcp-servers-data.ts
@@ -4,6 +4,8 @@ import {
 	buildMcpServerStatusView,
 	loadMcpClientHubSnapshotOrNull,
 } from '#mcp/capabilities/mcp-servers/shared.ts'
+import { backfillMissingMcpServerFavicons } from '#worker/mcp-client/mcp-server-favicon.ts'
+import { buildMcpServerAutoLogoPath } from '#worker/mcp-client/mcp-server-logo.ts'
 import {
 	listMcpServerSettings,
 	resolveMcpServerOAuthClientUrls,
@@ -17,6 +19,7 @@ export async function loadAccountMcpServersData(input: {
 	env: Env
 	user: AuthenticatedUser
 	requestUrl?: string | URL | null
+	waitUntil?: (promise: Promise<unknown>) => void
 }): Promise<AccountMcpServersLoaderData> {
 	const userId = input.user.mcpUser.userId
 	const oauth = resolveMcpServerOAuthClientUrls({
@@ -24,6 +27,13 @@ export async function loadAccountMcpServersData(input: {
 		requestUrl: input.requestUrl,
 	})
 	const settings = await listMcpServerSettings({ env: input.env, userId })
+	await backfillMissingMcpServerFavicons({
+		db: input.env.APP_DB,
+		env: input.env,
+		userId,
+		servers: settings,
+		waitUntil: input.waitUntil,
+	})
 	const snapshot =
 		settings.length > 0
 			? await loadMcpClientHubSnapshotOrNull({ env: input.env, userId })
@@ -35,8 +45,8 @@ export async function loadAccountMcpServersData(input: {
 		oauthClientOrigin: oauth.clientOrigin,
 		oauthCallbackUrl: oauth.callbackUrl,
 		oauthClientMetadataUrl: oauth.clientMetadataUrl,
-		servers: settings.map((setting) =>
-			buildMcpServerStatusView({
+		servers: settings.map((setting) => ({
+			...buildMcpServerStatusView({
 				setting,
 				snapshot:
 					snapshot?.servers.find((server) => server.serverId === setting.id) ??
@@ -45,6 +55,7 @@ export async function loadAccountMcpServersData(input: {
 				oauthClientOrigin: oauth.clientOrigin,
 				oauthClientMetadataUrl: oauth.clientMetadataUrl,
 			}),
-		),
+			autoLogoPath: buildMcpServerAutoLogoPath(setting),
+		})),
 	}
 }

--- a/packages/worker/src/app/handlers/account-mcp-servers.node.test.ts
+++ b/packages/worker/src/app/handlers/account-mcp-servers.node.test.ts
@@ -1,6 +1,8 @@
 import { expect, test, vi } from 'vitest'
+import type * as CloudflareWorkers from 'cloudflare:workers'
 
 const mockModule = vi.hoisted(() => ({
+	waitUntil: vi.fn(),
 	readAuthenticatedAppUser: vi.fn(async () => ({
 		sessionUserId: '42',
 		userId: 42,
@@ -95,6 +97,14 @@ const mockModule = vi.hoisted(() => ({
 		toolCount: 0,
 	})),
 }))
+
+vi.mock('cloudflare:workers', async (importOriginal) => {
+	const actual = await importOriginal<typeof CloudflareWorkers>()
+	return {
+		...actual,
+		waitUntil: (...args: Array<unknown>) => mockModule.waitUntil(...args),
+	}
+})
 
 vi.mock('#app/authenticated-user.ts', () => ({
 	readAuthenticatedAppUser: (...args: Array<unknown>) =>
@@ -196,6 +206,7 @@ test('MCP servers API lists servers with live hub status', async () => {
 				tools: ['create_issue', 'list_issues'],
 				createdAt: new Date(0).toISOString(),
 				updatedAt: new Date(0).toISOString(),
+				autoLogoPath: null,
 			},
 		],
 	})

--- a/packages/worker/src/app/handlers/account-mcp-servers.node.test.ts
+++ b/packages/worker/src/app/handlers/account-mcp-servers.node.test.ts
@@ -237,6 +237,7 @@ test('MCP servers API add action uses the canonical OAuth callback origin', asyn
 			url: 'https://mcp.notion.example/mcp',
 			baseUrl: 'https://example.com',
 			bearerToken: 'secret-token',
+			waitUntil: expect.any(Function),
 		}),
 	)
 	const payload = (await addResponse.json()) as {

--- a/packages/worker/src/app/handlers/account-mcp-servers.ts
+++ b/packages/worker/src/app/handlers/account-mcp-servers.ts
@@ -1,3 +1,4 @@
+import { waitUntil } from 'cloudflare:workers'
 import { jsonResponse } from '#worker/json-response.ts'
 import { getErrorMessage } from '@kody-internal/shared/error-message.ts'
 import { type Action } from 'remix/router'
@@ -41,6 +42,7 @@ export function createAccountMcpServersHandler(env: Env) {
 				env,
 				user,
 				requestUrl: request.url,
+				waitUntil,
 			})
 			return renderAppPage({
 				request,
@@ -71,6 +73,7 @@ export function createAccountMcpServersApiHandler(env: Env) {
 						env,
 						user,
 						requestUrl: request.url,
+						waitUntil,
 					}),
 				)
 			}
@@ -237,6 +240,7 @@ async function handleAddAction(input: {
 		env: input.env,
 		user: input.user,
 		requestUrl: input.request.url,
+		waitUntil,
 	})
 	return jsonResponse({
 		...payload,
@@ -272,6 +276,7 @@ async function handleConnectionAction(input: {
 		env: input.env,
 		user: input.user,
 		requestUrl: input.request.url,
+		waitUntil,
 	})
 	return jsonResponse({
 		...payload,
@@ -296,6 +301,7 @@ async function handleSetEnabledAction(input: {
 		env: input.env,
 		user: input.user,
 		requestUrl: input.request.url,
+		waitUntil,
 	})
 	return jsonResponse({
 		...payload,
@@ -323,6 +329,7 @@ async function handleDeleteAction(input: {
 			env: input.env,
 			user: input.user,
 			requestUrl: input.request.url,
+			waitUntil,
 		}),
 	)
 }

--- a/packages/worker/src/app/handlers/account-mcp-servers.ts
+++ b/packages/worker/src/app/handlers/account-mcp-servers.ts
@@ -235,6 +235,7 @@ async function handleAddAction(input: {
 		url: readTrimmedStringOrEmpty(input.body, 'url'),
 		baseUrl: oauth.clientOrigin,
 		bearerToken: readNonEmptyTrimmedString(input.body, 'bearerToken'),
+		waitUntil,
 	})
 	const payload = await loadAccountMcpServersData({
 		env: input.env,

--- a/packages/worker/src/app/handlers/mcp-server-logo.node.test.ts
+++ b/packages/worker/src/app/handlers/mcp-server-logo.node.test.ts
@@ -1,0 +1,71 @@
+import { expect, test, vi } from 'vitest'
+
+const mockModule = vi.hoisted(() => ({
+	readAuthenticatedAppUser: vi.fn(),
+	getMcpServerSettingById: vi.fn(),
+	getMcpServerLogoObject: vi.fn(),
+}))
+
+vi.mock('#app/authenticated-user.ts', () => ({
+	readAuthenticatedAppUser: (...args: Array<unknown>) =>
+		mockModule.readAuthenticatedAppUser(...args),
+}))
+
+vi.mock('#worker/mcp-client/settings-service.ts', () => ({
+	getMcpServerSettingById: (...args: Array<unknown>) =>
+		mockModule.getMcpServerSettingById(...args),
+}))
+
+vi.mock('#worker/mcp-client/mcp-server-logo.ts', () => ({
+	getMcpServerLogoObject: (...args: Array<unknown>) =>
+		mockModule.getMcpServerLogoObject(...args),
+}))
+
+const { createMcpServerLogoHandler } = await import('./mcp-server-logo.ts')
+
+test('MCP server logo route is owner-scoped and private', async () => {
+	const handler = createMcpServerLogoHandler({} as Env)
+
+	mockModule.readAuthenticatedAppUser.mockResolvedValueOnce(null)
+	const anonymous = await handler.handler({
+		request: new Request('https://example.com/account/mcp-servers/logos/s1'),
+		params: { serverId: 's1' },
+	} as never)
+	expect(anonymous.status).toBe(404)
+
+	mockModule.readAuthenticatedAppUser.mockResolvedValueOnce({
+		mcpUser: { userId: 'user-1' },
+	})
+	mockModule.getMcpServerSettingById.mockResolvedValueOnce(null)
+	const missing = await handler.handler({
+		request: new Request('https://example.com/account/mcp-servers/logos/s1'),
+		params: { serverId: 's1' },
+	} as never)
+	expect(missing.status).toBe(404)
+
+	mockModule.readAuthenticatedAppUser.mockResolvedValueOnce({
+		mcpUser: { userId: 'user-1' },
+	})
+	mockModule.getMcpServerSettingById.mockResolvedValueOnce({
+		id: 's1',
+		logoKey: 'user-mcp-server-logos/user-1/s1/abc.png',
+		logoContentType: 'image/png',
+	})
+	mockModule.getMcpServerLogoObject.mockResolvedValueOnce({
+		body: new Uint8Array([1, 2, 3]),
+		size: 3,
+		httpEtag: '"abc"',
+	})
+	const ok = await handler.handler({
+		request: new Request('https://example.com/account/mcp-servers/logos/s1'),
+		params: { serverId: 's1' },
+	} as never)
+	expect(ok.status).toBe(200)
+	expect(ok.headers.get('Cache-Control')).toBe('private, no-store')
+	expect(ok.headers.get('Content-Type')).toBe('image/png')
+	expect(mockModule.getMcpServerSettingById).toHaveBeenLastCalledWith({
+		env: {},
+		userId: 'user-1',
+		id: 's1',
+	})
+})

--- a/packages/worker/src/app/handlers/mcp-server-logo.ts
+++ b/packages/worker/src/app/handlers/mcp-server-logo.ts
@@ -1,0 +1,46 @@
+import { type Action } from 'remix/router'
+import { readAuthenticatedAppUser } from '#app/authenticated-user.ts'
+import { getMcpServerLogoObject } from '#worker/mcp-client/mcp-server-logo.ts'
+import { getMcpServerSettingById } from '#worker/mcp-client/settings-service.ts'
+import { type routes } from '#universal/routes.ts'
+
+/**
+ * Serving route for user-added MCP server favicons. Requires a signed-in
+ * session and resolves the caller's server so one user cannot read another
+ * user's stored mark.
+ */
+export function createMcpServerLogoHandler(env: Env) {
+	return {
+		middleware: [],
+		async handler({ request, params }) {
+			const user = await readAuthenticatedAppUser(request, env)
+			if (!user) {
+				return new Response('Not found', { status: 404 })
+			}
+			const server = await getMcpServerSettingById({
+				env,
+				userId: user.mcpUser.userId,
+				id: params.serverId,
+			})
+			if (!server?.logoKey) {
+				return new Response('Not found', { status: 404 })
+			}
+			const object = await getMcpServerLogoObject({
+				env,
+				logoKey: server.logoKey,
+			})
+			if (!object) {
+				return new Response('Not found', { status: 404 })
+			}
+			return new Response(object.body, {
+				headers: {
+					'Cache-Control': 'private, no-store',
+					'Content-Length': String(object.size),
+					'Content-Type': server.logoContentType ?? 'application/octet-stream',
+					ETag: object.httpEtag,
+					'X-Content-Type-Options': 'nosniff',
+				},
+			})
+		},
+	} satisfies Action<typeof routes.accountMcpServerLogo>
+}

--- a/packages/worker/src/app/router-specificity.node.test.ts
+++ b/packages/worker/src/app/router-specificity.node.test.ts
@@ -19,6 +19,10 @@ test('router prefers static nested paths and package files over dynamic siblings
 		createStubHandler('oauth-callback'),
 	)
 	router.get(
+		routePattern(routes.accountMcpServerLogo),
+		createStubHandler('server-logo'),
+	)
+	router.get(
 		routePattern(routes.accountMcpServerDetail),
 		createStubHandler('server-detail'),
 	)
@@ -62,6 +66,15 @@ test('router prefers static nested paths and package files over dynamic siblings
 			)
 		).text(),
 	).toBe('oauth-callback')
+	expect(
+		await (
+			await router.fetch(
+				new Request(
+					'http://localhost/account/mcp-servers/logos/550e8400-e29b-41d4-a716-446655440000',
+				),
+			)
+		).text(),
+	).toBe('server-logo')
 	expect(
 		await (
 			await router.fetch(

--- a/packages/worker/src/app/router.ts
+++ b/packages/worker/src/app/router.ts
@@ -150,6 +150,7 @@ import {
 import { createCommunityFeatureApiPostHandler } from '#app/handlers/community-feature.ts'
 import { createCommunityIconHandler } from '#app/handlers/community-icon.ts'
 import { createIntegrationLogoHandler } from '#app/handlers/integration-logo.ts'
+import { createMcpServerLogoHandler } from '#app/handlers/mcp-server-logo.ts'
 import { createCommunityInstallApiPostHandler } from '#app/handlers/community-install.ts'
 import { createCommunityTrustApiPostHandler } from '#app/handlers/community-trust.ts'
 import {
@@ -313,6 +314,7 @@ export function createAppRouter(env: Env) {
 			accountIntegrationsApiPost: createAccountIntegrationsApiHandler(env),
 			accountMcpServers: createAccountMcpServersHandler(env),
 			accountMcpServerNew: createAccountMcpServersHandler(env),
+			accountMcpServerLogo: createMcpServerLogoHandler(env),
 			accountMcpServerDetail: createAccountMcpServersHandler(env),
 			accountMcpServersOauthCallback:
 				createAccountMcpServersOauthCallbackHandler(env),

--- a/packages/worker/src/mcp-client/mcp-server-favicon.node.test.ts
+++ b/packages/worker/src/mcp-client/mcp-server-favicon.node.test.ts
@@ -1,0 +1,53 @@
+import { expect, test } from 'vitest'
+import { shouldFetchMcpServerFavicon } from './mcp-server-favicon.ts'
+import { buildMcpServerAutoLogoPath } from './mcp-server-logo.ts'
+
+test('shouldFetchMcpServerFavicon fetches missing public hosts and stale domains', () => {
+	expect(
+		shouldFetchMcpServerFavicon({
+			url: 'https://mcp.agentcard.sh/mcp',
+			logoKey: null,
+			logoSource: null,
+			faviconSourceHost: null,
+		}),
+	).toBe(true)
+	expect(
+		shouldFetchMcpServerFavicon({
+			url: 'https://localhost:8787/mcp',
+			logoKey: null,
+			logoSource: null,
+			faviconSourceHost: null,
+		}),
+	).toBe(false)
+	expect(
+		shouldFetchMcpServerFavicon({
+			url: 'https://mcp.agentcard.sh/mcp',
+			logoKey: 'user-mcp-server-logos/user-1/server-1/abc.png',
+			logoSource: 'favicon',
+			faviconSourceHost: 'agentcard.sh',
+		}),
+	).toBe(false)
+	expect(
+		shouldFetchMcpServerFavicon({
+			url: 'https://mcp.example.com/mcp',
+			logoKey: 'user-mcp-server-logos/user-1/server-1/abc.png',
+			logoSource: 'favicon',
+			faviconSourceHost: 'agentcard.sh',
+		}),
+	).toBe(true)
+})
+
+test('buildMcpServerAutoLogoPath uses the content-hash cache buster', () => {
+	expect(
+		buildMcpServerAutoLogoPath({
+			id: 'server-1',
+			logoKey: null,
+		}),
+	).toBeNull()
+	expect(
+		buildMcpServerAutoLogoPath({
+			id: 'server-1',
+			logoKey: 'user-mcp-server-logos/user-1/server-1/0123456789abcdef.png',
+		}),
+	).toBe('/account/mcp-servers/logos/server-1?v=0123456789abcdef')
+})

--- a/packages/worker/src/mcp-client/mcp-server-favicon.ts
+++ b/packages/worker/src/mcp-client/mcp-server-favicon.ts
@@ -96,7 +96,7 @@ export async function scheduleMcpServerFaviconFill(input: {
 		input.waitUntil(work)
 		return
 	}
-	void work
+	await work
 }
 
 export async function backfillMissingMcpServerFavicons(input: {
@@ -134,5 +134,5 @@ export async function backfillMissingMcpServerFavicons(input: {
 		input.waitUntil(work)
 		return
 	}
-	void work
+	await work
 }

--- a/packages/worker/src/mcp-client/mcp-server-favicon.ts
+++ b/packages/worker/src/mcp-client/mcp-server-favicon.ts
@@ -1,0 +1,138 @@
+import { getErrorMessage } from '@kody-internal/shared/error-message.ts'
+import {
+	fetchFaviconBytes,
+	resolveFaviconOrigin,
+} from '#worker/integrations/user-oauth-app-favicon.ts'
+import { setMcpServerLogo } from './mcp-server-logo.ts'
+import { getMcpServerSettingRowById } from './settings-repo.ts'
+import { type McpServerSettingMetadata } from './settings-types.ts'
+
+const maxBackfillPerPage = 5
+
+export function shouldFetchMcpServerFavicon(
+	server: Pick<
+		McpServerSettingMetadata,
+		'url' | 'logoKey' | 'logoSource' | 'faviconSourceHost'
+	>,
+): boolean {
+	const resolved = resolveFaviconOrigin([server.url])
+	if (!resolved) return false
+	if (server.logoSource === 'favicon' && server.logoKey) {
+		return server.faviconSourceHost !== resolved.host
+	}
+	return true
+}
+
+export async function fillMcpServerFavicon(input: {
+	db: D1Database
+	env: Pick<Env, 'COMMUNITY_ASSETS'>
+	userId: string
+	serverId: string
+	fetchImpl?: typeof fetch
+}): Promise<void> {
+	const row = await getMcpServerSettingRowById({
+		db: input.db,
+		userId: input.userId,
+		id: input.serverId,
+	})
+	if (!row) return
+	const server = {
+		url: row.url,
+		logoKey: row.logo_key,
+		logoSource: row.logo_source,
+		faviconSourceHost: row.favicon_source_host,
+	}
+	if (!shouldFetchMcpServerFavicon(server)) return
+	const resolved = resolveFaviconOrigin([row.url])
+	if (!resolved) return
+	const bytes = await fetchFaviconBytes({
+		origin: resolved.origin,
+		fetchImpl: input.fetchImpl,
+	})
+	if (!bytes) return
+	try {
+		await setMcpServerLogo({
+			db: input.db,
+			env: input.env,
+			userId: input.userId,
+			serverId: row.id,
+			sourceBytes: bytes,
+			source: 'favicon',
+			faviconSourceHost: resolved.host,
+		})
+	} catch (error) {
+		console.error(
+			'mcp-server-favicon-store-failed',
+			row.id,
+			getErrorMessage(error),
+		)
+	}
+}
+
+export async function scheduleMcpServerFaviconFill(input: {
+	db: D1Database
+	env: Pick<Env, 'APP_DB' | 'COMMUNITY_ASSETS'> | Pick<Env, 'APP_DB'>
+	userId: string
+	serverId: string
+	waitUntil?: (promise: Promise<unknown>) => void
+}) {
+	if (!('COMMUNITY_ASSETS' in input.env) || !input.env.COMMUNITY_ASSETS) {
+		return
+	}
+	const env = input.env as Pick<Env, 'APP_DB' | 'COMMUNITY_ASSETS'>
+	const work = fillMcpServerFavicon({
+		db: input.db,
+		env,
+		userId: input.userId,
+		serverId: input.serverId,
+	}).catch((error: unknown) => {
+		console.error(
+			'mcp-server-favicon-fill-failed',
+			input.serverId,
+			getErrorMessage(error),
+		)
+	})
+	if (input.waitUntil) {
+		input.waitUntil(work)
+		return
+	}
+	void work
+}
+
+export async function backfillMissingMcpServerFavicons(input: {
+	db: D1Database
+	env: Pick<Env, 'APP_DB' | 'COMMUNITY_ASSETS'> | Pick<Env, 'APP_DB'>
+	userId: string
+	servers: Array<McpServerSettingMetadata>
+	waitUntil?: (promise: Promise<unknown>) => void
+}) {
+	if (!('COMMUNITY_ASSETS' in input.env) || !input.env.COMMUNITY_ASSETS) {
+		return
+	}
+	const pending = input.servers
+		.filter((server) => shouldFetchMcpServerFavicon(server))
+		.slice(0, maxBackfillPerPage)
+	if (pending.length === 0) return
+	const env = input.env as Pick<Env, 'APP_DB' | 'COMMUNITY_ASSETS'>
+	const work = (async () => {
+		for (const server of pending) {
+			await fillMcpServerFavicon({
+				db: input.db,
+				env,
+				userId: input.userId,
+				serverId: server.id,
+			}).catch((error: unknown) => {
+				console.error(
+					'mcp-server-favicon-backfill-failed',
+					server.id,
+					getErrorMessage(error),
+				)
+			})
+		}
+	})()
+	if (input.waitUntil) {
+		input.waitUntil(work)
+		return
+	}
+	void work
+}

--- a/packages/worker/src/mcp-client/mcp-server-logo.ts
+++ b/packages/worker/src/mcp-client/mcp-server-logo.ts
@@ -1,0 +1,156 @@
+import { toHex } from '@kody-internal/shared/hex.ts'
+import { routes } from '#universal/routes.ts'
+import {
+	processPlatformOauthAppLogo,
+	type PlatformOauthAppLogoContentType,
+} from '#worker/integrations/platform-app-logo.ts'
+import { getMcpServerSettingRowById } from './settings-repo.ts'
+import { type McpServerLogoSource } from './settings-types.ts'
+
+export const mcpServerLogoR2KeyPrefix = 'user-mcp-server-logos/'
+const mcpServerLogoCacheControl = 'private, no-store'
+
+/**
+ * Relative serving path for a user-added MCP server favicon. `v` is the
+ * content hash so a re-fetch busts the private cache key.
+ */
+export function buildMcpServerLogoPath(server: {
+	id: string
+	logoKey: string | null
+}): string | null {
+	if (!server.logoKey) return null
+	const contentTag = /\/([0-9a-f]{16})[^/]*$/.exec(server.logoKey)?.[1]
+	return routes.accountMcpServerLogo.href(
+		{ serverId: server.id },
+		contentTag ? { searchParams: { v: contentTag } } : undefined,
+	)
+}
+
+export function buildMcpServerAutoLogoPath(server: {
+	id: string
+	logoKey?: string | null
+}): string | null {
+	return buildMcpServerLogoPath({
+		id: server.id,
+		logoKey: server.logoKey ?? null,
+	})
+}
+
+function extensionForContentType(contentType: PlatformOauthAppLogoContentType) {
+	switch (contentType) {
+		case 'image/png':
+			return 'png'
+		case 'image/jpeg':
+			return 'jpg'
+		case 'image/webp':
+			return 'webp'
+		default: {
+			const unreachable: never = contentType
+			throw new Error(`Unsupported logo content type: ${unreachable}`)
+		}
+	}
+}
+
+async function sha256Hex(bytes: Uint8Array) {
+	const copy = new Uint8Array(bytes.byteLength)
+	copy.set(bytes)
+	const digest = await crypto.subtle.digest('SHA-256', copy)
+	return toHex(new Uint8Array(digest))
+}
+
+export async function setMcpServerLogo(input: {
+	db: D1Database
+	env: Pick<Env, 'COMMUNITY_ASSETS'>
+	userId: string
+	serverId: string
+	sourceBytes: Uint8Array
+	source: McpServerLogoSource
+	faviconSourceHost: string
+}): Promise<void> {
+	const existing = await getMcpServerSettingRowById({
+		db: input.db,
+		userId: input.userId,
+		id: input.serverId,
+	})
+	if (!existing) return
+	const previousKey = existing.logo_key
+	const processed = await processPlatformOauthAppLogo(input.sourceBytes)
+	const contentHash = (await sha256Hex(processed.bytes)).slice(0, 16)
+	const nextKey = `${mcpServerLogoR2KeyPrefix}${input.userId}/${existing.id}/${contentHash}.${extensionForContentType(processed.contentType)}`
+	await input.env.COMMUNITY_ASSETS.put(nextKey, processed.bytes, {
+		httpMetadata: {
+			contentType: processed.contentType,
+			cacheControl: mcpServerLogoCacheControl,
+		},
+		customMetadata: {
+			userId: input.userId,
+			mcpServerId: existing.id,
+			logoSource: input.source,
+			contentHash,
+		},
+	})
+
+	const updated = await input.db
+		.prepare(
+			`UPDATE mcp_server_settings
+			SET logo_key = ?, logo_content_type = ?, logo_source = ?,
+				favicon_source_host = ?, updated_at = ?
+			WHERE user_id = ? AND id = ?`,
+		)
+		.bind(
+			nextKey,
+			processed.contentType,
+			input.source,
+			input.faviconSourceHost,
+			new Date().toISOString(),
+			input.userId,
+			existing.id,
+		)
+		.run()
+
+	if ((updated.meta.changes ?? 0) === 0) {
+		try {
+			await input.env.COMMUNITY_ASSETS.delete(nextKey)
+		} catch (error) {
+			console.error(
+				'mcp-server-logo-raced-favicon-delete-failed',
+				nextKey,
+				error,
+			)
+		}
+		return
+	}
+
+	if (previousKey && previousKey !== nextKey) {
+		try {
+			await input.env.COMMUNITY_ASSETS.delete(previousKey)
+		} catch (error) {
+			console.error(
+				'mcp-server-logo-previous-delete-failed',
+				previousKey,
+				error,
+			)
+		}
+	}
+}
+
+export async function deleteMcpServerLogoAsset(input: {
+	env: Pick<Env, 'COMMUNITY_ASSETS'>
+	logoKey: string | null
+}) {
+	if (!input.logoKey) return
+	if (!input.logoKey.startsWith(mcpServerLogoR2KeyPrefix)) return
+	try {
+		await input.env.COMMUNITY_ASSETS.delete(input.logoKey)
+	} catch (error) {
+		console.error('mcp-server-logo-delete-failed', input.logoKey, error)
+	}
+}
+
+export async function getMcpServerLogoObject(input: {
+	env: Pick<Env, 'COMMUNITY_ASSETS'>
+	logoKey: string
+}): Promise<R2ObjectBody | null> {
+	if (!input.logoKey.startsWith(mcpServerLogoR2KeyPrefix)) return null
+	return await input.env.COMMUNITY_ASSETS.get(input.logoKey)
+}

--- a/packages/worker/src/mcp-client/settings-repo.ts
+++ b/packages/worker/src/mcp-client/settings-repo.ts
@@ -1,6 +1,10 @@
-import { type McpServerSettingRow } from './settings-types.ts'
+import {
+	type McpServerLogoSource,
+	type McpServerSettingRow,
+} from './settings-types.ts'
 
-const selectColumns = 'id, user_id, name, url, enabled, created_at, updated_at'
+const selectColumns =
+	'id, user_id, name, url, enabled, created_at, updated_at, logo_key, logo_content_type, logo_source, favicon_source_host'
 
 export async function listMcpServerSettingRows(input: {
 	db: D1Database
@@ -134,6 +138,10 @@ export async function deleteMcpServerSettingRow(input: {
 	return (result.meta.changes ?? 0) > 0
 }
 
+function mapLogoSource(value: unknown): McpServerLogoSource | null {
+	return value === 'favicon' ? 'favicon' : null
+}
+
 function mapMcpServerSettingRow(
 	row: Record<string, unknown>,
 ): McpServerSettingRow {
@@ -145,5 +153,15 @@ function mapMcpServerSettingRow(
 		enabled: Boolean(Number(row['enabled'])),
 		created_at: String(row['created_at']),
 		updated_at: String(row['updated_at']),
+		logo_key: row['logo_key'] == null ? null : String(row['logo_key']),
+		logo_content_type:
+			row['logo_content_type'] == null
+				? null
+				: String(row['logo_content_type']),
+		logo_source: mapLogoSource(row['logo_source']),
+		favicon_source_host:
+			row['favicon_source_host'] == null
+				? null
+				: String(row['favicon_source_host']),
 	}
 }

--- a/packages/worker/src/mcp-client/settings-service.node.test.ts
+++ b/packages/worker/src/mcp-client/settings-service.node.test.ts
@@ -53,6 +53,10 @@ function createSettingRow(input: { id: string; enabled?: boolean }) {
 		enabled: input.enabled ?? true,
 		created_at: '2026-07-01T00:00:00.000Z',
 		updated_at: '2026-07-01T00:00:00.000Z',
+		logo_key: null,
+		logo_content_type: null,
+		logo_source: null,
+		favicon_source_host: null,
 	}
 }
 

--- a/packages/worker/src/mcp-client/settings-service.ts
+++ b/packages/worker/src/mcp-client/settings-service.ts
@@ -23,6 +23,8 @@ import {
 	listMcpServerSettingRows,
 	updateMcpServerSettingRow,
 } from './settings-repo.ts'
+import { scheduleMcpServerFaviconFill } from './mcp-server-favicon.ts'
+import { deleteMcpServerLogoAsset } from './mcp-server-logo.ts'
 import {
 	type McpServerSettingMetadata,
 	type McpServerSettingRow,
@@ -68,6 +70,10 @@ function toMetadata(row: McpServerSettingRow): McpServerSettingMetadata {
 		enabled: row.enabled,
 		createdAt: row.created_at,
 		updatedAt: row.updated_at,
+		logoKey: row.logo_key,
+		logoContentType: row.logo_content_type,
+		logoSource: row.logo_source,
+		faviconSourceHost: row.favicon_source_host,
 	}
 }
 
@@ -192,6 +198,10 @@ export async function addMcpServer(input: {
 		enabled: true,
 		created_at: now,
 		updated_at: now,
+		logo_key: null,
+		logo_content_type: null,
+		logo_source: null,
+		favicon_source_host: null,
 	} satisfies McpServerSettingRow
 
 	const hub = createMcpClientHubClient({
@@ -221,6 +231,12 @@ export async function addMcpServer(input: {
 		throw error
 	}
 	invalidateEnabledMcpServerRefsCache({ userId: input.userId })
+	await scheduleMcpServerFaviconFill({
+		db: input.env.APP_DB,
+		env: input.env,
+		userId: input.userId,
+		serverId: row.id,
+	})
 	return {
 		setting: toMetadata(row),
 		connection,
@@ -274,6 +290,12 @@ export async function deleteMcpServer(input: {
 		userId: input.userId,
 	})
 	await hub.removeServer({ serverId: input.id })
+	if ('COMMUNITY_ASSETS' in input.env && input.env.COMMUNITY_ASSETS) {
+		await deleteMcpServerLogoAsset({
+			env: input.env,
+			logoKey: existing.logo_key,
+		})
+	}
 	const deleted = await deleteMcpServerSettingRow({
 		db: input.env.APP_DB,
 		userId: input.userId,

--- a/packages/worker/src/mcp-client/settings-service.ts
+++ b/packages/worker/src/mcp-client/settings-service.ts
@@ -166,6 +166,7 @@ export async function addMcpServer(input: {
 	 * D1 — only forwarded into the hub DO's Agents SDK server options.
 	 */
 	bearerToken?: string | null
+	waitUntil?: (promise: Promise<unknown>) => void
 }): Promise<{
 	setting: McpServerSettingMetadata
 	connection: McpServerConnectResult
@@ -236,6 +237,7 @@ export async function addMcpServer(input: {
 		env: input.env,
 		userId: input.userId,
 		serverId: row.id,
+		waitUntil: input.waitUntil,
 	})
 	return {
 		setting: toMetadata(row),

--- a/packages/worker/src/mcp-client/settings-types.ts
+++ b/packages/worker/src/mcp-client/settings-types.ts
@@ -1,3 +1,5 @@
+export type McpServerLogoSource = 'favicon'
+
 export type McpServerSettingRow = {
 	id: string
 	user_id: string
@@ -6,6 +8,10 @@ export type McpServerSettingRow = {
 	enabled: boolean
 	created_at: string
 	updated_at: string
+	logo_key: string | null
+	logo_content_type: string | null
+	logo_source: McpServerLogoSource | null
+	favicon_source_host: string | null
 }
 
 export type McpServerSettingMetadata = {
@@ -15,4 +21,8 @@ export type McpServerSettingMetadata = {
 	enabled: boolean
 	createdAt: string
 	updatedAt: string
+	logoKey: string | null
+	logoContentType: string | null
+	logoSource: McpServerLogoSource | null
+	faviconSourceHost: string | null
 }

--- a/packages/worker/src/mcp/capabilities/mcp-servers/mcp-server-add.ts
+++ b/packages/worker/src/mcp/capabilities/mcp-servers/mcp-server-add.ts
@@ -84,6 +84,7 @@ export const mcpServerAddCapability = defineDomainCapability(
 				url: args.url,
 				baseUrl: oauth.clientOrigin,
 				bearerToken: args.bearerToken,
+				waitUntil: ctx.waitUntil,
 			})
 			const error = connection.error
 				? enrichMcpOAuthProviderError(connection.error, oauth)

--- a/packages/worker/src/mcp/capabilities/mcp-servers/shared.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/mcp-servers/shared.node.test.ts
@@ -26,6 +26,10 @@ function setting(
 		enabled: true,
 		createdAt: '2026-01-01T00:00:00.000Z',
 		updatedAt: '2026-01-01T00:00:00.000Z',
+		logoKey: null,
+		logoContentType: null,
+		logoSource: null,
+		faviconSourceHost: null,
 		...overrides,
 	}
 }

--- a/packages/worker/universal/loader-data.ts
+++ b/packages/worker/universal/loader-data.ts
@@ -1100,6 +1100,8 @@ export type AccountMcpServerListItem = {
 	tools: Array<string>
 	createdAt: string
 	updatedAt: string
+	/** Auto-fetched registrable-domain favicon for the server URL. */
+	autoLogoPath: string | null
 }
 
 export type AccountMcpServersLoaderData = {

--- a/packages/worker/universal/routes.ts
+++ b/packages/worker/universal/routes.ts
@@ -25,6 +25,9 @@ export const routes = route({
 	accountIntegrationsApiPost: post('/account/integrations.json'),
 	accountMcpServers: '/account/mcp-servers',
 	accountMcpServerNew: '/account/mcp-servers/new',
+	// More specific than `:serverId` so favicon assets do not collide with
+	// the expand-detail route.
+	accountMcpServerLogo: '/account/mcp-servers/logos/:serverId',
 	accountMcpServerDetail: '/account/mcp-servers/:serverId',
 	accountMcpServersOauthCallback: '/account/mcp-servers/oauth/callback',
 	accountMcpServersApi: '/account/mcp-servers.json',

--- a/tools/migration-ledger.json
+++ b/tools/migration-ledger.json
@@ -107,6 +107,10 @@
 		{
 			"filename": "0026-integration-owned-credentials.sql",
 			"sha256": "cedea1c9d99566ef07cc1f942037c3a7f9045ae594ff3165eafd3adb208a08fb"
+		},
+		{
+			"filename": "0027-mcp-server-logos.sql",
+			"sha256": "c48d9b5814af7a15900e5eb1cbabe4998b817ba988748f8b54d3ac1863c969fb"
 		}
 	]
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

The MCP servers table should show a mark next to each server name, the same way Integrations does — derived from the server URL’s favicon, with a letter fallback.

## Why

Saved servers like `agentcard`, `home`, and `mediarss` are custom remotes. Catalog brand SVGs do not cover them. Integrations already fetch, store, and serve a registrable-domain favicon; MCP servers should reuse that pipeline instead of pointing `<img>` at third-party `/favicon.ico`.

## Summary

- Account MCP list and detail render `ProviderMark` beside the server name.
- Page/API loads backfill missing favicons from the server URL’s registrable domain (same HTTPS fetch as user-lane OAuth apps).
- Rasters live in `COMMUNITY_ASSETS` under `user-mcp-server-logos/{userId}/{id}/` and are served only to the signed-in owner at `/account/mcp-servers/logos/:serverId`.
- First paint can show the letter fallback until the background fetch lands; the next load shows the favicon.
- `addMcpServer` / `mcp_server_add` pass `waitUntil` (and await the fill when it is missing) so the fetch is not dropped after the response.

## Testing

- Node-unit: favicon fetch gating, logo path cache-buster, owner-scoped logo route, MCP servers API includes `autoLogoPath`, router prefers `/logos/:id` over `/:serverId`, account add posts `waitUntil`.
- Pre-push `test:push`: node-unit 2086, workers-unit 301, Playwright 7 — all passed.
- Preview (`kody-pr-1777`): signed in as `me@kentcdodds.com`, added `agentcard` (`https://mcp.agentcard.sh/mcp`). List JSON returned `autoLogoPath` and `GET` of that path served a 180×180 PNG. Browser list and detail both show the fetched mark next to the name.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `03e13ec6` · **Head:** `d5e5ee9d`

**Classification:** extends — MCP server settings gain stored favicons and a private serve route.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `mcp-client-servers` | assistant | extends — favicon columns, fetch/store, owner-only logo route |
| `d1-app-db` | storage | extends — `mcp_server_settings` logo columns |
| `app-ui` | surfaces | composes — `ProviderMark` on the MCP servers table and detail |
| `community-assets-r2` | storage | composes — stores rasters under `user-mcp-server-logos/` |

### Change flow

Account MCP page load backfills missing favicons, then the table reads the stored mark.

```mermaid
sequenceDiagram
	actor User
	participant appUi as app-ui
	participant mcpClientServers as mcp-client-servers
	participant d1AppDb as d1-app-db
	participant communityAssetsR2 as community-assets-r2
	User->>appUi: open /account/mcp-servers
	appUi->>mcpClientServers: load settings plus live hub state
	mcpClientServers->>d1AppDb: read mcp_server_settings
	mcpClientServers->>mcpClientServers: fetch registrable-domain favicon when missing
	mcpClientServers->>communityAssetsR2: put user-mcp-server-logos raster
	mcpClientServers->>d1AppDb: write logo_key and favicon_source_host
	appUi-->>User: ProviderMark via /account/mcp-servers/logos/:serverId
```

### Invariants

Per-user isolation: logo GET resolves the signed-in owner's server id; R2 keys are prefixed with `userId`.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d2e9331f-8e81-48a9-8bb2-55b7442a5065?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d2e9331f-8e81-48a9-8bb2-55b7442a5065&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

