### PR TITLE
Remove tautological test assertions

### DIFF
--- a/docs/contributing/testing-principles.md
+++ b/docs/contributing/testing-principles.md
@@ -57,8 +57,9 @@ factories explicitly inside each test (or a per-test factory). Do not introduce
     `toSummary(post)` returns). Use an independent oracle (hardcoded quoted
     string, live schema after migration).
   - Self-equality: `equal(x, x)`. Type-only checks, instructional-copy pins, and
-    absence-only deleted details (the next bullets) are the same failure mode. A
-    cheap syntactic checker cannot see this reliably; reject it in review.
+    a lone "q is not there" after a deletion (later bullets) are the same
+    failure mode. A cheap syntactic checker cannot see this reliably; reject it
+    in review.
 - Don't write tests for what the type system already guarantees.
 - Use disposable objects only when there is real cleanup. If no cleanup, skip
   `using` and `Symbol.dispose`.
@@ -86,13 +87,15 @@ factories explicitly inside each test (or a per-test factory). Do not introduce
   as tool descriptions, usage hints, warnings, or other instructional copy. If
   the behavior matters, test the behavior or stable structured contract rather
   than asserting that specific prose appears.
-- Do not commit tests whose only job is asserting a deleted implementation
-  detail is absent (old class names, old script filenames, old `aria-label`s,
-  leftover CSS selectors, renamed copy). Those cannot fail unless someone pastes
-  the old code back. Fine to use such checks locally while verifying a deletion.
-  Absence is a good assertion when the code still has a path that could show the
-  thing: loading vs ready, empty vs populated, secret vs redacted, branch A vs
-  branch B, or transform input vs output.
+- Keep absence assertions that flip state. "x is there, z is not; click y; now x
+  is gone and z is there" is useful. A lone "q is not there" after q was deleted
+  is not. That only fails if someone pastes the old name back. Fine to use
+  locally while deleting; do not commit it. Same for old class names, filenames,
+  aria-labels, CSS selectors, retired capability ids, and deleted table names on
+  a static inventory list. Absence is still a good assertion when a live path
+  could show the thing: loading vs ready, empty vs populated, secret vs
+  redacted, admin vs user, or generated SQL vs a table the generator could still
+  emit.
 - Run server/unit tests with `npm run test` (plus targeted Vitest paths when
   needed) to avoid Playwright spec discovery and accidental matches like
   `packages/worker/src/mcp/mcp-server.mcp-e2e.test.ts`.
@@ -162,6 +165,18 @@ expect(retries).toEqual([{ attempt: 1, nextDelayMs: 100 }])
 expect(windowsEqual(window, { ...window, end: window.end + 1 })).toBe(false)
 ```
 
+### Absence assertions
+
+```ts
+// Bad — q is gone; nothing can show it again
+expect(capabilityMap.old_write).toBeUndefined()
+expect(html).not.toContain('old-aria-label')
+
+// Good — state flip: present on one path, absent on the other
+expect(adminMap.admin_user_list).toBeTruthy()
+expect(userMap.admin_user_list).toBeUndefined()
+```
+
 ### `Symbol.dispose` with `using`
 
 ```ts
@@ -223,4 +238,21 @@ test('fetches from a disposable server', async () => {
 	const response = await fetch(server.url)
 	expect(await response.text()).toBe('ok')
 })
+```
+
+## Nightly cleanup
+
+A scheduled Cursor automation (Keep Tests Tight) re-reads this page and removes
+tests that do not meet the bar. Prompt for that automation:
+
+```
+If the default branch had no commits in the last 24 hours, exit early.
+
+Read docs/contributing/testing-principles.md and apply that bar. Agents often leave extra regression tests, tautological asserts (a value compared to itself), static-value pins, and lone "q is not there" checks after a deletion. Those help while verifying; they are not worth keeping.
+
+Keep absence asserts that flip state: x is there, z is not; click y; now x is gone and z is there. Delete a lone "q is not there" after q was removed.
+
+Edit, combine, or delete until every remaining test has an independent oracle and could still fail if a live path regresses. A test has to justify its existence.
+
+If you change anything: run formatting before each commit, open a ready-for-review PR, then follow .agents/skills/ship-pr/SKILL.md. Squash-merge when risk is low or medium and CI is green.
 ```

--- a/docs/contributing/testing-principles.md
+++ b/docs/contributing/testing-principles.md
@@ -41,6 +41,24 @@ factories explicitly inside each test (or a per-test factory). Do not introduce
 - Avoid shared mutable test state across cases. If the next assertion depends on
   the same rendered object, request, or response, it likely belongs in the same
   test.
+- Do not add tautological assertions. An assertion is tautological when it
+  cannot fail unless the implementation and the test change in lockstep — there
+  is no independent oracle. Typical forms:
+  - Identity predicates: `isFoo(FOO_CONSTANT)` when `isFoo` is `===`,
+    `includes`, or `Set.has` of that same constant. Keep the interesting
+    branches (normalization, prefix/suffix, negatives, Error wrapping, cause
+    chains).
+  - Constant-to-self pins: `expect(EXPORTED_DAYS).toBe(14)` or
+    `expect(exportedDelays).toEqual([100, 500, 1_500])`. If the value is a
+    public contract, assert it where a caller observes it (serialized payload,
+    HTTP body, retry `nextDelayMs`), not on the export itself.
+  - Algorithm echo: building `expected` with the same helper the production
+    function uses (`shellQuote(x)` on both sides; picking the same fields
+    `toSummary(post)` returns). Use an independent oracle (hardcoded quoted
+    string, live schema after migration).
+  - Self-equality: `equal(x, x)`. Type-only checks, instructional-copy pins, and
+    absence-only deleted details (the next bullets) are the same failure mode. A
+    cheap syntactic checker cannot see this reliably; reject it in review.
 - Don't write tests for what the type system already guarantees.
 - Use disposable objects only when there is real cleanup. If no cleanup, skip
   `using` and `Symbol.dispose`.
@@ -129,6 +147,20 @@ factories explicitly inside each test (or a per-test factory). Do not introduce
   and route `logAuditEvent` back through the shared spy.
 
 ## Examples
+
+### Tautological assertions
+
+```ts
+// Bad — matcher is `normalized === THE_CONSTANT`
+expect(isResetMessage(resetMessageConstant)).toBe(true)
+expect(exportedRetryDelaysMs).toEqual([100, 500, 1_500])
+expect(windowsEqual(window, window)).toBe(true)
+
+// Good — independent oracle or a real branch
+expect(isResetMessage(resetMessageConstant.replace(/\.$/, ''))).toBe(true)
+expect(retries).toEqual([{ attempt: 1, nextDelayMs: 100 }])
+expect(windowsEqual(window, { ...window, end: window.end + 1 })).toBe(false)
+```
 
 ### `Symbol.dispose` with `using`
 

--- a/packages/worker/client/routes/connect-oauth-chooser-list.node.test.ts
+++ b/packages/worker/client/routes/connect-oauth-chooser-list.node.test.ts
@@ -1,10 +1,7 @@
 import { expect, test } from 'vitest'
-import {
-	connectOauthChooserFilterMinOptions,
-	filterConnectOauthChooserOptions,
-} from './connect-oauth-chooser-list.ts'
+import { filterConnectOauthChooserOptions } from './connect-oauth-chooser-list.ts'
 
-test('connect chooser filter matches label, detail, and provider key and stays hidden at six options', () => {
+test('connect chooser filter matches label, detail, and provider key', () => {
 	const options = [
 		{
 			label: 'Google',
@@ -23,7 +20,6 @@ test('connect chooser filter matches label, detail, and provider key and stays h
 		},
 	]
 
-	expect(connectOauthChooserFilterMinOptions).toBe(6)
 	expect(filterConnectOauthChooserOptions(options, '')).toEqual(options)
 	expect(filterConnectOauthChooserOptions(options, '  built-in  ')).toEqual([
 		options[0],

--- a/packages/worker/client/routes/integration-provider-catalog.node.test.ts
+++ b/packages/worker/client/routes/integration-provider-catalog.node.test.ts
@@ -28,10 +28,6 @@ test('integration provider suggestions resolve guide-backed prompts and keep a g
 		expect(prompt).toContain(`provider_${provider.guideSlug}`)
 	}
 
-	expect(
-		integrationProviderSuggestions.some((provider) => provider.id === 'origin'),
-	).toBe(false)
-
 	const slack = integrationProviderSuggestions.find(
 		(provider) => provider.id === 'slack',
 	)

--- a/packages/worker/client/routes/landing-hero-agents.node.test.ts
+++ b/packages/worker/client/routes/landing-hero-agents.node.test.ts
@@ -1,5 +1,4 @@
 import { expect, test } from 'vitest'
-import { landingOrbitAgents } from '#universal/landing-agent-orbit.ts'
 import {
 	listAllWalkthroughHosts,
 	pickWalkthroughHosts,
@@ -18,11 +17,6 @@ import {
 
 test('hero ring always includes the pinned hosts and fills leftover slots from the SSR shuffle', () => {
 	const catalog = listAllWalkthroughHosts()
-	expect(landingHeroPinnedHostIds).toHaveLength(3)
-	expect(landingHeroSlots).toHaveLength(landingOrbitAgents.length)
-	expect(landingHeroSlots.map((slot) => ({ x: slot.x, y: slot.y }))).toEqual(
-		landingOrbitAgents.map((agent) => ({ x: agent.x, y: agent.y })),
-	)
 	expect(landingHeroSlots.length).toBeLessThan(catalog.length)
 
 	const fallback = placeLandingHeroAgents()

--- a/packages/worker/client/routes/onboarding-mcp-clients.node.test.ts
+++ b/packages/worker/client/routes/onboarding-mcp-clients.node.test.ts
@@ -14,11 +14,9 @@ import {
 	buildOpenCodeMcpJson,
 	buildVsCodeInstallUrl,
 	buildVsCodeMcpJson,
-	codexMcpLoginCommand,
 	defaultKodyMcpUrl,
 	isDefaultKodyMcpUrl,
 	mcpClientTabs,
-	openCodeMcpAuthCommand,
 } from './onboarding-mcp-clients.ts'
 
 const mcpServerUrl = defaultKodyMcpUrl
@@ -42,7 +40,6 @@ test('onboarding MCP client builders emit the structured configs each host expec
 		mcpClientTabs.filter((tab) => tab.isNonCodingAgent).map((tab) => tab.id),
 	).toEqual(['chatgpt', 'claude-desktop', 'grok', 'grok-bot', 'copilot-app'])
 
-	expect(isDefaultKodyMcpUrl(mcpServerUrl)).toBe(true)
 	expect(isDefaultKodyMcpUrl(`${mcpServerUrl}/`)).toBe(true)
 	expect(isDefaultKodyMcpUrl('http://localhost:3742/mcp')).toBe(false)
 	expect(buildKodyCliInstallCommand(mcpServerUrl)).toBe(
@@ -69,11 +66,9 @@ test('onboarding MCP client builders emit the structured configs each host expec
 	expect(buildCodexMcpAddCommand(mcpServerUrl)).toBe(
 		`codex mcp add kody --url ${mcpServerUrl}`,
 	)
-	expect(codexMcpLoginCommand).toBe('codex mcp login kody')
 	expect(buildOpenCodeMcpAddCommand(mcpServerUrl)).toBe(
 		`opencode mcp add kody --url ${mcpServerUrl}`,
 	)
-	expect(openCodeMcpAuthCommand).toBe('opencode mcp auth kody')
 	expect(JSON.parse(buildVsCodeMcpJson(mcpServerUrl))).toEqual({
 		servers: {
 			kody: {

--- a/packages/worker/client/routes/walkthrough-host-intro.node.test.ts
+++ b/packages/worker/client/routes/walkthrough-host-intro.node.test.ts
@@ -32,7 +32,6 @@ test('host intro names the three story agents as styleable selects', async () =>
 	expect(html).toContain(`/images/icons/${hosts.coding.icon}.svg`)
 	expect(html).toContain('@supports (appearance: base-select)')
 	expect(html).toContain('@supports not (appearance: base-select)')
-	expect(html).not.toContain('data-native')
 	expect(latest).toEqual(hosts)
 
 	const picker = await renderToString(
@@ -52,9 +51,6 @@ test('host intro names the three story agents as styleable selects', async () =>
 	expect(picker).toContain('aria-label="Chat agent on your phone"')
 	expect(picker).toContain('aria-label="Another agent you sometimes use"')
 	expect(picker).not.toContain("Let's say you use")
-	expect(picker).not.toContain('Daily coding agent')
-	expect(picker).not.toContain('Phone Chat agent')
-	expect(picker).not.toContain('Secondary coding agent')
 })
 
 test('how-kody-works walkthrough uses the intro and host marks instead of the old lead', async () => {
@@ -63,7 +59,6 @@ test('how-kody-works walkthrough uses the intro and host marks instead of the ol
 
 	expect(html).toContain("Let's say you use")
 	expect(html).not.toContain('A question you would ask again')
-	expect(html).not.toContain('Example of a conversation')
 	expect(html).toContain(`>${hosts.coding.label}</figcaption>`)
 	expect(html).toContain('What your agents')
 	expect(html).toContain(`/images/icons/${hosts.coding.icon}.svg`)
@@ -83,6 +78,4 @@ test('how-kody-works walkthrough uses the intro and host marks instead of the ol
 	expect(html).not.toContain('You start on the computer with {coding}.')
 	expect(html).not.toContain('Later, on your phone with {invoke}.')
 	expect(html).not.toContain('Later still, with {notify}.')
-	expect(html).not.toContain('a different agent')
-	expect(html).not.toContain('another Kody-connected agent')
 })

--- a/packages/worker/src/account/data-targets.node.test.ts
+++ b/packages/worker/src/account/data-targets.node.test.ts
@@ -258,12 +258,6 @@ test('operator-owned tables are explicit deletion/export exclusions', () => {
 })
 
 test('final schema drops entitlement_daily_counters without stale inventory coverage', () => {
-	expect(getAccountExportExcludedD1Surfaces()).not.toEqual(
-		expect.arrayContaining([
-			expect.objectContaining({ name: 'entitlement_daily_counters' }),
-		]),
-	)
-
 	const deletionStatements = accountUserDataTargets.map((target) => {
 		const match = matchFor(target)
 		return buildUserScopedDeleteOrUpdateSql(match).sql
@@ -311,7 +305,6 @@ test('final schema drops entitlement_daily_counters without stale inventory cove
 		}
 	}
 	const coveredColumns = getAccountD1UserColumnCoverage()
-	expect(coveredColumns.has('entitlement_daily_counters.user_id')).toBe(false)
 	expect(liveUserColumns.has('entitlement_daily_counters.user_id')).toBe(false)
 	const missing = [...liveUserColumns].filter(
 		(column) => !coveredColumns.has(column),
@@ -385,7 +378,6 @@ test('final schema drops legacy RunLog D1 projections without stale inventory co
 	}
 	const coveredColumns = getAccountD1UserColumnCoverage()
 	for (const table of retiredTables) {
-		expect(coveredColumns.has(`${table}.user_id`)).toBe(false)
 		expect(liveUserColumns.has(`${table}.user_id`)).toBe(false)
 	}
 	const missing = [...liveUserColumns].filter(

--- a/packages/worker/src/account/data-targets.node.test.ts
+++ b/packages/worker/src/account/data-targets.node.test.ts
@@ -197,7 +197,6 @@ test('every accountUserDataTargets kind has a shared match builder and export gu
 	expect(accountExportForeignUserIdColumnsByTable.user_follows).toEqual(
 		expect.arrayContaining(['follower_user_id', 'followee_user_id']),
 	)
-	expect(typeof accountExportRedactedForeignUserId).toBe('string')
 	expect(accountExportRedactedForeignUserId.length).toBeGreaterThan(0)
 
 	const excludedListingChildren = accountUserDataTargets.filter(
@@ -259,12 +258,6 @@ test('operator-owned tables are explicit deletion/export exclusions', () => {
 })
 
 test('final schema drops entitlement_daily_counters without stale inventory coverage', () => {
-	expect(
-		accountUserDataTargets.some(
-			(target) =>
-				'table' in target && target.table === 'entitlement_daily_counters',
-		),
-	).toBe(false)
 	expect(getAccountExportExcludedD1Surfaces()).not.toEqual(
 		expect.arrayContaining([
 			expect.objectContaining({ name: 'entitlement_daily_counters' }),
@@ -336,13 +329,6 @@ test('final schema drops legacy RunLog D1 projections without stale inventory co
 		'user_package_run_successes',
 		'user_activation_milestones',
 	] as const
-	for (const table of retiredTables) {
-		expect(
-			accountUserDataTargets.some(
-				(target) => 'table' in target && target.table === table,
-			),
-		).toBe(false)
-	}
 
 	const deletionStatements = accountUserDataTargets.map((target) => {
 		const match = matchFor(target)

--- a/packages/worker/src/account/export.node.test.ts
+++ b/packages/worker/src/account/export.node.test.ts
@@ -277,11 +277,6 @@ test('account export documents and excludes operator-owned system email rows', a
 			}),
 		]),
 	)
-	expect(accountExport.manifest.excludedD1Surfaces).not.toEqual(
-		expect.arrayContaining([
-			expect.objectContaining({ name: 'entitlement_daily_counters' }),
-		]),
-	)
 	expect(accountExport.d1).not.toHaveProperty('entitlement_daily_counters')
 })
 

--- a/packages/worker/src/account/user-owned-surfaces.node.test.ts
+++ b/packages/worker/src/account/user-owned-surfaces.node.test.ts
@@ -131,17 +131,6 @@ test('account deletion and export consume the out-of-band surface registry', () 
 			(surface) => surface.id === 'run_log',
 		)?.notes,
 	).toMatch(/There are no D1 tables workflow_runs/)
-	expect(
-		accountUserOwnedDurableObjectSurfaces.find(
-			(surface) => surface.id === 'run_log',
-		)?.notes,
-	).not.toMatch(/retired by migration|quiescent pending/)
-	expect(
-		accountUserOwnedDurableObjectSurfaces.find(
-			(surface) => surface.id === 'user_meter',
-		)?.notes,
-	).not.toMatch(/dropped by migration|Migration 0141 dropped/)
-
 	expect(accountDeletionSource).toContain(
 		"from '#worker/account/user-owned-surfaces.ts'",
 	)

--- a/packages/worker/src/app/account-billing-data.node.test.ts
+++ b/packages/worker/src/app/account-billing-data.node.test.ts
@@ -66,7 +66,6 @@ test('loadAccountBillingData refreshes Stripe status and degrades when refresh i
 		'totally_new_code',
 	)
 	expect(resolveBillingErrorMessage(null)).toBeUndefined()
-	expect(typeof resolveBillingErrorMessage('no_customer')).toBe('string')
 
 	refreshStripePlanForUser.mockResolvedValueOnce({
 		stripePlan: 'pro',

--- a/packages/worker/src/app/account-retention-dispositions.node.test.ts
+++ b/packages/worker/src/app/account-retention-dispositions.node.test.ts
@@ -56,14 +56,6 @@ test('retention dispositions stay aligned with scheduled policies and documented
 	).toBe(true)
 	expect(
 		nonScheduled.some(
-			(disposition) => disposition.table === 'entitlement_daily_counters',
-		),
-	).toBe(false)
-	expect(getRetentionPolicyCoverage().has('entitlement_daily_counters')).toBe(
-		false,
-	)
-	expect(
-		nonScheduled.some(
 			(disposition) =>
 				disposition.table === 'mcp_memories' &&
 				disposition.kind === 'durable_forever',
@@ -76,14 +68,6 @@ test('retention dispositions stay aligned with scheduled policies and documented
 				disposition.kind === 'durable_forever',
 		),
 	).toBe(true)
-	expect(
-		nonScheduled.some((disposition) => disposition.table === 'workflow_runs'),
-	).toBe(false)
-	expect(
-		nonScheduled.some(
-			(disposition) => disposition.table === 'user_package_run_successes',
-		),
-	).toBe(false)
 	// The schema-growth heuristic in retention.node.test.ts remains the broader
 	// guardrail for discovering new growth-pattern tables.
 	expect(getRetentionPolicyCoverage().has('mcp_memories')).toBe(true)

--- a/packages/worker/src/app/onboarding-data.node.test.ts
+++ b/packages/worker/src/app/onboarding-data.node.test.ts
@@ -39,8 +39,6 @@ test('onboarding data builds the MCP URL and derives incomplete setup from verif
 		}),
 	).toContain('https://preview.example/guides/quick-example')
 	expect(buildOnboardingSetupPrompt()).toContain('give Kody access')
-	expect(buildOnboardingSetupPrompt()).not.toContain('community_fork')
-	expect(buildOnboardingSetupPrompt()).not.toContain('kody:@kody/')
 
 	expect(
 		loadPublicOnboardingData({
@@ -191,8 +189,6 @@ test('onboarding data builds the MCP URL and derives incomplete setup from verif
 	expect(withCustomPersist.persistPrompt).toContain(
 		'I gave Kody access to acme',
 	)
-	expect(withCustomPersist.persistPrompt).not.toContain('community_fork')
-	expect(withCustomPersist.persistPrompt).not.toContain('kody:@kody/')
 	expect(withCustomPersist.customMcpServers).toEqual([])
 
 	const withExamplePersist = await loadOnboardingData({

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -615,7 +615,6 @@ test('renderAppPage emits a doctype, meta description, and inlines the styleshee
 		withoutAssetsHtml.match(/aria-label="Agents Kody plugs into"/g),
 	).toEqual(['aria-label="Agents Kody plugs into"'])
 	expect(withoutAssetsHtml).toContain('landing-hero-agent-light')
-	expect(withoutAssetsHtml).not.toContain('landing-hero-hosts')
 	expect(withoutAssetsHtml).toContain('Kody keeps it')
 	expect(withoutAssetsHtml).toContain('href="/images/hero/kody-base-640.webp"')
 	expect(withoutAssetsHtml).toContain('kody-base-960.webp')

--- a/packages/worker/src/blog/catalog.node.test.ts
+++ b/packages/worker/src/blog/catalog.node.test.ts
@@ -1,10 +1,5 @@
 import { expect, test } from 'vitest'
-import {
-	getBlogPost,
-	getReadNextBlogPost,
-	listBlogPosts,
-	toBlogPostSummary,
-} from './catalog.ts'
+import { getBlogPost, getReadNextBlogPost, listBlogPosts } from './catalog.ts'
 import { parseBlogPostMarkdown } from './parse-frontmatter.ts'
 import { buildBlogRssXml } from './rss.ts'
 
@@ -168,13 +163,6 @@ test('blog catalog enumerates posts with required fields and slug lookup', () =>
 		expect(Number.isInteger(post.order)).toBe(true)
 		expect(post.body.length).toBeGreaterThan(0)
 		expect(getBlogPost(post.slug)).toEqual(post)
-		expect(toBlogPostSummary(post)).toEqual({
-			slug: post.slug,
-			title: post.title,
-			date: post.date,
-			description: post.description,
-			order: post.order,
-		})
 	}
 
 	const comparison = getBlogPost('kody-vs-executor')

--- a/packages/worker/src/durable-object-reset-retry.node.test.ts
+++ b/packages/worker/src/durable-object-reset-retry.node.test.ts
@@ -5,31 +5,21 @@ import {
 	durableObjectSqliteOutOfMemoryMessage,
 } from '#worker/sentry-options.ts'
 import {
-	durableObjectResetRetryDelaysMs,
 	isTransientDurableObjectResetError,
 	runWithTransientDurableObjectResetRetry,
 } from './durable-object-reset-retry.ts'
 
 test('transient Durable Object reset retry recovers thrown and result errors then exhausts', async () => {
-	expect(durableObjectResetRetryDelaysMs).toEqual([100, 500, 1_500])
 	expect(
 		isTransientDurableObjectResetError(
 			new Error(durableObjectCodeUpdatedResetMessage),
 		),
 	).toBe(true)
 	expect(
-		isTransientDurableObjectResetError(durableObjectCodeUpdatedResetMessage),
-	).toBe(true)
-	expect(
 		isTransientDurableObjectResetError(
 			new Error('wrapped', {
 				cause: new Error(durableObjectCodeUpdatedResetMessage),
 			}),
-		),
-	).toBe(true)
-	expect(
-		isTransientDurableObjectResetError(
-			durableObjectInstanceInactiveCloseMessage,
 		),
 	).toBe(true)
 	expect(

--- a/packages/worker/src/email/mailbox-inbound-ledger.workers.test.ts
+++ b/packages/worker/src/email/mailbox-inbound-ledger.workers.test.ts
@@ -36,7 +36,6 @@ test('Mailbox inbound ledger CAS covers USER authority transition matrix', async
 	await runInDurableObject(
 		stubFor(ownerA),
 		async (_instance: Mailbox, state) => {
-			expect(mailboxSchemaVersion).toBe(5)
 			const version = state.storage.sql
 				.exec<{ value: number }>(
 					`SELECT value FROM mailbox_meta WHERE key = ?`,

--- a/packages/worker/src/execute-maintenance.node.test.ts
+++ b/packages/worker/src/execute-maintenance.node.test.ts
@@ -35,8 +35,6 @@ test('runExecuteSmokeCheck executes trivial code through the origin gateway and 
 		proves: executeSmokeProves,
 		notMcpExecute: true,
 	})
-	expect(executeSmokeScope).toBe('origin-only')
-	expect(executeSmokeProves).toBe('origin-kody-fetch-gateway')
 	expect(createExecuteExecutorMock).toHaveBeenCalledWith(
 		expect.objectContaining({
 			timeoutMs: 10_000,

--- a/packages/worker/src/identity/git-author-identity.node.test.ts
+++ b/packages/worker/src/identity/git-author-identity.node.test.ts
@@ -2,7 +2,6 @@ import { expect, test } from 'vitest'
 import {
 	gitAuthorIdentityFromUser,
 	gitAuthorSetupCommands,
-	shellQuote,
 } from './git-author-identity.ts'
 
 test('git author identity uses the Kody account and quotes setup commands', () => {
@@ -33,11 +32,9 @@ test('git author identity uses the Kody account and quotes setup commands', () =
 		email: "o'brien@example.com",
 	})
 	expect(quoted).toEqual([
-		`git config --local user.email -- ${shellQuote("o'brien@example.com")}`,
-		`git config --local user.name -- ${shellQuote("O'Brien")}`,
+		`git config --local user.email -- 'o'"'"'brien@example.com'`,
+		`git config --local user.name -- 'O'"'"'Brien'`,
 	])
-	expect(quoted[0]).toContain(`'"'"'`)
-	expect(quoted[1]).toContain(`'"'"'`)
 
 	const dashed = gitAuthorSetupCommands({
 		name: '-dash-name',

--- a/packages/worker/src/identity/user-lifecycle-subscription-event.node.test.ts
+++ b/packages/worker/src/identity/user-lifecycle-subscription-event.node.test.ts
@@ -38,8 +38,6 @@ test('user lifecycle event builders keep a metadata-only identity snapshot', () 
 		user: created.user,
 		deleted_at: '2026-08-20T13:00:00.000Z',
 	})
-	expect(isUserLifecycleEventTopic(userCreatedTopic)).toBe(true)
-	expect(isUserLifecycleEventTopic(userDeletedTopic)).toBe(true)
 	expect(isUserLifecycleEventTopic('user.updated')).toBe(false)
 	expect(
 		buildUserLifecycleIdempotencyKey({

--- a/packages/worker/src/mcp/capabilities/registry.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/registry.node.test.ts
@@ -62,9 +62,7 @@ test('getStaticRegistry memoizes the builtin registry', () => {
 	const first = getStaticRegistry()
 	const second = getStaticRegistry()
 	expect(first).toBe(second)
-	expect(first.capabilityMap.email_send).toBeTruthy()
 	expect(Object.keys(first.capabilitySpecs).length).toBeGreaterThan(0)
-	expect('email_send' in first.capabilityMap).toBe(true)
 })
 
 test('getCapabilityRegistryForContext filters admin capabilities by current caller roles', async () => {
@@ -117,25 +115,4 @@ test('getCapabilityRegistryForContext filters admin capabilities by current call
 	expect(
 		regularRegistry.capabilityDomains.some((domain) => domain.name === 'admin'),
 	).toBe(false)
-})
-
-test('the email domain no longer exposes self-service inbox or sender-identity capabilities', () => {
-	// Inboxes are auto-provisioned at {username}@<platform domain> and the
-	// outbound from address is platform-assigned, so these capabilities were
-	// removed and must never come back silently.
-	const { capabilityMap } = getStaticRegistry()
-	expect(capabilityMap.email_inbox_create).toBeUndefined()
-	expect(capabilityMap.email_sender_identity_verify).toBeUndefined()
-	expect(capabilityMap.email_inbox_list).toBeTruthy()
-	expect(capabilityMap.email_send).toBeTruthy()
-	expect(capabilityMap.email_reply).toBeTruthy()
-	expect(capabilityMap.email_message_list).toBeTruthy()
-	expect(capabilityMap.email_message_get).toBeTruthy()
-	expect(capabilityMap.email_message_classify).toBeTruthy()
-	expect(capabilityMap.email_sender_rule_list).toBeTruthy()
-	expect(capabilityMap.email_sender_rule_set).toBeTruthy()
-	expect(capabilityMap.email_sender_rule_delete).toBeTruthy()
-	expect(capabilityMap.admin_system_email_sender_rule_list).toBeTruthy()
-	expect(capabilityMap.admin_system_email_sender_rule_set).toBeTruthy()
-	expect(capabilityMap.admin_system_email_sender_rule_delete).toBeTruthy()
 })

--- a/packages/worker/src/mcp/capabilities/repo/package-artifact-rebuild.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/repo/package-artifact-rebuild.node.test.ts
@@ -1,6 +1,5 @@
 import { expect, test, vi } from 'vitest'
 import { consoleWarn } from '#worker/test-support/console-spies.ts'
-import { publishedPackageArtifactRebuildConcurrency } from './package-artifact-rebuild.ts'
 
 const mockModule = vi.hoisted(() => ({
 	listPublishedPackageArtifactTargets: vi.fn(),
@@ -65,7 +64,6 @@ function resetMocks() {
 }
 
 test('isolated rebuild lists then stages once, fans out with bounded concurrency, and discards staging', async () => {
-	expect(publishedPackageArtifactRebuildConcurrency).toBe(2)
 	resetMocks()
 
 	const run = vi.fn(async () => ({

--- a/packages/worker/src/mcp/capabilities/values/value-capabilities.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/values/value-capabilities.node.test.ts
@@ -64,7 +64,7 @@ test('value list treats underscore-prefixed names as ordinary leftovers', async 
 	])
 })
 
-test('values domain is unadvertised and value_set is not a capability', () => {
+test('values domain is unadvertised while read and delete stay on the map', () => {
 	const registry = getStaticRegistry()
 	expect(
 		registry.capabilityDomains.some((domain) => domain.name === 'values'),
@@ -72,16 +72,12 @@ test('values domain is unadvertised and value_set is not a capability', () => {
 	expect(registry.capabilitySpecs.value_get).toBeUndefined()
 	expect(registry.capabilitySpecs.value_list).toBeUndefined()
 	expect(registry.capabilitySpecs.value_delete).toBeUndefined()
-	expect(registry.capabilitySpecs.value_set).toBeUndefined()
 	expect(registry.capabilityMap.value_get).toBeTruthy()
 	expect(registry.capabilityMap.value_list).toBeTruthy()
 	expect(registry.capabilityMap.value_delete).toBeTruthy()
-	expect(registry.capabilityMap.value_set).toBeUndefined()
 	expect(createRemovedValueWriteError().message).toBe(removedValueWriteMessage)
 	expect(removedValueWriteMessage).toMatch(/memories/)
 	expect(removedValueWriteMessage).toMatch(/packageStorage/)
 	expect(removedValueWriteMessage).toMatch(/repo/)
 	expect(removedValueWriteMessage).toMatch(/secrets/)
-	expect(removedValueWriteMessage.toLowerCase()).not.toMatch(/retir/)
-	expect(removedValueWriteMessage).not.toMatch(/value_set/)
 })

--- a/packages/worker/src/mcp/evaluation-side-effects.node.test.ts
+++ b/packages/worker/src/mcp/evaluation-side-effects.node.test.ts
@@ -5,7 +5,6 @@ import {
 	evaluationHasHostMediatedSideEffects,
 	hostSideEffectProviderName,
 	isPlatformOnlyHostSideEffectProvider,
-	staticCallMeterRuntimeBridgeProviderName,
 } from './evaluation-side-effects.ts'
 
 test('evaluation side-effect tracker counts attempts and treats a missing snapshot as dirty', () => {
@@ -39,14 +38,6 @@ test('evaluation side-effect tracker counts attempts and treats a missing snapsh
 	})
 	expect(evaluationHasHostMediatedSideEffects(fetchOnly.snapshot())).toBe(true)
 
-	expect(isPlatformOnlyHostSideEffectProvider(hostSideEffectProviderName)).toBe(
-		true,
-	)
-	expect(
-		isPlatformOnlyHostSideEffectProvider(
-			staticCallMeterRuntimeBridgeProviderName,
-		),
-	).toBe(true)
 	expect(isPlatformOnlyHostSideEffectProvider('kody')).toBe(false)
 
 	const provider = createHostSideEffectProvider(fetchOnly)

--- a/packages/worker/src/mcp/run-kody-registry.node.test.ts
+++ b/packages/worker/src/mcp/run-kody-registry.node.test.ts
@@ -2030,14 +2030,7 @@ test('runBundledModuleWithRegistry passes params and injects runtime helpers', a
 		)
 		expect(packageResult.result).toBe('ok')
 		expect(providerFns).not.toBeNull()
-		expect(providerFns?.package_invoke_check).toBeUndefined()
-		expect(providerFns?.package_invoke).toBeUndefined()
-		expect(providerFns?.package_invoke_checked).toBeUndefined()
 		expect(packageBridgeFns).not.toBeNull()
-		// Unsupported helpers have no bridge tools; only invoke crosses the
-		// sandbox boundary.
-		expect(packageBridgeFns?.check).toBeUndefined()
-		expect(packageBridgeFns?.invokeChecked).toBeUndefined()
 		await expect(
 			packageBridgeFns?.invoke({
 				specifier:

--- a/packages/worker/src/mcp/secrets/errors.node.test.ts
+++ b/packages/worker/src/mcp/secrets/errors.node.test.ts
@@ -1,12 +1,9 @@
 import { expect, test } from 'vitest'
 import {
-	capabilityInputSecretAuthRequiredMessage,
 	createCapabilitySecretAccessDeniedMessage,
 	createCapabilitySecretAccessDeniedBatchMessage,
 	createHostSecretAccessDeniedBatchMessage,
 	createMissingSecretMessage,
-	fetchSecretAuthRequiredMessage,
-	isSecretAuthRequiredMessage,
 	parseCapabilityAccessRequiredBatchMessage,
 	parseCapabilityAccessRequiredMessage,
 	parseHostApprovalRequiredBatchMessage,
@@ -15,10 +12,6 @@ import {
 } from './errors.ts'
 
 test('secret error message helpers parse auth, missing-secret, and approval payloads', () => {
-	expect(isSecretAuthRequiredMessage(fetchSecretAuthRequiredMessage)).toBe(true)
-	expect(
-		isSecretAuthRequiredMessage(capabilityInputSecretAuthRequiredMessage),
-	).toBe(true)
 	expect(
 		parseMissingSecretMessage(createMissingSecretMessage('lutronPassword')),
 	).toEqual({

--- a/packages/worker/src/mcp/server-instructions.node.test.ts
+++ b/packages/worker/src/mcp/server-instructions.node.test.ts
@@ -48,16 +48,6 @@ test('popular package MCP instructions omit cold start, list kody ids under budg
 	})
 	expect(instructions).toMatch(/`notes`/)
 	expect(instructions).toContain('Prefer concise replies.')
-	expect(instructions).not.toContain('Retiring primitives')
-
-	const affected = buildMcpServerInstructions({
-		popularPackages: [{ kodyId: 'notes', description: 'Scratch notes' }],
-		userOverlay: 'Prefer concise replies.',
-		domains: [],
-		retiringNoticeIds: new Set(),
-	})
-	expect(affected).not.toContain('Retiring primitives')
-	expect(affected).not.toContain('coding_guide_get({ guide: "values" })')
 })
 
 test('domain instructions list builtins and summarize connected bindings', () => {

--- a/packages/worker/src/package-invocations/service.node.test.ts
+++ b/packages/worker/src/package-invocations/service.node.test.ts
@@ -1250,10 +1250,6 @@ test('runtime invoke tools expose only the supported invoke helper', () => {
 	const tools = createRuntimeDispatchTools(db) as Record<string, unknown>
 
 	expect(typeof tools.invoke).toBe('function')
-	// Sandbox teaching stubs reject unsupported names; the host tool set
-	// exposes only invoke.
-	expect(tools.check).toBeUndefined()
-	expect(tools.invokeChecked).toBeUndefined()
 })
 
 test('runtime invoke tools reject the removed object API before resolving a target', async () => {

--- a/packages/worker/src/repo/large-file-policy.node.test.ts
+++ b/packages/worker/src/repo/large-file-policy.node.test.ts
@@ -35,6 +35,5 @@ test('large-file policy measures UTF-8 bytes, finds the first oversize file, and
 		byteLength: maxRepoSourceFileBytes + 1,
 	})
 	expect(message).toContain('"assets/too-big.txt"')
-	expect(isRepoLargeFileMessage(message)).toBe(true)
 	expect(isRepoLargeFileMessage('Source "x" was not found.')).toBe(false)
 })

--- a/packages/worker/src/run-records/continuity-and-retention.workers.test.ts
+++ b/packages/worker/src/run-records/continuity-and-retention.workers.test.ts
@@ -114,10 +114,6 @@ test('job observability counters start from zero on first terminal finish', asyn
 		lastRunStatus: 'error',
 		lastRunError: 'new failure',
 	})
-	expect(
-		await getJobRunObservability({ env, userId, jobId }),
-	).not.toHaveProperty('legacySeeded')
-
 	const second = beginRunRecord({
 		env,
 		userId,

--- a/packages/worker/src/run-records/stale-running-interrupt.node.test.ts
+++ b/packages/worker/src/run-records/stale-running-interrupt.node.test.ts
@@ -1,8 +1,6 @@
 import { expect, test } from 'vitest'
 import {
 	runErrorTriageForPlatformInterrupt,
-	runRecordPlatformInterruptedErrorMessage,
-	runRecordPlatformInterruptedErrorName,
 	type RunRecordContext,
 } from './types.ts'
 
@@ -15,11 +13,6 @@ function platformInterruptTriage(overrides: Partial<RunRecordContext>) {
 }
 
 test('platform interrupt has a stable error contract and only auto-ignores retryable deliveries', () => {
-	expect(runRecordPlatformInterruptedErrorName).toBe('platform_interrupted')
-	expect(runRecordPlatformInterruptedErrorMessage).toBe(
-		'The platform interrupted this run before completion; outcome unknown.',
-	)
-
 	expect(
 		platformInterruptTriage({
 			surface: 'job',

--- a/packages/worker/src/sentry-options.node.test.ts
+++ b/packages/worker/src/sentry-options.node.test.ts
@@ -7,7 +7,6 @@ import {
 	durableObjectBlockConcurrencyWhileTimeoutResetMessage,
 	durableObjectCodeUpdatedResetMessage,
 	durableObjectInstanceInactiveCloseMessage,
-	durableObjectIsolateCpuResetMessage,
 	durableObjectIsolateMemoryResetMessage,
 	durableObjectSqliteOutOfMemoryMessage,
 	durableObjectStorageOperationTimeoutResetMessage,
@@ -24,21 +23,6 @@ import {
 test('filterSentryEvent drops expected platform and caller noise and keeps real errors', () => {
 	// Isolate resource-limit resets are the only DO resets that isolated
 	// artifact rebuild / check phases treat as retryable.
-	expect(
-		isDurableObjectIsolateResourceLimitResetMessage(
-			durableObjectIsolateMemoryResetMessage,
-		),
-	).toBe(true)
-	expect(
-		isDurableObjectIsolateResourceLimitResetMessage(
-			durableObjectIsolateCpuResetMessage,
-		),
-	).toBe(true)
-	expect(
-		isDurableObjectIsolateResourceLimitResetMessage(
-			durableObjectSqliteOutOfMemoryMessage,
-		),
-	).toBe(true)
 	expect(
 		isDurableObjectIsolateResourceLimitResetMessage(
 			durableObjectSqliteOutOfMemoryMessage.replace(/\.$/, ''),
@@ -150,11 +134,6 @@ test('filterSentryEvent drops expected platform and caller noise and keeps real 
 	// wrapped recovery text must also stay visible.
 	expect(
 		isCloudflareOpaqueInternalErrorMessage(
-			cloudflareOpaqueInternalErrorMessage,
-		),
-	).toBe(true)
-	expect(
-		isCloudflareOpaqueInternalErrorMessage(
 			cloudflareArtifactsOpaqueInternalErrorMessage.replace(/\.$/, ''),
 		),
 	).toBe(true)
@@ -235,11 +214,6 @@ test('filterSentryEvent drops expected platform and caller noise and keeps real 
 
 	// Bare Agents MCP session teardown abort (`ctx.abort("destroyed")`) —
 	// KODY-CLOUDFLARE-4K. Wrapped "stream was destroyed" forms stay visible.
-	expect(
-		isMcpAgentSessionDestroyedAbortMessage(
-			mcpAgentSessionDestroyedAbortMessage,
-		),
-	).toBe(true)
 	expect(isMcpAgentSessionDestroyedAbortMessage('Error: destroyed')).toBe(true)
 	expect(isMcpAgentSessionDestroyedAbortMessage('destroyed.')).toBe(true)
 	expect(

--- a/packages/worker/src/usage/activation.node.test.ts
+++ b/packages/worker/src/usage/activation.node.test.ts
@@ -1,8 +1,5 @@
 import { expect, test } from 'vitest'
-import {
-	activationMilestoneValues,
-	countsTowardPackageActivation,
-} from '#worker/run-records/package-activation-state.ts'
+import { countsTowardPackageActivation } from '#worker/run-records/package-activation-state.ts'
 
 test('countsTowardPackageActivation excludes high-frequency HTTP surfaces', () => {
 	expect(countsTowardPackageActivation('webhook')).toBe(false)
@@ -11,11 +8,4 @@ test('countsTowardPackageActivation excludes high-frequency HTTP surfaces', () =
 	expect(countsTowardPackageActivation('workflow')).toBe(true)
 	expect(countsTowardPackageActivation(undefined)).toBe(true)
 	expect(countsTowardPackageActivation(null)).toBe(true)
-})
-
-test('activation defines the canonical milestone values', () => {
-	expect(activationMilestoneValues).toEqual([
-		'package_run_succeeded',
-		'package_activated',
-	])
 })

--- a/packages/worker/src/usage/fleet-entitlement-crossing-subscription-event.node.test.ts
+++ b/packages/worker/src/usage/fleet-entitlement-crossing-subscription-event.node.test.ts
@@ -53,9 +53,6 @@ test('fleet entitlement crossing builders keep a metadata-only operator snapshot
 		users_url: entitlement.users_url,
 		observed_at: entitlement.observed_at,
 	})
-	expect(
-		isFleetEntitlementCrossingEventTopic(fleetEntitlementCrossedTopic),
-	).toBe(true)
 	expect(isFleetEntitlementCrossingEventTopic('user.created')).toBe(false)
 	expect(
 		buildFleetEntitlementCrossingIdempotencyKey({

--- a/packages/worker/universal/account-deletion-confirmation.node.test.ts
+++ b/packages/worker/universal/account-deletion-confirmation.node.test.ts
@@ -5,9 +5,9 @@ import {
 } from './account-deletion-confirmation.ts'
 
 test('account deletion confirmation requires the exact GOODBYE KODY phrase', () => {
-	expect(accountDeletionConfirmationPhrase).toBe('GOODBYE KODY')
-	expect(isAccountDeletionConfirmation('GOODBYE KODY')).toBe(true)
-	expect(isAccountDeletionConfirmation('  GOODBYE KODY  ')).toBe(true)
+	expect(
+		isAccountDeletionConfirmation(`  ${accountDeletionConfirmationPhrase}  `),
+	).toBe(true)
 	expect(isAccountDeletionConfirmation('goodbye kody')).toBe(false)
 	expect(isAccountDeletionConfirmation('GOODBYE  KODY')).toBe(false)
 	expect(isAccountDeletionConfirmation('')).toBe(false)

--- a/packages/worker/universal/code-runs.node.test.ts
+++ b/packages/worker/universal/code-runs.node.test.ts
@@ -280,7 +280,6 @@ test('thin windows sit on the integer until the next real +1', () => {
 
 test('a regressing end shows immediately and refresh waits until updateAt', () => {
 	const still = { start: 100, end: 100, updateAt }
-	expect(publicCodeRunsWindowsEqual(still, still)).toBe(true)
 	expect(publicCodeRunsWindowsEqual(still, { ...still, end: 101 })).toBe(false)
 	expect(isStillPublicCodeRunsWindow({ start: 200, end: 150, updateAt })).toBe(
 		true,

--- a/packages/worker/universal/community-listing-ahead.node.test.ts
+++ b/packages/worker/universal/community-listing-ahead.node.test.ts
@@ -2,7 +2,6 @@ import { expect, test } from 'vitest'
 import {
 	buildListingAheadPrompt,
 	isCommunityListingAhead,
-	listingAheadSearchNotice,
 	readListingAheadFlag,
 } from './community-listing-ahead.ts'
 
@@ -54,8 +53,4 @@ test('listing-ahead helpers gate on commit mismatch and expose absorb contracts'
 	expect(prompt).toContain('community_fork_absorb')
 	expect(prompt).toContain('community_get')
 	expect(prompt).toContain('repo_publish_session')
-
-	expect(listingAheadSearchNotice).toContain('community_get')
-	expect(listingAheadSearchNotice).toContain('community_fork_absorb')
-	expect(listingAheadSearchNotice).not.toContain('repo_publish_session')
 })

--- a/packages/worker/universal/package-token-export-selection.node.test.ts
+++ b/packages/worker/universal/package-token-export-selection.node.test.ts
@@ -10,9 +10,6 @@ import {
 } from './package-token-export-selection.ts'
 
 test('package token export selection normalizes names, wildcard exclusivity, and stale choices', () => {
-	expect(tryNormalizePackageTokenExportName('*')).toBe(
-		packageTokenWildcardExport,
-	)
 	expect(tryNormalizePackageTokenExportName('dispatch-event')).toBe(
 		'./dispatch-event',
 	)
@@ -94,6 +91,5 @@ test('package token export selection normalizes names, wildcard exclusivity, and
 		}),
 	).toEqual(['.', './dispatch-message-created'])
 
-	expect(isPackageTokenWildcardSelected(['*'])).toBe(true)
 	expect(isPackageTokenWildcardSelected(['./process-video'])).toBe(false)
 })

--- a/tools/ci/nx-cache-resources.node.test.ts
+++ b/tools/ci/nx-cache-resources.node.test.ts
@@ -2,10 +2,6 @@ import { expect, test, vi } from 'vitest'
 
 import {
 	ensureNxCacheResources,
-	NX_CACHE_LIFECYCLE_RULE_ID,
-	NX_CACHE_MULTIPART_ABORT_DAYS,
-	NX_CACHE_OBJECT_PREFIX,
-	NX_CACHE_OBJECT_RETENTION_DAYS,
 	NX_CACHE_R2_BUCKET_NAME,
 	nxCacheLifecyclePolicy,
 } from './nx-cache-resources.ts'
@@ -43,27 +39,4 @@ test('ensureNxCacheResources creates the shared R2 bucket and applies 14-day exp
 		policy: nxCacheLifecyclePolicy,
 		dryRun: true,
 	})
-	expect(nxCacheLifecyclePolicy).toEqual({
-		rules: [
-			{
-				id: NX_CACHE_LIFECYCLE_RULE_ID,
-				enabled: true,
-				conditions: { prefix: NX_CACHE_OBJECT_PREFIX },
-				deleteObjectsTransition: {
-					condition: {
-						type: 'Age',
-						maxAge: NX_CACHE_OBJECT_RETENTION_DAYS * 86_400,
-					},
-				},
-				abortMultipartUploadsTransition: {
-					condition: {
-						type: 'Age',
-						maxAge: NX_CACHE_MULTIPART_ABORT_DAYS * 86_400,
-					},
-				},
-			},
-		],
-	})
-	expect(NX_CACHE_OBJECT_RETENTION_DAYS).toBe(14)
-	expect(NX_CACHE_MULTIPART_ABORT_DAYS).toBe(1)
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop spending review and runtime budget on assertions that cannot fail independently of the implementation, and write that bar down so new tests and the nightly cleanup job do not reintroduce them.

## Why

A tautological assertion restates a constant, matcher, or algorithm against itself. A lone "q is not there" after q was deleted is the same failure mode: it only fails if someone pastes the old name back. Useful negatives flip state — x is there, z is not; click y; now x is gone and z is there.

## Summary

- About **60 tautological assertions** removed across **25 test files**, then another **~30 lone-absence pins** across **13 files** (retired inventory names, old aria-labels, deleted capability ids, copy that nothing can emit).
- Two whole tests were deleted earlier (activation milestone pin; email domain "no longer exposes"). Remaining tests keep behavioral checks, live schema-after-migration, generated SQL, and state flips.
- `docs/contributing/testing-principles.md` now:
  - Defines tautological assertions and the typical forms
  - Distinguishes state-flip absence from "q is not there"
  - Holds the Keep Tests Tight nightly prompt so the Cursor automation can be updated from the same text

## Testing

- Targeted Vitest after each edit (node-unit + the one workers-unit file)
- Full `CI=1 npm run test:node`: 2103 passed (earlier revision)
- Full `CI=1 npm run test:workers`: 301 passed (earlier revision)
- `npm run docs:check-temporal` passed
- Pre-push Playwright `webServer` timed out at 180s on this Cloud Agent VM (unrelated; no app or e2e files changed)

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `e285ac01` · **Head:** `96874f68`

**Classification:** composes — test-only deletions plus contributing-doc guidance; no production behavior, schema, or contracts change.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | composes — unit tests only |
| `capability-registry` | assistant | composes — unit tests only |
| `mailbox` | storage | composes — unit tests only |
| `mcp-server` | surfaces | composes — unit tests only |
| `repo-sessions` | runtime | composes — unit tests only |
| `run-records` | storage | composes — unit tests only |
| `usage-metering` | storage | composes — unit tests only |

Unmatched paths are test-only helpers plus `docs/contributing/testing-principles.md`.

### Change flow

Reviewers see deleted expects and a clearer testing-principles rule. Production code is untouched.

```mermaid
sequenceDiagram
	participant tests as unit tests
	participant docs as testing-principles
	participant impl as implementation
	Note over tests: identity pins and lone q-is-not-there
	tests->>impl: used to assert CONST matches CONST
	tests->>impl: used to assert deleted name is absent
	Note over tests: this PR deletes those expects
	tests->>impl: keep state flips and live-path checks
	docs->>tests: name tautology and the x/z/y vs q rule
```

### Invariants

No production invariants change. Remaining tests still cover trim/normalize branches, negatives that flip state, encode/decode pairs, and live schema-after-migration checks.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d7fde42-1c4a-40b9-adad-7e5c6885ba40?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d7fde42-1c4a-40b9-adad-7e5c6885ba40&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Simplified and stabilized coverage across account, onboarding, authentication, MCP, billing, email, repository, and lifecycle workflows.
  * Removed assertions tied to deprecated behavior, hard-coded values, internal implementation details, and configuration constants.
  * Retained coverage for core validation, schema consistency, request handling, filtering, and resource setup.
  * Updated account deletion confirmation coverage to use the exported confirmation phrase while preserving whitespace handling.

* **Documentation**
  * Expanded testing guidance with examples for avoiding tautological and fragile absence assertions.
  * Documented nightly cleanup automation for removing tests without independent verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->