### PR TITLE
Fit package and integration images to 256px WebP at ingest

### DIFF
--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -364,7 +364,7 @@ The schema is defined by migrations in `packages/worker/migrations/`:
   accessor. `logo_key` / `logo_content_type`
   (`0005-platform-oauth-app-logos.sql`) point at an operator-owned provider logo
   asset in the `COMMUNITY_ASSETS` R2 bucket (content-hashed
-  `platform-oauth-app-logos/{slug}/` keys; SVG uploads are rasterized to PNG
+  `platform-oauth-app-logos/{slug}/` keys; uploads are fitted to 256px WebP
   before storage). See
   [OAuth integrations](./integrations.md#platform-built-in-oauth-apps).
 - `user_integrations` (squashed baseline, rebuilt by
@@ -486,12 +486,15 @@ ticker.
 Processed public community icons live in the private `COMMUNITY_ASSETS` bucket.
 The public icon route reads the active listing first, then resolves a cachified
 descriptor from `BUNDLE_ARTIFACTS_KV` and streams the referenced R2 object.
-Source files remain in the listing's pinned Artifacts commit; R2 stores only
-validated derived output or a generated fallback.
+Source files remain in the listing's pinned Artifacts commit; R2 stores only the
+256-pixel WebP ingest (Cloudflare Images, `fit: scale-down`) or a generated
+fallback.
 
-- Keys use `community-icon:v1/{listingId}/{commit}/asset`, where the commit is
+- Keys use `community-icon:v2/{listingId}/{commit}/asset`, where the commit is
   the listing's icon commit (the owner package's current published commit) or
-  its pinned snapshot commit.
+  its pinned snapshot commit. Derived bytes are a 256-pixel WebP from the
+  Cloudflare Images ingest fit. Account deletion also prefix-deletes leftover
+  `community-icon:v1/` objects.
 - Descriptor keys include the same listing id and commit, so package publish and
   listing re-publish cannot serve an older icon.
 - Unpublish, admin hard delete, and re-publish prune all descriptor and object
@@ -1320,9 +1323,10 @@ app-owned keys in it. App-owned `BUNDLE_ARTIFACTS_KV` keys are:
 - `derived-cache:v1:usage-rollups:user:{userId}:asof:{YYYY-MM}` — derived
   per-user usage read model written with KV `expirationTtl`; retention is five
   minutes, so immediate account-deletion cleanup is not required.
-- `derived-cache:v1:community-icon:v1:{listingId}:...` — derived community
+- `derived-cache:v1:community-icon:v2:{listingId}:...` — derived community
   listing icon cache; registered as a user-owned KV surface and deleted for a
-  user's listings during account deletion.
+  user's listings during account deletion (including leftover
+  `community-icon:v1` prefixes).
 - `webhook-dispatch-payload:v1:{userId}:{deliveryId}` — ephemeral ack-mode
   webhook body spill written with KV `expirationTtl` (24 hours) when the
   serialized queue message would exceed 120 KB. Immediate account-deletion
@@ -1342,10 +1346,11 @@ or a deliberate retention note.
 
 App-owned R2 keys are:
 
-- `community-icon:v1/{listingId}/{commit}/asset` — processed public community
-  icon bytes at the listing's pinned or icon commit. The listing id is the
-  public ownership boundary. Account deletion paginates and strictly deletes
-  every key under each D1-owned listing prefix, including historical revisions.
+- `community-icon:v2/{listingId}/{commit}/asset` — processed public community
+  icon bytes (256px WebP) at the listing's pinned or icon commit. The listing id
+  is the public ownership boundary. Account deletion paginates and strictly
+  deletes every key under each D1-owned listing prefix, including historical
+  `community-icon:v1/` revisions.
 
 - `user-avatars/{stableUserId}/{contentHash}.{extension}` — profile avatars.
   Account deletion paginates and strictly deletes the complete stable-user

--- a/docs/contributing/architecture/integrations.md
+++ b/docs/contributing/architecture/integrations.md
@@ -166,17 +166,17 @@ capability use it within the import boundaries.
 Operators may attach a logo per platform app (`admin_platform_oauth_app_save`
 `logoBase64`; `null` clears). Uploads accept SVG, PNG, JPEG, or WebP. The shared
 community-icon pipeline sanitizes SVG, then Cloudflare Images fits every
-accepted source to a 256-pixel WebP (`fit: scale-down`, quality 90), so an
-active image format is never stored or served. Assets live in the
-`COMMUNITY_ASSETS` R2 bucket under content-hashed
+accepted source to a 256-pixel WebP (`fit: scale-down`, quality 90), so a newly
+ingested asset is stored and served as WebP. GET paths that still hold a
+pre-ingest object (`iconFitVersion` other than `2`) rewrite the hashed key in
+place; if Images fails they fall back to the original bytes so the mark still
+renders. Assets live in the `COMMUNITY_ASSETS` R2 bucket under content-hashed
 `platform-oauth-app-logos/{slug}/` keys (operator-owned, like the app row);
 `platform_oauth_apps.logo_key` / `logo_content_type` point at the current asset.
-GET paths lazily re-fit objects that predate that ingest (custom metadata
-`iconFitVersion` other than `2`) and rewrite the hashed key so caches pick up
-the smaller file. Serving is the public `/integrations/logos/:integrationSlug`
-route with immutable caching; projections expose the relative `logoPath`. The
-connect page and account integration views render it, falling back to the
-auto-favicon and then the letter.
+Serving is the public `/integrations/logos/:integrationSlug` route with
+immutable caching; projections expose the relative `logoPath`. The connect page
+and account integration views render it, falling back to the auto-favicon and
+then the letter.
 
 User-lane OAuth apps have the same asset pipeline on `user_oauth_apps`
 (`logo_key`, `logo_content_type`, `logo_source`, `favicon_source_host`).

--- a/docs/contributing/architecture/integrations.md
+++ b/docs/contributing/architecture/integrations.md
@@ -164,16 +164,19 @@ capability use it within the import boundaries.
 ### Provider logos
 
 Operators may attach a logo per platform app (`admin_platform_oauth_app_save`
-`logoBase64`; `null` clears). Uploads accept SVG, PNG, JPEG, or WebP; SVG is
-sanitized and rasterized to PNG through the community-icon pipeline, so an
+`logoBase64`; `null` clears). Uploads accept SVG, PNG, JPEG, or WebP. The shared
+community-icon pipeline sanitizes SVG, then Cloudflare Images fits every
+accepted source to a 256-pixel WebP (`fit: scale-down`, quality 90), so an
 active image format is never stored or served. Assets live in the
 `COMMUNITY_ASSETS` R2 bucket under content-hashed
 `platform-oauth-app-logos/{slug}/` keys (operator-owned, like the app row);
 `platform_oauth_apps.logo_key` / `logo_content_type` point at the current asset.
-Serving is the public `/integrations/logos/:integrationSlug` route with
-immutable caching; projections expose the relative `logoPath`. The connect page
-and account integration views render it, falling back to the auto-favicon and
-then the letter.
+GET paths lazily re-fit objects that predate that ingest (custom metadata
+`iconFitVersion` other than `2`) and rewrite the hashed key so caches pick up
+the smaller file. Serving is the public `/integrations/logos/:integrationSlug`
+route with immutable caching; projections expose the relative `logoPath`. The
+connect page and account integration views render it, falling back to the
+auto-favicon and then the letter.
 
 User-lane OAuth apps have the same asset pipeline on `user_oauth_apps`
 (`logo_key`, `logo_content_type`, `logo_source`, `favicon_source_host`).

--- a/docs/contributing/cloudflare-offerings.md
+++ b/docs/contributing/cloudflare-offerings.md
@@ -4,10 +4,10 @@ kody binds a broad set of Cloudflare offerings. Origin
 (`packages/worker/wrangler.jsonc`) is the largest surface — D1 (`APP_DB`), KV
 (`OAUTH_KV`, `BUNDLE_ARTIFACTS_KV`), **cross-script** Durable Object bindings
 (`MCP_OBJECT` and others), R2 (`COMMUNITY_ASSETS`, `EMAIL_BLOBS`,
-`REPO_SESSION_BLOBS`), Workers AI (`AI`, optionally routed through AI Gateway
-via `AI_GATEWAY_ID`), Vectorize (`CAPABILITY_VECTOR_INDEX`), Queues, Analytics
-Engine (`USAGE_EVENTS`), Workflows, and worker loaders — but it is not the whole
-inventory. Platform, runtime, and jobs wranglers
+`REPO_SESSION_BLOBS`), Images (`IMAGES`), Workers AI (`AI`, optionally routed
+through AI Gateway via `AI_GATEWAY_ID`), Vectorize (`CAPABILITY_VECTOR_INDEX`),
+Queues, Analytics Engine (`USAGE_EVENTS`), Workflows, and worker loaders — but
+it is not the whole inventory. Platform, runtime, and jobs wranglers
 (`packages/platform-worker/wrangler.jsonc`,
 `packages/runtime-worker/wrangler.jsonc`, `packages/jobs-worker/wrangler.jsonc`)
 own Durable Object **classes**, `JOBS_DB`, and runtime-only bindings. See
@@ -19,6 +19,7 @@ This guide covers how those common offerings are added, useful when you need
 another one of:
 
 - R2 (object storage)
+- Images (resize / re-encode)
 - Workers AI
 - AI Gateway
 - An additional KV namespace for app data (separate from `OAUTH_KV`)
@@ -62,6 +63,30 @@ Add these permissions when you add the corresponding offering:
 
 If you use `npx wrangler secret put ...` in CI, your token must also be able to
 edit Worker secrets (covered by `Workers Scripts:Edit`).
+
+## Images (resize / re-encode)
+
+Use the Images binding for off-isolate raster transforms so a large upload
+cannot OOM the Worker. Origin and platform wranglers bind `IMAGES`; package
+icons and integration / MCP logos fit to 256px WebP at ingest.
+
+### Token permissions
+
+Images uses the Worker script binding. Deploy is covered by
+`Workers Scripts:Edit`; there is no extra Images resource to create.
+
+### Bindings (`packages/worker/wrangler.jsonc`)
+
+```jsonc
+"images": { "binding": "IMAGES" }
+```
+
+Local wrangler and workers-unit tests use the offline Images simulator (`width`
+/ `height` / `fit` / `format`). Wrangler does not inherit the `images` key into
+named environments, so production, preview, and test each restate
+`"images": { "binding": "IMAGES" }`. Node-unit tests use
+`createFakeImagesBinding()` in
+`packages/worker/src/test-support/images-binding.ts`.
 
 ## R2 (object storage)
 

--- a/docs/contributing/community-packages.md
+++ b/docs/contributing/community-packages.md
@@ -155,17 +155,19 @@ the listing's pinned commit when the source row is gone). Listing reads join the
 entity source, so a plain package publish moves the icon commit forward — and
 with it the icon URL — without a community republish. `@epic-web/cachified`
 stores a small descriptor in `BUNDLE_ARTIFACTS_KV` under
-`derived-cache:v1:community-icon:v1:{listingId}:{commit}`. The processed bytes
+`derived-cache:v1:community-icon:v2:{listingId}:{commit}`. The processed bytes
 live in the private `COMMUNITY_ASSETS` R2 bucket under
-`community-icon:v1/{listingId}/{commit}/asset`.
+`community-icon:v2/{listingId}/{commit}/asset`.
 
 On a descriptor cache miss, the icon service resolves the standardized root
 `community-icon.*` path (from the pinned snapshot when serving the pinned
 commit, otherwise by probing the Artifacts git repo at the icon commit), reads
 the bytes, validates them, and writes the derived asset to R2 before returning
 the descriptor. A dangling descriptor is deleted and regenerated once. Packages
-without an icon receive a generated fallback. SVG input is rasterized to PNG;
-PNG, WebP, and JPEG input remains in its validated source format.
+without an icon receive a generated fallback. Every accepted source (SVG
+rasterized first, then PNG, WebP, and JPEG) is fitted through the Cloudflare
+Images binding to a 256-pixel WebP (`fit: scale-down`, quality 90). Publish and
+account-deletion cleanup also remove leftover `community-icon:v1` keys.
 
 The icon route serves only the current icon commit and the pinned commit; stale
 commit URLs 404. Package publish (`finalizePublishedEntitySource`) calls

--- a/docs/contributing/setup-manifest.md
+++ b/docs/contributing/setup-manifest.md
@@ -115,6 +115,13 @@ This project uses the following resources:
     (same for preview). **Dimensions must match** the embedding model in
     `packages/worker/src/vectorize/embedding.ts` (`@cf/baai/bge-small-en-v1.5`,
     384 dimensions, `cls` pooling).
+- Cloudflare Images binding for package-icon and integration-logo ingest
+  - `binding`: `IMAGES`
+  - Origin (`packages/worker/wrangler.jsonc`) and platform
+    (`packages/platform-worker/wrangler.jsonc`) bind the same Images API.
+    Derived community icons and OAuth / MCP logos are fitted to 256px WebP at
+    ingest. No extra Cloudflare resource to create; local wrangler uses the
+    offline simulator.
 - Workers AI binding for semantic search embeddings
   - `binding`: `AI`
   - Production and preview route embedding calls through this binding. When

--- a/docs/guides/package-authoring.md
+++ b/docs/guides/package-authoring.md
@@ -274,8 +274,9 @@ user explicitly skips a surface) treat the package as ready to run.
 Public community packages should include one root `community-icon.svg`,
 `community-icon.png`, `community-icon.webp`, `community-icon.jpg`, or
 `community-icon.jpeg`. Prefer a square visual with a simple silhouette that
-remains legible at 56 pixels. Keep it under 2 MiB and 16 megapixels. Kody
-generates a package-name fallback when the repository has no icon.
+remains legible at 56 pixels. Keep it under 2 MiB and 16 megapixels. Kody stores
+a 256-pixel WebP derivative of that source (or a generated package-name fallback
+when the repository has no icon).
 
 Publishing the package refreshes the community listing icon automatically. The
 candidate paths win in the order listed above, so when replacing an icon with a

--- a/docs/use/community-packages.md
+++ b/docs/use/community-packages.md
@@ -51,10 +51,9 @@ Include an icon at the package root:
 - `community-icon.jpg` or `community-icon.jpeg`
 
 The first file in that order wins when more than one exists. Icons must be at
-most 2 MiB, 4096 pixels per side, and 16 megapixels total. Kody rasterizes SVG
-icons to PNG before serving them; PNG, WebP, and JPEG files are validated and
-served in their original format. Packages without an icon receive a generated
-visual based on the package name.
+most 2 MiB, 4096 pixels per side, and 16 megapixels total. Kody validates the
+source, then stores a 256-pixel WebP derivative (SVG is rasterized first).
+Packages without an icon receive a generated visual based on the package name.
 
 Icon URLs embed the package's **current published commit** (falling back to the
 listing's pinned commit if the package source no longer exists), so publishing a

--- a/packages/platform-worker/wrangler.jsonc
+++ b/packages/platform-worker/wrangler.jsonc
@@ -10,6 +10,13 @@
 	"name": "kody-platform",
 	"compatibility_date": "2026-04-16",
 	"compatibility_flags": ["nodejs_compat", "global_fetch_strictly_public"],
+	// Same Images binding as origin: MCP admin/integration logo uploads run
+	// on this script and must fit rasters before they land in R2. Wrangler
+	// does not inherit `images` into named envs — restate it on production
+	// and preview.
+	"images": {
+		"binding": "IMAGES",
+	},
 	// Same rationale as the origin worker: the MCP Agent Durable Object
 	// keeps a long-lived session and fans out into many D1 + Durable
 	// Object subrequests per invocation.
@@ -275,6 +282,9 @@
 			"ai": {
 				"binding": "AI",
 			},
+			"images": {
+				"binding": "IMAGES",
+			},
 			"send_email": [
 				{
 					"name": "EMAIL",
@@ -456,6 +466,9 @@
 			],
 			"ai": {
 				"binding": "AI",
+			},
+			"images": {
+				"binding": "IMAGES",
 			},
 			"send_email": [
 				{

--- a/packages/worker/src/account/user-owned-surfaces.ts
+++ b/packages/worker/src/account/user-owned-surfaces.ts
@@ -203,9 +203,9 @@ export const accountUserOwnedKvKeySchemes: ReadonlyArray<UserOwnedKvKeyScheme> =
 		{
 			id: 'community_icon_derived_cache',
 			binding: 'BUNDLE_ARTIFACTS_KV',
-			prefixTemplate: 'derived-cache:v1:community-icon:v1:{listingId}:',
+			prefixTemplate: 'derived-cache:v1:community-icon:v2:{listingId}:',
 			notes:
-				'Derived cache key from derivedCacheKeyPrefix + buildCommunityIconCacheKey.',
+				'Derived cache key from derivedCacheKeyPrefix + buildCommunityIconCacheKey. Account deletion also prefixes historical community-icon:v1 keys.',
 		},
 		{
 			id: 'usage_rollup_derived_cache',
@@ -265,8 +265,10 @@ export const accountUserOwnedR2Surfaces: ReadonlyArray<UserOwnedR2Surface> = [
 		id: 'community_icon',
 		binding: 'COMMUNITY_ASSETS',
 		sourceTable: 'community_listings',
-		keyTemplate: 'community-icon:v1/{listingId}/{commit}/asset',
+		keyTemplate: 'community-icon:v2/{listingId}/{commit}/asset',
 		export: 'chunked_bytes',
+		notes:
+			'Current fitted WebP derivative. Account deletion also removes historical community-icon:v1 prefixes.',
 	},
 	{
 		id: 'user_avatar',

--- a/packages/worker/src/app/account-deletion.node.test.ts
+++ b/packages/worker/src/app/account-deletion.node.test.ts
@@ -921,6 +921,8 @@ test('deleteUserAccount cascades user-scoped rows for the requested user', async
 		'derived-cache:v1:community-icon:v1:listing-1:commit-1',
 		'derived-cache:v1:community-icon:v1:listing-1:abc123',
 		'derived-cache:v1:community-icon:v1:listing-1:historical',
+		'derived-cache:v1:community-icon:v2:listing-1:commit-1',
+		'derived-cache:v1:community-icon:v2:listing-1:abc123',
 		'source-snapshot:v1:src-2:def456',
 		`package-codemod-revert:${userAaa}:item-1`,
 		`package-codemod-revert:${userAaa}:item-2`,
@@ -996,6 +998,8 @@ test('deleteUserAccount cascades user-scoped rows for the requested user', async
 		'community-icon:v1/listing-1/abc123/asset',
 		'community-icon:v1/listing-1/commit-1/asset',
 		'community-icon:v1/listing-1/historical/asset',
+		'community-icon:v2/listing-1/abc123/asset',
+		'community-icon:v2/listing-1/commit-1/asset',
 		'community-icon:v1/listing-2/other/asset',
 	])
 	const communityAssets = {
@@ -1337,6 +1341,8 @@ test('deleteUserAccount cascades user-scoped rows for the requested user', async
 		'derived-cache:v1:community-icon:v1:listing-1:abc123',
 		'derived-cache:v1:community-icon:v1:listing-1:commit-1',
 		'derived-cache:v1:community-icon:v1:listing-1:historical',
+		'derived-cache:v1:community-icon:v2:listing-1:abc123',
+		'derived-cache:v1:community-icon:v2:listing-1:commit-1',
 		`package-codemod-revert:${userAaa}:item-1`,
 		`package-codemod-revert:${userAaa}:item-2`,
 		'package-retriever-index-entry:v1:user-aaa:context:pkg-1:notes',
@@ -1371,14 +1377,16 @@ test('deleteUserAccount cascades user-scoped rows for the requested user', async
 	expect(result.updatedRowCounts.community_bans).toBe(1)
 	expect(result.deletedRowCounts.platform_feedback).toBe(1)
 	expect(result.updatedRowCounts.platform_feedback).toBe(1)
-	expect(result.deletedKvKeys).toBe(14)
-	expect(result.deletedCommunityAssets).toBe(5)
+	expect(result.deletedKvKeys).toBe(16)
+	expect(result.deletedCommunityAssets).toBe(7)
 	expect(result.deletedEmailBlobs).toBe(2)
 	// Prefix sweeps remove current and historical assets without crossing users.
 	expect(deletedCommunityAssetKeys.sort()).toEqual([
 		'community-icon:v1/listing-1/abc123/asset',
 		'community-icon:v1/listing-1/commit-1/asset',
 		'community-icon:v1/listing-1/historical/asset',
+		'community-icon:v2/listing-1/abc123/asset',
+		'community-icon:v2/listing-1/commit-1/asset',
 		'user-avatars/user-aaa/abc123.png',
 		'user-avatars/user-aaa/old.png',
 	])

--- a/packages/worker/src/app/account-deletion.ts
+++ b/packages/worker/src/app/account-deletion.ts
@@ -61,7 +61,10 @@ import {
 } from '#worker/package-runtime/published-runtime-artifacts.ts'
 import { deleteAllPackageRetrieverCacheEntriesForUser } from '#worker/package-retrievers/manifest-cache.ts'
 import { buildCommunitySnapshotKvKey } from '#worker/community/snapshot.ts'
-import { buildCommunityIconCacheKey } from '#worker/community/community-icon.ts'
+import {
+	communityIconKvListingPrefixes,
+	buildCommunityIconCacheKey,
+} from '#worker/community/community-icon.ts'
 import { derivedCacheKeyPrefix } from '#worker/kv-cachified.ts'
 import {
 	maybeRemoveDiscordGuildRoles,
@@ -1102,9 +1105,8 @@ export async function deleteUserAccount(input: {
 					`source-snapshot:v1:${source.sourceId}:`,
 					`source-manifest-snapshot:v1:${source.sourceId}:`,
 				]),
-				...inventory.communityListings.map(
-					(listing) =>
-						`${derivedCacheKeyPrefix}community-icon:v1:${listing.id}:`,
+				...inventory.communityListings.flatMap((listing) =>
+					communityIconKvListingPrefixes(listing.id),
 				),
 				// Package-codemod apply snapshots are user-namespaced in KV
 				// (`package-codemod-revert:{userId}:{itemId}`). D1 run items are

--- a/packages/worker/src/app/account-r2-prefix-cleanup.node.test.ts
+++ b/packages/worker/src/app/account-r2-prefix-cleanup.node.test.ts
@@ -11,6 +11,8 @@ test('community asset prefix cleanup paginates and preserves other users', async
 		'user-avatars/user-bbb/other.png',
 		'community-icon:v1/listing-a/current/asset',
 		'community-icon:v1/listing-a/historical/asset',
+		'community-icon:v2/listing-a/current/asset',
+		'community-icon:v2/listing-a/historical/asset',
 		'community-icon:v1/listing-b/other/asset',
 	])
 	const list = vi.fn(async (options?: { prefix?: string; cursor?: string }) => {
@@ -44,11 +46,13 @@ test('community asset prefix cleanup paginates and preserves other users', async
 		stableUserId: 'user-aaa',
 		listingIds: ['listing-a'],
 	})
-	expect(count).toBe(4)
-	expect(list).toHaveBeenCalledTimes(4)
+	expect(count).toBe(6)
+	expect(list).toHaveBeenCalledTimes(6)
 	expect(deleted.sort()).toEqual([
 		'community-icon:v1/listing-a/current/asset',
 		'community-icon:v1/listing-a/historical/asset',
+		'community-icon:v2/listing-a/current/asset',
+		'community-icon:v2/listing-a/historical/asset',
 		'user-avatars/user-aaa/current.png',
 		'user-avatars/user-aaa/historical.png',
 	])

--- a/packages/worker/src/app/account-r2-prefix-cleanup.ts
+++ b/packages/worker/src/app/account-r2-prefix-cleanup.ts
@@ -1,11 +1,8 @@
+import { communityIconR2ListingPrefixes } from '#worker/community/community-icon.ts'
 import { getErrorMessage } from '@kody-internal/shared/error-message.ts'
 
 function userAvatarPrefix(stableUserId: string) {
 	return `user-avatars/${stableUserId}/`
-}
-
-function communityIconPrefix(listingId: string) {
-	return `community-icon:v1/${listingId}/`
 }
 
 async function deletePrefixStrict(input: {
@@ -57,11 +54,13 @@ export async function deleteAccountCommunityAssetPrefixes(input: {
 		label: 'User avatar',
 	})
 	for (const listingId of new Set(input.listingIds)) {
-		deleted += await deletePrefixStrict({
-			bucket: input.bucket,
-			prefix: communityIconPrefix(listingId),
-			label: 'Community icon',
-		})
+		for (const prefix of communityIconR2ListingPrefixes(listingId)) {
+			deleted += await deletePrefixStrict({
+				bucket: input.bucket,
+				prefix,
+				label: 'Community icon',
+			})
+		}
 	}
 	return deleted
 }

--- a/packages/worker/src/app/handlers/admin-platform-integrations.node.test.ts
+++ b/packages/worker/src/app/handlers/admin-platform-integrations.node.test.ts
@@ -5,6 +5,7 @@ import type * as AuditLog from '#worker/audit-log.ts'
 import { logAuditEventSpy } from '#worker/test-support/audit-log-spy.ts'
 import { applyAllMigrations as applyRepositoryMigrations } from '#worker/test-support/apply-all-migrations.ts'
 import { createD1FromSqlite } from '#worker/test-support/create-d1-from-sqlite.ts'
+import { createFakeImagesBinding } from '#worker/test-support/images-binding.ts'
 
 const mockModule = vi.hoisted(() => ({
 	readAuthenticatedAppUser: vi.fn<() => Promise<unknown>>(),
@@ -70,6 +71,7 @@ function createHarness() {
 				objects.delete(key)
 			},
 		} as unknown as R2Bucket,
+		IMAGES: createFakeImagesBinding(),
 	} as Env
 	return { sqlite, env, objects }
 }

--- a/packages/worker/src/app/handlers/community-detail-og-image.node.test.ts
+++ b/packages/worker/src/app/handlers/community-detail-og-image.node.test.ts
@@ -1,5 +1,6 @@
 import { expect, test, vi } from 'vitest'
 import { type CommunityListingWithAggregates } from '#worker/community/types.ts'
+import type * as IconFitModule from '#worker/community/icon-fit.ts'
 import { createCommunityDetailOgImageHandler } from './community-detail.tsx'
 
 const mocks = vi.hoisted(() => ({
@@ -7,6 +8,7 @@ const mocks = vi.hoisted(() => ({
 	getCommunityListingWithAggregates: vi.fn(),
 	renderCommunityIconFallbackPng: vi.fn(),
 	renderCommunityOgImage: vi.fn(),
+	convertIconRasterToPng: vi.fn(),
 }))
 
 vi.mock('#worker/community/community-icon.ts', () => ({
@@ -21,6 +23,15 @@ vi.mock('#worker/community/service.ts', () => ({
 		mocks.getCommunityListingWithAggregates(...args),
 	reportCommunityListing: vi.fn(),
 }))
+
+vi.mock('#worker/community/icon-fit.ts', async (importOriginal) => {
+	const actual = await importOriginal<typeof IconFitModule>()
+	return {
+		...actual,
+		convertIconRasterToPng: (...args: Array<unknown>) =>
+			mocks.convertIconRasterToPng(...args),
+	}
+})
 
 vi.mock('#worker/community/og-image.ts', () => ({
 	renderCommunityOgImage: (...args: Array<unknown>) =>
@@ -67,7 +78,7 @@ const tinyPng = Uint8Array.from([
 	0x44, 0xae, 0x42, 0x60, 0x82,
 ])
 
-test('community detail OG image embeds PNG icons and falls back for WebP', async () => {
+test('community detail OG image embeds PNG icons and converts WebP for satori', async () => {
 	mocks.getCommunityListingWithAggregates.mockResolvedValue(listing)
 	mocks.getCommunityIconObject.mockResolvedValue({
 		descriptor: {
@@ -105,12 +116,13 @@ test('community detail OG image embeds PNG icons and falls back for WebP', async
 
 	mocks.renderCommunityOgImage.mockClear()
 	mocks.renderCommunityIconFallbackPng.mockClear()
+	mocks.convertIconRasterToPng.mockResolvedValue(tinyPng)
 	mocks.getCommunityIconObject.mockResolvedValue({
 		descriptor: {
-			version: 1,
+			version: 2,
 			listingId: listing.id,
 			iconCommit: listing.iconCommit,
-			r2Key: 'community-icon:v1/listing-1/def456/asset',
+			r2Key: 'community-icon:v2/listing-1/def456/asset',
 			contentType: 'image/webp',
 			sourcePath: 'community-icon.webp',
 			byteLength: 12,
@@ -119,7 +131,6 @@ test('community detail OG image embeds PNG icons and falls back for WebP', async
 			arrayBuffer: async () => new ArrayBuffer(12),
 		},
 	})
-	mocks.renderCommunityIconFallbackPng.mockResolvedValue(tinyPng)
 	mocks.renderCommunityOgImage.mockResolvedValue(tinyPng)
 
 	const webpResponse = await handler.handler({
@@ -129,9 +140,8 @@ test('community detail OG image embeds PNG icons and falls back for WebP', async
 	} as never)
 
 	expect(webpResponse.status).toBe(200)
-	expect(mocks.renderCommunityIconFallbackPng).toHaveBeenCalledWith(
-		listing.name,
-	)
+	expect(mocks.convertIconRasterToPng).toHaveBeenCalled()
+	expect(mocks.renderCommunityIconFallbackPng).not.toHaveBeenCalled()
 	expect(mocks.renderCommunityOgImage).toHaveBeenCalledWith(
 		expect.objectContaining({
 			iconDataUri: expect.stringMatching(/^data:image\/png;base64,/),

--- a/packages/worker/src/app/handlers/community-detail.tsx
+++ b/packages/worker/src/app/handlers/community-detail.tsx
@@ -24,6 +24,7 @@ import {
 	getCommunityIconObject,
 	renderCommunityIconFallbackPng,
 } from '#worker/community/community-icon.ts'
+import { convertIconRasterToPng } from '#worker/community/icon-fit.ts'
 import {
 	getCommunityListingWithAggregates,
 	reportCommunityListing,
@@ -265,8 +266,8 @@ export function createCommunityPackageApiHandler(env: Env) {
 
 /**
  * Resolve a satori-safe data URI for the package community icon. PNG and JPEG
- * bytes embed directly; WebP (unsupported by satori) and load failures fall
- * back to the same generated mark the public icon route uses.
+ * bytes embed directly; WebP is converted to PNG through Images because satori
+ * cannot decode it. Load failures fall back to the generated mark.
  */
 async function loadCommunityOgIconDataUri(input: {
 	env: Env
@@ -278,12 +279,19 @@ async function loadCommunityOgIconDataUri(input: {
 			listing: input.listing,
 			iconCommit: input.listing.iconCommit,
 		})
+		const bytes = new Uint8Array(await object.arrayBuffer())
 		if (
 			descriptor.contentType === 'image/png' ||
 			descriptor.contentType === 'image/jpeg'
 		) {
-			const bytes = new Uint8Array(await object.arrayBuffer())
 			return `data:${descriptor.contentType};base64,${bytesToBase64(bytes)}`
+		}
+		if (descriptor.contentType === 'image/webp') {
+			const png = await convertIconRasterToPng({
+				images: input.env.IMAGES,
+				bytes,
+			})
+			return `data:image/png;base64,${bytesToBase64(png)}`
 		}
 	} catch (error) {
 		console.error('community-og-icon-load-failed', input.listing.id, error)

--- a/packages/worker/src/app/handlers/community-icon.node.test.ts
+++ b/packages/worker/src/app/handlers/community-icon.node.test.ts
@@ -1,6 +1,7 @@
 import { expect, test, vi } from 'vitest'
 import { consoleError } from '#worker/test-support/console-spies.ts'
 import { createCommunityIconHandler } from './community-icon.ts'
+import type * as CommunityIconModule from '#worker/community/community-icon.ts'
 import { type CommunityListingRecord } from '#worker/community/types.ts'
 
 const mocks = vi.hoisted(() => ({
@@ -9,10 +10,10 @@ const mocks = vi.hoisted(() => ({
 	renderCommunityIconFallbackPng: vi.fn(),
 }))
 
-vi.mock('#worker/community/community-icon.ts', () => {
+vi.mock('#worker/community/community-icon.ts', async (importOriginal) => {
+	const actual = await importOriginal<typeof CommunityIconModule>()
 	return {
-		buildCommunityIconFallbackSvg: (name: string) =>
-			`<svg xmlns="http://www.w3.org/2000/svg"><text>${name}</text></svg>`,
+		...actual,
 		getCommunityIconObject: (...args: Array<unknown>) =>
 			mocks.getCommunityIconObject(...args),
 		renderCommunityIconFallbackPng: (...args: Array<unknown>) =>
@@ -84,6 +85,9 @@ test('community icon handler serves cached R2 bytes for current and pinned commi
 	const currentResponse = await callHandler()
 	expect(currentResponse.status).toBe(200)
 	expect(currentResponse.headers.get('Content-Type')).toBe('image/png')
+	expect(currentResponse.headers.get('Cache-Control')).toBe(
+		'public, max-age=31536000, immutable',
+	)
 	expect(currentResponse.headers.get('ETag')).toBe('"icon-etag"')
 	expect(currentResponse.headers.get('X-Content-Type-Options')).toBe('nosniff')
 	expect(new Uint8Array(await currentResponse.arrayBuffer())).toEqual(bytes)

--- a/packages/worker/src/app/handlers/community-icon.ts
+++ b/packages/worker/src/app/handlers/community-icon.ts
@@ -1,13 +1,12 @@
 import { type Action } from 'remix/router'
 import {
 	buildCommunityIconFallbackSvg,
+	communityIconCacheControl,
 	getCommunityIconObject,
 	renderCommunityIconFallbackPng,
 } from '#worker/community/community-icon.ts'
 import { getCommunityListingById } from '#worker/community/repo.ts'
 import { type routes } from '#universal/routes.ts'
-
-const communityIconCacheControl = 'public, max-age=3600'
 
 export function createCommunityIconHandler(env: Env) {
 	return {

--- a/packages/worker/src/app/handlers/integration-logo.ts
+++ b/packages/worker/src/app/handlers/integration-logo.ts
@@ -1,9 +1,12 @@
 import { type Action } from 'remix/router'
 import { readAuthenticatedAppUser } from '#app/authenticated-user.ts'
-import { getPlatformOauthAppLogoObject } from '#worker/integrations/platform-app-logo.ts'
+import {
+	loadFittedPlatformOauthAppLogo,
+	type ServedFittedLogo,
+} from '#worker/integrations/platform-app-logo.ts'
 import { getPlatformOauthAppBySlug } from '#worker/integrations/platform-apps.ts'
 import { getOauthApp } from '#worker/integrations/service.ts'
-import { getUserOauthAppLogoObject } from '#worker/integrations/user-oauth-app-logo.ts'
+import { loadFittedUserOauthAppLogo } from '#worker/integrations/user-oauth-app-logo.ts'
 import { type routes } from '#universal/routes.ts'
 
 /**
@@ -23,16 +26,12 @@ export function createIntegrationLogoHandler(env: Env) {
 				includeDisabled: true,
 			})
 			if (platformApp?.logoKey) {
-				const object = await getPlatformOauthAppLogoObject({
+				const logo = await loadFittedPlatformOauthAppLogo({
+					db: env.APP_DB,
 					env,
-					logoKey: platformApp.logoKey,
+					app: platformApp,
 				})
-				if (object) {
-					return logoResponse(object, {
-						contentType: platformApp.logoContentType,
-						cacheControl: 'public, max-age=31536000, immutable',
-					})
-				}
+				if (logo) return logoResponse(logo)
 			}
 
 			const user = await readAuthenticatedAppUser(request, env)
@@ -47,31 +46,27 @@ export function createIntegrationLogoHandler(env: Env) {
 			if (!app?.logoKey) {
 				return new Response('Not found', { status: 404 })
 			}
-			const object = await getUserOauthAppLogoObject({
+			const logo = await loadFittedUserOauthAppLogo({
+				db: env.APP_DB,
 				env,
-				logoKey: app.logoKey,
+				userId: user.mcpUser.userId,
+				app,
 			})
-			if (!object) {
+			if (!logo) {
 				return new Response('Not found', { status: 404 })
 			}
-			return logoResponse(object, {
-				contentType: app.logoContentType ?? null,
-				cacheControl: 'private, no-store',
-			})
+			return logoResponse(logo)
 		},
 	} satisfies Action<typeof routes.integrationLogo>
 }
 
-function logoResponse(
-	object: R2ObjectBody,
-	headers: { contentType: string | null; cacheControl: string },
-) {
-	return new Response(object.body, {
+function logoResponse(logo: ServedFittedLogo) {
+	return new Response(logo.body, {
 		headers: {
-			'Cache-Control': headers.cacheControl,
-			'Content-Length': String(object.size),
-			'Content-Type': headers.contentType ?? 'application/octet-stream',
-			ETag: object.httpEtag,
+			'Cache-Control': logo.cacheControl,
+			'Content-Length': String(logo.size),
+			'Content-Type': logo.contentType,
+			ETag: logo.httpEtag,
 			'X-Content-Type-Options': 'nosniff',
 		},
 	})

--- a/packages/worker/src/app/handlers/mcp-server-logo.node.test.ts
+++ b/packages/worker/src/app/handlers/mcp-server-logo.node.test.ts
@@ -3,7 +3,7 @@ import { expect, test, vi } from 'vitest'
 const mockModule = vi.hoisted(() => ({
 	readAuthenticatedAppUser: vi.fn(),
 	getMcpServerSettingById: vi.fn(),
-	getMcpServerLogoObject: vi.fn(),
+	loadFittedMcpServerLogo: vi.fn(),
 }))
 
 vi.mock('#app/authenticated-user.ts', () => ({
@@ -17,8 +17,8 @@ vi.mock('#worker/mcp-client/settings-service.ts', () => ({
 }))
 
 vi.mock('#worker/mcp-client/mcp-server-logo.ts', () => ({
-	getMcpServerLogoObject: (...args: Array<unknown>) =>
-		mockModule.getMcpServerLogoObject(...args),
+	loadFittedMcpServerLogo: (...args: Array<unknown>) =>
+		mockModule.loadFittedMcpServerLogo(...args),
 }))
 
 const { createMcpServerLogoHandler } = await import('./mcp-server-logo.ts')
@@ -48,13 +48,17 @@ test('MCP server logo route is owner-scoped and private', async () => {
 	})
 	mockModule.getMcpServerSettingById.mockResolvedValueOnce({
 		id: 's1',
-		logoKey: 'user-mcp-server-logos/user-1/s1/abc.png',
-		logoContentType: 'image/png',
+		logoKey: 'user-mcp-server-logos/user-1/s1/abc.webp',
+		logoContentType: 'image/webp',
+		logoSource: 'favicon',
+		faviconSourceHost: 'example.com',
 	})
-	mockModule.getMcpServerLogoObject.mockResolvedValueOnce({
-		body: new Uint8Array([1, 2, 3]),
+	mockModule.loadFittedMcpServerLogo.mockResolvedValueOnce({
+		body: new Blob([Uint8Array.from([1, 2, 3])]).stream(),
 		size: 3,
 		httpEtag: '"abc"',
+		contentType: 'image/webp',
+		cacheControl: 'private, no-store',
 	})
 	const ok = await handler.handler({
 		request: new Request('https://example.com/account/mcp-servers/logos/s1'),
@@ -62,7 +66,7 @@ test('MCP server logo route is owner-scoped and private', async () => {
 	} as never)
 	expect(ok.status).toBe(200)
 	expect(ok.headers.get('Cache-Control')).toBe('private, no-store')
-	expect(ok.headers.get('Content-Type')).toBe('image/png')
+	expect(ok.headers.get('Content-Type')).toBe('image/webp')
 	expect(mockModule.getMcpServerSettingById).toHaveBeenLastCalledWith({
 		env: {},
 		userId: 'user-1',

--- a/packages/worker/src/app/handlers/mcp-server-logo.ts
+++ b/packages/worker/src/app/handlers/mcp-server-logo.ts
@@ -1,6 +1,6 @@
 import { type Action } from 'remix/router'
 import { readAuthenticatedAppUser } from '#app/authenticated-user.ts'
-import { getMcpServerLogoObject } from '#worker/mcp-client/mcp-server-logo.ts'
+import { loadFittedMcpServerLogo } from '#worker/mcp-client/mcp-server-logo.ts'
 import { getMcpServerSettingById } from '#worker/mcp-client/settings-service.ts'
 import { type routes } from '#universal/routes.ts'
 
@@ -25,19 +25,25 @@ export function createMcpServerLogoHandler(env: Env) {
 			if (!server?.logoKey) {
 				return new Response('Not found', { status: 404 })
 			}
-			const object = await getMcpServerLogoObject({
+			const logo = await loadFittedMcpServerLogo({
+				db: env.APP_DB,
 				env,
+				userId: user.mcpUser.userId,
+				serverId: server.id,
 				logoKey: server.logoKey,
+				logoContentType: server.logoContentType,
+				logoSource: server.logoSource,
+				faviconSourceHost: server.faviconSourceHost,
 			})
-			if (!object) {
+			if (!logo) {
 				return new Response('Not found', { status: 404 })
 			}
-			return new Response(object.body, {
+			return new Response(logo.body, {
 				headers: {
-					'Cache-Control': 'private, no-store',
-					'Content-Length': String(object.size),
-					'Content-Type': server.logoContentType ?? 'application/octet-stream',
-					ETag: object.httpEtag,
+					'Cache-Control': logo.cacheControl,
+					'Content-Length': String(logo.size),
+					'Content-Type': logo.contentType,
+					ETag: logo.httpEtag,
 					'X-Content-Type-Options': 'nosniff',
 				},
 			})

--- a/packages/worker/src/community/community-icon.node.test.ts
+++ b/packages/worker/src/community/community-icon.node.test.ts
@@ -12,6 +12,10 @@ import {
 	renderCommunityIconFallbackPng,
 } from './community-icon.ts'
 import { type CommunityListingRecord } from './types.ts'
+import {
+	createFakeImagesBinding,
+	tinyWebpBytes,
+} from '#worker/test-support/images-binding.ts'
 import { createInMemoryUserMeterEnv } from '#worker/test-support/user-meter.ts'
 
 const mocks = vi.hoisted(() => ({
@@ -165,6 +169,7 @@ function createCommunityIconTestEnv(input: {
 		APP_DB: input.db,
 		BUNDLE_ARTIFACTS_KV: input.kv,
 		COMMUNITY_ASSETS: input.bucket,
+		IMAGES: createFakeImagesBinding(),
 		USER_METER: meter.env.USER_METER,
 	} as Env
 }
@@ -248,46 +253,49 @@ const entitySourceRow = {
 	updated_at: '2026-07-10T00:00:00.000Z',
 }
 
-test('community raster icon formats are validated and preserved', async () => {
+test('community raster icon formats are validated then fitted to WebP', async () => {
 	const png = createPngHeader(256, 256)
 	const webp = createWebpHeader(320, 180)
 	const jpeg = createJpegHeader(640, 480)
 	const svg = new TextEncoder().encode(
 		'<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64"><circle cx="32" cy="32" r="30" fill="#2563eb"/></svg>',
 	)
+	const fitted = { bytes: tinyWebpBytes, contentType: 'image/webp' as const }
 
 	await expect(
 		processCommunityIcon({
 			path: 'community-icon.png',
 			sourceBytes: png,
+			images: createFakeImagesBinding(),
 		}),
-	).resolves.toEqual({ bytes: png, contentType: 'image/png' })
+	).resolves.toEqual(fitted)
 	await expect(
 		processCommunityIcon({
 			path: 'community-icon.webp',
 			sourceBytes: webp,
+			images: createFakeImagesBinding(),
 		}),
-	).resolves.toEqual({ bytes: webp, contentType: 'image/webp' })
+	).resolves.toEqual(fitted)
 	await expect(
 		processCommunityIcon({
 			path: 'community-icon.jpeg',
 			sourceBytes: jpeg,
+			images: createFakeImagesBinding(),
 		}),
-	).resolves.toEqual({ bytes: jpeg, contentType: 'image/jpeg' })
+	).resolves.toEqual(fitted)
 	await expect(
 		processCommunityIcon({
 			path: 'community-icon.png',
 			sourceBytes: createPngHeader(5000, 100),
+			images: createFakeImagesBinding(),
 		}),
 	).rejects.toThrow('at most 4096px')
 	const renderedSvg = await processCommunityIcon({
 		path: 'community-icon.svg',
 		sourceBytes: svg,
+		images: createFakeImagesBinding(),
 	})
-	expect(renderedSvg.contentType).toBe('image/png')
-	expect(Array.from(renderedSvg.bytes.slice(0, 4))).toEqual([
-		0x89, 0x50, 0x4e, 0x47,
-	])
+	expect(renderedSvg).toEqual(fitted)
 	const fallbackPng = await renderCommunityIconFallbackPng(
 		'@kentcdodds/github-tools',
 	)
@@ -298,6 +306,7 @@ test('community raster icon formats are validated and preserved', async () => {
 			sourceBytes: new TextEncoder().encode(
 				'<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>',
 			),
+			images: createFakeImagesBinding(),
 		}),
 	).rejects.toThrow('active external content')
 	expect(
@@ -316,6 +325,7 @@ test('community SVG icons load directly from the retained listing snapshot', asy
 		APP_DB: {} as D1Database,
 		BUNDLE_ARTIFACTS_KV: kv,
 		COMMUNITY_ASSETS: bucket,
+		IMAGES: createFakeImagesBinding(),
 	} as Env
 	mocks.readCommunitySnapshot.mockResolvedValue({
 		version: 1,
@@ -337,14 +347,10 @@ test('community SVG icons load directly from the retained listing snapshot', asy
 	})
 
 	expect(result.descriptor.sourcePath).toBe('community-icon.svg')
-	expect(result.descriptor.contentType).toBe('image/png')
+	expect(result.descriptor.contentType).toBe('image/webp')
 	expect(
-		Array.from(
-			new Uint8Array(
-				await new Response(result.object.body).arrayBuffer(),
-			).slice(0, 4),
-		),
-	).toEqual([0x89, 0x50, 0x4e, 0x47])
+		new Uint8Array(await new Response(result.object.body).arrayBuffer()),
+	).toEqual(tinyWebpBytes)
 	expect(mocks.getEntitySourceById).not.toHaveBeenCalled()
 	expect(mocks.readFirstArtifactFileAtCommit).not.toHaveBeenCalled()
 })
@@ -357,6 +363,7 @@ test('community icon descriptor caches the R2 reference and repairs a dangling r
 		APP_DB: {} as D1Database,
 		BUNDLE_ARTIFACTS_KV: kv,
 		COMMUNITY_ASSETS: bucket,
+		IMAGES: createFakeImagesBinding(),
 	} as Env
 	mocks.readCommunitySnapshot.mockResolvedValue({
 		version: 1,
@@ -383,7 +390,7 @@ test('community icon descriptor caches the R2 reference and repairs a dangling r
 		listing,
 		iconCommit: listing.pinnedCommit,
 	})
-	expect(first.descriptor.contentType).toBe('image/png')
+	expect(first.descriptor.contentType).toBe('image/webp')
 	expect(second.descriptor.r2Key).toBe(first.descriptor.r2Key)
 	expect(mocks.readFirstArtifactFileAtCommit).toHaveBeenCalledTimes(1)
 
@@ -451,6 +458,7 @@ test('community icons ahead of the pinned snapshot load from the artifact repo a
 		APP_DB: {} as D1Database,
 		BUNDLE_ARTIFACTS_KV: kv,
 		COMMUNITY_ASSETS: bucket,
+		IMAGES: createFakeImagesBinding(),
 	} as Env
 	mocks.readCommunitySnapshot.mockResolvedValue(null)
 	mocks.getEntitySourceById.mockResolvedValue({
@@ -491,22 +499,24 @@ test('community icons ahead of the pinned snapshot load from the artifact repo a
 test('deleteCommunityIconAssets removes superseded revisions and keeps servable commits', async () => {
 	const { kv, values: kvValues } = createFakeKv()
 	const { bucket, values: r2Values } = createFakeR2()
-	const kvKey = (commit: string) =>
-		`derived-cache:v1:community-icon:v1:${listing.id}:${commit}`
-	const r2Key = (commit: string) =>
-		`community-icon:v1/${listing.id}/${commit}/asset`
+	const kvKeyV1 = (listingId: string, commit: string) =>
+		`derived-cache:v1:community-icon:v1:${listingId}:${commit}`
+	const kvKeyV2 = (listingId: string, commit: string) =>
+		`derived-cache:v1:community-icon:v2:${listingId}:${commit}`
+	const r2KeyV1 = (listingId: string, commit: string) =>
+		`community-icon:v1/${listingId}/${commit}/asset`
+	const r2KeyV2 = (listingId: string, commit: string) =>
+		`community-icon:v2/${listingId}/${commit}/asset`
 	for (const commit of ['commit-1', 'commit-2', 'commit-3']) {
-		kvValues.set(kvKey(commit), '{}')
-		r2Values.set(r2Key(commit), Uint8Array.from([1]))
+		kvValues.set(kvKeyV1(listing.id, commit), '{}')
+		kvValues.set(kvKeyV2(listing.id, commit), '{}')
+		r2Values.set(r2KeyV1(listing.id, commit), Uint8Array.from([1]))
+		r2Values.set(r2KeyV2(listing.id, commit), Uint8Array.from([1]))
 	}
-	kvValues.set(
-		'derived-cache:v1:community-icon:v1:other-listing:commit-1',
-		'{}',
-	)
-	r2Values.set(
-		'community-icon:v1/other-listing/commit-1/asset',
-		Uint8Array.from([1]),
-	)
+	kvValues.set(kvKeyV1('other-listing', 'commit-1'), '{}')
+	kvValues.set(kvKeyV2('other-listing', 'commit-1'), '{}')
+	r2Values.set(r2KeyV1('other-listing', 'commit-1'), Uint8Array.from([1]))
+	r2Values.set(r2KeyV2('other-listing', 'commit-1'), Uint8Array.from([1]))
 
 	await deleteCommunityIconAssets({
 		env: { BUNDLE_ARTIFACTS_KV: kv, COMMUNITY_ASSETS: bucket },
@@ -516,14 +526,16 @@ test('deleteCommunityIconAssets removes superseded revisions and keeps servable 
 
 	expect(Array.from(kvValues.keys()).sort()).toEqual(
 		[
-			kvKey('commit-2'),
-			'derived-cache:v1:community-icon:v1:other-listing:commit-1',
+			kvKeyV2(listing.id, 'commit-2'),
+			kvKeyV1('other-listing', 'commit-1'),
+			kvKeyV2('other-listing', 'commit-1'),
 		].sort(),
 	)
 	expect(Array.from(r2Values.keys()).sort()).toEqual(
 		[
-			r2Key('commit-2'),
-			'community-icon:v1/other-listing/commit-1/asset',
+			r2KeyV2(listing.id, 'commit-2'),
+			r2KeyV1('other-listing', 'commit-1'),
+			r2KeyV2('other-listing', 'commit-1'),
 		].sort(),
 	)
 })
@@ -536,14 +548,21 @@ test('refreshCommunityIconForPackagePublish drops superseded icon caches for act
 		APP_DB: {} as D1Database,
 		BUNDLE_ARTIFACTS_KV: kv,
 		COMMUNITY_ASSETS: bucket,
+		IMAGES: createFakeImagesBinding(),
 	} as Env
-	const kvKey = (commit: string) =>
+	const kvKeyV1 = (commit: string) =>
 		`derived-cache:v1:community-icon:v1:${listing.id}:${commit}`
-	const r2Key = (commit: string) =>
+	const kvKeyV2 = (commit: string) =>
+		`derived-cache:v1:community-icon:v2:${listing.id}:${commit}`
+	const r2KeyV1 = (commit: string) =>
 		`community-icon:v1/${listing.id}/${commit}/asset`
+	const r2KeyV2 = (commit: string) =>
+		`community-icon:v2/${listing.id}/${commit}/asset`
 	for (const commit of [listing.pinnedCommit, 'old-publish', 'new-publish']) {
-		kvValues.set(kvKey(commit), '{}')
-		r2Values.set(r2Key(commit), Uint8Array.from([1]))
+		kvValues.set(kvKeyV1(commit), '{}')
+		kvValues.set(kvKeyV2(commit), '{}')
+		r2Values.set(r2KeyV1(commit), Uint8Array.from([1]))
+		r2Values.set(r2KeyV2(commit), Uint8Array.from([1]))
 	}
 
 	mocks.getCommunityListingByOwnerAndPackage.mockResolvedValue({
@@ -558,23 +577,23 @@ test('refreshCommunityIconForPackagePublish drops superseded icon caches for act
 	})
 
 	expect(Array.from(kvValues.keys()).sort()).toEqual(
-		[kvKey(listing.pinnedCommit), kvKey('new-publish')].sort(),
+		[kvKeyV2(listing.pinnedCommit), kvKeyV2('new-publish')].sort(),
 	)
 	expect(Array.from(r2Values.keys()).sort()).toEqual(
-		[r2Key(listing.pinnedCommit), r2Key('new-publish')].sort(),
+		[r2KeyV2(listing.pinnedCommit), r2KeyV2('new-publish')].sort(),
 	)
 	expect(getCommunityPublicCacheVersion()).toBe(1)
 
 	// Without an active listing the hook must be a no-op.
 	mocks.getCommunityListingByOwnerAndPackage.mockResolvedValue(null)
-	r2Values.set(r2Key('old-publish'), Uint8Array.from([1]))
+	r2Values.set(r2KeyV2('old-publish'), Uint8Array.from([1]))
 	await refreshCommunityIconForPackagePublish({
 		env,
 		userId: listing.ownerUserId,
 		packageId: listing.packageId,
 		publishedCommit: 'newest-publish',
 	})
-	expect(r2Values.has(r2Key('old-publish'))).toBe(true)
+	expect(r2Values.has(r2KeyV2('old-publish'))).toBe(true)
 	expect(getCommunityPublicCacheVersion()).toBe(1)
 	resetDataCacheForTests()
 })

--- a/packages/worker/src/community/community-icon.ts
+++ b/packages/worker/src/community/community-icon.ts
@@ -15,19 +15,28 @@ import { readFirstArtifactFileAtCommit } from '#worker/repo/artifact-file.ts'
 import { getEntitySourceById } from '#worker/repo/entity-sources.ts'
 import { type EntitySourceRow } from '#worker/repo/types.ts'
 import {
+	fitIconRaster,
+	iconFitCustomMetadata,
+	iconFitMaxDimension,
+	iconFitVersion,
+	publicFittedIconCacheControl,
+} from './icon-fit.ts'
+import {
 	getCommunityListingById,
 	getCommunityListingByOwnerAndPackage,
 } from './repo.ts'
 import { readCommunitySnapshot } from './snapshot.ts'
 import { type CommunityListingRecord } from './types.ts'
 
-const communityIconVersion = 1 as const
-const communityIconOutputSize = 256
+export const communityIconVersion = iconFitVersion
+const communityIconAssetVersions = [1, communityIconVersion] as const
+const communityIconOutputSize = iconFitMaxDimension
 const maxCommunityIconSourceBytes = 2 * 1024 * 1024
 const maxCommunityIconDimension = 4096
 const maxCommunityIconPixels = 16_777_216
 const maxCommunityIconRenderedBytes = 2 * 1024 * 1024
 const communityIconDescriptorTtlMs = 30 * 24 * 60 * 60 * 1000
+export const communityIconCacheControl = publicFittedIconCacheControl
 
 export const communityIconPaths = [
 	'community-icon.svg',
@@ -61,8 +70,11 @@ export function buildCommunityIconCacheKey(input: {
 	return `community-icon:v${communityIconVersion}:${input.listingId}:${input.commit}`
 }
 
-function buildCommunityIconKvListingPrefix(listingId: string) {
-	return `${derivedCacheKeyPrefix}community-icon:v${communityIconVersion}:${listingId}:`
+export function communityIconKvListingPrefixes(listingId: string) {
+	return communityIconAssetVersions.map(
+		(version) =>
+			`${derivedCacheKeyPrefix}community-icon:v${version}:${listingId}:`,
+	)
 }
 
 export function buildCommunityIconR2Key(input: {
@@ -72,8 +84,10 @@ export function buildCommunityIconR2Key(input: {
 	return `community-icon:v${communityIconVersion}/${input.listingId}/${input.commit}/asset`
 }
 
-function buildCommunityIconR2ListingPrefix(listingId: string) {
-	return `community-icon:v${communityIconVersion}/${listingId}/`
+export function communityIconR2ListingPrefixes(listingId: string) {
+	return communityIconAssetVersions.map(
+		(version) => `community-icon:v${version}/${listingId}/`,
+	)
 }
 
 export function findCommunityIconPath(
@@ -168,34 +182,46 @@ export async function deleteCommunityIconAssets(input: {
 			buildCommunityIconR2Key({ listingId: input.listingId, commit }),
 		),
 	)
-	let kvCursor: string | undefined
-	do {
-		const page = await input.env.BUNDLE_ARTIFACTS_KV.list({
-			prefix: buildCommunityIconKvListingPrefix(input.listingId),
-			cursor: kvCursor,
-		})
-		await Promise.all(
-			page.keys
-				.map((key) => key.name)
-				.filter((name) => !keptKvKeys.has(name))
-				.map((name) => input.env.BUNDLE_ARTIFACTS_KV.delete(name)),
-		)
-		kvCursor = page.list_complete ? undefined : page.cursor
-	} while (kvCursor)
-	let r2Cursor: string | undefined
-	do {
-		const page = await input.env.COMMUNITY_ASSETS.list({
-			prefix: buildCommunityIconR2ListingPrefix(input.listingId),
-			cursor: r2Cursor,
-		})
-		await Promise.all(
-			page.objects
-				.map((object) => object.key)
-				.filter((objectKey) => !keptR2Keys.has(objectKey))
-				.map((objectKey) => input.env.COMMUNITY_ASSETS.delete(objectKey)),
-		)
-		r2Cursor = page.truncated ? page.cursor : undefined
-	} while (r2Cursor)
+	for (const prefix of communityIconKvListingPrefixes(input.listingId)) {
+		let kvCursor: string | undefined
+		do {
+			const page = await input.env.BUNDLE_ARTIFACTS_KV.list({
+				prefix,
+				cursor: kvCursor,
+			})
+			const keepCurrentVersion = prefix.includes(
+				`community-icon:v${communityIconVersion}:`,
+			)
+			await Promise.all(
+				page.keys
+					.map((key) => key.name)
+					.filter((name) => !keepCurrentVersion || !keptKvKeys.has(name))
+					.map((name) => input.env.BUNDLE_ARTIFACTS_KV.delete(name)),
+			)
+			kvCursor = page.list_complete ? undefined : page.cursor
+		} while (kvCursor)
+	}
+	for (const prefix of communityIconR2ListingPrefixes(input.listingId)) {
+		let r2Cursor: string | undefined
+		do {
+			const page = await input.env.COMMUNITY_ASSETS.list({
+				prefix,
+				cursor: r2Cursor,
+			})
+			const keepCurrentVersion = prefix.includes(
+				`community-icon:v${communityIconVersion}/`,
+			)
+			await Promise.all(
+				page.objects
+					.map((object) => object.key)
+					.filter(
+						(objectKey) => !keepCurrentVersion || !keptR2Keys.has(objectKey),
+					)
+					.map((objectKey) => input.env.COMMUNITY_ASSETS.delete(objectKey)),
+			)
+			r2Cursor = page.truncated ? page.cursor : undefined
+		} while (r2Cursor)
+	}
 }
 
 /**
@@ -319,13 +345,14 @@ async function createCommunityIconDescriptor(input: {
 			? await processCommunityIcon({
 					path: iconSource.path,
 					sourceBytes: iconSource.bytes,
+					images: input.env.IMAGES,
 				})
-			: {
+			: await fitIconRaster({
+					images: input.env.IMAGES,
 					bytes: await renderCommunitySvgIcon(
 						buildCommunityIconFallbackSvg(input.listing.name),
 					),
-					contentType: 'image/png',
-				}
+				})
 
 		const r2Key = buildCommunityIconR2Key({
 			listingId: input.listing.id,
@@ -334,13 +361,13 @@ async function createCommunityIconDescriptor(input: {
 		await input.env.COMMUNITY_ASSETS.put(r2Key, processed.bytes, {
 			httpMetadata: {
 				contentType: processed.contentType,
-				cacheControl: 'public, max-age=3600',
+				cacheControl: communityIconCacheControl,
 			},
-			customMetadata: {
+			customMetadata: iconFitCustomMetadata({
 				listingId: input.listing.id,
 				iconCommit: input.iconCommit,
 				sourcePath: iconSource?.path ?? '',
-			},
+			}),
 		})
 		if (!(await isServableIconCommit(input))) {
 			await input.env.COMMUNITY_ASSETS.delete(r2Key)
@@ -403,24 +430,22 @@ async function isServableIconCommit(input: {
 export async function processCommunityIcon(input: {
 	path: (typeof communityIconPaths)[number]
 	sourceBytes: Uint8Array
+	images: ImagesBinding
 }): Promise<ProcessedCommunityIcon> {
 	assertCommunityIconSourceSize(input.sourceBytes)
 	if (input.path.endsWith('.svg')) {
 		const source = decodeSvg(input.sourceBytes)
 		assertSafeCommunitySvg(source)
 		const bytes = await renderCommunitySvgIcon(source)
-		return { bytes, contentType: 'image/png' }
+		return await fitIconRaster({ images: input.images, bytes })
 	}
 
 	const dimensions = readRasterDimensions(input.path, input.sourceBytes)
 	assertCommunityIconDimensions(dimensions)
-	if (input.path.endsWith('.png')) {
-		return { bytes: input.sourceBytes, contentType: 'image/png' }
-	}
-	if (input.path.endsWith('.webp')) {
-		return { bytes: input.sourceBytes, contentType: 'image/webp' }
-	}
-	return { bytes: input.sourceBytes, contentType: 'image/jpeg' }
+	return await fitIconRaster({
+		images: input.images,
+		bytes: input.sourceBytes,
+	})
 }
 
 function assertCommunityIconSourceSize(bytes: Uint8Array) {

--- a/packages/worker/src/community/community-icon.workers.test.ts
+++ b/packages/worker/src/community/community-icon.workers.test.ts
@@ -1,12 +1,17 @@
 import { env } from 'cloudflare:test'
 import { expect, test } from 'vitest'
+import { Resvg } from '@resvg/resvg-wasm'
 import {
 	buildCommunityIconCacheKey,
 	buildCommunityIconR2Key,
 	getCommunityIconObject,
+	processCommunityIcon,
 } from './community-icon.ts'
 import { type CommunityListingRecord } from './types.ts'
 import { derivedCacheKeyPrefix } from '#worker/kv-cachified.ts'
+import { iconFitMaxDimension, uint8ArrayToStream } from './icon-fit.ts'
+import { ensureResvgWasmReady } from '#worker/og/resvg-wasm-init.ts'
+import { tinyWebpBytes } from '#worker/test-support/images-binding.ts'
 
 test('community icon resolves a cachified descriptor to R2 bytes', async () => {
 	const listing = {
@@ -34,7 +39,7 @@ test('community icon resolves a cachified descriptor to R2 bytes', async () => {
 		updatedAt: '2026-07-10T00:00:00.000Z',
 		publishedAt: '2026-07-10T00:00:00.000Z',
 	} satisfies CommunityListingRecord
-	const bytes = Uint8Array.from([0x89, 0x50, 0x4e, 0x47])
+	const bytes = tinyWebpBytes
 	const r2Key = buildCommunityIconR2Key({
 		listingId: listing.id,
 		commit: listing.iconCommit,
@@ -46,7 +51,7 @@ test('community icon resolves a cachified descriptor to R2 bytes', async () => {
 			commit: listing.iconCommit,
 		})
 	await env.COMMUNITY_ASSETS.put(r2Key, bytes, {
-		httpMetadata: { contentType: 'image/png' },
+		httpMetadata: { contentType: 'image/webp' },
 	})
 	await env.BUNDLE_ARTIFACTS_KV.put(
 		cacheKey,
@@ -56,11 +61,11 @@ test('community icon resolves a cachified descriptor to R2 bytes', async () => {
 				ttl: 30 * 24 * 60 * 60 * 1000,
 			},
 			value: {
-				version: 1,
+				version: 2,
 				listingId: listing.id,
 				iconCommit: listing.iconCommit,
 				r2Key,
-				contentType: 'image/png',
+				contentType: 'image/webp',
 				sourcePath: 'community-icon.png',
 				byteLength: bytes.byteLength,
 			},
@@ -74,5 +79,41 @@ test('community icon resolves a cachified descriptor to R2 bytes', async () => {
 	})
 
 	expect(result.descriptor.r2Key).toBe(r2Key)
+	expect(result.descriptor.contentType).toBe('image/webp')
 	expect(new Uint8Array(await result.object.arrayBuffer())).toEqual(bytes)
+})
+
+test('community icon ingest fits an oversized PNG to 256px WebP via Images', async () => {
+	await ensureResvgWasmReady()
+	const svg =
+		'<svg xmlns="http://www.w3.org/2000/svg" width="1024" height="512"><rect width="1024" height="512" fill="#2563eb"/></svg>'
+	const resvg = new Resvg(svg, { fitTo: { mode: 'width', value: 1024 } })
+	const rendered = resvg.render()
+	let png: Uint8Array
+	try {
+		png = rendered.asPng()
+	} finally {
+		rendered.free()
+		resvg.free()
+	}
+	expect(png.byteLength).toBeGreaterThan(256)
+
+	const processed = await processCommunityIcon({
+		path: 'community-icon.png',
+		sourceBytes: png,
+		images: env.IMAGES,
+	})
+	expect(processed.contentType).toBe('image/webp')
+	expect(processed.bytes.byteLength).toBeGreaterThan(0)
+	expect(processed.bytes.byteLength).toBeLessThan(png.byteLength)
+
+	const info = await env.IMAGES.info(uint8ArrayToStream(processed.bytes))
+	if (info.format === 'image/svg+xml') {
+		throw new Error('Fitted icon info reported SVG instead of a raster.')
+	}
+	expect(info.format).toBe('image/webp')
+	expect(Math.max(info.width, info.height)).toBeLessThanOrEqual(
+		iconFitMaxDimension,
+	)
+	expect(Math.max(info.width, info.height)).toBeGreaterThan(1)
 })

--- a/packages/worker/src/community/icon-fit.node.test.ts
+++ b/packages/worker/src/community/icon-fit.node.test.ts
@@ -1,0 +1,60 @@
+import { expect, test } from 'vitest'
+import {
+	convertIconRasterToPng,
+	fitIconRaster,
+	iconFitCustomMetadata,
+	iconFitMaxDimension,
+	iconFitMetadataKey,
+	iconFitOutputContentType,
+	iconFitVersion,
+	logoNeedsIconFit,
+} from '#worker/community/icon-fit.ts'
+import {
+	createFakeImagesBinding,
+	tinyPngBytes,
+	tinyWebpBytes,
+} from '#worker/test-support/images-binding.ts'
+
+test('fitIconRaster asks Images to scale-down to 256px WebP and records fit metadata', async () => {
+	const images = createFakeImagesBinding()
+	const fitted = await fitIconRaster({
+		images,
+		bytes: tinyPngBytes,
+	})
+	expect(fitted.contentType).toBe(iconFitOutputContentType)
+	expect(fitted.bytes).toEqual(tinyWebpBytes)
+	expect(images.calls).toEqual([
+		{
+			inputBytes: tinyPngBytes,
+			transform: {
+				width: iconFitMaxDimension,
+				height: iconFitMaxDimension,
+				fit: 'scale-down',
+			},
+			output: {
+				format: 'image/webp',
+				quality: 90,
+				anim: false,
+			},
+		},
+	])
+	expect(logoNeedsIconFit(undefined)).toBe(true)
+	expect(logoNeedsIconFit({ [iconFitMetadataKey]: '1' })).toBe(true)
+	expect(logoNeedsIconFit(iconFitCustomMetadata({ slug: 'github' }))).toBe(
+		false,
+	)
+	expect(iconFitCustomMetadata({ slug: 'github' })).toEqual({
+		slug: 'github',
+		[iconFitMetadataKey]: String(iconFitVersion),
+	})
+
+	const png = await convertIconRasterToPng({
+		images,
+		bytes: tinyWebpBytes,
+	})
+	expect(png).toEqual(tinyPngBytes)
+	expect(images.calls[1]?.output).toEqual({
+		format: 'image/png',
+		anim: false,
+	})
+})

--- a/packages/worker/src/community/icon-fit.ts
+++ b/packages/worker/src/community/icon-fit.ts
@@ -1,0 +1,96 @@
+/**
+ * Shared ingest fit for package icons and integration / MCP logos.
+ *
+ * Source files may be up to 4096px / 2 MiB. The UI paints them at ~56–88 CSS
+ * pixels, so derived assets are scaled down to {@link iconFitMaxDimension} and
+ * re-encoded as WebP once, then stored in R2. Cloudflare Images runs the
+ * raster work off-isolate so a 16-megapixel upload cannot OOM the Worker.
+ */
+
+export const iconFitVersion = 2 as const
+export const iconFitMaxDimension = 256
+export const iconFitWebpQuality = 90
+export const iconFitMetadataKey = 'iconFitVersion'
+export const publicFittedIconCacheControl =
+	'public, max-age=31536000, immutable'
+export const iconFitOutputContentType = 'image/webp' as const
+
+const maxFittedIconBytes = 2 * 1024 * 1024
+
+export type FittedIconRaster = {
+	bytes: Uint8Array
+	contentType: typeof iconFitOutputContentType
+}
+
+export function iconFitCustomMetadata(
+	extra?: Record<string, string>,
+): Record<string, string> {
+	return {
+		...extra,
+		[iconFitMetadataKey]: String(iconFitVersion),
+	}
+}
+
+export function logoNeedsIconFit(
+	metadata: Record<string, string> | undefined,
+): boolean {
+	return metadata?.[iconFitMetadataKey] !== String(iconFitVersion)
+}
+
+export function uint8ArrayToStream(
+	bytes: Uint8Array,
+): ReadableStream<Uint8Array> {
+	const copy = new Uint8Array(bytes.byteLength)
+	copy.set(bytes)
+	return new Blob([copy]).stream()
+}
+
+export async function fitIconRaster(input: {
+	images: ImagesBinding
+	bytes: Uint8Array
+}): Promise<FittedIconRaster> {
+	const result = await input.images
+		.input(uint8ArrayToStream(input.bytes))
+		.transform({
+			width: iconFitMaxDimension,
+			height: iconFitMaxDimension,
+			fit: 'scale-down',
+		})
+		.output({
+			format: iconFitOutputContentType,
+			quality: iconFitWebpQuality,
+			anim: false,
+		})
+	const contentType = result.contentType()
+	if (contentType !== iconFitOutputContentType) {
+		throw new Error(
+			`Icon fit produced ${contentType} instead of ${iconFitOutputContentType}.`,
+		)
+	}
+	const bytes = new Uint8Array(await result.response().arrayBuffer())
+	if (bytes.byteLength === 0 || bytes.byteLength > maxFittedIconBytes) {
+		throw new Error(
+			`Fitted icons must be between 1 byte and ${maxFittedIconBytes} bytes.`,
+		)
+	}
+	return { bytes, contentType: iconFitOutputContentType }
+}
+
+export async function convertIconRasterToPng(input: {
+	images: ImagesBinding
+	bytes: Uint8Array
+}): Promise<Uint8Array> {
+	const result = await input.images
+		.input(uint8ArrayToStream(input.bytes))
+		.output({ format: 'image/png', anim: false })
+	if (result.contentType() !== 'image/png') {
+		throw new Error(
+			`Icon PNG conversion produced ${result.contentType()} instead of image/png.`,
+		)
+	}
+	const bytes = new Uint8Array(await result.response().arrayBuffer())
+	if (bytes.byteLength === 0) {
+		throw new Error('Icon PNG conversion produced an empty image.')
+	}
+	return bytes
+}

--- a/packages/worker/src/integrations/platform-app-logo.node.test.ts
+++ b/packages/worker/src/integrations/platform-app-logo.node.test.ts
@@ -226,3 +226,52 @@ test('serving an unfitted logo rewrites it to the current WebP ingest', async ()
 	expect(fitted.bytes).toEqual(tinyWebpBytes)
 	expect(fitted.customMetadata?.iconFitVersion).toBe('2')
 })
+
+test('lazy refit does not overwrite a newer logo key', async () => {
+	const harness = createHarness()
+	const app = await provisionApp(harness)
+	const previousKey = `platform-oauth-app-logos/${app.slug}/aaaaaaaaaaaaaaaa.png`
+	const newerKey = `platform-oauth-app-logos/${app.slug}/bbbbbbbbbbbbbbbb.webp`
+	await harness.env.COMMUNITY_ASSETS.put(previousKey, tinyPngBytes, {
+		httpMetadata: { contentType: 'image/png' },
+	})
+	await harness.env.COMMUNITY_ASSETS.put(newerKey, tinyWebpBytes, {
+		httpMetadata: { contentType: 'image/webp' },
+		customMetadata: { iconFitVersion: '2' },
+	})
+	await harness.db
+		.prepare(
+			`UPDATE platform_oauth_apps
+			SET logo_key = ?, logo_content_type = ?, updated_at = ?
+			WHERE slug = ?`,
+		)
+		.bind(previousKey, 'image/png', new Date().toISOString(), app.slug)
+		.run()
+	const stale = await getPlatformOauthAppBySlug({
+		db: harness.db,
+		slug: 'github',
+		includeDisabled: true,
+	})
+	await harness.db
+		.prepare(
+			`UPDATE platform_oauth_apps
+			SET logo_key = ?, logo_content_type = ?, updated_at = ?
+			WHERE slug = ?`,
+		)
+		.bind(newerKey, 'image/webp', new Date().toISOString(), app.slug)
+		.run()
+
+	const served = await loadFittedPlatformOauthAppLogo({
+		db: harness.db,
+		env: harness.env,
+		app: stale!,
+	})
+	expect(served?.contentType).toBe('image/webp')
+	const current = await getPlatformOauthAppBySlug({
+		db: harness.db,
+		slug: 'github',
+		includeDisabled: true,
+	})
+	expect(current?.logoKey).toBe(newerKey)
+	expect(harness.r2.objects.has(newerKey)).toBe(true)
+})

--- a/packages/worker/src/integrations/platform-app-logo.node.test.ts
+++ b/packages/worker/src/integrations/platform-app-logo.node.test.ts
@@ -3,27 +3,29 @@ import { expect, test } from 'vitest'
 import { applyAllMigrations as applyRepositoryMigrations } from '#worker/test-support/apply-all-migrations.ts'
 import { createD1FromSqlite } from '#worker/test-support/create-d1-from-sqlite.ts'
 import {
+	createFakeImagesBinding,
+	tinyPngBytes,
+	tinyWebpBytes,
+} from '#worker/test-support/images-binding.ts'
+import {
 	buildPlatformOauthAppLogoPath,
 	getPlatformOauthAppLogoObject,
+	loadFittedPlatformOauthAppLogo,
 	setPlatformOauthAppLogo,
 } from './platform-app-logo.ts'
-import { upsertPlatformOauthApp } from './platform-apps.ts'
+import {
+	getPlatformOauthAppBySlug,
+	upsertPlatformOauthApp,
+} from './platform-apps.ts'
 
 const migrationsDirectory = new URL('../../migrations/', import.meta.url)
 
-const tinyPngBytes = Uint8Array.from(
-	atob(
-		'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==',
-	),
-	(character) => character.charCodeAt(0),
-)
-
 type StoredObject = {
 	bytes: Uint8Array
-	httpMetadata?: { contentType?: string }
+	httpMetadata?: { contentType?: string; cacheControl?: string }
+	customMetadata?: Record<string, string>
 	httpEtag: string
 	size: number
-	body: Uint8Array
 }
 
 function createInMemoryR2() {
@@ -32,20 +34,35 @@ function createInMemoryR2() {
 		async put(
 			key: string,
 			bytes: Uint8Array,
-			options?: { httpMetadata?: { contentType?: string } },
+			options?: {
+				httpMetadata?: { contentType?: string; cacheControl?: string }
+				customMetadata?: Record<string, string>
+			},
 		) {
 			objects.set(key, {
 				bytes,
 				...(options?.httpMetadata
 					? { httpMetadata: options.httpMetadata }
 					: {}),
+				...(options?.customMetadata
+					? { customMetadata: options.customMetadata }
+					: {}),
 				httpEtag: `"etag-${objects.size}"`,
 				size: bytes.byteLength,
-				body: bytes,
 			})
 		},
 		async get(key: string) {
-			return objects.get(key) ?? null
+			const stored = objects.get(key)
+			if (!stored) return null
+			return {
+				...stored,
+				body: new Blob([stored.bytes]).stream(),
+				async arrayBuffer() {
+					const copy = new Uint8Array(stored.bytes.byteLength)
+					copy.set(stored.bytes)
+					return copy.buffer
+				},
+			}
 		},
 		async delete(key: string) {
 			objects.delete(key)
@@ -62,7 +79,8 @@ function createHarness() {
 	const env = {
 		SECRET_STORE_KEY: 'test-secret-store-key-32-chars-minimum',
 		COMMUNITY_ASSETS: r2.bucket,
-	} as Pick<Env, 'SECRET_STORE_KEY' | 'COMMUNITY_ASSETS'>
+		IMAGES: createFakeImagesBinding(),
+	} as Pick<Env, 'SECRET_STORE_KEY' | 'COMMUNITY_ASSETS' | 'IMAGES'>
 	return { sqlite, db, env, r2 }
 }
 
@@ -92,10 +110,13 @@ test('logo lifecycle uploads, clears, and survives app upserts without touching 
 		sourceBytes: tinyPngBytes,
 	})
 	expect(withLogo.logoKey).toMatch(
-		/^platform-oauth-app-logos\/github\/[0-9a-f]{16}\.png$/,
+		/^platform-oauth-app-logos\/github\/[0-9a-f]{16}\.webp$/,
 	)
-	expect(withLogo.logoContentType).toBe('image/png')
+	expect(withLogo.logoContentType).toBe('image/webp')
 	expect(harness.r2.objects.size).toBe(1)
+	const stored = harness.r2.objects.get(withLogo.logoKey!)
+	expect(stored?.bytes).toEqual(tinyWebpBytes)
+	expect(stored?.customMetadata?.iconFitVersion).toBe('2')
 	expect(buildPlatformOauthAppLogoPath(withLogo)).toMatch(
 		/^\/integrations\/logos\/github\?v=[0-9a-f]{16}$/,
 	)
@@ -139,7 +160,7 @@ test('logo lifecycle uploads, clears, and survives app upserts without touching 
 	expect(
 		buildPlatformOauthAppLogoPath({
 			slug: 'openai.com',
-			logoKey: 'platform-oauth-app-logos/openai.com/0123456789abcdef.png',
+			logoKey: 'platform-oauth-app-logos/openai.com/0123456789abcdef.webp',
 		}),
 	).toBe('/integrations/logos/openai%2Ecom?v=0123456789abcdef')
 })
@@ -165,4 +186,43 @@ test('uploads reject unknown formats and unknown apps', async () => {
 			sourceBytes: tinyPngBytes,
 		}),
 	).rejects.toThrow('was not found')
+})
+
+test('serving an unfitted logo rewrites it to the current WebP ingest', async () => {
+	const harness = createHarness()
+	const app = await provisionApp(harness)
+	const previousKey = `platform-oauth-app-logos/${app.slug}/aaaaaaaaaaaaaaaa.png`
+	await harness.env.COMMUNITY_ASSETS.put(previousKey, tinyPngBytes, {
+		httpMetadata: { contentType: 'image/png' },
+	})
+	await harness.db
+		.prepare(
+			`UPDATE platform_oauth_apps
+			SET logo_key = ?, logo_content_type = ?, updated_at = ?
+			WHERE slug = ?`,
+		)
+		.bind(previousKey, 'image/png', new Date().toISOString(), app.slug)
+		.run()
+	const stale = await getPlatformOauthAppBySlug({
+		db: harness.db,
+		slug: 'github',
+		includeDisabled: true,
+	})
+	expect(stale?.logoKey).toBe(previousKey)
+
+	const served = await loadFittedPlatformOauthAppLogo({
+		db: harness.db,
+		env: harness.env,
+		app: stale!,
+	})
+	expect(served?.contentType).toBe('image/webp')
+	expect(served?.cacheControl).toBe('public, max-age=31536000, immutable')
+	expect(harness.r2.objects.has(previousKey)).toBe(false)
+	expect(harness.r2.objects.size).toBe(1)
+	const [fittedKey, fitted] = [...harness.r2.objects.entries()][0]!
+	expect(fittedKey).toMatch(
+		/^platform-oauth-app-logos\/github\/[0-9a-f]{16}\.webp$/,
+	)
+	expect(fitted.bytes).toEqual(tinyWebpBytes)
+	expect(fitted.customMetadata?.iconFitVersion).toBe('2')
 })

--- a/packages/worker/src/integrations/platform-app-logo.node.test.ts
+++ b/packages/worker/src/integrations/platform-app-logo.node.test.ts
@@ -275,3 +275,53 @@ test('lazy refit does not overwrite a newer logo key', async () => {
 	expect(current?.logoKey).toBe(newerKey)
 	expect(harness.r2.objects.has(newerKey)).toBe(true)
 })
+
+test('lost same-hash refit race keeps the stored object', async () => {
+	const harness = createHarness()
+	const app = await provisionApp(harness)
+	const previousKey = `platform-oauth-app-logos/${app.slug}/aaaaaaaaaaaaaaaa.png`
+	await harness.env.COMMUNITY_ASSETS.put(previousKey, tinyPngBytes, {
+		httpMetadata: { contentType: 'image/png' },
+	})
+	await harness.db
+		.prepare(
+			`UPDATE platform_oauth_apps
+			SET logo_key = ?, logo_content_type = ?, updated_at = ?
+			WHERE slug = ?`,
+		)
+		.bind(previousKey, 'image/png', new Date().toISOString(), app.slug)
+		.run()
+	const stale = await getPlatformOauthAppBySlug({
+		db: harness.db,
+		slug: 'github',
+		includeDisabled: true,
+	})
+	await loadFittedPlatformOauthAppLogo({
+		db: harness.db,
+		env: harness.env,
+		app: stale!,
+	})
+	const winner = await getPlatformOauthAppBySlug({
+		db: harness.db,
+		slug: 'github',
+		includeDisabled: true,
+	})
+	expect(winner?.logoKey).toMatch(
+		/^platform-oauth-app-logos\/github\/[0-9a-f]{16}\.webp$/,
+	)
+
+	await setPlatformOauthAppLogo({
+		db: harness.db,
+		env: harness.env,
+		slug: 'github',
+		sourceBytes: tinyPngBytes,
+		replaceLogoKey: previousKey,
+	})
+	const current = await getPlatformOauthAppBySlug({
+		db: harness.db,
+		slug: 'github',
+		includeDisabled: true,
+	})
+	expect(current?.logoKey).toBe(winner?.logoKey)
+	expect(harness.r2.objects.has(winner!.logoKey!)).toBe(true)
+})

--- a/packages/worker/src/integrations/platform-app-logo.ts
+++ b/packages/worker/src/integrations/platform-app-logo.ts
@@ -216,17 +216,8 @@ export async function setPlatformOauthAppLogo(input: {
 				`Platform OAuth app "${app.slug}" disappeared during logo update.`,
 			)
 		}
-		if (nextKey && nextKey !== current.logoKey) {
-			try {
-				await input.env.COMMUNITY_ASSETS.delete(nextKey)
-			} catch (error) {
-				console.error(
-					'platform-oauth-app-logo-raced-refit-delete-failed',
-					nextKey,
-					error,
-				)
-			}
-		}
+		// Leave nextKey. A concurrent writer can store the same content hash
+		// after this lookup; deleting here can remove a live object.
 		return current
 	}
 

--- a/packages/worker/src/integrations/platform-app-logo.ts
+++ b/packages/worker/src/integrations/platform-app-logo.ts
@@ -147,6 +147,11 @@ export async function setPlatformOauthAppLogo(input: {
 	env: Pick<Env, 'COMMUNITY_ASSETS' | 'IMAGES'>
 	slug: string
 	sourceBytes: Uint8Array | null
+	/**
+	 * When set, the column update is compare-and-swap on `logo_key` so a
+	 * concurrent ingest cannot be overwritten by a stale lazy refit.
+	 */
+	replaceLogoKey?: string | null
 }): Promise<PlatformOauthApp> {
 	const app = await getPlatformOauthAppBySlug({
 		db: input.db,
@@ -180,14 +185,50 @@ export async function setPlatformOauthAppLogo(input: {
 		})
 	}
 
-	await input.db
+	const casLogoKey = input.replaceLogoKey !== undefined
+	const updated = await input.db
 		.prepare(
-			`UPDATE platform_oauth_apps
+			casLogoKey
+				? `UPDATE platform_oauth_apps
+			SET logo_key = ?, logo_content_type = ?, updated_at = ?
+			WHERE slug = ? AND logo_key IS ?`
+				: `UPDATE platform_oauth_apps
 			SET logo_key = ?, logo_content_type = ?, updated_at = ?
 			WHERE slug = ?`,
 		)
-		.bind(nextKey, nextContentType, new Date().toISOString(), app.slug)
+		.bind(
+			nextKey,
+			nextContentType,
+			new Date().toISOString(),
+			app.slug,
+			...(casLogoKey ? [input.replaceLogoKey] : []),
+		)
 		.run()
+
+	if ((updated.meta.changes ?? 0) === 0) {
+		if (nextKey) {
+			try {
+				await input.env.COMMUNITY_ASSETS.delete(nextKey)
+			} catch (error) {
+				console.error(
+					'platform-oauth-app-logo-raced-refit-delete-failed',
+					nextKey,
+					error,
+				)
+			}
+		}
+		const current = await getPlatformOauthAppBySlug({
+			db: input.db,
+			slug: app.slug,
+			includeDisabled: true,
+		})
+		if (!current) {
+			throw new Error(
+				`Platform OAuth app "${app.slug}" disappeared during logo update.`,
+			)
+		}
+		return current
+	}
 
 	if (previousKey && previousKey !== nextKey) {
 		try {
@@ -279,7 +320,7 @@ export async function loadFittedPlatformOauthAppLogo(input: {
 		env: input.env,
 		logoKey: input.app.logoKey,
 	})
-	if (!object) return null
+	if (!object) return await serveCurrentPlatformOauthAppLogo(input)
 	if (!logoNeedsIconFit(object.customMetadata)) {
 		return servedLogoFromObject(
 			object,
@@ -294,18 +335,20 @@ export async function loadFittedPlatformOauthAppLogo(input: {
 			env: input.env,
 			slug: input.app.slug,
 			sourceBytes,
+			replaceLogoKey: input.app.logoKey,
 		})
 		if (!updated.logoKey) return null
 		const fitted = await getPlatformOauthAppLogoObject({
 			env: input.env,
 			logoKey: updated.logoKey,
 		})
-		if (!fitted) return null
-		return servedLogoFromObject(
-			fitted,
-			updated.logoContentType,
-			platformOauthAppLogoCacheControl,
-		)
+		if (fitted) {
+			return servedLogoFromObject(
+				fitted,
+				updated.logoContentType,
+				platformOauthAppLogoCacheControl,
+			)
+		}
 	} catch (error) {
 		console.error('platform-oauth-app-logo-refit-failed', input.app.slug, error)
 		return servedFittedLogoFromBytes({
@@ -315,4 +358,28 @@ export async function loadFittedPlatformOauthAppLogo(input: {
 			cacheControl: platformOauthAppLogoCacheControl,
 		})
 	}
+	return await serveCurrentPlatformOauthAppLogo(input)
+}
+
+async function serveCurrentPlatformOauthAppLogo(input: {
+	db: D1Database
+	env: Pick<Env, 'COMMUNITY_ASSETS' | 'IMAGES'>
+	app: PlatformOauthApp
+}): Promise<ServedFittedLogo | null> {
+	const current = await getPlatformOauthAppBySlug({
+		db: input.db,
+		slug: input.app.slug,
+		includeDisabled: true,
+	})
+	if (!current?.logoKey || current.logoKey === input.app.logoKey) return null
+	const latest = await getPlatformOauthAppLogoObject({
+		env: input.env,
+		logoKey: current.logoKey,
+	})
+	if (!latest) return null
+	return servedLogoFromObject(
+		latest,
+		current.logoContentType,
+		platformOauthAppLogoCacheControl,
+	)
 }

--- a/packages/worker/src/integrations/platform-app-logo.ts
+++ b/packages/worker/src/integrations/platform-app-logo.ts
@@ -206,17 +206,6 @@ export async function setPlatformOauthAppLogo(input: {
 		.run()
 
 	if ((updated.meta.changes ?? 0) === 0) {
-		if (nextKey) {
-			try {
-				await input.env.COMMUNITY_ASSETS.delete(nextKey)
-			} catch (error) {
-				console.error(
-					'platform-oauth-app-logo-raced-refit-delete-failed',
-					nextKey,
-					error,
-				)
-			}
-		}
 		const current = await getPlatformOauthAppBySlug({
 			db: input.db,
 			slug: app.slug,
@@ -226,6 +215,17 @@ export async function setPlatformOauthAppLogo(input: {
 			throw new Error(
 				`Platform OAuth app "${app.slug}" disappeared during logo update.`,
 			)
+		}
+		if (nextKey && nextKey !== current.logoKey) {
+			try {
+				await input.env.COMMUNITY_ASSETS.delete(nextKey)
+			} catch (error) {
+				console.error(
+					'platform-oauth-app-logo-raced-refit-delete-failed',
+					nextKey,
+					error,
+				)
+			}
 		}
 		return current
 	}

--- a/packages/worker/src/integrations/platform-app-logo.ts
+++ b/packages/worker/src/integrations/platform-app-logo.ts
@@ -2,18 +2,32 @@ import { toHex } from '@kody-internal/shared/hex.ts'
 import { routes } from '#universal/routes.ts'
 import { processCommunityIcon } from '#worker/community/community-icon.ts'
 import {
+	iconFitCustomMetadata,
+	logoNeedsIconFit,
+	publicFittedIconCacheControl,
+	uint8ArrayToStream,
+} from '#worker/community/icon-fit.ts'
+import {
 	getPlatformOauthAppBySlug,
 	type PlatformOauthApp,
 } from './platform-apps.ts'
 
 const platformOauthAppLogoR2KeyPrefix = 'platform-oauth-app-logos/'
-const platformOauthAppLogoCacheControl = 'public, max-age=31536000, immutable'
+const platformOauthAppLogoCacheControl = publicFittedIconCacheControl
 const maxPlatformOauthAppLogoSourceBytes = 1_000_000
 
 export type PlatformOauthAppLogoContentType =
 	| 'image/png'
 	| 'image/jpeg'
 	| 'image/webp'
+
+export type ServedFittedLogo = {
+	body: ReadableStream
+	contentType: string
+	size: number
+	httpEtag: string
+	cacheControl: string
+}
 
 type ProcessedPlatformOauthAppLogo = {
 	bytes: Uint8Array
@@ -38,8 +52,8 @@ export function buildPlatformOauthAppLogoPath(app: {
 
 /**
  * Detects the upload format from magic bytes. SVG is accepted as *input*
- * only: it is sanitized and rasterized to PNG by `processCommunityIcon`, so
- * an active image format is never stored or served.
+ * only: it is sanitized, rasterized, and fitted to WebP by the shared icon
+ * pipeline, so an active image format is never stored or served.
  */
 export function sniffPlatformOauthAppLogoFormat(
 	bytes: Uint8Array,
@@ -67,6 +81,7 @@ export function sniffPlatformOauthAppLogoFormat(
 
 export async function processPlatformOauthAppLogo(
 	sourceBytes: Uint8Array,
+	images: ImagesBinding,
 ): Promise<ProcessedPlatformOauthAppLogo> {
 	if (
 		sourceBytes.byteLength === 0 ||
@@ -88,7 +103,11 @@ export async function processPlatformOauthAppLogo(
 			webp: 'community-icon.webp',
 		} as const
 	)[format]
-	const processed = await processCommunityIcon({ path, sourceBytes })
+	const processed = await processCommunityIcon({
+		path,
+		sourceBytes,
+		images,
+	})
 	return {
 		bytes: processed.bytes,
 		contentType: processed.contentType,
@@ -125,7 +144,7 @@ async function sha256Hex(bytes: Uint8Array) {
  */
 export async function setPlatformOauthAppLogo(input: {
 	db: D1Database
-	env: Pick<Env, 'COMMUNITY_ASSETS'>
+	env: Pick<Env, 'COMMUNITY_ASSETS' | 'IMAGES'>
 	slug: string
 	sourceBytes: Uint8Array | null
 }): Promise<PlatformOauthApp> {
@@ -142,7 +161,10 @@ export async function setPlatformOauthAppLogo(input: {
 	let nextKey: string | null = null
 	let nextContentType: PlatformOauthAppLogoContentType | null = null
 	if (input.sourceBytes) {
-		const processed = await processPlatformOauthAppLogo(input.sourceBytes)
+		const processed = await processPlatformOauthAppLogo(
+			input.sourceBytes,
+			input.env.IMAGES,
+		)
 		const contentHash = (await sha256Hex(processed.bytes)).slice(0, 16)
 		nextKey = `${platformOauthAppLogoR2KeyPrefix}${app.slug}/${contentHash}.${extensionForContentType(processed.contentType)}`
 		nextContentType = processed.contentType
@@ -151,10 +173,10 @@ export async function setPlatformOauthAppLogo(input: {
 				contentType: processed.contentType,
 				cacheControl: platformOauthAppLogoCacheControl,
 			},
-			customMetadata: {
+			customMetadata: iconFitCustomMetadata({
 				platformAppSlug: app.slug,
 				contentHash,
-			},
+			}),
 		})
 	}
 
@@ -212,4 +234,85 @@ export async function getPlatformOauthAppLogoObject(input: {
 }): Promise<R2ObjectBody | null> {
 	if (!input.logoKey.startsWith(platformOauthAppLogoR2KeyPrefix)) return null
 	return await input.env.COMMUNITY_ASSETS.get(input.logoKey)
+}
+
+export function servedLogoFromObject(
+	object: R2ObjectBody,
+	contentType: string | null | undefined,
+	cacheControl: string,
+): ServedFittedLogo {
+	return {
+		body: object.body,
+		contentType: contentType ?? 'application/octet-stream',
+		size: object.size,
+		httpEtag: object.httpEtag,
+		cacheControl,
+	}
+}
+
+export function servedFittedLogoFromBytes(input: {
+	bytes: Uint8Array
+	contentType: string | null | undefined
+	httpEtag: string
+	cacheControl: string
+}): ServedFittedLogo {
+	return {
+		body: uint8ArrayToStream(input.bytes),
+		contentType: input.contentType ?? 'application/octet-stream',
+		size: input.bytes.byteLength,
+		httpEtag: input.httpEtag,
+		cacheControl: input.cacheControl,
+	}
+}
+
+/**
+ * Serves the current platform logo, lazily re-fitting assets stored before
+ * the ingest pipeline started writing 256px WebP derivatives.
+ */
+export async function loadFittedPlatformOauthAppLogo(input: {
+	db: D1Database
+	env: Pick<Env, 'COMMUNITY_ASSETS' | 'IMAGES'>
+	app: PlatformOauthApp
+}): Promise<ServedFittedLogo | null> {
+	if (!input.app.logoKey) return null
+	const object = await getPlatformOauthAppLogoObject({
+		env: input.env,
+		logoKey: input.app.logoKey,
+	})
+	if (!object) return null
+	if (!logoNeedsIconFit(object.customMetadata)) {
+		return servedLogoFromObject(
+			object,
+			input.app.logoContentType,
+			platformOauthAppLogoCacheControl,
+		)
+	}
+	const sourceBytes = new Uint8Array(await object.arrayBuffer())
+	try {
+		const updated = await setPlatformOauthAppLogo({
+			db: input.db,
+			env: input.env,
+			slug: input.app.slug,
+			sourceBytes,
+		})
+		if (!updated.logoKey) return null
+		const fitted = await getPlatformOauthAppLogoObject({
+			env: input.env,
+			logoKey: updated.logoKey,
+		})
+		if (!fitted) return null
+		return servedLogoFromObject(
+			fitted,
+			updated.logoContentType,
+			platformOauthAppLogoCacheControl,
+		)
+	} catch (error) {
+		console.error('platform-oauth-app-logo-refit-failed', input.app.slug, error)
+		return servedFittedLogoFromBytes({
+			bytes: sourceBytes,
+			contentType: input.app.logoContentType,
+			httpEtag: object.httpEtag,
+			cacheControl: platformOauthAppLogoCacheControl,
+		})
+	}
 }

--- a/packages/worker/src/integrations/service.ts
+++ b/packages/worker/src/integrations/service.ts
@@ -52,7 +52,7 @@ import {
 export type { IntegrationConfig, PlatformOauthApp }
 
 type IntegrationWriteEnv = Pick<Env, 'APP_DB'> &
-	Partial<Pick<Env, 'COMMUNITY_ASSETS' | 'SECRET_STORE_KEY'>>
+	Partial<Pick<Env, 'COMMUNITY_ASSETS' | 'IMAGES' | 'SECRET_STORE_KEY'>>
 
 type LogoWriteInput = {
 	logoBase64?: string | null
@@ -969,10 +969,11 @@ async function applyUserOauthAppLogoWrite(input: {
 	logoBase64?: string | null
 	waitUntil?: (promise: Promise<unknown>) => void
 }) {
-	if (!input.env.COMMUNITY_ASSETS) return
+	if (!input.env.COMMUNITY_ASSETS || !input.env.IMAGES) return
 	const env = {
 		APP_DB: input.env.APP_DB,
 		COMMUNITY_ASSETS: input.env.COMMUNITY_ASSETS,
+		IMAGES: input.env.IMAGES,
 	}
 	if (input.logoBase64 !== undefined) {
 		await setUserOauthAppLogo({

--- a/packages/worker/src/integrations/user-oauth-app-favicon.ts
+++ b/packages/worker/src/integrations/user-oauth-app-favicon.ts
@@ -282,7 +282,7 @@ export function shouldFetchUserOauthAppFavicon(app: UserOauthApp): boolean {
 
 export async function fillUserOauthAppFavicon(input: {
 	db: D1Database
-	env: Pick<Env, 'COMMUNITY_ASSETS'>
+	env: Pick<Env, 'COMMUNITY_ASSETS' | 'IMAGES'>
 	userId: string
 	slug: string
 	fetchImpl?: typeof fetch
@@ -326,15 +326,20 @@ export async function fillUserOauthAppFavicon(input: {
 
 export async function scheduleUserOauthAppFaviconFill(input: {
 	db: D1Database
-	env: Pick<Env, 'APP_DB' | 'COMMUNITY_ASSETS'> | Pick<Env, 'APP_DB'>
+	env: Pick<Env, 'APP_DB' | 'COMMUNITY_ASSETS' | 'IMAGES'> | Pick<Env, 'APP_DB'>
 	userId: string
 	slug: string
 	waitUntil?: (promise: Promise<unknown>) => void
 }) {
-	if (!('COMMUNITY_ASSETS' in input.env) || !input.env.COMMUNITY_ASSETS) {
+	if (
+		!('COMMUNITY_ASSETS' in input.env) ||
+		!input.env.COMMUNITY_ASSETS ||
+		!('IMAGES' in input.env) ||
+		!input.env.IMAGES
+	) {
 		return
 	}
-	const env = input.env as Pick<Env, 'APP_DB' | 'COMMUNITY_ASSETS'>
+	const env = input.env as Pick<Env, 'APP_DB' | 'COMMUNITY_ASSETS' | 'IMAGES'>
 	const work = fillUserOauthAppFavicon({
 		db: input.db,
 		env,
@@ -356,19 +361,24 @@ export async function scheduleUserOauthAppFaviconFill(input: {
 
 export async function backfillMissingUserOauthAppFavicons(input: {
 	db: D1Database
-	env: Pick<Env, 'APP_DB' | 'COMMUNITY_ASSETS'> | Pick<Env, 'APP_DB'>
+	env: Pick<Env, 'APP_DB' | 'COMMUNITY_ASSETS' | 'IMAGES'> | Pick<Env, 'APP_DB'>
 	userId: string
 	apps: Array<UserOauthApp>
 	waitUntil?: (promise: Promise<unknown>) => void
 }) {
-	if (!('COMMUNITY_ASSETS' in input.env) || !input.env.COMMUNITY_ASSETS) {
+	if (
+		!('COMMUNITY_ASSETS' in input.env) ||
+		!input.env.COMMUNITY_ASSETS ||
+		!('IMAGES' in input.env) ||
+		!input.env.IMAGES
+	) {
 		return
 	}
 	const pending = input.apps
 		.filter((app) => shouldFetchUserOauthAppFavicon(app))
 		.slice(0, maxBackfillPerPage)
 	if (pending.length === 0) return
-	const env = input.env as Pick<Env, 'APP_DB' | 'COMMUNITY_ASSETS'>
+	const env = input.env as Pick<Env, 'APP_DB' | 'COMMUNITY_ASSETS' | 'IMAGES'>
 	const work = (async () => {
 		for (const app of pending) {
 			await fillUserOauthAppFavicon({

--- a/packages/worker/src/integrations/user-oauth-app-logo.node.test.ts
+++ b/packages/worker/src/integrations/user-oauth-app-logo.node.test.ts
@@ -10,7 +10,10 @@ import {
 import { getOauthAppBySlug } from './repo.ts'
 import { upsertOauthAppWithoutConnection } from './service.ts'
 import { shouldFetchUserOauthAppFavicon } from './user-oauth-app-favicon.ts'
-import { loadFittedUserOauthAppLogo } from './user-oauth-app-logo.ts'
+import {
+	loadFittedUserOauthAppLogo,
+	setUserOauthAppLogo,
+} from './user-oauth-app-logo.ts'
 
 const migrationsDirectory = new URL('../../migrations/', import.meta.url)
 
@@ -212,4 +215,65 @@ test('lazy refit does not overwrite a newer user logo key', async () => {
 	})
 	expect(current?.logoKey).toBe(newerKey)
 	expect(harness.r2.objects.has(newerKey)).toBe(true)
+})
+
+test('lost same-hash refit race keeps the stored user logo', async () => {
+	const harness = createHarness()
+	const app = await provisionApp(harness)
+	const previousKey = `user-oauth-app-logos/${app.userId}/${app.slug}/aaaaaaaaaaaaaaaa.png`
+	await harness.env.COMMUNITY_ASSETS.put(previousKey, tinyPngBytes, {
+		httpMetadata: { contentType: 'image/png' },
+	})
+	await harness.db
+		.prepare(
+			`UPDATE user_oauth_apps
+			SET logo_key = ?, logo_content_type = ?, logo_source = ?,
+				favicon_source_host = ?, updated_at = ?
+			WHERE user_id = ? AND slug = ?`,
+		)
+		.bind(
+			previousKey,
+			'image/png',
+			'favicon',
+			'dropbox.com',
+			new Date().toISOString(),
+			app.userId,
+			app.slug,
+		)
+		.run()
+	const stale = await getOauthAppBySlug({
+		db: harness.db,
+		userId: app.userId,
+		slug: app.slug,
+	})
+	await loadFittedUserOauthAppLogo({
+		db: harness.db,
+		env: harness.env,
+		userId: app.userId,
+		app: stale!,
+	})
+	const winner = await getOauthAppBySlug({
+		db: harness.db,
+		userId: app.userId,
+		slug: app.slug,
+	})
+	expect(winner?.logoKey).toMatch(/\.webp$/)
+
+	await setUserOauthAppLogo({
+		db: harness.db,
+		env: harness.env,
+		userId: app.userId,
+		slug: app.slug,
+		sourceBytes: tinyPngBytes,
+		source: 'favicon',
+		faviconSourceHost: 'dropbox.com',
+		replaceLogoKey: previousKey,
+	})
+	const current = await getOauthAppBySlug({
+		db: harness.db,
+		userId: app.userId,
+		slug: app.slug,
+	})
+	expect(current?.logoKey).toBe(winner?.logoKey)
+	expect(harness.r2.objects.has(winner!.logoKey!)).toBe(true)
 })

--- a/packages/worker/src/integrations/user-oauth-app-logo.node.test.ts
+++ b/packages/worker/src/integrations/user-oauth-app-logo.node.test.ts
@@ -1,0 +1,215 @@
+import { DatabaseSync } from 'node:sqlite'
+import { expect, test } from 'vitest'
+import { applyAllMigrations as applyRepositoryMigrations } from '#worker/test-support/apply-all-migrations.ts'
+import { createD1FromSqlite } from '#worker/test-support/create-d1-from-sqlite.ts'
+import {
+	createFakeImagesBinding,
+	tinyPngBytes,
+	tinyWebpBytes,
+} from '#worker/test-support/images-binding.ts'
+import { getOauthAppBySlug } from './repo.ts'
+import { upsertOauthAppWithoutConnection } from './service.ts'
+import { shouldFetchUserOauthAppFavicon } from './user-oauth-app-favicon.ts'
+import { loadFittedUserOauthAppLogo } from './user-oauth-app-logo.ts'
+
+const migrationsDirectory = new URL('../../migrations/', import.meta.url)
+
+type StoredObject = {
+	bytes: Uint8Array
+	httpMetadata?: { contentType?: string; cacheControl?: string }
+	customMetadata?: Record<string, string>
+	httpEtag: string
+	size: number
+}
+
+function createInMemoryR2() {
+	const objects = new Map<string, StoredObject>()
+	const bucket = {
+		async put(
+			key: string,
+			bytes: Uint8Array,
+			options?: {
+				httpMetadata?: { contentType?: string; cacheControl?: string }
+				customMetadata?: Record<string, string>
+			},
+		) {
+			objects.set(key, {
+				bytes,
+				...(options?.httpMetadata
+					? { httpMetadata: options.httpMetadata }
+					: {}),
+				...(options?.customMetadata
+					? { customMetadata: options.customMetadata }
+					: {}),
+				httpEtag: `"etag-${objects.size}"`,
+				size: bytes.byteLength,
+			})
+		},
+		async get(key: string) {
+			const stored = objects.get(key)
+			if (!stored) return null
+			return {
+				...stored,
+				body: new Blob([stored.bytes]).stream(),
+				async arrayBuffer() {
+					const copy = new Uint8Array(stored.bytes.byteLength)
+					copy.set(stored.bytes)
+					return copy.buffer
+				},
+			}
+		},
+		async delete(key: string) {
+			objects.delete(key)
+		},
+	} as unknown as R2Bucket
+	return { bucket, objects }
+}
+
+function createHarness() {
+	const sqlite = new DatabaseSync(':memory:')
+	applyRepositoryMigrations(sqlite, migrationsDirectory)
+	const db = createD1FromSqlite(sqlite)
+	const r2 = createInMemoryR2()
+	const env = {
+		APP_DB: db,
+		SECRET_STORE_KEY: 'test-secret-store-key-32-chars-minimum',
+		COMMUNITY_ASSETS: r2.bucket,
+		IMAGES: createFakeImagesBinding(),
+	} as Pick<Env, 'APP_DB' | 'SECRET_STORE_KEY' | 'COMMUNITY_ASSETS' | 'IMAGES'>
+	return { sqlite, db, env, r2 }
+}
+
+async function provisionApp(harness: ReturnType<typeof createHarness>) {
+	return upsertOauthAppWithoutConnection({
+		env: harness.env,
+		userId: 'user-1',
+		config: {
+			name: 'dropbox',
+			tokenUrl: 'https://api.dropboxapi.com/oauth2/token',
+			apiBaseUrl: 'https://api.dropboxapi.com/2',
+			flow: 'pkce',
+			clientId: 'dropbox-client',
+			authorization: {
+				authorizeUrl: 'https://www.dropbox.com/oauth2/authorize',
+				scopes: [],
+			},
+		},
+	})
+}
+
+test('lazy refit of a favicon logo keeps faviconSourceHost', async () => {
+	const harness = createHarness()
+	const app = await provisionApp(harness)
+	const previousKey = `user-oauth-app-logos/${app.userId}/${app.slug}/aaaaaaaaaaaaaaaa.png`
+	await harness.env.COMMUNITY_ASSETS.put(previousKey, tinyPngBytes, {
+		httpMetadata: { contentType: 'image/png' },
+	})
+	await harness.db
+		.prepare(
+			`UPDATE user_oauth_apps
+			SET logo_key = ?, logo_content_type = ?, logo_source = ?,
+				favicon_source_host = ?, updated_at = ?
+			WHERE user_id = ? AND slug = ?`,
+		)
+		.bind(
+			previousKey,
+			'image/png',
+			'favicon',
+			'dropbox.com',
+			new Date().toISOString(),
+			app.userId,
+			app.slug,
+		)
+		.run()
+	const stale = await getOauthAppBySlug({
+		db: harness.db,
+		userId: app.userId,
+		slug: app.slug,
+	})
+	expect(stale?.faviconSourceHost).toBe('dropbox.com')
+
+	const served = await loadFittedUserOauthAppLogo({
+		db: harness.db,
+		env: harness.env,
+		userId: app.userId,
+		app: stale!,
+	})
+	expect(served?.contentType).toBe('image/webp')
+	const current = await getOauthAppBySlug({
+		db: harness.db,
+		userId: app.userId,
+		slug: app.slug,
+	})
+	expect(current?.logoSource).toBe('favicon')
+	expect(current?.faviconSourceHost).toBe('dropbox.com')
+	expect(current?.logoContentType).toBe('image/webp')
+	expect(shouldFetchUserOauthAppFavicon(current!)).toBe(false)
+})
+
+test('lazy refit does not overwrite a newer user logo key', async () => {
+	const harness = createHarness()
+	const app = await provisionApp(harness)
+	const previousKey = `user-oauth-app-logos/${app.userId}/${app.slug}/aaaaaaaaaaaaaaaa.png`
+	const newerKey = `user-oauth-app-logos/${app.userId}/${app.slug}/bbbbbbbbbbbbbbbb.webp`
+	await harness.env.COMMUNITY_ASSETS.put(previousKey, tinyPngBytes, {
+		httpMetadata: { contentType: 'image/png' },
+	})
+	await harness.env.COMMUNITY_ASSETS.put(newerKey, tinyWebpBytes, {
+		httpMetadata: { contentType: 'image/webp' },
+		customMetadata: { iconFitVersion: '2' },
+	})
+	await harness.db
+		.prepare(
+			`UPDATE user_oauth_apps
+			SET logo_key = ?, logo_content_type = ?, logo_source = ?,
+				favicon_source_host = ?, updated_at = ?
+			WHERE user_id = ? AND slug = ?`,
+		)
+		.bind(
+			previousKey,
+			'image/png',
+			'upload',
+			null,
+			new Date().toISOString(),
+			app.userId,
+			app.slug,
+		)
+		.run()
+	const stale = await getOauthAppBySlug({
+		db: harness.db,
+		userId: app.userId,
+		slug: app.slug,
+	})
+	await harness.db
+		.prepare(
+			`UPDATE user_oauth_apps
+			SET logo_key = ?, logo_content_type = ?, logo_source = ?,
+				favicon_source_host = ?, updated_at = ?
+			WHERE user_id = ? AND slug = ?`,
+		)
+		.bind(
+			newerKey,
+			'image/webp',
+			'upload',
+			null,
+			new Date().toISOString(),
+			app.userId,
+			app.slug,
+		)
+		.run()
+
+	const served = await loadFittedUserOauthAppLogo({
+		db: harness.db,
+		env: harness.env,
+		userId: app.userId,
+		app: stale!,
+	})
+	expect(served?.contentType).toBe('image/webp')
+	const current = await getOauthAppBySlug({
+		db: harness.db,
+		userId: app.userId,
+		slug: app.slug,
+	})
+	expect(current?.logoKey).toBe(newerKey)
+	expect(harness.r2.objects.has(newerKey)).toBe(true)
+})

--- a/packages/worker/src/integrations/user-oauth-app-logo.ts
+++ b/packages/worker/src/integrations/user-oauth-app-logo.ts
@@ -166,7 +166,13 @@ export async function setUserOauthAppLogo(input: {
 		.run()
 
 	if ((updated.meta.changes ?? 0) === 0) {
-		if (nextKey) {
+		const current =
+			(await getOauthAppBySlug({
+				db: input.db,
+				userId: input.userId,
+				slug: app.slug,
+			})) ?? app
+		if (nextKey && nextKey !== current.logoKey) {
 			try {
 				await input.env.COMMUNITY_ASSETS.delete(nextKey)
 			} catch (error) {
@@ -177,13 +183,7 @@ export async function setUserOauthAppLogo(input: {
 				)
 			}
 		}
-		return (
-			(await getOauthAppBySlug({
-				db: input.db,
-				userId: input.userId,
-				slug: app.slug,
-			})) ?? app
-		)
+		return current
 	}
 
 	if (previousKey && previousKey !== nextKey) {

--- a/packages/worker/src/integrations/user-oauth-app-logo.ts
+++ b/packages/worker/src/integrations/user-oauth-app-logo.ts
@@ -166,24 +166,15 @@ export async function setUserOauthAppLogo(input: {
 		.run()
 
 	if ((updated.meta.changes ?? 0) === 0) {
-		const current =
+		// Leave nextKey. A concurrent writer can store the same content hash
+		// after this lookup; deleting here can remove a live object.
+		return (
 			(await getOauthAppBySlug({
 				db: input.db,
 				userId: input.userId,
 				slug: app.slug,
 			})) ?? app
-		if (nextKey && nextKey !== current.logoKey) {
-			try {
-				await input.env.COMMUNITY_ASSETS.delete(nextKey)
-			} catch (error) {
-				console.error(
-					'user-oauth-app-logo-raced-favicon-delete-failed',
-					nextKey,
-					error,
-				)
-			}
-		}
-		return current
+		)
 	}
 
 	if (previousKey && previousKey !== nextKey) {

--- a/packages/worker/src/integrations/user-oauth-app-logo.ts
+++ b/packages/worker/src/integrations/user-oauth-app-logo.ts
@@ -84,6 +84,11 @@ export async function setUserOauthAppLogo(input: {
 	sourceBytes: Uint8Array | null
 	source: UserOauthAppLogoSource
 	faviconSourceHost?: string | null
+	/**
+	 * When set, the column update is compare-and-swap on `logo_key` so a
+	 * concurrent ingest cannot be overwritten by a stale lazy refit.
+	 */
+	replaceLogoKey?: string | null
 }): Promise<UserOauthApp> {
 	const app = await getOauthAppBySlug({
 		db: input.db,
@@ -133,19 +138,21 @@ export async function setUserOauthAppLogo(input: {
 		})
 	}
 
-	const updated = await input.db
-		.prepare(
-			input.source === 'favicon'
-				? `UPDATE user_oauth_apps
+	const casLogoKey = input.replaceLogoKey !== undefined
+	let updateSql = `UPDATE user_oauth_apps
 			SET logo_key = ?, logo_content_type = ?, logo_source = ?,
 				favicon_source_host = ?, updated_at = ?
-			WHERE user_id = ? AND slug = ?
+			WHERE user_id = ? AND slug = ?`
+	if (input.source === 'favicon') {
+		updateSql += `
 				AND (logo_source IS NULL OR logo_source <> 'upload')`
-				: `UPDATE user_oauth_apps
-			SET logo_key = ?, logo_content_type = ?, logo_source = ?,
-				favicon_source_host = ?, updated_at = ?
-			WHERE user_id = ? AND slug = ?`,
-		)
+	}
+	if (casLogoKey) {
+		updateSql += `
+				AND logo_key IS ?`
+	}
+	const updated = await input.db
+		.prepare(updateSql)
 		.bind(
 			nextKey,
 			nextContentType,
@@ -154,10 +161,11 @@ export async function setUserOauthAppLogo(input: {
 			new Date().toISOString(),
 			input.userId,
 			app.slug,
+			...(casLogoKey ? [input.replaceLogoKey] : []),
 		)
 		.run()
 
-	if (input.source === 'favicon' && (updated.meta.changes ?? 0) === 0) {
+	if ((updated.meta.changes ?? 0) === 0) {
 		if (nextKey) {
 			try {
 				await input.env.COMMUNITY_ASSETS.delete(nextKey)
@@ -233,7 +241,7 @@ export async function loadFittedUserOauthAppLogo(input: {
 		env: input.env,
 		logoKey: input.app.logoKey,
 	})
-	if (!object) return null
+	if (!object) return await serveCurrentUserOauthAppLogo(input)
 	if (!logoNeedsIconFit(object.customMetadata)) {
 		return servedLogoFromObject(
 			object,
@@ -250,18 +258,21 @@ export async function loadFittedUserOauthAppLogo(input: {
 			slug: input.app.slug,
 			sourceBytes,
 			source: input.app.logoSource ?? 'upload',
+			faviconSourceHost: input.app.faviconSourceHost,
+			replaceLogoKey: input.app.logoKey,
 		})
 		if (!updated.logoKey) return null
 		const fitted = await getUserOauthAppLogoObject({
 			env: input.env,
 			logoKey: updated.logoKey,
 		})
-		if (!fitted) return null
-		return servedLogoFromObject(
-			fitted,
-			updated.logoContentType,
-			userOauthAppLogoCacheControl,
-		)
+		if (fitted) {
+			return servedLogoFromObject(
+				fitted,
+				updated.logoContentType,
+				userOauthAppLogoCacheControl,
+			)
+		}
 	} catch (error) {
 		console.error('user-oauth-app-logo-refit-failed', input.app.slug, error)
 		return servedFittedLogoFromBytes({
@@ -271,4 +282,29 @@ export async function loadFittedUserOauthAppLogo(input: {
 			cacheControl: userOauthAppLogoCacheControl,
 		})
 	}
+	return await serveCurrentUserOauthAppLogo(input)
+}
+
+async function serveCurrentUserOauthAppLogo(input: {
+	db: D1Database
+	env: Pick<Env, 'COMMUNITY_ASSETS' | 'IMAGES'>
+	userId: string
+	app: UserOauthApp
+}): Promise<ServedFittedLogo | null> {
+	const current = await getOauthAppBySlug({
+		db: input.db,
+		userId: input.userId,
+		slug: input.app.slug,
+	})
+	if (!current?.logoKey || current.logoKey === input.app.logoKey) return null
+	const latest = await getUserOauthAppLogoObject({
+		env: input.env,
+		logoKey: current.logoKey,
+	})
+	if (!latest) return null
+	return servedLogoFromObject(
+		latest,
+		current.logoContentType,
+		userOauthAppLogoCacheControl,
+	)
 }

--- a/packages/worker/src/integrations/user-oauth-app-logo.ts
+++ b/packages/worker/src/integrations/user-oauth-app-logo.ts
@@ -1,9 +1,16 @@
 import { toHex } from '@kody-internal/shared/hex.ts'
 import { routes } from '#universal/routes.ts'
+import {
+	iconFitCustomMetadata,
+	logoNeedsIconFit,
+} from '#worker/community/icon-fit.ts'
 import { getOauthAppBySlug } from './repo.ts'
 import {
 	processPlatformOauthAppLogo,
+	servedFittedLogoFromBytes,
+	servedLogoFromObject,
 	type PlatformOauthAppLogoContentType,
+	type ServedFittedLogo,
 } from './platform-app-logo.ts'
 import { type UserOauthApp } from './types.ts'
 
@@ -71,7 +78,7 @@ async function sha256Hex(bytes: Uint8Array) {
 
 export async function setUserOauthAppLogo(input: {
 	db: D1Database
-	env: Pick<Env, 'COMMUNITY_ASSETS'>
+	env: Pick<Env, 'COMMUNITY_ASSETS' | 'IMAGES'>
 	userId: string
 	slug: string
 	sourceBytes: Uint8Array | null
@@ -102,7 +109,10 @@ export async function setUserOauthAppLogo(input: {
 	let nextSource: UserOauthAppLogoSource | null = null
 	let nextFaviconHost: string | null = null
 	if (input.sourceBytes) {
-		const processed = await processPlatformOauthAppLogo(input.sourceBytes)
+		const processed = await processPlatformOauthAppLogo(
+			input.sourceBytes,
+			input.env.IMAGES,
+		)
 		const contentHash = (await sha256Hex(processed.bytes)).slice(0, 16)
 		nextKey = `${userOauthAppLogoR2KeyPrefix}${input.userId}/${app.slug}/${contentHash}.${extensionForContentType(processed.contentType)}`
 		nextContentType = processed.contentType
@@ -114,12 +124,12 @@ export async function setUserOauthAppLogo(input: {
 				contentType: processed.contentType,
 				cacheControl: userOauthAppLogoCacheControl,
 			},
-			customMetadata: {
+			customMetadata: iconFitCustomMetadata({
 				userId: input.userId,
 				userAppSlug: app.slug,
 				logoSource: input.source,
 				contentHash,
-			},
+			}),
 		})
 	}
 
@@ -210,4 +220,55 @@ export async function getUserOauthAppLogoObject(input: {
 }): Promise<R2ObjectBody | null> {
 	if (!input.logoKey.startsWith(userOauthAppLogoR2KeyPrefix)) return null
 	return await input.env.COMMUNITY_ASSETS.get(input.logoKey)
+}
+
+export async function loadFittedUserOauthAppLogo(input: {
+	db: D1Database
+	env: Pick<Env, 'COMMUNITY_ASSETS' | 'IMAGES'>
+	userId: string
+	app: UserOauthApp
+}): Promise<ServedFittedLogo | null> {
+	if (!input.app.logoKey) return null
+	const object = await getUserOauthAppLogoObject({
+		env: input.env,
+		logoKey: input.app.logoKey,
+	})
+	if (!object) return null
+	if (!logoNeedsIconFit(object.customMetadata)) {
+		return servedLogoFromObject(
+			object,
+			input.app.logoContentType,
+			userOauthAppLogoCacheControl,
+		)
+	}
+	const sourceBytes = new Uint8Array(await object.arrayBuffer())
+	try {
+		const updated = await setUserOauthAppLogo({
+			db: input.db,
+			env: input.env,
+			userId: input.userId,
+			slug: input.app.slug,
+			sourceBytes,
+			source: input.app.logoSource ?? 'upload',
+		})
+		if (!updated.logoKey) return null
+		const fitted = await getUserOauthAppLogoObject({
+			env: input.env,
+			logoKey: updated.logoKey,
+		})
+		if (!fitted) return null
+		return servedLogoFromObject(
+			fitted,
+			updated.logoContentType,
+			userOauthAppLogoCacheControl,
+		)
+	} catch (error) {
+		console.error('user-oauth-app-logo-refit-failed', input.app.slug, error)
+		return servedFittedLogoFromBytes({
+			bytes: sourceBytes,
+			contentType: input.app.logoContentType,
+			httpEtag: object.httpEtag,
+			cacheControl: userOauthAppLogoCacheControl,
+		})
+	}
 }

--- a/packages/worker/src/mcp-client/mcp-server-favicon.ts
+++ b/packages/worker/src/mcp-client/mcp-server-favicon.ts
@@ -25,7 +25,7 @@ export function shouldFetchMcpServerFavicon(
 
 export async function fillMcpServerFavicon(input: {
 	db: D1Database
-	env: Pick<Env, 'COMMUNITY_ASSETS'>
+	env: Pick<Env, 'COMMUNITY_ASSETS' | 'IMAGES'>
 	userId: string
 	serverId: string
 	fetchImpl?: typeof fetch
@@ -71,15 +71,20 @@ export async function fillMcpServerFavicon(input: {
 
 export async function scheduleMcpServerFaviconFill(input: {
 	db: D1Database
-	env: Pick<Env, 'APP_DB' | 'COMMUNITY_ASSETS'> | Pick<Env, 'APP_DB'>
+	env: Pick<Env, 'APP_DB' | 'COMMUNITY_ASSETS' | 'IMAGES'> | Pick<Env, 'APP_DB'>
 	userId: string
 	serverId: string
 	waitUntil?: (promise: Promise<unknown>) => void
 }) {
-	if (!('COMMUNITY_ASSETS' in input.env) || !input.env.COMMUNITY_ASSETS) {
+	if (
+		!('COMMUNITY_ASSETS' in input.env) ||
+		!input.env.COMMUNITY_ASSETS ||
+		!('IMAGES' in input.env) ||
+		!input.env.IMAGES
+	) {
 		return
 	}
-	const env = input.env as Pick<Env, 'APP_DB' | 'COMMUNITY_ASSETS'>
+	const env = input.env as Pick<Env, 'APP_DB' | 'COMMUNITY_ASSETS' | 'IMAGES'>
 	const work = fillMcpServerFavicon({
 		db: input.db,
 		env,
@@ -101,19 +106,24 @@ export async function scheduleMcpServerFaviconFill(input: {
 
 export async function backfillMissingMcpServerFavicons(input: {
 	db: D1Database
-	env: Pick<Env, 'APP_DB' | 'COMMUNITY_ASSETS'> | Pick<Env, 'APP_DB'>
+	env: Pick<Env, 'APP_DB' | 'COMMUNITY_ASSETS' | 'IMAGES'> | Pick<Env, 'APP_DB'>
 	userId: string
 	servers: Array<McpServerSettingMetadata>
 	waitUntil?: (promise: Promise<unknown>) => void
 }) {
-	if (!('COMMUNITY_ASSETS' in input.env) || !input.env.COMMUNITY_ASSETS) {
+	if (
+		!('COMMUNITY_ASSETS' in input.env) ||
+		!input.env.COMMUNITY_ASSETS ||
+		!('IMAGES' in input.env) ||
+		!input.env.IMAGES
+	) {
 		return
 	}
 	const pending = input.servers
 		.filter((server) => shouldFetchMcpServerFavicon(server))
 		.slice(0, maxBackfillPerPage)
 	if (pending.length === 0) return
-	const env = input.env as Pick<Env, 'APP_DB' | 'COMMUNITY_ASSETS'>
+	const env = input.env as Pick<Env, 'APP_DB' | 'COMMUNITY_ASSETS' | 'IMAGES'>
 	const work = (async () => {
 		for (const server of pending) {
 			await fillMcpServerFavicon({

--- a/packages/worker/src/mcp-client/mcp-server-logo.node.test.ts
+++ b/packages/worker/src/mcp-client/mcp-server-logo.node.test.ts
@@ -1,0 +1,226 @@
+import { DatabaseSync } from 'node:sqlite'
+import { expect, test } from 'vitest'
+import { applyAllMigrations as applyRepositoryMigrations } from '#worker/test-support/apply-all-migrations.ts'
+import { createD1FromSqlite } from '#worker/test-support/create-d1-from-sqlite.ts'
+import {
+	createFakeImagesBinding,
+	tinyPngBytes,
+	tinyWebpBytes,
+} from '#worker/test-support/images-binding.ts'
+import { shouldFetchMcpServerFavicon } from './mcp-server-favicon.ts'
+import { loadFittedMcpServerLogo } from './mcp-server-logo.ts'
+import {
+	getMcpServerSettingRowById,
+	insertMcpServerSettingRow,
+} from './settings-repo.ts'
+
+const migrationsDirectory = new URL('../../migrations/', import.meta.url)
+
+type StoredObject = {
+	bytes: Uint8Array
+	httpMetadata?: { contentType?: string; cacheControl?: string }
+	customMetadata?: Record<string, string>
+	httpEtag: string
+	size: number
+}
+
+function createInMemoryR2() {
+	const objects = new Map<string, StoredObject>()
+	const bucket = {
+		async put(
+			key: string,
+			bytes: Uint8Array,
+			options?: {
+				httpMetadata?: { contentType?: string; cacheControl?: string }
+				customMetadata?: Record<string, string>
+			},
+		) {
+			objects.set(key, {
+				bytes,
+				...(options?.httpMetadata
+					? { httpMetadata: options.httpMetadata }
+					: {}),
+				...(options?.customMetadata
+					? { customMetadata: options.customMetadata }
+					: {}),
+				httpEtag: `"etag-${objects.size}"`,
+				size: bytes.byteLength,
+			})
+		},
+		async get(key: string) {
+			const stored = objects.get(key)
+			if (!stored) return null
+			return {
+				...stored,
+				body: new Blob([stored.bytes]).stream(),
+				async arrayBuffer() {
+					const copy = new Uint8Array(stored.bytes.byteLength)
+					copy.set(stored.bytes)
+					return copy.buffer
+				},
+			}
+		},
+		async delete(key: string) {
+			objects.delete(key)
+		},
+	} as unknown as R2Bucket
+	return { bucket, objects }
+}
+
+function createHarness() {
+	const sqlite = new DatabaseSync(':memory:')
+	applyRepositoryMigrations(sqlite, migrationsDirectory)
+	const db = createD1FromSqlite(sqlite)
+	const r2 = createInMemoryR2()
+	const env = {
+		COMMUNITY_ASSETS: r2.bucket,
+		IMAGES: createFakeImagesBinding(),
+	} as Pick<Env, 'COMMUNITY_ASSETS' | 'IMAGES'>
+	return { sqlite, db, env, r2 }
+}
+
+async function provisionServer(harness: ReturnType<typeof createHarness>) {
+	const row = {
+		id: 'server-1',
+		user_id: 'user-1',
+		name: 'linear',
+		url: 'https://mcp.linear.app/mcp',
+		enabled: true,
+		logo_key: null,
+		logo_content_type: null,
+		logo_source: null,
+		favicon_source_host: null,
+	}
+	await insertMcpServerSettingRow({ db: harness.db, row })
+	return row
+}
+
+test('lazy refit of an MCP favicon keeps faviconSourceHost', async () => {
+	const harness = createHarness()
+	const server = await provisionServer(harness)
+	const previousKey = `user-mcp-server-logos/${server.user_id}/${server.id}/aaaaaaaaaaaaaaaa.png`
+	await harness.env.COMMUNITY_ASSETS.put(previousKey, tinyPngBytes, {
+		httpMetadata: { contentType: 'image/png' },
+	})
+	await harness.db
+		.prepare(
+			`UPDATE mcp_server_settings
+			SET logo_key = ?, logo_content_type = ?, logo_source = ?,
+				favicon_source_host = ?, updated_at = ?
+			WHERE user_id = ? AND id = ?`,
+		)
+		.bind(
+			previousKey,
+			'image/png',
+			'favicon',
+			'linear.app',
+			new Date().toISOString(),
+			server.user_id,
+			server.id,
+		)
+		.run()
+	const stale = await getMcpServerSettingRowById({
+		db: harness.db,
+		userId: server.user_id,
+		id: server.id,
+	})
+
+	const served = await loadFittedMcpServerLogo({
+		db: harness.db,
+		env: harness.env,
+		userId: server.user_id,
+		serverId: server.id,
+		logoKey: stale!.logo_key!,
+		logoContentType: stale!.logo_content_type,
+		logoSource: stale!.logo_source,
+		faviconSourceHost: stale!.favicon_source_host,
+	})
+	expect(served?.contentType).toBe('image/webp')
+	const current = await getMcpServerSettingRowById({
+		db: harness.db,
+		userId: server.user_id,
+		id: server.id,
+	})
+	expect(current?.favicon_source_host).toBe('linear.app')
+	expect(current?.logo_source).toBe('favicon')
+	expect(
+		shouldFetchMcpServerFavicon({
+			url: current!.url,
+			logoKey: current!.logo_key,
+			logoSource: current!.logo_source,
+			faviconSourceHost: current!.favicon_source_host,
+		}),
+	).toBe(false)
+})
+
+test('lazy refit does not overwrite a newer MCP logo key', async () => {
+	const harness = createHarness()
+	const server = await provisionServer(harness)
+	const previousKey = `user-mcp-server-logos/${server.user_id}/${server.id}/aaaaaaaaaaaaaaaa.png`
+	const newerKey = `user-mcp-server-logos/${server.user_id}/${server.id}/bbbbbbbbbbbbbbbb.webp`
+	await harness.env.COMMUNITY_ASSETS.put(previousKey, tinyPngBytes, {
+		httpMetadata: { contentType: 'image/png' },
+	})
+	await harness.env.COMMUNITY_ASSETS.put(newerKey, tinyWebpBytes, {
+		httpMetadata: { contentType: 'image/webp' },
+		customMetadata: { iconFitVersion: '2' },
+	})
+	await harness.db
+		.prepare(
+			`UPDATE mcp_server_settings
+			SET logo_key = ?, logo_content_type = ?, logo_source = ?,
+				favicon_source_host = ?, updated_at = ?
+			WHERE user_id = ? AND id = ?`,
+		)
+		.bind(
+			previousKey,
+			'image/png',
+			'favicon',
+			'linear.app',
+			new Date().toISOString(),
+			server.user_id,
+			server.id,
+		)
+		.run()
+	const stale = await getMcpServerSettingRowById({
+		db: harness.db,
+		userId: server.user_id,
+		id: server.id,
+	})
+	await harness.db
+		.prepare(
+			`UPDATE mcp_server_settings
+			SET logo_key = ?, logo_content_type = ?, logo_source = ?,
+				favicon_source_host = ?, updated_at = ?
+			WHERE user_id = ? AND id = ?`,
+		)
+		.bind(
+			newerKey,
+			'image/webp',
+			'favicon',
+			'linear.app',
+			new Date().toISOString(),
+			server.user_id,
+			server.id,
+		)
+		.run()
+
+	const served = await loadFittedMcpServerLogo({
+		db: harness.db,
+		env: harness.env,
+		userId: server.user_id,
+		serverId: server.id,
+		logoKey: stale!.logo_key!,
+		logoContentType: stale!.logo_content_type,
+		logoSource: stale!.logo_source,
+		faviconSourceHost: stale!.favicon_source_host,
+	})
+	expect(served?.contentType).toBe('image/webp')
+	const current = await getMcpServerSettingRowById({
+		db: harness.db,
+		userId: server.user_id,
+		id: server.id,
+	})
+	expect(current?.logo_key).toBe(newerKey)
+	expect(harness.r2.objects.has(newerKey)).toBe(true)
+})

--- a/packages/worker/src/mcp-client/mcp-server-logo.node.test.ts
+++ b/packages/worker/src/mcp-client/mcp-server-logo.node.test.ts
@@ -8,7 +8,7 @@ import {
 	tinyWebpBytes,
 } from '#worker/test-support/images-binding.ts'
 import { shouldFetchMcpServerFavicon } from './mcp-server-favicon.ts'
-import { loadFittedMcpServerLogo } from './mcp-server-logo.ts'
+import { loadFittedMcpServerLogo, setMcpServerLogo } from './mcp-server-logo.ts'
 import {
 	getMcpServerSettingRowById,
 	insertMcpServerSettingRow,
@@ -223,4 +223,69 @@ test('lazy refit does not overwrite a newer MCP logo key', async () => {
 	})
 	expect(current?.logo_key).toBe(newerKey)
 	expect(harness.r2.objects.has(newerKey)).toBe(true)
+})
+
+test('lost same-hash refit race keeps the stored MCP logo', async () => {
+	const harness = createHarness()
+	const server = await provisionServer(harness)
+	const previousKey = `user-mcp-server-logos/${server.user_id}/${server.id}/aaaaaaaaaaaaaaaa.png`
+	await harness.env.COMMUNITY_ASSETS.put(previousKey, tinyPngBytes, {
+		httpMetadata: { contentType: 'image/png' },
+	})
+	await harness.db
+		.prepare(
+			`UPDATE mcp_server_settings
+			SET logo_key = ?, logo_content_type = ?, logo_source = ?,
+				favicon_source_host = ?, updated_at = ?
+			WHERE user_id = ? AND id = ?`,
+		)
+		.bind(
+			previousKey,
+			'image/png',
+			'favicon',
+			'linear.app',
+			new Date().toISOString(),
+			server.user_id,
+			server.id,
+		)
+		.run()
+	const stale = await getMcpServerSettingRowById({
+		db: harness.db,
+		userId: server.user_id,
+		id: server.id,
+	})
+	await loadFittedMcpServerLogo({
+		db: harness.db,
+		env: harness.env,
+		userId: server.user_id,
+		serverId: server.id,
+		logoKey: stale!.logo_key!,
+		logoContentType: stale!.logo_content_type,
+		logoSource: stale!.logo_source,
+		faviconSourceHost: stale!.favicon_source_host,
+	})
+	const winner = await getMcpServerSettingRowById({
+		db: harness.db,
+		userId: server.user_id,
+		id: server.id,
+	})
+	expect(winner?.logo_key).toMatch(/\.webp$/)
+
+	await setMcpServerLogo({
+		db: harness.db,
+		env: harness.env,
+		userId: server.user_id,
+		serverId: server.id,
+		sourceBytes: tinyPngBytes,
+		source: 'favicon',
+		faviconSourceHost: 'linear.app',
+		replaceLogoKey: previousKey,
+	})
+	const current = await getMcpServerSettingRowById({
+		db: harness.db,
+		userId: server.user_id,
+		id: server.id,
+	})
+	expect(current?.logo_key).toBe(winner?.logo_key)
+	expect(harness.r2.objects.has(winner!.logo_key!)).toBe(true)
 })

--- a/packages/worker/src/mcp-client/mcp-server-logo.ts
+++ b/packages/worker/src/mcp-client/mcp-server-logo.ts
@@ -131,22 +131,8 @@ export async function setMcpServerLogo(input: {
 		.run()
 
 	if ((updated.meta.changes ?? 0) === 0) {
-		const current = await getMcpServerSettingRowById({
-			db: input.db,
-			userId: input.userId,
-			id: existing.id,
-		})
-		if (nextKey !== current?.logo_key) {
-			try {
-				await input.env.COMMUNITY_ASSETS.delete(nextKey)
-			} catch (error) {
-				console.error(
-					'mcp-server-logo-raced-favicon-delete-failed',
-					nextKey,
-					error,
-				)
-			}
-		}
+		// Leave nextKey. A concurrent writer can store the same content hash
+		// after this lookup; deleting here can remove a live object.
 		return
 	}
 

--- a/packages/worker/src/mcp-client/mcp-server-logo.ts
+++ b/packages/worker/src/mcp-client/mcp-server-logo.ts
@@ -131,14 +131,21 @@ export async function setMcpServerLogo(input: {
 		.run()
 
 	if ((updated.meta.changes ?? 0) === 0) {
-		try {
-			await input.env.COMMUNITY_ASSETS.delete(nextKey)
-		} catch (error) {
-			console.error(
-				'mcp-server-logo-raced-favicon-delete-failed',
-				nextKey,
-				error,
-			)
+		const current = await getMcpServerSettingRowById({
+			db: input.db,
+			userId: input.userId,
+			id: existing.id,
+		})
+		if (nextKey !== current?.logo_key) {
+			try {
+				await input.env.COMMUNITY_ASSETS.delete(nextKey)
+			} catch (error) {
+				console.error(
+					'mcp-server-logo-raced-favicon-delete-failed',
+					nextKey,
+					error,
+				)
+			}
 		}
 		return
 	}

--- a/packages/worker/src/mcp-client/mcp-server-logo.ts
+++ b/packages/worker/src/mcp-client/mcp-server-logo.ts
@@ -1,8 +1,15 @@
 import { toHex } from '@kody-internal/shared/hex.ts'
 import { routes } from '#universal/routes.ts'
 import {
+	iconFitCustomMetadata,
+	logoNeedsIconFit,
+} from '#worker/community/icon-fit.ts'
+import {
 	processPlatformOauthAppLogo,
+	servedFittedLogoFromBytes,
+	servedLogoFromObject,
 	type PlatformOauthAppLogoContentType,
+	type ServedFittedLogo,
 } from '#worker/integrations/platform-app-logo.ts'
 import { getMcpServerSettingRowById } from './settings-repo.ts'
 import { type McpServerLogoSource } from './settings-types.ts'
@@ -60,7 +67,7 @@ async function sha256Hex(bytes: Uint8Array) {
 
 export async function setMcpServerLogo(input: {
 	db: D1Database
-	env: Pick<Env, 'COMMUNITY_ASSETS'>
+	env: Pick<Env, 'COMMUNITY_ASSETS' | 'IMAGES'>
 	userId: string
 	serverId: string
 	sourceBytes: Uint8Array
@@ -74,7 +81,10 @@ export async function setMcpServerLogo(input: {
 	})
 	if (!existing) return
 	const previousKey = existing.logo_key
-	const processed = await processPlatformOauthAppLogo(input.sourceBytes)
+	const processed = await processPlatformOauthAppLogo(
+		input.sourceBytes,
+		input.env.IMAGES,
+	)
 	const contentHash = (await sha256Hex(processed.bytes)).slice(0, 16)
 	const nextKey = `${mcpServerLogoR2KeyPrefix}${input.userId}/${existing.id}/${contentHash}.${extensionForContentType(processed.contentType)}`
 	await input.env.COMMUNITY_ASSETS.put(nextKey, processed.bytes, {
@@ -82,12 +92,12 @@ export async function setMcpServerLogo(input: {
 			contentType: processed.contentType,
 			cacheControl: mcpServerLogoCacheControl,
 		},
-		customMetadata: {
+		customMetadata: iconFitCustomMetadata({
 			userId: input.userId,
 			mcpServerId: existing.id,
 			logoSource: input.source,
 			contentHash,
-		},
+		}),
 	})
 
 	const updated = await input.db
@@ -153,4 +163,64 @@ export async function getMcpServerLogoObject(input: {
 }): Promise<R2ObjectBody | null> {
 	if (!input.logoKey.startsWith(mcpServerLogoR2KeyPrefix)) return null
 	return await input.env.COMMUNITY_ASSETS.get(input.logoKey)
+}
+
+export async function loadFittedMcpServerLogo(input: {
+	db: D1Database
+	env: Pick<Env, 'COMMUNITY_ASSETS' | 'IMAGES'>
+	userId: string
+	serverId: string
+	logoKey: string
+	logoContentType: string | null
+	logoSource: McpServerLogoSource | null
+	faviconSourceHost: string | null
+}): Promise<ServedFittedLogo | null> {
+	const object = await getMcpServerLogoObject({
+		env: input.env,
+		logoKey: input.logoKey,
+	})
+	if (!object) return null
+	if (!logoNeedsIconFit(object.customMetadata)) {
+		return servedLogoFromObject(
+			object,
+			input.logoContentType,
+			mcpServerLogoCacheControl,
+		)
+	}
+	const sourceBytes = new Uint8Array(await object.arrayBuffer())
+	try {
+		await setMcpServerLogo({
+			db: input.db,
+			env: input.env,
+			userId: input.userId,
+			serverId: input.serverId,
+			sourceBytes,
+			source: input.logoSource ?? 'favicon',
+			faviconSourceHost: input.faviconSourceHost ?? '',
+		})
+		const row = await getMcpServerSettingRowById({
+			db: input.db,
+			userId: input.userId,
+			id: input.serverId,
+		})
+		if (!row?.logo_key) return null
+		const fitted = await getMcpServerLogoObject({
+			env: input.env,
+			logoKey: row.logo_key,
+		})
+		if (!fitted) return null
+		return servedLogoFromObject(
+			fitted,
+			row.logo_content_type,
+			mcpServerLogoCacheControl,
+		)
+	} catch (error) {
+		console.error('mcp-server-logo-refit-failed', input.serverId, error)
+		return servedFittedLogoFromBytes({
+			bytes: sourceBytes,
+			contentType: input.logoContentType,
+			httpEtag: object.httpEtag,
+			cacheControl: mcpServerLogoCacheControl,
+		})
+	}
 }

--- a/packages/worker/src/mcp-client/mcp-server-logo.ts
+++ b/packages/worker/src/mcp-client/mcp-server-logo.ts
@@ -73,6 +73,11 @@ export async function setMcpServerLogo(input: {
 	sourceBytes: Uint8Array
 	source: McpServerLogoSource
 	faviconSourceHost: string
+	/**
+	 * When set, the column update is compare-and-swap on `logo_key` so a
+	 * concurrent ingest cannot be overwritten by a stale lazy refit.
+	 */
+	replaceLogoKey?: string | null
 }): Promise<void> {
 	const existing = await getMcpServerSettingRowById({
 		db: input.db,
@@ -100,9 +105,15 @@ export async function setMcpServerLogo(input: {
 		}),
 	})
 
+	const casLogoKey = input.replaceLogoKey !== undefined
 	const updated = await input.db
 		.prepare(
-			`UPDATE mcp_server_settings
+			casLogoKey
+				? `UPDATE mcp_server_settings
+			SET logo_key = ?, logo_content_type = ?, logo_source = ?,
+				favicon_source_host = ?, updated_at = ?
+			WHERE user_id = ? AND id = ? AND logo_key IS ?`
+				: `UPDATE mcp_server_settings
 			SET logo_key = ?, logo_content_type = ?, logo_source = ?,
 				favicon_source_host = ?, updated_at = ?
 			WHERE user_id = ? AND id = ?`,
@@ -115,6 +126,7 @@ export async function setMcpServerLogo(input: {
 			new Date().toISOString(),
 			input.userId,
 			existing.id,
+			...(casLogoKey ? [input.replaceLogoKey] : []),
 		)
 		.run()
 
@@ -179,7 +191,7 @@ export async function loadFittedMcpServerLogo(input: {
 		env: input.env,
 		logoKey: input.logoKey,
 	})
-	if (!object) return null
+	if (!object) return await serveCurrentMcpServerLogo(input)
 	if (!logoNeedsIconFit(object.customMetadata)) {
 		return servedLogoFromObject(
 			object,
@@ -197,6 +209,7 @@ export async function loadFittedMcpServerLogo(input: {
 			sourceBytes,
 			source: input.logoSource ?? 'favicon',
 			faviconSourceHost: input.faviconSourceHost ?? '',
+			replaceLogoKey: input.logoKey,
 		})
 		const row = await getMcpServerSettingRowById({
 			db: input.db,
@@ -208,12 +221,13 @@ export async function loadFittedMcpServerLogo(input: {
 			env: input.env,
 			logoKey: row.logo_key,
 		})
-		if (!fitted) return null
-		return servedLogoFromObject(
-			fitted,
-			row.logo_content_type,
-			mcpServerLogoCacheControl,
-		)
+		if (fitted) {
+			return servedLogoFromObject(
+				fitted,
+				row.logo_content_type,
+				mcpServerLogoCacheControl,
+			)
+		}
 	} catch (error) {
 		console.error('mcp-server-logo-refit-failed', input.serverId, error)
 		return servedFittedLogoFromBytes({
@@ -223,4 +237,30 @@ export async function loadFittedMcpServerLogo(input: {
 			cacheControl: mcpServerLogoCacheControl,
 		})
 	}
+	return await serveCurrentMcpServerLogo(input)
+}
+
+async function serveCurrentMcpServerLogo(input: {
+	db: D1Database
+	env: Pick<Env, 'COMMUNITY_ASSETS' | 'IMAGES'>
+	userId: string
+	serverId: string
+	logoKey: string
+}): Promise<ServedFittedLogo | null> {
+	const row = await getMcpServerSettingRowById({
+		db: input.db,
+		userId: input.userId,
+		id: input.serverId,
+	})
+	if (!row?.logo_key || row.logo_key === input.logoKey) return null
+	const latest = await getMcpServerLogoObject({
+		env: input.env,
+		logoKey: row.logo_key,
+	})
+	if (!latest) return null
+	return servedLogoFromObject(
+		latest,
+		row.logo_content_type,
+		mcpServerLogoCacheControl,
+	)
 }

--- a/packages/worker/src/mcp/capabilities/admin/admin-platform-oauth-app-save.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-platform-oauth-app-save.ts
@@ -82,7 +82,7 @@ const inputSchema = z
 			.nullable()
 			.optional()
 			.describe(
-				'Base64-encoded provider logo (SVG, PNG, JPEG, or WebP; SVG is rasterized to PNG before storage). Omit to keep the current logo, pass null to remove it.',
+				'Base64-encoded provider logo (SVG, PNG, JPEG, or WebP). Kody fits the image to 256px WebP before storage. Omit to keep the current logo, pass null to remove it.',
 			),
 	})
 	.strict()

--- a/packages/worker/src/mcp/capabilities/integrations/integration-shared.ts
+++ b/packages/worker/src/mcp/capabilities/integrations/integration-shared.ts
@@ -103,7 +103,7 @@ export const integrationSaveSchema = z
 			.nullable()
 			.optional()
 			.describe(
-				'Base64-encoded OAuth app logo (SVG, PNG, JPEG, or WebP; SVG is rasterized to PNG). Omit to keep the current logo, pass null to clear it and re-fetch the provider favicon.',
+				'Base64-encoded OAuth app logo (SVG, PNG, JPEG, or WebP). Kody fits the image to 256px WebP before storage. Omit to keep the current logo, pass null to clear it and re-fetch the provider favicon.',
 			),
 	})
 	.strict()

--- a/packages/worker/src/test-support/images-binding.ts
+++ b/packages/worker/src/test-support/images-binding.ts
@@ -1,0 +1,66 @@
+export const tinyPngBytes = Uint8Array.from(
+	atob(
+		'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==',
+	),
+	(character) => character.charCodeAt(0),
+)
+
+export const tinyWebpBytes = Uint8Array.from(
+	atob('UklGRiIAAABXRUJQVlA4IBYAAAAwAQCdASoBAAEADsD+JaQAA3AAAAAA'),
+	(character) => character.charCodeAt(0),
+)
+
+export type FakeImagesCall = {
+	inputBytes: Uint8Array
+	transform: ImageTransform | null
+	output: ImageOutputOptions
+}
+
+export type FakeImagesBinding = ImagesBinding & {
+	calls: Array<FakeImagesCall>
+}
+
+/**
+ * Node-unit stand-in for `env.IMAGES`. It does not decode pixels; it records
+ * the requested transform and returns a tiny fixture in the asked format so
+ * ingest tests can run without the Workers Images simulator.
+ */
+export function createFakeImagesBinding(): FakeImagesBinding {
+	const calls: Array<FakeImagesCall> = []
+	return {
+		calls,
+		async info() {
+			throw new Error('Fake ImagesBinding.info is not implemented.')
+		},
+		input(stream: ReadableStream<Uint8Array>) {
+			let transform: ImageTransform | null = null
+			const transformer = {
+				transform(next: ImageTransform) {
+					transform = next
+					return transformer
+				},
+				draw() {
+					return transformer
+				},
+				async output(output: ImageOutputOptions) {
+					const inputBytes = new Uint8Array(
+						await new Response(stream).arrayBuffer(),
+					)
+					calls.push({ inputBytes, transform, output })
+					const bytes =
+						output.format === 'image/png' ? tinyPngBytes : tinyWebpBytes
+					return {
+						response: () =>
+							new Response(bytes, {
+								headers: { 'content-type': output.format },
+							}),
+						contentType: () => output.format,
+						image: () => new Blob([bytes]).stream(),
+					}
+				},
+			}
+			return transformer
+		},
+		hosted: {} as HostedImagesBinding,
+	} as FakeImagesBinding
+}

--- a/packages/worker/universal/community-listing-icon.tsx
+++ b/packages/worker/universal/community-listing-icon.tsx
@@ -49,8 +49,8 @@ export function CommunityListingIcon(
 					display: 'block',
 					width: '100%',
 					height: '100%',
-					// `contain`, not `cover`: the icon endpoint serves raster
-					// icons at their source dimensions, so a wide logo would be
+					// `contain`, not `cover`: fitted icons keep their source
+					// aspect ratio inside a 256px box, so a wide logo would be
 					// center-cropped. The generated square fallback fills the
 					// well identically either way.
 					objectFit: 'contain',

--- a/packages/worker/worker-configuration.d.ts
+++ b/packages/worker/worker-configuration.d.ts
@@ -26,6 +26,7 @@ interface __BaseEnv_Env {
 	LOADER: WorkerLoader;
 	APP_LOADER: WorkerLoader;
 	AI: Ai;
+	IMAGES: ImagesBinding;
 	ASSETS: Fetcher;
 	SENTRY_ENVIRONMENT: "production";
 	SIGNUP_MODE: "invite";

--- a/packages/worker/wrangler.jsonc
+++ b/packages/worker/wrangler.jsonc
@@ -13,6 +13,13 @@
 		"global_fetch_strictly_public",
 		"enhanced_error_serialization",
 	],
+	// Resize/re-encode package icons and integration logos at ingest. Local
+	// wrangler uses the offline Images simulator (width/height/fit/format).
+	// Wrangler does not inherit `images` into named envs — restate it on
+	// production, preview, and test.
+	"images": {
+		"binding": "IMAGES",
+	},
 	// Paid default is 10_000 subrequests/invocation. The MCP Agent Durable
 	// Object keeps a long-lived session and each mutating storage_query pays
 	// several D1 + StorageRunner RPCs (entitlement baseline, sqlQuery,
@@ -481,6 +488,9 @@
 			"ai": {
 				"binding": "AI",
 			},
+			"images": {
+				"binding": "IMAGES",
+			},
 			"artifacts": [
 				{
 					"binding": "ARTIFACTS",
@@ -874,6 +884,9 @@
 			"ai": {
 				"binding": "AI",
 			},
+			"images": {
+				"binding": "IMAGES",
+			},
 			"artifacts": [
 				{
 					"binding": "ARTIFACTS",
@@ -1145,6 +1158,9 @@
 					"bucket_name": "kody-preview-repo-session-blobs",
 				},
 			],
+			"images": {
+				"binding": "IMAGES",
+			},
 			"vars": {
 				"SENTRY_ENVIRONMENT": "test",
 				"SIGNUP_MODE": "open",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Make package listing icons and integration / MCP logos load quickly without a one-off compress of today's files, and without dropping visual quality into mush.

## Why

Community icons and OAuth/MCP logos were validated then stored and served as the original bytes. Sources can be up to 4096px / 16MP / 2 MiB, while the UI paints them at about 56–88 CSS pixels. That is a durable mismatch, not a one-time fat file.

## Summary

- Cloudflare Images (`env.IMAGES`) fits every accepted source to a 256px WebP (`fit: scale-down`, quality 90) off-isolate, so a 16-megapixel upload cannot OOM the Worker.
- Derived community-icon cache keys move to v2; leftover v1 KV/R2 prefixes are still deleted on publish and account deletion.
- Public fitted assets use immutable cache (`public, max-age=31536000, immutable`). Icon URLs already embed `iconCommit`; platform logos already embed a content hash.
- Existing unfitted logos lazy-refit on GET (custom metadata `iconFitVersion !== "2"`) and rewrite the hashed key so caches pick up the smaller file. The rewrite is compare-and-swap on the original `logo_key`, keeps `favicon_source_host`, and does not delete the winner's object when two refits hash to the same key.
- Satori OG cards convert stored WebP back to PNG through Images.
- Wrangler does not inherit `images` into named envs; production, preview, and test restate the binding on origin and platform.

## Testing

- Focused node-unit: community icon, icon-fit, platform/user/MCP logos (lazy-refit CAS, favicon-host preservation, same-hash lost-race), account deletion/R2 cleanup, community icon/OG handlers
- Focused workers-unit: real `env.IMAGES` ingest of an oversized PNG to ≤256px WebP
- Pre-push after review fixes: `test:node` 2135 passed, `test:workers` 302 passed
- Preview (`kody-pr-1821`): signed in as seed user, saved a GitHub OAuth app, GET `/integrations/logos/github-fit` returned `image/webp` 120×120 (1824 bytes)

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` · **Head:** `cursor/optimize-package-integration-images-f1d3`

**Classification:** extends — ingest now always scale-down/re-encodes derived icons and logos; cache keys, HTTP cache, and logo GET contracts change.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `community-assets-r2` | storage | extends — v2 256px WebP derivatives via Images, immutable cache, v1 prefix cleanup |
| `community-listings` | assistant | extends — shared `processCommunityIcon` always fits; OG WebP→PNG |
| `integrations` | assistant | extends — platform/user logos fitted at upload; lazy refit CAS on GET |
| `mcp-client-servers` | assistant | extends — MCP logos fitted at upload; lazy refit CAS on GET |
| `app-ui` | surfaces | composes — icon/logo handlers stream fitted assets; deletion prefixes both versions |
| `platform-worker` | surfaces | composes — `IMAGES` binding for logo uploads on that script |
| `rbac` | auth | composes — admin logo schema copy; test harness binds Images |

### Change flow

Package icons and integration logos share one ingest: validate source, Images scale-down to 256px WebP, store in `COMMUNITY_ASSETS`, then serve with immutable (public) or private cache.

```mermaid
sequenceDiagram
	actor User
	participant appUi as app-ui
	participant communityListings as community-listings
	participant integrations as integrations
	participant images as IMAGES
	participant communityAssetsR2 as community-assets-r2
	User->>appUi: GET listing icon or integration logo
	appUi->>communityListings: getCommunityIconObject / loadFitted*Logo
	alt derived miss or logoNeedsIconFit
		communityListings->>images: fit scale-down 256 WebP q90
		integrations->>images: same ingest for OAuth and MCP logos
		integrations->>communityAssetsR2: CAS logo_key then put hashed .webp
		images->>communityAssetsR2: put v2 key or hashed .webp
	end
	communityAssetsR2-->>appUi: stream fitted bytes Cache-Control immutable
```

### Before / after

| | Before | After |
| --- | --- | --- |
| Stored raster | source PNG/JPEG/WebP bytes | 256px WebP (`iconFitVersion=2`) |
| Community keys | `community-icon:v1/...` | `community-icon:v2/...` (v1 still purged) |
| Public Cache-Control | `max-age=3600` for listing icons | `public, max-age=31536000, immutable` |
| Existing logos | stay large until re-upload | lazy refit on next GET, CAS on original key |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fbabbd16-03f6-4e1f-aaca-c9b7d111f1d3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fbabbd16-03f6-4e1f-aaca-c9b7d111f1d3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Community icons, provider logos, OAuth app logos, and MCP logos are consistently optimized to 256-pixel WebP images.
  * SVG, PNG, JPEG, and WebP uploads are supported.
  * Older image assets are refreshed automatically when accessed.
  * WebP community icons can appear in generated preview images.
  * Optimized assets use long-term browser caching.

* **Bug Fixes**
  * Account cleanup now removes current and legacy icon assets and caches.
  * Image refreshes no longer overwrite newer uploaded logos.

* **Documentation**
  * Updated image storage, setup, authoring, and Cloudflare configuration guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->