### PR TITLE
Stop MCP refresh tokens and DCR clients from expiring on a timer

### DIFF
--- a/docs/contributing/architecture/authentication.md
+++ b/docs/contributing/architecture/authentication.md
@@ -566,12 +566,28 @@ routed from `packages/worker/src/index.ts`.
 - Approval is rejected before `completeAuthorization` when the account email is
   unverified, so no grant/token is created until verification succeeds.
 
+Token lifetimes are set on the `OAuthProvider` in
+`packages/worker/src/index.ts`:
+
+- Access tokens keep the provider default of 1 hour
+- Refresh tokens are issued with no expiry (`refreshTokenTTL: undefined`). The
+  provider default is 30 days; omitting the option keeps that default, so the
+  explicit `undefined` is required
+- Dynamically registered clients are stored with no KV expiry
+  (`clientRegistrationTTL: undefined`). The provider default is 90 days. Clients
+  created through `OAuthHelpers.createClient()` are unexpiring. A DCR client
+  record that already has a KV TTL still expires at that instant unless the host
+  re-registers
+
 `/mcp` is protected by `packages/worker/src/mcp-auth.ts`:
 
 - Requires `Authorization: Bearer <token>`
 - Token is validated via OAuth provider helpers (`unwrapToken`)
 - Audience must match the app origin or `<origin>/mcp`
-- Unauthenticated requests return `401` with `WWW-Authenticate` metadata
+- Unauthenticated requests return `401` with `WWW-Authenticate` metadata. The
+  challenge includes RFC 6750 `error="invalid_token"` plus RFC 9728
+  `resource_metadata`, so hosts that refresh on an invalid-token challenge can
+  do so without starting a new browser login
 - The account email must be verified; unverified accounts receive a
   `403 email_verification_required` response (see the email verification section
   above)

--- a/docs/contributing/architecture/authentication.md
+++ b/docs/contributing/architecture/authentication.md
@@ -584,10 +584,13 @@ Token lifetimes are set on the `OAuthProvider` in
 - Requires `Authorization: Bearer <token>`
 - Token is validated via OAuth provider helpers (`unwrapToken`)
 - Audience must match the app origin or `<origin>/mcp`
-- Unauthenticated requests return `401` with `WWW-Authenticate` metadata. The
-  challenge includes RFC 6750 `error="invalid_token"` plus RFC 9728
-  `resource_metadata`, so hosts that refresh on an invalid-token challenge can
-  do so without starting a new browser login
+- Requests without a Bearer token return `401` with `WWW-Authenticate` carrying
+  RFC 9728 `resource_metadata` (and scopes). RFC 6750 omits `error` when
+  credentials are absent
+- A present but rejected Bearer token returns `401` with RFC 6750
+  `error="invalid_token"` plus `error_description` and the same
+  `resource_metadata`, so hosts that refresh on that challenge can do so without
+  starting a new browser login
 - The account email must be verified; unverified accounts receive a
   `403 email_verification_required` response (see the email verification section
   above)

--- a/docs/use/connect-your-agent.md
+++ b/docs/use/connect-your-agent.md
@@ -81,7 +81,9 @@ Manual on Get started has one tab per host. Use those when you are not running
 - **Codex** — ChatGPT desktop is Codex. After the CLI writes the shared config,
   run `codex mcp login kody` if OAuth does not start. Manual includes
   `codex mcp add kody --url <url>` and the shared `~/.codex/config.toml`
-  `[mcp_servers.kody]` `url` entry.
+  `[mcp_servers.kody]` `url` entry. If Codex asks you to log in again after
+  about an hour, see
+  [Codex keeps asking for `codex mcp login kody`](./troubleshooting.md#codex-keeps-asking-for-codex-mcp-login-kody).
 - **OpenCode** — After the CLI writes the remote entry, run
   `opencode mcp auth kody` if prompted. Manual includes
   `opencode mcp add kody --url <url>` and a `mcp.kody` remote entry in

--- a/docs/use/troubleshooting.md
+++ b/docs/use/troubleshooting.md
@@ -15,6 +15,24 @@ authorization. Open the verification link sent at signup, or sign in and use
 authorize page. Keep an open `/oauth/authorize` tab so you can continue the same
 OAuth request after verifying in another tab, then reconnect or approve again.
 
+## Codex keeps asking for `codex mcp login kody`
+
+Kody access tokens last one hour. A host that stores the refresh token should
+call `/oauth/token` and stay signed in. Cursor does this. Some Codex builds send
+the expired access token, get a 401, and ask for a full browser login instead.
+
+Try this first:
+
+1. Update Codex.
+2. Run `codex mcp logout kody`, then `codex mcp login kody`.
+3. Avoid running Codex desktop and the CLI at the same time against the same
+   login. They can race a rotating refresh token and both get kicked out.
+
+If it still happens about every hour or every new Codex launch, that is the host
+skipping refresh. Cursor and Claude Code stay logged in. Email
+[`support@kody.codes`](mailto:support@kody.codes) with your Codex version and
+how often it asks again if you want us to look.
+
 ## The host never opens the Kody authorize window
 
 Dynamic OAuth needs the host to open `/oauth/authorize`. If Admin add-connection

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -424,6 +424,11 @@ const oauthProvider = new OAuthProvider({
 	// wrangler.jsonc) so metadata fetches are SSRF-safe; the provider only
 	// advertises CIMD support when both are on.
 	clientIdMetadataDocumentEnabled: true,
+	// Provider defaults are 30-day refresh tokens and 90-day DCR clients.
+	// Explicit `undefined` disables those expiries (omitting the option keeps
+	// the defaults). Access tokens stay at the 1-hour default.
+	refreshTokenTTL: undefined,
+	clientRegistrationTTL: undefined,
 	// Provider default onError logs every structured OAuth error via console.warn.
 	// Keep those responses on the wire without duplicating them into worker logs /
 	// test console guards; unexpected throws still reach our fetch catch + Sentry.

--- a/packages/worker/src/mcp-auth.ts
+++ b/packages/worker/src/mcp-auth.ts
@@ -64,11 +64,16 @@ export function handleProtectedResourceMetadata(request: Request, env?: Env) {
 	})
 }
 
+export const mcpInvalidTokenDescription =
+	'Authentication required. Obtain an access token via OAuth and retry with Authorization: Bearer.'
+
 function buildWwwAuthenticateHeader(origin: string) {
 	const resourceMetadata = `${origin}${protectedResourceMetadataPath}`
 	const scope =
-		oauthScopes.length > 0 ? ` scope="${oauthScopes.join(' ')}"` : ''
-	return `Bearer resource_metadata="${resourceMetadata}"${scope}`
+		oauthScopes.length > 0 ? `, scope="${oauthScopes.join(' ')}"` : ''
+	// RFC 6750 + RFC 9728: hosts that refresh on `error="invalid_token"` need
+	// that challenge attribute on the wire, not only in the JSON body.
+	return `Bearer error="invalid_token", error_description="${mcpInvalidTokenDescription}", resource_metadata="${resourceMetadata}"${scope}`
 }
 
 function createUnauthorizedResponse(origin: string) {
@@ -78,8 +83,7 @@ function createUnauthorizedResponse(origin: string) {
 	return Response.json(
 		{
 			error: 'invalid_token',
-			error_description:
-				'Authentication required. Obtain an access token via OAuth and retry with Authorization: Bearer.',
+			error_description: mcpInvalidTokenDescription,
 		},
 		{
 			status: 401,

--- a/packages/worker/src/mcp-auth.ts
+++ b/packages/worker/src/mcp-auth.ts
@@ -67,31 +67,54 @@ export function handleProtectedResourceMetadata(request: Request, env?: Env) {
 export const mcpInvalidTokenDescription =
 	'Authentication required. Obtain an access token via OAuth and retry with Authorization: Bearer.'
 
-function buildWwwAuthenticateHeader(origin: string) {
+type McpUnauthorizedKind = 'missing_credential' | 'invalid_token'
+
+function buildWwwAuthenticateHeader(origin: string, kind: McpUnauthorizedKind) {
 	const resourceMetadata = `${origin}${protectedResourceMetadataPath}`
 	const scope =
 		oauthScopes.length > 0 ? `, scope="${oauthScopes.join(' ')}"` : ''
-	// RFC 6750 + RFC 9728: hosts that refresh on `error="invalid_token"` need
-	// that challenge attribute on the wire, not only in the JSON body.
-	return `Bearer error="invalid_token", error_description="${mcpInvalidTokenDescription}", resource_metadata="${resourceMetadata}"${scope}`
+	const resourceAndScope = `resource_metadata="${resourceMetadata}"${scope}`
+	switch (kind) {
+		case 'missing_credential':
+			// RFC 6750 §3.1: omit error attributes when no credentials were sent.
+			return `Bearer ${resourceAndScope}`
+		case 'invalid_token':
+			// Hosts that refresh on `error="invalid_token"` need that attribute on
+			// the wire, not only in the JSON body.
+			return `Bearer error="invalid_token", error_description="${mcpInvalidTokenDescription}", ${resourceAndScope}`
+		default: {
+			const exhaustive: never = kind
+			throw new Error(`unexpected MCP unauthorized kind: ${exhaustive}`)
+		}
+	}
 }
 
-function createUnauthorizedResponse(origin: string) {
+function createUnauthorizedBody(kind: McpUnauthorizedKind) {
+	switch (kind) {
+		case 'missing_credential':
+			return { error_description: mcpInvalidTokenDescription }
+		case 'invalid_token':
+			return {
+				error: 'invalid_token',
+				error_description: mcpInvalidTokenDescription,
+			}
+		default: {
+			const exhaustive: never = kind
+			throw new Error(`unexpected MCP unauthorized kind: ${exhaustive}`)
+		}
+	}
+}
+
+function createUnauthorizedResponse(origin: string, kind: McpUnauthorizedKind) {
 	// Keep a JSON body in addition to WWW-Authenticate. Some remote MCP clients
 	// (notably Gemini custom connected apps) treat an empty 401 as a hard
 	// connectivity failure and never start OAuth discovery / DCR.
-	return Response.json(
-		{
-			error: 'invalid_token',
-			error_description: mcpInvalidTokenDescription,
+	return Response.json(createUnauthorizedBody(kind), {
+		status: 401,
+		headers: {
+			'WWW-Authenticate': buildWwwAuthenticateHeader(origin, kind),
 		},
-		{
-			status: 401,
-			headers: {
-				'WWW-Authenticate': buildWwwAuthenticateHeader(origin),
-			},
-		},
-	)
+	})
 }
 
 function acceptsMediaType(accept: string, mediaType: string) {
@@ -206,22 +229,22 @@ export async function handleMcpRequest({
 	// traffic belongs at the edge; see docs/contributing/security.md.
 	const authHeader = request.headers.get('Authorization')
 	if (!authHeader || !authHeader.startsWith('Bearer ')) {
-		return createUnauthorizedResponse(origin)
+		return createUnauthorizedResponse(origin, 'missing_credential')
 	}
 
 	const token = authHeader.slice('Bearer '.length).trim()
 	if (!token) {
-		return createUnauthorizedResponse(origin)
+		return createUnauthorizedResponse(origin, 'missing_credential')
 	}
 
 	const helpers = (env as OAuthEnv).OAUTH_PROVIDER
 	if (!helpers) {
-		return createUnauthorizedResponse(origin)
+		return createUnauthorizedResponse(origin, 'invalid_token')
 	}
 
 	const tokenSummary = await helpers.unwrapToken(token)
 	if (!tokenSummary || !audienceMatches(tokenSummary.audience, origin)) {
-		return createUnauthorizedResponse(origin)
+		return createUnauthorizedResponse(origin, 'invalid_token')
 	}
 
 	const context = ctx as OAuthExecutionContext

--- a/packages/worker/src/mcp-auth.ts
+++ b/packages/worker/src/mcp-auth.ts
@@ -105,6 +105,14 @@ function createUnauthorizedBody(kind: McpUnauthorizedKind) {
 	}
 }
 
+function readBearerToken(authorization: string | null) {
+	if (!authorization) return null
+	const match = authorization.match(/^Bearer(?:\s+(.*))?$/i)
+	if (!match) return null
+	const token = match[1]?.trim() ?? ''
+	return token.length > 0 ? token : null
+}
+
 function createUnauthorizedResponse(origin: string, kind: McpUnauthorizedKind) {
 	// Keep a JSON body in addition to WWW-Authenticate. Some remote MCP clients
 	// (notably Gemini custom connected apps) treat an empty 401 as a hard
@@ -227,13 +235,8 @@ export async function handleMcpRequest({
 	// a stranger drive unbounded D1 writes, and an unattributable "someone sent
 	// a bad token" carries little signal on its own. Flood control for anonymous
 	// traffic belongs at the edge; see docs/contributing/security.md.
-	const authHeader = request.headers.get('Authorization')
-	if (!authHeader || !authHeader.startsWith('Bearer ')) {
-		return createUnauthorizedResponse(origin, 'missing_credential')
-	}
-
-	const token = authHeader.slice('Bearer '.length).trim()
-	if (!token) {
+	const token = readBearerToken(request.headers.get('Authorization'))
+	if (token === null) {
 		return createUnauthorizedResponse(origin, 'missing_credential')
 	}
 

--- a/packages/worker/src/mcp-auth.workers.test.ts
+++ b/packages/worker/src/mcp-auth.workers.test.ts
@@ -8,6 +8,7 @@ import {
 	buildProtectedResourceMetadata,
 	handleMcpRequest,
 	handleProtectedResourceMetadata,
+	mcpInvalidTokenDescription,
 	mcpResourcePath,
 	protectedResourceMetadataPath,
 } from './mcp-auth.ts'
@@ -23,6 +24,8 @@ function expectAuthenticateHeader(
 		expectScope?: boolean
 	} = {},
 ) {
+	expect(header).toContain('error="invalid_token"')
+	expect(header).toContain(`error_description="${mcpInvalidTokenDescription}"`)
 	expect(header).toContain(
 		`resource_metadata="${origin}${protectedResourceMetadataPath}"`,
 	)
@@ -398,8 +401,7 @@ test('mcp endpoint serves browser guidance without changing protocol auth challe
 		expect(response.headers.get('Content-Type')).toMatch(/application\/json/)
 		expect(await response.json()).toEqual({
 			error: 'invalid_token',
-			error_description:
-				'Authentication required. Obtain an access token via OAuth and retry with Authorization: Bearer.',
+			error_description: mcpInvalidTokenDescription,
 		})
 		expectAuthenticateHeader(
 			response.headers.get('WWW-Authenticate') ?? '',
@@ -446,8 +448,7 @@ test('protected resource metadata and auth challenge resolve origin consistently
 	)
 	expect(await requestOriginUnauthorizedResponse.json()).toEqual({
 		error: 'invalid_token',
-		error_description:
-			'Authentication required. Obtain an access token via OAuth and retry with Authorization: Bearer.',
+		error_description: mcpInvalidTokenDescription,
 	})
 	expectAuthenticateHeader(
 		requestOriginUnauthorizedResponse.headers.get('WWW-Authenticate') ?? '',

--- a/packages/worker/src/mcp-auth.workers.test.ts
+++ b/packages/worker/src/mcp-auth.workers.test.ts
@@ -22,10 +22,26 @@ function expectAuthenticateHeader(
 	origin: string,
 	options: {
 		expectScope?: boolean
+		kind?: 'missing_credential' | 'invalid_token'
 	} = {},
 ) {
-	expect(header).toContain('error="invalid_token"')
-	expect(header).toContain(`error_description="${mcpInvalidTokenDescription}"`)
+	const kind = options.kind ?? 'invalid_token'
+	switch (kind) {
+		case 'missing_credential':
+			expect(header).not.toContain('error=')
+			expect(header).not.toContain('error_description=')
+			break
+		case 'invalid_token':
+			expect(header).toContain('error="invalid_token"')
+			expect(header).toContain(
+				`error_description="${mcpInvalidTokenDescription}"`,
+			)
+			break
+		default: {
+			const exhaustive: never = kind
+			throw new Error(`unexpected challenge kind: ${exhaustive}`)
+		}
+	}
 	expect(header).toContain(
 		`resource_metadata="${origin}${protectedResourceMetadataPath}"`,
 	)
@@ -366,7 +382,7 @@ test('mcp endpoint serves browser guidance without changing protocol auth challe
 	)
 	expect(browserResponse.headers.get('WWW-Authenticate')).toBeNull()
 
-	const protocolRequests = [
+	const missingCredentialRequests = [
 		new Request(`${origin}${mcpResourcePath}`, {
 			headers: { Accept: 'text/event-stream' },
 		}),
@@ -383,14 +399,11 @@ test('mcp endpoint serves browser guidance without changing protocol auth challe
 			}),
 		}),
 		new Request(`${origin}${mcpResourcePath}`, {
-			headers: {
-				Accept: 'text/html',
-				Authorization: 'Bearer invalid-token',
-			},
+			headers: { Authorization: 'Bearer ' },
 		}),
 	]
 
-	for (const request of protocolRequests) {
+	for (const request of missingCredentialRequests) {
 		const response = await handleMcpRequestAndDrain({
 			request,
 			env,
@@ -400,14 +413,38 @@ test('mcp endpoint serves browser guidance without changing protocol auth challe
 		expect(response.status).toBe(401)
 		expect(response.headers.get('Content-Type')).toMatch(/application\/json/)
 		expect(await response.json()).toEqual({
-			error: 'invalid_token',
 			error_description: mcpInvalidTokenDescription,
 		})
 		expectAuthenticateHeader(
 			response.headers.get('WWW-Authenticate') ?? '',
 			origin,
+			{ kind: 'missing_credential' },
 		)
 	}
+
+	const invalidTokenResponse = await handleMcpRequestAndDrain({
+		request: new Request(`${origin}${mcpResourcePath}`, {
+			headers: {
+				Accept: 'text/html',
+				Authorization: 'Bearer invalid-token',
+			},
+		}),
+		env,
+		ctx: createContext(),
+		fetchMcp,
+	})
+	expect(invalidTokenResponse.status).toBe(401)
+	expect(invalidTokenResponse.headers.get('Content-Type')).toMatch(
+		/application\/json/,
+	)
+	expect(await invalidTokenResponse.json()).toEqual({
+		error: 'invalid_token',
+		error_description: mcpInvalidTokenDescription,
+	})
+	expectAuthenticateHeader(
+		invalidTokenResponse.headers.get('WWW-Authenticate') ?? '',
+		origin,
+	)
 })
 
 test('protected resource metadata and auth challenge resolve origin consistently', async () => {
@@ -447,12 +484,12 @@ test('protected resource metadata and auth challenge resolve origin consistently
 		/application\/json/,
 	)
 	expect(await requestOriginUnauthorizedResponse.json()).toEqual({
-		error: 'invalid_token',
 		error_description: mcpInvalidTokenDescription,
 	})
 	expectAuthenticateHeader(
 		requestOriginUnauthorizedResponse.headers.get('WWW-Authenticate') ?? '',
 		requestOrigin,
+		{ kind: 'missing_credential' },
 	)
 
 	const appBaseUrlUnauthorizedResponse = await handleMcpRequestAndDrain({
@@ -467,6 +504,7 @@ test('protected resource metadata and auth challenge resolve origin consistently
 	expectAuthenticateHeader(
 		appBaseUrlUnauthorizedResponse.headers.get('WWW-Authenticate') ?? '',
 		workersDevOrigin,
+		{ kind: 'missing_credential' },
 	)
 })
 
@@ -515,6 +553,10 @@ test('mcp request enforces token audience and forwards caller props', async () =
 		fetchMcp: () => new Response('ok'),
 	})
 	expect(invalidResponse.status).toBe(401)
+	expectAuthenticateHeader(
+		invalidResponse.headers.get('WWW-Authenticate') ?? '',
+		'https://example.com',
+	)
 
 	const missingAudienceResponse = await handleMcpRequestAndDrain({
 		request,
@@ -527,6 +569,10 @@ test('mcp request enforces token audience and forwards caller props', async () =
 		fetchMcp: () => new Response('ok'),
 	})
 	expect(missingAudienceResponse.status).toBe(401)
+	expectAuthenticateHeader(
+		missingAudienceResponse.headers.get('WWW-Authenticate') ?? '',
+		'https://example.com',
+	)
 
 	let receivedProps: unknown = null
 	const validResponse = await handleMcpRequestAndDrain({

--- a/packages/worker/src/mcp-auth.workers.test.ts
+++ b/packages/worker/src/mcp-auth.workers.test.ts
@@ -445,6 +445,24 @@ test('mcp endpoint serves browser guidance without changing protocol auth challe
 		invalidTokenResponse.headers.get('WWW-Authenticate') ?? '',
 		origin,
 	)
+
+	const lowercaseBearerResponse = await handleMcpRequestAndDrain({
+		request: new Request(`${origin}${mcpResourcePath}`, {
+			headers: { Authorization: 'bearer invalid-token' },
+		}),
+		env,
+		ctx: createContext(),
+		fetchMcp,
+	})
+	expect(lowercaseBearerResponse.status).toBe(401)
+	expect(await lowercaseBearerResponse.json()).toEqual({
+		error: 'invalid_token',
+		error_description: mcpInvalidTokenDescription,
+	})
+	expectAuthenticateHeader(
+		lowercaseBearerResponse.headers.get('WWW-Authenticate') ?? '',
+		origin,
+	)
 })
 
 test('protected resource metadata and auth challenge resolve origin consistently', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Keep MCP hosts that store a refresh token signed in, and give refresh-capable clients an RFC 6750 `invalid_token` challenge they can act on. This does not paper over Codex skipping refresh by lengthening the 1-hour access token.

## Why

Codex CLI asks for `codex mcp login kody` about every hour. That is a host bug: it sends the expired access token, gets 401, and starts a new browser login instead of calling `/oauth/token`. Cursor, Grok, and OpenCode refresh and stay connected.

Kody still had two timer-based expiries that can kick even well-behaved hosts out later: 30-day refresh tokens and 90-day DCR client records. The `/mcp` 401 already returned JSON `invalid_token`, but `WWW-Authenticate` only advertised `resource_metadata` + scopes, so hosts that key refresh off the RFC 6750 challenge attribute never saw it.

## Summary

- Set `refreshTokenTTL: undefined` and `clientRegistrationTTL: undefined` on `OAuthProvider` (explicit `undefined` is required; omitting the option keeps the provider defaults). Access tokens stay 1 hour.
- `/mcp` 401s: missing or empty `Authorization` is a Bearer + `resource_metadata` challenge (RFC 6750 omits `error` when no credentials were sent). A present but rejected bearer includes `error="invalid_token"` and `error_description`.
- Document Codex's skip-refresh loop and the new token lifetimes.

Existing DCR client records that already have a KV TTL still expire at that instant unless the host re-registers. New grants and registrations after deploy are unexpiring.

## Testing

- `CI=1 nx run worker:test-workers -- packages/worker/src/mcp-auth.workers.test.ts` — 6 passed (covers missing-credential vs invalid-token challenges).
- Local `npm run test:push` e2e webServer timed out on this Cloud Agent VM: wrangler 4.120 entered a reload loop while writing `generated/esbuild.wasm`. GitHub 🎭 E2E passed on the first commit of this PR.
- Preview [kody-pr-1793](https://kody-pr-1793.kody-a99.workers.dev) as seed user `me@kentcdodds.com` (first commit):
  - Default smoke (health, login, session, account) passed.
  - `GET /mcp` is 401 with JSON `invalid_token` both unauthenticated and with a session cookie.
  - Re-verify after `54053831`: missing `Authorization` must omit `error=` on `WWW-Authenticate`; `Authorization: Bearer expired` must include `error="invalid_token"`.

## System changes

Auth / MCP OAuth contract change. Visual-recap classification is **extends** `mcp-oauth`. Ship risk is **high** because it changes production grant and DCR lifetimes; `/ship-pr deploy` granted merge authority.

CodeRabbit: kept unexpiring TTLs (intentional); split missing-credential vs invalid-token challenges.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends mcp-oauth</b> (medium risk; auth lifetime change)</summary>

**Mode:** recap · **Base:** `main` @ `1f2ba5a0` · **Head:** `54053831`

**Classification:** extends — MCP OAuth grant/client TTLs and the `/mcp` 401 challenge change. `scheduled-cron` matched `packages/worker/src/index.ts` as a false positive (OAuthProvider options only).

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `mcp-oauth` | auth | extends — unexpiring refresh tokens and DCR clients; RFC 6750 `invalid_token` only on a rejected bearer |

### Change flow

Missing credentials get a metadata-only challenge. A rejected bearer gets `invalid_token`. New refresh grants and DCR clients no longer get a KV/timer expiry.

```mermaid
sequenceDiagram
	actor host as MCP host
	participant mcpOauth as mcp-oauth
	alt no Authorization
		host->>mcpOauth: GET /mcp
		mcpOauth-->>host: 401 WWW-Authenticate resource_metadata only
	else expired or invalid bearer
		host->>mcpOauth: GET /mcp Authorization Bearer expired
		mcpOauth-->>host: 401 WWW-Authenticate error="invalid_token"
		opt host refreshes
			host->>mcpOauth: POST /oauth/token with refresh_token
			mcpOauth-->>host: new 1-hour access token (refresh grant has no TTL)
		end
	end
```

### Before / after

| | Before | After |
| --- | --- | --- |
| Access token | 1 hour | 1 hour (unchanged) |
| Refresh token | 30 days | no expiry |
| DCR client KV | 90 days | no expiry (new records) |
| `/mcp` with no Bearer | `resource_metadata` + scopes | same, still no `error` (RFC 6750) |
| `/mcp` with rejected Bearer | `resource_metadata` + scopes | `error="invalid_token"`, `error_description`, `resource_metadata`, scopes |

### Invariants

`per-user-isolation` is unchanged. Grants remain per authorized user. This PR only removes timer-based expiry on refresh tokens and new DCR client records.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-04a40327-5128-4bcc-851f-1e619b3ad37b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-04a40327-5128-4bcc-851f-1e619b3ad37b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved authentication compatibility with standardized challenges for missing credentials and invalid tokens.
  * Authentication responses now provide clearer guidance for refreshing rejected sessions.
  * Access tokens continue to expire after one hour, while refresh tokens and registered client sessions no longer expire automatically.

* **Documentation**
  * Added guidance for resolving repeated Codex login prompts.
  * Documented authentication challenge behavior, token lifetimes, session refresh steps, and troubleshooting options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->