### PR TITLE
Add signup consent, footer legal links, DMCA and licensing terms, and privacy disclosures

### DIFF
--- a/docs/use/privacy.md
+++ b/docs/use/privacy.md
@@ -26,6 +26,13 @@ metadata, and public activity are visible on `/@username`. When visibility is
 **private**, the public profile is not found. See
 [Public packages](./community-packages.md#public-profiles).
 
+The only cookies are the session cookie (`kody_session`) and the package-app
+session cookie on `kody.run` (`__Host-kody_pkg_session` on HTTPS,
+`kody_pkg_session` on HTTP). Short-lived cookies support two-factor
+verification, passkey challenges, and OAuth login. Analytics (Fathom) is
+cookieless. The browser uses sessionStorage for first-touch signup attribution
+and scroll restoration, not tracking cookies.
+
 Account export includes your profile columns and activity you authored. The
 browser download is a bounded metadata manifest; use its `accountExportSection`
 instructions to retrieve every D1, Durable Object, and R2 page for a complete
@@ -50,7 +57,8 @@ Kody fetches data from a connected service only to fulfill a request you, or a
 job you saved, just made. Content a package or job persists (for example a saved
 summary) stays in your account under the same isolation rules. Kody does not
 sell that data, use it for advertising, share it with other Kody users, or use
-it to train a Kody model. Kody makes no inference calls of its own.
+it to train a Kody model. We do not sell or share personal information as
+defined by the CCPA/CPRA. Kody makes no inference calls of its own.
 
 **Share, transfer, and disclose.** Provider data leaves your isolated account
 only to Cloudflare, which hosts the application, database, object storage, and
@@ -88,42 +96,43 @@ UI lists users and roles; it does not expose account content.
 Platform feedback you explicitly approve for admin review is a narrow
 user-content exception.
 
-Admins also moderate public community listings and attributed community reports,
-and can see who forked or rated a public listing, when, and the rating scores.
-One-click installs appear as forks because both use the same activity record.
-This activity view never includes private package source, rating notes, email,
-stable user ids, private profiles, secrets, or unrelated account content.
-Admin-configured notification packages may receive the same community metadata,
-and a metadata-only `user.created` or `user.deleted` event when a person account
-is created or self-deleted (stable user id, username, email, the create source
-or delete timestamp, the consumed invite code when `user.created` used one, and
-first-touch marketing attribution fields when present). Those lifecycle events
-omit passwords, roles, plan, secrets, and unrelated account content.
-Admin-configured notification packages may also receive a metadata-only
-`user.email_verification.failed` event when signup/verify mail first hits a
-terminal delivery failure (stable user id, username, email, status, `class`
-(`sender_block` / `other` / `null`), an admin user URL, and `occurred_at`). That
-event omits SMTP transcripts, tokens, and unrelated account content.
-Admin-configured notification packages may also receive a metadata-only
-`user.email_verification.stalled` event when signup/verify mail stays `accepted`
-for an hour with no Cloudflare lifecycle event (stable user id, username, email,
-`accepted_at`, stall threshold, an admin user URL, and `occurred_at`). That
-event omits SMTP transcripts, tokens, and unrelated account content.
-Admin-configured notification packages may also receive a metadata-only
-`user.email_outbound.paused` event when outbound sending is paused after a spam
-complaint or repeated bounces (stable user id, username, email, reason, bounce
-threshold when the reason is `bounced`, an admin user URL, and `occurred_at`).
-That event omits SMTP transcripts, message bodies, and unrelated account
-content. Admin-configured notification packages may also receive
-`email.system-message.sent` when operator correspondence leaves a reserved
-system sender (`kody@`, `support@`, and the other system locals). That event
-includes the recipients, subject, and sent text/HTML because outbound system
-mail is not stored on the inbound system-email graph; it is admin-only and omits
+Admins also moderate public community listings and community reports. Reporting
+a listing requires a signed-in user; reports are **not** anonymous — the
+reporter identity is attached. Admins can see who forked or rated a public
+listing, when, and the rating scores. One-click installs appear as forks because
+both use the same activity record. This activity view never includes private
+package source, rating notes, email, stable user ids, private profiles, secrets,
+or unrelated account content. Admin-configured notification packages may receive
+the same community metadata, and a metadata-only `user.created` or
+`user.deleted` event when a person account is created or self-deleted (stable
+user id, username, email, the create source or delete timestamp, the consumed
+invite code when `user.created` used one, and first-touch marketing attribution
+fields when present). Those lifecycle events omit passwords, roles, plan,
+secrets, and unrelated account content. Admin-configured notification packages
+may also receive a metadata-only `user.email_verification.failed` event when
+signup/verify mail first hits a terminal delivery failure (stable user id,
+username, email, status, `class` (`sender_block` / `other` / `null`), an admin
+user URL, and `occurred_at`). That event omits SMTP transcripts, tokens, and
 unrelated account content. Admin-configured notification packages may also
-receive metadata-only `auth.denial.burst` or `email.delivery.burst` events when
-hourly MCP auth denials or shared-domain bounce/complaint counts cross their
-thresholds (count, threshold, window, insights URL, and `observed_at`). Those
-events omit user identities, tokens, recipients, and message content.
+receive a metadata-only `user.email_verification.stalled` event when
+signup/verify mail stays `accepted` for an hour with no Cloudflare lifecycle
+event (stable user id, username, email, `accepted_at`, stall threshold, an admin
+user URL, and `occurred_at`). That event omits SMTP transcripts, tokens, and
+unrelated account content. Admin-configured notification packages may also
+receive a metadata-only `user.email_outbound.paused` event when outbound sending
+is paused after a spam complaint or repeated bounces (stable user id, username,
+email, reason, bounce threshold when the reason is `bounced`, an admin user URL,
+and `occurred_at`). That event omits SMTP transcripts, message bodies, and
+unrelated account content. Admin-configured notification packages may also
+receive `email.system-message.sent` when operator correspondence leaves a
+reserved system sender (`kody@`, `support@`, and the other system locals). That
+event includes the recipients, subject, and sent text/HTML because outbound
+system mail is not stored on the inbound system-email graph; it is admin-only
+and omits unrelated account content. Admin-configured notification packages may
+also receive metadata-only `auth.denial.burst` or `email.delivery.burst` events
+when hourly MCP auth denials or shared-domain bounce/complaint counts cross
+their thresholds (count, threshold, window, insights URL, and `observed_at`).
+Those events omit user identities, tokens, recipients, and message content.
 Admin-configured notification packages may also receive a metadata-only
 `fleet.package_error_rate.elevated` event when anonymous package-runtime error
 rates rise (window bounds, per-metric counts and rates, public status URL, and
@@ -238,3 +247,12 @@ deployment — holding the Cloudflare account, D1 database access, and
 `SECRET_STORE_KEY` — sits outside any application-level control. The admin role
 grants no infrastructure access, and infrastructure access requires no admin
 role.
+
+Kody processes personal data to perform the contract for account and assistant
+features, on legitimate interests for security, abuse prevention, and analytics,
+and with consent for the waiting list and product email. Data is processed in
+the United States on Cloudflare's network. If you use Kody from outside the
+United States, you consent to that transfer. You also have the right to lodge a
+complaint with a supervisory authority where you live, including in the EEA or
+the United Kingdom. The in-app Privacy page at `/privacy` is the hosted legal
+policy.

--- a/packages/worker/client/routes/legal-last-updated.ts
+++ b/packages/worker/client/routes/legal-last-updated.ts
@@ -1,0 +1,1 @@
+export const legalLastUpdated = '2026-09-02'

--- a/packages/worker/client/routes/login-sections.tsx
+++ b/packages/worker/client/routes/login-sections.tsx
@@ -330,6 +330,13 @@ export function renderAuthForm(
 					{props.submitBusyLabel}
 				</span>
 			</button>
+			{props.isSignup ? (
+				<p mix={css(signupConsentCss)}>
+					By creating an account you agree to the{' '}
+					<a href="/terms">Terms of Service</a> and acknowledge the{' '}
+					<a href="/privacy">Privacy Policy</a>.
+				</p>
+			) : null}
 			{!props.isSignup ? (
 				<button
 					type="button"
@@ -480,6 +487,20 @@ const inlineLinkCss = {
 const fieldAsideCss = {
 	...inlineLinkCss,
 	fontSize: '0.88rem',
+}
+
+const signupConsentCss = {
+	margin: 0,
+	fontSize: '0.85rem',
+	lineHeight: 1.5,
+	color: colors.textMuted,
+	'& a': {
+		color: colors.textMuted,
+		textDecoration: 'underline',
+		textDecorationThickness: '1.5px',
+		textUnderlineOffset: '3px',
+	},
+	'& a:hover': { color: colors.text },
 }
 
 const rememberCss = {

--- a/packages/worker/client/routes/privacy.tsx
+++ b/packages/worker/client/routes/privacy.tsx
@@ -11,6 +11,7 @@ import {
 	sectionTitleCss,
 	stackedPageCss,
 } from '#universal/styles/style-primitives.ts'
+import { legalLastUpdated } from './legal-last-updated.ts'
 
 export function PrivacyRoute(_handle: Handle) {
 	return () => (
@@ -19,6 +20,10 @@ export function PrivacyRoute(_handle: Handle) {
 				<h1 mix={css(pageTitleCss)}>Privacy</h1>
 				<p mix={css(pageDescriptionCss)}>
 					What Kody collects, why it is needed, and the choices you have.
+				</p>
+				<p mix={css(lastUpdatedCss)}>
+					Last updated:{' '}
+					<time datetime={legalLastUpdated}>{legalLastUpdated}</time>
 				</p>
 			</header>
 
@@ -32,6 +37,17 @@ export function PrivacyRoute(_handle: Handle) {
 					</a>
 					. A separately operated Kody deployment has its own operator and data
 					controller.
+				</p>
+				<p mix={css(descriptionCss)}>
+					Kody processes personal data to perform the contract for account and
+					assistant features, on legitimate interests for security, abuse
+					prevention, and analytics, and with consent for the waiting list and
+					product email.
+				</p>
+				<p mix={css(descriptionCss)}>
+					Data is processed in the United States on Cloudflare&apos;s network.
+					If you use Kody from outside the United States, you consent to that
+					transfer.
 				</p>
 			</section>
 
@@ -129,18 +145,19 @@ export function PrivacyRoute(_handle: Handle) {
 					exception.
 				</p>
 				<p mix={css(descriptionCss)}>
-					Admins also moderate public community listings and attributed
-					community reports, and can see who forked or rated a public listing,
-					when, and the rating scores. One-click installs appear as forks
-					because both use the same activity record. This activity view never
-					includes private package source, rating notes, email, stable user ids,
-					private profiles, secrets, or unrelated account content.
-					Admin-configured notification packages may receive the same community
-					metadata, and a metadata-only <code>user.created</code> or{' '}
-					<code>user.deleted</code> event when a person account is created or
-					self-deleted (stable user id, username, email, the create source or
-					delete timestamp, the consumed invite code when{' '}
-					<code>user.created</code> used one, and first-touch marketing
+					Admins also moderate public community listings and community reports.
+					Reporting a listing requires a signed-in user; reports are not
+					anonymous — the reporter identity is attached. Admins can see who
+					forked or rated a public listing, when, and the rating scores.
+					One-click installs appear as forks because both use the same activity
+					record. This activity view never includes private package source,
+					rating notes, email, stable user ids, private profiles, secrets, or
+					unrelated account content. Admin-configured notification packages may
+					receive the same community metadata, and a metadata-only{' '}
+					<code>user.created</code> or <code>user.deleted</code> event when a
+					person account is created or self-deleted (stable user id, username,
+					email, the create source or delete timestamp, the consumed invite code
+					when <code>user.created</code> used one, and first-touch marketing
 					attribution fields when present). Those lifecycle events omit
 					passwords, roles, plan, secrets, and unrelated account content.
 					Admin-configured notification packages may also receive a
@@ -343,6 +360,16 @@ export function PrivacyRoute(_handle: Handle) {
 					</li>
 					<li>Fathom — privacy-focused website traffic analytics</li>
 				</ul>
+				<p mix={css(descriptionCss)}>
+					The only cookies are the session cookie (<code>kody_session</code>)
+					and the package-app session cookie on <code>kody.run</code> (
+					<code>__Host-kody_pkg_session</code> on HTTPS,{' '}
+					<code>kody_pkg_session</code> on HTTP). Short-lived cookies support
+					two-factor verification, passkey challenges, and OAuth login.
+					Analytics (Fathom) is cookieless. The browser uses sessionStorage for
+					first-touch signup attribution and scroll restoration, not tracking
+					cookies.
+				</p>
 			</section>
 
 			<section mix={css(cardCss)}>
@@ -358,6 +385,14 @@ export function PrivacyRoute(_handle: Handle) {
 					</a>
 					. Which rights apply depends on where you live. We may need to verify
 					your identity before acting on a request.
+				</p>
+				<p mix={css(descriptionCss)}>
+					You also have the right to lodge a complaint with a supervisory
+					authority where you live, including in the EEA or the United Kingdom.
+				</p>
+				<p mix={css(descriptionCss)}>
+					We do not sell or share personal information as defined by the
+					CCPA/CPRA.
 				</p>
 			</section>
 
@@ -393,6 +428,12 @@ const pageCss = {
 	...stackedPageCss,
 	maxWidth: '42rem',
 	margin: '0 auto',
+}
+
+const lastUpdatedCss = {
+	margin: 0,
+	color: colors.textMuted,
+	fontSize: typography.fontSize.sm,
 }
 
 const listCss = {

--- a/packages/worker/client/routes/terms.tsx
+++ b/packages/worker/client/routes/terms.tsx
@@ -10,6 +10,7 @@ import {
 	pageTitleCss,
 	stackedPageCss,
 } from '#universal/styles/style-primitives.ts'
+import { legalLastUpdated } from './legal-last-updated.ts'
 
 export function TermsRoute(_handle: Handle) {
 	return () => (
@@ -18,6 +19,10 @@ export function TermsRoute(_handle: Handle) {
 				<h1 mix={css(pageTitleCss)}>Terms and Acceptable Use</h1>
 				<p mix={css(pageDescriptionCss)}>
 					The plain-spoken agreement for creating an account and using Kody.
+				</p>
+				<p mix={css(lastUpdatedCss)}>
+					Last updated:{' '}
+					<time datetime={legalLastUpdated}>{legalLastUpdated}</time>
 				</p>
 			</header>
 
@@ -138,6 +143,37 @@ export function TermsRoute(_handle: Handle) {
 			</section>
 
 			<section mix={css(cardCss)}>
+				<h2 mix={css(cardTitleCss)}>Public packages</h2>
+				<p mix={css(descriptionCss)}>
+					By publishing a package publicly you grant Kody a licence to host,
+					display, and distribute it through the community catalog, and you
+					grant other Kody users a licence to fork and run it under the licence
+					declared in the package (or, if none is declared, a non-exclusive
+					licence to fork and run it within Kody). You retain copyright.
+				</p>
+			</section>
+
+			<section mix={css(cardCss)}>
+				<h2 mix={css(cardTitleCss)}>Copyright and DMCA notices</h2>
+				<p mix={css(descriptionCss)}>
+					Kody responds to notices of claimed copyright infringement under 17
+					U.S.C. §512 concerning public community packages and profiles. Send
+					notices to{' '}
+					<a href="mailto:dmca@kody.codes" mix={css(mutedLinkCss)}>
+						dmca@kody.codes
+					</a>
+					. A valid notice must identify the copyrighted work, identify the
+					allegedly infringing material with its Kody URL, include your contact
+					information, a good-faith statement that use of the material is not
+					authorized, a statement under penalty of perjury that the information
+					is accurate and that you are the copyright owner or authorized to act
+					on the owner&apos;s behalf, and a physical or electronic signature.
+					Counter-notices go to the same address. Repeat infringers have their
+					community publishing revoked or their accounts terminated.
+				</p>
+			</section>
+
+			<section mix={css(cardCss)}>
 				<h2 mix={css(cardTitleCss)}>Suspension and termination</h2>
 				<p mix={css(descriptionCss)}>
 					Operators may suspend or terminate accounts that violate these terms,
@@ -220,6 +256,12 @@ const pageCss = {
 	...stackedPageCss,
 	maxWidth: '42rem',
 	margin: '0 auto',
+}
+
+const lastUpdatedCss = {
+	margin: 0,
+	color: colors.textMuted,
+	fontSize: typography.fontSize.sm,
 }
 
 const listCss = {

--- a/packages/worker/client/routes/terms.tsx
+++ b/packages/worker/client/routes/terms.tsx
@@ -145,11 +145,11 @@ export function TermsRoute(_handle: Handle) {
 			<section mix={css(cardCss)}>
 				<h2 mix={css(cardTitleCss)}>Public packages</h2>
 				<p mix={css(descriptionCss)}>
-					By publishing a package publicly you grant Kody a licence to host,
+					By publishing a package publicly you grant Kody a license to host,
 					display, and distribute it through the community catalog, and you
-					grant other Kody users a licence to fork and run it under the licence
+					grant other Kody users a license to fork and run it under the license
 					declared in the package (or, if none is declared, a non-exclusive
-					licence to fork and run it within Kody). You retain copyright.
+					license to fork and run it within Kody). You retain copyright.
 				</p>
 			</section>
 

--- a/packages/worker/client/site-footer.tsx
+++ b/packages/worker/client/site-footer.tsx
@@ -27,6 +27,8 @@ export function SiteFooter(handle: Handle<SiteFooterProps>) {
 					<a href="/pricing">Pricing</a>
 					<a href="/faq">FAQ</a>
 					<a href="/blog">Blog</a>
+					<a href="/privacy">Privacy</a>
+					<a href="/terms">Terms</a>
 					{handle.props.loggedIn ? (
 						<a href="/account">Account</a>
 					) : (

--- a/packages/worker/src/email/system-email.ts
+++ b/packages/worker/src/email/system-email.ts
@@ -23,6 +23,7 @@ export const systemEmailLocals = [
 	'kody',
 	'support',
 	'abuse',
+	'dmca',
 	'postmaster',
 	'security',
 	'admin',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Finish the legal surface before public signup: make agreement to the Terms explicit at signup, make the legal pages reachable from every page, add the copyright/DMCA and public-package licensing terms the community catalog needs, and fill the privacy-policy gaps.

## Why

From the 2026-09-01 launch-readiness audit: the signup form had no consent line (weak clickwrap for the AUP, liability limits, and free-plan revocation), `site-footer.tsx` omitted Privacy/Terms, there was no DMCA notice or designated address despite a public forkable catalog, and the privacy policy lacked legal bases, transfer, complaint-right, CCPA, and cookie statements. Age (13) and governing law (Utah) were already set on `main` and are unchanged. No cookie banner.

## Summary

- `login-sections.tsx`: signup-only line under the submit button — "By creating an account you agree to the Terms of Service and acknowledge the Privacy Policy." (real links, underlined, muted).
- `site-footer.tsx`: `Privacy` and `Terms` links.
- `legal-last-updated.ts`: shared `legalLastUpdated = '2026-09-02'`, rendered on both pages.
- `terms.tsx`: "Public packages" licensing paragraph (hosting/display licence to Kody; fork/run licence to other users under the declared package license, else within Kody; author keeps copyright) and a "Copyright and DMCA notices" section (§512 elements, `dmca@kody.codes`, counter-notices, repeat-infringer policy).
- `privacy.tsx` and `docs/use/privacy.md`: legal bases; US/Cloudflare processing and transfer consent; EEA/UK complaint right; CCPA/CPRA no-sale statement; cookies (`kody_session`, `__Host-kody_pkg_session` / `kody_pkg_session`, short-lived auth cookies, cookieless Fathom); community reports are attributed.
- `system-email.ts`: `dmca` added to the reserved operator inbox locals so mail to `dmca@` lands with `abuse@`/`security@` (username was already reserved; inbox is provisioned on first inbound, no migration).

Operator follow-up (not code): register the DMCA designated agent with the US Copyright Office.

## Testing

`npm run typecheck`, `npm run lint`, `npm run format:check`, `npm run docs:check-temporal`; `reserved-usernames.node.test.ts` passes; `terms.tsx` 275 / `privacy.tsx` 452 lines (under the 800 ratchet). `e2e/a11y.spec.ts` already covers `/login` in CI.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `40e70929` · **Head:** `HEAD`

**Classification:** composes — static legal copy, two footer links, one consent line, and one more reserved system-inbox local.

### Primitives touched

| Primitive       | Group    | Impact                                         |
| --------------- | -------- | ---------------------------------------------- |
| `app-ui`        | surfaces | composes — legal copy, footer links, consent   |
| `system-email`  | features | composes — `dmca` reserved local               |

### Change flow

The signup form now states agreement inline, and legal pages are one click from any footer.

```mermaid
flowchart LR
	signup["app-ui signup form"]:::touched
	footer["app-ui site footer"]:::touched
	terms["/terms — DMCA + public-package license"]:::touched
	privacy["/privacy — legal bases, transfers, CCPA, cookies"]:::touched
	inbox["system-email reserved locals"]:::touched
	signup -->|"consent line links"| terms
	signup -->|"consent line links"| privacy
	footer -->|"Terms / Privacy links"| terms
	footer -->|"Terms / Privacy links"| privacy
	terms -->|"dmca@kody.codes"| inbox
	classDef touched fill:#1a7f37,color:#fff
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b0f6a92a-81cd-4157-8b60-188c83ca84c0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b0f6a92a-81cd-4157-8b60-188c83ca84c0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

