### PR TITLE
Split record-table toolbar controls out of the shared table module.

### DIFF
--- a/packages/worker/client/routes/record-table-controls.tsx
+++ b/packages/worker/client/routes/record-table-controls.tsx
@@ -1,0 +1,272 @@
+import { css, ref, type Handle, type RemixNode } from 'remix/ui'
+import { on } from '#client/event-mixin.ts'
+import {
+	colors,
+	radius,
+	spacing,
+	typography,
+} from '#universal/styles/tokens.ts'
+import {
+	getAuthInputCss,
+	getSelectCss,
+} from '#universal/styles/style-primitives.ts'
+import {
+	acknowledgeRecordTableSearchInput,
+	reconcileRecordTableSearchExternalValue,
+	type RecordTableSearchSync,
+} from './record-table-search-sync.ts'
+
+type Slot = RemixNode
+
+/*
+ * Toolbar controls. These came out of a sidebar that stacked a visible label
+ * over each field and spent ~230px of height on three of them; on one row
+ * they cost 48px, so the label becomes the control's accessible name.
+ */
+
+/**
+ * Live filter fields write the query into the URL on every keystroke. A
+ * Remix-controlled `value` lets the first character schedule a restore of the
+ * previous (empty) query, and WebKit's search cancel control appears on that
+ * same keystroke — either one drops focus and the reader has to click back in.
+ * The field stays uncontrolled. URL/back-button updates apply immediately
+ * when it is not focused, and on blur if they arrived while it was. A
+ * keystroke records the typed string as the last applied value so a later
+ * render that returns `q` to that value (clear, or back to the same query)
+ * cannot leave a stale pending string for blur to write back.
+ */
+const searchCancelHiddenCss = {
+	'&::-webkit-search-decoration': {
+		WebkitAppearance: 'none',
+		appearance: 'none',
+	},
+	'&::-webkit-search-cancel-button': {
+		WebkitAppearance: 'none',
+		appearance: 'none',
+		display: 'none',
+	},
+	'&::-webkit-search-results-button': {
+		WebkitAppearance: 'none',
+		appearance: 'none',
+	},
+	'&::-webkit-search-results-decoration': {
+		WebkitAppearance: 'none',
+		appearance: 'none',
+	},
+} as const
+
+export function RecordTableSearch(
+	handle: Handle<{
+		label: string
+		placeholder: string
+		value: string
+		onInput: (value: string) => void
+	}>,
+) {
+	let input: HTMLInputElement | null = null
+	const initialValue = handle.props.value
+	let sync: RecordTableSearchSync = {
+		lastExternalValue: initialValue,
+		pendingExternalValue: null,
+	}
+
+	function applyExternalValue(nextValue: string) {
+		if (input) input.value = nextValue
+		sync = acknowledgeRecordTableSearchInput(nextValue)
+	}
+
+	return () => {
+		const nextValue = handle.props.value
+		const focused = Boolean(input && document.activeElement === input)
+		const reconciled = reconcileRecordTableSearchExternalValue(
+			sync,
+			nextValue,
+			focused,
+		)
+		sync = reconciled.state
+		if (reconciled.applyValue !== null)
+			applyExternalValue(reconciled.applyValue)
+		return (
+			<input
+				type="search"
+				data-field-ring
+				defaultValue={initialValue}
+				placeholder={handle.props.placeholder}
+				aria-label={handle.props.label}
+				mix={[
+					ref((node, signal) => {
+						input = node as HTMLInputElement
+						signal.addEventListener('abort', () => {
+							if (input === node) input = null
+						})
+					}),
+					on('input', (event) => {
+						const value = (event.currentTarget as HTMLInputElement).value
+						sync = acknowledgeRecordTableSearchInput(value)
+						handle.props.onInput(value)
+					}),
+					on('blur', () => {
+						if (sync.pendingExternalValue !== null) {
+							applyExternalValue(sync.pendingExternalValue)
+						}
+					}),
+					css({
+						...getAuthInputCss(),
+						flex: '1 1 12rem',
+						minWidth: '7rem',
+						width: 'auto',
+						...searchCancelHiddenCss,
+					}),
+				]}
+			/>
+		)
+	}
+}
+
+export function RecordTableSelect(
+	handle: Handle<{
+		label: string
+		value: string
+		onChange: (value: string) => void
+		children: Slot
+	}>,
+) {
+	return () => (
+		<select
+			data-field-ring
+			value={handle.props.value}
+			aria-label={handle.props.label}
+			mix={[
+				on('change', (event) =>
+					handle.props.onChange(
+						(event.currentTarget as HTMLSelectElement).value,
+					),
+				),
+				css({
+					...getSelectCss(),
+					width: 'auto',
+					flex: 'none',
+					'@container (max-width: 620px)': { flex: '1 1 8rem' },
+				}),
+			]}
+		>
+			{handle.props.children}
+		</select>
+	)
+}
+
+/**
+ * One-line cell text with an ellipsis. A table cell will not shrink below its
+ * content, so the clamp has to live on a block inside it — and the width is
+ * `min(…, 100%)` because below 620px that block sits in a card that can be
+ * narrower than the clamp itself.
+ */
+export function recordCellClamp(ch: number) {
+	return {
+		display: 'block',
+		minWidth: 0,
+		maxWidth: `min(${ch}ch, 100%)`,
+		overflow: 'hidden',
+		textOverflow: 'ellipsis',
+		whiteSpace: 'nowrap' as const,
+	}
+}
+
+/** Date/duration cell: one token, aligned figures, quieter than the name. */
+export const recordStampCss = {
+	whiteSpace: 'nowrap' as const,
+	fontVariantNumeric: 'tabular-nums',
+	color: colors.textMuted,
+	fontSize: '0.84rem',
+}
+
+export const visuallyHiddenCss = {
+	position: 'absolute' as const,
+	width: '1px',
+	height: '1px',
+	padding: 0,
+	margin: '-1px',
+	overflow: 'hidden',
+	clip: 'rect(0 0 0 0)',
+	whiteSpace: 'nowrap' as const,
+	border: 0,
+}
+
+/**
+ * A boolean column reads as a mark you can scan down, not a word you have to
+ * read on every row. The title carries the meaning for anyone who needs it.
+ */
+export function RecordDot(handle: Handle<{ active: boolean; title: string }>) {
+	return () => (
+		<span
+			title={handle.props.title}
+			mix={css({
+				display: 'inline-grid',
+				placeContent: 'center',
+				width: '1.2rem',
+				height: '1.2rem',
+				borderRadius: radius.full,
+				border: `1px solid ${handle.props.active ? colors.primary : colors.border}`,
+				backgroundColor: handle.props.active
+					? colors.primarySoft
+					: 'transparent',
+				color: handle.props.active ? colors.primaryText : colors.textMuted,
+				fontSize: '0.68rem',
+			})}
+		>
+			<span aria-hidden="true">{handle.props.active ? '●' : '–'}</span>
+			<span mix={css(visuallyHiddenCss)}>{handle.props.title}</span>
+		</span>
+	)
+}
+
+const chipCss = {
+	display: 'inline-block',
+	padding: `0 ${spacing.sm}`,
+	borderRadius: radius.md,
+	border: `1px solid ${colors.border}`,
+	backgroundColor: colors.surface,
+	color: colors.textMuted,
+	fontSize: typography.fontSize.xs,
+	lineHeight: '1.5rem',
+	whiteSpace: 'nowrap' as const,
+}
+
+const activeChipCss = {
+	...chipCss,
+	borderColor: colors.primary,
+	color: colors.primaryText,
+	backgroundColor: colors.primarySoft,
+}
+
+/** Tags, roles, scopes — a short set of labels in one cell or one band field. */
+export function RecordChips(
+	handle: Handle<{ items: Array<string>; active?: boolean; empty?: string }>,
+) {
+	return () => {
+		if (handle.props.items.length === 0) {
+			return handle.props.empty ? (
+				<span mix={css({ color: colors.textMuted })}>{handle.props.empty}</span>
+			) : null
+		}
+		return (
+			<span
+				mix={css({
+					display: 'flex',
+					gap: '0.3rem',
+					flexWrap: 'wrap',
+					overflow: 'hidden',
+				})}
+			>
+				{handle.props.items.map((item) => (
+					<span
+						key={item}
+						mix={css(handle.props.active ? activeChipCss : chipCss)}
+					>
+						{item}
+					</span>
+				))}
+			</span>
+		)
+	}
+}

--- a/packages/worker/client/routes/record-table.tsx
+++ b/packages/worker/client/routes/record-table.tsx
@@ -1,24 +1,26 @@
-import { css, ref, type Handle, type RemixNode } from 'remix/ui'
+import { css, type Handle, type RemixNode } from 'remix/ui'
 import { shouldRouterHandleClick } from '#client/client-router.tsx'
 import { on } from '#client/event-mixin.ts'
 import {
 	colors,
-	radius,
 	spacing,
 	transitions,
 	typography,
 } from '#universal/styles/tokens.ts'
 import {
-	getAuthInputCss,
-	getSelectCss,
 	getSurfaceCardCss,
 	hoverMq,
 } from '#universal/styles/style-primitives.ts'
-import {
-	acknowledgeRecordTableSearchInput,
-	reconcileRecordTableSearchExternalValue,
-	type RecordTableSearchSync,
-} from './record-table-search-sync.ts'
+import { visuallyHiddenCss } from './record-table-controls.tsx'
+
+export {
+	RecordChips,
+	RecordDot,
+	RecordTableSearch,
+	RecordTableSelect,
+	recordCellClamp,
+	recordStampCss,
+} from './record-table-controls.tsx'
 
 /*
  * The account and admin list/detail screens, as one table.
@@ -376,259 +378,6 @@ const footerCss = {
 	display: 'grid',
 	padding: spacing.sm,
 	borderTop: `1px solid ${colors.border}`,
-}
-
-/*
- * Toolbar controls. These came out of a sidebar that stacked a visible label
- * over each field and spent ~230px of height on three of them; on one row
- * they cost 48px, so the label becomes the control's accessible name.
- */
-
-/**
- * Live filter fields write the query into the URL on every keystroke. A
- * Remix-controlled `value` lets the first character schedule a restore of the
- * previous (empty) query, and WebKit's search cancel control appears on that
- * same keystroke — either one drops focus and the reader has to click back in.
- * The field stays uncontrolled. URL/back-button updates apply immediately
- * when it is not focused, and on blur if they arrived while it was. A
- * keystroke records the typed string as the last applied value so a later
- * render that returns `q` to that value (clear, or back to the same query)
- * cannot leave a stale pending string for blur to write back.
- */
-const searchCancelHiddenCss = {
-	'&::-webkit-search-decoration': {
-		WebkitAppearance: 'none',
-		appearance: 'none',
-	},
-	'&::-webkit-search-cancel-button': {
-		WebkitAppearance: 'none',
-		appearance: 'none',
-		display: 'none',
-	},
-	'&::-webkit-search-results-button': {
-		WebkitAppearance: 'none',
-		appearance: 'none',
-	},
-	'&::-webkit-search-results-decoration': {
-		WebkitAppearance: 'none',
-		appearance: 'none',
-	},
-} as const
-
-export function RecordTableSearch(
-	handle: Handle<{
-		label: string
-		placeholder: string
-		value: string
-		onInput: (value: string) => void
-	}>,
-) {
-	let input: HTMLInputElement | null = null
-	const initialValue = handle.props.value
-	let sync: RecordTableSearchSync = {
-		lastExternalValue: initialValue,
-		pendingExternalValue: null,
-	}
-
-	function applyExternalValue(nextValue: string) {
-		if (input) input.value = nextValue
-		sync = acknowledgeRecordTableSearchInput(nextValue)
-	}
-
-	return () => {
-		const nextValue = handle.props.value
-		const focused = Boolean(input && document.activeElement === input)
-		const reconciled = reconcileRecordTableSearchExternalValue(
-			sync,
-			nextValue,
-			focused,
-		)
-		sync = reconciled.state
-		if (reconciled.applyValue !== null)
-			applyExternalValue(reconciled.applyValue)
-		return (
-			<input
-				type="search"
-				data-field-ring
-				defaultValue={initialValue}
-				placeholder={handle.props.placeholder}
-				aria-label={handle.props.label}
-				mix={[
-					ref((node, signal) => {
-						input = node as HTMLInputElement
-						signal.addEventListener('abort', () => {
-							if (input === node) input = null
-						})
-					}),
-					on('input', (event) => {
-						const value = (event.currentTarget as HTMLInputElement).value
-						sync = acknowledgeRecordTableSearchInput(value)
-						handle.props.onInput(value)
-					}),
-					on('blur', () => {
-						if (sync.pendingExternalValue !== null) {
-							applyExternalValue(sync.pendingExternalValue)
-						}
-					}),
-					css({
-						...getAuthInputCss(),
-						flex: '1 1 12rem',
-						minWidth: '7rem',
-						width: 'auto',
-						...searchCancelHiddenCss,
-					}),
-				]}
-			/>
-		)
-	}
-}
-
-export function RecordTableSelect(
-	handle: Handle<{
-		label: string
-		value: string
-		onChange: (value: string) => void
-		children: Slot
-	}>,
-) {
-	return () => (
-		<select
-			data-field-ring
-			value={handle.props.value}
-			aria-label={handle.props.label}
-			mix={[
-				on('change', (event) =>
-					handle.props.onChange(
-						(event.currentTarget as HTMLSelectElement).value,
-					),
-				),
-				css({
-					...getSelectCss(),
-					width: 'auto',
-					flex: 'none',
-					'@container (max-width: 620px)': { flex: '1 1 8rem' },
-				}),
-			]}
-		>
-			{handle.props.children}
-		</select>
-	)
-}
-
-/**
- * One-line cell text with an ellipsis. A table cell will not shrink below its
- * content, so the clamp has to live on a block inside it — and the width is
- * `min(…, 100%)` because below 620px that block sits in a card that can be
- * narrower than the clamp itself.
- */
-export function recordCellClamp(ch: number) {
-	return {
-		display: 'block',
-		minWidth: 0,
-		maxWidth: `min(${ch}ch, 100%)`,
-		overflow: 'hidden',
-		textOverflow: 'ellipsis',
-		whiteSpace: 'nowrap' as const,
-	}
-}
-
-/** Date/duration cell: one token, aligned figures, quieter than the name. */
-export const recordStampCss = {
-	whiteSpace: 'nowrap' as const,
-	fontVariantNumeric: 'tabular-nums',
-	color: colors.textMuted,
-	fontSize: '0.84rem',
-}
-
-/**
- * A boolean column reads as a mark you can scan down, not a word you have to
- * read on every row. The title carries the meaning for anyone who needs it.
- */
-export function RecordDot(handle: Handle<{ active: boolean; title: string }>) {
-	return () => (
-		<span
-			title={handle.props.title}
-			mix={css({
-				display: 'inline-grid',
-				placeContent: 'center',
-				width: '1.2rem',
-				height: '1.2rem',
-				borderRadius: radius.full,
-				border: `1px solid ${handle.props.active ? colors.primary : colors.border}`,
-				backgroundColor: handle.props.active
-					? colors.primarySoft
-					: 'transparent',
-				color: handle.props.active ? colors.primaryText : colors.textMuted,
-				fontSize: '0.68rem',
-			})}
-		>
-			<span aria-hidden="true">{handle.props.active ? '●' : '–'}</span>
-			<span mix={css(visuallyHiddenCss)}>{handle.props.title}</span>
-		</span>
-	)
-}
-
-const visuallyHiddenCss = {
-	position: 'absolute' as const,
-	width: '1px',
-	height: '1px',
-	padding: 0,
-	margin: '-1px',
-	overflow: 'hidden',
-	clip: 'rect(0 0 0 0)',
-	whiteSpace: 'nowrap' as const,
-	border: 0,
-}
-
-const chipCss = {
-	display: 'inline-block',
-	padding: `0 ${spacing.sm}`,
-	borderRadius: radius.md,
-	border: `1px solid ${colors.border}`,
-	backgroundColor: colors.surface,
-	color: colors.textMuted,
-	fontSize: typography.fontSize.xs,
-	lineHeight: '1.5rem',
-	whiteSpace: 'nowrap' as const,
-}
-
-const activeChipCss = {
-	...chipCss,
-	borderColor: colors.primary,
-	color: colors.primaryText,
-	backgroundColor: colors.primarySoft,
-}
-
-/** Tags, roles, scopes — a short set of labels in one cell or one band field. */
-export function RecordChips(
-	handle: Handle<{ items: Array<string>; active?: boolean; empty?: string }>,
-) {
-	return () => {
-		if (handle.props.items.length === 0) {
-			return handle.props.empty ? (
-				<span mix={css({ color: colors.textMuted })}>{handle.props.empty}</span>
-			) : null
-		}
-		return (
-			<span
-				mix={css({
-					display: 'flex',
-					gap: '0.3rem',
-					flexWrap: 'wrap',
-					overflow: 'hidden',
-				})}
-			>
-				{handle.props.items.map((item) => (
-					<span
-						key={item}
-						mix={css(handle.props.active ? activeChipCss : chipCss)}
-					>
-						{item}
-					</span>
-				))}
-			</span>
-		)
-	}
 }
 
 export function RecordTable(handle: Handle<RecordTableProps>) {

--- a/tools/file-size-ratchet.json
+++ b/tools/file-size-ratchet.json
@@ -9,8 +9,7 @@
 		"packages/worker/client/routes/admin-users.tsx",
 		"packages/worker/client/routes/community-detail.tsx",
 		"packages/worker/client/routes/login.tsx",
-		"packages/worker/client/routes/onboarding-mcp-client-tabs.tsx",
-		"packages/worker/client/routes/record-table.tsx"
+		"packages/worker/client/routes/onboarding-mcp-client-tabs.tsx"
 	],
 	"node-tests": [
 		"packages/worker/src/account/export.node.test.ts",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Get `record-table.tsx` under the client-route file-size budget without changing list/detail table behavior.

## Why

`record-table.tsx` was 837 lines — the last Cursor-claimed leftover on the 800-line client-route ratchet. Toolbar widgets already lived as their own exports; this extract makes that file split explicit.

## Summary

- Move `RecordTableSearch`, `RecordTableSelect`, `RecordDot`, `RecordChips`, `recordCellClamp`, and `recordStampCss` to `record-table-controls.tsx`.
- Re-export those symbols from `record-table.tsx` so existing `#client/routes/record-table.tsx` import sites stay put.
- The table module keeps types, selection, and `RecordTable` (837 → 586).
- Drop `record-table.tsx` from `tools/file-size-ratchet.json`.

## Testing

- `npm run file-size-ratchet:check` passed.
- `vitest run --project node-unit` for `record-table.node.test.ts` and `check-file-size-ratchet.node.test.ts`: 7 passed.
- Worker typecheck passed on the extract commit.
- Validate green (Static, Node, Workers, MCP, E2E). Bugbot passed with no comments.
- Preview deploy first failed on a Cloudflare 10021 D1 bind flake for `kody-pr-1863-jobs`; rerun succeeded.
- `npm run preview:manual-test -- --pr 1863` as `user-me`: `/account/email.json`, `/account/email`, and `/account/mcp-servers` all 200.
- Browser pass on https://kody-pr-1863.kody-a99.workers.dev: email search+classification select keep focus; MCP servers search keeps focus; jobs search+status select keep focus. Empty states stay intact.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `64c38134` · **Head:** `76f3d7ef`

**Classification:** composes — no primitives added or changed; this PR splits toolbar widgets out of the shared record table.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `app-ui` | surfaces | composes — record-table extract only |

### Change flow

Account and admin list screens still import toolbar widgets from `record-table.tsx`. Those widgets now live in a sibling module and are re-exported from the original path.

```mermaid
sequenceDiagram
	actor screen as Account or admin list
	participant appUi as app-ui
	screen->>appUi: import RecordTable and toolbar widgets
	appUi->>appUi: record-table.tsx re-exports search, select, chips, dots, clamp
	appUi->>appUi: record-table-controls.tsx owns the toolbar widgets
	appUi-->>screen: same public exports, smaller table module
```

### Before / after

| File | Before | After |
| ---- | ------ | ----- |
| `record-table.tsx` | 837 | 586 |
| `record-table-controls.tsx` | — | 272 |

</details>

<!-- system-recap:end -->

![Email inbox search and classification select](https://cursor.com/artifacts/c/art-e3af0989-d5ef-4436-8b5c-c7383a5bbf80)
![MCP servers search toolbar](https://cursor.com/artifacts/c/art-aeb61efb-97cb-4937-953e-df3ea10dff77)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-25718c3a-21ed-492b-a38f-54c0d3a0fa36?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-25718c3a-21ed-492b-a38f-54c0d3a0fa36&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reusable record table controls, including search, select filters, status indicators, and label chips.
  * Improved search behavior when navigating with browser history or changing URL values.
  * Added accessible labels, hidden helper text, and empty-state support for table controls.

* **Refactor**
  * Consolidated record table controls for easier reuse while preserving existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->