### PR TITLE
Include consumed invite code on user.created events

### DIFF
--- a/docs/contributing/architecture/authorization.md
+++ b/docs/contributing/architecture/authorization.md
@@ -397,9 +397,10 @@ the same threshold does not emit again.
 social-login signup, and admin-created person accounts fan `user.created`.
 Self-service account deletion fans `user.deleted`. Fan-out selects only packages
 whose owners hold the admin role at dispatch time. The event contains the stable
-user id, username, email, create source or delete timestamp. It omits passwords,
-roles, plan, secrets, and unrelated account content. Delivery is best-effort (no
-Queue) after the account change commits.
+user id, username, email, create source or delete timestamp, and the consumed
+invite code when `user.created` used one. It omits passwords, roles, plan,
+secrets, and unrelated account content. Delivery is best-effort (no Queue) after
+the account change commits.
 
 **Admins can see** operator-owned system mail for reserved platform addresses
 (`kody`, `support`, `abuse`, `postmaster`, `security`, and `admin`). That mail

--- a/docs/guides/package-subscriptions.md
+++ b/docs/guides/package-subscriptions.md
@@ -1086,6 +1086,7 @@ type UserCreatedEvent = {
 	}
 	source: 'signup' | 'oauth' | 'admin'
 	created_at: string
+	invite_code: string | null
 }
 
 type UserDeletedEvent = {
@@ -1100,7 +1101,9 @@ type UserDeletedEvent = {
 ```
 
 `user.id` is the stable account user id. `source` is the create path that
-committed. Timestamps are ISO-8601 UTC. The event omits passwords, roles, plan,
-secrets, packages, and unrelated account content. Notification copies already
-delivered outside Kody cannot be recalled after account deletion. Idempotency
-keys include the topic, user id, timestamp, and package id.
+committed. `invite_code` is the consumed, normalized invite code when signup
+used one, otherwise `null`. Timestamps are ISO-8601 UTC. The event omits
+passwords, roles, plan, secrets, packages, and unrelated account content.
+Notification copies already delivered outside Kody cannot be recalled after
+account deletion. Idempotency keys include the topic, user id, timestamp, and
+package id.

--- a/docs/use/privacy.md
+++ b/docs/use/privacy.md
@@ -89,13 +89,14 @@ This activity view never includes private package source, rating notes, email,
 stable user ids, private profiles, secrets, or unrelated account content.
 Admin-configured notification packages may receive the same community metadata,
 and a metadata-only `user.created` or `user.deleted` event when a person account
-is created or self-deleted (stable user id, username, email, and the create
-source or delete timestamp). Those lifecycle events omit passwords, roles, plan,
-secrets, and unrelated account content. Admin-configured notification packages
-may also receive a metadata-only `fleet.entitlement.crossed` event when a swept
-account first crosses 80% or 100% of a plan-limit resource, or when a non-admin
-account first exceeds the monthly runtime-duration threshold. Entitlement events
-include stable user id, username, resource counts, and admin dashboard URLs;
+is created or self-deleted (stable user id, username, email, the create source
+or delete timestamp, and the consumed invite code when `user.created` used one).
+Those lifecycle events omit passwords, roles, plan, secrets, and unrelated
+account content. Admin-configured notification packages may also receive a
+metadata-only `fleet.entitlement.crossed` event when a swept account first
+crosses 80% or 100% of a plan-limit resource, or when a non-admin account first
+exceeds the monthly runtime-duration threshold. Entitlement events include
+stable user id, username, resource counts, and admin dashboard URLs;
 runtime-duration events include stable user id, username, `total_duration_ms`,
 `threshold_ms`, and admin dashboard URLs. Both event kinds omit emails, plans,
 secrets, package source, and unrelated account content.

--- a/packages/worker/src/app/handlers/auth-handler.node.test.ts
+++ b/packages/worker/src/app/handlers/auth-handler.node.test.ts
@@ -448,6 +448,16 @@ test('auth handler login and signup workflow', async () => {
 			result: 'success',
 		}),
 	)
+	expect(lifecycleMocks.scheduleUserCreatedEvent).toHaveBeenCalledWith({
+		env: expect.anything(),
+		source: 'signup',
+		inviteCode: 'PROD-INVITE',
+		user: {
+			id: await createStableUserIdFromEmail('invited@example.com'),
+			username: 'invited-user',
+			email: 'invited@example.com',
+		},
+	})
 
 	const weakPasswordSignupResponse = await signupContext.request({
 		email: 'weak@example.com',
@@ -620,6 +630,7 @@ test('successful open signup schedules an admin user.created event', async () =>
 	expect(lifecycleMocks.scheduleUserCreatedEvent).toHaveBeenCalledWith({
 		env: expect.anything(),
 		source: 'signup',
+		inviteCode: null,
 		user: {
 			id: await createStableUserIdFromEmail(email),
 			username: 'newbie',

--- a/packages/worker/src/app/handlers/auth-provider.node.test.ts
+++ b/packages/worker/src/app/handlers/auth-provider.node.test.ts
@@ -334,6 +334,7 @@ test('github sign-in creates a verified account, then signs it back in', async (
 	expect(lifecycleMocks.scheduleUserCreatedEvent).toHaveBeenCalledWith({
 		env: expect.anything(),
 		source: 'oauth',
+		inviteCode: null,
 		user: {
 			id: await createStableUserIdFromEmail('octo@example.com'),
 			username: 'octo-cat',
@@ -1281,6 +1282,16 @@ test('production OAuth signup is invite-gated while existing connections still l
 			reason: expect.stringContaining('invite_code=SOCIAL-INVITE'),
 		}),
 	)
+	expect(lifecycleMocks.scheduleUserCreatedEvent).toHaveBeenCalledWith({
+		env: expect.anything(),
+		source: 'oauth',
+		inviteCode: 'SOCIAL-INVITE',
+		user: {
+			id: await createStableUserIdFromEmail('social-invited@example.com'),
+			username: user.username,
+			email: 'social-invited@example.com',
+		},
+	})
 
 	const existingLogin = createMigratedDb()
 	const existingEnv = createAppEnv(existingLogin.db, {

--- a/packages/worker/src/app/handlers/auth-provider.ts
+++ b/packages/worker/src/app/handlers/auth-provider.ts
@@ -720,6 +720,7 @@ export function createAuthProviderCallbackHandler(env: Env) {
 					email,
 				},
 				source: 'oauth',
+				inviteCode: consumedInviteCode,
 			})
 
 			void logAuditEvent({

--- a/packages/worker/src/app/handlers/auth.ts
+++ b/packages/worker/src/app/handlers/auth.ts
@@ -441,6 +441,7 @@ export function createAuthHandler(env: Env) {
 						email: normalizedEmail,
 					},
 					source: 'signup',
+					inviteCode: consumedInviteCode,
 				})
 
 				const cookie = await createAuthCookie(

--- a/packages/worker/src/identity/schedule-user-lifecycle-event.ts
+++ b/packages/worker/src/identity/schedule-user-lifecycle-event.ts
@@ -35,6 +35,7 @@ export function scheduleUserCreatedEvent(input: {
 	user: UserLifecycleIdentity
 	source: UserCreatedSource
 	createdAt?: string
+	inviteCode?: string | null
 }) {
 	scheduleUserLifecycleSubscriptionEvent({
 		env: input.env,
@@ -42,6 +43,7 @@ export function scheduleUserCreatedEvent(input: {
 			user: input.user,
 			source: input.source,
 			createdAt: input.createdAt ?? new Date().toISOString(),
+			inviteCode: input.inviteCode,
 		}),
 	})
 }

--- a/packages/worker/src/identity/user-lifecycle-subscription-event.node.test.ts
+++ b/packages/worker/src/identity/user-lifecycle-subscription-event.node.test.ts
@@ -32,6 +32,21 @@ test('user lifecycle event builders keep a metadata-only identity snapshot', () 
 		},
 		source: 'signup',
 		created_at: '2026-08-20T12:00:00.000Z',
+		invite_code: null,
+	})
+	expect(
+		buildUserCreatedEvent({
+			user: created.user,
+			source: 'oauth',
+			createdAt: '2026-08-20T12:00:00.000Z',
+			inviteCode: 'KODY-AAAA-BBBB-CCCC-DDDD',
+		}),
+	).toEqual({
+		event: userCreatedTopic,
+		user: created.user,
+		source: 'oauth',
+		created_at: '2026-08-20T12:00:00.000Z',
+		invite_code: 'KODY-AAAA-BBBB-CCCC-DDDD',
 	})
 	expect(deleted).toEqual({
 		event: userDeletedTopic,

--- a/packages/worker/src/identity/user-lifecycle-subscription-event.ts
+++ b/packages/worker/src/identity/user-lifecycle-subscription-event.ts
@@ -24,6 +24,7 @@ export type UserCreatedEvent = {
 	user: UserLifecycleIdentity
 	source: UserCreatedSource
 	created_at: string
+	invite_code: string | null
 }
 
 export type UserDeletedEvent = {
@@ -44,12 +45,14 @@ export function buildUserCreatedEvent(input: {
 	user: UserLifecycleIdentity
 	source: UserCreatedSource
 	createdAt: string
+	inviteCode?: string | null
 }): UserCreatedEvent {
 	return {
 		event: userCreatedTopic,
 		user: input.user,
 		source: input.source,
 		created_at: input.createdAt,
+		invite_code: input.inviteCode ?? null,
 	}
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Let admin-owned `user.created` subscribers (for example `@kentcdodds/user-lifecycle-discord`) show which invite a new account used, when one was used.

## Why

Password and OAuth signup already consume a normalized invite code, but the admin-only lifecycle snapshot omitted it. The Discord card therefore cannot show the code.

## Summary

- Add nullable `invite_code` to the `user.created` payload (`string | null`).
- Thread `inviteCode` through `buildUserCreatedEvent` / `scheduleUserCreatedEvent`.
- Password signup and OAuth signup pass `consumedInviteCode`. Admin create omits the argument, so the payload is `null`.
- The field is metadata-only: the consumed/normalized code (for example `KODY-XXXX-...`), not invite note, plan, or other invite-table columns.
- Garden the package-subscriptions contract plus the privacy and authorization field lists.

Surrounding subscription events already use present `string | null` fields rather than omitting unused keys, so `invite_code` is always on the snapshot.

## Testing

- `npx vitest run --project node-unit` on the event builder, dispatch, auth, OAuth, and admin-create suites: 5 files, 32 tests passed.
- Pre-push `test:node` (2096) and `test:workers` (301) passed. Local Playwright `webServer` timed out after `test:e2e:ensure` tried to install Chromium (known Cloud Agent hang); CI runs the same e2e job.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `631e5938` · **Head:** `5d0366fd`

**Classification:** extends — `user.created` gains a nullable `invite_code` field. Auth handlers only pass the already-consumed code through.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `app-sessions` | auth | composes — password and OAuth signup pass `consumedInviteCode` into `scheduleUserCreatedEvent` |
| `app-ui` | surfaces | composes — handler tests assert the scheduled payload |

Unmatched ownership (not a map `id`): `packages/worker/src/identity/user-lifecycle-subscription-event.ts` and `schedule-user-lifecycle-event.ts` — this is the contract change. No new primitive.

### Change flow

Password and OAuth signup already consume a normalized invite; this PR copies that code onto the admin `user.created` snapshot.

```mermaid
sequenceDiagram
	actor NewUser
	participant appSessions as app-sessions
	participant eventBuilder as user.created snapshot
	NewUser->>appSessions: password signup or OAuth callback
	appSessions->>appSessions: consumeInviteCode
	appSessions->>eventBuilder: scheduleUserCreatedEvent({ inviteCode })
	Note over eventBuilder: invite_code is the normalized code or null
```

### Before / after

```ts
// before
{ event, user, source, created_at }

// after
{ event, user, source, created_at, invite_code: string | null }
```

Admin create still omits `inviteCode`; the builder writes `null`.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f4c495b4-8caf-4cca-b9b7-646683e4c22f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f4c495b4-8caf-4cca-b9b7-646683e4c22f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * User-created lifecycle events now include the consumed, normalized invite code when signup used one.
  * The new `invite_code` field is `null` when no invite code was used.

* **Documentation**
  * Updated authorization, subscription, and privacy documentation to describe the invite code field and its behavior.

* **Tests**
  * Added coverage for invited and open signups, including OAuth-based registration flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->