### PR TITLE
Tighten execute caps and show per-user Dynamic Worker cost

### DIFF
--- a/docs/contributing/architecture/authorization.md
+++ b/docs/contributing/architecture/authorization.md
@@ -403,11 +403,13 @@ repeat pages.
 `usage_entitlement_alert` lane sweeps the top ~15 active accounts and fans
 `fleet.entitlement.crossed` only to packages whose owners hold the admin role at
 dispatch time. One event fires per 80% or 100% crossing of a plan-limit
-resource, or per first over-threshold runtime-duration month. The event contains
-the stable user id, username, resource label and counts (or runtime duration),
-and admin insights/users URLs. It omits emails, plans, secrets, package source,
-and unrelated account content. Delivery is best-effort (no Queue). Staying over
-the same threshold does not emit again.
+resource, per first over-threshold runtime-duration month, per first
+over-threshold unique Dynamic Worker cost month, or per first three-of-seven
+execute-cap train. The event contains the stable user id, username, resource
+label and counts (or runtime duration, unique-worker days, or days at the
+execute cap), and admin insights/users URLs. It omits emails, plans, secrets,
+package source, and unrelated account content. Delivery is best-effort (no
+Queue). Staying over the same threshold does not emit again.
 
 **Admins can subscribe to person-account create and delete.** Password signup,
 social-login signup, and admin-created person accounts fan `user.created`.

--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -628,7 +628,7 @@ Naming matches `RunLog` and `JobManager`: one object per untrimmed stable MCP
 column inside the DO because the object identity is the user.
 
 SQLite ownership (schema version tracked in `user_meter_meta`; current version
-**10**):
+**11**):
 
 - `daily_counters` — authoritative UTC-day counters for `email_sends_per_day`,
   `email_receives_per_day`, `execute_calls_per_day`, and
@@ -657,13 +657,17 @@ SQLite ownership (schema version tracked in `user_meter_meta`; current version
   user row. After that row is deleted, origin clears the tombstone so the
   email-derived `stable_user_id` can be reused by a later signup. Account export
   emits a sanitized `deletionState` without raw token/holder.
+- `dynamic_worker_days` — first-seen Dynamic Worker ids per UTC day
+  (`worker_id`, `day`, `created_at`; PK `(day, worker_id)`). Used only to emit
+  one `dynamic_worker_day` usage event per unique Cloudflare bill unit. Not an
+  entitlement counter and not included in `exportCounters`.
 
 Retention is self-enforced inside the DO: every read/write path
-opportunistically deletes counter and claim rows older than seven UTC days
-(`userMeterDailyCounterRetentionDays`). Enforcement only needs the current day;
-the window covers timezone edge cases, recent account exports, and inbound
-retries. Storage-byte state is not time-pruned. Write-lease rows clear on
-release/repair/purge.
+opportunistically deletes counter, inbound-claim, and unique-worker-day rows
+older than seven UTC days (`userMeterDailyCounterRetentionDays`). Enforcement
+only needs the current day; the window covers timezone edge cases, recent
+account exports, and inbound retries. Storage-byte state is not time-pruned.
+Write-lease rows clear on release/repair/purge.
 
 **Daily counter authority:** enforcement, point reads, bootstrap, and account
 export/deletion paths use `UserMeter`; D1 has no daily entitlement counter table

--- a/docs/contributing/architecture/entitlements.md
+++ b/docs/contributing/architecture/entitlements.md
@@ -194,12 +194,16 @@ the same cold zero-init path):
   same `readAdminEntitlementConsumption` helper over a bounded sweep of the top
   ~15 active users by current-month event count. The lane emits one
   `fleet.entitlement.crossed` event per 80% or 100% crossing (and per first
-  over-threshold runtime-duration month) to admin-owned packages. Staying over
-  the same threshold does not emit again; dropping below and climbing back is a
-  new instance. KV prefix `fleet-entitlement-crossing:v1` stores
+  over-threshold runtime-duration month, unique Dynamic Worker cost month, or
+  three-of-seven execute-cap train) to admin-owned packages. Staying over the
+  same threshold does not emit again; dropping below and climbing back is a new
+  instance. KV prefix `fleet-entitlement-crossing:v1` stores
   `{prefix}:{userId}:entitlement:{threshold}:{resource}` for stock limits,
-  appends the UTC day for `*_per_day` counters, and uses
-  `{prefix}:{userId}:runtime_duration:{month}` for the 24h runtime signal.
+  appends the UTC day for `*_per_day` counters, uses
+  `{prefix}:{userId}:runtime_duration:{month}` for the 24h runtime signal,
+  `{prefix}:{userId}:dynamic_worker_cost:{month}` for the unique-worker cost
+  signal, and `{prefix}:{userId}:repeated_entitlement:{resource}` for the
+  execute-cap train. Hit days live under `fleet-entitlement-hit:v1`.
 - User entitlement warning emails (same hourly lane) — emails verified person
   accounts when usage crosses 80% or 100% of their effective plan (transactional
   template). Throttle is one mail per crossing of a given percentage on a

--- a/docs/contributing/architecture/entitlements.md
+++ b/docs/contributing/architecture/entitlements.md
@@ -138,7 +138,10 @@ Daily rate-style resources (`email_sends_per_day`, `email_receives_per_day`,
 **authoritative in the per-user `UserMeter` Durable Object** (`USER_METER`
 binding). Code lives in `packages/worker/src/entitlements/user-meter-do.ts` and
 `user-meter-client.ts`; storage layout and naming are documented in
-[Data storage](./data-storage.md).
+[Data storage](./data-storage.md). UserMeter also stores first-seen Dynamic
+Worker ids per UTC day so usage metering can record `dynamic_worker_day` without
+double-counting; that table is cost attribution, not a plan cap. See
+[Usage metering](./usage-metering.md).
 
 **D1 payload storage bytes** (`storage_bytes`) are **authoritative in
 UserMeter**. `assertWithinStorageBytesEntitlement` uses atomic DO

--- a/docs/contributing/architecture/entitlements.md
+++ b/docs/contributing/architecture/entitlements.md
@@ -4,7 +4,7 @@ Per-user plans with per-plan resource limits. This is Kody's denial-of-wallet
 protection for open signup: it bounds how many billable resources a single
 account can consume. Stripe subscription billing lives in a separate module
 (`packages/worker/src/billing/`); see [Billing](#billing) below. Limit numbers
-in `planLimits` remain independently configured placeholders.
+in `planLimits` stay independently configured from Stripe list prices.
 
 Module: `packages/worker/src/entitlements/` plus the client-safe plan registry
 at `packages/worker/universal/plans.ts`.

--- a/docs/contributing/architecture/usage-metering.md
+++ b/docs/contributing/architecture/usage-metering.md
@@ -385,14 +385,21 @@ Guarantees and rules:
   `packages/worker/src/app/usage-entitlement-alerts.ts`): hourly sweep of the
   same ~15-user bound. Emits `fleet.entitlement.crossed` to admin-owned packages
   once when a swept account first crosses 80% or 100% of a plan-limit resource,
-  or when a non-admin account's combined execute, job_run, and workflow_run
+  when a non-admin account's combined execute, job_run, and workflow_run
   duration for the month first exceeds `fleetRuntimeDurationAlertThresholdMs`
-  (24h). Staying over the same threshold does not emit again. Admin-role
-  dogfooding stays on `/admin/insights` rankings and can still appear as an
-  entitlement crossing, but does not page the runtime-duration signal. KV prefix
-  `fleet-entitlement-crossing:v1` claims each crossing. Admin links in the
-  payload are built with `joinAppUrl` so a trailing slash on `APP_BASE_URL`
-  cannot produce `https://host//admin/…`. See
+  (24h), when a non-admin account's unique Dynamic Worker cost for the month
+  first reaches the plan-aware threshold (Free
+  $2 / 1,000 unique days, Standard
+  $12, Pro $29), or when a non-admin account
+  hits 100% of `execute_calls_per_day` on three of the last seven UTC days.
+  Staying over the same threshold does not emit again. Admin-role dogfooding
+  stays on `/admin/insights` rankings and can still appear as an entitlement
+  crossing, but does not page the runtime-duration, unique-worker-cost, or
+  repeated- execute signals. KV prefix `fleet-entitlement-crossing:v1` claims
+  each crossing. Execute-cap trains also write `fleet-entitlement-hit:v1` day
+  keys so a later drop below 100% the same day does not erase the count. Admin
+  links in the payload are built with `joinAppUrl` so a trailing slash on
+  `APP_BASE_URL` cannot produce `https://host//admin/…`. See
   [Package subscriptions](../../guides/package-subscriptions.md#fleetentitlementcrossed-admins).
 - **Fleet package error rate** (same `usage_aggregation` hour): a second
   Analytics Engine SQL, not grouped by user, totals `package_export`,

--- a/docs/contributing/architecture/usage-metering.md
+++ b/docs/contributing/architecture/usage-metering.md
@@ -16,16 +16,16 @@ required `userId`, the Analytics Engine index is the `userId`, and the D1 rollup
 table is keyed by `user_id`. Admin and account reads stay scoped to one user.
 
 The homepage code-runs ticker is a documented exception: an anonymous delayed
-lifetime total of fleet `execute` events (no user ids) is replayed across the
-current UTC day. Daily counts live in platform-owned `fleet_execute_days`. The
-official `{ start, end, updateAt }` triple — cumulative through the day before
-yesterday, cumulative through yesterday, and the next UTC midnight — is cached
-at `public-code-runs:v2` on `BUNDLE_ARTIFACTS_KV`. Homepage GET fills that cache
-from D1 when the key is missing or `updateAt` has passed; it does not latch a
-high-water mark. A D1 read failure is not an empty series: GET serves the last
-cached triple when one exists, and hourly refresh does not delete the key. The
-public payload never includes per-user rows. See
-[Authorization](./authorization.md).
+lifetime total of fleet MCP execute-tool `execute` events (no user ids) is
+replayed across the current UTC day. Daily counts live in platform-owned
+`fleet_execute_days`. The official `{ start, end, updateAt }` triple —
+cumulative through the day before yesterday, cumulative through yesterday, and
+the next UTC midnight — is cached at `public-code-runs:v2` on
+`BUNDLE_ARTIFACTS_KV`. Homepage GET fills that cache from D1 when the key is
+missing or `updateAt` has passed; it does not latch a high-water mark. A D1 read
+failure is not an empty series: GET serves the last cached triple when one
+exists, and hourly refresh does not delete the key. The public payload never
+includes per-user rows. See [Authorization](./authorization.md).
 
 ## The event schema
 
@@ -58,7 +58,7 @@ events for the admin on/off cohort readout.
 
 | `eventType`           | Metered unit                                                                      | Recorded at                                                                                                                                                                 | `entityId`                     |
 | --------------------- | --------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------ |
-| `execute`             | one dynamic-worker sandbox evaluation                                             | `packages/worker/src/mcp/executor.ts` (`execute`)                                                                                                                           | none                           |
+| `execute`             | one MCP execute-tool sandbox evaluation                                           | `packages/worker/src/mcp/executor.ts` (`execute`), only when the run surface is execute                                                                                     | none                           |
 | `package_export`      | one saved-package bundled-code run                                                | `packages/worker/src/mcp/run-kody-registry.ts` (bundled runs with a package context)                                                                                        | package id                     |
 | `package_static_call` | one call of a statically imported package export (function-valued, incl. default) | sandbox-side wrapper stamped by the bundler; validated and recorded host-side by `packages/worker/src/usage/package-static-call-usage.ts` (wired in `run-kody-registry.ts`) | callee package id              |
 | `job_run`             | one job execution                                                                 | `packages/worker/src/jobs/service.ts` (`executeJobOnce`)                                                                                                                    | job id                         |
@@ -137,13 +137,14 @@ package code is reused, so calls through them are metered per call:
 
 ### Nesting: metrics are independent, do not sum across types
 
-Execution surfaces nest. A job run funnels through the bundled-module runner and
-the sandbox executor, so a single package job produces one `job_run`, one
-`package_export`, and one `execute` event, each measuring its own layer.
-Likewise, a bundled run that calls statically imported package exports produces
-one `package_static_call` event per call **inside** the run's own
-`execute`/`package_export` span. This is intentional: each metric answers its
-own question (`execute` is total sandbox pressure; `job_run` is job activity;
+Execution surfaces nest. A package job funnels through the bundled-module runner
+and the sandbox executor, so it produces one `job_run` and one `package_export`.
+It does **not** also emit `execute` — that metric is MCP `execute` tool work
+only, matching `execute_calls_per_day` and `first_execute_at`. A bundled
+execute-tool run that calls statically imported package exports still produces
+one `package_static_call` per call **inside** that run's `execute` span. Each
+metric answers its own question (`execute` is ad-hoc execute-tool volume;
+`job_run` is job activity; `package_export` is saved-package entrypoints;
 `package_static_call` is per-callee reuse). Never add durations across different
 `eventType` values — that double counts nested layers. Within one `eventType`,
 each chokepoint records exactly one event per metered unit, so sums are safe.

--- a/docs/contributing/architecture/usage-metering.md
+++ b/docs/contributing/architecture/usage-metering.md
@@ -67,6 +67,7 @@ events for the admin on/off cohort readout.
 | `outbound_fetch`      | one outbound fetch through the gateway                                            | `packages/worker/src/mcp/fetch-gateway.ts` (`KodyFetchGateway.fetch`)                                                                                                       | request host                   |
 | `email_send`          | one outbound email send attempt                                                   | `packages/worker/src/email/outbound.ts` (`sendOutboundEmail`)                                                                                                               | email message id               |
 | `email_received`      | one inbound receive attempt for a routed inbox                                    | `packages/worker/src/email/inbound.ts` (`handleInboundEmail`, after inbox resolution)                                                                                       | email message id (when stored) |
+| `dynamic_worker_day`  | first use of one Dynamic Worker id on a UTC day                                   | `packages/worker/src/mcp/executor.ts` after `createStableDynamicWorkerId`, every surface; uniqueness via `UserMeter.claimDynamicWorkerDay`                                  | worker id                      |
 
 `email_received` covers receive attempts once an inbound message is routed to a
 known, enabled inbox: stored messages record `success`; unverified-account
@@ -145,9 +146,18 @@ execute-tool run that calls statically imported package exports still produces
 one `package_static_call` per call **inside** that run's `execute` span. Each
 metric answers its own question (`execute` is ad-hoc execute-tool volume;
 `job_run` is job activity; `package_export` is saved-package entrypoints;
-`package_static_call` is per-callee reuse). Never add durations across different
+`package_static_call` is per-callee reuse). `dynamic_worker_day` is the
+Cloudflare bill unit: one unique Dynamic Worker id per user per UTC day, on
+every sandbox surface that creates a worker. It is not an entitlement and does
+not replace `execute` / `job_run`. Never add durations across different
 `eventType` values — that double counts nested layers. Within one `eventType`,
 each chokepoint records exactly one event per metered unit, so sums are safe.
+
+Admin usage and insights convert `dynamic_worker_day` counts to a **gross**
+Cloudflare estimate (`unique days × $0.002`). The 1,000 included unique
+worker-days per month are account-wide, so per-user dollars are not a net bill
+share. Worker ids stay inside UserMeter and Analytics Engine `entityId`; account
+export does not list them.
 
 ## Sinks
 

--- a/docs/contributing/packages-and-manifests.md
+++ b/docs/contributing/packages-and-manifests.md
@@ -423,10 +423,11 @@ this topic. See
 Fleet entitlement crossings are a separate admin-only, best-effort path. The
 hourly `usage_entitlement_alert` lane fans `fleet.entitlement.crossed` only to
 packages whose owners hold the admin role at dispatch time, once per 80% or 100%
-crossing (and per first over-threshold runtime-duration month). The payload is
-stable user id, username, resource counts or runtime duration, and admin URLs.
-It omits emails, plans, secrets, and package source. There is no Queue for this
-topic. See
+crossing (and per first over-threshold runtime-duration month, unique Dynamic
+Worker cost month, or three-of-seven execute-cap train). The payload is stable
+user id, username, resource counts, runtime duration, unique-worker days, or
+days at the execute cap, and admin URLs. It omits emails, plans, secrets, and
+package source. There is no Queue for this topic. See
 [Package subscriptions](../guides/package-subscriptions.md#fleetentitlementcrossed-admins).
 
 Verification-mail terminal failures are a separate admin-only, best-effort path.

--- a/docs/guides/package-subscriptions.md
+++ b/docs/guides/package-subscriptions.md
@@ -1038,11 +1038,17 @@ topic, but it never receives the event. Role revocation stops delivery on the
 next crossing.
 
 One event fires per crossing of 80% (`approaching`) or 100% (`reached`) on a
-specific entitlement, or when a non-admin account first exceeds 24h of combined
-execute / job / workflow runtime in the UTC month. Staying over the same
-threshold does not emit again. A later drop below that threshold, then a climb
-back over it, is a new instance. A same-hour jump to 100% emits `reached` only
-and claims the 80% crossing so a later drop into the 80–99% band stays silent.
+specific entitlement, when a non-admin account first exceeds 24h of combined
+execute / job / workflow runtime in the UTC month, when a non-admin account
+first reaches a plan-aware unique Dynamic Worker cost threshold this UTC month
+(Free $2, Standard $12, Pro $29; `max` and admin accounts do not page), or when
+a non-admin account first hits 100% of `execute_calls_per_day` on three of the
+last seven UTC days. Staying over the same threshold does not emit again. A
+later drop below that threshold, then a climb back over it, is a new instance. A
+same-hour jump to 100% emits `reached` only and claims the 80% crossing so a
+later drop into the 80–99% band stays silent. Execute-cap days are recorded on
+durable hit keys so a later drop below 100% the same day does not erase the
+train.
 
 There is no Queue / DLQ for this topic. A missed invoke is logged and does not
 fail the hourly sweep. Retry happens on the next hour if the crossing is still
@@ -1088,6 +1094,29 @@ type FleetEntitlementCrossedEvent =
 			users_url: string
 			observed_at: string
 	  }
+	| {
+			event: 'fleet.entitlement.crossed'
+			kind: 'repeated_entitlement'
+			user: { id: string; username: string }
+			resource: 'execute_calls_per_day'
+			days_at_limit: number
+			window_days: 7
+			threshold_days: 3
+			insights_url: string
+			users_url: string
+			observed_at: string
+	  }
+	| {
+			event: 'fleet.entitlement.crossed'
+			kind: 'dynamic_worker_cost'
+			user: { id: string; username: string }
+			unique_worker_days: number
+			estimated_gross_usd: number
+			threshold_usd: number
+			insights_url: string
+			users_url: string
+			observed_at: string
+	  }
 ```
 
 `user.id` is the stable account user id. `insights_url` and `users_url` are
@@ -1097,8 +1126,10 @@ include the topic, user id, crossing kind, threshold or UTC month, resource, UTC
 day for `*_per_day` resources, and subscriber package id.
 
 Use this topic for notifier packages that send an operator message (for example
-Discord) when an account first crosses a plan limit. Do not treat this topic as
-permission to read another user's packages, secrets, or Activity.
+Discord) when an account first crosses a plan limit, repeats an execute cap, or
+crosses the unique-worker cost line. Filter on `kind` if a busy-day 80% crossing
+is too noisy. Do not treat this topic as permission to read another user's
+packages, secrets, or Activity.
 
 ## User created and deleted (admins)
 

--- a/docs/guides/package-subscriptions.md
+++ b/docs/guides/package-subscriptions.md
@@ -1123,7 +1123,8 @@ type FleetEntitlementCrossedEvent =
 operator dashboards. Timestamps are ISO-8601 UTC. The event omits emails, plan
 names, secrets, package source, and unrelated account content. Idempotency keys
 include the topic, user id, crossing kind, threshold or UTC month, resource, UTC
-day for `*_per_day` resources, and subscriber package id.
+day for `*_per_day` resources and `repeated_entitlement`, and subscriber package
+id.
 
 Use this topic for notifier packages that send an operator message (for example
 Discord) when an account first crosses a plan limit, repeats an execute cap, or

--- a/docs/use/email-primitives.md
+++ b/docs/use/email-primitives.md
@@ -93,9 +93,10 @@ Inbound storage is quota-gated per user:
   unless an invite assigns another tier. The operator-only `max` plan uses
   finite email caps (10,000 sends/day, 20,000 receives/day, 100,000 stored
   messages, 768 KiB per message); it is not a public or paid tier.
-- Paid email caps are Standard: 200 sends/day, 1,000 receives/day, 10,000 stored
-  messages; Pro: 500 sends/day, 2,000 receives/day, 25,000 stored messages. Both
-  allow up to 768 KiB per message.
+- Free email caps are 10 sends/day, 10 receives/day, 100 stored messages, and
+  256 KiB per message. Paid email caps are Standard: 200 sends/day, 1,000
+  receives/day, 10,000 stored messages; Pro: 500 sends/day, 2,000 receives/day,
+  25,000 stored messages. Both paid plans allow up to 768 KiB per message.
 - Quota, size, and unverified-account rejections store at most five detailed
   `rejected` delivery events per inbox per UTC day; further rejections increment
   a single daily aggregate event (with a total count and the last reason) so

--- a/docs/use/privacy.md
+++ b/docs/use/privacy.md
@@ -128,11 +128,15 @@ rates rise (window bounds, per-metric counts and rates, public status URL, and
 insights URL). That event omits user ids, package ids, error strings, logs, and
 unrelated account content. Admin-configured notification packages may also
 receive a metadata-only `fleet.entitlement.crossed` event when a swept account
-first crosses 80% or 100% of a plan-limit resource, or when a non-admin account
-first exceeds the monthly runtime-duration threshold. Entitlement events include
-stable user id, username, resource counts, and admin dashboard URLs;
-runtime-duration events include stable user id, username, `total_duration_ms`,
-`threshold_ms`, and admin dashboard URLs. Both event kinds omit emails, plans,
+first crosses 80% or 100% of a plan-limit resource, when a non-admin account
+first exceeds the monthly runtime-duration threshold, when a non-admin account
+first reaches a plan-aware unique Dynamic Worker cost threshold, or when a
+non-admin account first hits the execute cap on three of the last seven UTC
+days. Entitlement events include stable user id, username, resource counts, and
+admin dashboard URLs; runtime-duration events include stable user id, username,
+`total_duration_ms`, `threshold_ms`, and admin dashboard URLs;
+unique-worker-cost and repeated-execute events include the counts that tripped
+the threshold and admin dashboard URLs. These event kinds omit emails, plans,
 secrets, package source, and unrelated account content.
 
 ## Platform feedback

--- a/packages/worker/client/charts/usage-metric-series.ts
+++ b/packages/worker/client/charts/usage-metric-series.ts
@@ -33,6 +33,11 @@ export const usageMetricSeries: Array<UsageMetricSeries> = [
 		label: 'Email receives',
 		color: chartColor.fuchsia,
 	},
+	{
+		metric: 'dynamic_worker_day',
+		label: 'Unique worker-days',
+		color: chartColor.rose,
+	},
 ]
 
 export const monthShortNames = [

--- a/packages/worker/client/routes/admin-insights-dashboard.tsx
+++ b/packages/worker/client/routes/admin-insights-dashboard.tsx
@@ -16,6 +16,7 @@ import {
 	formatMonthKeyLabel,
 	usageMetricSeries,
 } from '#client/charts/usage-metric-series.ts'
+import { dynamicWorkerCostFootnote } from '#universal/dynamic-worker-cost.ts'
 import { AccountManagementMessage } from './account-management-components.tsx'
 import { type AdminInsightsLoaderData } from '#universal/loader-data.ts'
 import {
@@ -32,6 +33,7 @@ import {
 	renderActivationFunnel,
 	renderDurationByMetric,
 	renderDurationConsumers,
+	renderDynamicWorkerCost,
 	renderEntitlementPressure,
 	renderEventCountConsumers,
 	renderPackageErrorRate,
@@ -264,6 +266,13 @@ export function renderDashboard(data: AdminInsightsLoaderData) {
 					span={6}
 				>
 					{renderEventCountConsumers(data.topEventCountConsumers)}
+				</ChartCard>
+				<ChartCard
+					title="Dynamic Worker cost"
+					sub={dynamicWorkerCostFootnote}
+					span={6}
+				>
+					{renderDynamicWorkerCost(data.dynamicWorkerCost)}
 				</ChartCard>
 
 				<ChartCard

--- a/packages/worker/client/routes/admin-insights-sections.tsx
+++ b/packages/worker/client/routes/admin-insights-sections.tsx
@@ -6,11 +6,13 @@ import {
 	formatIntegerNumber,
 	formatPercentShare,
 } from '#client/charts/chart-theme.ts'
+import { formatDynamicWorkerUsd } from '#universal/dynamic-worker-cost.ts'
 import {
 	type AdminInsightsActivation,
 	type AdminInsightsActivationStep,
 	type AdminInsightsDurationConsumer,
 	type AdminInsightsEntitlementPressureUser,
+	type AdminInsightsDynamicWorkerCost,
 	type AdminInsightsEventCountConsumer,
 	type AdminInsightsMetricDurationConsumers,
 	type AdminInsightsPackageErrorRate,
@@ -119,6 +121,45 @@ export function renderDurationConsumers(
 			value: formatDurationHours(consumer.totalDurationMs),
 		})),
 	})
+}
+
+export function renderDynamicWorkerCost(cost: AdminInsightsDynamicWorkerCost) {
+	return (
+		<div mix={css({ display: 'grid', gap: spacing.md })}>
+			<div
+				mix={css({
+					display: 'flex',
+					justifyContent: 'space-between',
+					gap: spacing.sm,
+					flexWrap: 'wrap',
+				})}
+			>
+				<strong mix={css({ fontSize: typography.fontSize.sm })}>
+					{formatDynamicWorkerUsd(cost.estimatedGrossUsd)} gross
+				</strong>
+				<span
+					mix={css({
+						color: colors.textMuted,
+						fontSize: typography.fontSize.sm,
+						fontVariantNumeric: 'tabular-nums',
+					})}
+				>
+					{formatIntegerNumber(cost.uniqueWorkerDays)} unique worker-days
+				</span>
+			</div>
+			{renderConsumerTable({
+				ariaLabel: 'Top Dynamic Worker cost consumers this month',
+				emptyText: 'No unique Dynamic Worker days recorded this month yet.',
+				valueHeader: 'Gross cost',
+				rows: cost.topConsumers.map((consumer) => ({
+					key: consumer.stableUserId,
+					username: consumer.username,
+					stableUserId: consumer.stableUserId,
+					value: `${formatDynamicWorkerUsd(consumer.estimatedGrossUsd)} (${formatIntegerNumber(consumer.uniqueWorkerDays)})`,
+				})),
+			})}
+		</div>
+	)
 }
 
 export function renderEventCountConsumers(

--- a/packages/worker/client/routes/admin-insights-shared.ts
+++ b/packages/worker/client/routes/admin-insights-shared.ts
@@ -80,6 +80,7 @@ export const runtimeDurationMetricLabels: Record<AdminUsageMetric, string> = {
 	outbound_fetch: 'Fetches',
 	email_send: 'Email sends',
 	email_received: 'Email receives',
+	dynamic_worker_day: 'Unique worker-days',
 }
 
 /** Null when run-derived totals are complete; otherwise a user-facing warning. */

--- a/packages/worker/client/routes/admin-users-detail.tsx
+++ b/packages/worker/client/routes/admin-users-detail.tsx
@@ -33,6 +33,10 @@ import {
 } from '#universal/loader-data.ts'
 import { describeEmailVerificationDelivery } from '#universal/email-verification-delivery.ts'
 import { formatUsageLimit, formatUsagePercent } from './admin-users-shared.ts'
+import {
+	dynamicWorkerCostFootnote,
+	formatDynamicWorkerUsd,
+} from '#universal/dynamic-worker-cost.ts'
 
 const selectCss = getSelectCss()
 const primaryButtonCss = getPillButtonCss({ size: 'sm' })
@@ -497,6 +501,41 @@ export function renderAdminUserDetail(props: AdminUserDetailProps) {
 									.join(', ')}
 							</div>
 						) : null}
+						<div mix={css({ display: 'grid', gap: spacing.sm })}>
+							<h3
+								mix={css({
+									margin: 0,
+									fontSize: typography.fontSize.base,
+								})}
+							>
+								Cloudflare Dynamic Worker cost
+							</h3>
+							<p
+								mix={css({
+									margin: 0,
+									fontSize: typography.fontSize.sm,
+									fontVariantNumeric: 'tabular-nums',
+								})}
+							>
+								{formatDynamicWorkerUsd(
+									selectedUsage.dynamicWorkerCost.estimatedGrossUsd,
+								)}{' '}
+								gross this month (
+								{formatIntegerNumber(
+									selectedUsage.dynamicWorkerCost.uniqueWorkerDays,
+								)}{' '}
+								unique worker-days)
+							</p>
+							<p
+								mix={css({
+									margin: 0,
+									color: colors.textMuted,
+									fontSize: typography.fontSize.xs,
+								})}
+							>
+								{dynamicWorkerCostFootnote}
+							</p>
+						</div>
 						<div mix={css({ display: 'grid', gap: spacing.md })}>
 							<h3
 								mix={css({

--- a/packages/worker/client/routes/privacy.tsx
+++ b/packages/worker/client/routes/privacy.tsx
@@ -172,14 +172,18 @@ export function PrivacyRoute(_handle: Handle) {
 					ids, package ids, error strings, logs, and unrelated account content.
 					Admin-configured notification packages may also receive a
 					metadata-only <code>fleet.entitlement.crossed</code> event when a
-					swept account first crosses 80% or 100% of a plan-limit resource, or
-					when a non-admin account first exceeds the monthly runtime-duration
-					threshold. Entitlement events include stable user id, username,
-					resource counts, and admin dashboard URLs; runtime-duration events
-					include stable user id, username, <code>total_duration_ms</code>,{' '}
-					<code>threshold_ms</code>, and admin dashboard URLs. Both event kinds
-					omit emails, plans, secrets, package source, and unrelated account
-					content.
+					swept account first crosses 80% or 100% of a plan-limit resource, when
+					a non-admin account first exceeds the monthly runtime-duration
+					threshold, when a non-admin account first reaches a plan-aware unique
+					Dynamic Worker cost threshold, or when a non-admin account first hits
+					the execute cap on three of the last seven UTC days. Entitlement
+					events include stable user id, username, resource counts, and admin
+					dashboard URLs; runtime-duration events include stable user id,
+					username, <code>total_duration_ms</code>, <code>threshold_ms</code>,
+					and admin dashboard URLs; unique-worker-cost and repeated-execute
+					events include the counts that tripped the threshold and admin
+					dashboard URLs. These event kinds omit emails, plans, secrets, package
+					source, and unrelated account content.
 				</p>
 			</section>
 

--- a/packages/worker/client/routes/terms.tsx
+++ b/packages/worker/client/routes/terms.tsx
@@ -58,12 +58,20 @@ export function TermsRoute(_handle: Handle) {
 						Attack, scrape, or disrupt third-party systems without permission
 					</li>
 					<li>Probe or abuse other users&apos; accounts or data</li>
-					<li>Circumvent plan limits, suspensions, or security controls</li>
+					<li>
+						Circumvent plan limits, suspensions, or security controls —
+						including by creating extra accounts, cycling identity, or farming
+						Free compute
+					</li>
 					<li>Host or distribute malware, or violate applicable law</li>
 				</ul>
 				<p mix={css(descriptionCss)}>
 					Outbound email, compute, and storage are shared platform resources.
-					Heavy or abusive use may be rate-limited, paused, or suspended.
+					Heavy or abusive use may be rate-limited, paused, or suspended. Using
+					the full published cap on a busy day is ordinary use, not a violation.
+					Free is not a guaranteed compute allotment: we may revoke or restrict
+					Free access when we reasonably believe the plan is being gamed or is
+					harming the service for other users.
 				</p>
 			</section>
 
@@ -106,7 +114,8 @@ export function TermsRoute(_handle: Handle) {
 					<a href="/pricing" mix={css(mutedLinkCss)}>
 						Pricing
 					</a>{' '}
-					page.
+					page. Published limits can change; we will give reasonable notice of
+					material reductions when practical.
 				</p>
 				<p mix={css(descriptionCss)}>
 					There are no automatic refunds. If something went wrong, email{' '}
@@ -133,9 +142,11 @@ export function TermsRoute(_handle: Handle) {
 				<h2 mix={css(cardTitleCss)}>Suspension and termination</h2>
 				<p mix={css(descriptionCss)}>
 					Operators may suspend or terminate accounts that violate these terms,
-					threaten platform reputation (including email sending), or put other
-					users at risk. When practical, we will explain the reason. You may
-					delete your account at any time.
+					evade limits or a prior suspension, threaten platform reputation
+					(including email sending), or put other users at risk. We may act
+					without prior notice when we reasonably believe terms are being
+					evaded. Free access is revocable. When practical, we will explain the
+					reason. You may delete your account at any time.
 				</p>
 			</section>
 

--- a/packages/worker/src/admin/fleet-usage-insights.node.test.ts
+++ b/packages/worker/src/admin/fleet-usage-insights.node.test.ts
@@ -43,6 +43,12 @@ function createFleetDb(input: {
 	}>
 	runtimeByUser?: Record<string, number>
 	adminUserIds?: Array<string>
+	dynamicWorkerLeaders?: Array<{
+		stable_user_id: string
+		username: string
+		event_count: number
+	}>
+	dynamicWorkerDays?: number
 	onDurationQueryBind?: (params: Array<unknown>) => void
 }) {
 	return {
@@ -57,6 +63,17 @@ function createFleetDb(input: {
 						input.onDurationQueryBind?.(params)
 					}
 					return this
+				},
+				async first<T>() {
+					if (
+						normalized.includes("metric = 'dynamic_worker_day'") &&
+						normalized.includes('sum(event_count)')
+					) {
+						return {
+							unique_worker_days: input.dynamicWorkerDays ?? 0,
+						} as T
+					}
+					return null
 				},
 				async all<T>() {
 					if (
@@ -94,6 +111,14 @@ function createFleetDb(input: {
 					) {
 						return {
 							results: (input.eventLeaders ?? []) as Array<T>,
+						}
+					}
+					if (
+						normalized.includes("metric = 'dynamic_worker_day'") &&
+						normalized.includes('ranked.event_count')
+					) {
+						return {
+							results: (input.dynamicWorkerLeaders ?? []) as Array<T>,
 						}
 					}
 					if (normalized.includes('row_number() over')) {
@@ -163,6 +188,14 @@ test('loadFleetUsageInsights returns bounded consumer rankings and pressure pane
 				event_count: 50,
 			},
 		],
+		dynamicWorkerDays: 150,
+		dynamicWorkerLeaders: [
+			{
+				stable_user_id: 'user-c',
+				username: 'cara',
+				event_count: 90,
+			},
+		],
 	})
 	const data = await loadFleetUsageInsights({
 		db,
@@ -207,6 +240,20 @@ test('loadFleetUsageInsights returns bounded consumer rankings and pressure pane
 			],
 		},
 	])
+	expect(data.dynamicWorkerCost).toEqual({
+		uniqueWorkerDays: 150,
+		estimatedGrossUsd: 0.3,
+		usdPerUniqueDay: 0.002,
+		includedPerAccountMonth: 1000,
+		topConsumers: [
+			{
+				stableUserId: 'user-c',
+				username: 'cara',
+				uniqueWorkerDays: 90,
+				estimatedGrossUsd: 0.18,
+			},
+		],
+	})
 })
 
 test('detectFleetUsagePressure flags entitlement and runtime duration thresholds', async () => {

--- a/packages/worker/src/admin/fleet-usage-insights.node.test.ts
+++ b/packages/worker/src/admin/fleet-usage-insights.node.test.ts
@@ -49,6 +49,7 @@ function createFleetDb(input: {
 		event_count: number
 	}>
 	dynamicWorkerDays?: number
+	uniqueWorkerDaysByUser?: Record<string, number>
 	onDurationQueryBind?: (params: Array<unknown>) => void
 }) {
 	return {
@@ -77,10 +78,9 @@ function createFleetDb(input: {
 				},
 				async all<T>() {
 					if (
-						normalized.includes('sum(total_duration_ms)') &&
-						normalized.includes('group by user_id') &&
+						normalized.includes('sum(r.total_duration_ms)') &&
 						normalized.includes('limit ?') &&
-						!normalized.includes('partition by metric')
+						!normalized.includes('partition by')
 					) {
 						return {
 							results: (input.runtimeLeaders ?? []) as Array<T>,
@@ -88,7 +88,7 @@ function createFleetDb(input: {
 					}
 					if (
 						normalized.includes('u.plan') &&
-						normalized.includes('ranked.event_count')
+						normalized.includes('event_count')
 					) {
 						return {
 							results: (input.activeUsers ?? []) as Array<T>,
@@ -105,8 +105,7 @@ function createFleetDb(input: {
 						}
 					}
 					if (
-						normalized.includes('sum(event_count)') &&
-						normalized.includes('group by user_id') &&
+						normalized.includes('sum(r.event_count)') &&
 						normalized.includes('limit ?')
 					) {
 						return {
@@ -115,7 +114,19 @@ function createFleetDb(input: {
 					}
 					if (
 						normalized.includes("metric = 'dynamic_worker_day'") &&
-						normalized.includes('ranked.event_count')
+						normalized.includes('user_id in')
+					) {
+						const rows = Object.entries(input.uniqueWorkerDaysByUser ?? {}).map(
+							([user_id, event_count]) => ({
+								user_id,
+								event_count,
+							}),
+						)
+						return { results: rows as Array<T> }
+					}
+					if (
+						normalized.includes("metric = 'dynamic_worker_day'") &&
+						normalized.includes('limit ?')
 					) {
 						return {
 							results: (input.dynamicWorkerLeaders ?? []) as Array<T>,
@@ -256,7 +267,7 @@ test('loadFleetUsageInsights returns bounded consumer rankings and pressure pane
 	})
 })
 
-test('detectFleetUsagePressure flags entitlement and runtime duration thresholds', async () => {
+test('detectFleetUsagePressure flags entitlement, runtime, and unique-worker cost', async () => {
 	entitlementMocks.readAdminEntitlementConsumption.mockImplementation(
 		async (input) => {
 			if (input.usageUserId === 'user-a') {
@@ -316,6 +327,10 @@ test('detectFleetUsagePressure flags entitlement and runtime duration thresholds
 			'user-b': fleetRuntimeDurationAlertThresholdMs + 1,
 			'user-admin': fleetRuntimeDurationAlertThresholdMs * 2,
 		},
+		uniqueWorkerDaysByUser: {
+			'user-a': 1000,
+			'user-admin': 50_000,
+		},
 		onDurationQueryBind(params) {
 			durationQueryBind = params
 		},
@@ -335,6 +350,14 @@ test('detectFleetUsagePressure flags entitlement and runtime duration thresholds
 			current: 9,
 			limit: 10,
 			percentOfLimit: 0.9,
+		},
+		{
+			kind: 'dynamic_worker_cost',
+			stableUserId: 'user-a',
+			username: 'alice',
+			uniqueWorkerDays: 1000,
+			estimatedGrossUsd: 2,
+			thresholdUsd: 2,
 		},
 		{
 			kind: 'entitlement',

--- a/packages/worker/src/admin/fleet-usage-insights.ts
+++ b/packages/worker/src/admin/fleet-usage-insights.ts
@@ -1,6 +1,7 @@
 import { utcMonthKey } from '@kody-internal/shared/date-keys.ts'
 import {
 	estimateDynamicWorkerUsd,
+	fleetDynamicWorkerCostAlertUsd,
 	toAdminDynamicWorkerCost,
 } from '#universal/dynamic-worker-cost.ts'
 import {
@@ -85,10 +86,19 @@ export type FleetEntitlementPressureIssue =
 			username: string
 			totalDurationMs: number
 	  }
+	| {
+			kind: 'dynamic_worker_cost'
+			stableUserId: string
+			username: string
+			uniqueWorkerDays: number
+			estimatedGrossUsd: number
+			thresholdUsd: number
+	  }
 
 export type FleetEntitlementCrossingSnapshot = {
 	stableUserId: string
 	username: string
+	plan: PlanName
 	isAdmin: boolean
 	entitlements: Array<{
 		resource: AdminUsageEntitlementResource
@@ -99,6 +109,7 @@ export type FleetEntitlementCrossingSnapshot = {
 		overEightyPercent: boolean
 	}>
 	runtimeDurationMs: number
+	uniqueWorkerDays: number
 }
 
 export async function loadFleetUsageInsights(input: {
@@ -147,15 +158,18 @@ export async function loadFleetEntitlementCrossingSnapshots(input: {
 	)
 	if (activeUsers.length === 0) return []
 
-	const [durationByUser, adminUserIds] = await Promise.all([
-		queryCombinedRuntimeDurationByUserIds(
-			input.db,
-			currentMonth,
-			activeUsers.map((user) => user.stable_user_id),
-			adminFleetRuntimeDurationAlertMetrics,
-		),
-		listAdminStableUserIds(input.db),
-	])
+	const userIds = activeUsers.map((user) => user.stable_user_id)
+	const [durationByUser, uniqueWorkerDaysByUser, adminUserIds] =
+		await Promise.all([
+			queryCombinedRuntimeDurationByUserIds(
+				input.db,
+				currentMonth,
+				userIds,
+				adminFleetRuntimeDurationAlertMetrics,
+			),
+			queryUniqueWorkerDaysByUserIds(input.db, currentMonth, userIds),
+			listAdminStableUserIds(input.db),
+		])
 	const snapshots: Array<FleetEntitlementCrossingSnapshot> = []
 
 	await mapWithConcurrency(
@@ -175,6 +189,7 @@ export async function loadFleetEntitlementCrossingSnapshots(input: {
 			snapshots.push({
 				stableUserId: user.stable_user_id,
 				username: user.username,
+				plan,
 				isAdmin: adminUserIds.has(user.stable_user_id),
 				entitlements: consumption.map((item) => ({
 					resource: item.resource,
@@ -185,6 +200,7 @@ export async function loadFleetEntitlementCrossingSnapshots(input: {
 					overEightyPercent: item.overEightyPercent,
 				})),
 				runtimeDurationMs: durationByUser.get(user.stable_user_id) ?? 0,
+				uniqueWorkerDays: uniqueWorkerDaysByUser.get(user.stable_user_id) ?? 0,
 			})
 		},
 	)
@@ -227,6 +243,21 @@ export async function detectFleetUsagePressure(input: {
 				totalDurationMs: snapshot.runtimeDurationMs,
 			})
 		}
+		const thresholdUsd = fleetDynamicWorkerCostAlertUsd(snapshot.plan)
+		if (thresholdUsd == null) continue
+		const estimatedGrossUsd = estimateDynamicWorkerUsd(
+			snapshot.uniqueWorkerDays,
+		)
+		if (estimatedGrossUsd >= thresholdUsd) {
+			issues.push({
+				kind: 'dynamic_worker_cost',
+				stableUserId: snapshot.stableUserId,
+				username: snapshot.username,
+				uniqueWorkerDays: snapshot.uniqueWorkerDays,
+				estimatedGrossUsd,
+				thresholdUsd,
+			})
+		}
 	}
 	return issues
 }
@@ -240,19 +271,15 @@ async function queryTopRuntimeDurationConsumers(
 		.join(', ')
 	const rows = await db
 		.prepare(
-			`SELECT u.stable_user_id, u.username, ranked.total_duration_ms
-			 FROM (
-				SELECT user_id, SUM(total_duration_ms) AS total_duration_ms
-				FROM usage_rollups
-				WHERE month = ?
-					AND metric IN (${metricPlaceholders})
-				GROUP BY user_id
-				ORDER BY total_duration_ms DESC
-				LIMIT ?
-			 ) AS ranked
-			 INNER JOIN users u ON u.stable_user_id = ranked.user_id
-			 WHERE u.deleting_at IS NULL
-			 ORDER BY ranked.total_duration_ms DESC`,
+			`SELECT u.stable_user_id, u.username, SUM(r.total_duration_ms) AS total_duration_ms
+			 FROM usage_rollups r
+			 INNER JOIN users u ON u.stable_user_id = r.user_id
+			 WHERE r.month = ?
+				AND r.metric IN (${metricPlaceholders})
+				AND u.deleting_at IS NULL
+			 GROUP BY u.stable_user_id, u.username
+			 ORDER BY total_duration_ms DESC
+			 LIMIT ?`,
 		)
 		.bind(
 			currentMonth,
@@ -277,18 +304,14 @@ async function queryTopEventCountConsumers(
 ): Promise<Array<AdminInsightsEventCountConsumer>> {
 	const rows = await db
 		.prepare(
-			`SELECT u.stable_user_id, u.username, ranked.event_count
-			 FROM (
-				SELECT user_id, SUM(event_count) AS event_count
-				FROM usage_rollups
-				WHERE month = ?
-				GROUP BY user_id
-				ORDER BY event_count DESC
-				LIMIT ?
-			 ) AS ranked
-			 INNER JOIN users u ON u.stable_user_id = ranked.user_id
-			 WHERE u.deleting_at IS NULL
-			 ORDER BY ranked.event_count DESC`,
+			`SELECT u.stable_user_id, u.username, SUM(r.event_count) AS event_count
+			 FROM usage_rollups r
+			 INNER JOIN users u ON u.stable_user_id = r.user_id
+			 WHERE r.month = ?
+				AND u.deleting_at IS NULL
+			 GROUP BY u.stable_user_id, u.username
+			 ORDER BY event_count DESC
+			 LIMIT ?`,
 		)
 		.bind(currentMonth, adminFleetTopConsumersLimit)
 		.all<{ stable_user_id: string; username: string; event_count: number }>()
@@ -315,18 +338,14 @@ async function queryDynamicWorkerCost(
 			.first<{ unique_worker_days: number }>(),
 		db
 			.prepare(
-				`SELECT u.stable_user_id, u.username, ranked.event_count
-				 FROM (
-					SELECT user_id, event_count
-					FROM usage_rollups
-					WHERE month = ?
-						AND metric = 'dynamic_worker_day'
-					ORDER BY event_count DESC
-					LIMIT ?
-				 ) AS ranked
-				 INNER JOIN users u ON u.stable_user_id = ranked.user_id
-				 WHERE u.deleting_at IS NULL
-				 ORDER BY ranked.event_count DESC`,
+				`SELECT u.stable_user_id, u.username, r.event_count
+				 FROM usage_rollups r
+				 INNER JOIN users u ON u.stable_user_id = r.user_id
+				 WHERE r.month = ?
+					AND r.metric = 'dynamic_worker_day'
+					AND u.deleting_at IS NULL
+				 ORDER BY r.event_count DESC
+				 LIMIT ?`,
 			)
 			.bind(currentMonth, adminFleetTopConsumersLimit)
 			.all<{
@@ -359,21 +378,21 @@ async function queryTopDurationConsumersByMetric(
 		.join(', ')
 	const rows = await db
 		.prepare(
-			`SELECT ranked.user_id, ranked.metric, ranked.total_duration_ms, u.username
+			`SELECT ranked.user_id, ranked.metric, ranked.total_duration_ms, ranked.username
 			 FROM (
-				SELECT user_id, metric, total_duration_ms,
+				SELECT r.user_id, r.metric, r.total_duration_ms, u.username,
 					ROW_NUMBER() OVER (
-						PARTITION BY metric
-						ORDER BY total_duration_ms DESC
+						PARTITION BY r.metric
+						ORDER BY r.total_duration_ms DESC
 					) AS rank_in_metric
-				FROM usage_rollups
-				WHERE month = ?
-					AND metric IN (${metricPlaceholders})
-					AND total_duration_ms > 0
+				FROM usage_rollups r
+				INNER JOIN users u ON u.stable_user_id = r.user_id
+				WHERE r.month = ?
+					AND r.metric IN (${metricPlaceholders})
+					AND r.total_duration_ms > 0
+					AND u.deleting_at IS NULL
 			 ) AS ranked
-			 INNER JOIN users u ON u.stable_user_id = ranked.user_id
 			 WHERE ranked.rank_in_metric <= ?
-				AND u.deleting_at IS NULL
 			 ORDER BY ranked.metric ASC, ranked.total_duration_ms DESC`,
 		)
 		.bind(
@@ -464,18 +483,14 @@ async function listActiveUsersForEntitlementSweep(
 ): Promise<Array<ActiveUserRow>> {
 	const rows = await db
 		.prepare(
-			`SELECT u.stable_user_id, u.username, u.plan, u.stripe_plan, ranked.event_count
-			 FROM (
-				SELECT user_id, SUM(event_count) AS event_count
-				FROM usage_rollups
-				WHERE month = ?
-				GROUP BY user_id
-				ORDER BY event_count DESC
-				LIMIT ?
-			 ) AS ranked
-			 INNER JOIN users u ON u.stable_user_id = ranked.user_id
-			 WHERE u.deleting_at IS NULL
-			 ORDER BY ranked.event_count DESC`,
+			`SELECT u.stable_user_id, u.username, u.plan, u.stripe_plan, SUM(r.event_count) AS event_count
+			 FROM usage_rollups r
+			 INNER JOIN users u ON u.stable_user_id = r.user_id
+			 WHERE r.month = ?
+				AND u.deleting_at IS NULL
+			 GROUP BY u.stable_user_id, u.username, u.plan, u.stripe_plan
+			 ORDER BY event_count DESC
+			 LIMIT ?`,
 		)
 		.bind(currentMonth, adminFleetEntitlementSweepUserLimit)
 		.all<ActiveUserRow>()
@@ -494,6 +509,30 @@ async function listAdminStableUserIds(db: D1Database) {
 		)
 		.all<{ stable_user_id: string }>()
 	return new Set((rows.results ?? []).map((row) => row.stable_user_id))
+}
+
+async function queryUniqueWorkerDaysByUserIds(
+	db: D1Database,
+	currentMonth: string,
+	userIds: ReadonlyArray<string>,
+): Promise<Map<string, number>> {
+	if (userIds.length === 0) return new Map()
+	const userPlaceholders = userIds.map(() => '?').join(', ')
+	const rows = await db
+		.prepare(
+			`SELECT user_id, event_count
+			 FROM usage_rollups
+			 WHERE month = ?
+				AND metric = 'dynamic_worker_day'
+				AND user_id IN (${userPlaceholders})`,
+		)
+		.bind(currentMonth, ...userIds)
+		.all<{ user_id: string; event_count: number }>()
+	const byUser = new Map<string, number>()
+	for (const row of rows.results ?? []) {
+		byUser.set(row.user_id, Number(row.event_count))
+	}
+	return byUser
 }
 
 async function queryCombinedRuntimeDurationByUserIds(

--- a/packages/worker/src/admin/fleet-usage-insights.ts
+++ b/packages/worker/src/admin/fleet-usage-insights.ts
@@ -1,5 +1,9 @@
 import { utcMonthKey } from '@kody-internal/shared/date-keys.ts'
 import {
+	estimateDynamicWorkerUsd,
+	toAdminDynamicWorkerCost,
+} from '#universal/dynamic-worker-cost.ts'
+import {
 	parseStoredPlanName,
 	resolveEffectivePlan,
 	type PlanName,
@@ -8,6 +12,7 @@ import { adminUsageMetrics } from '#worker/admin/user-usage-data.ts'
 import { readAdminEntitlementConsumption } from '#worker/admin/entitlement-consumption.ts'
 import {
 	type AdminInsightsDurationConsumer,
+	type AdminInsightsDynamicWorkerCost,
 	type AdminInsightsEntitlementPressureUser,
 	type AdminInsightsEventCountConsumer,
 	type AdminInsightsMetricDurationConsumers,
@@ -105,6 +110,7 @@ export async function loadFleetUsageInsights(input: {
 	topEventCountConsumers: Array<AdminInsightsEventCountConsumer>
 	topDurationConsumersByMetric: Array<AdminInsightsMetricDurationConsumers>
 	entitlementPressure: Array<AdminInsightsEntitlementPressureUser>
+	dynamicWorkerCost: AdminInsightsDynamicWorkerCost
 }> {
 	const currentMonth = utcMonthKey(input.now)
 	const [
@@ -112,17 +118,20 @@ export async function loadFleetUsageInsights(input: {
 		topEventCountConsumers,
 		topDurationConsumersByMetric,
 		entitlementPressure,
+		dynamicWorkerCost,
 	] = await Promise.all([
 		queryTopRuntimeDurationConsumers(input.db, currentMonth),
 		queryTopEventCountConsumers(input.db, currentMonth),
 		queryTopDurationConsumersByMetric(input.db, currentMonth),
 		buildEntitlementPressurePanel(input),
+		queryDynamicWorkerCost(input.db, currentMonth),
 	])
 	return {
 		topRuntimeDurationConsumers,
 		topEventCountConsumers,
 		topDurationConsumersByMetric,
 		entitlementPressure,
+		dynamicWorkerCost,
 	}
 }
 
@@ -288,6 +297,57 @@ async function queryTopEventCountConsumers(
 		username: row.username,
 		eventCount: Number(row.event_count),
 	}))
+}
+
+async function queryDynamicWorkerCost(
+	db: D1Database,
+	currentMonth: string,
+): Promise<AdminInsightsDynamicWorkerCost> {
+	const [totalRow, consumerRows] = await Promise.all([
+		db
+			.prepare(
+				`SELECT COALESCE(SUM(event_count), 0) AS unique_worker_days
+				 FROM usage_rollups
+				 WHERE month = ?
+					AND metric = 'dynamic_worker_day'`,
+			)
+			.bind(currentMonth)
+			.first<{ unique_worker_days: number }>(),
+		db
+			.prepare(
+				`SELECT u.stable_user_id, u.username, ranked.event_count
+				 FROM (
+					SELECT user_id, event_count
+					FROM usage_rollups
+					WHERE month = ?
+						AND metric = 'dynamic_worker_day'
+					ORDER BY event_count DESC
+					LIMIT ?
+				 ) AS ranked
+				 INNER JOIN users u ON u.stable_user_id = ranked.user_id
+				 WHERE u.deleting_at IS NULL
+				 ORDER BY ranked.event_count DESC`,
+			)
+			.bind(currentMonth, adminFleetTopConsumersLimit)
+			.all<{
+				stable_user_id: string
+				username: string
+				event_count: number
+			}>(),
+	])
+	const uniqueWorkerDays = Number(totalRow?.unique_worker_days ?? 0)
+	return {
+		...toAdminDynamicWorkerCost(uniqueWorkerDays),
+		topConsumers: (consumerRows.results ?? []).map((row) => {
+			const days = Number(row.event_count)
+			return {
+				stableUserId: row.stable_user_id,
+				username: row.username,
+				uniqueWorkerDays: days,
+				estimatedGrossUsd: estimateDynamicWorkerUsd(days),
+			}
+		}),
+	}
 }
 
 async function queryTopDurationConsumersByMetric(

--- a/packages/worker/src/admin/user-usage-data.node.test.ts
+++ b/packages/worker/src/admin/user-usage-data.node.test.ts
@@ -261,6 +261,51 @@ test('loadAdminUserUsageData returns null for unknown users and zeroed usage for
 		},
 	])
 	expect(data?.warnings).toEqual([])
+	expect(data?.dynamicWorkerCost).toEqual({
+		uniqueWorkerDays: 0,
+		estimatedGrossUsd: 0,
+		usdPerUniqueDay: 0.002,
+		includedPerAccountMonth: 1000,
+	})
+})
+
+test('loadAdminUserUsageData estimates Dynamic Worker cost from unique worker-days', async () => {
+	const email = 'dw-cost@example.com'
+	const usageUserId = await createStableUserIdFromEmail(email)
+	const db = createAdminUserUsageTestDb({
+		users: [
+			{
+				id: 3,
+				username: 'dwcost',
+				email,
+				plan: 'pro',
+				stable_user_id: usageUserId,
+			},
+		],
+		usageRollups: [
+			usageRow({
+				user_id: usageUserId,
+				metric: 'dynamic_worker_day',
+				month: '2026-07',
+				event_count: 150,
+			}),
+		],
+		resourceCounts: { [usageUserId]: {} },
+	})
+
+	const data = await loadAdminUserUsageData(
+		withUserMeter({ APP_DB: db }) as Env,
+		usageUserId,
+		new Date('2026-07-05T12:00:00.000Z'),
+	)
+
+	expect(getEventCount(data?.currentMonthUsage, 'dynamic_worker_day')).toBe(150)
+	expect(data?.dynamicWorkerCost).toEqual({
+		uniqueWorkerDays: 150,
+		estimatedGrossUsd: 0.3,
+		usdPerUniqueDay: 0.002,
+		includedPerAccountMonth: 1000,
+	})
 })
 
 test('loadAdminUserUsageData warns above eighty percent of plan limits', async () => {
@@ -314,6 +359,7 @@ test('loadAdminUserUsageData warns above eighty percent of plan limits', async (
 
 	expect(data?.stableUserId).toBe(usageUserId)
 	expect(getEventCount(data?.currentMonthUsage, 'job_run')).toBe(4)
+	expect(data?.dynamicWorkerCost.uniqueWorkerDays).toBe(0)
 	expect(data?.monthUsage.map((month) => month.month)).toEqual([
 		'2026-07',
 		'2026-06',

--- a/packages/worker/src/admin/user-usage-data.ts
+++ b/packages/worker/src/admin/user-usage-data.ts
@@ -4,6 +4,7 @@ import { parseStoredPlanName, resolveEffectivePlan } from '#universal/plans.ts'
 import { readAdminEntitlementConsumption } from '#worker/admin/entitlement-consumption.ts'
 import { createKvCachifiedCache } from '#worker/kv-cachified.ts'
 import { resolveUserStableId } from '#worker/user-id.ts'
+import { toAdminDynamicWorkerCost } from '#universal/dynamic-worker-cost.ts'
 import {
 	type AdminUsageMetric,
 	type AdminUsageMonthRollup,
@@ -20,6 +21,7 @@ export const adminUsageMetrics = [
 	'outbound_fetch',
 	'email_send',
 	'email_received',
+	'dynamic_worker_day',
 ] as const satisfies ReadonlyArray<AdminUsageMetric>
 
 /**
@@ -99,6 +101,9 @@ export async function loadAdminUserUsageData(
 	const currentMonthUsage =
 		monthUsage.find((entry) => entry.month === currentMonth)?.usage ??
 		toCompleteUsage([])
+	const uniqueWorkerDays =
+		currentMonthUsage.find((row) => row.metric === 'dynamic_worker_day')
+			?.eventCount ?? 0
 
 	return {
 		ok: true,
@@ -111,6 +116,7 @@ export async function loadAdminUserUsageData(
 		monthUsage,
 		entitlementConsumption,
 		warnings: entitlementConsumption.filter((item) => item.overEightyPercent),
+		dynamicWorkerCost: toAdminDynamicWorkerCost(uniqueWorkerDays),
 	}
 }
 

--- a/packages/worker/src/app/admin-insights-data.node.test.ts
+++ b/packages/worker/src/app/admin-insights-data.node.test.ts
@@ -39,6 +39,13 @@ const fleetUsageMocks = vi.hoisted(() => ({
 		topEventCountConsumers: [],
 		topDurationConsumersByMetric: [],
 		entitlementPressure: [],
+		dynamicWorkerCost: {
+			uniqueWorkerDays: 0,
+			estimatedGrossUsd: 0,
+			usdPerUniqueDay: 0.002,
+			includedPerAccountMonth: 1000,
+			topConsumers: [],
+		},
 	})),
 	loadFleetPackageErrorRateSnapshot: vi.fn(async () => null),
 }))
@@ -512,6 +519,13 @@ test('loadAdminInsightsData assembles the dashboard payload from D1 plus RunLog 
 		usersAttempted: 2,
 		usersLoaded: 2,
 		complete: true,
+	})
+	expect(data.dynamicWorkerCost).toEqual({
+		uniqueWorkerDays: 0,
+		estimatedGrossUsd: 0,
+		usdPerUniqueDay: 0.002,
+		includedPerAccountMonth: 1000,
+		topConsumers: [],
 	})
 	expect(runLogMocks.getAdminInsightsSnapshot).toHaveBeenCalledTimes(2)
 	expect(runLogMocks.maxInFlight).toBeLessThanOrEqual(

--- a/packages/worker/src/app/admin-insights-data.ts
+++ b/packages/worker/src/app/admin-insights-data.ts
@@ -287,6 +287,7 @@ async function queryAdminInsights(
 		topEventCountConsumers: fleetUsage.topEventCountConsumers,
 		topDurationConsumersByMetric: fleetUsage.topDurationConsumersByMetric,
 		entitlementPressure: fleetUsage.entitlementPressure,
+		dynamicWorkerCost: fleetUsage.dynamicWorkerCost,
 		packageErrorRate: toInsightsPackageErrorRate(packageErrorRateSnapshot),
 	}
 }

--- a/packages/worker/src/app/usage-entitlement-alerts.node.test.ts
+++ b/packages/worker/src/app/usage-entitlement-alerts.node.test.ts
@@ -37,6 +37,7 @@ vi.mock('#worker/usage/fleet-entitlement-crossing-subscriptions.ts', () => ({
 const {
 	emitFleetEntitlementCrossingEvents,
 	fleetEntitlementCrossingKvKey,
+	fleetEntitlementHitKvKey,
 	shouldRunUsageEntitlementAlertCron,
 } = await import('#app/usage-entitlement-alerts.ts')
 
@@ -61,12 +62,14 @@ function createKv() {
 function snapshot(input: {
 	stableUserId?: string
 	username?: string
+	plan?: FleetEntitlementCrossingSnapshot['plan']
 	isAdmin?: boolean
 	resource?: FleetEntitlementCrossingSnapshot['entitlements'][number]['resource']
 	label?: string
 	current?: number
 	limit?: number
 	runtimeDurationMs?: number
+	uniqueWorkerDays?: number
 }): FleetEntitlementCrossingSnapshot {
 	const current = input.current ?? 0
 	const limit = input.limit ?? 10
@@ -74,6 +77,7 @@ function snapshot(input: {
 	return {
 		stableUserId: input.stableUserId ?? 'user-a',
 		username: input.username ?? 'alice',
+		plan: input.plan ?? 'free',
 		isAdmin: input.isAdmin ?? false,
 		entitlements: [
 			{
@@ -86,6 +90,7 @@ function snapshot(input: {
 			},
 		],
 		runtimeDurationMs: input.runtimeDurationMs ?? 0,
+		uniqueWorkerDays: input.uniqueWorkerDays ?? 0,
 	}
 }
 
@@ -384,6 +389,179 @@ test('runtime duration crossings emit once per UTC month and daily resources key
 			now: new Date('2026-08-24T19:00:00.000Z'),
 		})
 		expect(failed).toEqual({ status: 'no_new_crossings', issueCount: 1 })
+	} finally {
+		consoleWarn.mockReset()
+	}
+})
+
+test('repeated execute-cap days and unique-worker cost emit once, then rematch after a drop', async () => {
+	silenceExpectedConsoleWarns(['fleet-entitlement-crossing-emitted'])
+	dispatchFleetEntitlementCrossingSubscriptionEvent.mockResolvedValue([])
+	const { kv, store } = createKv()
+	const env = createEnv(kv)
+	const day1 = new Date('2026-08-24T12:00:00.000Z')
+	const executeSnapshot = (uniqueWorkerDays = 0) =>
+		snapshot({
+			resource: 'execute_calls_per_day',
+			label: 'execute calls per day',
+			current: 100,
+			limit: 100,
+			uniqueWorkerDays,
+			plan: 'free',
+		})
+
+	try {
+		loadFleetEntitlementCrossingSnapshots.mockResolvedValue([executeSnapshot()])
+		const firstDay = await emitFleetEntitlementCrossingEvents({
+			env,
+			now: day1,
+		})
+		expect(firstDay).toEqual({
+			status: 'emitted',
+			issueCount: 1,
+			crossingCount: 1,
+		})
+		expect(
+			store.get(
+				fleetEntitlementHitKvKey({
+					userId: 'user-a',
+					resource: 'execute_calls_per_day',
+					day: utcDayKey(day1),
+				}),
+			),
+		).toBe(String(day1.getTime()))
+
+		const day2 = new Date('2026-08-25T12:00:00.000Z')
+		loadFleetEntitlementCrossingSnapshots.mockResolvedValue([executeSnapshot()])
+		const secondDay = await emitFleetEntitlementCrossingEvents({
+			env,
+			now: day2,
+		})
+		expect(secondDay).toEqual({
+			status: 'emitted',
+			issueCount: 1,
+			crossingCount: 1,
+		})
+
+		const day3 = new Date('2026-08-26T12:00:00.000Z')
+		loadFleetEntitlementCrossingSnapshots.mockResolvedValue([
+			executeSnapshot(1000),
+		])
+		const thirdDay = await emitFleetEntitlementCrossingEvents({
+			env,
+			now: day3,
+		})
+		expect(thirdDay).toEqual({
+			status: 'emitted',
+			issueCount: 3,
+			crossingCount: 3,
+		})
+		const kinds =
+			dispatchFleetEntitlementCrossingSubscriptionEvent.mock.calls.map(
+				(call) =>
+					(call[0] as { event: FleetEntitlementCrossedEvent }).event.kind,
+			)
+		expect(kinds).toEqual([
+			'entitlement',
+			'entitlement',
+			'entitlement',
+			'repeated_entitlement',
+			'dynamic_worker_cost',
+		])
+		const repeated = dispatchFleetEntitlementCrossingSubscriptionEvent.mock
+			.calls[3]?.[0] as { event: FleetEntitlementCrossedEvent }
+		expect(repeated.event).toMatchObject({
+			kind: 'repeated_entitlement',
+			resource: 'execute_calls_per_day',
+			days_at_limit: 3,
+			window_days: 7,
+			threshold_days: 3,
+		})
+		const cost = dispatchFleetEntitlementCrossingSubscriptionEvent.mock
+			.calls[4]?.[0] as { event: FleetEntitlementCrossedEvent }
+		expect(cost.event).toMatchObject({
+			kind: 'dynamic_worker_cost',
+			unique_worker_days: 1000,
+			estimated_gross_usd: 2,
+			threshold_usd: 2,
+		})
+		expect(
+			store.get(
+				fleetEntitlementCrossingKvKey({
+					userId: 'user-a',
+					crossing: {
+						kind: 'repeated_entitlement',
+						resource: 'execute_calls_per_day',
+					},
+				}),
+			),
+		).toBe(String(day3.getTime()))
+
+		const stillOver = await emitFleetEntitlementCrossingEvents({
+			env,
+			now: new Date('2026-08-26T18:00:00.000Z'),
+		})
+		expect(stillOver).toEqual({ status: 'no_new_crossings', issueCount: 3 })
+
+		loadFleetEntitlementCrossingSnapshots.mockResolvedValue([
+			snapshot({
+				resource: 'execute_calls_per_day',
+				label: 'execute calls per day',
+				current: 10,
+				limit: 100,
+				uniqueWorkerDays: 100,
+				plan: 'free',
+			}),
+		])
+		const dropped = await emitFleetEntitlementCrossingEvents({
+			env,
+			now: new Date('2026-09-03T12:00:00.000Z'),
+		})
+		expect(dropped).toEqual({ status: 'no_pressure' })
+		expect(
+			store.get(
+				fleetEntitlementCrossingKvKey({
+					userId: 'user-a',
+					crossing: {
+						kind: 'repeated_entitlement',
+						resource: 'execute_calls_per_day',
+					},
+				}),
+			),
+		).toBeUndefined()
+	} finally {
+		consoleWarn.mockReset()
+	}
+})
+
+test('admin accounts do not page repeated-execute or unique-worker cost trains', async () => {
+	silenceExpectedConsoleWarns(['fleet-entitlement-crossing-emitted'])
+	dispatchFleetEntitlementCrossingSubscriptionEvent.mockResolvedValue([])
+	const { kv } = createKv()
+	loadFleetEntitlementCrossingSnapshots.mockResolvedValue([
+		snapshot({
+			isAdmin: true,
+			plan: 'max',
+			resource: 'execute_calls_per_day',
+			label: 'execute calls per day',
+			current: 100,
+			limit: 100,
+			uniqueWorkerDays: 50_000,
+		}),
+	])
+	try {
+		const result = await emitFleetEntitlementCrossingEvents({
+			env: createEnv(kv),
+			now: new Date('2026-08-24T12:00:00.000Z'),
+		})
+		expect(result).toEqual({
+			status: 'emitted',
+			issueCount: 1,
+			crossingCount: 1,
+		})
+		const event = dispatchFleetEntitlementCrossingSubscriptionEvent.mock
+			.calls[0]?.[0] as { event: FleetEntitlementCrossedEvent }
+		expect(event.event.kind).toBe('entitlement')
 	} finally {
 		consoleWarn.mockReset()
 	}

--- a/packages/worker/src/app/usage-entitlement-alerts.ts
+++ b/packages/worker/src/app/usage-entitlement-alerts.ts
@@ -1,13 +1,19 @@
 import { utcDayKey, utcMonthKey } from '@kody-internal/shared/date-keys.ts'
 import {
+	estimateDynamicWorkerUsd,
+	fleetDynamicWorkerCostAlertUsd,
+} from '#universal/dynamic-worker-cost.ts'
+import { type AdminUsageEntitlementResource } from '#universal/loader-data.ts'
+import {
 	fleetRuntimeDurationAlertThresholdMs,
 	loadFleetEntitlementCrossingSnapshots,
 	type FleetEntitlementCrossingSnapshot,
 } from '#worker/admin/fleet-usage-insights.ts'
 import { joinAppUrl } from '#worker/app-base-url.ts'
-import { type AdminUsageEntitlementResource } from '#universal/loader-data.ts'
 import {
+	buildFleetDynamicWorkerCostCrossedEvent,
 	buildFleetEntitlementResourceCrossedEvent,
+	buildFleetRepeatedEntitlementCrossedEvent,
 	buildFleetRuntimeDurationCrossedEvent,
 	type FleetEntitlementCrossedEvent,
 	type FleetEntitlementCrossingThreshold,
@@ -17,17 +23,42 @@ import { dispatchFleetEntitlementCrossingSubscriptionEvent } from '#worker/usage
 /**
  * Hourly fleet usage / entitlement crossing check. The admin insights page
  * surfaces the same bounded sweep; this lane emits one
- * `fleet.entitlement.crossed` event per 80% or 100% crossing (and per
- * first-over-threshold runtime-duration month) so an admin package can notify
+ * `fleet.entitlement.crossed` event per 80% or 100% crossing, per
+ * first-over-threshold runtime-duration month, per first-over-threshold
+ * unique Dynamic Worker cost month, and per first execute-cap train (three
+ * of the last seven UTC days at 100%) so an admin package can notify
  * operators. Staying over the same threshold does not emit again.
  */
 
 export const fleetEntitlementCrossingKvKeyPrefix =
 	'fleet-entitlement-crossing:v1'
+export const fleetEntitlementHitKvKeyPrefix = 'fleet-entitlement-hit:v1'
 export const fleetEntitlementCrossingDailyClaimTtlSeconds = 36 * 60 * 60
 export const fleetEntitlementCrossingStockClaimTtlSeconds = 30 * 24 * 60 * 60
 export const fleetRuntimeDurationCrossingClaimTtlSeconds = 40 * 24 * 60 * 60
+export const fleetRepeatedEntitlementCrossingClaimTtlSeconds = 8 * 24 * 60 * 60
+export const fleetDynamicWorkerCostCrossingClaimTtlSeconds =
+	fleetRuntimeDurationCrossingClaimTtlSeconds
+export const fleetEntitlementHitClaimTtlSeconds = 8 * 24 * 60 * 60
+export const fleetRepeatedEntitlementWindowDays = 7
+export const fleetRepeatedEntitlementThresholdDays = 3
+export const fleetRepeatedEntitlementResource =
+	'execute_calls_per_day' as const satisfies AdminUsageEntitlementResource
 const dailyClaimLookbackDays = 3
+
+type FleetCrossingClaim =
+	| {
+			kind: 'entitlement'
+			threshold: FleetEntitlementCrossingThreshold
+			resource: AdminUsageEntitlementResource
+			day?: string
+	  }
+	| { kind: 'runtime_duration'; month: string }
+	| {
+			kind: 'repeated_entitlement'
+			resource: AdminUsageEntitlementResource
+	  }
+	| { kind: 'dynamic_worker_cost'; month: string }
 
 type UsageEntitlementAlertEnv = {
 	APP_DB: D1Database
@@ -53,26 +84,42 @@ export function isDailyEntitlementCrossingResource(
 
 export function fleetEntitlementCrossingKvKey(input: {
 	userId: string
-	crossing:
-		| {
-				kind: 'entitlement'
-				threshold: FleetEntitlementCrossingThreshold
-				resource: AdminUsageEntitlementResource
-				day?: string
-		  }
-		| { kind: 'runtime_duration'; month: string }
+	crossing: FleetCrossingClaim
 }) {
-	if (input.crossing.kind === 'runtime_duration') {
-		return `${fleetEntitlementCrossingKvKeyPrefix}:${input.userId}:runtime_duration:${input.crossing.month}`
+	switch (input.crossing.kind) {
+		case 'runtime_duration':
+			return `${fleetEntitlementCrossingKvKeyPrefix}:${input.userId}:runtime_duration:${input.crossing.month}`
+		case 'repeated_entitlement':
+			return `${fleetEntitlementCrossingKvKeyPrefix}:${input.userId}:repeated_entitlement:${input.crossing.resource}`
+		case 'dynamic_worker_cost':
+			return `${fleetEntitlementCrossingKvKeyPrefix}:${input.userId}:dynamic_worker_cost:${input.crossing.month}`
+		case 'entitlement': {
+			const base = `${fleetEntitlementCrossingKvKeyPrefix}:${input.userId}:entitlement:${input.crossing.threshold}:${input.crossing.resource}`
+			if (!isDailyEntitlementCrossingResource(input.crossing.resource)) {
+				return base
+			}
+			if (!input.crossing.day) {
+				throw new Error(
+					`Daily fleet entitlement crossing key for ${input.crossing.resource} requires a UTC day`,
+				)
+			}
+			return `${base}:${input.crossing.day}`
+		}
+		default: {
+			const exhaustive: never = input.crossing
+			throw new Error(
+				`Unsupported fleet entitlement crossing: ${String(exhaustive)}`,
+			)
+		}
 	}
-	const base = `${fleetEntitlementCrossingKvKeyPrefix}:${input.userId}:entitlement:${input.crossing.threshold}:${input.crossing.resource}`
-	if (!isDailyEntitlementCrossingResource(input.crossing.resource)) return base
-	if (!input.crossing.day) {
-		throw new Error(
-			`Daily fleet entitlement crossing key for ${input.crossing.resource} requires a UTC day`,
-		)
-	}
-	return `${base}:${input.crossing.day}`
+}
+
+export function fleetEntitlementHitKvKey(input: {
+	userId: string
+	resource: AdminUsageEntitlementResource
+	day: string
+}) {
+	return `${fleetEntitlementHitKvKeyPrefix}:${input.userId}:${input.resource}:${input.day}`
 }
 
 export async function emitFleetEntitlementCrossingEvents(input: {
@@ -181,6 +228,17 @@ async function collectCrossingsForSnapshot(input: {
 		if (atReached || atApproaching) issueCount += 1
 
 		if (atReached) {
+			if (
+				item.resource === fleetRepeatedEntitlementResource &&
+				!input.snapshot.isAdmin
+			) {
+				await putExecuteReachedHit({
+					kv: input.kv,
+					userId: input.snapshot.stableUserId,
+					day: utcDayKey(input.now),
+					now: input.now,
+				})
+			}
 			const reached = await unclaimedOrRefresh({
 				kv: input.kv,
 				userId: input.snapshot.stableUserId,
@@ -310,20 +368,93 @@ async function collectCrossingsForSnapshot(input: {
 		})
 	}
 
+	if (!input.snapshot.isAdmin) {
+		const daysAtLimit = await countExecuteReachedHits({
+			kv: input.kv,
+			userId: input.snapshot.stableUserId,
+			now: input.now,
+		})
+		const repeatedOver = daysAtLimit >= fleetRepeatedEntitlementThresholdDays
+		if (repeatedOver) {
+			issueCount += 1
+			const repeated = await unclaimedOrRefresh({
+				kv: input.kv,
+				userId: input.snapshot.stableUserId,
+				crossing: {
+					kind: 'repeated_entitlement',
+					resource: fleetRepeatedEntitlementResource,
+				},
+				now: input.now,
+			})
+			if (repeated === 'unclaimed') {
+				pending.push(
+					buildFleetRepeatedEntitlementCrossedEvent({
+						user,
+						resource: fleetRepeatedEntitlementResource,
+						daysAtLimit,
+						windowDays: fleetRepeatedEntitlementWindowDays,
+						thresholdDays: fleetRepeatedEntitlementThresholdDays,
+						insightsUrl: input.insightsUrl,
+						usersUrl: input.usersUrl,
+						observedAt,
+					}),
+				)
+			}
+		} else {
+			await deleteCrossingClaims({
+				kv: input.kv,
+				userId: input.snapshot.stableUserId,
+				crossing: {
+					kind: 'repeated_entitlement',
+					resource: fleetRepeatedEntitlementResource,
+				},
+				now: input.now,
+			})
+		}
+
+		const thresholdUsd = fleetDynamicWorkerCostAlertUsd(input.snapshot.plan)
+		const estimatedGrossUsd = estimateDynamicWorkerUsd(
+			input.snapshot.uniqueWorkerDays,
+		)
+		const costOver = thresholdUsd != null && estimatedGrossUsd >= thresholdUsd
+		if (costOver && thresholdUsd != null) {
+			issueCount += 1
+			const cost = await unclaimedOrRefresh({
+				kv: input.kv,
+				userId: input.snapshot.stableUserId,
+				crossing: { kind: 'dynamic_worker_cost', month },
+				now: input.now,
+			})
+			if (cost === 'unclaimed') {
+				pending.push(
+					buildFleetDynamicWorkerCostCrossedEvent({
+						user,
+						uniqueWorkerDays: input.snapshot.uniqueWorkerDays,
+						estimatedGrossUsd,
+						thresholdUsd,
+						insightsUrl: input.insightsUrl,
+						usersUrl: input.usersUrl,
+						observedAt,
+					}),
+				)
+			}
+		} else {
+			await deleteCrossingClaims({
+				kv: input.kv,
+				userId: input.snapshot.stableUserId,
+				crossing: { kind: 'dynamic_worker_cost', month },
+				now: input.now,
+			})
+		}
+	}
+
 	return { issueCount, pending }
 }
 
 async function unclaimedOrRefresh(input: {
 	kv: KVNamespace
 	userId: string
-	crossing:
-		| {
-				kind: 'entitlement'
-				threshold: FleetEntitlementCrossingThreshold
-				resource: AdminUsageEntitlementResource
-				day: string
-		  }
-		| { kind: 'runtime_duration'; month: string }
+	crossing: FleetCrossingClaim
 	now: Date
 }): Promise<'unclaimed' | 'claimed'> {
 	const key = fleetEntitlementCrossingKvKey({
@@ -386,6 +517,28 @@ async function claimCrossing(input: {
 				claimedAt,
 			})
 			return
+		case 'repeated_entitlement':
+			await putCrossingClaim({
+				kv: input.kv,
+				userId: input.event.user.id,
+				crossing: {
+					kind: 'repeated_entitlement',
+					resource: input.event.resource,
+				},
+				claimedAt,
+			})
+			return
+		case 'dynamic_worker_cost':
+			await putCrossingClaim({
+				kv: input.kv,
+				userId: input.event.user.id,
+				crossing: {
+					kind: 'dynamic_worker_cost',
+					month: utcMonthKey(input.now),
+				},
+				claimedAt,
+			})
+			return
 		default: {
 			const exhaustive: never = input.event
 			throw new Error(
@@ -398,26 +551,14 @@ async function claimCrossing(input: {
 async function putCrossingClaim(input: {
 	kv: KVNamespace
 	userId: string
-	crossing:
-		| {
-				kind: 'entitlement'
-				threshold: FleetEntitlementCrossingThreshold
-				resource: AdminUsageEntitlementResource
-				day?: string
-		  }
-		| { kind: 'runtime_duration'; month: string }
+	crossing: FleetCrossingClaim
 	claimedAt: string
 }) {
 	const key = fleetEntitlementCrossingKvKey({
 		userId: input.userId,
 		crossing: input.crossing,
 	})
-	const expirationTtl =
-		input.crossing.kind === 'runtime_duration'
-			? fleetRuntimeDurationCrossingClaimTtlSeconds
-			: isDailyEntitlementCrossingResource(input.crossing.resource)
-				? fleetEntitlementCrossingDailyClaimTtlSeconds
-				: fleetEntitlementCrossingStockClaimTtlSeconds
+	const expirationTtl = crossingClaimTtlSeconds(input.crossing)
 	try {
 		await input.kv.put(key, input.claimedAt, { expirationTtl })
 	} catch (error) {
@@ -426,6 +567,67 @@ async function putCrossingClaim(input: {
 			error,
 		})
 	}
+}
+
+function crossingClaimTtlSeconds(crossing: FleetCrossingClaim) {
+	switch (crossing.kind) {
+		case 'runtime_duration':
+			return fleetRuntimeDurationCrossingClaimTtlSeconds
+		case 'dynamic_worker_cost':
+			return fleetDynamicWorkerCostCrossingClaimTtlSeconds
+		case 'repeated_entitlement':
+			return fleetRepeatedEntitlementCrossingClaimTtlSeconds
+		case 'entitlement':
+			return isDailyEntitlementCrossingResource(crossing.resource)
+				? fleetEntitlementCrossingDailyClaimTtlSeconds
+				: fleetEntitlementCrossingStockClaimTtlSeconds
+		default: {
+			const exhaustive: never = crossing
+			throw new Error(
+				`Unsupported fleet entitlement crossing: ${String(exhaustive)}`,
+			)
+		}
+	}
+}
+
+async function putExecuteReachedHit(input: {
+	kv: KVNamespace
+	userId: string
+	day: string
+	now: Date
+}) {
+	const key = fleetEntitlementHitKvKey({
+		userId: input.userId,
+		resource: fleetRepeatedEntitlementResource,
+		day: input.day,
+	})
+	try {
+		await input.kv.put(key, String(input.now.getTime()), {
+			expirationTtl: fleetEntitlementHitClaimTtlSeconds,
+		})
+	} catch (error) {
+		console.warn('fleet-entitlement-hit-claim-failed', { key, error })
+	}
+}
+
+async function countExecuteReachedHits(input: {
+	kv: KVNamespace
+	userId: string
+	now: Date
+}) {
+	const days = recentUtcDayKeys(input.now, fleetRepeatedEntitlementWindowDays)
+	const hits = await Promise.all(
+		days.map((day) =>
+			input.kv.get(
+				fleetEntitlementHitKvKey({
+					userId: input.userId,
+					resource: fleetRepeatedEntitlementResource,
+					day,
+				}),
+			),
+		),
+	)
+	return hits.filter((hit) => hit != null).length
 }
 
 async function deleteCrossingClaims(input: {
@@ -438,9 +640,18 @@ async function deleteCrossingClaims(input: {
 				resource: AdminUsageEntitlementResource
 		  }
 		| { kind: 'runtime_duration'; month: string }
+		| {
+				kind: 'repeated_entitlement'
+				resource: AdminUsageEntitlementResource
+		  }
+		| { kind: 'dynamic_worker_cost'; month: string }
 	now: Date
 }) {
-	if (input.crossing.kind === 'runtime_duration') {
+	if (
+		input.crossing.kind === 'runtime_duration' ||
+		input.crossing.kind === 'repeated_entitlement' ||
+		input.crossing.kind === 'dynamic_worker_cost'
+	) {
 		await input.kv.delete(
 			fleetEntitlementCrossingKvKey({
 				userId: input.userId,
@@ -476,9 +687,9 @@ async function deleteCrossingClaims(input: {
 	)
 }
 
-function recentUtcDayKeys(now: Date) {
+function recentUtcDayKeys(now: Date, dayCount = dailyClaimLookbackDays) {
 	const keys: Array<string> = []
-	for (let daysAgo = 0; daysAgo < dailyClaimLookbackDays; daysAgo += 1) {
+	for (let daysAgo = 0; daysAgo < dayCount; daysAgo += 1) {
 		keys.push(
 			utcDayKey(new Date(now.getTime() - daysAgo * 24 * 60 * 60 * 1000)),
 		)

--- a/packages/worker/src/entitlements/user-meter-do.ts
+++ b/packages/worker/src/entitlements/user-meter-do.ts
@@ -32,7 +32,7 @@ export const userMeterDailyCounterRetentionDays = 7
 
 const metaSchemaVersionKey = 'schema_version'
 /** Bump when initializeSchema DDL changes; warm objects skip DDL. */
-const userMeterSchemaVersion = 10
+const userMeterSchemaVersion = 11
 /** Singleton row id for authoritative storage-byte state (schema v4). */
 const storageBytesStateRowId = 1
 /** Singleton row id for deletion fence / write leases (schema v6+). */
@@ -40,6 +40,7 @@ const deletionStateRowId = 1
 const defaultExportPageSize = 100
 const maxExportPageSize = 500
 const maxInboundDeliveryIdLength = 256
+const maxDynamicWorkerIdLength = 128
 const maxWriteLeaseTokenLength = 64
 const maxWriteLeaseHolderLength = 256
 const maxWriteLeaseRepairIdLength = 64
@@ -284,6 +285,19 @@ function assertInboundDeliveryId(deliveryId: string): string {
 		)
 	}
 	return deliveryId
+}
+
+function assertDynamicWorkerId(workerId: string): string {
+	if (
+		typeof workerId !== 'string' ||
+		workerId.length === 0 ||
+		workerId.length > maxDynamicWorkerIdLength
+	) {
+		throw new Error(
+			`UserMeter dynamic worker id must be a non-empty string up to ${maxDynamicWorkerIdLength} characters.`,
+		)
+	}
+	return workerId
 }
 
 function assertDeletionTimestamp(label: string, value: string): string {
@@ -557,6 +571,18 @@ class UserMeterBase extends DurableObject<Env> {
 			`CREATE INDEX IF NOT EXISTS idx_account_write_leases_acquired_token
 			ON account_write_leases (acquired_at, token)`,
 		)
+		// Unique Dynamic Worker ids per UTC day (schema v11). Used to emit
+		// one `dynamic_worker_day` usage event per (user, worker, day) so
+		// Cloudflare unique-worker billing can be attributed without
+		// exporting the hashed worker ids.
+		this.ctx.storage.sql.exec(`
+			CREATE TABLE IF NOT EXISTS dynamic_worker_days (
+				worker_id TEXT NOT NULL,
+				day TEXT NOT NULL,
+				created_at TEXT NOT NULL,
+				PRIMARY KEY (day, worker_id)
+			)
+		`)
 		this.ctx.storage.sql.exec(
 			`INSERT INTO user_meter_meta (key, value) VALUES (?, ?)
 			ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
@@ -608,6 +634,10 @@ class UserMeterBase extends DurableObject<Env> {
 		)
 		this.ctx.storage.sql.exec(
 			`DELETE FROM inbound_delivery_claims WHERE day < ?`,
+			cutoffDay,
+		)
+		this.ctx.storage.sql.exec(
+			`DELETE FROM dynamic_worker_days WHERE day < ?`,
 			cutoffDay,
 		)
 	}
@@ -852,6 +882,31 @@ class UserMeterBase extends DurableObject<Env> {
 			day,
 			resource,
 		}
+	}
+
+	/**
+	 * Claim one unique Dynamic Worker id for a UTC day. First insert wins;
+	 * later claims for the same `(day, worker_id)` return `created: false`.
+	 * Used only for cost attribution — not an entitlement cap.
+	 */
+	async claimDynamicWorkerDay(input: {
+		workerId: string
+		day: string
+		createdAt: string
+	}): Promise<{ created: boolean }> {
+		const workerId = assertDynamicWorkerId(input.workerId)
+		const day = assertUtcDayKey(input.day)
+		const now = new Date(input.createdAt)
+		this.deleteStaleCounters(Number.isNaN(now.valueOf()) ? new Date() : now)
+		const cursor = this.ctx.storage.sql.exec(
+			`INSERT INTO dynamic_worker_days (worker_id, day, created_at)
+			VALUES (?, ?, ?)
+			ON CONFLICT(day, worker_id) DO NOTHING`,
+			workerId,
+			day,
+			input.createdAt,
+		)
+		return { created: cursor.rowsWritten > 0 }
 	}
 
 	/** Decrement one unit (floors at zero); missing keys stay uninitialized. */
@@ -1574,6 +1629,12 @@ export type UserMeterRpc = DurableObjectPitrRpc & {
 		day: string
 		updatedAt: string
 	}) => Promise<UserMeterRefundResult>
+	/** First-seen unique Dynamic Worker id for a UTC day. */
+	claimDynamicWorkerDay: (input: {
+		workerId: string
+		day: string
+		createdAt: string
+	}) => Promise<{ created: boolean }>
 	/** Cold initialize authoritative state from a caller-provided physical byte count. */
 	initializeStorageBytes: (input: {
 		bytes: number

--- a/packages/worker/src/entitlements/user-meter.workers.test.ts
+++ b/packages/worker/src/entitlements/user-meter.workers.test.ts
@@ -56,8 +56,8 @@ function accountWriteLeaseColumnNames(state: DurableObjectState) {
 		.map((row) => String(row.name))
 }
 
-test('fresh UserMeter schema v10 creates the final write-lease shape', async () => {
-	const user = await seedFreeUser('meter-schema-v10-fresh')
+test('fresh UserMeter schema v11 creates write-lease and unique worker-day tables', async () => {
+	const user = await seedFreeUser('meter-schema-v11-fresh')
 	const stub = env.USER_METER.get(
 		env.USER_METER.idFromName(userMeterDurableObjectName(user.userId)),
 	)
@@ -69,17 +69,25 @@ test('fresh UserMeter schema v10 creates the final write-lease shape', async () 
 				WHERE key = 'schema_version' LIMIT 1`,
 			)
 			.toArray()[0]
-		expect(Number(version?.value)).toBe(10)
+		expect(Number(version?.value)).toBe(11)
 		expect(accountWriteLeaseColumnNames(state)).toEqual([
 			'token',
 			'holder',
 			'acquired_at',
 			'pending_repair_id',
 		])
+		expect(
+			state.storage.sql
+				.exec<{ name: string }>(
+					`SELECT name FROM sqlite_master
+					WHERE type = 'table' AND name = 'dynamic_worker_days'`,
+				)
+				.toArray(),
+		).toEqual([{ name: 'dynamic_worker_days' }])
 	})
 }, 30_000)
 
-test('warm UserMeter schema v7 upgrades to v10 and preserves leases', async () => {
+test('warm UserMeter schema v7 upgrades to v11 and preserves leases', async () => {
 	const user = await seedFreeUser('meter-schema-v7-upgrade')
 	const stub = env.USER_METER.get(
 		env.USER_METER.idFromName(userMeterDurableObjectName(user.userId)),
@@ -130,7 +138,7 @@ test('warm UserMeter schema v7 upgrades to v10 and preserves leases', async () =
 				WHERE key = 'schema_version' LIMIT 1`,
 			)
 			.toArray()[0]
-		expect(Number(version?.value)).toBe(10)
+		expect(Number(version?.value)).toBe(11)
 		expect(accountWriteLeaseColumnNames(state)).toEqual([
 			'token',
 			'holder',
@@ -175,6 +183,71 @@ test('warm UserMeter schema v7 upgrades to v10 and preserves leases', async () =
 			)
 			.toArray()
 		expect(packageServiceTables).toEqual([])
+		expect(
+			state.storage.sql
+				.exec<{ name: string }>(
+					`SELECT name FROM sqlite_master
+					WHERE type = 'table' AND name = 'dynamic_worker_days'`,
+				)
+				.toArray(),
+		).toEqual([{ name: 'dynamic_worker_days' }])
+	})
+}, 30_000)
+
+test('UserMeter claimDynamicWorkerDay is first-seen per worker and day', async () => {
+	const user = await seedFreeUser('meter-dw-day-claim')
+	const meter = userMeterRpc({ env, userId: user.userId })
+	const day = utcDayKey(new Date())
+	const createdAt = new Date().toISOString()
+
+	expect(
+		await meter.claimDynamicWorkerDay({
+			workerId: 'kody-worker-a',
+			day,
+			createdAt,
+		}),
+	).toEqual({ created: true })
+	expect(
+		await meter.claimDynamicWorkerDay({
+			workerId: 'kody-worker-a',
+			day,
+			createdAt,
+		}),
+	).toEqual({ created: false })
+	expect(
+		await meter.claimDynamicWorkerDay({
+			workerId: 'kody-worker-b',
+			day,
+			createdAt,
+		}),
+	).toEqual({ created: true })
+}, 30_000)
+
+test('UserMeter prunes stale unique worker-day claims with daily counters', async () => {
+	const user = await seedFreeUser('meter-dw-day-prune')
+	const stub = env.USER_METER.get(
+		env.USER_METER.idFromName(userMeterDurableObjectName(user.userId)),
+	)
+	const staleDay = '2020-01-01'
+	const today = utcDayKey(new Date())
+	await stub.claimDynamicWorkerDay({
+		workerId: 'kody-stale',
+		day: staleDay,
+		createdAt: `${staleDay}T00:00:00.000Z`,
+	})
+	await stub.claimDynamicWorkerDay({
+		workerId: 'kody-fresh',
+		day: today,
+		createdAt: new Date().toISOString(),
+	})
+
+	await runInDurableObject(stub, async (_instance: UserMeter, state) => {
+		const rows = state.storage.sql
+			.exec<{ worker_id: string; day: string }>(
+				`SELECT worker_id, day FROM dynamic_worker_days ORDER BY worker_id`,
+			)
+			.toArray()
+		expect(rows).toEqual([{ worker_id: 'kody-fresh', day: today }])
 	})
 }, 30_000)
 

--- a/packages/worker/src/mcp/capabilities/admin/admin-user-usage.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-user-usage.ts
@@ -19,6 +19,7 @@ const usageMetricSchema = z.enum([
 	'outbound_fetch',
 	'email_send',
 	'email_received',
+	'dynamic_worker_day',
 ])
 
 const entitlementResourceSchema = z.enum([
@@ -90,6 +91,12 @@ const outputSchema = z.object({
 			),
 			entitlementConsumption: z.array(entitlementConsumptionSchema),
 			warnings: z.array(entitlementConsumptionSchema),
+			dynamicWorkerCost: z.object({
+				uniqueWorkerDays: z.number().int().nonnegative(),
+				estimatedGrossUsd: z.number().nonnegative(),
+				usdPerUniqueDay: z.number().nonnegative(),
+				includedPerAccountMonth: z.number().int().nonnegative(),
+			}),
 		})
 		.nullable(),
 })
@@ -100,8 +107,16 @@ export const adminUserUsageCapability = defineDomainCapability(
 		...adminCapabilityAccess,
 		name: 'admin_user_usage',
 		description:
-			'Read usage rollups, entitlement counters, and plan-limit consumption for one user account by stable user id, email, or username. Admin-only; never returns user content.',
-		keywords: ['admin', 'usage', 'quotas', 'entitlements', 'plans', 'metering'],
+			'Read usage rollups, entitlement counters, plan-limit consumption, and estimated Cloudflare Dynamic Worker cost for one user account by stable user id, email, or username. Admin-only; never returns user content.',
+		keywords: [
+			'admin',
+			'usage',
+			'quotas',
+			'entitlements',
+			'plans',
+			'metering',
+			'cost',
+		],
 		inputSchema,
 		outputSchema,
 		async handler(args, ctx) {

--- a/packages/worker/src/mcp/executor.node.test.ts
+++ b/packages/worker/src/mcp/executor.node.test.ts
@@ -1245,6 +1245,21 @@ test('createExecuteExecutor records one usage event per sandbox run with duratio
 	expect(validationResult.error).toContain('reserved')
 	expect(dataPoints).toHaveLength(3)
 	expect(rollupWrites).toHaveLength(0)
+
+	// Nested surfaces (jobs, package exports) opt out so they do not inflate
+	// the execute-tool metric or stamp first_execute_at.
+	const skippedLoader = createFakeWorkerLoader()
+	await createExecuteExecutor({
+		env: {
+			...createExecutorTestEnv(skippedLoader.loader),
+			...usageBindings,
+		} as Env,
+		exports,
+		gatewayProps: createGatewayProps('usage-user-1'),
+		recordExecuteUsage: false,
+	}).execute('async () => "ok"', providers)
+	expect(dataPoints).toHaveLength(3)
+	expect(activationStampWrites).toHaveLength(1)
 })
 
 test('createExecuteExecutor rejects reserved JavaScript provider names before loading a worker', async () => {

--- a/packages/worker/src/mcp/executor.node.test.ts
+++ b/packages/worker/src/mcp/executor.node.test.ts
@@ -31,6 +31,7 @@ import {
 import { assertGeneratedExecutorSourceIsBundleSafe } from './kody-remote-proxy-source.ts'
 import { createDynamicWorkerCompatibilityOptions } from '#worker/dynamic-worker-compatibility.ts'
 import { createEvaluationSideEffectTracker } from '#mcp/evaluation-side-effects.ts'
+import { createInMemoryUserMeterEnv } from '#worker/test-support/user-meter.ts'
 
 type FakeWorkerOptions = Record<string, unknown>
 
@@ -1260,6 +1261,49 @@ test('createExecuteExecutor records one usage event per sandbox run with duratio
 	}).execute('async () => "ok"', providers)
 	expect(dataPoints).toHaveLength(3)
 	expect(activationStampWrites).toHaveLength(1)
+})
+
+test('createExecuteExecutor records one unique Dynamic Worker day per worker id', async () => {
+	const dataPoints: Array<AnalyticsEngineDataPoint> = []
+	const meter = createInMemoryUserMeterEnv()
+	const usageBindings = {
+		...meter.env,
+		USAGE_EVENTS: {
+			writeDataPoint(point?: AnalyticsEngineDataPoint) {
+				if (point) dataPoints.push(point)
+			},
+		},
+	}
+	const exports = createExecutorTestExports()
+	const providers = [{ name: 'kody', fns: {} }]
+	const firstLoader = createFakeWorkerLoader()
+	await createExecuteExecutor({
+		env: {
+			...createExecutorTestEnv(firstLoader.loader),
+			...usageBindings,
+		} as Env,
+		exports,
+		gatewayProps: createGatewayProps('usage-user-dw'),
+		recordExecuteUsage: false,
+	}).execute('async () => "ok"', providers)
+
+	expect(dataPoints.map((point) => point.blobs?.[1])).toEqual([
+		'dynamic_worker_day',
+	])
+	expect(dataPoints[0]?.indexes).toEqual(['usage-user-dw'])
+
+	const secondLoader = createFakeWorkerLoader()
+	await createExecuteExecutor({
+		env: {
+			...createExecutorTestEnv(secondLoader.loader),
+			...usageBindings,
+		} as Env,
+		exports,
+		gatewayProps: createGatewayProps('usage-user-dw'),
+		recordExecuteUsage: false,
+	}).execute('async () => "ok"', providers)
+
+	expect(dataPoints).toHaveLength(1)
 })
 
 test('createExecuteExecutor rejects reserved JavaScript provider names before loading a worker', async () => {

--- a/packages/worker/src/mcp/executor.ts
+++ b/packages/worker/src/mcp/executor.ts
@@ -149,6 +149,12 @@ type DynamicWorkerExecutorInput = {
 	appCommitSha?: string | null
 	usageEnv: UsageEnv
 	rawFetchHostSink?: RawFetchHostSink
+	/**
+	 * When false, skip the `execute` usage event. Job, package-export, and
+	 * other nested surfaces record their own metrics; only MCP execute-tool
+	 * runs (and ad-hoc executor callers) should emit `execute`.
+	 */
+	recordExecuteUsage?: boolean
 }
 
 type DynamicWorkerExecutorOptions = {
@@ -582,6 +588,12 @@ export function createExecuteExecutor(input: {
 	 * so saved-package outbound requests are not counted.
 	 */
 	rawFetchHostSink?: RawFetchHostSink
+	/**
+	 * When false, skip the `execute` usage event. Nested surfaces (jobs,
+	 * package exports, workflows) already record their own metrics.
+	 * Defaults to true for ad-hoc executor callers.
+	 */
+	recordExecuteUsage?: boolean
 }) {
 	const loopbackExports = input.exports ?? workerExports
 	if (!loopbackExports?.KodyFetchGateway) {
@@ -609,6 +621,7 @@ export function createExecuteExecutor(input: {
 		appCommitSha: input.env.APP_COMMIT_SHA ?? null,
 		usageEnv: input.env,
 		rawFetchHostSink: input.rawFetchHostSink,
+		recordExecuteUsage: input.recordExecuteUsage,
 	})
 }
 
@@ -747,7 +760,7 @@ function createStableDynamicWorkerExecutor(input: DynamicWorkerExecutorInput) {
 				throw error
 			} finally {
 				executionState.active = false
-				if (input.gatewayProps.userId) {
+				if (input.recordExecuteUsage !== false && input.gatewayProps.userId) {
 					await recordUsage(input.usageEnv, {
 						userId: input.gatewayProps.userId,
 						eventType: 'execute',

--- a/packages/worker/src/mcp/executor.ts
+++ b/packages/worker/src/mcp/executor.ts
@@ -24,6 +24,8 @@ import {
 } from '#mcp/raw-fetch-host-nudge.ts'
 import { extractMcpPassthrough } from '#mcp/downstream-mcp-result.ts'
 import { recordUsage, type UsageEnv } from '#worker/usage/record-usage.ts'
+import { recordUniqueDynamicWorkerDay } from '#worker/usage/dynamic-worker-day.ts'
+import { type UserMeterEnv } from '#worker/entitlements/user-meter-client.ts'
 import { type WorkerLoaderModules } from '#worker/worker-loader-types.ts'
 import {
 	isSecretAuthRequiredMessage,
@@ -147,7 +149,7 @@ type DynamicWorkerExecutorInput = {
 	modules?: WorkerLoaderModules
 	gatewayProps: FetchGatewayProps
 	appCommitSha?: string | null
-	usageEnv: UsageEnv
+	usageEnv: UsageEnv & UserMeterEnv
 	rawFetchHostSink?: RawFetchHostSink
 	/**
 	 * When false, skip the `execute` usage event. Job, package-export, and
@@ -665,6 +667,11 @@ function createStableDynamicWorkerExecutor(input: DynamicWorkerExecutorInput) {
 				gatewayProps: input.gatewayProps,
 				timeoutMs: input.timeout,
 				workerOptions,
+			})
+			await recordUniqueDynamicWorkerDay({
+				env: input.usageEnv,
+				userId: input.gatewayProps.userId,
+				workerId,
 			})
 			const executionState = { active: true }
 			const startedAtMs = Date.now()

--- a/packages/worker/src/mcp/run-kody-registry-bundled.node.test.ts
+++ b/packages/worker/src/mcp/run-kody-registry-bundled.node.test.ts
@@ -459,6 +459,11 @@ test('runBundledModuleWithRegistry records package_export usage for bundled runs
 			},
 		)
 		expect(successResult.result).toBe('ok')
+		expect(createExecuteExecutorSpy).toHaveBeenCalledWith(
+			expect.objectContaining({
+				recordExecuteUsage: false,
+			}),
+		)
 		expect(recordUsageSpy).toHaveBeenCalledTimes(1)
 		expect(recordUsageSpy).toHaveBeenCalledWith(
 			env,

--- a/packages/worker/src/mcp/run-kody-registry.ts
+++ b/packages/worker/src/mcp/run-kody-registry.ts
@@ -66,6 +66,7 @@ import {
 	type RunRecordContext,
 	type RunRecordHandle,
 } from '#worker/run-records/types.ts'
+import { shouldRecordExecuteUsageForRun } from '#worker/usage/execute-usage-surface.ts'
 import { createDynamicCallableWorkflow } from '#worker/package-runtime/package-workflows.ts'
 import { type BundleArtifactDependency } from '#worker/package-runtime/published-runtime-artifacts.ts'
 import { recordUsage } from '#worker/usage/record-usage.ts'
@@ -859,6 +860,10 @@ export async function runBundledModuleWithRegistry(
 			rawFetchHostSink: options?.packageContext
 				? undefined
 				: options?.rawFetchHostSink,
+			recordExecuteUsage: shouldRecordExecuteUsageForRun({
+				surface: options?.runRecord?.surface,
+				hasPackageContext: Boolean(options?.packageContext),
+			}),
 		})
 		const workflowTools =
 			options?.workflowTools ??

--- a/packages/worker/src/package-runtime/package-workflows-runs.node.test.ts
+++ b/packages/worker/src/package-runtime/package-workflows-runs.node.test.ts
@@ -1008,6 +1008,7 @@ test('DynamicCallableWorkflowBase records workflow_run usage on terminal transit
 	}
 
 	recordUsageSpy.mockClear()
+	runRecordMocks.resetProjections()
 	const failedBinding = createStatefulWorkflowBinding()
 	const failedDb = createWorkflowRunsDatabase()
 	const failedEnv = {
@@ -1142,6 +1143,7 @@ test('workflow_run usage is recorded once across replays and never on failed ter
 		// write fails must not be recorded as usage (and is not recorded at all
 		// until the terminal transition succeeds on a later replay).
 		recordUsageSpy.mockClear()
+		runRecordMocks.resetProjections()
 		const statusFailureDb = createWorkflowRunsDatabase()
 		const statusFailureEnv = {
 			APP_DB: statusFailureDb,

--- a/packages/worker/src/test-support/user-meter.ts
+++ b/packages/worker/src/test-support/user-meter.ts
@@ -29,6 +29,7 @@ export function createInMemoryUserMeterEnv() {
 	const metersByUser = new Map<string, Map<string, MeterRow>>()
 	const storageByUser = new Map<string, StorageRow>()
 	const deletionByUser = new Map<string, DeletionState>()
+	const dynamicWorkerDaysByUser = new Map<string, Set<string>>()
 	function counterKey(resource: string, day: string) {
 		return `${resource}\0${day}`
 	}
@@ -50,6 +51,11 @@ export function createInMemoryUserMeterEnv() {
 		if (!existingRows) metersByUser.set(userId, rows)
 
 		const deletion = deletionStateFor(userId)
+		const existingDynamicWorkerDays = dynamicWorkerDaysByUser.get(userId)
+		const dynamicWorkerDays = existingDynamicWorkerDays ?? new Set<string>()
+		if (!existingDynamicWorkerDays) {
+			dynamicWorkerDaysByUser.set(userId, dynamicWorkerDays)
+		}
 
 		function readRow(resource: string, day: string) {
 			return rows.get(counterKey(resource, day)) ?? null
@@ -194,6 +200,16 @@ export function createInMemoryUserMeterEnv() {
 				const existing = readRow(input.resource, input.day)
 				if (!existing) return { outcome: 'needs_bootstrap' as const }
 				return ready(existing)
+			},
+			async claimDynamicWorkerDay(input: {
+				workerId: string
+				day: string
+				createdAt: string
+			}) {
+				const key = `${input.day}\0${input.workerId}`
+				if (dynamicWorkerDays.has(key)) return { created: false }
+				dynamicWorkerDays.add(key)
+				return { created: true }
 			},
 			async refund(input: {
 				resource: string

--- a/packages/worker/src/usage/dynamic-worker-day.node.test.ts
+++ b/packages/worker/src/usage/dynamic-worker-day.node.test.ts
@@ -1,0 +1,96 @@
+import { expect, test, vi } from 'vitest'
+import { consoleWarn } from '#worker/test-support/console-spies.ts'
+import { createInMemoryUserMeterEnv } from '#worker/test-support/user-meter.ts'
+import { recordUniqueDynamicWorkerDay } from './dynamic-worker-day.ts'
+
+test('recordUniqueDynamicWorkerDay records the first claim and skips repeats', async () => {
+	const usageModule = await import('#worker/usage/record-usage.ts')
+	const recordUsageSpy = vi
+		.spyOn(usageModule, 'recordUsage')
+		.mockResolvedValue(undefined)
+	const meter = createInMemoryUserMeterEnv()
+	const now = new Date('2026-09-01T12:00:00.000Z')
+
+	await recordUniqueDynamicWorkerDay({
+		env: meter.env,
+		userId: 'user-1',
+		workerId: 'kody-worker-a',
+		now,
+	})
+	await recordUniqueDynamicWorkerDay({
+		env: meter.env,
+		userId: 'user-1',
+		workerId: 'kody-worker-a',
+		now,
+	})
+	await recordUniqueDynamicWorkerDay({
+		env: meter.env,
+		userId: 'user-1',
+		workerId: 'kody-worker-b',
+		now,
+	})
+
+	expect(recordUsageSpy).toHaveBeenCalledTimes(2)
+	expect(recordUsageSpy.mock.calls[0]?.[1]).toEqual({
+		userId: 'user-1',
+		eventType: 'dynamic_worker_day',
+		entityId: 'kody-worker-a',
+		outcome: 'success',
+	})
+	expect(recordUsageSpy.mock.calls[1]?.[1]).toEqual({
+		userId: 'user-1',
+		eventType: 'dynamic_worker_day',
+		entityId: 'kody-worker-b',
+		outcome: 'success',
+	})
+	recordUsageSpy.mockRestore()
+})
+
+test('recordUniqueDynamicWorkerDay skips when USER_METER is missing', async () => {
+	const usageModule = await import('#worker/usage/record-usage.ts')
+	const spy = vi.spyOn(usageModule, 'recordUsage').mockResolvedValue(undefined)
+
+	await recordUniqueDynamicWorkerDay({
+		env: {},
+		userId: 'user-1',
+		workerId: 'kody-worker-a',
+		now: new Date('2026-09-01T12:00:00.000Z'),
+	})
+
+	expect(spy).not.toHaveBeenCalled()
+	spy.mockRestore()
+})
+
+test('recordUniqueDynamicWorkerDay skips anonymous runs and never throws', async () => {
+	const usageModule = await import('#worker/usage/record-usage.ts')
+	const spy = vi.spyOn(usageModule, 'recordUsage').mockResolvedValue(undefined)
+	const meter = createInMemoryUserMeterEnv()
+	consoleWarn.mockImplementation(() => {})
+
+	await recordUniqueDynamicWorkerDay({
+		env: meter.env,
+		userId: null,
+		workerId: 'kody-worker-a',
+	})
+	await recordUniqueDynamicWorkerDay({
+		env: {
+			USER_METER: {
+				idFromName() {
+					throw new Error('meter exploded')
+				},
+				get() {
+					throw new Error('meter exploded')
+				},
+			} as unknown as DurableObjectNamespace,
+		},
+		userId: 'user-1',
+		workerId: 'kody-worker-a',
+	})
+
+	expect(spy).not.toHaveBeenCalled()
+	expect(consoleWarn).toHaveBeenCalledWith(
+		'dynamic-worker-day-record-failed',
+		expect.any(Error),
+	)
+	spy.mockRestore()
+})

--- a/packages/worker/src/usage/dynamic-worker-day.node.test.ts
+++ b/packages/worker/src/usage/dynamic-worker-day.node.test.ts
@@ -36,12 +36,14 @@ test('recordUniqueDynamicWorkerDay records the first claim and skips repeats', a
 		eventType: 'dynamic_worker_day',
 		entityId: 'kody-worker-a',
 		outcome: 'success',
+		timestamp: now.toISOString(),
 	})
 	expect(recordUsageSpy.mock.calls[1]?.[1]).toEqual({
 		userId: 'user-1',
 		eventType: 'dynamic_worker_day',
 		entityId: 'kody-worker-b',
 		outcome: 'success',
+		timestamp: now.toISOString(),
 	})
 	recordUsageSpy.mockRestore()
 })

--- a/packages/worker/src/usage/dynamic-worker-day.ts
+++ b/packages/worker/src/usage/dynamic-worker-day.ts
@@ -1,0 +1,47 @@
+import { utcDayKey } from '@kody-internal/shared/date-keys.ts'
+import {
+	userMeterNamespace,
+	userMeterRpc,
+	type UserMeterEnv,
+} from '#worker/entitlements/user-meter-client.ts'
+import { recordUsage, type UsageEnv } from '#worker/usage/record-usage.ts'
+
+export type DynamicWorkerDayEnv = UsageEnv & UserMeterEnv
+
+/**
+ * Record one `dynamic_worker_day` when this user first uses `workerId` on
+ * the current UTC day. Cloudflare bills unique Dynamic Worker ids per UTC
+ * day, so repeats of the same id must not increment the usage metric.
+ *
+ * Never throws. Missing `USER_METER` skips the write so local/tests without
+ * the binding cannot overcount unique days.
+ */
+export async function recordUniqueDynamicWorkerDay(input: {
+	env: DynamicWorkerDayEnv
+	userId: string | null | undefined
+	workerId: string
+	now?: Date
+}): Promise<void> {
+	try {
+		if (!input.userId) return
+		if (!userMeterNamespace(input.env)) return
+		const now = input.now ?? new Date()
+		const claimed = await userMeterRpc({
+			env: input.env,
+			userId: input.userId,
+		}).claimDynamicWorkerDay({
+			workerId: input.workerId,
+			day: utcDayKey(now),
+			createdAt: now.toISOString(),
+		})
+		if (!claimed.created) return
+		await recordUsage(input.env, {
+			userId: input.userId,
+			eventType: 'dynamic_worker_day',
+			entityId: input.workerId,
+			outcome: 'success',
+		})
+	} catch (error) {
+		console.warn('dynamic-worker-day-record-failed', error)
+	}
+}

--- a/packages/worker/src/usage/dynamic-worker-day.ts
+++ b/packages/worker/src/usage/dynamic-worker-day.ts
@@ -40,6 +40,7 @@ export async function recordUniqueDynamicWorkerDay(input: {
 			eventType: 'dynamic_worker_day',
 			entityId: input.workerId,
 			outcome: 'success',
+			timestamp: now.toISOString(),
 		})
 	} catch (error) {
 		console.warn('dynamic-worker-day-record-failed', error)

--- a/packages/worker/src/usage/execute-usage-surface.node.test.ts
+++ b/packages/worker/src/usage/execute-usage-surface.node.test.ts
@@ -1,0 +1,49 @@
+import { expect, test } from 'vitest'
+import { runSurfaceValues } from '#worker/run-records/types.ts'
+import { shouldRecordExecuteUsageForRun } from './execute-usage-surface.ts'
+
+test('only MCP execute-tool runs record the execute usage metric', () => {
+	expect(
+		shouldRecordExecuteUsageForRun({
+			surface: 'execute',
+			hasPackageContext: false,
+		}),
+	).toBe(true)
+	expect(
+		shouldRecordExecuteUsageForRun({
+			surface: 'execute',
+			hasPackageContext: true,
+		}),
+	).toBe(true)
+
+	const nestedSurfaces = runSurfaceValues.filter(
+		(surface) => surface !== 'execute',
+	)
+	for (const surface of nestedSurfaces) {
+		expect(
+			shouldRecordExecuteUsageForRun({
+				surface,
+				hasPackageContext: false,
+			}),
+		).toBe(false)
+		expect(
+			shouldRecordExecuteUsageForRun({
+				surface,
+				hasPackageContext: true,
+			}),
+		).toBe(false)
+	}
+
+	expect(
+		shouldRecordExecuteUsageForRun({
+			surface: null,
+			hasPackageContext: false,
+		}),
+	).toBe(true)
+	expect(
+		shouldRecordExecuteUsageForRun({
+			surface: undefined,
+			hasPackageContext: true,
+		}),
+	).toBe(false)
+})

--- a/packages/worker/src/usage/execute-usage-surface.ts
+++ b/packages/worker/src/usage/execute-usage-surface.ts
@@ -1,0 +1,35 @@
+import { type RunSurface } from '#worker/run-records/types.ts'
+
+/**
+ * Whether a bundled sandbox run should emit the `execute` usage metric.
+ *
+ * `execute` is MCP execute-tool sandbox work only — the same unit as
+ * `execute_calls_per_day`. Job, package-export, workflow, and other
+ * surfaces already record their own event types; they must not also
+ * inflate `execute` or stamp `first_execute_at`.
+ */
+export function shouldRecordExecuteUsageForRun(input: {
+	surface: RunSurface | null | undefined
+	hasPackageContext: boolean
+}): boolean {
+	if (input.surface) {
+		switch (input.surface) {
+			case 'execute':
+				return true
+			case 'export':
+			case 'subscription':
+			case 'app_fetch':
+			case 'app_realtime':
+			case 'job':
+			case 'workflow':
+			case 'retriever':
+			case 'webhook':
+				return false
+			default: {
+				const exhaustive: never = input.surface
+				throw new Error(`Unhandled run surface: ${String(exhaustive)}`)
+			}
+		}
+	}
+	return !input.hasPackageContext
+}

--- a/packages/worker/src/usage/fleet-entitlement-crossing-subscription-event.node.test.ts
+++ b/packages/worker/src/usage/fleet-entitlement-crossing-subscription-event.node.test.ts
@@ -1,7 +1,9 @@
 import { expect, test } from 'vitest'
 import {
+	buildFleetDynamicWorkerCostCrossedEvent,
 	buildFleetEntitlementCrossingIdempotencyKey,
 	buildFleetEntitlementResourceCrossedEvent,
+	buildFleetRepeatedEntitlementCrossedEvent,
 	buildFleetRuntimeDurationCrossedEvent,
 	fleetEntitlementCrossedTopic,
 	isFleetEntitlementCrossingEventTopic,
@@ -90,5 +92,43 @@ test('fleet entitlement crossing builders keep a metadata-only operator snapshot
 		}),
 	).toBe(
 		'fleet-entitlement-crossing:fleet.entitlement.crossed:user-1:entitlement:reached:execute_calls_per_day:2026-08-24:package-1',
+	)
+
+	const repeated = buildFleetRepeatedEntitlementCrossedEvent({
+		user: entitlement.user,
+		resource: 'execute_calls_per_day',
+		daysAtLimit: 3,
+		windowDays: 7,
+		thresholdDays: 3,
+		insightsUrl: entitlement.insights_url,
+		usersUrl: entitlement.users_url,
+		observedAt: entitlement.observed_at,
+	})
+	const cost = buildFleetDynamicWorkerCostCrossedEvent({
+		user: entitlement.user,
+		uniqueWorkerDays: 1000,
+		estimatedGrossUsd: 2,
+		thresholdUsd: 2,
+		insightsUrl: entitlement.insights_url,
+		usersUrl: entitlement.users_url,
+		observedAt: entitlement.observed_at,
+	})
+	expect(repeated.kind).toBe('repeated_entitlement')
+	expect(cost.kind).toBe('dynamic_worker_cost')
+	expect(
+		buildFleetEntitlementCrossingIdempotencyKey({
+			event: repeated,
+			packageId: 'package-1',
+		}),
+	).toBe(
+		'fleet-entitlement-crossing:fleet.entitlement.crossed:user-1:repeated_entitlement:execute_calls_per_day:package-1',
+	)
+	expect(
+		buildFleetEntitlementCrossingIdempotencyKey({
+			event: cost,
+			packageId: 'package-1',
+		}),
+	).toBe(
+		'fleet-entitlement-crossing:fleet.entitlement.crossed:user-1:dynamic_worker_cost:2026-08:package-1',
 	)
 })

--- a/packages/worker/src/usage/fleet-entitlement-crossing-subscription-event.node.test.ts
+++ b/packages/worker/src/usage/fleet-entitlement-crossing-subscription-event.node.test.ts
@@ -121,7 +121,7 @@ test('fleet entitlement crossing builders keep a metadata-only operator snapshot
 			packageId: 'package-1',
 		}),
 	).toBe(
-		'fleet-entitlement-crossing:fleet.entitlement.crossed:user-1:repeated_entitlement:execute_calls_per_day:package-1',
+		'fleet-entitlement-crossing:fleet.entitlement.crossed:user-1:repeated_entitlement:execute_calls_per_day:2026-08-24:package-1',
 	)
 	expect(
 		buildFleetEntitlementCrossingIdempotencyKey({

--- a/packages/worker/src/usage/fleet-entitlement-crossing-subscription-event.ts
+++ b/packages/worker/src/usage/fleet-entitlement-crossing-subscription-event.ts
@@ -201,7 +201,7 @@ export function buildFleetEntitlementCrossingIdempotencyKey(input: {
 		case 'runtime_duration':
 			return `fleet-entitlement-crossing:${input.event.event}:${input.event.user.id}:${input.event.kind}:${input.event.observed_at.slice(0, 7)}:${input.packageId}`
 		case 'repeated_entitlement':
-			return `fleet-entitlement-crossing:${input.event.event}:${input.event.user.id}:${input.event.kind}:${input.event.resource}:${input.packageId}`
+			return `fleet-entitlement-crossing:${input.event.event}:${input.event.user.id}:${input.event.kind}:${input.event.resource}:${isoTimestampDayKey(input.event.observed_at)}:${input.packageId}`
 		case 'dynamic_worker_cost':
 			return `fleet-entitlement-crossing:${input.event.event}:${input.event.user.id}:${input.event.kind}:${input.event.observed_at.slice(0, 7)}:${input.packageId}`
 		default: {

--- a/packages/worker/src/usage/fleet-entitlement-crossing-subscription-event.ts
+++ b/packages/worker/src/usage/fleet-entitlement-crossing-subscription-event.ts
@@ -17,7 +17,11 @@ export const fleetEntitlementCrossingThresholds = [
 export type FleetEntitlementCrossingThreshold =
 	(typeof fleetEntitlementCrossingThresholds)[number]
 
-export type FleetEntitlementCrossingKind = 'entitlement' | 'runtime_duration'
+export type FleetEntitlementCrossingKind =
+	| 'entitlement'
+	| 'runtime_duration'
+	| 'repeated_entitlement'
+	| 'dynamic_worker_cost'
 
 export type FleetEntitlementCrossingUser = {
 	id: string
@@ -50,9 +54,36 @@ export type FleetRuntimeDurationCrossedEvent = {
 	observed_at: string
 }
 
+export type FleetRepeatedEntitlementCrossedEvent = {
+	event: FleetEntitlementCrossedTopic
+	kind: 'repeated_entitlement'
+	user: FleetEntitlementCrossingUser
+	resource: AdminUsageEntitlementResource
+	days_at_limit: number
+	window_days: number
+	threshold_days: number
+	insights_url: string
+	users_url: string
+	observed_at: string
+}
+
+export type FleetDynamicWorkerCostCrossedEvent = {
+	event: FleetEntitlementCrossedTopic
+	kind: 'dynamic_worker_cost'
+	user: FleetEntitlementCrossingUser
+	unique_worker_days: number
+	estimated_gross_usd: number
+	threshold_usd: number
+	insights_url: string
+	users_url: string
+	observed_at: string
+}
+
 export type FleetEntitlementCrossedEvent =
 	| FleetEntitlementResourceCrossedEvent
 	| FleetRuntimeDurationCrossedEvent
+	| FleetRepeatedEntitlementCrossedEvent
+	| FleetDynamicWorkerCostCrossedEvent
 
 export function isFleetEntitlementCrossingEventTopic(
 	value: string,
@@ -110,6 +141,52 @@ export function buildFleetRuntimeDurationCrossedEvent(input: {
 	}
 }
 
+export function buildFleetRepeatedEntitlementCrossedEvent(input: {
+	user: FleetEntitlementCrossingUser
+	resource: AdminUsageEntitlementResource
+	daysAtLimit: number
+	windowDays: number
+	thresholdDays: number
+	insightsUrl: string
+	usersUrl: string
+	observedAt: string
+}): FleetRepeatedEntitlementCrossedEvent {
+	return {
+		event: fleetEntitlementCrossedTopic,
+		kind: 'repeated_entitlement',
+		user: input.user,
+		resource: input.resource,
+		days_at_limit: input.daysAtLimit,
+		window_days: input.windowDays,
+		threshold_days: input.thresholdDays,
+		insights_url: input.insightsUrl,
+		users_url: input.usersUrl,
+		observed_at: input.observedAt,
+	}
+}
+
+export function buildFleetDynamicWorkerCostCrossedEvent(input: {
+	user: FleetEntitlementCrossingUser
+	uniqueWorkerDays: number
+	estimatedGrossUsd: number
+	thresholdUsd: number
+	insightsUrl: string
+	usersUrl: string
+	observedAt: string
+}): FleetDynamicWorkerCostCrossedEvent {
+	return {
+		event: fleetEntitlementCrossedTopic,
+		kind: 'dynamic_worker_cost',
+		user: input.user,
+		unique_worker_days: input.uniqueWorkerDays,
+		estimated_gross_usd: input.estimatedGrossUsd,
+		threshold_usd: input.thresholdUsd,
+		insights_url: input.insightsUrl,
+		users_url: input.usersUrl,
+		observed_at: input.observedAt,
+	}
+}
+
 export function buildFleetEntitlementCrossingIdempotencyKey(input: {
 	event: FleetEntitlementCrossedEvent
 	packageId: string
@@ -122,6 +199,10 @@ export function buildFleetEntitlementCrossingIdempotencyKey(input: {
 			return `fleet-entitlement-crossing:${input.event.event}:${input.event.user.id}:${input.event.kind}:${input.event.threshold}:${input.event.resource}${dailySuffix}:${input.packageId}`
 		}
 		case 'runtime_duration':
+			return `fleet-entitlement-crossing:${input.event.event}:${input.event.user.id}:${input.event.kind}:${input.event.observed_at.slice(0, 7)}:${input.packageId}`
+		case 'repeated_entitlement':
+			return `fleet-entitlement-crossing:${input.event.event}:${input.event.user.id}:${input.event.kind}:${input.event.resource}:${input.packageId}`
+		case 'dynamic_worker_cost':
 			return `fleet-entitlement-crossing:${input.event.event}:${input.event.user.id}:${input.event.kind}:${input.event.observed_at.slice(0, 7)}:${input.packageId}`
 		default: {
 			const exhaustive: never = input.event

--- a/packages/worker/src/usage/record-usage.ts
+++ b/packages/worker/src/usage/record-usage.ts
@@ -4,7 +4,7 @@
  * One event schema covers every metered chokepoint (execute runs, package
  * export invocations, statically imported package export calls, job runs,
  * workflow runs, realtime websocket sessions, gateway fetches, email sends and
- * receives).
+ * receives, and unique Dynamic Worker days).
  *
  * The write path depends on the environment:
  *

--- a/packages/worker/universal/dynamic-worker-cost.node.test.ts
+++ b/packages/worker/universal/dynamic-worker-cost.node.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from 'vitest'
+import {
+	dynamicWorkersIncludedPerAccountMonth,
+	dynamicWorkerUsdPerUniqueDay,
+	estimateDynamicWorkerUsd,
+	formatDynamicWorkerUsd,
+	toAdminDynamicWorkerCost,
+} from './dynamic-worker-cost.ts'
+
+test('estimateDynamicWorkerUsd multiplies unique days by the Cloudflare list price', () => {
+	expect(dynamicWorkerUsdPerUniqueDay).toBe(0.002)
+	expect(dynamicWorkersIncludedPerAccountMonth).toBe(1000)
+	expect(estimateDynamicWorkerUsd(0)).toBe(0)
+	expect(estimateDynamicWorkerUsd(1)).toBe(0.002)
+	expect(estimateDynamicWorkerUsd(500)).toBe(1)
+	expect(estimateDynamicWorkerUsd(-3)).toBe(0)
+	expect(estimateDynamicWorkerUsd(Number.NaN)).toBe(0)
+})
+
+test('toAdminDynamicWorkerCost truncates to a non-negative integer day count', () => {
+	expect(toAdminDynamicWorkerCost(12.9)).toEqual({
+		uniqueWorkerDays: 12,
+		estimatedGrossUsd: 0.024,
+		usdPerUniqueDay: 0.002,
+		includedPerAccountMonth: 1000,
+	})
+	expect(formatDynamicWorkerUsd(0.002)).toBe('$0.002')
+	expect(formatDynamicWorkerUsd(1)).toBe('$1.00')
+})

--- a/packages/worker/universal/dynamic-worker-cost.node.test.ts
+++ b/packages/worker/universal/dynamic-worker-cost.node.test.ts
@@ -3,6 +3,8 @@ import {
 	dynamicWorkersIncludedPerAccountMonth,
 	dynamicWorkerUsdPerUniqueDay,
 	estimateDynamicWorkerUsd,
+	fleetDynamicWorkerCostAlertUsd,
+	fleetDynamicWorkerCostAlertUsdByPlan,
 	formatDynamicWorkerUsd,
 	toAdminDynamicWorkerCost,
 } from './dynamic-worker-cost.ts'
@@ -26,4 +28,13 @@ test('toAdminDynamicWorkerCost truncates to a non-negative integer day count', (
 	})
 	expect(formatDynamicWorkerUsd(0.002)).toBe('$0.002')
 	expect(formatDynamicWorkerUsd(1)).toBe('$1.00')
+	expect(fleetDynamicWorkerCostAlertUsdByPlan).toEqual({
+		free: 2,
+		standard: 12,
+		pro: 29,
+	})
+	expect(fleetDynamicWorkerCostAlertUsd('free')).toBe(2)
+	expect(fleetDynamicWorkerCostAlertUsd('standard')).toBe(12)
+	expect(fleetDynamicWorkerCostAlertUsd('pro')).toBe(29)
+	expect(fleetDynamicWorkerCostAlertUsd('max')).toBeNull()
 })

--- a/packages/worker/universal/dynamic-worker-cost.ts
+++ b/packages/worker/universal/dynamic-worker-cost.ts
@@ -1,0 +1,45 @@
+/**
+ * Cloudflare Dynamic Worker list price used for operator cost estimates.
+ *
+ * Cloudflare bills $0.002 per unique worker id per UTC day, with 1,000
+ * unique worker-days included per account per month. The included allotment
+ * is account-wide, so per-user estimates are always gross (unique days ×
+ * list price) and do not subtract a share of the included bucket.
+ */
+
+export const dynamicWorkerUsdPerUniqueDay = 0.002
+export const dynamicWorkersIncludedPerAccountMonth = 1000
+
+export function estimateDynamicWorkerUsd(uniqueWorkerDays: number): number {
+	const safeDays = Number.isFinite(uniqueWorkerDays)
+		? Math.max(0, uniqueWorkerDays)
+		: 0
+	return safeDays * dynamicWorkerUsdPerUniqueDay
+}
+
+export function toAdminDynamicWorkerCost(uniqueWorkerDays: number) {
+	const safeDays = Number.isFinite(uniqueWorkerDays)
+		? Math.max(0, Math.trunc(uniqueWorkerDays))
+		: 0
+	return {
+		uniqueWorkerDays: safeDays,
+		estimatedGrossUsd: estimateDynamicWorkerUsd(safeDays),
+		usdPerUniqueDay: dynamicWorkerUsdPerUniqueDay,
+		includedPerAccountMonth: dynamicWorkersIncludedPerAccountMonth,
+	}
+}
+
+const usdFormatter = new Intl.NumberFormat('en-US', {
+	style: 'currency',
+	currency: 'USD',
+	minimumFractionDigits: 2,
+	maximumFractionDigits: 3,
+})
+
+/** Format a Dynamic Worker cost so $0.002 stays visible. */
+export function formatDynamicWorkerUsd(amount: number): string {
+	return usdFormatter.format(amount)
+}
+
+export const dynamicWorkerCostFootnote =
+	'Gross estimate: unique Dynamic Worker ids × $0.002 per UTC day. Cloudflare includes 1,000 unique worker-days per account per month, so this is not a net bill share.'

--- a/packages/worker/universal/dynamic-worker-cost.ts
+++ b/packages/worker/universal/dynamic-worker-cost.ts
@@ -1,3 +1,5 @@
+import { type PlanName } from './plans.ts'
+
 /**
  * Cloudflare Dynamic Worker list price used for operator cost estimates.
  *
@@ -9,6 +11,35 @@
 
 export const dynamicWorkerUsdPerUniqueDay = 0.002
 export const dynamicWorkersIncludedPerAccountMonth = 1000
+
+/**
+ * Gross unique-worker-day cost at which a non-admin account pages operators.
+ * Paid thresholds match monthly list price (the unique-execute break-even).
+ * Free uses the account-wide included allotment ($2 = 1,000 unique days) so
+ * one Free account eating that bucket is enough to look.
+ */
+export const fleetDynamicWorkerCostAlertUsdByPlan = {
+	free: 2,
+	standard: 12,
+	pro: 29,
+} as const
+
+export function fleetDynamicWorkerCostAlertUsd(plan: PlanName): number | null {
+	switch (plan) {
+		case 'free':
+			return fleetDynamicWorkerCostAlertUsdByPlan.free
+		case 'standard':
+			return fleetDynamicWorkerCostAlertUsdByPlan.standard
+		case 'pro':
+			return fleetDynamicWorkerCostAlertUsdByPlan.pro
+		case 'max':
+			return null
+		default: {
+			const exhaustive: never = plan
+			throw new Error(`Unknown plan: ${String(exhaustive)}`)
+		}
+	}
+}
 
 export function estimateDynamicWorkerUsd(uniqueWorkerDays: number): number {
 	const safeDays = Number.isFinite(uniqueWorkerDays)

--- a/packages/worker/universal/loader-data.ts
+++ b/packages/worker/universal/loader-data.ts
@@ -478,6 +478,7 @@ export type AdminUsageMetric =
 	| 'outbound_fetch'
 	| 'email_send'
 	| 'email_received'
+	| 'dynamic_worker_day'
 
 export type AdminUsageEntitlementResource =
 	| 'saved_packages'
@@ -534,6 +535,7 @@ export type AdminUserUsageLoaderData = {
 	monthUsage: Array<AdminUsageMonthRollup>
 	entitlementConsumption: Array<AdminUsageEntitlementConsumption>
 	warnings: Array<AdminUsageEntitlementConsumption>
+	dynamicWorkerCost: AdminDynamicWorkerCost
 }
 
 export type AdminInsightsTotals = {
@@ -672,6 +674,24 @@ export type AdminInsightsEventCountConsumer = {
 	eventCount: number
 }
 
+export type AdminDynamicWorkerCost = {
+	uniqueWorkerDays: number
+	estimatedGrossUsd: number
+	usdPerUniqueDay: number
+	includedPerAccountMonth: number
+}
+
+export type AdminInsightsDynamicWorkerCostConsumer = {
+	stableUserId: string
+	username: string
+	uniqueWorkerDays: number
+	estimatedGrossUsd: number
+}
+
+export type AdminInsightsDynamicWorkerCost = AdminDynamicWorkerCost & {
+	topConsumers: Array<AdminInsightsDynamicWorkerCostConsumer>
+}
+
 export type AdminInsightsMetricDurationConsumers = {
 	metric: AdminUsageMetric
 	consumers: Array<AdminInsightsDurationConsumer>
@@ -750,6 +770,7 @@ export type AdminInsightsLoaderData = {
 	topEventCountConsumers: Array<AdminInsightsEventCountConsumer>
 	topDurationConsumersByMetric: Array<AdminInsightsMetricDurationConsumers>
 	entitlementPressure: Array<AdminInsightsEntitlementPressureUser>
+	dynamicWorkerCost: AdminInsightsDynamicWorkerCost
 	packageErrorRate: AdminInsightsPackageErrorRate
 }
 

--- a/packages/worker/universal/plans.ts
+++ b/packages/worker/universal/plans.ts
@@ -211,16 +211,17 @@ export const maxPlanEmailLimits = {
 } as const satisfies Partial<Record<EntitlementResource, number>>
 
 /**
- * Initial limit numbers are conservative placeholders chosen before usage
- * metering exists. They are expected to be tuned once metering data is
- * available. Billing (packages/worker/src/billing/) maps Stripe
- * subscriptions onto these plan names but the limit numbers stay
- * independent of pricing.
+ * Limit numbers are denial-of-wallet caps, tuned from production metering
+ * (August 2026). The expensive surface is MCP `execute`: each unique
+ * Dynamic Worker id is $0.002/UTC day after the account-wide included
+ * allotment. Billing (`packages/worker/src/billing/`) maps Stripe
+ * subscriptions onto these plan names; the limit numbers stay independent
+ * of list prices.
  *
- * Ordinary `max` ceilings are explicit product choices based on the new
- * `pro` plan. Most retain the previous ceilings even where that is 25× or
- * 50× pro rather than a uniform multiplier. Email resources intentionally
- * use {@link maxPlanEmailLimits} abuse caps instead.
+ * Ordinary `max` ceilings are explicit product choices based on the `pro`
+ * plan. Most retain high operator ceilings even where that is 25× or 50×
+ * pro rather than a uniform multiplier. Email resources intentionally use
+ * {@link maxPlanEmailLimits} abuse caps instead.
  */
 export const planLimits: Record<PlanName, PlanLimits> = {
 	// Free stays roomy for setup (secrets, a handful of jobs) and tighter on
@@ -235,21 +236,27 @@ export const planLimits: Record<PlanName, PlanLimits> = {
 		// Sessions are cheap (catalog row + dormant DO workspace + Artifacts
 		// branch). Unused (never-checkpointed) leftovers sweep after 30
 		// minutes idle; checkpointed sessions use the 7-day window so
-		// unpublished work is not lost mid-conversation. Sized for a few
-		// agent conversations, not dozens.
-		maxRepoSessions: 15,
+		// unpublished work is not lost mid-conversation. Sized for a couple
+		// of concurrent agent conversations, not a leftover pile.
+		maxRepoSessions: 5,
 		// notify-self and reply-to-stored only, so the outreach-abuse surface
 		// is small; a daily digest plus a few alerts should not hit the wall.
 		maxEmailSendsPerDay: 10,
-		// Inbound volume is attacker-controlled. Unchanged.
-		maxEmailReceivesPerDay: 50,
-		maxStoredEmailMessages: 500,
+		// Inbound volume is attacker-controlled. Free inbound is unused in
+		// production; keep a small mailbox so a leaked address cannot fill
+		// storage.
+		maxEmailReceivesPerDay: 10,
+		maxStoredEmailMessages: 100,
 		maxEmailMessageBytes: 256 * 1024,
 		maxSecrets: 25,
 		maxStorageBytes: 16 * 1024 * 1024,
-		// Concurrent active runs (not lifetime or daily).
-		maxConcurrentWorkflows: 2,
-		maxExecuteCallsPerDay: 250,
+		// Concurrent active runs (not lifetime or daily). One at a time on
+		// free; a second deferred workflow is the upgrade nudge.
+		maxConcurrentWorkflows: 1,
+		// Unique execute is the Dynamic Worker bill. 100/day covers a real
+		// agent morning (~70 observed) without pricing a free account at
+		// Standard's unique-execute ceiling.
+		maxExecuteCallsPerDay: 100,
 		maxOutboundFetchesPerDay: 500,
 		maxJobRunsPerDay: 500,
 		minJobIntervalMs: 15 * 60 * 1000,
@@ -266,7 +273,9 @@ export const planLimits: Record<PlanName, PlanLimits> = {
 		maxSecrets: 100,
 		maxStorageBytes: 1024 * 1024 * 1024,
 		maxConcurrentWorkflows: 50,
-		maxExecuteCallsPerDay: 5_000,
+		// Above the heaviest Standard payer (~200/day avg). Unique-execute
+		// ceiling is still above list price if someone maxes new modules.
+		maxExecuteCallsPerDay: 500,
 		maxOutboundFetchesPerDay: 20_000,
 		maxJobRunsPerDay: 10_000,
 		minJobIntervalMs: 0,
@@ -283,7 +292,8 @@ export const planLimits: Record<PlanName, PlanLimits> = {
 		maxSecrets: 200,
 		maxStorageBytes: 5 * 1024 * 1024 * 1024,
 		maxConcurrentWorkflows: 100,
-		maxExecuteCallsPerDay: 10_000,
+		// Above the heaviest Pro payer (~670/day avg).
+		maxExecuteCallsPerDay: 2_000,
 		maxOutboundFetchesPerDay: 40_000,
 		maxJobRunsPerDay: 20_000,
 		minJobIntervalMs: 0,
@@ -308,7 +318,7 @@ export const planLimits: Record<PlanName, PlanLimits> = {
 		maxStorageBytes: 100 * 1024 * 1024 * 1024,
 		// 50× pro (100) → 5_000.
 		maxConcurrentWorkflows: 5_000,
-		// 50× pro (10_000) → 500_000.
+		// Retained operator ceiling (not 50× the current pro 2_000).
 		maxExecuteCallsPerDay: 500_000,
 		// 50× pro (40_000) → 2_000_000.
 		maxOutboundFetchesPerDay: 2_000_000,

--- a/packages/worker/universal/usage-event-types.ts
+++ b/packages/worker/universal/usage-event-types.ts
@@ -17,6 +17,7 @@ export const usageEventTypes = [
 	'outbound_fetch',
 	'email_send',
 	'email_received',
+	'dynamic_worker_day',
 ] as const
 
 export type UsageEventType = (typeof usageEventTypes)[number]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Keep open signup from turning unique MCP `execute` calls into an unbounded Dynamic Worker bill, make usage metrics match entitlements, show which users cost how much, and page the operator on a train of abuse rather than a single busy day.

## Why

Cloudflare bills Dynamic Workers at **$0.002 per unique worker id per UTC day** (after 1,000 included / month, account-wide). Kody sandbox evaluation creates a Dynamic Worker; same code + bindings reuse an id. Agentic use writes a new module each call, so unique execute is the expensive case.

Two separate problems were getting mixed:

1. **Entitlement ceilings** were too high for open signup (old Standard 5,000 / Pro 10,000 unique execute ≈ $300 / $600 per month at the cap).
2. **Usage rollups were lying.** Shared `createExecuteExecutor` recorded `execute` for every sandbox eval, including jobs. A job-only user looked 1:1 execute/job. Entitlements were already separate (`execute_calls_per_day` vs `job_runs_per_day`); the rollups were not.

Execute-call count is still only a proxy for Cloudflare cost. The bill unit is unique worker ids per UTC day.

## Summary

- Free: execute 250 → **100**, concurrent workflows 2 → **1**, inbound email 50 → **10**, stored messages 500 → **100**, repo sessions 15 → **5**
- Standard: execute 5,000 → **500**
- Pro: execute 10,000 → **2,000**
- Unchanged: packages 10, secrets 25, job stock 5, 15-minute job floor, storage 16 MiB, list prices, `max` execute 500,000
- No new paid tier and no monthly execute entitlement in this PR
- `execute` usage events now fire only for MCP execute-tool runs (jobs/exports/workflows keep their own metrics)
- New `dynamic_worker_day` usage event: first unique Dynamic Worker id per user per UTC day (UserMeter schema v11 claim)
- Admin user usage and insights show **gross** Cloudflare $ (unique days × $0.002). The 1,000 included days are account-wide, so this is not a net bill share
- `/terms`: evasion (extra accounts, identity cycling, Free farms) is a violation; a busy day at the published cap is not; Free is revocable; limits can change
- `fleet.entitlement.crossed` adds `repeated_entitlement` (execute cap on 3 of the last 7 UTC days) and `dynamic_worker_cost` (Free $2 / Standard $12 / Pro $29). Admin packages own the reaction; no hardcoded operator mail

## Testing

- Focused node tests for cost helpers, unique-day recording, admin usage/insights, crossing kinds, and executor
- UserMeter workers-unit tests for schema v11, claim idempotency, and prune
- Pre-push on `8da1888e`: `test:node` 2320, `test:workers` 314
- Typecheck + lint via commit hook
- Preview `https://kody-pr-1940.kody-a99.workers.dev`: pricing/FAQ/account usage show the new caps. Seed user is **not** admin, so `/admin` is 403 and the new cost cards cannot be exercised on preview

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `dcf0cfee` · **Head:** `8da1888e`

**Classification:** extends — plan execute/free caps change, `execute` usage matches `execute_calls_per_day`, UserMeter claims unique Dynamic Worker days, and `fleet.entitlement.crossed` gains cost/train kinds.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `entitlements` | auth | extends — free/standard/pro execute and unused free stock/rate caps |
| `usage-metering` | storage | extends — execute-tool-only `execute`; `dynamic_worker_day`; new crossing kinds |
| `user-meter` | storage | extends — schema v11 unique `(day, worker_id)` claim, 7-day prune |
| `mcp-server` | surfaces | extends — executor claims a unique worker-day on every sandbox surface |
| `app-ui` | surfaces | extends — admin cost cards; ToS evasion / revocable Free copy |
| `rbac` | auth | composes — `admin_user_usage` returns the cost object |
| `capabilities-execute` | runtime | composes — bundled runs pass `recordExecuteUsage` |
| `package-runtime` | runtime | composes — workflow test isolation when free concurrency is 1 |

### Change flow

Sandbox evaluation consumes `execute_calls_per_day` only on the MCP execute tool. Every sandbox surface claims a unique Dynamic Worker id for the UTC day. The hourly entitlement lane pages admin packages on first 80%/100% crossings, a three-of-seven execute-cap train, or plan-aware unique-worker cost.

```mermaid
sequenceDiagram
	actor User
	participant mcpServer as mcp-server
	participant entitlements as entitlements
	participant userMeter as user-meter
	participant usageMetering as usage-metering
	participant appUi as app-ui
	User->>mcpServer: sandbox run
	opt execute-tool surface
		mcpServer->>entitlements: consumeDailyEntitlement(execute_calls_per_day)
		Note over entitlements: free 100 / standard 500 / pro 2,000
	end
	mcpServer->>userMeter: claimDynamicWorkerDay(workerId, UTC day)
	alt first id today
		userMeter-->>mcpServer: created
		mcpServer->>usageMetering: recordUsage(dynamic_worker_day)
	end
	usageMetering->>appUi: hourly fleet.entitlement.crossed
	Note over appUi: kinds include repeated_entitlement and dynamic_worker_cost
```

### Before / after

| Resource | Free | Standard | Pro |
| --- | ---: | ---: | ---: |
| `execute_calls_per_day` | 250 → **100** | 5,000 → **500** | 10,000 → **2,000** |
| `concurrent_workflows` | 2 → **1** | 50 | 100 |
| `email_receives_per_day` | 50 → **10** | 1,000 | 2,000 |
| `stored_email_messages` | 500 → **100** | 10,000 | 25,000 |
| `repo_sessions` | 15 → **5** | 200 | 400 |

| Usage metric | Before | After |
| --- | --- | --- |
| `execute` | every sandbox eval, including jobs | MCP execute-tool only |
| `dynamic_worker_day` | missing | first unique worker id per user per UTC day |

### Invariants

Per-user isolation is unchanged. Jobs still do not consume execute entitlement. Unique worker-day claims are cost attribution, not a plan cap. Operator crossings stay admin-topic-only. The 1,000 included Cloudflare worker-days per month stay account-wide; admin dollars are gross.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3ace7e23-b05c-4b6e-b716-a2080104dc5b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3ace7e23-b05c-4b6e-b716-a2080104dc5b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changed Limits**
  * Updated plan quotas based on production usage measurements.
  * Reduced Free, Standard, and Pro execution allowances and several Free-plan quotas.
  * Retained the maximum plan’s existing execution ceiling.

* **New Features**
  * Added Dynamic Worker usage tracking, estimated costs, unique worker-day metrics, and top consumers to admin views.
  * Added alerts for Dynamic Worker cost thresholds and repeated execution-cap crossings.

* **Documentation**
  * Clarified plan pricing, email quotas, message-size limits, usage metering, and entitlement alerts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->