### PR TITLE
Add control-kody CLI and Feature Map for agent verification

### DIFF
--- a/.agents/skills/control-kody/SKILL.md
+++ b/.agents/skills/control-kody/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: control-kody
+description: >
+  Drive and verify the Kody app with a Feature Map and one CLI. Use when
+  changing UI, account routes, preview deploys, or proving a Cloud Agent change
+  with a real origin, session, and /health SHA.
+---
+
+# control-kody
+
+Do not invent a throwaway curl script, scrape PR comments by hand, or rediscover
+account routes from `routes.ts`. Use the CLI and the Feature Map.
+
+```bash
+node tools/control-kody.ts doctor
+node tools/control-kody.ts dev
+node tools/control-kody.ts login
+node tools/control-kody.ts request GET /account/waiting.json
+node tools/control-kody.ts map waiting
+node tools/control-kody.ts health --sha <merge-sha>
+node tools/control-kody.ts preview -- --request 'GET /account/waiting.json' --check /account/waiting
+```
+
+`npm run control-kody -- <command>` is the same entry.
+
+## Feature Map
+
+[references/features/README.md](./references/features/README.md) is the
+human-readable index. `tools/control-kody/feature-catalog.ts` is the
+machine-readable source. `map --check` (and its node test) fail when a listed
+path leaves `routes.ts` or a required HTML route has no entry.
+
+Load **one** feature file for the surface you are changing.
+
+## Seed users
+
+- Local: `jane@example.com` / `ilikecode` (non-admin)
+- Preview: `me@kentcdodds.com` / `ilikecode` (non-admin, empty until you create
+  data through JSON APIs)
+- `/admin` 403 and `/mcp` 401 are expected for those seeds
+
+## Proof
+
+CI green is not enough for a user-visible account change. Prefer:
+
+1. `doctor` then `dev` or `preview`
+2. `request` / `--check` as the seed user **with data for this change**
+3. A computerUse video or screenshot of the same page
+4. After merge, `health --origin https://kody.codes --sha <merge>`
+
+See
+[docs/contributing/control-kody.md](../../../docs/contributing/control-kody.md)
+and [preview-manual-test](../preview-manual-test/SKILL.md).

--- a/.agents/skills/control-kody/references/features/README.md
+++ b/.agents/skills/control-kody/references/features/README.md
@@ -1,0 +1,55 @@
+# Feature Map
+
+Searchable map of Kody user-facing surfaces. Load one file, not this whole
+directory.
+
+The catalog in `tools/control-kody/feature-catalog.ts` is the machine-readable
+source. `node tools/control-kody.ts map --check` fails when a listed path leaves
+`routes.ts` or a required HTML route has no entry.
+
+## How to use it
+
+```bash
+node tools/control-kody.ts map
+node tools/control-kody.ts map waiting
+node tools/control-kody.ts map --check
+```
+
+Then drive the surface with `login`, `request`, `preview`, and `health`. See the
+[control-kody skill](../../SKILL.md).
+
+## Surfaces
+
+- [login](./login.md) — `/login`
+- [signup](./signup.md) — `/signup`
+- [onboarding](./onboarding.md) — `/onboarding`
+- [password-reset](./password-reset.md) — `/reset-password`
+- [two-factor](./two-factor.md) — `/account/two-factor`
+- [passkeys](./passkeys.md) — `/account/passkeys`
+- [account](./account.md) — `/account`
+- [packages](./packages.md) — `/account/packages`
+- [secrets](./secrets.md) — `/account/secrets`
+- [integrations](./integrations.md) — `/account/integrations`
+- [mcp-servers](./mcp-servers.md) — `/account/mcp-servers`
+- [jobs](./jobs.md) — `/account/jobs`
+- [workflows](./workflows.md) — `/account/workflows`
+- [activity](./activity.md) — `/account/activity`
+- [waiting](./waiting.md) — `/account/waiting`
+- [memories](./memories.md) — `/account/memories`
+- [email](./email.md) — `/account/email`
+- [values](./values.md) — `/account/values`
+- [billing](./billing.md) — `/account/billing`
+- [admin](./admin.md) — `/admin` (seed user is 403)
+- [community](./community.md) — `/community`
+- [marketing](./marketing.md) — `/`, `/guides`, `/blog`
+
+## Seed users
+
+| Environment | Email               | Password    | Notes                                        |
+| ----------- | ------------------- | ----------- | -------------------------------------------- |
+| Local       | `jane@example.com`  | `ilikecode` | Non-admin. Prefer this.                      |
+| Local       | `kody@example.com`  | `ilikecode` | Admin. Avoid unless needed.                  |
+| Preview     | `me@kentcdodds.com` | `ilikecode` | Non-admin. Empty until seeded via JSON APIs. |
+
+Create preview data with `control-kody request` / `preview --request`. Do not
+raw-D1-seed preview.

--- a/.agents/skills/control-kody/references/features/account.md
+++ b/.agents/skills/control-kody/references/features/account.md
@@ -5,7 +5,7 @@ surfaces.
 
 ## How to get there
 
-`/account` after login.
+`/account` after login. Account deletion is `/account/delete`.
 
 ## Drive it
 

--- a/.agents/skills/control-kody/references/features/account.md
+++ b/.agents/skills/control-kody/references/features/account.md
@@ -1,0 +1,29 @@
+# Account hub
+
+Signed-in home: profile, export, delete, and links to the other account
+surfaces.
+
+## How to get there
+
+`/account` after login.
+
+## Drive it
+
+```bash
+node tools/control-kody.ts login
+node tools/control-kody.ts request GET /account/profile.json
+```
+
+## APIs
+
+- `GET|POST /account/profile.json`
+- `POST /account/profile/avatar.json`
+- `POST /account/email-change.json`
+- `GET /account/export.json`
+- `POST /account/delete`
+- `GET|POST /account/connections.json`
+
+## Gotchas
+
+- Seed users start empty. Profile fields exist; packages/secrets/jobs do not
+  until you create them.

--- a/.agents/skills/control-kody/references/features/activity.md
+++ b/.agents/skills/control-kody/references/features/activity.md
@@ -1,0 +1,22 @@
+# Activity
+
+User-level execution history (jobs, execute, webhooks, apps).
+
+## How to get there
+
+`/account/activity` → `/account/activity/:runId`.
+
+## Drive it
+
+```bash
+node tools/control-kody.ts request GET /account/activity.json
+```
+
+## APIs
+
+- `GET /account/activity.json`
+
+## Gotchas
+
+- This is not the waiting inbox. Waiting is human-action items; activity is run
+  history.

--- a/.agents/skills/control-kody/references/features/admin.md
+++ b/.agents/skills/control-kody/references/features/admin.md
@@ -1,0 +1,23 @@
+# Admin
+
+Operator tools. Seed and preview users are **not** admin.
+
+## How to get there
+
+`/admin` and its children (`/admin/users`, `/admin/roles`, `/admin/invites`,
+`/admin/feature-flags`, `/admin/platform-integrations`, `/admin/provider-marks`,
+`/admin/codemods`, `/admin/community-reports`, `/admin/insights`,
+`/admin/platform-feedback`, `/admin/system-email`).
+
+## Drive it
+
+```bash
+node tools/control-kody.ts request GET /admin 403
+```
+
+403 on the seed account is success. Local `kody@example.com` is admin; do not
+use it unless the change is an admin surface.
+
+## APIs
+
+JSON siblings under `/admin/*.json`. Same 403 for the preview seed.

--- a/.agents/skills/control-kody/references/features/billing.md
+++ b/.agents/skills/control-kody/references/features/billing.md
@@ -1,0 +1,24 @@
+# Billing and usage
+
+Plan, checkout, portal, and entitlement usage.
+
+## How to get there
+
+`/account/billing` (success `/account/billing/success`, portal
+`/account/billing/portal`) and `/account/usage`.
+
+## Drive it
+
+```bash
+node tools/control-kody.ts request GET /account/billing.json
+node tools/control-kody.ts request GET /account/usage.json
+```
+
+Do not complete a real Stripe checkout from a Cloud Agent.
+
+## APIs
+
+- `GET /account/billing.json`
+- `POST /account/billing/checkout.json`
+- `POST /account/billing/cancellation-feedback.json`
+- `GET /account/usage.json`

--- a/.agents/skills/control-kody/references/features/community.md
+++ b/.agents/skills/control-kody/references/features/community.md
@@ -1,0 +1,28 @@
+# Community listings and profiles
+
+Public catalog and owner-scoped package URLs.
+
+## How to get there
+
+`/community` → `/community/:listingId`. Human share URL: `/@username/kody-id`
+(never construct `/community/{listing_id}` for people). Profile: `/@username`.
+
+## Drive it
+
+```bash
+node tools/control-kody.ts request GET /community.json --skip-login
+```
+
+## APIs
+
+- `GET /community.json`
+- `GET /community/:listingId.json`
+- `GET /profiles/:username.json`
+- `GET /profiles/:username/packages/:kodyId.json`
+- `POST /community/:listingId/{report,trust,feature,install}.json`
+
+## Gotchas
+
+- Follows, stars, and the social timeline are gone. Do not add them back from
+  memory.
+- Files and tree URLs are public read for listed packages.

--- a/.agents/skills/control-kody/references/features/email.md
+++ b/.agents/skills/control-kody/references/features/email.md
@@ -1,0 +1,22 @@
+# Email inbox
+
+Per-user stored mail (notify-self, reply).
+
+## How to get there
+
+`/account/email` → `/account/email/:messageId`.
+
+## Drive it
+
+```bash
+node tools/control-kody.ts request GET /account/email.json
+```
+
+## APIs
+
+- `GET /account/email.json`
+
+## Gotchas
+
+- Preview seed starts empty. Inbound mail is not something a Cloud Agent can
+  mint without the email store APIs.

--- a/.agents/skills/control-kody/references/features/integrations.md
+++ b/.agents/skills/control-kody/references/features/integrations.md
@@ -1,0 +1,26 @@
+# Integrations and OAuth connect
+
+Saved OAuth connections and the hosted connect start.
+
+## How to get there
+
+`/account/integrations` → `/account/integrations/:integrationName`. OAuth apps:
+`/account/integrations/apps/:appSlug`. One-click grant:
+`/account/integrations/approve`. Start connect: `/connect/oauth`.
+
+## Drive it
+
+```bash
+node tools/control-kody.ts request GET /account/integrations.json
+```
+
+## APIs
+
+- `GET|POST /account/integrations.json`
+- `/connect/oauth` (browser; needs a real provider client)
+
+## Gotchas
+
+- Cloud Agents cannot complete a third-party OAuth dance without credentials in
+  the environment. HTTP list/empty-state is the usual proof.
+- `/guides/connect` is the public how-to, not the account page.

--- a/.agents/skills/control-kody/references/features/jobs.md
+++ b/.agents/skills/control-kody/references/features/jobs.md
@@ -1,0 +1,24 @@
+# Jobs
+
+Package-owned schedules and their run history.
+
+## How to get there
+
+`/account/jobs` → `/account/jobs/:jobId`.
+
+## Drive it
+
+```bash
+node tools/control-kody.ts request GET /account/jobs.json
+```
+
+Preview seed has no jobs until a package with `kody.jobs` exists.
+
+## APIs
+
+- `GET|POST /account/jobs.json`
+
+## Gotchas
+
+- Republishing `"enabled": false` does not disable a running job. Use
+  `job_update` or the package pause export.

--- a/.agents/skills/control-kody/references/features/login.md
+++ b/.agents/skills/control-kody/references/features/login.md
@@ -1,0 +1,30 @@
+# Sign in
+
+Email + password (and social providers when configured).
+
+## How to get there
+
+Open `/login`. Button label is **Sign in**.
+
+## Drive it
+
+```bash
+node tools/control-kody.ts login --origin http://localhost:3742
+node tools/control-kody.ts request GET /session --origin http://localhost:3742
+```
+
+Local default: `jane@example.com` / `ilikecode`. Preview default:
+`me@kentcdodds.com` / `ilikecode`.
+
+## APIs
+
+- `POST /auth` `{ email, password, mode: "login" }`
+- `GET /session`
+- `POST /logout`
+- `GET /auth/providers.json`
+
+## Gotchas
+
+- `/mcp` is 401 without OAuth. Not a regression.
+- Social-login e2e is a known wrangler-sensitive path; prefer the email lane for
+  agent verification.

--- a/.agents/skills/control-kody/references/features/marketing.md
+++ b/.agents/skills/control-kody/references/features/marketing.md
@@ -1,0 +1,24 @@
+# Public marketing pages
+
+Logged-out landing, pricing, FAQ, legal, guides, blog, Discord invite.
+
+## How to get there
+
+`/`, `/pricing`, `/faq`, `/privacy`, `/terms`, `/guides`, `/guides/:slug`,
+`/guides/connect`, `/blog`, `/blog/:slug`, `/discord`.
+
+## Drive it
+
+```bash
+node tools/control-kody.ts health --origin https://kody.codes
+node tools/control-kody.ts request GET /guides.json --skip-login --origin https://kody.codes
+```
+
+Anonymous HTML on `/` and several marketing routes is short-CDN-cached. Weekly
+site-perf owns landing budgets.
+
+## APIs
+
+- `GET /guides.json`
+- `GET /blog.json`
+- `GET /discord.json`

--- a/.agents/skills/control-kody/references/features/mcp-servers.md
+++ b/.agents/skills/control-kody/references/features/mcp-servers.md
@@ -1,0 +1,26 @@
+# MCP servers
+
+User-added MCP servers and the OAuth clients they mint.
+
+## How to get there
+
+`/account/mcp-servers` → `/account/mcp-servers/new` →
+`/account/mcp-servers/:serverId`. Clients: `/account/mcp-oauth-clients`.
+
+## Drive it
+
+```bash
+node tools/control-kody.ts request GET /account/mcp-servers.json
+node tools/control-kody.ts request GET /account/mcp-oauth-clients.json
+```
+
+## APIs
+
+- `GET|POST /account/mcp-servers.json`
+- `GET|POST /account/mcp-oauth-clients.json`
+- `/account/mcp-servers/oauth/callback`
+
+## Gotchas
+
+- App `/mcp` (Kody-as-server) is a different surface. Unauthenticated GET is 401
+  by design.

--- a/.agents/skills/control-kody/references/features/memories.md
+++ b/.agents/skills/control-kody/references/features/memories.md
@@ -1,0 +1,23 @@
+# Memories
+
+Durable user facts. Verify-first writes (`meta_memory_verify` before
+upsert/delete).
+
+## How to get there
+
+`/account/memories` → `/account/memories/:memoryId`.
+
+## Drive it
+
+```bash
+node tools/control-kody.ts request GET /account/memories.json
+```
+
+## APIs
+
+- `GET|POST /account/memories.json`
+- `GET /account/memories-export.json`
+
+## Gotchas
+
+- MCP instruction overlay is not memory. Do not store package inventory there.

--- a/.agents/skills/control-kody/references/features/onboarding.md
+++ b/.agents/skills/control-kody/references/features/onboarding.md
@@ -10,9 +10,10 @@ Signed-in visit to `/onboarding`. Also linked from account.
 
 ```bash
 node tools/control-kody.ts preview -- \
-  --request 'POST /onboarding/checklist-dismiss.json {}' \
   --request 'GET /onboarding.json' \
-  --check /onboarding
+  --check /onboarding \
+  --request 'POST /onboarding/checklist-dismiss.json {}' \
+  --request 'GET /onboarding.json'
 ```
 
 ## APIs

--- a/.agents/skills/control-kody/references/features/onboarding.md
+++ b/.agents/skills/control-kody/references/features/onboarding.md
@@ -1,0 +1,26 @@
+# Onboarding
+
+First-run checklist after signup.
+
+## How to get there
+
+Signed-in visit to `/onboarding`. Also linked from account.
+
+## Drive it
+
+```bash
+node tools/control-kody.ts preview -- \
+  --request 'POST /onboarding/checklist-dismiss.json {}' \
+  --request 'GET /onboarding.json' \
+  --check /onboarding
+```
+
+## APIs
+
+- `GET /onboarding.json`
+- `POST /onboarding/checklist-dismiss.json`
+
+## Gotchas
+
+- Local wrangler reload loops have blocked real `/onboarding` screenshots. Use
+  `control-kody doctor` and `dev:ensure` before a UI pass.

--- a/.agents/skills/control-kody/references/features/packages.md
+++ b/.agents/skills/control-kody/references/features/packages.md
@@ -1,0 +1,33 @@
+# Packages
+
+Repo-backed saved packages: list, detail, files, approve-publish.
+
+## How to get there
+
+`/account/packages` → `/account/packages/:packageId` →
+`/account/packages/:packageId/approve-publish`.
+
+## Drive it
+
+Preview seed has **no** packages until you create one through the JSON API the
+UI posts to (`/account/packages.json`).
+
+```bash
+node tools/control-kody.ts preview -- \
+  --request 'GET /account/packages.json' \
+  --check /account/packages
+```
+
+Package delete `#1932` used a preview video plus the empty-state shot.
+
+## APIs
+
+- `GET|POST /account/packages.json`
+- `GET /account/packages/:packageId/files.json`
+- `GET|POST /account/packages/:packageId/approve-publish.json`
+
+## Gotchas
+
+- Stay on the preview origin. Do not follow a package-app handoff into
+  production.
+- Unlocking a locked package is website-only.

--- a/.agents/skills/control-kody/references/features/passkeys.md
+++ b/.agents/skills/control-kody/references/features/passkeys.md
@@ -1,0 +1,23 @@
+# Passkeys
+
+WebAuthn registration and authentication.
+
+## How to get there
+
+`/account/passkeys`. Browser-gated; Cloud Agent VMs often lack a platform
+authenticator.
+
+## Drive it
+
+```bash
+node tools/control-kody.ts request GET /account/passkeys.json
+```
+
+HTTP can assert the empty list. Do not fail a ship because computerUse cannot
+complete a WebAuthn ceremony.
+
+## APIs
+
+- `GET|POST /account/passkeys.json`
+- `/webauthn/registration`
+- `/webauthn/authentication`

--- a/.agents/skills/control-kody/references/features/password-reset.md
+++ b/.agents/skills/control-kody/references/features/password-reset.md
@@ -1,0 +1,22 @@
+# Password reset
+
+Forgot-password and signed-in password change.
+
+## How to get there
+
+Signed-out: `/reset-password`. Signed-in: account settings password form.
+
+## Drive it
+
+```bash
+node tools/control-kody.ts request POST /account/password.json --body '{"currentPassword":"ilikecode","newPassword":"ilikecode"}'
+```
+
+Password `#1923` proved this with a preview video. GET the page after a change;
+do not stop at "try this URL."
+
+## APIs
+
+- `POST /password-reset`
+- `POST /password-reset/confirm`
+- `POST /account/password.json`

--- a/.agents/skills/control-kody/references/features/password-reset.md
+++ b/.agents/skills/control-kody/references/features/password-reset.md
@@ -8,12 +8,17 @@ Signed-out: `/reset-password`. Signed-in: account settings password form.
 
 ## Drive it
 
+Do not POST a new password that matches the shared seed (`ilikecode`) — that
+does not prove the change. Prefer GET the form. If you must mutate, use a
+distinct temporary password and restore `ilikecode` afterward.
+
 ```bash
-node tools/control-kody.ts request POST /account/password.json --body '{"currentPassword":"ilikecode","newPassword":"ilikecode"}'
+node tools/control-kody.ts request GET /account
+node tools/control-kody.ts request GET /reset-password --skip-login
 ```
 
-Password `#1923` proved this with a preview video. GET the page after a change;
-do not stop at "try this URL."
+Password `#1923` proved the signed-in change with a preview video. GET the page
+after a change; do not stop at "try this URL."
 
 ## APIs
 

--- a/.agents/skills/control-kody/references/features/secrets.md
+++ b/.agents/skills/control-kody/references/features/secrets.md
@@ -1,0 +1,29 @@
+# Secrets
+
+User, session, and package secret rows. Host approval and package grants.
+
+## How to get there
+
+`/account/secrets` → new `/account/secrets/new` → detail under
+`/account/secrets/{user|session|package}/…`. Approve lane:
+`/account/secrets/approve`.
+
+## Drive it
+
+```bash
+node tools/control-kody.ts preview -- \
+  --request 'GET /account/secrets.json' \
+  --check /account/secrets
+```
+
+GET the page body after a claimed fix. `#1918` shipped with “try
+https://kody.codes/account/secrets” and no body — that is not proof.
+
+## APIs
+
+- `GET|POST /account/secrets.json`
+
+## Gotchas
+
+- Never paste secret values into chat, PRs, or execute params.
+- Preview seed starts with zero secrets.

--- a/.agents/skills/control-kody/references/features/signup.md
+++ b/.agents/skills/control-kody/references/features/signup.md
@@ -1,0 +1,25 @@
+# Sign up and email verify
+
+Create an account, then confirm email.
+
+## How to get there
+
+`/signup` → verification email → `/verify-email` or `/pending-verification`.
+
+## Drive it
+
+Prefer the seeded login. Creating accounts in preview is rarely needed.
+
+```bash
+node tools/control-kody.ts request GET /signup --origin http://localhost:3742 --skip-login
+```
+
+## APIs
+
+- `POST /auth` `{ mode: "signup", ... }`
+- `POST /account/resend-verification.json`
+
+## Gotchas
+
+- Preview seed is already verified. Do not invent a second user unless the
+  change is the signup path itself.

--- a/.agents/skills/control-kody/references/features/signup.md
+++ b/.agents/skills/control-kody/references/features/signup.md
@@ -5,6 +5,7 @@ Create an account, then confirm email.
 ## How to get there
 
 `/signup` → verification email → `/verify-email` or `/pending-verification`.
+Email-change confirm is `/verify-email-change` (token from the change email).
 
 ## Drive it
 

--- a/.agents/skills/control-kody/references/features/two-factor.md
+++ b/.agents/skills/control-kody/references/features/two-factor.md
@@ -1,0 +1,23 @@
+# Two-factor auth
+
+TOTP setup and the `/verify` challenge after password login.
+
+## How to get there
+
+`/account/two-factor` while signed in. Challenge: `/verify`.
+
+## Drive it
+
+```bash
+node tools/control-kody.ts request GET /account/two-factor.json
+```
+
+## APIs
+
+- `GET|POST /account/two-factor.json`
+- `POST /verify/2fa.json`
+
+## Gotchas
+
+- SSR can paint before Remix binds click handlers. E2E waits on
+  `html[data-hydrated]`. A screenshot of the form is not proof the submit works.

--- a/.agents/skills/control-kody/references/features/values.md
+++ b/.agents/skills/control-kody/references/features/values.md
@@ -1,0 +1,19 @@
+# Values
+
+Named user values (locale and similar knobs).
+
+## How to get there
+
+`/account/values` → `/account/values/new` → `/account/values/:valueId`.
+
+## Drive it
+
+```bash
+node tools/control-kody.ts request \
+  POST /account/values.json \
+  --body '{"action":"save","name":"locale","value":"en-US"}'
+```
+
+## APIs
+
+- `GET|POST /account/values.json`

--- a/.agents/skills/control-kody/references/features/waiting.md
+++ b/.agents/skills/control-kody/references/features/waiting.md
@@ -1,0 +1,27 @@
+# Waiting inbox
+
+Things waiting on the signed-in human (approvals, reconnects, publish locks).
+
+## How to get there
+
+`/account/waiting`. Not a notifications product — fold connection-health and
+approve-publish here instead of inventing another inbox.
+
+## Drive it
+
+```bash
+node tools/control-kody.ts preview -- \
+  --request 'GET /account/waiting.json' \
+  --check /account/waiting
+```
+
+`#1928` seeded a waiting probe, then recorded a preview video of the live page.
+
+## APIs
+
+- `GET /account/waiting.json`
+
+## Gotchas
+
+- Empty is the common seed state. Create the pending grant or locked package
+  through the same JSON APIs the UI uses before asserting copy.

--- a/.agents/skills/control-kody/references/features/workflows.md
+++ b/.agents/skills/control-kody/references/features/workflows.md
@@ -1,0 +1,21 @@
+# Workflows
+
+Deferred one-shot runs (`workflows.create({ runAt })`).
+
+## How to get there
+
+`/account/workflows` → `/account/workflows/:workflowId`.
+
+## Drive it
+
+```bash
+node tools/control-kody.ts request GET /account/workflows.json
+```
+
+## APIs
+
+- `GET|POST /account/workflows.json`
+
+## Gotchas
+
+- Recurring work belongs on `kody.jobs`, not workflows.

--- a/.agents/skills/preview-manual-test/SKILL.md
+++ b/.agents/skills/preview-manual-test/SKILL.md
@@ -13,6 +13,13 @@ Read
 Do not improvise `gh` comment scraping, local E2E against the preview URL, or
 raw D1 seeding of preview resources.
 
+Prefer [`control-kody`](../control-kody/SKILL.md) when you also need `doctor`,
+local login, Feature Map lookup, or a `/health` SHA check:
+
+```bash
+npm run control-kody -- preview -- --request 'GET /onboarding.json' --check /onboarding
+```
+
 ## Command
 
 ```bash

--- a/.agents/skills/ship-pr/SKILL.md
+++ b/.agents/skills/ship-pr/SKILL.md
@@ -47,9 +47,12 @@ CodeRabbit when the change is **high** risk (or the user explicitly asks).
 2. Wait for CI — `gh pr checks` (or compose `loop-on-ci` / `fix-ci`).
 3. Fix failures; for **medium+**, wait on AI reviewer(s) (Bugbot first; see
    above for CodeRabbit) and address valid feedback. Rebase only when actually
-   unmergeable. For **medium+**, also run `npm run preview:manual-test` as the
-   seeded user **with data for this change** (`--request` / session cookie; see
-   [preview-manual-test skill](../preview-manual-test/SKILL.md)).
+   unmergeable. For **medium+**, also run `npm run control-kody -- preview` (or
+   `npm run preview:manual-test`) as the seeded user **with data for this
+   change** (`--request` / session cookie; see
+   [control-kody](../control-kody/SKILL.md) and
+   [preview-manual-test](../preview-manual-test/SKILL.md)). After merge,
+   `npm run control-kody -- health --origin https://kody.codes --sha <merge>`.
 4. Green + (medium+: valid feedback cleared) → break.
 5. Push → repeat.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,9 +21,12 @@ This file is intentionally brief. Detailed instructions live in focused docs:
 - Setup, checks, docs maintenance, preview deploys, and seeding:
   - [docs/contributing/setup/index.md](./docs/contributing/setup/index.md)
 - Manual PR preview testing (medium/high risk, logged-in user + data):
-  - [docs/contributing/preview-manual-testing.md](./docs/contributing/preview-manual-testing.md)
-    and the
-    [preview-manual-test skill](./.agents/skills/preview-manual-test/SKILL.md)
+- [docs/contributing/preview-manual-testing.md](./docs/contributing/preview-manual-testing.md)
+  and the
+  [preview-manual-test skill](./.agents/skills/preview-manual-test/SKILL.md)
+- App verification CLI and Feature Map:
+- [docs/contributing/control-kody.md](./docs/contributing/control-kody.md) and
+  the [control-kody skill](./.agents/skills/control-kody/SKILL.md)
 - Documentation principles (usage vs contributing, MCP text, gardening, prefer
   checkers over should-lists):
   - [docs/contributing/documentation.md](./docs/contributing/documentation.md)

--- a/docs/contributing/cloud-agents.md
+++ b/docs/contributing/cloud-agents.md
@@ -87,14 +87,15 @@ dispatcher. The command is a no-op on machines without `~/.cursor/agent-hooks`.
 
 ## Quick commands
 
-| Task               | Command                                                         |
-| ------------------ | --------------------------------------------------------------- |
-| Install deps       | `npm install`                                                   |
-| Start or reuse dev | `npm run dev:ensure` (prints the resolved URL)                  |
-| Migrate local D1   | `npm run migrate:local`                                         |
-| Seed test login    | `node tools/seed-test-data.ts --local` (see seeding note below) |
-| Full validate gate | `npm run validate` (CI runs the same checks as parallel jobs)   |
-| Manual PR preview  | `npm run preview:manual-test` (see preview-manual-testing.md)   |
+| Task               | Command                                                                                                                          |
+| ------------------ | -------------------------------------------------------------------------------------------------------------------------------- |
+| Install deps       | `npm install`                                                                                                                    |
+| Start or reuse dev | `npm run dev:ensure` (prints the resolved URL)                                                                                   |
+| Migrate local D1   | `npm run migrate:local`                                                                                                          |
+| Seed test login    | `node tools/seed-test-data.ts --local` (see seeding note below)                                                                  |
+| Full validate gate | `npm run validate` (CI runs the same checks as parallel jobs)                                                                    |
+| Manual PR preview  | `npm run preview:manual-test` (see preview-manual-testing.md)                                                                    |
+| App verification   | `npm run control-kody -- doctor` then `login` / `request` / `map` / `preview` / `health` (see [control-kody](./control-kody.md)) |
 
 ## Dev server
 

--- a/docs/contributing/control-kody.md
+++ b/docs/contributing/control-kody.md
@@ -1,0 +1,60 @@
+# control-kody
+
+Cloud Agents verify Kody with one CLI and a Feature Map instead of throwaway
+scripts. The CLI wraps `dev:ensure`, seed login, authenticated HTTP, PR preview
+smoke, `/health` SHA checks, and the Feature Map.
+
+```bash
+npm run control-kody -- doctor
+npm run control-kody -- dev
+npm run control-kody -- login
+npm run control-kody -- request GET /account/waiting.json
+npm run control-kody -- map waiting
+npm run control-kody -- health --sha <commit>
+npm run control-kody -- preview -- --pr 42 --check /account/waiting
+```
+
+Same entry: `node tools/control-kody.ts`.
+
+## Feature Map
+
+[`.agents/skills/control-kody/references/features/`](../../.agents/skills/control-kody/references/features/README.md)
+is the human index.
+[`tools/control-kody/feature-catalog.ts`](../../tools/control-kody/feature-catalog.ts)
+is the catalog `map --check` and `tools/control-kody.node.test.ts` enforce
+against
+[`packages/worker/universal/routes.ts`](../../packages/worker/universal/routes.ts).
+
+When you add, remove, or rename a user-facing HTML route under `/account`,
+`/admin`, `/login`, `/onboarding`, `/community`, or `/@`, update the catalog and
+the matching feature file in the same change.
+
+## Seed login
+
+`login` and `request` pick credentials from the origin host:
+
+- `localhost` / `127.0.0.1` → `jane@example.com` / `ilikecode`
+- anything else (PR preview, production) → `me@kentcdodds.com` / `ilikecode`
+
+Override with `--email` / `--password`. `--cookie-file` defaults to
+`.tmp/control-kody-cookie`. `preview` uses
+[`preview-manual-test`](./preview-manual-testing.md) and its own seed.
+
+## Daily garden
+
+`@kentcdodds/verification-skill-maintain` runs every day at 06:00
+America/Denver. It scans the Feature Map on `kentcdodds/kody` `main` and spawns
+one Cursor Cloud Agent when the catalog is stale or a required route is
+unmapped. The agent updates the map, follows
+[`ship-pr`](../../.agents/skills/ship-pr/SKILL.md) for low or medium risk, and
+records an outcome. Pause with
+`kody:@kentcdodds/verification-skill-maintain/pause`.
+
+This is the same shape as the [friction log](./friction-log.md) and e2e flake
+hunter packages: a Kody job, not a GitHub cron.
+
+## Related
+
+- [control-kody skill](../../.agents/skills/control-kody/SKILL.md)
+- [Manual preview testing](./preview-manual-testing.md)
+- [Cursor Cloud Agent notes](./cloud-agents.md)

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -16,6 +16,8 @@ style, tests, MCP capabilities, and runtime architecture.
   [environment variables](./environment-variables.md),
   [setup manifest](./setup-manifest.md)
 - [Manual PR preview testing](./preview-manual-testing.md)
+- [control-kody](./control-kody.md) (Feature Map + CLI; daily
+  `@kentcdodds/verification-skill-maintain`)
 - [Optional Cloudflare offerings](./cloudflare-offerings.md)
 - [Cursor Cloud Agent notes](./cloud-agents.md)
 - [Nx remote cache](../../packages/nx-cache/readme.md) (self-hosted HTTP cache

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "e2e:web-server": "node tools/prepare-e2e-env.ts && node tools/ensure-e2e-client.ts && npm run migrate:e2e && node --env-file=packages/worker/.env ./wrangler-env.ts dev --local --persist-to .wrangler/state/e2e",
     "preview:e2e": "node tools/prepare-e2e-env.ts && nx run worker:build-client && npm run migrate:e2e && node --env-file=packages/worker/.env ./wrangler-env.ts dev --local --persist-to .wrangler/state/e2e",
     "preview:manual-test": "node tools/preview-manual-test.ts",
+    "control-kody": "node tools/control-kody.ts",
     "site-perf": "node tools/site-perf/collect.ts",
     "generate-types": "node --env-file=packages/worker/.env ./wrangler-env.ts types ./packages/worker/worker-configuration.d.ts",
     "typecheck": "nx run worker:typecheck && tsc --noEmit -p packages/backup-control-plane/tsconfig.json && tsc --noEmit -p packages/status/tsconfig.json && tsc --noEmit -p packages/jobs-worker/tsconfig.json && tsc --noEmit -p packages/highlight-worker/tsconfig.json && tsc --noEmit -p packages/nx-cache/tsconfig.json",

--- a/tools/control-kody.node.test.ts
+++ b/tools/control-kody.node.test.ts
@@ -20,6 +20,7 @@ import {
 	readHealth,
 	repoRootFromHere,
 	requestAsSession,
+	runCommand,
 	runDoctor,
 	runMapCheck,
 } from './control-kody.ts'
@@ -219,6 +220,56 @@ test('control-kody parses commands, maps every required route, and drives a seed
 			expect(stale.ok).toBe(false)
 		},
 	)
+})
+
+test('control-kody request stops when auto-login fails', async () => {
+	await withAuthServer(
+		(_request, response) => {
+			response.statusCode = 401
+			response.setHeader('Content-Type', 'application/json')
+			response.end(JSON.stringify({ ok: false }))
+		},
+		async (origin) => {
+			const code = await runCommand(
+				parseControlArgs([
+					'request',
+					'GET',
+					'/account/waiting.json',
+					'--origin',
+					origin,
+					'--json',
+					'--cookie-file',
+					path.join(tmpdir(), 'control-kody-missing-cookie'),
+				]),
+			)
+			expect(code).toBe(1)
+		},
+	)
+})
+
+test('control-kody map --check reports a new /account page as unmapped', async () => {
+	const dir = await mkdtemp(path.join(tmpdir(), 'control-kody-unmapped-'))
+	try {
+		const files = featureCatalog.map((feature) => feature.file)
+		for (const name of files) {
+			await writeFile(path.join(dir, name), `# ${name}\n`)
+		}
+		const report = runMapCheck({
+			routeSource: `${readFileSync(defaultRoutesPath(repoRootFromHere()), 'utf8')}
+export const extra = '/account/new-surface'`,
+			featuresDir: dir,
+		})
+		expect(report.ok).toBe(false)
+		expect(
+			report.issues.some(
+				(issue) =>
+					issue.kind === 'unmapped-route' &&
+					issue.path === '/account/new-surface',
+			),
+		).toBe(true)
+	} finally {
+		await rm(dir, { recursive: true, force: true })
+	}
 })
 
 test('control-kody map --check reports a stale Feature Map path', async () => {

--- a/tools/control-kody.node.test.ts
+++ b/tools/control-kody.node.test.ts
@@ -1,0 +1,239 @@
+import {
+	createServer,
+	type IncomingMessage,
+	type ServerResponse,
+} from 'node:http'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import { tmpdir } from 'node:os'
+import { expect, test } from 'vitest'
+import { readFileSync, readdirSync } from 'node:fs'
+import {
+	credentialsForOrigin,
+	defaultFeaturesDir,
+	defaultRoutesPath,
+	formatFeatureMap,
+	loginToOrigin,
+	localSeedEmail,
+	parseControlArgs,
+	playwrightBrowsersInstalled,
+	readHealth,
+	repoRootFromHere,
+	requestAsSession,
+	runDoctor,
+	runMapCheck,
+} from './control-kody.ts'
+import { previewSeedEmail } from './preview-manual-test.ts'
+import { featureCatalog } from './control-kody/feature-catalog.ts'
+
+async function withAuthServer(
+	handler: (request: IncomingMessage, response: ServerResponse) => void,
+	run: (origin: string) => Promise<void>,
+) {
+	const server = createServer(handler)
+	await new Promise<void>((resolve) => {
+		server.listen(0, '127.0.0.1', resolve)
+	})
+	const address = server.address()
+	if (!address || typeof address === 'string') {
+		throw new Error('expected TCP address')
+	}
+	try {
+		await run(`http://127.0.0.1:${address.port}`)
+	} finally {
+		await new Promise<void>((resolve, reject) => {
+			server.close((error) => {
+				if (error) reject(error)
+				else resolve()
+			})
+		})
+	}
+}
+
+test('control-kody parses commands, maps every required route, and drives a seed login', async () => {
+	expect(parseControlArgs(['--help']).command).toBe('help')
+	expect(parseControlArgs(['map', 'waiting', '--check'])).toEqual(
+		expect.objectContaining({
+			command: 'map',
+			featureId: 'waiting',
+			check: true,
+		}),
+	)
+	expect(
+		parseControlArgs([
+			'request',
+			'GET',
+			'/account/waiting.json',
+			'--origin',
+			'http://localhost:3742',
+		]).request,
+	).toEqual({
+		method: 'GET',
+		path: '/account/waiting.json',
+		expectedStatus: null,
+		body: null,
+	})
+	expect(
+		parseControlArgs(['request', 'GET', '/admin', '403', '--skip-login'])
+			.request,
+	).toEqual({
+		method: 'GET',
+		path: '/admin',
+		expectedStatus: 403,
+		body: null,
+	})
+	expect(parseControlArgs(['preview', '--', '--pr', '42']).previewArgv).toEqual(
+		['--pr', '42'],
+	)
+	expect(() => parseControlArgs(['nope'])).toThrow(/Unknown command/)
+
+	expect(credentialsForOrigin('http://localhost:3742').email).toBe(
+		localSeedEmail,
+	)
+	expect(credentialsForOrigin('https://kody-pr-9.kody.workers.dev').email).toBe(
+		previewSeedEmail,
+	)
+
+	const root = repoRootFromHere()
+	const report = runMapCheck({
+		routeSource: readFileSync(defaultRoutesPath(root), 'utf8'),
+		featuresDir: defaultFeaturesDir(root),
+	})
+	expect(report.issues).toEqual([])
+	expect(report.ok).toBe(true)
+	expect(formatFeatureMap(featureCatalog)).toContain(
+		'waiting\t/account/waiting',
+	)
+	expect(
+		readdirSync(defaultFeaturesDir(root)).filter((name) =>
+			name.endsWith('.md'),
+		),
+	).toEqual(
+		expect.arrayContaining(featureCatalog.map((feature) => feature.file)),
+	)
+
+	const doctor = await runDoctor({
+		nodeVersion: 'v26.1.2',
+		homeDir: tmpdir(),
+		hooksPath: '.husky',
+		playwrightMarkerExists: () => true,
+		probeHealth: async () => true,
+		ports: [3742],
+		origin: 'http://localhost:3742',
+	})
+	expect(doctor.ok).toBe(true)
+	expect(doctor.checks.map((check) => check.name)).toEqual([
+		'node',
+		'playwright',
+		'hooks',
+		'health',
+	])
+
+	const oldNode = await runDoctor({
+		nodeVersion: 'v22.14.0',
+		homeDir: tmpdir(),
+		hooksPath: null,
+		playwrightMarkerExists: () => false,
+		probeHealth: async () => false,
+		ports: [3742],
+		origin: null,
+	})
+	expect(oldNode.ok).toBe(false)
+	expect(oldNode.checks.find((check) => check.name === 'node')?.detail).toMatch(
+		/below 26/,
+	)
+	expect(playwrightBrowsersInstalled(tmpdir())).toBe(false)
+
+	await withAuthServer(
+		(request, response) => {
+			const url = request.url ?? '/'
+			if (request.method === 'POST' && url === '/auth') {
+				response.setHeader('Set-Cookie', 'kody_session=abc; Path=/')
+				response.setHeader('Content-Type', 'application/json')
+				response.end(JSON.stringify({ ok: true }))
+				return
+			}
+			if (url === '/health') {
+				response.setHeader('Content-Type', 'application/json')
+				response.end(JSON.stringify({ ok: true, commitSha: 'abc123' }))
+				return
+			}
+			if (url === '/account/waiting.json') {
+				if (request.headers.cookie !== 'kody_session=abc') {
+					response.statusCode = 401
+					response.end('{"ok":false}')
+					return
+				}
+				response.setHeader('Content-Type', 'application/json')
+				response.end(JSON.stringify({ items: [] }))
+				return
+			}
+			if (url === '/admin') {
+				response.statusCode = 403
+				response.end('forbidden')
+				return
+			}
+			response.statusCode = 404
+			response.end('missing')
+		},
+		async (origin) => {
+			const session = await loginToOrigin({
+				origin,
+				email: localSeedEmail,
+				password: 'ilikecode',
+			})
+			expect(session.ok).toBe(true)
+			expect(session.cookieHeader).toBe('kody_session=abc')
+
+			const waiting = await requestAsSession({
+				origin,
+				cookieHeader: session.cookieHeader,
+				spec: {
+					method: 'GET',
+					path: '/account/waiting.json',
+					expectedStatus: null,
+					body: null,
+				},
+			})
+			expect(waiting.ok).toBe(true)
+			expect(waiting.body).toEqual({ items: [] })
+
+			const admin = await requestAsSession({
+				origin,
+				cookieHeader: session.cookieHeader,
+				spec: {
+					method: 'GET',
+					path: '/admin',
+					expectedStatus: 403,
+					body: null,
+				},
+			})
+			expect(admin.ok).toBe(true)
+			expect(admin.status).toBe(403)
+
+			const health = await readHealth({ origin, expectedSha: 'abc123' })
+			expect(health.ok).toBe(true)
+			expect(health.commitSha).toBe('abc123')
+
+			const stale = await readHealth({ origin, expectedSha: 'fff' })
+			expect(stale.ok).toBe(false)
+		},
+	)
+})
+
+test('control-kody map --check reports a stale Feature Map path', async () => {
+	const dir = await mkdtemp(path.join(tmpdir(), 'control-kody-map-'))
+	try {
+		await writeFile(path.join(dir, 'waiting.md'), '# Waiting\n')
+		const report = runMapCheck({
+			routeSource: `export const routes = { waiting: '/account/waiting' }`,
+			featuresDir: dir,
+		})
+		expect(report.ok).toBe(false)
+		expect(report.issues.some((issue) => issue.kind === 'missing-file')).toBe(
+			true,
+		)
+	} finally {
+		await rm(dir, { recursive: true, force: true })
+	}
+})

--- a/tools/control-kody.ts
+++ b/tools/control-kody.ts
@@ -1,0 +1,738 @@
+import { execFile, execFileSync } from 'node:child_process'
+import { existsSync, readdirSync, readFileSync } from 'node:fs'
+import { mkdir, writeFile } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import path from 'node:path'
+import { promisify } from 'node:util'
+import {
+	createDefaultEnsureDevDeps,
+	ensureDev,
+	formatAppRunning,
+} from './ensure-dev.ts'
+import {
+	findHealthyWorkerOrigin,
+	healthUrlForOrigin,
+	isWorkerHealthOk,
+	workerPortRange,
+} from './dev-server.ts'
+import { isExecutedDirectly, resolveNpmCommand } from './node-runtime.ts'
+import {
+	checkFeatureCatalog,
+	featureCatalog,
+	featuresDirRelativePath,
+	findFeature,
+	type Feature,
+} from './control-kody/feature-catalog.ts'
+import {
+	cookieHeaderFromSetCookie,
+	evaluateAppHealth,
+	parseArgs as parsePreviewArgs,
+	parseSessionRequest,
+	previewSeedEmail,
+	previewSeedPassword,
+	runPreviewManualTest,
+	type SessionRequestSpec,
+} from './preview-manual-test.ts'
+
+const execFileAsync = promisify(execFile)
+
+export const localSeedEmail = 'jane@example.com'
+export const localSeedPassword = 'ilikecode'
+export const localAdminEmail = 'kody@example.com'
+
+const usageLines = [
+	'Usage: node tools/control-kody.ts <command> [options]',
+	'',
+	'Drive and verify the Kody app without throwaway scripts.',
+	'',
+	'Commands:',
+	'  doctor     Check Node, Playwright browsers, hooks, and /health',
+	'  dev        Start or reuse the local origin (npm run dev:ensure)',
+	'  login      POST /auth and write a session cookie',
+	'  request    Authenticated HTTP as the current session',
+	'  preview    PR preview smoke (wraps preview:manual-test)',
+	'  health     GET /health and optionally assert commitSha',
+	'  map        List or print a Feature Map entry; --check for drift',
+	'',
+	'Common options:',
+	'  --origin <url>       App origin (default: healthy local 3742-3751)',
+	'  --json               Machine-readable stdout',
+	'  --cookie-file <p>    Session Cookie header file',
+	'  --help               Print this help',
+	'',
+	'Docs: docs/contributing/control-kody.md',
+]
+
+export type ControlKodyCommand =
+	| 'doctor'
+	| 'dev'
+	| 'login'
+	| 'request'
+	| 'preview'
+	| 'health'
+	| 'map'
+	| 'help'
+
+export type ControlKodyOptions = {
+	command: ControlKodyCommand
+	origin: string | null
+	json: boolean
+	help: boolean
+	cookieFile: string
+	email: string | null
+	password: string | null
+	skipLogin: boolean
+	sha: string | null
+	featureId: string | null
+	check: boolean
+	request: SessionRequestSpec | null
+	body: string | null
+	previewArgv: Array<string>
+}
+
+export class ControlKodyError extends Error {
+	constructor(message: string) {
+		super(message)
+		this.name = 'ControlKodyError'
+	}
+}
+
+export function defaultCookieFile() {
+	return path.join('.tmp', 'control-kody-cookie')
+}
+
+export function credentialsForOrigin(origin: string) {
+	try {
+		const host = new URL(origin).hostname
+		if (host === 'localhost' || host === '127.0.0.1') {
+			return {
+				email: localSeedEmail,
+				password: localSeedPassword,
+				kind: 'local' as const,
+			}
+		}
+	} catch {
+		// fall through to preview seed
+	}
+	return {
+		email: previewSeedEmail,
+		password: previewSeedPassword,
+		kind: 'preview' as const,
+	}
+}
+
+export function parseControlArgs(argv: Array<string>): ControlKodyOptions {
+	const options: ControlKodyOptions = {
+		command: 'help',
+		origin: null,
+		json: false,
+		help: false,
+		cookieFile: defaultCookieFile(),
+		email: null,
+		password: null,
+		skipLogin: false,
+		sha: null,
+		featureId: null,
+		check: false,
+		request: null,
+		body: null,
+		previewArgv: [],
+	}
+
+	const [command, ...rest] = argv
+	if (
+		!command ||
+		command === '--help' ||
+		command === '-h' ||
+		command === 'help'
+	) {
+		options.command = 'help'
+		options.help = true
+		return options
+	}
+
+	const commands: ReadonlyArray<ControlKodyCommand> = [
+		'doctor',
+		'dev',
+		'login',
+		'request',
+		'preview',
+		'health',
+		'map',
+		'help',
+	]
+	if (!commands.includes(command as ControlKodyCommand)) {
+		throw new ControlKodyError(
+			`Unknown command ${command}. Try: ${commands.join(', ')}`,
+		)
+	}
+	options.command = command as ControlKodyCommand
+
+	if (options.command === 'preview') {
+		const separator = rest.indexOf('--')
+		options.previewArgv = separator === -1 ? rest : rest.slice(separator + 1)
+		if (separator === -1) {
+			parseSharedFlags(rest, options)
+		} else {
+			parseSharedFlags(rest.slice(0, separator), options)
+		}
+		return options
+	}
+
+	if (options.command === 'request') {
+		const positional: Array<string> = []
+		parseSharedFlags(rest, options, positional)
+		if (positional.length > 0) {
+			const spec = [positional[0], positional[1], positional[2]]
+				.filter((part): part is string => Boolean(part))
+				.join(' ')
+			const parsed = parseSessionRequest(spec)
+			if (options.body) {
+				parsed.body = JSON.parse(options.body)
+			}
+			options.request = parsed
+		}
+		return options
+	}
+
+	if (options.command === 'map') {
+		const positional: Array<string> = []
+		parseSharedFlags(rest, options, positional)
+		options.featureId = positional[0] ?? null
+		return options
+	}
+
+	parseSharedFlags(rest, options)
+	return options
+}
+
+function parseSharedFlags(
+	argv: Array<string>,
+	options: ControlKodyOptions,
+	positional: Array<string> = [],
+) {
+	for (let index = 0; index < argv.length; index += 1) {
+		const arg = argv[index]
+		if (!arg) continue
+		switch (arg) {
+			case '--help':
+			case '-h': {
+				options.help = true
+				break
+			}
+			case '--json': {
+				options.json = true
+				break
+			}
+			case '--check': {
+				options.check = true
+				break
+			}
+			case '--skip-login': {
+				options.skipLogin = true
+				break
+			}
+			case '--origin': {
+				options.origin = requireValue(argv[index + 1], '--origin')
+				index += 1
+				break
+			}
+			case '--cookie-file': {
+				options.cookieFile = requireValue(argv[index + 1], '--cookie-file')
+				index += 1
+				break
+			}
+			case '--email': {
+				options.email = requireValue(argv[index + 1], '--email')
+				index += 1
+				break
+			}
+			case '--password': {
+				options.password = requireValue(argv[index + 1], '--password')
+				index += 1
+				break
+			}
+			case '--sha': {
+				options.sha = requireValue(argv[index + 1], '--sha')
+				index += 1
+				break
+			}
+			case '--body': {
+				options.body = requireValue(argv[index + 1], '--body')
+				index += 1
+				break
+			}
+			default: {
+				if (arg.startsWith('-')) {
+					throw new ControlKodyError(`Unknown flag ${arg}`)
+				}
+				positional.push(arg)
+			}
+		}
+	}
+}
+
+function requireValue(value: string | undefined, flag: string) {
+	if (!value || value.startsWith('-')) {
+		throw new ControlKodyError(`${flag} requires a value`)
+	}
+	return value
+}
+
+export type DoctorCheck = {
+	name: string
+	ok: boolean
+	detail: string
+}
+
+export type DoctorReport = {
+	ok: boolean
+	checks: Array<DoctorCheck>
+}
+
+export type DoctorDeps = {
+	nodeVersion: string
+	homeDir: string
+	hooksPath: string | null
+	playwrightMarkerExists: (homeDir: string) => boolean
+	probeHealth: (origin: string) => Promise<boolean>
+	ports: ReadonlyArray<number>
+	origin: string | null
+}
+
+export function playwrightBrowsersInstalled(homeDir: string) {
+	const root = path.join(homeDir, '.cache', 'ms-playwright')
+	if (!existsSync(root)) return false
+	try {
+		const entries = readdirSync(root, { withFileTypes: true })
+		return entries.some((entry) => {
+			if (!entry.isDirectory()) return false
+			return existsSync(path.join(root, entry.name, 'INSTALLATION_COMPLETE'))
+		})
+	} catch {
+		return false
+	}
+}
+
+export async function runDoctor(deps: DoctorDeps): Promise<DoctorReport> {
+	const checks: Array<DoctorCheck> = []
+	const major = Number.parseInt(deps.nodeVersion.replace(/^v/, ''), 10)
+	const nodeOk = Number.isFinite(major) && major >= 26
+	checks.push({
+		name: 'node',
+		ok: nodeOk,
+		detail: nodeOk
+			? `Node ${deps.nodeVersion} (>=26)`
+			: `Node ${deps.nodeVersion} is below 26. Prepend nvm's Node 26 bin to PATH. See docs/contributing/cloud-agents.md.`,
+	})
+
+	const playwrightOk = deps.playwrightMarkerExists(deps.homeDir)
+	checks.push({
+		name: 'playwright',
+		ok: playwrightOk,
+		detail: playwrightOk
+			? 'Playwright INSTALLATION_COMPLETE marker present'
+			: 'Playwright browsers missing. Do not run playwright install on this VM; unzip per docs/contributing/cloud-agents.md.',
+	})
+
+	const hooksOk = Boolean(deps.hooksPath && deps.hooksPath.length > 0)
+	checks.push({
+		name: 'hooks',
+		ok: hooksOk,
+		detail: hooksOk
+			? `core.hooksPath=${deps.hooksPath}`
+			: 'git core.hooksPath is empty. Run npm run hooks:ensure.',
+	})
+
+	const origin =
+		deps.origin ??
+		(await findHealthyWorkerOrigin(deps.ports, { probe: deps.probeHealth }))
+	if (origin) {
+		const healthy = await deps.probeHealth(origin)
+		checks.push({
+			name: 'health',
+			ok: healthy,
+			detail: healthy
+				? `${origin}/health ok`
+				: `${origin} accepted TCP but /health failed. Run control-kody dev.`,
+		})
+	} else {
+		checks.push({
+			name: 'health',
+			ok: true,
+			detail: 'no local origin yet; run control-kody dev when you need one',
+		})
+	}
+
+	return { ok: checks.every((check) => check.ok), checks }
+}
+
+export async function resolveOrigin(options: {
+	origin: string | null
+	probeHealth?: (origin: string) => Promise<boolean>
+}) {
+	if (options.origin) return options.origin.replace(/\/$/, '')
+	const probe =
+		options.probeHealth ?? ((origin: string) => isWorkerHealthOk(origin))
+	const found = await findHealthyWorkerOrigin(workerPortRange(), { probe })
+	if (!found) {
+		throw new ControlKodyError(
+			'No healthy origin on 3742-3751. Run: node tools/control-kody.ts dev',
+		)
+	}
+	return found
+}
+
+export type SessionResult = {
+	ok: boolean
+	origin: string
+	email: string
+	cookieHeader: string | null
+	status: number | null
+	detail: string
+}
+
+export async function loginToOrigin(input: {
+	origin: string
+	email: string
+	password: string
+	fetchImpl?: typeof fetch
+}): Promise<SessionResult> {
+	const fetchImpl = input.fetchImpl ?? fetch
+	const response = await fetchImpl(`${input.origin}/auth`, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify({
+			email: input.email,
+			password: input.password,
+			mode: 'login',
+		}),
+	})
+	const setCookie = response.headers.getSetCookie?.() ?? []
+	const cookieHeader = cookieHeaderFromSetCookie(setCookie)
+	let body: unknown = null
+	try {
+		body = await response.json()
+	} catch {
+		body = null
+	}
+	const ok =
+		response.ok &&
+		Boolean(cookieHeader) &&
+		(body as { ok?: unknown } | null)?.ok !== false
+	return {
+		ok,
+		origin: input.origin,
+		email: input.email,
+		cookieHeader: cookieHeader || null,
+		status: response.status,
+		detail: ok
+			? `signed in as ${input.email}`
+			: `HTTP ${response.status} ${JSON.stringify(body)}; cookie ${cookieHeader ? 'present' : 'missing'}`,
+	}
+}
+
+export type RequestResult = {
+	ok: boolean
+	status: number
+	path: string
+	body: unknown
+	detail: string
+}
+
+export async function requestAsSession(input: {
+	origin: string
+	spec: SessionRequestSpec
+	cookieHeader: string | null
+	fetchImpl?: typeof fetch
+}): Promise<RequestResult> {
+	const fetchImpl = input.fetchImpl ?? fetch
+	const headers: Record<string, string> = {
+		Accept: 'application/json, text/html',
+	}
+	if (input.cookieHeader) headers.Cookie = input.cookieHeader
+	if (input.spec.body !== null) headers['Content-Type'] = 'application/json'
+	const response = await fetchImpl(`${input.origin}${input.spec.path}`, {
+		method: input.spec.method,
+		headers,
+		body:
+			input.spec.body === null ? undefined : JSON.stringify(input.spec.body),
+	})
+	const text = await response.text()
+	let body: unknown = text
+	try {
+		body = JSON.parse(text) as unknown
+	} catch {
+		body = text
+	}
+	const expected = input.spec.expectedStatus
+	const ok = expected === null ? response.ok : response.status === expected
+	return {
+		ok,
+		status: response.status,
+		path: input.spec.path,
+		body,
+		detail: ok
+			? `HTTP ${response.status}`
+			: `expected ${expected ?? '2xx'}, got HTTP ${response.status}`,
+	}
+}
+
+export async function readHealth(input: {
+	origin: string
+	expectedSha: string | null
+	fetchImpl?: typeof fetch
+}) {
+	const fetchImpl = input.fetchImpl ?? fetch
+	const response = await fetchImpl(healthUrlForOrigin(input.origin))
+	let body: unknown = null
+	try {
+		body = await response.json()
+	} catch {
+		body = null
+	}
+	const evaluated = evaluateAppHealth(body, input.expectedSha)
+	return {
+		ok: response.ok && evaluated.ok,
+		status: response.status,
+		origin: input.origin,
+		commitSha: evaluated.commitSha,
+		detail: response.ok
+			? evaluated.detail
+			: `HTTP ${response.status}: ${evaluated.detail}`,
+	}
+}
+
+export function readCookieFile(cookieFile: string) {
+	if (!existsSync(cookieFile)) return null
+	const value = readFileSync(cookieFile, 'utf8').trim()
+	return value.length > 0 ? value : null
+}
+
+export async function writeCookieFile(
+	cookieFile: string,
+	cookieHeader: string,
+) {
+	await mkdir(path.dirname(cookieFile), { recursive: true })
+	await writeFile(cookieFile, `${cookieHeader}\n`)
+}
+
+export function formatFeatureMap(features: ReadonlyArray<Feature>) {
+	return features
+		.map(
+			(feature) => `${feature.id}\t${feature.paths[0] ?? ''}\t${feature.title}`,
+		)
+		.join('\n')
+}
+
+export function repoRootFromHere(here = import.meta.dirname) {
+	return path.resolve(here, '..')
+}
+
+export function defaultRoutesPath(root: string) {
+	return path.join(root, 'packages/worker/universal/routes.ts')
+}
+
+export function defaultFeaturesDir(root: string) {
+	return path.join(root, featuresDirRelativePath)
+}
+
+export function runMapCheck(input: {
+	routeSource: string
+	featuresDir: string
+}) {
+	const existingFiles = existsSync(input.featuresDir)
+		? readdirSync(input.featuresDir).filter((name) => name.endsWith('.md'))
+		: []
+	return checkFeatureCatalog({
+		routeSource: input.routeSource,
+		existingFiles,
+	})
+}
+
+export function defaultDoctorDeps(origin: string | null = null): DoctorDeps {
+	return {
+		nodeVersion: process.version,
+		homeDir: homedir(),
+		hooksPath: readGitHooksPath(),
+		playwrightMarkerExists: playwrightBrowsersInstalled,
+		probeHealth: (value) => isWorkerHealthOk(value),
+		ports: workerPortRange(),
+		origin,
+	}
+}
+
+function readGitHooksPath() {
+	try {
+		const result = execFileSyncGit(['config', '--get', 'core.hooksPath'])
+		return result || null
+	} catch {
+		return existsSync(path.join(process.cwd(), '.husky')) ? '.husky' : null
+	}
+}
+
+function execFileSyncGit(args: Array<string>) {
+	return execFileSync('git', args, { encoding: 'utf8' }).trim()
+}
+
+function printJson(value: unknown) {
+	console.log(JSON.stringify(value, null, 2))
+}
+
+async function runCommand(options: ControlKodyOptions) {
+	if (options.help || options.command === 'help') {
+		console.log(usageLines.join('\n'))
+		return 0
+	}
+
+	switch (options.command) {
+		case 'doctor': {
+			const report = await runDoctor(defaultDoctorDeps(options.origin))
+			if (options.json) printJson(report)
+			else {
+				for (const check of report.checks) {
+					console.log(
+						`${check.ok ? 'ok' : 'FAIL'}  ${check.name}: ${check.detail}`,
+					)
+				}
+			}
+			return report.ok ? 0 : 1
+		}
+		case 'dev': {
+			const result = await ensureDev(createDefaultEnsureDevDeps())
+			if (options.json) printJson(result)
+			else console.log(formatAppRunning(result.origin))
+			return 0
+		}
+		case 'login': {
+			const origin = await resolveOrigin(options)
+			const defaults = credentialsForOrigin(origin)
+			const session = await loginToOrigin({
+				origin,
+				email: options.email ?? defaults.email,
+				password: options.password ?? defaults.password,
+			})
+			if (session.cookieHeader) {
+				await writeCookieFile(options.cookieFile, session.cookieHeader)
+			}
+			if (options.json) {
+				printJson({ ...session, cookieFile: options.cookieFile })
+			} else {
+				console.log(session.detail)
+				if (session.ok) console.log(`cookie-file ${options.cookieFile}`)
+			}
+			return session.ok ? 0 : 1
+		}
+		case 'request': {
+			if (!options.request) {
+				throw new ControlKodyError(
+					'request needs METHOD /path [status]. Example: request GET /account/waiting.json',
+				)
+			}
+			const origin = await resolveOrigin(options)
+			let cookieHeader = readCookieFile(options.cookieFile)
+			if (!options.skipLogin && !cookieHeader) {
+				const defaults = credentialsForOrigin(origin)
+				const session = await loginToOrigin({
+					origin,
+					email: options.email ?? defaults.email,
+					password: options.password ?? defaults.password,
+				})
+				cookieHeader = session.cookieHeader
+				if (cookieHeader) {
+					await writeCookieFile(options.cookieFile, cookieHeader)
+				}
+			}
+			const result = await requestAsSession({
+				origin,
+				spec: options.request,
+				cookieHeader,
+			})
+			if (options.json) printJson(result)
+			else {
+				console.log(`${result.detail} ${result.path}`)
+				if (typeof result.body === 'string') console.log(result.body)
+				else console.log(JSON.stringify(result.body, null, 2))
+			}
+			return result.ok ? 0 : 1
+		}
+		case 'preview': {
+			const previewOptions = parsePreviewArgs(options.previewArgv)
+			if (previewOptions.help) {
+				await execFileAsync(resolveNpmCommand(), [
+					'run',
+					'preview:manual-test',
+					'--',
+					'--help',
+				])
+				return 0
+			}
+			const result = await runPreviewManualTest(previewOptions)
+			return result.ok ? 0 : 1
+		}
+		case 'health': {
+			const origin = await resolveOrigin(options)
+			const result = await readHealth({
+				origin,
+				expectedSha: options.sha,
+			})
+			if (options.json) printJson(result)
+			else
+				console.log(`${result.ok ? 'ok' : 'FAIL'} ${origin} ${result.detail}`)
+			return result.ok ? 0 : 1
+		}
+		case 'map': {
+			if (options.check) {
+				const root = repoRootFromHere()
+				const report = runMapCheck({
+					routeSource: readFileSync(defaultRoutesPath(root), 'utf8'),
+					featuresDir: defaultFeaturesDir(root),
+				})
+				if (options.json) printJson(report)
+				else if (report.ok) console.log('Feature Map matches routes.ts')
+				else {
+					for (const issue of report.issues) {
+						console.error(issue.detail)
+					}
+				}
+				return report.ok ? 0 : 1
+			}
+			if (options.featureId) {
+				const feature = findFeature(featureCatalog, options.featureId)
+				if (!feature) {
+					throw new ControlKodyError(
+						`Unknown feature ${options.featureId}. Run: node tools/control-kody.ts map`,
+					)
+				}
+				const filePath = path.join(
+					defaultFeaturesDir(repoRootFromHere()),
+					feature.file,
+				)
+				if (options.json)
+					printJson({ feature, body: readFileSync(filePath, 'utf8') })
+				else console.log(readFileSync(filePath, 'utf8'))
+				return 0
+			}
+			if (options.json) printJson(featureCatalog)
+			else console.log(formatFeatureMap(featureCatalog))
+			return 0
+		}
+		default: {
+			const exhaustive: never = options.command
+			throw new ControlKodyError(`Unhandled command ${String(exhaustive)}`)
+		}
+	}
+}
+
+export { usageLines }
+
+if (isExecutedDirectly(import.meta.url)) {
+	void runCommand(parseControlArgs(process.argv.slice(2)))
+		.then((code) => {
+			process.exit(code)
+		})
+		.catch((error) => {
+			console.error(error instanceof Error ? error.message : error)
+			process.exit(1)
+		})
+}

--- a/tools/control-kody.ts
+++ b/tools/control-kody.ts
@@ -1,9 +1,8 @@
-import { execFile, execFileSync } from 'node:child_process'
+import { execFileSync } from 'node:child_process'
 import { existsSync, readdirSync, readFileSync } from 'node:fs'
-import { mkdir, writeFile } from 'node:fs/promises'
+import { chmod, mkdir, writeFile } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import path from 'node:path'
-import { promisify } from 'node:util'
 import {
 	createDefaultEnsureDevDeps,
 	ensureDev,
@@ -15,7 +14,7 @@ import {
 	isWorkerHealthOk,
 	workerPortRange,
 } from './dev-server.ts'
-import { isExecutedDirectly, resolveNpmCommand } from './node-runtime.ts'
+import { isExecutedDirectly } from './node-runtime.ts'
 import {
 	checkFeatureCatalog,
 	featureCatalog,
@@ -26,15 +25,12 @@ import {
 import {
 	cookieHeaderFromSetCookie,
 	evaluateAppHealth,
-	parseArgs as parsePreviewArgs,
 	parseSessionRequest,
 	previewSeedEmail,
 	previewSeedPassword,
 	runPreviewManualTest,
 	type SessionRequestSpec,
 } from './preview-manual-test.ts'
-
-const execFileAsync = promisify(execFile)
 
 export const localSeedEmail = 'jane@example.com'
 export const localSeedPassword = 'ilikecode'
@@ -305,10 +301,22 @@ export function playwrightBrowsersInstalled(homeDir: string) {
 	if (!existsSync(root)) return false
 	try {
 		const entries = readdirSync(root, { withFileTypes: true })
-		return entries.some((entry) => {
-			if (!entry.isDirectory()) return false
-			return existsSync(path.join(root, entry.name, 'INSTALLATION_COMPLETE'))
-		})
+		const installed = new Set(
+			entries
+				.filter(
+					(entry) =>
+						entry.isDirectory() &&
+						existsSync(path.join(root, entry.name, 'INSTALLATION_COMPLETE')),
+				)
+				.map((entry) => entry.name),
+		)
+		const hasChromium = [...installed].some((name) =>
+			name.startsWith('chromium-'),
+		)
+		const hasHeadlessShell = [...installed].some((name) =>
+			name.startsWith('chromium_headless_shell-'),
+		)
+		return hasChromium && hasHeadlessShell
 	} catch {
 		return false
 	}
@@ -514,7 +522,8 @@ export async function writeCookieFile(
 	cookieHeader: string,
 ) {
 	await mkdir(path.dirname(cookieFile), { recursive: true })
-	await writeFile(cookieFile, `${cookieHeader}\n`)
+	await writeFile(cookieFile, `${cookieHeader}\n`, { mode: 0o600 })
+	await chmod(cookieFile, 0o600)
 }
 
 export function formatFeatureMap(features: ReadonlyArray<Feature>) {
@@ -638,10 +647,13 @@ async function runCommand(options: ControlKodyOptions) {
 					email: options.email ?? defaults.email,
 					password: options.password ?? defaults.password,
 				})
-				cookieHeader = session.cookieHeader
-				if (cookieHeader) {
-					await writeCookieFile(options.cookieFile, cookieHeader)
+				if (!session.ok || !session.cookieHeader) {
+					if (options.json) printJson(session)
+					else console.error(session.detail)
+					return 1
 				}
+				cookieHeader = session.cookieHeader
+				await writeCookieFile(options.cookieFile, cookieHeader)
 			}
 			const result = await requestAsSession({
 				origin,
@@ -657,18 +669,8 @@ async function runCommand(options: ControlKodyOptions) {
 			return result.ok ? 0 : 1
 		}
 		case 'preview': {
-			const previewOptions = parsePreviewArgs(options.previewArgv)
-			if (previewOptions.help) {
-				await execFileAsync(resolveNpmCommand(), [
-					'run',
-					'preview:manual-test',
-					'--',
-					'--help',
-				])
-				return 0
-			}
-			const result = await runPreviewManualTest(previewOptions)
-			return result.ok ? 0 : 1
+			const result = await runPreviewManualTest(options.previewArgv)
+			return result.exitCode
 		}
 		case 'health': {
 			const origin = await resolveOrigin(options)
@@ -724,7 +726,7 @@ async function runCommand(options: ControlKodyOptions) {
 	}
 }
 
-export { usageLines }
+export { usageLines, runCommand }
 
 if (isExecutedDirectly(import.meta.url)) {
 	void runCommand(parseControlArgs(process.argv.slice(2)))

--- a/tools/control-kody/feature-catalog.ts
+++ b/tools/control-kody/feature-catalog.ts
@@ -81,7 +81,7 @@ export const featureCatalog: ReadonlyArray<Feature> = [
 		id: 'account',
 		title: 'Account hub',
 		file: 'account.md',
-		paths: ['/account'],
+		paths: ['/account', '/account/delete'],
 		apis: [
 			'/account/profile.json',
 			'/account/profile/avatar.json',
@@ -211,6 +211,10 @@ export const featureCatalog: ReadonlyArray<Feature> = [
 		apis: [
 			'/community.json',
 			'/community/:listingId.json',
+			'/community/:listingId/report.json',
+			'/community/:listingId/trust.json',
+			'/community/:listingId/feature.json',
+			'/community/:listingId/install.json',
 			'/profiles/:username.json',
 			'/profiles/:username/packages/:kodyId.json',
 		],
@@ -281,9 +285,22 @@ export function featureCoversPath(feature: Feature, routePath: string) {
 	return feature.paths.some((owned) => pathCoveredBy(owned, routePath))
 }
 
+/** Hub paths that must not swallow sibling Feature Map entries. */
+export const exactOnlyOwnedPaths = ['/', '/account'] as const
+
+export function isExactOnlyOwnedPath(owned: string) {
+	return (exactOnlyOwnedPaths as ReadonlyArray<string>).includes(owned)
+}
+
+export function prefixMatches(prefix: string, routePath: string) {
+	if (routePath === prefix) return true
+	if (prefix === '/') return routePath === '/'
+	return routePath.startsWith(`${prefix}/`)
+}
+
 export function pathCoveredBy(owned: string, routePath: string) {
 	if (routePath === owned) return true
-	if (owned === '/') return routePath === '/'
+	if (isExactOnlyOwnedPath(owned)) return false
 	return routePath.startsWith(`${owned}/`)
 }
 
@@ -329,9 +346,7 @@ export function checkFeatureCatalog(input: {
 			})
 		}
 		for (const owned of feature.paths) {
-			const present = routePaths.some(
-				(routePath) => routePath === owned || pathCoveredBy(owned, routePath),
-			)
+			const present = routePaths.includes(owned)
 			if (!present) {
 				issues.push({
 					kind: 'stale-path',
@@ -346,7 +361,7 @@ export function checkFeatureCatalog(input: {
 	for (const routePath of routePaths) {
 		if (!isHtmlUserPath(routePath)) continue
 		if (
-			!requiredHtmlPrefixes.some((prefix) => pathCoveredBy(prefix, routePath))
+			!requiredHtmlPrefixes.some((prefix) => prefixMatches(prefix, routePath))
 		) {
 			continue
 		}

--- a/tools/control-kody/feature-catalog.ts
+++ b/tools/control-kody/feature-catalog.ts
@@ -1,0 +1,363 @@
+export type Feature = {
+	id: string
+	title: string
+	file: string
+	paths: Array<string>
+	apis: Array<string>
+}
+
+export const featuresDirRelativePath = pathToFeaturesDir()
+
+function pathToFeaturesDir() {
+	return '.agents/skills/control-kody/references/features'
+}
+
+/**
+ * User-facing surfaces agents rediscover. Keep `paths` aligned with
+ * `packages/worker/universal/routes.ts` HTML routes. JSON companions go in
+ * `apis`.
+ */
+export const featureCatalog: ReadonlyArray<Feature> = [
+	{
+		id: 'login',
+		title: 'Sign in',
+		file: 'login.md',
+		paths: ['/login'],
+		apis: ['/auth', '/session', '/logout', '/auth/providers.json'],
+	},
+	{
+		id: 'signup',
+		title: 'Sign up and email verify',
+		file: 'signup.md',
+		paths: [
+			'/signup',
+			'/verify-email',
+			'/pending-verification',
+			'/verify-email-change',
+		],
+		apis: ['/account/resend-verification.json'],
+	},
+	{
+		id: 'onboarding',
+		title: 'Onboarding',
+		file: 'onboarding.md',
+		paths: ['/onboarding'],
+		apis: ['/onboarding.json', '/onboarding/checklist-dismiss.json'],
+	},
+	{
+		id: 'password-reset',
+		title: 'Password reset',
+		file: 'password-reset.md',
+		paths: ['/reset-password'],
+		apis: [
+			'/password-reset',
+			'/password-reset/confirm',
+			'/account/password.json',
+		],
+	},
+	{
+		id: 'two-factor',
+		title: 'Two-factor auth',
+		file: 'two-factor.md',
+		paths: ['/account/two-factor', '/verify'],
+		apis: ['/account/two-factor.json', '/verify/2fa.json'],
+	},
+	{
+		id: 'passkeys',
+		title: 'Passkeys',
+		file: 'passkeys.md',
+		paths: [
+			'/account/passkeys',
+			'/webauthn/registration',
+			'/webauthn/authentication',
+		],
+		apis: [
+			'/account/passkeys.json',
+			'/webauthn/registration',
+			'/webauthn/authentication',
+		],
+	},
+	{
+		id: 'account',
+		title: 'Account hub',
+		file: 'account.md',
+		paths: ['/account'],
+		apis: [
+			'/account/profile.json',
+			'/account/profile/avatar.json',
+			'/account/email-change.json',
+			'/account/export.json',
+			'/account/delete',
+			'/account/connections.json',
+		],
+	},
+	{
+		id: 'packages',
+		title: 'Packages',
+		file: 'packages.md',
+		paths: ['/account/packages'],
+		apis: [
+			'/account/packages.json',
+			'/account/packages/:packageId/approve-publish.json',
+			'/account/packages/:packageId/files.json',
+		],
+	},
+	{
+		id: 'secrets',
+		title: 'Secrets',
+		file: 'secrets.md',
+		paths: ['/account/secrets'],
+		apis: ['/account/secrets.json'],
+	},
+	{
+		id: 'integrations',
+		title: 'Integrations and OAuth connect',
+		file: 'integrations.md',
+		paths: ['/account/integrations', '/connect/oauth'],
+		apis: ['/account/integrations.json'],
+	},
+	{
+		id: 'mcp-servers',
+		title: 'MCP servers',
+		file: 'mcp-servers.md',
+		paths: ['/account/mcp-servers', '/account/mcp-oauth-clients'],
+		apis: ['/account/mcp-servers.json', '/account/mcp-oauth-clients.json'],
+	},
+	{
+		id: 'jobs',
+		title: 'Jobs',
+		file: 'jobs.md',
+		paths: ['/account/jobs'],
+		apis: ['/account/jobs.json'],
+	},
+	{
+		id: 'workflows',
+		title: 'Workflows',
+		file: 'workflows.md',
+		paths: ['/account/workflows'],
+		apis: ['/account/workflows.json'],
+	},
+	{
+		id: 'activity',
+		title: 'Activity',
+		file: 'activity.md',
+		paths: ['/account/activity'],
+		apis: ['/account/activity.json'],
+	},
+	{
+		id: 'waiting',
+		title: 'Waiting inbox',
+		file: 'waiting.md',
+		paths: ['/account/waiting'],
+		apis: ['/account/waiting.json'],
+	},
+	{
+		id: 'memories',
+		title: 'Memories',
+		file: 'memories.md',
+		paths: ['/account/memories'],
+		apis: ['/account/memories.json', '/account/memories-export.json'],
+	},
+	{
+		id: 'email',
+		title: 'Email inbox',
+		file: 'email.md',
+		paths: ['/account/email'],
+		apis: ['/account/email.json'],
+	},
+	{
+		id: 'values',
+		title: 'Values',
+		file: 'values.md',
+		paths: ['/account/values'],
+		apis: ['/account/values.json'],
+	},
+	{
+		id: 'billing',
+		title: 'Billing and usage',
+		file: 'billing.md',
+		paths: ['/account/billing', '/account/usage'],
+		apis: [
+			'/account/billing.json',
+			'/account/billing/checkout.json',
+			'/account/billing/cancellation-feedback.json',
+			'/account/usage.json',
+		],
+	},
+	{
+		id: 'admin',
+		title: 'Admin',
+		file: 'admin.md',
+		paths: ['/admin'],
+		apis: [
+			'/admin/users.json',
+			'/admin/roles.json',
+			'/admin/invites.json',
+			'/admin/feature-flags.json',
+			'/admin/platform-integrations.json',
+			'/admin/provider-marks.json',
+			'/admin/codemods.json',
+			'/admin/community-reports.json',
+			'/admin/insights.json',
+			'/admin/platform-feedback.json',
+			'/admin/system-email.json',
+		],
+	},
+	{
+		id: 'community',
+		title: 'Community listings and profiles',
+		file: 'community.md',
+		paths: ['/community', '/@:username'],
+		apis: [
+			'/community.json',
+			'/community/:listingId.json',
+			'/profiles/:username.json',
+			'/profiles/:username/packages/:kodyId.json',
+		],
+	},
+	{
+		id: 'marketing',
+		title: 'Public marketing pages',
+		file: 'marketing.md',
+		paths: [
+			'/',
+			'/pricing',
+			'/faq',
+			'/privacy',
+			'/terms',
+			'/guides',
+			'/blog',
+			'/discord',
+		],
+		apis: ['/guides.json', '/blog.json', '/discord.json'],
+	},
+]
+
+/** HTML prefixes that must stay mapped. JSON, assets, and well-known stay out. */
+export const requiredHtmlPrefixes = [
+	'/login',
+	'/signup',
+	'/onboarding',
+	'/reset-password',
+	'/verify',
+	'/account',
+	'/admin',
+	'/connect/oauth',
+	'/community',
+	'/@:username',
+] as const
+
+export function extractQuotedPaths(source: string) {
+	const paths = new Set<string>()
+	for (const match of source.matchAll(/['"`](\/[^'"`\s]*)['"`]/g)) {
+		const value = match[1]
+		if (value) paths.add(value)
+	}
+	return [...paths].toSorted()
+}
+
+export function isHtmlUserPath(routePath: string) {
+	if (routePath.startsWith('/.')) return false
+	if (routePath.startsWith('/integrations/')) return false
+	if (routePath.startsWith('/webhooks/')) return false
+	if (routePath.startsWith('/og/')) return false
+	if (routePath === '/health' || routePath.startsWith('/health/')) return false
+	if (routePath === '/session') return false
+	if (routePath === '/code-runs.json') return false
+	if (routePath === '/sentry-tunnel') return false
+	if (
+		routePath.endsWith('.json') ||
+		routePath.endsWith('.md') ||
+		routePath.endsWith('.xml') ||
+		routePath.endsWith('.txt') ||
+		routePath.endsWith('.png')
+	) {
+		return false
+	}
+	return true
+}
+
+export function featureCoversPath(feature: Feature, routePath: string) {
+	return feature.paths.some((owned) => pathCoveredBy(owned, routePath))
+}
+
+export function pathCoveredBy(owned: string, routePath: string) {
+	if (routePath === owned) return true
+	if (owned === '/') return routePath === '/'
+	return routePath.startsWith(`${owned}/`)
+}
+
+export function catalogCoversPath(
+	catalog: ReadonlyArray<Feature>,
+	routePath: string,
+) {
+	return catalog.some((feature) => featureCoversPath(feature, routePath))
+}
+
+export function findFeature(
+	catalog: ReadonlyArray<Feature>,
+	id: string,
+): Feature | null {
+	return catalog.find((feature) => feature.id === id) ?? null
+}
+
+export type CatalogCheckIssue = {
+	kind: 'stale-path' | 'unmapped-route' | 'missing-file' | 'unknown-feature'
+	id?: string
+	path?: string
+	file?: string
+	detail: string
+}
+
+export function checkFeatureCatalog(input: {
+	catalog?: ReadonlyArray<Feature>
+	routeSource: string
+	existingFiles: ReadonlyArray<string>
+}): { ok: boolean; issues: Array<CatalogCheckIssue> } {
+	const catalog = input.catalog ?? featureCatalog
+	const routePaths = extractQuotedPaths(input.routeSource)
+	const files = new Set(input.existingFiles)
+	const issues: Array<CatalogCheckIssue> = []
+
+	for (const feature of catalog) {
+		if (!files.has(feature.file)) {
+			issues.push({
+				kind: 'missing-file',
+				id: feature.id,
+				file: feature.file,
+				detail: `${feature.id} is missing ${feature.file}`,
+			})
+		}
+		for (const owned of feature.paths) {
+			const present = routePaths.some(
+				(routePath) => routePath === owned || pathCoveredBy(owned, routePath),
+			)
+			if (!present) {
+				issues.push({
+					kind: 'stale-path',
+					id: feature.id,
+					path: owned,
+					detail: `${feature.id} lists ${owned}, which is not in routes.ts`,
+				})
+			}
+		}
+	}
+
+	for (const routePath of routePaths) {
+		if (!isHtmlUserPath(routePath)) continue
+		if (
+			!requiredHtmlPrefixes.some((prefix) => pathCoveredBy(prefix, routePath))
+		) {
+			continue
+		}
+		if (!catalogCoversPath(catalog, routePath)) {
+			issues.push({
+				kind: 'unmapped-route',
+				path: routePath,
+				detail: `${routePath} has no Feature Map entry`,
+			})
+		}
+	}
+
+	return { ok: issues.length === 0, issues }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop Cloud Agents from rediscovering Kody account surfaces and inventing throwaway curl scripts. Give them one Feature Map, one CLI, and a daily garden that keeps the map honest.

## Why

Lauren Tan’s pstack Pt. 1 (“verification is all you need”) matches what recent `kentcdodds/kody` Cloud runs already show: gold ships close the loop when they load `ship-pr` + `preview-manual-test`; failures rediscover waiting-inbox / overlay / runtime-audit surfaces, skip proof when preview flakes, or die in factory essays.

Adopt the Kody-specific slice only:

1. A Feature Map of account/app surfaces
2. A `control-kody` CLI
3. A daily maintain job — this belongs in Kody packages (same shape as friction-log and e2e-flake-hunter). Community search found nothing close, so `@kentcdodds/verification-skill-maintain` is the new package.

Do **not** vendor the pstack plugin, 21 principle files, or worktrees. The fleet is already Cloud.

## Summary

- Machine-readable catalog in `tools/control-kody/feature-catalog.ts` checked against `packages/worker/universal/routes.ts`
- Human Feature Map under `.agents/skills/control-kody/references/features/`
- CLI: `doctor`, `dev`, `login`, `request`, `preview`, `health`, `map` (`--check`)
- `npm run control-kody` plus links from AGENTS.md, ship-pr, preview-manual-test, and Cloud Agent notes
- Daily package `@kentcdodds/verification-skill-maintain` at 06:00 America/Denver. Scan of `main` waits (`catalog-not-on-main`) until this PR merges; then it spawns one Cursor agent on drift. The child opens the PR itself with ManagePullRequest.

## Testing

- `npx vitest run tools/control-kody.node.test.ts --project node-unit` — 2 passed
- `CI=1 npm run test:node` — 2301 passed; `CI=1 npm run test:workers` — 310 passed (push hook)
- `node tools/control-kody.ts map --check` — Feature Map matches `routes.ts`
- `node tools/control-kody.ts doctor` — node/playwright/hooks ok; no local origin yet
- Package tests: 9 passed (`node --test --experimental-strip-types`)
- `kody:@kentcdodds/verification-skill-maintain/scan` and `./daily` — `{ reason: "catalog-not-on-main", wouldSpawn: false }`
- Job `package-job:17fe5bcd-…:daily` enabled; next run 2026-09-01T12:00:00.000Z

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `c3f26760` · **Head:** `4fc894a6`

**Classification:** composes — no primitives added or changed; this PR adds contributor CLI, Feature Map, and docs. The daily garden is a Kody package, not a new origin primitive.

### Primitives touched

None in the diff. The classifier matched no `code` roots. Unmatched paths are `.agents/skills/control-kody/**`, `tools/control-kody*`, and contributing docs. Runtime calls compose existing `app-sessions` and `app-ui` routes without changing them.

### Change flow

A Cloud Agent drives a real origin through `control-kody` instead of throwaway curl. The daily package scans GitHub `main` and spawns at most one gardener.

```mermaid
sequenceDiagram
	actor CloudAgent
	participant controlKody as control-kody CLI
	participant appSessions as app-sessions
	participant appUi as app-ui
	CloudAgent->>controlKody: doctor / map --check
	controlKody->>controlKody: catalog vs routes.ts
	CloudAgent->>controlKody: login
	controlKody->>appSessions: POST /auth as seed user
	appSessions-->>controlKody: session cookie
	CloudAgent->>controlKody: request GET /account/*.json
	controlKody->>appUi: authenticated JSON used by the UI
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c092ff16-f704-4616-9827-10ca6bd7e119?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c092ff16-f704-4616-9827-10ca6bd7e119&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the Control Kody verification CLI for login, authenticated requests, previews, diagnostics, health checks, and feature-map validation.
  * Added an npm command for running the verification CLI.
  * Added a searchable catalog covering user-facing routes and APIs.

* **Documentation**
  * Added contributor guidance for verification workflows and production health checks.
  * Added reference documentation covering account, authentication, billing, integrations, packages, workflows, and other app features.

* **Tests**
  * Added coverage for CLI commands, authentication flows, health checks, and feature-map validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->