### PR TITLE
Split the home waitlist form out of the landing route

### DIFF
--- a/packages/worker/client/routes/home.tsx
+++ b/packages/worker/client/routes/home.tsx
@@ -1,7 +1,5 @@
-import { type Handle, ref } from 'remix/ui'
+import { type Handle } from 'remix/ui'
 import { CopyTextButton } from '#client/copy-text-button.tsx'
-import { observeNearViewport } from '#client/deferred-turnstile.ts'
-import { on } from '#client/event-mixin.ts'
 import { readCurrentRouterHref } from '#client/client-router.tsx'
 import { createRouteLoadLatch } from '#client/route-load-latch.ts'
 import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
@@ -18,13 +16,6 @@ import { fetchCodeRunsPayload } from '#client/routes/code-runs-payload.ts'
 import { type PublicCodeRunsWindow } from '#universal/code-runs.ts'
 import { reveal, revealPop } from '#client/reveal.ts'
 import { fetchPublicAuthConfig } from '#client/social-sign-in.ts'
-import {
-	honeypotFieldName,
-	readPublicFormProtection,
-	renderTurnstileWidgets,
-	resetTurnstileWidgets,
-	turnstileWidgetClassName,
-} from '#client/public-form-protection.ts'
 import { landingArtAttrs } from '#universal/landing-images.ts'
 import { homepageSignupPath } from '#universal/first-touch-attribution.ts'
 import { type SignupMode } from '#universal/signup-mode.ts'
@@ -35,6 +26,7 @@ import {
 import { LandingHeroAgents } from '#client/routes/landing-hero-agents.tsx'
 import { LandingTestimonialsCarousel } from './landing-testimonials-carousel.tsx'
 import { LandingLoopPlayer } from './landing-loop-player.tsx'
+import { WaitlistForm } from './landing-waitlist-form.tsx'
 import { WalkthroughHostIntro } from './walkthrough-host-intro.tsx'
 
 /**
@@ -565,244 +557,6 @@ export function HomeRoute(handle: Handle) {
 					)}
 				</section>
 			</div>
-		)
-	}
-}
-
-/**
- * Connected-pill waitlist form (name · divider · email · button) with an
- * inline success swap. Posts to the real `/waiting-list` endpoint with the
- * same honeypot + Turnstile protection as the signup page. The challenge
- * script stays off first paint: it loads once the form is near the viewport.
- */
-function WaitlistForm(handle: Handle) {
-	type Status = 'idle' | 'submitting' | 'success' | 'error'
-	let status: Status = 'idle'
-	let message: string | null = null
-	let protectionArmed = false
-	let turnstileSiteKey: string | null | undefined
-	let widgetReady = false
-
-	async function loadProtectionConfig(signal: AbortSignal) {
-		if (turnstileSiteKey !== undefined) return
-		const config = await fetchPublicAuthConfig(signal)
-		if (signal.aborted) return
-		turnstileSiteKey = config?.turnstileSiteKey ?? null
-		handle.update()
-	}
-
-	function setState(nextStatus: Status, nextMessage: string | null = null) {
-		status = nextStatus
-		message = nextMessage
-		handle.update()
-	}
-
-	function waitingForProtection() {
-		if (!protectionArmed) return true
-		if (turnstileSiteKey === undefined) return true
-		return Boolean(turnstileSiteKey) && !widgetReady
-	}
-
-	async function handleSubmit(event: SubmitEvent) {
-		event.preventDefault()
-		if (status === 'submitting') return
-		if (waitingForProtection()) return
-		if (!(event.currentTarget instanceof HTMLFormElement)) return
-		const form = event.currentTarget
-
-		const formData = new FormData(form)
-		const firstName = String(formData.get('firstName') ?? '').trim()
-		const email = String(formData.get('email') ?? '').trim()
-		const protection = readPublicFormProtection(formData)
-
-		if (!firstName) {
-			setState('error', 'What should we call you?')
-			form.querySelector<HTMLInputElement>('input[name="firstName"]')?.focus()
-			return
-		}
-		// Stricter than type=email alone: require a TLD so "you@example"
-		// bounces here, not at the server.
-		if (!/^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/.test(email)) {
-			setState('error', "That email doesn't look complete. Mind checking it?")
-			form.querySelector<HTMLInputElement>('input[name="email"]')?.focus()
-			return
-		}
-
-		setState('submitting')
-
-		try {
-			const response = await fetch('/waiting-list', {
-				method: 'POST',
-				headers: { 'Content-Type': 'application/json' },
-				credentials: 'include',
-				body: JSON.stringify({ firstName, email, ...protection }),
-			})
-			const payload = await response.json().catch(() => null)
-
-			if (!response.ok) {
-				const errorMessage =
-					typeof payload?.error === 'string'
-						? payload.error
-						: 'Unable to join the waiting list.'
-				// The form stays mounted for another try, and the token it
-				// carries has already been spent server-side.
-				resetTurnstileWidgets()
-				setState('error', errorMessage)
-				return
-			}
-
-			const successMessage =
-				typeof payload?.message === 'string'
-					? payload.message
-					: "You're on the list. We'll be in touch."
-			setState('success', successMessage)
-			// Success replaces the fields — including the submit button that
-			// currently holds focus — so focus has to be placed deliberately
-			// or it falls back to the top of the document.
-			handle.queueTask(() => {
-				form.querySelector<HTMLElement>('[data-waitlist-success]')?.focus()
-			})
-		} catch {
-			resetTurnstileWidgets()
-			setState('error', 'Network error. Please try again.')
-		}
-	}
-
-	return () => {
-		if (typeof document !== 'undefined' && protectionArmed) {
-			if (turnstileSiteKey === undefined) {
-				handle.queueTask(loadProtectionConfig)
-			} else if (turnstileSiteKey) {
-				handle.queueTask(async () => {
-					try {
-						await renderTurnstileWidgets(turnstileSiteKey ?? null)
-					} catch {
-						// Load/render failure must not pin the submit button
-						// disabled. A later POST can still surface the server
-						// error the way the immediate-load waitlist did.
-					}
-					if (widgetReady) return
-					widgetReady = true
-					handle.update()
-				})
-			}
-		}
-		const isSubmitting = status === 'submitting'
-		const protectionPending = waitingForProtection()
-		const submitDisabled = isSubmitting || protectionPending
-
-		return (
-			<form
-				noValidate
-				class="landing-waitlist"
-				mix={[
-					on('submit', handleSubmit),
-					ref((node, signal) => {
-						const stop = observeNearViewport(node, () => {
-							if (protectionArmed) return
-							protectionArmed = true
-							handle.update()
-						})
-						signal.addEventListener('abort', stop, { once: true })
-					}),
-				]}
-			>
-				{/*
-				 * A live region only announces text that changes while the
-				 * region is already in the accessibility tree, so the announcer
-				 * stays mounted for the life of the form. Success is left out:
-				 * that state unmounts the submit button, so focus moves to the
-				 * confirmation instead, which announces it once.
-				 */}
-				<p role="status" class="visually-hidden">
-					{status === 'success' ? '' : (message ?? '')}
-				</p>
-				{status === 'success' ? (
-					<p tabindex={-1} data-waitlist-success class="landing-form-success">
-						{message}{' '}
-						<button
-							type="button"
-							class="landing-form-reset"
-							mix={on('click', () => {
-								setState('idle')
-								handle.queueTask(() => {
-									document.getElementById(`${handle.id}-email`)?.focus()
-								})
-							})}
-						>
-							Wrong email?
-						</button>
-					</p>
-				) : (
-					<>
-						<div data-focus-container class="landing-waitlist-fields">
-							<input
-								type="text"
-								name={honeypotFieldName}
-								tabIndex={-1}
-								autoComplete="off"
-								aria-hidden="true"
-								class="visually-hidden landing-honeypot"
-							/>
-							<label for={`${handle.id}-name`} class="visually-hidden">
-								First name
-							</label>
-							<input
-								id={`${handle.id}-name`}
-								type="text"
-								name="firstName"
-								required
-								maxLength={80}
-								placeholder="First name"
-								autoComplete="given-name"
-								class="landing-waitlist-input"
-							/>
-							<label for={`${handle.id}-email`} class="visually-hidden">
-								Email address
-							</label>
-							<input
-								id={`${handle.id}-email`}
-								type="email"
-								name="email"
-								required
-								placeholder="you@yourdomain.dev"
-								autoComplete="email"
-								class="landing-waitlist-input landing-waitlist-email"
-							/>
-							<button
-								type="submit"
-								aria-disabled={submitDisabled ? 'true' : undefined}
-								aria-busy={isSubmitting ? 'true' : undefined}
-								class="landing-pill landing-pill-swap"
-							>
-								<span
-									data-swap-label
-									data-active={isSubmitting ? undefined : 'true'}
-									aria-hidden={isSubmitting ? 'true' : undefined}
-								>
-									Join the waiting list
-								</span>
-								<span
-									data-swap-label
-									data-active={isSubmitting ? 'true' : undefined}
-									aria-hidden={isSubmitting ? undefined : 'true'}
-								>
-									Joining…
-								</span>
-							</button>
-						</div>
-						{protectionArmed && turnstileSiteKey ? (
-							<div class={turnstileWidgetClassName}></div>
-						) : null}
-						{status === 'error' && message ? (
-							// Announced by the mounted live region above.
-							<p aria-hidden="true" class="landing-form-error">
-								{message}
-							</p>
-						) : null}
-					</>
-				)}
-			</form>
 		)
 	}
 }

--- a/packages/worker/client/routes/landing-waitlist-form.tsx
+++ b/packages/worker/client/routes/landing-waitlist-form.tsx
@@ -1,0 +1,249 @@
+import { type Handle, ref } from 'remix/ui'
+import { observeNearViewport } from '#client/deferred-turnstile.ts'
+import { on } from '#client/event-mixin.ts'
+import { fetchPublicAuthConfig } from '#client/social-sign-in.ts'
+import {
+	honeypotFieldName,
+	readPublicFormProtection,
+	renderTurnstileWidgets,
+	resetTurnstileWidgets,
+	turnstileWidgetClassName,
+} from '#client/public-form-protection.ts'
+
+/**
+ * Connected-pill waitlist form (name · divider · email · button) with an
+ * inline success swap. Posts to the real `/waiting-list` endpoint with the
+ * same honeypot + Turnstile protection as the signup page. The challenge
+ * script stays off first paint: it loads once the form is near the viewport.
+ */
+export function WaitlistForm(handle: Handle) {
+	type Status = 'idle' | 'submitting' | 'success' | 'error'
+	let status: Status = 'idle'
+	let message: string | null = null
+	let protectionArmed = false
+	let turnstileSiteKey: string | null | undefined
+	let widgetReady = false
+
+	async function loadProtectionConfig(signal: AbortSignal) {
+		if (turnstileSiteKey !== undefined) return
+		const config = await fetchPublicAuthConfig(signal)
+		if (signal.aborted) return
+		turnstileSiteKey = config?.turnstileSiteKey ?? null
+		handle.update()
+	}
+
+	function setState(nextStatus: Status, nextMessage: string | null = null) {
+		status = nextStatus
+		message = nextMessage
+		handle.update()
+	}
+
+	function waitingForProtection() {
+		if (!protectionArmed) return true
+		if (turnstileSiteKey === undefined) return true
+		return Boolean(turnstileSiteKey) && !widgetReady
+	}
+
+	async function handleSubmit(event: SubmitEvent) {
+		event.preventDefault()
+		if (status === 'submitting') return
+		if (waitingForProtection()) return
+		if (!(event.currentTarget instanceof HTMLFormElement)) return
+		const form = event.currentTarget
+
+		const formData = new FormData(form)
+		const firstName = String(formData.get('firstName') ?? '').trim()
+		const email = String(formData.get('email') ?? '').trim()
+		const protection = readPublicFormProtection(formData)
+
+		if (!firstName) {
+			setState('error', 'What should we call you?')
+			form.querySelector<HTMLInputElement>('input[name="firstName"]')?.focus()
+			return
+		}
+		// Stricter than type=email alone: require a TLD so "you@example"
+		// bounces here, not at the server.
+		if (!/^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/.test(email)) {
+			setState('error', "That email doesn't look complete. Mind checking it?")
+			form.querySelector<HTMLInputElement>('input[name="email"]')?.focus()
+			return
+		}
+
+		setState('submitting')
+
+		try {
+			const response = await fetch('/waiting-list', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				credentials: 'include',
+				body: JSON.stringify({ firstName, email, ...protection }),
+			})
+			const payload = await response.json().catch(() => null)
+
+			if (!response.ok) {
+				const errorMessage =
+					typeof payload?.error === 'string'
+						? payload.error
+						: 'Unable to join the waiting list.'
+				// The form stays mounted for another try, and the token it
+				// carries has already been spent server-side.
+				resetTurnstileWidgets()
+				setState('error', errorMessage)
+				return
+			}
+
+			const successMessage =
+				typeof payload?.message === 'string'
+					? payload.message
+					: "You're on the list. We'll be in touch."
+			setState('success', successMessage)
+			// Success replaces the fields — including the submit button that
+			// currently holds focus — so focus has to be placed deliberately
+			// or it falls back to the top of the document.
+			handle.queueTask(() => {
+				form.querySelector<HTMLElement>('[data-waitlist-success]')?.focus()
+			})
+		} catch {
+			resetTurnstileWidgets()
+			setState('error', 'Network error. Please try again.')
+		}
+	}
+
+	return () => {
+		if (typeof document !== 'undefined' && protectionArmed) {
+			if (turnstileSiteKey === undefined) {
+				handle.queueTask(loadProtectionConfig)
+			} else if (turnstileSiteKey) {
+				handle.queueTask(async () => {
+					try {
+						await renderTurnstileWidgets(turnstileSiteKey ?? null)
+					} catch {
+						// Load/render failure must not pin the submit button
+						// disabled. A later POST can still surface the server
+						// error the way the immediate-load waitlist did.
+					}
+					if (widgetReady) return
+					widgetReady = true
+					handle.update()
+				})
+			}
+		}
+		const isSubmitting = status === 'submitting'
+		const protectionPending = waitingForProtection()
+		const submitDisabled = isSubmitting || protectionPending
+
+		return (
+			<form
+				noValidate
+				class="landing-waitlist"
+				mix={[
+					on('submit', handleSubmit),
+					ref((node, signal) => {
+						const stop = observeNearViewport(node, () => {
+							if (protectionArmed) return
+							protectionArmed = true
+							handle.update()
+						})
+						signal.addEventListener('abort', stop, { once: true })
+					}),
+				]}
+			>
+				{/*
+				 * A live region only announces text that changes while the
+				 * region is already in the accessibility tree, so the announcer
+				 * stays mounted for the life of the form. Success is left out:
+				 * that state unmounts the submit button, so focus moves to the
+				 * confirmation instead, which announces it once.
+				 */}
+				<p role="status" class="visually-hidden">
+					{status === 'success' ? '' : (message ?? '')}
+				</p>
+				{status === 'success' ? (
+					<p tabindex={-1} data-waitlist-success class="landing-form-success">
+						{message}{' '}
+						<button
+							type="button"
+							class="landing-form-reset"
+							mix={on('click', () => {
+								setState('idle')
+								handle.queueTask(() => {
+									document.getElementById(`${handle.id}-email`)?.focus()
+								})
+							})}
+						>
+							Wrong email?
+						</button>
+					</p>
+				) : (
+					<>
+						<div data-focus-container class="landing-waitlist-fields">
+							<input
+								type="text"
+								name={honeypotFieldName}
+								tabIndex={-1}
+								autoComplete="off"
+								aria-hidden="true"
+								class="visually-hidden landing-honeypot"
+							/>
+							<label for={`${handle.id}-name`} class="visually-hidden">
+								First name
+							</label>
+							<input
+								id={`${handle.id}-name`}
+								type="text"
+								name="firstName"
+								required
+								maxLength={80}
+								placeholder="First name"
+								autoComplete="given-name"
+								class="landing-waitlist-input"
+							/>
+							<label for={`${handle.id}-email`} class="visually-hidden">
+								Email address
+							</label>
+							<input
+								id={`${handle.id}-email`}
+								type="email"
+								name="email"
+								required
+								placeholder="you@yourdomain.dev"
+								autoComplete="email"
+								class="landing-waitlist-input landing-waitlist-email"
+							/>
+							<button
+								type="submit"
+								aria-disabled={submitDisabled ? 'true' : undefined}
+								aria-busy={isSubmitting ? 'true' : undefined}
+								class="landing-pill landing-pill-swap"
+							>
+								<span
+									data-swap-label
+									data-active={isSubmitting ? undefined : 'true'}
+									aria-hidden={isSubmitting ? 'true' : undefined}
+								>
+									Join the waiting list
+								</span>
+								<span
+									data-swap-label
+									data-active={isSubmitting ? 'true' : undefined}
+									aria-hidden={isSubmitting ? undefined : 'true'}
+								>
+									Joining…
+								</span>
+							</button>
+						</div>
+						{protectionArmed && turnstileSiteKey ? (
+							<div class={turnstileWidgetClassName}></div>
+						) : null}
+						{status === 'error' && message ? (
+							// Announced by the mounted live region above.
+							<p aria-hidden="true" class="landing-form-error">
+								{message}
+							</p>
+						) : null}
+					</>
+				)}
+			</form>
+		)
+	}
+}

--- a/tools/file-size-ratchet.json
+++ b/tools/file-size-ratchet.json
@@ -9,7 +9,6 @@
 		"packages/worker/client/routes/admin-platform-integrations.tsx",
 		"packages/worker/client/routes/admin-users.tsx",
 		"packages/worker/client/routes/community-detail.tsx",
-		"packages/worker/client/routes/home.tsx",
 		"packages/worker/client/routes/login.tsx",
 		"packages/worker/client/routes/onboarding-mcp-client-tabs.tsx",
 		"packages/worker/client/routes/record-table.tsx"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Get `home.tsx` under the client-route file-size budget without changing landing behavior.

## Why

`home.tsx` was eight lines over the 800-line ratchet. The waitlist form already owned its own Turnstile, honeypot, and submit state, so it is a real module boundary rather than a cosmetic cut.

## Summary

- Move `WaitlistForm` to `landing-waitlist-form.tsx`.
- `home.tsx` keeps the landing loader, hero, and marketing sections (808 → 562).
- Drop `home.tsx` from `tools/file-size-ratchet.json`.

## Testing

- `npm run validate` passed on this branch (typecheck, slop ratchet, node-unit 2238, workers-unit 306, MCP e2e 5, Playwright 7).
- Local `dev:ensure` hung on `/health` after wrangler printed ready (known Cloud VM wrangler reload stall). Homepage waitlist will be checked on the preview origin once it is up.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `263de7f3` · **Head:** `c5660850`

**Classification:** composes — no primitives added or changed; this PR moves an existing landing form into its own module.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `app-ui` | surfaces | composes — waitlist form extract only |

### Change flow

The homepage still loads onboarding, code-runs, and signup mode, then renders the same waitlist form.

```mermaid
sequenceDiagram
	actor visitor as Visitor
	participant appUi as app-ui
	visitor->>appUi: GET /
	appUi->>appUi: HomeRoute keeps loader and marketing sections
	appUi->>appUi: WaitlistForm posts /waiting-list from landing-waitlist-form.tsx
```

### Before / after

| File | Before | After |
| ---- | ------ | ----- |
| `home.tsx` | 808 | 562 |
| `landing-waitlist-form.tsx` | — | 249 |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-25718c3a-21ed-492b-a38f-54c0d3a0fa36?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-25718c3a-21ed-492b-a38f-54c0d3a0fa36&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated landing-page waitlist form with first-name and email fields.
  * Added inline success confirmation with an option to submit again.
  * Added protected submission handling and clear status feedback.

* **Bug Fixes**
  * Improved email validation and error messaging.
  * Enhanced recovery after failed submissions so users can retry securely.
  * Added accessibility announcements for submission errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->