### PR TITLE
Use friction-skipped label instead of HTML skip marker

### DIFF
--- a/docs/contributing/friction-log.md
+++ b/docs/contributing/friction-log.md
@@ -11,6 +11,17 @@ command that needs a secret handshake, a type that lies.
 This page is the policy for humans and agents. Do not write entries under
 `.agents/friction-log/`. GitHub is the log.
 
+## Labels
+
+| Label              | Purpose                                                           |
+| ------------------ | ----------------------------------------------------------------- |
+| `friction`         | Marks a repo papercut. Applied by the issue form and by `create`. |
+| `friction-skipped` | Daily sweep will not re-investigate until this label is removed.  |
+
+This repository does not define labels in-tree (no `.github/labels.yml`). Create
+or update them with the GitHub API or `gh label create` / `gh label edit`. The
+live `friction-skipped` label description should match the table above.
+
 ## File an entry
 
 Search open `friction` issues first (`gh issue list --label friction` or
@@ -58,8 +69,9 @@ papercuts.
 ## Daily investigation
 
 Kent's `@kentcdodds/friction-log` package runs a daily job at 05:00
-America/Denver. It lists open `friction` issues and, when any are eligible,
-spawns one Cursor Cloud Agent on `kentcdodds/kody` `main`.
+America/Denver. Daily sweep eligibility is: open + `friction` + NOT
+`friction-skipped`. When any issues are eligible, it spawns one Cursor Cloud
+Agent on `kentcdodds/kody` `main`. Eligibility does not scrape issue comments.
 
 If this run was spawned by that package, the prompt already lists eligible
 issues. Do not re-query every open issue from scratch. Fetch only the listed
@@ -76,13 +88,10 @@ For each listed issue, choose exactly one outcome:
    and close the issue.
 3. **Skip** — a fix is possible but you should not ship it without Kent (unclear
    product call, high risk, or you are not confident). Comment a concrete
-   recommended fix and include this HTML marker on its own line:
-
-   `<!-- friction-log:skipped -->`
-
-   Tell @kentcdodds the next run stays skipped until he replies with: close as
-   already fixed, close as invalid, ship the recommended fix, or a different
-   approach. Do not open a speculative PR.
+   recommended fix, ping @kentcdodds, and apply the GitHub label
+   `friction-skipped`. Tell @kentcdodds he can reply with: close as already
+   fixed, close as invalid, ship the recommended fix, or a different approach.
+   Unskip by removing `friction-skipped`. Do not open a speculative PR.
 
 4. **Fix** — implement on a fresh branch, push, and create or update the pull
    request with Cursor Cloud **ManagePullRequest**. Do not have Kody, a Kody
@@ -92,8 +101,10 @@ For each listed issue, choose exactly one outcome:
    Close the issue when the PR merges; if the PR is parked, skip the issue
    (outcome 3) and link the PR.
 
-If @kentcdodds already replied after a skip, follow that reply. Do not re-skip
-the same recommendation unless new evidence changed the choice.
+If @kentcdodds already replied after a skip, follow that reply. When acting on
+that reply (close, ship, or a different approach), remove `friction-skipped` if
+present. Do not re-skip the same recommendation unless new evidence changed the
+choice.
 
 Risk gate: docs, tests, harness, or isolated contributor-tooling changes are low
 or medium. Auth, per-user isolation, billing, migrations, or disaster-recovery
@@ -128,7 +139,7 @@ finish, record `failed` with what you learned.
 | Export                                         | Purpose                                        |
 | ---------------------------------------------- | ---------------------------------------------- |
 | `kody:@kentcdodds/friction-log/create`         | File a `friction` issue (always labeled).      |
-| `kody:@kentcdodds/friction-log/scan`           | Read-only eligibility scan. No agent.          |
+| `kody:@kentcdodds/friction-log/scan`           | Read-only label eligibility scan. No agent.    |
 | `kody:@kentcdodds/friction-log/sweep`          | Scan and optionally spawn (`dryRun`, `force`). |
 | `kody:@kentcdodds/friction-log/pause`          | Kill switch: stop spawning.                    |
 | `kody:@kentcdodds/friction-log/resume`         | Re-enable spawning.                            |

--- a/tools/check-friction-log-policy.node.test.ts
+++ b/tools/check-friction-log-policy.node.test.ts
@@ -1,0 +1,46 @@
+import { expect, test } from 'vitest'
+import {
+	checkFrictionLogPolicy,
+	checkFrictionLogPolicyContent,
+	frictionSkippedLabel,
+	retiredHtmlSkipMarker,
+} from './check-friction-log-policy.ts'
+
+test('friction-log policy rejects HTML skip marker and requires label gate', () => {
+	const bad = [
+		'# Friction log',
+		'',
+		'Include `<!-- friction-log:skipped -->` to skip.',
+	].join('\n')
+	expect(checkFrictionLogPolicyContent(bad)).toEqual({
+		ok: false,
+		errors: expect.arrayContaining([
+			expect.stringContaining(retiredHtmlSkipMarker),
+			expect.stringContaining('HTML comment'),
+			expect.stringContaining(frictionSkippedLabel),
+		]),
+	})
+
+	const good = [
+		'# Friction log',
+		'',
+		'| `friction-skipped` | Daily sweep will not re-investigate until this label is removed. |',
+		'',
+		'This repository does not define labels in-tree (no `.github/labels.yml`).',
+		'',
+		'Daily sweep eligibility is: open + `friction` + NOT',
+		'`friction-skipped`. Eligibility does not scrape issue comments.',
+		'',
+		'apply the GitHub label `friction-skipped`. Unskip by removing',
+		'`friction-skipped`. When acting, remove `friction-skipped` if present.',
+	].join('\n')
+	expect(checkFrictionLogPolicyContent(good)).toEqual({
+		ok: true,
+		errors: [],
+	})
+})
+
+test('contributing friction-log.md matches label-based skip policy', async () => {
+	const result = await checkFrictionLogPolicy()
+	expect(result).toEqual({ ok: true, errors: [] })
+})

--- a/tools/check-friction-log-policy.ts
+++ b/tools/check-friction-log-policy.ts
@@ -1,0 +1,95 @@
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+import { isExecutedDirectly } from './node-runtime.ts'
+
+export const defaultFrictionLogPolicyPath = path.join(
+	'docs',
+	'contributing',
+	'friction-log.md',
+)
+
+export const retiredHtmlSkipMarker = 'friction-log:skipped'
+export const frictionSkippedLabel = 'friction-skipped'
+
+export type FrictionLogPolicyCheckResult = {
+	ok: boolean
+	errors: Array<string>
+}
+
+/**
+ * Keep the contributing friction-log page aligned with label-based skip.
+ * The hosted @kentcdodds/friction-log package owns runtime eligibility; this
+ * repo owns the agent-facing policy copy agents load from main.
+ */
+export function checkFrictionLogPolicyContent(
+	content: string,
+): FrictionLogPolicyCheckResult {
+	const errors: Array<string> = []
+
+	if (content.includes(retiredHtmlSkipMarker)) {
+		errors.push(
+			`Policy must not mention the retired HTML skip marker ${retiredHtmlSkipMarker}. Use the ${frictionSkippedLabel} GitHub label.`,
+		)
+	}
+	if (content.includes('<!-- friction')) {
+		errors.push(
+			'Policy must not use an HTML comment as the skip gate. Use the friction-skipped GitHub label.',
+		)
+	}
+	if (!content.includes(`\`${frictionSkippedLabel}\``)) {
+		errors.push(
+			`Policy must document the \`${frictionSkippedLabel}\` GitHub label.`,
+		)
+	}
+	if (
+		!/Daily sweep eligibility is:\s*open \+ `friction` \+ NOT\s*`friction-skipped`/m.test(
+			content,
+		)
+	) {
+		errors.push(
+			'Policy must describe daily sweep eligibility as open + `friction` + NOT `friction-skipped`.',
+		)
+	}
+	if (
+		!/apply the GitHub label\s*`friction-skipped`/m.test(content) &&
+		!/Apply the GitHub label\s*`friction-skipped`/m.test(content)
+	) {
+		errors.push(
+			'Policy must tell agents to apply the `friction-skipped` label on skip.',
+		)
+	}
+	if (!/remove `friction-skipped`/m.test(content)) {
+		errors.push(
+			'Policy must tell agents to remove `friction-skipped` when unskipping or acting on Kent reply.',
+		)
+	}
+	if (!/does not scrape issue comments/m.test(content)) {
+		errors.push(
+			'Policy must state that eligibility does not scrape issue comments.',
+		)
+	}
+	if (!/no `\.github\/labels\.yml`/m.test(content)) {
+		errors.push(
+			'Policy must note that labels are not defined in-tree (no .github/labels.yml).',
+		)
+	}
+
+	return { ok: errors.length === 0, errors }
+}
+
+export async function checkFrictionLogPolicy(
+	policyPath: string = defaultFrictionLogPolicyPath,
+): Promise<FrictionLogPolicyCheckResult> {
+	const content = await readFile(policyPath, 'utf8')
+	return checkFrictionLogPolicyContent(content)
+}
+
+if (isExecutedDirectly(import.meta.url)) {
+	const result = await checkFrictionLogPolicy()
+	if (!result.ok) {
+		for (const error of result.errors) {
+			console.error(error)
+		}
+		process.exitCode = 1
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Make friction-log skip a GitHub label gate so the daily sweep can decide eligibility without scraping comments.

## Why

Skip used to mean leaving `<!-- friction-log:skipped -->` in a comment and waiting for @kentcdodds. That is ambiguous and comment-scraped. The decided design is label-based: apply `friction-skipped` to skip, remove it to unskip.

## Summary

- Update `docs/contributing/friction-log.md`: skip applies `friction-skipped`, eligibility is open + `friction` + NOT `friction-skipped`, unskip removes the label, and comments are not scraped for eligibility.
- Document both labels and note that this repo does not ship `.github/labels.yml` (labels are created via GitHub API / `gh`).
- Add a small policy checker and node test so the HTML marker cannot drift back into the contributing page.
- No issue-template change: the form still only applies `friction` at file time.
- Hosted `@kentcdodds/friction-log` package changes stay out of this PR (Connie).

## Testing

- `npx vitest run --config vitest.node.config.ts tools/check-friction-log-policy.node.test.ts` (2 passed)
- Pre-push hook: `npm run test:node` (2269 passed) and `npm run test:workers` (312 passed)
- `npm run docs:check-temporal` passed
- Repo grep: no remaining policy use of `friction-log:skipped` as the skip gate

## System changes

Docs and a harness checker only. Classifier reports no primitive `code` roots.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `acf2ca8f` · **Head:** `1f5c3ee7`

**Classification:** composes — no primitives added or changed; this PR updates contributor policy and a docs checker for friction-log skip.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| _(none)_  | —     | unmatched paths are contributing docs and tools checkers |

### Change flow

Daily sweep and investigators treat skip as a GitHub label instead of an HTML comment marker.

```mermaid
sequenceDiagram
	actor Investigator
	participant githubIssues as GitHub issues
	participant frictionPkg as friction-log package
	Investigator->>githubIssues: apply label friction-skipped on skip
	Note over frictionPkg: daily 05:00 America/Denver
	frictionPkg->>githubIssues: list open friction without friction-skipped
	alt Kent replies close/ship/different approach
		Investigator->>githubIssues: remove friction-skipped when acting
	end
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-23092e3e-c8c4-4ff6-bb32-29909d35f938?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-23092e3e-c8c4-4ff6-bb32-29909d35f938&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

