### PR TITLE
Filter Turnstile client Sentry noise (KODY-6D / KODY-6E)

### DIFF
--- a/packages/worker/client/public-form-protection.node.test.ts
+++ b/packages/worker/client/public-form-protection.node.test.ts
@@ -75,15 +75,21 @@ test('renderTurnstileWidgets remounts hosts whose children were wiped by a re-re
 	expect(render).toHaveBeenCalledWith(orphan, {
 		sitekey: 'site-key',
 		'response-field-name': 'turnstileToken',
+		'error-callback': expect.any(Function),
 	})
 	expect(render).toHaveBeenCalledWith(fresh, {
 		sitekey: 'site-key',
 		'response-field-name': 'turnstileToken',
+		'error-callback': expect.any(Function),
 	})
 	expect(render).not.toHaveBeenCalledWith(live, expect.anything())
 	expect(orphan.dataset.turnstileRendered).toBe('true')
 	expect(fresh.dataset.turnstileRendered).toBe('true')
 	expect(live.dataset.turnstileRendered).toBe('true')
+	const renderOptions = render.mock.calls[0]?.[1] as {
+		'error-callback': (code: number) => boolean
+	}
+	expect(renderOptions['error-callback'](300010)).toBe(true)
 
 	vi.unstubAllGlobals()
 })
@@ -103,6 +109,37 @@ test('renderTurnstileWidgets does not leave the rendered marker when render thro
 		'render failed',
 	)
 	expect(container.dataset.turnstileRendered).toBeUndefined()
+
+	vi.unstubAllGlobals()
+})
+
+test('renderTurnstileWidgets soft-fails when the Turnstile script fails to load', async () => {
+	const listeners = new Map<string, EventListener>()
+	const script = {
+		async: false,
+		defer: false,
+		src: '',
+		dataset: {} as DOMStringMap & { kodyTurnstile?: string },
+		addEventListener(type: string, handler: EventListener) {
+			listeners.set(type, handler)
+		},
+		remove: vi.fn(),
+	}
+
+	vi.stubGlobal('window', {})
+	vi.stubGlobal('document', {
+		querySelector: vi.fn(() => null),
+		querySelectorAll: vi.fn(() => []),
+		createElement: vi.fn(() => script),
+		head: {
+			append() {
+				listeners.get('error')?.(new Event('error'))
+			},
+		},
+	})
+
+	await expect(renderTurnstileWidgets('site-key')).resolves.toBeUndefined()
+	expect(script.remove).toHaveBeenCalled()
 
 	vi.unstubAllGlobals()
 })

--- a/packages/worker/client/public-form-protection.ts
+++ b/packages/worker/client/public-form-protection.ts
@@ -17,7 +17,16 @@ export const turnstileWidgetClassName = 'kody-turnstile'
 type TurnstileApi = {
 	render(
 		container: HTMLElement,
-		options: { sitekey: string; 'response-field-name': string },
+		options: {
+			sitekey: string
+			'response-field-name': string
+			/**
+			 * Returning a non-falsy value tells Turnstile the error was handled so
+			 * it does not escalate to console / window listeners that Sentry
+			 * captures as TurnstileError (KODY-6E).
+			 */
+			'error-callback'?: (errorCode: string | number) => boolean | void
+		},
 	): string
 	reset?(container: HTMLElement | string): void
 	remove?(container: HTMLElement | string): void
@@ -29,6 +38,16 @@ function getTurnstileApi() {
 	return (window as typeof window & { turnstile?: TurnstileApi }).turnstile
 }
 
+/**
+ * Exact messages thrown when challenges.cloudflare.com is blocked (ad
+ * blocker / privacy extension / network) or the script loads without
+ * exposing `window.turnstile`. Matched by browser Sentry filters (KODY-6D).
+ */
+export const turnstileScriptFailedToLoadMessage =
+	'Turnstile script failed to load.'
+export const turnstileApiDidNotInitializeMessage =
+	'Turnstile API did not initialize.'
+
 function loadTurnstileScript() {
 	const existingApi = getTurnstileApi()
 	if (existingApi) return Promise.resolve(existingApi)
@@ -39,15 +58,24 @@ function loadTurnstileScript() {
 			'script[data-kody-turnstile]',
 		)
 		const script = existingScript ?? document.createElement('script')
+		const fail = (message: string) => {
+			// Clear so a later render attempt can inject a fresh script tag
+			// (one blocked load must not pin the page for the whole session).
+			turnstileScriptPromise = null
+			if (!existingScript) {
+				script.remove()
+			}
+			reject(new Error(message))
+		}
 		const handleLoad = () => {
 			const api = getTurnstileApi()
 			if (api) resolve(api)
-			else reject(new Error('Turnstile API did not initialize.'))
+			else fail(turnstileApiDidNotInitializeMessage)
 		}
 		script.addEventListener('load', handleLoad, { once: true })
 		script.addEventListener(
 			'error',
-			() => reject(new Error('Turnstile script failed to load.')),
+			() => fail(turnstileScriptFailedToLoadMessage),
 			{ once: true },
 		)
 		if (!existingScript) {
@@ -88,9 +116,26 @@ function abandonOrphanedTurnstileWidget(
 	}
 }
 
+/**
+ * Turnstile's documented contract: a non-falsy return means the host handled
+ * the client error (300* generic challenge failures, iframe load blips, …)
+ * so Turnstile skips its default window escalation.
+ */
+function handleTurnstileWidgetError(_errorCode: string | number) {
+	return true
+}
+
 export async function renderTurnstileWidgets(siteKey: string | null) {
 	if (!siteKey || typeof document === 'undefined') return
-	const api = await loadTurnstileScript()
+	let api: TurnstileApi
+	try {
+		api = await loadTurnstileScript()
+	} catch {
+		// Script blocked or CDN blip — expected visitor-environment degradation
+		// (KODY-6D). Auth/waitlist POSTs still surface a server-side protection
+		// error if the user submits without a token; do not Sentry-noise this.
+		return
+	}
 	for (const container of document.querySelectorAll<HTMLElement>(
 		`.${turnstileWidgetClassName}`,
 	)) {
@@ -102,6 +147,7 @@ export async function renderTurnstileWidgets(siteKey: string | null) {
 			api.render(container, {
 				sitekey: siteKey,
 				'response-field-name': turnstileResponseFieldName,
+				'error-callback': handleTurnstileWidgetError,
 			})
 			container.dataset.turnstileRendered = 'true'
 		} catch (error) {

--- a/packages/worker/client/sentry-browser-filters.node.test.ts
+++ b/packages/worker/client/sentry-browser-filters.node.test.ts
@@ -848,3 +848,73 @@ test('browser Sentry filters drop Chromium Failed to fetch (host) via createFram
 		}),
 	).not.toBeNull()
 })
+
+test('browser Sentry filters drop Turnstile client load and challenge failures (KODY-6D / KODY-6E)', () => {
+	expect(
+		filterBrowserSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'Error',
+						value: 'Turnstile script failed to load.',
+						stacktrace: {
+							frames: [
+								{
+									function: 'r.addEventListener.once',
+									filename: '../../client/public-form-protection.ts',
+								},
+							],
+						},
+					},
+				],
+			},
+		}),
+	).toBeNull()
+	expect(
+		filterBrowserSentryEvent(
+			{
+				exception: {
+					values: [{ type: 'Error', value: 'something else' }],
+				},
+			},
+			new Error('Turnstile API did not initialize.'),
+		),
+	).toBeNull()
+	expect(
+		filterBrowserSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'TurnstileError',
+						value: '[Cloudflare Turnstile] Error: 300010.',
+					},
+				],
+			},
+		}),
+	).toBeNull()
+	expect(
+		filterBrowserSentryEvent(
+			{
+				exception: {
+					values: [{ type: 'Error', value: 'wrapped' }],
+				},
+			},
+			Object.assign(new Error('[Cloudflare Turnstile] Error: 300010.'), {
+				name: 'TurnstileError',
+			}),
+		),
+	).toBeNull()
+	// Unrelated Errors must stay visible.
+	expect(
+		filterBrowserSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'Error',
+						value: 'Turnstile widget host missing in layout',
+					},
+				],
+			},
+		}),
+	).not.toBeNull()
+})

--- a/packages/worker/client/sentry-browser-filters.ts
+++ b/packages/worker/client/sentry-browser-filters.ts
@@ -1045,6 +1045,59 @@ export function filterResolveFrameFetchNetworkSentryEvent<
 	return event
 }
 
+/**
+ * Cloudflare Turnstile client failures that are visitor-environment or
+ * challenge-edge noise, not app defects (KODY-6D script blocked by
+ * ad-blocker / network; KODY-6E TurnstileError 300* generic challenge
+ * failure). Match only our exact load/init strings and Turnstile's own
+ * `[Cloudflare Turnstile] Error: NNNNNN` / `TurnstileError` signature so
+ * unrelated Errors stay Sentry-visible.
+ */
+const cloudflareTurnstileClientErrorMessage =
+	/^(?:Error:\s*)?(?:Turnstile script failed to load\.|Turnstile API did not initialize\.|\[Cloudflare Turnstile\] Error: \d+\.?)$/i
+
+export function isCloudflareTurnstileClientErrorMessage(message: string) {
+	return cloudflareTurnstileClientErrorMessage.test(message.trim())
+}
+
+export function isCloudflareTurnstileClientError(error: unknown) {
+	if (typeof error === 'string') {
+		return isCloudflareTurnstileClientErrorMessage(error)
+	}
+	if (typeof error !== 'object' || error === null) return false
+	const name =
+		'name' in error && typeof error.name === 'string' ? error.name : undefined
+	if (name === 'TurnstileError') return true
+	if (!('message' in error) || typeof error.message !== 'string') return false
+	return isCloudflareTurnstileClientErrorMessage(error.message)
+}
+
+export function isCloudflareTurnstileClientSentryEvent(
+	event: SentryErrorEventLike,
+	originalException?: unknown,
+) {
+	if (isCloudflareTurnstileClientError(originalException)) return true
+	if (
+		event.exception?.values?.some((value) => value.type === 'TurnstileError')
+	) {
+		return true
+	}
+	return sentryEventMessages(event).some(
+		(message) =>
+			typeof message === 'string' &&
+			isCloudflareTurnstileClientErrorMessage(message),
+	)
+}
+
+export function filterCloudflareTurnstileClientSentryEvent<
+	T extends SentryErrorEventLike,
+>(event: T, originalException?: unknown): T | null {
+	if (isCloudflareTurnstileClientSentryEvent(event, originalException)) {
+		return null
+	}
+	return event
+}
+
 /** Combined browser beforeSend / capture gate used by the client SDK. */
 export function filterBrowserSentryEvent<T extends SentryErrorEventLike>(
 	event: T,
@@ -1154,6 +1207,12 @@ export function filterBrowserSentryEvent<T extends SentryErrorEventLike>(
 	}
 	if (
 		filterResolveFrameFetchNetworkSentryEvent(event, originalException) === null
+	) {
+		return null
+	}
+	if (
+		filterCloudflareTurnstileClientSentryEvent(event, originalException) ===
+		null
 	) {
 		return null
 	}

--- a/packages/worker/client/sentry-client.ts
+++ b/packages/worker/client/sentry-client.ts
@@ -1,6 +1,7 @@
 import {
 	isBrowserAbortError,
 	isBrowserInjectedGlobalNoiseError,
+	isCloudflareTurnstileClientError,
 	isFirefoxDomPermissionDeniedError,
 	isMetaMaskWalletNoAccountError,
 	isResolveFrameFetchNetworkError,
@@ -55,7 +56,8 @@ function shouldIgnoreBufferedError(error: unknown) {
 		isBrowserInjectedGlobalNoiseError(error) ||
 		isMetaMaskWalletNoAccountError(error) ||
 		isSyntaxHighlightCoreDynamicImportFailureError(error) ||
-		isResolveFrameFetchNetworkError(error)
+		isResolveFrameFetchNetworkError(error) ||
+		isCloudflareTurnstileClientError(error)
 	)
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop Cloudflare Turnstile visitor-environment failures from opening Sentry issues, without weakening bot protection on successful loads.

## Why

KODY-6D (`Turnstile script failed to load` on `/login`) and sibling KODY-6E (`TurnstileError: 300010`) are external challenge/CDN/ad-blocker noise. Fire-and-forget `renderTurnstileWidgets` calls rejected into Sentry, and Turnstile’s default error escalation was captured via `browserapierrors`.

## Summary

- Soft-fail script load/init in `renderTurnstileWidgets`; clear the script promise so a later attempt can retry
- Pass Turnstile `error-callback` that returns `true` so 300* challenge failures are not escalated to window listeners
- Narrow browser `beforeSend` filter (+ pre-SDK buffer ignore) for the exact load/init strings and `TurnstileError` / `[Cloudflare Turnstile] Error: NNNNNN` signatures

## Testing

- Focused vitest: `public-form-protection.node.test.ts`, `sentry-browser-filters.node.test.ts`
- Pre-push gate: typecheck + `test:node` + `test:workers` (via commit hook)

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `d8aa1b86` · **Head:** `8dbdafaf`

**Classification:** composes — soft-fail + Turnstile `error-callback` + browser Sentry filter for known external Turnstile client signatures; successful challenge path unchanged.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | composes — Turnstile load soft-fail, error-callback, browser beforeSend filter |

### Change flow

Visitor-blocked or challenge-edge Turnstile failures no longer reach Sentry; forms still depend on a real token when the widget loads.

```mermaid
sequenceDiagram
	actor Visitor
	participant appUi as app-ui
	participant turnstile as challenges.cloudflare.com
	participant sentry as Sentry browser SDK
	Visitor->>appUi: open /login (or waitlist)
	appUi->>turnstile: load api.js + render widget
	alt script blocked or 300* challenge failure
		turnstile-->>appUi: onerror / error-callback
		Note over appUi: soft-fail; error-callback returns true
		appUi--xsentry: beforeSend drops matching signature
	else widget loads
		turnstile-->>appUi: token in turnstileToken field
		Note over appUi: server verify unchanged
	end
```

### Before / after

```text
before: script onerror → rejected promise → Sentry (KODY-6D)
        Turnstile 300* → window escalation → Sentry (KODY-6E)
after:  script onerror → soft-fail + retryable promise clear + filter
        Turnstile 300* → error-callback handled + filter backstop
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-72f92524-fe67-4907-9c36-286556b8d2cd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-72f92524-fe67-4907-9c36-286556b8d2cd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

