### PR TITLE
Fix /account/secrets 500 for users with 99+ packages

### DIFF
--- a/packages/worker/src/mcp/secrets/repo.node.test.ts
+++ b/packages/worker/src/mcp/secrets/repo.node.test.ts
@@ -1,0 +1,83 @@
+import { maxD1BoundParameters } from '@kody-internal/shared/chunk.ts'
+import { DatabaseSync } from 'node:sqlite'
+import { expect, test } from 'vitest'
+import { applyAllMigrations } from '#worker/test-support/apply-all-migrations.ts'
+import { createD1FromSqlite } from '#worker/test-support/create-d1-from-sqlite.ts'
+import { listPackageScopeSecretMetadata } from './repo.ts'
+
+function createSecretsDb(options?: { maxBindings?: number }) {
+	const sqlite = new DatabaseSync(':memory:')
+	applyAllMigrations(sqlite, new URL('../../../migrations/', import.meta.url))
+	return {
+		sqlite,
+		db: createD1FromSqlite(sqlite, options),
+	}
+}
+
+function insertPackageSecret(
+	sqlite: DatabaseSync,
+	input: {
+		bucketId: string
+		userId: string
+		packageId: string
+		name: string
+	},
+) {
+	sqlite
+		.prepare(
+			`INSERT INTO secret_buckets (
+				id, user_id, scope, binding_key, created_at, updated_at
+			) VALUES (?, ?, 'package', ?, '2026-08-01T00:00:00.000Z', '2026-08-01T00:00:00.000Z')`,
+		)
+		.run(input.bucketId, input.userId, input.packageId)
+	sqlite
+		.prepare(
+			`INSERT INTO secret_entries (
+				bucket_id, name, description, encrypted_value,
+				allowed_hosts, allowed_packages,
+				created_at, updated_at
+			) VALUES (?, ?, '', 'ciphertext', '[]', '[]', '2026-08-01T00:00:00.000Z', '2026-08-01T00:00:00.000Z')`,
+		)
+		.run(input.bucketId, input.name)
+}
+
+test('listPackageScopeSecretMetadata chunks package ids to stay within the D1 binding limit', async () => {
+	const { sqlite, db } = createSecretsDb({ maxBindings: maxD1BoundParameters })
+	const userId = 'user-with-many-packages'
+	const packageIds = Array.from(
+		{ length: maxD1BoundParameters + 1 },
+		(_, index) => `package-${String(index).padStart(3, '0')}`,
+	)
+	insertPackageSecret(sqlite, {
+		bucketId: 'bucket-first',
+		userId,
+		packageId: packageIds[0] ?? 'package-000',
+		name: 'alpha-token',
+	})
+	insertPackageSecret(sqlite, {
+		bucketId: 'bucket-last',
+		userId,
+		packageId: packageIds.at(-1) ?? 'package-100',
+		name: 'zeta-token',
+	})
+
+	const rows = await listPackageScopeSecretMetadata({
+		db,
+		userId,
+		packageIds,
+		now: '2026-08-31T00:00:00.000Z',
+	})
+
+	expect(rows).toEqual([
+		expect.objectContaining({
+			name: 'alpha-token',
+			binding_key: 'package-000',
+			scope: 'package',
+		}),
+		expect.objectContaining({
+			name: 'zeta-token',
+			binding_key: 'package-100',
+			scope: 'package',
+		}),
+	])
+})

--- a/packages/worker/src/mcp/secrets/repo.ts
+++ b/packages/worker/src/mcp/secrets/repo.ts
@@ -1,9 +1,15 @@
+import {
+	chunkArray,
+	maxD1BoundParameters,
+} from '@kody-internal/shared/chunk.ts'
 import { earliestSecretExpiresAt } from '@kody-internal/shared/secret-expires-at.ts'
 import {
 	type SecretBucketRow,
 	type SecretEntryRow,
 	type SecretScope,
 } from './types.ts'
+
+const listPackageScopeSecretFixedBindings = 2
 
 type SecretMetadataRow = {
 	scope: SecretScope
@@ -409,20 +415,33 @@ export async function listPackageScopeSecretMetadata(input: {
 }): Promise<Array<SecretMetadataRow>> {
 	if (input.packageIds.length === 0) return []
 	const now = input.now ?? new Date().toISOString()
-	const placeholders = input.packageIds.map(() => '?').join(', ')
-	const { results } = await input.db
-		.prepare(
-			`SELECT b.scope, b.binding_key, e.name, e.description, e.allowed_hosts, e.allowed_packages, e.created_at, e.updated_at, e.expires_at AS entry_expires_at, b.expires_at AS bucket_expires_at
-			FROM secret_buckets b
-			JOIN secret_entries e ON e.bucket_id = b.id
-			WHERE b.user_id = ? AND b.scope = 'package'
-				AND b.binding_key IN (${placeholders})
-				AND (b.expires_at IS NULL OR b.expires_at > ?)
-			ORDER BY e.name ASC`,
-		)
-		.bind(input.userId, ...input.packageIds, now)
-		.all<Record<string, unknown>>()
-	return (results ?? []).map(mapSecretMetadataRow)
+	const uniquePackageIds = [...new Set(input.packageIds)]
+	const rows: Array<SecretMetadataRow> = []
+	// `/account/secrets` lists every saved package, then binds those ids in one
+	// IN (...). userId + now are two extra params; 99+ packages exceeds D1's
+	// 100-binding cap (`too many SQL variables`) and 500s the page.
+	for (const idChunk of chunkArray(
+		uniquePackageIds,
+		maxD1BoundParameters - listPackageScopeSecretFixedBindings,
+	)) {
+		const placeholders = idChunk.map(() => '?').join(', ')
+		const { results } = await input.db
+			.prepare(
+				`SELECT b.scope, b.binding_key, e.name, e.description, e.allowed_hosts, e.allowed_packages, e.created_at, e.updated_at, e.expires_at AS entry_expires_at, b.expires_at AS bucket_expires_at
+				FROM secret_buckets b
+				JOIN secret_entries e ON e.bucket_id = b.id
+				WHERE b.user_id = ? AND b.scope = 'package'
+					AND b.binding_key IN (${placeholders})
+					AND (b.expires_at IS NULL OR b.expires_at > ?)
+				ORDER BY e.name ASC`,
+			)
+			.bind(input.userId, ...idChunk, now)
+			.all<Record<string, unknown>>()
+		for (const row of results ?? []) {
+			rows.push(mapSecretMetadataRow(row))
+		}
+	}
+	return rows.sort((left, right) => left.name.localeCompare(right.name))
 }
 
 function mapSecretBucketRow(row: Record<string, unknown>): SecretBucketRow {


### PR DESCRIPTION
## Summary
- `/account/secrets` listed package-scoped secrets by binding **every** saved package id in one D1 `IN (...)` plus `userId` and a timestamp.
- D1 caps a statement at 100 bound parameters, so 99+ packages threw `too many SQL variables` and the route returned a generic 500. Kent's account currently has 101 packages.
- Chunk that listing query (same helper as other D1 `IN` lists) and add a regression test that fails at 101 ids under the cap.

## Test plan
- [x] `listPackageScopeSecretMetadata` with 101 package ids under `maxBindings: 100` returns first and last secrets instead of throwing
- [ ] Production `/account/secrets` loads after deploy (was 500)

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `35dba7bac` · **Head:** `d0ce9c3cf`

**Classification:** composes — no primitives added or changed; the secrets listing query now chunks D1 bindings the same way other `IN` lists already do.

### Primitives touched

| Primitive    | Group    | Impact |
| ------------ | -------- | ------ |
| `mcp-server` | surfaces | composes — `packages/worker/src/mcp/secrets/repo.ts` listing query only |

### Change flow

The account secrets page still lists package-scoped secrets from APP_DB; this PR only splits the package-id `IN` list so it stays under D1's 100-parameter cap.

```mermaid
sequenceDiagram
	actor User
	participant appUi as app-ui
	participant mcpServer as mcp-server
	participant d1AppDb as d1-app-db
	User->>appUi: GET /account/secrets
	appUi->>mcpServer: listPackageScopeSecretMetadata(all saved package ids)
	mcpServer->>d1AppDb: chunked IN (package ids) plus userId and now
	Note over mcpServer,d1AppDb: 99+ packages used to overflow 100 bindings
	d1AppDb-->>mcpServer: secret metadata rows
	mcpServer-->>appUi: sorted package-scoped secrets
	appUi-->>User: secrets page
```

</details>

<!-- system-recap:end -->

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved package-scoped secret metadata retrieval for large sets of package IDs.
  - Prevented query failures caused by database parameter limits.
  - Ensured results are deduplicated, consistently sorted by secret name, and returned completely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->