### PR TITLE
Fix account deletion redirect loop and leftover fence

### DIFF
--- a/docs/contributing/account-write-lease-repair.md
+++ b/docs/contributing/account-write-lease-repair.md
@@ -35,3 +35,15 @@ held) → audit insert/verify → finalize DO deletion. Retries after a lost
 finalize response succeed when the matching audit exists and the DO lease is
 already gone. Wrong user, stale timestamp, or short reason requests fail closed.
 Retry account deletion only after inspection shows no active leases.
+
+A failed delete that marked `users.deleting_at` before cleanup can leave the
+account fenced with no active leases. Confirm with `admin_user_meter_parity`
+(`deletion.d1DeletingAt` / `deletion.meterDeletingAt`), then clear both sides:
+
+```javascript
+await kody.admin_account_deletion_abort({
+	stable_user_id: 'user-id-from-admin-account-lookup',
+	reason:
+		'Leftover fence after a pre-cleanup delete failure; no writers remain.',
+})
+```

--- a/docs/contributing/adding-capabilities.md
+++ b/docs/contributing/adding-capabilities.md
@@ -232,6 +232,7 @@ rule.
 - `admin_user_verify`
 - `admin_account_write_lease_list`
 - `admin_account_write_lease_repair`
+- `admin_account_deletion_abort`
 - `admin_platform_account_create`
 - `admin_package_scope_grant_create`
 - `admin_package_scope_grant_revoke`

--- a/docs/contributing/architecture/entitlements.md
+++ b/docs/contributing/architecture/entitlements.md
@@ -279,7 +279,8 @@ is the audit log for repairs. ALS nested-lease reuse propagates per
 
 **`markAccountDeleting`:** `COALESCE`s D1 `deleting_at` (idempotent), then calls
 `markDeleting` on the DO (sets/preserves the tombstone). Returns the active DO
-lease count for drain waits.
+lease count for drain waits. If the DO call fails and D1 did not already have a
+tombstone, the D1 fence is rolled back.
 
 **`abortAccountDeleting`:** used when deletion fails before cleanup (active
 writes or incomplete inventory). Clears D1 `users.deleting_at` first, then

--- a/docs/contributing/architecture/entitlements.md
+++ b/docs/contributing/architecture/entitlements.md
@@ -285,7 +285,9 @@ tombstone, the D1 fence is rolled back.
 **`abortAccountDeleting`:** used when deletion fails before cleanup (active
 writes or incomplete inventory). Clears D1 `users.deleting_at` first, then
 `UserMeter.clearDeleting()` so the account is not left fenced. Cleanup failures
-still keep the tombstone so a retry can finish.
+still keep the tombstone so a retry can finish. Operators restore a leftover
+fence with `admin_account_deletion_abort` (stable user id + audit reason), which
+resolves `users.id` internally.
 
 **Admin list / repair:** `listActiveAccountWriteLeases(env, userId)` reads DO
 leases via `listWriteLeases` pages — no D1 union. Repair is DO-only and

--- a/docs/contributing/architecture/entitlements.md
+++ b/docs/contributing/architecture/entitlements.md
@@ -281,6 +281,11 @@ is the audit log for repairs. ALS nested-lease reuse propagates per
 `markDeleting` on the DO (sets/preserves the tombstone). Returns the active DO
 lease count for drain waits.
 
+**`abortAccountDeleting`:** used when deletion fails before cleanup (active
+writes or incomplete inventory). Clears D1 `users.deleting_at` first, then
+`UserMeter.clearDeleting()` so the account is not left fenced. Cleanup failures
+still keep the tombstone so a retry can finish.
+
 **Admin list / repair:** `listActiveAccountWriteLeases(env, userId)` reads DO
 leases via `listWriteLeases` pages — no D1 union. Repair is DO-only and
 audit-first: prepare (stable `repairId`, lease stays held) → insert/verify D1

--- a/docs/contributing/architecture/entitlements.md
+++ b/docs/contributing/architecture/entitlements.md
@@ -283,11 +283,12 @@ lease count for drain waits. If the DO call fails and D1 did not already have a
 tombstone, the D1 fence is rolled back.
 
 **`abortAccountDeleting`:** used when deletion fails before cleanup (active
-writes or incomplete inventory). Clears D1 `users.deleting_at` first, then
-`UserMeter.clearDeleting()` so the account is not left fenced. Cleanup failures
-still keep the tombstone so a retry can finish. Operators restore a leftover
-fence with `admin_account_deletion_abort` (stable user id + audit reason), which
-resolves `users.id` internally.
+writes or incomplete inventory) **and this invocation created the fence**.
+Automatic abort passes `expectedDeletingAt` so D1 and
+`UserMeter.clearDeleting()` only drop a matching tombstone. Cleanup failures and
+retries against an already-fenced account keep the tombstone so a retry can
+finish. Operators restore a leftover fence with `admin_account_deletion_abort`
+(stable user id + audit reason), which resolves `users.id` internally.
 
 **Admin list / repair:** `listActiveAccountWriteLeases(env, userId)` reads DO
 leases via `listWriteLeases` pages — no D1 union. Repair is DO-only and

--- a/packages/worker/src/account/deletion-state.node.test.ts
+++ b/packages/worker/src/account/deletion-state.node.test.ts
@@ -10,6 +10,7 @@ import { durableObjectInstanceInactiveCloseMessage } from '#worker/sentry-option
 import {
 	AccountDeletionInProgressError,
 	AccountWriteLeaseLostError,
+	abortAccountDeleting,
 	listActiveAccountWriteLeases,
 	markAccountDeleting,
 	repairAccountWriteLease,
@@ -1210,4 +1211,44 @@ test('purge resets lease state but preserves deletingAt tombstone', async () => 
 	await expect(held.operation).rejects.toBeInstanceOf(
 		AccountWriteLeaseLostError,
 	)
+})
+
+test('abortAccountDeleting clears the D1 gate and UserMeter tombstone', async () => {
+	const { sqlite, db } = createLeaseTestDb()
+	const meter = createInMemoryUserMeterEnv()
+	const meterA = userMeterRpc({ env: meter.env, userId: 'user-a' })
+
+	await markAccountDeleting({
+		db,
+		dbUserId: 1,
+		now: new Date('2099-01-01T00:00:00.000Z'),
+		env: meter.env,
+	})
+	expect(
+		sqlite.prepare(`SELECT deleting_at FROM users WHERE id = 1`).get(),
+	).toEqual({ deleting_at: '2099-01-01 00:00:00' })
+	expect(await meterA.readDeletionState()).toEqual({
+		deletingAt: '2099-01-01 00:00:00',
+	})
+
+	await abortAccountDeleting({
+		db,
+		dbUserId: 1,
+		now: new Date('2099-01-01T00:01:00.000Z'),
+		env: meter.env,
+	})
+	expect(
+		sqlite.prepare(`SELECT deleting_at FROM users WHERE id = 1`).get(),
+	).toEqual({ deleting_at: null })
+	expect(await meterA.readDeletionState()).toEqual({ deletingAt: null })
+	await expect(
+		withAccountWriteLease({
+			db,
+			stableUserId: 'user-a',
+			env: meter.env,
+			async write() {
+				return 'ok'
+			},
+		}),
+	).resolves.toBe('ok')
 })

--- a/packages/worker/src/account/deletion-state.node.test.ts
+++ b/packages/worker/src/account/deletion-state.node.test.ts
@@ -11,6 +11,7 @@ import {
 	AccountDeletionInProgressError,
 	AccountWriteLeaseLostError,
 	abortAccountDeleting,
+	abortAccountDeletingByStableUserId,
 	listActiveAccountWriteLeases,
 	markAccountDeleting,
 	repairAccountWriteLease,
@@ -1251,4 +1252,41 @@ test('abortAccountDeleting clears the D1 gate and UserMeter tombstone', async ()
 			},
 		}),
 	).resolves.toBe('ok')
+})
+
+test('abortAccountDeletingByStableUserId resolves the user then clears the fence', async () => {
+	const { sqlite, db } = createLeaseTestDb()
+	const meter = createInMemoryUserMeterEnv()
+	const meterA = userMeterRpc({ env: meter.env, userId: 'user-a' })
+
+	await markAccountDeleting({
+		db,
+		dbUserId: 1,
+		now: new Date('2099-01-01T00:00:00.000Z'),
+		env: meter.env,
+	})
+
+	await abortAccountDeletingByStableUserId({
+		db,
+		stableUserId: 'user-a',
+		now: new Date('2099-01-01T00:02:00.000Z'),
+		env: meter.env,
+	})
+	expect(
+		sqlite.prepare(`SELECT deleting_at FROM users WHERE id = 1`).get(),
+	).toEqual({ deleting_at: null })
+	expect(await meterA.readDeletionState()).toEqual({ deletingAt: null })
+})
+
+test('abortAccountDeletingByStableUserId fails closed for an unknown user', async () => {
+	const { db } = createLeaseTestDb()
+	const meter = createInMemoryUserMeterEnv()
+
+	await expect(
+		abortAccountDeletingByStableUserId({
+			db,
+			stableUserId: 'missing-user',
+			env: meter.env,
+		}),
+	).rejects.toThrow('User not found.')
 })

--- a/packages/worker/src/account/deletion-state.node.test.ts
+++ b/packages/worker/src/account/deletion-state.node.test.ts
@@ -295,7 +295,11 @@ test('env is required: UserMeter authoritative for acquire/held/release with D1 
 			now: new Date('2099-01-01T00:00:00.000Z'),
 			env: meter.env,
 		}),
-	).resolves.toBe(1)
+	).resolves.toEqual({
+		leaseCount: 1,
+		created: true,
+		deletingAt: '2099-01-01 00:00:00',
+	})
 	expect(await meterA.readDeletionState()).toEqual({
 		deletingAt: '2099-01-01 00:00:00',
 	})
@@ -812,7 +816,7 @@ test('DO repair prepare/audit/finalize is idempotent and lease-lost aware', asyn
 })
 
 test('USER_METER failures fail closed (missing binding throws)', async () => {
-	const { db } = createLeaseTestDb()
+	const { sqlite, db } = createLeaseTestDb()
 	const failingEnv = {
 		USER_METER: {
 			idFromName: (name: string) => ({ name, toString: () => name }),
@@ -845,6 +849,9 @@ test('USER_METER failures fail closed (missing binding throws)', async () => {
 			env: failingEnv,
 		}),
 	).rejects.toThrow('do mark failed')
+	expect(
+		sqlite.prepare(`SELECT deleting_at FROM users WHERE id = 1`).get(),
+	).toEqual({ deleting_at: null })
 
 	await expect(
 		withAccountWriteLease({
@@ -1289,4 +1296,70 @@ test('abortAccountDeletingByStableUserId fails closed for an unknown user', asyn
 			env: meter.env,
 		}),
 	).rejects.toThrow('User not found.')
+})
+
+test('markAccountDeleting does not roll back a fence another attempt owns', async () => {
+	const { sqlite, db } = createLeaseTestDb()
+	const meter = createInMemoryUserMeterEnv()
+	await markAccountDeleting({
+		db,
+		dbUserId: 1,
+		now: new Date('2099-01-01T00:00:00.000Z'),
+		env: meter.env,
+	})
+
+	const failingEnv = {
+		USER_METER: {
+			idFromName: (name: string) => ({ name, toString: () => name }),
+			get: () => ({
+				async markDeleting() {
+					throw new Error('do mark failed')
+				},
+			}),
+		},
+	} as unknown as UserMeterEnv
+
+	await expect(
+		markAccountDeleting({
+			db,
+			dbUserId: 1,
+			now: new Date('2099-01-01T00:05:00.000Z'),
+			env: failingEnv,
+		}),
+	).rejects.toThrow('do mark failed')
+	expect(
+		sqlite.prepare(`SELECT deleting_at FROM users WHERE id = 1`).get(),
+	).toEqual({ deleting_at: '2099-01-01 00:00:00' })
+	expect(
+		await userMeterRpc({
+			env: meter.env,
+			userId: 'user-a',
+		}).readDeletionState(),
+	).toEqual({ deletingAt: '2099-01-01 00:00:00' })
+})
+
+test('abortAccountDeleting leaves a newer fence when expectedDeletingAt does not match', async () => {
+	const { sqlite, db } = createLeaseTestDb()
+	const meter = createInMemoryUserMeterEnv()
+	const meterA = userMeterRpc({ env: meter.env, userId: 'user-a' })
+	await markAccountDeleting({
+		db,
+		dbUserId: 1,
+		now: new Date('2099-01-01T00:00:00.000Z'),
+		env: meter.env,
+	})
+
+	await abortAccountDeleting({
+		db,
+		dbUserId: 1,
+		now: new Date('2099-01-01T00:05:00.000Z'),
+		env: meter.env,
+		expectedDeletingAt: '2098-12-31 00:00:00',
+	})
+	expect(
+		sqlite.prepare(`SELECT deleting_at FROM users WHERE id = 1`).get(),
+	).toEqual({ deleting_at: '2099-01-01 00:00:00' })
+	expect(await meterA.readDeletionState()).toEqual({
+		deletingAt: '2099-01-01 00:00:00',
+	})
 })

--- a/packages/worker/src/account/deletion-state.ts
+++ b/packages/worker/src/account/deletion-state.ts
@@ -203,6 +203,49 @@ export async function markAccountDeleting(input: {
 	return marked.leaseCount
 }
 
+/**
+ * Undo {@link markAccountDeleting} when deletion aborts before cleanup.
+ * Clears D1 `users.deleting_at` first (permanent gate), then the UserMeter
+ * tombstone. A later write may still fail closed if the DO clear is delayed.
+ */
+export async function abortAccountDeleting(input: {
+	db: D1Database
+	dbUserId: number
+	now?: Date
+	env: UserMeterEnv
+}) {
+	const userRow = await input.db
+		.prepare(
+			`SELECT stable_user_id
+			FROM users
+			WHERE id = ?`,
+		)
+		.bind(input.dbUserId)
+		.first<{ stable_user_id: string }>()
+	const now = utcSqliteTimestamp(input.now ?? new Date())
+	const result = await input.db
+		.prepare(
+			`UPDATE users
+			SET deleting_at = NULL, updated_at = ?
+			WHERE id = ?`,
+		)
+		.bind(now, input.dbUserId)
+		.run()
+	if ((result.meta.changes ?? 0) !== 1) {
+		throw new Error('Account deletion fence could not be cleared.')
+	}
+	const stableUserId = userRow?.stable_user_id
+	if (!stableUserId) {
+		throw new Error('Account deletion fence could not be cleared.')
+	}
+	const env = requireUserMeterEnv(input.env)
+	await runUserMeterRpc({
+		env,
+		stableUserId,
+		operation: async (meter) => await meter.clearDeleting(),
+	})
+}
+
 export async function assertAccountWritableDb(
 	db: D1Database,
 	stableUserId: string,

--- a/packages/worker/src/account/deletion-state.ts
+++ b/packages/worker/src/account/deletion-state.ts
@@ -160,36 +160,34 @@ async function findMatchingRepairAudit(input: {
 		.first<{ id: string }>()
 }
 
+export type MarkAccountDeletingResult = {
+	leaseCount: number
+	/** True when this invocation wrote `users.deleting_at`. */
+	created: boolean
+	deletingAt: string
+}
+
 export async function markAccountDeleting(input: {
 	db: D1Database
 	dbUserId: number
 	now?: Date
 	env: UserMeterEnv
-}) {
+}): Promise<MarkAccountDeletingResult> {
 	// D1 deleting_at is set first: it is the permanent point gate and must be
 	// written before any UserMeter call so the gate is never missed even if
-	// the DO call subsequently fails. If that DO call fails, roll back a
-	// tombstone we just created so the account is not left half-fenced.
+	// the DO call subsequently fails. Only roll back a tombstone this
+	// invocation created (`WHERE deleting_at IS NULL`) so a concurrent or
+	// retrying delete cannot wipe another attempt's fence.
 	const now = utcSqliteTimestamp(input.now ?? new Date())
-	const prior = await input.db
-		.prepare(
-			`SELECT stable_user_id, deleting_at
-			FROM users
-			WHERE id = ?`,
-		)
-		.bind(input.dbUserId)
-		.first<{ stable_user_id: string; deleting_at: string | null }>()
-	const result = await input.db
+	const createResult = await input.db
 		.prepare(
 			`UPDATE users
-			SET deleting_at = COALESCE(deleting_at, ?), updated_at = ?
-			WHERE id = ?`,
+			SET deleting_at = ?, updated_at = ?
+			WHERE id = ? AND deleting_at IS NULL`,
 		)
 		.bind(now, now, input.dbUserId)
 		.run()
-	if ((result.meta.changes ?? 0) !== 1) {
-		throw new Error('Account could not be marked for deletion.')
-	}
+	const created = (createResult.meta.changes ?? 0) === 1
 	const userRow = await input.db
 		.prepare(
 			`SELECT stable_user_id, deleting_at
@@ -210,16 +208,20 @@ export async function markAccountDeleting(input: {
 			stableUserId,
 			operation: async (meter) => await meter.markDeleting({ deletingAt }),
 		})
-		return marked.leaseCount
+		return {
+			leaseCount: marked.leaseCount,
+			created,
+			deletingAt,
+		}
 	} catch (error) {
-		if (prior?.deleting_at == null) {
+		if (created) {
 			await input.db
 				.prepare(
 					`UPDATE users
 					SET deleting_at = NULL, updated_at = ?
-					WHERE id = ?`,
+					WHERE id = ? AND deleting_at = ?`,
 				)
-				.bind(now, input.dbUserId)
+				.bind(now, input.dbUserId, now)
 				.run()
 		}
 		throw error
@@ -229,13 +231,19 @@ export async function markAccountDeleting(input: {
 /**
  * Undo {@link markAccountDeleting} when deletion aborts before cleanup.
  * Clears D1 `users.deleting_at` first (permanent gate), then the UserMeter
- * tombstone. A later write may still fail closed if the DO clear is delayed.
+ * tombstone. Pass `expectedDeletingAt` so a concurrent/retry fence is left
+ * alone. A later write may still fail closed if the DO clear is delayed.
  */
 export async function abortAccountDeleting(input: {
 	db: D1Database
 	dbUserId: number
 	now?: Date
 	env: UserMeterEnv
+	/**
+	 * When set, clear D1 and UserMeter only if they still hold this exact
+	 * fence. Omit for an operator abort of whatever leftover tombstone exists.
+	 */
+	expectedDeletingAt?: string
 }) {
 	const userRow = await input.db
 		.prepare(
@@ -246,15 +254,24 @@ export async function abortAccountDeleting(input: {
 		.bind(input.dbUserId)
 		.first<{ stable_user_id: string }>()
 	const now = utcSqliteTimestamp(input.now ?? new Date())
-	const result = await input.db
-		.prepare(
-			`UPDATE users
-			SET deleting_at = NULL, updated_at = ?
-			WHERE id = ?`,
-		)
-		.bind(now, input.dbUserId)
-		.run()
-	if ((result.meta.changes ?? 0) !== 1) {
+	const result = input.expectedDeletingAt
+		? await input.db
+				.prepare(
+					`UPDATE users
+					SET deleting_at = NULL, updated_at = ?
+					WHERE id = ? AND deleting_at = ?`,
+				)
+				.bind(now, input.dbUserId, input.expectedDeletingAt)
+				.run()
+		: await input.db
+				.prepare(
+					`UPDATE users
+					SET deleting_at = NULL, updated_at = ?
+					WHERE id = ?`,
+				)
+				.bind(now, input.dbUserId)
+				.run()
+	if (!input.expectedDeletingAt && (result.meta.changes ?? 0) !== 1) {
 		throw new Error('Account deletion fence could not be cleared.')
 	}
 	const stableUserId = userRow?.stable_user_id
@@ -265,7 +282,12 @@ export async function abortAccountDeleting(input: {
 	await runUserMeterRpc({
 		env,
 		stableUserId,
-		operation: async (meter) => await meter.clearDeleting(),
+		operation: async (meter) =>
+			await meter.clearDeleting(
+				input.expectedDeletingAt
+					? { expectedDeletingAt: input.expectedDeletingAt }
+					: undefined,
+			),
 	})
 }
 

--- a/packages/worker/src/account/deletion-state.ts
+++ b/packages/worker/src/account/deletion-state.ts
@@ -168,8 +168,17 @@ export async function markAccountDeleting(input: {
 }) {
 	// D1 deleting_at is set first: it is the permanent point gate and must be
 	// written before any UserMeter call so the gate is never missed even if
-	// the DO call subsequently fails.
+	// the DO call subsequently fails. If that DO call fails, roll back a
+	// tombstone we just created so the account is not left half-fenced.
 	const now = utcSqliteTimestamp(input.now ?? new Date())
+	const prior = await input.db
+		.prepare(
+			`SELECT stable_user_id, deleting_at
+			FROM users
+			WHERE id = ?`,
+		)
+		.bind(input.dbUserId)
+		.first<{ stable_user_id: string; deleting_at: string | null }>()
 	const result = await input.db
 		.prepare(
 			`UPDATE users
@@ -194,13 +203,27 @@ export async function markAccountDeleting(input: {
 	if (!stableUserId || !deletingAt) {
 		throw new Error('Account could not be marked for deletion.')
 	}
-	const env = requireUserMeterEnv(input.env)
-	const marked = await runUserMeterRpc({
-		env,
-		stableUserId,
-		operation: async (meter) => await meter.markDeleting({ deletingAt }),
-	})
-	return marked.leaseCount
+	try {
+		const env = requireUserMeterEnv(input.env)
+		const marked = await runUserMeterRpc({
+			env,
+			stableUserId,
+			operation: async (meter) => await meter.markDeleting({ deletingAt }),
+		})
+		return marked.leaseCount
+	} catch (error) {
+		if (prior?.deleting_at == null) {
+			await input.db
+				.prepare(
+					`UPDATE users
+					SET deleting_at = NULL, updated_at = ?
+					WHERE id = ?`,
+				)
+				.bind(now, input.dbUserId)
+				.run()
+		}
+		throw error
+	}
 }
 
 /**

--- a/packages/worker/src/account/deletion-state.ts
+++ b/packages/worker/src/account/deletion-state.ts
@@ -269,6 +269,35 @@ export async function abortAccountDeleting(input: {
 	})
 }
 
+/**
+ * Operator entry for {@link abortAccountDeleting}. Resolves `users.id` from
+ * `stable_user_id` so admin tools never take the numeric D1 join key.
+ */
+export async function abortAccountDeletingByStableUserId(input: {
+	db: D1Database
+	stableUserId: string
+	now?: Date
+	env: UserMeterEnv
+}) {
+	const userRow = await input.db
+		.prepare(
+			`SELECT id
+			FROM users
+			WHERE stable_user_id = ?`,
+		)
+		.bind(input.stableUserId)
+		.first<{ id: number }>()
+	if (!userRow) {
+		throw new Error('User not found.')
+	}
+	await abortAccountDeleting({
+		db: input.db,
+		dbUserId: userRow.id,
+		now: input.now,
+		env: input.env,
+	})
+}
+
 export async function assertAccountWritableDb(
 	db: D1Database,
 	stableUserId: string,

--- a/packages/worker/src/app/account-deletion-cleanup.node.test.ts
+++ b/packages/worker/src/app/account-deletion-cleanup.node.test.ts
@@ -253,7 +253,7 @@ test('account deletion reports missing Durable Object / blob bindings and remain
 	expect(missingMailboxRows.users).toEqual([
 		expect.objectContaining({
 			id: 1,
-			deleting_at: expect.any(String),
+			deleting_at: null,
 		}),
 	])
 
@@ -272,7 +272,7 @@ test('account deletion reports missing Durable Object / blob bindings and remain
 	expect(missingMeterRows.users).toEqual([
 		expect.objectContaining({
 			id: 1,
-			deleting_at: expect.any(String),
+			deleting_at: null,
 		}),
 	])
 })
@@ -296,7 +296,7 @@ test('deleteUserAccount fails closed when REPO_SESSION_INDEX is missing', async 
 		expect.objectContaining({
 			id: 1,
 			email: 'a@example.com',
-			deleting_at: expect.any(String),
+			deleting_at: null,
 		}),
 	])
 	expect(rows.mcp_memories).toEqual([{ id: 'memory-a', user_id: 'user-aaa' }])
@@ -333,7 +333,7 @@ test('deleteUserAccount fails closed when preflight inventory cannot be read', a
 		expect.objectContaining({
 			id: 1,
 			email: 'a@example.com',
-			deleting_at: expect.any(String),
+			deleting_at: null,
 		}),
 	])
 	expect(rows.mcp_memories).toEqual([{ id: 'memory-a', user_id: 'user-aaa' }])
@@ -451,7 +451,7 @@ test('account deletion waits for an active writer and resumes on retry', async (
 	).rejects.toBeInstanceOf(AccountDeletionWritersActiveError)
 	expect(rows.users?.[0]).toEqual(
 		expect.objectContaining({
-			deleting_at: expect.any(String),
+			deleting_at: null,
 		}),
 	)
 	// Release the meter lease to simulate the crashed writer being repaired.

--- a/packages/worker/src/app/account-deletion.node.test.ts
+++ b/packages/worker/src/app/account-deletion.node.test.ts
@@ -4,9 +4,12 @@ import { expect, test, vi } from 'vitest'
 import * as stripeClient from '#worker/billing/stripe-client.ts'
 import {
 	AccountDeletionCleanupError,
+	AccountDeletionInventoryError,
 	deleteUserAccount,
 	getAccountDeletionD1UserColumnCoverage,
 } from './account-deletion.ts'
+import { AccountDeletionWritersActiveError } from '#worker/account/deletion-state.ts'
+import { userMeterRpc } from '#worker/entitlements/user-meter-client.ts'
 import { accountUserDataExcludedOwnerIds } from '#worker/account/data-targets.ts'
 import { jobVectorId } from '#mcp/jobs-vectorize.ts'
 import { consoleError } from '#worker/test-support/console-spies.ts'
@@ -1094,4 +1097,60 @@ test('account deletion cancels Stripe billing and remains non-blocking on Stripe
 		deleteCustomer.mockRestore()
 		consoleError.mockReset()
 	}
+})
+
+test('deleteUserAccount clears the deletion fence when writers are still active', async () => {
+	const { db, rows } = createTestDb({
+		users: [{ id: 1, email: 'a@example.com' }],
+	})
+	const env = createSuccessfulDeletionEnv(db)
+	const meter = userMeterRpc({ env, userId: 'user-aaa' })
+	await meter.acquireWriteLease({
+		token: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+		holder: 'test:signup',
+		acquiredAt: '2026-08-31 15:00:00',
+	})
+
+	await expect(
+		deleteUserAccount({
+			env,
+			dbUserId: 1,
+			mcpUserId: 'user-aaa',
+		}),
+	).rejects.toBeInstanceOf(AccountDeletionWritersActiveError)
+	expect(rows.users).toEqual([
+		expect.objectContaining({
+			id: 1,
+			stable_user_id: 'user-aaa',
+			deleting_at: null,
+		}),
+	])
+	expect(await meter.readDeletionState()).toEqual({ deletingAt: null })
+})
+
+test('deleteUserAccount clears the deletion fence when inventory cannot be collected', async () => {
+	const { db, rows } = createTestDb(
+		{
+			users: [{ id: 1, email: 'a@example.com' }],
+		},
+		{ failSelectContaining: 'from mcp_memories' },
+	)
+	const env = createSuccessfulDeletionEnv(db)
+	const meter = userMeterRpc({ env, userId: 'user-aaa' })
+
+	await expect(
+		deleteUserAccount({
+			env,
+			dbUserId: 1,
+			mcpUserId: 'user-aaa',
+		}),
+	).rejects.toBeInstanceOf(AccountDeletionInventoryError)
+	expect(rows.users).toEqual([
+		expect.objectContaining({
+			id: 1,
+			stable_user_id: 'user-aaa',
+			deleting_at: null,
+		}),
+	])
+	expect(await meter.readDeletionState()).toEqual({ deletingAt: null })
 })

--- a/packages/worker/src/app/account-deletion.node.test.ts
+++ b/packages/worker/src/app/account-deletion.node.test.ts
@@ -1154,3 +1154,41 @@ test('deleteUserAccount clears the deletion fence when inventory cannot be colle
 	])
 	expect(await meter.readDeletionState()).toEqual({ deletingAt: null })
 })
+
+test('deleteUserAccount keeps an existing fence when writers are still active', async () => {
+	const { db, rows } = createTestDb({
+		users: [
+			{
+				id: 1,
+				email: 'a@example.com',
+				deleting_at: '2026-08-31 15:22:12',
+			},
+		],
+	})
+	const env = createSuccessfulDeletionEnv(db)
+	const meter = userMeterRpc({ env, userId: 'user-aaa' })
+	await meter.acquireWriteLease({
+		token: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+		holder: 'test:cleanup-retry',
+		acquiredAt: '2026-08-31 15:23:00',
+	})
+	await meter.markDeleting({ deletingAt: '2026-08-31 15:22:12' })
+
+	await expect(
+		deleteUserAccount({
+			env,
+			dbUserId: 1,
+			mcpUserId: 'user-aaa',
+		}),
+	).rejects.toBeInstanceOf(AccountDeletionWritersActiveError)
+	expect(rows.users).toEqual([
+		expect.objectContaining({
+			id: 1,
+			stable_user_id: 'user-aaa',
+			deleting_at: '2026-08-31 15:22:12',
+		}),
+	])
+	expect(await meter.readDeletionState()).toEqual({
+		deletingAt: '2026-08-31 15:22:12',
+	})
+})

--- a/packages/worker/src/app/account-deletion.ts
+++ b/packages/worker/src/app/account-deletion.ts
@@ -57,6 +57,7 @@ import {
 } from '#mcp/session-registry.ts'
 import {
 	AccountDeletionWritersActiveError,
+	abortAccountDeleting,
 	markAccountDeleting,
 } from '#worker/account/deletion-state.ts'
 import {
@@ -958,6 +959,11 @@ export async function deleteUserAccount(input: {
 		env: input.env,
 	})
 	if (activeWriteCount > 0) {
+		await abortAccountDeleting({
+			db: input.env.APP_DB,
+			dbUserId: input.dbUserId,
+			env: input.env,
+		})
 		throw new AccountDeletionWritersActiveError(activeWriteCount)
 	}
 	const warnings: Array<string> = []
@@ -978,12 +984,24 @@ export async function deleteUserAccount(input: {
 		warnings,
 	}
 
-	const inventory = await collectUserDeletionInventory({
-		env: input.env,
-		userId: input.mcpUserId,
-		dbUserId: input.dbUserId,
-		warnings,
-	})
+	let inventory: UserDeletionInventory
+	try {
+		inventory = await collectUserDeletionInventory({
+			env: input.env,
+			userId: input.mcpUserId,
+			dbUserId: input.dbUserId,
+			warnings,
+		})
+	} catch (error) {
+		if (error instanceof AccountDeletionInventoryError) {
+			await abortAccountDeleting({
+				db: input.env.APP_DB,
+				dbUserId: input.dbUserId,
+				env: input.env,
+			})
+		}
+		throw error
+	}
 
 	result.deletedVectors = await deleteVectorsByIds({
 		env: input.env,

--- a/packages/worker/src/app/account-deletion.ts
+++ b/packages/worker/src/app/account-deletion.ts
@@ -953,18 +953,21 @@ export async function deleteUserAccount(input: {
 	dbUserId: number
 	mcpUserId: string
 }): Promise<AccountDeletionResult> {
-	const activeWriteCount = await markAccountDeleting({
+	const marked = await markAccountDeleting({
 		db: input.env.APP_DB,
 		dbUserId: input.dbUserId,
 		env: input.env,
 	})
-	if (activeWriteCount > 0) {
-		await abortAccountDeleting({
-			db: input.env.APP_DB,
-			dbUserId: input.dbUserId,
-			env: input.env,
-		})
-		throw new AccountDeletionWritersActiveError(activeWriteCount)
+	if (marked.leaseCount > 0) {
+		if (marked.created) {
+			await abortAccountDeleting({
+				db: input.env.APP_DB,
+				dbUserId: input.dbUserId,
+				env: input.env,
+				expectedDeletingAt: marked.deletingAt,
+			})
+		}
+		throw new AccountDeletionWritersActiveError(marked.leaseCount)
 	}
 	const warnings: Array<string> = []
 	const clearedDurableObjects: Record<string, number> = {}
@@ -993,11 +996,12 @@ export async function deleteUserAccount(input: {
 			warnings,
 		})
 	} catch (error) {
-		if (error instanceof AccountDeletionInventoryError) {
+		if (error instanceof AccountDeletionInventoryError && marked.created) {
 			await abortAccountDeleting({
 				db: input.env.APP_DB,
 				dbUserId: input.dbUserId,
 				env: input.env,
+				expectedDeletingAt: marked.deletingAt,
 			})
 		}
 		throw error

--- a/packages/worker/src/app/account-write-lease-middleware.node.test.ts
+++ b/packages/worker/src/app/account-write-lease-middleware.node.test.ts
@@ -82,3 +82,26 @@ test('authenticated delayed mutation holds web lease through handler completion'
 	await expect(responsePromise).resolves.toMatchObject({ status: 200 })
 	expect(await meterA.countActiveWriteLeases()).toEqual({ count: 0 })
 })
+
+test('logout is not blocked while an account is deleting', async () => {
+	authMock.loadResolvedRequestAuth.mockResolvedValue({
+		sessionUserId: '1',
+		user: {
+			accountDeleting: true,
+			mcpUser: { userId: 'user-a' },
+		},
+	})
+	const next = vi.fn(async () => new Response(null, { status: 302 }))
+	const middleware = createAccountWriteLeaseMiddleware({} as Env)
+	const response = await middleware(
+		{
+			request: new Request('https://example.com/logout', { method: 'POST' }),
+			url: new URL('https://example.com/logout'),
+			params: {},
+			context: new Map(),
+		} as never,
+		next,
+	)
+	expect(next).toHaveBeenCalledOnce()
+	expect(response.status).toBe(302)
+})

--- a/packages/worker/src/app/account-write-lease-middleware.ts
+++ b/packages/worker/src/app/account-write-lease-middleware.ts
@@ -30,7 +30,13 @@ export function createAccountWriteLeaseMiddleware(env: Env): Middleware {
 	return async ({ request, url }, next) => {
 		const mutating =
 			unsafeMethods.has(request.method) || mutatingGetPaths.has(url.pathname)
-		if (!mutating || url.pathname === '/account/delete') return await next()
+		if (
+			!mutating ||
+			url.pathname === '/account/delete' ||
+			url.pathname === '/logout'
+		) {
+			return await next()
+		}
 		const auth = await loadResolvedRequestAuth(request, env)
 		if (!auth.user) return await next()
 		if (auth.user.accountDeleting) return accountDeletingResponse(409)

--- a/packages/worker/src/app/handlers/account.node.test.ts
+++ b/packages/worker/src/app/handlers/account.node.test.ts
@@ -80,3 +80,75 @@ test('account handler redirects to login with a session-destroy cookie for stale
 	expect(setCookie).toContain('kody_session=')
 	expect(setCookie).toContain('Max-Age=0')
 })
+
+test('account handler redirects to login and clears the cookie for a deleting account', async () => {
+	setAuthSessionSecret(testCookieSecret)
+	const session: AuthSession = {
+		stableUserId: 'a'.repeat(64),
+		email: 'deleting@example.com',
+		rememberMe: false,
+	}
+	const cookie = await createAuthCookie(session, false)
+	const env = {
+		COOKIE_SECRET: testCookieSecret,
+		APP_DB: {
+			prepare(query: string) {
+				const normalizedQuery = query.replace(/\s+/g, ' ').trim().toLowerCase()
+				return {
+					bind() {
+						return {
+							async all() {
+								if (
+									normalizedQuery.startsWith('select') &&
+									normalizedQuery.includes('from "users"')
+								) {
+									return {
+										results: [
+											{
+												id: 7,
+												email: 'deleting@example.com',
+												username: 'deleting-user',
+												stable_user_id: 'a'.repeat(64),
+												deleting_at: '2026-08-31 15:00:00',
+											},
+										],
+										meta: { changes: 0 },
+									}
+								}
+								if (normalizedQuery.includes('from user_roles ur')) {
+									return { results: [], meta: { changes: 0 } }
+								}
+								return { results: [], meta: { changes: 0 } }
+							},
+							async first() {
+								return null
+							},
+							async run() {
+								return { meta: { changes: 0 } }
+							},
+						}
+					},
+				}
+			},
+			async exec() {
+				return
+			},
+		} as unknown as D1Database,
+	} as Env
+	const handler = createAccountHandler(env)
+	const response = await handler.handler(
+		new RequestContext(
+			new Request('https://example.com/account', {
+				headers: { Cookie: cookie },
+			}),
+		),
+	)
+
+	expect(response.status).toBe(302)
+	expect(response.headers.get('Location')).toBe(
+		'https://example.com/login?redirectTo=%2Faccount',
+	)
+	const setCookie = response.headers.get('Set-Cookie') ?? ''
+	expect(setCookie).toContain('kody_session=')
+	expect(setCookie).toContain('Max-Age=0')
+})

--- a/packages/worker/src/app/handlers/auth-page.node.test.ts
+++ b/packages/worker/src/app/handlers/auth-page.node.test.ts
@@ -10,11 +10,16 @@ import { createAuthPageHandler } from '#app/handlers/auth-page.ts'
 const testCookieSecret = 'test-cookie-secret-0123456789abcdef0123456789'
 
 vi.mock('#app/ssr-render.tsx', () => ({
-	renderAppPage: async () =>
-		new Response('login-page', {
+	renderAppPage: async (input: { extraSetCookies?: Array<string> }) => {
+		const headers = new Headers({ 'Content-Type': 'text/html' })
+		for (const cookie of input.extraSetCookies ?? []) {
+			headers.append('Set-Cookie', cookie)
+		}
+		return new Response('login-page', {
 			status: 200,
-			headers: { 'Content-Type': 'text/html' },
-		}),
+			headers,
+		})
+	},
 }))
 
 function createStaleSessionTestEnv() {
@@ -141,4 +146,7 @@ test('auth page renders login for a deleting account instead of redirecting to /
 
 	expect(response.status).toBe(200)
 	expect(await response.text()).toBe('login-page')
+	const setCookie = response.headers.get('Set-Cookie') ?? ''
+	expect(setCookie).toContain('kody_session=')
+	expect(setCookie).toContain('Max-Age=0')
 })

--- a/packages/worker/src/app/handlers/auth-page.node.test.ts
+++ b/packages/worker/src/app/handlers/auth-page.node.test.ts
@@ -75,3 +75,70 @@ test('auth page renders login for a stale session instead of redirecting away', 
 	expect(response.status).toBe(200)
 	expect(await response.text()).toBe('login-page')
 })
+
+test('auth page renders login for a deleting account instead of redirecting to /account', async () => {
+	setAuthSessionSecret(testCookieSecret)
+	const session: AuthSession = {
+		stableUserId: 'a'.repeat(64),
+		email: 'deleting@example.com',
+		rememberMe: false,
+	}
+	const cookie = await createAuthCookie(session, false)
+	const env = {
+		COOKIE_SECRET: testCookieSecret,
+		APP_DB: {
+			prepare(query: string) {
+				const normalizedQuery = query.replace(/\s+/g, ' ').trim().toLowerCase()
+				return {
+					bind() {
+						return {
+							async all() {
+								if (
+									normalizedQuery.startsWith('select') &&
+									normalizedQuery.includes('from "users"')
+								) {
+									return {
+										results: [
+											{
+												id: 7,
+												email: 'deleting@example.com',
+												username: 'deleting-user',
+												stable_user_id: 'a'.repeat(64),
+												deleting_at: '2026-08-31 15:00:00',
+											},
+										],
+										meta: { changes: 0 },
+									}
+								}
+								if (normalizedQuery.includes('from user_roles ur')) {
+									return { results: [], meta: { changes: 0 } }
+								}
+								return { results: [], meta: { changes: 0 } }
+							},
+							async first() {
+								return null
+							},
+							async run() {
+								return { meta: { changes: 0 } }
+							},
+						}
+					},
+				}
+			},
+			async exec() {
+				return
+			},
+		} as unknown as D1Database,
+	} as Env
+	const handler = createAuthPageHandler(env, 'login')
+	const response = await handler.handler(
+		new RequestContext(
+			new Request('https://example.com/login?redirectTo=%2Faccount', {
+				headers: { Cookie: cookie },
+			}),
+		),
+	)
+
+	expect(response.status).toBe(200)
+	expect(await response.text()).toBe('login-page')
+})

--- a/packages/worker/src/app/handlers/auth-page.ts
+++ b/packages/worker/src/app/handlers/auth-page.ts
@@ -46,6 +46,7 @@ export function createAuthPageHandler(
 			return renderAppPage({
 				request,
 				env,
+				extraSetCookies: setCookie ? [setCookie] : undefined,
 				loaderData: {
 					authProviders: {
 						ok: true,

--- a/packages/worker/src/app/page-auth.ts
+++ b/packages/worker/src/app/page-auth.ts
@@ -6,7 +6,12 @@ import {
 	readAuthenticatedAppUser,
 	type AuthenticatedAppUser,
 } from '#app/authenticated-user.ts'
-import { readAuthSessionResult } from '#app/auth-session.ts'
+import {
+	destroyAuthCookie,
+	isSecureRequest,
+	readAuthSessionResult,
+} from '#app/auth-session.ts'
+import { loadResolvedRequestAuth } from '#app/request-auth-cache.ts'
 import { requireUserWithRole } from '#app/permissions-server.ts'
 import { type RoleName } from '#universal/permissions.ts'
 
@@ -31,11 +36,18 @@ export async function requireAuthenticatedPageUser(
 	}
 
 	const user = await readAuthenticatedAppUser(request, env)
-	if (!user) {
-		return redirectToLoginWhenUnauthenticated(request, env)
+	if (user) {
+		return user
 	}
 
-	return user
+	const resolved = await loadResolvedRequestAuth(request, env)
+	if (resolved.user?.accountDeleting) {
+		return redirectToLogin(request, {
+			setCookie: await destroyAuthCookie(isSecureRequest(request)),
+		})
+	}
+
+	return redirectToLoginWhenUnauthenticated(request, env)
 }
 
 export async function requirePageUserWithRole(

--- a/packages/worker/src/app/session-info.node.test.ts
+++ b/packages/worker/src/app/session-info.node.test.ts
@@ -1,0 +1,73 @@
+import { expect, test } from 'vitest'
+import {
+	createAuthCookie,
+	setAuthSessionSecret,
+	type AuthSession,
+} from '#app/auth-session.ts'
+import { loadSessionInfo } from '#app/session-info.ts'
+
+const testCookieSecret = 'test-cookie-secret-0123456789abcdef0123456789'
+
+test('loadSessionInfo signs out a deleting account and clears the session cookie', async () => {
+	setAuthSessionSecret(testCookieSecret)
+	const session: AuthSession = {
+		stableUserId: 'a'.repeat(64),
+		email: 'deleting@example.com',
+		rememberMe: false,
+	}
+	const cookie = await createAuthCookie(session, false)
+	const env = {
+		COOKIE_SECRET: testCookieSecret,
+		APP_DB: {
+			prepare(query: string) {
+				const normalizedQuery = query.replace(/\s+/g, ' ').trim().toLowerCase()
+				return {
+					bind() {
+						return {
+							async all() {
+								if (
+									normalizedQuery.startsWith('select') &&
+									normalizedQuery.includes('from "users"')
+								) {
+									return {
+										results: [
+											{
+												id: 7,
+												email: 'deleting@example.com',
+												username: 'deleting-user',
+												stable_user_id: 'a'.repeat(64),
+												deleting_at: '2026-08-31 15:00:00',
+											},
+										],
+										meta: { changes: 0 },
+									}
+								}
+								if (normalizedQuery.includes('from user_roles ur')) {
+									return { results: [], meta: { changes: 0 } }
+								}
+								return { results: [], meta: { changes: 0 } }
+							},
+							async first() {
+								return null
+							},
+							async run() {
+								return { meta: { changes: 0 } }
+							},
+						}
+					},
+				}
+			},
+			async exec() {
+				return
+			},
+		} as unknown as D1Database,
+	} as Env
+
+	const loaded = await loadSessionInfo(
+		new Request('https://example.com/', { headers: { Cookie: cookie } }),
+		env,
+	)
+	expect(loaded.session).toBeNull()
+	expect(loaded.setCookie ?? '').toContain('kody_session=')
+	expect(loaded.setCookie ?? '').toContain('Max-Age=0')
+})

--- a/packages/worker/src/app/session-info.ts
+++ b/packages/worker/src/app/session-info.ts
@@ -1,3 +1,4 @@
+import { destroyAuthCookie, isSecureRequest } from '#app/auth-session.ts'
 import { loadResolvedRequestAuth } from '#app/request-auth-cache.ts'
 import {
 	loadRequestFeatureFlags,
@@ -26,12 +27,19 @@ export async function loadSessionInfo(
 	env: Env,
 ): Promise<LoadedSessionResult> {
 	const resolved = await loadResolvedRequestAuth(request, env)
-	// A suspended account's session is treated as signed out everywhere,
-	// including the SSR shell (matching readAuthenticatedAppUser).
-	if (!resolved.user || resolved.user.accountSuspended) {
+	// Suspended and deleting accounts are signed out in the SSR shell
+	// (matching readAuthenticatedAppUser). Deleting also clears the cookie
+	// so /login does not bounce back to /account.
+	if (
+		!resolved.user ||
+		resolved.user.accountSuspended ||
+		resolved.user.accountDeleting
+	) {
 		return {
 			session: null,
-			setCookie: resolved.setCookie,
+			setCookie: resolved.user?.accountDeleting
+				? await destroyAuthCookie(isSecureRequest(request))
+				: resolved.setCookie,
 		}
 	}
 

--- a/packages/worker/src/entitlements/user-meter-do.ts
+++ b/packages/worker/src/entitlements/user-meter-do.ts
@@ -153,6 +153,10 @@ export type UserMeterMarkDeletingResult = {
 	leaseCount: number
 }
 
+export type UserMeterClearDeletingResult = {
+	cleared: boolean
+}
+
 export type UserMeterAcquireWriteLeaseResult = {
 	acquired: boolean
 }
@@ -1233,6 +1237,22 @@ class UserMeterBase extends DurableObject<Env> {
 		})
 	}
 
+	/**
+	 * Abort a deletion that has not started cleanup: drop the DO tombstone so
+	 * later writes and a retry can proceed. D1 `users.deleting_at` is cleared
+	 * by the caller first (permanent gate).
+	 */
+	async clearDeleting(): Promise<UserMeterClearDeletingResult> {
+		return await this.ctx.blockConcurrencyWhile(async () => {
+			if (this.readDeletingAt() == null) return { cleared: false }
+			this.ctx.storage.sql.exec(
+				`DELETE FROM deletion_state WHERE id = ?`,
+				deletionStateRowId,
+			)
+			return { cleared: true }
+		})
+	}
+
 	/** Authoritative lease acquire. */
 	async acquireWriteLease(input: {
 		token: string
@@ -1573,6 +1593,8 @@ export type UserMeterRpc = DurableObjectPitrRpc & {
 	markDeleting: (input: {
 		deletingAt: string
 	}) => Promise<UserMeterMarkDeletingResult>
+	/** Drop the deletion tombstone after a pre-cleanup abort. */
+	clearDeleting: () => Promise<UserMeterClearDeletingResult>
 	/** Authoritative lease acquire. */
 	acquireWriteLease: (input: {
 		token: string

--- a/packages/worker/src/entitlements/user-meter-do.ts
+++ b/packages/worker/src/entitlements/user-meter-do.ts
@@ -1242,9 +1242,22 @@ class UserMeterBase extends DurableObject<Env> {
 	 * later writes and a retry can proceed. D1 `users.deleting_at` is cleared
 	 * by the caller first (permanent gate).
 	 */
-	async clearDeleting(): Promise<UserMeterClearDeletingResult> {
+	async clearDeleting(input?: {
+		expectedDeletingAt?: string
+	}): Promise<UserMeterClearDeletingResult> {
+		const expectedDeletingAt =
+			input?.expectedDeletingAt == null
+				? undefined
+				: assertDeletionTimestamp(
+						'expectedDeletingAt',
+						input.expectedDeletingAt,
+					)
 		return await this.ctx.blockConcurrencyWhile(async () => {
-			if (this.readDeletingAt() == null) return { cleared: false }
+			const current = this.readDeletingAt()
+			if (current == null) return { cleared: false }
+			if (expectedDeletingAt != null && current !== expectedDeletingAt) {
+				return { cleared: false }
+			}
 			this.ctx.storage.sql.exec(
 				`DELETE FROM deletion_state WHERE id = ?`,
 				deletionStateRowId,
@@ -1594,7 +1607,9 @@ export type UserMeterRpc = DurableObjectPitrRpc & {
 		deletingAt: string
 	}) => Promise<UserMeterMarkDeletingResult>
 	/** Drop the deletion tombstone after a pre-cleanup abort. */
-	clearDeleting: () => Promise<UserMeterClearDeletingResult>
+	clearDeleting: (input?: {
+		expectedDeletingAt?: string
+	}) => Promise<UserMeterClearDeletingResult>
 	/** Authoritative lease acquire. */
 	acquireWriteLease: (input: {
 		token: string

--- a/packages/worker/src/entitlements/user-meter.workers.test.ts
+++ b/packages/worker/src/entitlements/user-meter.workers.test.ts
@@ -833,6 +833,17 @@ test('UserMeter deletion leases: mark, acquire, release, repair, export, and pur
 		created: false,
 		leaseCount: 0,
 	})
+	expect(await meterA.clearDeleting()).toEqual({ cleared: true })
+	expect(await meterA.readDeletionState()).toEqual({ deletingAt: null })
+	expect(await meterA.clearDeleting()).toEqual({ cleared: false })
+	const rematch = await meterA.markDeleting({
+		deletingAt: '2026-08-01 10:00:00',
+	})
+	expect(rematch).toEqual({
+		deletingAt: '2026-08-01 10:00:00',
+		created: true,
+		leaseCount: 0,
+	})
 
 	// acquireWriteLease is idempotent (same token).
 	await expect(

--- a/packages/worker/src/entitlements/user-meter.workers.test.ts
+++ b/packages/worker/src/entitlements/user-meter.workers.test.ts
@@ -836,6 +836,23 @@ test('UserMeter deletion leases: mark, acquire, release, repair, export, and pur
 	expect(await meterA.clearDeleting()).toEqual({ cleared: true })
 	expect(await meterA.readDeletionState()).toEqual({ deletingAt: null })
 	expect(await meterA.clearDeleting()).toEqual({ cleared: false })
+	const thirdMark = await meterA.markDeleting({
+		deletingAt: '2026-08-01 12:00:00',
+	})
+	expect(thirdMark.created).toBe(true)
+	expect(
+		await meterA.clearDeleting({
+			expectedDeletingAt: '2026-08-01 10:00:00',
+		}),
+	).toEqual({ cleared: false })
+	expect(await meterA.readDeletionState()).toEqual({
+		deletingAt: '2026-08-01 12:00:00',
+	})
+	expect(
+		await meterA.clearDeleting({
+			expectedDeletingAt: '2026-08-01 12:00:00',
+		}),
+	).toEqual({ cleared: true })
 	const rematch = await meterA.markDeleting({
 		deletingAt: '2026-08-01 10:00:00',
 	})

--- a/packages/worker/src/mcp/capabilities/admin/admin-account-deletion-abort.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-account-deletion-abort.node.test.ts
@@ -1,0 +1,131 @@
+import { DatabaseSync } from 'node:sqlite'
+import { expect, test, vi } from 'vitest'
+import type * as AuditLog from '#worker/audit-log.ts'
+import { createD1FromSqlite } from '#worker/test-support/create-d1-from-sqlite.ts'
+import { createMcpCallerContext } from '#mcp/context.ts'
+import { testStableUserIdFromEmail } from '#worker/test-support/stable-user-id.ts'
+import { createInMemoryUserMeterEnv } from '#worker/test-support/user-meter.ts'
+import { userMeterRpc } from '#worker/entitlements/user-meter-client.ts'
+import { markAccountDeleting } from '#worker/account/deletion-state.ts'
+
+const mockModule = vi.hoisted(() => ({
+	logAuditEvent: vi.fn(async () => undefined),
+}))
+
+vi.mock('#worker/audit-log.ts', async (importOriginal) => {
+	const actual = await importOriginal<typeof AuditLog>()
+	return {
+		...actual,
+		logAuditEvent: (...args: Array<unknown>) =>
+			mockModule.logAuditEvent(...args),
+	}
+})
+
+const { adminAccountDeletionAbortCapability } =
+	await import('./admin-account-deletion-abort.ts')
+
+const stableUserId = testStableUserIdFromEmail('abort-fence@example.com')
+const abortReason = 'Leftover fence after a failed brand-new account delete.'
+
+function createCapabilityTestDb() {
+	const sqlite = new DatabaseSync(':memory:')
+	sqlite.exec(`
+		CREATE TABLE users (
+			id INTEGER PRIMARY KEY,
+			stable_user_id TEXT UNIQUE NOT NULL,
+			username TEXT NOT NULL,
+			email TEXT NOT NULL,
+			deleting_at TEXT,
+			created_at TEXT NOT NULL DEFAULT '2026-01-01T00:00:00.000Z',
+			updated_at TEXT NOT NULL DEFAULT '2026-01-01T00:00:00.000Z'
+		);
+		INSERT INTO users (stable_user_id, username, email)
+		VALUES ('${stableUserId}', 'abort-fence', 'abort-fence@example.com');
+	`)
+	return { sqlite, db: createD1FromSqlite(sqlite) }
+}
+
+function createAdminContext(
+	db: D1Database,
+	meterEnv: ReturnType<typeof createInMemoryUserMeterEnv>['env'],
+) {
+	return {
+		env: {
+			APP_DB: db,
+			...meterEnv,
+		} as unknown as Env,
+		callerContext: createMcpCallerContext({
+			baseUrl: 'https://heykody.dev',
+			user: {
+				userId: testStableUserIdFromEmail('admin@example.com'),
+				email: 'admin@example.com',
+				displayName: 'Admin',
+				roles: ['admin'],
+			},
+		}),
+	}
+}
+
+test('admin_account_deletion_abort clears D1 and UserMeter fences', async () => {
+	const { sqlite, db } = createCapabilityTestDb()
+	const meter = createInMemoryUserMeterEnv()
+	const meterStub = userMeterRpc({ env: meter.env, userId: stableUserId })
+	const ctx = createAdminContext(db, meter.env)
+
+	await markAccountDeleting({
+		db,
+		dbUserId: 1,
+		now: new Date('2026-08-31T15:22:12.000Z'),
+		env: meter.env,
+	})
+	expect(
+		sqlite.prepare(`SELECT deleting_at FROM users WHERE id = 1`).get(),
+	).toEqual({ deleting_at: '2026-08-31 15:22:12' })
+	expect(await meterStub.readDeletionState()).toEqual({
+		deletingAt: '2026-08-31 15:22:12',
+	})
+
+	const result = await adminAccountDeletionAbortCapability.handler(
+		{
+			stable_user_id: stableUserId,
+			reason: abortReason,
+		},
+		ctx,
+	)
+	expect(result).toEqual({ aborted: true })
+	expect(
+		sqlite.prepare(`SELECT deleting_at FROM users WHERE id = 1`).get(),
+	).toEqual({ deleting_at: null })
+	expect(await meterStub.readDeletionState()).toEqual({ deletingAt: null })
+	expect(mockModule.logAuditEvent).toHaveBeenCalledWith(
+		expect.objectContaining({
+			action: 'admin_account_deletion_abort',
+			result: 'success',
+			reason: `target_stable_user_id=${stableUserId};reason=${abortReason}`,
+		}),
+	)
+})
+
+test('admin_account_deletion_abort fails closed for an unknown user', async () => {
+	const { db } = createCapabilityTestDb()
+	const meter = createInMemoryUserMeterEnv()
+	const ctx = createAdminContext(db, meter.env)
+	const missingUserId = testStableUserIdFromEmail('missing@example.com')
+
+	await expect(
+		adminAccountDeletionAbortCapability.handler(
+			{
+				stable_user_id: missingUserId,
+				reason: abortReason,
+			},
+			ctx,
+		),
+	).rejects.toThrow('User not found.')
+	expect(mockModule.logAuditEvent).toHaveBeenCalledWith(
+		expect.objectContaining({
+			action: 'admin_account_deletion_abort',
+			result: 'failure',
+			reason: 'User not found.',
+		}),
+	)
+})

--- a/packages/worker/src/mcp/capabilities/admin/admin-account-deletion-abort.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-account-deletion-abort.ts
@@ -1,0 +1,51 @@
+import { z } from 'zod'
+import { abortAccountDeletingByStableUserId } from '#worker/account/deletion-state.ts'
+import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
+import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
+import {
+	adminMutationCapabilityAccess,
+	auditAdminCapabilityInvocation,
+	stableUserIdSchema,
+} from './admin-shared.ts'
+
+export const adminAccountDeletionAbortCapability = defineDomainCapability(
+	capabilityDomainNames.admin,
+	{
+		...adminMutationCapabilityAccess,
+		name: 'admin_account_deletion_abort',
+		description:
+			'Clear a leftover account-deletion fence (D1 users.deleting_at and the UserMeter tombstone) when cleanup never started or an operator needs to restore the account. Admin-only and destructive.',
+		keywords: ['admin', 'account', 'deletion', 'fence', 'abort', 'repair'],
+		destructive: true,
+		inputSchema: z.object({
+			stable_user_id: stableUserIdSchema,
+			reason: z
+				.string()
+				.min(10)
+				.describe(
+					'Audit reason for clearing the leftover deletion fence, at least 10 characters.',
+				),
+		}),
+		outputSchema: z.object({
+			aborted: z.literal(true),
+		}),
+		async handler(args, ctx) {
+			return auditAdminCapabilityInvocation(
+				ctx,
+				'admin_account_deletion_abort',
+				async () => {
+					await abortAccountDeletingByStableUserId({
+						db: ctx.env.APP_DB,
+						stableUserId: args.stable_user_id,
+						env: ctx.env,
+					})
+					return { aborted: true as const }
+				},
+				{
+					successReason: () =>
+						`target_stable_user_id=${args.stable_user_id};reason=${args.reason}`,
+				},
+			)
+		},
+	},
+)

--- a/packages/worker/src/mcp/capabilities/admin/domain.ts
+++ b/packages/worker/src/mcp/capabilities/admin/domain.ts
@@ -31,6 +31,7 @@ import { adminUserGetCapability } from './admin-user-get.ts'
 import { adminUserListCapability } from './admin-user-list.ts'
 import { adminUserUpdateCapability } from './admin-user-update.ts'
 import { adminUserVerifyCapability } from './admin-user-verify.ts'
+import { adminAccountDeletionAbortCapability } from './admin-account-deletion-abort.ts'
 import { adminAccountWriteLeaseListCapability } from './admin-account-write-lease-list.ts'
 import { adminAccountWriteLeaseRepairCapability } from './admin-account-write-lease-repair.ts'
 import { adminUserMeterParityCapability } from './admin-user-meter-parity.ts'
@@ -82,6 +83,7 @@ export const adminDomain = defineDomain({
 		adminMailboxMaintenanceCapability,
 		adminAccountWriteLeaseListCapability,
 		adminAccountWriteLeaseRepairCapability,
+		adminAccountDeletionAbortCapability,
 		adminPlatformAccountCreateCapability,
 		adminPlatformOauthAppSaveCapability,
 		adminPlatformOauthAppListCapability,

--- a/packages/worker/src/mcp/capabilities/registry.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/registry.node.test.ts
@@ -97,6 +97,7 @@ test('getCapabilityRegistryForContext filters admin capabilities by current call
 
 	expect(adminRegistry.capabilityMap.admin_user_list).toBeTruthy()
 	expect(adminRegistry.capabilityMap.admin_user_meter_parity).toBeTruthy()
+	expect(adminRegistry.capabilityMap.admin_account_deletion_abort).toBeTruthy()
 	expect(adminRegistry.capabilityMap.admin_mailbox_maintenance).toBeTruthy()
 	expect(
 		adminRegistry.capabilityMap.admin_user_meter_storage_reconcile,
@@ -106,6 +107,9 @@ test('getCapabilityRegistryForContext filters admin capabilities by current call
 	).toBe(true)
 	expect(regularRegistry.capabilityMap.admin_user_list).toBeUndefined()
 	expect(regularRegistry.capabilityMap.admin_user_meter_parity).toBeUndefined()
+	expect(
+		regularRegistry.capabilityMap.admin_account_deletion_abort,
+	).toBeUndefined()
 	expect(
 		regularRegistry.capabilityMap.admin_user_meter_storage_reconcile,
 	).toBeUndefined()

--- a/packages/worker/src/test-support/account-deletion.ts
+++ b/packages/worker/src/test-support/account-deletion.ts
@@ -93,6 +93,15 @@ export function createTestDb(
 									}))
 								return { results: results as Array<T>, meta: { changes: 0 } }
 							}
+							if (lower === 'select stable_user_id from users where id = ?') {
+								const numericId = Number(params[0])
+								results = (rows.users ?? [])
+									.filter((row) => Number(row['id']) === numericId)
+									.map((row) => ({
+										stable_user_id: row['stable_user_id'],
+									}))
+								return { results: results as Array<T>, meta: { changes: 0 } }
+							}
 							if (
 								lower ===
 								'select stable_user_id, deleting_at from users where id = ?'
@@ -272,6 +281,19 @@ export function createTestDb(
 									if (row['id'] !== params[2]) continue
 									row['deleting_at'] ??= params[0]
 									row['updated_at'] = params[1]
+									changed += 1
+								}
+								return { meta: { changes: changed } }
+							}
+							if (
+								lower ===
+								'update users set deleting_at = null, updated_at = ? where id = ?'
+							) {
+								let changed = 0
+								for (const row of rows.users ?? []) {
+									if (row['id'] !== params[1]) continue
+									row['deleting_at'] = null
+									row['updated_at'] = params[0]
 									changed += 1
 								}
 								return { meta: { changes: changed } }

--- a/packages/worker/src/test-support/account-deletion.ts
+++ b/packages/worker/src/test-support/account-deletion.ts
@@ -274,13 +274,28 @@ export function createTestDb(
 							const userId = params[0] as string | number
 							if (
 								lower ===
-								'update users set deleting_at = coalesce(deleting_at, ?), updated_at = ? where id = ?'
+								'update users set deleting_at = ?, updated_at = ? where id = ? and deleting_at is null'
 							) {
 								let changed = 0
 								for (const row of rows.users ?? []) {
 									if (row['id'] !== params[2]) continue
-									row['deleting_at'] ??= params[0]
+									if (row['deleting_at'] != null) continue
+									row['deleting_at'] = params[0]
 									row['updated_at'] = params[1]
+									changed += 1
+								}
+								return { meta: { changes: changed } }
+							}
+							if (
+								lower ===
+								'update users set deleting_at = null, updated_at = ? where id = ? and deleting_at = ?'
+							) {
+								let changed = 0
+								for (const row of rows.users ?? []) {
+									if (row['id'] !== params[1]) continue
+									if (row['deleting_at'] !== params[2]) continue
+									row['deleting_at'] = null
+									row['updated_at'] = params[0]
 									changed += 1
 								}
 								return { meta: { changes: changed } }

--- a/packages/worker/src/test-support/user-meter.ts
+++ b/packages/worker/src/test-support/user-meter.ts
@@ -307,6 +307,11 @@ export function createInMemoryUserMeterEnv() {
 					leaseCount,
 				}
 			},
+			async clearDeleting() {
+				if (deletion.deletingAt == null) return { cleared: false }
+				deletion.deletingAt = null
+				return { cleared: true }
+			},
 			async acquireWriteLease(input: {
 				token: string
 				holder: string

--- a/packages/worker/src/test-support/user-meter.ts
+++ b/packages/worker/src/test-support/user-meter.ts
@@ -307,8 +307,14 @@ export function createInMemoryUserMeterEnv() {
 					leaseCount,
 				}
 			},
-			async clearDeleting() {
+			async clearDeleting(input?: { expectedDeletingAt?: string }) {
 				if (deletion.deletingAt == null) return { cleared: false }
+				if (
+					input?.expectedDeletingAt != null &&
+					deletion.deletingAt !== input.expectedDeletingAt
+				) {
+					return { cleared: false }
+				}
 				deletion.deletingAt = null
 				return { cleared: true }
 			},


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

A failed account delete must not trap the user in a `/account` ↔ `/login` redirect loop, block logout, or leave `users.deleting_at` set when cleanup never started.

## Why

Deleting a brand-new account marked `users.deleting_at` (and the UserMeter tombstone) before cleanup. After that:

1. `/account` treated the user as unauthenticated and redirected to `/login?redirectTo=/account`.
2. `/login` still saw a live session and redirected back to `/account`.
3. `POST /logout` hit the write-lease middleware and returned `409 account_deleting`, so the cookie never cleared and the nav still showed the user.
4. Signing in again issued a new cookie, then the same loop hit `/account`.

That matches a leftover deletion fence, not a missing user row. Production still has one leftover fence on a brand-new test account (no active write leases). New deletes abort that fence themselves when **this attempt** created it; already-fenced rows need an operator abort after this deploys.

## Summary

- Abort the deletion fence when writers are still active or inventory cannot be collected **and this invocation created the fence** (`WHERE deleting_at IS NULL`, then `expectedDeletingAt` on abort).
- If `markDeleting` on UserMeter fails and this invocation wrote D1, roll back only that timestamp.
- A retry against an already-fenced account keeps the tombstone so cleanup can finish.
- Treat deleting accounts as signed out in the SSR shell and destroy the session cookie, including on the rendered `/login` page.
- Allow `POST /logout` while an account is deleting.
- Add `admin_account_deletion_abort` so operators can clear a leftover fence by stable user id after confirming with `admin_user_meter_parity`.

Cleanup failures that happen after inventory still keep the fence so a retry can finish.

## Testing

- Node: account deletion, deletion-state abort/ownership, cleanup pre-cleanup cases, `/account` + `/login` deleting-session handlers, session-info cookie clear, logout middleware, admin abort capability
- Workers: UserMeter `clearDeleting` including expected-timestamp mismatch
- Pre-push: `CI=1 npm run test:node` and `CI=1 npm run test:workers`

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `d3d6f588` · **Head:** `00c14f75`

**Classification:** extends — UserMeter gains `clearDeleting` with an expected-timestamp guard; app session/auth treats a deleting account as signed out and destroys the cookie; admin RBAC gains an abort capability for leftover fences.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | extends — deleting sessions are signed out; `/logout` is exempt from the write-lease fence |
| `user-meter` | storage | extends — `clearDeleting` plus D1 fence abort only for the fence this attempt created |
| `rbac` | auth | extends — `admin_account_deletion_abort` clears leftover D1 + UserMeter fences |
| `capability-registry` | assistant | composes — registers the admin abort capability |
| `entitlements` | auth | composes — workers coverage for the new meter RPC |

### Change flow

A failed first delete no longer leaves the browser bouncing. A retry after cleanup started cannot unfence another attempt.

```mermaid
sequenceDiagram
	actor User
	actor Admin
	participant appUi as app-ui
	participant userMeter as user-meter
	participant rbac as rbac
	User->>appUi: POST /account/delete
	appUi->>appUi: SET deleting_at WHERE deleting_at IS NULL
	appUi->>userMeter: markDeleting
	alt this attempt created the fence and writers or inventory fail
		appUi->>userMeter: clearDeleting expectedDeletingAt
		appUi->>appUi: clear matching users.deleting_at
		appUi-->>User: 503 try again
	else fence already existed or cleanup started
		Note over appUi: fence stays so retry can finish
	end
	User->>appUi: GET /account with leftover fence
	appUi-->>User: 302 /login and destroy kody_session
	User->>appUi: GET /login
	appUi-->>User: 200 login plus Max-Age=0 cookie
	User->>appUi: POST /logout
	appUi-->>User: 302 /login (no 409)
	Admin->>rbac: admin_account_deletion_abort
	rbac->>userMeter: clearDeleting
	rbac->>rbac: clear users.deleting_at
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d2e9331f-8e81-48a9-8bb2-55b7442a5065?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d2e9331f-8e81-48a9-8bb2-55b7442a5065&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Account deletion now safely rolls back when validation or active writers prevent completion.
  * Deletion attempts no longer clear state owned by another attempt.
  * Users in deletion are signed out, redirected to login, and have their session cookie cleared.
  * Logout remains available while deletion is in progress.

* **New Features**
  * Added an administrative capability to clear leftover account-deletion state.

* **Documentation**
  * Clarified account-deletion recovery and cleanup procedures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->