### PR TITLE
Wrap long tokens in walkthrough chat bubbles

### DIFF
--- a/packages/worker/client/routes/interactive-guide-walkthrough.node.test.ts
+++ b/packages/worker/client/routes/interactive-guide-walkthrough.node.test.ts
@@ -1,0 +1,30 @@
+import { renderToString } from 'remix/ui/server'
+import { expect, test } from 'vitest'
+import { googleOauthTranscriptActs } from './google-oauth-transcript.ts'
+import { renderGoogleOauthWalkthrough } from './google-oauth-walkthrough.tsx'
+import { renderInteractiveGuideLine } from './interactive-guide-walkthrough.tsx'
+
+test('google oauth connect bubbles wrap the prefilled url instead of overflowing', async () => {
+	const connectLine = googleOauthTranscriptActs
+		.find((act) => act.id === 'connect')
+		?.lines.find(
+			(line) =>
+				line.role === 'agent' &&
+				line.text.includes('/connect/oauth?provider=google'),
+		)
+	expect(connectLine?.role).toBe('agent')
+	if (connectLine?.role !== 'agent') return
+
+	const bubble = await renderToString(renderInteractiveGuideLine(connectLine))
+	expect(bubble).toContain('overflow-wrap: anywhere')
+	expect(bubble).toContain('white-space: pre-line')
+	expect(bubble).toContain('/connect/oauth?provider=google')
+	expect(bubble).toContain(
+		'authorizeUrl=https%3A%2F%2Faccounts.google.com%2Fo%2Foauth2%2Fv2%2Fauth',
+	)
+
+	const guide = await renderToString(renderGoogleOauthWalkthrough())
+	expect(guide).toContain('overflow-wrap: anywhere')
+	expect(guide).toContain('/connect/oauth?provider=google')
+	expect(guide).toContain('Connect and verify')
+})

--- a/packages/worker/client/routes/interactive-guide-walkthrough.tsx
+++ b/packages/worker/client/routes/interactive-guide-walkthrough.tsx
@@ -480,6 +480,8 @@ const agentMarkCss = {
 
 const bubbleCss = {
 	margin: 0,
+	minWidth: 0,
+	maxWidth: '100%',
 	'& figcaption': {
 		display: 'flex',
 		alignItems: 'center',
@@ -496,10 +498,16 @@ const bubbleCss = {
 		padding: `${spacing.sm} ${spacing.md}`,
 		borderRadius: radius.lg,
 		border: `1px solid ${colors.border}`,
+		minWidth: 0,
 	},
 	'& p': {
 		margin: 0,
+		minWidth: 0,
 		textWrap: 'pretty' as const,
+		// Long tokens (prefilled /connect/oauth URLs) have no wrap points.
+		// `anywhere` also shrinks grid min-content; `break-word` does not.
+		overflowWrap: 'anywhere' as const,
+		whiteSpace: 'pre-line' as const,
 	},
 }
 
@@ -550,10 +558,13 @@ const agentReasoningCss = {
 	},
 	'& p': {
 		margin: 0,
+		minWidth: 0,
 		fontSize: '0.92rem',
 		fontStyle: 'italic' as const,
 		color: colors.textMuted,
 		textWrap: 'pretty' as const,
+		overflowWrap: 'anywhere' as const,
+		whiteSpace: 'pre-line' as const,
 	},
 }
 
@@ -641,8 +652,10 @@ const toolNoteCss = {
 	},
 	'& p': {
 		margin: 0,
+		minWidth: 0,
 		fontSize: '0.95rem',
 		textWrap: 'pretty' as const,
+		overflowWrap: 'anywhere' as const,
 	},
 	'& code': {
 		font: '500 0.9em/1.2 ui-monospace, "SF Mono", Menlo, monospace',
@@ -650,6 +663,7 @@ const toolNoteCss = {
 		border: `1px solid ${colors.primarySoft}`,
 		borderRadius: '5px',
 		padding: '0.1em 0.35em',
+		overflowWrap: 'anywhere' as const,
 	},
 }
 

--- a/packages/worker/public/styles.css
+++ b/packages/worker/public/styles.css
@@ -1520,7 +1520,10 @@ html.is-settled {
 
 .landing-loop-you p {
 	margin: 0;
+	min-width: 0;
 	text-wrap: pretty;
+	overflow-wrap: anywhere;
+	white-space: pre-line;
 }
 
 .landing-loop-line * {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop the Google OAuth guide's Connect and verify agent bubble from overflowing when it prints the prefilled `/connect/oauth` URL.

## Why

That URL is one long token (`provider`, `authorizeUrl`, `tokenUrl`, scopes, extra params). Walkthrough bubbles used `text-wrap: pretty` only, so the query string ran into the right edge of the chat bubble.

## Summary

- Apply the same wrap rule already used on guide prose lists and inline code: `overflow-wrap: anywhere` plus `min-width: 0` on shared walkthrough bubbles, reasoning lines, and tool notes.
- Honor the `\n\n` around the connect URL with `white-space: pre-line`.
- Match the homepage factory-loop `.landing-loop-you` bubble so a long token there cannot overflow either.
- Add a node test that renders the Google OAuth connect line and the full walkthrough and asserts the wrap CSS plus the prefilled URL.

## Testing

- `vitest run --project node-unit packages/worker/client/routes/interactive-guide-walkthrough.node.test.ts`
- Pre-push: `CI=1 npm run test:node` (2239) and `CI=1 npm run test:workers` (306)
- Browser: `/guides/google-oauth` Connect and verify act — URL stays inside the bubble on a narrow viewport (in progress after this PR opens)

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `c9871054` · **Head:** `e977fd04`

**Classification:** composes — no primitives added or changed; this PR applies the existing prose wrap rule to walkthrough chat bubbles.

### Primitives touched

| Primitive | Group    | Impact |
| --------- | -------- | ------ |
| `app-ui`  | surfaces | composes — walkthrough bubble CSS only |

Unmatched path: `packages/worker/public/styles.css` (homepage factory-loop You bubble, same wrap rule).

### Change flow

The Google OAuth connect act renders through the shared walkthrough helper; the bubble now wraps the prefilled URL instead of overflowing.

```mermaid
sequenceDiagram
	actor Viewer
	participant appUi as app-ui
	Viewer->>appUi: GET /guides/google-oauth
	appUi->>appUi: render connect act agent line
	Note over appUi: overflow-wrap: anywhere on bubble p
	appUi-->>Viewer: prefilled /connect/oauth URL stays inside the bubble
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d2e9331f-8e81-48a9-8bb2-55b7442a5065?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d2e9331f-8e81-48a9-8bb2-55b7442a5065&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

