### PR TITLE
Fix repo_promote_to_package stale-session after kind flip

### DIFF
--- a/docs/use/repos.md
+++ b/docs/use/repos.md
@@ -57,7 +57,9 @@ When a plain repo has `package.json` at HEAD, `repo_get` and publish surfaces
 surface progressive disclosure (`package_shaped`, `activated: false`, promote
 notice). `repo_promote_to_package` enforces the `saved_packages` entitlement,
 runs full publish checks, creates the `saved_packages` row, flips
-`entity_sources` to `package`, and deletes the `user_repos` row.
+`entity_sources` to `package` while seeding `published_commit` from the
+session's HEAD (plain repos have no publish pointer, and a null pointer after
+the flip looks like a stale session), and deletes the `user_repos` row.
 
 ## Mental model
 

--- a/packages/worker/src/mcp/capabilities/repo/repo-promote-to-package.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/repo/repo-promote-to-package.node.test.ts
@@ -143,7 +143,10 @@ function createSessionRpc(overrides?: {
 	}
 }) {
 	return {
-		openSession: vi.fn(async () => undefined),
+		openSession: vi.fn(async () => ({
+			id: 'repo-promote-source-1-test',
+			base_commit: 'commit-1',
+		})),
 		runChecks: vi.fn(async () => ({
 			ok: overrides?.checkOk ?? true,
 			results:
@@ -214,9 +217,19 @@ test('repo_promote_to_package rejects repos without package.json at HEAD', async
 	expect(mockModule.repoSessionRpc).not.toHaveBeenCalled()
 })
 
-test('repo_promote_to_package seeds published_commit from HEAD so publish is not treated as a stale session', async () => {
+test('repo_promote_to_package seeds published_commit from the opened session base so publish is not treated as a stale session', async () => {
 	resetMocks()
+	// HEAD snapshot can lag a concurrent git-lane push; the opened session
+	// base is the commit publishSession will compare against.
+	mockModule.resolveArtifactSourceHead.mockResolvedValue({
+		branch: 'main',
+		commit: 'commit-stale',
+	})
 	const rpc = createSessionRpc()
+	rpc.openSession.mockResolvedValue({
+		id: 'repo-promote-source-1-test',
+		base_commit: 'commit-1',
+	})
 	mockModule.repoSessionRpc.mockReturnValue(rpc)
 	const { ctx } = createCapabilityContext()
 

--- a/packages/worker/src/mcp/capabilities/repo/repo-promote-to-package.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/repo/repo-promote-to-package.node.test.ts
@@ -2,57 +2,295 @@ import { expect, test, vi } from 'vitest'
 import { McpCallerError } from '#mcp/caller-error.ts'
 import { createMcpCallerContext } from '#mcp/context.ts'
 
+const mockModule = vi.hoisted(() => ({
+	resolveOwnedUserRepo: vi.fn(),
+	resolveArtifactSourceHead: vi.fn(),
+	readArtifactFileAtCommit: vi.fn(),
+	getSavedPackageById: vi.fn(),
+	getSavedPackageByKodyId: vi.fn(),
+	insertSavedPackage: vi.fn(),
+	assertWithinEntitlement: vi.fn(),
+	repoSessionRpc: vi.fn(),
+	updateEntitySource: vi.fn(),
+	upsertSavedPackageVector: vi.fn(),
+	refreshSavedPackageProjection: vi.fn(),
+	deleteUserRepo: vi.fn(),
+}))
+
 vi.mock('./resolve-user-repo.ts', () => ({
-	resolveOwnedUserRepo: vi.fn(async () => ({
-		userRepo: {
-			id: 'repo-1',
-			userId: 'user-1',
-			name: 'notes',
-			description: null,
-			createdAt: '2026-01-01T00:00:00.000Z',
-			updatedAt: '2026-01-01T00:00:00.000Z',
-		},
-		source: {
-			id: 'source-1',
-			user_id: 'user-1',
-			entity_kind: 'repo',
-			entity_id: 'repo-1',
-			repo_id: 'repo-artifacts-1',
-			published_commit: null,
-			indexed_commit: null,
-			manifest_path: 'package.json',
-			source_root: '/',
-			last_external_check_at: null,
-			external_check_until: null,
-			created_at: '2026-01-01T00:00:00.000Z',
-			updated_at: '2026-01-01T00:00:00.000Z',
-		},
-	})),
+	resolveOwnedUserRepo: (...args: Array<unknown>) =>
+		mockModule.resolveOwnedUserRepo(...args),
 }))
 
 vi.mock('#worker/repo/artifacts.ts', () => ({
-	resolveArtifactSourceHead: vi.fn(async () => ({
-		branch: 'main',
-		commit: 'commit-1',
-	})),
+	resolveArtifactSourceHead: (...args: Array<unknown>) =>
+		mockModule.resolveArtifactSourceHead(...args),
 }))
 
 vi.mock('#worker/repo/artifact-file.ts', () => ({
-	readArtifactFileAtCommit: vi.fn(async () => null),
+	readArtifactFileAtCommit: (...args: Array<unknown>) =>
+		mockModule.readArtifactFileAtCommit(...args),
+}))
+
+vi.mock('#worker/package-registry/repo.ts', () => ({
+	getSavedPackageById: (...args: Array<unknown>) =>
+		mockModule.getSavedPackageById(...args),
+	getSavedPackageByKodyId: (...args: Array<unknown>) =>
+		mockModule.getSavedPackageByKodyId(...args),
+	insertSavedPackage: (...args: Array<unknown>) =>
+		mockModule.insertSavedPackage(...args),
+}))
+
+vi.mock('#worker/entitlements/service.ts', () => ({
+	assertWithinEntitlement: (...args: Array<unknown>) =>
+		mockModule.assertWithinEntitlement(...args),
+}))
+
+vi.mock('#worker/repo/repo-session-rpc.ts', () => ({
+	repoSessionRpc: (...args: Array<unknown>) =>
+		mockModule.repoSessionRpc(...args),
+}))
+
+vi.mock('#worker/repo/entity-sources.ts', () => ({
+	updateEntitySource: (...args: Array<unknown>) =>
+		mockModule.updateEntitySource(...args),
+}))
+
+vi.mock('#worker/package-registry/vectorize.ts', () => ({
+	upsertSavedPackageVector: (...args: Array<unknown>) =>
+		mockModule.upsertSavedPackageVector(...args),
+}))
+
+vi.mock('#worker/package-registry/service.ts', () => ({
+	refreshSavedPackageProjection: (...args: Array<unknown>) =>
+		mockModule.refreshSavedPackageProjection(...args),
+}))
+
+vi.mock('#worker/repo/user-repos.ts', () => ({
+	deleteUserRepo: (...args: Array<unknown>) =>
+		mockModule.deleteUserRepo(...args),
 }))
 
 const { repoPromoteToPackageCapability } =
 	await import('./repo-promote-to-package.ts')
 
-test('repo_promote_to_package rejects repos without package.json at HEAD', async () => {
-	const ctx = {
-		env: { APP_DB: {} as D1Database } as Env,
-		callerContext: createMcpCallerContext({
-			user: { userId: 'user-1', email: 'user@test.invalid' },
-			baseUrl: 'https://kody.test',
-		}),
+const packageJson = JSON.stringify({
+	name: '@user/brave-search',
+	exports: { '.': './src/index.ts' },
+	kody: {
+		id: 'brave-search',
+		description: 'Search the web with Brave.',
+	},
+})
+
+function createPlainRepoSource() {
+	return {
+		id: 'source-1',
+		user_id: 'user-1',
+		entity_kind: 'repo' as const,
+		entity_id: 'repo-1',
+		repo_id: 'repo-artifacts-1',
+		published_commit: null,
+		indexed_commit: null,
+		manifest_path: 'package.json',
+		source_root: '/',
+		last_external_check_at: null,
+		external_check_until: null,
+		created_at: '2026-01-01T00:00:00.000Z',
+		updated_at: '2026-01-01T00:00:00.000Z',
 	}
+}
+
+function createCapabilityContext() {
+	const deleted: Array<Array<unknown>> = []
+	return {
+		deleted,
+		ctx: {
+			env: {
+				APP_DB: {
+					prepare(sql: string) {
+						return {
+							bind(...values: Array<unknown>) {
+								return {
+									run: async () => {
+										deleted.push([sql, ...values])
+										return { meta: { changes: 1 } }
+									},
+								}
+							},
+						}
+					},
+				} as unknown as D1Database,
+			} as Env,
+			callerContext: createMcpCallerContext({
+				user: {
+					userId: 'user-1',
+					email: 'user@test.invalid',
+					username: 'user',
+				},
+				baseUrl: 'https://kody.test',
+			}),
+		},
+	}
+}
+
+function createSessionRpc(overrides?: {
+	checkOk?: boolean
+	publish?: {
+		status: 'ok' | 'base_moved' | 'checks_outdated'
+		publishedCommit?: string | null
+		message?: string
+	}
+}) {
+	return {
+		openSession: vi.fn(async () => undefined),
+		runChecks: vi.fn(async () => ({
+			ok: overrides?.checkOk ?? true,
+			results:
+				overrides?.checkOk === false
+					? [{ kind: 'manifest', ok: false, message: 'Manifest invalid.' }]
+					: [
+							{
+								kind: 'manifest',
+								ok: true,
+								message: 'Validated package.json.',
+							},
+						],
+		})),
+		publishSession: vi.fn(async () => ({
+			status: overrides?.publish?.status ?? 'ok',
+			sessionId: 'repo-promote-source-1-test',
+			publishedCommit: overrides?.publish?.publishedCommit ?? 'commit-1',
+			message:
+				overrides?.publish?.message ?? 'Published session to repo-artifacts-1.',
+		})),
+		discardSession: vi.fn(async () => ({
+			ok: true,
+			sessionId: 'repo-promote-source-1-test',
+			deleted: true,
+		})),
+	}
+}
+
+function resetMocks() {
+	for (const fn of Object.values(mockModule)) {
+		fn.mockReset()
+	}
+	mockModule.resolveOwnedUserRepo.mockResolvedValue({
+		userRepo: {
+			id: 'repo-1',
+			userId: 'user-1',
+			name: 'brave-search',
+			description: null,
+			createdAt: '2026-01-01T00:00:00.000Z',
+			updatedAt: '2026-01-01T00:00:00.000Z',
+		},
+		source: createPlainRepoSource(),
+	})
+	mockModule.resolveArtifactSourceHead.mockResolvedValue({
+		branch: 'main',
+		commit: 'commit-1',
+	})
+	mockModule.readArtifactFileAtCommit.mockResolvedValue(
+		new TextEncoder().encode(packageJson),
+	)
+	mockModule.getSavedPackageById.mockResolvedValue(null)
+	mockModule.getSavedPackageByKodyId.mockResolvedValue(null)
+	mockModule.insertSavedPackage.mockResolvedValue(undefined)
+	mockModule.assertWithinEntitlement.mockResolvedValue(undefined)
+	mockModule.updateEntitySource.mockResolvedValue(true)
+	mockModule.upsertSavedPackageVector.mockResolvedValue(undefined)
+	mockModule.refreshSavedPackageProjection.mockResolvedValue({ record: {} })
+	mockModule.deleteUserRepo.mockResolvedValue(undefined)
+}
+
+test('repo_promote_to_package rejects repos without package.json at HEAD', async () => {
+	resetMocks()
+	mockModule.readArtifactFileAtCommit.mockResolvedValueOnce(null)
+	const { ctx } = createCapabilityContext()
 	await expect(
-		repoPromoteToPackageCapability.handler({ name: 'notes' }, ctx),
+		repoPromoteToPackageCapability.handler({ name: 'brave-search' }, ctx),
 	).rejects.toThrow(McpCallerError)
+	expect(mockModule.repoSessionRpc).not.toHaveBeenCalled()
+})
+
+test('repo_promote_to_package seeds published_commit from HEAD so publish is not treated as a stale session', async () => {
+	resetMocks()
+	const rpc = createSessionRpc()
+	mockModule.repoSessionRpc.mockReturnValue(rpc)
+	const { ctx } = createCapabilityContext()
+
+	const result = await repoPromoteToPackageCapability.handler(
+		{ name: 'brave-search' },
+		ctx,
+	)
+
+	expect(result).toMatchObject({
+		status: 'promoted',
+		kody_id: 'brave-search',
+		name: '@user/brave-search',
+		published_commit: 'commit-1',
+	})
+	expect(rpc.runChecks).toHaveBeenCalledWith(
+		expect.objectContaining({
+			userId: 'user-1',
+			expectedPackageScope: 'user',
+		}),
+	)
+	expect(mockModule.updateEntitySource).toHaveBeenCalledWith(
+		expect.anything(),
+		expect.objectContaining({
+			id: 'source-1',
+			entityKind: 'package',
+			manifestPath: 'package.json',
+			publishedCommit: 'commit-1',
+		}),
+	)
+	expect(rpc.publishSession).toHaveBeenCalled()
+	expect(mockModule.deleteUserRepo).toHaveBeenCalledWith(expect.anything(), {
+		userId: 'user-1',
+		repoId: 'repo-1',
+	})
+})
+
+test('repo_promote_to_package rolls back the kind flip and published_commit when publish reports base_moved', async () => {
+	resetMocks()
+	const rpc = createSessionRpc({
+		publish: {
+			status: 'base_moved',
+			publishedCommit: null,
+			message:
+				'The source repo has moved since this session opened. Rebase the session before publishing.',
+		},
+	})
+	mockModule.repoSessionRpc.mockReturnValue(rpc)
+	const { ctx, deleted } = createCapabilityContext()
+
+	await expect(
+		repoPromoteToPackageCapability.handler({ name: 'brave-search' }, ctx),
+	).rejects.toThrow(/source repo has moved/)
+
+	expect(mockModule.updateEntitySource).toHaveBeenNthCalledWith(
+		1,
+		expect.anything(),
+		expect.objectContaining({
+			entityKind: 'package',
+			publishedCommit: 'commit-1',
+		}),
+	)
+	expect(mockModule.updateEntitySource).toHaveBeenNthCalledWith(
+		2,
+		expect.anything(),
+		expect.objectContaining({
+			id: 'source-1',
+			entityKind: 'repo',
+			entityId: 'repo-1',
+			manifestPath: 'package.json',
+			sourceRoot: '/',
+			publishedCommit: null,
+		}),
+	)
+	expect(deleted[0]?.[0]).toMatch(/DELETE FROM saved_packages/)
+	expect(rpc.discardSession).toHaveBeenCalled()
+	expect(mockModule.deleteUserRepo).not.toHaveBeenCalled()
 })

--- a/packages/worker/src/mcp/capabilities/repo/repo-promote-to-package.ts
+++ b/packages/worker/src/mcp/capabilities/repo/repo-promote-to-package.ts
@@ -125,7 +125,7 @@ export const repoPromoteToPackageCapability = defineDomainCapability(
 			})
 			const sessionId = `repo-promote-${source.id}-${crypto.randomUUID()}`
 			const session = repoSessionRpc(ctx.env, sessionId)
-			await session.openSession({
+			const opened = await session.openSession({
 				sessionId,
 				sourceId: source.id,
 				userId: user.userId,
@@ -165,9 +165,10 @@ export const repoPromoteToPackageCapability = defineDomainCapability(
 				created_at: now,
 				updated_at: now,
 			})
-			// Seed published_commit to the HEAD the session opened on. After
-			// the kind flip, publishSession compares that pointer to the
-			// session base. A null pointer looks like "source has moved" even
+			// Seed published_commit from the opened session base, not the
+			// earlier HEAD snapshot. A git-lane push between those two reads
+			// would otherwise seed the old commit and fail publish as
+			// base_moved. A null pointer looks like "source has moved" even
 			// though this is the first package publish.
 			await updateEntitySource(ctx.env.APP_DB, {
 				id: source.id,
@@ -176,7 +177,7 @@ export const repoPromoteToPackageCapability = defineDomainCapability(
 				entityId: packageId,
 				manifestPath: 'package.json',
 				sourceRoot: source.source_root,
-				publishedCommit: head.commit,
+				publishedCommit: opened.base_commit || head.commit,
 			})
 			const publishResult = await session.publishSession({
 				sessionId,

--- a/packages/worker/src/mcp/capabilities/repo/repo-promote-to-package.ts
+++ b/packages/worker/src/mcp/capabilities/repo/repo-promote-to-package.ts
@@ -165,6 +165,10 @@ export const repoPromoteToPackageCapability = defineDomainCapability(
 				created_at: now,
 				updated_at: now,
 			})
+			// Seed published_commit to the HEAD the session opened on. After
+			// the kind flip, publishSession compares that pointer to the
+			// session base. A null pointer looks like "source has moved" even
+			// though this is the first package publish.
 			await updateEntitySource(ctx.env.APP_DB, {
 				id: source.id,
 				userId: user.userId,
@@ -172,6 +176,7 @@ export const repoPromoteToPackageCapability = defineDomainCapability(
 				entityId: packageId,
 				manifestPath: 'package.json',
 				sourceRoot: source.source_root,
+				publishedCommit: head.commit,
 			})
 			const publishResult = await session.publishSession({
 				sessionId,
@@ -193,6 +198,7 @@ export const repoPromoteToPackageCapability = defineDomainCapability(
 					// leaves the entity source byte-identical to its prior state.
 					manifestPath: source.manifest_path,
 					sourceRoot: source.source_root,
+					publishedCommit: source.published_commit,
 				})
 				await session
 					.discardSession({ sessionId, userId: user.userId })

--- a/packages/worker/src/repo/repo-session-do.node.test.ts
+++ b/packages/worker/src/repo/repo-session-do.node.test.ts
@@ -2735,3 +2735,30 @@ test('publishSession maps non-fast-forward PushRejectedError to base_moved witho
 		expect.not.objectContaining({ force: true }),
 	)
 })
+
+test('runChecks forwards expectedPackageScope for a still-plain repo so promote can run package checks', async () => {
+	setCommonSessionFixtures()
+	mockModule.getEntitySourceById.mockResolvedValue({
+		id: 'source-1',
+		user_id: 'user-1',
+		entity_kind: 'repo',
+		entity_id: 'repo-1',
+		repo_id: 'source-repo',
+		published_commit: null,
+		manifest_path: 'package.json',
+		source_root: '/',
+	})
+	mockModule.runRepoChecks.mockClear()
+	const repoSession = new RepoSession(createDurableObjectState(), createEnv())
+	const result = await repoSession.runChecks({
+		sessionId: 'session-1',
+		userId: 'user-1',
+		expectedPackageScope: 'user',
+	})
+	expect(result.ok).toBe(true)
+	expect(mockModule.runRepoChecks).toHaveBeenCalledWith(
+		expect.objectContaining({
+			expectedPackageScope: 'user',
+		}),
+	)
+})

--- a/packages/worker/src/repo/repo-session-do.ts
+++ b/packages/worker/src/repo/repo-session-do.ts
@@ -2149,10 +2149,9 @@ class RepoSessionBase extends DurableObject<Env> {
 			env: this.env,
 			baseUrl: source.source_root,
 			userId: input.userId,
-			expectedPackageScope:
-				source.entity_kind === 'package'
-					? input.expectedPackageScope
-					: undefined,
+			// Honor an explicit scope even on a still-plain repo: promote
+			// runs package checks before flipping entity_kind.
+			expectedPackageScope: input.expectedPackageScope,
 		})
 		const { sourceFiles: _sourceFiles, ...publicResult } = result
 		const runId = crypto.randomUUID()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Make `repo_promote_to_package` succeed for package-shaped plain repos created through the git lane, instead of failing with a stale-session / "source has moved" error.

## Why

Discord help thread: https://discord.com/channels/1539764478470656101/1543712936541949963

`.hypercubed` (via their agent) reported that `repo_promote_to_package` on `@hypercubed/brave-search` failed with "source has moved even after discarding sessions." This is not caller error.

Promote opens a session against live HEAD (plain repos have no `published_commit`), then flips `entity_sources.entity_kind` to `package` and calls `publishSession`. The package publish path compares `published_commit` to the session base. A still-null pointer is `'' !== <HEAD>`, so every promote of a git-lane repo returns `base_moved`. Discarding sessions cannot help: the next promote opens a fresh session and hits the same comparison.

They later said it worked after reauthorizing MCP. That can still happen if a lagged catalog read publishes through the plain-repo path. The platform bug remains.

## Summary

- Seed `published_commit` from the opened session base (not the earlier HEAD snapshot) when flipping the source to `package`.
- Restore the original `published_commit` (typically `null`) if publish fails and the kind flip is rolled back.
- Pass `expectedPackageScope` through `runChecks` even while the source is still a plain repo, so promote's package-scoped checks actually run.
- Cover the happy path, a stale-HEAD vs session-base race, the `base_moved` rollback, and the `runChecks` scope forward.

## Testing

- Local: `npm run test:node` (2233 passed) and `npm run test:workers` (306 passed).
- Focused coverage in `repo-promote-to-package.node.test.ts` and `repo-session-do.node.test.ts`.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `d1f83e86` · **Head:** `5ee4791b`

**Classification:** extends — `repo_promote_to_package` now seeds `published_commit` from the opened session base, and repo-session checks honor an explicit package scope before that flip.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `repos` | assistant | extends — promote writes `published_commit` from the session base and restores it on rollback |
| `repo-sessions` | runtime | extends — `runChecks` forwards `expectedPackageScope` on still-plain repos |
| `capability-registry` | assistant | composes — promote capability tests only |

### Change flow

Promote used to flip the source to a package with a null publish pointer, so `publishSession` treated the session as stale.

```mermaid
sequenceDiagram
	actor Agent
	participant mcpServer as mcp-server
	participant repos as repos
	participant repoSessions as repo-sessions
	participant d1AppDb as d1-app-db
	Agent->>mcpServer: repo_promote_to_package
	mcpServer->>repos: openSession
	repos->>repoSessions: openSession returns base_commit
	repos->>repoSessions: runChecks(expectedPackageScope)
	Note over repoSessions: scope is honored while entity_kind is still repo
	repos->>d1AppDb: insert saved_packages
	repos->>d1AppDb: flip entity_kind to package and seed published_commit from session base
	repos->>repoSessions: publishSession
	Note over repoSessions: published_commit now matches session base
	alt publish fails
		repos->>d1AppDb: restore entity_kind repo and published_commit
	end
```

### Invariants

Per-user isolation is unchanged. The failed-promote rollback still leaves the entity source byte-identical to its pre-promote columns, including `published_commit`.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bb38fb30-a481-49f8-8633-81871cb784d8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bb38fb30-a481-49f8-8633-81871cb784d8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Repository promotion now initializes the published commit from the opened session’s base commit.
  * Failed promotions correctly restore the previous repository state and remove any temporary package.
  * Package checks now use the expected package scope when promoting plain repositories.
  * Promotion is rejected when `package.json` is missing at the repository HEAD.

* **Documentation**
  * Updated plain repository documentation to explain published commit handling during promotion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->