### PR TITLE
Fix Cloud Agent wrangler reload that blocks real /onboarding screenshots

### DIFF
--- a/.agents/skills/control-kody/references/features/onboarding.md
+++ b/.agents/skills/control-kody/references/features/onboarding.md
@@ -23,5 +23,8 @@ node tools/control-kody.ts preview -- \
 
 ## Gotchas
 
-- Local wrangler reload loops have blocked real `/onboarding` screenshots. Use
-  `control-kody doctor` and `dev:ensure` before a UI pass.
+- `/onboarding` screenshots come from the real origin after
+  `control-kody doctor` and `dev:ensure`. `npm run dev` writes the client bundle
+  before wrangler watches `public/`, and `dev:ensure` waits for a starting
+  leftover instead of killing it mid-reload. Do not dump one onboarding
+  component to static HTML.

--- a/.agents/skills/testing-multi-worker-dev/SKILL.md
+++ b/.agents/skills/testing-multi-worker-dev/SKILL.md
@@ -17,10 +17,11 @@ description:
   `/health` on 3742–3751, prints `App running at http://localhost:<port>` and
   exits 0 when a server is already up, waits for a stale kody/workerd leftover
   that is listening but not serving before replacing it, then starts
-  `npm run dev` and waits until `/health` is actually ok. `npm run dev` writes
-  the first client bundle before Wrangler so `public/` does not trigger
-  Reloading after Ready. Do not inventory Cursor terminal files or curl 3742 as
-  a substitute.
+  `npm run dev` and waits until `/health` is actually ok. `npm run dev` waits up
+  to 30s for the first client bundle before Wrangler so `public/` does not
+  trigger Reloading after Ready. If that wait expires, Wrangler still starts and
+  may reload when the bundle lands. Do not inventory Cursor terminal files or
+  curl 3742 as a substitute.
 - Run interactive `npm run dev` in tmux when you need the CLI shortcuts; it
   starts the client watcher, the mock Cloudflare API worker, and
   `wrangler dev --local` with the origin config, the committed `kody-jobs`

--- a/.agents/skills/testing-multi-worker-dev/SKILL.md
+++ b/.agents/skills/testing-multi-worker-dev/SKILL.md
@@ -15,10 +15,12 @@ description:
 - Node 26 required: `export PATH="$HOME/.nvm/versions/node/v26.7.0/bin:$PATH"`.
 - To start or reuse the local app, run `npm run dev:ensure`. It probes origin
   `/health` on 3742–3751, prints `App running at http://localhost:<port>` and
-  exits 0 when a server is already up, replaces a stale kody/workerd leftover
-  that is listening but not serving, then starts `npm run dev` and waits until
-  `/health` is actually ok. Do not inventory Cursor terminal files or curl 3742
-  as a substitute.
+  exits 0 when a server is already up, waits for a stale kody/workerd leftover
+  that is listening but not serving before replacing it, then starts
+  `npm run dev` and waits until `/health` is actually ok. `npm run dev` writes
+  the first client bundle before Wrangler so `public/` does not trigger
+  Reloading after Ready. Do not inventory Cursor terminal files or curl 3742 as
+  a substitute.
 - Run interactive `npm run dev` in tmux when you need the CLI shortcuts; it
   starts the client watcher, the mock Cloudflare API worker, and
   `wrangler dev --local` with the origin config, the committed `kody-jobs`

--- a/cli.ts
+++ b/cli.ts
@@ -13,6 +13,11 @@ import {
 	type ProcessOutputMode,
 } from './tools/dev-process-output.ts'
 import {
+	defaultClientEntryPath,
+	defaultClientReadyTimeoutMs,
+	waitForClientEntryReady,
+} from './tools/dev-client-ready.ts'
+import {
 	defaultHealthTimeoutMs,
 	defaultWorkerPort,
 	isWorkerHealthOk,
@@ -285,6 +290,7 @@ async function restartDev(
 	clearLockedPorts()
 	const workerPort = await getPort({ port: portRange })
 	workerOrigin = resolveWorkerOrigin(workerPort)
+	const clientStartedAt = Date.now()
 	const client = runNpmScript(
 		'dev:client',
 		[],
@@ -295,6 +301,17 @@ async function restartDev(
 			mode: 'buffer-on-error',
 		},
 	)
+	const clientDidBuild = await waitForClientEntryReady({
+		sinceMs: clientStartedAt,
+		timeoutMs: defaultClientReadyTimeoutMs,
+		isCancelled: () => client.killed || client.exitCode !== null,
+	})
+	if (!clientDidBuild) {
+		console.warn(
+			`dev:client did not write ${defaultClientEntryPath} within ${defaultClientReadyTimeoutMs}ms; ` +
+				`wrangler may reload when the bundle lands in public/.`,
+		)
+	}
 	const workerVarEnv = {
 		...mockEnv,
 	}

--- a/docs/contributing/cloud-agents.md
+++ b/docs/contributing/cloud-agents.md
@@ -101,13 +101,20 @@ dispatcher. The command is a no-op on machines without `~/.cursor/agent-hooks`.
 
 - `npm run dev:ensure` is the agent entry point. It probes origin `/health` on
   3742–3751, prints `App running at http://localhost:<port>` and exits 0 when a
-  server is already up, replaces a stale kody/workerd leftover that accepts TCP
-  but does not serve `/health`, then starts `npm run dev` and waits until
-  `/health` is actually ok before printing the resolved URL.
-- `npm run dev` starts the client esbuild watcher, optional Cloudflare API mock
-  worker, and Wrangler with origin plus generated platform, runtime, and jobs
-  siblings in one Miniflare (local D1/KV/DO persistence). Non-TTY sessions print
-  `App running at` only after `/health` responds.
+  server is already up, waits for a kody/workerd leftover that accepts TCP but
+  does not serve `/health` before replacing it, then starts `npm run dev` and
+  waits until `/health` is actually ok before printing the resolved URL. If
+  wrangler printed Ready / Reloading and `/health` still misses the budget, the
+  process is left running so a retry can reuse it. UI verification opens that
+  real origin (for example `/onboarding`); do not substitute a `renderToString`
+  dump of one component.
+- `npm run dev` starts the client esbuild watcher and waits for the first
+  `public/client-entry.js` write before launching Wrangler, so that first bundle
+  does not hit wrangler's assets watcher and trigger `Reloading local server...`
+  after Ready. Then the optional Cloudflare API mock worker and Wrangler run
+  origin plus generated platform, runtime, and jobs siblings in one Miniflare
+  (local D1/KV/DO persistence). Non-TTY sessions print `App running at` only
+  after `/health` responds.
 - Default worker port is **3742** (`cli.ts`); the CLI picks a free port when
   3742 is taken and prints `App running at http://localhost:<port>`.
 - Run long-lived interactive `npm run dev` in tmux so the session survives tool

--- a/docs/contributing/cloud-agents.md
+++ b/docs/contributing/cloud-agents.md
@@ -103,18 +103,18 @@ dispatcher. The command is a no-op on machines without `~/.cursor/agent-hooks`.
   3742–3751, prints `App running at http://localhost:<port>` and exits 0 when a
   server is already up, waits for a kody/workerd leftover that accepts TCP but
   does not serve `/health` before replacing it, then starts `npm run dev` and
-  waits until `/health` is actually ok before printing the resolved URL. If
-  wrangler printed Ready / Reloading and `/health` still misses the budget, the
+  waits until `/health` is actually ok before printing the resolved URL. If the
+  latest wrangler line is Reloading and `/health` still misses the budget, the
   process is left running so a retry can reuse it. UI verification opens that
   real origin (for example `/onboarding`); do not substitute a `renderToString`
   dump of one component.
-- `npm run dev` starts the client esbuild watcher and waits for the first
-  `public/client-entry.js` write before launching Wrangler, so that first bundle
-  does not hit wrangler's assets watcher and trigger `Reloading local server...`
-  after Ready. Then the optional Cloudflare API mock worker and Wrangler run
-  origin plus generated platform, runtime, and jobs siblings in one Miniflare
-  (local D1/KV/DO persistence). Non-TTY sessions print `App running at` only
-  after `/health` responds.
+- `npm run dev` starts the client esbuild watcher and waits up to 30s for the
+  first `public/client-entry.js` write before launching Wrangler, so that first
+  bundle does not hit wrangler's assets watcher. If the wait expires, Wrangler
+  still starts and may reload when the bundle lands. Then the optional
+  Cloudflare API mock worker and Wrangler run origin plus generated platform,
+  runtime, and jobs siblings in one Miniflare (local D1/KV/DO persistence).
+  Non-TTY sessions print `App running at` only after `/health` responds.
 - Default worker port is **3742** (`cli.ts`); the CLI picks a free port when
   3742 is taken and prints `App running at http://localhost:<port>`.
 - Run long-lived interactive `npm run dev` in tmux so the session survives tool

--- a/docs/contributing/setup/local-development.md
+++ b/docs/contributing/setup/local-development.md
@@ -38,12 +38,14 @@ Prerequisites, install, and `npm run dev` notes. See the
   both secrets (see
   [`docs/contributing/secret-rotation.md`](../secret-rotation.md)).
 - `npm run dev:ensure` reuses a healthy origin `/health` on 3742–3751 (prints
-  `App running at http://localhost:<port>` and exits 0), replaces a stale
-  kody/workerd leftover that is listening but not serving, then starts
-  `npm run dev` and waits until `/health` is ok. Agents should call this instead
-  of reconstructing a startup playbook from terminal files.
-- `npm run dev` starts mock API servers automatically plus origin, platform,
-  runtime, and jobs in one Miniflare; it sets `CLOUDFLARE_API_BASE_URL`,
+  `App running at http://localhost:<port>` and exits 0), waits for a stale
+  kody/workerd leftover that is listening but not serving before replacing it,
+  then starts `npm run dev` and waits until `/health` is ok. Agents should call
+  this instead of reconstructing a startup playbook from terminal files.
+- `npm run dev` writes the first client bundle into `packages/worker/public/`
+  before Wrangler starts so that write does not reload the worker after Ready.
+  It then starts mock API servers automatically plus origin, platform, runtime,
+  and jobs in one Miniflare; it sets `CLOUDFLARE_API_BASE_URL`,
   `CLOUDFLARE_API_TOKEN`, and `CLOUDFLARE_ACCOUNT_ID` to the local Cloudflare
   API mock Worker for the internal Cloudflare API client, local email sending,
   and Artifacts REST repo create/get/list/token/fork calls. Those REST calls do

--- a/docs/contributing/setup/local-development.md
+++ b/docs/contributing/setup/local-development.md
@@ -42,26 +42,28 @@ Prerequisites, install, and `npm run dev` notes. See the
   kody/workerd leftover that is listening but not serving before replacing it,
   then starts `npm run dev` and waits until `/health` is ok. Agents should call
   this instead of reconstructing a startup playbook from terminal files.
-- `npm run dev` writes the first client bundle into `packages/worker/public/`
-  before Wrangler starts so that write does not reload the worker after Ready.
-  It then starts mock API servers automatically plus origin, platform, runtime,
-  and jobs in one Miniflare; it sets `CLOUDFLARE_API_BASE_URL`,
-  `CLOUDFLARE_API_TOKEN`, and `CLOUDFLARE_ACCOUNT_ID` to the local Cloudflare
-  API mock Worker for the internal Cloudflare API client, local email sending,
-  and Artifacts REST repo create/get/list/token/fork calls. Those REST calls do
-  not hit the live Cloudflare Artifacts control plane during normal local
-  development. The mock covers only the REST control plane; repo-session git
-  clone/pull/push flows need a real Git-capable Artifacts remote and are not
-  fully simulated by the local mock. Password reset and email-verification
-  messages send through the same Cloudflare Email API helper. Both send from
-  `kody@<SYSTEM_EMAIL_DOMAIN>` (falling back to the `APP_BASE_URL` hostname) and
-  put that same sending domain on action and asset links when
-  `SYSTEM_EMAIL_DOMAIN` is set, so a stale `APP_BASE_URL` cannot pin a retired
-  hostname into the message. Local `npm run dev` keeps those action and asset
-  links on the request origin so they stay clickable. Set
-  `SKIP_CLOUDFLARE_MOCK=1` to skip the local Cloudflare mock entirely. The main
-  worker streams logs live; the client bundle and background mock workers buffer
-  logs and only print them if that child process exits with an error.
+- `npm run dev` waits up to 30s for the first client bundle in
+  `packages/worker/public/` before Wrangler starts so that write does not reload
+  the worker after Ready. If the wait expires, Wrangler still starts and may
+  reload when the bundle lands. It then starts mock API servers automatically
+  plus origin, platform, runtime, and jobs in one Miniflare; it sets
+  `CLOUDFLARE_API_BASE_URL`, `CLOUDFLARE_API_TOKEN`, and `CLOUDFLARE_ACCOUNT_ID`
+  to the local Cloudflare API mock Worker for the internal Cloudflare API
+  client, local email sending, and Artifacts REST repo
+  create/get/list/token/fork calls. Those REST calls do not hit the live
+  Cloudflare Artifacts control plane during normal local development. The mock
+  covers only the REST control plane; repo-session git clone/pull/push flows
+  need a real Git-capable Artifacts remote and are not fully simulated by the
+  local mock. Password reset and email-verification messages send through the
+  same Cloudflare Email API helper. Both send from `kody@<SYSTEM_EMAIL_DOMAIN>`
+  (falling back to the `APP_BASE_URL` hostname) and put that same sending domain
+  on action and asset links when `SYSTEM_EMAIL_DOMAIN` is set, so a stale
+  `APP_BASE_URL` cannot pin a retired hostname into the message. Local
+  `npm run dev` keeps those action and asset links on the request origin so they
+  stay clickable. Set `SKIP_CLOUDFLARE_MOCK=1` to skip the local Cloudflare mock
+  entirely. The main worker streams logs live; the client bundle and background
+  mock workers buffer logs and only print them if that child process exits with
+  an error.
 - MCP **`search`** uses a deterministic offline ranker in tests and when
   `WRANGLER_IS_LOCAL_DEV` is set (no Vectorize / Workers AI embedding calls
   required for `npm run test` or unauthenticated local runs). Production uses

--- a/tools/dev-client-ready.node.test.ts
+++ b/tools/dev-client-ready.node.test.ts
@@ -1,0 +1,57 @@
+import { expect, test } from 'vitest'
+import { waitForClientEntryReady } from './dev-client-ready.ts'
+
+test('waitForClientEntryReady waits for a rewrite after sinceMs and stops on cancel or timeout', async () => {
+	const files = new Map<string, { mtimeMs: number }>([
+		['packages/worker/public/client-entry.js', { mtimeMs: 10 }],
+	])
+	let now = 0
+	const slept: Array<number> = []
+
+	const stale = await waitForClientEntryReady({
+		sinceMs: 50,
+		timeoutMs: 4,
+		pollMs: 1,
+		stat: (path) => files.get(path) ?? null,
+		now: () => {
+			now += 1
+			return now
+		},
+		sleep: async (ms) => {
+			slept.push(ms)
+		},
+	})
+	expect(stale).toBe(false)
+	expect(slept.length).toBeGreaterThan(0)
+
+	now = 0
+	const written = await waitForClientEntryReady({
+		sinceMs: 50,
+		timeoutMs: 10,
+		pollMs: 1,
+		stat: (path) => files.get(path) ?? null,
+		now: () => {
+			now += 1
+			return now
+		},
+		sleep: async () => {
+			files.set('packages/worker/public/client-entry.js', { mtimeMs: 80 })
+		},
+	})
+	expect(written).toBe(true)
+
+	now = 0
+	const cancelled = await waitForClientEntryReady({
+		sinceMs: 50,
+		timeoutMs: 10,
+		pollMs: 1,
+		stat: () => ({ mtimeMs: 80 }),
+		now: () => {
+			now += 1
+			return now
+		},
+		sleep: async () => {},
+		isCancelled: () => true,
+	})
+	expect(cancelled).toBe(false)
+})

--- a/tools/dev-client-ready.ts
+++ b/tools/dev-client-ready.ts
@@ -1,0 +1,40 @@
+import { statSync } from 'node:fs'
+import { setTimeout as delay } from 'node:timers/promises'
+
+export const defaultClientEntryPath = 'packages/worker/public/client-entry.js'
+export const defaultClientReadyTimeoutMs = 30_000
+export const defaultClientReadyPollMs = 200
+
+export function clientEntryStat(filePath: string) {
+	try {
+		return { mtimeMs: statSync(filePath).mtimeMs }
+	} catch {
+		return null
+	}
+}
+
+export async function waitForClientEntryReady(input: {
+	path?: string
+	sinceMs: number
+	timeoutMs: number
+	pollMs?: number
+	stat?: (path: string) => { mtimeMs: number } | null
+	now?: () => number
+	sleep?: (ms: number) => Promise<void>
+	isCancelled?: () => boolean
+}) {
+	const filePath = input.path ?? defaultClientEntryPath
+	const pollMs = input.pollMs ?? defaultClientReadyPollMs
+	const now = input.now ?? Date.now
+	const sleep = input.sleep ?? delay
+	const stat = input.stat ?? clientEntryStat
+	const deadline = now() + input.timeoutMs
+	while (now() < deadline) {
+		if (input.isCancelled?.()) return false
+		const info = stat(filePath)
+		if (info && info.mtimeMs >= input.sinceMs) return true
+		await sleep(pollMs)
+	}
+	const info = stat(filePath)
+	return Boolean(info && info.mtimeMs >= input.sinceMs)
+}

--- a/tools/ensure-dev.node.test.ts
+++ b/tools/ensure-dev.node.test.ts
@@ -185,9 +185,15 @@ test('ensureDev replaces a stale workerd leftover then starts until /health is o
 			return { unref() {}, async stop() {} }
 		},
 		sleep: async () => {},
-		now: () => 0,
-		readyTimeoutMs: 1_000,
-		readyPollMs: 10,
+		now: (() => {
+			let t = 0
+			return () => {
+				t += 1
+				return t
+			}
+		})(),
+		readyTimeoutMs: 10,
+		readyPollMs: 1,
 		log: (line) => {
 			logs.push(line)
 		},
@@ -199,6 +205,9 @@ test('ensureDev replaces a stale workerd leftover then starts until /health is o
 	})
 	expect(killed).toEqual(['699', '700'])
 	expect(logs[0]).toBe(
+		'Existing kody listener is not healthy yet; waiting before replacing it.',
+	)
+	expect(logs).toContain(
 		'Replaced stale kody listener pid=699 comm=npm port=3742',
 	)
 	expect(logs.at(-1)).toBe('App running at http://localhost:3742')

--- a/tools/ensure-dev.node.test.ts
+++ b/tools/ensure-dev.node.test.ts
@@ -6,6 +6,7 @@ import {
 	envWithPreferredNode26,
 	isKodyDevProcess,
 	isKodyDevSupervisor,
+	isWranglerStillStarting,
 	parseLsofListenPids,
 	parseSsListenPids,
 	replaceStaleKodyListeners,
@@ -331,4 +332,103 @@ test('ensureDev stops the child and surfaces output when /health never becomes r
 		}),
 	).rejects.toThrow(/Reloading local server/)
 	expect(stopped).toEqual(['stop'])
+})
+
+test('ensureDev waits for an existing kody listener instead of killing it mid-reload', async () => {
+	const logs: Array<string> = []
+	const killed: Array<string> = []
+	const started: Array<string> = []
+	let healthy = false
+	const result = await ensureDev({
+		ports: [3742],
+		probeHealth: async () => healthy,
+		listListenerPids: () => [700],
+		readProcess: () => ({
+			pid: 700,
+			ppid: 1,
+			comm: 'workerd',
+			cmdline: 'workerd --port 3742',
+		}),
+		protectedPids: new Set([1]),
+		killProcess: (pid) => {
+			killed.push(String(pid))
+		},
+		startDev: () => {
+			started.push('start')
+			return { unref() {}, async stop() {} }
+		},
+		sleep: async () => {
+			healthy = true
+		},
+		now: (() => {
+			let t = 0
+			return () => {
+				t += 1
+				return t
+			}
+		})(),
+		readyTimeoutMs: 10,
+		readyPollMs: 1,
+		log: (line) => {
+			logs.push(line)
+		},
+	})
+	expect(result).toEqual({
+		status: 'reused',
+		origin: 'http://localhost:3742',
+	})
+	expect(started).toEqual([])
+	expect(killed).toEqual([])
+	expect(logs[0]).toBe(
+		'Existing kody listener is not healthy yet; waiting before replacing it.',
+	)
+	expect(logs.at(-1)).toBe('App running at http://localhost:3742')
+})
+
+test('ensureDev leaves a still-starting wrangler running when /health misses the budget', async () => {
+	const stopped: Array<string> = []
+	const unrefed: Array<string> = []
+	await expect(
+		ensureDev({
+			ports: [3742],
+			probeHealth: async () => false,
+			listListenerPids: () => [],
+			readProcess: () => null,
+			protectedPids: new Set([1]),
+			killProcess: () => {},
+			startDev: () => ({
+				unref() {
+					unrefed.push('unref')
+				},
+				async stop() {
+					stopped.push('stop')
+				},
+				hasExited: () => false,
+				lastOutput: () =>
+					'Local server updated and ready\nReloading local server...',
+			}),
+			sleep: async () => {},
+			now: (() => {
+				let t = 0
+				return () => {
+					t += 1
+					return t
+				}
+			})(),
+			readyTimeoutMs: 2,
+			readyPollMs: 1,
+			log: () => {},
+		}),
+	).rejects.toThrow(/still starting/)
+	expect(stopped).toEqual([])
+	expect(unrefed).toEqual(['unref'])
+	expect(
+		isWranglerStillStarting(
+			'Local server updated and ready\nReloading local server...',
+		),
+	).toBe(true)
+	expect(isWranglerStillStarting('Ready on http://localhost:3742')).toBe(true)
+	expect(
+		isWranglerStillStarting('Cannot apply deleted_classes migration'),
+	).toBe(false)
 })

--- a/tools/ensure-dev.node.test.ts
+++ b/tools/ensure-dev.node.test.ts
@@ -427,8 +427,52 @@ test('ensureDev leaves a still-starting wrangler running when /health misses the
 			'Local server updated and ready\nReloading local server...',
 		),
 	).toBe(true)
-	expect(isWranglerStillStarting('Ready on http://localhost:3742')).toBe(true)
+	expect(isWranglerStillStarting('Ready on http://localhost:3742')).toBe(false)
+	expect(
+		isWranglerStillStarting(
+			'Reloading local server...\nReady on http://localhost:3742',
+		),
+	).toBe(false)
 	expect(
 		isWranglerStillStarting('Cannot apply deleted_classes migration'),
 	).toBe(false)
+})
+
+test('ensureDev stops a wrangler that claimed Ready but never became healthy', async () => {
+	const stopped: Array<string> = []
+	const unrefed: Array<string> = []
+	await expect(
+		ensureDev({
+			ports: [3742],
+			probeHealth: async () => false,
+			listListenerPids: () => [],
+			readProcess: () => null,
+			protectedPids: new Set([1]),
+			killProcess: () => {},
+			startDev: () => ({
+				unref() {
+					unrefed.push('unref')
+				},
+				async stop() {
+					stopped.push('stop')
+				},
+				hasExited: () => false,
+				lastOutput: () =>
+					'Local server updated and ready\nReady on http://localhost:3742',
+			}),
+			sleep: async () => {},
+			now: (() => {
+				let t = 0
+				return () => {
+					t += 1
+					return t
+				}
+			})(),
+			readyTimeoutMs: 2,
+			readyPollMs: 1,
+			log: () => {},
+		}),
+	).rejects.toThrow(/did not become ready/)
+	expect(stopped).toEqual(['stop'])
+	expect(unrefed).toEqual([])
 })

--- a/tools/ensure-dev.ts
+++ b/tools/ensure-dev.ts
@@ -17,7 +17,7 @@ import {
 } from './dev-server.ts'
 import { isExecutedDirectly, resolveNpmCommand } from './node-runtime.ts'
 
-export const defaultReadyTimeoutMs = 120_000
+export const defaultReadyTimeoutMs = 180_000
 export const defaultReadyPollMs = 500
 export const defaultStaleKillWaitMs = 2_000
 
@@ -86,6 +86,32 @@ export function isKodyDevSupervisor(identity: {
 
 export function isKodyDevProcess(identity: { comm: string; cmdline: string }) {
 	return isWorkerdProcess(identity) || isKodyDevSupervisor(identity)
+}
+
+export function hasKodyDevListeners(input: {
+	ports: ReadonlyArray<number>
+	listListenerPids: (port: number) => Array<number>
+	readProcess: (pid: number) => ProcessIdentity | null
+	protectedPids: ReadonlySet<number>
+}) {
+	for (const port of input.ports) {
+		for (const pid of input.listListenerPids(port)) {
+			if (input.protectedPids.has(pid)) continue
+			const identity = input.readProcess(pid)
+			if (identity && isKodyDevProcess(identity)) return true
+		}
+	}
+	return false
+}
+
+export function isWranglerStillStarting(output: string) {
+	const text = output.toLowerCase()
+	if (!text.trim()) return false
+	return (
+		text.includes('reloading local server') ||
+		text.includes('local server updated') ||
+		text.includes('ready on http')
+	)
 }
 
 export function collectAncestorPids(
@@ -313,6 +339,24 @@ export async function ensureDev(deps: EnsureDevDeps): Promise<EnsureDevResult> {
 		return { status: 'reused', origin: existing }
 	}
 
+	if (hasKodyDevListeners(deps)) {
+		deps.log(
+			'Existing kody listener is not healthy yet; waiting before replacing it.',
+		)
+		const starting = await waitForHealthyOrigin({
+			ports: deps.ports,
+			probeHealth: deps.probeHealth,
+			timeoutMs: deps.readyTimeoutMs,
+			pollMs: deps.readyPollMs,
+			now: deps.now,
+			sleep: deps.sleep,
+		})
+		if (starting) {
+			deps.log(formatAppRunning(starting))
+			return { status: 'reused', origin: starting }
+		}
+	}
+
 	const replacedPids = await replaceStaleKodyListeners(deps)
 	const started = deps.startDev()
 	const origin = await waitForHealthyOrigin({
@@ -325,7 +369,19 @@ export async function ensureDev(deps: EnsureDevDeps): Promise<EnsureDevResult> {
 		isCancelled: started.hasExited,
 	})
 	if (!origin) {
-		const output = started.lastOutput?.()?.trim()
+		const output = started.lastOutput?.()?.trim() ?? ''
+		const stillStarting = Boolean(
+			started.hasExited &&
+			!started.hasExited() &&
+			isWranglerStillStarting(output),
+		)
+		if (stillStarting) {
+			started.unref()
+			throw new Error(
+				`Local app did not become ready on ${deps.ports[0]}-${deps.ports.at(-1)} within ${deps.readyTimeoutMs}ms; wrangler is still starting. Retry \`npm run dev:ensure\` without killing the process.` +
+					(output ? `\n${output}` : ''),
+			)
+		}
 		await started.stop()
 		throw new Error(
 			`Local app did not become ready on ${deps.ports[0]}-${deps.ports.at(-1)} within ${deps.readyTimeoutMs}ms.` +

--- a/tools/ensure-dev.ts
+++ b/tools/ensure-dev.ts
@@ -105,13 +105,22 @@ export function hasKodyDevListeners(input: {
 }
 
 export function isWranglerStillStarting(output: string) {
-	const text = output.toLowerCase()
-	if (!text.trim()) return false
-	return (
-		text.includes('reloading local server') ||
-		text.includes('local server updated') ||
-		text.includes('ready on http')
-	)
+	const lines = output
+		.toLowerCase()
+		.split(/\r?\n/)
+		.map((line) => line.trim())
+		.filter(Boolean)
+	for (let index = lines.length - 1; index >= 0; index -= 1) {
+		const line = lines[index] ?? ''
+		if (line.includes('reloading local server')) return true
+		if (
+			line.includes('local server updated') ||
+			line.includes('ready on http')
+		) {
+			return false
+		}
+	}
+	return false
 }
 
 export function collectAncestorPids(

--- a/tools/ensure-e2e-client.ts
+++ b/tools/ensure-e2e-client.ts
@@ -1,8 +1,7 @@
 import { existsSync } from 'node:fs'
 import { spawnSync } from 'node:child_process'
+import { defaultClientEntryPath } from './dev-client-ready.ts'
 import { isExecutedDirectly } from './node-runtime.ts'
-
-const defaultClientEntryPath = 'packages/worker/public/client-entry.js'
 
 export function ensureE2eClientBuilt(options?: {
 	clientEntryPath?: string


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Make `npm run dev:ensure` leave a healthy origin so Cloud Agents can open the real `/onboarding` page instead of falling back to a static component dump.

Closes #1893.

## Why

`npm run dev` started the client watcher and Wrangler together. `dev:client` writes `packages/worker/public/` (the assets directory wrangler watches), so the first Ready was immediately followed by `Reloading local server...`. During that reload `/health` accepted TCP but did not answer. `ensure-dev` then killed the tree after 120s, leaving wedged workerd listeners. Playwright already avoids this by building the client before Wrangler; local `dev` did not.

## Summary

- Wait up to 30s for the first `public/client-entry.js` write before launching Wrangler (still starts, and may reload, if that wait expires).
- If a kody leftover is listening but not healthy yet, wait for `/health` before replacing it.
- If the latest wrangler line is Reloading and `/health` still misses the budget, leave the process running so a retry can reuse it. A historical Ready line does not preserve a dead process.
- Raise the ready budget from 120s to 180s.
- Document that UI verification must use the real origin.

## Testing

- Node assertion script against `ensureDev` / `waitForClientEntryReady` / latest-line Reloading predicate (local vitest forks hung on this VM; CI runs `vitest run --project node-unit`).
- Focused files: `tools/ensure-dev.node.test.ts`, `tools/dev-client-ready.node.test.ts`.

## System changes

Contributor tooling and docs only. No app/auth/billing/migration surface.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `369595a2` · **Head:** `f9cce129`

**Classification:** composes — no primitives added or changed; this PR only changes local `npm run dev` / `dev:ensure` harness behavior.

### Primitives touched

_None. Classifier reported unmatched paths (`cli.ts`, `tools/ensure-dev.ts`, docs, skills)._

### Change flow

`dev:ensure` starts `npm run dev`; the client bundle lands in `public/` before Wrangler watches assets, then `/health` is what the agent opens.

```mermaid
sequenceDiagram
	actor Agent
	participant ensureDev as ensure-dev
	participant cli as npm run dev
	participant publicDir as public/
	participant wrangler as wrangler dev
	Agent->>ensureDev: npm run dev:ensure
	ensureDev->>cli: start npm run dev
	cli->>publicDir: wait up to 30s for client-entry.js
	cli->>wrangler: start after first bundle or wait expiry
	wrangler-->>ensureDev: GET /health ok
	ensureDev-->>Agent: App running at http://localhost:3742
```

### Before / after

| Step | Before | After |
| --- | --- | --- |
| Client vs Wrangler | Started in parallel; `public/` writes reloaded the worker | Wait up to 30s for `client-entry.js`, then Wrangler |
| Existing leftover | Killed immediately if `/health` failed | Wait for `/health`, then replace only if still down |
| Timeout while Reloading | Killed the tree (wedged ports) | Leave running only when the latest line is Reloading |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-611bf42c-6504-4ee8-83c3-99d4a2e21a9c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-611bf42c-6504-4ee8-83c3-99d4a2e21a9c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved local development startup reliability by waiting up to 30 seconds for the initial client bundle before launching the worker.
  * Prevented unnecessary reloads after the development server reports readiness.
  * Improved recovery from stale or unhealthy development processes, with clearer handling of startup timeouts and failures.

* **Documentation**
  * Updated onboarding and local development guidance for reliable server startup and UI verification.
  * Clarified how to access the real application origin during development.

* **Tests**
  * Added coverage for bundle readiness, cancellation, timeouts, and development server recovery scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->