### PR TITLE
Stop Turnstile remounting on Remix re-renders

### DIFF
--- a/packages/worker/client/public-form-protection.node.test.ts
+++ b/packages/worker/client/public-form-protection.node.test.ts
@@ -1,11 +1,15 @@
 import { expect, test, vi } from 'vitest'
 import {
+	readPublicFormProtection,
 	renderTurnstileWidgets,
 	resetTurnstileWidgets,
 } from '#client/public-form-protection.ts'
 
 type FakeContainer = HTMLElement & {
-	dataset: DOMStringMap & { turnstileRendered?: string }
+	dataset: DOMStringMap & {
+		turnstileRendered?: string
+		turnstileWidgetId?: string
+	}
 	childElementCount: number
 	querySelector: ReturnType<typeof vi.fn>
 }
@@ -13,14 +17,45 @@ type FakeContainer = HTMLElement & {
 function createContainer(options: {
 	rendered?: boolean
 	childElementCount?: number
+	widgetId?: string
 }): FakeContainer {
-	const dataset: DOMStringMap & { turnstileRendered?: string } = {}
+	const dataset: DOMStringMap & {
+		turnstileRendered?: string
+		turnstileWidgetId?: string
+	} = {}
 	if (options.rendered) dataset.turnstileRendered = 'true'
+	if (options.widgetId) dataset.turnstileWidgetId = options.widgetId
 	return {
 		dataset,
 		childElementCount: options.childElementCount ?? 0,
 		querySelector: vi.fn(),
 	} as unknown as FakeContainer
+}
+
+function createShadowContainer(options: {
+	rendered?: boolean
+	lightChildElementCount?: number
+	mountChildElementCount?: number
+	widgetId?: string
+}) {
+	const container = createContainer({
+		rendered: options.rendered,
+		childElementCount: options.lightChildElementCount ?? 0,
+		widgetId: options.widgetId,
+	})
+	const mount = {
+		childElementCount: options.mountChildElementCount ?? 0,
+		querySelector: vi.fn(),
+	}
+	const shadowRoot = {
+		querySelector: (selector: string) =>
+			selector === '[data-turnstile-mount]' ? mount : null,
+	}
+	return Object.assign(container, {
+		shadowRoot,
+		attachShadow: vi.fn(() => shadowRoot),
+		mount,
+	})
 }
 
 test('resetTurnstileWidgets clears orphaned hosts instead of throwing', () => {
@@ -49,6 +84,30 @@ test('resetTurnstileWidgets clears orphaned hosts instead of throwing', () => {
 	expect(reset).toHaveBeenCalledWith(live)
 	expect(reset).toHaveBeenCalledWith(zombie)
 	expect(live.dataset.turnstileRendered).toBe('true')
+
+	vi.unstubAllGlobals()
+})
+
+test('resetTurnstileWidgets resets a live shadow mount after a light-DOM wipe', () => {
+	const liveShadow = createShadowContainer({
+		rendered: true,
+		lightChildElementCount: 0,
+		mountChildElementCount: 1,
+		widgetId: 'live-widget',
+	})
+	const reset = vi.fn()
+	const remove = vi.fn()
+
+	vi.stubGlobal('document', {
+		querySelectorAll: vi.fn(() => [liveShadow]),
+	})
+	vi.stubGlobal('window', { turnstile: { reset, remove } })
+
+	expect(() => resetTurnstileWidgets()).not.toThrow()
+	expect(reset).toHaveBeenCalledWith(liveShadow.mount)
+	expect(remove).not.toHaveBeenCalled()
+	expect(liveShadow.dataset.turnstileRendered).toBe('true')
+	expect(liveShadow.dataset.turnstileWidgetId).toBe('live-widget')
 
 	vi.unstubAllGlobals()
 })
@@ -90,6 +149,100 @@ test('renderTurnstileWidgets remounts hosts whose children were wiped by a re-re
 		'error-callback': (code: number) => boolean
 	}
 	expect(renderOptions['error-callback'](300010)).toBe(true)
+	expect(orphan.dataset.turnstileWidgetId).toBe('widget-id')
+	expect(fresh.dataset.turnstileWidgetId).toBe('widget-id')
+
+	vi.unstubAllGlobals()
+})
+
+test('renderTurnstileWidgets keeps a live shadow mount after a light-DOM wipe', async () => {
+	const liveShadow = createShadowContainer({
+		rendered: true,
+		lightChildElementCount: 0,
+		mountChildElementCount: 1,
+		widgetId: 'live-widget',
+	})
+	const wipedShadow = createShadowContainer({
+		rendered: true,
+		lightChildElementCount: 0,
+		mountChildElementCount: 0,
+	})
+	const render = vi.fn((mount: { childElementCount: number }) => {
+		mount.childElementCount = 1
+		return 'remounted-widget'
+	})
+	const remove = vi.fn()
+
+	vi.stubGlobal('document', {
+		querySelectorAll: vi.fn(() => [liveShadow, wipedShadow]),
+	})
+	vi.stubGlobal('window', { turnstile: { render, remove } })
+
+	await renderTurnstileWidgets('site-key')
+
+	expect(remove).not.toHaveBeenCalledWith(liveShadow)
+	expect(remove).not.toHaveBeenCalledWith(liveShadow.mount)
+	expect(render).not.toHaveBeenCalledWith(liveShadow, expect.anything())
+	expect(render).not.toHaveBeenCalledWith(liveShadow.mount, expect.anything())
+	expect(remove).toHaveBeenCalledWith(wipedShadow.mount)
+	expect(render).toHaveBeenCalledTimes(1)
+	expect(render).toHaveBeenCalledWith(wipedShadow.mount, {
+		sitekey: 'site-key',
+		'response-field-name': 'turnstileToken',
+		'error-callback': expect.any(Function),
+	})
+	expect(liveShadow.dataset.turnstileRendered).toBe('true')
+	expect(liveShadow.dataset.turnstileWidgetId).toBe('live-widget')
+	expect(wipedShadow.dataset.turnstileRendered).toBe('true')
+	expect(wipedShadow.dataset.turnstileWidgetId).toBe('remounted-widget')
+
+	vi.unstubAllGlobals()
+})
+
+test('readPublicFormProtection falls back to Turnstile getResponse in a form scope', () => {
+	const other = createContainer({
+		rendered: true,
+		widgetId: 'other-widget',
+	})
+	const target = createContainer({
+		rendered: true,
+		widgetId: 'target-widget',
+	})
+	const form = {
+		querySelectorAll: vi.fn((selector: string) => {
+			expect(selector).toBe('.kody-turnstile')
+			return [target]
+		}),
+	}
+	const getResponse = vi.fn((widgetId: string) => {
+		if (widgetId === 'target-widget') return 'solved-token'
+		if (widgetId === 'other-widget') return 'wrong-token'
+		return ''
+	})
+
+	vi.stubGlobal('document', {
+		querySelectorAll: vi.fn(() => [other, target]),
+	})
+	vi.stubGlobal('window', { turnstile: { getResponse } })
+
+	const formData = new FormData()
+	formData.set('kody_hp', '')
+	expect(
+		readPublicFormProtection(formData, form as unknown as ParentNode),
+	).toEqual({
+		kody_hp: '',
+		turnstileToken: 'solved-token',
+	})
+	expect(getResponse).toHaveBeenCalledWith('target-widget')
+	expect(getResponse).not.toHaveBeenCalledWith('other-widget')
+
+	formData.set('turnstileToken', 'field-token')
+	expect(
+		readPublicFormProtection(formData, form as unknown as ParentNode),
+	).toEqual({
+		kody_hp: '',
+		turnstileToken: 'field-token',
+	})
 
 	vi.unstubAllGlobals()
 })

--- a/packages/worker/client/public-form-protection.ts
+++ b/packages/worker/client/public-form-protection.ts
@@ -30,6 +30,7 @@ type TurnstileApi = {
 	): string
 	reset?(container: HTMLElement | string): void
 	remove?(container: HTMLElement | string): void
+	getResponse?(widgetId: string): string | undefined
 }
 
 let turnstileScriptPromise: Promise<TurnstileApi> | null = null
@@ -91,29 +92,82 @@ function loadTurnstileScript() {
 }
 
 /**
- * Remix re-renders can wipe Turnstile's injected children from a declarative
- * empty host while leaving our `data-turnstile-rendered` marker. Without this
- * check we skip re-render and later `reset()` throws "Nothing to reset found…".
- * A live widget always leaves at least one child (iframe / response input).
+ * Remix re-renders wipe children of a declarative empty host. The widget
+ * lives in a shadow mount Remix does not touch, so a light-DOM wipe is not
+ * enough to remount. Fake test hosts without `attachShadow` fall back to
+ * the container itself.
  */
-function isTurnstileWidgetAlive(container: HTMLElement) {
-	return container.childElementCount > 0
+function ensureTurnstileMount(container: HTMLElement) {
+	if (!container.shadowRoot && typeof container.attachShadow === 'function') {
+		try {
+			container.attachShadow({ mode: 'open' })
+		} catch {
+			// Already attached, or this host cannot take a shadow root.
+		}
+	}
+	const root = container.shadowRoot
+	if (!root) {
+		return container
+	}
+	const existing = root.querySelector<HTMLElement>('[data-turnstile-mount]')
+	if (existing) {
+		return existing
+	}
+	if (typeof document === 'undefined') {
+		return container
+	}
+	if (!root.querySelector('style[data-turnstile-host]')) {
+		const style = document.createElement('style')
+		style.dataset.turnstileHost = ''
+		style.textContent =
+			':host{display:block;min-height:65px;width:min(300px,100%)}[data-turnstile-mount]{min-height:65px}'
+		root.append(style)
+	}
+	const mount = document.createElement('div')
+	mount.dataset.turnstileMount = ''
+	root.append(mount)
+	return mount
+}
+
+function isTurnstileWidgetAlive(mount: HTMLElement) {
+	return mount.childElementCount > 0
 }
 
 function clearTurnstileRenderedMarker(container: HTMLElement) {
 	delete container.dataset.turnstileRendered
+	delete container.dataset.turnstileWidgetId
 }
 
 function abandonOrphanedTurnstileWidget(
 	api: TurnstileApi,
 	container: HTMLElement,
+	mount = ensureTurnstileMount(container),
 ) {
 	clearTurnstileRenderedMarker(container)
 	try {
-		api.remove?.(container)
+		api.remove?.(mount)
 	} catch {
 		// Widget is already gone from Turnstile's registry; ignore.
 	}
+}
+
+function readTurnstileResponseFromWidgets(scope?: ParentNode | null) {
+	const api = getTurnstileApi()
+	if (!api?.getResponse || typeof document === 'undefined') {
+		return ''
+	}
+	const root = scope ?? document
+	for (const container of root.querySelectorAll<HTMLElement>(
+		`.${turnstileWidgetClassName}`,
+	)) {
+		const widgetId = container.dataset.turnstileWidgetId
+		if (!widgetId) continue
+		const response = api.getResponse(widgetId)
+		if (typeof response === 'string' && response.length > 0) {
+			return response
+		}
+	}
+	return ''
 }
 
 /**
@@ -139,17 +193,21 @@ export async function renderTurnstileWidgets(siteKey: string | null) {
 	for (const container of document.querySelectorAll<HTMLElement>(
 		`.${turnstileWidgetClassName}`,
 	)) {
+		const mount = ensureTurnstileMount(container)
 		if (container.dataset.turnstileRendered === 'true') {
-			if (isTurnstileWidgetAlive(container)) continue
-			abandonOrphanedTurnstileWidget(api, container)
+			if (isTurnstileWidgetAlive(mount)) continue
+			abandonOrphanedTurnstileWidget(api, container, mount)
 		}
 		try {
-			api.render(container, {
+			const widgetId = api.render(mount, {
 				sitekey: siteKey,
 				'response-field-name': turnstileResponseFieldName,
 				'error-callback': handleTurnstileWidgetError,
 			})
 			container.dataset.turnstileRendered = 'true'
+			if (widgetId) {
+				container.dataset.turnstileWidgetId = widgetId
+			}
 		} catch (error) {
 			clearTurnstileRenderedMarker(container)
 			throw error
@@ -174,25 +232,27 @@ export function resetTurnstileWidgets() {
 	for (const container of document.querySelectorAll<HTMLElement>(
 		`.${turnstileWidgetClassName}[data-turnstile-rendered]`,
 	)) {
-		if (!isTurnstileWidgetAlive(container)) {
-			abandonOrphanedTurnstileWidget(api, container)
+		const mount = ensureTurnstileMount(container)
+		if (!isTurnstileWidgetAlive(mount)) {
+			abandonOrphanedTurnstileWidget(api, container, mount)
 			continue
 		}
 		try {
-			api.reset(container)
+			api.reset(mount)
 		} catch {
-			abandonOrphanedTurnstileWidget(api, container)
+			abandonOrphanedTurnstileWidget(api, container, mount)
 		}
 	}
 }
 
 export function readPublicFormProtection(
 	formData: FormData,
+	scope?: ParentNode | null,
 ): PublicFormProtectionFields {
+	const fromField = String(formData.get(turnstileResponseFieldName) ?? '')
 	return {
 		[honeypotFieldName]: String(formData.get(honeypotFieldName) ?? ''),
-		[turnstileResponseFieldName]: String(
-			formData.get(turnstileResponseFieldName) ?? '',
-		),
+		[turnstileResponseFieldName]:
+			fromField || readTurnstileResponseFromWidgets(scope),
 	}
 }

--- a/packages/worker/client/routes/discord.tsx
+++ b/packages/worker/client/routes/discord.tsx
@@ -131,7 +131,7 @@ export function DiscordRoute(handle: Handle) {
 			const protection =
 				page?.signedIn || !connectForm
 					? emptyPublicFormProtection()
-					: readPublicFormProtection(new FormData(connectForm))
+					: readPublicFormProtection(new FormData(connectForm), connectForm)
 			const errorMessage = await startSocialSignIn(
 				'discord',
 				discordPath,

--- a/packages/worker/client/routes/landing-waitlist-form.tsx
+++ b/packages/worker/client/routes/landing-waitlist-form.tsx
@@ -54,7 +54,7 @@ export function WaitlistForm(handle: Handle) {
 		const formData = new FormData(form)
 		const firstName = String(formData.get('firstName') ?? '').trim()
 		const email = String(formData.get('email') ?? '').trim()
-		const protection = readPublicFormProtection(formData)
+		const protection = readPublicFormProtection(formData, form)
 
 		if (!firstName) {
 			setState('error', 'What should we call you?')

--- a/packages/worker/client/routes/login.tsx
+++ b/packages/worker/client/routes/login.tsx
@@ -177,7 +177,7 @@ export function LoginRoute(handle: Handle) {
 		const formData = new FormData(form)
 		const firstName = String(formData.get('firstName') ?? '').trim()
 		const email = String(formData.get('email') ?? '').trim()
-		const protection = readPublicFormProtection(formData)
+		const protection = readPublicFormProtection(formData, form)
 
 		if (!firstName || !email) {
 			setState('error', 'First name and email are required.')
@@ -218,8 +218,9 @@ export function LoginRoute(handle: Handle) {
 	async function handleSubmit(event: SubmitEvent) {
 		event.preventDefault()
 		if (!(event.currentTarget instanceof HTMLFormElement)) return
+		const form = event.currentTarget
 
-		const formData = new FormData(event.currentTarget)
+		const formData = new FormData(form)
 		const email = String(formData.get('email') ?? '').trim()
 		const password = String(formData.get('password') ?? '')
 		const mode = getCurrentAuthMode(handle)
@@ -228,7 +229,7 @@ export function LoginRoute(handle: Handle) {
 		const inviteCode =
 			mode === 'signup' ? String(formData.get('inviteCode') ?? '').trim() : ''
 		const rememberMe = mode === 'login' && formData.get('rememberMe') === 'on'
-		const protection = readPublicFormProtection(formData)
+		const protection = readPublicFormProtection(formData, form)
 
 		if (!email || !password) {
 			setState('error', 'Email and password are required.')
@@ -325,7 +326,7 @@ export function LoginRoute(handle: Handle) {
 				'form[data-public-auth-form]',
 			)
 			const protection = authForm
-				? readPublicFormProtection(new FormData(authForm))
+				? readPublicFormProtection(new FormData(authForm), authForm)
 				: emptyPublicFormProtection()
 			const errorMessage = await startSocialSignIn(
 				providerId,
@@ -381,7 +382,7 @@ export function LoginRoute(handle: Handle) {
 				'form[data-public-auth-form]',
 			)
 			const protection = authForm
-				? readPublicFormProtection(new FormData(authForm))
+				? readPublicFormProtection(new FormData(authForm), authForm)
 				: emptyPublicFormProtection()
 
 			const verificationResponse = await fetch('/webauthn/authentication', {

--- a/packages/worker/client/routes/oauth-authorize.tsx
+++ b/packages/worker/client/routes/oauth-authorize.tsx
@@ -316,7 +316,7 @@ export function OAuthAuthorizeRoute(handle: Handle) {
 				}
 				body.set('email', email)
 				body.set('password', password)
-				const protection = readPublicFormProtection(formData)
+				const protection = readPublicFormProtection(formData, form)
 				body.set(honeypotFieldName, protection[honeypotFieldName])
 				body.set(
 					turnstileResponseFieldName,

--- a/packages/worker/client/routes/reset-password.tsx
+++ b/packages/worker/client/routes/reset-password.tsx
@@ -57,10 +57,11 @@ export function ResetPasswordRoute(handle: Handle) {
 	async function submitResetRequest(event: SubmitEvent) {
 		event.preventDefault()
 		if (!(event.currentTarget instanceof HTMLFormElement)) return
+		const form = event.currentTarget
 
-		const formData = new FormData(event.currentTarget)
+		const formData = new FormData(form)
 		const email = String(formData.get('email') ?? '').trim()
-		const protection = readPublicFormProtection(formData)
+		const protection = readPublicFormProtection(formData, form)
 		if (!email) {
 			setState('error', 'Email is required.')
 			return
@@ -97,10 +98,11 @@ export function ResetPasswordRoute(handle: Handle) {
 	async function submitResetConfirm(event: SubmitEvent, token: string) {
 		event.preventDefault()
 		if (!(event.currentTarget instanceof HTMLFormElement)) return
+		const form = event.currentTarget
 
-		const formData = new FormData(event.currentTarget)
+		const formData = new FormData(form)
 		const password = String(formData.get('password') ?? '')
-		const protection = readPublicFormProtection(formData)
+		const protection = readPublicFormProtection(formData, form)
 		if (!password) {
 			setState('error', 'Password is required.')
 			return

--- a/packages/worker/client/routes/verify.tsx
+++ b/packages/worker/client/routes/verify.tsx
@@ -51,10 +51,11 @@ export function VerifyRoute(handle: Handle) {
 	async function handleSubmit(event: SubmitEvent) {
 		event.preventDefault()
 		if (!(event.currentTarget instanceof HTMLFormElement)) return
+		const form = event.currentTarget
 
-		const formData = new FormData(event.currentTarget)
+		const formData = new FormData(form)
 		const code = String(formData.get('code') ?? '').trim()
-		const protection = readPublicFormProtection(formData)
+		const protection = readPublicFormProtection(formData, form)
 		if (!code) {
 			message = 'Enter the 6-digit code from your authenticator app.'
 			handle.update()

--- a/packages/worker/client/waitlist-banner.tsx
+++ b/packages/worker/client/waitlist-banner.tsx
@@ -54,7 +54,7 @@ export function WaitlistBanner(handle: Handle) {
 		const formData = new FormData(form)
 		const firstName = String(formData.get('firstName') ?? '').trim()
 		const email = String(formData.get('email') ?? '').trim()
-		const protection = readPublicFormProtection(formData)
+		const protection = readPublicFormProtection(formData, form)
 
 		if (!firstName || !email) {
 			setState('error', 'First name and email are required.')

--- a/packages/worker/public/styles.css
+++ b/packages/worker/public/styles.css
@@ -1986,6 +1986,17 @@ html.is-settled {
 	font-size: 1rem;
 }
 
+/*
+ * Cloudflare's managed Turnstile widget is 300×65. Reserve that box on
+ * every `.kody-turnstile` host so the first iframe paint and later Remix
+ * re-renders cannot collapse the form.
+ */
+.kody-turnstile {
+	display: block;
+	min-height: 65px;
+	width: min(300px, 100%);
+}
+
 .landing-waitlist {
 	position: relative;
 	display: grid;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Keep the Cloudflare Turnstile widget stable on public forms so Remix updates no longer flash it in and out or shift the layout.

## Why

Remix 3 re-renders wipe children of the declarative empty `.kody-turnstile` host while leaving `data-turnstile-rendered` on the reused element. `renderTurnstileWidgets()` then treats that host as dead, removes the widget, and mounts a new iframe. Submit, session load, and error paths all call `handle.update()`, so the challenge pops in and out and the form jumps.

## Summary

- Mount Turnstile inside an open shadow root Remix does not reconcile.
- Only remount when that shadow mount is actually empty.
- Reserve the managed widget box (`300×65`) on `.kody-turnstile` so first paint and later updates cannot collapse the form.
- Read the solved token via `turnstile.getResponse()` when the hidden input lives in the shadow and is invisible to `FormData`.
- Scope that fallback to the submitting form so login + waitlist widgets do not steal each other's tokens.

## Testing

- `vitest run --project node-unit packages/worker/client/public-form-protection.node.test.ts` (7 passed)
- Pre-push: `CI=1 npm run test:node` (2303 passed) and `CI=1 npm run test:workers` (313 passed)
- Preview often has Turnstile off (both site and secret keys required). The real widget proof is production `/login` after deploy, plus a local or preview pass to confirm the reserved host does not collapse on submit/error updates.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `72e11d1d` · **Head:** `b5c69823`

**Classification:** extends — the public-form Turnstile host contract changes so Remix re-renders no longer remount the widget.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | extends — shadow mount, reserved `300×65` host, `getResponse` token fallback scoped to the submitting form |

`packages/worker/public/styles.css` is unmatched by the classifier; it only reserves the `.kody-turnstile` box used by those same auth/waitlist hosts.

### Change flow

Remix updates wipe light-DOM children of the empty host; the widget now lives in a shadow mount and the token is read from Turnstile when `FormData` cannot see the hidden input.

```mermaid
sequenceDiagram
	actor Visitor
	participant appUi as app-ui
	participant turnstile as Turnstile
	Visitor->>appUi: load /login or waitlist
	appUi->>turnstile: render into shadow mount
	Note over appUi: reserved 300×65 host
	Visitor->>appUi: submit or error update
	appUi->>appUi: handle.update wipes light children
	appUi->>appUi: live shadow mount skips remount
	appUi->>turnstile: getResponse(widgetId) for this form
	Visitor->>appUi: failed submit needs a fresh token
	appUi->>turnstile: reset(mount) without abandoning a live widget
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d2e9331f-8e81-48a9-8bb2-55b7442a5065?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d2e9331f-8e81-48a9-8bb2-55b7442a5065&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved form protection reliability when pages re-render, preserving security widgets instead of removing them.
  - Added fallback token detection when the hidden form field is unavailable.
  - Prevented layout shifts by reserving space for the protection widget.
- **Tests**
  - Added coverage for widget resets, re-rendering, shadow-root forms, and token fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->