### PR TITLE
Reclaim unverified accounts on social link and clear factors on password reset

### DIFF
--- a/docs/contributing/architecture/authentication.md
+++ b/docs/contributing/architecture/authentication.md
@@ -42,13 +42,19 @@ The cookie payload stores:
 
 Password reset confirmation and signed-in password change revoke every MCP OAuth
 grant for that user, write `users.password_changed_at`, then revoke again so a
-grant created in that window cannot survive. Session resolution rejects cookies
-whose `issuedAt` is missing or at/before that timestamp, so a reset invalidates
-every existing browser and package-app session. A signed-in change re-issues the
-current `kody_session` cookie with a later `issuedAt` so that browser stays
-signed in. `/mcp` rejects access tokens whose `createdAt` is at or before that
-timestamp (`invalid_token`), so already-issued bearers die immediately; hosts
-that refresh then hit the revoked grant and must start a new OAuth flow.
+grant created in that window cannot survive. Password-reset confirmation also
+disables two-factor authentication, deletes passkeys, and deletes linked sign-in
+providers (`oauth_connections`), then emails the owner listing those cleared
+methods.
+
+Session resolution rejects cookies whose `issuedAt` is missing or at/before that
+timestamp, so a reset invalidates every existing browser and package-app
+session. A signed-in change re-issues the current `kody_session` cookie with a
+later `issuedAt` so that browser stays signed in and leaves second factors and
+linked providers in place. `/mcp` rejects access tokens whose `createdAt` is at
+or before that timestamp (`invalid_token`), so already-issued bearers die
+immediately; hosts that refresh then hit the revoked grant and must start a new
+OAuth flow.
 
 `users.id` never crosses the cookie boundary. Session resolution looks up the
 stable id and only then uses the numeric primary key for internal D1 joins.
@@ -409,7 +415,9 @@ Password reset handlers are in
 - `POST /password-reset/confirm` verifies token hash and expiry, updates the
   password, revokes every MCP OAuth grant for that user, stamps
   `users.password_changed_at`, then revokes again so a grant created in that
-  window cannot survive
+  window cannot survive. It also disables two-factor authentication, deletes
+  passkeys and `oauth_connections`, and sends a confirmation email listing those
+  cleared sign-in methods
 - Session cookies and package-app sessions whose `issuedAt` is missing or at or
   before `password_changed_at` fail closed; `/mcp` rejects access tokens whose
   `createdAt` is at or before that timestamp (`invalid_token`)
@@ -433,7 +441,9 @@ Signed-in password change is `POST /account/password.json`
   first password without a current password
 - New passwords go through `getPasswordPolicyError`
 - Shares `applyPasswordChange` with reset confirmation: revoke MCP grants, stamp
-  `users.password_changed_at`, revoke again, delete outstanding reset tokens
+  `users.password_changed_at`, revoke again, delete outstanding reset tokens.
+  Unlike reset confirmation, this path does not clear two-factor, passkeys, or
+  linked providers
 - Re-issues the current session cookie with `issuedAt` strictly after
   `password_changed_at` so this browser stays signed in
 - Joins the shared auth rate-limit bucket and a per-user password-change budget
@@ -587,8 +597,12 @@ token. The member role is assigned on connect; Standard and Pro roles follow
   `/account/connections.json` (disconnect is refused when the connection is the
   only sign-in method). `/discord` is the public **Connect Discord** page (one
   action joins the official server and links the account)
-- A provider-verified email matching an existing account auto-links and signs
-  in; otherwise account creation follows the signup posture
+- A provider-verified email matching an existing **verified** account auto-links
+  and signs in. A match against an **unverified** account reclaims that row
+  first (unusable password sentinel, `password_changed_at` lockout, TOTP /
+  passkeys / other `oauth_connections` / reset tokens cleared) so a squatted
+  password signup cannot keep access after the real owner signs in with the
+  provider; otherwise account creation follows the signup posture
   (`SIGNUP_MODE !== 'open'` requires a valid invite code carried from the invite
   signup panel; the `test` env remains open without one)
 - Buttons only render for providers whose client id/secret env vars are set;

--- a/docs/contributing/security.md
+++ b/docs/contributing/security.md
@@ -83,6 +83,18 @@ package-app surfaces:
     only) and suspend or delete the squatting account with existing
     capabilities. `users.stable_user_id` is never recomputed for an existing
     account.
+12. **Unverified accounts are reclaimed on a provider-verified social match.**
+    When a social login profile presents a verified email that matches
+    `users.email` and `email_verified_at` is null, treat the row as a possible
+    squat before linking: rotate `password_hash` to an unusable sentinel, stamp
+    `password_changed_at` (browser sessions and MCP bearers fail closed), revoke
+    MCP grants, delete TOTP rows, passkeys, other `oauth_connections`, and
+    outstanding `password_resets`, then link the provider and mark the account
+    verified. An already-verified match only links and signs in.
+13. **Password-reset confirmation clears second factors and linked providers.**
+    `POST /password-reset/confirm` disables TOTP, deletes passkeys and
+    `oauth_connections`, and tells the owner in the confirmation email.
+    Signed-in `POST /account/password.json` leaves those factors in place.
 
 ## First-party HTTP security headers
 
@@ -506,13 +518,16 @@ change to these decisions here so future agents do not relitigate them.
   signed cookie with no server store, so there is no separate "log out
   everywhere" button. Password reset confirmation and signed-in password change
   (`POST /account/password.json`) both revoke every MCP OAuth grant for the
-  user, stamp `users.password_changed_at`, then revoke again. Browser and
-  package-app sessions carry `issuedAt`; `resolveRequestAuth` rejects cookies
-  issued at or before that timestamp (missing `issuedAt` fails closed once a
-  password change exists). `/mcp` applies the same timestamp to the access token
-  `createdAt` (Unix seconds) so already-issued bearers fail closed as
-  `invalid_token`. A signed-in password change re-issues the current browser
-  cookie so that tab stays signed in; every other session still dies.
+  user, stamp `users.password_changed_at`, then revoke again. Password-reset
+  confirmation also disables TOTP, deletes passkeys, and deletes
+  `oauth_connections`. Browser and package-app sessions carry `issuedAt`;
+  `resolveRequestAuth` rejects cookies issued at or before that timestamp
+  (missing `issuedAt` fails closed once a password change exists). `/mcp`
+  applies the same timestamp to the access token `createdAt` (Unix seconds) so
+  already-issued bearers fail closed as `invalid_token`. A signed-in password
+  change re-issues the current browser cookie so that tab stays signed in; every
+  other session still dies. Reclaiming an unverified account on a
+  provider-verified social match uses the same `password_changed_at` lockout.
 - **OAuth authorize client reset is grant-scoped.** A signed-in user can reset a
   mismatched DCR client for **their** grants only. `deleteClient` runs only when
   `user_mcp_oauth_clients` shows they own that registration. Shared host clients

--- a/docs/contributing/social-login.md
+++ b/docs/contributing/social-login.md
@@ -47,8 +47,11 @@ Callback resolution order:
 2. A known connection signs in its user (the two-factor gate applies exactly as
    it does for password logins; passkey sign-in skips TOTP).
 3. A **provider-verified** email matching an existing account links the identity
-   and signs that account in (this also marks the account email verified, since
-   the provider asserted ownership of the same address).
+   and signs that account in. If that account is unverified, the callback
+   reclaims it first (unusable password, session lockout, TOTP / passkeys /
+   other connections / reset tokens cleared) so a squatted password signup
+   cannot keep access. The provider also marks the account email verified, since
+   it asserted ownership of the same address.
 4. Otherwise a new account is created. Production requires a valid invite code
    carried in the signed OAuth state cookie (the invite signup panel passes
    `inviteCode` into `POST /auth/:provider`). Non-production stays open without

--- a/packages/shared/src/password-hash.node.test.ts
+++ b/packages/shared/src/password-hash.node.test.ts
@@ -61,4 +61,11 @@ test('password hash verify upgrades legacy, rejects over-cap and tampered metada
 	]) {
 		await expect(verifyPassword(password, tamperedHash)).resolves.toBe(false)
 	}
+
+	await expect(
+		verifyPassword(password, 'reclaimed_unverified_no_usable_password'),
+	).resolves.toBe(false)
+	await expect(
+		verifyPassword(password, 'oauth_created_no_usable_password'),
+	).resolves.toBe(false)
 })

--- a/packages/worker/src/app/apply-password-change.node.test.ts
+++ b/packages/worker/src/app/apply-password-change.node.test.ts
@@ -1,0 +1,106 @@
+import { quoteSqlString } from '@kody-internal/shared/sql-literals.ts'
+import { DatabaseSync } from 'node:sqlite'
+import { expect, test } from 'vitest'
+import { createPasswordHash } from '@kody-internal/shared/password-hash.ts'
+import { applyAllMigrations } from '#worker/test-support/apply-all-migrations.ts'
+import { createD1FromSqlite } from '#worker/test-support/create-d1-from-sqlite.ts'
+import { createDb } from '#worker/db.ts'
+import { createStableUserIdFromEmail } from '#worker/user-id.ts'
+import { applyPasswordChange } from './apply-password-change.ts'
+
+async function seedUserWithFactors() {
+	const sqlite = new DatabaseSync(':memory:')
+	applyAllMigrations(sqlite, new URL('../../migrations/', import.meta.url))
+	const email = 'factors@example.com'
+	const passwordHash = await createPasswordHash('old-password-ok')
+	const stableUserId = await createStableUserIdFromEmail(email)
+	sqlite.exec(`
+		INSERT INTO users (
+			id, username, email, stable_user_id, password_hash, email_verified_at
+		) VALUES (
+			1, 'factors', ${quoteSqlString(email)}, ${quoteSqlString(stableUserId)},
+			${quoteSqlString(passwordHash)}, CURRENT_TIMESTAMP
+		);
+		INSERT INTO oauth_connections (provider_name, provider_id, user_id, provider_display_name)
+		VALUES ('github', 'factors-github', 1, 'factors');
+		INSERT INTO password_resets (user_id, token_hash, expires_at)
+		VALUES (1, 'token-hash', ${Date.now() + 60_000});
+	`)
+	const d1 = createD1FromSqlite(sqlite)
+	return { sqlite, d1, db: createDb(d1), stableUserId, passwordHash }
+}
+
+const helpers = {
+	listUserGrants: async () => ({ items: [] }),
+	revokeGrant: async () => {},
+} as never
+
+test('a failed factor cleanup leaves the password, stamp, and reset token untouched', async () => {
+	const { sqlite, d1, db, stableUserId, passwordHash } =
+		await seedUserWithFactors()
+	// Force the connection delete inside clearSecondFactorsAndConnections to
+	// throw so the ordering guarantee is observable.
+	sqlite.exec(`DROP TABLE oauth_connections`)
+
+	await expect(
+		applyPasswordChange({
+			db,
+			d1,
+			helpers,
+			userId: 1,
+			stableUserId,
+			password: 'brand-new-password',
+			clearSecondFactorsAndConnections: true,
+		}),
+	).rejects.toThrow()
+
+	const row = sqlite
+		.prepare(
+			`SELECT password_hash, password_changed_at FROM users WHERE id = 1`,
+		)
+		.get() as { password_hash: string; password_changed_at: string | null }
+	expect(row.password_hash).toBe(passwordHash)
+	expect(row.password_changed_at).toBeNull()
+	expect(
+		sqlite.prepare(`SELECT COUNT(*) AS count FROM password_resets`).get(),
+	).toEqual({ count: 1 })
+})
+
+test('factors are cleared before password_changed_at is stamped', async () => {
+	const { sqlite, d1, db, stableUserId } = await seedUserWithFactors()
+	let connectionsAtStamp: number | null = null
+	// Observe the connection count at the moment the users row is stamped.
+	sqlite.exec(`
+		CREATE TABLE stamp_markers (connections INTEGER NOT NULL);
+		CREATE TRIGGER capture_connections_at_stamp
+		AFTER UPDATE OF password_changed_at ON users
+		BEGIN
+			INSERT INTO stamp_markers (connections)
+			SELECT COUNT(*) FROM oauth_connections;
+		END;
+	`)
+
+	const result = await applyPasswordChange({
+		db,
+		d1,
+		helpers,
+		userId: 1,
+		stableUserId,
+		password: 'brand-new-password',
+		clearSecondFactorsAndConnections: true,
+	})
+	expect(result.ok).toBe(true)
+
+	const marker = sqlite
+		.prepare(`SELECT connections FROM stamp_markers`)
+		.get() as { connections: number } | undefined
+	connectionsAtStamp = marker?.connections ?? null
+	expect(connectionsAtStamp).toBe(0)
+	expect(
+		sqlite
+			.prepare(
+				`SELECT COUNT(*) AS count FROM password_resets WHERE user_id = 1`,
+			)
+			.get(),
+	).toEqual({ count: 0 })
+})

--- a/packages/worker/src/app/apply-password-change.node.test.ts
+++ b/packages/worker/src/app/apply-password-change.node.test.ts
@@ -52,7 +52,7 @@ test('a failed factor cleanup leaves the password, stamp, and reset token untouc
 			password: 'brand-new-password',
 			clearSecondFactorsAndConnections: true,
 		}),
-	).rejects.toThrow()
+	).rejects.toThrow(/no such table/)
 
 	const row = sqlite
 		.prepare(

--- a/packages/worker/src/app/apply-password-change.ts
+++ b/packages/worker/src/app/apply-password-change.ts
@@ -88,6 +88,14 @@ export async function applyPasswordChange(
 		}
 	}
 
+	// Clear second factors and linked providers before the stamp: a passkey or
+	// provider sign-in that completes after `password_changed_at` would mint a
+	// cookie that postdates it and survives the lockout. A failure here leaves
+	// the account unstamped and the reset token intact so the caller can retry.
+	const cleared = input.clearSecondFactorsAndConnections
+		? await clearSecondFactorsAndConnections(input.d1, input.userId)
+		: null
+
 	const changedAtMs = Date.now()
 	const passwordHash = await resolvePasswordHash(input)
 	await input.db.update(usersTable, input.userId, {
@@ -109,13 +117,11 @@ export async function applyPasswordChange(
 		}
 	}
 
+	// Reset tokens go last so every earlier step can be retried with the same
+	// token if it fails.
 	await input.db.deleteMany(passwordResetsTable, {
 		where: { user_id: input.userId },
 	})
-
-	const cleared = input.clearSecondFactorsAndConnections
-		? await clearSecondFactorsAndConnections(input.d1, input.userId)
-		: null
 
 	return { ok: true, changedAtMs, cleared }
 }

--- a/packages/worker/src/app/apply-password-change.ts
+++ b/packages/worker/src/app/apply-password-change.ts
@@ -9,9 +9,15 @@ import {
 	type OAuthGrantHelpers,
 	revokeAllOAuthGrantsForUser,
 } from '#worker/oauth-grants.ts'
+import {
+	type ClearedAccountFactors,
+	clearSecondFactorsAndConnections,
+} from '#app/clear-account-factors.ts'
+
+export type { ClearedAccountFactors }
 
 export type ApplyPasswordChangeResult =
-	| { ok: true; changedAtMs: number }
+	| { ok: true; changedAtMs: number; cleared: ClearedAccountFactors | null }
 	| {
 			ok: false
 			reason: 'oauth_provider_unavailable'
@@ -25,6 +31,10 @@ export type ApplyPasswordChangeResult =
 			changedAtMs?: number
 	  }
 
+type ApplyPasswordChangeCredential =
+	| { password: string; unusablePasswordHash?: undefined }
+	| { unusablePasswordHash: string; password?: undefined }
+
 /**
  * Stamp a new password hash, revoke MCP grants around the stamp, and drop
  * outstanding reset tokens. Callers map the result onto HTTP + audit events.
@@ -32,14 +42,21 @@ export type ApplyPasswordChangeResult =
  * Reset tokens stay until both revoke passes succeed so a retry remains
  * safe. `changedAtMs` is millisecond-precision so a freshly issued session
  * cookie can postdate `password_changed_at`.
+ *
+ * Password-reset confirmation passes `clearSecondFactorsAndConnections` so
+ * attacker-added TOTP, passkeys, and linked providers cannot survive the
+ * new password. Signed-in password change leaves those factors in place.
  */
-export async function applyPasswordChange(input: {
-	db: AppDatabase
-	helpers: OAuthGrantHelpers | undefined
-	userId: number
-	stableUserId: string
-	password: string
-}): Promise<ApplyPasswordChangeResult> {
+export async function applyPasswordChange(
+	input: {
+		db: AppDatabase
+		d1: D1Database
+		helpers: OAuthGrantHelpers | undefined
+		userId: number
+		stableUserId: string
+		clearSecondFactorsAndConnections?: boolean
+	} & ApplyPasswordChangeCredential,
+): Promise<ApplyPasswordChangeResult> {
 	if (!input.helpers) {
 		return { ok: false, reason: 'oauth_provider_unavailable', stamped: false }
 	}
@@ -72,7 +89,7 @@ export async function applyPasswordChange(input: {
 	}
 
 	const changedAtMs = Date.now()
-	const passwordHash = await createPasswordHash(input.password)
+	const passwordHash = await resolvePasswordHash(input)
 	await input.db.update(usersTable, input.userId, {
 		password_hash: passwordHash,
 		password_changed_at: new Date(changedAtMs).toISOString(),
@@ -96,5 +113,16 @@ export async function applyPasswordChange(input: {
 		where: { user_id: input.userId },
 	})
 
-	return { ok: true, changedAtMs }
+	const cleared = input.clearSecondFactorsAndConnections
+		? await clearSecondFactorsAndConnections(input.d1, input.userId)
+		: null
+
+	return { ok: true, changedAtMs, cleared }
+}
+
+async function resolvePasswordHash(input: ApplyPasswordChangeCredential) {
+	if (input.unusablePasswordHash !== undefined) {
+		return input.unusablePasswordHash
+	}
+	return createPasswordHash(input.password)
 }

--- a/packages/worker/src/app/apply-password-change.ts
+++ b/packages/worker/src/app/apply-password-change.ts
@@ -97,7 +97,7 @@ export async function applyPasswordChange(
 	// provider sign-in that completes after `password_changed_at` would mint a
 	// cookie that postdates it and survives the lockout. A failure here leaves
 	// the account unstamped and the reset token intact so the caller can retry.
-	const cleared = input.clearSecondFactorsAndConnections
+	const clearedBeforeStamp = input.clearSecondFactorsAndConnections
 		? await clearSecondFactorsAndConnections(input.d1, input.userId)
 		: null
 
@@ -123,9 +123,20 @@ export async function applyPasswordChange(
 
 	// Same double-pass for factors: a still-live session could have enrolled a
 	// passkey or TOTP between the first sweep and the stamp.
-	if (input.clearSecondFactorsAndConnections) {
-		await clearSecondFactorsAndConnections(input.d1, input.userId)
-	}
+	const clearedAfterStamp = input.clearSecondFactorsAndConnections
+		? await clearSecondFactorsAndConnections(input.d1, input.userId)
+		: null
+	const cleared =
+		clearedBeforeStamp && clearedAfterStamp
+			? {
+					twoFactorRows:
+						clearedBeforeStamp.twoFactorRows + clearedAfterStamp.twoFactorRows,
+					passkeys: clearedBeforeStamp.passkeys + clearedAfterStamp.passkeys,
+					oauthConnections:
+						clearedBeforeStamp.oauthConnections +
+						clearedAfterStamp.oauthConnections,
+				}
+			: clearedBeforeStamp
 
 	// Reset tokens go last so every earlier step can be retried with the same
 	// token if it fails.

--- a/packages/worker/src/app/apply-password-change.ts
+++ b/packages/worker/src/app/apply-password-change.ts
@@ -88,6 +88,11 @@ export async function applyPasswordChange(
 		}
 	}
 
+	// Hash before touching account state: PBKDF2 is slow by design, and any
+	// time spent between the timestamp and the row write is a window where a
+	// login could mint a cookie that postdates the stamp.
+	const passwordHash = await resolvePasswordHash(input)
+
 	// Clear second factors and linked providers before the stamp: a passkey or
 	// provider sign-in that completes after `password_changed_at` would mint a
 	// cookie that postdates it and survives the lockout. A failure here leaves
@@ -97,7 +102,6 @@ export async function applyPasswordChange(
 		: null
 
 	const changedAtMs = Date.now()
-	const passwordHash = await resolvePasswordHash(input)
 	await input.db.update(usersTable, input.userId, {
 		password_hash: passwordHash,
 		password_changed_at: new Date(changedAtMs).toISOString(),
@@ -115,6 +119,12 @@ export async function applyPasswordChange(
 			detail: afterStampFailure,
 			changedAtMs,
 		}
+	}
+
+	// Same double-pass for factors: a still-live session could have enrolled a
+	// passkey or TOTP between the first sweep and the stamp.
+	if (input.clearSecondFactorsAndConnections) {
+		await clearSecondFactorsAndConnections(input.d1, input.userId)
 	}
 
 	// Reset tokens go last so every earlier step can be retried with the same

--- a/packages/worker/src/app/clear-account-factors.ts
+++ b/packages/worker/src/app/clear-account-factors.ts
@@ -1,0 +1,29 @@
+import { deletePasskeysForUser } from '#app/passkeys.ts'
+import { disableTwoFactor } from '#app/two-factor.ts'
+
+export type ClearedAccountFactors = {
+	twoFactorRows: number
+	passkeys: number
+	oauthConnections: number
+}
+
+export function clearedFactorsAuditReason(cleared: ClearedAccountFactors) {
+	return `two_factor=${cleared.twoFactorRows};passkeys=${cleared.passkeys};oauth_connections=${cleared.oauthConnections}`
+}
+
+export async function clearSecondFactorsAndConnections(
+	d1: D1Database,
+	userId: number,
+): Promise<ClearedAccountFactors> {
+	const twoFactorRows = await disableTwoFactor(d1, userId)
+	const passkeys = await deletePasskeysForUser(d1, userId)
+	const oauthResult = await d1
+		.prepare(`DELETE FROM oauth_connections WHERE user_id = ?`)
+		.bind(userId)
+		.run()
+	return {
+		twoFactorRows,
+		passkeys,
+		oauthConnections: oauthResult.meta?.changes ?? 0,
+	}
+}

--- a/packages/worker/src/app/email/messages.ts
+++ b/packages/worker/src/app/email/messages.ts
@@ -332,3 +332,22 @@ export function buildPasswordResetEmail(input: {
 			'If you did not request a reset, you can safely ignore this email — your password stays unchanged.',
 	})
 }
+
+export function buildPasswordResetConfirmedEmail(input: {
+	appBaseUrl: string
+	accountUrl: string
+}) {
+	return renderTransactionalEmail({
+		appBaseUrl: input.appBaseUrl,
+		subject: 'Your Kody password was reset',
+		preheader: 'Your password changed. Extra sign-in methods were removed.',
+		heading: 'Your password was reset',
+		body: [
+			'Your Kody password was changed using a reset link.',
+			'Two-factor authentication, passkeys, and linked sign-in providers were removed; set them up again from your account.',
+		],
+		action: { label: 'Open account settings', url: input.accountUrl },
+		footnote:
+			'If you did not reset your password, sign in and change it again, then review your account security.',
+	})
+}

--- a/packages/worker/src/app/handlers/account-password.node.test.ts
+++ b/packages/worker/src/app/handlers/account-password.node.test.ts
@@ -132,6 +132,18 @@ test('signed-in password change requires the current password, revokes MCP grant
 	sqlite.exec(`
 		INSERT INTO password_resets (user_id, token_hash, expires_at)
 		VALUES (1, 'pending-reset', ${Date.now() + 60_000});
+		INSERT INTO verifications (
+			type, target, secret, algorithm, digits, period, char_set
+		) VALUES ('2fa', '1', 'KEEPSECRET', 'SHA-1', 6, 30, '0123456789');
+		INSERT INTO passkeys (
+			id, aaguid, public_key, user_id, webauthn_user_handle, counter,
+			device_type, backed_up, transports, name
+		) VALUES (
+			'keep-passkey', '00000000-0000-0000-0000-000000000000', 'cHVibGlj',
+			1, 'd2ViYXV0aG4tdXNlcg', 0, 'multiDevice', 1, 'internal', 'laptop'
+		);
+		INSERT INTO oauth_connections (provider_name, provider_id, user_id, provider_display_name)
+		VALUES ('github', 'keep-github', 1, 'ada');
 	`)
 	const { helpers, revokedGrantIds } = createTrackingGrantHelpers()
 	const handler = createAccountPasswordHandler(
@@ -233,6 +245,23 @@ test('signed-in password change requires the current password, revokes MCP grant
 	expect(
 		sqlite.prepare(`SELECT COUNT(*) AS count FROM password_resets`).get(),
 	).toEqual({ count: 0 })
+	expect(
+		sqlite
+			.prepare(`SELECT COUNT(*) AS count FROM verifications WHERE target = '1'`)
+			.get(),
+	).toEqual({ count: 1 })
+	expect(
+		sqlite
+			.prepare(`SELECT COUNT(*) AS count FROM passkeys WHERE user_id = 1`)
+			.get(),
+	).toEqual({ count: 1 })
+	expect(
+		sqlite
+			.prepare(
+				`SELECT COUNT(*) AS count FROM oauth_connections WHERE user_id = 1`,
+			)
+			.get(),
+	).toEqual({ count: 1 })
 
 	const row = sqlite
 		.prepare(

--- a/packages/worker/src/app/handlers/account-password.ts
+++ b/packages/worker/src/app/handlers/account-password.ts
@@ -219,6 +219,7 @@ export function createAccountPasswordHandler(env: Env) {
 				.OAUTH_PROVIDER
 			const result = await applyPasswordChange({
 				db,
+				d1: env.APP_DB,
 				helpers,
 				userId: user.userId,
 				stableUserId: resolveUserStableId(userRecord),

--- a/packages/worker/src/app/handlers/auth-provider.node.test.ts
+++ b/packages/worker/src/app/handlers/auth-provider.node.test.ts
@@ -22,7 +22,11 @@ const {
 import { createMswNodeServer } from '#worker/test-support/msw-node-server.ts'
 import { createStableUserIdFromEmail } from '#worker/user-id.ts'
 import { quoteSqlString } from '@kody-internal/shared/sql-literals.ts'
-import { createPasswordHash } from '@kody-internal/shared/password-hash.ts'
+import {
+	createPasswordHash,
+	verifyPassword,
+} from '@kody-internal/shared/password-hash.ts'
+import { unusablePasswordHash } from '#worker/identity/usable-password.ts'
 import {
 	auditEventSummaries,
 	logAuditEventSpy,
@@ -127,26 +131,29 @@ async function seedUser(
 		email: string
 		username: string
 		stableUserId?: string
+		emailVerified?: boolean
 	},
 ) {
 	const passwordHash = await createPasswordHash('test-password')
 	const stableUserId =
 		input.stableUserId ?? (await createStableUserIdFromEmail(input.email))
+	const verifiedAt = input.emailVerified ? 'CURRENT_TIMESTAMP' : 'NULL'
 	sqlite.exec(`
-		INSERT INTO users (id, username, email, stable_user_id, password_hash)
+		INSERT INTO users (id, username, email, stable_user_id, password_hash, email_verified_at)
 		VALUES (
 			${input.id},
 			${quoteSqlString(input.username)},
 			${quoteSqlString(input.email)},
 			${quoteSqlString(stableUserId)},
-			${quoteSqlString(passwordHash)}
+			${quoteSqlString(passwordHash)},
+			${verifiedAt}
 		);
 	`)
 }
 
 function createAppEnv(
 	db: D1Database,
-	overrides: Record<string, string> = {},
+	overrides: Record<string, unknown> = {},
 ): Env {
 	return {
 		APP_DB: db,
@@ -402,7 +409,22 @@ test('google sign-in links a matching verified email to the existing account', a
 		id: 7,
 		email: 'existing@example.com',
 		username: 'existing-user',
+		emailVerified: true,
 	})
+	sqlite.exec(`
+		INSERT INTO verifications (
+			type, target, secret, algorithm, digits, period, char_set
+		) VALUES ('2fa', '7', 'KEEPSECRET', 'SHA-1', 6, 30, '0123456789');
+		INSERT INTO passkeys (
+			id, aaguid, public_key, user_id, webauthn_user_handle, counter,
+			device_type, backed_up, transports, name
+		) VALUES (
+			'keep-passkey', '00000000-0000-0000-0000-000000000000', 'cHVibGlj',
+			7, 'd2ViYXV0aG4tdXNlcg', 0, 'multiDevice', 1, 'internal', 'laptop'
+		);
+		INSERT INTO oauth_connections (provider_name, provider_id, user_id, provider_display_name)
+		VALUES ('github', 'keep-github', 7, 'existing-user');
+	`)
 
 	msw.use(
 		http.post('https://oauth2.googleapis.com/token', async ({ request }) => {
@@ -442,11 +464,11 @@ test('google sign-in links a matching verified email to the existing account', a
 		{ provider: 'google' },
 	)
 	expect(callbackResponse.status).toBe(302)
-	expect(callbackResponse.headers.get('Location')).toBe('/account')
+	expect(callbackResponse.headers.get('Location')).toBe('/verify')
 	expect(
 		callbackResponse.headers
 			.getSetCookie()
-			.some((cookie) => cookie.startsWith('kody_session=')),
+			.some((cookie) => cookie.startsWith('kody_verify=')),
 	).toBe(true)
 
 	const connection = sqlite
@@ -458,13 +480,151 @@ test('google sign-in links a matching verified email to the existing account', a
 	// The provider verified the exact account email, so the account is
 	// treated as email-verified.
 	const user = sqlite
-		.prepare(`SELECT email_verified_at FROM users WHERE id = 7`)
-		.get() as { email_verified_at: string | null }
+		.prepare(`SELECT password_hash, email_verified_at FROM users WHERE id = 7`)
+		.get() as { password_hash: string; email_verified_at: string | null }
 	expect(user.email_verified_at).toBeTruthy()
+	expect(await verifyPassword('test-password', user.password_hash)).toBe(true)
+	expect(
+		sqlite
+			.prepare(`SELECT COUNT(*) AS count FROM verifications WHERE target = '7'`)
+			.get(),
+	).toEqual({ count: 1 })
+	expect(
+		sqlite
+			.prepare(`SELECT COUNT(*) AS count FROM passkeys WHERE user_id = 7`)
+			.get(),
+	).toEqual({ count: 1 })
+	expect(
+		sqlite
+			.prepare(
+				`SELECT COUNT(*) AS count FROM oauth_connections WHERE user_id = 7`,
+			)
+			.get(),
+	).toEqual({ count: 2 })
+	expect(auditEventSummaries()).not.toContain(
+		'social_link_reclaimed_unverified_account:success',
+	)
 	const userCount = sqlite
 		.prepare(`SELECT COUNT(*) AS count FROM users`)
 		.get() as { count: number }
 	expect(userCount.count).toBe(1)
+})
+
+test('google sign-in reclaims an unverified password account matching the provider email', async () => {
+	const { sqlite, db } = createMigratedDb()
+	const revokedGrantIds = new Array<string>()
+	const env = createAppEnv(db, {
+		OAUTH_PROVIDER: {
+			listUserGrants: async () => ({
+				items: revokedGrantIds.includes('grant-1')
+					? []
+					: [{ id: 'grant-1', clientId: 'client-a' }],
+			}),
+			revokeGrant: async (grantId: string) => {
+				revokedGrantIds.push(grantId)
+			},
+		},
+	})
+	await seedUser(sqlite, {
+		id: 8,
+		email: 'squat@example.com',
+		username: 'squatter',
+		emailVerified: false,
+	})
+	sqlite.exec(`
+		INSERT INTO verifications (
+			type, target, secret, algorithm, digits, period, char_set
+		) VALUES ('2fa', '8', 'ATTACKERSECRET', 'SHA-1', 6, 30, '0123456789');
+		INSERT INTO passkeys (
+			id, aaguid, public_key, user_id, webauthn_user_handle, counter,
+			device_type, backed_up, transports, name
+		) VALUES (
+			'attacker-passkey', '00000000-0000-0000-0000-000000000000', 'cHVibGlj',
+			8, 'd2ViYXV0aG4tdXNlcg', 0, 'multiDevice', 1, 'internal', 'attacker'
+		);
+		INSERT INTO oauth_connections (provider_name, provider_id, user_id, provider_display_name)
+		VALUES ('github', 'attacker-github', 8, 'squatter');
+		INSERT INTO password_resets (user_id, token_hash, expires_at)
+		VALUES (8, 'pending-reset', ${Date.now() + 60_000});
+	`)
+
+	msw.use(
+		http.post('https://oauth2.googleapis.com/token', () =>
+			HttpResponse.json({ access_token: 'google-access-token' }),
+		),
+		http.get('https://openidconnect.googleapis.com/v1/userinfo', () =>
+			HttpResponse.json({
+				sub: 'google-victim-sub',
+				email: 'squat@example.com',
+				email_verified: true,
+				name: 'Real Owner',
+			}),
+		),
+	)
+
+	const start = await startProviderFlow(
+		env,
+		'google',
+		'http://example.com/auth/google',
+	)
+	const callbackResponse = await runHandler(
+		createAuthProviderCallbackHandler(env),
+		new Request(
+			`http://example.com/auth/google/callback?code=google-auth-code&state=${start.state}`,
+			{ headers: { Cookie: start.stateCookie } },
+		),
+		{ provider: 'google' },
+	)
+	expect(callbackResponse.status).toBe(302)
+	expect(callbackResponse.headers.get('Location')).toBe('/account')
+	expect(
+		callbackResponse.headers
+			.getSetCookie()
+			.some((cookie) => cookie.startsWith('kody_session=')),
+	).toBe(true)
+
+	const user = sqlite
+		.prepare(`SELECT password_hash, email_verified_at FROM users WHERE id = 8`)
+		.get() as { password_hash: string; email_verified_at: string | null }
+	expect(user.email_verified_at).toBeTruthy()
+	expect(user.password_hash).toBe(unusablePasswordHash.reclaimedUnverified)
+	expect(await verifyPassword('test-password', user.password_hash)).toBe(false)
+	expect(
+		sqlite
+			.prepare(`SELECT COUNT(*) AS count FROM verifications WHERE target = '8'`)
+			.get(),
+	).toEqual({ count: 0 })
+	expect(
+		sqlite
+			.prepare(`SELECT COUNT(*) AS count FROM passkeys WHERE user_id = 8`)
+			.get(),
+	).toEqual({ count: 0 })
+	expect(
+		sqlite.prepare(`SELECT COUNT(*) AS count FROM password_resets`).get(),
+	).toEqual({ count: 0 })
+	const connections = sqlite
+		.prepare(
+			`SELECT provider_name, provider_id FROM oauth_connections WHERE user_id = 8`,
+		)
+		.all() as Array<{ provider_name: string; provider_id: string }>
+	expect(connections).toEqual([
+		{ provider_name: 'google', provider_id: 'google-victim-sub' },
+	])
+	expect(revokedGrantIds).toEqual(['grant-1'])
+	expect(auditEventSummaries()).toEqual([
+		'social_link_reclaimed_unverified_account:success',
+		'oauth_login:success',
+	])
+	expect(logAuditEventSpy).toHaveBeenCalledWith(
+		expect.objectContaining({
+			category: 'auth',
+			action: 'social_link_reclaimed_unverified_account',
+			result: 'success',
+			reason: expect.stringContaining(
+				'provider=google;two_factor=1;passkeys=1;oauth_connections=1',
+			),
+		}),
+	)
 })
 
 test('discord sign-in creates a verified account and assigns the guild role', async () => {

--- a/packages/worker/src/app/handlers/auth-provider.ts
+++ b/packages/worker/src/app/handlers/auth-provider.ts
@@ -83,12 +83,16 @@ import {
 	maybeJoinOfficialDiscordGuild,
 	maybeSyncDiscordGuildRolesForUser,
 } from '#worker/discord/guild-role.ts'
+import { applyPasswordChange } from '#app/apply-password-change.ts'
+import { clearedFactorsAuditReason } from '#app/clear-account-factors.ts'
+import { type OAuthGrantHelpers } from '#worker/oauth-grants.ts'
+import { unusablePasswordHash } from '#worker/identity/usable-password.ts'
 
 /**
  * Accounts created through social login have no usable password until the
  * user sets one via password reset; verifyPassword rejects this sentinel.
  */
-const oauthNoUsablePasswordHash = 'oauth_created_no_usable_password'
+const oauthNoUsablePasswordHash = unusablePasswordHash.oauthCreated
 
 function getCallbackRedirectUri(env: Env, url: URL, provider: OauthProviderId) {
 	// The OAuth login state lives in a host-scoped cookie, so the provider must
@@ -429,6 +433,11 @@ export function createAuthProviderCallbackHandler(env: Env) {
 					 * signups can append accountCreated=1 for Fathom).
 					 */
 					destination?: string
+					/**
+					 * Cookie `issuedAt`. Reclaim stamps `password_changed_at` first,
+					 * so the new session must postdate that timestamp.
+					 */
+					issuedAt?: number
 				} = {},
 			) {
 				const stableUserId = resolveUserStableId(user)
@@ -466,6 +475,7 @@ export function createAuthProviderCallbackHandler(env: Env) {
 				const sessionCookie = await createAuthCookie(
 					{ stableUserId, email: user.email, rememberMe: false },
 					secure,
+					options.issuedAt ?? Date.now(),
 				)
 				await touchLastActiveAt(env.APP_DB, { stableUserId })
 				void logAuditEvent({
@@ -572,9 +582,44 @@ export function createAuthProviderCallbackHandler(env: Env) {
 			const email = normalizeEmail(profile.email)
 
 			// 3. A provider-verified email matching an existing account links
-			// the identity and signs that account in.
+			// the identity and signs that account in. An unverified row is
+			// treated as a possible squat: invalidate the password, drop
+			// attacker-added factors, then link.
 			const existingUser = await db.findOne(usersTable, { where: { email } })
 			if (existingUser) {
+				let sessionIssuedAt: number | undefined
+				if (!existingUser.email_verified_at) {
+					const helpers = (env as Env & { OAUTH_PROVIDER?: OAuthGrantHelpers })
+						.OAUTH_PROVIDER
+					const reclaim = await applyPasswordChange({
+						db,
+						d1: env.APP_DB,
+						helpers,
+						userId: existingUser.id,
+						stableUserId: resolveUserStableId(existingUser),
+						unusablePasswordHash: unusablePasswordHash.reclaimedUnverified,
+						clearSecondFactorsAndConnections: true,
+					})
+					if (!reclaim.ok) {
+						return fail(
+							'account-error',
+							reclaim.reason === 'oauth_grant_revoke_failed'
+								? reclaim.detail
+								: reclaim.reason,
+						)
+					}
+					sessionIssuedAt = reclaim.changedAtMs + 1
+					void logAuditEvent({
+						db: auditDatabaseFromEnv(env),
+						category: 'auth',
+						action: 'social_link_reclaimed_unverified_account',
+						result: 'success',
+						email: existingUser.email,
+						ip: requestIp,
+						path: url.pathname,
+						reason: `provider=${provider};${clearedFactorsAuditReason(reclaim.cleared ?? { twoFactorRows: 0, passkeys: 0, oauthConnections: 0 })}`,
+					})
+				}
 				try {
 					await createConnection({
 						provider,
@@ -600,7 +645,9 @@ export function createAuthProviderCallbackHandler(env: Env) {
 					discordUserId: profile.providerUserId,
 					accessToken,
 				})
-				return issueLogin(existingUser)
+				return issueLogin(existingUser, '/account', {
+					issuedAt: sessionIssuedAt,
+				})
 			}
 
 			// 4. New account. Production requires a valid invite carried in the

--- a/packages/worker/src/app/handlers/password-reset-confirm.node.test.ts
+++ b/packages/worker/src/app/handlers/password-reset-confirm.node.test.ts
@@ -1,0 +1,146 @@
+import { quoteSqlString } from '@kody-internal/shared/sql-literals.ts'
+import { DatabaseSync } from 'node:sqlite'
+import { expect, test, vi } from 'vitest'
+import {
+	createPasswordHash,
+	verifyPassword,
+} from '@kody-internal/shared/password-hash.ts'
+import { applyAllMigrations } from '#worker/test-support/apply-all-migrations.ts'
+import { createD1FromSqlite } from '#worker/test-support/create-d1-from-sqlite.ts'
+import { logAuditEventSpy } from '#worker/test-support/audit-log-spy.ts'
+import { createStableUserIdFromEmail } from '#worker/user-id.ts'
+import { hashPasswordResetToken } from '#worker/identity/password-reset-tokens.ts'
+
+const mockSendCloudflareEmail = vi.fn(async () => ({ ok: true }))
+
+vi.mock('#app/email/cloudflare-email.ts', () => ({
+	sendCloudflareEmail: (...args: Array<unknown>) =>
+		mockSendCloudflareEmail(...args),
+}))
+
+const { createPasswordResetConfirmHandler } =
+	await import('./password-reset.ts')
+
+function createMigratedDb() {
+	const sqlite = new DatabaseSync(':memory:')
+	applyAllMigrations(sqlite, new URL('../../../migrations/', import.meta.url))
+	return {
+		sqlite,
+		db: createD1FromSqlite(sqlite),
+	}
+}
+
+test('password reset confirm clears TOTP, passkeys, and linked providers', async () => {
+	const { sqlite, db } = createMigratedDb()
+	const email = 'reset-owner@example.com'
+	const passwordHash = await createPasswordHash('old-password-ok')
+	const stableUserId = await createStableUserIdFromEmail(email)
+	const token = 'b'.repeat(64)
+	const tokenHash = await hashPasswordResetToken(token)
+	sqlite.exec(`
+		INSERT INTO users (
+			id, username, email, stable_user_id, password_hash, email_verified_at
+		) VALUES (
+			1,
+			'reset-owner',
+			${quoteSqlString(email)},
+			${quoteSqlString(stableUserId)},
+			${quoteSqlString(passwordHash)},
+			CURRENT_TIMESTAMP
+		);
+		INSERT INTO verifications (
+			type, target, secret, algorithm, digits, period, char_set
+		) VALUES ('2fa', '1', 'RESETSECRET', 'SHA-1', 6, 30, '0123456789');
+		INSERT INTO verifications (
+			type, target, secret, algorithm, digits, period, char_set
+		) VALUES ('2fa-verify', '1', 'PENDINGSECRET', 'SHA-1', 6, 30, '0123456789');
+		INSERT INTO passkeys (
+			id, aaguid, public_key, user_id, webauthn_user_handle, counter,
+			device_type, backed_up, transports, name
+		) VALUES (
+			'reset-passkey', '00000000-0000-0000-0000-000000000000', 'cHVibGlj',
+			1, 'd2ViYXV0aG4tdXNlcg', 0, 'multiDevice', 1, 'internal', 'laptop'
+		);
+		INSERT INTO oauth_connections (provider_name, provider_id, user_id, provider_display_name)
+		VALUES ('github', 'reset-github', 1, 'reset-owner');
+		INSERT INTO password_resets (user_id, token_hash, expires_at)
+		VALUES (1, ${quoteSqlString(tokenHash)}, ${Date.now() + 60_000});
+	`)
+
+	const revokedGrantIds = new Array<string>()
+	const handler = createPasswordResetConfirmHandler({
+		APP_DB: db,
+		APP_BASE_URL: 'https://kody.codes',
+		SYSTEM_EMAIL_DOMAIN: 'kody.codes',
+		CLOUDFLARE_ACCOUNT_ID: 'account-id',
+		CLOUDFLARE_API_BASE_URL: 'https://api.cloudflare.test',
+		CLOUDFLARE_API_TOKEN: 'api-token',
+		OAUTH_PROVIDER: {
+			listUserGrants: async () => ({
+				items: revokedGrantIds.includes('grant-1')
+					? []
+					: [{ id: 'grant-1', clientId: 'client-a' }],
+			}),
+			revokeGrant: async (grantId: string) => {
+				revokedGrantIds.push(grantId)
+			},
+		},
+	} as unknown as Env)
+
+	const response = await handler.handler({
+		request: new Request('https://kody.codes/password-reset/confirm', {
+			method: 'POST',
+			body: JSON.stringify({
+				token,
+				password: 'brand-new-password',
+			}),
+		}),
+		url: new URL('https://kody.codes/password-reset/confirm'),
+		params: {},
+	} as never)
+
+	expect(response.status).toBe(200)
+	expect(await response.json()).toEqual({ ok: true })
+	expect(revokedGrantIds).toEqual(['grant-1'])
+
+	const row = sqlite
+		.prepare(`SELECT password_hash FROM users WHERE id = 1`)
+		.get() as { password_hash: string }
+	expect(await verifyPassword('brand-new-password', row.password_hash)).toBe(
+		true,
+	)
+	expect(await verifyPassword('old-password-ok', row.password_hash)).toBe(false)
+	expect(
+		sqlite.prepare(`SELECT COUNT(*) AS count FROM password_resets`).get(),
+	).toEqual({ count: 0 })
+	expect(
+		sqlite
+			.prepare(`SELECT COUNT(*) AS count FROM verifications WHERE target = '1'`)
+			.get(),
+	).toEqual({ count: 0 })
+	expect(
+		sqlite
+			.prepare(`SELECT COUNT(*) AS count FROM passkeys WHERE user_id = 1`)
+			.get(),
+	).toEqual({ count: 0 })
+	expect(
+		sqlite
+			.prepare(
+				`SELECT COUNT(*) AS count FROM oauth_connections WHERE user_id = 1`,
+			)
+			.get(),
+	).toEqual({ count: 0 })
+	expect(logAuditEventSpy).toHaveBeenCalledWith(
+		expect.objectContaining({
+			category: 'auth',
+			action: 'password_reset_confirm',
+			result: 'success',
+			reason: 'two_factor=2;passkeys=1;oauth_connections=1',
+		}),
+	)
+	const [, message] = mockSendCloudflareEmail.mock.calls[0]!
+	expect((message as { to: string }).to).toBe(email)
+	expect((message as { text: string }).text).toContain(
+		'Two-factor authentication, passkeys, and linked sign-in providers were removed',
+	)
+})

--- a/packages/worker/src/app/handlers/password-reset.node.test.ts
+++ b/packages/worker/src/app/handlers/password-reset.node.test.ts
@@ -339,6 +339,8 @@ test('password reset confirm revokes MCP grants before stamping password_changed
 	const handler = createPasswordResetConfirmHandler(
 		createEnv({
 			OAUTH_PROVIDER: helpers,
+			APP_BASE_URL: 'https://kody.codes',
+			SYSTEM_EMAIL_DOMAIN: 'kody.codes',
 		}),
 	)
 
@@ -373,7 +375,14 @@ test('password reset confirm revokes MCP grants before stamping password_changed
 			category: 'auth',
 			action: 'password_reset_confirm',
 			result: 'success',
+			reason: 'two_factor=0;passkeys=0;oauth_connections=0',
 		}),
+	)
+	const [, confirmMessage] = mockModule.sendCloudflareEmail.mock.calls[0]!
+	expect((confirmMessage as { to: string }).to).toBe('user@example.com')
+	expect((confirmMessage as { from: string }).from).toBe('kody@kody.codes')
+	expect((confirmMessage as { text: string }).text).toContain(
+		'Two-factor authentication, passkeys, and linked sign-in providers were removed',
 	)
 })
 
@@ -388,6 +397,8 @@ test('password reset confirm revokes a grant created between first revoke and pa
 	const handler = createPasswordResetConfirmHandler(
 		createEnv({
 			OAUTH_PROVIDER: helpers,
+			APP_BASE_URL: 'https://kody.codes',
+			SYSTEM_EMAIL_DOMAIN: 'kody.codes',
 		}),
 	)
 

--- a/packages/worker/src/app/handlers/password-reset.ts
+++ b/packages/worker/src/app/handlers/password-reset.ts
@@ -17,9 +17,13 @@ import {
 } from '#worker/identity/password-reset-tokens.ts'
 import { type routes } from '#universal/routes.ts'
 import { applyPasswordChange } from '#app/apply-password-change.ts'
+import { clearedFactorsAuditReason } from '#app/clear-account-factors.ts'
 import { getPasswordPolicyError } from '@kody-internal/shared/password-policy.ts'
 import { verifyPublicFormProtection } from '#app/public-form-protection.ts'
-import { buildPasswordResetEmail } from '#app/email/messages.ts'
+import {
+	buildPasswordResetConfirmedEmail,
+	buildPasswordResetEmail,
+} from '#app/email/messages.ts'
 import { resolveTransactionalEmailConfig } from '#app/email/sender-config.ts'
 import { type OAuthGrantHelpers } from '#worker/oauth-grants.ts'
 import { resolveUserStableId } from '#worker/user-id.ts'
@@ -289,10 +293,12 @@ export function createPasswordResetConfirmHandler(env: Env) {
 				.OAUTH_PROVIDER
 			const result = await applyPasswordChange({
 				db,
+				d1: env.APP_DB,
 				helpers,
 				userId: resetRecord.user_id,
 				stableUserId: resolveUserStableId(userRecord),
 				password,
+				clearSecondFactorsAndConnections: true,
 			})
 			if (!result.ok) {
 				void logAuditEvent({
@@ -320,7 +326,45 @@ export function createPasswordResetConfirmHandler(env: Env) {
 				result: 'success',
 				ip: requestIp,
 				path: url.pathname,
+				reason: result.cleared
+					? clearedFactorsAuditReason(result.cleared)
+					: undefined,
 			})
+
+			const emailConfig = getPasswordResetEmailConfig(env, url)
+			const accountUrl = new URL(
+				'/account',
+				emailConfig?.appBaseUrl ?? url,
+			).toString()
+			const email = buildPasswordResetConfirmedEmail({
+				appBaseUrl: emailConfig?.appBaseUrl ?? new URL(url).origin,
+				accountUrl,
+			})
+			if (!emailConfig) {
+				logMissingEmailConfig({
+					to: userRecord.email,
+					subject: email.subject,
+				})
+			} else {
+				try {
+					await sendCloudflareEmail(
+						{
+							accountId: env.CLOUDFLARE_ACCOUNT_ID,
+							apiBaseUrl: env.CLOUDFLARE_API_BASE_URL,
+							apiToken: env.CLOUDFLARE_API_TOKEN,
+						},
+						{
+							to: userRecord.email,
+							from: emailConfig.fromEmail,
+							subject: email.subject,
+							html: email.html,
+							text: email.text,
+						},
+					)
+				} catch (error) {
+					console.warn('cloudflare-email-error', error)
+				}
+			}
 
 			return Response.json({ ok: true })
 		},

--- a/packages/worker/src/app/passkeys.ts
+++ b/packages/worker/src/app/passkeys.ts
@@ -122,3 +122,11 @@ export async function deletePasskeyForUser(
 		.run()
 	return (result.meta?.changes ?? 0) > 0
 }
+
+export async function deletePasskeysForUser(db: D1Database, userId: number) {
+	const result = await db
+		.prepare(`DELETE FROM passkeys WHERE user_id = ?`)
+		.bind(userId)
+		.run()
+	return result.meta?.changes ?? 0
+}

--- a/packages/worker/src/app/two-factor.ts
+++ b/packages/worker/src/app/two-factor.ts
@@ -167,7 +167,7 @@ export async function cancelTwoFactorSetup(db: D1Database, userId: number) {
 export async function disableTwoFactor(db: D1Database, userId: number) {
 	// Also drop any pending setup so a stale scanned secret can't be
 	// re-activated later without going through the full setup flow.
-	await db
+	const result = await db
 		.prepare(`DELETE FROM verifications WHERE target = ? AND type IN (?, ?)`)
 		.bind(
 			getTwoFactorTarget(userId),
@@ -175,4 +175,5 @@ export async function disableTwoFactor(db: D1Database, userId: number) {
 			twoFactorSetupVerificationType,
 		)
 		.run()
+	return result.meta?.changes ?? 0
 }

--- a/packages/worker/src/identity/admin-user-creation.ts
+++ b/packages/worker/src/identity/admin-user-creation.ts
@@ -14,8 +14,7 @@ import {
 	normalizeUsername,
 } from '#worker/identity/username.ts'
 import { createStableUserIdFromEmail } from '#worker/user-id.ts'
-
-const adminCreatedNoUsablePasswordHash = 'admin_created_no_usable_password'
+import { unusablePasswordHash } from '#worker/identity/usable-password.ts'
 
 export type AdminCreateUserErrorCode =
 	| 'invalid_email'
@@ -121,7 +120,7 @@ export async function adminCreateUserWithPasswordSetup(input: {
 			.bind(
 				username,
 				email,
-				adminCreatedNoUsablePasswordHash,
+				unusablePasswordHash.adminCreated,
 				nowIso,
 				stableUserId,
 			)

--- a/packages/worker/src/identity/platform-account-creation.ts
+++ b/packages/worker/src/identity/platform-account-creation.ts
@@ -7,9 +7,7 @@ import {
 	normalizeUsername,
 } from '#worker/identity/username.ts'
 import { createStableUserIdFromEmail } from '#worker/user-id.ts'
-
-const platformAccountNoUsablePasswordHash =
-	'platform_account_no_usable_password'
+import { unusablePasswordHash } from '#worker/identity/usable-password.ts'
 
 export type PlatformAccountCreateErrorCode =
 	| 'invalid_email'
@@ -95,7 +93,7 @@ export async function createPlatformAccount(input: {
 			.bind(
 				username,
 				email,
-				platformAccountNoUsablePasswordHash,
+				unusablePasswordHash.platformAccount,
 				nowIso,
 				stableUserId,
 			)

--- a/packages/worker/src/identity/usable-password.node.test.ts
+++ b/packages/worker/src/identity/usable-password.node.test.ts
@@ -8,6 +8,9 @@ test('isUsablePasswordHash accepts only pbkdf2 hashes', () => {
 	expect(isUsablePasswordHash('platform_account_no_usable_password')).toBe(
 		false,
 	)
+	expect(isUsablePasswordHash('reclaimed_unverified_no_usable_password')).toBe(
+		false,
+	)
 	expect(isUsablePasswordHash(null)).toBe(false)
 	expect(isUsablePasswordHash(undefined)).toBe(false)
 	expect(isUsablePasswordHash('')).toBe(false)

--- a/packages/worker/src/identity/usable-password.ts
+++ b/packages/worker/src/identity/usable-password.ts
@@ -1,5 +1,17 @@
 const usablePasswordHashPrefix = 'pbkdf2_sha256$'
 
+/**
+ * Stored `users.password_hash` values that are not PBKDF2 and never verify.
+ * `verifyPassword` rejects anything that is not a pbkdf2_sha256 hash; these
+ * labels exist so operators can tell why an account has no usable password.
+ */
+export const unusablePasswordHash = {
+	oauthCreated: 'oauth_created_no_usable_password',
+	adminCreated: 'admin_created_no_usable_password',
+	platformAccount: 'platform_account_no_usable_password',
+	reclaimedUnverified: 'reclaimed_unverified_no_usable_password',
+} as const
+
 export function isUsablePasswordHash(passwordHash: string | null | undefined) {
 	return passwordHash?.startsWith(usablePasswordHashPrefix) === true
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Close the pre-account-takeover path that open signup would expose through social login, and make password reset a complete recovery.

## Why

From the 2026-09-01 launch-readiness audit (highest-severity finding). `auth-provider.ts` step 3 linked a provider-verified email to an existing `users` row and marked it verified without checking whether that row was already verified. With open signup an attacker registers `victim@example.com` with their own password; the row sits unverified. When the victim later clicks "Sign in with Google" they are logged into the attacker's account, it becomes verified, and the attacker keeps password access to every secret, integration token, and inbox the victim then creates.

The natural remedy — password reset — did not remove attacker-added TOTP, passkeys, or linked providers (`apply-password-change.ts` only rotated the hash, stamped `password_changed_at`, revoked MCP grants, and deleted reset tokens), so a squatter could keep a login path after "recovery".

## Summary

- **Social link reclaim** (`auth-provider.ts`): when the matched account has no `email_verified_at`, before linking: set `password_hash` to the `reclaimed_unverified_no_usable_password` sentinel (new shared `identity/usable-password.ts`; existing `oauth_created` / `admin_created` / platform sentinels consolidated there), stamp `password_changed_at` (kills existing browser sessions and MCP bearers), revoke MCP OAuth grants, disable TOTP, delete passkeys, delete other `oauth_connections`, delete reset tokens — then link, mark verified, and issue a session whose `issuedAt` postdates the stamp. Audited as `social_link_reclaimed_unverified_account` with removal counts. Already-verified matches behave exactly as before.
- **Password reset confirm** (`password-reset.ts`): `applyPasswordChange({ clearSecondFactorsAndConnections: true })` clears TOTP, passkeys, and `oauth_connections`; the confirmation email lists what was removed. Signed-in password change (`account-password.ts`) is unchanged and does not clear factors.
- New `app/clear-account-factors.ts` shared by both paths; `deletePasskeysForUser` added; `disableTwoFactor` returns a count.
- Docs: `security.md` (invariants and residual risks), `architecture/authentication.md`, `social-login.md`.

Failure posture: if grant revocation fails during reclaim the login fails closed (`account-error`) rather than linking. If the reclaim succeeds but the connection insert then conflicts, the squatted account is already neutralised — the safe direction.

## Testing

`npm run typecheck`, `npm run lint`, `npm run format:check`, `npm run docs:check-temporal`; node suites `password-hash`, `usable-password`, `admin-user-creation`, `auth-provider` (new: reclaim scenario asserting attacker password fails, factors/connections gone, grants revoked, audit row; regression: verified account links as before), `password-reset`, `password-reset-confirm` (new: TOTP/passkeys/connections cleared), `account-password` (regression: not cleared) — 7 files, 32 tests passed.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends</b> app-sessions and social-login contracts (high risk)</summary>

**Mode:** recap · **Base:** `main` @ `40e70929` · **Head:** `HEAD`

**Classification:** extends — social-login linking and password-reset confirmation gain destructive cleanup steps; touches the account-takeover boundary.

### Primitives touched

| Primitive        | Group    | Impact                                                            |
| ---------------- | -------- | ----------------------------------------------------------------- |
| `social-login`   | surfaces | extends — unverified match is reclaimed before link               |
| `app-sessions`   | surfaces | extends — reset confirm clears 2FA/passkeys/connections           |
| `mcp-oauth`      | surfaces | composes — grants revoked around the stamp (existing helper)      |
| `d1-app-db`      | storage  | composes — writes to users, passkeys, two-factor, oauth_connections |

### Change flow

A provider-verified email matching an unverified password account now neutralises that account before signing the provider user in.

```mermaid
sequenceDiagram
	actor Victim
	participant social as social-login callback
	participant pwd as apply-password-change
	participant d1AppDb as d1-app-db
	participant grants as mcp-oauth grants
	participant auditLog as audit-log
	Victim->>social: GET /auth/:provider/callback (verified email)
	social->>d1AppDb: find users by email
	alt email_verified_at is null
		social->>pwd: applyPasswordChange(unusable sentinel, clear factors)
		pwd->>grants: revoke all grants (before + after stamp)
		pwd->>d1AppDb: UPDATE users password_hash, password_changed_at
		pwd->>d1AppDb: DELETE two-factor, passkeys, oauth_connections, password_resets
		social->>auditLog: auth/social_link_reclaimed_unverified_account (counts)
	end
	social->>d1AppDb: INSERT oauth_connections (provider), SET email_verified_at
	social-->>Victim: session cookie issuedAt > password_changed_at
```

### Invariants

Touches the account-ownership boundary: after this change no unverified row can be inherited with a usable third-party password. Per-user isolation is unaffected (all writes are keyed by the matched `users.id`).

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b0f6a92a-81cd-4157-8b60-188c83ca84c0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b0f6a92a-81cd-4157-8b60-188c83ca84c0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Password resets now disable two-factor authentication and remove passkeys and linked social sign-ins.
  - Confirmation emails list the sign-in methods removed during the reset.
  - Verified social sign-ins can securely reclaim matching unverified accounts while invalidating previous access.
  - Conflicting account matches now return a controlled sign-in error.

- **Account Management**
  - Signed-in password changes preserve two-factor authentication, passkeys, and linked social sign-ins.
  - Reclaimed accounts are protected from continued password-based access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->