### PR TITLE
Price Pro at $49 and cap execute at 800/day

### DIFF
--- a/docs/contributing/architecture/entitlements.md
+++ b/docs/contributing/architecture/entitlements.md
@@ -806,7 +806,7 @@ instead of acknowledging an unrecoverable stale projection. The
 class exists without moving canonical billing data out of D1.
 
 Published prices: Free $0, Standard $12/mo or $120/year ($10/mo billed
-annually), Pro $29/mo or $288/year ($24/mo billed annually). Env vars and deploy
+annually), Pro $49/mo or $480/year ($40/mo billed annually). Env vars and deploy
 wiring are documented in
 [`../environment-variables.md`](../environment-variables.md).
 

--- a/docs/contributing/architecture/entitlements.md
+++ b/docs/contributing/architecture/entitlements.md
@@ -75,24 +75,27 @@ sending is an outreach-abuse surface — `resolvePlanLimit` resolves those caps
 like any other limit. The caps stay finite but dominate every other plan's email
 limits, so granting `max` never reduces email capacity (`email_message_bytes`
 stays at standard/pro parity because the per-message ceiling is a platform
-bound, not a scalable quota). All other resources use the ordinary
-`planLimits.max` numbers.
+bound, not a scalable quota). Compute rate limits on `max`
+(`execute_calls_per_day`, `outbound_fetches_per_day`, `job_runs_per_day`,
+`concurrent_workflows`) are operator runaway caps sized from production usage
+with at least 2× busy-day headroom, and they still dominate every paid plan. All
+other resources use the ordinary `planLimits.max` numbers.
 
-| Resource                   | Limit     |
-| -------------------------- | --------- |
-| `email_sends_per_day`      | 10,000    |
-| `email_receives_per_day`   | 20,000    |
-| `stored_email_messages`    | 100,000   |
-| `email_message_bytes`      | 768 KiB   |
-| `concurrent_workflows`     | 5,000     |
-| `scheduled_jobs`           | 5,000     |
-| `saved_packages`           | 10,000    |
-| `repo_sessions`            | 20,000    |
-| `secrets`                  | 10,000    |
-| `storage_bytes`            | 100 GiB   |
-| `execute_calls_per_day`    | 500,000   |
-| `outbound_fetches_per_day` | 2,000,000 |
-| `job_runs_per_day`         | 1,000,000 |
+| Resource                   | Limit   |
+| -------------------------- | ------- |
+| `email_sends_per_day`      | 10,000  |
+| `email_receives_per_day`   | 20,000  |
+| `stored_email_messages`    | 100,000 |
+| `email_message_bytes`      | 768 KiB |
+| `concurrent_workflows`     | 200     |
+| `scheduled_jobs`           | 5,000   |
+| `saved_packages`           | 10,000  |
+| `repo_sessions`            | 20,000  |
+| `secrets`                  | 10,000  |
+| `storage_bytes`            | 100 GiB |
+| `execute_calls_per_day`    | 25,000  |
+| `outbound_fetches_per_day` | 80,000  |
+| `job_runs_per_day`         | 40,000  |
 
 ## Compute rate limits
 

--- a/docs/contributing/architecture/usage-metering.md
+++ b/docs/contributing/architecture/usage-metering.md
@@ -390,7 +390,7 @@ Guarantees and rules:
   (24h), when a non-admin account's unique Dynamic Worker cost for the month
   first reaches the plan-aware threshold (Free
   $2 / 1,000 unique days, Standard
-  $12, Pro $29), or when a non-admin account
+  $12, Pro $49), or when a non-admin account
   hits 100% of `execute_calls_per_day` on three of the last seven UTC days.
   Staying over the same threshold does not emit again. Admin-role dogfooding
   stays on `/admin/insights` rankings and can still appear as an entitlement

--- a/docs/contributing/environment-variables.md
+++ b/docs/contributing/environment-variables.md
@@ -251,10 +251,10 @@ safely. Manual `users.plan` grants and invite-assigned plans apply regardless.
 - `STRIPE_STANDARD_YEARLY_PRICE_ID` — Stripe Price id for the
   $120/year
   `standard` plan ($10/month billed annually).
-- `STRIPE_PRO_PRICE_ID` — Stripe Price id for the $29/month `pro` plan.
+- `STRIPE_PRO_PRICE_ID` — Stripe Price id for the $49/month `pro` plan.
 - `STRIPE_PRO_YEARLY_PRICE_ID` — Stripe Price id for the
-  $288/year `pro` plan
-  ($24/month billed annually).
+  $480/year `pro` plan
+  ($40/month billed annually).
 
 Each price id independently enables authenticated Checkout and subscription
 matching for its tier and interval; leaving a monthly or yearly id unset makes

--- a/docs/contributing/setup-manifest.md
+++ b/docs/contributing/setup-manifest.md
@@ -470,10 +470,10 @@ automatically:
   `packages/worker/wrangler.jsonc`; Stripe Price id mapped to the $120/year
   `standard` plan.)
 - `STRIPE_PRO_PRICE_ID` (optional public Wrangler var committed in
-  `packages/worker/wrangler.jsonc`; Stripe Price id mapped to the $29/month
+  `packages/worker/wrangler.jsonc`; Stripe Price id mapped to the $49/month
   `pro` plan and used for authenticated Checkout Sessions.)
 - `STRIPE_PRO_YEARLY_PRICE_ID` (optional public Wrangler var committed in
-  `packages/worker/wrangler.jsonc`; Stripe Price id mapped to the $288/year
+  `packages/worker/wrangler.jsonc`; Stripe Price id mapped to the $480/year
   `pro` plan.) Each price id is independent; an unset value only disables
   checkout for that tier and interval.
 

--- a/docs/guides/package-subscriptions.md
+++ b/docs/guides/package-subscriptions.md
@@ -1042,7 +1042,7 @@ One event fires per crossing of 80% (`approaching`) or 100% (`reached`) on a
 specific entitlement, when a non-admin account first exceeds 24h of combined
 execute / job / workflow runtime in the UTC month, when a non-admin account
 first reaches a plan-aware unique Dynamic Worker cost threshold this UTC month
-(Free $2, Standard $12, Pro $29; `max` and admin accounts do not page), or when
+(Free $2, Standard $12, Pro $49; `max` and admin accounts do not page), or when
 a non-admin account first hits 100% of `execute_calls_per_day` on three of the
 last seven UTC days. Staying over the same threshold does not emit again. A
 later drop below that threshold, then a climb back over it, is a new instance. A

--- a/packages/worker/client/routes/account-billing.tsx
+++ b/packages/worker/client/routes/account-billing.tsx
@@ -82,10 +82,10 @@ const planTiers: Array<{
 	{
 		id: 'pro',
 		name: 'Pro',
-		price: '$29/month',
-		annualPrice: '$24/mo billed annually',
+		price: '$49/month',
+		annualPrice: '$40/mo billed annually',
 		description:
-			'For heavy daily automation — roughly double Standard on every axis.',
+			'For heavy daily automation — more room for storage, jobs, workflows, and daily volume.',
 	},
 ]
 

--- a/packages/worker/client/routes/pricing.tsx
+++ b/packages/worker/client/routes/pricing.tsx
@@ -190,9 +190,9 @@ export function PricingRoute(handle: Handle) {
 							Pro
 						</h2>
 						<p mix={css(planPriceCss)}>
-							$29<small mix={css(planPriceUnitCss)}>/month</small>
+							$49<small mix={css(planPriceUnitCss)}>/month</small>
 						</p>
-						<p mix={css(planPriceNoteCss)}>$24/mo billed annually</p>
+						<p mix={css(planPriceNoteCss)}>$40/mo billed annually</p>
 						<p mix={css(planCopyCss)}>
 							Same factory. More room for storage, jobs, workflows, and daily
 							volume.
@@ -223,8 +223,8 @@ export function PricingRoute(handle: Handle) {
 									</th>
 									<th scope="col">
 										<span data-limits-plan>Pro</span>
-										<span data-limits-price>$29/mo</span>
-										<span data-limits-annual>$24/mo billed annually</span>
+										<span data-limits-price>$49/mo</span>
+										<span data-limits-annual>$40/mo billed annually</span>
 									</th>
 								</tr>
 							</thead>

--- a/packages/worker/src/billing/billing-config.node.test.ts
+++ b/packages/worker/src/billing/billing-config.node.test.ts
@@ -279,3 +279,44 @@ test('resolveSubscriptionPlan maps active price and metadata plans with soonest 
 	expect(getPriceIdForPlan(env, 'pro', 'year')).toBe('price_pro_yearly')
 	expect(getPriceIdForPlan({}, 'standard', 'year')).toBeNull()
 })
+
+test('resolveSubscriptionPlan maps retired Pro list prices after checkout ids rotate', () => {
+	const env = {
+		STRIPE_PRO_PRICE_ID: 'price_pro_current',
+		STRIPE_PRO_YEARLY_PRICE_ID: 'price_pro_yearly_current',
+	}
+
+	expect(
+		resolveSubscriptionPlan(
+			[
+				subscription({
+					status: 'active',
+					priceIds: ['price_1U3sg6LAQpAnsYszlVpEIFGx'],
+				}),
+			],
+			env,
+		).stripePlan,
+	).toBe('pro')
+	expect(
+		resolveSubscriptionPlan(
+			[
+				subscription({
+					status: 'active',
+					priceIds: ['price_1U3sg7LAQpAnsYszpozAEFUi'],
+				}),
+			],
+			env,
+		).stripePlan,
+	).toBe('pro')
+	expect(
+		resolveSubscriptionPlan(
+			[
+				subscription({
+					status: 'active',
+					priceIds: ['price_1U1AISLAQpAnsYszIQvRJNhl'],
+				}),
+			],
+			env,
+		).stripePlan,
+	).toBe('pro')
+})

--- a/packages/worker/src/billing/billing-config.ts
+++ b/packages/worker/src/billing/billing-config.ts
@@ -30,13 +30,19 @@ const planRetainingSubscriptionStatuses = new Set([
 ])
 
 /**
- * Retired production monthly prices that still have live subscribers.
- * Checkout uses the $12 / $29 monthly prices; these ids stay in Stripe and
+ * Retired production prices that still have live subscribers.
+ * Checkout uses the $12 / $49 monthly prices; these ids stay in Stripe and
  * must resolve to standard/pro so existing subscriptions do not drop to free.
  * Standard $5 (`price_1Tv3W2…`) has one customer through 2026-09-08.
+ * Pro $29 monthly (`price_1U3sg6…`) and $288 yearly (`price_1U3sg7…`) remain
+ * matched so existing subscriptions do not drop to free.
  */
 const retiredStandardPriceIds = ['price_1Tv3W2LAQpAnsYszSr4PGBkE'] as const
-const retiredProPriceIds = ['price_1U1AISLAQpAnsYszIQvRJNhl'] as const
+const retiredProPriceIds = [
+	'price_1U1AISLAQpAnsYszIQvRJNhl',
+	'price_1U3sg6LAQpAnsYszlVpEIFGx',
+	'price_1U3sg7LAQpAnsYszpozAEFUi',
+] as const
 
 /** Higher rank = more useful UX signal when no active/trialing sub exists. */
 const subscriptionStatusSignalRank: Record<string, number> = {

--- a/packages/worker/src/blog/posts/zero-inference-calls.md
+++ b/packages/worker/src/blog/posts/zero-inference-calls.md
@@ -71,7 +71,7 @@ That's why the pricing looks the way it does: a free
 $0 tier with tight limits,
 Standard at $12/month (or
 $10/month billed annually),
-and Pro at $29/month (or $24/month billed annually)
+and Pro at $49/month (or $40/month billed annually)
 for heavier daily automation. Kody doesn't need to charge like a model company
 because it doesn't spend like one. When your costs are Workers primitives
 instead of GPU time, you can price like a utility instead of an oracle.

--- a/packages/worker/universal/dynamic-worker-cost.node.test.ts
+++ b/packages/worker/universal/dynamic-worker-cost.node.test.ts
@@ -25,6 +25,6 @@ test('toAdminDynamicWorkerCost truncates to a non-negative integer day count', (
 	expect(formatDynamicWorkerUsd(1)).toBe('$1.00')
 	expect(fleetDynamicWorkerCostAlertUsd('free')).toBe(2)
 	expect(fleetDynamicWorkerCostAlertUsd('standard')).toBe(12)
-	expect(fleetDynamicWorkerCostAlertUsd('pro')).toBe(29)
+	expect(fleetDynamicWorkerCostAlertUsd('pro')).toBe(49)
 	expect(fleetDynamicWorkerCostAlertUsd('max')).toBeNull()
 })

--- a/packages/worker/universal/dynamic-worker-cost.ts
+++ b/packages/worker/universal/dynamic-worker-cost.ts
@@ -21,7 +21,7 @@ export const dynamicWorkersIncludedPerAccountMonth = 1000
 export const fleetDynamicWorkerCostAlertUsdByPlan = {
 	free: 2,
 	standard: 12,
-	pro: 29,
+	pro: 49,
 } as const
 
 export function fleetDynamicWorkerCostAlertUsd(plan: PlanName): number | null {

--- a/packages/worker/universal/plans.ts
+++ b/packages/worker/universal/plans.ts
@@ -218,9 +218,10 @@ export const maxPlanEmailLimits = {
  * subscriptions onto these plan names; the limit numbers stay independent
  * of list prices.
  *
- * Ordinary `max` ceilings are explicit product choices based on the `pro`
- * plan. Most retain high operator ceilings even where that is 25× or 50×
- * pro rather than a uniform multiplier. Email resources intentionally use
+ * Ordinary `max` stock ceilings are explicit product choices based on the
+ * `pro` plan (often 25× or 50×). Compute rate limits on `max` are operator
+ * runaway caps sized from production usage with at least 2× busy-day
+ * headroom, and they still dominate every paid plan. Email resources use
  * {@link maxPlanEmailLimits} abuse caps instead.
  */
 export const planLimits: Record<PlanName, PlanLimits> = {
@@ -318,14 +319,17 @@ export const planLimits: Record<PlanName, PlanLimits> = {
 		maxSecrets: 10_000,
 		// 20× pro (5 GiB) → 100 GiB.
 		maxStorageBytes: 100 * 1024 * 1024 * 1024,
-		// 50× pro (100) → 5_000.
-		maxConcurrentWorkflows: 5_000,
-		// Retained operator ceiling (not 50× the current pro 800).
-		maxExecuteCallsPerDay: 500_000,
-		// 50× pro (40_000) → 2_000_000.
-		maxOutboundFetchesPerDay: 2_000_000,
-		// 50× pro (20_000) → 1_000_000.
-		maxJobRunsPerDay: 1_000_000,
+		// 2× pro (100). Observed concurrent ~35.
+		maxConcurrentWorkflows: 200,
+		// Operator runaway cap. kentcdodds August 2026 rollup avg ~3,800
+		// execute/day (116k/month); entitlement meter today ~1,810. Daily
+		// peak is not stored; 25,000 is at least 2× a ~12,500 peak (~3×
+		// August avg). Unique-DW ceiling is $50/day ($0.002 × 25,000).
+		maxExecuteCallsPerDay: 25_000,
+		// 2× pro (40_000). Today's fetch spike (~17,000) stays well under.
+		maxOutboundFetchesPerDay: 80_000,
+		// 2× pro (20_000). Busy days are ~1,500–1,700 job runs.
+		maxJobRunsPerDay: 40_000,
 		minJobIntervalMs: 0,
 	},
 }

--- a/packages/worker/universal/plans.ts
+++ b/packages/worker/universal/plans.ts
@@ -292,8 +292,10 @@ export const planLimits: Record<PlanName, PlanLimits> = {
 		maxSecrets: 200,
 		maxStorageBytes: 5 * 1024 * 1024 * 1024,
 		maxConcurrentWorkflows: 100,
-		// Above the heaviest Pro payer (~670/day avg).
-		maxExecuteCallsPerDay: 2_000,
+		// Above the heaviest Pro payer (~670/day August avg) with room
+		// for a busy day. Unique-execute ceiling at 800/day is about
+		// the $49 list price ($0.002 × 800 × 30 ≈ $48).
+		maxExecuteCallsPerDay: 800,
 		maxOutboundFetchesPerDay: 40_000,
 		maxJobRunsPerDay: 20_000,
 		minJobIntervalMs: 0,
@@ -318,7 +320,7 @@ export const planLimits: Record<PlanName, PlanLimits> = {
 		maxStorageBytes: 100 * 1024 * 1024 * 1024,
 		// 50× pro (100) → 5_000.
 		maxConcurrentWorkflows: 5_000,
-		// Retained operator ceiling (not 50× the current pro 2_000).
+		// Retained operator ceiling (not 50× the current pro 800).
 		maxExecuteCallsPerDay: 500_000,
 		// 50× pro (40_000) → 2_000_000.
 		maxOutboundFetchesPerDay: 2_000_000,

--- a/packages/worker/wrangler.jsonc
+++ b/packages/worker/wrangler.jsonc
@@ -572,8 +572,8 @@
 				// Payment Link). STRIPE_STANDARD_PRICE_ID is the $12/month
 				// price on the "Kody Standard" product;
 				// STRIPE_STANDARD_YEARLY_PRICE_ID is $120/year (two months
-				// free). STRIPE_PRO_PRICE_ID is the $29/month price on the
-				// "Kody Pro" product; STRIPE_PRO_YEARLY_PRICE_ID is $288/year.
+				// free). STRIPE_PRO_PRICE_ID is the $49/month price on the
+				// "Kody Pro" product; STRIPE_PRO_YEARLY_PRICE_ID is $480/year.
 				// Historical $5/$20 monthly price ids remain in Stripe and
 				// match in billing-config for existing subscribers.
 				"STRIPE_STANDARD_PRICE_ID": "price_1U3sg6LAQpAnsYszGeL2nc8O",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Set Pro at a price and execute cap that match how people actually use it today, and give the operator `max` plan a runaway compute ceiling instead of a $1,000/day unique-worker hole. No public power tier.

## Why

Cloudflare bills unique Dynamic Worker ids, not raw execute count. At $29 and 2,000 executes/day, Pro was cheaper per daily slot than Standard and the cap sat far above the only Pro user.

Cameron (`cameronpak`) averaged about 670 MCP executes/day in August and is at ~427 so far today (2026-09-01). A cap of 800 is just above that average with busy-day room. Unique-execute at 800/day is about $48/month (`$0.002 × 800 × 30`), so $49 is the matching list price.

`max` was 500,000 execute/day. That is $1,000 of unique-worker list price in one UTC day if every call is a new module — a runaway task, not a plan anyone wants. kentcdodds (`max`) is ~3,800 execute rollup events/day in August (116k/month) and ~1,810 on the entitlement meter today, with ~1,500–1,700 job runs and a ~17,000 fetch spike today. Daily peak is not stored; 25,000 execute is at least 2× a ~12,500 peak (~3× August avg). Unique-DW ceiling at that cap is $50/day.

A later public power seat can sit a bit above Kent-shaped usage and be priced then. This PR does not add that tier. `max` stays operator-only.

## Summary

- Pro list price: **$49/month** or **$480/year** ($40/mo billed annually)
- Pro execute entitlement: **2,000 → 800**/day
- Operator unique-DW cost alert for Pro: **$29 → $49**
- Standard stays $12 / $10 annual and 500 executes/day
- `max` compute runaway caps (still above Pro on every axis):
  - execute **500,000 → 25,000**/day
  - outbound fetches **2,000,000 → 80,000**/day
  - job runs **1,000,000 → 40,000**/day
  - concurrent workflows **5,000 → 200**
- Stock, storage, and email abuse caps on `max` stay as they are
- Retired Pro Stripe price ids (`$29` monthly, `$288` yearly, plus the older Pro id) stay matched so existing subscriptions do not drop to free
- `/pricing`, `/account/billing`, entitlements docs, and the cost-alert test follow the new numbers

**Before production deploy:** create new Stripe prices at $49/month and $480/year, then replace `STRIPE_PRO_PRICE_ID` / `STRIPE_PRO_YEARLY_PRICE_ID` in `packages/worker/wrangler.jsonc`. The committed ids still point at the current $29 / $288 Stripe prices. Display copy in this PR already says $49 / $40. Nobody is paying $29 Pro today; Cameron is gifted Pro on a Standard Stripe subscription — talk to him as a person, do not auto-charge $49.

## Testing

- `test:push` (node + workers unit) on both commits
- Focused cost-alert and retired-price matching tests
- `CI=1 npm run test:e2e:run` — 8 passed (first validate run failed e2e after a hung leftover workerd on `:3742` raced D1; retry after stopping those PIDs was green)
- Second `npm run validate`: format, lint, typecheck, node, workers, e2e, mcp, docs, knip, builds all exited 0. `slop-ratchet` failed on `packages/worker/client/routes/admin-users.tsx` (812 vs 800) — that file is unchanged here and already over budget on `main`
- Preview `https://kody-pr-1966.kody-a99.workers.dev`: health/login smoke, `GET /pricing` 200, signed-in `GET /account/billing` 200 (first head). Preview will redeploy this `max` cap commit
- Preview UI (first head): Pro **$49** / **$40/mo billed annually**, execute **100 / 500 / 800**. No leftover $29/$24 or Pro 2,000
- Production admin usage for `kentcdodds` (2026-09-01): execute 1,810 / 500,000, fetches 17,082, jobs 1,480, concurrent 35 — all well under the new `max` caps

![Preview /pricing Pro card at $49](https://cursor.com/artifacts/c/art-88431903-63c5-467c-890c-49b70e9d979c)
![Preview execute limits 100 / 500 / 800](https://cursor.com/artifacts/c/art-dd49f44f-7f5e-41ca-b6e5-07a3e89d2295)
![Preview /account/billing Pro at $49](https://cursor.com/artifacts/c/art-32b4f67c-97a1-4d2c-bba7-18870ec40c04)
<a href="https://cursor.com/agents/bc-3ace7e23-b05c-4b6e-b716-a2080104dc5b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpreview_pricing_and_billing_pro_49.mp4"><img src="https://cursor.com/artifacts/c/art-5362de16-f6c6-46c0-8376-5eb95f22b211" alt="preview_pricing_and_billing_pro_49.mp4" /></a>

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `54fab226` · **Head:** `94911070`

**Classification:** extends — Pro list price, Pro execute cap, `max` compute runaway caps, and unique-DW alert threshold change; retired Stripe price matching expands so old Pro ids keep entitlements.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `entitlements` | auth | extends — Pro execute 2,000 → 800; `max` execute 500,000 → 25,000, fetches 2,000,000 → 80,000, jobs 1,000,000 → 40,000, concurrent 5,000 → 200 |
| `billing` | auth | extends — retired $29 / $288 Pro price ids stay matched |
| `app-ui` | surfaces | extends — `/pricing` and `/account/billing` publish $49 / $40 annual; Pro unique-DW alert $49 |

### Change flow

Published Pro price and plan compute caps flow from `plans.ts` into checkout matching, entitlement enforcement, and the unique-DW operator alert.

```mermaid
sequenceDiagram
	actor User
	participant appUi as app-ui
	participant entitlements as entitlements
	participant billing as billing
	User->>appUi: GET /pricing or /account/billing
	appUi->>entitlements: read planLimits.pro (800 execute/day)
	Note over appUi: list price $49/mo or $480/year
	User->>billing: checkout / webhook refresh
	billing->>entitlements: resolveEffectivePlan via Stripe price id
	Note over billing: current + retired Pro ids map to pro
	entitlements-->>appUi: enforce plan execute / fetch / job / workflow caps
	Note over entitlements: max execute 25,000/day ($50 unique-DW ceiling)
```

### Before / after

| Surface | Before | After |
| --- | --- | --- |
| Pro monthly / annual | $29 / $24/mo ($288/year) | $49 / $40/mo ($480/year) |
| Pro execute/day | 2,000 | 800 |
| Pro unique-DW alert | $29 | $49 |
| `max` execute/day | 500,000 | 25,000 |
| `max` fetches/day | 2,000,000 | 80,000 |
| `max` job runs/day | 1,000,000 | 40,000 |
| `max` concurrent workflows | 5,000 | 200 |
| Stripe checkout ids | $29 / $288 prices | same ids until Kent creates $49 / $480 prices |

### Invariants

Per-user isolation is unchanged. `max` stays manual-only and is not a public power tier. Every `max` compute cap still dominates Pro.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3ace7e23-b05c-4b6e-b716-a2080104dc5b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3ace7e23-b05c-4b6e-b716-a2080104dc5b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated Pro plan pricing to $49/month or $480/year ($40/month billed annually).
  * Revised Pro plan messaging to reflect expanded capacity.
  * Updated Pro execution limits to 800 calls per day.
  * Increased the Pro Dynamic Worker cost alert threshold to $49.
  * Adjusted Max plan compute and rate limits to better reflect production usage.

* **Bug Fixes**
  * Preserved recognition of existing Pro subscriptions using retired pricing.

* **Documentation**
  * Updated pricing, billing, usage, setup, and subscription documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->