### PR TITLE
Stop treating an up-to-date install as a copy prompt

### DIFF
--- a/packages/worker/src/app/community-detail-content.node.test.ts
+++ b/packages/worker/src/app/community-detail-content.node.test.ts
@@ -68,9 +68,35 @@ test('community detail head covers install, installed, and listing-ahead badges'
 	expect(installedHtml).toContain(
 		'data-testid="community-detail-viewer-install-badge"',
 	)
-	expect(installedHtml).toContain('data-copy-prompt')
-	expect(installedHtml).toContain(agentPrompt)
+	expect(installedHtml).toContain('Installed')
+	expect(installedHtml).not.toContain('data-copy-prompt')
+	expect(installedHtml).not.toContain(agentPrompt)
 	expect(installedHtml).not.toContain('data-testid="community-detail-install"')
+
+	const ownInstalledHtml = await renderCommunityDetailContentHtml({
+		listing: {
+			...sampleListing,
+			viewerInstall: {
+				status: 'installed',
+				targetName: '@kentcdodds/github-triage',
+				agentPrompt,
+				packageId: 'pkg-1',
+				listingAhead: false,
+				listingAheadPrompt: null,
+			},
+		},
+		...detailBase,
+		viewerIsOwner: true,
+		loggedIn: true,
+		starredByViewer: false,
+	})
+	expect(ownInstalledHtml).not.toContain(
+		'data-testid="community-detail-viewer-install-badge"',
+	)
+	expect(ownInstalledHtml).not.toContain(
+		'data-testid="community-detail-install"',
+	)
+	expect(ownInstalledHtml).not.toContain('data-copy-prompt')
 
 	const aheadPrompt =
 		'Compare the current listing snapshot, keep local customizations, then call community_fork_absorb.'

--- a/packages/worker/src/app/community-detail-content.tsx
+++ b/packages/worker/src/app/community-detail-content.tsx
@@ -107,6 +107,7 @@ export function CommunityDetailContent(
 							variant: 'detail',
 							loggedIn,
 							returnTo,
+							viewerIsOwner,
 						})}
 					</span>
 					{/* A div, not a p: the signed-in follow control is a form, and

--- a/packages/worker/src/app/community-listings-content.node.test.ts
+++ b/packages/worker/src/app/community-listings-content.node.test.ts
@@ -150,7 +150,8 @@ test('community listings render sort controls, categories, empty states, and for
 	expect(installedHtml).toContain(
 		'data-testid="community-listing-viewer-install-listing-1"',
 	)
-	expect(installedHtml).toContain('data-copy-prompt')
+	expect(installedHtml).toContain('Installed')
+	expect(installedHtml).not.toContain('data-copy-prompt')
 	expect(installedHtml).not.toContain(
 		'data-testid="community-listing-ahead-listing-1"',
 	)

--- a/packages/worker/src/app/community-listings-content.tsx
+++ b/packages/worker/src/app/community-listings-content.tsx
@@ -19,7 +19,6 @@ import { CommunityListingIcon } from '#universal/community-listing-icon.tsx'
 import {
 	FORKED_COPY_TOOLTIP,
 	FORK_OUTDATED_COPY_TOOLTIP,
-	INSTALLED_COPY_TOOLTIP,
 	renderCopyPromptPill,
 } from '#universal/fork-outdated-copy-button.tsx'
 import { routes } from '#universal/routes.ts'
@@ -296,7 +295,9 @@ export function renderCommunityViewerInstallBadge(input: {
 	variant: 'card' | 'detail'
 	loggedIn?: boolean
 	returnTo?: string
+	viewerIsOwner?: boolean
 }) {
+	if (input.viewerIsOwner) return null
 	const install = input.listing.viewerInstall
 	if (install?.listingAhead && install.listingAheadPrompt) {
 		return renderCopyPromptPill({
@@ -311,15 +312,22 @@ export function renderCommunityViewerInstallBadge(input: {
 		})
 	}
 	if (install) {
-		const installed = install.status === 'installed'
+		const testId =
+			input.variant === 'card'
+				? `community-listing-viewer-install-${input.listing.id}`
+				: 'community-detail-viewer-install-badge'
+		if (install.status === 'installed') {
+			return (
+				<span data-testid={testId} mix={css(communityViewerInstallStatusCss)}>
+					Installed
+				</span>
+			)
+		}
 		return renderCopyPromptPill({
-			label: installed ? 'Installed' : 'Forked',
+			label: 'Forked',
 			prompt: install.agentPrompt,
-			testId:
-				input.variant === 'card'
-					? `community-listing-viewer-install-${input.listing.id}`
-					: 'community-detail-viewer-install-badge',
-			tooltip: installed ? INSTALLED_COPY_TOOLTIP : FORKED_COPY_TOOLTIP,
+			testId,
+			tooltip: FORKED_COPY_TOOLTIP,
 			tone: 'badge',
 		})
 	}
@@ -607,6 +615,12 @@ const listingLinkCss = {
 		position: 'absolute' as const,
 		inset: 0,
 	},
+}
+
+const communityViewerInstallStatusCss = {
+	...communityStatusPillBoxCss,
+	color: colors.primaryText,
+	backgroundColor: `oklch(from ${colors.primary} l c h / 0.13)`,
 }
 
 /* The prototype's `.badge-trusted` pill; the detail head reuses it without

--- a/packages/worker/universal/fork-outdated-copy-button.tsx
+++ b/packages/worker/universal/fork-outdated-copy-button.tsx
@@ -14,8 +14,6 @@ import {
 export const COPY_PROMPT_ATTRIBUTE = 'data-copy-prompt'
 export const COPY_PROMPT_SELECTOR = '[data-copy-prompt]'
 export const FORK_OUTDATED_COPY_TOOLTIP = 'Click to copy an update prompt'
-export const INSTALLED_COPY_TOOLTIP =
-	'Click to copy a prompt to look up this package and adapt it'
 export const FORKED_COPY_TOOLTIP =
 	'Click to copy a prompt to finish adapting this fork'
 export const COPY_PROMPT_COPIED_TOOLTIP = 'Copied'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Make the Installed pill a status, not an action, and hide it on your own package.

## Why

An installed, current fork does not need a "copy a prompt to look up this package and adapt it" tooltip. That copy is for finishing or updating a fork. On your own listing the pill is noise.

## Summary

- Installed and up to date: render a static status pill. No button, tooltip, or clipboard prompt.
- Your own package: hide the viewer-install / Install pill entirely (including Fork outdated).
- Forked (needs adaptation) and Fork outdated still copy their prompts.

## Testing

- Node unit tests for community detail and listings HTML
- Pre-push `test:push` (node-unit, workers-unit, e2e) passed

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `631e5938` · **Head:** `ee542865`

**Classification:** composes — no primitives added or changed; this PR adjusts how the existing viewer-install pill is rendered.

### Primitives touched

| Primitive | Group | Impact |
| ------------ | -------- | --------------------------------------- |
| `app-ui` | surfaces | composes — Installed is a status span when current; hidden when the viewer owns the listing |

### Change flow

The community detail and listing frames pick the viewer-install control from existing install state.

```mermaid
sequenceDiagram
	actor Viewer
	participant appUi as app-ui
	Viewer->>appUi: open a community listing
	alt viewer owns the listing
		appUi->>appUi: omit Installed, Forked, Fork outdated, and Install
	else installed and up to date
		appUi->>appUi: render a static Installed status pill
	else forked or listing ahead
		appUi->>appUi: keep the existing copy-prompt button
	end
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d2e9331f-8e81-48a9-8bb2-55b7442a5065?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d2e9331f-8e81-48a9-8bb2-55b7442a5065&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installed listing indicators with a clear “Installed” status.
  * Removed unnecessary copy prompts and install controls for installed listings.
  * Hidden installation controls when viewing listings owned by the viewer.
  * Updated outdated-version prompts to clearly indicate that an update prompt can be copied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->