### PR TITLE
Close MCP lockout after password reset and stop shared DCR deletes

### DIFF
--- a/docs/contributing/architecture/authentication.md
+++ b/docs/contributing/architecture/authentication.md
@@ -40,9 +40,13 @@ The cookie payload stores:
 - `issuedAt` (epoch ms when the cookie was issued or last renewed)
 - `rememberMe` when the login used remember-me
 
-Password reset confirmation writes `users.password_changed_at`. Session
-resolution rejects cookies whose `issuedAt` is missing or at/before that
-timestamp, so a reset invalidates every existing browser session.
+Password reset confirmation revokes every MCP OAuth grant for that user, then
+writes `users.password_changed_at`. Session resolution rejects cookies whose
+`issuedAt` is missing or at/before that timestamp, so a reset invalidates every
+existing browser and package-app session. `/mcp` rejects access tokens whose
+`createdAt` is at or before that timestamp (`invalid_token`), so already-issued
+bearers die immediately; hosts that refresh then hit the revoked grant and must
+start a new OAuth flow.
 
 `users.id` never crosses the cookie boundary. Session resolution looks up the
 stable id and only then uses the numeric primary key for internal D1 joins.

--- a/docs/contributing/architecture/authentication.md
+++ b/docs/contributing/architecture/authentication.md
@@ -40,13 +40,14 @@ The cookie payload stores:
 - `issuedAt` (epoch ms when the cookie was issued or last renewed)
 - `rememberMe` when the login used remember-me
 
-Password reset confirmation revokes every MCP OAuth grant for that user, then
-writes `users.password_changed_at`. Session resolution rejects cookies whose
-`issuedAt` is missing or at/before that timestamp, so a reset invalidates every
-existing browser and package-app session. `/mcp` rejects access tokens whose
-`createdAt` is at or before that timestamp (`invalid_token`), so already-issued
-bearers die immediately; hosts that refresh then hit the revoked grant and must
-start a new OAuth flow.
+Password reset confirmation revokes every MCP OAuth grant for that user, writes
+`users.password_changed_at`, then revokes again so a grant created in that
+window cannot survive. Session resolution rejects cookies whose `issuedAt` is
+missing or at/before that timestamp, so a reset invalidates every existing
+browser and package-app session. `/mcp` rejects access tokens whose `createdAt`
+is at or before that timestamp (`invalid_token`), so already-issued bearers die
+immediately; hosts that refresh then hit the revoked grant and must start a new
+OAuth flow.
 
 `users.id` never crosses the cookie boundary. Session resolution looks up the
 stable id and only then uses the numeric primary key for internal D1 joins.

--- a/docs/contributing/security.md
+++ b/docs/contributing/security.md
@@ -466,13 +466,13 @@ change to these decisions here so future agents do not relitigate them.
 - **Stateless sessions revoke after password reset.** `kody_session` is a signed
   cookie with no server store, so there is no global "log out everywhere"
   button. Password reset confirmation revokes every MCP OAuth grant for the
-  user, then stamps `users.password_changed_at`. Browser and package-app
-  sessions carry `issuedAt`; `resolveRequestAuth` rejects cookies issued at or
-  before that timestamp (missing `issuedAt` fails closed once a password change
-  exists). `/mcp` applies the same timestamp to the access token `createdAt`
-  (Unix seconds) so already-issued bearers fail closed as `invalid_token`. A
-  future hardening could add an explicit "sign out other sessions" control
-  without waiting for a reset.
+  user, stamps `users.password_changed_at`, then revokes again. Browser and
+  package-app sessions carry `issuedAt`; `resolveRequestAuth` rejects cookies
+  issued at or before that timestamp (missing `issuedAt` fails closed once a
+  password change exists). `/mcp` applies the same timestamp to the access token
+  `createdAt` (Unix seconds) so already-issued bearers fail closed as
+  `invalid_token`. A future hardening could add an explicit "sign out other
+  sessions" control without waiting for a reset.
 - **OAuth authorize client reset is grant-scoped.** A signed-in user can reset a
   mismatched DCR client for **their** grants only. `deleteClient` runs only when
   `user_mcp_oauth_clients` shows they own that registration. Shared host clients

--- a/docs/contributing/security.md
+++ b/docs/contributing/security.md
@@ -465,11 +465,18 @@ change to these decisions here so future agents do not relitigate them.
 
 - **Stateless sessions revoke after password reset.** `kody_session` is a signed
   cookie with no server store, so there is no global "log out everywhere"
-  button. Password reset confirmation stamps `users.password_changed_at` and
-  every browser session carries `issuedAt`; `resolveRequestAuth` rejects cookies
-  issued at or before that timestamp (missing `issuedAt` fails closed once a
-  password change exists). A future hardening could add an explicit "sign out
-  other sessions" control without waiting for a reset.
+  button. Password reset confirmation revokes every MCP OAuth grant for the
+  user, then stamps `users.password_changed_at`. Browser and package-app
+  sessions carry `issuedAt`; `resolveRequestAuth` rejects cookies issued at or
+  before that timestamp (missing `issuedAt` fails closed once a password change
+  exists). `/mcp` applies the same timestamp to the access token `createdAt`
+  (Unix seconds) so already-issued bearers fail closed as `invalid_token`. A
+  future hardening could add an explicit "sign out other sessions" control
+  without waiting for a reset.
+- **OAuth authorize client reset is grant-scoped.** A signed-in user can reset a
+  mismatched DCR client for **their** grants only. `deleteClient` runs only when
+  `user_mcp_oauth_clients` shows they own that registration. Shared host clients
+  (Cursor, Claude, Gemini) stay registered for other users.
 - **Account secret reveal is owner-scoped, not password-reauthenticated.** See
   the "Account secret reveal" section of
   [`architecture/authentication.md`](./architecture/authentication.md).

--- a/packages/worker/client/routes/oauth-authorize.tsx
+++ b/packages/worker/client/routes/oauth-authorize.tsx
@@ -443,8 +443,8 @@ export function OAuthAuthorizeRoute(handle: Handle) {
 				: 'Authorize'
 		const resetClientLabel =
 			submittingDecision === 'reset-client'
-				? 'Deleting stored client...'
-				: 'Delete stored client'
+				? 'Resetting this connection...'
+				: 'Reset this connection'
 
 		return (
 			<section mix={css(pageCss)}>
@@ -526,9 +526,9 @@ export function OAuthAuthorizeRoute(handle: Handle) {
 					<section mix={css(cardCss)}>
 						<p mix={css(sectionTitleCss)}>Reset stored connection</p>
 						<p mix={css(descriptionCss)}>
-							Delete this trusted client&apos;s saved registration and grants,
-							then start the connection again from the client to create a fresh
-							record.
+							Revoke this account&apos;s grants for the client, then start the
+							connection again. Shared client registrations used by other
+							accounts stay in place.
 						</p>
 						{isLoggedIn ? (
 							<button
@@ -543,7 +543,7 @@ export function OAuthAuthorizeRoute(handle: Handle) {
 							</button>
 						) : isSessionReady ? (
 							<p mix={css(descriptionCss)}>
-								Sign in first, then delete the stored client record.
+								Sign in first, then reset this connection.
 							</p>
 						) : null}
 					</section>

--- a/packages/worker/src/app/account-deletion.ts
+++ b/packages/worker/src/app/account-deletion.ts
@@ -1,5 +1,9 @@
 import { getErrorMessage } from '@kody-internal/shared/error-message.ts'
 import {
+	type OAuthGrantHelpers,
+	revokeAllOAuthGrantsBestEffort,
+} from '#worker/oauth-grants.ts'
+import {
 	cancelSubscription,
 	deleteCustomer,
 	listSubscriptions,
@@ -75,16 +79,7 @@ import {
 // node-only unit tests can require this module without dragging in
 // `cloudflare:workers` (the OAuth provider package re-exports through that
 // runtime symbol). The shape mirrors the subset of OAuthHelpers we use.
-type OAuthGrantPage = {
-	items: Array<{ id: string; clientId: string }>
-	cursor: string | undefined
-}
-type OAuthHelpersShape = {
-	listUserGrants(
-		userId: string,
-		options: { cursor: string | undefined },
-	): Promise<OAuthGrantPage>
-	revokeGrant(grantId: string, userId: string): Promise<unknown>
+type OAuthHelpersShape = OAuthGrantHelpers & {
 	deleteClient?(clientId: string): Promise<unknown>
 }
 
@@ -456,44 +451,6 @@ async function cancelSubscriptionsAndDeleteStripeCustomer(input: {
 			failures,
 			`Stripe account cleanup encountered ${failures.length} failure(s).`,
 		)
-	}
-}
-
-async function revokeAllOAuthGrants(input: {
-	helpers: OAuthHelpersShape
-	userId: string
-	warnings: Array<string>
-}): Promise<number> {
-	// Both the page listing and the individual revoke calls can throw, and
-	// neither failure should abort the larger account-deletion cascade -
-	// the rest of the steps still need to run so the user's data is
-	// removed even if the OAuth provider is briefly unavailable.
-	let cursor: string | undefined
-	let revoked = 0
-	while (true) {
-		let page: Awaited<ReturnType<OAuthHelpersShape['listUserGrants']>>
-		try {
-			page = await input.helpers.listUserGrants(input.userId, { cursor })
-		} catch (error) {
-			const message = getErrorMessage(error)
-			input.warnings.push(
-				`OAuth grant listing failed; revoked ${revoked} grant(s) before the failure: ${message}`,
-			)
-			return revoked
-		}
-		for (const grant of page.items) {
-			try {
-				await input.helpers.revokeGrant(grant.id, input.userId)
-				revoked += 1
-			} catch (error) {
-				const message = getErrorMessage(error)
-				input.warnings.push(
-					`OAuth grant revoke failed for grant ${grant.id}: ${message}`,
-				)
-			}
-		}
-		if (!page.cursor) return revoked
-		cursor = page.cursor
 	}
 }
 
@@ -1211,7 +1168,7 @@ export async function deleteUserAccount(input: {
 			}
 		}
 		try {
-			result.revokedOAuthGrants = await revokeAllOAuthGrants({
+			result.revokedOAuthGrants = await revokeAllOAuthGrantsBestEffort({
 				helpers,
 				userId: input.mcpUserId,
 				warnings,

--- a/packages/worker/src/app/account-mcp-oauth-clients.ts
+++ b/packages/worker/src/app/account-mcp-oauth-clients.ts
@@ -158,6 +158,37 @@ export async function listOwnedUserMcpOauthClientIds(
 	return (result.results ?? []).map((row) => row.client_id)
 }
 
+export async function userOwnsMcpOauthClient(
+	db: D1Database,
+	userId: number,
+	clientId: string,
+): Promise<boolean> {
+	const row = await db
+		.prepare(
+			`SELECT client_id
+			FROM user_mcp_oauth_clients
+			WHERE user_id = ? AND client_id = ? AND revoked_at IS NULL`,
+		)
+		.bind(userId, clientId)
+		.first<{ client_id: string }>()
+	return row?.client_id === clientId
+}
+
+export async function markUserMcpOauthClientRevokedByClientId(
+	db: D1Database,
+	userId: number,
+	clientId: string,
+): Promise<void> {
+	await db
+		.prepare(
+			`UPDATE user_mcp_oauth_clients
+			SET revoked_at = ?
+			WHERE user_id = ? AND client_id = ? AND revoked_at IS NULL`,
+		)
+		.bind(new Date().toISOString(), userId, clientId)
+		.run()
+}
+
 async function discardCreatedProviderClient(input: {
 	db: D1Database
 	helpers: McpOauthClientHelpers

--- a/packages/worker/src/app/auth-session.node.test.ts
+++ b/packages/worker/src/app/auth-session.node.test.ts
@@ -124,6 +124,16 @@ test('password-change invalidation covers legacy cookies, second-precision SQLit
 		}),
 	).toBe(false)
 
+	expect(parsePasswordChangedAtMs('2026-07-25T12:00:00+00:00')).toBe(
+		Date.parse('2026-07-25T12:00:00+00:00') + 999,
+	)
+	expect(parsePasswordChangedAtMs('2026-07-25 12:00:00+00:00')).toBe(
+		Date.parse('2026-07-25T12:00:00+00:00') + 999,
+	)
+	expect(parsePasswordChangedAtMs('2026-07-25T12:00:00Z')).toBe(
+		Date.parse('2026-07-25T12:00:00Z') + 999,
+	)
+
 	const msPrecisionChangedAt = parsePasswordChangedAtMs(
 		'2026-07-25T12:00:00.400Z',
 	)

--- a/packages/worker/src/app/auth-session.ts
+++ b/packages/worker/src/app/auth-session.ts
@@ -1,4 +1,5 @@
 import { createCookie } from 'remix/cookie'
+import { isIssuedAtInvalidatedByPasswordChange } from '#worker/password-change-lockout.ts'
 import { isStableUserId } from '#worker/user-id.ts'
 
 const defaultSessionMaxAgeSeconds = 60 * 60 * 24 * 7
@@ -124,9 +125,10 @@ export function isAuthSessionInvalidatedByPasswordChange(input: {
 	issuedAt: number | undefined
 	passwordChangedAtMs: number | null
 }): boolean {
-	if (input.passwordChangedAtMs == null) return false
-	if (typeof input.issuedAt !== 'number') return true
-	return input.issuedAt <= input.passwordChangedAtMs
+	return isIssuedAtInvalidatedByPasswordChange({
+		issuedAtMs: input.issuedAt,
+		passwordChangedAtMs: input.passwordChangedAtMs,
+	})
 }
 
 function normalizeAuthSession(session: StoredAuthSession): AuthSession {

--- a/packages/worker/src/app/handlers/password-reset.node.test.ts
+++ b/packages/worker/src/app/handlers/password-reset.node.test.ts
@@ -249,20 +249,33 @@ test('password reset skips sending when APP_BASE_URL is missing and logs a redac
 	}
 })
 
+function createTrackingGrantHelpers(
+	initialGrants: Array<{ id: string; clientId: string }>,
+) {
+	const revokedGrantIds = new Array<string>()
+	const liveGrants = [...initialGrants]
+	return {
+		revokedGrantIds,
+		liveGrants,
+		helpers: {
+			listUserGrants: vi.fn(async () => ({
+				items: liveGrants.filter(
+					(grant) => !revokedGrantIds.includes(grant.id),
+				),
+			})),
+			revokeGrant: vi.fn(async (grantId: string) => {
+				revokedGrantIds.push(grantId)
+			}),
+		},
+	}
+}
+
 test('password reset confirm revokes MCP grants before stamping password_changed_at', async () => {
 	vi.clearAllMocks()
-	const revokedGrantIds = new Array<string>()
-	const helpers = {
-		listUserGrants: vi.fn(async () => ({
-			items: [
-				{ id: 'grant-1', clientId: 'client-a' },
-				{ id: 'grant-2', clientId: 'client-b' },
-			],
-		})),
-		revokeGrant: vi.fn(async (grantId: string) => {
-			revokedGrantIds.push(grantId)
-		}),
-	}
+	const { helpers, revokedGrantIds } = createTrackingGrantHelpers([
+		{ id: 'grant-1', clientId: 'client-a' },
+		{ id: 'grant-2', clientId: 'client-b' },
+	])
 	const handler = createPasswordResetConfirmHandler(
 		createEnv({
 			OAUTH_PROVIDER: helpers,
@@ -302,6 +315,38 @@ test('password reset confirm revokes MCP grants before stamping password_changed
 			result: 'success',
 		}),
 	)
+})
+
+test('password reset confirm revokes a grant created between first revoke and password_changed_at', async () => {
+	vi.clearAllMocks()
+	const { helpers, revokedGrantIds, liveGrants } = createTrackingGrantHelpers([
+		{ id: 'grant-a', clientId: 'client-a' },
+	])
+	mockModule.update.mockImplementationOnce(async () => {
+		liveGrants.push({ id: 'grant-raced', clientId: 'client-b' })
+	})
+	const handler = createPasswordResetConfirmHandler(
+		createEnv({
+			OAUTH_PROVIDER: helpers,
+		}),
+	)
+
+	const response = await handler.handler({
+		request: new Request('https://example.com/password-reset/confirm', {
+			method: 'POST',
+			body: JSON.stringify({
+				token: 'a'.repeat(64),
+				password: 'new-password-123',
+			}),
+		}),
+		url: new URL('https://example.com/password-reset/confirm'),
+		params: {},
+	})
+
+	expect(response.status).toBe(200)
+	expect(revokedGrantIds).toEqual(['grant-a', 'grant-raced'])
+	expect(mockModule.update).toHaveBeenCalled()
+	expect(mockModule.deleteMany).toHaveBeenCalled()
 })
 
 test('password reset confirm fails closed when MCP grants cannot be revoked', async () => {

--- a/packages/worker/src/app/handlers/password-reset.node.test.ts
+++ b/packages/worker/src/app/handlers/password-reset.node.test.ts
@@ -5,10 +5,24 @@ import type * as AuditLog from '#worker/audit-log.ts'
 const mockModule = vi.hoisted(() => ({
 	createRecord: vi.fn(async () => undefined),
 	deleteMany: vi.fn(async () => undefined),
-	findOne: vi.fn(async () => ({
-		id: 123,
-		email: 'user@example.com',
-	})),
+	update: vi.fn(async () => undefined),
+	findOne: vi.fn(
+		async (_table: unknown, query?: { where?: Record<string, unknown> }) => {
+			if (query?.where && 'token_hash' in query.where) {
+				return {
+					id: 1,
+					user_id: 123,
+					token_hash: query.where.token_hash,
+					expires_at: Date.now() + 60_000,
+				}
+			}
+			return {
+				id: 123,
+				email: 'user@example.com',
+				stable_user_id: 'a'.repeat(64),
+			}
+		},
+	),
 	sendCloudflareEmail: vi.fn(async () => ({ ok: true })),
 }))
 
@@ -17,6 +31,7 @@ vi.mock('#worker/db.ts', () => ({
 		create: mockModule.createRecord,
 		deleteMany: mockModule.deleteMany,
 		findOne: mockModule.findOne,
+		update: mockModule.update,
 	}),
 	passwordResetsTable: {},
 	usersTable: {},
@@ -39,7 +54,7 @@ vi.mock('#app/email/cloudflare-email.ts', () => ({
 		mockModule.sendCloudflareEmail(...args),
 }))
 
-const { createPasswordResetRequestHandler } =
+const { createPasswordResetRequestHandler, createPasswordResetConfirmHandler } =
 	await import('./password-reset.ts')
 
 function createPasswordResetD1Mock() {
@@ -68,7 +83,7 @@ function createPasswordResetD1Mock() {
 	} as unknown as D1Database
 }
 
-function createEnv(overrides: Partial<Env> = {}) {
+function createEnv(overrides: Record<string, unknown> = {}) {
 	return {
 		APP_DB: createPasswordResetD1Mock(),
 		CLOUDFLARE_ACCOUNT_ID: 'account-id',
@@ -232,4 +247,101 @@ test('password reset skips sending when APP_BASE_URL is missing and logs a redac
 	} finally {
 		warnSpy.mockRestore()
 	}
+})
+
+test('password reset confirm revokes MCP grants before stamping password_changed_at', async () => {
+	vi.clearAllMocks()
+	const revokedGrantIds = new Array<string>()
+	const helpers = {
+		listUserGrants: vi.fn(async () => ({
+			items: [
+				{ id: 'grant-1', clientId: 'client-a' },
+				{ id: 'grant-2', clientId: 'client-b' },
+			],
+		})),
+		revokeGrant: vi.fn(async (grantId: string) => {
+			revokedGrantIds.push(grantId)
+		}),
+	}
+	const handler = createPasswordResetConfirmHandler(
+		createEnv({
+			OAUTH_PROVIDER: helpers,
+		}),
+	)
+
+	const response = await handler.handler({
+		request: new Request('https://example.com/password-reset/confirm', {
+			method: 'POST',
+			body: JSON.stringify({
+				token: 'a'.repeat(64),
+				password: 'new-password-123',
+			}),
+		}),
+		url: new URL('https://example.com/password-reset/confirm'),
+		params: {},
+	})
+
+	expect(response.status).toBe(200)
+	expect(await response.json()).toEqual({ ok: true })
+	expect(helpers.listUserGrants).toHaveBeenCalledWith('a'.repeat(64), {
+		cursor: undefined,
+	})
+	expect(revokedGrantIds).toEqual(['grant-1', 'grant-2'])
+	expect(mockModule.update).toHaveBeenCalledWith(
+		{},
+		123,
+		expect.objectContaining({
+			password_changed_at: expect.any(String),
+		}),
+	)
+	expect(mockModule.deleteMany).toHaveBeenCalled()
+	expect(logAuditEventSpy).toHaveBeenCalledWith(
+		expect.objectContaining({
+			category: 'auth',
+			action: 'password_reset_confirm',
+			result: 'success',
+		}),
+	)
+})
+
+test('password reset confirm fails closed when MCP grants cannot be revoked', async () => {
+	vi.clearAllMocks()
+	const handler = createPasswordResetConfirmHandler(
+		createEnv({
+			OAUTH_PROVIDER: {
+				listUserGrants: async () => ({
+					items: [{ id: 'grant-1', clientId: 'client-a' }],
+				}),
+				revokeGrant: async () => {
+					throw new Error('kv unavailable')
+				},
+			},
+		}),
+	)
+
+	const response = await handler.handler({
+		request: new Request('https://example.com/password-reset/confirm', {
+			method: 'POST',
+			body: JSON.stringify({
+				token: 'a'.repeat(64),
+				password: 'new-password-123',
+			}),
+		}),
+		url: new URL('https://example.com/password-reset/confirm'),
+		params: {},
+	})
+
+	expect(response.status).toBe(500)
+	expect(await response.json()).toEqual({
+		error: 'Unable to finish password reset right now.',
+	})
+	expect(mockModule.update).not.toHaveBeenCalled()
+	expect(logAuditEventSpy).toHaveBeenCalledWith(
+		expect.objectContaining({
+			category: 'auth',
+			action: 'password_reset_confirm',
+			result: 'failure',
+			reason: 'kv unavailable',
+		}),
+	)
 })

--- a/packages/worker/src/app/handlers/password-reset.ts
+++ b/packages/worker/src/app/handlers/password-reset.ts
@@ -297,31 +297,41 @@ export function createPasswordResetConfirmHandler(env: Env) {
 				)
 			}
 
-			// Revoke MCP grants before stamping password_changed_at so a failed
-			// revoke cannot leave refresh tokens alive after the user thinks
-			// lockout succeeded. Retrying the same reset token is safe.
-			try {
-				await revokeAllOAuthGrantsForUser({
-					helpers,
-					userId: resolveUserStableId(userRecord),
-				})
-			} catch (error) {
-				void logAuditEvent({
-					category: 'auth',
-					action: 'password_reset_confirm',
-					result: 'failure',
-					ip: requestIp,
-					path: url.pathname,
-					reason:
-						error instanceof Error
-							? error.message
-							: 'oauth_grant_revoke_failed',
-				})
-				return Response.json(
-					{ error: 'Unable to finish password reset right now.' },
-					{ status: 500 },
-				)
+			const stableUserId = resolveUserStableId(userRecord)
+			const oauthHelpers = helpers
+			async function revokeGrantsOrFail() {
+				try {
+					await revokeAllOAuthGrantsForUser({
+						helpers: oauthHelpers,
+						userId: stableUserId,
+					})
+					return null
+				} catch (error) {
+					void logAuditEvent({
+						category: 'auth',
+						action: 'password_reset_confirm',
+						result: 'failure',
+						ip: requestIp,
+						path: url.pathname,
+						reason:
+							error instanceof Error
+								? error.message
+								: 'oauth_grant_revoke_failed',
+					})
+					return Response.json(
+						{ error: 'Unable to finish password reset right now.' },
+						{ status: 500 },
+					)
+				}
 			}
+
+			// Revoke before stamping so a failed listing/revoke cannot leave
+			// refresh tokens alive after the user thinks lockout succeeded.
+			// Stamp, then revoke again so a grant created in that window is
+			// still collected. Reset tokens stay until the second pass
+			// succeeds so retry remains safe.
+			const beforeStampFailure = await revokeGrantsOrFail()
+			if (beforeStampFailure) return beforeStampFailure
 
 			const passwordHash = await createPasswordHash(password)
 			// Millisecond ISO so same-second re-login after reset is not
@@ -331,6 +341,10 @@ export function createPasswordResetConfirmHandler(env: Env) {
 				password_changed_at: new Date().toISOString(),
 				updated_at: utcSqliteTimestamp(),
 			})
+
+			const afterStampFailure = await revokeGrantsOrFail()
+			if (afterStampFailure) return afterStampFailure
+
 			await db.deleteMany(passwordResetsTable, {
 				where: { user_id: resetRecord.user_id },
 			})

--- a/packages/worker/src/app/handlers/password-reset.ts
+++ b/packages/worker/src/app/handlers/password-reset.ts
@@ -20,6 +20,11 @@ import { getPasswordPolicyError } from '@kody-internal/shared/password-policy.ts
 import { verifyPublicFormProtection } from '#app/public-form-protection.ts'
 import { buildPasswordResetEmail } from '#app/email/messages.ts'
 import { resolveTransactionalEmailConfig } from '#app/email/sender-config.ts'
+import {
+	type OAuthGrantHelpers,
+	revokeAllOAuthGrantsForUser,
+} from '#worker/oauth-grants.ts'
+import { resolveUserStableId } from '#worker/user-id.ts'
 
 const resetRequestSchema = object({
 	email: string(),
@@ -254,6 +259,67 @@ export function createPasswordResetConfirmHandler(env: Env) {
 				return Response.json(
 					{ error: 'Reset link is invalid or expired.' },
 					{ status: 400 },
+				)
+			}
+
+			const userRecord = await db.findOne(usersTable, {
+				where: { id: resetRecord.user_id },
+			})
+			if (!userRecord) {
+				void logAuditEvent({
+					category: 'auth',
+					action: 'password_reset_confirm',
+					result: 'failure',
+					ip: requestIp,
+					path: url.pathname,
+					reason: 'user_not_found',
+				})
+				return Response.json(
+					{ error: 'Reset link is invalid or expired.' },
+					{ status: 400 },
+				)
+			}
+
+			const helpers = (env as Env & { OAUTH_PROVIDER?: OAuthGrantHelpers })
+				.OAUTH_PROVIDER
+			if (!helpers) {
+				void logAuditEvent({
+					category: 'auth',
+					action: 'password_reset_confirm',
+					result: 'failure',
+					ip: requestIp,
+					path: url.pathname,
+					reason: 'oauth_provider_unavailable',
+				})
+				return Response.json(
+					{ error: 'Unable to finish password reset right now.' },
+					{ status: 500 },
+				)
+			}
+
+			// Revoke MCP grants before stamping password_changed_at so a failed
+			// revoke cannot leave refresh tokens alive after the user thinks
+			// lockout succeeded. Retrying the same reset token is safe.
+			try {
+				await revokeAllOAuthGrantsForUser({
+					helpers,
+					userId: resolveUserStableId(userRecord),
+				})
+			} catch (error) {
+				void logAuditEvent({
+					category: 'auth',
+					action: 'password_reset_confirm',
+					result: 'failure',
+					ip: requestIp,
+					path: url.pathname,
+					reason:
+						error instanceof Error
+							? error.message
+							: 'oauth_grant_revoke_failed',
+				})
+				return Response.json(
+					{ error: 'Unable to finish password reset right now.' },
+					{ status: 500 },
 				)
 			}
 

--- a/packages/worker/src/app/request-auth-cache.ts
+++ b/packages/worker/src/app/request-auth-cache.ts
@@ -11,10 +11,10 @@
 import * as Sentry from '@sentry/cloudflare'
 import {
 	destroyAuthCookie,
-	isAuthSessionInvalidatedByPasswordChange,
 	isSecureRequest,
 	readParsedAuthSession,
 } from '#app/auth-session.ts'
+import { isCredentialInvalidatedByStoredPasswordChange } from '#worker/password-change-lockout.ts'
 import { getUserRolesAndPermissions } from '#worker/identity/permissions-db.ts'
 import { type PermissionString, type RoleName } from '#universal/permissions.ts'
 import { resolveDisplayName } from '#worker/identity/username.ts'
@@ -150,25 +150,14 @@ async function resolveRequestAuth(
  * that second so cookies issued later in the same second cannot survive a
  * reset that only recorded second precision.
  */
-export function parsePasswordChangedAtMs(value: string | null | undefined) {
-	if (!value) return null
-	const trimmed = value.trim()
-	if (!trimmed) return null
-	const normalized = trimmed.includes('T')
-		? trimmed
-		: `${trimmed.replace(' ', 'T')}Z`
-	const ms = Date.parse(normalized)
-	if (!Number.isFinite(ms)) return null
-	const hasFractionalSeconds = /(?:[T ])\d{2}:\d{2}:\d{2}\.\d/.test(normalized)
-	return hasFractionalSeconds ? ms : ms + 999
-}
+export { parsePasswordChangedAtMs } from '#worker/password-change-lockout.ts'
 
 /**
  * True when a session predates the account's stored `password_changed_at`.
  *
- * Every session flavor (browser `kody_session`, package-app `kody_pkg_session`)
- * must share this decision, so a password reset can never revoke one and leave
- * another alive.
+ * Every session flavor (browser `kody_session`, package-app `kody_pkg_session`,
+ * and MCP access tokens) must share this decision, so a password reset can
+ * never revoke one and leave another alive.
  *
  * Fail-closed behavior is scoped to accounts that have a stored timestamp: a
  * value that exists but cannot be parsed invalidates the session, and so does a
@@ -181,12 +170,9 @@ export function isSessionInvalidatedByStoredPasswordChange(input: {
 	issuedAt: number | undefined
 	storedPasswordChangedAt: string | null | undefined
 }): boolean {
-	const passwordChangedAtRaw = input.storedPasswordChangedAt?.trim() ?? ''
-	const passwordChangedAtMs = parsePasswordChangedAtMs(passwordChangedAtRaw)
-	if (passwordChangedAtRaw !== '' && passwordChangedAtMs === null) return true
-	return isAuthSessionInvalidatedByPasswordChange({
-		issuedAt: input.issuedAt,
-		passwordChangedAtMs,
+	return isCredentialInvalidatedByStoredPasswordChange({
+		issuedAtMs: input.issuedAt,
+		storedPasswordChangedAt: input.storedPasswordChangedAt,
 	})
 }
 

--- a/packages/worker/src/mcp-auth-user-context.node.test.ts
+++ b/packages/worker/src/mcp-auth-user-context.node.test.ts
@@ -22,6 +22,7 @@ type GrantUserRow = {
 	deleting_at?: string | null
 	email_verified_at?: string | null
 	suspended_at?: string | null
+	password_changed_at?: string | null
 }
 
 function createMockAppDb(options: {
@@ -86,11 +87,13 @@ test('buildMcpUserContextFromGrantProps resolves identity from the stable user i
 		},
 		emailVerified: false,
 		suspended: false,
+		passwordChangedAt: null,
 	})
 	expect(refreshed.queries).toHaveLength(1)
 	expect(refreshed.queries[0]?.params).toEqual(['stable-admin-id'])
 	expect(refreshed.queries[0]?.sql).toContain('email_verified_at')
 	expect(refreshed.queries[0]?.sql).toContain('suspended_at')
+	expect(refreshed.queries[0]?.sql).toContain('password_changed_at')
 	expect(mockModule.getUserRolesAndPermissions).toHaveBeenCalledWith(
 		refreshed.db,
 		42,
@@ -129,6 +132,7 @@ test('buildMcpUserContextFromGrantProps resolves identity from the stable user i
 		},
 		emailVerified: false,
 		suspended: false,
+		passwordChangedAt: null,
 	})
 	expect(mockModule.getUserRolesAndPermissions).toHaveBeenCalledWith(
 		staleEmailOwnedElsewhere.db,
@@ -163,6 +167,7 @@ test('buildMcpUserContextFromGrantProps resolves identity from the stable user i
 		},
 		emailVerified: false,
 		suspended: false,
+		passwordChangedAt: null,
 	})
 	expect(emailOmitted.queries[0]?.params).toEqual(['legacy-id'])
 

--- a/packages/worker/src/mcp-auth-user-context.ts
+++ b/packages/worker/src/mcp-auth-user-context.ts
@@ -21,12 +21,14 @@ type GrantUserRow = {
 	deleting_at: string | null
 	email_verified_at: string | null
 	suspended_at: string | null
+	password_changed_at: string | null
 }
 
 export type McpAuthUserContext = {
 	user: McpUserContext
 	emailVerified: boolean
 	suspended: boolean
+	passwordChangedAt: string | null
 }
 
 function buildBaseUserFromGrant(
@@ -76,7 +78,7 @@ export async function buildMcpUserContextFromGrantProps(
 	try {
 		const row = await env.APP_DB.prepare(
 			`SELECT id, email, username, display_name, stable_user_id,
-				deleting_at, email_verified_at, suspended_at
+				deleting_at, email_verified_at, suspended_at, password_changed_at
 			 FROM users
 			 WHERE stable_user_id = ?`,
 		)
@@ -111,6 +113,7 @@ export async function buildMcpUserContextFromGrantProps(
 			},
 			emailVerified: Boolean(row.email_verified_at),
 			suspended: Boolean(row.suspended_at),
+			passwordChangedAt: row.password_changed_at ?? null,
 		}
 	} catch (error) {
 		console.error('Failed to load MCP auth user context:', error)

--- a/packages/worker/src/mcp-auth.ts
+++ b/packages/worker/src/mcp-auth.ts
@@ -19,6 +19,7 @@ import { handleStatelessMcpRequest } from './mcp/stateless-lane.ts'
 import { oauthScopes } from './oauth-handlers.ts'
 import { stampFirstMcpConnected } from '#worker/identity/activation-stamps.ts'
 import { scheduleKitSubscriberSync } from '#worker/kit/subscriber-sync.ts'
+import { isCredentialInvalidatedByStoredPasswordChange } from '#worker/password-change-lockout.ts'
 
 export const mcpResourcePath = '/mcp'
 export const protectedResourceMetadataPath =
@@ -277,6 +278,20 @@ export async function handleMcpRequest({
 	if (authContext.suspended) {
 		await recordRejection('account_suspended', mcpUser.email)
 		return createAccountSuspendedResponse()
+	}
+
+	// Password reset stamps password_changed_at and revokes grants. Already-
+	// issued access tokens can still unwrap for up to an hour, so reject them
+	// the same way browser cookies die — hosts then refresh, the revoked grant
+	// fails, and they start a new OAuth flow.
+	if (
+		isCredentialInvalidatedByStoredPasswordChange({
+			issuedAtMs: tokenSummary.createdAt * 1000,
+			storedPasswordChangedAt: authContext.passwordChangedAt,
+		})
+	) {
+		await recordRejection('password_changed', mcpUser.email)
+		return createUnauthorizedResponse(origin, 'invalid_token')
 	}
 
 	const props: OAuthContextProps = createMcpCallerContext({

--- a/packages/worker/src/mcp-auth.workers.test.ts
+++ b/packages/worker/src/mcp-auth.workers.test.ts
@@ -92,6 +92,7 @@ type MockAccountRow = {
 	email_verified_at: string | null
 	deleting_at?: string | null
 	suspended_at?: string | null
+	password_changed_at?: string | null
 }
 
 type VerificationLookupKind =
@@ -104,6 +105,8 @@ type MockDbOptions = {
 	emailVerifiedAt?: string | null
 	// Row returned for the `suspended_at` lookup keyed by account identity.
 	suspendedAt?: string | null
+	// Row returned for the password-reset lockout lookup.
+	passwordChangedAt?: string | null
 	// Row returned for the indexed `stable_user_id` verification lookup.
 	stableUserVerifiedAt?: string | null
 	// Expected bind values for the default verified fixture identity.
@@ -196,6 +199,7 @@ function createMockDb(options: MockDbOptions = {}) {
 						email_verified_at: verifiedAt,
 						deleting_at: null,
 						suspended_at: options.suspendedAt ?? null,
+						password_changed_at: options.passwordChangedAt ?? null,
 					} satisfies MockAccountRow
 				}
 				if (normalized.includes('select deleting_at from users')) {
@@ -618,6 +622,7 @@ test('mcp request enforces token audience and forwards caller props', async () =
 	expect(userSelects).toHaveLength(1)
 	expect(userSelects[0]).toContain('email_verified_at')
 	expect(userSelects[0]).toContain('suspended_at')
+	expect(userSelects[0]).toContain('password_changed_at')
 	expect(verificationLookups).toHaveLength(0)
 
 	const withConnectorResponse = await handleMcpRequestAndDrain({
@@ -965,4 +970,83 @@ test('mcp request rejects unverified and unidentifiable accounts fail-closed', a
 	expect(fallbackUserSelects).toHaveLength(1)
 	expect(fallbackUserSelects[0]).toContain('email_verified_at')
 	expect(fallbackUserSelects[0]).toContain('suspended_at')
+	expect(fallbackUserSelects[0]).toContain('password_changed_at')
+})
+
+test('mcp request rejects access tokens issued before a password reset', async () => {
+	const origin = 'https://example.com'
+	const passwordChangedAt = '2026-08-29T15:00:00.000Z'
+	const passwordChangedAtSeconds = Math.floor(
+		Date.parse(passwordChangedAt) / 1000,
+	)
+	const auditInserts: Array<Array<unknown>> = []
+	function createToken(createdAt: number): TokenSummary {
+		return {
+			id: 'token',
+			grantId: 'grant',
+			userId: 'user',
+			createdAt,
+			expiresAt: passwordChangedAtSeconds + 3600,
+			audience: `${origin}${mcpResourcePath}`,
+			grant: {
+				clientId: 'client',
+				scope: oauthScopes,
+				props: { userId: 'user', email: 'user@example.com' },
+			},
+		}
+	}
+
+	let fetchMcpCalled = false
+	const fetchMcp = () => {
+		fetchMcpCalled = true
+		return new Response('ok')
+	}
+
+	const staleResponse = await handleMcpRequestAndDrain({
+		request: new Request(`${origin}${mcpResourcePath}`, {
+			headers: { Authorization: 'Bearer token' },
+		}),
+		env: createEnv(
+			createHelpers({
+				unwrapToken: async () => createToken(passwordChangedAtSeconds - 60),
+			}),
+			{},
+			{
+				emailVerifiedAt: new Date(0).toISOString(),
+				passwordChangedAt,
+				auditInserts,
+			},
+		),
+		ctx: createContext(),
+		fetchMcp,
+	})
+	expect(staleResponse.status).toBe(401)
+	expect(await staleResponse.json()).toEqual({
+		error: 'invalid_token',
+		error_description: mcpInvalidTokenDescription,
+	})
+	expect(fetchMcpCalled).toBe(false)
+	expect(auditInserts[0]).toEqual(
+		expect.arrayContaining(['auth', 'mcp_token_rejected', 'failure']),
+	)
+
+	const freshResponse = await handleMcpRequestAndDrain({
+		request: new Request(`${origin}${mcpResourcePath}`, {
+			headers: { Authorization: 'Bearer token' },
+		}),
+		env: createEnv(
+			createHelpers({
+				unwrapToken: async () => createToken(passwordChangedAtSeconds + 1),
+			}),
+			{},
+			{
+				emailVerifiedAt: new Date(0).toISOString(),
+				passwordChangedAt,
+			},
+		),
+		ctx: createContext(),
+		fetchMcp,
+	})
+	expect(freshResponse.status).toBe(200)
+	expect(fetchMcpCalled).toBe(true)
 })

--- a/packages/worker/src/mcp/auth-audit.ts
+++ b/packages/worker/src/mcp/auth-audit.ts
@@ -23,6 +23,7 @@ export type McpAuthDenialReason =
 	| 'unidentified_grant'
 	| 'email_unverified'
 	| 'account_suspended'
+	| 'password_changed'
 	| 'no_user'
 	| 'role'
 	| 'permission'

--- a/packages/worker/src/oauth-grants.node.test.ts
+++ b/packages/worker/src/oauth-grants.node.test.ts
@@ -1,0 +1,81 @@
+import { expect, test } from 'vitest'
+import {
+	listUserOAuthGrantsForClient,
+	revokeAllOAuthGrantsBestEffort,
+	revokeAllOAuthGrantsForUser,
+} from '#worker/oauth-grants.ts'
+
+test('revokeAllOAuthGrantsForUser pages grants and revokes every id', async () => {
+	const revoked: Array<string> = []
+	const helpers = {
+		async listUserGrants(_userId: string, options?: { cursor?: string }) {
+			if (options?.cursor === 'page-2') {
+				return {
+					items: [{ id: 'grant-3', clientId: 'client-b' }],
+				}
+			}
+			return {
+				items: [
+					{ id: 'grant-1', clientId: 'client-a' },
+					{ id: 'grant-2', clientId: 'client-a' },
+				],
+				cursor: 'page-2',
+			}
+		},
+		async revokeGrant(grantId: string, userId: string) {
+			expect(userId).toBe('user-1')
+			revoked.push(grantId)
+		},
+	}
+
+	await expect(
+		revokeAllOAuthGrantsForUser({ helpers, userId: 'user-1' }),
+	).resolves.toBe(3)
+	expect(revoked).toEqual(['grant-1', 'grant-2', 'grant-3'])
+	expect(
+		await listUserOAuthGrantsForClient(helpers, 'user-1', 'client-a'),
+	).toEqual([
+		{ id: 'grant-1', clientId: 'client-a' },
+		{ id: 'grant-2', clientId: 'client-a' },
+	])
+})
+
+test('revokeAllOAuthGrantsBestEffort records listing and revoke failures', async () => {
+	const warnings: Array<string> = []
+	const listingFailure = await revokeAllOAuthGrantsBestEffort({
+		helpers: {
+			async listUserGrants() {
+				throw new Error('kv list failed')
+			},
+			async revokeGrant() {
+				throw new Error('should not run')
+			},
+		},
+		userId: 'user-1',
+		warnings,
+	})
+	expect(listingFailure).toBe(0)
+	expect(warnings[0]).toContain('kv list failed')
+
+	const revokeWarnings: Array<string> = []
+	const revoked = await revokeAllOAuthGrantsBestEffort({
+		helpers: {
+			async listUserGrants() {
+				return {
+					items: [
+						{ id: 'ok', clientId: 'client-a' },
+						{ id: 'bad', clientId: 'client-a' },
+					],
+				}
+			},
+			async revokeGrant(grantId: string) {
+				if (grantId === 'bad') throw new Error('revoke boom')
+			},
+		},
+		userId: 'user-1',
+		warnings: revokeWarnings,
+	})
+	expect(revoked).toBe(1)
+	expect(revokeWarnings[0]).toContain('grant bad')
+	expect(revokeWarnings[0]).toContain('revoke boom')
+})

--- a/packages/worker/src/oauth-grants.node.test.ts
+++ b/packages/worker/src/oauth-grants.node.test.ts
@@ -5,28 +5,50 @@ import {
 	revokeAllOAuthGrantsForUser,
 } from '#worker/oauth-grants.ts'
 
-test('revokeAllOAuthGrantsForUser pages grants and revokes every id', async () => {
-	const revoked: Array<string> = []
-	const helpers = {
-		async listUserGrants(_userId: string, options?: { cursor?: string }) {
-			if (options?.cursor === 'page-2') {
-				return {
-					items: [{ id: 'grant-3', clientId: 'client-b' }],
+function createPagingGrantHelpers(input: {
+	pages: Array<{
+		items: Array<{ id: string; clientId: string }>
+		cursor?: string
+	}>
+	revoked?: Array<string>
+}) {
+	const revoked = input.revoked ?? []
+	return {
+		revoked,
+		helpers: {
+			async listUserGrants(_userId: string, options?: { cursor?: string }) {
+				const livePages = input.pages.map((page) => ({
+					...page,
+					items: page.items.filter((grant) => !revoked.includes(grant.id)),
+				}))
+				if (options?.cursor === 'page-2') {
+					return livePages[1] ?? { items: [] }
 				}
-			}
-			return {
+				return livePages[0] ?? { items: [] }
+			},
+			async revokeGrant(grantId: string, userId: string) {
+				expect(userId).toBe('user-1')
+				revoked.push(grantId)
+			},
+		},
+	}
+}
+
+test('revokeAllOAuthGrantsForUser pages grants and revokes every id', async () => {
+	const { helpers, revoked } = createPagingGrantHelpers({
+		pages: [
+			{
 				items: [
 					{ id: 'grant-1', clientId: 'client-a' },
 					{ id: 'grant-2', clientId: 'client-a' },
 				],
 				cursor: 'page-2',
-			}
-		},
-		async revokeGrant(grantId: string, userId: string) {
-			expect(userId).toBe('user-1')
-			revoked.push(grantId)
-		},
-	}
+			},
+			{
+				items: [{ id: 'grant-3', clientId: 'client-b' }],
+			},
+		],
+	})
 
 	await expect(
 		revokeAllOAuthGrantsForUser({ helpers, userId: 'user-1' }),
@@ -34,10 +56,48 @@ test('revokeAllOAuthGrantsForUser pages grants and revokes every id', async () =
 	expect(revoked).toEqual(['grant-1', 'grant-2', 'grant-3'])
 	expect(
 		await listUserOAuthGrantsForClient(helpers, 'user-1', 'client-a'),
-	).toEqual([
-		{ id: 'grant-1', clientId: 'client-a' },
-		{ id: 'grant-2', clientId: 'client-a' },
-	])
+	).toEqual([])
+})
+
+test('revokeAllOAuthGrantsForUser revokes a grant created during the first pass', async () => {
+	const revoked: Array<string> = []
+	let listCalls = 0
+	const helpers = {
+		async listUserGrants() {
+			listCalls += 1
+			if (listCalls === 1) {
+				return { items: [{ id: 'grant-a', clientId: 'client-a' }] }
+			}
+			if (listCalls === 2) {
+				return { items: [{ id: 'grant-interleaved', clientId: 'client-b' }] }
+			}
+			return { items: [] }
+		},
+		async revokeGrant(grantId: string) {
+			revoked.push(grantId)
+		},
+	}
+
+	await expect(
+		revokeAllOAuthGrantsForUser({ helpers, userId: 'user-1' }),
+	).resolves.toBe(2)
+	expect(revoked).toEqual(['grant-a', 'grant-interleaved'])
+})
+
+test('revokeAllOAuthGrantsForUser fails closed when grants remain after max passes', async () => {
+	await expect(
+		revokeAllOAuthGrantsForUser({
+			helpers: {
+				async listUserGrants() {
+					return { items: [{ id: 'grant-stuck', clientId: 'client-a' }] }
+				},
+				async revokeGrant() {
+					return
+				},
+			},
+			userId: 'user-1',
+		}),
+	).rejects.toThrow('oauth_grants_still_present')
 })
 
 test('revokeAllOAuthGrantsBestEffort records listing and revoke failures', async () => {

--- a/packages/worker/src/oauth-grants.ts
+++ b/packages/worker/src/oauth-grants.ts
@@ -43,19 +43,33 @@ export async function listUserOAuthGrantsForClient(
 	return grants.filter((grant) => grant.clientId === clientId)
 }
 
+const maxRevokePasses = 3
+
 /**
- * Revoke every grant for `userId`. Throws if listing or any revoke fails so
- * password-reset lockout cannot succeed while MCP refresh tokens remain.
+ * Revoke every grant for `userId`. Re-lists after each pass so a grant
+ * created while the previous snapshot was being revoked cannot survive.
+ * Throws if listing, any revoke, or leftover grants after
+ * `maxRevokePasses` fail so password-reset lockout cannot succeed while
+ * MCP refresh tokens remain.
  */
 export async function revokeAllOAuthGrantsForUser(input: {
 	helpers: OAuthGrantHelpers
 	userId: string
 }): Promise<number> {
-	const grants = await listUserOAuthGrants(input.helpers, input.userId)
-	for (const grant of grants) {
-		await input.helpers.revokeGrant(grant.id, input.userId)
+	let revoked = 0
+	for (let pass = 0; pass < maxRevokePasses; pass++) {
+		const grants = await listUserOAuthGrants(input.helpers, input.userId)
+		if (grants.length === 0) return revoked
+		for (const grant of grants) {
+			await input.helpers.revokeGrant(grant.id, input.userId)
+			revoked += 1
+		}
 	}
-	return grants.length
+	const leftover = await listUserOAuthGrants(input.helpers, input.userId)
+	if (leftover.length > 0) {
+		throw new Error('oauth_grants_still_present')
+	}
+	return revoked
 }
 
 /**

--- a/packages/worker/src/oauth-grants.ts
+++ b/packages/worker/src/oauth-grants.ts
@@ -1,0 +1,95 @@
+import { getErrorMessage } from '@kody-internal/shared/error-message.ts'
+
+export type OAuthGrantListItem = {
+	id: string
+	clientId: string
+}
+
+export type OAuthGrantPage = {
+	items: Array<OAuthGrantListItem>
+	cursor?: string
+}
+
+export type OAuthGrantHelpers = {
+	listUserGrants(
+		userId: string,
+		options?: { cursor?: string },
+	): Promise<OAuthGrantPage>
+	revokeGrant(grantId: string, userId: string): Promise<unknown>
+}
+
+export async function listUserOAuthGrants(
+	helpers: OAuthGrantHelpers,
+	userId: string,
+): Promise<Array<OAuthGrantListItem>> {
+	const grants = new Array<OAuthGrantListItem>()
+	let cursor: string | undefined
+	do {
+		const page = await helpers.listUserGrants(userId, { cursor })
+		for (const grant of page.items) {
+			grants.push({ id: grant.id, clientId: grant.clientId })
+		}
+		cursor = page.cursor
+	} while (cursor)
+	return grants
+}
+
+export async function listUserOAuthGrantsForClient(
+	helpers: OAuthGrantHelpers,
+	userId: string,
+	clientId: string,
+): Promise<Array<OAuthGrantListItem>> {
+	const grants = await listUserOAuthGrants(helpers, userId)
+	return grants.filter((grant) => grant.clientId === clientId)
+}
+
+/**
+ * Revoke every grant for `userId`. Throws if listing or any revoke fails so
+ * password-reset lockout cannot succeed while MCP refresh tokens remain.
+ */
+export async function revokeAllOAuthGrantsForUser(input: {
+	helpers: OAuthGrantHelpers
+	userId: string
+}): Promise<number> {
+	const grants = await listUserOAuthGrants(input.helpers, input.userId)
+	for (const grant of grants) {
+		await input.helpers.revokeGrant(grant.id, input.userId)
+	}
+	return grants.length
+}
+
+/**
+ * Best-effort revoke used by account deletion: listing or per-grant failures
+ * become warnings so the rest of the cascade can continue.
+ */
+export async function revokeAllOAuthGrantsBestEffort(input: {
+	helpers: OAuthGrantHelpers
+	userId: string
+	warnings: Array<string>
+}): Promise<number> {
+	let cursor: string | undefined
+	let revoked = 0
+	while (true) {
+		let page: OAuthGrantPage
+		try {
+			page = await input.helpers.listUserGrants(input.userId, { cursor })
+		} catch (error) {
+			input.warnings.push(
+				`OAuth grant listing failed; revoked ${revoked} grant(s) before the failure: ${getErrorMessage(error)}`,
+			)
+			return revoked
+		}
+		for (const grant of page.items) {
+			try {
+				await input.helpers.revokeGrant(grant.id, input.userId)
+				revoked += 1
+			} catch (error) {
+				input.warnings.push(
+					`OAuth grant revoke failed for grant ${grant.id}: ${getErrorMessage(error)}`,
+				)
+			}
+		}
+		if (!page.cursor) return revoked
+		cursor = page.cursor
+	}
+}

--- a/packages/worker/src/oauth-handlers.ts
+++ b/packages/worker/src/oauth-handlers.ts
@@ -28,6 +28,11 @@ import { getPkceValidationError } from '#worker/oauth-pkce.ts'
 import { oauthPaths } from '#universal/oauth-paths.ts'
 import { getAppBaseUrl } from '#worker/app-base-url.ts'
 import { mcpResourcePath } from './mcp-auth.ts'
+import { listUserOAuthGrantsForClient } from '#worker/oauth-grants.ts'
+import {
+	markUserMcpOauthClientRevokedByClientId,
+	userOwnsMcpOauthClient,
+} from '#app/account-mcp-oauth-clients.ts'
 
 export { oauthPaths }
 
@@ -331,27 +336,6 @@ async function requestHasRedirectUriMismatch(
 	return !redirectUriMatchesRegisteredUri(redirectUri, registeredUris)
 }
 
-async function listUserGrantsForClient(
-	helpers: OAuthHelpers,
-	userId: string,
-	clientId: string,
-) {
-	const grants = new Array<{ id: string }>()
-	let cursor: string | undefined
-
-	do {
-		const page = await helpers.listUserGrants(userId, { cursor })
-		for (const grant of page.items) {
-			if (grant.clientId === clientId) {
-				grants.push({ id: grant.id })
-			}
-		}
-		cursor = page.cursor
-	} while (cursor)
-
-	return grants
-}
-
 function resolveScopes(requestedScopes: Array<string>) {
 	if (requestedScopes.length === 0) return oauthScopes
 	const invalidScopes = requestedScopes.filter(
@@ -469,7 +453,7 @@ async function handleResetClientRequest(
 		})
 		return respondAuthorizeError(
 			request,
-			'Sign in before deleting stored client records.',
+			'Sign in before resetting this connection.',
 			401,
 			'unauthorized',
 			createSetCookieHeaders([clearResetVerificationCookie]),
@@ -500,11 +484,23 @@ async function handleResetClientRequest(
 			)
 		}
 		const userId = resolveUserStableId(userRecord)
-		const grants = await listUserGrantsForClient(helpers, userId, clientId)
+		const grants = await listUserOAuthGrantsForClient(helpers, userId, clientId)
 		await Promise.all(
 			grants.map((grant) => helpers.revokeGrant(grant.id, userId)),
 		)
-		await helpers.deleteClient(clientId)
+		const ownsClient = await userOwnsMcpOauthClient(
+			env.APP_DB,
+			userRecord.id,
+			clientId,
+		)
+		if (ownsClient) {
+			await helpers.deleteClient(clientId)
+			await markUserMcpOauthClientRevokedByClientId(
+				env.APP_DB,
+				userRecord.id,
+				clientId,
+			)
+		}
 		void logAuditEvent({
 			category: 'oauth',
 			action: 'reset_client',
@@ -512,12 +508,14 @@ async function handleResetClientRequest(
 			email: sessionEmail,
 			ip: requestIp,
 			clientId,
+			reason: ownsClient ? 'deleted_owned_client' : 'revoked_grants_only',
 		})
 		return jsonResponse(
 			{
 				ok: true,
-				message:
-					'Deleted the stored client records for this connection. Start the connection again from your client to create a fresh trusted client.',
+				message: ownsClient
+					? "Deleted your stored client registration and revoked this account's grants. Start the connection again from your client to create a fresh trusted client."
+					: "Revoked this account's grants for the client. Shared client registrations stay in place. Start the connection again from your client.",
 			},
 			{
 				headers: createSetCookieHeaders([
@@ -538,7 +536,7 @@ async function handleResetClientRequest(
 		})
 		return respondAuthorizeError(
 			request,
-			'Unable to delete stored client records right now.',
+			'Unable to reset this connection right now.',
 			500,
 			'server_error',
 			createSetCookieHeaders([clearResetVerificationCookie]),

--- a/packages/worker/src/oauth-handlers.workers.test.ts
+++ b/packages/worker/src/oauth-handlers.workers.test.ts
@@ -108,7 +108,10 @@ function createHelpers(overrides: Partial<OAuthHelpers> = {}): OAuthHelpers {
 
 async function createDatabase(
 	password: string,
-	options: { emailVerifiedAt?: string | null } = {},
+	options: {
+		emailVerifiedAt?: string | null
+		ownedClientIds?: ReadonlyArray<string>
+	} = {},
 ) {
 	const passwordHash = await createPasswordHash(password)
 	const email = 'user@example.com'
@@ -130,30 +133,43 @@ async function createDatabase(
 			// The 2FA gate queries verifications during inline OAuth login; the
 			// mocked user has no verification rows, so those queries are empty.
 			const isVerificationsQuery = query.includes('FROM verifications')
+			const isOwnedClientQuery = query.includes('FROM user_mcp_oauth_clients')
 			const isEmailVerifiedQuery =
 				query.includes('email_verified_at') && !query.includes('stable_user_id')
-			return {
-				bind() {
+			let bound: Array<unknown> = []
+			const statement = {
+				bind(...params: Array<unknown>) {
+					bound = params
+					return statement
+				},
+				async all() {
 					return {
-						async all() {
-							return {
-								results: isVerificationsQuery ? [] : [userRow],
-								meta: { changes: 0, last_row_id: 0 },
-							}
-						},
-						async first() {
-							if (isVerificationsQuery) return null
-							if (isEmailVerifiedQuery) {
-								return { email_verified_at: emailVerifiedAt }
-							}
-							return userRow
-						},
-						async run() {
-							return { meta: { changes: 1, last_row_id: 1 } }
-						},
+						results: isVerificationsQuery ? [] : [userRow],
+						meta: { changes: 0, last_row_id: 0 },
 					}
 				},
+				async first() {
+					if (isVerificationsQuery) return null
+					if (isOwnedClientQuery) {
+						const clientId = bound.find((value) => typeof value === 'string')
+						if (
+							typeof clientId === 'string' &&
+							options.ownedClientIds?.includes(clientId)
+						) {
+							return { client_id: clientId }
+						}
+						return null
+					}
+					if (isEmailVerifiedQuery) {
+						return { email_verified_at: emailVerifiedAt }
+					}
+					return userRow
+				},
+				async run() {
+					return { meta: { changes: 1, last_row_id: 1 } }
+				},
 			}
+			return statement
 		},
 		async exec() {
 			return
@@ -927,7 +943,7 @@ test('worker entrypoint renders OAuth errors for delegated authorize route excep
 	})
 })
 
-test('reset client deletes matching grants for redirect-uri, client-id, and authorize-info mismatches', async () => {
+test('reset client revokes matching grants without deleting a shared DCR client', async () => {
 	const userId = await createStableUserIdFromEmail('user@example.com')
 	const appDb = await createDatabase('password123')
 	setAuthSessionSecret(cookieSecret)
@@ -1007,10 +1023,10 @@ test('reset client deletes matching grants for redirect-uri, client-id, and auth
 	expect(redirectUriResponse.status).toBe(200)
 	await expect(redirectUriResponse.json()).resolves.toMatchObject({
 		ok: true,
-		message: expect.stringMatching(/deleted the stored client records/i),
+		message: expect.stringMatching(/revoked this account/i),
 	})
 	expect(redirectUriRevokedGrantIds).toEqual(['grant-1', 'grant-3'])
-	expect(redirectUriDeletedClientIds).toEqual(['client-123'])
+	expect(redirectUriDeletedClientIds).toEqual([])
 
 	const clientMismatchRevokedGrantIds = new Array<string>()
 	const clientMismatchDeletedClientIds = new Array<string>()
@@ -1077,10 +1093,10 @@ test('reset client deletes matching grants for redirect-uri, client-id, and auth
 	expect(clientMismatchResponse.status).toBe(200)
 	await expect(clientMismatchResponse.json()).resolves.toMatchObject({
 		ok: true,
-		message: expect.stringMatching(/deleted the stored client records/i),
+		message: expect.stringMatching(/revoked this account/i),
 	})
 	expect(clientMismatchRevokedGrantIds).toEqual(['grant-1', 'grant-2'])
-	expect(clientMismatchDeletedClientIds).toEqual(['client-123'])
+	expect(clientMismatchDeletedClientIds).toEqual([])
 
 	const authorizeInfoRevokedGrantIds = new Array<string>()
 	const authorizeInfoDeletedClientIds = new Array<string>()
@@ -1129,10 +1145,81 @@ test('reset client deletes matching grants for redirect-uri, client-id, and auth
 	expect(authorizeInfoResetResponse.status).toBe(200)
 	await expect(authorizeInfoResetResponse.json()).resolves.toMatchObject({
 		ok: true,
-		message: expect.stringMatching(/deleted the stored client records/i),
+		message: expect.stringMatching(/revoked this account/i),
 	})
 	expect(authorizeInfoRevokedGrantIds).toEqual(['grant-1'])
-	expect(authorizeInfoDeletedClientIds).toEqual(['client-123'])
+	expect(authorizeInfoDeletedClientIds).toEqual([])
+})
+
+test("reset client deletes an owned MCP OAuth client after revoking this user's grants", async () => {
+	const userId = await createStableUserIdFromEmail('user@example.com')
+	const appDb = await createDatabase('password123', {
+		ownedClientIds: ['client-123'],
+	})
+	setAuthSessionSecret(cookieSecret)
+	const cookie = await createAuthCookie(
+		{
+			stableUserId: userId,
+			email: 'user@example.com',
+			rememberMe: false,
+		},
+		false,
+	)
+	const revokedGrantIds = new Array<string>()
+	const deletedClientIds = new Array<string>()
+	const helpers = createHelpers({
+		parseAuthRequest: async () => {
+			throw new Error(
+				'Invalid redirect URI. The redirect URI provided does not match any registered URI for this client.',
+			)
+		},
+		listUserGrants: async (requestedUserId) => {
+			expect(requestedUserId).toBe(userId)
+			return {
+				items: [
+					{
+						id: 'grant-owned',
+						clientId: 'client-123',
+						userId,
+						scope: ['profile'],
+						metadata: {},
+						createdAt: 0,
+					},
+				],
+			}
+		},
+		revokeGrant: async (grantId, requestedUserId) => {
+			expect(requestedUserId).toBe(userId)
+			revokedGrantIds.push(grantId)
+		},
+		deleteClient: async (clientId) => {
+			deletedClientIds.push(clientId)
+		},
+	})
+
+	const response = await handleAuthorizeRequest(
+		new Request(
+			`https://example.com/oauth/authorize?client_id=client-123&redirect_uri=${encodeURIComponent('https://example.com/invalid')}&error_description=${encodeURIComponent('Invalid redirect URI. The redirect URI provided does not match any registered URI for this client.')}`,
+			{
+				method: 'POST',
+				headers: {
+					Accept: 'application/json',
+					Cookie: cookie,
+					'Content-Type': 'application/x-www-form-urlencoded',
+				},
+				body: new URLSearchParams({ decision: 'reset-client' }),
+			},
+		),
+		createEnv(helpers, appDb),
+	)
+
+	expect(response.status).toBe(200)
+	await expect(response.json()).resolves.toMatchObject({
+		ok: true,
+		message: expect.stringMatching(/deleted your stored client registration/i),
+	})
+	expect(revokedGrantIds).toEqual(['grant-owned'])
+	expect(deletedClientIds).toEqual(['client-123'])
 })
 
 test('reset client rejects requests without a stale or mismatched client registration', async () => {

--- a/packages/worker/src/password-change-lockout.ts
+++ b/packages/worker/src/password-change-lockout.ts
@@ -1,0 +1,55 @@
+/**
+ * Shared password-reset lockout: browser cookies, package-app cookies, and
+ * MCP access tokens must all die at the same `users.password_changed_at`.
+ */
+
+/**
+ * Parse a stored password_changed_at / SQLite-style timestamp to epoch ms.
+ * Whole-second timestamps (no fractional seconds) are treated as the end of
+ * that second so credentials issued later in the same second cannot survive a
+ * reset that only recorded second precision.
+ */
+export function parsePasswordChangedAtMs(value: string | null | undefined) {
+	if (!value) return null
+	const trimmed = value.trim()
+	if (!trimmed) return null
+	const normalized = trimmed.includes('T')
+		? trimmed
+		: `${trimmed.replace(' ', 'T')}Z`
+	const ms = Date.parse(normalized)
+	if (!Number.isFinite(ms)) return null
+	const hasFractionalSeconds = /(?:[T ])\d{2}:\d{2}:\d{2}\.\d/.test(normalized)
+	return hasFractionalSeconds ? ms : ms + 999
+}
+
+/**
+ * True when `issuedAtMs` predates (or cannot prove it postdates) a password
+ * change. Missing `issuedAtMs` fails closed once `passwordChangedAtMs` is set.
+ */
+export function isIssuedAtInvalidatedByPasswordChange(input: {
+	issuedAtMs: number | undefined
+	passwordChangedAtMs: number | null
+}): boolean {
+	if (input.passwordChangedAtMs == null) return false
+	if (typeof input.issuedAtMs !== 'number') return true
+	return input.issuedAtMs <= input.passwordChangedAtMs
+}
+
+/**
+ * True when a credential predates the account's stored `password_changed_at`.
+ *
+ * Fail-closed when a stored timestamp exists but cannot be parsed. An account
+ * that has never changed its password keeps credentials with no issued-at.
+ */
+export function isCredentialInvalidatedByStoredPasswordChange(input: {
+	issuedAtMs: number | undefined
+	storedPasswordChangedAt: string | null | undefined
+}): boolean {
+	const passwordChangedAtRaw = input.storedPasswordChangedAt?.trim() ?? ''
+	const passwordChangedAtMs = parsePasswordChangedAtMs(passwordChangedAtRaw)
+	if (passwordChangedAtRaw !== '' && passwordChangedAtMs === null) return true
+	return isIssuedAtInvalidatedByPasswordChange({
+		issuedAtMs: input.issuedAtMs,
+		passwordChangedAtMs,
+	})
+}

--- a/packages/worker/src/password-change-lockout.ts
+++ b/packages/worker/src/password-change-lockout.ts
@@ -13,9 +13,9 @@ export function parsePasswordChangedAtMs(value: string | null | undefined) {
 	if (!value) return null
 	const trimmed = value.trim()
 	if (!trimmed) return null
-	const normalized = trimmed.includes('T')
-		? trimmed
-		: `${trimmed.replace(' ', 'T')}Z`
+	const withT = trimmed.includes('T') ? trimmed : trimmed.replace(' ', 'T')
+	const hasTimezone = /(?:Z|[+-]\d{2}:?\d{2})$/i.test(withT)
+	const normalized = hasTimezone ? withT : `${withT}Z`
 	const ms = Date.parse(normalized)
 	if (!Number.isFinite(ms)) return null
 	const hasFractionalSeconds = /(?:[T ])\d{2}:\d{2}:\d{2}\.\d/.test(normalized)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Close the two invite-only launch lockout holes from the readiness audit: a password reset must kill MCP access, and authorize client reset must not delete a shared DCR client.

## Why

Password reset already invalidated browser cookies via `password_changed_at`. It left MCP refresh tokens alive (`refreshTokenTTL` is unset) and already-issued access tokens valid for up to an hour. Authorize `reset-client` revoked this user's grants, then called `deleteClient` globally — any signed-in user who can see a host `client_id` could break MCP for everyone else.

## Summary

- Password reset revokes every MCP OAuth grant, stamps `password_changed_at`, then revokes again so a grant created in that window cannot survive. Reset tokens stay until the second pass succeeds. If revoke fails, the password does not change.
- `/mcp` rejects access tokens whose `createdAt` is at or before `password_changed_at` (`invalid_token`), so hosts refresh, hit the revoked grant, and start a new OAuth flow.
- Authorize client reset still revokes this account's grants. `deleteClient` runs only when `user_mcp_oauth_clients` shows the user owns that registration.
- Authorize UI copy now says "Reset this connection" instead of promising a global client delete.
- Shared helpers: `password-change-lockout.ts` (cookie + MCP timestamp; preserves numeric timezone offsets) and `oauth-grants.ts` (list/revoke with re-enumeration, including account-deletion best-effort).

Rebased onto `main` @ `eb608130` (launch prep + later). The only conflict was keeping both `scheduleKitSubscriberSync` and the password-change lockout import in `mcp-auth.ts`.

Not in this PR (still operator / follow-up): #1092 launch ops, #1300 / #1428 domain sunset readout, `refreshTokenTTL`, open-signup pagination / webhook limiter / admin-insights fanout.

## Testing

- `vitest` node-unit: `oauth-grants`, `password-reset`, `mcp-auth-user-context`, `auth-session`, `account-deletion`
- `vitest` workers-unit: `oauth-handlers`, `mcp-auth`
- Pre-commit typecheck + migrations check
- Preview: password-reset request + authorize reset copy as the seeded user (verified on pre-rebase preview; will re-check after this rebase deploy)

## System changes

See the system recap below.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `eb608130` · **Head:** `3cfb009c`

**Classification:** extends — password reset and `/mcp` now share one `password_changed_at` lockout, and authorize client reset no longer deletes shared DCR clients.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `mcp-oauth` | auth | extends — revoke grants on password reset (re-list around the stamp); `/mcp` rejects pre-reset access tokens; `reset-client` is grant-scoped |
| `app-sessions` | auth | extends — password reset lockout now also covers MCP; shared timestamp helper preserves numeric offsets |
| `app-ui` | surfaces | composes — authorize copy + password-reset handler wiring |
| `mcp-server` | surfaces | composes — new `password_changed` audit reason |

### Change flow

Password reset revokes MCP grants, stamps `password_changed_at`, then revokes again. `/mcp` and browser cookies share that timestamp. Authorize reset deletes a client only when this user owns it.

```mermaid
sequenceDiagram
	actor User
	participant appUi as app-ui
	participant appSessions as app-sessions
	participant mcpOauth as mcp-oauth
	participant mcpServer as mcp-server
	User->>appUi: POST /password-reset/confirm
	appUi->>mcpOauth: revokeAllOAuthGrantsForUser (re-list until empty)
	mcpOauth-->>appUi: snapshot grants revoked
	appUi->>appSessions: stamp users.password_changed_at
	Note over appSessions: browser + package-app cookies die
	appUi->>mcpOauth: revokeAllOAuthGrantsForUser again
	Note over mcpOauth: catches a grant created during the first pass
	User->>mcpServer: Authorization Bearer (pre-reset token)
	mcpServer->>mcpOauth: unwrapToken + createdAt vs password_changed_at
	mcpOauth-->>mcpServer: invalid_token
	User->>appUi: POST /oauth/authorize reset-client
	appUi->>mcpOauth: revoke this user's grants
	alt user owns client in user_mcp_oauth_clients
		mcpOauth->>mcpOauth: deleteClient + mark revoked
	else shared host DCR client
		Note over mcpOauth: skip deleteClient
	end
```

### Invariants

- Per-user isolation: one signed-in user can no longer delete a DCR client that other accounts still use.
- Password-reset lockout now covers MCP grants and already-issued access tokens, not only `kody_session`.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-589c58d0-329a-4f3c-b2a6-72fccea28e71?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-589c58d0-329a-4f3c-b2a6-72fccea28e71&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Enhancements**
  * Password resets now revoke all OAuth connections and invalidate existing browser, app, and MCP sessions.
  * Previously issued MCP access tokens are rejected and require fresh authorization.
  * Connection resets preserve shared client registrations while revoking the account’s grants.
  * Owned client registrations may still be removed during reset.
* **Bug Fixes**
  * Improved failure handling and audit logging when grant revocation cannot be completed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->