### PR TITLE
Put commit, PR, and deploy metadata on /health

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,6 +13,7 @@ on:
 permissions:
   contents: read
   deployments: write
+  pull-requests: read
 
 concurrency:
   group: deploy-production
@@ -726,6 +727,18 @@ jobs:
             echo "url=$RUNTIME_URL" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: 🧾 Collect deploy info
+        id: deploy_info
+        if: needs.sha-guard.outputs.deploy_main == 'true'
+        env:
+          DEPLOY_COMMIT_SHA: ${{ needs.sha-guard.outputs.deploy_sha }}
+          DEPLOY_ENVIRONMENT: production
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          APP_DEPLOY_INFO="$(node tools/ci/build-deploy-info.ts)"
+          echo "app_deploy_info=$APP_DEPLOY_INFO" >> "$GITHUB_OUTPUT"
+
       - name: ☁️ Deploy to Cloudflare Workers
         id: deploy
         if: needs.sha-guard.outputs.deploy_main == 'true'
@@ -733,10 +746,11 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           APP_BASE_URL: ${{ vars.APP_BASE_URL }}
           DEPLOY_COMMIT_SHA: ${{ needs.sha-guard.outputs.deploy_sha }}
+          APP_DEPLOY_INFO: ${{ steps.deploy_info.outputs.app_deploy_info }}
           WRANGLER_CONFIG: ${{ steps.resources.outputs.wrangler_config }}
         run: |
           set -euo pipefail
-          DEPLOY_ARGS=(--config "$WRANGLER_CONFIG" --var "APP_COMMIT_SHA:${DEPLOY_COMMIT_SHA}")
+          DEPLOY_ARGS=(--config "$WRANGLER_CONFIG" --var "APP_COMMIT_SHA:${DEPLOY_COMMIT_SHA}" --var "APP_DEPLOY_INFO:${APP_DEPLOY_INFO}")
 
           is_retryable_deploy_failure() {
             node <<'NODE'

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -78,6 +78,21 @@ jobs:
       - name: 📥 Install Dependencies
         run: npm ci
 
+      - name: 🧾 Collect deploy info
+        id: deploy_info
+        env:
+          DEPLOY_COMMIT_SHA: ${{ github.sha }}
+          DEPLOY_ENVIRONMENT: preview
+          DEPLOY_PR_NUMBER:
+            ${{ github.event.pull_request.number || inputs.pr_number }}
+          DEPLOY_PR_URL: ${{ github.event.pull_request.html_url }}
+          DEPLOY_PR_TITLE: ${{ github.event.pull_request.title }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          APP_DEPLOY_INFO="$(node tools/ci/build-deploy-info.ts)"
+          echo "app_deploy_info=$APP_DEPLOY_INFO" >> "$GITHUB_OUTPUT"
+
       - name: 🧾 Resolve preview names
         id: names
         shell: bash
@@ -340,9 +355,10 @@ jobs:
           WRANGLER_CONFIG:
             ${{ steps.runtime_config.outputs.main_bootstrap_wrangler_config }}
           DEPLOY_COMMIT_SHA: ${{ github.sha }}
+          APP_DEPLOY_INFO: ${{ steps.deploy_info.outputs.app_deploy_info }}
         run: |
           set -euo pipefail
-          npm run deploy -- --name "$APP_WORKER_NAME" --config "$WRANGLER_CONFIG" --var "APP_COMMIT_SHA:${DEPLOY_COMMIT_SHA}"
+          npm run deploy -- --name "$APP_WORKER_NAME" --config "$WRANGLER_CONFIG" --var "APP_COMMIT_SHA:${DEPLOY_COMMIT_SHA}" --var "APP_DEPLOY_INFO:${APP_DEPLOY_INFO}"
 
       - name: ☁️ Bootstrap preview platform Worker (runtime DOs on main)
         env:
@@ -412,11 +428,12 @@ jobs:
           APP_WORKER_NAME: ${{ steps.names.outputs.worker_name }}
           WRANGLER_CONFIG: ${{ steps.resources.outputs.wrangler_config }}
           DEPLOY_COMMIT_SHA: ${{ github.sha }}
+          APP_DEPLOY_INFO: ${{ steps.deploy_info.outputs.app_deploy_info }}
         run: |
           set -euo pipefail
           echo "worker_name=$APP_WORKER_NAME" >> "$GITHUB_OUTPUT"
 
-          npm run deploy -- --name "$APP_WORKER_NAME" --config "$WRANGLER_CONFIG" --var "APP_COMMIT_SHA:${DEPLOY_COMMIT_SHA}" ${APP_BASE_URL:+--var "APP_BASE_URL:${APP_BASE_URL}"} 2>&1 | tee deploy.log
+          npm run deploy -- --name "$APP_WORKER_NAME" --config "$WRANGLER_CONFIG" --var "APP_COMMIT_SHA:${DEPLOY_COMMIT_SHA}" --var "APP_DEPLOY_INFO:${APP_DEPLOY_INFO}" ${APP_BASE_URL:+--var "APP_BASE_URL:${APP_BASE_URL}"} 2>&1 | tee deploy.log
 
           PREVIEW_URL="$(node -e 'const fs = require("node:fs"); const text = fs.readFileSync(process.argv[1], "utf8").replace(/\u001b\[[0-9;]*m/g, ""); const worker = process.argv[2]; const escaped = worker.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"); const workerUrlRegex = new RegExp(`https://(?:[a-zA-Z0-9-]+\\.)?${escaped}\\.[a-zA-Z0-9._-]+\\.workers\\.dev`, "g"); const matches = text.match(workerUrlRegex); process.stdout.write(matches?.at(-1) ?? "")' deploy.log "$APP_WORKER_NAME")"
           if [ -n "$PREVIEW_URL" ]; then

--- a/docs/contributing/cloud-agents.md
+++ b/docs/contributing/cloud-agents.md
@@ -90,8 +90,10 @@ dispatcher. The command is a no-op on machines without `~/.cursor/agent-hooks`.
   3742 is taken and prints `App running at http://localhost:<port>`.
 - Run long-lived dev in tmux so the session survives tool timeouts.
 - Health check (no auth): `curl http://localhost:<port>/health` →
-  `{"ok":true,"commitSha":...}`. Platform and runtime health paths
-  (`/__platform/health`, `/__runtime/health`) 404 on the origin port.
+  `{"ok":true,"commitSha":...,"commit":...,"pullRequest":...,"deploy":...}`.
+  Locally the extra fields are `null` unless a deploy var is set. Platform and
+  runtime health paths (`/__platform/health`, `/__runtime/health`) 404 on the
+  origin port.
 
 ## Environment file
 

--- a/docs/contributing/environment-variables.md
+++ b/docs/contributing/environment-variables.md
@@ -85,6 +85,19 @@ Optional Wrangler `var` (public, non-secret; see
   `https://cdn.usefathom.com` in `script-src` and `img-src` for the tracker and
   its image beacon.
 
+## Build metadata
+
+Optional Wrangler vars set by the production and preview deploy workflows (see
+`packages/worker/src/deploy-info.ts` and `tools/ci/build-deploy-info.ts`):
+
+- `APP_COMMIT_SHA` — the git SHA being deployed. `GET /health` reports it as
+  `commitSha` so post-deploy healthchecks can pin the version. Also used as the
+  Sentry **release**.
+- `APP_DEPLOY_INFO` — base64url JSON (raw JSON is also accepted) with the commit
+  message and date, repo/PR links, and the GitHub Actions run that deployed.
+  `GET /health` decodes it; invalid values are ignored so a bad var cannot take
+  the worker down. Unset in local dev.
+
 ## App origin and domain migration
 
 Wrangler `vars` (public and non-secret; see

--- a/docs/contributing/setup-manifest.md
+++ b/docs/contributing/setup-manifest.md
@@ -401,6 +401,9 @@ automatically:
   `{username}.kody.run`. Leave unset to dual-serve.)
 - `APP_COMMIT_SHA` (optional; set automatically by deploy workflows for
   version-aware `/health` checks)
+- `APP_DEPLOY_INFO` (optional; set automatically by deploy workflows as
+  base64url JSON. `GET /health` decodes it for commit message/date, commit and
+  PR links, and deploy job metadata. Invalid values are ignored.)
 - `CLOUDFLARE_ACCOUNT_ID` (required for the Cloudflare Email Service REST API
   fallback used by local mocks and preview deploys)
 - `CLOUDFLARE_API_TOKEN` (used by the Cloudflare Email Service REST API fallback

--- a/docs/contributing/setup/preview-deploys.md
+++ b/docs/contributing/setup/preview-deploys.md
@@ -36,7 +36,9 @@ migrations/deploy:
 Both the preview and production deploy workflows run post-deploy healthchecks
 and fail the job if any expected worker is missing the deployed commit:
 
-- origin: `<deploy-url>/health` → `{ ok: true, commitSha }`
+- origin: `<deploy-url>/health` →
+  `{ ok: true, commitSha, commit, pullRequest, deploy }` (`commitSha` is the
+  version pin; browsers that prefer HTML get clickable commit/PR/job links)
 - platform: `/__platform/health` → `{ status: "ok", commitSha }`
 - runtime: `/__runtime/health` → `{ status: "ok", commitSha }`
 - jobs: `/health` on the jobs workers.dev URL → `{ ok: true, commit }` (jobs has

--- a/packages/worker/.env.example
+++ b/packages/worker/.env.example
@@ -62,6 +62,13 @@ DISCORD_CLIENT_SECRET=MOCK_DISCORD_CLIENT_SECRET
 # wrangler.jsonc). When set, SSR pages embed the Fathom tracker script.
 # FATHOM_SITE_ID=WKKSDJGN
 
+# Build metadata (optional; deploy workflows set these as Wrangler vars).
+# APP_COMMIT_SHA is the deployed git SHA for GET /health and Sentry release.
+# APP_DEPLOY_INFO is opaque base64url JSON (commit message/date, PR and deploy
+# job links). Invalid values are ignored.
+# APP_COMMIT_SHA=
+# APP_DEPLOY_INFO=
+
 # Sentry (optional; omit locally if you are not sending errors to Sentry)
 # SENTRY_DSN=https://examplePublicKey@o0.ingest.sentry.io/0
 # SENTRY_ENVIRONMENT=development

--- a/packages/worker/src/app/handlers/health-handler.node.test.ts
+++ b/packages/worker/src/app/handlers/health-handler.node.test.ts
@@ -1,39 +1,109 @@
 import { expect, test } from 'vitest'
 import { RequestContext } from 'remix/router'
+import { encodeDeployInfo, type DeployInfo } from '#worker/deploy-info.ts'
 import { createHealthHandler } from '#app/handlers/health.ts'
 
-function createHealthRequestContext() {
-	return new RequestContext(new Request('https://example.com/health'))
+const commitSha = 'f2d82dba4ba50cf2ad3f56f5c88f7b8ef5f97d8e'
+const deployInfo = {
+	repoUrl: 'https://github.com/kentcdodds/kody',
+	commit: {
+		sha: commitSha,
+		message: 'feat: richer /health metadata (#1799)',
+		committedAt: '2026-08-27T18:00:00Z',
+	},
+	pullRequest: {
+		number: 1799,
+		url: 'https://github.com/kentcdodds/kody/pull/1799',
+		title: 'Richer /health metadata',
+	},
+	deploy: {
+		deployedAt: '2026-08-27T18:05:00Z',
+		environment: 'preview',
+		workflow: '🔎 Preview',
+		job: 'deploy',
+		runId: '99',
+		runUrl: 'https://github.com/kentcdodds/kody/actions/runs/99',
+	},
+} satisfies DeployInfo
+
+function createHealthRequestContext(accept?: string) {
+	return new RequestContext(
+		new Request('https://example.com/health', {
+			headers: accept ? { Accept: accept } : undefined,
+		}),
+	)
 }
 
-test('health handler reports cache and commit SHA metadata for unset and configured builds', async () => {
-	const scenarios = [
-		{
-			appCommitSha: undefined,
-			headerCommitSha: 'unknown',
-			bodyCommitSha: null,
-		},
-		{
-			appCommitSha: 'f2d82dba4ba50cf2ad3f56f5c88f7b8ef5f97d8e',
-			headerCommitSha: 'f2d82dba4ba50cf2ad3f56f5c88f7b8ef5f97d8e',
-			bodyCommitSha: 'f2d82dba4ba50cf2ad3f56f5c88f7b8ef5f97d8e',
-		},
-	] as const
+test('health handler reports commit, PR, and deploy metadata for JSON and HTML clients', async () => {
+	const unsetHandler = createHealthHandler({
+		APP_COMMIT_SHA: undefined,
+		APP_DEPLOY_INFO: undefined,
+	})
+	const unsetResponse = await unsetHandler.handler(createHealthRequestContext())
+	expect(unsetResponse.status).toBe(200)
+	expect(unsetResponse.headers.get('Cache-Control')).toBe('no-store')
+	expect(unsetResponse.headers.get('X-App-Commit-Sha')).toBe('unknown')
+	expect(await unsetResponse.json()).toEqual({
+		ok: true,
+		commitSha: null,
+		commit: null,
+		pullRequest: null,
+		deploy: null,
+	})
 
-	for (const scenario of scenarios) {
-		const handler = createHealthHandler({
-			APP_COMMIT_SHA: scenario.appCommitSha,
-		})
-		const response = await handler.handler(createHealthRequestContext())
+	const shaOnlyHandler = createHealthHandler({
+		APP_COMMIT_SHA: commitSha,
+		APP_DEPLOY_INFO: undefined,
+	})
+	const shaOnlyResponse = await shaOnlyHandler.handler(
+		createHealthRequestContext('application/json'),
+	)
+	expect(shaOnlyResponse.headers.get('X-App-Commit-Sha')).toBe(commitSha)
+	expect(await shaOnlyResponse.json()).toEqual({
+		ok: true,
+		commitSha,
+		commit: {
+			sha: commitSha,
+			url: `https://github.com/kentcdodds/kody/commit/${commitSha}`,
+			message: null,
+			committedAt: null,
+		},
+		pullRequest: null,
+		deploy: null,
+	})
 
-		expect(response.status).toBe(200)
-		expect(response.headers.get('Cache-Control')).toBe('no-store')
-		expect(response.headers.get('X-App-Commit-Sha')).toBe(
-			scenario.headerCommitSha,
-		)
-		expect(await response.json()).toEqual({
-			ok: true,
-			commitSha: scenario.bodyCommitSha,
-		})
-	}
+	const deployedHandler = createHealthHandler({
+		APP_COMMIT_SHA: commitSha,
+		APP_DEPLOY_INFO: encodeDeployInfo(deployInfo),
+	})
+	const jsonResponse = await deployedHandler.handler(
+		createHealthRequestContext(),
+	)
+	expect(await jsonResponse.json()).toEqual({
+		ok: true,
+		commitSha,
+		commit: {
+			sha: commitSha,
+			url: `https://github.com/kentcdodds/kody/commit/${commitSha}`,
+			message: deployInfo.commit.message,
+			committedAt: deployInfo.commit.committedAt,
+		},
+		pullRequest: deployInfo.pullRequest,
+		deploy: deployInfo.deploy,
+	})
+
+	const htmlResponse = await deployedHandler.handler(
+		createHealthRequestContext('text/html'),
+	)
+	expect(htmlResponse.headers.get('Content-Type')).toBe(
+		'text/html; charset=utf-8',
+	)
+	const html = await htmlResponse.text()
+	expect(html).toContain(commitSha)
+	expect(html).toContain(
+		`https://github.com/kentcdodds/kody/commit/${commitSha}`,
+	)
+	expect(html).toContain(deployInfo.pullRequest.url)
+	expect(html).toContain(deployInfo.deploy.runUrl)
+	expect(html).toContain(deployInfo.commit.message)
 })

--- a/packages/worker/src/app/handlers/health.ts
+++ b/packages/worker/src/app/handlers/health.ts
@@ -1,25 +1,86 @@
 import { type Action } from 'remix/router'
+import { escapeHtml } from '@kody-internal/shared/escape-html.ts'
 import { type routes } from '#universal/routes.ts'
+import {
+	buildHealthReport,
+	prefersHtml,
+	type HealthReport,
+} from '#worker/deploy-info.ts'
 import { type AppEnv } from '#worker/env-schema.ts'
 
 type HealthEnv = {
 	APP_COMMIT_SHA: AppEnv['APP_COMMIT_SHA']
+	APP_DEPLOY_INFO: AppEnv['APP_DEPLOY_INFO']
 }
 
 export function createHealthHandler(appEnv: HealthEnv) {
 	return {
 		middleware: [],
-		async handler() {
-			const commitSha = appEnv.APP_COMMIT_SHA ?? null
-			return Response.json(
-				{ ok: true, commitSha },
-				{
+		async handler({ request }) {
+			const report = buildHealthReport(appEnv)
+			const commitSha = report.commitSha ?? 'unknown'
+			const headers = {
+				'Cache-Control': 'no-store',
+				'X-App-Commit-Sha': commitSha,
+			}
+			if (prefersHtml(request.headers.get('Accept'))) {
+				return new Response(renderHealthHtml(report), {
 					headers: {
-						'Cache-Control': 'no-store',
-						'X-App-Commit-Sha': commitSha ?? 'unknown',
+						...headers,
+						'Content-Type': 'text/html; charset=utf-8',
 					},
-				},
-			)
+				})
+			}
+			return Response.json(report, { headers })
 		},
 	} satisfies Action<typeof routes.health>
+}
+
+function renderHealthHtml(report: HealthReport) {
+	const commitLink = report.commit
+		? `<a href="${escapeHtml(report.commit.url)}">${escapeHtml(report.commit.sha)}</a>`
+		: 'unset'
+	const pullRequestLink = report.pullRequest
+		? `<a href="${escapeHtml(report.pullRequest.url)}">#${String(report.pullRequest.number)}${report.pullRequest.title ? ` ${escapeHtml(report.pullRequest.title)}` : ''}</a>`
+		: 'none'
+	const deployLink = report.deploy?.runUrl
+		? `<a href="${escapeHtml(report.deploy.runUrl)}">${escapeHtml(report.deploy.runUrl)}</a>`
+		: 'unset'
+	return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Kody health</title>
+<style>
+body { font-family: ui-sans-serif, system-ui, sans-serif; margin: 2rem auto; max-width: 48rem; padding: 0 1.25rem; line-height: 1.5; }
+dt { font-weight: 600; margin-top: 1rem; }
+dd { margin: 0.25rem 0 0; }
+pre { white-space: pre-wrap; overflow-wrap: anywhere; }
+a { overflow-wrap: anywhere; }
+</style>
+</head>
+<body>
+<h1>ok</h1>
+<dl>
+<dt>Commit</dt>
+<dd>${commitLink}</dd>
+<dt>Commit message</dt>
+<dd><pre>${escapeHtml(report.commit?.message ?? 'unset')}</pre></dd>
+<dt>Committed</dt>
+<dd>${escapeHtml(report.commit?.committedAt ?? 'unset')}</dd>
+<dt>Pull request</dt>
+<dd>${pullRequestLink}</dd>
+<dt>Deployed</dt>
+<dd>${escapeHtml(report.deploy?.deployedAt ?? 'unset')}</dd>
+<dt>Environment</dt>
+<dd>${escapeHtml(report.deploy?.environment ?? 'unset')}</dd>
+<dt>Workflow / job</dt>
+<dd>${escapeHtml(report.deploy?.workflow ?? 'unset')} / ${escapeHtml(report.deploy?.job ?? 'unset')}</dd>
+<dt>Deploy job</dt>
+<dd>${deployLink}</dd>
+</dl>
+</body>
+</html>
+`
 }

--- a/packages/worker/src/deploy-info.node.test.ts
+++ b/packages/worker/src/deploy-info.node.test.ts
@@ -1,0 +1,104 @@
+import { expect, test } from 'vitest'
+import {
+	buildHealthReport,
+	encodeDeployInfo,
+	parseDeployInfo,
+	prefersHtml,
+	pullRequestNumberFromCommitMessage,
+	truncateCommitMessage,
+	type DeployInfo,
+} from './deploy-info.ts'
+
+const sampleDeployInfo = {
+	repoUrl: 'https://github.com/kentcdodds/kody',
+	commit: {
+		sha: 'f2d82dba4ba50cf2ad3f56f5c88f7b8ef5f97d8e',
+		message: 'feat: richer /health metadata (#1799)',
+		committedAt: '2026-08-27T18:00:00Z',
+	},
+	pullRequest: {
+		number: 1799,
+		url: 'https://github.com/kentcdodds/kody/pull/1799',
+		title: 'Richer /health metadata',
+	},
+	deploy: {
+		deployedAt: '2026-08-27T18:05:00Z',
+		environment: 'production',
+		workflow: '🚀 Deploy (production)',
+		job: 'deploy',
+		runId: '12345',
+		runUrl: 'https://github.com/kentcdodds/kody/actions/runs/12345',
+	},
+} satisfies DeployInfo
+
+test('deploy info encodes for wrangler vars and rebuilds the /health report', () => {
+	expect(parseDeployInfo(undefined)).toBeNull()
+	expect(parseDeployInfo('not-valid')).toBeNull()
+	expect(parseDeployInfo('{')).toBeNull()
+	expect(parseDeployInfo(JSON.stringify(sampleDeployInfo))).toEqual(
+		sampleDeployInfo,
+	)
+	expect(parseDeployInfo(encodeDeployInfo(sampleDeployInfo))).toEqual(
+		sampleDeployInfo,
+	)
+
+	expect(buildHealthReport({})).toEqual({
+		ok: true,
+		commitSha: null,
+		commit: null,
+		pullRequest: null,
+		deploy: null,
+	})
+
+	expect(
+		buildHealthReport({
+			APP_COMMIT_SHA: 'f2d82dba4ba50cf2ad3f56f5c88f7b8ef5f97d8e',
+		}),
+	).toEqual({
+		ok: true,
+		commitSha: 'f2d82dba4ba50cf2ad3f56f5c88f7b8ef5f97d8e',
+		commit: {
+			sha: 'f2d82dba4ba50cf2ad3f56f5c88f7b8ef5f97d8e',
+			url: 'https://github.com/kentcdodds/kody/commit/f2d82dba4ba50cf2ad3f56f5c88f7b8ef5f97d8e',
+			message: null,
+			committedAt: null,
+		},
+		pullRequest: null,
+		deploy: null,
+	})
+
+	expect(
+		buildHealthReport({
+			APP_COMMIT_SHA: 'f2d82dba4ba50cf2ad3f56f5c88f7b8ef5f97d8e',
+			APP_DEPLOY_INFO: encodeDeployInfo(sampleDeployInfo),
+		}),
+	).toEqual({
+		ok: true,
+		commitSha: 'f2d82dba4ba50cf2ad3f56f5c88f7b8ef5f97d8e',
+		commit: {
+			sha: 'f2d82dba4ba50cf2ad3f56f5c88f7b8ef5f97d8e',
+			url: 'https://github.com/kentcdodds/kody/commit/f2d82dba4ba50cf2ad3f56f5c88f7b8ef5f97d8e',
+			message: 'feat: richer /health metadata (#1799)',
+			committedAt: '2026-08-27T18:00:00Z',
+		},
+		pullRequest: sampleDeployInfo.pullRequest,
+		deploy: sampleDeployInfo.deploy,
+	})
+
+	expect(
+		buildHealthReport({
+			APP_COMMIT_SHA: 'f2d82dba4ba50cf2ad3f56f5c88f7b8ef5f97d8e',
+			APP_DEPLOY_INFO: '%%%',
+		}).commitSha,
+	).toBe('f2d82dba4ba50cf2ad3f56f5c88f7b8ef5f97d8e')
+
+	expect(pullRequestNumberFromCommitMessage('feat: foo (#12)\n\n(#99)')).toBe(
+		99,
+	)
+	expect(pullRequestNumberFromCommitMessage('no pr here')).toBeNull()
+	expect(truncateCommitMessage(`${'a'.repeat(500)}extra`).length).toBe(500)
+	expect(prefersHtml(null)).toBe(false)
+	expect(prefersHtml('application/json')).toBe(false)
+	expect(prefersHtml('text/html,application/xhtml+xml')).toBe(true)
+	expect(prefersHtml('application/json, text/html')).toBe(false)
+})

--- a/packages/worker/src/deploy-info.node.test.ts
+++ b/packages/worker/src/deploy-info.node.test.ts
@@ -92,6 +92,24 @@ test('deploy info encodes for wrangler vars and rebuilds the /health report', ()
 		}).commitSha,
 	).toBe('f2d82dba4ba50cf2ad3f56f5c88f7b8ef5f97d8e')
 
+	expect(
+		buildHealthReport({
+			APP_COMMIT_SHA: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+			APP_DEPLOY_INFO: encodeDeployInfo(sampleDeployInfo),
+		}),
+	).toEqual({
+		ok: true,
+		commitSha: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+		commit: {
+			sha: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+			url: 'https://github.com/kentcdodds/kody/commit/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+			message: null,
+			committedAt: null,
+		},
+		pullRequest: null,
+		deploy: null,
+	})
+
 	expect(pullRequestNumberFromCommitMessage('feat: foo (#12)\n\n(#99)')).toBe(
 		99,
 	)

--- a/packages/worker/src/deploy-info.ts
+++ b/packages/worker/src/deploy-info.ts
@@ -96,7 +96,12 @@ export function buildHealthReport(env: {
 	APP_DEPLOY_INFO?: string
 }): HealthReport {
 	const commitSha = env.APP_COMMIT_SHA ?? null
-	const info = parseDeployInfo(env.APP_DEPLOY_INFO)
+	const parsed = parseDeployInfo(env.APP_DEPLOY_INFO)
+	const info =
+		parsed &&
+		(!commitSha || parsed.commit.sha.toLowerCase() === commitSha.toLowerCase())
+			? parsed
+			: null
 	const repoUrl = info?.repoUrl ?? defaultGithubRepoUrl
 	const sha = commitSha ?? info?.commit.sha ?? null
 	return {

--- a/packages/worker/src/deploy-info.ts
+++ b/packages/worker/src/deploy-info.ts
@@ -1,0 +1,219 @@
+export const defaultGithubRepoUrl = 'https://github.com/kentcdodds/kody'
+export const maxCommitMessageLength = 500
+
+export type DeployCommitInfo = {
+	sha: string
+	message: string
+	committedAt: string | null
+}
+
+export type DeployPullRequestInfo = {
+	number: number
+	url: string
+	title: string | null
+}
+
+export type DeployRunInfo = {
+	deployedAt: string
+	environment: string
+	workflow: string | null
+	job: string | null
+	runId: string | null
+	runUrl: string | null
+}
+
+export type DeployInfo = {
+	repoUrl: string
+	commit: DeployCommitInfo
+	pullRequest: DeployPullRequestInfo | null
+	deploy: DeployRunInfo
+}
+
+export type HealthCommit = {
+	sha: string
+	url: string
+	message: string | null
+	committedAt: string | null
+}
+
+export type HealthReport = {
+	ok: true
+	commitSha: string | null
+	commit: HealthCommit | null
+	pullRequest: DeployPullRequestInfo | null
+	deploy: DeployRunInfo | null
+}
+
+export function githubCommitUrl(repoUrl: string, sha: string) {
+	return `${trimTrailingSlash(repoUrl)}/commit/${sha}`
+}
+
+export function githubPullRequestUrl(repoUrl: string, number: number) {
+	return `${trimTrailingSlash(repoUrl)}/pull/${number}`
+}
+
+export function githubActionsRunUrl(
+	repoUrl: string,
+	runId: string,
+	attempt?: string | null,
+) {
+	const url = `${trimTrailingSlash(repoUrl)}/actions/runs/${runId}`
+	return attempt && attempt !== '1' ? `${url}/attempts/${attempt}` : url
+}
+
+export function truncateCommitMessage(message: string) {
+	const normalized = message.replaceAll('\r\n', '\n').trim()
+	if (normalized.length <= maxCommitMessageLength) return normalized
+	return `${normalized.slice(0, maxCommitMessageLength - 1)}…`
+}
+
+export function pullRequestNumberFromCommitMessage(message: string) {
+	const matches = [...message.matchAll(/\(#(\d+)\)/g)]
+	const last = matches.at(-1)?.[1]
+	if (!last) return null
+	const number = Number(last)
+	return Number.isInteger(number) && number > 0 ? number : null
+}
+
+export function encodeDeployInfo(info: DeployInfo) {
+	return encodeBase64Url(JSON.stringify(info))
+}
+
+export function parseDeployInfo(raw: string | undefined) {
+	if (!raw) return null
+	const trimmed = raw.trim()
+	if (!trimmed) return null
+	try {
+		const json = trimmed.startsWith('{') ? trimmed : decodeBase64Url(trimmed)
+		return validateDeployInfo(JSON.parse(json) as unknown)
+	} catch {
+		return null
+	}
+}
+
+export function buildHealthReport(env: {
+	APP_COMMIT_SHA?: string
+	APP_DEPLOY_INFO?: string
+}): HealthReport {
+	const commitSha = env.APP_COMMIT_SHA ?? null
+	const info = parseDeployInfo(env.APP_DEPLOY_INFO)
+	const repoUrl = info?.repoUrl ?? defaultGithubRepoUrl
+	const sha = commitSha ?? info?.commit.sha ?? null
+	return {
+		ok: true,
+		commitSha,
+		commit: sha
+			? {
+					sha,
+					url: githubCommitUrl(repoUrl, sha),
+					message: info?.commit.message ?? null,
+					committedAt: info?.commit.committedAt ?? null,
+				}
+			: null,
+		pullRequest: info?.pullRequest ?? null,
+		deploy: info?.deploy ?? null,
+	}
+}
+
+export function prefersHtml(accept: string | null) {
+	if (!accept) return false
+	const html = accept.indexOf('text/html')
+	if (html === -1) return false
+	const json = accept.indexOf('application/json')
+	return json === -1 || html < json
+}
+
+function trimTrailingSlash(value: string) {
+	return value.endsWith('/') ? value.slice(0, -1) : value
+}
+
+function encodeBase64Url(text: string) {
+	const bytes = new TextEncoder().encode(text)
+	let binary = ''
+	for (const byte of bytes) binary += String.fromCharCode(byte)
+	return btoa(binary)
+		.replaceAll('+', '-')
+		.replaceAll('/', '_')
+		.replaceAll('=', '')
+}
+
+function decodeBase64Url(encoded: string) {
+	const padded = encoded.replaceAll('-', '+').replaceAll('_', '/')
+	const pad = padded.length % 4 === 0 ? '' : '='.repeat(4 - (padded.length % 4))
+	const binary = atob(padded + pad)
+	const bytes = Uint8Array.from(binary, (character) => character.charCodeAt(0))
+	return new TextDecoder().decode(bytes)
+}
+
+function validateDeployInfo(value: unknown): DeployInfo | null {
+	if (!isRecord(value)) return null
+	if (typeof value.repoUrl !== 'string' || !value.repoUrl.trim()) return null
+	if (!isRecord(value.commit)) return null
+	if (typeof value.commit.sha !== 'string' || !value.commit.sha.trim()) {
+		return null
+	}
+	if (typeof value.commit.message !== 'string') return null
+	if (
+		value.commit.committedAt !== null &&
+		typeof value.commit.committedAt !== 'string'
+	) {
+		return null
+	}
+	if (!isRecord(value.deploy)) return null
+	if (typeof value.deploy.deployedAt !== 'string') return null
+	if (typeof value.deploy.environment !== 'string') return null
+	const pullRequest = validatePullRequest(value.pullRequest)
+	if (
+		value.pullRequest !== null &&
+		value.pullRequest !== undefined &&
+		!pullRequest
+	) {
+		return null
+	}
+	return {
+		repoUrl: value.repoUrl.trim(),
+		commit: {
+			sha: value.commit.sha.trim(),
+			message: value.commit.message,
+			committedAt: value.commit.committedAt,
+		},
+		pullRequest,
+		deploy: {
+			deployedAt: value.deploy.deployedAt,
+			environment: value.deploy.environment,
+			workflow: optionalString(value.deploy.workflow),
+			job: optionalString(value.deploy.job),
+			runId: optionalString(value.deploy.runId),
+			runUrl: optionalString(value.deploy.runUrl),
+		},
+	}
+}
+
+function validatePullRequest(value: unknown): DeployPullRequestInfo | null {
+	if (value == null) return null
+	if (!isRecord(value)) return null
+	if (typeof value.number !== 'number' || !Number.isInteger(value.number)) {
+		return null
+	}
+	if (typeof value.url !== 'string' || !value.url.trim()) return null
+	if (
+		value.title !== null &&
+		value.title !== undefined &&
+		typeof value.title !== 'string'
+	) {
+		return null
+	}
+	return {
+		number: value.number,
+		url: value.url,
+		title: typeof value.title === 'string' ? value.title : null,
+	}
+}
+
+function optionalString(value: unknown) {
+	return typeof value === 'string' && value.trim() ? value : null
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null
+}

--- a/packages/worker/src/env-schema.ts
+++ b/packages/worker/src/env-schema.ts
@@ -257,6 +257,10 @@ export const EnvSchema = object({
 	// those hosts alongside the canonical SYSTEM_EMAIL_DOMAIN.
 	LEGACY_SYSTEM_EMAIL_DOMAINS: optionalNonEmptyStringSchema,
 	APP_COMMIT_SHA: optionalCommitShaSchema,
+	// Opaque deploy metadata (JSON or base64url JSON) for GET /health. Set
+	// automatically by deploy workflows; invalid values must not fail env
+	// validation because that would take the worker down.
+	APP_DEPLOY_INFO: optionalNonEmptyStringSchema,
 	EMAIL: optionalSendEmailSchema,
 	EMAIL_EVENTS: optionalAnalyticsEngineDatasetSchema,
 	USAGE_EVENTS: optionalAnalyticsEngineDatasetSchema,

--- a/tools/ci/build-deploy-info.node.test.ts
+++ b/tools/ci/build-deploy-info.node.test.ts
@@ -1,0 +1,114 @@
+import { expect, test } from 'vitest'
+import {
+	encodeDeployInfo,
+	parseDeployInfo,
+	type DeployInfo,
+} from '#worker/deploy-info.ts'
+import {
+	buildDeployInfo,
+	readDeployInfoInputFromEnv,
+} from './build-deploy-info.ts'
+
+const commitSha = 'f2d82dba4ba50cf2ad3f56f5c88f7b8ef5f97d8e'
+
+test('build-deploy-info collects git, PR, and Actions metadata for /health', async () => {
+	const fromEnv = readDeployInfoInputFromEnv({
+		DEPLOY_COMMIT_SHA: commitSha,
+		DEPLOY_ENVIRONMENT: 'preview',
+		GITHUB_SERVER_URL: 'https://github.com',
+		GITHUB_REPOSITORY: 'kentcdodds/kody',
+		GITHUB_WORKFLOW: '🔎 Preview',
+		GITHUB_JOB: 'deploy',
+		GITHUB_RUN_ID: '99',
+		GITHUB_RUN_ATTEMPT: '2',
+		DEPLOY_PR_NUMBER: '1799',
+		DEPLOY_PR_URL: 'https://github.com/kentcdodds/kody/pull/1799',
+		DEPLOY_PR_TITLE: 'Richer /health metadata',
+		DEPLOYED_AT: '2026-08-27T18:05:00Z',
+	})
+	expect(fromEnv.sha).toBe(commitSha)
+	expect(fromEnv.repoUrl).toBe('https://github.com/kentcdodds/kody')
+	expect(fromEnv.pullRequest).toEqual({
+		number: 1799,
+		url: 'https://github.com/kentcdodds/kody/pull/1799',
+		title: 'Richer /health metadata',
+	})
+
+	const info = await buildDeployInfo({
+		...fromEnv,
+		commit: {
+			message: 'feat: richer /health metadata (#1799)\n\nMore detail.',
+			committedAt: '2026-08-27T18:00:00Z',
+		},
+	})
+	expect(info).toEqual({
+		repoUrl: 'https://github.com/kentcdodds/kody',
+		commit: {
+			sha: commitSha,
+			message: 'feat: richer /health metadata (#1799)\n\nMore detail.',
+			committedAt: '2026-08-27T18:00:00Z',
+		},
+		pullRequest: fromEnv.pullRequest,
+		deploy: {
+			deployedAt: '2026-08-27T18:05:00Z',
+			environment: 'preview',
+			workflow: '🔎 Preview',
+			job: 'deploy',
+			runId: '99',
+			runUrl: 'https://github.com/kentcdodds/kody/actions/runs/99/attempts/2',
+		},
+	} satisfies DeployInfo)
+	expect(parseDeployInfo(encodeDeployInfo(info))).toEqual(info)
+
+	expect(
+		(
+			await buildDeployInfo({
+				sha: commitSha,
+				commit: {
+					message: 'squash merge without lookup (#42)',
+					committedAt: null,
+				},
+				pullRequest: null,
+				lookupPullRequests: async () => [],
+				now: '2026-08-27T18:05:00Z',
+			})
+		).pullRequest,
+	).toBeNull()
+
+	expect(
+		(
+			await buildDeployInfo({
+				sha: commitSha,
+				commit: {
+					message: 'squash merge without lookup (#42)',
+					committedAt: null,
+				},
+				lookupPullRequests: async () => [],
+				now: '2026-08-27T18:05:00Z',
+			})
+		).pullRequest,
+	).toEqual({
+		number: 42,
+		url: 'https://github.com/kentcdodds/kody/pull/42',
+		title: null,
+	})
+
+	expect(
+		(
+			await buildDeployInfo({
+				sha: commitSha,
+				commit: { message: 'no pr in message', committedAt: null },
+				lookupPullRequests: async () => [
+					{
+						number: 7,
+						url: 'https://github.com/kentcdodds/kody/pull/7',
+						title: 'From API',
+					},
+				],
+				now: '2026-08-27T18:05:00Z',
+			})
+		).pullRequest?.number,
+	).toBe(7)
+
+	expect(() => readDeployInfoInputFromEnv({})).toThrow(/DEPLOY_COMMIT_SHA/)
+})

--- a/tools/ci/build-deploy-info.ts
+++ b/tools/ci/build-deploy-info.ts
@@ -1,0 +1,245 @@
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+import { isExecutedDirectly } from '../node-runtime.ts'
+import {
+	defaultGithubRepoUrl,
+	encodeDeployInfo,
+	githubActionsRunUrl,
+	githubPullRequestUrl,
+	pullRequestNumberFromCommitMessage,
+	truncateCommitMessage,
+	type DeployInfo,
+	type DeployPullRequestInfo,
+} from '#worker/deploy-info.ts'
+
+const execFileAsync = promisify(execFile)
+
+export type BuildDeployInfoInput = {
+	sha: string
+	repoUrl?: string
+	environment?: string
+	workflow?: string | null
+	job?: string | null
+	runId?: string | null
+	runAttempt?: string | null
+	runUrl?: string | null
+	pullRequest?: DeployPullRequestInfo | null
+	commit?: {
+		message: string
+		committedAt: string | null
+	}
+	now?: string
+	githubApiUrl?: string
+	githubToken?: string
+	readCommit?: (sha: string) => Promise<{
+		message: string
+		committedAt: string | null
+	}>
+	lookupPullRequests?: (sha: string) => Promise<Array<DeployPullRequestInfo>>
+}
+
+export async function buildDeployInfo(
+	input: BuildDeployInfoInput,
+): Promise<DeployInfo> {
+	const repoUrl = trimOr(input.repoUrl, defaultGithubRepoUrl)
+	const commit =
+		input.commit ?? (await (input.readCommit ?? readGitCommit)(input.sha))
+	const message = truncateCommitMessage(commit.message)
+	const pullRequest =
+		input.pullRequest === undefined
+			? await resolvePullRequest({
+					sha: input.sha,
+					repoUrl,
+					message,
+					lookupPullRequests: input.lookupPullRequests,
+					githubApiUrl: input.githubApiUrl,
+					githubToken: input.githubToken,
+				})
+			: input.pullRequest
+	const runId = trimToNull(input.runId)
+	const runUrl =
+		trimToNull(input.runUrl) ??
+		(runId ? githubActionsRunUrl(repoUrl, runId, input.runAttempt) : null)
+	return {
+		repoUrl,
+		commit: {
+			sha: input.sha,
+			message,
+			committedAt: commit.committedAt,
+		},
+		pullRequest,
+		deploy: {
+			deployedAt: input.now ?? new Date().toISOString(),
+			environment: trimOr(input.environment, 'unknown'),
+			workflow: trimToNull(input.workflow),
+			job: trimToNull(input.job),
+			runId,
+			runUrl,
+		},
+	}
+}
+
+export function readDeployInfoInputFromEnv(
+	env: NodeJS.ProcessEnv,
+): BuildDeployInfoInput {
+	const sha = env.DEPLOY_COMMIT_SHA?.trim() || env.APP_COMMIT_SHA?.trim()
+	if (!sha) {
+		throw new Error(
+			'build-deploy-info requires DEPLOY_COMMIT_SHA or APP_COMMIT_SHA',
+		)
+	}
+	const serverUrl = trimOr(env.GITHUB_SERVER_URL, 'https://github.com')
+	const repository = env.GITHUB_REPOSITORY?.trim()
+	const repoUrl = repository
+		? `${trimTrailingSlash(serverUrl)}/${repository}`
+		: defaultGithubRepoUrl
+	const prNumber = parsePositiveInteger(env.DEPLOY_PR_NUMBER)
+	const prUrl =
+		env.DEPLOY_PR_URL?.trim() ||
+		(prNumber ? githubPullRequestUrl(repoUrl, prNumber) : null)
+	const pullRequest = prNumber
+		? {
+				number: prNumber,
+				url: prUrl ?? githubPullRequestUrl(repoUrl, prNumber),
+				title: env.DEPLOY_PR_TITLE?.trim() || null,
+			}
+		: undefined
+	return {
+		sha,
+		repoUrl,
+		environment: env.DEPLOY_ENVIRONMENT?.trim() || undefined,
+		workflow: env.GITHUB_WORKFLOW,
+		job: env.GITHUB_JOB,
+		runId: env.GITHUB_RUN_ID,
+		runAttempt: env.GITHUB_RUN_ATTEMPT,
+		runUrl: env.DEPLOY_RUN_URL,
+		pullRequest,
+		now: env.DEPLOYED_AT,
+		githubApiUrl: env.GITHUB_API_URL,
+		githubToken: env.GITHUB_TOKEN ?? env.GH_TOKEN,
+	}
+}
+
+async function resolvePullRequest(input: {
+	sha: string
+	repoUrl: string
+	message: string
+	lookupPullRequests?: BuildDeployInfoInput['lookupPullRequests']
+	githubApiUrl?: string
+	githubToken?: string
+}): Promise<DeployPullRequestInfo | null> {
+	const lookedUp = await (
+		input.lookupPullRequests ??
+		((sha: string) =>
+			lookupGithubPullRequests({
+				sha,
+				repoUrl: input.repoUrl,
+				apiUrl: input.githubApiUrl,
+				token: input.githubToken,
+			}))
+	)(input.sha)
+	if (lookedUp[0]) return lookedUp[0]
+	const number = pullRequestNumberFromCommitMessage(input.message)
+	if (!number) return null
+	return {
+		number,
+		url: githubPullRequestUrl(input.repoUrl, number),
+		title: null,
+	}
+}
+
+async function lookupGithubPullRequests(input: {
+	sha: string
+	repoUrl: string
+	apiUrl?: string
+	token?: string
+}): Promise<Array<DeployPullRequestInfo>> {
+	const repository = repositoryFromRepoUrl(input.repoUrl)
+	if (!repository || !input.token) return []
+	const apiUrl = trimOr(input.apiUrl, 'https://api.github.com')
+	try {
+		const response = await fetch(
+			`${trimTrailingSlash(apiUrl)}/repos/${repository}/commits/${input.sha}/pulls`,
+			{
+				headers: {
+					Accept: 'application/vnd.github+json',
+					Authorization: `Bearer ${input.token}`,
+					'X-GitHub-Api-Version': '2022-11-28',
+				},
+			},
+		)
+		if (!response.ok) return []
+		const payload: unknown = await response.json()
+		if (!Array.isArray(payload)) return []
+		return payload.flatMap((entry) => {
+			if (!isRecord(entry)) return []
+			if (typeof entry.number !== 'number') return []
+			if (typeof entry.html_url !== 'string') return []
+			return [
+				{
+					number: entry.number,
+					url: entry.html_url,
+					title: typeof entry.title === 'string' ? entry.title : null,
+				},
+			]
+		})
+	} catch {
+		return []
+	}
+}
+
+async function readGitCommit(sha: string) {
+	const { stdout } = await execFileAsync('git', [
+		'show',
+		'-s',
+		'--format=%cI%n%B',
+		sha,
+	])
+	const [committedAt, ...messageLines] = stdout.split('\n')
+	return {
+		committedAt: committedAt?.trim() || null,
+		message: messageLines.join('\n').trim(),
+	}
+}
+
+function repositoryFromRepoUrl(repoUrl: string) {
+	try {
+		const url = new URL(repoUrl)
+		return url.pathname.replace(/^\//, '').replace(/\.git$/, '')
+	} catch {
+		return null
+	}
+}
+
+function parsePositiveInteger(value: string | undefined) {
+	if (!value?.trim()) return null
+	const number = Number(value)
+	return Number.isInteger(number) && number > 0 ? number : null
+}
+
+function trimOr(value: string | undefined, fallback: string) {
+	const trimmed = value?.trim()
+	return trimmed ? trimmed : fallback
+}
+
+function trimToNull(value: string | null | undefined) {
+	const trimmed = value?.trim()
+	return trimmed ? trimmed : null
+}
+
+function trimTrailingSlash(value: string) {
+	return value.endsWith('/') ? value.slice(0, -1) : value
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null
+}
+
+export async function main() {
+	const info = await buildDeployInfo(readDeployInfoInputFromEnv(process.env))
+	process.stdout.write(encodeDeployInfo(info))
+}
+
+if (isExecutedDirectly(import.meta.url)) {
+	await main()
+}


### PR DESCRIPTION
## Summary
- `GET /health` keeps `ok` and `commitSha` for deploy healthchecks, and adds commit message/date, commit and PR links, and deploy-job metadata.
- Production and preview deploys collect that metadata at deploy time and pass it as `APP_DEPLOY_INFO` (base64url JSON) so wrangler `--var` quoting cannot break on commit messages.
- Browsers that prefer HTML get a small page with clickable commit, PR, and Actions links.

## Test plan
- [ ] Unit tests: `deploy-info`, health handler (JSON + HTML), `build-deploy-info`
- [ ] Preview `/health` JSON includes `commitSha` matching the deploy SHA, plus `commit.url`, `commit.message`, `deploy.runUrl`, and a `pullRequest` link
- [ ] Open preview `/health` in a browser and click the commit/PR/job links
- [ ] Local `curl /health` still returns `{ ok: true, commitSha: null, ...null fields }`
- [ ] Production healthcheck still pins on `json.ok === true` and `json.commitSha`

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `79f0c002` · **Head:** `48c709bb`

**Classification:** extends — `GET /health` grows an additive JSON/HTML contract, and deploy workflows inject a new public Wrangler var.

### Primitives touched

| Primitive | Group    | Impact                                                             |
| --------- | -------- | ------------------------------------------------------------------ |
| `app-ui`  | surfaces | extends — origin `/health` reports commit, PR, and deploy metadata |

Unmatched paths are deploy/preview workflow wiring, env schema, and the shared `deploy-info` codec used by those workflows.

### Change flow

Production and preview deploys bake git/GitHub metadata into the origin worker; `/health` decodes it for operators.

```mermaid
sequenceDiagram
	actor DeployCI
	actor Operator
	participant appUi as app-ui
	DeployCI->>appUi: --var APP_COMMIT_SHA and APP_DEPLOY_INFO
	Note over appUi: APP_DEPLOY_INFO is base64url JSON
	Operator->>appUi: GET /health
	appUi-->>Operator: commitSha plus commit, PR, and deploy links
```

### Before / after

```
{ ok: true, commitSha }
```

```
{ ok: true, commitSha, commit, pullRequest, deploy }
```

`commitSha` remains the version pin for post-deploy healthchecks. Deploy metadata is ignored when its SHA does not match `APP_COMMIT_SHA`.

</details>

<!-- system-recap:end -->

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Health checks now show deployment details, including commit, pull request, and deployment job information.
  * Health checks support JSON responses and browser-friendly HTML with clickable links.
  * Deployment metadata is automatically included in production and preview deployments.
  * Invalid or missing deployment metadata is safely ignored.

* **Documentation**
  * Expanded guidance for health-check responses and deployment metadata configuration.

* **Tests**
  * Added coverage for health reports, deployment metadata, response formats, and deployment information generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
