### PR TITLE
Fix onboarding Step 1 agent marks in dark mode

### DIFF
--- a/packages/worker/client/routes/onboarding-mcp-client-tabs.node.test.ts
+++ b/packages/worker/client/routes/onboarding-mcp-client-tabs.node.test.ts
@@ -1,6 +1,7 @@
 import { jsx } from 'remix/ui/jsx-runtime'
 import { renderToString } from 'remix/ui/server'
 import { expect, test } from 'vitest'
+import { colors } from '#universal/styles/tokens.ts'
 import { OnboardingMcpClientTabs } from './onboarding-mcp-client-tabs.tsx'
 import {
 	buildClaudeCodeAddCommand,
@@ -33,6 +34,12 @@ test('onboarding Step 1 picker selects an agent, then Not listed, and flips Grok
 	expect(picker).not.toContain(
 		'href="/onboarding?agent=grok-cli&amp;surface=desktop"',
 	)
+	expect(picker).toContain('/images/icons/cursor.svg')
+	expect(picker).toContain('/images/icons/grokbot.svg')
+	// Black Simple Icons sit on the shared white logo well so they stay
+	// readable when prefers-color-scheme is dark.
+	expect(picker).toContain(colors.logoWell)
+	expect(picker).toContain(colors.logoWellInk)
 
 	const cursor = await renderToString(
 		jsx(OnboardingMcpClientTabs, {

--- a/packages/worker/client/routes/onboarding-mcp-client-tabs.tsx
+++ b/packages/worker/client/routes/onboarding-mcp-client-tabs.tsx
@@ -54,6 +54,7 @@ import {
 import {
 	getAccentCalloutCss,
 	getGhostButtonCss,
+	getLogoWellCss,
 	getPillButtonCss,
 	hoverMq,
 } from '#universal/styles/style-primitives.ts'
@@ -1262,13 +1263,7 @@ const pickerCardCss = {
 	},
 }
 
-const pickerMarkCss = {
-	display: 'grid',
-	placeItems: 'center',
-	width: '2.4rem',
-	height: '2.4rem',
-	color: colors.text,
-}
+const pickerMarkCss = getLogoWellCss({ size: '2.4rem', radius: '12px' })
 
 const pickerIconImgCss = {
 	display: 'block',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Keep the Step 1 agent picker marks readable in dark mode.

## Why

The featured host marks are black Simple Icons (`fill="#000000"`) drawn straight on the page background. In `prefers-color-scheme: dark` they disappear into the card.

## Summary

- Sit Step 1 picker marks on the shared white logo well (`getLogoWellCss`), the same plate Step 2 cards and provider marks already use.
- Assert the picker HTML includes the well colors and the Cursor / Grok Bot icon URLs.

## Testing

- `npx vitest run --project node-unit packages/worker/client/routes/onboarding-mcp-client-tabs.node.test.ts`
- Preview + UI pass in dark mode after CI (ship-pr).

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `13aa2b46` · **Head:** `9701130a`

**Classification:** composes — no primitives added or changed; Step 1 marks reuse the existing logo-well plate.

### Primitives touched

| Primitive | Group    | Impact   |
| --------- | -------- | -------- |
| `app-ui`  | surfaces | composes |

### Change flow

Dark-mode Step 1 picker marks now render through the shared logo well instead of sitting on the page background.

```mermaid
sequenceDiagram
	actor User
	participant appUi as app-ui
	User->>appUi: open /onboarding Step 1
	appUi->>appUi: render picker marks with getLogoWellCss
	Note over appUi: white logoWell plate keeps black Simple Icons readable
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1384f0fd-3e7f-473b-9dd3-daa0c53bbabf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1384f0fd-3e7f-473b-9dd3-daa0c53bbabf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the onboarding agent picker icons with consistent shared logo-well styling.
  * Improved icon appearance across light and dark modes, including clearer contrast for black icons.
  * Applied rounded corners and standardized sizing to picker marks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->