### PR TITLE
Verify Turnstile token hostname and stop signup from confirming registered emails

### DIFF
--- a/docs/contributing/security.md
+++ b/docs/contributing/security.md
@@ -535,6 +535,22 @@ change to these decisions here so future agents do not relitigate them.
 - **Account secret reveal is owner-scoped, not password-reauthenticated.** See
   the "Account secret reveal" section of
   [`architecture/authentication.md`](./architecture/authentication.md).
+- **Signup does not confirm whether an email is registered, except through the
+  session cookie.** `POST /auth` with `mode: signup` for an address that already
+  has an account returns the same `200` body as a fresh signup
+  (`emailVerificationRequired: true`), creates nothing, sends nothing, and
+  audits `signup` / `email_exists`. Only the fresh signup carries a
+  `Set-Cookie: kody_session` header, so a scripted caller that inspects headers
+  can still distinguish the two; the shared per-IP auth rate limit bounds that
+  probing to 10 attempts a minute. Closing the header side channel means not
+  issuing a session at signup at all (session on verification instead), which is
+  a larger onboarding change than the copy-level fix. Usernames are public
+  identifiers, so a duplicate username still returns `409`.
+- **Turnstile tokens must come from the request's own hostname.**
+  `verifyPublicFormProtection` rejects a siteverify success whose `hostname`
+  differs from the request URL's hostname (logged as
+  `turnstile-hostname-mismatch`), so a token minted on a preview deployment or a
+  third-party page embedding the same sitekey is not accepted on production.
 - **Sandbox `fetch` has no general SSRF denylist.** Secret-bearing requests are
   constrained by per-secret host allowlists; non-secret requests rely on the
   Cloudflare Workers platform egress model.

--- a/e2e/playwright-utils.ts
+++ b/e2e/playwright-utils.ts
@@ -214,13 +214,13 @@ async function signupOrLoginViaAuth(
 		...requestTimeout,
 	})
 
-	if (signupResponse.status() === 409) {
-		const signupDetail = await readResponseDetail(signupResponse)
-		if (signupDetail !== 'Email already registered.') {
-			throw new Error(
-				`Failed to seed user (${signupResponse.status()}): ${signupDetail}`,
-			)
-		}
+	// An already-registered email gets the same accepted body as a fresh
+	// signup but no session cookie (anti-enumeration), so fall back to login
+	// whenever the signup did not establish a session.
+	if (
+		signupResponse.ok() &&
+		!signupResponse.headers()['set-cookie']?.includes('kody_session=')
+	) {
 		const loginResponse = await request.post('/auth', {
 			data: { email, password, mode: 'login' },
 			headers: { 'Content-Type': 'application/json' },

--- a/packages/worker/src/app/handlers/auth-handler.node.test.ts
+++ b/packages/worker/src/app/handlers/auth-handler.node.test.ts
@@ -481,6 +481,12 @@ test('auth handler login and signup workflow', async () => {
 		inviteCode: 'prod-invite',
 	})
 	expect(existingWithInviteResponse.status).toBe(200)
+	expect(await existingWithInviteResponse.json()).toEqual({
+		ok: true,
+		mode: 'signup',
+		emailVerificationRequired: true,
+		message: 'Check your email to verify your account.',
+	})
 	expect(existingWithInviteResponse.headers.get('Set-Cookie')).toBeNull()
 	expect(productionContext.testDb.invites.get('PROD-INVITE')?.use_count).toBe(0)
 

--- a/packages/worker/src/app/handlers/auth-handler.node.test.ts
+++ b/packages/worker/src/app/handlers/auth-handler.node.test.ts
@@ -456,7 +456,34 @@ test('auth handler login and signup workflow', async () => {
 	})
 	expect(productionContext.testDb.users.has('new@example.com')).toBe(false)
 
+	// A registered address without a code fails exactly like an unregistered
+	// one, so invite mode does not leak which emails hold accounts.
+	await productionContext.testDb.addUser('taken@example.com', 'secret', 'taken')
+	const blockedExistingResponse = await productionContext.request({
+		email: 'taken@example.com',
+		username: 'another-name',
+		password: 'password123',
+		mode: 'signup',
+	})
+	expect(blockedExistingResponse.status).toBe(400)
+	expect(await blockedExistingResponse.json()).toEqual({
+		error: 'Invite code is required.',
+	})
+
 	productionContext.testDb.addInvite('PROD-INVITE')
+	// With a valid code the registered address gets the accepted body, no
+	// session, and the invite use is handed back.
+	const existingWithInviteResponse = await productionContext.request({
+		email: 'taken@example.com',
+		username: 'another-name',
+		password: 'password123',
+		mode: 'signup',
+		inviteCode: 'prod-invite',
+	})
+	expect(existingWithInviteResponse.status).toBe(200)
+	expect(existingWithInviteResponse.headers.get('Set-Cookie')).toBeNull()
+	expect(productionContext.testDb.invites.get('PROD-INVITE')?.use_count).toBe(0)
+
 	const invitedSignupResponse = await productionContext.request({
 		email: 'invited@example.com',
 		username: 'invited-user',
@@ -669,12 +696,15 @@ test('auth handler login and signup workflow', async () => {
 		'Secure',
 	)
 	// The full workflow audits exactly these events, in order: the unknown
-	// login, the invite-less production signup, the invited signup (+ invite
-	// use), the weak-password rejection, the open signup, the six username
+	// login, the invite-less production signup, the invite-less and invited
+	// registered-email attempts, the invited signup (+ invite use), the
+	// weak-password rejection, the open signup, the six username
 	// rejections, the duplicate-email rejection, and the three successful
 	// logins.
 	expect(auditEventSummaries()).toEqual([
 		'login:failure',
+		'signup:failure',
+		'signup:failure',
 		'signup:failure',
 		'signup:success',
 		'invite_use:success',

--- a/packages/worker/src/app/handlers/auth-handler.node.test.ts
+++ b/packages/worker/src/app/handlers/auth-handler.node.test.ts
@@ -601,6 +601,32 @@ test('auth handler login and signup workflow', async () => {
 		error: 'Username already registered.',
 	})
 
+	// An already-registered email must be indistinguishable from a fresh
+	// signup in status and body (no account enumeration); only the session
+	// cookie is withheld and nothing is created.
+	const duplicateEmailResponse = await signupContext.request({
+		email: 'existing@example.com',
+		username: 'brand-new-name',
+		password: 'password123',
+		mode: 'signup',
+	})
+	expect(duplicateEmailResponse.status).toBe(200)
+	expect(await duplicateEmailResponse.json()).toEqual({
+		ok: true,
+		mode: 'signup',
+		emailVerificationRequired: true,
+		message: 'Check your email to verify your account.',
+	})
+	expect(duplicateEmailResponse.headers.get('Set-Cookie')).toBeNull()
+	expect(logAuditEventSpy).toHaveBeenCalledWith(
+		expect.objectContaining({
+			category: 'auth',
+			action: 'signup',
+			result: 'failure',
+			reason: 'email_exists',
+		}),
+	)
+
 	const email = 'session-user@example.com'
 	await productionContext.testDb.addUser(email, 'secret')
 
@@ -645,7 +671,8 @@ test('auth handler login and signup workflow', async () => {
 	// The full workflow audits exactly these events, in order: the unknown
 	// login, the invite-less production signup, the invited signup (+ invite
 	// use), the weak-password rejection, the open signup, the six username
-	// rejections, and the three successful logins.
+	// rejections, the duplicate-email rejection, and the three successful
+	// logins.
 	expect(auditEventSummaries()).toEqual([
 		'login:failure',
 		'signup:failure',
@@ -653,6 +680,7 @@ test('auth handler login and signup workflow', async () => {
 		'invite_use:success',
 		'signup:failure',
 		'signup:success',
+		'signup:failure',
 		'signup:failure',
 		'signup:failure',
 		'signup:failure',

--- a/packages/worker/src/app/handlers/auth.ts
+++ b/packages/worker/src/app/handlers/auth.ts
@@ -237,25 +237,6 @@ export function createAuthHandler(env: Env) {
 			}
 
 			if (normalizedMode === 'signup') {
-				const existingUser = await db.findOne(usersTable, {
-					where: { email: normalizedEmail },
-				})
-				if (existingUser) {
-					void logAuditEvent({
-						db: auditDatabaseFromEnv(env),
-						category: 'auth',
-						action: 'signup',
-						result: 'failure',
-						email: normalizedEmail,
-						ip: requestIp,
-						path: url.pathname,
-						reason: 'email_exists',
-					})
-					// Same body and status as a fresh signup so the endpoint does not
-					// confirm which addresses hold accounts. Nothing is created or
-					// sent; the owner can sign in or reset their password as usual.
-					return Response.json(signupAcceptedBody(normalizedMode))
-				}
 				const existingUsername = await db.findOne(usersTable, {
 					where: { username: normalizedUsername },
 				})
@@ -318,6 +299,29 @@ export function createAuthHandler(env: Env) {
 					}
 					consumedInviteCode = inviteResult.invite.code
 					consumedInvitePlan = parseStoredPlanName(inviteResult.invite.plan)
+				}
+
+				// Checked after invite validation so that, in invite and waitlist
+				// modes, a registered and an unregistered address fail the same
+				// way without a code. Same body and status as a fresh signup so
+				// the endpoint does not confirm which addresses hold accounts.
+				// Nothing is created or sent; the invite is handed back.
+				const existingUser = await db.findOne(usersTable, {
+					where: { email: normalizedEmail },
+				})
+				if (existingUser) {
+					await releaseConsumedInvite()
+					void logAuditEvent({
+						db: auditDatabaseFromEnv(env),
+						category: 'auth',
+						action: 'signup',
+						result: 'failure',
+						email: normalizedEmail,
+						ip: requestIp,
+						path: url.pathname,
+						reason: 'email_exists',
+					})
+					return Response.json(signupAcceptedBody(normalizedMode))
 				}
 
 				let record: { id: number; stableUserId: string } | null = null

--- a/packages/worker/src/app/handlers/auth.ts
+++ b/packages/worker/src/app/handlers/auth.ts
@@ -101,6 +101,15 @@ function signupUniqueConflict(
 	}
 }
 
+function signupAcceptedBody(mode: AuthMode) {
+	return {
+		ok: true,
+		mode,
+		emailVerificationRequired: true,
+		message: 'Check your email to verify your account.',
+	}
+}
+
 export function createAuthHandler(env: Env) {
 	const db = createDb(env.APP_DB)
 
@@ -242,10 +251,10 @@ export function createAuthHandler(env: Env) {
 						path: url.pathname,
 						reason: 'email_exists',
 					})
-					return Response.json(
-						{ error: 'Email already registered.' },
-						{ status: 409 },
-					)
+					// Same body and status as a fresh signup so the endpoint does not
+					// confirm which addresses hold accounts. Nothing is created or
+					// sent; the owner can sign in or reset their password as usual.
+					return Response.json(signupAcceptedBody(normalizedMode))
 				}
 				const existingUsername = await db.findOne(usersTable, {
 					where: { username: normalizedUsername },
@@ -530,19 +539,11 @@ export function createAuthHandler(env: Env) {
 						reason: `invite_code=${consumedInviteCode};stable_user_id=${record.stableUserId};plan=${resolvePlanWrite(consumedInvitePlan)}`,
 					})
 				}
-				return Response.json(
-					{
-						ok: true,
-						mode: normalizedMode,
-						emailVerificationRequired: true,
-						message: 'Check your email to verify your account.',
+				return Response.json(signupAcceptedBody(normalizedMode), {
+					headers: {
+						'Set-Cookie': cookie,
 					},
-					{
-						headers: {
-							'Set-Cookie': cookie,
-						},
-					},
-				)
+				})
 			}
 
 			const userRecord = await db.findOne(usersTable, {

--- a/packages/worker/src/app/handlers/auth.ts
+++ b/packages/worker/src/app/handlers/auth.ts
@@ -306,9 +306,16 @@ export function createAuthHandler(env: Env) {
 				// way without a code. Same body and status as a fresh signup so
 				// the endpoint does not confirm which addresses hold accounts.
 				// Nothing is created or sent; the invite is handed back.
-				const existingUser = await db.findOne(usersTable, {
-					where: { email: normalizedEmail },
-				})
+				let existingUser: Awaited<ReturnType<typeof db.findOne>> | null
+				try {
+					existingUser = await db.findOne(usersTable, {
+						where: { email: normalizedEmail },
+					})
+				} catch (error) {
+					// A transient read must not spend a single-use invite.
+					await releaseConsumedInvite()
+					throw error
+				}
 				if (existingUser) {
 					await releaseConsumedInvite()
 					void logAuditEvent({

--- a/packages/worker/src/app/handlers/auth.ts
+++ b/packages/worker/src/app/handlers/auth.ts
@@ -371,6 +371,11 @@ export function createAuthHandler(env: Env) {
 							path: url.pathname,
 							reason: conflict.reason,
 						})
+						// A concurrent signup that lost the race on `email` must not
+						// leak the address either; only public identifiers get a 409.
+						if (uniqueField === 'email') {
+							return Response.json(signupAcceptedBody(normalizedMode))
+						}
 						return Response.json({ error: conflict.error }, { status: 409 })
 					}
 					await releaseConsumedInvite()

--- a/packages/worker/src/app/public-form-protection.node.test.ts
+++ b/packages/worker/src/app/public-form-protection.node.test.ts
@@ -5,6 +5,7 @@ import {
 	verifyPublicFormProtection,
 } from '#app/public-form-protection.ts'
 import { getSignupMode } from '#universal/signup-mode.ts'
+import { consoleWarn } from '#worker/test-support/console-spies.ts'
 
 test('public form protection defaults closed, rejects honeypots, and verifies Turnstile', async () => {
 	expect(getSignupMode({} as Pick<Env, 'SIGNUP_MODE'>)).toBe('invite')
@@ -55,9 +56,17 @@ test('public form protection defaults closed, rejects honeypots, and verifies Tu
 		expect(init.method).toBe('POST')
 		const body = new URLSearchParams(String(init.body))
 		expect(body.get('secret')).toBe('secret-key')
-		expect(body.get('response')).toBe('valid-token')
+		expect(['valid-token', 'foreign-host-token']).toContain(
+			body.get('response'),
+		)
 		expect(body.get('remoteip')).toBe('203.0.113.11')
-		return Response.json({ success: true })
+		return Response.json({
+			success: true,
+			hostname:
+				body.get('response') === 'foreign-host-token'
+					? 'kody-pr-99.kody-a99.workers.dev'
+					: 'example.com',
+		})
 	})
 	vi.stubGlobal('fetch', fetchSpy)
 	try {
@@ -91,6 +100,24 @@ test('public form protection defaults closed, rejects honeypots, and verifies Tu
 			}),
 		).resolves.toEqual({ ok: true })
 		expect(fetchSpy).toHaveBeenCalledOnce()
+
+		fetchSpy.mockClear()
+		consoleWarn.mockImplementation(() => {})
+		const foreign = await verifyPublicFormProtection({
+			env,
+			request: turnstileRequest,
+			body: { turnstileToken: 'foreign-host-token' },
+		})
+		expect(foreign.ok).toBe(false)
+		if (foreign.ok) throw new Error('Expected foreign-hostname rejection.')
+		expect(foreign.response.status).toBe(400)
+		expect(await foreign.response.json()).toEqual({
+			error: 'Human verification failed. Please try again.',
+		})
+		expect(consoleWarn).toHaveBeenCalledWith('turnstile-hostname-mismatch', {
+			expected: 'example.com',
+			received: 'kody-pr-99.kody-a99.workers.dev',
+		})
 	} finally {
 		vi.unstubAllGlobals()
 	}

--- a/packages/worker/src/app/public-form-protection.ts
+++ b/packages/worker/src/app/public-form-protection.ts
@@ -76,8 +76,26 @@ export async function verifyPublicFormProtection(input: {
 		)
 		const payload = (await response.json().catch(() => null)) as {
 			success?: unknown
+			hostname?: unknown
 		} | null
-		if (response.ok && payload?.success === true) return { ok: true }
+		if (response.ok && payload?.success === true) {
+			// A token is bound to the hostname that rendered the widget. Without
+			// this check a token minted on any other site sharing the sitekey
+			// (a preview deploy, a phishing page embedding the widget) would be
+			// accepted here.
+			const expectedHostname = new URL(input.request.url).hostname
+			if (
+				typeof payload.hostname === 'string' &&
+				payload.hostname.toLowerCase() === expectedHostname.toLowerCase()
+			) {
+				return { ok: true }
+			}
+			console.warn('turnstile-hostname-mismatch', {
+				expected: expectedHostname,
+				received:
+					typeof payload.hostname === 'string' ? payload.hostname : null,
+			})
+		}
 	} catch {
 		// The challenge is configured, so a verification outage must not turn
 		// into an authentication bypass.

--- a/tools/mcp-test-support.ts
+++ b/tools/mcp-test-support.ts
@@ -337,7 +337,13 @@ function isPortAlreadyInUseError(error: unknown) {
 
 async function loginToApp(origin: string, user: TestUser) {
 	const signupResponse = await authenticateAppUser(origin, user, 'signup')
-	if (signupResponse.ok) {
+	// An already-registered email gets the same accepted body as a fresh
+	// signup but no session cookie (anti-enumeration), so only a response
+	// that actually set the session counts as a signup.
+	if (
+		signupResponse.ok &&
+		signupResponse.headers.get('Set-Cookie')?.includes('kody_session=')
+	) {
 		return readCookieHeader(signupResponse)
 	}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Two small signup-surface hardenings from the launch audit, approved to ship (the rest of that item lives in #1970).

## Why

- `verifyPublicFormProtection` accepted any Turnstile siteverify response with `success: true`. Tokens are bound to the hostname that rendered the widget, so without checking `hostname` a token minted on a preview deployment or a third-party page embedding the same sitekey was valid on production.
- `POST /auth` with `mode: signup` returned `409 Email already registered.` for existing addresses while password reset deliberately returns a uniform response — so the signup endpoint undid that protection and let anyone confirm which emails hold Kody accounts (which hold API keys and inboxes).

## Summary

- `public-form-protection.ts`: a successful siteverify is accepted only when `payload.hostname` equals the request URL's hostname (case-insensitive); mismatches are rejected with the existing generic error and logged as `turnstile-hostname-mismatch`. Test covers the foreign-hostname case.
- `auth.ts`: an already-registered email now returns the same `200` body as a fresh signup (`ok, mode, emailVerificationRequired: true, message`), creates nothing, sends nothing, and still audits `signup` / `email_exists`. No notice email is sent (per owner). Duplicate usernames keep `409` (usernames are public). Shared `signupAcceptedBody` helper so the two paths cannot drift.
- `e2e/playwright-utils.ts`: the seeding helper falls back to login when a signup response carries no `kody_session` cookie instead of matching the old 409 string.
- `docs/contributing/security.md`: both behaviors recorded, including the residual — only the fresh signup sets the session cookie, so a header-inspecting scripted caller can still distinguish the cases within the 10/min per-IP auth rate limit; closing that needs session-on-verification instead of session-at-signup, called out as the larger follow-up.

## Testing

`npm run typecheck`, `lint`, `format:check`, `docs:check-temporal`; node: `public-form-protection` (with the new mismatch case), `auth-handler` (new duplicate-email case; audit sequence updated), `auth.audit-persist`, `auth-stable-user-id-conflict`; Playwright `e2e/smoke.spec.ts` passes through the changed seeding helper.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends</b> signup guards (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `50c3c1e3` · **Head:** `HEAD`

**Classification:** extends — one stricter check on the Turnstile verification path and one changed response shape on the signup endpoint; no storage or schema changes.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `signup` | surfaces | extends — uniform response for existing emails |
| `public-form-protection` | features | extends — Turnstile hostname binding |

### Change flow

```mermaid
sequenceDiagram
	actor Caller
	participant auth as POST /auth (signup)
	participant turnstile as Turnstile siteverify
	participant d1AppDb as d1-app-db
	Caller->>auth: email, username, password, turnstileToken
	auth->>turnstile: verify token
	turnstile-->>auth: success, hostname
	alt hostname != request host
		auth-->>Caller: 400 generic failure (logged turnstile-hostname-mismatch)
	end
	auth->>d1AppDb: SELECT users by email
	alt email exists
		auth-->>Caller: 200 accepted body, no Set-Cookie, nothing created
	else new
		auth->>d1AppDb: INSERT user, verification token
		auth-->>Caller: 200 accepted body + kody_session
	end
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b0f6a92a-81cd-4157-8b60-188c83ca84c0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b0f6a92a-81cd-4157-8b60-188c83ca84c0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Signup attempts for existing email addresses no longer reveal whether an account exists or create a new account or session.
  - Invite-code validation remains consistent for registered and unregistered email addresses.
  - Turnstile tokens verified for a different hostname are rejected and logged.

- **Bug Fixes**
  - Signup flows now continue to login when signup succeeds without issuing a session cookie.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->