### PR TITLE
Unify public and private package pages on /@user/name

### DIFF
--- a/.agents/skills/control-kody/references/features/community.md
+++ b/.agents/skills/control-kody/references/features/community.md
@@ -1,11 +1,14 @@
 # Community listings and profiles
 
-Public catalog and owner-scoped package URLs.
+Public catalog and owner-scoped package URLs. Public and private packages share
+the same `/@username/:kodyId` surface; visibility is the only gate.
 
 ## How to get there
 
-`/community` → `/community/:listingId`. Human share URL: `/@username/kody-id`
-(never construct `/community/{listing_id}` for people). Profile: `/@username`.
+`/community` → `/@username/kody-id`. Human share URL: `/@username/kody-id`
+(never construct `/community/{listing_id}` for people). Files:
+`/@username/kody-id/tree/main`. Owner settings: `/@username/kody-id/settings`.
+Profile: `/@username`.
 
 ## Drive it
 
@@ -19,6 +22,7 @@ node tools/control-kody.ts request GET /community.json --skip-login
 - `GET /community/:listingId.json`
 - `GET /profiles/:username.json`
 - `GET /profiles/:username/packages/:kodyId.json`
+- `GET /profiles/:username/packages/:kodyId/files.json`
 - `POST /community/:listingId/{report,feature,install}.json`
 - `POST /community/:listingId/trust.json` returns 410 (no trusted-listing mark)
 
@@ -26,4 +30,6 @@ node tools/control-kody.ts request GET /community.json --skip-login
 
 - Profiles are public catalogs (packages, ratings, forks). There is no follow
   graph, bookmark-star, or social timeline.
-- Files and tree URLs are public read for listed packages.
+- Files and tree URLs are public read for listed packages and owner-only for
+  private ones.
+- Package settings 404 for anyone who is not the owner.

--- a/.agents/skills/control-kody/references/features/packages.md
+++ b/.agents/skills/control-kody/references/features/packages.md
@@ -4,8 +4,11 @@ Repo-backed saved packages: list, detail, files, approve-publish.
 
 ## How to get there
 
-`/account/packages` → `/account/packages/:packageId` →
-`/account/packages/:packageId/approve-publish`.
+`/account/packages` lists your packages. Each package lives at
+`/@username/:kodyId` (README), `/@username/:kodyId/tree/:ref` (files), and
+`/@username/:kodyId/settings` (tokens, lock, visibility, delete). Leftover
+`/account/packages/:packageId` and `/account/packages/:packageId/files` redirect
+to those URLs.
 
 ## Drive it
 
@@ -24,7 +27,9 @@ assert the empty state.
 ## APIs
 
 - `GET|POST /account/packages.json`
-- `GET /account/packages/:packageId/files.json`
+- `GET /profiles/:username/packages/:kodyId.json`
+- `GET /profiles/:username/packages/:kodyId/files.json`
+- `GET /account/packages/:packageId/files.json` (404 + `redirectTo` the tree)
 - `GET|POST /account/packages/:packageId/approve-publish.json`
 
 ## Gotchas
@@ -32,3 +37,4 @@ assert the empty state.
 - Stay on the preview origin. Do not follow a package-app handoff into
   production.
 - Unlocking a locked package is website-only.
+- Making a package public or private requires typing the slug.

--- a/docs/contributing/community-packages.md
+++ b/docs/contributing/community-packages.md
@@ -15,7 +15,7 @@ Owner sets visibility public (packageUpdate)
 D1 saved_packages.is_private = 0 + community_listings row
         │              KV source snapshot keyed by SHA
         ▼
-Public /community + /@username/:name + /tree/:ref
+Public /community + /@username/:name + /tree/:ref + /settings
         │
         ▼
 Visitor forks ──► communityFork ──► entity_sources (no saved_packages row)

--- a/docs/use/community-packages.md
+++ b/docs/use/community-packages.md
@@ -31,6 +31,9 @@ Tags, description, category, and an icon are optional (ranking can prefer
 filled-in cards).
 
 - New packages are always created **private**.
+- Making a package **public** lists it on `/community`. Type the package slug to
+  confirm (`confirm_name` for agents). Anyone can then read and fork the default
+  branch.
 - Making a package **private** unlists it: public URLs 404; existing forks keep
   their copies. Type the package slug to confirm (`confirm_name` for agents).
 - Deleting a package (`packageDelete` or **Delete package** on the package page)
@@ -52,7 +55,9 @@ at `/@username/:name` — for example `/@kentcdodds/devin`.
 `/@username/:name/tree/:ref/...` where `:ref` is the repo's **default branch
 name** (usually `main`, whatever git reports — not hardcoded `master`), a SHA,
 or another branch. `HEAD` and leftover `/files` URLs 301 to
-`/tree/{defaultBranch}` (`main` when lookup misses).
+`/tree/{defaultBranch}` (`main` when lookup misses). Private packages use the
+same tree URL; unauthenticated visitors get 404. Owner settings are
+`/@username/:name/settings`. The package home renders the README.
 
 The catalog defaults to **Best**. **Newest** orders by last community publish.
 **Featured** is editorial onboarding placement only — not a safety badge. There

--- a/docs/use/packages.md
+++ b/docs/use/packages.md
@@ -22,8 +22,10 @@ Think in terms of:
 - package-owned webhooks
 
 Packages are the saved-entity unit across search, execute, repo editing, and UI
-hosting. `/account/packages/:packageId/files` browses the published text
-snapshot of a saved package.
+hosting. Browse files at `/@username/:name/tree/:ref` — the same URL whether the
+package is public or private. Visibility, not a separate account files path, is
+what keeps private source off the public web. Owner controls (tokens, lock,
+visibility, delete) live at `/@username/:name/settings`.
 
 ## Package state model
 

--- a/packages/worker/client/lazy-route.tsx
+++ b/packages/worker/client/lazy-route.tsx
@@ -315,6 +315,7 @@ registerPreloadPatterns(
 		routePattern(routes.community),
 		routePattern(routes.communityDetail),
 		routePattern(routes.communityPackage),
+		routePattern(routes.communityPackageSettings),
 		routePattern(routes.profile),
 	],
 	{

--- a/packages/worker/client/package-files-explorer.tsx
+++ b/packages/worker/client/package-files-explorer.tsx
@@ -13,6 +13,7 @@ import {
 	listPackageFilesChildren,
 	packageFileLanguageLabel,
 } from '#universal/package-files.ts'
+import { renderPackageRepoChrome } from '#universal/package-repo-nav.tsx'
 import { type PackageFilesLoaderData } from '#universal/loader-data.ts'
 import {
 	colors,
@@ -101,6 +102,8 @@ export function PackageFilesExplorer(
 			contentNode = renderContent(data)
 		}
 
+		const showRepoChrome = Boolean(data.username && data.kodyId)
+
 		return (
 			<article
 				mix={css(articleCss)}
@@ -109,12 +112,24 @@ export function PackageFilesExplorer(
 				// assistive tech is told the region is mid-update.
 				aria-busy={handle.props.busy ? 'true' : undefined}
 			>
-				<a href={data.backHref} mix={css(backLinkCss)}>
-					{arrowLeftIcon()} {data.backLabel}
-				</a>
-				<header mix={css(headCss)}>
-					<h1 mix={css(titleCss)}>{data.title}</h1>
-				</header>
+				{showRepoChrome && data.username && data.kodyId ? (
+					renderPackageRepoChrome({
+						username: data.username,
+						kodyId: data.kodyId,
+						isPrivate: data.isPrivate ?? false,
+						viewerIsOwner: data.viewerIsOwner ?? false,
+						active: 'code',
+					})
+				) : (
+					<>
+						<a href={data.backHref} mix={css(backLinkCss)}>
+							{arrowLeftIcon()} {data.backLabel}
+						</a>
+						<header mix={css(headCss)}>
+							<h1 mix={css(titleCss)}>{data.title}</h1>
+						</header>
+					</>
+				)}
 				<div mix={css(layoutCss)}>
 					<nav aria-label="Files" mix={css(treeCss)}>
 						<div mix={css(treeHeadCss)}>

--- a/packages/worker/client/routes/account-package-approve-publish.node.test.ts
+++ b/packages/worker/client/routes/account-package-approve-publish.node.test.ts
@@ -22,7 +22,7 @@ const loaderData: AccountPackageApprovePublishLoaderData = {
 	publishedCommit: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
 	pendingCommit: '34f338c19f91c698c3a28edd2992e0ab87dcb4e0',
 	alreadyPublished: false,
-	filesHref: '/account/packages/1c43570a-b9ab-46c9-86ec-6c9f02926944/files',
+	filesHref: '/@kodykoala/gmail-drafts/tree/main',
 	packageHref: '/@kodykoala/gmail-drafts',
 }
 

--- a/packages/worker/client/routes/account-package-owner-details.tsx
+++ b/packages/worker/client/routes/account-package-owner-details.tsx
@@ -24,7 +24,6 @@ import {
 import { RecordChips, recordBodyCss } from './record-table.tsx'
 import { AccountPackageDeleteDialog } from './account-package-delete-dialog.tsx'
 import { AccountPackageTokens } from './account-package-tokens.tsx'
-import { getAccountPackageFilesHref } from '#universal/package-files.ts'
 import {
 	type AccountPackageDetail,
 	type AccountPackagesLoaderData,
@@ -54,12 +53,12 @@ export function AccountPackageOwnerDetails(
 		visibility: 'public' | 'private',
 	) {
 		if (visibilityState === 'submitting') return
-		if (
-			visibility === 'private' &&
-			confirmName.trim() !== packageDetail.kodyId
-		) {
+		if (confirmName.trim() !== packageDetail.kodyId) {
 			visibilityState = 'error'
-			visibilityMessage = `Type ${packageDetail.kodyId} to make this package private. Public URLs will 404; existing forks keep their copies.`
+			visibilityMessage =
+				visibility === 'public'
+					? `Type ${packageDetail.kodyId} to make this package public. Anyone will be able to read and fork the default branch.`
+					: `Type ${packageDetail.kodyId} to make this package private. Public URLs will 404; existing forks keep their copies.`
 			handle.update()
 			return
 		}
@@ -201,70 +200,67 @@ export function AccountPackageOwnerDetails(
 					mix={css({ display: 'grid', gap: spacing.xs })}
 					data-testid="package-visibility-controls"
 				>
-					{packageDetail.isPrivate ? (
-						<button
-							type="button"
-							disabled={visibilityState === 'submitting'}
-							data-testid="package-make-public"
+					<p mix={css({ margin: 0, color: colors.textMuted })}>
+						{packageDetail.isPrivate
+							? 'Making this package public lists it on /community. Anyone can read and fork the default branch. Type the slug to confirm.'
+							: 'Making this package private unlists it from /community and 404s public URLs. Existing forks keep their copies. Type the slug to confirm.'}
+					</p>
+					<label mix={css({ display: 'grid', gap: spacing.xs })}>
+						<span mix={css(visuallyHiddenCss)}>
+							Type {packageDetail.kodyId} to change visibility
+						</span>
+						<input
+							value={confirmName}
+							placeholder={packageDetail.kodyId}
+							data-testid={
+								packageDetail.isPrivate
+									? 'package-make-public-confirm'
+									: 'package-make-private-confirm'
+							}
 							mix={[
-								css(getGhostButtonCss()),
-								on(
-									'click',
-									() => void submitVisibility(packageDetail, 'public'),
-								),
+								css({
+									padding: spacing.sm,
+									borderRadius: radius.md,
+									border: `1px solid ${colors.border}`,
+									backgroundColor: colors.surface,
+									color: colors.text,
+								}),
+								on('input', (event) => {
+									if (!(event.currentTarget instanceof HTMLInputElement)) {
+										return
+									}
+									confirmName = event.currentTarget.value
+									handle.update()
+								}),
 							]}
-						>
-							{visibilityState === 'submitting' ? 'Saving…' : 'Make public'}
-						</button>
-					) : (
-						<>
-							<p mix={css({ margin: 0, color: colors.textMuted })}>
-								Making this package private unlists it from /community and 404s
-								public URLs. Existing forks keep their copies. Type the slug to
-								confirm.
-							</p>
-							<label mix={css({ display: 'grid', gap: spacing.xs })}>
-								<span mix={css(visuallyHiddenCss)}>
-									Type {packageDetail.kodyId} to make private
-								</span>
-								<input
-									value={confirmName}
-									placeholder={packageDetail.kodyId}
-									data-testid="package-make-private-confirm"
-									mix={[
-										css({
-											padding: spacing.sm,
-											borderRadius: radius.md,
-											border: `1px solid ${colors.border}`,
-											backgroundColor: colors.surface,
-											color: colors.text,
-										}),
-										on('input', (event) => {
-											if (!(event.currentTarget instanceof HTMLInputElement)) {
-												return
-											}
-											confirmName = event.currentTarget.value
-											handle.update()
-										}),
-									]}
-								/>
-							</label>
-							<button
-								type="button"
-								disabled={visibilityState === 'submitting'}
-								data-testid="package-make-private"
-								mix={[
-									css(getGhostButtonCss()),
-									on(
-										'click',
-										() => void submitVisibility(packageDetail, 'private'),
+						/>
+					</label>
+					<button
+						type="button"
+						disabled={visibilityState === 'submitting'}
+						data-testid={
+							packageDetail.isPrivate
+								? 'package-make-public'
+								: 'package-make-private'
+						}
+						mix={[
+							css(getGhostButtonCss()),
+							on(
+								'click',
+								() =>
+									void submitVisibility(
+										packageDetail,
+										packageDetail.isPrivate ? 'public' : 'private',
 									),
-								]}
-							>
-								{visibilityState === 'submitting' ? 'Saving…' : 'Make private'}
-							</button>
-						</>
-					)}
+							),
+						]}
+					>
+						{visibilityState === 'submitting'
+							? 'Saving…'
+							: packageDetail.isPrivate
+								? 'Make public'
+								: 'Make private'}
+					</button>
 					{visibilityMessage ? (
 						<p mix={css({ margin: 0, color: colors.danger })} role="alert">
 							{visibilityMessage}
@@ -340,18 +336,6 @@ export function AccountPackageOwnerDetails(
 						</div>
 					) : null}
 				</div>
-				<a
-					href={getAccountPackageFilesHref({
-						packageId: packageDetail.id,
-					})}
-					data-testid="account-browse-files"
-					mix={css({
-						...getGhostButtonCss({ size: 'sm' }),
-						width: 'fit-content',
-					})}
-				>
-					Browse files
-				</a>
 				<AccountPackageTokens
 					packageDetail={packageDetail}
 					currentHref={currentHref}

--- a/packages/worker/client/routes/community-area.ts
+++ b/packages/worker/client/routes/community-area.ts
@@ -1,4 +1,5 @@
 export { CommunityDetailRoute } from './community-detail.tsx'
 export { communityDetailRouteLoader } from './community-detail-shared.ts'
+export { PackageSettingsRoute } from './package-settings.tsx'
 export { CommunityRoute, communityRouteLoader } from './community.tsx'
 export { ProfileRoute, profileRouteLoader } from './profile.tsx'

--- a/packages/worker/client/routes/community-detail-sections.tsx
+++ b/packages/worker/client/routes/community-detail-sections.tsx
@@ -178,6 +178,17 @@ export function renderReadmeSection(readme: Array<RemixNode>) {
 	)
 }
 
+export function renderEmptyReadme() {
+	return (
+		<section aria-labelledby="readme-title" mix={css(readmeSectionCss)}>
+			<h2 id="readme-title">README</h2>
+			<p data-testid="community-readme-empty" mix={css(mutedTextCss)}>
+				This package has no README yet.
+			</p>
+		</section>
+	)
+}
+
 export type AdminFeatureSectionProps = {
 	featured: boolean
 	featureState: 'idle' | 'submitting' | 'error'

--- a/packages/worker/client/routes/community-detail-shared.node.test.ts
+++ b/packages/worker/client/routes/community-detail-shared.node.test.ts
@@ -1,0 +1,93 @@
+import { expect, test, vi } from 'vitest'
+import { isRouteLoaderRedirect } from '#client/route-loader.ts'
+
+vi.mock('#client/frame-prefetch.ts', () => ({
+	prefetchFrame: async () => {},
+}))
+
+const { communityDetailRouteLoader, packageMoveDestination } =
+	await import('./community-detail-shared.ts')
+
+function jsonResponse(body: unknown, status: number) {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { 'Content-Type': 'application/json' },
+	})
+}
+
+test('settings rename hops keep the settings path', () => {
+	expect(packageMoveDestination('/@owner/old/settings', '/@owner/new')).toBe(
+		'/@owner/new/settings',
+	)
+	expect(packageMoveDestination('/@owner/old', '/@owner/new')).toBe(
+		'/@owner/new',
+	)
+})
+
+test('settings loader follows a rename to settings, not the README', async () => {
+	vi.stubGlobal(
+		'fetch',
+		vi.fn(async () =>
+			jsonResponse(
+				{
+					ok: false,
+					error: 'Public package moved.',
+					redirectTo: '/@owner/new',
+				},
+				404,
+			),
+		),
+	)
+	const result = await communityDetailRouteLoader(
+		new URL('https://example.com/@owner/old/settings'),
+		new AbortController().signal,
+	)
+	expect(isRouteLoaderRedirect(result)).toBe(true)
+	if (isRouteLoaderRedirect(result)) {
+		expect(result.to).toBe('/@owner/new/settings')
+	}
+	vi.unstubAllGlobals()
+})
+
+test('settings loader 404s for listed packages the viewer does not own', async () => {
+	const listedPublic = {
+		ok: true,
+		listing: { id: 'listing-1', kodyId: 'demo' },
+		viewerIsOwner: false,
+		ownerPackage: null,
+		username: 'owner',
+		kodyId: 'demo',
+		loggedIn: true,
+		viewerIsAdmin: false,
+		forkPrompt: '',
+		viewerInstall: null,
+		readmeContent: '# Demo',
+		isPrivate: false,
+		ownerProfilePublic: true,
+		invocationUrlOrigin: 'https://example.com',
+	}
+	vi.stubGlobal(
+		'fetch',
+		vi.fn(async () => jsonResponse(listedPublic, 200)),
+	)
+	await expect(
+		communityDetailRouteLoader(
+			new URL('https://example.com/@owner/demo/settings'),
+			new AbortController().signal,
+		),
+	).rejects.toThrow('Community listing not found.')
+
+	await expect(
+		communityDetailRouteLoader(
+			new URL('https://example.com/@owner/demo'),
+			new AbortController().signal,
+		),
+	).resolves.toMatchObject({
+		communityDetailShell: {
+			ok: true,
+			viewerIsOwner: false,
+			kodyId: 'demo',
+		},
+	})
+	vi.unstubAllGlobals()
+})

--- a/packages/worker/client/routes/community-detail-shared.ts
+++ b/packages/worker/client/routes/community-detail-shared.ts
@@ -175,6 +175,10 @@ export function getPackageDetailApiRef(
 	return getListingPageRef(pathname) ?? getPackageSettingsPageRef(pathname)
 }
 
+export function packageMoveDestination(pathname: string, movedTo: string) {
+	return getPackageSettingsPageRef(pathname) ? `${movedTo}/settings` : movedTo
+}
+
 /**
  * True for the package home (`/@owner/kody-id`), its listing-uuid fallback,
  * and owner settings (`/@owner/kody-id/settings`).
@@ -222,11 +226,18 @@ export async function communityDetailRouteLoader(
 		const movedTo = payload && !payload.ok ? payload.redirectTo : null
 		// A renamed package is a real destination, not a dead link: leave the SPA
 		// so the visitor lands on (and can copy) the canonical URL.
-		if (movedTo) return routeLoaderRedirect(movedTo)
+		if (movedTo) {
+			return routeLoaderRedirect(packageMoveDestination(url.pathname, movedTo))
+		}
 		throw new Error('Community listing not found.')
 	}
 	if (!response.ok || !payload?.ok) {
 		throw new Error('Unable to load public package.')
+	}
+	if (getPackageSettingsPageRef(url.pathname)) {
+		if (!payload.viewerIsOwner || !payload.ownerPackage) {
+			throw new Error('Community listing not found.')
+		}
 	}
 
 	await framePrefetchPromise

--- a/packages/worker/client/routes/community-detail-shared.ts
+++ b/packages/worker/client/routes/community-detail-shared.ts
@@ -23,11 +23,15 @@ export type CommunityDetailApiPayload = {
 	ownerProfilePublic: boolean
 	loggedIn: boolean
 	viewerIsAdmin: boolean
+	viewerIsOwner: boolean
 	forkPrompt: string
 	viewerInstall: ViewerListingInstall | null
+	readmeContent: string | null
 	readmeFences?: Array<HighlightedCode>
 	ownerPackage: AccountPackageDetail | null
 	username: string
+	kodyId: string
+	isPrivate: boolean
 	invocationUrlOrigin: string
 }
 
@@ -51,12 +55,15 @@ export type CommunityInstallApiPayload = {
 export type CommunityShellSnapshot = {
 	loggedIn: boolean
 	viewerIsAdmin: boolean
+	viewerIsOwner: boolean
 	trusted: boolean
 	featured: boolean
 	readmeContent: string | null
 	readmeFences?: Array<HighlightedCode> | undefined
 	ownerPackage: AccountPackageDetail | null
 	username: string
+	kodyId: string
+	isPrivate: boolean
 	invocationUrlOrigin: string
 }
 
@@ -86,6 +93,9 @@ export function getListingIdFromPathname(pathname: string) {
 }
 
 const communityPackageMatcher = createMatcher(routes.communityPackage.pattern)
+const communityPackageSettingsMatcher = createMatcher(
+	routes.communityPackageSettings.pattern,
+)
 
 /**
  * The canonical package URL (`/@owner/kody-id`) carries no listing id, and
@@ -142,12 +152,35 @@ export function getListingPageRef(pathname: string): ListingPageRef | null {
 	}
 }
 
+export function getPackageSettingsPageRef(
+	pathname: string,
+): ListingPageRef | null {
+	const params = communityPackageSettingsMatcher.match(
+		new URL(pathname, 'http://localhost'),
+	)?.params
+	if (!params) return null
+	return {
+		pathname,
+		detailApiHref: routes.communityPackageApi.href({
+			username: params.username,
+			kodyId: params.kodyId,
+		}),
+		listingId: listingIdsByPathname.get(pathname) ?? null,
+	}
+}
+
+export function getPackageDetailApiRef(
+	pathname: string,
+): ListingPageRef | null {
+	return getListingPageRef(pathname) ?? getPackageSettingsPageRef(pathname)
+}
+
 /**
- * True for both public spellings of a listing page: the canonical
- * `/@owner/kody-id` and the listing-uuid URL that redirects to it.
+ * True for the package home (`/@owner/kody-id`), its listing-uuid fallback,
+ * and owner settings (`/@owner/kody-id/settings`).
  */
 export function isCommunityListingPathname(pathname: string) {
-	return getListingPageRef(pathname) !== null
+	return getPackageDetailApiRef(pathname) !== null
 }
 
 export function buildCommunityDetailFrameSrc(href: string) {
@@ -160,7 +193,7 @@ export async function communityDetailRouteLoader(
 	url: URL,
 	signal: AbortSignal,
 ): Promise<RouteLoaderResult> {
-	const ref = getListingPageRef(url.pathname)
+	const ref = getPackageDetailApiRef(url.pathname)
 	if (!ref) {
 		throw new Error('Community listing not found.')
 	}
@@ -210,13 +243,21 @@ export async function communityDetailRouteLoader(
 			forkPrompt: payload.forkPrompt,
 			loggedIn: payload.loggedIn,
 			viewerIsAdmin: payload.viewerIsAdmin,
+			viewerIsOwner: payload.viewerIsOwner,
 			trusted: payload.listing?.trusted ?? false,
 			featured: payload.listing?.featured ?? false,
-			readmeContent: payload.listing?.readmeContent ?? null,
+			readmeContent:
+				payload.readmeContent ?? payload.listing?.readmeContent ?? null,
 			readmeFences: payload.readmeFences,
 			viewerInstall: payload.viewerInstall,
 			ownerPackage: payload.ownerPackage,
 			username: payload.username,
+			kodyId:
+				payload.kodyId ||
+				payload.listing?.kodyId ||
+				payload.ownerPackage?.kodyId ||
+				'',
+			isPrivate: payload.isPrivate ?? payload.ownerPackage?.isPrivate ?? false,
 			invocationUrlOrigin: payload.invocationUrlOrigin,
 		},
 	}

--- a/packages/worker/client/routes/community-detail.tsx
+++ b/packages/worker/client/routes/community-detail.tsx
@@ -13,10 +13,7 @@ import { renderMarkdownNodes } from '#client/markdown-view.tsx'
 import { type HighlightedCode } from '#universal/highlighted-code.ts'
 import { readJson } from '#client/routes/account-approval-shared.ts'
 import { decideCommunityInstallClick } from '#client/routes/community-detail-install.ts'
-import {
-	type AccountPackageDetail,
-	type AppLoaderData,
-} from '#universal/loader-data.ts'
+import { type AppLoaderData } from '#universal/loader-data.ts'
 import {
 	type CommunityDetailApiPayload,
 	type CommunityInstallApiPayload,
@@ -26,17 +23,14 @@ import {
 	buildCommunityDetailFrameSrc,
 	buildReportApiPath,
 	getListingPageRef,
-	postPackageLock,
 	rememberListingId,
 } from './community-detail-shared.ts'
 import {
 	detailArticleCss,
-	inlineLinkCss,
-	missingHeadCss,
 	renderAdminFeatureSection,
+	renderEmptyReadme,
 	renderInstallStrip,
 	renderMissingListing,
-	renderOwnerPackageSection,
 	renderReadmeSection,
 	renderReportDisclosure,
 	renderShellStatus,
@@ -45,12 +39,12 @@ import {
 /**
  * Community detail, ported from the redesign prototype
  * (`landing/community-detail.html`). A 46rem article mirroring the blog
- * post: the listing head (back link, icon + name + author + badges, tags,
- * quiet meta row) stays server-rendered in the `community-detail` frame —
- * see `src/app/community-detail-content.tsx` — while this shell renders the
- * interactive sections around it: the README as `.prose`, admin tools, and
- * the report disclosure. Install / Installed / Fork outdated live in the
- * frame next to Trusted.
+ * post: the listing head (back link, `@owner / name`, visibility, Code /
+ * Settings tabs, tags, quiet meta row) stays server-rendered in the
+ * `community-detail` frame — see `src/app/community-detail-content.tsx` —
+ * while this shell renders the README as `.prose`, admin tools, and the
+ * report disclosure. Install / Installed / Fork outdated live in the frame
+ * next to Featured. Owner controls live on `/settings`.
  */
 
 function getCurrentListingId(handle: Handle) {
@@ -78,11 +72,6 @@ export function CommunityDetailRoute(handle: Handle) {
 	// way.
 	let shellLoadedForPathname: string | null = null
 	let shellRequestedForPathname: string | null = null
-	let ownerPackage: AccountPackageDetail | null = null
-	let username = ''
-	let invocationUrlOrigin = ''
-	let ownerDetailsMessage: string | null = null
-	const lockInFlight = new Map<string, string | null>()
 	let shellUnauthorized = false
 
 	// Re-lexing markdown on every handle.update() would be wasted work; cache
@@ -123,10 +112,6 @@ export function CommunityDetailRoute(handle: Handle) {
 		readmeFences = snapshot.readmeFences ?? []
 		reportState = 'idle'
 		reportMessage = null
-		ownerPackage = snapshot.ownerPackage
-		username = snapshot.username
-		invocationUrlOrigin = snapshot.invocationUrlOrigin
-		ownerDetailsMessage = null
 		shellUnauthorized = false
 		shellLoadedForPathname = pathname
 		shellStatus = 'ready'
@@ -181,12 +166,21 @@ export function CommunityDetailRoute(handle: Handle) {
 				{
 					loggedIn: payload.loggedIn,
 					viewerIsAdmin: payload.viewerIsAdmin,
+					viewerIsOwner: payload.viewerIsOwner,
 					trusted: payload.listing?.trusted ?? false,
 					featured: payload.listing?.featured ?? false,
-					readmeContent: payload.listing?.readmeContent ?? null,
+					readmeContent:
+						payload.readmeContent ?? payload.listing?.readmeContent ?? null,
 					readmeFences: payload.readmeFences,
 					ownerPackage: payload.ownerPackage,
 					username: payload.username,
+					kodyId:
+						payload.kodyId ||
+						payload.listing?.kodyId ||
+						payload.ownerPackage?.kodyId ||
+						'',
+					isPrivate:
+						payload.isPrivate ?? payload.ownerPackage?.isPrivate ?? false,
 					invocationUrlOrigin: payload.invocationUrlOrigin,
 				},
 				ref.pathname,
@@ -200,47 +194,6 @@ export function CommunityDetailRoute(handle: Handle) {
 			shellStatus = 'error'
 			handle.update()
 		}
-	}
-
-	function applyOwnerPackageLock(packageId: string, lockedAt: string | null) {
-		if (ownerPackage?.id === packageId) {
-			ownerPackage = { ...ownerPackage, lockedAt }
-		}
-	}
-
-	async function togglePackageLock() {
-		if (!ownerPackage || lockInFlight.has(ownerPackage.id)) return
-		const packageId = ownerPackage.id
-		const previousLockedAt = ownerPackage.lockedAt
-		const nextLocked = !(
-			typeof previousLockedAt === 'string' && previousLockedAt.trim().length > 0
-		)
-		const nextLockedAt = nextLocked ? new Date().toISOString() : null
-		lockInFlight.set(packageId, nextLockedAt)
-		ownerDetailsMessage = null
-		applyOwnerPackageLock(packageId, nextLockedAt)
-		handle.update()
-
-		const result = await postPackageLock(packageId, nextLocked)
-		lockInFlight.delete(packageId)
-		if (result.status === 'unauthorized') {
-			window.location.assign('/login')
-			handle.update()
-			return
-		}
-		if (result.status === 'error') {
-			applyOwnerPackageLock(packageId, previousLockedAt)
-			if (ownerPackage?.id === packageId) {
-				ownerDetailsMessage = result.message
-			}
-			handle.update()
-			return
-		}
-		applyOwnerPackageLock(packageId, result.lockedAt ?? nextLockedAt)
-		if (result.selectedPackage?.id === packageId) {
-			ownerPackage = result.selectedPackage
-		}
-		handle.update()
 	}
 
 	async function submitReport() {
@@ -527,7 +480,7 @@ export function CommunityDetailRoute(handle: Handle) {
 			? 'Unable to load fork and report details for this listing.'
 			: showShellReady
 				? ''
-				: 'Loading public package details…'
+				: 'Loading package details…'
 
 		return (
 			<article
@@ -535,41 +488,28 @@ export function CommunityDetailRoute(handle: Handle) {
 			>
 				<Frame name={COMMUNITY_DETAIL_TARGET} src={frameSrc} />
 
-				{showShellReady && ownerPackage && !listingId ? (
-					<header mix={css(missingHeadCss)}>
-						<h1>{ownerPackage.name}</h1>
-						<p>
-							Owner view for{' '}
-							<a
-								href={routes.profile.href({ username })}
-								mix={css(inlineLinkCss)}
-							>
-								@{username}
-							</a>
-						</p>
-					</header>
-				) : null}
-
 				{renderShellStatus(shellStatusMessage)}
 
-				{showShellReady && listingId ? (
+				{showShellReady ? (
 					<>
-						{renderInstallStrip({
-							installState,
-							installMessage,
-							installOutcome,
-							onConfirmInstall: () => void submitInstall(),
-							onCancelInstall: () => {
-								installState = 'idle'
-								handle.update()
-							},
-						})}
+						{listingId
+							? renderInstallStrip({
+									installState,
+									installMessage,
+									installOutcome,
+									onConfirmInstall: () => void submitInstall(),
+									onCancelInstall: () => {
+										installState = 'idle'
+										handle.update()
+									},
+								})
+							: null}
 
 						{readmeContent
 							? renderReadmeSection(renderReadme(readmeContent, readmeFences))
-							: null}
+							: renderEmptyReadme()}
 
-						{viewerIsAdmin
+						{listingId && viewerIsAdmin
 							? renderAdminFeatureSection({
 									featured,
 									featureState,
@@ -578,37 +518,21 @@ export function CommunityDetailRoute(handle: Handle) {
 								})
 							: null}
 
-						{renderReportDisclosure({
-							loggedIn,
-							reportReason,
-							reportState,
-							reportMessage,
-							onReasonInput: (value) => {
-								reportReason = value
-								handle.update()
-							},
-							onSubmitReport: () => void submitReport(),
-						})}
+						{listingId
+							? renderReportDisclosure({
+									loggedIn,
+									reportReason,
+									reportState,
+									reportMessage,
+									onReasonInput: (value) => {
+										reportReason = value
+										handle.update()
+									},
+									onSubmitReport: () => void submitReport(),
+								})
+							: null}
 					</>
 				) : null}
-
-				{showShellReady && ownerPackage
-					? renderOwnerPackageSection({
-							ownerPackage,
-							username,
-							invocationUrlOrigin,
-							currentHref,
-							lockInFlight: lockInFlight.has(ownerPackage.id),
-							ownerDetailsMessage,
-							onToggleLock: () => void togglePackageLock(),
-							onPackagesPayload: (payload) => {
-								if (payload.selectedPackage?.id === ownerPackage?.id) {
-									ownerPackage = payload.selectedPackage
-									handle.update()
-								}
-							},
-						})
-					: null}
 			</article>
 		)
 	}

--- a/packages/worker/client/routes/index.tsx
+++ b/packages/worker/client/routes/index.tsx
@@ -270,6 +270,10 @@ export const clientRouteLoaders: Record<string, RouteLoader> = {
 		communityArea,
 		(m) => m.communityDetailRouteLoader,
 	),
+	[routePattern(routes.communityPackageSettings)]: lazyRouteLoader(
+		communityArea,
+		(m) => m.communityDetailRouteLoader,
+	),
 	[routePattern(routes.communityDetailFiles)]: lazyRouteLoader(
 		packageFilesArea,
 		(m) => m.packageFilesRouteLoader,
@@ -504,6 +508,9 @@ export const clientRoutes = {
 	),
 	[routePattern(routes.communityPackage)]: (
 		<LazyCommunityRoute render={(m) => <m.CommunityDetailRoute />} />
+	),
+	[routePattern(routes.communityPackageSettings)]: (
+		<LazyCommunityRoute render={(m) => <m.PackageSettingsRoute />} />
 	),
 	[routePattern(routes.communityDetailFiles)]: (
 		<LazyPackageFilesRoute render={(m) => <m.PackageFilesRoute />} />

--- a/packages/worker/client/routes/package-settings.tsx
+++ b/packages/worker/client/routes/package-settings.tsx
@@ -1,0 +1,270 @@
+// remix-skill: owner settings for a package (`/@user/name/settings`).
+import { type Handle, css } from 'remix/ui'
+import { createMatcher } from 'remix/route-pattern/match'
+import { readCurrentRouterHref } from '#client/client-router.tsx'
+import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
+import { consumeStaleNavigationData } from '#client/navigation-data.ts'
+import { readRouterPathname } from '#client/router-location.tsx'
+import { readJson } from '#client/routes/account-approval-shared.ts'
+import {
+	type AccountPackageDetail,
+	type AppLoaderData,
+} from '#universal/loader-data.ts'
+import { renderPackageRepoChrome } from '#universal/package-repo-nav.tsx'
+import { routes } from '#universal/routes.ts'
+import {
+	type CommunityDetailApiPayload,
+	type CommunityPackageMovedPayload,
+	getPackageSettingsPageRef,
+	postPackageLock,
+	rememberListingId,
+} from './community-detail-shared.ts'
+import {
+	detailArticleCss,
+	renderMissingListing,
+	renderOwnerPackageSection,
+	renderShellStatus,
+} from './community-detail-sections.tsx'
+
+const settingsMatcher = createMatcher(routes.communityPackageSettings.pattern)
+
+export function PackageSettingsRoute(handle: Handle) {
+	let ownerPackage: AccountPackageDetail | null = null
+	let username = ''
+	let kodyId = ''
+	let isPrivate = false
+	let ownerProfilePublic = true
+	let invocationUrlOrigin = ''
+	let ownerDetailsMessage: string | null = null
+	let shellStatus: 'loading' | 'ready' | 'error' = 'loading'
+	let shellLoadRequestId = 0
+	let shellLoadedForPathname: string | null = null
+	let shellRequestedForPathname: string | null = null
+	let shellUnauthorized = false
+	const lockInFlight = new Map<string, string | null>()
+
+	function applyOwnerPackageLock(packageId: string, lockedAt: string | null) {
+		if (ownerPackage?.id === packageId) {
+			ownerPackage = { ...ownerPackage, lockedAt }
+		}
+	}
+
+	async function togglePackageLock() {
+		if (!ownerPackage || lockInFlight.has(ownerPackage.id)) return
+		const packageId = ownerPackage.id
+		const previousLockedAt = ownerPackage.lockedAt
+		const nextLocked = !(
+			typeof previousLockedAt === 'string' && previousLockedAt.trim().length > 0
+		)
+		const nextLockedAt = nextLocked ? new Date().toISOString() : null
+		lockInFlight.set(packageId, nextLockedAt)
+		ownerDetailsMessage = null
+		applyOwnerPackageLock(packageId, nextLockedAt)
+		handle.update()
+
+		const result = await postPackageLock(packageId, nextLocked)
+		lockInFlight.delete(packageId)
+		if (result.status === 'unauthorized') {
+			window.location.assign('/login')
+			handle.update()
+			return
+		}
+		if (result.status === 'error') {
+			applyOwnerPackageLock(packageId, previousLockedAt)
+			if (ownerPackage?.id === packageId) {
+				ownerDetailsMessage = result.message
+			}
+			handle.update()
+			return
+		}
+		applyOwnerPackageLock(packageId, result.lockedAt ?? nextLockedAt)
+		if (result.selectedPackage?.id === packageId) {
+			ownerPackage = result.selectedPackage
+		}
+		handle.update()
+	}
+
+	async function loadSettingsShell() {
+		const ref = getPackageSettingsPageRef(readRouterPathname(handle))
+		if (!ref) return
+
+		const requestId = ++shellLoadRequestId
+		if (shellLoadedForPathname !== ref.pathname) {
+			shellStatus = 'loading'
+			handle.update()
+		}
+
+		try {
+			const response = await fetch(ref.detailApiHref, {
+				headers: { Accept: 'application/json' },
+			})
+			if (requestId !== shellLoadRequestId) return
+			const payload = await readJson<
+				CommunityDetailApiPayload | CommunityPackageMovedPayload
+			>(response)
+			if (response.status === 401) {
+				shellLoadedForPathname = ref.pathname
+				shellUnauthorized = true
+				shellStatus = 'ready'
+				handle.update()
+				return
+			}
+			if (response.status === 404) {
+				const movedTo = payload && !payload.ok ? payload.redirectTo : null
+				if (movedTo) {
+					window.location.assign(`${movedTo}/settings`)
+					return
+				}
+				shellLoadedForPathname = ref.pathname
+				shellStatus = 'error'
+				handle.update()
+				return
+			}
+			if (!response.ok || !payload?.ok || !payload.ownerPackage) {
+				throw new Error('Unable to load package settings.')
+			}
+			if (payload.listing) {
+				rememberListingId(ref.pathname, payload.listing.id)
+			}
+			ownerPackage = payload.ownerPackage
+			username = payload.username
+			kodyId = payload.kodyId || payload.ownerPackage.kodyId
+			isPrivate = payload.isPrivate ?? payload.ownerPackage.isPrivate
+			ownerProfilePublic = payload.ownerProfilePublic
+			invocationUrlOrigin = payload.invocationUrlOrigin
+			ownerDetailsMessage = null
+			shellUnauthorized = false
+			shellLoadedForPathname = ref.pathname
+			shellStatus = 'ready'
+			handle.update()
+		} catch {
+			if (requestId !== shellLoadRequestId) return
+			shellLoadedForPathname = ref.pathname
+			shellStatus = 'error'
+			handle.update()
+		}
+	}
+
+	function applyRouteShellData(
+		routeData: AppLoaderData['communityDetailShell'],
+		pathname: string,
+	) {
+		if (!routeData) return false
+		if (!routeData.ok) {
+			shellUnauthorized = true
+			shellLoadedForPathname = pathname
+			shellStatus = 'ready'
+			return true
+		}
+		if (!routeData.ownerPackage) return false
+		ownerPackage = routeData.ownerPackage
+		username = routeData.username
+		kodyId = routeData.kodyId || routeData.ownerPackage.kodyId
+		isPrivate = routeData.isPrivate
+		invocationUrlOrigin = routeData.invocationUrlOrigin
+		ownerDetailsMessage = null
+		shellUnauthorized = false
+		shellLoadedForPathname = pathname
+		shellStatus = 'ready'
+		return true
+	}
+
+	return () => {
+		const currentHref = readCurrentRouterHref(handle)
+		const pathname = readRouterPathname(handle)
+		const routeData = tryConsumeRouteLoaderData(
+			handle,
+			'communityDetailShell',
+			currentHref,
+		)
+		if (routeData?.ok && routeData.listingId) {
+			rememberListingId(pathname, routeData.listingId)
+		}
+		const ref = getPackageSettingsPageRef(pathname)
+		const urlParams = settingsMatcher.match(
+			new URL(pathname, 'http://localhost'),
+		)?.params
+
+		if (
+			(routeData && !routeData.ok) ||
+			(shellUnauthorized && shellLoadedForPathname === pathname)
+		) {
+			applyRouteShellData(routeData, pathname)
+			return renderMissingListing(
+				'Unauthorized',
+				'You are not allowed to view this page.',
+			)
+		}
+
+		if (!ref) {
+			return renderMissingListing(
+				'Package settings not found',
+				'This package is unavailable.',
+			)
+		}
+
+		const appliedShellData = applyRouteShellData(routeData, pathname)
+		const needsStaleRefresh =
+			consumeStaleNavigationData(currentHref) && !appliedShellData
+		if (
+			(needsStaleRefresh ||
+				(shellLoadedForPathname !== pathname &&
+					shellRequestedForPathname !== pathname)) &&
+			typeof document !== 'undefined'
+		) {
+			if (shellLoadedForPathname !== pathname) {
+				shellStatus = 'loading'
+			}
+			shellRequestedForPathname = pathname
+			handle.queueTask(loadSettingsShell)
+		}
+
+		const shellMatches = shellLoadedForPathname === pathname
+		const showReady = shellStatus === 'ready' && shellMatches
+		const showError = shellStatus === 'error' && shellMatches
+		const statusMessage = showError
+			? 'Unable to load package settings.'
+			: showReady
+				? ''
+				: 'Loading package settings…'
+
+		const chromeUsername = username || urlParams?.username || ''
+		const chromeKodyId = kodyId || urlParams?.kodyId || ''
+
+		return (
+			<article mix={css(detailArticleCss)} data-testid="package-settings">
+				{chromeUsername && chromeKodyId
+					? renderPackageRepoChrome({
+							username: chromeUsername,
+							kodyId: chromeKodyId,
+							isPrivate,
+							viewerIsOwner: true,
+							active: 'settings',
+							description: ownerPackage?.description ?? '',
+							ownerProfilePublic,
+						})
+					: null}
+				{renderShellStatus(statusMessage)}
+				{showReady && ownerPackage
+					? renderOwnerPackageSection({
+							ownerPackage,
+							username: chromeUsername,
+							invocationUrlOrigin,
+							currentHref,
+							lockInFlight: lockInFlight.has(ownerPackage.id),
+							ownerDetailsMessage,
+							onToggleLock: () => void togglePackageLock(),
+							onPackagesPayload: (payload) => {
+								const selected = payload.selectedPackage
+								if (selected && selected.id === ownerPackage?.id) {
+									ownerPackage = selected
+									isPrivate = selected.isPrivate
+									handle.update()
+								}
+							},
+						})
+					: null}
+			</article>
+		)
+	}
+}

--- a/packages/worker/client/routes/package-settings.tsx
+++ b/packages/worker/client/routes/package-settings.tsx
@@ -16,6 +16,7 @@ import {
 	type CommunityDetailApiPayload,
 	type CommunityPackageMovedPayload,
 	getPackageSettingsPageRef,
+	packageMoveDestination,
 	postPackageLock,
 	rememberListingId,
 } from './community-detail-shared.ts'
@@ -36,7 +37,7 @@ export function PackageSettingsRoute(handle: Handle) {
 	let ownerProfilePublic = true
 	let invocationUrlOrigin = ''
 	let ownerDetailsMessage: string | null = null
-	let shellStatus: 'loading' | 'ready' | 'error' = 'loading'
+	let shellStatus: 'loading' | 'ready' | 'error' | 'missing' = 'loading'
 	let shellLoadRequestId = 0
 	let shellLoadedForPathname: string | null = null
 	let shellRequestedForPathname: string | null = null
@@ -112,16 +113,24 @@ export function PackageSettingsRoute(handle: Handle) {
 			if (response.status === 404) {
 				const movedTo = payload && !payload.ok ? payload.redirectTo : null
 				if (movedTo) {
-					window.location.assign(`${movedTo}/settings`)
+					window.location.assign(packageMoveDestination(ref.pathname, movedTo))
 					return
 				}
 				shellLoadedForPathname = ref.pathname
-				shellStatus = 'error'
+				shellStatus = 'missing'
 				handle.update()
 				return
 			}
-			if (!response.ok || !payload?.ok || !payload.ownerPackage) {
-				throw new Error('Unable to load package settings.')
+			if (
+				!response.ok ||
+				!payload?.ok ||
+				!payload.ownerPackage ||
+				!payload.viewerIsOwner
+			) {
+				shellLoadedForPathname = ref.pathname
+				shellStatus = 'missing'
+				handle.update()
+				return
 			}
 			if (payload.listing) {
 				rememberListingId(ref.pathname, payload.listing.id)
@@ -156,7 +165,11 @@ export function PackageSettingsRoute(handle: Handle) {
 			shellStatus = 'ready'
 			return true
 		}
-		if (!routeData.ownerPackage) return false
+		if (!routeData.ownerPackage || !routeData.viewerIsOwner) {
+			shellLoadedForPathname = pathname
+			shellStatus = 'missing'
+			return true
+		}
 		ownerPackage = routeData.ownerPackage
 		username = routeData.username
 		kodyId = routeData.kodyId || routeData.ownerPackage.kodyId
@@ -222,6 +235,10 @@ export function PackageSettingsRoute(handle: Handle) {
 		const shellMatches = shellLoadedForPathname === pathname
 		const showReady = shellStatus === 'ready' && shellMatches
 		const showError = shellStatus === 'error' && shellMatches
+		const showMissing = shellStatus === 'missing' && shellMatches
+		if (showMissing) {
+			return renderMissingListing('Not Found', 'We could not find that page.')
+		}
 		const statusMessage = showError
 			? 'Unable to load package settings.'
 			: showReady

--- a/packages/worker/src/app/account-package-publish-lock.ts
+++ b/packages/worker/src/app/account-package-publish-lock.ts
@@ -1,5 +1,5 @@
 import { type AccountPackageApprovePublishLoaderData } from '#universal/loader-data.ts'
-import { getAccountPackageFilesHref } from '#universal/package-files.ts'
+import { getPackageTreeHref } from '#universal/package-files.ts'
 import { routes } from '#universal/routes.ts'
 import { jsonResponse } from '#worker/json-response.ts'
 import {
@@ -74,7 +74,10 @@ export async function loadAccountPackageApprovePublishData(input: {
 			pendingCommit != null &&
 			publishedCommit != null &&
 			pendingCommit === publishedCommit,
-		filesHref: getAccountPackageFilesHref({ packageId: savedPackage.id }),
+		filesHref: getPackageTreeHref({
+			username: input.user.username,
+			kodyId: savedPackage.kodyId,
+		}),
 		packageHref: routes.communityPackage.href({
 			username: input.user.username,
 			kodyId: savedPackage.kodyId,

--- a/packages/worker/src/app/account-package-visibility.node.test.ts
+++ b/packages/worker/src/app/account-package-visibility.node.test.ts
@@ -1,0 +1,137 @@
+import { expect, test, vi } from 'vitest'
+
+const mockModule = vi.hoisted(() => ({
+	getSavedPackageById: vi.fn(),
+	updateSavedPackage: vi.fn(),
+	publishCommunityListing: vi.fn(),
+	unpublishCommunityListing: vi.fn(),
+	getCommunityListingByOwnerAndPackage: vi.fn(),
+	loadAccountPackagesData: vi.fn(),
+}))
+
+vi.mock('#worker/package-registry/repo.ts', () => ({
+	getSavedPackageById: (...args: Array<unknown>) =>
+		mockModule.getSavedPackageById(...args),
+	updateSavedPackage: (...args: Array<unknown>) =>
+		mockModule.updateSavedPackage(...args),
+}))
+
+vi.mock('#worker/community/service.ts', () => ({
+	publishCommunityListing: (...args: Array<unknown>) =>
+		mockModule.publishCommunityListing(...args),
+	unpublishCommunityListing: (...args: Array<unknown>) =>
+		mockModule.unpublishCommunityListing(...args),
+}))
+
+vi.mock('#worker/community/repo.ts', () => ({
+	getCommunityListingByOwnerAndPackage: (...args: Array<unknown>) =>
+		mockModule.getCommunityListingByOwnerAndPackage(...args),
+}))
+
+vi.mock('#app/account-packages-data.ts', () => ({
+	loadAccountPackagesData: (...args: Array<unknown>) =>
+		mockModule.loadAccountPackagesData(...args),
+}))
+
+const { handleAccountPackageVisibilityAction } =
+	await import('./account-package-visibility.ts')
+
+function createUser() {
+	return {
+		sessionUserId: '42',
+		userId: 42,
+		username: 'user',
+		email: 'user@example.com',
+		displayName: 'user',
+		artifactOwnerIds: [],
+		mcpUser: {
+			userId: 'stable-user-1',
+			email: 'user@example.com',
+			username: 'user',
+			displayName: 'user',
+		},
+	}
+}
+
+function createSavedPackage(isPrivate: boolean) {
+	return {
+		id: 'pkg-1',
+		userId: 'stable-user-1',
+		name: '@user/notes',
+		kodyId: 'notes',
+		description: 'Personal notes',
+		tags: ['notes'],
+		searchText: null,
+		sourceId: 'source-1',
+		hasApp: false,
+		hidden: false,
+		isPrivate,
+		lockedAt: null,
+		createdAt: '2026-01-01T00:00:00.000Z',
+		updatedAt: '2026-07-14T00:00:00.000Z',
+	}
+}
+
+test('making a package public or private requires typing the slug', async () => {
+	const env = { APP_DB: {} } as Env
+	const user = createUser()
+	const request = new Request('https://example.com/account/packages.json', {
+		method: 'POST',
+	})
+	mockModule.loadAccountPackagesData.mockResolvedValue({ ok: true })
+
+	expect(
+		await handleAccountPackageVisibilityAction({
+			env,
+			request,
+			user,
+			body: { action: 'delete' },
+		}),
+	).toBeNull()
+
+	mockModule.getSavedPackageById.mockResolvedValue(createSavedPackage(true))
+	const missingPublicConfirm = await handleAccountPackageVisibilityAction({
+		env,
+		request,
+		user,
+		body: {
+			action: 'set-visibility',
+			packageId: 'pkg-1',
+			visibility: 'public',
+		},
+	})
+	expect(missingPublicConfirm?.status).toBe(400)
+	await expect(missingPublicConfirm?.json()).resolves.toMatchObject({
+		ok: false,
+		error: expect.stringContaining('Type the package slug "notes"'),
+	})
+	expect(mockModule.publishCommunityListing).not.toHaveBeenCalled()
+
+	const publicOk = await handleAccountPackageVisibilityAction({
+		env,
+		request,
+		user,
+		body: {
+			action: 'set-visibility',
+			packageId: 'pkg-1',
+			visibility: 'public',
+			confirmName: 'notes',
+		},
+	})
+	expect(publicOk?.status).toBe(200)
+	expect(mockModule.publishCommunityListing).toHaveBeenCalled()
+
+	mockModule.getSavedPackageById.mockResolvedValue(createSavedPackage(false))
+	const missingPrivateConfirm = await handleAccountPackageVisibilityAction({
+		env,
+		request,
+		user,
+		body: {
+			action: 'set-visibility',
+			packageId: 'pkg-1',
+			visibility: 'private',
+		},
+	})
+	expect(missingPrivateConfirm?.status).toBe(400)
+	expect(mockModule.unpublishCommunityListing).not.toHaveBeenCalled()
+})

--- a/packages/worker/src/app/account-package-visibility.ts
+++ b/packages/worker/src/app/account-package-visibility.ts
@@ -50,6 +50,15 @@ export async function handleAccountPackageVisibilityAction(input: {
 
 	try {
 		if (visibility === 'public' && savedPackage.isPrivate) {
+			if (confirmName !== savedPackage.kodyId) {
+				return jsonResponse(
+					{
+						ok: false,
+						error: `Type the package slug "${savedPackage.kodyId}" to make it public. Anyone will be able to read and fork the default branch.`,
+					},
+					400,
+				)
+			}
 			await publishCommunityListing({
 				env: input.env,
 				baseUrl: new URL(input.request.url).origin,

--- a/packages/worker/src/app/community-detail-content.node.test.ts
+++ b/packages/worker/src/app/community-detail-content.node.test.ts
@@ -24,6 +24,11 @@ const sampleListing = {
 } satisfies PublicCommunityListing
 
 const detailBase = {
+	listing: sampleListing,
+	username: 'kentcdodds',
+	kodyId: 'github-triage',
+	description: sampleListing.description,
+	isPrivate: false,
 	ownerProfilePublic: true,
 	viewerIsOwner: false,
 	returnTo: '/@kentcdodds/github-triage',
@@ -31,7 +36,6 @@ const detailBase = {
 
 test('community detail head covers install, installed, and listing-ahead badges', async () => {
 	const installHtml = await renderCommunityDetailContentHtml({
-		listing: sampleListing,
 		...detailBase,
 		loggedIn: true,
 	})
@@ -42,6 +46,7 @@ test('community detail head covers install, installed, and listing-ahead badges'
 	const agentPrompt =
 		'Call packageGet for @me/github-triage and adapt it to my needs.'
 	const installedHtml = await renderCommunityDetailContentHtml({
+		...detailBase,
 		listing: {
 			...sampleListing,
 			viewerInstall: {
@@ -53,7 +58,6 @@ test('community detail head covers install, installed, and listing-ahead badges'
 				listingAheadPrompt: null,
 			},
 		},
-		...detailBase,
 		loggedIn: true,
 	})
 	expect(installedHtml).toContain(
@@ -65,11 +69,11 @@ test('community detail head covers install, installed, and listing-ahead badges'
 	expect(installedHtml).not.toContain('data-testid="community-detail-install"')
 
 	const sourceAheadHtml = await renderCommunityDetailContentHtml({
+		...detailBase,
 		listing: {
 			...sampleListing,
 			sourceAhead: true,
 		},
-		...detailBase,
 		loggedIn: true,
 	})
 	expect(sourceAheadHtml).toContain(
@@ -77,6 +81,7 @@ test('community detail head covers install, installed, and listing-ahead badges'
 	)
 
 	const ownInstalledHtml = await renderCommunityDetailContentHtml({
+		...detailBase,
 		listing: {
 			...sampleListing,
 			viewerInstall: {
@@ -88,7 +93,6 @@ test('community detail head covers install, installed, and listing-ahead badges'
 				listingAheadPrompt: null,
 			},
 		},
-		...detailBase,
 		viewerIsOwner: true,
 		loggedIn: true,
 	})
@@ -103,6 +107,7 @@ test('community detail head covers install, installed, and listing-ahead badges'
 	const aheadPrompt =
 		'Compare the current listing snapshot, keep local customizations, then publish with repoPublishSession and absorbed_upstream_commit.'
 	const aheadHtml = await renderCommunityDetailContentHtml({
+		...detailBase,
 		listing: {
 			...sampleListing,
 			viewerInstall: {
@@ -114,7 +119,6 @@ test('community detail head covers install, installed, and listing-ahead badges'
 				listingAheadPrompt: aheadPrompt,
 			},
 		},
-		...detailBase,
 		returnTo: '/community',
 		loggedIn: true,
 	})
@@ -127,4 +131,44 @@ test('community detail head covers install, installed, and listing-ahead badges'
 		'data-testid="community-detail-viewer-install-badge"',
 	)
 	expect(aheadHtml).not.toContain('data-testid="community-detail-install"')
+})
+
+test('package chrome is shared for public listings and private owner packages', async () => {
+	const publicHtml = await renderCommunityDetailContentHtml({
+		...detailBase,
+		loggedIn: false,
+	})
+	expect(publicHtml).toContain('data-testid="package-repo-chrome"')
+	expect(publicHtml).toContain('data-testid="package-repo-nav-code"')
+	expect(publicHtml).not.toContain('data-testid="package-repo-nav-settings"')
+	expect(publicHtml).toContain('data-visibility="public"')
+	expect(publicHtml).toContain('data-testid="community-browse-files"')
+	expect(publicHtml).toContain('href="/@kentcdodds/github-triage/tree/main"')
+	expect(publicHtml).toContain('data-testid="community-detail-forks"')
+	expect(publicHtml).toContain('← Public packages')
+
+	const ownerHtml = await renderCommunityDetailContentHtml({
+		...detailBase,
+		viewerIsOwner: true,
+		loggedIn: true,
+	})
+	expect(ownerHtml).toContain('data-testid="package-repo-nav-settings"')
+	expect(ownerHtml).toContain('href="/@kentcdodds/github-triage/settings"')
+	expect(ownerHtml).toContain('← Packages')
+
+	const privateHtml = await renderCommunityDetailContentHtml({
+		...detailBase,
+		listing: null,
+		isPrivate: true,
+		viewerIsOwner: true,
+		loggedIn: true,
+		description: 'Local notes.',
+	})
+	expect(privateHtml).toContain('data-testid="package-repo-chrome"')
+	expect(privateHtml).toContain('data-visibility="private"')
+	expect(privateHtml).toContain('data-testid="package-repo-nav-settings"')
+	expect(privateHtml).toContain('href="/@kentcdodds/github-triage/tree/main"')
+	expect(privateHtml).not.toContain('data-testid="community-detail-forks"')
+	expect(privateHtml).not.toContain('data-testid="community-listing-category"')
+	expect(privateHtml).toContain('Local notes.')
 })

--- a/packages/worker/src/app/community-detail-content.tsx
+++ b/packages/worker/src/app/community-detail-content.tsx
@@ -12,64 +12,77 @@ import {
 	shortCommunityCommit,
 } from '#universal/community-display.ts'
 import { CommunityListingIcon } from '#universal/community-listing-icon.tsx'
-import { renderCommunityListingName } from '#universal/community-listing-name.tsx'
 import {
-	communityBadgePillCss,
 	communityTagListCss,
 	communityTagPillCss,
 	renderCommunityViewerInstallBadge,
 } from '#app/community-listings-content.tsx'
-import { getCommunityPackageFilesHref } from '#universal/package-files.ts'
-import { routes } from '#universal/routes.ts'
-import { visuallyHiddenCss } from '#universal/styles/style-primitives.ts'
+import {
+	fallbackDefaultBranchName,
+	getPackageTreeHref,
+} from '#universal/package-files.ts'
+import { renderPackageRepoChrome } from '#universal/package-repo-nav.tsx'
 import { colors } from '#universal/styles/tokens.ts'
 
 /**
- * Server-rendered community detail head (the `community-detail` frame),
- * restyled to the redesign prototype's `.pkg-detail` grammar
- * (`landing/community-detail.html`): back link → icon + name + author +
- * badges → description → hairline tag chips → quiet dt/dd meta row between
- * hairlines. The page-open `data-rise` choreography is pure CSS keyed on
- * `html.js` + reduced-motion, so this frame HTML animates on every load or
- * reload without any client component hydrating here.
+ * Server-rendered package head (the `community-detail` frame): GitHub-style
+ * `@owner / name` + visibility + Code/Settings tabs, then the public catalog
+ * extras (icon, install badges, tags, facts) when a listing exists.
  */
 
 export type CommunityDetailContentProps = {
 	listing: PublicCommunityListing | null
+	username: string
+	kodyId: string
+	description: string
+	isPrivate: boolean
 	ownerProfilePublic: boolean
 	loggedIn: boolean
 	viewerIsOwner: boolean
 	returnTo: string
+	treeRef?: string
 }
 
 export function CommunityDetailContent(
 	handle: Handle<CommunityDetailContentProps>,
 ) {
-	const { listing, ownerProfilePublic, loggedIn, viewerIsOwner, returnTo } =
-		handle.props
+	const {
+		listing,
+		username,
+		kodyId,
+		description,
+		isPrivate,
+		ownerProfilePublic,
+		loggedIn,
+		viewerIsOwner,
+		returnTo,
+		treeRef,
+	} = handle.props
 
-	if (!listing) {
-		return () => null
-	}
+	const filesHref = getPackageTreeHref({
+		username,
+		kodyId,
+		listingId: listing?.id,
+		ref: listing?.defaultBranch ?? treeRef ?? fallbackDefaultBranchName,
+	})
 
 	return () => (
 		<div data-testid="community-detail-frame">
-			<a
-				data-rise
-				style={{ '--rise': '0' }}
-				href={routes.community.href()}
-				mix={css(backLinkCss)}
-			>
-				← Public packages
-			</a>
+			{renderPackageRepoChrome({
+				username,
+				kodyId,
+				isPrivate,
+				viewerIsOwner,
+				active: 'code',
+				description,
+				ownerProfilePublic,
+				animate: true,
+			})}
 
-			<header data-rise style={{ '--rise': '1' }} mix={css(detailHeadCss)}>
-				<CommunityListingIcon listing={listing} size="detail" />
-				<div mix={css(headTextCss)}>
-					<div mix={css(titleRowCss)}>
-						<h1>{renderCommunityListingName(listing.name)}</h1>
-					</div>
-					<span mix={css(detailBadgeGroupCss)}>
+			{listing ? (
+				<header data-rise style={{ '--rise': '2' }} mix={css(listingHeadCss)}>
+					<CommunityListingIcon listing={listing} size="detail" />
+					<div mix={css(listingBadgeGroupCss)}>
 						{listing.sourceAhead ? (
 							<span
 								data-testid="community-detail-source-ahead-badge"
@@ -95,65 +108,13 @@ export function CommunityDetailContent(
 							returnTo,
 							viewerIsOwner,
 						})}
-					</span>
-					<div
-						mix={css(ownerLineCss)}
-						data-testid="community-detail-owner-line"
-					>
-						<span>by</span>
-						{ownerProfilePublic ? (
-							<a
-								href={routes.profile.href({
-									username: listing.ownerUsername,
-								})}
-								mix={css(ownerLinkCss)}
-							>
-								@{listing.ownerUsername}
-							</a>
-						) : (
-							<span mix={css(ownerPrivateNameCss)}>
-								@{listing.ownerUsername}
-								<span
-									data-testid="community-detail-owner-private"
-									title="This profile is private"
-									mix={css(ownerPrivateLockCss)}
-								>
-									<svg
-										viewBox="0 0 16 16"
-										width="0.9em"
-										height="0.9em"
-										aria-hidden="true"
-										focusable={false}
-										fill="none"
-										stroke="currentColor"
-										strokeWidth="1.5"
-										strokeLinecap="round"
-										strokeLinejoin="round"
-									>
-										<rect x="3.5" y="7.2" width="9" height="6.3" rx="1.4" />
-										<path d="M5.4 7.2V5.4a2.6 2.6 0 0 1 5.2 0v1.8" />
-									</svg>
-									<span mix={css(visuallyHiddenCss)}>
-										This profile is private
-									</span>
-								</span>
-							</span>
-						)}
 					</div>
-				</div>
-			</header>
+				</header>
+			) : null}
 
-			<p data-rise style={{ '--rise': '2' }} mix={css(detailSubCss)}>
-				{listing.description}
-			</p>
-			<p data-rise style={{ '--rise': '2' }} mix={css(filesLinkRowCss)}>
+			<p data-rise style={{ '--rise': '3' }} mix={css(filesLinkRowCss)}>
 				<a
-					href={getCommunityPackageFilesHref({
-						listingId: listing.id,
-						ownerUsername: listing.ownerUsername,
-						kodyId: listing.kodyId,
-						ref: listing.defaultBranch,
-					})}
+					href={filesHref}
 					data-testid="community-browse-files"
 					mix={css(filesLinkCss)}
 				>
@@ -161,61 +122,69 @@ export function CommunityDetailContent(
 				</a>
 			</p>
 
-			<ul
-				data-rise
-				style={{ '--rise': '3' }}
-				aria-label="Category and tags"
-				mix={css(detailTagListCss)}
-			>
-				<li mix={css(communityTagPillCss)}>
-					<a
-						href={buildCommunityIndexHref({ category: listing.category })}
-						data-testid="community-listing-category"
-						mix={css(detailCategoryLinkCss)}
+			{listing ? (
+				<>
+					<ul
+						data-rise
+						style={{ '--rise': '3' }}
+						aria-label="Category and tags"
+						mix={css(detailTagListCss)}
 					>
-						{communityPackageCategoryCopy[listing.category].label}
-					</a>
-				</li>
-				{listing.tags.map((tag) => (
-					<li key={tag} mix={css(communityTagPillCss)}>
-						{tag}
-					</li>
-				))}
-			</ul>
+						<li mix={css(communityTagPillCss)}>
+							<a
+								href={buildCommunityIndexHref({ category: listing.category })}
+								data-testid="community-listing-category"
+								mix={css(detailCategoryLinkCss)}
+							>
+								{communityPackageCategoryCopy[listing.category].label}
+							</a>
+						</li>
+						{listing.tags.map((tag) => (
+							<li key={tag} mix={css(communityTagPillCss)}>
+								{tag}
+							</li>
+						))}
+					</ul>
 
-			{/* Facts as a quiet definition row, not a stat billboard. */}
-			<dl data-rise style={{ '--rise': '4' }} mix={css(metaCss)}>
-				<div>
-					<dt>License</dt>
-					<dd>{listing.license}</dd>
-				</div>
-				<div>
-					<dt>Published</dt>
-					<dd>{formatCommunityPublishedDate(listing.publishedAt)}</dd>
-				</div>
-				<div>
-					<dt>Pinned commit</dt>
-					<dd>
-						<code>{shortCommunityCommit(listing.pinnedCommit)}</code>
-					</dd>
-				</div>
-				<div>
-					<dt>Rating</dt>
-					<dd data-testid="community-detail-rating">
-						{formatCommunityStars(listing.averageStars, listing.ratingCount)}
-					</dd>
-				</div>
-				<div>
-					<dt>Forks</dt>
-					<dd data-testid="community-detail-forks">{listing.forkCount}</dd>
-				</div>
-				<div>
-					<dt>Adaptation effort</dt>
-					<dd>
-						{formatCommunityAdaptationEffort(listing.averageAdaptationEffort)}
-					</dd>
-				</div>
-			</dl>
+					<dl data-rise style={{ '--rise': '4' }} mix={css(metaCss)}>
+						<div>
+							<dt>License</dt>
+							<dd>{listing.license}</dd>
+						</div>
+						<div>
+							<dt>Published</dt>
+							<dd>{formatCommunityPublishedDate(listing.publishedAt)}</dd>
+						</div>
+						<div>
+							<dt>Pinned commit</dt>
+							<dd>
+								<code>{shortCommunityCommit(listing.pinnedCommit)}</code>
+							</dd>
+						</div>
+						<div>
+							<dt>Rating</dt>
+							<dd data-testid="community-detail-rating">
+								{formatCommunityStars(
+									listing.averageStars,
+									listing.ratingCount,
+								)}
+							</dd>
+						</div>
+						<div>
+							<dt>Forks</dt>
+							<dd data-testid="community-detail-forks">{listing.forkCount}</dd>
+						</div>
+						<div>
+							<dt>Adaptation effort</dt>
+							<dd>
+								{formatCommunityAdaptationEffort(
+									listing.averageAdaptationEffort,
+								)}
+							</dd>
+						</div>
+					</dl>
+				</>
+			) : null}
 		</div>
 	)
 }
@@ -226,112 +195,35 @@ export async function renderCommunityDetailContentHtml(
 	return renderToString(<CommunityDetailContent {...props} />)
 }
 
-/* ---------- styles (prototype: `.pkg-detail` in landing/styles.css) ---------- */
-
-const backLinkCss = {
-	display: 'inline-flex',
-	alignItems: 'center',
-	gap: '0.4rem',
-	fontSize: '0.95rem',
-	fontWeight: 550,
-	color: colors.primaryText,
-	textDecoration: 'none',
-	'&:hover': {
-		color: colors.text,
-	},
-}
-
-const detailHeadCss = {
-	marginTop: '1.8rem',
+const listingHeadCss = {
+	marginTop: '1.4rem',
 	display: 'flex',
 	alignItems: 'flex-start',
 	gap: '1.1rem',
 }
 
-const headTextCss = {
-	minWidth: 0,
-	flex: 1,
-	display: 'flex',
-	flexDirection: 'column' as const,
-	gap: '0.45rem',
-	'& h1': {
-		margin: 0,
-		fontSize: 'clamp(1.7rem, 4vw, 2.4rem)',
-		fontWeight: 760,
-		letterSpacing: '-0.024em',
-		lineHeight: 1.05,
-		overflowWrap: 'anywhere' as const,
-	},
-}
-
-const titleRowCss = {
-	display: 'flex',
-	alignItems: 'center',
-	flexWrap: 'wrap' as const,
-	gap: '0.5rem',
-	minWidth: 0,
-	'& h1': {
-		flex: '0 1 auto',
-		minWidth: 0,
-	},
-}
-
-const detailBadgeGroupCss = {
+const listingBadgeGroupCss = {
 	display: 'flex',
 	alignItems: 'center',
 	flexWrap: 'wrap' as const,
 	gap: '0.35rem',
-}
-
-const ownerLineCss = {
-	display: 'inline-flex',
-	alignItems: 'center',
-	flexWrap: 'nowrap' as const,
-	gap: '0.35rem',
-	margin: 0,
-	color: colors.textMuted,
-	fontSize: '0.95rem',
-	width: 'max-content',
-	maxWidth: '100%',
-}
-
-const ownerLinkCss = {
-	color: colors.textMuted,
-	fontWeight: 550,
-	textDecoration: 'none',
-	'&:hover': {
-		color: colors.primaryText,
-	},
-}
-
-const ownerPrivateNameCss = {
-	display: 'inline-flex',
-	alignItems: 'center',
-	gap: '0.25rem',
-	minWidth: 0,
-}
-
-const ownerPrivateLockCss = {
-	display: 'inline-flex',
-	alignItems: 'center',
-	color: colors.textMuted,
-	cursor: 'help',
-	flexShrink: 0,
+	paddingTop: '0.35rem',
 }
 
 const badgeCss = {
-	...communityBadgePillCss,
-}
-
-const detailSubCss = {
-	margin: '1.4rem 0 0',
+	display: 'inline-flex',
+	alignItems: 'center',
+	padding: '0.15rem 0.55rem',
+	borderRadius: '999px',
+	fontSize: '0.78rem',
+	fontWeight: 600,
+	backgroundColor: colors.surface,
+	border: `1px solid ${colors.border}`,
 	color: colors.textMuted,
-	fontSize: '1.05rem',
-	maxWidth: '58ch',
 }
 
 const filesLinkRowCss = {
-	margin: '0.7rem 0 0',
+	margin: '0.9rem 0 0',
 }
 
 const filesLinkCss = {

--- a/packages/worker/src/app/community-package-route.node.test.ts
+++ b/packages/worker/src/app/community-package-route.node.test.ts
@@ -5,6 +5,7 @@ const mockModule = vi.hoisted(() => ({
 	getCommunityListingById: vi.fn<() => Promise<unknown>>(),
 	getEntitySourceById: vi.fn<() => Promise<unknown>>(),
 	resolveArtifactSourceHead: vi.fn<() => Promise<unknown>>(),
+	loadPackagePage: vi.fn<() => Promise<unknown>>(),
 }))
 
 vi.mock('#worker/community/package-url.ts', () => ({
@@ -27,6 +28,11 @@ vi.mock('#worker/repo/entity-sources.ts', () => ({
 vi.mock('#worker/repo/artifacts.ts', () => ({
 	resolveArtifactSourceHead: (...args: Array<unknown>) =>
 		mockModule.resolveArtifactSourceHead(...args),
+}))
+
+vi.mock('#app/package-page.ts', () => ({
+	loadPackagePage: (...args: Array<unknown>) =>
+		mockModule.loadPackagePage(...args),
 }))
 
 const { resolveCommunityFilesRoute } =
@@ -116,4 +122,43 @@ test('leftover /files and /tree/HEAD 301 to the looked-up default branch', async
 		kind: 'redirect',
 		to: '/@kentcdodds/devin/tree/main',
 	})
+})
+
+test('unlisted owner tree uses the package page; strangers are unauthorized', async () => {
+	mockModule.resolveCommunityPackageUrl.mockResolvedValue(null)
+	mockModule.loadPackagePage.mockResolvedValue({
+		kind: 'page',
+		username: 'kentcdodds',
+		kodyId: 'friction-log',
+		listing: null,
+		ownerPackage: { sourceId: 'src-1', isPrivate: true },
+		viewerIsOwner: true,
+		loggedIn: true,
+		invocationUrlOrigin: 'https://example.com',
+	})
+
+	const owner = await resolveCommunityFilesRoute({
+		env,
+		url: filesUrl('/@kentcdodds/friction-log/tree/main'),
+		request: new Request(
+			'https://example.com/@kentcdodds/friction-log/tree/main',
+		),
+	})
+	expect(owner).toEqual({
+		kind: 'package',
+		username: 'kentcdodds',
+		kodyId: 'friction-log',
+		selectedPath: '',
+		ref: 'main',
+	})
+
+	mockModule.loadPackagePage.mockResolvedValue({ kind: 'unauthorized' })
+	const stranger = await resolveCommunityFilesRoute({
+		env,
+		url: filesUrl('/@kentcdodds/friction-log/tree/main'),
+		request: new Request(
+			'https://example.com/@kentcdodds/friction-log/tree/main',
+		),
+	})
+	expect(stranger).toEqual({ kind: 'unauthorized' })
 })

--- a/packages/worker/src/app/community-package-route.node.test.ts
+++ b/packages/worker/src/app/community-package-route.node.test.ts
@@ -68,6 +68,7 @@ test('leftover /files and /tree/HEAD 301 to the looked-up default branch', async
 	expect(leftover).toEqual({
 		kind: 'redirect',
 		to: '/@kentcdodds/devin/tree/release/src/index.ts',
+		shared: true,
 	})
 
 	const head = await resolveCommunityFilesRoute({
@@ -77,6 +78,7 @@ test('leftover /files and /tree/HEAD 301 to the looked-up default branch', async
 	expect(head).toEqual({
 		kind: 'redirect',
 		to: '/@kentcdodds/devin/tree/release',
+		shared: true,
 	})
 
 	const headFile = await resolveCommunityFilesRoute({
@@ -86,6 +88,7 @@ test('leftover /files and /tree/HEAD 301 to the looked-up default branch', async
 	expect(headFile).toEqual({
 		kind: 'redirect',
 		to: '/@kentcdodds/devin/tree/release/src/index.ts',
+		shared: true,
 	})
 
 	mockModule.resolveArtifactSourceHead.mockClear()
@@ -121,6 +124,7 @@ test('leftover /files and /tree/HEAD 301 to the looked-up default branch', async
 	expect(fallback).toEqual({
 		kind: 'redirect',
 		to: '/@kentcdodds/devin/tree/main',
+		shared: true,
 	})
 })
 
@@ -161,4 +165,46 @@ test('unlisted owner tree uses the package page; strangers are unauthorized', as
 		),
 	})
 	expect(stranger).toEqual({ kind: 'unauthorized' })
+})
+
+test('unlisted leftover /files and rename hops stay owner-private', async () => {
+	mockModule.resolveCommunityPackageUrl.mockResolvedValue(null)
+	mockModule.getEntitySourceById.mockResolvedValue(null)
+	mockModule.loadPackagePage.mockResolvedValue({
+		kind: 'page',
+		username: 'kentcdodds',
+		kodyId: 'friction-log',
+		listing: null,
+		ownerPackage: { sourceId: 'src-1', isPrivate: true },
+		viewerIsOwner: true,
+		loggedIn: true,
+		invocationUrlOrigin: 'https://example.com',
+	})
+
+	const leftover = await resolveCommunityFilesRoute({
+		env,
+		url: filesUrl('/@kentcdodds/friction-log/files'),
+		request: new Request('https://example.com/@kentcdodds/friction-log/files'),
+	})
+	expect(leftover).toEqual({
+		kind: 'redirect',
+		to: '/@kentcdodds/friction-log/tree/main',
+		shared: false,
+	})
+
+	mockModule.loadPackagePage.mockResolvedValue({
+		kind: 'redirect',
+		to: '/@kentcdodds/friction-log',
+		shared: false,
+	})
+	const renamed = await resolveCommunityFilesRoute({
+		env,
+		url: filesUrl('/@kentcdodds/old-log/tree/main'),
+		request: new Request('https://example.com/@kentcdodds/old-log/tree/main'),
+	})
+	expect(renamed).toEqual({
+		kind: 'redirect',
+		to: '/@kentcdodds/friction-log/tree/main',
+		shared: false,
+	})
 })

--- a/packages/worker/src/app/community-package-route.node.test.ts
+++ b/packages/worker/src/app/community-package-route.node.test.ts
@@ -207,4 +207,27 @@ test('unlisted leftover /files and rename hops stay owner-private', async () => 
 		to: '/@kentcdodds/friction-log/tree/main',
 		shared: false,
 	})
+
+	mockModule.loadPackagePage.mockResolvedValue({
+		kind: 'page',
+		username: 'kentcdodds',
+		kodyId: 'friction-log-two',
+		listing: { listing: { id: 'listing-1', kodyId: 'friction-log' } },
+		ownerPackage: { sourceId: 'src-1', isPrivate: false },
+		viewerIsOwner: true,
+		loggedIn: true,
+		invocationUrlOrigin: 'https://example.com',
+	})
+	const unpublishedLeftover = await resolveCommunityFilesRoute({
+		env,
+		url: filesUrl('/@kentcdodds/friction-log-two/files'),
+		request: new Request(
+			'https://example.com/@kentcdodds/friction-log-two/files',
+		),
+	})
+	expect(unpublishedLeftover).toEqual({
+		kind: 'redirect',
+		to: '/@kentcdodds/friction-log-two/tree/main',
+		shared: false,
+	})
 })

--- a/packages/worker/src/app/community-package-route.ts
+++ b/packages/worker/src/app/community-package-route.ts
@@ -1,4 +1,5 @@
 import { createMatcher } from 'remix/route-pattern/match'
+import { loadPackagePage } from '#app/package-page.ts'
 import {
 	getCommunityPackageHref,
 	resolveCommunityPackageUrl,
@@ -6,6 +7,7 @@ import {
 import {
 	fallbackDefaultBranchName,
 	getCommunityPackageFilesHref,
+	getPackageTreeHref,
 	isPublicTreeDefaultRefAlias,
 	isReservedPackageFilesKodyId,
 	normalizePackageFilesPath,
@@ -90,7 +92,15 @@ export type CommunityFilesRouteTarget =
 			selectedPath: string
 			ref: string
 	  }
+	| {
+			kind: 'package'
+			username: string
+			kodyId: string
+			selectedPath: string
+			ref: string
+	  }
 	| { kind: 'redirect'; to: string }
+	| { kind: 'unauthorized' }
 	| { kind: 'invalid-path' }
 
 function selectedPathFromParams(relativePath: string | undefined) {
@@ -101,20 +111,107 @@ function requestedTreeRef(ref: string | undefined) {
 	return ref?.trim() ?? ''
 }
 
-async function resolveListingDefaultTreeRef(env: Env, listingId: string) {
+async function resolveSourceDefaultTreeRef(env: Env, sourceId: string | null) {
+	if (!sourceId) return fallbackDefaultBranchName
 	try {
-		const listing = await getCommunityListingById(env.APP_DB, {
-			listingId,
-			includeDelisted: false,
-		})
-		if (!listing) return fallbackDefaultBranchName
-		const source = await getEntitySourceById(env.APP_DB, listing.sourceId)
+		const source = await getEntitySourceById(env.APP_DB, sourceId)
 		if (!source?.repo_id) return fallbackDefaultBranchName
 		const head = await resolveArtifactSourceHead(env, source.repo_id)
 		const branch = head.branch?.trim()
 		return branch || fallbackDefaultBranchName
 	} catch {
 		return fallbackDefaultBranchName
+	}
+}
+
+async function resolveListingDefaultTreeRef(env: Env, listingId: string) {
+	try {
+		const listing = await getCommunityListingById(env.APP_DB, {
+			listingId,
+			includeDelisted: false,
+		})
+		return resolveSourceDefaultTreeRef(env, listing?.sourceId ?? null)
+	} catch {
+		return fallbackDefaultBranchName
+	}
+}
+
+export function treeHrefFromPackageHome(
+	packageHref: string,
+	input: { ref?: string; relativePath?: string },
+) {
+	const match = communityPackageMatcher.match(
+		new URL(packageHref, 'http://localhost'),
+	)
+	if (!match) return packageHref
+	return getPackageTreeHref({
+		username: match.params.username,
+		kodyId: match.params.kodyId,
+		ref: input.ref,
+		relativePath: input.relativePath,
+	})
+}
+
+async function resolveOwnerPackageFilesTarget(input: {
+	env: Env
+	request: Request
+	username: string
+	kodyId: string
+	selectedPath: string
+	ref: string | undefined
+	pathname: string
+}): Promise<CommunityFilesRouteTarget | null> {
+	const page = await loadPackagePage({
+		env: input.env,
+		request: input.request,
+		username: input.username,
+		kodyId: input.kodyId,
+	})
+	if (page.kind === 'not_found') return null
+	if (page.kind === 'unauthorized') return { kind: 'unauthorized' }
+	const requestedRef = requestedTreeRef(input.ref)
+	if (page.kind === 'redirect') {
+		const ref = isPublicTreeDefaultRefAlias(requestedRef)
+			? fallbackDefaultBranchName
+			: requestedRef
+		return {
+			kind: 'redirect',
+			to: treeHrefFromPackageHome(page.to, {
+				ref,
+				relativePath: input.selectedPath,
+			}),
+		}
+	}
+	const listingSourceId = page.listing?.listing
+		? (
+				await getCommunityListingById(input.env.APP_DB, {
+					listingId: page.listing.listing.id,
+					includeDelisted: false,
+				})
+			)?.sourceId
+		: null
+	const ref = isPublicTreeDefaultRefAlias(requestedRef)
+		? await resolveSourceDefaultTreeRef(
+				input.env,
+				page.ownerPackage?.sourceId ?? listingSourceId ?? null,
+			)
+		: requestedRef
+	const canonicalPath = getPackageTreeHref({
+		username: page.username,
+		kodyId: page.kodyId,
+		listingId: page.listing?.listing?.id ?? null,
+		relativePath: input.selectedPath,
+		ref,
+	})
+	if (canonicalPath !== input.pathname) {
+		return { kind: 'redirect', to: canonicalPath }
+	}
+	return {
+		kind: 'package',
+		username: page.username,
+		kodyId: page.kodyId,
+		selectedPath: input.selectedPath,
+		ref,
 	}
 }
 
@@ -132,6 +229,7 @@ async function canonicalPublicTreeRef(input: {
 export async function resolveCommunityFilesRoute(input: {
 	env: Env
 	url: URL
+	request?: Request
 }): Promise<CommunityFilesRouteTarget | null> {
 	const detailMatch = communityDetailFilesMatcher.match(input.url)
 	if (detailMatch) {
@@ -164,22 +262,33 @@ export async function resolveCommunityFilesRoute(input: {
 			username: leftoverFilesMatch.params.username,
 			kodyId: leftoverFilesMatch.params.kodyId,
 		})
-		if (!target) return null
-		const ref = await canonicalPublicTreeRef({
-			env: input.env,
-			listingId: target.listingId,
-			ref: input.url.searchParams.get('ref') ?? '',
-		})
-		return {
-			kind: 'redirect',
-			to: getCommunityPackageFilesHref({
+		if (target) {
+			const ref = await canonicalPublicTreeRef({
+				env: input.env,
 				listingId: target.listingId,
-				ownerUsername: target.username,
-				kodyId: target.kodyId,
-				relativePath: selectedPath,
-				ref,
-			}),
+				ref: input.url.searchParams.get('ref') ?? '',
+			})
+			return {
+				kind: 'redirect',
+				to: getCommunityPackageFilesHref({
+					listingId: target.listingId,
+					ownerUsername: target.username,
+					kodyId: target.kodyId,
+					relativePath: selectedPath,
+					ref,
+				}),
+			}
 		}
+		if (!input.request) return null
+		return resolveOwnerPackageFilesTarget({
+			env: input.env,
+			request: input.request,
+			username: leftoverFilesMatch.params.username,
+			kodyId: leftoverFilesMatch.params.kodyId,
+			selectedPath,
+			ref: input.url.searchParams.get('ref') ?? '',
+			pathname: input.url.pathname,
+		})
 	}
 
 	const treeMatch = communityPackageTreeMatcher.match(input.url)
@@ -193,31 +302,43 @@ export async function resolveCommunityFilesRoute(input: {
 		username: treeMatch.params.username,
 		kodyId: treeMatch.params.kodyId,
 	})
-	if (!target) return null
-	const ref = await canonicalPublicTreeRef({
-		env: input.env,
-		listingId: target.listingId,
-		ref: treeMatch.params.ref,
-	})
-	const canonicalPath = getCommunityPackageFilesHref({
-		listingId: target.listingId,
-		ownerUsername: target.username,
-		kodyId: target.kodyId,
-		relativePath: selectedPath,
-		ref,
-	})
-	if (target.kind === 'redirect' || canonicalPath !== input.url.pathname) {
+	if (target) {
+		const ref = await canonicalPublicTreeRef({
+			env: input.env,
+			listingId: target.listingId,
+			ref: treeMatch.params.ref,
+		})
+		const canonicalPath = getCommunityPackageFilesHref({
+			listingId: target.listingId,
+			ownerUsername: target.username,
+			kodyId: target.kodyId,
+			relativePath: selectedPath,
+			ref,
+		})
+		if (target.kind === 'redirect' || canonicalPath !== input.url.pathname) {
+			return {
+				kind: 'redirect',
+				to: canonicalPath,
+			}
+		}
 		return {
-			kind: 'redirect',
-			to: canonicalPath,
+			kind: 'listing',
+			listingId: target.listingId,
+			selectedPath,
+			ref,
 		}
 	}
-	return {
-		kind: 'listing',
-		listingId: target.listingId,
+
+	if (!input.request) return null
+	return resolveOwnerPackageFilesTarget({
+		env: input.env,
+		request: input.request,
+		username: treeMatch.params.username,
+		kodyId: treeMatch.params.kodyId,
 		selectedPath,
-		ref,
-	}
+		ref: treeMatch.params.ref,
+		pathname: input.url.pathname,
+	})
 }
 
 export async function resolveCanonicalFilesPath(input: {

--- a/packages/worker/src/app/community-package-route.ts
+++ b/packages/worker/src/app/community-package-route.ts
@@ -99,9 +99,16 @@ export type CommunityFilesRouteTarget =
 			selectedPath: string
 			ref: string
 	  }
-	| { kind: 'redirect'; to: string }
+	| { kind: 'redirect'; to: string; shared: boolean }
 	| { kind: 'unauthorized' }
 	| { kind: 'invalid-path' }
+
+function filesPathRedirect(
+	to: string,
+	shared: boolean,
+): CommunityFilesRouteTarget {
+	return { kind: 'redirect', to, shared }
+}
 
 function selectedPathFromParams(relativePath: string | undefined) {
 	return normalizePackageFilesPath(relativePath ?? '')
@@ -174,13 +181,13 @@ async function resolveOwnerPackageFilesTarget(input: {
 		const ref = isPublicTreeDefaultRefAlias(requestedRef)
 			? fallbackDefaultBranchName
 			: requestedRef
-		return {
-			kind: 'redirect',
-			to: treeHrefFromPackageHome(page.to, {
+		return filesPathRedirect(
+			treeHrefFromPackageHome(page.to, {
 				ref,
 				relativePath: input.selectedPath,
 			}),
-		}
+			page.shared,
+		)
 	}
 	const listingSourceId = page.listing?.listing
 		? (
@@ -204,7 +211,9 @@ async function resolveOwnerPackageFilesTarget(input: {
 		ref,
 	})
 	if (canonicalPath !== input.pathname) {
-		return { kind: 'redirect', to: canonicalPath }
+		// Leftover `/files` and default-ref aliases for a listed pair may be
+		// cached. Unlisted owner hops must not leak the current tree URL.
+		return filesPathRedirect(canonicalPath, Boolean(page.listing?.listing))
 	}
 	return {
 		kind: 'package',
@@ -268,16 +277,16 @@ export async function resolveCommunityFilesRoute(input: {
 				listingId: target.listingId,
 				ref: input.url.searchParams.get('ref') ?? '',
 			})
-			return {
-				kind: 'redirect',
-				to: getCommunityPackageFilesHref({
+			return filesPathRedirect(
+				getCommunityPackageFilesHref({
 					listingId: target.listingId,
 					ownerUsername: target.username,
 					kodyId: target.kodyId,
 					relativePath: selectedPath,
 					ref,
 				}),
-			}
+				true,
+			)
 		}
 		if (!input.request) return null
 		return resolveOwnerPackageFilesTarget({
@@ -316,10 +325,7 @@ export async function resolveCommunityFilesRoute(input: {
 			ref,
 		})
 		if (target.kind === 'redirect' || canonicalPath !== input.url.pathname) {
-			return {
-				kind: 'redirect',
-				to: canonicalPath,
-			}
+			return filesPathRedirect(canonicalPath, true)
 		}
 		return {
 			kind: 'listing',

--- a/packages/worker/src/app/community-package-route.ts
+++ b/packages/worker/src/app/community-package-route.ts
@@ -211,9 +211,10 @@ async function resolveOwnerPackageFilesTarget(input: {
 		ref,
 	})
 	if (canonicalPath !== input.pathname) {
-		// Leftover `/files` and default-ref aliases for a listed pair may be
-		// cached. Unlisted owner hops must not leak the current tree URL.
-		return filesPathRedirect(canonicalPath, Boolean(page.listing?.listing))
+		// This URL did not resolve as a public listing, so leftover `/files`
+		// and default-ref hops stay owner-private even when a listing exists
+		// under a different unpublished pair.
+		return filesPathRedirect(canonicalPath, false)
 	}
 	return {
 		kind: 'package',

--- a/packages/worker/src/app/frames/community-detail.ts
+++ b/packages/worker/src/app/frames/community-detail.ts
@@ -1,13 +1,42 @@
 import { loadCommunityDetailData } from '#app/community-data.ts'
 import { resolveCommunityListingRoute } from '#app/community-package-route.ts'
+import { loadPackagePage } from '#app/package-page.ts'
 import { renderCommunityDetailContentHtml } from '#app/community-detail-content.tsx'
 import { COMMUNITY_DETAIL_TARGET } from '#universal/community-frame-constants.ts'
 import { registerFrame } from '#app/frame-registry.ts'
 import { routes } from '#universal/routes.ts'
+import { createMatcher } from 'remix/route-pattern/match'
+
+const communityPackageMatcher = createMatcher(routes.communityPackage.pattern)
 
 registerFrame(COMMUNITY_DETAIL_TARGET, {
 	routes: [routes.communityPackage, routes.communityDetail],
 	render: async ({ request, env, url }) => {
+		const packageParams = communityPackageMatcher.match(url)?.params
+		if (packageParams) {
+			const page = await loadPackagePage({
+				env,
+				request,
+				username: packageParams.username,
+				kodyId: packageParams.kodyId,
+			})
+			if (page.kind !== 'page') return ''
+			return renderCommunityDetailContentHtml({
+				listing: page.listing?.listing ?? null,
+				username: page.username,
+				kodyId: page.kodyId,
+				description:
+					page.listing?.listing?.description ??
+					page.ownerPackage?.description ??
+					'',
+				isPrivate: page.ownerPackage?.isPrivate ?? false,
+				ownerProfilePublic: page.listing?.ownerProfilePublic ?? true,
+				loggedIn: page.loggedIn,
+				viewerIsOwner: page.viewerIsOwner,
+				returnTo: url.pathname,
+			})
+		}
+
 		const target = await resolveCommunityListingRoute({ env, url })
 		// A frame never redirects: the page handler owns the visitor's URL, and
 		// this content is only ever fetched for a URL it already resolved.
@@ -20,6 +49,10 @@ registerFrame(COMMUNITY_DETAIL_TARGET, {
 		}
 		return renderCommunityDetailContentHtml({
 			listing: detail.listing,
+			username: detail.listing?.ownerUsername ?? '',
+			kodyId: detail.listing?.kodyId ?? '',
+			description: detail.listing?.description ?? '',
+			isPrivate: false,
 			ownerProfilePublic: detail.ownerProfilePublic,
 			loggedIn: detail.loggedIn,
 			viewerIsOwner: detail.viewerIsOwner,

--- a/packages/worker/src/app/handlers/community-detail.frame.node.test.ts
+++ b/packages/worker/src/app/handlers/community-detail.frame.node.test.ts
@@ -123,8 +123,7 @@ test('community detail handler returns bare detail frame HTML for target header'
 	expect(publicHtml).toContain('data-testid="community-detail-frame"')
 	expect(publicHtml).toContain('data-testid="community-listing-icon-detail"')
 	expect(publicHtml).toContain('/community/listing-1/icon/abc1234567890')
-	expect(publicHtml).toContain('data-testid="community-detail-owner-line"')
-	expect(publicHtml).toContain('>by</')
+	expect(publicHtml).toContain('data-testid="package-repo-chrome"')
 	expect(publicHtml).toContain('href="/@kentcdodds"')
 	expect(publicHtml).toContain('>@kentcdodds</a>')
 	expect(publicHtml).not.toContain(
@@ -147,10 +146,8 @@ test('community detail handler returns bare detail frame HTML for target header'
 		url: new URL('https://example.com/community/listing-1'),
 	} as never)
 	const privateHtml = await privateResponse.text()
-	expect(privateHtml).toContain('>by</')
 	expect(privateHtml).toContain('@kentcdodds')
 	expect(privateHtml).toContain('data-testid="community-detail-owner-private"')
-	expect(privateHtml).toContain('title="This profile is private"')
 	expect(privateHtml).not.toContain('href="/@kentcdodds"')
 
 	mockModule.getUserSocialRowByUsername.mockResolvedValue({
@@ -178,19 +175,14 @@ test('community detail handler returns bare detail frame HTML for target header'
 		url: new URL('https://example.com/community/listing-1'),
 	} as never)
 	const signedInHtml = await signedInResponse.text()
-	expect(signedInHtml).toMatch(
-		/<div[^>]*data-testid="community-detail-owner-line"/,
-	)
-	expect(signedInHtml).not.toMatch(
-		/<p[^>]*data-testid="community-detail-owner-line"/,
-	)
+	expect(signedInHtml).toContain('data-testid="package-repo-chrome"')
 	expect(signedInHtml).toContain(
 		'data-testid="community-detail-viewer-install-badge"',
 	)
 	expect(signedInHtml).toContain('Installed')
 	expect(
 		signedInHtml.indexOf('data-testid="community-detail-viewer-install-badge"'),
-	).toBeGreaterThan(signedInHtml.indexOf('</h1>'))
+	).toBeGreaterThan(signedInHtml.indexOf('data-testid="package-repo-nav"'))
 })
 
 test('community detail browse-files uses the looked-up default branch', async () => {

--- a/packages/worker/src/app/handlers/community-detail.tsx
+++ b/packages/worker/src/app/handlers/community-detail.tsx
@@ -4,6 +4,7 @@ import { type Action } from 'remix/router'
 import { toPublicCommunityListing } from '#app/community-public.ts'
 import { loadCommunityDetailData } from '#app/community-data.ts'
 import { loadPackagePage } from '#app/package-page.ts'
+import { loadOwnerPackageReadme } from '#app/package-files-data.ts'
 import { resolveCanonicalListingPath } from '#app/community-package-route.ts'
 import { REMIX_FRAME_TARGET_HEADER } from '#universal/frame-constants.ts'
 import { handleFrameRequest } from '#app/frame-registry.ts'
@@ -111,6 +112,9 @@ async function renderCommunityListingPage(input: {
 				viewerInstall: detail.viewerInstall,
 				ownerPackage: detail.ownerPackage,
 				username: detail.username,
+				kodyId: detail.listing.kodyId,
+				viewerIsOwner: detail.viewerIsOwner,
+				isPrivate: false,
 				invocationUrlOrigin: detail.invocationUrlOrigin,
 			},
 		},
@@ -144,6 +148,38 @@ async function highlightReadmeFences(
 ): Promise<Array<HighlightedCode>> {
 	if (!readmeContent) return []
 	return highlightMarkdownFences(env, readmeContent, { serverTiming })
+}
+
+async function readmeForPackagePage(
+	input: {
+		env: Env
+		request: Request
+		listingReadme: string | null | undefined
+		ownerSourceId: string | null | undefined
+		viewerIsOwner: boolean
+	},
+	serverTiming?: Array<ServerTimingEntry>,
+) {
+	let readmeContent = input.listingReadme ?? null
+	if (!readmeContent && input.viewerIsOwner && input.ownerSourceId) {
+		const user = await readAuthenticatedAppUser(input.request, input.env)
+		if (user) {
+			readmeContent = await loadOwnerPackageReadme({
+				env: input.env,
+				request: input.request,
+				userId: user.mcpUser.userId,
+				sourceId: input.ownerSourceId,
+			})
+		}
+	}
+	return {
+		readmeContent,
+		readmeFences: await highlightReadmeFences(
+			input.env,
+			readmeContent,
+			serverTiming,
+		),
+	}
 }
 
 /**
@@ -212,9 +248,14 @@ export function createCommunityPackageHandler(env: Env) {
 
 			if (page.listing?.listing) {
 				const serverTiming: Array<ServerTimingEntry> = []
-				const readmeFences = await highlightReadmeFences(
-					env,
-					page.listing.listing.readmeContent,
+				const readme = await readmeForPackagePage(
+					{
+						env,
+						request,
+						listingReadme: page.listing.listing.readmeContent,
+						ownerSourceId: page.ownerPackage?.sourceId,
+						viewerIsOwner: page.viewerIsOwner,
+					},
 					serverTiming,
 				)
 				return renderAppPage({
@@ -232,11 +273,14 @@ export function createCommunityPackageHandler(env: Env) {
 							viewerIsAdmin: page.listing.viewerIsAdmin,
 							trusted: page.listing.listing.trusted,
 							featured: page.listing.listing.featured,
-							readmeContent: page.listing.listing.readmeContent,
-							readmeFences,
+							readmeContent: readme.readmeContent,
+							readmeFences: readme.readmeFences,
 							viewerInstall: page.listing.viewerInstall,
 							ownerPackage: page.ownerPackage,
 							username: page.username,
+							kodyId: page.kodyId,
+							viewerIsOwner: page.viewerIsOwner,
+							isPrivate: page.ownerPackage?.isPrivate ?? false,
 							invocationUrlOrigin: page.invocationUrlOrigin,
 						},
 					},
@@ -247,10 +291,22 @@ export function createCommunityPackageHandler(env: Env) {
 				return renderPackageNotFoundPage({ request, env })
 			}
 
+			const serverTiming: Array<ServerTimingEntry> = []
+			const readme = await readmeForPackagePage(
+				{
+					env,
+					request,
+					listingReadme: null,
+					ownerSourceId: page.ownerPackage.sourceId,
+					viewerIsOwner: page.viewerIsOwner,
+				},
+				serverTiming,
+			)
 			return renderAppPage({
 				request,
 				env,
 				title: page.ownerPackage.name,
+				serverTiming,
 				loaderData: {
 					communityDetailShell: {
 						ok: true,
@@ -262,10 +318,14 @@ export function createCommunityPackageHandler(env: Env) {
 						viewerIsAdmin: false,
 						trusted: false,
 						featured: false,
-						readmeContent: null,
+						readmeContent: readme.readmeContent,
+						readmeFences: readme.readmeFences,
 						viewerInstall: null,
 						ownerPackage: page.ownerPackage,
 						username: page.username,
+						kodyId: page.kodyId,
+						viewerIsOwner: page.viewerIsOwner,
+						isPrivate: page.ownerPackage.isPrivate,
 						invocationUrlOrigin: page.invocationUrlOrigin,
 					},
 				},
@@ -293,6 +353,9 @@ export function createCommunityDetailApiHandler(env: Env) {
 				request,
 				{
 					...detail,
+					readmeContent: detail.listing.readmeContent,
+					kodyId: detail.listing.kodyId,
+					isPrivate: false,
 					readmeFences: await highlightReadmeFences(
 						env,
 						detail.listing.readmeContent,
@@ -339,13 +402,16 @@ export function createCommunityPackageApiHandler(env: Env) {
 			}
 
 			const serverTiming: Array<ServerTimingEntry> = []
-			const readmeFences = page.listing?.listing?.readmeContent
-				? await highlightReadmeFences(
-						env,
-						page.listing.listing.readmeContent,
-						serverTiming,
-					)
-				: []
+			const readme = await readmeForPackagePage(
+				{
+					env,
+					request,
+					listingReadme: page.listing?.listing?.readmeContent,
+					ownerSourceId: page.ownerPackage?.sourceId,
+					viewerIsOwner: page.viewerIsOwner,
+				},
+				serverTiming,
+			)
 			return jsonResponse(
 				request,
 				{
@@ -357,9 +423,12 @@ export function createCommunityPackageApiHandler(env: Env) {
 					viewerIsAdmin: page.listing?.viewerIsAdmin ?? false,
 					forkPrompt: page.listing?.forkPrompt ?? '',
 					viewerInstall: page.listing?.viewerInstall ?? null,
-					readmeFences,
+					readmeContent: readme.readmeContent,
+					readmeFences: readme.readmeFences,
 					ownerPackage: page.ownerPackage,
 					username: page.username,
+					kodyId: page.kodyId,
+					isPrivate: page.ownerPackage?.isPrivate ?? false,
 					invocationUrlOrigin: page.invocationUrlOrigin,
 				},
 				200,
@@ -367,6 +436,63 @@ export function createCommunityPackageApiHandler(env: Env) {
 			)
 		},
 	} satisfies Action<typeof routes.communityPackageApi>
+}
+
+export function createCommunityPackageSettingsHandler(env: Env) {
+	return {
+		middleware: [],
+		async handler({ request, params }) {
+			const page = await loadPackagePage({
+				env,
+				request,
+				username: params.username,
+				kodyId: params.kodyId,
+			})
+			if (page.kind === 'redirect') {
+				return redirectToCanonicalPath({
+					path: `${page.to}/settings`,
+					url: new URL(request.url),
+					cache: page.shared ? 'public' : 'private',
+				})
+			}
+			if (page.kind === 'not_found') {
+				return renderPackageNotFoundPage({ request, env })
+			}
+			if (page.kind === 'unauthorized') {
+				return renderPackageUnauthorizedPage({ request, env })
+			}
+			if (!page.viewerIsOwner || !page.ownerPackage) {
+				return renderPackageNotFoundPage({ request, env })
+			}
+
+			return renderAppPage({
+				request,
+				env,
+				title: `${page.ownerPackage.name} settings`,
+				loaderData: {
+					communityDetailShell: {
+						ok: true,
+						listingId: page.listing?.listing?.id ?? null,
+						name: page.ownerPackage.name,
+						description: page.ownerPackage.description,
+						forkPrompt: '',
+						loggedIn: page.loggedIn,
+						viewerIsAdmin: false,
+						trusted: false,
+						featured: false,
+						readmeContent: null,
+						viewerInstall: null,
+						ownerPackage: page.ownerPackage,
+						username: page.username,
+						kodyId: page.kodyId,
+						viewerIsOwner: true,
+						isPrivate: page.ownerPackage.isPrivate,
+						invocationUrlOrigin: page.invocationUrlOrigin,
+					},
+				},
+			})
+		},
+	} satisfies Action<typeof routes.communityPackageSettings>
 }
 
 /**

--- a/packages/worker/src/app/handlers/community-package-settings.node.test.ts
+++ b/packages/worker/src/app/handlers/community-package-settings.node.test.ts
@@ -1,0 +1,92 @@
+import { expect, test, vi } from 'vitest'
+
+const mockModule = vi.hoisted(() => ({
+	loadPackagePage: vi.fn<() => Promise<unknown>>(),
+	renderAppPage: vi.fn<(input: unknown) => Promise<Response>>(
+		async (input) =>
+			new Response('ok', {
+				status: (input as { status?: number }).status ?? 200,
+			}),
+	),
+}))
+
+vi.mock('#app/package-page.ts', () => ({
+	loadPackagePage: (...args: Array<unknown>) =>
+		mockModule.loadPackagePage(...args),
+}))
+
+vi.mock('#app/ssr-render.tsx', () => ({
+	renderAppPage: (...args: Array<unknown>) => mockModule.renderAppPage(...args),
+}))
+
+vi.mock('#app/frame-registrations.ts', () => ({}))
+vi.mock('#app/frame-registry.ts', () => ({
+	handleFrameRequest: async () => null,
+}))
+
+const { createCommunityPackageSettingsHandler } =
+	await import('./community-detail.tsx')
+
+test('package settings 404 unless the viewer owns the package', async () => {
+	const handler = createCommunityPackageSettingsHandler({} as Env)
+	mockModule.loadPackagePage.mockResolvedValue({
+		kind: 'page',
+		username: 'kentcdodds',
+		kodyId: 'friction-log',
+		listing: null,
+		ownerPackage: { id: 'pkg-1', name: 'friction-log', isPrivate: true },
+		viewerIsOwner: false,
+		loggedIn: true,
+		invocationUrlOrigin: 'https://example.com',
+	})
+
+	const stranger = await handler.handler({
+		request: new Request(
+			'https://example.com/@kentcdodds/friction-log/settings',
+		),
+		params: { username: 'kentcdodds', kodyId: 'friction-log' },
+		url: new URL('https://example.com/@kentcdodds/friction-log/settings'),
+	} as never)
+	expect(mockModule.renderAppPage).toHaveBeenCalledWith(
+		expect.objectContaining({ notFound: true, status: 404 }),
+	)
+	expect(stranger.status).toBe(404)
+
+	mockModule.renderAppPage.mockClear()
+	mockModule.loadPackagePage.mockResolvedValue({
+		kind: 'page',
+		username: 'kentcdodds',
+		kodyId: 'friction-log',
+		listing: null,
+		ownerPackage: {
+			id: 'pkg-1',
+			name: 'friction-log',
+			description: '',
+			isPrivate: true,
+			kodyId: 'friction-log',
+		},
+		viewerIsOwner: true,
+		loggedIn: true,
+		invocationUrlOrigin: 'https://example.com',
+	})
+	const owner = await handler.handler({
+		request: new Request(
+			'https://example.com/@kentcdodds/friction-log/settings',
+		),
+		params: { username: 'kentcdodds', kodyId: 'friction-log' },
+		url: new URL('https://example.com/@kentcdodds/friction-log/settings'),
+	} as never)
+	expect(owner.status).toBe(200)
+	expect(mockModule.renderAppPage).toHaveBeenCalledWith(
+		expect.objectContaining({
+			title: 'friction-log settings',
+			loaderData: expect.objectContaining({
+				communityDetailShell: expect.objectContaining({
+					kodyId: 'friction-log',
+					viewerIsOwner: true,
+					isPrivate: true,
+				}),
+			}),
+		}),
+	)
+})

--- a/packages/worker/src/app/handlers/package-files.node.test.ts
+++ b/packages/worker/src/app/handlers/package-files.node.test.ts
@@ -8,6 +8,7 @@ const mockModule = vi.hoisted(() => ({
 	loadAccessiblePackageFilesData: vi.fn<() => Promise<unknown>>(),
 	loadPackagePage: vi.fn<() => Promise<unknown>>(),
 	getSavedPackageById: vi.fn<() => Promise<unknown>>(),
+	resolveCommunityFilesRoute: vi.fn<() => Promise<unknown>>(),
 	renderAppPage: vi.fn<(input: unknown) => Promise<Response>>(
 		async () => new Response('ok'),
 	),
@@ -26,6 +27,22 @@ vi.mock('#app/page-auth.ts', () => ({
 vi.mock('#app/package-page.ts', () => ({
 	loadPackagePage: (...args: Array<unknown>) =>
 		mockModule.loadPackagePage(...args),
+}))
+
+vi.mock('#app/community-package-route.ts', () => ({
+	resolveCommunityFilesRoute: (...args: Array<unknown>) =>
+		mockModule.resolveCommunityFilesRoute(...args),
+	resolveCanonicalFilesPath: async () => null,
+	treeHrefFromPackageHome: (
+		packageHref: string,
+		input: { ref?: string; relativePath?: string },
+	) => {
+		const ref = input.ref?.trim() || 'main'
+		const relativePath = input.relativePath?.trim()
+		return relativePath
+			? `${packageHref}/tree/${ref}/${relativePath}`
+			: `${packageHref}/tree/${ref}`
+	},
 }))
 
 vi.mock('#worker/package-registry/repo.ts', () => ({
@@ -57,6 +74,7 @@ const {
 	createAccountPackageFilesApiHandler,
 	createAccountPackageFilesHandler,
 	createCommunityPackageFilesApiHandler,
+	createCommunityPackageFilesHandler,
 } = await import('./package-files.ts')
 
 const filesPayload = {
@@ -182,4 +200,36 @@ test('account files HTML and JSON redirect to the package tree', async () => {
 	expect(html.headers.get('location')).toBe(
 		'https://example.com/@owner/demo/tree/main',
 	)
+})
+
+test('unlisted leftover tree redirects stay private; listed leftovers stay public', async () => {
+	const handler = createCommunityPackageFilesHandler({} as Env)
+
+	mockModule.resolveCommunityFilesRoute.mockResolvedValue({
+		kind: 'redirect',
+		to: '/@owner/friction-log/tree/main',
+		shared: false,
+	})
+	const privateHop = await handler.handler({
+		request: new Request('https://example.com/@owner/friction-log/files'),
+	} as never)
+	expect(privateHop.status).toBe(302)
+	expect(privateHop.headers.get('location')).toBe(
+		'https://example.com/@owner/friction-log/tree/main',
+	)
+	expect(privateHop.headers.get('cache-control')).toBe('private, no-store')
+
+	mockModule.resolveCommunityFilesRoute.mockResolvedValue({
+		kind: 'redirect',
+		to: '/@owner/sentry/tree/main',
+		shared: true,
+	})
+	const publicHop = await handler.handler({
+		request: new Request('https://example.com/@owner/sentry/files'),
+	} as never)
+	expect(publicHop.status).toBe(301)
+	expect(publicHop.headers.get('location')).toBe(
+		'https://example.com/@owner/sentry/tree/main',
+	)
+	expect(publicHop.headers.get('cache-control')).toBe('public, max-age=3600')
 })

--- a/packages/worker/src/app/handlers/package-files.node.test.ts
+++ b/packages/worker/src/app/handlers/package-files.node.test.ts
@@ -5,7 +5,9 @@ const mockModule = vi.hoisted(() => ({
 	requireAuthenticatedPageUser: vi.fn<() => Promise<unknown>>(),
 	loadCommunityPackageFilesData: vi.fn<() => Promise<unknown>>(),
 	loadAccountPackageFilesData: vi.fn<() => Promise<unknown>>(),
-	resolveCommunityPackageUrl: vi.fn<() => Promise<unknown>>(),
+	loadAccessiblePackageFilesData: vi.fn<() => Promise<unknown>>(),
+	loadPackagePage: vi.fn<() => Promise<unknown>>(),
+	getSavedPackageById: vi.fn<() => Promise<unknown>>(),
 	renderAppPage: vi.fn<(input: unknown) => Promise<Response>>(
 		async () => new Response('ok'),
 	),
@@ -21,11 +23,23 @@ vi.mock('#app/page-auth.ts', () => ({
 		mockModule.requireAuthenticatedPageUser(...args),
 }))
 
+vi.mock('#app/package-page.ts', () => ({
+	loadPackagePage: (...args: Array<unknown>) =>
+		mockModule.loadPackagePage(...args),
+}))
+
+vi.mock('#worker/package-registry/repo.ts', () => ({
+	getSavedPackageById: (...args: Array<unknown>) =>
+		mockModule.getSavedPackageById(...args),
+}))
+
 vi.mock('#app/package-files-data.ts', () => ({
 	loadCommunityPackageFilesData: (...args: Array<unknown>) =>
 		mockModule.loadCommunityPackageFilesData(...args),
 	loadAccountPackageFilesData: (...args: Array<unknown>) =>
 		mockModule.loadAccountPackageFilesData(...args),
+	loadAccessiblePackageFilesData: (...args: Array<unknown>) =>
+		mockModule.loadAccessiblePackageFilesData(...args),
 	readPackageFilesSelectedPath: (requestUrl: string) => {
 		const url = new URL(requestUrl, 'http://localhost')
 		const raw = url.searchParams.get('path')
@@ -35,17 +49,13 @@ vi.mock('#app/package-files-data.ts', () => ({
 	},
 }))
 
-vi.mock('#worker/community/package-url.ts', () => ({
-	resolveCommunityPackageUrl: (...args: Array<unknown>) =>
-		mockModule.resolveCommunityPackageUrl(...args),
-}))
-
 vi.mock('#app/ssr-render.tsx', () => ({
 	renderAppPage: (...args: Array<unknown>) => mockModule.renderAppPage(...args),
 }))
 
 const {
 	createAccountPackageFilesApiHandler,
+	createAccountPackageFilesHandler,
 	createCommunityPackageFilesApiHandler,
 } = await import('./package-files.ts')
 
@@ -53,8 +63,8 @@ const filesPayload = {
 	ok: true,
 	title: '@owner/demo',
 	backHref: '/@owner/demo',
-	backLabel: 'Package listing',
-	filesBasePath: '/@owner/demo/files',
+	backLabel: 'Code',
+	filesBasePath: '/@owner/demo/tree/main',
 	selectedPath: 'src/index.ts',
 	kind: 'file',
 	paths: ['src/index.ts'],
@@ -65,15 +75,16 @@ const filesPayload = {
 	language: 'ts',
 }
 
-test('community files API resolves the listing, rejects traversal, and 404s misses', async () => {
+test('community files API resolves the package page and rejects traversal', async () => {
 	const handler = createCommunityPackageFilesApiHandler({} as Env)
-	mockModule.resolveCommunityPackageUrl.mockResolvedValue({
-		kind: 'listing',
-		listingId: 'listing-1',
+	mockModule.loadPackagePage.mockResolvedValue({
+		kind: 'page',
 		username: 'owner',
 		kodyId: 'demo',
+		listing: { listing: { id: 'listing-1' } },
+		viewerIsOwner: false,
 	})
-	mockModule.loadCommunityPackageFilesData.mockResolvedValue(filesPayload)
+	mockModule.loadAccessiblePackageFilesData.mockResolvedValue(filesPayload)
 
 	const success = await handler.handler({
 		request: new Request(
@@ -86,11 +97,13 @@ test('community files API resolves the listing, rejects traversal, and 404s miss
 	} as never)
 	expect(success.status).toBe(200)
 	expect(await success.json()).toEqual(filesPayload)
-	expect(mockModule.loadCommunityPackageFilesData).toHaveBeenCalledWith({
+	expect(mockModule.loadAccessiblePackageFilesData).toHaveBeenCalledWith({
 		env: {},
-		listingId: 'listing-1',
+		request: expect.any(Request),
+		username: 'owner',
+		kodyId: 'demo',
 		selectedPath: 'src/index.ts',
-		ref: 'HEAD',
+		ref: '',
 		serverTiming: expect.any(Array),
 	})
 
@@ -105,7 +118,7 @@ test('community files API resolves the listing, rejects traversal, and 404s miss
 	} as never)
 	expect(invalid.status).toBe(400)
 
-	mockModule.loadCommunityPackageFilesData.mockResolvedValue(null)
+	mockModule.loadAccessiblePackageFilesData.mockResolvedValue(null)
 	const missing = await handler.handler({
 		request: new Request(
 			'https://example.com/profiles/owner/packages/demo/files.json',
@@ -116,10 +129,12 @@ test('community files API resolves the listing, rejects traversal, and 404s miss
 	expect(missing.status).toBe(404)
 })
 
-test('account files API requires the owner session and does not leak other users', async () => {
-	const handler = createAccountPackageFilesApiHandler({} as Env)
+test('account files HTML and JSON redirect to the package tree', async () => {
+	const htmlHandler = createAccountPackageFilesHandler({} as Env)
+	const apiHandler = createAccountPackageFilesApiHandler({} as Env)
+
 	mockModule.readAuthenticatedAppUser.mockResolvedValue(null)
-	const unauthorized = await handler.handler({
+	const unauthorized = await apiHandler.handler({
 		request: new Request(
 			'https://example.com/account/packages/pkg-1/files.json',
 		),
@@ -127,14 +142,21 @@ test('account files API requires the owner session and does not leak other users
 		url: new URL('https://example.com/account/packages/pkg-1/files.json'),
 	} as never)
 	expect(unauthorized.status).toBe(401)
-	expect(mockModule.loadAccountPackageFilesData).not.toHaveBeenCalled()
+	expect(mockModule.getSavedPackageById).not.toHaveBeenCalled()
 
 	mockModule.readAuthenticatedAppUser.mockResolvedValue({
 		mcpUser: { userId: 'stable-user-1' },
 		username: 'owner',
 	})
-	mockModule.loadAccountPackageFilesData.mockResolvedValue(filesPayload)
-	const success = await handler.handler({
+	mockModule.requireAuthenticatedPageUser.mockResolvedValue({
+		mcpUser: { userId: 'stable-user-1' },
+		username: 'owner',
+	})
+	mockModule.getSavedPackageById.mockResolvedValue({
+		kodyId: 'demo',
+	})
+
+	const json = await apiHandler.handler({
 		request: new Request(
 			'https://example.com/account/packages/pkg-1/files.json?path=src/index.ts',
 		),
@@ -143,14 +165,21 @@ test('account files API requires the owner session and does not leak other users
 			'https://example.com/account/packages/pkg-1/files.json?path=src/index.ts',
 		),
 	} as never)
-	expect(success.status).toBe(200)
-	expect(mockModule.loadAccountPackageFilesData).toHaveBeenCalledWith({
-		env: {},
-		request: expect.any(Request),
-		userId: 'stable-user-1',
-		username: 'owner',
-		packageId: 'pkg-1',
-		selectedPath: 'src/index.ts',
-		serverTiming: expect.any(Array),
+	expect(json.status).toBe(404)
+	expect(await json.json()).toEqual({
+		ok: false,
+		error: 'Package files moved.',
+		redirectTo: '/@owner/demo/tree/main/src/index.ts',
 	})
+	expect(mockModule.loadAccountPackageFilesData).not.toHaveBeenCalled()
+
+	const html = await htmlHandler.handler({
+		request: new Request('https://example.com/account/packages/pkg-1/files'),
+		params: { packageId: 'pkg-1' },
+		url: new URL('https://example.com/account/packages/pkg-1/files'),
+	} as never)
+	expect(html.status).toBe(302)
+	expect(html.headers.get('location')).toBe(
+		'https://example.com/@owner/demo/tree/main',
+	)
 })

--- a/packages/worker/src/app/handlers/package-files.ts
+++ b/packages/worker/src/app/handlers/package-files.ts
@@ -1,16 +1,19 @@
-// remix-skill: HTML + JSON /files controllers for community and account
-// snapshots. Pages SSR the explorer; JSON companions use `?path=`.
+// remix-skill: HTML + JSON /files controllers. Pages SSR the explorer;
+// JSON companions use `?path=`. Public and private packages share this
+// path; visibility is enforced by loadPackagePage.
 import { jsonResponse } from '#worker/json-response.ts'
 import { type Action } from 'remix/router'
 import { getOwnerUsernameFromListingName } from '#worker/community/public-urls.ts'
 import { getCommunityListingById } from '#worker/community/repo.ts'
-import { resolveCommunityPackageUrl } from '#worker/community/package-url.ts'
+import { getSavedPackageById } from '#worker/package-registry/repo.ts'
 import {
 	resolveCanonicalFilesPath,
 	resolveCommunityFilesRoute,
+	treeHrefFromPackageHome,
 } from '#app/community-package-route.ts'
+import { loadPackagePage } from '#app/package-page.ts'
 import {
-	loadAccountPackageFilesData,
+	loadAccessiblePackageFilesData,
 	loadCommunityPackageFilesData,
 	readPackageFilesSelectedPath,
 } from '#app/package-files-data.ts'
@@ -18,15 +21,28 @@ import { readAuthenticatedAppUser } from '#app/authenticated-user.ts'
 import { requireAuthenticatedPageUser } from '#app/page-auth.ts'
 import { renderAppPage } from '#app/ssr-render.tsx'
 import {
-	getCommunityPackageFilesHref,
+	getPackageTreeHref,
 	normalizePackageFilesPath,
 } from '#universal/package-files.ts'
 import { type routes } from '#universal/routes.ts'
 import { type ServerTimingEntry } from '#worker/server-timing.ts'
 
-function redirectToCanonicalPath(input: { path: string; url: URL }) {
+function redirectToCanonicalPath(input: {
+	path: string
+	url: URL
+	cache?: 'public' | 'private'
+}) {
 	const destination = new URL(input.path, input.url)
 	destination.search = input.url.search
+	if (input.cache === 'private') {
+		return new Response(null, {
+			status: 302,
+			headers: {
+				location: destination.toString(),
+				'cache-control': 'private, no-store',
+			},
+		})
+	}
 	return new Response(null, {
 		status: 301,
 		headers: {
@@ -36,7 +52,32 @@ function redirectToCanonicalPath(input: { path: string; url: URL }) {
 	})
 }
 
-async function renderCommunityFilesPage(input: {
+function renderFilesNotFound(input: {
+	request: Request
+	env: Env
+	serverTiming?: Array<ServerTimingEntry>
+}) {
+	return renderAppPage({
+		request: input.request,
+		env: input.env,
+		title: 'Package files not found',
+		notFound: true,
+		status: 404,
+		serverTiming: input.serverTiming,
+	})
+}
+
+function renderFilesUnauthorized(input: { request: Request; env: Env }) {
+	return renderAppPage({
+		request: input.request,
+		env: input.env,
+		title: 'Unauthorized',
+		unauthorized: true,
+		status: 401,
+	})
+}
+
+async function renderListingFilesPage(input: {
 	request: Request
 	env: Env
 	listingId: string | null
@@ -54,12 +95,9 @@ async function renderCommunityFilesPage(input: {
 			})
 		: null
 	if (!data) {
-		return renderAppPage({
+		return renderFilesNotFound({
 			request: input.request,
 			env: input.env,
-			title: 'Package files not found',
-			notFound: true,
-			status: 404,
 			serverTiming,
 		})
 	}
@@ -72,29 +110,86 @@ async function renderCommunityFilesPage(input: {
 	})
 }
 
+async function renderPackageFilesPage(input: {
+	request: Request
+	env: Env
+	username: string
+	kodyId: string
+	selectedPath: string
+	ref?: string
+}) {
+	const serverTiming: Array<ServerTimingEntry> = []
+	const data = await loadAccessiblePackageFilesData({
+		env: input.env,
+		request: input.request,
+		username: input.username,
+		kodyId: input.kodyId,
+		selectedPath: input.selectedPath,
+		ref: input.ref,
+		serverTiming,
+	})
+	if (!data) {
+		return renderFilesNotFound({
+			request: input.request,
+			env: input.env,
+			serverTiming,
+		})
+	}
+	return renderAppPage({
+		request: input.request,
+		env: input.env,
+		title: `${data.title} files`,
+		loaderData: { packageFiles: data },
+		serverTiming,
+	})
+}
+
+async function renderResolvedFilesPage(input: {
+	request: Request
+	env: Env
+	url: URL
+}) {
+	const target = await resolveCommunityFilesRoute({
+		env: input.env,
+		url: input.url,
+		request: input.request,
+	})
+	if (target?.kind === 'invalid-path' || !target) {
+		return renderFilesNotFound({ request: input.request, env: input.env })
+	}
+	if (target.kind === 'unauthorized') {
+		return renderFilesUnauthorized({ request: input.request, env: input.env })
+	}
+	if (target.kind === 'redirect') {
+		return redirectToCanonicalPath({ path: target.to, url: input.url })
+	}
+	if (target.kind === 'package') {
+		return renderPackageFilesPage({
+			request: input.request,
+			env: input.env,
+			username: target.username,
+			kodyId: target.kodyId,
+			selectedPath: target.selectedPath,
+			ref: target.ref,
+		})
+	}
+	return renderListingFilesPage({
+		request: input.request,
+		env: input.env,
+		listingId: target.listingId,
+		selectedPath: target.selectedPath,
+		ref: target.ref,
+	})
+}
+
 export function createCommunityPackageFilesHandler(env: Env) {
 	return {
 		middleware: [],
 		async handler({ request }) {
-			const url = new URL(request.url)
-			const target = await resolveCommunityFilesRoute({ env, url })
-			if (target?.kind === 'invalid-path') {
-				return renderCommunityFilesPage({
-					request,
-					env,
-					listingId: null,
-					selectedPath: '',
-				})
-			}
-			if (target?.kind === 'redirect') {
-				return redirectToCanonicalPath({ path: target.to, url })
-			}
-			return renderCommunityFilesPage({
+			return renderResolvedFilesPage({
 				request,
 				env,
-				listingId: target?.listingId ?? null,
-				selectedPath: target?.selectedPath ?? '',
-				ref: target?.kind === 'listing' ? target.ref : undefined,
+				url: new URL(request.url),
 			})
 		},
 	} satisfies Action<typeof routes.communityPackageFiles>
@@ -111,17 +206,29 @@ export function createCommunityDetailFilesHandler(env: Env) {
 		middleware: [],
 		async handler({ request }) {
 			const url = new URL(request.url)
-			const target = await resolveCommunityFilesRoute({ env, url })
+			const target = await resolveCommunityFilesRoute({
+				env,
+				url,
+				request,
+			})
 			if (target?.kind === 'invalid-path' || !target) {
-				return renderCommunityFilesPage({
-					request,
-					env,
-					listingId: null,
-					selectedPath: '',
-				})
+				return renderFilesNotFound({ request, env })
+			}
+			if (target.kind === 'unauthorized') {
+				return renderFilesUnauthorized({ request, env })
 			}
 			if (target.kind === 'redirect') {
 				return redirectToCanonicalPath({ path: target.to, url })
+			}
+			if (target.kind === 'package') {
+				return renderPackageFilesPage({
+					request,
+					env,
+					username: target.username,
+					kodyId: target.kodyId,
+					selectedPath: target.selectedPath,
+					ref: target.ref,
+				})
 			}
 
 			const listing = await getCommunityListingById(env.APP_DB, {
@@ -146,7 +253,7 @@ export function createCommunityDetailFilesHandler(env: Env) {
 				return redirectToCanonicalPath({ path: canonicalPath, url })
 			}
 
-			return renderCommunityFilesPage({
+			return renderListingFilesPage({
 				request,
 				env,
 				listingId: target.listingId,
@@ -169,21 +276,19 @@ export function createCommunityPackageFilesApiHandler(env: Env) {
 					400,
 				)
 			}
-			const treeRef = url.searchParams.get('ref')?.trim() || 'HEAD'
-			const target = await resolveCommunityPackageUrl({
-				db: env.APP_DB,
+			const treeRef = url.searchParams.get('ref')?.trim() || ''
+			const page = await loadPackagePage({
+				env,
+				request,
 				username: params.username,
 				kodyId: params.kodyId,
 			})
-			if (target?.kind === 'redirect') {
+			if (page.kind === 'redirect') {
 				return jsonResponse(
 					{
 						ok: false,
-						error: 'Public package moved.',
-						redirectTo: getCommunityPackageFilesHref({
-							listingId: target.listingId,
-							ownerUsername: target.username,
-							kodyId: target.kodyId,
+						error: 'Package moved.',
+						redirectTo: treeHrefFromPackageHome(page.to, {
 							relativePath: selectedPath,
 							ref: treeRef,
 						}),
@@ -191,19 +296,28 @@ export function createCommunityPackageFilesApiHandler(env: Env) {
 					404,
 				)
 			}
+			if (page.kind === 'unauthorized') {
+				return jsonResponse({ ok: false, error: 'Unauthorized.' }, 401)
+			}
+			if (page.kind !== 'page') {
+				return jsonResponse(
+					{ ok: false, error: 'Package files not found.' },
+					404,
+				)
+			}
 			const serverTiming: Array<ServerTimingEntry> = []
-			const data = target
-				? await loadCommunityPackageFilesData({
-						env,
-						listingId: target.listingId,
-						selectedPath,
-						ref: treeRef,
-						serverTiming,
-					})
-				: null
+			const data = await loadAccessiblePackageFilesData({
+				env,
+				request,
+				username: page.username,
+				kodyId: page.kodyId,
+				selectedPath,
+				ref: treeRef,
+				serverTiming,
+			})
 			if (!data) {
 				return jsonResponse(
-					{ ok: false, error: 'Public package files not found.' },
+					{ ok: false, error: 'Package files not found.' },
 					404,
 				)
 			}
@@ -223,8 +337,7 @@ export function createCommunityDetailFilesApiHandler(env: Env) {
 					400,
 				)
 			}
-			const treeRef =
-				new URL(request.url).searchParams.get('ref')?.trim() || 'HEAD'
+			const treeRef = new URL(request.url).searchParams.get('ref')?.trim() || ''
 			const serverTiming: Array<ServerTimingEntry> = []
 			const data = await loadCommunityPackageFilesData({
 				env,
@@ -255,41 +368,24 @@ export function createAccountPackageFilesHandler(env: Env) {
 				typeof params.relativePath === 'string' ? params.relativePath : '',
 			)
 			if (selectedPath == null) {
-				return renderAppPage({
-					request,
-					env,
-					title: 'Package files not found',
-					notFound: true,
-					status: 404,
-				})
+				return renderFilesNotFound({ request, env })
 			}
 
-			const serverTiming: Array<ServerTimingEntry> = []
-			const data = await loadAccountPackageFilesData({
-				env,
-				request,
+			const record = await getSavedPackageById(env.APP_DB, {
 				userId: user.mcpUser.userId,
-				username: user.username,
 				packageId: params.packageId,
-				selectedPath,
-				serverTiming,
 			})
-			if (!data) {
-				return renderAppPage({
-					request,
-					env,
-					title: 'Package files not found',
-					notFound: true,
-					status: 404,
-					serverTiming,
-				})
+			if (!record) {
+				return renderFilesNotFound({ request, env })
 			}
-			return renderAppPage({
-				request,
-				env,
-				title: `${data.title} files`,
-				loaderData: { packageFiles: data },
-				serverTiming,
+			return redirectToCanonicalPath({
+				path: getPackageTreeHref({
+					username: user.username,
+					kodyId: record.kodyId,
+					relativePath: selectedPath,
+				}),
+				url: new URL(request.url),
+				cache: 'private',
 			})
 		},
 	} satisfies Action<typeof routes.accountPackageFiles>
@@ -313,23 +409,28 @@ export function createAccountPackageFilesApiHandler(env: Env) {
 					400,
 				)
 			}
-			const serverTiming: Array<ServerTimingEntry> = []
-			const data = await loadAccountPackageFilesData({
-				env,
-				request,
+			const record = await getSavedPackageById(env.APP_DB, {
 				userId: user.mcpUser.userId,
-				username: user.username,
 				packageId: params.packageId,
-				selectedPath,
-				serverTiming,
 			})
-			if (!data) {
+			if (!record) {
 				return jsonResponse(
 					{ ok: false, error: 'Package files not found.' },
 					404,
 				)
 			}
-			return jsonResponse(data, { serverTiming })
+			return jsonResponse(
+				{
+					ok: false,
+					error: 'Package files moved.',
+					redirectTo: getPackageTreeHref({
+						username: user.username,
+						kodyId: record.kodyId,
+						relativePath: selectedPath,
+					}),
+				},
+				404,
+			)
 		},
 	} satisfies Action<typeof routes.accountPackageFilesApi>
 }

--- a/packages/worker/src/app/handlers/package-files.ts
+++ b/packages/worker/src/app/handlers/package-files.ts
@@ -88,6 +88,7 @@ async function renderListingFilesPage(input: {
 	const data = input.listingId
 		? await loadCommunityPackageFilesData({
 				env: input.env,
+				request: input.request,
 				listingId: input.listingId,
 				selectedPath: input.selectedPath,
 				ref: input.ref,
@@ -161,7 +162,11 @@ async function renderResolvedFilesPage(input: {
 		return renderFilesUnauthorized({ request: input.request, env: input.env })
 	}
 	if (target.kind === 'redirect') {
-		return redirectToCanonicalPath({ path: target.to, url: input.url })
+		return redirectToCanonicalPath({
+			path: target.to,
+			url: input.url,
+			cache: target.shared ? 'public' : 'private',
+		})
 	}
 	if (target.kind === 'package') {
 		return renderPackageFilesPage({
@@ -218,7 +223,11 @@ export function createCommunityDetailFilesHandler(env: Env) {
 				return renderFilesUnauthorized({ request, env })
 			}
 			if (target.kind === 'redirect') {
-				return redirectToCanonicalPath({ path: target.to, url })
+				return redirectToCanonicalPath({
+					path: target.to,
+					url,
+					cache: target.shared ? 'public' : 'private',
+				})
 			}
 			if (target.kind === 'package') {
 				return renderPackageFilesPage({
@@ -341,6 +350,7 @@ export function createCommunityDetailFilesApiHandler(env: Env) {
 			const serverTiming: Array<ServerTimingEntry> = []
 			const data = await loadCommunityPackageFilesData({
 				env,
+				request,
 				listingId: params.listingId,
 				selectedPath,
 				ref: treeRef,

--- a/packages/worker/src/app/package-files-data.node.test.ts
+++ b/packages/worker/src/app/package-files-data.node.test.ts
@@ -1,0 +1,109 @@
+import { expect, test, vi } from 'vitest'
+
+const mockModule = vi.hoisted(() => ({
+	getCommunityListingById: vi.fn<() => Promise<unknown>>(),
+	getEntitySourceById: vi.fn<() => Promise<unknown>>(),
+	resolveArtifactSourceHead: vi.fn<() => Promise<unknown>>(),
+	readPublishedSourceSnapshot: vi.fn<() => Promise<unknown>>(),
+	readAuthenticatedAppUser: vi.fn<() => Promise<unknown>>(),
+	highlightMarkdownFences: vi.fn(async () => []),
+	highlightSnippets: vi.fn(async () => []),
+}))
+
+vi.mock('#worker/community/repo.ts', () => ({
+	getCommunityListingById: (...args: Array<unknown>) =>
+		mockModule.getCommunityListingById(...args),
+}))
+
+vi.mock('#worker/repo/entity-sources.ts', () => ({
+	getEntitySourceById: (...args: Array<unknown>) =>
+		mockModule.getEntitySourceById(...args),
+}))
+
+vi.mock('#worker/repo/artifacts.ts', () => ({
+	resolveArtifactSourceHead: (...args: Array<unknown>) =>
+		mockModule.resolveArtifactSourceHead(...args),
+	readMockArtifactSnapshot: async () => null,
+}))
+
+vi.mock('#worker/package-runtime/published-runtime-artifacts.ts', () => ({
+	readPublishedSourceSnapshot: (...args: Array<unknown>) =>
+		mockModule.readPublishedSourceSnapshot(...args),
+}))
+
+vi.mock('#app/authenticated-user.ts', () => ({
+	readAuthenticatedAppUser: (...args: Array<unknown>) =>
+		mockModule.readAuthenticatedAppUser(...args),
+}))
+
+vi.mock('#app/highlight-code.ts', () => ({
+	highlightMarkdownFences: (...args: Array<unknown>) =>
+		mockModule.highlightMarkdownFences(...args),
+	highlightSnippets: (...args: Array<unknown>) =>
+		mockModule.highlightSnippets(...args),
+}))
+
+const { loadCommunityPackageFilesData } =
+	await import('./package-files-data.ts')
+
+const env = { APP_DB: {}, BUNDLE_ARTIFACTS_KV: {} } as Env
+const listing = {
+	id: 'listing-1',
+	ownerUserId: 'owner-1',
+	sourceId: 'src-1',
+	kodyId: 'sentry',
+	name: '@kentcdodds/sentry',
+	pinnedCommit: 'abc123',
+}
+
+test('listed package tree marks the owner so Settings stays on the chrome', async () => {
+	mockModule.getCommunityListingById.mockResolvedValue(listing)
+	mockModule.getEntitySourceById.mockResolvedValue({
+		repo_id: 'repo-1',
+		published_commit: 'abc123',
+	})
+	mockModule.resolveArtifactSourceHead.mockResolvedValue({
+		branch: 'main',
+		commit: 'abc123',
+	})
+	mockModule.readPublishedSourceSnapshot.mockResolvedValue({
+		files: { 'README.md': '# Sentry\n' },
+	})
+	mockModule.readAuthenticatedAppUser.mockResolvedValue({
+		mcpUser: { userId: 'owner-1' },
+	})
+
+	const ownerRequest = new Request(
+		'https://example.com/@kentcdodds/sentry/tree/main',
+	)
+	const owner = await loadCommunityPackageFilesData({
+		env,
+		request: ownerRequest,
+		listingId: 'listing-1',
+		selectedPath: '',
+		ref: 'main',
+	})
+	expect(owner).toMatchObject({
+		ok: true,
+		username: 'kentcdodds',
+		kodyId: 'sentry',
+		viewerIsOwner: true,
+		isPrivate: false,
+		backHref: '/@kentcdodds/sentry',
+		filesBasePath: '/@kentcdodds/sentry/tree/main',
+	})
+
+	mockModule.readAuthenticatedAppUser.mockResolvedValue(null)
+	const stranger = await loadCommunityPackageFilesData({
+		env,
+		request: new Request('https://example.com/@kentcdodds/sentry/tree/main'),
+		listingId: 'listing-1',
+		selectedPath: '',
+		ref: 'main',
+	})
+	expect(stranger).toMatchObject({
+		viewerIsOwner: false,
+		username: 'kentcdodds',
+		kodyId: 'sentry',
+	})
+})

--- a/packages/worker/src/app/package-files-data.ts
+++ b/packages/worker/src/app/package-files-data.ts
@@ -93,8 +93,22 @@ async function toLoaderData(input: {
 	}
 }
 
+async function readOptionalViewerUserId(input: { env: Env; request: Request }) {
+	try {
+		const user = await readAuthenticatedAppUser(input.request, input.env)
+		return user?.mcpUser.userId ?? null
+	} catch (error) {
+		console.error(
+			'Failed to resolve authenticated viewer for package files:',
+			error,
+		)
+		return null
+	}
+}
+
 export async function loadCommunityPackageFilesData(input: {
 	env: Env
+	request: Request
 	listingId: string
 	selectedPath: string
 	ref?: string
@@ -153,6 +167,10 @@ export async function loadCommunityPackageFilesData(input: {
 	})
 	if (!view) return null
 
+	const viewerUserId = await readOptionalViewerUserId({
+		env: input.env,
+		request: input.request,
+	})
 	return toLoaderData({
 		env: input.env,
 		title: listing.name,
@@ -167,6 +185,7 @@ export async function loadCommunityPackageFilesData(input: {
 		serverTiming: input.serverTiming,
 		username: ownerUsername ?? undefined,
 		kodyId: listing.kodyId,
+		viewerIsOwner: viewerUserId === listing.ownerUserId,
 		isPrivate: false,
 	})
 }
@@ -373,6 +392,7 @@ export async function loadAccessiblePackageFilesData(input: {
 	if (page.listing?.listing) {
 		const data = await loadCommunityPackageFilesData({
 			env: input.env,
+			request: input.request,
 			listingId: page.listing.listing.id,
 			selectedPath: input.selectedPath,
 			ref: input.ref,

--- a/packages/worker/src/app/package-files-data.ts
+++ b/packages/worker/src/app/package-files-data.ts
@@ -9,14 +9,17 @@ import { getCommunityListingHref } from '#universal/community-links.ts'
 import {
 	buildPackageFilesView,
 	fallbackDefaultBranchName,
-	getAccountPackageFilesHref,
+	findDirectoryReadmePath,
 	getCommunityPackageFilesHref,
+	getPackageTreeHref,
 	isPublicTreeDefaultRefAlias,
 	normalizePackageFilesPath,
 	type PackageFilesView,
 } from '#universal/package-files.ts'
 import { type PackageFilesLoaderData } from '#universal/loader-data.ts'
 import { routes } from '#universal/routes.ts'
+import { loadPackagePage } from '#app/package-page.ts'
+import { readAuthenticatedAppUser } from '#app/authenticated-user.ts'
 import {
 	highlightMarkdownFences,
 	highlightSnippets,
@@ -42,6 +45,10 @@ async function toLoaderData(input: {
 	filesBasePath: string
 	view: PackageFilesView
 	serverTiming?: Array<ServerTimingEntry>
+	username?: string
+	kodyId?: string
+	viewerIsOwner?: boolean
+	isPrivate?: boolean
 }): Promise<PackageFilesLoaderData> {
 	const content = input.view.content
 	const language = input.view.language
@@ -79,6 +86,10 @@ async function toLoaderData(input: {
 		language,
 		contentFences,
 		contentHighlighted,
+		username: input.username,
+		kodyId: input.kodyId,
+		viewerIsOwner: input.viewerIsOwner,
+		isPrivate: input.isPrivate,
 	}
 }
 
@@ -150,10 +161,13 @@ export async function loadCommunityPackageFilesData(input: {
 			ownerUsername,
 			kodyId: listing.kodyId,
 		}),
-		backLabel: 'Package listing',
+		backLabel: 'Code',
 		filesBasePath,
 		view,
 		serverTiming: input.serverTiming,
+		username: ownerUsername ?? undefined,
+		kodyId: listing.kodyId,
+		isPrivate: false,
 	})
 }
 
@@ -208,7 +222,7 @@ async function resolvePublicTreeCommit(input: {
 
 async function loadPublicTreeFiles(input: {
 	env: Env
-	listingId: string
+	listingId?: string | null
 	sourceId: string
 	sourceRepoId: string | null
 	commit: string | null
@@ -246,7 +260,7 @@ async function loadPublicTreeFiles(input: {
 			// Fall through to the listing pin snapshot.
 		}
 	}
-	if (input.env.BUNDLE_ARTIFACTS_KV) {
+	if (input.listingId && input.env.BUNDLE_ARTIFACTS_KV) {
 		const listingSnapshot = await readCommunitySnapshot(
 			input.env.BUNDLE_ARTIFACTS_KV,
 			input.listingId,
@@ -255,7 +269,7 @@ async function loadPublicTreeFiles(input: {
 			return { files: listingSnapshot.files, fromListingSnapshot: true }
 		}
 	}
-	return { files: {}, fromListingSnapshot: true }
+	return { files: {}, fromListingSnapshot: Boolean(input.listingId) }
 }
 
 export async function loadAccountPackageFilesData(input: {
@@ -265,6 +279,7 @@ export async function loadAccountPackageFilesData(input: {
 	username: string
 	packageId: string
 	selectedPath: string
+	ref?: string
 	serverTiming?: Array<ServerTimingEntry>
 }): Promise<PackageFilesLoaderData | null> {
 	const record = await getSavedPackageById(input.env.APP_DB, {
@@ -273,17 +288,38 @@ export async function loadAccountPackageFilesData(input: {
 	})
 	if (!record) return null
 
-	let files: Record<string, string> = {}
-	try {
-		const loaded = await loadPackageSourceBySourceId({
-			env: input.env,
-			baseUrl: getAppBaseUrl({ env: input.env, requestUrl: input.request.url }),
-			userId: input.userId,
-			sourceId: record.sourceId,
-		})
-		files = loaded.files
-	} catch {
-		files = {}
+	const source = await getEntitySourceById(input.env.APP_DB, record.sourceId)
+	const treeRef = input.ref?.trim() ?? ''
+	const resolved = await resolvePublicTreeCommit({
+		env: input.env,
+		sourceRepoId: source?.repo_id ?? null,
+		publishedCommit: source?.published_commit ?? '',
+		pinnedCommit: source?.published_commit ?? '',
+		ref: treeRef,
+	})
+	const loaded = await loadPublicTreeFiles({
+		env: input.env,
+		sourceId: record.sourceId,
+		sourceRepoId: source?.repo_id ?? null,
+		commit: resolved.commit,
+		pinnedCommit: source?.published_commit ?? '',
+	})
+	let files = loaded.files
+	if (Object.keys(files).length === 0) {
+		try {
+			const packageSource = await loadPackageSourceBySourceId({
+				env: input.env,
+				baseUrl: getAppBaseUrl({
+					env: input.env,
+					requestUrl: input.request.url,
+				}),
+				userId: input.userId,
+				sourceId: record.sourceId,
+			})
+			files = packageSource.files
+		} catch {
+			files = {}
+		}
 	}
 
 	const view = buildPackageFilesView({
@@ -292,6 +328,9 @@ export async function loadAccountPackageFilesData(input: {
 	})
 	if (!view) return null
 
+	const urlRef = isPublicTreeDefaultRefAlias(treeRef)
+		? resolved.defaultBranch
+		: treeRef || resolved.defaultBranch
 	return toLoaderData({
 		env: input.env,
 		title: record.name,
@@ -299,9 +338,92 @@ export async function loadAccountPackageFilesData(input: {
 			username: input.username,
 			kodyId: record.kodyId,
 		}),
-		backLabel: 'Package',
-		filesBasePath: getAccountPackageFilesHref({ packageId: record.id }),
+		backLabel: 'Code',
+		filesBasePath: getPackageTreeHref({
+			username: input.username,
+			kodyId: record.kodyId,
+			ref: urlRef,
+		}),
 		view,
 		serverTiming: input.serverTiming,
+		username: input.username,
+		kodyId: record.kodyId,
+		viewerIsOwner: true,
+		isPrivate: record.isPrivate,
 	})
+}
+
+export async function loadAccessiblePackageFilesData(input: {
+	env: Env
+	request: Request
+	username: string
+	kodyId: string
+	selectedPath: string
+	ref?: string
+	serverTiming?: Array<ServerTimingEntry>
+}): Promise<PackageFilesLoaderData | null> {
+	const page = await loadPackagePage({
+		env: input.env,
+		request: input.request,
+		username: input.username,
+		kodyId: input.kodyId,
+	})
+	if (page.kind !== 'page') return null
+
+	if (page.listing?.listing) {
+		const data = await loadCommunityPackageFilesData({
+			env: input.env,
+			listingId: page.listing.listing.id,
+			selectedPath: input.selectedPath,
+			ref: input.ref,
+			serverTiming: input.serverTiming,
+		})
+		if (!data) return null
+		return {
+			...data,
+			viewerIsOwner: page.viewerIsOwner,
+			isPrivate: page.ownerPackage?.isPrivate ?? false,
+			username: page.username,
+			kodyId: page.kodyId,
+		}
+	}
+
+	if (!page.ownerPackage) return null
+	const user = await readAuthenticatedAppUser(input.request, input.env)
+	if (!user) return null
+	return loadAccountPackageFilesData({
+		env: input.env,
+		request: input.request,
+		userId: user.mcpUser.userId,
+		username: page.username,
+		packageId: page.ownerPackage.id,
+		selectedPath: input.selectedPath,
+		ref: input.ref,
+		serverTiming: input.serverTiming,
+	})
+}
+
+export async function loadOwnerPackageReadme(input: {
+	env: Env
+	request: Request
+	userId: string
+	sourceId: string
+}): Promise<string | null> {
+	try {
+		const loaded = await loadPackageSourceBySourceId({
+			env: input.env,
+			baseUrl: getAppBaseUrl({
+				env: input.env,
+				requestUrl: input.request.url,
+			}),
+			userId: input.userId,
+			sourceId: input.sourceId,
+		})
+		const path = findDirectoryReadmePath(loaded.files, '')
+		if (!path) return null
+		const content = loaded.files[path]?.trim()
+		return content ? content : null
+	} catch {
+		return null
+	}
 }

--- a/packages/worker/src/app/router.ts
+++ b/packages/worker/src/app/router.ts
@@ -157,6 +157,7 @@ import {
 	createCommunityDetailOgImageHandler,
 	createCommunityPackageApiHandler,
 	createCommunityPackageHandler,
+	createCommunityPackageSettingsHandler,
 	createCommunityReportApiPostHandler,
 } from '#app/handlers/community-detail.tsx'
 import { createCommunityFeatureApiPostHandler } from '#app/handlers/community-feature.ts'
@@ -449,6 +450,7 @@ export function createAppRouter(env: Env) {
 			communityDetailFilesApi: createCommunityDetailFilesApiHandler(env),
 			communityPackage: createCommunityPackageHandler(env),
 			communityPackageApi: createCommunityPackageApiHandler(env),
+			communityPackageSettings: createCommunityPackageSettingsHandler(env),
 			communityPackageFiles: createCommunityPackageFilesHandler(env),
 			communityPackageTree: createCommunityPackageTreeHandler(env),
 			communityPackageFilesApi: createCommunityPackageFilesApiHandler(env),

--- a/packages/worker/universal/document-head.ts
+++ b/packages/worker/universal/document-head.ts
@@ -93,9 +93,17 @@ function communityListingHead({
 }: DocumentHeadContext): DocumentHeadDescriptor {
 	const shell = loaderData?.communityDetailShell
 	if (!shell?.ok) {
-		return titleOnly('Public packages')
+		return titleOnly('Package')
 	}
-	const title = `${shell.name} — Kody public package`
+	const title = shell.listingId
+		? `${shell.name} — Kody public package`
+		: shell.name
+	if (!shell.listingId) {
+		return {
+			title,
+			canonicalPath: pathname,
+		}
+	}
 	return {
 		title,
 		canonicalPath: pathname,
@@ -257,6 +265,17 @@ const routeDocumentHeads = {
 	),
 	[routePattern(routes.communityDetail)]: communityListingHead,
 	[routePattern(routes.communityPackage)]: communityListingHead,
+	[routePattern(routes.communityPackageSettings)]: ({
+		loaderData,
+		pathname,
+	}) => {
+		const shell = loaderData?.communityDetailShell
+		if (!shell?.ok) return titleOnly('Package settings')
+		return {
+			title: `${shell.name} settings`,
+			canonicalPath: pathname,
+		}
+	},
 	[routePattern(routes.communityDetailFiles)]: ({ loaderData, pathname }) => {
 		const files = loaderData?.packageFiles
 		if (!files?.ok) return titleOnly('Package files')

--- a/packages/worker/universal/loader-data.ts
+++ b/packages/worker/universal/loader-data.ts
@@ -179,6 +179,10 @@ export type PackageFilesLoaderData = {
 	language: string | null
 	contentHighlighted?: HighlightedCode | null
 	contentFences?: Array<HighlightedCode>
+	username?: string
+	kodyId?: string
+	viewerIsOwner?: boolean
+	isPrivate?: boolean
 }
 
 /** SSR-embedded shell data for client-only regions on the detail page. */
@@ -197,6 +201,9 @@ export type CommunityDetailShellLoaderData = {
 	viewerInstall: ViewerListingInstall | null
 	ownerPackage: AccountPackageDetail | null
 	username: string
+	kodyId: string
+	viewerIsOwner: boolean
+	isPrivate: boolean
 	invocationUrlOrigin: string
 }
 

--- a/packages/worker/universal/package-files.node.test.ts
+++ b/packages/worker/universal/package-files.node.test.ts
@@ -6,6 +6,8 @@ import {
 	findDirectoryReadmePath,
 	getAccountPackageFilesHref,
 	getCommunityPackageFilesHref,
+	getPackageSettingsHref,
+	getPackageTreeHref,
 	isReservedPackageFilesKodyId,
 	joinPackageFilesPath,
 	listPackageFilesChildren,
@@ -133,6 +135,18 @@ test('files hrefs use the default-branch fallback and avoid reserved kody ids', 
 	expect(getAccountPackageFilesHref({ packageId: 'pkg-1' })).toBe(
 		'/account/packages/pkg-1/files',
 	)
+	expect(
+		getPackageTreeHref({
+			username: 'kentcdodds',
+			kodyId: 'friction-log',
+		}),
+	).toBe('/@kentcdodds/friction-log/tree/main')
+	expect(
+		getPackageSettingsHref({
+			username: 'kentcdodds',
+			kodyId: 'friction-log',
+		}),
+	).toBe('/@kentcdodds/friction-log/settings')
 	expect(
 		joinPackageFilesPath('/@kentcdodds/devin/tree/main', 'src/index.ts'),
 	).toBe('/@kentcdodds/devin/tree/main/src/index.ts')

--- a/packages/worker/universal/package-files.ts
+++ b/packages/worker/universal/package-files.ts
@@ -396,6 +396,32 @@ export function getCommunityPackageFilesHref(input: {
 	return getCommunityPackageTreeHref(input)
 }
 
+export function getPackageTreeHref(input: {
+	username: string
+	kodyId: string
+	listingId?: string | null
+	ref?: string
+	relativePath?: string
+}) {
+	return getCommunityPackageTreeHref({
+		listingId: input.listingId ?? '',
+		ownerUsername: input.username,
+		kodyId: input.kodyId,
+		ref: input.ref,
+		relativePath: input.relativePath,
+	})
+}
+
+export function getPackageSettingsHref(input: {
+	username: string
+	kodyId: string
+}) {
+	return routes.communityPackageSettings.href({
+		username: input.username,
+		kodyId: input.kodyId,
+	})
+}
+
 export function getAccountPackageFilesHref(input: {
 	packageId: string
 	relativePath?: string

--- a/packages/worker/universal/package-repo-nav.tsx
+++ b/packages/worker/universal/package-repo-nav.tsx
@@ -1,0 +1,235 @@
+/** @jsxImportSource remix/ui */
+/** @jsxRuntime automatic */
+import { css } from 'remix/ui'
+import { getPackageSettingsHref } from '#universal/package-files.ts'
+import { routes } from '#universal/routes.ts'
+import {
+	colors,
+	radius,
+	spacing,
+	typography,
+} from '#universal/styles/tokens.ts'
+
+export type PackageRepoNavActive = 'code' | 'settings'
+
+export function renderPackageVisibilityBadge(isPrivate: boolean) {
+	return (
+		<span
+			data-testid="package-visibility-badge"
+			data-visibility={isPrivate ? 'private' : 'public'}
+			mix={css(isPrivate ? privateBadgeCss : publicBadgeCss)}
+		>
+			{isPrivate ? 'Private' : 'Public'}
+		</span>
+	)
+}
+
+export function renderPackageRepoNav(input: {
+	username: string
+	kodyId: string
+	viewerIsOwner: boolean
+	active: PackageRepoNavActive
+}) {
+	const codeHref = routes.communityPackage.href({
+		username: input.username,
+		kodyId: input.kodyId,
+	})
+	const settingsHref = getPackageSettingsHref({
+		username: input.username,
+		kodyId: input.kodyId,
+	})
+	return (
+		<nav aria-label="Package" data-testid="package-repo-nav" mix={css(navCss)}>
+			<a
+				href={codeHref}
+				aria-current={input.active === 'code' ? 'page' : undefined}
+				data-testid="package-repo-nav-code"
+				mix={css(tabCss)}
+			>
+				Code
+			</a>
+			{input.viewerIsOwner ? (
+				<a
+					href={settingsHref}
+					aria-current={input.active === 'settings' ? 'page' : undefined}
+					data-testid="package-repo-nav-settings"
+					mix={css(tabCss)}
+				>
+					Settings
+				</a>
+			) : null}
+		</nav>
+	)
+}
+
+export function renderPackageRepoChrome(input: {
+	username: string
+	kodyId: string
+	isPrivate: boolean
+	viewerIsOwner: boolean
+	active: PackageRepoNavActive
+	description?: string
+	ownerProfilePublic?: boolean
+	animate?: boolean
+}) {
+	const backHref = input.viewerIsOwner
+		? routes.accountPackages.href()
+		: routes.community.href()
+	const backLabel = input.viewerIsOwner ? 'Packages' : 'Public packages'
+	const profileHref =
+		input.ownerProfilePublic === false
+			? null
+			: routes.profile.href({ username: input.username })
+	const rise = (step: string) =>
+		input.animate
+			? ({
+					'data-rise': true,
+					style: { '--rise': step },
+				} as const)
+			: {}
+
+	return (
+		<div data-testid="package-repo-chrome">
+			<a
+				{...rise('0')}
+				href={backHref}
+				data-testid="package-repo-back"
+				mix={css(backLinkCss)}
+			>
+				← {backLabel}
+			</a>
+			<header {...rise('1')} mix={css(headCss)}>
+				<h1 mix={css(titleCss)}>
+					{profileHref ? (
+						<a href={profileHref} mix={css(ownerLinkCss)}>
+							@{input.username}
+						</a>
+					) : (
+						<span data-testid="community-detail-owner-private">
+							@{input.username}
+						</span>
+					)}
+					<span mix={css(slashCss)}>/</span>
+					<span>{input.kodyId}</span>
+					{renderPackageVisibilityBadge(input.isPrivate)}
+				</h1>
+			</header>
+			{input.description ? (
+				<p {...rise('2')} mix={css(descriptionCss)}>
+					{input.description}
+				</p>
+			) : null}
+			<div {...rise('3')}>
+				{renderPackageRepoNav({
+					username: input.username,
+					kodyId: input.kodyId,
+					viewerIsOwner: input.viewerIsOwner,
+					active: input.active,
+				})}
+			</div>
+		</div>
+	)
+}
+
+const backLinkCss = {
+	display: 'inline-flex',
+	alignItems: 'center',
+	gap: '0.4rem',
+	fontSize: '0.95rem',
+	fontWeight: 550,
+	color: colors.primaryText,
+	textDecoration: 'none',
+	'&:hover': {
+		color: colors.text,
+	},
+}
+
+const headCss = {
+	marginTop: '1.8rem',
+}
+
+const titleCss = {
+	margin: 0,
+	display: 'flex',
+	alignItems: 'center',
+	flexWrap: 'wrap' as const,
+	gap: '0.45rem',
+	fontSize: 'clamp(1.5rem, 3.6vw, 2rem)',
+	fontWeight: 760,
+	letterSpacing: '-0.024em',
+	lineHeight: 1.15,
+	overflowWrap: 'anywhere' as const,
+}
+
+const slashCss = {
+	color: colors.textMuted,
+	fontWeight: 500,
+}
+
+const ownerLinkCss = {
+	color: colors.text,
+	fontWeight: 550,
+	textDecoration: 'none',
+	'&:hover': {
+		color: colors.primaryText,
+	},
+}
+
+const descriptionCss = {
+	margin: '1rem 0 0',
+	color: colors.textMuted,
+	fontSize: '1.05rem',
+	maxWidth: '58ch',
+}
+
+const badgeCss = {
+	display: 'inline-flex',
+	alignItems: 'center',
+	padding: `${spacing.xs} ${spacing.sm}`,
+	borderRadius: radius.full,
+	fontSize: typography.fontSize.xs,
+	fontWeight: typography.fontWeight.medium,
+	lineHeight: 1.2,
+}
+
+const privateBadgeCss = {
+	...badgeCss,
+	backgroundColor: colors.surface,
+	border: `1px solid ${colors.border}`,
+	color: colors.textMuted,
+}
+
+const publicBadgeCss = {
+	...badgeCss,
+	backgroundColor: colors.primarySoft,
+	border: 'none',
+	color: colors.primaryText,
+	fontWeight: typography.fontWeight.semibold,
+}
+
+const navCss = {
+	display: 'flex',
+	alignItems: 'center',
+	gap: spacing.sm,
+	marginTop: '1.1rem',
+	borderBottom: `1px solid ${colors.border}`,
+}
+
+const tabCss = {
+	display: 'inline-flex',
+	alignItems: 'center',
+	padding: '0.55rem 0.15rem',
+	marginBottom: '-1px',
+	borderBottom: '2px solid transparent',
+	color: colors.textMuted,
+	fontSize: '0.95rem',
+	fontWeight: 550,
+	textDecoration: 'none',
+	'&:hover': {
+		color: colors.text,
+	},
+	'&[aria-current="page"]': {
+		color: colors.text,
+		borderBottomColor: colors.primary,
+	},
+}

--- a/packages/worker/universal/routes.ts
+++ b/packages/worker/universal/routes.ts
@@ -180,6 +180,7 @@ export const routes = route({
 	communityPackage: '/@:username/:kodyId',
 	communityPackageFiles: '/@:username/:kodyId/files(/*relativePath)',
 	communityPackageTree: '/@:username/:kodyId/tree/:ref(/*relativePath)',
+	communityPackageSettings: '/@:username/:kodyId/settings',
 	// JSON companion lives under `/profiles/…` with the other username-keyed
 	// APIs, keeping the `/@…` namespace to human-shareable page URLs.
 	communityPackageApi: '/profiles/:username/packages/:kodyId.json',

--- a/tools/control-kody/feature-catalog.ts
+++ b/tools/control-kody/feature-catalog.ts
@@ -207,7 +207,7 @@ export const featureCatalog: ReadonlyArray<Feature> = [
 		id: 'community',
 		title: 'Community listings and profiles',
 		file: 'community.md',
-		paths: ['/community', '/@:username'],
+		paths: ['/community', '/@:username', '/@:username/:kodyId'],
 		apis: [
 			'/community.json',
 			'/community/:listingId.json',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

One GitHub-style package surface for public and private repos: home is the README, files live at `/tree/{branch}`, and owner controls live at `/settings`. Visibility is the only access gate.

## Why

Private packages used a different account files URL (`/account/packages/{uuid}/files`) and a different page than public listings like `/@kentcdodds/sentry`. `/@user/name/tree/main` 404'd. Making a repo public was a one-click action with no name confirmation.

## Summary

- Canonical URLs: `/@username/kodyId` (README), `/@username/kodyId/tree/:ref` (files), `/@username/kodyId/settings` (tokens, lock, visibility, delete)
- Shared chrome (Code / Settings tabs + Public/Private badge) for home, tree, and settings
- `loadPackagePage` gates tree and home; leftover `/account/packages/:id/files` 302s to the tree
- Making a package public requires typing the slug, same as making it private
- Settings 404 for anyone who is not the owner, including SPA navigation
- Rename hops from a stale `/settings` URL stay on `/settings`
- Unlisted leftover `/files` and rename hops use a private 302 (`private, no-store`)
- Listed-package tree pages resolve `viewerIsOwner` so the owner still sees Settings

## Testing

- `vitest` node-unit + workers-unit (pre-push), including leftover-files cache policy, listed-tree owner chrome, settings SPA 404, and settings rename hops
- Preview as the seeded user: empty packages list, missing `/@user-me/…` home/tree/settings 404, leftover UUID files 404 (`https://kody-pr-1958.kody-a99.workers.dev`)

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `acf2ca8f` · **Head:** `3860e3d2`

**Classification:** extends — package home, tree, and settings now share one `/@user/name` surface; visibility is the access gate instead of a separate account files path.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | extends — shared repo chrome, `/settings` route, leftover account files redirect to `/tree/{branch}` |
| `community-listings` | assistant | extends — private packages use the same listing routes; make-public requires typing the slug |

### Change flow

A visitor hits `/@user/name`, `/tree/{ref}`, or `/settings`; the same package page loader applies visibility, then the matching view renders.

```mermaid
sequenceDiagram
	actor User
	participant appUi as app-ui
	participant communityListings as community-listings
	User->>appUi: GET /@user/name or /tree/main or /settings
	appUi->>communityListings: loadPackagePage visibility gate
	alt listed public package
		communityListings-->>appUi: README plus catalog meta
		appUi-->>User: Code tab (shared chrome)
	else private owner
		communityListings-->>appUi: README or settings payload
		appUi-->>User: Code or Settings tab
	else stranger or anonymous
		communityListings-->>appUi: not_found or unauthorized
		appUi-->>User: 404
	end
```

### Before / after

| Surface | Before | After |
| --- | --- | --- |
| Files | `/account/packages/{uuid}/files` for private | `/@user/name/tree/{branch}` for everyone who can see the package |
| Owner controls | On the package home | `/@user/name/settings` |
| Make public | One click | Type the package slug |
| Home | Owner details for private; README for public | README for both |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7a1bd068-26ba-4e17-8728-53ae2ceb475a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7a1bd068-26ba-4e17-8728-53ae2ceb475a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added owner-only package settings pages at `/@username/:kodyId/settings`.
  * Added repository-style navigation with Code and Settings tabs, visibility badges, and owner controls.
  * Unified public and private package browsing under `/@username/:kodyId/tree/:ref`.
  * Added redirects from legacy file URLs to canonical tree pages.
  * Added required slug confirmation for visibility changes and clearer empty README messaging.
  * Improved access handling for private and unlisted packages.

* **Documentation**
  * Updated package and community documentation with the new URLs, redirects, visibility rules, and owner controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->