### PR TITLE
Record the Vectorize per-user namespace ceiling decision (ADR 0047)

### DIFF
--- a/docs/contributing/decisions/0047-vectorize-per-user-namespaces-until-5k-users.md
+++ b/docs/contributing/decisions/0047-vectorize-per-user-namespaces-until-5k-users.md
@@ -1,0 +1,53 @@
+# 0047: One Vectorize index with per-user namespaces until 5,000 users
+
+- **Status:** accepted
+- **Date:** 2026-09-02
+
+## Context
+
+Every user-owned vector (memories, jobs, saved packages) lives in one Vectorize
+index, `CAPABILITY_VECTOR_INDEX`, inside a namespace named by the account's
+64-character `stable_user_id`
+(`packages/worker/src/vectorize/vector-namespaces.ts`). Builtin capability
+vectors use the reserved `__kody_builtin__` namespace. Namespace filtering is
+the primary isolation boundary and the `userId` metadata filter is defense in
+depth (see
+[Data storage](../architecture/data-storage.md#vectorize-metadata-contracts)).
+
+Cloudflare caps a Vectorize index at 50,000 namespaces on Workers Paid
+(https://developers.cloudflare.com/vectorize/platform/limits/). With one
+namespace per account, the 50,001st user's first embedding upsert fails. That
+failure is silent today: it surfaces as `saved_package_search_index_debt`
+accumulating and the reindex lane retrying forever, not as an alert.
+
+The 2026-09-01 launch audit flagged the ceiling. The account count at the time
+was 172, and the next agent to touch search would otherwise propose a sharding
+scheme (or a switch to metadata-only filtering) as part of an unrelated change.
+
+## Decision
+
+Keep one index with one namespace per user, and do not shard, split, or move to
+metadata-only filtering before the platform reaches 5,000 person accounts.
+
+When sharding becomes necessary, the shape is fixed now so it is not re-derived:
+N indexes bound as `CAPABILITY_VECTOR_INDEX_0..N-1`, an account's index chosen
+by the first hex byte of `stable_user_id` modulo N, the same per-user namespace
+inside the chosen index, and `__kody_builtin__` duplicated into every index so a
+single search still hits builtins plus the caller's namespace with one query per
+index. Existing accounts migrate by reindex
+(`POST /__maintenance/reindex-capabilities` with `force: true`), which is
+already the recovery path for Vectorize data loss. Do not drop namespace
+isolation in favour of a shared namespace with `userId` metadata: namespace
+filtering is applied before the similarity search and is the isolation boundary
+the security model relies on.
+
+## Consequences
+
+- Search stays one Vectorize query per call, and account deletion stays one
+  `deleteByIds` per user.
+- Nothing warns as the namespace count grows. `adminUserList.total` is the
+  proxy; the reviewer of any PR that adds a new per-user vector kind checks it.
+- Revisit when `adminUserList` reports 5,000 person accounts, or earlier if
+  Cloudflare lowers the per-index namespace limit or an upsert fails with a
+  namespace-limit error. At that point implement the shape above; the budget for
+  the change is one migration lane plus one reindex pass, not a redesign.

--- a/docs/contributing/decisions/index.md
+++ b/docs/contributing/decisions/index.md
@@ -93,6 +93,9 @@ Open these before proposing a new primitive, surface, or storage home.
 - [0046 — Community is the catalog; public is the visibility word](./0046-community-is-the-catalog.md)
   — no “community package” kind-name; do not rename `/community` or the MCP
   `community` domain; listing_* identifiers stay until a dual-declare cut
+- [0047 — One Vectorize index with per-user namespaces until 5,000 users](./0047-vectorize-per-user-namespaces-until-5k-users.md)
+  — no sharding or metadata-only filtering before 5k accounts; the shard shape
+  is pre-decided for when it is needed
 
 ## Historical / UI / implementation
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Write down the decision on the Vectorize namespace limit so nobody re-derives a sharding scheme inside an unrelated search change.

## Why

Every user-owned vector lives in one index under a per-user namespace; Cloudflare caps an index at 50,000 namespaces (Workers Paid). The 2026-09-01 audit flagged the ceiling; the failure mode is silent (reindex debt retrying forever). At 172 accounts this is not urgent, which is exactly when a steering record is cheapest.

## Summary

`docs/contributing/decisions/0047-vectorize-per-user-namespaces-until-5k-users.md`: keep one index and per-user namespaces; do not shard or switch to metadata-only filtering before 5,000 person accounts; pre-decide the shard shape (N indexes chosen by the first hex byte of `stable_user_id`, same namespace inside, builtins duplicated per index, migration by forced reindex); never trade namespace isolation for a shared namespace. Revisit-if: 5k accounts, a lowered platform limit, or a namespace-limit upsert error. Linked from the steering list in `decisions/index.md`.

## Testing

`npm run docs:check-decisions`, `npm run format:check`. Documentation only.

## System changes

Decision record only; no primitives touched.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b0f6a92a-81cd-4157-8b60-188c83ca84c0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b0f6a92a-81cd-4157-8b60-188c83ca84c0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

