### PR TITLE
Make admin role-assignment tests deterministic and surface e2e flakes

### DIFF
--- a/e2e/admin-rbac.spec.ts
+++ b/e2e/admin-rbac.spec.ts
@@ -100,7 +100,35 @@ test('admin RBAC controls access, role assignment, and privacy boundaries', asyn
 	await page.getByRole('link', { name: memberUser.username }).click()
 	const roleSelect = page.getByLabel('Role', { exact: true })
 	await roleSelect.selectOption('admin')
+	const assignRoleResponse = page.waitForResponse((response) => {
+		if (response.request().method() !== 'POST') return false
+		let pathname = ''
+		try {
+			pathname = new URL(response.url()).pathname
+		} catch {
+			return false
+		}
+		if (pathname !== '/admin/users.json') return false
+		try {
+			const body: unknown = JSON.parse(response.request().postData() ?? '')
+			return (
+				typeof body === 'object' &&
+				body !== null &&
+				'action' in body &&
+				body.action === 'assign_role'
+			)
+		} catch {
+			return false
+		}
+	})
 	await page.getByRole('button', { name: 'Assign', exact: true }).click()
+	expect((await assignRoleResponse).ok()).toBe(true)
+	await expect(
+		page.getByRole('status', { name: 'Assigned admin role.' }),
+	).toBeVisible()
+	await expect(
+		page.getByRole('button', { name: 'Remove', exact: true }),
+	).toBeEnabled()
 
 	await page.context().clearCookies()
 	await login({

--- a/e2e/admin-rbac.spec.ts
+++ b/e2e/admin-rbac.spec.ts
@@ -123,9 +123,8 @@ test('admin RBAC controls access, role assignment, and privacy boundaries', asyn
 	})
 	await page.getByRole('button', { name: 'Assign', exact: true }).click()
 	expect((await assignRoleResponse).ok()).toBe(true)
-	await expect(
-		page.getByRole('status', { name: 'Assigned admin role.' }),
-	).toBeVisible()
+	await expect(page.getByText('Assigned admin role.')).toBeVisible()
+	await expect(page.getByText('admin, user')).toBeVisible()
 	await expect(
 		page.getByRole('button', { name: 'Remove', exact: true }),
 	).toBeEnabled()

--- a/packages/worker/src/mcp/mcp-server.mcp-e2e.test.ts
+++ b/packages/worker/src/mcp/mcp-server.mcp-e2e.test.ts
@@ -52,15 +52,7 @@ test('authenticated MCP search shows admin capabilities only to admin users', as
 			limit: 10,
 		},
 	})
-	const regularMatches =
-		(
-			(regularSearch as CallToolResult).structuredContent as {
-				result?: { matches?: Array<{ id?: string }> }
-			}
-		)?.result?.matches ?? []
-	expect(regularMatches.some((match) => match.id === 'adminUserList')).toBe(
-		false,
-	)
+	expect(searchMatchIds(regularSearch)).not.toContain('adminUserList')
 
 	await using bootstrapClient = await createMcpClient(
 		server.origin,
@@ -79,18 +71,34 @@ test('authenticated MCP search shows admin capabilities only to admin users', as
 		{ persistDir: database.persistDir },
 	)
 
-	const adminSearch = await adminClient.client.callTool({
-		name: 'search',
-		arguments: {
-			query: 'admin users roles audit',
-			limit: 10,
-		},
-	})
-	const adminMatches =
+	// Role writes go through a separate `wrangler d1 execute --persist-to`
+	// process. Auth and the capability registry load roles per request
+	// (`request-auth-cache` is a WeakMap; registry cache is not keyed by
+	// role), so this is local D1 snapshot lag, not a production stale-role
+	// cache. Poll until the running worker observes the grant.
+	await expect
+		.poll(
+			async () => {
+				const adminSearch = await adminClient.client.callTool({
+					name: 'search',
+					arguments: {
+						query: 'admin users roles audit',
+						limit: 10,
+					},
+				})
+				return searchMatchIds(adminSearch)
+			},
+			{ timeout: 10_000, interval: 250 },
+		)
+		.toContain('adminUserList')
+})
+
+function searchMatchIds(result: unknown) {
+	return (
 		(
-			(adminSearch as CallToolResult).structuredContent as {
+			(result as CallToolResult).structuredContent as {
 				result?: { matches?: Array<{ id?: string }> }
 			}
 		)?.result?.matches ?? []
-	expect(adminMatches.some((match) => match.id === 'adminUserList')).toBe(true)
-})
+	).flatMap((match) => (typeof match.id === 'string' ? [match.id] : []))
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
 	testIgnore: ['**/*.node.test.ts'],
 	fullyParallel: true,
 	forbidOnly: !!process.env.CI,
-	retries: process.env.CI ? 2 : 0,
+	retries: process.env.CI ? 1 : 0,
 	// CI runs `validate`, which executes unit, MCP, and Playwright suites
 	// concurrently on one runner. The default 30s per-test budget flakes under
 	// that resource contention (page.goto alone has been observed taking >30s).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop the two known flaky suites from flaking, and stop Playwright retries from hiding new ones.

## Why

The 2026-09-01 audit found `e2e/admin-rbac.spec.ts` flaked on 3 of the last 12 green `main` runs (masked by `retries: 2`), always at `expect(sessionPayload.session.roles).toContain('admin')` because the spec clicked Assign and immediately cleared cookies without awaiting the mutation. `mcp-server.mcp-e2e.test.ts` failed once on a main-bound PR at the admin-search assertion for the same reason: the role grant is written by a separate `wrangler d1 execute --persist-to` process and the running worker may not observe it yet.

Investigated whether production has a stale-role cache: it does not. `request-auth-cache` is a per-request `WeakMap`, the capability registry cache is not keyed by role and is filtered per request, and MCP auth re-reads roles from D1 each request. The lag is local-D1-snapshot only.

## Summary

- `e2e/admin-rbac.spec.ts`: after clicking Assign, await the `POST /admin/users.json` `assign_role` response (2xx), the "Assigned admin role." copy, the `admin, user` roles value, and the enabled Remove button before `clearCookies()`.
- `mcp-server.mcp-e2e.test.ts`: `expect.poll` (10 s, 250 ms) around the admin search with a comment stating why; shared `searchMatchIds` helper.
- `playwright.config.ts`: CI `retries` 2 → 1. The targeted whole-suite re-run in `validate.yml` for the known wrangler crash signature is unchanged.

## Testing

`npm run typecheck`, `npm run lint`, `npm run format:check`; `CI=1 npm run test:mcp` 5/5 (136 s) and `npx vitest run --project mcp-e2e` 5/5; `npx playwright test e2e/admin-rbac.spec.ts --repeat-each=3 --retries=0` 3/3 passed (59.6 s).

## System changes

Test-only plus one Playwright config value; no primitives touched.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b0f6a92a-81cd-4157-8b60-188c83ca84c0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b0f6a92a-81cd-4157-8b60-188c83ca84c0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

