### PR TITLE
Give Actions a read-only Nx cache token

### DIFF
--- a/.github/actions/setup-validate/action.yml
+++ b/.github/actions/setup-validate/action.yml
@@ -56,8 +56,8 @@ runs:
           exit 0
         fi
         # Nx treats a configured-but-unauthorized cache as fatal. Probe a
-        # missing hash so a rotated GitHub secret that has not been synced
-        # to the worker falls back to local cache instead of failing validate.
+        # missing hash so a rotated read token that has not been synced to
+        # the worker falls back to local cache instead of failing validate.
         probe_status="$(curl -sS --max-time 5 -o /dev/null -w '%{http_code}' \
           --header "Authorization: Bearer ${NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN}" \
           "$server/v1/cache/0000000000000000" || true)"

--- a/.github/workflows/nx-cache-deploy.yml
+++ b/.github/workflows/nx-cache-deploy.yml
@@ -97,21 +97,24 @@ jobs:
             deploy_delay_seconds=$((deploy_delay_seconds * 2))
           done
 
-      - name: 🔐 Sync Nx cache access token
+      - name: 🔐 Sync Nx cache access tokens
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
           CACHE_ACCESS_TOKEN:
             ${{ secrets.NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN }}
+          CACHE_READ_TOKEN:
+            ${{ secrets.NX_SELF_HOSTED_REMOTE_CACHE_READ_TOKEN }}
         run: |
           set -euo pipefail
           if [ -z "${CACHE_ACCESS_TOKEN:-}" ]; then
-            echo "Skipping Nx cache secret sync: token is not set."
+            echo "Skipping Nx cache secret sync: write token is not set."
             exit 0
           fi
           node tools/ci/sync-worker-secrets.ts --env "" --config \
             packages/nx-cache/wrangler.jsonc --name kody-nx-cache \
-            --set-from-env CACHE_ACCESS_TOKEN
+            --set-from-env CACHE_ACCESS_TOKEN \
+            --set-from-env-optional CACHE_READ_TOKEN
 
       - name: 🩺 Healthcheck (Nx cache worker)
         shell: bash

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -18,13 +18,15 @@ permissions:
   contents: read
 
 # Pin CI=1 (not GitHub's CI=true) so Nx cache hashes match local
-# `validate` / `test:push`. Remote cache is used only when the access
-# token secret is present and setup-validate can reach /health; Nx
-# treats an unreachable self-hosted cache as a fatal error.
+# `validate` / `test:push`. Actions gets the read-only cache token so
+# untrusted PR branches cannot PUT artifacts that main later consumes.
+# Agents keep the write token. Nx treats an unreachable self-hosted
+# cache as a fatal error, so setup-validate probes before setting the
+# server URL.
 env:
   CI: '1'
   NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN:
-    ${{ secrets.NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN }}
+    ${{ secrets.NX_SELF_HOSTED_REMOTE_CACHE_READ_TOKEN }}
 
 concurrency:
   group: >-

--- a/docs/contributing/cloud-agents.md
+++ b/docs/contributing/cloud-agents.md
@@ -42,12 +42,13 @@ manually with native `unzip`:
 ## Nx remote cache
 
 Validate and `test:push` write Nx task artifacts. Those stay local unless the
-self-hosted cache is configured. To share hits with GitHub Actions, set both in
-this VM (same values as the GitHub Actions secret / Worker secret):
+self-hosted cache is configured. To populate GitHub Actions hits, set both on
+the Cloud **environment** (not a one-off `export`). Use the write token
+(`NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN`), not the Actions read token:
 
 ```bash
 export NX_SELF_HOSTED_REMOTE_CACHE_SERVER=https://nx-cache.kody.codes
-export NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN="$NX_CACHE_TOKEN"
+export NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN="$NX_CACHE_WRITE_TOKEN"
 ```
 
 Use `CI=1` on cached test commands (the repo scripts already do). Leave the

--- a/docs/contributing/decisions/0038-no-nx-cloud-read-write-cache-tokens.md
+++ b/docs/contributing/decisions/0038-no-nx-cloud-read-write-cache-tokens.md
@@ -1,0 +1,32 @@
+# 0038: Still no Nx Cloud; split self-hosted cache read and write tokens
+
+- **Status:** accepted
+- **Date:** 2026-08-27
+
+## Context
+
+[0019](./0019-self-hosted-nx-remote-cache.md) keeps `neverConnectToCloud` and
+shares Nx artifacts through `kody-nx-cache`. A later Nx-team review of that
+worker asked to replace it with Nx Cloud (OSS plan, `nx affected`, Playwright
+Atomizer, `start-ci-run --distribute-on`) because one read-write bearer was
+shared by GitHub Actions and agent VMs. Same-repo `pull_request` jobs receive
+repository secrets, so an untrusted branch could PUT an artifact that `main`
+later GETs (the CREEP-shaped hole 0019 cited when declining the deprecated S3
+plugins). First PUT still wins; it does not decide who may write first.
+
+## Decision
+
+Keep the self-hosted worker. Do not adopt Nx Cloud, `nx affected` as a validate
+rewrite, Playwright Atomizer, or distributed Nx agents. Trusted writers (Cursor
+Cloud Agent environments, and any host that should populate the cache) use
+`CACHE_ACCESS_TOKEN`. GitHub Actions validate uses
+`NX_SELF_HOSTED_REMOTE_CACHE_READ_TOKEN` (`CACHE_READ_TOKEN` on the worker). PUT
+with the read token returns `403` (`text/plain`); the Nx HTTP spec treats that
+as a silent write skip.
+
+## Consequences
+
+PR CI can hit artifacts agents already wrote and cannot poison hashes for
+`main`. A miss still runs locally. The worker, secret sync, and health/auth
+probes stay contributor infra. Revisit Nx Cloud only if a required Nx feature
+cannot work without their control plane (same gate as 0019).

--- a/docs/contributing/decisions/index.md
+++ b/docs/contributing/decisions/index.md
@@ -96,6 +96,8 @@ Do not treat this list as homework. History stays; it is not silently deleted.
   — legal/process; see [CONTRIBUTING.md](../../../CONTRIBUTING.md)
 - [0019 — Self-hosted Nx remote cache (not Nx Cloud)](./0019-self-hosted-nx-remote-cache.md)
   — contributor infra, not a product primitive
+- [0038 — Still no Nx Cloud; split self-hosted cache read and write tokens](./0038-no-nx-cloud-read-write-cache-tokens.md)
+  — Actions validate is read-only; agents keep the write token
 - [0028 — List/detail records expand inside the table](./0028-list-detail-expand.md)
   — UI mode assignment (supersedes 0010)
 - [0029 — Discord social login and official guild role](./0029-discord-social-login-and-guild-role.md)

--- a/docs/contributing/setup-manifest.md
+++ b/docs/contributing/setup-manifest.md
@@ -566,16 +566,18 @@ Configure these GitHub Actions secrets and variables for workflows:
 - `SENTRY_AUTH_TOKEN` (optional GitHub **secret**; Sentry auth token with
   `project:releases` / source map upload permissions — used only by CI to run
   `npm run sentry:upload-sourcemaps` after deploy)
-- `NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN` (optional GitHub **secret**; bearer
-  token for the Nx HTTP cache worker at `https://nx-cache.kody.codes`. Generate
-  with `openssl rand -hex 32`. Validate jobs enable remote cache when this is
-  set; production deploy and the dedicated `🧊 Nx cache worker` workflow sync it
-  to the worker as `CACHE_ACCESS_TOKEN` and create the `kody-nx-cache` R2 bucket
-  with a 14-day object lifecycle. Use the same value in Cursor Cloud Agent
-  environments so agent `validate` / `test:push` can populate CI hits. Validate
-  jobs probe `/health` and an authorized cache GET before setting the server URL
-  so an undeployed worker or unsynced token does not fail Nx. Leave unset to run
-  CI with local `.nx` + `actions/cache` only.)
+- `NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN` (optional GitHub **secret**; write
+  bearer for the Nx HTTP cache worker at `https://nx-cache.kody.codes`. Generate
+  with `openssl rand -hex 32`. Production deploy and the dedicated
+  `🧊 Nx cache worker` workflow sync it to the worker as `CACHE_ACCESS_TOKEN`.
+  Use the same value in Cursor Cloud Agent environments so agent `validate` /
+  `test:push` can populate the cache. Leave unset to run without remote writes.)
+- `NX_SELF_HOSTED_REMOTE_CACHE_READ_TOKEN` (optional GitHub **secret**; read
+  bearer for the same worker. Generate a second `openssl rand -hex 32` value,
+  not the write token. Validate jobs set Nx's
+  `NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN` from this secret so PR CI can GET
+  and cannot PUT. The worker syncs it as `CACHE_READ_TOKEN`. PUT with this token
+  returns 403. Leave unset to run CI with local `.nx` + `actions/cache` only.)
 - **Repository variables** `SENTRY_ORG` and `SENTRY_PROJECT` (optional; Sentry
   organization and project **slugs** for source map upload — same values as in
   the Sentry wizard’s `--org` / `--project` flags)
@@ -670,10 +672,15 @@ How to get/set each value:
   - Generate locally: `openssl rand -hex 32`
   - Store the exact value as the repository secret
     `NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN`, and use the same value in Cursor
-    Cloud Agent environments. Production deploy and the dedicated
+    Cloud Agent environments (write token). Production deploy and the dedicated
     `🧊 Nx cache worker` workflow sync it to the `kody-nx-cache` Worker as
     `CACHE_ACCESS_TOKEN`. After rotating the GitHub secret, run that workflow on
     `main` so the worker secret matches.
+- `NX_SELF_HOSTED_REMOTE_CACHE_READ_TOKEN` (optional)
+  - Generate a second `openssl rand -hex 32` value. Store it as the repository
+    secret `NX_SELF_HOSTED_REMOTE_CACHE_READ_TOKEN` only. Do not put this value
+    on Cloud Agent environments. The same deploy workflow syncs it as
+    `CACHE_READ_TOKEN`.
 - `SENTRY_ORG` / `SENTRY_PROJECT` (optional)
   - In GitHub: **Settings → Secrets and variables → Actions → Variables**, add
     `SENTRY_ORG` and `SENTRY_PROJECT` with your Sentry slugs (for example from

--- a/docs/contributing/setup-manifest.md
+++ b/docs/contributing/setup-manifest.md
@@ -680,7 +680,8 @@ How to get/set each value:
   - Generate a second `openssl rand -hex 32` value. Store it as the repository
     secret `NX_SELF_HOSTED_REMOTE_CACHE_READ_TOKEN` only. Do not put this value
     on Cloud Agent environments. The same deploy workflow syncs it as
-    `CACHE_READ_TOKEN`.
+    `CACHE_READ_TOKEN`. After adding or rotating the GitHub secret, run that
+    workflow on `main` so the worker secret matches.
 - `SENTRY_ORG` / `SENTRY_PROJECT` (optional)
   - In GitHub: **Settings → Secrets and variables → Actions → Variables**, add
     `SENTRY_ORG` and `SENTRY_PROJECT` with your Sentry slugs (for example from

--- a/docs/contributing/setup/checks.md
+++ b/docs/contributing/setup/checks.md
@@ -39,10 +39,12 @@ pushes. See the [setup index](./index.md) for the other setup pages.
   worker limits, and Nx cache hashes match the contended parallel layout used in
   GitHub Actions. CI runs the same checks as parallel jobs (🧹 Static, 🧪 Node,
   ☁️ Workers, 🔌 MCP, 🎭 E2E, aggregated by ✅ Validate). If `npm run validate`
-  passes locally, CI will pass. When `NX_SELF_HOSTED_REMOTE_CACHE_SERVER` and
-  `NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN` are set, Nx uploads those task
-  artifacts to `https://nx-cache.kody.codes` so CI can reuse them (see
-  [decision 0019](../decisions/0019-self-hosted-nx-remote-cache.md) and
+  passes locally, CI will pass. Trusted writers (Cloud Agent environments) set
+  `NX_SELF_HOSTED_REMOTE_CACHE_SERVER` and the write token so Nx uploads task
+  artifacts to `https://nx-cache.kody.codes`. GitHub Actions validate uses the
+  read token and can only GET (see
+  [decision 0019](../decisions/0019-self-hosted-nx-remote-cache.md),
+  [decision 0038](../decisions/0038-no-nx-cloud-read-write-cache-tokens.md), and
   [`packages/nx-cache/readme.md`](../../../packages/nx-cache/readme.md)).
 - `npm run deploy-guardrails:check` protects reviewed Durable Object migration
   history and bindings in both Wrangler configs, requires exact allowlisting for

--- a/packages/nx-cache/handle-request.node.test.ts
+++ b/packages/nx-cache/handle-request.node.test.ts
@@ -5,11 +5,15 @@ import { createMemoryCacheStore } from './memory-store.ts'
 import { type NxCacheEnv } from './nx-cache-types.ts'
 
 const ACCESS_TOKEN = 'test-nx-cache-token'
+const READ_TOKEN = 'test-nx-cache-read-token'
 const HASH = '0123456789abcdef0123456789abcdef'
 
-function env(overrides: { token?: string; commit?: string } = {}) {
+function env(
+	overrides: { token?: string; readToken?: string; commit?: string } = {},
+) {
 	return {
 		CACHE_ACCESS_TOKEN: overrides.token ?? ACCESS_TOKEN,
+		CACHE_READ_TOKEN: overrides.readToken,
 		BUILD_COMMIT: overrides.commit ?? 'commit-sha',
 	}
 }
@@ -17,16 +21,24 @@ function env(overrides: { token?: string; commit?: string } = {}) {
 async function handle(
 	request: Request,
 	store = createMemoryCacheStore(),
-	environment: Pick<NxCacheEnv, 'CACHE_ACCESS_TOKEN' | 'BUILD_COMMIT'> = env(),
+	environment: Pick<
+		NxCacheEnv,
+		'CACHE_ACCESS_TOKEN' | 'CACHE_READ_TOKEN' | 'BUILD_COMMIT'
+	> = env(),
 ) {
 	return handleNxCacheRequest(request, environment, store)
 }
 
-function authorized(method: string, path: string, body?: ArrayBuffer) {
+function authorized(
+	method: string,
+	path: string,
+	body?: ArrayBuffer,
+	token = ACCESS_TOKEN,
+) {
 	return new Request(`https://nx-cache.kody.codes${path}`, {
 		method,
 		headers: {
-			authorization: `Bearer ${ACCESS_TOKEN}`,
+			authorization: `Bearer ${token}`,
 			...(body
 				? {
 						'content-type': 'application/octet-stream',
@@ -106,6 +118,23 @@ test('PUT then GET round-trips an artifact and rejects invalid writes', async ()
 
 	const badHash = await handle(authorized('GET', '/v1/cache/../secrets'), store)
 	expect(badHash.status).toBe(404)
+
+	const readGet = await handle(
+		authorized('GET', `/v1/cache/${HASH}`, undefined, READ_TOKEN),
+		store,
+		env({ readToken: READ_TOKEN }),
+	)
+	expect(readGet.status).toBe(200)
+	expect(await readGet.text()).toBe('nx-cache-artifact')
+
+	const readPut = await handle(
+		authorized('PUT', `/v1/cache/${'b'.repeat(32)}`, artifact, READ_TOKEN),
+		store,
+		env({ readToken: READ_TOKEN }),
+	)
+	expect(readPut.status).toBe(403)
+	expect(readPut.headers.get('content-type')).toMatch(/^text\/plain/)
+	expect(await store.get('b'.repeat(32))).toBeNull()
 
 	const missingLength = await handle(
 		new Request(`https://nx-cache.kody.codes/v1/cache/${HASH}`, {

--- a/packages/nx-cache/handle-request.node.test.ts
+++ b/packages/nx-cache/handle-request.node.test.ts
@@ -87,6 +87,14 @@ test('health is public; cache routes require a configured bearer token', async (
 		{ CACHE_ACCESS_TOKEN: undefined, BUILD_COMMIT: 'commit-sha' },
 	)
 	expect(unconfigured.status).toBe(503)
+
+	const identicalTokens = await handle(
+		authorized('PUT', `/v1/cache/${HASH}`),
+		createMemoryCacheStore(),
+		env({ token: ACCESS_TOKEN, readToken: ACCESS_TOKEN }),
+	)
+	expect(identicalTokens.status).toBe(503)
+	expect(await identicalTokens.text()).toBe('Nx cache tokens are misconfigured')
 })
 
 test('PUT then GET round-trips an artifact and rejects invalid writes', async () => {

--- a/packages/nx-cache/handle-request.ts
+++ b/packages/nx-cache/handle-request.ts
@@ -33,12 +33,18 @@ export async function authorizeCacheRequest(
 			response: plainText(503, 'Nx cache is not configured'),
 		}
 	}
+	const read = tokens.read?.trim() ?? ''
+	if (read && (await timingSafeEqualString(write, read))) {
+		return {
+			ok: false,
+			response: plainText(503, 'Nx cache tokens are misconfigured'),
+		}
+	}
 	const bearer = readBearerToken(request)
 	if (bearer === null) {
 		return { ok: false, response: plainText(401, 'Unauthorized') }
 	}
 	const writeMatch = await timingSafeEqualString(bearer, write)
-	const read = tokens.read?.trim() ?? ''
 	const readMatch = read ? await timingSafeEqualString(bearer, read) : false
 	if (writeMatch) return { ok: true, canWrite: true }
 	if (readMatch) return { ok: true, canWrite: false }

--- a/packages/nx-cache/handle-request.ts
+++ b/packages/nx-cache/handle-request.ts
@@ -11,30 +11,52 @@ export function parseCacheHash(pathname: string): string | null {
 	return match[1]
 }
 
+function plainText(status: number, message: string): Response {
+	return new Response(message, {
+		status,
+		headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+	})
+}
+
+export type CacheAuthorization =
+	| { ok: true; canWrite: boolean }
+	| { ok: false; response: Response }
+
 export async function authorizeCacheRequest(
 	request: Request,
-	accessToken: string | undefined,
-): Promise<Response | null> {
-	const configured = accessToken?.trim() ?? ''
-	if (!configured) {
-		return new Response('Nx cache is not configured', { status: 503 })
+	tokens: { write?: string; read?: string },
+): Promise<CacheAuthorization> {
+	const write = tokens.write?.trim() ?? ''
+	if (!write) {
+		return {
+			ok: false,
+			response: plainText(503, 'Nx cache is not configured'),
+		}
 	}
 	const bearer = readBearerToken(request)
-	if (bearer === null || !(await timingSafeEqualString(bearer, configured))) {
-		return new Response('Unauthorized', { status: 401 })
+	if (bearer === null) {
+		return { ok: false, response: plainText(401, 'Unauthorized') }
 	}
-	return null
+	const writeMatch = await timingSafeEqualString(bearer, write)
+	const read = tokens.read?.trim() ?? ''
+	const readMatch = read ? await timingSafeEqualString(bearer, read) : false
+	if (writeMatch) return { ok: true, canWrite: true }
+	if (readMatch) return { ok: true, canWrite: false }
+	return { ok: false, response: plainText(401, 'Unauthorized') }
 }
 
 export async function handleNxCacheRequest(
 	request: Request,
-	env: Pick<NxCacheEnv, 'CACHE_ACCESS_TOKEN' | 'BUILD_COMMIT'>,
+	env: Pick<
+		NxCacheEnv,
+		'CACHE_ACCESS_TOKEN' | 'CACHE_READ_TOKEN' | 'BUILD_COMMIT'
+	>,
 	store: NxCacheStore,
 ): Promise<Response> {
 	const url = new URL(request.url)
 	if (url.pathname === '/health') {
 		if (request.method !== 'GET' && request.method !== 'HEAD') {
-			return new Response('Method not allowed', { status: 405 })
+			return plainText(405, 'Method not allowed')
 		}
 		return Response.json(
 			{ ok: true, commit: env.BUILD_COMMIT ?? null },
@@ -44,19 +66,18 @@ export async function handleNxCacheRequest(
 
 	const hash = parseCacheHash(url.pathname)
 	if (!hash) {
-		return new Response('Not found', { status: 404 })
+		return plainText(404, 'Not found')
 	}
 
-	const unauthorized = await authorizeCacheRequest(
-		request,
-		env.CACHE_ACCESS_TOKEN,
-	)
-	if (unauthorized) return unauthorized
+	const authorization = await authorizeCacheRequest(request, {
+		write: env.CACHE_ACCESS_TOKEN,
+		read: env.CACHE_READ_TOKEN,
+	})
+	if (!authorization.ok) return authorization.response
 
 	if (request.method === 'GET') {
 		const object = await store.get(hash)
-		if (!object)
-			return new Response('The record was not found', { status: 404 })
+		if (!object) return plainText(404, 'The record was not found')
 		return new Response(object.body, {
 			status: 200,
 			headers: {
@@ -67,28 +88,29 @@ export async function handleNxCacheRequest(
 	}
 
 	if (request.method === 'PUT') {
+		if (!authorization.canWrite) {
+			return plainText(403, 'Read-only token cannot write')
+		}
 		const contentLengthHeader = request.headers.get('content-length')
 		if (!contentLengthHeader) {
-			return new Response('Content-Length is required', { status: 400 })
+			return plainText(400, 'Content-Length is required')
 		}
 		const contentLength = Number(contentLengthHeader)
 		if (!Number.isInteger(contentLength) || contentLength < 0) {
-			return new Response('Content-Length is invalid', { status: 400 })
+			return plainText(400, 'Content-Length is invalid')
 		}
 		if (contentLength > MAX_ARTIFACT_BYTES) {
-			return new Response('Artifact exceeds 100MB limit', { status: 413 })
+			return plainText(413, 'Artifact exceeds 100MB limit')
 		}
 		if (!request.body) {
-			return new Response('Request body is required', { status: 400 })
+			return plainText(400, 'Request body is required')
 		}
 		const result = await store.putIfAbsent(hash, request.body)
 		if (result === 'exists') {
-			return new Response('Cannot override an existing record', {
-				status: 409,
-			})
+			return plainText(409, 'Cannot override an existing record')
 		}
 		return new Response(null, { status: 200 })
 	}
 
-	return new Response('Method not allowed', { status: 405 })
+	return plainText(405, 'Method not allowed')
 }

--- a/packages/nx-cache/nx-cache-types.ts
+++ b/packages/nx-cache/nx-cache-types.ts
@@ -1,6 +1,7 @@
 export type NxCacheEnv = {
 	CACHE_BUCKET: R2Bucket
 	CACHE_ACCESS_TOKEN?: string
+	CACHE_READ_TOKEN?: string
 	BUILD_COMMIT?: string
 }
 

--- a/packages/nx-cache/readme.md
+++ b/packages/nx-cache/readme.md
@@ -21,7 +21,7 @@ GitHub Actions (`NX_SELF_HOSTED_REMOTE_CACHE_READ_TOKEN`).
 
 ```bash
 export NX_SELF_HOSTED_REMOTE_CACHE_SERVER=https://nx-cache.kody.codes
-export NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN="$NX_CACHE_WRITE_OR_READ_TOKEN"
+export NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN="<write-or-read-token>"
 ```
 
 Leave them unset to run with the local `.nx` cache only. Validate and

--- a/packages/nx-cache/readme.md
+++ b/packages/nx-cache/readme.md
@@ -5,19 +5,23 @@ share task artifacts so CI does not rerun work the agent already completed.
 
 The worker implements the
 [Nx self-hosted cache OpenAPI spec](https://nx.dev/docs/kb/self-hosted-caching):
-`GET`/`PUT /v1/cache/{hash}` with bearer auth, `409` on overwrite, and artifacts
-stored in R2. `neverConnectToCloud` stays on so Nx does not prompt for Nx Cloud.
+`GET`/`PUT /v1/cache/{hash}` with bearer auth, `409` on overwrite, `403` when a
+read-only token PUTs, and artifacts stored in R2. `neverConnectToCloud` stays on
+so Nx does not prompt for Nx Cloud. GitHub Actions validate uses the read token;
+Cursor Cloud Agent environments keep the write token so agents populate the
+cache and untrusted PR branches cannot.
 
 Public URL: `https://nx-cache.kody.codes`.
 
 ## Clients
 
-Set both variables in GitHub Actions (validate jobs) and in Cursor Cloud Agent
-environments:
+Nx always reads `NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN`. The value is the
+write token on trusted writers (Cloud Agent environments) and the read token in
+GitHub Actions (`NX_SELF_HOSTED_REMOTE_CACHE_READ_TOKEN`).
 
 ```bash
 export NX_SELF_HOSTED_REMOTE_CACHE_SERVER=https://nx-cache.kody.codes
-export NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN="$NX_CACHE_TOKEN"
+export NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN="$NX_CACHE_WRITE_OR_READ_TOKEN"
 ```
 
 Leave them unset to run with the local `.nx` cache only. Validate and
@@ -46,12 +50,12 @@ the window after which a poisoned hash can be replaced.
 
 Production deploy (`.github/workflows/deploy.yml`) creates the `kody-nx-cache`
 R2 bucket, applies the 14-day lifecycle, uploads the worker, and syncs
-`CACHE_ACCESS_TOKEN` from the `NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN` GitHub
-Actions secret when cache-related paths change or when that workflow is
-dispatched on `main`. The job no-ops when that secret is missing so a first
-merge does not block production.
+`CACHE_ACCESS_TOKEN` / `CACHE_READ_TOKEN` from the matching GitHub Actions
+secrets when cache-related paths change or when that workflow is dispatched on
+`main`. The job no-ops when the write secret is missing so a first merge does
+not block production.
 
-To redeploy only the cache worker (for example after rotating
-`NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN`), run **Actions → 🧊 Nx cache worker
-→ Run workflow** on `main` (`.github/workflows/nx-cache-deploy.yml`). That
-reuses the same job and does not cancel an in-progress production deploy.
+To redeploy only the cache worker (for example after rotating either token), run
+**Actions → 🧊 Nx cache worker → Run workflow** on `main`
+(`.github/workflows/nx-cache-deploy.yml`). That reuses the same job and does not
+cancel an in-progress production deploy.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Address the Nx-team review of the self-hosted cache without adopting Nx Cloud. Close the CREEP-shaped hole where a shared read-write bearer lets same-repo `pull_request` jobs PUT artifacts that `main` can later GET.

## Summary

- Keep `neverConnectToCloud` and `kody-nx-cache` ([0019](docs/contributing/decisions/0019-self-hosted-nx-remote-cache.md), new [0038](docs/contributing/decisions/0038-no-nx-cloud-read-write-cache-tokens.md))
- Worker accepts `CACHE_ACCESS_TOKEN` (write) and `CACHE_READ_TOKEN` (GET only; PUT → `403` `text/plain`)
- Identical configured tokens fail closed with `503` so Actions cannot silently inherit write
- GitHub Actions validate uses `NX_SELF_HOSTED_REMOTE_CACHE_READ_TOKEN` (minted as a repo secret; never printed)
- Cloud Agent environments keep the existing write token so agents still populate the cache
- Declined from that review: Nx Cloud, `nx affected` as a validate rewrite, Playwright Atomizer, `start-ci-run --distribute-on`

## Testing

- `packages/nx-cache/handle-request.node.test.ts` — write PUT/GET, read GET 200, read PUT 403 and no store, identical tokens → 503
- `docs:check-temporal`, `docs:check-decisions`, `format:check`
- Pre-push `test:push` passed on this branch

After merge: dispatch **Actions → 🧊 Nx cache worker** so production picks up `CACHE_READ_TOKEN`. Until then, validate probes 401 on the new read token and falls back to local `.nx` (existing fail-closed gate).

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `396753f7` · **Head:** `b547eeb6`

**Classification:** composes — no product primitives added or changed; contributor CI cache auth only.

### Primitives touched

None. Classifier unmatched paths are the nx-cache worker, GitHub Actions, and contributing docs.

### Change flow

Trusted writers keep the write bearer. Actions validate presents the read bearer. PUT with the read token is forbidden. Identical write and read secrets fail closed.

```mermaid
sequenceDiagram
	actor Agent
	actor Actions
	participant nxCache as kody-nx-cache
	Agent->>nxCache: Bearer write token PUT /v1/cache/{hash}
	nxCache->>nxCache: store if absent
	Actions->>nxCache: Bearer read token GET /v1/cache/{hash}
	nxCache-->>Actions: 200 or 404
	Actions->>nxCache: Bearer read token PUT /v1/cache/{hash}
	nxCache-->>Actions: 403 text/plain
	Note over nxCache: identical configured tokens return 503
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2c093569-b79d-4898-8907-76e37a3a853f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2c093569-b79d-4898-8907-76e37a3a853f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added separate read-only and write access for the remote build cache.
  - Validation jobs can retrieve cached artifacts but cannot upload or modify them.
  - Trusted environments continue to upload new cache artifacts.

- **Bug Fixes**
  - Prevented untrusted validation runs from changing artifacts used by the main branch.
  - Read-only write attempts now return a forbidden response and are not stored.
  - Identical read and write credentials are rejected as misconfigured.

- **Documentation**
  - Updated setup, deployment, contribution, and cache usage guidance.
  - Added a decision record documenting the access model.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->