### PR TITLE
Treat a 200 multipart Worker script GET as exists

### DIFF
--- a/tools/ci/origin-production-deploy-state.node.test.ts
+++ b/tools/ci/origin-production-deploy-state.node.test.ts
@@ -5,7 +5,9 @@ import { expect, test } from 'vitest'
 import {
 	classifyOriginProductionScriptState,
 	inspectOriginProductionScriptState,
+	getCloudflareWorkerScriptExists,
 	isCloudflareNotFoundError,
+	isCloudflareOkNonJsonError,
 	originBootstrapConfigPath,
 	planOriginProductionDeploy,
 	platformOwnedClassNames,
@@ -154,6 +156,86 @@ test('falls back to script existence only when namespace listing is unavailable'
 			namespaces: null,
 		}).mode,
 	).toBe('ambiguous')
+})
+
+test('isCloudflareOkNonJsonError matches only HTTP 200 non-JSON bodies', () => {
+	expect(
+		isCloudflareOkNonJsonError(
+			new Error(
+				'Malformed Cloudflare response (200) for /workers/scripts/kody-runtime: --boundary',
+			),
+		),
+	).toBe(true)
+	expect(
+		isCloudflareOkNonJsonError(
+			new Error(
+				'Malformed Cloudflare response (502) for /workers/scripts/kody-runtime: upstream',
+			),
+		),
+	).toBe(false)
+})
+
+test('getCloudflareWorkerScriptExists treats a 200 multipart script download as present', async () => {
+	await expect(
+		getCloudflareWorkerScriptExists({
+			accountId: 'acct',
+			apiToken: 'token',
+			scriptName: productionRuntimeScriptName,
+			apiBaseUrl: 'https://cf.test',
+			fetcher: async () =>
+				new Response(
+					'--fe71c953c6db05262becd226201515a4e42a8860e6be9669fec682876e63',
+					{
+						status: 200,
+						headers: {
+							'Content-Type':
+								'multipart/form-data; boundary=fe71c953c6db05262becd226201515a4e42a8860e6be9669fec682876e63',
+						},
+					},
+				),
+		}),
+	).resolves.toBe(true)
+})
+
+test('inspectOriginProductionScriptState classifies a multipart script GET plus ownership as steady', async () => {
+	const state = await inspectOriginProductionScriptState({
+		accountId: 'acct',
+		apiToken: 'token',
+		apiBaseUrl: 'https://cf.test',
+		fetcher: async (input) => {
+			const url = String(input)
+			if (url.includes('/workers/durable_objects/namespaces')) {
+				return new Response(
+					JSON.stringify({
+						success: true,
+						result: [
+							...platformOwnedClassNames.map((className) => ({
+								script: productionPlatformScriptName,
+								class: className,
+							})),
+							...runtimeOwnedClassNames.map((className) => ({
+								script: productionRuntimeScriptName,
+								class: className,
+							})),
+						],
+						result_info: { total_pages: 1 },
+					}),
+					{ status: 200, headers: { 'Content-Type': 'application/json' } },
+				)
+			}
+			return new Response(
+				'--fe71c953c6db05262becd226201515a4e42a8860e6be9669fec682876e63',
+				{
+					status: 200,
+					headers: {
+						'Content-Type':
+							'multipart/form-data; boundary=fe71c953c6db05262becd226201515a4e42a8860e6be9669fec682876e63',
+					},
+				},
+			)
+		},
+	})
+	expect(state.mode).toBe('steady')
 })
 
 test('isCloudflareNotFoundError matches only 404 probe failures', () => {

--- a/tools/ci/origin-production-deploy-state.ts
+++ b/tools/ci/origin-production-deploy-state.ts
@@ -57,6 +57,16 @@ export function isCloudflareNotFoundError(error: unknown) {
 	return /Cloudflare API request failed \(404\)/.test(error.message)
 }
 
+/**
+ * GET /workers/scripts/:name returns the Worker upload as multipart, not
+ * the JSON envelope `cloudflareApiRequest` expects. HTTP 200 still means
+ * the script exists.
+ */
+export function isCloudflareOkNonJsonError(error: unknown) {
+	if (!(error instanceof Error)) return false
+	return /Malformed Cloudflare response \(200\)/.test(error.message)
+}
+
 export function planOriginProductionDeploy(
 	state: OriginProductionScriptState,
 ): OriginProductionDeployPlan {
@@ -273,6 +283,7 @@ export async function getCloudflareWorkerScriptExists(input: {
 		return true
 	} catch (error) {
 		if (isCloudflareNotFoundError(error)) return false
+		if (isCloudflareOkNonJsonError(error)) return true
 		throw error
 	}
 }

--- a/tools/ci/resource-utils.node.test.ts
+++ b/tools/ci/resource-utils.node.test.ts
@@ -890,6 +890,13 @@ test('Cloudflare API requests retry gateway HTML/text blips then succeed', async
 			new Error('Cloudflare API request failed (400): invalid queue name'),
 		),
 	).toBe(false)
+	expect(
+		isRetryableCloudflareApiError(
+			new Error(
+				'Malformed Cloudflare response (200) for /workers/scripts/kody-runtime: --boundary',
+			),
+		),
+	).toBe(false)
 })
 
 test('ensureArtifactsAccountEventSubscription creates account-level lifecycle subscription', async () => {

--- a/tools/ci/resource-utils.ts
+++ b/tools/ci/resource-utils.ts
@@ -52,7 +52,8 @@ export function isRetryableCloudflareApiError(error: unknown) {
 	if (error.name === 'AbortError') return true
 	const message = error.message
 	return (
-		message.includes('Malformed Cloudflare response') ||
+		(message.includes('Malformed Cloudflare response') &&
+			!/Malformed Cloudflare response \(200\).*--/u.test(message)) ||
 		message.includes('upstream connect error') ||
 		message.includes('Cloudflare API request failed (429)') ||
 		/Cloudflare API request failed \(5\d\d\)/.test(message) ||


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

The first production deploy after #1825 fail-closed to the full origin entry. Cloudflare `GET /workers/scripts/:name` can return the Worker upload as multipart instead of the JSON envelope, and that 200 was treated as a probe failure.

## Summary

- HTTP 200, including a multipart script body, means the script exists.
- Do not retry a multipart 200 (it is deterministic, not a gateway blip).
- Real JSON/`null` 200 blips on other endpoints stay retryable.

This is the leftover of leftover #1823: live origin is still on the full entry until a deploy classifies **steady** and uploads `production-worker.ts`.

## Testing

- Targeted deploy-state + resource-utils node tests: 32 passing.
- Full `test:node`: 2,203 passing.
- Full `test:workers`: 302 passing.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `033acdb` · **Head:** `6bdb5bc`

**Classification:** composes — no primitives added or changed; this PR only corrects how the production deploy probe interprets a Cloudflare 200.

### Primitives touched

None. Unmatched paths are `tools/ci/origin-production-deploy-state.ts` and `tools/ci/resource-utils.ts` (script-existence probe only).

### Change flow

A production deploy classifies origin script existence from the Cloudflare Workers API. A 200 multipart script download now counts as present so a known-steady fleet can upload the slim entry.

```mermaid
sequenceDiagram
	actor actions as GitHub Actions deploy
	participant generator as production-resources
	participant appUi as app-ui
	actions->>generator: GET /workers/scripts/:name
	alt 200 JSON or 200 multipart
		generator->>generator: script exists
		generator->>appUi: slim production-worker.ts when ownership is steady
	else 404
		generator->>generator: script missing
	else other probe failure
		generator->>appUi: keep full index.ts (fail closed)
	end
```

### Invariants

Per-user Durable Object storage stays on the owning script. A failed or unknown probe still keeps the full entry and does not bootstrap transfers.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dc059e87-a2bd-4d2f-8692-406b0d7d4f68?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dc059e87-a2bd-4d2f-8692-406b0d7d4f68&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of successful Cloudflare responses containing multipart script data.
  * Existing Worker scripts are now correctly recognized instead of being reported as missing or failed.
  * Prevented unnecessary retries for valid HTTP 200 responses with multipart content.
* **Tests**
  * Added coverage for multipart script downloads, production deployment state detection, and retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->