### PR TITLE
Tell ship-pr to trigger BugBot via kody:@kentcdodds/bugbot

### DIFF
--- a/.agents/skills/ship-pr/SKILL.md
+++ b/.agents/skills/ship-pr/SKILL.md
@@ -26,8 +26,15 @@ explicitly.
 ## AI reviewers
 
 Prefer **Cursor Bugbot** (`Cursor Bugbot` check / `cursor[bot]` review
-comments). Trigger with `bugbot run` or `@cursor review` on the PR if it has not
-started.
+comments). Never comment `bugbot run` or `cursor review` yourself, including via
+`gh` or GitHub request as kody-bot. Trigger with `kody:@kentcdodds/bugbot` using
+`{ prUrl }` or `{ owner, repo, prNumber }`. Do not pass a GitHub account.
+
+```javascript
+import triggerBugbot from 'kody:@kentcdodds/bugbot'
+
+await triggerBugbot({ prUrl })
+```
 
 **CodeRabbit:** if it is rate-limited, errored, or otherwise unavailable, **do
 not wait** on it for low/medium risk — proceed with Bugbot + CI. Only wait on


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop ship-pr agents from posting `bugbot run` themselves. Cursor BugBot rejects kody-bot, so the only supported trigger is `kody:@kentcdodds/bugbot`, which comments as kentcdodds.

## Why

A `bugbot run` comment from kody-bot is skipped with: "Skipping Bugbot: Unable to authenticate your request. Please make sure Bugbot is properly installed and configured for this repository." The package always posts the trigger as kentcdodds (GitHub account `kent` / github-kent).

## Summary

- Prefer Cursor Bugbot (same `Cursor Bugbot` check / `cursor[bot]` comments).
- Never comment `bugbot run` or `cursor review` yourself, including via `gh` or GitHub request as kody-bot.
- Trigger with `kody:@kentcdodds/bugbot` using `{ prUrl }` or `{ owner, repo, prNumber }`. Do not pass a GitHub account.
- CodeRabbit guidance, the loop, merge policy, and the rest of the skill are unchanged.

## Testing

- Diff review of `.agents/skills/ship-pr/SKILL.md` only: AI-reviewers paragraph replaced; CodeRabbit / Loop / Merge / Discord sections unchanged.
- Confirmed no duplicate `ship-pr` skill in this repo.
- Confirmed `kody:@kentcdodds/bugbot` default export accepts `{ prUrl }` or `{ owner, repo, prNumber }` and does not take a GitHub account.
- `npm run format -- .agents/skills/ship-pr/SKILL.md` (oxfmt) — already formatted; no rewrite.
- `npm run format:check -- .agents/skills/ship-pr/SKILL.md` — "All matched files use the correct format."
- Pre-push `test:node` (2270) and `test:workers` (307) passed. No product code changed.
- Did not comment `bugbot run` on this PR and did not call the bugbot package here.

## System changes

Skill-only docs. No primitives added or changed.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `33a9f1b` · **Head:** `e09578f`

**Classification:** composes — no primitives added or changed; this PR only
rewrites agent skill text.

### Primitives touched

None. The classifier reports `.agents/skills/ship-pr/SKILL.md` unmatched.

### Change flow

Ship-pr agents trigger Cursor BugBot through `kody:@kentcdodds/bugbot`, which
posts `bugbot run` as kentcdodds instead of kody-bot.

```mermaid
sequenceDiagram
	actor Agent
	participant shipPr as ship-pr skill
	participant bugbotPkg as kody:@kentcdodds/bugbot
	participant github as GitHub PR
	participant cursorBot as cursor[bot]
	Agent->>shipPr: medium+ PR ready
	shipPr->>bugbotPkg: triggerBugbot({ prUrl })
	bugbotPkg->>github: comment bugbot run as kentcdodds
	github->>cursorBot: authenticated BugBot trigger
	Note over Agent,github: Agent never comments bugbot run as kody-bot
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f396109f-e060-4342-adac-b49259626436?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f396109f-e060-4342-adac-b49259626436&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the AI reviewer workflow instructions to use the Kody Bugbot trigger.
  * Added a JavaScript invocation example.
  * Clarified that direct `bugbot run` and `@cursor review` commands are not supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->