### PR TITLE
Wait for Remix hydration before passkey e2e clicks

### DIFF
--- a/e2e/passkeys.spec.ts
+++ b/e2e/passkeys.spec.ts
@@ -1,5 +1,10 @@
 import { generateTOTP } from '@epic-web/totp'
-import { type Page, expect, test } from './playwright-utils.ts'
+import {
+	type Page,
+	expect,
+	test,
+	waitForClientHydration,
+} from './playwright-utils.ts'
 import { clearAuthRateLimitsInE2eDatabase } from './d1-utils.ts'
 
 // WebAuthn relying party ids must be domains, not IP addresses, so passkey
@@ -17,10 +22,14 @@ async function gotoLocalhost(
 	pathname: string,
 ) {
 	// Prefer domcontentloaded: under CI load the full `load` event can stall on
-	// late assets while the app shell is already interactive.
+	// late assets while the app shell is already interactive. Hydration still
+	// has to finish before JS-only `type="button"` clicks (register, enable 2FA,
+	// passkey sign-in, delete) or they are silent no-ops — same race #1628
+	// fixed in the two-factor spec.
 	await page.goto(localhostUrl(baseURL, pathname), {
 		waitUntil: 'domcontentloaded',
 	})
+	await waitForClientHydration(page)
 }
 
 async function addVirtualAuthenticator(page: Page) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop the passkey Playwright journey from clicking JS-only buttons before Remix has bound `on('click')`.

## Why

Validate run [33481052120](https://github.com/kentcdodds/kody/actions/runs/33481052120) failed `e2e/passkeys.spec.ts` three times at different clicks: register (`Passkey registered.`), enable 2FA (`totp-secret`), and delete (`Passkey deleted.`). Those are `type="button"` controls with Remix `on('click')` mixins.

`entry.tsx` preloads the route chunk before `run()`, so SSR headings such as "No passkeys yet" are visible while handlers are still unbound. A click in that gap is a silent no-op. The spec already uses `waitUntil: 'domcontentloaded'`, which makes the race more likely under CI load.

[#1628](https://github.com/kentcdodds/kody/pull/1628) fixed the same race in `e2e/two-factor.spec.ts` with `waitForClientHydration`. The passkey spec never got that wait when the 2FA enable step was folded into it.

## Summary

- `gotoLocalhost` now waits for `html[data-hydrated]` after navigation.
- Register, enable 2FA, passkey sign-in, and delete all go through that helper.

## Testing

- Focused Playwright: `CI=1 npx playwright test e2e/passkeys.spec.ts` — 1 passed (27.3s).
- Pre-push: `test:node` and `test:workers` (cached pass).

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `6ac454f0` · **Head:** `6b36532f`

**Classification:** composes — test harness only; no product primitive behavior, schema, or API change.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | composes — e2e waits for the existing `data-hydrated` marker before JS-only clicks |

### Change flow

Passkey e2e navigations wait for Remix hydration before clicking `type="button"` controls.

```mermaid
sequenceDiagram
	actor spec as passkey e2e
	participant appUi as app-ui
	spec->>appUi: goto localhost (domcontentloaded)
	Note over spec,appUi: this PR waits for html[data-hydrated]
	spec->>appUi: click Register / Enable 2FA / Sign in / Delete
	appUi-->>spec: bound on(click) handlers run
```

### Before / after

| Step | Before | After |
| --- | --- | --- |
| `gotoLocalhost` | `domcontentloaded` only | `domcontentloaded` then `waitForClientHydration` |
| JS-only button click | can be a silent no-op | waits until handlers are bound |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3a6425e5-7266-495a-a08d-551f85e632dd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3a6425e5-7266-495a-a08d-551f85e632dd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved passkey and two-factor authentication test reliability by ensuring client-side interactions are ready before proceeding.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->