### PR TITLE
Gate email change on verification and handle stable_user_id collisions

### DIFF
--- a/docs/contributing/adding-capabilities.md
+++ b/docs/contributing/adding-capabilities.md
@@ -223,6 +223,7 @@ rule.
 - `adminUserGet`
 - `adminUserCreate`
 - `adminUserUpdate`
+- `adminUserStableIdConflict`
 - `adminUserVerify`
 - `adminAccountWriteLeaseList`
 - `adminAccountWriteLeaseRepair`

--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -271,7 +271,11 @@ The schema is defined by migrations in `packages/worker/migrations/`:
 - `users`: login identity and password hash, plus the persisted stable MCP
   `userId` (`stable_user_id`, with a NOT NULL unique index in
   `0001-squashed-init.sql`; initially SHA-256 of the normalized email at signup
-  via `createStableUserIdFromEmail`, then preserved across email changes).
+  via `createStableUserIdFromEmail`, then preserved across email changes). Email
+  change requires a verified current address (`users.email_verified_at` is
+  non-null). A `stable_user_id` unique collision at signup is a controlled 409;
+  operators inspect collisions with `adminUserStableIdConflict` (returns stable
+  user id, username, `created_at`, and email-verified state — never content).
   Optional community profile fields are `display_name`, `bio`, and
   `profile_visibility` (default `public`). `account_type` (`'person'` default or
   `'platform'`) distinguishes normal signups from operator-provisioned platform

--- a/docs/contributing/security.md
+++ b/docs/contributing/security.md
@@ -73,6 +73,16 @@ package-app surfaces:
     endpoint that accepts `application/x-www-form-urlencoded` or
     `multipart/form-data` from the browser, and do not relax the cookie to
     `SameSite=None`, without adding CSRF tokens at the same time.
+11. **Email change requires a verified current address.**
+    `POST /account/email-change.json` refuses to start a change when
+    `users.email_verified_at` is null (403, audit reason `email_unverified`). A
+    `stable_user_id` unique conflict at password or social-login signup is a
+    controlled 409 with audit reason `stable_user_id_exists` (message directs
+    the person to contact `support@kody.codes`) and releases a consumed invite.
+    Operators inspect collisions with `adminUserStableIdConflict` (metadata
+    only) and suspend or delete the squatting account with existing
+    capabilities. `users.stable_user_id` is never recomputed for an existing
+    account.
 
 ## First-party HTTP security headers
 

--- a/packages/worker/client/routes/account-profile-panel.tsx
+++ b/packages/worker/client/routes/account-profile-panel.tsx
@@ -278,80 +278,87 @@ export function renderAccountProfilePanel(props: AccountProfilePanelProps) {
 					</button>
 				</div>
 			</form>
-			<details
-				mix={css({
-					...accountDisclosureCss,
-					marginTop: '0.6rem',
-				})}
-			>
-				<summary>Change email</summary>
-				<form
-					{...passwordManagerIgnoreProps}
-					mix={[
-						css({
-							display: 'grid',
-							gap: spacing.md,
-							maxWidth: '26rem',
-						}),
-						on('submit', onEmailChangeSubmit),
-					]}
+			{emailVerified ? (
+				<details
+					mix={css({
+						...accountDisclosureCss,
+						marginTop: '0.6rem',
+					})}
 				>
-					<p mix={css(accountFieldNoteCss)}>
-						Enter your current password. We will send a verification link to the
-						new address before changing your account email.
-					</p>
-					<label mix={css(accountFieldCss)}>
-						<span mix={css(accountFieldLabelCss)}>New email</span>
-						<input
-							type="email"
-							name="email"
-							data-field-ring
-							required
-							autoComplete="email"
-							value={draftEmail}
-							mix={[css(accountInputCss), on('input', onDraftEmailInput)]}
-						/>
-					</label>
-					<label mix={css(accountFieldCss)}>
-						<span mix={css(accountFieldLabelCss)}>Current password</span>
-						<input
-							type="password"
-							name="password"
-							data-field-ring
-							required
-							{...passwordManagerIgnoreProps}
-							value={emailChangePassword}
-							mix={[
-								css(accountInputCss),
-								on('input', onEmailChangePasswordInput),
-							]}
-						/>
-					</label>
-					<div>
-						<button
-							type="submit"
-							disabled={
-								isSendingEmailChange ||
-								normalizedDraftEmail === email.trim().toLowerCase()
-							}
-							mix={css(compactGhostButtonCss)}
-						>
-							{isSendingEmailChange ? 'Sending...' : 'Send verification link'}
-						</button>
-					</div>
-					{emailChangeMessage ? (
-						<p
-							role="status"
-							mix={css({
-								color: emailChangeTone === 'error' ? colors.error : colors.text,
-								margin: 0,
-							})}
-						>
-							{emailChangeMessage}
+					<summary>Change email</summary>
+					<form
+						{...passwordManagerIgnoreProps}
+						mix={[
+							css({
+								display: 'grid',
+								gap: spacing.md,
+								maxWidth: '26rem',
+							}),
+							on('submit', onEmailChangeSubmit),
+						]}
+					>
+						<p mix={css(accountFieldNoteCss)}>
+							Enter your current password. We will send a verification link to
+							the new address before changing your account email.
 						</p>
-					) : null}
-				</form>
-			</details>
+						<label mix={css(accountFieldCss)}>
+							<span mix={css(accountFieldLabelCss)}>New email</span>
+							<input
+								type="email"
+								name="email"
+								data-field-ring
+								required
+								autoComplete="email"
+								value={draftEmail}
+								mix={[css(accountInputCss), on('input', onDraftEmailInput)]}
+							/>
+						</label>
+						<label mix={css(accountFieldCss)}>
+							<span mix={css(accountFieldLabelCss)}>Current password</span>
+							<input
+								type="password"
+								name="password"
+								data-field-ring
+								required
+								{...passwordManagerIgnoreProps}
+								value={emailChangePassword}
+								mix={[
+									css(accountInputCss),
+									on('input', onEmailChangePasswordInput),
+								]}
+							/>
+						</label>
+						<div>
+							<button
+								type="submit"
+								disabled={
+									isSendingEmailChange ||
+									normalizedDraftEmail === email.trim().toLowerCase()
+								}
+								mix={css(compactGhostButtonCss)}
+							>
+								{isSendingEmailChange ? 'Sending...' : 'Send verification link'}
+							</button>
+						</div>
+						{emailChangeMessage ? (
+							<p
+								role="status"
+								mix={css({
+									color:
+										emailChangeTone === 'error' ? colors.error : colors.text,
+									margin: 0,
+								})}
+							>
+								{emailChangeMessage}
+							</p>
+						) : null}
+					</form>
+				</details>
+			) : (
+				<p mix={css({ ...accountFieldNoteCss, marginTop: '0.6rem' })}>
+					Verify your current email address before changing it.
+				</p>
+			)}
 		</AccountManagementPanel>
 	)
 }

--- a/packages/worker/src/admin/users-data.ts
+++ b/packages/worker/src/admin/users-data.ts
@@ -27,7 +27,12 @@ import {
 	emailVerificationStallCutoffIso,
 	emailVerificationStallSqlConditions,
 } from '#worker/identity/email-verification-stall.ts'
-import { isStableUserId, normalizeStableUserId } from '#worker/user-id.ts'
+import { normalizeEmail } from '#worker/identity/normalize-email.ts'
+import {
+	createStableUserIdFromEmail,
+	isStableUserId,
+	normalizeStableUserId,
+} from '#worker/user-id.ts'
 
 export const adminUserRowSelectSql = `id, stable_user_id, username, email, email_verified_at, plan, stripe_plan, stripe_customer_id, suspended_at,
 				email_outbound_paused_at, email_verification_delivery_status, email_verification_delivery_at, email_verification_delivery_detail, email_verification_delivery_class,
@@ -512,6 +517,44 @@ export async function loadAdminUserRowByStableUserId(
 		)
 		.bind(stableUserId)
 		.first<AdminUserRow>()
+}
+
+export type StableUserIdConflict = {
+	stableUserId: string
+	username: string
+	created_at: string
+	email_verified: boolean
+}
+
+export async function findStableUserIdConflictByEmail(
+	db: D1Database,
+	email: string,
+): Promise<StableUserIdConflict | null> {
+	const normalizedEmail = normalizeEmail(email)
+	if (!normalizedEmail) return null
+	const stableUserId = await createStableUserIdFromEmail(normalizedEmail)
+	const row = await db
+		.prepare(
+			`SELECT stable_user_id, username, email, created_at, email_verified_at
+			 FROM users
+			 WHERE stable_user_id = ?`,
+		)
+		.bind(stableUserId)
+		.first<{
+			stable_user_id: string
+			username: string
+			email: string
+			created_at: string
+			email_verified_at: string | null
+		}>()
+	if (!row) return null
+	if (normalizeEmail(row.email) === normalizedEmail) return null
+	return {
+		stableUserId: row.stable_user_id,
+		username: row.username,
+		created_at: row.created_at,
+		email_verified: Boolean(row.email_verified_at),
+	}
 }
 
 function isRoleName(value: string): value is RoleName {

--- a/packages/worker/src/app/handlers/account-email-change.node.test.ts
+++ b/packages/worker/src/app/handlers/account-email-change.node.test.ts
@@ -11,6 +11,10 @@ import { hashVerificationToken } from '#app/email-verification.ts'
 import { createStableUserIdFromEmail } from '#worker/user-id.ts'
 import { createPasswordHash } from '@kody-internal/shared/password-hash.ts'
 import { applyAllMigrations } from '#worker/test-support/apply-all-migrations.ts'
+import {
+	auditEventSummaries,
+	logAuditEventSpy,
+} from '#worker/test-support/audit-log-spy.ts'
 import { consoleWarn } from '#worker/test-support/console-spies.ts'
 import { testStableUserIdFromEmail } from '#worker/test-support/stable-user-id.ts'
 import { createAccountEmailChangeHandler } from './account-email-change.ts'
@@ -270,6 +274,50 @@ test('email change requests require the current password and create a pending ve
 	})
 	expect(pendingRows[0]?.token_hash).not.toBe(firstPendingToken)
 	expect(consoleWarn).toHaveBeenCalledWith('email-change-send-skipped', 1)
+})
+
+test('unverified accounts cannot start an email change', async () => {
+	const { sqlite, db } = createMigratedDb()
+	await seedUser(sqlite, {
+		id: 1,
+		email: 'unverified@example.com',
+		username: 'unverified-user',
+		password: 'correct-password',
+		verified: false,
+	})
+	const handler = createAccountEmailChangeHandler(createAppEnv(db))
+
+	const response = await runHandler(
+		handler,
+		await createRequest({
+			session: {
+				stableUserId: testStableUserIdFromEmail('unverified@example.com'),
+				email: 'unverified@example.com',
+				rememberMe: false,
+			},
+			email: 'new@example.com',
+			password: 'correct-password',
+		}),
+	)
+	expect(response.status).toBe(403)
+	expect(await response.json()).toEqual({
+		ok: false,
+		error: 'Verify your current email address before changing it.',
+	})
+	expect(
+		sqlite
+			.prepare(`SELECT COUNT(*) AS count FROM pending_email_changes`)
+			.get() as { count: number },
+	).toEqual({ count: 0 })
+	expect(logAuditEventSpy).toHaveBeenCalledWith(
+		expect.objectContaining({
+			category: 'account',
+			action: 'email_change_request',
+			result: 'failure',
+			reason: 'email_unverified',
+		}),
+	)
+	expect(auditEventSummaries()).toEqual(['email_change_request:failure'])
 })
 
 test('email change requests reject emails already owned by another account', async () => {

--- a/packages/worker/src/app/handlers/account-email-change.ts
+++ b/packages/worker/src/app/handlers/account-email-change.ts
@@ -87,6 +87,26 @@ export function createAccountEmailChangeHandler(env: Env) {
 				return jsonResponse({ ok: false, error: 'Unauthorized.' }, 401)
 			}
 
+			if (!userRecord.email_verified_at) {
+				void logAuditEvent({
+					db: auditDatabaseFromEnv(env),
+					category: 'account',
+					action: 'email_change_request',
+					result: 'failure',
+					email: user.email,
+					ip: requestIp,
+					path: url.pathname,
+					reason: 'email_unverified',
+				})
+				return jsonResponse(
+					{
+						ok: false,
+						error: 'Verify your current email address before changing it.',
+					},
+					403,
+				)
+			}
+
 			const rateLimitKey = `email-change:user:${user.userId}`
 			const rateLimit = await checkRateLimit(
 				env.APP_DB,

--- a/packages/worker/src/app/handlers/auth-provider.node.test.ts
+++ b/packages/worker/src/app/handlers/auth-provider.node.test.ts
@@ -122,10 +122,16 @@ function createMigratedDb() {
 
 async function seedUser(
 	sqlite: DatabaseSync,
-	input: { id: number; email: string; username: string },
+	input: {
+		id: number
+		email: string
+		username: string
+		stableUserId?: string
+	},
 ) {
 	const passwordHash = await createPasswordHash('test-password')
-	const stableUserId = await createStableUserIdFromEmail(input.email)
+	const stableUserId =
+		input.stableUserId ?? (await createStableUserIdFromEmail(input.email))
 	sqlite.exec(`
 		INSERT INTO users (id, username, email, stable_user_id, password_hash)
 		VALUES (
@@ -1387,6 +1393,54 @@ test('OAuth signup persists first-touch UTMs from the start URL through login st
 				utmCampaign: 'bwk-2026-08-27',
 				landingPath: '/signup',
 			}),
+		}),
+	)
+})
+
+test('OAuth signup returns a controlled error when stable_user_id already exists and releases the invite', async () => {
+	const { sqlite, db } = createMigratedDb()
+	const victimEmail = 'victim-oauth@example.com'
+	await seedUser(sqlite, {
+		id: 1,
+		email: 'attacker-oauth@example.com',
+		username: 'attacker-oauth',
+		stableUserId: await createStableUserIdFromEmail(victimEmail),
+	})
+	seedInvite(sqlite, 'OAUTH-STABLE-ID')
+	const env = createAppEnv(db, { SIGNUP_MODE: 'invite' })
+	mockGithubProfileExchange(victimEmail)
+
+	const start = await startProviderFlow(
+		env,
+		'github',
+		'http://example.com/auth/github?inviteCode=oauth-stable-id',
+	)
+	const callback = await runHandler(
+		createAuthProviderCallbackHandler(env),
+		new Request(
+			`http://example.com/auth/github/callback?code=github-auth-code&state=${start.state}`,
+			{ headers: { Cookie: start.stateCookie } },
+		),
+		{ provider: 'github' },
+	)
+	expect(callback.status).toBe(302)
+	expect(callback.headers.get('Location')).toBe(
+		'/login?oauthError=email-unavailable',
+	)
+	expect(sqlite.prepare(`SELECT COUNT(*) AS count FROM users`).get()).toEqual({
+		count: 1,
+	})
+	expect(
+		sqlite
+			.prepare(`SELECT use_count FROM invites WHERE code = ?`)
+			.get('OAUTH-STABLE-ID') as { use_count: number },
+	).toEqual({ use_count: 0 })
+	expect(logAuditEventSpy).toHaveBeenCalledWith(
+		expect.objectContaining({
+			category: 'auth',
+			action: 'oauth_login',
+			result: 'failure',
+			reason: 'stable_user_id_exists',
 		}),
 	)
 })

--- a/packages/worker/src/app/handlers/auth-provider.ts
+++ b/packages/worker/src/app/handlers/auth-provider.ts
@@ -670,7 +670,11 @@ export function createAuthProviderCallbackHandler(env: Env) {
 				newUser = { id: createdUser.id, stable_user_id: stableUserId, email }
 			} catch (error) {
 				await releaseConsumedInvite()
-				if (getUniqueConstraintField(error)) {
+				const uniqueField = getUniqueConstraintField(error)
+				if (uniqueField === 'stable_user_id') {
+					return fail('email-unavailable', 'stable_user_id_exists')
+				}
+				if (uniqueField) {
 					return fail('account-error', 'user_create_conflict')
 				}
 				throw error

--- a/packages/worker/src/app/handlers/auth-stable-user-id-conflict.node.test.ts
+++ b/packages/worker/src/app/handlers/auth-stable-user-id-conflict.node.test.ts
@@ -1,0 +1,137 @@
+import { DatabaseSync } from 'node:sqlite'
+import { RequestContext } from 'remix/router'
+import { beforeAll, expect, test, vi } from 'vitest'
+import { setAuthSessionSecret } from '#app/auth-session.ts'
+import { quoteSqlString } from '@kody-internal/shared/sql-literals.ts'
+import { applyAllMigrations } from '#worker/test-support/apply-all-migrations.ts'
+import { createD1FromSqlite } from '#worker/test-support/create-d1-from-sqlite.ts'
+import {
+	auditEventSummaries,
+	logAuditEventSpy,
+} from '#worker/test-support/audit-log-spy.ts'
+import { createStableUserIdFromEmail } from '#worker/user-id.ts'
+
+const lifecycleMocks = vi.hoisted(() => ({
+	scheduleUserCreatedEvent: vi.fn(),
+}))
+
+vi.mock('#worker/identity/schedule-user-lifecycle-event.ts', () => ({
+	scheduleUserCreatedEvent: (...args: Array<unknown>) =>
+		lifecycleMocks.scheduleUserCreatedEvent(...args),
+	scheduleUserDeletedEvent: vi.fn(),
+}))
+
+const { createAuthHandler } = await import('#app/handlers/auth.ts')
+
+const testCookieSecret = 'test-cookie-secret-0123456789abcdef0123456789'
+const conflictMessage =
+	'This email address cannot be used for a new account. Contact support@kody.codes.'
+
+function applyMigrations(db: DatabaseSync) {
+	const migrationsDir = new URL('../../../migrations/', import.meta.url)
+	applyAllMigrations(db, migrationsDir)
+}
+
+function createMigratedDb() {
+	const sqlite = new DatabaseSync(':memory:')
+	applyMigrations(sqlite)
+	return { sqlite, db: createD1FromSqlite(sqlite) }
+}
+
+function seedSquattingAccount(
+	sqlite: DatabaseSync,
+	input: { email: string; username: string; stableUserId: string },
+) {
+	sqlite.exec(`
+		INSERT INTO users (username, email, stable_user_id, password_hash)
+		VALUES (
+			${quoteSqlString(input.username)},
+			${quoteSqlString(input.email)},
+			${quoteSqlString(input.stableUserId)},
+			'oauth_created_no_usable_password'
+		);
+	`)
+}
+
+function seedInvite(sqlite: DatabaseSync, code: string) {
+	sqlite.exec(`
+		INSERT INTO invites (code, created_by, note, max_uses, use_count)
+		VALUES (${quoteSqlString(code)}, NULL, '', 1, 0);
+	`)
+}
+
+function createHandler(db: D1Database, signupMode: 'open' | 'invite') {
+	return createAuthHandler({
+		COOKIE_SECRET: testCookieSecret,
+		APP_DB: db,
+		SIGNUP_MODE: signupMode,
+		SENTRY_ENVIRONMENT: signupMode === 'open' ? 'test' : 'production',
+	} as unknown as Parameters<typeof createAuthHandler>[0])
+}
+
+async function signup(
+	handler: ReturnType<typeof createAuthHandler>,
+	body: Record<string, unknown>,
+) {
+	const request = new Request('http://example.com/auth', {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify(body),
+	})
+	return handler.handler(new RequestContext(request))
+}
+
+beforeAll(() => {
+	setAuthSessionSecret(testCookieSecret)
+})
+
+test('signup returns 409 when sha256(email) collides with an existing stable_user_id and releases the invite', async () => {
+	const victimEmail = 'victim@example.com'
+	const victimStableUserId = await createStableUserIdFromEmail(victimEmail)
+	const { sqlite, db } = createMigratedDb()
+	seedSquattingAccount(sqlite, {
+		email: 'attacker@example.com',
+		username: 'attacker',
+		stableUserId: victimStableUserId,
+	})
+	const openHandler = createHandler(db, 'open')
+
+	const openResponse = await signup(openHandler, {
+		email: victimEmail,
+		username: 'victim-user',
+		password: 'password123',
+		mode: 'signup',
+	})
+	expect(openResponse.status).toBe(409)
+	expect(await openResponse.json()).toEqual({ error: conflictMessage })
+	expect(sqlite.prepare(`SELECT COUNT(*) AS count FROM users`).get()).toEqual({
+		count: 1,
+	})
+	expect(lifecycleMocks.scheduleUserCreatedEvent).not.toHaveBeenCalled()
+	expect(logAuditEventSpy).toHaveBeenCalledWith(
+		expect.objectContaining({
+			category: 'auth',
+			action: 'signup',
+			result: 'failure',
+			reason: 'stable_user_id_exists',
+		}),
+	)
+
+	seedInvite(sqlite, 'STABLE-ID-INVITE')
+	const inviteHandler = createHandler(db, 'invite')
+	const invitedResponse = await signup(inviteHandler, {
+		email: victimEmail,
+		username: 'victim-invited',
+		password: 'password123',
+		mode: 'signup',
+		inviteCode: 'stable-id-invite',
+	})
+	expect(invitedResponse.status).toBe(409)
+	expect(await invitedResponse.json()).toEqual({ error: conflictMessage })
+	expect(
+		sqlite
+			.prepare(`SELECT use_count FROM invites WHERE code = ?`)
+			.get('STABLE-ID-INVITE') as { use_count: number },
+	).toEqual({ use_count: 0 })
+	expect(auditEventSummaries()).toEqual(['signup:failure', 'signup:failure'])
+})

--- a/packages/worker/src/app/handlers/auth.ts
+++ b/packages/worker/src/app/handlers/auth.ts
@@ -72,6 +72,35 @@ const authRequestSchema = object({
 const dummyPasswordHash =
 	'pbkdf2_sha256$100000$00000000000000000000000000000000$0000000000000000000000000000000000000000000000000000000000000000'
 
+const stableUserIdConflictSignupMessage =
+	'This email address cannot be used for a new account. Contact support@kody.codes.'
+
+function signupUniqueConflict(
+	uniqueField: 'email' | 'username' | 'stable_user_id',
+) {
+	switch (uniqueField) {
+		case 'username':
+			return {
+				reason: 'username_exists',
+				error: 'Username already registered.',
+			}
+		case 'email':
+			return {
+				reason: 'email_exists',
+				error: 'Email already registered.',
+			}
+		case 'stable_user_id':
+			return {
+				reason: 'stable_user_id_exists',
+				error: stableUserIdConflictSignupMessage,
+			}
+		default: {
+			const exhaustive: never = uniqueField
+			throw new Error(`Unhandled unique field: ${String(exhaustive)}`)
+		}
+	}
+}
+
 export function createAuthHandler(env: Env) {
 	const db = createDb(env.APP_DB)
 
@@ -305,9 +334,13 @@ export function createAuthHandler(env: Env) {
 					record = { id: createdUser.id, stableUserId }
 				} catch (error) {
 					const uniqueField = getUniqueConstraintField(error)
-					if (uniqueField === 'email' || uniqueField === 'username') {
+					if (
+						uniqueField === 'email' ||
+						uniqueField === 'username' ||
+						uniqueField === 'stable_user_id'
+					) {
 						await releaseConsumedInvite()
-						const isUsernameConflict = uniqueField === 'username'
+						const conflict = signupUniqueConflict(uniqueField)
 						void logAuditEvent({
 							db: auditDatabaseFromEnv(env),
 							category: 'auth',
@@ -316,16 +349,9 @@ export function createAuthHandler(env: Env) {
 							email: normalizedEmail,
 							ip: requestIp,
 							path: url.pathname,
-							reason: isUsernameConflict ? 'username_exists' : 'email_exists',
+							reason: conflict.reason,
 						})
-						return Response.json(
-							{
-								error: isUsernameConflict
-									? 'Username already registered.'
-									: 'Email already registered.',
-							},
-							{ status: 409 },
-						)
+						return Response.json({ error: conflict.error }, { status: 409 })
 					}
 					await releaseConsumedInvite()
 					throw error

--- a/packages/worker/src/database-errors.node.test.ts
+++ b/packages/worker/src/database-errors.node.test.ts
@@ -1,0 +1,33 @@
+import { expect, test } from 'vitest'
+import { getUniqueConstraintField } from './database-errors.ts'
+
+test('getUniqueConstraintField reads table columns, named unique indexes, and wrapped causes', () => {
+	expect(
+		getUniqueConstraintField(
+			new Error('UNIQUE constraint failed: users.email'),
+		),
+	).toBe('email')
+	expect(
+		getUniqueConstraintField(
+			new Error('UNIQUE constraint failed: users.stable_user_id'),
+		),
+	).toBe('stable_user_id')
+	expect(
+		getUniqueConstraintField(
+			new Error('UNIQUE constraint failed: idx_users_stable_user_id'),
+		),
+	).toBe('stable_user_id')
+	expect(
+		getUniqueConstraintField(
+			new Error(
+				'D1_ERROR: UNIQUE constraint failed: idx_users_stable_user_id: SQLITE_CONSTRAINT',
+			),
+		),
+	).toBe('stable_user_id')
+
+	const wrapped = new Error('D1_ERROR')
+	wrapped.cause = new Error(
+		'UNIQUE constraint failed: idx_users_stable_user_id',
+	)
+	expect(getUniqueConstraintField(wrapped)).toBe('stable_user_id')
+})

--- a/packages/worker/src/database-errors.ts
+++ b/packages/worker/src/database-errors.ts
@@ -1,11 +1,23 @@
+const uniqueIndexFieldNames: Record<string, string> = {
+	idx_users_stable_user_id: 'stable_user_id',
+}
+
 export function getUniqueConstraintField(error: unknown) {
 	let currentError = error
 	while (currentError instanceof Error) {
-		const match = /unique constraint failed:\s*[^.]+\.([a-z0-9_]+)/i.exec(
+		const tableColumnMatch =
+			/unique constraint failed:\s*[^.]+\.([a-z0-9_]+)/i.exec(
+				currentError.message,
+			)
+		if (tableColumnMatch?.[1]) {
+			return tableColumnMatch[1].toLowerCase()
+		}
+		const indexMatch = /unique constraint failed:\s*(idx_[a-z0-9_]+)/i.exec(
 			currentError.message,
 		)
-		if (match?.[1]) {
-			return match[1].toLowerCase()
+		const indexName = indexMatch?.[1]?.toLowerCase()
+		if (indexName) {
+			return uniqueIndexFieldNames[indexName] ?? indexName
 		}
 		currentError = currentError.cause
 	}

--- a/packages/worker/src/mcp/capabilities/admin/admin-user-stable-id-conflict.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-user-stable-id-conflict.node.test.ts
@@ -1,0 +1,146 @@
+import { DatabaseSync } from 'node:sqlite'
+import { expect, test } from 'vitest'
+import { createMcpCallerContext } from '#mcp/context.ts'
+import { quoteSqlString } from '@kody-internal/shared/sql-literals.ts'
+import { applyAllMigrations } from '#worker/test-support/apply-all-migrations.ts'
+import {
+	auditEventSummaries,
+	logAuditEventSpy,
+} from '#worker/test-support/audit-log-spy.ts'
+import { createD1FromSqlite } from '#worker/test-support/create-d1-from-sqlite.ts'
+import { createStableUserIdFromEmail } from '#worker/user-id.ts'
+import { adminUserStableIdConflictCapability } from './admin-user-stable-id-conflict.ts'
+
+function createMigratedDb() {
+	const sqlite = new DatabaseSync(':memory:')
+	applyAllMigrations(
+		sqlite,
+		new URL('../../../../migrations/', import.meta.url),
+	)
+	return { sqlite, db: createD1FromSqlite(sqlite) }
+}
+
+function seedUser(
+	sqlite: DatabaseSync,
+	input: {
+		email: string
+		username: string
+		stableUserId: string
+		emailVerified: boolean
+		createdAt: string
+	},
+) {
+	sqlite.exec(`
+		INSERT INTO users (
+			username,
+			email,
+			stable_user_id,
+			password_hash,
+			email_verified_at,
+			created_at
+		) VALUES (
+			${quoteSqlString(input.username)},
+			${quoteSqlString(input.email)},
+			${quoteSqlString(input.stableUserId)},
+			'oauth_created_no_usable_password',
+			${input.emailVerified ? quoteSqlString(input.createdAt) : 'NULL'},
+			${quoteSqlString(input.createdAt)}
+		);
+	`)
+}
+
+function createContext(db: D1Database, roles: Array<string>) {
+	return {
+		env: { APP_DB: db } as Env,
+		callerContext: createMcpCallerContext({
+			baseUrl: 'https://heykody.dev',
+			user: {
+				userId: 'actor-1',
+				username: 'actor',
+				email: 'actor@example.com',
+				roles,
+			},
+		}),
+	}
+}
+
+test('adminUserStableIdConflict reports collisions without content and denies non-admins', async () => {
+	expect(adminUserStableIdConflictCapability.requiredRole).toBe('admin')
+	expect(adminUserStableIdConflictCapability.readOnly).toBe(true)
+
+	const { sqlite, db } = createMigratedDb()
+	const userCtx = createContext(db, ['user'])
+	await expect(
+		adminUserStableIdConflictCapability.handler(
+			{ email: 'victim@example.com' },
+			userCtx,
+		),
+	).rejects.toThrow('lacks required role "admin"')
+	expect(logAuditEventSpy).toHaveBeenCalledWith(
+		expect.objectContaining({
+			category: 'auth',
+			action: 'mcp_capability_denied',
+			result: 'failure',
+			reason: 'role',
+		}),
+	)
+
+	const adminCtx = createContext(db, ['admin'])
+	const missing = await adminUserStableIdConflictCapability.handler(
+		{ email: 'missing@example.com' },
+		adminCtx,
+	)
+	expect(missing).toEqual({ conflict: null })
+
+	const sameEmail = 'same@example.com'
+	const sameCreatedAt = '2026-01-02T00:00:00.000Z'
+	seedUser(sqlite, {
+		email: sameEmail,
+		username: 'same-user',
+		stableUserId: await createStableUserIdFromEmail(sameEmail),
+		emailVerified: true,
+		createdAt: sameCreatedAt,
+	})
+	const sameAccount = await adminUserStableIdConflictCapability.handler(
+		{ email: sameEmail },
+		adminCtx,
+	)
+	expect(sameAccount).toEqual({ conflict: null })
+
+	const victimEmail = 'victim@example.com'
+	const squatterCreatedAt = '2026-03-04T05:06:07.000Z'
+	const squatterStableUserId = await createStableUserIdFromEmail(victimEmail)
+	seedUser(sqlite, {
+		email: 'attacker@example.com',
+		username: 'squatter',
+		stableUserId: squatterStableUserId,
+		emailVerified: false,
+		createdAt: squatterCreatedAt,
+	})
+	const found = await adminUserStableIdConflictCapability.handler(
+		{ email: victimEmail },
+		adminCtx,
+	)
+	expect(found).toEqual({
+		conflict: {
+			stableUserId: squatterStableUserId,
+			username: 'squatter',
+			created_at: squatterCreatedAt,
+			email_verified: false,
+		},
+	})
+	expect(logAuditEventSpy).toHaveBeenCalledWith(
+		expect.objectContaining({
+			category: 'admin',
+			action: 'adminUserStableIdConflict',
+			result: 'success',
+			reason: `stable_user_id_conflict;target_stable_user_id=${squatterStableUserId}`,
+		}),
+	)
+	expect(auditEventSummaries()).toEqual([
+		'mcp_capability_denied:failure',
+		'adminUserStableIdConflict:success',
+		'adminUserStableIdConflict:success',
+		'adminUserStableIdConflict:success',
+	])
+})

--- a/packages/worker/src/mcp/capabilities/admin/admin-user-stable-id-conflict.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-user-stable-id-conflict.ts
@@ -1,0 +1,69 @@
+import { z } from 'zod'
+import { findStableUserIdConflictByEmail } from '#worker/admin/users-data.ts'
+import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
+import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
+import {
+	adminCapabilityAccess,
+	auditAdminCapabilityInvocation,
+	stableUserIdSchema,
+} from './admin-shared.ts'
+
+const inputSchema = z.object({
+	email: z
+		.string()
+		.email()
+		.describe(
+			'Email whose sha256 may already be stored as another account stable_user_id.',
+		),
+})
+
+const conflictSchema = z.object({
+	stableUserId: stableUserIdSchema,
+	username: z.string(),
+	created_at: z.string(),
+	email_verified: z.boolean(),
+})
+
+const outputSchema = z.object({
+	conflict: conflictSchema.nullable(),
+})
+
+export const adminUserStableIdConflictCapability = defineDomainCapability(
+	capabilityDomainNames.admin,
+	{
+		...adminCapabilityAccess,
+		name: 'adminUserStableIdConflict',
+		description:
+			'Report whether sha256 of an email is already stored as stable_user_id on an account whose current email is different. Admin-only metadata; never returns user content.',
+		keywords: [
+			'admin',
+			'user',
+			'stable user id',
+			'email',
+			'collision',
+			'signup',
+			'squat',
+		],
+		inputSchema,
+		outputSchema,
+		async handler(args, ctx) {
+			return auditAdminCapabilityInvocation(
+				ctx,
+				'adminUserStableIdConflict',
+				async () => {
+					const conflict = await findStableUserIdConflictByEmail(
+						ctx.env.APP_DB,
+						args.email,
+					)
+					return { conflict }
+				},
+				{
+					successReason: ({ conflict }) =>
+						conflict
+							? `stable_user_id_conflict;target_stable_user_id=${conflict.stableUserId}`
+							: 'stable_user_id_conflict_none',
+				},
+			)
+		},
+	},
+)

--- a/packages/worker/src/mcp/capabilities/admin/domain.ts
+++ b/packages/worker/src/mcp/capabilities/admin/domain.ts
@@ -33,6 +33,7 @@ import { adminUserCreateCapability } from './admin-user-create.ts'
 import { adminUserGetCapability } from './admin-user-get.ts'
 import { adminUserListCapability } from './admin-user-list.ts'
 import { adminUserUpdateCapability } from './admin-user-update.ts'
+import { adminUserStableIdConflictCapability } from './admin-user-stable-id-conflict.ts'
 import { adminUserVerifyCapability } from './admin-user-verify.ts'
 import { adminAccountDeletionAbortCapability } from './admin-account-deletion-abort.ts'
 import { adminAccountWriteLeaseListCapability } from './admin-account-write-lease-list.ts'
@@ -81,6 +82,7 @@ export const adminDomain = defineDomain({
 		adminUserGetCapability,
 		adminUserCreateCapability,
 		adminUserUpdateCapability,
+		adminUserStableIdConflictCapability,
 		adminUserVerifyCapability,
 		adminUserMeterParityCapability,
 		adminUserMeterStorageReconcileCapability,

--- a/packages/worker/src/mcp/capabilities/registry.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/registry.node.test.ts
@@ -96,6 +96,7 @@ test('getCapabilityRegistryForContext filters admin capabilities by current call
 	})
 
 	expect(adminRegistry.capabilityMap.adminUserList).toBeTruthy()
+	expect(adminRegistry.capabilityMap.adminUserStableIdConflict).toBeTruthy()
 	expect(adminRegistry.capabilityMap.adminUserMeterParity).toBeTruthy()
 	expect(adminRegistry.capabilityMap.adminAccountDeletionAbort).toBeTruthy()
 	expect(adminRegistry.capabilityMap.adminMailboxMaintenance).toBeTruthy()
@@ -106,6 +107,9 @@ test('getCapabilityRegistryForContext filters admin capabilities by current call
 		adminRegistry.capabilityDomains.some((domain) => domain.name === 'admin'),
 	).toBe(true)
 	expect(regularRegistry.capabilityMap.adminUserList).toBeUndefined()
+	expect(
+		regularRegistry.capabilityMap.adminUserStableIdConflict,
+	).toBeUndefined()
 	expect(regularRegistry.capabilityMap.adminUserMeterParity).toBeUndefined()
 	expect(
 		regularRegistry.capabilityMap.adminAccountDeletionAbort,

--- a/packages/worker/universal/oauth-login-errors.ts
+++ b/packages/worker/universal/oauth-login-errors.ts
@@ -21,6 +21,8 @@ export const oauthLoginErrorMessages = {
 	'invite-exhausted': 'That invite code has already been used.',
 	'connection-conflict':
 		'That provider account is already connected to a different user.',
+	'email-unavailable':
+		'This email address cannot be used for a new account. Contact support@kody.codes.',
 	'account-error': 'We could not create your account. Please try again.',
 	'rate-limited': 'Too many sign-in attempts. Please try again later.',
 } as const


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Close the permanent email-squatting path that open signup would expose, and give operators a way to see it.

## Why

`users.stable_user_id` is `sha256(signup email)` and is preserved across email changes (correctly — it names every Durable Object, Vectorize namespace, and KV prefix). But email change required only the current password, not a verified current address, and a `stable_user_id` unique-constraint hit on signup fell through to a 500. So: register `victim@x` (unverified), immediately rename the account to an attacker address, and the real owner can never sign up (hidden 500) or reset a password (no row for their address). One request per victim, unrecoverable without an operator. From the 2026-09-01 launch-readiness audit.

## Summary

- `account-email-change.ts`: refuse to start an email change while `email_verified_at` is null (`403`, audited as `email_change_request` / `email_unverified`); `account-profile-panel.tsx` hides the form and shows the same copy for unverified users.
- `auth.ts` and `auth-provider.ts` (new-account path): a `stable_user_id` unique conflict is a controlled `409` — "This email address cannot be used for a new account. Contact support@kody.codes." — releasing any consumed invite and auditing `stable_user_id_exists`. Exhaustive `switch` over the three conflict fields.
- `database-errors.ts`: `getUniqueConstraintField` recognizes `users.stable_user_id` and the `idx_users_stable_user_id` index-name form of SQLite's message.
- New admin-only capability `adminUserStableIdConflict({ email })` reports whether `sha256(email)` is stored on an account whose current email differs (metadata only: stable id, username, `created_at`, verified flag; never the account's email or content). Operators then suspend or delete with existing capabilities; id reassignment is deliberately out of scope.
- Docs: `security.md`, `architecture/data-storage.md`, `adding-capabilities.md`.

Not changed: `stable_user_id` derivation for existing or new accounts.

## Testing

`npm run typecheck`, `npm run lint`, `npm run format:check`, `npm run docs:check-temporal`, `npm run primitives:check`; node suites `account-email-change`, `auth-stable-user-id-conflict` (new), `auth-provider`, `auth-handler`, `admin-user-stable-id-conflict` (new), `database-errors`, `registry` — 7 files, 35 tests passed.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends</b> account identity guards (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `40e70929` · **Head:** `HEAD`

**Classification:** extends — new guard on email change, new controlled error path on signup, and a new read-only admin capability inside the existing `admin` domain (no new primitive; `primitives:check` passes).

### Primitives touched

| Primitive        | Group    | Impact                                                   |
| ---------------- | -------- | -------------------------------------------------------- |
| `app-sessions`   | surfaces | extends — email change requires verified current address |
| `signup`         | surfaces | extends — `stable_user_id` conflict → 409 + audit        |
| `admin-tools`    | features | extends — `adminUserStableIdConflict` (read-only)        |
| `d1-app-db`      | storage  | composes — reads `users` by `stable_user_id`             |

### Change flow

An unverified account cannot rename itself, and a colliding signup gets a controlled response instead of a 500.

```mermaid
sequenceDiagram
	actor User
	participant appSessions as app-sessions
	participant auth as signup (/auth)
	participant d1AppDb as d1-app-db
	participant auditLog as audit-log
	User->>appSessions: POST /account/email-change.json
	appSessions->>d1AppDb: read users.email_verified_at
	alt unverified
		appSessions->>auditLog: account/email_change_request failure email_unverified
		appSessions-->>User: 403 Verify your current email address first
	end
	User->>auth: POST /auth signup
	auth->>d1AppDb: INSERT users (stable_user_id = sha256(email))
	alt UNIQUE users.stable_user_id
		auth->>auditLog: auth/signup failure stable_user_id_exists
		auth-->>User: 409 controlled message (invite released)
	end
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b0f6a92a-81cd-4157-8b60-188c83ca84c0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b0f6a92a-81cd-4157-8b60-188c83ca84c0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

