### PR TITLE
Stop teaching Slack built-in as a user-token connect path

### DIFF
--- a/docs/guides/integration-bootstrap.md
+++ b/docs/guides/integration-bootstrap.md
@@ -101,6 +101,10 @@ If those conditions are not met, stop and fix the integration first.
    - Example:
      `import { refreshAccessToken, createAuthenticatedFetch } from 'kody:runtime'`
    - Use the real auth path the final integration will use.
+   - Confirm **token kind** as well as scopes. A connected Slack grant that
+     `auth.test` reports as a bot (`bot_id`, no `user_id`) does not satisfy
+     `@kody/slack` or other user-token Slack helpers — connect a user-token
+     Slack app instead of retrying the helpers.
    - Prefer a cheap read-only request such as `GET /me`, `GET /viewer`, or a
      similarly small account/profile endpoint.
    - Confirm the integration or secret name, token refresh behavior, and allowed

--- a/docs/guides/providers/slack.md
+++ b/docs/guides/providers/slack.md
@@ -2,8 +2,8 @@
 id: provider_slack
 title: Connect Slack
 summary:
-  Verified walkthrough for connecting Slack to Kody with a user-token Slack
-  app, then calling it from `@kody/slack`.
+  Verified walkthrough for connecting Slack to Kody with a user-token Slack app,
+  then calling it from `@kody/slack`.
 category: provider
 provider: Slack
 lastVerified: 2026-08
@@ -13,8 +13,8 @@ lastVerified: 2026-08
 
 `@kody/slack` talks Slack with a **user token**. Create your own Slack app with
 **User Token Scopes**, register Kody's redirect URI, then finish on
-`/connect/oauth`. The helpers reject bot-only grants (`xoxb-` / `auth.test`
-with `bot_id` and no `user_id`).
+`/connect/oauth`. The helpers reject bot-only grants (`xoxb-` / `auth.test` with
+`bot_id` and no `user_id`).
 
 ## What you get
 
@@ -29,11 +29,11 @@ Exact capabilities depend on the User Token Scopes granted at connect time.
 ## Create a user-token Slack app
 
 1. Confirm there is no existing **user-token** Slack connection:
-   `integration_list`. A connection named `slack` that only has a bot grant
-   does not count — leave it and use a distinct name such as `slack-user`.
+   `integration_list`. A connection named `slack` that only has a bot grant does
+   not count — leave it and use a distinct name such as `slack-user`.
 2. Create a Slack app at <https://api.slack.com/apps> with **User Token
-   Scopes**. User-token Slack uses `oauth/v2_user` + `oauth.v2.user.access`,
-   not the bot-token `oauth/v2` + `oauth.v2.access`.
+   Scopes**. User-token Slack uses `oauth/v2_user` + `oauth.v2.user.access`, not
+   the bot-token `oauth/v2` + `oauth.v2.access`.
 3. Register the redirect URI `https://kody.codes/connect/oauth`.
 4. Ask the user for the **client id**. They paste the **client secret** on
    `/connect/oauth` — never in chat.
@@ -47,9 +47,9 @@ Exact capabilities depend on the User Token Scopes granted at connect time.
    - **Scopes:** comma-separated User Token Scopes
    - **PKCE:** off (confidential client)
    - **Allowed hosts:** `slack.com,files.slack.com`
-6. After they authorize, `./smoke-test` on `@kody/slack` (or the forked
-   package) must report a user identity. A bot token is a failed setup, not a
-   package bug.
+6. After they authorize, `./smoke-test` on `@kody/slack` (or the forked package)
+   must report a user identity. A bot token is a failed setup, not a package
+   bug.
 
 See the [OAuth guide](../oauth.md) for query parameters, confidential exchange,
 and reconnect behavior.
@@ -99,13 +99,13 @@ store Slack OAuth tokens as named secrets.
 ## Troubleshooting
 
 - `invalid_auth` / `token_revoked`: reconnect with your `/connect/oauth` URL.
-- Missing channels or post failures: the granted User Token Scopes do not
-  cover the API method. Reconnect with a Slack app that includes them.
+- Missing channels or post failures: the granted User Token Scopes do not cover
+  the API method. Reconnect with a Slack app that includes them.
 - `redirect_uri` mismatches: the registered redirect must be exactly
   `https://kody.codes/connect/oauth`.
-- `auth.test` shows `bot_id` and no `user_id`: this is a bot token. Do not
-  retry `@kody/slack` helpers. Connect a user-token Slack app instead (use a
-  distinct name such as `slack-user` if `slack` is already the bot connection).
+- `auth.test` shows `bot_id` and no `user_id`: this is a bot token. Do not retry
+  `@kody/slack` helpers. Connect a user-token Slack app instead (use a distinct
+  name such as `slack-user` if `slack` is already the bot connection).
 
 ## Do not
 

--- a/docs/guides/providers/slack.md
+++ b/docs/guides/providers/slack.md
@@ -2,9 +2,8 @@
 id: provider_slack
 title: Connect Slack
 summary:
-  Verified walkthrough for connecting Slack to Kody: create your own Slack
-  app, register the redirect URI, reconnect links, and an auth.test smoke
-  test.
+  Verified walkthrough for connecting Slack to Kody with a user-token Slack
+  app, then calling it from `@kody/slack`.
 category: provider
 provider: Slack
 lastVerified: 2026-08
@@ -12,8 +11,10 @@ lastVerified: 2026-08
 
 # Connect Slack
 
-Connect Slack by creating your own Slack app, registering Kody's redirect URI,
-choosing the bot/user scopes you need, then finishing on `/connect/oauth`.
+`@kody/slack` talks Slack with a **user token**. Create your own Slack app with
+**User Token Scopes**, register Kody's redirect URI, then finish on
+`/connect/oauth`. The helpers reject bot-only grants (`xoxb-` / `auth.test`
+with `bot_id` and no `user_id`).
 
 ## What you get
 
@@ -23,16 +24,35 @@ Once connected, you can ask Kody things like:
 - "Post this deploy summary to #eng-alerts."
 - "Find recent messages mentioning the billing outage."
 
-Exact capabilities depend on the scopes granted at connect time.
+Exact capabilities depend on the User Token Scopes granted at connect time.
 
-## Create a Slack app
+## Create a user-token Slack app
 
-Create a Slack app in the Slack API dashboard, register the redirect URI
-`https://kody.codes/connect/oauth`, choose the bot/user scopes you need, then
-build a `/connect/oauth` URL with Slack's authorize and token endpoints
-(`https://slack.com/oauth/v2/authorize` and
-`https://slack.com/api/oauth.v2.access`). See the [OAuth guide](../oauth.md) for
-query parameters, confidential exchange, and reconnect behavior.
+1. Confirm there is no existing **user-token** Slack connection:
+   `integration_list`. A connection named `slack` that only has a bot grant
+   does not count — leave it and use a distinct name such as `slack-user`.
+2. Create a Slack app at <https://api.slack.com/apps> with **User Token
+   Scopes**. User-token Slack uses `oauth/v2_user` + `oauth.v2.user.access`,
+   not the bot-token `oauth/v2` + `oauth.v2.access`.
+3. Register the redirect URI `https://kody.codes/connect/oauth`.
+4. Ask the user for the **client id**. They paste the **client secret** on
+   `/connect/oauth` — never in chat.
+5. Open `/connect/oauth` (or `/connect/oauth?provider=slack-user` when `slack`
+   is already a bot grant). Fill:
+   - **Name:** `slack` when free, otherwise a distinct name
+   - **Authorization URL:** `https://slack.com/oauth/v2/authorize`
+   - **Token URL:** `https://slack.com/api/oauth.v2.user.access`
+   - **Client ID:** the Slack app client id
+   - **Client secret:** paste on the form
+   - **Scopes:** comma-separated User Token Scopes
+   - **PKCE:** off (confidential client)
+   - **Allowed hosts:** `slack.com,files.slack.com`
+6. After they authorize, `./smoke-test` on `@kody/slack` (or the forked
+   package) must report a user identity. A bot token is a failed setup, not a
+   package bug.
+
+See the [OAuth guide](../oauth.md) for query parameters, confidential exchange,
+and reconnect behavior.
 
 ## Verify
 
@@ -56,19 +76,41 @@ export default async function main() {
 		ok?: boolean
 		error?: string
 		user?: string
+		user_id?: string
+		bot_id?: string
 		team?: string
 	}
 	if (!data.ok) {
 		throw new Error(`Slack auth.test failed: ${data.error ?? 'unknown'}`)
 	}
-	return { user: data.user, team: data.team }
+	if (!data.user_id || data.bot_id) {
+		throw new Error(
+			'Slack auth.test returned a bot grant. @kody/slack needs a user token.',
+		)
+	}
+	return { user: data.user, userId: data.user_id, team: data.team }
 }
 ```
+
+After the connection exists, call Slack through
+`createAuthenticatedFetch('slack')` (or the connection name you chose). Do not
+store Slack OAuth tokens as named secrets.
 
 ## Troubleshooting
 
 - `invalid_auth` / `token_revoked`: reconnect with your `/connect/oauth` URL.
-- Missing channels or post failures: the granted scopes do not cover the API
-  method. Reconnect with a Slack app that includes them.
+- Missing channels or post failures: the granted User Token Scopes do not
+  cover the API method. Reconnect with a Slack app that includes them.
 - `redirect_uri` mismatches: the registered redirect must be exactly
   `https://kody.codes/connect/oauth`.
+- `auth.test` shows `bot_id` and no `user_id`: this is a bot token. Do not
+  retry `@kody/slack` helpers. Connect a user-token Slack app instead (use a
+  distinct name such as `slack-user` if `slack` is already the bot connection).
+
+## Do not
+
+- Do not send the user to `/account/secrets/new` for Slack OAuth tokens.
+- Do not `secret_set` Slack access or refresh tokens.
+- Do not paste tokens or the Slack client secret in chat.
+- Do not treat a bot-token Slack connection as a working `@kody/slack` setup.
+- Do not invent `xoxp-` / `xoxb-` token collection outside `/connect/oauth`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Keep agents from sending people through a Slack bot grant when they need `@kody/slack`.

## Why

https://x.com/bradhave/status/2092941031754932347 — the `@kody/slack` listing said built-in Slack was an option. That grant is typically a bot token. `@kody/slack` rejects bot tokens, so agents rabbit-hole after `./smoke-test` fails.

Repo guides already dropped built-in OAuth as a first-time connect path (#1781). This change makes the Slack provider walkthrough match the user-token contract.

## Summary

- `docs/guides/providers/slack.md` walks through a user-token Slack app (`oauth/v2_user` + `oauth.v2.user.access`) and fails `auth.test` when the grant is a bot.
- `docs/guides/integration-bootstrap.md` asks the smoke test to check token kind, not only scopes.

Official listings republished in the same audit (not this git repo):

- https://kody.codes/@kody/slack — BYO user-token only; no “try built-in first”
- https://kody.codes/@kody/notify — Slack channel uses the same user-token URL
- https://kody.codes/@kody/github — PAT or a GitHub OAuth App you register
- https://kody.codes/@kody/google — BYO Google client; inbox/Drive-wide need those scopes
- https://kody.codes/@kody/morning-briefing — calendar/inbox described as Google OAuth, not built-in

`@kentcdodds/slack` already taught BYO user-token only. PAT/API-key `/account/secrets/new` teaching on other packages is unchanged.

## Testing

- Live `community_get` re-scan of the five republished listings: no “Try first” / “Lane A — built-in” / `accessTokenSecretName` hits.
- `@kentcdodds/slack` listing still BYO user-token only.
- `npm run docs:check-temporal` passed.
- `npm run format` applied wrap on the Slack guide.

## System recap

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `92616a50` · **Head:** `2c3135cf`

**Classification:** composes — no primitives added or changed; this PR updates agent/user teaching only.

### Primitives touched

None. The classifier matched no `code` roots. The diff is two coding guides.

### Change flow

Agents load the Slack provider guide, then smoke-test token kind before treating Slack as ready.

```mermaid
sequenceDiagram
	actor User
	participant codingGuides as coding-guides
	participant connectOauth as connect-oauth
	participant slackApi as slack.com
	User->>codingGuides: provider_slack / integration_bootstrap
	codingGuides->>User: BYO user-token /connect/oauth URL
	User->>connectOauth: authorize user-token Slack app
	connectOauth->>slackApi: oauth.v2.user.access
	codingGuides->>slackApi: auth.test must show user_id, no bot_id
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fa394a15-0a40-43d3-b71c-2a848fece0f9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fa394a15-0a40-43d3-b71c-2a848fece0f9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified Slack integration setup requirements for user tokens, including required scopes and OAuth settings.
  - Updated verification steps to confirm a `user_id` and reject bot-token connections.
  - Added troubleshooting guidance for missing scopes, incorrect token types, connection naming, and confidential OAuth credentials.
  - Documented that bot tokens cannot be used with Slack user-token helpers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->