### PR TITLE
fix(client): drop Chromium Failed to fetch (host) resolveFrame noise (KODY-6A)

### DIFF
--- a/packages/worker/client/browser-fetch-network-error.ts
+++ b/packages/worker/client/browser-fetch-network-error.ts
@@ -2,6 +2,10 @@
  * Browser `fetch()` network failures that reject as TypeError. Exact strings
  * only — Firefox (KODY-CLOUDFLARE-3P), Chromium, and WebKit — so unrelated
  * TypeErrors still surface their own message.
+ *
+ * Chromium Mobile sometimes appends the failed origin as a parenthetical
+ * (`Failed to fetch (kody.codes)`, KODY-6A) — that is still the same network
+ * blip, not "Failed to fetch dynamically imported module: …".
  */
 
 const browserFetchNetworkErrorMessages = new Set([
@@ -10,8 +14,15 @@ const browserFetchNetworkErrorMessages = new Set([
 	'Load failed',
 ])
 
+/** Chromium "Failed to fetch (hostname)" without matching dynamic-import text. */
+const chromiumFailedToFetchWithOrigin = /^Failed to fetch(?:\s+\([^)]+\))?$/i
+
 export function normalizeBrowserFetchNetworkErrorMessage(message: string) {
-	return message.trim().replace(/^TypeError:\s*/i, '')
+	const withoutTypePrefix = message.trim().replace(/^TypeError:\s*/i, '')
+	if (chromiumFailedToFetchWithOrigin.test(withoutTypePrefix)) {
+		return 'Failed to fetch'
+	}
+	return withoutTypePrefix
 }
 
 export function isBrowserFetchNetworkErrorMessage(message: string) {
@@ -26,12 +37,16 @@ export function isBrowserFetchNetworkError(error: unknown): boolean {
 }
 
 /**
- * True when a thrown Error's stack names Remix `resolveFrame` or the
- * `fetchFrameResolve` helper that owns the `fetch` (KODY-CLOUDFLARE-5Y).
- * Mobile Safari often keeps only the immediate caller on `Error.stack`.
+ * True when a thrown Error's stack names Remix `resolveFrame`, the
+ * `fetchFrameResolve` helper that owns the `fetch`, or `createFrameResolveInit`
+ * (bundler/source-map often attributes the fetch to that init helper —
+ * KODY-CLOUDFLARE-5Y / KODY-6A). Mobile Safari often keeps only the immediate
+ * caller on `Error.stack`.
  */
 export function errorStackMentionsResolveFrame(error: unknown) {
 	if (typeof error !== 'object' || error === null) return false
 	if (!('stack' in error) || typeof error.stack !== 'string') return false
-	return /\b(?:resolveFrame|fetchFrameResolve)\b/.test(error.stack)
+	return /\b(?:resolveFrame|fetchFrameResolve|createFrameResolveInit)\b/.test(
+		error.stack,
+	)
 }

--- a/packages/worker/client/frame-resolve.node.test.ts
+++ b/packages/worker/client/frame-resolve.node.test.ts
@@ -49,6 +49,18 @@ test('fetchFrameResolve retries once on GET network TypeErrors only', async () =
 		vi.unstubAllGlobals()
 	}
 
+	const chromiumWithOrigin = vi
+		.fn()
+		.mockRejectedValueOnce(new TypeError('Failed to fetch (kody.codes)'))
+		.mockResolvedValueOnce(ok)
+	vi.stubGlobal('fetch', chromiumWithOrigin)
+	try {
+		expect(await fetchFrameResolve('/')).toBe(ok)
+		expect(chromiumWithOrigin).toHaveBeenCalledTimes(2)
+	} finally {
+		vi.unstubAllGlobals()
+	}
+
 	const postNoRetry = vi
 		.fn()
 		.mockRejectedValueOnce(new TypeError('Failed to fetch'))

--- a/packages/worker/client/frame-resolve.ts
+++ b/packages/worker/client/frame-resolve.ts
@@ -35,8 +35,9 @@ export function createFrameResolveInit(options?: ResolveFrameOptions) {
 /**
  * Fetch a Remix frame document. Idempotent GET/HEAD retries once on browser
  * `fetch` network TypeErrors (WebKit "Load failed", Chromium "Failed to
- * fetch", Firefox NetworkError) — KODY-CLOUDFLARE-5Y Mobile Safari blips after
- * the same URL already succeeded.
+ * fetch" / "Failed to fetch (host)", Firefox NetworkError) — KODY-CLOUDFLARE-5Y
+ * / KODY-6A Mobile Safari and Chrome Mobile blips after the same URL already
+ * succeeded.
  */
 export async function fetchFrameResolve(
 	src: string,

--- a/packages/worker/client/routes/connect-oauth.node.test.ts
+++ b/packages/worker/client/routes/connect-oauth.node.test.ts
@@ -949,9 +949,11 @@ test('browser fetch network TypeErrors map to a stable in-page status (KODY-CLOU
 		'NetworkError when attempting to fetch resource.',
 	)
 	const chromium = new TypeError('Failed to fetch')
+	const chromiumWithOrigin = new TypeError('Failed to fetch (kody.codes)')
 	const webkit = new TypeError('Load failed')
 	expect(isBrowserFetchNetworkError(firefox)).toBe(true)
 	expect(isBrowserFetchNetworkError(chromium)).toBe(true)
+	expect(isBrowserFetchNetworkError(chromiumWithOrigin)).toBe(true)
 	expect(isBrowserFetchNetworkError(webkit)).toBe(true)
 	expect(
 		isBrowserFetchNetworkError(new TypeError('null is not an object')),
@@ -960,6 +962,13 @@ test('browser fetch network TypeErrors map to a stable in-page status (KODY-CLOU
 	expect(
 		isBrowserFetchNetworkError(new TypeError('TypeError: Failed to fetch')),
 	).toBe(true)
+	expect(
+		isBrowserFetchNetworkError(
+			new TypeError(
+				'Failed to fetch dynamically imported module: https://kody.codes/assets/x.js',
+			),
+		),
+	).toBe(false)
 
 	const networkStatus = formatConnectOauthCaughtError(firefox, 'fallback')
 	expect(networkStatus).not.toBe('fallback')

--- a/packages/worker/client/sentry-browser-filters.node.test.ts
+++ b/packages/worker/client/sentry-browser-filters.node.test.ts
@@ -779,3 +779,72 @@ test('browser Sentry filters drop resolveFrame fetch network TypeErrors (KODY-CL
 		}),
 	).not.toBeNull()
 })
+
+test('browser Sentry filters drop Chromium Failed to fetch (host) via createFrameResolveInit (KODY-6A)', () => {
+	// Production Chrome Mobile: exception value includes the origin, and
+	// sourcemapped frames name createFrameResolveInit / boot — not resolveFrame.
+	expect(
+		filterBrowserSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'TypeError',
+						value: 'Failed to fetch (kody.codes)',
+						stacktrace: {
+							frames: [
+								{
+									function: 'createFrameResolveInit',
+									filename: '../client/frame-resolve.ts',
+								},
+								{
+									function: 'boot',
+									filename: '../client/entry.tsx',
+								},
+							],
+						},
+					},
+				],
+			},
+		}),
+	).toBeNull()
+	expect(
+		filterBrowserSentryEvent(
+			{
+				exception: {
+					values: [
+						{
+							type: 'TypeError',
+							value: 'Failed to fetch (kody.codes)',
+						},
+					],
+				},
+			},
+			Object.assign(new TypeError('Failed to fetch (kody.codes)'), {
+				stack:
+					'TypeError: Failed to fetch\n    at Yn (https://kody.codes/client-entry.js:3:2497)\n    at Object.resolveFrame (https://kody.codes/client-entry.js:3:76468)',
+			}),
+		),
+	).toBeNull()
+	// Dynamic-import failures must stay visible even with a host-looking suffix.
+	expect(
+		filterBrowserSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'TypeError',
+						value:
+							'Failed to fetch dynamically imported module: https://kody.codes/assets/blog-area-ABC123.js',
+						stacktrace: {
+							frames: [
+								{
+									function: 'createFrameResolveInit',
+									filename: '../client/frame-resolve.ts',
+								},
+							],
+						},
+					},
+				],
+			},
+		}),
+	).not.toBeNull()
+})

--- a/packages/worker/client/sentry-browser-filters.ts
+++ b/packages/worker/client/sentry-browser-filters.ts
@@ -983,12 +983,13 @@ export function filterSyntaxHighlightCoreDynamicImportFailureSentryEvent<
 
 /**
  * Remix `resolveFrame` `fetch()` network TypeErrors (WebKit "Load failed",
- * Chromium "Failed to fetch", Firefox NetworkError). Observed as a handled
- * client hydration error after a successful GET of the same frame URL
- * (KODY-CLOUDFLARE-5Y, Mobile Safari on `/@kody/planetscale`). External
- * connectivity blips — not an app defect. Match only when a stack frame names
- * `resolveFrame` or `fetchFrameResolve` so other fetch TypeErrors stay
- * Sentry-visible.
+ * Chromium "Failed to fetch" / "Failed to fetch (host)", Firefox NetworkError).
+ * Observed as a handled client hydration error after a successful GET of the
+ * same frame URL (KODY-CLOUDFLARE-5Y, Mobile Safari on `/@kody/planetscale`;
+ * KODY-6A, Chrome Mobile on `/` with sourcemapped `createFrameResolveInit`).
+ * External connectivity blips — not an app defect. Match only when a stack
+ * frame names `resolveFrame`, `fetchFrameResolve`, or `createFrameResolveInit`
+ * so other fetch TypeErrors stay Sentry-visible.
  */
 export function isResolveFrameFetchNetworkSentryEvent(
 	event: SentryErrorEventLike,
@@ -1015,9 +1016,16 @@ export function isResolveFrameFetchNetworkSentryEvent(
 	if (!networkFromException && !networkFromEvent) return false
 
 	if (errorStackMentionsResolveFrame(originalException)) return true
-	return sentryEventStackFrameFunctions(event).some(
-		(name) =>
-			name.includes('resolveFrame') || name.includes('fetchFrameResolve'),
+	return sentryEventStackFrameFunctions(event).some((name) =>
+		isResolveFrameFetchStackFunction(name),
+	)
+}
+
+function isResolveFrameFetchStackFunction(name: string) {
+	return (
+		name.includes('resolveFrame') ||
+		name.includes('fetchFrameResolve') ||
+		name.includes('createFrameResolveInit')
 	)
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop Chrome Mobile `TypeError: Failed to fetch (kody.codes)` from Remix `resolveFrame` paging Sentry when the failure is a transient browser `fetch` blip (KODY-6A / leak from KODY-CLOUDFLARE-5Y).

## Why

Production event on `/` (Chrome Mobile 151 / Android): navigation `GET https://kody.codes/` rejected as Chromium `Failed to fetch (kody.codes)`. That rejection bubbled through `app.resolveFrame` → `fetchFrameResolve` and was captured as a handled hydration error. The existing KODY-CLOUDFLARE-5Y filter required an exact `Failed to fetch` message and stack frames named `resolveFrame` / `fetchFrameResolve`; this event used the host-suffixed Chromium message and sourcemapped `createFrameResolveInit` / `boot` frames, so it leaked. External connectivity noise — not an app defect.

## Summary

- Normalize Chromium `Failed to fetch (hostname)` to the same network TypeError signature (without matching dynamic-import failures).
- Treat sourcemapped `createFrameResolveInit` stacks like `resolveFrame` / `fetchFrameResolve` for the browser Sentry gate and pre-SDK buffer.
- Retry idempotent GET once on the host-suffixed message in `fetchFrameResolve` (same path as other network TypeErrors).

## Testing

- `npx vitest run packages/worker/client/sentry-browser-filters.node.test.ts packages/worker/client/frame-resolve.node.test.ts packages/worker/client/routes/connect-oauth.node.test.ts` — pass
- Pre-push `test:node` + `test:workers` — pass
- CI Validate / Bugbot / CodeRabbit — pass
- Squash-merged; production deploy `b68b62db` healthcheck ok; Sentry issue ignored

Skip preview: no logged-in UI or data-shape change; filter + GET retry only.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` · **Head:** `b68b62db` (squash merge)

**Classification:** composes — narrow extension of the existing resolveFrame fetch network filter + one idempotent retry message match; no new primitives.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `app-ui` | surfaces | composes — browser Sentry beforeSend + resolveFrame fetch helper |

### Change flow

```mermaid
sequenceDiagram
	actor Browser
	participant appUi as app-ui
	participant Sentry
	Browser->>appUi: resolveFrame fetch (GET)
	appUi->>appUi: network TypeError Failed to fetch (host)
	appUi->>appUi: retry GET once
	alt retry succeeds
		appUi-->>Browser: frame Response
	else still fails
		appUi->>Sentry: captureException
		Sentry-->>Sentry: beforeSend drops createFrameResolveInit/resolveFrame network TypeError
	end
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eacc91ff-2416-4951-b01f-720a5097ff2c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eacc91ff-2416-4951-b01f-720a5097ff2c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Chromium network errors that include a hostname, ensuring eligible frame-resolution requests retry as expected.
  * Prevented dynamic module import failures from being misclassified as network errors or filtered from error reporting.
  * Expanded error detection across additional browser environments and stack formats.

* **Tests**
  * Added coverage for hostname-suffixed fetch errors, retry behavior, and preserved reporting of dynamic import failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->