### PR TITLE
Retire built-in OAuth as a connect and reconnect path

### DIFF
--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -354,14 +354,14 @@ The schema is defined by migrations in `packages/worker/migrations/`:
   dual-write also keeps `client_secret_secret_name`), provider endpoints, and
   flow options. See [OAuth integrations](./integrations.md).
 - `platform_oauth_apps` (`0004-platform-oauth-apps.sql`): operator-provisioned
-  built-in OAuth apps users connect to without registering their own provider
-  app. Global operator config with **no `user_id`** (like feature flags, not
-  user data). Keyed by `slug`; holds the inline non-secret `client_id`, provider
-  endpoints, flow options, the allowed/default scope menu,
-  `required_hosts_json`, and `enabled`. `client_secret_encrypted` is the one
-  credential ciphertext stored outside `secret_entries` (AES-GCM with a
-  dedicated purpose, so no `{{secret:…}}` placeholder can name it);
-  `getPlatformOauthAppClientSecret` in
+  built-in OAuth apps that remaining connections still refresh against. New
+  connects and reconnects are bring-your-own only. Global operator config with
+  **no `user_id`** (like feature flags, not user data). Keyed by `slug`; holds
+  the inline non-secret `client_id`, provider endpoints, flow options, the
+  allowed/default scope menu, `required_hosts_json`, and `enabled`.
+  `client_secret_encrypted` is the one credential ciphertext stored outside
+  `secret_entries` (AES-GCM with a dedicated purpose, so no `{{secret:…}}`
+  placeholder can name it); `getPlatformOauthAppClientSecret` in
   `packages/worker/src/integrations/platform-apps.ts` is its only decrypt
   accessor. `logo_key` / `logo_content_type`
   (`0005-platform-oauth-app-logos.sql`) point at an operator-owned provider logo

--- a/docs/contributing/architecture/integrations.md
+++ b/docs/contributing/architecture/integrations.md
@@ -5,14 +5,14 @@ Saved third-party OAuth config is a first-class primitive: an **OAuth app**
 **connections** (connected accounts that share that app). An app lives in one of
 two lanes: **user lane** — a per-user `user_oauth_apps` row the user registered
 with the provider — or **platform lane** — an operator-provisioned built-in
-`platform_oauth_apps` row every user can connect to (see
-[Platform (built-in) OAuth apps](#platform-built-in-oauth-apps)). Per-user
-access and refresh tokens live encrypted on the connection
-(`access_token_encrypted` / `refresh_token_encrypted`). User-lane client secrets
-live encrypted on the app (`client_secret_encrypted`). During soak those values
-are dual-written to `secret_entries` under the `*_secret_name` columns so
-placeholder resolution and reconnect still work; those names stay hidden from
-`/account/secrets`, `secret_list`, and search.
+`platform_oauth_apps` row some users still have tokens against (see
+[Platform (built-in) OAuth apps](#platform-built-in-oauth-apps)). New connects
+are bring-your-own only. Per-user access and refresh tokens live encrypted on
+the connection (`access_token_encrypted` / `refresh_token_encrypted`). User-lane
+client secrets live encrypted on the app (`client_secret_encrypted`). During
+soak those values are dual-written to `secret_entries` under the `*_secret_name`
+columns so placeholder resolution and reconnect still work; those names stay
+hidden from `/account/secrets`, `secret_list`, and search.
 
 Data access lives under `packages/worker/src/integrations/`. MCP capabilities
 live under `packages/worker/src/mcp/capabilities/integrations/`. The hosted
@@ -73,11 +73,13 @@ shared user-lane client secret. Deleting the app removes the client secret.
 
 `platform_oauth_apps` (migration
 `packages/worker/migrations/0004-platform-oauth-apps.sql`) holds
-operator-provisioned OAuth app registrations users connect to without creating
-their own provider app. The table is global (no `user_id`) — operator config
-like feature flags, not user data — so it is not a per-user-isolation exception.
-Rows are keyed by `slug` and carry `provider`, `label`, the inline non-secret
-`client_id`, `client_secret_encrypted`, endpoints (`token_url`, `authorize_url`,
+operator-provisioned OAuth app registrations some existing connections still
+refresh against. New connects and reconnects are bring-your-own only; unused
+built-ins are hidden from `/connect/oauth` and `integration_platform_app_list`.
+The table is global (no `user_id`) — operator config like feature flags, not
+user data — so it is not a per-user-isolation exception. Rows are keyed by
+`slug` and carry `provider`, `label`, the inline non-secret `client_id`,
+`client_secret_encrypted`, endpoints (`token_url`, `authorize_url`,
 `api_base_url`), flow options (`flow`, `use_pkce`, `token_exchange_style`,
 `scope_separator`, `extra_authorize_params_json`), the scope menu,
 `required_hosts_json`, and `enabled`.
@@ -94,12 +96,11 @@ so sandboxed code has no resolution path to the shared credential.
 
 **Invariant:** `getPlatformOauthAppClientSecret`
 (`packages/worker/src/integrations/platform-apps.ts`) is the only decrypt
-accessor, and its callers are host-side token-exchange paths only — the
-`/connect/oauth` handler actions in
-`packages/worker/src/app/handlers/account-secrets.ts` and the
-`integration_token_refresh` capability. The decrypted value must never appear in
-capability outputs, loader payloads, or logs. Public projections
-(`platform-app-shared.ts`) expose at most a `hasClientSecret` boolean.
+accessor, and its remaining caller is host-side token refresh
+(`integration_token_refresh`). `/connect/oauth` no longer decrypts or exchanges
+through the shared secret. The decrypted value must never appear in capability
+outputs, loader payloads, or logs. Public projections (`platform-app-shared.ts`)
+expose at most a `hasClientSecret` boolean.
 
 ### Scope menu
 
@@ -250,26 +251,20 @@ note on the architecture index.
 `/connect/oauth` runs authorize → callback → token exchange in the browser
 session, writes access/refresh tokens on the connection (and dual-writes the
 soak secret-store names), and upserts the app + connection via the integrations
-service. A signed-in visit with no `provider` renders a chooser of enabled
-built-ins and saved connections that can start from a name alone. Reconnect with
-`?provider=<integration-name>` reuses saved authorize metadata (scopes,
-`scopeSeparator`, `extraAuthorizeParams`) and the current app client
-credentials.
+service. A signed-in visit with no `provider` renders a chooser of saved
+connections that can start from a name alone. Unused platform (built-in) apps do
+not appear. Existing platform connections stay listed so their tokens can keep
+refreshing, but reconnect is always bring-your-own: `?provider=<name>` prefills
+endpoints and scopes and asks for the user's own client credentials. `platform=`
+query flags and `platformAppSlug` on `oauth_exchange` / `connect_oauth` are
+rejected. Reconnect with `?provider=<integration-name>` reuses saved authorize
+metadata (scopes, `scopeSeparator`, `extraAuthorizeParams`) from a user-lane
+app.
 
-When the user has no matching user-lane app, `?provider=<slug>` prefills from an
-enabled platform app (`loadAccountIntegrationByName` in
-`packages/worker/src/app/account-integrations-data.ts`). The client then skips
-the client-credentials setup step entirely — no client ID/secret inputs and no
-redirect-URI card. The hosted page leads with the provider mark, credentials or
-a connect button, a terms note, and a **Change scopes** disclosure (defaults
-checked; the operator-verified `allowed_scopes` menu is the rest of the list).
-Endpoints, host allowlists, stored config, and the built-in-alternative pitch
-stay behind an advanced disclosure. A `?provider=` visit that cannot resolve
-authorize and token URLs offers a copy-prompt for an agent. The `oauth_exchange`
-/ `connect_oauth` JSON actions accept `platformAppSlug`; for the platform lane
-every exchange input (token URL, flow, exchange style, client id, client secret)
-comes from the operator-provisioned row, never the request body, so a caller
-cannot point the decrypted shared secret at an arbitrary token URL.
+The hosted page leads with the provider mark, credentials or a connect button, a
+terms note, and a **Change scopes** disclosure. Endpoints, host allowlists, and
+stored config stay behind an advanced disclosure. A `?provider=` visit that
+cannot resolve authorize and token URLs offers a copy-prompt for an agent.
 
 `createAuthenticatedFetch(providerName)` (execute runtime helper) loads the
 named connection joined to its app, refreshes the access token when needed, and
@@ -290,16 +285,17 @@ Google, GitHub). Selecting a row shows that integration and the connections
 (signed-in accounts) on it. Each connection shows how many scopes it requests
 versus the built-in menu when one exists, and a copy-prompt asks an agent to
 widen the integration's reconnect scopes (then ask the user to reconnect).
-Built-in integrations show a small “Provided by Kody” indicator. Deep links to a
-connection (`/account/integrations/:name`) open the parent integration and
-highlight that connection. User-registered integrations also have
-`/account/integrations/apps/:appSlug` (a connection named `apps` resolves at
-`/account/integrations/apps`). Endpoints, secret names, host allowlists, flow /
-PKCE / exchange style, and credential rotation stay behind an advanced
-disclosure. Each connection also shows a usage grant: **any context** (execute
-and every package) or **specific packages** only. Agents tighten that grant with
-`integration_lock` (switch to packages mode and add a saved package id;
-unlocking or removing a grant is website-only). One-click approval lives at
+Existing built-in connections show a small “Provided by Kody” indicator.
+Reconnect and add-account links go to bring-your-own `/connect/oauth` (no
+`platform=`). Deep links to a connection (`/account/integrations/:name`) open
+the parent integration and highlight that connection. User-registered
+integrations also have `/account/integrations/apps/:appSlug` (a connection named
+`apps` resolves at `/account/integrations/apps`). Endpoints, secret names, host
+allowlists, flow / PKCE / exchange style, and credential rotation stay behind an
+advanced disclosure. Each connection also shows a usage grant: **any context**
+(execute and every package) or **specific packages** only. Agents tighten that
+grant with `integration_lock` (switch to packages mode and add a saved package
+id; unlocking or removing a grant is website-only). One-click approval lives at
 `/account/integrations/approve?name=&package_id=`; approving a package while the
 connection is still `any` leaves it `any` so execute stays usable. The rotate
 form posts to `/account/integrations.json` with
@@ -326,7 +322,7 @@ Domain: `integrations`
 | `integration_oauth_app_list`                           | Apps with connection counts and sibling connection names                          |
 | `integration_oauth_app_delete`                         | Delete a user-lane app and every connection on it                                 |
 | `integration_oauth_app_rotate_credentials`             | Rotate shared app `clientId` / client-secret name                                 |
-| `integration_platform_app_list`                        | Enabled platform (built-in) apps; public projection, never any secret             |
+| `integration_platform_app_list`                        | Always empty while platform apps are retired; operators use admin list            |
 | `integration_token_refresh`                            | Host-side OAuth refresh; returns metadata only, never token values                |
 | `integration_refresh_access_token`                     | User-lane host refresh plus materialized access token for `refreshAccessToken`    |
 | `integration_registry_search` / `integration_discover` | Untrusted integrations.sh research                                                |

--- a/packages/worker/client/routes/account-integrations-detail.tsx
+++ b/packages/worker/client/routes/account-integrations-detail.tsx
@@ -381,7 +381,6 @@ export function renderIntegrationRecord(props: IntegrationRecordProps) {
 						<a
 							href={buildConnectOauthHref({
 								name: selectedApp.slug,
-								platform: isBuiltInApp(selectedApp),
 								appSlug: selectedApp.slug,
 							})}
 							mix={css({
@@ -411,8 +410,9 @@ export function renderIntegrationRecord(props: IntegrationRecordProps) {
 								: 'Needs setup'
 							const connectHref = buildConnectOauthHref({
 								name: connectionRef.name,
-								platform: connection?.platform ?? isBuiltInApp(selectedApp),
-								appSlug: connection?.appSlug ?? selectedApp.slug,
+								appSlug: connection?.platform
+									? undefined
+									: (connection?.appSlug ?? selectedApp.slug),
 							})
 							const disconnectCheck = getDisconnectCheck(connectionRef.name)
 							const confirmingDisconnect = disconnectCheck.doubleCheck
@@ -542,7 +542,6 @@ export function renderIntegrationRecord(props: IntegrationRecordProps) {
 						})}
 						<AddAccountForm
 							slug={selectedApp.slug}
-							platform={isBuiltInApp(selectedApp)}
 							existingNames={[
 								...integrations.map((entry) => entry.name),
 								...apps.map((app) => app.slug),

--- a/packages/worker/client/routes/account-integrations-forms.tsx
+++ b/packages/worker/client/routes/account-integrations-forms.tsx
@@ -40,7 +40,6 @@ const addAccountLinkCss = {
 export function AddAccountForm(
 	handle: Handle<{
 		slug: string
-		platform: boolean
 		existingNames: ReadonlyArray<string>
 		open: boolean
 		openHref: string
@@ -53,7 +52,6 @@ export function AddAccountForm(
 	function connectHref(connectionName: string) {
 		return buildConnectOauthHref({
 			name: connectionName,
-			platform: handle.props.platform,
 			appSlug: handle.props.slug,
 		})
 	}

--- a/packages/worker/client/routes/account-integrations.tsx
+++ b/packages/worker/client/routes/account-integrations.tsx
@@ -138,7 +138,7 @@ export function AccountIntegrationsRoute(handle: Handle) {
 				(connection) => connection.name !== name,
 			)
 			if (connections.length === app.connections.length) return [app]
-			if (connections.length === 0 && !isBuiltInApp(app)) return []
+			if (connections.length === 0) return []
 			return [
 				{
 					...app,

--- a/packages/worker/client/routes/connect-oauth-chooser-list.node.test.ts
+++ b/packages/worker/client/routes/connect-oauth-chooser-list.node.test.ts
@@ -5,12 +5,12 @@ test('connect chooser filter matches label, detail, and provider key', () => {
 	const options = [
 		{
 			label: 'Google',
-			detail: "Connect with Kody's built-in app",
+			detail: 'Set up your own OAuth app to reconnect',
 			providerKey: 'google',
 		},
 		{
 			label: 'GitHub work',
-			detail: 'Reconnect this built-in account',
+			detail: 'Reconnect your OAuth app',
 			providerKey: 'github',
 		},
 		{
@@ -21,9 +21,8 @@ test('connect chooser filter matches label, detail, and provider key', () => {
 	]
 
 	expect(filterConnectOauthChooserOptions(options, '')).toEqual(options)
-	expect(filterConnectOauthChooserOptions(options, '  built-in  ')).toEqual([
+	expect(filterConnectOauthChooserOptions(options, '  set up  ')).toEqual([
 		options[0],
-		options[1],
 	])
 	expect(filterConnectOauthChooserOptions(options, 'GITHUB')).toEqual([
 		options[1],

--- a/packages/worker/client/routes/connect-oauth-config.ts
+++ b/packages/worker/client/routes/connect-oauth-config.ts
@@ -397,18 +397,9 @@ export function mergeConnectOauthConfig(input: {
 		input.queryConfig.usePkce ??
 		input.storedIntegration?.usePkce ??
 		defaultConnectOauthUsePkce({ flow, tokenUrl })
-	const platformAllowedScopes = input.storedIntegration?.platformAppSlug
-		? (input.storedIntegration.platformAllowedScopes ?? [])
-		: null
-	// Platform apps clamp requested scopes to the operator-verified menu, so
-	// query-supplied scopes can never widen the authorize request. The server
-	// re-validates before persisting anything.
-	const scopes =
-		platformAllowedScopes === null
-			? resolveConnectOauthScopes(input)
-			: resolveConnectOauthScopes(input).filter((scope) =>
-					platformAllowedScopes.includes(scope),
-				)
+	// Platform connect is retired: never clamp to an operator-verified menu
+	// or skip client-credential setup. Existing platform tokens still refresh.
+	const scopes = resolveConnectOauthScopes(input)
 	const extraAuthorizeParams = {
 		...resolveConnectOauthExtraAuthorizeParams(input),
 	}
@@ -422,18 +413,13 @@ export function mergeConnectOauthConfig(input: {
 		...(input.storedIntegration?.requiredHosts ?? []),
 	])
 	if (allowedHosts.length === 0) return null
-	const platformAppSlug = input.storedIntegration?.platformAppSlug ?? null
 	return {
-		platformAppSlug,
-		platformLogoPath: platformAppSlug
-			? parsePlatformLogoPath(input.storedIntegration?.platformLogoPath)
-			: null,
+		platformAppSlug: null,
+		platformLogoPath: null,
 		logoPath: input.storedIntegration?.logoPath?.trim() || null,
 		autoLogoPath: input.storedIntegration?.autoLogoPath?.trim() || null,
-		platformDescription: platformAppSlug
-			? input.storedIntegration?.platformDescription?.trim() || null
-			: null,
-		platformAllowedScopes: platformAllowedScopes ?? [],
+		platformDescription: null,
+		platformAllowedScopes: [],
 		provider,
 		providerKey,
 		authorizeHost,
@@ -457,11 +443,11 @@ export function mergeConnectOauthConfig(input: {
 		extraAuthorizeParams,
 		providerSetupInstructions: input.queryConfig.providerSetupInstructions,
 		dashboardUrl: input.queryConfig.dashboardUrl,
-		clientId: input.storedIntegration?.clientId?.trim() || '',
-		// Platform apps keep the shared client secret server-side: there is
-		// never a user secret name for it, whatever the flow.
+		clientId: input.storedIntegration?.platformAppSlug
+			? ''
+			: input.storedIntegration?.clientId?.trim() || '',
 		clientSecretSecretName:
-			flow === 'confidential' && !platformAppSlug
+			flow === 'confidential'
 				? (input.storedIntegration?.clientSecretSecretName ??
 					`${providerKey}ClientSecret`)
 				: null,

--- a/packages/worker/client/routes/connect-oauth-detail.tsx
+++ b/packages/worker/client/routes/connect-oauth-detail.tsx
@@ -20,7 +20,6 @@ import {
 	type StoredIntegrationConfig,
 	isSafeExternalUrl,
 } from './connect-oauth-config.ts'
-import { renderBuiltInAlternative } from './connect-oauth-sections.tsx'
 import {
 	connectOauthAdvancedDetailsCss,
 	connectOauthRedirectUriCardCss,
@@ -241,7 +240,6 @@ export function renderExistingIntegrationConfig(
 
 export function renderAdvancedDetails(input: {
 	config: ConnectOauthConfig
-	builtInAvailable: boolean
 	existingIntegrationConfig: StoredIntegrationConfig | null
 }) {
 	return (
@@ -251,10 +249,6 @@ export function renderAdvancedDetails(input: {
 		>
 			<summary>Advanced details</summary>
 			<div mix={css({ display: 'grid', gap: spacing.md })}>
-				{renderBuiltInAlternative({
-					builtInAvailable: input.builtInAvailable,
-					config: input.config,
-				})}
 				{renderProviderDetails(input.config)}
 				{renderAllowedHosts(input.config)}
 				{renderExistingIntegrationConfig(input.existingIntegrationConfig)}

--- a/packages/worker/client/routes/connect-oauth-forms.tsx
+++ b/packages/worker/client/routes/connect-oauth-forms.tsx
@@ -240,11 +240,9 @@ export function renderConnectStep(input: {
 		typeof renderReplaceConfirmation
 	>[0]['existingConnection']
 	replaceConfirmed: boolean
-	renameInput: string
 	submitting: boolean
 	offeredScopeMenu: Array<string>
 	onConfirmReplace: () => void
-	onRenameInput: (value: string) => void
 	onConnect: () => void
 	onToggleScope: (scope: string) => void
 	wouldReplace: boolean
@@ -255,10 +253,8 @@ export function renderConnectStep(input: {
 				config: input.config,
 				existingConnection: input.existingConnection,
 				replaceConfirmed: input.replaceConfirmed,
-				renameInput: input.renameInput,
 				submitting: input.submitting,
 				onConfirm: input.onConfirmReplace,
-				onRenameInput: input.onRenameInput,
 			})}
 			<p mix={css({ margin: 0, color: colors.text })}>
 				Connecting authorizes your agent — and any code you run or install — to

--- a/packages/worker/client/routes/connect-oauth-sections.tsx
+++ b/packages/worker/client/routes/connect-oauth-sections.tsx
@@ -4,14 +4,12 @@ import { CopyTextButton } from '#client/copy-text-button.tsx'
 import { buildIncompleteConnectOauthPrompt } from '#universal/oauth-scopes.ts'
 import { isConnectOauthCallbackUrl } from '#universal/oauth-connect.ts'
 import { on } from '#client/event-mixin.ts'
-import { passwordManagerIgnoreProps } from '#client/password-manager-ignore.ts'
 import { ProviderMark } from '#client/provider-icons.tsx'
 import { colors, spacing } from '#universal/styles/tokens.ts'
 import {
 	cardCss,
 	descriptionCss,
 	getAccentCalloutCss,
-	getPrimaryButtonCss,
 	getSecondaryButtonCss,
 	inputCss,
 	insetCardCss,
@@ -37,12 +35,6 @@ export function wouldReplaceDifferentApp(input: {
 	existingConnection: ConnectOauthExistingConnection | null
 }) {
 	if (!input.config || !input.existingConnection) return false
-	if (input.config.platformAppSlug) {
-		return (
-			input.existingConnection.lane !== 'platform' ||
-			input.existingConnection.appSlug !== input.config.platformAppSlug
-		)
-	}
 	return input.existingConnection.lane === 'platform'
 }
 
@@ -50,10 +42,8 @@ export function renderReplaceConfirmation(input: {
 	config: ConnectOauthConfig
 	existingConnection: ConnectOauthExistingConnection | null
 	replaceConfirmed: boolean
-	renameInput: string
 	submitting: boolean
 	onConfirm: () => void
-	onRenameInput: (value: string) => void
 }) {
 	if (
 		!wouldReplaceDifferentApp({
@@ -68,7 +58,6 @@ export function renderReplaceConfirmation(input: {
 		input.existingConnection?.lane === 'platform'
 			? `the built-in ${input.existingConnection.appSlug} integration`
 			: 'your own OAuth app'
-	const renameSuggestion = `${input.config.providerKey}-2`
 	return (
 		<div mix={css(insetCardCss)}>
 			<p mix={css({ margin: 0, color: colors.text, fontWeight: 600 })}>
@@ -100,84 +89,8 @@ export function renderReplaceConfirmation(input: {
 				>
 					Replace {input.config.providerKey}
 				</button>
-				{input.config.platformAppSlug ? (
-					<>
-						<span mix={css(descriptionCss)}>or connect as</span>
-						<input
-							type="text"
-							placeholder={renameSuggestion}
-							value={input.renameInput}
-							{...passwordManagerIgnoreProps}
-							mix={[
-								on('input', (event) => {
-									input.onRenameInput(event.currentTarget.value)
-								}),
-								css({ ...inputCss, maxWidth: '12rem' }),
-							]}
-							data-testid="connect-rename-input"
-						/>
-						<button
-							type="button"
-							disabled={input.submitting}
-							mix={[
-								on('click', () => {
-									const name = input.renameInput.trim() || renameSuggestion
-									// Full document load: the renamed connect
-									// resolves the built-in on a fresh page.
-									window.location.assign(
-										`/connect/oauth?provider=${encodeURIComponent(name)}&platform=${encodeURIComponent(input.config.platformAppSlug!)}`,
-									)
-								}),
-								css(getPrimaryButtonCss()),
-							]}
-							data-testid="connect-rename-submit"
-						>
-							Connect
-						</button>
-					</>
-				) : null}
 			</div>
 		</div>
-	)
-}
-
-/**
- * Shown when the current (or prospective) connection runs on the user's
- * own OAuth app while an enabled built-in exists for the same name. A
- * complete bring-your-own record wins the lookup by design, so without
- * this the built-in lane is invisible from the connect page.
- */
-export function renderBuiltInAlternative(input: {
-	builtInAvailable: boolean
-	config: ConnectOauthConfig | null
-}) {
-	if (
-		!input.builtInAvailable ||
-		!input.config ||
-		input.config.platformAppSlug
-	) {
-		return null
-	}
-	return (
-		<p mix={css(descriptionCss)}>
-			This uses your own OAuth app for {input.config.provider}. Prefer the
-			hosted one?{' '}
-			<a
-				href={`/connect/oauth?provider=${encodeURIComponent(input.config.providerKey)}&platform=1`}
-				mix={[
-					css(primaryLinkCss),
-					// Full document load on purpose: switching lanes
-					// re-resolves config from a fresh page.
-					on('click', (event) => {
-						event.preventDefault()
-						window.location.assign(event.currentTarget.href)
-					}),
-				]}
-			>
-				Use the built-in {input.config.provider} integration instead
-			</a>{' '}
-			— connecting it replaces this connection&apos;s tokens and scopes.
-		</p>
 	)
 }
 
@@ -388,10 +301,6 @@ export function connectOauthHeaderDescription(input: {
 		return input.statusMessage
 	}
 	if (input.currentStep === 'success') return "You're connected."
-	if (input.config.platformDescription) return input.config.platformDescription
-	if (input.config.platformAppSlug) {
-		return `Continue to ${input.config.provider} to approve access.`
-	}
 	if (input.currentStep === 'setup') {
 		return `Create an OAuth app on ${input.config.provider}, register the redirect URL, and paste the credentials below.`
 	}

--- a/packages/worker/client/routes/connect-oauth-shared.ts
+++ b/packages/worker/client/routes/connect-oauth-shared.ts
@@ -95,8 +95,6 @@ export function buildConnectOauthIntegrationLookupHref(
 	searchParams: URLSearchParams,
 ) {
 	const params = new URLSearchParams({ name: providerKey })
-	const platform = searchParams.get('platform')?.trim()
-	if (platform) params.set('platform', platform)
 	const app = searchParams.get('app')?.trim()
 	if (app) params.set('app', app)
 	return `/account/integrations.json?${params.toString()}`
@@ -104,7 +102,7 @@ export function buildConnectOauthIntegrationLookupHref(
 
 /**
  * SPA-navigation prefetch mirroring the server handler's SSR embed: the
- * stored or built-in record for `?provider=` visits, resolved before the
+ * stored bring-your-own record for `?provider=` visits, resolved before the
  * route renders. Callback returns (`code`/`error`) restore config from
  * sessionStorage and bare visits redirect server-side, so both prefetch
  * nothing.

--- a/packages/worker/client/routes/connect-oauth.node.test.ts
+++ b/packages/worker/client/routes/connect-oauth.node.test.ts
@@ -259,8 +259,9 @@ test('connect OAuth helpers parse stored integrations, merge reconnect configs, 
 	})
 	expect(platformGoogle).toMatchObject({
 		scopes: ['openid', 'email'],
-		platformAppSlug: 'google',
-		platformAllowedScopes: ['openid', 'email', 'profile'],
+		platformAppSlug: null,
+		platformAllowedScopes: [],
+		clientId: '',
 	})
 
 	const spotifyConfig = mergeConnectOauthConfig({

--- a/packages/worker/client/routes/connect-oauth.tsx
+++ b/packages/worker/client/routes/connect-oauth.tsx
@@ -94,13 +94,10 @@ export function ConnectOauthRoute(handle: Handle) {
 	let hasConfigError = false
 	let connectOauthHandled = false
 	let hostApprovalLinks: Array<ConnectOauthHostApprovalLink> = []
-	/** An enabled built-in exists that this user-lane connection is not using. */
-	let builtInAvailable = false
 	/** The connection currently stored under the target name, when any. */
 	let existingConnection: ConnectOauthExistingConnection | null = null
 	/** The user explicitly confirmed replacing a different-app connection. */
 	let replaceConfirmed = false
-	let renameInput = ''
 	let chooserOptions: Array<ConnectOauthChooserOption> = []
 	let chooserFilter = ''
 	let requestedProvider: string | null = null
@@ -117,9 +114,9 @@ export function ConnectOauthRoute(handle: Handle) {
 	let routeDataApplied = false
 	/**
 	 * Normalized pathname+search the current resolution state belongs to.
-	 * SPA navigations to a different connect URL (another provider, a
-	 * platform lane switch) reset and re-resolve instead of keeping the
-	 * previous provider's config on screen.
+	 * SPA navigations to a different connect URL (another provider)
+	 * reset and re-resolve instead of keeping the previous provider's
+	 * config on screen.
 	 */
 	let resolvedHref: string | null = null
 	/** Server-computed redirect URI so SSR renders the card `window` builds. */
@@ -137,11 +134,9 @@ export function ConnectOauthRoute(handle: Handle) {
 		config = null
 		existingIntegrationConfig = null
 		existingConnection = null
-		builtInAvailable = false
 		hasStoredClientSecret = false
 		hasConfigError = false
 		replaceConfirmed = false
-		renameInput = ''
 		chooserOptions = []
 		chooserFilter = ''
 		requestedProvider = null
@@ -224,7 +219,6 @@ export function ConnectOauthRoute(handle: Handle) {
 			.json()
 			.catch(() => null)) as AccountIntegrationDetailLoaderData | null
 		if (!response.ok || payload?.ok !== true) return null
-		builtInAvailable = payload.builtInAvailable ?? false
 		existingConnection = payload.existingConnection ?? null
 		hasStoredClientSecret = payload.hasStoredClientSecret === true
 		if (!payload.integration) return null
@@ -481,7 +475,6 @@ export function ConnectOauthRoute(handle: Handle) {
 		if (!routeData) return
 		routeDataApplied = true
 		ssrRedirectUri = routeData.redirectUri ?? null
-		builtInAvailable = routeData.builtInAvailable ?? false
 		existingConnection = routeData.existingConnection ?? null
 		chooserOptions = routeData.chooser?.options ?? []
 		if (url.searchParams.get('code') || url.searchParams.get('error')) {
@@ -745,15 +738,10 @@ export function ConnectOauthRoute(handle: Handle) {
 							config: currentConfig,
 							existingConnection,
 							replaceConfirmed,
-							renameInput,
 							submitting,
 							offeredScopeMenu,
 							onConfirmReplace: () => {
 								replaceConfirmed = true
-								update()
-							},
-							onRenameInput: (value) => {
-								renameInput = value
 								update()
 							},
 							onConnect: () => {
@@ -786,7 +774,6 @@ export function ConnectOauthRoute(handle: Handle) {
 						})
 					: renderAdvancedDetails({
 							config: currentConfig,
-							builtInAvailable,
 							existingIntegrationConfig,
 						})}
 			</section>

--- a/packages/worker/src/app/account-integrations-data.node.test.ts
+++ b/packages/worker/src/app/account-integrations-data.node.test.ts
@@ -8,7 +8,9 @@ import {
 	upsertPlatformIntegration,
 } from '#worker/integrations/service.ts'
 import { upsertPlatformOauthApp } from '#worker/integrations/platform-apps.ts'
+import { updateOauthAppClientSecretCiphertext } from '#worker/integrations/repo.ts'
 import {
+	hasStoredConnectClientSecret,
 	loadAccountIntegrationByName,
 	loadAccountIntegrationsData,
 	loadAccountOauthAppBySlug,
@@ -194,6 +196,7 @@ test('connect lookup never prefills a built-in and converts platform reconnects 
 	)
 	expect(platformReconnect).toMatchObject({
 		name: 'github',
+		appSlug: '',
 		platform: false,
 		clientId: '',
 		authorization: {
@@ -213,6 +216,7 @@ test('connect lookup never prefills a built-in and converts platform reconnects 
 	)
 	expect(addAccountOnPlatform).toMatchObject({
 		name: 'github-2',
+		appSlug: '',
 		platform: false,
 		clientId: '',
 		tokenUrl: 'https://github.com/login/oauth/access_token',
@@ -223,6 +227,43 @@ test('connect lookup never prefills a built-in and converts platform reconnects 
 		accessTokenSecretName: 'github-2AccessToken',
 		refreshTokenSecretName: 'github-2RefreshToken',
 	})
+
+	await upsertOauthAppWithoutConnection({
+		env,
+		userId,
+		config: {
+			name: 'github',
+			tokenUrl: 'https://github.com/login/oauth/access_token',
+			flow: 'confidential',
+			clientId: 'user-github-client',
+			clientSecretSecretName: 'otherGithubClientSecret',
+			authorization: {
+				authorizeUrl: 'https://github.com/login/oauth/authorize',
+			},
+		},
+	})
+	await updateOauthAppClientSecretCiphertext({
+		db: env.APP_DB,
+		userId,
+		slug: 'github',
+		clientSecretEncrypted: 'ciphertext-from-other-byo-app',
+	})
+	expect(
+		await hasStoredConnectClientSecret(
+			env,
+			fakeUser(userId),
+			'github',
+			platformReconnect,
+		),
+	).toBe(false)
+	expect(
+		await hasStoredConnectClientSecret(
+			env,
+			fakeUser(userId),
+			'github-2',
+			addAccountOnPlatform,
+		),
+	).toBe(false)
 
 	await upsertIntegration({
 		env,

--- a/packages/worker/src/app/account-integrations-data.node.test.ts
+++ b/packages/worker/src/app/account-integrations-data.node.test.ts
@@ -173,6 +173,11 @@ test('connect lookup never prefills a built-in and converts platform reconnects 
 	expect(
 		await loadAccountIntegrationByName(env, fakeUser(userId), 'github'),
 	).toBeNull()
+	expect(
+		await loadAccountIntegrationByName(env, fakeUser(userId), 'github-2', {
+			appSlug: 'github',
+		}),
+	).toBeNull()
 
 	await upsertPlatformIntegration({
 		env,
@@ -199,6 +204,25 @@ test('connect lookup never prefills a built-in and converts platform reconnects 
 	expect(
 		await loadExistingConnectionSummary(env, fakeUser(userId), 'github'),
 	).toEqual({ lane: 'platform', appSlug: 'github' })
+
+	const addAccountOnPlatform = await loadAccountIntegrationByName(
+		env,
+		fakeUser(userId),
+		'github-2',
+		{ appSlug: 'github' },
+	)
+	expect(addAccountOnPlatform).toMatchObject({
+		name: 'github-2',
+		platform: false,
+		clientId: '',
+		tokenUrl: 'https://github.com/login/oauth/access_token',
+		authorization: {
+			authorizeUrl: 'https://github.com/login/oauth/authorize',
+			scopes: ['read:user'],
+		},
+		accessTokenSecretName: 'github-2AccessToken',
+		refreshTokenSecretName: 'github-2RefreshToken',
+	})
 
 	await upsertIntegration({
 		env,

--- a/packages/worker/src/app/account-integrations-data.node.test.ts
+++ b/packages/worker/src/app/account-integrations-data.node.test.ts
@@ -9,7 +9,6 @@ import {
 } from '#worker/integrations/service.ts'
 import { upsertPlatformOauthApp } from '#worker/integrations/platform-apps.ts'
 import {
-	hasAlternativeBuiltInApp,
 	loadAccountIntegrationByName,
 	loadAccountIntegrationsData,
 	loadAccountOauthAppBySlug,
@@ -149,7 +148,7 @@ test('loadAccountIntegrationByName covers setup prefill, reconnect, and exact-sl
 	})
 })
 
-test('endpoint-incomplete user records defer to an enabled built-in of the same name', async () => {
+test('connect lookup never prefills a built-in and converts platform reconnects to BYO', async () => {
 	const { env } = createEnv()
 	const userId = 'user-platform-priority'
 	const platformEnv = {
@@ -171,39 +170,36 @@ test('endpoint-incomplete user records defer to an enabled built-in of the same 
 		},
 	})
 
-	// API-use-only connection (the shape agents save: token endpoint and API
-	// base, no authorize URL). It cannot drive the connect page, so the
-	// built-in wins.
-	await upsertIntegration({
+	expect(
+		await loadAccountIntegrationByName(env, fakeUser(userId), 'github'),
+	).toBeNull()
+
+	await upsertPlatformIntegration({
 		env,
 		userId,
-		config: {
-			name: 'github',
-			tokenUrl: 'https://github.com/login/oauth/access_token',
-			apiBaseUrl: 'https://api.github.com',
-			flow: 'confidential',
-			clientId: 'user-github-client',
-			clientSecretSecretName: 'githubClientSecret',
-			accessTokenSecretName: 'githubAccessToken',
-			refreshTokenSecretName: null,
-			requiredHosts: ['api.github.com'],
-		},
+		platformAppSlug: 'github',
+		name: 'github',
+		scopes: ['read:user'],
+		accessTokenSecretName: 'githubAccessToken',
 	})
-	const deferred = await loadAccountIntegrationByName(
+	const platformReconnect = await loadAccountIntegrationByName(
 		env,
 		fakeUser(userId),
 		'github',
 	)
-	expect(deferred).toMatchObject({
+	expect(platformReconnect).toMatchObject({
 		name: 'github',
-		platform: true,
-		clientId: 'platform-github-client',
+		platform: false,
+		clientId: '',
 		authorization: {
 			authorizeUrl: 'https://github.com/login/oauth/authorize',
+			scopes: ['read:user'],
 		},
 	})
+	expect(
+		await loadExistingConnectionSummary(env, fakeUser(userId), 'github'),
+	).toEqual({ lane: 'platform', appSlug: 'github' })
 
-	// A complete bring-your-own record still wins over the built-in.
 	await upsertIntegration({
 		env,
 		userId,
@@ -232,73 +228,19 @@ test('endpoint-incomplete user records defer to an enabled built-in of the same 
 	)
 	expect(byoWins?.clientId).toBe('user-github-client')
 	expect(byoWins?.platform ?? false).toBe(false)
-	// The winning BYO record shadows an enabled built-in — the connect page
-	// surfaces the alternative lane instead of hiding it.
-	expect(await hasAlternativeBuiltInApp(env, 'github', byoWins)).toBe(true)
 
-	// Explicit built-in intent overrides the BYO win.
-	const forced = await loadAccountIntegrationByName(
-		env,
-		fakeUser(userId),
-		'github',
-		{ preferPlatform: true },
-	)
-	expect(forced?.platform).toBe(true)
-	expect(forced?.clientId).toBe('platform-github-client')
-	expect(await hasAlternativeBuiltInApp(env, 'github', forced)).toBe(false)
-
-	// platform=<slug>: the built-in connects under a different name so the
-	// existing connection survives (rename-instead-of-replace).
-	const renamed = await loadAccountIntegrationByName(
+	const familyPrefill = await loadAccountIntegrationByName(
 		env,
 		fakeUser(userId),
 		'github-2',
-		{ platformSlug: 'github' },
 	)
-	expect(renamed).toMatchObject({
+	expect(familyPrefill).toMatchObject({
 		name: 'github-2',
 		appSlug: 'github',
-		platform: true,
-		accessTokenSecretName: 'github-2AccessToken',
+		clientId: 'user-github-client',
 	})
+	expect(familyPrefill?.platform ?? false).toBe(false)
 
-	// The existing-connection summary powers the replace confirmation.
-	expect(
-		await loadExistingConnectionSummary(env, fakeUser(userId), 'github'),
-	).toEqual({ lane: 'user', appSlug: 'github' })
-	expect(
-		await loadExistingConnectionSummary(env, fakeUser(userId), 'github-2'),
-	).toBeNull()
-
-	// Exact platform slug beats the fuzzy provider-family prefill: with a
-	// built-in named github-platform, a user who owns a github app must
-	// still land on the built-in (the family matcher would otherwise treat
-	// github-platform as a github multi-account name).
-	await upsertPlatformOauthApp({
-		db: env.APP_DB,
-		env: platformEnv,
-		app: {
-			slug: 'github-platform',
-			clientId: 'platform-suffixed-client',
-			clientSecret: 'platform-suffixed-secret',
-			tokenUrl: 'https://github.com/login/oauth/access_token',
-			authorizeUrl: 'https://github.com/login/oauth/authorize',
-			flow: 'confidential',
-		},
-	})
-	const suffixed = await loadAccountIntegrationByName(
-		env,
-		fakeUser(userId),
-		'github-platform',
-	)
-	expect(suffixed).toMatchObject({
-		name: 'github-platform',
-		platform: true,
-		clientId: 'platform-suffixed-client',
-	})
-
-	// No built-in for the slug: the incomplete record still returns so the
-	// setup form can prefill what exists.
 	await upsertIntegration({
 		env,
 		userId,
@@ -311,13 +253,13 @@ test('endpoint-incomplete user records defer to an enabled built-in of the same 
 			refreshTokenSecretName: null,
 		},
 	})
-	const noFallback = await loadAccountIntegrationByName(
+	const incomplete = await loadAccountIntegrationByName(
 		env,
 		fakeUser(userId),
 		'linear',
 	)
-	expect(noFallback?.clientId).toBe('user-linear-client')
-	expect(noFallback?.platform ?? false).toBe(false)
+	expect(incomplete?.clientId).toBe('user-linear-client')
+	expect(incomplete?.platform ?? false).toBe(false)
 
 	const pinnedByo = await loadAccountIntegrationByName(
 		env,
@@ -332,8 +274,6 @@ test('endpoint-incomplete user records defer to an enabled built-in of the same 
 	})
 	expect(pinnedByo?.platform ?? false).toBe(false)
 
-	// An incomplete pinned app must not fall back to a built-in that
-	// happens to share the typed connection name.
 	const pinnedIncomplete = await loadAccountIntegrationByName(
 		env,
 		fakeUser(userId),

--- a/packages/worker/src/app/account-integrations-data.ts
+++ b/packages/worker/src/app/account-integrations-data.ts
@@ -77,6 +77,29 @@ function toBringYourOwnReconnectRecord(
 }
 
 /**
+ * Add-account on a leftover platform integration (`app=<platform-slug>`).
+ * Reuse endpoints and scopes from a sibling platform connection the user
+ * already has, but keep the new name and empty client credentials so the
+ * setup form is bring-your-own.
+ */
+function toBringYourOwnSetupFromPlatformConnection(
+	entry: Extract<JoinedIntegration, { lane: 'platform' }>,
+	requestedName: string,
+): AccountIntegrationRecord {
+	const providerKey = canonicalIntegrationName(requestedName) || requestedName
+	const record = toBringYourOwnReconnectRecord(
+		toAccountIntegrationRecord(entry),
+	)
+	return {
+		...record,
+		name: providerKey,
+		accountLabel: null,
+		accessTokenSecretName: `${providerKey}AccessToken`,
+		refreshTokenSecretName: `${providerKey}RefreshToken`,
+	}
+}
+
+/**
  * Convert a setup prefill (exact app, sole family member, or field-wise family
  * merge) into the connect-flow payload. `requestedName` is the connection name
  * being set up — it may differ from `prefill.slug` when the app was reused
@@ -369,6 +392,17 @@ export async function loadAccountIntegrationByName(
 		})
 		if (app) {
 			return toAppOnlyIntegrationRecord(oauthAppToSetupPrefill(app), name)
+		}
+		const siblings = await listJoinedIntegrations({
+			env,
+			userId: user.mcpUser.userId,
+		})
+		const platformSibling = siblings.find(
+			(entry): entry is Extract<JoinedIntegration, { lane: 'platform' }> =>
+				entry.lane === 'platform' && entry.app.slug === options.appSlug,
+		)
+		if (platformSibling) {
+			return toBringYourOwnSetupFromPlatformConnection(platformSibling, name)
 		}
 	}
 

--- a/packages/worker/src/app/account-integrations-data.ts
+++ b/packages/worker/src/app/account-integrations-data.ts
@@ -68,6 +68,10 @@ function toBringYourOwnReconnectRecord(
 	return {
 		...record,
 		platform: false,
+		// Do not keep the leftover platform slug: hasStoredConnectClientSecret
+		// treats a non-platform appSlug as a user-lane app and can pick up a
+		// sibling BYO client secret.
+		appSlug: '',
 		clientId: '',
 		clientSecretSecretName: null,
 		platformAllowedScopes: undefined,

--- a/packages/worker/src/app/account-integrations-data.ts
+++ b/packages/worker/src/app/account-integrations-data.ts
@@ -10,7 +10,6 @@ import { canonicalIntegrationName } from '#mcp/capabilities/integrations/integra
 import { listSecrets } from '#mcp/secrets/service.ts'
 import {
 	findOauthAppForProviderSetup,
-	getAvailablePlatformApp,
 	getJoinedIntegration,
 	getOauthApp,
 	listJoinedIntegrations,
@@ -59,45 +58,21 @@ function toAccountIntegrationRecord(
 }
 
 /**
- * Connect-flow payload for a platform (built-in) app the user has not
- * connected yet. No client credentials appear: the operator owns the app
- * registration and token exchange runs host-side.
+ * Existing platform connections stay listed so tokens can keep refreshing,
+ * but reconnect is always bring-your-own: keep endpoints and scopes, drop
+ * the operator client id and platform-lane flags so the setup form appears.
  */
-function toPlatformAppPrefillRecord(
-	app: PlatformOauthApp,
-	requestedName: string,
+function toBringYourOwnReconnectRecord(
+	record: AccountIntegrationRecord,
 ): AccountIntegrationRecord {
-	const providerKey = canonicalIntegrationName(requestedName) || app.slug
 	return {
-		name: providerKey,
-		appSlug: app.slug,
-		provider: app.provider,
-		appLabel: app.label,
-		accountLabel: null,
-		tokenUrl: app.tokenUrl,
-		apiBaseUrl: app.apiBaseUrl,
-		flow: app.flow,
-		...(typeof app.usePkce === 'boolean' ? { usePkce: app.usePkce } : {}),
-		clientId: app.clientId,
+		...record,
+		platform: false,
+		clientId: '',
 		clientSecretSecretName: null,
-		accessTokenSecretName: `${providerKey}AccessToken`,
-		refreshTokenSecretName: `${providerKey}RefreshToken`,
-		requiredHosts: app.requiredHosts,
-		...(app.tokenExchangeStyle
-			? { tokenExchangeStyle: app.tokenExchangeStyle }
-			: {}),
-		authorization: {
-			authorizeUrl: app.authorizeUrl,
-			scopes: app.defaultScopes,
-			scopeSeparator: app.scopeSeparator,
-			extraAuthorizeParams: app.extraAuthorizeParams,
-		},
-		platform: true,
-		platformAllowedScopes: app.allowedScopes,
-		platformLogoPath: buildPlatformOauthAppLogoPath(app),
-		platformDescription: app.description,
-		createdAt: app.createdAt,
-		updatedAt: app.updatedAt,
+		platformAllowedScopes: undefined,
+		platformLogoPath: undefined,
+		platformDescription: undefined,
 	}
 }
 
@@ -348,31 +323,13 @@ export async function loadAccountOauthAppBySlug(
 	)
 }
 
-/**
- * True when the record carries the endpoints the connect page needs to run
- * an authorize → token exchange flow. Records created for API use only
- * (agents typically save tokenUrl and apiBaseUrl but no authorize URL)
- * cannot, and would dead-end the page on "missing configuration".
- */
 export function readConnectOauthLookupOptions(searchParams: URLSearchParams) {
-	const platformParam = searchParams.get('platform')?.trim()
 	const appParam = searchParams.get('app')?.trim()
 	return {
-		preferPlatform: platformParam === '1',
-		platformSlug:
-			platformParam && platformParam !== '1'
-				? (normalizeProviderKey(platformParam) ?? undefined)
-				: undefined,
 		appSlug: appParam
 			? (normalizeProviderKey(appParam) ?? undefined)
 			: undefined,
 	}
-}
-
-function recordCanDriveConnectFlow(record: AccountIntegrationRecord): boolean {
-	return Boolean(
-		record.authorization?.authorizeUrl?.trim() && record.tokenUrl?.trim(),
-	)
 }
 
 export async function loadAccountIntegrationByName(
@@ -381,19 +338,6 @@ export async function loadAccountIntegrationByName(
 	name: string,
 	options?: {
 		/**
-		 * Explicit built-in intent (`platform=1` on /connect/oauth): resolve
-		 * the enabled platform app directly instead of letting a complete
-		 * bring-your-own record win. Falls back to the normal priority when
-		 * no built-in exists for the name.
-		 */
-		preferPlatform?: boolean
-		/**
-		 * Built-in slug to resolve when it differs from the connection name
-		 * (`platform=<slug>`): connecting the google built-in under the name
-		 * google-2 keeps an existing bring-your-own google connection intact.
-		 */
-		platformSlug?: string
-		/**
 		 * Saved bring-your-own app to reuse under a new connection name
 		 * (`app=<slug>`): connecting `work` on the google app must not depend
 		 * on inferring that app from the typed name.
@@ -401,20 +345,9 @@ export async function loadAccountIntegrationByName(
 		appSlug?: string
 	},
 ): Promise<AccountIntegrationRecord | null> {
-	// A user-lane record still wins when it can actually drive the flow (the
-	// bring-your-own override); an endpoint-incomplete one defers to an
-	// enabled built-in of the same name instead of dead-ending the page.
-	const platformFallback = async (slug: string = name) => {
-		const platformApp = await getAvailablePlatformApp({ env, slug })
-		return platformApp ? toPlatformAppPrefillRecord(platformApp, name) : null
-	}
-
-	if (options?.preferPlatform || options?.platformSlug) {
-		const platformRecord = await platformFallback(options.platformSlug ?? name)
-		if (platformRecord) return platformRecord
-	}
-
 	// 1. Existing connection (reconnect) — connection name, not app slug.
+	// Platform-lane rows stay listed so tokens can keep refreshing, but
+	// reconnect is always bring-your-own.
 	const joined = await getJoinedIntegration({
 		env,
 		userId: user.mcpUser.userId,
@@ -422,8 +355,10 @@ export async function loadAccountIntegrationByName(
 	})
 	if (joined) {
 		const record = toAccountIntegrationRecord(joined)
-		if (recordCanDriveConnectFlow(record)) return record
-		return (await platformFallback()) ?? record
+		if (joined.lane === 'platform') {
+			return toBringYourOwnReconnectRecord(record)
+		}
+		return record
 	}
 
 	if (options?.appSlug) {
@@ -433,9 +368,6 @@ export async function loadAccountIntegrationByName(
 			slug: options.appSlug,
 		})
 		if (app) {
-			// Keep the pinned app even when it cannot drive authorize yet.
-			// Falling back by the typed connection name can land on a
-			// different built-in (`app=linear&provider=github-platform`).
 			return toAppOnlyIntegrationRecord(oauthAppToSetupPrefill(app), name)
 		}
 	}
@@ -448,25 +380,10 @@ export async function loadAccountIntegrationByName(
 		name,
 	})
 	if (prefill) {
-		// Exact beats fuzzy across lanes: a *family* prefill (slug differs
-		// from the requested name) must not shadow a built-in whose slug
-		// matches the name exactly — otherwise a user with any github app
-		// could never reach a github-platform built-in. An exact BYO slug
-		// match still wins (the bring-your-own override).
-		const exactByoSlug =
-			canonicalIntegrationName(prefill.slug) === canonicalIntegrationName(name)
-		if (!exactByoSlug) {
-			const platformExact = await platformFallback()
-			if (platformExact) return platformExact
-		}
-		const record = toAppOnlyIntegrationRecord(prefill, name)
-		if (recordCanDriveConnectFlow(record)) return record
-		return (await platformFallback()) ?? record
+		return toAppOnlyIntegrationRecord(prefill, name)
 	}
 
-	// 4. Platform (built-in) app: the user needs no OAuth app of their own, so
-	// the connect flow can skip client-credential setup entirely.
-	return platformFallback()
+	return null
 }
 
 /**
@@ -522,18 +439,4 @@ export async function hasStoredConnectClientSecret(
 	return secrets.some(
 		(secret) => secret.scope === 'user' && secret.name === secretName,
 	)
-}
-
-/**
- * True when an enabled built-in exists for `name` that the resolved record
- * is not already using — the connect page offers it as an alternative lane.
- */
-export async function hasAlternativeBuiltInApp(
-	env: Env,
-	name: string,
-	record: AccountIntegrationRecord | null,
-): Promise<boolean> {
-	if (record?.platform) return false
-	const platformApp = await getAvailablePlatformApp({ env, slug: name })
-	return platformApp != null
 }

--- a/packages/worker/src/app/connect-oauth-chooser.node.test.ts
+++ b/packages/worker/src/app/connect-oauth-chooser.node.test.ts
@@ -17,7 +17,7 @@ function createEnv() {
 	return { APP_DB: createD1FromSqlite(sqlite) } as Env
 }
 
-test('connect chooser includes unused built-ins and saved BYO connections', async () => {
+test('connect chooser includes saved connections and hides unused built-ins', async () => {
 	const env = createEnv()
 	const platformEnv = {
 		...env,
@@ -86,18 +86,19 @@ test('connect chooser includes unused built-ins and saved BYO connections', asyn
 	expect(chooser.options.map((option) => option.id)).toEqual([
 		'connection:github',
 		'connection:spotify-home',
-		'platform:google',
 	])
 	expect(
 		chooser.options.find((option) => option.id === 'connection:spotify-home'),
 	).toMatchObject({
 		href: '/connect/oauth?provider=spotify-home&app=spotify-home',
 		kind: 'connection',
+		detail: 'Reconnect your OAuth app',
 	})
 	expect(
-		chooser.options.find((option) => option.id === 'platform:google'),
+		chooser.options.find((option) => option.id === 'connection:github'),
 	).toMatchObject({
-		href: '/connect/oauth?provider=google&platform=google',
-		kind: 'platform',
+		href: '/connect/oauth?provider=github',
+		kind: 'connection',
+		detail: 'Set up your own OAuth app to reconnect',
 	})
 })

--- a/packages/worker/src/app/connect-oauth-chooser.ts
+++ b/packages/worker/src/app/connect-oauth-chooser.ts
@@ -4,10 +4,7 @@ import {
 } from '#universal/oauth-connect.ts'
 import { buildPlatformOauthAppLogoPath } from '#worker/integrations/platform-app-logo.ts'
 import { buildUserOauthAppLogoPaths } from '#worker/integrations/user-oauth-app-logo.ts'
-import {
-	listAvailablePlatformApps,
-	listJoinedIntegrations,
-} from '#worker/integrations/service.ts'
+import { listJoinedIntegrations } from '#worker/integrations/service.ts'
 
 export type { ConnectOauthChooserOption }
 
@@ -15,10 +12,10 @@ export async function loadConnectOauthChooser(input: {
 	env: Pick<Env, 'APP_DB'>
 	userId: string
 }): Promise<{ options: Array<ConnectOauthChooserOption> }> {
-	const [joined, platformApps] = await Promise.all([
-		listJoinedIntegrations({ env: input.env, userId: input.userId }),
-		listAvailablePlatformApps({ env: input.env }),
-	])
+	const joined = await listJoinedIntegrations({
+		env: input.env,
+		userId: input.userId,
+	})
 	return {
 		options: buildConnectOauthChooserOptions({
 			connections: joined.map((entry) => ({
@@ -41,12 +38,6 @@ export async function loadConnectOauthChooser(input: {
 				canDrive: Boolean(
 					entry.app.authorizeUrl?.trim() && entry.app.tokenUrl.trim(),
 				),
-			})),
-			platformApps: platformApps.map((app) => ({
-				slug: app.slug,
-				label: app.label?.trim() || app.slug,
-				provider: app.provider,
-				logoPath: buildPlatformOauthAppLogoPath(app),
 			})),
 		}),
 	}

--- a/packages/worker/src/app/handlers/account-integrations.ts
+++ b/packages/worker/src/app/handlers/account-integrations.ts
@@ -4,7 +4,6 @@ import { jsonResponse } from '#worker/json-response.ts'
 import { type Action } from 'remix/router'
 import { safeParseHost } from '@kody-internal/shared/url-hosts.ts'
 import {
-	hasAlternativeBuiltInApp,
 	hasStoredConnectClientSecret,
 	loadAccountIntegrationByName,
 	readConnectOauthLookupOptions,
@@ -140,26 +139,24 @@ export function createAccountIntegrationsApiHandler(env: Env) {
 				const name = searchParams.get('name')?.trim()
 				const approvalPackageId = searchParams.get('package_id')?.trim()
 				if (name && !approvalPackageId) {
-					// `platform=1` forces the built-in of the same name;
-					// `platform=<slug>` connects that built-in under a
-					// different connection name (rename-instead-of-replace).
 					// `app=<slug>` reuses a saved bring-your-own app under `name`.
+					// `platform=` is ignored: built-in connect is retired.
 					const integration = await loadAccountIntegrationByName(
 						env,
 						user,
 						name,
 						readConnectOauthLookupOptions(searchParams),
 					)
-					const [builtInAvailable, existingConnection, hasStoredClientSecret] =
-						await Promise.all([
-							hasAlternativeBuiltInApp(env, name, integration),
+					const [existingConnection, hasStoredClientSecret] = await Promise.all(
+						[
 							loadExistingConnectionSummary(env, user, name),
 							hasStoredConnectClientSecret(env, user, name, integration),
-						])
+						],
+					)
 					return jsonResponse({
 						ok: true,
 						integration,
-						builtInAvailable,
+						builtInAvailable: false,
 						existingConnection,
 						hasStoredClientSecret,
 					})

--- a/packages/worker/src/app/handlers/account-secrets.node.test.ts
+++ b/packages/worker/src/app/handlers/account-secrets.node.test.ts
@@ -1522,63 +1522,15 @@ test('connect oauth persists usePkce for confidential + PKCE providers like Canv
 	)
 })
 
-const githubPlatformApp = {
-	slug: 'github',
-	provider: 'github',
-	label: 'GitHub',
-	clientId: 'platform-github-client-id',
-	hasClientSecret: true,
-	tokenUrl: 'https://github.com/login/oauth/access_token',
-	authorizeUrl: 'https://github.com/login/oauth/authorize',
-	apiBaseUrl: 'https://api.github.com',
-	flow: 'confidential' as const,
-	usePkce: null,
-	tokenExchangeStyle: null,
-	scopeSeparator: null,
-	extraAuthorizeParams: {},
-	allowedScopes: ['repo', 'read:user'],
-	defaultScopes: ['read:user'],
-	requiredHosts: ['api.github.com'],
-	enabled: true,
-	createdAt: new Date(0).toISOString(),
-	updatedAt: new Date(0).toISOString(),
-}
-
-test('platform-lane oauth exchange and connect ignore spoofed body fields and enforce scope policy', async () => {
+test('platform-lane oauth exchange and connect are rejected', async () => {
 	const fetchMock = vi.fn()
 	vi.stubGlobal('fetch', fetchMock)
 	const handler = createAccountSecretsApiHandler(createEnv())
-
-	mockModule.getAvailablePlatformApp.mockResolvedValueOnce(null)
-	const unknownExchange = await handler.handler({
-		request: new Request('https://example.com/account/secrets.json', {
-			method: 'POST',
-			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify({
-				action: 'oauth_exchange',
-				platformAppSlug: 'unknown',
-				params: 'grant_type=authorization_code',
-			}),
-		}),
-		params: {},
-	} as never)
-	expect(unknownExchange.status).toBe(400)
-	await expect(unknownExchange.json()).resolves.toEqual({
+	const retired = {
 		ok: false,
-		error: 'Platform integration is not available.',
-	})
-	expect(fetchMock).not.toHaveBeenCalled()
-
-	mockModule.getAvailablePlatformApp.mockResolvedValueOnce(githubPlatformApp)
-	mockModule.getPlatformOauthAppClientSecret.mockResolvedValueOnce(
-		'platform-github-client-secret-value',
-	)
-	fetchMock.mockResolvedValueOnce(
-		new Response(JSON.stringify({ access_token: 'gh-access' }), {
-			status: 200,
-			headers: { 'Content-Type': 'application/json' },
-		}),
-	)
+		error:
+			'Built-in platform OAuth apps are no longer a connect path. Create your own OAuth app and connect it at /connect/oauth.',
+	}
 
 	const exchangeResponse = await handler.handler({
 		request: new Request('https://example.com/account/secrets.json', {
@@ -1587,39 +1539,14 @@ test('platform-lane oauth exchange and connect ignore spoofed body fields and en
 			body: JSON.stringify({
 				action: 'oauth_exchange',
 				platformAppSlug: 'github',
-				tokenUrl: 'https://evil.example.com/token',
-				flow: 'pkce',
-				clientSecretSecretName: 'attackerSecret',
-				params: new URLSearchParams({
-					grant_type: 'authorization_code',
-					client_id: 'spoofed-client-id',
-					code: 'auth-code',
-					redirect_uri: 'https://example.com/connect/oauth',
-				}).toString(),
+				params: 'grant_type=authorization_code',
 			}),
 		}),
 		params: {},
 	} as never)
-	expect(exchangeResponse.status).toBe(200)
-	await expect(exchangeResponse.json()).resolves.toMatchObject({
-		access_token: 'gh-access',
-	})
-	expect(mockModule.resolveSecret).not.toHaveBeenCalled()
-	expect(fetchMock).toHaveBeenCalledTimes(1)
-	expect(fetchMock.mock.calls[0]?.[0]).toBe(
-		'https://github.com/login/oauth/access_token',
-	)
-	const exchangeRequest = fetchMock.mock.calls[0]?.[1] as RequestInit
-	const body = new URLSearchParams(String(exchangeRequest.body))
-	expect(body.get('client_secret')).toBe('platform-github-client-secret-value')
-	expect(body.get('client_id')).toBe('platform-github-client-id')
-
-	vi.unstubAllGlobals()
-
-	mockModule.getAvailablePlatformApp.mockResolvedValueOnce(githubPlatformApp)
-	mockModule.saveSecret.mockClear()
-	mockModule.upsertPlatformIntegration.mockClear()
-	mockModule.dispatchIntegrationAuthSucceededSubscriptionEvents.mockClear()
+	expect(exchangeResponse.status).toBe(400)
+	await expect(exchangeResponse.json()).resolves.toEqual(retired)
+	expect(fetchMock).not.toHaveBeenCalled()
 
 	const connectResponse = await handler.handler({
 		request: new Request('https://example.com/account/secrets.json', {
@@ -1631,85 +1558,15 @@ test('platform-lane oauth exchange and connect ignore spoofed body fields and en
 				platformAppSlug: 'github',
 				scopes: ['read:user'],
 				accessTokenSecretName: 'githubAccessToken',
-				refreshTokenSecretName: 'githubRefreshToken',
-				tokenPayload: {
-					access_token: 'gh-access-token',
-					refresh_token: 'gh-refresh-token',
-				},
-			}),
-		}),
-		params: {},
-	} as never)
-	expect(connectResponse.status).toBe(200)
-	await expect(connectResponse.json()).resolves.toMatchObject({
-		ok: true,
-		accessTokenSaved: true,
-		refreshTokenSaved: true,
-		integrationName: 'github',
-	})
-	expect(mockModule.upsertPlatformIntegration).toHaveBeenCalledWith(
-		expect.objectContaining({
-			platformAppSlug: 'github',
-			name: 'github',
-			scopes: ['read:user'],
-			accessTokenSecretName: 'githubAccessToken',
-			refreshTokenSecretName: 'githubRefreshToken',
-		}),
-	)
-	expect(
-		mockModule.dispatchIntegrationAuthSucceededSubscriptionEvents,
-	).toHaveBeenCalledWith(
-		expect.objectContaining({
-			userId: 'stable-user-1',
-			source: 'oauth_connect',
-			integration: expect.objectContaining({
-				name: 'github',
-				lane: 'platform',
-				platform_app_slug: 'github',
-			}),
-		}),
-	)
-	expect(mockModule.upsertIntegration).not.toHaveBeenCalledWith(
-		expect.objectContaining({
-			config: expect.objectContaining({ name: 'github' }),
-		}),
-	)
-	expect(mockModule.saveSecret).toHaveBeenCalledWith(
-		expect.objectContaining({
-			name: 'githubAccessToken',
-			value: 'gh-access-token',
-			scope: 'user',
-		}),
-	)
-
-	mockModule.getAvailablePlatformApp.mockResolvedValueOnce(githubPlatformApp)
-	mockModule.saveSecret.mockClear()
-	mockModule.upsertPlatformIntegration.mockClear()
-	mockModule.dispatchIntegrationAuthSucceededSubscriptionEvents.mockClear()
-
-	const rejectedScopes = await handler.handler({
-		request: new Request('https://example.com/account/secrets.json', {
-			method: 'POST',
-			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify({
-				action: 'connect_oauth',
-				provider: 'github',
-				platformAppSlug: 'github',
-				scopes: ['admin:org'],
-				accessTokenSecretName: 'githubAccessToken',
 				tokenPayload: { access_token: 'gh-access-token' },
 			}),
 		}),
 		params: {},
 	} as never)
-	expect(rejectedScopes.status).toBe(400)
-	await expect(rejectedScopes.json()).resolves.toMatchObject({
-		ok: false,
-		error: expect.stringContaining('Scopes not allowed'),
-	})
-	expect(mockModule.saveSecret).not.toHaveBeenCalled()
+	expect(connectResponse.status).toBe(400)
+	await expect(connectResponse.json()).resolves.toEqual(retired)
 	expect(mockModule.upsertPlatformIntegration).not.toHaveBeenCalled()
-	expect(
-		mockModule.dispatchIntegrationAuthSucceededSubscriptionEvents,
-	).not.toHaveBeenCalled()
+	expect(mockModule.saveSecret).not.toHaveBeenCalled()
+
+	vi.unstubAllGlobals()
 })

--- a/packages/worker/src/app/handlers/account-secrets.ts
+++ b/packages/worker/src/app/handlers/account-secrets.ts
@@ -39,18 +39,14 @@ import {
 	integrationConfigSchema,
 } from '#mcp/capabilities/integrations/integration-shared.ts'
 import {
-	assertScopesAllowedForPlatformApp,
-	getAvailablePlatformApp,
 	getJoinedIntegration,
 	upsertIntegration,
 	upsertOauthAppWithoutConnection,
-	upsertPlatformIntegration,
 } from '#worker/integrations/service.ts'
 import {
 	persistIntegrationTokens,
 	persistUserOauthAppClientSecret,
 } from '#worker/integrations/credentials.ts'
-import { getPlatformOauthAppClientSecret } from '#worker/integrations/platform-apps.ts'
 import { dispatchIntegrationAuthSucceededSubscriptionEvents } from '#worker/integrations/package-subscriptions.ts'
 import { requireAuthenticatedPageUser } from '#app/page-auth.ts'
 import {
@@ -306,52 +302,33 @@ async function handleConnectOauthAction(input: {
 }) {
 	const provider = readString(input.body, 'provider')
 	const platformAppSlug = readOptionalString(input.body, 'platformAppSlug')
-	const platformApp = platformAppSlug
-		? await getAvailablePlatformApp({ env: input.env, slug: platformAppSlug })
-		: null
-	if (platformAppSlug && !platformApp) {
+	if (platformAppSlug) {
 		return jsonResponse(
-			{ ok: false, error: 'Platform integration is not available.' },
+			{
+				ok: false,
+				error:
+					'Built-in platform OAuth apps are no longer a connect path. Create your own OAuth app and connect it at /connect/oauth.',
+			},
 			400,
 		)
 	}
-	// Platform lane: endpoints and hosts come from the operator-provisioned
-	// app row, not the request body.
-	const tokenUrl = platformApp
-		? platformApp.tokenUrl
-		: readOptionalString(input.body, 'tokenUrl')
-	const apiBaseUrl = platformApp
-		? platformApp.apiBaseUrl
-		: readOptionalString(input.body, 'apiBaseUrl')
-	const authorizeUrl = platformApp
-		? platformApp.authorizeUrl
-		: readOptionalString(input.body, 'authorizeUrl')
-	const flow = platformApp
-		? platformApp.flow
-		: readOptionalString(input.body, 'flow')
-	const usePkce = platformApp
-		? platformApp.usePkce
-		: readOptionalBoolean(input.body, 'usePkce')
-	const clientId = platformApp
-		? platformApp.clientId
-		: readOptionalString(input.body, 'clientId')
-	const clientSecretSecretName = platformApp
-		? null
-		: readOptionalString(input.body, 'clientSecretSecretName')
+	const tokenUrl = readOptionalString(input.body, 'tokenUrl')
+	const apiBaseUrl = readOptionalString(input.body, 'apiBaseUrl')
+	const authorizeUrl = readOptionalString(input.body, 'authorizeUrl')
+	const flow = readOptionalString(input.body, 'flow')
+	const usePkce = readOptionalBoolean(input.body, 'usePkce')
+	const clientId = readOptionalString(input.body, 'clientId')
+	const clientSecretSecretName = readOptionalString(
+		input.body,
+		'clientSecretSecretName',
+	)
 	const accessTokenSecretName = readString(input.body, 'accessTokenSecretName')
 	const refreshTokenSecretName = readOptionalString(
 		input.body,
 		'refreshTokenSecretName',
 	)
 	const allowedHosts = normalizeAllowedHosts(
-		platformApp
-			? [
-					...platformApp.requiredHosts,
-					...(platformApp.apiBaseUrl
-						? [safeParseHost(platformApp.apiBaseUrl) ?? '']
-						: []),
-				]
-			: readStringArray(input.body, 'allowedHosts'),
+		readStringArray(input.body, 'allowedHosts'),
 	)
 	const scopes = readStringArray(input.body, 'scopes')
 	const scopeSeparator = readRawOptionalString(input.body, 'scopeSeparator')
@@ -404,25 +381,6 @@ async function handleConnectOauthAction(input: {
 			400,
 		)
 	}
-	// Scope validation must precede token persistence: a rejected scope set
-	// must not leave orphan token secrets behind.
-	if (platformApp) {
-		try {
-			assertScopesAllowedForPlatformApp(platformApp, scopes)
-		} catch (error) {
-			return jsonResponse(
-				{
-					ok: false,
-					error:
-						error instanceof Error
-							? error.message
-							: 'Requested scopes are not allowed.',
-				},
-				400,
-			)
-		}
-	}
-
 	const approvedHostsBySecretName = new Map(
 		(
 			await listSecrets({
@@ -465,49 +423,32 @@ async function handleConnectOauthAction(input: {
 			? refreshTokenSecretName
 			: null
 
-	let integrationName: string
-	if (platformApp) {
-		const saved = await upsertPlatformIntegration({
-			env: input.env,
-			userId: input.user.mcpUser.userId,
-			platformAppSlug: platformApp.slug,
-			name: provider,
-			scopes,
-			accessTokenSecretName,
-			refreshTokenSecretName: persistRefreshTokenSecretName,
-		})
-		integrationName = saved.name
-	} else {
-		integrationName = await saveIntegrationConfig({
-			env: input.env,
-			userId: input.user.mcpUser.userId,
-			provider,
+	const integrationName = await saveIntegrationConfig({
+		env: input.env,
+		userId: input.user.mcpUser.userId,
+		provider,
+		tokenUrl,
+		apiBaseUrl,
+		flow: flow === 'confidential' ? 'confidential' : 'pkce',
+		usePkce,
+		clientId,
+		clientSecretSecretName,
+		accessTokenSecretName,
+		refreshTokenSecretName: persistRefreshTokenSecretName,
+		tokenExchangeStyle: resolveTokenExchangeStyle({
 			tokenUrl,
-			apiBaseUrl,
-			flow: flow === 'confidential' ? 'confidential' : 'pkce',
-			usePkce,
-			clientId,
-			clientSecretSecretName,
-			accessTokenSecretName,
-			refreshTokenSecretName: persistRefreshTokenSecretName,
-			tokenExchangeStyle: resolveTokenExchangeStyle({
-				tokenUrl,
-				tokenExchangeStyle: readOptionalString(
-					input.body,
-					'tokenExchangeStyle',
-				),
-			}),
-			allowedHosts,
-			authorization: authorizeUrl
-				? {
-						authorizeUrl,
-						scopes,
-						scopeSeparator,
-						extraAuthorizeParams,
-					}
-				: null,
-		})
-	}
+			tokenExchangeStyle: readOptionalString(input.body, 'tokenExchangeStyle'),
+		}),
+		allowedHosts,
+		authorization: authorizeUrl
+			? {
+					authorizeUrl,
+					scopes,
+					scopeSeparator,
+					extraAuthorizeParams,
+				}
+			: null,
+	})
 	await persistIntegrationTokens({
 		env: input.env,
 		userId: input.user.mcpUser.userId,
@@ -520,7 +461,7 @@ async function handleConnectOauthAction(input: {
 		refreshTokenSecretName: persistRefreshTokenSecretName,
 		descriptionPrefix: provider,
 	})
-	if (!platformApp && clientSecretSecretName) {
+	if (clientSecretSecretName) {
 		const resolvedClientSecret = await resolveSecret({
 			env: input.env,
 			userId: input.user.mcpUser.userId,
@@ -597,11 +538,11 @@ async function handleConnectOauthAction(input: {
 		userId: input.user.mcpUser.userId,
 		integration: {
 			name: integrationName,
-			lane: platformApp ? 'platform' : 'user',
+			lane: 'user',
 			account_label: null,
 			description: null,
-			provider: platformApp?.provider ?? null,
-			platform_app_slug: platformApp?.slug ?? null,
+			provider: null,
+			platform_app_slug: null,
 			scopes,
 			connected_at: null,
 			token_refreshed_at: null,
@@ -725,115 +666,71 @@ async function handleOAuthExchangeAction(input: {
 	if (!paramsRaw) {
 		return jsonResponse({ ok: false, error: 'Token params are required.' }, 400)
 	}
-	const platformAppSlug = readOptionalString(input.body, 'platformAppSlug')
+	if (readOptionalString(input.body, 'platformAppSlug')) {
+		return jsonResponse(
+			{
+				ok: false,
+				error:
+					'Built-in platform OAuth apps are no longer a connect path. Create your own OAuth app and connect it at /connect/oauth.',
+			},
+			400,
+		)
+	}
 
-	// Platform lane: every exchange input comes from the operator-provisioned
-	// app row, never from the request body, so a caller cannot point the
-	// decrypted shared client secret at an arbitrary token URL.
-	let tokenUrl: string | null
-	let flow: string
-	let tokenExchangeStyle: TokenExchangeStyle
+	const tokenUrl = readOptionalString(input.body, 'tokenUrl')
+	const flow = readOptionalString(input.body, 'flow') ?? 'pkce'
+	const clientSecretSecretName = readOptionalString(
+		input.body,
+		'clientSecretSecretName',
+	)
+	const allowedHosts = normalizeAllowedHosts(
+		readStringArray(input.body, 'allowedHosts'),
+	)
 	let clientSecret: string | null = null
-	let platformClientId: string | null = null
-	if (platformAppSlug) {
-		const platformApp = await getAvailablePlatformApp({
-			env: input.env,
-			slug: platformAppSlug,
-		})
-		if (!platformApp) {
-			return jsonResponse(
-				{ ok: false, error: 'Platform integration is not available.' },
-				400,
-			)
-		}
-		tokenUrl = platformApp.tokenUrl
-		flow = platformApp.flow
-		platformClientId = platformApp.clientId
-		tokenExchangeStyle = resolveTokenExchangeStyle({
-			tokenUrl: platformApp.tokenUrl,
-			tokenExchangeStyle: platformApp.tokenExchangeStyle,
-		})
-		if (platformApp.flow === 'confidential') {
-			clientSecret = await getPlatformOauthAppClientSecret({
-				db: input.env.APP_DB,
-				env: input.env,
-				slug: platformApp.slug,
-			})
-			if (!clientSecret) {
-				return jsonResponse(
-					{ ok: false, error: 'Platform client secret is not configured.' },
-					500,
-				)
-			}
-		}
-	} else {
-		tokenUrl = readOptionalString(input.body, 'tokenUrl')
-		flow = readOptionalString(input.body, 'flow') ?? 'pkce'
-		const clientSecretSecretName = readOptionalString(
-			input.body,
-			'clientSecretSecretName',
-		)
-		const allowedHosts = normalizeAllowedHosts(
-			readStringArray(input.body, 'allowedHosts'),
-		)
 
-		if (!tokenUrl) {
-			return jsonResponse({ ok: false, error: 'Token URL is required.' }, 400)
-		}
-		if (flow !== 'pkce' && flow !== 'confidential') {
-			return jsonResponse({ ok: false, error: 'Invalid OAuth flow.' }, 400)
-		}
-		const tokenHost = safeParseHost(tokenUrl)
-		if (!tokenHost) {
-			return jsonResponse({ ok: false, error: 'Token URL is invalid.' }, 400)
-		}
-		if (allowedHosts.length > 0 && !allowedHosts.includes(tokenHost)) {
-			return jsonResponse(
-				{ ok: false, error: 'Token host is not in allowed hosts.' },
-				400,
-			)
-		}
-
-		tokenExchangeStyle = resolveTokenExchangeStyle({
-			tokenUrl,
-			tokenExchangeStyle: readOptionalString(input.body, 'tokenExchangeStyle'),
-		})
-
-		if (flow === 'confidential') {
-			if (!clientSecretSecretName) {
-				return jsonResponse(
-					{ ok: false, error: 'Client secret name is required.' },
-					400,
-				)
-			}
-			const resolved = await resolveSecret({
-				env: input.env,
-				userId: input.user.mcpUser.userId,
-				name: clientSecretSecretName,
-				scope: 'user',
-				storageContext: { sessionId: null, appId: null, packageId: null },
-			})
-			if (!resolved.found || !resolved.value) {
-				return jsonResponse(
-					{ ok: false, error: 'Client secret not found.' },
-					400,
-				)
-			}
-			clientSecret = resolved.value
-		}
+	if (!tokenUrl) {
+		return jsonResponse({ ok: false, error: 'Token URL is required.' }, 400)
 	}
 	if (flow !== 'pkce' && flow !== 'confidential') {
 		return jsonResponse({ ok: false, error: 'Invalid OAuth flow.' }, 400)
 	}
+	const tokenHost = safeParseHost(tokenUrl)
+	if (!tokenHost) {
+		return jsonResponse({ ok: false, error: 'Token URL is invalid.' }, 400)
+	}
+	if (allowedHosts.length > 0 && !allowedHosts.includes(tokenHost)) {
+		return jsonResponse(
+			{ ok: false, error: 'Token host is not in allowed hosts.' },
+			400,
+		)
+	}
+
+	const tokenExchangeStyle = resolveTokenExchangeStyle({
+		tokenUrl,
+		tokenExchangeStyle: readOptionalString(input.body, 'tokenExchangeStyle'),
+	})
+
+	if (flow === 'confidential') {
+		if (!clientSecretSecretName) {
+			return jsonResponse(
+				{ ok: false, error: 'Client secret name is required.' },
+				400,
+			)
+		}
+		const resolved = await resolveSecret({
+			env: input.env,
+			userId: input.user.mcpUser.userId,
+			name: clientSecretSecretName,
+			scope: 'user',
+			storageContext: { sessionId: null, appId: null, packageId: null },
+		})
+		if (!resolved.found || !resolved.value) {
+			return jsonResponse({ ok: false, error: 'Client secret not found.' }, 400)
+		}
+		clientSecret = resolved.value
+	}
 
 	const params = new URLSearchParams(paramsRaw)
-	if (platformClientId) {
-		// Every credential in a platform exchange comes from the app row: pin
-		// the client id and drop any caller-supplied client_secret so it can
-		// never reach the provider.
-		params.set('client_id', platformClientId)
-		params.delete('client_secret')
-	}
 
 	let exchangeRequest: { headers: Record<string, string>; body: string }
 	try {

--- a/packages/worker/src/app/handlers/connect-oauth.node.test.ts
+++ b/packages/worker/src/app/handlers/connect-oauth.node.test.ts
@@ -9,17 +9,12 @@ const mockModule = vi.hoisted(() => ({
 	readAuthenticatedAppUser: vi.fn<() => Promise<unknown>>(),
 	requirePageSession: vi.fn<() => Promise<Response | null>>(),
 	loadAccountIntegrationByName: vi.fn<() => Promise<unknown>>(),
-	hasAlternativeBuiltInApp: vi.fn<() => Promise<boolean>>(),
 	loadExistingConnectionSummary: vi.fn<() => Promise<unknown>>(),
 	hasStoredConnectClientSecret: vi.fn<() => Promise<boolean>>(),
 	loadConnectOauthChooser: vi.fn(async () => ({ options: [] })),
 	readConnectOauthLookupOptions: (searchParams: URLSearchParams) => {
-		const platformParam = searchParams.get('platform')?.trim()
 		const appParam = searchParams.get('app')?.trim()
 		return {
-			preferPlatform: platformParam === '1',
-			platformSlug:
-				platformParam && platformParam !== '1' ? platformParam : undefined,
 			appSlug: appParam || undefined,
 		}
 	},
@@ -44,8 +39,6 @@ vi.mock('#app/connect-oauth-chooser.ts', () => ({
 vi.mock('#app/account-integrations-data.ts', () => ({
 	loadAccountIntegrationByName: (...args: Array<unknown>) =>
 		mockModule.loadAccountIntegrationByName(...args),
-	hasAlternativeBuiltInApp: (...args: Array<unknown>) =>
-		mockModule.hasAlternativeBuiltInApp(...args),
 	loadExistingConnectionSummary: (...args: Array<unknown>) =>
 		mockModule.loadExistingConnectionSummary(...args),
 	hasStoredConnectClientSecret: (...args: Array<unknown>) =>
@@ -113,7 +106,7 @@ test('bare and provider visits require a session; signed-in bare visits render t
 	)
 })
 
-test('provider visits embed SSR loader data and honor platform lookup flags', async () => {
+test('provider visits embed SSR loader data and ignore platform lookup flags', async () => {
 	const env = {} as Env
 	const record = { name: 'github', platform: true }
 	mockModule.requirePageSession.mockResolvedValue(null)
@@ -122,7 +115,6 @@ test('provider visits embed SSR loader data and honor platform lookup flags', as
 	})
 	mockModule.loadAccountIntegrationByName.mockResolvedValue(record)
 	mockModule.renderAppPage.mockResolvedValue(new Response('ok'))
-	mockModule.hasAlternativeBuiltInApp.mockResolvedValue(false)
 	mockModule.loadExistingConnectionSummary.mockResolvedValue(null)
 	mockModule.hasStoredConnectClientSecret.mockResolvedValue(true)
 
@@ -135,7 +127,7 @@ test('provider visits embed SSR loader data and honor platform lookup flags', as
 		env,
 		expect.anything(),
 		'github',
-		{ preferPlatform: false, platformSlug: undefined, appSlug: undefined },
+		{ appSlug: undefined },
 	)
 	expect(mockModule.renderAppPage).toHaveBeenCalledWith(
 		expect.objectContaining({
@@ -170,7 +162,7 @@ test('provider visits embed SSR loader data and honor platform lookup flags', as
 		env,
 		expect.anything(),
 		'google',
-		{ preferPlatform: true, platformSlug: undefined, appSlug: undefined },
+		{ appSlug: undefined },
 	)
 
 	await createConnectOauthHandler(env).handler(
@@ -184,7 +176,7 @@ test('provider visits embed SSR loader data and honor platform lookup flags', as
 		env,
 		expect.anything(),
 		'google-2',
-		{ preferPlatform: false, platformSlug: 'google', appSlug: undefined },
+		{ appSlug: undefined },
 	)
 
 	await createConnectOauthHandler(env).handler(
@@ -196,7 +188,7 @@ test('provider visits embed SSR loader data and honor platform lookup flags', as
 		env,
 		expect.anything(),
 		'work',
-		{ preferPlatform: false, platformSlug: undefined, appSlug: 'google' },
+		{ appSlug: 'google' },
 	)
 })
 

--- a/packages/worker/src/app/handlers/connect-oauth.ts
+++ b/packages/worker/src/app/handlers/connect-oauth.ts
@@ -1,7 +1,6 @@
 import { type Action } from 'remix/router'
 import { normalizeProviderKey } from '@kody-internal/shared/url-hosts.ts'
 import {
-	hasAlternativeBuiltInApp,
 	hasStoredConnectClientSecret,
 	loadAccountIntegrationByName,
 	loadExistingConnectionSummary,
@@ -17,7 +16,7 @@ import { type routes } from '#universal/routes.ts'
 
 /**
  * Every working visit to /connect/oauth carries at least one of these:
- * `provider` (agent-built setup URLs and built-in connects), `code` (the
+ * `provider` (agent-built setup URLs), `code` (the
  * provider's success redirect — config is restored from sessionStorage, so
  * the query has no provider), or `error` (the provider's denial redirect).
  * A visit with none of them is the signed-in provider chooser.
@@ -70,26 +69,23 @@ async function loadConnectOauthLoaderData(
 	if (!user) {
 		return { ok: true, provider: null, integration: null, redirectUri }
 	}
-	// `platform=1` forces the built-in of the same name; `platform=<slug>`
-	// connects that built-in under a different connection name.
 	// `app=<slug>` reuses a saved bring-your-own app under `provider`.
+	// `platform=` is ignored: built-in connect is retired.
 	const integration = await loadAccountIntegrationByName(
 		env,
 		user,
 		providerKey,
 		readConnectOauthLookupOptions(requestUrl.searchParams),
 	)
-	const [builtInAvailable, existingConnection, hasStoredClientSecret] =
-		await Promise.all([
-			hasAlternativeBuiltInApp(env, providerKey, integration),
-			loadExistingConnectionSummary(env, user, providerKey),
-			hasStoredConnectClientSecret(env, user, providerKey, integration),
-		])
+	const [existingConnection, hasStoredClientSecret] = await Promise.all([
+		loadExistingConnectionSummary(env, user, providerKey),
+		hasStoredConnectClientSecret(env, user, providerKey, integration),
+	])
 	return {
 		ok: true,
 		provider: providerKey,
 		integration,
-		builtInAvailable,
+		builtInAvailable: false,
 		existingConnection,
 		hasStoredClientSecret,
 		redirectUri,

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -971,59 +971,9 @@ test('renderAppPage server-renders connect-oauth provider visits without a loadi
 	expect(html).toContain('data-testid="connect-oauth-scopes"')
 	expect(html).toContain('https://accounts.google.com/o/oauth2/v2/auth')
 
-	// A built-in connect that would replace a user-lane connection under the
-	// same name server-renders the replace confirmation and withholds the
-	// Continue button (and the scope picker) until the user confirms.
+	// Reconnecting a platform connection is bring-your-own setup: the page
+	// asks for the user's client credentials instead of one-click authorize.
 	const replaceResponse = await renderAppPage({
-		request: new Request(
-			'https://example.com/connect/oauth?provider=google&platform=1',
-		),
-		env,
-		loaderData: {
-			connectOauth: {
-				ok: true,
-				provider: 'google',
-				integration: {
-					name: 'google',
-					appSlug: 'google',
-					provider: 'google',
-					appLabel: 'Google',
-					accountLabel: null,
-					tokenUrl: 'https://oauth2.googleapis.com/token',
-					apiBaseUrl: 'https://www.googleapis.com',
-					flow: 'pkce',
-					usePkce: true,
-					clientId: 'platform-google-client',
-					clientSecretSecretName: null,
-					accessTokenSecretName: 'googleAccessToken',
-					refreshTokenSecretName: 'googleRefreshToken',
-					requiredHosts: ['oauth2.googleapis.com'],
-					authorization: {
-						authorizeUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
-						scopes: ['openid'],
-						scopeSeparator: null,
-						extraAuthorizeParams: {},
-					},
-					platform: true,
-					platformAllowedScopes: ['openid'],
-					platformDescription: 'Send-only Gmail access.',
-					createdAt: '2026-01-01T00:00:00.000Z',
-					updatedAt: '2026-01-01T00:00:00.000Z',
-				},
-				builtInAvailable: false,
-				existingConnection: { lane: 'user', appSlug: 'google' },
-				hasStoredClientSecret: false,
-				redirectUri: 'https://example.com/connect/oauth',
-			},
-		},
-	})
-	expect(replaceResponse.status).toBe(200)
-	const replaceHtml = await readResponseText(replaceResponse)
-	expect(replaceHtml).toContain('data-testid="connect-replace-confirm"')
-	expect(replaceHtml).toContain('data-testid="provider-mark"')
-	expect(replaceHtml).not.toContain('data-testid="connect-oauth-scopes"')
-
-	const platformConnectResponse = await renderAppPage({
 		request: new Request('https://example.com/connect/oauth?provider=google'),
 		env,
 		loaderData: {
@@ -1039,35 +989,33 @@ test('renderAppPage server-renders connect-oauth provider visits without a loadi
 					tokenUrl: 'https://oauth2.googleapis.com/token',
 					apiBaseUrl: 'https://www.googleapis.com',
 					flow: 'confidential',
-					usePkce: false,
-					clientId: 'platform-google-client',
+					usePkce: true,
+					clientId: '',
 					clientSecretSecretName: null,
 					accessTokenSecretName: 'googleAccessToken',
 					refreshTokenSecretName: 'googleRefreshToken',
 					requiredHosts: ['oauth2.googleapis.com'],
 					authorization: {
 						authorizeUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
-						scopes: ['openid', 'email'],
+						scopes: ['openid'],
 						scopeSeparator: null,
 						extraAuthorizeParams: {},
 					},
-					platform: true,
-					platformAllowedScopes: ['openid', 'email', 'profile'],
 					createdAt: '2026-01-01T00:00:00.000Z',
 					updatedAt: '2026-01-01T00:00:00.000Z',
 				},
 				builtInAvailable: false,
+				existingConnection: { lane: 'platform', appSlug: 'google' },
 				hasStoredClientSecret: false,
 				redirectUri: 'https://example.com/connect/oauth',
 			},
 		},
 	})
-	expect(platformConnectResponse.status).toBe(200)
-	const platformConnectHtml = await readResponseText(platformConnectResponse)
-	expect(platformConnectHtml).toContain('data-testid="connect-oauth-scopes"')
-	expect(platformConnectHtml).not.toContain(
-		'data-testid="connect-replace-confirm"',
-	)
+	expect(replaceResponse.status).toBe(200)
+	const replaceHtml = await readResponseText(replaceResponse)
+	expect(replaceHtml).toContain('Paste the client ID')
+	expect(replaceHtml).toContain('https://example.com/connect/oauth')
+	expect(replaceHtml).not.toContain('data-testid="connect-replace-confirm"')
 
 	// First-time bring-your-own setup: credentials form and redirect URL are
 	// visible; endpoints and allowed hosts stay behind the disclosure.
@@ -1131,14 +1079,14 @@ test('renderAppPage server-renders connect-oauth provider visits without a loadi
 				chooser: {
 					options: [
 						{
-							id: 'platform:google',
-							href: '/connect/oauth?provider=google&platform=google',
+							id: 'connection:google',
+							href: '/connect/oauth?provider=google&app=google',
 							label: 'Google',
-							detail: "Connect with Kody's built-in app",
+							detail: 'Reconnect your OAuth app',
 							providerKey: 'google',
 							logoPath: null,
 							autoLogoPath: null,
-							kind: 'platform',
+							kind: 'connection',
 						},
 					],
 				},
@@ -1153,9 +1101,7 @@ test('renderAppPage server-renders connect-oauth provider visits without a loadi
 	expect(chooserHtml).not.toContain(
 		'data-testid="connect-oauth-chooser-filter"',
 	)
-	expect(chooserHtml).toContain(
-		'/connect/oauth?provider=google&platform=google',
-	)
+	expect(chooserHtml).toContain('/connect/oauth?provider=google&app=google')
 
 	const longChooserOptions = [
 		'google',
@@ -1166,14 +1112,14 @@ test('renderAppPage server-renders connect-oauth provider visits without a loadi
 		'spotify',
 		'linear',
 	].map((slug) => ({
-		id: `platform:${slug}`,
-		href: `/connect/oauth?provider=${slug}&platform=${slug}`,
+		id: `connection:${slug}`,
+		href: `/connect/oauth?provider=${slug}&app=${slug}`,
 		label: slug,
-		detail: "Connect with Kody's built-in app",
+		detail: 'Reconnect your OAuth app',
 		providerKey: slug,
 		logoPath: null,
 		autoLogoPath: null,
-		kind: 'platform' as const,
+		kind: 'connection' as const,
 	}))
 	const sixChooserResponse = await renderAppPage({
 		request: new Request('https://example.com/connect/oauth'),
@@ -1214,9 +1160,7 @@ test('renderAppPage server-renders connect-oauth provider visits without a loadi
 		'data-testid="connect-oauth-chooser-filter"',
 	)
 	expect(longChooserHtml).toContain('data-testid="connect-oauth-chooser-list"')
-	expect(longChooserHtml).toContain(
-		'/connect/oauth?provider=linear&platform=linear',
-	)
+	expect(longChooserHtml).toContain('/connect/oauth?provider=linear&app=linear')
 
 	const callbackResponse = await renderAppPage({
 		request: new Request(
@@ -1434,9 +1378,7 @@ test('renderAppPage server-renders simplified integration and secret-approval pa
 	expect(addAccountHtml).not.toContain('data-testid="add-account-open"')
 	expect(builtInHtml).toContain('Needs setup')
 	expect(builtInHtml).toContain('>Connect<')
-	expect(builtInHtml).toContain(
-		'/connect/oauth?provider=google-work&amp;platform=google',
-	)
+	expect(builtInHtml).toContain('/connect/oauth?provider=google-work')
 	expect(builtInHtml).not.toContain('Rotate credentials')
 
 	const missingConnectionResponse = await renderAppPage({

--- a/packages/worker/src/integrations/platform-apps.ts
+++ b/packages/worker/src/integrations/platform-apps.ts
@@ -30,8 +30,8 @@ export class PlatformOauthAppValidationError extends Error {
  * deliberately outside the user secret store: no `{{secret:...}}` placeholder
  * can reference it, so sandboxed code has no resolution path to the shared
  * credential. `getPlatformOauthAppClientSecret` is the only decrypt accessor;
- * its callers are host-side token-exchange paths (connect flow and
- * `integration_token_refresh`). Never expose the decrypted value in capability
+ * its remaining caller is host-side token refresh
+ * (`integration_token_refresh`). Never expose the decrypted value in capability
  * outputs, loader payloads, or logs.
  */
 export type PlatformOauthApp = {

--- a/packages/worker/src/mcp/capabilities/integrations/integration-platform-app-list.ts
+++ b/packages/worker/src/mcp/capabilities/integrations/integration-platform-app-list.ts
@@ -1,15 +1,8 @@
 import { z } from 'zod'
 import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
-import {
-	emptyCapabilityInputSchema,
-	type CapabilityContext,
-} from '#mcp/capabilities/types.ts'
-import { listAvailablePlatformApps } from '#worker/integrations/service.ts'
-import {
-	platformOauthAppPublicSchema,
-	toPlatformOauthAppPublic,
-} from './platform-app-shared.ts'
+import { emptyCapabilityInputSchema } from '#mcp/capabilities/types.ts'
+import { platformOauthAppPublicSchema } from './platform-app-shared.ts'
 
 const outputSchema = z.object({
 	apps: z.array(platformOauthAppPublicSchema),
@@ -20,7 +13,7 @@ export const integrationPlatformAppListCapability = defineDomainCapability(
 	{
 		name: 'integration_platform_app_list',
 		description:
-			'List operator-provisioned platform OAuth apps on this deployment. OAuth connections use a bring-your-own provider app at /connect/oauth; this list is inspection only and is not a connect path.',
+			'Platform (built-in) OAuth apps are being retired. This list is always empty. Connect with a bring-your-own provider app at /connect/oauth. Operators inspect remaining apps with admin_platform_oauth_app_list.',
 		keywords: [
 			'integration',
 			'oauth',
@@ -35,11 +28,8 @@ export const integrationPlatformAppListCapability = defineDomainCapability(
 		destructive: false,
 		inputSchema: emptyCapabilityInputSchema,
 		outputSchema,
-		async handler(_args, ctx: CapabilityContext) {
-			const apps = await listAvailablePlatformApps({ env: ctx.env })
-			return {
-				apps: apps.map(toPlatformOauthAppPublic),
-			}
+		async handler() {
+			return { apps: [] }
 		},
 	},
 )

--- a/packages/worker/universal/loader-data.ts
+++ b/packages/worker/universal/loader-data.ts
@@ -1071,9 +1071,8 @@ export type AccountIntegrationDetailLoaderData = {
 	ok: true
 	integration: AccountIntegrationListItem | null
 	/**
-	 * True when an enabled built-in app exists for the requested name and the
-	 * returned record is not already using it (the bring-your-own record won
-	 * the lookup). The connect page offers the built-in as an alternative.
+	 * Always false. Platform connect is retired; the field stays so older
+	 * clients keep a stable loader shape.
 	 */
 	builtInAvailable?: boolean
 	/** See {@link ConnectOauthExistingConnection}. */
@@ -1097,7 +1096,7 @@ export type ConnectOauthExistingConnection = {
 }
 
 /**
- * /connect/oauth prefill for `?provider=` visits: the stored or built-in
+ * /connect/oauth prefill for `?provider=` visits: the stored bring-your-own
  * record the page merges into its config. `provider` is the normalized key
  * the record was resolved for; null on callback visits, which restore config
  * from sessionStorage instead.
@@ -1119,9 +1118,8 @@ export type ConnectOauthLoaderData = {
 	 */
 	redirectUri?: string
 	/**
-	 * Signed-in bare `/connect/oauth` visits: built-ins and saved connections
-	 * that can start from `?provider=` alone. Omitted on provider/callback
-	 * visits.
+	 * Signed-in bare `/connect/oauth` visits: saved connections that can
+	 * start from `?provider=` alone. Omitted on provider/callback visits.
 	 */
 	chooser?: {
 		options: Array<{
@@ -1132,7 +1130,7 @@ export type ConnectOauthLoaderData = {
 			providerKey: string
 			logoPath: string | null
 			autoLogoPath: string | null
-			kind: 'connection' | 'platform'
+			kind: 'connection'
 		}>
 	}
 }

--- a/packages/worker/universal/oauth-connect.node.test.ts
+++ b/packages/worker/universal/oauth-connect.node.test.ts
@@ -5,7 +5,7 @@ import {
 	isConnectOauthCallbackUrl,
 } from './oauth-connect.ts'
 
-test('connect chooser lists reconnectable connections and unused built-ins', () => {
+test('connect chooser lists reconnectable connections and hides unused built-ins', () => {
 	expect(
 		isConnectOauthCallbackUrl(
 			new URL('https://example.com/connect/oauth?code=abc&state=1'),
@@ -31,10 +31,9 @@ test('connect chooser lists reconnectable connections and unused built-ins', () 
 	expect(
 		buildConnectOauthHref({
 			name: 'google',
-			platform: true,
 			appSlug: 'google',
 		}),
-	).toBe('/connect/oauth?provider=google&platform=google')
+	).toBe('/connect/oauth?provider=google&app=google')
 
 	const options = buildConnectOauthChooserOptions({
 		connections: [
@@ -69,40 +68,20 @@ test('connect chooser lists reconnectable connections and unused built-ins', () 
 				canDrive: true,
 			},
 		],
-		platformApps: [
-			{
-				slug: 'github',
-				label: 'GitHub',
-				provider: 'github',
-				logoPath: '/integrations/logos/github',
-			},
-			{
-				slug: 'google',
-				label: 'Google',
-				provider: 'google',
-				logoPath: null,
-			},
-			{
-				slug: 'spotify',
-				label: 'Spotify',
-				provider: 'spotify',
-				logoPath: null,
-			},
-		],
 	})
 
 	expect(options.map((option) => option.id)).toEqual([
 		'connection:google-work',
 		'connection:github',
-		'platform:google',
-		'platform:spotify',
 	])
 	expect(options[0]).toMatchObject({
 		href: '/connect/oauth?provider=google-work&app=google',
 		kind: 'connection',
+		detail: 'Reconnect your OAuth app',
 	})
-	expect(options[2]).toMatchObject({
-		href: '/connect/oauth?provider=google&platform=google',
-		kind: 'platform',
+	expect(options[1]).toMatchObject({
+		href: '/connect/oauth?provider=github',
+		kind: 'connection',
+		detail: 'Set up your own OAuth app to reconnect',
 	})
 })

--- a/packages/worker/universal/oauth-connect.ts
+++ b/packages/worker/universal/oauth-connect.ts
@@ -1,6 +1,6 @@
 import { normalizeProviderKey } from '@kody-internal/shared/url-hosts.ts'
 
-export type ConnectOauthChooserKind = 'connection' | 'platform'
+export type ConnectOauthChooserKind = 'connection'
 
 export type ConnectOauthChooserOption = {
 	id: string
@@ -19,14 +19,11 @@ export function isConnectOauthCallbackUrl(url: URL): boolean {
 
 export function buildConnectOauthHref(input: {
 	name: string
-	platform?: boolean
 	appSlug?: string
 }): string {
 	const params = new URLSearchParams({ provider: input.name })
 	const appSlug = input.appSlug?.trim()
-	if (input.platform) {
-		params.set('platform', appSlug || '1')
-	} else if (appSlug) {
+	if (appSlug) {
 		params.set('app', appSlug)
 	}
 	return `/connect/oauth?${params.toString()}`
@@ -43,22 +40,8 @@ export function buildConnectOauthChooserOptions(input: {
 		appSlug: string
 		canDrive: boolean
 	}>
-	platformApps: ReadonlyArray<{
-		slug: string
-		label: string
-		provider: string
-		logoPath: string | null
-	}>
 }): Array<ConnectOauthChooserOption> {
-	const takenNames = new Set(
-		input.connections.map((connection) => connection.name),
-	)
-	const connectedPlatformSlugs = new Set(
-		input.connections
-			.filter((connection) => connection.platform)
-			.map((connection) => connection.appSlug),
-	)
-	const connectionOptions = input.connections
+	return input.connections
 		.filter((connection) => connection.canDrive)
 		.map((connection) => {
 			const providerKey =
@@ -67,12 +50,14 @@ export function buildConnectOauthChooserOptions(input: {
 				id: `connection:${connection.name}`,
 				href: buildConnectOauthHref({
 					name: connection.name,
-					platform: connection.platform,
-					appSlug: connection.appSlug,
+					// Existing platform connections stay listed so the owner
+					// can migrate, but the href is a bring-your-own reconnect
+					// (no `app=` that would look like a built-in slug).
+					appSlug: connection.platform ? undefined : connection.appSlug,
 				}),
 				label: connection.label,
 				detail: connection.platform
-					? 'Reconnect this built-in account'
+					? 'Set up your own OAuth app to reconnect'
 					: 'Reconnect your OAuth app',
 				providerKey,
 				logoPath: connection.logoPath,
@@ -80,27 +65,4 @@ export function buildConnectOauthChooserOptions(input: {
 				kind: 'connection' as const,
 			}
 		})
-	const platformOptions = input.platformApps
-		.filter(
-			(app) =>
-				!takenNames.has(app.slug) && !connectedPlatformSlugs.has(app.slug),
-		)
-		.map((app) => {
-			const providerKey = normalizeProviderKey(app.provider) || app.slug
-			return {
-				id: `platform:${app.slug}`,
-				href: buildConnectOauthHref({
-					name: app.slug,
-					platform: true,
-					appSlug: app.slug,
-				}),
-				label: app.label,
-				detail: "Connect with Kody's built-in app",
-				providerKey,
-				logoPath: app.logoPath,
-				autoLogoPath: null,
-				kind: 'platform' as const,
-			}
-		})
-	return [...connectionOptions, ...platformOptions]
 }

--- a/packages/worker/universal/oauth-scopes.node.test.ts
+++ b/packages/worker/universal/oauth-scopes.node.test.ts
@@ -70,5 +70,8 @@ test('oauth scope helpers unique, order the menu, and steer reconnect prompts', 
 		allowedScopes: ['openid', 'email'],
 	})
 	expect(platform).toContain('Do not call integration_save')
+	expect(platform).toContain('being retired')
+	expect(platform).toContain('bring-your-own OAuth app')
 	expect(platform).toContain('/connect/oauth?provider=google')
+	expect(platform).not.toContain('operator-verified menu')
 })

--- a/packages/worker/universal/oauth-scopes.ts
+++ b/packages/worker/universal/oauth-scopes.ts
@@ -80,25 +80,18 @@ export function buildChangeIntegrationScopesPrompt(input: {
 }): string {
 	const name = input.name.trim() || 'this'
 	const current = uniqueOauthScopes(input.currentScopes)
-	const allowed = uniqueOauthScopes(input.allowedScopes)
 	const currentList =
 		current.length > 0
 			? current.map((scope) => `\`${scope}\``).join(', ')
 			: 'none'
 	const reconnectHref = `/connect/oauth?provider=${encodeURIComponent(name)}`
 	if (input.platform) {
-		const allowedList =
-			allowed.length > 0
-				? allowed.map((scope) => `\`${scope}\``).join(', ')
-				: 'none'
 		return [
-			`The "${name}" connection is a built-in (platform) integration.`,
+			`The "${name}" connection is a built-in (platform) integration that is being retired.`,
 			`It currently requests these scopes: ${currentList}.`,
-			`The operator-verified menu is: ${allowedList}.`,
 			`Do not call integration_save to change authorization.scopes on a built-in — that capability refuses platform connections.`,
-			`If the access I need is already on that menu, send me to ${reconnectHref} so I can check those scopes and reconnect.`,
-			`If it is outside the menu, explain that I need a bring-your-own OAuth app and give me a complete /connect/oauth URL after loading the oauth and provider_* guides.`,
-			`Make clear that updating stored scopes does not enlarge the current token until I reconnect.`,
+			`To change access or reconnect, set up a bring-your-own OAuth app at ${reconnectHref} (or a complete /connect/oauth URL after loading the oauth and provider_* guides).`,
+			`Reconnecting replaces this built-in connection with the user's own app. Existing tokens stay valid until then.`,
 		].join(' ')
 	}
 	return [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Phase built-in (platform) OAuth apps out of every connect surface we can leave, while existing connections keep refreshing until users migrate.

## Why

`/connect/oauth` still listed unused GitHub (Built-in) and Google (Built-in) rows next to bring-your-own reconnects. New connects and reconnects should require the user to set up their own OAuth app. Existing platform tokens stay valid until then.

## Summary

- `/connect/oauth` chooser lists only saved connections. Unused enabled platform apps no longer appear.
- Reconnect and add-account links are bring-your-own (`?provider=<name>`, no `platform=`). Existing platform connections still show so tokens can keep refreshing; the setup form asks for the user's own client credentials.
- `oauth_exchange` / `connect_oauth` reject `platformAppSlug`. Token refresh for existing platform connections is unchanged.
- `integration_platform_app_list` always returns `{ apps: [] }`. Operators still use `admin_platform_oauth_app_list`.
- Removed the “Use the built-in … instead” offer and platform-lane rename connect path.
- Empty built-in apps drop from `/account/integrations` after the last disconnect (same as user-lane apps).
- Follow-up leftover (table, admin apps, refresh lane): #1922.

## Testing

- `npm run validate` (authoritative local gate): passed. Pre-push node unit 751/2271 and workers unit 88/310 also passed. E2E had one flaky `admin-rbac` retry that then passed.
- Preview `https://kody-pr-1926.kody-a99.workers.dev` as seeded `user-me`:
  - Chooser JSON lists only the two saved Google BYO connections (`Personal`, `Work`); no unused built-ins and no `platform=` hrefs.
  - `POST /account/secrets.json` with `platformAppSlug: "github"` returns 400: built-in connect is no longer a path.
  - `?provider=github&platform=1` is ignored and shows BYO missing-config setup, not a ready built-in GitHub connect.
  - UI pass: chooser, BYO reconnect, leftover `platform=` bookmark, and `/account/integrations` all show no unused built-in rows and no “Use the built-in … instead” offer.

![Connect chooser lists only saved BYO connections](https://cursor.com/artifacts/c/art-2e8d55f5-84ac-48bb-9901-fb72ba743664)
![Google reconnect stays bring-your-own with app= not platform=](https://cursor.com/artifacts/c/art-b238b9fa-2983-4bed-bae1-e0a9ef6b9453)
![Leftover platform= GitHub bookmark shows BYO setup, not built-in connect](https://cursor.com/artifacts/c/art-ba5436ed-9827-4b0d-b22f-658572e8c11f)
![Account integrations lists the user Google app only](https://cursor.com/artifacts/c/art-c5f3b9d8-0c55-4c16-8b34-1396905e840a)

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `5ed6ce17` · **Head:** `77b7d912`

**Classification:** extends — connect and reconnect no longer offer platform OAuth apps; `integration_platform_app_list` is empty. Existing platform tokens still refresh.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `app-ui` | surfaces | extends — chooser, reconnect hrefs, and `/connect/oauth` setup no longer start a built-in connect |
| `integrations` | assistant | extends — `integration_platform_app_list` always empty; `oauth_exchange` / `connect_oauth` reject `platformAppSlug` |

### Change flow

A signed-in visit to `/connect/oauth` or an account reconnect link now resolves only user-owned apps; leftover `platform=` bookmarks are ignored and existing platform rows convert to a bring-your-own setup form.

```mermaid
sequenceDiagram
	actor User
	participant appUi as app-ui
	participant integrations as integrations
	User->>appUi: GET /connect/oauth
	appUi->>integrations: list joined connections only
	integrations-->>appUi: omit unused platform apps
	User->>appUi: reconnect existing platform connection
	appUi->>integrations: lookup by name; ignore platform=
	integrations-->>appUi: BYO prefill (endpoints/scopes; no client id)
	Note over appUi: setup form asks for the user's own OAuth app
	User->>appUi: POST oauth_exchange with platformAppSlug
	appUi-->>User: reject; create your own app at /connect/oauth
```

### Before / after

| Surface | Before | After |
| ------- | ------ | ----- |
| `/connect/oauth` chooser | unused enabled built-ins listed | saved connections only |
| reconnect href | `?provider=&platform=` | `?provider=` (BYO setup) |
| `oauth_exchange` / `connect_oauth` | decrypts platform client secret | rejects `platformAppSlug` |
| `integration_platform_app_list` | enabled platform apps | `{ apps: [] }` |
| existing platform tokens | refresh | refresh (unchanged) |

### Invariants

Per-user isolation is unchanged. `platform_oauth_apps` stays global operator config for remaining refresh until #1922.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-84ec6891-cc49-40f6-94cd-790b1fedf5d6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-84ec6891-cc49-40f6-94cd-790b1fedf5d6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Changes**
  - Retired built-in OAuth apps for new connections and reconnects.
  - OAuth setup now requires your own app credentials.
  - Removed built-in apps from connection choosers and listings.
  - Existing built-in connections continue refreshing, with reconnect prompts directing you to create your own OAuth app.
  - Added clearer labels and details for existing built-in connections.
  - Platform OAuth connection and exchange requests are now rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->