### PR TITLE
Confirm ToS age 13 and Utah governing law

### DIFF
--- a/packages/worker/client/routes/terms.tsx
+++ b/packages/worker/client/routes/terms.tsx
@@ -43,9 +43,8 @@ export function TermsRoute(_handle: Handle) {
 					data from Account settings.
 				</p>
 				<p mix={css(descriptionCss)}>
-					<strong>Age requirement needing confirmation:</strong> you must be at
-					least [13/16 — Kent to confirm] and legally able to agree to these
-					terms. If local law requires parental consent, you must have it.
+					You must be at least 13 and legally able to agree to these terms. If
+					local law requires parental consent, you must have it.
 				</p>
 			</section>
 
@@ -179,11 +178,10 @@ export function TermsRoute(_handle: Handle) {
 			<section mix={css(cardCss)}>
 				<h2 mix={css(cardTitleCss)}>Governing law</h2>
 				<p mix={css(descriptionCss)}>
-					<strong>Kent must confirm before launch:</strong> these terms are
-					governed by the laws of [STATE/COUNTRY], without regard to
-					conflict-of-law rules, and disputes must be brought in the courts
-					located in [COUNTY, STATE/COUNTRY], unless applicable law requires
-					otherwise.
+					These terms are governed by the laws of the State of Utah, without
+					regard to conflict-of-law rules, and disputes must be brought in the
+					state or federal courts located in Utah, unless applicable law
+					requires otherwise.
 				</p>
 			</section>
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Fill the launch placeholders on `/terms` so the public agreement states a real age floor and venue before open signup.

## Why

The operator confirmed the US COPPA floor (13, not 16) and Utah as governing law. The page still said “Kent to confirm,” which is not shippable copy.

## Summary

- Age: at least 13, plus the existing parental-consent sentence
- Governing law: State of Utah
- Venue: state or federal courts located in Utah (no invented county)

## Testing

- `test:push` (node + workers) on push
- `npm run validate` after the PR opens
- Production `/terms` after deploy

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `a0dd699f` · **Head:** `73d739c6`

**Classification:** composes — no primitives added or changed; this PR replaces launch placeholders on the existing terms page.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | composes — `/terms` copy only |

### Change flow

A visitor reads the public terms page; the placeholders become confirmed age and Utah venue.

```mermaid
sequenceDiagram
	actor Visitor
	participant appUi as app-ui
	Visitor->>appUi: GET /terms
	appUi-->>Visitor: age 13 plus parental-consent sentence
	appUi-->>Visitor: Utah law and Utah courts
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3ace7e23-b05c-4b6e-b716-a2080104dc5b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3ace7e23-b05c-4b6e-b716-a2080104dc5b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the terms page to specify a minimum age of 13.
  * Clarified that Utah law governs the terms and that applicable state or federal courts in Utah are the designated forum.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->