### PR TITLE
Add tighten-only integration_lock and secret_lock for agents

### DIFF
--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -1252,10 +1252,11 @@ on write unless a migration backfills existing rows.
   `forker_user_id`; index in `0001-squashed-init.sql`). Self-authored packages
   and adopted forks (`community_forks.adopted_at` / `adoption_note`) skip that
   grant for read/use only. Mutations from package code (`secret_set` /
-  `secret_delete`) always require the grant. Official OAuth token rotation
-  persists host-side and does not use that write grant. Authorship and adoption
-  never imply a host allowlist. Package-scoped secrets are owned exclusively by
-  the package id in their bucket binding.
+  `secret_delete`) always require the grant. Agents add a package to that grant
+  with `secret_lock`; removing a grant is website-only. Official OAuth token
+  rotation persists host-side and does not use that write grant. Authorship and
+  adoption never imply a host allowlist. Package-scoped secrets are owned
+  exclusively by the package id in their bucket binding.
 - `user_oauth_apps.extra_authorize_params_json`,
   `user_integrations.scopes_json`, `user_integrations.required_hosts_json`, and
   `user_integrations.allowed_packages_json` (`0001-squashed-init.sql` /

--- a/docs/contributing/architecture/integrations.md
+++ b/docs/contributing/architecture/integrations.md
@@ -297,7 +297,9 @@ highlight that connection. User-registered integrations also have
 `/account/integrations/apps`). Endpoints, secret names, host allowlists, flow /
 PKCE / exchange style, and credential rotation stay behind an advanced
 disclosure. Each connection also shows a usage grant: **any context** (execute
-and every package) or **specific packages** only. One-click approval lives at
+and every package) or **specific packages** only. Agents tighten that grant with
+`integration_lock` (switch to packages mode and add a saved package id;
+unlocking or removing a grant is website-only). One-click approval lives at
 `/account/integrations/approve?name=&package_id=`; approving a package while the
 connection is still `any` leaves it `any` so execute stays usable. The rotate
 form posts to `/account/integrations.json` with
@@ -317,17 +319,18 @@ connections instead.
 Domain: `integrations`
 (`packages/worker/src/mcp/capabilities/integrations/domain.ts`).
 
-| Capability                                             | Role                                                                           |
-| ------------------------------------------------------ | ------------------------------------------------------------------------------ |
-| `integration_save` / `_get` / `_list` / `_delete`      | Connection CRUD with flat `clientId` output                                    |
-| `integration_oauth_app_list`                           | Apps with connection counts and sibling connection names                       |
-| `integration_oauth_app_delete`                         | Delete a user-lane app and every connection on it                              |
-| `integration_oauth_app_rotate_credentials`             | Rotate shared app `clientId` / client-secret name                              |
-| `integration_platform_app_list`                        | Enabled platform (built-in) apps; public projection, never any secret          |
-| `integration_token_refresh`                            | Host-side OAuth refresh; returns metadata only, never token values             |
-| `integration_refresh_access_token`                     | User-lane host refresh plus materialized access token for `refreshAccessToken` |
-| `integration_registry_search` / `integration_discover` | Untrusted integrations.sh research                                             |
-| `openapi_spec_summarize` / `openapi_client_scaffold`   | Spec research helpers (bindings live in the `openapi` domain)                  |
+| Capability                                             | Role                                                                              |
+| ------------------------------------------------------ | --------------------------------------------------------------------------------- |
+| `integration_save` / `_get` / `_list` / `_delete`      | Connection CRUD with flat `clientId` output                                       |
+| `integration_lock`                                     | Tighten-only usage lock: packages mode + add a package id; unlock is website-only |
+| `integration_oauth_app_list`                           | Apps with connection counts and sibling connection names                          |
+| `integration_oauth_app_delete`                         | Delete a user-lane app and every connection on it                                 |
+| `integration_oauth_app_rotate_credentials`             | Rotate shared app `clientId` / client-secret name                                 |
+| `integration_platform_app_list`                        | Enabled platform (built-in) apps; public projection, never any secret             |
+| `integration_token_refresh`                            | Host-side OAuth refresh; returns metadata only, never token values                |
+| `integration_refresh_access_token`                     | User-lane host refresh plus materialized access token for `refreshAccessToken`    |
+| `integration_registry_search` / `integration_discover` | Untrusted integrations.sh research                                                |
+| `openapi_spec_summarize` / `openapi_client_scaffold`   | Spec research helpers (bindings live in the `openapi` domain)                     |
 
 OpenAPI provider bindings (`user_openapi_bindings` /
 `user_openapi_binding_operations`) are a separate primitive; see

--- a/docs/contributing/architecture/mcp-client-servers.md
+++ b/docs/contributing/architecture/mcp-client-servers.md
@@ -134,7 +134,8 @@ fetch `{canonical-app-origin}/oauth/client-metadata.json`; that document's
   `mcp_server_list`, `mcp_server_reconnect`, `mcp_server_refresh`,
   `mcp_server_remove`, `mcp_server_set_enabled`, `mcp_server_lock`).
   `mcp_server_add` accepts optional `bearerToken`. `mcp_server_lock` grants a
-  package; unlock is website-only.
+  package; unlock is website-only. Integration connections and user secrets use
+  the same tighten-only shape (`integration_lock`, `secret_lock`).
 
 ## Isolation and lifecycle
 

--- a/docs/guides/account-secret-setup.md
+++ b/docs/guides/account-secret-setup.md
@@ -62,10 +62,11 @@ so the user can paste immediately.
 
 Self-authored packages and adopted community forks (`community_fork_adopt`) can
 read and use the user's secrets without an `allowed_packages` grant; updating or
-deleting a user secret from package code still requires that grant. When an
-**unadopted community-forked** package needs access to one or more **existing**
-user secrets, either adopt it after reviewing the source or send the user an
-approval link — do not ask them to recreate the secrets.
+deleting a user secret from package code still requires that grant. Agents can
+add a package to that grant with `secret_lock`; removing a grant is
+website-only. When an **unadopted community-forked** package needs access to one
+or more **existing** user secrets, either adopt it after reviewing the source or
+send the user an approval link — do not ask them to recreate the secrets.
 
 - Single secret:
   `/account/secrets/user/{secretName}?package_id={savedPackageId}&package={kodyId}`

--- a/docs/guides/locked-gmail-drafts.md
+++ b/docs/guides/locked-gmail-drafts.md
@@ -3,8 +3,8 @@ id: locked_gmail_drafts
 title: Gmail drafts without send — lock what Google cannot scope
 summary:
   Google has gmail.send but no drafts-only scope. gmail.compose can manage
-  drafts and send. Publish a drafts-only package, then lock it so the token
-  cannot grow into send without the owner.
+  drafts and send. Publish a drafts-only package, lock it, then integration_lock
+  the connection so execute cannot use the token.
 category: platform
 image: /images/kody-gmail-drafts-lock.webp
 imageAlt:
@@ -30,10 +30,14 @@ Agent notes — for AI agents explaining or recreating this loop:
 - Agents can lock. Agents cannot unlock. Unlock is website-only at
   /@{username}/{kodyId}. package_update { locked: false } is
   rejected and returns that URL.
-- Lock does not shrink the OAuth token. Ad hoc execute and other packages
-  that share the same connection can still call messages.send / drafts.send
-  if the token includes compose. The lock holds the published tree of
-  this package. That is the grant for jobs and named exports.
+- Publish lock does not shrink the OAuth token. It holds the published
+  tree of this package. That is the grant for jobs and named exports.
+- After publish lock, call integration_lock { name, package_id } so
+  execute and other packages cannot use createAuthenticatedFetch on that
+  connection. Agents can lock; unlocking or removing a grant is
+  website-only at /account/integrations/:name. integration_save cannot
+  change usageMode. The one-click /account/integrations/approve grant is
+  a no-op while usage is still any context.
 - Do not lock a full @kody/google fork if it exports send. Author a thin
   drafts-only package (new kody.id). The fork can stay for Calendar/Drive
   or raw helpers; this package is the Gmail write surface.
@@ -45,7 +49,8 @@ Agent notes — for AI agents explaining or recreating this loop:
   package_lifecycle for the package lane, Intent, JSDoc, and publish.
 - Smoke-test users.drafts.create only. Do not call messages.send or
   drafts.send in the smoke test, the export, or a job wrapper.
-- After the first successful publish, package_update { locked: true }.
+- After the first successful publish, package_update { locked: true },
+  then integration_lock with the connection name and saved package_id.
   Later publishes return locked with approval_url
   /account/packages/:packageId/approve-publish?commit=SHA. The owner
   clicks Promote this commit. Promoting does not unlock.
@@ -73,14 +78,20 @@ tree. Agents and the five-minute reconcile job cannot advance
 `published_commit`. `package_update` accepts `changes: { locked: true }`. Agents
 cannot unlock; send the owner to `/@{username}/{kodyId}`.
 
-Lock does **not** revoke send on the token, hide `createAuthenticatedFetch` from
-`execute`, or stop a different unlocked package from calling send. It stops
-_this_ package's jobs and exports from silently becoming a sender.
+Publish lock does **not** revoke send on the token. It stops _this_ package's
+jobs and exports from silently becoming a sender.
 
-A connected MCP server is different: lock the **server** to a package so execute
-and other packages cannot call `kody.mcp["name"]`. That grant lives on the
-server, not on `locked_at`. See
-[Lock an MCP server to a package](./locked-mcp-server.md).
+**Integration usage lock** (`usage_mode` on the connection) is the token grant.
+`integration_lock { name, package_id }` switches Usage to specific packages and
+adds that package id. Ad hoc execute cannot call `createAuthenticatedFetch`.
+Other packages are denied. Additional grants accumulate. Unlocking or removing a
+grant is website-only at `/account/integrations/:name`.
+
+A connected MCP server uses the same tighten-only shape: lock the **server** to
+a package so execute and other packages cannot call `kody.mcp["name"]`. See
+[Lock an MCP server to a package](./locked-mcp-server.md). User secrets use
+`secret_lock` to add a package to `allowed_packages`; removing that grant is
+website-only at `/account/secrets/user/:name`.
 
 Usage detail: [Packages → Publish lock](../use/packages.md#publish-lock).
 
@@ -107,8 +118,11 @@ Usage detail: [Packages → Publish lock](../use/packages.md#publish-lock).
    creates a draft and does not send.
 5. **Publish, then lock.** After checks pass and `published_commit` moves, call
    `package_update` with `changes: { locked: true }` (or the lock icon on
-   `/@{username}/{kodyId}`). Say so in chat so the owner knows later publishes
-   need their **Promote this commit** click.
+   `/@{username}/{kodyId}`). Then call `integration_lock` with the connection
+   name and this package's saved `package_id` so execute cannot use the token.
+   Say so in chat so the owner knows later publishes need their **Promote this
+   commit** click, and that unlocking usage is a website click on
+   `/account/integrations/:name`.
 
 ## Draft-create export
 

--- a/docs/guides/locked-mcp-server.md
+++ b/docs/guides/locked-mcp-server.md
@@ -37,7 +37,8 @@ published surface can call it.
 This is the MCP counterpart to
 [Gmail drafts without send](./locked-gmail-drafts.md). OAuth tokens stay as wide
 as the provider issued them; a publish lock holds a package tree. An MCP server
-lock holds **who may call the connector**.
+lock holds **who may call the connector**. Integration connections use the same
+tighten-only grant via `integration_lock`.
 
 ## What the lock does
 
@@ -86,8 +87,8 @@ If a package needs the lock off, send the owner to
 
 Load `locked_mcp_server` when someone wants a connected MCP server that execute
 must not call, when a home or third-party MCP is coarser than the intended
-package, or when they ask how MCP usage compares to publish lock or integration
-package grants. For connecting the server, load the
+package, or when they ask how MCP usage compares to publish lock or
+`integration_lock`. For connecting the server, load the
 [usage page](../use/mcp-client-servers.md) and `local_mcp_tunnels` for home LAN
 servers. For holding a published tree still, load `locked_gmail_drafts` and
 [Packages → Publish lock](../use/packages.md#publish-lock).

--- a/docs/guides/what-is-kody.md
+++ b/docs/guides/what-is-kody.md
@@ -74,12 +74,13 @@ supporting cast.
    one. Code references secrets by name and Kody substitutes them at the network
    boundary, only for hosts you approved. The
    [secrets capabilities](https://github.com/kentcdodds/kody/tree/main/packages/worker/src/mcp/capabilities/secrets)
-   are `secret_list`, `secret_set`, `secret_set_many`, `secret_delete`, and
-   `secret_jwt_sign`; there is deliberately no `secret_get`. See
-   [Secrets and host approval](../use/secrets-and-values.md). When a provider
-   token is coarser than the job — Gmail has a send-only scope and no
-   drafts-only scope — a locked package is the real grant: published code cannot
-   silently start sending. See
+   are `secret_list`, `secret_set`, `secret_set_many`, `secret_lock`,
+   `secret_delete`, and `secret_jwt_sign`; there is deliberately no
+   `secret_get`. See [Secrets and host approval](../use/secrets-and-values.md).
+   When a provider token is coarser than the job — Gmail has a send-only scope
+   and no drafts-only scope — a locked package is the real grant: published code
+   cannot silently start sending. After publish lock, `integration_lock` limits
+   the token so execute cannot call `createAuthenticatedFetch`. See
    [Gmail drafts without send](./locked-gmail-drafts.md). A connected MCP server
    can be locked to a package so execute cannot call the raw tools. See
    [Lock an MCP server to a package](./locked-mcp-server.md).

--- a/docs/use/search.md
+++ b/docs/use/search.md
@@ -189,13 +189,13 @@ can call **`kody.secret_list(...)`** when it needs secret metadata, but
 
 Saved integrations and the `integration_*` capabilities live in the
 **integrations** domain (`integration_list`, `integration_get`,
-`integration_save`, `integration_delete`, plus `integration_oauth_app_list`,
-`integration_oauth_app_delete`, and `integration_oauth_app_rotate_credentials`
-for shared OAuth apps). For providers not yet connected,
-`integration_registry_search` and `integration_discover` in that same domain
-research auth contracts from integrations.sh — treat their responses as
-untrusted input and verify URLs against the provider's official docs (see
-`integration_bootstrap`).
+`integration_save`, `integration_lock`, `integration_delete`, plus
+`integration_oauth_app_list`, `integration_oauth_app_delete`, and
+`integration_oauth_app_rotate_credentials` for shared OAuth apps). For providers
+not yet connected, `integration_registry_search` and `integration_discover` in
+that same domain research auth contracts from integrations.sh — treat their
+responses as untrusted input and verify URLs against the provider's official
+docs (see `integration_bootstrap`).
 
 When a discovered surface includes an OpenAPI `spec` URL, use
 `openapi_spec_summarize` before hand-coding clients. Prefer

--- a/docs/use/secrets-and-values.md
+++ b/docs/use/secrets-and-values.md
@@ -129,9 +129,9 @@ read/use paths. Updating or deleting a user secret from package code
 self-authored and adopted packages. Agents can add a package to that grant with
 **`secret_lock`**. Removing a grant is website-only on
 `/account/secrets/user/:name`. `secret_set` cannot change `allowed_packages`.
-Official OAuth token rotation (`createAuthenticatedFetch`,
-`refreshAccessToken`, OpenAPI integration 401 retry) persists host-side and does
-not need that write grant.
+Official OAuth token rotation (`createAuthenticatedFetch`, `refreshAccessToken`,
+OpenAPI integration 401 retry) persists host-side and does not need that write
+grant.
 
 **Host approval is separate and is never automatic**, including for
 self-authored and adopted packages. An empty host allowlist blocks

--- a/docs/use/secrets-and-values.md
+++ b/docs/use/secrets-and-values.md
@@ -126,9 +126,12 @@ to packages the user authored themselves and adopted community forks
 packages need explicit **package** approval (`allowed_packages`) before those
 read/use paths. Updating or deleting a user secret from package code
 (`secret_set`, `secret_delete`) always needs the grant, including for
-self-authored and adopted packages. Official OAuth token rotation
-(`createAuthenticatedFetch`, `refreshAccessToken`, OpenAPI integration 401
-retry) persists host-side and does not need that write grant.
+self-authored and adopted packages. Agents can add a package to that grant with
+**`secret_lock`**. Removing a grant is website-only on
+`/account/secrets/user/:name`. `secret_set` cannot change `allowed_packages`.
+Official OAuth token rotation (`createAuthenticatedFetch`,
+`refreshAccessToken`, OpenAPI integration 401 retry) persists host-side and does
+not need that write grant.
 
 **Host approval is separate and is never automatic**, including for
 self-authored and adopted packages. An empty host allowlist blocks

--- a/packages/worker/src/integrations/owned-credentials.node.test.ts
+++ b/packages/worker/src/integrations/owned-credentials.node.test.ts
@@ -25,6 +25,7 @@ import {
 	deleteIntegration,
 	deleteOauthAppWithConnections,
 	grantIntegrationPackage,
+	lockIntegrationToPackage,
 	setIntegrationUsage,
 	upsertIntegration,
 } from './service.ts'
@@ -397,4 +398,58 @@ test('disconnecting the last user-lane connection deletes the leftover client se
 			includeIntegrationOwned: true,
 		}),
 	).toEqual([])
+})
+
+test('lockIntegrationToPackage switches any-context usage to packages and rejects unknown packages', async () => {
+	const { sqlite, env } = createHarness()
+	const userId = 'user-lock-usage'
+	seedPackage(sqlite, { id: 'pkg-drafts', userId, kodyId: 'gmail-drafts' })
+	await upsertIntegration({ env, userId, config: googleConfig })
+
+	const grantedWhileAny = await grantIntegrationPackage({
+		env,
+		userId,
+		name: 'google',
+		packageId: 'pkg-drafts',
+	})
+	expect(grantedWhileAny).toMatchObject({
+		usageMode: 'any',
+		allowedPackageIds: [],
+	})
+
+	const locked = await lockIntegrationToPackage({
+		env,
+		userId,
+		name: 'google',
+		packageId: 'pkg-drafts',
+	})
+	expect(locked).toMatchObject({
+		usageMode: 'packages',
+		allowedPackageIds: ['pkg-drafts'],
+	})
+	await expect(
+		assertCanUseIntegration({
+			env,
+			baseUrl: 'https://kody.codes',
+			userId,
+			name: 'google',
+		}),
+	).rejects.toBeInstanceOf(IntegrationPackageAccessDeniedError)
+	await assertCanUseIntegration({
+		env,
+		baseUrl: 'https://kody.codes',
+		userId,
+		name: 'google',
+		packageId: 'pkg-drafts',
+		packageKodyId: 'gmail-drafts',
+	})
+
+	await expect(
+		lockIntegrationToPackage({
+			env,
+			userId,
+			name: 'google',
+			packageId: 'missing-package',
+		}),
+	).rejects.toThrow('Saved package not found for this user.')
 })

--- a/packages/worker/src/integrations/package-access.node.test.ts
+++ b/packages/worker/src/integrations/package-access.node.test.ts
@@ -1,0 +1,17 @@
+import { expect, test } from 'vitest'
+import { buildIntegrationUsageUrl } from './package-access.ts'
+
+test('buildIntegrationUsageUrl keeps Remix %2E encoding for dotted names', () => {
+	expect(
+		buildIntegrationUsageUrl({
+			baseUrl: 'https://example.com',
+			name: 'google',
+		}),
+	).toBe('https://example.com/account/integrations/google')
+	expect(
+		buildIntegrationUsageUrl({
+			baseUrl: 'https://example.com',
+			name: 'google.personal',
+		}),
+	).toBe('https://example.com/account/integrations/google%2Epersonal')
+})

--- a/packages/worker/src/integrations/package-access.ts
+++ b/packages/worker/src/integrations/package-access.ts
@@ -1,4 +1,5 @@
 import { McpCallerError } from '#mcp/caller-error.ts'
+import { routes } from '#universal/routes.ts'
 import { getJoinedIntegrationByName } from './repo.ts'
 import { normalizeIntegrationUsageMode } from './usage-mode.ts'
 
@@ -22,6 +23,16 @@ export function buildIntegrationPackageApprovalUrl(input: {
 		url.searchParams.set('package', input.kodyId)
 	}
 	return url.toString()
+}
+
+export function buildIntegrationUsageUrl(input: {
+	baseUrl: string
+	name: string
+}) {
+	return new URL(
+		routes.accountIntegrationDetail.href({ integrationName: input.name }),
+		input.baseUrl,
+	).toString()
 }
 
 export function createIntegrationPackageAccessDeniedMessage(input: {

--- a/packages/worker/src/integrations/package-access.ts
+++ b/packages/worker/src/integrations/package-access.ts
@@ -1,5 +1,5 @@
 import { McpCallerError } from '#mcp/caller-error.ts'
-import { routes } from '#universal/routes.ts'
+import { buildIntegrationAccountUrl } from './account-identity.ts'
 import { getJoinedIntegrationByName } from './repo.ts'
 import { normalizeIntegrationUsageMode } from './usage-mode.ts'
 
@@ -29,10 +29,10 @@ export function buildIntegrationUsageUrl(input: {
 	baseUrl: string
 	name: string
 }) {
-	return new URL(
-		routes.accountIntegrationDetail.href({ integrationName: input.name }),
-		input.baseUrl,
-	).toString()
+	return buildIntegrationAccountUrl({
+		baseUrl: input.baseUrl,
+		integrationName: input.name,
+	})
 }
 
 export function createIntegrationPackageAccessDeniedMessage(input: {

--- a/packages/worker/src/integrations/service.ts
+++ b/packages/worker/src/integrations/service.ts
@@ -9,6 +9,7 @@ import {
 } from '#mcp/capabilities/integrations/integration-shared.ts'
 import { normalizeAllowedHosts } from '#mcp/secrets/allowed-hosts.ts'
 import { normalizeAllowedPackages } from '#mcp/secrets/allowed-packages.ts'
+import { getSavedPackageById } from '#worker/package-registry/repo.ts'
 import {
 	getPlatformOauthAppBySlug,
 	listPlatformOauthApps,
@@ -1327,4 +1328,69 @@ export async function grantIntegrationPackage(input: {
 		name,
 	})
 	return saved?.connection ?? null
+}
+
+/**
+ * Tighten-only usage lock. Switches the connection from any context to
+ * packages mode and adds `packageId`. Additional grants accumulate.
+ * Unlocking or removing a grant is website-only.
+ */
+export async function lockIntegrationToPackage(input: {
+	env: Pick<Env, 'APP_DB'>
+	userId: string
+	name: string
+	packageId: string
+}): Promise<UserIntegrationConnection> {
+	const name = canonicalIntegrationName(input.name)
+	const packageId = input.packageId.trim()
+	if (!name) {
+		throw new Error('Integration name is required.')
+	}
+	if (!packageId) {
+		throw new Error('Package id is required.')
+	}
+	const existing = await getJoinedIntegrationByName({
+		db: input.env.APP_DB,
+		userId: input.userId,
+		name,
+	})
+	if (!existing) {
+		throw new Error(`Integration "${input.name}" was not found.`)
+	}
+	const savedPackage = await getSavedPackageById(input.env.APP_DB, {
+		userId: input.userId,
+		packageId,
+	})
+	if (!savedPackage) {
+		throw new Error('Saved package not found for this user.')
+	}
+	if (
+		existing.connection.usageMode === 'packages' &&
+		existing.connection.allowedPackageIds.includes(packageId)
+	) {
+		return existing.connection
+	}
+	const allowedPackageIds = normalizeAllowedPackages([
+		...existing.connection.allowedPackageIds,
+		packageId,
+	])
+	const updated = await updateIntegrationUsage({
+		db: input.env.APP_DB,
+		userId: input.userId,
+		name,
+		usageMode: 'packages',
+		allowedPackageIds,
+	})
+	if (!updated) {
+		throw new Error(`Unable to lock integration "${name}" to a package.`)
+	}
+	const saved = await getJoinedIntegrationByName({
+		db: input.env.APP_DB,
+		userId: input.userId,
+		name,
+	})
+	if (!saved) {
+		throw new Error(`Unable to lock integration "${name}" to a package.`)
+	}
+	return saved.connection
 }

--- a/packages/worker/src/mcp/capabilities/coding/kody-official-guide.ts
+++ b/packages/worker/src/mcp/capabilities/coding/kody-official-guide.ts
@@ -34,7 +34,7 @@ function buildCapabilityDescription(): string {
 		'Use `guide: "heavy_work_offload"` when package checks or publish rebuilds exceed isolate memory or CPU — usually a large npm graph — so the package stays a thin orchestrator and the owner operates the heavy process.',
 		'Use `guide: "how_kody_works"` to explain the factory loop: ask once, save an export, invoke from any agent, then a quiet daily email.',
 		'Use `guide: "package_lifecycle"` to choose reuse vs temporary execute vs community fork vs deferred workflows vs a new durable package, and before enabling package-owned schedules.',
-		'Use `guide: "locked_gmail_drafts"` when an OAuth token is coarser than the intended published surface — Gmail has send-only and no drafts-only scope — and the owner should lock a drafts-only package so it cannot grow into send.',
+		'Use `guide: "locked_gmail_drafts"` when an OAuth token is coarser than the intended published surface — Gmail has send-only and no drafts-only scope — and the owner should lock a drafts-only package, then integration_lock the connection so execute cannot use the token.',
 		'Use `guide: "locked_mcp_server"` when a connected MCP server should be callable only from a named package — not from ad hoc execute or other packages.',
 		'Integration bootstrap covers checking saved `integration` / `secret` entities, running a cheap authenticated smoke test, then preferring a close community fork before building.',
 		'Use `guide: "platform_friction"` for meaningful Kody friction, bugs, poor experiences, or suggestions; it distinguishes inline fixes, approved memory changes, and consent-gated attributed feedback.',

--- a/packages/worker/src/mcp/capabilities/integrations/domain.ts
+++ b/packages/worker/src/mcp/capabilities/integrations/domain.ts
@@ -4,6 +4,7 @@ import { integrationDeleteCapability } from './integration-delete.ts'
 import { integrationDiscoverCapability } from './integration-discover.ts'
 import { integrationGetCapability } from './integration-get.ts'
 import { integrationListCapability } from './integration-list.ts'
+import { integrationLockCapability } from './integration-lock.ts'
 import { integrationOauthAppDeleteCapability } from './integration-oauth-app-delete.ts'
 import { integrationOauthAppListCapability } from './integration-oauth-app-list.ts'
 import { integrationOauthAppRotateCredentialsCapability } from './integration-oauth-app-rotate-credentials.ts'
@@ -34,11 +35,14 @@ export const integrationsDomain = defineDomain({
 		'scaffold',
 		'oauth app',
 		'client credentials',
+		'lock',
+		'usage',
 	],
 	capabilities: [
 		integrationSaveCapability,
 		integrationGetCapability,
 		integrationListCapability,
+		integrationLockCapability,
 		integrationDeleteCapability,
 		integrationOauthAppListCapability,
 		integrationOauthAppDeleteCapability,

--- a/packages/worker/src/mcp/capabilities/integrations/integration-lock.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/integrations/integration-lock.node.test.ts
@@ -1,0 +1,63 @@
+import { expect, test, vi } from 'vitest'
+import { McpCallerError } from '#mcp/caller-error.ts'
+import { createMcpCallerContext } from '#mcp/context.ts'
+
+const mockModule = vi.hoisted(() => ({
+	lockIntegrationToPackage: vi.fn(),
+}))
+
+vi.mock('#worker/integrations/service.ts', () => ({
+	lockIntegrationToPackage: (...args: Array<unknown>) =>
+		mockModule.lockIntegrationToPackage(...args),
+}))
+
+const { integrationLockCapability } = await import('./integration-lock.ts')
+
+test('integration_lock grants a package and rejects missing packages', async () => {
+	mockModule.lockIntegrationToPackage.mockResolvedValue({
+		name: 'google',
+		allowedPackageIds: ['pkg-drafts'],
+	})
+
+	const ctx = {
+		env: {} as Env,
+		callerContext: createMcpCallerContext({
+			baseUrl: 'https://kody.codes',
+			user: {
+				userId: 'user-1',
+				email: 'alice@example.com',
+				displayName: 'Alice',
+			},
+		}),
+	}
+
+	await expect(
+		integrationLockCapability.handler(
+			{ name: 'google', package_id: 'pkg-drafts' },
+			ctx,
+		),
+	).resolves.toEqual({
+		name: 'google',
+		usage_mode: 'packages',
+		allowed_package_ids: ['pkg-drafts'],
+		usage_url: 'https://kody.codes/account/integrations/google',
+	})
+	expect(mockModule.lockIntegrationToPackage).toHaveBeenCalledWith({
+		env: ctx.env,
+		userId: 'user-1',
+		name: 'google',
+		packageId: 'pkg-drafts',
+	})
+
+	mockModule.lockIntegrationToPackage.mockRejectedValueOnce(
+		new Error('Saved package not found for this user.'),
+	)
+	const missing = await integrationLockCapability
+		.handler({ name: 'google', package_id: 'missing' }, ctx)
+		.then(
+			() => null,
+			(error: unknown) => error,
+		)
+	expect(missing).toBeInstanceOf(McpCallerError)
+	expect((missing as Error).message).toContain('Saved package not found')
+})

--- a/packages/worker/src/mcp/capabilities/integrations/integration-lock.ts
+++ b/packages/worker/src/mcp/capabilities/integrations/integration-lock.ts
@@ -1,0 +1,78 @@
+import { z } from 'zod'
+import { McpCallerError } from '#mcp/caller-error.ts'
+import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
+import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
+import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
+import { type CapabilityContext } from '#mcp/capabilities/types.ts'
+import { buildIntegrationUsageUrl } from '#worker/integrations/package-access.ts'
+import { lockIntegrationToPackage } from '#worker/integrations/service.ts'
+
+const outputSchema = z.object({
+	name: z.string(),
+	usage_mode: z.literal('packages'),
+	allowed_package_ids: z.array(z.string()),
+	usage_url: z.string(),
+})
+
+export const integrationLockCapability = defineDomainCapability(
+	capabilityDomainNames.integrations,
+	{
+		name: 'integration_lock',
+		description:
+			'Lock an OAuth integration connection to a package so only that package (and any previously granted packages) can call createAuthenticatedFetch / token refresh. Execute and other packages are denied. Agents can lock; unlocking or removing a grant is website-only at /account/integrations/:name. This capability cannot loosen usage. integration_save still cannot change usageMode.',
+		keywords: [
+			'integration',
+			'oauth',
+			'lock',
+			'package',
+			'usage',
+			'restrict',
+			'grant',
+			'token',
+		],
+		readOnly: false,
+		idempotent: true,
+		destructive: false,
+		inputSchema: z.object({
+			name: z
+				.string()
+				.min(1)
+				.describe('Saved integration connection name (provider key).'),
+			package_id: z
+				.string()
+				.min(1)
+				.describe('Saved package id that may use this integration.'),
+		}),
+		outputSchema,
+		async handler(
+			args: { name: string; package_id: string },
+			ctx: CapabilityContext,
+		) {
+			const user = requireMcpUser(ctx.callerContext)
+			try {
+				const updated = await lockIntegrationToPackage({
+					env: ctx.env,
+					userId: user.userId,
+					name: args.name,
+					packageId: args.package_id,
+				})
+				return {
+					name: updated.name,
+					usage_mode: 'packages' as const,
+					allowed_package_ids: updated.allowedPackageIds,
+					usage_url: buildIntegrationUsageUrl({
+						baseUrl: ctx.callerContext.baseUrl,
+						name: updated.name,
+					}),
+				}
+			} catch (error) {
+				throw new McpCallerError(
+					error instanceof Error
+						? error.message
+						: 'Unable to lock this integration to a package.',
+					{ cause: error },
+				)
+			}
+		},
+	},
+)

--- a/packages/worker/src/mcp/capabilities/secrets/domain.ts
+++ b/packages/worker/src/mcp/capabilities/secrets/domain.ts
@@ -3,6 +3,7 @@ import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { jwtSignCapability } from './jwt-sign.ts'
 import { secretDeleteCapability } from './secret-delete.ts'
 import { secretListCapability } from './secret-list.ts'
+import { secretLockCapability } from './secret-lock.ts'
 import { secretSetCapability } from './secret-set.ts'
 import { secretSetManyCapability } from './secret-set-many.ts'
 
@@ -10,11 +11,19 @@ export const secretsDomain = defineDomain({
 	name: capabilityDomainNames.secrets,
 	description:
 		'Server-side secret references (never paste secret values into chat).',
-	keywords: ['secret', 'credentials', 'reference', 'secure input'],
+	keywords: [
+		'secret',
+		'credentials',
+		'reference',
+		'secure input',
+		'lock',
+		'usage',
+	],
 	capabilities: [
 		secretListCapability,
 		secretSetCapability,
 		secretSetManyCapability,
+		secretLockCapability,
 		secretDeleteCapability,
 		jwtSignCapability,
 	],

--- a/packages/worker/src/mcp/capabilities/secrets/secret-lock.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/secrets/secret-lock.node.test.ts
@@ -1,0 +1,63 @@
+import { expect, test, vi } from 'vitest'
+import { McpCallerError } from '#mcp/caller-error.ts'
+import { createMcpCallerContext } from '#mcp/context.ts'
+
+const mockModule = vi.hoisted(() => ({
+	lockSecretToPackage: vi.fn(),
+}))
+
+vi.mock('#mcp/secrets/service.ts', () => ({
+	lockSecretToPackage: (...args: Array<unknown>) =>
+		mockModule.lockSecretToPackage(...args),
+}))
+
+const { secretLockCapability } = await import('./secret-lock.ts')
+
+test('secret_lock grants a package and rejects missing packages', async () => {
+	mockModule.lockSecretToPackage.mockResolvedValue({
+		name: 'openai-api-key',
+		allowedPackages: ['pkg-drafts'],
+	})
+
+	const ctx = {
+		env: {} as Env,
+		callerContext: createMcpCallerContext({
+			baseUrl: 'https://kody.codes',
+			user: {
+				userId: 'user-1',
+				email: 'alice@example.com',
+				displayName: 'Alice',
+			},
+		}),
+	}
+
+	await expect(
+		secretLockCapability.handler(
+			{ name: 'openai-api-key', package_id: 'pkg-drafts' },
+			ctx,
+		),
+	).resolves.toEqual({
+		name: 'openai-api-key',
+		scope: 'user',
+		allowed_packages: ['pkg-drafts'],
+		usage_url: 'https://kody.codes/account/secrets/user/openai-api-key',
+	})
+	expect(mockModule.lockSecretToPackage).toHaveBeenCalledWith({
+		env: ctx.env,
+		userId: 'user-1',
+		name: 'openai-api-key',
+		packageId: 'pkg-drafts',
+	})
+
+	mockModule.lockSecretToPackage.mockRejectedValueOnce(
+		new Error('Saved package not found for this user.'),
+	)
+	const missing = await secretLockCapability
+		.handler({ name: 'openai-api-key', package_id: 'missing' }, ctx)
+		.then(
+			() => null,
+			(error: unknown) => error,
+		)
+	expect(missing).toBeInstanceOf(McpCallerError)
+	expect((missing as Error).message).toContain('Saved package not found')
+})

--- a/packages/worker/src/mcp/capabilities/secrets/secret-lock.ts
+++ b/packages/worker/src/mcp/capabilities/secrets/secret-lock.ts
@@ -1,0 +1,74 @@
+import { z } from 'zod'
+import { McpCallerError } from '#mcp/caller-error.ts'
+import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
+import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
+import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
+import { type CapabilityContext } from '#mcp/capabilities/types.ts'
+import { buildSecretUsageUrl } from '#mcp/secrets/package-approval-url.ts'
+import { lockSecretToPackage } from '#mcp/secrets/service.ts'
+
+const outputSchema = z.object({
+	name: z.string(),
+	scope: z.literal('user'),
+	allowed_packages: z.array(z.string()),
+	usage_url: z.string(),
+})
+
+export const secretLockCapability = defineDomainCapability(
+	capabilityDomainNames.secrets,
+	{
+		name: 'secret_lock',
+		description:
+			'Grant a user-scoped secret to a saved package by adding that package id to allowed_packages. Additional grants accumulate. Agents can grant; removing a grant is website-only at /account/secrets/user/:name. This capability cannot remove packages. User secrets still allow execute and self-authored / adopted packages to read unless the owner tightens further on the account page. secret_set cannot change allowed_packages.',
+		keywords: [
+			'secret',
+			'lock',
+			'package',
+			'usage',
+			'restrict',
+			'grant',
+			'allowed_packages',
+		],
+		readOnly: false,
+		idempotent: true,
+		destructive: false,
+		inputSchema: z.object({
+			name: z.string().min(1).describe('User-scoped secret name to grant.'),
+			package_id: z
+				.string()
+				.min(1)
+				.describe('Saved package id that may use this secret.'),
+		}),
+		outputSchema,
+		async handler(
+			args: { name: string; package_id: string },
+			ctx: CapabilityContext,
+		) {
+			const user = requireMcpUser(ctx.callerContext)
+			try {
+				const updated = await lockSecretToPackage({
+					env: ctx.env,
+					userId: user.userId,
+					name: args.name,
+					packageId: args.package_id,
+				})
+				return {
+					name: updated.name,
+					scope: 'user' as const,
+					allowed_packages: updated.allowedPackages,
+					usage_url: buildSecretUsageUrl({
+						baseUrl: ctx.callerContext.baseUrl,
+						name: updated.name,
+					}),
+				}
+			} catch (error) {
+				throw new McpCallerError(
+					error instanceof Error
+						? error.message
+						: 'Unable to lock this secret to a package.',
+					{ cause: error },
+				)
+			}
+		},
+	},
+)

--- a/packages/worker/src/mcp/secrets/lock-to-package.node.test.ts
+++ b/packages/worker/src/mcp/secrets/lock-to-package.node.test.ts
@@ -1,0 +1,99 @@
+import { DatabaseSync } from 'node:sqlite'
+import { expect, test } from 'vitest'
+import { applyAllMigrations as applyRepositoryMigrations } from '#worker/test-support/apply-all-migrations.ts'
+import { createD1FromSqlite } from '#worker/test-support/create-d1-from-sqlite.ts'
+import { createInMemoryUserMeterEnv } from '#worker/test-support/user-meter.ts'
+import { lockSecretToPackage, saveSecret } from './service.ts'
+
+const migrationsDirectory = new URL('../../../migrations/', import.meta.url)
+
+function createHarness() {
+	const sqlite = new DatabaseSync(':memory:')
+	applyRepositoryMigrations(sqlite, migrationsDirectory)
+	const env = {
+		APP_DB: createD1FromSqlite(sqlite),
+		SECRET_STORE_KEY: 'test-secret-store-key-32-chars-minimum',
+		...createInMemoryUserMeterEnv().env,
+	} as Env
+	return { sqlite, env }
+}
+
+function seedPackage(
+	sqlite: DatabaseSync,
+	input: { id: string; userId: string; kodyId: string },
+) {
+	sqlite
+		.prepare(
+			`INSERT INTO saved_packages (
+				id, user_id, name, kody_id, description, source_id
+			) VALUES (?, ?, ?, ?, ?, ?)`,
+		)
+		.run(
+			input.id,
+			input.userId,
+			input.kodyId,
+			input.kodyId,
+			'',
+			`source-${input.id}`,
+		)
+}
+
+test('lockSecretToPackage adds a package grant and rejects unknown packages', async () => {
+	const { sqlite, env } = createHarness()
+	const userId = 'user-secret-lock'
+	seedPackage(sqlite, { id: 'pkg-notes', userId, kodyId: 'notes' })
+	seedPackage(sqlite, { id: 'pkg-mail', userId, kodyId: 'mail' })
+
+	await saveSecret({
+		env,
+		userId,
+		scope: 'user',
+		name: 'openai-api-key',
+		value: 'sk-test',
+	})
+
+	const locked = await lockSecretToPackage({
+		env,
+		userId,
+		name: 'openai-api-key',
+		packageId: 'pkg-notes',
+	})
+	expect(locked).toMatchObject({
+		name: 'openai-api-key',
+		scope: 'user',
+		allowedPackages: ['pkg-notes'],
+	})
+
+	const grantedAgain = await lockSecretToPackage({
+		env,
+		userId,
+		name: 'openai-api-key',
+		packageId: 'pkg-mail',
+	})
+	expect(grantedAgain.allowedPackages).toEqual(['pkg-mail', 'pkg-notes'])
+
+	const idempotent = await lockSecretToPackage({
+		env,
+		userId,
+		name: 'openai-api-key',
+		packageId: 'pkg-notes',
+	})
+	expect(idempotent.allowedPackages).toEqual(['pkg-mail', 'pkg-notes'])
+
+	await expect(
+		lockSecretToPackage({
+			env,
+			userId,
+			name: 'openai-api-key',
+			packageId: 'missing-package',
+		}),
+	).rejects.toThrow('Saved package not found for this user.')
+	await expect(
+		lockSecretToPackage({
+			env,
+			userId,
+			name: 'missing-secret',
+			packageId: 'pkg-notes',
+		}),
+	).rejects.toThrow('Secret not found for this scope.')
+})

--- a/packages/worker/src/mcp/secrets/package-approval-url.node.test.ts
+++ b/packages/worker/src/mcp/secrets/package-approval-url.node.test.ts
@@ -3,8 +3,24 @@ import {
 	buildSecretPackageApprovalUrl,
 	buildSecretPackageBulkApprovalUrl,
 	buildSecretPackageBulkApprovalUrlIfNeeded,
+	buildSecretUsageUrl,
 	normalizeBulkPackageSecretApprovalNames,
 } from './package-approval-url.ts'
+
+test('buildSecretUsageUrl keeps Remix %2E encoding for dotted secret names', () => {
+	expect(
+		buildSecretUsageUrl({
+			baseUrl: 'https://kody.codes',
+			name: 'openai-api-key',
+		}),
+	).toBe('https://kody.codes/account/secrets/user/openai-api-key')
+	expect(
+		buildSecretUsageUrl({
+			baseUrl: 'https://kody.codes',
+			name: 'google.api.key',
+		}),
+	).toBe('https://kody.codes/account/secrets/user/google%2Eapi%2Ekey')
+})
 
 test('buildSecretPackageApprovalUrl keeps the single-secret detail path', () => {
 	expect(

--- a/packages/worker/src/mcp/secrets/package-approval-url.ts
+++ b/packages/worker/src/mcp/secrets/package-approval-url.ts
@@ -3,6 +3,7 @@ import {
 	joinOriginAndEncodedPath,
 } from '@kody-internal/shared/account-secret-route.ts'
 import { type StorageContext } from '#mcp/storage.ts'
+import { routes } from '#universal/routes.ts'
 import { type SecretScope } from './types.ts'
 
 const accountSecretsApprovePath = '/account/secrets/approve'
@@ -39,6 +40,13 @@ export function buildSecretPackageApprovalUrl(input: {
 		search.set('package', input.kodyId)
 	}
 	return `${joinOriginAndEncodedPath(input.baseUrl, secretPath)}?${search}`
+}
+
+export function buildSecretUsageUrl(input: { baseUrl: string; name: string }) {
+	return new URL(
+		routes.accountSecretUserDetail.href({ secretName: input.name }),
+		input.baseUrl,
+	).toString()
 }
 
 export function normalizeBulkPackageSecretApprovalNames(names: Array<string>) {

--- a/packages/worker/src/mcp/secrets/package-approval-url.ts
+++ b/packages/worker/src/mcp/secrets/package-approval-url.ts
@@ -1,9 +1,9 @@
 import {
 	buildAccountSecretPath,
+	buildAccountSecretUrl,
 	joinOriginAndEncodedPath,
 } from '@kody-internal/shared/account-secret-route.ts'
 import { type StorageContext } from '#mcp/storage.ts'
-import { routes } from '#universal/routes.ts'
 import { type SecretScope } from './types.ts'
 
 const accountSecretsApprovePath = '/account/secrets/approve'
@@ -43,10 +43,11 @@ export function buildSecretPackageApprovalUrl(input: {
 }
 
 export function buildSecretUsageUrl(input: { baseUrl: string; name: string }) {
-	return new URL(
-		routes.accountSecretUserDetail.href({ secretName: input.name }),
-		input.baseUrl,
-	).toString()
+	return buildAccountSecretUrl({
+		baseUrl: input.baseUrl,
+		name: input.name,
+		scope: 'user',
+	})
 }
 
 export function normalizeBulkPackageSecretApprovalNames(names: Array<string>) {

--- a/packages/worker/src/mcp/secrets/service.ts
+++ b/packages/worker/src/mcp/secrets/service.ts
@@ -47,6 +47,7 @@ import {
 import { type UserMeterEnv } from '#worker/entitlements/user-meter-client.ts'
 import { type SecretMetadata, type SecretScope } from './types.ts'
 import { listReferencedIntegrationSecretNames } from '#worker/integrations/owned-secret-names.ts'
+import { getSavedPackageById } from '#worker/package-registry/repo.ts'
 
 type SecretOwnerContext = {
 	userId: string
@@ -1077,6 +1078,71 @@ export async function setSecretAllowedPackages(input: {
 			existingEntry.expires_at,
 			bucket.expires_at,
 		),
+	})
+}
+
+/**
+ * Tighten-only package grant on a user secret. Adds `packageId` to
+ * `allowed_packages`. Additional grants accumulate. Removing a grant is
+ * website-only. User-scope only — package secrets do not have this grant.
+ */
+export async function lockSecretToPackage(input: {
+	env: Pick<Env, 'APP_DB'>
+	userId: string
+	name: string
+	packageId: string
+}): Promise<SecretMetadata> {
+	const packageId = input.packageId.trim()
+	if (!packageId) {
+		throw new Error('Package id is required.')
+	}
+	const savedPackage = await getSavedPackageById(input.env.APP_DB, {
+		userId: input.userId,
+		packageId,
+	})
+	if (!savedPackage) {
+		throw new Error('Saved package not found for this user.')
+	}
+	const bucket = await getExistingBucketForScope({
+		db: input.env.APP_DB,
+		userId: input.userId,
+		scope: 'user',
+		storageContext: null,
+	})
+	if (!bucket) {
+		throw new Error('Secret not found for this scope.')
+	}
+	const existingEntry = await getSecretEntry({
+		db: input.env.APP_DB,
+		bucketId: bucket.id,
+		name: input.name.trim(),
+	})
+	if (!existingEntry) {
+		throw new Error('Secret not found for this scope.')
+	}
+	const currentPackages = parseAllowedPackages(existingEntry.allowed_packages)
+	if (currentPackages.includes(packageId)) {
+		return toSecretMetadata({
+			name: input.name.trim(),
+			scope: 'user',
+			description: existingEntry.description,
+			packageId: null,
+			allowedHosts: parseAllowedHosts(existingEntry.allowed_hosts),
+			allowedPackages: currentPackages,
+			createdAt: existingEntry.created_at,
+			updatedAt: existingEntry.updated_at,
+			expiresAt: earliestSecretExpiresAt(
+				existingEntry.expires_at,
+				bucket.expires_at,
+			),
+		})
+	}
+	return setSecretAllowedPackages({
+		env: input.env,
+		userId: input.userId,
+		name: input.name,
+		scope: 'user',
+		allowedPackages: [...currentPackages, packageId],
 	})
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Let agents finish the Gmail-drafts / coarse-token loop by tightening OAuth and secret grants to named packages, the same one-way shape as `mcp_server_lock`.

## Why

Usage mode already exists on connections, and the runtime already denies execute when a connection is limited to specific packages. Agents could lock a package and an MCP server, but not the token itself — only the owner could set Usage on `/account/integrations`. The one-click approve URL is a no-op while usage is still any context. Secrets had the same gap: `secret_set` cannot change `allowed_packages`.

## Summary

- Add `integration_lock { name, package_id }`. It switches the connection from any context to packages mode and adds that package id. Additional grants accumulate. Unlocking or removing a grant stays website-only. `grantIntegrationPackage` (the approve click) is still a no-op while usage is any.
- Add `secret_lock { name, package_id }`. It adds a user-secret package grant and cannot remove one. Execute and self-authored/adopted read/use still follow the existing secret model (no usageMode on secrets).
- `integration_save` still cannot change `usageMode`.
- Garden the Gmail-drafts guide, usage docs, and architecture tables so agents call `integration_lock` after publish lock.
- Lock `usage_url`s reuse the existing Remix-safe account URL helpers so dotted names (`google.api.key`, `google.personal`) keep `%2E` and do not 404.

## Testing

- `vitest` node-unit: `integration-lock`, `secret-lock`, `owned-credentials` (new lock vs grant case), `lock-to-package`, official-guide, catalog, usage-URL encoding
- Pre-push hook after rebase: `npm run test:node` (758 files / 2284 tests) and `npm run test:workers` (89 files / 312 tests)
- Typecheck ran on commit via lint-staged
- Preview `https://kody-pr-1924.kody-a99.workers.dev` as `me@kentcdodds.com`: created `google.api.key`, `GET /account/secrets/user/google%2Eapi%2Ekey` 200, secrets and integrations JSON/HTML 200
- Signed-in UI: dotted secret detail loaded (not 404); integrations still show Usage any vs packages

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `13263ff5` · **Head:** `4786dc3a`

**Classification:** extends — new tighten-only lock capabilities on integrations and secrets; no new primitive.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `integrations` | assistant | extends — `integration_lock` switches usage to packages and adds a package id |
| `secrets` | assistant | extends — `secret_lock` adds a user-secret package grant |
| `mcp-server` | surfaces | extends — secret service lock helper used by the new capability |
| `capability-registry` | assistant | composes — official-guide copy points at `integration_lock` |

### Change flow

An agent tightens a Google connection to a saved package so execute can no longer call `createAuthenticatedFetch`.

```mermaid
sequenceDiagram
	actor Agent
	participant mcpServer as mcp-server
	participant capabilityRegistry as capability-registry
	participant integrations as integrations
	participant d1AppDb as d1-app-db
	Agent->>mcpServer: execute integration_lock
	mcpServer->>capabilityRegistry: integration_lock
	capabilityRegistry->>integrations: lockIntegrationToPackage
	integrations->>d1AppDb: usage_mode=packages plus package id
	Note over integrations: grantIntegrationPackage still no-ops while any
	integrations-->>Agent: usage_mode packages and usage_url
```

### Before / after

```text
Before: agents can package_update { locked: true } and mcp_server_lock;
        integration_save omits usageMode; approve is a no-op while any.
After:  integration_lock switches any → packages and adds package_id;
        secret_lock adds allowed_packages; unlock stays website-only;
        usage_url keeps Remix %2E encoding for dotted names.
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-658fae00-2614-4abf-8aad-fa3a77b1d61f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-658fae00-2614-4abf-8aad-fa3a77b1d61f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `integration_lock` to restrict integrations to selected packages.
  - Added `secret_lock` to grant user secrets to selected packages.
  - Added usage links for managing integration and secret access.
  - Expanded discovery for locking and usage controls.

- **Documentation**
  - Clarified package approval, tightening, and website-only removal guidance.
  - Updated Gmail drafts, MCP server, integration, and secret management guidance.

- **Tests**
  - Added coverage for restrictions, repeated grants, invalid packages, URL handling, and errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->