### PR TITLE
Add an understated memories JSON export on /account/memories

### DIFF
--- a/docs/use/memory.md
+++ b/docs/use/memory.md
@@ -93,6 +93,12 @@ Use these through **`execute`**:
 Memory records can also include optional **`source_uris`** — opaque canonical
 document URLs such as GitHub files, R2 object URLs, or Notion pages.
 
+## Account download
+
+The signed-in user can download their own memories as JSON from
+`/account/memories`. The file is memories only: no credentials or other account
+primitives. Deleted memories are included only when **Include deleted** is on.
+
 ## Categories
 
 Memory categories are freeform strings. Kody does not force a closed list.

--- a/packages/worker/client/routes/account-memories.tsx
+++ b/packages/worker/client/routes/account-memories.tsx
@@ -19,6 +19,8 @@ import {
 	type AccountMemoryListItem,
 	type AccountMemoriesLoaderData,
 } from '#universal/loader-data.ts'
+import { buildMemoriesExportFilename } from '#universal/memory-export.ts'
+import { routes } from '#universal/routes.ts'
 import { matchesSearchQuery } from '#client/search-filter.ts'
 import {
 	AccountManagementMessage,
@@ -51,8 +53,9 @@ import {
 
 const clampedCellCss = css(recordCellClamp(30))
 
-const accountMemoriesApiPath = '/account/memories.json'
-const memoriesRoute = createListDetailRoute('/account/memories')
+const accountMemoriesApiPath = routes.accountMemoriesApi.href()
+const accountMemoriesExportPath = routes.accountMemoriesExport.href()
+const memoriesRoute = createListDetailRoute(routes.accountMemories.href())
 
 type MessageTone = 'info' | 'error'
 type DeleteMode = 'soft' | 'hard' | null
@@ -93,6 +96,13 @@ function filterMemories(
 			...memory.tags,
 		]),
 	)
+}
+
+function buildMemoriesExportHref(includeDeleted: boolean) {
+	if (!includeDeleted) return accountMemoriesExportPath
+	const requestUrl = new URL(accountMemoriesExportPath, 'http://localhost')
+	requestUrl.searchParams.set('includeDeleted', 'true')
+	return `${requestUrl.pathname}${requestUrl.search}`
 }
 
 function buildMemoriesApiRequestUrl(href: string) {
@@ -417,6 +427,13 @@ export function AccountMemoriesRoute(handle: Handle) {
 										/>
 										Include deleted
 									</label>
+									<a
+										href={buildMemoriesExportHref(includeDeleted)}
+										download={buildMemoriesExportFilename()}
+										mix={css(secondaryButtonCss)}
+									>
+										Export
+									</a>
 								</>
 							}
 							columns={[

--- a/packages/worker/src/app/account-memories-data.ts
+++ b/packages/worker/src/app/account-memories-data.ts
@@ -1,8 +1,15 @@
 import { type readAuthenticatedAppUser } from '#app/authenticated-user.ts'
 import { parseJsonStringArray } from '@kody-internal/shared/json-parsing.ts'
-import { listMemoriesByUserId } from '#mcp/memory/repo.ts'
+import {
+	listMemoriesByUserId,
+	listMemoriesByUserIdPage,
+} from '#mcp/memory/repo.ts'
 import { getMemory } from '#mcp/memory/service.ts'
-import { type MemoryRecord, type MemoryStatus } from '#mcp/memory/types.ts'
+import {
+	type McpMemoryRow,
+	type MemoryRecord,
+	type MemoryStatus,
+} from '#mcp/memory/types.ts'
 
 type AuthenticatedUser = NonNullable<
 	Awaited<ReturnType<typeof readAuthenticatedAppUser>>
@@ -36,6 +43,21 @@ export type AccountMemoriesLoaderData = {
 	query: string
 	includeDeleted: boolean
 }
+
+/**
+ * Portable memories document for the signed-in user. Includes deleted
+ * rows only when the page's Include deleted control is on. Omits
+ * credentials and other account primitives.
+ */
+export type AccountMemoriesExport = {
+	kind: 'kody-memories'
+	version: 1
+	exportedAt: string
+	includeDeleted: boolean
+	memories: Array<AccountMemoryDetail>
+}
+
+const accountMemoriesExportPageSize = 200
 
 const accountMemoriesBasePath = '/account/memories'
 
@@ -96,6 +118,30 @@ function toDetail(memory: MemoryRecord): AccountMemoryDetail {
 	}
 }
 
+function toExportItem(row: McpMemoryRow): AccountMemoryDetail {
+	return {
+		id: row.id,
+		subject: row.subject,
+		category: row.category,
+		status: row.status,
+		tags: parseJsonStringArray(row.tags_json),
+		summary: row.summary,
+		updatedAt: row.updated_at,
+		details: row.details,
+		sourceUris: parseJsonStringArray(row.source_uris_json),
+		dedupeKey: row.dedupe_key,
+		createdAt: row.created_at,
+		lastAccessedAt: row.last_accessed_at,
+		deletedAt: row.deleted_at,
+	}
+}
+
+function memoryStatusesForExport(includeDeleted: boolean): Array<MemoryStatus> {
+	return includeDeleted
+		? ['active', 'archived', 'deleted']
+		: ['active', 'archived']
+}
+
 export function memoryMatchesQuery(
 	memory: AccountMemoryListItem,
 	query: string,
@@ -128,9 +174,7 @@ export async function loadAccountMemoriesData(input: {
 		input.request.url,
 		input.pathMemoryId,
 	)
-	const statuses: Array<MemoryStatus> = includeDeleted
-		? ['active', 'archived', 'deleted']
-		: ['active', 'archived']
+	const statuses = memoryStatusesForExport(includeDeleted)
 
 	const rows = await listMemoriesByUserId(input.env.APP_DB, userId, {
 		statuses,
@@ -186,4 +230,38 @@ async function resolveSelectedMemory(input: {
 		memoryId: input.memoryId,
 	})
 	return memory ? toDetail(memory) : null
+}
+
+export async function loadAccountMemoriesExport(input: {
+	env: Env
+	user: AuthenticatedUser
+	includeDeleted: boolean
+}): Promise<AccountMemoriesExport> {
+	const userId = input.user.mcpUser.userId
+	const statuses = memoryStatusesForExport(input.includeDeleted)
+	const memories: Array<AccountMemoryDetail> = []
+	let afterId: string | null = null
+	while (true) {
+		const rows = await listMemoriesByUserIdPage({
+			db: input.env.APP_DB,
+			userId,
+			afterId,
+			statuses,
+			limit: accountMemoriesExportPageSize,
+		})
+		for (const row of rows) {
+			memories.push(toExportItem(row))
+		}
+		if (rows.length < accountMemoriesExportPageSize) break
+		const lastId = rows.at(-1)?.id
+		if (!lastId) break
+		afterId = lastId
+	}
+	return {
+		kind: 'kody-memories',
+		version: 1,
+		exportedAt: new Date().toISOString(),
+		includeDeleted: input.includeDeleted,
+		memories,
+	}
 }

--- a/packages/worker/src/app/handlers/account-memories.node.test.ts
+++ b/packages/worker/src/app/handlers/account-memories.node.test.ts
@@ -1,4 +1,5 @@
 import { expect, test, vi } from 'vitest'
+import { buildMemoriesExportFilename } from '#universal/memory-export.ts'
 
 const mockModule = vi.hoisted(() => {
 	const memoryRow = {
@@ -16,8 +17,25 @@ const mockModule = vi.hoisted(() => {
 		lastAccessedAt: null as string | null,
 		deletedAt: null as string | null,
 	}
+	const memoryDbRow = {
+		id: memoryRow.id,
+		user_id: 'stable-user-1',
+		category: memoryRow.category,
+		status: memoryRow.status,
+		subject: memoryRow.subject,
+		summary: memoryRow.summary,
+		details: memoryRow.details,
+		tags_json: JSON.stringify(memoryRow.tags),
+		source_uris_json: JSON.stringify(memoryRow.sourceUris),
+		dedupe_key: memoryRow.dedupeKey,
+		created_at: memoryRow.createdAt,
+		updated_at: memoryRow.updatedAt,
+		last_accessed_at: memoryRow.lastAccessedAt,
+		deleted_at: memoryRow.deletedAt,
+	}
 	return {
 		memoryRow,
+		memoryDbRow,
 		readAuthenticatedAppUser: vi.fn(async () => ({
 			sessionUserId: '42',
 			userId: 42,
@@ -33,24 +51,8 @@ const mockModule = vi.hoisted(() => {
 			},
 		})),
 		readAuthSessionResult: async () => ({ session: null, setCookie: null }),
-		listMemoriesByUserId: vi.fn(async () => [
-			{
-				id: memoryRow.id,
-				user_id: 'stable-user-1',
-				category: memoryRow.category,
-				status: memoryRow.status,
-				subject: memoryRow.subject,
-				summary: memoryRow.summary,
-				details: memoryRow.details,
-				tags_json: JSON.stringify(memoryRow.tags),
-				source_uris_json: JSON.stringify(memoryRow.sourceUris),
-				dedupe_key: memoryRow.dedupeKey,
-				created_at: memoryRow.createdAt,
-				updated_at: memoryRow.updatedAt,
-				last_accessed_at: memoryRow.lastAccessedAt,
-				deleted_at: memoryRow.deletedAt,
-			},
-		]),
+		listMemoriesByUserId: vi.fn(async () => [memoryDbRow]),
+		listMemoriesByUserIdPage: vi.fn(async () => [memoryDbRow]),
 		getMemory: vi.fn(async () => memoryRow),
 		deleteMemory: vi.fn(async () => ({
 			...memoryRow,
@@ -83,6 +85,8 @@ vi.mock('#app/ssr-render.tsx', () => ({
 vi.mock('#mcp/memory/repo.ts', () => ({
 	listMemoriesByUserId: (...args: Array<unknown>) =>
 		mockModule.listMemoriesByUserId(...args),
+	listMemoriesByUserIdPage: (...args: Array<unknown>) =>
+		mockModule.listMemoriesByUserIdPage(...args),
 }))
 
 vi.mock('#mcp/memory/service.ts', () => ({
@@ -90,7 +94,7 @@ vi.mock('#mcp/memory/service.ts', () => ({
 	deleteMemory: (...args: Array<unknown>) => mockModule.deleteMemory(...args),
 }))
 
-const { createAccountMemoriesApiHandler } =
+const { createAccountMemoriesApiHandler, createAccountMemoriesExportHandler } =
 	await import('./account-memories.ts')
 
 function createEnv() {
@@ -255,4 +259,123 @@ test('memories API soft/force deletes and rejects invalid delete requests', asyn
 		params: {},
 	} as never)
 	expect(notFound.status).toBe(404)
+})
+
+test('memories export filename uses the UTC calendar date', () => {
+	expect(
+		buildMemoriesExportFilename(new Date('2026-08-31T23:30:00.000Z')),
+	).toBe('kody-memories-2026-08-31.json')
+})
+
+test('memories export downloads the signed-in user memories as JSON', async () => {
+	const handler = createAccountMemoriesExportHandler(createEnv())
+
+	mockModule.readAuthenticatedAppUser.mockResolvedValueOnce(null)
+	const unauthorized = await handler.handler({
+		request: new Request('https://example.com/account/memories-export.json'),
+		params: {},
+	} as never)
+	expect(unauthorized.status).toBe(401)
+
+	const defaultExport = await handler.handler({
+		request: new Request('https://example.com/account/memories-export.json'),
+		params: {},
+	} as never)
+	expect(defaultExport.status).toBe(200)
+	expect(defaultExport.headers.get('Cache-Control')).toBe('no-store')
+	expect(defaultExport.headers.get('Content-Type')).toBe(
+		'application/json; charset=utf-8',
+	)
+	expect(defaultExport.headers.get('Content-Disposition')).toMatch(
+		/^attachment; filename="kody-memories-\d{4}-\d{2}-\d{2}\.json"$/,
+	)
+	expect(mockModule.listMemoriesByUserIdPage).toHaveBeenCalledWith(
+		expect.objectContaining({
+			userId: 'stable-user-1',
+			afterId: null,
+			statuses: ['active', 'archived'],
+			limit: 200,
+		}),
+	)
+	const payload = (await defaultExport.json()) as {
+		kind: string
+		version: number
+		exportedAt: string
+		includeDeleted: boolean
+		memories: Array<Record<string, unknown>>
+	}
+	expect(payload.kind).toBe('kody-memories')
+	expect(payload.version).toBe(1)
+	expect(payload.exportedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+	expect(payload.includeDeleted).toBe(false)
+	expect(payload.memories).toEqual([
+		{
+			id: memoryRow.id,
+			subject: memoryRow.subject,
+			category: memoryRow.category,
+			status: memoryRow.status,
+			tags: memoryRow.tags,
+			summary: memoryRow.summary,
+			details: memoryRow.details,
+			sourceUris: memoryRow.sourceUris,
+			dedupeKey: memoryRow.dedupeKey,
+			createdAt: memoryRow.createdAt,
+			updatedAt: memoryRow.updatedAt,
+			lastAccessedAt: memoryRow.lastAccessedAt,
+			deletedAt: memoryRow.deletedAt,
+		},
+	])
+	expect(JSON.stringify(payload)).not.toContain('user@example.com')
+	expect(JSON.stringify(payload)).not.toContain('stable-user-1')
+	expect(payload.memories[0]).not.toHaveProperty('user_id')
+	expect(payload.memories[0]).not.toHaveProperty('userId')
+
+	mockModule.listMemoriesByUserIdPage.mockClear()
+	const withDeleted = await handler.handler({
+		request: new Request(
+			'https://example.com/account/memories-export.json?includeDeleted=true',
+		),
+		params: {},
+	} as never)
+	expect(withDeleted.status).toBe(200)
+	expect(mockModule.listMemoriesByUserIdPage).toHaveBeenCalledWith(
+		expect.objectContaining({
+			statuses: ['active', 'archived', 'deleted'],
+		}),
+	)
+	const deletedPayload = (await withDeleted.json()) as {
+		includeDeleted: boolean
+	}
+	expect(deletedPayload.includeDeleted).toBe(true)
+
+	const firstPage = Array.from({ length: 200 }, (_, index) => ({
+		...mockModule.memoryDbRow,
+		id: `page-1-${String(index).padStart(3, '0')}`,
+	}))
+	mockModule.listMemoriesByUserIdPage
+		.mockResolvedValueOnce(firstPage)
+		.mockResolvedValueOnce([{ ...mockModule.memoryDbRow, id: 'page-2-000' }])
+	const paged = await handler.handler({
+		request: new Request('https://example.com/account/memories-export.json'),
+		params: {},
+	} as never)
+	const pagedPayload = (await paged.json()) as {
+		memories: Array<{ id: string }>
+	}
+	expect(pagedPayload.memories).toHaveLength(201)
+	expect(pagedPayload.memories.at(-1)?.id).toBe('page-2-000')
+	expect(mockModule.listMemoriesByUserIdPage).toHaveBeenNthCalledWith(
+		2,
+		expect.objectContaining({
+			afterId: 'page-1-199',
+		}),
+	)
+
+	const disallowed = await handler.handler({
+		request: new Request('https://example.com/account/memories-export.json', {
+			method: 'POST',
+		}),
+		params: {},
+	} as never)
+	expect(disallowed.status).toBe(405)
 })

--- a/packages/worker/src/app/handlers/account-memories.node.test.ts
+++ b/packages/worker/src/app/handlers/account-memories.node.test.ts
@@ -348,6 +348,7 @@ test('memories export downloads the signed-in user memories as JSON', async () =
 	}
 	expect(deletedPayload.includeDeleted).toBe(true)
 
+	mockModule.listMemoriesByUserIdPage.mockClear()
 	const firstPage = Array.from({ length: 200 }, (_, index) => ({
 		...mockModule.memoryDbRow,
 		id: `page-1-${String(index).padStart(3, '0')}`,

--- a/packages/worker/src/app/handlers/account-memories.ts
+++ b/packages/worker/src/app/handlers/account-memories.ts
@@ -3,10 +3,13 @@ import { type Action } from 'remix/router'
 import {
 	type AccountMemoriesLoaderData,
 	loadAccountMemoriesData,
+	loadAccountMemoriesExport,
+	readAccountMemoriesIncludeDeleted,
 } from '#app/account-memories-data.ts'
 import { readAuthenticatedAppUser } from '#app/authenticated-user.ts'
 import { requireAuthenticatedPageUser } from '#app/page-auth.ts'
 import { readTrimmedStringOrEmpty } from '#app/request-body.ts'
+import { buildMemoriesExportFilename } from '#universal/memory-export.ts'
 import { type routes } from '#universal/routes.ts'
 import { renderAppPage } from '#app/ssr-render.tsx'
 import { deleteMemory } from '#mcp/memory/service.ts'
@@ -43,6 +46,42 @@ export function createAccountMemoriesHandler(env: Env) {
 	} satisfies Action<
 		typeof routes.accountMemories | typeof routes.accountMemoryDetail
 	>
+}
+
+/**
+ * GET /account/memories-export.json for the signed-in user only.
+ * Follows the page Include deleted toggle: active and archived by default;
+ * deleted rows only when that control is on.
+ */
+export function createAccountMemoriesExportHandler(env: Env) {
+	return {
+		middleware: [],
+		async handler({ request }) {
+			const user = await readAuthenticatedAppUser(request, env)
+			if (!user) {
+				return jsonResponse({ ok: false, error: 'Unauthorized.' }, 401)
+			}
+			if (request.method !== 'GET') {
+				return jsonResponse({ ok: false, error: 'Method not allowed.' }, 405)
+			}
+
+			const includeDeleted = readAccountMemoriesIncludeDeleted(request.url)
+			const payload = await loadAccountMemoriesExport({
+				env,
+				user,
+				includeDeleted,
+			})
+			const filename = buildMemoriesExportFilename()
+			return new Response(JSON.stringify(payload, null, 2), {
+				status: 200,
+				headers: {
+					'Cache-Control': 'no-store',
+					'Content-Disposition': `attachment; filename="${filename}"`,
+					'Content-Type': 'application/json; charset=utf-8',
+				},
+			})
+		},
+	} satisfies Action<typeof routes.accountMemoriesExport>
 }
 
 export function createAccountMemoriesApiHandler(env: Env) {

--- a/packages/worker/src/app/router.ts
+++ b/packages/worker/src/app/router.ts
@@ -74,6 +74,7 @@ import {
 } from '#app/handlers/account-mcp-servers.ts'
 import {
 	createAccountMemoriesApiHandler,
+	createAccountMemoriesExportHandler,
 	createAccountMemoriesHandler,
 } from '#app/handlers/account-memories.ts'
 import {
@@ -391,6 +392,7 @@ export function createAppRouter(env: Env) {
 			accountActivityDetail: createAccountActivityHandler(env),
 			accountActivityApi: createAccountActivityApiHandler(env),
 			accountMemories: createAccountMemoriesHandler(env),
+			accountMemoriesExport: createAccountMemoriesExportHandler(env),
 			accountMemoryDetail: createAccountMemoriesHandler(env),
 			accountMemoriesApi: createAccountMemoriesApiHandler(env),
 			accountMemoriesApiPost: createAccountMemoriesApiHandler(env),

--- a/packages/worker/src/mcp/memory/repo.node.test.ts
+++ b/packages/worker/src/mcp/memory/repo.node.test.ts
@@ -1,0 +1,97 @@
+import { DatabaseSync } from 'node:sqlite'
+import { expect, test } from 'vitest'
+import { createD1FromSqlite } from '#worker/test-support/create-d1-from-sqlite.ts'
+import { listMemoriesByUserIdPage } from './repo.ts'
+
+function createMemoryDb() {
+	const sqlite = new DatabaseSync(':memory:')
+	sqlite.exec(`
+		CREATE TABLE mcp_memories (
+			id TEXT PRIMARY KEY NOT NULL,
+			user_id TEXT NOT NULL,
+			category TEXT,
+			status TEXT NOT NULL DEFAULT 'active',
+			subject TEXT NOT NULL,
+			summary TEXT NOT NULL,
+			details TEXT NOT NULL DEFAULT '',
+			tags_json TEXT NOT NULL DEFAULT '[]',
+			source_uris_json TEXT NOT NULL DEFAULT '[]',
+			dedupe_key TEXT,
+			created_at TEXT NOT NULL,
+			updated_at TEXT NOT NULL,
+			last_accessed_at TEXT,
+			deleted_at TEXT
+		)
+	`)
+	return { sqlite, db: createD1FromSqlite(sqlite) }
+}
+
+function insertMemory(
+	sqlite: DatabaseSync,
+	row: { id: string; userId: string; status: string; subject: string },
+) {
+	sqlite
+		.prepare(
+			`INSERT INTO mcp_memories (
+				id, user_id, status, subject, summary, details, created_at, updated_at
+			) VALUES (?, ?, ?, ?, ?, '', '2026-01-01T00:00:00.000Z', '2026-01-01T00:00:00.000Z')`,
+		)
+		.run(row.id, row.userId, row.status, row.subject, row.subject)
+}
+
+test('listMemoriesByUserIdPage is user-scoped, status-filtered, and keyset-paged', async () => {
+	const { sqlite, db } = createMemoryDb()
+	insertMemory(sqlite, {
+		id: 'mem-a',
+		userId: 'user-1',
+		status: 'active',
+		subject: 'Owned active',
+	})
+	insertMemory(sqlite, {
+		id: 'mem-b',
+		userId: 'user-1',
+		status: 'deleted',
+		subject: 'Owned deleted',
+	})
+	insertMemory(sqlite, {
+		id: 'mem-c',
+		userId: 'user-1',
+		status: 'archived',
+		subject: 'Owned archived',
+	})
+	insertMemory(sqlite, {
+		id: 'mem-other',
+		userId: 'user-2',
+		status: 'active',
+		subject: 'Foreign active',
+	})
+
+	const firstPage = await listMemoriesByUserIdPage({
+		db,
+		userId: 'user-1',
+		afterId: null,
+		limit: 2,
+		statuses: ['active', 'archived'],
+	})
+	expect(firstPage.map((row) => row.id)).toEqual(['mem-a', 'mem-c'])
+	expect(firstPage.every((row) => row.user_id === 'user-1')).toBe(true)
+
+	const secondPage = await listMemoriesByUserIdPage({
+		db,
+		userId: 'user-1',
+		afterId: firstPage.at(-1)?.id ?? null,
+		limit: 2,
+		statuses: ['active', 'archived'],
+	})
+	expect(secondPage).toEqual([])
+
+	const withDeleted = await listMemoriesByUserIdPage({
+		db,
+		userId: 'user-1',
+		afterId: null,
+		limit: 10,
+		statuses: ['active', 'archived', 'deleted'],
+	})
+	expect(withDeleted.map((row) => row.id)).toEqual(['mem-a', 'mem-b', 'mem-c'])
+	expect(withDeleted.some((row) => row.user_id !== 'user-1')).toBe(false)
+})

--- a/packages/worker/src/mcp/memory/repo.ts
+++ b/packages/worker/src/mcp/memory/repo.ts
@@ -185,6 +185,38 @@ export async function listMemoriesByUserId(
 	return (results ?? []).map(mapMemoryRow)
 }
 
+/**
+ * Keyset-paged listing of one user's memories. The account memories export
+ * uses this so a single query never loads the whole table.
+ */
+export async function listMemoriesByUserIdPage(input: {
+	db: D1Database
+	userId: string
+	afterId: string | null
+	limit: number
+	statuses?: Array<McpMemoryRow['status']>
+}): Promise<Array<McpMemoryRow>> {
+	const statuses =
+		input.statuses && input.statuses.length > 0 ? input.statuses : null
+	const statusClause = statuses
+		? `AND status IN (${statuses.map(() => '?').join(', ')})`
+		: ''
+	const { results } = await input.db
+		.prepare(
+			`SELECT id, user_id, category, status, subject, summary, details, tags_json,
+				source_uris_json, dedupe_key, created_at, updated_at, last_accessed_at, deleted_at
+			FROM mcp_memories
+			WHERE user_id = ?
+				AND id > ?
+				${statusClause}
+			ORDER BY id
+			LIMIT ?`,
+		)
+		.bind(input.userId, input.afterId ?? '', ...(statuses ?? []), input.limit)
+		.all<Record<string, unknown>>()
+	return (results ?? []).map(mapMemoryRow)
+}
+
 export async function listMemoriesByIds(
 	db: D1Database,
 	userId: string,

--- a/packages/worker/universal/memory-export.ts
+++ b/packages/worker/universal/memory-export.ts
@@ -1,0 +1,10 @@
+/**
+ * Calendar-date filename for the signed-in user's memories download.
+ * Uses UTC so the same instant produces the same name in every timezone.
+ */
+export function buildMemoriesExportFilename(now = new Date()) {
+	const year = String(now.getUTCFullYear())
+	const month = String(now.getUTCMonth() + 1).padStart(2, '0')
+	const day = String(now.getUTCDate()).padStart(2, '0')
+	return `kody-memories-${year}-${month}-${day}.json`
+}

--- a/packages/worker/universal/routes.ts
+++ b/packages/worker/universal/routes.ts
@@ -67,6 +67,9 @@ export const routes = route({
 	accountActivityApi: '/account/activity.json',
 	accountMemories: '/account/memories',
 	accountMemoryDetail: '/account/memories/:memoryId',
+	// Sibling of `/account/memories.json` so `:memoryId` cannot claim the
+	// signed-in user's memories download.
+	accountMemoriesExport: '/account/memories-export.json',
 	accountMemoriesApi: '/account/memories.json',
 	accountMemoriesApiPost: post('/account/memories.json'),
 	accountEmail: '/account/email',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Give the signed-in user a quiet way to download their own memories as JSON from the memories page — for backup, another agent, or leaving.

## Why

Memories are already browsable. There was no one-click export. The full account export is a different, heavier surface. This is memories only.

## Summary

- `GET /account/memories-export.json` downloads the signed-in user's memories as `kody-memories-YYYY-MM-DD.json`.
- Default export is active and archived memories. Deleted rows are included only when the page **Include deleted** control is on (the download URL follows that query).
- The file is memories only: no credentials, email, username, or other account primitives.
- A ghost **Export** button sits in the memories toolbar next to Include deleted. No new page, no empty-state hero, no import.

## Testing

- Extended `account-memories.node.test.ts` for 401, default vs include-deleted statuses, payload shape, filename, paging, and POST 405.
- Added `repo.node.test.ts` for user-scoped, status-filtered, keyset-paged listing.
- `npm run validate` is green locally.
- Preview `kody-pr-1899`: authenticated `GET /account/memories-export.json` returns `kind: kody-memories`, `Content-Disposition: attachment; filename="kody-memories-2026-08-31.json"`, and `Cache-Control: no-store`. Unauthenticated GET is 401. Include deleted flips `includeDeleted` in the JSON.
- Logged-in UI pass on the preview: Export sits next to Include deleted; click downloads `kody-memories-2026-08-31.json`; checking Include deleted updates the href to `?includeDeleted=true`.

![Export button next to Include deleted](https://cursor.com/artifacts/c/art-44704d6b-999b-4986-bb90-2e27408d81ce)
![Export href includes includeDeleted when the checkbox is on](https://cursor.com/artifacts/c/art-9010a7d4-ad0e-49b8-88b2-bda777678b16)
![Browser download of kody-memories-2026-08-31.json](https://cursor.com/artifacts/c/art-b4996b69-103d-48f1-bc31-5f9f97a17fb0)

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `cb79a6e4` · **Head:** `6b76464f`

**Classification:** extends — new memories download route and toolbar control on app-ui; memory repo gains a user-scoped keyset list. No primitives added.

### Primitives touched

| Primitive    | Group    | Impact                                                                 |
| ------------ | -------- | ---------------------------------------------------------------------- |
| `app-ui`     | surfaces | extends — `GET /account/memories-export.json` and toolbar Export link |
| `mcp-server` | surfaces | composes — `listMemoriesByUserIdPage` read helper, no MCP tool change |

### Change flow

The signed-in user downloads their own memories from the memories page; deleted rows follow Include deleted.

```mermaid
sequenceDiagram
	actor User
	participant appUi as app-ui
	participant mcpServer as mcp-server
	User->>appUi: click Export (toolbar, next to Include deleted)
	appUi->>appUi: GET /account/memories-export.json
	Note over appUi: 401 unless the request has a signed-in session
	appUi->>mcpServer: listMemoriesByUserIdPage(userId, statuses)
	Note over mcpServer: statuses are active+archived, or +deleted when Include deleted is on
	mcpServer-->>appUi: keyset pages of that user's mcp_memories rows
	appUi-->>User: attachment kody-memories-YYYY-MM-DD.json
```

### Before / after

**Route**

```text
Before: GET /account/memories.json  → page loader (≤100, search, email/username)
After:  GET /account/memories-export.json → attachment (all matching memories, memories only)
```

**Include deleted**

```text
Before: list/detail only
After:  export URL copies the page toggle; off = active+archived, on = +deleted
```

### Invariants

- Per-user isolation: the export binds `mcpUser.userId`. There is no admin or cross-user path.
- The JSON omits credentials and other primitives (no email, username, or `user_id`).

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5de51fd8-7768-4138-ab36-6f22e3341999?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5de51fd8-7768-4138-ab36-6f22e3341999&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Export button to download the signed-in user’s memories as a dated JSON file.
  * Exported files include memory data only and can optionally include deleted memories.
  * Large memory collections are exported across multiple pages.

* **Documentation**
  * Added guidance for downloading account memories and selecting deleted memories.

* **Bug Fixes**
  * Improved account memory route handling and export response validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->