### PR TITLE
Explain secret scope misses instead of a bare not-found

### DIFF
--- a/packages/shared/src/account-secret-route.node.test.ts
+++ b/packages/shared/src/account-secret-route.node.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from 'vitest'
 import {
 	buildAccountSecretPath,
+	buildAccountSecretUrl,
 	parseAccountSecretPath,
 } from './account-secret-route.ts'
 
@@ -46,6 +47,33 @@ test('account secret paths encode route segments and round-trip through the pars
 		sessionId: null,
 		name: 'google.api.key',
 	})
+
+	const grokBotWakeName = 'grokBotWake.71e7550e-746d-417f-b253-05165975ff69'
+	const grokBotWakePath = buildAccountSecretPath({
+		scope: 'user',
+		name: grokBotWakeName,
+	})
+	expect(grokBotWakePath).toBe(
+		'/account/secrets/user/grokBotWake%2E71e7550e-746d-417f-b253-05165975ff69',
+	)
+	expect(grokBotWakePath).not.toContain(`/${grokBotWakeName}`)
+	expect(parseAccountSecretPath(grokBotWakePath)).toEqual({
+		id: `user::::${grokBotWakeName}`,
+		scope: 'user',
+		packageId: null,
+		sessionId: null,
+		name: grokBotWakeName,
+	})
+
+	const grokBotWakeUrl = buildAccountSecretUrl({
+		baseUrl: 'https://kody.codes',
+		scope: 'user',
+		name: grokBotWakeName,
+	})
+	expect(grokBotWakeUrl).toBe(
+		'https://kody.codes/account/secrets/user/grokBotWake%2E71e7550e-746d-417f-b253-05165975ff69',
+	)
+	expect(grokBotWakeUrl).not.toContain(`user/${grokBotWakeName}`)
 })
 
 test('account secret paths fail fast when scope binding ids are missing', () => {

--- a/packages/shared/src/account-secret-route.ts
+++ b/packages/shared/src/account-secret-route.ts
@@ -86,6 +86,23 @@ export function buildAccountSecretPath(input: AccountSecretRouteIdInput) {
 	})
 }
 
+/**
+ * Absolute account-secret URL that keeps Remix path encoding.
+ *
+ * `createHref` encodes `.` as `%2E` because Remix treats `.` as a route
+ * delimiter. `new URL(pathname, baseUrl).toString()` decodes that unreserved
+ * escape back to `.`, and the account secret route 404s.
+ */
+export function buildAccountSecretUrl(
+	input: AccountSecretRouteIdInput & { baseUrl: string },
+) {
+	return joinOriginAndEncodedPath(input.baseUrl, buildAccountSecretPath(input))
+}
+
+export function joinOriginAndEncodedPath(baseUrl: string, pathname: string) {
+	return `${new URL(baseUrl).origin}${pathname}`
+}
+
 export function parseAccountSecretPath(
 	pathname: string,
 ): ParsedAccountSecretRoutePath | null {

--- a/packages/worker/src/mcp/capabilities/secrets/jwt-sign.ts
+++ b/packages/worker/src/mcp/capabilities/secrets/jwt-sign.ts
@@ -4,10 +4,8 @@ import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
 import { type CapabilityContext } from '#mcp/capabilities/types.ts'
 import { buildSecretCapabilityApprovalUrl } from '#mcp/secrets/capability-approval-url.ts'
-import {
-	createCapabilitySecretAccessDeniedMessage,
-	createMissingSecretMessage,
-} from '#mcp/secrets/errors.ts'
+import { createCapabilitySecretAccessDeniedMessage } from '#mcp/secrets/errors.ts'
+import { createUnresolvedSecretMessage } from '#mcp/secrets/unresolved-secret.ts'
 import { assertPackageCanAccessResolvedSecret } from '#mcp/secrets/package-access.ts'
 import { resolveSecret } from '#mcp/secrets/service.ts'
 import { secretScopeValues } from '#mcp/secrets/types.ts'
@@ -88,7 +86,14 @@ export const jwtSignCapability = defineDomainCapability(
 			})
 			if (!resolved.found || typeof resolved.value !== 'string') {
 				throw new Error(
-					createMissingSecretMessage(args.private_key_secret_name),
+					await createUnresolvedSecretMessage({
+						env: ctx.env,
+						userId: user.userId,
+						name: args.private_key_secret_name,
+						scope: args.private_key_secret_scope,
+						storageContext,
+						baseUrl: ctx.callerContext.baseUrl,
+					}),
 				)
 			}
 			await assertPackageCanAccessResolvedSecret({

--- a/packages/worker/src/mcp/executor.node.test.ts
+++ b/packages/worker/src/mcp/executor.node.test.ts
@@ -6,6 +6,7 @@ import {
 	createHostSecretAccessDeniedBatchMessage,
 	createMissingSecretMessage,
 	createPackageSecretAccessDeniedBatchMessage,
+	createSecretScopeUnavailableMessage,
 } from '#mcp/secrets/errors.ts'
 import { createKodyProviderProxySource } from '#mcp/kody-provider-proxy-source.ts'
 import { EntitlementLimitError } from '#worker/entitlements/errors.ts'
@@ -1599,6 +1600,50 @@ test('executor maps secret errors, formats guidance, extracts raw content, and t
 			{ secretName: 'xAccessToken', packageId: 'pkg-1' },
 		],
 	})
+
+	const missingSecretError = new Error(
+		createMissingSecretMessage('missingToken'),
+	)
+	expect(getExecutionErrorDetails(missingSecretError)).toMatchObject({
+		kind: 'secret_required',
+		secretNames: ['missingToken'],
+		suggestedAction: {
+			type: 'connect_secret',
+			reason: 'collect_secret',
+		},
+	})
+
+	const scopeUnavailableError = new Error(
+		createSecretScopeUnavailableMessage([
+			{
+				secretName: 'discordBotToken',
+				scope: 'package',
+				packageId: 'pkg-1',
+				packageName: 'discord-gateway',
+				sessionId: null,
+				editorUrl:
+					'https://example.com/account/secrets/package/pkg-1/discordBotToken',
+			},
+		]),
+	)
+	expect(getExecutionErrorDetails(scopeUnavailableError)).toMatchObject({
+		kind: 'secret_scope_unavailable',
+		secretNames: ['discordBotToken'],
+		scope: 'package',
+		packageName: 'discord-gateway',
+		editorUrl:
+			'https://example.com/account/secrets/package/pkg-1/discordBotToken',
+		suggestedAction: {
+			type: 'edit_secret_policy',
+			policyField: 'scope',
+		},
+	})
+	expect(getExecutionErrorDetails(scopeUnavailableError)?.nextStep).toContain(
+		'invoke the work through that package',
+	)
+	expect(
+		formatExecutionOutput({ error: scopeUnavailableError } as const),
+	).toContain('Editor link:')
 
 	const entitlementError = new EntitlementLimitError({
 		resource: 'saved_packages',

--- a/packages/worker/src/mcp/executor.node.test.ts
+++ b/packages/worker/src/mcp/executor.node.test.ts
@@ -1631,12 +1631,31 @@ test('executor maps secret errors, formats guidance, extracts raw content, and t
 		secretNames: ['discordBotToken'],
 		scope: 'package',
 		packageName: 'discord-gateway',
+		packageId: null,
 		editorUrl:
 			'https://example.com/account/secrets/package/pkg-1/discordBotToken',
 		suggestedAction: {
 			type: 'edit_secret_policy',
 			policyField: 'scope',
 		},
+	})
+	const packageIdOnlyError = new Error(
+		createSecretScopeUnavailableMessage([
+			{
+				secretName: 'discordBotToken',
+				scope: 'package',
+				packageId: 'pkg-1',
+				packageName: null,
+				sessionId: null,
+				editorUrl:
+					'https://example.com/account/secrets/package/pkg-1/discordBotToken',
+			},
+		]),
+	)
+	expect(getExecutionErrorDetails(packageIdOnlyError)).toMatchObject({
+		kind: 'secret_scope_unavailable',
+		packageName: null,
+		packageId: 'pkg-1',
 	})
 	expect(getExecutionErrorDetails(scopeUnavailableError)?.nextStep).toContain(
 		'invoke the work through that package',

--- a/packages/worker/src/mcp/executor.ts
+++ b/packages/worker/src/mcp/executor.ts
@@ -34,7 +34,9 @@ import {
 	parseMissingSecretMessage,
 	parsePackageAccessRequiredBatchMessage,
 	parsePackageAccessRequiredMessage,
+	parseSecretScopeUnavailableMessage,
 } from '#mcp/secrets/errors.ts'
+import { type SecretScope } from '#mcp/secrets/types.ts'
 import {
 	isEntitlementLimitError,
 	parseEntitlementLimitMessage,
@@ -1196,6 +1198,19 @@ export type ExecutionErrorDetails =
 			}
 	  }
 	| {
+			kind: 'secret_scope_unavailable'
+			message: string
+			nextStep: string
+			secretNames: Array<string>
+			scope: SecretScope
+			packageName: string | null
+			editorUrl: string | null
+			suggestedAction: {
+				type: 'edit_secret_policy'
+				policyField: 'scope'
+			}
+	  }
+	| {
 			kind: 'secret_required'
 			message: string
 			nextStep: string
@@ -1436,6 +1451,27 @@ export function getExecutionErrorDetails(
 			suggestedAction: {
 				type: 'edit_secret_policy',
 				policyField: 'allowed_packages',
+			},
+		}
+	}
+
+	const scopeUnavailableDetails = parseSecretScopeUnavailableMessage(message)
+	if (scopeUnavailableDetails) {
+		const editorUrl = extractFirstUrl(message)
+		return {
+			kind: 'secret_scope_unavailable',
+			message,
+			nextStep:
+				scopeUnavailableDetails.scope === 'package'
+					? 'This secret exists on a package this runtime cannot see. Either invoke the work through that package, or send the user the editor link so they can change the secret scope, then retry.'
+					: 'This secret exists in another scope this runtime cannot see. Send the user the editor link so they can change the secret scope, or retry from a runtime that can see it.',
+			secretNames: [scopeUnavailableDetails.secretName],
+			scope: scopeUnavailableDetails.scope,
+			packageName: scopeUnavailableDetails.packageName,
+			editorUrl,
+			suggestedAction: {
+				type: 'edit_secret_policy',
+				policyField: 'scope',
 			},
 		}
 	}

--- a/packages/worker/src/mcp/executor.ts
+++ b/packages/worker/src/mcp/executor.ts
@@ -1204,6 +1204,7 @@ export type ExecutionErrorDetails =
 			secretNames: Array<string>
 			scope: SecretScope
 			packageName: string | null
+			packageId: string | null
 			editorUrl: string | null
 			suggestedAction: {
 				type: 'edit_secret_policy'
@@ -1468,6 +1469,7 @@ export function getExecutionErrorDetails(
 			secretNames: [scopeUnavailableDetails.secretName],
 			scope: scopeUnavailableDetails.scope,
 			packageName: scopeUnavailableDetails.packageName,
+			packageId: scopeUnavailableDetails.packageId,
 			editorUrl,
 			suggestedAction: {
 				type: 'edit_secret_policy',

--- a/packages/worker/src/mcp/fetch-gateway.node.test.ts
+++ b/packages/worker/src/mcp/fetch-gateway.node.test.ts
@@ -39,6 +39,9 @@ const env = {
 							}
 							return null
 						},
+						async all() {
+							return { results: [], meta: { changes: 0 } }
+						},
 					}
 				},
 			}

--- a/packages/worker/src/mcp/fetch-gateway.ts
+++ b/packages/worker/src/mcp/fetch-gateway.ts
@@ -19,6 +19,7 @@ import {
 	createMissingSecretMessage,
 	fetchSecretAuthRequiredMessage,
 } from '#mcp/secrets/errors.ts'
+import { createUnresolvedSecretMessage } from '#mcp/secrets/unresolved-secret.ts'
 import { normalizeHost } from '#mcp/secrets/allowed-hosts.ts'
 import { resolveSecret, type ResolvedSecret } from '#mcp/secrets/service.ts'
 import { assertPackageCanAccessResolvedSecret } from '#mcp/secrets/package-access.ts'
@@ -352,7 +353,16 @@ export async function expandSecretPlaceholders(input: {
 				storageContext: input.props.storageContext,
 			})
 			if (!resolved.found || typeof resolved.value !== 'string') {
-				throw new Error(createMissingSecretMessage(referenced.name))
+				throw new Error(
+					await createUnresolvedSecretMessage({
+						env: input.env,
+						userId: input.props.userId!,
+						name: referenced.name,
+						scope: referenced.scope,
+						storageContext: input.props.storageContext,
+						baseUrl: input.props.baseUrl,
+					}),
+				)
 			}
 			const owningIntegration =
 				resolved.scope === 'user'

--- a/packages/worker/src/mcp/run-kody-registry.ts
+++ b/packages/worker/src/mcp/run-kody-registry.ts
@@ -25,8 +25,8 @@ import {
 	capabilityInputSecretAuthRequiredMessage,
 	createCapabilitySecretAccessDeniedMessage,
 	createCapabilitySecretAccessDeniedBatchMessage,
-	createMissingSecretMessage,
 } from '#mcp/secrets/errors.ts'
+import { createUnresolvedSecretMessage } from '#mcp/secrets/unresolved-secret.ts'
 import {
 	assertPackageCanAccessResolvedSecret,
 	resolvePackageMountedSecret,
@@ -564,7 +564,16 @@ function createCapabilityInputSecretResolver(
 			storageContext: normalizedStorageContext,
 		})
 		if (!resolved.found || typeof resolved.value !== 'string') {
-			throw new Error(createMissingSecretMessage(secret.name))
+			throw new Error(
+				await createUnresolvedSecretMessage({
+					env,
+					userId,
+					name: secret.name,
+					scope: secret.scope,
+					storageContext: normalizedStorageContext,
+					baseUrl: callerContext.baseUrl,
+				}),
+			)
 		}
 		await assertPackageCanAccessResolvedSecret({
 			env,

--- a/packages/worker/src/mcp/secrets/capability-approval-url.ts
+++ b/packages/worker/src/mcp/secrets/capability-approval-url.ts
@@ -1,4 +1,7 @@
-import { buildAccountSecretPath } from '@kody-internal/shared/account-secret-route.ts'
+import {
+	buildAccountSecretPath,
+	joinOriginAndEncodedPath,
+} from '@kody-internal/shared/account-secret-route.ts'
 import { type StorageContext } from '#mcp/storage.ts'
 import { type SecretScope } from './types.ts'
 
@@ -15,7 +18,7 @@ export function buildSecretCapabilityApprovalUrl(input: {
 		packageId: input.storageContext?.packageId ?? null,
 		sessionId: input.storageContext?.sessionId ?? null,
 	})
-	const url = new URL(secretPath, input.baseUrl)
-	url.searchParams.set('capability', input.capabilityName)
-	return url.toString()
+	const search = new URLSearchParams()
+	search.set('capability', input.capabilityName)
+	return `${joinOriginAndEncodedPath(input.baseUrl, secretPath)}?${search}`
 }

--- a/packages/worker/src/mcp/secrets/errors.node.test.ts
+++ b/packages/worker/src/mcp/secrets/errors.node.test.ts
@@ -106,6 +106,25 @@ test('secret error message helpers parse auth, missing-secret, and approval payl
 		secretName: 'discordBotToken',
 		scope: 'package',
 		packageName: 'discord-gateway',
+		packageId: null,
+	})
+	const packageIdOnlyMessage = createSecretScopeUnavailableMessage([
+		{
+			secretName: 'discordBotToken',
+			scope: 'package',
+			packageId: 'pkg-1',
+			packageName: null,
+			sessionId: null,
+			editorUrl:
+				'https://example.com/account/secrets/package/pkg-1/discordBotToken',
+		},
+	])
+	expect(packageIdOnlyMessage).toContain('package id "pkg-1"')
+	expect(parseSecretScopeUnavailableMessage(packageIdOnlyMessage)).toEqual({
+		secretName: 'discordBotToken',
+		scope: 'package',
+		packageName: null,
+		packageId: 'pkg-1',
 	})
 	expect(parseMissingSecretMessage(scopeUnavailableMessage)).toBeNull()
 	expect(

--- a/packages/worker/src/mcp/secrets/errors.node.test.ts
+++ b/packages/worker/src/mcp/secrets/errors.node.test.ts
@@ -4,11 +4,13 @@ import {
 	createCapabilitySecretAccessDeniedBatchMessage,
 	createHostSecretAccessDeniedBatchMessage,
 	createMissingSecretMessage,
+	createSecretScopeUnavailableMessage,
 	parseCapabilityAccessRequiredBatchMessage,
 	parseCapabilityAccessRequiredMessage,
 	parseHostApprovalRequiredBatchMessage,
 	parseHostApprovalRequiredMessage,
 	parseMissingSecretMessage,
+	parseSecretScopeUnavailableMessage,
 } from './errors.ts'
 
 test('secret error message helpers parse auth, missing-secret, and approval payloads', () => {
@@ -82,4 +84,37 @@ test('secret error message helpers parse auth, missing-secret, and approval payl
 			createHostSecretAccessDeniedBatchMessage(hostEntries),
 		),
 	).toEqual(hostEntries)
+
+	const scopeUnavailableMessage = createSecretScopeUnavailableMessage([
+		{
+			secretName: 'discordBotToken',
+			scope: 'package',
+			packageId: 'pkg-1',
+			packageName: 'discord-gateway',
+			sessionId: null,
+			editorUrl:
+				'https://example.com/account/secrets/package/pkg-1/discordBotToken',
+		},
+	])
+	expect(scopeUnavailableMessage).toContain(
+		'Either invoke this work through the owning package',
+	)
+	expect(scopeUnavailableMessage).toContain(
+		'https://example.com/account/secrets/package/pkg-1/discordBotToken',
+	)
+	expect(parseSecretScopeUnavailableMessage(scopeUnavailableMessage)).toEqual({
+		secretName: 'discordBotToken',
+		scope: 'package',
+		packageName: 'discord-gateway',
+	})
+	expect(parseMissingSecretMessage(scopeUnavailableMessage)).toBeNull()
+	expect(
+		parseCapabilityAccessRequiredMessage(scopeUnavailableMessage),
+	).toBeNull()
+	expect(
+		parseSecretScopeUnavailableMessage(
+			createMissingSecretMessage('discordBotToken'),
+		),
+	).toBeNull()
+	expect(parseSecretScopeUnavailableMessage(capabilityMessage)).toBeNull()
 })

--- a/packages/worker/src/mcp/secrets/errors.ts
+++ b/packages/worker/src/mcp/secrets/errors.ts
@@ -11,7 +11,7 @@ const hostBatchDeniedPrefix = 'Secrets require host approval:'
 const packageBatchDeniedPrefix = 'Secrets require package approval:'
 const missingSecretRegex = /^Secret "([^"]+)" was not found\.$/
 const secretScopeUnavailableRegex =
-	/^Secret "([^"]+)" exists in (session|package|user) scope(?: for package(?: id)? "([^"]+)")?/
+	/^Secret "([^"]+)" exists in (session|package|user) scope(?: for package( id)? "([^"]+)")?/
 
 export const fetchSecretAuthRequiredMessage =
 	'Network requests that use secret placeholders require an authenticated user.'
@@ -280,10 +280,13 @@ export function parseSecretScopeUnavailableMessage(message: string) {
 	if (!match?.[1] || !match[2]) return null
 	const scope = parseSecretErrorScope(match[2])
 	if (!scope) return null
+	const label = match[4] ?? null
+	const usesPackageId = Boolean(match[3])
 	return {
 		secretName: match[1],
 		scope,
-		packageName: match[3] ?? null,
+		packageName: usesPackageId ? null : label,
+		packageId: usesPackageId ? label : null,
 	}
 }
 

--- a/packages/worker/src/mcp/secrets/errors.ts
+++ b/packages/worker/src/mcp/secrets/errors.ts
@@ -1,3 +1,5 @@
+import { type SecretScope } from './types.ts'
+
 const hostApprovalRequiredRegex =
 	/^Secret "([^"]+)" is not allowed for host "([^"]+)"/
 const capabilityAccessRequiredRegex =
@@ -8,6 +10,8 @@ const capabilityBatchDeniedPrefix = 'Secrets require capability approval:'
 const hostBatchDeniedPrefix = 'Secrets require host approval:'
 const packageBatchDeniedPrefix = 'Secrets require package approval:'
 const missingSecretRegex = /^Secret "([^"]+)" was not found\.$/
+const secretScopeUnavailableRegex =
+	/^Secret "([^"]+)" exists in (session|package|user) scope(?: for package(?: id)? "([^"]+)")?/
 
 export const fetchSecretAuthRequiredMessage =
 	'Network requests that use secret placeholders require an authenticated user.'
@@ -22,6 +26,56 @@ const secretAuthRequiredMessages = new Set([
 
 export function createMissingSecretMessage(secretName: string) {
 	return `Secret "${secretName}" was not found.`
+}
+
+export type SecretScopeUnavailableMatch = {
+	secretName: string
+	scope: SecretScope
+	packageId: string | null
+	packageName: string | null
+	sessionId: string | null
+	editorUrl: string | null
+}
+
+function describeSecretScopeLocation(match: SecretScopeUnavailableMatch) {
+	switch (match.scope) {
+		case 'package':
+			if (match.packageName) {
+				return `package scope for package "${match.packageName}"`
+			}
+			if (match.packageId) {
+				return `package scope for package id "${match.packageId}"`
+			}
+			return 'package scope'
+		case 'session':
+			return 'session scope'
+		case 'user':
+			return 'user scope'
+		default: {
+			const _exhaustive: never = match.scope
+			return _exhaustive
+		}
+	}
+}
+
+export function createSecretScopeUnavailableMessage(
+	matches: Array<SecretScopeUnavailableMatch>,
+) {
+	const [first, ...rest] = matches
+	if (!first) {
+		throw new Error('At least one secret scope match is required.')
+	}
+	const extra =
+		rest.length === 0
+			? ''
+			: ` It also exists in ${rest.map(describeSecretScopeLocation).join(', ')}.`
+	const hasPackageMatch = matches.some((match) => match.scope === 'package')
+	const guidance = hasPackageMatch
+		? " Package-scoped secrets are only available while that package runs. Either invoke this work through the owning package, or ask the user to change the secret's scope in the account secrets UI."
+		: " Ask the user to change the secret's scope in the account secrets UI, or retry from a runtime that can see this scope."
+	const editorUrl = matches.find((match) => match.editorUrl)?.editorUrl ?? null
+	const editorSuffix = editorUrl ? ` Editor link: ${editorUrl}` : ''
+	return `Secret "${first.secretName}" exists in ${describeSecretScopeLocation(first)} and is not visible from this runtime.${extra}${guidance}${editorSuffix}`
 }
 
 export function createCapabilitySecretAccessDeniedMessage(
@@ -207,6 +261,29 @@ export function parseMissingSecretMessage(message: string) {
 	if (!match?.[1]) return null
 	return {
 		secretName: match[1],
+	}
+}
+
+function parseSecretErrorScope(value: string): SecretScope | null {
+	switch (value) {
+		case 'session':
+		case 'package':
+		case 'user':
+			return value
+		default:
+			return null
+	}
+}
+
+export function parseSecretScopeUnavailableMessage(message: string) {
+	const match = message.match(secretScopeUnavailableRegex)
+	if (!match?.[1] || !match[2]) return null
+	const scope = parseSecretErrorScope(match[2])
+	if (!scope) return null
+	return {
+		secretName: match[1],
+		scope,
+		packageName: match[3] ?? null,
 	}
 }
 

--- a/packages/worker/src/mcp/secrets/host-approval.ts
+++ b/packages/worker/src/mcp/secrets/host-approval.ts
@@ -1,4 +1,7 @@
-import { buildAccountSecretPath } from '@kody-internal/shared/account-secret-route.ts'
+import {
+	buildAccountSecretPath,
+	joinOriginAndEncodedPath,
+} from '@kody-internal/shared/account-secret-route.ts'
 import { type StorageContext } from '#mcp/storage.ts'
 import { normalizeHost } from './allowed-hosts.ts'
 import { type SecretScope } from './types.ts'
@@ -16,7 +19,7 @@ export function buildSecretHostApprovalUrl(input: {
 		packageId: input.storageContext?.packageId ?? null,
 		sessionId: input.storageContext?.sessionId ?? null,
 	})
-	const url = new URL(secretPath, input.baseUrl)
-	url.searchParams.set('allowed-host', normalizeHost(input.requestedHost))
-	return url.toString()
+	const search = new URLSearchParams()
+	search.set('allowed-host', normalizeHost(input.requestedHost))
+	return `${joinOriginAndEncodedPath(input.baseUrl, secretPath)}?${search}`
 }

--- a/packages/worker/src/mcp/secrets/package-access.ts
+++ b/packages/worker/src/mcp/secrets/package-access.ts
@@ -5,10 +5,10 @@ import {
 	buildSecretPackageBulkApprovalUrlIfNeeded,
 } from './package-approval-url.ts'
 import {
-	createMissingSecretMessage,
 	createPackageSecretAccessDeniedBatchMessage,
 	createPackageSecretAccessDeniedMessage,
 } from './errors.ts'
+import { createUnresolvedSecretMessage } from './unresolved-secret.ts'
 import { resolveSecret, type ResolvedSecret } from './service.ts'
 import { type SecretScope } from './types.ts'
 import { type StorageContext } from '#mcp/storage.ts'
@@ -285,7 +285,21 @@ export async function resolvePackageMountedSecret(input: {
 		},
 	})
 	if (!resolved.found || typeof resolved.value !== 'string') {
-		throw new PackageSecretMissingError(createMissingSecretMessage(mount.name))
+		throw new PackageSecretMissingError(
+			await createUnresolvedSecretMessage({
+				env: input.env,
+				userId,
+				name: mount.name,
+				scope: mount.scope,
+				storageContext: {
+					sessionId: input.callerContext.storageContext?.sessionId ?? null,
+					appId: input.callerContext.storageContext?.appId ?? null,
+					packageId: input.callerContext.storageContext?.packageId ?? null,
+					storageId: input.callerContext.storageContext?.storageId ?? null,
+				},
+				baseUrl: input.callerContext.baseUrl,
+			}),
+		)
 	}
 	await assertPackageCanAccessResolvedSecret({
 		env: input.env,

--- a/packages/worker/src/mcp/secrets/package-approval-url.node.test.ts
+++ b/packages/worker/src/mcp/secrets/package-approval-url.node.test.ts
@@ -19,6 +19,18 @@ test('buildSecretPackageApprovalUrl keeps the single-secret detail path', () => 
 	).toBe(
 		'https://example.com/account/secrets/user/discordBotToken?package_id=pkg-1&package=release',
 	)
+	expect(
+		buildSecretPackageApprovalUrl({
+			baseUrl: 'https://kody.codes',
+			name: 'grokBotWake.71e7550e-746d-417f-b253-05165975ff69',
+			scope: 'user',
+			packageId: 'pkg-1',
+			kodyId: 'release',
+			storageContext: null,
+		}),
+	).toBe(
+		'https://kody.codes/account/secrets/user/grokBotWake%2E71e7550e-746d-417f-b253-05165975ff69?package_id=pkg-1&package=release',
+	)
 })
 
 test('bulk package approval URL lists unique secret names on the approve route', () => {

--- a/packages/worker/src/mcp/secrets/package-approval-url.ts
+++ b/packages/worker/src/mcp/secrets/package-approval-url.ts
@@ -1,4 +1,7 @@
-import { buildAccountSecretPath } from '@kody-internal/shared/account-secret-route.ts'
+import {
+	buildAccountSecretPath,
+	joinOriginAndEncodedPath,
+} from '@kody-internal/shared/account-secret-route.ts'
 import { type StorageContext } from '#mcp/storage.ts'
 import { type SecretScope } from './types.ts'
 
@@ -30,12 +33,12 @@ export function buildSecretPackageApprovalUrl(input: {
 		packageId: input.storageContext?.packageId ?? null,
 		sessionId: input.storageContext?.sessionId ?? null,
 	})
-	const url = new URL(secretPath, input.baseUrl)
-	url.searchParams.set('package_id', input.packageId)
+	const search = new URLSearchParams()
+	search.set('package_id', input.packageId)
 	if (input.kodyId) {
-		url.searchParams.set('package', input.kodyId)
+		search.set('package', input.kodyId)
 	}
-	return url.toString()
+	return `${joinOriginAndEncodedPath(input.baseUrl, secretPath)}?${search}`
 }
 
 export function normalizeBulkPackageSecretApprovalNames(names: Array<string>) {

--- a/packages/worker/src/mcp/secrets/repo.ts
+++ b/packages/worker/src/mcp/secrets/repo.ts
@@ -362,6 +362,48 @@ export async function listUserScopeSecretMetadata(input: {
 	return (results ?? []).map(mapSecretMetadataRow)
 }
 
+export type SecretLocationRow = {
+	scope: SecretScope
+	binding_key: string
+	name: string
+	expires_at: string | null
+}
+
+/**
+ * Same-user locations for a secret name across every scope/binding. Does not
+ * return ciphertext. Used to distinguish a true miss from a scope the current
+ * runtime cannot see.
+ */
+export async function listSecretLocationsByNameForUser(input: {
+	db: D1Database
+	userId: string
+	name: string
+	now?: string
+}): Promise<Array<SecretLocationRow>> {
+	const now = input.now ?? new Date().toISOString()
+	const { results } = await input.db
+		.prepare(
+			`SELECT b.scope, b.binding_key, e.name, e.expires_at AS entry_expires_at, b.expires_at AS bucket_expires_at
+			FROM secret_buckets b
+			JOIN secret_entries e ON e.bucket_id = b.id
+			WHERE b.user_id = ? AND e.name = ?
+				AND (b.expires_at IS NULL OR b.expires_at > ?)
+				AND (e.expires_at IS NULL OR e.expires_at > ?)
+			ORDER BY b.scope ASC, b.binding_key ASC`,
+		)
+		.bind(input.userId, input.name, now, now)
+		.all<Record<string, unknown>>()
+	return (results ?? []).map((row) => {
+		const mapped = mapSecretMetadataRow(row)
+		return {
+			scope: mapped.scope,
+			binding_key: mapped.binding_key,
+			name: mapped.name,
+			expires_at: mapped.expires_at,
+		}
+	})
+}
+
 export async function listPackageScopeSecretMetadata(input: {
 	db: D1Database
 	userId: string

--- a/packages/worker/src/mcp/secrets/service.node.test.ts
+++ b/packages/worker/src/mcp/secrets/service.node.test.ts
@@ -1104,7 +1104,8 @@ test('createUnresolvedSecretMessage explains a package-scoped secret from ad-hoc
 	expect(parseSecretScopeUnavailableMessage(executeMiss)).toEqual({
 		secretName,
 		scope: 'package',
-		packageName: packageId,
+		packageName: null,
+		packageId,
 	})
 	expect(executeMiss).toContain(
 		`https://example.com/account/secrets/package/${packageId}/${secretName}`,

--- a/packages/worker/src/mcp/secrets/service.node.test.ts
+++ b/packages/worker/src/mcp/secrets/service.node.test.ts
@@ -5,6 +5,10 @@ import { planLimits } from '#universal/plans.ts'
 import { createStableUserIdFromEmail } from '#worker/user-id.ts'
 import { createInMemoryUserMeterEnv } from '#worker/test-support/user-meter.ts'
 import {
+	createMissingSecretMessage,
+	parseSecretScopeUnavailableMessage,
+} from './errors.ts'
+import {
 	listPackageSecretsByPackageIds,
 	listSecrets,
 	resolveSecret,
@@ -15,6 +19,7 @@ import {
 	updateUserSecretForPackage,
 	updateUserSecretsForPackageAtomically,
 } from './service.ts'
+import { createUnresolvedSecretMessage } from './unresolved-secret.ts'
 
 type SecretBucketRow = {
 	id: string
@@ -160,6 +165,47 @@ function createSecretTestDb(
 							return null
 						},
 						async all<T>() {
+							if (
+								normalizedQuery.includes('from secret_buckets b') &&
+								normalizedQuery.includes('join secret_entries e') &&
+								normalizedQuery.includes('e.name = ?')
+							) {
+								const [userId, name, now] = params as Array<string>
+								const results = Array.from(entries.values())
+									.flatMap((entry) => {
+										const bucket = Array.from(buckets.values()).find(
+											(candidate) => candidate.id === entry.bucket_id,
+										)
+										if (
+											!bucket ||
+											bucket.user_id !== userId ||
+											entry.name !== name
+										) {
+											return []
+										}
+										if (bucket.expires_at != null && bucket.expires_at <= now) {
+											return []
+										}
+										if (entry.expires_at != null && entry.expires_at <= now) {
+											return []
+										}
+										return [
+											{
+												scope: bucket.scope,
+												binding_key: bucket.binding_key,
+												name: entry.name,
+												entry_expires_at: entry.expires_at,
+												bucket_expires_at: bucket.expires_at,
+											},
+										]
+									})
+									.sort(
+										(left, right) =>
+											left.scope.localeCompare(right.scope) ||
+											left.binding_key.localeCompare(right.binding_key),
+									)
+								return { results: results as Array<T>, meta: { changes: 0 } }
+							}
 							if (
 								normalizedQuery.includes('from secret_buckets b') &&
 								normalizedQuery.includes("b.scope = 'package'")
@@ -1002,4 +1048,93 @@ test('user secrets persist per-entry expiry, stay listed after expiry, and fail 
 	await expect(
 		resolveSecret({ env, userId, name: 'githubPat', scope: 'user' }),
 	).resolves.toMatchObject({ found: true, value: 'ghp_old' })
+})
+
+test('createUnresolvedSecretMessage explains a package-scoped secret from ad-hoc execute', async () => {
+	const testDb = createSecretTestDb()
+	const env = {
+		APP_DB: testDb.db,
+		COOKIE_SECRET: 'test-cookie-secret',
+		SECRET_STORE_KEY: 'test-secret-store-key-32-chars-minimum',
+		...createInMemoryUserMeterEnv().env,
+	}
+	const userId = 'user-123'
+	const secretName = 'discordBotToken'
+	const packageId = 'pkg-discord'
+	await saveSecret({
+		env,
+		userId,
+		scope: 'package',
+		name: secretName,
+		value: 'package-only-value',
+		storageContext: {
+			sessionId: null,
+			appId: null,
+			packageId,
+			storageId: packageId,
+		},
+	})
+
+	await expect(
+		resolveSecret({
+			env,
+			userId,
+			name: secretName,
+			storageContext: {
+				sessionId: null,
+				appId: null,
+				packageId: null,
+				storageId: null,
+			},
+		}),
+	).resolves.toMatchObject({ found: false, value: null })
+
+	const executeMiss = await createUnresolvedSecretMessage({
+		env,
+		userId,
+		name: secretName,
+		storageContext: {
+			sessionId: null,
+			appId: null,
+			packageId: null,
+			storageId: null,
+		},
+		baseUrl: 'https://example.com',
+	})
+	expect(parseSecretScopeUnavailableMessage(executeMiss)).toEqual({
+		secretName,
+		scope: 'package',
+		packageName: packageId,
+	})
+	expect(executeMiss).toContain(
+		`https://example.com/account/secrets/package/${packageId}/${secretName}`,
+	)
+	expect(executeMiss).toContain('package id "pkg-discord"')
+
+	await expect(
+		createUnresolvedSecretMessage({
+			env,
+			userId,
+			name: 'noSuchSecret',
+			baseUrl: 'https://example.com',
+		}),
+	).resolves.toBe(createMissingSecretMessage('noSuchSecret'))
+
+	await expect(
+		resolveSecret({
+			env,
+			userId,
+			name: secretName,
+			storageContext: {
+				sessionId: null,
+				appId: null,
+				packageId,
+				storageId: packageId,
+			},
+		}),
+	).resolves.toMatchObject({
+		found: true,
+		value: 'package-only-value',
+		scope: 'package',
+	})
 })

--- a/packages/worker/src/mcp/secrets/unresolved-secret.node.test.ts
+++ b/packages/worker/src/mcp/secrets/unresolved-secret.node.test.ts
@@ -72,6 +72,7 @@ test('unresolved secret errors distinguish inaccessible scopes from a true miss'
 		secretName,
 		scope: 'package',
 		packageName: 'discord-gateway',
+		packageId: null,
 	})
 	expect(packageMiss).toContain(
 		'Either invoke this work through the owning package',
@@ -123,6 +124,7 @@ test('unresolved secret errors distinguish inaccessible scopes from a true miss'
 		secretName,
 		scope: 'user',
 		packageName: null,
+		packageId: null,
 	})
 	expect(pinnedPackageMiss).toContain(
 		'https://example.com/account/secrets/user/discordBotToken',

--- a/packages/worker/src/mcp/secrets/unresolved-secret.node.test.ts
+++ b/packages/worker/src/mcp/secrets/unresolved-secret.node.test.ts
@@ -128,6 +128,35 @@ test('unresolved secret errors distinguish inaccessible scopes from a true miss'
 		'https://example.com/account/secrets/user/discordBotToken',
 	)
 
+	const dottedSecretName = 'grokBotWake.71e7550e-746d-417f-b253-05165975ff69'
+	mockModule.listSecretLocationsByNameForUser.mockResolvedValue([
+		{
+			scope: 'user',
+			binding_key: '',
+			name: dottedSecretName,
+			expires_at: null,
+		},
+	])
+	const dottedMiss = await createUnresolvedSecretMessage({
+		env,
+		userId,
+		name: dottedSecretName,
+		scope: 'package',
+		storageContext: {
+			sessionId: null,
+			appId: null,
+			packageId: null,
+			storageId: null,
+		},
+		baseUrl: 'https://kody.codes',
+	})
+	expect(dottedMiss).toContain(
+		'https://kody.codes/account/secrets/user/grokBotWake%2E71e7550e-746d-417f-b253-05165975ff69',
+	)
+	expect(dottedMiss).not.toContain(
+		'https://kody.codes/account/secrets/user/grokBotWake.71e7550e-746d-417f-b253-05165975ff69',
+	)
+
 	mockModule.listSecretLocationsByNameForUser.mockRejectedValue(
 		new Error('d1 unavailable'),
 	)

--- a/packages/worker/src/mcp/secrets/unresolved-secret.node.test.ts
+++ b/packages/worker/src/mcp/secrets/unresolved-secret.node.test.ts
@@ -1,0 +1,142 @@
+import { expect, test, vi } from 'vitest'
+import {
+	createMissingSecretMessage,
+	parseMissingSecretMessage,
+	parseSecretScopeUnavailableMessage,
+} from './errors.ts'
+
+const mockModule = vi.hoisted(() => ({
+	listSecretLocationsByNameForUser: vi.fn(),
+	getSavedPackageById: vi.fn(),
+}))
+
+vi.mock('./repo.ts', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('./repo.ts')>()
+	return {
+		...actual,
+		listSecretLocationsByNameForUser: (...args: Array<unknown>) =>
+			mockModule.listSecretLocationsByNameForUser(...args),
+	}
+})
+
+vi.mock('#worker/package-registry/repo.ts', () => ({
+	getSavedPackageById: (...args: Array<unknown>) =>
+		mockModule.getSavedPackageById(...args),
+}))
+
+const { createUnresolvedSecretMessage } = await import('./unresolved-secret.ts')
+
+test('unresolved secret errors distinguish inaccessible scopes from a true miss', async () => {
+	const env = { APP_DB: {} as D1Database }
+	const userId = 'user-1'
+	const baseUrl = 'https://example.com'
+	const secretName = 'discordBotToken'
+
+	mockModule.listSecretLocationsByNameForUser.mockResolvedValue([])
+	await expect(
+		createUnresolvedSecretMessage({
+			env,
+			userId,
+			name: secretName,
+			baseUrl,
+		}),
+	).resolves.toBe(createMissingSecretMessage(secretName))
+
+	mockModule.listSecretLocationsByNameForUser.mockResolvedValue([
+		{
+			scope: 'package',
+			binding_key: 'pkg-1',
+			name: secretName,
+			expires_at: null,
+		},
+	])
+	mockModule.getSavedPackageById.mockResolvedValue({
+		id: 'pkg-1',
+		kodyId: 'discord-gateway',
+		name: '@user/discord-gateway',
+	})
+	const packageMiss = await createUnresolvedSecretMessage({
+		env,
+		userId,
+		name: secretName,
+		storageContext: {
+			sessionId: null,
+			appId: null,
+			packageId: null,
+			storageId: null,
+		},
+		baseUrl,
+	})
+	expect(parseMissingSecretMessage(packageMiss)).toBeNull()
+	expect(parseSecretScopeUnavailableMessage(packageMiss)).toEqual({
+		secretName,
+		scope: 'package',
+		packageName: 'discord-gateway',
+	})
+	expect(packageMiss).toContain(
+		'Either invoke this work through the owning package',
+	)
+	expect(packageMiss).toContain(
+		'https://example.com/account/secrets/package/pkg-1/discordBotToken',
+	)
+	expect(mockModule.getSavedPackageById).toHaveBeenCalledWith(env.APP_DB, {
+		userId,
+		packageId: 'pkg-1',
+	})
+
+	const visibleInPackageRuntime = await createUnresolvedSecretMessage({
+		env,
+		userId,
+		name: secretName,
+		storageContext: {
+			sessionId: null,
+			appId: null,
+			packageId: 'pkg-1',
+			storageId: 'pkg-1',
+		},
+		baseUrl,
+	})
+	expect(visibleInPackageRuntime).toBe(createMissingSecretMessage(secretName))
+
+	mockModule.listSecretLocationsByNameForUser.mockResolvedValue([
+		{
+			scope: 'user',
+			binding_key: '',
+			name: secretName,
+			expires_at: null,
+		},
+	])
+	const pinnedPackageMiss = await createUnresolvedSecretMessage({
+		env,
+		userId,
+		name: secretName,
+		scope: 'package',
+		storageContext: {
+			sessionId: null,
+			appId: null,
+			packageId: null,
+			storageId: null,
+		},
+		baseUrl,
+	})
+	expect(parseSecretScopeUnavailableMessage(pinnedPackageMiss)).toEqual({
+		secretName,
+		scope: 'user',
+		packageName: null,
+	})
+	expect(pinnedPackageMiss).toContain(
+		'https://example.com/account/secrets/user/discordBotToken',
+	)
+
+	mockModule.listSecretLocationsByNameForUser.mockRejectedValue(
+		new Error('d1 unavailable'),
+	)
+	await expect(
+		createUnresolvedSecretMessage({
+			env,
+			userId,
+			name: secretName,
+			baseUrl,
+		}),
+	).resolves.toBe(createMissingSecretMessage(secretName))
+})

--- a/packages/worker/src/mcp/secrets/unresolved-secret.ts
+++ b/packages/worker/src/mcp/secrets/unresolved-secret.ts
@@ -1,0 +1,160 @@
+import { buildAccountSecretPath } from '@kody-internal/shared/account-secret-route.ts'
+import { isSecretExpired } from '@kody-internal/shared/secret-expires-at.ts'
+import { type StorageContext } from '#mcp/storage.ts'
+import { getSavedPackageById } from '#worker/package-registry/repo.ts'
+import {
+	createMissingSecretMessage,
+	createSecretScopeUnavailableMessage,
+	type SecretScopeUnavailableMatch,
+} from './errors.ts'
+import { isReservedSecretName } from './name-guards.ts'
+import { listSecretLocationsByNameForUser } from './repo.ts'
+import { getSecretBindingKey } from './secret-bindings.ts'
+import { type SecretScope } from './types.ts'
+
+const inaccessibleScopeRank: Record<SecretScope, number> = {
+	package: 0,
+	session: 1,
+	user: 2,
+}
+
+export async function createUnresolvedSecretMessage(input: {
+	env: Pick<Env, 'APP_DB'>
+	userId: string
+	name: string
+	scope?: SecretScope | null
+	storageContext?: StorageContext | null
+	baseUrl: string
+}) {
+	const secretName = input.name.trim()
+	if (!secretName) return createMissingSecretMessage(input.name)
+	if (!input.env.APP_DB) return createMissingSecretMessage(secretName)
+	try {
+		const matches = await listInaccessibleSecretMatches({
+			env: input.env,
+			userId: input.userId,
+			name: secretName,
+			requestedScope: input.scope ?? null,
+			storageContext: input.storageContext ?? null,
+			baseUrl: input.baseUrl,
+		})
+		if (matches.length === 0) return createMissingSecretMessage(secretName)
+		return createSecretScopeUnavailableMessage(matches)
+	} catch {
+		return createMissingSecretMessage(secretName)
+	}
+}
+
+async function listInaccessibleSecretMatches(input: {
+	env: Pick<Env, 'APP_DB'>
+	userId: string
+	name: string
+	requestedScope: SecretScope | null
+	storageContext: StorageContext | null
+	baseUrl: string
+}): Promise<Array<SecretScopeUnavailableMatch>> {
+	if (isReservedSecretName(input.name)) return []
+	const locations = await listSecretLocationsByNameForUser({
+		db: input.env.APP_DB,
+		userId: input.userId,
+		name: input.name,
+	})
+	const inaccessible = locations.filter((location) => {
+		if (isSecretExpired(location.expires_at)) return false
+		return !isSecretVisibleToLookup({
+			scope: location.scope,
+			bindingKey: location.binding_key,
+			requestedScope: input.requestedScope,
+			storageContext: input.storageContext,
+		})
+	})
+	if (inaccessible.length === 0) return []
+
+	const packageIds = [
+		...new Set(
+			inaccessible
+				.filter((location) => location.scope === 'package')
+				.map((location) => location.binding_key)
+				.filter((packageId) => packageId.length > 0),
+		),
+	]
+	const packageNames = new Map<string, string>()
+	await Promise.all(
+		packageIds.map(async (packageId) => {
+			try {
+				const savedPackage = await getSavedPackageById(input.env.APP_DB, {
+					userId: input.userId,
+					packageId,
+				})
+				if (savedPackage?.kodyId) {
+					packageNames.set(packageId, savedPackage.kodyId)
+				}
+			} catch {
+				// Keep the package id in the error when the title lookup fails.
+			}
+		}),
+	)
+
+	return inaccessible
+		.map((location) => {
+			const packageId =
+				location.scope === 'package' ? location.binding_key : null
+			const sessionId =
+				location.scope === 'session' ? location.binding_key : null
+			return {
+				secretName: input.name,
+				scope: location.scope,
+				packageId,
+				packageName: packageId ? (packageNames.get(packageId) ?? null) : null,
+				sessionId,
+				editorUrl: buildSecretScopeEditorUrl({
+					baseUrl: input.baseUrl,
+					name: input.name,
+					scope: location.scope,
+					packageId,
+					sessionId,
+				}),
+			}
+		})
+		.sort((left, right) => {
+			const rankDelta =
+				inaccessibleScopeRank[left.scope] - inaccessibleScopeRank[right.scope]
+			if (rankDelta !== 0) return rankDelta
+			return (left.packageId ?? left.sessionId ?? '').localeCompare(
+				right.packageId ?? right.sessionId ?? '',
+			)
+		})
+}
+
+function isSecretVisibleToLookup(input: {
+	scope: SecretScope
+	bindingKey: string
+	requestedScope: SecretScope | null
+	storageContext: StorageContext | null
+}) {
+	if (input.requestedScope && input.requestedScope !== input.scope) {
+		return false
+	}
+	const currentBinding = getSecretBindingKey(input.scope, input.storageContext)
+	return currentBinding != null && currentBinding === input.bindingKey
+}
+
+function buildSecretScopeEditorUrl(input: {
+	baseUrl: string
+	name: string
+	scope: SecretScope
+	packageId: string | null
+	sessionId: string | null
+}) {
+	try {
+		const secretPath = buildAccountSecretPath({
+			name: input.name,
+			scope: input.scope,
+			packageId: input.packageId,
+			sessionId: input.sessionId,
+		})
+		return new URL(secretPath, input.baseUrl).toString()
+	} catch {
+		return null
+	}
+}

--- a/packages/worker/src/mcp/secrets/unresolved-secret.ts
+++ b/packages/worker/src/mcp/secrets/unresolved-secret.ts
@@ -1,4 +1,4 @@
-import { buildAccountSecretPath } from '@kody-internal/shared/account-secret-route.ts'
+import { buildAccountSecretUrl } from '@kody-internal/shared/account-secret-route.ts'
 import { isSecretExpired } from '@kody-internal/shared/secret-expires-at.ts'
 import { type StorageContext } from '#mcp/storage.ts'
 import { getSavedPackageById } from '#worker/package-registry/repo.ts'
@@ -147,13 +147,13 @@ function buildSecretScopeEditorUrl(input: {
 	sessionId: string | null
 }) {
 	try {
-		const secretPath = buildAccountSecretPath({
+		return buildAccountSecretUrl({
+			baseUrl: input.baseUrl,
 			name: input.name,
 			scope: input.scope,
 			packageId: input.packageId,
 			sessionId: input.sessionId,
 		})
-		return new URL(secretPath, input.baseUrl).toString()
 	} catch {
 		return null
 	}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Give agents a recoverable error when they try to use a secret that exists for the user but is not visible from the current runtime (especially a package-scoped secret from ad-hoc `execute`).

## Why

`resolveSecret` only walks scopes the current `storageContext` can bind. Ad-hoc execute has no `packageId`, so a package-scoped secret looks missing. Host / capability / package *approval* denials already include an account URL. Scope/visibility misses returned only `Secret "name" was not found.`, so the agent told the user to create a new secret instead of running through the owning package or opening the existing editor.

A follow-up 404: `https://kody.codes/account/secrets/user/grokBotWake.71e7550e-…` fails because Remix treats `.` as a route delimiter. The working URL keeps the `createHref` encoding (`grokBotWake%2E71e7550e-…`).

## Summary

- After a failed resolve, look up same-user, non-expired locations for that name across every scope/binding (metadata only; no values).
- If the secret exists only in a scope this runtime cannot see, return a parseable error that names the scope and owning package and includes the real account editor URL.
- Editor / approval absolute URLs are now `origin + createHref path` so `%2E` (and other reserved path encodings) survive. Do not use `new URL(path, base).toString()` on those paths.
- True missing stays `Secret "name" was not found.` (executor still sends the user to `/account/secrets/new?name=...`).
- Existing host / capability / package approval errors are unchanged aside from the same encoding-preserving join.
- The scope-miss parser now splits `packageName` from `packageId` so `package id "…"` is not treated as a package name.
- Wired at the resolve/use throw sites: fetch-gateway placeholders, capability-input placeholders, `secret_jwt_sign`, and package mounts. `secret_list` still lists only accessible scopes.
- Rebased onto current `main` so the PR is mergeable again.

## Testing

- Focused node-unit including `account-secret-route` with `grokBotWake.71e7550e-746d-417f-b253-05165975ff69` → `%2E` path and absolute URL
- Unresolved-secret error for that name includes the `%2E` editor URL and not the raw-dot 404 form
- Parser and executor tests cover named-package vs package-id-only scope-miss messages
- Pre-push `test:node` (2163) and `test:workers` (302) passed after rebase

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `7f312eb9` · **Head:** `9f9c3c7e`

**Classification:** extends — secret resolve/use errors now distinguish an inaccessible same-user scope from a true miss, keep Remix `%2E` editor encodings, and parse package id separately from package name.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `secrets` | assistant | extends — `secret_jwt_sign` uses the new unresolved-secret helper |
| `mcp-server` | surfaces | extends — fetch-gateway, package mounts, secret error protocol, executor classification, approval URL join |
| `capabilities-execute` | runtime | composes — capability-input placeholder resolve calls the same helper |

Unmatched path: `packages/shared/src/account-secret-route.ts` (account secret path/URL encoding used by the new editor links).

### Change flow

A failed secret resolve now looks up same-user locations before returning not-found, then builds the editor URL from origin plus the already-encoded `createHref` path.

```mermaid
sequenceDiagram
	actor Agent
	participant capabilitiesExecute as capabilities-execute
	participant mcpServer as mcp-server
	participant secrets as secrets
	Agent->>capabilitiesExecute: execute / fetch with {{secret:name}}
	capabilitiesExecute->>mcpServer: resolveSecret (visible scopes only)
	mcpServer-->>capabilitiesExecute: found false
	capabilitiesExecute->>mcpServer: listSecretLocationsByNameForUser
	mcpServer->>secrets: same-user metadata (no values)
	alt exists only in inaccessible scope
		mcpServer-->>Agent: scope-unavailable + packageName or packageId + %2E editor URL
	else no row in any scope
		mcpServer-->>Agent: Secret "name" was not found.
	end
```

### Before / after

```text
Before: Secret "grokBotWake.71e7550e-…" was not found.
After:  … Editor link: https://kody.codes/account/secrets/user/grokBotWake%2E71e7550e-746d-417f-b253-05165975ff69
        (not …/user/grokBotWake.71e7550e-… which 404s)

Parser: "package id \"pkg-1\"" -> packageId, not packageName
```

### Invariants

Per-user isolation is unchanged: the location lookup is `user_id = caller`. Secret values are never included in the error.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4e7b7816-bd66-4598-b7eb-37785ed0e0bb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4e7b7816-bd66-4598-b7eb-37785ed0e0bb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer guidance when secrets exist in an inaccessible scope, including suggested policy updates and links to relevant settings.
  * Secret resolution now distinguishes unavailable-scope errors from genuinely missing secrets.

* **Bug Fixes**
  * Fixed percent-encoding of dotted secret names in approval and editor URLs, preventing broken links.
  * Added safer handling for expired, invalid, or unavailable secret records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->