### PR TITLE
Fill leftover seats on the desktop onboarding agent chooser

### DIFF
--- a/packages/worker/client/routes/onboarding-mcp-client-tabs.node.test.ts
+++ b/packages/worker/client/routes/onboarding-mcp-client-tabs.node.test.ts
@@ -27,10 +27,25 @@ test('onboarding Step 1 picker selects an agent, then Not listed, and flips Grok
 	expect(picker).toContain(
 		'href="/onboarding?agent=openclaw&amp;surface=desktop"',
 	)
+	expect(picker).toContain(
+		'href="/onboarding?agent=chatgpt&amp;surface=desktop"',
+	)
+	expect(picker).toContain(
+		'href="/onboarding?agent=claude-desktop&amp;surface=desktop"',
+	)
+	expect(picker).toContain(
+		'href="/onboarding?agent=gemini&amp;surface=desktop"',
+	)
 	expect(picker).not.toContain('data-testid="onboarding-agent-instructions"')
 	expect(picker).not.toContain(buildClaudeCodeAddCommand(defaultKodyMcpUrl))
 	expect(picker).not.toContain(
 		'href="/onboarding?agent=grok-cli&amp;surface=desktop"',
+	)
+	expect(picker).not.toContain(
+		'href="/onboarding?agent=grok&amp;surface=desktop"',
+	)
+	expect(picker).not.toContain(
+		'href="/onboarding?agent=copilot-app&amp;surface=desktop"',
 	)
 	expect(picker).toContain('/images/icons/cursor.svg')
 	expect(picker).toContain('/images/icons/grokbot.svg')
@@ -71,7 +86,11 @@ test('onboarding Step 1 picker selects an agent, then Not listed, and flips Grok
 	)
 	expect(other).toContain(defaultKodyMcpUrl)
 	expect(other).toContain('data-testid="onboarding-agent-grok-cli"')
-	expect(other).toContain('data-testid="onboarding-agent-chatgpt"')
+	expect(other).toContain('data-testid="onboarding-agent-grok"')
+	expect(other).toContain('data-testid="onboarding-agent-copilot-app"')
+	expect(other).not.toContain('data-testid="onboarding-agent-chatgpt"')
+	expect(other).not.toContain('data-testid="onboarding-agent-claude-desktop"')
+	expect(other).not.toContain('data-testid="onboarding-agent-gemini"')
 	expect(other).not.toContain('data-testid="onboarding-agent-grok-bot"')
 	expect(other).not.toContain(grokBotInstallUrl)
 	expect(other).not.toContain(buildCodexMcpAddCommand(defaultKodyMcpUrl))

--- a/packages/worker/client/routes/onboarding-mcp-clients.node.test.ts
+++ b/packages/worker/client/routes/onboarding-mcp-clients.node.test.ts
@@ -35,6 +35,24 @@ const mcpServerUrl = defaultKodyMcpUrl
 test('onboarding MCP client builders emit the structured configs each host expects', () => {
 	const tabIds = mcpClientTabs.map((tab) => tab.id)
 	expect(new Set(tabIds).size).toBe(tabIds.length)
+	expect([...onboardingDesktopFeaturedAgentIds]).toEqual([
+		'claude-code',
+		'cursor',
+		'codex',
+		'copilot',
+		'devin',
+		'opencode',
+		'openclaw',
+		'chatgpt',
+		'claude-desktop',
+		'gemini',
+		'grok-bot',
+	])
+	expect(onboardingMoreAgentIdsFor('desktop')).toEqual([
+		'grok',
+		'grok-cli',
+		'copilot-app',
+	])
 	expect(onboardingMoreAgentIdsFor('desktop')).not.toContain(
 		onboardingDesktopFeaturedAgentIds[0],
 	)

--- a/packages/worker/universal/onboarding-mcp-clients.ts
+++ b/packages/worker/universal/onboarding-mcp-clients.ts
@@ -51,10 +51,14 @@ export const mcpClientTabs = [
 ] as const satisfies ReadonlyArray<McpClientTab>
 
 /**
- * Desktop chooser: coding agents first. Devin stands in for Devin Desktop
+ * Desktop chooser: coding agents first, then the highest-traffic chat hosts
+ * that are not already represented. Devin stands in for Devin Desktop
  * (ex-Windsurf). OpenCode is the Cline / OpenCode slot. OpenClaw is the
- * local-first personal-AI slot. Grok Bot fills the last featured seat
- * (Aider is not a Kody connect path yet).
+ * local-first personal-AI slot. ChatGPT.com, Claude Desktop, and Gemini
+ * fill the three leftover seats after OpenClaw so a 4-column grid is
+ * three full rows with Not listed. Grok.com, Grok CLI, and the Copilot
+ * app stay under Not listed (Copilot desktop/CLI is already featured;
+ * Aider is not a Kody connect path yet).
  */
 export const onboardingDesktopFeaturedAgentIds = [
 	'claude-code',
@@ -64,6 +68,9 @@ export const onboardingDesktopFeaturedAgentIds = [
 	'devin',
 	'opencode',
 	'openclaw',
+	'chatgpt',
+	'claude-desktop',
+	'gemini',
 	'grok-bot',
 ] as const satisfies ReadonlyArray<McpClientKind>
 

--- a/packages/worker/universal/onboarding-mcp-clients.ts
+++ b/packages/worker/universal/onboarding-mcp-clients.ts
@@ -55,10 +55,10 @@ export const mcpClientTabs = [
  * that are not already represented. Devin stands in for Devin Desktop
  * (ex-Windsurf). OpenCode is the Cline / OpenCode slot. OpenClaw is the
  * local-first personal-AI slot. ChatGPT.com, Claude Desktop, and Gemini
- * fill the three leftover seats after OpenClaw so a 4-column grid is
- * three full rows with Not listed. Grok.com, Grok CLI, and the Copilot
- * app stay under Not listed (Copilot desktop/CLI is already featured;
- * Aider is not a Kody connect path yet).
+ * fill the three leftover seats after OpenClaw so the auto-fill desktop
+ * grid lands on complete rows with Not listed (12 cards). Grok.com,
+ * Grok CLI, and the Copilot app stay under Not listed (Copilot
+ * desktop/CLI is already featured; Aider is not a Kody connect path yet).
  */
 export const onboardingDesktopFeaturedAgentIds = [
 	'claude-code',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Fill the three empty cells on the desktop Get started Step 1 chooser after OpenClaw was added.

## Why

The featured list plus **Not listed** was 9 cards. The desktop picker uses `auto-fill` (`minmax(10.5rem, 1fr)`), so a typical desktop lands on 4 or 6 columns. Nine cards leave three leftover holes (4+4+1 or 6+3). Promoting the three highest-traffic hosts that were still under More makes 12 cards and complete rows at both widths.

ChatGPT.com, Claude Desktop, and Gemini are the leftovers that are not already represented by a featured sibling. Grok.com and Grok CLI stay under Not listed. Copilot App stays there too because Copilot desktop/CLI is already featured.

## Summary

- Add `chatgpt`, `claude-desktop`, and `gemini` to `onboardingDesktopFeaturedAgentIds` (11 featured + Not listed = 12).
- Desktop More / Not listed is now Grok.com, Grok CLI, and Copilot App.
- Mobile featured list is unchanged.
- Tests pin the featured set, the More leftover ids, and picker vs Not listed hrefs.

## Testing

- Focused vitest on the onboarding clients + picker suites
- `test:push` on the first commit (`test:node` + `test:workers`)
- Browser snapshot of the real Remix picker: 12 cards with no leftover holes at 6-column and 4-column desktop widths; ChatGPT.com, Claude Desktop, and Gemini show install steps; Grok.com / Grok CLI / Copilot App remain under Not listed

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `d3d6f588` · **Head:** `6d03e741`

**Classification:** composes — featured-list wiring only; no new primitives or host install paths.

### Primitives touched

| Primitive | Group    | Impact   |
| --------- | -------- | -------- |
| `app-ui`  | surfaces | composes |

### Change flow

Signed-in `/onboarding` Step 1 reads the desktop featured id list and renders one card per id plus Not listed.

```mermaid
sequenceDiagram
	actor person as Person
	participant appUi as app-ui
	person->>appUi: GET /onboarding
	appUi->>appUi: shuffle onboardingDesktopFeaturedAgentIds
	Note over appUi: featured now includes chatgpt, claude-desktop, gemini
	appUi-->>person: 12-card desktop chooser
	opt Not listed
		person->>appUi: open other
		appUi-->>person: More hosts grok, grok-cli, copilot-app
	end
```

### Before / after

| Surface | Before (featured + Not listed) | After |
| ------- | ------------------------------ | ----- |
| Desktop | 8 featured + other = 9 cards (3 leftover cells on auto-fill) | 11 featured + other = 12 cards |
| Desktop More | chatgpt, claude-desktop, grok, grok-cli, copilot-app, gemini | grok, grok-cli, copilot-app |
| Mobile | unchanged | unchanged |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1384f0fd-3e7f-473b-9dd3-daa0c53bbabf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1384f0fd-3e7f-473b-9dd3-daa0c53bbabf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated onboarding to feature ChatGPT, Claude Desktop, and Gemini as selectable desktop agents.
  * Added clearer organization of featured and additional desktop agent options.
* **Improvements**
  * Moved Grok and the Copilot app to the “Other” or unlisted options for easier discovery.
  * Refined the ordering of featured agents, prioritizing coding tools before popular chat assistants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->