### PR TITLE
Backfill leftover integration OAuth ciphertext from the secret store

### DIFF
--- a/.github/workflows/backfill-integration-credentials.yml
+++ b/.github/workflows/backfill-integration-credentials.yml
@@ -1,0 +1,63 @@
+name: 🔐 Backfill integration credentials
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Count leftovers and resolve secrets without writes
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: backfill-integration-credentials
+  cancel-in-progress: false
+
+jobs:
+  backfill:
+    runs-on: ubuntu-latest
+    name: 🔐 Backfill integration credentials
+    timeout-minutes: 10
+    steps:
+      - name: 🔐 POST /__maintenance/backfill-integration-credentials
+        shell: bash
+        env:
+          CAPABILITY_REINDEX_SECRET: ${{ secrets.CAPABILITY_REINDEX_SECRET }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          if [ -z "${CAPABILITY_REINDEX_SECRET:-}" ]; then
+            echo "CAPABILITY_REINDEX_SECRET is not set." >&2
+            exit 1
+          fi
+
+          if [ "${DRY_RUN}" = "true" ]; then
+            body='{"dryRun":true}'
+          else
+            body='{}'
+          fi
+
+          echo "POST https://kody.codes/__maintenance/backfill-integration-credentials"
+          echo "dryRun=${DRY_RUN}"
+
+          status="$(curl --silent --show-error --location --max-time 180 \
+            -X POST \
+            -H "Authorization: Bearer ${CAPABILITY_REINDEX_SECRET}" \
+            -H "Accept: application/json" \
+            -H "Content-Type: application/json" \
+            --data "${body}" \
+            --output backfill.json \
+            --write-out "%{http_code}" \
+            "https://kody.codes/__maintenance/backfill-integration-credentials")"
+
+          STATUS="${status}" node -e '
+            const fs = require("node:fs");
+            const status = Number(process.env.STATUS);
+            const json = JSON.parse(fs.readFileSync("backfill.json", "utf8"));
+            console.log(JSON.stringify({ status, ...json }, null, 2));
+            if (status < 200 || status >= 300 || json.ok !== true) {
+              process.exit(1);
+            }
+          '

--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -1246,7 +1246,10 @@ on write unless a migration backfills existing rows.
   layer own the shapes. Access and refresh token ciphertexts live on
   `user_integrations`; the user-lane client secret ciphertext lives on
   `user_oauth_apps`. Account export redacts those columns. `*_secret_name`
-  columns remain for dual-write soak.
+  columns remain for dual-write soak. The operator backfill at
+  `POST /__maintenance/backfill-integration-credentials` copies leftover
+  secret-store values onto null ciphertext columns (see
+  [Secret rotation](../secret-rotation.md#backfilling-integration-owned-credentials)).
 - `user_openapi_bindings.auth_json`, `user_openapi_bindings.selection_json`, and
   `user_openapi_binding_operations.operation_json` (`0001-squashed-init.sql`,
   `packages/worker/src/openapi/`) store the auth discriminant, selection object,

--- a/docs/contributing/architecture/integrations.md
+++ b/docs/contributing/architecture/integrations.md
@@ -221,6 +221,10 @@ and the inline `client_id`, never encrypted secret payloads. Exporting
 credential value. `platform_oauth_apps` is global operator config and is not
 part of any user's export.
 
+Connections that still have a `*_secret_name` and a null ciphertext column are
+copied by `POST /__maintenance/backfill-integration-credentials` (see
+[Secret rotation](../secret-rotation.md#backfilling-integration-owned-credentials)).
+
 ## Two independent host gates
 
 Outbound OAuth calls enforce two allowlists that are not collapsed:

--- a/docs/contributing/environment-variables.md
+++ b/docs/contributing/environment-variables.md
@@ -283,18 +283,20 @@ Worker secrets:
   skips the post-deploy capability reindex and origin-only execute smoke check
   when it is unset); bearer token for
   `POST /__maintenance/reindex-capabilities`,
-  `POST /__maintenance/reencrypt-secrets`, and other secret-gated maintenance
-  endpoints. Production deploy POSTs `{ "phases": ["capabilities"] }` so only
-  builtin capability vectors refresh after a ship. User-owned memory, job, and
-  saved-package vectors upsert on write. Omit `phases` (or list every kind)
-  after changing the embedding model, pooling, or Vectorize index dimensions to
-  rebuild those rows too, with per-user `userId` metadata on user-owned rows.
-  Unchanged embed text and Vectorize metadata skip embed and Vectorize upsert;
-  after Vectorize data loss or a pooling-only change, POST `{ "force": true }`
-  (and omit `phases` for every kind) so matching fingerprints cannot skip
-  upserts. Each call is time-budgeted and may return `complete: false` plus a
-  `cursor` to resume. Use the re-encrypt endpoint to rewrite remaining pre-AAD
-  (2-part) secret ciphertexts to v2 without rotating `SECRET_STORE_KEY` (see
+  `POST /__maintenance/reencrypt-secrets`,
+  `POST /__maintenance/backfill-integration-credentials`, and other secret-gated
+  maintenance endpoints. Production deploy POSTs
+  `{ "phases": ["capabilities"] }` so only builtin capability vectors refresh
+  after a ship. User-owned memory, job, and saved-package vectors upsert on
+  write. Omit `phases` (or list every kind) after changing the embedding model,
+  pooling, or Vectorize index dimensions to rebuild those rows too, with
+  per-user `userId` metadata on user-owned rows. Unchanged embed text and
+  Vectorize metadata skip embed and Vectorize upsert; after Vectorize data loss
+  or a pooling-only change, POST `{ "force": true }` (and omit `phases` for
+  every kind) so matching fingerprints cannot skip upserts. Each call is
+  time-budgeted and may return `complete: false` plus a `cursor` to resume. Use
+  the re-encrypt endpoint to rewrite remaining pre-AAD (2-part) secret
+  ciphertexts to v2 without rotating `SECRET_STORE_KEY` (see
   [Secret rotation](./secret-rotation.md)). Local dev uses offline search while
   `WRANGLER_IS_LOCAL_DEV` is set or the binding is missing.
 - **`JOB_REINDEX_SECRET`** — optional Worker secret; bearer token for

--- a/docs/contributing/secret-rotation.md
+++ b/docs/contributing/secret-rotation.md
@@ -127,12 +127,12 @@ Optional JSON body: `{ "dryRun": true }` to resolve-verify without writes;
 `{ "maxRows": 50 }` to bound leftover **fields that can still make progress**
 (copied or raced) in one invocation (default 500). Missing or unreadable
 leftovers are scanned and reported; they do not consume `maxRows`, so a later
-copyable connection or app still copies in the same invocation. Repeat the
-write until every field reports `remaining: 0`. `remaining` includes rows
-whose secret is missing. If `remaining` stalls and `missingSecrets` is
-non-empty after a run that did not hit the copy budget, inspect those keys
-instead of looping. This is a production mutation; run `dryRun: true` first
-and only write after an explicit operator go-ahead.
+copyable connection or app still copies in the same invocation. Repeat the write
+until every field reports `remaining: 0`. `remaining` includes rows whose secret
+is missing. If `remaining` stalls and `missingSecrets` is non-empty after a run
+that did not hit the copy budget, inspect those keys instead of looping. This is
+a production mutation; run `dryRun: true` first and only write after an explicit
+operator go-ahead.
 
 ## Generating secure key values
 

--- a/docs/contributing/secret-rotation.md
+++ b/docs/contributing/secret-rotation.md
@@ -124,10 +124,15 @@ The pass:
    (`userId:name:access`, never plaintext or ciphertext).
 
 Optional JSON body: `{ "dryRun": true }` to resolve-verify without writes;
-`{ "maxRows": 50 }` to bound leftover **rows** in one invocation (default 500).
-Repeat the write until every field reports `remaining: 0`. `remaining` includes
-rows whose secret is missing. This is a production mutation; run `dryRun: true`
-first and only write after an explicit operator go-ahead.
+`{ "maxRows": 50 }` to bound leftover **fields that can still make progress**
+(copied or raced) in one invocation (default 500). Missing or unreadable
+leftovers are scanned and reported; they do not consume `maxRows`, so a later
+copyable connection or app still copies in the same invocation. Repeat the
+write until every field reports `remaining: 0`. `remaining` includes rows
+whose secret is missing. If `remaining` stalls and `missingSecrets` is
+non-empty after a run that did not hit the copy budget, inspect those keys
+instead of looping. This is a production mutation; run `dryRun: true` first
+and only write after an explicit operator go-ahead.
 
 ## Generating secure key values
 

--- a/docs/contributing/secret-rotation.md
+++ b/docs/contributing/secret-rotation.md
@@ -98,6 +98,37 @@ rows that failed decryption and stay 2-part). If `remaining` stalls and
 inspect those keys instead of looping. This is a production mutation; run it
 only after an explicit operator go-ahead.
 
+## Backfilling integration-owned credentials
+
+After [OAuth integrations](./architecture/integrations.md) persist access,
+refresh, and user-lane client secrets as ciphertext on `user_integrations` /
+`user_oauth_apps`, some rows can still have a `*_secret_name` and a null
+ciphertext column (idle pre-migration connections, names-only seed rows).
+Resolve falls back to `secret_entries` for those rows. The operator pass copies
+the leftover secret-store values onto the columns so
+[#1773](https://github.com/kentcdodds/kody/issues/1773) can drop the dual-write
+and the names.
+
+`POST /__maintenance/backfill-integration-credentials` (bearer
+`CAPABILITY_REINDEX_SECRET`). Operators with Actions access dispatch
+`.github/workflows/backfill-integration-credentials.yml` (`dry_run` defaults to
+true) so the bearer never leaves GitHub Actions.
+
+The pass:
+
+1. Counts leftover fields (`*_secret_name` set, matching `*_encrypted` null).
+2. Resolves each leftover name from the user secret store, encrypts it with the
+   integration/app AAD, and writes only `WHERE <column> IS NULL` so a concurrent
+   persist wins.
+3. Leaves missing or unreadable secrets unchanged and reports stable row keys
+   (`userId:name:access`, never plaintext or ciphertext).
+
+Optional JSON body: `{ "dryRun": true }` to resolve-verify without writes;
+`{ "maxRows": 50 }` to bound leftover **rows** in one invocation (default 500).
+Repeat the write until every field reports `remaining: 0`. `remaining` includes
+rows whose secret is missing. This is a production mutation; run `dryRun: true`
+first and only write after an explicit operator go-ahead.
+
 ## Generating secure key values
 
 Use a cryptographically random string of at least 32 characters:

--- a/docs/contributing/security.md
+++ b/docs/contributing/security.md
@@ -383,11 +383,15 @@ guarded by a bearer secret comparison.
   under the same KEK and upgrade to `v2` on write re-encryption, or via the
   operator pass at `POST /__maintenance/reencrypt-secrets` (same KEK; optimistic
   compare so a concurrent user rotation wins; decrypt failures are counted and
-  left unchanged). Only `v2` provides owner binding: a 2-part ciphertext carries
-  no AAD, so a copied row would decrypt until rewritten (metadata-only writes
-  preserve the 2-part ciphertext). Row swaps already require write access to the
-  database, so this is defense-in-depth, not a standing hole. Decrypt dual-reads
-  both shapes; user-facing reads never rewrite.
+  left unchanged). Leftover integration-owned OAuth values that still live only
+  in `secret_entries` are copied onto the connection/app ciphertext columns by
+  `POST /__maintenance/backfill-integration-credentials` (same bearer; writes
+  only where the ciphertext column is still null). Only `v2` provides owner
+  binding: a 2-part ciphertext carries no AAD, so a copied row would decrypt
+  until rewritten (metadata-only writes preserve the 2-part ciphertext). Row
+  swaps already require write access to the database, so this is
+  defense-in-depth, not a standing hole. Decrypt dual-reads both shapes;
+  user-facing reads never rewrite.
 - `SECRET_STORE_KEY` is escrowed for disaster recovery as a passphrase-sealed
   blob in the DR backup bucket (solo operator; see
   [Disaster recovery](./disaster-recovery.md) and

--- a/docs/contributing/setup-manifest.md
+++ b/docs/contributing/setup-manifest.md
@@ -435,7 +435,8 @@ automatically:
   builtin capability vectors only (`{ "phases": ["capabilities"] }`). Omit
   `phases` to rebuild memories, jobs, and saved packages too. Saved package
   projections also refresh when packages are saved or published. Same bearer
-  authenticates `POST /__maintenance/reencrypt-secrets` — see
+  authenticates `POST /__maintenance/reencrypt-secrets` and
+  `POST /__maintenance/backfill-integration-credentials` — see
   [Secret rotation](./secret-rotation.md).)
 - `JOB_REINDEX_SECRET` (optional Worker secret; bearer auth for
   `POST /__maintenance/reindex-jobs` for a jobs-only Vectorize rebuild. Not
@@ -695,7 +696,8 @@ How to get/set each value:
     the fingerprint, so a pooling-only change also needs `force` (or a
     `vectorEmbedFingerprintVersion` bump). After Vectorize data loss, `force` is
     required so restored D1 fingerprints cannot skip an empty index. The same
-    bearer authenticates `POST /__maintenance/reencrypt-secrets` (see
+    bearer authenticates `POST /__maintenance/reencrypt-secrets` and
+    `POST /__maintenance/backfill-integration-credentials` (see
     [Secret rotation](./secret-rotation.md)). Local and preview environments can
     omit it; CI skips reindex and origin-only execute-smoke when the secret is
     unset.

--- a/docs/contributing/setup/preview-deploys.md
+++ b/docs/contributing/setup/preview-deploys.md
@@ -4,7 +4,9 @@ The GitHub Actions preview workflow creates per-preview Cloudflare resources so
 each PR preview is isolated. See the [setup index](./index.md) for the other
 setup pages.
 
-- App worker: `<preview-worker-name>` (for kody: `kody-pr-<n>`)
+- App worker: `<preview-worker-name>` (for kody: `kody-pr-<n>`). Generated
+  preview config sets `workers_dev: true` so secret-bulk reapply cannot drop the
+  `<name>.<subdomain>.workers.dev` trigger (Cloudflare error 1042).
 - Platform worker: `<preview-worker-name>-platform`
 - Runtime worker: `<preview-worker-name>-runtime`
 - Jobs worker: `<preview-worker-name>-jobs`

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -64,6 +64,7 @@ import { handleDoPitrRequest } from '#worker/dr/do-pitr-maintenance.ts'
 import { handleMailboxImportRequest } from '#worker/dr/mailbox-import-maintenance.ts'
 import { handleStatusIncidentEventRequest } from '#worker/status-incidents/maintenance.ts'
 import { handleSecretReencryptRequest } from './secret-reencrypt-maintenance.ts'
+import { handleIntegrationCredentialBackfillRequest } from './integration-credential-backfill-maintenance.ts'
 import { OAuthPurgeCoordinator } from './oauth-purge.ts'
 import { verifyPublicFormProtection } from '#app/public-form-protection.ts'
 import { getLegacyHostRedirectResponse } from '#worker/app-legacy-redirect.ts'
@@ -273,6 +274,10 @@ const appHandler = withCors({
 
 		if (url.pathname === '/__maintenance/reencrypt-secrets') {
 			return handleSecretReencryptRequest(request, env)
+		}
+
+		if (url.pathname === '/__maintenance/backfill-integration-credentials') {
+			return handleIntegrationCredentialBackfillRequest(request, env)
 		}
 
 		if (url.pathname.startsWith('/__maintenance/')) {

--- a/packages/worker/src/integration-credential-backfill-maintenance.node.test.ts
+++ b/packages/worker/src/integration-credential-backfill-maintenance.node.test.ts
@@ -1,0 +1,119 @@
+import { DatabaseSync } from 'node:sqlite'
+import { expect, test } from 'vitest'
+import { applyAllMigrations } from '#worker/test-support/apply-all-migrations.ts'
+import { createD1FromSqlite } from '#worker/test-support/create-d1-from-sqlite.ts'
+import { handleIntegrationCredentialBackfillRequest } from './integration-credential-backfill-maintenance.ts'
+
+const storeKey = 'backfill-handler-secret-store-key-32!!'
+
+function createRequest(
+	input: {
+		method?: string
+		authorization?: string
+		body?: unknown
+	} = {},
+) {
+	const headers = new Headers()
+	if (input.authorization !== undefined) {
+		headers.set('Authorization', input.authorization)
+	}
+	if (input.body !== undefined) {
+		headers.set('Content-Type', 'application/json')
+	}
+	return new Request(
+		'https://example.com/__maintenance/backfill-integration-credentials',
+		{
+			method: input.method ?? 'POST',
+			headers,
+			body: input.body === undefined ? undefined : JSON.stringify(input.body),
+		},
+	)
+}
+
+test('integration credential backfill route enforces auth and returns leftover counts without ciphertext', async () => {
+	const sqlite = new DatabaseSync(':memory:')
+	applyAllMigrations(sqlite, new URL('../migrations/', import.meta.url))
+	const env = {
+		APP_DB: createD1FromSqlite(sqlite),
+		SECRET_STORE_KEY: storeKey,
+		CAPABILITY_REINDEX_SECRET: 'secret',
+	} as Env
+
+	const methodResponse = await handleIntegrationCredentialBackfillRequest(
+		createRequest({ method: 'GET', authorization: 'Bearer secret' }),
+		env,
+	)
+	expect(methodResponse.status).toBe(405)
+
+	const unauthorized = await handleIntegrationCredentialBackfillRequest(
+		createRequest(),
+		env,
+	)
+	expect(unauthorized.status).toBe(401)
+
+	const unconfigured = await handleIntegrationCredentialBackfillRequest(
+		createRequest({ authorization: 'Bearer secret' }),
+		{ ...env, CAPABILITY_REINDEX_SECRET: ' ' },
+	)
+	expect(unconfigured.status).toBe(503)
+	expect(await unconfigured.text()).toBe(
+		'Integration credential backfill is not configured',
+	)
+
+	const badBody = await handleIntegrationCredentialBackfillRequest(
+		createRequest({
+			authorization: 'Bearer secret',
+			body: { confirm: true },
+		}),
+		env,
+	)
+	expect(badBody.status).toBe(500)
+	await expect(badBody.json()).resolves.toEqual({
+		ok: false,
+		error: 'unknown request field: confirm',
+	})
+
+	const dryRun = await handleIntegrationCredentialBackfillRequest(
+		createRequest({
+			authorization: 'Bearer secret',
+			body: { dryRun: true, maxRows: 10 },
+		}),
+		env,
+	)
+	expect(dryRun.status).toBe(200)
+	const payload = (await dryRun.json()) as Record<string, unknown>
+	expect(payload).toEqual({
+		ok: true,
+		dryRun: true,
+		userIntegrations: {
+			access: {
+				leftover: 0,
+				scanned: 0,
+				copied: 0,
+				missingSecret: 0,
+				skippedConcurrent: 0,
+				remaining: 0,
+			},
+			refresh: {
+				leftover: 0,
+				scanned: 0,
+				copied: 0,
+				missingSecret: 0,
+				skippedConcurrent: 0,
+				remaining: 0,
+			},
+		},
+		userOauthApps: {
+			clientSecret: {
+				leftover: 0,
+				scanned: 0,
+				copied: 0,
+				missingSecret: 0,
+				skippedConcurrent: 0,
+				remaining: 0,
+			},
+		},
+		missingSecrets: [],
+	})
+	expect(JSON.stringify(payload)).not.toMatch(/encrypted/i)
+})

--- a/packages/worker/src/integration-credential-backfill-maintenance.ts
+++ b/packages/worker/src/integration-credential-backfill-maintenance.ts
@@ -1,0 +1,71 @@
+import { backfillIntegrationCredentials } from './integrations/credential-backfill.ts'
+import {
+	handleSecretMaintenanceRequest,
+	MaintenanceFailureError,
+} from './maintenance-handler.ts'
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}
+
+function failure(message: string) {
+	return new MaintenanceFailureError(message, {})
+}
+
+async function readJsonObject(
+	request: Request,
+): Promise<Record<string, unknown>> {
+	const text = await request.text()
+	if (text.trim() === '') return {}
+	let value: unknown
+	try {
+		value = JSON.parse(text)
+	} catch {
+		throw failure('Request body must be a JSON object')
+	}
+	if (!isRecord(value)) throw failure('Request body must be a JSON object')
+	return value
+}
+
+function parseDryRun(value: unknown) {
+	if (value === undefined) return false
+	if (typeof value !== 'boolean') throw failure('dryRun must be a boolean')
+	return value
+}
+
+function parseMaxRows(value: unknown) {
+	if (value === undefined) return undefined
+	if (typeof value !== 'number' || !Number.isInteger(value) || value < 1) {
+		throw failure('maxRows must be a positive integer')
+	}
+	return value
+}
+
+function parseRequestOptions(body: Record<string, unknown>) {
+	const allowed = new Set(['dryRun', 'maxRows'])
+	for (const key of Object.keys(body)) {
+		if (!allowed.has(key)) throw failure(`unknown request field: ${key}`)
+	}
+	return {
+		dryRun: parseDryRun(body['dryRun']),
+		maxRows: parseMaxRows(body['maxRows']),
+	}
+}
+
+export async function handleIntegrationCredentialBackfillRequest(
+	request: Request,
+	env: Env,
+): Promise<Response> {
+	return handleSecretMaintenanceRequest({
+		request,
+		secret: env.CAPABILITY_REINDEX_SECRET,
+		notConfiguredMessage: 'Integration credential backfill is not configured',
+		run: async () => {
+			const options = parseRequestOptions(await readJsonObject(request))
+			return backfillIntegrationCredentials({
+				env,
+				...options,
+			})
+		},
+	})
+}

--- a/packages/worker/src/integrations/credential-backfill.node.test.ts
+++ b/packages/worker/src/integrations/credential-backfill.node.test.ts
@@ -407,8 +407,12 @@ test('missing leftover prefix does not starve later copyable connections or apps
 		},
 	])
 	expect(readCiphertexts(sqlite, 'user-a').access_token_encrypted).toBeNull()
-	expect(readCiphertexts(sqlite, 'user-z').access_token_encrypted).not.toBeNull()
-	expect(readCiphertexts(sqlite, 'user-z').refresh_token_encrypted).not.toBeNull()
+	expect(
+		readCiphertexts(sqlite, 'user-z').access_token_encrypted,
+	).not.toBeNull()
+	expect(
+		readCiphertexts(sqlite, 'user-z').refresh_token_encrypted,
+	).not.toBeNull()
 	expect(
 		(
 			sqlite

--- a/packages/worker/src/integrations/credential-backfill.node.test.ts
+++ b/packages/worker/src/integrations/credential-backfill.node.test.ts
@@ -315,6 +315,126 @@ test('missing leftover secrets are counted and left null', async () => {
 	expect(readCiphertexts(sqlite, userId).access_token_encrypted).toBeNull()
 })
 
+test('missing leftover prefix does not starve later copyable connections or apps', async () => {
+	const { sqlite, env } = createHarness()
+	for (const userId of ['user-a', 'user-b', 'user-c']) {
+		await seedLeftoverConnection({
+			env,
+			userId,
+			userEmail: `${userId}@example.com`,
+		})
+	}
+	await seedLeftoverConnection({
+		env,
+		userId: 'user-z',
+		userEmail: 'user-z@example.com',
+		accessToken: 'access-after-missing',
+		refreshToken: 'refresh-after-missing',
+		clientSecret: 'client-after-missing',
+	})
+
+	const result = await backfillIntegrationCredentials({
+		env,
+		maxRows: 3,
+	})
+
+	expect(result.userIntegrations.access).toMatchObject({
+		leftover: 4,
+		scanned: 4,
+		copied: 1,
+		missingSecret: 3,
+		remaining: 3,
+	})
+	expect(result.userIntegrations.refresh).toMatchObject({
+		leftover: 4,
+		scanned: 4,
+		copied: 1,
+		missingSecret: 3,
+		remaining: 3,
+	})
+	expect(result.userOauthApps.clientSecret).toMatchObject({
+		leftover: 4,
+		scanned: 4,
+		copied: 1,
+		missingSecret: 3,
+		remaining: 3,
+	})
+	expect(result.missingSecrets).toEqual([
+		{
+			table: 'user_integrations',
+			key: 'user-a:google:access',
+			reason: 'not_found',
+		},
+		{
+			table: 'user_integrations',
+			key: 'user-a:google:refresh',
+			reason: 'not_found',
+		},
+		{
+			table: 'user_integrations',
+			key: 'user-b:google:access',
+			reason: 'not_found',
+		},
+		{
+			table: 'user_integrations',
+			key: 'user-b:google:refresh',
+			reason: 'not_found',
+		},
+		{
+			table: 'user_integrations',
+			key: 'user-c:google:access',
+			reason: 'not_found',
+		},
+		{
+			table: 'user_integrations',
+			key: 'user-c:google:refresh',
+			reason: 'not_found',
+		},
+		{
+			table: 'user_oauth_apps',
+			key: 'user-a:google:clientSecret',
+			reason: 'not_found',
+		},
+		{
+			table: 'user_oauth_apps',
+			key: 'user-b:google:clientSecret',
+			reason: 'not_found',
+		},
+		{
+			table: 'user_oauth_apps',
+			key: 'user-c:google:clientSecret',
+			reason: 'not_found',
+		},
+	])
+	expect(readCiphertexts(sqlite, 'user-a').access_token_encrypted).toBeNull()
+	expect(readCiphertexts(sqlite, 'user-z').access_token_encrypted).not.toBeNull()
+	expect(readCiphertexts(sqlite, 'user-z').refresh_token_encrypted).not.toBeNull()
+	expect(
+		(
+			sqlite
+				.prepare(
+					`SELECT client_secret_encrypted
+					FROM user_oauth_apps
+					WHERE user_id = ? AND slug = ?`,
+				)
+				.get('user-z', leftoverConfig.name) as {
+				client_secret_encrypted: string | null
+			}
+		).client_secret_encrypted,
+	).not.toBeNull()
+	expect(
+		await resolveIntegrationAccessToken({
+			env,
+			userId: 'user-z',
+			name: leftoverConfig.name,
+			secretName: leftoverConfig.accessTokenSecretName,
+		}),
+	).toBe('access-after-missing')
+	expect(JSON.stringify(result)).not.toMatch(
+		/access-after-missing|refresh-after-missing|client-after-missing/,
+	)
+})
+
 test('write does not overwrite ciphertext when a persist lands first', async () => {
 	const { env } = createHarness()
 	const userId = 'user-leftover-race'

--- a/packages/worker/src/integrations/credential-backfill.node.test.ts
+++ b/packages/worker/src/integrations/credential-backfill.node.test.ts
@@ -1,0 +1,354 @@
+import { DatabaseSync } from 'node:sqlite'
+import { expect, test } from 'vitest'
+import { saveSecret } from '#mcp/secrets/service.ts'
+import { applyAllMigrations as applyRepositoryMigrations } from '#worker/test-support/apply-all-migrations.ts'
+import { createD1FromSqlite } from '#worker/test-support/create-d1-from-sqlite.ts'
+import { createInMemoryUserMeterEnv } from '#worker/test-support/user-meter.ts'
+import { backfillIntegrationCredentials } from './credential-backfill.ts'
+import {
+	persistIntegrationTokens,
+	resolveIntegrationAccessToken,
+	resolveIntegrationRefreshToken,
+	resolveUserOauthAppClientSecret,
+} from './credentials.ts'
+import { upsertIntegration } from './service.ts'
+
+const migrationsDirectory = new URL('../../migrations/', import.meta.url)
+const storageContext = { sessionId: null, appId: null, packageId: null }
+
+function createHarness() {
+	const sqlite = new DatabaseSync(':memory:')
+	applyRepositoryMigrations(sqlite, migrationsDirectory)
+	const env = {
+		APP_DB: createD1FromSqlite(sqlite),
+		SECRET_STORE_KEY: 'test-secret-store-key-32-chars-minimum',
+		...createInMemoryUserMeterEnv().env,
+	} as Env
+	return { sqlite, env }
+}
+
+const leftoverConfig = {
+	name: 'google',
+	tokenUrl: 'https://oauth2.googleapis.com/token',
+	apiBaseUrl: 'https://www.googleapis.com',
+	flow: 'confidential' as const,
+	clientId: 'google-client-id',
+	clientSecretSecretName: 'googleClientSecret',
+	accessTokenSecretName: 'googleAccessToken',
+	refreshTokenSecretName: 'googleRefreshToken',
+	requiredHosts: ['www.googleapis.com', 'oauth2.googleapis.com'],
+	authorization: {
+		authorizeUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
+		scopes: ['openid', 'email'],
+		scopeSeparator: null,
+		extraAuthorizeParams: { access_type: 'offline' },
+	},
+}
+
+async function seedLeftoverConnection(input: {
+	env: Env
+	userId: string
+	userEmail: string
+	accessToken?: string
+	refreshToken?: string
+	clientSecret?: string
+}) {
+	await upsertIntegration({
+		env: input.env,
+		userId: input.userId,
+		config: leftoverConfig,
+	})
+	if (input.accessToken) {
+		await saveSecret({
+			env: input.env,
+			userId: input.userId,
+			userEmail: input.userEmail,
+			name: leftoverConfig.accessTokenSecretName,
+			value: input.accessToken,
+			scope: 'user',
+			description: 'leftover access',
+			storageContext,
+		})
+	}
+	if (input.refreshToken) {
+		await saveSecret({
+			env: input.env,
+			userId: input.userId,
+			userEmail: input.userEmail,
+			name: leftoverConfig.refreshTokenSecretName,
+			value: input.refreshToken,
+			scope: 'user',
+			description: 'leftover refresh',
+			storageContext,
+		})
+	}
+	if (input.clientSecret) {
+		await saveSecret({
+			env: input.env,
+			userId: input.userId,
+			userEmail: input.userEmail,
+			name: leftoverConfig.clientSecretSecretName,
+			value: input.clientSecret,
+			scope: 'user',
+			description: 'leftover client secret',
+			storageContext,
+		})
+	}
+}
+
+function readCiphertexts(sqlite: DatabaseSync, userId: string) {
+	return sqlite
+		.prepare(
+			`SELECT access_token_encrypted, refresh_token_encrypted
+			FROM user_integrations
+			WHERE user_id = ? AND name = ?`,
+		)
+		.get(userId, leftoverConfig.name) as {
+		access_token_encrypted: string | null
+		refresh_token_encrypted: string | null
+	}
+}
+
+test('dry-run counts leftover named secrets and does not write ciphertext', async () => {
+	const { sqlite, env } = createHarness()
+	const userId = 'user-leftover-dry'
+	await seedLeftoverConnection({
+		env,
+		userId,
+		userEmail: 'leftover@example.com',
+		accessToken: 'access-leftover',
+		refreshToken: 'refresh-leftover',
+		clientSecret: 'client-leftover',
+	})
+
+	const result = await backfillIntegrationCredentials({
+		env,
+		dryRun: true,
+	})
+
+	expect(result).toEqual({
+		dryRun: true,
+		userIntegrations: {
+			access: {
+				leftover: 1,
+				scanned: 1,
+				copied: 1,
+				missingSecret: 0,
+				skippedConcurrent: 0,
+				remaining: 1,
+			},
+			refresh: {
+				leftover: 1,
+				scanned: 1,
+				copied: 1,
+				missingSecret: 0,
+				skippedConcurrent: 0,
+				remaining: 1,
+			},
+		},
+		userOauthApps: {
+			clientSecret: {
+				leftover: 1,
+				scanned: 1,
+				copied: 1,
+				missingSecret: 0,
+				skippedConcurrent: 0,
+				remaining: 1,
+			},
+		},
+		missingSecrets: [],
+	})
+	expect(JSON.stringify(result)).not.toMatch(
+		/access-leftover|refresh-leftover|client-leftover/,
+	)
+	const ciphertexts = readCiphertexts(sqlite, userId)
+	expect(ciphertexts.access_token_encrypted).toBeNull()
+	expect(ciphertexts.refresh_token_encrypted).toBeNull()
+	expect(
+		(
+			sqlite
+				.prepare(
+					`SELECT client_secret_encrypted
+					FROM user_oauth_apps
+					WHERE user_id = ? AND slug = ?`,
+				)
+				.get(userId, leftoverConfig.name) as {
+				client_secret_encrypted: string | null
+			}
+		).client_secret_encrypted,
+	).toBeNull()
+})
+
+test('write copies leftover secret-store values onto ciphertext and leaves existing columns alone', async () => {
+	const { sqlite, env } = createHarness()
+	const userId = 'user-leftover-write'
+	const userEmail = 'write@example.com'
+	await seedLeftoverConnection({
+		env,
+		userId,
+		userEmail,
+		accessToken: 'access-from-store',
+		refreshToken: 'refresh-from-store',
+		clientSecret: 'client-from-store',
+	})
+	await persistIntegrationTokens({
+		env,
+		userId,
+		userEmail,
+		name: leftoverConfig.name,
+		accessToken: 'access-already-on-connection',
+		refreshToken: null,
+		accessTokenSecretName: leftoverConfig.accessTokenSecretName,
+		refreshTokenSecretName: leftoverConfig.refreshTokenSecretName,
+		descriptionPrefix: 'google',
+	})
+	sqlite
+		.prepare(
+			`UPDATE user_integrations
+			SET refresh_token_encrypted = NULL
+			WHERE user_id = ? AND name = ?`,
+		)
+		.run(userId, leftoverConfig.name)
+
+	const result = await backfillIntegrationCredentials({ env })
+	expect(result.dryRun).toBe(false)
+	expect(result.userIntegrations.access).toMatchObject({
+		leftover: 0,
+		scanned: 0,
+		copied: 0,
+		remaining: 0,
+	})
+	expect(result.userIntegrations.refresh).toMatchObject({
+		leftover: 1,
+		scanned: 1,
+		copied: 1,
+		remaining: 0,
+	})
+	expect(result.userOauthApps.clientSecret).toMatchObject({
+		leftover: 1,
+		scanned: 1,
+		copied: 1,
+		remaining: 0,
+	})
+	expect(result.missingSecrets).toEqual([])
+	expect(JSON.stringify(result)).not.toMatch(
+		/access-from-store|refresh-from-store|client-from-store|access-already-on-connection/,
+	)
+
+	expect(
+		await resolveIntegrationAccessToken({
+			env,
+			userId,
+			name: leftoverConfig.name,
+			secretName: leftoverConfig.accessTokenSecretName,
+		}),
+	).toBe('access-already-on-connection')
+	expect(
+		await resolveIntegrationRefreshToken({
+			env,
+			userId,
+			name: leftoverConfig.name,
+			secretName: leftoverConfig.refreshTokenSecretName,
+		}),
+	).toMatchObject({ value: 'refresh-from-store', source: 'integration' })
+	expect(
+		await resolveUserOauthAppClientSecret({
+			env,
+			userId,
+			slug: leftoverConfig.name,
+			secretName: leftoverConfig.clientSecretSecretName,
+		}),
+	).toMatchObject({ value: 'client-from-store', source: 'integration' })
+})
+
+test('missing leftover secrets are counted and left null', async () => {
+	const { sqlite, env } = createHarness()
+	const userId = 'user-leftover-missing'
+	await seedLeftoverConnection({
+		env,
+		userId,
+		userEmail: 'missing@example.com',
+	})
+
+	const result = await backfillIntegrationCredentials({
+		env,
+		dryRun: true,
+	})
+	expect(result.userIntegrations.access).toMatchObject({
+		leftover: 1,
+		scanned: 1,
+		copied: 0,
+		missingSecret: 1,
+		remaining: 1,
+	})
+	expect(result.userIntegrations.refresh).toMatchObject({
+		leftover: 1,
+		scanned: 1,
+		copied: 0,
+		missingSecret: 1,
+		remaining: 1,
+	})
+	expect(result.userOauthApps.clientSecret).toMatchObject({
+		leftover: 1,
+		scanned: 1,
+		copied: 0,
+		missingSecret: 1,
+		remaining: 1,
+	})
+	expect(result.missingSecrets).toEqual([
+		{
+			table: 'user_integrations',
+			key: `${userId}:${leftoverConfig.name}:access`,
+			reason: 'not_found',
+		},
+		{
+			table: 'user_integrations',
+			key: `${userId}:${leftoverConfig.name}:refresh`,
+			reason: 'not_found',
+		},
+		{
+			table: 'user_oauth_apps',
+			key: `${userId}:${leftoverConfig.name}:clientSecret`,
+			reason: 'not_found',
+		},
+	])
+	expect(readCiphertexts(sqlite, userId).access_token_encrypted).toBeNull()
+})
+
+test('write does not overwrite ciphertext when a persist lands first', async () => {
+	const { env } = createHarness()
+	const userId = 'user-leftover-race'
+	const userEmail = 'race@example.com'
+	await seedLeftoverConnection({
+		env,
+		userId,
+		userEmail,
+		accessToken: 'access-from-store',
+	})
+	await persistIntegrationTokens({
+		env,
+		userId,
+		userEmail,
+		name: leftoverConfig.name,
+		accessToken: 'access-won-the-race',
+		refreshToken: null,
+		accessTokenSecretName: leftoverConfig.accessTokenSecretName,
+		descriptionPrefix: 'google',
+	})
+
+	const result = await backfillIntegrationCredentials({ env })
+	expect(result.userIntegrations.access).toMatchObject({
+		leftover: 0,
+		scanned: 0,
+		copied: 0,
+		remaining: 0,
+	})
+	expect(
+		await resolveIntegrationAccessToken({
+			env,
+			userId,
+			name: leftoverConfig.name,
+			secretName: leftoverConfig.accessTokenSecretName,
+		}),
+	).toBe('access-won-the-race')
+})

--- a/packages/worker/src/integrations/credential-backfill.ts
+++ b/packages/worker/src/integrations/credential-backfill.ts
@@ -1,0 +1,523 @@
+import {
+	encryptUserOauthAccessToken,
+	encryptUserOauthClientSecret,
+	encryptUserOauthRefreshToken,
+	userIntegrationCredentialContext,
+	userOauthAppCredentialContext,
+} from '#mcp/secrets/crypto.ts'
+import { resolveSecret } from '#mcp/secrets/service.ts'
+import { runD1WithRetry } from '#worker/d1-retry.ts'
+
+const defaultPageSize = 50
+const defaultMaxRows = 500
+const maxReportedMissingSecrets = 20
+const storageContext = { sessionId: null, appId: null, packageId: null }
+
+const leftoverAccessPredicate = `access_token_secret_name IS NOT NULL
+	AND TRIM(access_token_secret_name) != ''
+	AND access_token_encrypted IS NULL`
+
+const leftoverRefreshPredicate = `refresh_token_secret_name IS NOT NULL
+	AND TRIM(refresh_token_secret_name) != ''
+	AND refresh_token_encrypted IS NULL`
+
+const leftoverClientSecretPredicate = `client_secret_secret_name IS NOT NULL
+	AND TRIM(client_secret_secret_name) != ''
+	AND client_secret_encrypted IS NULL`
+
+export type CredentialBackfillMissingReason =
+	| 'not_found'
+	| 'unreadable'
+	| 'empty'
+
+export type CredentialBackfillMissingSecret = {
+	table: 'user_integrations' | 'user_oauth_apps'
+	key: string
+	reason: CredentialBackfillMissingReason
+}
+
+export type CredentialBackfillFieldResult = {
+	leftover: number
+	scanned: number
+	copied: number
+	missingSecret: number
+	skippedConcurrent: number
+	remaining: number
+}
+
+export type BackfillIntegrationCredentialsInput = {
+	env: Pick<Env, 'APP_DB' | 'SECRET_STORE_KEY'>
+	dryRun?: boolean
+	maxRows?: number
+	pageSize?: number
+}
+
+export type BackfillIntegrationCredentialsResult = {
+	dryRun: boolean
+	userIntegrations: {
+		access: CredentialBackfillFieldResult
+		refresh: CredentialBackfillFieldResult
+	}
+	userOauthApps: {
+		clientSecret: CredentialBackfillFieldResult
+	}
+	missingSecrets: Array<CredentialBackfillMissingSecret>
+}
+
+type LeftoverIntegrationRow = {
+	user_id: string
+	name: string
+	access_token_secret_name: string | null
+	refresh_token_secret_name: string | null
+	access_token_encrypted: string | null
+	refresh_token_encrypted: string | null
+}
+
+type LeftoverOauthAppRow = {
+	user_id: string
+	slug: string
+	client_secret_secret_name: string | null
+	client_secret_encrypted: string | null
+}
+
+type CopyOutcome = 'copied' | 'skippedConcurrent' | 'missingSecret'
+
+function emptyFieldResult(leftover = 0): CredentialBackfillFieldResult {
+	return {
+		leftover,
+		scanned: 0,
+		copied: 0,
+		missingSecret: 0,
+		skippedConcurrent: 0,
+		remaining: leftover,
+	}
+}
+
+function readCount(row: Record<string, unknown> | null, column: string) {
+	const value = row?.[column]
+	if (typeof value === 'number' && Number.isFinite(value)) return value
+	if (typeof value === 'bigint') return Number(value)
+	if (typeof value === 'string' && value.trim() !== '') {
+		const parsed = Number(value)
+		return Number.isFinite(parsed) ? parsed : 0
+	}
+	return 0
+}
+
+function recordOutcome(
+	result: CredentialBackfillFieldResult,
+	outcome: CopyOutcome,
+) {
+	result.scanned += 1
+	switch (outcome) {
+		case 'copied':
+			result.copied += 1
+			return
+		case 'skippedConcurrent':
+			result.skippedConcurrent += 1
+			return
+		case 'missingSecret':
+			result.missingSecret += 1
+			return
+		default: {
+			const exhaustive: never = outcome
+			throw new Error(`Unhandled credential backfill outcome: ${exhaustive}`)
+		}
+	}
+}
+
+function recordMissingSecret(
+	missingSecrets: Array<CredentialBackfillMissingSecret>,
+	missing: CredentialBackfillMissingSecret,
+) {
+	if (missingSecrets.length >= maxReportedMissingSecrets) return
+	missingSecrets.push(missing)
+}
+
+function isNonEmptyName(value: string | null | undefined): value is string {
+	return Boolean(value && value.trim() !== '')
+}
+
+function isLeftoverCiphertext(
+	secretName: string | null | undefined,
+	encrypted: string | null | undefined,
+): secretName is string {
+	return isNonEmptyName(secretName) && !encrypted
+}
+
+async function countColumn(input: {
+	db: D1Database
+	sql: string
+	column: string
+}): Promise<number> {
+	const row = await runD1WithRetry(() =>
+		input.db.prepare(input.sql).first<Record<string, unknown>>(),
+	)
+	return readCount(row, input.column)
+}
+
+async function countLeftovers(db: D1Database) {
+	const [leftoverAccess, leftoverRefresh, leftoverClientSecret] =
+		await Promise.all([
+			countColumn({
+				db,
+				sql: `SELECT COUNT(*) AS leftover
+					FROM user_integrations
+					WHERE ${leftoverAccessPredicate}`,
+				column: 'leftover',
+			}),
+			countColumn({
+				db,
+				sql: `SELECT COUNT(*) AS leftover
+					FROM user_integrations
+					WHERE ${leftoverRefreshPredicate}`,
+				column: 'leftover',
+			}),
+			countColumn({
+				db,
+				sql: `SELECT COUNT(*) AS leftover
+					FROM user_oauth_apps
+					WHERE ${leftoverClientSecretPredicate}`,
+				column: 'leftover',
+			}),
+		])
+	return { leftoverAccess, leftoverRefresh, leftoverClientSecret }
+}
+
+async function listLeftoverIntegrationPage(input: {
+	db: D1Database
+	afterUserId: string
+	afterName: string
+	limit: number
+}): Promise<Array<LeftoverIntegrationRow>> {
+	const { results } = await runD1WithRetry(() =>
+		input.db
+			.prepare(
+				`SELECT user_id, name,
+					access_token_secret_name, refresh_token_secret_name,
+					access_token_encrypted, refresh_token_encrypted
+				FROM user_integrations
+				WHERE (
+					(${leftoverAccessPredicate})
+					OR (${leftoverRefreshPredicate})
+				)
+					AND (user_id > ? OR (user_id = ? AND name > ?))
+				ORDER BY user_id, name
+				LIMIT ?`,
+			)
+			.bind(input.afterUserId, input.afterUserId, input.afterName, input.limit)
+			.all<Record<string, unknown>>(),
+	)
+	return (results ?? []).map((row) => ({
+		user_id: String(row['user_id'] ?? ''),
+		name: String(row['name'] ?? ''),
+		access_token_secret_name:
+			typeof row['access_token_secret_name'] === 'string'
+				? row['access_token_secret_name']
+				: null,
+		refresh_token_secret_name:
+			typeof row['refresh_token_secret_name'] === 'string'
+				? row['refresh_token_secret_name']
+				: null,
+		access_token_encrypted:
+			typeof row['access_token_encrypted'] === 'string'
+				? row['access_token_encrypted']
+				: null,
+		refresh_token_encrypted:
+			typeof row['refresh_token_encrypted'] === 'string'
+				? row['refresh_token_encrypted']
+				: null,
+	}))
+}
+
+async function listLeftoverOauthAppPage(input: {
+	db: D1Database
+	afterUserId: string
+	afterSlug: string
+	limit: number
+}): Promise<Array<LeftoverOauthAppRow>> {
+	const { results } = await runD1WithRetry(() =>
+		input.db
+			.prepare(
+				`SELECT user_id, slug, client_secret_secret_name, client_secret_encrypted
+				FROM user_oauth_apps
+				WHERE ${leftoverClientSecretPredicate}
+					AND (user_id > ? OR (user_id = ? AND slug > ?))
+				ORDER BY user_id, slug
+				LIMIT ?`,
+			)
+			.bind(input.afterUserId, input.afterUserId, input.afterSlug, input.limit)
+			.all<Record<string, unknown>>(),
+	)
+	return (results ?? []).map((row) => ({
+		user_id: String(row['user_id'] ?? ''),
+		slug: String(row['slug'] ?? ''),
+		client_secret_secret_name:
+			typeof row['client_secret_secret_name'] === 'string'
+				? row['client_secret_secret_name']
+				: null,
+		client_secret_encrypted:
+			typeof row['client_secret_encrypted'] === 'string'
+				? row['client_secret_encrypted']
+				: null,
+	}))
+}
+
+async function updateNullCiphertext(input: {
+	db: D1Database
+	sql: string
+	bindings: Array<string>
+}): Promise<number> {
+	const result = await runD1WithRetry(() =>
+		input.db
+			.prepare(input.sql)
+			.bind(...input.bindings)
+			.run(),
+	)
+	return Number(result.meta.changes ?? 0)
+}
+
+async function resolveNamedSecret(input: {
+	env: Pick<Env, 'APP_DB' | 'SECRET_STORE_KEY'>
+	userId: string
+	secretName: string
+}): Promise<
+	| { ok: true; value: string }
+	| { ok: false; reason: CredentialBackfillMissingReason }
+> {
+	try {
+		const resolved = await resolveSecret({
+			env: input.env,
+			userId: input.userId,
+			name: input.secretName,
+			scope: 'user',
+			storageContext,
+		})
+		if (!resolved.found) return { ok: false, reason: 'not_found' }
+		const value = resolved.value?.trim() ?? ''
+		if (value === '') return { ok: false, reason: 'empty' }
+		return { ok: true, value }
+	} catch {
+		return { ok: false, reason: 'unreadable' }
+	}
+}
+
+async function copyLeftoverField(input: {
+	env: Pick<Env, 'APP_DB' | 'SECRET_STORE_KEY'>
+	dryRun: boolean
+	userId: string
+	secretName: string
+	encrypt: (plaintext: string) => Promise<string>
+	write: (nextPayload: string) => Promise<number>
+	missing: CredentialBackfillMissingSecret
+	missingSecrets: Array<CredentialBackfillMissingSecret>
+}): Promise<CopyOutcome> {
+	const resolved = await resolveNamedSecret({
+		env: input.env,
+		userId: input.userId,
+		secretName: input.secretName,
+	})
+	if (!resolved.ok) {
+		recordMissingSecret(input.missingSecrets, {
+			...input.missing,
+			reason: resolved.reason,
+		})
+		return 'missingSecret'
+	}
+	if (input.dryRun) return 'copied'
+	const nextPayload = await input.encrypt(resolved.value)
+	const changes = await input.write(nextPayload)
+	return changes > 0 ? 'copied' : 'skippedConcurrent'
+}
+
+/**
+ * Copy leftover integration-owned OAuth values from `secret_entries` onto the
+ * connection/app ciphertext columns. Skips rows that already have ciphertext.
+ * Writes only where the target column is still null so a concurrent persist
+ * wins. The JSON result is counts plus stable row keys — never plaintext or
+ * ciphertext.
+ */
+export async function backfillIntegrationCredentials(
+	input: BackfillIntegrationCredentialsInput,
+): Promise<BackfillIntegrationCredentialsResult> {
+	const dryRun = input.dryRun === true
+	const pageSize = input.pageSize ?? defaultPageSize
+	let remainingBudget = input.maxRows ?? defaultMaxRows
+	const db = input.env.APP_DB
+	const missingSecrets: Array<CredentialBackfillMissingSecret> = []
+	const starting = await countLeftovers(db)
+	const access = emptyFieldResult(starting.leftoverAccess)
+	const refresh = emptyFieldResult(starting.leftoverRefresh)
+	const clientSecret = emptyFieldResult(starting.leftoverClientSecret)
+
+	let afterUserId = ''
+	let afterName = ''
+	while (remainingBudget > 0) {
+		const rows = await listLeftoverIntegrationPage({
+			db,
+			afterUserId,
+			afterName,
+			limit: Math.min(pageSize, remainingBudget),
+		})
+		if (rows.length === 0) break
+		for (const row of rows) {
+			remainingBudget -= 1
+			if (
+				isLeftoverCiphertext(
+					row.access_token_secret_name,
+					row.access_token_encrypted,
+				)
+			) {
+				const outcome = await copyLeftoverField({
+					env: input.env,
+					dryRun,
+					userId: row.user_id,
+					secretName: row.access_token_secret_name,
+					encrypt: (plaintext) =>
+						encryptUserOauthAccessToken(
+							input.env,
+							plaintext,
+							userIntegrationCredentialContext(row.user_id, row.name),
+						),
+					write: (nextPayload) =>
+						updateNullCiphertext({
+							db,
+							sql: `UPDATE user_integrations
+								SET access_token_encrypted = ?, updated_at = ?
+								WHERE user_id = ? AND name = ?
+									AND access_token_encrypted IS NULL`,
+							bindings: [
+								nextPayload,
+								new Date().toISOString(),
+								row.user_id,
+								row.name,
+							],
+						}),
+					missing: {
+						table: 'user_integrations',
+						key: `${row.user_id}:${row.name}:access`,
+						reason: 'not_found',
+					},
+					missingSecrets,
+				})
+				recordOutcome(access, outcome)
+			}
+			if (
+				isLeftoverCiphertext(
+					row.refresh_token_secret_name,
+					row.refresh_token_encrypted,
+				)
+			) {
+				const outcome = await copyLeftoverField({
+					env: input.env,
+					dryRun,
+					userId: row.user_id,
+					secretName: row.refresh_token_secret_name,
+					encrypt: (plaintext) =>
+						encryptUserOauthRefreshToken(
+							input.env,
+							plaintext,
+							userIntegrationCredentialContext(row.user_id, row.name),
+						),
+					write: (nextPayload) =>
+						updateNullCiphertext({
+							db,
+							sql: `UPDATE user_integrations
+								SET refresh_token_encrypted = ?, updated_at = ?
+								WHERE user_id = ? AND name = ?
+									AND refresh_token_encrypted IS NULL`,
+							bindings: [
+								nextPayload,
+								new Date().toISOString(),
+								row.user_id,
+								row.name,
+							],
+						}),
+					missing: {
+						table: 'user_integrations',
+						key: `${row.user_id}:${row.name}:refresh`,
+						reason: 'not_found',
+					},
+					missingSecrets,
+				})
+				recordOutcome(refresh, outcome)
+			}
+		}
+		const last = rows[rows.length - 1]
+		if (!last) break
+		afterUserId = last.user_id
+		afterName = last.name
+	}
+
+	afterUserId = ''
+	let afterSlug = ''
+	while (remainingBudget > 0) {
+		const rows = await listLeftoverOauthAppPage({
+			db,
+			afterUserId,
+			afterSlug,
+			limit: Math.min(pageSize, remainingBudget),
+		})
+		if (rows.length === 0) break
+		for (const row of rows) {
+			remainingBudget -= 1
+			if (
+				!isLeftoverCiphertext(
+					row.client_secret_secret_name,
+					row.client_secret_encrypted,
+				)
+			) {
+				continue
+			}
+			const outcome = await copyLeftoverField({
+				env: input.env,
+				dryRun,
+				userId: row.user_id,
+				secretName: row.client_secret_secret_name,
+				encrypt: (plaintext) =>
+					encryptUserOauthClientSecret(
+						input.env,
+						plaintext,
+						userOauthAppCredentialContext(row.user_id, row.slug),
+					),
+				write: (nextPayload) =>
+					updateNullCiphertext({
+						db,
+						sql: `UPDATE user_oauth_apps
+							SET client_secret_encrypted = ?, updated_at = ?
+							WHERE user_id = ? AND slug = ?
+								AND client_secret_encrypted IS NULL`,
+						bindings: [
+							nextPayload,
+							new Date().toISOString(),
+							row.user_id,
+							row.slug,
+						],
+					}),
+				missing: {
+					table: 'user_oauth_apps',
+					key: `${row.user_id}:${row.slug}:clientSecret`,
+					reason: 'not_found',
+				},
+				missingSecrets,
+			})
+			recordOutcome(clientSecret, outcome)
+		}
+		const last = rows[rows.length - 1]
+		if (!last) break
+		afterUserId = last.user_id
+		afterSlug = last.slug
+	}
+
+	const remaining = await countLeftovers(db)
+	access.remaining = remaining.leftoverAccess
+	refresh.remaining = remaining.leftoverRefresh
+	clientSecret.remaining = remaining.leftoverClientSecret
+
+	return {
+		dryRun,
+		userIntegrations: { access, refresh },
+		userOauthApps: { clientSecret },
+		missingSecrets,
+	}
+}

--- a/packages/worker/src/integrations/credential-backfill.ts
+++ b/packages/worker/src/integrations/credential-backfill.ts
@@ -126,6 +126,20 @@ function recordOutcome(
 	}
 }
 
+function consumeCopyBudget(remainingBudget: number, outcome: CopyOutcome) {
+	switch (outcome) {
+		case 'copied':
+		case 'skippedConcurrent':
+			return remainingBudget - 1
+		case 'missingSecret':
+			return remainingBudget
+		default: {
+			const exhaustive: never = outcome
+			throw new Error(`Unhandled credential backfill outcome: ${exhaustive}`)
+		}
+	}
+}
+
 function recordMissingSecret(
 	missingSecrets: Array<CredentialBackfillMissingSecret>,
 	missing: CredentialBackfillMissingSecret,
@@ -334,8 +348,9 @@ async function copyLeftoverField(input: {
  * Copy leftover integration-owned OAuth values from `secret_entries` onto the
  * connection/app ciphertext columns. Skips rows that already have ciphertext.
  * Writes only where the target column is still null so a concurrent persist
- * wins. The JSON result is counts plus stable row keys — never plaintext or
- * ciphertext.
+ * wins. Missing or unreadable leftovers are reported and do not consume
+ * `maxRows`, so a later copyable row still copies. The JSON result is counts
+ * plus stable row keys — never plaintext or ciphertext.
  */
 export async function backfillIntegrationCredentials(
 	input: BackfillIntegrationCredentialsInput,
@@ -352,16 +367,15 @@ export async function backfillIntegrationCredentials(
 
 	let afterUserId = ''
 	let afterName = ''
-	while (remainingBudget > 0) {
+	scanIntegrations: while (remainingBudget > 0) {
 		const rows = await listLeftoverIntegrationPage({
 			db,
 			afterUserId,
 			afterName,
-			limit: Math.min(pageSize, remainingBudget),
+			limit: pageSize,
 		})
 		if (rows.length === 0) break
 		for (const row of rows) {
-			remainingBudget -= 1
 			if (
 				isLeftoverCiphertext(
 					row.access_token_secret_name,
@@ -401,6 +415,8 @@ export async function backfillIntegrationCredentials(
 					missingSecrets,
 				})
 				recordOutcome(access, outcome)
+				remainingBudget = consumeCopyBudget(remainingBudget, outcome)
+				if (remainingBudget <= 0) break scanIntegrations
 			}
 			if (
 				isLeftoverCiphertext(
@@ -441,6 +457,8 @@ export async function backfillIntegrationCredentials(
 					missingSecrets,
 				})
 				recordOutcome(refresh, outcome)
+				remainingBudget = consumeCopyBudget(remainingBudget, outcome)
+				if (remainingBudget <= 0) break scanIntegrations
 			}
 		}
 		const last = rows[rows.length - 1]
@@ -451,16 +469,15 @@ export async function backfillIntegrationCredentials(
 
 	afterUserId = ''
 	let afterSlug = ''
-	while (remainingBudget > 0) {
+	scanOauthApps: while (remainingBudget > 0) {
 		const rows = await listLeftoverOauthAppPage({
 			db,
 			afterUserId,
 			afterSlug,
-			limit: Math.min(pageSize, remainingBudget),
+			limit: pageSize,
 		})
 		if (rows.length === 0) break
 		for (const row of rows) {
-			remainingBudget -= 1
 			if (
 				!isLeftoverCiphertext(
 					row.client_secret_secret_name,
@@ -502,6 +519,8 @@ export async function backfillIntegrationCredentials(
 				missingSecrets,
 			})
 			recordOutcome(clientSecret, outcome)
+			remainingBudget = consumeCopyBudget(remainingBudget, outcome)
+			if (remainingBudget <= 0) break scanOauthApps
 		}
 		const last = rows[rows.length - 1]
 		if (!last) break

--- a/packages/worker/src/security/public-route-hardening.workers.test.ts
+++ b/packages/worker/src/security/public-route-hardening.workers.test.ts
@@ -132,6 +132,11 @@ test('public route hardening rejects retired connector paths, unknown paths, and
 			secret: env.CAPABILITY_REINDEX_SECRET,
 			notConfiguredMessage: 'Secret re-encryption is not configured',
 		},
+		{
+			path: '/__maintenance/backfill-integration-credentials',
+			secret: env.CAPABILITY_REINDEX_SECRET,
+			notConfiguredMessage: 'Integration credential backfill is not configured',
+		},
 	] as const
 
 	for (const route of registeredMaintenanceRoutes) {

--- a/tools/ci/resource-utils.node.test.ts
+++ b/tools/ci/resource-utils.node.test.ts
@@ -243,10 +243,11 @@ test('writeGeneratedWranglerConfig preserves migrations and copies environment a
 				},
 			],
 		})
-		// Preview serves package apps inline on its own origin, so it publishes no
-		// routes and keeps whatever domains and triggers it already had.
+		// Preview serves package apps inline on its own origin, so it publishes
+		// no routes. It still sets workers_dev so secret-bulk reapply cannot
+		// drop the workers.dev trigger (Cloudflare 1042).
 		expect(previewConfig.env?.preview?.routes).toBeUndefined()
-		expect(previewConfig.env?.preview?.workers_dev).toBeUndefined()
+		expect(previewConfig.env?.preview?.workers_dev).toBe(true)
 		expect(consoleError).toHaveBeenCalledWith(
 			`Wrote generated Wrangler config: ${previewOutPath}`,
 		)

--- a/tools/ci/resource-utils.ts
+++ b/tools/ci/resource-utils.ts
@@ -1862,6 +1862,13 @@ export async function writeGeneratedWranglerConfig({
 		sortWranglerMigrations(migrationList)
 	}
 
+	// Preview publishes no custom-domain routes, so the earlier route helper
+	// never sets this. `wrangler secret bulk` still reapplies the generated
+	// config after deploy; omitting `workers_dev` drops the
+	// `<name>.<subdomain>.workers.dev` trigger and Cloudflare answers that
+	// hostname with error 1042.
+	;(targetEnv as Record<string, unknown>).workers_dev = true
+
 	const resolvedOut = path.resolve(outConfigPath)
 	await writeFile(
 		resolvedOut,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Give operators a dry-run-first way to copy leftover integration-owned OAuth values from `secret_entries` onto the connection/app ciphertext columns so [#1773](https://github.com/kentcdodds/kody/issues/1773) can drop the dual-write after leftover counts hit zero.

## Why

[#1771](https://github.com/kentcdodds/kody/pull/1771) is live. Idle pre-migration connections and names-only seed rows can still have a `*_secret_name` and a null ciphertext column. Resolve falls back to the secret store for those rows. This pass fills the columns without waiting on reconnect/refresh. It does **not** drop dual-write, fallback, or the name columns.

## Summary

- `POST /__maintenance/backfill-integration-credentials` (bearer `CAPABILITY_REINDEX_SECRET`)
- Counts leftover access/refresh/client-secret fields
- Resolves each leftover name, encrypts with the integration/app AAD, and writes only `WHERE <column> IS NULL`
- Missing/unreadable secrets stay null and are reported as stable row keys (never plaintext or ciphertext)
- Missing leftovers do **not** consume `maxRows`, so a later copyable connection or OAuth app still copies in the same invocation (Bugbot)
- Actions workflow `.github/workflows/backfill-integration-credentials.yml` (`dry_run` defaults to true)
- Operator docs in `docs/contributing/secret-rotation.md`
- Cherry-picked preview `workers_dev: true` (already on `main` via #1776)

## Testing

- `npx vitest run --project node-unit` on the backfill suites (6 passed, including the missing-prefix starvation case)
- Preview-manual-test as seeded user `me@kentcdodds.com` / `user-me` on https://kody-pr-1778.kody-a99.workers.dev
  - `GET /account/integrations.json` — seeded Google connection (soak `*_secretName` fields still on the account JSON API)
  - `GET /account/secrets.json` — `"secrets":[]` (owned names hidden)
  - `POST /__maintenance/backfill-integration-credentials` — HTTP 503 `Integration credential backfill is not configured` (preview has no `CAPABILITY_REINDEX_SECRET`; seed session cannot run the write)
  - UI: Integrations lists Google (2 accounts); Secrets empty state “No secrets yet. Create one to get started.”
- Did **not** dispatch the production write. Dry-run against production waits for this to deploy, then Actions `workflow_dispatch` with `dry_run: true`.

## System changes

Medium: extends `integrations` (operator copy onto ciphertext columns). Does not change connect, refresh, or agent-facing secret teaching.

Do not merge the live write until a dry-run receipt exists. Do not drop dual-write in this PR.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends OAuth integrations</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `e132f5dc` · **Head:** `a7f348ad`

**Classification:** extends — operator backfill copies leftover secret-store OAuth values onto integration/app ciphertext columns. No new primitive.

### Primitives touched

| Primitive        | Group     | Impact                                                                                            |
| ---------------- | --------- | ------------------------------------------------------------------------------------------------- |
| `integrations`   | assistant | extends — leftover-count + copy pass onto `*_encrypted`; missing leftovers skip the `maxRows` budget |
| `secrets`        | assistant | composes — reads `secret_entries` for leftover names; no secret API change                        |
| `scheduled-cron` | surfaces  | composes — `index.ts` fetch path registers `POST /__maintenance/backfill-integration-credentials` |

### Change flow

Operators dispatch a dry-run-first maintenance POST; leftover named secrets are resolved, encrypted with the connection/app AAD, and written only where the ciphertext column is still null. Missing leftovers are reported and do not consume `maxRows`.

```mermaid
sequenceDiagram
	actor Operator
	participant scheduledCron as scheduled-cron
	participant integrations as integrations
	participant secrets as secrets
	participant d1AppDb as d1-app-db
	Operator->>scheduledCron: POST /__maintenance/backfill-integration-credentials
	scheduledCron->>integrations: backfillIntegrationCredentials({ dryRun, maxRows })
	integrations->>d1AppDb: count leftover *_secret_name with null *_encrypted
	integrations->>secrets: resolveSecret leftover name
	alt secret missing or unreadable
		integrations-->>Operator: missingSecrets key; maxRows unchanged
	else dryRun true
		integrations-->>Operator: leftover / would-copy / missing keys
	else dryRun false
		integrations->>d1AppDb: UPDATE ciphertext WHERE column IS NULL
		integrations-->>Operator: copied / remaining / missing keys
	end
```

### Invariants

Per-user isolation: encrypt AAD is `user:{userId}:integration:{name}` or `user:{userId}:oauth-app:{slug}`. The JSON result is counts plus stable row keys — never plaintext or ciphertext.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fa394a15-0a40-43d3-b71c-2a848fece0f9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fa394a15-0a40-43d3-b71c-2a848fece0f9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

