### PR TITLE
Raise homepage HTML budget for post-launch landing growth

### DIFF
--- a/docs/contributing/weekly-site-perf.md
+++ b/docs/contributing/weekly-site-perf.md
@@ -88,5 +88,6 @@ inlined `styles.css` `<style>` block (see
 [`inline-stylesheet.ts`](../../packages/worker/src/app/inline-stylesheet.ts)).
 That trade removes a render-blocking stylesheet round trip; do not "fix" an
 `html-over-budget` finding by switching back to a `<link rel="stylesheet">`
-without a product call. When landing CSS grows for real product work, raise
-`htmlBytes` to the new honest production size instead.
+without a product call. When landing CSS or below-fold marketing markup grows
+for real product work (hero agents, testimonials, factory loop, and so on),
+raise `htmlBytes` to the new honest production size instead of cutting the page.

--- a/tools/site-perf/budget.json
+++ b/tools/site-perf/budget.json
@@ -1,5 +1,5 @@
 {
-	"htmlBytes": 85000,
+	"htmlBytes": 110000,
 	"sameOriginJsBytes": 450000,
 	"lcpImageBytes": 40000
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Keep the weekly site-perf collector honest about production homepage HTML after post-launch landing growth.

## Why

Weekly production measurement flagged `html-over-budget` (102069 vs 85000). Since the 85KB budget (#1722), the anonymous homepage grew with real product work: hero agents stage, testimonials carousel, factory-loop markup, and related `.landing-*` CSS in the intentionally inlined `styles.css`.

Cutting ~17KB would mean redesigning or removing marketing content, or undoing stylesheet inlining — product calls. Per `docs/contributing/weekly-site-perf.md`, raise the threshold to the new honest production baseline.

## Summary

- Raise `tools/site-perf/budget.json` `htmlBytes` from 85000 → 110000 (live ~102KB, modest headroom).
- Clarify the weekly-site-perf budget note that below-fold marketing markup growth also warrants a budget bump.
- Closes the path for [#1887](https://github.com/kentcdodds/kody/issues/1887) once this reaches `main` and the next collector run sees `ok`.

Not in this PR: CSS splitting, stopping inlining, converting `kody-mark.png` to SVG, Worker/cache/auth changes, or inventing Lighthouse numbers.

## Testing

- `npm run site-perf -- --url https://kody.codes/ --json` → `verdict: "ok"`, `htmlBytes: ~102KB`, no findings.
- `vitest run` `tools/site-perf/collect.node.test.ts` + `invoke-site-perf-package.node.test.ts` + `inline-stylesheet.node.test.ts` — 5 passed.
- Pre-push `test:node` + `test:workers` green.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `58de7e35` · **Head:** `abfbf2f5`

**Classification:** composes — no app primitives added or changed; budget + docs only for the weekly collector.

### Primitives touched

_None. Diff is `tools/site-perf/budget.json` and `docs/contributing/weekly-site-perf.md` only._

### Change flow

Weekly collector compares live HTML (with inlined `styles.css`) against the committed budget; this PR only moves the `htmlBytes` ceiling.

```mermaid
sequenceDiagram
	actor cron as weekly-cron
	participant collector as site-perf-collector
	participant budget as budget.json
	participant issue as tracking-issue
	cron->>collector: fetch https://kody.codes/
	collector->>budget: compare htmlBytes to 110000
	budget-->>collector: within budget
	collector->>issue: verdict ok (close needs-fix)
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-abee39ec-4e1b-40b5-96a7-5f6338d48348?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-abee39ec-4e1b-40b5-96a7-5f6338d48348&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Increased the HTML size budget from 85 KB to 110 KB to accommodate legitimate growth in landing-page content.
* **Documentation**
  * Clarified when the HTML budget should be adjusted, with examples including hero sections, testimonials, and product showcase content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->