### PR TITLE
Launch prep: free job interval floor, public door, Kit sync, billing thank-you

### DIFF
--- a/docs/contributing/architecture/authentication.md
+++ b/docs/contributing/architecture/authentication.md
@@ -104,6 +104,19 @@ Account signup Kit tagging (password and OAuth signup):
 - Leaves existing tags alone (including `waitlist::kody`)
 - Best-effort only: Kit errors or a missing key never fail account creation
 
+Exist-only Kit subscriber sync (`packages/worker/src/kit/subscriber-sync.ts`)
+then keeps tags in step with account facts. Lookup by email; skip if missing;
+add lifecycle tags; remove only paid tags on cancel. Call sites: signup, email
+verify, first MCP connection, first saved package, Stripe plan refresh, and the
+hourly `kit_subscriber_sync` lane. Tags:
+
+- `signed_up::kody`
+- `verified::kody`
+- `agent_connected::kody`
+- `activated::kody`
+- `standard::kody` / `pro::kody` (cleared when the Stripe plan is no longer
+  paid)
+
 The `invites` table stores operator-created invite codes:
 
 - `code` is the primary key shown to the invited user

--- a/docs/contributing/architecture/entitlements.md
+++ b/docs/contributing/architecture/entitlements.md
@@ -117,6 +117,11 @@ enforcement loop for the compute surfaces `usage-metering.md` already observes:
   (`packages/worker/src/jobs/service.ts`) after caller-context resolution and
   before sandbox work, so over-limit ticks fail cheaply. This is separate from
   `scheduled_jobs` (how many job rows an account may own).
+- **Job interval floor** (`planLimits.*.minJobIntervalMs`) applies only to free:
+  recurring jobs cannot run more often than every 15 minutes. The floor is
+  asserted on create and on an actual schedule change (`JobIntervalFloorError`).
+  Identity-only refreshes of an existing faster job are grandfathered. Paid
+  plans have no extra floor.
 
 These consume only when the context has a `userId`, matching the usage-metering
 rule that events without an owning user are skipped. Daily consumption is
@@ -687,21 +692,21 @@ workflows via RunLog, and similar).
 
 ## Enforcement points
 
-| Resource                   | Enforcement point                                                                                                                                                                                                                     |
-| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `scheduled_jobs`           | Full-addition preflight in `syncPackageJobsForPackage` in `packages/worker/src/jobs/service.ts` (package sync subtracts same-sync removals before checking, so replacements do not consume an extra slot)                             |
-| `saved_packages`           | new-package branch of `package_save` and projection insert                                                                                                                                                                            |
-| `repo_sessions`            | `repo_open_session` before creating a new session                                                                                                                                                                                     |
-| `email_sends_per_day`      | `sendOutboundEmail` (`consumeDailyEntitlement`; plan limit from `resolvePlanLimit`)                                                                                                                                                   |
-| `email_receives_per_day`   | `handleInboundEmail` (`consumeDailyEntitlement`; same plan limits; refund only on `RetryableInboundStorageError`)                                                                                                                     |
-| `stored_email_messages`    | `handleInboundEmail` before storage (`assertWithinEntitlement`; `max` caps from `planLimits.max`)                                                                                                                                     |
-| `email_message_bytes`      | `handleInboundEmail` before quota/parse (per-message raw size via `resolvePlanLimit`)                                                                                                                                                 |
-| `secrets`                  | new-entry branch of `saveSecret` in `packages/worker/src/mcp/secrets/service.ts`                                                                                                                                                      |
-| `concurrent_workflows`     | `createDynamicCallableWorkflow` (`reserveWorkflowProjectionSlot` + `assertWithinEntitlement` getCurrent; `max` = 5,000)                                                                                                               |
-| `execute_calls_per_day`    | MCP `execute` tool handler (`consumeDailyEntitlement` before bundling/sandbox)                                                                                                                                                        |
-| `outbound_fetches_per_day` | `executeGatewayFetch` (`consumeDailyEntitlement` before secret expansion)                                                                                                                                                             |
-| `job_runs_per_day`         | `executeJobOnce` (`consumeDailyEntitlement` before sandbox work; cron, interval, and run-now)                                                                                                                                         |
-| `storage_bytes`            | UserMeter DO reserve via `assertWithinStorageBytesEntitlement` (atomic `reserveStorageBytes`; cold zero-init bootstrap; required `env.USER_METER`); StorageRunner write tools/app RPCs (`getCurrent` check-only for bucket component) |
+| Resource                   | Enforcement point                                                                                                                                                                                                                                                                                                                  |
+| -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `scheduled_jobs`           | Full-addition preflight in `syncPackageJobsForPackage` in `packages/worker/src/jobs/service.ts` (package sync subtracts same-sync removals before checking, so replacements do not consume an extra slot). Free also asserts `minJobIntervalMs` (15 minutes) on create or schedule change; existing faster jobs are grandfathered. |
+| `saved_packages`           | new-package branch of `package_save` and projection insert                                                                                                                                                                                                                                                                         |
+| `repo_sessions`            | `repo_open_session` before creating a new session                                                                                                                                                                                                                                                                                  |
+| `email_sends_per_day`      | `sendOutboundEmail` (`consumeDailyEntitlement`; plan limit from `resolvePlanLimit`)                                                                                                                                                                                                                                                |
+| `email_receives_per_day`   | `handleInboundEmail` (`consumeDailyEntitlement`; same plan limits; refund only on `RetryableInboundStorageError`)                                                                                                                                                                                                                  |
+| `stored_email_messages`    | `handleInboundEmail` before storage (`assertWithinEntitlement`; `max` caps from `planLimits.max`)                                                                                                                                                                                                                                  |
+| `email_message_bytes`      | `handleInboundEmail` before quota/parse (per-message raw size via `resolvePlanLimit`)                                                                                                                                                                                                                                              |
+| `secrets`                  | new-entry branch of `saveSecret` in `packages/worker/src/mcp/secrets/service.ts`                                                                                                                                                                                                                                                   |
+| `concurrent_workflows`     | `createDynamicCallableWorkflow` (`reserveWorkflowProjectionSlot` + `assertWithinEntitlement` getCurrent; `max` = 5,000)                                                                                                                                                                                                            |
+| `execute_calls_per_day`    | MCP `execute` tool handler (`consumeDailyEntitlement` before bundling/sandbox)                                                                                                                                                                                                                                                     |
+| `outbound_fetches_per_day` | `executeGatewayFetch` (`consumeDailyEntitlement` before secret expansion)                                                                                                                                                                                                                                                          |
+| `job_runs_per_day`         | `executeJobOnce` (`consumeDailyEntitlement` before sandbox work; cron, interval, and run-now)                                                                                                                                                                                                                                      |
+| `storage_bytes`            | UserMeter DO reserve via `assertWithinStorageBytesEntitlement` (atomic `reserveStorageBytes`; cold zero-init bootstrap; required `env.USER_METER`); StorageRunner write tools/app RPCs (`getCurrent` check-only for bucket component)                                                                                              |
 
 ## Billing
 
@@ -722,9 +727,10 @@ Checkout sessions are created server-side for authenticated users via
 `metadata.kody_stable_user_id`). There is no public Payment Link path — checkout
 requires a signed-in session so unauthenticated card-testing is not possible.
 `GET /account/billing/success` verifies `client_reference_id` before linking
-`users.stripe_customer_id`, then refreshes `users.stripe_plan`. A successful
-`stripe_plan` write also best-effort re-syncs official Kody Discord Standard/Pro
-roles when the user has a Discord social-login connection (see
+`users.stripe_customer_id`, then refreshes `users.stripe_plan` and renders a
+thank-you page (Discord invite; connect-your-agent when `needsOnboarding`). A
+successful `stripe_plan` write also best-effort re-syncs official Kody Discord
+Standard/Pro roles when the user has a Discord social-login connection (see
 [`social-login.md`](../social-login.md)). `GET /account/billing/portal` opens
 the Stripe customer portal for linked customers.
 

--- a/docs/contributing/architecture/primitives.yaml
+++ b/docs/contributing/architecture/primitives.yaml
@@ -142,6 +142,8 @@ primitives:
       - packages/worker/src/app/handlers/waiting-list.ts
       - packages/worker/src/app/kit-waitlist.ts
       - packages/worker/src/app/kit-signup.ts
+      - packages/worker/src/kit/subscriber-sync.ts
+      - packages/worker/src/app/kit-subscriber-sync.ts
       - packages/worker/src/app/handlers/account-connections.ts
       - packages/worker/src/discord/guild-role.ts
       - packages/worker/src/app/oauth-

--- a/docs/contributing/environment-variables.md
+++ b/docs/contributing/environment-variables.md
@@ -220,7 +220,13 @@ Optional Worker secrets / vars for the public `/signup` waiting-list form
   (defaults to "Kody Waitlist Welcome", from `hello@kentcdodds.com`).
 - `KIT_SIGNED_UP_TAG_ID` — optional override for the Kit tag applied on account
   signup when the email already exists in Kit (defaults to `signed_up::kody`).
-  Signup never creates Kit subscribers and never fails when Kit is unset.
+  Account events never create Kit subscribers and never fail when Kit is unset.
+  When a subscriber already exists, lifecycle tags are added in place
+  (`signed_up::kody`, `verified::kody`, `agent_connected::kody`,
+  `activated::kody`, plus `standard::kody` / `pro::kody` from Stripe). Paid tags
+  are removed on cancel. The hourly `kit_subscriber_sync` lane reconciles the
+  same exist-only tags. Waitlist joins still create subscribers via
+  `POST /waiting-list`.
 
 See [`architecture/authentication.md`](./architecture/authentication.md).
 

--- a/docs/contributing/setup-manifest.md
+++ b/docs/contributing/setup-manifest.md
@@ -550,12 +550,11 @@ Configure these GitHub Actions secrets and variables for workflows:
   Discord guild join and role sync. Synced to the Worker under the same names.
   The bot needs Create Instant Invite and Manage Roles.)
 - `KIT_API_KEY` (optional GitHub / Worker secret; Kit / kit.com API key for
-  `/waiting-list` signup and best-effort `signed_up::kody` tagging on account
-  signup when the email already exists in Kit. Production deploy syncs it when
-  set; without it, production waiting-list joins return 503 while the rest of
-  the app still deploys (account signup simply skips Kit tagging). Preview
-  deploys intentionally omit the key so preview/E2E joins do not write to the
-  production Kit audience. Create a Kit API key at
+  `/waiting-list` signup and exist-only lifecycle tagging when the email already
+  exists in Kit. Production deploy syncs it when set; without it, production
+  waiting-list joins return 503 while the rest of the app still deploys (account
+  events skip Kit). Preview deploys intentionally omit the key so preview/E2E
+  joins do not write to the production Kit audience. Create a Kit API key at
   https://app.kit.com/account_settings/developer_settings and use the same value
   as the Kody user secret `kitApiKey` when convenient.)
 - `STRIPE_SECRET_KEY` (optional GitHub / Worker secret; Stripe secret API key

--- a/packages/shared/src/jobs/schedule.ts
+++ b/packages/shared/src/jobs/schedule.ts
@@ -194,6 +194,64 @@ export function normalizeJobSchedule(schedule: JobSchedule) {
 	return assertNeverJobSchedule(schedule)
 }
 
+const cronIntervalSampleCount = 24
+
+/**
+ * Smallest gap between recurring firings. `once` schedules (and crons that
+ * do not produce two future runs) return null so a one-shot is never treated
+ * as a polling interval.
+ */
+export function estimateScheduleMinIntervalMs(input: {
+	schedule: JobSchedule
+	timezone?: string | null
+	from?: Date | string | null
+}): number | null {
+	const schedule = normalizeJobSchedule(input.schedule)
+	switch (schedule.type) {
+		case 'once':
+			return null
+		case 'interval':
+			return parseIntervalEvery(schedule.every).everyMs
+		case 'cron': {
+			const timezone = normalizeJobTimezone(input.timezone)
+			assertValidJobTimezone(timezone)
+			const from =
+				input.from instanceof Date
+					? input.from
+					: input.from
+						? new Date(input.from)
+						: new Date()
+			if (Number.isNaN(from.valueOf())) {
+				throw new Error(
+					'Cannot estimate a cron interval from an invalid reference date.',
+				)
+			}
+			const cron = new Cron(schedule.expression, {
+				paused: true,
+				timezone,
+			})
+			const dates: Array<Date> = []
+			let cursor = from
+			for (let i = 0; i < cronIntervalSampleCount; i += 1) {
+				const next = cron.nextRun(cursor)
+				if (!next) break
+				dates.push(next)
+				cursor = next
+			}
+			if (dates.length < 2) return null
+			let min = Number.POSITIVE_INFINITY
+			for (let i = 1; i < dates.length; i += 1) {
+				const previous = dates[i - 1]
+				const current = dates[i]
+				if (!previous || !current) continue
+				min = Math.min(min, current.getTime() - previous.getTime())
+			}
+			return Number.isFinite(min) ? min : null
+		}
+	}
+	return assertNeverJobSchedule(schedule)
+}
+
 export function formatScheduleSummary(input: {
 	schedule: JobSchedule
 	timezone?: string | null

--- a/packages/shared/src/jobs/scheduled-lanes.ts
+++ b/packages/shared/src/jobs/scheduled-lanes.ts
@@ -21,6 +21,7 @@ export const scheduledLaneNames = [
 	'auth_denial_alert',
 	'email_delivery_alert',
 	'usage_entitlement_alert',
+	'kit_subscriber_sync',
 	'dr_export',
 	'dr_export_watchdog',
 	'job_schedule_watchdog',
@@ -114,6 +115,10 @@ export function shouldRunUsageEntitlementAlertCron(now: Date) {
 	return now.getUTCMinutes() === 0
 }
 
+export function shouldRunKitSubscriberSyncCron(now: Date) {
+	return now.getUTCMinutes() === 0
+}
+
 /**
  * Nightly DR export window: roughly 00:30–06:10 UTC on the worker's
  * every-5-minute cron (~68 ticks × 20 s ≈ 22 minutes of staging work).
@@ -187,6 +192,9 @@ export function getScheduledLaneCadence(
 	}
 	if (shouldRunUsageEntitlementAlertCron(scheduledAt)) {
 		lanes.push('usage_entitlement_alert')
+	}
+	if (shouldRunKitSubscriberSyncCron(scheduledAt)) {
+		lanes.push('kit_subscriber_sync')
 	}
 	if (
 		shouldRunDrExportCron(scheduledAt) ||

--- a/packages/worker/client/lazy-route.tsx
+++ b/packages/worker/client/lazy-route.tsx
@@ -246,6 +246,7 @@ registerPreloadPatterns(
 	[
 		routePattern(routes.account),
 		routePattern(routes.accountBilling),
+		routePattern(routes.accountBillingSuccess),
 		routePattern(routes.accountUsage),
 		routePattern(routes.accountIntegrations),
 		routePattern(routes.accountOauthAppDetail),

--- a/packages/worker/client/routes/account-area.ts
+++ b/packages/worker/client/routes/account-area.ts
@@ -3,6 +3,10 @@ export {
 	AccountBillingRoute,
 	accountBillingRouteLoader,
 } from './account-billing.tsx'
+export {
+	AccountBillingSuccessRoute,
+	accountBillingSuccessRouteLoader,
+} from './account-billing-success.tsx'
 export { AccountEmailRoute, accountEmailRouteLoader } from './account-email.tsx'
 export { AccountUsageRoute, accountUsageRouteLoader } from './account-usage.tsx'
 export {

--- a/packages/worker/client/routes/account-billing-success.tsx
+++ b/packages/worker/client/routes/account-billing-success.tsx
@@ -1,0 +1,114 @@
+import { type Handle, css } from 'remix/ui'
+import { kodyDiscordInviteUrl } from '#universal/community-links.ts'
+import { type AccountBillingSuccessLoaderData } from '#universal/loader-data.ts'
+import { readCurrentRouterHref } from '#client/client-router.tsx'
+import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
+import {
+	routeLoaderRedirect,
+	type RouteLoaderResult,
+} from '#client/route-loader.ts'
+import {
+	cardCss,
+	getGhostButtonCss,
+	getPrimaryButtonCss,
+	mutedLinkCss,
+	pageDescriptionCss,
+	pageHeaderCss,
+	pageTitleCss,
+	stackedPageCss,
+} from '#universal/styles/style-primitives.ts'
+import { colors, spacing, typography } from '#universal/styles/tokens.ts'
+
+const billingPath = '/account/billing'
+const onboardingPath = '/onboarding'
+
+export async function accountBillingSuccessRouteLoader(
+	url: URL,
+): Promise<RouteLoaderResult> {
+	if (!url.searchParams.get('session_id')?.trim()) {
+		return routeLoaderRedirect(billingPath)
+	}
+	return {
+		accountBillingSuccess: {
+			ok: true,
+			needsOnboarding: true,
+		},
+	}
+}
+
+export function AccountBillingSuccessRoute(handle: Handle) {
+	return () => {
+		const href = readCurrentRouterHref(handle)
+		const routeData = tryConsumeRouteLoaderData(
+			handle,
+			'accountBillingSuccess',
+			href,
+		)
+		const data: AccountBillingSuccessLoaderData = routeData ?? {
+			ok: true,
+			needsOnboarding: true,
+		}
+
+		return (
+			<section mix={css(pageCss)}>
+				<header mix={css(pageHeaderCss)}>
+					<h1 mix={css(pageTitleCss)}>You&rsquo;re in</h1>
+					<p mix={css(pageDescriptionCss)}>
+						Your paid plan is active. Same factory, more room for jobs,
+						workflows, and daily volume.
+					</p>
+				</header>
+				<div mix={css(cardCss)}>
+					<p mix={css(statusCss)} role="status">
+						Thanks for paying for the volume you actually use.
+					</p>
+					<div mix={css(ctaRowCss)}>
+						<a href={kodyDiscordInviteUrl} mix={css(primaryCtaCss)}>
+							Join the Kody Discord
+						</a>
+						{data.needsOnboarding ? (
+							<a href={onboardingPath} mix={css(secondaryCtaCss)}>
+								Connect your agent
+							</a>
+						) : null}
+						<a href={billingPath} mix={css(mutedLinkCss)}>
+							Manage billing
+						</a>
+					</div>
+				</div>
+			</section>
+		)
+	}
+}
+
+const pageCss = {
+	...stackedPageCss,
+	maxWidth: '36rem',
+	margin: '0 auto',
+	gap: spacing.lg,
+}
+
+const statusCss = {
+	color: colors.text,
+	fontSize: typography.fontSize.base,
+	margin: 0,
+}
+
+const ctaRowCss = {
+	display: 'flex',
+	alignItems: 'center',
+	gap: spacing.md,
+	flexWrap: 'wrap' as const,
+}
+
+const primaryCtaCss = {
+	...getPrimaryButtonCss({ size: 'lg', weight: 'semibold' }),
+	display: 'inline-flex',
+	textDecoration: 'none',
+}
+
+const secondaryCtaCss = {
+	...getGhostButtonCss(),
+	display: 'inline-flex',
+	textDecoration: 'none',
+}

--- a/packages/worker/client/routes/account-billing-success.tsx
+++ b/packages/worker/client/routes/account-billing-success.tsx
@@ -37,6 +37,8 @@ export async function accountBillingSuccessRouteLoader(
 }
 
 export function AccountBillingSuccessRoute(handle: Handle) {
+	let persisted: AccountBillingSuccessLoaderData | null = null
+
 	return () => {
 		const href = readCurrentRouterHref(handle)
 		const routeData = tryConsumeRouteLoaderData(
@@ -44,7 +46,8 @@ export function AccountBillingSuccessRoute(handle: Handle) {
 			'accountBillingSuccess',
 			href,
 		)
-		const data: AccountBillingSuccessLoaderData = routeData ?? {
+		if (routeData) persisted = routeData
+		const data: AccountBillingSuccessLoaderData = persisted ?? {
 			ok: true,
 			needsOnboarding: true,
 		}

--- a/packages/worker/client/routes/home.tsx
+++ b/packages/worker/client/routes/home.tsx
@@ -27,6 +27,7 @@ import {
 } from '#client/public-form-protection.ts'
 import { landingArtAttrs } from '#universal/landing-images.ts'
 import { homepageSignupPath } from '#universal/first-touch-attribution.ts'
+import { type SignupMode } from '#universal/signup-mode.ts'
 import {
 	pickWalkthroughHosts,
 	type WalkthroughHostPick,
@@ -117,13 +118,15 @@ export async function homeRouteLoader(
 	_url: URL,
 	signal: AbortSignal,
 ): Promise<RouteLoaderResult> {
-	const [onboarding, codeRuns] = await Promise.all([
+	const [onboarding, codeRuns, authConfig] = await Promise.all([
 		fetchOnboardingPayload(signal),
 		fetchCodeRunsPayload(signal),
+		fetchPublicAuthConfig(signal),
 	])
 	const result: RouteLoaderResult = {}
 	if (onboarding) result.onboarding = onboarding
 	if (codeRuns) result.codeRuns = codeRuns
+	if (authConfig) result.signupMode = authConfig.signupMode
 	result.walkthroughHosts = pickWalkthroughHosts()
 	return result
 }
@@ -136,6 +139,7 @@ export function HomeRoute(handle: Handle) {
 	let codeRunsWindow: PublicCodeRunsWindow | null = null
 	let onboardingStatus: 'idle' | 'loading' | 'ready' = 'idle'
 	let walkthroughHosts: WalkthroughHostPick | null = null
+	let signupMode: SignupMode = 'invite'
 	const loadLatch = createRouteLoadLatch()
 
 	function applyOnboardingPayload(payload: OnboardingPayload | null) {
@@ -156,13 +160,15 @@ export function HomeRoute(handle: Handle) {
 	async function loadHomePayload(signal: AbortSignal) {
 		const href = readCurrentRouterHref(handle)
 		try {
-			const [payload, codeRuns] = await Promise.all([
+			const [payload, codeRuns, authConfig] = await Promise.all([
 				fetchOnboardingPayload(signal),
 				fetchCodeRunsPayload(signal),
+				fetchPublicAuthConfig(signal),
 			])
 			if (signal.aborted) return
 			applyOnboardingPayload(payload)
 			applyCodeRunsPayload(codeRuns)
+			if (authConfig) signupMode = authConfig.signupMode
 			if (!walkthroughHosts) walkthroughHosts = pickWalkthroughHosts()
 			loadLatch.markLoaded(href)
 			handle.update()
@@ -184,8 +190,10 @@ export function HomeRoute(handle: Handle) {
 			'walkthroughHosts',
 			href,
 		)
+		const signupModeData = tryConsumeRouteLoaderData(handle, 'signupMode', href)
 		if (hostsData) walkthroughHosts = hostsData
 		if (codeRunsData) applyCodeRunsPayload(codeRunsData)
+		if (signupModeData) signupMode = signupModeData
 		if (!onboardingData) return false
 		applyOnboardingPayload(onboardingData)
 		loadLatch.markLoaded(href)
@@ -239,6 +247,15 @@ export function HomeRoute(handle: Handle) {
 								)}
 								<a href="/account" class="landing-code-link">
 									Open your account
+								</a>
+							</>
+						) : signupMode === 'open' ? (
+							<>
+								<a href={homepageSignupPath} class="landing-pill">
+									Create a free account
+								</a>
+								<a href="/login" class="landing-code-link">
+									I already have an account
 								</a>
 							</>
 						) : (
@@ -528,6 +545,17 @@ export function HomeRoute(handle: Handle) {
 							<p class="landing-invite-cta">
 								<a href={onboardingPath} class="landing-pill">
 									Connect your agent
+								</a>
+							</p>
+						</div>
+					) : signupMode === 'open' ? (
+						<div>
+							<p class="landing-invite-lead">
+								Create a free account and connect the agent you already use.
+							</p>
+							<p class="landing-invite-cta">
+								<a href={homepageSignupPath} class="landing-pill">
+									Create a free account
 								</a>
 							</p>
 						</div>

--- a/packages/worker/client/routes/index.tsx
+++ b/packages/worker/client/routes/index.tsx
@@ -34,6 +34,10 @@ export const clientRouteLoaders: Record<string, RouteLoader> = {
 		accountArea,
 		(m) => m.accountBillingRouteLoader,
 	),
+	[routePattern(routes.accountBillingSuccess)]: lazyRouteLoader(
+		accountArea,
+		(m) => m.accountBillingSuccessRouteLoader,
+	),
 	[routePattern(routes.accountUsage)]: lazyRouteLoader(
 		accountArea,
 		(m) => m.accountUsageRouteLoader,
@@ -306,6 +310,10 @@ export const clientRouteLoaders: Record<string, RouteLoader> = {
 		marketingArea,
 		(m) => m.discordRouteLoader,
 	),
+	[routePattern(routes.pricing)]: lazyRouteLoader(
+		marketingArea,
+		(m) => m.pricingRouteLoader,
+	),
 }
 
 export const clientRoutes = {
@@ -315,6 +323,9 @@ export const clientRoutes = {
 	),
 	[routePattern(routes.accountBilling)]: (
 		<LazyAccountRoute render={(m) => <m.AccountBillingRoute />} />
+	),
+	[routePattern(routes.accountBillingSuccess)]: (
+		<LazyAccountRoute render={(m) => <m.AccountBillingSuccessRoute />} />
 	),
 	[routePattern(routes.accountUsage)]: (
 		<LazyAccountRoute render={(m) => <m.AccountUsageRoute />} />

--- a/packages/worker/client/routes/marketing-area.ts
+++ b/packages/worker/client/routes/marketing-area.ts
@@ -1,4 +1,4 @@
 export { DiscordRoute, discordRouteLoader } from './discord.tsx'
-export { PricingRoute } from './pricing.tsx'
+export { PricingRoute, pricingRouteLoader } from './pricing.tsx'
 export { PrivacyRoute } from './privacy.tsx'
 export { TermsRoute } from './terms.tsx'

--- a/packages/worker/client/routes/pricing.tsx
+++ b/packages/worker/client/routes/pricing.tsx
@@ -1,7 +1,16 @@
 import { type Handle, css } from 'remix/ui'
 import { readAppSession } from '#client/app-session-context.tsx'
+import { readCurrentRouterHref } from '#client/client-router.tsx'
+import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
 import { reveal } from '#client/reveal.ts'
-import { planLimits, type PlanLimits } from '#universal/plans.ts'
+import { type RouteLoaderResult } from '#client/route-loader.ts'
+import { fetchPublicAuthConfig } from '#client/social-sign-in.ts'
+import {
+	formatMinJobInterval,
+	planLimits,
+	type PlanLimits,
+} from '#universal/plans.ts'
+import { type SignupMode } from '#universal/signup-mode.ts'
 import { colors, radius, typography } from '#universal/styles/tokens.ts'
 import {
 	getGhostButtonCss,
@@ -46,6 +55,11 @@ const limitGroups: ReadonlyArray<LimitGroup> = [
 			{ label: 'Connected repos', key: 'maxRepos' },
 			{ label: 'Saved packages', key: 'maxSavedPackages' },
 			{ label: 'Scheduled jobs', key: 'maxScheduledJobs' },
+			{
+				label: 'Fastest job interval',
+				key: 'minJobIntervalMs',
+				format: (value) => ({ text: formatMinJobInterval(value) }),
+			},
 			{ label: 'Active repo sessions', key: 'maxRepoSessions' },
 		],
 	},
@@ -84,9 +98,25 @@ const limitGroups: ReadonlyArray<LimitGroup> = [
 	},
 ]
 
+export async function pricingRouteLoader(
+	_url: URL,
+	signal: AbortSignal,
+): Promise<RouteLoaderResult> {
+	const config = await fetchPublicAuthConfig(signal)
+	return { signupMode: config?.signupMode ?? 'invite' }
+}
+
 export function PricingRoute(handle: Handle) {
+	let signupMode: SignupMode = 'invite'
 	return () => {
 		const isSignedIn = readAppSession(handle).session !== null
+		const href = readCurrentRouterHref(handle)
+		const loadedSignupMode = tryConsumeRouteLoaderData(
+			handle,
+			'signupMode',
+			href,
+		)
+		if (loadedSignupMode) signupMode = loadedSignupMode
 		return (
 			<section mix={css(pricingCss)}>
 				<header mix={css(pageHeadCss)}>
@@ -108,11 +138,21 @@ export function PricingRoute(handle: Handle) {
 						</h2>
 						<p mix={css(planPriceCss)}>$0</p>
 						<p mix={css(planCopyCss)}>
-							The whole factory. Tight caps so you can see if it earns a place.
+							The whole factory. 5 jobs, no faster than every 15 minutes.
 						</p>
-						<a href="/signup" mix={css(planPillButtonCss)}>
-							Create a free account
-						</a>
+						{isSignedIn ? (
+							<a href="/account" mix={css(planPillButtonCss)}>
+								Open your account
+							</a>
+						) : signupMode === 'open' ? (
+							<a href="/signup" mix={css(planPillButtonCss)}>
+								Create a free account
+							</a>
+						) : (
+							<a href="/#invite" mix={css(planPillButtonCss)}>
+								Join the waiting list
+							</a>
+						)}
 					</section>
 
 					{/*
@@ -208,6 +248,10 @@ export function PricingRoute(handle: Handle) {
 						<a href="/account" mix={css(limitsCtaButtonCss)}>
 							Open your account
 						</a>
+					) : signupMode === 'open' ? (
+						<a href="/signup" mix={css(limitsCtaButtonCss)}>
+							Create a free account
+						</a>
 					) : (
 						<a href="/#invite" mix={css(limitsCtaButtonCss)}>
 							Join the waiting list
@@ -228,9 +272,9 @@ function renderPaidPlanCta(isSignedIn: boolean) {
 		)
 	}
 	return (
-		<button type="button" disabled mix={css(planGhostButtonCss)}>
-			Launch coming soon
-		</button>
+		<a href="/signup" mix={css(planGhostButtonCss)}>
+			Create a free account
+		</a>
 	)
 }
 

--- a/packages/worker/src/app/email-verification.ts
+++ b/packages/worker/src/app/email-verification.ts
@@ -148,7 +148,13 @@ export async function createEmailVerification(input: {
 }
 
 export type VerifyEmailResult =
-	| { ok: true; userId: number; email: string }
+	| {
+			ok: true
+			userId: number
+			email: string
+			stableUserId: string
+			newlyVerified: boolean
+	  }
 	| { ok: false; reason: 'missing_token' | 'invalid_token' | 'expired_token' }
 
 export async function verifyEmailToken(input: {
@@ -162,13 +168,21 @@ export async function verifyEmailToken(input: {
 	const tokenHash = await hashVerificationToken(token)
 	const record = await input.db
 		.prepare(
-			`SELECT ev.id, ev.user_id, ev.expires_at, u.email
+			`SELECT ev.id, ev.user_id, ev.expires_at, u.email,
+			        u.stable_user_id, u.email_verified_at
 			 FROM email_verifications ev
 			 INNER JOIN users u ON u.id = ev.user_id
 			 WHERE ev.token_hash = ?`,
 		)
 		.bind(tokenHash)
-		.first<{ id: number; user_id: number; expires_at: number; email: string }>()
+		.first<{
+			id: number
+			user_id: number
+			expires_at: number
+			email: string
+			stable_user_id: string
+			email_verified_at: string | null
+		}>()
 	const now = input.now ?? new Date()
 
 	if (!record) return { ok: false, reason: 'invalid_token' }
@@ -180,6 +194,7 @@ export async function verifyEmailToken(input: {
 		return { ok: false, reason: 'expired_token' }
 	}
 
+	const newlyVerified = !record.email_verified_at
 	const verifiedAt = now.toISOString()
 	await input.db
 		.prepare(
@@ -198,5 +213,11 @@ export async function verifyEmailToken(input: {
 		.bind(record.user_id)
 		.run()
 
-	return { ok: true, userId: record.user_id, email: record.email }
+	return {
+		ok: true,
+		userId: record.user_id,
+		email: record.email,
+		stableUserId: record.stable_user_id,
+		newlyVerified,
+	}
 }

--- a/packages/worker/src/app/email/messages.ts
+++ b/packages/worker/src/app/email/messages.ts
@@ -126,6 +126,138 @@ function entitlementWarningCopy(kind: UserEntitlementWarningKind) {
 	}
 }
 
+export function buildConnectAgentEmail(input: {
+	appBaseUrl: string
+	onboardingUrl: string
+}) {
+	return renderTransactionalEmail({
+		appBaseUrl: input.appBaseUrl,
+		subject: 'Connect your agent to Kody',
+		preheader: 'One connection and your assistant has a home.',
+		heading: 'Connect the agent you already use',
+		body: [
+			'Your email is verified. Next, connect Cursor, Claude, ChatGPT, or another MCP host so Kody can keep memory, secrets, and jobs for you.',
+			'It takes a couple of minutes. After that, every agent you use can share the same home.',
+		],
+		action: { label: 'Connect your agent', url: input.onboardingUrl },
+		illustration: {
+			src: '/images/kody-lantern.png',
+			alt: '',
+			width: 96,
+			height: 96,
+		},
+		footnote: "You're receiving this because you just verified a Kody account.",
+	})
+}
+
+export function buildBillingSuccessEmail(input: {
+	appBaseUrl: string
+	billingUrl: string
+	discordUrl: string
+	planLabel: string
+}) {
+	return renderTransactionalEmail({
+		appBaseUrl: input.appBaseUrl,
+		subject: `You're on Kody ${input.planLabel}`,
+		preheader: 'Thanks for paying for the volume you actually use.',
+		heading: `Welcome to ${input.planLabel}`,
+		body: [
+			`Your Kody account is now on the ${input.planLabel} plan. Same factory, more room for jobs, workflows, and daily volume.`,
+			'Join the Discord if you want help, examples, or to talk to other people building with Kody.',
+		],
+		action: { label: 'Join the Kody Discord', url: input.discordUrl },
+		afterAction: [`You can manage billing anytime: ${input.billingUrl}`],
+		illustration: {
+			src: '/images/kody-lantern.png',
+			alt: '',
+			width: 96,
+			height: 96,
+		},
+		footnote: "You're receiving this because you subscribed to a Kody plan.",
+	})
+}
+
+export function buildPaymentFailedEmail(input: {
+	appBaseUrl: string
+	billingUrl: string
+}) {
+	return renderTransactionalEmail({
+		appBaseUrl: input.appBaseUrl,
+		subject: 'Kody could not process your payment',
+		preheader: 'Update your payment method to keep your paid plan.',
+		heading: 'Your payment did not go through',
+		body: [
+			'Stripe could not charge the card on your Kody subscription. Update your payment method so your paid limits stay in place.',
+		],
+		action: { label: 'Update billing', url: input.billingUrl },
+		illustration: {
+			src: '/images/kody-lantern.png',
+			alt: '',
+			width: 96,
+			height: 96,
+		},
+		footnote:
+			"You're receiving this because a Kody subscription payment failed.",
+	})
+}
+
+export function buildPastDueEmail(input: {
+	appBaseUrl: string
+	billingUrl: string
+}) {
+	return renderTransactionalEmail({
+		appBaseUrl: input.appBaseUrl,
+		subject: 'Your Kody subscription is past due',
+		preheader: 'Your paid plan is waiting on a successful payment.',
+		heading: 'Your subscription is past due',
+		body: [
+			'Your Kody subscription is past due. Update your payment method to keep Standard or Pro limits. If payment stays failed, the account returns to the free plan.',
+		],
+		action: { label: 'Fix billing', url: input.billingUrl },
+		illustration: {
+			src: '/images/kody-lantern.png',
+			alt: '',
+			width: 96,
+			height: 96,
+		},
+		footnote:
+			"You're receiving this because your Kody subscription is past due.",
+	})
+}
+
+export function buildUserErrorRateEmail(input: {
+	appBaseUrl: string
+	activityUrl: string
+	triagePackageUrl: string
+	errorCount: number
+	eventCount: number
+}) {
+	const percent =
+		input.eventCount > 0
+			? Math.round((input.errorCount / input.eventCount) * 100)
+			: 0
+	return renderTransactionalEmail({
+		appBaseUrl: input.appBaseUrl,
+		subject: 'Your Kody runs are erroring more than usual',
+		preheader: 'A look at the failures, and a package that can help.',
+		heading: 'A few runs need attention',
+		body: [
+			`This month Kody recorded ${input.errorCount.toLocaleString('en-US')} errors across ${input.eventCount.toLocaleString('en-US')} runs (${percent}%).`,
+			'Review the activity log, or fork Kent’s issue-triage package so a cloud agent can inspect the failures for you.',
+		],
+		action: { label: 'Review account activity', url: input.activityUrl },
+		afterAction: [`Loop-safe Cursor triage package: ${input.triagePackageUrl}`],
+		illustration: {
+			src: '/images/kody-lantern.png',
+			alt: '',
+			width: 96,
+			height: 96,
+		},
+		footnote:
+			"You're receiving this because your Kody account crossed an error-rate threshold.",
+	})
+}
+
 export function buildPasswordResetEmail(input: {
 	appBaseUrl: string
 	resetUrl: string

--- a/packages/worker/src/app/email/template.node.test.ts
+++ b/packages/worker/src/app/email/template.node.test.ts
@@ -1,6 +1,9 @@
 import { expect, test } from 'vitest'
 import {
+	buildBillingSuccessEmail,
+	buildConnectAgentEmail,
 	buildUserEntitlementWarningEmail,
+	buildUserErrorRateEmail,
 	buildVerificationEmail,
 } from './messages.ts'
 import { renderTransactionalEmail } from './template.ts'
@@ -73,4 +76,32 @@ test('transactional emails escape untrusted content and put action URLs in both 
 	})
 	expect(reached.subject).toContain('reached')
 	expect(reached.html).toContain('250 of 250 (100%)')
+
+	const connect = buildConnectAgentEmail({
+		appBaseUrl: 'https://kody.codes',
+		onboardingUrl: 'https://kody.codes/onboarding',
+	})
+	expect(connect.subject).toContain('Connect your agent')
+	expect(connect.html).toContain('https://kody.codes/onboarding')
+
+	const billing = buildBillingSuccessEmail({
+		appBaseUrl: 'https://kody.codes',
+		billingUrl: 'https://kody.codes/account/billing',
+		discordUrl: 'https://kcd.im/kody-discord',
+		planLabel: 'Pro',
+	})
+	expect(billing.subject).toContain('Pro')
+	expect(billing.html).toContain('https://kcd.im/kody-discord')
+	expect(billing.text).toContain('https://kody.codes/account/billing')
+
+	const errorRate = buildUserErrorRateEmail({
+		appBaseUrl: 'https://kody.codes',
+		activityUrl: 'https://kody.codes/account/activity',
+		triagePackageUrl: 'https://kody.codes/@kentcdodds/kody-issue-triage',
+		errorCount: 10,
+		eventCount: 40,
+	})
+	expect(errorRate.html).toContain('https://kody.codes/account/activity')
+	expect(errorRate.text).toContain('/@kentcdodds/kody-issue-triage')
+	expect(errorRate.html).toContain('25%')
 })

--- a/packages/worker/src/app/handlers/account-billing.node.test.ts
+++ b/packages/worker/src/app/handlers/account-billing.node.test.ts
@@ -1,16 +1,54 @@
 import { expect, test, vi } from 'vitest'
 import type * as StripeClient from '#worker/billing/stripe-client.ts'
-import { createAccountBillingCheckoutApiHandler } from './account-billing.ts'
+import {
+	createAccountBillingCheckoutApiHandler,
+	createAccountBillingSuccessHandler,
+} from './account-billing.ts'
 
 const mockModule = vi.hoisted(() => ({
 	readAuthenticatedAppUser: vi.fn<() => Promise<unknown>>(),
+	requireAuthenticatedPageUser: vi.fn<() => Promise<unknown>>(),
+	userHasMcpOAuthGrants: vi.fn<() => Promise<boolean>>(),
+	linkStripeCustomerFromCheckoutSessionAttribution:
+		vi.fn<(...args: Array<unknown>) => Promise<unknown>>(),
 	createCheckoutSession:
 		vi.fn<(...args: Array<unknown>) => Promise<{ id: string; url: string }>>(),
+	renderAppPage: vi.fn(async ({ loaderData }: { loaderData?: unknown }) =>
+		Response.json({ ok: true, loaderData }),
+	),
 }))
 
 vi.mock('#app/authenticated-user.ts', () => ({
 	readAuthenticatedAppUser: (...args: Array<unknown>) =>
 		mockModule.readAuthenticatedAppUser(...args),
+}))
+
+vi.mock('#app/page-auth.ts', () => ({
+	requireAuthenticatedPageUser: (...args: Array<unknown>) =>
+		mockModule.requireAuthenticatedPageUser(...args),
+}))
+
+vi.mock('#app/onboarding-data.ts', () => ({
+	userHasMcpOAuthGrants: (...args: Array<unknown>) =>
+		mockModule.userHasMcpOAuthGrants(...args),
+}))
+
+vi.mock('#app/ssr-render.tsx', () => ({
+	renderAppPage: (...args: Array<unknown>) =>
+		mockModule.renderAppPage(...(args as [never])),
+}))
+
+vi.mock('#worker/billing/subscription-sync.ts', () => ({
+	BillingLinkError: class BillingLinkError extends Error {
+		readonly code: string
+		constructor(code: string, message: string) {
+			super(message)
+			this.name = 'BillingLinkError'
+			this.code = code
+		}
+	},
+	linkStripeCustomerFromCheckoutSessionAttribution: (...args: Array<unknown>) =>
+		mockModule.linkStripeCustomerFromCheckoutSessionAttribution(...args),
 }))
 
 vi.mock('#worker/billing/stripe-client.ts', async (importOriginal) => {
@@ -144,4 +182,47 @@ test('billing checkout selects monthly vs yearly Stripe price ids', async () => 
 	)
 	expect(yearlyMissing.status).toBe(409)
 	expect(mockModule.createCheckoutSession).toHaveBeenCalledTimes(4)
+})
+
+test('billing success renders a thank-you page instead of redirecting', async () => {
+	mockModule.requireAuthenticatedPageUser.mockResolvedValue({
+		...authenticatedUser,
+		emailVerified: true,
+	})
+	mockModule.userHasMcpOAuthGrants.mockResolvedValue(false)
+	mockModule.linkStripeCustomerFromCheckoutSessionAttribution.mockResolvedValue(
+		{},
+	)
+
+	const handler = createAccountBillingSuccessHandler(createEnv())
+	const missingSession = await handler.handler({
+		request: new Request('https://example.com/account/billing/success'),
+		params: {},
+		url: new URL('https://example.com/account/billing/success'),
+	} as never)
+	expect(missingSession.status).toBe(302)
+	expect(missingSession.headers.get('location')).toContain(
+		'/account/billing?error=missing_session',
+	)
+
+	const success = await handler.handler({
+		request: new Request(
+			'https://example.com/account/billing/success?session_id=cs_test',
+		),
+		params: {},
+		url: new URL(
+			'https://example.com/account/billing/success?session_id=cs_test',
+		),
+	} as never)
+	expect(success.status).toBe(200)
+	expect(await success.json()).toEqual({
+		ok: true,
+		loaderData: {
+			accountBillingSuccess: {
+				ok: true,
+				needsOnboarding: true,
+			},
+		},
+	})
+	expect(success.headers.get('location')).toBeNull()
 })

--- a/packages/worker/src/app/handlers/account-billing.ts
+++ b/packages/worker/src/app/handlers/account-billing.ts
@@ -3,6 +3,7 @@ import { type Action } from 'remix/router'
 import { loadAccountBillingData } from '#app/account-billing-data.ts'
 import { getRequestIp, logAuditEvent } from '#worker/audit-log.ts'
 import { readAuthenticatedAppUser } from '#app/authenticated-user.ts'
+import { userHasMcpOAuthGrants } from '#app/onboarding-data.ts'
 import { requireAuthenticatedPageUser } from '#app/page-auth.ts'
 import { renderAppPage } from '#app/ssr-render.tsx'
 import { type routes } from '#universal/routes.ts'
@@ -213,7 +214,22 @@ export function createAccountBillingSuccessHandler(env: Env) {
 					ip: requestIp,
 					path: new URL(request.url).pathname,
 				})
-				return Response.redirect(new URL('/account/billing', request.url), 302)
+				const hasMcpClient = await userHasMcpOAuthGrants(
+					env,
+					user.mcpUser.userId,
+				)
+				const needsOnboarding = !user.emailVerified || !hasMcpClient
+				return renderAppPage({
+					request,
+					env,
+					title: "You're in",
+					loaderData: {
+						accountBillingSuccess: {
+							ok: true,
+							needsOnboarding,
+						},
+					},
+				})
 			} catch (error) {
 				const code =
 					error instanceof BillingLinkError ? error.code : 'link_failed'

--- a/packages/worker/src/app/handlers/auth-provider.ts
+++ b/packages/worker/src/app/handlers/auth-provider.ts
@@ -10,6 +10,7 @@ import {
 } from '#app/auth-session.ts'
 import { getUniqueConstraintField } from '#worker/database-errors.ts'
 import { maybeTagKitSubscriberOnSignup } from '#app/kit-signup.ts'
+import { scheduleKitSubscriberSync } from '#worker/kit/subscriber-sync.ts'
 import { getAvailableUsernameFromBase } from '#worker/identity/generated-username.ts'
 import {
 	consumeInviteCode,
@@ -733,6 +734,11 @@ export function createAuthProviderCallbackHandler(env: Env) {
 			await maybeTagKitSubscriberOnSignup({
 				env,
 				email,
+			})
+			scheduleKitSubscriberSync({
+				env,
+				email,
+				stableUserId,
 			})
 			await followDefaultWelcomeAccounts({
 				db: env.APP_DB,

--- a/packages/worker/src/app/handlers/auth.ts
+++ b/packages/worker/src/app/handlers/auth.ts
@@ -46,6 +46,7 @@ import {
 } from '@kody-internal/shared/password-hash.ts'
 import { getPasswordPolicyError } from '@kody-internal/shared/password-policy.ts'
 import { maybeTagKitSubscriberOnSignup } from '#app/kit-signup.ts'
+import { scheduleKitSubscriberSync } from '#worker/kit/subscriber-sync.ts'
 import { verifyPublicFormProtection } from '#app/public-form-protection.ts'
 import { getSignupMode } from '#universal/signup-mode.ts'
 import {
@@ -443,6 +444,11 @@ export function createAuthHandler(env: Env) {
 				await maybeTagKitSubscriberOnSignup({
 					env,
 					email: normalizedEmail,
+				})
+				scheduleKitSubscriberSync({
+					env,
+					email: normalizedEmail,
+					stableUserId: record.stableUserId,
 				})
 				await followDefaultWelcomeAccounts({
 					db: env.APP_DB,

--- a/packages/worker/src/app/handlers/home.ts
+++ b/packages/worker/src/app/handlers/home.ts
@@ -15,6 +15,7 @@ import {
 	loadPublicOnboardingData,
 } from '#app/onboarding-data.ts'
 import { renderAppPage } from '#app/ssr-render.tsx'
+import { getSignupMode } from '#universal/signup-mode.ts'
 import { pickWalkthroughHosts } from '#universal/walkthrough-hosts.ts'
 import { loadPublicCodeRunsWindow } from '#worker/usage/code-runs-window.ts'
 import { type routes } from '#universal/routes.ts'
@@ -43,6 +44,7 @@ export function createHomeHandler(env: Env) {
 			)
 			const codeRuns = { ok: true as const, window: codeRunsWindow }
 			const walkthroughHosts = pickWalkthroughHosts()
+			const signupMode = getSignupMode(env)
 
 			const user = await readAuthenticatedAppUser(request, env)
 			if (!user) {
@@ -61,6 +63,7 @@ export function createHomeHandler(env: Env) {
 								}),
 								codeRuns,
 								walkthroughHosts,
+								signupMode,
 							},
 							serverTiming,
 						}),
@@ -81,7 +84,12 @@ export function createHomeHandler(env: Env) {
 					await renderAppPage({
 						request,
 						env,
-						loaderData: { onboarding, codeRuns, walkthroughHosts },
+						loaderData: {
+							onboarding,
+							codeRuns,
+							walkthroughHosts,
+							signupMode,
+						},
 						serverTiming,
 					}),
 				),

--- a/packages/worker/src/app/handlers/pricing.ts
+++ b/packages/worker/src/app/handlers/pricing.ts
@@ -1,5 +1,6 @@
 import { type Action } from 'remix/router'
 import { renderAppPage } from '#app/ssr-render.tsx'
+import { getSignupMode } from '#universal/signup-mode.ts'
 import { type routes } from '#universal/routes.ts'
 
 export function createPricingHandler(env: Env) {
@@ -9,6 +10,9 @@ export function createPricingHandler(env: Env) {
 			return renderAppPage({
 				request,
 				env,
+				loaderData: {
+					signupMode: getSignupMode(env),
+				},
 			})
 		},
 	} satisfies Action<typeof routes.pricing>

--- a/packages/worker/src/app/handlers/verify-email.node.test.ts
+++ b/packages/worker/src/app/handlers/verify-email.node.test.ts
@@ -2,6 +2,8 @@ import { expect, test, vi } from 'vitest'
 import { createVerifyEmailHandler } from '#app/handlers/verify-email.ts'
 import { verifyEmailToken } from '#app/email-verification.ts'
 import { renderAppPage } from '#app/ssr-render.tsx'
+import { sendConnectAgentEmail } from '#app/user-account-emails.ts'
+import { scheduleKitSubscriberSync } from '#worker/kit/subscriber-sync.ts'
 
 vi.mock('#app/email-verification.ts', () => ({
 	verifyEmailToken: vi.fn(),
@@ -13,11 +15,21 @@ vi.mock('#app/ssr-render.tsx', () => ({
 	),
 }))
 
+vi.mock('#app/user-account-emails.ts', () => ({
+	sendConnectAgentEmail: vi.fn(async () => true),
+}))
+
+vi.mock('#worker/kit/subscriber-sync.ts', () => ({
+	scheduleKitSubscriberSync: vi.fn(),
+}))
+
 test('verify-email handler wires success CTA from redirectTo and rejects open redirects', async () => {
 	vi.mocked(verifyEmailToken).mockResolvedValue({
 		ok: true,
 		userId: 1,
 		email: 'verified@example.com',
+		stableUserId: 'user_verified',
+		newlyVerified: false,
 	})
 	const handler = createVerifyEmailHandler({
 		APP_DB: {} as D1Database,
@@ -69,4 +81,34 @@ test('verify-email handler wires success CTA from redirectTo and rejects open re
 	})
 
 	expect(renderAppPage).toHaveBeenCalled()
+	expect(sendConnectAgentEmail).not.toHaveBeenCalled()
+	expect(scheduleKitSubscriberSync).not.toHaveBeenCalled()
+})
+
+test('verify-email sends the connect-agent mail only on newly verified accounts', async () => {
+	vi.mocked(verifyEmailToken).mockResolvedValue({
+		ok: true,
+		userId: 1,
+		email: 'verified@example.com',
+		stableUserId: 'user_verified',
+		newlyVerified: true,
+	})
+	const handler = createVerifyEmailHandler({
+		APP_DB: {} as D1Database,
+	} as Env)
+	await handler.handler({
+		request: new Request('https://example.com/verify-email?token=ok'),
+		url: new URL('https://example.com/verify-email?token=ok'),
+		params: {},
+	} as never)
+	expect(sendConnectAgentEmail).toHaveBeenCalledWith({
+		env: expect.anything(),
+		email: 'verified@example.com',
+		userId: 'user_verified',
+	})
+	expect(scheduleKitSubscriberSync).toHaveBeenCalledWith({
+		env: expect.anything(),
+		email: 'verified@example.com',
+		stableUserId: 'user_verified',
+	})
 })

--- a/packages/worker/src/app/handlers/verify-email.ts
+++ b/packages/worker/src/app/handlers/verify-email.ts
@@ -1,6 +1,8 @@
 import { type Action } from 'remix/router'
 import { getRequestIp, logAuditEvent } from '#worker/audit-log.ts'
 import { verifyEmailToken } from '#app/email-verification.ts'
+import { scheduleKitSubscriberSync } from '#worker/kit/subscriber-sync.ts'
+import { sendConnectAgentEmail } from '#app/user-account-emails.ts'
 import { resolveVerifyEmailSuccessCta } from '#universal/safe-redirect.ts'
 import { renderAppPage } from '#app/ssr-render.tsx'
 import { type routes } from '#universal/routes.ts'
@@ -63,6 +65,20 @@ export function createVerifyEmailHandler(env: Env) {
 				ip: requestIp,
 				path: url.pathname,
 			})
+			if (result.newlyVerified) {
+				void sendConnectAgentEmail({
+					env,
+					email: result.email,
+					userId: result.stableUserId,
+				}).catch((error) => {
+					console.warn('connect-agent-email-failed', error)
+				})
+				scheduleKitSubscriberSync({
+					env,
+					email: result.email,
+					stableUserId: result.stableUserId,
+				})
+			}
 			const cta = resolveVerifyEmailSuccessCta(
 				url.searchParams.get('redirectTo'),
 			)

--- a/packages/worker/src/app/kit-subscriber-sync.ts
+++ b/packages/worker/src/app/kit-subscriber-sync.ts
@@ -1,0 +1,14 @@
+export {
+	desiredKitTagKeys,
+	kitFactsFromUserRow,
+	kitLifecycleTagNames,
+	kitSubscriberSyncSweepLimit,
+	maybeSyncKitSubscriber,
+	maybeSyncKitSubscriberForUser,
+	reconcileKitSubscribers,
+	scheduleKitSubscriberSync,
+	syncExistingKitSubscriber,
+	type KitLifecycleTagKey,
+	type KitSubscriberFacts,
+	type KitSubscriberReconcileResult,
+} from '#worker/kit/subscriber-sync.ts'

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -1578,6 +1578,11 @@ test('renderAppPage renders the redesigned pricing page', async () => {
 		count.format(planLimits.standard.maxExecuteCallsPerDay),
 	)
 	expect(html).toContain(count.format(planLimits.pro.maxExecuteCallsPerDay))
+	expect(html).toContain('Fastest job interval')
+	expect(html).toContain('15 minutes')
+	expect(html).toContain('5 jobs, no faster than every 15 minutes')
+	expect(html).toContain('None')
+	expect(html).not.toContain('Launch coming soon')
 })
 
 test('renderAppPage renders the public Discord connect page', async () => {

--- a/packages/worker/src/app/user-account-emails.node.test.ts
+++ b/packages/worker/src/app/user-account-emails.node.test.ts
@@ -1,0 +1,126 @@
+import { expect, test, vi } from 'vitest'
+
+const sendCloudflareEmail = vi.fn(async () => ({ ok: true }))
+
+vi.mock('#app/email/cloudflare-email.ts', () => ({
+	sendCloudflareEmail: (...args: Array<unknown>) =>
+		sendCloudflareEmail(...args),
+}))
+
+const {
+	sendBillingSuccessEmail,
+	sendConnectAgentEmail,
+	sendPastDueEmail,
+	sendPaymentFailedEmail,
+	userAccountEmailClaimTtlSeconds,
+	userAccountEmailKvKey,
+} = await import('#app/user-account-emails.ts')
+
+function createKv() {
+	const store = new Map<string, string>()
+	const puts: Array<{
+		key: string
+		value: string
+		options?: { expirationTtl?: number }
+	}> = []
+	return {
+		store,
+		puts,
+		kv: {
+			async get(key: string) {
+				return store.get(key) ?? null
+			},
+			async put(
+				key: string,
+				value: string,
+				options?: { expirationTtl?: number },
+			) {
+				puts.push({ key, value, options })
+				store.set(key, value)
+			},
+		} as unknown as KVNamespace,
+	}
+}
+
+function createEnv(kv?: KVNamespace) {
+	return {
+		APP_BASE_URL: 'https://kody.codes/',
+		CLOUDFLARE_ACCOUNT_ID: 'acct',
+		CLOUDFLARE_API_TOKEN: 'token',
+		BUNDLE_ARTIFACTS_KV: kv,
+	} as unknown as Env
+}
+
+test('account emails claim once per kind and skip when KV or sender is missing', async () => {
+	expect(
+		await sendConnectAgentEmail({
+			env: createEnv(),
+			email: 'ada@example.com',
+			userId: 'user-1',
+		}),
+	).toBe(false)
+	expect(sendCloudflareEmail).not.toHaveBeenCalled()
+
+	const { kv, store, puts } = createKv()
+	const env = createEnv(kv)
+	expect(
+		await sendConnectAgentEmail({
+			env,
+			email: 'ada@example.com',
+			userId: 'user-1',
+		}),
+	).toBe(true)
+	expect(sendCloudflareEmail).toHaveBeenCalledTimes(1)
+	const payload = sendCloudflareEmail.mock.calls[0]?.[1] as {
+		to: string
+		subject: string
+		html: string
+		text: string
+	}
+	expect(payload.to).toBe('ada@example.com')
+	expect(payload.subject).toContain('Connect your agent')
+	expect(payload.html).toContain('https://kody.codes/onboarding')
+	expect(payload.text).toContain('https://kody.codes/onboarding')
+	expect(
+		store.get(
+			userAccountEmailKvKey({ userId: 'user-1', kind: 'connect_agent' }),
+		),
+	).toBeTruthy()
+	expect(puts[0]?.options?.expirationTtl).toBe(userAccountEmailClaimTtlSeconds)
+
+	sendCloudflareEmail.mockClear()
+	expect(
+		await sendConnectAgentEmail({
+			env,
+			email: 'ada@example.com',
+			userId: 'user-1',
+		}),
+	).toBe(false)
+	expect(sendCloudflareEmail).not.toHaveBeenCalled()
+
+	expect(
+		await sendBillingSuccessEmail({
+			env,
+			email: 'ada@example.com',
+			userId: 'user-1',
+			planLabel: 'Pro',
+		}),
+	).toBe(true)
+	expect(
+		await sendPaymentFailedEmail({
+			env,
+			email: 'ada@example.com',
+			userId: 'user-1',
+			day: '2026-08-29',
+		}),
+	).toBe(true)
+	expect(
+		await sendPastDueEmail({
+			env,
+			email: 'ada@example.com',
+			userId: 'user-1',
+			day: '2026-08-29',
+		}),
+	).toBe(true)
+	expect(sendCloudflareEmail).toHaveBeenCalledTimes(3)
+})

--- a/packages/worker/src/app/user-account-emails.node.test.ts
+++ b/packages/worker/src/app/user-account-emails.node.test.ts
@@ -1,4 +1,5 @@
 import { expect, test, vi } from 'vitest'
+import { consoleWarn } from '#worker/test-support/console-spies.ts'
 
 const sendCloudflareEmail = vi.fn(async () => ({ ok: true }))
 
@@ -37,6 +38,9 @@ function createKv() {
 			) {
 				puts.push({ key, value, options })
 				store.set(key, value)
+			},
+			async delete(key: string) {
+				store.delete(key)
 			},
 		} as unknown as KVNamespace,
 	}
@@ -123,4 +127,54 @@ test('account emails claim once per kind and skip when KV or sender is missing',
 		}),
 	).toBe(true)
 	expect(sendCloudflareEmail).toHaveBeenCalledTimes(3)
+})
+
+test('account emails reserve the KV claim before sending and release it on send failure', async () => {
+	const { kv, store } = createKv()
+	const env = createEnv(kv)
+	const order: Array<string> = []
+	const originalPut = kv.put.bind(kv)
+	kv.put = async (...args: Parameters<KVNamespace['put']>) => {
+		order.push('put')
+		return originalPut(...args)
+	}
+	sendCloudflareEmail.mockImplementation(async () => {
+		order.push('send')
+		return { ok: true }
+	})
+
+	expect(
+		await sendConnectAgentEmail({
+			env,
+			email: 'ada@example.com',
+			userId: 'user-claim',
+		}),
+	).toBe(true)
+	expect(order).toEqual(['put', 'send'])
+
+	sendCloudflareEmail.mockImplementation(async () => {
+		throw new Error('smtp down')
+	})
+	consoleWarn.mockImplementation(() => {})
+	expect(
+		await sendBillingSuccessEmail({
+			env,
+			email: 'ada@example.com',
+			userId: 'user-claim',
+			planLabel: 'Pro',
+		}),
+	).toBe(false)
+	expect(consoleWarn).toHaveBeenCalledWith('user-account-email-send-failed', {
+		kind: 'billing_success',
+		error: expect.any(Error),
+	})
+	expect(
+		store.get(
+			userAccountEmailKvKey({
+				userId: 'user-claim',
+				kind: 'billing_success',
+				suffix: 'pro',
+			}),
+		),
+	).toBeUndefined()
 })

--- a/packages/worker/src/app/user-account-emails.ts
+++ b/packages/worker/src/app/user-account-emails.ts
@@ -1,0 +1,177 @@
+import { sendCloudflareEmail } from '#app/email/cloudflare-email.ts'
+import {
+	buildBillingSuccessEmail,
+	buildConnectAgentEmail,
+	buildPastDueEmail,
+	buildPaymentFailedEmail,
+} from '#app/email/messages.ts'
+import { resolveTransactionalEmailConfig } from '#app/email/sender-config.ts'
+import { kodyDiscordInviteUrl } from '#universal/community-links.ts'
+
+export const userAccountEmailKvKeyPrefix = 'account-email-user:v1'
+export const userAccountEmailClaimTtlSeconds = 30 * 24 * 60 * 60
+
+export type UserAccountEmailKind =
+	| 'connect_agent'
+	| 'billing_success'
+	| 'payment_failed'
+	| 'past_due'
+
+export function userAccountEmailKvKey(input: {
+	userId: string
+	kind: UserAccountEmailKind
+	suffix?: string
+}) {
+	const base = `${userAccountEmailKvKeyPrefix}:${input.userId}:${input.kind}`
+	return input.suffix ? `${base}:${input.suffix}` : base
+}
+
+type EmailConfig = { appBaseUrl: string; fromEmail: string }
+
+async function claimAndSend(input: {
+	env: Env
+	to: string
+	userId: string
+	kind: UserAccountEmailKind
+	suffix?: string
+	build: (config: EmailConfig) => {
+		subject: string
+		html: string
+		text: string
+	}
+}): Promise<boolean> {
+	const kv = input.env.BUNDLE_ARTIFACTS_KV
+	const emailConfig = resolveTransactionalEmailConfig({ env: input.env })
+	if (!kv || !emailConfig) return false
+
+	const key = userAccountEmailKvKey({
+		userId: input.userId,
+		kind: input.kind,
+		suffix: input.suffix,
+	})
+	if (await kv.get(key)) return false
+
+	const email = input.build(emailConfig)
+	let sendResult: Awaited<ReturnType<typeof sendCloudflareEmail>>
+	try {
+		sendResult = await sendCloudflareEmail(
+			{
+				accountId: input.env.CLOUDFLARE_ACCOUNT_ID,
+				apiBaseUrl: input.env.CLOUDFLARE_API_BASE_URL,
+				apiToken: input.env.CLOUDFLARE_API_TOKEN,
+			},
+			{
+				to: input.to,
+				from: emailConfig.fromEmail,
+				subject: email.subject,
+				html: email.html,
+				text: email.text,
+			},
+		)
+	} catch (error) {
+		console.warn('user-account-email-send-failed', {
+			kind: input.kind,
+			error,
+		})
+		return false
+	}
+	if (!sendResult.ok) {
+		console.warn('user-account-email-send-skipped', {
+			kind: input.kind,
+			reason: sendResult.error ?? 'unconfigured',
+		})
+		return false
+	}
+
+	try {
+		await kv.put(key, String(Date.now()), {
+			expirationTtl: userAccountEmailClaimTtlSeconds,
+		})
+	} catch (error) {
+		console.warn('user-account-email-claim-failed', {
+			kind: input.kind,
+			error,
+		})
+	}
+	return true
+}
+
+export async function sendConnectAgentEmail(input: {
+	env: Env
+	email: string
+	userId: string
+}): Promise<boolean> {
+	return await claimAndSend({
+		env: input.env,
+		to: input.email,
+		userId: input.userId,
+		kind: 'connect_agent',
+		build: (config) =>
+			buildConnectAgentEmail({
+				appBaseUrl: config.appBaseUrl,
+				onboardingUrl: new URL('/onboarding', config.appBaseUrl).toString(),
+			}),
+	})
+}
+
+export async function sendBillingSuccessEmail(input: {
+	env: Env
+	email: string
+	userId: string
+	planLabel: string
+}): Promise<boolean> {
+	return await claimAndSend({
+		env: input.env,
+		to: input.email,
+		userId: input.userId,
+		kind: 'billing_success',
+		suffix: input.planLabel.toLowerCase(),
+		build: (config) =>
+			buildBillingSuccessEmail({
+				appBaseUrl: config.appBaseUrl,
+				billingUrl: new URL('/account/billing', config.appBaseUrl).toString(),
+				discordUrl: kodyDiscordInviteUrl,
+				planLabel: input.planLabel,
+			}),
+	})
+}
+
+export async function sendPaymentFailedEmail(input: {
+	env: Env
+	email: string
+	userId: string
+	day: string
+}): Promise<boolean> {
+	return await claimAndSend({
+		env: input.env,
+		to: input.email,
+		userId: input.userId,
+		kind: 'payment_failed',
+		suffix: input.day,
+		build: (config) =>
+			buildPaymentFailedEmail({
+				appBaseUrl: config.appBaseUrl,
+				billingUrl: new URL('/account/billing', config.appBaseUrl).toString(),
+			}),
+	})
+}
+
+export async function sendPastDueEmail(input: {
+	env: Env
+	email: string
+	userId: string
+	day: string
+}): Promise<boolean> {
+	return await claimAndSend({
+		env: input.env,
+		to: input.email,
+		userId: input.userId,
+		kind: 'past_due',
+		suffix: input.day,
+		build: (config) =>
+			buildPastDueEmail({
+				appBaseUrl: config.appBaseUrl,
+				billingUrl: new URL('/account/billing', config.appBaseUrl).toString(),
+			}),
+	})
+}

--- a/packages/worker/src/app/user-account-emails.ts
+++ b/packages/worker/src/app/user-account-emails.ts
@@ -51,6 +51,18 @@ async function claimAndSend(input: {
 	})
 	if (await kv.get(key)) return false
 
+	try {
+		await kv.put(key, String(Date.now()), {
+			expirationTtl: userAccountEmailClaimTtlSeconds,
+		})
+	} catch (error) {
+		console.warn('user-account-email-claim-failed', {
+			kind: input.kind,
+			error,
+		})
+		return false
+	}
+
 	const email = input.build(emailConfig)
 	let sendResult: Awaited<ReturnType<typeof sendCloudflareEmail>>
 	try {
@@ -73,6 +85,7 @@ async function claimAndSend(input: {
 			kind: input.kind,
 			error,
 		})
+		await releaseEmailClaim(kv, key)
 		return false
 	}
 	if (!sendResult.ok) {
@@ -80,20 +93,18 @@ async function claimAndSend(input: {
 			kind: input.kind,
 			reason: sendResult.error ?? 'unconfigured',
 		})
+		await releaseEmailClaim(kv, key)
 		return false
 	}
-
-	try {
-		await kv.put(key, String(Date.now()), {
-			expirationTtl: userAccountEmailClaimTtlSeconds,
-		})
-	} catch (error) {
-		console.warn('user-account-email-claim-failed', {
-			kind: input.kind,
-			error,
-		})
-	}
 	return true
+}
+
+async function releaseEmailClaim(kv: KVNamespace, key: string) {
+	try {
+		await kv.delete(key)
+	} catch (error) {
+		console.warn('user-account-email-claim-release-failed', { key, error })
+	}
 }
 
 export async function sendConnectAgentEmail(input: {

--- a/packages/worker/src/app/user-error-rate-emails.node.test.ts
+++ b/packages/worker/src/app/user-error-rate-emails.node.test.ts
@@ -1,0 +1,122 @@
+import { expect, test, vi } from 'vitest'
+
+const sendCloudflareEmail = vi.fn(async () => ({ ok: true }))
+
+vi.mock('#app/email/cloudflare-email.ts', () => ({
+	sendCloudflareEmail: (...args: Array<unknown>) =>
+		sendCloudflareEmail(...args),
+}))
+
+const {
+	sendUserErrorRateEmails,
+	shouldSendUserErrorRateEmail,
+	userErrorRateEmailKvKey,
+	userErrorRateMinErrors,
+} = await import('#app/user-error-rate-emails.ts')
+
+test('shouldSendUserErrorRateEmail uses the 20% or absolute-error floor', () => {
+	expect(shouldSendUserErrorRateEmail({ errorCount: 4, eventCount: 10 })).toBe(
+		false,
+	)
+	expect(shouldSendUserErrorRateEmail({ errorCount: 5, eventCount: 30 })).toBe(
+		false,
+	)
+	expect(shouldSendUserErrorRateEmail({ errorCount: 5, eventCount: 25 })).toBe(
+		true,
+	)
+	expect(
+		shouldSendUserErrorRateEmail({ errorCount: 10, eventCount: 200 }),
+	).toBe(true)
+})
+
+function createKv() {
+	const store = new Map<string, string>()
+	return {
+		store,
+		kv: {
+			async get(key: string) {
+				return store.get(key) ?? null
+			},
+			async put(key: string, value: string) {
+				store.set(key, value)
+			},
+		} as unknown as KVNamespace,
+	}
+}
+
+function createEnv(input: {
+	users: Array<{
+		stable_user_id: string
+		email: string
+		event_count: number
+		error_count: number
+	}>
+	kv?: KVNamespace
+}) {
+	return {
+		APP_DB: {
+			prepare(query: string) {
+				const normalized = query.replace(/\s+/g, ' ').trim().toLowerCase()
+				return {
+					bind() {
+						return this
+					},
+					async all<T>() {
+						if (normalized.includes('from usage_rollups')) {
+							return { results: input.users as Array<T> }
+						}
+						return { results: [] }
+					},
+				}
+			},
+		} as unknown as D1Database,
+		APP_BASE_URL: 'https://kody.codes/',
+		CLOUDFLARE_ACCOUNT_ID: 'acct',
+		CLOUDFLARE_API_TOKEN: 'token',
+		BUNDLE_ARTIFACTS_KV: input.kv,
+	} as unknown as Env
+}
+
+test('error-rate emails skip below-threshold users and claim once per month', async () => {
+	const { kv, store } = createKv()
+	const now = new Date('2026-08-15T12:00:00.000Z')
+	const env = createEnv({
+		users: [
+			{
+				stable_user_id: 'user-low',
+				email: 'low@example.com',
+				event_count: 30,
+				error_count: userErrorRateMinErrors,
+			},
+			{
+				stable_user_id: 'user-hot',
+				email: 'hot@example.com',
+				event_count: 20,
+				error_count: 10,
+			},
+		],
+		kv,
+	})
+
+	const first = await sendUserErrorRateEmails({ env, now })
+	expect(first).toEqual({ status: 'notified', emailedUsers: 1 })
+	expect(sendCloudflareEmail).toHaveBeenCalledTimes(1)
+	const payload = sendCloudflareEmail.mock.calls[0]?.[1] as {
+		to: string
+		html: string
+		text: string
+	}
+	expect(payload.to).toBe('hot@example.com')
+	expect(payload.html).toContain('https://kody.codes/account/activity')
+	expect(payload.text).toContain('/@kentcdodds/kody-issue-triage')
+	expect(
+		store.get(
+			userErrorRateEmailKvKey({ userId: 'user-hot', month: '2026-08' }),
+		),
+	).toBeTruthy()
+
+	sendCloudflareEmail.mockClear()
+	const again = await sendUserErrorRateEmails({ env, now })
+	expect(again).toEqual({ status: 'no_warnings' })
+	expect(sendCloudflareEmail).not.toHaveBeenCalled()
+})

--- a/packages/worker/src/app/user-error-rate-emails.ts
+++ b/packages/worker/src/app/user-error-rate-emails.ts
@@ -1,0 +1,169 @@
+import { utcMonthKey } from '@kody-internal/shared/date-keys.ts'
+import { sendCloudflareEmail } from '#app/email/cloudflare-email.ts'
+import { buildUserErrorRateEmail } from '#app/email/messages.ts'
+import { resolveTransactionalEmailConfig } from '#app/email/sender-config.ts'
+import { kodyIssueTriageListingPath } from '#universal/community-links.ts'
+
+export const userErrorRateEmailKvKeyPrefix = 'error-rate-email-user:v1'
+export const userErrorRateEmailSweepLimit = 80
+export const userErrorRateEmailClaimTtlSeconds = 40 * 24 * 60 * 60
+export const userErrorRateMinErrors = 5
+export const userErrorRateMinPercent = 0.2
+export const userErrorRateAbsoluteErrors = 10
+
+export function userErrorRateEmailKvKey(input: {
+	userId: string
+	month: string
+}) {
+	return `${userErrorRateEmailKvKeyPrefix}:${input.userId}:${input.month}`
+}
+
+export function shouldSendUserErrorRateEmail(input: {
+	errorCount: number
+	eventCount: number
+}) {
+	if (input.errorCount >= userErrorRateAbsoluteErrors) return true
+	if (input.errorCount < userErrorRateMinErrors) return false
+	if (input.eventCount <= 0) return false
+	return input.errorCount / input.eventCount >= userErrorRateMinPercent
+}
+
+type ErrorRateCandidate = {
+	stable_user_id: string
+	email: string
+	event_count: number
+	error_count: number
+}
+
+export type UserErrorRateEmailResult =
+	| { status: 'skipped'; reason: 'no_kv' | 'no_email_config' }
+	| { status: 'no_warnings' }
+	| { status: 'notified'; emailedUsers: number }
+
+export async function sendUserErrorRateEmails(input: {
+	env: Env
+	now?: Date
+}): Promise<UserErrorRateEmailResult> {
+	const now = input.now ?? new Date()
+	if (!input.env.BUNDLE_ARTIFACTS_KV) {
+		return { status: 'skipped', reason: 'no_kv' }
+	}
+	const emailConfig = resolveTransactionalEmailConfig({ env: input.env })
+	if (!emailConfig) {
+		return { status: 'skipped', reason: 'no_email_config' }
+	}
+
+	const month = utcMonthKey(now)
+	const candidates = await input.env.APP_DB.prepare(
+		`SELECT u.stable_user_id, u.email,
+		        SUM(r.event_count) AS event_count,
+		        SUM(r.error_count) AS error_count
+		 FROM usage_rollups r
+		 INNER JOIN users u ON u.stable_user_id = r.user_id
+		 WHERE r.month = ?
+		   AND u.deleting_at IS NULL
+		   AND u.account_type = 'person'
+		   AND u.email_verified_at IS NOT NULL
+		 GROUP BY u.stable_user_id
+		 HAVING SUM(r.error_count) >= ?
+		 ORDER BY SUM(r.error_count) DESC
+		 LIMIT ?`,
+	)
+		.bind(month, userErrorRateMinErrors, userErrorRateEmailSweepLimit)
+		.all<ErrorRateCandidate>()
+
+	const rows = candidates.results ?? []
+	let emailedUsers = 0
+	for (const user of rows) {
+		if (
+			!shouldSendUserErrorRateEmail({
+				errorCount: Number(user.error_count),
+				eventCount: Number(user.event_count),
+			})
+		) {
+			continue
+		}
+		const sent = await sendOneUserErrorRateEmail({
+			env: input.env,
+			emailConfig,
+			user: {
+				...user,
+				event_count: Number(user.event_count),
+				error_count: Number(user.error_count),
+			},
+			month,
+		})
+		if (sent) emailedUsers += 1
+	}
+
+	if (emailedUsers === 0) return { status: 'no_warnings' }
+	console.info('user-error-rate-emailed', { emailedUsers, month })
+	return { status: 'notified', emailedUsers }
+}
+
+async function sendOneUserErrorRateEmail(input: {
+	env: Env
+	emailConfig: { appBaseUrl: string; fromEmail: string }
+	user: ErrorRateCandidate
+	month: string
+}): Promise<boolean> {
+	const kv = input.env.BUNDLE_ARTIFACTS_KV
+	if (!kv) return false
+	const key = userErrorRateEmailKvKey({
+		userId: input.user.stable_user_id,
+		month: input.month,
+	})
+	if (await kv.get(key)) return false
+
+	const activityUrl = new URL(
+		'/account/activity',
+		input.emailConfig.appBaseUrl,
+	).toString()
+	const triagePackageUrl = new URL(
+		kodyIssueTriageListingPath,
+		input.emailConfig.appBaseUrl,
+	).toString()
+	const email = buildUserErrorRateEmail({
+		appBaseUrl: input.emailConfig.appBaseUrl,
+		activityUrl,
+		triagePackageUrl,
+		errorCount: input.user.error_count,
+		eventCount: input.user.event_count,
+	})
+
+	let sendResult: Awaited<ReturnType<typeof sendCloudflareEmail>>
+	try {
+		sendResult = await sendCloudflareEmail(
+			{
+				accountId: input.env.CLOUDFLARE_ACCOUNT_ID,
+				apiBaseUrl: input.env.CLOUDFLARE_API_BASE_URL,
+				apiToken: input.env.CLOUDFLARE_API_TOKEN,
+			},
+			{
+				to: input.user.email,
+				from: input.emailConfig.fromEmail,
+				subject: email.subject,
+				html: email.html,
+				text: email.text,
+			},
+		)
+	} catch (error) {
+		console.warn('user-error-rate-email-send-failed', error)
+		return false
+	}
+	if (!sendResult.ok) {
+		console.warn('user-error-rate-email-send-skipped', {
+			reason: sendResult.error ?? 'unconfigured',
+		})
+		return false
+	}
+
+	try {
+		await kv.put(key, String(Date.now()), {
+			expirationTtl: userErrorRateEmailClaimTtlSeconds,
+		})
+	} catch (error) {
+		console.warn('user-error-rate-email-claim-failed', error)
+	}
+	return true
+}

--- a/packages/worker/src/billing/stripe-webhooks.ts
+++ b/packages/worker/src/billing/stripe-webhooks.ts
@@ -14,6 +14,8 @@ import {
 	record,
 	string,
 } from 'remix/data-schema'
+import { utcDayKey } from '@kody-internal/shared/date-keys.ts'
+import { sendPaymentFailedEmail } from '#app/user-account-emails.ts'
 import { isBillingConfigured } from './billing-config.ts'
 import {
 	BillingLinkError,
@@ -207,6 +209,22 @@ async function handleInvoicePaymentFailed(input: {
 		customerId,
 		subscriptionStatus: result.resolved?.subscriptionStatus ?? null,
 	})
+	const user = await input.env.APP_DB.prepare(
+		`SELECT email, stable_user_id FROM users WHERE id = ?`,
+	)
+		.bind(result.userId)
+		.first<{ email: string; stable_user_id: string }>()
+	if (!user?.email) return
+	try {
+		await sendPaymentFailedEmail({
+			env: input.env,
+			email: user.email,
+			userId: user.stable_user_id,
+			day: utcDayKey(input.now ?? new Date()),
+		})
+	} catch (error) {
+		console.warn('billing-payment-failed-email-failed', error)
+	}
 }
 
 export async function processStripeWebhookEvent(input: {

--- a/packages/worker/src/billing/stripe-webhooks.ts
+++ b/packages/worker/src/billing/stripe-webhooks.ts
@@ -14,6 +14,7 @@ import {
 	record,
 	string,
 } from 'remix/data-schema'
+import { waitUntil } from 'cloudflare:workers'
 import { utcDayKey } from '@kody-internal/shared/date-keys.ts'
 import { sendPaymentFailedEmail } from '#app/user-account-emails.ts'
 import { isBillingConfigured } from './billing-config.ts'
@@ -204,27 +205,34 @@ async function handleInvoicePaymentFailed(input: {
 		console.error('stripe_webhook_invoice_user_not_found', { customerId })
 		return
 	}
+	const subscriptionStatus = result.resolved?.subscriptionStatus ?? null
 	console.error('stripe_webhook_invoice_payment_failed', {
 		userId: result.userId,
 		customerId,
-		subscriptionStatus: result.resolved?.subscriptionStatus ?? null,
+		subscriptionStatus,
 	})
+	// refreshStripePlanForUser already sends past-due when Stripe has moved
+	// the subscription there. Skip the invoice-specific mail in that case so
+	// one failed charge is not two emails.
+	if (subscriptionStatus === 'past_due' || subscriptionStatus === 'unpaid') {
+		return
+	}
 	const user = await input.env.APP_DB.prepare(
 		`SELECT email, stable_user_id FROM users WHERE id = ?`,
 	)
 		.bind(result.userId)
 		.first<{ email: string; stable_user_id: string }>()
 	if (!user?.email) return
-	try {
-		await sendPaymentFailedEmail({
+	waitUntil(
+		sendPaymentFailedEmail({
 			env: input.env,
 			email: user.email,
 			userId: user.stable_user_id,
 			day: utcDayKey(input.now ?? new Date()),
-		})
-	} catch (error) {
-		console.warn('billing-payment-failed-email-failed', error)
-	}
+		}).catch((error) => {
+			console.warn('billing-payment-failed-email-failed', error)
+		}),
+	)
 }
 
 export async function processStripeWebhookEvent(input: {

--- a/packages/worker/src/billing/subscription-sync.ts
+++ b/packages/worker/src/billing/subscription-sync.ts
@@ -1,4 +1,10 @@
 import { waitUntil } from 'cloudflare:workers'
+import { utcDayKey } from '@kody-internal/shared/date-keys.ts'
+import { scheduleKitSubscriberSync } from '#worker/kit/subscriber-sync.ts'
+import {
+	sendBillingSuccessEmail,
+	sendPastDueEmail,
+} from '#app/user-account-emails.ts'
 import { maybeSyncDiscordGuildRolesForUser } from '#worker/discord/guild-role.ts'
 import { normalizeEmail } from '#worker/identity/normalize-email.ts'
 import { parseStripePlanName, type PlanName } from '#universal/plans.ts'
@@ -53,6 +59,16 @@ export async function refreshStripePlanForUser(input: {
 	now?: Date
 }): Promise<ResolvedSubscriptionPlan> {
 	const now = input.now ?? new Date()
+	const previous = await input.env.APP_DB.prepare(
+		`SELECT email, stable_user_id, stripe_plan
+		 FROM users WHERE id = ?`,
+	)
+		.bind(input.userId)
+		.first<{
+			email: string
+			stable_user_id: string
+			stripe_plan: string | null
+		}>()
 	const subscriptions = await listSubscriptions(input.env, input.customerId)
 	const resolved = resolveSubscriptionPlan(subscriptions, input.env)
 	await input.env.APP_DB.prepare(
@@ -74,6 +90,43 @@ export async function refreshStripePlanForUser(input: {
 			stripePlan: resolved.stripePlan,
 		}),
 	)
+	if (previous?.email) {
+		const previousPlan = parseStripePlanName(previous.stripe_plan)
+		const nextPlan = resolved.stripePlan
+		if (
+			(nextPlan === 'standard' || nextPlan === 'pro') &&
+			nextPlan !== previousPlan
+		) {
+			waitUntil(
+				sendBillingSuccessEmail({
+					env: input.env,
+					email: previous.email,
+					userId: previous.stable_user_id,
+					planLabel: nextPlan === 'pro' ? 'Pro' : 'Standard',
+				}).catch((error) => {
+					console.warn('billing-success-email-failed', error)
+				}),
+			)
+		}
+		const status = resolved.subscriptionStatus
+		if (status === 'past_due' || status === 'unpaid') {
+			waitUntil(
+				sendPastDueEmail({
+					env: input.env,
+					email: previous.email,
+					userId: previous.stable_user_id,
+					day: utcDayKey(now),
+				}).catch((error) => {
+					console.warn('billing-past-due-email-failed', error)
+				}),
+			)
+		}
+		scheduleKitSubscriberSync({
+			env: input.env,
+			email: previous.email,
+			stableUserId: previous.stable_user_id,
+		})
+	}
 	return resolved
 }
 

--- a/packages/worker/src/entitlements/errors.ts
+++ b/packages/worker/src/entitlements/errors.ts
@@ -1,5 +1,6 @@
 import {
 	entitlementResourceLabels,
+	formatMinJobInterval,
 	parsePlanName,
 	type EntitlementResource,
 	type PlanName,
@@ -90,6 +91,60 @@ export function isEntitlementLimitError(
 			error.details !== null &&
 			'code' in error.details &&
 			error.details.code === entitlementLimitErrorCode)
+	)
+}
+
+export const jobIntervalFloorErrorCode = 'job_interval_floor' as const
+
+export type JobIntervalFloorErrorDetails = {
+	code: typeof jobIntervalFloorErrorCode
+	plan: PlanName
+	minIntervalMs: number
+	upgradeHint: string
+}
+
+export function buildJobIntervalFloorUpgradeHint() {
+	return 'Space this job out, or upgrade at /account/billing.'
+}
+
+export function buildJobIntervalFloorMessage(
+	details: JobIntervalFloorErrorDetails,
+) {
+	const interval = formatMinJobInterval(details.minIntervalMs)
+	return `Your "${details.plan}" plan cannot run jobs more often than every ${interval}. ${details.upgradeHint}`
+}
+
+export class JobIntervalFloorError extends Error {
+	readonly details: JobIntervalFloorErrorDetails
+
+	constructor(
+		details: Omit<JobIntervalFloorErrorDetails, 'code' | 'upgradeHint'> & {
+			upgradeHint?: string
+		},
+	) {
+		const fullDetails: JobIntervalFloorErrorDetails = {
+			code: jobIntervalFloorErrorCode,
+			upgradeHint: details.upgradeHint ?? buildJobIntervalFloorUpgradeHint(),
+			plan: details.plan,
+			minIntervalMs: details.minIntervalMs,
+		}
+		super(buildJobIntervalFloorMessage(fullDetails))
+		this.name = 'JobIntervalFloorError'
+		this.details = fullDetails
+	}
+}
+
+export function isJobIntervalFloorError(
+	error: unknown,
+): error is JobIntervalFloorError {
+	return (
+		error instanceof JobIntervalFloorError ||
+		(error instanceof Error &&
+			'details' in error &&
+			typeof error.details === 'object' &&
+			error.details !== null &&
+			'code' in error.details &&
+			error.details.code === jobIntervalFloorErrorCode)
 	)
 }
 

--- a/packages/worker/src/jobs/schedule.node.test.ts
+++ b/packages/worker/src/jobs/schedule.node.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from 'vitest'
 import {
 	computeNextRunAt,
+	estimateScheduleMinIntervalMs,
 	isJobDue,
 	isJobExpired,
 	normalizeJobExpiresAt,
@@ -55,6 +56,33 @@ test('job schedule helpers normalize schedules and compute the next run time', (
 			from: '2026-04-17T15:00:00.000Z',
 		}),
 	).toBe('2026-04-17T15:15:00.000Z')
+})
+
+test('estimateScheduleMinIntervalMs measures interval and cron gaps and ignores once', () => {
+	expect(
+		estimateScheduleMinIntervalMs({
+			schedule: { type: 'once', runAt: '2026-04-17T15:00:00Z' },
+		}),
+	).toBeNull()
+	expect(
+		estimateScheduleMinIntervalMs({
+			schedule: { type: 'interval', every: '5m' },
+		}),
+	).toBe(5 * 60 * 1000)
+	expect(
+		estimateScheduleMinIntervalMs({
+			schedule: { type: 'cron', expression: '*/5 * * * *' },
+			timezone: 'UTC',
+			from: '2026-04-17T15:00:00.000Z',
+		}),
+	).toBe(5 * 60 * 1000)
+	expect(
+		estimateScheduleMinIntervalMs({
+			schedule: { type: 'cron', expression: '0 * * * *' },
+			timezone: 'UTC',
+			from: '2026-04-17T15:00:00.000Z',
+		}),
+	).toBe(60 * 60 * 1000)
 })
 
 test('expires_at helpers treat UTC expiry as a schedule gate separate from enabled', () => {

--- a/packages/worker/src/jobs/service.node.test.ts
+++ b/packages/worker/src/jobs/service.node.test.ts
@@ -1830,6 +1830,64 @@ test('free plan rejects new or changed schedules faster than 15 minutes and gran
 	expect(paidCreated.schedule).toEqual({ type: 'interval', every: '1m' })
 })
 
+test('package job sync preflights interval floors so a later invalid job writes nothing', async () => {
+	const email = 'interval-preflight@example.com'
+	const userId = await createStableUserIdFromEmail(email)
+	identityMockModule.resolveBackgroundMcpUser.mockImplementation(
+		async (_db: D1Database, id: string) => ({
+			userId: id,
+			email: id === userId ? email : `${id}@example.com`,
+			username: id,
+			displayName: id,
+		}),
+	)
+	const env = createJobServiceTestEnv({
+		APP_DB: createDatabase({
+			users: [{ email, plan: 'free', stable_user_id: userId }],
+		}),
+	})
+	await insertPublishedEntitySource({
+		db: env.APP_DB as ReturnType<typeof createDatabase>,
+		userId,
+		sourceId: 'mixed-interval-source',
+		entityKind: 'package',
+		entityId: 'mixed-interval-package',
+		publishedCommit: 'mixed-interval-commit',
+		manifestPath: 'package.json',
+	})
+	const before = await listJobRowsByUserId(env.APP_DB, userId)
+	await expect(
+		syncPackageJobsForPackage({
+			env,
+			userId,
+			baseUrl: 'https://example.com',
+			packageId: 'mixed-interval-package',
+			sourceId: 'mixed-interval-source',
+			manifest: parseAuthoredPackageJson({
+				content: JSON.stringify({
+					name: '@owner/mixed-interval-package',
+					exports: { '.': './index.ts' },
+					kody: {
+						id: 'mixed-interval-package',
+						description: 'Mixed interval jobs',
+						jobs: {
+							'ok-job': {
+								entry: './ok.ts',
+								schedule: { type: 'interval', every: '15m' },
+							},
+							'too-fast-job': {
+								entry: './fast.ts',
+								schedule: { type: 'interval', every: '5m' },
+							},
+						},
+					},
+				}),
+			}),
+		}),
+	).rejects.toSatisfy((error: unknown) => isJobIntervalFloorError(error))
+	expect(await listJobRowsByUserId(env.APP_DB, userId)).toEqual(before)
+})
+
 test('updateJob and deleteJob sync the job manager alarm', async () => {
 	const env = createJobServiceTestEnv({
 		APP_DB: createDatabase(),

--- a/packages/worker/src/jobs/service.node.test.ts
+++ b/packages/worker/src/jobs/service.node.test.ts
@@ -1807,6 +1807,16 @@ test('free plan rejects new or changed schedules faster than 15 minutes and gran
 			},
 		}),
 	).rejects.toSatisfy((error: unknown) => isJobIntervalFloorError(error))
+	await expect(
+		updateJob({
+			env,
+			callerContext,
+			body: {
+				id: grandfathered.id,
+				timezone: 'America/Denver',
+			},
+		}),
+	).rejects.toSatisfy((error: unknown) => isJobIntervalFloorError(error))
 
 	const paidCreated = await syncSinglePackageJob({
 		env,

--- a/packages/worker/src/jobs/service.node.test.ts
+++ b/packages/worker/src/jobs/service.node.test.ts
@@ -6,7 +6,10 @@ import {
 	createInMemoryUserMeterEnv,
 	createPermissiveAccountWriteLeaseDbHooks,
 } from '#worker/test-support/user-meter.ts'
-import { isEntitlementLimitError } from '#worker/entitlements/errors.ts'
+import {
+	isEntitlementLimitError,
+	isJobIntervalFloorError,
+} from '#worker/entitlements/errors.ts'
 import { planLimits } from '#universal/plans.ts'
 import { createStableUserIdFromEmail } from '#worker/user-id.ts'
 import { createCapabilitySecretAccessDeniedMessage } from '#mcp/secrets/errors.ts'
@@ -1499,7 +1502,7 @@ test('package job sync reports scheduler changes for add, update, and remove onl
 	const intervalJob = {
 		'event-runner': {
 			entry: './src/jobs/event-runner.ts',
-			schedule: { type: 'interval', every: '1m' },
+			schedule: { type: 'interval', every: '15m' },
 			timezone: 'America/Denver',
 			enabled: true,
 		},
@@ -1551,7 +1554,7 @@ test('package job sync reports scheduler changes for add, update, and remove onl
 			manifest: createManifest({
 				'event-runner': {
 					...intervalJob['event-runner'],
-					schedule: { type: 'interval', every: '5m' },
+					schedule: { type: 'interval', every: '30m' },
 				},
 			}),
 		}),
@@ -1559,7 +1562,7 @@ test('package job sync reports scheduler changes for add, update, and remove onl
 	const rowsAfterUpdate = await listJobRowsByUserId(env.APP_DB, input.userId)
 	expect(rowsAfterUpdate[0]?.record.schedule).toEqual({
 		type: 'interval',
-		every: '5m',
+		every: '30m',
 	})
 
 	expect(
@@ -1725,6 +1728,96 @@ test('package job sync preflights the full addition set without partial inserts'
 		current: existingJobCount,
 	})
 	expect(await listJobRowsByUserId(db, userId)).toHaveLength(existingJobCount)
+})
+
+test('free plan rejects new or changed schedules faster than 15 minutes and grandfathers existing jobs', async () => {
+	const email = 'interval-floor@example.com'
+	const userId = await createStableUserIdFromEmail(email)
+	const paidEmail = 'interval-floor-paid@example.com'
+	const paidUserId = await createStableUserIdFromEmail(paidEmail)
+	identityMockModule.resolveBackgroundMcpUser.mockImplementation(
+		async (_db: D1Database, id: string) => ({
+			userId: id,
+			email:
+				id === paidUserId
+					? paidEmail
+					: id === userId
+						? email
+						: `${id}@example.com`,
+			username: id,
+			displayName: id,
+		}),
+	)
+	const env = createJobServiceTestEnv({
+		APP_DB: createDatabase({
+			users: [
+				{ email, plan: 'free', stable_user_id: userId },
+				{ email: paidEmail, plan: 'standard', stable_user_id: paidUserId },
+			],
+		}),
+	})
+	const callerContext = createPlanUserCallerContext({ userId, email })
+
+	await expect(
+		syncSinglePackageJob({
+			env,
+			userId,
+			baseUrl: 'https://example.com',
+			packageId: 'too-fast-package',
+			sourceId: 'too-fast-package-source',
+			jobName: 'quota-job',
+			schedule: { type: 'interval', every: '5m' },
+		}),
+	).rejects.toSatisfy((error: unknown) => isJobIntervalFloorError(error))
+
+	const created = await syncSinglePackageJob({
+		env,
+		userId,
+		baseUrl: 'https://example.com',
+		packageId: 'ok-interval-package',
+		sourceId: 'ok-interval-package-source',
+		jobName: 'ok-job',
+		schedule: { type: 'interval', every: '15m' },
+	})
+	expect(created.schedule).toEqual({ type: 'interval', every: '15m' })
+
+	const grandfathered = await insertLeftoverJob({
+		env,
+		callerContext,
+		body: {
+			name: 'Legacy five-minute poller',
+			schedule: { type: 'interval', every: '5m' },
+			sourceId: 'legacy-5m-source',
+		},
+	})
+	await expect(
+		updateJob({
+			env,
+			callerContext,
+			body: { id: grandfathered.id, enabled: false },
+		}),
+	).resolves.toMatchObject({ enabled: false })
+	await expect(
+		updateJob({
+			env,
+			callerContext,
+			body: {
+				id: grandfathered.id,
+				schedule: { type: 'interval', every: '1m' },
+			},
+		}),
+	).rejects.toSatisfy((error: unknown) => isJobIntervalFloorError(error))
+
+	const paidCreated = await syncSinglePackageJob({
+		env,
+		userId: paidUserId,
+		baseUrl: 'https://example.com',
+		packageId: 'paid-fast-package',
+		sourceId: 'paid-fast-package-source',
+		jobName: 'fast-job',
+		schedule: { type: 'interval', every: '1m' },
+	})
+	expect(paidCreated.schedule).toEqual({ type: 'interval', every: '1m' })
 })
 
 test('updateJob and deleteJob sync the job manager alarm', async () => {

--- a/packages/worker/src/jobs/service.ts
+++ b/packages/worker/src/jobs/service.ts
@@ -766,7 +766,8 @@ export async function syncPackageJobsForPackage(input: {
 					}
 					if (
 						JSON.stringify(existing.record.schedule) !==
-						JSON.stringify(schedule)
+							JSON.stringify(schedule) ||
+						existing.record.timezone !== timezone
 					) {
 						assertJobScheduleIntervalFloor({
 							plan,
@@ -1001,7 +1002,8 @@ export async function updateJob(input: {
 				: (input.body.enabled ?? existing.enabled)
 			const scheduleChanged =
 				JSON.stringify(nextSchedule) !== JSON.stringify(existing.schedule)
-			if (scheduleChanged) {
+			const timezoneChanged = nextTimezone !== existing.timezone
+			if (scheduleChanged || timezoneChanged) {
 				assertJobScheduleIntervalFloor({
 					plan: await getCachedUserPlan(input.env.APP_DB, {
 						userId: callerContext.user.userId,

--- a/packages/worker/src/jobs/service.ts
+++ b/packages/worker/src/jobs/service.ts
@@ -29,6 +29,7 @@ import {
 } from './execution-safety.ts'
 import {
 	computeNextRunAt,
+	estimateScheduleMinIntervalMs,
 	formatJobError,
 	isJobExpired,
 	normalizeJobExpiresAt,
@@ -41,15 +42,21 @@ import {
 	type JobExecutionResult,
 	type JobRepoCheckPolicy,
 	type JobRecord,
+	type JobSchedule,
 	type JobUpdateInput,
 	type PersistedJobCallerContext,
 } from './types.ts'
 import { createJobStorageId, storageRunnerRpc } from '#worker/storage-runner.ts'
-import { isEntitlementLimitError } from '#worker/entitlements/errors.ts'
+import {
+	isEntitlementLimitError,
+	JobIntervalFloorError,
+} from '#worker/entitlements/errors.ts'
 import {
 	assertWithinEntitlement,
 	consumeDailyEntitlement,
+	getCachedUserPlan,
 } from '#worker/entitlements/service.ts'
+import { planLimits, type PlanName } from '#universal/plans.ts'
 import { resolveBackgroundMcpUser } from '#worker/identity/background-mcp-user.ts'
 import { assertPublishedSourceCanRebuildWithoutInstallingDeps } from '#worker/package-runtime/published-source-dependencies.ts'
 import {
@@ -718,6 +725,10 @@ export async function syncPackageJobsForPackage(input: {
 						),
 				})
 			}
+			const plan = await getCachedUserPlan(input.env.APP_DB, {
+				userId: input.userId,
+				email: callerContext.user.email,
+			})
 			const now = new Date().toISOString()
 			let schedulerStateChanged = false
 
@@ -753,6 +764,16 @@ export async function syncPackageJobsForPackage(input: {
 						}
 						continue
 					}
+					if (
+						JSON.stringify(existing.record.schedule) !==
+						JSON.stringify(schedule)
+					) {
+						assertJobScheduleIntervalFloor({
+							plan,
+							schedule,
+							timezone,
+						})
+					}
 					const updated: JobRecord = {
 						...existing.record,
 						name: jobName,
@@ -776,6 +797,11 @@ export async function syncPackageJobsForPackage(input: {
 					continue
 				}
 
+				assertJobScheduleIntervalFloor({
+					plan,
+					schedule,
+					timezone,
+				})
 				const created: JobRecord = {
 					version: 1,
 					id: buildPackageJobId(input.packageId, jobName),
@@ -821,6 +847,24 @@ export async function syncPackageJobsForPackage(input: {
 			}
 			return schedulerStateChanged
 		},
+	})
+}
+
+function assertJobScheduleIntervalFloor(input: {
+	plan: PlanName
+	schedule: JobSchedule
+	timezone?: string | null
+}) {
+	const minIntervalMs = planLimits[input.plan].minJobIntervalMs
+	if (minIntervalMs <= 0) return
+	const intervalMs = estimateScheduleMinIntervalMs({
+		schedule: input.schedule,
+		timezone: input.timezone,
+	})
+	if (intervalMs == null || intervalMs >= minIntervalMs) return
+	throw new JobIntervalFloorError({
+		plan: input.plan,
+		minIntervalMs,
 	})
 }
 
@@ -955,8 +999,20 @@ export async function updateJob(input: {
 			const nextEnabled = expired
 				? false
 				: (input.body.enabled ?? existing.enabled)
+			const scheduleChanged =
+				JSON.stringify(nextSchedule) !== JSON.stringify(existing.schedule)
+			if (scheduleChanged) {
+				assertJobScheduleIntervalFloor({
+					plan: await getCachedUserPlan(input.env.APP_DB, {
+						userId: callerContext.user.userId,
+						email: callerContext.user.email,
+					}),
+					schedule: nextSchedule,
+					timezone: nextTimezone,
+				})
+			}
 			const shouldRecomputeNextRunAt =
-				JSON.stringify(nextSchedule) !== JSON.stringify(existing.schedule) ||
+				scheduleChanged ||
 				nextTimezone !== existing.timezone ||
 				(existing.enabled === false && nextEnabled === true)
 			const shape = resolveUpdatedShape({

--- a/packages/worker/src/jobs/service.ts
+++ b/packages/worker/src/jobs/service.ts
@@ -729,6 +729,25 @@ export async function syncPackageJobsForPackage(input: {
 				userId: input.userId,
 				email: callerContext.user.email,
 			})
+			for (const [jobName, definition] of Object.entries(desiredJobs)) {
+				const existing = existingByName.get(jobName)
+				const schedule = normalizeJobSchedule(definition.schedule)
+				const timezone = normalizeJobTimezone(definition.timezone)
+				if (
+					packageJobNeedsIntervalFloor({
+						existingSchedule: existing?.record.schedule,
+						existingTimezone: existing?.record.timezone,
+						schedule,
+						timezone,
+					})
+				) {
+					assertJobScheduleIntervalFloor({
+						plan,
+						schedule,
+						timezone,
+					})
+				}
+			}
 			const now = new Date().toISOString()
 			let schedulerStateChanged = false
 
@@ -849,6 +868,19 @@ export async function syncPackageJobsForPackage(input: {
 			return schedulerStateChanged
 		},
 	})
+}
+
+function packageJobNeedsIntervalFloor(input: {
+	existingSchedule?: JobSchedule
+	existingTimezone?: string | null
+	schedule: JobSchedule
+	timezone?: string | null
+}) {
+	if (input.existingSchedule === undefined) return true
+	return (
+		JSON.stringify(input.existingSchedule) !== JSON.stringify(input.schedule) ||
+		input.existingTimezone !== input.timezone
+	)
 }
 
 function assertJobScheduleIntervalFloor(input: {

--- a/packages/worker/src/kit/subscriber-sync.node.test.ts
+++ b/packages/worker/src/kit/subscriber-sync.node.test.ts
@@ -1,0 +1,177 @@
+import { expect, test, vi } from 'vitest'
+import { consoleWarn } from '#worker/test-support/console-spies.ts'
+import {
+	desiredKitTagKeys,
+	kitFactsFromUserRow,
+	kitLifecycleTagNames,
+	maybeSyncKitSubscriber,
+	syncExistingKitSubscriber,
+} from '#worker/kit/subscriber-sync.ts'
+
+const tagCatalog = [
+	{ id: 11, name: kitLifecycleTagNames.signedUp },
+	{ id: 12, name: kitLifecycleTagNames.verified },
+	{ id: 13, name: kitLifecycleTagNames.agentConnected },
+	{ id: 14, name: kitLifecycleTagNames.activated },
+	{ id: 15, name: kitLifecycleTagNames.standard },
+	{ id: 16, name: kitLifecycleTagNames.pro },
+]
+
+function kitFetchImpl(input: {
+	subscriberId?: number | null
+	calls?: Array<{ url: string; method: string; body: unknown }>
+}) {
+	const calls = input.calls ?? []
+	const fetchImpl = async (request: RequestInfo | URL, init?: RequestInit) => {
+		const url = String(request)
+		const method = init?.method ?? 'GET'
+		const body = init?.body ? JSON.parse(String(init.body)) : null
+		calls.push({ url, method, body })
+		if (url.includes('/subscribers?email_address=')) {
+			if (input.subscriberId == null) {
+				return Response.json({ subscribers: [] })
+			}
+			return Response.json({
+				subscribers: [
+					{ id: input.subscriberId, email_address: 'ada@example.com' },
+				],
+			})
+		}
+		if (url.endsWith('/tags') || url.includes('/tags?')) {
+			return Response.json({ tags: tagCatalog })
+		}
+		if (
+			url.includes('/tags/') &&
+			url.includes('/subscribers') &&
+			method === 'POST'
+		) {
+			return Response.json(
+				{ subscriber: { id: input.subscriberId } },
+				{ status: 201 },
+			)
+		}
+		if (
+			url.includes('/subscribers/') &&
+			url.includes('/tags/') &&
+			method === 'DELETE'
+		) {
+			return new Response(null, { status: 204 })
+		}
+		throw new Error(`Unexpected Kit call: ${method} ${url}`)
+	}
+	return { calls, fetchImpl: fetchImpl as typeof fetch }
+}
+
+test('kitFactsFromUserRow maps activation and paid-plan columns', () => {
+	expect(
+		kitFactsFromUserRow({
+			email_verified_at: null,
+			first_mcp_connected_at: null,
+			first_saved_package_at: null,
+			stripe_plan: null,
+		}),
+	).toEqual({
+		signedUp: true,
+		verified: false,
+		agentConnected: false,
+		activated: false,
+		paidPlan: null,
+	})
+	expect(
+		desiredKitTagKeys(
+			kitFactsFromUserRow({
+				email_verified_at: '2026-08-01T00:00:00.000Z',
+				first_mcp_connected_at: '2026-08-02T00:00:00.000Z',
+				first_saved_package_at: '2026-08-03T00:00:00.000Z',
+				stripe_plan: 'pro',
+			}),
+		),
+	).toEqual(['signedUp', 'verified', 'agentConnected', 'activated', 'pro'])
+})
+
+test('syncExistingKitSubscriber skips missing subscribers and never creates them', async () => {
+	const { calls, fetchImpl } = kitFetchImpl({ subscriberId: null })
+	expect(
+		await syncExistingKitSubscriber({
+			apiKey: 'key',
+			email: 'new@example.com',
+			facts: kitFactsFromUserRow({}),
+			fetchImpl,
+		}),
+	).toEqual({ synced: false, reason: 'not_found' })
+	expect(calls).toHaveLength(1)
+	expect(calls[0]?.url).toContain('/subscribers?email_address=')
+	expect(calls.some((call) => call.method === 'POST')).toBe(false)
+})
+
+test('syncExistingKitSubscriber adds lifecycle tags and removes paid tags on cancel', async () => {
+	const { calls, fetchImpl } = kitFetchImpl({ subscriberId: 9 })
+	expect(
+		await syncExistingKitSubscriber({
+			apiKey: 'key',
+			email: 'ada@example.com',
+			facts: {
+				signedUp: true,
+				verified: true,
+				agentConnected: false,
+				activated: false,
+				paidPlan: null,
+			},
+			fetchImpl,
+		}),
+	).toEqual({ synced: true, subscriberId: 9 })
+	const added = calls.filter(
+		(call) => call.method === 'POST' && call.url.includes('/tags/'),
+	)
+	expect(added.map((call) => call.url)).toEqual([
+		'https://api.kit.com/v4/tags/11/subscribers',
+		'https://api.kit.com/v4/tags/12/subscribers',
+	])
+	const removed = calls.filter((call) => call.method === 'DELETE')
+	expect(removed.map((call) => call.url)).toEqual([
+		'https://api.kit.com/v4/subscribers/9/tags/15',
+		'https://api.kit.com/v4/subscribers/9/tags/16',
+	])
+	expect(
+		calls.some((call) => call.url === 'https://api.kit.com/v4/subscribers'),
+	).toBe(false)
+})
+
+test('maybeSyncKitSubscriber no-ops without Kit config and swallows failures', async () => {
+	consoleWarn.mockImplementation(() => {})
+	const idleFetch = vi.fn()
+	await maybeSyncKitSubscriber({
+		env: {},
+		email: 'ada@example.com',
+		facts: kitFactsFromUserRow({}),
+		fetchImpl: idleFetch,
+	})
+	expect(idleFetch).not.toHaveBeenCalled()
+
+	await maybeSyncKitSubscriber({
+		env: { KIT_API_KEY: 'key', KIT_SIGNED_UP_TAG_ID: 'nope' },
+		email: 'ada@example.com',
+		facts: kitFactsFromUserRow({}),
+		fetchImpl: idleFetch,
+	})
+	expect(idleFetch).not.toHaveBeenCalled()
+	expect(consoleWarn).toHaveBeenCalledWith(
+		'Skipping Kit subscriber sync: KIT_SIGNED_UP_TAG_ID is invalid.',
+	)
+
+	consoleWarn.mockClear()
+	const failingFetch = vi.fn(async () =>
+		Response.json({ errors: ['boom'] }, { status: 500 }),
+	)
+	await maybeSyncKitSubscriber({
+		env: { KIT_API_KEY: 'key' },
+		email: 'ada@example.com',
+		facts: kitFactsFromUserRow({}),
+		fetchImpl: failingFetch as typeof fetch,
+	})
+	expect(failingFetch).toHaveBeenCalled()
+	expect(consoleWarn).toHaveBeenCalledWith(
+		'Failed to sync Kit subscriber:',
+		expect.any(Error),
+	)
+})

--- a/packages/worker/src/kit/subscriber-sync.ts
+++ b/packages/worker/src/kit/subscriber-sync.ts
@@ -1,0 +1,533 @@
+/**
+ * Exist-only Kit subscriber sync. Never creates Kit subscribers from account
+ * events — waitlist joins stay on {@link subscribeToKitWaitlist}. Account
+ * lifecycle only adds/removes tags when the email already exists in Kit.
+ */
+
+import { waitUntil } from 'cloudflare:workers'
+import { parseStripePlanName } from '#universal/plans.ts'
+
+const KIT_API_BASE_URL = 'https://api.kit.com/v4'
+const DEFAULT_KIT_SIGNED_UP_TAG_ID = 21252175
+
+class KitSyncError extends Error {
+	readonly status: number | null
+	readonly kind: 'client' | 'server' | 'network'
+
+	constructor(
+		message: string,
+		options: { status?: number | null; kind: KitSyncError['kind'] },
+	) {
+		super(message)
+		this.name = 'KitSyncError'
+		this.status = options.status ?? null
+		this.kind = options.kind
+	}
+}
+
+function resolvePositiveIntId(
+	raw: string | undefined,
+	fallback: number,
+): number | null {
+	if (raw === undefined) return fallback
+	const trimmed = raw.trim()
+	if (!trimmed) return fallback
+	if (!/^\d+$/.test(trimmed)) return null
+	const parsed = Number.parseInt(trimmed, 10)
+	if (!Number.isSafeInteger(parsed) || parsed <= 0) return null
+	return parsed
+}
+
+function resolveKitSignedUpTagId(raw: string | undefined): number | null {
+	return resolvePositiveIntId(raw, DEFAULT_KIT_SIGNED_UP_TAG_ID)
+}
+
+export const KIT_SYNC_REQUEST_TIMEOUT_MS = 8_000
+
+export const kitLifecycleTagNames = {
+	signedUp: 'signed_up::kody',
+	verified: 'verified::kody',
+	agentConnected: 'agent_connected::kody',
+	activated: 'activated::kody',
+	standard: 'standard::kody',
+	pro: 'pro::kody',
+} as const
+
+export type KitLifecycleTagKey = keyof typeof kitLifecycleTagNames
+
+export type KitSubscriberFacts = {
+	signedUp: boolean
+	verified: boolean
+	agentConnected: boolean
+	activated: boolean
+	paidPlan: 'standard' | 'pro' | null
+}
+
+type KitTag = {
+	id?: number
+	name?: string
+}
+
+type KitJson = {
+	subscriber?: { id?: number }
+	subscribers?: Array<{ id?: number }>
+	tags?: Array<KitTag>
+	errors?: Array<string>
+}
+
+const kitSyncConcurrency = 4
+export const kitSubscriberSyncSweepLimit = 80
+
+function kitHeaders(apiKey: string): HeadersInit {
+	return {
+		Accept: 'application/json',
+		'Content-Type': 'application/json',
+		'X-Kit-Api-Key': apiKey,
+	}
+}
+
+function isAbortError(error: unknown) {
+	return (
+		(error instanceof DOMException && error.name === 'TimeoutError') ||
+		(error instanceof Error && error.name === 'AbortError')
+	)
+}
+
+async function kitFetch(
+	fetchImpl: typeof fetch,
+	url: string,
+	init: RequestInit,
+	timeoutMs: number,
+): Promise<Response> {
+	try {
+		return await fetchImpl(url, {
+			...init,
+			signal: AbortSignal.timeout(timeoutMs),
+		})
+	} catch (error) {
+		if (isAbortError(error)) {
+			throw new KitSyncError('Kit request timed out.', {
+				status: null,
+				kind: 'network',
+			})
+		}
+		throw new KitSyncError('Kit request failed.', {
+			status: null,
+			kind: 'network',
+		})
+	}
+}
+
+async function readKitJson(response: Response): Promise<KitJson | null> {
+	try {
+		return (await response.json()) as KitJson
+	} catch {
+		return null
+	}
+}
+
+function kitErrorMessage(payload: KitJson | null, fallback: string) {
+	const first = payload?.errors?.[0]
+	return typeof first === 'string' && first.trim() ? first : fallback
+}
+
+function classifyHttpKind(status: number): 'client' | 'server' {
+	return status >= 500 ? 'server' : 'client'
+}
+
+function throwIfKitFailed(
+	response: Response,
+	payload: KitJson | null,
+	fallback: string,
+) {
+	if (response.ok) return
+	throw new KitSyncError(
+		kitErrorMessage(payload, `${fallback} (${response.status}).`),
+		{
+			status: response.status,
+			kind: classifyHttpKind(response.status),
+		},
+	)
+}
+
+export function kitFactsFromUserRow(row: {
+	email_verified_at?: string | null
+	first_mcp_connected_at?: string | null
+	first_saved_package_at?: string | null
+	stripe_plan?: string | null
+}): KitSubscriberFacts {
+	const stripePlan = parseStripePlanName(row.stripe_plan)
+	const paidPlan =
+		stripePlan === 'standard' || stripePlan === 'pro' ? stripePlan : null
+	return {
+		signedUp: true,
+		verified: Boolean(row.email_verified_at),
+		agentConnected: Boolean(row.first_mcp_connected_at),
+		activated: Boolean(row.first_saved_package_at),
+		paidPlan,
+	}
+}
+
+export function desiredKitTagKeys(
+	facts: KitSubscriberFacts,
+): Array<KitLifecycleTagKey> {
+	const keys: Array<KitLifecycleTagKey> = []
+	if (facts.signedUp) keys.push('signedUp')
+	if (facts.verified) keys.push('verified')
+	if (facts.agentConnected) keys.push('agentConnected')
+	if (facts.activated) keys.push('activated')
+	if (facts.paidPlan === 'standard') keys.push('standard')
+	if (facts.paidPlan === 'pro') keys.push('pro')
+	return keys
+}
+
+async function lookupKitSubscriberId(input: {
+	apiKey: string
+	email: string
+	fetchImpl: typeof fetch
+	timeoutMs: number
+}): Promise<number | null> {
+	const response = await kitFetch(
+		input.fetchImpl,
+		`${KIT_API_BASE_URL}/subscribers?email_address=${encodeURIComponent(input.email)}`,
+		{ method: 'GET', headers: kitHeaders(input.apiKey) },
+		input.timeoutMs,
+	)
+	const payload = await readKitJson(response)
+	throwIfKitFailed(response, payload, 'Kit subscriber lookup failed')
+	const existing = payload?.subscribers?.find(
+		(subscriber) => typeof subscriber.id === 'number',
+	)
+	return typeof existing?.id === 'number' ? existing.id : null
+}
+
+async function listKitTagsByName(input: {
+	apiKey: string
+	fetchImpl: typeof fetch
+	timeoutMs: number
+}): Promise<Map<string, number>> {
+	const byName = new Map<string, number>()
+	let after: string | null = null
+	for (let page = 0; page < 10; page += 1) {
+		const url = new URL(`${KIT_API_BASE_URL}/tags`)
+		url.searchParams.set('per_page', '50')
+		if (after) url.searchParams.set('after', after)
+		const response = await kitFetch(
+			input.fetchImpl,
+			url.toString(),
+			{ method: 'GET', headers: kitHeaders(input.apiKey) },
+			input.timeoutMs,
+		)
+		const payload = await readKitJson(response)
+		throwIfKitFailed(response, payload, 'Kit tag list failed')
+		const tags = payload?.tags ?? []
+		for (const tag of tags) {
+			if (typeof tag.id === 'number' && typeof tag.name === 'string') {
+				byName.set(tag.name, tag.id)
+			}
+		}
+		if (tags.length < 50) break
+		const lastId = tags.at(-1)?.id
+		after = typeof lastId === 'number' ? String(lastId) : null
+		if (!after) break
+	}
+	return byName
+}
+
+async function addKitTag(input: {
+	apiKey: string
+	email: string
+	tagId: number
+	fetchImpl: typeof fetch
+	timeoutMs: number
+}) {
+	const response = await kitFetch(
+		input.fetchImpl,
+		`${KIT_API_BASE_URL}/tags/${input.tagId}/subscribers`,
+		{
+			method: 'POST',
+			headers: kitHeaders(input.apiKey),
+			body: JSON.stringify({ email_address: input.email }),
+		},
+		input.timeoutMs,
+	)
+	const payload = await readKitJson(response)
+	throwIfKitFailed(response, payload, 'Kit tag add failed')
+}
+
+async function removeKitTag(input: {
+	apiKey: string
+	subscriberId: number
+	tagId: number
+	fetchImpl: typeof fetch
+	timeoutMs: number
+}) {
+	const response = await kitFetch(
+		input.fetchImpl,
+		`${KIT_API_BASE_URL}/subscribers/${input.subscriberId}/tags/${input.tagId}`,
+		{ method: 'DELETE', headers: kitHeaders(input.apiKey) },
+		input.timeoutMs,
+	)
+	if (response.status === 404) return
+	const payload = await readKitJson(response)
+	throwIfKitFailed(response, payload, 'Kit tag remove failed')
+}
+
+export async function syncExistingKitSubscriber(input: {
+	apiKey: string
+	email: string
+	facts: KitSubscriberFacts
+	signedUpTagId?: number
+	fetchImpl?: typeof fetch
+	timeoutMs?: number
+	tagNames?: Map<string, number>
+}): Promise<
+	| { synced: true; subscriberId: number }
+	| { synced: false; reason: 'not_found' }
+> {
+	const fetchImpl = input.fetchImpl ?? fetch
+	const timeoutMs = input.timeoutMs ?? KIT_SYNC_REQUEST_TIMEOUT_MS
+	const subscriberId = await lookupKitSubscriberId({
+		apiKey: input.apiKey,
+		email: input.email,
+		fetchImpl,
+		timeoutMs,
+	})
+	if (subscriberId == null) {
+		return { synced: false, reason: 'not_found' }
+	}
+
+	const tagNames =
+		input.tagNames ??
+		(await listKitTagsByName({
+			apiKey: input.apiKey,
+			fetchImpl,
+			timeoutMs,
+		}))
+	const desired = new Set(desiredKitTagKeys(input.facts))
+	const paidKeys: Array<KitLifecycleTagKey> = ['standard', 'pro']
+
+	for (const key of Object.keys(
+		kitLifecycleTagNames,
+	) as Array<KitLifecycleTagKey>) {
+		const name = kitLifecycleTagNames[key]
+		const tagId =
+			key === 'signedUp'
+				? (input.signedUpTagId ??
+					tagNames.get(name) ??
+					DEFAULT_KIT_SIGNED_UP_TAG_ID)
+				: tagNames.get(name)
+		if (tagId == null) {
+			if (desired.has(key) || paidKeys.includes(key)) {
+				console.warn(`Skipping Kit tag ${name}: tag is missing in Kit.`)
+			}
+			continue
+		}
+		if (desired.has(key)) {
+			await addKitTag({
+				apiKey: input.apiKey,
+				email: input.email,
+				tagId,
+				fetchImpl,
+				timeoutMs,
+			})
+			continue
+		}
+		if (paidKeys.includes(key)) {
+			await removeKitTag({
+				apiKey: input.apiKey,
+				subscriberId,
+				tagId,
+				fetchImpl,
+				timeoutMs,
+			})
+		}
+	}
+
+	return { synced: true, subscriberId }
+}
+
+export function resolveKitApiKey(env: Pick<Env, 'KIT_API_KEY'>): string | null {
+	const apiKey = env.KIT_API_KEY?.trim()
+	return apiKey || null
+}
+
+export async function maybeSyncKitSubscriber(input: {
+	env: Pick<Env, 'KIT_API_KEY' | 'KIT_SIGNED_UP_TAG_ID'>
+	email: string
+	facts: KitSubscriberFacts
+	fetchImpl?: typeof fetch
+	tagNames?: Map<string, number>
+}): Promise<void> {
+	const apiKey = resolveKitApiKey(input.env)
+	if (!apiKey) return
+	const tagId = resolveKitSignedUpTagId(input.env.KIT_SIGNED_UP_TAG_ID)
+	if (tagId === null) {
+		console.warn(
+			'Skipping Kit subscriber sync: KIT_SIGNED_UP_TAG_ID is invalid.',
+		)
+		return
+	}
+	try {
+		await syncExistingKitSubscriber({
+			apiKey,
+			email: input.email,
+			facts: input.facts,
+			signedUpTagId: tagId,
+			fetchImpl: input.fetchImpl,
+			tagNames: input.tagNames,
+		})
+	} catch (error) {
+		console.warn('Failed to sync Kit subscriber:', error)
+	}
+}
+
+type KitUserRow = {
+	email: string
+	email_verified_at: string | null
+	first_mcp_connected_at: string | null
+	first_saved_package_at: string | null
+	stripe_plan: string | null
+}
+
+export async function maybeSyncKitSubscriberForUser(input: {
+	env: Pick<Env, 'APP_DB' | 'KIT_API_KEY' | 'KIT_SIGNED_UP_TAG_ID'>
+	email?: string | null
+	stableUserId?: string | null
+	fetchImpl?: typeof fetch
+	tagNames?: Map<string, number>
+}): Promise<void> {
+	const email = input.email?.trim()
+	const stableUserId = input.stableUserId?.trim()
+	if (!email && !stableUserId) return
+	const row = email
+		? await input.env.APP_DB.prepare(
+				`SELECT email, email_verified_at, first_mcp_connected_at,
+				        first_saved_package_at, stripe_plan
+				 FROM users
+				 WHERE email = ? AND deleting_at IS NULL
+				 LIMIT 1`,
+			)
+				.bind(email)
+				.first<KitUserRow>()
+		: await input.env.APP_DB.prepare(
+				`SELECT email, email_verified_at, first_mcp_connected_at,
+				        first_saved_package_at, stripe_plan
+				 FROM users
+				 WHERE stable_user_id = ? AND deleting_at IS NULL
+				 LIMIT 1`,
+			)
+				.bind(stableUserId)
+				.first<KitUserRow>()
+	if (!row?.email) return
+	await maybeSyncKitSubscriber({
+		env: input.env,
+		email: row.email,
+		facts: kitFactsFromUserRow(row),
+		fetchImpl: input.fetchImpl,
+		tagNames: input.tagNames,
+	})
+}
+
+export function scheduleKitSubscriberSync(input: {
+	env: Pick<Env, 'APP_DB' | 'KIT_API_KEY' | 'KIT_SIGNED_UP_TAG_ID'>
+	email?: string | null
+	stableUserId?: string | null
+}) {
+	if (!resolveKitApiKey(input.env)) return
+	waitUntil(
+		maybeSyncKitSubscriberForUser(input).catch((error) => {
+			console.warn('Failed to sync Kit subscriber:', error)
+		}),
+	)
+}
+
+async function mapWithConcurrency<T>(
+	items: ReadonlyArray<T>,
+	concurrency: number,
+	mapper: (item: T) => Promise<void>,
+): Promise<void> {
+	if (items.length === 0) return
+	const limit = Math.max(1, Math.min(concurrency, items.length))
+	let nextIndex = 0
+	await Promise.all(
+		Array.from({ length: limit }, async () => {
+			while (nextIndex < items.length) {
+				const index = nextIndex
+				nextIndex += 1
+				const item = items[index]
+				if (item === undefined) return
+				await mapper(item)
+			}
+		}),
+	)
+}
+
+export type KitSubscriberReconcileResult =
+	| { status: 'skipped'; reason: 'no_api_key' }
+	| { status: 'synced'; considered: number; tagged: number }
+
+export async function reconcileKitSubscribers(input: {
+	env: Env
+	now?: Date
+	fetchImpl?: typeof fetch
+}): Promise<KitSubscriberReconcileResult> {
+	const apiKey = resolveKitApiKey(input.env)
+	if (!apiKey) return { status: 'skipped', reason: 'no_api_key' }
+	const tagId = resolveKitSignedUpTagId(input.env.KIT_SIGNED_UP_TAG_ID)
+	if (tagId === null) {
+		console.warn(
+			'Skipping Kit subscriber reconcile: KIT_SIGNED_UP_TAG_ID is invalid.',
+		)
+		return { status: 'skipped', reason: 'no_api_key' }
+	}
+
+	const users = await input.env.APP_DB.prepare(
+		`SELECT email, email_verified_at, first_mcp_connected_at,
+		        first_saved_package_at, stripe_plan
+		 FROM users
+		 WHERE deleting_at IS NULL
+		   AND account_type = 'person'
+		   AND email IS NOT NULL
+		 ORDER BY updated_at DESC
+		 LIMIT ?`,
+	)
+		.bind(kitSubscriberSyncSweepLimit)
+		.all<KitUserRow>()
+
+	const rows = users.results ?? []
+	if (rows.length === 0) {
+		return { status: 'synced', considered: 0, tagged: 0 }
+	}
+
+	const fetchImpl = input.fetchImpl ?? fetch
+	let tagNames: Map<string, number>
+	try {
+		tagNames = await listKitTagsByName({
+			apiKey,
+			fetchImpl,
+			timeoutMs: KIT_SYNC_REQUEST_TIMEOUT_MS,
+		})
+	} catch (error) {
+		console.warn('Failed to list Kit tags for reconcile:', error)
+		return { status: 'synced', considered: 0, tagged: 0 }
+	}
+
+	let tagged = 0
+	await mapWithConcurrency(rows, kitSyncConcurrency, async (row) => {
+		try {
+			const result = await syncExistingKitSubscriber({
+				apiKey,
+				email: row.email,
+				facts: kitFactsFromUserRow(row),
+				signedUpTagId: tagId,
+				fetchImpl,
+				tagNames,
+			})
+			if (result.synced) tagged += 1
+		} catch (error) {
+			console.warn('Failed to reconcile Kit subscriber:', error)
+		}
+	})
+	return { status: 'synced', considered: rows.length, tagged }
+}

--- a/packages/worker/src/mcp-auth.ts
+++ b/packages/worker/src/mcp-auth.ts
@@ -18,6 +18,7 @@ import {
 import { handleStatelessMcpRequest } from './mcp/stateless-lane.ts'
 import { oauthScopes } from './oauth-handlers.ts'
 import { stampFirstMcpConnected } from '#worker/identity/activation-stamps.ts'
+import { scheduleKitSubscriberSync } from '#worker/kit/subscriber-sync.ts'
 
 export const mcpResourcePath = '/mcp'
 export const protectedResourceMetadataPath =
@@ -307,10 +308,24 @@ export async function handleMcpRequest({
 		})(),
 	})
 	ctx.waitUntil(
-		stampFirstMcpConnected(env.APP_DB, {
-			stableUserId: mcpUser.userId,
-			clientName: classification.clientName || null,
-		}),
+		(async () => {
+			const before = await env.APP_DB.prepare(
+				`SELECT first_mcp_connected_at FROM users WHERE stable_user_id = ?`,
+			)
+				.bind(mcpUser.userId)
+				.first<{ first_mcp_connected_at: string | null }>()
+			await stampFirstMcpConnected(env.APP_DB, {
+				stableUserId: mcpUser.userId,
+				clientName: classification.clientName || null,
+			})
+			if (!before?.first_mcp_connected_at) {
+				scheduleKitSubscriberSync({
+					env,
+					stableUserId: mcpUser.userId,
+					email: mcpUser.email,
+				})
+			}
+		})(),
 	)
 
 	return await withAccountWriteLease({

--- a/packages/worker/src/mcp-auth.ts
+++ b/packages/worker/src/mcp-auth.ts
@@ -325,7 +325,9 @@ export async function handleMcpRequest({
 					email: mcpUser.email,
 				})
 			}
-		})(),
+		})().catch((error) => {
+			console.warn('mcp-first-connected-kit-sync-failed', error)
+		}),
 	)
 
 	return await withAccountWriteLease({

--- a/packages/worker/src/mcp/executor.ts
+++ b/packages/worker/src/mcp/executor.ts
@@ -39,6 +39,7 @@ import {
 import { type SecretScope } from '#mcp/secrets/types.ts'
 import {
 	isEntitlementLimitError,
+	isJobIntervalFloorError,
 	parseEntitlementLimitMessage,
 	type EntitlementLimitErrorDetails,
 } from '#worker/entitlements/errors.ts'
@@ -1258,6 +1259,15 @@ export type ExecutionErrorDetails =
 			}
 	  }
 	| {
+			kind: 'job_interval_floor'
+			message: string
+			nextStep: string
+			suggestedAction: {
+				type: 'review_plan_limit'
+				resource: 'scheduled_jobs'
+			}
+	  }
+	| {
 			kind: 'sandbox_runtime_stale'
 			message: string
 			nextStep: string
@@ -1302,6 +1312,18 @@ export function getExecutionErrorDetails(
 
 	if (isEntitlementLimitError(error)) {
 		return toEntitlementExecutionErrorDetails(message, error.details)
+	}
+
+	if (isJobIntervalFloorError(error)) {
+		return {
+			kind: 'job_interval_floor',
+			message,
+			nextStep: error.details.upgradeHint,
+			suggestedAction: {
+				type: 'review_plan_limit',
+				resource: 'scheduled_jobs',
+			},
+		}
 	}
 
 	const entitlementDetails = parseEntitlementLimitMessage(message)

--- a/packages/worker/src/mcp/index.ts
+++ b/packages/worker/src/mcp/index.ts
@@ -23,6 +23,7 @@ import {
 	registerMcpAgentSession,
 } from './session-registry.ts'
 import { stampFirstMcpConnected } from '#worker/identity/activation-stamps.ts'
+import { scheduleKitSubscriberSync } from '#worker/kit/subscriber-sync.ts'
 
 export type State = {
 	searchConversationIdsWithPreamble?: Array<string>
@@ -52,9 +53,23 @@ class MCPBase extends McpAgent<Env, State, Props> {
 				doId: this.ctx.id.toString(),
 			})
 			this.ctx.waitUntil(
-				stampFirstMcpConnected(this.env.APP_DB, {
-					stableUserId: userId,
-				}),
+				(async () => {
+					const before = await this.env.APP_DB.prepare(
+						`SELECT first_mcp_connected_at FROM users WHERE stable_user_id = ?`,
+					)
+						.bind(userId)
+						.first<{ first_mcp_connected_at: string | null }>()
+					await stampFirstMcpConnected(this.env.APP_DB, {
+						stableUserId: userId,
+					})
+					if (!before?.first_mcp_connected_at) {
+						scheduleKitSubscriberSync({
+							env: this.env,
+							stableUserId: userId,
+							email: caller.user?.email,
+						})
+					}
+				})(),
 			)
 		}
 		const [overlay, registry, popularPackages, retiringNoticeIds] =

--- a/packages/worker/src/mcp/index.ts
+++ b/packages/worker/src/mcp/index.ts
@@ -69,7 +69,9 @@ class MCPBase extends McpAgent<Env, State, Props> {
 							email: caller.user?.email,
 						})
 					}
-				})(),
+				})().catch((error) => {
+					console.warn('mcp-first-connected-kit-sync-failed', error)
+				}),
 			)
 		}
 		const [overlay, registry, popularPackages, retiringNoticeIds] =

--- a/packages/worker/src/mcp/observability.ts
+++ b/packages/worker/src/mcp/observability.ts
@@ -2,7 +2,10 @@ import * as Sentry from '@sentry/cloudflare'
 import { type McpCallerContext } from '@kody-internal/shared/chat.ts'
 import { getErrorCauseChain } from '@kody-internal/shared/error-message.ts'
 import { CommunityActionError } from '#worker/community/errors.ts'
-import { isEntitlementLimitError } from '#worker/entitlements/errors.ts'
+import {
+	isEntitlementLimitError,
+	isJobIntervalFloorError,
+} from '#worker/entitlements/errors.ts'
 import { PackageScopeAccessError } from '#worker/package-registry/package-owner.ts'
 import { isRepoLargeFileMessage } from '#worker/repo/large-file-policy.ts'
 import {
@@ -106,6 +109,7 @@ function isCallerFailure(payload: McpObservabilityPayload, cause?: unknown) {
 	if (payload.callerError) return true
 	if (isUserCodeError(cause)) return true
 	if (getErrorCauseChain(cause).some(isEntitlementLimitError)) return true
+	if (getErrorCauseChain(cause).some(isJobIntervalFloorError)) return true
 	// Community preconditions (rate before fork, self-rate, banned, …) are
 	// caller-clearable; keep them on mcp-event and out of Sentry.
 	if (

--- a/packages/worker/src/package-registry/service.node.test.ts
+++ b/packages/worker/src/package-registry/service.node.test.ts
@@ -1068,6 +1068,9 @@ function createEntitlementsDatabase(input: {
 								const user = users.find((row) => row.email === params[0])
 								return (user ? { plan: user.plan } : null) as T | null
 							}
+							if (query.includes('SELECT first_saved_package_at FROM users')) {
+								return { first_saved_package_at: null } as T
+							}
 							// Synthetic-context probe: no users row in this mock, so the
 							// storage reserve path applies free-plan semantics without a DO.
 							if (query.includes('SELECT 1 AS present FROM users')) {

--- a/packages/worker/src/package-registry/service.ts
+++ b/packages/worker/src/package-registry/service.ts
@@ -29,6 +29,7 @@ import { deleteSavedPackageVector } from './vectorize.ts'
 import { scheduleSavedPackageSearchIndexUpsert } from './search-index-debt.ts'
 import { deletePackageInvocationTokensForPackage } from '#worker/package-invocations/repo.ts'
 import { jobsData } from '#worker/jobs/jobs-data.ts'
+import { scheduleKitSubscriberSync } from '#worker/kit/subscriber-sync.ts'
 import { syncJobManagerAlarm } from '#worker/jobs/manager-client.ts'
 import { rebuildPublishedPackageArtifacts } from '#worker/package-runtime/published-bundle-artifacts.ts'
 import {
@@ -317,7 +318,19 @@ export async function refreshSavedPackageProjection(input: {
 					email: input.userEmail,
 					resource: 'saved_packages',
 				})
+				const beforePackage = await input.env.APP_DB.prepare(
+					`SELECT first_saved_package_at FROM users WHERE stable_user_id = ?`,
+				)
+					.bind(input.userId)
+					.first<{ first_saved_package_at: string | null }>()
 				await insertSavedPackage(input.env.APP_DB, row)
+				if (!beforePackage?.first_saved_package_at) {
+					scheduleKitSubscriberSync({
+						env: input.env,
+						stableUserId: input.userId,
+						email: input.userEmail,
+					})
+				}
 				// A brand new package claims its id outright, so an earlier package's
 				// retirement row must not keep forwarding it elsewhere.
 				await releasePackageKodyIdRedirect({

--- a/packages/worker/src/package-registry/service.ts
+++ b/packages/worker/src/package-registry/service.ts
@@ -318,13 +318,20 @@ export async function refreshSavedPackageProjection(input: {
 					email: input.userEmail,
 					resource: 'saved_packages',
 				})
-				const beforePackage = await input.env.APP_DB.prepare(
-					`SELECT first_saved_package_at FROM users WHERE stable_user_id = ?`,
-				)
-					.bind(input.userId)
-					.first<{ first_saved_package_at: string | null }>()
+				let isFirstSavedPackage = false
+				try {
+					const beforePackage = await input.env.APP_DB.prepare(
+						`SELECT first_saved_package_at FROM users WHERE stable_user_id = ?`,
+					)
+						.bind(input.userId)
+						.first<{ first_saved_package_at: string | null }>()
+					isFirstSavedPackage = !beforePackage?.first_saved_package_at
+				} catch (error) {
+					console.warn('kit-first-package-pre-read-failed', error)
+					isFirstSavedPackage = true
+				}
 				await insertSavedPackage(input.env.APP_DB, row)
-				if (!beforePackage?.first_saved_package_at) {
+				if (isFirstSavedPackage) {
 					scheduleKitSubscriberSync({
 						env: input.env,
 						stableUserId: input.userId,

--- a/packages/worker/src/scheduled/scheduled-lanes.ts
+++ b/packages/worker/src/scheduled/scheduled-lanes.ts
@@ -3,7 +3,9 @@ import { checkAuthDenialBurstAndNotify } from '#app/auth-denial-alerts.ts'
 import { checkEmailDeliveryBurstAndNotify } from '#app/email-delivery-alerts.ts'
 import { refreshFleetPackageErrorRateAndMaybeAlert } from '#app/fleet-package-error-rate-alerts.ts'
 import { pruneRetention } from '#app/retention.ts'
+import { reconcileKitSubscribers } from '#worker/kit/subscriber-sync.ts'
 import { sendUserEntitlementWarningEmails } from '#app/user-entitlement-warning-emails.ts'
+import { sendUserErrorRateEmails } from '#app/user-error-rate-emails.ts'
 import { emitFleetEntitlementCrossingEvents } from '#app/usage-entitlement-alerts.ts'
 import { isRetryableD1LockError } from '#worker/d1-retry.ts'
 import {
@@ -150,11 +152,34 @@ export async function runScheduledLane(input: {
 				console.warn('user-entitlement-warning-emails-failed', error)
 				userWarnings = { status: 'failed' }
 			}
+			let errorRateEmails:
+				| Awaited<ReturnType<typeof sendUserErrorRateEmails>>
+				| { status: 'failed' }
+			try {
+				errorRateEmails = await sendUserErrorRateEmails({
+					env: input.env,
+					now: input.scheduledAt,
+				})
+			} catch (error) {
+				console.warn('user-error-rate-emails-failed', error)
+				errorRateEmails = { status: 'failed' }
+			}
 			const ops = await emitFleetEntitlementCrossingEvents({
 				env: input.env,
 				now: input.scheduledAt,
 			})
-			return { ...ops, userWarnings }
+			return { ...ops, userWarnings, errorRateEmails }
+		}
+		case 'kit_subscriber_sync': {
+			try {
+				return await reconcileKitSubscribers({
+					env: input.env,
+					now: input.scheduledAt,
+				})
+			} catch (error) {
+				console.warn('kit-subscriber-sync-failed', error)
+				return { status: 'failed' }
+			}
 		}
 		// DR export lanes are dispatched on cadence by the jobs worker without
 		// access to DR configuration; both ticks exit cheaply with a

--- a/packages/worker/universal/community-links.ts
+++ b/packages/worker/universal/community-links.ts
@@ -3,6 +3,9 @@ import { routes } from '#universal/routes.ts'
 /** Public invite for the Kody community Discord. */
 export const kodyDiscordInviteUrl = 'https://kcd.im/kody-discord'
 
+/** Kent's public issue-triage package — linked from user error-rate mail. */
+export const kodyIssueTriageListingPath = '/@kentcdodds/kody-issue-triage'
+
 const scopedPackageNamePattern = /^@([a-z0-9][a-z0-9._-]*)\//
 
 /**

--- a/packages/worker/universal/document-head.ts
+++ b/packages/worker/universal/document-head.ts
@@ -134,6 +134,7 @@ const routeDocumentHeads = {
 	[routePattern(routes.home)]: publicPageHead('home', DEFAULT_DOCUMENT_TITLE),
 	[routePattern(routes.account)]: titleOnly('Account'),
 	[routePattern(routes.accountBilling)]: titleOnly('Billing'),
+	[routePattern(routes.accountBillingSuccess)]: titleOnly("You're in"),
 	[routePattern(routes.accountUsage)]: titleOnly('Usage'),
 	[routePattern(routes.accountIntegrations)]: titleOnly('Integrations'),
 	[routePattern(routes.accountOauthAppDetail)]: titleOnly('Integrations'),

--- a/packages/worker/universal/loader-data.ts
+++ b/packages/worker/universal/loader-data.ts
@@ -1746,11 +1746,13 @@ export type AppLoaderData = {
 	emailVerification?: EmailVerificationLoaderData
 	oauthAuthorize?: OAuthAuthorizeLoaderData
 	accountBilling?: AccountBillingLoaderData
+	accountBillingSuccess?: AccountBillingSuccessLoaderData
 	accountUsage?: AccountUsageLoaderData
 	discord?: DiscordPageLoaderData
 	codeRuns?: CodeRunsLoaderData
 	walkthroughHosts?: WalkthroughHostPick
 	onboardingAgentChooser?: OnboardingAgentChooserPick
+	signupMode?: SignupMode
 }
 
 export type CodeRunsLoaderData = {
@@ -1772,6 +1774,11 @@ export type AccountBillingLoaderData = {
 	/** Deep link to the account usage page (limits / consumption). */
 	usageHref: '/account/usage'
 	error?: string
+}
+
+export type AccountBillingSuccessLoaderData = {
+	ok: true
+	needsOnboarding: boolean
 }
 
 export type AccountUsageEntitlementConsumption = {

--- a/packages/worker/universal/og-pages.ts
+++ b/packages/worker/universal/og-pages.ts
@@ -48,17 +48,21 @@ export const publicOgPages = {
 		path: '/blog',
 	},
 	login: {
-		imageTitle: 'Welcome back',
-		imageSubtitle: 'Log in to continue to kody.',
+		imageTitle: 'The Home Your Agents Share',
+		imageSubtitle:
+			"For all the agents you use today,\nand the ones you'll use tomorrow",
 		ogTitle: 'Sign in — Kody',
-		ogDescription: 'Log in to continue to kody.',
+		ogDescription:
+			"For all the agents you use today, and the ones you'll use tomorrow.",
 		path: '/login',
 	},
 	signup: {
-		imageTitle: 'Create your account',
-		imageSubtitle: 'Sign up to start using kody.',
+		imageTitle: 'The Home Your Agents Share',
+		imageSubtitle:
+			"For all the agents you use today,\nand the ones you'll use tomorrow",
 		ogTitle: 'Sign up — Kody',
-		ogDescription: 'Sign up to start using kody.',
+		ogDescription:
+			"For all the agents you use today, and the ones you'll use tomorrow.",
 		path: '/signup',
 	},
 	pricing: {

--- a/packages/worker/universal/plans.ts
+++ b/packages/worker/universal/plans.ts
@@ -146,6 +146,12 @@ export type PlanLimits = {
 	 * own) so a handful of minutely jobs cannot burn unbounded compute.
 	 */
 	maxJobRunsPerDay: number
+	/**
+	 * Fastest allowed recurring job interval on this plan. `0` means no extra
+	 * floor beyond the schedule itself. Enforced when a schedule is created
+	 * or changed — existing faster jobs are grandfathered.
+	 */
+	minJobIntervalMs: number
 }
 
 export const entitlementResources = [
@@ -246,6 +252,7 @@ export const planLimits: Record<PlanName, PlanLimits> = {
 		maxExecuteCallsPerDay: 250,
 		maxOutboundFetchesPerDay: 500,
 		maxJobRunsPerDay: 500,
+		minJobIntervalMs: 15 * 60 * 1000,
 	},
 	standard: {
 		maxRepos: 200,
@@ -262,6 +269,7 @@ export const planLimits: Record<PlanName, PlanLimits> = {
 		maxExecuteCallsPerDay: 5_000,
 		maxOutboundFetchesPerDay: 20_000,
 		maxJobRunsPerDay: 10_000,
+		minJobIntervalMs: 0,
 	},
 	pro: {
 		maxRepos: 400,
@@ -278,6 +286,7 @@ export const planLimits: Record<PlanName, PlanLimits> = {
 		maxExecuteCallsPerDay: 10_000,
 		maxOutboundFetchesPerDay: 40_000,
 		maxJobRunsPerDay: 20_000,
+		minJobIntervalMs: 0,
 	},
 	max: {
 		// 25× pro (400) → 10_000.
@@ -305,7 +314,29 @@ export const planLimits: Record<PlanName, PlanLimits> = {
 		maxOutboundFetchesPerDay: 2_000_000,
 		// 50× pro (20_000) → 1_000_000.
 		maxJobRunsPerDay: 1_000_000,
+		minJobIntervalMs: 0,
 	},
+}
+
+/** 15-minute floor on free recurring jobs. Paid plans have no extra floor. */
+export const freeMinJobIntervalMs = planLimits.free.minJobIntervalMs
+
+/**
+ * Human label for a plan's fastest job interval. `0` means no extra floor.
+ */
+export function formatMinJobInterval(minJobIntervalMs: number): string {
+	if (minJobIntervalMs <= 0) return 'None'
+	const minuteMs = 60 * 1000
+	const hourMs = 60 * minuteMs
+	if (minJobIntervalMs % hourMs === 0) {
+		const hours = minJobIntervalMs / hourMs
+		return hours === 1 ? '1 hour' : `${hours} hours`
+	}
+	if (minJobIntervalMs % minuteMs === 0) {
+		const minutes = minJobIntervalMs / minuteMs
+		return minutes === 1 ? '1 minute' : `${minutes} minutes`
+	}
+	return `${minJobIntervalMs} ms`
 }
 
 /**

--- a/tools/wrangler-filter-kody-generated-watch.node.test.ts
+++ b/tools/wrangler-filter-kody-generated-watch.node.test.ts
@@ -39,12 +39,18 @@ test('the additional-module watch filter is idempotent and marked', () => {
 })
 
 test('the bundle-watch gate is idempotent and env-gated', () => {
-	const first = wranglerBundleWatchSource('watch: config6.dev.watch ?? true')
-	expect(first.changed).toBe(true)
-	expect(first.source).toContain('WRANGLER_DISABLE_BUNDLE_WATCH')
-	const second = wranglerBundleWatchSource(first.source)
-	expect(second.changed).toBe(false)
-	expect(second.source).toBe(first.source)
+	for (const identifier of ['config5', 'config6']) {
+		const first = wranglerBundleWatchSource(
+			`watch: ${identifier}.dev.watch ?? true`,
+		)
+		expect(first.changed).toBe(true)
+		expect(first.source).toBe(
+			`watch: ${identifier}.dev.watch ?? (process.env.WRANGLER_DISABLE_BUNDLE_WATCH !== "true")`,
+		)
+		const second = wranglerBundleWatchSource(first.source)
+		expect(second.changed).toBe(false)
+		expect(second.source).toBe(first.source)
+	}
 })
 
 test('ensureWranglerFiltersKodyGeneratedWatch patches the installed wrangler CLI', async () => {

--- a/tools/wrangler-filter-kody-generated-watch.ts
+++ b/tools/wrangler-filter-kody-generated-watch.ts
@@ -36,9 +36,8 @@ const patchedBlock = `if (props.findAdditionalModules) {
               // ${patchMarker}: generated additional modules must not be watched
             }`
 
-const unpatchedBundleWatch = 'watch: config6.dev.watch ?? true'
-const patchedBundleWatch =
-	'watch: config6.dev.watch ?? (process.env.WRANGLER_DISABLE_BUNDLE_WATCH !== "true")'
+const unpatchedBundleWatchPattern = /watch: (config\d+)\.dev\.watch \?\? true/
+const patchedBundleWatchNeedle = 'WRANGLER_DISABLE_BUNDLE_WATCH'
 
 export function wranglerAdditionalModuleWatchSource(source: string) {
 	if (source.includes(patchMarker)) {
@@ -57,16 +56,20 @@ export function wranglerAdditionalModuleWatchSource(source: string) {
 }
 
 export function wranglerBundleWatchSource(source: string) {
-	if (source.includes(patchedBundleWatch)) {
+	if (source.includes(patchedBundleWatchNeedle)) {
 		return { source, patched: true, changed: false }
 	}
-	if (!source.includes(unpatchedBundleWatch)) {
+	const match = unpatchedBundleWatchPattern.exec(source)
+	if (!match?.[1]) {
 		throw new Error(
 			`wrangler ${wranglerCliPath} no longer defaults BundlerController watch to true; rebase the Friction #1789 bundle-watch gate.`,
 		)
 	}
 	return {
-		source: source.replace(unpatchedBundleWatch, patchedBundleWatch),
+		source: source.replace(
+			unpatchedBundleWatchPattern,
+			`watch: ${match[1]}.dev.watch ?? (process.env.WRANGLER_DISABLE_BUNDLE_WATCH !== "true")`,
+		),
 		patched: true,
 		changed: true,
 	}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Finish the aligned pre-open-signup launch work without flipping `SIGNUP_MODE` to `open`.

## Why

Open signup needs a free-plan cadence floor, honest public CTAs, exist-only Kit lifecycle tags, and transactional billing/verify/error mail — not a nurture drip and not subscriber creation from account events.

## Summary

- Free plans keep 5 jobs and 500 `job_runs_per_day`. Recurring jobs cannot run faster than every 15 minutes on create, schedule change, or timezone change; existing faster jobs are grandfathered for identity-only refresh. Pricing says “5 jobs, no faster than every 15 minutes.”
- Package job sync preflights every interval floor before writing any job row, so a later invalid schedule cannot leave a partial projection.
- Public door is mode-aware: `open` → Create a free account; invite → waitlist + “I have a code.” Paid pricing CTAs no longer say “Launch coming soon.” Login/signup OG copy matches the homepage.
- Kit account events never create subscribers. Lookup by email, skip if missing, add lifecycle tags, remove only paid tags on cancel. Hourly `kit_subscriber_sync` lane reconciles. First-package / first-MCP Kit work cannot fail the user request.
- `GET /account/billing/success` renders a thank-you page (Discord + connect-agent when `needsOnboarding`) and keeps the SSR onboarding flag across consume-once loader reads.
- Transactional mail covers connect-agent after verify, billing success, payment failed, past due, and user error-rate. KV claims are reserved before SMTP; a failed invoice sends past-due or payment-failed, not both.

Out of scope: flipping signup mode, tightening job count/run caps, creating Kit subscribers, onboarding wizard, ChatGPT plugin, official `@kody/*` admin-notify package.

## Testing

- Focused node-unit suites for jobs (timezone re-validation + mixed-job preflight), Kit sync, account emails (claim-before-send + release on SMTP failure), error-rate threshold, billing success render, verify-email, pricing SSR, and the wrangler watch gate.
- Pre-push after review fixes: `npm run test:node` (2226) and `npm run test:workers` (304).
- `npm run validate` passed on the pre-review-fix tip (format, lint, typecheck, node/workers/e2e/mcp, primitives, migrations, deploy guardrails).
- Preview `kody-pr-1843` (merge of `8cb41739`): signed in as `me@kentcdodds.com`. `/pricing` and `/account/billing.json` 200. Signed-out pricing has the 15-minute floor copy and no “Launch coming soon”; signed-in paid CTAs are “Upgrade in settings.” Homepage invite mode still shows waitlist + “I have a code.” Stripe is unconfigured on preview, so live checkout success was not exercised there.

![Signed-out preview homepage waitlist and invite code](https://cursor.com/artifacts/c/art-e1c502cb-2c7a-4678-9078-83b6c211839a)
![Signed-out preview pricing with 15-minute floor](https://cursor.com/artifacts/c/art-344334c4-bf19-4a6e-869b-9083d4bdc901)
![Signed-out preview signup invite form](https://cursor.com/artifacts/c/art-9c609aa8-264d-4c4a-bb6e-d683884042e0)
![Signed-in preview pricing Upgrade in settings](https://cursor.com/artifacts/c/art-3c6a52aa-e4d9-4859-80a9-8f7d3d084d27)
![Signed-in preview billing unconfigured](https://cursor.com/artifacts/c/art-920b8d24-6f55-4b0c-8a28-26a483fd7b2f)

<a href="https://cursor.com/agents/bc-444898b0-abe5-4f62-b88b-f955f33ad172/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpreview_launch_prep_signed_in_walkthrough.mp4"><img src="https://cursor.com/artifacts/c/art-37643cba-0111-476c-a1aa-0a59fdf8c9a3" alt="preview_launch_prep_signed_in_walkthrough.mp4" /></a>

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `36e577cc` · **Head:** `eb75a985`

**Classification:** extends — free job interval becomes an entitlement contract, Kit tagging becomes exist-only lifecycle sync, and billing success becomes a rendered page with transactional mail.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `entitlements` | auth | extends — `minJobIntervalMs` on free (15 minutes) |
| `jobs` | assistant | extends — floor on create/schedule/timezone change; preflight before writes |
| `app-ui` | surfaces | extends — mode-aware public CTAs, pricing copy, billing thank-you page |
| `app-sessions` | auth | extends — exist-only Kit lifecycle tags on signup/verify |
| `billing` | auth | extends — thank-you render, claim-before-send mail, one email per failed invoice |
| `scheduled-cron` | surfaces | extends — hourly `kit_subscriber_sync` + error-rate mail on entitlement lane |
| `mcp-oauth` | auth | composes — first MCP connection schedules Kit sync without failing the request |
| `mcp-server` | surfaces | composes — `JobIntervalFloorError` is a caller failure |
| `saved-packages` | assistant | composes — first saved package schedules Kit sync; pre-read failure does not block insert |

### Change flow

Free job create/change hits the new interval floor; paid checkout now lands on a thank-you page and exist-only Kit tags follow account facts.

```mermaid
sequenceDiagram
	actor User
	participant appUi as app-ui
	participant entitlements as entitlements
	participant jobs as jobs
	participant billing as billing
	participant appSessions as app-sessions
	participant scheduledCron as scheduled-cron
	User->>jobs: create or change free job schedule or timezone
	jobs->>entitlements: assert minJobIntervalMs (15m) before writes
	entitlements-->>jobs: JobIntervalFloorError or allow / grandfather
	User->>billing: Stripe checkout return GET /account/billing/success
	billing->>appUi: render thank-you and persist SSR needsOnboarding
	billing->>appSessions: claim KV then send success/past-due/failed mail
	billing->>appSessions: schedule exist-only Kit paid-tag sync
	appSessions->>scheduledCron: hourly kit_subscriber_sync reconcile
```

### Before / after

| Surface | Before | After |
| --- | --- | --- |
| Free job cadence | Any interval the scheduler accepts | No faster than 15 minutes unless already saved |
| Package job sync | Writes then validates | Preflight every floor, then write |
| Pricing paid CTA | “Launch coming soon” | Signed-out `/signup`, signed-in `/account/billing` |
| Kit account events | `signed_up::kody` only | Exist-only lifecycle + paid tags; never create |
| Billing success | Redirect to `/account/billing` | Render thank-you page; keep SSR onboarding flag |
| Failed-invoice mail | Checkout + webhook, or failed + past-due | Claim before send; one email per failed invoice |

### Invariants

Per-user isolation is unchanged: plan lookup, Kit tags, and mail claims stay keyed to the signed-in account. Kit still never creates subscribers from account events. `SIGNUP_MODE` stays `invite` until a later change.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-444898b0-abe5-4f62-b88b-f955f33ad172?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-444898b0-abe5-4f62-b88b-f955f33ad172&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a billing confirmation page with onboarding guidance, community access, and billing management links.
  * Pricing and home pages now show signup or waitlist options based on availability.
  * Added transactional notifications for agent connection, billing, payment issues, and elevated error rates.
  * Added automatic subscriber lifecycle updates for existing mailing-list contacts.
* **Bug Fixes**
  * Free plans now enforce a minimum 15-minute interval between recurring jobs, with clear upgrade guidance.
  * Improved handling of missing billing sessions and signup configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->