### PR TITLE
Add npm run dev:ensure for leftover local wrangler sessions

### DIFF
--- a/.agents/skills/testing-multi-worker-dev/SKILL.md
+++ b/.agents/skills/testing-multi-worker-dev/SKILL.md
@@ -13,12 +13,18 @@ description:
 ## Basics
 
 - Node 26 required: `export PATH="$HOME/.nvm/versions/node/v26.7.0/bin:$PATH"`.
-- Run `npm run dev` in tmux; it starts the client watcher, the mock Cloudflare
-  API worker, and `wrangler dev --local` with the origin config, the committed
-  `kody-jobs` config, and generated secondary configs for `kody-runtime` and
-  `kody-platform` in one miniflare. Default port 3742; the CLI picks the next
-  free port if taken — stale `workerd` processes commonly hold 3742, so
-  `pkill -9 workerd` before restarting.
+- To start or reuse the local app, run `npm run dev:ensure`. It probes origin
+  `/health` on 3742–3751, prints `App running at http://localhost:<port>` and
+  exits 0 when a server is already up, replaces a stale kody/workerd leftover
+  that is listening but not serving, then starts `npm run dev` and waits until
+  `/health` is actually ok. Do not inventory Cursor terminal files or curl 3742
+  as a substitute.
+- Run interactive `npm run dev` in tmux when you need the CLI shortcuts; it
+  starts the client watcher, the mock Cloudflare API worker, and
+  `wrangler dev --local` with the origin config, the committed `kody-jobs`
+  config, and generated secondary configs for `kody-runtime` and `kody-platform`
+  in one miniflare. Default port 3742; the CLI picks the next free port if
+  taken.
 - Local dev uses `--env production` (CLOUDFLARE_ENV defaults to production in
   `wrangler-env.ts`).
 - Migrate + seed login: `npm run migrate:local` then

--- a/.cursor/CLOUD.md
+++ b/.cursor/CLOUD.md
@@ -6,7 +6,7 @@ A full-stack web application built on Cloudflare Workers with Remix 3 (beta).
 
 | Task                          | Command                |
 | ----------------------------- | ---------------------- |
-| Start dev server              | `npm run dev`          |
+| Start or reuse dev server     | `npm run dev:ensure`   |
 | Full validation               | `npm run validate`     |
 | Compose Cloud Agent git hooks | `npm run hooks:ensure` |
 | Apply formatter / lint        | `npm run validate:fix` |
@@ -23,10 +23,11 @@ so a green local `validate` means CI will pass. `validate` is read-only; use
 
 ## Services
 
-- **Dev server**: Runs at `localhost:3742` by default (the CLI picks the next
-  free port and prints the resolved URL)
-- `npm run dev` starts both the client esbuild watcher and Wrangler worker
-  server
+- **Dev server**: `npm run dev:ensure` reuses or starts the origin and prints
+  `App running at http://localhost:<port>` once `/health` is ok (default 3742;
+  the CLI hops if that port is taken by a non-kody process)
+- `npm run dev` starts the client esbuild watcher and Wrangler worker server and
+  stays attached for an interactive session
 
 ## Architecture
 

--- a/cli.ts
+++ b/cli.ts
@@ -84,9 +84,7 @@ async function startDev() {
 	const ready = await restartDev({ announce: false })
 	setupInteractiveCli({
 		getWorkerOrigin: () => workerOrigin,
-		restart: async () => {
-			await restartDev()
-		},
+		restart: restartDev,
 		ready,
 	})
 	shutdown = setupShutdown(
@@ -194,17 +192,18 @@ function setupShutdown(
 
 function setupInteractiveCli(options: {
 	getWorkerOrigin: () => string
-	restart: () => Promise<void>
+	restart: () => Promise<boolean>
 	ready: boolean
 }) {
 	const stdin = process.stdin
+	let ready = options.ready
 	if (!stdin.isTTY || typeof stdin.setRawMode !== 'function') {
-		if (options.ready) logAppRunning(options.getWorkerOrigin)
+		if (ready) logAppRunning(options.getWorkerOrigin)
 		return
 	}
 
 	showHelp()
-	if (options.ready) logAppRunning(options.getWorkerOrigin)
+	if (ready) logAppRunning(options.getWorkerOrigin)
 
 	readline.emitKeypressEvents(stdin)
 	stdin.setRawMode(true)
@@ -233,11 +232,13 @@ function setupInteractiveCli(options: {
 			case 'c': {
 				console.clear()
 				showHelp()
-				logAppRunning(options.getWorkerOrigin)
+				if (ready) logAppRunning(options.getWorkerOrigin)
 				break
 			}
 			case 'r': {
-				void options.restart()
+				void options.restart().then((nextReady) => {
+					ready = nextReady
+				})
 				break
 			}
 			case 'h':

--- a/cli.ts
+++ b/cli.ts
@@ -236,6 +236,7 @@ function setupInteractiveCli(options: {
 				break
 			}
 			case 'r': {
+				ready = false
 				void options.restart().then((nextReady) => {
 					ready = nextReady
 				})

--- a/cli.ts
+++ b/cli.ts
@@ -12,9 +12,13 @@ import {
 	createProcessOutputController,
 	type ProcessOutputMode,
 } from './tools/dev-process-output.ts'
+import {
+	defaultHealthTimeoutMs,
+	defaultWorkerPort,
+	isWorkerHealthOk,
+	workerPortRange,
+} from './tools/dev-server.ts'
 import { resolveNpmCommand } from './tools/node-runtime.ts'
-
-const defaultWorkerPort = 3742
 const defaultMockPort = 8788
 const mockReadyTimeoutMs = 10_000
 const mockReadyPollMs = 200
@@ -77,10 +81,13 @@ void startDev().catch((error) => {
 })
 
 async function startDev() {
-	await restartDev({ announce: false })
+	const ready = await restartDev({ announce: false })
 	setupInteractiveCli({
 		getWorkerOrigin: () => workerOrigin,
-		restart: restartDev,
+		restart: async () => {
+			await restartDev()
+		},
+		ready,
 	})
 	shutdown = setupShutdown(
 		() => devChildren,
@@ -188,12 +195,16 @@ function setupShutdown(
 function setupInteractiveCli(options: {
 	getWorkerOrigin: () => string
 	restart: () => Promise<void>
+	ready: boolean
 }) {
 	const stdin = process.stdin
-	if (!stdin.isTTY || typeof stdin.setRawMode !== 'function') return
+	if (!stdin.isTTY || typeof stdin.setRawMode !== 'function') {
+		if (options.ready) logAppRunning(options.getWorkerOrigin)
+		return
+	}
 
 	showHelp()
-	logAppRunning(options.getWorkerOrigin)
+	if (options.ready) logAppRunning(options.getWorkerOrigin)
 
 	readline.emitKeypressEvents(stdin)
 	stdin.setRawMode(true)
@@ -268,10 +279,7 @@ async function restartDev(
 		process.env.PORT ?? String(defaultWorkerPort),
 		10,
 	)
-	const portRange = Array.from(
-		{ length: 10 },
-		(_, index) => desiredPort + index,
-	)
+	const portRange = workerPortRange(desiredPort)
 	clearLockedPorts()
 	const workerPort = await getPort({ port: portRange })
 	workerOrigin = resolveWorkerOrigin(workerPort)
@@ -319,6 +327,7 @@ async function restartDev(
 		// Only claim the app is running when /health actually responded.
 		if (workerDidStart) logAppRunning(() => workerOrigin)
 	}
+	return workerDidStart
 }
 
 function hasEnvValue(value: string | undefined) {
@@ -354,13 +363,7 @@ async function waitForMockReady(baseUrl: string, child: ChildProcess) {
 }
 
 async function isWorkerReady(workerOrigin: string) {
-	try {
-		const response = await fetch(`${workerOrigin}/health`)
-		await response.body?.cancel()
-		return response.ok
-	} catch {
-		return false
-	}
+	return isWorkerHealthOk(workerOrigin, { timeoutMs: defaultHealthTimeoutMs })
 }
 
 async function waitForWorkerReady(workerOrigin: string, child: ChildProcess) {

--- a/docs/contributing/cloud-agents.md
+++ b/docs/contributing/cloud-agents.md
@@ -80,7 +80,7 @@ dispatcher. The command is a no-op on machines without `~/.cursor/agent-hooks`.
 | Task               | Command                                                         |
 | ------------------ | --------------------------------------------------------------- |
 | Install deps       | `npm install`                                                   |
-| Start dev          | `npm run dev` (prints the resolved URL)                         |
+| Start or reuse dev | `npm run dev:ensure` (prints the resolved URL)                  |
 | Migrate local D1   | `npm run migrate:local`                                         |
 | Seed test login    | `node tools/seed-test-data.ts --local` (see seeding note below) |
 | Full validate gate | `npm run validate` (CI runs the same checks as parallel jobs)   |
@@ -88,12 +88,20 @@ dispatcher. The command is a no-op on machines without `~/.cursor/agent-hooks`.
 
 ## Dev server
 
+- `npm run dev:ensure` is the agent entry point. It probes origin `/health` on
+  3742–3751, prints `App running at http://localhost:<port>` and exits 0 when a
+  server is already up, replaces a stale kody/workerd leftover that accepts TCP
+  but does not serve `/health`, then starts `npm run dev` and waits until
+  `/health` is actually ok before printing the resolved URL.
 - `npm run dev` starts the client esbuild watcher, optional Cloudflare API mock
   worker, and Wrangler with origin plus generated platform, runtime, and jobs
-  siblings in one Miniflare (local D1/KV/DO persistence).
+  siblings in one Miniflare (local D1/KV/DO persistence). Non-TTY sessions print
+  `App running at` only after `/health` responds.
 - Default worker port is **3742** (`cli.ts`); the CLI picks a free port when
   3742 is taken and prints `App running at http://localhost:<port>`.
-- Run long-lived dev in tmux so the session survives tool timeouts.
+- Run long-lived interactive `npm run dev` in tmux so the session survives tool
+  timeouts. `dev:ensure` detaches the started process so the ensure command can
+  exit.
 - Health check (no auth): `curl http://localhost:<port>/health` →
   `{"ok":true,"commitSha":...,"commit":...,"pullRequest":...,"deploy":...}`.
   Locally the extra fields are `null` unless a deploy var is set. Platform and

--- a/docs/contributing/getting-started.md
+++ b/docs/contributing/getting-started.md
@@ -81,10 +81,13 @@ npm run migrate:local
 3. Start local development:
 
 ```bash
-npm run dev
+npm run dev:ensure
 ```
 
-The CLI prints the resolved URL (default port `3742`). Health check:
+That reuses a healthy origin if one is already up, otherwise starts
+`npm run dev`. Either way it prints the resolved URL (default port `3742`) once
+`/health` is ok. For an interactive session, run `npm run dev` instead. Health
+check:
 
 ```bash
 curl http://localhost:<port>/health

--- a/docs/contributing/setup/index.md
+++ b/docs/contributing/setup/index.md
@@ -4,7 +4,7 @@ Quick notes for getting a local kody environment running. Load only the page you
 need.
 
 - [Local development](./local-development.md) — prerequisites, install,
-  `npm run dev`, D1/KV, mocks, and env files
+  `npm run dev` / `npm run dev:ensure`, D1/KV, mocks, and env files
 - [Checks](./checks.md) — Husky hooks, `npm run validate`, and test commands
 - [Authoring D1 migrations](./migrations.md)
 - [Documentation maintenance](./documentation-maintenance.md)

--- a/docs/contributing/setup/local-development.md
+++ b/docs/contributing/setup/local-development.md
@@ -37,6 +37,11 @@ Prerequisites, install, and `npm run dev` notes. See the
   values for `COOKIE_SECRET` and `SECRET_STORE_KEY`; all environments must set
   both secrets (see
   [`docs/contributing/secret-rotation.md`](../secret-rotation.md)).
+- `npm run dev:ensure` reuses a healthy origin `/health` on 3742–3751 (prints
+  `App running at http://localhost:<port>` and exits 0), replaces a stale
+  kody/workerd leftover that is listening but not serving, then starts
+  `npm run dev` and waits until `/health` is ok. Agents should call this instead
+  of reconstructing a startup playbook from terminal files.
 - `npm run dev` starts mock API servers automatically plus origin, platform,
   runtime, and jobs in one Miniflare; it sets `CLOUDFLARE_API_BASE_URL`,
   `CLOUDFLARE_API_TOKEN`, and `CLOUDFLARE_ACCOUNT_ID` to the local Cloudflare

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "scripts": {
     "dev": "node --env-file=packages/worker/.env cli.ts",
+    "dev:ensure": "node --env-file=packages/worker/.env tools/ensure-dev.ts",
     "dev:client": "npm run dev:client:web",
     "clean:client": "node -e \"const{rmSync}=require('node:fs');for(const p of ['packages/worker/public/assets','packages/worker/public/client-manifest.json'])rmSync(p,{recursive:true,force:true})\"",
     "dev:client:web": "npm run clean:client && esbuild packages/worker/client/entry.tsx --bundle --splitting --format=esm --target=es2022 --outdir=packages/worker/public --entry-names=client-entry --chunk-names=assets/[name]-[hash] --asset-names=assets/[name] --jsx=automatic --jsx-import-source=remix/ui --watch",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "scripts": {
     "dev": "node --env-file=packages/worker/.env cli.ts",
-    "dev:ensure": "node --env-file=packages/worker/.env tools/ensure-dev.ts",
+    "dev:ensure": "node --env-file-if-exists=packages/worker/.env tools/ensure-dev.ts",
     "dev:client": "npm run dev:client:web",
     "clean:client": "node -e \"const{rmSync}=require('node:fs');for(const p of ['packages/worker/public/assets','packages/worker/public/client-manifest.json'])rmSync(p,{recursive:true,force:true})\"",
     "dev:client:web": "npm run clean:client && esbuild packages/worker/client/entry.tsx --bundle --splitting --format=esm --target=es2022 --outdir=packages/worker/public --entry-names=client-entry --chunk-names=assets/[name]-[hash] --asset-names=assets/[name] --jsx=automatic --jsx-import-source=remix/ui --watch",

--- a/tools/dev-server.node.test.ts
+++ b/tools/dev-server.node.test.ts
@@ -1,0 +1,100 @@
+import http from 'node:http'
+import { type AddressInfo } from 'node:net'
+import { expect, test } from 'vitest'
+import {
+	findHealthyWorkerOrigin,
+	healthUrlForOrigin,
+	isWorkerHealthOk,
+	parsePortFromOrigin,
+	workerOriginForPort,
+	workerPortRange,
+} from './dev-server.ts'
+
+function listenHealthServer() {
+	const server = http.createServer((request, response) => {
+		if (request.url === '/health') {
+			response.writeHead(200, { 'content-type': 'application/json' })
+			response.end(JSON.stringify({ ok: true }))
+			return
+		}
+		response.writeHead(404)
+		response.end()
+	})
+	return {
+		server,
+		async listen() {
+			await new Promise<void>((resolve) => {
+				server.listen(0, '127.0.0.1', () => resolve())
+			})
+			const address = server.address() as AddressInfo
+			return address.port
+		},
+		async close() {
+			await new Promise<void>((resolve, reject) => {
+				server.close((error) => {
+					if (error) reject(error)
+					else resolve()
+				})
+			})
+		},
+	}
+}
+
+test('findHealthyWorkerOrigin returns the first origin whose /health is ok', async () => {
+	const probed: Array<string> = []
+	const origin = await findHealthyWorkerOrigin([3742, 3743, 3744], {
+		probe: async (candidate) => {
+			probed.push(candidate)
+			return candidate === 'http://localhost:3743'
+		},
+	})
+	expect(origin).toBe('http://localhost:3743')
+	expect(probed).toEqual(['http://localhost:3742', 'http://localhost:3743'])
+	expect(workerPortRange(3742, 3)).toEqual([3742, 3743, 3744])
+	expect(workerOriginForPort(3742)).toBe('http://localhost:3742')
+	expect(healthUrlForOrigin('http://localhost:3742/')).toBe(
+		'http://localhost:3742/health',
+	)
+	expect(parsePortFromOrigin('http://localhost:3743')).toBe(3743)
+})
+
+test('isWorkerHealthOk treats hung or failed /health as down', async () => {
+	const ok = await isWorkerHealthOk('http://localhost:3742', {
+		timeoutMs: 20,
+		fetchImpl: async () =>
+			new Response(JSON.stringify({ ok: true }), { status: 200 }),
+	})
+	expect(ok).toBe(true)
+
+	const refused = await isWorkerHealthOk('http://localhost:3742', {
+		timeoutMs: 20,
+		fetchImpl: async () => {
+			throw new Error('connect ECONNREFUSED')
+		},
+	})
+	expect(refused).toBe(false)
+
+	const hung = await isWorkerHealthOk('http://localhost:3742', {
+		timeoutMs: 20,
+		fetchImpl: async (_url, init) => {
+			await new Promise<never>((_resolve, reject) => {
+				init?.signal?.addEventListener('abort', () => {
+					reject(new DOMException('aborted', 'AbortError'))
+				})
+			})
+			return new Response('late')
+		},
+	})
+	expect(hung).toBe(false)
+})
+
+test('isWorkerHealthOk accepts a real HTTP /health listener', async () => {
+	const health = listenHealthServer()
+	try {
+		const port = await health.listen()
+		expect(await isWorkerHealthOk(`http://127.0.0.1:${port}`)).toBe(true)
+		expect(await isWorkerHealthOk(`http://127.0.0.1:${port + 1}`)).toBe(false)
+	} finally {
+		await health.close()
+	}
+})

--- a/tools/dev-server.ts
+++ b/tools/dev-server.ts
@@ -1,0 +1,87 @@
+import { isExecutedDirectly } from './node-runtime.ts'
+
+export const defaultWorkerPort = 3742
+export const defaultWorkerPortCount = 10
+export const defaultHealthTimeoutMs = 1_500
+
+export function workerPortRange(
+	startPort = defaultWorkerPort,
+	count = defaultWorkerPortCount,
+) {
+	return Array.from({ length: count }, (_, index) => startPort + index)
+}
+
+export function workerOriginForPort(port: number) {
+	return `http://localhost:${port}`
+}
+
+export function healthUrlForOrigin(origin: string) {
+	return `${origin.replace(/\/$/, '')}/health`
+}
+
+export function parsePortFromOrigin(origin: string) {
+	try {
+		const port = Number.parseInt(new URL(origin).port, 10)
+		return Number.isFinite(port) && port > 0 ? port : null
+	} catch {
+		return null
+	}
+}
+
+export async function isWorkerHealthOk(
+	origin: string,
+	options: {
+		timeoutMs?: number
+		fetchImpl?: typeof fetch
+	} = {},
+) {
+	const timeoutMs = options.timeoutMs ?? defaultHealthTimeoutMs
+	const fetchImpl = options.fetchImpl ?? fetch
+	const controller = new AbortController()
+	const timer = setTimeout(() => {
+		controller.abort()
+	}, timeoutMs)
+	try {
+		const response = await fetchImpl(healthUrlForOrigin(origin), {
+			signal: controller.signal,
+		})
+		await response.body?.cancel()
+		return response.ok
+	} catch {
+		return false
+	} finally {
+		clearTimeout(timer)
+	}
+}
+
+export async function findHealthyWorkerOrigin(
+	ports: ReadonlyArray<number>,
+	options: {
+		timeoutMs?: number
+		fetchImpl?: typeof fetch
+		probe?: (origin: string) => Promise<boolean>
+	} = {},
+) {
+	const probe =
+		options.probe ??
+		((origin: string) =>
+			isWorkerHealthOk(origin, {
+				timeoutMs: options.timeoutMs,
+				fetchImpl: options.fetchImpl,
+			}))
+	for (const port of ports) {
+		const origin = workerOriginForPort(port)
+		if (await probe(origin)) return origin
+	}
+	return null
+}
+
+if (isExecutedDirectly(import.meta.url)) {
+	const origin = await findHealthyWorkerOrigin(workerPortRange())
+	if (origin) {
+		console.log(`App running at ${origin}`)
+		process.exit(0)
+	}
+	console.error('No healthy local origin found.')
+	process.exit(1)
+}

--- a/tools/ensure-dev.node.test.ts
+++ b/tools/ensure-dev.node.test.ts
@@ -1,0 +1,278 @@
+import { expect, test } from 'vitest'
+import {
+	collectAncestorPids,
+	collectKodyDevKillPids,
+	ensureDev,
+	envWithPreferredNode26,
+	isKodyDevProcess,
+	parseLsofListenPids,
+	parseSsListenPids,
+	replaceStaleKodyListeners,
+	resolveNode26BinDir,
+	waitForHealthyOrigin,
+	type ProcessIdentity,
+} from './ensure-dev.ts'
+
+test('isKodyDevProcess recognizes leftover wrangler/workerd/cli sessions and ignores others', () => {
+	expect(
+		isKodyDevProcess({ comm: 'workerd', cmdline: '/opt/workerd --socket' }),
+	).toBe(true)
+	expect(
+		isKodyDevProcess({
+			comm: 'node',
+			cmdline:
+				'node --env-file=packages/worker/.env ./wrangler-env.ts dev --local',
+		}),
+	).toBe(true)
+	expect(
+		isKodyDevProcess({
+			comm: 'node',
+			cmdline: 'node --env-file=packages/worker/.env cli.ts',
+		}),
+	).toBe(true)
+	expect(
+		isKodyDevProcess({
+			comm: 'npm',
+			cmdline: 'npm run dev',
+		}),
+	).toBe(true)
+	expect(
+		isKodyDevProcess({
+			comm: 'npm',
+			cmdline: 'npm run --silent dev:worker',
+		}),
+	).toBe(true)
+	expect(
+		isKodyDevProcess({
+			comm: 'node',
+			cmdline: 'node tools/ensure-dev.ts',
+		}),
+	).toBe(false)
+	expect(
+		isKodyDevProcess({
+			comm: 'node',
+			cmdline: 'node some-other-server.js',
+		}),
+	).toBe(false)
+	expect(
+		isKodyDevProcess({
+			comm: 'nginx',
+			cmdline: 'nginx: master process',
+		}),
+	).toBe(false)
+})
+
+test('collectKodyDevKillPids walks only kody leftovers and never protected ancestors', () => {
+	const processes = new Map<number, ProcessIdentity>([
+		[40, { pid: 40, ppid: 1, comm: 'bash', cmdline: '-bash' }],
+		[41, { pid: 41, ppid: 40, comm: 'npm', cmdline: 'npm run dev' }],
+		[
+			42,
+			{
+				pid: 42,
+				ppid: 41,
+				comm: 'node',
+				cmdline: 'node --env-file=packages/worker/.env cli.ts',
+			},
+		],
+		[43, { pid: 43, ppid: 42, comm: 'workerd', cmdline: 'workerd' }],
+	])
+	expect(
+		collectKodyDevKillPids({
+			startPid: 43,
+			readProcess: (pid) => processes.get(pid) ?? null,
+			protectedPids: new Set([40, 99]),
+		}),
+	).toEqual([43, 42, 41])
+	expect(
+		collectKodyDevKillPids({
+			startPid: 43,
+			readProcess: (pid) => processes.get(pid) ?? null,
+			protectedPids: new Set([42, 99]),
+		}),
+	).toEqual([43])
+	expect(
+		collectAncestorPids(43, (pid) => processes.get(pid)?.ppid ?? null),
+	).toEqual(new Set([43, 42, 41, 40]))
+})
+
+test('ensureDev reuses a healthy origin without starting or killing', async () => {
+	const logs: Array<string> = []
+	const started: Array<string> = []
+	const killed: Array<string> = []
+	const result = await ensureDev({
+		ports: [3742, 3743],
+		probeHealth: async (origin) => origin === 'http://localhost:3743',
+		listListenerPids: () => [99],
+		readProcess: () => ({
+			pid: 99,
+			ppid: 1,
+			comm: 'workerd',
+			cmdline: 'workerd',
+		}),
+		protectedPids: new Set([1]),
+		killProcess: (pid, signal) => {
+			killed.push(`${pid}:${signal}`)
+		},
+		startDev: () => {
+			started.push('start')
+			return { unref() {} }
+		},
+		sleep: async () => {},
+		now: () => 0,
+		readyTimeoutMs: 1_000,
+		readyPollMs: 10,
+		log: (line) => {
+			logs.push(line)
+		},
+	})
+	expect(result).toEqual({
+		status: 'reused',
+		origin: 'http://localhost:3743',
+	})
+	expect(logs).toEqual(['App running at http://localhost:3743'])
+	expect(started).toEqual([])
+	expect(killed).toEqual([])
+})
+
+test('ensureDev replaces a stale workerd leftover then starts until /health is ok', async () => {
+	const logs: Array<string> = []
+	const killed: Array<string> = []
+	let healthy = false
+	const processes = new Map<number, ProcessIdentity>([
+		[
+			700,
+			{ pid: 700, ppid: 1, comm: 'workerd', cmdline: 'workerd --port 3742' },
+		],
+	])
+	const result = await ensureDev({
+		ports: [3742],
+		probeHealth: async () => healthy,
+		listListenerPids: (port) =>
+			port === 3742 && processes.has(700) ? [700] : [],
+		readProcess: (pid) => processes.get(pid) ?? null,
+		protectedPids: new Set([1, process.pid]),
+		killProcess: (pid) => {
+			killed.push(String(pid))
+			processes.delete(pid)
+		},
+		startDev: () => {
+			healthy = true
+			return { unref() {} }
+		},
+		sleep: async () => {},
+		now: () => 0,
+		readyTimeoutMs: 1_000,
+		readyPollMs: 10,
+		log: (line) => {
+			logs.push(line)
+		},
+	})
+	expect(result).toEqual({
+		status: 'started',
+		origin: 'http://localhost:3742',
+		replacedPids: [700],
+	})
+	expect(killed).toEqual(['700'])
+	expect(logs[0]).toBe(
+		'Replaced stale kody listener pid=700 comm=workerd port=3742',
+	)
+	expect(logs.at(-1)).toBe('App running at http://localhost:3742')
+})
+
+test('replaceStaleKodyListeners leaves a non-kody occupant on the port', async () => {
+	const killed: Array<number> = []
+	const replaced = await replaceStaleKodyListeners({
+		ports: [3742],
+		probeHealth: async () => false,
+		listListenerPids: () => [55],
+		readProcess: () => ({
+			pid: 55,
+			ppid: 1,
+			comm: 'nginx',
+			cmdline: 'nginx: master process',
+		}),
+		protectedPids: new Set([1]),
+		killProcess: (pid) => {
+			killed.push(pid)
+		},
+		sleep: async () => {},
+		log: () => {},
+	})
+	expect(replaced).toEqual([])
+	expect(killed).toEqual([])
+})
+
+test('waitForHealthyOrigin polls until /health responds or the budget ends', async () => {
+	let calls = 0
+	const origin = await waitForHealthyOrigin({
+		ports: [3742],
+		probeHealth: async () => {
+			calls += 1
+			return calls >= 3
+		},
+		timeoutMs: 1_000,
+		pollMs: 1,
+		now: (() => {
+			let t = 0
+			return () => {
+				t += 1
+				return t
+			}
+		})(),
+		sleep: async () => {},
+	})
+	expect(origin).toBe('http://localhost:3742')
+
+	const missed = await waitForHealthyOrigin({
+		ports: [3742],
+		probeHealth: async () => false,
+		timeoutMs: 2,
+		pollMs: 1,
+		now: (() => {
+			let t = 0
+			return () => {
+				t += 1
+				return t
+			}
+		})(),
+		sleep: async () => {},
+	})
+	expect(missed).toBeNull()
+})
+
+test('lsof and ss listener pid parsers ignore junk', () => {
+	expect(parseLsofListenPids('700\n701\n\nbad\n700\n')).toEqual([700, 701])
+	expect(
+		parseSsListenPids(
+			'LISTEN 0 511 127.0.0.1:3742 0.0.0.0:* users:(("workerd",pid=700,fd=3))\n',
+		),
+	).toEqual([700])
+})
+
+test('envWithPreferredNode26 prepends nvm Node 26 only when the current runtime is older', () => {
+	const homeDir = '/home/agent'
+	const readDir = (dir: string) => {
+		expect(dir).toBe('/home/agent/.nvm/versions/node')
+		return ['v22.17.0', 'v26.7.0', 'v26.4.0']
+	}
+	const hasNodeBin = () => true
+	expect(
+		envWithPreferredNode26(
+			{ PATH: '/exec-daemon:/usr/bin' },
+			{ nodeMajor: 26, homeDir, readDir, hasNodeBin },
+		).PATH,
+	).toBe('/exec-daemon:/usr/bin')
+	expect(
+		envWithPreferredNode26(
+			{ PATH: '/exec-daemon:/usr/bin' },
+			{ nodeMajor: 22, homeDir, readDir, hasNodeBin },
+		).PATH,
+	).toBe('/home/agent/.nvm/versions/node/v26.7.0/bin:/exec-daemon:/usr/bin')
+
+	const binDir = resolveNode26BinDir(homeDir, {
+		readDir: () => ['v26.7.0'],
+		hasNodeBin: () => true,
+	})
+	expect(binDir).toBe('/home/agent/.nvm/versions/node/v26.7.0/bin')
+})

--- a/tools/ensure-dev.node.test.ts
+++ b/tools/ensure-dev.node.test.ts
@@ -5,6 +5,7 @@ import {
 	ensureDev,
 	envWithPreferredNode26,
 	isKodyDevProcess,
+	isKodyDevSupervisor,
 	parseLsofListenPids,
 	parseSsListenPids,
 	replaceStaleKodyListeners,
@@ -60,6 +61,15 @@ test('isKodyDevProcess recognizes leftover wrangler/workerd/cli sessions and ign
 			cmdline: 'nginx: master process',
 		}),
 	).toBe(false)
+	expect(
+		isKodyDevSupervisor({ comm: 'workerd', cmdline: 'workerd --socket' }),
+	).toBe(false)
+	expect(
+		isKodyDevSupervisor({
+			comm: 'node',
+			cmdline: 'node --env-file=packages/worker/.env cli.ts',
+		}),
+	).toBe(true)
 })
 
 test('collectKodyDevKillPids walks only kody leftovers and never protected ancestors', () => {
@@ -90,7 +100,19 @@ test('collectKodyDevKillPids walks only kody leftovers and never protected ances
 			readProcess: (pid) => processes.get(pid) ?? null,
 			protectedPids: new Set([42, 99]),
 		}),
-	).toEqual([43])
+	).toEqual([])
+	expect(
+		collectKodyDevKillPids({
+			startPid: 700,
+			readProcess: () => ({
+				pid: 700,
+				ppid: 1,
+				comm: 'workerd',
+				cmdline: 'workerd --port 3742',
+			}),
+			protectedPids: new Set([1]),
+		}),
+	).toEqual([])
 	expect(
 		collectAncestorPids(43, (pid) => processes.get(pid)?.ppid ?? null),
 	).toEqual(new Set([43, 42, 41, 40]))
@@ -116,7 +138,7 @@ test('ensureDev reuses a healthy origin without starting or killing', async () =
 		},
 		startDev: () => {
 			started.push('start')
-			return { unref() {} }
+			return { unref() {}, async stop() {} }
 		},
 		sleep: async () => {},
 		now: () => 0,
@@ -140,9 +162,10 @@ test('ensureDev replaces a stale workerd leftover then starts until /health is o
 	const killed: Array<string> = []
 	let healthy = false
 	const processes = new Map<number, ProcessIdentity>([
+		[699, { pid: 699, ppid: 1, comm: 'npm', cmdline: 'npm run dev' }],
 		[
 			700,
-			{ pid: 700, ppid: 1, comm: 'workerd', cmdline: 'workerd --port 3742' },
+			{ pid: 700, ppid: 699, comm: 'workerd', cmdline: 'workerd --port 3742' },
 		],
 	])
 	const result = await ensureDev({
@@ -158,7 +181,7 @@ test('ensureDev replaces a stale workerd leftover then starts until /health is o
 		},
 		startDev: () => {
 			healthy = true
-			return { unref() {} }
+			return { unref() {}, async stop() {} }
 		},
 		sleep: async () => {},
 		now: () => 0,
@@ -171,11 +194,11 @@ test('ensureDev replaces a stale workerd leftover then starts until /health is o
 	expect(result).toEqual({
 		status: 'started',
 		origin: 'http://localhost:3742',
-		replacedPids: [700],
+		replacedPids: [699, 700],
 	})
-	expect(killed).toEqual(['700'])
+	expect(killed).toEqual(['699', '700'])
 	expect(logs[0]).toBe(
-		'Replaced stale kody listener pid=700 comm=workerd port=3742',
+		'Replaced stale kody listener pid=699 comm=npm port=3742',
 	)
 	expect(logs.at(-1)).toBe('App running at http://localhost:3742')
 })
@@ -275,4 +298,37 @@ test('envWithPreferredNode26 prepends nvm Node 26 only when the current runtime 
 		hasNodeBin: () => true,
 	})
 	expect(binDir).toBe('/home/agent/.nvm/versions/node/v26.7.0/bin')
+})
+
+test('ensureDev stops the child and surfaces output when /health never becomes ready', async () => {
+	const stopped: Array<string> = []
+	await expect(
+		ensureDev({
+			ports: [3742],
+			probeHealth: async () => false,
+			listListenerPids: () => [],
+			readProcess: () => null,
+			protectedPids: new Set([1]),
+			killProcess: () => {},
+			startDev: () => ({
+				unref() {},
+				async stop() {
+					stopped.push('stop')
+				},
+				lastOutput: () => 'Reloading local server...',
+			}),
+			sleep: async () => {},
+			now: (() => {
+				let t = 0
+				return () => {
+					t += 1
+					return t
+				}
+			})(),
+			readyTimeoutMs: 2,
+			readyPollMs: 1,
+			log: () => {},
+		}),
+	).rejects.toThrow(/Reloading local server/)
+	expect(stopped).toEqual(['stop'])
 })

--- a/tools/ensure-dev.ts
+++ b/tools/ensure-dev.ts
@@ -32,6 +32,13 @@ export type EnsureDevResult =
 	| { status: 'reused'; origin: string }
 	| { status: 'started'; origin: string; replacedPids: Array<number> }
 
+export type StartedDevHandle = {
+	unref: () => void
+	stop: () => Promise<void>
+	hasExited?: () => boolean
+	lastOutput?: () => string
+}
+
 export type EnsureDevDeps = {
 	ports: ReadonlyArray<number>
 	probeHealth: (origin: string) => Promise<boolean>
@@ -39,7 +46,7 @@ export type EnsureDevDeps = {
 	readProcess: (pid: number) => ProcessIdentity | null
 	protectedPids: ReadonlySet<number>
 	killProcess: (pid: number, signal: NodeJS.Signals) => void
-	startDev: () => { unref: () => void }
+	startDev: () => StartedDevHandle
 	sleep: (ms: number) => Promise<void>
 	now: () => number
 	readyTimeoutMs: number
@@ -47,15 +54,26 @@ export type EnsureDevDeps = {
 	log: (line: string) => void
 }
 
-export function isKodyDevProcess(identity: {
+function normalizeCmdline(cmdline: string) {
+	return cmdline.toLowerCase().replaceAll('\0', ' ')
+}
+
+export function isWorkerdProcess(identity: { comm: string; cmdline: string }) {
+	const comm = identity.comm.toLowerCase()
+	const cmdline = normalizeCmdline(identity.cmdline)
+	return (
+		comm === 'workerd' ||
+		comm.includes('workerd') ||
+		cmdline.includes('workerd')
+	)
+}
+
+export function isKodyDevSupervisor(identity: {
 	comm: string
 	cmdline: string
-}): boolean {
-	const comm = identity.comm.toLowerCase()
-	const cmdline = identity.cmdline.toLowerCase().replaceAll('\0', ' ')
+}) {
+	const cmdline = normalizeCmdline(identity.cmdline)
 	if (cmdline.includes('ensure-dev')) return false
-	if (comm === 'workerd' || comm.includes('workerd')) return true
-	if (cmdline.includes('workerd')) return true
 	if (cmdline.includes('wrangler-env.ts') && cmdline.includes('dev')) {
 		return true
 	}
@@ -64,6 +82,10 @@ export function isKodyDevProcess(identity: {
 		return /(?:^|\s)dev(?::worker)?(?:\s|$)/.test(cmdline)
 	}
 	return false
+}
+
+export function isKodyDevProcess(identity: { comm: string; cmdline: string }) {
+	return isWorkerdProcess(identity) || isKodyDevSupervisor(identity)
 }
 
 export function collectAncestorPids(
@@ -90,19 +112,26 @@ export function collectKodyDevKillPids(input: {
 	maxWalk?: number
 }) {
 	const maxWalk = input.maxWalk ?? 8
-	const pids: Array<number> = []
+	const chain: Array<{ pid: number; identity: ProcessIdentity }> = []
 	let pid = input.startPid
 	for (let index = 0; index < maxWalk; index += 1) {
-		if (pid <= 1 || input.protectedPids.has(pid) || pids.includes(pid)) {
+		if (
+			pid <= 1 ||
+			input.protectedPids.has(pid) ||
+			chain.some((entry) => entry.pid === pid)
+		) {
 			break
 		}
 		const identity = input.readProcess(pid)
 		if (!identity || !isKodyDevProcess(identity)) break
-		pids.push(pid)
+		chain.push({ pid, identity })
 		if (identity.ppid <= 1 || identity.ppid === pid) break
 		pid = identity.ppid
 	}
-	return pids
+	if (!chain.some((entry) => isKodyDevSupervisor(entry.identity))) {
+		return []
+	}
+	return chain.map((entry) => entry.pid)
 }
 
 export function parseLsofListenPids(stdout: string) {
@@ -293,12 +322,14 @@ export async function ensureDev(deps: EnsureDevDeps): Promise<EnsureDevResult> {
 		pollMs: deps.readyPollMs,
 		now: deps.now,
 		sleep: deps.sleep,
+		isCancelled: started.hasExited,
 	})
 	if (!origin) {
-		started.unref()
+		const output = started.lastOutput?.()?.trim()
+		await started.stop()
 		throw new Error(
-			`Local app did not become ready on ${deps.ports[0]}-${deps.ports.at(-1)} within ${deps.readyTimeoutMs}ms. ` +
-				`Check wrangler output from \`npm run dev\`.`,
+			`Local app did not become ready on ${deps.ports[0]}-${deps.ports.at(-1)} within ${deps.readyTimeoutMs}ms.` +
+				(output ? `\n${output}` : ' Check wrangler output from `npm run dev`.'),
 		)
 	}
 	started.unref()
@@ -346,13 +377,14 @@ function defaultKillProcess(pid: number, signal: NodeJS.Signals) {
 	}
 }
 
-function createDefaultStartDev(env: NodeJS.ProcessEnv) {
+function createDefaultStartDev(env: NodeJS.ProcessEnv): StartedDevHandle {
 	const child = spawnInOwnProcessGroup(resolveNpmCommand(), ['run', 'dev'], {
 		stdio: ['ignore', 'pipe', 'pipe'],
 		env,
 		cwd: process.cwd(),
 	})
 	const buffered: Array<string> = []
+	let exited = false
 	const onLine = (chunk: Buffer | string) => {
 		const text = chunk.toString()
 		for (const line of text.split(/\r?\n/)) {
@@ -364,19 +396,28 @@ function createDefaultStartDev(env: NodeJS.ProcessEnv) {
 	child.stdout?.on('data', onLine)
 	child.stderr?.on('data', onLine)
 	child.once('exit', (code, signal) => {
+		exited = true
 		if (code && code !== 0) {
 			console.error(
 				`npm run dev exited (${signal ?? `code ${code}`}). Last output:\n${buffered.join('\n')}`,
 			)
 		}
 	})
+	function detachPipes() {
+		child.stdout?.removeAllListeners()
+		child.stderr?.removeAllListeners()
+		child.stdout?.destroy()
+		child.stderr?.destroy()
+	}
 	return {
+		hasExited: () => exited || child.exitCode !== null,
+		lastOutput: () => buffered.join('\n'),
 		unref() {
-			child.stdout?.resume()
-			child.stderr?.resume()
+			detachPipes()
 			child.unref()
 		},
 		async stop() {
+			detachPipes()
 			await stopChildProcessTree(child)
 		},
 	}
@@ -420,8 +461,8 @@ export async function main() {
 
 if (isExecutedDirectly(import.meta.url)) {
 	void main()
-		.then((result) => {
-			process.exitCode = result ? 0 : 1
+		.then(() => {
+			process.exit(0)
 		})
 		.catch((error) => {
 			console.error(error instanceof Error ? error.message : error)

--- a/tools/ensure-dev.ts
+++ b/tools/ensure-dev.ts
@@ -1,0 +1,430 @@
+import { spawnSync } from 'node:child_process'
+import { existsSync, readdirSync, readFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import path from 'node:path'
+import { setTimeout as delay } from 'node:timers/promises'
+import {
+	spawnInOwnProcessGroup,
+	stopChildProcessTree,
+} from './dev-process-utils.ts'
+import {
+	defaultHealthTimeoutMs,
+	defaultWorkerPort,
+	findHealthyWorkerOrigin,
+	isWorkerHealthOk,
+	workerOriginForPort,
+	workerPortRange,
+} from './dev-server.ts'
+import { isExecutedDirectly, resolveNpmCommand } from './node-runtime.ts'
+
+export const defaultReadyTimeoutMs = 120_000
+export const defaultReadyPollMs = 500
+export const defaultStaleKillWaitMs = 2_000
+
+export type ProcessIdentity = {
+	pid: number
+	ppid: number
+	comm: string
+	cmdline: string
+}
+
+export type EnsureDevResult =
+	| { status: 'reused'; origin: string }
+	| { status: 'started'; origin: string; replacedPids: Array<number> }
+
+export type EnsureDevDeps = {
+	ports: ReadonlyArray<number>
+	probeHealth: (origin: string) => Promise<boolean>
+	listListenerPids: (port: number) => Array<number>
+	readProcess: (pid: number) => ProcessIdentity | null
+	protectedPids: ReadonlySet<number>
+	killProcess: (pid: number, signal: NodeJS.Signals) => void
+	startDev: () => { unref: () => void }
+	sleep: (ms: number) => Promise<void>
+	now: () => number
+	readyTimeoutMs: number
+	readyPollMs: number
+	log: (line: string) => void
+}
+
+export function isKodyDevProcess(identity: {
+	comm: string
+	cmdline: string
+}): boolean {
+	const comm = identity.comm.toLowerCase()
+	const cmdline = identity.cmdline.toLowerCase().replaceAll('\0', ' ')
+	if (cmdline.includes('ensure-dev')) return false
+	if (comm === 'workerd' || comm.includes('workerd')) return true
+	if (cmdline.includes('workerd')) return true
+	if (cmdline.includes('wrangler-env.ts') && cmdline.includes('dev')) {
+		return true
+	}
+	if (cmdline.includes('cli.ts')) return true
+	if (/\bnpm\b/.test(cmdline) && /\brun\b/.test(cmdline)) {
+		return /(?:^|\s)dev(?::worker)?(?:\s|$)/.test(cmdline)
+	}
+	return false
+}
+
+export function collectAncestorPids(
+	startPid: number,
+	readParentPid: (pid: number) => number | null,
+	maxWalk = 12,
+) {
+	const pids = new Set<number>()
+	let pid = startPid
+	for (let index = 0; index < maxWalk; index += 1) {
+		if (pid <= 1 || pids.has(pid)) break
+		pids.add(pid)
+		const ppid = readParentPid(pid)
+		if (ppid == null || ppid <= 1 || ppid === pid) break
+		pid = ppid
+	}
+	return pids
+}
+
+export function collectKodyDevKillPids(input: {
+	startPid: number
+	readProcess: (pid: number) => ProcessIdentity | null
+	protectedPids: ReadonlySet<number>
+	maxWalk?: number
+}) {
+	const maxWalk = input.maxWalk ?? 8
+	const pids: Array<number> = []
+	let pid = input.startPid
+	for (let index = 0; index < maxWalk; index += 1) {
+		if (pid <= 1 || input.protectedPids.has(pid) || pids.includes(pid)) {
+			break
+		}
+		const identity = input.readProcess(pid)
+		if (!identity || !isKodyDevProcess(identity)) break
+		pids.push(pid)
+		if (identity.ppid <= 1 || identity.ppid === pid) break
+		pid = identity.ppid
+	}
+	return pids
+}
+
+export function parseLsofListenPids(stdout: string) {
+	const pids = new Set<number>()
+	for (const line of stdout.split(/\r?\n/)) {
+		const trimmed = line.trim()
+		if (!trimmed) continue
+		const pid = Number.parseInt(trimmed, 10)
+		if (Number.isFinite(pid) && pid > 0) pids.add(pid)
+	}
+	return [...pids]
+}
+
+export function parseSsListenPids(stdout: string) {
+	const pids = new Set<number>()
+	for (const match of stdout.matchAll(/pid=(\d+)/g)) {
+		const pid = Number.parseInt(match[1] ?? '', 10)
+		if (Number.isFinite(pid) && pid > 0) pids.add(pid)
+	}
+	return [...pids]
+}
+
+export function readLinuxProcessIdentity(pid: number): ProcessIdentity | null {
+	try {
+		const comm = readFileSync(`/proc/${pid}/comm`, 'utf8').trim()
+		const cmdline = readFileSync(`/proc/${pid}/cmdline`, 'utf8')
+		const status = readFileSync(`/proc/${pid}/status`, 'utf8')
+		const ppidMatch = status.match(/^PPid:\s+(\d+)/m)
+		const ppid = Number.parseInt(ppidMatch?.[1] ?? '', 10)
+		if (!Number.isFinite(ppid)) return null
+		return { pid, ppid, comm, cmdline }
+	} catch {
+		return null
+	}
+}
+
+export function listListenerPidsWithCommands(
+	port: number,
+	run: (command: string, args: Array<string>) => string | null,
+) {
+	const lsof = run('lsof', [`-iTCP:${port}`, '-sTCP:LISTEN', '-n', '-P', '-t'])
+	if (lsof != null) return parseLsofListenPids(lsof)
+	const ss = run('ss', ['-lptn', `sport = :${port}`])
+	if (ss != null) return parseSsListenPids(ss)
+	return []
+}
+
+export function resolveNode26BinDir(
+	homeDir: string,
+	options: {
+		readDir?: (dir: string) => Array<string>
+		hasNodeBin?: (binDir: string) => boolean
+	} = {},
+) {
+	const readDir = options.readDir ?? ((dir) => readdirSync(dir))
+	const hasNodeBin =
+		options.hasNodeBin ?? ((binDir) => existsSync(path.join(binDir, 'node')))
+	const versionsDir = path.join(homeDir, '.nvm', 'versions', 'node')
+	let names: Array<string>
+	try {
+		names = readDir(versionsDir)
+	} catch {
+		return null
+	}
+	const node26 = names
+		.filter((name) => name.startsWith('v26.'))
+		.sort((left, right) =>
+			right.localeCompare(left, undefined, { numeric: true }),
+		)
+	const binDir = node26
+		.map((name) => path.join(versionsDir, name, 'bin'))
+		.find((dir) => hasNodeBin(dir))
+	return binDir ?? null
+}
+
+export function envWithPreferredNode26(
+	env: NodeJS.ProcessEnv,
+	options: {
+		nodeMajor?: number
+		homeDir?: string
+		readDir?: (dir: string) => Array<string>
+		hasNodeBin?: (binDir: string) => boolean
+	} = {},
+) {
+	const nodeMajor =
+		options.nodeMajor ?? Number.parseInt(process.versions.node, 10)
+	if (Number.isFinite(nodeMajor) && nodeMajor >= 26) return env
+	const binDir = resolveNode26BinDir(options.homeDir ?? homedir(), options)
+	if (!binDir) return env
+	return {
+		...env,
+		PATH: `${binDir}${path.delimiter}${env.PATH ?? ''}`,
+	}
+}
+
+export function formatAppRunning(origin: string) {
+	return `App running at ${origin}`
+}
+
+export async function waitForHealthyOrigin(input: {
+	ports: ReadonlyArray<number>
+	probeHealth: (origin: string) => Promise<boolean>
+	timeoutMs: number
+	pollMs: number
+	now?: () => number
+	sleep?: (ms: number) => Promise<void>
+	isCancelled?: () => boolean
+}) {
+	const now = input.now ?? Date.now
+	const sleep = input.sleep ?? delay
+	const deadline = now() + input.timeoutMs
+	while (now() < deadline) {
+		if (input.isCancelled?.()) return null
+		const origin = await findHealthyWorkerOrigin(input.ports, {
+			probe: input.probeHealth,
+		})
+		if (origin) return origin
+		await sleep(input.pollMs)
+	}
+	return findHealthyWorkerOrigin(input.ports, { probe: input.probeHealth })
+}
+
+export async function replaceStaleKodyListeners(input: {
+	ports: ReadonlyArray<number>
+	probeHealth: (origin: string) => Promise<boolean>
+	listListenerPids: (port: number) => Array<number>
+	readProcess: (pid: number) => ProcessIdentity | null
+	protectedPids: ReadonlySet<number>
+	killProcess: (pid: number, signal: NodeJS.Signals) => void
+	sleep: (ms: number) => Promise<void>
+	log: (line: string) => void
+}) {
+	const replaced = new Set<number>()
+	for (const port of input.ports) {
+		if (await input.probeHealth(workerOriginForPort(port))) continue
+		for (const listenerPid of input.listListenerPids(port)) {
+			const killPids = collectKodyDevKillPids({
+				startPid: listenerPid,
+				readProcess: input.readProcess,
+				protectedPids: input.protectedPids,
+			})
+			for (const pid of [...killPids].reverse()) {
+				if (replaced.has(pid)) continue
+				const identity = input.readProcess(pid)
+				input.log(
+					`Replaced stale kody listener pid=${pid} comm=${identity?.comm ?? 'unknown'} port=${port}`,
+				)
+				try {
+					input.killProcess(pid, 'SIGTERM')
+				} catch {
+					// Process may have already exited.
+				}
+				replaced.add(pid)
+			}
+		}
+	}
+	if (replaced.size > 0) {
+		await input.sleep(defaultStaleKillWaitMs)
+		for (const pid of replaced) {
+			const stillThere = input.readProcess(pid)
+			if (!stillThere) continue
+			try {
+				input.killProcess(pid, 'SIGKILL')
+			} catch {
+				// Process may have already exited.
+			}
+		}
+		await input.sleep(250)
+	}
+	return [...replaced]
+}
+
+export async function ensureDev(deps: EnsureDevDeps): Promise<EnsureDevResult> {
+	const existing = await findHealthyWorkerOrigin(deps.ports, {
+		probe: deps.probeHealth,
+	})
+	if (existing) {
+		deps.log(formatAppRunning(existing))
+		return { status: 'reused', origin: existing }
+	}
+
+	const replacedPids = await replaceStaleKodyListeners(deps)
+	const started = deps.startDev()
+	const origin = await waitForHealthyOrigin({
+		ports: deps.ports,
+		probeHealth: deps.probeHealth,
+		timeoutMs: deps.readyTimeoutMs,
+		pollMs: deps.readyPollMs,
+		now: deps.now,
+		sleep: deps.sleep,
+	})
+	if (!origin) {
+		started.unref()
+		throw new Error(
+			`Local app did not become ready on ${deps.ports[0]}-${deps.ports.at(-1)} within ${deps.readyTimeoutMs}ms. ` +
+				`Check wrangler output from \`npm run dev\`.`,
+		)
+	}
+	started.unref()
+	deps.log(formatAppRunning(origin))
+	return { status: 'started', origin, replacedPids }
+}
+
+function runCommandOutput(command: string, args: Array<string>) {
+	if (!commandExists(command)) return null
+	const result = spawnSync(command, args, {
+		encoding: 'utf8',
+		timeout: 2_000,
+	})
+	if (result.error) return null
+	return `${result.stdout ?? ''}${result.stderr ?? ''}`
+}
+
+function commandExists(command: string) {
+	if (process.platform === 'win32') {
+		const result = spawnSync('where', [command], { encoding: 'utf8' })
+		return result.status === 0
+	}
+	const result = spawnSync('sh', ['-c', `command -v ${shellQuote(command)}`], {
+		encoding: 'utf8',
+	})
+	return result.status === 0
+}
+
+function shellQuote(value: string) {
+	return `'${value.replaceAll("'", `'\\''`)}'`
+}
+
+function defaultListListenerPids(port: number) {
+	return listListenerPidsWithCommands(port, runCommandOutput)
+}
+
+function defaultKillProcess(pid: number, signal: NodeJS.Signals) {
+	try {
+		process.kill(pid, signal)
+	} catch (error) {
+		if (error instanceof Error && 'code' in error && error.code === 'ESRCH') {
+			return
+		}
+		throw error
+	}
+}
+
+function createDefaultStartDev(env: NodeJS.ProcessEnv) {
+	const child = spawnInOwnProcessGroup(resolveNpmCommand(), ['run', 'dev'], {
+		stdio: ['ignore', 'pipe', 'pipe'],
+		env,
+		cwd: process.cwd(),
+	})
+	const buffered: Array<string> = []
+	const onLine = (chunk: Buffer | string) => {
+		const text = chunk.toString()
+		for (const line of text.split(/\r?\n/)) {
+			if (!line) continue
+			buffered.push(line)
+			if (buffered.length > 80) buffered.shift()
+		}
+	}
+	child.stdout?.on('data', onLine)
+	child.stderr?.on('data', onLine)
+	child.once('exit', (code, signal) => {
+		if (code && code !== 0) {
+			console.error(
+				`npm run dev exited (${signal ?? `code ${code}`}). Last output:\n${buffered.join('\n')}`,
+			)
+		}
+	})
+	return {
+		unref() {
+			child.stdout?.resume()
+			child.stderr?.resume()
+			child.unref()
+		},
+		async stop() {
+			await stopChildProcessTree(child)
+		},
+	}
+}
+
+export function createDefaultEnsureDevDeps(
+	overrides: Partial<EnsureDevDeps> = {},
+): EnsureDevDeps {
+	const startPort = Number.parseInt(
+		process.env.PORT ?? String(defaultWorkerPort),
+		10,
+	)
+	const ports = overrides.ports ?? workerPortRange(startPort)
+	return {
+		ports,
+		probeHealth: (origin) =>
+			isWorkerHealthOk(origin, { timeoutMs: defaultHealthTimeoutMs }),
+		listListenerPids: defaultListListenerPids,
+		readProcess: readLinuxProcessIdentity,
+		protectedPids: collectAncestorPids(process.pid, (pid) => {
+			if (pid === process.pid) return process.ppid
+			return readLinuxProcessIdentity(pid)?.ppid ?? null
+		}),
+		killProcess: defaultKillProcess,
+		startDev: () => createDefaultStartDev(envWithPreferredNode26(process.env)),
+		sleep: delay,
+		now: Date.now,
+		readyTimeoutMs: defaultReadyTimeoutMs,
+		readyPollMs: defaultReadyPollMs,
+		log: (line) => {
+			console.log(line)
+		},
+		...overrides,
+	}
+}
+
+export async function main() {
+	const result = await ensureDev(createDefaultEnsureDevDeps())
+	return result
+}
+
+if (isExecutedDirectly(import.meta.url)) {
+	void main()
+		.then((result) => {
+			process.exitCode = result ? 0 : 1
+		})
+		.catch((error) => {
+			console.error(error instanceof Error ? error.message : error)
+			process.exit(1)
+		})
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Give agents one command that can reuse a healthy local origin, replace a dead leftover, and print the real URL once `/health` is ok.

## Why

[#1818](https://github.com/kentcdodds/kody/issues/1818): Cursor terminals still say `npm run dev` is running after the process is dead, `/health` is connection-refused, and `cli.ts` hops off 3742. Agents then reconstruct the multi-worker startup playbook instead of bringing the app up.

## Summary

- Add `npm run dev:ensure` (`tools/ensure-dev.ts`): probe `/health` on 3742–3751, exit 0 with `App running at http://localhost:<port>` when already up, replace stale kody leftovers by pid (kody supervisor in the tree — not bare workerd), then start `npm run dev` and wait until `/health` answers.
- After a successful start, destroy piped stdio and `process.exit(0)` so the parent actually returns. A failed boot stops the child and prints the last wrangler lines.
- Reuse works without `packages/worker/.env` (`--env-file-if-exists`).
- `cli.ts` prints `App running at` only when `/health` responded, including after clear-console.
- Point Cloud Agent / local-dev docs and the multi-worker skill at `dev:ensure`.

## Testing

- `npx vitest run --project node-unit tools/dev-server.node.test.ts tools/ensure-dev.node.test.ts` (12 tests)
- Husky `test:push`: node-unit 2197 passed; workers-unit 302 passed
- Local reuse smoke: stub `GET /health` on `:3742` with no `.env` → `App running at http://localhost:3742` and exit 0

## System changes

Contributor tooling only. No production worker, auth, or storage changes.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `65451b0` · **Head:** `c830d1b9`

**Classification:** composes — no primitives added or changed; this PR only wires local contributor tooling around the existing `npm run dev` / `/health` path.

### Primitives touched

_None._ Classifier matched 0 of 12 paths (`cli.ts`, `tools/ensure-dev.ts`, docs, and skills are unmatched).

### Change flow

Agents ask `dev:ensure` to probe `/health`, replace a stale leftover, or start `npm run dev` and print the resolved origin.

```mermaid
sequenceDiagram
	actor Agent
	participant ensureDev as npm run dev:ensure
	participant originHealth as GET /health
	participant npmDev as npm run dev
	Agent->>ensureDev: npm run dev:ensure
	ensureDev->>originHealth: probe 3742-3751
	alt already serving
		originHealth-->>ensureDev: 200 ok
		ensureDev-->>Agent: App running at http://localhost:port
	else leftover listening, not serving
		ensureDev->>ensureDev: SIGTERM kody supervisor tree on that port
		ensureDev->>npmDev: start cli.ts
		npmDev->>originHealth: wait until ok
		ensureDev-->>Agent: App running at http://localhost:port
	else nothing listening
		ensureDev->>npmDev: start cli.ts
		npmDev->>originHealth: wait until ok
		ensureDev-->>Agent: App running at http://localhost:port
	end
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-20fc9e1e-2ab8-4225-9bdd-ed2931531b92?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-20fc9e1e-2ab8-4225-9bdd-ed2931531b92&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `npm run dev:ensure` to reuse a healthy local development server or start one when needed.
  * Displays the resolved app URL after health checks pass.
  * Automatically selects an available port and replaces stale local development processes when necessary.
* **Documentation**
  * Updated local development and contributor guidance with the streamlined startup workflow.
* **Tests**
  * Added coverage for health checks, startup, reuse, recovery, port handling, and timeouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->