### PR TITLE
Fix ChatGPT MCP OAuth CIMD token exchange

### DIFF
--- a/docs/contributing/architecture/authentication.md
+++ b/docs/contributing/architecture/authentication.md
@@ -577,8 +577,8 @@ routed from `packages/worker/src/index.ts`.
 - Token endpoint: `/oauth/token` (via provider)
 - Client registration: `/oauth/register` (via provider), plus Client ID Metadata
   Documents (`clientIdMetadataDocumentEnabled` in
-  `packages/worker/src/index.ts`): a client may present an HTTPS URL as its
-  `client_id` with no registration step. Signed-in users can also mint a
+  `packages/worker/src/origin-handler.ts`): a client may present an HTTPS URL as
+  its `client_id` with no registration step. Signed-in users can also mint a
   confidential pre-registered client from `/account/mcp-oauth-clients` (Account
   → Advanced). `user_mcp_oauth_clients` stores the account-owned metadata. The
   provider stores the secret hash in `OAUTH_KV` via
@@ -586,12 +586,17 @@ routed from `packages/worker/src/index.ts`.
   `user_id`. The plaintext secret is shown once and never written to D1. MCP
   `2026-07-28` deprecates RFC 7591 dynamic registration in favor of CIMD, so
   both stay enabled: clients without a pre-registered credential that do not use
-  CIMD register via `/oauth/register`, and a failed CIMD metadata fetch returns
-  `invalid_client` (any DCR retry after that is the client's own recovery, not a
-  server-side fallback). CIMD metadata fetches rely on the
-  `global_fetch_strictly_public` compatibility flag in
+  CIMD register via `/oauth/register`. Failed CIMD fetches throw
+  `CimdFetchError`: authorize maps that to an unknown-client page, and the token
+  endpoint still returns generic `invalid_client`. Any DCR retry after that is
+  the client's own recovery, not a server-side fallback. CIMD metadata fetches
+  rely on the `global_fetch_strictly_public` compatibility flag in
   `packages/worker/wrangler.jsonc` for SSRF safety; the provider only advertises
-  `client_id_metadata_document_supported` when both are set.
+  `client_id_metadata_document_supported` when both are set. ChatGPT CIMD
+  documents prefer `private_key_jwt` while also offering `none`; the provider
+  negotiates the mutually supported public method `none` and requires PKCE.
+  `onError.internal` category `client-id-metadata-document` is reported to
+  Sentry. Authorization-server metadata advertises `S256` PKCE only.
 - Kody-as-client (user-added remote MCP servers) hosts its own CIMD at
   `/oauth/client-metadata.json`. The document is origin-exact: `client_id`
   matches the fetch URL, and `redirect_uris` lists

--- a/docs/contributing/security.md
+++ b/docs/contributing/security.md
@@ -39,8 +39,8 @@ package-app surfaces:
    from `@kody-internal/shared/password-policy.ts` wherever a password is set.
 6. **OAuth PKCE stays S256-only.** Keep the `getPkceValidationError` check in
    `oauth-handlers.ts` (reject `code_challenge_method` other than S256 when a
-   challenge is present). Do not switch to the provider's `allowPlainPKCE`
-   option — see the OAuth section below for why.
+   challenge is present). Do not set the provider's `allowPlainPKCE: true` — see
+   the OAuth section below.
 7. **Every data path is `userId`-scoped.** New D1 queries, Durable Object names,
    and Vectorize filters must include `userId`. Prefer parameterized SQL
    (`.prepare(...).bind(...)`); never interpolate user input into SQL.
@@ -301,11 +301,10 @@ accounts are never locked out.
 - PKCE is validated at the application layer: `getPkceValidationError`
   (`packages/worker/src/oauth-handlers.ts`) rejects an authorize request whose
   `code_challenge_method` is anything other than `S256` when a `code_challenge`
-  is present. Plain PKCE offers no protection against code interception. We do
-  **not** use the provider's `allowPlainPKCE: false` option because, in this
-  provider version, it rejects every authorize request that lacks an explicit
-  `code_challenge_method=S256` — including legitimate confidential-client flows
-  that use no PKCE at all — which breaks real MCP clients.
+  is present. Plain PKCE offers no protection against code interception.
+  `@cloudflare/workers-oauth-provider` 0.10+ defaults `allowPlainPKCE` to false
+  (S256-only) while allowing confidential clients to omit PKCE. Keep the
+  app-layer check; do not set `allowPlainPKCE: true`.
 - Dynamic client registration (`/oauth/register`) is intentionally **open**: the
   MCP OAuth spec requires it, and clients (including native/public clients using
   PKCE) rely on it. This is a deliberate acceptance, not a gap. Do not add

--- a/package-lock.json
+++ b/package-lock.json
@@ -686,9 +686,9 @@
       }
     },
     "node_modules/@cloudflare/workers-oauth-provider": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-oauth-provider/-/workers-oauth-provider-0.8.3.tgz",
-      "integrity": "sha512-5dIeQlJTDKAQvy3GcrtWBhPvTb9lHeRp/m8MoostTkcrbrGImH8zKSdJhogQ5YSTFUCg+b7FBg38b7KCM/x3VQ==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-oauth-provider/-/workers-oauth-provider-0.10.3.tgz",
+      "integrity": "sha512-25ufMONJir9PllqVpK4GwOOoSFgpYm3+bM6NBedj7ufMCIfNf5jk4OI0LPuTJBaJgLl2lGCLqFqEPJXcSuPopQ==",
       "license": "MIT"
     },
     "node_modules/@cloudflare/workers-types": {
@@ -12483,7 +12483,7 @@
         "@cloudflare/codemode": "^0.5.1",
         "@cloudflare/shell": "^0.4.3",
         "@cloudflare/worker-bundler": "^0.2.2",
-        "@cloudflare/workers-oauth-provider": "^0.8.3",
+        "@cloudflare/workers-oauth-provider": "^0.10.3",
         "@epic-web/cachified": "^5.6.3",
         "@epic-web/invariant": "^1.0.0",
         "@epic-web/totp": "^4.0.1",

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -10,7 +10,7 @@
     "@cloudflare/codemode": "^0.5.1",
     "@cloudflare/shell": "^0.4.3",
     "@cloudflare/worker-bundler": "^0.2.2",
-    "@cloudflare/workers-oauth-provider": "^0.8.3",
+    "@cloudflare/workers-oauth-provider": "^0.10.3",
     "@epic-web/cachified": "^5.6.3",
     "@epic-web/invariant": "^1.0.0",
     "@epic-web/totp": "^4.0.1",

--- a/packages/worker/src/oauth-handlers.ts
+++ b/packages/worker/src/oauth-handlers.ts
@@ -1,6 +1,8 @@
 import { jsonResponse } from '#worker/json-response.ts'
+import * as Sentry from '@sentry/cloudflare'
 import {
 	type AuthRequest,
+	CimdFetchError,
 	type ClientInfo,
 	type OAuthHelpers,
 } from '@cloudflare/workers-oauth-provider'
@@ -239,6 +241,15 @@ function defaultMcpResourceForAuthRequest(
 	authRequest.resource = `${origin}${mcpResourcePath}`
 }
 
+function isCimdMetadataResolutionError(error: unknown) {
+	return (
+		error instanceof CimdFetchError ||
+		(error instanceof Error &&
+			error.name === 'CimdFetchError' &&
+			'metadataUrl' in error)
+	)
+}
+
 async function resolveAuthRequest(
 	helpers: OAuthHelpers,
 	request: Request,
@@ -259,6 +270,10 @@ async function resolveAuthRequest(
 		defaultMcpResourceForAuthRequest(authRequest, request, env)
 		return { authRequest, client }
 	} catch (error) {
+		if (isCimdMetadataResolutionError(error)) {
+			Sentry.captureException(error)
+			return { error: 'Unknown OAuth client.' }
+		}
 		const message =
 			error instanceof TypeError
 				? invalidOAuthClientRegistrationMessage

--- a/packages/worker/src/oauth-handlers.workers.test.ts
+++ b/packages/worker/src/oauth-handlers.workers.test.ts
@@ -8,6 +8,7 @@ import {
 } from '@cloudflare/workers-oauth-provider'
 import { createExecutionContext, waitOnExecutionContext } from 'cloudflare:test'
 import { env, exports } from 'cloudflare:workers'
+import { consoleWarn } from '#worker/test-support/console-spies.ts'
 import {
 	createAuthCookie,
 	readAuthSessionResult,
@@ -848,6 +849,182 @@ test('worker entrypoint completes Claude-shaped dynamic registration and token e
 	})
 })
 
+test('worker entrypoint advertises MCP resource metadata on both RFC 9728 paths', async () => {
+	const expected = {
+		resource: 'https://heykody.dev/mcp',
+		authorization_servers: ['https://heykody.dev'],
+		scopes_supported: oauthScopes,
+		bearer_methods_supported: ['header'],
+	}
+	for (const path of [
+		'/.well-known/oauth-protected-resource',
+		'/.well-known/oauth-protected-resource/mcp',
+	]) {
+		const response = await workerFetch(
+			new Request(`https://heykody.dev${path}`),
+		)
+		expect(response.status).toBe(200)
+		await expect(response.json()).resolves.toEqual(expected)
+	}
+
+	const discovery = await workerFetch(
+		new Request('https://heykody.dev/.well-known/oauth-authorization-server'),
+	)
+	expect(discovery.status).toBe(200)
+	const metadata = (await discovery.json()) as {
+		client_id_metadata_document_supported?: boolean
+		code_challenge_methods_supported?: Array<string>
+		token_endpoint_auth_methods_supported?: Array<string>
+	}
+	expect(metadata.client_id_metadata_document_supported).toBe(true)
+	expect(metadata.code_challenge_methods_supported).toEqual(['S256'])
+	expect(metadata.token_endpoint_auth_methods_supported).toContain('none')
+	expect(metadata.token_endpoint_auth_methods_supported).not.toContain(
+		'private_key_jwt',
+	)
+})
+
+test('worker entrypoint completes ChatGPT-shaped CIMD authorize and token exchange', async () => {
+	const email = `chatgpt-oauth-${crypto.randomUUID()}@example.com`
+	const password = 'password123'
+	await seedWorkerUser(email, password)
+
+	const chatgptClientMetadataUrl =
+		'https://chatgpt.com/oauth/vG3-MLZWUV83/client.json'
+	const chatgptRedirectUri = 'https://chatgpt.com/connector/oauth/vG3-MLZWUV83'
+	const chatgptClientDocument = {
+		client_id: chatgptClientMetadataUrl,
+		client_uri: 'https://chatgpt.com/',
+		redirect_uris: [chatgptRedirectUri],
+		token_endpoint_auth_method: 'private_key_jwt',
+		token_endpoint_auth_methods_supported: ['none', 'private_key_jwt'],
+		grant_types: ['authorization_code', 'refresh_token'],
+		response_types: ['code'],
+		client_name: 'ChatGPT',
+		logo_uri: 'https://persistent.oaistatic.com/sonic/misc/openai-logo.png',
+		token_endpoint_auth_signing_alg: 'RS256',
+		jwks_uri: 'https://chatgpt.com/oauth/jwks.json',
+	}
+	const originalFetch = globalThis.fetch
+	globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+		const url = input instanceof Request ? input.url : String(input)
+		if (url.split('?')[0] === chatgptClientMetadataUrl) {
+			return new Response(JSON.stringify(chatgptClientDocument), {
+				status: 200,
+				headers: { 'Content-Type': 'application/json; charset=utf-8' },
+			})
+		}
+		return originalFetch(input, init)
+	}) as typeof fetch
+
+	try {
+		const verifier = 'chatgpt-verifier-0123456789'
+		const authorizeUrl = new URL('https://heykody.dev/oauth/authorize')
+		authorizeUrl.searchParams.set('response_type', 'code')
+		authorizeUrl.searchParams.set('client_id', chatgptClientMetadataUrl)
+		authorizeUrl.searchParams.set('redirect_uri', chatgptRedirectUri)
+		authorizeUrl.searchParams.set('scope', 'profile email')
+		authorizeUrl.searchParams.set(
+			'code_challenge',
+			await createS256CodeChallenge(verifier),
+		)
+		authorizeUrl.searchParams.set('code_challenge_method', 'S256')
+		authorizeUrl.searchParams.set('resource', 'https://heykody.dev/mcp')
+		authorizeUrl.searchParams.set('state', 'chatgpt-demo-state')
+
+		const authorizeResponse = await workerFetch(new Request(authorizeUrl))
+		expect(authorizeResponse.status).toBe(200)
+		expect(await authorizeResponse.text()).toContain('ChatGPT')
+
+		const approvalResponse = await workerFetch(
+			new Request(authorizeUrl, {
+				method: 'POST',
+				headers: {
+					Accept: 'application/json',
+					'Content-Type': 'application/x-www-form-urlencoded',
+				},
+				body: new URLSearchParams({
+					decision: 'approve',
+					email,
+					password,
+				}),
+			}),
+		)
+		expect(approvalResponse.status).toBe(200)
+		const approvalPayload = (await approvalResponse.json()) as {
+			redirectTo: string
+		}
+		const callbackUrl = new URL(approvalPayload.redirectTo)
+		const code = callbackUrl.searchParams.get('code')
+		expect(code).toBeTruthy()
+		expect(callbackUrl.searchParams.get('iss')).toBe('https://heykody.dev')
+
+		const tokenResponse = await workerFetch(
+			new Request('https://heykody.dev/oauth/token', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+				body: new URLSearchParams({
+					grant_type: 'authorization_code',
+					client_id: chatgptClientMetadataUrl,
+					code: code ?? '',
+					redirect_uri: chatgptRedirectUri,
+					code_verifier: verifier,
+					resource: 'https://heykody.dev/mcp',
+				}),
+			}),
+		)
+		expect(tokenResponse.status).toBe(200)
+		await expect(tokenResponse.json()).resolves.toMatchObject({
+			token_type: 'bearer',
+			resource: 'https://heykody.dev/mcp',
+			scope: 'profile email',
+		})
+	} finally {
+		globalThis.fetch = originalFetch
+	}
+})
+
+test('worker entrypoint treats a failed ChatGPT CIMD fetch as an unknown client', async () => {
+	const chatgptClientMetadataUrl =
+		'https://chatgpt.com/oauth/vG3-MLZWUV83/client.json'
+	const originalFetch = globalThis.fetch
+	consoleWarn.mockImplementation(() => {})
+	globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+		const url = input instanceof Request ? input.url : String(input)
+		if (url.split('?')[0] === chatgptClientMetadataUrl) {
+			return new Response('upstream unavailable', { status: 503 })
+		}
+		return originalFetch(input, init)
+	}) as typeof fetch
+
+	try {
+		const authorizeUrl = new URL('https://heykody.dev/oauth/authorize')
+		authorizeUrl.searchParams.set('response_type', 'code')
+		authorizeUrl.searchParams.set('client_id', chatgptClientMetadataUrl)
+		authorizeUrl.searchParams.set(
+			'redirect_uri',
+			'https://chatgpt.com/connector/oauth/vG3-MLZWUV83',
+		)
+		authorizeUrl.searchParams.set('code_challenge', 'x'.repeat(43))
+		authorizeUrl.searchParams.set('code_challenge_method', 'S256')
+		authorizeUrl.searchParams.set('resource', 'https://heykody.dev/mcp')
+
+		const authorizeInfoUrl = new URL('https://heykody.dev/oauth/authorize-info')
+		authorizeInfoUrl.search = authorizeUrl.search
+		const response = await workerFetch(new Request(authorizeInfoUrl))
+		expect(response.status).toBe(400)
+		await expect(response.json()).resolves.toMatchObject({
+			ok: false,
+			error: 'Unknown OAuth client.',
+		})
+		expect(consoleWarn.mock.calls.flat().join(' ')).toContain(
+			'CIMD fetch failed',
+		)
+	} finally {
+		globalThis.fetch = originalFetch
+	}
+})
+
 test('worker entrypoint returns OAuth errors for provider-owned route exceptions', async () => {
 	const registerResponse = await workerFetch(
 		new Request('https://heykody.dev/oauth/register', {
@@ -858,14 +1035,15 @@ test('worker entrypoint returns OAuth errors for provider-owned route exceptions
 	)
 	expect(registerResponse.status).toBe(400)
 	await expect(registerResponse.json()).resolves.toEqual({
-		error: 'invalid_request',
-		error_description: 'Invalid OAuth client registration.',
+		error: 'invalid_client_metadata',
+		error_description: 'Client metadata must be a JSON object',
 	})
 
 	const clientId = `malformed-token-client-${crypto.randomUUID()}`
 	const userId = `oauth-user-${crypto.randomUUID()}`
 	const grantId = `oauth-grant-${crypto.randomUUID()}`
 	const code = `${userId}:${grantId}:secret`
+	const verifier = 'verifier'
 	await env.OAUTH_KV.put(
 		`client:${clientId}`,
 		JSON.stringify({
@@ -885,14 +1063,14 @@ test('worker entrypoint returns OAuth errors for provider-owned route exceptions
 			encryptedProps: '',
 			createdAt: Math.floor(Date.now() / 1000),
 			authCodeId: await createSha256Hex(code),
-			// 0.8+ treats a missing authCodeWrappedKey as an already-used code and
+			// 0.10+ treats a missing authCodeWrappedKey as an already-used code and
 			// returns invalid_grant before redirect_uri validation. Keep a dummy
 			// wrapped key so the malformed-client redirectUris TypeError still
 			// reaches the worker exception mapper under test.
 			authCodeWrappedKey: 'malformed-client-auth-code-wrapped-key',
 			resource: 'https://heykody.dev/mcp',
-			codeChallenge: 'verifier',
-			codeChallengeMethod: 'plain',
+			codeChallenge: await createS256CodeChallenge(verifier),
+			codeChallengeMethod: 'S256',
 		}),
 	)
 
@@ -908,7 +1086,7 @@ test('worker entrypoint returns OAuth errors for provider-owned route exceptions
 				client_id: clientId,
 				code,
 				redirect_uri: claudeAuthRequest.redirectUri,
-				code_verifier: 'verifier',
+				code_verifier: verifier,
 				resource: 'https://heykody.dev/mcp',
 			}),
 		}),

--- a/packages/worker/src/oauth-pkce.ts
+++ b/packages/worker/src/oauth-pkce.ts
@@ -3,10 +3,11 @@
  * present it must use the S256 method. The `plain` method offers no protection
  * against authorization-code interception, so we reject it.
  *
- * This is enforced at the application layer rather than via the provider's
- * `allowPlainPKCE` option: that option rejects every authorize request lacking
- * an explicit `code_challenge_method=S256` — including legitimate no-PKCE
- * confidential-client flows — which breaks real MCP clients.
+ * `@cloudflare/workers-oauth-provider` 0.10+ defaults `allowPlainPKCE` to
+ * false (S256-only discovery and challenges) while still allowing
+ * confidential clients to omit PKCE. This check stays as defense in depth so
+ * authorize still rejects `plain` even if a future provider default changes.
+ * Do not set `allowPlainPKCE: true`.
  *
  * The input type is structural (not the provider's `AuthRequest`) so this
  * module stays importable in the plain-Node test pool — the provider package

--- a/packages/worker/src/origin-handler.ts
+++ b/packages/worker/src/origin-handler.ts
@@ -386,8 +386,10 @@ const oauthProvider = new OAuthProvider({
 	// 2026-07-28 revision deprecates RFC 7591 DCR in favor of CIMD, so both
 	// stay enabled: CIMD clients present their URL client_id with no
 	// registration step, and clients that do not use CIMD register via
-	// /oauth/register. A failed CIMD metadata fetch returns invalid_client;
-	// whether a client then registers via DCR is the client's own recovery.
+	// /oauth/register. A failed CIMD metadata fetch throws CimdFetchError;
+	// authorize maps that to an unknown-client page, and the token endpoint
+	// still returns generic invalid_client. Whether a client then registers
+	// via DCR is the client's own recovery.
 	// Requires the global_fetch_strictly_public compatibility flag (set in
 	// wrangler.jsonc) so metadata fetches are SSRF-safe; the provider only
 	// advertises CIMD support when both are on.
@@ -397,15 +399,28 @@ const oauthProvider = new OAuthProvider({
 	// the defaults). Access tokens stay at the 1-hour default.
 	refreshTokenTTL: undefined,
 	clientRegistrationTTL: undefined,
+	// Do not pin resourceMetadata.resource: preview, local, and production
+	// origins all serve MCP. Unconfigured 0.10 inherits an explicit RFC 8707
+	// resource (ChatGPT sends `/mcp`) and Kody's authorize handler defaults
+	// omitted resources to `/mcp` (Gemini). Custom PRM below advertises
+	// `<origin>/mcp` so discovery matches that audience.
 	// Provider default onError logs every structured OAuth error via console.warn.
 	// Keep those responses on the wire without duplicating them into worker logs /
-	// test console guards; unexpected throws still reach our fetch catch + Sentry.
-	onError: () => undefined,
-	// NOTE: we intentionally do NOT set `allowPlainPKCE: false`. In this provider
-	// version that option rejects EVERY authorize request whose
-	// `code_challenge_method` is absent or `plain` — including confidential
-	// clients that legitimately use no PKCE — which breaks real MCP clients. See
-	// the OAuth section of docs/contributing/security.md before changing this.
+	// test console guards. CIMD fetch failures stay generic on the wire and are
+	// reported here for Sentry; unexpected throws still reach fetch catch + Sentry.
+	onError: (error) => {
+		if (error.internal?.category === 'client-id-metadata-document') {
+			Sentry.captureException(
+				new Error(
+					`CIMD metadata resolution failed (${error.internal.reason}): ${error.description}`,
+				),
+			)
+		}
+	},
+	// 0.10+ defaults allowPlainPKCE to false (S256-only) while still allowing
+	// confidential clients to omit PKCE. Do not set allowPlainPKCE: true. App
+	// layer getPkceValidationError remains defense in depth. See
+	// docs/contributing/security.md.
 })
 
 /**
@@ -539,7 +554,11 @@ const workerHandler = {
 			return addOAuthDiscoveryCorsHeaders(clientIdMetadataResponse, request)
 		}
 
-		if (url.pathname === protectedResourceMetadataPath) {
+		// Serve both RFC 9728 PRM paths before OAuthProvider: the root document
+		// and the path-aware `.../mcp` document. 0.10+ would otherwise publish
+		// origin-only resource metadata on the path-aware URL and disagree with
+		// `<origin>/mcp` token audiences.
+		if (isProtectedResourceMetadataRequest(url.pathname)) {
 			if (request.method === 'OPTIONS') {
 				return addOAuthDiscoveryCorsHeaders(
 					new Response(null, {


### PR DESCRIPTION
## Summary

- ChatGPT developer-mode plugins connect via CIMD (`client_id` is a URL) and advertise `private_key_jwt` plus `none`. `@cloudflare/workers-oauth-provider` 0.8.3 read the scalar method first and rejected `POST /oauth/token`, so approve succeeded and ChatGPT still showed Connect.
- Upgrade to 0.10.3 so the provider negotiates `none` + PKCE. Keep Kody's RFC 9728 PRM on both well-known paths (resource stays `<origin>/mcp`) and map failed CIMD fetches to an unknown-client authorize page.
- Cursor/Codex DCR clients with `token_endpoint_auth_method: none` keep working. Do not set `allowPlainPKCE: true`; 0.10 defaults to S256-only while still allowing confidential clients to omit PKCE.

## Test plan

- [x] Workers unit: ChatGPT-shaped CIMD authorize + token exchange, failed CIMD fetch → unknown client, PRM on both RFC 9728 paths, AS metadata S256 + `none` and no `private_key_jwt`
- [x] `npm run validate` (passkeys e2e flake retried green)
- [ ] Preview: seed-user CIMD authorize/token against ChatGPT's live `client.json`, plus PRM/discovery
- [ ] Production: ChatGPT Settings → Apps & Connectors → Kody the Koala → Connect; Connection no longer shows Connect after approve

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends MCP OAuth</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `b0e364c4` · **Head:** `411503d2`

**Classification:** extends — ChatGPT CIMD clients that prefer `private_key_jwt` while also offering `none` can complete token exchange; PRM stays origin-aware at `/mcp`.

### Primitives touched

| Primitive      | Group | Impact                                                                                          |
| -------------- | ----- | ----------------------------------------------------------------------------------------------- |
| `mcp-oauth`    | auth  | extends — upgrade to workers-oauth-provider 0.10.3, CIMD auth-method negotiation, dual PRM paths |
| `app-sessions` | auth  | composes — same authorize file; CIMD fetch failures map to unknown-client                       |

Unmatched construction site: `packages/worker/src/origin-handler.ts` (OAuthProvider config + PRM intercept).

### Change flow

ChatGPT developer-mode plugins send a CIMD `client_id` URL whose document prefers `private_key_jwt` and also lists `none`. The upgraded provider negotiates `none` plus PKCE so `/oauth/token` succeeds.

```mermaid
sequenceDiagram
	actor ChatGPT
	participant mcpOauth as mcp-oauth
	participant appSessions as app-sessions
	ChatGPT->>mcpOauth: GET both RFC 9728 PRM paths (resource is origin /mcp)
	ChatGPT->>mcpOauth: GET /oauth/authorize with CIMD client_id URL and PKCE S256
	mcpOauth->>appSessions: inline login or existing session on approve
	Note over mcpOauth: 0.10.3 negotiates none from private_key_jwt plus none
	ChatGPT->>mcpOauth: POST /oauth/token as public client (no private_key_jwt)
	mcpOauth-->>ChatGPT: bearer token with /mcp audience
```

### Before / after

|                        | Before (0.8.3)                                      | After (0.10.3)                                              |
| ---------------------- | --------------------------------------------------- | ----------------------------------------------------------- |
| CIMD auth method       | Reads scalar `private_key_jwt` and rejects token    | Negotiates mutually supported `none` + PKCE                 |
| Path-aware PRM         | Root document only; 0.10 would publish origin-only  | Both `/.well-known/oauth-protected-resource` and `.../mcp`  |
| AS `code_challenge`    | Could advertise `plain`                             | `S256` only; do not set `allowPlainPKCE: true`              |
| Failed CIMD fetch      | Generic invalid_client                              | Authorize: unknown client; token: invalid_client; Sentry    |

### Invariants

Per-user OAuth grants stay isolated. PKCE remains S256-only at both provider and app layer.

</details>

<!-- system-recap:end -->

Made with [Cursor](https://cursor.com)