### PR TITLE
Generate tasteful swirl fallbacks for public package icons

### DIFF
--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -488,11 +488,11 @@ Source files remain in the listing's pinned Artifacts commit; R2 stores only the
 256-pixel WebP ingest (Cloudflare Images, `fit: scale-down`) or a generated
 fallback.
 
-- Keys use `community-icon:v2/{listingId}/{commit}/asset`, where the commit is
+- Keys use `community-icon:v3/{listingId}/{commit}/asset`, where the commit is
   the listing's icon commit (the owner package's current published commit) or
   its pinned snapshot commit. Derived bytes are a 256-pixel WebP from the
   Cloudflare Images ingest fit. Account deletion also prefix-deletes leftover
-  `community-icon:v1/` objects.
+  `community-icon:v1/` and `community-icon:v2/` objects.
 - Descriptor keys include the same listing id and commit, so package publish and
   listing re-publish cannot serve an older icon.
 - Unpublish, admin hard delete, and re-publish prune all descriptor and object
@@ -1328,10 +1328,10 @@ app-owned keys in it. App-owned `BUNDLE_ARTIFACTS_KV` keys are:
 - `derived-cache:v1:usage-rollups:user:{userId}:asof:{YYYY-MM}` — derived
   per-user usage read model written with KV `expirationTtl`; retention is five
   minutes, so immediate account-deletion cleanup is not required.
-- `derived-cache:v1:community-icon:v2:{listingId}:...` — derived community
+- `derived-cache:v1:community-icon:v3:{listingId}:...` — derived community
   listing icon cache; registered as a user-owned KV surface and deleted for a
   user's listings during account deletion (including leftover
-  `community-icon:v1` prefixes).
+  `community-icon:v1` and `community-icon:v2` prefixes).
 - `webhook-dispatch-payload:v1:{userId}:{deliveryId}` — ephemeral ack-mode
   webhook body spill written with KV `expirationTtl` (24 hours) when the
   serialized queue message would exceed 120 KB. Immediate account-deletion
@@ -1351,11 +1351,11 @@ or a deliberate retention note.
 
 App-owned R2 keys are:
 
-- `community-icon:v2/{listingId}/{commit}/asset` — processed public community
+- `community-icon:v3/{listingId}/{commit}/asset` — processed public community
   icon bytes (256px WebP) at the listing's pinned or icon commit. The listing id
   is the public ownership boundary. Account deletion paginates and strictly
   deletes every key under each D1-owned listing prefix, including historical
-  `community-icon:v1/` revisions.
+  `community-icon:v1/` and `community-icon:v2/` revisions.
 
 - `user-avatars/{stableUserId}/{contentHash}.{extension}` — profile avatars.
   Account deletion paginates and strictly deletes the complete stable-user

--- a/docs/contributing/community-packages.md
+++ b/docs/contributing/community-packages.md
@@ -136,19 +136,21 @@ the listing's pinned commit when the source row is gone). Listing reads join the
 entity source, so a plain package publish moves the icon commit forward — and
 with it the icon URL — without a community republish. `@epic-web/cachified`
 stores a small descriptor in `BUNDLE_ARTIFACTS_KV` under
-`derived-cache:v1:community-icon:v2:{listingId}:{commit}`. The processed bytes
+`derived-cache:v1:community-icon:v3:{listingId}:{commit}`. The processed bytes
 live in the private `COMMUNITY_ASSETS` R2 bucket under
-`community-icon:v2/{listingId}/{commit}/asset`.
+`community-icon:v3/{listingId}/{commit}/asset`.
 
 On a descriptor cache miss, the icon service resolves the standardized root
 `community-icon.*` path (from the pinned snapshot when serving the pinned
 commit, otherwise by probing the Artifacts git repo at the icon commit), reads
 the bytes, validates them, and writes the derived asset to R2 before returning
 the descriptor. A dangling descriptor is deleted and regenerated once. Packages
-without an icon receive a generated fallback. Every accepted source (SVG
-rasterized first, then PNG, WebP, and JPEG) is fitted through the Cloudflare
-Images binding to a 256-pixel WebP (`fit: scale-down`, quality 90). Publish and
-account-deletion cleanup also remove leftover `community-icon:v1` keys.
+without an icon receive a generated fallback: a deterministic swirl from the
+package name (`packages/worker/src/community/community-icon-fallback.ts`). Every
+accepted source (SVG rasterized first, then PNG, WebP, and JPEG) is fitted
+through the Cloudflare Images binding to a 256-pixel WebP (`fit: scale-down`,
+quality 90). Publish and account-deletion cleanup also remove leftover
+`community-icon:v1` and `community-icon:v2` keys.
 
 The icon route serves only the current icon commit and the pinned commit; stale
 commit URLs 404. Package publish (`finalizePublishedEntitySource`) calls

--- a/docs/guides/package-authoring.md
+++ b/docs/guides/package-authoring.md
@@ -285,7 +285,7 @@ Public packages should include one root `icon.svg`, `icon.png`, `icon.webp`,
 `icon.jpg`, or `icon.jpeg`. `community-icon.*` is also accepted. Prefer a square
 visual with a simple silhouette that remains legible at 56 pixels. Keep it under
 2 MiB and 16 megapixels. Kody stores a 256-pixel WebP derivative of that source
-(or a generated package-name fallback when the repository has no icon).
+(or a generated package-name swirl when the repository has no icon).
 
 Publishing the package refreshes the catalog listing icon automatically. The
 candidate paths win in the order `icon.*` then `community-icon.*` (svg, png,

--- a/docs/use/community-packages.md
+++ b/docs/use/community-packages.md
@@ -49,7 +49,8 @@ filled-in cards).
 
 Prefer a root `icon.svg`, `icon.png`, `icon.webp`, `icon.jpg`, or `icon.jpeg`.
 `community-icon.*` is also accepted. The first existing file in that combined
-order wins.
+order wins. Packages without an icon get a generated swirl based on the package
+name.
 
 ## Browsing listings
 

--- a/packages/worker/src/account/user-owned-surfaces.ts
+++ b/packages/worker/src/account/user-owned-surfaces.ts
@@ -203,9 +203,9 @@ export const accountUserOwnedKvKeySchemes: ReadonlyArray<UserOwnedKvKeyScheme> =
 		{
 			id: 'community_icon_derived_cache',
 			binding: 'BUNDLE_ARTIFACTS_KV',
-			prefixTemplate: 'derived-cache:v1:community-icon:v2:{listingId}:',
+			prefixTemplate: 'derived-cache:v1:community-icon:v3:{listingId}:',
 			notes:
-				'Derived cache key from derivedCacheKeyPrefix + buildCommunityIconCacheKey. Account deletion also prefixes historical community-icon:v1 keys.',
+				'Derived cache key from derivedCacheKeyPrefix + buildCommunityIconCacheKey. Account deletion also prefixes historical community-icon:v1 and community-icon:v2 keys.',
 		},
 		{
 			id: 'usage_rollup_derived_cache',
@@ -265,10 +265,10 @@ export const accountUserOwnedR2Surfaces: ReadonlyArray<UserOwnedR2Surface> = [
 		id: 'community_icon',
 		binding: 'COMMUNITY_ASSETS',
 		sourceTable: 'community_listings',
-		keyTemplate: 'community-icon:v2/{listingId}/{commit}/asset',
+		keyTemplate: 'community-icon:v3/{listingId}/{commit}/asset',
 		export: 'chunked_bytes',
 		notes:
-			'Current fitted WebP derivative. Account deletion also removes historical community-icon:v1 prefixes.',
+			'Current fitted WebP derivative. Account deletion also removes historical community-icon:v1 and community-icon:v2 prefixes.',
 	},
 	{
 		id: 'user_avatar',

--- a/packages/worker/src/app/account-deletion.node.test.ts
+++ b/packages/worker/src/app/account-deletion.node.test.ts
@@ -358,6 +358,8 @@ test('deleteUserAccount cascades user-scoped rows for the requested user', async
 		'derived-cache:v1:community-icon:v1:listing-1:historical',
 		'derived-cache:v1:community-icon:v2:listing-1:commit-1',
 		'derived-cache:v1:community-icon:v2:listing-1:abc123',
+		'derived-cache:v1:community-icon:v3:listing-1:commit-1',
+		'derived-cache:v1:community-icon:v3:listing-1:abc123',
 		'source-snapshot:v1:src-2:def456',
 		`package-codemod-revert:${userAaa}:item-1`,
 		`package-codemod-revert:${userAaa}:item-2`,
@@ -772,6 +774,8 @@ test('deleteUserAccount cascades user-scoped rows for the requested user', async
 		'derived-cache:v1:community-icon:v1:listing-1:historical',
 		'derived-cache:v1:community-icon:v2:listing-1:abc123',
 		'derived-cache:v1:community-icon:v2:listing-1:commit-1',
+		'derived-cache:v1:community-icon:v3:listing-1:abc123',
+		'derived-cache:v1:community-icon:v3:listing-1:commit-1',
 		`package-codemod-revert:${userAaa}:item-1`,
 		`package-codemod-revert:${userAaa}:item-2`,
 		'package-retriever-index-entry:v1:user-aaa:context:pkg-1:notes',
@@ -804,7 +808,7 @@ test('deleteUserAccount cascades user-scoped rows for the requested user', async
 	expect(result.updatedRowCounts.community_bans).toBe(1)
 	expect(result.deletedRowCounts.platform_feedback).toBe(1)
 	expect(result.updatedRowCounts.platform_feedback).toBe(1)
-	expect(result.deletedKvKeys).toBe(16)
+	expect(result.deletedKvKeys).toBe(18)
 	expect(result.deletedCommunityAssets).toBe(7)
 	expect(result.deletedEmailBlobs).toBe(2)
 	// Prefix sweeps remove current and historical assets without crossing users.

--- a/packages/worker/src/app/account-r2-prefix-cleanup.node.test.ts
+++ b/packages/worker/src/app/account-r2-prefix-cleanup.node.test.ts
@@ -47,7 +47,7 @@ test('community asset prefix cleanup paginates and preserves other users', async
 		listingIds: ['listing-a'],
 	})
 	expect(count).toBe(6)
-	expect(list).toHaveBeenCalledTimes(6)
+	expect(list).toHaveBeenCalledTimes(7)
 	expect(deleted.sort()).toEqual([
 		'community-icon:v1/listing-a/current/asset',
 		'community-icon:v1/listing-a/historical/asset',

--- a/packages/worker/src/community/community-icon-fallback.node.test.ts
+++ b/packages/worker/src/community/community-icon-fallback.node.test.ts
@@ -1,0 +1,74 @@
+import { expect, test } from 'vitest'
+import { renderCommunityIconFallbackPng } from './community-icon.ts'
+import {
+	buildCommunityIconFallbackSvg,
+	type communityIconFallbackPalettes,
+	pickCommunityIconFallbackPalette,
+} from './community-icon-fallback.ts'
+
+const sampleNames = [
+	'@kentcdodds/friction-log',
+	'@kentcdodds/github-tools',
+	'@kody/notion-mcp',
+	'@kody/github-triage',
+	'@jane/inbox-digest',
+	'plain-slug',
+] as const
+
+function hexColorsIn(svg: string) {
+	return [...svg.matchAll(/#(?:[0-9a-f]{6})/gi)].map((match) =>
+		match[0].toLowerCase(),
+	)
+}
+
+function paletteHexes(palette: (typeof communityIconFallbackPalettes)[number]) {
+	return new Set(
+		[palette.wash, palette.ribbon, palette.accent, palette.ink].map((hex) =>
+			hex.toLowerCase(),
+		),
+	)
+}
+
+test('package-name fallbacks are deterministic swirls from a curated palette', async () => {
+	const friction = buildCommunityIconFallbackSvg('@kentcdodds/friction-log')
+	expect(friction).toBe(
+		buildCommunityIconFallbackSvg('@kentcdodds/friction-log'),
+	)
+	expect(friction).not.toBe(
+		buildCommunityIconFallbackSvg('@kentcdodds/github-tools'),
+	)
+	expect(friction).not.toContain('<text')
+	expect(friction).toContain('data-fallback-art="1"')
+	expect(friction).toMatch(
+		/data-palette="(dusk|sea|lichen|apricot|fog|lilac|inkwell|sand)"/,
+	)
+	expect(friction).toContain('<linearGradient')
+	expect(friction).toContain('<clipPath')
+	expect(friction.match(/<ellipse /g)?.length).toBe(2)
+	expect(friction.match(/<path /g)?.length).toBe(3)
+
+	for (const name of sampleNames) {
+		const svg = buildCommunityIconFallbackSvg(name)
+		const palette = pickCommunityIconFallbackPalette(name)
+		const allowed = paletteHexes(palette)
+		expect(svg).toContain(`data-palette="${palette.id}"`)
+		expect(new Set(hexColorsIn(svg))).toEqual(allowed)
+	}
+
+	const palettesUsed = new Set(
+		sampleNames.map((name) => pickCommunityIconFallbackPalette(name).id),
+	)
+	expect(palettesUsed.size).toBeGreaterThan(1)
+
+	const frictionPng = await renderCommunityIconFallbackPng(
+		'@kentcdodds/friction-log',
+	)
+	const toolsPng = await renderCommunityIconFallbackPng(
+		'@kentcdodds/github-tools',
+	)
+	expect(Array.from(frictionPng.slice(0, 4))).toEqual([0x89, 0x50, 0x4e, 0x47])
+	expect(Array.from(toolsPng.slice(0, 4))).toEqual([0x89, 0x50, 0x4e, 0x47])
+	expect(frictionPng.byteLength).toBeGreaterThan(2_000)
+	expect(toolsPng.byteLength).toBeGreaterThan(2_000)
+	expect(frictionPng).not.toEqual(toolsPng)
+})

--- a/packages/worker/src/community/community-icon-fallback.ts
+++ b/packages/worker/src/community/community-icon-fallback.ts
@@ -1,0 +1,262 @@
+/**
+ * Deterministic package-icon fallbacks for listings without community-icon.*.
+ *
+ * Taste is the constraint. A hash must never produce neon sludge, complementary
+ * overlays, or high-chroma brown/olive. Every icon draws from a hand-tuned
+ * analogous palette (wash + two ribbons + a deep ink) and the same spiral
+ * composition, so the set reads as one designed family instead of random art.
+ *
+ * Soft overlapping color fields are a common generative-identicon idea — see
+ * boring-avatars "marble" (MIT,
+ * https://github.com/boringdesigners/boring-avatars). The spiral ribbons and
+ * palettes here are original.
+ */
+
+export const communityIconFallbackArtVersion = 1 as const
+
+type FallbackPalette = {
+	id: string
+	wash: string
+	ribbon: string
+	accent: string
+	ink: string
+}
+
+/**
+ * Mid-chroma, high-wash families. Hue spans stay under ~40° so ribbons cannot
+ * mix into mud. No neon, no complementary pairs.
+ */
+export const communityIconFallbackPalettes = [
+	{
+		id: 'dusk',
+		wash: '#eee8f6',
+		ribbon: '#7d6bb3',
+		accent: '#c4a8d8',
+		ink: '#3d3560',
+	},
+	{
+		id: 'sea',
+		wash: '#e6f1f3',
+		ribbon: '#3d8b9a',
+		accent: '#86c0c8',
+		ink: '#1e4d56',
+	},
+	{
+		id: 'lichen',
+		wash: '#e8f1e6',
+		ribbon: '#5a8f6a',
+		accent: '#a8c9a4',
+		ink: '#2d4a34',
+	},
+	{
+		id: 'apricot',
+		wash: '#f7eee6',
+		ribbon: '#c98468',
+		accent: '#e4b89a',
+		ink: '#6b3d32',
+	},
+	{
+		id: 'fog',
+		wash: '#eceef2',
+		ribbon: '#6b7c94',
+		accent: '#a8b4c4',
+		ink: '#2e3848',
+	},
+	{
+		id: 'lilac',
+		wash: '#f2e8f4',
+		ribbon: '#8b6ba8',
+		accent: '#c9b0d8',
+		ink: '#3e2d52',
+	},
+	{
+		id: 'inkwell',
+		wash: '#e6eef4',
+		ribbon: '#3d6b8a',
+		accent: '#86adc0',
+		ink: '#1c3344',
+	},
+	{
+		id: 'sand',
+		wash: '#f4efe6',
+		ribbon: '#a88464',
+		accent: '#d4c0a4',
+		ink: '#5c4634',
+	},
+] as const satisfies ReadonlyArray<FallbackPalette>
+
+const tileSize = 256
+const tileRadius = 56
+const spiralSamples = 22
+
+export function hashCommunityIconSeed(name: string) {
+	let hash = 2166136261
+	for (const character of name) {
+		hash ^= character.charCodeAt(0)
+		hash = Math.imul(hash, 16777619)
+	}
+	return hash >>> 0
+}
+
+function mulberry32(seed: number) {
+	let state = seed >>> 0
+	return function next() {
+		state = (state + 0x6d2b79f5) >>> 0
+		let t = state
+		t = Math.imul(t ^ (t >>> 15), t | 1)
+		t ^= t + Math.imul(t ^ (t >>> 7), t | 61)
+		return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+	}
+}
+
+export function pickCommunityIconFallbackPalette(name: string) {
+	const palettes = communityIconFallbackPalettes
+	return palettes[hashCommunityIconSeed(name) % palettes.length] ?? palettes[0]
+}
+
+function formatNumber(value: number) {
+	return value.toFixed(2)
+}
+
+function spiralPoints(input: {
+	cx: number
+	cy: number
+	innerRadius: number
+	outerRadius: number
+	turns: number
+	phase: number
+}) {
+	const points: Array<[number, number]> = []
+	for (let index = 0; index < spiralSamples; index += 1) {
+		const t = index / (spiralSamples - 1)
+		const theta = input.phase + t * input.turns * Math.PI * 2
+		const radius =
+			input.outerRadius + (input.innerRadius - input.outerRadius) * t
+		points.push([
+			input.cx + radius * Math.cos(theta),
+			input.cy + radius * Math.sin(theta),
+		])
+	}
+	return points
+}
+
+function pointsToPath(points: ReadonlyArray<[number, number]>) {
+	const first = points[0]
+	if (!first) return ''
+	let path = `M${formatNumber(first[0])} ${formatNumber(first[1])}`
+	for (let index = 1; index < points.length - 1; index += 1) {
+		const current = points[index]
+		const next = points[index + 1]
+		if (!current || !next) continue
+		path += ` Q${formatNumber(current[0])} ${formatNumber(current[1])} ${formatNumber((current[0] + next[0]) / 2)} ${formatNumber((current[1] + next[1]) / 2)}`
+	}
+	const last = points[points.length - 1]
+	if (last) path += ` T${formatNumber(last[0])} ${formatNumber(last[1])}`
+	return path
+}
+
+function ellipse(input: {
+	cx: number
+	cy: number
+	rx: number
+	ry: number
+	rotate: number
+	fill: string
+	opacity: number
+}) {
+	return `<ellipse cx="${formatNumber(input.cx)}" cy="${formatNumber(input.cy)}" rx="${formatNumber(input.rx)}" ry="${formatNumber(input.ry)}" fill="${input.fill}" opacity="${formatNumber(input.opacity)}" transform="rotate(${formatNumber(input.rotate)} ${formatNumber(input.cx)} ${formatNumber(input.cy)})"/>`
+}
+
+function ribbon(input: {
+	d: string
+	color: string
+	width: number
+	opacity: number
+}) {
+	return `<path d="${input.d}" fill="none" stroke="${input.color}" stroke-width="${formatNumber(input.width)}" stroke-linecap="round" stroke-linejoin="round" opacity="${formatNumber(input.opacity)}"/>`
+}
+
+export function buildCommunityIconFallbackSvg(name: string) {
+	const seed = hashCommunityIconSeed(name)
+	const random = mulberry32(seed)
+	const palette = pickCommunityIconFallbackPalette(name)
+	const id = seed.toString(16)
+	const cx = 118 + random() * 20
+	const cy = 118 + random() * 20
+	const phase = random() * Math.PI * 2
+	const turns = 1.65 + random() * 0.55
+	const wide = ribbon({
+		d: pointsToPath(
+			spiralPoints({
+				cx,
+				cy,
+				innerRadius: 18,
+				outerRadius: 118,
+				turns,
+				phase,
+			}),
+		),
+		color: palette.ribbon,
+		width: 38,
+		opacity: 0.78,
+	})
+	const mid = ribbon({
+		d: pointsToPath(
+			spiralPoints({
+				cx: cx + 10,
+				cy: cy - 8,
+				innerRadius: 14,
+				outerRadius: 102,
+				turns: turns - 0.18,
+				phase: phase + 0.9,
+			}),
+		),
+		color: palette.accent,
+		width: 28,
+		opacity: 0.62,
+	})
+	const fine = ribbon({
+		d: pointsToPath(
+			spiralPoints({
+				cx: cx - 6,
+				cy: cy + 12,
+				innerRadius: 10,
+				outerRadius: 86,
+				turns: turns + 0.22,
+				phase: phase + 2.1,
+			}),
+		),
+		color: palette.ink,
+		width: 16,
+		opacity: 0.4,
+	})
+	const wash = `<linearGradient id="wash-${id}" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="${palette.wash}"/><stop offset="1" stop-color="${palette.accent}" stop-opacity="0.38"/></linearGradient>`
+	return [
+		`<svg xmlns="http://www.w3.org/2000/svg" width="${tileSize}" height="${tileSize}" viewBox="0 0 ${tileSize} ${tileSize}" data-fallback-art="${communityIconFallbackArtVersion}" data-palette="${palette.id}">`,
+		`<defs><clipPath id="tile-${id}"><rect width="${tileSize}" height="${tileSize}" rx="${tileRadius}"/></clipPath>${wash}</defs>`,
+		`<g clip-path="url(#tile-${id})">`,
+		`<rect width="${tileSize}" height="${tileSize}" fill="url(#wash-${id})"/>`,
+		ellipse({
+			cx: 70 + random() * 30,
+			cy: 78 + random() * 24,
+			rx: 86,
+			ry: 62,
+			rotate: random() * 50 - 25,
+			fill: palette.ribbon,
+			opacity: 0.22,
+		}),
+		ellipse({
+			cx: 176 + random() * 24,
+			cy: 168 + random() * 22,
+			rx: 78,
+			ry: 54,
+			rotate: random() * 40 - 20,
+			fill: palette.accent,
+			opacity: 0.28,
+		}),
+		wide,
+		mid,
+		fine,
+		`</g></svg>`,
+	].join('')
+}

--- a/packages/worker/src/community/community-icon.node.test.ts
+++ b/packages/worker/src/community/community-icon.node.test.ts
@@ -440,15 +440,21 @@ test('deleteCommunityIconAssets removes superseded revisions and keeps servable 
 		`derived-cache:v1:community-icon:v1:${listingId}:${commit}`
 	const kvKeyV2 = (listingId: string, commit: string) =>
 		`derived-cache:v1:community-icon:v2:${listingId}:${commit}`
+	const kvKeyV3 = (listingId: string, commit: string) =>
+		`derived-cache:v1:community-icon:v3:${listingId}:${commit}`
 	const r2KeyV1 = (listingId: string, commit: string) =>
 		`community-icon:v1/${listingId}/${commit}/asset`
 	const r2KeyV2 = (listingId: string, commit: string) =>
 		`community-icon:v2/${listingId}/${commit}/asset`
+	const r2KeyV3 = (listingId: string, commit: string) =>
+		`community-icon:v3/${listingId}/${commit}/asset`
 	for (const commit of ['commit-1', 'commit-2', 'commit-3']) {
 		kvValues.set(kvKeyV1(listing.id, commit), '{}')
 		kvValues.set(kvKeyV2(listing.id, commit), '{}')
+		kvValues.set(kvKeyV3(listing.id, commit), '{}')
 		r2Values.set(r2KeyV1(listing.id, commit), Uint8Array.from([1]))
 		r2Values.set(r2KeyV2(listing.id, commit), Uint8Array.from([1]))
+		r2Values.set(r2KeyV3(listing.id, commit), Uint8Array.from([1]))
 	}
 	kvValues.set(kvKeyV1('other-listing', 'commit-1'), '{}')
 	kvValues.set(kvKeyV2('other-listing', 'commit-1'), '{}')
@@ -463,14 +469,14 @@ test('deleteCommunityIconAssets removes superseded revisions and keeps servable 
 
 	expect(Array.from(kvValues.keys()).sort()).toEqual(
 		[
-			kvKeyV2(listing.id, 'commit-2'),
+			kvKeyV3(listing.id, 'commit-2'),
 			kvKeyV1('other-listing', 'commit-1'),
 			kvKeyV2('other-listing', 'commit-1'),
 		].sort(),
 	)
 	expect(Array.from(r2Values.keys()).sort()).toEqual(
 		[
-			r2KeyV2(listing.id, 'commit-2'),
+			r2KeyV3(listing.id, 'commit-2'),
 			r2KeyV1('other-listing', 'commit-1'),
 			r2KeyV2('other-listing', 'commit-1'),
 		].sort(),
@@ -491,15 +497,21 @@ test('refreshCommunityIconForPackagePublish drops superseded icon caches for act
 		`derived-cache:v1:community-icon:v1:${listing.id}:${commit}`
 	const kvKeyV2 = (commit: string) =>
 		`derived-cache:v1:community-icon:v2:${listing.id}:${commit}`
+	const kvKeyV3 = (commit: string) =>
+		`derived-cache:v1:community-icon:v3:${listing.id}:${commit}`
 	const r2KeyV1 = (commit: string) =>
 		`community-icon:v1/${listing.id}/${commit}/asset`
 	const r2KeyV2 = (commit: string) =>
 		`community-icon:v2/${listing.id}/${commit}/asset`
+	const r2KeyV3 = (commit: string) =>
+		`community-icon:v3/${listing.id}/${commit}/asset`
 	for (const commit of [listing.pinnedCommit, 'old-publish', 'new-publish']) {
 		kvValues.set(kvKeyV1(commit), '{}')
 		kvValues.set(kvKeyV2(commit), '{}')
+		kvValues.set(kvKeyV3(commit), '{}')
 		r2Values.set(r2KeyV1(commit), Uint8Array.from([1]))
 		r2Values.set(r2KeyV2(commit), Uint8Array.from([1]))
+		r2Values.set(r2KeyV3(commit), Uint8Array.from([1]))
 	}
 
 	mocks.getCommunityListingByOwnerAndPackage.mockResolvedValue({
@@ -514,10 +526,10 @@ test('refreshCommunityIconForPackagePublish drops superseded icon caches for act
 	})
 
 	expect(Array.from(kvValues.keys()).sort()).toEqual(
-		[kvKeyV2(listing.pinnedCommit), kvKeyV2('new-publish')].sort(),
+		[kvKeyV3(listing.pinnedCommit), kvKeyV3('new-publish')].sort(),
 	)
 	expect(Array.from(r2Values.keys()).sort()).toEqual(
-		[r2KeyV2(listing.pinnedCommit), r2KeyV2('new-publish')].sort(),
+		[r2KeyV3(listing.pinnedCommit), r2KeyV3('new-publish')].sort(),
 	)
 	expect(getCommunityPublicCacheVersion()).toBe(1)
 

--- a/packages/worker/src/community/community-icon.ts
+++ b/packages/worker/src/community/community-icon.ts
@@ -16,9 +16,9 @@ import {
 	fitIconRaster,
 	iconFitCustomMetadata,
 	iconFitMaxDimension,
-	iconFitVersion,
 	publicFittedIconCacheControl,
 } from './icon-fit.ts'
+import { buildCommunityIconFallbackSvg } from './community-icon-fallback.ts'
 import {
 	getCommunityListingById,
 	getCommunityListingByOwnerAndPackage,
@@ -26,8 +26,9 @@ import {
 import { readCommunitySnapshot } from './snapshot.ts'
 import { type CommunityListingRecord } from './types.ts'
 
-export const communityIconVersion = iconFitVersion
-const communityIconAssetVersions = [1, communityIconVersion] as const
+export const communityIconVersion = 3 as const
+const communityIconAssetVersions = [1, 2, communityIconVersion] as const
+export { buildCommunityIconFallbackSvg } from './community-icon-fallback.ts'
 const communityIconOutputSize = iconFitMaxDimension
 const maxCommunityIconSourceBytes = 2 * 1024 * 1024
 const maxCommunityIconDimension = 4096
@@ -659,31 +660,6 @@ function readUint32BigEndian(bytes: Uint8Array, offset: number) {
 			(bytes[offset + 3] ?? 0)) >>>
 		0
 	)
-}
-
-export function buildCommunityIconFallbackSvg(name: string) {
-	const words = name
-		.replace(/^@[^/]+\//, '')
-		.split(/[^a-z0-9]+/i)
-		.filter(Boolean)
-	const initials =
-		(words.length > 1
-			? `${words[0]?.[0]}${words[1]?.[0]}`
-			: words[0]?.slice(0, 2)
-		)
-			?.toUpperCase()
-			.replace(/[^A-Z0-9]/g, '') || 'K'
-	const colors = [
-		'#2563eb',
-		'#7c3aed',
-		'#db2777',
-		'#0891b2',
-		'#059669',
-	] as const
-	let hash = 0
-	for (const character of name) hash = (hash * 31 + character.charCodeAt(0)) | 0
-	const background = colors[Math.abs(hash) % colors.length]
-	return `<svg xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewBox="0 0 256 256"><rect width="256" height="256" rx="56" fill="${background}"/><text x="128" y="136" fill="white" font-family="sans-serif" font-size="92" font-weight="700" text-anchor="middle" dominant-baseline="middle">${initials}</text></svg>`
 }
 
 export async function renderCommunityIconFallbackPng(name: string) {

--- a/packages/worker/src/community/community-icon.workers.test.ts
+++ b/packages/worker/src/community/community-icon.workers.test.ts
@@ -61,7 +61,7 @@ test('community icon resolves a cachified descriptor to R2 bytes', async () => {
 				ttl: 30 * 24 * 60 * 60 * 1000,
 			},
 			value: {
-				version: 2,
+				version: 3,
 				listingId: listing.id,
 				iconCommit: listing.iconCommit,
 				r2Key,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Public packages without a custom icon should get a generated mark that looks designed, not a flat colored square.

## Why

Listings without `community-icon.*` were falling back to a hashed solid fill plus initials. Resvg has no sans-serif font, so the initials often never painted and the page showed a blank purple tile. Even when the fill landed, it was lackluster.

## Summary

- New `community-icon-fallback.ts` builds a deterministic 256×256 SVG from the package name: FNV-1a seed, mulberry32, one of eight hand-tuned analogous palettes, a wash gradient, two soft ellipses, and three Archimedean spiral ribbons clipped to a rounded square.
- No `<text>` — the Resvg font gap cannot produce a blank tile anymore.
- Palettes stay mid-chroma and analogous so a hash cannot emit neon, complementary mud, or high-chroma brown/olive.
- Soft overlapping color fields follow the marble idea from [boring-avatars](https://github.com/boringdesigners/boring-avatars) (MIT). Spirals and palettes are original.
- Community icon cache bumped to **v3** so existing solid squares regenerate. Cleanup still prefix-deletes leftover v1 and v2 keys.

![Generated package fallback icon grid](https://cursor.com/artifacts/c/art-6f744607-b3ee-4a0a-be66-2a631fbd85fc)

## Testing

- `vitest` node-unit: fallback SVG/PNG contract, icon keep/delete at v3, account-deletion KV inventory, R2 prefix list count
- `vitest` workers-unit: cached descriptor version 3
- Visual pass: rasterized a palette grid (friction-log → dusk, github-tools → fog, notion-mcp → sand, plus one of each family). Nothing neon, muddy, or yucky.
- `test:push` (node-unit + workers-unit) on the branch before push

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `fd3b48da` · **Head:** `4a0582ed`

**Classification:** extends — community icon fallback art and the `community-icon:v3` cache/R2 contract change; account-deletion tests and inventory templates follow that version bump.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `community-assets-r2` | storage | extends — fallback bytes and current key version are now v3 swirl WebPs; leftover v1/v2 prefixes still delete |
| `community-listings` | assistant | extends — listings without `community-icon.*` render a name-seeded swirl instead of a solid square |
| `app-ui` | surfaces | composes — account-deletion / R2-prefix tests only |

### Change flow

A listing icon request with no uploaded `community-icon.*` now rasterizes a name-seeded swirl and stores it under the v3 cache keys.

```mermaid
sequenceDiagram
	actor Viewer
	participant appUi as app-ui
	participant communityListings as community-listings
	participant communityAssetsR2 as community-assets-r2
	Viewer->>appUi: GET /@owner/kody-id
	appUi->>communityListings: listing.iconUrl (icon commit)
	communityListings->>communityAssetsR2: miss on community-icon:v3 descriptor
	Note over communityAssetsR2: buildCommunityIconFallbackSvg(name)<br/>Resvg PNG then Images 256 WebP
	communityAssetsR2-->>communityListings: store v3 R2 asset + KV descriptor
	communityListings-->>appUi: serve fitted swirl
```

### Before / after

| | Before | After |
| --- | --- | --- |
| Fallback | hashed solid fill + initials (`<text>`) | name-seeded swirl from 8 analogous palettes, no text |
| KV | `derived-cache:v1:community-icon:v2:{listingId}:{commit}` | `...:v3:{listingId}:{commit}` |
| R2 | `community-icon:v2/{listingId}/{commit}/asset` | `community-icon:v3/{listingId}/{commit}/asset` |
| Cleanup | prefix-delete leftover v1 | leftover v1 and v2 |

### Invariants

Account deletion still prefix-scans listing-owned icon keys only. The extra v3 prefix is the same listing-id ownership boundary.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d2e9331f-8e81-48a9-8bb2-55b7442a5065?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d2e9331f-8e81-48a9-8bb2-55b7442a5065&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deterministic, name-based swirl icons for community packages without supported icon files.
  * Fallback icons can be rendered as SVG or PNG with varied visual palettes.
* **Bug Fixes**
  * Improved account deletion and publishing cleanup to remove legacy community icon data.
  * Updated icon caching to the latest version while preserving compatibility with older entries.
* **Documentation**
  * Clarified fallback icon behavior and supported image formats.
* **Tests**
  * Added coverage for deterministic fallback artwork, PNG output, cache versioning, and cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->