### PR TITLE
Fix Turnstile reset crash after Remix re-renders wipe the widget

### DIFF
--- a/packages/worker/client/public-form-protection.node.test.ts
+++ b/packages/worker/client/public-form-protection.node.test.ts
@@ -1,0 +1,117 @@
+import { expect, test, vi } from 'vitest'
+import {
+	renderTurnstileWidgets,
+	resetTurnstileWidgets,
+	turnstileWidgetClassName,
+} from '#client/public-form-protection.ts'
+
+type FakeContainer = HTMLElement & {
+	dataset: DOMStringMap & { turnstileRendered?: string }
+	childElementCount: number
+	querySelector: ReturnType<typeof vi.fn>
+}
+
+function createContainer(options: {
+	rendered?: boolean
+	childElementCount?: number
+}): FakeContainer {
+	const dataset: DOMStringMap & { turnstileRendered?: string } = {}
+	if (options.rendered) dataset.turnstileRendered = 'true'
+	return {
+		dataset,
+		childElementCount: options.childElementCount ?? 0,
+		querySelector: vi.fn(),
+	} as unknown as FakeContainer
+}
+
+test('resetTurnstileWidgets clears orphaned hosts instead of throwing', () => {
+	const orphan = createContainer({ rendered: true, childElementCount: 0 })
+	const live = createContainer({ rendered: true, childElementCount: 2 })
+	const zombie = createContainer({ rendered: true, childElementCount: 1 })
+	const reset = vi.fn((container: FakeContainer) => {
+		if (container === zombie) {
+			throw new Error(
+				'[Cloudflare Turnstile] Nothing to reset found for provided container.',
+			)
+		}
+	})
+	const remove = vi.fn()
+
+	vi.stubGlobal('document', {
+		querySelectorAll: vi.fn((selector: string) => {
+			expect(selector).toBe(
+				`.${turnstileWidgetClassName}[data-turnstile-rendered]`,
+			)
+			return [orphan, live, zombie]
+		}),
+	})
+	vi.stubGlobal('window', { turnstile: { reset, remove } })
+
+	expect(() => resetTurnstileWidgets()).not.toThrow()
+	expect(orphan.dataset.turnstileRendered).toBeUndefined()
+	expect(zombie.dataset.turnstileRendered).toBeUndefined()
+	expect(remove).toHaveBeenCalledWith(orphan)
+	expect(remove).toHaveBeenCalledWith(zombie)
+	expect(reset).toHaveBeenCalledWith(live)
+	expect(reset).toHaveBeenCalledWith(zombie)
+	expect(live.dataset.turnstileRendered).toBe('true')
+
+	vi.unstubAllGlobals()
+})
+
+test('renderTurnstileWidgets remounts hosts whose children were wiped by a re-render', async () => {
+	const orphan = createContainer({ rendered: true, childElementCount: 0 })
+	const live = createContainer({ rendered: true, childElementCount: 1 })
+	const fresh = createContainer({ rendered: false, childElementCount: 0 })
+	const render = vi.fn((container: FakeContainer) => {
+		container.childElementCount = 1
+		return 'widget-id'
+	})
+	const remove = vi.fn()
+
+	vi.stubGlobal('document', {
+		querySelectorAll: vi.fn((selector: string) => {
+			expect(selector).toBe(`.${turnstileWidgetClassName}`)
+			return [orphan, live, fresh]
+		}),
+	})
+	vi.stubGlobal('window', { turnstile: { render, remove } })
+
+	await renderTurnstileWidgets('site-key')
+
+	expect(remove).toHaveBeenCalledWith(orphan)
+	expect(render).toHaveBeenCalledTimes(2)
+	expect(render).toHaveBeenCalledWith(orphan, {
+		sitekey: 'site-key',
+		'response-field-name': 'turnstileToken',
+	})
+	expect(render).toHaveBeenCalledWith(fresh, {
+		sitekey: 'site-key',
+		'response-field-name': 'turnstileToken',
+	})
+	expect(render).not.toHaveBeenCalledWith(live, expect.anything())
+	expect(orphan.dataset.turnstileRendered).toBe('true')
+	expect(fresh.dataset.turnstileRendered).toBe('true')
+	expect(live.dataset.turnstileRendered).toBe('true')
+
+	vi.unstubAllGlobals()
+})
+
+test('renderTurnstileWidgets does not leave the rendered marker when render throws', async () => {
+	const container = createContainer({ rendered: false, childElementCount: 0 })
+	const render = vi.fn(() => {
+		throw new Error('render failed')
+	})
+
+	vi.stubGlobal('document', {
+		querySelectorAll: vi.fn(() => [container]),
+	})
+	vi.stubGlobal('window', { turnstile: { render } })
+
+	await expect(renderTurnstileWidgets('site-key')).rejects.toThrow(
+		'render failed',
+	)
+	expect(container.dataset.turnstileRendered).toBeUndefined()
+
+	vi.unstubAllGlobals()
+})

--- a/packages/worker/client/public-form-protection.ts
+++ b/packages/worker/client/public-form-protection.ts
@@ -7,7 +7,8 @@ type TurnstileApi = {
 		container: HTMLElement,
 		options: { sitekey: string; 'response-field-name': string },
 	): string
-	reset?(container: HTMLElement): void
+	reset?(container: HTMLElement | string): void
+	remove?(container: HTMLElement | string): void
 }
 
 let turnstileScriptPromise: Promise<TurnstileApi> | null = null
@@ -49,17 +50,52 @@ function loadTurnstileScript() {
 	return turnstileScriptPromise
 }
 
+/**
+ * Remix re-renders can wipe Turnstile's injected children from a declarative
+ * empty host while leaving our `data-turnstile-rendered` marker. Without this
+ * check we skip re-render and later `reset()` throws "Nothing to reset found…".
+ * A live widget always leaves at least one child (iframe / response input).
+ */
+function isTurnstileWidgetAlive(container: HTMLElement) {
+	return container.childElementCount > 0
+}
+
+function clearTurnstileRenderedMarker(container: HTMLElement) {
+	delete container.dataset.turnstileRendered
+}
+
+function abandonOrphanedTurnstileWidget(
+	api: TurnstileApi,
+	container: HTMLElement,
+) {
+	clearTurnstileRenderedMarker(container)
+	try {
+		api.remove?.(container)
+	} catch {
+		// Widget is already gone from Turnstile's registry; ignore.
+	}
+}
+
 export async function renderTurnstileWidgets(siteKey: string | null) {
 	if (!siteKey || typeof document === 'undefined') return
 	const api = await loadTurnstileScript()
 	for (const container of document.querySelectorAll<HTMLElement>(
-		`.${turnstileWidgetClassName}:not([data-turnstile-rendered])`,
+		`.${turnstileWidgetClassName}`,
 	)) {
-		container.dataset.turnstileRendered = 'true'
-		api.render(container, {
-			sitekey: siteKey,
-			'response-field-name': turnstileResponseFieldName,
-		})
+		if (container.dataset.turnstileRendered === 'true') {
+			if (isTurnstileWidgetAlive(container)) continue
+			abandonOrphanedTurnstileWidget(api, container)
+		}
+		try {
+			api.render(container, {
+				sitekey: siteKey,
+				'response-field-name': turnstileResponseFieldName,
+			})
+			container.dataset.turnstileRendered = 'true'
+		} catch (error) {
+			clearTurnstileRenderedMarker(container)
+			throw error
+		}
 	}
 }
 
@@ -68,6 +104,10 @@ export async function renderTurnstileWidgets(siteKey: string | null) {
  * consumes one on every verify, so a form that stays mounted after a failed
  * submit would resubmit a spent token and be rejected for the wrong reason.
  * Call this on any path that leaves the form up for another try.
+ *
+ * Never throws: a dead/orphaned widget (DOM wiped by a re-render) must not
+ * surface as an unhandled rejection from submit handlers. Clear the marker so
+ * the next `renderTurnstileWidgets` call can remount.
  */
 export function resetTurnstileWidgets() {
 	if (typeof document === 'undefined') return
@@ -76,7 +116,15 @@ export function resetTurnstileWidgets() {
 	for (const container of document.querySelectorAll<HTMLElement>(
 		`.${turnstileWidgetClassName}[data-turnstile-rendered]`,
 	)) {
-		api.reset(container)
+		if (!isTurnstileWidgetAlive(container)) {
+			abandonOrphanedTurnstileWidget(api, container)
+			continue
+		}
+		try {
+			api.reset(container)
+		} catch {
+			abandonOrphanedTurnstileWidget(api, container)
+		}
 	}
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop production Sentry noise and broken waitlist retries when Cloudflare Turnstile's host is emptied by a Remix re-render ([issue 7703462825](https://sentry.io/organizations/kent-c-dodds-tech-llc/issues/7703462825/)).

## Why

On `kody.codes/` waitlist submit (Chrome Mobile iOS), Remix `handle.update()` clears children from the declarative empty `.kody-turnstile` host while leaving `data-turnstile-rendered`. Turnstile then logs "Cannot find Widget…", submits go out without a live challenge (400), and `resetTurnstileWidgets()` throws — becoming an unhandled rejection from the submit `catch` path.

## Summary

- Detect orphaned Turnstile hosts (marked rendered but `childElementCount === 0`) and remount them in `renderTurnstileWidgets`
- Make `resetTurnstileWidgets` never throw: abandon orphans / failed resets so submit handlers stay clean
- Only set the rendered marker after a successful `render`
- Unit tests for orphan reset, remount, and failed-render marker cleanup

Siblings `KODY-6B` / `KODY-3W` do not share this root cause.

## Testing

- `vitest run --project node-unit packages/worker/client/public-form-protection.node.test.ts` (3 passed)
- Pre-push gate: `test:node` + `test:workers` (passed)

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `13263ff5` · **Head:** `e8b6ab08`

**Classification:** composes — isolated client helper bugfix inside the existing browser app surface; no new primitives or contracts.

### Primitives touched

| Primitive | Group    | Impact |
| --------- | -------- | ------ |
| `app-ui`  | surfaces | composes — recover orphaned Turnstile hosts; never throw from reset |

### Change flow

Waitlist (and other public forms) remount wiped Turnstile widgets and swallow dead resets.

```mermaid
sequenceDiagram
	actor visitor as Visitor
	participant appUi as app-ui
	participant turnstile as Cloudflare Turnstile
	visitor->>appUi: submit waitlist / public form
	appUi->>appUi: handle.update may wipe .kody-turnstile children
	appUi->>appUi: renderTurnstileWidgets remounts orphaned hosts
	alt failed submit needs fresh token
		appUi->>turnstile: resetTurnstileWidgets (catch + abandon if dead)
		Note over appUi: no unhandled TurnstileError rejection
	end
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d0ad63a-3efa-467c-bf4c-e12f26a66264?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d0ad63a-3efa-467c-bf4c-e12f26a66264&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

