### PR TITLE
Clarify self-authored secret access: host approval stays required

### DIFF
--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -347,7 +347,8 @@ The schema is defined by migrations in `packages/worker/migrations/`:
   read path. Updating or deleting a user secret from package code (`secret_set`
   / `secret_delete`) always requires that grant, regardless of fork or adoption
   state. Official OAuth token rotation persists host-side and does not use that
-  write grant.
+  write grant. Host allowlists (`secret_entries.allowed_hosts`) stay a separate
+  gate and are never implied by authorship or adoption.
 - `user_oauth_apps` (`0001-squashed-init.sql`): per-user OAuth app rows keyed by
   `(user_id, slug)`. Holds shared client id, client-secret ciphertext (soak
   dual-write also keeps `client_secret_secret_name`), provider endpoints, and
@@ -1252,8 +1253,9 @@ on write unless a migration backfills existing rows.
   and adopted forks (`community_forks.adopted_at` / `adoption_note`) skip that
   grant for read/use only. Mutations from package code (`secret_set` /
   `secret_delete`) always require the grant. Official OAuth token rotation
-  persists host-side and does not use that write grant. Package-scoped secrets
-  are owned exclusively by the package id in their bucket binding.
+  persists host-side and does not use that write grant. Authorship and adoption
+  never imply a host allowlist. Package-scoped secrets are owned exclusively by
+  the package id in their bucket binding.
 - `user_oauth_apps.extra_authorize_params_json`,
   `user_integrations.scopes_json`, `user_integrations.required_hosts_json`, and
   `user_integrations.allowed_packages_json` (`0001-squashed-init.sql` /

--- a/docs/use/secrets-and-values.md
+++ b/docs/use/secrets-and-values.md
@@ -113,21 +113,28 @@ returned strings.
 
 If a request fails because a host is not approved for that secret, use the
 approval path the error provides (typically in the web app). Saving a secret
-does not by itself approve new hosts.
+does not by itself approve new hosts. Self-authored and adopted packages do not
+skip this gate: an empty host allowlist blocks secret-bearing fetch even when
+package read/use is automatic.
 
 ## Package approval
 
 User-scoped secrets are available automatically for **reading and using**
-(mounts, fetch placeholders, named capability lookups) to packages the user
-authored themselves and adopted community forks (`community_fork_adopt` after a
-real source review). Unadopted community-forked packages need explicit
-**package** approval (`allowed_packages`) before those read/use paths. Updating
-or deleting a user secret from package code (`secret_set`, `secret_delete`)
-always needs the grant, including for self-authored and adopted packages.
-Official OAuth token rotation (`createAuthenticatedFetch`, `refreshAccessToken`,
-OpenAPI integration 401 retry) persists host-side and does not need that write
-grant. Saving a secret, approving a host, or succeeding in an ad hoc execute
-smoke test does not grant package access. Host approvals are unchanged.
+(mounts, fetch placeholders, named capability lookups including `secret_list`)
+to packages the user authored themselves and adopted community forks
+(`community_fork_adopt` after a real source review). Unadopted community-forked
+packages need explicit **package** approval (`allowed_packages`) before those
+read/use paths. Updating or deleting a user secret from package code
+(`secret_set`, `secret_delete`) always needs the grant, including for
+self-authored and adopted packages. Official OAuth token rotation
+(`createAuthenticatedFetch`, `refreshAccessToken`, OpenAPI integration 401
+retry) persists host-side and does not need that write grant.
+
+**Host approval is separate and is never automatic**, including for
+self-authored and adopted packages. An empty host allowlist blocks
+`{{secret:name}}` fetch placeholders even when package read/use is automatic.
+Saving a secret or succeeding in an ad hoc execute smoke test does not approve a
+host or grant package write access.
 
 When several secrets need the same package approved, Kody can provide a bulk
 approval URL shaped like

--- a/docs/use/troubleshooting.md
+++ b/docs/use/troubleshooting.md
@@ -86,7 +86,7 @@ signed in, user-scoped package results are empty.
 ## Fetch or secret errors
 
 - **Host not approved:** complete the approval flow in the app for that secret
-  and host.
+  and host. Self-authored and adopted packages still need this host grant.
 - **Package not approved for secret:** self-authored and adopted packages can
   read and use user secrets; unadopted community forks need an
   `allowed_packages` grant (or adoption after review). See

--- a/packages/worker/client/routes/account-secrets-editor.tsx
+++ b/packages/worker/client/routes/account-secrets-editor.tsx
@@ -230,8 +230,11 @@ export function renderSecretEditor(props: SecretEditorProps) {
 					<div mix={css({ display: 'grid', gap: spacing.xs })}>
 						<span mix={css(fieldLabelCss)}>Allowed packages</span>
 						<p mix={css({ margin: 0, color: colors.textMuted })}>
-							Only selected packages may access this user secret from package
-							runtimes.
+							Self-authored and adopted packages can already read and use this
+							secret. Add a package here to grant an unadopted community fork,
+							or to let any package update or delete this secret. Sending the
+							secret to a site still needs a host under Advanced details — that
+							is never automatic, including for packages you wrote.
 						</p>
 					</div>
 					{editorState.allowedPackages.length > 0 ? (
@@ -273,7 +276,8 @@ export function renderSecretEditor(props: SecretEditorProps) {
 						</div>
 					) : (
 						<p mix={css({ margin: 0, color: colors.textMuted })}>
-							No packages currently have access.
+							No extra package grants. Self-authored and adopted packages can
+							still read and use this secret.
 						</p>
 					)}
 					{availableAllowedPackageOptions.length > 0 ? (

--- a/packages/worker/client/routes/secret-editor-fields.tsx
+++ b/packages/worker/client/routes/secret-editor-fields.tsx
@@ -213,7 +213,7 @@ export function SecretEditorFields(handle: Handle<SecretEditorFieldsProps>) {
 								</span>
 								<p mix={css({ margin: 0, color: colors.textMuted })}>
 									Leave this empty to ask before Kody sends this secret to a
-									site.
+									site. Self-authored packages do not skip host approval.
 								</p>
 							</div>
 							<div

--- a/packages/worker/src/mcp/capabilities/secrets/secret-list.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/secrets/secret-list.node.test.ts
@@ -1,0 +1,146 @@
+import { expect, test, vi } from 'vitest'
+import { createMcpCallerContext } from '#mcp/context.ts'
+import * as secretService from '#mcp/secrets/service.ts'
+import { type SecretMetadata } from '#mcp/secrets/types.ts'
+import { secretListCapability } from './secret-list.ts'
+
+const mockModule = vi.hoisted(() => ({
+	getSavedPackageById: vi.fn(),
+	getCommunityForkByForkedPackageId: vi.fn(),
+}))
+
+vi.mock('#worker/package-registry/repo.ts', () => ({
+	getSavedPackageById: (...args: Array<unknown>) =>
+		mockModule.getSavedPackageById(...args),
+}))
+
+vi.mock('#worker/community/repo.ts', () => ({
+	getCommunityForkByForkedPackageId: (...args: Array<unknown>) =>
+		mockModule.getCommunityForkByForkedPackageId(...args),
+}))
+
+const savedPackage = {
+	id: 'pkg-1',
+	kodyId: 'web-search',
+	name: '@user/web-search',
+	sourceId: 'source-1',
+}
+
+const communityFork = {
+	id: 'fork-1',
+	listingId: 'listing-1',
+	forkerUserId: 'user-1',
+	originCommit: 'abc123',
+	forkedPackageId: 'pkg-1',
+	forkedSourceId: 'source-1',
+	targetKodyId: 'web-search',
+	createdAt: '2026-01-01T00:00:00.000Z',
+	adoptedAt: null,
+	adoptionNote: null,
+}
+
+function secretMetadata(
+	overrides: Partial<SecretMetadata> & Pick<SecretMetadata, 'name' | 'scope'>,
+): SecretMetadata {
+	return {
+		description: '',
+		packageId: overrides.scope === 'package' ? 'pkg-1' : null,
+		allowedHosts: [],
+		allowedPackages: [],
+		createdAt: '2026-01-01T00:00:00.000Z',
+		updatedAt: '2026-01-01T00:00:00.000Z',
+		expiresAt: null,
+		ttlMs: null,
+		...overrides,
+	}
+}
+
+const listedSecrets = [
+	secretMetadata({ name: 'BraveSearch', scope: 'user' }),
+	secretMetadata({
+		name: 'GrantedSearch',
+		scope: 'user',
+		allowedPackages: ['pkg-1'],
+	}),
+	secretMetadata({ name: 'packageToken', scope: 'package' }),
+]
+
+test('secret_list matches implicit user-secret read access and still lists package secrets', async () => {
+	const listSecretsSpy = vi
+		.spyOn(secretService, 'listSecrets')
+		.mockResolvedValue(listedSecrets)
+	const env = { APP_DB: {} } as Env
+	const executeContext = {
+		env,
+		callerContext: createMcpCallerContext({
+			baseUrl: 'https://example.com',
+			user: { userId: 'user-1' },
+		}),
+	}
+	const packageContext = {
+		env,
+		callerContext: createMcpCallerContext({
+			baseUrl: 'https://example.com',
+			user: { userId: 'user-1' },
+			storageContext: {
+				sessionId: null,
+				packageId: 'pkg-1',
+			},
+		}),
+	}
+
+	const executeListed = await secretListCapability.handler({}, executeContext)
+	expect(executeListed.secrets.map((secret) => secret.name)).toEqual([
+		'BraveSearch',
+		'GrantedSearch',
+		'packageToken',
+	])
+	expect(mockModule.getSavedPackageById).not.toHaveBeenCalled()
+
+	mockModule.getSavedPackageById.mockResolvedValueOnce(savedPackage)
+	mockModule.getCommunityForkByForkedPackageId.mockResolvedValueOnce(null)
+	const selfAuthoredListed = await secretListCapability.handler(
+		{},
+		packageContext,
+	)
+	expect(selfAuthoredListed.secrets.map((secret) => secret.name)).toEqual([
+		'BraveSearch',
+		'GrantedSearch',
+		'packageToken',
+	])
+
+	mockModule.getSavedPackageById.mockResolvedValueOnce(savedPackage)
+	mockModule.getCommunityForkByForkedPackageId.mockResolvedValueOnce({
+		...communityFork,
+		adoptedAt: '2026-07-01T00:00:00.000Z',
+		adoptionNote: 'Reviewed source; trusted for my use.',
+	})
+	const adoptedListed = await secretListCapability.handler({}, packageContext)
+	expect(adoptedListed.secrets.map((secret) => secret.name)).toEqual([
+		'BraveSearch',
+		'GrantedSearch',
+		'packageToken',
+	])
+
+	mockModule.getSavedPackageById.mockResolvedValueOnce(savedPackage)
+	mockModule.getCommunityForkByForkedPackageId.mockResolvedValueOnce(
+		communityFork,
+	)
+	const unadoptedListed = await secretListCapability.handler({}, packageContext)
+	expect(unadoptedListed.secrets.map((secret) => secret.name)).toEqual([
+		'GrantedSearch',
+		'packageToken',
+	])
+
+	mockModule.getSavedPackageById.mockResolvedValueOnce(null)
+	const missingPackageListed = await secretListCapability.handler(
+		{},
+		packageContext,
+	)
+	expect(missingPackageListed.secrets.map((secret) => secret.name)).toEqual([
+		'GrantedSearch',
+		'packageToken',
+	])
+	expect(listSecretsSpy).toHaveBeenCalled()
+	listSecretsSpy.mockRestore()
+})

--- a/packages/worker/src/mcp/capabilities/secrets/secret-list.ts
+++ b/packages/worker/src/mcp/capabilities/secrets/secret-list.ts
@@ -3,6 +3,7 @@ import { defineDomainCapability } from '#mcp/capabilities/define-domain-capabili
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { type CapabilityContext } from '#mcp/capabilities/types.ts'
 import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
+import { packageHasImplicitUserSecretReadAccess } from '#mcp/secrets/package-access.ts'
 import { listSecrets } from '#mcp/secrets/service.ts'
 import { secretScopeValues } from '#mcp/secrets/types.ts'
 import { secretMetadataSchema, toSecretCapabilityOutput } from './shared.ts'
@@ -12,7 +13,7 @@ export const secretListCapability = defineDomainCapability(
 	{
 		name: 'secret_list',
 		description:
-			'List available secret references for the signed-in user. Results include metadata such as names, descriptions, allowed hosts, and allowed kody. Use `kody.secret_list({ scope })` inside execute-time code when you want the same metadata from the sandbox. To use a listed secret in an outbound `fetch`, reference it by placeholder — e.g. `Authorization: "Bearer {{secret:name}}"` (optionally `{{secret:name|scope=user}}`) — and Kody resolves it for approved hosts; plaintext values are never returned. Use `/account/secrets/new` for user-provided API key, token, and credential entry or rotation.',
+			'List available secret references for the signed-in user. Results include metadata such as names, descriptions, allowed hosts, and allowed packages — never plaintext values. From a package runtime, self-authored and adopted packages see user secrets they can already read; unadopted community forks see only explicitly granted user secrets. Listing a secret does not approve a host: outbound `fetch` still resolves `{{secret:name}}` (optionally `{{secret:name|scope=user}}`) only for approved hosts. Use `kody.secret_list({ scope })` inside execute-time code for the same metadata. Use `/account/secrets/new` for user-provided API key, token, and credential entry or rotation.',
 		keywords: ['secret', 'list', 'discovery', 'metadata', 'credentials'],
 		readOnly: true,
 		idempotent: true,
@@ -43,13 +44,22 @@ export const secretListCapability = defineDomainCapability(
 					storageId: ctx.callerContext.storageContext?.storageId ?? null,
 				},
 			})
-			const accessibleSecrets = packageId
-				? secrets.filter(
-						(secret) =>
-							secret.scope !== 'user' ||
-							secret.allowedPackages.includes(packageId),
-					)
-				: secrets
+			const implicitReadAccess =
+				packageId == null
+					? true
+					: await packageHasImplicitUserSecretReadAccess({
+							env: ctx.env,
+							userId: user.userId,
+							packageId,
+						})
+			const accessibleSecrets =
+				packageId && !implicitReadAccess
+					? secrets.filter(
+							(secret) =>
+								secret.scope !== 'user' ||
+								secret.allowedPackages.includes(packageId),
+						)
+					: secrets
 			return {
 				secrets: accessibleSecrets.map((secret) =>
 					toSecretCapabilityOutput(secret),

--- a/packages/worker/src/mcp/secrets/package-access.ts
+++ b/packages/worker/src/mcp/secrets/package-access.ts
@@ -75,6 +75,42 @@ async function resolvePackageRecordForSecretAccess(input: {
 	})
 }
 
+/**
+ * Self-authored packages (no `community_forks` row) and adopted community
+ * forks may read/use user secrets without an explicit `allowed_packages`
+ * grant. Missing packages and unadopted forks do not. Host allowlists are
+ * a separate gate and are never implied by this check.
+ */
+export async function packageHasImplicitUserSecretReadAccess(input: {
+	env: Pick<Env, 'APP_DB'>
+	userId: string
+	packageId: string
+}): Promise<boolean> {
+	const savedPackage = await resolvePackageRecordForSecretAccess({
+		db: input.env.APP_DB,
+		userId: input.userId,
+		packageId: input.packageId,
+	})
+	if (!savedPackage) return false
+	return await savedPackageHasImplicitUserSecretReadAccess({
+		db: input.env.APP_DB,
+		userId: input.userId,
+		savedPackage,
+	})
+}
+
+async function savedPackageHasImplicitUserSecretReadAccess(input: {
+	db: D1Database
+	userId: string
+	savedPackage: SavedPackageRecord
+}): Promise<boolean> {
+	const communityFork = await getCommunityForkByForkedPackageId(input.db, {
+		forkerUserId: input.userId,
+		forkedPackageId: input.savedPackage.id,
+	})
+	return !communityFork || Boolean(communityFork.adoptedAt)
+}
+
 export async function assertPackageCanAccessResolvedSecret(input: {
 	env: Pick<Env, 'APP_DB'>
 	baseUrl: string
@@ -108,19 +144,15 @@ export async function assertPackageCanAccessResolvedSecret(input: {
 		)
 	}
 	const intent = input.intent ?? 'use'
-	if (intent === 'use') {
-		const communityFork = await getCommunityForkByForkedPackageId(
-			input.env.APP_DB,
-			{
-				forkerUserId: input.userId,
-				forkedPackageId: savedPackage.id,
-			},
-		)
-		// Self-authored packages (no community fork row) and adopted
-		// community forks may read/use user secrets without an explicit
-		// allowed_packages grant. Unadopted community forks still require
-		// approval. Mutations never take this path.
-		if (!communityFork || communityFork.adoptedAt) return
+	if (
+		intent === 'use' &&
+		(await savedPackageHasImplicitUserSecretReadAccess({
+			db: input.env.APP_DB,
+			userId: input.userId,
+			savedPackage,
+		}))
+	) {
+		return
 	}
 
 	const approvalUrl = buildSecretPackageApprovalUrl({
@@ -334,14 +366,15 @@ export async function findMissingPackageApprovals(input: {
 	if (!savedPackage) {
 		throw new Error(`Saved package "${input.packageId}" was not found.`)
 	}
-	const communityFork = await getCommunityForkByForkedPackageId(
-		input.env.APP_DB,
-		{
-			forkerUserId: input.userId,
-			forkedPackageId: savedPackage.id,
-		},
-	)
-	if (!communityFork || communityFork.adoptedAt) return []
+	if (
+		await savedPackageHasImplicitUserSecretReadAccess({
+			db: input.env.APP_DB,
+			userId: input.userId,
+			savedPackage,
+		})
+	) {
+		return []
+	}
 
 	const storageContext = {
 		sessionId: input.storageContext?.sessionId ?? null,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Make the documented self-authored user-secret **read/use** auto-grant match what package runtimes can discover and what the account UI says — without auto-approving hosts.

## Why

Platform feedback (`friction:user-scoped-secret-docs-suggest-auto-access-for-self-authored-packages-but-requi`) reported that `docs/use/secrets-and-values.md` promised automatic access for self-authored packages, but `@hypercubed/web-search` still needed Allowed packages and Allowed sites for `{{secret:BraveSearch}}`.

Kent's decision: **do not** auto-approve hosts for self-authored packages. Keep host approval as a human gate. If the contract is unclear, make it clearer.

Fetch/mounts already auto-grant read/use for self-authored and adopted packages. The Wikipedia/422 fallback with `allowed_hosts: []` is the package catching a correct host deny. Two surfaces contradicted that contract:

- The account secret editor said only listed packages could access the secret.
- `secret_list` from a package runtime hid user secrets unless they were on `allowed_packages`.

## Summary

- Share the implicit-read helper used by fetch/mounts and use it in `secret_list` (self-authored and adopted packages see user secrets they can already read; unadopted forks stay on the explicit grant).
- Rewrite the secret editor copy so Allowed packages is for unadopted forks and writes, and host approval is never automatic — including for packages you wrote.
- Garden usage, troubleshooting, and architecture docs so host allowlists stay a separate gate.

## Testing

- `packages/worker/src/mcp/capabilities/secrets/secret-list.node.test.ts` covers execute, self-authored, adopted, unadopted, and missing-package listing.
- Existing `package-access.node.test.ts` still covers fetch/mount implicit read and mutate-requires-grant.
- `npm run test:node` and `npm run test:workers` passed on push.
- CI green (Node, Workers, Static, MCP, E2E, Bugbot). CodeRabbit: no actionable comments.
- Preview (`https://kody-pr-1921.kody-a99.workers.dev`) as seed user `me@kentcdodds.com`: created `BraveSearch` via `POST /account/secrets.json`, then opened `/account/secrets/user/BraveSearch`. Editor copy shows implicit read/use, "No extra package grants", and "Self-authored packages do not skip host approval."

## System changes

Medium: `secret_list` now returns user-secret metadata to self-authored/adopted package runtimes that could already resolve those secrets. Host allowlists are unchanged.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `2bfaefc6` · **Head:** `5efc873b`

**Classification:** extends — `secret_list` now follows the existing self-authored/adopted implicit-read grant; host allowlists stay a separate human gate.

### Primitives touched

| Primitive    | Group     | Impact                                                                 |
| ------------ | --------- | ---------------------------------------------------------------------- |
| `secrets`    | assistant | extends — package-runtime `secret_list` matches implicit read/use      |
| `mcp-server` | surfaces  | extends — shared implicit-read helper for package secret access        |
| `app-ui`     | surfaces  | composes — account secret editor copy for package grants and hosts     |

### Change flow

A self-authored package listing user secrets now sees the same secrets it can already resolve; sending them still requires a host grant.

```mermaid
sequenceDiagram
	actor PackageRuntime
	participant secrets as secrets
	participant mcpServer as mcp-server
	participant appUi as app-ui
	PackageRuntime->>secrets: secret_list from package runtime
	secrets->>mcpServer: packageHasImplicitUserSecretReadAccess
	Note over secrets: self-authored or adopted: include user secrets
	Note over secrets: unadopted fork: allowed_packages only
	PackageRuntime->>secrets: fetch with {{secret:name}}
	secrets-->>PackageRuntime: host deny when allowed_hosts is empty
	appUi->>appUi: editor copy: hosts never auto-approve
```

### Before / after

| Surface | Before | After |
| --- | --- | --- |
| `secret_list` in a self-authored package | hid user secrets unless listed in `allowed_packages` | lists user secrets the package can already read/use |
| Account secret editor | "Only selected packages may access" / "No packages currently have access" | implicit read/use called out; host grant stays a separate gate |
| Host allowlist | required | still required; never implied by authorship |

### Invariants

Per-user secret isolation is unchanged. Host allowlists remain a human-only policy and are never implied by package authorship or adoption.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-accac9c7-2db2-4e42-91d2-59bd10660153?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-accac9c7-2db2-4e42-91d2-59bd10660153&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Secret listings now clearly communicate metadata, package visibility, and host approval requirements.
  - Self-authored and adopted packages can automatically read and use user secrets, while unadopted forks still require approval.
  - Secret editor guidance now distinguishes package access from host approval and write permissions.

- **Documentation**
  - Updated storage, usage, and troubleshooting guidance to clarify authorization rules, package-scoped ownership, and host approval requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->