### PR TITLE
Point ship-pr Discord summaries at send-shipped-pr

### DIFF
--- a/.agents/skills/ship-pr/SKILL.md
+++ b/.agents/skills/ship-pr/SKILL.md
@@ -49,15 +49,29 @@ When policy + risk allow: squash-merge via `kody:@kentcdodds/github/pr/merge`
 
 ## Done → Discord
 
-Always summarize (merged or not) with agent / PR / CI / deploy links:
+Always summarize (merged or not) by calling
+`kody:@kentcdodds/discord/send-shipped-pr` with structured fields. Do **not**
+use raw `post-message` and do **not** compute or guess token cost — the export
+fetches the billed Cursor Cloud Agent usage and formats the cost line.
+
+**agentId (required):**
+- In a Cursor Cloud Agent VM, read it from the metadata socket:
+  curl -fsS --unix-socket "${CURSOR_AGENT_SOCKET:-/run/cursor/api.sock}" http://cursor-agent/v1/meta-data/agent/id
+- Otherwise pass the `bc-` id from the agent URL you were launched as
+  (https://cursor.com/agents/{id}).
 
 ```javascript
-import postMessage from 'kody:@kentcdodds/discord/post-message'
+import sendShippedPr from 'kody:@kentcdodds/discord/send-shipped-pr'
 
 export default async function main() {
-	return postMessage({
-		channelId: '1491568683737157683',
-		content: '…summary with links…',
+	return sendShippedPr({
+		agentId, // bc- id from the metadata socket or launch URL
+		title: 'PR title',
+		summary: 'What shipped / parked / blocked and why.',
+		prUrl: 'https://github.com/owner/repo/pull/1',
+		repo: 'owner/repo',
+		extras: ['CI green', 'preview verified'],
+		status: 'Shipped', // or 'Parked' | 'Blocked'
 	})
 }
 ```

--- a/.agents/skills/ship-pr/SKILL.md
+++ b/.agents/skills/ship-pr/SKILL.md
@@ -55,8 +55,10 @@ use raw `post-message` and do **not** compute or guess token cost — the export
 fetches the billed Cursor Cloud Agent usage and formats the cost line.
 
 **agentId (required):**
-- In a Cursor Cloud Agent VM, read it from the metadata socket:
-  curl -fsS --unix-socket "${CURSOR_AGENT_SOCKET:-/run/cursor/api.sock}" http://cursor-agent/v1/meta-data/agent/id
+
+- In a Cursor Cloud Agent VM, read it from the metadata socket: curl -fsS
+  --unix-socket "${CURSOR_AGENT_SOCKET:-/run/cursor/api.sock}"
+  http://cursor-agent/v1/meta-data/agent/id
 - Otherwise pass the `bc-` id from the agent URL you were launched as
   (https://cursor.com/agents/{id}).
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Keep ship-pr Discord summaries structured and billed from Cursor Cloud Agent usage, instead of freeform `post-message` text.

## Why

Agents were told to post a raw Discord message and invent a summary (including guessed token cost). The `send-shipped-pr` export already fetches billed usage and formats the cost line when given structured fields plus `agentId`.

## Summary

- Update only the **Done → Discord** section of `.agents/skills/ship-pr/SKILL.md`.
- Require `kody:@kentcdodds/discord/send-shipped-pr` with `agentId`, `title`, `summary`, `prUrl`, `repo`, `extras`, and `status` (`Shipped` | `Parked` | `Blocked`).
- Document how to get `agentId` (Cloud Agent metadata socket, or the `bc-…` id from the launch URL).
- Leave risk, reviewers, loop, gates, and merge/deploy unchanged.
- Do not change official Kody Discord / kody-discord, and do not require a Cursor `agentId` from ship-pr-devin.
- Follow-up: wrap the long `agentId` curl so `oxfmt --check` is clean.

## Testing

- Diff review: only `.agents/skills/ship-pr/SKILL.md` changed; the prefix through Merge / deploy is identical to `main`.
- `npx oxfmt .agents/skills/ship-pr/SKILL.md` wrapped the long curl; `npx oxfmt --check` on that file is clean.
- `npm run docs:check-temporal` passed (skills are in that check's path set).
- Metadata socket `curl` on this Cloud Agent VM returned a `bc-…` id, matching the documented lookup.

## System changes

Skill text only. No primitives, packages, or Discord exports changed.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `b109b3cd` · **Head:** `1868baa6`

**Classification:** composes — no primitives added or changed; this PR updates contributor skill text only.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| _(none)_  | —     | unmatched path: `.agents/skills/ship-pr/SKILL.md` |

### Change flow

After ship-pr finishes, agents call `send-shipped-pr` with structured fields and a Cursor `agentId`; the export fetches billed usage instead of a raw `post-message`.

```mermaid
sequenceDiagram
	actor Agent
	participant shipPrSkill as ship-pr skill
	participant cursorMeta as Cursor agent metadata
	participant sendShippedPr as send-shipped-pr
	Agent->>shipPrSkill: Done → Discord
	shipPrSkill->>cursorMeta: read bc- agentId (socket or launch URL)
	shipPrSkill->>sendShippedPr: title summary prUrl repo extras status
	Note over sendShippedPr: export fetches billed Cursor Cloud Agent usage
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fd0b2c1c-bdec-4520-ba7f-0f1244ad2925?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fd0b2c1c-bdec-4520-ba7f-0f1244ad2925&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Completion notifications now include structured pull request status, summaries, repository details, and agent information.
  * Notification links and related metadata are generated automatically for more consistent, reliable updates.
* **Chores**
  * Simplified completion reporting by removing manual message composition and token-cost handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->