### PR TITLE
Let same-repo validate write the Nx cache

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -20,17 +20,19 @@ permissions:
 # Pin CI=1 (not GitHub's CI=true) so Nx cache hashes match local
 # `validate` / `test:push`. Anyone who can push already has the write
 # token locally, so same-repo validate (push, workflow_dispatch, and
-# non-fork pull_request) presents it too. Fork PRs select the read
-# secret by name so a missing read token stays empty and does not
-# fall through to write. Nx treats an unreachable self-hosted cache
-# as a fatal error, so setup-validate probes before setting the
-# server URL.
+# non-fork pull_request) presents it too. Fork PRs use the read token
+# only: a missing read secret stays empty and does not fall through
+# to write. Literal secret refs only — do not index `secrets[...]`
+# (overprovisions the whole secrets context). Nx treats an
+# unreachable self-hosted cache as a fatal error, so setup-validate
+# probes before setting the server URL.
 env:
   CI: '1'
   NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN:
-    ${{ secrets[github.event.pull_request.head.repo.fork == true &&
-    'NX_SELF_HOSTED_REMOTE_CACHE_READ_TOKEN' ||
-    'NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN'] }}
+    ${{ github.event.pull_request.head.repo.fork == true &&
+    secrets.NX_SELF_HOSTED_REMOTE_CACHE_READ_TOKEN ||
+    github.event.pull_request.head.repo.fork != true &&
+    secrets.NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN || '' }}
 
 concurrency:
   group: >-

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -18,16 +18,15 @@ permissions:
   contents: read
 
 # Pin CI=1 (not GitHub's CI=true) so Nx cache hashes match local
-# `validate` / `test:push`. pull_request jobs get the read token so a
-# same-repo branch cannot PUT artifacts that main later GETs (the
-# workflow file and checkout are the PR's). push to main and
-# workflow_dispatch on main get the write token. Agents also write.
+# `validate` / `test:push`. Anyone who can push already has the write
+# token locally, so same-repo validate (push, workflow_dispatch, and
+# non-fork pull_request) presents it too. Fork PRs get the read token.
 # Nx treats an unreachable self-hosted cache as a fatal error, so
 # setup-validate probes before setting the server URL.
 env:
   CI: '1'
   NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN:
-    ${{ (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')) && secrets.NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN || secrets.NX_SELF_HOSTED_REMOTE_CACHE_READ_TOKEN }}
+    ${{ github.event.pull_request.head.repo.fork == true && secrets.NX_SELF_HOSTED_REMOTE_CACHE_READ_TOKEN || secrets.NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN }}
 
 concurrency:
   group: >-

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -20,15 +20,17 @@ permissions:
 # Pin CI=1 (not GitHub's CI=true) so Nx cache hashes match local
 # `validate` / `test:push`. Anyone who can push already has the write
 # token locally, so same-repo validate (push, workflow_dispatch, and
-# non-fork pull_request) presents it too. Fork PRs get the read token.
-# Nx treats an unreachable self-hosted cache as a fatal error, so
-# setup-validate probes before setting the server URL.
+# non-fork pull_request) presents it too. Fork PRs select the read
+# secret by name so a missing read token stays empty and does not
+# fall through to write. Nx treats an unreachable self-hosted cache
+# as a fatal error, so setup-validate probes before setting the
+# server URL.
 env:
   CI: '1'
   NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN:
-    ${{ github.event.pull_request.head.repo.fork == true &&
-    secrets.NX_SELF_HOSTED_REMOTE_CACHE_READ_TOKEN ||
-    secrets.NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN }}
+    ${{ secrets[github.event.pull_request.head.repo.fork == true &&
+    'NX_SELF_HOSTED_REMOTE_CACHE_READ_TOKEN' ||
+    'NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN'] }}
 
 concurrency:
   group: >-

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -26,7 +26,9 @@ permissions:
 env:
   CI: '1'
   NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN:
-    ${{ github.event.pull_request.head.repo.fork == true && secrets.NX_SELF_HOSTED_REMOTE_CACHE_READ_TOKEN || secrets.NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN }}
+    ${{ github.event.pull_request.head.repo.fork == true &&
+    secrets.NX_SELF_HOSTED_REMOTE_CACHE_READ_TOKEN ||
+    secrets.NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN }}
 
 concurrency:
   group: >-

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -18,15 +18,16 @@ permissions:
   contents: read
 
 # Pin CI=1 (not GitHub's CI=true) so Nx cache hashes match local
-# `validate` / `test:push`. Actions gets the read-only cache token so
-# untrusted PR branches cannot PUT artifacts that main later consumes.
-# Agents keep the write token. Nx treats an unreachable self-hosted
-# cache as a fatal error, so setup-validate probes before setting the
-# server URL.
+# `validate` / `test:push`. pull_request jobs get the read token so a
+# same-repo branch cannot PUT artifacts that main later GETs (the
+# workflow file and checkout are the PR's). push to main and
+# workflow_dispatch on main get the write token. Agents also write.
+# Nx treats an unreachable self-hosted cache as a fatal error, so
+# setup-validate probes before setting the server URL.
 env:
   CI: '1'
   NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN:
-    ${{ secrets.NX_SELF_HOSTED_REMOTE_CACHE_READ_TOKEN }}
+    ${{ (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')) && secrets.NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN || secrets.NX_SELF_HOSTED_REMOTE_CACHE_READ_TOKEN }}
 
 concurrency:
   group: >-

--- a/docs/contributing/cloud-agents.md
+++ b/docs/contributing/cloud-agents.md
@@ -44,8 +44,8 @@ manually with native `unzip`:
 Validate and `test:push` write Nx task artifacts. Those stay local unless the
 self-hosted cache is configured. To populate GitHub Actions hits, set both on
 the Cloud **environment** (not a one-off `export`). Use the write token
-(`NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN`), not the Actions pull_request read
-token. Validate on `push` to `main` also writes; PR jobs do not:
+(`NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN`). Same-repo Actions validate uses
+that token too; only fork `pull_request` jobs use the read token:
 
 ```bash
 export NX_SELF_HOSTED_REMOTE_CACHE_SERVER=https://nx-cache.kody.codes

--- a/docs/contributing/cloud-agents.md
+++ b/docs/contributing/cloud-agents.md
@@ -44,7 +44,8 @@ manually with native `unzip`:
 Validate and `test:push` write Nx task artifacts. Those stay local unless the
 self-hosted cache is configured. To populate GitHub Actions hits, set both on
 the Cloud **environment** (not a one-off `export`). Use the write token
-(`NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN`), not the Actions read token:
+(`NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN`), not the Actions pull_request read
+token. Validate on `push` to `main` also writes; PR jobs do not:
 
 ```bash
 export NX_SELF_HOSTED_REMOTE_CACHE_SERVER=https://nx-cache.kody.codes

--- a/docs/contributing/decisions/0039-no-same-repo-pr-cache-writes.md
+++ b/docs/contributing/decisions/0039-no-same-repo-pr-cache-writes.md
@@ -1,0 +1,33 @@
+# 0039: Same-repo pull_request jobs do not write the Nx cache
+
+- **Status:** accepted
+- **Date:** 2026-08-27
+
+## Context
+
+[0038](./0038-no-nx-cloud-read-write-cache-tokens.md) split read and write
+tokens so Actions could not poison hashes that `main` later GETs. After that
+landed, validate on `push` to `main` was also read-only, so a change that never
+went through a Cloud Agent never populated the remote cache. A follow-up asked
+to restore writes from "trusted" same-repo PRs (owner/collaborator branches).
+
+For `pull_request` on this repository, secrets are available **and** the
+workflow file plus checkout come from the PR. A branch that only looks like a
+docs tweak can still change `.github/actions/setup-validate` and PUT an artifact
+for a hash of **unchanged** task inputs. First PUT wins. Author association does
+not change which code the job runs.
+
+## Decision
+
+Do not give `CACHE_ACCESS_TOKEN` to `pull_request` jobs, including same-repo and
+owner-authored PRs. Do not use `pull_request_target` to work around that.
+Validate on `push` to `main` (and `workflow_dispatch` on `main`) may write.
+Agents keep the write token. PR validate stays on the read token.
+
+## Consequences
+
+The first post-merge validate on `main` can PUT; later PRs GET those hashes.
+`workflow_dispatch` on a non-`main` ref stays read-only. Revisit only if
+validate is rewritten so the privileged job is defined only on the default
+branch and never executes PR-controlled workflow or checkout while holding the
+write token.

--- a/docs/contributing/decisions/0039-no-same-repo-pr-cache-writes.md
+++ b/docs/contributing/decisions/0039-no-same-repo-pr-cache-writes.md
@@ -1,6 +1,6 @@
 # 0039: Same-repo pull_request jobs do not write the Nx cache
 
-- **Status:** accepted
+- **Status:** superseded by [0040](./0040-same-repo-writers-may-put-nx-cache.md)
 - **Date:** 2026-08-27
 
 ## Context

--- a/docs/contributing/decisions/0040-same-repo-writers-may-put-nx-cache.md
+++ b/docs/contributing/decisions/0040-same-repo-writers-may-put-nx-cache.md
@@ -1,0 +1,33 @@
+# 0040: Same-repo writers may PUT the Nx cache; fork PRs may not
+
+- **Status:** accepted
+- **Date:** 2026-08-27
+
+## Context
+
+[0038](./0038-no-nx-cloud-read-write-cache-tokens.md) split read and write
+tokens so untrusted CI could not poison hashes `main` later GETs.
+[0039](./0039-no-same-repo-pr-cache-writes.md) treated every `pull_request` job
+as untrusted, including same-repo branches, because the workflow file and
+checkout come from the PR. That over-counted the threat. The people who can push
+to this repository already have the write token on Cloud Agent environments and
+locally. Giving the same token to their `pull_request` jobs does not create a
+new writer.
+
+Fork PRs are the other class: they cannot push to origin and must not receive
+the write token.
+
+## Decision
+
+Anyone who can push may write the remote cache before review. Validate uses
+`CACHE_ACCESS_TOKEN` on `push`, `workflow_dispatch`, and non-fork
+`pull_request`. Fork `pull_request` jobs use `CACHE_READ_TOKEN` only. Do not use
+`pull_request_target` to hand the write token to a fork. Agents keep the write
+token. Supersedes 0039.
+
+## Consequences
+
+Same-repo PR CI can populate hashes `main` later GETs. A fork still cannot PUT.
+The remaining hole is a compromised or prompt-injected session of someone who
+already has write access — the same session that can PUT from a laptop. Revisit
+if write access is granted to actors who must not hold the local write token.

--- a/docs/contributing/decisions/0040-same-repo-writers-may-put-nx-cache.md
+++ b/docs/contributing/decisions/0040-same-repo-writers-may-put-nx-cache.md
@@ -19,11 +19,13 @@ the write token.
 
 ## Decision
 
-Anyone who can push may write the remote cache before review. Validate uses
-`CACHE_ACCESS_TOKEN` on `push`, `workflow_dispatch`, and non-fork
-`pull_request`. Fork `pull_request` jobs use `CACHE_READ_TOKEN` only. Do not use
-`pull_request_target` to hand the write token to a fork. Agents keep the write
-token. Supersedes 0039.
+Anyone who can push may write the remote cache before review. Validate presents
+`NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN` (worker `CACHE_ACCESS_TOKEN`) on
+`push`, `workflow_dispatch`, and non-fork `pull_request`. Fork `pull_request`
+jobs present `NX_SELF_HOSTED_REMOTE_CACHE_READ_TOKEN` (worker
+`CACHE_READ_TOKEN`) only — if that secret is unset, remote cache stays off. Do
+not use `pull_request_target` to hand the write token to a fork. Agents keep the
+write token. Supersedes 0039.
 
 ## Consequences
 

--- a/docs/contributing/decisions/index.md
+++ b/docs/contributing/decisions/index.md
@@ -97,7 +97,9 @@ Do not treat this list as homework. History stays; it is not silently deleted.
 - [0019 — Self-hosted Nx remote cache (not Nx Cloud)](./0019-self-hosted-nx-remote-cache.md)
   — contributor infra, not a product primitive
 - [0038 — Still no Nx Cloud; split self-hosted cache read and write tokens](./0038-no-nx-cloud-read-write-cache-tokens.md)
-  — Actions validate is read-only; agents keep the write token
+  — token split; refined by 0039
+- [0039 — Same-repo pull_request jobs do not write the Nx cache](./0039-no-same-repo-pr-cache-writes.md)
+  — PR validate stays read-only; `push` to `main` may write
 - [0028 — List/detail records expand inside the table](./0028-list-detail-expand.md)
   — UI mode assignment (supersedes 0010)
 - [0029 — Discord social login and official guild role](./0029-discord-social-login-and-guild-role.md)

--- a/docs/contributing/decisions/index.md
+++ b/docs/contributing/decisions/index.md
@@ -97,9 +97,11 @@ Do not treat this list as homework. History stays; it is not silently deleted.
 - [0019 — Self-hosted Nx remote cache (not Nx Cloud)](./0019-self-hosted-nx-remote-cache.md)
   — contributor infra, not a product primitive
 - [0038 — Still no Nx Cloud; split self-hosted cache read and write tokens](./0038-no-nx-cloud-read-write-cache-tokens.md)
-  — token split; refined by 0039
+  — token split; who may write is 0040
 - [0039 — Same-repo pull_request jobs do not write the Nx cache](./0039-no-same-repo-pr-cache-writes.md)
-  — PR validate stays read-only; `push` to `main` may write
+  — superseded by 0040
+- [0040 — Same-repo writers may PUT the Nx cache; fork PRs may not](./0040-same-repo-writers-may-put-nx-cache.md)
+  — push access already implies the local write token
 - [0028 — List/detail records expand inside the table](./0028-list-detail-expand.md)
   — UI mode assignment (supersedes 0010)
 - [0029 — Discord social login and official guild role](./0029-discord-social-login-and-guild-role.md)

--- a/docs/contributing/setup-manifest.md
+++ b/docs/contributing/setup-manifest.md
@@ -571,15 +571,15 @@ Configure these GitHub Actions secrets and variables for workflows:
   with `openssl rand -hex 32`. Production deploy and the dedicated
   `🧊 Nx cache worker` workflow sync it to the worker as `CACHE_ACCESS_TOKEN`.
   Use the same value in Cursor Cloud Agent environments so agent `validate` /
-  `test:push` can populate the cache. Validate on `push` to `main` (and
-  `workflow_dispatch` on `main`) also uses this write token. Leave unset to run
-  without remote writes.)
+  `test:push` can populate the cache. Same-repo validate (`push`,
+  `workflow_dispatch`, and non-fork `pull_request`) uses this write token too.
+  Leave unset to run without remote writes.)
 - `NX_SELF_HOSTED_REMOTE_CACHE_READ_TOKEN` (optional GitHub **secret**; read
   bearer for the same worker. Generate a second `openssl rand -hex 32` value,
-  not the write token. `pull_request` validate jobs set Nx's
-  `NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN` from this secret so PR CI can GET
+  not the write token. Fork `pull_request` validate jobs set Nx's
+  `NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN` from this secret so they can GET
   and cannot PUT. The worker syncs it as `CACHE_READ_TOKEN`. PUT with this token
-  returns 403. Leave unset to run PR CI with local `.nx` + `actions/cache`
+  returns 403. Leave unset to run fork CI with local `.nx` + `actions/cache`
   only.)
 - **Repository variables** `SENTRY_ORG` and `SENTRY_PROJECT` (optional; Sentry
   organization and project **slugs** for source map upload — same values as in
@@ -678,15 +678,15 @@ How to get/set each value:
     Cloud Agent environments (write token). Production deploy and the dedicated
     `🧊 Nx cache worker` workflow sync it to the `kody-nx-cache` Worker as
     `CACHE_ACCESS_TOKEN`. After rotating the GitHub secret, run that workflow on
-    `main` so the worker secret matches. Validate on `push` to `main` also
-    presents this write token to Nx.
+    `main` so the worker secret matches. Same-repo validate presents this write
+    token to Nx.
 - `NX_SELF_HOSTED_REMOTE_CACHE_READ_TOKEN` (optional)
   - Generate a second `openssl rand -hex 32` value. Store it as the repository
     secret `NX_SELF_HOSTED_REMOTE_CACHE_READ_TOKEN` only. Do not put this value
     on Cloud Agent environments. The same deploy workflow syncs it as
     `CACHE_READ_TOKEN`. After adding or rotating the GitHub secret, run that
-    workflow on `main` so the worker secret matches. `pull_request` validate
-    uses this token so a same-repo branch cannot PUT.
+    workflow on `main` so the worker secret matches. Fork `pull_request`
+    validate uses this token so a fork cannot PUT.
 - `SENTRY_ORG` / `SENTRY_PROJECT` (optional)
   - In GitHub: **Settings → Secrets and variables → Actions → Variables**, add
     `SENTRY_ORG` and `SENTRY_PROJECT` with your Sentry slugs (for example from

--- a/docs/contributing/setup-manifest.md
+++ b/docs/contributing/setup-manifest.md
@@ -571,13 +571,16 @@ Configure these GitHub Actions secrets and variables for workflows:
   with `openssl rand -hex 32`. Production deploy and the dedicated
   `🧊 Nx cache worker` workflow sync it to the worker as `CACHE_ACCESS_TOKEN`.
   Use the same value in Cursor Cloud Agent environments so agent `validate` /
-  `test:push` can populate the cache. Leave unset to run without remote writes.)
+  `test:push` can populate the cache. Validate on `push` to `main` (and
+  `workflow_dispatch` on `main`) also uses this write token. Leave unset to run
+  without remote writes.)
 - `NX_SELF_HOSTED_REMOTE_CACHE_READ_TOKEN` (optional GitHub **secret**; read
   bearer for the same worker. Generate a second `openssl rand -hex 32` value,
-  not the write token. Validate jobs set Nx's
+  not the write token. `pull_request` validate jobs set Nx's
   `NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN` from this secret so PR CI can GET
   and cannot PUT. The worker syncs it as `CACHE_READ_TOKEN`. PUT with this token
-  returns 403. Leave unset to run CI with local `.nx` + `actions/cache` only.)
+  returns 403. Leave unset to run PR CI with local `.nx` + `actions/cache`
+  only.)
 - **Repository variables** `SENTRY_ORG` and `SENTRY_PROJECT` (optional; Sentry
   organization and project **slugs** for source map upload — same values as in
   the Sentry wizard’s `--org` / `--project` flags)
@@ -675,13 +678,15 @@ How to get/set each value:
     Cloud Agent environments (write token). Production deploy and the dedicated
     `🧊 Nx cache worker` workflow sync it to the `kody-nx-cache` Worker as
     `CACHE_ACCESS_TOKEN`. After rotating the GitHub secret, run that workflow on
-    `main` so the worker secret matches.
+    `main` so the worker secret matches. Validate on `push` to `main` also
+    presents this write token to Nx.
 - `NX_SELF_HOSTED_REMOTE_CACHE_READ_TOKEN` (optional)
   - Generate a second `openssl rand -hex 32` value. Store it as the repository
     secret `NX_SELF_HOSTED_REMOTE_CACHE_READ_TOKEN` only. Do not put this value
     on Cloud Agent environments. The same deploy workflow syncs it as
     `CACHE_READ_TOKEN`. After adding or rotating the GitHub secret, run that
-    workflow on `main` so the worker secret matches.
+    workflow on `main` so the worker secret matches. `pull_request` validate
+    uses this token so a same-repo branch cannot PUT.
 - `SENTRY_ORG` / `SENTRY_PROJECT` (optional)
   - In GitHub: **Settings → Secrets and variables → Actions → Variables**, add
     `SENTRY_ORG` and `SENTRY_PROJECT` with your Sentry slugs (for example from

--- a/docs/contributing/setup/checks.md
+++ b/docs/contributing/setup/checks.md
@@ -40,12 +40,12 @@ pushes. See the [setup index](./index.md) for the other setup pages.
   GitHub Actions. CI runs the same checks as parallel jobs (🧹 Static, 🧪 Node,
   ☁️ Workers, 🔌 MCP, 🎭 E2E, aggregated by ✅ Validate). If `npm run validate`
   passes locally, CI will pass. Trusted writers (Cloud Agent environments, and
-  validate on `push` to `main`) set `NX_SELF_HOSTED_REMOTE_CACHE_SERVER` and the
-  write token so Nx uploads task artifacts to `https://nx-cache.kody.codes`.
+  same-repo validate) set `NX_SELF_HOSTED_REMOTE_CACHE_SERVER` and the write
+  token so Nx uploads task artifacts to `https://nx-cache.kody.codes`. Fork
   `pull_request` validate uses the read token and can only GET (see
   [decision 0019](../decisions/0019-self-hosted-nx-remote-cache.md),
   [decision 0038](../decisions/0038-no-nx-cloud-read-write-cache-tokens.md),
-  [decision 0039](../decisions/0039-no-same-repo-pr-cache-writes.md), and
+  [decision 0040](../decisions/0040-same-repo-writers-may-put-nx-cache.md), and
   [`packages/nx-cache/readme.md`](../../../packages/nx-cache/readme.md)).
 - `npm run deploy-guardrails:check` protects reviewed Durable Object migration
   history and bindings in both Wrangler configs, requires exact allowlisting for

--- a/docs/contributing/setup/checks.md
+++ b/docs/contributing/setup/checks.md
@@ -39,12 +39,13 @@ pushes. See the [setup index](./index.md) for the other setup pages.
   worker limits, and Nx cache hashes match the contended parallel layout used in
   GitHub Actions. CI runs the same checks as parallel jobs (🧹 Static, 🧪 Node,
   ☁️ Workers, 🔌 MCP, 🎭 E2E, aggregated by ✅ Validate). If `npm run validate`
-  passes locally, CI will pass. Trusted writers (Cloud Agent environments) set
-  `NX_SELF_HOSTED_REMOTE_CACHE_SERVER` and the write token so Nx uploads task
-  artifacts to `https://nx-cache.kody.codes`. GitHub Actions validate uses the
-  read token and can only GET (see
+  passes locally, CI will pass. Trusted writers (Cloud Agent environments, and
+  validate on `push` to `main`) set `NX_SELF_HOSTED_REMOTE_CACHE_SERVER` and the
+  write token so Nx uploads task artifacts to `https://nx-cache.kody.codes`.
+  `pull_request` validate uses the read token and can only GET (see
   [decision 0019](../decisions/0019-self-hosted-nx-remote-cache.md),
-  [decision 0038](../decisions/0038-no-nx-cloud-read-write-cache-tokens.md), and
+  [decision 0038](../decisions/0038-no-nx-cloud-read-write-cache-tokens.md),
+  [decision 0039](../decisions/0039-no-same-repo-pr-cache-writes.md), and
   [`packages/nx-cache/readme.md`](../../../packages/nx-cache/readme.md)).
 - `npm run deploy-guardrails:check` protects reviewed Durable Object migration
   history and bindings in both Wrangler configs, requires exact allowlisting for

--- a/packages/nx-cache/readme.md
+++ b/packages/nx-cache/readme.md
@@ -7,17 +7,16 @@ The worker implements the
 [Nx self-hosted cache OpenAPI spec](https://nx.dev/docs/kb/self-hosted-caching):
 `GET`/`PUT /v1/cache/{hash}` with bearer auth, `409` on overwrite, `403` when a
 read-only token PUTs, and artifacts stored in R2. `neverConnectToCloud` stays on
-so Nx does not prompt for Nx Cloud. `pull_request` validate uses the read token.
-Validate on `push` to `main` and Cloud Agent environments use the write token so
-post-merge CI and agents populate the cache and PR branches cannot.
+so Nx does not prompt for Nx Cloud. Same-repo validate and Cloud Agent
+environments use the write token. Fork `pull_request` jobs use the read token.
 
 Public URL: `https://nx-cache.kody.codes`.
 
 ## Clients
 
 Nx always reads `NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN`. The value is the
-write token on trusted writers (Cloud Agent environments, validate `push` to
-`main`) and the read token on `pull_request` validate
+write token on trusted writers (Cloud Agent environments and same-repo validate)
+and the read token on fork `pull_request` validate
 (`NX_SELF_HOSTED_REMOTE_CACHE_READ_TOKEN`).
 
 ```bash

--- a/packages/nx-cache/readme.md
+++ b/packages/nx-cache/readme.md
@@ -7,17 +7,18 @@ The worker implements the
 [Nx self-hosted cache OpenAPI spec](https://nx.dev/docs/kb/self-hosted-caching):
 `GET`/`PUT /v1/cache/{hash}` with bearer auth, `409` on overwrite, `403` when a
 read-only token PUTs, and artifacts stored in R2. `neverConnectToCloud` stays on
-so Nx does not prompt for Nx Cloud. GitHub Actions validate uses the read token;
-Cursor Cloud Agent environments keep the write token so agents populate the
-cache and untrusted PR branches cannot.
+so Nx does not prompt for Nx Cloud. `pull_request` validate uses the read token.
+Validate on `push` to `main` and Cloud Agent environments use the write token so
+post-merge CI and agents populate the cache and PR branches cannot.
 
 Public URL: `https://nx-cache.kody.codes`.
 
 ## Clients
 
 Nx always reads `NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN`. The value is the
-write token on trusted writers (Cloud Agent environments) and the read token in
-GitHub Actions (`NX_SELF_HOSTED_REMOTE_CACHE_READ_TOKEN`).
+write token on trusted writers (Cloud Agent environments, validate `push` to
+`main`) and the read token on `pull_request` validate
+(`NX_SELF_HOSTED_REMOTE_CACHE_READ_TOKEN`).
 
 ```bash
 export NX_SELF_HOSTED_REMOTE_CACHE_SERVER=https://nx-cache.kody.codes


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Treat push access as cache-write access. Same-repo validate may PUT. Fork PRs may not.

## Why

Anyone who can push already has the write token on Cloud Agent environments and locally. Giving the same token to their `pull_request` jobs does not create a new writer. [0039](docs/contributing/decisions/0039-no-same-repo-pr-cache-writes.md) over-counted that as untrusted.

## Summary

- Non-fork `pull_request`, `push`, and `workflow_dispatch` present `NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN` (write)
- Fork `pull_request` presents the read token only; if it is unset the env stays empty (no fall-through to write)
- Literal `secrets.*` refs only — no `secrets[...]` indexing
- [0040](docs/contributing/decisions/0040-same-repo-writers-may-put-nx-cache.md) supersedes 0039

## Testing

- `docs:check-decisions`, `docs:check-temporal`, `format:check`
- Pre-push `test:push` on this branch

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `915e50e1` · **Head:** `caface3f`

**Classification:** composes — no product primitives added or changed; contributor CI cache auth only.

### Primitives touched

None. Classifier unmatched paths are validate.yml and contributing docs.

### Change flow

Same-repo validate PUTs. A fork can only GET. A missing fork read secret stays empty.

```mermaid
sequenceDiagram
	actor SameRepo
	actor ForkPR
	participant nxCache as kody-nx-cache
	SameRepo->>nxCache: Bearer write token PUT /v1/cache/{hash}
	nxCache->>nxCache: store if absent
	ForkPR->>nxCache: Bearer read token GET /v1/cache/{hash}
	nxCache-->>ForkPR: 200 or 404
	ForkPR->>nxCache: Bearer read token PUT /v1/cache/{hash}
	nxCache-->>ForkPR: 403 text/plain
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2c093569-b79d-4898-8907-76e37a3a853f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2c093569-b79d-4898-8907-76e37a3a853f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Same-repository validation jobs can now populate the remote build cache.
  * Fork pull-request validation remains restricted to read-only cache access.

* **Documentation**
  * Updated setup guides and package documentation to explain cache access rules.
  * Added decision records documenting token permissions, security considerations, and cache behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->