### PR TITLE
Add factory-loop blog post: How to turn agent work into software you own

### DIFF
--- a/packages/worker/src/blog/catalog.node.test.ts
+++ b/packages/worker/src/blog/catalog.node.test.ts
@@ -178,6 +178,33 @@ test('blog catalog enumerates posts with required fields and slug lookup', () =>
 	expect((openclaw?.body ?? '').replace(/\s+/g, ' ')).toContain(
 		'openclaw mcp add kody',
 	)
+	const factoryLoop = getBlogPost(
+		'how-to-turn-agent-work-into-software-you-own',
+	)
+	expect(factoryLoop?.title).toBe(
+		'How to turn agent work into software you own',
+	)
+	expect(factoryLoop?.date).toBe('2026-08-31')
+	expect(factoryLoop?.order).toBe(8)
+	expect(factoryLoop?.placeholder).toBe(true)
+	expect(factoryLoop?.image).toBe('/images/kody-factory-map.webp')
+	expect(factoryLoop?.ogImage).toBe('/images/kody-factory-map-og.jpg')
+	const factoryLoopBody = (factoryLoop?.body ?? '').replace(/\s+/g, ' ')
+	expect(factoryLoopBody).toContain('I call that the factory loop')
+	expect(factoryLoopBody).toContain('https://kody.codes/guides/how-kody-works')
+	expect(factoryLoopBody).toContain('https://kody.codes/onboarding')
+	expect(factoryLoopBody).toContain(
+		'https://kody.codes/blog/your-assistants-home',
+	)
+	expect(factoryLoopBody).toContain(
+		'https://kody.codes/blog/the-automations-you-never-built',
+	)
+	expect(factoryLoopBody).toContain(
+		'https://kody.codes/blog/zero-inference-calls',
+	)
+	expect(factoryLoopBody).toContain(
+		'https://kody.codes/blog/every-install-is-a-fork-you-own',
+	)
 	expect(comparison?.image).toBe('/images/kody-vs-executor.webp')
 	expect(comparison?.ogImage).toBe('/images/kody-vs-executor-og.jpg')
 	const comparisonBody = (comparison?.body ?? '').replace(/\s+/g, ' ')

--- a/packages/worker/src/blog/catalog.ts
+++ b/packages/worker/src/blog/catalog.ts
@@ -1,6 +1,7 @@
 import { parseBlogPostMarkdown, type BlogPost } from './parse-frontmatter.ts'
 import everyInstallIsAForkYouOwn from './posts/every-install-is-a-fork-you-own.md'
 import gatewaysConnectHomesAccumulate from './posts/gateways-connect-homes-accumulate.md'
+import howToTurnAgentWorkIntoSoftwareYouOwn from './posts/how-to-turn-agent-work-into-software-you-own.md'
 import selfServiceMeansOwnership from './posts/self-service-means-ownership.md'
 import theAssistantThatCantLeakYourKeychain from './posts/the-assistant-that-cant-leak-your-keychain.md'
 import theAutomationsYouNeverBuilt from './posts/the-automations-you-never-built.md'
@@ -41,6 +42,10 @@ const postSources: Array<{ slug: string; raw: string }> = [
 	{
 		slug: 'openclaw-2-needs-a-home',
 		raw: openclaw2NeedsAHome,
+	},
+	{
+		slug: 'how-to-turn-agent-work-into-software-you-own',
+		raw: howToTurnAgentWorkIntoSoftwareYouOwn,
 	},
 ]
 

--- a/packages/worker/src/blog/posts/how-to-turn-agent-work-into-software-you-own.md
+++ b/packages/worker/src/blog/posts/how-to-turn-agent-work-into-software-you-own.md
@@ -1,0 +1,151 @@
+---
+title: How to turn agent work into software you own
+date: 2026-08-31
+description:
+  Ask once in the agent you already use, persist the working code as a package
+  you own, then trigger it — invoke, job, webhook, or app — without paying the
+  model again.
+order: 8
+placeholder: true
+image: /images/kody-factory-map.webp
+imageAlt:
+  Kody, a 3D koala in a white jacket, presents a wooden factory board with a
+  magnifying glass, a play button, a locked chest, and sprouting packages.
+ogImage: /images/kody-factory-map-og.jpg
+---
+
+I keep having a conversation I should have stopped having.
+
+It isn't a hard conversation. I ask an agent something useful — what shipped,
+what's overdue, whether a price moved — and it goes and finds out. Tomorrow I
+ask again. The agent walks the same APIs, spends the same tokens, and hands me
+an answer I already taught it how to get. The work was real. The software never
+existed.
+
+That's the loop I wanted to break, and it's the one I want to teach you as an
+operator, not as a platform pitch.
+
+**Ask once in the agent you already use. Persist the working code as a package
+you own. Then trigger it — invoke it, hang a job on it, mint a webhook, or give
+it an app — without paying the model again.**
+
+I call that the factory loop. [Kody](https://kody.codes) is the home the agents
+you use today and tomorrow share, so the package isn't locked inside whichever
+chat you happened to open.
+
+## Ask once
+
+You already have an agent. Cursor, Claude Code, Codex, ChatGPT, OpenClaw,
+whatever you actually talk to. Connect it to Kody
+[over MCP](https://github.com/kentcdodds/kody/blob/main/docs/use/connect-your-agent.md)
+and it gets two tools: `search` and `execute`. Your agent does the thinking.
+Kody runs the code next to your secrets and your storage.
+
+A concrete ask: "What did my favorite bot ship recently on GitHub?"
+
+Search finds the saved GitHub token and a memory that names the bot. Execute
+fetches that user's public events with
+`Authorization: Bearer {{secret:githubAccessToken}}` and keeps published
+releases and new public repos. You get a list, or you get "nothing new." Either
+way, the shape of the answer is now known.
+
+That's the whole first step. One conversation. One working walk. Don't automate
+yet. Don't schedule yet. Make the answer exist once, against your real APIs,
+with your real keys.
+
+The reason this step is cheap is not that hosting got easier. I already wrote
+about
+[why small automations die of activation energy](https://kody.codes/blog/the-automations-you-never-built).
+The reason is that the agent you already pay for can write the walk in seconds,
+and Kody is where that walk can run without becoming a second brain.
+[Kody makes zero inference calls](https://kody.codes/blog/zero-inference-calls).
+Your host reasons. The home does the doing.
+
+## Persist the working code
+
+Once the walk works, ask the same agent to save it.
+
+In Kody that means a
+[saved package](https://github.com/kentcdodds/kody/blob/main/docs/use/packages.md):
+repo-backed TypeScript with a `package.json`, a callable export, and version
+history you can open. The export is the answer shape you just proved — load a
+cursor from `packageStorage()`, return what is new, advance the cursor. The
+one-off `execute` is gone. The software remains.
+
+This is the moment agent work becomes something you own. Not a prompt you hope
+still works next month. Not a chat you will never find again. Code, in your
+account, with a name.
+
+If you start from a community listing instead of a blank execute,
+[every install is already a fork you own](https://kody.codes/blog/every-install-is-a-fork-you-own).
+Same destination: a package in your account that you can read, change, and run.
+
+You do not have to decide "this is a product" to save it. You decide "I will ask
+this again."
+
+## Trigger it without the model
+
+A package that just sits there is a library. The factory loop finishes when you
+hang a trigger on the export so the model is out of the way.
+
+Four doors, all of them run the saved code:
+
+- **Invoke.** From any connected agent, in a new conversation, search finds the
+  package and `execute` imports the export:
+  `import whatShipped from 'kody:@you/favorite-bot/whatShipped'`. A phone agent
+  does not rewrite the GitHub walk. It calls your function.
+- **Job.** Declare a schedule on the package (`package.json#kody.jobs`) that
+  calls the same export. Cron or interval. The job runs on Cloudflare while your
+  laptop is in a bag. For the GitHub example there is no public-activity
+  webhook, so a daily wrapper is the honest trigger — and the wrapper only
+  emails you when the list is non-empty.
+- **Webhook.** When a provider _can_ push, declare `kody.webhooks`, mint a URL,
+  and point Sentry or Stripe or GitHub at it. The inbound POST dispatches to the
+  bound export. No model on the delivery.
+- **App.** Give the package a hosted HTTP and browser surface (`kody.app`). Same
+  runtime, same `packageStorage()`, a URL you can open or hit from a shortcut.
+
+Pick the door that matches how the world talks to that code. A question you will
+ask again is an invoke. A question the calendar should ask is a job. A question
+a provider should ask is a webhook. A question a browser or a shortcut should
+ask is an app.
+
+None of those four spend tokens on reasoning. The thinking happened in the first
+conversation. After that you are running software.
+
+## The home has to outlive the agent
+
+This only works if the package does not live inside the agent that wrote it.
+
+I already made the [home argument](https://kody.codes/blog/your-assistants-home)
+at length: memories, keys, code, and jobs should accumulate somewhere durable
+you own, no matter which front door you use this quarter. The factory loop is
+what that home is _for_. You ask in Cursor on Monday. You invoke the same export
+from Claude Code on Tuesday. You hang a job so Wednesday happens without you.
+Next month you try whatever ships, point it at the same MCP URL, and the package
+is still there.
+
+Kody is not a second agent and it is not a second bill. It is the shared home.
+The agents change. The software you already paid to invent should not have to.
+
+## Walk it once
+
+The playbook is [How Kody works](https://kody.codes/guides/how-kody-works): the
+favorite-bot question, the export, the invoke from a second agent, the quiet
+daily email. That page is the interactive transcript. This post is the operator
+version of the same loop.
+
+If you have not connected a host yet, start at
+[Get started](https://kody.codes/onboarding). Pick the agent you already use,
+finish OAuth, then give it one question you already know you will ask again.
+
+Honest caveat: the loop does not notice the question for you. Some exports need
+a tweak after the first real run. A job you forgot about is still code running
+on your behalf, which is why I wanted these to be packages you can open, not
+toggles in someone else's dashboard.
+
+Signup is invite-gated; the waitlist is on
+[kody.codes/signup](https://kody.codes/signup). The source is
+[Fair Source](https://github.com/kentcdodds/kody).
+
+You already know the question. Ask it once. Keep the software.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Ship a public blog post that teaches the factory loop in operator language: ask once in the agent you already use, persist the working code as a package you own, then trigger it (invoke / job / webhook / app) without paying the model again.

## Why

The existing posts cover the home metaphor, activation energy, zero-inference incentives, and community forks. This one is the missing operator walk: how a useful conversation becomes software you own, and why that software has to live in a home the agents you use today and tomorrow share.

## Summary

- Add `packages/worker/src/blog/posts/how-to-turn-agent-work-into-software-you-own.md` (placeholder, dated 2026-08-31, order 8).
- Register the post in `catalog.ts` the same way existing posts are imported.
- Reuse the existing factory-map `/images` asset (no new artwork).
- Link the four existing posts instead of retelling them. Point readers at `/guides/how-kody-works` and `/onboarding`.
- Pin catalog assertions for title, date, order, artwork, and those links.
- Homepage copy is unchanged. No social, Discord, or Kit posting.

## Testing

- `npm run validate` green (`VALIDATE_EXIT:0`), including typecheck, node-unit, workers-unit, MCP (5), and Playwright e2e (7).
- Catalog unit pins for the new slug, frontmatter, reused artwork, and the four existing-post links plus how-kody-works / onboarding.
- Browser pass on the local e2e origin (`http://127.0.0.1:3847`): `/blog` lists the post, `/blog/how-to-turn-agent-work-into-software-you-own` renders title, byline, factory-map art, AI placeholder callout, and the factory-loop sections. Homepage hero copy is unchanged.

![Blog index listing the new factory-loop post](https://cursor.com/artifacts/c/art-aafef4a3-4af4-4344-9cce-68df0ce636ef)
![Post header with factory-map artwork](https://cursor.com/artifacts/c/art-0698fe60-35f8-4379-b5e2-8893727a7339)
![AI placeholder callout on the new post](https://cursor.com/artifacts/c/art-0d3dfa60-7151-4970-9745-777f9571404f)

## System changes

Catalog-only content. No primitive contracts, routes, or homepage copy change.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `cb79a6e4` · **Head:** `7eb83bff`

**Classification:** composes — no primitives added or changed; this PR adds one static catalog post that existing blog routes already render.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| _(none matched)_ | — | `packages/worker/src/blog/` is outside `primitives.yaml` code roots. Existing `app-ui` blog routes consume the catalog as-is. |

### Change flow

The new markdown file is imported into the static blog catalog. Existing index, post, RSS, and OG routes read it with no handler changes.

```mermaid
sequenceDiagram
	participant catalog as blog catalog
	participant appUi as app-ui
	Note over catalog: add how-to-turn-agent-work-into-software-you-own.md and catalog import
	catalog->>appUi: listBlogPosts includes the new slug
	appUi->>appUi: GET /blog, /blog/:slug, RSS, and /og.png render the placeholder post
```

### Before / after

```diff
+ catalog entry: how-to-turn-agent-work-into-software-you-own
+ frontmatter: date 2026-08-31, order 8, placeholder true
+ artwork: reuse /images/kody-factory-map.webp
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dd51dd9c-9aee-4095-b27a-f84be9ade871?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dd51dd9c-9aee-4095-b27a-f84be9ade871&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Content**
  * Added a new blog post, “How to Turn Agent Work Into Software You Own.”
  * Explains how to convert agent conversations into reusable, versioned software packages.
  * Covers invocation options, including direct calls, scheduled jobs, webhooks, and apps.
  * Includes a GitHub example, interactive playbook, onboarding guidance, and implementation caveats.
* **Blog Updates**
  * The new post is now available in the blog catalog with its metadata and imagery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->