### PR TITLE
Batch onboarding MCP chooser listing loads

### DIFF
--- a/packages/worker/src/app/community-data.node.test.ts
+++ b/packages/worker/src/app/community-data.node.test.ts
@@ -21,6 +21,7 @@ const mockModule = vi.hoisted(() => ({
 	searchCommunityListings: vi.fn(),
 	listFeaturedCommunityListingsWithAggregates: vi.fn(),
 	getCommunityListingWithAggregates: vi.fn(),
+	getCommunityListingsByIds: vi.fn(),
 	listCommunityForksByListingIdsAndUser: vi.fn(),
 	getCommunityListingById: vi.fn(),
 	getEntitySourceById: vi.fn(),
@@ -48,6 +49,8 @@ vi.mock('#worker/community/service.ts', () => ({
 		mockModule.listFeaturedCommunityListingsWithAggregates(...args),
 	getCommunityListingWithAggregates: (...args: Array<unknown>) =>
 		mockModule.getCommunityListingWithAggregates(...args),
+	getCommunityListingsByIds: (...args: Array<unknown>) =>
+		mockModule.getCommunityListingsByIds(...args),
 }))
 
 vi.mock('#worker/community/repo.ts', () => ({
@@ -178,19 +181,16 @@ test('community index overlays matching kody_id installs for signed-in viewers',
 test('onboarding MCP chooser listings load official packages by pinned id', async () => {
 	resetDataCacheForTests()
 	mockModule.readAuthenticatedAppUser.mockResolvedValue(null)
-	mockModule.getCommunityListingWithAggregates.mockImplementation(
-		async (input: { listingId: string }) => {
-			if (input.listingId !== onboardingFeaturedMcpServers[0].listingId) {
-				return null
-			}
-			return {
-				...sampleListing,
-				id: input.listingId,
-				kodyId: 'notion-mcp',
-				name: '@kody/notion-mcp',
-			}
-		},
+	const pinnedIds = onboardingFeaturedMcpServers.map(
+		(server) => server.listingId,
 	)
+	const visibleListing = {
+		...sampleListing,
+		id: onboardingFeaturedMcpServers[0].listingId,
+		kodyId: 'notion-mcp',
+		name: '@kody/notion-mcp',
+	}
+	mockModule.getCommunityListingsByIds.mockResolvedValue([visibleListing])
 
 	const listings = await loadOnboardingMcpChooserListings(
 		{} as Env,
@@ -203,7 +203,19 @@ test('onboarding MCP chooser listings load official packages by pinned id', asyn
 			name: '@kody/notion-mcp',
 		}),
 	])
-	expect(mockModule.getCommunityListingWithAggregates).toHaveBeenCalledTimes(6)
+	expect(mockModule.getCommunityListingsByIds).toHaveBeenCalledTimes(1)
+	expect(mockModule.getCommunityListingsByIds).toHaveBeenCalledWith(
+		undefined,
+		pinnedIds,
+		{ includeDelisted: false },
+	)
+
+	const cached = await loadOnboardingMcpChooserListings(
+		{} as Env,
+		new Request('https://example.com/onboarding'),
+	)
+	expect(cached).toEqual(listings)
+	expect(mockModule.getCommunityListingsByIds).toHaveBeenCalledTimes(1)
 })
 
 test('onboarding featured listings overlay inert forks as adaptation_required', async () => {

--- a/packages/worker/src/app/community-data.ts
+++ b/packages/worker/src/app/community-data.ts
@@ -33,6 +33,7 @@ import { recordServerTiming } from '#worker/request-context.ts'
 import {
 	getCommunityCategoryCounts,
 	getCommunityListingWithAggregates,
+	getCommunityListingsByIds,
 	listCommunityIndexOverview,
 	listCommunityListingsWithAggregates,
 	listFeaturedCommunityListingsWithAggregates,
@@ -245,18 +246,10 @@ export async function loadOnboardingMcpChooserListings(
 			request,
 			buildCommunityOnboardingMcpPackagesCacheKey(),
 			async () => {
-				const rows = await Promise.all(
-					listingIds.map((listingId) =>
-						getCommunityListingWithAggregates({
-							env,
-							listingId,
-							includeDelisted: false,
-						}),
-					),
-				)
-				return rows
-					.filter((row) => row != null)
-					.map(toOnboardingFeaturedListing)
+				const rows = await getCommunityListingsByIds(env.APP_DB, listingIds, {
+					includeDelisted: false,
+				})
+				return rows.map(toOnboardingFeaturedListing)
 			},
 		)
 		const user = await readOptionalAuthenticatedViewer(request, env)

--- a/packages/worker/src/app/handlers/onboarding.node.test.ts
+++ b/packages/worker/src/app/handlers/onboarding.node.test.ts
@@ -36,6 +36,7 @@ vi.mock('#app/authenticated-user.ts', () => ({
 vi.mock('#worker/community/service.ts', () => ({
 	listFeaturedCommunityListingsWithAggregates: vi.fn(async () => []),
 	getCommunityListingWithAggregates: vi.fn(async () => null),
+	getCommunityListingsByIds: vi.fn(async () => []),
 }))
 
 vi.mock('#worker/mcp-client/settings-service.ts', () => ({

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -68,6 +68,7 @@ vi.mock('#worker/community/service.ts', () => ({
 		communityMockModule.getCommunityListingWithAggregates(...args),
 	reportCommunityListing: vi.fn(),
 	listFeaturedCommunityListingsWithAggregates: vi.fn(async () => []),
+	getCommunityListingsByIds: vi.fn(async () => []),
 }))
 
 // Owner/kody-id resolution is covered against the real schema in

--- a/packages/worker/src/community/community-listings-by-ids.node.test.ts
+++ b/packages/worker/src/community/community-listings-by-ids.node.test.ts
@@ -1,0 +1,193 @@
+import { DatabaseSync } from 'node:sqlite'
+import { expect, test } from 'vitest'
+import { createD1FromSqlite } from '#worker/test-support/create-d1-from-sqlite.ts'
+import { ensureCommunityFlowSchema } from './community-flow-test-schema.ts'
+import {
+	getCommunityListingById,
+	insertCommunityBan,
+	insertCommunityFork,
+	insertCommunityListing,
+	upsertCommunityRating,
+} from './repo.ts'
+import {
+	getCommunityListingWithAggregates,
+	getCommunityListingsByIds,
+} from './service.ts'
+import { type CommunityListingStatus } from './types.ts'
+
+async function createListingsDb() {
+	const sqlite = new DatabaseSync(':memory:')
+	await ensureCommunityFlowSchema(createD1FromSqlite(sqlite))
+	const queries: Array<string> = []
+	const db = createD1FromSqlite(sqlite, { queries })
+	return { db, queries }
+}
+
+async function insertListing(
+	db: D1Database,
+	input: {
+		id: string
+		status?: CommunityListingStatus
+		ownerUserId?: string
+		kodyId?: string
+	},
+) {
+	const kodyId = input.kodyId ?? input.id
+	await insertCommunityListing(db, {
+		id: input.id,
+		owner_user_id: input.ownerUserId ?? 'owner-1',
+		package_id: `pkg-${input.id}`,
+		source_id: `src-${input.id}`,
+		kody_id: kodyId,
+		name: `@owner/${kodyId}`,
+		description: `${kodyId} helpers`,
+		tags_json: '[]',
+		category: 'other',
+		search_text: null,
+		readme_content: null,
+		license: 'MIT',
+		pinned_commit: 'commit-1',
+		status: input.status ?? 'active',
+	})
+}
+
+test('getCommunityListingsByIds returns public listings in input order with batched aggregates', async () => {
+	const { db, queries } = await createListingsDb()
+
+	queries.length = 0
+	expect(
+		await getCommunityListingsByIds(db, [], { includeDelisted: false }),
+	).toEqual([])
+	expect(queries).toEqual([])
+
+	await insertListing(db, { id: 'listing-a', kodyId: 'alpha' })
+	await insertListing(db, { id: 'listing-b', kodyId: 'beta' })
+	await insertListing(db, { id: 'listing-c', kodyId: 'gamma' })
+	await insertListing(db, {
+		id: 'listing-delisted',
+		kodyId: 'retired',
+		status: 'delisted',
+	})
+	await insertListing(db, {
+		id: 'listing-banned-owner',
+		kodyId: 'banned-pkg',
+		ownerUserId: 'owner-banned',
+	})
+	await insertCommunityBan(db, {
+		user_id: 'owner-banned',
+		banned_by_user_id: 'admin-1',
+		reason: 'spam',
+	})
+	await upsertCommunityRating(db, {
+		id: 'rating-b',
+		listing_id: 'listing-b',
+		user_id: 'rater-1',
+		stars: 4,
+		adaptation_effort: 2,
+		note: null,
+	})
+	await insertCommunityFork(db, {
+		id: 'fork-b-1',
+		listing_id: 'listing-b',
+		forker_user_id: 'forker-1',
+		origin_commit: 'commit-1',
+		forked_package_id: 'pkg-fork-b-1',
+		forked_source_id: 'src-fork-b-1',
+		target_kody_id: 'beta',
+		listing_name: '@owner/beta',
+		listing_kody_id: 'beta',
+	})
+	await insertCommunityFork(db, {
+		id: 'fork-b-2',
+		listing_id: 'listing-b',
+		forker_user_id: 'forker-2',
+		origin_commit: 'commit-1',
+		forked_package_id: 'pkg-fork-b-2',
+		forked_source_id: 'src-fork-b-2',
+		target_kody_id: 'beta',
+		listing_name: '@owner/beta',
+		listing_kody_id: 'beta',
+	})
+
+	expect(
+		await getCommunityListingById(db, {
+			listingId: 'listing-delisted',
+			includeDelisted: false,
+		}),
+	).toBeNull()
+	expect(
+		await getCommunityListingById(db, {
+			listingId: 'missing',
+			includeDelisted: false,
+		}),
+	).toBeNull()
+	expect(
+		await getCommunityListingById(db, {
+			listingId: 'listing-banned-owner',
+			includeDelisted: false,
+		}),
+	).toEqual(
+		expect.objectContaining({
+			id: 'listing-banned-owner',
+			status: 'active',
+		}),
+	)
+
+	queries.length = 0
+	const publicRows = await getCommunityListingsByIds(
+		db,
+		[
+			'listing-c',
+			'missing',
+			'listing-a',
+			'listing-delisted',
+			'listing-b',
+			'listing-banned-owner',
+		],
+		{ includeDelisted: false },
+	)
+	expect(publicRows.map((listing) => listing.id)).toEqual([
+		'listing-c',
+		'listing-a',
+		'listing-b',
+		'listing-banned-owner',
+	])
+	expect(publicRows.find((listing) => listing.id === 'listing-b')).toEqual(
+		expect.objectContaining({
+			id: 'listing-b',
+			averageStars: 4,
+			ratingCount: 1,
+			averageAdaptationEffort: 2,
+			forkCount: 2,
+		}),
+	)
+	expect(queries).toHaveLength(3)
+	expect(queries.filter((query) => query.includes(' IN ('))).toHaveLength(3)
+
+	const withDelisted = await getCommunityListingsByIds(
+		db,
+		['listing-delisted', 'listing-a', 'missing'],
+		{ includeDelisted: true },
+	)
+	expect(withDelisted.map((listing) => listing.id)).toEqual([
+		'listing-delisted',
+		'listing-a',
+	])
+	expect(
+		await getCommunityListingById(db, {
+			listingId: 'listing-delisted',
+			includeDelisted: true,
+		}),
+	).toEqual(
+		expect.objectContaining({ id: 'listing-delisted', status: 'delisted' }),
+	)
+
+	const single = await getCommunityListingWithAggregates({
+		env: { APP_DB: db } as Env,
+		listingId: 'listing-b',
+		includeDelisted: false,
+	})
+	expect(publicRows.find((listing) => listing.id === 'listing-b')).toEqual(
+		single,
+	)
+})

--- a/packages/worker/src/community/repo.ts
+++ b/packages/worker/src/community/repo.ts
@@ -411,6 +411,51 @@ export async function getCommunityListingById(
 	return row ? mapCommunityListingRow(row) : null
 }
 
+/**
+ * Same visibility and owner-source join as `getCommunityListingById`, for a
+ * set of ids. Unknown ids are omitted. Results follow `listingIds` order
+ * (first occurrence wins if an id is repeated).
+ */
+export async function getCommunityListingsByIds(
+	db: D1Database,
+	input: {
+		listingIds: Array<string>
+		includeDelisted: boolean
+	},
+): Promise<Array<CommunityListingRecord>> {
+	if (input.listingIds.length === 0) return []
+	const uniqueIds = [...new Set(input.listingIds)]
+	const statusClause = input.includeDelisted
+		? ''
+		: `AND community_listings.status = 'active'`
+	const byId = new Map<string, CommunityListingRecord>()
+	for (const idChunk of chunkArray(uniqueIds, maxSqlBindingsPerChunk)) {
+		const placeholders = idChunk.map(() => '?').join(', ')
+		const rows = await db
+			.prepare(
+				`SELECT ${communityListingSelectColumns}
+				FROM community_listings
+				${communityListingSourceJoin}
+				WHERE community_listings.id IN (${placeholders}) ${statusClause}`,
+			)
+			.bind(...idChunk)
+			.all<Record<string, unknown>>()
+		for (const row of rows.results ?? []) {
+			const listing = mapCommunityListingRow(row)
+			byId.set(listing.id, listing)
+		}
+	}
+	const ordered: Array<CommunityListingRecord> = []
+	const seen = new Set<string>()
+	for (const listingId of input.listingIds) {
+		if (seen.has(listingId)) continue
+		seen.add(listingId)
+		const listing = byId.get(listingId)
+		if (listing) ordered.push(listing)
+	}
+	return ordered
+}
+
 export async function getActiveCommunityListingWithPublisherUsername(
 	db: D1Database,
 	input: { listingId: string },

--- a/packages/worker/src/community/service.ts
+++ b/packages/worker/src/community/service.ts
@@ -59,6 +59,7 @@ import {
 	getCommunityForkByListingAndUser,
 	getActiveCommunityListingWithPublisherUsername,
 	getCommunityListingById,
+	getCommunityListingsByIds as getCommunityListingsByIdsFromDb,
 	getCommunityListingByOwnerAndKodyId,
 	getCommunityListingByOwnerAndPackage,
 	listCommunityForksByListingAndUser,
@@ -830,6 +831,22 @@ export async function getCommunityListingWithAggregates(input: {
 	})
 	if (!listing) return null
 	return await attachListingAggregates(input.env.APP_DB, listing)
+}
+
+/**
+ * Public listing cards for a fixed id set (onboarding chooser). One listing
+ * `IN (...)` plus the two aggregate batch queries, then ordered by `ids`.
+ */
+export async function getCommunityListingsByIds(
+	db: D1Database,
+	ids: Array<string>,
+	options: { includeDelisted: boolean },
+): Promise<Array<CommunityListingWithAggregates>> {
+	const listings = await getCommunityListingsByIdsFromDb(db, {
+		listingIds: ids,
+		includeDelisted: options.includeDelisted,
+	})
+	return await attachListingAggregatesBatch(db, listings)
 }
 
 export async function listCommunityListingsWithAggregates(input: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Make `/onboarding` — the first page every new user lands on — stop paying an N+1 over the six pinned MCP-server listings.

## Why

The 2026-09-01 launch-readiness audit measured `server-timing: listings;dur=246..655ms` and TTFB up to 3.6 s on production `/onboarding`. `loadOnboardingMcpChooserListings` called `getCommunityListingWithAggregates` per id (listing + ratings + forks = 3 D1 queries each, ~18 per cache miss), and the per-isolate 60 s cache misses most of the time at low traffic.

## Summary

- `community/repo.ts`: `getCommunityListingsByIds` — one `WHERE id IN (...)` (chunked by the existing max-bindings helper) with the same `status = 'active'` filter and `entity_sources` join as `getCommunityListingById`; results follow input order, unknown ids are skipped, empty input issues no query.
- `community/service.ts`: `getCommunityListingsByIds(db, ids, options)` composes that with the existing `attachListingAggregatesBatch`.
- `app/community-data.ts`: the onboarding chooser uses the batch helper. Detail and MCP `get` paths are unchanged.
- Tests: `community-data.node.test.ts` now asserts the batched shape; new `community-listings-by-ids.node.test.ts` covers ordering, unknown ids, visibility parity with `getCommunityListingById`, and the empty case.

Before: 18 D1 queries per chooser cache miss. After: 3, independent of listing count.

## Testing

`npm run typecheck`, `npm run lint`, `npm run format:check`; `CI=1 npx vitest run --config vitest.node.config.ts packages/worker/src/app/community-data.node.test.ts packages/worker/src/community/community-listings-by-ids.node.test.ts` (7 passed) and `packages/worker/src/community/community-service.node.test.ts` (27 passed, regression).

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `40e70929` · **Head:** `HEAD`

**Classification:** composes — a new batched read helper over existing tables; no schema, contract, or visibility change.

### Primitives touched

| Primitive            | Group    | Impact                                          |
| -------------------- | -------- | ----------------------------------------------- |
| `community-catalog`  | features | composes — batched read of pinned listings      |
| `d1-app-db`          | storage  | composes — `IN (...)` read on `community_listings` |

### Change flow

The onboarding chooser loads its six pinned listings with one listing query plus the two existing aggregate batch queries.

```mermaid
sequenceDiagram
	participant onboarding as app-ui /onboarding
	participant communityData as community-data
	participant service as community service
	participant d1AppDb as d1-app-db
	onboarding->>communityData: loadOnboardingMcpChooserListings
	communityData->>service: getCommunityListingsByIds(ids, includeDelisted=false)
	service->>d1AppDb: SELECT … WHERE id IN (?, ?, …) AND status='active'
	service->>d1AppDb: ratings aggregate batch (existing)
	service->>d1AppDb: forks aggregate batch (existing)
	Note over service: results reordered to input id order; unknown ids dropped
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b0f6a92a-81cd-4157-8b60-188c83ca84c0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b0f6a92a-81cd-4157-8b60-188c83ca84c0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added batch retrieval of community listings by ID, preserving requested order and removing duplicates.
  * Community listings now include ratings and fork counts from batched data.
  * Added an option to include delisted listings.

* **Performance**
  * Improved onboarding MCP chooser loading by fetching pinned listings in a single request.
  * Prevented repeated lookups when cached listings are requested again.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->