### PR TITLE
Keep MCP read paths off the write lease and defer execute bookkeeping

### DIFF
--- a/docs/contributing/account-write-lease-repair.md
+++ b/docs/contributing/account-write-lease-repair.md
@@ -4,6 +4,10 @@ Account write leases do not expire. A crashed writer intentionally blocks
 account deletion until an administrator verifies that the process is gone and
 releases its exact token with an audit reason.
 
+Read-only MCP traffic (`initialize`, `tools/list`, `ping`, and `search`) does
+not acquire a write lease; mutating `tools/call` (including `execute`) still
+does. Deleting accounts are rejected on both paths via D1 `users.deleting_at`.
+
 Active leases live in the UserMeter DO. All callers supply `env` (including
 email paths), so every lease is a UserMeter-authoritative row. D1 has no
 `account_write_leases` table; `account_write_lease_repairs` remains the audit

--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -1554,6 +1554,10 @@ Current retention policies:
 - `stripe_webhook_events`: platform Stripe webhook idempotency rows keep 30 days
   by `processed_at`. They are not user-owned and remain independent of account
   deletion/export.
+- `agent_package_conversation_uses`: per-user package popularity rows keep 180
+  days by `last_used_at`, matching the query-time window used to hint popular
+  packages in MCP server instructions. The prune orders by the existing
+  `(user_id, last_used_at)` time index via `last_used_at` then `rowid`.
 
 The squashed baseline defines the global time-column indexes these prunes order
 by (`created_at` / `day` / `month` / `started_at` across users); per-user

--- a/docs/contributing/architecture/entitlements.md
+++ b/docs/contributing/architecture/entitlements.md
@@ -292,7 +292,12 @@ authoritative for lease acquire / held / release / count via `acquireWriteLease`
 / `assertWriteLeaseHeld` / `releaseWriteLease` / `countActiveWriteLeases`.
 Missing `USER_METER` binding **fails closed**. D1 `account_write_lease_repairs`
 is the audit log for repairs. ALS nested-lease reuse propagates per
-`stableUserId` across the async call chain.
+`stableUserId` across the async call chain. MCP `/mcp` takes the full UserMeter
+write lease only for mutating JSON-RPC (`tools/call` other than `search`,
+batches that include a write, and unclassified bodies); read-only methods
+(`initialize`, `tools/list`, `ping`, and `search`) check D1 `users.deleting_at`
+only so a deleting account still gets `409 account_deleting` without the acquire
+/ held / release RPCs.
 
 **`markAccountDeleting`:** `COALESCE`s D1 `deleting_at` (idempotent), then calls
 `markDeleting` on the DO (sets/preserves the tombstone). Returns the active DO

--- a/packages/worker/migrations/0039-agent-package-conversation-uses-last-used-index.sql
+++ b/packages/worker/migrations/0039-agent-package-conversation-uses-last-used-index.sql
@@ -1,0 +1,5 @@
+-- Global time-column index for the hourly retention prune, which orders the
+-- whole table by last_used_at. The existing (user_id, last_used_at) index
+-- serves per-user popularity reads but cannot serve that cross-user scan.
+CREATE INDEX IF NOT EXISTS idx_agent_package_conversation_uses_last_used
+	ON agent_package_conversation_uses (last_used_at);

--- a/packages/worker/src/app/account-retention-dispositions.ts
+++ b/packages/worker/src/app/account-retention-dispositions.ts
@@ -15,6 +15,10 @@ export const accountRetentionDispositions: ReadonlyArray<AccountRetentionDisposi
 		{ table: 'feature_flag_exposure_rollups', kind: 'scheduled_policy' },
 		{ table: 'stripe_webhook_events', kind: 'scheduled_policy' },
 		{
+			table: 'agent_package_conversation_uses',
+			kind: 'scheduled_policy',
+		},
+		{
 			table: 'system_email_delivery_events',
 			kind: 'alternate_cleanup',
 			reason:

--- a/packages/worker/src/app/retention.node.test.ts
+++ b/packages/worker/src/app/retention.node.test.ts
@@ -2,11 +2,13 @@ import { quoteSqlIdentifier } from '@kody-internal/shared/sql-literals.ts'
 import { DatabaseSync } from 'node:sqlite'
 import { expect, test, vi } from 'vitest'
 import {
+	agentPackageConversationUseRetentionDays,
 	auditEventRetentionDays,
 	featureFlagExposureRetentionDays,
 	getRetentionPolicyCoverage,
 	memorySuppressionRetentionDays,
 	platformFeedbackRetentionDays,
+	pruneAgentPackageConversationUsesForRetention,
 	pruneAuditEventsForRetention,
 	pruneFeatureFlagExposuresForRetention,
 	pruneMemorySuppressionsForRetention,
@@ -162,6 +164,14 @@ function createRetentionDb() {
 			status TEXT NOT NULL,
 			updated_at TEXT NOT NULL
 		);
+		CREATE TABLE agent_package_conversation_uses (
+			user_id TEXT NOT NULL,
+			package_id TEXT NOT NULL,
+			conversation_id TEXT NOT NULL,
+			first_used_at TEXT NOT NULL,
+			last_used_at TEXT NOT NULL,
+			PRIMARY KEY (user_id, package_id, conversation_id)
+		);
 	`)
 	return {
 		sqlite,
@@ -284,7 +294,9 @@ test('platform feedback retention prunes terminal rows in bounded batches and ru
 	>
 	const result = await pruneRetention({ env, now })
 	expect(result.platformFeedback).toBe(1)
+	expect(result.agentPackageConversationUses).toBe(0)
 	expect(result.batchesPerTable['platform_feedback']).toBe(1)
+	expect(result.batchesPerTable['agent_package_conversation_uses']).toBe(1)
 	expect(idsForTable(sqlite, 'platform_feedback')).toEqual([
 		'active-old-open',
 		'active-old-triaged',
@@ -335,6 +347,19 @@ test('memory suppression, audit, and stripe webhook retention respect boundaries
 			)
 			.run(eventId, processedAt)
 	}
+	for (const [packageId, lastUsedAt] of [
+		['pkg-old', daysAgo(agentPackageConversationUseRetentionDays + 1)],
+		['pkg-boundary', daysAgo(agentPackageConversationUseRetentionDays)],
+		['pkg-recent', daysAgo(1)],
+	]) {
+		sqlite
+			.prepare(
+				`INSERT INTO agent_package_conversation_uses (
+				user_id, package_id, conversation_id, first_used_at, last_used_at
+			) VALUES ('user-1', ?, 'conversation', ?, ?)`,
+			)
+			.run(packageId, lastUsedAt, lastUsedAt)
+	}
 
 	expect(await pruneMemorySuppressionsForRetention({ db, now })).toEqual({
 		selected: 1,
@@ -345,6 +370,12 @@ test('memory suppression, audit, and stripe webhook retention respect boundaries
 		deleted: 1,
 	})
 	expect(await pruneStripeWebhookEventsForRetention({ db, now })).toEqual({
+		selected: 1,
+		deleted: 1,
+	})
+	expect(
+		await pruneAgentPackageConversationUsesForRetention({ db, now }),
+	).toEqual({
 		selected: 1,
 		deleted: 1,
 	})
@@ -373,6 +404,15 @@ test('memory suppression, audit, and stripe webhook retention respect boundaries
 				.all() as Array<{ event_id: string }>
 		).map((row) => row.event_id),
 	).toEqual(['evt_boundary'])
+	expect(
+		(
+			sqlite
+				.prepare(
+					`SELECT package_id FROM agent_package_conversation_uses ORDER BY package_id`,
+				)
+				.all() as Array<{ package_id: string }>
+		).map((row) => row.package_id),
+	).toEqual(['pkg-boundary', 'pkg-recent'])
 })
 
 test('retention prune reports selected separately from deleted when rows vanish mid-batch', async () => {
@@ -814,10 +854,15 @@ test('retention coverage includes every live growth-pattern table or documented 
 			table.name === 'platform_feedback' &&
 			columnNames.has('submitter_user_id') &&
 			columnNames.has('updated_at')
+		const hasAgentPackageConversationUsesGrowthShape =
+			table.name === 'agent_package_conversation_uses' &&
+			columnNames.has('user_id') &&
+			columnNames.has('last_used_at')
 		if (
 			hasUserCreatedGrowthShape ||
 			hasGlobalStripeWebhookShape ||
-			hasPlatformFeedbackGrowthShape
+			hasPlatformFeedbackGrowthShape ||
+			hasAgentPackageConversationUsesGrowthShape
 		) {
 			candidateTables.add(table.name)
 		}

--- a/packages/worker/src/app/retention.ts
+++ b/packages/worker/src/app/retention.ts
@@ -1,5 +1,6 @@
 import { accountRetentionDispositions } from '#app/account-retention-dispositions.ts'
 import { runD1WithRetry } from '#worker/d1-retry.ts'
+import { agentPackagePopularityMaxAgeDays } from '#worker/usage/agent-package-conversation-uses.ts'
 import {
 	buildPublishedSourceManifestSnapshotKvKey,
 	buildPublishedSourceSnapshotKvKey,
@@ -46,6 +47,8 @@ export const usageRollupRetentionMonths = 24
 export const featureFlagExposureRetentionDays = 90
 export const auditEventRetentionDays = 180
 export const stripeWebhookEventRetentionDays = 30
+export const agentPackageConversationUseRetentionDays =
+	agentPackagePopularityMaxAgeDays
 
 const millisecondsPerDay = 24 * 60 * 60 * 1000
 
@@ -107,6 +110,14 @@ export const retentionPolicies: ReadonlyArray<RetentionPolicy> = [
 		description:
 			'Stripe platform webhook idempotency rows keep 30 days by processed_at and are independent of account deletion.',
 	},
+	{
+		table: 'agent_package_conversation_uses',
+		scope: 'per-user',
+		retentionDays: agentPackageConversationUseRetentionDays,
+		batchSize: retentionDefaultBatchSize,
+		description:
+			'Agent package conversation-use rows keep 180 days by last_used_at, matching the query-time popularity window.',
+	},
 ] as const
 
 export const retentionPolicyExemptions: ReadonlyArray<RetentionPolicyExemption> =
@@ -139,6 +150,7 @@ export type RetentionPruneResult = {
 	featureFlagExposureRollups: number
 	auditEvents: number
 	stripeWebhookEvents: number
+	agentPackageConversationUses: number
 	batchesPerTable: Record<string, number>
 	timeBudgetExhausted: boolean
 }
@@ -525,6 +537,29 @@ export async function pruneStripeWebhookEventsForRetention(input: {
 	})
 }
 
+export async function pruneAgentPackageConversationUsesForRetention(input: {
+	db: D1Database
+	now?: Date
+	batchSize?: number
+}) {
+	const cutoff = cutoffIso(
+		input.now ?? new Date(),
+		agentPackageConversationUseRetentionDays,
+	)
+	return selectAndDeleteByIds({
+		db: input.db,
+		column: 'rowid',
+		bindings: [cutoff, input.batchSize ?? retentionDefaultBatchSize],
+		sql: `SELECT rowid
+			FROM agent_package_conversation_uses
+			WHERE last_used_at < ?
+			ORDER BY last_used_at ASC, rowid ASC
+			LIMIT ?`,
+		table: 'agent_package_conversation_uses',
+		idColumn: 'rowid',
+	})
+}
+
 export async function pruneRetention(input: {
 	env: Pick<Env, 'APP_DB' | 'AUDIT_DB' | 'BUNDLE_ARTIFACTS_KV'>
 	now?: Date
@@ -548,6 +583,7 @@ export async function pruneRetention(input: {
 		featureFlagExposureRollups: 0,
 		auditEvents: 0,
 		stripeWebhookEvents: 0,
+		agentPackageConversationUses: 0,
 		batchesPerTable: {},
 		timeBudgetExhausted: false,
 	}
@@ -627,6 +663,13 @@ export async function pruneRetention(input: {
 			() => pruneStripeWebhookEventsForRetention({ db, now }),
 			(count) => {
 				result.stripeWebhookEvents += count
+			},
+		),
+		countTask(
+			'agent_package_conversation_uses',
+			() => pruneAgentPackageConversationUsesForRetention({ db, now }),
+			(count) => {
+				result.agentPackageConversationUses += count
 			},
 		),
 	]

--- a/packages/worker/src/mcp-auth.ts
+++ b/packages/worker/src/mcp-auth.ts
@@ -2,6 +2,7 @@ import {
 	type OAuthHelpers,
 	type TokenSummary,
 } from '@cloudflare/workers-oauth-provider'
+import { isRecord } from '@kody-internal/shared/is-record.ts'
 import { getAppBaseUrl } from '#worker/app-base-url.ts'
 import { auditDatabaseFromEnv, getRequestIp } from '#worker/audit-log.ts'
 import { buildMcpUserContextFromGrantProps } from './mcp-auth-user-context.ts'
@@ -12,6 +13,7 @@ import {
 import {
 	AccountDeletionInProgressError,
 	AccountWriteLeaseLostError,
+	assertAccountWritableDb,
 	withAccountWriteLease,
 } from '#worker/account/deletion-state.ts'
 import { createMcpCallerContext, type McpServerProps } from './mcp/context.ts'
@@ -216,6 +218,35 @@ function audienceMatches(
 	return allowed.some((value) => value === origin || value === resourcePath)
 }
 
+/**
+ * The account write lease fences mutating MCP traffic during deletion. Read-only
+ * JSON-RPC (`initialize`, `tools/list`, `ping`, `search`) skips the UserMeter
+ * RPCs and checks D1 `users.deleting_at` only. Unclassified bodies, JSON-RPC
+ * batches that include a write, and any `tools/call` other than `search` keep
+ * the full lease.
+ */
+export function mcpParsedBodyNeedsAccountWriteLease(parsedBody: unknown) {
+	if (parsedBody === undefined) return true
+	const messages = Array.isArray(parsedBody)
+		? parsedBody.filter(isRecord)
+		: isRecord(parsedBody)
+			? [parsedBody]
+			: []
+	if (messages.length === 0) return true
+	return messages.some((message) =>
+		jsonRpcMessageNeedsAccountWriteLease(message),
+	)
+}
+
+function jsonRpcMessageNeedsAccountWriteLease(
+	message: Record<string, unknown>,
+) {
+	if (message['method'] !== 'tools/call') return false
+	const params = isRecord(message['params']) ? message['params'] : null
+	const name = typeof params?.['name'] === 'string' ? params['name'] : null
+	return name !== 'search'
+}
+
 export async function handleMcpRequest({
 	request,
 	env,
@@ -363,28 +394,33 @@ export async function handleMcpRequest({
 	)
 
 	try {
-		return await withAccountWriteLease({
-			db: env.APP_DB,
-			stableUserId: mcpUser.userId,
-			holder: `mcp:${request.method} ${url.pathname}`,
-			env,
-			write: async () =>
-				classification.lane === 'legacy'
-					? await fetchMcp(
-							request,
-							env,
-							context as ExecutionContext<OAuthContextProps>,
-						)
-					: await handleStatelessMcpRequest({
-							request,
-							env,
-							ctx,
-							callerContext: props,
-							...(classification.parsedBody === undefined
-								? {}
-								: { parsedBody: classification.parsedBody }),
-						}),
-		})
+		const serveMcp = async () =>
+			classification.lane === 'legacy'
+				? await fetchMcp(
+						request,
+						env,
+						context as ExecutionContext<OAuthContextProps>,
+					)
+				: await handleStatelessMcpRequest({
+						request,
+						env,
+						ctx,
+						callerContext: props,
+						...(classification.parsedBody === undefined
+							? {}
+							: { parsedBody: classification.parsedBody }),
+					})
+		if (mcpParsedBodyNeedsAccountWriteLease(classification.parsedBody)) {
+			return await withAccountWriteLease({
+				db: env.APP_DB,
+				stableUserId: mcpUser.userId,
+				holder: `mcp:${request.method} ${url.pathname}`,
+				env,
+				write: serveMcp,
+			})
+		}
+		await assertAccountWritableDb(env.APP_DB, mcpUser.userId)
+		return await serveMcp()
 	} catch (error) {
 		if (error instanceof AccountDeletionInProgressError) {
 			return createAccountDeletingResponse(409)

--- a/packages/worker/src/mcp-auth.workers.test.ts
+++ b/packages/worker/src/mcp-auth.workers.test.ts
@@ -9,6 +9,7 @@ import {
 	handleMcpRequest,
 	handleProtectedResourceMetadata,
 	mcpInvalidTokenDescription,
+	mcpParsedBodyNeedsAccountWriteLease,
 	mcpResourcePath,
 	protectedResourceMetadataPath,
 } from './mcp-auth.ts'
@@ -123,6 +124,10 @@ type MockDbOptions = {
 	verificationLookups?: Array<VerificationLookupKind>
 	// Optional sink for consolidated users SELECTs.
 	userSelects?: Array<string>
+	// Optional deleting_at for the write-lease D1 gate only (profile lookup
+	// still uses accountByStableId.deleting_at). Lets tests reach 409 without
+	// the auth context loader treating the account as unidentified.
+	writableCheckDeletingAt?: string | null
 }
 
 function createMockDb(options: MockDbOptions = {}) {
@@ -205,6 +210,9 @@ function createMockDb(options: MockDbOptions = {}) {
 				}
 				if (normalized.includes('select deleting_at from users')) {
 					if (!boundStableUserId) return null
+					if (options.writableCheckDeletingAt !== undefined) {
+						return { deleting_at: options.writableCheckDeletingAt }
+					}
 					if (options.accountByStableId !== undefined) {
 						if (
 							options.accountByStableId === null ||
@@ -1135,4 +1143,236 @@ test('mcp request heals a leftover UserMeter tombstone for a live account', asyn
 	expect(response.status).toBe(200)
 	expect(fetchMcpCalled).toBe(true)
 	expect(await meter.readDeletionState()).toEqual({ deletingAt: null })
+})
+
+function instrumentWriteLeaseRpcs(namespace: DurableObjectNamespace) {
+	const calls: Array<string> = []
+	return {
+		calls,
+		namespace: {
+			idFromName: (name: string) => namespace.idFromName(name),
+			get(id: DurableObjectId) {
+				const target = namespace.get(id)
+				return new Proxy(target, {
+					get(target, prop, receiver) {
+						const value = Reflect.get(target, prop, receiver)
+						if (
+							prop === 'acquireWriteLease' ||
+							prop === 'assertWriteLeaseHeld' ||
+							prop === 'releaseWriteLease'
+						) {
+							return async (args: unknown) => {
+								calls.push(String(prop))
+								return (
+									target as unknown as Record<
+										string,
+										(args: unknown) => Promise<unknown>
+									>
+								)[String(prop)](args)
+							}
+						}
+						return typeof value === 'function'
+							? (value as (...args: Array<unknown>) => unknown).bind(target)
+							: value
+					},
+				})
+			},
+		} as unknown as DurableObjectNamespace,
+	}
+}
+
+function createVerifiedMcpToken(input: {
+	userId: string
+	email: string
+	origin: string
+}): TokenSummary {
+	return {
+		id: 'token',
+		grantId: 'grant',
+		userId: input.userId,
+		createdAt: 0,
+		expiresAt: 999999,
+		audience: `${input.origin}${mcpResourcePath}`,
+		grant: {
+			clientId: 'client',
+			scope: oauthScopes,
+			props: { userId: input.userId, email: input.email },
+		},
+	}
+}
+
+function createJsonRpcMcpRequest(input: { origin: string; body: unknown }) {
+	return new Request(`${input.origin}${mcpResourcePath}`, {
+		method: 'POST',
+		headers: {
+			Authorization: 'Bearer token',
+			'Content-Type': 'application/json',
+			Accept: 'application/json, text/event-stream',
+		},
+		body: JSON.stringify(input.body),
+	})
+}
+
+test('mcp write lease is scoped to mutating tools/call and still rejects deleting accounts', async () => {
+	const origin = 'https://example.com'
+	const userId = `lease-scope-${crypto.randomUUID()}`
+	const email = 'lease-scope@example.com'
+	const verifiedAt = new Date(0).toISOString()
+	const instrumented = instrumentWriteLeaseRpcs(env.USER_METER)
+	const token = createVerifiedMcpToken({ userId, email, origin })
+	const envForUser = (writableCheckDeletingAt?: string | null) =>
+		createEnv(
+			createHelpers({ unwrapToken: async () => token }),
+			{ USER_METER: instrumented.namespace },
+			{
+				emailVerifiedAt: verifiedAt,
+				expectedEmail: email,
+				expectedStableUserId: userId,
+				writableCheckDeletingAt,
+				accountByStableId: {
+					id: 31,
+					email,
+					username: 'lease-scope',
+					display_name: null,
+					stable_user_id: userId,
+					email_verified_at: verifiedAt,
+					deleting_at: null,
+				},
+			},
+		)
+	let fetchMcpCalls = 0
+	const fetchMcp = () => {
+		fetchMcpCalls += 1
+		return new Response('legacy-ok')
+	}
+
+	expect(mcpParsedBodyNeedsAccountWriteLease(undefined)).toBe(true)
+	expect(
+		mcpParsedBodyNeedsAccountWriteLease({
+			jsonrpc: '2.0',
+			method: 'tools/list',
+			id: 1,
+		}),
+	).toBe(false)
+	expect(
+		mcpParsedBodyNeedsAccountWriteLease({
+			jsonrpc: '2.0',
+			method: 'tools/call',
+			params: { name: 'search', arguments: { query: 'email' } },
+			id: 2,
+		}),
+	).toBe(false)
+	expect(
+		mcpParsedBodyNeedsAccountWriteLease({
+			jsonrpc: '2.0',
+			method: 'tools/call',
+			params: { name: 'execute', arguments: { code: 'async () => 1' } },
+			id: 3,
+		}),
+	).toBe(true)
+	expect(
+		mcpParsedBodyNeedsAccountWriteLease([
+			{ jsonrpc: '2.0', method: 'tools/list', id: 4 },
+			{
+				jsonrpc: '2.0',
+				method: 'tools/call',
+				params: { name: 'execute' },
+				id: 5,
+			},
+		]),
+	).toBe(true)
+
+	const listResponse = await handleMcpRequestAndDrain({
+		request: createJsonRpcMcpRequest({
+			origin,
+			body: { jsonrpc: '2.0', id: 1, method: 'tools/list' },
+		}),
+		env: envForUser(),
+		ctx: createContext(),
+		fetchMcp,
+	})
+	expect(listResponse.status).toBe(200)
+	expect(await listResponse.text()).toBe('legacy-ok')
+	expect(instrumented.calls).toEqual([])
+
+	const searchResponse = await handleMcpRequestAndDrain({
+		request: createJsonRpcMcpRequest({
+			origin,
+			body: {
+				jsonrpc: '2.0',
+				id: 2,
+				method: 'tools/call',
+				params: { name: 'search', arguments: { query: 'email' } },
+			},
+		}),
+		env: envForUser(),
+		ctx: createContext(),
+		fetchMcp,
+	})
+	expect(searchResponse.status).toBe(200)
+	expect(instrumented.calls).toEqual([])
+
+	const executeResponse = await handleMcpRequestAndDrain({
+		request: createJsonRpcMcpRequest({
+			origin,
+			body: {
+				jsonrpc: '2.0',
+				id: 3,
+				method: 'tools/call',
+				params: { name: 'execute', arguments: { code: 'async () => 1' } },
+			},
+		}),
+		env: envForUser(),
+		ctx: createContext(),
+		fetchMcp,
+	})
+	expect(executeResponse.status).toBe(200)
+	expect(instrumented.calls).toEqual([
+		'acquireWriteLease',
+		'assertWriteLeaseHeld',
+		'releaseWriteLease',
+	])
+	expect(fetchMcpCalls).toBe(3)
+
+	instrumented.calls.length = 0
+	const deletingSearch = await handleMcpRequestAndDrain({
+		request: createJsonRpcMcpRequest({
+			origin,
+			body: {
+				jsonrpc: '2.0',
+				id: 4,
+				method: 'tools/call',
+				params: { name: 'search', arguments: { query: 'email' } },
+			},
+		}),
+		env: envForUser('2026-09-02 00:00:00'),
+		ctx: createContext(),
+		fetchMcp,
+	})
+	expect(deletingSearch.status).toBe(409)
+	expect(await deletingSearch.json()).toMatchObject({
+		error: 'account_deleting',
+	})
+	expect(instrumented.calls).toEqual([])
+
+	const deletingExecute = await handleMcpRequestAndDrain({
+		request: createJsonRpcMcpRequest({
+			origin,
+			body: {
+				jsonrpc: '2.0',
+				id: 5,
+				method: 'tools/call',
+				params: { name: 'execute', arguments: { code: 'async () => 1' } },
+			},
+		}),
+		env: envForUser('2026-09-02 00:00:00'),
+		ctx: createContext(),
+		fetchMcp,
+	})
+	expect(deletingExecute.status).toBe(409)
+	expect(await deletingExecute.json()).toMatchObject({
+		error: 'account_deleting',
+	})
+	expect(instrumented.calls).toEqual([])
+	expect(fetchMcpCalls).toBe(3)
 })

--- a/packages/worker/src/mcp/executor.node.test.ts
+++ b/packages/worker/src/mcp/executor.node.test.ts
@@ -1230,6 +1230,59 @@ test('createExecuteExecutor records one unique Dynamic Worker day per worker id'
 	expect(dataPoints).toHaveLength(1)
 })
 
+test('createExecuteExecutor defers unique-worker-day and first-execute stamp via waitUntil', async () => {
+	const dataPoints: Array<AnalyticsEngineDataPoint> = []
+	const activationStampWrites: Array<string> = []
+	const meter = createInMemoryUserMeterEnv()
+	const usageBindings = {
+		...meter.env,
+		USAGE_EVENTS: {
+			writeDataPoint(point?: AnalyticsEngineDataPoint) {
+				if (point) dataPoints.push(point)
+			},
+		},
+		APP_DB: {
+			prepare(sql: string) {
+				return {
+					bind() {
+						return {
+							async run() {
+								if (sql.includes('first_execute_at')) {
+									activationStampWrites.push(sql)
+								}
+								return {}
+							},
+						}
+					},
+				}
+			},
+		},
+	}
+	const waitUntilTasks: Array<Promise<unknown>> = []
+	const waitUntil = (promise: Promise<unknown>) => {
+		waitUntilTasks.push(promise)
+	}
+	const loader = createFakeWorkerLoader()
+	const result = await createExecuteExecutor({
+		env: {
+			...createExecutorTestEnv(loader.loader),
+			...usageBindings,
+		} as Env,
+		exports: createExecutorTestExports(),
+		gatewayProps: createGatewayProps('usage-user-waituntil'),
+		waitUntil,
+	}).execute('async () => "ok"', [{ name: 'kody', fns: {} }])
+
+	expect(result.error).toBeUndefined()
+	expect(waitUntilTasks.length).toBeGreaterThanOrEqual(2)
+	await Promise.all(waitUntilTasks)
+	expect(activationStampWrites).toHaveLength(1)
+	expect(dataPoints.map((point) => point.blobs?.[1]).sort()).toEqual([
+		'dynamic_worker_day',
+		'execute',
+	])
+})
+
 test('createExecuteExecutor rejects reserved JavaScript provider names before loading a worker', async () => {
 	const fakeLoader = createFakeWorkerLoader()
 	for (const name of ['class', 'private']) {

--- a/packages/worker/src/mcp/executor.ts
+++ b/packages/worker/src/mcp/executor.ts
@@ -160,6 +160,12 @@ type DynamicWorkerExecutorInput = {
 	 * runs (and ad-hoc executor callers) should emit `execute`.
 	 */
 	recordExecuteUsage?: boolean
+	/**
+	 * When set, unique-worker-day metering and the first-execute activation
+	 * stamp run on `waitUntil` instead of the sandbox critical path. Without
+	 * an execution context the writes stay awaited so they are not dropped.
+	 */
+	waitUntil?: (promise: Promise<unknown>) => void
 }
 
 type DynamicWorkerExecutorOptions = {
@@ -606,6 +612,11 @@ export function createExecuteExecutor(input: {
 	 * closed-world. Defaults to true.
 	 */
 	allowOutboundFetch?: boolean
+	/**
+	 * When set, unique-worker-day metering and the first-execute activation
+	 * stamp run on `waitUntil` instead of the sandbox critical path.
+	 */
+	waitUntil?: (promise: Promise<unknown>) => void
 }) {
 	const allowOutboundFetch = input.allowOutboundFetch !== false
 	const loopbackExports = input.exports ?? workerExports
@@ -636,6 +647,7 @@ export function createExecuteExecutor(input: {
 		usageEnv: input.env,
 		rawFetchHostSink: input.rawFetchHostSink,
 		recordExecuteUsage: input.recordExecuteUsage,
+		waitUntil: input.waitUntil,
 	})
 }
 
@@ -680,11 +692,15 @@ function createStableDynamicWorkerExecutor(input: DynamicWorkerExecutorInput) {
 				timeoutMs: input.timeout,
 				workerOptions,
 			})
-			await recordUniqueDynamicWorkerDay({
-				env: input.usageEnv,
-				userId: input.gatewayProps.userId,
-				workerId,
-			})
+			await runExecuteBookkeeping(
+				recordUniqueDynamicWorkerDay({
+					env: input.usageEnv,
+					userId: input.gatewayProps.userId,
+					workerId,
+				}),
+				input.waitUntil,
+				'dynamic-worker-day-record-failed',
+			)
 			const executionState = { active: true }
 			const startedAtMs = Date.now()
 			let outcome: 'success' | 'error' = 'success'
@@ -780,16 +796,35 @@ function createStableDynamicWorkerExecutor(input: DynamicWorkerExecutorInput) {
 			} finally {
 				executionState.active = false
 				if (input.recordExecuteUsage !== false && input.gatewayProps.userId) {
-					await recordUsage(input.usageEnv, {
-						userId: input.gatewayProps.userId,
-						eventType: 'execute',
-						durationMs: Date.now() - startedAtMs,
-						outcome,
-					})
+					await recordUsage(
+						input.usageEnv,
+						{
+							userId: input.gatewayProps.userId,
+							eventType: 'execute',
+							durationMs: Date.now() - startedAtMs,
+							outcome,
+						},
+						{ waitUntil: input.waitUntil },
+					)
 				}
 			}
 		},
 	}
+}
+
+async function runExecuteBookkeeping(
+	work: Promise<unknown>,
+	waitUntil: ((promise: Promise<unknown>) => void) | undefined,
+	warnKey: string,
+) {
+	const tracked = work.catch((error: unknown) => {
+		console.warn(warnKey, error)
+	})
+	if (waitUntil) {
+		waitUntil(tracked)
+		return
+	}
+	await tracked
 }
 
 function validateProviders(providers: Array<ResolvedProvider>) {

--- a/packages/worker/src/mcp/run-kody-registry.ts
+++ b/packages/worker/src/mcp/run-kody-registry.ts
@@ -90,6 +90,19 @@ type ExecuteServerTimingEntry = {
 	durationMs: number
 }
 
+async function scheduleAgentPackageConversationUses(
+	env: Env,
+	input: Parameters<typeof recordAgentPackageConversationUses>[1],
+	waitUntil?: (promise: Promise<unknown>) => void,
+) {
+	const work = recordAgentPackageConversationUses(env, input)
+	if (waitUntil) {
+		waitUntil(work)
+		return
+	}
+	await work
+}
+
 export type {
 	PackageEventDispatchInput,
 	PackageEventTools,
@@ -521,11 +534,15 @@ export async function runModuleWithRegistry(
 			.map((dependency) => dependency.packageId)
 			.filter((packageId): packageId is string => Boolean(packageId))
 		if (packageIds.length > 0) {
-			void recordAgentPackageConversationUses(env, {
-				userId,
-				packageIds,
-				conversationId,
-			})
+			await scheduleAgentPackageConversationUses(
+				env,
+				{
+					userId,
+					packageIds,
+					conversationId,
+				},
+				options?.waitUntil,
+			)
 		}
 	}
 	const runStartedAtMs = Date.now()
@@ -755,11 +772,15 @@ export async function runBundledModuleWithRegistry(
 			agentUserId &&
 			dynamicDependencyPackageIds.length > 0
 		) {
-			void recordAgentPackageConversationUses(env, {
-				userId: agentUserId,
-				packageIds: dynamicDependencyPackageIds,
-				conversationId: agentConversationId,
-			})
+			await scheduleAgentPackageConversationUses(
+				env,
+				{
+					userId: agentUserId,
+					packageIds: dynamicDependencyPackageIds,
+					conversationId: agentConversationId,
+				},
+				waitUntil,
+			)
 		}
 		await reportExecutePhaseProgress(reportProgress, 'provider-assembly')
 		const providerAssemblyStartedAtMs = Date.now()
@@ -817,6 +838,7 @@ export async function runBundledModuleWithRegistry(
 				hasPackageContext: Boolean(options?.packageContext),
 			}),
 			allowOutboundFetch: !closedWorldRetrieverRuntime,
+			waitUntil: options?.waitUntil,
 		})
 		const workflowTools = closedWorldRetrieverRuntime
 			? undefined

--- a/packages/worker/src/usage/agent-package-conversation-uses.ts
+++ b/packages/worker/src/usage/agent-package-conversation-uses.ts
@@ -85,7 +85,7 @@ export async function recordAgentPackageConversationUse(
 
 /**
  * Record conversation uses for many packages (e.g. static/dynamic execute
- * deps). Dedupes package ids; never throws.
+ * deps). Dedupes package ids; never throws. Issues one D1 batch of upserts.
  */
 export async function recordAgentPackageConversationUses(
 	env: AgentPackageConversationUseEnv,
@@ -96,17 +96,35 @@ export async function recordAgentPackageConversationUses(
 		usedAt?: string
 	},
 ): Promise<void> {
-	const seen = new Set<string>()
-	for (const packageId of input.packageIds) {
-		const trimmed = packageId.trim()
-		if (!trimmed || seen.has(trimmed)) continue
-		seen.add(trimmed)
-		await recordAgentPackageConversationUse(env, {
-			userId: input.userId,
-			packageId: trimmed,
-			conversationId: input.conversationId,
-			usedAt: input.usedAt,
-		})
+	try {
+		const userId = input.userId.trim()
+		const conversationId = input.conversationId.trim()
+		if (!userId || !conversationId) return
+		const db = env.APP_DB
+		if (!db) {
+			console.debug('agent-package-conversation-use-skipped', 'missing APP_DB')
+			return
+		}
+		const seen = new Set<string>()
+		const packageIds: Array<string> = []
+		for (const packageId of input.packageIds) {
+			const trimmed = packageId.trim()
+			if (!trimmed || seen.has(trimmed)) continue
+			seen.add(trimmed)
+			packageIds.push(trimmed)
+		}
+		if (packageIds.length === 0) return
+		const usedAt = input.usedAt ?? new Date().toISOString()
+		const conversationKey = await hashConversationId(conversationId)
+		await db.batch(
+			packageIds.map((packageId) =>
+				db
+					.prepare(upsertStatement)
+					.bind(userId, packageId, conversationKey, usedAt),
+			),
+		)
+	} catch (error) {
+		console.warn('agent-package-conversation-use-record-failed', error)
 	}
 }
 

--- a/packages/worker/src/usage/record-usage.ts
+++ b/packages/worker/src/usage/record-usage.ts
@@ -112,11 +112,13 @@ ON CONFLICT (day) DO UPDATE SET
  *
  * Callers should `await` it (cheap: one `writeDataPoint`, or one D1 upsert in
  * local dev) or hand the promise to `ctx.waitUntil(...)` inside Durable
- * Objects.
+ * Objects. Successful `execute` events still stamp `users.first_execute_at`;
+ * pass `waitUntil` to keep that D1 write off the critical path.
  */
 export async function recordUsage(
 	env: UsageEnv,
 	event: UsageEvent,
+	options?: { waitUntil?: (promise: Promise<unknown>) => void },
 ): Promise<void> {
 	try {
 		if (!event.userId) {
@@ -130,10 +132,17 @@ export async function recordUsage(
 			event.outcome === 'success' &&
 			env.APP_DB
 		) {
-			await stampFirstExecute(env.APP_DB, {
+			const stamp = stampFirstExecute(env.APP_DB, {
 				stableUserId: event.userId,
 				at: timestamp,
+			}).catch((error: unknown) => {
+				console.warn('activation-stamp-execute-failed', error)
 			})
+			if (options?.waitUntil) {
+				options.waitUntil(stamp)
+			} else {
+				await stamp
+			}
 		}
 		if (env.USAGE_EVENTS) {
 			writeUsageDataPoint(env, event, timestamp)

--- a/tools/migration-ledger.json
+++ b/tools/migration-ledger.json
@@ -155,6 +155,10 @@
 		{
 			"filename": "0038-integration-auth-failure.sql",
 			"sha256": "147acc4287512ae6666f4be4a0dbcc7f61edfd412f7ed932c5688a1634000339"
+		},
+		{
+			"filename": "0039-agent-package-conversation-uses-last-used-index.sql",
+			"sha256": "24df954f08b0aa7fbbb76b880ee8cbb9b276cf120ed2c8633c37e464c39b4a68"
 		}
 	]
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Remove per-request overhead from the MCP hot path that only exists to fence a rare event (account deletion) or to record analytics, and put a retention bound on the fastest-growing APP_DB table.

## Why

From the 2026-09-01 launch-readiness audit:

- Every `/mcp` request — `initialize`, `tools/list`, `ping`, and the read-only `search` tool included — ran inside `withAccountWriteLease`: 1 D1 read plus three sequential cross-worker `UserMeter` RPCs (acquire, assertHeld, release). Parallel `search` calls from one agent serialized on that user's Durable Object.
- Every successful `execute` awaited `stampFirstExecute` (a 0-row `UPDATE users` after day one) and `recordUniqueDynamicWorkerDay` (a UserMeter RPC) on the critical path, contrary to `invocation-overhead-guardrails.md`.
- `agent_package_conversation_uses` is written on every execute with one upsert per package, grows O(sessions × packages), and had no retention policy (the coverage test's growth heuristic missed the `_uses` suffix); reads already filter to 180 days.

## Summary

- `mcp-auth.ts`: `mcpParsedBodyNeedsAccountWriteLease` — non-`tools/call` messages and `tools/call` of `search` skip the lease and run only `assertAccountWritableDb` (1 D1 `SELECT deleting_at`), so a deleting account still gets `409`. `execute`, any other tool, JSON-RPC batches containing a write, and unclassifiable bodies (GET, invalid JSON, legacy lane) keep the full lease.
- `executor.ts` / `record-usage.ts`: `stampFirstExecute` and `recordUniqueDynamicWorkerDay` run via `waitUntil` when an execution context is available (MCP execute threads `agent.waitUntil`); callers without one keep the awaited behaviour so nothing is dropped. Failures still `console.warn` under stable keys.
- `agent-package-conversation-uses.ts`: one `APP_DB.batch` of upserts instead of sequential awaits; callers schedule it on `waitUntil`.
- `retention.ts`: 180-day prune on `last_used_at` (batched, `rowid`-keyed), coverage test updated. New migration `0039` adds a global `last_used_at` index so the hourly ordered scan does not walk the table (the existing `(user_id, last_used_at)` index only serves per-user reads); ledger updated.
- Docs: `entitlements.md` (lease read-path exemption), `data-storage.md` (retention list).

Verified from the workers test: `tools/list` and `search` issue zero UserMeter RPCs; `execute` still issues `acquireWriteLease`, `assertWriteLeaseHeld`, `releaseWriteLease`.

## Testing

`npm run typecheck`, `npm run lint`, `npm run format:check`, `npm run docs:check-temporal`, `npm run migrations:check`; `CI=1 npx vitest run --config vitest.node.config.ts` on `retention`, `account-retention-dispositions`, `usage/*`, `executor` — 16 files / 82 tests; `mcp-auth.workers.test.ts` — 9 passed against real bindings; `account/` suites (schema-introspecting) 71 passed with the new migration applied.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends</b> mcp-server request lifecycle and d1-app-db retention (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `40e70929` · **Head:** `HEAD`

**Classification:** extends — the write-lease contract gains a read-path exemption; execute bookkeeping moves to `waitUntil`; one new index migration and one new retention policy.

### Primitives touched

| Primitive        | Group    | Impact                                                            |
| ---------------- | -------- | ----------------------------------------------------------------- |
| `mcp-server`     | surfaces | extends — lease only on mutating JSON-RPC                         |
| `user-meter`     | storage  | composes — fewer RPCs per request; dynamic-worker-day deferred    |
| `usage-metering` | features | extends — stamp/conversation-use writes deferred and batched      |
| `d1-app-db`      | storage  | extends — migration 0039 index; 180-day prune                     |

### Change flow

Read-only MCP traffic checks the deletion marker once and skips the Durable Object lease; execute defers its bookkeeping.

```mermaid
sequenceDiagram
	participant host as MCP host
	participant mcpServer as mcp-server (/mcp)
	participant d1AppDb as d1-app-db
	participant userMeter as user-meter DO
	host->>mcpServer: tools/list · search
	mcpServer->>d1AppDb: SELECT users.deleting_at (assertAccountWritableDb)
	Note over mcpServer,userMeter: no acquire / assertHeld / release RPCs
	host->>mcpServer: tools/call execute
	mcpServer->>userMeter: acquireWriteLease → run → releaseWriteLease (unchanged)
	mcpServer-->>host: result
	mcpServer->>d1AppDb: waitUntil: stampFirstExecute, batch conversation uses
	mcpServer->>userMeter: waitUntil: recordUniqueDynamicWorkerDay
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b0f6a92a-81cd-4157-8b60-188c83ca84c0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b0f6a92a-81cd-4157-8b60-188c83ca84c0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

