### PR TITLE
Tighten homepage hero copy and mark Share in green

### DIFF
--- a/packages/worker/client/code-runs-ticker.tsx
+++ b/packages/worker/client/code-runs-ticker.tsx
@@ -180,9 +180,7 @@ export function CodeRunsTicker(
 					</span>
 					<span class="landing-hero-runs-label">code runs</span>
 				</span>
-				<span class="landing-hero-runs-caption">
-					Sandboxed executes across Kody accounts
-				</span>
+				<span class="landing-hero-runs-caption">Sandboxed executes</span>
 			</p>
 		)
 	}

--- a/packages/worker/client/routes/home.tsx
+++ b/packages/worker/client/routes/home.tsx
@@ -215,7 +215,7 @@ export function HomeRoute(handle: Handle) {
 				{/* ============ hero ============ */}
 				<section data-parallax-scope class="landing-hero">
 					<h1 data-rise style={{ '--rise': '0' }} class="landing-hero-title">
-						The Home Your Agents Share
+						The Home Your Agents <em>Share</em>
 					</h1>
 					<p data-rise style={{ '--rise': '1' }} class="landing-hero-sub">
 						For all the agents you use today,
@@ -331,8 +331,17 @@ export function HomeRoute(handle: Handle) {
 						<strong>pretty much anything</strong>. What will{' '}
 						<strong>you</strong> build?
 					</p>
-					{walkthroughHosts ? (
-						<div class="landing-walkthrough-story">
+					<section
+						aria-labelledby="walkthrough-title"
+						class="landing-walkthrough-story"
+					>
+						<h2
+							id="walkthrough-title"
+							class="landing-section-heading landing-walkthrough-heading"
+						>
+							Watch some example conversations
+						</h2>
+						{walkthroughHosts ? (
 							<div class="landing-walkthrough-intro">
 								<WalkthroughHostIntro
 									variant="picker"
@@ -343,11 +352,9 @@ export function HomeRoute(handle: Handle) {
 									}}
 								/>
 							</div>
-							<LandingLoopPlayer hosts={walkthroughHosts} />
-						</div>
-					) : (
-						<LandingLoopPlayer />
-					)}
+						) : null}
+						<LandingLoopPlayer hosts={walkthroughHosts ?? undefined} />
+					</section>
 				</section>
 
 				{/* ============ testimonials ============ */}

--- a/packages/worker/client/routes/landing-hero-agents.tsx
+++ b/packages/worker/client/routes/landing-hero-agents.tsx
@@ -416,9 +416,6 @@ export function LandingHeroAgents(
 						))}
 					</ul>
 				</div>
-				<p class="landing-hero-agents-mcp">
-					Kody works with any agent that supports MCP
-				</p>
 			</figure>
 		)
 	}

--- a/packages/worker/public/styles.css
+++ b/packages/worker/public/styles.css
@@ -759,6 +759,11 @@ html.is-settled {
 	font-variation-settings: 'opsz' 96;
 }
 
+.landing-hero-title em {
+	font-style: normal;
+	color: var(--color-primary-text);
+}
+
 .landing-hero-sub {
 	margin: 1.5rem auto 0;
 	font-size: clamp(1.05rem, 1.6vw, 1.2rem);
@@ -1112,14 +1117,6 @@ html.is-settled {
 	text-shadow: 0 1px 0 var(--color-background);
 }
 
-.landing-hero-agents-mcp {
-	margin: 0.6rem 0 0;
-	text-align: center;
-	font-size: 0.82rem;
-	font-weight: 500;
-	color: var(--color-text-muted);
-}
-
 @keyframes agent-drift {
 	from {
 		translate: -50% -50%;
@@ -1164,10 +1161,6 @@ html.is-settled {
 
 	.landing-hero-agent-name {
 		font-size: 0.66rem;
-	}
-
-	.landing-hero-agents-mcp {
-		font-size: 0.75rem;
 	}
 }
 
@@ -1282,8 +1275,12 @@ html.is-settled {
 }
 
 .landing-walkthrough-story {
-	margin: clamp(1.75rem, 4vw, 2.5rem) auto 0;
+	margin: clamp(3.75rem, 8vw, 6rem) auto 0;
 	max-width: 40rem;
+}
+
+.landing-walkthrough-heading {
+	margin: 0 0 1.35rem;
 }
 
 .landing-walkthrough-intro {

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -611,7 +611,6 @@ test('renderAppPage emits a doctype, meta description, and inlines the styleshee
 		'Kody works with any agent that supports MCP',
 	)
 	expect(withoutAssetsHtml).toContain('Watch some example conversations')
-	expect(withoutAssetsHtml).toContain('Choose three agents you use:')
 	expect(withoutAssetsHtml).toContain('For all the agents you use today,')
 	expect(withoutAssetsHtml).toContain("and the ones you'll use tomorrow")
 	// Hero stage: one agent list around Kody, every token tethered by a line.

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -606,7 +606,12 @@ test('renderAppPage emits a doctype, meta description, and inlines the styleshee
 	expect(withoutAssetsHtml.startsWith('<!DOCTYPE html>')).toBe(true)
 	expect(withoutAssetsHtml).toContain('href="/styles.css')
 	expect(withoutAssetsHtml).toContain('name="description"')
-	expect(withoutAssetsHtml).toContain('The Home Your Agents Share')
+	expect(withoutAssetsHtml).toContain('The Home Your Agents <em>Share</em>')
+	expect(withoutAssetsHtml).not.toContain(
+		'Kody works with any agent that supports MCP',
+	)
+	expect(withoutAssetsHtml).toContain('Watch some example conversations')
+	expect(withoutAssetsHtml).toContain('Choose three agents you use:')
 	expect(withoutAssetsHtml).toContain('For all the agents you use today,')
 	expect(withoutAssetsHtml).toContain("and the ones you'll use tomorrow")
 	// Hero stage: one agent list around Kody, every token tethered by a line.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Make the homepage title and example-conversation block easier to read.

## Why

"Share" should carry the green accent. The MCP line and the long ticker caption were extra. The conversation picker needed a clearer break from the factory beats.

## Summary

- Color only **Share** in the H1 (`The Home Your Agents Share`).
- Remove "Kody works with any agent that supports MCP".
- Shorten the ticker caption to "Sandboxed executes".
- Add space and an h2, **Watch some example conversations**, above "Choose three agents you use:".

## Testing

- `npx vitest run --project node-unit packages/worker/src/app/ssr-render.node.test.ts`
- Pre-push `test:node` and `test:workers` passed.
- Local homepage at `http://localhost:3742`: Share is the green accent; no MCP line; new heading sits above the picker with a larger gap.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `30a4a091` · **Head:** `225cf409`

**Classification:** composes — homepage copy and CSS only.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `app-ui` | surfaces | composes — landing copy and heading |

Unmatched path: `packages/worker/public/styles.css`.

### Change flow

Anonymous visitors still get the same homepage; the H1, ticker caption, and conversation block change in the browser.

```mermaid
sequenceDiagram
	actor Visitor
	participant appUi as app-ui
	Visitor->>appUi: GET /
	appUi->>Visitor: H1 with green Share
	Note over appUi: MCP caption removed
	appUi->>Visitor: Watch some example conversations then picker
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d2e9331f-8e81-48a9-8bb2-55b7442a5065?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d2e9331f-8e81-48a9-8bb2-55b7442a5065&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an “Watch some example conversations” section to the landing page.
  * Updated the hero heading to emphasize “Share.”

* **Improvements**
  * Simplified the sandbox ticker caption.
  * Streamlined the agent hero area by removing redundant descriptive text.
  * Improved spacing and styling around the walkthrough content.

* **Bug Fixes**
  * Ensured the walkthrough player appears consistently when example content is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->