### PR TITLE
Remove Keep Tests Tight prompt from the repo

### DIFF
--- a/docs/contributing/testing-principles.md
+++ b/docs/contributing/testing-principles.md
@@ -239,20 +239,3 @@ test('fetches from a disposable server', async () => {
 	expect(await response.text()).toBe('ok')
 })
 ```
-
-## Nightly cleanup
-
-A scheduled Cursor automation (Keep Tests Tight) re-reads this page and removes
-tests that do not meet the bar. Prompt for that automation:
-
-```
-If the default branch had no commits in the last 24 hours, exit early.
-
-Read docs/contributing/testing-principles.md and apply that bar. Agents often leave extra regression tests, tautological asserts (a value compared to itself), static-value pins, and lone "q is not there" checks after a deletion. Those help while verifying; they are not worth keeping.
-
-Keep absence asserts that flip state: x is there, z is not; click y; now x is gone and z is there. Delete a lone "q is not there" after q was removed.
-
-Edit, combine, or delete until every remaining test has an independent oracle and could still fail if a live path regresses. A test has to justify its existence.
-
-If you change anything: run formatting before each commit, open a ready-for-review PR, then follow .agents/skills/ship-pr/SKILL.md. Squash-merge when risk is low or medium and CI is green.
-```


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Keep the nightly Cursor automation prompt out of the repository. It belongs in Cursor, not contributing docs.

## Why

The Keep Tests Tight prompt was added to `docs/contributing/testing-principles.md` by mistake. The testing bar (tautologies and state-flip vs lone-absence asserts) stays. The copy-paste automation prompt does not.

## Summary

- Delete the Nightly cleanup section and the fenced Keep Tests Tight prompt from testing principles.

## Testing

- `oxfmt` on the edited doc
- Pre-commit typecheck and migrations check
- Docs-only; no product behavior change

## System changes

Docs-only. No primitives touched. Low risk.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `f56187bd` · **Head:** `443d1394`

**Classification:** composes — no primitives added or changed; this PR deletes a docs-only automation prompt.

### Primitives touched

None. Classifier matched no `code` roots (`docs/contributing/testing-principles.md` only).

### Change flow

The nightly Cursor prompt is removed from contributing docs. The testing bar on that page stays.

```mermaid
sequenceDiagram
	actor Contributor
	participant docs as contributing-docs
	Contributor->>docs: open testing-principles.md
	docs-->>Contributor: tautology and absence rules only
	Note over docs: Nightly cleanup prompt deleted
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d7fde42-1c4a-40b9-adad-7e5c6885ba40?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d7fde42-1c4a-40b9-adad-7e5c6885ba40&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed the section describing the scheduled “Nightly cleanup” automation and its prompt from the testing principles guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->