### PR TITLE
Resolve secret placeholders in fetch URL paths

### DIFF
--- a/packages/worker/src/mcp/fetch-gateway.node.test.ts
+++ b/packages/worker/src/mcp/fetch-gateway.node.test.ts
@@ -121,6 +121,106 @@ test('fetch gateway blocks or expands secret placeholders based on host approval
 	}
 })
 
+test('fetch gateway expands secret placeholders in URL paths after Request serialization', async () => {
+	const telegramToken = '123456:AAHfakeTelegramToken'
+	const probeValue = '11111111-1111-4111-8111-111111111111'
+	const allowedResolveSpy = vi
+		.spyOn(secretService, 'resolveSecret')
+		.mockImplementation(async ({ name }: { name: string }) => ({
+			found: true,
+			value: name === 'telegramBotToken' ? telegramToken : probeValue,
+			scope: 'user',
+			allowedHosts: ['api.telegram.org', 'api.notion.com', 'api.example.com'],
+			allowedCapabilities: [],
+		}))
+	try {
+		const pathOnlyRequest = new Request(
+			'https://api.telegram.org/bot{{secret:telegramBotToken|scope=user}}/getMe',
+		)
+		expect(pathOnlyRequest.url).toContain(
+			'%7B%7Bsecret:telegramBotToken|scope=user%7D%7D',
+		)
+		const pathOnlyTransformed = await expandSecretPlaceholders({
+			request: pathOnlyRequest,
+			props,
+			env,
+		})
+		expect(pathOnlyTransformed.url).toBe(
+			`https://api.telegram.org/bot${telegramToken}/getMe`,
+		)
+
+		const headerAndPathRequest = new Request(
+			'https://api.notion.com/v1/users/{{secret:kodyPathProbe|scope=user}}',
+			{
+				headers: {
+					Authorization: 'Bearer {{secret:notionToken|scope=user}}',
+				},
+			},
+		)
+		expect(headerAndPathRequest.url).toContain(
+			'%7B%7Bsecret:kodyPathProbe|scope=user%7D%7D',
+		)
+		const headerAndPathTransformed = await expandSecretPlaceholders({
+			request: headerAndPathRequest,
+			props,
+			env,
+		})
+		expect(headerAndPathTransformed.url).toBe(
+			`https://api.notion.com/v1/users/${probeValue}`,
+		)
+		expect(headerAndPathTransformed.headers.get('Authorization')).toBe(
+			`Bearer ${probeValue}`,
+		)
+
+		const queryRequest = new Request(
+			'https://api.example.com/search?key={{secret:queryToken|scope=user}}',
+		)
+		expect(queryRequest.url).toContain('{{secret:queryToken|scope=user}}')
+		const queryTransformed = await expandSecretPlaceholders({
+			request: queryRequest,
+			props,
+			env,
+		})
+		expect(queryTransformed.url).toBe(
+			`https://api.example.com/search?key=${probeValue}`,
+		)
+	} finally {
+		allowedResolveSpy.mockRestore()
+	}
+
+	const blockedResolveSpy = vi
+		.spyOn(secretService, 'resolveSecret')
+		.mockResolvedValue({
+			found: true,
+			value: telegramToken,
+			scope: 'user',
+			allowedHosts: [],
+			allowedCapabilities: [],
+		})
+	try {
+		await expandSecretPlaceholders({
+			request: new Request(
+				'https://api.telegram.org/bot{{secret:telegramBotToken}}/getMe',
+			),
+			props,
+			env,
+		})
+		throw new Error('Expected host approval error.')
+	} catch (error) {
+		const approvals = parseHostApprovalRequiredBatchMessage(
+			getErrorMessage(error),
+		)
+		expect(approvals).toEqual([
+			expect.objectContaining({
+				secretName: 'telegramBotToken',
+				host: 'api.telegram.org',
+			}),
+		])
+	} finally {
+		blockedResolveSpy.mockRestore()
+	}
+})
+
 test('fetch gateway requires package approval before resolving user secrets', async () => {
 	const request = () =>
 		new Request('https://example.com/api', {
@@ -932,6 +1032,26 @@ test('gateway fetch metering never derives a hostname from expanded secret place
 			globalFetch: fetchStub,
 		})
 		expect(fetchStub).toHaveBeenCalledTimes(1)
+		expect(recordUsageSpy).toHaveBeenCalledTimes(1)
+		expect(recordUsageSpy.mock.calls[0]?.[1]).toMatchObject({
+			entityId: '',
+			outcome: 'success',
+		})
+
+		// Path-only URL whose placeholder was percent-encoded the same way
+		// `Request.url` serializes `{` / `}` in pathnames.
+		recordUsageSpy.mockClear()
+		fetchStub.mockClear()
+		await executeGatewayFetch({
+			env,
+			props,
+			request: createPathOnlyRequest('/bot%7B%7Bsecret:token%7D%7D/getMe'),
+			globalFetch: fetchStub,
+		})
+		expect(fetchStub).toHaveBeenCalledTimes(1)
+		expect(fetchStub.mock.calls[0]?.[0]?.url).toBe(
+			'https://example.com/botresolved-secret-value/getMe',
+		)
 		expect(recordUsageSpy).toHaveBeenCalledTimes(1)
 		expect(recordUsageSpy.mock.calls[0]?.[1]).toMatchObject({
 			entityId: '',

--- a/packages/worker/src/mcp/fetch-gateway.ts
+++ b/packages/worker/src/mcp/fetch-gateway.ts
@@ -4,6 +4,7 @@ import { buildSecretHostApprovalUrl } from '#mcp/secrets/host-approval.ts'
 import {
 	buildBasicAuthSecretPlaceholderFromReference,
 	buildSecretPlaceholder,
+	decodeSecretPlaceholderDelimiters,
 	parseBasicAuthSecretPlaceholders,
 	parseBasicAuthSecretPlaceholdersFromFormUrlEncoded,
 	parseSecretPlaceholders,
@@ -247,8 +248,11 @@ function readMeteredRequestHostname(
 ) {
 	const originalHostname = readRequestHostname(originalUrl)
 	if (originalHostname) return originalHostname
-	if (parseSecretPlaceholders(originalUrl).length > 0) return ''
-	if (parseBasicAuthSecretPlaceholders(originalUrl).length > 0) return ''
+	const urlForPlaceholderScan = decodeSecretPlaceholderDelimiters(originalUrl)
+	if (parseSecretPlaceholders(urlForPlaceholderScan).length > 0) return ''
+	if (parseBasicAuthSecretPlaceholders(urlForPlaceholderScan).length > 0) {
+		return ''
+	}
 	if (transformedUrl === null) return ''
 	return readRequestHostname(transformedUrl)
 }
@@ -309,6 +313,7 @@ export async function expandSecretPlaceholders(input: {
 			},
 		)
 	}
+	const requestUrl = decodeSecretPlaceholderDelimiters(input.request.url)
 	const resolvedSecrets: Array<{
 		referenced: ReferencedSecret
 		resolved: ResolvedSecret
@@ -317,7 +322,7 @@ export async function expandSecretPlaceholders(input: {
 	const resolvedValues = new Map<string, string>()
 	const basicAuthPlaceholders = dedupeBasicAuthSecretPlaceholders([
 		...collectReferencedBasicAuthSecretPlaceholders([
-			input.request.url,
+			requestUrl,
 			...Array.from(headers.values()),
 		]),
 		...collectReferencedBasicAuthSecretPlaceholdersFromRequestBody(
@@ -326,10 +331,7 @@ export async function expandSecretPlaceholders(input: {
 		),
 	])
 	const referencedSecrets = dedupeReferencedSecrets([
-		...collectReferencedSecrets([
-			input.request.url,
-			...Array.from(headers.values()),
-		]),
+		...collectReferencedSecrets([requestUrl, ...Array.from(headers.values())]),
 		...collectReferencedSecretsFromRequestBody(headers, requestBody),
 		...basicAuthPlaceholders.flatMap((placeholder) => [
 			placeholder.username,
@@ -414,7 +416,7 @@ export async function expandSecretPlaceholders(input: {
 	let requestedHost = ''
 	if (hasReferencedSecrets) {
 		const nextUrl = resolveRequestUrlForFetchGateway(
-			replaceSecretPlaceholders(input.request.url, replacements),
+			replaceSecretPlaceholders(requestUrl, replacements),
 			baseUrl,
 		)
 		requestedHost = readRequestedHost(nextUrl)
@@ -437,7 +439,7 @@ export async function expandSecretPlaceholders(input: {
 		}
 	}
 	const nextUrl = resolveRequestUrlForFetchGateway(
-		replaceSecretPlaceholders(input.request.url, replacements),
+		replaceSecretPlaceholders(requestUrl, replacements),
 		baseUrl,
 	)
 	for (const [key, value] of Array.from(headers.entries())) {

--- a/packages/worker/src/mcp/secrets/placeholders.ts
+++ b/packages/worker/src/mcp/secrets/placeholders.ts
@@ -16,6 +16,18 @@ export type ReferencedBasicAuthSecretPlaceholder = {
 	scope: SecretScope | null
 }
 
+/**
+ * WHATWG URL serialization percent-encodes `{` and `}` in pathnames
+ * (`%7B` / `%7D`). `new Request('https://host/bot{{secret:name}}/me')`
+ * therefore stores `bot%7B%7Bsecret:name%7D%7D` on `request.url`, and
+ * the literal `{{secret:...}}` regex never matches. Restore those
+ * delimiters so path placeholders parse and replace the same as
+ * headers, bodies, and query strings (where `{` / `}` stay unencoded).
+ */
+export function decodeSecretPlaceholderDelimiters(value: string) {
+	return value.replaceAll(/%7B/gi, '{').replaceAll(/%7D/gi, '}')
+}
+
 export function parseSecretPlaceholders(value: string) {
 	const secrets: Array<ReferencedSecret> = []
 	for (const match of value.matchAll(secretPlaceholderRegex)) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Make execute-time `fetch` honor the documented secret-placeholder contract in URL **paths**, not only in headers, bodies, and query strings.

## Why

WHATWG `Request` serialization percent-encodes `{` and `}` in pathnames. A call such as `fetch('https://api.telegram.org/bot{{secret:telegramBotToken}}/getMe')` therefore arrives at the fetch gateway as `bot%7B%7Bsecret:telegramBotToken%7D%7D`. The placeholder regex never matched, so the literal (or percent-encoded) token went to the third party. Header and query placeholders were unaffected because those characters stay unencoded there.

That breaks any API that puts a credential in the path — including official `@kody/telegram` `telegramRequest` — while `docs/use/secrets-and-values.md` says placeholders resolve in the URL, headers, or body.

## Summary

- Decode `%7B` / `%7D` on `request.url` before collecting and replacing `{{secret:...}}` placeholders.
- Apply the same decode when scanning path-only URLs for usage-meter hostname safety.
- Add a node-unit regression that constructs a real `Request` (Telegram path, Notion path+header, query string, and host-approval deny).

## Testing

- `npx vitest run --project node-unit packages/worker/src/mcp/fetch-gateway.node.test.ts` — 12 passed
- `git push` pre-push `test:push` (`test:node` + `test:workers`) — 2106 node + 301 workers passed
- GitHub Validate (static/node/workers/MCP/e2e) green; CodeRabbit and Bugbot had no actionable comments
- Preview retry succeeded after a transient platform-worker startup CPU limit (`kody-pr-1804-platform`)
- `npm run preview:manual-test -- --pr 1804` as seed user `me@kentcdodds.com`: created user secret `kodyPathProbe` with host `api.notion.com`; `/account/secrets` 200; `/admin` 403; `/mcp` 401
- UI pass on https://kody-pr-1804.kody-a99.workers.dev/account/secrets: `kodyPathProbe` listed with description “Preview path-placeholder probe”; detail shows allowed host `api.notion.com`
- Fetch-gateway path substitution itself is covered by the Request-serialization unit tests; preview `/mcp` is OAuth-protected so execute fetch cannot be driven from the cookie session

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends mcp-server</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `1e6a1de0` · **Head:** `8573647f`

**Classification:** extends — fetch-gateway secret expansion now treats WHATWG-serialized path placeholders the same as header, body, and query placeholders.

### Primitives touched

| Primitive    | Group    | Impact                                                                                         |
| ------------ | -------- | ---------------------------------------------------------------------------------------------- |
| `mcp-server` | surfaces | extends — decode `%7B` / `%7D` on `request.url` before parse, replace, and usage-meter scans |

### Change flow

Sandbox `fetch` goes through the fetch gateway. `Request` percent-encodes `{` / `}` in pathnames, so Telegram-style path placeholders used to miss resolution.

```mermaid
sequenceDiagram
	actor Caller
	participant mcpServer as mcp-server
	Caller->>mcpServer: fetch https://api.example/bot{{secret:name}}/getMe
	Note over mcpServer: Request.url stores bot%7B%7Bsecret:name%7D%7D
	mcpServer->>mcpServer: decode %7B/%7D then parse and resolve the secret
	mcpServer->>mcpServer: host-approval check on api.example
	mcpServer-->>Caller: outbound URL with the secret substituted in the path
```

### Before / after

```text
before: Request.url path {{secret:name}} → %7B%7Bsecret:name%7D%7D → no match → third party sees the literal
after:  same serialized path is decoded, resolved, host-checked, and substituted
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2576d055-056f-49e3-be1e-9606ab0b3960?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2576d055-056f-49e3-be1e-9606ab0b3960&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed secret placeholders in URL paths so they are correctly expanded after URL encoding.
  - Ensured placeholders work consistently in paths, headers, and query strings.
  - Improved blocked-host approval handling for URLs containing secret placeholders.
  - Preserved accurate usage metering when expanded URL paths do not include an entity identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->