### PR TITLE
Name owners when one account owns a fleet error-rate spike

### DIFF
--- a/docs/contributing/architecture/authorization.md
+++ b/docs/contributing/architecture/authorization.md
@@ -399,10 +399,13 @@ hourly usage-aggregation lane compares anonymous Analytics Engine totals for
 combined error rate rises, Kody fans `fleet.package_error_rate.elevated` only to
 packages whose owners hold the admin role at dispatch time. The event contains
 window bounds, per-metric counts and rates, the public status URL, and the
-insights URL. It omits user ids, package ids, error strings, logs, and unrelated
-account content. This is operator telemetry about kody itself, not a user-data
-exception. Delivery is best-effort (no Queue). A six-hour cooldown suppresses
-repeat pages.
+insights URL. When one account or a few accounts own the recent-window errors,
+it also names those usernames and package kody ids. It omits user ids, package
+UUIDs, emails, error strings, logs, and unrelated account content. This is
+operator telemetry about kody itself, not a user-data exception. Delivery is
+best-effort (no Queue). A six-hour cooldown suppresses repeat pages. A
+concentrated spike still pages the fleet; it does not reroute as a per-user
+storm.
 
 **Admins can subscribe to fleet entitlement crossings.** The hourly
 `usage_entitlement_alert` lane sweeps the top ~15 active accounts and fans

--- a/docs/contributing/architecture/usage-metering.md
+++ b/docs/contributing/architecture/usage-metering.md
@@ -407,11 +407,14 @@ Guarantees and rules:
   hour vs the hour before and the last 24 hours vs the 24 hours before. The
   snapshot lives at the platform KV key `fleet-package-error-rate:v1` and feeds
   `/admin/insights`. When the combined rate rises past a volume floor, a third
-  query groups recent-window errors by owner. One account at ≥80% of those
-  errors, or three accounts together at ≥80%, is concentrated; otherwise the
-  spike stays fleet-wide. Kody still fans `fleet.package_error_rate.elevated` to
-  admin-owned packages in every case. Concentrated payloads name usernames and
-  package kody ids only. The KV cooldown key
-  `ops-alert:fleet-package-error-rate:v1` suppresses repeat pages for six hours.
-  The payload has no user ids, package UUIDs, emails, or error strings. See
+  query ranks owners of recent-window errors. Shares use the anonymous window
+  error total so a truncated owner sample cannot look like one account. One
+  account at ≥80% of those errors, or three accounts together at ≥80%, is
+  concentrated; otherwise the spike stays fleet-wide. A follow-up query then
+  loads package ids only for the named owners. Kody still fans
+  `fleet.package_error_rate.elevated` to admin-owned packages in every case.
+  Concentrated payloads name usernames and package kody ids only. The KV
+  cooldown key `ops-alert:fleet-package-error-rate:v1` suppresses repeat pages
+  for six hours. The payload has no user ids, package UUIDs, emails, or error
+  strings. See
   [Package subscriptions](../../guides/package-subscriptions.md#fleetpackageerrorrateelevated-admins).

--- a/docs/contributing/architecture/usage-metering.md
+++ b/docs/contributing/architecture/usage-metering.md
@@ -405,10 +405,13 @@ Guarantees and rules:
   Analytics Engine SQL, not grouped by user, totals `package_export`,
   `package_static_call`, `job_run`, and `workflow_run` for the last completed
   hour vs the hour before and the last 24 hours vs the 24 hours before. The
-  content-free snapshot lives at the platform KV key
-  `fleet-package-error-rate:v1` and feeds `/admin/insights`. When the combined
-  rate rises past a volume floor, Kody fans `fleet.package_error_rate.elevated`
-  to admin-owned packages. The KV cooldown key
+  snapshot lives at the platform KV key `fleet-package-error-rate:v1` and feeds
+  `/admin/insights`. When the combined rate rises past a volume floor, a third
+  query groups recent-window errors by owner. One account at ≥80% of those
+  errors, or three accounts together at ≥80%, is concentrated; otherwise the
+  spike stays fleet-wide. Kody still fans `fleet.package_error_rate.elevated` to
+  admin-owned packages in every case. Concentrated payloads name usernames and
+  package kody ids only. The KV cooldown key
   `ops-alert:fleet-package-error-rate:v1` suppresses repeat pages for six hours.
-  The payload has no user ids, package ids, or error strings. See
+  The payload has no user ids, package UUIDs, emails, or error strings. See
   [Package subscriptions](../../guides/package-subscriptions.md#fleetpackageerrorrateelevated-admins).

--- a/docs/contributing/packages-and-manifests.md
+++ b/docs/contributing/packages-and-manifests.md
@@ -407,12 +407,13 @@ when the secret is unset or the POST fails. See
 [Package subscriptions](../guides/package-subscriptions.md).
 
 Fleet package-runtime error-rate elevation is a separate admin-only, best-effort
-path. The hourly `usage_aggregation` lane writes a content-free Analytics Engine
-snapshot and fans `fleet.package_error_rate.elevated` only to packages whose
-owners hold the admin role at dispatch time. The payload is window bounds,
-per-metric counts and rates, `status_url`, and `insights_url`. It omits user
-ids, package ids, error strings, and all user content. There is no Queue for
-this topic. See
+path. The hourly `usage_aggregation` lane writes an Analytics Engine snapshot
+and fans `fleet.package_error_rate.elevated` only to packages whose owners hold
+the admin role at dispatch time. The payload is window bounds, per-metric counts
+and rates, `status_url`, and `insights_url`. When one account or a few accounts
+own the recent-window errors, it also names those usernames and package kody
+ids. It omits user ids, package UUIDs, emails, error strings, and all other user
+content. There is no Queue for this topic. See
 [Package subscriptions](../guides/package-subscriptions.md#fleetpackageerrorrateelevated-admins).
 
 Fleet entitlement crossings are a separate admin-only, best-effort path. The

--- a/docs/guides/package-subscriptions.md
+++ b/docs/guides/package-subscriptions.md
@@ -961,11 +961,14 @@ The hourly `usage_aggregation` lane queries Analytics Engine for anonymous fleet
 totals of `package_export`, `package_static_call`, `job_run`, and
 `workflow_run`. It compares the last completed hour to the hour before it, and
 the last 24 hours to the 24 hours before that. When the combined error rate
-rises past a volume floor, Kody writes a content-free KV snapshot for
-`/admin/insights` and fans `fleet.package_error_rate.elevated` to packages saved
-by users who hold the admin role at dispatch time. A non-admin package may
-declare the topic, but it never receives the event. Role revocation stops
-delivery on the next elevation.
+rises past a volume floor, Kody writes a KV snapshot for `/admin/insights` and
+fans `fleet.package_error_rate.elevated` to packages saved by users who hold the
+admin role at dispatch time. A second query then groups recent-window errors by
+owner. One account at ≥80% of those errors, or three accounts together at ≥80%,
+is concentrated; a true multi-user spike stays fleet-wide. Concentrated pages
+still fan out to admin packages — they name the owning accounts instead of
+looking like a fleet outage. A non-admin package may declare the topic, but it
+never receives the event. Role revocation stops delivery on the next elevation.
 
 There is no Queue / DLQ for this topic. A missed invoke is logged and does not
 fail usage rollup aggregation. A six-hour cooldown suppresses repeat pages
@@ -1016,14 +1019,28 @@ type FleetPackageErrorRateElevatedEvent = {
 		errors: number
 		rate: number | null
 	}>
+	concentration: {
+		kind: 'one_account' | 'few_accounts' | 'fleet'
+		recent_errors: number
+		owner_count: number
+		package_count: number
+		top_owner_share: number
+		owners: Array<{
+			username: string
+			error_share: number
+			packages: Array<{ kody_id: string }>
+		}>
+	} | null
 }
 ```
 
 `status_url` is the public status page. `insights_url` is the operator insights
 dashboard. Counts are fleet-wide and weighted by Analytics Engine
-`_sample_interval`. The event omits user ids, package ids, package names, error
-strings, logs, and unrelated account content. Idempotency keys include the
-topic, event id, and subscriber package id.
+`_sample_interval`. `concentration` is present when the elevation query
+succeeds. `owners` is populated only for `one_account` and `few_accounts` after
+D1 resolves usernames and package kody ids. The event omits user ids, package
+UUIDs, emails, error strings, logs, and unrelated account content. Idempotency
+keys include the topic, event id, and subscriber package id.
 
 Use this topic for notifier packages that enqueue a Kody-repo investigation
 request. Agent spawning stays on the scheduled sweep, not in the subscription

--- a/docs/use/privacy.md
+++ b/docs/use/privacy.md
@@ -145,21 +145,23 @@ when hourly MCP auth denials or shared-domain bounce/complaint counts cross
 their thresholds (count, threshold, window, insights URL, and `observed_at`).
 Those events omit user identities, tokens, recipients, and message content.
 Admin-configured notification packages may also receive a metadata-only
-`fleet.package_error_rate.elevated` event when anonymous package-runtime error
-rates rise (window bounds, per-metric counts and rates, public status URL, and
-insights URL). That event omits user ids, package ids, error strings, logs, and
-unrelated account content. Admin-configured notification packages may also
-receive a metadata-only `fleet.entitlement.crossed` event when a swept account
-first crosses 80% or 100% of a plan-limit resource, when a non-admin account
-first exceeds the monthly runtime-duration threshold, when a non-admin account
-first reaches a plan-aware unique Dynamic Worker cost threshold, or when a
-non-admin account first hits the execute cap on three of the last seven UTC
-days. Entitlement events include stable user id, username, resource counts, and
-admin dashboard URLs; runtime-duration events include stable user id, username,
-`total_duration_ms`, `threshold_ms`, and admin dashboard URLs;
-unique-worker-cost and repeated-execute events include the counts that tripped
-the threshold and admin dashboard URLs. These event kinds omit emails, plans,
-secrets, package source, and unrelated account content.
+`fleet.package_error_rate.elevated` event when package-runtime error rates rise
+(window bounds, per-metric counts and rates, public status URL, insights URL,
+and — when one account or a few accounts own the recent-window errors — those
+usernames and package kody ids). That event omits user ids, package UUIDs,
+emails, error strings, logs, and unrelated account content. Admin-configured
+notification packages may also receive a metadata-only
+`fleet.entitlement.crossed` event when a swept account first crosses 80% or 100%
+of a plan-limit resource, when a non-admin account first exceeds the monthly
+runtime-duration threshold, when a non-admin account first reaches a plan-aware
+unique Dynamic Worker cost threshold, or when a non-admin account first hits the
+execute cap on three of the last seven UTC days. Entitlement events include
+stable user id, username, resource counts, and admin dashboard URLs;
+runtime-duration events include stable user id, username, `total_duration_ms`,
+`threshold_ms`, and admin dashboard URLs; unique-worker-cost and
+repeated-execute events include the counts that tripped the threshold and admin
+dashboard URLs. These event kinds omit emails, plans, secrets, package source,
+and unrelated account content.
 
 ## Platform feedback
 

--- a/packages/worker/client/routes/admin-insights-dashboard.tsx
+++ b/packages/worker/client/routes/admin-insights-dashboard.tsx
@@ -291,7 +291,7 @@ export function renderDashboard(data: AdminInsightsLoaderData) {
 				</ChartCard>
 				<ChartCard
 					title="Fleet package error rate"
-					sub="Anonymous Analytics Engine rates for user-package runtime metrics. Rising rates page admin packages and email."
+					sub="Analytics Engine rates for user-package runtime metrics. Rising rates page admin packages. Concentrated spikes name the owning accounts."
 					span={6}
 				>
 					{renderPackageErrorRate(data.packageErrorRate)}

--- a/packages/worker/client/routes/admin-insights-sections.tsx
+++ b/packages/worker/client/routes/admin-insights-sections.tsx
@@ -7,6 +7,7 @@ import {
 	formatPercentShare,
 } from '#client/charts/chart-theme.ts'
 import { formatDynamicWorkerUsd } from '#universal/dynamic-worker-cost.ts'
+import { formatFleetPackageErrorRateConcentration } from '#universal/fleet-package-error-rate-concentration.ts'
 import {
 	type AdminInsightsActivation,
 	type AdminInsightsActivationStep,
@@ -404,8 +405,8 @@ export function renderPackageErrorRate(rate: AdminInsightsPackageErrorRate) {
 						paddingBottom: spacing.xs,
 					})}
 				>
-					Anonymous combined rates for package_export, package_static_call,
-					job_run, and workflow_run. No user ids or package names.
+					Combined rates for package_export, package_static_call, job_run, and
+					workflow_run. Totals omit user ids and package UUIDs.
 				</caption>
 				<thead>
 					<tr>
@@ -449,6 +450,11 @@ export function renderPackageErrorRate(rate: AdminInsightsPackageErrorRate) {
 					))}
 				</tbody>
 			</table>
+			{rate.concentration ? (
+				<p mix={css({ margin: 0 })}>
+					{formatFleetPackageErrorRateConcentration(rate.concentration)}
+				</p>
+			) : null}
 			{rate.lastAlertAt ? (
 				<p mix={css({ margin: 0, color: colors.textMuted })}>
 					Last elevation alert {rate.lastAlertAt}.

--- a/packages/worker/client/routes/privacy.tsx
+++ b/packages/worker/client/routes/privacy.tsx
@@ -195,23 +195,25 @@ export function PrivacyRoute(_handle: Handle) {
 					). Those events omit user identities, tokens, recipients, and message
 					content. Admin-configured notification packages may also receive a
 					metadata-only <code>fleet.package_error_rate.elevated</code> event
-					when anonymous package-runtime error rates rise (window bounds,
-					per-metric counts and rates, public status URL, and insights URL).
-					That event omits user ids, package ids, error strings, logs, and
-					unrelated account content. Admin-configured notification packages may
-					also receive a metadata-only <code>fleet.entitlement.crossed</code>{' '}
-					event when a swept account first crosses 80% or 100% of a plan-limit
-					resource, when a non-admin account first exceeds the monthly
-					runtime-duration threshold, when a non-admin account first reaches a
-					plan-aware unique Dynamic Worker cost threshold, or when a non-admin
-					account first hits the execute cap on three of the last seven UTC
-					days. Entitlement events include stable user id, username, resource
-					counts, and admin dashboard URLs; runtime-duration events include
-					stable user id, username, <code>total_duration_ms</code>,{' '}
-					<code>threshold_ms</code>, and admin dashboard URLs;
-					unique-worker-cost and repeated-execute events include the counts that
-					tripped the threshold and admin dashboard URLs. These event kinds omit
-					emails, plans, secrets, package source, and unrelated account content.
+					when package-runtime error rates rise (window bounds, per-metric
+					counts and rates, public status URL, insights URL, and — when one
+					account or a few accounts own the recent-window errors — those
+					usernames and package kody ids). That event omits user ids, package
+					UUIDs, emails, error strings, logs, and unrelated account content.
+					Admin-configured notification packages may also receive a
+					metadata-only <code>fleet.entitlement.crossed</code> event when a
+					swept account first crosses 80% or 100% of a plan-limit resource, when
+					a non-admin account first exceeds the monthly runtime-duration
+					threshold, when a non-admin account first reaches a plan-aware unique
+					Dynamic Worker cost threshold, or when a non-admin account first hits
+					the execute cap on three of the last seven UTC days. Entitlement
+					events include stable user id, username, resource counts, and admin
+					dashboard URLs; runtime-duration events include stable user id,
+					username, <code>total_duration_ms</code>, <code>threshold_ms</code>,
+					and admin dashboard URLs; unique-worker-cost and repeated-execute
+					events include the counts that tripped the threshold and admin
+					dashboard URLs. These event kinds omit emails, plans, secrets, package
+					source, and unrelated account content.
 				</p>
 			</section>
 

--- a/packages/worker/src/app/admin-insights-data.node.test.ts
+++ b/packages/worker/src/app/admin-insights-data.node.test.ts
@@ -830,10 +830,11 @@ test('admin insights uses content-free getAdminInsightsSnapshot point reads only
 		day: null,
 		hour: null,
 		lastAlertAt: null,
+		concentration: null,
 	})
 })
 
-test('admin insights surfaces the content-free fleet package error-rate snapshot', async () => {
+test('admin insights surfaces the fleet package error-rate snapshot', async () => {
 	consoleWarn.mockImplementation(() => {})
 	stubSnapshotsByUser({
 		'user-a': emptySnapshot(),
@@ -875,6 +876,20 @@ test('admin insights surfaces the content-free fleet package error-rate snapshot
 				by_metric: [],
 			},
 		},
+		concentration: {
+			kind: 'one_account',
+			recent_errors: 90,
+			owner_count: 1,
+			package_count: 3,
+			top_owner_share: 1,
+			owners: [
+				{
+					username: 'jett',
+					error_share: 1,
+					packages: [{ kody_id: 'dji-cloud-relay-staging-deploy' }],
+				},
+			],
+		},
 	})
 	const data = await loadAdminInsightsData(
 		{
@@ -891,7 +906,22 @@ test('admin insights surfaces the content-free fleet package error-rate snapshot
 		lastAlertAt: '2026-08-22T19:32:00.000Z',
 		day: expect.objectContaining({ kind: 'day' }),
 		hour: expect.objectContaining({ kind: 'hour' }),
+		concentration: {
+			kind: 'one_account',
+			recent_errors: 90,
+			owner_count: 1,
+			package_count: 3,
+			top_owner_share: 1,
+			owners: [
+				{
+					username: 'jett',
+					error_share: 1,
+					packages: [{ kody_id: 'dji-cloud-relay-staging-deploy' }],
+				},
+			],
+		},
 	})
+	expect(JSON.stringify(data.packageErrorRate)).toContain('jett')
 	expect(JSON.stringify(data.packageErrorRate)).not.toContain('user_id')
 })
 

--- a/packages/worker/src/app/admin-insights-data.ts
+++ b/packages/worker/src/app/admin-insights-data.ts
@@ -303,6 +303,7 @@ function toInsightsPackageErrorRate(
 			day: null,
 			hour: null,
 			lastAlertAt: null,
+			concentration: null,
 		}
 	}
 	return {
@@ -312,6 +313,7 @@ function toInsightsPackageErrorRate(
 		day: snapshot.day,
 		hour: snapshot.hour,
 		lastAlertAt: snapshot.lastAlertAt,
+		concentration: snapshot.concentration,
 	}
 }
 

--- a/packages/worker/src/app/fleet-package-error-rate-alerts.node.test.ts
+++ b/packages/worker/src/app/fleet-package-error-rate-alerts.node.test.ts
@@ -108,11 +108,13 @@ test('refreshFleetPackageErrorRateAndMaybeAlert writes a content-free snapshot a
 	expect(payload).not.toContain('admin@example.com')
 	expect(payload).not.toMatch(/[0-9a-f]{8}-[0-9a-f]{4}-/)
 	expect(dispatched.event.event).toBe('fleet.package_error_rate.elevated')
+	expect(dispatched.event.concentration).toBeNull()
 
 	const snapshot = JSON.parse(stored.get(fleetPackageErrorRateKvKey) ?? 'null')
 	expect(snapshot?.environment).toBe('production')
 	expect(snapshot?.day.recent.combined.errors).toBe(16)
 	expect(snapshot?.lastAlertEventId).toBe('day:2026-08-22T19:00:00.000Z')
+	expect(snapshot?.concentration).toBeNull()
 
 	const second = await refreshFleetPackageErrorRateAndMaybeAlert({
 		env,
@@ -175,4 +177,160 @@ test('refreshFleetPackageErrorRateAndMaybeAlert writes a content-free snapshot a
 		alert: { status: 'skipped', reason: 'notify_failed' },
 	})
 	expect(failedKv.stored.get(fleetPackageErrorRateAlertKvKey)).toBeUndefined()
+})
+
+test('refreshFleetPackageErrorRateAndMaybeAlert names a one-account concentration without leaking identifiers', async () => {
+	consoleWarn.mockImplementation(() => {})
+	dispatchFleetPackageErrorRateSubscriptionEvent.mockClear()
+	const { stored, kv } = createKv()
+	const jettPackageIds = {
+		dji: '11111111-1111-4111-8111-111111111111',
+		earth: '22222222-2222-4222-8222-222222222222',
+		analysis: '33333333-3333-4333-8333-333333333333',
+	}
+	queryAnalyticsEngineSql.mockImplementation(
+		async (input: { query: string }) => {
+			if (input.query.includes('blob1 AS user_id')) {
+				return [
+					{
+						user_id: 'jett-user',
+						entity_id: jettPackageIds.dji,
+						error_count: 40,
+					},
+					{
+						user_id: 'jett-user',
+						entity_id: jettPackageIds.earth,
+						error_count: 30,
+					},
+					{
+						user_id: 'jett-user',
+						entity_id: jettPackageIds.analysis,
+						error_count: 20,
+					},
+				]
+			}
+			if (input.query.includes("toDateTime('2026-08-21 19:00:00')")) {
+				return [
+					{
+						window: 'recent',
+						metric: 'package_export',
+						event_count: 80,
+						error_count: 16,
+					},
+					{
+						window: 'previous',
+						metric: 'package_export',
+						event_count: 80,
+						error_count: 2,
+					},
+				]
+			}
+			return [
+				{
+					window: 'recent',
+					metric: 'package_export',
+					event_count: 40,
+					error_count: 2,
+				},
+				{
+					window: 'previous',
+					metric: 'package_export',
+					event_count: 40,
+					error_count: 1,
+				},
+			]
+		},
+	)
+	const db = {
+		prepare(query: string) {
+			return {
+				bind(...params: Array<unknown>) {
+					return {
+						async all() {
+							if (query.includes('FROM users')) {
+								return {
+									results: params.includes('jett-user')
+										? [
+												{
+													stable_user_id: 'jett-user',
+													username: 'jett',
+												},
+											]
+										: [],
+								}
+							}
+							if (query.includes('FROM saved_packages')) {
+								const kodyIds: Record<string, string> = {
+									[jettPackageIds.dji]: 'dji-cloud-relay-staging-deploy',
+									[jettPackageIds.earth]: 'earthranger-relay-staging-deploy',
+									[jettPackageIds.analysis]: 'analysis-staging-deploy',
+								}
+								return {
+									results: params
+										.filter((id): id is string => typeof id === 'string')
+										.flatMap((id) =>
+											kodyIds[id] ? [{ id, kody_id: kodyIds[id] }] : [],
+										),
+								}
+							}
+							return { results: [] }
+						},
+					}
+				},
+			}
+		},
+	} as unknown as D1Database
+
+	const result = await refreshFleetPackageErrorRateAndMaybeAlert({
+		env: {
+			USAGE_EVENTS: {} as AnalyticsEngineDataset,
+			APP_DB: db,
+			BUNDLE_ARTIFACTS_KV: kv,
+			APP_BASE_URL: 'https://kody.codes',
+			CLOUDFLARE_ACCOUNT_ID: 'account',
+			CLOUDFLARE_API_TOKEN: 'token',
+			SENTRY_ENVIRONMENT: 'production',
+		},
+		now: new Date('2026-08-22T19:32:00.000Z'),
+	})
+	expect(result).toMatchObject({
+		status: 'refreshed',
+		elevated: true,
+		alert: { status: 'notified' },
+	})
+	const dispatched =
+		dispatchFleetPackageErrorRateSubscriptionEvent.mock.calls.at(-1)?.[0] as {
+			event: Record<string, unknown>
+		}
+	const payload = JSON.stringify(dispatched.event)
+	expect(dispatched.event.concentration).toMatchObject({
+		kind: 'one_account',
+		owners: [
+			{
+				username: 'jett',
+				packages: [
+					{ kody_id: 'dji-cloud-relay-staging-deploy' },
+					{ kody_id: 'earthranger-relay-staging-deploy' },
+					{ kody_id: 'analysis-staging-deploy' },
+				],
+			},
+		],
+	})
+	expect(payload).toContain('jett')
+	expect(payload).toContain('dji-cloud-relay-staging-deploy')
+	expect(payload).not.toContain('user_id')
+	expect(payload).not.toContain('jett-user')
+	expect(payload).not.toContain('admin@example.com')
+	expect(payload).not.toMatch(/[0-9a-f]{8}-[0-9a-f]{4}-/)
+	expect(consoleWarn).toHaveBeenCalledWith(
+		'fleet-package-error-rate-alerted',
+		expect.objectContaining({
+			concentration:
+				'One account owns 100% of recent errors (jett: dji-cloud-relay-staging-deploy, earthranger-relay-staging-deploy, analysis-staging-deploy).',
+		}),
+	)
+	const snapshot = JSON.parse(stored.get(fleetPackageErrorRateKvKey) ?? 'null')
+	expect(snapshot?.concentration?.kind).toBe('one_account')
+	expect(JSON.stringify(snapshot)).not.toContain('user_id')
+	expect(JSON.stringify(snapshot)).not.toMatch(/[0-9a-f]{8}-[0-9a-f]{4}-/)
 })

--- a/packages/worker/src/app/fleet-package-error-rate-alerts.node.test.ts
+++ b/packages/worker/src/app/fleet-package-error-rate-alerts.node.test.ts
@@ -190,7 +190,7 @@ test('refreshFleetPackageErrorRateAndMaybeAlert names a one-account concentratio
 	}
 	queryAnalyticsEngineSql.mockImplementation(
 		async (input: { query: string }) => {
-			if (input.query.includes('blob1 AS user_id')) {
+			if (input.query.includes('GROUP BY user_id, entity_id')) {
 				return [
 					{
 						user_id: 'jett-user',
@@ -208,6 +208,9 @@ test('refreshFleetPackageErrorRateAndMaybeAlert names a one-account concentratio
 						error_count: 20,
 					},
 				]
+			}
+			if (input.query.includes('blob1 AS user_id')) {
+				return [{ user_id: 'jett-user', error_count: 16 }]
 			}
 			if (input.query.includes("toDateTime('2026-08-21 19:00:00')")) {
 				return [

--- a/packages/worker/src/app/fleet-package-error-rate-alerts.ts
+++ b/packages/worker/src/app/fleet-package-error-rate-alerts.ts
@@ -1,3 +1,4 @@
+import { formatFleetPackageErrorRateConcentration } from '#universal/fleet-package-error-rate-concentration.ts'
 import { joinAppUrl } from '#worker/app-base-url.ts'
 import {
 	fleetPackageErrorRateAlertCooldownMinutes as defaultCooldownMinutes,
@@ -38,9 +39,10 @@ export type FleetPackageErrorRateRefreshResult =
 	  }
 
 /**
- * Recompute the anonymous fleet snapshot, then fan
+ * Recompute the fleet snapshot, then fan
  * `fleet.package_error_rate.elevated` to admin-owned packages when the
- * combined package-runtime error rate is rising.
+ * combined package-runtime error rate is rising. A concentrated spike
+ * still pages the fleet; the event names the owning accounts.
  */
 export async function refreshFleetPackageErrorRateAndMaybeAlert(input: {
 	env: FleetPackageErrorRateEnv
@@ -97,6 +99,9 @@ export async function refreshFleetPackageErrorRateAndMaybeAlert(input: {
 			window: event.trigger.window,
 			reason: event.trigger.reason,
 			checkedAt: now.toISOString(),
+			concentration: event.concentration
+				? formatFleetPackageErrorRateConcentration(event.concentration)
+				: null,
 		})
 		return {
 			status: 'refreshed',
@@ -132,6 +137,7 @@ function buildElevatedEvent(input: {
 		reason: input.elevation.reason,
 		recent: input.elevation.comparison.recent,
 		previous: input.elevation.comparison.previous,
+		concentration: input.snapshot.concentration,
 	})
 }
 

--- a/packages/worker/src/usage/fleet-package-error-rate-concentration.node.test.ts
+++ b/packages/worker/src/usage/fleet-package-error-rate-concentration.node.test.ts
@@ -141,6 +141,7 @@ test('fleet package error-rate concentration classifies, names, and stays identi
 	})
 	expect(packageQuery).toContain("blob1 IN ('jett-user')")
 	expect(packageQuery).toContain('GROUP BY user_id, entity_id')
+	expect(packageQuery).toContain('LIMIT 5')
 
 	queryAnalyticsEngineSql.mockImplementation(
 		async (input: { query: string }) => {
@@ -257,6 +258,52 @@ test('fleet package error-rate concentration classifies, names, and stays identi
 	).toBe(
 		'A few accounts own most recent errors (top owner 40%: ada: ada-relay; bea: bea-relay).',
 	)
+
+	queryAnalyticsEngineSql.mockImplementation(
+		async (input: { query: string }) => {
+			if (input.query.includes("blob1 IN ('user-a')")) {
+				return Array.from({ length: 5 }, (_, index) => ({
+					user_id: 'user-a',
+					entity_id: `pkg-a-${index}`,
+					error_count: 10 - index,
+				}))
+			}
+			if (input.query.includes("blob1 IN ('user-b')")) {
+				return [{ user_id: 'user-b', entity_id: 'pkg-b', error_count: 1 }]
+			}
+			return [
+				{ user_id: 'user-a', error_count: 50 },
+				{ user_id: 'user-b', error_count: 40 },
+			]
+		},
+	)
+	const few = await resolveFleetPackageErrorRateConcentration({
+		env: {
+			APP_DB: createConcentrationDb({
+				users: [
+					{ stable_user_id: 'user-a', username: 'ada' },
+					{ stable_user_id: 'user-b', username: 'bea' },
+				],
+				packages: [
+					{ id: 'pkg-a-0', kody_id: 'ada-relay' },
+					{ id: 'pkg-b', kody_id: 'bea-relay' },
+				],
+			}),
+			CLOUDFLARE_ACCOUNT_ID: 'account',
+			CLOUDFLARE_API_TOKEN: 'token',
+		},
+		dataset: 'kody_usage_events',
+		recentStart: new Date('2026-09-01T00:00:00.000Z'),
+		recentEnd: new Date('2026-09-01T01:00:00.000Z'),
+		recentErrors: 100,
+	})
+	expect(few).toMatchObject({
+		kind: 'few_accounts',
+		owners: [
+			{ username: 'ada', packages: [{ kody_id: 'ada-relay' }] },
+			{ username: 'bea', packages: [{ kody_id: 'bea-relay' }] },
+		],
+	})
 
 	expect(parseFleetPackageErrorRateConcentration(null)).toBeNull()
 	expect(

--- a/packages/worker/src/usage/fleet-package-error-rate-concentration.node.test.ts
+++ b/packages/worker/src/usage/fleet-package-error-rate-concentration.node.test.ts
@@ -12,6 +12,7 @@ vi.mock('./aggregate-rollups.ts', async (importOriginal) => {
 })
 
 const {
+	buildFleetPackageErrorRateConcentrationPackageQuery,
 	buildFleetPackageErrorRateConcentrationQuery,
 	foldFleetPackageErrorRateConcentrationRows,
 	parseFleetPackageErrorRateConcentration,
@@ -92,36 +93,35 @@ test('fleet package error-rate concentration classifies, names, and stays identi
 		}),
 	).toBe('fleet')
 
-	const folded = foldFleetPackageErrorRateConcentrationRows([
-		{
-			user_id: 'jett-user',
-			entity_id: jettPackageIds.dji,
-			error_count: 40,
-		},
-		{
-			user_id: 'jett-user',
-			entity_id: jettPackageIds.earth,
-			error_count: 30,
-		},
-		{
-			user_id: 'jett-user',
-			entity_id: jettPackageIds.analysis,
-			error_count: 20,
-		},
-		{ user_id: 'quiet-user', entity_id: 'pkg-quiet', error_count: 2 },
-	])
+	const folded = foldFleetPackageErrorRateConcentrationRows(
+		[
+			{ user_id: 'jett-user', error_count: 90 },
+			{ user_id: 'quiet-user', error_count: 2 },
+		],
+		92,
+	)
 	expect(folded.recentErrors).toBe(92)
 	expect(folded.ownerCount).toBe(2)
-	expect(folded.packageCount).toBe(4)
 	expect(folded.topOwnerShare).toBeCloseTo(90 / 92)
+	const truncatedFleet = foldFleetPackageErrorRateConcentrationRows(
+		Array.from({ length: 50 }, (_, index) => ({
+			user_id: `user-${index}`,
+			entity_id: `pkg-${index}`,
+			error_count: 1,
+		})),
+		200,
+	)
+	expect(truncatedFleet.topOwnerShare).toBe(1 / 200)
+	expect(
+		classifyFleetPackageErrorRateConcentrationKind({
+			topOwnerShare: truncatedFleet.topOwnerShare,
+			topFewShare: truncatedFleet.topFewShare,
+		}),
+	).toBe('fleet')
 	expect(folded.ranked[0]).toMatchObject({
 		ownerId: 'jett-user',
 		errors: 90,
-		entityIds: [
-			jettPackageIds.dji,
-			jettPackageIds.earth,
-			jettPackageIds.analysis,
-		],
+		entityIds: [],
 	})
 
 	const query = buildFleetPackageErrorRateConcentrationQuery({
@@ -130,26 +130,42 @@ test('fleet package error-rate concentration classifies, names, and stays identi
 		recentEnd: new Date('2026-09-01T01:00:00.000Z'),
 	})
 	expect(query).toContain('blob1 AS user_id')
-	expect(query).toContain('GROUP BY user_id, entity_id')
+	expect(query).toContain('GROUP BY user_id')
+	expect(query).not.toContain('GROUP BY user_id, entity_id')
 	expect(query).toContain("blob4 = 'error'")
+	const packageQuery = buildFleetPackageErrorRateConcentrationPackageQuery({
+		dataset: 'kody_usage_events',
+		recentStart: new Date('2026-09-01T00:00:00.000Z'),
+		recentEnd: new Date('2026-09-01T01:00:00.000Z'),
+		ownerIds: ['jett-user'],
+	})
+	expect(packageQuery).toContain("blob1 IN ('jett-user')")
+	expect(packageQuery).toContain('GROUP BY user_id, entity_id')
 
-	queryAnalyticsEngineSql.mockResolvedValueOnce([
-		{
-			user_id: 'jett-user',
-			entity_id: jettPackageIds.dji,
-			error_count: 40,
+	queryAnalyticsEngineSql.mockImplementation(
+		async (input: { query: string }) => {
+			if (input.query.includes('GROUP BY user_id, entity_id')) {
+				return [
+					{
+						user_id: 'jett-user',
+						entity_id: jettPackageIds.dji,
+						error_count: 40,
+					},
+					{
+						user_id: 'jett-user',
+						entity_id: jettPackageIds.earth,
+						error_count: 30,
+					},
+					{
+						user_id: 'jett-user',
+						entity_id: jettPackageIds.analysis,
+						error_count: 20,
+					},
+				]
+			}
+			return [{ user_id: 'jett-user', error_count: 90 }]
 		},
-		{
-			user_id: 'jett-user',
-			entity_id: jettPackageIds.earth,
-			error_count: 30,
-		},
-		{
-			user_id: 'jett-user',
-			entity_id: jettPackageIds.analysis,
-			error_count: 20,
-		},
-	])
+	)
 	const concentration = await resolveFleetPackageErrorRateConcentration({
 		env: {
 			APP_DB: createConcentrationDb(),
@@ -159,6 +175,7 @@ test('fleet package error-rate concentration classifies, names, and stays identi
 		dataset: 'kody_usage_events',
 		recentStart: new Date('2026-09-01T00:00:00.000Z'),
 		recentEnd: new Date('2026-09-01T01:00:00.000Z'),
+		recentErrors: 90,
 	})
 	expect(concentration).toEqual({
 		kind: 'one_account',
@@ -185,12 +202,12 @@ test('fleet package error-rate concentration classifies, names, and stays identi
 	expect(JSON.stringify(concentration)).not.toContain('jett-user')
 	expect(JSON.stringify(concentration)).not.toMatch(/[0-9a-f]{8}-[0-9a-f]{4}-/)
 
-	queryAnalyticsEngineSql.mockResolvedValueOnce([
-		{ user_id: 'user-a', entity_id: 'pkg-a', error_count: 20 },
-		{ user_id: 'user-b', entity_id: 'pkg-b', error_count: 20 },
-		{ user_id: 'user-c', entity_id: 'pkg-c', error_count: 20 },
-		{ user_id: 'user-d', entity_id: 'pkg-d', error_count: 20 },
-		{ user_id: 'user-e', entity_id: 'pkg-e', error_count: 20 },
+	queryAnalyticsEngineSql.mockImplementation(async () => [
+		{ user_id: 'user-a', error_count: 20 },
+		{ user_id: 'user-b', error_count: 20 },
+		{ user_id: 'user-c', error_count: 20 },
+		{ user_id: 'user-d', error_count: 20 },
+		{ user_id: 'user-e', error_count: 20 },
 	])
 	const fleet = await resolveFleetPackageErrorRateConcentration({
 		env: {
@@ -206,6 +223,7 @@ test('fleet package error-rate concentration classifies, names, and stays identi
 		dataset: 'kody_usage_events',
 		recentStart: new Date('2026-09-01T00:00:00.000Z'),
 		recentEnd: new Date('2026-09-01T01:00:00.000Z'),
+		recentErrors: 100,
 	})
 	expect(fleet).toMatchObject({
 		kind: 'fleet',

--- a/packages/worker/src/usage/fleet-package-error-rate-concentration.node.test.ts
+++ b/packages/worker/src/usage/fleet-package-error-rate-concentration.node.test.ts
@@ -1,0 +1,263 @@
+import { expect, test, vi } from 'vitest'
+
+const queryAnalyticsEngineSql = vi.fn()
+
+vi.mock('./aggregate-rollups.ts', async (importOriginal) => {
+	const original = (await importOriginal()) as Record<string, unknown>
+	return {
+		...original,
+		queryAnalyticsEngineSql: (...args: Array<unknown>) =>
+			queryAnalyticsEngineSql(...args),
+	}
+})
+
+const {
+	buildFleetPackageErrorRateConcentrationQuery,
+	foldFleetPackageErrorRateConcentrationRows,
+	parseFleetPackageErrorRateConcentration,
+	resolveFleetPackageErrorRateConcentration,
+} = await import('./fleet-package-error-rate-concentration.ts')
+const {
+	classifyFleetPackageErrorRateConcentrationKind,
+	formatFleetPackageErrorRateConcentration,
+} = await import('#universal/fleet-package-error-rate-concentration.ts')
+
+const jettPackageIds = {
+	dji: '11111111-1111-4111-8111-111111111111',
+	earth: '22222222-2222-4222-8222-222222222222',
+	analysis: '33333333-3333-4333-8333-333333333333',
+} as const
+
+function createConcentrationDb(
+	input: {
+		users?: Array<{ stable_user_id: string; username: string }>
+		packages?: Array<{ id: string; kody_id: string }>
+	} = {},
+) {
+	const users = input.users ?? [
+		{ stable_user_id: 'jett-user', username: 'jett' },
+	]
+	const packages = input.packages ?? [
+		{ id: jettPackageIds.dji, kody_id: 'dji-cloud-relay-staging-deploy' },
+		{
+			id: jettPackageIds.earth,
+			kody_id: 'earthranger-relay-staging-deploy',
+		},
+		{ id: jettPackageIds.analysis, kody_id: 'analysis-staging-deploy' },
+	]
+	return {
+		prepare(query: string) {
+			return {
+				bind(...params: Array<unknown>) {
+					return {
+						async all() {
+							if (query.includes('FROM users')) {
+								return {
+									results: users.filter((user) =>
+										params.includes(user.stable_user_id),
+									),
+								}
+							}
+							if (query.includes('FROM saved_packages')) {
+								return {
+									results: packages.filter((pkg) => params.includes(pkg.id)),
+								}
+							}
+							return { results: [] }
+						},
+					}
+				},
+			}
+		},
+	} as unknown as D1Database
+}
+
+test('fleet package error-rate concentration classifies, names, and stays identifier-safe', async () => {
+	expect(
+		classifyFleetPackageErrorRateConcentrationKind({
+			topOwnerShare: 0.8,
+			topFewShare: 0.8,
+		}),
+	).toBe('one_account')
+	expect(
+		classifyFleetPackageErrorRateConcentrationKind({
+			topOwnerShare: 0.5,
+			topFewShare: 0.85,
+		}),
+	).toBe('few_accounts')
+	expect(
+		classifyFleetPackageErrorRateConcentrationKind({
+			topOwnerShare: 0.3,
+			topFewShare: 0.6,
+		}),
+	).toBe('fleet')
+
+	const folded = foldFleetPackageErrorRateConcentrationRows([
+		{
+			user_id: 'jett-user',
+			entity_id: jettPackageIds.dji,
+			error_count: 40,
+		},
+		{
+			user_id: 'jett-user',
+			entity_id: jettPackageIds.earth,
+			error_count: 30,
+		},
+		{
+			user_id: 'jett-user',
+			entity_id: jettPackageIds.analysis,
+			error_count: 20,
+		},
+		{ user_id: 'quiet-user', entity_id: 'pkg-quiet', error_count: 2 },
+	])
+	expect(folded.recentErrors).toBe(92)
+	expect(folded.ownerCount).toBe(2)
+	expect(folded.packageCount).toBe(4)
+	expect(folded.topOwnerShare).toBeCloseTo(90 / 92)
+	expect(folded.ranked[0]).toMatchObject({
+		ownerId: 'jett-user',
+		errors: 90,
+		entityIds: [
+			jettPackageIds.dji,
+			jettPackageIds.earth,
+			jettPackageIds.analysis,
+		],
+	})
+
+	const query = buildFleetPackageErrorRateConcentrationQuery({
+		dataset: 'kody_usage_events',
+		recentStart: new Date('2026-09-01T00:00:00.000Z'),
+		recentEnd: new Date('2026-09-01T01:00:00.000Z'),
+	})
+	expect(query).toContain('blob1 AS user_id')
+	expect(query).toContain('GROUP BY user_id, entity_id')
+	expect(query).toContain("blob4 = 'error'")
+
+	queryAnalyticsEngineSql.mockResolvedValueOnce([
+		{
+			user_id: 'jett-user',
+			entity_id: jettPackageIds.dji,
+			error_count: 40,
+		},
+		{
+			user_id: 'jett-user',
+			entity_id: jettPackageIds.earth,
+			error_count: 30,
+		},
+		{
+			user_id: 'jett-user',
+			entity_id: jettPackageIds.analysis,
+			error_count: 20,
+		},
+	])
+	const concentration = await resolveFleetPackageErrorRateConcentration({
+		env: {
+			APP_DB: createConcentrationDb(),
+			CLOUDFLARE_ACCOUNT_ID: 'account',
+			CLOUDFLARE_API_TOKEN: 'token',
+		},
+		dataset: 'kody_usage_events',
+		recentStart: new Date('2026-09-01T00:00:00.000Z'),
+		recentEnd: new Date('2026-09-01T01:00:00.000Z'),
+	})
+	expect(concentration).toEqual({
+		kind: 'one_account',
+		recent_errors: 90,
+		owner_count: 1,
+		package_count: 3,
+		top_owner_share: 1,
+		owners: [
+			{
+				username: 'jett',
+				error_share: 1,
+				packages: [
+					{ kody_id: 'dji-cloud-relay-staging-deploy' },
+					{ kody_id: 'earthranger-relay-staging-deploy' },
+					{ kody_id: 'analysis-staging-deploy' },
+				],
+			},
+		],
+	})
+	expect(formatFleetPackageErrorRateConcentration(concentration!)).toBe(
+		'One account owns 100% of recent errors (jett: dji-cloud-relay-staging-deploy, earthranger-relay-staging-deploy, analysis-staging-deploy).',
+	)
+	expect(JSON.stringify(concentration)).not.toContain('user_id')
+	expect(JSON.stringify(concentration)).not.toContain('jett-user')
+	expect(JSON.stringify(concentration)).not.toMatch(/[0-9a-f]{8}-[0-9a-f]{4}-/)
+
+	queryAnalyticsEngineSql.mockResolvedValueOnce([
+		{ user_id: 'user-a', entity_id: 'pkg-a', error_count: 20 },
+		{ user_id: 'user-b', entity_id: 'pkg-b', error_count: 20 },
+		{ user_id: 'user-c', entity_id: 'pkg-c', error_count: 20 },
+		{ user_id: 'user-d', entity_id: 'pkg-d', error_count: 20 },
+		{ user_id: 'user-e', entity_id: 'pkg-e', error_count: 20 },
+	])
+	const fleet = await resolveFleetPackageErrorRateConcentration({
+		env: {
+			APP_DB: createConcentrationDb({
+				users: [
+					{ stable_user_id: 'user-a', username: 'ada' },
+					{ stable_user_id: 'user-b', username: 'bea' },
+				],
+			}),
+			CLOUDFLARE_ACCOUNT_ID: 'account',
+			CLOUDFLARE_API_TOKEN: 'token',
+		},
+		dataset: 'kody_usage_events',
+		recentStart: new Date('2026-09-01T00:00:00.000Z'),
+		recentEnd: new Date('2026-09-01T01:00:00.000Z'),
+	})
+	expect(fleet).toMatchObject({
+		kind: 'fleet',
+		owner_count: 5,
+		owners: [],
+	})
+	expect(formatFleetPackageErrorRateConcentration(fleet!)).toBe(
+		'Errors are spread across the fleet (top owner 20%).',
+	)
+
+	expect(
+		formatFleetPackageErrorRateConcentration({
+			kind: 'few_accounts',
+			recent_errors: 100,
+			owner_count: 3,
+			package_count: 3,
+			top_owner_share: 0.4,
+			owners: [
+				{
+					username: 'ada',
+					error_share: 0.4,
+					packages: [{ kody_id: 'ada-relay' }],
+				},
+				{
+					username: 'bea',
+					error_share: 0.3,
+					packages: [{ kody_id: 'bea-relay' }],
+				},
+			],
+		}),
+	).toBe(
+		'A few accounts own most recent errors (top owner 40%: ada: ada-relay; bea: bea-relay).',
+	)
+
+	expect(parseFleetPackageErrorRateConcentration(null)).toBeNull()
+	expect(
+		parseFleetPackageErrorRateConcentration({
+			kind: 'one_account',
+			recent_errors: 90,
+			owner_count: 1,
+			package_count: 3,
+			top_owner_share: 1,
+			owners: [
+				{
+					username: 'jett',
+					error_share: 1,
+					packages: [{ kody_id: 'dji-cloud-relay-staging-deploy' }],
+				},
+			],
+		}),
+	).toMatchObject({
+		kind: 'one_account',
+		owners: [{ username: 'jett' }],
+	})
+})

--- a/packages/worker/src/usage/fleet-package-error-rate-concentration.ts
+++ b/packages/worker/src/usage/fleet-package-error-rate-concentration.ts
@@ -62,8 +62,6 @@ export function buildFleetPackageErrorRateConcentrationPackageQuery(input: {
 		.map((ownerId) => `'${ownerId}'`)
 		.join(', ')
 	if (ownerList.length === 0) return null
-	const packageLimit =
-		fleetPackageErrorRateMaxNamedOwners * fleetPackageErrorRateMaxNamedPackages
 	return `
 SELECT
 	blob1 AS user_id,
@@ -74,7 +72,7 @@ WHERE ${concentrationWhereClause(input)}
 	AND blob1 IN (${ownerList})
 GROUP BY user_id, entity_id
 ORDER BY error_count DESC
-LIMIT ${packageLimit}
+LIMIT ${fleetPackageErrorRateMaxNamedPackages}
 FORMAT JSON
 `.trim()
 }
@@ -310,24 +308,32 @@ async function loadOwnerPackageRows(input: {
 	recentEnd: Date
 	ownerIds: ReadonlyArray<string>
 }) {
-	const query = buildFleetPackageErrorRateConcentrationPackageQuery(input)
-	if (!query) return []
-	try {
-		return await queryAnalyticsEngineSql<FleetPackageErrorRateConcentrationRow>(
-			{
-				accountId: input.accountId,
-				apiToken: input.apiToken,
-				baseUrl: input.baseUrl,
-				query,
-			},
-		)
-	} catch (error) {
-		console.warn(
-			'fleet-package-error-rate-concentration-packages-failed',
-			error,
-		)
-		return []
+	const rows: Array<FleetPackageErrorRateConcentrationRow> = []
+	for (const ownerId of input.ownerIds) {
+		const query = buildFleetPackageErrorRateConcentrationPackageQuery({
+			...input,
+			ownerIds: [ownerId],
+		})
+		if (!query) continue
+		try {
+			rows.push(
+				...(await queryAnalyticsEngineSql<FleetPackageErrorRateConcentrationRow>(
+					{
+						accountId: input.accountId,
+						apiToken: input.apiToken,
+						baseUrl: input.baseUrl,
+						query,
+					},
+				)),
+			)
+		} catch (error) {
+			console.warn(
+				'fleet-package-error-rate-concentration-packages-failed',
+				error,
+			)
+		}
 	}
+	return rows
 }
 
 function attachOwnerPackages(

--- a/packages/worker/src/usage/fleet-package-error-rate-concentration.ts
+++ b/packages/worker/src/usage/fleet-package-error-rate-concentration.ts
@@ -1,0 +1,299 @@
+import { chunkArray } from '@kody-internal/shared/chunk.ts'
+import {
+	classifyFleetPackageErrorRateConcentrationKind,
+	fleetPackageErrorRateFewAccountLimit,
+	fleetPackageErrorRateMaxNamedOwners,
+	fleetPackageErrorRateMaxNamedPackages,
+	isFleetPackageErrorRateConcentrationKind,
+	type FleetPackageErrorRateConcentration,
+} from '#universal/fleet-package-error-rate-concentration.ts'
+import { queryAnalyticsEngineSql } from './aggregate-rollups.ts'
+import { fleetPackageErrorRateMetrics } from './fleet-package-error-rate-subscription-event.ts'
+
+const maxSqlBindingsPerChunk = 90
+
+export type FleetPackageErrorRateConcentrationRow = {
+	user_id?: string
+	entity_id?: string
+	error_count?: number | string
+}
+
+export type FleetPackageErrorRateConcentrationQueryEnv = {
+	APP_DB?: D1Database
+	CLOUDFLARE_ACCOUNT_ID?: string
+	CLOUDFLARE_API_TOKEN?: string
+	CLOUDFLARE_API_BASE_URL?: string
+}
+
+export function buildFleetPackageErrorRateConcentrationQuery(input: {
+	dataset: string
+	recentStart: Date
+	recentEnd: Date
+}) {
+	const metrics = fleetPackageErrorRateMetrics
+		.map((metric) => `'${metric}'`)
+		.join(', ')
+	return `
+SELECT
+	blob1 AS user_id,
+	blob3 AS entity_id,
+	sum(_sample_interval) AS error_count
+FROM ${input.dataset}
+WHERE timestamp >= toDateTime('${toAnalyticsDateTime(input.recentStart)}')
+	AND timestamp < toDateTime('${toAnalyticsDateTime(input.recentEnd)}')
+	AND blob2 IN (${metrics})
+	AND blob4 = 'error'
+GROUP BY user_id, entity_id
+ORDER BY error_count DESC
+LIMIT 50
+FORMAT JSON
+`.trim()
+}
+
+export function foldFleetPackageErrorRateConcentrationRows(
+	rows: ReadonlyArray<FleetPackageErrorRateConcentrationRow>,
+) {
+	const errorsByOwner = new Map<
+		string,
+		{ errors: number; entityIds: Map<string, number> }
+	>()
+	let recentErrors = 0
+	const packageIds = new Set<string>()
+	for (const row of rows) {
+		const ownerId = row.user_id?.trim() ?? ''
+		if (ownerId.length === 0) continue
+		const errors = Math.max(0, Math.round(Number(row.error_count ?? 0)))
+		if (errors <= 0) continue
+		recentErrors += errors
+		const existing = errorsByOwner.get(ownerId) ?? {
+			errors: 0,
+			entityIds: new Map<string, number>(),
+		}
+		existing.errors += errors
+		const entityId = row.entity_id?.trim() ?? ''
+		if (entityId.length > 0) {
+			existing.entityIds.set(
+				entityId,
+				(existing.entityIds.get(entityId) ?? 0) + errors,
+			)
+			packageIds.add(entityId)
+		}
+		errorsByOwner.set(ownerId, existing)
+	}
+	const ranked = [...errorsByOwner.entries()]
+		.map(([ownerId, owner]) => ({
+			ownerId,
+			errors: owner.errors,
+			entityIds: [...owner.entityIds.entries()]
+				.sort((left, right) => right[1] - left[1])
+				.map(([entityId]) => entityId),
+		}))
+		.sort((left, right) => right.errors - left.errors)
+	const topOwnerShare =
+		recentErrors === 0 ? 0 : (ranked[0]?.errors ?? 0) / recentErrors
+	const topFewShare =
+		recentErrors === 0
+			? 0
+			: ranked
+					.slice(0, fleetPackageErrorRateFewAccountLimit)
+					.reduce((sum, owner) => sum + owner.errors, 0) / recentErrors
+	return {
+		recentErrors,
+		ownerCount: ranked.length,
+		packageCount: packageIds.size,
+		topOwnerShare,
+		topFewShare,
+		ranked,
+	}
+}
+
+export async function resolveFleetPackageErrorRateConcentration(input: {
+	env: FleetPackageErrorRateConcentrationQueryEnv
+	dataset: string
+	recentStart: Date
+	recentEnd: Date
+}): Promise<FleetPackageErrorRateConcentration | null> {
+	const accountId = input.env.CLOUDFLARE_ACCOUNT_ID?.trim()
+	const apiToken = input.env.CLOUDFLARE_API_TOKEN?.trim()
+	if (!accountId || !apiToken) return null
+	const baseUrl =
+		input.env.CLOUDFLARE_API_BASE_URL?.trim() || 'https://api.cloudflare.com'
+	let rows: Array<FleetPackageErrorRateConcentrationRow>
+	try {
+		rows = await queryAnalyticsEngineSql<FleetPackageErrorRateConcentrationRow>(
+			{
+				accountId,
+				apiToken,
+				baseUrl,
+				query: buildFleetPackageErrorRateConcentrationQuery({
+					dataset: input.dataset,
+					recentStart: input.recentStart,
+					recentEnd: input.recentEnd,
+				}),
+			},
+		)
+	} catch (error) {
+		console.warn('fleet-package-error-rate-concentration-query-failed', error)
+		return null
+	}
+	const folded = foldFleetPackageErrorRateConcentrationRows(rows)
+	if (folded.recentErrors === 0) return null
+	const kind = classifyFleetPackageErrorRateConcentrationKind({
+		topOwnerShare: folded.topOwnerShare,
+		topFewShare: folded.topFewShare,
+	})
+	let named: FleetPackageErrorRateConcentration['owners'] = []
+	if (kind !== 'fleet') {
+		try {
+			named = await resolveNamedOwners({
+				db: input.env.APP_DB,
+				owners: folded.ranked.slice(0, fleetPackageErrorRateMaxNamedOwners),
+				recentErrors: folded.recentErrors,
+			})
+		} catch (error) {
+			console.warn('fleet-package-error-rate-concentration-names-failed', error)
+		}
+	}
+	return {
+		kind,
+		recent_errors: folded.recentErrors,
+		owner_count: folded.ownerCount,
+		package_count: folded.packageCount,
+		top_owner_share: folded.topOwnerShare,
+		owners: named,
+	}
+}
+
+export function parseFleetPackageErrorRateConcentration(
+	value: unknown,
+): FleetPackageErrorRateConcentration | null {
+	if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+	const record = value as Record<string, unknown>
+	if (
+		typeof record.kind !== 'string' ||
+		!isFleetPackageErrorRateConcentrationKind(record.kind) ||
+		typeof record.recent_errors !== 'number' ||
+		typeof record.owner_count !== 'number' ||
+		typeof record.package_count !== 'number' ||
+		typeof record.top_owner_share !== 'number' ||
+		!Array.isArray(record.owners)
+	) {
+		return null
+	}
+	const owners: Array<FleetPackageErrorRateConcentration['owners'][number]> = []
+	for (const entry of record.owners) {
+		if (!entry || typeof entry !== 'object' || Array.isArray(entry)) continue
+		const owner = entry as Record<string, unknown>
+		if (
+			typeof owner.username !== 'string' ||
+			owner.username.trim().length === 0 ||
+			typeof owner.error_share !== 'number' ||
+			!Array.isArray(owner.packages)
+		) {
+			continue
+		}
+		const packages: Array<{ kody_id: string }> = []
+		for (const pkg of owner.packages) {
+			if (!pkg || typeof pkg !== 'object' || Array.isArray(pkg)) continue
+			const row = pkg as Record<string, unknown>
+			if (typeof row.kody_id === 'string' && row.kody_id.trim().length > 0) {
+				packages.push({ kody_id: row.kody_id.trim() })
+			}
+		}
+		owners.push({
+			username: owner.username.trim(),
+			error_share: owner.error_share,
+			packages,
+		})
+	}
+	return {
+		kind: record.kind,
+		recent_errors: record.recent_errors,
+		owner_count: record.owner_count,
+		package_count: record.package_count,
+		top_owner_share: record.top_owner_share,
+		owners,
+	}
+}
+
+async function resolveNamedOwners(input: {
+	db: D1Database | undefined
+	owners: Array<{
+		ownerId: string
+		errors: number
+		entityIds: Array<string>
+	}>
+	recentErrors: number
+}): Promise<FleetPackageErrorRateConcentration['owners']> {
+	if (!input.db || input.owners.length === 0) return []
+	const usernames = await loadUsernames(
+		input.db,
+		input.owners.map((owner) => owner.ownerId),
+	)
+	const packageIds = input.owners.flatMap((owner) => owner.entityIds)
+	const packages = await loadPackageKodyIds(input.db, packageIds)
+	const named: FleetPackageErrorRateConcentration['owners'] = []
+	for (const owner of input.owners) {
+		const username = usernames.get(owner.ownerId)
+		if (!username) continue
+		named.push({
+			username,
+			error_share: owner.errors / input.recentErrors,
+			packages: owner.entityIds
+				.map((entityId) => packages.get(entityId))
+				.filter((kodyId): kodyId is string => kodyId != null)
+				.slice(0, fleetPackageErrorRateMaxNamedPackages)
+				.map((kody_id) => ({ kody_id })),
+		})
+	}
+	return named
+}
+
+async function loadUsernames(db: D1Database, ownerIds: Array<string>) {
+	const usernames = new Map<string, string>()
+	for (const chunk of chunkArray(ownerIds, maxSqlBindingsPerChunk)) {
+		if (chunk.length === 0) continue
+		const placeholders = chunk.map(() => '?').join(', ')
+		const result = await db
+			.prepare(
+				`SELECT stable_user_id, username
+				FROM users
+				WHERE deleting_at IS NULL
+					AND stable_user_id IN (${placeholders})`,
+			)
+			.bind(...chunk)
+			.all<{ stable_user_id: string; username: string }>()
+		for (const row of result.results ?? []) {
+			const username = row.username.trim()
+			if (username.length === 0) continue
+			usernames.set(row.stable_user_id, username)
+		}
+	}
+	return usernames
+}
+
+async function loadPackageKodyIds(db: D1Database, packageIds: Array<string>) {
+	const kodyIds = new Map<string, string>()
+	for (const chunk of chunkArray(packageIds, maxSqlBindingsPerChunk)) {
+		if (chunk.length === 0) continue
+		const placeholders = chunk.map(() => '?').join(', ')
+		const result = await db
+			.prepare(
+				`SELECT id, kody_id
+				FROM saved_packages
+				WHERE id IN (${placeholders})`,
+			)
+			.bind(...chunk)
+			.all<{ id: string; kody_id: string }>()
+		for (const row of result.results ?? []) {
+			const kodyId = row.kody_id.trim()
+			if (kodyId.length === 0) continue
+			kodyIds.set(row.id, kodyId)
+		}
+	}
+	return kodyIds
+}
+
+function toAnalyticsDateTime(date: Date) {
+	return date.toISOString().slice(0, 19).replace('T', ' ')
+}

--- a/packages/worker/src/usage/fleet-package-error-rate-concentration.ts
+++ b/packages/worker/src/usage/fleet-package-error-rate-concentration.ts
@@ -11,6 +11,8 @@ import { queryAnalyticsEngineSql } from './aggregate-rollups.ts'
 import { fleetPackageErrorRateMetrics } from './fleet-package-error-rate-subscription-event.ts'
 
 const maxSqlBindingsPerChunk = 90
+const maxRankedOwners = 50
+const analyticsEngineIdPattern = /^[A-Za-z0-9:._-]+$/
 
 export type FleetPackageErrorRateConcentrationRow = {
 	user_id?: string
@@ -25,46 +27,78 @@ export type FleetPackageErrorRateConcentrationQueryEnv = {
 	CLOUDFLARE_API_BASE_URL?: string
 }
 
+type RankedOwner = {
+	ownerId: string
+	errors: number
+	entityIds: Array<string>
+}
+
 export function buildFleetPackageErrorRateConcentrationQuery(input: {
 	dataset: string
 	recentStart: Date
 	recentEnd: Date
 }) {
-	const metrics = fleetPackageErrorRateMetrics
-		.map((metric) => `'${metric}'`)
+	return `
+SELECT
+	blob1 AS user_id,
+	sum(_sample_interval) AS error_count
+FROM ${input.dataset}
+WHERE ${concentrationWhereClause(input)}
+GROUP BY user_id
+ORDER BY error_count DESC
+LIMIT ${maxRankedOwners}
+FORMAT JSON
+`.trim()
+}
+
+export function buildFleetPackageErrorRateConcentrationPackageQuery(input: {
+	dataset: string
+	recentStart: Date
+	recentEnd: Date
+	ownerIds: ReadonlyArray<string>
+}) {
+	const ownerList = input.ownerIds
+		.filter((ownerId) => analyticsEngineIdPattern.test(ownerId))
+		.map((ownerId) => `'${ownerId}'`)
 		.join(', ')
+	if (ownerList.length === 0) return null
+	const packageLimit =
+		fleetPackageErrorRateMaxNamedOwners * fleetPackageErrorRateMaxNamedPackages
 	return `
 SELECT
 	blob1 AS user_id,
 	blob3 AS entity_id,
 	sum(_sample_interval) AS error_count
 FROM ${input.dataset}
-WHERE timestamp >= toDateTime('${toAnalyticsDateTime(input.recentStart)}')
-	AND timestamp < toDateTime('${toAnalyticsDateTime(input.recentEnd)}')
-	AND blob2 IN (${metrics})
-	AND blob4 = 'error'
+WHERE ${concentrationWhereClause(input)}
+	AND blob1 IN (${ownerList})
 GROUP BY user_id, entity_id
 ORDER BY error_count DESC
-LIMIT 50
+LIMIT ${packageLimit}
 FORMAT JSON
 `.trim()
 }
 
+/**
+ * Rank owners from the owner-only AE rows. Shares use the anonymous
+ * window error total so a truncated owner sample cannot inflate
+ * `one_account` / `few_accounts`.
+ */
 export function foldFleetPackageErrorRateConcentrationRows(
 	rows: ReadonlyArray<FleetPackageErrorRateConcentrationRow>,
+	recentErrors: number,
 ) {
+	const windowErrors = Math.max(0, Math.round(recentErrors))
 	const errorsByOwner = new Map<
 		string,
 		{ errors: number; entityIds: Map<string, number> }
 	>()
-	let recentErrors = 0
 	const packageIds = new Set<string>()
 	for (const row of rows) {
 		const ownerId = row.user_id?.trim() ?? ''
 		if (ownerId.length === 0) continue
 		const errors = Math.max(0, Math.round(Number(row.error_count ?? 0)))
 		if (errors <= 0) continue
-		recentErrors += errors
 		const existing = errorsByOwner.get(ownerId) ?? {
 			errors: 0,
 			entityIds: new Map<string, number>(),
@@ -89,20 +123,18 @@ export function foldFleetPackageErrorRateConcentrationRows(
 				.map(([entityId]) => entityId),
 		}))
 		.sort((left, right) => right.errors - left.errors)
-	const topOwnerShare =
-		recentErrors === 0 ? 0 : (ranked[0]?.errors ?? 0) / recentErrors
-	const topFewShare =
-		recentErrors === 0
-			? 0
-			: ranked
-					.slice(0, fleetPackageErrorRateFewAccountLimit)
-					.reduce((sum, owner) => sum + owner.errors, 0) / recentErrors
+	const share = (errors: number) =>
+		windowErrors === 0 ? 0 : Math.min(1, errors / windowErrors)
 	return {
-		recentErrors,
+		recentErrors: windowErrors,
 		ownerCount: ranked.length,
 		packageCount: packageIds.size,
-		topOwnerShare,
-		topFewShare,
+		topOwnerShare: share(ranked[0]?.errors ?? 0),
+		topFewShare: share(
+			ranked
+				.slice(0, fleetPackageErrorRateFewAccountLimit)
+				.reduce((sum, owner) => sum + owner.errors, 0),
+		),
 		ranked,
 	}
 }
@@ -112,16 +144,19 @@ export async function resolveFleetPackageErrorRateConcentration(input: {
 	dataset: string
 	recentStart: Date
 	recentEnd: Date
+	recentErrors: number
 }): Promise<FleetPackageErrorRateConcentration | null> {
 	const accountId = input.env.CLOUDFLARE_ACCOUNT_ID?.trim()
 	const apiToken = input.env.CLOUDFLARE_API_TOKEN?.trim()
 	if (!accountId || !apiToken) return null
+	const windowErrors = Math.max(0, Math.round(input.recentErrors))
+	if (windowErrors === 0) return null
 	const baseUrl =
 		input.env.CLOUDFLARE_API_BASE_URL?.trim() || 'https://api.cloudflare.com'
-	let rows: Array<FleetPackageErrorRateConcentrationRow>
+	let ownerRows: Array<FleetPackageErrorRateConcentrationRow>
 	try {
-		rows = await queryAnalyticsEngineSql<FleetPackageErrorRateConcentrationRow>(
-			{
+		ownerRows =
+			await queryAnalyticsEngineSql<FleetPackageErrorRateConcentrationRow>({
 				accountId,
 				apiToken,
 				baseUrl,
@@ -130,24 +165,45 @@ export async function resolveFleetPackageErrorRateConcentration(input: {
 					recentStart: input.recentStart,
 					recentEnd: input.recentEnd,
 				}),
-			},
-		)
+			})
 	} catch (error) {
 		console.warn('fleet-package-error-rate-concentration-query-failed', error)
 		return null
 	}
-	const folded = foldFleetPackageErrorRateConcentrationRows(rows)
-	if (folded.recentErrors === 0) return null
+	const folded = foldFleetPackageErrorRateConcentrationRows(
+		ownerRows,
+		windowErrors,
+	)
+	if (folded.ranked.length === 0) return null
 	const kind = classifyFleetPackageErrorRateConcentrationKind({
 		topOwnerShare: folded.topOwnerShare,
 		topFewShare: folded.topFewShare,
 	})
+	const namedOwners = folded.ranked.slice(
+		0,
+		fleetPackageErrorRateMaxNamedOwners,
+	)
+	if (kind !== 'fleet') {
+		const packageRows = await loadOwnerPackageRows({
+			accountId,
+			apiToken,
+			baseUrl,
+			dataset: input.dataset,
+			recentStart: input.recentStart,
+			recentEnd: input.recentEnd,
+			ownerIds: namedOwners.map((owner) => owner.ownerId),
+		})
+		attachOwnerPackages(namedOwners, packageRows)
+		folded.packageCount = new Set(
+			namedOwners.flatMap((owner) => owner.entityIds),
+		).size
+	}
 	let named: FleetPackageErrorRateConcentration['owners'] = []
 	if (kind !== 'fleet') {
 		try {
 			named = await resolveNamedOwners({
 				db: input.env.APP_DB,
-				owners: folded.ranked.slice(0, fleetPackageErrorRateMaxNamedOwners),
+				owners: namedOwners,
 				recentErrors: folded.recentErrors,
 			})
 		} catch (error) {
@@ -218,11 +274,7 @@ export function parseFleetPackageErrorRateConcentration(
 
 async function resolveNamedOwners(input: {
 	db: D1Database | undefined
-	owners: Array<{
-		ownerId: string
-		errors: number
-		entityIds: Array<string>
-	}>
+	owners: Array<RankedOwner>
 	recentErrors: number
 }): Promise<FleetPackageErrorRateConcentration['owners']> {
 	if (!input.db || input.owners.length === 0) return []
@@ -238,7 +290,7 @@ async function resolveNamedOwners(input: {
 		if (!username) continue
 		named.push({
 			username,
-			error_share: owner.errors / input.recentErrors,
+			error_share: Math.min(1, owner.errors / input.recentErrors),
 			packages: owner.entityIds
 				.map((entityId) => packages.get(entityId))
 				.filter((kodyId): kodyId is string => kodyId != null)
@@ -247,6 +299,58 @@ async function resolveNamedOwners(input: {
 		})
 	}
 	return named
+}
+
+async function loadOwnerPackageRows(input: {
+	accountId: string
+	apiToken: string
+	baseUrl: string
+	dataset: string
+	recentStart: Date
+	recentEnd: Date
+	ownerIds: ReadonlyArray<string>
+}) {
+	const query = buildFleetPackageErrorRateConcentrationPackageQuery(input)
+	if (!query) return []
+	try {
+		return await queryAnalyticsEngineSql<FleetPackageErrorRateConcentrationRow>(
+			{
+				accountId: input.accountId,
+				apiToken: input.apiToken,
+				baseUrl: input.baseUrl,
+				query,
+			},
+		)
+	} catch (error) {
+		console.warn(
+			'fleet-package-error-rate-concentration-packages-failed',
+			error,
+		)
+		return []
+	}
+}
+
+function attachOwnerPackages(
+	owners: Array<RankedOwner>,
+	rows: ReadonlyArray<FleetPackageErrorRateConcentrationRow>,
+) {
+	const entityIdsByOwner = new Map<string, Map<string, number>>()
+	for (const row of rows) {
+		const ownerId = row.user_id?.trim() ?? ''
+		const entityId = row.entity_id?.trim() ?? ''
+		const errors = Math.max(0, Math.round(Number(row.error_count ?? 0)))
+		if (ownerId.length === 0 || entityId.length === 0 || errors <= 0) continue
+		const existing = entityIdsByOwner.get(ownerId) ?? new Map<string, number>()
+		existing.set(entityId, (existing.get(entityId) ?? 0) + errors)
+		entityIdsByOwner.set(ownerId, existing)
+	}
+	for (const owner of owners) {
+		const packages = entityIdsByOwner.get(owner.ownerId)
+		if (!packages) continue
+		owner.entityIds = [...packages.entries()]
+			.sort((left, right) => right[1] - left[1])
+			.map(([entityId]) => entityId)
+	}
 }
 
 async function loadUsernames(db: D1Database, ownerIds: Array<string>) {
@@ -292,6 +396,19 @@ async function loadPackageKodyIds(db: D1Database, packageIds: Array<string>) {
 		}
 	}
 	return kodyIds
+}
+
+function concentrationWhereClause(input: {
+	recentStart: Date
+	recentEnd: Date
+}) {
+	const metrics = fleetPackageErrorRateMetrics
+		.map((metric) => `'${metric}'`)
+		.join(', ')
+	return `timestamp >= toDateTime('${toAnalyticsDateTime(input.recentStart)}')
+	AND timestamp < toDateTime('${toAnalyticsDateTime(input.recentEnd)}')
+	AND blob2 IN (${metrics})
+	AND blob4 = 'error'`
 }
 
 function toAnalyticsDateTime(date: Date) {

--- a/packages/worker/src/usage/fleet-package-error-rate-subscription-event.ts
+++ b/packages/worker/src/usage/fleet-package-error-rate-subscription-event.ts
@@ -1,3 +1,7 @@
+import { type FleetPackageErrorRateConcentration } from '#universal/fleet-package-error-rate-concentration.ts'
+
+export type { FleetPackageErrorRateConcentration }
+
 export const fleetPackageErrorRateElevatedTopic =
 	'fleet.package_error_rate.elevated'
 
@@ -59,6 +63,7 @@ export type FleetPackageErrorRateElevatedEvent = {
 		previous: FleetPackageErrorRateWindowSnapshot
 	}
 	by_metric: FleetPackageErrorRateWindowSnapshot['by_metric']
+	concentration: FleetPackageErrorRateConcentration | null
 }
 
 export function isFleetPackageErrorRateEventTopic(
@@ -79,6 +84,7 @@ export function buildFleetPackageErrorRateElevatedEvent(input: {
 	reason: FleetPackageErrorRateElevationReason
 	recent: FleetPackageErrorRateWindowSnapshot
 	previous: FleetPackageErrorRateWindowSnapshot
+	concentration?: FleetPackageErrorRateConcentration | null
 }): FleetPackageErrorRateElevatedEvent {
 	return {
 		event: fleetPackageErrorRateElevatedTopic,
@@ -94,6 +100,7 @@ export function buildFleetPackageErrorRateElevatedEvent(input: {
 			previous: input.previous,
 		},
 		by_metric: input.recent.by_metric,
+		concentration: input.concentration ?? null,
 	}
 }
 

--- a/packages/worker/src/usage/fleet-package-error-rate-subscriptions.node.test.ts
+++ b/packages/worker/src/usage/fleet-package-error-rate-subscriptions.node.test.ts
@@ -107,6 +107,7 @@ test('fleet package error-rate dispatch fans metadata-only events through admin 
 			actorTokenId: 'internal:fleet-package-error-rate-subscriptions',
 		},
 	})
+	expect(event.concentration).toBeNull()
 	expect(JSON.stringify(result[0]?.params)).not.toContain('user_id')
 	expect(JSON.stringify(result[0]?.params)).not.toContain('error_message')
 })

--- a/packages/worker/src/usage/fleet-package-error-rate-subscriptions.ts
+++ b/packages/worker/src/usage/fleet-package-error-rate-subscriptions.ts
@@ -9,7 +9,7 @@ const fleetPackageErrorRateSubscriptionActorTokenId =
 	'internal:fleet-package-error-rate-subscriptions'
 
 /**
- * Fans a content-free fleet package error-rate elevation to admin-owned
+ * Fans a fleet package error-rate elevation to admin-owned
  * packages that declare `fleet.package_error_rate.elevated`. Best-effort: the
  * KV snapshot is already written, and a missed invoke is logged rather than
  * failing usage aggregation.

--- a/packages/worker/src/usage/fleet-package-error-rate.node.test.ts
+++ b/packages/worker/src/usage/fleet-package-error-rate.node.test.ts
@@ -178,6 +178,41 @@ test('fleet package error-rate detection stays anonymous and prefers day rises',
 		}),
 	).toBeNull()
 	expect(
+		parseFleetPackageErrorRateSnapshot({
+			version: 1,
+			updatedAt: '2026-08-22T19:00:00.000Z',
+			environment: 'production',
+			day: windowOf({
+				kind: 'day',
+				recentEvents: 80,
+				recentErrors: 16,
+				previousEvents: 80,
+				previousErrors: 2,
+			}),
+			hour: windowOf({
+				kind: 'hour',
+				recentEvents: 40,
+				recentErrors: 2,
+				previousEvents: 40,
+				previousErrors: 1,
+			}),
+			concentration: {
+				kind: 'one_account',
+				recent_errors: 90,
+				owner_count: 1,
+				package_count: 1,
+				top_owner_share: 1,
+				owners: [
+					{
+						username: 'jett',
+						error_share: 1,
+						packages: [{ kody_id: 'dji-cloud-relay-staging-deploy' }],
+					},
+				],
+			},
+		})?.concentration,
+	).toMatchObject({ kind: 'one_account', owners: [{ username: 'jett' }] })
+	expect(
 		alignToUtcHour(new Date('2026-08-22T19:32:11.123Z')).toISOString(),
 	).toBe('2026-08-22T19:00:00.000Z')
 })

--- a/packages/worker/src/usage/fleet-package-error-rate.ts
+++ b/packages/worker/src/usage/fleet-package-error-rate.ts
@@ -3,7 +3,12 @@ import {
 	resolveUsageEventsDataset,
 } from './aggregate-rollups.ts'
 import {
+	parseFleetPackageErrorRateConcentration,
+	resolveFleetPackageErrorRateConcentration,
+} from './fleet-package-error-rate-concentration.ts'
+import {
 	fleetPackageErrorRateMetrics,
+	type FleetPackageErrorRateConcentration,
 	type FleetPackageErrorRateCounts,
 	type FleetPackageErrorRateElevationReason,
 	type FleetPackageErrorRateMetric,
@@ -52,6 +57,12 @@ export type FleetPackageErrorRateSnapshot = {
 	hour: FleetPackageErrorRateComparison
 	lastAlertAt: string | null
 	lastAlertEventId: string | null
+	/**
+	 * Who owns the recent-window error spike. Null when the rate is not
+	 * elevated, the concentration query failed, or owners could not be
+	 * resolved. Never includes user ids, emails, or package UUIDs.
+	 */
+	concentration: FleetPackageErrorRateConcentration | null
 }
 
 export type FleetPackageErrorRateElevation = {
@@ -203,6 +214,9 @@ export function parseFleetPackageErrorRateSnapshot(
 			typeof record.lastAlertEventId === 'string'
 				? record.lastAlertEventId
 				: null,
+		concentration: parseFleetPackageErrorRateConcentration(
+			record.concentration,
+		),
 	}
 }
 
@@ -357,8 +371,10 @@ export type FleetPackageErrorRateSnapshotResult =
 	  }
 
 /**
- * Recompute anonymous fleet package-runtime error rates from Analytics
- * Engine and persist the content-free KV snapshot for `/admin/insights`.
+ * Recompute fleet package-runtime error rates from Analytics Engine and
+ * persist the KV snapshot for `/admin/insights`. Totals stay anonymous;
+ * an elevated refresh may attach named concentration (usernames and
+ * package kody ids only).
  */
 export async function refreshFleetPackageErrorRateSnapshot(input: {
 	env: FleetPackageErrorRateEnv
@@ -458,6 +474,7 @@ export async function refreshFleetPackageErrorRateSnapshot(input: {
 		}),
 	}
 
+	const elevation = chooseFleetPackageErrorRateElevation({ hour, day })
 	const snapshot: FleetPackageErrorRateSnapshot = {
 		version: 1,
 		updatedAt: now.toISOString(),
@@ -466,11 +483,37 @@ export async function refreshFleetPackageErrorRateSnapshot(input: {
 		hour,
 		lastAlertAt: existing?.lastAlertAt ?? null,
 		lastAlertEventId: existing?.lastAlertEventId ?? null,
+		concentration: elevation
+			? await resolveElevatedConcentration({
+					env: input.env,
+					dataset,
+					recentStart: elevation.comparison.recent.start,
+					recentEnd: elevation.comparison.recent.end,
+				})
+			: null,
 	}
 
-	const elevation = chooseFleetPackageErrorRateElevation({ hour, day })
 	await writeFleetPackageErrorRateSnapshot(kv, snapshot)
 	return { status: 'refreshed', snapshot, elevation }
+}
+
+async function resolveElevatedConcentration(input: {
+	env: FleetPackageErrorRateEnv
+	dataset: string
+	recentStart: string
+	recentEnd: string
+}): Promise<FleetPackageErrorRateConcentration | null> {
+	try {
+		return await resolveFleetPackageErrorRateConcentration({
+			env: input.env,
+			dataset: input.dataset,
+			recentStart: new Date(input.recentStart),
+			recentEnd: new Date(input.recentEnd),
+		})
+	} catch (error) {
+		console.warn('fleet-package-error-rate-concentration-failed', error)
+		return null
+	}
 }
 
 export async function writeFleetPackageErrorRateSnapshot(

--- a/packages/worker/src/usage/fleet-package-error-rate.ts
+++ b/packages/worker/src/usage/fleet-package-error-rate.ts
@@ -489,6 +489,7 @@ export async function refreshFleetPackageErrorRateSnapshot(input: {
 					dataset,
 					recentStart: elevation.comparison.recent.start,
 					recentEnd: elevation.comparison.recent.end,
+					recentErrors: elevation.comparison.recent.combined.errors,
 				})
 			: null,
 	}
@@ -502,6 +503,7 @@ async function resolveElevatedConcentration(input: {
 	dataset: string
 	recentStart: string
 	recentEnd: string
+	recentErrors: number
 }): Promise<FleetPackageErrorRateConcentration | null> {
 	try {
 		return await resolveFleetPackageErrorRateConcentration({
@@ -509,6 +511,7 @@ async function resolveElevatedConcentration(input: {
 			dataset: input.dataset,
 			recentStart: new Date(input.recentStart),
 			recentEnd: new Date(input.recentEnd),
+			recentErrors: input.recentErrors,
 		})
 	} catch (error) {
 		console.warn('fleet-package-error-rate-concentration-failed', error)

--- a/packages/worker/universal/fleet-package-error-rate-concentration.ts
+++ b/packages/worker/universal/fleet-package-error-rate-concentration.ts
@@ -1,0 +1,107 @@
+export const fleetPackageErrorRateConcentrationKinds = [
+	'one_account',
+	'few_accounts',
+	'fleet',
+] as const
+
+export type FleetPackageErrorRateConcentrationKind =
+	(typeof fleetPackageErrorRateConcentrationKinds)[number]
+
+/** Share of recent-window errors that counts as concentrated. */
+export const fleetPackageErrorRateConcentrationShare = 0.8
+
+/** How many leading accounts can still count as "a few" rather than fleet-wide. */
+export const fleetPackageErrorRateFewAccountLimit = 3
+
+export const fleetPackageErrorRateMaxNamedOwners = 3
+export const fleetPackageErrorRateMaxNamedPackages = 5
+
+export type FleetPackageErrorRateConcentrationPackage = {
+	kody_id: string
+}
+
+export type FleetPackageErrorRateConcentrationOwner = {
+	username: string
+	error_share: number
+	packages: Array<FleetPackageErrorRateConcentrationPackage>
+}
+
+/**
+ * Operator-facing concentration of a fleet error-rate elevation.
+ * Names usernames and package kody ids only — no emails, user ids, or
+ * package UUIDs.
+ */
+export type FleetPackageErrorRateConcentration = {
+	kind: FleetPackageErrorRateConcentrationKind
+	recent_errors: number
+	owner_count: number
+	package_count: number
+	top_owner_share: number
+	owners: Array<FleetPackageErrorRateConcentrationOwner>
+}
+
+export function isFleetPackageErrorRateConcentrationKind(
+	value: string,
+): value is FleetPackageErrorRateConcentrationKind {
+	return (
+		fleetPackageErrorRateConcentrationKinds as ReadonlyArray<string>
+	).includes(value)
+}
+
+export function classifyFleetPackageErrorRateConcentrationKind(input: {
+	topOwnerShare: number
+	topFewShare: number
+}): FleetPackageErrorRateConcentrationKind {
+	if (input.topOwnerShare >= fleetPackageErrorRateConcentrationShare) {
+		return 'one_account'
+	}
+	if (input.topFewShare >= fleetPackageErrorRateConcentrationShare) {
+		return 'few_accounts'
+	}
+	return 'fleet'
+}
+
+export function formatFleetPackageErrorRateConcentration(
+	concentration: FleetPackageErrorRateConcentration,
+): string {
+	const topPercent = formatSharePercent(concentration.top_owner_share)
+	switch (concentration.kind) {
+		case 'one_account': {
+			const owner = formatOwnerList(concentration.owners)
+			return owner.length > 0
+				? `One account owns ${topPercent} of recent errors (${owner}).`
+				: `One account owns ${topPercent} of recent errors.`
+		}
+		case 'few_accounts': {
+			const owners = formatOwnerList(concentration.owners)
+			return owners.length > 0
+				? `A few accounts own most recent errors (top owner ${topPercent}: ${owners}).`
+				: `A few accounts own most recent errors (top owner ${topPercent}).`
+		}
+		case 'fleet':
+			return `Errors are spread across the fleet (top owner ${topPercent}).`
+		default: {
+			const exhaustive: never = concentration.kind
+			throw new Error(
+				`Unhandled fleet package error-rate concentration kind: ${exhaustive}`,
+			)
+		}
+	}
+}
+
+function formatSharePercent(share: number) {
+	return `${Math.round(share * 100)}%`
+}
+
+function formatOwnerList(
+	owners: ReadonlyArray<FleetPackageErrorRateConcentrationOwner>,
+) {
+	return owners
+		.map((owner) => {
+			const packages = owner.packages.map((pkg) => pkg.kody_id).join(', ')
+			return packages.length > 0
+				? `${owner.username}: ${packages}`
+				: owner.username
+		})
+		.join('; ')
+}

--- a/packages/worker/universal/loader-data.ts
+++ b/packages/worker/universal/loader-data.ts
@@ -34,6 +34,7 @@ import {
 	type AccountActivityTriageFilter,
 	type AccountActivityViewFilter,
 } from '#universal/account-activity-filters.ts'
+import { type FleetPackageErrorRateConcentration } from '#universal/fleet-package-error-rate-concentration.ts'
 
 export type { ProfileVisibility }
 export type { AdminFeatureFlag }
@@ -725,7 +726,7 @@ export type AdminInsightsPackageErrorRateComparison = {
 	previous: AdminInsightsPackageErrorRateWindow
 }
 
-/** Content-free fleet package-runtime error rates. Missing when AE/KV is empty. */
+/** Fleet package-runtime error rates. Missing when AE/KV is empty. */
 export type AdminInsightsPackageErrorRate = {
 	available: boolean
 	updatedAt: string | null
@@ -733,6 +734,7 @@ export type AdminInsightsPackageErrorRate = {
 	day: AdminInsightsPackageErrorRateComparison | null
 	hour: AdminInsightsPackageErrorRateComparison | null
 	lastAlertAt: string | null
+	concentration: FleetPackageErrorRateConcentration | null
 }
 
 export type AdminInsightsLoaderData = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Close #1982: when `fleet.package_error_rate.elevated` fires because one account (or a few) own the recent-window errors, the page must name those owners so it does not look like a fleet outage.

## Why

The 2026-09-01 jett staging-deploy storm was almost entirely one user retrying three packages. The fleet alert still paged correctly, but the copy and insights card looked like kody itself was failing. A true multi-user spike should stay fleet-wide; a concentrated spike should still page the fleet and say who owns it.

## Summary

- After an elevation, a second Analytics Engine query ranks owners of recent-window errors. Shares use the anonymous window error total so a truncated sample cannot look like one account. ≥80% from one account is `one_account`; ≥80% from the top three is `few_accounts`; otherwise `fleet`.
- Package ids load per named owner (not one global LIMIT). D1 resolves usernames and `kody_id`s. The event, KV snapshot, and `/admin/insights` never include user ids, package UUIDs, emails, or error strings.
- Fan-out, cooldown, and who gets paged are unchanged. A failed concentration query still pages with `concentration: null`.
- Privacy, subscription, and architecture docs match the new payload.

## Testing

- Focused node-unit plus `test:push` on each commit.
- `npm run validate` green on the first commit (typecheck, lint, knip, startup budgets, e2e, mcp).
- Preview `https://kody-pr-1990.kody-a99.workers.dev`: privacy copy names usernames + kody ids; seed login works; `/admin` and `/admin/insights` stay 403.
- Addressed Bugbot/CodeRabbit: window-total shares, then per-owner package queries.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `a89a32eb` · **Head:** `b8291a12`

**Classification:** extends — `fleet.package_error_rate.elevated` and the insights snapshot gain an optional named-concentration contract.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `usage-metering` | storage | extends — owner-rank AE query after elevation; shares use the window error total; per-owner package query; event and KV snapshot may name usernames + kody ids |
| `app-ui` | surfaces | extends — insights card and privacy copy surface concentration |
| `d1-app-db` | storage | composes — username / kody_id lookup only when concentrated |

`email-reporting` matched because `admin-insights-data.ts` is one of its roots; this PR only maps concentration onto the existing insights payload.

### Change flow

Hourly usage aggregation still pages the fleet; a concentrated spike adds owner names on the same event.

```mermaid
sequenceDiagram
	participant usageMetering as usage-metering
	participant d1AppDb as d1-app-db
	participant appUi as app-ui
	usageMetering->>usageMetering: anonymous hour/day AE totals
	alt combined rate elevated
		usageMetering->>usageMetering: rank owners of recent errors
		Note over usageMetering: shares use the window error total
		usageMetering->>usageMetering: load package ids per named owner
		usageMetering->>d1AppDb: resolve usernames and kody_ids
		Note over usageMetering: owners stay empty on fleet or lookup miss
		usageMetering->>usageMetering: fan fleet.package_error_rate.elevated with concentration
	end
	appUi->>usageMetering: read fleet-package-error-rate:v1
	appUi->>appUi: render named owners on /admin/insights
```

### Before / after

**Event / snapshot `concentration`**

```ts
// before
// (field absent; payload is window bounds + rates only)

// after
concentration: {
  kind: 'one_account' | 'few_accounts' | 'fleet'
  recent_errors: number
  owner_count: number
  package_count: number
  top_owner_share: number
  owners: Array<{ username: string; error_share: number; packages: Array<{ kody_id: string }> }>
} | null
```

### Invariants

Per-user isolation is unchanged: totals stay ungrouped by user; the concentration query runs only after elevation and publishes usernames + kody ids, never user ids, package UUIDs, emails, or error strings.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b2884311-ad5f-4f4a-92aa-fe9cf0ba4e5a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b2884311-ad5f-4f4a-92aa-fe9cf0ba4e5a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fleet package error-rate alerts now classify spikes as concentrated in one account, a few accounts, or spread across the fleet.
  * Admin insights display concentration details, including affected usernames and package Kody IDs when applicable.
  * Alerts include a link to related insights and continue to page the fleet for concentrated spikes.

* **Documentation**
  * Updated architecture, subscription, package, usage, and privacy documentation to reflect concentration analysis, alert behavior, and data disclosures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->