### PR TITLE
Render locked-package approve-publish URL instead of a blank page

### DIFF
--- a/packages/worker/client/client-router.node.test.ts
+++ b/packages/worker/client/client-router.node.test.ts
@@ -85,6 +85,27 @@ test('client route and loader matching prefer specific static routes over dynami
 	)
 })
 
+test('package approve-publish is not swallowed by the package detail route', () => {
+	const packageDetailRoute = 'package-detail-route' as unknown as JSX.Element
+	const approvePublishRoute = 'approve-publish-route' as unknown as JSX.Element
+	const packageRoutes = {
+		[routePattern(routes.accountPackageDetail)]: packageDetailRoute,
+		[routePattern(routes.accountPackageApprovePublish)]: approvePublishRoute,
+	}
+	expect(matchRoute('/account/packages/pkg-1', packageRoutes)).toBe(
+		packageDetailRoute,
+	)
+	expect(
+		matchRoute('/account/packages/pkg-1/approve-publish', packageRoutes),
+	).toBe(approvePublishRoute)
+	expect(
+		matchRoute(
+			'/account/packages/pkg-1/approve-publish?commit=abc1234',
+			packageRoutes,
+		),
+	).toBe(approvePublishRoute)
+})
+
 test('view transitions skip shell tab switches, including when from-path was never recorded', () => {
 	// Tab switching inside the account/admin shell: the rail is unchanged and
 	// full-height, so a snapshot transition would squash it between two page

--- a/packages/worker/client/routes/account-package-approve-publish.node.test.ts
+++ b/packages/worker/client/routes/account-package-approve-publish.node.test.ts
@@ -1,0 +1,53 @@
+import { jsx } from 'remix/ui/jsx-runtime'
+import { renderToString } from 'remix/ui/server'
+import { expect, test } from 'vitest'
+import { AppLoaderDataProvider } from '#client/loader-data-context.tsx'
+import { RouterLocationProvider } from '#client/router-location.tsx'
+import { AccountPackageApprovePublishRoute } from '#client/routes/account-package-approve-publish.tsx'
+import { type AccountPackageApprovePublishLoaderData } from '#universal/loader-data.ts'
+
+const approvePublishHref =
+	'/account/packages/1c43570a-b9ab-46c9-86ec-6c9f02926944/approve-publish?commit=34f338c19f91c698c3a28edd2992e0ab87dcb4e0'
+
+const loaderData: AccountPackageApprovePublishLoaderData = {
+	ok: true,
+	email: 'owner@example.com',
+	package: {
+		id: '1c43570a-b9ab-46c9-86ec-6c9f02926944',
+		name: '@kodykoala/gmail-drafts',
+		kodyId: 'gmail-drafts',
+		sourceId: 'source-1',
+		lockedAt: '2026-08-31T18:00:00.000Z',
+	},
+	publishedCommit: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+	pendingCommit: '34f338c19f91c698c3a28edd2992e0ab87dcb4e0',
+	alreadyPublished: false,
+	filesHref: '/account/packages/1c43570a-b9ab-46c9-86ec-6c9f02926944/files',
+	packageHref: '/@kodykoala/gmail-drafts',
+}
+
+test('approve-publish SSR renders the promote card without a browser location', async () => {
+	// Workers SSR has no `location` global. The previous setup-phase read of
+	// `location.pathname` threw and streamed a blank document for the
+	// documented locked-package approval_url.
+	expect(typeof globalThis.location).toBe('undefined')
+
+	const html = await renderToString(
+		jsx(RouterLocationProvider, {
+			url: approvePublishHref,
+			children: jsx(AppLoaderDataProvider, {
+				loaderData: { accountPackageApprovePublish: loaderData },
+				children: jsx(AccountPackageApprovePublishRoute, {}),
+			}),
+		}),
+	)
+
+	expect(html).toContain('Approve package publish')
+	expect(html).toContain('data-testid="package-approve-publish-card"')
+	expect(html).toContain('@kodykoala/gmail-drafts')
+	expect(html).toContain('34f338c19f91c698c3a28edd2992e0ab87dcb4e0')
+	expect(html).toContain('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
+	expect(html).toContain('Promote this commit')
+	expect(html).toContain('Browse published files')
+	expect(html).not.toContain('Loading…')
+})

--- a/packages/worker/client/routes/account-package-approve-publish.tsx
+++ b/packages/worker/client/routes/account-package-approve-publish.tsx
@@ -1,7 +1,10 @@
 import { type Handle, css } from 'remix/ui'
 import { routes } from '#universal/routes.ts'
 import { on } from '#client/event-mixin.ts'
+import { readCurrentRouterHref } from '#client/client-router.tsx'
 import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
+import { consumeStaleNavigationData } from '#client/navigation-data.ts'
+import { createRouteLoadLatch } from '#client/route-load-latch.ts'
 import { readJson } from '#client/routes/account-approval-shared.ts'
 import {
 	AccountManagementMessage,
@@ -23,14 +26,20 @@ import {
 } from '#client/route-loader.ts'
 
 const accountPackagesApiPath = '/account/packages.json'
+const approvePublishPathPattern =
+	/^\/account\/packages\/([^/]+)\/approve-publish\/?$/
 
 type PageStatus = 'loading' | 'ready' | 'error' | 'promoting'
 
+function isApprovePublishPath(href: string) {
+	return approvePublishPathPattern.test(
+		new URL(href, 'http://localhost').pathname,
+	)
+}
+
 function buildApprovePublishApiUrl(href: string) {
 	const url = new URL(href, 'http://localhost')
-	const match = url.pathname.match(
-		/^\/account\/packages\/([^/]+)\/approve-publish\/?$/,
-	)
+	const match = url.pathname.match(approvePublishPathPattern)
 	const packageId = match?.[1] ? decodeURIComponent(match[1]) : ''
 	const apiUrl = new URL(
 		routes.accountPackageApprovePublishApi.href({ packageId }),
@@ -66,30 +75,17 @@ export function AccountPackageApprovePublishRoute(handle: Handle) {
 	let status: PageStatus = 'loading'
 	let payload: AccountPackageApprovePublishLoaderData | null = null
 	let message: string | null = null
-	let currentHref = `${location.pathname}${location.search}`
+	const loadLatch = createRouteLoadLatch()
 
-	async function loadPage() {
-		const href = `${location.pathname}${location.search}`
-		const routeData = tryConsumeRouteLoaderData(
-			handle,
-			'accountPackageApprovePublish',
-			href,
-		)
-		if (routeData) {
-			payload = routeData
-			status = 'ready'
-			handle.update()
-			return
-		}
-		status = 'loading'
-		handle.update()
+	async function loadPage(href: string) {
+		// Do not call handle.update() before the first await — see blog.tsx.
 		try {
 			const response = await fetch(buildApprovePublishApiUrl(href), {
 				headers: { Accept: 'application/json' },
 				credentials: 'include',
 			})
 			if (response.status === 401) {
-				location.href = '/login'
+				window.location.assign('/login')
 				return
 			}
 			const next =
@@ -97,15 +93,19 @@ export function AccountPackageApprovePublishRoute(handle: Handle) {
 			if (!response.ok || !next?.ok) {
 				status = 'error'
 				message = 'Unable to load this publish approval.'
+				loadLatch.markFailed(href)
 				handle.update()
 				return
 			}
 			payload = next
 			status = 'ready'
+			message = null
+			loadLatch.markLoaded(href)
 			handle.update()
 		} catch {
 			status = 'error'
 			message = 'Unable to load this publish approval.'
+			loadLatch.markFailed(href)
 			handle.update()
 		}
 	}
@@ -136,7 +136,7 @@ export function AccountPackageApprovePublishRoute(handle: Handle) {
 				handle.update()
 				return
 			}
-			location.href = payload.packageHref
+			window.location.assign(payload.packageHref)
 		} catch {
 			status = 'ready'
 			message = 'Could not promote this commit.'
@@ -144,140 +144,175 @@ export function AccountPackageApprovePublishRoute(handle: Handle) {
 		}
 	}
 
-	handle.queueTask(loadPage)
+	return () => {
+		const currentHref = readCurrentRouterHref(handle)
+		if (!isApprovePublishPath(currentHref)) {
+			return <AccountManagementShell>{null}</AccountManagementShell>
+		}
 
-	return () => (
-		<AccountManagementShell>
-			<AccountPageHeader
-				title="Approve package publish"
-				description="Review the commit, then promote it to the live published pointer. The package stays locked."
-				currentHref={currentHref}
-			/>
-			{message ? (
-				<AccountManagementMessage tone="error">
-					{message}
-				</AccountManagementMessage>
-			) : null}
-			{status === 'loading' ? (
-				<p mix={css({ margin: 0, color: colors.textMuted })}>Loading…</p>
-			) : null}
-			{status === 'error' ? (
-				<p mix={css({ margin: 0, color: colors.textMuted })}>
-					This publish approval could not be loaded.
-				</p>
-			) : null}
-			{payload && (status === 'ready' || status === 'promoting') ? (
-				<section
-					data-testid="package-approve-publish-card"
-					mix={css(getAccentCalloutCss())}
-				>
-					<div mix={css({ display: 'grid', gap: spacing.xs })}>
-						<h2
-							mix={css({
-								margin: 0,
-								fontSize: typography.fontSize.lg,
-								fontWeight: typography.fontWeight.semibold,
-								color: colors.text,
-							})}
-						>
-							{payload.package.name}
-						</h2>
-						<p mix={css({ margin: 0, color: colors.textMuted })}>
-							{payload.package.lockedAt
-								? 'This package is locked. Promoting a commit does not unlock it.'
-								: 'This package is not locked. Lock it from the package page if you want later publishes to require approval.'}
-						</p>
-					</div>
-					<MetadataGrid
-						items={[
-							{
-								label: 'Kody id',
-								value: (
-									<IdValue value={payload.package.kodyId} label="Kody id" />
-								),
-							},
-							{
-								label: 'Current published commit',
-								value: payload.publishedCommit ? (
-									<IdValue
-										value={payload.publishedCommit}
-										label="published commit"
-									/>
-								) : (
-									'None'
-								),
-							},
-							{
-								label: 'Commit to promote',
-								value: payload.pendingCommit ? (
-									<IdValue
-										value={payload.pendingCommit}
-										label="pending commit"
-									/>
-								) : (
-									'No unpublished commit'
-								),
-							},
-						]}
-					/>
-					<div
-						mix={css({
-							display: 'flex',
-							flexWrap: 'wrap',
-							gap: spacing.xs,
-						})}
+		const routeData = tryConsumeRouteLoaderData(
+			handle,
+			'accountPackageApprovePublish',
+			currentHref,
+		)
+		const appliedRouteData = Boolean(routeData?.ok)
+		if (routeData?.ok) {
+			payload = routeData
+			status = 'ready'
+			message = null
+			loadLatch.markLoaded(currentHref)
+		}
+
+		const needsStaleRefresh = consumeStaleNavigationData(currentHref)
+		const needsLoad = loadLatch.needsLoad({
+			currentHref,
+			appliedRouteData,
+			needsStaleRefresh,
+		})
+		if (needsLoad && typeof document !== 'undefined') {
+			status = 'loading'
+			handle.queueTask(async () => {
+				try {
+					await loadPage(currentHref)
+				} catch {
+					loadLatch.markFailed(currentHref)
+				}
+			})
+		}
+
+		return (
+			<AccountManagementShell>
+				<AccountPageHeader
+					title="Approve package publish"
+					description="Review the commit, then promote it to the live published pointer. The package stays locked."
+					currentHref={currentHref}
+				/>
+				{message ? (
+					<AccountManagementMessage tone="error">
+						{message}
+					</AccountManagementMessage>
+				) : null}
+				{status === 'loading' ? (
+					<p mix={css({ margin: 0, color: colors.textMuted })}>Loading…</p>
+				) : null}
+				{status === 'error' ? (
+					<p mix={css({ margin: 0, color: colors.textMuted })}>
+						This publish approval could not be loaded.
+					</p>
+				) : null}
+				{payload && (status === 'ready' || status === 'promoting') ? (
+					<section
+						data-testid="package-approve-publish-card"
+						mix={css(getAccentCalloutCss())}
 					>
-						{payload.alreadyPublished || !payload.pendingCommit ? (
-							<a
-								href={payload.packageHref}
+						<div mix={css({ display: 'grid', gap: spacing.xs })}>
+							<h2
 								mix={css({
-									...getPillButtonCss({ size: 'sm' }),
-									display: 'inline-flex',
-									textDecoration: 'none',
+									margin: 0,
+									fontSize: typography.fontSize.lg,
+									fontWeight: typography.fontWeight.semibold,
+									color: colors.text,
 								})}
 							>
-								Back to package
-							</a>
-						) : (
-							<>
-								<button
-									type="button"
-									data-testid="approve-package-publish"
-									disabled={status === 'promoting'}
-									mix={[
-										css(getPillButtonCss({ size: 'sm' })),
-										on('click', () => void promoteCommit()),
-									]}
-								>
-									{status === 'promoting'
-										? 'Promoting…'
-										: 'Promote this commit'}
-								</button>
+								{payload.package.name}
+							</h2>
+							<p mix={css({ margin: 0, color: colors.textMuted })}>
+								{payload.package.lockedAt
+									? 'This package is locked. Promoting a commit does not unlock it.'
+									: 'This package is not locked. Lock it from the package page if you want later publishes to require approval.'}
+							</p>
+						</div>
+						<MetadataGrid
+							items={[
+								{
+									label: 'Kody id',
+									value: (
+										<IdValue value={payload.package.kodyId} label="Kody id" />
+									),
+								},
+								{
+									label: 'Current published commit',
+									value: payload.publishedCommit ? (
+										<IdValue
+											value={payload.publishedCommit}
+											label="published commit"
+										/>
+									) : (
+										'None'
+									),
+								},
+								{
+									label: 'Commit to promote',
+									value: payload.pendingCommit ? (
+										<IdValue
+											value={payload.pendingCommit}
+											label="pending commit"
+										/>
+									) : (
+										'No unpublished commit'
+									),
+								},
+							]}
+						/>
+						<div
+							mix={css({
+								display: 'flex',
+								flexWrap: 'wrap',
+								gap: spacing.xs,
+							})}
+						>
+							{payload.alreadyPublished || !payload.pendingCommit ? (
 								<a
 									href={payload.packageHref}
 									mix={css({
-										...getGhostButtonCss({ size: 'sm' }),
+										...getPillButtonCss({ size: 'sm' }),
 										display: 'inline-flex',
 										textDecoration: 'none',
 									})}
 								>
-									Cancel
+									Back to package
 								</a>
-							</>
-						)}
-						<a
-							href={payload.filesHref}
-							mix={css({
-								...getGhostButtonCss({ size: 'sm' }),
-								display: 'inline-flex',
-								textDecoration: 'none',
-							})}
-						>
-							Browse published files
-						</a>
-					</div>
-				</section>
-			) : null}
-		</AccountManagementShell>
-	)
+							) : (
+								<>
+									<button
+										type="button"
+										data-testid="approve-package-publish"
+										disabled={status === 'promoting'}
+										mix={[
+											css(getPillButtonCss({ size: 'sm' })),
+											on('click', () => void promoteCommit()),
+										]}
+									>
+										{status === 'promoting'
+											? 'Promoting…'
+											: 'Promote this commit'}
+									</button>
+									<a
+										href={payload.packageHref}
+										mix={css({
+											...getGhostButtonCss({ size: 'sm' }),
+											display: 'inline-flex',
+											textDecoration: 'none',
+										})}
+									>
+										Cancel
+									</a>
+								</>
+							)}
+							<a
+								href={payload.filesHref}
+								mix={css({
+									...getGhostButtonCss({ size: 'sm' }),
+									display: 'inline-flex',
+									textDecoration: 'none',
+								})}
+							>
+								Browse published files
+							</a>
+						</div>
+					</section>
+				) : null}
+			</AccountManagementShell>
+		)
+	}
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Make the documented locked-package `approval_url` (`/account/packages/:packageId/approve-publish?commit=<sha>`) render so an owner can review the named commit and promote it.

## Why

`repo_publish_session` / locked-package publish returns `status: "locked"` with that URL. Opening it streamed a blank document: the route read the browser `location` global during component setup, which does not exist in Workers SSR, and it only consumed embedded loader data inside `queueTask` (a no-op on the server). The package page still had a working promote path, so this was degraded rather than a blocked publish.

## Summary

- Read the Remix router href instead of `location` during setup.
- Consume SSR-embedded approve-publish loader data on first render, matching other account routes.
- Keep client refetch behind `typeof document !== 'undefined'` and the existing route load latch.
- Add an SSR `renderToString` test that asserts the promote card with no `location` global, plus a client-router specificity check so package detail does not swallow `/approve-publish`.

This does **not** add a pending-vs-live file diff. The page still shows the two commit SHAs and a "Browse published files" link (published tree only). A tree diff is a separate product surface.

## Testing

- `npx vitest run --project node-unit` on the new approve-publish SSR test and client-router specificity test (8 passed).
- Pre-push hook: `CI=1 npm run test:node` (747 files / 2261 tests) and `CI=1 npm run test:workers` (88 files / 307 tests).
- Commit hook typecheck and `migrations:check` passed.

Could not verify the live logged-in promote flow in a browser here (needs a locked package with a pending commit). The SSR test is the contract that failed in production: Workers has no `location`, and the page must render the promote card from embedded loader data.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `f6e9ff47` · **Head:** `8074470e`

**Classification:** composes — no primitives added or changed; the approve-publish account route now uses the existing Remix SSR loader-data path.

### Primitives touched

| Primitive | Group    | Impact   |
| --------- | -------- | -------- |
| `app-ui`  | surfaces | composes |

### Change flow

Locked-package `approval_url` SSR now reads the router href and embedded loader data instead of the missing browser `location` global.

```mermaid
sequenceDiagram
	actor Owner
	participant appUi as app-ui
	Owner->>appUi: GET /account/packages/:id/approve-publish?commit=sha
	Note over appUi: previously threw on location.pathname during setup
	appUi->>appUi: readCurrentRouterHref + consume embedded loader data
	appUi-->>Owner: promote card (pending vs published SHAs)
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dd6a952f-9221-4822-9f8b-e837a46afd03?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dd6a952f-9221-4822-9f8b-e837a46afd03&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed package approval and publish routes taking precedence over package detail routes, including URLs with query parameters.
  * Improved client-side navigation so approval and publish pages load the correct content after navigation.
  * Fixed server-rendered approval and publish pages to display package and commit details instead of an incorrect loading state.
  * Improved redirects after authentication failures and successful promotions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->