### PR TITLE
Run every validate lane in CI and queue production deploys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,9 @@ permissions:
 # Queue rather than cancel: the job runs D1 migrations before the worker
 # uploads and deploys platform before runtime, so cancelling mid-sequence
 # leaves new schema with old code or mismatched Durable Object bindings.
+# GitHub keeps at most one pending run per group and replaces it with a newer
+# one; that is intended, because the job only ever deploys `main` HEAD, so a
+# superseded pending run would have been a no-op.
 concurrency:
   group: deploy-production
   cancel-in-progress: false

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,9 +15,12 @@ permissions:
   deployments: write
   pull-requests: read
 
+# Queue rather than cancel: the job runs D1 migrations before the worker
+# uploads and deploys platform before runtime, so cancelling mid-sequence
+# leaves new schema with old code or mismatched Durable Object bindings.
 concurrency:
   group: deploy-production
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   sha-guard:

--- a/.github/workflows/dr-escrow.yml
+++ b/.github/workflows/dr-escrow.yml
@@ -3,6 +3,9 @@ name: DR secret escrow
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   seal-escrow:
     name: Seal SECRET_STORE_KEY into DR backup bucket

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -102,6 +102,26 @@ jobs:
         if: ${{ !cancelled() }}
         run: npm run platform:build
 
+      - name: 🖍️ Highlight build
+        if: ${{ !cancelled() }}
+        run: npm run highlight:build
+
+      - name: 📦 Worker startup bundles
+        if: ${{ !cancelled() }}
+        run: npm run worker-startup-bundles:check
+
+      - name: 🚚 Origin production exports
+        if: ${{ !cancelled() }}
+        run: npm run origin-production-exports:check
+
+      - name: 🧽 Slop ratchet
+        if: ${{ !cancelled() }}
+        run: npm run slop-ratchet:check
+
+      - name: 🪓 Knip
+        if: ${{ !cancelled() }}
+        run: npm run knip
+
       - name: 🗺️ Primitives
         if: ${{ !cancelled() }}
         run: npm run primitives:check

--- a/packages/worker/client/routes/admin-users-shared.ts
+++ b/packages/worker/client/routes/admin-users-shared.ts
@@ -64,6 +64,33 @@ export function getListKey(href: string) {
 	return `q=${filters.search}&role=${filters.role}&verification=${filters.verification}`
 }
 
+/** Apply filter changes to the current href; filter changes re-anchor at page one. */
+export function buildFilteredListHref(
+	currentHref: string,
+	nextFilters: Partial<AdminUserFilterState>,
+) {
+	const url = new URL(currentHref, 'http://localhost')
+	const filters = { ...readFilterState(url.toString()), ...nextFilters }
+	if (filters.search) url.searchParams.set('q', filters.search)
+	else url.searchParams.delete('q')
+	if (filters.role) url.searchParams.set('role', filters.role)
+	else url.searchParams.delete('role')
+	if (filters.verification) {
+		url.searchParams.set('verification', filters.verification)
+	} else url.searchParams.delete('verification')
+	url.searchParams.delete('page')
+	return `${url.pathname}${url.search}`
+}
+
+export function buildUserDetailHrefFrom(
+	currentHref: string,
+	stableUserId: string,
+) {
+	const url = new URL(currentHref, 'http://localhost')
+	url.searchParams.delete('page')
+	return buildDetailHref(stableUserId, url.search)
+}
+
 export function getDataKey(href: string) {
 	const pathname = new URL(href, 'http://localhost').pathname
 	return `${pathname}?${getListKey(href)}`

--- a/packages/worker/client/routes/admin-users.tsx
+++ b/packages/worker/client/routes/admin-users.tsx
@@ -26,7 +26,8 @@ import {
 	type AdminUserFilterState,
 	adminUserUsageApiPath,
 	buildAdminUsersApiRequestUrl,
-	buildDetailHref,
+	buildFilteredListHref,
+	buildUserDetailHrefFrom,
 	getDataKey,
 	getListKey,
 	getSelection,
@@ -153,24 +154,11 @@ export function AdminUsersRoute(handle: Handle) {
 	function buildHrefWithUpdatedFilters(
 		nextFilters: Partial<AdminUserFilterState>,
 	) {
-		const url = new URL(getCurrentHref(), 'http://localhost')
-		const filters = { ...readFilterState(url.toString()), ...nextFilters }
-		if (filters.search) url.searchParams.set('q', filters.search)
-		else url.searchParams.delete('q')
-		if (filters.role) url.searchParams.set('role', filters.role)
-		else url.searchParams.delete('role')
-		if (filters.verification) {
-			url.searchParams.set('verification', filters.verification)
-		} else url.searchParams.delete('verification')
-		// Filter changes re-anchor the list at the first page.
-		url.searchParams.delete('page')
-		return `${url.pathname}${url.search}`
+		return buildFilteredListHref(getCurrentHref(), nextFilters)
 	}
 
 	function buildUserDetailHref(stableUserId: string) {
-		const url = new URL(getCurrentHref(), 'http://localhost')
-		url.searchParams.delete('page')
-		return buildDetailHref(stableUserId, url.search)
+		return buildUserDetailHrefFrom(getCurrentHref(), stableUserId)
 	}
 
 	async function loadUserUsage(stableUserId: string) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Make the CI gate actually equal to `npm run validate`, and make production deploys queue instead of cancelling each other.

## Why

The 2026-09-01 launch-readiness audit found:

- `validate.yml` ran 18 of the 23 `validate` lanes. Missing: `worker-startup-bundles:check`, `origin-production-exports:check`, `slop-ratchet:check`, `knip`, `highlight:build`. The two multi-worker drift checks and the size ratchet were enforced only when a contributor ran `validate` locally. Proof: `slop-ratchet:check` is already red on `main` — `admin-users.tsx` reached 812 lines against an 800-line budget.
- `deploy.yml` used `cancel-in-progress: true` on `deploy-production`. The job applies D1 migrations before the origin upload and deploys platform before runtime, so a second merge within a few minutes could cancel the first between steps and leave new schema on old code or mismatched Durable Object bindings.
- `dr-escrow.yml` was the only workflow without a `permissions:` block while holding `SECRET_STORE_KEY` and the escrow passphrase.

## Summary

- `validate.yml`: add the five missing lanes to the `static` job (`if: !cancelled()` like their siblings).
- `deploy.yml`: `cancel-in-progress: false` with a comment explaining the ordering hazard.
- `dr-escrow.yml`: `permissions: contents: read`.
- `admin-users.tsx` → 800 lines by moving the two pure href builders (`buildFilteredListHref`, `buildUserDetailHrefFrom`) into `admin-users-shared.ts`. No behaviour change.

## Testing

Ran locally on this branch: `npm run deploy-guardrails:check`, `npm run format:check`, `npm run lint`, `npm run knip`, `npm run highlight:build`, `npm run worker-startup-bundles:check`, `npm run origin-production-exports:check`, `npm run slop-ratchet:check` (now passes), `nx run worker:typecheck` (uncached). The five new CI steps are the same commands.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `40e70929` · **Head:** `HEAD`

**Classification:** composes — CI/workflow configuration plus a pure-function move inside `app-ui`; no primitive behaviour changes.

### Primitives touched

| Primitive | Group    | Impact                                              |
| --------- | -------- | --------------------------------------------------- |
| `app-ui`  | surfaces | composes — href builders moved to a shared module   |

### Change flow

The CI static job gains the five lanes that `npm run validate` already runs; production deploys queue.

```mermaid
flowchart LR
	validate["validate.yml static job"]:::touched
	lanes["highlight:build · worker-startup-bundles:check · origin-production-exports:check · slop-ratchet:check · knip"]:::touched
	deploy["deploy.yml deploy-production"]:::touched
	validate -->|"new steps"| lanes
	validate -->|"workflow_run success → queued, never cancelled"| deploy
	classDef touched fill:#1a7f37,color:#fff
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b0f6a92a-81cd-4157-8b60-188c83ca84c0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b0f6a92a-81cd-4157-8b60-188c83ca84c0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved navigation for admin user lists and details.
  * Updating search, role, or verification filters now returns results to the first page.
  * User detail links preserve relevant list context.

* **Bug Fixes**
  * Production deployments now wait for active deployments to finish instead of cancelling them.
  * Validation now includes additional build and quality checks.
  * Deployment workflows use more restricted permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->