### PR TITLE
Add account password change and stop reset-form autofill errors

### DIFF
--- a/docs/contributing/architecture/authentication.md
+++ b/docs/contributing/architecture/authentication.md
@@ -40,14 +40,15 @@ The cookie payload stores:
 - `issuedAt` (epoch ms when the cookie was issued or last renewed)
 - `rememberMe` when the login used remember-me
 
-Password reset confirmation revokes every MCP OAuth grant for that user, writes
-`users.password_changed_at`, then revokes again so a grant created in that
-window cannot survive. Session resolution rejects cookies whose `issuedAt` is
-missing or at/before that timestamp, so a reset invalidates every existing
-browser and package-app session. `/mcp` rejects access tokens whose `createdAt`
-is at or before that timestamp (`invalid_token`), so already-issued bearers die
-immediately; hosts that refresh then hit the revoked grant and must start a new
-OAuth flow.
+Password reset confirmation and signed-in password change revoke every MCP OAuth
+grant for that user, write `users.password_changed_at`, then revoke again so a
+grant created in that window cannot survive. Session resolution rejects cookies
+whose `issuedAt` is missing or at/before that timestamp, so a reset invalidates
+every existing browser and package-app session. A signed-in change re-issues the
+current `kody_session` cookie with a later `issuedAt` so that browser stays
+signed in. `/mcp` rejects access tokens whose `createdAt` is at or before that
+timestamp (`invalid_token`), so already-issued bearers die immediately; hosts
+that refresh then hit the revoked grant and must start a new OAuth flow.
 
 `users.id` never crosses the cookie boundary. Session resolution looks up the
 stable id and only then uses the numeric primary key for internal D1 joins.
@@ -412,6 +413,25 @@ Password reset handlers are in
 - when required Cloudflare Email API credentials are unset, the helper logs a
   redacted diagnostic without the email body or token URL to prevent token
   leakage in logs
+- public reset forms include a honeypot whose field name is not an HTML
+  autocomplete token (`kody_hp` in
+  `packages/worker/universal/public-form-protection.ts`), so password managers
+  do not treat it as a login website field
+
+## Password change
+
+Signed-in password change is `POST /account/password.json`
+(`packages/worker/src/app/handlers/account-password.ts`), exposed on `/account`.
+
+- Requires the current password when the account has a usable password hash
+- Accounts that only sign in with a connected provider or passkey can set a
+  first password without a current password
+- New passwords go through `getPasswordPolicyError`
+- Shares `applyPasswordChange` with reset confirmation: revoke MCP grants, stamp
+  `users.password_changed_at`, revoke again, delete outstanding reset tokens
+- Re-issues the current session cookie with `issuedAt` strictly after
+  `password_changed_at` so this browser stays signed in
+- Joins the shared auth rate-limit bucket and a per-user password-change budget
 
 ## Package app origin handoff
 

--- a/docs/contributing/security.md
+++ b/docs/contributing/security.md
@@ -34,7 +34,7 @@ package-app surfaces:
    production.
 4. **Credential endpoints are rate limited.** Any new endpoint that accepts a
    password, token, or reset code must join the shared auth rate-limit bucket in
-   `packages/worker/src/index.ts` (`rateLimitedAuthPaths`).
+   `packages/worker/src/origin-handler.ts` (`rateLimitedAuthPaths`).
 5. **New passwords go through the shared policy.** Use `getPasswordPolicyError`
    from `@kody-internal/shared/password-policy.ts` wherever a password is set.
 6. **OAuth PKCE stays S256-only.** Keep the `getPkceValidationError` check in
@@ -275,7 +275,7 @@ fails closed: env validation (`packages/worker/src/app/env.ts`) rejects a
 production runtime without the binding, so the D1 fallback can never silently
 become the production limiter. The shared bucket means brute-force attempts
 cannot fan out across parallel paths. Covered paths (`rateLimitedAuthPaths` in
-`packages/worker/src/index.ts`):
+`packages/worker/src/origin-handler.ts`):
 
 - `POST /auth` (password login/signup)
 - `POST /auth/github`, `POST /auth/google`, `POST /auth/x`, `POST /auth/discord`
@@ -283,6 +283,7 @@ cannot fan out across parallel paths. Covered paths (`rateLimitedAuthPaths` in
 - `POST /oauth/authorize` (inline OAuth login)
 - `POST /password-reset` (reset request)
 - `POST /password-reset/confirm` (reset confirmation)
+- `POST /account/password.json` (signed-in password change or first-time set)
 - `POST /verify/2fa.json` and `POST /account/two-factor.json` (two-factor)
 - `POST /webauthn/authentication` (passkey authentication)
 
@@ -306,10 +307,10 @@ before the 10 MB cap can apply.
 
 ## Password policy
 
-Signup and password-reset confirmation enforce a minimum password length via
-`@kody-internal/shared/password-policy.ts`. The server is the trust boundary;
-the browser hint is advisory. Login does not re-check length, so existing
-accounts are never locked out.
+Signup, password-reset confirmation, and signed-in password change enforce a
+minimum password length via `@kody-internal/shared/password-policy.ts`. The
+server is the trust boundary; the browser hint is advisory. Login does not
+re-check length, so existing accounts are never locked out.
 
 ## OAuth / MCP hardening
 
@@ -479,16 +480,17 @@ blast radius:
 These were reviewed and intentionally left as-is for this project. Document any
 change to these decisions here so future agents do not relitigate them.
 
-- **Stateless sessions revoke after password reset.** `kody_session` is a signed
-  cookie with no server store, so there is no global "log out everywhere"
-  button. Password reset confirmation revokes every MCP OAuth grant for the
-  user, stamps `users.password_changed_at`, then revokes again. Browser and
+- **Stateless sessions revoke after a password change.** `kody_session` is a
+  signed cookie with no server store, so there is no separate "log out
+  everywhere" button. Password reset confirmation and signed-in password change
+  (`POST /account/password.json`) both revoke every MCP OAuth grant for the
+  user, stamp `users.password_changed_at`, then revoke again. Browser and
   package-app sessions carry `issuedAt`; `resolveRequestAuth` rejects cookies
   issued at or before that timestamp (missing `issuedAt` fails closed once a
   password change exists). `/mcp` applies the same timestamp to the access token
   `createdAt` (Unix seconds) so already-issued bearers fail closed as
-  `invalid_token`. A future hardening could add an explicit "sign out other
-  sessions" control without waiting for a reset.
+  `invalid_token`. A signed-in password change re-issues the current browser
+  cookie so that tab stays signed in; every other session still dies.
 - **OAuth authorize client reset is grant-scoped.** A signed-in user can reset a
   mismatched DCR client for **their** grants only. `deleteClient` runs only when
   `user_mcp_oauth_clients` shows they own that registration. Shared host clients

--- a/docs/use/privacy.md
+++ b/docs/use/privacy.md
@@ -34,8 +34,9 @@ authored). The browser download is a bounded metadata manifest; use its
 `account_export_section` instructions to retrieve every D1, Durable Object, and
 R2 page for a complete portable export. Account settings can delete the account
 after you type `GOODBYE KODY` in a confirmation modal (and re-enter your
-password when the account has one). Account deletion removes those same
-user-owned rows and objects.
+password when the account has one), and can change a password or set one on an
+account that currently signs in only with a connected provider or passkey.
+Account deletion removes those same user-owned rows and objects.
 
 ## Connected accounts
 

--- a/docs/use/troubleshooting.md
+++ b/docs/use/troubleshooting.md
@@ -103,9 +103,11 @@ normal outbound MCP server (`kody.mcp["home"]`). See
 [Connect remote MCP servers](./mcp-client-servers.md) and
 [Lock an MCP server to a package](../guides/locked-mcp-server.md).
 
-After a password reset, reconnect the MCP host: Kody revokes OAuth grants and
-rejects access tokens issued at or before the reset, so a refresh alone is not
-enough.
+After a password reset or an in-account password change, reconnect the MCP host:
+Kody revokes OAuth grants and rejects access tokens issued at or before the
+change, so a refresh alone is not enough. Signed-in users can also change or set
+a password from [Account](https://kody.codes/account) without waiting for a
+reset email.
 
 ## Job, webhook, or package app failed
 

--- a/packages/shared/src/password-policy.ts
+++ b/packages/shared/src/password-policy.ts
@@ -1,8 +1,8 @@
 /**
  * Server-side password policy shared by every code path that sets a new
- * password (signup and password-reset confirmation). The browser UI hints the
- * same minimum, but the server is the trust boundary: never rely on the client
- * to enforce password strength.
+ * password (signup, password-reset confirmation, and in-account password
+ * change). The browser UI hints the same minimum, but the server is the trust
+ * boundary: never rely on the client to enforce password strength.
  */
 export const minPasswordLength = 8
 // Upper bound keeps unbounded input out of PBKDF2 (100k iterations), which

--- a/packages/worker/client/honeypot-field.tsx
+++ b/packages/worker/client/honeypot-field.tsx
@@ -1,0 +1,26 @@
+import { css } from 'remix/ui'
+import { passwordManagerIgnoreProps } from '#client/password-manager-ignore.ts'
+import { honeypotFieldName } from '#universal/public-form-protection.ts'
+
+const honeypotCss = {
+	position: 'absolute' as const,
+	left: '-10000px',
+	width: '1px',
+	height: '1px',
+	overflow: 'hidden' as const,
+}
+
+export function renderHoneypot(options: { class?: string } = {}) {
+	return (
+		<input
+			type="text"
+			name={honeypotFieldName}
+			tabIndex={-1}
+			aria-hidden="true"
+			readOnly
+			class={options.class}
+			{...passwordManagerIgnoreProps}
+			mix={css(honeypotCss)}
+		/>
+	)
+}

--- a/packages/worker/client/public-form-protection.ts
+++ b/packages/worker/client/public-form-protection.ts
@@ -1,5 +1,17 @@
-export const honeypotFieldName = 'website'
-export const turnstileResponseFieldName = 'turnstileToken'
+import {
+	emptyPublicFormProtection,
+	honeypotFieldName,
+	turnstileResponseFieldName,
+	type PublicFormProtectionFields,
+} from '#universal/public-form-protection.ts'
+
+export {
+	emptyPublicFormProtection,
+	honeypotFieldName,
+	turnstileResponseFieldName,
+	type PublicFormProtectionFields,
+}
+
 export const turnstileWidgetClassName = 'kody-turnstile'
 
 type TurnstileApi = {
@@ -80,9 +92,13 @@ export function resetTurnstileWidgets() {
 	}
 }
 
-export function readPublicFormProtection(formData: FormData) {
+export function readPublicFormProtection(
+	formData: FormData,
+): PublicFormProtectionFields {
 	return {
-		website: String(formData.get(honeypotFieldName) ?? ''),
-		turnstileToken: String(formData.get(turnstileResponseFieldName) ?? ''),
+		[honeypotFieldName]: String(formData.get(honeypotFieldName) ?? ''),
+		[turnstileResponseFieldName]: String(
+			formData.get(turnstileResponseFieldName) ?? '',
+		),
 	}
 }

--- a/packages/worker/client/routes/account-connections-panel.tsx
+++ b/packages/worker/client/routes/account-connections-panel.tsx
@@ -194,6 +194,11 @@ export function createAccountConnections(handle: Handle) {
 		get hasUsablePassword() {
 			return hasUsablePassword
 		},
+		markHasUsablePassword() {
+			hasUsablePassword = true
+			canDisconnect = true
+			handle.update()
+		},
 		setMessage(next: { text: string; tone: 'error' | 'info' } | null) {
 			connectionsMessage = next ?? connectionsMessage
 		},

--- a/packages/worker/client/routes/account-password-panel.tsx
+++ b/packages/worker/client/routes/account-password-panel.tsx
@@ -1,0 +1,251 @@
+import { css, type Handle } from 'remix/ui'
+import { on } from '#client/event-mixin.ts'
+import { queueSessionRefresh } from '#client/session.ts'
+import { toast } from '#client/toast.ts'
+import {
+	AccountManagementPanel,
+	accountActionsCss,
+	accountDisclosureCss,
+	accountFieldCss,
+	accountFieldLabelCss,
+	accountFieldNoteCss,
+	accountInputCss,
+} from '#client/routes/account-management-components.tsx'
+import { readJson } from '#client/routes/account-approval-shared.ts'
+import { minPasswordLength } from '@kody-internal/shared/password-policy.ts'
+import { routes } from '#universal/routes.ts'
+import { colors, spacing } from '#universal/styles/tokens.ts'
+import {
+	getGhostButtonCss,
+	getPillButtonCss,
+} from '#universal/styles/style-primitives.ts'
+
+type PasswordStatus = 'idle' | 'saving'
+
+export function AccountPasswordPanel(
+	handle: Handle<{
+		hasUsablePassword: boolean
+		onPasswordSet: () => void
+	}>,
+) {
+	let currentPassword = ''
+	let newPassword = ''
+	let confirmPassword = ''
+	let status: PasswordStatus = 'idle'
+	let message: string | null = null
+	let messageTone: 'error' | 'info' = 'info'
+
+	function updateCurrentPassword(event: Event) {
+		if (!(event.currentTarget instanceof HTMLInputElement)) return
+		currentPassword = event.currentTarget.value
+		handle.update()
+	}
+
+	function updateNewPassword(event: Event) {
+		if (!(event.currentTarget instanceof HTMLInputElement)) return
+		newPassword = event.currentTarget.value
+		handle.update()
+	}
+
+	function updateConfirmPassword(event: Event) {
+		if (!(event.currentTarget instanceof HTMLInputElement)) return
+		confirmPassword = event.currentTarget.value
+		handle.update()
+	}
+
+	async function handleSubmit(event: SubmitEvent) {
+		event.preventDefault()
+		if (handle.props.hasUsablePassword && !currentPassword) {
+			message = 'Current password is required.'
+			messageTone = 'error'
+			handle.update()
+			return
+		}
+		if (!newPassword || !confirmPassword) {
+			message = 'New password and confirmation are required.'
+			messageTone = 'error'
+			handle.update()
+			return
+		}
+		if (newPassword !== confirmPassword) {
+			message = 'New password and confirmation do not match.'
+			messageTone = 'error'
+			handle.update()
+			return
+		}
+
+		status = 'saving'
+		message = null
+		messageTone = 'info'
+		handle.update()
+
+		try {
+			const response = await fetch(routes.accountPassword.href(), {
+				method: 'POST',
+				headers: {
+					Accept: 'application/json',
+					'Content-Type': 'application/json',
+				},
+				credentials: 'include',
+				body: JSON.stringify({
+					...(handle.props.hasUsablePassword ? { currentPassword } : {}),
+					newPassword,
+				}),
+			})
+			if (response.status === 401) {
+				const payload = await readJson<{ code?: string; error?: string }>(
+					response,
+				)
+				if (payload?.code === 'invalid_password') {
+					throw new Error(payload.error)
+				}
+				window.location.assign('/login')
+				return
+			}
+			const payload = await readJson<{
+				ok?: boolean
+				message?: string
+				error?: string
+			}>(response)
+			if (!response.ok || !payload?.ok) {
+				throw new Error(payload?.error || 'Unable to update your password.')
+			}
+			currentPassword = ''
+			newPassword = ''
+			confirmPassword = ''
+			message = payload.message ?? 'Password updated.'
+			messageTone = 'info'
+			if (!handle.props.hasUsablePassword) {
+				handle.props.onPasswordSet()
+			}
+			queueSessionRefresh()
+			toast.success('Password updated.')
+		} catch (error) {
+			message =
+				error instanceof Error
+					? error.message
+					: 'Unable to update your password.'
+			messageTone = 'error'
+		} finally {
+			status = 'idle'
+			handle.update()
+		}
+	}
+
+	return () => {
+		const hasUsablePassword = handle.props.hasUsablePassword
+		const isSaving = status === 'saving'
+		const title = hasUsablePassword ? 'Change password' : 'Set a password'
+		const canSubmit =
+			newPassword.length > 0 &&
+			confirmPassword.length > 0 &&
+			(!hasUsablePassword || currentPassword.length > 0)
+
+		return (
+			<AccountManagementPanel
+				title="Security"
+				description="Change your password, add two-factor authentication, or sign in with passkeys."
+			>
+				<details mix={css(accountDisclosureCss)}>
+					<summary>{title}</summary>
+					<form
+						data-testid="account-password-form"
+						mix={[
+							css({
+								display: 'grid',
+								gap: spacing.md,
+								maxWidth: '26rem',
+							}),
+							on('submit', handleSubmit),
+						]}
+					>
+						<p mix={css(accountFieldNoteCss)}>
+							{hasUsablePassword
+								? 'Other browser sessions and connected MCP hosts will need to sign in again.'
+								: 'This account signs in with a connected provider or passkey. Setting a password lets you also sign in with email.'}
+						</p>
+						{hasUsablePassword ? (
+							<label mix={css(accountFieldCss)}>
+								<span mix={css(accountFieldLabelCss)}>Current password</span>
+								<input
+									type="password"
+									name="currentPassword"
+									data-field-ring
+									required
+									autoComplete="current-password"
+									value={currentPassword}
+									mix={[
+										css(accountInputCss),
+										on('input', updateCurrentPassword),
+									]}
+								/>
+							</label>
+						) : null}
+						<label mix={css(accountFieldCss)}>
+							<span mix={css(accountFieldLabelCss)}>New password</span>
+							<input
+								type="password"
+								name="newPassword"
+								data-field-ring
+								required
+								minLength={minPasswordLength}
+								autoComplete="new-password"
+								placeholder={`At least ${minPasswordLength} characters`}
+								value={newPassword}
+								mix={[css(accountInputCss), on('input', updateNewPassword)]}
+							/>
+						</label>
+						<label mix={css(accountFieldCss)}>
+							<span mix={css(accountFieldLabelCss)}>Confirm new password</span>
+							<input
+								type="password"
+								name="confirmPassword"
+								data-field-ring
+								required
+								minLength={minPasswordLength}
+								autoComplete="new-password"
+								value={confirmPassword}
+								mix={[css(accountInputCss), on('input', updateConfirmPassword)]}
+							/>
+						</label>
+						<div>
+							<button
+								type="submit"
+								disabled={isSaving || !canSubmit}
+								mix={css(compactPillButtonCss)}
+							>
+								{isSaving
+									? 'Saving...'
+									: hasUsablePassword
+										? 'Update password'
+										: 'Set password'}
+							</button>
+						</div>
+						{message ? (
+							<p
+								role="status"
+								mix={css({
+									color: messageTone === 'error' ? colors.error : colors.text,
+									margin: 0,
+								})}
+							>
+								{message}
+							</p>
+						) : null}
+					</form>
+				</details>
+				<div mix={css(accountActionsCss)}>
+					<a href="/account/two-factor" mix={css(compactGhostButtonCss)}>
+						Two-factor authentication
+					</a>
+					<a href="/account/passkeys" mix={css(compactGhostButtonCss)}>
+						Passkeys
+					</a>
+				</div>
+			</AccountManagementPanel>
+		)
+	}
+}
+
+const compactPillButtonCss = getPillButtonCss({ size: 'sm' })
+const compactGhostButtonCss = getGhostButtonCss({ size: 'sm' })

--- a/packages/worker/client/routes/account.tsx
+++ b/packages/worker/client/routes/account.tsx
@@ -38,6 +38,7 @@ import {
 	accountActionsCss,
 } from '#client/routes/account-management-components.tsx'
 import { renderAccountProfilePanel } from '#client/routes/account-profile-panel.tsx'
+import { AccountPasswordPanel } from '#client/routes/account-password-panel.tsx'
 import {
 	createAccountConnections,
 	readConnectionCallbackMessage,
@@ -684,19 +685,12 @@ export function AccountRoute(handle: Handle) {
 							onDraftEmailInput: updateDraftEmail,
 							onEmailChangePasswordInput: updateEmailChangePassword,
 						})}
-						<AccountManagementPanel
-							title="Security"
-							description="Protect your account with two-factor authentication, or sign in without a password using passkeys."
-						>
-							<div mix={css(accountActionsCss)}>
-								<a href="/account/two-factor" mix={css(compactGhostButtonCss)}>
-									Two-factor authentication
-								</a>
-								<a href="/account/passkeys" mix={css(compactGhostButtonCss)}>
-									Passkeys
-								</a>
-							</div>
-						</AccountManagementPanel>
+						<AccountPasswordPanel
+							hasUsablePassword={accountConnections.hasUsablePassword}
+							onPasswordSet={() => {
+								accountConnections.markHasUsablePassword()
+							}}
+						/>
 						{accountConnections.render()}
 						<AccountManagementPanel
 							title="Your data"

--- a/packages/worker/client/routes/discord.tsx
+++ b/packages/worker/client/routes/discord.tsx
@@ -8,8 +8,9 @@ import { ProviderIcon } from '#client/provider-icons.tsx'
 import { startSocialSignIn } from '#client/social-sign-in.ts'
 import { type RouteLoaderResult } from '#client/route-loader.ts'
 import { readJson } from '#client/routes/account-approval-shared.ts'
+import { renderHoneypot } from '#client/honeypot-field.tsx'
 import {
-	honeypotFieldName,
+	emptyPublicFormProtection,
 	readPublicFormProtection,
 	renderTurnstileWidgets,
 	resetTurnstileWidgets,
@@ -32,7 +33,6 @@ import {
 	pageHeaderCss,
 	pageTitleCss,
 	stackedPageCss,
-	visuallyHiddenCss,
 } from '#universal/styles/style-primitives.ts'
 import { buildAuthLink } from '#client/auth-links.ts'
 
@@ -130,7 +130,7 @@ export function DiscordRoute(handle: Handle) {
 			)
 			const protection =
 				page?.signedIn || !connectForm
-					? { website: '', turnstileToken: '' }
+					? emptyPublicFormProtection()
 					: readPublicFormProtection(new FormData(connectForm))
 			const errorMessage = await startSocialSignIn(
 				'discord',
@@ -358,14 +358,7 @@ export function DiscordRoute(handle: Handle) {
 								}),
 							]}
 						>
-							<input
-								type="text"
-								name={honeypotFieldName}
-								tabIndex={-1}
-								autoComplete="off"
-								aria-hidden="true"
-								mix={css(visuallyHiddenCss)}
-							/>
+							{renderHoneypot()}
 							{turnstileSiteKey ? (
 								<div class={turnstileWidgetClassName}></div>
 							) : null}

--- a/packages/worker/client/routes/landing-waitlist-form.tsx
+++ b/packages/worker/client/routes/landing-waitlist-form.tsx
@@ -2,8 +2,8 @@ import { type Handle, ref } from 'remix/ui'
 import { observeNearViewport } from '#client/deferred-turnstile.ts'
 import { on } from '#client/event-mixin.ts'
 import { fetchPublicAuthConfig } from '#client/social-sign-in.ts'
+import { renderHoneypot } from '#client/honeypot-field.tsx'
 import {
-	honeypotFieldName,
 	readPublicFormProtection,
 	renderTurnstileWidgets,
 	resetTurnstileWidgets,
@@ -177,14 +177,7 @@ export function WaitlistForm(handle: Handle) {
 				) : (
 					<>
 						<div data-focus-container class="landing-waitlist-fields">
-							<input
-								type="text"
-								name={honeypotFieldName}
-								tabIndex={-1}
-								autoComplete="off"
-								aria-hidden="true"
-								class="visually-hidden landing-honeypot"
-							/>
+							{renderHoneypot({ class: 'visually-hidden landing-honeypot' })}
 							<label for={`${handle.id}-name`} class="visually-hidden">
 								First name
 							</label>

--- a/packages/worker/client/routes/login-sections.tsx
+++ b/packages/worker/client/routes/login-sections.tsx
@@ -1,10 +1,8 @@
 import { css } from 'remix/ui'
 import { on } from '#client/event-mixin.ts'
 import { HeroStage } from '#client/hero-stage.tsx'
-import {
-	honeypotFieldName,
-	turnstileWidgetClassName,
-} from '#client/public-form-protection.ts'
+import { renderHoneypot } from '#client/honeypot-field.tsx'
+import { turnstileWidgetClassName } from '#client/public-form-protection.ts'
 import { colors, transitions, typography } from '#universal/styles/tokens.ts'
 import {
 	authFieldCss,
@@ -93,19 +91,6 @@ function renderStatusMessage(status: AuthStatus, message: string | null) {
 				{message ?? ''}
 			</p>
 		</>
-	)
-}
-
-export function renderHoneypot() {
-	return (
-		<input
-			type="text"
-			name={honeypotFieldName}
-			tabIndex={-1}
-			autoComplete="off"
-			aria-hidden="true"
-			mix={css(honeypotCss)}
-		/>
 	)
 }
 
@@ -556,11 +541,3 @@ const authSubmitCss = mergeCss(getPillButtonCss(), getSwapLabelCss(), {
 })
 
 export const ghostButtonCss = getGhostButtonCss()
-
-const honeypotCss = {
-	position: 'absolute' as const,
-	left: '-10000px',
-	width: '1px',
-	height: '1px',
-	overflow: 'hidden' as const,
-}

--- a/packages/worker/client/routes/login.tsx
+++ b/packages/worker/client/routes/login.tsx
@@ -24,6 +24,7 @@ import { fathomEventNames, trackFathomEvent } from '#client/fathom-events.ts'
 import { serializeFirstTouchAttributionForTransport } from '#universal/first-touch-attribution.ts'
 import { withAccountCreatedQuery } from '#universal/fathom-events.ts'
 import {
+	emptyPublicFormProtection,
 	readPublicFormProtection,
 	renderTurnstileWidgets,
 	resetTurnstileWidgets,
@@ -325,7 +326,7 @@ export function LoginRoute(handle: Handle) {
 			)
 			const protection = authForm
 				? readPublicFormProtection(new FormData(authForm))
-				: { website: '', turnstileToken: '' }
+				: emptyPublicFormProtection()
 			const errorMessage = await startSocialSignIn(
 				providerId,
 				getCurrentRedirectTo(handle),
@@ -381,7 +382,7 @@ export function LoginRoute(handle: Handle) {
 			)
 			const protection = authForm
 				? readPublicFormProtection(new FormData(authForm))
-				: { website: '', turnstileToken: '' }
+				: emptyPublicFormProtection()
 
 			const verificationResponse = await fetch('/webauthn/authentication', {
 				method: 'POST',

--- a/packages/worker/client/routes/oauth-authorize.tsx
+++ b/packages/worker/client/routes/oauth-authorize.tsx
@@ -8,10 +8,12 @@ import { consumeStaleNavigationData } from '#client/navigation-data.ts'
 import { readRouterSearch } from '#client/router-location.tsx'
 import { type RouteLoaderResult } from '#client/route-loader.ts'
 import { fetchPublicAuthConfig } from '#client/social-sign-in.ts'
+import { renderHoneypot } from '#client/honeypot-field.tsx'
 import {
 	honeypotFieldName,
 	readPublicFormProtection,
 	renderTurnstileWidgets,
+	turnstileResponseFieldName,
 	turnstileWidgetClassName,
 } from '#client/public-form-protection.ts'
 import {
@@ -315,8 +317,11 @@ export function OAuthAuthorizeRoute(handle: Handle) {
 				body.set('email', email)
 				body.set('password', password)
 				const protection = readPublicFormProtection(formData)
-				body.set('website', protection.website)
-				body.set('turnstileToken', protection.turnstileToken)
+				body.set(honeypotFieldName, protection[honeypotFieldName])
+				body.set(
+					turnstileResponseFieldName,
+					protection[turnstileResponseFieldName],
+				)
 			}
 			const response = await fetch(window.location.href, {
 				method: 'POST',
@@ -558,14 +563,7 @@ export function OAuthAuthorizeRoute(handle: Handle) {
 							on('submit', handleSubmit),
 						]}
 					>
-						<input
-							type="text"
-							name={honeypotFieldName}
-							tabIndex={-1}
-							autoComplete="off"
-							aria-hidden="true"
-							mix={css(honeypotCss)}
-						/>
+						{renderHoneypot()}
 						{!isLoggedIn && isSessionReady ? (
 							<>
 								<label mix={css(fieldCss)}>
@@ -634,17 +632,12 @@ const pageCss = {
 	margin: '0 auto',
 }
 
-const honeypotCss = {
-	position: 'absolute' as const,
-	left: '-10000px',
-	width: '1px',
-	height: '1px',
-	overflow: 'hidden' as const,
-}
-
 const headerCss = pageHeaderCss
 const eyebrowCss = pageEyebrowCss
-const primaryButtonCss = getPrimaryButtonCss({ size: 'lg', weight: 'semibold' })
+const primaryButtonCss = getPrimaryButtonCss({
+	size: 'lg',
+	weight: 'semibold',
+})
 const secondaryButtonCss = getSecondaryButtonCss({
 	size: 'lg',
 	weight: 'semibold',

--- a/packages/worker/client/routes/reset-password.tsx
+++ b/packages/worker/client/routes/reset-password.tsx
@@ -17,10 +17,11 @@ import {
 	stackedPageCss,
 } from '#universal/styles/style-primitives.ts'
 import { fetchPublicAuthConfig } from '#client/social-sign-in.ts'
+import { renderHoneypot } from '#client/honeypot-field.tsx'
 import {
-	honeypotFieldName,
 	readPublicFormProtection,
 	renderTurnstileWidgets,
+	resetTurnstileWidgets,
 	turnstileWidgetClassName,
 } from '#client/public-form-protection.ts'
 
@@ -41,6 +42,7 @@ export function ResetPasswordRoute(handle: Handle) {
 	) {
 		status = nextStatus
 		message = nextMessage
+		if (nextStatus === 'error') resetTurnstileWidgets()
 		handle.update()
 	}
 
@@ -68,7 +70,10 @@ export function ResetPasswordRoute(handle: Handle) {
 		try {
 			const response = await fetch('/password-reset', {
 				method: 'POST',
-				headers: { 'Content-Type': 'application/json' },
+				headers: {
+					Accept: 'application/json',
+					'Content-Type': 'application/json',
+				},
 				body: JSON.stringify({ email, ...protection }),
 			})
 			const payload = await response.json().catch(() => null)
@@ -105,7 +110,10 @@ export function ResetPasswordRoute(handle: Handle) {
 		try {
 			const response = await fetch('/password-reset/confirm', {
 				method: 'POST',
-				headers: { 'Content-Type': 'application/json' },
+				headers: {
+					Accept: 'application/json',
+					'Content-Type': 'application/json',
+				},
 				body: JSON.stringify({ token, password, ...protection }),
 			})
 			const payload = await response.json().catch(() => null)
@@ -161,14 +169,7 @@ export function ResetPasswordRoute(handle: Handle) {
 						),
 					]}
 				>
-					<input
-						type="text"
-						name={honeypotFieldName}
-						tabIndex={-1}
-						autoComplete="off"
-						aria-hidden="true"
-						mix={css(honeypotCss)}
-					/>
+					{renderHoneypot()}
 					{mode === 'confirm' ? (
 						<label mix={css(fieldCss)}>
 							<span mix={css(fieldLabelCss)}>New password</span>
@@ -241,12 +242,7 @@ const pageCss = {
 	margin: '0 auto',
 }
 
-const primaryButtonCss = getPrimaryButtonCss({ size: 'lg', weight: 'semibold' })
-
-const honeypotCss = {
-	position: 'absolute' as const,
-	left: '-10000px',
-	width: '1px',
-	height: '1px',
-	overflow: 'hidden' as const,
-}
+const primaryButtonCss = getPrimaryButtonCss({
+	size: 'lg',
+	weight: 'semibold',
+})

--- a/packages/worker/client/routes/verify.tsx
+++ b/packages/worker/client/routes/verify.tsx
@@ -16,10 +16,11 @@ import {
 	stackedPageCss,
 } from '#universal/styles/style-primitives.ts'
 import { fetchPublicAuthConfig } from '#client/social-sign-in.ts'
+import { renderHoneypot } from '#client/honeypot-field.tsx'
 import {
-	honeypotFieldName,
 	readPublicFormProtection,
 	renderTurnstileWidgets,
+	resetTurnstileWidgets,
 	turnstileWidgetClassName,
 } from '#client/public-form-protection.ts'
 
@@ -82,6 +83,7 @@ export function VerifyRoute(handle: Handle) {
 					typeof payload?.error === 'string'
 						? payload.error
 						: 'Unable to verify the code.'
+				resetTurnstileWidgets()
 				handle.update()
 				return
 			}
@@ -90,6 +92,7 @@ export function VerifyRoute(handle: Handle) {
 		} catch {
 			status = 'idle'
 			message = 'Network error. Please try again.'
+			resetTurnstileWidgets()
 			handle.update()
 		}
 	}
@@ -113,14 +116,7 @@ export function VerifyRoute(handle: Handle) {
 					</p>
 				</header>
 				<form mix={[css(cardCss), on('submit', handleSubmit)]}>
-					<input
-						type="text"
-						name={honeypotFieldName}
-						tabIndex={-1}
-						autoComplete="off"
-						aria-hidden="true"
-						mix={css(honeypotCss)}
-					/>
+					{renderHoneypot()}
 					<label mix={css(fieldCss)}>
 						<span mix={css(fieldLabelCss)}>Verification code</span>
 						<input
@@ -173,12 +169,7 @@ const pageCss = {
 	margin: '0 auto',
 }
 
-const primaryButtonCss = getPrimaryButtonCss({ size: 'lg', weight: 'semibold' })
-
-const honeypotCss = {
-	position: 'absolute' as const,
-	left: '-10000px',
-	width: '1px',
-	height: '1px',
-	overflow: 'hidden' as const,
-}
+const primaryButtonCss = getPrimaryButtonCss({
+	size: 'lg',
+	weight: 'semibold',
+})

--- a/packages/worker/client/social-sign-in.ts
+++ b/packages/worker/client/social-sign-in.ts
@@ -3,6 +3,10 @@ import {
 	appendAttributionQueryParams,
 	type FirstTouchAttribution,
 } from '#universal/first-touch-attribution.ts'
+import {
+	emptyPublicFormProtection,
+	type PublicFormProtectionFields,
+} from '#universal/public-form-protection.ts'
 
 export type AuthProviderInfo = { id: string; label: string }
 export type PublicAuthConfig = {
@@ -85,10 +89,7 @@ export async function startSocialSignIn(
 	providerId: string,
 	redirectTo: string | null,
 	inviteCode: string | null = null,
-	protection: { website: string; turnstileToken: string } = {
-		website: '',
-		turnstileToken: '',
-	},
+	protection: PublicFormProtectionFields = emptyPublicFormProtection(),
 	attribution: FirstTouchAttribution | null = null,
 ): Promise<string | null> {
 	const response = await fetch(

--- a/packages/worker/client/waitlist-banner.tsx
+++ b/packages/worker/client/waitlist-banner.tsx
@@ -9,8 +9,8 @@ import {
 } from '#universal/styles/style-primitives.ts'
 import { colors, transitions, typography } from '#universal/styles/tokens.ts'
 import { fetchPublicAuthConfig } from '#client/social-sign-in.ts'
+import { renderHoneypot } from '#client/honeypot-field.tsx'
 import {
-	honeypotFieldName,
 	readPublicFormProtection,
 	renderTurnstileWidgets,
 	resetTurnstileWidgets,
@@ -122,14 +122,7 @@ export function WaitlistBanner(handle: Handle) {
 								Join the waitlist for an invite.
 							</p>
 							<form mix={[css(formCss), on('submit', handleSubmit)]}>
-								<input
-									type="text"
-									name={honeypotFieldName}
-									tabIndex={-1}
-									autoComplete="off"
-									aria-hidden="true"
-									mix={css(honeypotCss)}
-								/>
+								{renderHoneypot()}
 								{/*
 								 * One connected pill, same grammar as the hero waitlist and
 								 * the community search. `data-focus-container` opts into the
@@ -378,9 +371,4 @@ const visuallyHiddenCss = {
 	clip: 'rect(0, 0, 0, 0)',
 	whiteSpace: 'nowrap' as const,
 	border: 0,
-}
-
-const honeypotCss = {
-	...visuallyHiddenCss,
-	left: '-10000px',
 }

--- a/packages/worker/src/app/apply-password-change.ts
+++ b/packages/worker/src/app/apply-password-change.ts
@@ -1,0 +1,100 @@
+import {
+	type AppDatabase,
+	passwordResetsTable,
+	usersTable,
+} from '#worker/db.ts'
+import { utcSqliteTimestamp } from '@kody-internal/shared/date-keys.ts'
+import { createPasswordHash } from '@kody-internal/shared/password-hash.ts'
+import {
+	type OAuthGrantHelpers,
+	revokeAllOAuthGrantsForUser,
+} from '#worker/oauth-grants.ts'
+
+export type ApplyPasswordChangeResult =
+	| { ok: true; changedAtMs: number }
+	| {
+			ok: false
+			reason: 'oauth_provider_unavailable'
+			stamped: false
+	  }
+	| {
+			ok: false
+			reason: 'oauth_grant_revoke_failed'
+			stamped: boolean
+			detail: string
+			changedAtMs?: number
+	  }
+
+/**
+ * Stamp a new password hash, revoke MCP grants around the stamp, and drop
+ * outstanding reset tokens. Callers map the result onto HTTP + audit events.
+ *
+ * Reset tokens stay until both revoke passes succeed so a retry remains
+ * safe. `changedAtMs` is millisecond-precision so a freshly issued session
+ * cookie can postdate `password_changed_at`.
+ */
+export async function applyPasswordChange(input: {
+	db: AppDatabase
+	helpers: OAuthGrantHelpers | undefined
+	userId: number
+	stableUserId: string
+	password: string
+}): Promise<ApplyPasswordChangeResult> {
+	if (!input.helpers) {
+		return { ok: false, reason: 'oauth_provider_unavailable', stamped: false }
+	}
+
+	const helpers = input.helpers
+	async function revoke(): Promise<string | null> {
+		try {
+			await revokeAllOAuthGrantsForUser({
+				helpers,
+				userId: input.stableUserId,
+			})
+			return null
+		} catch (error) {
+			return error instanceof Error
+				? error.message
+				: 'oauth_grant_revoke_failed'
+		}
+	}
+
+	// Revoke before stamping so a failed listing/revoke cannot leave refresh
+	// tokens alive after the user thinks lockout succeeded.
+	const beforeStampFailure = await revoke()
+	if (beforeStampFailure) {
+		return {
+			ok: false,
+			reason: 'oauth_grant_revoke_failed',
+			stamped: false,
+			detail: beforeStampFailure,
+		}
+	}
+
+	const changedAtMs = Date.now()
+	const passwordHash = await createPasswordHash(input.password)
+	await input.db.update(usersTable, input.userId, {
+		password_hash: passwordHash,
+		password_changed_at: new Date(changedAtMs).toISOString(),
+		updated_at: utcSqliteTimestamp(),
+	})
+
+	// Stamp, then revoke again so a grant created in that window is still
+	// collected.
+	const afterStampFailure = await revoke()
+	if (afterStampFailure) {
+		return {
+			ok: false,
+			reason: 'oauth_grant_revoke_failed',
+			stamped: true,
+			detail: afterStampFailure,
+			changedAtMs,
+		}
+	}
+
+	await input.db.deleteMany(passwordResetsTable, {
+		where: { user_id: input.userId },
+	})
+
+	return { ok: true, changedAtMs }
+}

--- a/packages/worker/src/app/handlers/account-password.node.test.ts
+++ b/packages/worker/src/app/handlers/account-password.node.test.ts
@@ -1,0 +1,325 @@
+import { quoteSqlString } from '@kody-internal/shared/sql-literals.ts'
+import { DatabaseSync } from 'node:sqlite'
+import { beforeAll, expect, test, vi } from 'vitest'
+import {
+	createAuthCookie,
+	readParsedAuthSession,
+	setAuthSessionSecret,
+	type AuthSession,
+} from '#app/auth-session.ts'
+import { createAccountPasswordHandler } from './account-password.ts'
+import { createStableUserIdFromEmail } from '#worker/user-id.ts'
+import {
+	createPasswordHash,
+	verifyPassword,
+} from '@kody-internal/shared/password-hash.ts'
+import { applyAllMigrations } from '#worker/test-support/apply-all-migrations.ts'
+import { createD1FromSqlite } from '#worker/test-support/create-d1-from-sqlite.ts'
+import { logAuditEventSpy } from '#worker/test-support/audit-log-spy.ts'
+import { testStableUserIdFromEmail } from '#worker/test-support/stable-user-id.ts'
+import { isCredentialInvalidatedByStoredPasswordChange } from '#worker/password-change-lockout.ts'
+
+const testCookieSecret = 'test-cookie-secret-0123456789abcdef0123456789'
+
+function createMigratedDb() {
+	const sqlite = new DatabaseSync(':memory:')
+	applyAllMigrations(sqlite, new URL('../../../migrations/', import.meta.url))
+	return {
+		sqlite,
+		db: createD1FromSqlite(sqlite),
+	}
+}
+
+async function seedUser(
+	sqlite: DatabaseSync,
+	input: {
+		id: number
+		email: string
+		username: string
+		password?: string
+		passwordHash?: string
+	},
+) {
+	const passwordHash =
+		input.passwordHash ?? (await createPasswordHash(input.password ?? ''))
+	const stableUserId = await createStableUserIdFromEmail(input.email)
+	sqlite.exec(`
+		INSERT INTO users (
+			id,
+			username,
+			email,
+			stable_user_id,
+			password_hash,
+			email_verified_at
+		) VALUES (
+			${input.id},
+			${quoteSqlString(input.username)},
+			${quoteSqlString(input.email)},
+			${quoteSqlString(stableUserId)},
+			${quoteSqlString(passwordHash)},
+			CURRENT_TIMESTAMP
+		);
+	`)
+	return stableUserId
+}
+
+function createTrackingGrantHelpers() {
+	const revokedGrantIds = new Array<string>()
+	return {
+		revokedGrantIds,
+		helpers: {
+			listUserGrants: vi.fn(async () => ({
+				items: revokedGrantIds.includes('grant-1')
+					? []
+					: [{ id: 'grant-1', clientId: 'client-a' }],
+			})),
+			revokeGrant: vi.fn(async (grantId: string) => {
+				revokedGrantIds.push(grantId)
+			}),
+		},
+	}
+}
+
+function createAppEnv(db: D1Database, overrides: Record<string, unknown> = {}) {
+	return {
+		APP_DB: db,
+		APP_BASE_URL: 'http://example.com',
+		COOKIE_SECRET: testCookieSecret,
+		SENTRY_ENVIRONMENT: 'test',
+		...overrides,
+	} as unknown as Env
+}
+
+async function createRequest(input: { session: AuthSession; body: unknown }) {
+	const cookie = await createAuthCookie(input.session, false)
+	return {
+		cookie,
+		request: new Request('http://example.com/account/password.json', {
+			method: 'POST',
+			headers: {
+				Cookie: cookie,
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify(input.body),
+		}),
+	}
+}
+
+async function runHandler(
+	handler: ReturnType<typeof createAccountPasswordHandler>,
+	request: Request,
+) {
+	return handler.handler({
+		request,
+		url: new URL(request.url),
+		params: {},
+	} as never)
+}
+
+beforeAll(() => {
+	setAuthSessionSecret(testCookieSecret)
+})
+
+test('signed-in password change requires the current password, revokes MCP grants, and keeps this session', async () => {
+	const { sqlite, db } = createMigratedDb()
+	const email = 'ada@example.com'
+	await seedUser(sqlite, {
+		id: 1,
+		email,
+		username: 'ada',
+		password: 'correct-password',
+	})
+	sqlite.exec(`
+		INSERT INTO password_resets (user_id, token_hash, expires_at)
+		VALUES (1, 'pending-reset', ${Date.now() + 60_000});
+	`)
+	const { helpers, revokedGrantIds } = createTrackingGrantHelpers()
+	const handler = createAccountPasswordHandler(
+		createAppEnv(db, { OAUTH_PROVIDER: helpers }),
+	)
+	const session = {
+		stableUserId: testStableUserIdFromEmail(email),
+		email,
+		rememberMe: true,
+	}
+
+	const unauthenticated = await handler.handler({
+		request: new Request('http://example.com/account/password.json', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				currentPassword: 'correct-password',
+				newPassword: 'brand-new-password',
+			}),
+		}),
+		url: new URL('http://example.com/account/password.json'),
+		params: {},
+	} as never)
+	expect(unauthenticated.status).toBe(401)
+
+	const wrongPassword = await runHandler(
+		handler,
+		(
+			await createRequest({
+				session,
+				body: {
+					currentPassword: 'wrong-password',
+					newPassword: 'brand-new-password',
+				},
+			})
+		).request,
+	)
+	expect(wrongPassword.status).toBe(401)
+	expect(await wrongPassword.json()).toEqual({
+		ok: false,
+		code: 'invalid_password',
+		error: 'Current password is incorrect.',
+	})
+
+	const weakPassword = await runHandler(
+		handler,
+		(
+			await createRequest({
+				session,
+				body: { currentPassword: 'correct-password', newPassword: 'short' },
+			})
+		).request,
+	)
+	expect(weakPassword.status).toBe(400)
+	expect(await weakPassword.json()).toMatchObject({
+		ok: false,
+		error: 'Password must be at least 8 characters.',
+	})
+
+	const samePassword = await runHandler(
+		handler,
+		(
+			await createRequest({
+				session,
+				body: {
+					currentPassword: 'correct-password',
+					newPassword: 'correct-password',
+				},
+			})
+		).request,
+	)
+	expect(samePassword.status).toBe(400)
+	expect(await samePassword.json()).toEqual({
+		ok: false,
+		error: 'Choose a different password.',
+	})
+
+	const { cookie: oldCookie, request } = await createRequest({
+		session,
+		body: {
+			currentPassword: 'correct-password',
+			newPassword: 'brand-new-password',
+		},
+	})
+	const oldSession = await readParsedAuthSession(
+		new Request('http://example.com/account', {
+			headers: { Cookie: oldCookie },
+		}),
+	)
+	const response = await runHandler(handler, request)
+	expect(response.status).toBe(200)
+	const payload = (await response.json()) as {
+		ok: boolean
+		message: string
+	}
+	expect(payload.ok).toBe(true)
+	expect(payload.message).toContain('Password updated.')
+	expect(revokedGrantIds).toEqual(['grant-1'])
+	expect(
+		sqlite.prepare(`SELECT COUNT(*) AS count FROM password_resets`).get(),
+	).toEqual({ count: 0 })
+
+	const row = sqlite
+		.prepare(
+			`SELECT password_hash, password_changed_at FROM users WHERE id = 1`,
+		)
+		.get() as { password_hash: string; password_changed_at: string }
+	expect(await verifyPassword('brand-new-password', row.password_hash)).toBe(
+		true,
+	)
+	expect(await verifyPassword('correct-password', row.password_hash)).toBe(
+		false,
+	)
+
+	const setCookie = response.headers.get('Set-Cookie')
+	expect(setCookie).toContain('kody_session=')
+	const newSession = await readParsedAuthSession(
+		new Request('http://example.com/account', {
+			headers: { Cookie: setCookie?.split(';', 1)[0] ?? '' },
+		}),
+	)
+	expect(newSession?.session.rememberMe).toBe(true)
+	expect(
+		isCredentialInvalidatedByStoredPasswordChange({
+			issuedAtMs: oldSession?.issuedAt,
+			storedPasswordChangedAt: row.password_changed_at,
+		}),
+	).toBe(true)
+	expect(
+		isCredentialInvalidatedByStoredPasswordChange({
+			issuedAtMs: newSession?.issuedAt,
+			storedPasswordChangedAt: row.password_changed_at,
+		}),
+	).toBe(false)
+	expect(logAuditEventSpy).toHaveBeenCalledWith(
+		expect.objectContaining({
+			category: 'auth',
+			action: 'password_change',
+			result: 'success',
+		}),
+	)
+})
+
+test('oauth-only accounts can set a first password without a current password', async () => {
+	const { sqlite, db } = createMigratedDb()
+	const email = 'oauth@example.com'
+	await seedUser(sqlite, {
+		id: 2,
+		email,
+		username: 'oauth-user',
+		passwordHash: 'oauth_created_no_usable_password',
+	})
+	const { helpers } = createTrackingGrantHelpers()
+	const handler = createAccountPasswordHandler(
+		createAppEnv(db, { OAUTH_PROVIDER: helpers }),
+	)
+	const session = {
+		stableUserId: testStableUserIdFromEmail(email),
+		email,
+		rememberMe: false,
+	}
+
+	const missingNewPassword = await runHandler(
+		handler,
+		(
+			await createRequest({
+				session,
+				body: {},
+			})
+		).request,
+	)
+	expect(missingNewPassword.status).toBe(400)
+
+	const response = await runHandler(
+		handler,
+		(
+			await createRequest({
+				session,
+				body: { newPassword: 'first-password-ok' },
+			})
+		).request,
+	)
+	expect(response.status).toBe(200)
+	const row = sqlite
+		.prepare(`SELECT password_hash FROM users WHERE id = 2`)
+		.get() as { password_hash: string }
+	expect(await verifyPassword('first-password-ok', row.password_hash)).toBe(
+		true,
+	)
+	expect(response.headers.get('Set-Cookie')).toContain('kody_session=')
+})

--- a/packages/worker/src/app/handlers/account-password.ts
+++ b/packages/worker/src/app/handlers/account-password.ts
@@ -1,0 +1,283 @@
+import { jsonResponse } from '#worker/json-response.ts'
+import { type Action } from 'remix/router'
+import { object, optional, parseSafe, string } from 'remix/data-schema'
+import {
+	applyPasswordChange,
+	type ApplyPasswordChangeResult,
+} from '#app/apply-password-change.ts'
+import {
+	createAuthCookie,
+	isSecureRequest,
+	readParsedAuthSession,
+} from '#app/auth-session.ts'
+import { readAuthenticatedAppUser } from '#app/authenticated-user.ts'
+import { checkRateLimit } from '#app/rate-limit.ts'
+import { getRequestIp, logAuditEvent } from '#worker/audit-log.ts'
+import { createDb, usersTable } from '#worker/db.ts'
+import { isUsablePasswordHash } from '#worker/identity/usable-password.ts'
+import { type OAuthGrantHelpers } from '#worker/oauth-grants.ts'
+import { type routes } from '#universal/routes.ts'
+import { resolveUserStableId } from '#worker/user-id.ts'
+import { verifyPassword } from '@kody-internal/shared/password-hash.ts'
+import { getPasswordPolicyError } from '@kody-internal/shared/password-policy.ts'
+
+const passwordChangeRateLimitConfig = {
+	maxRequests: 5,
+	windowSeconds: 15 * 60,
+}
+
+const passwordChangeRequestSchema = object({
+	currentPassword: optional(string()),
+	newPassword: string(),
+})
+
+function applyFailureReason(
+	result: Extract<ApplyPasswordChangeResult, { ok: false }>,
+) {
+	switch (result.reason) {
+		case 'oauth_provider_unavailable':
+			return result.reason
+		case 'oauth_grant_revoke_failed':
+			return result.detail
+		default: {
+			const unreachable: never = result
+			return unreachable
+		}
+	}
+}
+
+function passwordChangeIssuedAt(result: ApplyPasswordChangeResult) {
+	if (result.ok) return result.changedAtMs + 1
+	if (
+		result.reason === 'oauth_grant_revoke_failed' &&
+		result.changedAtMs != null
+	) {
+		return result.changedAtMs + 1
+	}
+	return Date.now()
+}
+
+export function createAccountPasswordHandler(env: Env) {
+	const db = createDb(env.APP_DB)
+
+	return {
+		middleware: [],
+		async handler({ request, url }) {
+			const user = await readAuthenticatedAppUser(request, env)
+			if (!user) {
+				return jsonResponse({ ok: false, error: 'Unauthorized.' }, 401)
+			}
+
+			let body: unknown
+			try {
+				body = await request.json()
+			} catch {
+				return jsonResponse({ ok: false, error: 'Invalid JSON payload.' }, 400)
+			}
+
+			const parsed = parseSafe(passwordChangeRequestSchema, body)
+			const requestIp = getRequestIp(request) ?? undefined
+			const currentPassword = parsed.success
+				? (parsed.value.currentPassword ?? '')
+				: ''
+			const newPassword = parsed.success ? parsed.value.newPassword : ''
+
+			if (!parsed.success || !newPassword) {
+				void logAuditEvent({
+					category: 'auth',
+					action: 'password_change',
+					result: 'failure',
+					email: user.email,
+					ip: requestIp,
+					path: url.pathname,
+					reason: 'invalid_payload',
+				})
+				return jsonResponse(
+					{ ok: false, error: 'New password is required.' },
+					400,
+				)
+			}
+
+			const passwordError = getPasswordPolicyError(newPassword)
+			if (passwordError) {
+				void logAuditEvent({
+					category: 'auth',
+					action: 'password_change',
+					result: 'failure',
+					email: user.email,
+					ip: requestIp,
+					path: url.pathname,
+					reason: 'weak_password',
+				})
+				return jsonResponse({ ok: false, error: passwordError }, 400)
+			}
+
+			const userRecord = await db.findOne(usersTable, {
+				where: { id: user.userId },
+			})
+			if (!userRecord) {
+				return jsonResponse({ ok: false, error: 'Unauthorized.' }, 401)
+			}
+
+			const rateLimitKey = `password-change:user:${user.userId}`
+			const rateLimit = await checkRateLimit(
+				env.APP_DB,
+				rateLimitKey,
+				passwordChangeRateLimitConfig,
+			)
+			if (!rateLimit.allowed) {
+				void logAuditEvent({
+					category: 'auth',
+					action: 'password_change',
+					result: 'rate_limited',
+					email: user.email,
+					ip: requestIp,
+					path: url.pathname,
+				})
+				return jsonResponse(
+					{
+						ok: false,
+						error: 'Too many password change attempts. Please try again later.',
+					},
+					{
+						status: 429,
+						headers: {
+							'Retry-After': String(rateLimit.retryAfterSeconds ?? 60),
+						},
+					},
+				)
+			}
+
+			const hasUsablePassword = isUsablePasswordHash(userRecord.password_hash)
+			if (hasUsablePassword) {
+				if (!currentPassword) {
+					void logAuditEvent({
+						category: 'auth',
+						action: 'password_change',
+						result: 'failure',
+						email: user.email,
+						ip: requestIp,
+						path: url.pathname,
+						reason: 'missing_current_password',
+					})
+					return jsonResponse(
+						{ ok: false, error: 'Current password is required.' },
+						400,
+					)
+				}
+				const passwordValid = await verifyPassword(
+					currentPassword,
+					userRecord.password_hash,
+				)
+				if (!passwordValid) {
+					void logAuditEvent({
+						category: 'auth',
+						action: 'password_change',
+						result: 'failure',
+						email: user.email,
+						ip: requestIp,
+						path: url.pathname,
+						reason: 'invalid_password',
+					})
+					return jsonResponse(
+						{
+							ok: false,
+							code: 'invalid_password',
+							error: 'Current password is incorrect.',
+						},
+						401,
+					)
+				}
+				if (currentPassword === newPassword) {
+					void logAuditEvent({
+						category: 'auth',
+						action: 'password_change',
+						result: 'failure',
+						email: user.email,
+						ip: requestIp,
+						path: url.pathname,
+						reason: 'same_password',
+					})
+					return jsonResponse(
+						{ ok: false, error: 'Choose a different password.' },
+						400,
+					)
+				}
+			}
+
+			const helpers = (env as Env & { OAUTH_PROVIDER?: OAuthGrantHelpers })
+				.OAUTH_PROVIDER
+			const result = await applyPasswordChange({
+				db,
+				helpers,
+				userId: user.userId,
+				stableUserId: resolveUserStableId(userRecord),
+				password: newPassword,
+			})
+
+			const sessionUserId = user.sessionUserId
+			const sessionEmail = user.email
+			async function sessionCookieForChange() {
+				const parsedSession = await readParsedAuthSession(request)
+				return createAuthCookie(
+					{
+						stableUserId: sessionUserId,
+						email: sessionEmail,
+						rememberMe: parsedSession?.session.rememberMe ?? false,
+					},
+					isSecureRequest(request),
+					passwordChangeIssuedAt(result),
+				)
+			}
+
+			if (!result.ok) {
+				void logAuditEvent({
+					category: 'auth',
+					action: 'password_change',
+					result: 'failure',
+					email: user.email,
+					ip: requestIp,
+					path: url.pathname,
+					reason: applyFailureReason(result),
+				})
+				if (!result.stamped) {
+					return jsonResponse(
+						{
+							ok: false,
+							error: 'Unable to update your password right now.',
+						},
+						500,
+					)
+				}
+				return jsonResponse(
+					{
+						ok: false,
+						error: 'Unable to update your password right now.',
+					},
+					{
+						status: 500,
+						headers: { 'Set-Cookie': await sessionCookieForChange() },
+					},
+				)
+			}
+
+			void logAuditEvent({
+				category: 'auth',
+				action: 'password_change',
+				result: 'success',
+				email: user.email,
+				ip: requestIp,
+				path: url.pathname,
+			})
+			return jsonResponse(
+				{
+					ok: true,
+					message: hasUsablePassword
+						? 'Password updated. Other sessions and connected MCP hosts need to sign in again.'
+						: 'Password saved. You can sign in with email and password, and other sessions and connected MCP hosts need to sign in again.',
+				},
+				{ headers: { 'Set-Cookie': await sessionCookieForChange() } },
+			)
+		},
+	} satisfies Action<typeof routes.accountPassword>
+}

--- a/packages/worker/src/app/handlers/auth-provider.node.test.ts
+++ b/packages/worker/src/app/handlers/auth-provider.node.test.ts
@@ -28,6 +28,7 @@ import {
 	logAuditEventSpy,
 } from '#worker/test-support/audit-log-spy.ts'
 import { applyAllMigrations } from '#worker/test-support/apply-all-migrations.ts'
+import { emptyPublicFormProtection } from '#universal/public-form-protection.ts'
 
 const testCookieSecret = 'test-cookie-secret-0123456789abcdef0123456789'
 
@@ -877,7 +878,7 @@ test('JSON start consumes the request body for signed-out and signed-in requests
 			Accept: 'application/json',
 			'Content-Type': 'application/json',
 		},
-		body: JSON.stringify({ website: '', turnstileToken: '' }),
+		body: JSON.stringify(emptyPublicFormProtection()),
 	})
 
 	expect(signedOutRequest.bodyUsed).toBe(false)
@@ -916,7 +917,7 @@ test('JSON start consumes the request body for signed-out and signed-in requests
 			'Content-Type': 'application/json',
 			Cookie: sessionCookiePair,
 		},
-		body: JSON.stringify({ website: '', turnstileToken: '' }),
+		body: JSON.stringify(emptyPublicFormProtection()),
 	})
 	expect(signedInRequest.bodyUsed).toBe(false)
 	const signedInResponse = await runHandler(

--- a/packages/worker/src/app/handlers/password-reset.node.test.ts
+++ b/packages/worker/src/app/handlers/password-reset.node.test.ts
@@ -1,6 +1,7 @@
 import { expect, test, vi } from 'vitest'
 import { logAuditEventSpy } from '#worker/test-support/audit-log-spy.ts'
 import type * as AuditLog from '#worker/audit-log.ts'
+import { honeypotFieldName } from '#universal/public-form-protection.ts'
 
 const mockModule = vi.hoisted(() => ({
 	createRecord: vi.fn(async () => undefined),
@@ -117,6 +118,48 @@ function createResetRequest() {
 }
 
 const hexTokenPattern = /[0-9a-f]{64}/i
+
+test('password reset request ignores leftover website autofill and rejects the honeypot', async () => {
+	vi.clearAllMocks()
+	const handler = createPasswordResetRequestHandler(
+		createEnv({
+			APP_BASE_URL: 'https://kody.codes',
+			SYSTEM_EMAIL_DOMAIN: 'kody.codes',
+		}),
+	)
+
+	const autofilledWebsite = await requestResetAndFlush(handler, {
+		request: new Request('https://kody.codes/password-reset', {
+			method: 'POST',
+			body: JSON.stringify({
+				email: 'user@example.com',
+				website: 'https://kody.codes',
+			}),
+		}),
+		url: new URL('https://kody.codes/password-reset'),
+	})
+	expect(autofilledWebsite.response.status).toBe(200)
+	expect(await autofilledWebsite.response.json()).toEqual({
+		ok: true,
+		message: 'If the account exists, a reset email has been sent.',
+	})
+	await autofilledWebsite.flush()
+
+	const filledHoneypot = await requestResetAndFlush(handler, {
+		request: new Request('https://kody.codes/password-reset', {
+			method: 'POST',
+			body: JSON.stringify({
+				email: 'user@example.com',
+				[honeypotFieldName]: 'https://spam.example',
+			}),
+		}),
+		url: new URL('https://kody.codes/password-reset'),
+	})
+	expect(filledHoneypot.response.status).toBe(400)
+	expect(await filledHoneypot.response.json()).toEqual({
+		error: 'Unable to submit this form.',
+	})
+})
 
 test('password reset keeps local action links on the request origin', async () => {
 	vi.clearAllMocks()

--- a/packages/worker/src/app/handlers/password-reset.ts
+++ b/packages/worker/src/app/handlers/password-reset.ts
@@ -15,16 +15,12 @@ import {
 	passwordResetTokenExpiryMs,
 } from '#worker/identity/password-reset-tokens.ts'
 import { type routes } from '#universal/routes.ts'
-import { utcSqliteTimestamp } from '@kody-internal/shared/date-keys.ts'
-import { createPasswordHash } from '@kody-internal/shared/password-hash.ts'
+import { applyPasswordChange } from '#app/apply-password-change.ts'
 import { getPasswordPolicyError } from '@kody-internal/shared/password-policy.ts'
 import { verifyPublicFormProtection } from '#app/public-form-protection.ts'
 import { buildPasswordResetEmail } from '#app/email/messages.ts'
 import { resolveTransactionalEmailConfig } from '#app/email/sender-config.ts'
-import {
-	type OAuthGrantHelpers,
-	revokeAllOAuthGrantsForUser,
-} from '#worker/oauth-grants.ts'
+import { type OAuthGrantHelpers } from '#worker/oauth-grants.ts'
 import { resolveUserStableId } from '#worker/user-id.ts'
 
 const resetRequestSchema = object({
@@ -283,72 +279,30 @@ export function createPasswordResetConfirmHandler(env: Env) {
 
 			const helpers = (env as Env & { OAUTH_PROVIDER?: OAuthGrantHelpers })
 				.OAUTH_PROVIDER
-			if (!helpers) {
+			const result = await applyPasswordChange({
+				db,
+				helpers,
+				userId: resetRecord.user_id,
+				stableUserId: resolveUserStableId(userRecord),
+				password,
+			})
+			if (!result.ok) {
 				void logAuditEvent({
 					category: 'auth',
 					action: 'password_reset_confirm',
 					result: 'failure',
 					ip: requestIp,
 					path: url.pathname,
-					reason: 'oauth_provider_unavailable',
+					reason:
+						result.reason === 'oauth_grant_revoke_failed'
+							? result.detail
+							: result.reason,
 				})
 				return Response.json(
 					{ error: 'Unable to finish password reset right now.' },
 					{ status: 500 },
 				)
 			}
-
-			const stableUserId = resolveUserStableId(userRecord)
-			const oauthHelpers = helpers
-			async function revokeGrantsOrFail() {
-				try {
-					await revokeAllOAuthGrantsForUser({
-						helpers: oauthHelpers,
-						userId: stableUserId,
-					})
-					return null
-				} catch (error) {
-					void logAuditEvent({
-						category: 'auth',
-						action: 'password_reset_confirm',
-						result: 'failure',
-						ip: requestIp,
-						path: url.pathname,
-						reason:
-							error instanceof Error
-								? error.message
-								: 'oauth_grant_revoke_failed',
-					})
-					return Response.json(
-						{ error: 'Unable to finish password reset right now.' },
-						{ status: 500 },
-					)
-				}
-			}
-
-			// Revoke before stamping so a failed listing/revoke cannot leave
-			// refresh tokens alive after the user thinks lockout succeeded.
-			// Stamp, then revoke again so a grant created in that window is
-			// still collected. Reset tokens stay until the second pass
-			// succeeds so retry remains safe.
-			const beforeStampFailure = await revokeGrantsOrFail()
-			if (beforeStampFailure) return beforeStampFailure
-
-			const passwordHash = await createPasswordHash(password)
-			// Millisecond ISO so same-second re-login after reset is not
-			// invalidated by second-truncated CURRENT_TIMESTAMP-style values.
-			await db.update(usersTable, resetRecord.user_id, {
-				password_hash: passwordHash,
-				password_changed_at: new Date().toISOString(),
-				updated_at: utcSqliteTimestamp(),
-			})
-
-			const afterStampFailure = await revokeGrantsOrFail()
-			if (afterStampFailure) return afterStampFailure
-
-			await db.deleteMany(passwordResetsTable, {
-				where: { user_id: resetRecord.user_id },
-			})
 
 			void logAuditEvent({
 				category: 'auth',

--- a/packages/worker/src/app/public-form-protection.node.test.ts
+++ b/packages/worker/src/app/public-form-protection.node.test.ts
@@ -1,6 +1,7 @@
 import { expect, test, vi } from 'vitest'
 import {
 	getTurnstileSiteKey,
+	honeypotFieldName,
 	verifyPublicFormProtection,
 } from '#app/public-form-protection.ts'
 import { getSignupMode } from '#universal/signup-mode.ts'
@@ -33,11 +34,22 @@ test('public form protection defaults closed, rejects honeypots, and verifies Tu
 	const honeypot = await verifyPublicFormProtection({
 		env: {},
 		request,
-		body: { website: 'https://spam.example' },
+		body: { [honeypotFieldName]: 'https://spam.example' },
 	})
 	expect(honeypot.ok).toBe(false)
 	if (honeypot.ok) throw new Error('Expected honeypot rejection.')
 	expect(honeypot.response.status).toBe(400)
+	expect(await honeypot.response.json()).toEqual({
+		error: 'Unable to submit this form.',
+	})
+
+	await expect(
+		verifyPublicFormProtection({
+			env: {},
+			request,
+			body: { website: 'https://kody.codes' },
+		}),
+	).resolves.toEqual({ ok: true })
 
 	const fetchSpy = vi.fn(async (_url: string, init: RequestInit) => {
 		expect(init.method).toBe('POST')
@@ -66,6 +78,9 @@ test('public form protection defaults closed, rejects honeypots, and verifies Tu
 		expect(missing.ok).toBe(false)
 		if (missing.ok) throw new Error('Expected missing-token rejection.')
 		expect(missing.response.status).toBe(400)
+		expect(await missing.response.json()).toEqual({
+			error: 'Please complete the human verification challenge.',
+		})
 		expect(fetchSpy).not.toHaveBeenCalled()
 
 		await expect(

--- a/packages/worker/src/app/public-form-protection.ts
+++ b/packages/worker/src/app/public-form-protection.ts
@@ -1,7 +1,10 @@
 import { getRequestIp } from '#worker/audit-log.ts'
+import {
+	honeypotFieldName,
+	turnstileResponseFieldName,
+} from '#universal/public-form-protection.ts'
 
-export const honeypotFieldName = 'website'
-export const turnstileResponseFieldName = 'turnstileToken'
+export { honeypotFieldName, turnstileResponseFieldName }
 
 type PublicFormBody = Record<string, unknown>
 

--- a/packages/worker/src/app/router.ts
+++ b/packages/worker/src/app/router.ts
@@ -50,6 +50,7 @@ import {
 	createAccountEmailHandler,
 } from '#app/handlers/account-email.ts'
 import { createAccountEmailChangeHandler } from '#app/handlers/account-email-change.ts'
+import { createAccountPasswordHandler } from '#app/handlers/account-password.ts'
 import { createAccountExportHandler } from '#app/handlers/account-export.ts'
 import {
 	createAccountIntegrationsApiHandler,
@@ -369,6 +370,7 @@ export function createAppRouter(env: Env) {
 			accountUsage: createAccountUsageHandler(env),
 			accountUsageApi: createAccountUsageApiHandler(env),
 			accountEmailChange: createAccountEmailChangeHandler(env),
+			accountPassword: createAccountPasswordHandler(env),
 			accountResendVerification: createAccountResendVerificationHandler(env),
 			accountSecrets: createAccountSecretsHandler(env),
 			accountSecretNew: createAccountSecretsHandler(env),

--- a/packages/worker/src/origin-handler.ts
+++ b/packages/worker/src/origin-handler.ts
@@ -92,6 +92,7 @@ const rateLimitedAuthPaths = new Set([
 	'/password-reset/confirm',
 	'/verify/2fa.json',
 	'/account/two-factor.json',
+	'/account/password.json',
 	'/webauthn/authentication',
 ])
 

--- a/packages/worker/universal/public-form-protection.ts
+++ b/packages/worker/universal/public-form-protection.ts
@@ -1,0 +1,20 @@
+/**
+ * Hidden trap field on public auth forms. The name must not match HTML
+ * autocomplete tokens (`website`, `url`, `email`, …) or password-manager
+ * login fields — those get filled for real users and then fail closed with
+ * a generic error.
+ */
+export const honeypotFieldName = 'kody_hp' as const
+export const turnstileResponseFieldName = 'turnstileToken' as const
+
+export type PublicFormProtectionFields = {
+	[honeypotFieldName]: string
+	[turnstileResponseFieldName]: string
+}
+
+export function emptyPublicFormProtection(): PublicFormProtectionFields {
+	return {
+		[honeypotFieldName]: '',
+		[turnstileResponseFieldName]: '',
+	}
+}

--- a/packages/worker/universal/routes.ts
+++ b/packages/worker/universal/routes.ts
@@ -97,6 +97,7 @@ export const routes = route({
 	accountUsage: '/account/usage',
 	accountUsageApi: '/account/usage.json',
 	accountEmailChange: post('/account/email-change.json'),
+	accountPassword: post('/account/password.json'),
 	accountResendVerification: post('/account/resend-verification.json'),
 	accountExport: '/account/export.json',
 	admin: '/admin',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Let signed-in users change (or set) a password from Account, and make password reset succeed for real people instead of failing with a generic form error.

## Why

There was no in-account password change. Reset looked broken because the public-form honeypot was named `website`, so password managers autofilled the saved login URL and the server treated that as a bot (`Unable to submit this form.`).

## Summary

- Add `POST /account/password.json` and a Security panel on `/account` (change password, or set a first password on OAuth/passkey accounts).
- Share grant-revoke + `password_changed_at` lockout with reset confirmation via `applyPasswordChange`; re-issue this browser's `kody_session`.
- Rename the public honeypot to `kody_hp`, ignore leftover `website` autofill, and reset Turnstile after a failed submit.

## Testing

- `vitest` node-unit: account-password, password-reset (including leftover `website` still 200 / filled `kody_hp` still generic 400), public-form-protection
- Pre-push: `test:node` 2276 passed, `test:workers` 312 passed
- Local/browser verification of `/reset-password` and `/account` password form follows in this run

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `2bfaefc6` · **Head:** `0ad2e146`

**Classification:** extends — new signed-in password change on `app-ui`, and the public-form honeypot contract changes so reset (and other public auth forms) no longer fail closed on password-manager autofill.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `app-ui` | surfaces | extends — `/account` Security panel, `POST /account/password.json`, honeypot field `kody_hp` |

Unmatched paths: `packages/worker/src/origin-handler.ts` adds `/account/password.json` to the existing auth rate-limit bucket (composes). Shared password-policy comment and auth docs follow the new path.

### Change flow

Reset request no longer treats a leftover `website` value as a bot. Signed-in password change stamps the same lockout as reset, then re-issues this tab's session cookie.

```mermaid
sequenceDiagram
	actor User
	participant appUi as app-ui
	participant d1AppDb as d1-app-db
	User->>appUi: POST /password-reset (email + kody_hp)
	Note over appUi: leftover website autofill is ignored
	appUi->>d1AppDb: lookup user, defer reset token + email
	appUi-->>User: 200 If the account exists, a reset email has been sent.
	User->>appUi: POST /account/password.json
	appUi->>d1AppDb: verify current password, stamp hash + password_changed_at
	appUi->>appUi: revoke MCP grants around the stamp
	appUi-->>User: Set-Cookie kody_session issuedAt after password_changed_at
```

### Invariants

Password change and reset still fail closed for other sessions and MCP tokens at `users.password_changed_at`. This browser stays signed in only because the new cookie's `issuedAt` postdates that stamp.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c7b788e3-a9f7-4870-9b25-6003fb5c9444?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c7b788e3-a9f7-4870-9b25-6003fb5c9444&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

