### PR TITLE
Make ship-PR Discord summaries glanceable with a real title and difficulty

### DIFF
--- a/.agents/skills/ship-pr/SKILL.md
+++ b/.agents/skills/ship-pr/SKILL.md
@@ -77,6 +77,17 @@ and includes the model you pass. Never invent a dollar figure or a model id.
 When the work deployed user-visible pages, put clickable links to those pages in
 `extras` (see below) so Kent can open the live result from Discord.
 
+**title (required):** a human headline of the change itself so the Discord post
+is glanceable. Example: `OpenAPI spec fetches now count against daily quota`. Do
+**not** use `ship owner/repo#N` as the title — repo, PR, and agent already
+appear as links.
+
+**difficulty (required):** `'Easy' | 'Medium' | 'Hard'`. Always pass it.
+Distinct from Risk (merge authority). Easy = small/localized; Medium = several
+files or real behavior change; Hard = architecture, migrations, subtle
+correctness, or wide blast radius. The Discord export renders this on its own
+line.
+
 **agentId (required):**
 
 - In a Cursor Cloud Agent VM, read it from the metadata socket:
@@ -113,7 +124,8 @@ export default async function main() {
 	return sendShippedPr({
 		agentId: 'bc-…', // metadata socket or launch URL
 		model: 'grok-4.6', // metadata turn/model (deterministic)
-		title: 'ship owner/repo#123',
+		title: 'OpenAPI spec fetches now count against daily quota',
+		difficulty: 'Medium',
 		status: 'Shipped', // or Parked / Blocked
 		summary: 'One-screen what shipped and why it is done.',
 		prUrl: 'https://github.com/owner/repo/pull/123',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Make `#github` ship-PR posts glanceable: a human headline of the change, plus a self-evaluated difficulty that is distinct from merge risk.

## Why

Live posts look like `**Shipped** · ship kentcdodds/kody#1920` because the skill example used `title: 'ship owner/repo#123'`. Repo, PR, and agent already appear as links, so that slug is not a title.

## Summary

- `title` must be a human headline of the change (example: `OpenAPI spec fetches now count against daily quota`).
- Explicitly forbid `ship owner/repo#N` as the title.
- Always pass `difficulty: 'Easy' | 'Medium' | 'Hard'` into `kody:@kentcdodds/discord/send-shipped-pr`.
- Difficulty is distinct from Risk (merge authority): Easy = small/localized; Medium = several files or real behavior change; Hard = architecture, migrations, subtle correctness, or wide blast radius.
- Merge policy, Bugbot, preview-manual-test, model socket rules, and deployed-pages extras are unchanged.

## Testing

- `oxfmt` on `.agents/skills/ship-pr/SKILL.md`
- `npm run format:check`
- `npm run docs:check-temporal` (skills are in that scan)

## System changes

Skill-only. No runtime primitives. See the recap below.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `13263ff` · **Head:** `84672a5`

**Classification:** composes — no primitives added or changed; this PR only updates agent instructions in `.agents/skills/ship-pr/SKILL.md`.

### Primitives touched

_None. Unmatched path: `.agents/skills/ship-pr/SKILL.md`._

### Change flow

Ship-PR Discord summaries take a human title and a required difficulty; the export still posts repo, PR, and agent as links.

```mermaid
sequenceDiagram
	actor Agent
	participant skill as ship-pr skill
	participant export as send-shipped-pr
	Agent->>skill: Done → Discord
	skill->>export: title (human headline, never ship owner/repo#N)
	skill->>export: difficulty Easy or Medium or Hard
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b9e21e02-d02f-4985-848b-9c05b0ee0e59?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b9e21e02-d02f-4985-848b-9c05b0ee0e59&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

