### PR TITLE
Drop the onboarding-checklist values copy-on-read fallback

### DIFF
--- a/packages/worker/src/mcp/onboarding-checklist.node.test.ts
+++ b/packages/worker/src/mcp/onboarding-checklist.node.test.ts
@@ -103,11 +103,27 @@ test('checklist derives from stored signals, fails open on missing bindings, and
 	expect(doneById['connect-integration']).toBe(true)
 	expect(progressed.complete).toBe(false)
 
-	// Dismissal writes the users column and round-trips without a leftover value.
+	// Dismissal writes users.onboarding_checklist_dismissed_at and round-trips.
 	expect(await readOnboardingChecklistDismissed({ env, userId })).toBe(false)
 	await dismissOnboardingChecklist({ env, userId })
 	expect(await readOnboardingChecklistDismissed({ env, userId })).toBe(true)
 	expect(await readDismissedAt(env.APP_DB)).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+})
+
+test('checklist dismissal reads a seeded users.onboarding_checklist_dismissed_at column', async () => {
+	const { env } = createEnv()
+	await seedUser(env.APP_DB)
+	const dismissedAt = '2026-08-01T12:00:00.000Z'
+	await env.APP_DB.prepare(
+		`UPDATE users
+		 SET onboarding_checklist_dismissed_at = ?
+		 WHERE stable_user_id = ?`,
+	)
+		.bind(dismissedAt, userId)
+		.run()
+
+	expect(await readOnboardingChecklistDismissed({ env, userId })).toBe(true)
+	expect(await readDismissedAt(env.APP_DB)).toBe(dismissedAt)
 })
 
 test('checklist connect-integration completes from a saved MCP server without OAuth', async () => {

--- a/packages/worker/src/mcp/onboarding-checklist.ts
+++ b/packages/worker/src/mcp/onboarding-checklist.ts
@@ -4,7 +4,6 @@ import {
 } from '#worker/entitlements/service.ts'
 import { listIntegrations } from '#worker/integrations/service.ts'
 import { listMcpServerSettings } from '#worker/mcp-client/settings-service.ts'
-import { getValue } from '#mcp/values/service.ts'
 import {
 	type OnboardingChecklistItem,
 	type OnboardingChecklistItemId,
@@ -13,8 +12,6 @@ import {
 /**
  * Derived onboarding progress. Every item is computed from data the platform
  * already stores. Dismissal lives on `users.onboarding_checklist_dismissed_at`.
- * Leftover `onboardingChecklistDismissed` values are copied on read until
- * migration 0015 deletes those rows.
  */
 
 export type { OnboardingChecklistItem, OnboardingChecklistItemId }
@@ -23,12 +20,6 @@ export type OnboardingChecklist = {
 	items: Array<OnboardingChecklistItem>
 	complete: boolean
 }
-
-export const onboardingChecklistDismissedValueName =
-	'onboardingChecklistDismissed'
-
-/** User-scope value lookups bind with no session or app. */
-const userScopedStorageContext = { sessionId: null, appId: null }
 
 export type OnboardingChecklistEnv = Pick<Env, 'APP_DB'> & EntitlementUsageEnv
 
@@ -80,22 +71,11 @@ export async function readOnboardingChecklistDismissed(input: {
 	userId: string
 }): Promise<boolean> {
 	try {
-		const column = await readDismissedAtColumn(input.env.APP_DB, input.userId)
-		if (column) return true
-
-		const leftover = await getValue({
-			env: input.env,
-			userId: input.userId,
-			storageContext: userScopedStorageContext,
-			scope: 'user',
-			name: onboardingChecklistDismissedValueName,
-		})
-		if (!leftover) return false
-
-		const dismissedAt =
-			leftover.value.trim() || leftover.updatedAt || new Date().toISOString()
-		await writeDismissedAtColumn(input.env.APP_DB, input.userId, dismissedAt)
-		return true
+		const dismissedAt = await readDismissedAtColumn(
+			input.env.APP_DB,
+			input.userId,
+		)
+		return Boolean(dismissedAt)
 	} catch {
 		return false
 	}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Remove the expired onboarding-checklist copy-on-read fallback that still looked up leftover `onboardingChecklistDismissed` values. Dismissal already lives on `users.onboarding_checklist_dismissed_at`; production has zero leftover rows of that name.

## Why

Migration 0015 backfills `users.onboarding_checklist_dismissed_at` and deletes user-scope `onboardingChecklistDismissed` rows. Production D1 (kody account, db `8c1014d1-6b41-4695-a0a2-159071f0f919`) was queried 2026-08-31 ~08:10Z: **zero** rows named `onboardingChecklistDismissed`. The copy-on-read `getValue` branch is dead code.

This is Track A of the weekly Legacy Reaper (conductor `bc-ad63afe1-3f3d-4af6-864f-3759495cd84f`).

## Summary

- `readOnboardingChecklistDismissed` now reads only `users.onboarding_checklist_dismissed_at`.
- Removed `getValue` import, `onboardingChecklistDismissedValueName`, `userScopedStorageContext`, and the leftover values branch.
- Kept `onboarding-checklist-migration.node.test.ts` (guards SQL 0015).
- Kept the entire values drain (`value_get` / `value_list` / `value_delete` and tables) — that is #1728.
- Architecture runbooks, `architecture/index.md`, `deploy.yml` comments, and ADR 0022 are out of scope (Track B). Gate readouts are out of scope (Track C).

## Testing

- Focused: `npx vitest run --project node-unit packages/worker/src/mcp/onboarding-checklist.node.test.ts packages/worker/src/mcp/onboarding-checklist-migration.node.test.ts` — 5 passed.
- `git push` hook `npm run test:push` — node-unit 2239 passed, workers-unit 306 passed.
- PR CI green (Validate, Node, Workers, Static, MCP, E2E, Bugbot). Preview deployed, then squash-merged.
- Production deploy `33373461831` success; origin/platform/runtime/jobs/highlight healthchecks passed.

## Conductor report

- **Track:** A — drop expired onboarding-checklist values copy-on-read shim
- **Conductor:** `bc-ad63afe1-3f3d-4af6-864f-3759495cd84f`
- **Agent:** `bc-bc04e778-5db4-44fb-87f0-bf861d5d2792`
- **Status:** SHIPPED (squash-merged `a792d48`; production deploy green)
- **Shipped:** https://github.com/kentcdodds/kody/pull/1868
- **+/-:** +22 / −26 (2 files)
- **Evidence:** production D1 2026-08-31 ~08:10Z zero `onboardingChecklistDismissed` rows; 0015 already backfilled the users column; focused node-unit 5/5; `test:push` green; Bugbot pass; CI green; deploy 33373461831 success
- **Remains:** values drain (#1728); Track B architecture docs; Track C gate readouts

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `fe69e5e7` · **Head:** `d342a83d`

**Classification:** composes — no primitives added or changed; this PR drops a dead `getValue` call site on the onboarding checklist.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `mcp-server` | surfaces | composes — remove leftover values fallback from `readOnboardingChecklistDismissed` |

### Change flow

Onboarding dismissal reads and writes only `users.onboarding_checklist_dismissed_at`; the expired values copy-on-read hop is gone.

```mermaid
sequenceDiagram
	actor Caller
	participant mcpServer as mcp-server
	participant d1AppDb as d1-app-db
	Caller->>mcpServer: readOnboardingChecklistDismissed
	mcpServer->>d1AppDb: SELECT users.onboarding_checklist_dismissed_at
	Caller->>mcpServer: dismissOnboardingChecklist
	mcpServer->>d1AppDb: UPDATE users.onboarding_checklist_dismissed_at
	Note over mcpServer: getValue leftover copy-on-read removed
```

### Before / after

```
before: column ? true : getValue("onboardingChecklistDismissed") then copy onto column
after:  Boolean(users.onboarding_checklist_dismissed_at)
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bc04e778-5db4-44fb-87f0-bf861d5d2792?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bc04e778-5db4-44fb-87f0-bf861d5d2792&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Onboarding checklist dismissal status now consistently reflects the stored dismissal timestamp.
  - Preserves the exact dismissal timestamp when reading onboarding status.
  - Removed legacy fallback behavior that could migrate outdated dismissal values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->