### PR TITLE
Make MCP search retrievers read-only and closed-world

### DIFF
--- a/docs/contributing/packages-and-manifests.md
+++ b/docs/contributing/packages-and-manifests.md
@@ -523,8 +523,10 @@ automatic context retrieval without promoting those records to durable memory.
 - Package metadata is the source of truth; runtime discovery uses derived KV
   manifest and scope indexes that are rebuilt on package refresh
 - Retriever exports reach the package storage bucket through `packageStorage()`
-  (writable, like every packageStorage surface); keeping retrievers read-mostly
-  is a convention
+  in a closed-world, read-only sandbox: they can read granted buckets and return
+  results, but cannot write storage, call `kody.*` capabilities, invoke
+  packages, dispatch events, create workflows, or `fetch` the public internet.
+  Live integration reads and writes belong in `execute` or a package export.
 - Host budgets default to 3s for `search` and 1s for `context` (clamped to 5s /
   3s). Optional enrichment: a timed-out or failing retriever is skipped with a
   warning and must not fail the surrounding MCP `search` / `execute` call

--- a/docs/use/packages.md
+++ b/docs/use/packages.md
@@ -234,8 +234,8 @@ Every saved package owns one durable storage bucket per user
 `packageStorage()` from `kody:runtime`. One rule per context:
 
 - **Writing a saved package?** Use `packageStorage()` for the package's own data
-  — always, including package apps, exports, subscriptions, retrievers, jobs,
-  and workflows.
+  — from package apps, exports, subscriptions, jobs, and workflows. Retrievers
+  can only read granted buckets.
 - **Writing ad hoc `execute` code?** Persist durable state from a saved package
   with `packageStorage()`, or statically import the owning package's export. Ad
   hoc execute has no scratch SQLite helper.
@@ -244,8 +244,8 @@ Every saved package owns one durable storage bucket per user
   `packageStorage()` does the reading and writing.
 
 `packageStorage()` returns `get`/`set`/`list`/`sql`/`delete`/`clear`/`id`,
-writable, always bound to the declaring package's own bucket no matter where the
-code runs:
+writable except in retriever runs, always bound to the declaring package's own
+bucket no matter where the code runs:
 
 - In the package's own export/invocation runtime it is the only way to reach the
   package bucket.

--- a/docs/use/search.md
+++ b/docs/use/search.md
@@ -53,7 +53,9 @@ Pass optional **`domain`** with a capability domain id:
 
 - **With `query`** — ranks only that domain's capabilities. User-owned entities
   (packages, integrations, secrets, retriever results) are excluded because they
-  have no domain.
+  have no domain. Installed-package retrievers run in a read-only, closed-world
+  sandbox: they can read their package storage and return results, but they
+  cannot write, fetch, invoke, or call capabilities.
 - **Without `query`** — lists the domain's capabilities in curated registry
   order (with inlined call shapes for the top hits), which completes the two-hop
   browse flow: broad query → domain overview → domain listing.

--- a/packages/worker/src/mcp-client/hub-client.ts
+++ b/packages/worker/src/mcp-client/hub-client.ts
@@ -158,8 +158,31 @@ export function getCachedMcpClientHubSnapshot(
 	})
 }
 
+function mcpClientHubServersCacheKey(userId: string) {
+	return `${mcpClientHubKey(userId)}:servers`
+}
+
+/**
+ * Server cards only. Does not drain or dispatch connection-subscription
+ * events, so search waiting can stay read-only.
+ */
+export function getCachedMcpClientHubServers(
+	input: Pick<McpClientHubClientInput, 'env' | 'userId'>,
+): Promise<Pick<McpClientHubSnapshot, 'servers'>> {
+	const cacheKey = mcpClientHubServersCacheKey(input.userId)
+	return mcpClientHubSnapshotCache.getOrCreate({
+		cacheKey,
+		create: async () => {
+			const stub = getMcpClientHubStub(input)
+			return await stub.peekServers()
+		},
+	})
+}
+
 export function invalidateMcpClientHubSnapshotCache(input: { userId: string }) {
-	mcpClientHubSnapshotCache.delete(mcpClientHubKey(input.userId))
+	const key = mcpClientHubKey(input.userId)
+	mcpClientHubSnapshotCache.delete(key)
+	mcpClientHubSnapshotCache.delete(mcpClientHubServersCacheKey(input.userId))
 }
 
 export function clearMcpClientHubSnapshotCacheForTests() {

--- a/packages/worker/src/mcp-client/hub-oauth-recovery.node.test.ts
+++ b/packages/worker/src/mcp-client/hub-oauth-recovery.node.test.ts
@@ -484,6 +484,25 @@ test('used and missing callback states recover without exposing an internal stat
 	expect(manager.rows[0]?.auth_url).toContain('state=fresh-2.server-1')
 })
 
+test('peekServers returns cards without observing or reconnecting', async () => {
+	const { state, values } = createDurableObjectState()
+	const hub = new McpClientHub(state, {} as Env)
+	const manager = mockModule.manager
+	if (!manager) throw new Error('Fake manager was not constructed.')
+	const { connection } = await seedReadyHomeServer({ hub, manager })
+	const episodeBefore = values.get('mcp-connection-episode/server-1')
+	connection.connectionState = 'disconnected'
+	manager.connectCount = 0
+	manager.connectBehavior = 'ready'
+
+	const peeked = await hub.peekServers()
+	expect(peeked.servers[0]?.state).toBe('disconnected')
+	expect(manager.connectCount).toBe(0)
+	expect(values.get('mcp-connection-episode/server-1')).toEqual(episodeBefore)
+	expect(values.has('mcp-connection-events-pending')).toBe(false)
+	expect(await hub.takeConnectionEvents()).toEqual([])
+})
+
 test('snapshot retries a previously ready server before emitting disconnect', async () => {
 	const { state, values } = createDurableObjectState()
 	const hub = new McpClientHub(state, {} as Env)

--- a/packages/worker/src/mcp-client/hub.ts
+++ b/packages/worker/src/mcp-client/hub.ts
@@ -579,7 +579,7 @@ class McpClientHubBase extends DurableObject<Env> {
 		return this.buildConnectResult(serverId)
 	}
 
-	async getSnapshot(): Promise<McpClientHubSnapshot> {
+	private async collectServerSnapshots(): Promise<Array<McpServerSnapshot>> {
 		await this.ensureRestored()
 		await this.manager.waitForConnections({
 			timeout: connectionSettleTimeoutMs,
@@ -590,11 +590,26 @@ class McpClientHubBase extends DurableObject<Env> {
 				serverName: row.name,
 			})
 		}
+		return this.manager
+			.listServers()
+			.map((row) => this.buildServerSnapshot(row))
+	}
+
+	async getSnapshot(): Promise<McpClientHubSnapshot> {
 		return {
-			servers: this.manager
-				.listServers()
-				.map((row) => this.buildServerSnapshot(row)),
+			servers: await this.collectServerSnapshots(),
 			connectionEvents: await this.takeConnectionEvents(),
+		}
+	}
+
+	/**
+	 * Current server cards without draining pending connection events.
+	 * Read-only callers (search waiting) use this so a cache miss cannot
+	 * dispatch package subscriptions.
+	 */
+	async peekServers(): Promise<Pick<McpClientHubSnapshot, 'servers'>> {
+		return {
+			servers: await this.collectServerSnapshots(),
 		}
 	}
 

--- a/packages/worker/src/mcp-client/hub.ts
+++ b/packages/worker/src/mcp-client/hub.ts
@@ -579,20 +579,28 @@ class McpClientHubBase extends DurableObject<Env> {
 		return this.buildConnectResult(serverId)
 	}
 
-	private async collectServerSnapshots(): Promise<Array<McpServerSnapshot>> {
+	private async restoreAndWaitForServers() {
 		await this.ensureRestored()
 		await this.manager.waitForConnections({
 			timeout: connectionSettleTimeoutMs,
 		})
+	}
+
+	private listServerCards(): Array<McpServerSnapshot> {
+		return this.manager
+			.listServers()
+			.map((row) => this.buildServerSnapshot(row))
+	}
+
+	private async collectServerSnapshots(): Promise<Array<McpServerSnapshot>> {
+		await this.restoreAndWaitForServers()
 		for (const row of this.manager.listServers()) {
 			await this.observeServer({
 				serverId: row.id,
 				serverName: row.name,
 			})
 		}
-		return this.manager
-			.listServers()
-			.map((row) => this.buildServerSnapshot(row))
+		return this.listServerCards()
 	}
 
 	async getSnapshot(): Promise<McpClientHubSnapshot> {
@@ -603,13 +611,14 @@ class McpClientHubBase extends DurableObject<Env> {
 	}
 
 	/**
-	 * Current server cards without draining pending connection events.
-	 * Read-only callers (search waiting) use this so a cache miss cannot
-	 * dispatch package subscriptions.
+	 * Current server cards without observing, reconnecting, or draining
+	 * pending connection events. Search waiting uses this so a cache miss
+	 * cannot write episode state or later dispatch package subscriptions.
 	 */
 	async peekServers(): Promise<Pick<McpClientHubSnapshot, 'servers'>> {
+		await this.restoreAndWaitForServers()
 		return {
-			servers: await this.collectServerSnapshots(),
+			servers: this.listServerCards(),
 		}
 	}
 

--- a/packages/worker/src/mcp/executor.ts
+++ b/packages/worker/src/mcp/executor.ts
@@ -16,6 +16,7 @@ import { exports as workerExports } from 'cloudflare:workers'
 import { AsyncLocalStorage } from 'node:async_hooks'
 import {
 	outboundFetchTimeoutMsForExecutor,
+	retrieverOutboundFetchDeniedMessage,
 	type FetchGatewayProps,
 } from '#mcp/fetch-gateway.ts'
 import {
@@ -578,6 +579,8 @@ export function createKodyRemoteProxy(input: {
 	})
 }
 
+export { retrieverOutboundFetchDeniedMessage }
+
 export function createExecuteExecutor(input: {
 	env: Env
 	exports?: WorkerLoopbackExports
@@ -598,7 +601,13 @@ export function createExecuteExecutor(input: {
 	 * Defaults to true for ad-hoc executor callers.
 	 */
 	recordExecuteUsage?: boolean
+	/**
+	 * When false, sandbox `fetch` is rejected. Retriever runs use this to stay
+	 * closed-world. Defaults to true.
+	 */
+	allowOutboundFetch?: boolean
 }) {
+	const allowOutboundFetch = input.allowOutboundFetch !== false
 	const loopbackExports = input.exports ?? workerExports
 	if (!loopbackExports?.KodyFetchGateway) {
 		throw new Error(
@@ -612,6 +621,7 @@ export function createExecuteExecutor(input: {
 	const gatewayProps = {
 		...input.gatewayProps,
 		outboundFetchTimeoutMs: outboundFetchTimeoutMsForExecutor(timeout),
+		allowOutboundFetch,
 	}
 	return createStableDynamicWorkerExecutor({
 		loader: input.env.LOADER,

--- a/packages/worker/src/mcp/fetch-gateway.node.test.ts
+++ b/packages/worker/src/mcp/fetch-gateway.node.test.ts
@@ -1105,20 +1105,29 @@ test('fetch gateway aborts hung outbound fetches via timeoutMs or outboundFetchT
 })
 
 test('executeGatewayFetch rejects when allowOutboundFetch is false', async () => {
+	const usageModule = await import('#worker/usage/record-usage.ts')
+	const recordUsageSpy = vi
+		.spyOn(usageModule, 'recordUsage')
+		.mockResolvedValue(undefined)
 	const globalFetch = vi.fn(async () => new Response('ok'))
-	await expect(
-		executeGatewayFetch({
-			env,
-			props: {
-				baseUrl: 'https://kody.example',
-				userId: 'user-123',
-				email: 'user@example.com',
-				storageContext: null,
-				allowOutboundFetch: false,
-			},
-			request: new Request('https://example.com'),
-			globalFetch: globalFetch as unknown as typeof fetch,
-		}),
-	).rejects.toThrow('Outbound fetch is not available in retriever runs.')
-	expect(globalFetch).not.toHaveBeenCalled()
+	try {
+		await expect(
+			executeGatewayFetch({
+				env,
+				props: {
+					baseUrl: 'https://kody.example',
+					userId: 'user-123',
+					email: 'user@example.com',
+					storageContext: null,
+					allowOutboundFetch: false,
+				},
+				request: new Request('https://example.com'),
+				globalFetch: globalFetch as unknown as typeof fetch,
+			}),
+		).rejects.toThrow('Outbound fetch is not available in retriever runs.')
+		expect(globalFetch).not.toHaveBeenCalled()
+		expect(recordUsageSpy).not.toHaveBeenCalled()
+	} finally {
+		recordUsageSpy.mockRestore()
+	}
 })

--- a/packages/worker/src/mcp/fetch-gateway.node.test.ts
+++ b/packages/worker/src/mcp/fetch-gateway.node.test.ts
@@ -1103,3 +1103,22 @@ test('fetch gateway aborts hung outbound fetches via timeoutMs or outboundFetchT
 	expect(propsTimeout).toHaveBeenCalledTimes(1)
 	expect(propsTimeout.mock.calls[0]?.[0]?.signal.aborted).toBe(true)
 })
+
+test('executeGatewayFetch rejects when allowOutboundFetch is false', async () => {
+	const globalFetch = vi.fn(async () => new Response('ok'))
+	await expect(
+		executeGatewayFetch({
+			env,
+			props: {
+				baseUrl: 'https://kody.example',
+				userId: 'user-123',
+				email: 'user@example.com',
+				storageContext: null,
+				allowOutboundFetch: false,
+			},
+			request: new Request('https://example.com'),
+			globalFetch: globalFetch as unknown as typeof fetch,
+		}),
+	).rejects.toThrow('Outbound fetch is not available in retriever runs.')
+	expect(globalFetch).not.toHaveBeenCalled()
+})

--- a/packages/worker/src/mcp/fetch-gateway.ts
+++ b/packages/worker/src/mcp/fetch-gateway.ts
@@ -50,6 +50,11 @@ type FetchGatewayProps = {
 	 * budget. `null` disables the gateway timeout (caller signal only).
 	 */
 	outboundFetchTimeoutMs?: number | null
+	/**
+	 * When false, every sandbox `fetch` is rejected. Retriever runs use
+	 * this to stay closed-world. Defaults to true.
+	 */
+	allowOutboundFetch?: boolean
 }
 export type { FetchGatewayProps }
 
@@ -118,6 +123,9 @@ export function outboundFetchTimeoutMsForExecutor(executorTimeoutMs: number) {
 	return Math.max(defaultOutboundFetchTimeoutMs, derived)
 }
 
+export const retrieverOutboundFetchDeniedMessage =
+	'Outbound fetch is not available in retriever runs.'
+
 export class KodyFetchGateway extends WorkerEntrypoint<Env, FetchGatewayProps> {
 	async fetch(request: Request) {
 		return executeGatewayFetch({
@@ -177,6 +185,9 @@ export async function executeGatewayFetch(input: {
 	})
 
 	try {
+		if (input.props.allowOutboundFetch === false) {
+			throw new Error(retrieverOutboundFetchDeniedMessage)
+		}
 		// Daily outbound-fetch quota: every sandbox fetch leaves through
 		// this gateway, so the atomic counter here bounds cost abuse and
 		// third-party hammering from user code. Consumed before secret

--- a/packages/worker/src/mcp/fetch-gateway.ts
+++ b/packages/worker/src/mcp/fetch-gateway.ts
@@ -235,7 +235,7 @@ export async function executeGatewayFetch(input: {
 		outcome = 'error'
 		throw error
 	} finally {
-		if (input.props.userId) {
+		if (input.props.allowOutboundFetch !== false && input.props.userId) {
 			const usageEvent = {
 				userId: input.props.userId,
 				eventType: 'outbound_fetch' as const,

--- a/packages/worker/src/mcp/onboarding-checklist.node.test.ts
+++ b/packages/worker/src/mcp/onboarding-checklist.node.test.ts
@@ -138,6 +138,59 @@ test('checklist connect-integration completes from a saved MCP server without OA
 	expect(doneById['install-starter']).toBe(false)
 })
 
+test('search onboarding notice does not write dismissal when the checklist is complete', async () => {
+	const { env } = createEnv()
+	await seedUser(env.APP_DB)
+	await env.APP_DB.prepare(
+		`INSERT INTO mcp_server_settings (id, user_id, name, url, enabled, created_at, updated_at)
+		 VALUES (?, ?, 'notion', 'https://mcp.notion.com/mcp', 1, ?, ?)`,
+	)
+		.bind(
+			'srv-notion',
+			userId,
+			'2026-08-01T00:00:00.000Z',
+			'2026-08-01T00:00:00.000Z',
+		)
+		.run()
+	await env.APP_DB.prepare(
+		`INSERT INTO entity_sources (
+			id, user_id, entity_kind, entity_id, repo_id, manifest_path, source_root, created_at, updated_at
+		) VALUES (?, ?, 'package', ?, ?, 'package.json', '.', ?, ?)`,
+	)
+		.bind(
+			'source-1',
+			userId,
+			'pkg-1',
+			'repo-1',
+			'2026-08-01T00:00:00.000Z',
+			'2026-08-01T00:00:00.000Z',
+		)
+		.run()
+	await env.APP_DB.prepare(
+		`INSERT INTO saved_packages (
+			id, user_id, name, kody_id, description, source_id, created_at, updated_at
+		) VALUES (?, ?, '@user/starter', 'starter', 'Starter', ?, ?, ?)`,
+	)
+		.bind(
+			'pkg-1',
+			userId,
+			'source-1',
+			'2026-08-01T00:00:00.000Z',
+			'2026-08-01T00:00:00.000Z',
+		)
+		.run()
+
+	expect(
+		await buildOnboardingSearchNotice({
+			env,
+			userId,
+			baseUrl: 'https://kody.example',
+		}),
+	).toBe(null)
+	expect(await readOnboardingChecklistDismissed({ env, userId })).toBe(false)
+	expect(await readDismissedAt(env.APP_DB)).toBe(null)
+})
+
 test('search onboarding notice points at /onboarding and goes quiet after dismissal', async () => {
 	const { env } = createEnv()
 	await seedUser(env.APP_DB)

--- a/packages/worker/src/mcp/run-kody-registry-bundled.node.test.ts
+++ b/packages/worker/src/mcp/run-kody-registry-bundled.node.test.ts
@@ -336,6 +336,81 @@ test('runBundledModuleWithRegistry passes params and injects runtime helpers', a
 	}
 })
 
+test('closed-world retriever runtime skips capabilities, workflows, invoke, and outbound fetch', async () => {
+	silenceIncidentalRuntimeWarnings()
+	const env = {} as Env
+	const callerContext = createMcpCallerContext({
+		baseUrl: 'https://heykody.dev',
+		user: { userId: 'user-123' },
+	})
+	const bundle = {
+		mainModule: 'entry.js',
+		modules: {
+			'entry.js': 'export default async () => "ok"',
+		},
+	}
+	const getRegistrySpy = vi
+		.spyOn(
+			await import('#mcp/capabilities/registry.ts'),
+			'getCapabilityRegistryForContext',
+		)
+		.mockResolvedValue({} as never)
+	let executorInput: { allowOutboundFetch?: boolean } | null = null
+	let providerFns: Record<string, (args: unknown) => Promise<unknown>> | null =
+		null
+	const createExecuteExecutorSpy = vi
+		.spyOn(await import('#mcp/executor.ts'), 'createExecuteExecutor')
+		.mockImplementation((input) => {
+			executorInput = input
+			return {
+				async execute(_source, providers) {
+					providerFns = (
+						providers[0] as {
+							fns: Record<string, (args: unknown) => Promise<unknown>>
+						}
+					).fns
+					return {
+						result: 'ok',
+						logs: [],
+					}
+				},
+			} as never
+		})
+
+	try {
+		const result = await runBundledModuleWithRegistry(
+			env,
+			callerContext,
+			bundle,
+			undefined,
+			{
+				closedWorldRetrieverRuntime: true,
+				packageContext: {
+					packageId: 'pkg-1',
+					kodyId: 'notes',
+					sourceId: 'source-1',
+				},
+				packageInvokeTools: {
+					invoke: async () => {
+						throw new Error('invoke should not be bound')
+					},
+				},
+			},
+		)
+		expect(result.result).toBe('ok')
+		expect(getRegistrySpy).not.toHaveBeenCalled()
+		expect(executorInput?.allowOutboundFetch).toBe(false)
+		expect(providerFns?.packageWorkflowCreate).toBeUndefined()
+		expect(providerFns?.emailSend).toBeUndefined()
+		await expect(providerFns?.packageStorageSet?.({})).rejects.toThrow(
+			'packageStorage() is read-only during retriever runs',
+		)
+	} finally {
+		createExecuteExecutorSpy.mockRestore()
+		getRegistrySpy.mockRestore()
+	}
+})
+
 test('runBundledModuleWithRegistry uses a prebuilt capability registry without reloading', async () => {
 	silenceIncidentalRuntimeWarnings()
 	const env = {} as Env

--- a/packages/worker/src/mcp/run-kody-registry-bundled.node.test.ts
+++ b/packages/worker/src/mcp/run-kody-registry-bundled.node.test.ts
@@ -336,7 +336,7 @@ test('runBundledModuleWithRegistry passes params and injects runtime helpers', a
 	}
 })
 
-test('closed-world retriever runtime skips capabilities, workflows, invoke, and outbound fetch', async () => {
+test('closed-world retriever runtime skips capabilities, hub snapshots, workflows, invoke, and outbound fetch', async () => {
 	silenceIncidentalRuntimeWarnings()
 	const env = {} as Env
 	const callerContext = createMcpCallerContext({
@@ -355,6 +355,18 @@ test('closed-world retriever runtime skips capabilities, workflows, invoke, and 
 			'getCapabilityRegistryForContext',
 		)
 		.mockResolvedValue({} as never)
+	const listMcpServerRefsSpy = vi
+		.spyOn(
+			await import('#worker/mcp-client/settings-service.ts'),
+			'listVisibleEnabledMcpServerRefsCached',
+		)
+		.mockResolvedValue([])
+	const getHubSnapshotSpy = vi
+		.spyOn(
+			await import('#worker/mcp-client/hub-client.ts'),
+			'getCachedMcpClientHubSnapshot',
+		)
+		.mockResolvedValue({ servers: [] })
 	let executorInput: { allowOutboundFetch?: boolean } | null = null
 	let providerFns: Record<string, (args: unknown) => Promise<unknown>> | null =
 		null
@@ -399,6 +411,8 @@ test('closed-world retriever runtime skips capabilities, workflows, invoke, and 
 		)
 		expect(result.result).toBe('ok')
 		expect(getRegistrySpy).not.toHaveBeenCalled()
+		expect(listMcpServerRefsSpy).not.toHaveBeenCalled()
+		expect(getHubSnapshotSpy).not.toHaveBeenCalled()
 		expect(executorInput?.allowOutboundFetch).toBe(false)
 		expect(providerFns?.packageWorkflowCreate).toBeUndefined()
 		expect(providerFns?.emailSend).toBeUndefined()
@@ -408,6 +422,8 @@ test('closed-world retriever runtime skips capabilities, workflows, invoke, and 
 	} finally {
 		createExecuteExecutorSpy.mockRestore()
 		getRegistrySpy.mockRestore()
+		listMcpServerRefsSpy.mockRestore()
+		getHubSnapshotSpy.mockRestore()
 	}
 })
 

--- a/packages/worker/src/mcp/run-kody-registry.ts
+++ b/packages/worker/src/mcp/run-kody-registry.ts
@@ -616,6 +616,12 @@ export async function runBundledModuleWithRegistry(
 		packageInvokeTools?: PackageInvokeTools
 		packageEventTools?: PackageEventTools
 		skipCapabilityRegistry?: boolean
+		/**
+		 * Retriever enrichment profile: no capability map, no workflows,
+		 * no package invoke/events, read-only packageStorage, no outbound
+		 * fetch. Search annotations depend on this being a runtime constraint.
+		 */
+		closedWorldRetrieverRuntime?: boolean
 		executorTimeoutMs?: number | null
 		signal?: AbortSignal
 		runRecord?: RunRecordContext | null
@@ -783,6 +789,8 @@ export async function runBundledModuleWithRegistry(
 					.filter((packageId): packageId is string => Boolean(packageId)),
 			),
 		})
+		const closedWorldRetrieverRuntime =
+			options?.closedWorldRetrieverRuntime === true
 		const executor = createExecuteExecutor({
 			env,
 			exports: options?.executorExports ?? workerExports,
@@ -803,20 +811,25 @@ export async function runBundledModuleWithRegistry(
 				surface: options?.runRecord?.surface,
 				hasPackageContext: Boolean(options?.packageContext),
 			}),
+			allowOutboundFetch: !closedWorldRetrieverRuntime,
 		})
-		const workflowTools =
-			options?.workflowTools ??
-			createWorkflowTools({
-				env,
-				callerContext,
-				packageContext: options?.packageContext ?? null,
-			})
+		const workflowTools = closedWorldRetrieverRuntime
+			? undefined
+			: (options?.workflowTools ??
+				createWorkflowTools({
+					env,
+					callerContext,
+					packageContext: options?.packageContext ?? null,
+				}))
 		// Register the package_storage_* tools whenever the run has a user, even
 		// with an empty grant set: an unauthorized packageStorage() call then
 		// fails with the structured provenance message instead of a bare
 		// missing-capability TypeError.
 		const packageStorageTools = callerContext.user?.userId
-			? { grantedPackageIds: grantedPackageStorageIds }
+			? {
+					grantedPackageIds: grantedPackageStorageIds,
+					writable: !closedWorldRetrieverRuntime,
+				}
 			: undefined
 		const packageSecretTools = options?.packageContext
 			? createPackageSecretTools({
@@ -832,10 +845,13 @@ export async function runBundledModuleWithRegistry(
 			additionalTools: options?.additionalTools,
 			packageStorageTools,
 			packageSecretTools,
-			emailTools: options?.emailTools,
+			emailTools: closedWorldRetrieverRuntime ? undefined : options?.emailTools,
 			workflowTools,
-			skipCapabilityRegistry: options?.skipCapabilityRegistry,
-			capabilityRegistry: options?.capabilityRegistry,
+			skipCapabilityRegistry:
+				closedWorldRetrieverRuntime || options?.skipCapabilityRegistry,
+			capabilityRegistry: closedWorldRetrieverRuntime
+				? undefined
+				: options?.capabilityRegistry,
 			reportProgress,
 			waitUntil: options?.waitUntil,
 		})
@@ -850,10 +866,14 @@ export async function runBundledModuleWithRegistry(
 			provider,
 			packageStorageTools,
 			packageSecretTools,
-			emailTools: options?.emailTools,
+			emailTools: closedWorldRetrieverRuntime ? undefined : options?.emailTools,
 			workflowTools,
-			packageInvokeTools: options?.packageInvokeTools,
-			packageEventTools: options?.packageEventTools,
+			packageInvokeTools: closedWorldRetrieverRuntime
+				? undefined
+				: options?.packageInvokeTools,
+			packageEventTools: closedWorldRetrieverRuntime
+				? undefined
+				: options?.packageEventTools,
 			staticCallMeterTools,
 		}
 		const runtimeHelperPreludes =

--- a/packages/worker/src/mcp/run-kody-registry.ts
+++ b/packages/worker/src/mcp/run-kody-registry.ts
@@ -242,11 +242,16 @@ async function buildKodyToolContext(
 						callerContext,
 					})
 				).capabilityMap
-	const mcpServers = await buildKodyMcpServerMetadata({
-		env,
-		callerContext,
-		capabilityMap,
-	})
+	// Closed-world / registry-skipped runs have no kody.mcp capabilities.
+	// Assembling server metadata still lists enabled servers and, on a hub
+	// cache miss, drains connection events into package subscriptions.
+	const mcpServers = options?.skipCapabilityRegistry
+		? []
+		: await buildKodyMcpServerMetadata({
+				env,
+				callerContext,
+				capabilityMap,
+			})
 	const additionalTools = options?.additionalTools ?? {}
 	assertNoCapabilityCollisions(capabilityMap, additionalTools)
 	const capabilityKodyTools = Object.fromEntries(

--- a/packages/worker/src/mcp/runtime-helper-manifest.ts
+++ b/packages/worker/src/mcp/runtime-helper-manifest.ts
@@ -32,6 +32,12 @@ export type PackageStorageToolOptions = {
 	 * `collectPackageStorageGrantIds`.
 	 */
 	grantedPackageIds: ReadonlySet<string>
+	/**
+	 * Defaults to writable. Retriever runs set this to false so the sandbox
+	 * can read granted buckets but cannot set, delete, clear, or run mutating
+	 * SQL.
+	 */
+	writable?: boolean
 }
 
 export type PackageSecretToolOptions = {
@@ -451,7 +457,10 @@ const runtimeHelperManifest: Array<RuntimeHelperManifestEntry> = [
 		],
 		unboundNames: [],
 		isBound: (context) => Boolean(context.packageStorageTools),
-		createPrelude: () => createPackageStorageHelperPrelude(),
+		createPrelude: (context) =>
+			createPackageStorageHelperPrelude({
+				writable: context.packageStorageTools?.writable !== false,
+			}),
 		createKodyTools: (context) => {
 			const packageStorageTools = context.packageStorageTools
 			const packageStorageUserId = context.callerContext.user?.userId ?? ''
@@ -461,6 +470,7 @@ const runtimeHelperManifest: Array<RuntimeHelperManifestEntry> = [
 				userId: packageStorageUserId,
 				email: context.callerContext.user?.email,
 				grantedPackageIds: packageStorageTools.grantedPackageIds,
+				writable: packageStorageTools.writable,
 			})
 		},
 	},

--- a/packages/worker/src/mcp/tools/search-onboarding-notice.ts
+++ b/packages/worker/src/mcp/tools/search-onboarding-notice.ts
@@ -1,16 +1,15 @@
 import { onboardingChecklistSearchLabels } from '#universal/onboarding-process.ts'
 import {
 	deriveOnboardingChecklist,
-	dismissOnboardingChecklist,
 	readOnboardingChecklistDismissed,
 } from '#mcp/onboarding-checklist.ts'
 
 /**
  * One-line onboarding reminder appended to `search` notices, at most once per
  * conversation (the runner tracks shown conversations in agent state) and
- * only while the derived checklist is incomplete and undismissed. When the
- * checklist completes, the dismissal column is written automatically so
- * established accounts stop paying the derivation on new conversations.
+ * only while the derived checklist is incomplete and undismissed. Search does
+ * not write the dismissal column; that stays on `/onboarding` so search can
+ * stay read-only.
  */
 
 const itemLabels = onboardingChecklistSearchLabels
@@ -20,7 +19,6 @@ export async function buildOnboardingSearchNotice(input: {
 	userId: string
 	/** Deployment origin for the details link, e.g. https://kody.codes */
 	baseUrl: string
-	waitUntil?: (promise: Promise<unknown>) => void
 }): Promise<string | null> {
 	try {
 		const dismissed = await readOnboardingChecklistDismissed({
@@ -37,12 +35,6 @@ export async function buildOnboardingSearchNotice(input: {
 			hasMcpClient: true,
 		})
 		if (checklist.complete) {
-			const retire = dismissOnboardingChecklist({
-				env: input.env,
-				userId: input.userId,
-			}).catch(() => {})
-			if (input.waitUntil) input.waitUntil(retire)
-			else await retire
 			return null
 		}
 

--- a/packages/worker/src/mcp/tools/search-tool-runner.ts
+++ b/packages/worker/src/mcp/tools/search-tool-runner.ts
@@ -428,7 +428,6 @@ export async function runSearchTool(input: {
 				env: agent.getEnv(),
 				userId,
 				baseUrl,
-				waitUntil: agent.waitUntil?.bind(agent),
 			})
 			if (notice) {
 				structuredWarnings.push(notice)

--- a/packages/worker/src/mcp/waiting/derive-waiting.ts
+++ b/packages/worker/src/mcp/waiting/derive-waiting.ts
@@ -4,7 +4,7 @@ import {
 	readOnboardingChecklistDismissed,
 } from '#mcp/onboarding-checklist.ts'
 import { listSecrets } from '#mcp/secrets/service.ts'
-import { getCachedMcpClientHubSnapshot } from '#worker/mcp-client/hub-client.ts'
+import { getCachedMcpClientHubServers } from '#worker/mcp-client/hub-client.ts'
 import { type McpClientHubSnapshot } from '#worker/mcp-client/types.ts'
 import { listMcpServerSettings } from '#worker/mcp-client/settings-service.ts'
 import { listSavedPackagesByUserId } from '#worker/package-registry/repo.ts'
@@ -165,9 +165,9 @@ async function collectMcpServerSignals(
 	const enabled = settings.filter((server) => server.enabled)
 	if (enabled.length === 0) return []
 
-	let snapshot: McpClientHubSnapshot
+	let snapshot: Pick<McpClientHubSnapshot, 'servers'>
 	try {
-		snapshot = await getCachedMcpClientHubSnapshot({
+		snapshot = await getCachedMcpClientHubServers({
 			env,
 			userId,
 		})

--- a/packages/worker/src/package-retrievers/closed-world-runtime.workers.test.ts
+++ b/packages/worker/src/package-retrievers/closed-world-runtime.workers.test.ts
@@ -1,0 +1,113 @@
+import { env } from 'cloudflare:workers'
+import { expect, test } from 'vitest'
+import { createMcpCallerContext } from '#mcp/context.ts'
+import { runBundledModuleWithRegistry } from '#mcp/run-kody-registry.ts'
+import { retrieverOutboundFetchDeniedMessage } from '#mcp/executor.ts'
+import { ensureEntitlementTestSchema } from '#worker/entitlements/test-schema.ts'
+import { buildKodyModuleBundle } from '#worker/package-runtime/module-graph.ts'
+import { buildPackageStorageId } from '#worker/storage-ids.ts'
+import {
+	packageStorageRetrieverReadOnlyMessage,
+	storageRunnerRpc,
+} from '#worker/storage-runner.ts'
+import { silenceIncidentalRuntimeWarnings } from '#worker/test-support/incidental-runtime-warnings.ts'
+
+test(
+	'closed-world retriever runtime can read packageStorage but cannot write, fetch, or bind write helpers',
+	{ timeout: 90_000 },
+	async () => {
+		silenceIncidentalRuntimeWarnings()
+		await ensureEntitlementTestSchema(env.APP_DB)
+		const userId = `user-${crypto.randomUUID()}`
+		const packageId = crypto.randomUUID()
+		await storageRunnerRpc({
+			env,
+			userId,
+			storageId: buildPackageStorageId(packageId),
+		}).setValue({
+			key: 'seed',
+			value: 'hello',
+		})
+		const callerContext = createMcpCallerContext({
+			baseUrl: 'https://kody.dev',
+			user: {
+				userId,
+				email: 'retriever@example.com',
+				displayName: 'Retriever',
+			},
+		})
+		const bundle = await buildKodyModuleBundle({
+			env,
+			baseUrl: 'https://kody.dev',
+			userId,
+			sourceFiles: {
+				'entry.ts': [
+					"import { packageStorage, packages, events, workflows } from 'kody:runtime'",
+					'export default async function main() {',
+					'\tconst bucket = packageStorage()',
+					"\tconst read = await bucket.get('seed')",
+					'\tlet writeError = null',
+					'\ttry {',
+					"\t\tawait bucket.set('next', 'nope')",
+					'\t} catch (error) {',
+					'\t\twriteError = error instanceof Error ? error.message : String(error)',
+					'\t}',
+					'\tlet sqlError = null',
+					'\ttry {',
+					"\t\tawait bucket.sql('create table if not exists notes (name text)')",
+					'\t} catch (error) {',
+					'\t\tsqlError = error instanceof Error ? error.message : String(error)',
+					'\t}',
+					'\tlet fetchError = null',
+					'\ttry {',
+					"\t\tawait fetch('https://example.com')",
+					'\t} catch (error) {',
+					'\t\tfetchError = error instanceof Error ? error.message : String(error)',
+					'\t}',
+					'\treturn {',
+					'\t\tread,',
+					'\t\twriteError,',
+					'\t\tsqlError,',
+					'\t\tfetchError,',
+					'\t\tpackagesBound: packages != null,',
+					'\t\teventsBound: events != null,',
+					'\t\tworkflowsBound: workflows != null,',
+					'\t}',
+					'}',
+				].join('\n'),
+			},
+			entryPoint: 'entry.ts',
+		})
+		const result = await runBundledModuleWithRegistry(
+			env,
+			callerContext,
+			bundle,
+			undefined,
+			{
+				closedWorldRetrieverRuntime: true,
+				packageContext: {
+					packageId,
+					kodyId: 'notes',
+					sourceId: 'source-notes',
+				},
+			},
+		)
+		expect(result.error).toBeUndefined()
+		expect(result.result).toEqual({
+			read: 'hello',
+			writeError: packageStorageRetrieverReadOnlyMessage,
+			sqlError: expect.stringMatching(/Read-only storage\.sql/i),
+			fetchError: retrieverOutboundFetchDeniedMessage,
+			packagesBound: false,
+			eventsBound: false,
+			workflowsBound: false,
+		})
+		expect(
+			await storageRunnerRpc({
+				env,
+				userId,
+				storageId: buildPackageStorageId(packageId),
+			}).getValue({ key: 'next' }),
+		).toMatchObject({ value: null })
+	},
+)

--- a/packages/worker/src/package-retrievers/service.node.test.ts
+++ b/packages/worker/src/package-retrievers/service.node.test.ts
@@ -7,8 +7,6 @@ const mockFns = vi.hoisted(() => ({
 	listPackageRetrieversForScope: vi.fn(),
 	loadPublishedBundleArtifactByIdentity: vi.fn(),
 	runBundledModuleWithRegistry: vi.fn(),
-	createPackageEventTools: vi.fn(() => ({})),
-	createPackageRuntimeInvokeTools: vi.fn(() => ({})),
 }))
 
 vi.mock('#worker/package-registry/repo.ts', () => ({
@@ -30,11 +28,6 @@ vi.mock('#worker/package-runtime/published-bundle-artifacts.ts', () => ({
 
 vi.mock('#mcp/run-kody-registry.ts', () => ({
 	runBundledModuleWithRegistry: mockFns.runBundledModuleWithRegistry,
-}))
-
-vi.mock('#worker/package-invocations/service.ts', () => ({
-	createPackageEventTools: mockFns.createPackageEventTools,
-	createPackageRuntimeInvokeTools: mockFns.createPackageRuntimeInvokeTools,
 }))
 
 vi.mock('#worker/identity/background-mcp-user.ts', () => ({
@@ -192,7 +185,10 @@ test('runPackageRetrievers soft-fails a timed-out retriever and keeps healthy re
 		expect(call[4]).toEqual(
 			expect.objectContaining({
 				executorTimeoutMs: 2_500,
+				closedWorldRetrieverRuntime: true,
 			}),
 		)
+		expect(call[4]).not.toHaveProperty('packageInvokeTools')
+		expect(call[4]).not.toHaveProperty('packageEventTools')
 	}
 })

--- a/packages/worker/src/package-retrievers/service.ts
+++ b/packages/worker/src/package-retrievers/service.ts
@@ -173,19 +173,6 @@ async function invokeRetriever(input: {
 			limit,
 		},
 	}
-	// Avoid a top-level package-retrievers -> package-invocations cycle during
-	// capability registry initialization.
-	const { createPackageEventTools, createPackageRuntimeInvokeTools } =
-		await import('#worker/package-invocations/service.ts')
-	const packageRuntimeToolsInput = {
-		env: input.env,
-		baseUrl: input.baseUrl,
-		callerContext,
-		packageContext,
-		parentRunRecord: runRecord,
-		packageInvokeDepth: 0,
-		waitUntil: input.waitUntil,
-	}
 	const executionResult = await runBundledModuleWithRegistry(
 		input.env,
 		callerContext,
@@ -202,18 +189,12 @@ async function invokeRetriever(input: {
 			conversationId: input.conversationId ?? null,
 		},
 		{
-			// No ambient `storage` binding: retriever code reaches the package
-			// bucket via `packageStorage()` (granted through packageContext
-			// below). The old read-only ambient binding constrained only the
-			// ambient helper — `packageStorage()` has been writable in retriever
-			// context since it shipped — so retrievers staying read-mostly is a
-			// convention, not a runtime constraint.
+			// Retrievers enrich search/context. The closed-world profile is a
+			// runtime constraint: read-only packageStorage, no capability map,
+			// no invoke/events/workflows, no outbound fetch.
 			packageContext,
 			runRecord,
-			packageInvokeTools: createPackageRuntimeInvokeTools(
-				packageRuntimeToolsInput,
-			),
-			packageEventTools: createPackageEventTools(packageRuntimeToolsInput),
+			closedWorldRetrieverRuntime: true,
 			executorTimeoutMs: clampTimeout(input.entry.timeoutMs, input.scope),
 			waitUntil: input.waitUntil,
 		},

--- a/packages/worker/src/storage-runner.package-storage-prelude.node.test.ts
+++ b/packages/worker/src/storage-runner.package-storage-prelude.node.test.ts
@@ -1,0 +1,12 @@
+import { expect, test } from 'vitest'
+import { createPackageStorageHelperPrelude } from './storage-runner.ts'
+
+test('packageStorage prelude is writable by default and read-only for retrievers', () => {
+	expect(createPackageStorageHelperPrelude()).toContain('writable: true')
+	expect(createPackageStorageHelperPrelude({ writable: true })).toContain(
+		'writable: true',
+	)
+	expect(createPackageStorageHelperPrelude({ writable: false })).toContain(
+		'writable: false',
+	)
+})

--- a/packages/worker/src/storage-runner.ts
+++ b/packages/worker/src/storage-runner.ts
@@ -1209,17 +1209,22 @@ export function createPackageStorageAccessDeniedMessage(packageId: string) {
  * installed packages' buckets. Cross-user access is structurally impossible:
  * `storageRunnerDurableObjectName` keys the durable object on this run's user id.
  */
+export const packageStorageRetrieverReadOnlyMessage =
+	'packageStorage() is read-only during retriever runs. Persist writes from an export, job, or execute call.'
+
 export function createPackageStorageKodyTools(input: {
 	env: Env
 	userId: string
 	email?: string | null
 	grantedPackageIds: ReadonlySet<string>
+	writable?: boolean
 }) {
+	const writable = input.writable !== false
 	// One cache for the whole sandbox so nested packageStorage() SQL across
 	// granted packages (and repeated CREATE/INSERT in one export) does not
 	// rescan every inventoried bucket on each statement.
 	const entitlementCache = createStorageBytesEntitlementRunCache()
-	const createWritableStorageTools = (packageId: string) => {
+	const createGrantedStorageTools = (packageId: string) => {
 		const {
 			storageGet,
 			storageList,
@@ -1232,10 +1237,10 @@ export function createPackageStorageKodyTools(input: {
 			userId: input.userId,
 			email: input.email,
 			storageId: buildPackageStorageId(packageId),
-			writable: true,
+			writable,
 			entitlementCache,
 		})
-		if (!storageSet || !storageDelete || !storageClear) {
+		if (writable && (!storageSet || !storageDelete || !storageClear)) {
 			// createStorageKodyTools only omits these when writable is false.
 			throw new Error('Writable package storage tools are missing writes.')
 		}
@@ -1250,7 +1255,7 @@ export function createPackageStorageKodyTools(input: {
 	}
 	const toolsByPackageId = new Map<
 		string,
-		ReturnType<typeof createWritableStorageTools>
+		ReturnType<typeof createGrantedStorageTools>
 	>()
 	const resolveTools = (args: unknown) => {
 		const packageId =
@@ -1265,10 +1270,13 @@ export function createPackageStorageKodyTools(input: {
 		}
 		let tools = toolsByPackageId.get(packageId)
 		if (!tools) {
-			tools = createWritableStorageTools(packageId)
+			tools = createGrantedStorageTools(packageId)
 			toolsByPackageId.set(packageId, tools)
 		}
 		return tools
+	}
+	const rejectReadOnlyWrite = async () => {
+		throw new Error(packageStorageRetrieverReadOnlyMessage)
 	}
 	return {
 		packageStorageGet: async (args: unknown) =>
@@ -1277,12 +1285,15 @@ export function createPackageStorageKodyTools(input: {
 			await resolveTools(args).storageList(args),
 		packageStorageSql: async (args: unknown) =>
 			await resolveTools(args).storageSql(args),
-		packageStorageSet: async (args: unknown) =>
-			await resolveTools(args).storageSet(args),
-		packageStorageDelete: async (args: unknown) =>
-			await resolveTools(args).storageDelete(args),
-		packageStorageClear: async (args: unknown) =>
-			await resolveTools(args).storageClear(),
+		packageStorageSet: writable
+			? async (args: unknown) => await resolveTools(args).storageSet!(args)
+			: rejectReadOnlyWrite,
+		packageStorageDelete: writable
+			? async (args: unknown) => await resolveTools(args).storageDelete!(args)
+			: rejectReadOnlyWrite,
+		packageStorageClear: writable
+			? async (args: unknown) => await resolveTools(args).storageClear!()
+			: rejectReadOnlyWrite,
 	}
 }
 
@@ -1293,8 +1304,13 @@ export function createPackageStorageKodyTools(input: {
  * through the AsyncLocalStorage runtime store; the host still validates the
  * id against the run's provenance grants in `createPackageStorageKodyTools`.
  */
-export function createPackageStorageHelperPrelude() {
-	// Always writable; `id` mirrors buildPackageStorageId above (covered by a unit test).
+export function createPackageStorageHelperPrelude(input?: {
+	writable?: boolean
+}) {
+	const writable = input?.writable !== false
+	// `id` mirrors buildPackageStorageId above (covered by a unit test).
+	// Retriever runs pass writable:false so set/delete/clear/sql mutations
+	// fail in the sandbox instead of depending on a convention.
 	return `
 const __kodyPackageStorage = (packageId) => ({
   id: 'package:' + encodeURIComponent(packageId),
@@ -1305,7 +1321,7 @@ const __kodyPackageStorage = (packageId) => ({
       packageId,
       query,
       params,
-      writable: true,
+      writable: ${writable ? 'true' : 'false'},
     }),
   set: async (key, value) => await kody.packageStorageSet({ packageId, key, value }),
   delete: async (key) => await kody.packageStorageDelete({ packageId, key }),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Keep the public MCP `search` tool truthfully read-only and closed-world for ChatGPT plugin submission, without dropping package retriever enrichment.

## Why

OpenAI requires tool annotations to match maximum reachable behavior. Search advertised `readOnlyHint=true` and `openWorldHint=false`, but installed package retrievers ran the same bundled runtime as exports: writable `packageStorage()`, full `kody.*` capabilities, `packages.invoke`, `events.dispatch`, workflows, and outbound `fetch`. Read-mostly was a convention, not a constraint.

Search also had host-side writes: auto-dismissing a completed onboarding checklist, waiting cards that observed MCP hub connections (episode writes, reconnects, and later subscription dispatch), retriever provider assembly that listed MCP servers through the hub snapshot, and denied retriever fetches that still recorded `outbound_fetch` usage.

## Summary

- Retriever runs now use a `closedWorldRetrieverRuntime` profile: no capability map, no invoke/event/workflow helpers, read-only `packageStorage()`, and gateway-denied outbound `fetch`.
- Closed-world / `skipCapabilityRegistry` provider assembly skips MCP server metadata so it cannot drain hub connection events.
- `peekServers()` lists current server cards without observing, reconnecting, or draining pending events.
- Denied retriever fetches do not record `outbound_fetch` usage.
- Search no longer writes `users.onboarding_checklist_dismissed_at`.
- Docs now describe retrievers as a runtime constraint, not a convention.

Search annotations stay:

- `readOnlyHint: true`
- `destructiveHint: false`
- `idempotentHint: true`
- `openWorldHint: false`

`execute` stays write / destructive / open-world.

## Testing

- Focused: retriever service, closed-world workers sandbox, fetch-gateway deny (no usage), peekServers non-observing, onboarding notice, registry bundled options (including hub snapshot skip)

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `a0dd699` · **Head:** `51fb5da`

**Classification:** extends — retriever runs lose export-grade tools; search host paths stop writing user/subscription/usage state. No primitive added.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `capabilities-execute` | runtime | extends — `closedWorldRetrieverRuntime` skips the capability map, invoke/event/workflow helpers, outbound fetch, and MCP hub snapshot assembly |
| `durable-storage` | assistant | extends — `packageStorage()` can be `writable: false` |
| `mcp-server` | surfaces | extends — search/context enrichment uses the restricted profile and no longer dismisses onboarding or meters denied fetch |
| `mcp-client-servers` | assistant | extends — `peekServers()` is snapshot-only and does not observe, reconnect, or drain events |

Unmatched `packages/worker/src/package-retrievers/` is the retriever call site for that profile.

### Change flow

Search still discovers capabilities and still runs installed retrievers; the sandbox can only read granted package storage and return results.

```mermaid
sequenceDiagram
	actor Host as MCP_host
	participant mcpServer as mcp-server
	participant retrievers as package-retrievers
	participant capabilitiesExecute as capabilities-execute
	participant durableStorage as durable-storage
	participant mcpClientServers as mcp-client-servers
	Host->>mcpServer: search query
	mcpServer->>retrievers: runPackageRetrievers search plus context
	retrievers->>capabilitiesExecute: closedWorldRetrieverRuntime
	capabilitiesExecute-->>durableStorage: packageStorage get list SELECT only
	Note over capabilitiesExecute: skipCapabilityRegistry skips hub snapshot
	capabilitiesExecute-->>retrievers: results envelope
	retrievers-->>mcpServer: retriever_result matches
	mcpServer->>mcpClientServers: peekServers snapshot-only no observe
	Note over mcpServer: completed checklist no longer writes dismiss
	mcpServer-->>Host: read-only closed-world response
```

### Before / after

```text
Before: retrievers share export tools (write, fetch, invoke, events, workflows)
After:  retrievers are read-only and closed-world; writes stay on execute
```

### Plan vs actual

Shipped as planned, plus review follow-ups: skip hub snapshot during provider assembly, make peekServers non-observing, and skip usage metering for denied retriever fetch. Search annotations left unchanged.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-519ff81b-d27b-446f-873f-ee943fcd060e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-519ff81b-d27b-446f-873f-ee943fcd060e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Package retrievers now run in a read-only, closed-world environment.
  * Retrievers can read granted package storage but cannot modify data, access capabilities, invoke packages, trigger events or workflows, send emails, or access the public internet.
  * Search and waiting flows now use read-only data access without triggering background changes.

* **Bug Fixes**
  * Completed onboarding checklists no longer create unnecessary dismissal updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->