### PR TITLE
Trim completed-cutover historical residue from worker runbooks

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -139,10 +139,8 @@ jobs:
             echo "Nx cache worker deploy: skipped (no relevant path changes)."
           fi
 
-  # The jobs worker deploys before the main worker on every production
-  # deploy: its JobManager script-transfer migration must run while the main
-  # worker still owns the class, and the main worker's JOBS service binding
-  # requires the jobs worker script to exist. See
+  # The jobs worker deploys before origin so origin's JOBS service binding
+  # can validate against an existing jobs-worker script. See
   # docs/contributing/architecture/jobs-worker-migration-runbook.md.
   deploy-highlight-worker:
     runs-on: ubuntu-latest
@@ -453,9 +451,8 @@ jobs:
             --out-config packages/runtime-worker/wrangler-production.generated.json | tee -a "$GITHUB_OUTPUT"
 
       # Platform Durable Object worker (ADR 0034). Shares the origin worker's
-      # data plane and applies transferred_classes while the still-running
-      # origin script owns those classes. Deploy this script before runtime
-      # and origin retarget their bindings.
+      # data plane. Deploy this script before runtime and origin so their
+      # cross-script bindings target a live kody-platform script.
       - name: 🧩 Generate platform worker config
         id: platform_config
         if: >-
@@ -657,8 +654,8 @@ jobs:
             deploy_delay_seconds=$((deploy_delay_seconds * 2))
           done
 
-      # Deploys before runtime and origin: applies transferred_classes while
-      # the still-running origin script owns those classes. See
+      # Deploys before runtime and origin so cross-script Durable Object
+      # bindings stay valid. See
       # docs/contributing/architecture/platform-worker-migration-runbook.md.
       - name: ☁️ Deploy platform worker to Cloudflare Workers
         id: deploy_platform
@@ -713,10 +710,8 @@ jobs:
             echo "url=$PLATFORM_URL" >> "$GITHUB_OUTPUT"
           fi
 
-      # Deploys before the main worker: the main worker's cross-script
-      # Durable Object / service bindings require the kody-runtime script to
-      # exist. On the first production deploy this also runs the
-      # transferred_classes migration; see
+      # Deploys before origin so origin's cross-script Durable Object and
+      # service bindings target a live kody-runtime script. See
       # docs/contributing/architecture/runtime-worker-migration-runbook.md.
       - name: ☁️ Deploy runtime worker to Cloudflare Workers
         id: deploy_runtime

--- a/docs/contributing/architecture/index.md
+++ b/docs/contributing/architecture/index.md
@@ -78,18 +78,17 @@ smoke does not prove MCP execute health.
 - [Run records](./run-records.md): per-user execution history and logs across
   every runtime surface (`RunLog` Durable Object, `runs` MCP domain,
   `/account/activity`).
-- [Runtime worker migration runbook](./runtime-worker-migration-runbook.md): the
-  coordinated deploy order and Durable Object script migration for extracting
-  the package runtime lane into the `kody-runtime` Worker
+- [Runtime worker migration runbook](./runtime-worker-migration-runbook.md):
+  ownership of the package runtime lane on `kody-runtime` and the deploy
+  invariants later uploads must keep
   ([ADR 0016](../decisions/0016-mono-worker-extraction.md)).
 - [Platform worker migration runbook](./platform-worker-migration-runbook.md):
-  Durable Object script migration for extracting the remaining platform classes
-  onto the `kody-platform` Worker so the origin script owns none
+  ownership of remaining platform Durable Object classes on `kody-platform` and
+  the deploy invariants that keep origin owning none
   ([ADR 0034](../decisions/0034-origin-owns-no-durable-objects.md)).
-- [Jobs worker migration runbook](./jobs-worker-migration-runbook.md): Durable
-  Object transfer and bounded D1 copy for extracting the jobs/scheduled lane
-  into the `kody-jobs` Worker
-  ([ADR 0016](../decisions/0016-mono-worker-extraction.md)).
+- [Jobs worker migration runbook](./jobs-worker-migration-runbook.md): ownership
+  of `JobManager` and `JOBS_DB` on `kody-jobs` and the deploy invariants later
+  uploads must keep ([ADR 0016](../decisions/0016-mono-worker-extraction.md)).
 - [Values retirement runbook](./values-retirement-runbook.md): absorb values
   into memories, package storage, repos, secrets, and integrations
   ([ADR 0022](../decisions/0022-retire-values-primitive.md)).

--- a/docs/contributing/architecture/jobs-worker-migration-runbook.md
+++ b/docs/contributing/architecture/jobs-worker-migration-runbook.md
@@ -5,9 +5,6 @@ Production owns `JobManager`, `JOBS_DB`, and the five-minute cron on
 transfer or add `deleted_classes` for `JobManager`.
 
 This page records current ownership and the invariants later deploys must keep.
-The cutover that landed is in the
-[historical appendix](#historical-appendix-2026-jobs-cutover). Do not follow
-that appendix as a live playbook.
 
 Operational notes for the dedicated jobs worker (`packages/jobs-worker`, ADR
 [0016 — Mono-worker extraction](../decisions/0016-mono-worker-extraction.md)).
@@ -64,46 +61,3 @@ and queue consumption on `kody-scheduled-dispatch`), a due job running
 end-to-end (`JobManager` alarm → `HOST.runDueJobsForUser` → a run in the user's
 activity), and dashboards (`/account/jobs`) plus MCP `jobs_*` listing `JOBS_DB`
 rows.
-
-## Historical appendix: 2026 jobs cutover
-
-**Do not re-run these steps.** They describe the one-shot Durable Object
-transfer and bounded D1 copy that already landed. Re-exporting `jobs` /
-`archived_job_artifacts` from `APP_DB` fails: those tables are gone. Re-issuing
-`transferred_classes` or adding `deleted_classes` for `JobManager` destroys or
-orphans production scheduling state.
-
-Two coordinated moves landed:
-
-1. **Durable Object transfer** — `JobManager` moved from the deployed
-   `kody-production` script to the `kody-jobs` script via `transferred_classes`,
-   keeping every existing per-user DO's storage and alarm.
-2. **Bounded D1 data migration** — `jobs` and `archived_job_artifacts` rows
-   copied from `APP_DB` (`kody-db`) into `JOBS_DB` during a brief write pause
-   (job create/update/delete and finalization only). Dual-write was not used.
-   After the read/write flip, `APP_DB` held a cold copy until
-   `packages/worker/migrations/0010-drop-jobs-tables.sql` removed those tables.
-
-Coordinated order that landed:
-
-1. Provision `kody-jobs` D1 and the `kody-scheduled-dispatch` /
-   `kody-scheduled-dispatch-dlq` queues (`tools/ci/jobs-worker-resources.ts`).
-2. Apply the jobs D1 schema on `JOBS_DB`.
-3. Pause job mutation surfaces (or wait for a quiet window).
-4. Export the two tables from `APP_DB` and import into `JOBS_DB`; verify row
-   counts.
-5. Deploy `kody-jobs` (applied `v1` `transferred_classes`).
-6. Deploy origin without a `JobManager` export, jobs cron, or scheduled-queue
-   consumer — the read/write flip onto the `JOBS` binding.
-7. Unpause; confirm cron, a due job, and dashboard/MCP lists.
-8. After every remaining `APP_DB` reader of those tables was ported to the JOBS
-   service contract, apply 0010. That migration is in the schema. There is no
-   cold copy left on `APP_DB`.
-
-Recovery after the transfer applied: roll _forward_ on `kody-jobs`. A reverse
-`transferred_classes` migration (`from_script: "kody-jobs"`) was the escape
-hatch to hand the namespace back; do not use it under incident pressure. There
-is no `APP_DB` rollback copy.
-
-Leftovers that wait on a later drop follow
-[Cleanup after migrations](../cleanup-after-migrations.md).

--- a/docs/contributing/architecture/platform-worker-migration-runbook.md
+++ b/docs/contributing/architecture/platform-worker-migration-runbook.md
@@ -5,9 +5,6 @@ Production owns the platform Durable Object classes on `kody-platform`.
 add `deleted_classes` for those names.
 
 This page records current ownership and the invariants later deploys must keep.
-The cutover that landed is in the
-[historical appendix](#historical-appendix-2026-platform-cutover). Do not follow
-that appendix as a live playbook.
 
 How the remaining platform Durable Objects live on the `kody-platform` Worker
 (`packages/platform-worker/`), per
@@ -83,34 +80,3 @@ runtime and jobs, so those Durable Objects are not reset.
 
 Healthchecks: origin `/health`, platform `/__platform/health`, runtime
 `/__runtime/health`.
-
-## Historical appendix: 2026 platform cutover
-
-**Do not re-run these steps.** They describe the one-shot script migration that
-already landed. Re-issuing `transferred_classes` or adding `deleted_classes` for
-the names above destroys or orphans production Durable Object storage.
-
-The storage of `MCP`, `McpClientHub`, `OAuthPurgeCoordinator`, `UserMeter`,
-`Mailbox`, `RepoSession`, `RepoSessionIndex`, and `StripePlanRefresh` moved from
-the `kody` script to the `kody-platform` script via a Wrangler
-`transferred_classes` migration.
-
-Coordinated order that landed (encoded in `.github/workflows/deploy.yml`):
-
-1. Preview verification on a fresh `kody-pr-<n>` set (healthchecks, sign-in,
-   account/mailbox/session surfaces, unauthenticated `GET /mcp` → 401). Preview
-   used `new_sqlite_classes`, so it did not rehearse the transfer.
-2. Deploy `kody-platform` first — this applied the `v1` `transferred_classes`
-   migration. From that moment the still-running old `kody` deployment served
-   those objects against namespaces that had moved. Alarms on `Mailbox`,
-   `RepoSessionIndex`, and `StripePlanRefresh` moved with the classes.
-3. Deploy `kody-runtime` with platform bindings retargeted to `kody-platform`.
-4. Deploy `kody` with `script_name: "kody-platform"` on those eight classes.
-5. Healthchecks, then execute smoke. Post-deploy checks loaded pre-cutover
-   account, mailbox, and repo-session objects and confirmed an existing MCP
-   session still resumed.
-
-After the transfer applied, the recovery path was roll _forward_ on
-`kody-platform`. A reverse `transferred_classes` migration is a second risky
-migration and needs its own reviewed config change; deploy guardrails refuse
-unreviewed migration edits.

--- a/docs/contributing/architecture/runtime-worker-migration-runbook.md
+++ b/docs/contributing/architecture/runtime-worker-migration-runbook.md
@@ -5,9 +5,6 @@ routes on `kody-runtime`. `transferred_classes` is a one-shot cutover; do not
 invent a second transfer or add `deleted_classes` for those names.
 
 This page records current ownership and the invariants later deploys must keep.
-The cutover that landed is in the
-[historical appendix](#historical-appendix-2026-runtime-cutover). Do not follow
-that appendix as a live playbook.
 
 How the package runtime lane lives on the `kody-runtime` Worker
 (`packages/runtime-worker/`), per
@@ -99,45 +96,3 @@ together so they elide.
 `PackageServiceInstance` is gone from production `kody-runtime` (tag `v2`; no
 stub export). Preview applies `v1` `new_sqlite_classes` then `v2`
 `deleted_classes` on first deploy so create and delete elide.
-
-## Historical appendix: 2026 runtime cutover
-
-**Do not re-run these steps.** They describe the one-shot script migration that
-already landed. Re-issuing `transferred_classes`, detaching `kody.run` /
-`kodyapps.dev` zone routes, or adding `deleted_classes` for the live runtime
-classes destroys or orphans production storage and unserves package-app traffic.
-
-The storage of `StorageRunner`, `RunLog`, and `PackageRealtimeSession` moved
-from the `kody` script to the `kody-runtime` script via a Wrangler
-`transferred_classes` migration. `PackageServiceInstance` transferred in the
-same `v1` tag and was later removed with tag `v2`.
-
-`DynamicCallableWorkflow` was created on `kody-runtime` as a new workflow.
-Instances still running on the old `kody`-owned workflow at cutover were
-orphaned once origin stopped exporting that binding.
-
-Coordinated order that landed:
-
-1. Preview verification on a fresh worker set (healthchecks, `/apps/...` package
-   app, an end-to-end invocation). Preview used `new_sqlite_classes`.
-2. One-time detach of leftover `kody.run` / `kodyapps.dev` custom domains or
-   zone routes from the main worker so the first `kody-runtime` deploy could
-   publish those zone routes. That detach window is closed; the routes belong to
-   `kody-runtime`.
-3. Deploy `kody-runtime` first — this applied the `v1` `transferred_classes`
-   migration. There was no maintenance-mode traffic gate (ADR 0016): requests
-   that hit the old `kody` deployment in that seconds-long window failed.
-4. Deploy `kody` with `script_name: "kody-runtime"` on the three classes plus
-   the `RUNTIME_WORKER` service binding.
-5. Healthchecks and execute smoke. Post-deploy checks loaded a production
-   package app on `{username}.kody.run`, ran an invocation (RunLog storage
-   transferred, not recreated empty), and opened a pre-migration run's logs.
-
-After the transfer applied, the recovery path was roll _forward_ on
-`kody-runtime`. A reverse `transferred_classes` migration is a second risky
-migration and needs its own reviewed config change; deploy guardrails refuse
-unreviewed migration edits. The main worker can roll back independently as long
-as its config keeps the cross-script bindings.
-
-Leftovers that wait on a later tag or deploy follow
-[Cleanup after migrations](../cleanup-after-migrations.md).

--- a/docs/contributing/decisions/0022-retire-values-primitive.md
+++ b/docs/contributing/decisions/0022-retire-values-primitive.md
@@ -34,12 +34,8 @@ platform onboarding dismissal. Do not add a thinner "account settings" primitive
 unless, after the soak, something still has no home.
 
 The [values retirement runbook](../architecture/values-retirement-runbook.md) is
-the executable plan: about thirty days of deprecation, then removal when the
-mechanical gates there hold — not on a calendar date alone. Agents for users who
-still have stored values learn about the retirement from a compact MCP
-server-instruction notice that points at
-`coding_guide_get({ guide: "values" })`. Users with no live value rows do not
-see that notice.
+the executable plan: removal when the mechanical gates there hold — not on a
+calendar date alone.
 
 ## Consequences
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Delete completed-cutover historical residue in contributor docs and deploy comments. Line reduction only. No runtime behavior change.

## Why

Track B of the weekly Legacy Reaper. The platform, runtime, and jobs script migrations already landed. The **Do not re-run** appendices, cutover-tense deploy comments, and ADR 0022's thirty-day / MCP-notice timeline were leftover playbook.

## Summary

- Deleted the Historical appendix sections from `platform-worker-migration-runbook.md`, `runtime-worker-migration-runbook.md`, and `jobs-worker-migration-runbook.md`. Kept Ownership, Invariants, Later deploys (and runtime's Deleting a transferred class).
- Reworded architecture `index.md` runbook bullets from future-tense script extraction to present-tense ownership and deploy invariants.
- Replaced cutover-tense comments in `.github/workflows/deploy.yml` with steady-state binding-order rationale: jobs-before-origin for `JOBS` validation; platform/runtime-before-origin for cross-script bindings. Job order and YAML logic are unchanged.
- Trimmed ADR 0022: dropped "about thirty days of deprecation" and the stale MCP `retiringPrimitiveNotices` sentence (`retiringPrimitiveNotices` is already `[]`). Kept the runbook link and mechanical-gate language.

Out of scope (left in place): `onboarding-checklist.ts` (Track A), `values-retirement-runbook.md`, MCP 0005, domain dual-serve docs, `package-invoke-prefix-migration.md`, `docs/contributing/decisions/historical/0010-account-record-table/`, wrangler/worker code.

## Testing

- `npm run docs:check-temporal` passed.
- Diff is comments/docs only: **+18 / −153**. No worker, wrangler, or YAML logic edits.
- CI: Validate (Static, Node, Workers, E2E, MCP), CLA, Bugbot, and preview deploy all green. Did not wait on CodeRabbit (low risk).
- Production deploy succeeded: https://github.com/kentcdodds/kody/actions/runs/33372929596

## System changes

Docs and deploy comments only. Classifier matched no `code` roots (`composes`, low risk).

## Conductor report

**Track:** B (`docs-historical-trim`)
**Status:** SHIPPED
**Conductor:** `bc-ad63afe1-3f3d-4af6-864f-3759495cd84f`
**Shipped:** https://github.com/kentcdodds/kody/pull/1867 (merge `c3c5ab216b799d5c5ce0ec44c27823eb647aa8d1`)
**+/-:** +18 / −153
**Evidence:** `docs:check-temporal` passed; historical-appendix headings gone; deploy comments are present-tense binding-order rationale; ADR 0022 no longer mentions a thirty-day deprecation or MCP notice; Bugbot passed with no comments; production deploy https://github.com/kentcdodds/kody/actions/runs/33372929596 succeeded; Discord ship report posted
**Remains:** Track A owns `onboarding-checklist.ts`. Did not delete values-retirement-runbook, MCP 0005, domain dual-serve docs, package-invoke-prefix-migration, or ADR 0010 historical folder.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `fe69e5e7` · **Head:** `42fa2d00`

**Classification:** composes — no primitives added or changed; this PR deletes completed-cutover docs and rewords deploy comments. Runtime behavior is unchanged.

### Primitives touched

Classifier matched **no** `code` roots (docs/comments only). Related docs surfaces, wiring-only:

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `platform-worker` | surfaces | composes — runbook appendix deleted; ownership/invariants kept |
| `jobs-worker` | surfaces | composes — runbook appendix deleted; ownership/invariants kept |
| `package-runtime` | runtime | composes — runtime runbook appendix deleted; ownership/invariants kept |

Unmatched paths (no new surface): `.github/workflows/deploy.yml` (comment-only), `docs/contributing/architecture/index.md`, `docs/contributing/decisions/0022-retire-values-primitive.md`.

### Change flow

Contributor docs and deploy comments drop completed-cutover playbook and keep present-tense ownership plus binding-order invariants.

```mermaid
sequenceDiagram
	participant index as architecture-index
	participant runbooks as worker-migration-runbooks
	participant deploy as github-deploy-workflow
	participant adr as ADR-0022
	index->>runbooks: reword bullets to present-tense ownership
	runbooks->>runbooks: delete Do-not-re-run historical appendices
	Note over runbooks: keep Ownership / Invariants / Later deploys
	deploy->>deploy: reword comments to jobs-before-origin and platform/runtime-before-origin
	adr->>adr: drop thirty-day deprecation and stale MCP notice
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d83a39db-ff13-49ef-a78a-6b6b7ea696bd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d83a39db-ff13-49ef-a78a-6b6b7ea696bd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated migration runbooks to reflect current runtime, platform, and jobs ownership boundaries and deployment invariants.
  * Removed historical cutover appendices and outdated migration procedures from worker documentation.
  * Clarified that values removal follows executable retirement runbook gates rather than a fixed timeline.
  * Improved deployment workflow comments describing cross-script prerequisites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->