### PR TITLE
Tell fleet apply to take one page per workflow sandbox

### DIFF
--- a/docs/contributing/package-codemods.md
+++ b/docs/contributing/package-codemods.md
@@ -337,8 +337,17 @@ Builtin capability and domain ids are camelCase identifiers (`emailSend`,
 The engine entry point is `runPackageCodemodStep` in
 `packages/worker/src/package-codemods/engine.ts`. Long runs are **paged**: each
 call processes up to `limit` packages (or revert items) and returns `nextCursor`
-plus a per-step `summary` count by item status. Repeat with the same `runId` and
-`nextCursor` until `nextCursor` is null.
+plus a per-step `summary` count by item status. Continue with the same `runId`
+and `nextCursor` until `nextCursor` is null.
+
+The admin UI walks those pages as separate HTTP requests. MCP `execute` and
+inline workflow sandboxes do not: dry-run, apply, and revert are check-heavy
+enough that a second page in the same sandbox typically exceeds the workflow
+observer (~270s, under the Cloudflare Workflow step timeout). Those modes take
+one page per execute or workflow sandbox. When `nextCursor` is set, start a new
+`execute` or `workflows.create` with that `runId` and cursor. Capability results
+include a `nextStep` string that restates this. Scan pages are cheaper and can
+often continue in the same sandbox.
 
 ### Step limits
 

--- a/docs/contributing/package-codemods.md
+++ b/docs/contributing/package-codemods.md
@@ -345,9 +345,10 @@ inline workflow sandboxes do not: dry-run, apply, and revert are check-heavy
 enough that a second page in the same sandbox typically exceeds the workflow
 observer (~270s, under the Cloudflare Workflow step timeout). Those modes take
 one page per execute or workflow sandbox. When `nextCursor` is set, start a new
-`execute` or `workflows.create` with that `runId` and cursor. Capability results
-include a `nextStep` string that restates this. Scan pages are cheaper and can
-often continue in the same sandbox.
+`execute` or `workflows.create` with that `runId` and cursor. Omitted filters
+inherit from the stored run. Capability results include a `nextStep` string that
+restates this. Scan pages are cheaper and can often continue in the same
+sandbox.
 
 ### Step limits
 

--- a/docs/use/workflows.md
+++ b/docs/use/workflows.md
@@ -13,7 +13,10 @@ re-executes instead of replaying a cached timeout. Outbound `fetch` in that
 sandbox is capped ~30s under the same budget (~4 minutes), so a single slow
 upstream can finish without the execute-oriented 60s fetch deadline. The initial
 `execute` call should submit one `workflows.create`; inspect that workflow later
-with `workflowRunList`, or cancel it with `workflowRunCancel`.
+with `workflowRunList`, or cancel it with `workflowRunCancel`. Check-heavy admin
+steps such as fleet apply, dry-run, and revert take one page per workflow
+sandbox; when `nextCursor` is set, create another workflow with that `runId` and
+cursor instead of looping in the same run.
 
 ```ts
 import { workflows } from 'kody:runtime'

--- a/packages/worker/client/routes/admin-codemods.tsx
+++ b/packages/worker/client/routes/admin-codemods.tsx
@@ -497,7 +497,7 @@ export function AdminCodemodsRoute(handle: Handle) {
 
 					<AccountManagementPanel
 						title="Run codemod"
-						description="Each click walks the fleet in pages until nextCursor is null (stop anytime; hard ceiling 200 steps). Apply and revert require an explicit scope and confirmation."
+						description="Each click walks the fleet as one HTTP request per page until nextCursor is null (stop anytime; hard ceiling 200 steps). Apply and revert require an explicit scope and confirmation."
 					>
 						<form
 							mix={[

--- a/packages/worker/src/mcp/capabilities/admin/admin-package-codemod-apply.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-package-codemod-apply.ts
@@ -2,7 +2,7 @@ import { defineDomainCapability } from '#mcp/capabilities/define-domain-capabili
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import {
 	adminPackageCodemodStepInputSchema,
-	packageCodemodPagingHint,
+	packageCodemodHeavyPagingHint,
 	packageCodemodStepResultSchema,
 	runFleetPackageCodemodStep,
 } from '#mcp/capabilities/packages/package-codemod-shared.ts'
@@ -17,7 +17,7 @@ export const adminPackageCodemodApplyCapability = defineDomainCapability(
 		...adminMutationCapabilityAccess,
 		destructive: true,
 		name: 'adminPackageCodemodApply',
-		description: `Fleet-apply a registered package codemod: republishes transformed published trees after the same gates as dry-run. Prefer adminPackageCodemodDryRun first; canary with filters. Keep the returned runId to revert with adminPackageCodemodRevert. ${packageCodemodPagingHint}`,
+		description: `Fleet-apply a registered package codemod: republishes transformed published trees after the same gates as dry-run. Prefer adminPackageCodemodDryRun first; canary with filters. Keep the returned runId to revert with adminPackageCodemodRevert. ${packageCodemodHeavyPagingHint}`,
 		keywords: [
 			'admin',
 			'package',

--- a/packages/worker/src/mcp/capabilities/admin/admin-package-codemod-capabilities.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-package-codemod-capabilities.node.test.ts
@@ -129,12 +129,47 @@ test('admin package codemod capabilities are fleet-scoped, audited, and role-gat
 			},
 			createAdminCtx(),
 		),
-	).resolves.toMatchObject({ mode: 'apply' })
+	).resolves.toMatchObject({
+		mode: 'apply',
+		nextStep: 'This run has no further pages.',
+	})
 	expect(mockModule.runPackageCodemodStep).toHaveBeenLastCalledWith(
 		expect.objectContaining({
 			mode: 'apply',
 			scope: { kind: 'fleet' },
 			filters: { packageIds: ['pkg-canary'] },
+			initiatedByUserId: 'admin-1',
+		}),
+	)
+	mockModule.runPackageCodemodStep.mockResolvedValue({
+		...emptyStepResult({
+			runId: 'fleet-apply-1',
+			codemodId: '0001-ambient-storage-to-package-storage',
+			mode: 'apply',
+		}),
+		nextCursor: 'cursor-2',
+	})
+	await expect(
+		adminPackageCodemodApplyCapability.handler(
+			{
+				codemodId: '0001-ambient-storage-to-package-storage',
+				runId: 'fleet-apply-1',
+				cursor: 'cursor-1',
+			},
+			createAdminCtx(),
+		),
+	).resolves.toMatchObject({
+		mode: 'apply',
+		nextCursor: 'cursor-2',
+		nextStep:
+			'This page is done. Continue in a new execute or workflows.create call with runId fleet-apply-1 and cursor cursor-2 (limit ≤5). Do not page again in the same sandbox.',
+	})
+	expect(mockModule.runPackageCodemodStep).toHaveBeenLastCalledWith(
+		expect.objectContaining({
+			mode: 'apply',
+			scope: { kind: 'fleet' },
+			runId: 'fleet-apply-1',
+			cursor: 'cursor-1',
 			initiatedByUserId: 'admin-1',
 		}),
 	)

--- a/packages/worker/src/mcp/capabilities/admin/admin-package-codemod-dry-run.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-package-codemod-dry-run.ts
@@ -2,7 +2,7 @@ import { defineDomainCapability } from '#mcp/capabilities/define-domain-capabili
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import {
 	adminPackageCodemodStepInputSchema,
-	packageCodemodPagingHint,
+	packageCodemodHeavyPagingHint,
 	packageCodemodStepResultSchema,
 	runFleetPackageCodemodStep,
 } from '#mcp/capabilities/packages/package-codemod-shared.ts'
@@ -16,7 +16,7 @@ export const adminPackageCodemodDryRunCapability = defineDomainCapability(
 	{
 		...adminCapabilityAccess,
 		name: 'adminPackageCodemodDryRun',
-		description: `Fleet dry-run a registered package codemod: transform in memory and run publish checks without writing. Optional filters canary by userIds or packageIds. ${packageCodemodPagingHint}`,
+		description: `Fleet dry-run a registered package codemod: transform in memory and run publish checks without writing. Optional filters canary by userIds or packageIds. ${packageCodemodHeavyPagingHint}`,
 		keywords: [
 			'admin',
 			'package',

--- a/packages/worker/src/mcp/capabilities/admin/admin-package-codemod-revert.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-package-codemod-revert.ts
@@ -3,7 +3,7 @@ import { defineDomainCapability } from '#mcp/capabilities/define-domain-capabili
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import {
 	adminPackageCodemodRevertInputSchema,
-	packageCodemodPagingHint,
+	packageCodemodHeavyPagingHint,
 	packageCodemodStepResultSchema,
 	runFleetPackageCodemodStep,
 } from '#mcp/capabilities/packages/package-codemod-shared.ts'
@@ -19,7 +19,7 @@ export const adminPackageCodemodRevertCapability = defineDomainCapability(
 		...adminMutationCapabilityAccess,
 		destructive: true,
 		name: 'adminPackageCodemodRevert',
-		description: `Fleet-revert a prior adminPackageCodemodApply (or other apply) run by republishing stored pre-codemod snapshots. ${packageCodemodPagingHint}`,
+		description: `Fleet-revert a prior adminPackageCodemodApply (or other apply) run by republishing stored pre-codemod snapshots. ${packageCodemodHeavyPagingHint}`,
 		keywords: [
 			'admin',
 			'package',

--- a/packages/worker/src/mcp/capabilities/packages/package-codemod-shared.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/packages/package-codemod-shared.node.test.ts
@@ -1,0 +1,48 @@
+import { expect, test } from 'vitest'
+import { createPackageCodemodNextStep } from './package-codemod-shared.ts'
+
+test('createPackageCodemodNextStep tells callers how to continue a page', () => {
+	expect(
+		createPackageCodemodNextStep({
+			runId: 'run-apply-1',
+			nextCursor: 'cursor-2',
+			mode: 'apply',
+		}),
+	).toBe(
+		'This page is done. Continue in a new execute or workflows.create call with runId run-apply-1 and cursor cursor-2 (limit ≤5). Do not page again in the same sandbox.',
+	)
+	expect(
+		createPackageCodemodNextStep({
+			runId: 'run-dry-1',
+			nextCursor: 'cursor-3',
+			mode: 'dry-run',
+		}),
+	).toBe(
+		'This page is done. Continue in a new execute or workflows.create call with runId run-dry-1 and cursor cursor-3 (limit ≤5). Do not page again in the same sandbox.',
+	)
+	expect(
+		createPackageCodemodNextStep({
+			runId: 'run-revert-1',
+			nextCursor: 'cursor-4',
+			mode: 'revert',
+		}),
+	).toBe(
+		'This page is done. Continue in a new execute or workflows.create call with runId run-revert-1 and cursor cursor-4 (limit ≤5). Do not page again in the same sandbox.',
+	)
+	expect(
+		createPackageCodemodNextStep({
+			runId: 'run-scan-1',
+			nextCursor: 'cursor-2',
+			mode: 'scan',
+		}),
+	).toBe(
+		'Continue with runId run-scan-1 and cursor cursor-2. Scan pages usually fit in one sandbox; spawn a new workflow if the call is approaching the sandbox budget.',
+	)
+	expect(
+		createPackageCodemodNextStep({
+			runId: 'run-apply-1',
+			nextCursor: null,
+			mode: 'apply',
+		}),
+	).toBe('This run has no further pages.')
+})

--- a/packages/worker/src/mcp/capabilities/packages/package-codemod-shared.ts
+++ b/packages/worker/src/mcp/capabilities/packages/package-codemod-shared.ts
@@ -65,6 +65,11 @@ export const packageCodemodStepResultSchema = z.object({
 		packageCodemodItemStatusSchema,
 		z.number().int().nonnegative(),
 	),
+	nextStep: z
+		.string()
+		.describe(
+			'What to do with nextCursor. Dry-run, apply, and revert continue in a new execute or workflow sandbox.',
+		),
 })
 
 export const packageCodemodStepInputSchema = z.object({
@@ -90,7 +95,7 @@ export const packageCodemodStepInputSchema = z.object({
 		.max(50)
 		.optional()
 		.describe(
-			'Max packages to process in this step. Scan: default 20, max 50. Dry-run, apply, and revert are check-heavy: default 5, max 10 (higher values are clamped).',
+			'Max packages to process in this step. Scan: default 20, max 50. Dry-run, apply, and revert are check-heavy: default 5, max 10 (higher values are clamped). One apply/dry-run/revert page per execute or workflow sandbox.',
 		),
 })
 
@@ -118,7 +123,7 @@ export const packageCodemodRevertInputSchema = z.object({
 		.max(10)
 		.optional()
 		.describe(
-			'Max items to revert in this step (default 5, max 10 — reverts republish packages and are check-heavy).',
+			'Max items to revert in this step (default 5, max 10). Reverts republish packages: one page per execute or workflow sandbox.',
 		),
 })
 
@@ -145,10 +150,33 @@ export const adminPackageCodemodRevertInputSchema =
 		filters: packageCodemodFiltersSchema.optional(),
 	})
 
-const pagingDescription =
-	'Paged: call again with runId and nextCursor until nextCursor is null.'
+export const packageCodemodPagingHint =
+	'Paged: each call is one page. Continue with the same runId and nextCursor until nextCursor is null.'
 
-export const packageCodemodPagingHint = pagingDescription
+export const packageCodemodHeavyPagingHint =
+	'Paged: one page per execute or workflow sandbox (default limit 5). When nextCursor is set, start a new execute or workflows.create with that runId and cursor — do not loop pages in the same sandbox.'
+
+export function createPackageCodemodNextStep(result: {
+	runId: string
+	nextCursor: string | null
+	mode: PackageCodemodRunMode
+}) {
+	if (result.nextCursor == null) {
+		return 'This run has no further pages.'
+	}
+	switch (result.mode) {
+		case 'scan':
+			return `Continue with runId ${result.runId} and cursor ${result.nextCursor}. Scan pages usually fit in one sandbox; spawn a new workflow if the call is approaching the sandbox budget.`
+		case 'dry-run':
+		case 'apply':
+		case 'revert':
+			return `This page is done. Continue in a new execute or workflows.create call with runId ${result.runId} and cursor ${result.nextCursor} (limit ≤5). Do not page again in the same sandbox.`
+		default: {
+			const exhaustive: never = result.mode
+			throw new Error(`Unknown package codemod mode: ${String(exhaustive)}`)
+		}
+	}
+}
 
 export async function runFleetPackageCodemodStep(
 	ctx: CapabilityContext,
@@ -177,7 +205,7 @@ export async function runFleetPackageCodemodStep(
 					...(packageIds != null ? { packageIds } : {}),
 				}
 			: undefined
-	return await runPackageCodemodStep({
+	const result = await runPackageCodemodStep({
 		env: ctx.env,
 		baseUrl: ctx.callerContext.baseUrl,
 		initiatedByUserId: user.userId,
@@ -190,4 +218,8 @@ export async function runFleetPackageCodemodStep(
 		limit: input.limit,
 		revertOfRunId: input.revertOfRunId,
 	})
+	return {
+		...result,
+		nextStep: createPackageCodemodNextStep(result),
+	}
 }

--- a/packages/worker/src/package-codemods/engine.node.test.ts
+++ b/packages/worker/src/package-codemods/engine.node.test.ts
@@ -999,6 +999,72 @@ test('package codemod engine rejects resume steps with mismatched filters', asyn
 	expect(resumedWithoutFilters.runId).toBe(first.runId)
 })
 
+test('omitted continuation filters keep a canary fleet apply on the stored package set', async () => {
+	resetMocks()
+	const { env } = createEnv()
+	const pkgCanary = savedPackage({
+		id: 'pkg-canary',
+		userId: 'user-1',
+		kodyId: 'canary',
+		sourceId: 'source-canary',
+	})
+	const pkgOutside = savedPackage({
+		id: 'pkg-outside',
+		userId: 'user-1',
+		kodyId: 'outside',
+		sourceId: 'source-outside',
+	})
+	const fleet = [pkgCanary, pkgOutside]
+	mocks.listSavedPackagesPage.mockImplementation(
+		async (
+			_db: D1Database,
+			input: { afterId: string | null; limit: number },
+		) => {
+			if (input.afterId == null) return fleet
+			return fleet.filter(
+				(savedPackage) => savedPackage.id.localeCompare(input.afterId!) > 0,
+			)
+		},
+	)
+	mocks.loadPackageSourceBySourceId.mockResolvedValue(
+		loadedSource({
+			files: cleanFiles(),
+			publishedCommit: 'commit-canary',
+			repoId: 'repo-canary',
+			sourceId: 'source-canary',
+			userId: 'user-1',
+		}),
+	)
+
+	const first = await runPackageCodemodStep({
+		env,
+		baseUrl: 'https://example.com',
+		initiatedByUserId: 'admin-1',
+		codemodId,
+		mode: 'scan',
+		scope: { kind: 'fleet' },
+		filters: { packageIds: ['pkg-canary'] },
+		limit: 1,
+	})
+	expect(first.items.map((item) => item.packageId)).toEqual(['pkg-canary'])
+	expect(first.nextCursor).toBe('pkg-canary')
+
+	const continued = await runPackageCodemodStep({
+		env,
+		baseUrl: 'https://example.com',
+		initiatedByUserId: 'admin-1',
+		codemodId,
+		mode: 'scan',
+		scope: { kind: 'fleet' },
+		runId: first.runId,
+		cursor: first.nextCursor,
+		limit: 1,
+	})
+	expect(continued.runId).toBe(first.runId)
+	expect(continued.items).toEqual([])
+	expect(continued.nextCursor).toBeNull()
+})
+
 test('package codemod revert page ceiling and user-scoped SQL filter for sparse ownership', async () => {
 	resetMocks()
 	const { env } = createEnv()

--- a/packages/worker/src/package-codemods/engine.node.test.ts
+++ b/packages/worker/src/package-codemods/engine.node.test.ts
@@ -985,6 +985,18 @@ test('package codemod engine rejects resume steps with mismatched filters', asyn
 		limit: 10,
 	})
 	expect(resumed.runId).toBe(first.runId)
+
+	const resumedWithoutFilters = await runPackageCodemodStep({
+		env,
+		baseUrl: 'https://example.com',
+		initiatedByUserId: 'admin-2',
+		codemodId,
+		mode: 'scan',
+		scope: { kind: 'user', userId: 'user-1' },
+		runId: first.runId,
+		limit: 10,
+	})
+	expect(resumedWithoutFilters.runId).toBe(first.runId)
 })
 
 test('package codemod revert page ceiling and user-scoped SQL filter for sparse ownership', async () => {

--- a/packages/worker/src/package-codemods/engine.ts
+++ b/packages/worker/src/package-codemods/engine.ts
@@ -344,13 +344,17 @@ async function ensureRun(input: {
 				`Package codemod run "${input.runId}" revertOfRunId does not match the requested value.`,
 			)
 		}
-		const existingFiltersJson = normalizeFiltersJson(
-			parseStoredFiltersJson(existing.filtersJson),
-		)
-		if (existingFiltersJson !== filtersJson) {
-			throw new Error(
-				`Package codemod run "${input.runId}" filters do not match the requested filters.`,
+		// Continuation steps may omit filters; the stored run is the source of
+		// truth. Only an explicit mismatched value is rejected.
+		if (input.filters !== undefined) {
+			const existingFiltersJson = normalizeFiltersJson(
+				parseStoredFiltersJson(existing.filtersJson),
 			)
+			if (existingFiltersJson !== filtersJson) {
+				throw new Error(
+					`Package codemod run "${input.runId}" filters do not match the requested filters.`,
+				)
+			}
 		}
 		if (existing.status !== 'completed') {
 			// Heartbeat: every continuation step re-asserts `running` and bumps

--- a/packages/worker/src/package-codemods/engine.ts
+++ b/packages/worker/src/package-codemods/engine.ts
@@ -1216,7 +1216,7 @@ export async function runPackageCodemodStep(input: {
 		const { packages, nextCursor } = await listCandidatePackages({
 			env: input.env,
 			scope: input.scope,
-			filters: input.filters,
+			filters: input.filters ?? parseStoredFiltersJson(run.filtersJson),
 			cursor: input.cursor ?? null,
 			limit,
 		})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop inline fleet-apply workflows from looping `adminPackageCodemodApply` pages until the 270s observer aborts them.

## Why

`0009-snake-case-apply-known` and every other 0009 apply workflow today died at ~270s. The observer is working as designed (under Cloudflare’s 5-minute step timeout). One apply-heavy page of 5 can finish; a second page in the same sandbox does not. The advertised contract said “loop `runId` + `nextCursor` until null,” which is what those workflows did. A one-page continuation also failed in production when it omitted filters — the stored run requires an exact match unless we inherit.

## Summary

- Check-heavy admin codemod pages (dry-run, apply, revert) are one page per execute or workflow sandbox.
- Capability results include `nextStep` that says to start a new execute/`workflows.create` when `nextCursor` is set.
- Continuation steps that omit `filters` inherit the stored run’s filters (same as `revertOfRunId`).
- Scan paging is unchanged (cheaper; can continue in the same sandbox).
- Docs and the admin UI copy match that contract.

## Testing

- Focused node-unit: paging helper, admin capability `nextStep`, engine resume-without-filters.
- Pre-push: `test:node` (2285) and `test:workers` (312) passed.
- Head `95691363` CI is green, including preview. An earlier preview on `08588663` failed Worker startup CPU; that run is superseded.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `35ccc952` · **Head:** `95691363`

**Classification:** extends — fleet apply/dry-run/revert MCP results gain a `nextStep` continuation contract, and omitted continuation filters inherit from the stored run.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `package-codemods` | assistant | extends — omitted filters inherit on resume; explicit mismatches still reject |
| `saved-packages` | assistant | extends — `nextStep` on fleet codemod step results; heavy modes continue in a new sandbox |
| `rbac` | auth | composes — admin apply/dry-run/revert descriptions use the heavy paging hint |
| `app-ui` | surfaces | composes — admin codemods form copy notes one HTTP request per page |

### Change flow

A check-heavy fleet page returns `nextCursor` plus `nextStep`. The next page is a new execute or workflow with the same `runId` and cursor; stored filters are reused when the caller omits them.

```mermaid
sequenceDiagram
	actor Operator
	participant mcpServer as mcp-server
	participant savedPackages as saved-packages
	participant packageCodemods as package-codemods
	participant workflows as package-workflows
	Operator->>mcpServer: adminPackageCodemodApply (limit 5)
	mcpServer->>savedPackages: one page of apply
	savedPackages->>packageCodemods: runPackageCodemodStep
	packageCodemods-->>savedPackages: nextCursor
	savedPackages-->>mcpServer: nextCursor plus nextStep
	mcpServer-->>Operator: this page is done
	Operator->>workflows: workflows.create with runId and cursor
	workflows->>packageCodemods: inherit stored filters
	packageCodemods-->>workflows: next apply page
```

### Before / after

```text
before: "Paged: call again with runId and nextCursor until nextCursor is null."
        Continuation must resupply the exact filters JSON.
after:  one heavy page per sandbox; nextStep tells the caller to spawn the next
        workflow; omitted filters inherit from the stored run.
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8942c90a-fd23-4064-9078-1dda39d3f912?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8942c90a-fd23-4064-9078-1dda39d3f912&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added continuation guidance for paginated codemod apply, dry-run, revert, and scan operations.
  * Codemod results now indicate when another execution is needed and provide the cursor to continue.
  * Existing run filters are automatically reused when continuing without explicitly supplying them.

* **Documentation**
  * Clarified pagination behavior across codemod and administrative workflows, including execution limits and continuation requirements.

* **Bug Fixes**
  * Improved filter validation when resuming codemod operations to prevent mismatched filters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->