### PR TITLE
Add optimistic package lock icon and agent lock-only update

### DIFF
--- a/docs/contributing/packages-and-manifests.md
+++ b/docs/contributing/packages-and-manifests.md
@@ -626,6 +626,7 @@ entity lookup by UUID or `kody.id`, **`package_list`**, **`package_get`**, and
 context-scope package retrievers are unaffected. Hiding is not deletion,
 community delisting, or entitlement exclusion.
 
-`package_update` is reserved for mutable package settings. Manifest-derived
-metadata and projections remain canonical in `package.json` and change only
-through save or publish.
+`package_update` is reserved for mutable package settings (`hidden`, and
+`locked: true`; unlocking is website-only). Manifest-derived metadata and
+projections remain canonical in `package.json` and change only through save or
+publish.

--- a/docs/use/packages.md
+++ b/docs/use/packages.md
@@ -492,7 +492,8 @@ Use:
   file set when no local git client is available
 - `package_get` and `package_list` to inspect saved packages
 - `package_update` to change mutable package settings such as hidden search
-  discovery state. Publish lock (`locked_at`) is website-only.
+  discovery state or to lock publishes (`changes.locked: true`). Unlocking is
+  website-only.
 - `repo_edit_files`, `repo_apply_patch`, `repo_commit`, `repo_run_checks`, and
   `repo_publish_session` to edit, validate, and publish repo-backed package
   source through the file-level session API
@@ -535,9 +536,11 @@ resolve hidden packages.
 
 A package with a **`locked_at`** timestamp on `/account/packages` (and on
 `package_list` / `package_get`) keeps serving its current published tree. Agents
-and the five-minute reconcile job cannot advance `published_commit`. Unlocking
-and the first lock are website-only — `package_update` cannot change
-`locked_at`.
+and the five-minute reconcile job cannot advance `published_commit`. Use
+**`package_update`** with **`changes: { locked: true }`** to lock a package.
+Agents cannot unlock. If an agent needs the package unlocked, it should send the
+owner to `/account/packages/:packageId` so they can click the lock icon.
+`package_update` rejects **`changes.locked: false`** and returns that URL.
 
 When an agent pushes or saves a locked package, the commit still lands on
 Artifacts HEAD. Publish tools then return **`locked`** with an

--- a/packages/worker/client/routes/account-packages.tsx
+++ b/packages/worker/client/routes/account-packages.tsx
@@ -201,7 +201,6 @@ export function AccountPackagesRoute(handle: Handle) {
 					packageId,
 				}),
 			})
-			if (requestId !== lockRequestId || getCurrentHref() !== href) return
 			if (response.status === 401) {
 				window.location.assign('/login')
 				return
@@ -209,10 +208,13 @@ export function AccountPackagesRoute(handle: Handle) {
 			const payload = await readJson<
 				AccountPackagesLoaderData & { error?: string }
 			>(response)
-			if (requestId !== lockRequestId || getCurrentHref() !== href) return
+			const stillCurrent =
+				requestId === lockRequestId && getCurrentHref() === href
 			if (!response.ok || !payload?.ok) {
 				applyLocalLockState(packageId, previousLockedAt)
-				message = payload?.error ?? 'Could not update the publish lock.'
+				if (stillCurrent) {
+					message = payload?.error ?? 'Could not update the publish lock.'
+				}
 				handle.update()
 				return
 			}
@@ -222,9 +224,10 @@ export function AccountPackagesRoute(handle: Handle) {
 			)
 			handle.update()
 		} catch {
-			if (requestId !== lockRequestId || getCurrentHref() !== href) return
 			applyLocalLockState(packageId, previousLockedAt)
-			message = 'Could not update the publish lock.'
+			if (requestId === lockRequestId && getCurrentHref() === href) {
+				message = 'Could not update the publish lock.'
+			}
 			handle.update()
 		} finally {
 			if (requestId === lockRequestId) {

--- a/packages/worker/client/routes/account-packages.tsx
+++ b/packages/worker/client/routes/account-packages.tsx
@@ -156,6 +156,7 @@ export function AccountPackagesRoute(handle: Handle) {
 	let loadingDataKey: string | null = null
 	let lastFailedDataKey: string | null = null
 	let lockRequestId = 0
+	let lockBusy = false
 
 	function getCurrentHref() {
 		return readCurrentRouterHref(handle)
@@ -175,13 +176,14 @@ export function AccountPackagesRoute(handle: Handle) {
 	}
 
 	async function togglePackageLock() {
-		if (!selectedPackage) return
+		if (!selectedPackage || lockBusy) return
 		const href = getCurrentHref()
 		const packageId = selectedPackage.id
 		const requestId = ++lockRequestId
 		const previousLockedAt = selectedPackage.lockedAt
 		const nextLocked = !isPackageLocked(previousLockedAt)
 		const nextLockedAt = nextLocked ? new Date().toISOString() : null
+		lockBusy = true
 		message = null
 		applyLocalLockState(packageId, nextLockedAt)
 		handle.update()
@@ -224,6 +226,11 @@ export function AccountPackagesRoute(handle: Handle) {
 			applyLocalLockState(packageId, previousLockedAt)
 			message = 'Could not update the publish lock.'
 			handle.update()
+		} finally {
+			if (requestId === lockRequestId) {
+				lockBusy = false
+				handle.update()
+			}
 		}
 	}
 
@@ -268,6 +275,7 @@ export function AccountPackagesRoute(handle: Handle) {
 		selectedPackage = payload.selectedPackage
 		if ((selectedPackage?.id ?? null) !== previousSelectedId) {
 			lockRequestId += 1
+			lockBusy = false
 		}
 		username = payload.username
 		invocationUrlOrigin = payload.invocationUrlOrigin
@@ -598,6 +606,7 @@ export function AccountPackagesRoute(handle: Handle) {
 										</h2>
 										<button
 											type="button"
+											disabled={lockBusy}
 											title={
 												isPackageLocked(selectedPackage.lockedAt)
 													? 'Unlock publishes'

--- a/packages/worker/client/routes/account-packages.tsx
+++ b/packages/worker/client/routes/account-packages.tsx
@@ -155,11 +155,14 @@ export function AccountPackagesRoute(handle: Handle) {
 	let lastLoadedListKey = ''
 	let loadingDataKey: string | null = null
 	let lastFailedDataKey: string | null = null
-	let lockRequestId = 0
-	let lockBusy = false
+	const lockInFlight = new Map<string, string | null>()
 
 	function getCurrentHref() {
 		return readCurrentRouterHref(handle)
+	}
+
+	function isLockInFlight(packageId: string | null | undefined) {
+		return packageId != null && lockInFlight.has(packageId)
 	}
 
 	function isPackageLocked(lockedAt: string | null | undefined) {
@@ -175,15 +178,31 @@ export function AccountPackagesRoute(handle: Handle) {
 		)
 	}
 
+	function restoreInFlightLockState() {
+		if (lockInFlight.size === 0) return
+		if (selectedPackage && lockInFlight.has(selectedPackage.id)) {
+			selectedPackage = {
+				...selectedPackage,
+				lockedAt: lockInFlight.get(selectedPackage.id) ?? null,
+			}
+		}
+		packageList.updateItems((items) =>
+			items.map((pkg) =>
+				lockInFlight.has(pkg.id)
+					? { ...pkg, lockedAt: lockInFlight.get(pkg.id) ?? null }
+					: pkg,
+			),
+		)
+	}
+
 	async function togglePackageLock() {
-		if (!selectedPackage || lockBusy) return
+		if (!selectedPackage || lockInFlight.has(selectedPackage.id)) return
 		const href = getCurrentHref()
 		const packageId = selectedPackage.id
-		const requestId = ++lockRequestId
 		const previousLockedAt = selectedPackage.lockedAt
 		const nextLocked = !isPackageLocked(previousLockedAt)
 		const nextLockedAt = nextLocked ? new Date().toISOString() : null
-		lockBusy = true
+		lockInFlight.set(packageId, nextLockedAt)
 		message = null
 		applyLocalLockState(packageId, nextLockedAt)
 		handle.update()
@@ -208,11 +227,9 @@ export function AccountPackagesRoute(handle: Handle) {
 			const payload = await readJson<
 				AccountPackagesLoaderData & { error?: string }
 			>(response)
-			const stillCurrent =
-				requestId === lockRequestId && getCurrentHref() === href
 			if (!response.ok || !payload?.ok) {
 				applyLocalLockState(packageId, previousLockedAt)
-				if (stillCurrent) {
+				if (selectedPackage?.id === packageId) {
 					message = payload?.error ?? 'Could not update the publish lock.'
 				}
 				handle.update()
@@ -225,15 +242,13 @@ export function AccountPackagesRoute(handle: Handle) {
 			handle.update()
 		} catch {
 			applyLocalLockState(packageId, previousLockedAt)
-			if (requestId === lockRequestId && getCurrentHref() === href) {
+			if (selectedPackage?.id === packageId) {
 				message = 'Could not update the publish lock.'
 			}
 			handle.update()
 		} finally {
-			if (requestId === lockRequestId) {
-				lockBusy = false
-				handle.update()
-			}
+			lockInFlight.delete(packageId)
+			handle.update()
 		}
 	}
 
@@ -257,7 +272,6 @@ export function AccountPackagesRoute(handle: Handle) {
 	}
 
 	function applyPayload(payload: AccountPackagesLoaderData, href: string) {
-		const previousSelectedId = selectedPackage?.id ?? null
 		const listKey = getListKey(href)
 		// Selection-only navigations deep in the scroll window keep the
 		// already-loaded pages; anything else reseeds from page one so
@@ -276,10 +290,7 @@ export function AccountPackagesRoute(handle: Handle) {
 			lastLoadedListKey = listKey
 		}
 		selectedPackage = payload.selectedPackage
-		if ((selectedPackage?.id ?? null) !== previousSelectedId) {
-			lockRequestId += 1
-			lockBusy = false
-		}
+		restoreInFlightLockState()
 		username = payload.username
 		invocationUrlOrigin = payload.invocationUrlOrigin
 		message =
@@ -609,7 +620,7 @@ export function AccountPackagesRoute(handle: Handle) {
 										</h2>
 										<button
 											type="button"
-											disabled={lockBusy}
+											disabled={isLockInFlight(selectedPackage.id)}
 											title={
 												isPackageLocked(selectedPackage.lockedAt)
 													? 'Unlock publishes'

--- a/packages/worker/client/routes/account-packages.tsx
+++ b/packages/worker/client/routes/account-packages.tsx
@@ -1,6 +1,5 @@
 import { type Handle, css } from 'remix/ui'
 import { routes } from '#universal/routes.ts'
-import { createDoubleCheck } from '#client/double-check.ts'
 import { formatTimestampDate } from '#client/format-timestamp.ts'
 import { on } from '#client/event-mixin.ts'
 import { readCurrentRouterHref } from '#client/client-router.tsx'
@@ -23,9 +22,9 @@ import {
 import { ForkOutdatedCopyButton } from '#universal/fork-outdated-copy-button.tsx'
 import {
 	getAccentCalloutCss,
-	getDangerPillCss,
 	getGhostButtonCss,
 	getPillButtonCss,
+	visuallyHiddenCss,
 } from '#universal/styles/style-primitives.ts'
 import {
 	accountDisclosureCss,
@@ -156,19 +155,37 @@ export function AccountPackagesRoute(handle: Handle) {
 	let lastLoadedListKey = ''
 	let loadingDataKey: string | null = null
 	let lastFailedDataKey: string | null = null
-	const unlockCheck = createDoubleCheck(handle)
-	let lockBusy = false
+	let lockRequestId = 0
 
 	function getCurrentHref() {
 		return readCurrentRouterHref(handle)
 	}
 
-	async function postPackageLockAction(action: 'lock' | 'unlock') {
+	function isPackageLocked(lockedAt: string | null | undefined) {
+		return typeof lockedAt === 'string' && lockedAt.trim().length > 0
+	}
+
+	function applyLocalLockState(packageId: string, lockedAt: string | null) {
+		if (selectedPackage?.id === packageId) {
+			selectedPackage = { ...selectedPackage, lockedAt }
+		}
+		packageList.updateItems((items) =>
+			items.map((pkg) => (pkg.id === packageId ? { ...pkg, lockedAt } : pkg)),
+		)
+	}
+
+	async function togglePackageLock() {
 		if (!selectedPackage) return
 		const href = getCurrentHref()
-		lockBusy = true
+		const packageId = selectedPackage.id
+		const requestId = ++lockRequestId
+		const previousLockedAt = selectedPackage.lockedAt
+		const nextLocked = !isPackageLocked(previousLockedAt)
+		const nextLockedAt = nextLocked ? new Date().toISOString() : null
 		message = null
+		applyLocalLockState(packageId, nextLockedAt)
 		handle.update()
+
 		try {
 			const response = await fetch(buildPackagesApiRequestUrl(href), {
 				method: 'POST',
@@ -178,25 +195,34 @@ export function AccountPackagesRoute(handle: Handle) {
 				},
 				credentials: 'include',
 				body: JSON.stringify({
-					action,
-					packageId: selectedPackage.id,
+					action: nextLocked ? 'lock' : 'unlock',
+					packageId,
 				}),
 			})
+			if (requestId !== lockRequestId || getCurrentHref() !== href) return
+			if (response.status === 401) {
+				window.location.assign('/login')
+				return
+			}
 			const payload = await readJson<
 				AccountPackagesLoaderData & { error?: string }
 			>(response)
-			if (getCurrentHref() !== href) return
+			if (requestId !== lockRequestId || getCurrentHref() !== href) return
 			if (!response.ok || !payload?.ok) {
+				applyLocalLockState(packageId, previousLockedAt)
 				message = payload?.error ?? 'Could not update the publish lock.'
+				handle.update()
 				return
 			}
-			applyPayload(payload, href)
-			unlockCheck.reset()
+			applyLocalLockState(
+				packageId,
+				payload.selectedPackage?.lockedAt ?? nextLockedAt,
+			)
+			handle.update()
 		} catch {
-			if (getCurrentHref() !== href) return
+			if (requestId !== lockRequestId || getCurrentHref() !== href) return
+			applyLocalLockState(packageId, previousLockedAt)
 			message = 'Could not update the publish lock.'
-		} finally {
-			lockBusy = false
 			handle.update()
 		}
 	}
@@ -241,7 +267,7 @@ export function AccountPackagesRoute(handle: Handle) {
 		}
 		selectedPackage = payload.selectedPackage
 		if ((selectedPackage?.id ?? null) !== previousSelectedId) {
-			unlockCheck.reset()
+			lockRequestId += 1
 		}
 		username = payload.username
 		invocationUrlOrigin = payload.invocationUrlOrigin
@@ -470,13 +496,36 @@ export function AccountPackagesRoute(handle: Handle) {
 					rows={packages.map((pkg) => ({
 						id: pkg.id,
 						href: packagesRoute.buildDetailHref(pkg.id, getCurrentSearch()),
-						...(pkg.listingAhead
+						...(pkg.listingAhead || isPackageLocked(pkg.lockedAt)
 							? {
 									primaryAccessory: (
-										<ForkOutdatedCopyButton
-											prompt={pkg.listingAhead.prompt}
-											testId={`account-package-listing-ahead-${pkg.id}`}
-										/>
+										<span
+											mix={css({
+												display: 'inline-flex',
+												alignItems: 'center',
+												gap: spacing.xs,
+											})}
+										>
+											{isPackageLocked(pkg.lockedAt) ? (
+												<span
+													title="Publish lock on"
+													data-testid={`account-package-locked-${pkg.id}`}
+													mix={css({
+														display: 'inline-flex',
+														color: colors.textMuted,
+														flexShrink: 0,
+													})}
+												>
+													{packageLockGlyph(true)}
+												</span>
+											) : null}
+											{pkg.listingAhead ? (
+												<ForkOutdatedCopyButton
+													prompt={pkg.listingAhead.prompt}
+													testId={`account-package-listing-ahead-${pkg.id}`}
+												/>
+											) : null}
+										</span>
 									),
 								}
 							: {}),
@@ -547,6 +596,33 @@ export function AccountPackagesRoute(handle: Handle) {
 										>
 											{selectedPackage.name}
 										</h2>
+										<button
+											type="button"
+											title={
+												isPackageLocked(selectedPackage.lockedAt)
+													? 'Unlock publishes'
+													: 'Lock publishes'
+											}
+											data-testid="account-package-lock-toggle"
+											data-locked={
+												isPackageLocked(selectedPackage.lockedAt)
+													? 'true'
+													: 'false'
+											}
+											mix={[
+												css(packageLockToggleCss),
+												on('click', () => void togglePackageLock()),
+											]}
+										>
+											{packageLockGlyph(
+												isPackageLocked(selectedPackage.lockedAt),
+											)}
+											<span mix={css(visuallyHiddenCss)}>
+												{isPackageLocked(selectedPackage.lockedAt)
+													? `Unlock publishes for ${selectedPackage.name}`
+													: `Lock publishes for ${selectedPackage.name}`}
+											</span>
+										</button>
 										{selectedPackage.listingAhead ? (
 											<ForkOutdatedCopyButton
 												prompt={selectedPackage.listingAhead.prompt}
@@ -631,68 +707,32 @@ export function AccountPackagesRoute(handle: Handle) {
 								<div mix={css(getAccentCalloutCss())}>
 									<p mix={css({ margin: 0, color: colors.textMuted })}>
 										{selectedPackage.lockedAt
-											? 'Publishes stay on this reviewed tree until you promote a commit on the website.'
-											: 'Lock this package so agents cannot publish without your approval.'}
+											? 'Publishes stay on this reviewed tree until you promote a commit on the website. Click the lock icon to unlock.'
+											: 'Click the lock icon so agents cannot publish without your approval.'}
 									</p>
-									<div
-										mix={css({
-											display: 'flex',
-											flexWrap: 'wrap',
-											gap: spacing.xs,
-										})}
-									>
-										{selectedPackage.lockedAt ? (
-											<>
-												<a
-													href={routes.accountPackageApprovePublish.href({
-														packageId: selectedPackage.id,
-													})}
-													data-testid="account-approve-publish"
-													mix={css({
-														...getPillButtonCss({ size: 'sm' }),
-														display: 'inline-flex',
-														textDecoration: 'none',
-													})}
-												>
-													Approve a publish
-												</a>
-												<button
-													type="button"
-													data-testid="account-unlock-package"
-													disabled={lockBusy}
-													mix={[
-														css(getDangerPillCss({ size: 'sm' })),
-														unlockCheck.getButtonMix({
-															onFirstClick: () => undefined,
-															on: {
-																click: () => {
-																	if (unlockCheck.doubleCheck) {
-																		void postPackageLockAction('unlock')
-																	}
-																},
-															},
-														}),
-													]}
-												>
-													{unlockCheck.doubleCheck
-														? 'Click again to unlock'
-														: 'Unlock publishes'}
-												</button>
-											</>
-										) : (
-											<button
-												type="button"
-												data-testid="account-lock-package"
-												disabled={lockBusy}
-												mix={[
-													css(getPillButtonCss({ size: 'sm' })),
-													on('click', () => void postPackageLockAction('lock')),
-												]}
+									{selectedPackage.lockedAt ? (
+										<div
+											mix={css({
+												display: 'flex',
+												flexWrap: 'wrap',
+												gap: spacing.xs,
+											})}
+										>
+											<a
+												href={routes.accountPackageApprovePublish.href({
+													packageId: selectedPackage.id,
+												})}
+												data-testid="account-approve-publish"
+												mix={css({
+													...getPillButtonCss({ size: 'sm' }),
+													display: 'inline-flex',
+													textDecoration: 'none',
+												})}
 											>
-												Lock publishes
-											</button>
-										)}
-									</div>
+												Approve a publish
+											</a>
+										</div>
+									) : null}
 								</div>
 								<a
 									href={getAccountPackageFilesHref({
@@ -748,4 +788,61 @@ export function AccountPackagesRoute(handle: Handle) {
 			</AccountManagementShell>
 		)
 	}
+}
+
+function packageLockGlyph(locked: boolean) {
+	return (
+		<svg
+			viewBox="0 0 16 16"
+			width="1em"
+			height="1em"
+			aria-hidden="true"
+			focusable={false}
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="1.5"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+		>
+			{locked ? (
+				<path d="M5.2 7.4V5.8a2.8 2.8 0 0 1 5.6 0v1.6" />
+			) : (
+				<path d="M5.2 7.4V5.6a2.8 2.8 0 0 1 5.2-1.4" />
+			)}
+			<rect x="3.6" y="7.4" width="8.8" height="6.4" rx="1.3" />
+		</svg>
+	)
+}
+
+const packageLockToggleCss = {
+	display: 'inline-flex',
+	alignItems: 'center',
+	justifyContent: 'center',
+	width: '1.85rem',
+	height: '1.85rem',
+	padding: 0,
+	border: `1px solid ${colors.border}`,
+	borderRadius: '999px',
+	backgroundColor: 'transparent',
+	color: colors.textMuted,
+	cursor: 'pointer',
+	flexShrink: 0,
+	'&:hover': {
+		color: colors.primaryText,
+		borderColor: colors.primaryText,
+	},
+	'&:focus-visible': {
+		outline: `2px solid ${colors.primary}`,
+		outlineOffset: '2px',
+	},
+	'&[data-locked="true"]': {
+		color: colors.primary,
+		borderColor: colors.primary,
+		backgroundColor: `oklch(from ${colors.primary} l c h / 0.13)`,
+		'&:hover': {
+			color: colors.primaryText,
+			borderColor: colors.primaryText,
+			backgroundColor: `oklch(from ${colors.primary} l c h / 0.2)`,
+		},
+	},
 }

--- a/packages/worker/src/mcp/capabilities/packages/package-update.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/packages/package-update.node.test.ts
@@ -1,8 +1,10 @@
 import { expect, test, vi } from 'vitest'
+import { McpCallerError } from '#mcp/caller-error.ts'
 
 const mockModule = vi.hoisted(() => ({
 	getSavedPackageById: vi.fn(),
 	updateSavedPackage: vi.fn(),
+	setSavedPackageLockedAt: vi.fn(),
 	resolvePackageOwnerContext: vi.fn(),
 }))
 
@@ -11,6 +13,8 @@ vi.mock('#worker/package-registry/repo.ts', () => ({
 		mockModule.getSavedPackageById(...args),
 	updateSavedPackage: (...args: Array<unknown>) =>
 		mockModule.updateSavedPackage(...args),
+	setSavedPackageLockedAt: (...args: Array<unknown>) =>
+		mockModule.setSavedPackageLockedAt(...args),
 }))
 
 vi.mock('#worker/package-registry/package-owner.ts', () => ({
@@ -44,7 +48,10 @@ function createCtx(userId = 'user-1') {
 	}
 }
 
-function createSavedPackage(hidden: boolean) {
+function createSavedPackage(input?: {
+	hidden?: boolean
+	lockedAt?: string | null
+}) {
 	return {
 		id: 'pkg-1',
 		userId: 'user-1',
@@ -54,9 +61,9 @@ function createSavedPackage(hidden: boolean) {
 		tags: ['notes'],
 		searchText: null,
 		hasApp: false,
-		hidden,
+		hidden: input?.hidden ?? false,
 		isPrivate: false,
-		lockedAt: null,
+		lockedAt: input?.lockedAt ?? null,
 		sourceId: 'source-1',
 		createdAt: '2026-01-01T00:00:00.000Z',
 		updatedAt: '2026-07-14T00:00:00.000Z',
@@ -66,8 +73,10 @@ function createSavedPackage(hidden: boolean) {
 test('package_update hides and unhides a user-scoped package and returns persisted summaries', async () => {
 	mockModule.updateSavedPackage.mockResolvedValue(true)
 	mockModule.getSavedPackageById
-		.mockResolvedValueOnce(createSavedPackage(true))
-		.mockResolvedValueOnce(createSavedPackage(false))
+		.mockResolvedValueOnce(createSavedPackage())
+		.mockResolvedValueOnce(createSavedPackage({ hidden: true }))
+		.mockResolvedValueOnce(createSavedPackage({ hidden: true }))
+		.mockResolvedValueOnce(createSavedPackage({ hidden: false }))
 
 	await expect(
 		packageUpdateCapability.handler(
@@ -116,7 +125,74 @@ test('package_update hides and unhides a user-scoped package and returns persist
 			hidden: false,
 		},
 	)
-	expect(mockModule.getSavedPackageById).toHaveBeenCalledTimes(2)
+	expect(mockModule.setSavedPackageLockedAt).not.toHaveBeenCalled()
+	expect(mockModule.getSavedPackageById).toHaveBeenCalledTimes(4)
+})
+
+test('package_update locks a package and rejects unlock with the owner website URL', async () => {
+	const lockedPackage = createSavedPackage({
+		lockedAt: '2026-08-28T12:00:00.000Z',
+	})
+	mockModule.getSavedPackageById
+		.mockResolvedValueOnce(createSavedPackage())
+		.mockResolvedValueOnce(lockedPackage)
+		.mockResolvedValue(lockedPackage)
+	mockModule.setSavedPackageLockedAt.mockResolvedValue(true)
+
+	await expect(
+		packageUpdateCapability.handler(
+			{ package_id: 'pkg-1', changes: { locked: true } },
+			createCtx(),
+		),
+	).resolves.toMatchObject({
+		ok: true,
+		package: {
+			package_id: 'pkg-1',
+			locked_at: '2026-08-28T12:00:00.000Z',
+		},
+	})
+	expect(mockModule.setSavedPackageLockedAt).toHaveBeenCalledWith(
+		{},
+		{
+			userId: 'user-1',
+			packageId: 'pkg-1',
+			lockedAt: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T/),
+		},
+	)
+	expect(mockModule.updateSavedPackage).not.toHaveBeenCalled()
+
+	await expect(
+		packageUpdateCapability.handler(
+			{ package_id: 'pkg-1', changes: { locked: true } },
+			createCtx(),
+		),
+	).resolves.toMatchObject({
+		ok: true,
+		package: {
+			package_id: 'pkg-1',
+			locked_at: '2026-08-28T12:00:00.000Z',
+		},
+	})
+	expect(mockModule.setSavedPackageLockedAt).toHaveBeenCalledTimes(1)
+
+	const unlockError = await packageUpdateCapability
+		.handler({ package_id: 'pkg-1', changes: { locked: false } }, createCtx())
+		.catch((error: unknown) => error)
+	expect(unlockError).toBeInstanceOf(McpCallerError)
+	expect(unlockError).toMatchObject({
+		message:
+			'Agents cannot unlock packages. Send the owner to https://heykody.dev/account/packages/pkg-1 to unlock publishes.',
+	})
+	expect(mockModule.setSavedPackageLockedAt).toHaveBeenCalledTimes(1)
+	expect(mockModule.updateSavedPackage).not.toHaveBeenCalled()
+
+	await expect(
+		packageUpdateCapability.handler(
+			{ package_id: 'pkg-1', changes: { hidden: true, locked: false } },
+			createCtx(),
+		),
+	).rejects.toThrow(/cannot unlock/i)
+	expect(mockModule.updateSavedPackage).not.toHaveBeenCalled()
 })
 
 test('package_update rejects invalid changes and cross-user or unauthenticated access', async () => {
@@ -137,21 +213,17 @@ test('package_update rejects invalid changes and cross-user or unauthenticated a
 	).rejects.toThrow('Invalid input for capability "package_update"')
 	expect(mockModule.updateSavedPackage).not.toHaveBeenCalled()
 
-	mockModule.updateSavedPackage.mockResolvedValueOnce(false)
+	mockModule.getSavedPackageById.mockResolvedValueOnce(null)
 	await expect(
 		packageUpdateCapability.handler(
-			{ package_id: 'other-user-package', changes: { hidden: true } },
+			{
+				package_id: 'other-user-package',
+				changes: { hidden: true },
+			},
 			createCtx('user-2'),
 		),
 	).rejects.toThrow(/not found/i)
-	expect(mockModule.updateSavedPackage).toHaveBeenCalledWith(
-		{},
-		{
-			userId: 'user-2',
-			packageId: 'other-user-package',
-			hidden: true,
-		},
-	)
+	expect(mockModule.updateSavedPackage).not.toHaveBeenCalled()
 
 	await expect(
 		packageUpdateCapability.handler(
@@ -167,5 +239,5 @@ test('package_update rejects invalid changes and cross-user or unauthenticated a
 			},
 		),
 	).rejects.toThrow(/authenticated/i)
-	expect(mockModule.updateSavedPackage).toHaveBeenCalledTimes(1)
+	expect(mockModule.updateSavedPackage).not.toHaveBeenCalled()
 })

--- a/packages/worker/src/mcp/capabilities/packages/package-update.ts
+++ b/packages/worker/src/mcp/capabilities/packages/package-update.ts
@@ -8,7 +8,13 @@ import {
 	resolvePackageOwnerContext,
 } from '#worker/package-registry/package-owner.ts'
 import {
+	buildPackageUnlockUrl,
+	createPackageUnlockRequiredMessage,
+	isSavedPackageLocked,
+} from '#worker/package-registry/package-publish-lock.ts'
+import {
 	getSavedPackageById,
+	setSavedPackageLockedAt,
 	updateSavedPackage,
 } from '#worker/package-registry/repo.ts'
 import { packageSummarySchema, toPackageSummary } from './shared.ts'
@@ -21,18 +27,27 @@ const packageUpdateChangesSchema = z
 			.describe(
 				'When true, hide the package from ranked search discovery by default.',
 			),
+		locked: z
+			.boolean()
+			.optional()
+			.describe(
+				'When true, lock publishes so later agent publishes need a website click. Agents can lock but cannot unlock; send the owner to /account/packages/:packageId to unlock.',
+			),
 	})
-	.refine((changes) => changes.hidden !== undefined, {
-		message: 'Provide at least one supported package change.',
-	})
+	.refine(
+		(changes) => changes.hidden !== undefined || changes.locked !== undefined,
+		{
+			message: 'Provide at least one supported package change.',
+		},
+	)
 
 export const packageUpdateCapability = defineDomainCapability(
 	capabilityDomainNames.packages,
 	{
 		name: 'package_update',
 		description:
-			'Update mutable settings for a saved package. Supports hidden search-discovery state. Publish lock (`locked_at`) is website-only and cannot be changed here. Canonical package metadata such as name, description, tags, kody id, app projection, and source remains derived from package.json and must change through package save or publish.',
-		keywords: ['package', 'update', 'hidden', 'visibility', 'search'],
+			'Update mutable settings for a saved package. Supports hidden search-discovery state and locking publishes (`changes.locked: true`). Agents cannot unlock; send the owner to /account/packages/:packageId. Canonical package metadata such as name, description, tags, kody id, app projection, and source remains derived from package.json and must change through package save or publish.',
+		keywords: ['package', 'update', 'hidden', 'visibility', 'search', 'lock'],
 		readOnly: false,
 		idempotent: true,
 		destructive: false,
@@ -56,13 +71,45 @@ export const packageUpdateCapability = defineDomainCapability(
 				user,
 				args.package_scope,
 			)
-			const changed = await updateSavedPackage(ctx.env.APP_DB, {
+			const existing = await getSavedPackageById(ctx.env.APP_DB, {
 				userId: owner.ownerUserId,
 				packageId: args.package_id,
-				hidden: args.changes.hidden,
 			})
-			if (!changed) {
+			if (!existing) {
 				throw new McpCallerError('Saved package not found for this user.')
+			}
+			if (args.changes.locked === false) {
+				throw new McpCallerError(
+					createPackageUnlockRequiredMessage(
+						buildPackageUnlockUrl({
+							baseUrl: ctx.callerContext.baseUrl,
+							packageId: args.package_id,
+						}),
+					),
+				)
+			}
+			if (args.changes.hidden !== undefined) {
+				const changed = await updateSavedPackage(ctx.env.APP_DB, {
+					userId: owner.ownerUserId,
+					packageId: args.package_id,
+					hidden: args.changes.hidden,
+				})
+				if (!changed) {
+					throw new McpCallerError('Saved package not found for this user.')
+				}
+			}
+			if (
+				args.changes.locked === true &&
+				!isSavedPackageLocked(existing.lockedAt)
+			) {
+				const locked = await setSavedPackageLockedAt(ctx.env.APP_DB, {
+					userId: owner.ownerUserId,
+					packageId: args.package_id,
+					lockedAt: new Date().toISOString(),
+				})
+				if (!locked) {
+					throw new McpCallerError('Saved package not found for this user.')
+				}
 			}
 			const savedPackage = await getSavedPackageById(ctx.env.APP_DB, {
 				userId: owner.ownerUserId,

--- a/packages/worker/src/mcp/capabilities/packages/shared.ts
+++ b/packages/worker/src/mcp/capabilities/packages/shared.ts
@@ -30,7 +30,7 @@ export const packageSummarySchema = z.object({
 		.string()
 		.nullable()
 		.describe(
-			'When set, publishes require a website click at /account/packages/:packageId/approve-publish. Agents cannot lock or unlock this package.',
+			'When set, publishes require a website click at /account/packages/:packageId/approve-publish. Agents may lock via package_update (`changes.locked: true`). Unlocking is website-only at /account/packages/:packageId.',
 		),
 	source_id: z.string(),
 	created_at: z.string(),

--- a/packages/worker/src/package-registry/package-publish-lock.node.test.ts
+++ b/packages/worker/src/package-registry/package-publish-lock.node.test.ts
@@ -3,6 +3,8 @@ import {
 	PackagePublishLockedError,
 	buildPackagePublishApprovalPath,
 	buildPackagePublishApprovalUrl,
+	buildPackageUnlockPath,
+	buildPackageUnlockUrl,
 	createPackagePublishLockedMessage,
 	isGitCommitSha,
 	isSavedPackageLocked,
@@ -58,4 +60,12 @@ test('publish lock treats a stored timestamp as locked and builds a commit-named
 	expect(error.message).toContain(
 		'/account/packages/pkg-1/approve-publish?commit=abc1234',
 	)
+
+	expect(buildPackageUnlockPath('pkg-1')).toBe('/account/packages/pkg-1')
+	expect(
+		buildPackageUnlockUrl({
+			baseUrl: 'https://kody.codes',
+			packageId: 'pkg-1',
+		}),
+	).toBe('https://kody.codes/account/packages/pkg-1')
 })

--- a/packages/worker/src/package-registry/package-publish-lock.ts
+++ b/packages/worker/src/package-registry/package-publish-lock.ts
@@ -78,6 +78,24 @@ export function buildPackagePublishApprovalUrl(input: {
 	return url.toString()
 }
 
+export function buildPackageUnlockPath(packageId: string): string {
+	return routes.accountPackageDetail.href({ packageId })
+}
+
+export function buildPackageUnlockUrl(input: {
+	baseUrl: string
+	packageId: string
+}): string {
+	return new URL(
+		buildPackageUnlockPath(input.packageId),
+		input.baseUrl,
+	).toString()
+}
+
+export function createPackageUnlockRequiredMessage(unlockUrl: string): string {
+	return `Agents cannot unlock packages. Send the owner to ${unlockUrl} to unlock publishes.`
+}
+
 export function createPackagePublishLockedMessage(input: {
 	packageName: string
 	approvalUrl: string


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Make publish-lock state obvious and one-click on the package page, and let agents lock a package while keeping unlock on the owner website.

## Why

The lock shipped as metadata plus bulky Lock/Unlock buttons, and `package_update` could not lock. Owners need a small lock/unlock control with optimistic UI. Agents should be able to lock, but unlock must stay a human click — the agent gets the package URL to send the owner to.

## Summary

- Replace the package-page lock/unlock buttons with a lock icon next to the name. Clicking it toggles immediately (star/follow style) and reverts if the POST fails. Locked packages also show a lock mark in the list.
- Each package keeps its lock POST in flight across selection changes, so overlapping clicks or A → B → A cannot start a second write before the first settles.
- `package_update` accepts `changes.locked: true` and is a no-op when already locked.
- `changes.locked: false` is rejected with `Agents cannot unlock packages. Send the owner to <package URL> to unlock publishes.`
- Usage and contributing docs now describe lock-via-agent and website-only unlock.

## Testing

- Focused node-unit: `package_update` lock success / already-locked no-op / unlock rejected with owner URL
- Pre-push: `test:node` (2133) and `test:workers` (301) green
- Review: CodeRabbit overlapping-click and A → B → A races fixed; Bugbot stale list icon after navigation fixed
- Preview as seeded user: waiting on `0749577d`

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `48d525a9` · **Head:** `0749577d`

**Classification:** extends — `package_update` can lock but not unlock, and the account package page toggles lock with optimistic UI.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `saved-packages` | assistant | extends — `package_update` writes `locked_at` on `locked: true`; `locked: false` returns the owner unlock URL |
| `app-ui` | surfaces | extends — lock/unlock icon, optimistic toggle, per-package in-flight POSTs |

### Change flow

Owner clicks the lock icon; agents can lock through `package_update` but must send the owner to the package page to unlock.

```mermaid
sequenceDiagram
	actor owner as Owner
	actor agent as Agent
	participant appUi as app-ui
	participant savedPackages as saved-packages
	owner->>appUi: click lock/unlock icon
	appUi->>appUi: optimistic locked_at flip
	appUi->>savedPackages: POST /account/packages.json lock or unlock
	alt POST fails
		savedPackages-->>appUi: error
		appUi->>appUi: revert lock mark for that packageId
	end
	agent->>savedPackages: package_update changes.locked true
	savedPackages->>savedPackages: set locked_at when unlocked
	agent->>savedPackages: package_update changes.locked false
	savedPackages-->>agent: McpCallerError with /account/packages/:packageId
```

### Before / after

```text
Before: lock/unlock were callout buttons; package_update could not change locked_at
After:  icon toggle (optimistic, per-package in-flight); agents lock via package_update; unlock is website-only
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0a39b9b4-fc9e-46cc-817c-83f621d49d5a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0a39b9b4-fc9e-46cc-817c-83f621d49d5a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Packages can now be locked through package editing tools to prevent publishing.
  - Unlocking remains available through the package website, with a direct link provided when required.
  - Added streamlined lock controls in package lists and package detail views.
  - Locked packages now display clear status indicators and approval options.

- **Documentation**
  - Updated package management guidance to explain locking permissions, unlock requirements, and metadata behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->