### PR TITLE
Show package.json version on community listings

### DIFF
--- a/docs/contributing/community-packages.md
+++ b/docs/contributing/community-packages.md
@@ -42,13 +42,13 @@ package vector indexes.
 The squashed baseline (`packages/worker/migrations/0001-squashed-init.sql`)
 defines the community tables and profile columns.
 
-| Table                | Purpose                                                                            |
-| -------------------- | ---------------------------------------------------------------------------------- |
-| `community_listings` | Listing metadata, pinned commit, browse `category`, status (`active` / `delisted`) |
-| `community_forks`    | Fork records linking listing, forker, and inert `source_id`                        |
-| `community_ratings`  | Per-user ratings (upsert on `listing_id` + `user_id`)                              |
-| `community_reports`  | Reports with denormalized `listing_name` / `listing_owner_user_id`                 |
-| `community_bans`     | Community-wide bans (publish, fork, rate, report)                                  |
+| Table                | Purpose                                                                                                                                 |
+| -------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `community_listings` | Listing metadata, pinned commit, optional `package_version` (`package.json#version`), browse `category`, status (`active` / `delisted`) |
+| `community_forks`    | Fork records linking listing, forker, and inert `source_id`                                                                             |
+| `community_ratings`  | Per-user ratings (upsert on `listing_id` + `user_id`)                                                                                   |
+| `community_reports`  | Reports with denormalized `listing_name` / `listing_owner_user_id`                                                                      |
+| `community_bans`     | Community-wide bans (publish, fork, rate, report)                                                                                       |
 
 | Table / column                    | Purpose                                                                          |
 | --------------------------------- | -------------------------------------------------------------------------------- |

--- a/docs/use/community-packages.md
+++ b/docs/use/community-packages.md
@@ -68,11 +68,13 @@ The catalog defaults to **Best**. **Newest** orders by last community publish.
 **Featured** is editorial onboarding placement only — not a safety badge. There
 is no trusted-listing review mark.
 
-The detail page opens with the README. Next to **Featured** (when present) a
-pill says **Install**, **Installed**, **Forked**, or **Fork outdated**. When
-default-branch HEAD is newer than the last package publish, a **HEAD ahead of
-published** badge appears. You can also ask your agent to use `communitySearch`
-or `communityGet`.
+The detail page opens with the README. The facts row shows **Version** from
+`package.json#version` when the author set a string (same label on catalog
+cards), plus license, last publish date, and the pinned commit. Next to
+**Featured** (when present) a pill says **Install**, **Installed**, **Forked**,
+or **Fork outdated**. When default-branch HEAD is newer than the last package
+publish, a **HEAD ahead of published** badge appears. You can also ask your
+agent to use `communitySearch` or `communityGet`.
 
 ## Forking a listing
 

--- a/packages/worker/migrations/0040-community-listing-package-version.sql
+++ b/packages/worker/migrations/0040-community-listing-package-version.sql
@@ -1,0 +1,5 @@
+-- Author-supplied package.json#version for catalog display. Null when the
+-- author omitted it or the listing predates this column. Not a platform
+-- versioning contract — listings stay identified by pinned_commit.
+ALTER TABLE community_listings
+ADD COLUMN package_version TEXT;

--- a/packages/worker/migrations/0040-community-listing-package-version.sql
+++ b/packages/worker/migrations/0040-community-listing-package-version.sql
@@ -1,5 +1,65 @@
 -- Author-supplied package.json#version for catalog display. Null when the
 -- author omitted it or the listing predates this column. Not a platform
 -- versioning contract — listings stay identified by pinned_commit.
-ALTER TABLE community_listings
-ADD COLUMN package_version TEXT;
+--
+-- Rebuild instead of ADD COLUMN so this file is safe on preview D1s that
+-- already applied the same column under the pre-rebase filename
+-- 0039-community-listing-package-version.sql. Copy lists every live column
+-- except package_version (NULL when the source table lacks it; preview
+-- catalogs that already have the column are empty).
+DROP TABLE IF EXISTS community_listings_0040;
+CREATE TABLE community_listings_0040 (
+	id TEXT PRIMARY KEY NOT NULL,
+	owner_user_id TEXT NOT NULL,
+	package_id TEXT NOT NULL,
+	source_id TEXT NOT NULL,
+	kody_id TEXT NOT NULL,
+	name TEXT NOT NULL,
+	description TEXT NOT NULL,
+	tags_json TEXT NOT NULL DEFAULT '[]',
+	category TEXT NOT NULL DEFAULT 'other' CHECK (
+		category IN (
+			'integrations',
+			'examples',
+			'productivity',
+			'apps',
+			'utilities',
+			'other'
+		)
+	),
+	search_text TEXT,
+	readme_content TEXT,
+	license TEXT NOT NULL,
+	package_version TEXT,
+	pinned_commit TEXT NOT NULL,
+	status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'delisted')),
+	trusted_commit TEXT,
+	trusted_by_user_id TEXT,
+	trusted_at TEXT,
+	featured_at TEXT,
+	created_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+	updated_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+	published_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP)
+);
+INSERT INTO community_listings_0040 (
+	id, owner_user_id, package_id, source_id, kody_id, name, description,
+	tags_json, category, search_text, readme_content, license, package_version,
+	pinned_commit, status, trusted_commit, trusted_by_user_id, trusted_at,
+	featured_at, created_at, updated_at, published_at
+)
+SELECT
+	id, owner_user_id, package_id, source_id, kody_id, name, description,
+	tags_json, category, search_text, readme_content, license, NULL,
+	pinned_commit, status, trusted_commit, trusted_by_user_id, trusted_at,
+	featured_at, created_at, updated_at, published_at
+FROM community_listings;
+DROP TABLE community_listings;
+ALTER TABLE community_listings_0040 RENAME TO community_listings;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_community_listings_owner_package
+	ON community_listings(owner_user_id, package_id);
+CREATE INDEX IF NOT EXISTS idx_community_listings_status
+	ON community_listings(status);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_community_listings_owner_kody_id_active
+	ON community_listings(owner_user_id, kody_id) WHERE status = 'active';
+CREATE INDEX IF NOT EXISTS idx_community_listings_category
+	ON community_listings(category);

--- a/packages/worker/src/app/community-detail-content.node.test.ts
+++ b/packages/worker/src/app/community-detail-content.node.test.ts
@@ -12,6 +12,7 @@ const sampleListing = {
 	category: 'integrations',
 	readmeContent: '# README',
 	license: 'MIT',
+	version: '1.0.4',
 	pinnedCommit: 'abc1234567890',
 	publishedAt: '2026-07-13T00:00:00.000Z',
 	ownerUsername: 'kentcdodds',
@@ -145,7 +146,16 @@ test('package chrome is shared for public listings and private owner packages', 
 	expect(publicHtml).toContain('data-testid="community-browse-files"')
 	expect(publicHtml).toContain('href="/@kentcdodds/github-triage/tree/main"')
 	expect(publicHtml).toContain('data-testid="community-detail-forks"')
+	expect(publicHtml).toContain('data-testid="community-detail-version"')
+	expect(publicHtml).toContain('1.0.4')
 	expect(publicHtml).toContain('← Public packages')
+
+	const noVersionHtml = await renderCommunityDetailContentHtml({
+		...detailBase,
+		listing: { ...sampleListing, version: null },
+		loggedIn: false,
+	})
+	expect(noVersionHtml).not.toContain('data-testid="community-detail-version"')
 
 	const ownerHtml = await renderCommunityDetailContentHtml({
 		...detailBase,

--- a/packages/worker/src/app/community-detail-content.tsx
+++ b/packages/worker/src/app/community-detail-content.tsx
@@ -147,6 +147,14 @@ export function CommunityDetailContent(
 					</ul>
 
 					<dl data-rise style={{ '--rise': '4' }} mix={css(metaCss)}>
+						{listing.version ? (
+							<div>
+								<dt>Version</dt>
+								<dd data-testid="community-detail-version">
+									{listing.version}
+								</dd>
+							</div>
+						) : null}
 						<div>
 							<dt>License</dt>
 							<dd>{listing.license}</dd>

--- a/packages/worker/src/app/community-listings-content.node.test.ts
+++ b/packages/worker/src/app/community-listings-content.node.test.ts
@@ -12,6 +12,7 @@ const sampleListing = {
 	category: 'integrations',
 	readmeContent: '# README',
 	license: 'MIT',
+	version: '1.0.4',
 	pinnedCommit: 'abc1234567890',
 	publishedAt: '2026-07-13T00:00:00.000Z',
 	ownerUsername: 'kentcdodds',
@@ -61,6 +62,10 @@ test('community listings render sort controls, categories, empty states, and for
 	expect(listingsHtml).toContain(
 		'data-testid="community-listing-published-listing-1"',
 	)
+	expect(listingsHtml).toContain(
+		'data-testid="community-listing-version-listing-1"',
+	)
+	expect(listingsHtml).toContain('1.0.4')
 	expect(listingsHtml).toContain('href="/community?sort=newest"')
 	expect(listingsHtml).toContain('href="/community"')
 	expect(listingsHtml).toContain('data-testid="community-listings-categories"')

--- a/packages/worker/src/app/community-listings-content.tsx
+++ b/packages/worker/src/app/community-listings-content.tsx
@@ -256,6 +256,12 @@ function renderCommunityListingCard(
 				<span data-testid={`community-listing-forks-${listing.id}`}>
 					{formatCount(listing.forkCount, 'fork')}
 				</span>
+				{listing.version ? (
+					<span data-testid={`community-listing-version-${listing.id}`}>
+						<span mix={css(visuallyHiddenCss)}>Version </span>
+						{listing.version}
+					</span>
+				) : null}
 				<span
 					data-testid={`community-listing-published-${listing.id}`}
 					title={`Last published ${formatCommunityPublishedDate(listing.publishedAt)}`}

--- a/packages/worker/src/app/community-public.ts
+++ b/packages/worker/src/app/community-public.ts
@@ -119,6 +119,7 @@ export function toPublicCommunityListing(
 		category: listing.category,
 		readmeContent: listing.readmeContent,
 		license: listing.license,
+		version: listing.version ?? null,
 		pinnedCommit: listing.pinnedCommit,
 		publishedAt: listing.publishedAt,
 		ownerUsername: getOwnerUsernameFromListingName(listing.name),

--- a/packages/worker/src/community/community-activity-service.node.test.ts
+++ b/packages/worker/src/community/community-activity-service.node.test.ts
@@ -70,6 +70,7 @@ CREATE TABLE community_listings (
 	search_text TEXT,
 	readme_content TEXT,
 	license TEXT NOT NULL,
+	package_version TEXT,
 	pinned_commit TEXT NOT NULL,
 	status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'delisted')),
 	created_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP),

--- a/packages/worker/src/community/community-flow-test-schema.ts
+++ b/packages/worker/src/community/community-flow-test-schema.ts
@@ -96,6 +96,7 @@ export async function ensureCommunityFlowSchema(db: D1Database) {
 			search_text TEXT,
 			readme_content TEXT,
 			license TEXT NOT NULL,
+			package_version TEXT,
 			pinned_commit TEXT NOT NULL,
 			status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'delisted')),
 			trusted_commit TEXT,

--- a/packages/worker/src/community/community-flow.workers.test.ts
+++ b/packages/worker/src/community/community-flow.workers.test.ts
@@ -119,6 +119,7 @@ async function seedOwnerPackage(input: {
 	const packageJson = `${JSON.stringify(
 		{
 			name: packageName,
+			version: '1.0.4',
 			license: 'MIT',
 			exports: { '.': './src/index.ts' },
 			kody: {
@@ -254,6 +255,7 @@ test('public package flow works end-to-end through capability handlers', async (
 		name: `@usera/${kodyId}`,
 		kody_id: kodyId,
 		license: '',
+		version: '1.0.4',
 		status: 'active',
 		pinned_commit: publishedCommit,
 		public_url: `${baseUrl}/@usera/${kodyId}`,

--- a/packages/worker/src/community/community-service.node.test.ts
+++ b/packages/worker/src/community/community-service.node.test.ts
@@ -333,6 +333,7 @@ function validPublishSource() {
 		files: {
 			'package.json': JSON.stringify({
 				name: '@owner/discord-gateway',
+				version: '1.0.4',
 				license: 'MIT',
 				exports: { '.': './src/index.ts' },
 				kody: {
@@ -788,6 +789,7 @@ test('publishCommunityListing stores long README content and drops binary icon b
 		expect.objectContaining({
 			readme_content: expect.stringContaining('## Intent'),
 			category: 'integrations',
+			package_version: '1.0.4',
 		}),
 	)
 	expect(mockModule.writeCommunitySnapshot).toHaveBeenCalledWith(

--- a/packages/worker/src/community/community-service.node.test.ts
+++ b/packages/worker/src/community/community-service.node.test.ts
@@ -401,7 +401,7 @@ test('publishCommunityListing rolls back D1 when KV snapshot write fails', async
 		}),
 	)
 
-	const existingListing = sampleListing()
+	const existingListing = sampleListing({ version: '1.0.3' })
 	mockModule.getCommunityListingByOwnerAndPackage.mockResolvedValue(
 		existingListing,
 	)
@@ -422,6 +422,7 @@ test('publishCommunityListing rolls back D1 when KV snapshot write fails', async
 		expect.anything(),
 		expect.objectContaining({
 			listingId: existingListing.id,
+			packageVersion: '1.0.3',
 			pinnedCommit: existingListing.pinnedCommit,
 			publishedAt: existingListing.publishedAt,
 		}),

--- a/packages/worker/src/community/package-version.node.test.ts
+++ b/packages/worker/src/community/package-version.node.test.ts
@@ -1,0 +1,33 @@
+import { expect, test } from 'vitest'
+import {
+	readPackageManifestVersion,
+	resolveListingPackageVersion,
+} from './package-version.ts'
+
+test('readPackageManifestVersion accepts a string version and rejects the rest', () => {
+	expect(readPackageManifestVersion('{"version":"1.0.4"}')).toBe('1.0.4')
+	expect(readPackageManifestVersion('{"version":"  1.0.4-beta.1  "}')).toBe(
+		'1.0.4-beta.1',
+	)
+	expect(readPackageManifestVersion('{"version":1}')).toBeNull()
+	expect(readPackageManifestVersion('{"version":""}')).toBeNull()
+	expect(readPackageManifestVersion('{"version":"1 0"}')).toBeNull()
+	expect(readPackageManifestVersion('{"name":"@a/b"}')).toBeNull()
+	expect(readPackageManifestVersion('{')).toBeNull()
+	expect(readPackageManifestVersion(null)).toBeNull()
+	expect(
+		readPackageManifestVersion(`{"version":"${'x'.repeat(65)}"}`),
+	).toBeNull()
+	expect(
+		resolveListingPackageVersion({
+			stored: '1.0.3',
+			packageJson: '{"version":"1.0.4"}',
+		}),
+	).toBe('1.0.3')
+	expect(
+		resolveListingPackageVersion({
+			stored: null,
+			packageJson: '{"version":"1.0.4"}',
+		}),
+	).toBe('1.0.4')
+})

--- a/packages/worker/src/community/package-version.ts
+++ b/packages/worker/src/community/package-version.ts
@@ -1,0 +1,49 @@
+const maxPackageManifestVersionLength = 64
+
+export function normalizePackageManifestVersion(
+	value: string | null | undefined,
+): string | null {
+	if (value == null) return null
+	const trimmed = value.trim()
+	if (
+		trimmed.length === 0 ||
+		trimmed.length > maxPackageManifestVersionLength ||
+		/\s/.test(trimmed)
+	) {
+		return null
+	}
+	return trimmed
+}
+
+/**
+ * Read `package.json#version` as display metadata. The platform does not
+ * version packages (decision 0001); this is the author-supplied label when
+ * they set a string.
+ */
+export function readPackageManifestVersion(
+	content: string | null | undefined,
+): string | null {
+	if (content == null || content.trim() === '') return null
+	let parsed: unknown
+	try {
+		parsed = JSON.parse(content)
+	} catch {
+		return null
+	}
+	if (parsed == null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+		return null
+	}
+	const version = Reflect.get(parsed, 'version')
+	if (typeof version !== 'string') return null
+	return normalizePackageManifestVersion(version)
+}
+
+export function resolveListingPackageVersion(input: {
+	stored?: string | null
+	packageJson?: string | null
+}): string | null {
+	return (
+		normalizePackageManifestVersion(input.stored) ??
+		readPackageManifestVersion(input.packageJson)
+	)
+}

--- a/packages/worker/src/community/repo.ts
+++ b/packages/worker/src/community/repo.ts
@@ -7,6 +7,7 @@ import {
 	type CommunityCategoryCounts,
 	type CommunityListingCategory,
 } from '#universal/community-categories.ts'
+import { normalizePackageManifestVersion } from './package-version.ts'
 import {
 	type CommunityActivityKind,
 	type CommunityActivityRecord,
@@ -49,6 +50,10 @@ export function mapCommunityListingRow(
 		readmeContent:
 			row['readme_content'] == null ? null : String(row['readme_content']),
 		license: String(row['license']),
+		version:
+			row['package_version'] == null
+				? null
+				: normalizePackageManifestVersion(String(row['package_version'])),
 		pinnedCommit,
 		iconCommit:
 			row['source_published_commit'] == null
@@ -174,6 +179,7 @@ export const communityListingSelectColumns = `community_listings.id, community_l
 	community_listings.name, community_listings.description, community_listings.tags_json,
 	community_listings.category,
 	community_listings.search_text, community_listings.readme_content, community_listings.license,
+	community_listings.package_version,
 	community_listings.pinned_commit, community_listings.status, community_listings.created_at,
 	community_listings.updated_at, community_listings.published_at,
 	community_listings.trusted_commit, community_listings.trusted_by_user_id,
@@ -295,9 +301,10 @@ export async function insertCommunityListing(
 		.prepare(
 			`INSERT INTO community_listings (
 				id, owner_user_id, package_id, source_id, kody_id, name, description,
-				tags_json, category, search_text, readme_content, license, pinned_commit, status,
+				tags_json, category, search_text, readme_content, license, package_version,
+				pinned_commit, status,
 				created_at, updated_at, published_at
-			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		)
 		.bind(
 			row.id,
@@ -312,6 +319,7 @@ export async function insertCommunityListing(
 			row.search_text ?? null,
 			row.readme_content ?? null,
 			row.license,
+			row.package_version,
 			row.pinned_commit,
 			row.status,
 			row.created_at ?? now,
@@ -335,6 +343,7 @@ export async function updateCommunityListing(
 		searchText?: string | null
 		readmeContent?: string | null
 		license?: string
+		packageVersion?: string | null
 		pinnedCommit?: string
 		status?: CommunityListingStatus
 		publishedAt?: string
@@ -364,6 +373,9 @@ export async function updateCommunityListing(
 		addAssignment('readme_content', input.readmeContent ?? null)
 	}
 	if (input.license !== undefined) addAssignment('license', input.license)
+	if (input.packageVersion !== undefined) {
+		addAssignment('package_version', input.packageVersion)
+	}
 	if (input.pinnedCommit !== undefined) {
 		addAssignment('pinned_commit', input.pinnedCommit)
 	}

--- a/packages/worker/src/community/repo.ts
+++ b/packages/worker/src/community/repo.ts
@@ -290,10 +290,12 @@ export async function insertCommunityListing(
 		| 'trusted_by_user_id'
 		| 'trusted_at'
 		| 'featured_at'
+		| 'package_version'
 	> & {
 		created_at?: string
 		updated_at?: string
 		published_at?: string
+		package_version?: string | null
 	},
 ): Promise<void> {
 	const now = new Date().toISOString()
@@ -319,7 +321,7 @@ export async function insertCommunityListing(
 			row.search_text ?? null,
 			row.readme_content ?? null,
 			row.license,
-			row.package_version,
+			row.package_version ?? null,
 			row.pinned_commit,
 			row.status,
 			row.created_at ?? now,

--- a/packages/worker/src/community/service.ts
+++ b/packages/worker/src/community/service.ts
@@ -88,6 +88,10 @@ import {
 	deleteCommunityBan,
 } from './repo.ts'
 import {
+	readPackageManifestVersion,
+	resolveListingPackageVersion,
+} from './package-version.ts'
+import {
 	deleteCommunityActivityEventsByListingId,
 	insertCommunityActivityEvent,
 } from './profile-repo.ts'
@@ -549,6 +553,7 @@ export async function publishCommunityListing(input: {
 		)
 	}
 	const license = existingListing?.license ?? ''
+	const packageVersion = readPackageManifestVersion(packageJsonContent)
 	const fullReadme = buildPackageReadmeDetail({
 		files: loadedSource.files,
 		maxChars: Number.MAX_SAFE_INTEGER,
@@ -602,6 +607,7 @@ export async function publishCommunityListing(input: {
 				searchText: savedPackage.searchText,
 				readmeContent: fullReadme?.content ?? '',
 				license,
+				packageVersion,
 				pinnedCommit: publishedCommit,
 				publishedAt: now,
 				requireStatus: 'active',
@@ -625,6 +631,7 @@ export async function publishCommunityListing(input: {
 				search_text: savedPackage.searchText,
 				readme_content: fullReadme?.content ?? '',
 				license,
+				package_version: packageVersion,
 				pinned_commit: publishedCommit,
 				status: 'active',
 				published_at: now,
@@ -830,7 +837,26 @@ export async function getCommunityListingWithAggregates(input: {
 		includeDelisted: input.includeDelisted,
 	})
 	if (!listing) return null
-	return await attachListingAggregates(input.env.APP_DB, listing)
+	return await attachListingAggregates(
+		input.env.APP_DB,
+		await withSnapshotPackageVersion(input.env, listing),
+	)
+}
+
+async function withSnapshotPackageVersion(
+	env: Env,
+	listing: CommunityListingRecord,
+): Promise<CommunityListingRecord> {
+	if (listing.version || !env.BUNDLE_ARTIFACTS_KV) return listing
+	const snapshot = await readCommunitySnapshot(
+		env.BUNDLE_ARTIFACTS_KV,
+		listing.id,
+	)
+	const version = resolveListingPackageVersion({
+		stored: listing.version,
+		packageJson: snapshot?.files['package.json'],
+	})
+	return version ? { ...listing, version } : listing
 }
 
 /**

--- a/packages/worker/src/community/service.ts
+++ b/packages/worker/src/community/service.ts
@@ -468,6 +468,7 @@ async function restoreCommunityListingAfterPublishFailure(input: {
 				searchText: input.existingListing.searchText,
 				readmeContent: input.existingListing.readmeContent,
 				license: input.existingListing.license,
+				packageVersion: input.existingListing.version ?? null,
 				pinnedCommit: input.existingListing.pinnedCommit,
 				publishedAt: input.existingListing.publishedAt,
 			})
@@ -848,15 +849,23 @@ async function withSnapshotPackageVersion(
 	listing: CommunityListingRecord,
 ): Promise<CommunityListingRecord> {
 	if (listing.version || !env.BUNDLE_ARTIFACTS_KV) return listing
-	const snapshot = await readCommunitySnapshot(
-		env.BUNDLE_ARTIFACTS_KV,
-		listing.id,
-	)
-	const version = resolveListingPackageVersion({
-		stored: listing.version,
-		packageJson: snapshot?.files['package.json'],
-	})
-	return version ? { ...listing, version } : listing
+	try {
+		const snapshot = await readCommunitySnapshot(
+			env.BUNDLE_ARTIFACTS_KV,
+			listing.id,
+		)
+		const version = resolveListingPackageVersion({
+			stored: listing.version,
+			packageJson: snapshot?.files['package.json'],
+		})
+		return version ? { ...listing, version } : listing
+	} catch (error) {
+		console.error(
+			'Failed to read community snapshot for listing package version:',
+			error,
+		)
+		return listing
+	}
 }
 
 /**

--- a/packages/worker/src/community/types.ts
+++ b/packages/worker/src/community/types.ts
@@ -17,6 +17,8 @@ export type CommunityListingRow = {
 	search_text: string | null
 	readme_content: string | null
 	license: string
+	/** package.json#version at last community publish, or null when absent. */
+	package_version: string | null
 	pinned_commit: string
 	status: CommunityListingStatus
 	trusted_commit: string | null
@@ -45,6 +47,12 @@ export type CommunityListingRecord = {
 	searchText: string | null
 	readmeContent: string | null
 	license: string
+	/**
+	 * Author-supplied `package.json#version` captured at community publish.
+	 * Null/omitted when the author did not set a string, or the listing
+	 * predates the column. Not a platform versioning contract.
+	 */
+	version?: string | null
 	pinnedCommit: string
 	/**
 	 * Commit the public listing icon is derived from: the owner package's

--- a/packages/worker/src/mcp/capabilities/community/get.ts
+++ b/packages/worker/src/mcp/capabilities/community/get.ts
@@ -42,6 +42,12 @@ export const communityGetCapability = defineDomainCapability(
 			tags: z.array(z.string()),
 			category: z.enum(communityListingCategories),
 			license: z.string(),
+			version: z
+				.string()
+				.nullable()
+				.describe(
+					'package.json#version from the pinned listing snapshot, or null when the author did not set a string version.',
+				),
 			pinned_commit: z.string(),
 			status: communityListingStatusSchema,
 			trusted: communityTrustedFieldSchema,
@@ -81,6 +87,7 @@ export const communityGetCapability = defineDomainCapability(
 				tags: listing.tags,
 				category: listing.category,
 				license: listing.license,
+				version: listing.version ?? null,
 				pinned_commit: listing.pinnedCommit,
 				status: listing.status,
 				trusted: listing.trusted,

--- a/packages/worker/src/mcp/capabilities/community/search.ts
+++ b/packages/worker/src/mcp/capabilities/community/search.ts
@@ -88,6 +88,7 @@ export const communitySearchCapability = defineDomainCapability(
 					description: listing.description,
 					tags: listing.tags,
 					category: listing.category,
+					version: listing.version ?? null,
 					owner_anonymous: true as const,
 					trusted: listing.trusted,
 					relevance: listing.relevance,

--- a/packages/worker/src/mcp/capabilities/community/shared.ts
+++ b/packages/worker/src/mcp/capabilities/community/shared.ts
@@ -62,6 +62,12 @@ export const communityListingSummarySchema = z.object({
 	description: z.string(),
 	category: z.enum(communityListingCategories),
 	license: z.string(),
+	version: z
+		.string()
+		.nullable()
+		.describe(
+			'package.json#version from the pinned listing snapshot, or null when the author did not set a string version.',
+		),
 	pinned_commit: z.string(),
 	status: communityListingStatusSchema,
 	public_url: communityPublicUrlSchema,
@@ -93,6 +99,12 @@ export const communitySearchMatchSchema =
 		description: z.string(),
 		tags: z.array(z.string()),
 		category: z.enum(communityListingCategories),
+		version: z
+			.string()
+			.nullable()
+			.describe(
+				'package.json#version from the pinned listing snapshot, or null when the author did not set a string version.',
+			),
 		owner_anonymous: z.literal(true),
 		trusted: communityTrustedFieldSchema,
 		relevance: z
@@ -156,6 +168,7 @@ export function toCommunityListingSummaryOutput(
 		description: listing.description,
 		category: listing.category,
 		license: listing.license,
+		version: listing.version ?? null,
 		pinned_commit: listing.pinnedCommit,
 		status: listing.status,
 		public_url: buildCommunityPublicUrl(baseUrl, {

--- a/packages/worker/universal/community-public-types.ts
+++ b/packages/worker/universal/community-public-types.ts
@@ -36,6 +36,11 @@ export type PublicCommunityListing = {
 	category: CommunityListingCategory
 	readmeContent: string | null
 	license: string
+	/**
+	 * Author-supplied `package.json#version` when present on the pinned
+	 * snapshot. Omitted or null when the author did not set a string.
+	 */
+	version?: string | null
 	pinnedCommit: string
 	/**
 	 * Git default-branch name for public `/tree/:ref` URLs. Omitted on cached

--- a/tools/migration-ledger.json
+++ b/tools/migration-ledger.json
@@ -159,6 +159,10 @@
 		{
 			"filename": "0039-agent-package-conversation-uses-last-used-index.sql",
 			"sha256": "24df954f08b0aa7fbbb76b880ee8cbb9b276cf120ed2c8633c37e464c39b4a68"
+		},
+		{
+			"filename": "0040-community-listing-package-version.sql",
+			"sha256": "611c5b4cd71f1c6cb994276187a53a8b7536b31c79edc9fb7d34f63deae4f79d"
 		}
 	]
 }

--- a/tools/migration-ledger.json
+++ b/tools/migration-ledger.json
@@ -162,7 +162,7 @@
 		},
 		{
 			"filename": "0040-community-listing-package-version.sql",
-			"sha256": "611c5b4cd71f1c6cb994276187a53a8b7536b31c79edc9fb7d34f63deae4f79d"
+			"sha256": "5c81de9e1ed697b2bdf86ba930962ffbf1f4ef0d582d741796df9ab3d91a46b0"
 		}
 	]
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Surface the author-supplied `package.json#version` on public catalog cards, listing detail, and community MCP reads so people can tell republishes apart without opening Files.

## Why

Feedback: a listing showed the pinned commit and publish date but not `package.json#version`, so v1.0.3 vs v1.0.4 was invisible. Decision 0001 still stands — this is a display label, not a versioning system. Catalog identity remains `pinned_commit`.

## Summary

- Store `package_version` on `community_listings` at community publish (migration 0040)
- Show **Version** on listing detail and catalog cards when present
- `communityGet` / `communitySearch` / publish summary return `version` (`null` when unset)
- Existing listings without a stored value fall back to the pinned snapshot’s `package.json` on single-listing reads
- Catalog/search stay stored-column only (no N KV reads); they pick up version on the next publish
- 0040 rebuilds the listings table so it is safe on this PR’s preview D1, which already added the column under the pre-rebase `0039-community-listing-package-version.sql` filename

## Testing

- `vitest` node-unit: package-version helper, listing/detail render, community publish, by-ids insert after optional `package_version`
- Pre-push: `test:node` (789 files) and `test:workers` (90 files), including community-flow
- `migrations:check` and worker typecheck on commit
- Rebased onto `main` (`56c5f291`) and renumbered the migration from 0039 → 0040 because `0039-agent-package-conversation-uses-last-used-index` landed first
- Local sqlite apply of 0040 on both a production-like table (no column) and a preview-like table (column already present)
- Preview (pre-rebuild): isolated D1 catalog empty; logged-in `/community` empty state; version UI covered by unit tests (publish needs MCP repo session)

## System changes

See system recap below.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `56c5f291` · **Head:** `58e1c2da`

**Classification:** extends — listing storage, public catalog HTML, and community MCP output gain an optional `package.json#version` label.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `community-listings` | assistant | extends — publish stores `package_version`; snapshot fallback on single-listing reads |
| `app-ui` | surfaces | extends — detail facts row and catalog cards show Version |
| `d1-app-db` | storage | extends — `community_listings.package_version` via idempotent 0040 rebuild |
| `mcp-server` | surfaces | extends — `communityGet` / `communitySearch` / publish summary add `version` |

### Change flow

Community publish writes the author label; catalog and MCP reads return it; missing stored values read the pinned snapshot on single-listing reads.

```mermaid
sequenceDiagram
	actor Author
	participant communityListings as community-listings
	participant d1AppDb as d1-app-db
	participant appUi as app-ui
	participant mcpServer as mcp-server
	Author->>communityListings: communityPublish
	communityListings->>d1AppDb: write package_version from package.json
	appUi->>communityListings: GET /@user/pkg
	communityListings->>d1AppDb: read listing row
	opt stored version missing
		communityListings->>communityListings: read pinned snapshot package.json
	end
	communityListings-->>appUi: PublicCommunityListing.version
	mcpServer->>communityListings: communityGet / communitySearch
	communityListings-->>mcpServer: version or null
```

### Before / after

| Surface | Before | After |
| --- | --- | --- |
| Detail facts | License, Published, Pinned commit | Version (when set), License, Published, Pinned commit |
| Catalog card | date / forks / ratings | plus version when set |
| MCP | no version field | `version: string \| null` |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eb28ad88-cace-4573-bb61-a1715a3dcf9d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eb28ad88-cace-4573-bb61-a1715a3dcf9d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Community package listings now display the author-provided package version on catalog cards and detail pages when available.
  * Package versions are included in community search and package details data.
  * Published listings preserve package versions, including when restoring a previous listing state.

* **Documentation**
  * Updated contributor and browsing documentation to explain package version display and storage.

* **Tests**
  * Added coverage for valid, invalid, missing, and restored package versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->