### PR TITLE
Add package delete for people and agents

### DIFF
--- a/docs/contributing/packages-and-manifests.md
+++ b/docs/contributing/packages-and-manifests.md
@@ -632,7 +632,9 @@ package URLs, and owner-matching hosted package URLs without mixing in semantic
 capability results. Hidden exact query matches require the opt-in; known-id
 entity lookup by UUID or `kody.id`, **`package_list`**, **`package_get`**, and
 context-scope package retrievers are unaffected. Hiding is not deletion,
-community delisting, or entitlement exclusion.
+community delisting, or entitlement exclusion. Deletion is `package_delete`
+(agents, `confirm_name` matching the package name) or **Delete package** on the
+package page (type the package name).
 
 `package_update` is reserved for mutable package settings (`hidden`, and
 `locked: true`; unlocking is website-only). Manifest-derived metadata and

--- a/docs/guides/package-lifecycle.md
+++ b/docs/guides/package-lifecycle.md
@@ -208,6 +208,27 @@ Keep the schedule disabled when representative testing is inconclusive,
 credentials or host approval are missing, the result is unexpected, or the live
 mutation has not been explicitly confirmed by the user.
 
+## Delete a package
+
+`package_delete` permanently removes a saved package the signed-in user owns. Do
+not call it because a package is unused, failing, or over quota unless the owner
+explicitly asked to delete that package.
+
+1. Load the package with `package_get` or `package_list`.
+2. Show the owner the package name and that delete removes jobs, storage,
+   secrets, tokens, the public listing if one exists, and Artifacts repos.
+   Existing forks keep their copies. This cannot be undone.
+3. Wait for the owner to type the package name.
+4. Call `package_delete` with `package_id` and `confirm_name` matching that name
+   exactly. The capability refuses and names the expected value when
+   `confirm_name` is missing or wrong.
+
+People can delete from the package page: `/account/packages` → open the package
+→ **Delete package**, then type the package name in the modal.
+
+Hiding (`package_update` `changes.hidden`) and making a package private are not
+deletion.
+
 ## Evolve the durable behavior
 
 For later changes, inspect the current repo, preserve the package's intent,

--- a/docs/use/community-packages.md
+++ b/docs/use/community-packages.md
@@ -32,6 +32,9 @@ filled-in cards).
 - New packages are always created **private**.
 - Making a package **private** unlists it: public URLs 404; existing forks keep
   their copies. Type the package slug to confirm (`confirm_name` for agents).
+- Deleting a package (`package_delete` or **Delete package** on the package
+  page) also unlists it. Type the package name to confirm. Existing forks keep
+  their copies.
 - Hidden and locked stay separate from visibility.
 
 ### Icon
@@ -175,6 +178,8 @@ Use the MCP `community` domain:
   `package_update` with `changes.visibility: "public"`)
 - `community_unpublish` — make a package private / unlist it (prefer
   `package_update` with `changes.visibility: "private"` and `confirm_name`)
+- `package_delete` — permanently delete a saved package (type the package name;
+  `confirm_name` must match)
 - `community_search` — search active listings (`sort: "newest"` for last
   published first; optional `category` to browse one listing category)
 - `community_get` — fetch one listing's metadata and aggregates (including star

--- a/docs/use/packages.md
+++ b/docs/use/packages.md
@@ -501,6 +501,8 @@ Use:
 - `package_save` to create or replace a saved package from a complete UTF-8 text
   file set when no local git client is available
 - `package_get` and `package_list` to inspect saved packages
+- `package_delete` to permanently remove a saved package the owner typed the
+  name of (`confirm_name` must match the package name)
 - `package_update` to change mutable package settings such as hidden search
   discovery state or to lock publishes (`changes.locked: true`). Unlocking is
   website-only.
@@ -537,6 +539,29 @@ Hiding is a discovery preference, not deletion. The package stays saved,
 executable, and editable. Hiding is separate from **visibility**
 (`package_update` `changes.visibility`, which lists or unlists the catalog) and
 from entitlement or access grants.
+
+## Delete a package
+
+Deleting a package removes it from the account. It is permanent.
+
+Use:
+
+- The **Delete package** control on the package page (`/@username/{kodyId}`, or
+  open a row from `/account/packages`). A modal asks you to type the package
+  name to confirm.
+- **`package_delete`** with a saved **`package_id`**. Show the owner the package
+  name and what will be destroyed, wait for them to type that name, then pass
+  **`confirm_name`** matching the package name exactly (`package.json` `name`,
+  for example `@you/my-package`). The capability refuses the delete and names
+  the expected value when `confirm_name` is missing or wrong.
+
+Delete removes the package from discovery, stops its jobs, clears package
+storage and package-scoped secrets, drops invocation tokens, and unlists a
+public catalog entry if one exists. Artifact repos are cleaned up best-effort.
+Existing forks keep their copies.
+
+Hiding and making a package private are not deletion. Use those when the package
+should stay saved.
 
 **`package_list`** and **`package_get`** return a **`hidden`** boolean on each
 package summary. Ranked **search** excludes hidden packages unless the caller

--- a/packages/worker/client/routes/account-package-delete-dialog.tsx
+++ b/packages/worker/client/routes/account-package-delete-dialog.tsx
@@ -1,0 +1,258 @@
+import { css, ref, type Handle } from 'remix/ui'
+import { on } from '#client/event-mixin.ts'
+import { navigate } from '#client/client-router.tsx'
+import { routes } from '#universal/routes.ts'
+import {
+	colors,
+	radius,
+	shadows,
+	spacing,
+	typography,
+} from '#universal/styles/tokens.ts'
+import {
+	getAccentCalloutCss,
+	getDangerPillCss,
+	getGhostButtonCss,
+} from '#universal/styles/style-primitives.ts'
+import {
+	accountActionsCss,
+	accountFieldCss,
+	accountFieldLabelCss,
+	accountFieldNoteCss,
+	accountInputCss,
+} from './account-management-components.tsx'
+import { type AccountPackageDetail } from '#universal/loader-data.ts'
+
+type DeleteStatus = 'idle' | 'deleting'
+
+export function AccountPackageDeleteDialog(
+	handle: Handle<{ packageDetail: AccountPackageDetail }>,
+) {
+	let dialogOpen = false
+	let confirmation = ''
+	let status: DeleteStatus = 'idle'
+	let error: string | null = null
+	let dialogNode: HTMLDialogElement | null = null
+
+	function closeDialog() {
+		dialogOpen = false
+		confirmation = ''
+		error = null
+		status = 'idle'
+		dialogNode?.close()
+		handle.update()
+	}
+
+	function openDialog() {
+		dialogOpen = true
+		confirmation = ''
+		error = null
+		status = 'idle'
+		handle.update()
+		dialogNode?.showModal()
+	}
+
+	function updateConfirmation(event: Event) {
+		if (!(event.currentTarget instanceof HTMLInputElement)) return
+		confirmation = event.currentTarget.value
+		handle.update()
+	}
+
+	async function handleDeleteSubmit(event: SubmitEvent) {
+		event.preventDefault()
+		const packageDetail = handle.props.packageDetail
+		status = 'deleting'
+		error = null
+		handle.update()
+
+		try {
+			const response = await fetch('/account/packages.json', {
+				method: 'POST',
+				headers: {
+					Accept: 'application/json',
+					'Content-Type': 'application/json',
+				},
+				credentials: 'include',
+				body: JSON.stringify({
+					action: 'delete',
+					packageId: packageDetail.id,
+					confirmName: confirmation.trim(),
+				}),
+			})
+			const payload = (await response.json().catch(() => null)) as {
+				ok?: boolean
+				deleted?: boolean
+				error?: string
+			} | null
+			if (response.status === 401 && !payload?.error) {
+				window.location.assign('/login')
+				return
+			}
+			if (!response.ok || !payload?.ok || !payload.deleted) {
+				throw new Error(payload?.error || 'Unable to delete this package.')
+			}
+			closeDialog()
+			navigate(routes.accountPackages.href())
+		} catch (caught) {
+			error =
+				caught instanceof Error
+					? caught.message
+					: 'Unable to delete this package.'
+			status = 'idle'
+			handle.update()
+		}
+	}
+
+	return () => {
+		const packageName = handle.props.packageDetail.name
+		const isDeleting = status === 'deleting'
+		const canSubmit = confirmation.trim() === packageName && !isDeleting
+
+		return (
+			<>
+				<div
+					mix={css({ display: 'grid', gap: spacing.sm })}
+					data-testid="package-delete-controls"
+				>
+					<p mix={css(accountFieldNoteCss)}>
+						Permanently delete this package, its jobs, storage, secrets, tokens,
+						and public listing if it has one. Existing forks keep their copies.
+						This cannot be undone.
+					</p>
+					<div mix={css(accountActionsCss)}>
+						<button
+							type="button"
+							data-testid="package-delete"
+							mix={[
+								css(getDangerPillCss({ size: 'sm' })),
+								on('click', openDialog),
+							]}
+						>
+							Delete package
+						</button>
+					</div>
+				</div>
+				<dialog
+					aria-labelledby="delete-package-title"
+					data-testid="package-delete-dialog"
+					mix={[
+						css(deleteDialogCss),
+						ref((node, signal) => {
+							if (!(node instanceof HTMLDialogElement)) return
+							dialogNode = node
+							if (dialogOpen && !node.open) node.showModal()
+							signal.addEventListener('abort', () => {
+								dialogNode = null
+							})
+						}),
+						on('cancel', (event) => {
+							event.preventDefault()
+							closeDialog()
+						}),
+						on('click', (event) => {
+							if (event.target === event.currentTarget) closeDialog()
+						}),
+					]}
+				>
+					<form
+						method="dialog"
+						mix={[css(deleteDialogFormCss), on('submit', handleDeleteSubmit)]}
+					>
+						<h3 id="delete-package-title" mix={css(deleteDialogTitleCss)}>
+							Delete {packageName}?
+						</h3>
+						<div
+							mix={css(
+								getAccentCalloutCss({
+									accentColor: colors.error,
+								}),
+							)}
+						>
+							<p mix={css({ margin: 0 })}>
+								This cannot be undone. Type <strong>{packageName}</strong> to
+								confirm.
+							</p>
+						</div>
+						<label mix={css(accountFieldCss)}>
+							<span mix={css(accountFieldLabelCss)}>
+								Type the name of the package
+							</span>
+							<input
+								type="text"
+								name="confirmation"
+								data-testid="package-delete-confirmation"
+								data-field-ring
+								autocomplete="off"
+								spellcheck={false}
+								required
+								placeholder={packageName}
+								value={confirmation}
+								mix={[css(accountInputCss), on('input', updateConfirmation)]}
+							/>
+						</label>
+						{error ? (
+							<p
+								role="alert"
+								mix={css({
+									margin: 0,
+									color: colors.error,
+									fontSize: typography.fontSize.sm,
+								})}
+							>
+								{error}
+							</p>
+						) : null}
+						<div mix={css(accountActionsCss)}>
+							<button
+								type="button"
+								disabled={isDeleting}
+								mix={[
+									css(getGhostButtonCss({ size: 'sm' })),
+									on('click', closeDialog),
+								]}
+							>
+								Cancel
+							</button>
+							<button
+								type="submit"
+								disabled={!canSubmit}
+								data-testid="package-delete-confirm"
+								mix={css(getDangerPillCss({ size: 'sm' }))}
+							>
+								{isDeleting ? 'Deleting…' : 'Delete package'}
+							</button>
+						</div>
+					</form>
+				</dialog>
+			</>
+		)
+	}
+}
+
+const deleteDialogCss = {
+	width: 'min(32rem, calc(100vw - 2rem))',
+	maxWidth: '32rem',
+	padding: 0,
+	border: `1px solid ${colors.border}`,
+	borderRadius: radius.lg,
+	boxShadow: shadows.md,
+	backgroundColor: colors.surface,
+	color: colors.text,
+	'&::backdrop': {
+		backgroundColor: 'oklch(0 0 0 / 0.45)',
+	},
+}
+
+const deleteDialogFormCss = {
+	display: 'grid',
+	gap: spacing.md,
+	padding: spacing.lg,
+}
+
+const deleteDialogTitleCss = {
+	margin: 0,
+	fontSize: '1.2rem',
+	fontWeight: 720,
+	letterSpacing: '-0.014em',
+	lineHeight: 1.2,
+}

--- a/packages/worker/client/routes/account-package-owner-details.tsx
+++ b/packages/worker/client/routes/account-package-owner-details.tsx
@@ -22,6 +22,7 @@ import {
 	TimestampValue,
 } from './account-management-components.tsx'
 import { RecordChips, recordBodyCss } from './record-table.tsx'
+import { AccountPackageDeleteDialog } from './account-package-delete-dialog.tsx'
 import { AccountPackageTokens } from './account-package-tokens.tsx'
 import { getAccountPackageFilesHref } from '#universal/package-files.ts'
 import {
@@ -358,6 +359,7 @@ export function AccountPackageOwnerDetails(
 					invocationUrlOrigin={invocationUrlOrigin}
 					onPackagesPayload={onPackagesPayload}
 				/>
+				<AccountPackageDeleteDialog packageDetail={packageDetail} />
 				{packageDetail.searchText ? (
 					<details mix={css(accountDisclosureCss)}>
 						<summary>Search text</summary>

--- a/packages/worker/client/routes/account-packages.tsx
+++ b/packages/worker/client/routes/account-packages.tsx
@@ -320,7 +320,7 @@ export function AccountPackagesRoute(handle: Handle) {
 			<AccountManagementShell>
 				<AccountPageHeader
 					title="Packages"
-					description="Browse your saved packages. Open a row to see details on the package page."
+					description="Browse your saved packages. Open a row to see details, change visibility, or delete the package."
 					currentHref={currentHref}
 				/>
 				{status === 'loading' && lastLoadedDataKey === '' ? (

--- a/packages/worker/src/app/account-package-delete.node.test.ts
+++ b/packages/worker/src/app/account-package-delete.node.test.ts
@@ -1,0 +1,131 @@
+import { expect, test, vi } from 'vitest'
+
+const mockModule = vi.hoisted(() => ({
+	getSavedPackageById: vi.fn(),
+	deleteSavedPackageProjection: vi.fn(),
+}))
+
+vi.mock('#worker/package-registry/repo.ts', () => ({
+	getSavedPackageById: (...args: Array<unknown>) =>
+		mockModule.getSavedPackageById(...args),
+}))
+
+vi.mock('#worker/package-registry/service.ts', () => ({
+	deleteSavedPackageProjection: (...args: Array<unknown>) =>
+		mockModule.deleteSavedPackageProjection(...args),
+}))
+
+const { handleAccountPackageDeleteAction } =
+	await import('./account-package-delete.ts')
+
+function createUser() {
+	return {
+		sessionUserId: '42',
+		userId: 42,
+		username: 'user',
+		email: 'user@example.com',
+		displayName: 'user',
+		artifactOwnerIds: [],
+		mcpUser: {
+			userId: 'stable-user-1',
+			email: 'user@example.com',
+			username: 'user',
+			displayName: 'user',
+		},
+	}
+}
+
+function createSavedPackage() {
+	return {
+		id: 'pkg-1',
+		userId: 'stable-user-1',
+		name: '@user/notes',
+		kodyId: 'notes',
+		description: 'Personal notes',
+		tags: ['notes'],
+		searchText: null,
+		sourceId: 'source-1',
+		hasApp: false,
+		hidden: false,
+		isPrivate: false,
+		lockedAt: null,
+		createdAt: '2026-01-01T00:00:00.000Z',
+		updatedAt: '2026-07-14T00:00:00.000Z',
+	}
+}
+
+test('account package delete requires the typed package name then removes the package', async () => {
+	const env = { APP_DB: {} } as Env
+	const user = createUser()
+	expect(
+		await handleAccountPackageDeleteAction({
+			env,
+			user,
+			body: { action: 'set-visibility' },
+		}),
+	).toBeNull()
+
+	const missingId = await handleAccountPackageDeleteAction({
+		env,
+		user,
+		body: { action: 'delete' },
+	})
+	expect(missingId?.status).toBe(400)
+	await expect(missingId?.json()).resolves.toEqual({
+		ok: false,
+		error: 'Package id is required.',
+	})
+
+	mockModule.getSavedPackageById.mockResolvedValueOnce(null)
+	const missingPackage = await handleAccountPackageDeleteAction({
+		env,
+		user,
+		body: { action: 'delete', packageId: 'pkg-1', confirmName: '@user/notes' },
+	})
+	expect(missingPackage?.status).toBe(404)
+	await expect(missingPackage?.json()).resolves.toEqual({
+		ok: false,
+		error: 'Package not found.',
+	})
+	expect(mockModule.deleteSavedPackageProjection).not.toHaveBeenCalled()
+
+	mockModule.getSavedPackageById.mockResolvedValue(createSavedPackage())
+	const wrongName = await handleAccountPackageDeleteAction({
+		env,
+		user,
+		body: { action: 'delete', packageId: 'pkg-1', confirmName: 'notes' },
+	})
+	expect(wrongName?.status).toBe(400)
+	await expect(wrongName?.json()).resolves.toEqual({
+		ok: false,
+		error: 'Type the package name "@user/notes" to delete it.',
+	})
+	expect(mockModule.deleteSavedPackageProjection).not.toHaveBeenCalled()
+
+	mockModule.deleteSavedPackageProjection.mockResolvedValue(undefined)
+	const deleted = await handleAccountPackageDeleteAction({
+		env,
+		user,
+		body: {
+			action: 'delete',
+			packageId: 'pkg-1',
+			confirmName: '@user/notes',
+		},
+	})
+	expect(deleted?.status).toBe(200)
+	await expect(deleted?.json()).resolves.toEqual({
+		ok: true,
+		deleted: true,
+		packageId: 'pkg-1',
+	})
+	expect(mockModule.getSavedPackageById).toHaveBeenCalledWith(env.APP_DB, {
+		userId: 'stable-user-1',
+		packageId: 'pkg-1',
+	})
+	expect(mockModule.deleteSavedPackageProjection).toHaveBeenCalledWith({
+		env,
+		userId: 'stable-user-1',
+		actorUserId: 'stable-user-1',
+		packageId: 'pkg-1',
+	})
+})

--- a/packages/worker/src/app/account-package-delete.ts
+++ b/packages/worker/src/app/account-package-delete.ts
@@ -1,0 +1,63 @@
+import { jsonResponse } from '#worker/json-response.ts'
+import { CommunityActionError } from '#worker/community/errors.ts'
+import { getSavedPackageById } from '#worker/package-registry/repo.ts'
+import { deleteSavedPackageProjection } from '#worker/package-registry/service.ts'
+import { type readAuthenticatedAppUser } from '#app/authenticated-user.ts'
+import { readTrimmedStringOrEmpty } from '#app/request-body.ts'
+
+type AuthenticatedUser = NonNullable<
+	Awaited<ReturnType<typeof readAuthenticatedAppUser>>
+>
+
+export async function handleAccountPackageDeleteAction(input: {
+	env: Env
+	user: AuthenticatedUser
+	body: object
+}): Promise<Response | null> {
+	const action = readTrimmedStringOrEmpty(input.body, 'action')
+	if (action !== 'delete') return null
+
+	const packageId = readTrimmedStringOrEmpty(input.body, 'packageId')
+	const confirmName = readTrimmedStringOrEmpty(input.body, 'confirmName')
+	if (!packageId) {
+		return jsonResponse({ ok: false, error: 'Package id is required.' }, 400)
+	}
+
+	const userId = input.user.mcpUser.userId
+	const savedPackage = await getSavedPackageById(input.env.APP_DB, {
+		userId,
+		packageId,
+	})
+	if (!savedPackage) {
+		return jsonResponse({ ok: false, error: 'Package not found.' }, 404)
+	}
+	if (confirmName !== savedPackage.name) {
+		return jsonResponse(
+			{
+				ok: false,
+				error: `Type the package name "${savedPackage.name}" to delete it.`,
+			},
+			400,
+		)
+	}
+
+	try {
+		await deleteSavedPackageProjection({
+			env: input.env,
+			userId,
+			actorUserId: userId,
+			packageId,
+		})
+	} catch (error) {
+		if (error instanceof CommunityActionError) {
+			return jsonResponse({ ok: false, error: error.message }, 400)
+		}
+		throw error
+	}
+
+	return jsonResponse({
+		ok: true,
+		deleted: true,
+		packageId,
+	})
+}

--- a/packages/worker/src/app/handlers/account-packages.ts
+++ b/packages/worker/src/app/handlers/account-packages.ts
@@ -1,5 +1,6 @@
 import { jsonResponse } from '#worker/json-response.ts'
 import { type Action } from 'remix/router'
+import { handleAccountPackageDeleteAction } from '#app/account-package-delete.ts'
 import { handleAccountPackagePublishLockAction } from '#app/account-package-publish-lock.ts'
 import { handleAccountPackageTokenAction } from '#app/account-package-tokens.ts'
 import { handleAccountPackageVisibilityAction } from '#app/account-package-visibility.ts'
@@ -122,6 +123,13 @@ export function createAccountPackagesApiHandler(env: Env) {
 				body,
 			})
 			if (visibilityResponse) return visibilityResponse
+
+			const deleteResponse = await handleAccountPackageDeleteAction({
+				env,
+				user,
+				body,
+			})
+			if (deleteResponse) return deleteResponse
 
 			const action = readTrimmedStringOrEmpty(body, 'action')
 			if (action === 'absorb-listing') {

--- a/packages/worker/src/entitlements/resource-visibility.ts
+++ b/packages/worker/src/entitlements/resource-visibility.ts
@@ -45,7 +45,8 @@ export const entitlementResourceVisibility: Record<
 		group: 'counts',
 		kind: 'counter',
 		whatCounts: 'Saved packages published to your account.',
-		howToReduce: 'Remove packages you no longer use.',
+		howToReduce:
+			'Delete unused packages from the package page or with package_delete.',
 	},
 	scheduled_jobs: {
 		group: 'counts',

--- a/packages/worker/src/mcp/capabilities/packages/delete-package.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/packages/delete-package.node.test.ts
@@ -1,0 +1,129 @@
+import { expect, test, vi } from 'vitest'
+import { McpCallerError } from '#mcp/caller-error.ts'
+
+const mockModule = vi.hoisted(() => ({
+	getSavedPackageById: vi.fn(),
+	deleteSavedPackageProjection: vi.fn(),
+	resolvePackageOwnerContext: vi.fn(),
+}))
+
+vi.mock('#worker/package-registry/repo.ts', () => ({
+	getSavedPackageById: (...args: Array<unknown>) =>
+		mockModule.getSavedPackageById(...args),
+}))
+
+vi.mock('#worker/package-registry/service.ts', () => ({
+	deleteSavedPackageProjection: (...args: Array<unknown>) =>
+		mockModule.deleteSavedPackageProjection(...args),
+}))
+
+vi.mock('#worker/package-registry/package-owner.ts', () => ({
+	packageScopeInputDescription: 'package scope',
+	resolvePackageOwnerContext: (...args: Array<unknown>) =>
+		mockModule.resolvePackageOwnerContext(...args),
+}))
+
+const { deletePackageCapability } = await import('./delete-package.ts')
+
+function createCtx(userId = 'user-1') {
+	mockModule.resolvePackageOwnerContext.mockResolvedValue({
+		ownerUserId: userId,
+		ownerScope: 'user',
+		ownerEmail: 'user@example.com',
+		actorUserId: userId,
+		delegated: false,
+	})
+	return {
+		env: { APP_DB: {} } as Env,
+		callerContext: {
+			baseUrl: 'https://heykody.dev',
+			user: {
+				userId,
+				email: 'user@example.com',
+				displayName: 'User',
+			},
+			storageContext: null,
+			repoContext: null,
+		},
+	}
+}
+
+function createSavedPackage() {
+	return {
+		id: 'pkg-1',
+		userId: 'user-1',
+		kodyId: 'notes',
+		name: '@user/notes',
+		description: 'Personal notes',
+		tags: ['notes'],
+		searchText: null,
+		hasApp: false,
+		hidden: false,
+		isPrivate: false,
+		lockedAt: null,
+		sourceId: 'source-1',
+		createdAt: '2026-01-01T00:00:00.000Z',
+		updatedAt: '2026-07-14T00:00:00.000Z',
+	}
+}
+
+test('package_delete requires the owner-typed package name before deleting', async () => {
+	mockModule.getSavedPackageById.mockResolvedValue(createSavedPackage())
+	mockModule.deleteSavedPackageProjection.mockResolvedValue(undefined)
+	const expectedError =
+		'This permanently deletes "@user/notes". It removes the package from the account, stops its jobs, clears package storage and package-scoped secrets, drops invocation tokens, unlists a public catalog entry if one exists, and best-effort deletes Artifacts repos. Existing forks keep their copies. This cannot be undone. Hiding or making the package private is not deletion. Do not call this unless the owner explicitly asked to delete this package and typed its name. Then pass confirm_name: "@user/notes" (the package name).'
+
+	const missingName = await deletePackageCapability
+		.handler({ package_id: 'pkg-1' }, createCtx())
+		.catch((error: unknown) => error)
+	expect(missingName).toBeInstanceOf(McpCallerError)
+	expect(missingName).toMatchObject({ message: expectedError })
+	expect(mockModule.deleteSavedPackageProjection).not.toHaveBeenCalled()
+
+	const wrongName = await deletePackageCapability
+		.handler({ package_id: 'pkg-1', confirm_name: 'notes' }, createCtx())
+		.catch((error: unknown) => error)
+	expect(wrongName).toBeInstanceOf(McpCallerError)
+	expect(wrongName).toMatchObject({ message: expectedError })
+	expect(mockModule.deleteSavedPackageProjection).not.toHaveBeenCalled()
+
+	await expect(
+		deletePackageCapability.handler(
+			{ package_id: 'pkg-1', confirm_name: '@user/notes' },
+			createCtx(),
+		),
+	).resolves.toEqual({
+		ok: true,
+		package_id: 'pkg-1',
+	})
+	expect(mockModule.deleteSavedPackageProjection).toHaveBeenCalledWith({
+		env: expect.objectContaining({ APP_DB: {} }),
+		userId: 'user-1',
+		actorUserId: 'user-1',
+		packageId: 'pkg-1',
+	})
+
+	mockModule.getSavedPackageById.mockResolvedValueOnce(null)
+	await expect(
+		deletePackageCapability.handler(
+			{ package_id: 'missing', confirm_name: '@user/notes' },
+			createCtx(),
+		),
+	).rejects.toThrow(/not found/i)
+	expect(mockModule.deleteSavedPackageProjection).toHaveBeenCalledTimes(1)
+
+	await expect(
+		deletePackageCapability.handler(
+			{ package_id: 'pkg-1', confirm_name: '@user/notes' },
+			{
+				env: { APP_DB: {} } as Env,
+				callerContext: {
+					baseUrl: 'https://heykody.dev',
+					user: null,
+					storageContext: null,
+					repoContext: null,
+				},
+			},
+		),
+	).rejects.toThrow(/authenticated/i)
+})

--- a/packages/worker/src/mcp/capabilities/packages/delete-package.ts
+++ b/packages/worker/src/mcp/capabilities/packages/delete-package.ts
@@ -10,13 +10,33 @@ import {
 import { getSavedPackageById } from '#worker/package-registry/repo.ts'
 import { deleteSavedPackageProjection } from '#worker/package-registry/service.ts'
 
+function createPackageDeleteConfirmNameError(packageName: string) {
+	return [
+		`This permanently deletes "${packageName}".`,
+		'It removes the package from the account, stops its jobs, clears package storage and package-scoped secrets, drops invocation tokens, unlists a public catalog entry if one exists, and best-effort deletes Artifacts repos.',
+		'Existing forks keep their copies.',
+		'This cannot be undone.',
+		'Hiding or making the package private is not deletion.',
+		`Do not call this unless the owner explicitly asked to delete this package and typed its name.`,
+		`Then pass confirm_name: "${packageName}" (the package name).`,
+	].join(' ')
+}
+
 export const deletePackageCapability = defineDomainCapability(
 	capabilityDomainNames.packages,
 	{
 		name: 'package_delete',
 		description:
-			'Delete a saved package projection for the signed-in user. This removes the saved package from discovery and attempts to clean up associated Artifacts repos (best-effort).',
-		keywords: ['package', 'delete', 'remove'],
+			'Permanently delete a saved package the signed-in user owns. This cannot be undone. It removes the package from the account and from /community if it was public, stops its jobs, clears package storage and package-scoped secrets, drops invocation tokens, and best-effort deletes Artifacts repos. Existing forks keep their copies. Hiding (`package_update` hidden) or making a package private is not deletion. Do not call this because a package is unused, failing, or over quota unless the owner explicitly asked to delete that specific package. Load it with package_get or package_list, show the owner the package name and what will be destroyed, wait for them to type that name, then pass package_id and confirm_name matching the package name exactly.',
+		keywords: [
+			'package',
+			'delete',
+			'remove',
+			'destroy',
+			'uninstall',
+			'quota',
+			'limit',
+		],
 		readOnly: false,
 		idempotent: false,
 		destructive: true,
@@ -27,6 +47,13 @@ export const deletePackageCapability = defineDomainCapability(
 				.min(1)
 				.optional()
 				.describe(packageScopeInputDescription),
+			confirm_name: z
+				.string()
+				.min(1)
+				.optional()
+				.describe(
+					'Required. Must equal the package name (`package.json` name, for example @you/my-package). Ask the owner to type that name first. The capability refuses the delete and names the expected value when this is missing or wrong.',
+				),
 		}),
 		outputSchema: z.object({
 			ok: z.literal(true),
@@ -46,9 +73,15 @@ export const deletePackageCapability = defineDomainCapability(
 			if (!existing) {
 				throw new McpCallerError('Saved package not found for this user.')
 			}
+			if (args.confirm_name?.trim() !== existing.name) {
+				throw new McpCallerError(
+					createPackageDeleteConfirmNameError(existing.name),
+				)
+			}
 			await deleteSavedPackageProjection({
 				env: ctx.env,
 				userId: owner.ownerUserId,
+				actorUserId: owner.actorUserId,
 				packageId: args.package_id,
 			})
 			return {

--- a/packages/worker/src/mcp/package-app-storage.mcp-e2e.test.ts
+++ b/packages/worker/src/mcp/package-app-storage.mcp-e2e.test.ts
@@ -209,10 +209,13 @@ export default async function main(input) {
 				arguments: {
 					code: `import { kody } from 'kody:runtime'
 export default async function main(input) {
-	return await kody.package_delete({ package_id: input.packageId })
+	return await kody.package_delete({
+		package_id: input.packageId,
+		confirm_name: input.confirmName,
+	})
 }
 `,
-					params: { packageId },
+					params: { packageId, confirmName: `@${username}/${kodyId}` },
 				},
 			})
 		}

--- a/packages/worker/src/package-registry/service.node.test.ts
+++ b/packages/worker/src/package-registry/service.node.test.ts
@@ -39,6 +39,8 @@ const mockModule = vi.hoisted(() => ({
 	deleteAllAppScopedValues: vi.fn(),
 	clearStorage: vi.fn(async () => ({ ok: true as const })),
 	storageRunnerRpc: vi.fn(),
+	getCommunityListingByOwnerAndPackage: vi.fn(),
+	unpublishCommunityListing: vi.fn(),
 }))
 
 vi.mock('./manifest.ts', () => ({
@@ -151,6 +153,16 @@ vi.mock('#worker/repo/entity-sources.ts', () => ({
 		mockModule.deleteEntitySource(...args),
 }))
 
+vi.mock('#worker/community/repo.ts', () => ({
+	getCommunityListingByOwnerAndPackage: (...args: Array<unknown>) =>
+		mockModule.getCommunityListingByOwnerAndPackage(...args),
+}))
+
+vi.mock('#worker/community/service.ts', () => ({
+	unpublishCommunityListing: (...args: Array<unknown>) =>
+		mockModule.unpublishCommunityListing(...args),
+}))
+
 const {
 	deleteSavedPackageProjection,
 	filterPackageOwnedStorageIdsFromInventory,
@@ -219,6 +231,10 @@ function setupDefaultMocks() {
 	mockModule.clearStorage.mockResolvedValue({ ok: true as const })
 	mockModule.listJobRowsByUserId.mockResolvedValue([])
 	mockModule.loadPackageSourceFromFiles.mockReset()
+	mockModule.getCommunityListingByOwnerAndPackage.mockReset()
+	mockModule.getCommunityListingByOwnerAndPackage.mockResolvedValue(null)
+	mockModule.unpublishCommunityListing.mockReset()
+	mockModule.unpublishCommunityListing.mockResolvedValue(undefined)
 }
 
 test('refreshSavedPackageProjection defers search-index upsert and retriever cache via waitUntil', async () => {
@@ -638,6 +654,58 @@ test('deleteSavedPackageProjection resyncs the job manager after removing packag
 	expect(
 		mockModule.syncJobManagerAlarm.mock.invocationCallOrder[0],
 	).toBeGreaterThan(mockModule.deleteSavedPackage.mock.invocationCallOrder[0])
+	expect(mockModule.unpublishCommunityListing).not.toHaveBeenCalled()
+})
+
+test('deleteSavedPackageProjection unpublishes an active listing before removing the package', async () => {
+	setupDefaultMocks()
+	const env = createEnv()
+	mockModule.getSavedPackageById.mockResolvedValue({
+		id: 'package-1',
+		kodyId: 'shade-automation',
+		sourceId: 'source-1',
+	})
+	mockModule.getCommunityListingByOwnerAndPackage.mockResolvedValue({
+		id: 'listing-1',
+		status: 'active',
+	})
+
+	await deleteSavedPackageProjection({
+		env,
+		userId: 'user-1',
+		actorUserId: 'actor-1',
+		packageId: 'package-1',
+	})
+
+	expect(mockModule.getCommunityListingByOwnerAndPackage).toHaveBeenCalledWith(
+		env.APP_DB,
+		{
+			ownerUserId: 'user-1',
+			packageId: 'package-1',
+		},
+	)
+	expect(mockModule.unpublishCommunityListing).toHaveBeenCalledWith({
+		env,
+		userId: 'user-1',
+		actorUserId: 'actor-1',
+		listingId: 'listing-1',
+	})
+	expect(
+		mockModule.unpublishCommunityListing.mock.invocationCallOrder[0],
+	).toBeLessThan(mockModule.deleteSavedPackage.mock.invocationCallOrder[0])
+
+	mockModule.unpublishCommunityListing.mockClear()
+	mockModule.getCommunityListingByOwnerAndPackage.mockResolvedValue({
+		id: 'listing-2',
+		status: 'delisted',
+	})
+	await deleteSavedPackageProjection({
+		env,
+		userId: 'user-1',
+		packageId: 'package-1',
+	})
+	expect(mockModule.unpublishCommunityListing).not.toHaveBeenCalled()
+	expect(mockModule.deleteSavedPackage).toHaveBeenCalled()
 })
 
 test('deleteSavedPackageProjection continues best-effort cleanup when dependent steps fail', async () => {

--- a/packages/worker/src/package-registry/service.ts
+++ b/packages/worker/src/package-registry/service.ts
@@ -7,6 +7,8 @@ import {
 	releasePackageKodyIdRedirect,
 	retirePackageKodyId,
 } from '#worker/community/package-url.ts'
+import { getCommunityListingByOwnerAndPackage } from '#worker/community/repo.ts'
+import { unpublishCommunityListing } from '#worker/community/service.ts'
 import { buildSavedPackageEmbedText } from './embed.ts'
 import { buildPackageSearchProjection } from './manifest.ts'
 import {
@@ -478,6 +480,7 @@ export async function deleteSavedPackageProjection(input: {
 	env: Env
 	userId: string
 	packageId: string
+	actorUserId?: string
 }) {
 	return await withAccountWriteLease({
 		db: input.env.APP_DB,
@@ -494,6 +497,21 @@ export async function deleteSavedPackageProjection(input: {
 			])
 			let packageJobsRemoved = false
 			if (savedPackage) {
+				const listing = await getCommunityListingByOwnerAndPackage(
+					input.env.APP_DB,
+					{
+						ownerUserId: input.userId,
+						packageId: input.packageId,
+					},
+				)
+				if (listing?.status === 'active') {
+					await unpublishCommunityListing({
+						env: input.env,
+						userId: input.userId,
+						actorUserId: input.actorUserId ?? input.userId,
+						listingId: listing.id,
+					})
+				}
 				await cleanupArtifactReposForPackage({
 					env: input.env,
 					userId: input.userId,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Give people a website control to delete a saved package, and make the existing agent capability impossible to miss or fire by accident.

## Why

Free accounts cap saved packages at 10. Usage copy said to remove unused packages, but `/account/packages` had no delete control, and agents often missed `package_delete`.

## Summary

- Add a **Delete package** modal on the package page that requires typing the package name
- Require `confirm_name` on `package_delete` (must match the package name). The refusal names the expected value and what delete destroys
- Unlist an active community listing as part of package cleanup
- Point usage copy and package docs at both paths

## Testing

- Node unit: `delete-package`, `account-package-delete`, projection delete, account-packages handler
- Pre-push: `test:node` (2302) and `test:workers` (313)
- CI: Node, Workers, Static, E2E, MCP, Validate green
- Bugbot: no issues
- CodeRabbit: asked to make `confirm_name` required in the Zod schema. Left optional on purpose (same as `package_update` visibility) so a missing name still looks up the package and returns the exact `confirm_name` the owner must type, instead of a generic schema error
- Preview (`https://kody-pr-1932.kody-a99.workers.dev`) as `me@kentcdodds.com`:
  - `POST /account/packages.json` delete without `packageId` → 400
  - delete unknown id → 404
  - `/account/packages` copy: “Open a row to see details, change visibility, or delete the package.”
  - `/account/usage` saved packages: “Delete unused packages from the package page or with package_delete.”
  - Seed account has no packages, so the type-the-name modal was not clicked on a live row (create is MCP-only). Happy-path delete is covered by unit tests.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `cff14796` · **Head:** `322f63cf`

**Classification:** extends — `package_delete` now requires a typed package name, and package cleanup unlists an active catalog entry.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `saved-packages` | assistant | extends — `confirm_name` gate; delete unlists an active listing |
| `app-ui` | surfaces | extends — delete modal on the package page |
| `entitlements` | auth | composes — usage copy points at the new delete paths |
| `community-listings` | assistant | composes — calls existing unpublish during package delete |

### Change flow

A person or agent confirms the package name, then Kody deletes the saved package and unlists it if it was public.

```mermaid
sequenceDiagram
	actor Owner
	participant appUi as app-ui
	participant mcpServer as mcp-server
	participant savedPackages as saved-packages
	participant communityListings as community-listings
	Owner->>appUi: type package name in Delete package modal
	appUi->>savedPackages: POST /account/packages.json action delete
	Owner->>mcpServer: package_delete package_id + confirm_name
	mcpServer->>savedPackages: confirm_name must match package name
	savedPackages->>communityListings: unpublish active listing
	savedPackages->>savedPackages: delete projection, jobs, storage, secrets, tokens
```

### Before / after

```text
Before: package_delete(package_id)
After:  package_delete(package_id, confirm_name)  # confirm_name === package name
```

```text
Before: /account/packages had no delete control
After:  package page → Delete package → type name → delete
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5b59db8c-542a-478e-865c-59164c578869?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5b59db8c-542a-478e-865c-59164c578869&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added package deletion from the package details page.
  - Deletion requires typing the exact package name for confirmation.
  - Added `package_delete` support with matching name confirmation.
  - Deletion removes packages from discovery and unpublishes active community listings.
  - Existing forks remain available.

- **Documentation**
  - Documented deletion effects, confirmation requirements, and the distinction between deletion, hiding, and private visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->