### PR TITLE
Keep wrangler dev alive on ProxyWorker errors

### DIFF
--- a/docs/contributing/cloud-agents.md
+++ b/docs/contributing/cloud-agents.md
@@ -70,6 +70,9 @@ Playwright E2E is not in the push hook: wrangler can enter a
 `generated/esbuild.wasm` reload loop on these VMs, and a failed e2e leg skips
 the unit gate when the push is retried with `--no-verify`. Run
 `npm run test:e2e:run` or `npm run validate` for the Playwright gate locally.
+`wrangler-env.ts` applies `tools/patch-wrangler-proxy-worker-errors.ts` before
+`wrangler dev` so a request-scoped ProxyWorker failure does not exit the
+Playwright webServer.
 
 Cloud Agent environment `start` should run `npm run hooks:ensure` so a snapshot
 boot that skips `npm ci` still composes hooks after Cursor installs the

--- a/docs/contributing/cloud-agents.md
+++ b/docs/contributing/cloud-agents.md
@@ -72,7 +72,10 @@ the unit gate when the push is retried with `--no-verify`. Run
 `npm run test:e2e:run` or `npm run validate` for the Playwright gate locally.
 `wrangler-env.ts` applies `tools/patch-wrangler-proxy-worker-errors.ts` before
 `wrangler dev` so a request-scoped ProxyWorker failure does not exit the
-Playwright webServer.
+Playwright webServer. It also defaults `X_LOCAL_EXPLORER=false` on `dev` because
+wrangler 4.127+ local explorer writes under `.wrangler/tmp` on these VMs,
+retriggers esbuild, and leaves ProxyWorker in a pause/reload loop after Ready.
+Opt in with `X_LOCAL_EXPLORER=true`.
 
 Cloud Agent environment `start` should run `npm run hooks:ensure` so a snapshot
 boot that skips `npm ci` still composes hooks after Cursor installs the

--- a/docs/contributing/end-to-end-testing.md
+++ b/docs/contributing/end-to-end-testing.md
@@ -86,9 +86,13 @@ Avoid `page.locator('css')` unless no accessible alternative exists.
   `handleErrorEvent` so a request-scoped ProxyWorker failure is logged instead
   of exiting `wrangler dev` (workers-sdk#14926; same exemption as pending #15207
   / #15252). Playwright also keeps wrangler's default incoming-body drain
-  enabled so unused proxy tees do not kill the isolate. On CI, the `🎭 E2E` job
-  uploads `logs.local/` as the `e2e-wrangler-logs` artifact when the suite
-  fails.
+  enabled so unused proxy tees do not kill the isolate. `wrangler-env.ts` and
+  the Playwright webServer set `X_LOCAL_EXPLORER=false` because wrangler 4.127+
+  starts Miniflare's local explorer by default; on Cloud Agent / CI hosts,
+  explorer writes under `.wrangler/tmp` retrigger esbuild and leave ProxyWorker
+  in a pause/reload loop after Ready. Opt in with `X_LOCAL_EXPLORER=true`. On
+  CI, the `🎭 E2E` job uploads `logs.local/` as the `e2e-wrangler-logs` artifact
+  when the suite fails.
 - Ensure the `env.test` section in `packages/worker/wrangler.jsonc` includes
   assets, KV, and durable objects since these are not inherited from top-level
   Wrangler config.

--- a/docs/contributing/end-to-end-testing.md
+++ b/docs/contributing/end-to-end-testing.md
@@ -82,10 +82,13 @@ Avoid `page.locator('css')` unless no accessible alternative exists.
   exited mid-suite (avoids burning retries on `ECONNREFUSED`). That error names
   the unread `request.clone()` tee fix (`discardUnreadRequestBody` in
   `#worker/request-body.ts`) when logs show `Network connection lost` /
-  `Error inside ProxyWorker`. Playwright keeps wrangler's default incoming-body
-  drain enabled so unused proxy tees do not kill `wrangler dev` mid-suite. On
-  CI, the `🎭 E2E` job uploads `logs.local/` as the `e2e-wrangler-logs` artifact
-  when the suite fails.
+  `Error inside ProxyWorker`. `wrangler-env.ts` rewrites wrangler's
+  `handleErrorEvent` so a request-scoped ProxyWorker failure is logged instead
+  of exiting `wrangler dev` (workers-sdk#14926; same exemption as pending #15207
+  / #15252). Playwright also keeps wrangler's default incoming-body drain
+  enabled so unused proxy tees do not kill the isolate. On CI, the `🎭 E2E` job
+  uploads `logs.local/` as the `e2e-wrangler-logs` artifact when the suite
+  fails.
 - Ensure the `env.test` section in `packages/worker/wrangler.jsonc` includes
   assets, KV, and durable objects since these are not inherited from top-level
   Wrangler config.

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
       "devDependencies": {
         "@axe-core/playwright": "^4.12.1",
         "@cloudflare/vitest-pool-workers": "^0.20.1",
-        "@cloudflare/workers-types": "^5.20260801.1",
+        "@cloudflare/workers-types": "^5.20260829.1",
         "@epic-web/config": "^3.2.1",
         "@kody-internal/shared": "file:packages/shared",
         "@modelcontextprotocol/client": "2.0.0",
@@ -42,7 +42,7 @@
         "set-cookie-parser": "^3.1.2",
         "typescript": "^6.0.3",
         "vitest": "^4.1.10",
-        "wrangler": "^4.118.0"
+        "wrangler": "^4.127.1"
       },
       "engines": {
         "node": ">=26"
@@ -522,6 +522,57 @@
         "vitest": "^4.1.0"
       }
     },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/wrangler": {
+      "version": "4.120.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.120.0.tgz",
+      "integrity": "sha512-cBmu/MeaB/fPacC0JpATs4duTOCagBxrZo+vBzuTX06tLzwSyAHE1drlHUZ8rP0VqVz1fy3ReGYTiHdKkoHltg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.5.0",
+        "@cloudflare/unenv-preset": "2.16.1",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.28.1",
+        "miniflare": "5.20260801.1-alpha",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260801.1"
+      },
+      "bin": {
+        "cf-wrangler": "bin/cf-wrangler.js",
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.3"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^5.20260801.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@cloudflare/worker-bundler": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/@cloudflare/worker-bundler/-/worker-bundler-0.2.2.tgz",
@@ -640,9 +691,9 @@
       "license": "MIT"
     },
     "node_modules/@cloudflare/workers-types": {
-      "version": "5.20260801.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-5.20260801.1.tgz",
-      "integrity": "sha512-XCv5xWi47WQOK0LpLa6997Mrpz8Ct+nZmp/M5Xp8Z4BFsarf7nYjkznGOcOoYK5m1GfbMFEEuQ2OIZnbIWoe9A==",
+      "version": "5.20260829.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-5.20260829.1.tgz",
+      "integrity": "sha512-SsH4G9+JePvrBmz+b5Dl67LQ9w2/ycoIpAPcAkfg2aEs2SEisQHk7/AY0TymSXEBbDbWgcBqoLe4hNcuY3CxWA==",
       "license": "MIT OR Apache-2.0"
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -7828,7 +7879,7 @@
       "version": "5.20260801.1-alpha",
       "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260801.1-alpha.tgz",
       "integrity": "sha512-BHPVzIDA6mbx7LefxpvkXW7DHx9FKB9GorZatbnrrFTt3CVMU8zuUpbgyCuebwDKcTTOZos43ta8GQ0eMVEpxA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "0.8.1",
@@ -7846,7 +7897,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
       "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
@@ -10854,9 +10905,9 @@
       }
     },
     "node_modules/wrangler": {
-      "version": "4.120.0",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.120.0.tgz",
-      "integrity": "sha512-cBmu/MeaB/fPacC0JpATs4duTOCagBxrZo+vBzuTX06tLzwSyAHE1drlHUZ8rP0VqVz1fy3ReGYTiHdKkoHltg==",
+      "version": "4.127.1",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.127.1.tgz",
+      "integrity": "sha512-OzsiNgaI8i681L/+KnAKc+uEZ5D57xK5JuNvCOpRKICF4/5Q3Cu1oTGuUiT/f3GDUqQb3gzXNT0tfOHGMEtknw==",
       "devOptional": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
@@ -10864,10 +10915,10 @@
         "@cloudflare/unenv-preset": "2.16.1",
         "blake3-wasm": "2.1.5",
         "esbuild": "0.28.1",
-        "miniflare": "5.20260801.1-alpha",
+        "miniflare": "5.20260828.0-alpha",
         "path-to-regexp": "6.3.0",
         "unenv": "2.0.0-rc.24",
-        "workerd": "1.20260801.1"
+        "workerd": "1.20260828.1"
       },
       "bin": {
         "cf-wrangler": "bin/cf-wrangler.js",
@@ -10881,12 +10932,92 @@
         "fsevents": "2.3.3"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^5.20260801.1"
+        "@cloudflare/workers-types": "^5.20260828.1"
       },
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {
           "optional": true
         }
+      }
+    },
+    "node_modules/wrangler/node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20260828.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260828.1.tgz",
+      "integrity": "sha512-CVd+xPhqUESg8Xhq09TZx0wl4FSirfJGOzvbPz2yHhBIvmNHFFQkSN3rkd7wEwnhQQk37Xi0/aD6ykPLJbmGiQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/wrangler/node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20260828.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260828.1.tgz",
+      "integrity": "sha512-5HDPXRM152vU5JveByGFk34X57TVyIsfp4cabepAf45DC0MKvm52ucJqAjW1h8bvW4X+zRw9GU35OHF9FEC9Ww==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/wrangler/node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20260828.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260828.1.tgz",
+      "integrity": "sha512-MQ1Ll9P7F72HHUKizbb7BlDfbY8fRoNMpbIpZoU6uKsSkneFICWSKv6UlgU9EQZ+w0i7TMa12iUgJ8l29eRI9A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/wrangler/node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20260828.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260828.1.tgz",
+      "integrity": "sha512-FBTaUQ1xcU9jcp4OyBPcH8x0QiFvc1iuZL2GkD8zp2q1WyTVHYOptRDQUU+cuHjt0rQ2EIKVPBjahPxfa0joBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/wrangler/node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20260828.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260828.1.tgz",
+      "integrity": "sha512-yvr77hC7dUbvK5K+SCg062kkPq3sx+drV1PcgHslzHDYcJBtT0V3X80qLE49LW1vq2svaeNmsVQS+vHsqWu8cQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/wrangler/node_modules/fsevents": {
@@ -10901,6 +11032,55 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/wrangler/node_modules/miniflare": {
+      "version": "5.20260828.0-alpha",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260828.0-alpha.tgz",
+      "integrity": "sha512-6nbxhZEcz/UET3Y1OnYPsrAUjUmuFoib3ynUqteRdn1YnDxsLg8cwgZJZCk9QmtOmGzXwzXzgE/d/C0dJAPtVw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "sharp": "0.35.2",
+        "undici": "7.29.0",
+        "workerd": "1.20260828.1",
+        "ws": "8.21.0",
+        "youch": "4.1.0-beta.10"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/wrangler/node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/wrangler/node_modules/workerd": {
+      "version": "1.20260828.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260828.1.tgz",
+      "integrity": "sha512-pB9yvt0kkwZDAGZHmpY59r0o3hM0DzdW6BJERqwZOhunZ3ssOyDSgQxOQer2cSZW4YCFeOTIQYN1qwhK5wv/Cw==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20260828.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260828.1",
+        "@cloudflare/workerd-linux-64": "1.20260828.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260828.1",
+        "@cloudflare/workerd-windows-64": "1.20260828.1"
       }
     },
     "node_modules/wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "test:e2e:install": "playwright install chromium --with-deps",
     "test:mcp": "nx run worker:test-mcp",
     "hooks:ensure": "node tools/ensure-cloud-agent-hooks.ts",
-    "prepare": "husky && node tools/ensure-cloud-agent-hooks.ts",
+    "prepare": "husky && node tools/ensure-cloud-agent-hooks.ts && node tools/patch-wrangler-proxy-worker-errors.ts",
     "nx:graph": "nx graph",
     "nx:show-projects": "nx show projects",
     "audit:prod": "npm audit --omit=dev"
@@ -94,7 +94,7 @@
   "devDependencies": {
     "@axe-core/playwright": "^4.12.1",
     "@cloudflare/vitest-pool-workers": "^0.20.1",
-    "@cloudflare/workers-types": "^5.20260801.1",
+    "@cloudflare/workers-types": "^5.20260828.1",
     "@epic-web/config": "^3.2.1",
     "@kody-internal/shared": "file:packages/shared",
     "@modelcontextprotocol/client": "2.0.0",
@@ -115,7 +115,7 @@
     "set-cookie-parser": "^3.1.2",
     "typescript": "^6.0.3",
     "vitest": "^4.1.10",
-    "wrangler": "^4.118.0"
+    "wrangler": "^4.127.1"
   },
   "overrides": {
     "@modelcontextprotocol/sdk": "1.30.0",

--- a/packages/backup-control-plane/access-auth.node.test.ts
+++ b/packages/backup-control-plane/access-auth.node.test.ts
@@ -10,7 +10,10 @@ import {
 	verifyAccessJwt,
 } from './access-auth.ts'
 import { BackupError } from './backup-policy.ts'
-import { environment } from './backup-control-plane-test-support.ts'
+import {
+	encodeNodeBytesAsBase64,
+	environment,
+} from './backup-control-plane-test-support.ts'
 
 function rsaJwksAndSigner() {
 	const { privateKey, publicKey } = generateKeyPairSync('rsa', {
@@ -28,9 +31,7 @@ function rsaJwksAndSigner() {
 			const signer = createSign('RSA-SHA256')
 			signer.update(encoded)
 			signer.end()
-			const signature = signer
-				.sign(privateKey)
-				.toString('base64')
+			const signature = encodeNodeBytesAsBase64(signer.sign(privateKey))
 				.replaceAll('+', '-')
 				.replaceAll('/', '_')
 				.replaceAll('=', '')
@@ -179,9 +180,7 @@ test('unknown kid refreshes once and JWKS fetch failures use structured errors',
 		const signer = createSign('RSA-SHA256')
 		signer.update(encoded)
 		signer.end()
-		const signature = signer
-			.sign(privateKey)
-			.toString('base64')
+		const signature = encodeNodeBytesAsBase64(signer.sign(privateKey))
 			.replaceAll('+', '-')
 			.replaceAll('/', '_')
 			.replaceAll('=', '')

--- a/packages/backup-control-plane/backup-control-plane-test-support.ts
+++ b/packages/backup-control-plane/backup-control-plane-test-support.ts
@@ -1,5 +1,4 @@
 import { createHash, generateKeyPairSync, sign as signBytes } from 'node:crypto'
-
 import {
 	backupManifestSchemaVersion,
 	backupManifestSignatureAlgorithm,
@@ -15,6 +14,15 @@ import { type BackupRuntimeStep } from './backup-runtime.ts'
 import { type DurableExportStep } from './durable-export.ts'
 import { BackupError, objectKeyForBookmark } from './backup-policy.ts'
 import { type BackupEnvironment, type BackupManifest } from './backup-types.ts'
+
+export function encodeNodeBytesAsBase64(
+	bytes: ArrayBuffer | NodeJS.ArrayBufferView,
+) {
+	return Buffer.from(
+		bytes instanceof ArrayBuffer ? new Uint8Array(bytes) : bytes,
+	).toString('base64')
+}
+
 class TestDigestStream extends WritableStream<Uint8Array> {
 	readonly digest: Promise<ArrayBuffer>
 	private readonly bytes: () => number
@@ -239,14 +247,12 @@ export function environment(bucket = new MemoryBucket()): BackupEnvironment {
 		BACKUP_BENCHMARK_APPROVED: 'true',
 		BUILD_COMMIT: 'abc123',
 		BACKUP_MANIFEST_SIGNING_KEY_ID: 'backup-manifest-2026',
-		BACKUP_MANIFEST_SIGNING_PRIVATE_KEY_PKCS8_BASE64:
-			manifestSigningKeys.privateKey
-				.export({ format: 'der', type: 'pkcs8' })
-				.toString('base64'),
-		BACKUP_MANIFEST_VERIFYING_PUBLIC_KEY_SPKI_BASE64:
-			manifestSigningKeys.publicKey
-				.export({ format: 'der', type: 'spki' })
-				.toString('base64'),
+		BACKUP_MANIFEST_SIGNING_PRIVATE_KEY_PKCS8_BASE64: encodeNodeBytesAsBase64(
+			manifestSigningKeys.privateKey.export({ format: 'der', type: 'pkcs8' }),
+		),
+		BACKUP_MANIFEST_VERIFYING_PUBLIC_KEY_SPKI_BASE64: encodeNodeBytesAsBase64(
+			manifestSigningKeys.publicKey.export({ format: 'der', type: 'spki' }),
+		),
 		TRUSTED_RESTORE_BASELINE_ID: 'production-baseline-2026',
 		TRUSTED_RESTORE_BASELINE_SHA256: BASELINE_SHA256,
 		ACCESS_TEAM_DOMAIN: 'example.cloudflareaccess.com',
@@ -573,11 +579,13 @@ export function signedManifest(payload: BackupManifestPayload): BackupManifest {
 		signature: {
 			algorithm: backupManifestSignatureAlgorithm,
 			keyId: payload.signing.keyId,
-			value: signBytes(
-				null,
-				Buffer.from(canonicalBackupManifestPayload(payload)),
-				manifestSigningKeys.privateKey,
-			).toString('base64'),
+			value: encodeNodeBytesAsBase64(
+				signBytes(
+					null,
+					Buffer.from(canonicalBackupManifestPayload(payload)),
+					manifestSigningKeys.privateKey,
+				),
+			),
 		},
 	}
 }

--- a/packages/backup-control-plane/control-plane-fetch.node.test.ts
+++ b/packages/backup-control-plane/control-plane-fetch.node.test.ts
@@ -7,7 +7,10 @@ import {
 	encodeJwtPartForTests,
 	resetAccessJwksCacheForTests,
 } from './access-auth.ts'
-import { environment } from './backup-control-plane-test-support.ts'
+import {
+	encodeNodeBytesAsBase64,
+	environment,
+} from './backup-control-plane-test-support.ts'
 import { handleControlPlaneFetch } from './control-plane-fetch.ts'
 
 afterEach(() => {
@@ -28,9 +31,7 @@ function rsaJwksAndSigner() {
 			const signer = createSign('RSA-SHA256')
 			signer.update(encoded)
 			signer.end()
-			const signature = signer
-				.sign(privateKey)
-				.toString('base64')
+			const signature = encodeNodeBytesAsBase64(signer.sign(privateKey))
 				.replaceAll('+', '-')
 				.replaceAll('/', '_')
 				.replaceAll('=', '')

--- a/packages/backup-control-plane/freshness-check.node.test.ts
+++ b/packages/backup-control-plane/freshness-check.node.test.ts
@@ -15,6 +15,7 @@ import {
 	DATABASE_ID,
 	MemoryBucket,
 	badSqlStatsFixture,
+	encodeNodeBytesAsBase64,
 	environment,
 	identityApi,
 	identityEnvelope,
@@ -221,9 +222,12 @@ test('freshness requires a valid Ed25519 signature from the configured key', asy
 		}),
 		false,
 	)
-	const wrongPublicKey = generateKeyPairSync('ed25519')
-		.publicKey.export({ format: 'der', type: 'spki' })
-		.toString('base64')
+	const wrongPublicKey = encodeNodeBytesAsBase64(
+		generateKeyPairSync('ed25519').publicKey.export({
+			format: 'der',
+			type: 'spki',
+		}),
+	)
 	assert.equal(
 		await check(validManifest, {
 			...env,

--- a/packages/backup-control-plane/manifest-signing.node.test.ts
+++ b/packages/backup-control-plane/manifest-signing.node.test.ts
@@ -9,7 +9,10 @@ import { test } from 'vitest'
 
 import { signBackupManifest } from './manifest-signing.ts'
 import { BackupError } from './backup-policy.ts'
-import { environment } from './backup-control-plane-test-support.ts'
+import {
+	encodeNodeBytesAsBase64,
+	environment,
+} from './backup-control-plane-test-support.ts'
 
 function unsignedPayload(): Omit<
 	BackupManifestPayload,
@@ -42,9 +45,10 @@ test('Worker-compatible Ed25519 manifest signatures reject tampering and wrong k
 	const signingKeys = generateKeyPairSync('ed25519')
 	const wrongKeys = generateKeyPairSync('ed25519')
 	const env = environment()
-	env.BACKUP_MANIFEST_SIGNING_PRIVATE_KEY_PKCS8_BASE64 = signingKeys.privateKey
-		.export({ format: 'der', type: 'pkcs8' })
-		.toString('base64')
+	env.BACKUP_MANIFEST_SIGNING_PRIVATE_KEY_PKCS8_BASE64 =
+		encodeNodeBytesAsBase64(
+			signingKeys.privateKey.export({ format: 'der', type: 'pkcs8' }),
+		)
 	const manifest = await signBackupManifest(env, unsignedPayload())
 	const payloadBytes = new TextEncoder().encode(
 		canonicalBackupManifestPayload(manifest.payload),

--- a/packages/worker/src/test-support/cloudflare-mock-server.ts
+++ b/packages/worker/src/test-support/cloudflare-mock-server.ts
@@ -86,6 +86,7 @@ async function waitForCloudflareMock(
 		(error: unknown) => ({ status: 'error' as const, error }),
 	)
 	let origin: string | undefined
+	let lastProbeReason: string | undefined
 	while (Date.now() < deadline) {
 		const output = `${readStdout()}\n${readStderr()}`
 		if (!origin) {
@@ -102,6 +103,7 @@ async function waitForCloudflareMock(
 			if (probe.ready) {
 				return origin
 			}
+			lastProbeReason = probe.reason
 		}
 
 		const exitResult = await Promise.race([exited, delay(200).then(() => null)])
@@ -116,8 +118,10 @@ async function waitForCloudflareMock(
 			)
 		}
 	}
+	const lastProbe =
+		lastProbeReason === undefined ? '' : ` (last probe: ${lastProbeReason})`
 	throw new Error(
-		`mock cloudflare did not become ready within ${startupTimeout}ms\n${readStdout()}\n${readStderr()}`,
+		`mock cloudflare did not become ready within ${startupTimeout}ms${lastProbe}\n${readStdout()}\n${readStderr()}`,
 	)
 }
 
@@ -165,6 +169,11 @@ export async function startCloudflareMock(token: string) {
 			// contend with parallel mock wranglers during `test:node` and
 			// return 503 / empty JSON on the first DO-backed request.
 			X_LOCAL_OBSERVABILITY: 'false',
+			// Wrangler 4.127+ starts Miniflare's local explorer by default.
+			// On Cloud Agent / CI hosts, explorer writes under `.wrangler/tmp`
+			// retrigger esbuild and leave ProxyWorker in a pause/reload loop
+			// (Ready prints; authenticated `/__mocks/meta` hangs).
+			X_LOCAL_EXPLORER: 'false',
 			WRANGLER_CI_DISABLE_CONFIG_WATCHING: 'true',
 		},
 	})

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -52,6 +52,10 @@ export default defineConfig({
 			// `wrangler dev`. The extra collector/tail services have crashed the
 			// Playwright webServer mid-suite here; opt out for e2e stability.
 			X_LOCAL_OBSERVABILITY: 'false',
+			// Wrangler 4.127+ local explorer writes under `.wrangler/tmp` on
+			// Cloud Agent / CI hosts, retriggers esbuild, and leaves
+			// ProxyWorker in a pause/reload loop after Ready.
+			X_LOCAL_EXPLORER: 'false',
 			// Reduce ProxyWorker "Network connection lost" flakes under e2e load.
 			WRANGLER_CI_DISABLE_CONFIG_WATCHING: 'true',
 		},

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -45,8 +45,9 @@ export default defineConfig({
 			// Keep wrangler's default incoming-body drain. Setting
 			// WRANGLER_DISABLE_REQUEST_BODY_DRAINING=true recreates the
 			// workers-sdk#5106 ProxyWorker "Network connection lost" race on
-			// POST /auth and other JSON posts; wrangler 4.114+ then exits
-			// instead of recovering (workers-sdk#14926).
+			// POST /auth and other JSON posts. wrangler-env.ts also rewrites
+			// handleErrorEvent so that race cannot exit wrangler 4.114+
+			// (workers-sdk#14926; pending #15207 / #15252).
 			// Wrangler 4.118+ enables local observability capture by default in
 			// `wrangler dev`. The extra collector/tail services have crashed the
 			// Playwright webServer mid-suite here; opt out for e2e stability.

--- a/tools/patch-wrangler-proxy-worker-errors.node.test.ts
+++ b/tools/patch-wrangler-proxy-worker-errors.node.test.ts
@@ -1,0 +1,78 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { expect, test } from 'vitest'
+import {
+	defaultWranglerCliPath,
+	patchWranglerProxyWorkerErrors,
+	patchedProxyControllerExemption,
+	rewriteWranglerProxyWorkerErrors,
+	wranglerProxyWorkerErrorReason,
+} from './patch-wrangler-proxy-worker-errors.ts'
+
+const fullDevEnvBundle = `
+handleErrorEvent(event) {
+  if (event.source === "ProxyController" && (event.reason.startsWith("Failed to send message to") || event.reason.startsWith("Could not connect to InspectorProxyWorker"))) {
+    logger.debug(event.reason)
+  } else this.emit("error", event)
+}
+`
+
+const apiDevEnvBundle = `
+handleErrorEvent(event) {
+  else if (event.source === "ProxyController" && event.reason.startsWith("Failed to send message to")) {
+    logger.debug(event.reason)
+  } else this.emit("error", event)
+}
+`
+
+test('rewriteWranglerProxyWorkerErrors keeps ProxyWorker errors request-scoped', () => {
+	const both = `${fullDevEnvBundle}\n${apiDevEnvBundle}`
+	const first = rewriteWranglerProxyWorkerErrors(both)
+	expect(first.status).toBe('patched')
+	expect(first.replacements).toBe(2)
+	expect(first.source).toContain(patchedProxyControllerExemption)
+	expect(first.source).toContain(
+		`event.reason === "${wranglerProxyWorkerErrorReason}" || event.reason.startsWith("Failed to send message to") || event.reason.startsWith("Could not connect to InspectorProxyWorker")`,
+	)
+	expect(first.source).not.toContain(
+		'event.source === "ProxyController" && event.reason.startsWith("Failed to send message to")',
+	)
+
+	const second = rewriteWranglerProxyWorkerErrors(first.source)
+	expect(second.status).toBe('already-present')
+	expect(second.source).toBe(first.source)
+})
+
+test('rewriteWranglerProxyWorkerErrors fails when the exemption sites disappear', () => {
+	expect(() =>
+		rewriteWranglerProxyWorkerErrors(
+			'handleErrorEvent(event) { this.emit("error", event) }',
+		),
+	).toThrow(/workers-sdk#14926/)
+})
+
+test('patchWranglerProxyWorkerErrors writes the rewrite and is idempotent', async () => {
+	const dir = await mkdtemp(path.join(tmpdir(), 'kody-wrangler-patch-'))
+	try {
+		const cliPath = path.join(dir, 'cli.js')
+		await writeFile(cliPath, `${fullDevEnvBundle}\n${apiDevEnvBundle}`)
+
+		const first = patchWranglerProxyWorkerErrors(cliPath)
+		expect(first).toEqual({ status: 'patched', replacements: 2 })
+		const written = await readFile(cliPath, 'utf8')
+		expect(written).toContain(patchedProxyControllerExemption)
+
+		const second = patchWranglerProxyWorkerErrors(cliPath)
+		expect(second).toEqual({ status: 'already-present' })
+		expect(await readFile(cliPath, 'utf8')).toBe(written)
+	} finally {
+		await rm(dir, { recursive: true, force: true })
+	}
+})
+
+test('installed wrangler bundle still has a patchable or already-patched handleErrorEvent', () => {
+	const result = patchWranglerProxyWorkerErrors(defaultWranglerCliPath())
+	expect(result.status).not.toBe('missing-bundle')
+	expect(['patched', 'already-present']).toContain(result.status)
+})

--- a/tools/patch-wrangler-proxy-worker-errors.ts
+++ b/tools/patch-wrangler-proxy-worker-errors.ts
@@ -1,0 +1,112 @@
+/**
+ * Keep `wrangler dev` alive when one proxied request fails.
+ *
+ * Wrangler 4.114+ treats `Error inside ProxyWorker` as fatal, so a transient
+ * `Network connection lost` (unread `request.clone()` tee, idle keep-alive
+ * race, or isolate kill) exits the process. Playwright then fail-fasts the
+ * rest of the suite (workers-sdk#14926 / #15203). Upstream #15207 and #15252
+ * keep that error request-scoped; they are not in a released wrangler yet.
+ *
+ * This rewrite adds the same exemption wrangler already uses for other
+ * ProxyController disconnects. Drop it when a released wrangler logs the
+ * error without exiting (see the Cleanup issue on the introducing PR).
+ */
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import { isExecutedDirectly } from './node-runtime.ts'
+
+export const wranglerProxyWorkerErrorReason = 'Error inside ProxyWorker'
+
+export const patchedProxyControllerExemption = `event.source === "ProxyController" && (event.reason === "${wranglerProxyWorkerErrorReason}" || event.reason.startsWith("Failed to send message to")`
+
+const fullDevEnvExemption =
+	'event.source === "ProxyController" && (event.reason.startsWith("Failed to send message to") || event.reason.startsWith("Could not connect to InspectorProxyWorker"))'
+
+const apiDevEnvExemption =
+	'event.source === "ProxyController" && event.reason.startsWith("Failed to send message to")'
+
+const patchedFullDevEnvExemption = `event.source === "ProxyController" && (event.reason === "${wranglerProxyWorkerErrorReason}" || event.reason.startsWith("Failed to send message to") || event.reason.startsWith("Could not connect to InspectorProxyWorker"))`
+
+const patchedApiDevEnvExemption = `event.source === "ProxyController" && (event.reason === "${wranglerProxyWorkerErrorReason}" || event.reason.startsWith("Failed to send message to"))`
+
+export type PatchWranglerProxyWorkerErrorsResult =
+	| { status: 'already-present' }
+	| { status: 'patched'; replacements: number }
+	| { status: 'missing-bundle'; cliPath: string }
+
+export function defaultWranglerCliPath(repoRoot = process.cwd()) {
+	return path.join(
+		repoRoot,
+		'node_modules',
+		'wrangler',
+		'wrangler-dist',
+		'cli.js',
+	)
+}
+
+export function rewriteWranglerProxyWorkerErrors(source: string) {
+	if (source.includes(patchedProxyControllerExemption)) {
+		return { status: 'already-present' as const, source, replacements: 0 }
+	}
+
+	let next = source
+	let replacements = 0
+	if (next.includes(fullDevEnvExemption)) {
+		next = next.replaceAll(fullDevEnvExemption, patchedFullDevEnvExemption)
+		replacements += 1
+	}
+	if (next.includes(apiDevEnvExemption)) {
+		next = next.replaceAll(apiDevEnvExemption, patchedApiDevEnvExemption)
+		replacements += 1
+	}
+
+	if (replacements === 0) {
+		throw new Error(
+			'Could not find wrangler ProxyController handleErrorEvent exemptions to patch. ' +
+				'Inspect node_modules/wrangler/wrangler-dist/cli.js for handleErrorEvent. ' +
+				'If a released wrangler already keeps Error inside ProxyWorker non-fatal, ' +
+				'delete tools/patch-wrangler-proxy-worker-errors.ts. ' +
+				'Otherwise update the rewrite for the new bundle. ' +
+				'See workers-sdk#14926, #15207, and #15252.',
+		)
+	}
+
+	return { status: 'patched' as const, source: next, replacements }
+}
+
+export function patchWranglerProxyWorkerErrors(
+	cliPath = defaultWranglerCliPath(),
+): PatchWranglerProxyWorkerErrorsResult {
+	if (!existsSync(cliPath)) {
+		return { status: 'missing-bundle', cliPath }
+	}
+
+	const original = readFileSync(cliPath, 'utf8')
+	const rewritten = rewriteWranglerProxyWorkerErrors(original)
+	if (rewritten.status === 'already-present') {
+		return { status: 'already-present' }
+	}
+	if (rewritten.source !== original) {
+		writeFileSync(cliPath, rewritten.source)
+	}
+	return { status: 'patched', replacements: rewritten.replacements }
+}
+
+export function main() {
+	const result = patchWranglerProxyWorkerErrors()
+	if (result.status === 'missing-bundle') {
+		console.warn(
+			`Skipping wrangler ProxyWorker patch; missing ${result.cliPath}`,
+		)
+		return
+	}
+	if (result.status === 'patched') {
+		console.log(
+			`Patched wrangler ProxyWorker errors as non-fatal (${result.replacements} handleErrorEvent site(s)).`,
+		)
+	}
+}
+
+if (isExecutedDirectly(import.meta.url)) {
+	main()
+}

--- a/wrangler-env.ts
+++ b/wrangler-env.ts
@@ -226,6 +226,15 @@ const processEnv = {
 	...process.env,
 	CLOUDFLARE_ENV: envName,
 	...(resolvedPort ? { PORT: resolvedPort } : {}),
+	...(isDevCommand
+		? {
+				// Wrangler 4.127+ enables Miniflare's local explorer by default.
+				// On Cloud Agent / CI hosts, explorer writes under `.wrangler/tmp`
+				// retrigger esbuild and leave ProxyWorker in a pause/reload
+				// loop. Opt in with X_LOCAL_EXPLORER=true.
+				X_LOCAL_EXPLORER: process.env.X_LOCAL_EXPLORER ?? 'false',
+			}
+		: {}),
 	...(envName === 'test'
 		? {
 				X_LOCAL_OBSERVABILITY: process.env.X_LOCAL_OBSERVABILITY ?? 'false',

--- a/wrangler-env.ts
+++ b/wrangler-env.ts
@@ -20,6 +20,7 @@ import {
 } from './tools/wrangler-env-config.ts'
 import { writeLocalRuntimeDevConfig } from './tools/local-runtime-dev-config.ts'
 import { writeLocalPlatformDevConfig } from './tools/local-platform-dev-config.ts'
+import { patchWranglerProxyWorkerErrors } from './tools/patch-wrangler-proxy-worker-errors.ts'
 
 const envName = process.env.CLOUDFLARE_ENV ?? 'production'
 const portWaitTimeoutMs = 5000
@@ -243,6 +244,10 @@ const localWranglerPath = path.join(
 const wranglerCommand =
 	(existsSync(localWranglerPath) && localWranglerPath) ||
 	resolveLocalBinary('wrangler')
+
+// workers-sdk#14926: one ProxyWorker fetch failure must not exit `wrangler
+// dev`. Apply the pending upstream exemption before every local launch.
+patchWranglerProxyWorkerErrors()
 
 const proc = spawnChildProcess(wranglerCommand, commandArgs, {
 	stdio: ['inherit', 'inherit', 'inherit'],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Invest in the wrangler upgrade so a request-scoped `Error inside ProxyWorker` cannot kill the Playwright webServer, and so mock Cloudflare stays ready under wrangler 4.127.

## Why

The daily e2e-flake-hunter saw Validate 🎭 E2E die on PR #1820 (`page.goto('/account/passkeys')` after `login()` POST `/auth`) with `Error inside ProxyWorker` / `Network connection lost` (workers-sdk#14926). Official #15207 and #15252 keep that error request-scoped; they are not in a released wrangler yet. Latest wrangler is 4.127.1.

That bump also turns on Miniflare's local explorer by default. On Cloud Agent / CI hosts, explorer writes under `.wrangler/tmp` retrigger esbuild and leave ProxyWorker in a pause/reload loop (Ready prints; authenticated `/__mocks/meta` hangs). That is what broke `cloudflare-email.node.test.ts` and `artifacts-mock-cloudflare.node.test.ts` on the first push.

## Summary

- Bump `wrangler` to `^4.127.1` (and matching `@cloudflare/workers-types`).
- `tools/patch-wrangler-proxy-worker-errors.ts` rewrites wrangler's `handleErrorEvent` with the same ProxyController exemption as pending #15207 / #15252. `prepare` and `wrangler-env.ts` apply it.
- Default `X_LOCAL_EXPLORER=false` for `wrangler-env.ts` `dev`, Playwright's webServer, and the mock Cloudflare waiter. Opt in with `X_LOCAL_EXPLORER=true`.
- Encode Node crypto bytes as base64 in backup-control-plane tests after the workers-types `Buffer` change.

**Leftover:** drop `tools/patch-wrangler-proxy-worker-errors.ts` (and the `prepare` / `wrangler-env.ts` call sites) once a released wrangler logs `Error inside ProxyWorker` without exiting. Tracked in #1835.

## Testing

- `vitest run --project node-unit` packages for mock Cloudflare email/artifacts: pass after the explorer opt-out (previously 60s Ready hang).
- Husky `test:push`: node-unit 717 files / 2189 tests; workers-unit 88 files / 302 tests.
- `tools/patch-wrangler-proxy-worker-errors.node.test.ts` covers the rewrite and idempotence.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `65451b0c` · **Head:** `23ad4695`

**Classification:** composes — no primitives added or changed; this PR wires wrangler 4.127.1 and a local `handleErrorEvent` rewrite so request-scoped ProxyWorker failures stay non-fatal.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `backup-control-plane` | storage | composes — test helper encodes Node crypto bytes as base64 after the workers-types `Buffer` change |

Unmatched paths are the harness: `wrangler-env.ts`, `tools/patch-wrangler-proxy-worker-errors.ts`, Playwright webServer env, mock Cloudflare waiter, and contributing docs.

### Change flow

Playwright and node-unit spawn `wrangler dev` through `wrangler-env.ts`, which applies the ProxyWorker exemption and keeps local explorer off so Ready stays a live origin.

```mermaid
sequenceDiagram
	actor ci as Playwright / node-unit
	participant backupControlPlane as backup-control-plane
	ci->>backupControlPlane: encodeNodeBytesAsBase64 in signing tests
	Note over ci: wrangler-env.ts + mock waiter (unmatched harness)
	ci->>ci: patch handleErrorEvent; X_LOCAL_EXPLORER=false
	ci-->>ci: Ready stays live after request-scoped ProxyWorker errors
```

### Invariants

No primitives.yaml invariants. Per-user isolation and production request paths are unchanged.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-733798df-58c2-4ef1-bcfb-bcbcba800262?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-733798df-58c2-4ef1-bcfb-bcbcba800262&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved local development and end-to-end test stability by preventing request-level ProxyWorker failures from stopping the development server.
  * Prevented Wrangler’s local explorer from triggering reload loops and readiness hangs in CI and Cloud Agent environments.
  * Startup timeout errors now include the latest readiness-check failure reason.

* **Documentation**
  * Updated contributor and testing guidance to explain the new Wrangler behavior and configuration options.

* **Tests**
  * Expanded coverage for Wrangler error handling and reliable signature encoding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->