### PR TITLE
Optimistic star and follow toggles

### DIFF
--- a/packages/worker/client/community-social-toggle.node.test.ts
+++ b/packages/worker/client/community-social-toggle.node.test.ts
@@ -1,0 +1,167 @@
+import { expect, test, vi } from 'vitest'
+import {
+	applyCommunityStarAppearance,
+	applyDisplayedCount,
+	applyFollowAppearance,
+	applyFollowError,
+	communityStarCopy,
+	nextDisplayedCount,
+	parseDisplayedCount,
+	profileFollowCopy,
+	readDisplayedCount,
+	postSocialToggleJson,
+	readFollowButtonFromEvent,
+} from './community-social-toggle.ts'
+
+test('nextDisplayedCount increments, decrements, and clamps at zero', () => {
+	expect(nextDisplayedCount(5, false, true)).toBe(6)
+	expect(nextDisplayedCount(5, true, false)).toBe(4)
+	expect(nextDisplayedCount(0, true, false)).toBe(0)
+	expect(nextDisplayedCount(3, true, true)).toBe(3)
+	expect(nextDisplayedCount(3, false, false)).toBe(3)
+})
+
+test('parseDisplayedCount reads plain and grouped integers', () => {
+	expect(parseDisplayedCount('12')).toBe(12)
+	expect(parseDisplayedCount('1,234')).toBe(1234)
+	expect(parseDisplayedCount(' 8 ')).toBe(8)
+	expect(parseDisplayedCount('')).toBe(0)
+	expect(parseDisplayedCount('abc')).toBe(0)
+})
+
+test('star and follow copy match the SSR control labels', () => {
+	expect(communityStarCopy(false, '@kody/notes')).toEqual({
+		title: 'Star',
+		label: 'Star @kody/notes',
+	})
+	expect(communityStarCopy(true, '@kody/notes')).toEqual({
+		title: 'Unstar',
+		label: 'Unstar @kody/notes',
+	})
+	expect(profileFollowCopy(false, 'kody')).toEqual({
+		title: 'Follow',
+		label: 'Follow @kody',
+	})
+	expect(profileFollowCopy(true, 'kody')).toEqual({
+		title: 'Unfollow',
+		label: 'Unfollow @kody',
+	})
+})
+
+test('applyCommunityStarAppearance flips starred attrs, title, and label', () => {
+	const label = { textContent: 'Star @kody/notes' }
+	const button = {
+		dataset: { starred: 'false', listingName: '@kody/notes' },
+		title: 'Star',
+		querySelector(selector: string) {
+			return selector === '[data-community-star-label]' ? label : null
+		},
+	}
+
+	applyCommunityStarAppearance(button as never, true)
+
+	expect(button.dataset.starred).toBe('true')
+	expect(button.title).toBe('Unstar')
+	expect(label.textContent).toBe('Unstar @kody/notes')
+})
+
+test('applyFollowAppearance flips following attrs, label, and hidden input', () => {
+	const label = { textContent: 'Follow @kody' }
+	const followInput = { value: 'true' }
+	const form = {
+		querySelector(selector: string) {
+			return selector === 'input[name="follow"]' ? followInput : null
+		},
+	}
+	const button = {
+		dataset: { following: 'false', followUsername: 'kody' },
+		title: 'Follow',
+		querySelector(selector: string) {
+			return selector === '[data-community-follow-label]' ? label : null
+		},
+		closest(selector: string) {
+			return selector === 'form' ? form : null
+		},
+	}
+
+	applyFollowAppearance(button as never, true)
+
+	expect(button.dataset.following).toBe('true')
+	expect(button.title).toBe('Unfollow')
+	expect(label.textContent).toBe('Unfollow @kody')
+	expect(followInput.value).toBe('false')
+})
+
+test('applyFollowError shows and hides the follow alert', () => {
+	const errorEl = {
+		textContent: '',
+		removeAttribute: vi.fn(),
+		setAttribute: vi.fn(),
+	}
+
+	applyFollowError(errorEl as never, 'Unable to follow.')
+	expect(errorEl.textContent).toBe('Unable to follow.')
+	expect(errorEl.removeAttribute).toHaveBeenCalledWith('hidden')
+
+	applyFollowError(errorEl as never, null)
+	expect(errorEl.textContent).toBe('')
+	expect(errorEl.setAttribute).toHaveBeenCalledWith('hidden', '')
+})
+
+test('readDisplayedCount and applyDisplayedCount round-trip on an element', () => {
+	const countEl = { textContent: '4' }
+	expect(readDisplayedCount(countEl as never)).toBe(4)
+	applyDisplayedCount(countEl as never, 5)
+	expect(countEl.textContent).toBe('5')
+	expect(readDisplayedCount(null)).toBe(0)
+	applyDisplayedCount(null, 9)
+})
+
+test('postSocialToggleJson maps 401, payload errors, and success', async () => {
+	const fetchMock = vi.fn()
+	vi.stubGlobal('fetch', fetchMock)
+
+	fetchMock.mockResolvedValueOnce({
+		status: 401,
+		ok: false,
+		json: async () => ({ ok: false, error: 'Unauthorized.' }),
+	})
+	await expect(
+		postSocialToggleJson('/follow.json', { follow: true }, 'fallback'),
+	).resolves.toEqual({ status: 'unauthorized' })
+
+	fetchMock.mockResolvedValueOnce({
+		status: 400,
+		ok: false,
+		json: async () => ({ ok: false, error: 'You cannot follow yourself.' }),
+	})
+	await expect(
+		postSocialToggleJson('/follow.json', { follow: true }, 'fallback'),
+	).resolves.toEqual({
+		status: 'error',
+		message: 'You cannot follow yourself.',
+	})
+
+	fetchMock.mockResolvedValueOnce({
+		status: 200,
+		ok: true,
+		json: async () => ({ ok: true, following: true }),
+	})
+	await expect(
+		postSocialToggleJson('/follow.json', { follow: true }, 'fallback'),
+	).resolves.toEqual({
+		status: 'ok',
+		payload: { ok: true, following: true },
+	})
+
+	vi.unstubAllGlobals()
+})
+
+test('readFollowButtonFromEvent ignores non-element targets', () => {
+	expect(
+		readFollowButtonFromEvent({
+			type: 'click',
+			target: null,
+		} as never),
+	).toBeNull()
+})

--- a/packages/worker/client/community-social-toggle.ts
+++ b/packages/worker/client/community-social-toggle.ts
@@ -1,0 +1,239 @@
+import { readJson } from '#client/routes/account-approval-shared.ts'
+import { routes } from '#universal/routes.ts'
+
+export function nextDisplayedCount(
+	current: number,
+	wasActive: boolean,
+	willBeActive: boolean,
+) {
+	if (wasActive === willBeActive) return current
+	if (willBeActive) return current + 1
+	return Math.max(0, current - 1)
+}
+
+export function parseDisplayedCount(text: string) {
+	const parsed = Number.parseInt(text.replaceAll(',', '').trim(), 10)
+	return Number.isFinite(parsed) ? parsed : 0
+}
+
+export function communityStarCopy(starred: boolean, listingName: string) {
+	return starred
+		? { title: 'Unstar', label: `Unstar ${listingName}` }
+		: { title: 'Star', label: `Star ${listingName}` }
+}
+
+export function profileFollowCopy(following: boolean, username: string) {
+	return following
+		? { title: 'Unfollow', label: `Unfollow @${username}` }
+		: { title: 'Follow', label: `Follow @${username}` }
+}
+
+type CountSurface = {
+	textContent: string | null
+}
+
+type LabelSurface = {
+	textContent: string | null
+}
+
+type FollowValueInput = {
+	value: string
+}
+
+type FollowErrorSurface = {
+	textContent: string | null
+	removeAttribute: (name: string) => void
+	setAttribute: (name: string, value: string) => void
+}
+
+export type StarToggleButton = {
+	dataset: { starred?: string; listingName?: string }
+	title: string
+	querySelector: (selector: string) => LabelSurface | null
+}
+
+export type FollowToggleButton = {
+	dataset: { following?: string; followUsername?: string }
+	title: string
+	querySelector: (selector: string) => LabelSurface | null
+	closest: (
+		selector: string,
+	) => { querySelector: (selector: string) => FollowValueInput | null } | null
+}
+
+export function readDisplayedCount(element: CountSurface | null | undefined) {
+	if (!element) return 0
+	return parseDisplayedCount(element.textContent ?? '')
+}
+
+export function applyDisplayedCount(
+	element: CountSurface | null | undefined,
+	count: number,
+) {
+	if (!element) return
+	element.textContent = String(count)
+}
+
+export function findCommunityStarCountElement(from: Element) {
+	return from
+		.closest('[data-testid="community-detail-frame"]')
+		?.querySelector('[data-community-star-count]')
+}
+
+export function findProfileFollowerCountElement(from: Element) {
+	return from
+		.closest('[data-testid="profile-frame"]')
+		?.querySelector('[data-community-follower-count]')
+}
+
+export function findFollowErrorElement(from: Element) {
+	return from
+		.closest('[data-community-follow-control]')
+		?.querySelector('[data-community-follow-error]')
+}
+
+export function applyCommunityStarAppearance(
+	button: StarToggleButton | HTMLElement,
+	starred: boolean,
+) {
+	const copy = communityStarCopy(starred, button.dataset.listingName ?? '')
+	button.dataset.starred = starred ? 'true' : 'false'
+	button.title = copy.title
+	const label = button.querySelector('[data-community-star-label]')
+	if (label) label.textContent = copy.label
+}
+
+export function applyFollowAppearance(
+	button: FollowToggleButton | HTMLElement,
+	following: boolean,
+) {
+	const copy = profileFollowCopy(following, button.dataset.followUsername ?? '')
+	button.dataset.following = following ? 'true' : 'false'
+	button.title = copy.title
+	const label = button.querySelector('[data-community-follow-label]')
+	if (label) label.textContent = copy.label
+	const followInput = button
+		.closest('form')
+		?.querySelector('input[name="follow"]')
+	if (followInput && 'value' in followInput) {
+		followInput.value = String(!following)
+	}
+}
+
+export function applyFollowError(
+	errorEl: FollowErrorSurface | null | undefined,
+	message: string | null,
+) {
+	if (!errorEl) return
+	errorEl.textContent = message ?? ''
+	if (message) {
+		errorEl.removeAttribute('hidden')
+	} else {
+		errorEl.setAttribute('hidden', '')
+	}
+}
+
+export function readFollowButtonFromEvent(event: Event) {
+	const target = event.target
+	if (typeof Element === 'undefined' || !(target instanceof Element)) {
+		return null
+	}
+	if (event.type === 'submit' && target instanceof HTMLFormElement) {
+		const button = target.querySelector('[data-community-follow]')
+		return button instanceof HTMLButtonElement ? button : null
+	}
+	const button = target.closest('[data-community-follow]')
+	return button instanceof HTMLButtonElement ? button : null
+}
+
+export type SocialToggleResult<T> =
+	| { status: 'ok'; payload: T }
+	| { status: 'unauthorized' }
+	| { status: 'error'; message: string }
+
+export async function postSocialToggleJson<
+	T extends { ok?: boolean; error?: string },
+>(
+	href: string,
+	body: unknown,
+	fallbackError: string,
+): Promise<SocialToggleResult<T>> {
+	const response = await fetch(href, {
+		method: 'POST',
+		headers: {
+			Accept: 'application/json',
+			'Content-Type': 'application/json',
+		},
+		credentials: 'include',
+		body: JSON.stringify(body),
+	})
+	if (response.status === 401) return { status: 'unauthorized' }
+	const payload = await readJson<T>(response)
+	if (!response.ok || !payload?.ok) {
+		return {
+			status: 'error',
+			message: payload?.error ?? fallbackError,
+		}
+	}
+	return { status: 'ok', payload }
+}
+
+export async function submitOptimisticFollow(
+	button: HTMLElement,
+	isStale: () => boolean,
+): Promise<'unauthorized' | 'ok' | 'error'> {
+	const username = button.dataset.followUsername
+	if (!username) return 'error'
+
+	const previousFollowing = button.dataset.following === 'true'
+	const nextFollowing = !previousFollowing
+	const errorEl = findFollowErrorElement(button)
+	const countEl = findProfileFollowerCountElement(button)
+	const previousCount = readDisplayedCount(countEl)
+
+	applyFollowAppearance(button, nextFollowing)
+	applyDisplayedCount(
+		countEl,
+		nextDisplayedCount(previousCount, previousFollowing, nextFollowing),
+	)
+	applyFollowError(errorEl, null)
+
+	try {
+		const result = await postSocialToggleJson<{
+			ok: boolean
+			following?: boolean
+			error?: string
+		}>(
+			routes.profileFollowApiPost.href({ username }),
+			{ follow: nextFollowing },
+			'Unable to update follow status.',
+		)
+		if (result.status === 'unauthorized') return 'unauthorized'
+		if (isStale()) return 'ok'
+		switch (result.status) {
+			case 'ok':
+				applyFollowAppearance(button, result.payload.following ?? nextFollowing)
+				return 'ok'
+			case 'error':
+				applyFollowAppearance(button, previousFollowing)
+				applyDisplayedCount(countEl, previousCount)
+				applyFollowError(errorEl, result.message)
+				return 'error'
+			default: {
+				const exhaustive: never = result
+				throw new Error(`Unhandled follow result: ${String(exhaustive)}`)
+			}
+		}
+	} catch (error) {
+		if (isStale()) return 'ok'
+		applyFollowAppearance(button, previousFollowing)
+		applyDisplayedCount(countEl, previousCount)
+		applyFollowError(
+			errorEl,
+			error instanceof Error
+				? error.message
+				: 'Unable to update follow status.',
+		)
+		return 'error'
+	}
+}

--- a/packages/worker/client/routes/account-stars.tsx
+++ b/packages/worker/client/routes/account-stars.tsx
@@ -57,7 +57,6 @@ export function AccountStarsRoute(handle: Handle) {
 	let status: 'loading' | 'ready' | 'error' = 'loading'
 	let listings: Array<PublicCommunityListing> = []
 	let message: string | null = null
-	let busyListingId: string | null = null
 	const loadLatch = createRouteLoadLatch()
 
 	async function loadStars() {
@@ -88,8 +87,10 @@ export function AccountStarsRoute(handle: Handle) {
 	}
 
 	async function unstarListing(listingId: string) {
-		if (busyListingId) return
-		busyListingId = listingId
+		const index = listings.findIndex((listing) => listing.id === listingId)
+		const removed = listings[index]
+		if (index === -1 || !removed) return
+		listings = listings.filter((listing) => listing.id !== listingId)
 		message = null
 		handle.update()
 		try {
@@ -113,11 +114,14 @@ export function AccountStarsRoute(handle: Handle) {
 			if (!response.ok || !payload?.ok) {
 				throw new Error(payload?.error ?? 'Unable to unstar package.')
 			}
-			listings = listings.filter((listing) => listing.id !== listingId)
-			busyListingId = null
-			handle.update()
 		} catch (error) {
-			busyListingId = null
+			if (!listings.some((listing) => listing.id === listingId)) {
+				listings = [
+					...listings.slice(0, index),
+					removed,
+					...listings.slice(index),
+				]
+			}
 			message =
 				error instanceof Error ? error.message : 'Unable to unstar package.'
 			handle.update()
@@ -211,13 +215,12 @@ export function AccountStarsRoute(handle: Handle) {
 									</div>
 									<button
 										type="button"
-										disabled={busyListingId === listing.id}
 										mix={[
 											on('click', () => void unstarListing(listing.id)),
 											css(dangerButtonCss),
 										]}
 									>
-										{busyListingId === listing.id ? 'Removing…' : 'Unstar'}
+										Unstar
 									</button>
 								</div>
 							</li>

--- a/packages/worker/client/routes/community-detail.tsx
+++ b/packages/worker/client/routes/community-detail.tsx
@@ -23,6 +23,16 @@ import { renderMarkdownNodes } from '#client/markdown-view.tsx'
 import { type HighlightedCode } from '#universal/highlighted-code.ts'
 import { readJson } from '#client/routes/account-approval-shared.ts'
 import { decideCommunityInstallClick } from '#client/routes/community-detail-install.ts'
+import {
+	applyCommunityStarAppearance,
+	applyDisplayedCount,
+	findCommunityStarCountElement,
+	nextDisplayedCount,
+	postSocialToggleJson,
+	readDisplayedCount,
+	readFollowButtonFromEvent,
+	submitOptimisticFollow,
+} from '#client/community-social-toggle.ts'
 import { colors, transitions, typography } from '#universal/styles/tokens.ts'
 import {
 	getGhostButtonCss,
@@ -272,8 +282,9 @@ export function CommunityDetailRoute(handle: Handle) {
 	let shellLoadedForPathname: string | null = null
 	let shellRequestedForPathname: string | null = null
 	let starredByViewer = false
-	let starState: 'idle' | 'submitting' | 'error' = 'idle'
 	let starMessage: string | null = null
+	let starRequestId = 0
+	let followRequestId = 0
 
 	// Re-lexing markdown on every handle.update() would be wasted work; cache
 	// the rendered README per markdown string (same policy as MarkdownView).
@@ -347,7 +358,6 @@ export function CommunityDetailRoute(handle: Handle) {
 			readmeContent = payload.listing.readmeContent
 			readmeFences = payload.readmeFences ?? []
 			starredByViewer = payload.starredByViewer
-			starState = 'idle'
 			starMessage = null
 			reportState = 'idle'
 			reportMessage = null
@@ -364,50 +374,70 @@ export function CommunityDetailRoute(handle: Handle) {
 		}
 	}
 
-	async function submitStar(nextStarred: boolean) {
+	async function submitStar(button: HTMLElement, nextStarred: boolean) {
 		const listingId = getCurrentListingId(handle)
-		if (!listingId || starState === 'submitting') return
+		if (!listingId) return
 
-		starState = 'submitting'
+		const requestId = ++starRequestId
+		const previousStarred = button.dataset.starred === 'true'
+		const starCountEl = findCommunityStarCountElement(button)
+		const previousCount = readDisplayedCount(starCountEl)
+
+		starredByViewer = nextStarred
 		starMessage = null
+		applyCommunityStarAppearance(button, nextStarred)
+		applyDisplayedCount(
+			starCountEl,
+			nextDisplayedCount(previousCount, previousStarred, nextStarred),
+		)
 		handle.update()
 
-		try {
-			const response = await fetch(
-				routes.communityStarApiPost.href({ listingId }),
-				{
-					method: 'POST',
-					headers: {
-						Accept: 'application/json',
-						'Content-Type': 'application/json',
-					},
-					credentials: 'include',
-					body: JSON.stringify({ starred: nextStarred }),
-				},
-			)
-			if (response.status === 401) {
+		const result = await postSocialToggleJson<{
+			ok: boolean
+			starred?: boolean
+			starCount?: number
+			error?: string
+		}>(
+			routes.communityStarApiPost.href({ listingId }),
+			{ starred: nextStarred },
+			'Unable to update star status.',
+		)
+		if (requestId !== starRequestId) return
+
+		switch (result.status) {
+			case 'unauthorized':
 				window.location.assign('/login')
 				return
+			case 'ok':
+				starredByViewer = result.payload.starred ?? nextStarred
+				applyCommunityStarAppearance(button, starredByViewer)
+				if (result.payload.starCount != null) {
+					applyDisplayedCount(starCountEl, result.payload.starCount)
+				}
+				handle.update()
+				return
+			case 'error':
+				starredByViewer = previousStarred
+				applyCommunityStarAppearance(button, previousStarred)
+				applyDisplayedCount(starCountEl, previousCount)
+				starMessage = result.message
+				handle.update()
+				return
+			default: {
+				const exhaustive: never = result
+				throw new Error(`Unhandled star result: ${String(exhaustive)}`)
 			}
-			const payload = await readJson<{
-				ok: boolean
-				starred?: boolean
-				starCount?: number
-				error?: string
-			}>(response)
-			if (!response.ok || !payload?.ok) {
-				throw new Error(payload?.error ?? 'Unable to update star status.')
-			}
-			starredByViewer = payload.starred ?? nextStarred
-			starState = 'idle'
-			handle.update()
-			const frame = handle.frames.get(COMMUNITY_DETAIL_TARGET)
-			if (frame) void frame.reload()
-		} catch (error) {
-			starState = 'error'
-			starMessage =
-				error instanceof Error ? error.message : 'Unable to update star status.'
-			handle.update()
+		}
+	}
+
+	async function submitFollow(button: HTMLButtonElement) {
+		const requestId = ++followRequestId
+		const outcome = await submitOptimisticFollow(
+			button,
+			() => requestId !== followRequestId,
+		)
+		if (outcome === 'unauthorized') {
+			window.location.assign('/login')
 		}
 	}
 
@@ -649,10 +679,21 @@ export function CommunityDetailRoute(handle: Handle) {
 		const target = event.target
 		if (!(target instanceof Element)) return
 		const control = target.closest('[data-community-star]')
-		if (!control || control instanceof HTMLAnchorElement) return
+		if (
+			!(control instanceof HTMLElement) ||
+			control instanceof HTMLAnchorElement
+		)
+			return
 		event.preventDefault()
-		if (starState === 'submitting') return
-		void submitStar(!starredByViewer)
+		const nextStarred = control.dataset.starred !== 'true'
+		void submitStar(control, nextStarred)
+	}
+
+	function handleCommunityFollowActivate(event: Event) {
+		const button = readFollowButtonFromEvent(event)
+		if (!button) return
+		event.preventDefault()
+		void submitFollow(button)
 	}
 
 	listenToRouterNavigation(handle, () => {
@@ -690,7 +731,6 @@ export function CommunityDetailRoute(handle: Handle) {
 		readmeContent = routeData.readmeContent
 		readmeFences = routeData.readmeFences ?? []
 		starredByViewer = routeData.starredByViewer
-		starState = 'idle'
 		starMessage = null
 		reportState = 'idle'
 		reportMessage = null
@@ -779,7 +819,9 @@ export function CommunityDetailRoute(handle: Handle) {
 					on('click', (event) => {
 						handleCommunityInstallClick(event)
 						handleCommunityStarClick(event)
+						handleCommunityFollowActivate(event)
 					}),
+					on('submit', handleCommunityFollowActivate),
 				]}
 			>
 				<Frame name={COMMUNITY_DETAIL_TARGET} src={frameSrc} />

--- a/packages/worker/client/routes/profile.tsx
+++ b/packages/worker/client/routes/profile.tsx
@@ -16,7 +16,12 @@ import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
 import { consumeStaleNavigationData } from '#client/navigation-data.ts'
 import { type RouteLoaderResult } from '#client/route-loader.ts'
 import { readRouterPathname } from '#client/router-location.tsx'
+import { on } from '#client/event-mixin.ts'
 import { readJson } from '#client/routes/account-approval-shared.ts'
+import {
+	readFollowButtonFromEvent,
+	submitOptimisticFollow,
+} from '#client/community-social-toggle.ts'
 import { readProfileSearchQueryFromHref } from '#client/routes/profile-search.ts'
 import { colors, spacing, typography } from '#universal/styles/tokens.ts'
 import {
@@ -112,6 +117,25 @@ export function ProfileRoute(handle: Handle) {
 	let shellLoadedForUsername: string | null = null
 	let shellRequestedForUsername: string | null = null
 	let shellLoadRequestId = 0
+	let followRequestId = 0
+
+	async function submitFollow(button: HTMLButtonElement) {
+		const requestId = ++followRequestId
+		const outcome = await submitOptimisticFollow(
+			button,
+			() => requestId !== followRequestId,
+		)
+		if (outcome === 'unauthorized') {
+			window.location.assign('/login')
+		}
+	}
+
+	function handleFollowActivate(event: Event) {
+		const button = readFollowButtonFromEvent(event)
+		if (!button) return
+		event.preventDefault()
+		void submitFollow(button)
+	}
 
 	async function loadShell() {
 		const username = getCurrentUsername(handle)
@@ -234,7 +258,13 @@ export function ProfileRoute(handle: Handle) {
 		}
 
 		return (
-			<section mix={css(pageCss)}>
+			<section
+				mix={[
+					css(pageCss),
+					on('click', handleFollowActivate),
+					on('submit', handleFollowActivate),
+				]}
+			>
 				{readyShell?.isSelf ? (
 					<div mix={css(actionsCss)} data-testid="profile-actions">
 						<a href={routes.account.href()} mix={css(mutedLinkCss)}>

--- a/packages/worker/src/app/community-detail-content.node.test.ts
+++ b/packages/worker/src/app/community-detail-content.node.test.ts
@@ -112,6 +112,11 @@ test('community detail title star covers empty, starred, and logged-out states',
 	expect(emptyHtml).toContain('data-testid="community-detail-star"')
 	expect(emptyHtml).toContain('data-community-star')
 	expect(emptyHtml).toContain('data-starred="false"')
+	expect(emptyHtml).toContain('data-listing-name=')
+	expect(emptyHtml).toContain('data-community-star-label')
+	expect(emptyHtml).toContain('data-community-star-count')
+	expect(emptyHtml).toContain('data-community-follow')
+	expect(emptyHtml).toContain('data-follow-username="kentcdodds"')
 	expect(
 		emptyHtml.indexOf('data-testid="community-detail-star"'),
 	).toBeGreaterThan(emptyHtml.indexOf('<h1'))
@@ -134,5 +139,7 @@ test('community detail title star covers empty, starred, and logged-out states',
 	expect(loggedOutHtml).toContain(
 		'/login?redirectTo=%2F%40kentcdodds%2Fgithub-triage',
 	)
-	expect(loggedOutHtml).not.toContain('data-starred=')
+	expect(loggedOutHtml).not.toMatch(
+		/data-testid="community-detail-star"[^>]*data-starred=/,
+	)
 })

--- a/packages/worker/src/app/community-detail-content.tsx
+++ b/packages/worker/src/app/community-detail-content.tsx
@@ -238,7 +238,9 @@ export function CommunityDetailContent(
 				</div>
 				<div>
 					<dt>Stars</dt>
-					<dd data-testid="community-detail-stars">{listing.starCount}</dd>
+					<dd data-testid="community-detail-stars" data-community-star-count="">
+						{listing.starCount}
+					</dd>
 				</div>
 				<div>
 					<dt>Adaptation effort</dt>
@@ -266,7 +268,7 @@ function renderCommunityDetailStarControl(input: {
 	const label = input.starred
 		? `Unstar ${input.listingName}`
 		: `Star ${input.listingName}`
-	const glyph = renderCommunityStarGlyph(input.starred)
+	const glyph = renderCommunityStarGlyph()
 	if (!input.loggedIn) {
 		const loginHref = routes.login.href(null, {
 			searchParams: { redirectTo: input.returnTo },
@@ -291,15 +293,18 @@ function renderCommunityDetailStarControl(input: {
 			data-testid="community-detail-star"
 			data-community-star=""
 			data-starred={input.starred ? 'true' : 'false'}
-			mix={css(input.starred ? starredButtonCss : starButtonCss)}
+			data-listing-name={input.listingName}
+			mix={css(starButtonCss)}
 		>
 			{glyph}
-			<span mix={css(visuallyHiddenCss)}>{label}</span>
+			<span data-community-star-label="" mix={css(visuallyHiddenCss)}>
+				{label}
+			</span>
 		</button>
 	)
 }
 
-function renderCommunityStarGlyph(starred: boolean) {
+function renderCommunityStarGlyph() {
 	return (
 		<svg
 			viewBox="0 0 16 16"
@@ -307,9 +312,9 @@ function renderCommunityStarGlyph(starred: boolean) {
 			height="1em"
 			aria-hidden="true"
 			focusable={false}
-			fill={starred ? 'currentColor' : 'none'}
+			fill="none"
 			stroke="currentColor"
-			strokeWidth={starred ? 0 : 1.4}
+			strokeWidth={1.4}
 			strokeLinejoin="round"
 		>
 			<path d="M8 1.7 9.9 6.1l4.7.4-3.6 3.1 1.1 4.6L8 11.8l-4.1 2.4 1.1-4.6-3.6-3.1 4.7-.4z" />
@@ -389,17 +394,24 @@ const starButtonCss = {
 		outline: `2px solid ${colors.primary}`,
 		outlineOffset: '2px',
 	},
-}
-
-const starredButtonCss = {
-	...starButtonCss,
-	color: colors.primary,
-	borderColor: colors.primary,
-	backgroundColor: `oklch(from ${colors.primary} l c h / 0.13)`,
-	'&:hover': {
-		color: colors.primaryText,
-		borderColor: colors.primaryText,
-		backgroundColor: `oklch(from ${colors.primary} l c h / 0.2)`,
+	'& svg': {
+		fill: 'none',
+		stroke: 'currentColor',
+		strokeWidth: 1.4,
+	},
+	'&[data-starred="true"]': {
+		color: colors.primary,
+		borderColor: colors.primary,
+		backgroundColor: `oklch(from ${colors.primary} l c h / 0.13)`,
+		'& svg': {
+			fill: 'currentColor',
+			strokeWidth: 0,
+		},
+		'&:hover': {
+			color: colors.primaryText,
+			borderColor: colors.primaryText,
+			backgroundColor: `oklch(from ${colors.primary} l c h / 0.2)`,
+		},
 	},
 }
 

--- a/packages/worker/src/app/profile-content.node.test.ts
+++ b/packages/worker/src/app/profile-content.node.test.ts
@@ -105,7 +105,10 @@ test('profile packages link listings, prefer listing kody ids, and separate publ
 	expect(followingHtml).toMatch(/<div[^>]*data-testid="profile-username"/)
 	expect(followingHtml).not.toMatch(/<p[^>]*data-testid="profile-username"/)
 	expect(followingHtml).toContain('data-testid="profile-follow"')
+	expect(followingHtml).toContain('data-community-follow')
 	expect(followingHtml).toContain('data-following="true"')
+	expect(followingHtml).toContain('data-community-follow-label')
+	expect(followingHtml).toContain('data-community-follower-count')
 	expect(followingHtml).toContain('/profiles/kody/follow.json')
 	expect(followingHtml).toContain('data-testid="profile-follow-error"')
 	expect(followingHtml.indexOf('data-testid="profile-follow"')).toBeGreaterThan(

--- a/packages/worker/src/app/profile-content.tsx
+++ b/packages/worker/src/app/profile-content.tsx
@@ -158,7 +158,12 @@ export function ProfileContent(handle: Handle<ProfileContentProps>) {
 					</div>
 					<div>
 						<dt>Followers</dt>
-						<dd data-testid="profile-followers">{profile.followerCount}</dd>
+						<dd
+							data-testid="profile-followers"
+							data-community-follower-count=""
+						>
+							{profile.followerCount}
+						</dd>
 					</div>
 					<div>
 						<dt>Following</dt>

--- a/packages/worker/src/app/profile-follow-control.tsx
+++ b/packages/worker/src/app/profile-follow-control.tsx
@@ -30,14 +30,14 @@ export function renderProfileFollowControl(input: {
 				data-testid={input.testId}
 				mix={css(followButtonCss)}
 			>
-				{renderFollowGlyph(false)}
+				{renderFollowPlusGlyph()}
 				<span mix={css(visuallyHiddenCss)}>Follow @{input.username}</span>
 			</a>
 		)
 	}
 
 	return (
-		<div mix={css(followControlCss)}>
+		<div data-community-follow-control="" mix={css(followControlCss)}>
 			<form
 				method="post"
 				action={routes.profileFollowApiPost.href({ username: input.username })}
@@ -49,48 +49,47 @@ export function renderProfileFollowControl(input: {
 					type="submit"
 					title={input.isFollowing ? 'Unfollow' : 'Follow'}
 					data-testid={input.testId}
+					data-community-follow=""
+					data-follow-username={input.username}
 					data-following={input.isFollowing ? 'true' : 'false'}
 					mix={css(followButtonCss)}
 				>
-					{renderFollowGlyph(input.isFollowing)}
-					<span mix={css(visuallyHiddenCss)}>
+					{renderFollowGlyphs()}
+					<span data-community-follow-label="" mix={css(visuallyHiddenCss)}>
 						{input.isFollowing
 							? `Unfollow @${input.username}`
 							: `Follow @${input.username}`}
 					</span>
 				</button>
 			</form>
-			{input.followError ? (
-				<span
-					role="alert"
-					data-testid={input.errorTestId}
-					mix={css(followErrorCss)}
-				>
-					{input.followError}
-				</span>
-			) : null}
+			<span
+				role="alert"
+				hidden={input.followError ? undefined : true}
+				data-testid={input.errorTestId}
+				data-community-follow-error=""
+				mix={css(followErrorCss)}
+			>
+				{input.followError ?? ''}
+			</span>
 		</div>
 	)
 }
 
-function renderFollowGlyph(following: boolean) {
-	return following ? (
-		<svg
-			viewBox="0 0 16 16"
-			width="1em"
-			height="1em"
-			aria-hidden="true"
-			focusable={false}
-			fill="none"
-			stroke="currentColor"
-			strokeWidth="1.5"
-			strokeLinecap="round"
-			strokeLinejoin="round"
-		>
-			<circle cx="8" cy="8" r="5.4" />
-			<path d="M5.3 8.1 7.1 9.9 10.8 6.1" />
-		</svg>
-	) : (
+function renderFollowGlyphs() {
+	return (
+		<>
+			<span data-follow-glyph="follow" aria-hidden="true">
+				{renderFollowPlusGlyph()}
+			</span>
+			<span data-follow-glyph="following" aria-hidden="true">
+				{renderFollowCheckGlyph()}
+			</span>
+		</>
+	)
+}
+
+function renderFollowPlusGlyph() {
+	return (
 		<svg
 			viewBox="0 0 16 16"
 			width="1em"
@@ -105,6 +104,26 @@ function renderFollowGlyph(following: boolean) {
 		>
 			<circle cx="8" cy="8" r="5.4" />
 			<path d="M8 5.2v5.6M5.2 8h5.6" />
+		</svg>
+	)
+}
+
+function renderFollowCheckGlyph() {
+	return (
+		<svg
+			viewBox="0 0 16 16"
+			width="1em"
+			height="1em"
+			aria-hidden="true"
+			focusable={false}
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="1.5"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+		>
+			<circle cx="8" cy="8" r="5.4" />
+			<path d="M5.3 8.1 7.1 9.9 10.8 6.1" />
 		</svg>
 	)
 }
@@ -141,6 +160,18 @@ const followButtonCss = {
 	textDecoration: 'none',
 	cursor: 'pointer',
 	flexShrink: 0,
+	'& [data-follow-glyph="follow"]': {
+		display: 'inline-flex',
+	},
+	'& [data-follow-glyph="following"]': {
+		display: 'none',
+	},
+	'&[data-following="true"] [data-follow-glyph="follow"]': {
+		display: 'none',
+	},
+	'&[data-following="true"] [data-follow-glyph="following"]': {
+		display: 'inline-flex',
+	},
 	'&:hover': {
 		color: colors.primaryText,
 		borderColor: colors.primaryText,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Make starring a package and following a user feel instant.

## Why

The title star waited on a frame reload after the POST, so the filled/outline glyph lagged the click. Follow was a full form navigation. Both should flip immediately and only revert if the request fails.

## Summary

- Star and follow appearance is data-driven (`data-starred` / `data-following`), so the client can toggle the live control without swapping CSS objects or glyphs in JSX.
- Community detail intercepts star and owner-follow clicks, applies the next state and count immediately, POSTs JSON, then syncs or reverts. No `frame.reload()` on success.
- Profile follow uses the same optimistic path and updates the follower count.
- Account starred-packages list removes the row immediately and restores it on failure.
- Rapid clicks are last-write-wins instead of being blocked while a request is in flight.

## Testing

- `vitest run --project node-unit` for the new toggle helpers plus community detail / profile HTML tests
- Pre-push `test:push` (node-unit, workers-unit, e2e) passed on this branch
- Typecheck passed via the commit hook

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `631e5938` · **Head:** `21310b2a`

**Classification:** composes — no primitives added or changed; this PR wires existing listing and social APIs to optimistic client updates.

### Primitives touched

| Primitive | Group | Impact |
| ------------ | -------- | --------------------------------------- |
| `app-ui` | surfaces | composes — data-driven star/follow controls and last-write-wins JSON POSTs |
| `community-listings` | assistant | composes — community detail star no longer reloads the frame after a successful toggle |

### Change flow

A signed-in viewer click now updates the live control first, then the existing star/follow JSON APIs confirm or the UI reverts.

```mermaid
sequenceDiagram
	actor Viewer
	participant appUi as app-ui
	participant communityListings as community-listings
	Viewer->>appUi: click star or follow
	appUi->>appUi: flip data-starred or data-following immediately
	appUi->>communityListings: POST existing star.json or follow.json
	alt success
		communityListings-->>appUi: starred + starCount or following
		appUi->>appUi: sync count from payload without frame.reload
	else error
		communityListings-->>appUi: error payload
		appUi->>appUi: revert appearance and show the alert
	end
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d2e9331f-8e81-48a9-8bb2-55b7442a5065?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d2e9331f-8e81-48a9-8bb2-55b7442a5065&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Community stars and profile follows now update counts and button states immediately.
  * Follow and unfollow actions provide clearer feedback, including error messages and login redirects when needed.
  * Star and follow controls now expose improved accessibility labels and visual states.

* **Bug Fixes**
  * Failed optimistic updates now restore the previous count and control state.
  * Rapid follow actions are handled more reliably, preventing stale responses from overriding newer changes.

* **Tests**
  * Expanded coverage for star and follow interactions, response handling, rendered states, and accessibility attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->