### PR TITLE
Flag compact MCP server instructions for 2048-character clients

### DIFF
--- a/docs/contributing/architecture/feature-flags.md
+++ b/docs/contributing/architecture/feature-flags.md
@@ -70,7 +70,9 @@ default-on flag can never bypass an operator kill switch when D1 is unavailable.
 
 The registry ships with one permanent flag, `demo-indicator`, which renders a
 small badge in the app chrome and exists so the system stays exercised
-end-to-end (`e2e/admin-feature-flags.spec.ts`).
+end-to-end (`e2e/admin-feature-flags.spec.ts`). Experiment flags such as
+`compact-mcp-server-instructions` live in the same registry and are removed in
+the same way: delete the definition and every gate site.
 
 ## Success metrics
 

--- a/docs/use/execute.md
+++ b/docs/use/execute.md
@@ -291,13 +291,20 @@ Users can read or replace their own MCP server instruction overlay with
 **`meta_get_mcp_server_instructions`** and
 **`meta_set_mcp_server_instructions`**.
 
-This overlay is appended to Kody's built-in server instructions for that user.
-Prefer **memories** for durable facts and preferences; use the overlay only for
-rare always-on session policy — not for maintaining a package inventory. When
-agents have used saved packages via MCP `execute`, Kody may include a short
-“often used packages” hint automatically; discover others with **`search`**.
-Pass an empty string to clear the overlay. Changes apply to new MCP sessions, so
-reconnect the MCP client if the host caches server instructions.
+This overlay is appended after Kody's built-in server instructions for that
+user. Prefer **memories** for durable facts and preferences; use the overlay
+only for rare always-on session policy — not for maintaining a package
+inventory. When agents have used saved packages via MCP `execute`, Kody may
+include a short “often used packages” hint automatically; discover others with
+**`search`**. Pass an empty string to clear the overlay. Changes apply to new
+MCP sessions, so reconnect the MCP client if the host caches server
+instructions.
+
+Some MCP clients keep only the first 2048 characters of server instructions.
+**`meta_get_mcp_server_instructions`** and
+**`meta_set_mcp_server_instructions`** report `assembled_chars` and a `warning`
+when the assembled text meets that cut, so the overlay may never reach the
+model.
 
 ## Network and OAuth helpers
 

--- a/packages/worker/client/routes/email-verification-flow.node.test.ts
+++ b/packages/worker/client/routes/email-verification-flow.node.test.ts
@@ -52,7 +52,10 @@ test('email verification redirect helpers preserve safe targets and reject open 
 		username: 'account-user',
 		roles: ['user'],
 		permissions: [],
-		featureFlags: { 'demo-indicator': false },
+		featureFlags: {
+			'demo-indicator': false,
+			'compact-mcp-server-instructions': false,
+		},
 	}
 	const verifiedUser: SessionInfo = {
 		...unverifiedUser,

--- a/packages/worker/src/app/handlers/session-handler.node.test.ts
+++ b/packages/worker/src/app/handlers/session-handler.node.test.ts
@@ -168,6 +168,7 @@ test('session handler only renews remembered sessions after the renewal window',
 				permissions: [],
 				featureFlags: {
 					'demo-indicator': false,
+					'compact-mcp-server-instructions': false,
 				},
 			},
 		})

--- a/packages/worker/src/feature-flags/service.node.test.ts
+++ b/packages/worker/src/feature-flags/service.node.test.ts
@@ -270,6 +270,7 @@ test('isFeatureEnabled falls back to registry default when no DB state exists', 
 	)
 	await expect(getFeatureFlagsForUser(db, 1)).resolves.toEqual({
 		'demo-indicator': false,
+		'compact-mcp-server-instructions': false,
 	})
 })
 
@@ -436,6 +437,7 @@ test('user override wins over global off and global on; clear restores evaluatio
 	await expect(isFeatureEnabled(db, 'demo-indicator', 8)).resolves.toBe(false)
 	await expect(getFeatureFlagsForUser(db, 7)).resolves.toEqual({
 		'demo-indicator': true,
+		'compact-mcp-server-instructions': false,
 	})
 
 	await setFeatureFlagGlobalState(db, {
@@ -467,6 +469,7 @@ test('getFeatureFlagEvaluationsForUser reports assignment sources', async () => 
 
 	await expect(getFeatureFlagEvaluationsForUser(db, 7)).resolves.toEqual({
 		'demo-indicator': { enabled: false, source: 'default' },
+		'compact-mcp-server-instructions': { enabled: false, source: 'default' },
 	})
 
 	await setFeatureFlagGlobalState(db, {
@@ -552,8 +555,21 @@ test('listFeatureFlagsForAdmin includes registry flags and stale DB-only keys', 
 	})
 
 	const listed = await listFeatureFlagsForAdmin(db)
-	expect(listed).toHaveLength(3)
+	expect(listed).toHaveLength(4)
 
+	const compact = listed.find(
+		(flag) => flag.key === 'compact-mcp-server-instructions',
+	)
+	expect(compact).toMatchObject({
+		key: 'compact-mcp-server-instructions',
+		stale: false,
+		defaultEnabled: false,
+		successMetric: {
+			eventType: 'execute',
+			measure: 'event_count',
+			goal: 'increase',
+		},
+	})
 	const demo = listed.find((flag) => flag.key === 'demo-indicator')
 	expect(demo).toMatchObject({
 		key: 'demo-indicator',

--- a/packages/worker/src/mcp/assemble-mcp-server-instructions.ts
+++ b/packages/worker/src/mcp/assemble-mcp-server-instructions.ts
@@ -1,0 +1,57 @@
+/**
+ * Single MCP-lane switch for the compact-mcp-server-instructions experiment.
+ *
+ * Delete this file's compact branch (and
+ * `instructions/compact-mcp-server-instructions.ts`) when the experiment
+ * ends; both `/mcp` lanes already call this helper.
+ */
+
+import { type McpCallerContext } from '@kody-internal/shared/chat.ts'
+import { resolveCallerFeatureFlags } from '#mcp/capabilities/access-control.ts'
+import { getCapabilityRegistryForContext } from '#mcp/capabilities/registry.ts'
+import { compactMcpServerInstructionsFlagKey } from '#mcp/instructions/compact-mcp-server-instructions.ts'
+import { loadActiveRetiringNoticeIds } from '#mcp/instructions/retiring-primitives.ts'
+import { buildMcpServerInstructions } from '#mcp/server-instructions.ts'
+import { getMcpUserServerInstructions } from '#mcp/user-server-instructions-repo.ts'
+import { listPopularAgentPackagesForUser } from '#worker/usage/agent-package-conversation-uses.ts'
+
+export async function assembleMcpServerInstructionsForCaller(input: {
+	env: Env
+	callerContext: McpCallerContext
+}): Promise<string> {
+	const userId = input.callerContext.user?.userId ?? null
+	const flags = await resolveCallerFeatureFlags(input.env, input.callerContext)
+	const compact = flags[compactMcpServerInstructionsFlagKey] === true
+	if (compact) {
+		const overlay =
+			userId !== null
+				? await getMcpUserServerInstructions(input.env.APP_DB, userId)
+				: null
+		return buildMcpServerInstructions({
+			userOverlay: overlay,
+			compact: true,
+			displayName: input.callerContext.user?.displayName,
+		})
+	}
+
+	const [overlay, registry, popularPackages, retiringNoticeIds] =
+		await Promise.all([
+			userId !== null
+				? getMcpUserServerInstructions(input.env.APP_DB, userId)
+				: Promise.resolve(null),
+			getCapabilityRegistryForContext({
+				env: input.env,
+				callerContext: input.callerContext,
+			}),
+			userId !== null
+				? listPopularAgentPackagesForUser(input.env.APP_DB, { userId })
+				: Promise.resolve([]),
+			loadActiveRetiringNoticeIds(input.env.APP_DB, userId),
+		])
+	return buildMcpServerInstructions({
+		userOverlay: overlay,
+		domains: registry.capabilityDomains,
+		popularPackages,
+		retiringNoticeIds,
+	})
+}

--- a/packages/worker/src/mcp/capabilities/access-control.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/access-control.node.test.ts
@@ -12,6 +12,7 @@ import { type Capability } from './types.ts'
 function createFlagMap(enabled: boolean): CallerFeatureFlags {
 	return {
 		'demo-indicator': enabled,
+		'compact-mcp-server-instructions': false,
 	}
 }
 

--- a/packages/worker/src/mcp/capabilities/meta/meta-get-mcp-server-instructions.ts
+++ b/packages/worker/src/mcp/capabilities/meta/meta-get-mcp-server-instructions.ts
@@ -6,12 +6,15 @@ import {
 	type CapabilityContext,
 } from '#mcp/capabilities/types.ts'
 import { maxUserMcpServerInstructionsChars } from '#mcp/mcp-user-server-instruction-limits.ts'
+import { describeUserMcpServerInstructionOverlay } from '#mcp/mcp-server-instruction-overlay.ts'
 import { getMcpUserServerInstructions } from '#mcp/user-server-instructions-repo.ts'
 import { requireMcpUser } from './require-user.ts'
 
 const outputSchema = z.object({
 	instructions: z.string().nullable(),
 	max_length: z.number().int().positive(),
+	assembled_chars: z.number().int().nonnegative(),
+	warning: z.string().nullable(),
 })
 
 export const metaGetMcpServerInstructionsCapability = defineDomainCapability(
@@ -19,7 +22,7 @@ export const metaGetMcpServerInstructionsCapability = defineDomainCapability(
 	{
 		name: 'meta_get_mcp_server_instructions',
 		description:
-			'Read the signed-in user’s custom MCP server instructions overlay (if any). Empty means none. Same character limit as set. Prefer memories for durable facts and preferences; the overlay is only for rare always-on session policy.',
+			'Read the signed-in user’s custom MCP server instructions overlay (if any). Empty means none. Same character limit as set. Prefer memories for durable facts and preferences; the overlay is only for rare always-on session policy. Reports assembled_chars and a warning when some clients would truncate the overlay.',
 		keywords: [
 			'instructions',
 			'server',
@@ -40,9 +43,16 @@ export const metaGetMcpServerInstructionsCapability = defineDomainCapability(
 				ctx.env.APP_DB,
 				user.userId,
 			)
+			const assembly = await describeUserMcpServerInstructionOverlay({
+				env: ctx.env,
+				callerContext: ctx.callerContext,
+				overlay: instructions,
+			})
 			return {
 				instructions,
 				max_length: maxUserMcpServerInstructionsChars,
+				assembled_chars: assembly.assembled_chars,
+				warning: assembly.warning,
 			}
 		},
 	},

--- a/packages/worker/src/mcp/capabilities/meta/meta-set-mcp-server-instructions.ts
+++ b/packages/worker/src/mcp/capabilities/meta/meta-set-mcp-server-instructions.ts
@@ -3,6 +3,7 @@ import { defineDomainCapability } from '#mcp/capabilities/define-domain-capabili
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { type CapabilityContext } from '#mcp/capabilities/types.ts'
 import { maxUserMcpServerInstructionsChars } from '#mcp/mcp-user-server-instruction-limits.ts'
+import { describeUserMcpServerInstructionOverlay } from '#mcp/mcp-server-instruction-overlay.ts'
 import {
 	getMcpUserServerInstructions,
 	saveMcpUserServerInstructions,
@@ -14,6 +15,8 @@ const outputSchema = z.object({
 	max_length: z.number().int().positive(),
 	/** Effective stored text after trim (null if cleared). */
 	instructions: z.string().nullable(),
+	assembled_chars: z.number().int().nonnegative(),
+	warning: z.string().nullable(),
 })
 
 export const metaSetMcpServerInstructionsCapability = defineDomainCapability(
@@ -21,7 +24,7 @@ export const metaSetMcpServerInstructionsCapability = defineDomainCapability(
 	{
 		name: 'meta_set_mcp_server_instructions',
 		description:
-			'Replace or clear the signed-in user’s custom MCP server instructions overlay (appended to built-in server instructions for new MCP connections). Prefer memories for durable facts and preferences; use this overlay only for rare always-on session policy—not package inventory (popular packages are hinted automatically when available). Pass an empty string to clear. Changes apply to new MCP sessions—reconnect the client if the host caches server instructions.',
+			'Replace or clear the signed-in user’s custom MCP server instructions overlay (appended to built-in server instructions for new MCP connections). Prefer memories for durable facts and preferences; use this overlay only for rare always-on session policy—not package inventory (popular packages are hinted automatically when available). Pass an empty string to clear. Changes apply to new MCP sessions—reconnect the client if the host caches server instructions. Reports assembled_chars and a warning when some clients would truncate the overlay.',
 		keywords: [
 			'instructions',
 			'server',
@@ -57,10 +60,17 @@ export const metaSetMcpServerInstructionsCapability = defineDomainCapability(
 				ctx.env.APP_DB,
 				user.userId,
 			)
+			const assembly = await describeUserMcpServerInstructionOverlay({
+				env: ctx.env,
+				callerContext: ctx.callerContext,
+				overlay: stored,
+			})
 			return {
 				ok: true as const,
 				max_length: maxUserMcpServerInstructionsChars,
 				instructions: stored,
+				assembled_chars: assembly.assembled_chars,
+				warning: assembly.warning,
 			}
 		},
 	},

--- a/packages/worker/src/mcp/index.ts
+++ b/packages/worker/src/mcp/index.ts
@@ -6,18 +6,14 @@ import { CfWorkerJsonSchemaValidator } from '@modelcontextprotocol/sdk/validatio
 import { McpAgent } from 'agents/mcp'
 import { buildSentryOptions } from '../sentry-options.ts'
 import { parseMcpCallerContext, type McpServerProps } from './context.ts'
-import { loadActiveRetiringNoticeIds } from './instructions/retiring-primitives.ts'
-import { buildMcpServerInstructions } from './server-instructions.ts'
+import { assembleMcpServerInstructionsForCaller } from './assemble-mcp-server-instructions.ts'
 import { registerTools } from './register-tools.ts'
 import {
 	asMcpToolServer,
 	type McpRegistrationAgent,
 } from './mcp-registration-agent.ts'
 import { createKodyMcpServer } from './sentry-mcp-server.ts'
-import { getMcpUserServerInstructions } from './user-server-instructions-repo.ts'
-import { getCapabilityRegistryForContext } from './capabilities/registry.ts'
 import { type RawFetchHostNudgeState } from '#mcp/raw-fetch-host-nudge.ts'
-import { listPopularAgentPackagesForUser } from '#worker/usage/agent-package-conversation-uses.ts'
 import {
 	purgePersistedMcpAgentSession,
 	registerMcpAgentSession,
@@ -74,26 +70,10 @@ class MCPBase extends McpAgent<Env, State, Props> {
 				}),
 			)
 		}
-		const [overlay, registry, popularPackages, retiringNoticeIds] =
-			await Promise.all([
-				userId !== null
-					? getMcpUserServerInstructions(this.env.APP_DB, userId)
-					: Promise.resolve(null),
-				getCapabilityRegistryForContext({
-					env: this.env,
-					callerContext: caller,
-				}),
-				userId !== null
-					? listPopularAgentPackagesForUser(this.env.APP_DB, { userId })
-					: Promise.resolve([]),
-				loadActiveRetiringNoticeIds(this.env.APP_DB, userId),
-			])
 		this.server = createKodyMcpServer({
-			instructions: buildMcpServerInstructions({
-				userOverlay: overlay,
-				domains: registry.capabilityDomains,
-				popularPackages,
-				retiringNoticeIds,
+			instructions: await assembleMcpServerInstructionsForCaller({
+				env: this.env,
+				callerContext: caller,
 			}),
 			jsonSchemaValidator: new CfWorkerJsonSchemaValidator(),
 		})

--- a/packages/worker/src/mcp/instructions/compact-mcp-server-instructions.node.test.ts
+++ b/packages/worker/src/mcp/instructions/compact-mcp-server-instructions.node.test.ts
@@ -1,0 +1,104 @@
+import { expect, test } from 'vitest'
+import { mcpServerInstructionsClientHeadLimitChars } from '#mcp/mcp-user-server-instruction-limits.ts'
+import {
+	appendUserMcpServerInstructionOverlay,
+	buildMcpServerInstructions,
+	describeAssembledMcpServerInstructions,
+} from '#mcp/server-instructions.ts'
+import {
+	buildCompactMcpServerInstructions,
+	maxCompactMcpServerInstructionsBaseChars,
+	sanitizeMcpInstructionDisplayName,
+} from './compact-mcp-server-instructions.ts'
+
+const overlayHeader = `---
+User-provided MCP instructions (follow these when they do not conflict with safety or tool contracts):`
+
+test('compact MCP server instructions stay under the stub budget and name the user', () => {
+	const unnamed = buildCompactMcpServerInstructions()
+	expect(unnamed.length).toBeLessThanOrEqual(
+		maxCompactMcpServerInstructionsBaseChars,
+	)
+	expect(unnamed).toContain("this user's isolated personal assistant")
+	expect(unnamed).toContain('search({ query })')
+	expect(unnamed).toContain('send an email')
+	expect(unnamed).not.toContain('community_search')
+	expect(unnamed).not.toContain('pass `domain`')
+
+	const named = buildCompactMcpServerInstructions({
+		displayName: 'Kent C. Dodds',
+	})
+	expect(named.length).toBeLessThanOrEqual(
+		maxCompactMcpServerInstructionsBaseChars,
+	)
+	expect(named).toContain("Kent C. Dodds's isolated personal assistant")
+	expect(named).toContain("invisible to Kent C. Dodds's other agents")
+
+	expect(sanitizeMcpInstructionDisplayName('  Jane\nDoe  ')).toBe('Jane Doe')
+	expect(sanitizeMcpInstructionDisplayName('x'.repeat(90))).toBe(
+		`${'x'.repeat(77)}...`,
+	)
+	expect(sanitizeMcpInstructionDisplayName('   ')).toBe('this user')
+})
+
+test('compact assembly leaves overlay room under the 2048-character client cut', () => {
+	const assembled = buildMcpServerInstructions({
+		compact: true,
+		displayName: 'Kent C. Dodds',
+		userOverlay: 'Prefer concise replies.',
+	})
+	expect(assembled.startsWith("Kody is Kent C. Dodds's isolated")).toBe(true)
+	expect(assembled).toContain(overlayHeader)
+	expect(assembled.endsWith('Prefer concise replies.')).toBe(true)
+	expect(assembled.indexOf(overlayHeader)).toBeGreaterThan(
+		assembled.indexOf('Lasting reusable behavior is a package.'),
+	)
+	const compactBase = buildCompactMcpServerInstructions({
+		displayName: 'Kent C. Dodds',
+	})
+	const headerOnly = appendUserMcpServerInstructionOverlay(compactBase, 'x')
+	expect(headerOnly.length - 1).toBeLessThan(
+		mcpServerInstructionsClientHeadLimitChars,
+	)
+	expect(assembled.length).toBeLessThan(
+		mcpServerInstructionsClientHeadLimitChars,
+	)
+})
+
+test('overlay warning fires only when assembled text meets the client cut', () => {
+	const compactWithShortOverlay = buildMcpServerInstructions({
+		compact: true,
+		displayName: 'Maciek',
+		userOverlay: 'Prefer concise replies.',
+	})
+	expect(
+		describeAssembledMcpServerInstructions({
+			assembled: compactWithShortOverlay,
+			hasOverlay: true,
+		}),
+	).toEqual({
+		assembled_chars: compactWithShortOverlay.length,
+		warning: null,
+	})
+
+	const fatWithOverlay = buildMcpServerInstructions({
+		userOverlay: 'Prefer concise replies.',
+	})
+	const fatWarning = describeAssembledMcpServerInstructions({
+		assembled: fatWithOverlay,
+		hasOverlay: true,
+	})
+	expect(fatWithOverlay.length).toBeGreaterThanOrEqual(
+		mcpServerInstructionsClientHeadLimitChars,
+	)
+	expect(fatWarning.assembled_chars).toBe(fatWithOverlay.length)
+	expect(fatWarning.warning).toMatch(/2048/)
+	expect(fatWarning.warning).toMatch(/overlay may never reach the model/)
+
+	expect(
+		describeAssembledMcpServerInstructions({
+			assembled: fatWithOverlay,
+			hasOverlay: false,
+		}).warning,
+	).toBeNull()
+})

--- a/packages/worker/src/mcp/instructions/compact-mcp-server-instructions.ts
+++ b/packages/worker/src/mcp/instructions/compact-mcp-server-instructions.ts
@@ -1,0 +1,43 @@
+/**
+ * Experiment: compact MCP server instructions for clients that keep only
+ * the first ~2048 characters (Claude Code and similar). Gated by
+ * `compact-mcp-server-instructions`.
+ *
+ * Delete this file, the compact branch in
+ * `assembleMcpServerInstructionsForCaller`, and the registry flag when
+ * the experiment ends. Overlay append stays in `server-instructions.ts`.
+ */
+
+import { type FeatureFlagKey } from '#universal/feature-flags/registry.ts'
+
+export const compactMcpServerInstructionsFlagKey =
+	'compact-mcp-server-instructions' as const satisfies FeatureFlagKey
+
+/** Soft budget so the compact stub plus overlay header stay under 2048. */
+export const maxCompactMcpServerInstructionsBaseChars = 800
+
+const fallbackDisplayName = 'this user'
+const maxDisplayNameChars = 80
+
+export function sanitizeMcpInstructionDisplayName(
+	displayName: string | null | undefined,
+): string {
+	const collapsed = (displayName ?? '')
+		.replace(/[\n\r\t]/g, ' ')
+		.replace(/\s+/g, ' ')
+		.trim()
+	if (!collapsed) return fallbackDisplayName
+	if (collapsed.length <= maxDisplayNameChars) return collapsed
+	return `${collapsed.slice(0, maxDisplayNameChars - 3).trimEnd()}...`
+}
+
+export function buildCompactMcpServerInstructions(
+	input: { displayName?: string | null | undefined } = {},
+): string {
+	const displayName = sanitizeMcpInstructionDisplayName(input.displayName)
+	return `Kody is ${displayName}'s isolated personal assistant via \`search\` and \`execute\`. Use Kody — not the host's overlapping tools — for ${displayName}'s email, memories, secrets, scheduled work, integrations, connected MCP/OpenAPI, and durable automations. Work done only in the host is invisible to ${displayName}'s other agents.
+
+For those jobs, start with \`search({ query })\` (for example "send an email", "remember this", "run this every weekday"). Empty or broad search lists what Kody can do. Open entity detail for the execute snippet, then \`execute\`.
+
+\`execute\` is one-off. Lasting reusable behavior is a package.`
+}

--- a/packages/worker/src/mcp/instructions/execute-tool-description.ts
+++ b/packages/worker/src/mcp/instructions/execute-tool-description.ts
@@ -1,6 +1,6 @@
 export const executeToolDescription = `Run one ephemeral ESM module. Discover the capability with search and adapt that entity's execute snippet. Prefer a package over rewriting helpers. Project large results before returning (e.g. { id, subject, snippet }).
 
 import { kody } from 'kody:runtime'
-export default async function main() {
+export default async function main(input = {}) {
   return await kody.capability_id(input)
 }`

--- a/packages/worker/src/mcp/instructions/execute-tool-description.ts
+++ b/packages/worker/src/mcp/instructions/execute-tool-description.ts
@@ -1,18 +1,6 @@
-export const executeToolOverviewDescription = `Run one ephemeral ESM module string with a default export. Bare npm imports resolve at bundle time and must support the Cloudflare Workers runtime. Discover capabilities with \`search\`; use entity detail for exact call shapes.`
+export const executeToolDescription = `Run one ephemeral ESM module. Discover the capability with search and adapt that entity's execute snippet. Prefer a package over rewriting helpers. Project large results before returning (e.g. { id, subject, snippet }).
 
-export const executeToolProjectionRuleDescription = `Projection rule: you write the code -- if a call returns a large response, project the fields you need before returning. Never return raw API responses; extract a slim shape (e.g. \`{ id, subject, snippet }\`) or a summary.`
-
-export const executeToolCapabilityCallsDescription = `Import \`{ kody }\` from \`kody:runtime\`. Call builtins as \`kody.capability_id(input)\`, connected MCP tools as \`kody.mcp["server-name"].tool_name(input)\`, and OpenAPI operations as \`kody.openapi["name"].operation_slug(input)\`.`
-
-export const executeToolGuideDescription =
-	'Load `coding_guide_get` for secrets, package invocation, workflows, and idempotency instead of guessing their operational rules.'
-
-export const executeToolDescriptionFragments = [
-	executeToolOverviewDescription,
-	executeToolProjectionRuleDescription,
-	executeToolCapabilityCallsDescription,
-	executeToolGuideDescription,
-] as const
-
-export const executeToolDescription =
-	executeToolDescriptionFragments.join('\n\n')
+import { kody } from 'kody:runtime'
+export default async function main() {
+  return await kody.capability_id(input)
+}`

--- a/packages/worker/src/mcp/instructions/mcp-tool-descriptions.node.test.ts
+++ b/packages/worker/src/mcp/instructions/mcp-tool-descriptions.node.test.ts
@@ -15,6 +15,9 @@ test('search and execute tool descriptions fit a 2048-character client cut', () 
 	expect(executeToolDescription.length).toBeLessThan(
 		mcpServerInstructionsClientHeadLimitChars,
 	)
+	expect(executeToolDescription).toContain(
+		'export default async function main(input = {})',
+	)
 	expect(executeToolDescription).toContain('kody.capability_id(input)')
 	expect(executeToolDescription).toContain("from 'kody:runtime'")
 })

--- a/packages/worker/src/mcp/instructions/mcp-tool-descriptions.node.test.ts
+++ b/packages/worker/src/mcp/instructions/mcp-tool-descriptions.node.test.ts
@@ -1,0 +1,20 @@
+import { expect, test } from 'vitest'
+import { executeToolDescription } from '#mcp/instructions/execute-tool-description.ts'
+import { mcpServerInstructionsClientHeadLimitChars } from '#mcp/mcp-user-server-instruction-limits.ts'
+import { searchTool } from '#mcp/tools/search-tool-definition.ts'
+
+test('search and execute tool descriptions fit a 2048-character client cut', () => {
+	expect(searchTool.description.length).toBeLessThan(
+		mcpServerInstructionsClientHeadLimitChars,
+	)
+	expect(searchTool.description).toContain('"send a message"')
+	expect(searchTool.description).toContain('coding_guide_get:capability')
+	expect(searchTool.description).not.toContain('meta_list_capabilities')
+	expect(searchTool.description).not.toContain('drill in with')
+
+	expect(executeToolDescription.length).toBeLessThan(
+		mcpServerInstructionsClientHeadLimitChars,
+	)
+	expect(executeToolDescription).toContain('kody.capability_id(input)')
+	expect(executeToolDescription).toContain("from 'kody:runtime'")
+})

--- a/packages/worker/src/mcp/mcp-server-instruction-overlay.ts
+++ b/packages/worker/src/mcp/mcp-server-instruction-overlay.ts
@@ -1,0 +1,29 @@
+import { type McpCallerContext } from '@kody-internal/shared/chat.ts'
+import { resolveCallerFeatureFlags } from '#mcp/capabilities/access-control.ts'
+import { compactMcpServerInstructionsFlagKey } from '#mcp/instructions/compact-mcp-server-instructions.ts'
+import {
+	buildMcpServerInstructions,
+	describeAssembledMcpServerInstructions,
+} from '#mcp/server-instructions.ts'
+
+/**
+ * Size the overlay against the same assembly the next MCP session would
+ * serve. Compact vs full is the experiment branch; the 2048-character
+ * warning stays after the flag is deleted.
+ */
+export async function describeUserMcpServerInstructionOverlay(input: {
+	env: Env
+	callerContext: McpCallerContext
+	overlay: string | null
+}): Promise<{ assembled_chars: number; warning: string | null }> {
+	const flags = await resolveCallerFeatureFlags(input.env, input.callerContext)
+	const assembled = buildMcpServerInstructions({
+		userOverlay: input.overlay,
+		compact: flags[compactMcpServerInstructionsFlagKey] === true,
+		displayName: input.callerContext.user?.displayName,
+	})
+	return describeAssembledMcpServerInstructions({
+		assembled,
+		hasOverlay: Boolean(input.overlay?.trim()),
+	})
+}

--- a/packages/worker/src/mcp/mcp-user-server-instruction-limits.ts
+++ b/packages/worker/src/mcp/mcp-user-server-instruction-limits.ts
@@ -1,2 +1,9 @@
 /** Max characters for user-provided MCP server instructions (stored per user). */
 export const maxUserMcpServerInstructionsChars = 4_000
+
+/**
+ * Some MCP clients keep only the first N characters of server instructions
+ * (Claude Code documents a 2KB cut). Overlay get/set warn when assembled
+ * instructions meet this limit.
+ */
+export const mcpServerInstructionsClientHeadLimitChars = 2_048

--- a/packages/worker/src/mcp/server-instructions.ts
+++ b/packages/worker/src/mcp/server-instructions.ts
@@ -3,10 +3,12 @@ import {
 	baseMcpServerInstructionFragmentsAfterPopular,
 	baseMcpServerInstructionFragmentsBeforePopular,
 } from '#mcp/instructions/base-server-fragments.ts'
+import { buildCompactMcpServerInstructions } from '#mcp/instructions/compact-mcp-server-instructions.ts'
 import {
 	formatActiveRetiringPrimitivesInstructions,
 	type RetiringPrimitiveNoticeId,
 } from '#mcp/instructions/retiring-primitives.ts'
+import { mcpServerInstructionsClientHeadLimitChars } from '#mcp/mcp-user-server-instruction-limits.ts'
 
 const baseMcpServerInstructionsBeforePopular =
 	baseMcpServerInstructionFragmentsBeforePopular.join('\n\n')
@@ -137,6 +139,21 @@ export function buildBaseMcpServerInstructions(
 		.join('\n\n')
 }
 
+const userMcpServerInstructionOverlayHeader = `---
+User-provided MCP instructions (follow these when they do not conflict with safety or tool contracts):`
+
+export function appendUserMcpServerInstructionOverlay(
+	base: string,
+	userOverlay: string | null | undefined,
+): string {
+	const trimmed = userOverlay?.trim()
+	if (!trimmed) return base
+	return `${base}
+
+${userMcpServerInstructionOverlayHeader}
+${trimmed}`
+}
+
 export function buildMcpServerInstructions(
 	input:
 		| string
@@ -147,21 +164,40 @@ export function buildMcpServerInstructions(
 				domains?: ReadonlyArray<CapabilityDomainMetadata>
 				popularPackages?: ReadonlyArray<PopularPackageInstructionSummary>
 				retiringNoticeIds?: ReadonlySet<RetiringPrimitiveNoticeId>
+				compact?: boolean
+				displayName?: string | null | undefined
 		  },
 ): string {
 	const normalizedInput =
 		typeof input === 'object' && input !== null ? input : { userOverlay: input }
-	const base = buildBaseMcpServerInstructions({
-		domains: normalizedInput.domains,
-		popularPackages: normalizedInput.popularPackages,
-		retiringNoticeIds: normalizedInput.retiringNoticeIds,
-	})
-	const userOverlay = normalizedInput.userOverlay
-	const trimmed = userOverlay?.trim()
-	if (!trimmed) return base
-	return `${base}
+	const base = normalizedInput.compact
+		? buildCompactMcpServerInstructions({
+				displayName: normalizedInput.displayName,
+			})
+		: buildBaseMcpServerInstructions({
+				domains: normalizedInput.domains,
+				popularPackages: normalizedInput.popularPackages,
+				retiringNoticeIds: normalizedInput.retiringNoticeIds,
+			})
+	return appendUserMcpServerInstructionOverlay(
+		base,
+		normalizedInput.userOverlay,
+	)
+}
 
----
-User-provided MCP instructions (follow these when they do not conflict with safety or tool contracts):
-${trimmed}`
+export function describeAssembledMcpServerInstructions(input: {
+	assembled: string
+	hasOverlay: boolean
+}): { assembled_chars: number; warning: string | null } {
+	const assembled_chars = input.assembled.length
+	if (
+		!input.hasOverlay ||
+		assembled_chars < mcpServerInstructionsClientHeadLimitChars
+	) {
+		return { assembled_chars, warning: null }
+	}
+	return {
+		assembled_chars,
+		warning: `Assembled MCP server instructions are ${String(assembled_chars)} characters. Some clients keep only the first ${String(mcpServerInstructionsClientHeadLimitChars)} characters, so this overlay may never reach the model. Prefer memories for durable facts; keep the overlay short.`,
+	}
 }

--- a/packages/worker/src/mcp/stateless-lane.ts
+++ b/packages/worker/src/mcp/stateless-lane.ts
@@ -20,16 +20,12 @@ import { invariant } from '@epic-web/invariant'
 import { McpServer, createMcpHandler } from '@modelcontextprotocol/server'
 import { CfWorkerJsonSchemaValidator } from '@modelcontextprotocol/server/validators/cf-worker'
 import { type McpCallerContext } from '@kody-internal/shared/chat.ts'
-import { loadActiveRetiringNoticeIds } from './instructions/retiring-primitives.ts'
-import { buildMcpServerInstructions } from './server-instructions.ts'
+import { assembleMcpServerInstructionsForCaller } from './assemble-mcp-server-instructions.ts'
 import { registerTools } from './register-tools.ts'
 import {
 	asMcpToolServer,
 	type McpRegistrationAgent,
 } from './mcp-registration-agent.ts'
-import { getMcpUserServerInstructions } from './user-server-instructions-repo.ts'
-import { getCapabilityRegistryForContext } from './capabilities/registry.ts'
-import { listPopularAgentPackagesForUser } from '#worker/usage/agent-package-conversation-uses.ts'
 
 const kodyMcpServerInfo = {
 	name: 'kody-mcp',
@@ -53,12 +49,15 @@ export async function handleStatelessMcpRequest(input: {
 	const handler = createMcpHandler(
 		async () => {
 			// `server/discover` is the only modern method that returns server
-			// metadata, so instruction assembly (four D1 reads) stays off the
-			// tools/call hot path. Modern Streamable HTTP requires the
-			// Mcp-Method header, and the SDK rejects header/body mismatches.
+			// metadata, so instruction assembly stays off the tools/call hot
+			// path. Modern Streamable HTTP requires the Mcp-Method header, and
+			// the SDK rejects header/body mismatches.
 			const instructions =
 				request.headers.get('Mcp-Method') === 'server/discover'
-					? await buildStatelessServerInstructions({ env, callerContext })
+					? await assembleMcpServerInstructionsForCaller({
+							env,
+							callerContext,
+						})
 					: undefined
 			const server = new McpServer(kodyMcpServerInfo, {
 				...(instructions ? { instructions } : {}),
@@ -83,33 +82,6 @@ export async function handleStatelessMcpRequest(input: {
 			? undefined
 			: { parsedBody: input.parsedBody },
 	)
-}
-
-async function buildStatelessServerInstructions(input: {
-	env: Env
-	callerContext: McpCallerContext
-}) {
-	const userId = input.callerContext.user?.userId ?? null
-	const [overlay, registry, popularPackages, retiringNoticeIds] =
-		await Promise.all([
-			userId !== null
-				? getMcpUserServerInstructions(input.env.APP_DB, userId)
-				: Promise.resolve(null),
-			getCapabilityRegistryForContext({
-				env: input.env,
-				callerContext: input.callerContext,
-			}),
-			userId !== null
-				? listPopularAgentPackagesForUser(input.env.APP_DB, { userId })
-				: Promise.resolve([]),
-			loadActiveRetiringNoticeIds(input.env.APP_DB, userId),
-		])
-	return buildMcpServerInstructions({
-		userOverlay: overlay,
-		domains: registry.capabilityDomains,
-		popularPackages,
-		retiringNoticeIds,
-	})
 }
 
 /**

--- a/packages/worker/src/mcp/tools/search-format-list.ts
+++ b/packages/worker/src/mcp/tools/search-format-list.ts
@@ -24,7 +24,7 @@ export function formatSearchMarkdown(input: {
 	)
 	if (hasDomainMatch) {
 		lines.push(
-			'Domain overview for a broad query. Drill in with `search({ query: "<task>", domain: "<name>" })`, or list every capability in one domain with `search({ domain: "<name>" })`.',
+			'Domain overview for a broad query. Search again with a more specific query, or list every capability in one domain with `search({ domain: "<name>" })`.',
 			'',
 		)
 	}

--- a/packages/worker/src/mcp/tools/search-format.node.test.ts
+++ b/packages/worker/src/mcp/tools/search-format.node.test.ts
@@ -993,6 +993,8 @@ test('domain overview matches format as compact structured summaries', () => {
 		},
 	]
 	const markdown = formatSearchMarkdown({ matches: domainMatches })
+	expect(markdown).toContain('Search again with a more specific query')
+	expect(markdown).not.toContain('Drill in with')
 	expect(markdown).toContain('**domain** `email` (9 capabilities)')
 	expect(markdown).toContain('`email_send`')
 	expect(markdown).not.toContain('entity-backed')

--- a/packages/worker/src/mcp/tools/search-tool-definition.ts
+++ b/packages/worker/src/mcp/tools/search-tool-definition.ts
@@ -11,54 +11,18 @@ export const searchTool = {
 	name: 'search',
 	title: 'Search Capabilities, Packages, Integrations, and Secrets',
 	description: `
-Find **built-in capabilities**, **saved packages**,
-**saved integrations**, and **user secret references** (metadata only)
-before \`execute\`.
+Find built-in capabilities, saved packages, integrations, and secret references (metadata only) before \`execute\`.
 
-**query** — compact ranked markdown + structured matches (order matters). Query
-markdown is summary-only: type, title/name, one-line description, and entity ref.
-An empty call and broad/exploratory queries ("what can you do with email")
-return a compact **domain index** instead of individual hits; drill in with
-\`domain\`. General provider-name discovery returns one provider card and ranks
-a matching saved wrapper package above raw OpenAPI/MCP operations.
+**query** — compact ranked markdown + structured matches. Empty or broad queries return a domain index; search again with a more specific query. Domain ids appear on capability hits.
 
-**domain** — optional capability domain id (e.g. \`email\`, \`jobs\`,
-\`mcp:linear\`). With \`query\`, ranks only that domain's
-capabilities. Without \`query\`, lists the domain's capabilities in curated
-order. Domain ids appear on every capability hit and in domain summaries.
+**entity: "{id}:{type}"** — detail for one hit (\`capability\` | \`integration\` | \`package\` | \`secret\`), or 1–10 refs. Capability detail includes an execute snippet.
 
-An entire saved-package UUID, kody id, current-origin account package URL, or
-owner-matching hosted package URL resolves as exact user-scoped package identity
-without competing semantic matches. Hidden exact queries require
-\`includeHiddenPackages: true\`.
-
-**entity: "{id}:{type}"** — detail for one hit (\`capability\`
-| \`integration\` | \`package\` | \`secret\`), or an array of 1–10 refs to batch
-related lookups in one call. Package detail defaults to a slim index (export
-subpaths, job/retriever names, README Intent). Capability detail includes an
-exact \`execute\` module snippet plus TypeScript call-shape definitions.
-Synthesized provider detail reports its related-operation count. Integration
-detail may include a small set of
-same-provider package suggestions (user packages first, else trusted-first
-community listings). Package ids may be UUIDs or kody ids, and hidden packages
-resolve here regardless of \`includeHiddenPackages\`.
-
-Secret results expose metadata only; credential values never appear.
-
-If results look incomplete: \`meta_list_capabilities()\` for a domain index,
-then \`meta_list_capabilities({ domain })\` for one domain.
-
-Optional **limit** (default 15) and **maxResponseSize** trim low-ranked
-capability hits. Auto-surfaced memory one-liners are reserved first so a
-tight size budget does not drop them.
 Example arguments:
-- \`{ "query": "saved github automation package", "limit": 10 }\`
+- \`{ "query": "send a message" }\`
 - \`{}\`
 - \`{ "query": "send a message", "domain": "email" }\`
 - \`{ "domain": "jobs" }\`
 - \`{ "entity": "coding_guide_get:capability" }\`
-- \`{ "entity": ["openapi:canva:createdesignexportjob:capability", "openapi:canva:getdesignexportjob:capability"] }\`
-- \`{ "entity": "github:integration" }\`
 
 https://github.com/kentcdodds/kody/blob/main/docs/use/search.md
 	`.trim(),

--- a/packages/worker/universal/feature-flags/registry.ts
+++ b/packages/worker/universal/feature-flags/registry.ts
@@ -49,6 +49,19 @@ export const featureFlagDefinitions = [
 		// exercise the flag system itself (including the "no success metric"
 		// admin notice), not to move a product metric.
 	},
+	{
+		key: 'compact-mcp-server-instructions',
+		defaultEnabled: false,
+		description:
+			'Serves a short MCP server-instruction stub instead of the full always-on manual, so clients that keep only the first ~2048 characters still see how to use search/execute and the user overlay. Delete the flag and the compact branch when the experiment ends.',
+		successMetric: {
+			eventType: 'execute',
+			measure: 'event_count',
+			goal: 'increase',
+			hypothesis:
+				'A stub that fits in a 2048-character head cut makes agents reach for Kody execute more often from vague prompts.',
+		},
+	},
 ] as const satisfies ReadonlyArray<FeatureFlagDefinition>
 
 export type FeatureFlagKey = (typeof featureFlagDefinitions)[number]['key']


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Give MCP clients that keep only the first ~2048 characters of server instructions a chance to see how to use Kody — without replacing the current long instructions for everyone yet.

## Why

The built-in instruction base is already ~5KB. Clients such as Claude Code head-truncate at 2KB, so they never see the user overlay or the later “start with search” guidance. That makes the overlay look set (`meta_get`) while agents never receive it, and it makes vague prompts less likely to route to Kody.

## Summary

- New measured flag `compact-mcp-server-instructions` (default off). Flagged users get a short search-first stub (~590 chars) that still appends their overlay last.
- Isolated experiment files: `compact-mcp-server-instructions.ts` and one branch in `assembleMcpServerInstructionsForCaller`. Cleanup: #1902.
- Always-on (not leftover): slimmer `search` and `execute` tool descriptions under 2048 chars; domain-overview copy says “search again with a more specific query”; `meta_get` / `meta_set` report `assembled_chars` and warn when assembled text meets the 2048-character client cut.

## Testing

- Node unit tests for compact stub budget, overlay-last assembly, 2048 warning, search/execute description length, feature-flag map updates.
- `tsc` worker typecheck.
- Local `npm run validate` passed (node, workers, e2e, mcp).
- CodeRabbit: execute skeleton now declares `main(input = {})` so the example is copy-pasteable.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `cb79a6e4` · **Head:** `a6d9c2f1`

**Classification:** extends — MCP server-instruction contract and a new measured feature-flag key; no new primitive.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `mcp-server` | surfaces | extends — compact vs full server instructions; slimmer search/execute descriptions |
| `feature-flags` | auth | extends — new `compact-mcp-server-instructions` key with execute event_count success metric |
| `memories` | assistant | extends — overlay get/set report `assembled_chars` and a 2048-character warning |
| `capability-registry` | assistant | composes — access-control test map only |
| `app-ui` | surfaces | composes — session feature-flag test maps only |

### Change flow

Flagged MCP sessions assemble a short stub plus overlay; overlay get/set measure that same assembly and warn when a 2048-character client would miss the overlay.

```mermaid
sequenceDiagram
	actor Client
	participant mcpServer as mcp-server
	participant featureFlags as feature-flags
	participant d1AppDb as d1-app-db
	Client->>mcpServer: initialize / server/discover
	mcpServer->>featureFlags: resolve compact-mcp-server-instructions
	featureFlags->>d1AppDb: evaluate + record exposure
	alt flag on
		mcpServer->>d1AppDb: read overlay only
		mcpServer-->>Client: compact stub + overlay
	else flag off
		mcpServer->>d1AppDb: read overlay, domains, popular packages
		mcpServer-->>Client: full instructions + overlay
	end
	Client->>mcpServer: meta_set / meta_get overlay
	mcpServer-->>Client: assembled_chars + warning if assembled >= 2048
```

### Before / after

| Surface | Before | After |
| --- | --- | --- |
| Server instructions (flag off) | ~5KB always-on manual + overlay last | Unchanged |
| Server instructions (flag on) | same fat base | ~590-char stub + overlay last |
| `search` description | 2627 chars | under 2048, keeps JTBD examples |
| Overlay get/set | `{ instructions, max_length }` | plus `assembled_chars`, `warning` |

### Invariants

Per-user isolation is unchanged: the flag is evaluated for the signed-in MCP user, and overlay text stays user-scoped.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-355f849f-17f7-4524-8323-5d991c27052c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-355f849f-17f7-4524-8323-5d991c27052c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional compact format for MCP server instructions.
  * MCP instruction settings now report assembled character counts and truncation warnings.
  * Improved instruction assembly with personalized overlays and relevant capability guidance.

* **Improvements**
  * Simplified search and execute tool guidance for clearer results.
  * Added clearer guidance for overlays, memories, automatic hints, clearing settings, and session refreshes.

* **Documentation**
  * Clarified feature-flag cleanup requirements and MCP instruction behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->