### PR TITLE
Accept psl@kody.codes as a reserved system inbox

### DIFF
--- a/docs/contributing/architecture/authorization.md
+++ b/docs/contributing/architecture/authorization.md
@@ -433,8 +433,8 @@ identities, tokens, recipients, and message content. A six-hour KV cooldown
 suppresses repeat pages. Delivery is best-effort (no Queue).
 
 **Admins can see** operator-owned system mail for reserved platform addresses
-(`kody`, `support`, `abuse`, `postmaster`, `security`, and `admin`). That mail
-is stored under `system:email` as platform content, not under Kent's or any
+(`kody`, `support`, `abuse`, `postmaster`, `security`, `admin`, and `psl`). That
+mail is stored under `system:email` as platform content, not under Kent's or any
 other user's account. Admin reads through MCP (`admin_system_email_list`,
 `admin_system_email_get`) and the `/admin/system-email` UI are audit logged.
 Admins can also **send** from those reserved addresses with

--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -14,8 +14,8 @@ the project must follow the same convention; user-scoped tests should exercise
 both the "happy" path and a cross-user denial path.
 
 The deliberate storage exception is **operator-owned system email** for reserved
-platform local parts (`kody`, `support`, `abuse`, `postmaster`, `security`, and
-`admin`). The permanent D1 tables are `system_email_threads`,
+platform local parts (`kody`, `support`, `abuse`, `postmaster`, `security`,
+`admin`, and `psl`). The permanent D1 tables are `system_email_threads`,
 `system_email_messages`, `system_email_attachments`, and
 `system_email_delivery_events`. They omit `user_id` because the operator owner
 is implicit. They are the sole live `system:email` graph authority. The reserved

--- a/docs/contributing/security.md
+++ b/docs/contributing/security.md
@@ -258,7 +258,8 @@ to one account), but it is not zero.
 requires a `_psl` TXT record on the zone and a PR to
 [publicsuffix/list](https://github.com/publicsuffix/list) by the domain owner,
 plus 2+ years remaining on the registration. Abuse/contact mail is
-`psl@kody.codes`. Do not enable `allowPrivateDomains` on tldts:
+`psl@kody.codes`, a reserved operator system inbox (same storage as `abuse@` and
+`security@`). Do not enable `allowPrivateDomains` on tldts:
 `readPackageAppZoneName` must keep resolving the public-suffix zone without the
 PRIVATE list. The `__Host-` cookie is the primary cookie-tossing control; PSL
 entry is an additional layer.

--- a/docs/use/email-primitives.md
+++ b/docs/use/email-primitives.md
@@ -27,9 +27,9 @@ platform-assigned sender address.
   `inbox.` subdomain by default), while the apex hosts only system mail — the
   transactional sender (`kody@<apex>`, used for verification and password-reset
   mail) and the operator-owned system inboxes (`kody`, `support`, `abuse`,
-  `postmaster`, `security`, and `admin` at the apex route to Kody's system
-  inbox, so replies to transactional mail land there). All other apex mail is
-  rejected.
+  `postmaster`, `security`, `admin`, and `psl` at the apex route to Kody's
+  system inbox, so replies to transactional mail land there). All other apex
+  mail is rejected.
 - Reserved local parts never route to a user inbox and can never be registered
   as usernames.
 - User outbound mail always sends from `{username}@<platform domain>`. The from
@@ -327,11 +327,11 @@ do not dispatch after a newer delivery state has already been stored.
 ## `email.system-message.received` package subscription (admins)
 
 Mail stored in the operator-owned system inbox (`kody`, `support`, `abuse`,
-`postmaster`, `security`, and `admin` at the apex) dispatches the separate
-package subscription topic `email.system-message.received` when the message is
-accepted. It fans out to packages saved by users who hold the admin role at
-dispatch time — a non-admin saving the same subscription never receives system
-mail, and a revoked admin stops receiving immediately.
+`postmaster`, `security`, `admin`, and `psl` at the apex) dispatches the
+separate package subscription topic `email.system-message.received` when the
+message is accepted. It fans out to packages saved by users who hold the admin
+role at dispatch time — a non-admin saving the same subscription never receives
+system mail, and a revoked admin stops receiving immediately.
 
 Quarantined system-inbox mail is stored for operators but never dispatches
 `email.system-message.received` (or any other admin package subscription).

--- a/packages/worker/src/email/system-email.ts
+++ b/packages/worker/src/email/system-email.ts
@@ -26,6 +26,8 @@ export const systemEmailLocals = [
 	'postmaster',
 	'security',
 	'admin',
+	// Public Suffix List contact for the kody.run listing (#1405).
+	'psl',
 ] as const
 
 export type SystemEmailLocal = (typeof systemEmailLocals)[number]

--- a/packages/worker/src/email/system-email.workers.test.ts
+++ b/packages/worker/src/email/system-email.workers.test.ts
@@ -181,6 +181,31 @@ test('reserved system locals store under the operator-owned system inbox', async
 			.map((inbox) => inbox.name)
 			.sort(),
 	).toEqual(['kody', 'support'])
+
+	const psl = buildInboundMessage({
+		to: `psl@${systemDomain}`,
+		subject: 'Public suffix list contact',
+	})
+	await handleInboundEmail(psl, createInboundEnv())
+	expect(psl.rejectedReason).toBeNull()
+	const pslMessages = await listSystemEmailMessages({
+		db: env.APP_DB,
+		limit: 10,
+	})
+	expect(pslMessages[0]).toMatchObject({
+		subject: 'Public suffix list contact',
+		toAddresses: [`psl@${systemDomain}`],
+	})
+	expect(
+		(
+			await listEmailInboxesForUser({
+				db: env.APP_DB,
+				userId: systemEmailOwnerId,
+			})
+		)
+			.map((inbox) => inbox.name)
+			.sort(),
+	).toEqual(['kody', 'psl', 'support'])
 }, 30_000)
 
 test('non-system reserved locals still reject while username addresses are unaffected', async () => {

--- a/packages/worker/src/identity/reserved-usernames.node.test.ts
+++ b/packages/worker/src/identity/reserved-usernames.node.test.ts
@@ -14,6 +14,7 @@ test('reserved username validation rejects brand, support, and infrastructure na
 		'no-reply',
 		'admin',
 		'mcp',
+		'psl',
 		'kody-r-0123456789abcdef',
 	]) {
 		expect(isReservedUsername(reserved)).toBe(true)

--- a/packages/worker/src/identity/reserved-usernames.ts
+++ b/packages/worker/src/identity/reserved-usernames.ts
@@ -36,6 +36,7 @@ const reservedUsernameList = [
 	'feedback',
 	'contact',
 	'info',
+	'psl',
 
 	// Staff / elevated roles
 	'admin',

--- a/packages/worker/src/mcp/capabilities/admin/admin-system-email-get.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-system-email-get.ts
@@ -51,6 +51,7 @@ export const adminSystemEmailGetCapability = defineDomainCapability(
 			'message content',
 			'abuse',
 			'postmaster',
+			'psl',
 		],
 		inputSchema,
 		outputSchema,

--- a/packages/worker/src/mcp/capabilities/admin/admin-system-email-list.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-system-email-list.ts
@@ -64,6 +64,7 @@ export const adminSystemEmailListCapability = defineDomainCapability(
 			'operator inbox',
 			'abuse',
 			'postmaster',
+			'psl',
 		],
 		inputSchema,
 		outputSchema,

--- a/packages/worker/src/mcp/capabilities/admin/admin-system-email-send.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-system-email-send.ts
@@ -64,6 +64,7 @@ export const adminSystemEmailSendCapability = defineDomainCapability(
 			'outreach',
 			'transactional',
 			'kody@',
+			'psl@',
 			'operator',
 			'reply to feedback',
 		],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Make `psl@kody.codes` a real, monitored operator inbox so #1405 can use it as the Public Suffix List contact.

## Why

#1405 already names `psl@kody.codes` as the PSL abuse/contact address, but that local was not in `systemEmailLocals`. Apex mail that is not a system local is rejected as unknown, so reviewer mail to `psl@` never landed.

This is the next right step for #1405. It does **not** file the publicsuffix/list PR:

- `kody.run` expires **2027-08-13** (~1 year remaining). PSL requires 2+ years remaining plus a standing 1+ year commitment. Renew by **two years** (to 2029-08-13) in Cloudflare Registrar before filing.
- Login gating does not replace PSL (browser same-site / `Domain=` cookies are independent of the HTTP 403). Keep the issue open.
- PSL maintainers also decline private-use / sub-thousands-of-users listings. File after the term gate *and* when hosted apps are a public multi-tenant surface worth global PSL size.

Production Email Routing already catch-alls the apex to `kody-production`, so no DNS/routing change is required. After this deploys, inbound `psl@kody.codes` stores under `system:email` and fans `email.system-message.received` to admin packages.

## Summary

- Add `psl` to `systemEmailLocals` (inbound store + `admin_system_email_send` sender).
- Reserve `psl` as a username (no production account used that name).
- Garden the enumerated system-local lists in usage and architecture docs.

## Testing

- `npm run test:push` on this branch: node-unit 2271 passed, workers-unit 310 passed (includes inbound `psl@` storage in `system-email.workers.test.ts`).
- Preview login as the seed user cannot exercise this: `/admin` is 403, and inbound apex mail is production Email Routing.

Closes nothing. Leaves #1405 open for registrar renewal and the publicsuffix PR.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends email</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `35dba7ba` · **Head:** `5e37fb9a`

**Classification:** extends — `psl` becomes a reserved system inbox local; admin send/list keywords and username denylist follow that contract.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `email` | assistant | extends — `psl` is an accepted apex system local and `admin_system_email_send` sender |
| `rbac` | auth | composes — admin system-email capability keywords only |

Unmatched: `packages/worker/src/identity/reserved-usernames.ts` (username denylist so nobody can register `psl`).

### Change flow

Apex mail to `psl@kody.codes` is stored as operator system mail instead of rejected as an unknown local.

```mermaid
sequenceDiagram
	actor Reviewer
	participant email as email
	participant rbac as rbac
	Reviewer->>email: SMTP psl@kody.codes
	email->>email: isSystemEmailLocal(psl) now true
	Note over email: stored under system:email
	email->>rbac: email.system-message.received to admin packages
	rbac->>email: admin_system_email_send from_local=psl
```

### Invariants

Per-user isolation: `psl@` is operator-owned (`system:email`), not a user inbox. `psl` cannot be claimed as a username.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-89ae5af5-4ebf-4792-bde8-3b60518ce758?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-89ae5af5-4ebf-4792-bde8-3b60518ce758&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `psl` as a reserved operator-owned system email address.
  * Messages sent to `psl@` are now accepted and stored in the operator system inbox.
  * Administrators can retrieve, list, and send messages using the `psl` system inbox.

* **Bug Fixes**
  * Reserved `psl` as a username to prevent conflicts with the system address.

* **Documentation**
  * Updated authorization, storage, security, and email documentation to describe the new system inbox.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->