### PR TITLE
Keep prose guide lists inside the mobile viewport

### DIFF
--- a/packages/worker/universal/styles/style-primitives.prose.node.test.ts
+++ b/packages/worker/universal/styles/style-primitives.prose.node.test.ts
@@ -1,0 +1,25 @@
+import { jsx } from 'remix/ui/jsx-runtime'
+import { renderToString } from 'remix/ui/server'
+import { css } from 'remix/ui'
+import { expect, test } from 'vitest'
+import { proseCss } from './style-primitives.ts'
+
+test('prose lists wrap long inline code instead of stretching past the viewport', async () => {
+	const html = await renderToString(
+		jsx('div', {
+			mix: css(proseCss),
+			children: jsx('ol', {
+				children: jsx('li', {
+					children: jsx('code', {
+						children: 'https://www.googleapis.com/auth/gmail.compose',
+					}),
+				}),
+			}),
+		}),
+	)
+
+	expect(html).toContain('overflow-wrap: anywhere')
+	expect(html).toContain('min-width: 0')
+	expect(html).toContain('white-space: pre')
+	expect(html).toContain('overflow-wrap: normal')
+})

--- a/packages/worker/universal/styles/style-primitives.ts
+++ b/packages/worker/universal/styles/style-primitives.ts
@@ -459,9 +459,12 @@ export function getLanternGlowCss(options: { maxWidth: string }) {
 
 export const proseCss = {
 	marginTop: 'clamp(1.8rem, 4vw, 2.5rem)',
-	// Long literal URLs in link text must never force a horizontal scroll on
-	// narrow screens.
-	overflowWrap: 'break-word' as const,
+	minWidth: 0,
+	// `anywhere` (not `break-word`) shrinks min-content, so a grid list item
+	// with a long URL in `<code>` cannot stretch the page past the viewport.
+	// `body { overflow-x: clip }` would otherwise hide the overflow with no
+	// scrollbar. Interactive walkthroughs do not use this object.
+	overflowWrap: 'anywhere' as const,
 	'& a': {
 		color: colors.primaryText,
 		textDecorationThickness: '1.5px',
@@ -493,10 +496,15 @@ export const proseCss = {
 		paddingLeft: '1.25rem',
 		display: 'grid',
 		gap: '0.6rem',
+		// Grid items default to `min-width: auto` (min-content). Without this,
+		// one long token in a list item blows the column out on a phone.
+		minWidth: 0,
 	},
 	'& li': {
+		minWidth: 0,
 		paddingLeft: '0.25rem',
 		textWrap: 'pretty' as const,
+		overflowWrap: 'anywhere' as const,
 	},
 	'& li::marker': {
 		color: colors.primaryText,
@@ -520,11 +528,10 @@ export const proseCss = {
 		border: `1px solid ${colors.border}`,
 		borderRadius: '6px',
 		padding: '0.1em 0.4em',
-		// Inline code has to wrap. `nowrap` here would defeat the container's
-		// `overflow-wrap` guard above: one long package name or id would push
-		// the measure wider than a phone screen. `& pre code` keeps `nowrap`
-		// because the `pre` scrolls itself.
-		overflowWrap: 'break-word' as const,
+		// Inline code has to wrap, and the wrap has to affect min-content so
+		// a grid `<li>` can shrink. `break-word` does not; `anywhere` does.
+		// `& pre code` resets this so fenced blocks keep scrolling.
+		overflowWrap: 'anywhere' as const,
 	},
 	'& pre': {
 		margin: '1.4rem 0 0',
@@ -541,6 +548,7 @@ export const proseCss = {
 		borderRadius: 0,
 		padding: 0,
 		whiteSpace: 'pre' as const,
+		overflowWrap: 'normal' as const,
 	},
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

On a phone, official guide lists with long inline code (Gmail scope URLs, capability ids) must stay inside the viewport. Interactive conversation walkthroughs must keep their own styles.

## Why

`proseCss` lists are CSS grids. Grid items default to `min-width: auto` (min-content), and `overflow-wrap: break-word` does not shrink that min-content. One `https://www.googleapis.com/auth/gmail.compose` chip stretched the page; `body { overflow-x: clip }` hid the overflow with no scrollbar. `/guides/locked-gmail-drafts` is the visible case. Interactive slugs (`how-kody-works`, `google-oauth`) do not use `proseCss`.

## Summary

- Prose root, lists, and list items get `min-width: 0`.
- Inline code (and the prose root) use `overflow-wrap: anywhere` so wrap affects min-content.
- Fenced `pre code` keeps `white-space: pre` and resets wrap to `normal` so blocks still scroll.
- Regression test serializes the prose rules.

## Testing

- `vitest` prose wrap test
- `test:node` + `test:workers` on push
- Mobile viewport check of `/guides/locked-gmail-drafts` (and a glance at an interactive guide)

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `563e2442` · **Head:** `a47d9b2f`

**Classification:** extends — `app-ui` prose wrap contract changes so grid lists cannot blow out a phone.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | extends — `proseCss` wrap/min-width for lists and inline code |

### Change flow

A phone paints a prose guide list; long inline code wraps instead of widening the document.

```mermaid
sequenceDiagram
	actor Reader
	participant appUi as app-ui
	Reader->>appUi: open /guides/locked-gmail-drafts on a phone
	Note over appUi: proseCss ol/li min-width 0
	appUi-->>Reader: gmail.compose URL wraps inside the gutter
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0a39b9b4-fc9e-46cc-817c-83f621d49d5a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0a39b9b4-fc9e-46cc-817c-83f621d49d5a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved prose and ordered-list layouts so long URLs and inline code wrap instead of expanding the page.
  * Preserved horizontal scrolling behavior for fenced code blocks.
  * Added safeguards to prevent long content from disrupting grid and list layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->