### PR TITLE
Make signup mode a runtime setting managed from the admin invites page

### DIFF
--- a/docs/contributing/adding-capabilities.md
+++ b/docs/contributing/adding-capabilities.md
@@ -237,6 +237,8 @@ rule.
 - `adminFeatureFlagList`
 - `adminFeatureFlagSet`
 - `adminFeatureFlagOverride`
+- `adminSignupModeGet`
+- `adminSignupModeSet`
 - `adminSystemEmailList`
 - `adminSystemEmailGet`
 - `adminSystemEmailSend`

--- a/docs/contributing/architecture/authentication.md
+++ b/docs/contributing/architecture/authentication.md
@@ -76,17 +76,22 @@ request so cookie signing and verification are available to handlers.
 
 ### Signup posture and invites
 
-Signup gating is controlled by the `SIGNUP_MODE` Worker var
-(`packages/worker/universal/signup-mode.ts`), read through `getSignupMode`.
-Password and social signup require a valid invite whenever the mode is not
-`open` (`invite` and `waitlist` both gate). Wrangler sets
-`SIGNUP_MODE: 'invite'` for `production` and `preview`, and `'open'` for `test`
-(Playwright / `CLOUDFLARE_ENV=test`). Local `npm run dev` defaults to the
-`production` Wrangler env (`CLOUDFLARE_ENV` defaults to `production` in
-`wrangler-env.ts`), so invite gating applies unless you point at `test`.
-`isNonProductionRuntime` is unrelated to invite gating (it still gates Kit
-waitlist soft-fail, email-send skip when no sender is configured, and similar
-non-production shortcuts).
+Signup gating is the runtime setting `resolveSignupMode` reads from
+`packages/worker/src/signup-mode-setting.ts`. A valid JSON override at the
+platform KV key `platform-settings:v1:signup-mode` wins; otherwise the
+`SIGNUP_MODE` Worker var (`packages/worker/universal/signup-mode.ts`,
+`getSignupMode`) is the default. Password and social signup require a valid
+invite whenever the resolved mode is not `open` (`invite` and `waitlist` both
+gate). Wrangler sets `SIGNUP_MODE: 'invite'` for `production` and `preview`, and
+`'open'` for `test` (Playwright / `CLOUDFLARE_ENV=test`). Local `npm run dev`
+defaults to the `production` Wrangler env (`CLOUDFLARE_ENV` defaults to
+`production` in `wrangler-env.ts`), so invite gating applies unless an admin
+override is stored or you point at `test`. Admins change the override from
+`/admin/invites` or the `adminSignupModeGet` / `adminSignupModeSet`
+capabilities. Setting `open` is refused unless both `TURNSTILE_SITE_KEY` and
+`TURNSTILE_SECRET_KEY` are configured. `isNonProductionRuntime` is unrelated to
+invite gating (it still gates Kit waitlist soft-fail, email-send skip when no
+sender is configured, and similar non-production shortcuts).
 
 The public `/signup` page defaults to a waiting-list form (first name + email)
 backed by `POST /waiting-list`, which upserts a Kit subscriber and tags them
@@ -602,9 +607,9 @@ token. The member role is assigned on connect; Standard and Pro roles follow
   first (unusable password sentinel, `password_changed_at` lockout, TOTP /
   passkeys / other `oauth_connections` / reset tokens cleared) so a squatted
   password signup cannot keep access after the real owner signs in with the
-  provider; otherwise account creation follows the signup posture
-  (`SIGNUP_MODE !== 'open'` requires a valid invite code carried from the invite
-  signup panel; the `test` env remains open without one)
+  provider; otherwise account creation follows the signup posture (resolved mode
+  other than `open` requires a valid invite code carried from the invite signup
+  panel; the `test` env remains open without one unless a KV override is set)
 - Buttons only render for providers whose client id/secret env vars are set;
   `MOCK_`-prefixed client ids activate an in-worker mock flow on non-production
   runtimes for dev and E2E tests

--- a/docs/contributing/architecture/authentication.md
+++ b/docs/contributing/architecture/authentication.md
@@ -88,10 +88,12 @@ defaults to the `production` Wrangler env (`CLOUDFLARE_ENV` defaults to
 `production` in `wrangler-env.ts`), so invite gating applies unless an admin
 override is stored or you point at `test`. Admins change the override from
 `/admin/invites` or the `adminSignupModeGet` / `adminSignupModeSet`
-capabilities. Setting `open` is refused unless both `TURNSTILE_SITE_KEY` and
-`TURNSTILE_SECRET_KEY` are configured. `isNonProductionRuntime` is unrelated to
-invite gating (it still gates Kit waitlist soft-fail, email-send skip when no
-sender is configured, and similar non-production shortcuts).
+capabilities. Writes require `expectedCurrentMode` matching the stored mode; a
+mismatch is refused so a stale tab cannot clobber a newer override. Setting
+`open` is refused unless both `TURNSTILE_SITE_KEY` and `TURNSTILE_SECRET_KEY`
+are configured. `isNonProductionRuntime` is unrelated to invite gating (it still
+gates Kit waitlist soft-fail, email-send skip when no sender is configured, and
+similar non-production shortcuts).
 
 The public `/signup` page defaults to a waiting-list form (first name + email)
 backed by `POST /waiting-list`, which upserts a Kit subscriber and tags them

--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -471,7 +471,8 @@ OAuth provider state is stored in `OAUTH_KV` through the
 snapshots, bundle artifacts, package retriever caches, and community listing
 snapshots are stored in `BUNDLE_ARTIFACTS_KV`. That binding also holds the
 platform-owned `public-code-runs:v2` delayed daily window for the homepage
-ticker.
+ticker and the platform-owned `platform-settings:v1:signup-mode` runtime signup
+gating override.
 
 - Bindings are configured in `packages/worker/wrangler.jsonc` (remote KV IDs are
   supplied at deploy time via generated Wrangler configs, not committed in the
@@ -1355,6 +1356,13 @@ app-owned keys in it. App-owned `BUNDLE_ARTIFACTS_KV` keys are:
   deletion must not remove it. Homepage GET fills the cache from D1 when the key
   is missing or `updateAt` has passed; the `usage_aggregation` lane syncs daily
   D1 rows and refreshes the triple.
+- `platform-settings:v1:signup-mode` — platform-owned runtime signup gating
+  override (`{ mode, updatedAt, updatedBy }`, where `mode` is `invite`, `open`,
+  or `waitlist` and `updatedBy` is a stable user id). Not scoped by user id;
+  account deletion must not remove it. When the key is missing or invalid,
+  `resolveSignupMode` uses the `SIGNUP_MODE` Worker var. Admins manage it from
+  `/admin/invites` and the `adminSignupModeGet` / `adminSignupModeSet`
+  capabilities.
 
 Account deletion derives these keys from D1 rows and package ids before deleting
 D1 projections. New KV prefixes must add corresponding account-deletion coverage

--- a/docs/contributing/architecture/primitives.yaml
+++ b/docs/contributing/architecture/primitives.yaml
@@ -153,6 +153,7 @@ primitives:
       - packages/worker/src/app/handlers/account-two-factor.ts
       - packages/worker/src/app/handlers/account-passkeys.ts
       - packages/worker/src/app/invites.ts
+      - packages/worker/src/signup-mode-setting.ts
       - packages/worker/src/app/email-verification.ts
       - packages/worker/src/app/onboarding-data.ts
       - packages/worker/src/app/two-factor.ts

--- a/docs/contributing/environment-variables.md
+++ b/docs/contributing/environment-variables.md
@@ -229,6 +229,17 @@ Optional Worker secrets / vars for the public `/signup` waiting-list form
 
 See [`architecture/authentication.md`](./architecture/authentication.md).
 
+## Signup mode
+
+`SIGNUP_MODE` is a public Wrangler var (`invite` / `open` / `waitlist`) that
+supplies the default when no runtime override is stored. Production and preview
+are `invite`; the Wrangler `test` env is `open` for fixtures and E2E. The
+runtime override lives in `BUNDLE_ARTIFACTS_KV` at
+`platform-settings:v1:signup-mode` and is managed from `/admin/invites` (and the
+`adminSignupModeGet` / `adminSignupModeSet` capabilities). Setting `open` is
+refused unless both `TURNSTILE_SITE_KEY` and `TURNSTILE_SECRET_KEY` are
+configured.
+
 ## Stripe billing
 
 Optional Worker secret and vars for account subscription billing

--- a/docs/contributing/project-intent.md
+++ b/docs/contributing/project-intent.md
@@ -32,12 +32,15 @@ between users.
 
 - Optimization target: a high-quality personal assistant for each individual
   signed-in user, with hard isolation between users
-- Onboarding: signup gating is the `SIGNUP_MODE` Worker var (`invite` / `open` /
-  `waitlist`). Production and preview are `invite`; the Wrangler `test` env is
-  `open` for fixtures and E2E. People without a code can join a Kit-backed
-  waiting list from `/signup`. New signups must verify their email address;
-  unverified accounts can sign in but cannot send outbound email. There is still
-  no privileged "primary user" at runtime.
+- Onboarding: signup gating is a runtime setting (`invite` / `open` /
+  `waitlist`) stored at the platform KV key `platform-settings:v1:signup-mode`,
+  with the `SIGNUP_MODE` Worker var as the default when no override is set.
+  Production and preview default to `invite`; the Wrangler `test` env defaults
+  to `open` for fixtures and E2E. Admins change the mode from `/admin/invites`.
+  People without a code can join a Kit-backed waiting list from `/signup`. New
+  signups must verify their email address; unverified accounts can sign in but
+  cannot send outbound email. There is still no privileged "primary user" at
+  runtime.
 - Tests and fixtures may seed deterministic local accounts, but seeded accounts
   are fixtures only and are not privileged at runtime
 

--- a/docs/contributing/security.md
+++ b/docs/contributing/security.md
@@ -308,6 +308,11 @@ cannot fan out across parallel paths. Covered paths (`rateLimitedAuthPaths` in
 - `POST /verify/2fa.json` and `POST /account/two-factor.json` (two-factor)
 - `POST /webauthn/authentication` (passkey authentication)
 
+Open signup requires Turnstile. `adminSignupModeSet` and
+`POST /admin/invites.json` refuse `mode=open` unless both `TURNSTILE_SITE_KEY`
+and `TURNSTILE_SECRET_KEY` are configured, so public password and social signup
+cannot be opened without bot defence.
+
 Excess requests receive `429 Too Many Requests` with a `Retry-After` header. The
 D1 approach uses a batched INSERT + COUNT in a single transaction, avoiding the
 read-then-write race that KV-backed limiters suffer under concurrency.

--- a/docs/contributing/security.md
+++ b/docs/contributing/security.md
@@ -311,7 +311,8 @@ cannot fan out across parallel paths. Covered paths (`rateLimitedAuthPaths` in
 Open signup requires Turnstile. `adminSignupModeSet` and
 `POST /admin/invites.json` refuse `mode=open` unless both `TURNSTILE_SITE_KEY`
 and `TURNSTILE_SECRET_KEY` are configured, so public password and social signup
-cannot be opened without bot defence.
+cannot be opened without bot defence. Writes also require `expectedCurrentMode`
+matching the stored mode; a mismatch returns 409 with the live setting.
 
 Excess requests receive `429 Too Many Requests` with a `Retry-After` header. The
 D1 approach uses a batched INSERT + COUNT in a single transaction, avoiding the

--- a/docs/contributing/setup-manifest.md
+++ b/docs/contributing/setup-manifest.md
@@ -419,6 +419,10 @@ automatically:
 - `SENTRY_ENVIRONMENT` (set per deploy via `packages/worker/wrangler.jsonc`
   `vars` as `production`, `preview`, or `test`; optional override via env for
   local dev)
+- `SIGNUP_MODE` (Wrangler var; default/bootstrap `invite` / `open` / `waitlist`.
+  Production and preview are `invite`; the Wrangler `test` env is `open`. The
+  runtime override lives in KV and is managed from `/admin/invites` — see
+  [environment-variables.md](./environment-variables.md))
 - `SENTRY_TRACES_SAMPLE_RATE` (optional `0`–`1`, defaults to **`1.0`** in code
   when unset; production pins `0` via a Wrangler var — see
   [environment-variables.md](./environment-variables.md))

--- a/packages/worker/client/routes/admin-invites-signup-mode.node.test.ts
+++ b/packages/worker/client/routes/admin-invites-signup-mode.node.test.ts
@@ -1,0 +1,57 @@
+import { renderToString } from 'remix/ui/server'
+import { expect, test, vi } from 'vitest'
+import { type SignupModeSetting } from '#universal/signup-mode.ts'
+import { createAdminInvitesSignupModePanel } from './admin-invites-signup-mode.tsx'
+
+const loadedWaitlist: SignupModeSetting = {
+	mode: 'waitlist',
+	source: 'kv',
+	envDefault: 'invite',
+	updatedAt: '2026-09-02T00:00:00.000Z',
+	updatedBy: 'admin-stable-id',
+}
+
+test('signup mode Save is disabled until the setting has loaded', async () => {
+	const handle = { update: vi.fn() }
+	const onSave = vi.fn()
+	const onRetry = vi.fn()
+	const panel = createAdminInvitesSignupModePanel(handle as never)
+
+	const loadingHtml = await renderToString(
+		panel.render({
+			setting: null,
+			disabled: false,
+			saving: false,
+			onSave,
+		}),
+	)
+	expect(loadingHtml).toMatch(/<select[^>]*disabled/)
+	expect(loadingHtml).toMatch(/<button[^>]*disabled[^>]*>[\s\S]*Save mode/)
+	expect(loadingHtml).toContain('Loading…')
+	expect(loadingHtml).not.toContain('Retry')
+
+	const errorHtml = await renderToString(
+		panel.render({
+			setting: null,
+			disabled: false,
+			saving: false,
+			onSave,
+			onRetry,
+		}),
+	)
+	expect(errorHtml).toMatch(/<select[^>]*disabled/)
+	expect(errorHtml).toContain('Retry')
+	expect(errorHtml).not.toMatch(/<button[^>]*>[\s\S]*Save mode/)
+
+	const loadedHtml = await renderToString(
+		panel.render({
+			setting: loadedWaitlist,
+			disabled: false,
+			saving: false,
+			onSave,
+		}),
+	)
+	expect(loadedHtml).toContain('value="waitlist"')
+	expect(loadedHtml).toMatch(/<button[^>]*disabled[^>]*>[\s\S]*Save mode/)
+	expect(onSave).not.toHaveBeenCalled()
+})

--- a/packages/worker/client/routes/admin-invites-signup-mode.tsx
+++ b/packages/worker/client/routes/admin-invites-signup-mode.tsx
@@ -1,0 +1,162 @@
+import { type Handle, css } from 'remix/ui'
+import { createDoubleCheck } from '#client/double-check.ts'
+import { on } from '#client/event-mixin.ts'
+import {
+	isSignupMode,
+	type SignupMode,
+	type SignupModeSetting,
+	signupModes,
+} from '#universal/signup-mode.ts'
+import {
+	fieldCss,
+	fieldLabelCss,
+	getDangerPillCss,
+	getPillButtonCss,
+	getSelectCss,
+} from '#universal/styles/style-primitives.ts'
+import { mq, spacing } from '#universal/styles/tokens.ts'
+import {
+	AccountManagementPanel,
+	IdValue,
+	MetadataGrid,
+	TimestampValue,
+} from './account-management-components.tsx'
+
+const selectCss = getSelectCss()
+const primaryButtonCss = getPillButtonCss({ size: 'sm' })
+const dangerButtonCss = getDangerPillCss({ size: 'sm' })
+
+const signupModeLabels: Record<SignupMode, string> = {
+	invite: 'Invite',
+	open: 'Open',
+	waitlist: 'Waitlist',
+}
+
+export function createAdminInvitesSignupModePanel(handle: Handle) {
+	const openModeCheck = createDoubleCheck(handle)
+	let selectedMode: SignupMode = 'invite'
+	let lastAppliedMode: SignupMode | null = null
+
+	function syncFromSetting(setting: SignupModeSetting | null) {
+		if (!setting) return
+		if (lastAppliedMode !== setting.mode) {
+			selectedMode = setting.mode
+			lastAppliedMode = setting.mode
+			openModeCheck.reset()
+		}
+	}
+
+	function render(input: {
+		setting: SignupModeSetting | null
+		disabled: boolean
+		saving: boolean
+		onSave: (mode: SignupMode) => void
+	}) {
+		syncFromSetting(input.setting)
+		const setting = input.setting
+		const switchingToOpen = selectedMode === 'open' && setting?.mode !== 'open'
+		const unchanged = setting != null && selectedMode === setting.mode
+
+		return (
+			<AccountManagementPanel
+				title="Signup mode"
+				description="Invite, open, or waitlist. Invites only matter in invite mode. Open signup requires Turnstile bot defence."
+			>
+				<div
+					mix={css({
+						display: 'grid',
+						gridTemplateColumns: 'minmax(0, 1fr) auto',
+						gap: spacing.md,
+						alignItems: 'end',
+						[mq.mobile]: {
+							gridTemplateColumns: 'minmax(0, 1fr)',
+							alignItems: 'stretch',
+						},
+					})}
+				>
+					<label mix={css(fieldCss)}>
+						<span mix={css(fieldLabelCss)}>Mode</span>
+						<select
+							data-field-ring
+							value={selectedMode}
+							disabled={input.disabled}
+							mix={[
+								css(selectCss),
+								on('change', (event) => {
+									if (!(event.currentTarget instanceof HTMLSelectElement)) {
+										return
+									}
+									const next = event.currentTarget.value
+									if (isSignupMode(next)) {
+										selectedMode = next
+										openModeCheck.reset()
+										handle.update()
+									}
+								}),
+							]}
+						>
+							{signupModes.map((mode) => (
+								<option key={mode} value={mode}>
+									{signupModeLabels[mode]}
+								</option>
+							))}
+						</select>
+					</label>
+					<button
+						type="button"
+						disabled={input.disabled || unchanged}
+						mix={[
+							css(switchingToOpen ? dangerButtonCss : primaryButtonCss),
+							...(switchingToOpen
+								? openModeCheck.getButtonMix({
+										on: {
+											click: () => input.onSave(selectedMode),
+										},
+									})
+								: [
+										on('click', () => {
+											input.onSave(selectedMode)
+										}),
+									]),
+						]}
+					>
+						{input.saving
+							? 'Saving…'
+							: switchingToOpen && openModeCheck.doubleCheck
+								? 'Click again to open signup'
+								: 'Save mode'}
+					</button>
+				</div>
+				{setting ? (
+					<MetadataGrid
+						items={[
+							{
+								label: 'Source',
+								value:
+									setting.source === 'kv'
+										? 'KV override'
+										: `env default (${setting.envDefault})`,
+							},
+							{
+								label: 'Last changed',
+								value: (
+									<TimestampValue value={setting.updatedAt} fallback="Never" />
+								),
+							},
+							{
+								label: 'Changed by',
+								value: setting.updatedBy ? (
+									<IdValue value={setting.updatedBy} label="updated by" />
+								) : (
+									'—'
+								),
+							},
+						]}
+					/>
+				) : null}
+			</AccountManagementPanel>
+		)
+	}
+
+	return { render }
+}

--- a/packages/worker/client/routes/admin-invites-signup-mode.tsx
+++ b/packages/worker/client/routes/admin-invites-signup-mode.tsx
@@ -11,6 +11,7 @@ import {
 	fieldCss,
 	fieldLabelCss,
 	getDangerPillCss,
+	getGhostButtonCss,
 	getPillButtonCss,
 	getSelectCss,
 } from '#universal/styles/style-primitives.ts'
@@ -25,6 +26,7 @@ import {
 const selectCss = getSelectCss()
 const primaryButtonCss = getPillButtonCss({ size: 'sm' })
 const dangerButtonCss = getDangerPillCss({ size: 'sm' })
+const retryButtonCss = getGhostButtonCss({ size: 'sm' })
 
 const signupModeLabels: Record<SignupMode, string> = {
 	invite: 'Invite',
@@ -34,11 +36,16 @@ const signupModeLabels: Record<SignupMode, string> = {
 
 export function createAdminInvitesSignupModePanel(handle: Handle) {
 	const openModeCheck = createDoubleCheck(handle)
-	let selectedMode: SignupMode = 'invite'
+	let selectedMode: SignupMode | null = null
 	let lastAppliedMode: SignupMode | null = null
 
 	function syncFromSetting(setting: SignupModeSetting | null) {
-		if (!setting) return
+		if (!setting) {
+			selectedMode = null
+			lastAppliedMode = null
+			openModeCheck.reset()
+			return
+		}
 		if (lastAppliedMode !== setting.mode) {
 			selectedMode = setting.mode
 			lastAppliedMode = setting.mode
@@ -50,12 +57,16 @@ export function createAdminInvitesSignupModePanel(handle: Handle) {
 		setting: SignupModeSetting | null
 		disabled: boolean
 		saving: boolean
-		onSave: (mode: SignupMode) => void
+		onSave: (mode: SignupMode, expectedCurrentMode: SignupMode) => void
+		onRetry?: () => void
 	}) {
 		syncFromSetting(input.setting)
 		const setting = input.setting
-		const switchingToOpen = selectedMode === 'open' && setting?.mode !== 'open'
-		const unchanged = setting != null && selectedMode === setting.mode
+		const loaded = setting != null
+		const controlsDisabled = input.disabled || !loaded
+		const switchingToOpen =
+			loaded && selectedMode === 'open' && setting.mode !== 'open'
+		const unchanged = !loaded || selectedMode === setting.mode
 
 		return (
 			<AccountManagementPanel
@@ -78,8 +89,8 @@ export function createAdminInvitesSignupModePanel(handle: Handle) {
 						<span mix={css(fieldLabelCss)}>Mode</span>
 						<select
 							data-field-ring
-							value={selectedMode}
-							disabled={input.disabled}
+							value={selectedMode ?? ''}
+							disabled={controlsDisabled}
 							mix={[
 								css(selectCss),
 								on('change', (event) => {
@@ -95,6 +106,11 @@ export function createAdminInvitesSignupModePanel(handle: Handle) {
 								}),
 							]}
 						>
+							{selectedMode == null ? (
+								<option value="" disabled>
+									Loading…
+								</option>
+							) : null}
 							{signupModes.map((mode) => (
 								<option key={mode} value={mode}>
 									{signupModeLabels[mode]}
@@ -102,30 +118,48 @@ export function createAdminInvitesSignupModePanel(handle: Handle) {
 							))}
 						</select>
 					</label>
-					<button
-						type="button"
-						disabled={input.disabled || unchanged}
-						mix={[
-							css(switchingToOpen ? dangerButtonCss : primaryButtonCss),
-							...(switchingToOpen
-								? openModeCheck.getButtonMix({
-										on: {
-											click: () => input.onSave(selectedMode),
-										},
-									})
-								: [
-										on('click', () => {
-											input.onSave(selectedMode)
-										}),
-									]),
-						]}
-					>
-						{input.saving
-							? 'Saving…'
-							: switchingToOpen && openModeCheck.doubleCheck
-								? 'Click again to open signup'
-								: 'Save mode'}
-					</button>
+					{input.onRetry && !loaded ? (
+						<button
+							type="button"
+							mix={[
+								css(retryButtonCss),
+								on('click', () => {
+									input.onRetry?.()
+								}),
+							]}
+						>
+							Retry
+						</button>
+					) : (
+						<button
+							type="button"
+							disabled={controlsDisabled || unchanged}
+							mix={[
+								css(switchingToOpen ? dangerButtonCss : primaryButtonCss),
+								...(switchingToOpen
+									? openModeCheck.getButtonMix({
+											on: {
+												click: () => {
+													if (selectedMode == null || setting == null) return
+													input.onSave(selectedMode, setting.mode)
+												},
+											},
+										})
+									: [
+											on('click', () => {
+												if (selectedMode == null || setting == null) return
+												input.onSave(selectedMode, setting.mode)
+											}),
+										]),
+							]}
+						>
+							{input.saving
+								? 'Saving…'
+								: switchingToOpen && openModeCheck.doubleCheck
+									? 'Click again to open signup'
+									: 'Save mode'}
+						</button>
+					)}
 				</div>
 				{setting ? (
 					<MetadataGrid

--- a/packages/worker/client/routes/admin-invites.tsx
+++ b/packages/worker/client/routes/admin-invites.tsx
@@ -153,6 +153,14 @@ export function AdminInvitesRoute(handle: Handle) {
 		}
 	}
 
+	function retryLoad() {
+		lastFailedHref = null
+		status = 'loading'
+		message = null
+		handle.update()
+		handle.queueTask(loadInvites)
+	}
+
 	async function submitAdminAction(body: Record<string, unknown>) {
 		actionState =
 			body.action === 'create_invite'
@@ -184,8 +192,12 @@ export function AdminInvitesRoute(handle: Handle) {
 					ok?: boolean
 					error?: string
 					createdUser?: AdminCreatedUserSetup
+					signupMode?: SignupModeSetting
 				}
 			>(response)
+			if (payload?.signupMode) {
+				signupMode = payload.signupMode
+			}
 			if (!response.ok || !payload?.ok) {
 				throw new Error(payload?.error ?? 'Unable to update invites.')
 			}
@@ -290,12 +302,15 @@ export function AdminInvitesRoute(handle: Handle) {
 				) : null}
 				{signupModePanel.render({
 					setting: signupMode,
-					disabled: isMutating,
+					disabled: isMutating || signupMode == null,
 					saving: actionState === 'savingSignupMode',
-					onSave: (mode) => {
+					onRetry:
+						status === 'error' && signupMode == null ? retryLoad : undefined,
+					onSave: (mode, expectedCurrentMode) => {
 						void submitAdminAction({
 							action: 'set_signup_mode',
 							mode,
+							expectedCurrentMode,
 						})
 					},
 				})}

--- a/packages/worker/client/routes/admin-invites.tsx
+++ b/packages/worker/client/routes/admin-invites.tsx
@@ -31,6 +31,8 @@ import {
 	type AdminInvitesLoaderData,
 	type AdminPlanName,
 } from '#universal/loader-data.ts'
+import { type SignupModeSetting } from '#universal/signup-mode.ts'
+import { createAdminInvitesSignupModePanel } from './admin-invites-signup-mode.tsx'
 import {
 	routeLoaderRedirect,
 	type RouteLoaderResult,
@@ -81,10 +83,17 @@ export function AdminInvitesRoute(handle: Handle) {
 	let status: PageStatus = 'loading'
 	let invites: Array<AdminInviteListItem> = []
 	let availablePlans: Array<AdminPlanName> = []
+	let signupMode: SignupModeSetting | null = null
 	let createdUser: AdminCreatedUserSetup | null = null
 	let message: string | null = null
 	let messageTone: 'info' | 'error' = 'info'
-	let actionState: 'idle' | 'creating' | 'creatingUser' | 'revoking' = 'idle'
+	let actionState:
+		| 'idle'
+		| 'creating'
+		| 'creatingUser'
+		| 'revoking'
+		| 'savingSignupMode' = 'idle'
+	const signupModePanel = createAdminInvitesSignupModePanel(handle)
 	let lastLoadedHref = ''
 	let loadingForHref: string | null = null
 	let lastFailedHref: string | null = null
@@ -93,6 +102,7 @@ export function AdminInvitesRoute(handle: Handle) {
 	function applyData(payload: AdminInvitesLoaderData) {
 		invites = payload.invites
 		availablePlans = payload.availablePlans
+		signupMode = payload.signupMode
 		status = 'ready'
 		message = null
 		messageTone = 'info'
@@ -149,7 +159,9 @@ export function AdminInvitesRoute(handle: Handle) {
 				? 'creating'
 				: body.action === 'create_user'
 					? 'creatingUser'
-					: 'revoking'
+					: body.action === 'set_signup_mode'
+						? 'savingSignupMode'
+						: 'revoking'
 		message = null
 		messageTone = 'info'
 		handle.update()
@@ -184,7 +196,9 @@ export function AdminInvitesRoute(handle: Handle) {
 					? 'Invite created.'
 					: body.action === 'create_user'
 						? 'User created. Copy the setup link below.'
-						: 'Invite revoked.'
+						: body.action === 'set_signup_mode'
+							? 'Signup mode updated.'
+							: 'Invite revoked.'
 			messageTone = 'info'
 		} catch (error) {
 			message =
@@ -274,6 +288,17 @@ export function AdminInvitesRoute(handle: Handle) {
 						{message}
 					</AccountManagementMessage>
 				) : null}
+				{signupModePanel.render({
+					setting: signupMode,
+					disabled: isMutating,
+					saving: actionState === 'savingSignupMode',
+					onSave: (mode) => {
+						void submitAdminAction({
+							action: 'set_signup_mode',
+							mode,
+						})
+					},
+				})}
 				<AccountManagementPanel
 					title="Create user"
 					description="Create a verified account with no usable password, then copy the setup link into a manual email."

--- a/packages/worker/src/account/user-owned-surfaces.node.test.ts
+++ b/packages/worker/src/account/user-owned-surfaces.node.test.ts
@@ -113,6 +113,13 @@ test('account deletion and export consume the out-of-band surface registry', () 
 			scheme.prefixTemplate?.includes('source-snapshot:v1:'),
 		),
 	).toBe(true)
+	expect(
+		accountUserOwnedKvKeySchemes.every(
+			(scheme) =>
+				!scheme.prefixTemplate?.startsWith('platform-settings:') &&
+				scheme.prefixTemplate !== 'public-code-runs:v2',
+		),
+	).toBe(true)
 	expect(accountExportSource).toContain("'user_meter'")
 	expect(accountExportSource).toContain('userMeterRpc')
 	expect(accountExportSource).toContain("'mailbox'")

--- a/packages/worker/src/app/account-deletion.node.test.ts
+++ b/packages/worker/src/app/account-deletion.node.test.ts
@@ -368,6 +368,8 @@ test('deleteUserAccount cascades user-scoped rows for the requested user', async
 		'package-retriever-index-entry:v1:user-aaa:search:pkg-1:notes',
 		'package-retriever-index-entry:v1:user-aaa:context:pkg-1:notes',
 		'package-retriever-index-entry:v1:user-bbb:search:pkg-2:notes',
+		'platform-settings:v1:signup-mode',
+		'public-code-runs:v2',
 	]
 	const kv = {
 		async get(key: string) {
@@ -792,6 +794,8 @@ test('deleteUserAccount cascades user-scoped rows for the requested user', async
 	expect(deletedKvKeys).not.toContain(
 		`package-codemod-revert:${userBbb}:item-other`,
 	)
+	expect(deletedKvKeys).not.toContain('platform-settings:v1:signup-mode')
+	expect(deletedKvKeys).not.toContain('public-code-runs:v2')
 
 	// Result accounting captures the per-table counts. Job rows are purged
 	// through the JOBS service (ADR 0016), so they are not counted here.

--- a/packages/worker/src/app/admin-invites-data.ts
+++ b/packages/worker/src/app/admin-invites-data.ts
@@ -1,5 +1,6 @@
 import { type AdminInvitesLoaderData } from '#universal/loader-data.ts'
 import { parseStoredPlanName, planNames } from '#universal/plans.ts'
+import { loadSignupModeSetting } from '#app/signup-mode-setting.ts'
 
 type InviteRow = {
 	code: string
@@ -17,8 +18,9 @@ type InviteRow = {
 export async function loadAdminInvitesData(
 	env: Env,
 ): Promise<AdminInvitesLoaderData> {
-	const result = await env.APP_DB.prepare(
-		`SELECT i.code,
+	const [result, signupMode] = await Promise.all([
+		env.APP_DB.prepare(
+			`SELECT i.code,
 		        u.stable_user_id AS created_by_stable_user_id,
 		        u.email AS created_by_email,
 		        i.note,
@@ -32,7 +34,9 @@ export async function loadAdminInvitesData(
 		 LEFT JOIN users u ON u.id = i.created_by
 		 ORDER BY i.created_at DESC, i.code ASC
 		 LIMIT 200`,
-	).all<InviteRow>()
+		).all<InviteRow>(),
+		loadSignupModeSetting(env),
+	])
 
 	return {
 		ok: true,
@@ -49,5 +53,6 @@ export async function loadAdminInvitesData(
 			plan: parseStoredPlanName(row.plan),
 		})),
 		availablePlans: [...planNames],
+		signupMode,
 	}
 }

--- a/packages/worker/src/app/handlers/admin-invites.node.test.ts
+++ b/packages/worker/src/app/handlers/admin-invites.node.test.ts
@@ -1,0 +1,129 @@
+import { expect, test, vi } from 'vitest'
+import { type AdminInvitesLoaderData } from '#universal/loader-data.ts'
+import { signupModeKvKey } from '#worker/signup-mode-setting.ts'
+
+const mockModule = vi.hoisted(() => ({
+	requireUserWithRole: vi.fn(),
+	loadAdminInvitesData: vi.fn(),
+}))
+
+vi.mock('#app/permissions-server.ts', () => ({
+	requireUserWithRole: (...args: Array<unknown>) =>
+		mockModule.requireUserWithRole(...args),
+}))
+
+vi.mock('#app/admin-invites-data.ts', () => ({
+	loadAdminInvitesData: (...args: Array<unknown>) =>
+		mockModule.loadAdminInvitesData(...args),
+}))
+
+const { createAdminInvitesApiHandler } = await import('./admin-invites.ts')
+
+function createMemoryKv(initial?: Record<string, string>) {
+	const store = new Map<string, string>(Object.entries(initial ?? {}))
+	return {
+		async get(key: string, type?: string) {
+			const raw = store.get(key)
+			if (raw === undefined) return null
+			return type === 'json' ? JSON.parse(raw) : raw
+		},
+		async put(key: string, value: string) {
+			store.set(key, value)
+		},
+		async delete(key: string) {
+			store.delete(key)
+		},
+		store,
+	} as unknown as KVNamespace & { store: Map<string, string> }
+}
+
+function loaderPayload(
+	mode: 'invite' | 'open' | 'waitlist',
+): AdminInvitesLoaderData {
+	return {
+		ok: true,
+		invites: [],
+		availablePlans: ['free'],
+		signupMode: {
+			mode,
+			source: mode === 'invite' ? 'env' : 'kv',
+			envDefault: 'invite',
+			updatedAt: mode === 'invite' ? null : '2026-09-02T00:00:00.000Z',
+			updatedBy: mode === 'invite' ? null : 'admin-stable-id',
+		},
+	}
+}
+
+function postRequest(body: Record<string, unknown>) {
+	return new Request('https://example.com/admin/invites.json', {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify(body),
+	})
+}
+
+test('set_signup_mode writes when expectedCurrentMode matches and returns 409 when it does not', async () => {
+	mockModule.requireUserWithRole.mockResolvedValue({
+		email: 'admin@example.com',
+		mcpUser: { userId: 'admin-stable-id' },
+	})
+	mockModule.loadAdminInvitesData.mockResolvedValue(loaderPayload('waitlist'))
+
+	const kv = createMemoryKv()
+	const putSpy = vi.spyOn(kv, 'put')
+	const env = {
+		SIGNUP_MODE: 'invite',
+		BUNDLE_ARTIFACTS_KV: kv,
+		TURNSTILE_SITE_KEY: 'site-key',
+		TURNSTILE_SECRET_KEY: 'secret-key',
+		APP_DB: {} as D1Database,
+	} as unknown as Env
+	const handler = createAdminInvitesApiHandler(env)
+	const url = new URL('https://example.com/admin/invites.json')
+
+	const omitted = await handler.handler({
+		request: postRequest({ action: 'set_signup_mode', mode: 'waitlist' }),
+		params: {},
+		url,
+	} as never)
+	expect(omitted.status).toBe(400)
+	expect(await omitted.json()).toEqual({
+		ok: false,
+		error: 'expectedCurrentMode must be invite, open, or waitlist.',
+	})
+	expect(putSpy).not.toHaveBeenCalled()
+
+	const matched = await handler.handler({
+		request: postRequest({
+			action: 'set_signup_mode',
+			mode: 'waitlist',
+			expectedCurrentMode: 'invite',
+		}),
+		params: {},
+		url,
+	} as never)
+	expect(matched.status).toBe(200)
+	expect(putSpy).toHaveBeenCalledTimes(1)
+	expect(JSON.parse(kv.store.get(signupModeKvKey) ?? '{}').mode).toBe(
+		'waitlist',
+	)
+
+	putSpy.mockClear()
+	const stored = kv.store.get(signupModeKvKey)
+	const mismatched = await handler.handler({
+		request: postRequest({
+			action: 'set_signup_mode',
+			mode: 'open',
+			expectedCurrentMode: 'invite',
+		}),
+		params: {},
+		url,
+	} as never)
+	expect(mismatched.status).toBe(409)
+	expect(await mismatched.json()).toMatchObject({
+		ok: false,
+		signupMode: { mode: 'waitlist', source: 'kv' },
+	})
+	expect(putSpy).not.toHaveBeenCalled()
+	expect(kv.store.get(signupModeKvKey)).toBe(stored)
+})

--- a/packages/worker/src/app/handlers/admin-invites.ts
+++ b/packages/worker/src/app/handlers/admin-invites.ts
@@ -3,6 +3,11 @@ import { jsonResponse } from '#worker/json-response.ts'
 import { type Action } from 'remix/router'
 import { loadAdminInvitesData } from '#app/admin-invites-data.ts'
 import {
+	setSignupModeSetting,
+	SignupModeOpenWithoutTurnstileError,
+} from '#app/signup-mode-setting.ts'
+import { isSignupMode } from '#universal/signup-mode.ts'
+import {
 	auditDatabaseFromEnv,
 	getRequestIp,
 	logAuditEvent,
@@ -83,6 +88,9 @@ export function createAdminInvitesApiHandler(env: Env) {
 				}
 				if (action === 'create_user') {
 					return handleCreateUserAction({ env, request, url, actor, body })
+				}
+				if (action === 'set_signup_mode') {
+					return handleSetSignupModeAction({ env, request, url, actor, body })
 				}
 
 				return jsonResponse({ ok: false, error: 'Invalid action.' }, 400)
@@ -286,4 +294,43 @@ function readExpiresAt(body: object): string | null | false {
 	const date = new Date(value)
 	if (Number.isNaN(date.getTime())) return false
 	return date.toISOString()
+}
+
+async function handleSetSignupModeAction(input: {
+	env: Env
+	request: Request
+	url: URL
+	actor: Awaited<ReturnType<typeof requireUserWithRole>>
+	body: object
+}) {
+	const mode = readNonEmptyTrimmedStringOrNumber(input.body, 'mode')
+	if (!isSignupMode(mode)) {
+		return jsonResponse(
+			{
+				ok: false,
+				error: 'Signup mode must be invite, open, or waitlist.',
+			},
+			400,
+		)
+	}
+
+	try {
+		await setSignupModeSetting({
+			env: input.env,
+			mode,
+			updatedBy: input.actor.mcpUser.userId,
+			actorEmail: input.actor.email,
+			path: input.url.pathname,
+			ip: getRequestIp(input.request) ?? undefined,
+		})
+	} catch (error) {
+		const message =
+			error instanceof Error ? error.message : 'Unable to update signup mode.'
+		return jsonResponse(
+			{ ok: false, error: message },
+			error instanceof SignupModeOpenWithoutTurnstileError ? 400 : 500,
+		)
+	}
+
+	return jsonResponse(await loadAdminInvitesData(input.env))
 }

--- a/packages/worker/src/app/handlers/admin-invites.ts
+++ b/packages/worker/src/app/handlers/admin-invites.ts
@@ -5,6 +5,7 @@ import { loadAdminInvitesData } from '#app/admin-invites-data.ts'
 import {
 	setSignupModeSetting,
 	SignupModeOpenWithoutTurnstileError,
+	SignupModeStaleWriteError,
 } from '#app/signup-mode-setting.ts'
 import { isSignupMode } from '#universal/signup-mode.ts'
 import {
@@ -313,17 +314,41 @@ async function handleSetSignupModeAction(input: {
 			400,
 		)
 	}
+	const expectedCurrentMode = readNonEmptyTrimmedStringOrNumber(
+		input.body,
+		'expectedCurrentMode',
+	)
+	if (!isSignupMode(expectedCurrentMode)) {
+		return jsonResponse(
+			{
+				ok: false,
+				error: 'expectedCurrentMode must be invite, open, or waitlist.',
+			},
+			400,
+		)
+	}
 
 	try {
 		await setSignupModeSetting({
 			env: input.env,
 			mode,
+			expectedCurrentMode,
 			updatedBy: input.actor.mcpUser.userId,
 			actorEmail: input.actor.email,
 			path: input.url.pathname,
 			ip: getRequestIp(input.request) ?? undefined,
 		})
 	} catch (error) {
+		if (error instanceof SignupModeStaleWriteError) {
+			return jsonResponse(
+				{
+					ok: false,
+					error: error.message,
+					signupMode: error.current,
+				},
+				409,
+			)
+		}
 		const message =
 			error instanceof Error ? error.message : 'Unable to update signup mode.'
 		return jsonResponse(

--- a/packages/worker/src/app/handlers/auth-handler.node.test.ts
+++ b/packages/worker/src/app/handlers/auth-handler.node.test.ts
@@ -24,6 +24,7 @@ import {
 	logAuditEventSpy,
 } from '#worker/test-support/audit-log-spy.ts'
 import { createStableUserIdFromEmail } from '#worker/user-id.ts'
+import { signupModeKvKey } from '#worker/signup-mode-setting.ts'
 
 const testCookieSecret = 'test-cookie-secret-0123456789abcdef0123456789'
 
@@ -44,9 +45,24 @@ function createAuthRequest(
 	}
 }
 
+function createMemoryKv(initial?: Record<string, string>) {
+	const store = new Map<string, string>(Object.entries(initial ?? {}))
+	return {
+		async get(key: string, type?: string) {
+			const raw = store.get(key)
+			if (raw === undefined) return null
+			return type === 'json' ? JSON.parse(raw) : raw
+		},
+		async put(key: string, value: string) {
+			store.set(key, value)
+		},
+	} as unknown as KVNamespace
+}
+
 function createAuthTestContext(
 	options: {
 		signupMode?: 'invite' | 'open' | 'waitlist'
+		kvSignupMode?: 'invite' | 'open' | 'waitlist'
 		failRoleAssignment?: boolean
 		emailConfigured?: boolean
 	} = {},
@@ -59,9 +75,20 @@ function createAuthTestContext(
 		APP_DB: testDb.db,
 		SIGNUP_MODE: options.signupMode ?? 'invite',
 		SENTRY_ENVIRONMENT:
-			options.signupMode === 'open'
+			options.signupMode === 'open' || options.kvSignupMode === 'open'
 				? ('test' as const)
 				: ('production' as const),
+		...(options.kvSignupMode
+			? {
+					BUNDLE_ARTIFACTS_KV: createMemoryKv({
+						[signupModeKvKey]: JSON.stringify({
+							mode: options.kvSignupMode,
+							updatedAt: '2026-09-02T00:00:00.000Z',
+							updatedBy: 'admin-stable-id',
+						}),
+					}),
+				}
+			: {}),
 		...(options.emailConfigured
 			? {
 					CLOUDFLARE_ACCOUNT_ID: 'cf-account-test',
@@ -895,4 +922,35 @@ test('signup stops when an invite has an invalid stored plan', async () => {
 		false,
 	)
 	expect(logAuditEventSpy).not.toHaveBeenCalled()
+})
+
+test('password signup honors KV signup-mode override over the env default', async () => {
+	const openOverride = createAuthTestContext({
+		signupMode: 'invite',
+		kvSignupMode: 'open',
+	})
+	const openResponse = await openOverride.request({
+		email: 'kv-open@example.com',
+		username: 'kv-open',
+		password: 'password123',
+		mode: 'signup',
+	})
+	expect(openResponse.status).toBe(200)
+	expect(openOverride.testDb.users.has('kv-open@example.com')).toBe(true)
+
+	const inviteOverride = createAuthTestContext({
+		signupMode: 'open',
+		kvSignupMode: 'invite',
+	})
+	const blockedResponse = await inviteOverride.request({
+		email: 'kv-invite@example.com',
+		username: 'kv-invite',
+		password: 'password123',
+		mode: 'signup',
+	})
+	expect(blockedResponse.status).toBe(400)
+	expect(await blockedResponse.json()).toEqual({
+		error: 'Invite code is required.',
+	})
+	expect(inviteOverride.testDb.users.has('kv-invite@example.com')).toBe(false)
 })

--- a/packages/worker/src/app/handlers/auth-page.ts
+++ b/packages/worker/src/app/handlers/auth-page.ts
@@ -6,7 +6,7 @@ import {
 import { loadSessionInfo } from '#app/session-info.ts'
 import { renderAppPage } from '#app/ssr-render.tsx'
 import { getTurnstileSiteKey } from '#app/public-form-protection.ts'
-import { getSignupMode } from '#universal/signup-mode.ts'
+import { resolveSignupMode } from '#app/signup-mode-setting.ts'
 
 export function createAuthPageHandler(
 	env: Env,
@@ -50,7 +50,7 @@ export function createAuthPageHandler(
 				loaderData: {
 					authProviders: {
 						ok: true,
-						signupMode: getSignupMode(env),
+						signupMode: await resolveSignupMode(env),
 						turnstileSiteKey: getTurnstileSiteKey(env),
 						providers: getEnabledOauthProviders(env).map((provider) => ({
 							id: provider,

--- a/packages/worker/src/app/handlers/auth-provider.node.test.ts
+++ b/packages/worker/src/app/handlers/auth-provider.node.test.ts
@@ -33,6 +33,7 @@ import {
 } from '#worker/test-support/audit-log-spy.ts'
 import { applyAllMigrations } from '#worker/test-support/apply-all-migrations.ts'
 import { emptyPublicFormProtection } from '#universal/public-form-protection.ts'
+import { signupModeKvKey } from '#worker/signup-mode-setting.ts'
 
 const testCookieSecret = 'test-cookie-secret-0123456789abcdef0123456789'
 
@@ -170,6 +171,29 @@ function createAppEnv(
 		DISCORD_CLIENT_SECRET: 'discord-client-secret-test',
 		...overrides,
 	} as unknown as Env
+}
+
+function createSignupModeKv(mode: 'invite' | 'open' | 'waitlist') {
+	const store = new Map<string, string>([
+		[
+			signupModeKvKey,
+			JSON.stringify({
+				mode,
+				updatedAt: '2026-09-02T00:00:00.000Z',
+				updatedBy: 'admin-stable-id',
+			}),
+		],
+	])
+	return {
+		async get(key: string, type?: string) {
+			const raw = store.get(key)
+			if (raw === undefined) return null
+			return type === 'json' ? JSON.parse(raw) : raw
+		},
+		async put(key: string, value: string) {
+			store.set(key, value)
+		},
+	} as unknown as KVNamespace
 }
 
 type Handler = {
@@ -1603,4 +1627,60 @@ test('OAuth signup returns a controlled error when stable_user_id already exists
 			reason: 'stable_user_id_exists',
 		}),
 	)
+})
+
+test('OAuth signup honors KV signup-mode override over the env default', async () => {
+	const openOverride = createMigratedDb()
+	const openEnv = createAppEnv(openOverride.db, {
+		SIGNUP_MODE: 'invite',
+		BUNDLE_ARTIFACTS_KV: createSignupModeKv('open'),
+	})
+	mockGithubProfileExchange('kv-open-oauth@example.com')
+	const openStart = await startProviderFlow(
+		openEnv,
+		'github',
+		'http://example.com/auth/github',
+	)
+	const openCallback = await runHandler(
+		createAuthProviderCallbackHandler(openEnv),
+		new Request(
+			`http://example.com/auth/github/callback?code=github-auth-code&state=${openStart.state}`,
+			{ headers: { Cookie: openStart.stateCookie } },
+		),
+		{ provider: 'github' },
+	)
+	expect(openCallback.status).toBe(302)
+	expect(openCallback.headers.get('Location')).toBe(
+		'/onboarding?accountCreated=1',
+	)
+	expect(
+		openOverride.sqlite.prepare(`SELECT COUNT(*) AS count FROM users`).get(),
+	).toEqual({ count: 1 })
+
+	const inviteOverride = createMigratedDb()
+	const inviteEnv = createAppEnv(inviteOverride.db, {
+		SIGNUP_MODE: 'open',
+		BUNDLE_ARTIFACTS_KV: createSignupModeKv('invite'),
+	})
+	mockGithubProfileExchange('kv-invite-oauth@example.com')
+	const inviteStart = await startProviderFlow(
+		inviteEnv,
+		'github',
+		'http://example.com/auth/github',
+	)
+	const inviteCallback = await runHandler(
+		createAuthProviderCallbackHandler(inviteEnv),
+		new Request(
+			`http://example.com/auth/github/callback?code=github-auth-code&state=${inviteStart.state}`,
+			{ headers: { Cookie: inviteStart.stateCookie } },
+		),
+		{ provider: 'github' },
+	)
+	expect(inviteCallback.status).toBe(302)
+	expect(inviteCallback.headers.get('Location')).toBe(
+		'/login?oauthError=invite-required',
+	)
+	expect(
+		inviteOverride.sqlite.prepare(`SELECT COUNT(*) AS count FROM users`).get(),
+	).toEqual({ count: 0 })
 })

--- a/packages/worker/src/app/handlers/auth-provider.ts
+++ b/packages/worker/src/app/handlers/auth-provider.ts
@@ -69,7 +69,7 @@ import {
 	verifyPublicFormProtection,
 } from '#app/public-form-protection.ts'
 import { defaultPostVerificationRedirect } from '#universal/safe-redirect.ts'
-import { getSignupMode } from '#universal/signup-mode.ts'
+import { resolveSignupMode } from '#app/signup-mode-setting.ts'
 import {
 	firstTouchAttributionCreateFields,
 	hasFirstTouchAttribution,
@@ -203,7 +203,7 @@ export function createAuthProvidersApiHandler(env: Env) {
 		async handler() {
 			return jsonResponse({
 				ok: true,
-				signupMode: getSignupMode(env),
+				signupMode: await resolveSignupMode(env),
 				turnstileSiteKey: getTurnstileSiteKey(env),
 				providers: getEnabledOauthProviders(env).map((provider) => ({
 					id: provider,
@@ -666,7 +666,7 @@ export function createAuthProviderCallbackHandler(env: Env) {
 				consumedInvitePlan = null
 			}
 
-			const inviteRequired = getSignupMode(env) !== 'open'
+			const inviteRequired = (await resolveSignupMode(env)) !== 'open'
 			const inviteCodeFromState = loginState.inviteCode
 			if (inviteRequired || normalizeInviteCode(inviteCodeFromState)) {
 				const inviteResult = await consumeInviteCode({

--- a/packages/worker/src/app/handlers/auth.ts
+++ b/packages/worker/src/app/handlers/auth.ts
@@ -52,7 +52,7 @@ import { getPasswordPolicyError } from '@kody-internal/shared/password-policy.ts
 import { maybeTagKitSubscriberOnSignup } from '#app/kit-signup.ts'
 import { scheduleKitSubscriberSync } from '#worker/kit/subscriber-sync.ts'
 import { verifyPublicFormProtection } from '#app/public-form-protection.ts'
-import { getSignupMode } from '#universal/signup-mode.ts'
+import { resolveSignupMode } from '#app/signup-mode-setting.ts'
 import {
 	firstTouchAttributionCreateFields,
 	parseFirstTouchAttribution,
@@ -280,7 +280,7 @@ export function createAuthHandler(env: Env) {
 					consumedInvitePlan = null
 				}
 
-				const inviteRequired = getSignupMode(env) !== 'open'
+				const inviteRequired = (await resolveSignupMode(env)) !== 'open'
 				if (inviteRequired || normalizeInviteCode(inviteCode)) {
 					const inviteResult = await consumeInviteCode({
 						db: env.APP_DB,

--- a/packages/worker/src/app/handlers/home.ts
+++ b/packages/worker/src/app/handlers/home.ts
@@ -15,7 +15,7 @@ import {
 	loadPublicOnboardingData,
 } from '#app/onboarding-data.ts'
 import { renderAppPage } from '#app/ssr-render.tsx'
-import { getSignupMode } from '#universal/signup-mode.ts'
+import { resolveSignupMode } from '#app/signup-mode-setting.ts'
 import { pickWalkthroughHosts } from '#universal/walkthrough-hosts.ts'
 import { loadPublicCodeRunsWindow } from '#worker/usage/code-runs-window.ts'
 import { type routes } from '#universal/routes.ts'
@@ -44,7 +44,7 @@ export function createHomeHandler(env: Env) {
 			)
 			const codeRuns = { ok: true as const, window: codeRunsWindow }
 			const walkthroughHosts = pickWalkthroughHosts()
-			const signupMode = getSignupMode(env)
+			const signupMode = await resolveSignupMode(env)
 
 			const user = await readAuthenticatedAppUser(request, env)
 			if (!user) {

--- a/packages/worker/src/app/handlers/pricing.ts
+++ b/packages/worker/src/app/handlers/pricing.ts
@@ -1,6 +1,6 @@
 import { type Action } from 'remix/router'
 import { renderAppPage } from '#app/ssr-render.tsx'
-import { getSignupMode } from '#universal/signup-mode.ts'
+import { resolveSignupMode } from '#app/signup-mode-setting.ts'
 import { type routes } from '#universal/routes.ts'
 
 export function createPricingHandler(env: Env) {
@@ -11,7 +11,7 @@ export function createPricingHandler(env: Env) {
 				request,
 				env,
 				loaderData: {
-					signupMode: getSignupMode(env),
+					signupMode: await resolveSignupMode(env),
 				},
 			})
 		},

--- a/packages/worker/src/app/signup-mode-setting.ts
+++ b/packages/worker/src/app/signup-mode-setting.ts
@@ -3,4 +3,5 @@ export {
 	resolveSignupMode,
 	setSignupModeSetting,
 	SignupModeOpenWithoutTurnstileError,
+	SignupModeStaleWriteError,
 } from '#worker/signup-mode-setting.ts'

--- a/packages/worker/src/app/signup-mode-setting.ts
+++ b/packages/worker/src/app/signup-mode-setting.ts
@@ -1,0 +1,6 @@
+export {
+	loadSignupModeSetting,
+	resolveSignupMode,
+	setSignupModeSetting,
+	SignupModeOpenWithoutTurnstileError,
+} from '#worker/signup-mode-setting.ts'

--- a/packages/worker/src/mcp/capabilities/admin/admin-signup-mode-capabilities.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-signup-mode-capabilities.node.test.ts
@@ -1,0 +1,148 @@
+import { expect, test } from 'vitest'
+import { createMcpCallerContext } from '#mcp/context.ts'
+import {
+	auditEventSummaries,
+	logAuditEventSpy,
+} from '#worker/test-support/audit-log-spy.ts'
+import { testStableUserIdFromEmail } from '#worker/test-support/stable-user-id.ts'
+import { signupModeKvKey } from '#worker/signup-mode-setting.ts'
+import { adminSignupModeGetCapability } from './admin-signup-mode-get.ts'
+import { adminSignupModeSetCapability } from './admin-signup-mode-set.ts'
+
+function createMemoryKv(initial?: Record<string, string>) {
+	const store = new Map<string, string>(Object.entries(initial ?? {}))
+	return {
+		async get(key: string, type?: string) {
+			const raw = store.get(key)
+			if (raw === undefined) return null
+			return type === 'json' ? JSON.parse(raw) : raw
+		},
+		async put(key: string, value: string) {
+			store.set(key, value)
+		},
+		async delete(key: string) {
+			store.delete(key)
+		},
+		store,
+	} as unknown as KVNamespace & { store: Map<string, string> }
+}
+
+function createContext(
+	roles: Array<string>,
+	envOverrides: Record<string, unknown> = {},
+) {
+	const adminStableUserId = testStableUserIdFromEmail('admin@example.com')
+	return {
+		env: {
+			SIGNUP_MODE: 'invite',
+			APP_DB: {} as D1Database,
+			...envOverrides,
+		} as Env,
+		callerContext: createMcpCallerContext({
+			baseUrl: 'https://example.com',
+			user: {
+				userId: adminStableUserId,
+				email: 'admin@example.com',
+				displayName: 'admin',
+				roles,
+			},
+		}),
+		adminStableUserId,
+	}
+}
+
+test('adminSignupModeGet and adminSignupModeSet: found, missing, non-admin denied, audit row', async () => {
+	const userCtx = createContext(['user'], {
+		BUNDLE_ARTIFACTS_KV: createMemoryKv(),
+	})
+	await expect(
+		adminSignupModeGetCapability.handler({}, userCtx),
+	).rejects.toThrow('lacks required role "admin"')
+	await expect(
+		adminSignupModeSetCapability.handler({ mode: 'waitlist' }, userCtx),
+	).rejects.toThrow('lacks required role "admin"')
+	expect(logAuditEventSpy).toHaveBeenCalledWith(
+		expect.objectContaining({
+			category: 'auth',
+			action: 'mcp_capability_denied',
+			result: 'failure',
+			reason: 'role',
+		}),
+	)
+
+	const missingKv = createMemoryKv()
+	const missingCtx = createContext(['admin'], {
+		BUNDLE_ARTIFACTS_KV: missingKv,
+		TURNSTILE_SITE_KEY: 'site-key',
+		TURNSTILE_SECRET_KEY: 'secret-key',
+	})
+	const missing = await adminSignupModeGetCapability.handler({}, missingCtx)
+	expect(missing).toEqual({
+		signupMode: {
+			mode: 'invite',
+			source: 'env',
+			envDefault: 'invite',
+			updatedAt: null,
+			updatedBy: null,
+		},
+	})
+
+	const foundKv = createMemoryKv({
+		[signupModeKvKey]: JSON.stringify({
+			mode: 'waitlist',
+			updatedAt: '2026-09-01T00:00:00.000Z',
+			updatedBy: missingCtx.adminStableUserId,
+		}),
+	})
+	const foundCtx = createContext(['admin'], { BUNDLE_ARTIFACTS_KV: foundKv })
+	const found = await adminSignupModeGetCapability.handler({}, foundCtx)
+	expect(found.signupMode).toEqual({
+		mode: 'waitlist',
+		source: 'kv',
+		envDefault: 'invite',
+		updatedAt: '2026-09-01T00:00:00.000Z',
+		updatedBy: missingCtx.adminStableUserId,
+	})
+
+	const setResult = await adminSignupModeSetCapability.handler(
+		{ mode: 'waitlist' },
+		missingCtx,
+	)
+	expect(setResult.previousMode).toBe('invite')
+	expect(setResult.signupMode.mode).toBe('waitlist')
+	expect(setResult.signupMode.source).toBe('kv')
+	expect(setResult.signupMode.updatedBy).toBe(missingCtx.adminStableUserId)
+	expect(logAuditEventSpy).toHaveBeenCalledWith(
+		expect.objectContaining({
+			category: 'admin',
+			action: 'signup_mode_set',
+			result: 'success',
+			reason: 'old=invite;new=waitlist',
+		}),
+	)
+	expect(logAuditEventSpy).toHaveBeenCalledWith(
+		expect.objectContaining({
+			category: 'admin',
+			action: 'adminSignupModeSet',
+			result: 'success',
+			reason: 'old=invite;new=waitlist',
+		}),
+	)
+
+	await expect(
+		adminSignupModeSetCapability.handler(
+			{ mode: 'open' },
+			createContext(['admin'], { BUNDLE_ARTIFACTS_KV: createMemoryKv() }),
+		),
+	).rejects.toThrow('TURNSTILE_SITE_KEY and TURNSTILE_SECRET_KEY')
+
+	expect(auditEventSummaries()).toEqual([
+		'mcp_capability_denied:failure',
+		'mcp_capability_denied:failure',
+		'adminSignupModeGet:success',
+		'adminSignupModeGet:success',
+		'signup_mode_set:success',
+		'adminSignupModeSet:success',
+		'adminSignupModeSet:failure',
+	])
+})

--- a/packages/worker/src/mcp/capabilities/admin/admin-signup-mode-capabilities.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-signup-mode-capabilities.node.test.ts
@@ -59,7 +59,10 @@ test('adminSignupModeGet and adminSignupModeSet: found, missing, non-admin denie
 		adminSignupModeGetCapability.handler({}, userCtx),
 	).rejects.toThrow('lacks required role "admin"')
 	await expect(
-		adminSignupModeSetCapability.handler({ mode: 'waitlist' }, userCtx),
+		adminSignupModeSetCapability.handler(
+			{ mode: 'waitlist', expectedCurrentMode: 'invite' },
+			userCtx,
+		),
 	).rejects.toThrow('lacks required role "admin"')
 	expect(logAuditEventSpy).toHaveBeenCalledWith(
 		expect.objectContaining({
@@ -105,7 +108,7 @@ test('adminSignupModeGet and adminSignupModeSet: found, missing, non-admin denie
 	})
 
 	const setResult = await adminSignupModeSetCapability.handler(
-		{ mode: 'waitlist' },
+		{ mode: 'waitlist', expectedCurrentMode: 'invite' },
 		missingCtx,
 	)
 	expect(setResult.previousMode).toBe('invite')
@@ -129,9 +132,18 @@ test('adminSignupModeGet and adminSignupModeSet: found, missing, non-admin denie
 		}),
 	)
 
+	const storedAfterSet = missingKv.store.get(signupModeKvKey)
 	await expect(
 		adminSignupModeSetCapability.handler(
-			{ mode: 'open' },
+			{ mode: 'open', expectedCurrentMode: 'invite' },
+			missingCtx,
+		),
+	).rejects.toThrow('Current mode is waitlist')
+	expect(missingKv.store.get(signupModeKvKey)).toBe(storedAfterSet)
+
+	await expect(
+		adminSignupModeSetCapability.handler(
+			{ mode: 'open', expectedCurrentMode: 'invite' },
 			createContext(['admin'], { BUNDLE_ARTIFACTS_KV: createMemoryKv() }),
 		),
 	).rejects.toThrow('TURNSTILE_SITE_KEY and TURNSTILE_SECRET_KEY')
@@ -143,6 +155,7 @@ test('adminSignupModeGet and adminSignupModeSet: found, missing, non-admin denie
 		'adminSignupModeGet:success',
 		'signup_mode_set:success',
 		'adminSignupModeSet:success',
+		'adminSignupModeSet:failure',
 		'adminSignupModeSet:failure',
 	])
 })

--- a/packages/worker/src/mcp/capabilities/admin/admin-signup-mode-get.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-signup-mode-get.ts
@@ -1,0 +1,47 @@
+import { z } from 'zod'
+import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
+import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
+import { emptyCapabilityInputSchema } from '#mcp/capabilities/types.ts'
+import { loadSignupModeSetting } from '#worker/signup-mode-setting.ts'
+import {
+	adminCapabilityAccess,
+	auditAdminCapabilityInvocation,
+} from './admin-shared.ts'
+import { signupModeSettingSchema } from './signup-mode-shared.ts'
+
+const outputSchema = z.object({
+	signupMode: signupModeSettingSchema,
+})
+
+export const adminSignupModeGetCapability = defineDomainCapability(
+	capabilityDomainNames.admin,
+	{
+		...adminCapabilityAccess,
+		name: 'adminSignupModeGet',
+		description:
+			'Read the runtime signup mode (invite, open, or waitlist), whether it comes from the KV override or the SIGNUP_MODE Worker var default, and who last changed it. Admin-only platform setting; never returns user content.',
+		keywords: [
+			'admin',
+			'signup',
+			'signup mode',
+			'invite',
+			'waitlist',
+			'open signup',
+		],
+		inputSchema: emptyCapabilityInputSchema,
+		outputSchema,
+		async handler(_args, ctx) {
+			return auditAdminCapabilityInvocation(
+				ctx,
+				'adminSignupModeGet',
+				async () => ({
+					signupMode: await loadSignupModeSetting(ctx.env),
+				}),
+				{
+					successReason: ({ signupMode }) =>
+						`mode=${signupMode.mode};source=${signupMode.source}`,
+				},
+			)
+		},
+	},
+)

--- a/packages/worker/src/mcp/capabilities/admin/admin-signup-mode-set.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-signup-mode-set.ts
@@ -1,0 +1,75 @@
+import { z } from 'zod'
+import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
+import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
+import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
+import { type CapabilityContext } from '#mcp/capabilities/types.ts'
+import { signupModes } from '#universal/signup-mode.ts'
+import {
+	setSignupModeSetting,
+	SignupModeOpenWithoutTurnstileError,
+} from '#worker/signup-mode-setting.ts'
+import {
+	adminMutationCapabilityAccess,
+	auditAdminCapabilityInvocation,
+} from './admin-shared.ts'
+import {
+	signupModeInputSchema,
+	signupModeSettingSchema,
+} from './signup-mode-shared.ts'
+
+const outputSchema = z.object({
+	previousMode: z.enum(signupModes),
+	signupMode: signupModeSettingSchema,
+})
+
+export const adminSignupModeSetCapability = defineDomainCapability(
+	capabilityDomainNames.admin,
+	{
+		...adminMutationCapabilityAccess,
+		name: 'adminSignupModeSet',
+		description:
+			'Set the runtime signup mode stored in platform KV. Open signup is refused unless both Turnstile keys are configured. Admin-only; never returns user content.',
+		keywords: [
+			'admin',
+			'signup',
+			'signup mode',
+			'invite',
+			'waitlist',
+			'open signup',
+			'toggle',
+		],
+		inputSchema: signupModeInputSchema,
+		outputSchema,
+		async handler(args, ctx: CapabilityContext) {
+			return auditAdminCapabilityInvocation(
+				ctx,
+				'adminSignupModeSet',
+				async () => {
+					const user = requireMcpUser(ctx.callerContext)
+					try {
+						const result = await setSignupModeSetting({
+							env: ctx.env,
+							mode: args.mode,
+							updatedBy: user.userId,
+							actorEmail: user.email,
+							path: '/mcp',
+						})
+						return {
+							previousMode: result.previous.mode,
+							signupMode: result.current,
+						}
+					} catch (error) {
+						if (error instanceof SignupModeOpenWithoutTurnstileError) {
+							throw new Error(error.message)
+						}
+						throw error
+					}
+				},
+				{
+					successReason: ({ previousMode, signupMode }) =>
+						`old=${previousMode};new=${signupMode.mode}`,
+				},
+			)
+		},
+	},
+)

--- a/packages/worker/src/mcp/capabilities/admin/admin-signup-mode-set.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-signup-mode-set.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { McpCallerError } from '#mcp/caller-error.ts'
 import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
@@ -7,6 +8,7 @@ import { signupModes } from '#universal/signup-mode.ts'
 import {
 	setSignupModeSetting,
 	SignupModeOpenWithoutTurnstileError,
+	SignupModeStaleWriteError,
 } from '#worker/signup-mode-setting.ts'
 import {
 	adminMutationCapabilityAccess,
@@ -28,7 +30,7 @@ export const adminSignupModeSetCapability = defineDomainCapability(
 		...adminMutationCapabilityAccess,
 		name: 'adminSignupModeSet',
 		description:
-			'Set the runtime signup mode stored in platform KV. Open signup is refused unless both Turnstile keys are configured. Admin-only; never returns user content.',
+			'Set the runtime signup mode stored in platform KV. Requires expectedCurrentMode matching the stored mode (optimistic concurrency). Open signup is refused unless both Turnstile keys are configured. Admin-only; never returns user content.',
 		keywords: [
 			'admin',
 			'signup',
@@ -50,6 +52,7 @@ export const adminSignupModeSetCapability = defineDomainCapability(
 						const result = await setSignupModeSetting({
 							env: ctx.env,
 							mode: args.mode,
+							expectedCurrentMode: args.expectedCurrentMode,
 							updatedBy: user.userId,
 							actorEmail: user.email,
 							path: '/mcp',
@@ -59,8 +62,11 @@ export const adminSignupModeSetCapability = defineDomainCapability(
 							signupMode: result.current,
 						}
 					} catch (error) {
-						if (error instanceof SignupModeOpenWithoutTurnstileError) {
-							throw new Error(error.message)
+						if (
+							error instanceof SignupModeOpenWithoutTurnstileError ||
+							error instanceof SignupModeStaleWriteError
+						) {
+							throw new McpCallerError(error.message)
 						}
 						throw error
 					}

--- a/packages/worker/src/mcp/capabilities/admin/domain.ts
+++ b/packages/worker/src/mcp/capabilities/admin/domain.ts
@@ -5,6 +5,8 @@ import { adminCommunityActivityListCapability } from './admin-community-activity
 import { adminFeatureFlagListCapability } from './admin-feature-flag-list.ts'
 import { adminFeatureFlagOverrideCapability } from './admin-feature-flag-override.ts'
 import { adminFeatureFlagSetCapability } from './admin-feature-flag-set.ts'
+import { adminSignupModeGetCapability } from './admin-signup-mode-get.ts'
+import { adminSignupModeSetCapability } from './admin-signup-mode-set.ts'
 import { adminPackageCodemodApplyCapability } from './admin-package-codemod-apply.ts'
 import { adminPackageCodemodDryRunCapability } from './admin-package-codemod-dry-run.ts'
 import { adminPackageCodemodRevertCapability } from './admin-package-codemod-revert.ts'
@@ -45,7 +47,7 @@ import { adminMailboxMaintenanceCapability } from './admin-mailbox-maintenance.t
 export const adminDomain = defineDomain({
 	name: capabilityDomainNames.admin,
 	description:
-		'Admin-only operator tools for accounts, flags, maintenance, and community metadata.',
+		'Admin-only operator tools for accounts, flags, signup gating, maintenance, and community metadata.',
 	keywords: [
 		'admin',
 		'rbac',
@@ -57,6 +59,7 @@ export const adminDomain = defineDomain({
 		'verify',
 		'audit',
 		'feature flags',
+		'signup mode',
 		'system email',
 		'platform feedback',
 		'community activity',
@@ -109,6 +112,8 @@ export const adminDomain = defineDomain({
 		adminFeatureFlagListCapability,
 		adminFeatureFlagSetCapability,
 		adminFeatureFlagOverrideCapability,
+		adminSignupModeGetCapability,
+		adminSignupModeSetCapability,
 		adminSystemEmailListCapability,
 		adminSystemEmailGetCapability,
 		adminSystemEmailSendCapability,

--- a/packages/worker/src/mcp/capabilities/admin/signup-mode-shared.ts
+++ b/packages/worker/src/mcp/capabilities/admin/signup-mode-shared.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod'
+import { signupModes } from '#universal/signup-mode.ts'
+
+export const signupModeSettingSchema = z.object({
+	mode: z.enum(signupModes),
+	source: z.enum(['kv', 'env']),
+	envDefault: z.enum(signupModes),
+	updatedAt: z.string().nullable(),
+	updatedBy: z.string().nullable(),
+})
+
+export const signupModeInputSchema = z.object({
+	mode: z
+		.enum(signupModes)
+		.describe('Signup gating mode: invite, open, or waitlist.'),
+})

--- a/packages/worker/src/mcp/capabilities/admin/signup-mode-shared.ts
+++ b/packages/worker/src/mcp/capabilities/admin/signup-mode-shared.ts
@@ -13,4 +13,9 @@ export const signupModeInputSchema = z.object({
 	mode: z
 		.enum(signupModes)
 		.describe('Signup gating mode: invite, open, or waitlist.'),
+	expectedCurrentMode: z
+		.enum(signupModes)
+		.describe(
+			'The mode the caller last read. The write is refused when it does not match the stored mode.',
+		),
 })

--- a/packages/worker/src/mcp/capabilities/registry.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/registry.node.test.ts
@@ -100,6 +100,8 @@ test('getCapabilityRegistryForContext filters admin capabilities by current call
 	expect(adminRegistry.capabilityMap.adminUserMeterParity).toBeTruthy()
 	expect(adminRegistry.capabilityMap.adminAccountDeletionAbort).toBeTruthy()
 	expect(adminRegistry.capabilityMap.adminMailboxMaintenance).toBeTruthy()
+	expect(adminRegistry.capabilityMap.adminSignupModeGet).toBeTruthy()
+	expect(adminRegistry.capabilityMap.adminSignupModeSet).toBeTruthy()
 	expect(
 		adminRegistry.capabilityMap.adminUserMeterStorageReconcile,
 	).toBeTruthy()
@@ -118,6 +120,8 @@ test('getCapabilityRegistryForContext filters admin capabilities by current call
 		regularRegistry.capabilityMap.adminUserMeterStorageReconcile,
 	).toBeUndefined()
 	expect(regularRegistry.capabilityMap.adminMailboxMaintenance).toBeUndefined()
+	expect(regularRegistry.capabilityMap.adminSignupModeGet).toBeUndefined()
+	expect(regularRegistry.capabilityMap.adminSignupModeSet).toBeUndefined()
 	expect(
 		regularRegistry.capabilityDomains.some((domain) => domain.name === 'admin'),
 	).toBe(false)

--- a/packages/worker/src/signup-mode-setting.node.test.ts
+++ b/packages/worker/src/signup-mode-setting.node.test.ts
@@ -11,6 +11,7 @@ import {
 	resolveSignupMode,
 	setSignupModeSetting,
 	SignupModeOpenWithoutTurnstileError,
+	SignupModeStaleWriteError,
 	signupModeKvKey,
 	signupModeKvReadFailedLogKey,
 } from './signup-mode-setting.ts'
@@ -139,9 +140,11 @@ test('signup mode setting: KV override, fallbacks, memo, setter, and Turnstile g
 	const setEnv = createEnv({ signupMode: 'invite', kv: setKv, turnstile: true })
 	expect(await resolveSignupMode(setEnv)).toBe('invite')
 	expect(setGetSpy).toHaveBeenCalledTimes(1)
+	const putSpy = vi.spyOn(setKv, 'put')
 	const changed = await setSignupModeSetting({
 		env: setEnv,
 		mode: 'open',
+		expectedCurrentMode: 'invite',
 		updatedBy: 'admin-stable-id',
 		actorEmail: 'admin@example.com',
 		path: '/admin/invites.json',
@@ -164,6 +167,20 @@ test('signup mode setting: KV override, fallbacks, memo, setter, and Turnstile g
 		}),
 	)
 	expect(auditEventSummaries()).toEqual(['signup_mode_set:success'])
+	expect(putSpy).toHaveBeenCalledTimes(1)
+
+	const storedAfterMatch = setKv.store.get(signupModeKvKey)
+	await expect(
+		setSignupModeSetting({
+			env: setEnv,
+			mode: 'waitlist',
+			expectedCurrentMode: 'invite',
+			updatedBy: 'admin-stable-id',
+		}),
+	).rejects.toThrow(SignupModeStaleWriteError)
+	expect(setKv.store.get(signupModeKvKey)).toBe(storedAfterMatch)
+	expect(putSpy).toHaveBeenCalledTimes(1)
+	expect(await resolveSignupMode(setEnv)).toBe('open')
 
 	const noTurnstileEnv = createEnv({
 		signupMode: 'invite',
@@ -174,6 +191,7 @@ test('signup mode setting: KV override, fallbacks, memo, setter, and Turnstile g
 		setSignupModeSetting({
 			env: noTurnstileEnv,
 			mode: 'open',
+			expectedCurrentMode: 'invite',
 			updatedBy: 'admin-stable-id',
 		}),
 	).rejects.toThrow(SignupModeOpenWithoutTurnstileError)

--- a/packages/worker/src/signup-mode-setting.node.test.ts
+++ b/packages/worker/src/signup-mode-setting.node.test.ts
@@ -1,0 +1,180 @@
+import { expect, test, vi } from 'vitest'
+import { consoleWarn } from '#worker/test-support/console-spies.ts'
+import {
+	auditEventSummaries,
+	logAuditEventSpy,
+} from '#worker/test-support/audit-log-spy.ts'
+import {
+	areTurnstileKeysConfigured,
+	clearSignupModeSettingCacheForTests,
+	loadSignupModeSetting,
+	resolveSignupMode,
+	setSignupModeSetting,
+	SignupModeOpenWithoutTurnstileError,
+	signupModeKvKey,
+	signupModeKvReadFailedLogKey,
+} from './signup-mode-setting.ts'
+
+function createMemoryKv(initial?: Record<string, string>) {
+	const store = new Map<string, string>(Object.entries(initial ?? {}))
+	return {
+		async get(key: string, type?: string) {
+			const raw = store.get(key)
+			if (raw === undefined) return null
+			return type === 'json' ? JSON.parse(raw) : raw
+		},
+		async put(key: string, value: string) {
+			store.set(key, value)
+		},
+		async delete(key: string) {
+			store.delete(key)
+		},
+		store,
+	} as unknown as KVNamespace & { store: Map<string, string> }
+}
+
+function createEnv(input?: {
+	signupMode?: 'invite' | 'open' | 'waitlist'
+	kv?: KVNamespace
+	turnstile?: boolean
+}) {
+	return {
+		SIGNUP_MODE: input?.signupMode ?? 'invite',
+		BUNDLE_ARTIFACTS_KV: input?.kv,
+		TURNSTILE_SITE_KEY: input?.turnstile ? 'site-key' : undefined,
+		TURNSTILE_SECRET_KEY: input?.turnstile ? 'secret-key' : undefined,
+		APP_DB: {} as D1Database,
+	} as unknown as Env
+}
+
+test('signup mode setting: KV override, fallbacks, memo, setter, and Turnstile guard', async () => {
+	expect(await resolveSignupMode(createEnv({ signupMode: 'invite' }))).toBe(
+		'invite',
+	)
+	expect(
+		await loadSignupModeSetting(createEnv({ signupMode: 'invite' })),
+	).toEqual({
+		mode: 'invite',
+		source: 'env',
+		envDefault: 'invite',
+		updatedAt: null,
+		updatedBy: null,
+	})
+
+	const overrideKv = createMemoryKv({
+		[signupModeKvKey]: JSON.stringify({
+			mode: 'open',
+			updatedAt: '2026-09-02T00:00:00.000Z',
+			updatedBy: 'admin-stable-id',
+		}),
+	})
+	const envWithOverride = createEnv({ signupMode: 'invite', kv: overrideKv })
+	expect(await resolveSignupMode(envWithOverride)).toBe('open')
+	expect(await loadSignupModeSetting(envWithOverride)).toEqual({
+		mode: 'open',
+		source: 'kv',
+		envDefault: 'invite',
+		updatedAt: '2026-09-02T00:00:00.000Z',
+		updatedBy: 'admin-stable-id',
+	})
+
+	clearSignupModeSettingCacheForTests()
+	consoleWarn.mockImplementation(() => {})
+	expect(
+		await resolveSignupMode(
+			createEnv({
+				signupMode: 'waitlist',
+				kv: createMemoryKv({ [signupModeKvKey]: '{not-json' }),
+			}),
+		),
+	).toBe('waitlist')
+	expect(consoleWarn).toHaveBeenCalledWith(
+		signupModeKvReadFailedLogKey,
+		expect.anything(),
+	)
+
+	clearSignupModeSettingCacheForTests()
+	expect(
+		await resolveSignupMode(
+			createEnv({
+				signupMode: 'invite',
+				kv: createMemoryKv({
+					[signupModeKvKey]: JSON.stringify({
+						mode: 'nope',
+						updatedAt: 'x',
+					}),
+				}),
+			}),
+		),
+	).toBe('invite')
+
+	expect(
+		await resolveSignupMode(
+			createEnv({ signupMode: 'open', kv: createMemoryKv() }),
+		),
+	).toBe('open')
+
+	clearSignupModeSettingCacheForTests()
+	vi.useFakeTimers()
+	const memoKv = createMemoryKv({
+		[signupModeKvKey]: JSON.stringify({
+			mode: 'waitlist',
+			updatedAt: '2026-09-02T00:00:00.000Z',
+			updatedBy: 'admin-stable-id',
+		}),
+	})
+	const getSpy = vi.spyOn(memoKv, 'get')
+	const memoEnv = createEnv({ signupMode: 'invite', kv: memoKv })
+	expect(await resolveSignupMode(memoEnv)).toBe('waitlist')
+	expect(await resolveSignupMode(memoEnv)).toBe('waitlist')
+	expect(getSpy).toHaveBeenCalledTimes(1)
+	await vi.advanceTimersByTimeAsync(30_000)
+	expect(await resolveSignupMode(memoEnv)).toBe('waitlist')
+	expect(getSpy).toHaveBeenCalledTimes(2)
+	vi.useRealTimers()
+
+	clearSignupModeSettingCacheForTests()
+	const setKv = createMemoryKv()
+	const setGetSpy = vi.spyOn(setKv, 'get')
+	const setEnv = createEnv({ signupMode: 'invite', kv: setKv, turnstile: true })
+	expect(await resolveSignupMode(setEnv)).toBe('invite')
+	expect(setGetSpy).toHaveBeenCalledTimes(1)
+	const changed = await setSignupModeSetting({
+		env: setEnv,
+		mode: 'open',
+		updatedBy: 'admin-stable-id',
+		actorEmail: 'admin@example.com',
+		path: '/admin/invites.json',
+	})
+	expect(changed.previous.mode).toBe('invite')
+	expect(changed.current).toMatchObject({
+		mode: 'open',
+		source: 'kv',
+		updatedBy: 'admin-stable-id',
+	})
+	const getsAfterSet = setGetSpy.mock.calls.length
+	expect(await resolveSignupMode(setEnv)).toBe('open')
+	expect(setGetSpy.mock.calls.length).toBe(getsAfterSet + 1)
+	expect(logAuditEventSpy).toHaveBeenCalledWith(
+		expect.objectContaining({
+			category: 'admin',
+			action: 'signup_mode_set',
+			result: 'success',
+			reason: 'old=invite;new=open',
+		}),
+	)
+	expect(auditEventSummaries()).toEqual(['signup_mode_set:success'])
+
+	const noTurnstileEnv = createEnv({
+		signupMode: 'invite',
+		kv: createMemoryKv(),
+	})
+	expect(areTurnstileKeysConfigured(noTurnstileEnv)).toBe(false)
+	await expect(
+		setSignupModeSetting({
+			env: noTurnstileEnv,
+			mode: 'open',
+			updatedBy: 'admin-stable-id',
+		}),
+	).rejects.toThrow(SignupModeOpenWithoutTurnstileError)
+})

--- a/packages/worker/src/signup-mode-setting.ts
+++ b/packages/worker/src/signup-mode-setting.ts
@@ -1,0 +1,185 @@
+import {
+	getSignupMode,
+	isSignupMode,
+	type SignupMode,
+	type SignupModeSetting,
+} from '#universal/signup-mode.ts'
+import { auditDatabaseFromEnv, logAuditEvent } from '#worker/audit-log.ts'
+
+export const signupModeKvKey = 'platform-settings:v1:signup-mode'
+const signupModeCacheTtlMs = 30_000
+export const signupModeKvReadFailedLogKey = 'signup-mode-kv-read-failed'
+
+type SignupModeRecord = {
+	mode: SignupMode
+	updatedAt: string
+	updatedBy: string
+}
+
+type SignupModeEnv = Pick<
+	Env,
+	| 'SIGNUP_MODE'
+	| 'BUNDLE_ARTIFACTS_KV'
+	| 'TURNSTILE_SITE_KEY'
+	| 'TURNSTILE_SECRET_KEY'
+	| 'APP_DB'
+	| 'AUDIT_DB'
+	| 'SENTRY_ENVIRONMENT'
+>
+
+let cacheGeneration = 0
+const memos = new WeakMap<
+	object,
+	{ expiresAt: number; pending: Promise<SignupMode>; generation: number }
+>()
+
+export function clearSignupModeSettingCacheForTests() {
+	cacheGeneration += 1
+}
+
+function parseSignupModeRecord(value: unknown): SignupModeRecord | null {
+	if (!value || typeof value !== 'object') return null
+	const record = value as Record<string, unknown>
+	if (!isSignupMode(record.mode)) return null
+	if (typeof record.updatedAt !== 'string' || record.updatedAt.length === 0) {
+		return null
+	}
+	if (typeof record.updatedBy !== 'string' || record.updatedBy.length === 0) {
+		return null
+	}
+	return {
+		mode: record.mode,
+		updatedAt: record.updatedAt,
+		updatedBy: record.updatedBy,
+	}
+}
+
+function envDefault(env: Pick<Env, 'SIGNUP_MODE'>): SignupMode {
+	return getSignupMode(env)
+}
+
+function envFallbackSetting(env: Pick<Env, 'SIGNUP_MODE'>): SignupModeSetting {
+	const mode = envDefault(env)
+	return {
+		mode,
+		source: 'env',
+		envDefault: mode,
+		updatedAt: null,
+		updatedBy: null,
+	}
+}
+
+export function areTurnstileKeysConfigured(
+	env: Pick<Env, 'TURNSTILE_SITE_KEY' | 'TURNSTILE_SECRET_KEY'>,
+) {
+	return Boolean(
+		env.TURNSTILE_SITE_KEY?.trim() && env.TURNSTILE_SECRET_KEY?.trim(),
+	)
+}
+
+export class SignupModeOpenWithoutTurnstileError extends Error {
+	constructor() {
+		super(
+			'Cannot set signup mode to open until TURNSTILE_SITE_KEY and TURNSTILE_SECRET_KEY are both configured.',
+		)
+		this.name = 'SignupModeOpenWithoutTurnstileError'
+	}
+}
+
+async function loadSignupModeSettingUncached(
+	env: SignupModeEnv,
+): Promise<SignupModeSetting> {
+	const fallback = envFallbackSetting(env)
+	const kv = env.BUNDLE_ARTIFACTS_KV
+	if (!kv) return fallback
+	try {
+		const parsed = parseSignupModeRecord(await kv.get(signupModeKvKey, 'json'))
+		if (!parsed) return fallback
+		return {
+			mode: parsed.mode,
+			source: 'kv',
+			envDefault: fallback.envDefault,
+			updatedAt: parsed.updatedAt,
+			updatedBy: parsed.updatedBy,
+		}
+	} catch (error) {
+		console.warn(signupModeKvReadFailedLogKey, error)
+		return fallback
+	}
+}
+
+export async function loadSignupModeSetting(
+	env: SignupModeEnv,
+): Promise<SignupModeSetting> {
+	return loadSignupModeSettingUncached(env)
+}
+
+export async function resolveSignupMode(
+	env: SignupModeEnv,
+): Promise<SignupMode> {
+	const now = Date.now()
+	const cached = memos.get(env)
+	if (
+		cached &&
+		cached.generation === cacheGeneration &&
+		cached.expiresAt > now
+	) {
+		return cached.pending
+	}
+	const pending = loadSignupModeSettingUncached(env).then(
+		(setting) => setting.mode,
+	)
+	memos.set(env, {
+		expiresAt: now + signupModeCacheTtlMs,
+		pending,
+		generation: cacheGeneration,
+	})
+	pending.catch(() => {
+		if (memos.get(env)?.pending === pending) memos.delete(env)
+	})
+	return pending
+}
+
+export async function setSignupModeSetting(input: {
+	env: SignupModeEnv
+	mode: SignupMode
+	updatedBy: string
+	actorEmail?: string
+	path?: string
+	ip?: string
+}): Promise<{ previous: SignupModeSetting; current: SignupModeSetting }> {
+	if (input.mode === 'open' && !areTurnstileKeysConfigured(input.env)) {
+		throw new SignupModeOpenWithoutTurnstileError()
+	}
+	const kv = input.env.BUNDLE_ARTIFACTS_KV
+	if (!kv) {
+		throw new Error('BUNDLE_ARTIFACTS_KV is required to persist signup mode.')
+	}
+	const previous = await loadSignupModeSettingUncached(input.env)
+	const updatedAt = new Date().toISOString()
+	const record: SignupModeRecord = {
+		mode: input.mode,
+		updatedAt,
+		updatedBy: input.updatedBy,
+	}
+	await kv.put(signupModeKvKey, JSON.stringify(record))
+	memos.delete(input.env)
+	const current: SignupModeSetting = {
+		mode: input.mode,
+		source: 'kv',
+		envDefault: previous.envDefault,
+		updatedAt,
+		updatedBy: input.updatedBy,
+	}
+	void logAuditEvent({
+		db: auditDatabaseFromEnv(input.env),
+		category: 'admin',
+		action: 'signup_mode_set',
+		result: 'success',
+		email: input.actorEmail,
+		ip: input.ip,
+		path: input.path,
+		reason: `old=${previous.mode};new=${input.mode}`,
+	})
+	return { previous, current }
+}

--- a/packages/worker/src/signup-mode-setting.ts
+++ b/packages/worker/src/signup-mode-setting.ts
@@ -86,6 +86,17 @@ export class SignupModeOpenWithoutTurnstileError extends Error {
 	}
 }
 
+export class SignupModeStaleWriteError extends Error {
+	readonly current: SignupModeSetting
+	constructor(current: SignupModeSetting) {
+		super(
+			`Signup mode changed. Current mode is ${current.mode}. Retry with expectedCurrentMode=${current.mode}.`,
+		)
+		this.name = 'SignupModeStaleWriteError'
+		this.current = current
+	}
+}
+
 async function loadSignupModeSettingUncached(
 	env: SignupModeEnv,
 ): Promise<SignupModeSetting> {
@@ -143,19 +154,23 @@ export async function resolveSignupMode(
 export async function setSignupModeSetting(input: {
 	env: SignupModeEnv
 	mode: SignupMode
+	expectedCurrentMode: SignupMode
 	updatedBy: string
 	actorEmail?: string
 	path?: string
 	ip?: string
 }): Promise<{ previous: SignupModeSetting; current: SignupModeSetting }> {
-	if (input.mode === 'open' && !areTurnstileKeysConfigured(input.env)) {
-		throw new SignupModeOpenWithoutTurnstileError()
-	}
 	const kv = input.env.BUNDLE_ARTIFACTS_KV
 	if (!kv) {
 		throw new Error('BUNDLE_ARTIFACTS_KV is required to persist signup mode.')
 	}
 	const previous = await loadSignupModeSettingUncached(input.env)
+	if (previous.mode !== input.expectedCurrentMode) {
+		throw new SignupModeStaleWriteError(previous)
+	}
+	if (input.mode === 'open' && !areTurnstileKeysConfigured(input.env)) {
+		throw new SignupModeOpenWithoutTurnstileError()
+	}
 	const updatedAt = new Date().toISOString()
 	const record: SignupModeRecord = {
 		mode: input.mode,

--- a/packages/worker/universal/loader-data.ts
+++ b/packages/worker/universal/loader-data.ts
@@ -15,7 +15,10 @@ import {
 	type OnboardingFeaturedMcpServer,
 	type OnboardingFeaturedMcpServerId,
 } from '#universal/onboarding-mcp-chooser.ts'
-import { type SignupMode } from '#universal/signup-mode.ts'
+import {
+	type SignupMode,
+	type SignupModeSetting,
+} from '#universal/signup-mode.ts'
 import {
 	type CommunityCategoryCounts,
 	type CommunityListingCategory,
@@ -350,6 +353,7 @@ export type AdminInvitesLoaderData = {
 	ok: true
 	invites: Array<AdminInviteListItem>
 	availablePlans: Array<AdminPlanName>
+	signupMode: SignupModeSetting
 }
 
 export type AdminFeatureFlagsLoaderData = {

--- a/packages/worker/universal/signup-mode.ts
+++ b/packages/worker/universal/signup-mode.ts
@@ -1,9 +1,19 @@
 export const signupModes = ['invite', 'open', 'waitlist'] as const
 export type SignupMode = (typeof signupModes)[number]
+export type SignupModeSource = 'kv' | 'env'
+
+export type SignupModeSetting = {
+	mode: SignupMode
+	source: SignupModeSource
+	envDefault: SignupMode
+	updatedAt: string | null
+	updatedBy: string | null
+}
+
+export function isSignupMode(value: unknown): value is SignupMode {
+	return value === 'open' || value === 'waitlist' || value === 'invite'
+}
 
 export function getSignupMode(env: { SIGNUP_MODE?: SignupMode }): SignupMode {
-	const mode = env.SIGNUP_MODE
-	return mode === 'open' || mode === 'waitlist' || mode === 'invite'
-		? mode
-		: 'invite'
+	return isSignupMode(env.SIGNUP_MODE) ? env.SIGNUP_MODE : 'invite'
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Let an admin switch signup between `invite`, `open`, and `waitlist` in under a minute, without a code change, a deploy, or a D1 migration.

## Why

`SIGNUP_MODE` was a Worker var: flipping it meant editing `wrangler.jsonc`, merging, and waiting ~6 minutes for the fleet deploy. Launch week needs a kill switch that works at the speed of a signup flood. The owner ruled out feature flags as the home for this.

## Summary

- **Storage:** one platform-owned KV key, `platform-settings:v1:signup-mode` in `BUNDLE_ARTIFACTS_KV` (`{ mode, updatedAt, updatedBy }`), alongside `public-code-runs:v2`. Not user-scoped; account deletion does not touch the prefix (covered by the deletion/surfaces tests).
- **Resolution:** `resolveSignupMode(env)` in `packages/worker/src/signup-mode-setting.ts` — KV override → `SIGNUP_MODE` env default → `invite`; 30 s per-isolate memo; invalid or unreadable KV falls back to the env default with a `signup-mode-kv-read-failed` warning. `SIGNUP_MODE` remains the bootstrap default so the Wrangler `test` env stays `open` for e2e.
- **All readers migrated** (password and social signup gates, auth page, home, pricing, discord page, waiting list, loader data); `getSignupMode(env)` in `universal/` is now only the env fallback.
- **Admin write path:** `adminSignupModeGet` / `adminSignupModeSet` capabilities (admin-only, audited with old→new mode) and a "Signup mode" control on `/admin/invites` (select, current source `kv`/`env`, last changed by/at, double-check before `open`). Setting `open` is refused unless both Turnstile keys are configured on the env.
- **Docs:** `project-intent.md`, `environment-variables.md`, `setup-manifest.md`, `data-storage.md` (KV contract), `security.md`, `authentication.md`, `adding-capabilities.md`, `primitives.yaml`.

Operator note: production stays in `invite` until an admin flips it; nothing changes at deploy time.

## Testing

`npm run typecheck`, `lint`, `format:check`, `docs:check-temporal`, `primitives:check`, `slop-ratchet:check`; node: `signup-mode-setting` (override wins, invalid/missing KV falls back, memo expiry, setter clears memo, `open` without Turnstile refused), `admin-signup-mode-capabilities`, `auth-handler` and `auth-provider` (KV `open` over env `invite` admits invite-less signup; KV `invite` over env `open` refuses), `account-deletion`, `user-owned-surfaces`, `registry`, `admin-invites-data` — 8 files / 44 tests.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends</b> signup gating and admin tools (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `50c3c1e3` · **Head:** `HEAD`

**Classification:** extends — signup mode moves from a deploy-time var to a KV-backed runtime setting with an admin write path; new platform-owned KV key.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `signup` | surfaces | extends — gate reads the runtime setting |
| `admin-tools` | features | extends — get/set capabilities + `/admin/invites` control |
| `kv-bundle-artifacts` | storage | extends — `platform-settings:v1:signup-mode` |
| `audit-log` | storage | composes — mode changes audited |

### Change flow

```mermaid
sequenceDiagram
	actor Admin
	participant ui as /admin/invites
	participant setting as signup-mode-setting
	participant kv as BUNDLE_ARTIFACTS_KV
	participant auth as POST /auth (signup)
	Admin->>ui: choose mode (double-check for open)
	ui->>setting: adminSignupModeSet({ mode })
	setting->>setting: refuse open without Turnstile keys
	setting->>kv: put platform-settings:v1:signup-mode
	Note over setting: audit_events admin row (old → new); memo cleared
	auth->>setting: resolveSignupMode(env)
	setting->>kv: get (30 s memo) → else SIGNUP_MODE env → else invite
	auth-->>auth: inviteRequired = mode !== 'open'
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b0f6a92a-81cd-4157-8b60-188c83ca84c0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b0f6a92a-81cd-4157-8b60-188c83ca84c0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

