### PR TITLE
Point DR backup control plane at kody.codes

### DIFF
--- a/docs/contributing/decisions/0044-retired-brand-domains-stay-retired.md
+++ b/docs/contributing/decisions/0044-retired-brand-domains-stay-retired.md
@@ -29,6 +29,6 @@ remain so published trees that still mention the old hosts can rewrite to
 Cloudflare-level redirects to the canonical hosts; they are not product
 surfaces.
 
-Revisit-if a retired hostname must become a product origin again (new brand
+Revisit if a retired hostname must become a product origin again (new brand
 cutover, registrar constraint, or a documented traffic gate that the canonical
 host cannot serve).

--- a/docs/contributing/environment-variables.md
+++ b/docs/contributing/environment-variables.md
@@ -162,8 +162,8 @@ confirmed non-production runtimes; see `packages/worker/src/app-base-url.ts` and
   apex hostnames alongside `PACKAGE_APP_BASE_URL`. Generated runtime zone routes
   replace the Worker's whole route set, so every dual-served package-app host
   must be listed here — otherwise the next deploy detaches omitted origins and
-  deletes their DNS records. May also be set as a GitHub Actions repository
-  variable (non-empty overlay wins). Production leaves this unset.
+  deletes their DNS records. This variable may also be set as a GitHub Actions
+  repository variable (non-empty overlay wins). Production leaves this unset.
 - `PACKAGE_APP_LEGACY_REDIRECT` — exact string `true` enables path-and-query-
   preserving `308` redirects from dual-served package-app **user subdomains**
   (`{username}.<legacy-apex>` → `{username}.kody.run`) for browser GET/HEAD

--- a/docs/contributing/setup/local-development.md
+++ b/docs/contributing/setup/local-development.md
@@ -53,13 +53,13 @@ Prerequisites, install, and `npm run dev` notes. See the
   fully simulated by the local mock. Password reset and email-verification
   messages send through the same Cloudflare Email API helper. Both send from
   `kody@<SYSTEM_EMAIL_DOMAIN>` (falling back to the `APP_BASE_URL` hostname) and
-  put that same sending domain on action and asset links, so a stale
-  `APP_BASE_URL` cannot pin a retired hostname into the message. Local
-  `npm run dev` keeps those action and asset links on the request origin so they
-  stay clickable. Set `SKIP_CLOUDFLARE_MOCK=1` to skip the local Cloudflare mock
-  entirely. The main worker streams logs live; the client bundle and background
-  mock workers buffer logs and only print them if that child process exits with
-  an error.
+  put that same sending domain on action and asset links when
+  `SYSTEM_EMAIL_DOMAIN` is set, so a stale `APP_BASE_URL` cannot pin a retired
+  hostname into the message. Local `npm run dev` keeps those action and asset
+  links on the request origin so they stay clickable. Set
+  `SKIP_CLOUDFLARE_MOCK=1` to skip the local Cloudflare mock entirely. The main
+  worker streams logs live; the client bundle and background mock workers buffer
+  logs and only print them if that child process exits with an error.
 - MCP **`search`** uses a deterministic offline ranker in tests and when
   `WRANGLER_IS_LOCAL_DEV` is set (no Vectorize / Workers AI embedding calls
   required for `npm run test` or unauthenticated local runs). Production uses

--- a/packages/backup-control-plane/wrangler-config.node.test.ts
+++ b/packages/backup-control-plane/wrangler-config.node.test.ts
@@ -1,14 +1,14 @@
 import { readFileSync } from 'node:fs'
 import { expect, test } from 'vitest'
+import { parseJsonc } from '../../tools/ci/resource-utils.ts'
 
-const wranglerSource = readFileSync(
-	new URL('./wrangler.jsonc', import.meta.url),
-	'utf8',
-)
+const config = parseJsonc<{
+	vars: { PRIMARY_WORKER_ORIGIN?: string }
+}>(readFileSync(new URL('./wrangler.jsonc', import.meta.url), 'utf8'))
 
 test('PRIMARY_WORKER_ORIGIN is the canonical production origin', () => {
-	expect(wranglerSource).toMatch(
-		/"PRIMARY_WORKER_ORIGIN": "https:\/\/kody\.codes"/,
+	expect(config.vars.PRIMARY_WORKER_ORIGIN).toBe('https://kody.codes')
+	expect(JSON.stringify(config.vars)).not.toMatch(
+		/heykody\.(?:app|dev)|kodyapps\.dev/,
 	)
-	expect(wranglerSource).not.toMatch(/heykody\.(?:app|dev)|kodyapps\.dev/)
 })

--- a/packages/backup-control-plane/wrangler-config.node.test.ts
+++ b/packages/backup-control-plane/wrangler-config.node.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from 'node:fs'
+import { expect, test } from 'vitest'
+
+const wranglerSource = readFileSync(
+	new URL('./wrangler.jsonc', import.meta.url),
+	'utf8',
+)
+
+test('PRIMARY_WORKER_ORIGIN is the canonical production origin', () => {
+	expect(wranglerSource).toMatch(
+		/"PRIMARY_WORKER_ORIGIN": "https:\/\/kody\.codes"/,
+	)
+	expect(wranglerSource).not.toMatch(/heykody\.(?:app|dev)|kodyapps\.dev/)
+})

--- a/packages/backup-control-plane/wrangler.jsonc
+++ b/packages/backup-control-plane/wrangler.jsonc
@@ -57,6 +57,6 @@
 		"ACCESS_ALLOWED_EMAIL": "me@kentcdodds.com",
 		// DR (KCD) account: isolated restore drills only, never production.
 		"DRILL_ACCOUNT_ID": "a41d50ecaf0ae0f86dd1824ef6729cb2",
-		"PRIMARY_WORKER_ORIGIN": "https://heykody.dev",
+		"PRIMARY_WORKER_ORIGIN": "https://kody.codes",
 	},
 }

--- a/packages/worker/src/app/email/sender-config.ts
+++ b/packages/worker/src/app/email/sender-config.ts
@@ -27,10 +27,11 @@ function tryOrigin(value: string | URL | null | undefined) {
  * password-reset mail.
  *
  * From always follows the sending domain (`SYSTEM_EMAIL_DOMAIN`, else the
- * `APP_BASE_URL` hostname). Link hosts follow that same domain so a stale
- * `APP_BASE_URL` or dual-served host cannot pin a retired hostname into the
- * message. Local `npm run dev` keeps clickable links on the request origin
- * so signup still works against localhost.
+ * `APP_BASE_URL` hostname). When `SYSTEM_EMAIL_DOMAIN` is set, link hosts
+ * follow that same domain so a stale `APP_BASE_URL` or dual-served host
+ * cannot pin a retired hostname into the message. Local `npm run dev`
+ * keeps clickable links on the request origin so signup still works
+ * against localhost.
  */
 export function resolveTransactionalEmailConfig(input: {
 	env: TransactionalEmailEnv


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Finish leftover brand-host cleanup so disaster-recovery maintenance posts hit the live origin, not a retired host.

## Why

`#1935` removed heykody/kodyapps dual-serve from production, but `PRIMARY_WORKER_ORIGIN` on the backup control plane still pointed at `https://heykody.dev`. After that host was detached and parked on `kody-domain-redirect`, restore/PITR/`dr-export` posts would 301 away from origin (or miss it entirely).

## Summary

- Set `PRIMARY_WORKER_ORIGIN` to `https://kody.codes`
- Guard the committed Wrangler binding by parsing JSONC (`vars.PRIMARY_WORKER_ORIGIN`)
- Garden leftover `#1935` CodeRabbit nits (ADR revisit phrasing, `PACKAGE_APP_LEGACY_HOSTS` sentence, transactional-email host guarantee)

## Testing

- `packages/backup-control-plane/wrangler-config.node.test.ts`
- Pre-push node + workers suites (hooks)

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `8ee51a68` · **Head:** `91f37dcc`

**Classification:** composes — no primitives added or changed; the backup control plane already posts to `PRIMARY_WORKER_ORIGIN`, and this PR only points that var at the canonical origin. Comment/docs nits do not change runtime behavior.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `backup-control-plane` | storage | composes — Wrangler origin var only |
| `app-ui` | surfaces | composes — comment-only on transactional email config |

### Change flow

DR maintenance posts from the backup control plane go to the live app origin.

```mermaid
sequenceDiagram
	participant backupControlPlane as backup-control-plane
	participant origin as kody.codes
	backupControlPlane->>origin: POST /__maintenance/dr-restore (PRIMARY_WORKER_ORIGIN)
	Note over backupControlPlane: was https://heykody.dev
	Note over origin: now https://kody.codes
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5681f02c-e737-49a4-96e5-8f039c2be631?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5681f02c-e737-49a4-96e5-8f039c2be631&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Configuration**
  - Updated the backup control plane’s primary worker address to `https://kody.codes`.

- **Tests**
  - Added validation to confirm the new address is configured and legacy addresses are rejected.

- **Documentation**
  - Clarified how legacy host settings can be provided through repository variables.
  - Clarified email-link behavior for configured system domains and local development.
  - Improved guidance on retired brand domains.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->