### PR TITLE
Show recent successes on /account/activity

### DIFF
--- a/docs/contributing/architecture/run-records.md
+++ b/docs/contributing/architecture/run-records.md
@@ -377,8 +377,9 @@ retention anchors only. History browsers (`/account/activity`, `run_list` /
 Execution `status` stays `running` / `success` / `error`. Retained **error**
 rows may also carry soft triage (`error_triage`: `ignored` | `resolved`, plus
 optional `triage_note`, `triaged_at`, `triaged_by`). Triage is non-destructive:
-error name/message/logs stay put; Activity and `run_list` default to
-`error_triage=open` so handled noise drops out of the default view;
+error name/message/logs stay put; Activity's Open errors view and `run_list`
+default to `error_triage=open` so handled noise drops out of the default view;
+Activity's Recent runs view lists the last 7 days with `error_triage=all`;
 `run_summary.errors` counts only open errors and exposes separate `ignored` /
 `resolved` totals. Terminal `finishRun` upserts preserve triage on error
 finishes and clear it if a row somehow finishes non-error. A later successful
@@ -399,9 +400,10 @@ Schema version 10 on the RunLog DO.
 
 ## Reading the data
 
-- UI: `/account/activity` (open failures first by default; status / triage /
-  surface filters, 7-day summary with ignored/resolved counts, log viewer,
-  cursor pagination). `/account/jobs` recent runs link into it.
+- UI: `/account/activity` (open failures first by default; Recent runs lists the
+  last 7 days of successes and errors; status / triage / surface filters, 7-day
+  summary with ignored/resolved counts, log viewer, cursor pagination).
+  `/account/jobs` recent runs link into it.
 - MCP domain `runs`: `run_list`, `run_get`, `run_summary`, `run_update`,
   `run_update_bulk`.
 - Account export: section `run_records` pages through the user’s `RunLog`.

--- a/docs/use/activity.md
+++ b/docs/use/activity.md
@@ -6,16 +6,20 @@ keeps a short execution history so you (and your agent) can see what happened.
 ## Where to look
 
 Open **`/account/activity`** while signed in. The page defaults to **open
-failures first**, with:
+failures first**, and a **Recent runs** view lists the last 7 days of history
+(successes, running work, and errors) from the same records:
 
 - a short summary of recent totals, open errors, and ignored/resolved counts
-- filters by status, triage (open / ignored / resolved / all), and runtime
-  surface (jobs, webhooks, package apps, workflows, and others)
+- a view toggle between **Open errors** and **Recent runs**
+- filters by status (including success), triage (open / ignored / resolved /
+  all), and runtime surface (jobs, webhooks, package apps, workflows, and
+  others)
 - a detail view with captured log lines and any triage note
 - cursor pagination for older pages
 
-Ignored and resolved error runs stay in history but are hidden from the default
-view so soft-failures and already-fixed noise do not clutter Activity.
+Ignored and resolved error runs stay in history but are hidden from Open errors
+so soft-failures and already-fixed noise do not clutter triage. Recent runs
+shows them unless you change the triage filter.
 
 From **`/account/jobs`**, each job’s recent runs link into the same Activity
 detail view.
@@ -30,7 +34,8 @@ The MCP **`runs`** domain reads and triages the same data:
 - **`run_summary`** — “is anything broken?” open-error totals (plus ignored /
   resolved counts) and per-surface breakdown
 - **`run_list`** — filtered history (by surface, status, job, package, time, and
-  `error_triage`; defaults to **open**, hiding ignored/resolved)
+  `error_triage`; defaults to **open**, hiding ignored/resolved). Pass `status`
+  `success` (or omit `status` with `error_triage` `all`) to inspect what ran.
 - **`run_get`** — one run plus its log lines and triage fields
 - **`run_update`** — mark a retained **error** run as `ignored` or `resolved`
   (or `open` to clear triage), with an optional note — non-destructive soft

--- a/packages/worker/client/routes/account-activity-shared.ts
+++ b/packages/worker/client/routes/account-activity-shared.ts
@@ -5,14 +5,30 @@ import {
 	type RouteLoaderResult,
 } from '#client/route-loader.ts'
 import {
-	type AccountActivityLoaderData,
-	type AccountActivityRunDetail,
-	type AccountActivityRunListItem,
+	readAccountActivityStatusFilter,
+	readAccountActivitySurfaceFilter,
+	readAccountActivityTriageFilter,
+	readAccountActivityViewFilter,
 	type AccountActivityStatusFilter,
 	type AccountActivitySurfaceFilter,
 	type AccountActivityTriageFilter,
+	type AccountActivityViewFilter,
+} from '#universal/account-activity-filters.ts'
+import {
+	type AccountActivityLoaderData,
+	type AccountActivityRunDetail,
+	type AccountActivityRunListItem,
 } from '#universal/loader-data.ts'
 import { colors } from '#universal/styles/tokens.ts'
+
+export {
+	activityEmptyLabel,
+	buildActivitySearch,
+	readAccountActivityStatusFilter as readStatusFilter,
+	readAccountActivitySurfaceFilter as readSurfaceFilter,
+	readAccountActivityTriageFilter as readTriageFilter,
+	readAccountActivityViewFilter as readViewFilter,
+} from '#universal/account-activity-filters.ts'
 
 export const activityErrorReviewPrompt = [
 	'Look at my open Kody activity errors.',
@@ -23,12 +39,21 @@ export const activityErrorReviewPrompt = [
 export const accountActivityApiPath = '/account/activity.json'
 export const activityRoute = createListDetailRoute('/account/activity')
 
+export const viewFilterOptions: Array<{
+	value: AccountActivityViewFilter
+	label: string
+}> = [
+	{ value: 'errors', label: 'Open errors' },
+	{ value: 'recent', label: 'Recent runs' },
+]
+
 export const statusFilterOptions: Array<{
 	value: AccountActivityStatusFilter
 	label: string
 }> = [
 	{ value: 'error', label: 'Errors' },
 	{ value: 'all', label: 'All' },
+	{ value: 'success', label: 'Success' },
 	{ value: 'running', label: 'Running' },
 ]
 
@@ -123,30 +148,6 @@ export function runDisplayName(run: AccountActivityRunListItem) {
 	return run.name?.trim() || surfaceLabel(run.surface)
 }
 
-export function readStatusFilter(href: string): AccountActivityStatusFilter {
-	const value = new URL(href, 'http://localhost').searchParams
-		.get('status')
-		?.trim()
-	if (value === 'all' || value === 'running' || value === 'error') return value
-	return 'error'
-}
-
-export function readSurfaceFilter(href: string): AccountActivitySurfaceFilter {
-	const value = new URL(href, 'http://localhost').searchParams
-		.get('surface')
-		?.trim()
-	const match = surfaceFilterOptions.find((option) => option.value === value)
-	return match?.value ?? 'all'
-}
-
-export function readTriageFilter(href: string): AccountActivityTriageFilter {
-	const params = new URL(href, 'http://localhost').searchParams
-	const value =
-		params.get('error_triage')?.trim() ?? params.get('triage')?.trim()
-	const match = triageFilterOptions.find((option) => option.value === value)
-	return match?.value ?? 'open'
-}
-
 export function triageLabel(
 	run: Pick<AccountActivityRunListItem, 'status' | 'errorTriage'>,
 ) {
@@ -165,25 +166,13 @@ export function triageLabel(
 	}
 }
 
-export function buildActivitySearch(input: {
-	status: AccountActivityStatusFilter
-	surface: AccountActivitySurfaceFilter
-	triage: AccountActivityTriageFilter
-}) {
-	const params = new URLSearchParams()
-	if (input.status !== 'error') params.set('status', input.status)
-	if (input.surface !== 'all') params.set('surface', input.surface)
-	if (input.triage !== 'open') params.set('error_triage', input.triage)
-	const search = params.toString()
-	return search ? `?${search}` : ''
-}
-
 export function getDataLatchKey(href: string) {
 	const selection = activityRoute.getSelection(href)
-	const status = readStatusFilter(href)
-	const surface = readSurfaceFilter(href)
-	const triage = readTriageFilter(href)
-	const filterKey = `${status}:${surface}:${triage}`
+	const view = readAccountActivityViewFilter(href)
+	const status = readAccountActivityStatusFilter(href)
+	const surface = readAccountActivitySurfaceFilter(href)
+	const triage = readAccountActivityTriageFilter(href)
+	const filterKey = `${view}:${status}:${surface}:${triage}`
 	return selection.selectedId
 		? `/account/activity/${encodeURIComponent(selection.selectedId)}?${filterKey}`
 		: `/account/activity?${filterKey}`
@@ -194,13 +183,14 @@ export function buildActivityApiRequestUrl(
 	cursor?: string | null,
 ) {
 	const requestUrl = new URL(accountActivityApiPath, 'http://localhost')
-	const status = readStatusFilter(href)
-	const surface = readSurfaceFilter(href)
-	const triage = readTriageFilter(href)
-	if (status !== 'error') requestUrl.searchParams.set('status', status)
-	else requestUrl.searchParams.set('status', 'error')
+	const view = readAccountActivityViewFilter(href)
+	const status = readAccountActivityStatusFilter(href)
+	const surface = readAccountActivitySurfaceFilter(href)
+	const triage = readAccountActivityTriageFilter(href)
+	if (view !== 'errors') requestUrl.searchParams.set('view', view)
+	requestUrl.searchParams.set('status', status)
 	if (surface !== 'all') requestUrl.searchParams.set('surface', surface)
-	if (triage !== 'open') requestUrl.searchParams.set('error_triage', triage)
+	requestUrl.searchParams.set('error_triage', triage)
 	const selectedRunId = activityRoute.getSelection(href).selectedId
 	if (selectedRunId) {
 		requestUrl.searchParams.set('selected', selectedRunId)

--- a/packages/worker/client/routes/account-activity.tsx
+++ b/packages/worker/client/routes/account-activity.tsx
@@ -13,6 +13,7 @@ import {
 } from '#client/routes/account-approval-shared.ts'
 import { renderActivityRunDetail } from '#client/routes/account-activity-detail.tsx'
 import {
+	activityEmptyLabel,
 	activityErrorReviewPrompt,
 	activityRoute,
 	buildActivityApiRequestUrl,
@@ -22,6 +23,7 @@ import {
 	readStatusFilter,
 	readSurfaceFilter,
 	readTriageFilter,
+	readViewFilter,
 	runDisplayName,
 	statusColor,
 	statusLabel,
@@ -29,6 +31,7 @@ import {
 	surfaceFilterOptions,
 	surfaceLabel,
 	triageFilterOptions,
+	viewFilterOptions,
 } from '#client/routes/account-activity-shared.ts'
 import {
 	AccountManagementMessage,
@@ -43,13 +46,18 @@ import {
 	recordStampCss,
 } from '#client/routes/record-table.tsx'
 import {
+	defaultAccountActivityStatusFilter,
+	defaultAccountActivityTriageFilter,
+	type AccountActivityStatusFilter,
+	type AccountActivitySurfaceFilter,
+	type AccountActivityTriageFilter,
+	type AccountActivityViewFilter,
+} from '#universal/account-activity-filters.ts'
+import {
 	type AccountActivityLoaderData,
 	type AccountActivityRunDetail,
 	type AccountActivityRunListItem,
-	type AccountActivityStatusFilter,
-	type AccountActivitySurfaceFilter,
 	type AccountActivitySummary,
-	type AccountActivityTriageFilter,
 } from '#universal/loader-data.ts'
 import {
 	colors,
@@ -182,16 +190,29 @@ export function AccountActivityRoute(handle: Handle) {
 	}
 
 	function updateFilters(input: {
+		view?: AccountActivityViewFilter
 		status?: AccountActivityStatusFilter
 		surface?: AccountActivitySurfaceFilter
 		triage?: AccountActivityTriageFilter
 	}) {
 		const href = getCurrentHref()
 		const selection = activityRoute.getSelection(href)
+		const currentView = readViewFilter(href)
+		const view = input.view ?? currentView
+		const viewChanged = input.view != null && input.view !== currentView
 		const search = buildActivitySearch({
-			status: input.status ?? readStatusFilter(href),
+			view,
+			status:
+				input.status ??
+				(viewChanged
+					? defaultAccountActivityStatusFilter(view)
+					: readStatusFilter(href)),
 			surface: input.surface ?? readSurfaceFilter(href),
-			triage: input.triage ?? readTriageFilter(href),
+			triage:
+				input.triage ??
+				(viewChanged
+					? defaultAccountActivityTriageFilter(view)
+					: readTriageFilter(href)),
 		})
 		if (selection.selectedId) {
 			navigate(activityRoute.buildDetailHref(selection.selectedId, search))
@@ -216,10 +237,12 @@ export function AccountActivityRoute(handle: Handle) {
 		}
 
 		const selection = activityRoute.getSelection(currentHref)
+		const viewFilter = readViewFilter(currentHref)
 		const statusFilter = readStatusFilter(currentHref)
 		const surfaceFilter = readSurfaceFilter(currentHref)
 		const triageFilter = readTriageFilter(currentHref)
 		const filterSearch = buildActivitySearch({
+			view: viewFilter,
 			status: statusFilter,
 			surface: surfaceFilter,
 			triage: triageFilter,
@@ -239,18 +262,20 @@ export function AccountActivityRoute(handle: Handle) {
 			!detail &&
 			!waitingForDetail &&
 			status === 'ready'
-		const emptyBecauseErrors =
-			statusFilter === 'error' &&
-			surfaceFilter === 'all' &&
-			triageFilter === 'open' &&
-			runs.length === 0
 		const readySummary = status === 'ready' ? summary : null
+		const emptyLabel = activityEmptyLabel({
+			view: viewFilter,
+			status: statusFilter,
+			surface: surfaceFilter,
+			triage: triageFilter,
+			summaryTotal: readySummary?.total ?? 0,
+		})
 
 		return (
 			<AccountManagementShell>
 				<AccountPageHeader
 					title="Activity"
-					description="Failures and recent runs across jobs, packages, apps, and other surfaces — with the logs you need to diagnose them."
+					description="Open failures first, plus a Recent runs week of jobs, executes, package apps, webhooks, and workflows — with the logs you need to diagnose them."
 					currentHref={currentHref}
 				/>
 				<figure
@@ -352,9 +377,11 @@ export function AccountActivityRoute(handle: Handle) {
 							})}
 						>
 							Successful ad-hoc execute runs are not recorded (only failures
-							are). Run records are kept for about {retentionDays} days. The
-							default view shows open errors; ignored and resolved runs stay
-							hidden until you change the triage filter.
+							are). Run records are kept for about {retentionDays} days. Open
+							errors is the default view. Recent runs lists the last 7 days
+							across successes, running work, and errors. Ignored and resolved
+							errors stay hidden from Open errors until you change the triage
+							filter.
 						</p>
 
 						{showRunNotFound ? (
@@ -369,21 +396,39 @@ export function AccountActivityRoute(handle: Handle) {
 							ariaLabel="Activity runs"
 							selectedId={selection.selectedId}
 							onNavigate={() => setMessage(null)}
-							emptyLabel={
-								emptyBecauseErrors
-									? 'No failures in the last 7 days. That is good news — when something breaks, it will show up here with its logs.'
-									: 'No runs match the current filters.'
-							}
+							emptyLabel={emptyLabel}
 							toolbar={
 								<>
 									<RecordTableSelect
+										label="Activity view"
+										value={viewFilter}
+										onChange={(rawValue) => {
+											const value = rawValue as AccountActivityViewFilter
+											if (
+												!viewFilterOptions.some(
+													(option) => option.value === value,
+												)
+											) {
+												return
+											}
+											updateFilters({ view: value })
+										}}
+									>
+										{viewFilterOptions.map((option) => (
+											<option key={option.value} value={option.value}>
+												{option.label}
+											</option>
+										))}
+									</RecordTableSelect>
+									<RecordTableSelect
 										label="Status filter"
 										value={statusFilter}
-										onChange={(value) => {
+										onChange={(rawValue) => {
+											const value = rawValue as AccountActivityStatusFilter
 											if (
-												value !== 'error' &&
-												value !== 'all' &&
-												value !== 'running'
+												!statusFilterOptions.some(
+													(option) => option.value === value,
+												)
 											) {
 												return
 											}

--- a/packages/worker/client/routes/entity-explainer.tsx
+++ b/packages/worker/client/routes/entity-explainer.tsx
@@ -129,8 +129,8 @@ const entityExplainerDefinitions: Array<EntityExplainerDefinition> = [
 		question: 'What is activity?',
 		match: accountSection(routes.accountActivity.href()),
 		paragraphs: [
-			'Activity is a short execution history for jobs, package apps, webhooks, and other runtimes. When something fails, the run, logs, and a triage state (open, ignored, or resolved) show up here.',
-			'Use this page to see what broke and whether to ignore, resolve, or fix it. Your agent can review open errors through the runs capabilities. A later successful run for the same job automatically resolves earlier open errors.',
+			'Activity is a short execution history for jobs, package apps, webhooks, and other runtimes. Open errors shows failures with logs and triage (open, ignored, or resolved). Recent runs lists the last week of successes and errors from the same records.',
+			'Use Open errors to decide whether to ignore, resolve, or fix a failure. Switch to Recent runs to see what ran. Your agent can review the same data through the runs capabilities. A later successful run for the same job automatically resolves earlier open errors.',
 		],
 	},
 	{

--- a/packages/worker/src/app/account-activity-data.node.test.ts
+++ b/packages/worker/src/app/account-activity-data.node.test.ts
@@ -73,6 +73,7 @@ test('activity helpers parse filters and prefer path selected run ids', () => {
 	expect(
 		readAccountActivityFilters('https://example.com/account/activity'),
 	).toEqual({
+		viewFilter: 'errors',
 		statusFilter: 'error',
 		surfaceFilter: 'all',
 		triageFilter: 'open',
@@ -83,12 +84,25 @@ test('activity helpers parse filters and prefer path selected run ids', () => {
 			'https://example.com/account/activity?status=all&surface=job&cursor=abc&error_triage=ignored',
 		),
 	).toEqual({
+		viewFilter: 'errors',
 		statusFilter: 'all',
 		surfaceFilter: 'job',
 		triageFilter: 'ignored',
 		cursor: 'abc',
 	})
+	expect(
+		readAccountActivityFilters(
+			'https://example.com/account/activity?view=recent',
+		),
+	).toEqual({
+		viewFilter: 'recent',
+		statusFilter: 'all',
+		surfaceFilter: 'all',
+		triageFilter: 'all',
+		cursor: null,
+	})
 	expect(statusFilterToRunStatus('error')).toBe('error')
+	expect(statusFilterToRunStatus('success')).toBe('success')
 	expect(statusFilterToRunStatus('all')).toBeNull()
 	expect(surfaceFilterToRunSurface('all')).toBeNull()
 	expect(surfaceFilterToRunSurface('webhook')).toBe('webhook')
@@ -180,6 +194,7 @@ test('loadAccountActivityData maps filters, summary, pagination, detail, and cur
 	})
 	expect(data).toMatchObject({
 		ok: true,
+		viewFilter: 'errors',
 		statusFilter: 'error',
 		surfaceFilter: 'job',
 		triageFilter: 'open',
@@ -234,6 +249,44 @@ test('loadAccountActivityData maps filters, summary, pagination, detail, and cur
 				errorTriage: 'open',
 			},
 			cursor: 'page-2',
+		}),
+	)
+
+	mockModule.listRunRecords.mockClear()
+	await loadAccountActivityData({
+		env: {} as Env,
+		request: new Request('https://example.com/account/activity?view=recent'),
+		user,
+		now: new Date('2026-07-26T12:00:00.000Z'),
+	})
+	expect(mockModule.listRunRecords).toHaveBeenCalledWith(
+		expect.objectContaining({
+			filter: {
+				status: null,
+				surface: null,
+				since: '2026-07-19T12:00:00.000Z',
+				errorTriage: 'all',
+			},
+		}),
+	)
+
+	mockModule.listRunRecords.mockClear()
+	await loadAccountActivityData({
+		env: {} as Env,
+		request: new Request(
+			'https://example.com/account/activity?view=recent&status=success',
+		),
+		user,
+		now: new Date('2026-07-26T12:00:00.000Z'),
+	})
+	expect(mockModule.listRunRecords).toHaveBeenCalledWith(
+		expect.objectContaining({
+			filter: {
+				status: 'success',
+				surface: null,
+				since: '2026-07-19T12:00:00.000Z',
+				errorTriage: 'all',
+			},
 		}),
 	)
 })

--- a/packages/worker/src/app/account-activity-data.ts
+++ b/packages/worker/src/app/account-activity-data.ts
@@ -9,41 +9,39 @@ import {
 } from '#worker/run-records/service.ts'
 import {
 	type RunErrorTriage,
-	type RunErrorTriageFilter,
 	type RunLogLevel,
 	type RunRecord,
 	type RunRecordLog,
 	type RunStatus,
 	type RunSurface,
-	runErrorTriageFilterValues,
 	runRecordRetentionDays,
-	runSurfaceValues,
 } from '#worker/run-records/types.ts'
+import {
+	readAccountActivityFilters,
+	statusFilterToRunStatus,
+	surfaceFilterToRunSurface,
+	type AccountActivityStatusFilter,
+	type AccountActivitySurfaceFilter,
+	type AccountActivityTriageFilter,
+	type AccountActivityViewFilter,
+} from '#universal/account-activity-filters.ts'
+
+export {
+	readAccountActivityFilters,
+	statusFilterToRunStatus,
+	surfaceFilterToRunSurface,
+}
+
+export type {
+	AccountActivityStatusFilter,
+	AccountActivitySurfaceFilter,
+	AccountActivityTriageFilter,
+	AccountActivityViewFilter,
+}
 
 type AuthenticatedUser = NonNullable<
 	Awaited<ReturnType<typeof readAuthenticatedAppUser>>
 >
-
-export const accountActivityStatusFilterValues = [
-	'error',
-	'all',
-	'running',
-] as const
-
-export type AccountActivityStatusFilter =
-	(typeof accountActivityStatusFilterValues)[number]
-
-export const accountActivitySurfaceFilterValues = [
-	'all',
-	...runSurfaceValues,
-] as const
-
-export type AccountActivitySurfaceFilter =
-	(typeof accountActivitySurfaceFilterValues)[number]
-
-export const accountActivityTriageFilterValues = runErrorTriageFilterValues
-
-export type AccountActivityTriageFilter = RunErrorTriageFilter
 
 export type AccountActivityRunListItem = {
 	id: string
@@ -97,6 +95,7 @@ export type AccountActivitySummary = {
 
 export type AccountActivityLoaderData = {
 	ok: true
+	viewFilter: AccountActivityViewFilter
 	statusFilter: AccountActivityStatusFilter
 	surfaceFilter: AccountActivitySurfaceFilter
 	triageFilter: AccountActivityTriageFilter
@@ -111,35 +110,6 @@ export type AccountActivityLoaderData = {
 const accountActivityBasePath = '/account/activity'
 const summaryWindowMs = 7 * 24 * 60 * 60 * 1000
 const defaultPageSize = 25
-
-export function isAccountActivityStatusFilter(
-	value: string | null | undefined,
-): value is AccountActivityStatusFilter {
-	return (
-		typeof value === 'string' &&
-		(accountActivityStatusFilterValues as ReadonlyArray<string>).includes(value)
-	)
-}
-
-export function isAccountActivitySurfaceFilter(
-	value: string | null | undefined,
-): value is AccountActivitySurfaceFilter {
-	return (
-		typeof value === 'string' &&
-		(accountActivitySurfaceFilterValues as ReadonlyArray<string>).includes(
-			value,
-		)
-	)
-}
-
-export function isAccountActivityTriageFilter(
-	value: string | null | undefined,
-): value is AccountActivityTriageFilter {
-	return (
-		typeof value === 'string' &&
-		(accountActivityTriageFilterValues as ReadonlyArray<string>).includes(value)
-	)
-}
 
 export function readAccountActivitySelectedRunId(
 	requestUrl: string,
@@ -161,53 +131,6 @@ export function readAccountActivitySelectedRunId(
 	}
 	const selected = url.searchParams.get('selected')?.trim()
 	return selected ? selected : null
-}
-
-export function readAccountActivityFilters(requestUrl: string) {
-	const url = new URL(requestUrl, 'http://localhost')
-	const statusRaw = url.searchParams.get('status')?.trim() ?? null
-	const surfaceRaw = url.searchParams.get('surface')?.trim() ?? null
-	const triageRaw =
-		url.searchParams.get('error_triage')?.trim() ??
-		url.searchParams.get('triage')?.trim() ??
-		null
-	const cursor = url.searchParams.get('cursor')?.trim() || null
-	return {
-		statusFilter: isAccountActivityStatusFilter(statusRaw)
-			? statusRaw
-			: ('error' satisfies AccountActivityStatusFilter),
-		surfaceFilter: isAccountActivitySurfaceFilter(surfaceRaw)
-			? surfaceRaw
-			: ('all' satisfies AccountActivitySurfaceFilter),
-		triageFilter: isAccountActivityTriageFilter(triageRaw)
-			? triageRaw
-			: ('open' satisfies AccountActivityTriageFilter),
-		cursor,
-	}
-}
-
-export function statusFilterToRunStatus(
-	filter: AccountActivityStatusFilter,
-): RunStatus | null {
-	switch (filter) {
-		case 'error':
-			return 'error'
-		case 'running':
-			return 'running'
-		case 'all':
-			return null
-		default: {
-			const exhaustive: never = filter
-			return exhaustive
-		}
-	}
-}
-
-export function surfaceFilterToRunSurface(
-	filter: AccountActivitySurfaceFilter,
-): RunSurface | null {
-	if (filter === 'all') return null
-	return filter
 }
 
 function toListItem(run: RunRecord): AccountActivityRunListItem {
@@ -282,7 +205,7 @@ export async function loadAccountActivityData(input: {
 		input.request.url,
 		input.pathRunId,
 	)
-	const { statusFilter, surfaceFilter, triageFilter, cursor } =
+	const { viewFilter, statusFilter, surfaceFilter, triageFilter, cursor } =
 		readAccountActivityFilters(input.request.url)
 	const since = summarySince(now)
 
@@ -315,6 +238,7 @@ export async function loadAccountActivityData(input: {
 
 	return {
 		ok: true,
+		viewFilter,
 		statusFilter,
 		surfaceFilter,
 		triageFilter,

--- a/packages/worker/src/mcp/capabilities/runs/run-list.ts
+++ b/packages/worker/src/mcp/capabilities/runs/run-list.ts
@@ -66,7 +66,7 @@ export const runListCapability = defineDomainCapability(
 	{
 		name: 'run_list',
 		description:
-			'List recent execution history across jobs, webhooks, package apps, workflows, and other runtimes so you can debug failures, crashes, and "why did my job stop working" questions. Key-less successful ad-hoc execute runs are intentionally not recorded (only execute failures are, plus execute calls that supplied an idempotencyKey); every other surface records both success and error. Terminal rows may include a bounded metadata.result snapshot. By default, ignored/resolved error runs are hidden (error_triage defaults to open); use run_update or run_update_bulk to triage noise, or pass error_triage all/ignored/resolved to inspect those rows. Records are retained about 30 days, capped per user, and cap-pruned in this order: handled errors, successes, then open errors.',
+			'List recent execution history across jobs, webhooks, package apps, workflows, and other runtimes so you can debug failures or inspect what ran. Key-less successful ad-hoc execute runs are intentionally not recorded (only execute failures are, plus execute calls that supplied an idempotencyKey); every other surface records both success and error. Terminal rows may include a bounded metadata.result snapshot. By default, ignored/resolved error runs are hidden (error_triage defaults to open); use run_update or run_update_bulk to triage noise, or pass error_triage all/ignored/resolved to inspect those rows. Pass status success (or omit status with error_triage all) for a recent "what ran" list. Records are retained about 30 days, capped per user, and cap-pruned in this order: handled errors, successes, then open errors.',
 		keywords: [
 			'run',
 			'runs',
@@ -77,6 +77,9 @@ export const runListCapability = defineDomainCapability(
 			'failures',
 			'error',
 			'errors',
+			'success',
+			'recent',
+			'what ran',
 			'crash',
 			'job failed',
 			'scheduled job',

--- a/packages/worker/src/run-records/types.ts
+++ b/packages/worker/src/run-records/types.ts
@@ -46,7 +46,7 @@ export type RunErrorTriage = (typeof runErrorTriageValues)[number]
 
 /**
  * List/summary filter over {@link RunErrorTriage}. `open` = not ignored or
- * resolved (default for user-facing Activity / `run_list`).
+ * resolved (default for `run_list` and Activity's Open errors view).
  */
 export const runErrorTriageFilterValues = [
 	'open',

--- a/packages/worker/universal/account-activity-filters.node.test.ts
+++ b/packages/worker/universal/account-activity-filters.node.test.ts
@@ -1,0 +1,133 @@
+import { expect, test } from 'vitest'
+import {
+	activityEmptyLabel,
+	buildActivitySearch,
+	readAccountActivityFilters,
+	statusFilterToRunStatus,
+	surfaceFilterToRunSurface,
+} from './account-activity-filters.ts'
+
+test('activity URL defaults stay on open errors and recent runs flip to all history', () => {
+	expect(
+		readAccountActivityFilters('https://example.com/account/activity'),
+	).toEqual({
+		viewFilter: 'errors',
+		statusFilter: 'error',
+		surfaceFilter: 'all',
+		triageFilter: 'open',
+		cursor: null,
+	})
+	expect(
+		readAccountActivityFilters(
+			'https://example.com/account/activity?status=all&surface=job&cursor=abc&error_triage=ignored',
+		),
+	).toEqual({
+		viewFilter: 'errors',
+		statusFilter: 'all',
+		surfaceFilter: 'job',
+		triageFilter: 'ignored',
+		cursor: 'abc',
+	})
+	expect(
+		readAccountActivityFilters(
+			'https://example.com/account/activity?view=recent',
+		),
+	).toEqual({
+		viewFilter: 'recent',
+		statusFilter: 'all',
+		surfaceFilter: 'all',
+		triageFilter: 'all',
+		cursor: null,
+	})
+	expect(
+		readAccountActivityFilters(
+			'https://example.com/account/activity?view=recent&status=success&surface=webhook',
+		),
+	).toEqual({
+		viewFilter: 'recent',
+		statusFilter: 'success',
+		surfaceFilter: 'webhook',
+		triageFilter: 'all',
+		cursor: null,
+	})
+	expect(
+		readAccountActivityFilters(
+			'https://example.com/account/activity?view=nope&status=success',
+		),
+	).toEqual({
+		viewFilter: 'errors',
+		statusFilter: 'success',
+		surfaceFilter: 'all',
+		triageFilter: 'open',
+		cursor: null,
+	})
+
+	expect(statusFilterToRunStatus('error')).toBe('error')
+	expect(statusFilterToRunStatus('success')).toBe('success')
+	expect(statusFilterToRunStatus('running')).toBe('running')
+	expect(statusFilterToRunStatus('all')).toBeNull()
+	expect(surfaceFilterToRunSurface('all')).toBeNull()
+	expect(surfaceFilterToRunSurface('webhook')).toBe('webhook')
+
+	expect(
+		buildActivitySearch({
+			view: 'errors',
+			status: 'error',
+			surface: 'all',
+			triage: 'open',
+		}),
+	).toBe('')
+	expect(
+		buildActivitySearch({
+			view: 'recent',
+			status: 'all',
+			surface: 'all',
+			triage: 'all',
+		}),
+	).toBe('?view=recent')
+	expect(
+		buildActivitySearch({
+			view: 'recent',
+			status: 'success',
+			surface: 'job',
+			triage: 'open',
+		}),
+	).toBe('?view=recent&status=success&surface=job&error_triage=open')
+
+	expect(
+		activityEmptyLabel({
+			view: 'errors',
+			status: 'error',
+			surface: 'all',
+			triage: 'open',
+			summaryTotal: 0,
+		}),
+	).toMatch(/No failures in the last 7 days/)
+	expect(
+		activityEmptyLabel({
+			view: 'errors',
+			status: 'error',
+			surface: 'all',
+			triage: 'open',
+			summaryTotal: 4,
+		}),
+	).toMatch(/Switch to Recent runs/)
+	expect(
+		activityEmptyLabel({
+			view: 'recent',
+			status: 'all',
+			surface: 'all',
+			triage: 'all',
+			summaryTotal: 0,
+		}),
+	).toBe('Nothing ran in the last 7 days.')
+	expect(
+		activityEmptyLabel({
+			view: 'recent',
+			status: 'success',
+			surface: 'all',
+			triage: 'all',
+			summaryTotal: 3,
+		}),
+	).toBe('No runs match the current filters.')
+})

--- a/packages/worker/universal/account-activity-filters.ts
+++ b/packages/worker/universal/account-activity-filters.ts
@@ -1,0 +1,233 @@
+/**
+ * URL contract for `/account/activity`: view, status, surface, and triage.
+ * Client and server parse the same query so defaults cannot drift.
+ */
+
+export const accountActivityViewFilterValues = ['errors', 'recent'] as const
+
+export type AccountActivityViewFilter =
+	(typeof accountActivityViewFilterValues)[number]
+
+export const accountActivityStatusFilterValues = [
+	'error',
+	'all',
+	'success',
+	'running',
+] as const
+
+export type AccountActivityStatusFilter =
+	(typeof accountActivityStatusFilterValues)[number]
+
+export const accountActivitySurfaceFilterValues = [
+	'all',
+	'execute',
+	'export',
+	'subscription',
+	'app_fetch',
+	'app_realtime',
+	'job',
+	'workflow',
+	'retriever',
+	'webhook',
+] as const
+
+export type AccountActivitySurfaceFilter =
+	(typeof accountActivitySurfaceFilterValues)[number]
+
+export const accountActivityTriageFilterValues = [
+	'open',
+	'ignored',
+	'resolved',
+	'all',
+] as const
+
+export type AccountActivityTriageFilter =
+	(typeof accountActivityTriageFilterValues)[number]
+
+export function isAccountActivityViewFilter(
+	value: string | null | undefined,
+): value is AccountActivityViewFilter {
+	return (
+		typeof value === 'string' &&
+		(accountActivityViewFilterValues as ReadonlyArray<string>).includes(value)
+	)
+}
+
+export function isAccountActivityStatusFilter(
+	value: string | null | undefined,
+): value is AccountActivityStatusFilter {
+	return (
+		typeof value === 'string' &&
+		(accountActivityStatusFilterValues as ReadonlyArray<string>).includes(value)
+	)
+}
+
+export function isAccountActivitySurfaceFilter(
+	value: string | null | undefined,
+): value is AccountActivitySurfaceFilter {
+	return (
+		typeof value === 'string' &&
+		(accountActivitySurfaceFilterValues as ReadonlyArray<string>).includes(
+			value,
+		)
+	)
+}
+
+export function isAccountActivityTriageFilter(
+	value: string | null | undefined,
+): value is AccountActivityTriageFilter {
+	return (
+		typeof value === 'string' &&
+		(accountActivityTriageFilterValues as ReadonlyArray<string>).includes(value)
+	)
+}
+
+export function defaultAccountActivityStatusFilter(
+	view: AccountActivityViewFilter,
+): AccountActivityStatusFilter {
+	switch (view) {
+		case 'errors':
+			return 'error'
+		case 'recent':
+			return 'all'
+		default: {
+			const exhaustive: never = view
+			return exhaustive
+		}
+	}
+}
+
+export function defaultAccountActivityTriageFilter(
+	view: AccountActivityViewFilter,
+): AccountActivityTriageFilter {
+	switch (view) {
+		case 'errors':
+			return 'open'
+		case 'recent':
+			return 'all'
+		default: {
+			const exhaustive: never = view
+			return exhaustive
+		}
+	}
+}
+
+function searchParamsFromHref(href: string) {
+	return new URL(href, 'http://localhost').searchParams
+}
+
+export function readAccountActivityViewFilter(
+	href: string,
+): AccountActivityViewFilter {
+	const value = searchParamsFromHref(href).get('view')?.trim()
+	return isAccountActivityViewFilter(value) ? value : 'errors'
+}
+
+export function readAccountActivityStatusFilter(
+	href: string,
+): AccountActivityStatusFilter {
+	const value = searchParamsFromHref(href).get('status')?.trim()
+	if (isAccountActivityStatusFilter(value)) return value
+	return defaultAccountActivityStatusFilter(readAccountActivityViewFilter(href))
+}
+
+export function readAccountActivitySurfaceFilter(
+	href: string,
+): AccountActivitySurfaceFilter {
+	const value = searchParamsFromHref(href).get('surface')?.trim()
+	return isAccountActivitySurfaceFilter(value) ? value : 'all'
+}
+
+export function readAccountActivityTriageFilter(
+	href: string,
+): AccountActivityTriageFilter {
+	const params = searchParamsFromHref(href)
+	const value =
+		params.get('error_triage')?.trim() ?? params.get('triage')?.trim()
+	if (isAccountActivityTriageFilter(value)) return value
+	return defaultAccountActivityTriageFilter(readAccountActivityViewFilter(href))
+}
+
+export function readAccountActivityFilters(requestUrl: string) {
+	const url = new URL(requestUrl, 'http://localhost')
+	const href = `${url.pathname}${url.search}`
+	return {
+		viewFilter: readAccountActivityViewFilter(href),
+		statusFilter: readAccountActivityStatusFilter(href),
+		surfaceFilter: readAccountActivitySurfaceFilter(href),
+		triageFilter: readAccountActivityTriageFilter(href),
+		cursor: url.searchParams.get('cursor')?.trim() || null,
+	}
+}
+
+export function buildActivitySearch(input: {
+	view: AccountActivityViewFilter
+	status: AccountActivityStatusFilter
+	surface: AccountActivitySurfaceFilter
+	triage: AccountActivityTriageFilter
+}) {
+	const params = new URLSearchParams()
+	if (input.view !== 'errors') params.set('view', input.view)
+	if (input.status !== defaultAccountActivityStatusFilter(input.view)) {
+		params.set('status', input.status)
+	}
+	if (input.surface !== 'all') params.set('surface', input.surface)
+	if (input.triage !== defaultAccountActivityTriageFilter(input.view)) {
+		params.set('error_triage', input.triage)
+	}
+	const search = params.toString()
+	return search ? `?${search}` : ''
+}
+
+export function statusFilterToRunStatus(
+	filter: AccountActivityStatusFilter,
+): 'error' | 'success' | 'running' | null {
+	switch (filter) {
+		case 'error':
+			return 'error'
+		case 'success':
+			return 'success'
+		case 'running':
+			return 'running'
+		case 'all':
+			return null
+		default: {
+			const exhaustive: never = filter
+			return exhaustive
+		}
+	}
+}
+
+export function surfaceFilterToRunSurface(
+	filter: AccountActivitySurfaceFilter,
+): Exclude<AccountActivitySurfaceFilter, 'all'> | null {
+	if (filter === 'all') return null
+	return filter
+}
+
+export function activityEmptyLabel(input: {
+	view: AccountActivityViewFilter
+	status: AccountActivityStatusFilter
+	surface: AccountActivitySurfaceFilter
+	triage: AccountActivityTriageFilter
+	summaryTotal: number
+}) {
+	const defaultsForView =
+		input.status === defaultAccountActivityStatusFilter(input.view) &&
+		input.surface === 'all' &&
+		input.triage === defaultAccountActivityTriageFilter(input.view)
+	if (!defaultsForView) return 'No runs match the current filters.'
+	switch (input.view) {
+		case 'errors':
+			if (input.summaryTotal > 0) {
+				return 'No open failures in the last 7 days. Switch to Recent runs to see what ran.'
+			}
+			return 'No failures in the last 7 days. That is good news — when something breaks, it will show up here with its logs.'
+		case 'recent':
+			return 'Nothing ran in the last 7 days.'
+		default: {
+			const exhaustive: never = input.view
+			return exhaustive
+		}
+	}
+}

--- a/packages/worker/universal/loader-data.ts
+++ b/packages/worker/universal/loader-data.ts
@@ -27,6 +27,12 @@ import { type HighlightedCode } from '#universal/highlighted-code.ts'
 import { type WalkthroughHostPick } from '#universal/walkthrough-hosts.ts'
 import { type OnboardingAgentChooserPick } from '#universal/onboarding-mcp-clients.ts'
 import { type EmailVerificationDelivery } from '#universal/email-verification-delivery.ts'
+import {
+	type AccountActivityStatusFilter,
+	type AccountActivitySurfaceFilter,
+	type AccountActivityTriageFilter,
+	type AccountActivityViewFilter,
+} from '#universal/account-activity-filters.ts'
 
 export type { ProfileVisibility }
 export type { AdminFeatureFlag }
@@ -1444,25 +1450,12 @@ export type AccountWorkflowsLoaderData = {
 	selectedWorkflowId: string | null
 }
 
-export type AccountActivityStatusFilter = 'error' | 'all' | 'running'
-
-export type AccountActivitySurfaceFilter =
-	| 'all'
-	| 'execute'
-	| 'export'
-	| 'subscription'
-	| 'app_fetch'
-	| 'app_realtime'
-	| 'job'
-	| 'workflow'
-	| 'retriever'
-	| 'webhook'
-
-export type AccountActivityTriageFilter =
-	| 'open'
-	| 'ignored'
-	| 'resolved'
-	| 'all'
+export type {
+	AccountActivityStatusFilter,
+	AccountActivitySurfaceFilter,
+	AccountActivityTriageFilter,
+	AccountActivityViewFilter,
+}
 
 export type AccountActivityRunListItem = {
 	id: string
@@ -1516,6 +1509,7 @@ export type AccountActivitySummary = {
 
 export type AccountActivityLoaderData = {
 	ok: true
+	viewFilter: AccountActivityViewFilter
 	statusFilter: AccountActivityStatusFilter
 	surfaceFilter: AccountActivitySurfaceFilter
 	triageFilter: AccountActivityTriageFilter


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Let a signed-in user see what ran — jobs, executes, package apps, webhooks, workflows — on `/account/activity`, without turning the page into a notifications inbox or burying open failures.

## Why

Activity defaulted to open errors and stayed silent when things worked. The runs store already keeps successes (except key-less ad-hoc `execute`). This PR exposes that history through a Recent runs view and a success status filter.

## Summary

- Keep the default **Open errors** triage view (`status=error`, `error_triage=open`).
- Add **Recent runs** (`?view=recent`) for the last 7 days across successes, running work, and errors, using the existing `listRunRecords` path.
- Add a **Success** status filter.
- Share the URL/filter contract in `#universal/account-activity-filters.ts` so client and server defaults cannot drift.
- Update `docs/use/activity.md` and `run_list` keywords/description so agents can ask for what ran.

## Testing

- Filter/default unit tests: default stays open errors; `view=recent` and `status=success` parse and load through `listRunRecords`.
- `npm run validate` green.
- Local signed-in UI (`kody@example.com` on the e2e web server): Open errors empty state, Recent runs (`?view=recent`), Success status, then back to Open errors.
- Preview (`https://kody-pr-1896.kody-a99.workers.dev`, seed `me@kentcdodds.com`): `GET /account/activity.json` defaults to `viewFilter=errors` / `statusFilter=error` / `triageFilter=open`; `?view=recent` is `all`/`all`; `?view=recent&status=success` is success. UI pass confirmed both empty states and the URL toggle.

![Open errors default view](https://cursor.com/artifacts/c/art-7305b25f-4ead-4e72-b4be-32eade2d245c)
![Recent runs view](https://cursor.com/artifacts/c/art-a25ff18f-c265-4785-b6ec-4608f5504e6a)
![Preview Open errors](https://cursor.com/artifacts/c/art-d9cb8e03-5e57-4c43-9259-6cfa51826afd)
![Preview Recent runs](https://cursor.com/artifacts/c/art-9d891f3d-1b0a-4a8c-b9a3-22f7a39331cf)
<a href="https://cursor.com/agents/bc-7083374a-3c5b-46a5-b91f-db1cc4443922/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Factivity_open_errors_and_recent_runs.mp4"><img src="https://cursor.com/artifacts/c/art-663025ba-2076-4165-bc41-a3f3cbb5c570" alt="activity_open_errors_and_recent_runs.mp4" /></a>

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `cb79a6e4` · **Head:** `95f4c484`

**Classification:** extends — Activity's filter contract gains a Recent runs view and a success status; run-records list/storage are unchanged.

### Primitives touched

| Primitive     | Group    | Impact                                                                 |
| ------------- | -------- | ---------------------------------------------------------------------- |
| `app-ui`      | surfaces | extends — `/account/activity` view/status URL contract and loader data |
| `run-records` | storage  | composes — existing `listRunRecords` filters; MCP copy only            |

### Change flow

The signed-in user still lands on open errors; Recent runs reuses the same per-user RunLog list with a wider status/triage filter.

```mermaid
sequenceDiagram
	actor User
	participant appUi as app-ui
	participant runRecords as run-records
	User->>appUi: GET /account/activity
	appUi->>runRecords: listRunRecords status=error errorTriage=open since=7d
	runRecords-->>appUi: open failures
	User->>appUi: Activity view = Recent runs (?view=recent)
	appUi->>runRecords: listRunRecords status=null errorTriage=all since=7d
	runRecords-->>appUi: successes, running, and errors
```

### Before / after

| | Before | After |
| --- | --- | --- |
| Default `/account/activity` | open errors | open errors (unchanged) |
| Success / recent history | Status "All" only; easy to miss | **Recent runs** view + **Success** status |
| Store | RunLog | same RunLog; no second history table |

### Invariants

Per-user isolation is unchanged: list/summary/detail still take the signed-in `userId`. No org-wide analytics and no notifications inbox.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7083374a-3c5b-46a5-b91f-db1cc4443922?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7083374a-3c5b-46a5-b91f-db1cc4443922&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Activity view toggle between **Open errors** and **Recent runs**.
  * Recent runs displays successes, active work, and errors from the last seven days.
  * Added a **Success** status filter and view-aware filtering behavior.
  * Updated run inspection to support viewing recent successful runs.

* **Documentation**
  * Clarified Activity views, filtering, triage behavior, and recent run inspection in user and contributor documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->