### PR TITLE
fix(sentry): drop D1 Too many requests queued overload blips

### DIFF
--- a/packages/backup-control-plane/backup-control-plane-test-support.ts
+++ b/packages/backup-control-plane/backup-control-plane-test-support.ts
@@ -15,9 +15,7 @@ import { type DurableExportStep } from './durable-export.ts'
 import { BackupError, objectKeyForBookmark } from './backup-policy.ts'
 import { type BackupEnvironment, type BackupManifest } from './backup-types.ts'
 
-export function encodeNodeBytesAsBase64(
-	bytes: ArrayBuffer | NodeJS.ArrayBufferView,
-) {
+export function encodeNodeBytesAsBase64(bytes: ArrayBuffer | Uint8Array) {
 	return Buffer.from(
 		bytes instanceof ArrayBuffer ? new Uint8Array(bytes) : bytes,
 	).toString('base64')

--- a/packages/shared/src/d1-retry.ts
+++ b/packages/shared/src/d1-retry.ts
@@ -27,15 +27,19 @@ export const d1LongRunningExportMessage =
 export const d1NetworkConnectionLostMessage = 'Network connection lost'
 
 /**
- * Cloudflare D1 capacity blip
- * (`D1_ERROR: D1 DB is overloaded. Requests queued for too long.`).
- * Not an application defect — D1's request queue timed out under platform
- * load. Same retry / Sentry-drop class as SQLITE_BUSY and binding transport
- * blips. Match only the exact D1 forms (optional `Error:` / `D1_ERROR:`
- * prefixes) so unrelated "… overloaded …" messages stay out.
+ * Cloudflare D1 capacity blips. Two exact platform phrasings exist:
+ * - `D1_ERROR: D1 DB is overloaded. Requests queued for too long.`
+ * - `D1_ERROR: D1 DB is overloaded. Too many requests queued.`
+ * Not an application defect — D1's request queue timed out or rejected under
+ * platform load. Same retry / Sentry-drop class as SQLITE_BUSY and binding
+ * transport blips. Match only these exact D1 forms (optional `Error:` /
+ * `D1_ERROR:` prefixes) so unrelated "… overloaded …" messages stay out.
  */
 export const d1DbOverloadedMessage =
 	'D1 DB is overloaded. Requests queued for too long'
+
+export const d1DbOverloadedTooManyQueuedMessage =
+	'D1 DB is overloaded. Too many requests queued'
 
 /**
  * Cloudflare D1 opaque platform failures with a support reference, e.g.
@@ -67,7 +71,10 @@ function isD1NetworkConnectionLostMessage(message: string) {
 }
 
 function isD1DbOverloadedMessage(message: string) {
-	return isExactD1PlatformMessage(message, d1DbOverloadedMessage)
+	return (
+		isExactD1PlatformMessage(message, d1DbOverloadedMessage) ||
+		isExactD1PlatformMessage(message, d1DbOverloadedTooManyQueuedMessage)
+	)
 }
 
 function isD1InternalErrorMessage(message: string) {
@@ -130,13 +137,13 @@ function withAttemptTimeout<T>(
  * Retries transient D1 unavailability: SQLITE_BUSY lock contention,
  * Cloudflare's "Currently processing a long-running export" (DR / REST
  * exports block other requests), binding "Network connection lost"
- * transport blips, "D1 DB is overloaded. Requests queued for too long"
- * capacity blips, and opaque D1 "internal error …; reference = …" platform
- * faults (including storage object-reset). D1 does not automatically retry
- * write queries, so cron lanes and long-running retention batches need
- * application-level backoff when they overlap with concurrent writers, an
- * in-flight export, a brief D1 session drop, a D1 capacity spike, or a D1
- * backend blip.
+ * transport blips, "D1 DB is overloaded. Requests queued for too long" /
+ * "D1 DB is overloaded. Too many requests queued" capacity blips, and opaque
+ * D1 "internal error …; reference = …" platform faults (including storage
+ * object-reset). D1 does not automatically retry write queries, so cron lanes
+ * and long-running retention batches need application-level backoff when they
+ * overlap with concurrent writers, an in-flight export, a brief D1 session
+ * drop, a D1 capacity spike, or a D1 backend blip.
  *
  * When `attemptTimeoutMs` is set, a hung attempt is also retried so a single
  * idle-database stall cannot consume an outer deadline.

--- a/packages/worker/src/d1-retry.node.test.ts
+++ b/packages/worker/src/d1-retry.node.test.ts
@@ -31,6 +31,16 @@ test('runD1WithRetry matches lock errors, retries them, and rethrows other failu
 	).toBe(true)
 	expect(
 		isRetryableD1LockError(
+			new Error('D1_ERROR: D1 DB is overloaded. Too many requests queued.'),
+		),
+	).toBe(true)
+	expect(
+		isRetryableD1LockError(
+			new Error('D1 DB is overloaded. Too many requests queued'),
+		),
+	).toBe(true)
+	expect(
+		isRetryableD1LockError(
 			new Error(
 				'D1_ERROR: internal error; reference = 0u3odos5iotccpol68ppc0eg',
 			),

--- a/packages/worker/src/sentry-options.node.test.ts
+++ b/packages/worker/src/sentry-options.node.test.ts
@@ -90,6 +90,17 @@ test('filterSentryEvent drops expected platform and caller noise and keeps real 
 			exception: {
 				values: [
 					{
+						value: 'D1_ERROR: D1 DB is overloaded. Too many requests queued.',
+					},
+				],
+			},
+		}),
+	).toBeNull()
+	expect(
+		filterSentryEvent({
+			exception: {
+				values: [
+					{
 						value:
 							'D1_ERROR: internal error; reference = 0u3odos5iotccpol68ppc0eg',
 					},

--- a/packages/worker/src/sentry-options.ts
+++ b/packages/worker/src/sentry-options.ts
@@ -463,12 +463,12 @@ export function buildSentryOptions(env: Env): CloudflareOptions {
 		// forwarded them. The same applies to "Currently processing a
 		// long-running export" while the nightly DR D1 export holds the DB,
 		// "Network connection lost" when the D1 binding drops mid-query,
-		// "D1 DB is overloaded. Requests queued for too long" when D1's
-		// request queue times out under platform load, and opaque D1
-		// "internal error …; reference = …" platform faults (including
-		// storage object-reset). These are transient platform unavailability
-		// errors retried in app code and should not open or regress Sentry
-		// issues.
+		// "D1 DB is overloaded. Requests queued for too long" / "Too many
+		// requests queued" when D1's request queue times out or rejects under
+		// platform load, and opaque D1 "internal error …; reference = …"
+		// platform faults (including storage object-reset). These are
+		// transient platform unavailability errors retried in app code and
+		// should not open or regress Sentry issues.
 		//
 		// User-authored failures are dropped primarily via `UserCodeError`
 		// (`filterUserCodeErrorSentryEvent`). Plan-limit denials


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop Cloudflare's alternate D1 overload wording from opening Sentry issues, and retry it the same way as the existing overload form.

## Why

Sentry issue [7699471418](https://sentry.io/organizations/kent-c-dodds-tech-llc/issues/7699471418/) (and siblings KODY-67 / KODY-68) reports:

`D1_ERROR: D1 DB is overloaded. Too many requests queued.`

We already treat `D1 DB is overloaded. Requests queued for too long` as a retryable platform blip (#1473). Cloudflare now also emits this second exact phrasing on `/mcp` during `getUserRolesAndPermissions`. Exact-match filters missed it, so brief capacity spikes reopened Sentry noise.

## Summary

- Add `d1DbOverloadedTooManyQueuedMessage` next to the existing overload constant in `packages/shared/src/d1-retry.ts`.
- Include it in `isRetryableD1LockMessage` so `runD1WithRetry` and `beforeSend` (`filterRetryableD1LockSentryEvent`) both recognize it.
- Extend unit coverage in `d1-retry` and `sentry-options` tests.
- Unrelated unblocker: narrow `encodeNodeBytesAsBase64` to `Uint8Array` so pre-commit typecheck passes under current `@types/node` (BigUint64Array was included via `ArrayBufferView`).

Siblings addressed by the same filter: **7699471248 (KODY-67)**, **7699471388 (KODY-68)**. Unrelated client issue **KODY-3W** left alone.

## Testing

- `vitest` node-unit: `d1-retry.node.test.ts`, `sentry-options.node.test.ts`
- Pre-push: `npm run test:node` + `npm run test:workers` (green)

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `8a8b8ec7` · **Head:** `2e0c513c`

**Classification:** composes — adds a second exact Cloudflare D1 overload string to the existing retry/Sentry-drop matcher; no new primitives.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `backup-control-plane` | storage | composes — narrow test helper `encodeNodeBytesAsBase64` to `Uint8Array` so pre-commit typecheck passes under current `@types/node` |
| _(unmatched)_ `packages/shared/src/d1-retry.ts` + worker Sentry options | — | composes — recognize `D1 DB is overloaded. Too many requests queued` beside the existing overload wording |

### Change flow

D1 overload blips with the new Cloudflare wording retry and are dropped from Sentry like the prior overload form.

```mermaid
sequenceDiagram
	actor caller as caller
	participant runD1 as d1-retry
	participant d1 as Cloudflare D1
	participant sentry as Sentry beforeSend
	caller->>runD1: runD1WithRetry(query)
	runD1->>d1: prepare/bind/all
	d1-->>runD1: Too many requests queued
	runD1->>runD1: match new exact overload string + backoff
	Note over sentry: beforeSend drops both overload wordings via isRetryableD1LockSentryEvent
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-35c2ece2-58b6-4d17-9af2-c07f8533a1d9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-35c2ece2-58b6-4d17-9af2-c07f8533a1d9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of D1 database capacity errors by recognizing additional queue-overload messages as retryable.
  * Prevented expected D1 overload events from being reported as actionable errors.

* **Tests**
  * Added coverage for newly recognized D1 overload scenarios and error filtering behavior.

* **Refactor**
  * Limited byte encoding inputs to `ArrayBuffer` and `Uint8Array`, improving consistency for supported data formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->