### PR TITLE
Add Waiting, a current-state inbox at /account/waiting

### DIFF
--- a/docs/use/activity.md
+++ b/docs/use/activity.md
@@ -3,6 +3,9 @@
 When a job fails, a package app crashes, or a webhook delivery rejects, Kody
 keeps a short execution history so you (and your agent) can see what happened.
 
+[Waiting](./waiting.md) is the current-state queue of gates only you can clear.
+Activity is history; it does not replace Waiting.
+
 ## Where to look
 
 Open **`/account/activity`** while signed in. The page defaults to **open

--- a/docs/use/index.md
+++ b/docs/use/index.md
@@ -63,6 +63,8 @@ Read in order for a full tour, or jump to a topic.
   `app_fetch` smoke tests after publish
 - [Synthetic event dispatch](./synthetic-event-dispatch.md) — platform-marked
   real-surface subscription handler smoke tests
+- [Waiting](./waiting.md) — current-state items only you can clear
+  (`/account/waiting` and `waiting_summary`)
 - [Activity](./activity.md) — failures and recent runs for jobs, apps, webhooks,
   and other runtimes (`/account/activity` and the `runs` MCP capabilities)
 - [Plans and pricing](https://kody.codes/pricing) — every plan is the whole

--- a/docs/use/mcp-client-servers.md
+++ b/docs/use/mcp-client-servers.md
@@ -22,6 +22,10 @@ This is the inverse of [connecting your agent to Kody](./connect-your-agent.md)
 4. Confirm with `mcp_server_list` (or refresh the account page). Connected tools
    show up in `search` under a `mcp:<name>` domain.
 
+If a server is authenticating, failed, or disconnected, [Waiting](./waiting.md)
+lists it and links to `/account/mcp-servers/:id`. `waiting_summary` returns the
+same items.
+
 ## Lock a server to a package
 
 By default every enabled server is callable from execute and every package. Set

--- a/docs/use/waiting.md
+++ b/docs/use/waiting.md
@@ -1,0 +1,42 @@
+# Waiting
+
+Waiting is the current-state queue of things only **you** can clear. Open
+**`/account/waiting`** while signed in — the header avatar lands here.
+
+Items are derived from live account state. They disappear when the gate clears.
+There is no read/unread mark, archive, or notification table.
+
+The empty state is **Nothing is waiting on you.**
+
+## What shows up
+
+Typical items:
+
+- verify your email (outbound mail stays off until you confirm)
+- finish OAuth or reconnect an MCP server that is authenticating, failed, or
+  disconnected
+- promote a publish for a locked package
+- confirm a pending email change
+- a plan resource at its cap
+- an elevated error rate (one card that points at Activity)
+- unfinished onboarding steps, unless you dismissed the checklist
+
+Vendor outages, operator work, and other people's queues do not appear here.
+Session-scoped secret approvals stay on the session that requested them.
+
+OAuth integration last-failure is not stored, so a dead third-party grant does
+not invent a Waiting row. Reconnect from
+[Integrations](https://kody.codes/account/integrations) or the MCP server page
+the card already links to.
+
+## Not Activity, not Email
+
+- **[Activity](./activity.md)** is run history: jobs, apps, webhooks, and
+  triage. Waiting does not copy that error list.
+- **[Email](./email-primitives.md)** is your mailbox. Waiting does not send
+  mail.
+
+## Ask your agent
+
+`waiting_summary` lives on the existing `account` domain. It returns the same
+self-scoped items as the page. Use `run_summary` when you want Activity.

--- a/docs/use/waiting.md
+++ b/docs/use/waiting.md
@@ -15,7 +15,7 @@ Typical items:
 - verify your email (outbound mail stays off until you confirm)
 - finish OAuth or reconnect an MCP server that is authenticating, failed, or
   disconnected
-- promote a publish for a locked package
+- review a locked package (published code stays put until you promote or unlock)
 - confirm a pending email change
 - a plan resource at its cap
 - an elevated error rate (one card that points at Activity)

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -33,12 +33,11 @@ test('smoke test covers shell, auth redirect, and login', async ({ page }) => {
 	await page.getByRole('button', { name: 'Sign in', exact: true }).click()
 
 	await expect(page).toHaveURL(/\/account$/)
-	// Scoped to the header, and exact so the lowercase test username ("kody")
-	// does not also match the "Kody" brand links in the header and footer.
+	// Header avatar is labeled Waiting plus the username so it does not
+	// collide with the "Kody" brand link.
 	await expect(
 		page.getByRole('navigation', { name: 'Main' }).getByRole('link', {
-			name: primaryTestUser.username,
-			exact: true,
+			name: `Waiting — ${primaryTestUser.username}`,
 		}),
 	).toBeVisible()
 	await expect(
@@ -68,10 +67,10 @@ test('smoke test covers shell, auth redirect, and login', async ({ page }) => {
 		page.getByRole('heading', { name: 'Welcome back' }),
 	).toBeVisible()
 	await expect(page.getByRole('button', { name: 'Log out' })).not.toBeVisible()
-	// Exact, so this asserts the username link is gone rather than tripping on
-	// the "Kody" brand link that a case-insensitive match would also find.
 	await expect(
-		page.getByRole('link', { name: primaryTestUser.username, exact: true }),
+		page.getByRole('link', {
+			name: `Waiting — ${primaryTestUser.username}`,
+		}),
 	).not.toBeVisible()
 
 	await page.goto('/privacy')

--- a/packages/worker/client/app.tsx
+++ b/packages/worker/client/app.tsx
@@ -261,6 +261,7 @@ export function App(handle: Handle<AppProps>) {
 							<SiteHeader
 								loggedIn={isLoggedIn}
 								displayName={sessionDisplayName}
+								avatarUrl={session?.avatarUrl ?? null}
 								showAdminLink={showAdminLink}
 								showDemoIndicator={isLoggedIn && showDemoIndicator}
 								loginHref={loginHref}

--- a/packages/worker/client/lazy-route.tsx
+++ b/packages/worker/client/lazy-route.tsx
@@ -248,6 +248,7 @@ registerPreloadPatterns(
 		routePattern(routes.accountBilling),
 		routePattern(routes.accountBillingSuccess),
 		routePattern(routes.accountUsage),
+		routePattern(routes.accountWaiting),
 		routePattern(routes.accountIntegrations),
 		routePattern(routes.accountOauthAppDetail),
 		routePattern(routes.accountIntegrationsApprove),

--- a/packages/worker/client/routes/account-area.ts
+++ b/packages/worker/client/routes/account-area.ts
@@ -10,6 +10,10 @@ export {
 export { AccountEmailRoute, accountEmailRouteLoader } from './account-email.tsx'
 export { AccountUsageRoute, accountUsageRouteLoader } from './account-usage.tsx'
 export {
+	AccountWaitingRoute,
+	accountWaitingRouteLoader,
+} from './account-waiting.tsx'
+export {
 	AccountIntegrationsRoute,
 	accountIntegrationsRouteLoader,
 } from './account-integrations.tsx'

--- a/packages/worker/client/routes/account-management-components.tsx
+++ b/packages/worker/client/routes/account-management-components.tsx
@@ -436,6 +436,7 @@ export function AccountManagementInlineLinkNav(
 
 const accountNavItems = [
 	{ href: '/account', label: 'Overview' },
+	{ href: '/account/waiting', label: 'Waiting' },
 	{ href: '/account/billing', label: 'Billing' },
 	{ href: '/account/usage', label: 'Usage' },
 	{ href: '/account/activity', label: 'Activity' },

--- a/packages/worker/client/routes/account-waiting.tsx
+++ b/packages/worker/client/routes/account-waiting.tsx
@@ -1,0 +1,213 @@
+import { type Handle, css } from 'remix/ui'
+import { readCurrentRouterHref } from '#client/client-router.tsx'
+import { createRouteLoadLatch } from '#client/route-load-latch.ts'
+import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
+import { consumeStaleNavigationData } from '#client/navigation-data.ts'
+import {
+	type AccountStatus,
+	readJson,
+} from '#client/routes/account-approval-shared.ts'
+import {
+	routeLoaderRedirect,
+	type RouteLoaderResult,
+} from '#client/route-loader.ts'
+import {
+	AccountManagementMessage,
+	AccountManagementPanel,
+	AccountManagementShell,
+	AccountPageHeader,
+	noticeCardCss,
+} from '#client/routes/account-management-components.tsx'
+import { type AccountWaitingLoaderData } from '#universal/loader-data.ts'
+import { type WaitingItem, type WaitingSeverity } from '#universal/waiting.ts'
+import { routes } from '#universal/routes.ts'
+import { colors, spacing } from '#universal/styles/tokens.ts'
+import {
+	getAccentCalloutCss,
+	getPillButtonCss,
+} from '#universal/styles/style-primitives.ts'
+
+const waitingApiPath = routes.accountWaitingApi.href()
+const waitingPath = routes.accountWaiting.href()
+
+function isWaitingPath(href: string) {
+	return new URL(href, 'http://localhost').pathname === waitingPath
+}
+
+const severityAccent: Record<WaitingSeverity, string> = {
+	block: colors.danger,
+	degraded: colors.primary,
+	setup: colors.border,
+}
+
+export async function accountWaitingRouteLoader(
+	_url: URL,
+	signal: AbortSignal,
+): Promise<RouteLoaderResult> {
+	const response = await fetch(waitingApiPath, {
+		headers: { Accept: 'application/json' },
+		credentials: 'include',
+		signal,
+	})
+	if (response.status === 401) {
+		return routeLoaderRedirect('/login')
+	}
+	const payload = await readJson<AccountWaitingLoaderData>(response)
+	if (!response.ok || !payload?.ok) {
+		throw new Error('Unable to load waiting items.')
+	}
+	return { accountWaiting: payload }
+}
+
+export function AccountWaitingRoute(handle: Handle) {
+	let status: AccountStatus = 'loading'
+	let data: AccountWaitingLoaderData | null = null
+	let message: string | null = null
+	const loadLatch = createRouteLoadLatch()
+
+	function applyPayload(payload: AccountWaitingLoaderData) {
+		data = payload
+		status = 'ready'
+		message = null
+	}
+
+	async function loadWaiting(signal: AbortSignal) {
+		const href = readCurrentRouterHref(handle)
+		try {
+			const response = await fetch(waitingApiPath, {
+				headers: { Accept: 'application/json' },
+				credentials: 'include',
+				signal,
+			})
+			if (signal.aborted) return
+			if (response.status === 401) {
+				window.location.assign('/login')
+				return
+			}
+			const payload = await readJson<AccountWaitingLoaderData>(response)
+			if (!response.ok || !payload?.ok) {
+				throw new Error('Unable to load waiting items.')
+			}
+			applyPayload(payload)
+			loadLatch.markLoaded(href)
+			handle.update()
+		} catch (error) {
+			if (signal.aborted) return
+			status = 'error'
+			message =
+				error instanceof Error ? error.message : 'Unable to load waiting items.'
+			loadLatch.markFailed(href)
+			handle.update()
+		}
+	}
+
+	function applyRouteLoaderData(href: string) {
+		if (!isWaitingPath(href)) return false
+		const routeData = tryConsumeRouteLoaderData(handle, 'accountWaiting', href)
+		if (!routeData) return false
+		applyPayload(routeData)
+		loadLatch.markLoaded(href)
+		return true
+	}
+
+	return () => {
+		const currentHref = readCurrentRouterHref(handle)
+		const appliedRouteData = applyRouteLoaderData(currentHref)
+		const needsStaleRefresh =
+			consumeStaleNavigationData(currentHref) && !appliedRouteData
+		const needsLoad = loadLatch.needsLoad({
+			currentHref,
+			appliedRouteData,
+			needsStaleRefresh,
+		})
+		if (needsLoad && typeof document !== 'undefined') {
+			handle.queueTask(loadWaiting)
+		}
+
+		return (
+			<AccountManagementShell>
+				<AccountPageHeader
+					title="Waiting"
+					description="Things that need you. Not a history — items leave when you clear the gate."
+					currentHref={currentHref}
+				/>
+				{status === 'error' && message ? (
+					<AccountManagementMessage tone="error">
+						{message}
+					</AccountManagementMessage>
+				) : null}
+				{status === 'ready' && data ? renderWaitingBody(data.items) : null}
+			</AccountManagementShell>
+		)
+	}
+}
+
+function renderWaitingBody(items: Array<WaitingItem>) {
+	if (items.length === 0) {
+		return (
+			<AccountManagementPanel
+				title="Nothing is waiting on you"
+				description="Onboarding is done, connections are healthy, and no publishes or grants need a click."
+			>
+				<p mix={css({ margin: 0, color: colors.textMuted })}>
+					<a href={routes.accountActivity.href()}>Activity</a> is run history.{' '}
+					<a href={routes.accountEmail.href()}>Email</a> is your mailbox.
+				</p>
+			</AccountManagementPanel>
+		)
+	}
+
+	return (
+		<div
+			mix={css({
+				display: 'grid',
+				gap: spacing.md,
+			})}
+		>
+			{items.map((item) => (
+				<section
+					key={item.id}
+					data-testid={`waiting-item-${item.kind}`}
+					mix={css({
+						...noticeCardCss,
+						...getAccentCalloutCss({
+							accentColor: severityAccent[item.severity],
+						}),
+					})}
+				>
+					<h2
+						mix={css({
+							margin: 0,
+							fontSize: '1.05rem',
+							fontWeight: 700,
+							letterSpacing: '-0.01em',
+							lineHeight: 1.3,
+						})}
+					>
+						{item.title}
+					</h2>
+					<p
+						mix={css({
+							margin: 0,
+							color: colors.textMuted,
+							fontSize: '0.95rem',
+							lineHeight: 1.5,
+						})}
+					>
+						{item.why}
+					</p>
+					<a
+						href={item.href}
+						mix={css({
+							...getPillButtonCss({ size: 'sm' }),
+							width: 'fit-content',
+							textDecoration: 'none',
+						})}
+					>
+						{item.doLabel}
+					</a>
+				</section>
+			))}
+		</div>
+	)
+}

--- a/packages/worker/client/routes/email-verification-flow.node.test.ts
+++ b/packages/worker/client/routes/email-verification-flow.node.test.ts
@@ -50,6 +50,7 @@ test('email verification redirect helpers preserve safe targets and reject open 
 		emailVerified: false,
 		emailVerificationDelivery: null,
 		username: 'account-user',
+		avatarUrl: null,
 		roles: ['user'],
 		permissions: [],
 		featureFlags: {

--- a/packages/worker/client/routes/entity-explainer.tsx
+++ b/packages/worker/client/routes/entity-explainer.tsx
@@ -124,6 +124,15 @@ const entityExplainerDefinitions: Array<EntityExplainerDefinition> = [
 		},
 	},
 	{
+		id: 'waiting',
+		question: 'What is waiting?',
+		match: accountSection(routes.accountWaiting.href()),
+		paragraphs: [
+			'Waiting is the current-state queue of things only you can clear: verify email, reconnect an MCP server, promote a locked-package publish, confirm a pending email change, or finish setup.',
+			'Items disappear when the gate clears. Activity is run history. Email is your mailbox. Vendor outages and operator work do not show up here.',
+		],
+	},
+	{
 		id: 'activity',
 		question: 'What is activity?',
 		match: accountSection(routes.accountActivity.href()),

--- a/packages/worker/client/routes/index.tsx
+++ b/packages/worker/client/routes/index.tsx
@@ -42,6 +42,10 @@ export const clientRouteLoaders: Record<string, RouteLoader> = {
 		accountArea,
 		(m) => m.accountUsageRouteLoader,
 	),
+	[routePattern(routes.accountWaiting)]: lazyRouteLoader(
+		accountArea,
+		(m) => m.accountWaitingRouteLoader,
+	),
 	[routePattern(routes.accountIntegrations)]: lazyRouteLoader(
 		accountArea,
 		(m) => m.accountIntegrationsRouteLoader,
@@ -333,6 +337,9 @@ export const clientRoutes = {
 	),
 	[routePattern(routes.accountUsage)]: (
 		<LazyAccountRoute render={(m) => <m.AccountUsageRoute />} />
+	),
+	[routePattern(routes.accountWaiting)]: (
+		<LazyAccountRoute render={(m) => <m.AccountWaitingRoute />} />
 	),
 	[routePattern(routes.accountIntegrations)]: (
 		<LazyAccountRoute render={(m) => <m.AccountIntegrationsRoute />} />

--- a/packages/worker/client/session.ts
+++ b/packages/worker/client/session.ts
@@ -20,6 +20,7 @@ export type SessionInfo = {
 	emailVerified: boolean
 	emailVerificationDelivery: EmailVerificationDelivery | null
 	username: string
+	avatarUrl: string | null
 	roles: Array<RoleName>
 	permissions: Array<PermissionString>
 	featureFlags: Record<FeatureFlagKey, boolean>
@@ -62,6 +63,12 @@ export async function fetchSessionInfo(
 			typeof payload?.session?.username === 'string'
 				? payload.session.username.trim()
 				: ''
+		const avatarUrl =
+			response.ok &&
+			payload?.ok &&
+			typeof payload?.session?.avatarUrl === 'string'
+				? payload.session.avatarUrl.trim() || null
+				: null
 		const roles = readRoleNames(payload?.session?.roles)
 		const permissions = readPermissionStrings(payload?.session?.permissions)
 		const featureFlags = readFeatureFlags(payload?.session?.featureFlags)
@@ -82,6 +89,7 @@ export async function fetchSessionInfo(
 					emailVerified,
 					emailVerificationDelivery,
 					username,
+					avatarUrl,
 					roles,
 					permissions,
 					featureFlags,

--- a/packages/worker/client/site-header.tsx
+++ b/packages/worker/client/site-header.tsx
@@ -1,8 +1,10 @@
 import { type Handle, css } from 'remix/ui'
 import { listenToRouterNavigation } from '#client/client-router.tsx'
 import { on } from '#client/event-mixin.ts'
+import { UserAvatar } from '#universal/user-avatar.tsx'
 import {
 	colors,
+	radius,
 	shadows,
 	spacing,
 	transitions,
@@ -17,6 +19,7 @@ import {
 export type SiteHeaderProps = {
 	loggedIn: boolean
 	displayName: string
+	avatarUrl: string | null
 	showAdminLink: boolean
 	showDemoIndicator: boolean
 	loginHref: string
@@ -126,8 +129,22 @@ export function SiteHeader(handle: Handle<SiteHeaderProps>) {
 				<div mix={css(navActionsCss)}>
 					{handle.props.loggedIn ? (
 						<>
-							<a href="/account" mix={css(navUserCss)}>
-								{handle.props.displayName}
+							<a
+								href="/account/waiting"
+								aria-label={`Waiting — ${handle.props.displayName}`}
+								aria-current={ariaCurrent(
+									handle.props.currentPathname,
+									'/account/waiting',
+								)}
+								data-testid="site-header-waiting"
+								mix={css(navUserAvatarCss)}
+							>
+								<UserAvatar
+									displayName={handle.props.displayName}
+									avatarUrl={handle.props.avatarUrl}
+									size={32}
+									variant="well"
+								/>
 							</a>
 							{handle.props.showDemoIndicator ? (
 								<span data-testid="demo-indicator" mix={css(demoIndicatorCss)}>
@@ -205,13 +222,21 @@ export function SiteHeader(handle: Handle<SiteHeaderProps>) {
 						{handle.props.loggedIn ? (
 							<>
 								<a
-									href="/account"
+									href="/account/waiting"
+									aria-label={`Waiting — ${handle.props.displayName}`}
 									aria-current={ariaCurrent(
 										handle.props.currentPathname,
-										'/account',
+										'/account/waiting',
 									)}
+									data-testid="site-header-waiting-menu"
+									mix={css(menuWaitingAvatarCss)}
 								>
-									{handle.props.displayName}
+									<UserAvatar
+										displayName={handle.props.displayName}
+										avatarUrl={handle.props.avatarUrl}
+										size={32}
+										variant="well"
+									/>
 								</a>
 								<form
 									method="post"
@@ -467,10 +492,22 @@ const navLoginCss = {
 	'&:hover': { color: colors.primaryText },
 }
 
-const navUserCss = {
-	...navLoginCss,
+const navUserAvatarCss = {
+	display: 'inline-flex',
+	alignItems: 'center',
+	justifyContent: 'center',
+	lineHeight: 0,
+	padding: '0.15rem',
+	borderRadius: radius.full,
+	textDecoration: 'none',
 	color: colors.textMuted,
 	'&:hover': { color: colors.text },
+}
+
+const menuWaitingAvatarCss = {
+	display: 'inline-flex',
+	alignItems: 'center',
+	width: 'fit-content',
 }
 
 /**

--- a/packages/worker/src/app/account-waiting-data.ts
+++ b/packages/worker/src/app/account-waiting-data.ts
@@ -1,0 +1,28 @@
+import { type AccountWaitingLoaderData } from '#universal/loader-data.ts'
+import { deriveWaitingItems } from '#mcp/waiting/derive-waiting.ts'
+import { type readAuthenticatedAppUser } from '#app/authenticated-user.ts'
+
+type AuthenticatedUser = NonNullable<
+	Awaited<ReturnType<typeof readAuthenticatedAppUser>>
+>
+
+export async function loadAccountWaitingData(input: {
+	env: Env
+	user: AuthenticatedUser
+	now?: Date
+}): Promise<AccountWaitingLoaderData> {
+	const items = await deriveWaitingItems({
+		env: input.env,
+		user: {
+			userId: input.user.userId,
+			stableUserId: input.user.mcpUser.userId,
+			email: input.user.email,
+			emailVerified: input.user.emailVerified,
+		},
+		now: input.now,
+	})
+	return {
+		ok: true,
+		items,
+	}
+}

--- a/packages/worker/src/app/handlers/account-waiting.ts
+++ b/packages/worker/src/app/handlers/account-waiting.ts
@@ -1,0 +1,46 @@
+import { jsonResponse } from '#worker/json-response.ts'
+import { type Action } from 'remix/router'
+import { loadAccountWaitingData } from '#app/account-waiting-data.ts'
+import { readAuthenticatedAppUser } from '#app/authenticated-user.ts'
+import { requireAuthenticatedPageUser } from '#app/page-auth.ts'
+import { renderAppPage } from '#app/ssr-render.tsx'
+import { type routes } from '#universal/routes.ts'
+
+export function createAccountWaitingHandler(env: Env) {
+	return {
+		middleware: [],
+		async handler({ request }) {
+			const user = await requireAuthenticatedPageUser(request, env)
+			if (user instanceof Response) {
+				return user
+			}
+
+			const accountWaiting = await loadAccountWaitingData({ env, user })
+			return renderAppPage({
+				request,
+				env,
+				title: 'Waiting',
+				loaderData: { accountWaiting },
+			})
+		},
+	} satisfies Action<typeof routes.accountWaiting>
+}
+
+export function createAccountWaitingApiHandler(env: Env) {
+	return {
+		middleware: [],
+		async handler({ request }) {
+			const user = await readAuthenticatedAppUser(request, env)
+			if (!user) {
+				return jsonResponse({ ok: false, error: 'Unauthorized.' }, 401)
+			}
+
+			if (request.method !== 'GET') {
+				return jsonResponse({ ok: false, error: 'Method not allowed.' }, 405)
+			}
+
+			const accountWaiting = await loadAccountWaitingData({ env, user })
+			return jsonResponse(accountWaiting)
+		},
+	} satisfies Action<typeof routes.accountWaitingApi>
+}

--- a/packages/worker/src/app/handlers/session-handler.node.test.ts
+++ b/packages/worker/src/app/handlers/session-handler.node.test.ts
@@ -164,6 +164,7 @@ test('session handler only renews remembered sessions after the renewal window',
 				emailVerified: false,
 				emailVerificationDelivery: null,
 				username: 'session-user',
+				avatarUrl: null,
 				roles: [],
 				permissions: [],
 				featureFlags: {

--- a/packages/worker/src/app/request-auth-cache.ts
+++ b/packages/worker/src/app/request-auth-cache.ts
@@ -32,6 +32,7 @@ type ResolvedAuthUser = {
 	emailVerified: boolean
 	emailVerificationDelivery: EmailVerificationDelivery | null
 	username: string
+	avatarKey: string | null
 	displayName: string
 	accountDeleting: boolean
 	accountSuspended: boolean
@@ -128,6 +129,7 @@ async function resolveRequestAuth(
 				at: userRecord.email_verification_delivery_at,
 			}),
 			username: userRecord.username,
+			avatarKey: userRecord.avatar_key ?? null,
 			displayName,
 			accountDeleting: Boolean(userRecord.deleting_at),
 			accountSuspended: Boolean(userRecord.suspended_at),

--- a/packages/worker/src/app/router.ts
+++ b/packages/worker/src/app/router.ts
@@ -124,6 +124,10 @@ import {
 	createAccountUsageApiHandler,
 	createAccountUsageHandler,
 } from '#app/handlers/account-usage.ts'
+import {
+	createAccountWaitingApiHandler,
+	createAccountWaitingHandler,
+} from '#app/handlers/account-waiting.ts'
 import { createAccountResendVerificationHandler } from '#app/handlers/account-resend-verification.ts'
 import { createPendingVerificationHandler } from '#app/handlers/pending-verification.ts'
 import {
@@ -368,6 +372,8 @@ export function createAppRouter(env: Env) {
 			accountBillingPortal: createAccountBillingPortalHandler(env),
 			accountUsage: createAccountUsageHandler(env),
 			accountUsageApi: createAccountUsageApiHandler(env),
+			accountWaiting: createAccountWaitingHandler(env),
+			accountWaitingApi: createAccountWaitingApiHandler(env),
 			accountEmailChange: createAccountEmailChangeHandler(env),
 			accountResendVerification: createAccountResendVerificationHandler(env),
 			accountSecrets: createAccountSecretsHandler(env),

--- a/packages/worker/src/app/session-info.ts
+++ b/packages/worker/src/app/session-info.ts
@@ -1,4 +1,5 @@
 import { destroyAuthCookie, isSecureRequest } from '#app/auth-session.ts'
+import { buildUserAvatarUrl } from '#app/community-public.ts'
 import { loadResolvedRequestAuth } from '#app/request-auth-cache.ts'
 import {
 	loadRequestFeatureFlags,
@@ -12,6 +13,7 @@ export type SessionInfo = {
 	emailVerified: boolean
 	emailVerificationDelivery: EmailVerificationDelivery | null
 	username: string
+	avatarUrl: string | null
 	roles: Array<RoleName>
 	permissions: Array<PermissionString>
 	featureFlags: EvaluatedFeatureFlags
@@ -54,6 +56,10 @@ export async function loadSessionInfo(
 			emailVerified: resolved.user.emailVerified,
 			emailVerificationDelivery: resolved.user.emailVerificationDelivery,
 			username: resolved.user.username,
+			avatarUrl: buildUserAvatarUrl({
+				username: resolved.user.username,
+				avatarKey: resolved.user.avatarKey,
+			}),
 			roles: resolved.user.roles,
 			permissions: resolved.user.permissions,
 			featureFlags,

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -10,6 +10,7 @@ import { createAccountHandler } from '#app/handlers/account.ts'
 import { createAccountPasskeysHandler } from '#app/handlers/account-passkeys.ts'
 import { createAccountMcpOauthClientsHandler } from '#app/handlers/account-mcp-oauth-clients.ts'
 import { createAccountTwoFactorHandler } from '#app/handlers/account-two-factor.ts'
+import { createAccountWaitingHandler } from '#app/handlers/account-waiting.ts'
 import { createCommunityHandler } from '#app/handlers/community.tsx'
 import {
 	createCommunityDetailHandler,
@@ -355,6 +356,9 @@ test('SSR HTML routes render page content and embedded loader data', async () =>
 	expect(accountResponse.status).toBe(200)
 	const accountHtml = await readResponseText(accountResponse)
 	expect(accountHtml).toContain('aria-label="Account sections"')
+	expect(accountHtml).toContain('data-testid="site-header-waiting"')
+	expect(accountHtml).toContain('href="/account/waiting"')
+	expect(accountHtml).toContain('Waiting — account-user')
 	const accountProps = readAppRootProps(accountHtml)
 	expect(accountProps.loaderData?.accountProfile).toEqual({
 		ok: true,
@@ -421,6 +425,20 @@ test('SSR HTML routes render page content and embedded loader data', async () =>
 	expect(readAppRootProps(passkeysHtml).loaderData?.accountPasskeys).toEqual({
 		ok: true,
 		passkeys: [],
+	})
+
+	const waitingResponse = await runHtmlHandler(
+		createAccountWaitingHandler(env),
+		new Request('https://example.com/account/waiting', {
+			headers: { Cookie: accountCookie },
+		}),
+	)
+	expect(waitingResponse.status).toBe(200)
+	const waitingHtml = await readResponseText(waitingResponse)
+	expect(waitingHtml).toContain('>Waiting<')
+	expect(readAppRootProps(waitingHtml).loaderData?.accountWaiting).toEqual({
+		ok: true,
+		items: expect.any(Array),
 	})
 
 	const mcpOauthClientsResponse = await runHtmlHandler(

--- a/packages/worker/src/mcp/capabilities/account/domain.ts
+++ b/packages/worker/src/mcp/capabilities/account/domain.ts
@@ -3,11 +3,12 @@ import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { accountExportManifestCapability } from './account-export-manifest.ts'
 import { accountExportSectionCapability } from './account-export-section.ts'
 import { usageGetCapability } from './usage-get.ts'
+import { waitingSummaryCapability } from './waiting-summary.ts'
 
 export const accountDomain = defineDomain({
 	name: capabilityDomainNames.account,
 	description:
-		'Self-service account export, backup, migration, and entitlement usage (secrets never exported).',
+		'Self-service account export, backup, migration, entitlement usage, and the current-state waiting queue (secrets never exported).',
 	keywords: [
 		'account',
 		'export',
@@ -16,10 +17,14 @@ export const accountDomain = defineDomain({
 		'privacy',
 		'usage',
 		'quota',
+		'waiting',
+		'approvals',
+		'blockers',
 	],
 	capabilities: [
 		accountExportManifestCapability,
 		accountExportSectionCapability,
 		usageGetCapability,
+		waitingSummaryCapability,
 	],
 })

--- a/packages/worker/src/mcp/capabilities/account/waiting-summary.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/account/waiting-summary.node.test.ts
@@ -1,0 +1,133 @@
+import { expect, test } from 'vitest'
+import { createMcpCallerContext } from '#mcp/context.ts'
+import { testStableUserIdFromEmail } from '#worker/test-support/stable-user-id.ts'
+import { waitingSummaryCapability } from './waiting-summary.ts'
+
+function createWaitingTestDb(input: {
+	email: string
+	emailVerified: boolean
+	missingUser?: boolean
+	dismissedOnboarding?: boolean
+}) {
+	const stableUserId = testStableUserIdFromEmail(input.email)
+	return {
+		stableUserId,
+		db: {
+			prepare(query: string) {
+				const normalized = query.replace(/\s+/g, ' ').trim().toLowerCase()
+				return {
+					bind(...params: Array<unknown>) {
+						return {
+							async first<T>() {
+								if (input.missingUser) return null
+								if (
+									normalized.includes('from users') &&
+									normalized.includes('email_verified_at')
+								) {
+									return {
+										id: 11,
+										email_verified_at: input.emailVerified
+											? '2026-01-01 00:00:00'
+											: null,
+									} as T
+								}
+								if (
+									normalized.includes('from users') &&
+									normalized.includes('onboarding_checklist_dismissed_at')
+								) {
+									return {
+										onboarding_checklist_dismissed_at: input.dismissedOnboarding
+											? '2026-01-02 00:00:00'
+											: null,
+									} as T
+								}
+								void params
+								return null
+							},
+							async all() {
+								return { results: [] }
+							},
+						}
+					},
+				}
+			},
+		} as unknown as D1Database,
+	}
+}
+
+test('waiting_summary requires auth and stays self-scoped', async () => {
+	const email = 'waiting-summary@example.com'
+	const { stableUserId, db } = createWaitingTestDb({
+		email,
+		emailVerified: true,
+		dismissedOnboarding: true,
+	})
+	const env = { APP_DB: db } as Env
+	const callerContext = createMcpCallerContext({
+		baseUrl: 'https://example.com/',
+		user: { userId: stableUserId, email, displayName: 'Waiting' },
+	})
+
+	await expect(
+		waitingSummaryCapability.handler(
+			{},
+			{
+				env,
+				callerContext: createMcpCallerContext({
+					baseUrl: 'https://example.com/',
+				}),
+			},
+		),
+	).rejects.toThrow(/Authenticated MCP user/)
+
+	const empty = await waitingSummaryCapability.handler(
+		{},
+		{ env, callerContext },
+	)
+	expect(empty).toEqual({
+		count: 0,
+		waiting_url: 'https://example.com/account/waiting',
+		items: [],
+	})
+
+	const unverifiedDb = createWaitingTestDb({
+		email,
+		emailVerified: false,
+		dismissedOnboarding: true,
+	})
+	const unverified = await waitingSummaryCapability.handler(
+		{},
+		{
+			env: { APP_DB: unverifiedDb.db } as Env,
+			callerContext,
+		},
+	)
+	expect(unverified.count).toBe(1)
+	expect(unverified.items[0]).toMatchObject({
+		id: 'verify-email',
+		kind: 'verify-email',
+		who: 'you',
+		do_label: 'Verify email',
+		href: 'https://example.com/pending-verification',
+		severity: 'block',
+	})
+
+	const missing = await waitingSummaryCapability.handler(
+		{},
+		{
+			env: {
+				APP_DB: createWaitingTestDb({
+					email,
+					emailVerified: true,
+					missingUser: true,
+				}).db,
+			} as Env,
+			callerContext,
+		},
+	)
+	expect(missing).toEqual({
+		count: 0,
+		waiting_url: 'https://example.com/account/waiting',
+		items: [],
+	})
+})

--- a/packages/worker/src/mcp/capabilities/account/waiting-summary.ts
+++ b/packages/worker/src/mcp/capabilities/account/waiting-summary.ts
@@ -1,0 +1,89 @@
+import { z } from 'zod'
+import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
+import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
+import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
+import { emptyCapabilityInputSchema } from '#mcp/capabilities/types.ts'
+import { deriveWaitingItems } from '#mcp/waiting/derive-waiting.ts'
+import { waitingItemKinds, waitingSeverities } from '#universal/waiting.ts'
+
+const waitingItemSchema = z.object({
+	id: z.string(),
+	kind: z.enum(waitingItemKinds),
+	title: z.string(),
+	why: z.string(),
+	who: z.literal('you'),
+	do_label: z.string(),
+	href: z.string(),
+	severity: z.enum(waitingSeverities),
+})
+
+export const waitingSummaryCapability = defineDomainCapability(
+	capabilityDomainNames.account,
+	{
+		name: 'waiting_summary',
+		description:
+			'List things currently waiting on the signed-in human: email verification, MCP reconnects, locked-package publishes, plan caps, and unfinished setup. This is a current-state queue, not run history — use run_summary for Activity.',
+		keywords: [
+			'waiting',
+			'inbox',
+			'approvals',
+			'blockers',
+			'reconnect',
+			'needs you',
+			'onboarding',
+			'verify email',
+			'locked package',
+			'MCP disconnected',
+		],
+		readOnly: true,
+		idempotent: true,
+		destructive: false,
+		inputSchema: emptyCapabilityInputSchema,
+		outputSchema: z.object({
+			count: z.number().int().nonnegative(),
+			waiting_url: z.string(),
+			items: z.array(waitingItemSchema),
+		}),
+		async handler(_args, ctx) {
+			const user = requireMcpUser(ctx.callerContext)
+			const origin = ctx.callerContext.baseUrl.replace(/\/+$/, '')
+			const userRow = await ctx.env.APP_DB.prepare(
+				`SELECT id, email_verified_at FROM users WHERE stable_user_id = ? LIMIT 1`,
+			)
+				.bind(user.userId)
+				.first<{ id: number; email_verified_at: string | null }>()
+			if (!userRow) {
+				return {
+					count: 0,
+					waiting_url: `${origin}/account/waiting`,
+					items: [],
+				}
+			}
+			const items = await deriveWaitingItems({
+				env: ctx.env,
+				user: {
+					userId: userRow.id,
+					stableUserId: user.userId,
+					email: user.email,
+					emailVerified: Boolean(userRow.email_verified_at),
+				},
+			})
+			return {
+				count: items.length,
+				waiting_url: `${origin}/account/waiting`,
+				items: items.map((item) => ({
+					id: item.id,
+					kind: item.kind,
+					title: item.title,
+					why: item.why,
+					who: item.who,
+					do_label: item.doLabel,
+					href: item.href.startsWith('http')
+						? item.href
+						: `${origin}${item.href}`,
+					severity: item.severity,
+				})),
+			}
+		},
+	},
+)

--- a/packages/worker/src/mcp/waiting/derive-waiting.ts
+++ b/packages/worker/src/mcp/waiting/derive-waiting.ts
@@ -1,0 +1,232 @@
+import { utcMonthKey } from '@kody-internal/shared/date-keys.ts'
+import {
+	deriveOnboardingChecklist,
+	readOnboardingChecklistDismissed,
+} from '#mcp/onboarding-checklist.ts'
+import { getCachedMcpClientHubSnapshot } from '#worker/mcp-client/hub-client.ts'
+import { type McpClientHubSnapshot } from '#worker/mcp-client/types.ts'
+import { listMcpServerSettings } from '#worker/mcp-client/settings-service.ts'
+import { listSavedPackagesByUserId } from '#worker/package-registry/repo.ts'
+import { readEntitlementUsageSnapshot } from '#worker/entitlements/usage-snapshot.ts'
+import { getUserPlan } from '#worker/entitlements/service.ts'
+import { isSavedPackageLocked } from '#worker/package-registry/package-publish-lock.ts'
+import {
+	buildWaitingItems,
+	isWaitingMcpServerState,
+	type WaitingItem,
+	type WaitingMcpServerSignal,
+	type WaitingSignals,
+} from '#universal/waiting.ts'
+
+export type DeriveWaitingUser = {
+	userId: number
+	stableUserId: string
+	email: string
+	emailVerified: boolean
+}
+
+type WaitingEnv = Env & {
+	OAUTH_PROVIDER?: {
+		listUserGrants(
+			userId: string,
+			options?: { cursor?: string },
+		): Promise<{ items: Array<unknown>; cursor?: string }>
+	}
+}
+
+/**
+ * Current-state waiting queue for one signed-in user. Every probe fails open
+ * so a storage blip cannot hide the page or invent another user's items.
+ */
+export async function deriveWaitingItems(input: {
+	env: WaitingEnv
+	user: DeriveWaitingUser
+	now?: Date
+}): Promise<Array<WaitingItem>> {
+	const signals = await collectWaitingSignals(input)
+	return buildWaitingItems(signals)
+}
+
+export async function collectWaitingSignals(input: {
+	env: WaitingEnv
+	user: DeriveWaitingUser
+	now?: Date
+}): Promise<WaitingSignals> {
+	const now = input.now ?? new Date()
+	const { env, user } = input
+
+	const [
+		onboardingDismissed,
+		hasMcpClient,
+		mcpServers,
+		lockedPackages,
+		pendingEmailChange,
+		errorRate,
+		entitlementCaps,
+	] = await Promise.all([
+		readOnboardingChecklistDismissed({
+			env,
+			userId: user.stableUserId,
+		}).catch(() => true),
+		userHasMcpOAuthGrants(env, user.stableUserId),
+		collectMcpServerSignals(env, user.stableUserId),
+		collectLockedPackageSignals(env, user.stableUserId),
+		collectPendingEmailChange(env, user.userId),
+		collectErrorRate(env, user.stableUserId, now),
+		collectEntitlementCaps(env, user, now),
+	])
+
+	const checklist = await deriveOnboardingChecklist({
+		env,
+		userId: user.stableUserId,
+		emailVerified: user.emailVerified,
+		hasMcpClient,
+		now,
+	}).catch(() => ({
+		items: [],
+		complete: true,
+	}))
+
+	return {
+		emailVerified: user.emailVerified,
+		onboardingDismissed: onboardingDismissed || checklist.complete,
+		onboardingRemaining: checklist.items
+			.filter((item) => !item.done)
+			.map((item) => item.id),
+		mcpServers,
+		lockedPackages,
+		pendingEmailChange,
+		errorRate,
+		entitlementCaps,
+	}
+}
+
+async function userHasMcpOAuthGrants(env: WaitingEnv, stableUserId: string) {
+	const helpers = env.OAUTH_PROVIDER
+	if (!helpers) return false
+	try {
+		const page = await helpers.listUserGrants(stableUserId)
+		return page.items.length > 0
+	} catch {
+		return false
+	}
+}
+
+async function collectMcpServerSignals(
+	env: Env,
+	userId: string,
+): Promise<Array<WaitingMcpServerSignal>> {
+	const settings = await listMcpServerSettings({ env, userId }).catch(
+		() => [] as Awaited<ReturnType<typeof listMcpServerSettings>>,
+	)
+	const enabled = settings.filter((server) => server.enabled)
+	if (enabled.length === 0) return []
+
+	const snapshot = await getCachedMcpClientHubSnapshot({
+		env,
+		userId,
+	}).catch((): McpClientHubSnapshot => ({
+		servers: [],
+	}))
+	const byId = new Map(
+		snapshot.servers.map((server) => [server.serverId, server]),
+	)
+
+	const items: Array<WaitingMcpServerSignal> = []
+	for (const server of enabled) {
+		const live = byId.get(server.id)
+		const state = live?.state ?? 'disconnected'
+		if (!isWaitingMcpServerState(state)) continue
+		items.push({
+			id: server.id,
+			name: server.name,
+			state,
+			error: live?.error ?? null,
+		})
+	}
+	return items
+}
+
+async function collectLockedPackageSignals(env: Env, userId: string) {
+	const packages = await listSavedPackagesByUserId(env.APP_DB, {
+		userId,
+	}).catch(() => [] as Awaited<ReturnType<typeof listSavedPackagesByUserId>>)
+	return packages
+		.filter((pkg) => isSavedPackageLocked(pkg.lockedAt))
+		.map((pkg) => ({
+			id: pkg.id,
+			name: pkg.name,
+			kodyId: pkg.kodyId,
+		}))
+}
+
+async function collectPendingEmailChange(env: Env, userId: number) {
+	try {
+		const row = await env.APP_DB.prepare(
+			`SELECT new_email
+			 FROM pending_email_changes
+			 WHERE user_id = ?
+			   AND expires_at > CURRENT_TIMESTAMP
+			 ORDER BY expires_at DESC
+			 LIMIT 1`,
+		)
+			.bind(userId)
+			.first<{ new_email: string }>()
+		const email = row?.new_email?.trim()
+		return email ? email : null
+	} catch {
+		return null
+	}
+}
+
+async function collectErrorRate(env: Env, userId: string, now: Date) {
+	try {
+		const month = utcMonthKey(now)
+		const row = await env.APP_DB.prepare(
+			`SELECT SUM(event_count) AS event_count, SUM(error_count) AS error_count
+			 FROM usage_rollups
+			 WHERE user_id = ? AND month = ?`,
+		)
+			.bind(userId, month)
+			.first<{ event_count: number | null; error_count: number | null }>()
+		return {
+			errorCount: Number(row?.error_count ?? 0),
+			eventCount: Number(row?.event_count ?? 0),
+		}
+	} catch {
+		return null
+	}
+}
+
+async function collectEntitlementCaps(
+	env: Env,
+	user: DeriveWaitingUser,
+	now: Date,
+) {
+	try {
+		const plan = await getUserPlan(env.APP_DB, {
+			userId: user.stableUserId,
+			email: user.email,
+		})
+		const snapshot = await readEntitlementUsageSnapshot({
+			db: env.APP_DB,
+			env,
+			usageUserId: user.stableUserId,
+			plan,
+			now,
+		})
+		return snapshot.resources
+			.filter(
+				(row) =>
+					row.percentOfLimit != null &&
+					row.percentOfLimit >= 1 &&
+					row.limit > 0,
+			)
+			.map((row) => ({
+				resource: row.resource,
+				label: row.label,
+			}))
+	} catch {
+		return []
+	}
+}

--- a/packages/worker/src/mcp/waiting/derive-waiting.ts
+++ b/packages/worker/src/mcp/waiting/derive-waiting.ts
@@ -12,6 +12,7 @@ import { getUserPlan } from '#worker/entitlements/service.ts'
 import { isSavedPackageLocked } from '#worker/package-registry/package-publish-lock.ts'
 import {
 	buildWaitingItems,
+	isUnexpiredEpochMs,
 	isWaitingMcpServerState,
 	type WaitingItem,
 	type WaitingMcpServerSignal,
@@ -71,7 +72,7 @@ export async function collectWaitingSignals(input: {
 		userHasMcpOAuthGrants(env, user.stableUserId),
 		collectMcpServerSignals(env, user.stableUserId),
 		collectLockedPackageSignals(env, user.stableUserId),
-		collectPendingEmailChange(env, user.userId),
+		collectPendingEmailChange(env, user.userId, now),
 		collectErrorRate(env, user.stableUserId, now),
 		collectEntitlementCaps(env, user, now),
 	])
@@ -122,12 +123,16 @@ async function collectMcpServerSignals(
 	const enabled = settings.filter((server) => server.enabled)
 	if (enabled.length === 0) return []
 
-	const snapshot = await getCachedMcpClientHubSnapshot({
-		env,
-		userId,
-	}).catch((): McpClientHubSnapshot => ({
-		servers: [],
-	}))
+	let snapshot: McpClientHubSnapshot
+	try {
+		snapshot = await getCachedMcpClientHubSnapshot({
+			env,
+			userId,
+		})
+	} catch {
+		// A hub blip must not invent reconnect cards for every enabled server.
+		return []
+	}
 	const byId = new Map(
 		snapshot.servers.map((server) => [server.serverId, server]),
 	)
@@ -135,13 +140,12 @@ async function collectMcpServerSignals(
 	const items: Array<WaitingMcpServerSignal> = []
 	for (const server of enabled) {
 		const live = byId.get(server.id)
-		const state = live?.state ?? 'disconnected'
-		if (!isWaitingMcpServerState(state)) continue
+		if (!live || !isWaitingMcpServerState(live.state)) continue
 		items.push({
 			id: server.id,
 			name: server.name,
-			state,
-			error: live?.error ?? null,
+			state: live.state,
+			error: live.error ?? null,
 		})
 	}
 	return items
@@ -160,19 +164,21 @@ async function collectLockedPackageSignals(env: Env, userId: string) {
 		}))
 }
 
-async function collectPendingEmailChange(env: Env, userId: number) {
+async function collectPendingEmailChange(env: Env, userId: number, now: Date) {
 	try {
 		const row = await env.APP_DB.prepare(
-			`SELECT new_email
+			`SELECT new_email, expires_at
 			 FROM pending_email_changes
 			 WHERE user_id = ?
-			   AND expires_at > CURRENT_TIMESTAMP
 			 ORDER BY expires_at DESC
 			 LIMIT 1`,
 		)
 			.bind(userId)
-			.first<{ new_email: string }>()
-		const email = row?.new_email?.trim()
+			.first<{ new_email: string; expires_at: number }>()
+		if (!row || !isUnexpiredEpochMs(Number(row.expires_at), now)) {
+			return null
+		}
+		const email = row.new_email?.trim()
 		return email ? email : null
 	} catch {
 		return null

--- a/packages/worker/universal/document-head.ts
+++ b/packages/worker/universal/document-head.ts
@@ -136,6 +136,7 @@ const routeDocumentHeads = {
 	[routePattern(routes.accountBilling)]: titleOnly('Billing'),
 	[routePattern(routes.accountBillingSuccess)]: titleOnly("You're in"),
 	[routePattern(routes.accountUsage)]: titleOnly('Usage'),
+	[routePattern(routes.accountWaiting)]: titleOnly('Waiting'),
 	[routePattern(routes.accountIntegrations)]: titleOnly('Integrations'),
 	[routePattern(routes.accountOauthAppDetail)]: titleOnly('Integrations'),
 	[routePattern(routes.accountIntegrationsApprove)]: titleOnly('Integrations'),

--- a/packages/worker/universal/loader-data.ts
+++ b/packages/worker/universal/loader-data.ts
@@ -27,6 +27,7 @@ import { type HighlightedCode } from '#universal/highlighted-code.ts'
 import { type WalkthroughHostPick } from '#universal/walkthrough-hosts.ts'
 import { type OnboardingAgentChooserPick } from '#universal/onboarding-mcp-clients.ts'
 import { type EmailVerificationDelivery } from '#universal/email-verification-delivery.ts'
+import { type WaitingItem } from '#universal/waiting.ts'
 import {
 	type AccountActivityStatusFilter,
 	type AccountActivitySurfaceFilter,
@@ -1742,6 +1743,7 @@ export type AppLoaderData = {
 	accountBilling?: AccountBillingLoaderData
 	accountBillingSuccess?: AccountBillingSuccessLoaderData
 	accountUsage?: AccountUsageLoaderData
+	accountWaiting?: AccountWaitingLoaderData
 	discord?: DiscordPageLoaderData
 	codeRuns?: CodeRunsLoaderData
 	walkthroughHosts?: WalkthroughHostPick
@@ -1796,4 +1798,9 @@ export type AccountUsageLoaderData = {
 	today: string
 	entitlementConsumption: Array<AccountUsageEntitlementConsumption>
 	warnings: Array<AccountUsageEntitlementConsumption>
+}
+
+export type AccountWaitingLoaderData = {
+	ok: true
+	items: Array<WaitingItem>
 }

--- a/packages/worker/universal/routes.ts
+++ b/packages/worker/universal/routes.ts
@@ -65,6 +65,8 @@ export const routes = route({
 	accountActivity: '/account/activity',
 	accountActivityDetail: '/account/activity/:runId',
 	accountActivityApi: '/account/activity.json',
+	accountWaiting: '/account/waiting',
+	accountWaitingApi: '/account/waiting.json',
 	accountMemories: '/account/memories',
 	accountMemoryDetail: '/account/memories/:memoryId',
 	// Sibling of `/account/memories.json` so `:memoryId` cannot claim the

--- a/packages/worker/universal/waiting.node.test.ts
+++ b/packages/worker/universal/waiting.node.test.ts
@@ -1,0 +1,118 @@
+import { expect, test } from 'vitest'
+import {
+	buildWaitingItems,
+	isElevatedUserErrorRate,
+	isWaitingMcpServerState,
+	type WaitingSignals,
+} from './waiting.ts'
+
+const emptySignals: WaitingSignals = {
+	emailVerified: true,
+	onboardingDismissed: true,
+	onboardingRemaining: [],
+	mcpServers: [],
+	lockedPackages: [],
+	pendingEmailChange: null,
+	errorRate: null,
+	entitlementCaps: [],
+}
+
+test('waiting items are a current-state you-queue and skip noise', () => {
+	expect(isWaitingMcpServerState('authenticating')).toBe(true)
+	expect(isWaitingMcpServerState('failed')).toBe(true)
+	expect(isWaitingMcpServerState('disconnected')).toBe(true)
+	expect(isWaitingMcpServerState('ready')).toBe(false)
+	expect(isWaitingMcpServerState('connecting')).toBe(false)
+
+	expect(isElevatedUserErrorRate({ errorCount: 10, eventCount: 10 })).toBe(true)
+	expect(isElevatedUserErrorRate({ errorCount: 5, eventCount: 20 })).toBe(true)
+	expect(isElevatedUserErrorRate({ errorCount: 4, eventCount: 10 })).toBe(false)
+	expect(isElevatedUserErrorRate({ errorCount: 5, eventCount: 40 })).toBe(false)
+
+	expect(buildWaitingItems(emptySignals)).toEqual([])
+
+	const items = buildWaitingItems({
+		emailVerified: false,
+		onboardingDismissed: false,
+		onboardingRemaining: ['verify-email', 'connect-agent'],
+		mcpServers: [
+			{
+				id: 'srv-auth',
+				name: 'Notion',
+				state: 'authenticating',
+				error: null,
+			},
+			{
+				id: 'srv-down',
+				name: 'Linear',
+				state: 'disconnected',
+				error: null,
+			},
+			{
+				id: 'srv-ready',
+				name: 'Ready',
+				state: 'ready',
+				error: null,
+			},
+		],
+		lockedPackages: [
+			{ id: 'pkg-1', name: 'gmail-drafts', kodyId: 'gmail-drafts' },
+		],
+		pendingEmailChange: 'new@example.com',
+		errorRate: { errorCount: 12, eventCount: 20 },
+		entitlementCaps: [{ resource: 'saved_packages', label: 'Saved packages' }],
+	})
+
+	expect(items.map((item) => item.id)).toEqual([
+		'verify-email',
+		'mcp-server:srv-auth',
+		'publish-lock:pkg-1',
+		'email-change',
+		'mcp-server:srv-down',
+		'entitlement:saved_packages',
+		'error-rate',
+		'onboarding:connect-agent',
+	])
+	expect(items.every((item) => item.who === 'you')).toBe(true)
+	expect(items.find((item) => item.id === 'onboarding:verify-email')).toBe(
+		undefined,
+	)
+	expect(items.find((item) => item.id === 'mcp-server:srv-ready')).toBe(
+		undefined,
+	)
+
+	const notion = items.find((item) => item.id === 'mcp-server:srv-auth')
+	expect(notion).toMatchObject({
+		title: 'Notion needs authorization',
+		doLabel: 'Complete authorization',
+		href: '/account/mcp-servers/srv-auth',
+		severity: 'block',
+	})
+
+	const failed = buildWaitingItems({
+		...emptySignals,
+		mcpServers: [
+			{
+				id: 'srv-fail',
+				name: 'GitHub',
+				state: 'failed',
+				error: 'Token exchange failed.',
+			},
+		],
+	})
+	expect(failed[0]).toMatchObject({
+		id: 'mcp-server:srv-fail',
+		title: 'GitHub failed to connect',
+		why: 'Token exchange failed.',
+		doLabel: 'Reconnect',
+		href: '/account/mcp-servers/srv-fail',
+		severity: 'degraded',
+	})
+
+	const emptyAfterDismiss = buildWaitingItems({
+		...emptySignals,
+		onboardingDismissed: true,
+		onboardingRemaining: ['connect-agent'],
+	})
+	expect(emptyAfterDismiss).toEqual([])
+})

--- a/packages/worker/universal/waiting.node.test.ts
+++ b/packages/worker/universal/waiting.node.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from 'vitest'
 import {
 	buildWaitingItems,
 	isElevatedUserErrorRate,
+	isUnexpiredEpochMs,
 	isWaitingMcpServerState,
 	type WaitingSignals,
 } from './waiting.ts'
@@ -28,6 +29,11 @@ test('waiting items are a current-state you-queue and skip noise', () => {
 	expect(isElevatedUserErrorRate({ errorCount: 5, eventCount: 20 })).toBe(true)
 	expect(isElevatedUserErrorRate({ errorCount: 4, eventCount: 10 })).toBe(false)
 	expect(isElevatedUserErrorRate({ errorCount: 5, eventCount: 40 })).toBe(false)
+
+	const now = new Date('2026-08-31T00:00:00.000Z')
+	expect(isUnexpiredEpochMs(now.getTime() + 1, now)).toBe(true)
+	expect(isUnexpiredEpochMs(now.getTime(), now)).toBe(false)
+	expect(isUnexpiredEpochMs(Number.NaN, now)).toBe(false)
 
 	expect(buildWaitingItems(emptySignals)).toEqual([])
 

--- a/packages/worker/universal/waiting.ts
+++ b/packages/worker/universal/waiting.ts
@@ -102,6 +102,11 @@ export function isWaitingMcpServerState(state: string) {
 	return mcpHumanStates.has(state)
 }
 
+/** `pending_email_changes.expires_at` is a millisecond epoch, not a datetime. */
+export function isUnexpiredEpochMs(expiresAt: number, now: Date) {
+	return Number.isFinite(expiresAt) && expiresAt > now.getTime()
+}
+
 export function buildWaitingItems(signals: WaitingSignals): Array<WaitingItem> {
 	const items: Array<WaitingItem> = []
 
@@ -127,10 +132,10 @@ export function buildWaitingItems(signals: WaitingSignals): Array<WaitingItem> {
 		items.push({
 			id: `publish-lock:${pkg.id}`,
 			kind: 'publish-lock',
-			title: `Promote a publish for ${pkg.name}`,
-			why: 'This package is locked. Agents can push drafts, but published code does not move until you promote a commit.',
+			title: `${pkg.name} is locked`,
+			why: 'Agents can push drafts, but published code does not move until you promote a commit or unlock it.',
 			who: 'you',
-			doLabel: 'Review publish',
+			doLabel: 'Review lock',
 			href: routes.accountPackageApprovePublish.href({
 				packageId: pkg.id,
 			}),

--- a/packages/worker/universal/waiting.ts
+++ b/packages/worker/universal/waiting.ts
@@ -1,0 +1,254 @@
+import {
+	onboardingChecklistItemHref,
+	onboardingChecklistItemLabels,
+	type OnboardingChecklistItemId,
+} from './onboarding-process.ts'
+import { routes } from './routes.ts'
+
+export const waitingItemKinds = [
+	'verify-email',
+	'mcp-server',
+	'publish-lock',
+	'email-change',
+	'entitlement',
+	'error-rate',
+	'onboarding',
+] as const
+
+export type WaitingItemKind = (typeof waitingItemKinds)[number]
+
+export const waitingSeverities = ['block', 'degraded', 'setup'] as const
+
+export type WaitingSeverity = (typeof waitingSeverities)[number]
+
+/**
+ * A current-state item the signed-in human can clear. Not a notification:
+ * it disappears when the underlying gate clears. `who` is always `you` —
+ * vendor outages and operator work do not belong here.
+ */
+export type WaitingItem = {
+	id: string
+	kind: WaitingItemKind
+	title: string
+	why: string
+	who: 'you'
+	doLabel: string
+	href: string
+	severity: WaitingSeverity
+}
+
+export const userErrorRateMinErrors = 5
+export const userErrorRateMinPercent = 0.2
+export const userErrorRateAbsoluteErrors = 10
+
+export function isElevatedUserErrorRate(input: {
+	errorCount: number
+	eventCount: number
+}) {
+	if (input.errorCount >= userErrorRateAbsoluteErrors) return true
+	if (input.errorCount < userErrorRateMinErrors) return false
+	if (input.eventCount <= 0) return false
+	return input.errorCount / input.eventCount >= userErrorRateMinPercent
+}
+
+export type WaitingMcpServerSignal = {
+	id: string
+	name: string
+	state: string
+	error: string | null
+}
+
+export type WaitingLockedPackageSignal = {
+	id: string
+	name: string
+	kodyId: string
+}
+
+export type WaitingEntitlementCapSignal = {
+	resource: string
+	label: string
+}
+
+export type WaitingSignals = {
+	emailVerified: boolean
+	onboardingDismissed: boolean
+	onboardingRemaining: Array<OnboardingChecklistItemId>
+	mcpServers: Array<WaitingMcpServerSignal>
+	lockedPackages: Array<WaitingLockedPackageSignal>
+	pendingEmailChange: string | null
+	errorRate: { errorCount: number; eventCount: number } | null
+	entitlementCaps: Array<WaitingEntitlementCapSignal>
+}
+
+const severityRank: Record<WaitingSeverity, number> = {
+	block: 0,
+	degraded: 1,
+	setup: 2,
+}
+
+const kindRank: Record<WaitingItemKind, number> = {
+	'verify-email': 0,
+	'mcp-server': 1,
+	'publish-lock': 2,
+	'email-change': 3,
+	entitlement: 4,
+	'error-rate': 5,
+	onboarding: 6,
+}
+
+const mcpHumanStates = new Set(['authenticating', 'failed', 'disconnected'])
+
+export function isWaitingMcpServerState(state: string) {
+	return mcpHumanStates.has(state)
+}
+
+export function buildWaitingItems(signals: WaitingSignals): Array<WaitingItem> {
+	const items: Array<WaitingItem> = []
+
+	if (!signals.emailVerified) {
+		items.push({
+			id: 'verify-email',
+			kind: 'verify-email',
+			title: 'Verify your email',
+			why: 'Unverified accounts can sign in, but outbound email stays off until you confirm the address.',
+			who: 'you',
+			doLabel: 'Verify email',
+			href: routes.pendingVerification.href(),
+			severity: 'block',
+		})
+	}
+
+	for (const server of signals.mcpServers) {
+		const item = buildMcpServerWaitingItem(server)
+		if (item) items.push(item)
+	}
+
+	for (const pkg of signals.lockedPackages) {
+		items.push({
+			id: `publish-lock:${pkg.id}`,
+			kind: 'publish-lock',
+			title: `Promote a publish for ${pkg.name}`,
+			why: 'This package is locked. Agents can push drafts, but published code does not move until you promote a commit.',
+			who: 'you',
+			doLabel: 'Review publish',
+			href: routes.accountPackageApprovePublish.href({
+				packageId: pkg.id,
+			}),
+			severity: 'block',
+		})
+	}
+
+	if (signals.pendingEmailChange) {
+		items.push({
+			id: 'email-change',
+			kind: 'email-change',
+			title: 'Confirm your new email',
+			why: `A change to ${signals.pendingEmailChange} is waiting on the verification link sent to that address.`,
+			who: 'you',
+			doLabel: 'Open account email settings',
+			href: routes.account.href(),
+			severity: 'block',
+		})
+	}
+
+	for (const cap of signals.entitlementCaps) {
+		items.push({
+			id: `entitlement:${cap.resource}`,
+			kind: 'entitlement',
+			title: `${cap.label} is at your plan cap`,
+			why: 'New work that needs this resource will fail until you free some up or upgrade.',
+			who: 'you',
+			doLabel: 'Review usage',
+			href: routes.accountUsage.href(),
+			severity: 'degraded',
+		})
+	}
+
+	if (
+		signals.errorRate &&
+		isElevatedUserErrorRate({
+			errorCount: signals.errorRate.errorCount,
+			eventCount: signals.errorRate.eventCount,
+		})
+	) {
+		items.push({
+			id: 'error-rate',
+			kind: 'error-rate',
+			title: 'Error rate is elevated',
+			why: `${signals.errorRate.errorCount} of ${signals.errorRate.eventCount} recent runs failed. Activity is where you triage those errors.`,
+			who: 'you',
+			doLabel: 'Open Activity',
+			href: routes.accountActivity.href(),
+			severity: 'degraded',
+		})
+	}
+
+	if (!signals.onboardingDismissed) {
+		for (const step of signals.onboardingRemaining) {
+			if (step === 'verify-email' && !signals.emailVerified) continue
+			items.push({
+				id: `onboarding:${step}`,
+				kind: 'onboarding',
+				title: onboardingChecklistItemLabels[step],
+				why: 'Setup is still unfinished. Finish this step, or dismiss the checklist on Get started.',
+				who: 'you',
+				doLabel: 'Continue setup',
+				href: onboardingChecklistItemHref(step, routes.onboarding.href()),
+				severity: 'setup',
+			})
+		}
+	}
+
+	return items.sort((left, right) => {
+		const severity = severityRank[left.severity] - severityRank[right.severity]
+		if (severity !== 0) return severity
+		const kind = kindRank[left.kind] - kindRank[right.kind]
+		if (kind !== 0) return kind
+		return left.title.localeCompare(right.title)
+	})
+}
+
+function buildMcpServerWaitingItem(
+	server: WaitingMcpServerSignal,
+): WaitingItem | null {
+	const href = routes.accountMcpServerDetail.href({ serverId: server.id })
+	if (server.state === 'authenticating') {
+		return {
+			id: `mcp-server:${server.id}`,
+			kind: 'mcp-server',
+			title: `${server.name} needs authorization`,
+			why: 'This MCP server is waiting for you to finish OAuth. Until you do, its tools stay off.',
+			who: 'you',
+			doLabel: 'Complete authorization',
+			href,
+			severity: 'block',
+		}
+	}
+	if (server.state === 'failed') {
+		return {
+			id: `mcp-server:${server.id}`,
+			kind: 'mcp-server',
+			title: `${server.name} failed to connect`,
+			why:
+				server.error?.trim() ||
+				'Kody could not reach this MCP server. Reconnect it so your agent can use its tools.',
+			who: 'you',
+			doLabel: 'Reconnect',
+			href,
+			severity: 'degraded',
+		}
+	}
+	if (server.state === 'disconnected') {
+		return {
+			id: `mcp-server:${server.id}`,
+			kind: 'mcp-server',
+			title: `${server.name} is disconnected`,
+			why: 'The connection dropped. Reconnect it so your agent can use its tools.',
+			who: 'you',
+			doLabel: 'Reconnect',
+			href,
+			severity: 'degraded',
+		}
+	}
+	return null
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Give each signed-in human a current-state queue of things only they can clear, and make that the default landing from the header avatar.

## Why

A generic notifications page would invent read/unread and history. Waiting is derived from live account state: items appear when a gate needs the human and disappear when it clears. The sibling connection-health recommendation (`bc-c87bf195-b542-4f15-aad7-13fdb7a00bab`) said the same actor model — index `who === you` snapshots and deep-link. This PR folds MCP reconnect/auth into Waiting and does **not** persist OAuth last-failure or add `/account/connection-health`.

## Summary

- New `/account/waiting` page and `/account/waiting.json`
- Derived items: verify email, MCP authenticating/failed/disconnected (only from a live hub snapshot), locked-package review, pending email change (epoch expiry), plan caps, one elevated-error-rate card pointing at Activity, unfinished onboarding
- Header username replaced by a vertically aligned avatar that opens Waiting
- Account nav includes Waiting
- MCP `waiting_summary` on the existing `account` domain
- Usage docs: `docs/use/waiting.md`

## Testing

- Node-unit: waiting derive, `waiting_summary`, session `avatarUrl`, SSR header + waiting loader
- `git push` ran `test:node` (2275) and `test:workers` (312)
- Playwright smoke updated for the Waiting avatar accessible name; local `e2e/smoke.spec.ts` passed
- Bugbot: fixed email-change expiry (epoch ms) and invented MCP reconnects; locked-package copy no longer implies a pending draft (no Artifacts HEAD lookup)
- Preview-manual-test as `user-me` with Waiting data follows after the preview deploy

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `2bfaefc6` · **Head:** `9e2a6d96`

**Classification:** extends — new account route and `waiting_summary` contract; session JSON gains `avatarUrl`. No new primitive.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | extends — `/account/waiting`, header avatar default, session `avatarUrl` |
| `mcp-server` | surfaces | extends — self-scoped `waiting_summary` on the existing `account` domain |
| `account-export` | assistant | composes — account domain registry only; export unchanged |

### Change flow

Header and MCP both derive the same self-scoped queue; items deep-link to existing pages.

```mermaid
sequenceDiagram
	actor You
	participant appUi as app-ui
	participant mcpServer as mcp-server
	participant mcpClientServers as mcp-client-servers
	participant d1AppDb as d1-app-db
	You->>appUi: click header avatar
	appUi->>appUi: GET /account/waiting
	appUi->>mcpServer: deriveWaitingItems for the session user
	mcpServer->>mcpClientServers: list enabled servers plus hub snapshot
	mcpServer->>d1AppDb: read verify-email, locks, pending email, rollups, caps
	Note over mcpServer: who is always you; vendor or operator work stays out
	mcpServer-->>appUi: current-state items
	appUi-->>You: cards that vanish when the gate clears
	You->>mcpServer: waiting_summary
	mcpServer-->>You: same items plus waiting_url
```

### Before / after

| Surface | Before | After |
| --- | --- | --- |
| Header signed-in control | Username text → `/account` | Avatar → `/account/waiting` |
| Waiting | None | Derived queue, empty copy “Nothing is waiting on you.” |
| MCP account domain | export + `usage_get` | plus `waiting_summary` |

### Invariants

Per-user isolation: derive and `waiting_summary` take the signed-in user only. No notification table. Session-scoped secret approvals stay off this page.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-069fff06-f78b-4468-a369-594913c78944?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-069fff06-f78b-4468-a369-594913c78944&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Waiting page at `/account/waiting` showing current account items that require user action.
  * Added Waiting navigation and user avatar display in the account header.
  * Added actionable items for verification, onboarding, MCP connections, package publishing, email changes, limits, and elevated errors.
  * Added the `waiting_summary` capability with waiting counts, links, and item details.
* **Documentation**
  * Added comprehensive Waiting guidance and clarified its distinction from Activity and Email.
* **Bug Fixes**
  * Improved account avatar handling and related navigation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->