### PR TITLE
Require friction-log/create for filing friction issues

### DIFF
--- a/.agents/skills/friction-log/SKILL.md
+++ b/.agents/skills/friction-log/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: friction-log
 description: >
-  File contributor or agent papercuts as GitHub issues labeled friction, or
-  investigate those issues as the daily friction-log Cloud Agent. Use when you
-  hit repo friction, when asked to log friction, or when spawned to resolve open
-  friction issues.
+  File contributor or agent papercuts through
+  kody:@kentcdodds/friction-log/create (never raw GitHub), or investigate those
+  issues as the daily friction-log Cloud Agent. Use when you hit repo friction,
+  when asked to log friction, or when spawned to resolve open friction issues.
 ---
 
 # Friction log
@@ -22,7 +22,7 @@ feedback. Use this skill for developing `kentcdodds/kody`.
 When you hit a papercut and cannot (or should not) fix it in the current change,
 file it before you forget.
 
-Search open issues first:
+Search open issues first (`gh issue list --label friction` or the package scan):
 
 ```bash
 gh issue list --repo kentcdodds/kody --label friction --state open --search "in:title Friction:"
@@ -30,37 +30,30 @@ gh issue list --repo kentcdodds/kody --label friction --state open --search "in:
 
 Comment on a match instead of opening a duplicate.
 
-Title: `Friction: <what hurt>`.
+Create through `kody:@kentcdodds/friction-log/create` via Kody MCP `execute`.
+The export always applies the `friction` label, prefixes the title with
+`Friction:`, and reuses or labels an existing open issue with the same title.
 
-Label: `friction`.
+Do not use `gh issue create` or `kody:@kentcdodds/github/request` POST to
+`/repos/kentcdodds/kody/issues`. Those paths can omit the `friction` label, so
+the daily sweep never sees the issue.
 
-Body:
+```ts
+import createFrictionIssue from 'kody:@kentcdodds/friction-log/create'
 
-```markdown
-## What happened
-
-What you were doing and what got in the way.
-
-## What you wanted
-
-The expected path.
-
-## How to reproduce
-
-Commands, files, or conditions. Enough for a later agent to investigate without
-this session.
-
-## Cost
-
-Time lost, how often this happens, who it hits, and the workaround.
+export default async function main() {
+	return await createFrictionIssue({
+		title: 'what hurt',
+		whatHappened: '...',
+		whatYouWanted: '...',
+		howToReproduce: '...',
+		cost: '...',
+	})
+}
 ```
 
-```bash
-gh issue create --repo kentcdodds/kody --title "Friction: …" --label friction --body-file -
-```
-
-Or `kody:@kentcdodds/github/request` `POST /repos/kentcdodds/kody/issues` with
-`labels: ["friction"]`.
+`body` is accepted instead of the structured fields. `dryRun: true` previews
+without posting.
 
 One issue per papercut. Omit secrets. Quote the relevant excerpt, not a
 transcript.

--- a/docs/contributing/friction-log.md
+++ b/docs/contributing/friction-log.md
@@ -14,18 +14,39 @@ when they hit friction or when they are the daily investigator.
 
 ## File an entry
 
-Search open `friction` issues first. Comment on a match instead of opening a
+Search open `friction` issues first (`gh issue list --label friction` or
+`kody:@kentcdodds/friction-log/scan`). Comment on a match instead of opening a
 duplicate.
 
-Title: `Friction: <what hurt>`.
+Humans can use the
+[Friction issue form](../../.github/ISSUE_TEMPLATE/friction.yml), which applies
+the `friction` label.
 
-Label: `friction`.
+Agents create through `kody:@kentcdodds/friction-log/create` via Kody MCP
+`execute`. The export always applies the `friction` label, prefixes the title
+with `Friction:`, and reuses or labels an existing open issue with the same
+title.
 
-Use the [Friction issue form](../../.github/ISSUE_TEMPLATE/friction.yml) or:
+Do not use `gh issue create` or `kody:@kentcdodds/github/request` POST to
+`/repos/kentcdodds/kody/issues`. Those paths can omit the `friction` label, so
+the daily sweep never sees the issue.
 
-```bash
-gh issue create --repo kentcdodds/kody --title "Friction: …" --label friction --body-file -
+```ts
+import createFrictionIssue from 'kody:@kentcdodds/friction-log/create'
+
+export default async function main() {
+	return await createFrictionIssue({
+		title: 'what hurt',
+		whatHappened: '...',
+		whatYouWanted: '...',
+		howToReproduce: '...',
+		cost: '...',
+	})
+}
 ```
+
+`body` is accepted instead of the structured fields. `dryRun: true` previews
+without posting.
 
 Write one issue per papercut. Include what you were doing, the unexpected cost,
 the workaround, and enough reproduction to investigate without the original
@@ -56,6 +77,7 @@ give a different approach).
 
 | Export                                 | Purpose                                        |
 | -------------------------------------- | ---------------------------------------------- |
+| `kody:@kentcdodds/friction-log/create` | File a `friction` issue (always labeled).      |
 | `kody:@kentcdodds/friction-log/scan`   | Read-only eligibility scan. No agent.          |
 | `kody:@kentcdodds/friction-log/sweep`  | Scan and optionally spawn (`dryRun`, `force`). |
 | `kody:@kentcdodds/friction-log/pause`  | Kill switch: stop spawning.                    |

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -24,8 +24,8 @@ style, tests, MCP capabilities, and runtime architecture.
   lessons into checkers before should-lists)
 - [Cleanup after migrations](./cleanup-after-migrations.md) (drop leftovers in
   the same change, or open a GitHub issue)
-- [Friction log](./friction-log.md) (GitHub issues labeled `friction`; daily
-  Cursor agent investigates)
+- [Friction log](./friction-log.md) (file through
+  `kody:@kentcdodds/friction-log/create`; daily Cursor agent investigates)
 
 ## Code and tooling
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Route repo friction-issue filing through `@kentcdodds/friction-log/create` so every new issue is labeled `friction` and the daily sweep can see it.

## Why

#1789 was titled `Friction: …` but never got the `friction` label. The daily `@kentcdodds/friction-log` sweep only lists that label, so no agent spawned. The skill and contributing doc told agents to use `gh issue create --label friction` or `kody:@kentcdodds/github/request` POST with labels. Those paths can drop the label.

`./create` is already published on `@kentcdodds/friction-log`. It always applies `friction`, prefixes the title with `Friction:`, and reuses or labels an existing open issue with the same title.

## Summary

- Rewrite the friction-log skill File friction section: search may still use `gh issue list --label friction` or the package scan; create must go through `kody:@kentcdodds/friction-log/create` via Kody MCP `execute`.
- Forbid `gh issue create` and raw GitHub POST because they can omit the label.
- Rewrite `docs/contributing/friction-log.md` the same way. Keep the GitHub issue form as a human path (it already applies `friction`). Add `./create` to the operator table.
- Point `docs/contributing/index.md` at the package export. AGENTS.md does not mention a GitHub create recipe.

Docs and skill only. No application or runtime changes.

## Testing

Docs-only, low risk.

- Confirmed the GitHub Friction issue form still applies `labels: [friction]`.
- Grep: friction-log skill and contributing docs no longer prescribe `gh issue create` or `kody:@kentcdodds/github/request` POST. Remaining mentions of those commands are the forbidden-path warning.
- Cleanup-after-migrations docs still use `gh` / GitHub POST for `Cleanup:` issues (out of scope).
- Local commit hook ran oxfmt, typecheck, and workers tests (cache hit).

## System changes

Docs/skill only. Classifier reports no primitive `code` roots in the diff.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `84651d3e` · **Head:** `f6e7e918`

**Classification:** composes — no primitives added or changed; this PR updates agent and contributor docs so create goes through an existing saved-package export.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| _(none)_  | —     | unmatched paths are docs and the friction-log skill only |

### Change flow

Agents file a friction issue through MCP `execute` into `@kentcdodds/friction-log/create`, which always labels the GitHub issue. Raw `gh` / GitHub POST create is forbidden.

```mermaid
sequenceDiagram
	actor Agent
	participant mcpServer as mcp-server
	participant savedPackages as saved-packages
	participant github as GitHub
	Agent->>mcpServer: execute createFrictionIssue
	mcpServer->>savedPackages: kody:@kentcdodds/friction-log/create
	savedPackages->>github: open or reuse issue with friction label
	Note over Agent: gh issue create and raw GitHub POST are forbidden
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e4d6c703-063a-4472-81a1-611ff9815b22?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e4d6c703-063a-4472-81a1-611ff9815b22&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated friction log guidance to use the supported creation workflow.
  * Added instructions for searching existing open friction issues before creating entries.
  * Documented automatic labeling, title formatting, duplicate detection, request bodies, and dry-run options.
  * Replaced outdated manual issue-creation instructions and updated the contributor index.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->