### PR TITLE
Back up the kody-jobs D1 database alongside APP_DB

### DIFF
--- a/docs/contributing/disaster-recovery.md
+++ b/docs/contributing/disaster-recovery.md
@@ -442,10 +442,11 @@ import init/ingest etag. Without that prelude, drills fail with errors like
    manifest declares. Days without `d1Sources` restore APP_DB only and record
    `JOBS_DB: not present in this backup day` as a restore note, not a warning,
    so the Workflow instance completes. Days that list `d1Sources` restore every
-   listed database. Before any production write, restore HEAD/GET-verifies every
-   required SQL object (existence, size, sha256). It then safety-exports each
-   target and imports JOBS_DB (when listed) before APP_DB via the Cloudflare
-   API, then loops chunked
+   listed database. Before any production write, restore HEADs every required
+   SQL object for existence and size, then streams each body through a SHA-256
+   digest and discards it so SQL is not retained in memory. It then
+   safety-exports each target and imports JOBS_DB (when listed) before APP_DB by
+   streaming one database at a time via the Cloudflare API, then loops chunked
    `POST {PRIMARY_WORKER_ORIGIN}/__maintenance/dr-restore` with
    `Authorization: Bearer {DR_RESTORE_SECRET}` until the production worker
    reports `done` (StorageRunner replace, R2 put, published snapshot KV put).

--- a/docs/contributing/disaster-recovery.md
+++ b/docs/contributing/disaster-recovery.md
@@ -59,16 +59,17 @@ through its lifecycle.
 
 ## Objectives
 
-| Scope                 | RPO    | Notes                                                                                                                                                                                                               |
-| --------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| All canonical stores  | 24h    | D1, per-user Mailbox graphs, StorageRunner dumps, `EMAIL_BLOBS` / `COMMUNITY_ASSETS` blobs, published package/job source snapshots. `REPO_SESSION_BLOBS` is ephemeral session scratch and is not a canonical store. |
-| Selected RunLog state | 24h    | Never-pruned job observability, package-run success counters, and activation milestones; run history and correctness ledgers remain excluded                                                                        |
-| D1 freshness          | hourly | Control-plane size/ETag freshness; deep checksum via drill                                                                                                                                                          |
+| Scope                         | RPO    | Notes                                                                                                                                                                                                                            |
+| ----------------------------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| All canonical stores          | 24h    | APP_DB, JOBS_DB, per-user Mailbox graphs, StorageRunner dumps, `EMAIL_BLOBS` / `COMMUNITY_ASSETS` blobs, published package/job source snapshots. `REPO_SESSION_BLOBS` is ephemeral session scratch and is not a canonical store. |
+| APP_DB (`kody`)               | 24h    | Nightly control-plane D1 export; hourly size/ETag freshness; deep checksum via restore drill. Production size is ~117 MB — far below the 4.5 GB export ceiling (`BACKUP_MAX_SOURCE_BYTES`, not raisable above 4,500,000,000).    |
+| JOBS_DB (`kody-jobs`)         | 24h    | Nightly control-plane D1 export of scheduled-job definitions (`jobs`) and `archived_job_artifacts`; hourly freshness; isolated drill via `--database kody-jobs`. Job definitions do not live in APP_DB.                          |
+| Selected RunLog state         | 24h    | Never-pruned job observability, package-run success counters, and activation milestones; run history and correctness ledgers remain excluded                                                                                     |
+| D1 freshness (both databases) | hourly | Control-plane size/ETag freshness for every configured source; deep checksum via drill                                                                                                                                           |
 
 RTO is whatever the operator can achieve with the UI restore workflow after a
 successful sealed-day drill. There is no provider-level cross-store atomic
-snapshot. Current production D1 is ~117 MB — far below the 4.5 GB export ceiling
-(`BACKUP_MAX_SOURCE_BYTES`, not raisable above 4,500,000,000).
+snapshot.
 
 Retention (UTC):
 
@@ -86,11 +87,11 @@ administered **DR (“KCD”) Cloudflare account**:
 Production worker (source account)          Backup control plane (DR account)
 ───────────────────────────────             ────────────────────────────────
 Nightly */5 ticks 00:30–06:10 UTC           02:15 UTC: D1 export Workflow
-  stage Mailbox / selected RunLog state
-  / StorageRunner / R2 / artifacts      →   Hourly: D1 freshness + catch-up
-  into staging/{day}/...                    Hourly: seal complete days
-Daytime */15 ticks: staging catch-up        Admin UI: drill / production restore
-  resume a stranded day (≤2 days back)
+  stage Mailbox / selected RunLog state       (one instance per configured D1:
+  / StorageRunner / R2 / artifacts      →    APP_DB and JOBS_DB)
+  into staging/{day}/...                    Hourly: D1 freshness + catch-up
+Daytime */15 ticks: staging catch-up        Hourly: seal complete days
+  resume a stranded day (≤2 days back)      Admin UI: drill / production restore
 06:15 UTC: staging watchdog → Sentry
 ```
 
@@ -144,10 +145,21 @@ Contract: `packages/shared/src/backup-staging.ts`.
 
 1. **D1 (control plane)** — Dedicated Worker/Workflow in
    `packages/backup-control-plane/` calls the production-account D1 export API
-   with `CLOUDFLARE_API_TOKEN` (Account D1 Edit), streams SQL into the DR
-   bucket, and writes an Ed25519-signed schema-v2 manifest. Gates:
-   `ENABLE_PRODUCTION_D1_BACKUPS` and `BACKUP_BENCHMARK_APPROVED` must both be
-   exactly `"true"`. Schedule stays inert otherwise.
+   with `CLOUDFLARE_API_TOKEN` (Account D1 Edit) for every entry in
+   `SOURCE_DATABASES`: APP_DB (`kody`, `SOURCE_DATABASE_ID`) and JOBS_DB
+   (`kody-jobs`). Each database gets its own Workflow instance
+   (`d1-backup-<databaseId>-<day>`) and objects under
+   `<tier>/d1/<database-uuid>/<day>/`. The signed schema-v2 manifest records
+   that database's id, name, SQL byte count, and sha256. Restore drills sample
+   table counts after import; the manifest itself does not store row counts.
+   `SOURCE_DATABASE_ID` / `SOURCE_DATABASE_NAME` remain the primary APP_DB
+   identity (full-manifest `d1ManifestKey` and typed production-restore
+   confirmation). When `SOURCE_DATABASES` is unset, the control plane exports
+   only that primary database. Gates: `ENABLE_PRODUCTION_D1_BACKUPS` and
+   `BACKUP_BENCHMARK_APPROVED` must both be exactly `"true"`. Schedule stays
+   inert otherwise. The production `kody-jobs` UUID is the live D1 named
+   `kody-jobs`; deploy resolves it by name in
+   `tools/ci/jobs-worker-resources.ts` (`jobs_d1_database_id`).
 2. **Other canonical stores (production worker)** — When
    `DR_EXPORT_ENABLED=true` and DR S3 credentials are set, nightly ticks
    (`packages/worker/src/dr/exporter.ts`) stage:
@@ -202,10 +214,12 @@ Contract: `packages/shared/src/backup-staging.ts`.
      admission ceiling and summary-warning behavior as StorageRunner dumps.
 3. **Seal** — Control plane verifies staged checksums against
    `staging/{day}/exporter/summary.json`, requires a verified same-day D1
-   manifest, copies staged files under `daily/full/{day}/...`, and signs a
-   full-backup manifest (`packages/shared/src/backup-full-manifest.ts`). Hourly
-   freshness also attempts to seal the last three complete days; the UI can seal
-   a day on demand.
+   manifest for every configured source (APP_DB and JOBS_DB), copies staged
+   files under `daily/full/{day}/...`, and signs a full-backup manifest
+   (`packages/shared/src/backup-full-manifest.ts`). The sealed full-manifest
+   `d1ManifestKey` still points at the primary APP_DB export. Hourly freshness
+   also attempts to seal the last three complete days; the UI can seal a day on
+   demand.
 
 ### Restore-safe row sizes
 
@@ -245,6 +259,7 @@ Restore rebuilds the derived stores below; do not treat them as recovery media:
   upserts.
 - OAuth KV / browser sessions / provider tokens — users reconnect
 - Queues, Workflow instances, Durable Object alarms — recreate from config + D1
+  (`JobManager` alarms rebuild from restored `JOBS_DB`)
 - Derived community icons and ordinary KV caches
 - **UserMeter** — daily entitlement counters self-prune and can be
   re-established by traffic; authoritative storage-byte state is corrected by
@@ -280,7 +295,9 @@ Restore rebuilds the derived stores below; do not treat them as recovery media:
   **accepted-unprotected** operator/security evidence, not user content
   (confirmed 2026-08-07): losing the retained audit trail in a DR account-loss
   event is acceptable; new events accumulate again after restore. Revisit only
-  if forensics retention across account loss becomes a requirement.
+  if forensics retention across account loss becomes a requirement. Scheduled
+  job definitions live in `JOBS_DB` (`kody-jobs`) and are part of the nightly D1
+  export; APP_DB does not store them.
 
 ### Honest gaps
 
@@ -386,9 +403,9 @@ Routes (all require Access JWT):
 | Method | Path                       | Action                                                                                                                             |
 | ------ | -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
 | `GET`  | `/`                        | Dashboard: enable gates, source identity, live D1 size, escrow presence, 14-day D1/staging/seal status with signature verification |
-| `POST` | `/actions/run-backup`      | Enqueue today's D1 backup Workflow (respects enable gates)                                                                         |
-| `POST` | `/actions/seal-day`        | Verify staging + D1 manifest and seal `daily/full/{day}/...`                                                                       |
-| `POST` | `/actions/run-drill`       | Isolated restore drill (fresh D1 in `DRILL_ACCOUNT_ID`, never production)                                                          |
+| `POST` | `/actions/run-backup`      | Enqueue today's D1 backup Workflow for every configured source (APP_DB and JOBS_DB)                                                |
+| `POST` | `/actions/seal-day`        | Verify staging + every configured D1 manifest and seal `daily/full/{day}/...`                                                      |
+| `POST` | `/actions/run-drill`       | Isolated restore drill of one selected database (fresh D1 in `DRILL_ACCOUNT_ID`, never production)                                 |
 | `POST` | `/actions/restore/prepare` | Validate sealed day; issue 10-minute HMAC confirm token                                                                            |
 | `POST` | `/actions/restore/execute` | Require typed exact `SOURCE_DATABASE_NAME` + valid token; start restore Workflow                                                   |
 | `GET`  | `/restore-status?id=...`   | Poll restore Workflow status                                                                                                       |
@@ -396,10 +413,13 @@ Routes (all require Access JWT):
 ### Isolated restore drill
 
 Creates `kody-dr-drill-{day}-{hex}` in `DRILL_ACCOUNT_ID` (must differ from
-`SOURCE_ACCOUNT_ID`), imports the day's signed D1 SQL, runs
+`SOURCE_ACCOUNT_ID`), imports one selected database's signed D1 SQL (UI
+`database` select, or CLI `--database kody` / `--database kody-jobs`), runs
 `PRAGMA quick_check`, samples table counts, then deletes the drill database on
-success (keeps it on failure for inspection). This path does not restore
-StorageRunner/R2/artifacts into production.
+success (keeps it on failure for inspection). The CLI points `migrations_dir` at
+`packages/worker/migrations` for APP_DB and `packages/jobs-worker/migrations`
+for `kody-jobs`. This path does not restore StorageRunner/R2/artifacts into
+production. Run the drill once per database when proving a sealed day.
 
 D1 remote import enforces foreign keys while applying `CREATE TABLE`, but
 Cloudflare exports are not topologically ordered. Before upload, the control
@@ -412,9 +432,10 @@ import init/ingest etag. Without that prelude, drills fail with errors like
 
 1. **Prepare** — sealed full manifest + D1 manifest signatures must verify; UI
    shows SQL key/bytes/sha256 and a short-lived confirm token.
-2. **Execute** — operator types the exact production database name; Workflow
-   `kody-production-dr-restore` imports SQL into production D1 via the
-   Cloudflare API, then loops chunked
+2. **Execute** — operator types the exact primary production database name
+   (`SOURCE_DATABASE_NAME`, APP_DB `kody`); Workflow
+   `kody-production-dr-restore` imports SQL into every configured production D1
+   (APP_DB then JOBS_DB) via the Cloudflare API, then loops chunked
    `POST {PRIMARY_WORKER_ORIGIN}/__maintenance/dr-restore` with
    `Authorization: Bearer {DR_RESTORE_SECRET}` until the production worker
    reports `done` (StorageRunner replace, R2 put, published snapshot KV put).
@@ -424,9 +445,11 @@ import init/ingest etag. Without that prelude, drills fail with errors like
 
 Disable ingress / put the app in maintenance before execute. After restore:
 reindex Vectorize (`POST /__maintenance/reindex-capabilities` with
-`{ "force": true }`, omit `phases`, follow `cursor` until `complete`), re-arm
-jobs/alarms from D1, recreate queues from Wrangler config, and expect users to
-reauthorize OAuth and reconnect MCP servers.
+`{ "force": true }`, omit `phases`, follow `cursor` until `complete`); let
+`kody-jobs` re-arm JobManager Durable Object alarms from restored `JOBS_DB`
+(`jobs.next_run_at` via `JobManager.syncAlarm` and the jobs-worker watchdog —
+APP_DB is not the job schedule store); recreate queues from Wrangler config; and
+expect users to reauthorize OAuth and reconnect MCP servers.
 
 ### Durable Object point-in-time recovery
 
@@ -617,14 +640,14 @@ the correctness spec and incident-only fallback:
 
 ## Schedules and freshness
 
-| When (UTC)                       | Who               | What                                                                                                                     |
-| -------------------------------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------ |
-| `*/5` during 00:30–06:10         | Production worker | Stage Mailbox, selected RunLog state, and other non-D1 stores for the current UTC day (cheap no-op once complete)        |
-| Every 15 min outside 00:30–06:10 | Production worker | Staging catch-up: resume the most recent stranded day (progress without summary, today − ≤2 days); cheap no-op otherwise |
-| 06:15                            | Production worker | Staging watchdog: a missing `exporter/summary.json` for today, or an earlier stranded day, fails the lane → Sentry       |
-| 02:15                            | Control plane     | Primary D1 export Workflow                                                                                               |
-| 02:45–05:45 hourly               | Control plane     | Catch-up create/restart of same-day D1 Workflow                                                                          |
-| Hourly `:45`                     | Control plane     | D1 freshness (identity, size ceiling, manifest age ≤26h, R2 size/ETag) + seal recent complete days                       |
+| When (UTC)                       | Who               | What                                                                                                                           |
+| -------------------------------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `*/5` during 00:30–06:10         | Production worker | Stage Mailbox, selected RunLog state, and other non-D1 stores for the current UTC day (cheap no-op once complete)              |
+| Every 15 min outside 00:30–06:10 | Production worker | Staging catch-up: resume the most recent stranded day (progress without summary, today − ≤2 days); cheap no-op otherwise       |
+| 06:15                            | Production worker | Staging watchdog: a missing `exporter/summary.json` for today, or an earlier stranded day, fails the lane → Sentry             |
+| 02:15                            | Control plane     | Primary D1 export Workflow per configured database (APP_DB and JOBS_DB)                                                        |
+| 02:45–05:45 hourly               | Control plane     | Catch-up create/restart of same-day D1 Workflows                                                                               |
+| Hourly `:45`                     | Control plane     | D1 freshness for every configured source (identity, size ceiling, manifest age ≤26h, R2 size/ETag) + seal recent complete days |
 
 ### Stranded staging days (manual finish)
 
@@ -672,7 +695,8 @@ The UI is the primary drill/restore path. Keep the CLIs for air-gapped or
 UI-down recovery:
 
 - `node tools/disaster-recovery/d1-restore-drill-cli.ts` — isolated D1 import
-  against checked-in identity/baseline/manifest-key registries
+  against checked-in identity/baseline/manifest-key registries. Pass
+  `--database kody` or `--database kody-jobs` to select the export.
 - `node tools/disaster-recovery/canonical-readiness-cli.ts` — fail-closed
   readiness assessment from local Ed25519 evidence envelopes
 - `node tools/disaster-recovery/seal-escrow.ts` — same seal used by
@@ -707,8 +731,8 @@ Work top-to-bottom. Leave gates false until the matching gate item is done.
 
 - [ ] DR Cloudflare account exists and is administered separately from
       production.
-- [ ] Production source identities recorded: account id, D1 UUID, exact database
-      name (`kody`), Worker origin, R2 bucket names.
+- [ ] Production source identities recorded: account id, APP_DB UUID/name
+      (`kody`), JOBS_DB UUID/name (`kody-jobs`), Worker origin, R2 bucket names.
 - [ ] Drill account id differs from production; recorded as `DRILL_ACCOUNT_ID`.
 - [ ] Provisioner plan/apply creates the private DR bucket with `daily/` (35d)
       and `weekly/` (400d) lock/lifecycle rules; provisioner token never becomes
@@ -789,7 +813,9 @@ Work top-to-bottom. Leave gates false until the matching gate item is done.
 - D1 `file_size` ≥ 4.5 GB or any export/restore object ≥ 5 GiB (rejected)
 - Multipart D1 capture / statement-safe split restore
 - Full Artifacts Git history or unpublished repo-session work
-- Backup of Vectorize, OAuth KV, queues, Workflow runtime, alarms (rebuild)
+- Backup of Vectorize, OAuth KV, queues, Workflow runtime, Durable Object alarms
+  (JobManager rebuilds alarms from restored `JOBS_DB`; other DOs follow their
+  own restore or accepted-loss paths)
 - Backup of `RunLog` run records and logs (observability; ~30 day DO
   self-retention), invocation idempotency ledger, and workflow projections;
   never-pruned job observability and activation state are backed up

--- a/docs/contributing/disaster-recovery.md
+++ b/docs/contributing/disaster-recovery.md
@@ -214,12 +214,16 @@ Contract: `packages/shared/src/backup-staging.ts`.
      admission ceiling and summary-warning behavior as StorageRunner dumps.
 3. **Seal** — Control plane verifies staged checksums against
    `staging/{day}/exporter/summary.json`, requires a verified same-day D1
-   manifest for every configured source (APP_DB and JOBS_DB), copies staged
-   files under `daily/full/{day}/...`, and signs a full-backup manifest
-   (`packages/shared/src/backup-full-manifest.ts`). The sealed full-manifest
-   `d1ManifestKey` still points at the primary APP_DB export. Hourly freshness
-   also attempts to seal the last three complete days; the UI can seal a day on
-   demand.
+   manifest for every configured source (APP_DB and JOBS_DB) when sealing a new
+   day, copies staged files under `daily/full/{day}/...`, and signs a
+   full-backup manifest (`packages/shared/src/backup-full-manifest.ts`). New
+   seals record every configured D1 under optional payload `d1Sources`.
+   Historical days without `d1Sources` (schema-v1 and earlier schema-v2 mailbox
+   seals) stay restorable as APP_DB-only. Already-sealed days short-circuit
+   before source checks, so hourly seal does not treat them as incomplete when a
+   later-configured database is absent. The sealed full-manifest `d1ManifestKey`
+   still points at the primary APP_DB export. Hourly freshness also attempts to
+   seal the last three complete days; the UI can seal a day on demand.
 
 ### Restore-safe row sizes
 
@@ -434,8 +438,13 @@ import init/ingest etag. Without that prelude, drills fail with errors like
    shows SQL key/bytes/sha256 and a short-lived confirm token.
 2. **Execute** — operator types the exact primary production database name
    (`SOURCE_DATABASE_NAME`, APP_DB `kody`); Workflow
-   `kody-production-dr-restore` imports SQL into every configured production D1
-   (APP_DB then JOBS_DB) via the Cloudflare API, then loops chunked
+   `kody-production-dr-restore` restores the databases that sealed day's
+   manifest declares. Days without `d1Sources` restore APP_DB only and report
+   `JOBS_DB: not present in this backup day`. Days that list `d1Sources` restore
+   every listed database. Before any production write, restore HEAD/GET-verifies
+   every required SQL object (existence, size, sha256). It then safety-exports
+   each target and imports JOBS_DB (when listed) before APP_DB via the
+   Cloudflare API, then loops chunked
    `POST {PRIMARY_WORKER_ORIGIN}/__maintenance/dr-restore` with
    `Authorization: Bearer {DR_RESTORE_SECRET}` until the production worker
    reports `done` (StorageRunner replace, R2 put, published snapshot KV put).

--- a/docs/contributing/disaster-recovery.md
+++ b/docs/contributing/disaster-recovery.md
@@ -439,12 +439,13 @@ import init/ingest etag. Without that prelude, drills fail with errors like
 2. **Execute** — operator types the exact primary production database name
    (`SOURCE_DATABASE_NAME`, APP_DB `kody`); Workflow
    `kody-production-dr-restore` restores the databases that sealed day's
-   manifest declares. Days without `d1Sources` restore APP_DB only and report
-   `JOBS_DB: not present in this backup day`. Days that list `d1Sources` restore
-   every listed database. Before any production write, restore HEAD/GET-verifies
-   every required SQL object (existence, size, sha256). It then safety-exports
-   each target and imports JOBS_DB (when listed) before APP_DB via the
-   Cloudflare API, then loops chunked
+   manifest declares. Days without `d1Sources` restore APP_DB only and record
+   `JOBS_DB: not present in this backup day` as a restore note, not a warning,
+   so the Workflow instance completes. Days that list `d1Sources` restore every
+   listed database. Before any production write, restore HEAD/GET-verifies every
+   required SQL object (existence, size, sha256). It then safety-exports each
+   target and imports JOBS_DB (when listed) before APP_DB via the Cloudflare
+   API, then loops chunked
    `POST {PRIMARY_WORKER_ORIGIN}/__maintenance/dr-restore` with
    `Authorization: Bearer {DR_RESTORE_SECRET}` until the production worker
    reports `done` (StorageRunner replace, R2 put, published snapshot KV put).

--- a/docs/contributing/environment-variables.md
+++ b/docs/contributing/environment-variables.md
@@ -449,7 +449,14 @@ Non-secret vars:
 - `ENABLE_PRODUCTION_D1_BACKUPS` / `BACKUP_BENCHMARK_APPROVED` — both must be
   exactly `"true"` or schedules stay inert.
 - `SOURCE_ACCOUNT_ID` / `SOURCE_DATABASE_ID` / `SOURCE_DATABASE_NAME` plus
-  `ALLOWED_SOURCE_ACCOUNT_IDS` / `ALLOWED_SOURCE_DATABASE_IDS`.
+  `SOURCE_DATABASES` (JSON array of `{ id, name }` objects; the nightly path
+  exports every entry) and `ALLOWED_SOURCE_ACCOUNT_IDS` /
+  `ALLOWED_SOURCE_DATABASE_IDS`. `SOURCE_DATABASE_ID` / `SOURCE_DATABASE_NAME`
+  are the primary APP_DB (`kody`) identity and the single-database fallback when
+  `SOURCE_DATABASES` is unset. Every listed id must appear in
+  `ALLOWED_SOURCE_DATABASE_IDS`. Production `kody-jobs` UUID is the live D1
+  named `kody-jobs`; deploy resolves it by name in
+  `tools/ci/jobs-worker-resources.ts` (`jobs_d1_database_id`).
 - `BACKUP_MANIFEST_SIGNING_KEY_ID`,
   `BACKUP_MANIFEST_VERIFYING_PUBLIC_KEY_SPKI_BASE64`,
   `TRUSTED_RESTORE_BASELINE_ID`, `TRUSTED_RESTORE_BASELINE_SHA256`.

--- a/packages/backup-control-plane/backup-policy.node.test.ts
+++ b/packages/backup-control-plane/backup-policy.node.test.ts
@@ -1,19 +1,38 @@
 import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
 
 import { test } from 'vitest'
 
 import {
 	BackupError,
+	assertConfiguredIdentity,
 	assertRemoteDatabaseIdentity,
 	backupPayload,
+	configuredSourceDatabases,
 	isBackupEnabled,
 	objectKeyForBookmark,
+	resolveSourceDatabase,
+	sourceDatabaseFromObjectPrefix,
 	workflowInstanceId,
 } from './backup-policy.ts'
 import {
 	DATABASE_ID,
 	environment,
 } from './backup-control-plane-test-support.ts'
+
+const PRODUCTION_APP_DB_ID = '8c1014d1-6b41-4695-a0a2-159071f0f919'
+const PRODUCTION_JOBS_DB_ID = '5410331e-4d25-47e4-a1e5-a248f7cc764c'
+const JOBS_DATABASE_ID = '44444444-4444-4444-8444-444444444444'
+
+function multiDatabaseEnv() {
+	const env = environment()
+	env.SOURCE_DATABASES = JSON.stringify([
+		{ id: env.SOURCE_DATABASE_ID, name: env.SOURCE_DATABASE_NAME },
+		{ id: JOBS_DATABASE_ID, name: 'kody-jobs' },
+	])
+	env.ALLOWED_SOURCE_DATABASE_IDS = `${env.SOURCE_DATABASE_ID},${JOBS_DATABASE_ID}`
+	return env
+}
 
 test('requires both explicit enable and benchmark approval', () => {
 	const env = environment()
@@ -115,5 +134,107 @@ test('bookmark-derived keys reject unsafe bookmark path input', () => {
 	assert.notEqual(
 		objectKeyForBookmark(prefix, 'bookmark-1'),
 		objectKeyForBookmark(prefix, 'bookmark-2'),
+	)
+})
+
+test('falls back to SOURCE_DATABASE_ID when SOURCE_DATABASES is unset', () => {
+	const env = environment()
+	assert.deepEqual(configuredSourceDatabases(env), [
+		{ id: DATABASE_ID, name: 'production-db' },
+	])
+	assert.deepEqual(resolveSourceDatabase(env, undefined), {
+		id: DATABASE_ID,
+		name: 'production-db',
+	})
+})
+
+test('exports a database-specific prefix for each SOURCE_DATABASES entry', () => {
+	const env = multiDatabaseEnv()
+	assert.deepEqual(configuredSourceDatabases(env), [
+		{ id: DATABASE_ID, name: 'production-db' },
+		{ id: JOBS_DATABASE_ID, name: 'kody-jobs' },
+	])
+	const app = backupPayload(env, new Date('2026-07-22T02:15:00Z'))
+	assert.equal(app.objectPrefix, `daily/d1/${DATABASE_ID}/2026-07-22`)
+	const jobs = backupPayload(env, new Date('2026-07-22T02:15:00Z'), {
+		id: JOBS_DATABASE_ID,
+		name: 'kody-jobs',
+	})
+	assert.equal(jobs.objectPrefix, `daily/d1/${JOBS_DATABASE_ID}/2026-07-22`)
+	assert.equal(
+		jobs.manifestKey,
+		`daily/d1/${JOBS_DATABASE_ID}/2026-07-22/manifest.json`,
+	)
+	assert.equal(
+		workflowInstanceId(JOBS_DATABASE_ID, jobs.day),
+		`d1-backup-${JOBS_DATABASE_ID}-2026-07-22`,
+	)
+	assert.deepEqual(
+		sourceDatabaseFromObjectPrefix(
+			env,
+			jobs.objectPrefix,
+			jobs.day,
+			jobs.retentionTier,
+		),
+		{ id: JOBS_DATABASE_ID, name: 'kody-jobs' },
+	)
+	assert.deepEqual(resolveSourceDatabase(env, 'kody-jobs'), {
+		id: JOBS_DATABASE_ID,
+		name: 'kody-jobs',
+	})
+	assert.deepEqual(resolveSourceDatabase(env, JOBS_DATABASE_ID.toUpperCase()), {
+		id: JOBS_DATABASE_ID,
+		name: 'kody-jobs',
+	})
+	assert.throws(
+		() => resolveSourceDatabase(env, 'unknown-db'),
+		(error: unknown) =>
+			error instanceof BackupError && error.code === 'unknown-source-database',
+	)
+})
+
+test('rejects SOURCE_DATABASES entries that are missing from the allowlist', () => {
+	const env = multiDatabaseEnv()
+	env.ALLOWED_SOURCE_DATABASE_IDS = DATABASE_ID
+	assert.throws(
+		() => assertConfiguredIdentity(env),
+		(error: unknown) =>
+			error instanceof BackupError && error.code === 'source-not-allowlisted',
+	)
+})
+
+test('requires SOURCE_DATABASE_ID/NAME to appear in SOURCE_DATABASES', () => {
+	const env = environment()
+	env.SOURCE_DATABASES = JSON.stringify([
+		{ id: JOBS_DATABASE_ID, name: 'kody-jobs' },
+	])
+	env.ALLOWED_SOURCE_DATABASE_IDS = `${DATABASE_ID},${JOBS_DATABASE_ID}`
+	assert.throws(
+		() => assertConfiguredIdentity(env),
+		(error: unknown) =>
+			error instanceof BackupError && error.code === 'source-not-allowlisted',
+	)
+})
+
+test('committed control-plane allowlist includes production kody-jobs', async () => {
+	const wrangler = await readFile(
+		new URL('./wrangler.jsonc', import.meta.url),
+		'utf8',
+	)
+	assert.match(
+		wrangler,
+		new RegExp(
+			`"ALLOWED_SOURCE_DATABASE_IDS": "${PRODUCTION_APP_DB_ID},${PRODUCTION_JOBS_DB_ID}"`,
+		),
+	)
+	assert.ok(
+		wrangler.includes(
+			`\\"${PRODUCTION_JOBS_DB_ID}\\",\\"name\\":\\"kody-jobs\\"`,
+		),
+		'SOURCE_DATABASES must list production kody-jobs',
+	)
+	assert.ok(
+		wrangler.includes(`\\"${PRODUCTION_APP_DB_ID}\\",\\"name\\":\\"kody\\"`),
+		'SOURCE_DATABASES must list production kody',
 	)
 })

--- a/packages/backup-control-plane/backup-policy.node.test.ts
+++ b/packages/backup-control-plane/backup-policy.node.test.ts
@@ -5,7 +5,7 @@ import { test } from 'vitest'
 
 import {
 	BackupError,
-	absentConfiguredSourceWarning,
+	absentConfiguredSourceNote,
 	assertConfiguredIdentity,
 	assertRemoteDatabaseIdentity,
 	backupPayload,
@@ -243,7 +243,7 @@ test('committed control-plane allowlist includes production kody-jobs', async ()
 	)
 })
 
-test('declaredSourceDatabases uses the sealed day list and warns for absent configured DBs', () => {
+test('declaredSourceDatabases uses the sealed day list and notes absent configured DBs', () => {
 	const env = multiDatabaseEnv()
 	assert.deepEqual(declaredSourceDatabases(env), [primarySourceDatabase(env)])
 	assert.deepEqual(declaredSourceDatabases(env, []), [
@@ -278,7 +278,7 @@ test('declaredSourceDatabases uses the sealed day list and warns for absent conf
 		],
 	)
 	assert.equal(
-		absentConfiguredSourceWarning({
+		absentConfiguredSourceNote({
 			id: JOBS_DATABASE_ID,
 			name: 'kody-jobs',
 		}),

--- a/packages/backup-control-plane/backup-policy.node.test.ts
+++ b/packages/backup-control-plane/backup-policy.node.test.ts
@@ -5,13 +5,17 @@ import { test } from 'vitest'
 
 import {
 	BackupError,
+	absentConfiguredSourceWarning,
 	assertConfiguredIdentity,
 	assertRemoteDatabaseIdentity,
 	backupPayload,
 	configuredSourceDatabases,
+	declaredSourceDatabases,
 	isBackupEnabled,
 	objectKeyForBookmark,
+	primarySourceDatabase,
 	resolveSourceDatabase,
+	restoreImportOrder,
 	sourceDatabaseFromObjectPrefix,
 	workflowInstanceId,
 } from './backup-policy.ts'
@@ -236,5 +240,62 @@ test('committed control-plane allowlist includes production kody-jobs', async ()
 	assert.ok(
 		wrangler.includes(`\\"${PRODUCTION_APP_DB_ID}\\",\\"name\\":\\"kody\\"`),
 		'SOURCE_DATABASES must list production kody',
+	)
+})
+
+test('declaredSourceDatabases uses the sealed day list and warns for absent configured DBs', () => {
+	const env = multiDatabaseEnv()
+	assert.deepEqual(declaredSourceDatabases(env), [primarySourceDatabase(env)])
+	assert.deepEqual(declaredSourceDatabases(env, []), [
+		primarySourceDatabase(env),
+	])
+	const declared = [
+		{
+			databaseId: DATABASE_ID,
+			databaseName: 'production-db',
+			manifestKey: `daily/d1/${DATABASE_ID}/2026-07-22/manifest.json`,
+			manifestSha256: 'a'.repeat(64),
+		},
+		{
+			databaseId: JOBS_DATABASE_ID,
+			databaseName: 'kody-jobs',
+			manifestKey: `daily/d1/${JOBS_DATABASE_ID}/2026-07-22/manifest.json`,
+			manifestSha256: 'b'.repeat(64),
+		},
+	]
+	assert.deepEqual(declaredSourceDatabases(env, declared), [
+		{ id: DATABASE_ID, name: 'production-db' },
+		{ id: JOBS_DATABASE_ID, name: 'kody-jobs' },
+	])
+	assert.deepEqual(
+		restoreImportOrder(declaredSourceDatabases(env, declared), {
+			id: DATABASE_ID,
+			name: 'production-db',
+		}),
+		[
+			{ id: JOBS_DATABASE_ID, name: 'kody-jobs' },
+			{ id: DATABASE_ID, name: 'production-db' },
+		],
+	)
+	assert.equal(
+		absentConfiguredSourceWarning({
+			id: JOBS_DATABASE_ID,
+			name: 'kody-jobs',
+		}),
+		'JOBS_DB: not present in this backup day',
+	)
+	assert.throws(
+		() =>
+			declaredSourceDatabases(env, [
+				{
+					databaseId: '55555555-5555-4555-8555-555555555555',
+					databaseName: 'other',
+					manifestKey: 'daily/d1/other/2026-07-22/manifest.json',
+					manifestSha256: 'c'.repeat(64),
+				},
+			]),
+		(error: unknown) =>
+			error instanceof BackupError &&
+			error.code === 'restore-d1-source-not-configured',
 	)
 })

--- a/packages/backup-control-plane/backup-policy.ts
+++ b/packages/backup-control-plane/backup-policy.ts
@@ -141,6 +141,65 @@ export function configuredSourceDatabases(
 	return parseSourceDatabasesJson(env.SOURCE_DATABASES)
 }
 
+export type DeclaredD1Source = {
+	databaseId: string
+	databaseName: string
+	manifestKey: string
+	manifestSha256: string
+}
+
+export function declaredSourceDatabases(
+	env: BackupEnvironment,
+	declared?: Array<DeclaredD1Source>,
+): Array<SourceDatabase> {
+	if (declared === undefined || declared.length === 0) {
+		return [primarySourceDatabase(env)]
+	}
+	const configured = configuredSourceDatabases(env)
+	const sources: Array<SourceDatabase> = []
+	for (const entry of declared) {
+		const match = configured.find(
+			(source) =>
+				source.id.toLowerCase() === entry.databaseId.toLowerCase() &&
+				source.name === entry.databaseName,
+		)
+		if (match === undefined) {
+			throw new BackupError(
+				'restore-d1-source-not-configured',
+				`sealed D1 source ${entry.databaseName} (${entry.databaseId}) is not configured`,
+			)
+		}
+		sources.push(match)
+	}
+	return sources
+}
+
+export function absentConfiguredSourceWarning(source: SourceDatabase): string {
+	if (source.name === 'kody-jobs') {
+		return 'JOBS_DB: not present in this backup day'
+	}
+	return `${source.name}: not present in this backup day`
+}
+
+export function restoreImportOrder(
+	sources: Array<SourceDatabase>,
+	primary: SourceDatabase,
+): Array<SourceDatabase> {
+	const others = sources.filter(
+		(source) => source.id.toLowerCase() !== primary.id.toLowerCase(),
+	)
+	const primarySource = sources.find(
+		(source) => source.id.toLowerCase() === primary.id.toLowerCase(),
+	)
+	if (primarySource === undefined) {
+		throw new BackupError(
+			'restore-d1-source-not-configured',
+			'sealed D1 sources do not include the primary database',
+		)
+	}
+	return [...others, primarySource]
+}
+
 export function bindSourceDatabase(
 	env: BackupEnvironment,
 	source: SourceDatabase,

--- a/packages/backup-control-plane/backup-policy.ts
+++ b/packages/backup-control-plane/backup-policy.ts
@@ -174,7 +174,7 @@ export function declaredSourceDatabases(
 	return sources
 }
 
-export function absentConfiguredSourceWarning(source: SourceDatabase): string {
+export function absentConfiguredSourceNote(source: SourceDatabase): string {
 	if (source.name === 'kody-jobs') {
 		return 'JOBS_DB: not present in this backup day'
 	}

--- a/packages/backup-control-plane/backup-policy.ts
+++ b/packages/backup-control-plane/backup-policy.ts
@@ -9,6 +9,11 @@ import {
 const CLOUDFLARE_ID_PATTERN =
 	/^(?:[0-9a-f]{32}|[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})$/i
 
+export type SourceDatabase = {
+	id: string
+	name: string
+}
+
 export class BackupError extends Error {
 	readonly code: string
 	readonly retryable: boolean
@@ -45,6 +50,161 @@ function parseAllowlist(value: string, field: string): Set<string> {
 	return new Set(entries)
 }
 
+function hasExactKeys(
+	value: Record<string, unknown>,
+	expected: ReadonlyArray<string>,
+): boolean {
+	const actual = Object.keys(value).sort()
+	const sortedExpected = [...expected].sort()
+	return (
+		actual.length === sortedExpected.length &&
+		actual.every((key, index) => key === sortedExpected[index])
+	)
+}
+
+function parseSourceDatabasesJson(value: string): Array<SourceDatabase> {
+	const trimmed = value.trim()
+	if (trimmed.length === 0) {
+		throw new BackupError(
+			'invalid-source-databases',
+			'SOURCE_DATABASES must be a JSON array of { id, name } objects',
+		)
+	}
+	let parsed: unknown
+	try {
+		parsed = JSON.parse(trimmed) as unknown
+	} catch {
+		throw new BackupError(
+			'invalid-source-databases',
+			'SOURCE_DATABASES must be a JSON array of { id, name } objects',
+		)
+	}
+	if (!Array.isArray(parsed) || parsed.length === 0) {
+		throw new BackupError(
+			'invalid-source-databases',
+			'SOURCE_DATABASES must be a JSON array of { id, name } objects',
+		)
+	}
+	const sources: Array<SourceDatabase> = []
+	const ids = new Set<string>()
+	const names = new Set<string>()
+	for (const entry of parsed) {
+		if (
+			entry === null ||
+			typeof entry !== 'object' ||
+			Array.isArray(entry) ||
+			!hasExactKeys(entry as Record<string, unknown>, ['id', 'name'])
+		) {
+			throw new BackupError(
+				'invalid-source-databases',
+				'SOURCE_DATABASES entries must be { id, name } objects',
+			)
+		}
+		const record = entry as { id: unknown; name: unknown }
+		if (
+			typeof record.id !== 'string' ||
+			!CLOUDFLARE_ID_PATTERN.test(record.id) ||
+			typeof record.name !== 'string' ||
+			record.name.trim().length === 0
+		) {
+			throw new BackupError(
+				'invalid-source-databases',
+				'SOURCE_DATABASES entries need a UUID id and a non-empty name',
+			)
+		}
+		const id = record.id
+		const name = record.name
+		if (ids.has(id.toLowerCase()) || names.has(name)) {
+			throw new BackupError(
+				'duplicate-source-database',
+				'SOURCE_DATABASES contains a duplicate id or name',
+			)
+		}
+		ids.add(id.toLowerCase())
+		names.add(name)
+		sources.push({ id, name })
+	}
+	return sources
+}
+
+export function primarySourceDatabase(env: BackupEnvironment): SourceDatabase {
+	return { id: env.SOURCE_DATABASE_ID, name: env.SOURCE_DATABASE_NAME }
+}
+
+export function configuredSourceDatabases(
+	env: BackupEnvironment,
+): Array<SourceDatabase> {
+	assertConfiguredIdentity(env)
+	if (env.SOURCE_DATABASES === undefined) {
+		return [primarySourceDatabase(env)]
+	}
+	return parseSourceDatabasesJson(env.SOURCE_DATABASES)
+}
+
+export function bindSourceDatabase(
+	env: BackupEnvironment,
+	source: SourceDatabase,
+): BackupEnvironment {
+	return {
+		...env,
+		SOURCE_DATABASE_ID: source.id,
+		SOURCE_DATABASE_NAME: source.name,
+	}
+}
+
+export function resolveSourceDatabase(
+	env: BackupEnvironment,
+	selector: string | null | undefined,
+): SourceDatabase {
+	const sources = configuredSourceDatabases(env)
+	if (selector === null || selector === undefined || selector.trim() === '') {
+		return primarySourceDatabase(env)
+	}
+	const requested = selector.trim()
+	const match = sources.find(
+		(source) =>
+			source.name === requested ||
+			source.id.toLowerCase() === requested.toLowerCase(),
+	)
+	if (!match) {
+		throw new BackupError(
+			'unknown-source-database',
+			`source database ${requested} is not configured`,
+		)
+	}
+	return match
+}
+
+export function sourceDatabaseFromObjectPrefix(
+	env: BackupEnvironment,
+	objectPrefix: string,
+	day: string,
+	tier: RetentionTier,
+): SourceDatabase {
+	const expectedStart = `${tier}/d1/`
+	const expectedEnd = `/${day}`
+	if (
+		!objectPrefix.startsWith(expectedStart) ||
+		!objectPrefix.endsWith(expectedEnd)
+	) {
+		throw new BackupError(
+			'invalid-workflow-payload',
+			'workflow payload objectPrefix did not match the scheduled day',
+		)
+	}
+	const databaseId = objectPrefix.slice(
+		expectedStart.length,
+		objectPrefix.length - expectedEnd.length,
+	)
+	if (databaseId.includes('/')) {
+		throw new BackupError(
+			'invalid-workflow-payload',
+			'workflow payload objectPrefix is not a configured source database',
+		)
+	}
+	return resolveSourceDatabase(env, databaseId)
+}
+
 export function assertConfiguredIdentity(env: BackupEnvironment): void {
 	if (
 		!CLOUDFLARE_ID_PATTERN.test(env.SOURCE_ACCOUNT_ID) ||
@@ -55,26 +215,48 @@ export function assertConfiguredIdentity(env: BackupEnvironment): void {
 			'source account and database IDs must be UUIDs',
 		)
 	}
-	if (
-		!parseAllowlist(
-			env.ALLOWED_SOURCE_ACCOUNT_IDS,
-			'ALLOWED_SOURCE_ACCOUNT_IDS',
-		).has(env.SOURCE_ACCOUNT_ID.toLowerCase()) ||
-		!parseAllowlist(
-			env.ALLOWED_SOURCE_DATABASE_IDS,
-			'ALLOWED_SOURCE_DATABASE_IDS',
-		).has(env.SOURCE_DATABASE_ID.toLowerCase())
-	) {
-		throw new BackupError(
-			'source-not-allowlisted',
-			'configured source identity is not allowlisted',
-		)
-	}
 	if (!env.SOURCE_DATABASE_NAME) {
 		throw new BackupError(
 			'missing-source-name',
 			'source database name is required',
 		)
+	}
+	const allowedAccounts = parseAllowlist(
+		env.ALLOWED_SOURCE_ACCOUNT_IDS,
+		'ALLOWED_SOURCE_ACCOUNT_IDS',
+	)
+	const allowedDatabases = parseAllowlist(
+		env.ALLOWED_SOURCE_DATABASE_IDS,
+		'ALLOWED_SOURCE_DATABASE_IDS',
+	)
+	if (!allowedAccounts.has(env.SOURCE_ACCOUNT_ID.toLowerCase())) {
+		throw new BackupError(
+			'source-not-allowlisted',
+			'configured source identity is not allowlisted',
+		)
+	}
+	const sources =
+		env.SOURCE_DATABASES === undefined
+			? [primarySourceDatabase(env)]
+			: parseSourceDatabasesJson(env.SOURCE_DATABASES)
+	const primaryListed = sources.some(
+		(source) =>
+			source.id.toLowerCase() === env.SOURCE_DATABASE_ID.toLowerCase() &&
+			source.name === env.SOURCE_DATABASE_NAME,
+	)
+	if (!primaryListed) {
+		throw new BackupError(
+			'source-not-allowlisted',
+			'SOURCE_DATABASE_ID/NAME must appear in SOURCE_DATABASES',
+		)
+	}
+	for (const source of sources) {
+		if (!allowedDatabases.has(source.id.toLowerCase())) {
+			throw new BackupError(
+				'source-not-allowlisted',
+				'configured source identity is not allowlisted',
+			)
+		}
 	}
 }
 
@@ -110,11 +292,18 @@ export function retentionTier(day: string): RetentionTier {
 export function backupPayload(
 	env: BackupEnvironment,
 	scheduledAt: Date,
+	source: SourceDatabase = primarySourceDatabase(env),
 ): ScheduledBackupPayload {
-	assertConfiguredIdentity(env)
+	const resolved = resolveSourceDatabase(env, source.id)
+	if (source.name !== resolved.name) {
+		throw new BackupError(
+			'source-identity-mismatch',
+			'Cloudflare D1 identity did not match the configured UUID and name',
+		)
+	}
 	const day = utcDay(scheduledAt)
 	const tier = retentionTier(day)
-	const prefix = `${tier}/d1/${env.SOURCE_DATABASE_ID}/${day}`
+	const prefix = `${tier}/d1/${resolved.id}/${day}`
 	return {
 		kind: 'scheduled',
 		scheduledAt: scheduledAt.toISOString(),

--- a/packages/backup-control-plane/backup-runtime.ts
+++ b/packages/backup-control-plane/backup-runtime.ts
@@ -20,10 +20,14 @@ import {
 import {
 	BackupError,
 	backupPayload,
+	bindSourceDatabase,
 	errorCode,
 	isBackupEnabled,
 	objectKeyForPayload,
+	retentionTier,
 	safeLog,
+	sourceDatabaseFromObjectPrefix,
+	utcDay,
 } from './backup-policy.ts'
 import {
 	type BackupEnvironment,
@@ -218,6 +222,26 @@ function matchesExpectedPayload(
 	)
 }
 
+function expectedPayloadForRecord(
+	env: BackupEnvironment,
+	payload: Record<string, unknown>,
+): BackupPayload {
+	const scheduledAt = canonicalScheduledDate(payload.scheduledAt)
+	const day = utcDay(scheduledAt)
+	const tier = retentionTier(day)
+	if (typeof payload.objectPrefix !== 'string') {
+		throw new BackupError(
+			'invalid-workflow-payload',
+			'workflow payload did not match deterministic backup keys',
+		)
+	}
+	return backupPayload(
+		env,
+		scheduledAt,
+		sourceDatabaseFromObjectPrefix(env, payload.objectPrefix, day, tier),
+	)
+}
+
 function validatePayload(
 	env: BackupEnvironment,
 	payload: unknown,
@@ -235,10 +259,7 @@ function validatePayload(
 				'legacy workflow payload did not have exact scheduled fields',
 			)
 		}
-		const expected = backupPayload(
-			env,
-			canonicalScheduledDate(payload.scheduledAt),
-		)
+		const expected = expectedPayloadForRecord(env, payload)
 		const legacyExpected: LegacyScheduledBackupPayload = {
 			scheduledAt: expected.scheduledAt,
 			day: expected.day,
@@ -269,10 +290,7 @@ function validatePayload(
 			'scheduled workflow payload did not have exact fields',
 		)
 	}
-	const expected = backupPayload(
-		env,
-		canonicalScheduledDate(payload.scheduledAt),
-	)
+	const expected = expectedPayloadForRecord(env, payload)
 	if (!matchesExpectedPayload(payload, expected)) {
 		throw new BackupError(
 			'invalid-workflow-payload',
@@ -303,12 +321,19 @@ export async function runBackupRuntime(
 		}
 		const checkedPayload = validatePayload(env, event.payload)
 		payload = checkedPayload
+		const source = sourceDatabaseFromObjectPrefix(
+			env,
+			checkedPayload.objectPrefix,
+			checkedPayload.day,
+			checkedPayload.retentionTier,
+		)
+		const sourceEnv = bindSourceDatabase(env, source)
 		await step.do(
 			'verify-source-identity',
 			{ retries: { limit: 0, delay: '1 second' }, timeout: '1 minute' },
-			async () => verifySourceDatabaseIdentity(env, options.api),
+			async () => verifySourceDatabaseIdentity(sourceEnv, options.api),
 		)
-		const exported = await runDurableExport(env, step, {
+		const exported = await runDurableExport(sourceEnv, step, {
 			api: options.api,
 		})
 		const stored = await step.do(
@@ -321,7 +346,7 @@ export async function runBackupRuntime(
 				// Refresh may restart the export when the short-lived poll result
 				// has expired; the returned bookmark defines the immutable object key.
 				const refreshed = await refreshCompletedD1Export(
-					env,
+					sourceEnv,
 					exported.bookmark,
 					options.api,
 				)
@@ -360,9 +385,9 @@ export async function runBackupRuntime(
 		)
 		const unsignedManifest = {
 			source: {
-				accountId: env.SOURCE_ACCOUNT_ID,
-				databaseId: env.SOURCE_DATABASE_ID,
-				databaseName: env.SOURCE_DATABASE_NAME,
+				accountId: sourceEnv.SOURCE_ACCOUNT_ID,
+				databaseId: sourceEnv.SOURCE_DATABASE_ID,
+				databaseName: sourceEnv.SOURCE_DATABASE_NAME,
 			},
 			export: {
 				bookmark: stored.bookmark,
@@ -412,6 +437,8 @@ export async function runBackupRuntime(
 			status: 'success',
 			day: checkedPayload.day,
 			instanceId: event.instanceId,
+			databaseId: source.id,
+			databaseName: source.name,
 			objectKey: stored.objectKey,
 			manifestKey: checkedPayload.manifestKey,
 			bytes: stored.bytes,

--- a/packages/backup-control-plane/backup-types.ts
+++ b/packages/backup-control-plane/backup-types.ts
@@ -10,6 +10,7 @@ export interface BackupEnvironment {
 	SOURCE_ACCOUNT_ID: string
 	SOURCE_DATABASE_ID: string
 	SOURCE_DATABASE_NAME: string
+	SOURCE_DATABASES?: string
 	ALLOWED_SOURCE_ACCOUNT_IDS: string
 	ALLOWED_SOURCE_DATABASE_IDS: string
 	ENABLE_PRODUCTION_D1_BACKUPS: string
@@ -132,6 +133,8 @@ export interface LogRecord {
 	status: 'success' | 'failure' | 'stale-success' | 'disabled'
 	day?: string
 	instanceId?: string
+	databaseId?: string
+	databaseName?: string
 	objectKey?: string
 	manifestKey?: string
 	bytes?: number

--- a/packages/backup-control-plane/control-plane-fetch.ts
+++ b/packages/backup-control-plane/control-plane-fetch.ts
@@ -8,9 +8,11 @@ import {
 import {
 	BackupError,
 	backupPayload,
+	configuredSourceDatabases,
 	errorCode,
 	isBackupEnabled,
 	safeLog,
+	utcDay,
 	workflowInstanceId,
 } from './backup-policy.ts'
 import { type BackupEnvironment } from './backup-types.ts'
@@ -127,19 +129,28 @@ async function handleAuthenticated(
 				)
 			}
 			const scheduledAt = new Date()
-			const payload = backupPayload(env, scheduledAt)
-			const result = await enqueueBackup(
-				env.BACKUP_WORKFLOW,
-				env.SOURCE_DATABASE_ID,
-				payload,
+			const sources = configuredSourceDatabases(env)
+			const results: Array<string> = []
+			for (const source of sources) {
+				const payload = backupPayload(env, scheduledAt, source)
+				const result = await enqueueBackup(
+					env.BACKUP_WORKFLOW,
+					source.id,
+					payload,
+				)
+				safeLog({
+					event: 'ui-run-backup',
+					status: 'success',
+					day: payload.day,
+					instanceId: workflowInstanceId(source.id, payload.day),
+					databaseId: source.id,
+					databaseName: source.name,
+				})
+				results.push(`${source.name}: ${result}`)
+			}
+			return htmlResponse(
+				renderEnqueueResult(utcDay(scheduledAt), results.join('; ')),
 			)
-			safeLog({
-				event: 'ui-run-backup',
-				status: 'success',
-				day: payload.day,
-				instanceId: workflowInstanceId(env.SOURCE_DATABASE_ID, payload.day),
-			})
-			return htmlResponse(renderEnqueueResult(payload.day, result))
 		}
 		case '/actions/seal-day': {
 			const day = requireDay(form.get('day'))
@@ -182,7 +193,9 @@ async function handleAuthenticated(
 		}
 		case '/actions/run-drill': {
 			const day = requireDay(form.get('day'))
-			const report = await runRestoreDrill(env, day)
+			const report = await runRestoreDrill(env, day, {
+				database: form.get('database') ?? undefined,
+			})
 			safeLog({
 				event: 'ui-run-drill',
 				status: report.errorCode === null ? 'success' : 'failure',

--- a/packages/backup-control-plane/control-plane-ui.node.test.ts
+++ b/packages/backup-control-plane/control-plane-ui.node.test.ts
@@ -13,7 +13,11 @@ import {
 	signedManifest,
 } from './backup-control-plane-test-support.ts'
 import { backupPayload, objectKeyForBookmark } from './backup-policy.ts'
-import { collectDayStatuses, renderDashboard } from './control-plane-ui.ts'
+import {
+	collectDayStatuses,
+	renderDashboard,
+	renderRestoreStatusPage,
+} from './control-plane-ui.ts'
 import { putImmutableManifest } from './immutable-storage.ts'
 
 test('dashboard renders oversized D1 SQL as not restorable with a warning', async () => {
@@ -142,4 +146,23 @@ test('dashboard warns when a configured D1 source is missing and marks the day u
 	assert.match(html, /kody-jobs: D1 manifest missing/)
 	assert.match(html, /<td class="bad">unverified<\/td>/)
 	assert.match(html, /<td class="bad">no<\/td>/)
+})
+
+test('restore status lists undeclared databases as notes, not warnings', () => {
+	const html = renderRestoreStatusPage({
+		instanceId: 'dr-restore-2026-07-22-demo',
+		status: 'complete',
+		progress: {
+			day: '2026-07-22',
+			phase: 'complete',
+			d1ImportComplete: true,
+			storeRestoreComplete: true,
+			storeIterations: 1,
+			warnings: [],
+			notes: ['JOBS_DB: not present in this backup day'],
+		},
+	})
+	assert.match(html, /Not in this backup day/)
+	assert.match(html, /JOBS_DB: not present in this backup day/)
+	assert.doesNotMatch(html, /<span>Warnings<\/span>/)
 })

--- a/packages/backup-control-plane/control-plane-ui.node.test.ts
+++ b/packages/backup-control-plane/control-plane-ui.node.test.ts
@@ -12,7 +12,11 @@ import {
 	putSqlStatsFixture,
 	signedManifest,
 } from './backup-control-plane-test-support.ts'
-import { backupPayload, objectKeyForBookmark } from './backup-policy.ts'
+import {
+	backupPayload,
+	configuredSourceDatabases,
+	objectKeyForBookmark,
+} from './backup-policy.ts'
 import {
 	collectDayStatuses,
 	renderDashboard,
@@ -146,6 +150,60 @@ test('dashboard warns when a configured D1 source is missing and marks the day u
 	assert.match(html, /kody-jobs: D1 manifest missing/)
 	assert.match(html, /<td class="bad">unverified<\/td>/)
 	assert.match(html, /<td class="bad">no<\/td>/)
+})
+
+test('an unreadable D1 manifest keeps the day unverified even when a later source verifies', async () => {
+	const bucket = new MemoryBucket()
+	const env = environment(bucket)
+	const jobsId = '44444444-4444-4444-8444-444444444444'
+	env.SOURCE_DATABASES = JSON.stringify([
+		{ id: env.SOURCE_DATABASE_ID, name: env.SOURCE_DATABASE_NAME },
+		{ id: jobsId, name: 'kody-jobs' },
+	])
+	env.ALLOWED_SOURCE_DATABASE_IDS = `${env.SOURCE_DATABASE_ID},${jobsId}`
+	const day = '2026-07-31'
+	const scheduledAt = new Date(`${day}T12:00:00.000Z`)
+	const sql = 'CREATE TABLE t(id INTEGER);\n'
+	for (const source of configuredSourceDatabases(env)) {
+		const payload = backupPayload(env, scheduledAt, source)
+		const sqlObjectKey = objectKeyForBookmark(
+			payload.objectPrefix,
+			'bookmark-1',
+		)
+		const template = manifest({
+			bytes: sql.length,
+			sha256: createHash('sha256').update(sql).digest('hex'),
+			r2Etag: createHash('md5').update(sql).digest('hex'),
+		})
+		await bucket.put(sqlObjectKey, sql)
+		await putSqlStatsFixture(bucket, day, sqlObjectKey)
+		await putImmutableManifest(
+			bucket as unknown as R2Bucket,
+			payload.manifestKey,
+			signedManifest({
+				...template.payload,
+				export: {
+					...template.payload.export,
+					scheduledAt: `${day}T02:15:00.000Z`,
+					startedAt: `${day}T02:15:01.000Z`,
+					completedAt: `${day}T02:16:00.000Z`,
+				},
+				sql: { ...template.payload.sql, objectKey: sqlObjectKey },
+			}),
+		)
+	}
+	bucket.failGetFor(backupPayload(env, scheduledAt).manifestKey)
+
+	const [status] = await collectDayStatuses(env, scheduledAt)
+	assert.equal(status?.d1Present, false)
+	assert.equal(status?.d1Verified, false)
+	assert.equal(status?.d1Restorable, false)
+	assert.ok(
+		status?.warnings.includes(
+			`${env.SOURCE_DATABASE_NAME}: D1 manifest unreadable`,
+		),
+		status?.warnings.join('; '),
+	)
 })
 
 test('restore status lists undeclared databases as notes, not warnings', () => {

--- a/packages/backup-control-plane/control-plane-ui.node.test.ts
+++ b/packages/backup-control-plane/control-plane-ui.node.test.ts
@@ -90,3 +90,56 @@ test('dashboard renders oversized D1 SQL as not restorable with a warning', asyn
 		false,
 	)
 })
+
+test('dashboard warns when a configured D1 source is missing and marks the day unrestorable', async () => {
+	const bucket = new MemoryBucket()
+	const env = environment(bucket)
+	const jobsId = '44444444-4444-4444-8444-444444444444'
+	env.SOURCE_DATABASES = JSON.stringify([
+		{ id: env.SOURCE_DATABASE_ID, name: env.SOURCE_DATABASE_NAME },
+		{ id: jobsId, name: 'kody-jobs' },
+	])
+	env.ALLOWED_SOURCE_DATABASE_IDS = `${env.SOURCE_DATABASE_ID},${jobsId}`
+	const day = '2026-07-31'
+	const payload = backupPayload(env, new Date(`${day}T12:00:00.000Z`))
+	const sql = 'CREATE TABLE t(id INTEGER);\n'
+	const sqlObjectKey = objectKeyForBookmark(payload.objectPrefix, 'bookmark-1')
+	const template = manifest({
+		bytes: sql.length,
+		sha256: createHash('sha256').update(sql).digest('hex'),
+		r2Etag: createHash('md5').update(sql).digest('hex'),
+	})
+	await bucket.put(sqlObjectKey, sql)
+	await putSqlStatsFixture(bucket, day, sqlObjectKey)
+	await putImmutableManifest(
+		bucket as unknown as R2Bucket,
+		payload.manifestKey,
+		signedManifest({
+			...template.payload,
+			export: {
+				...template.payload.export,
+				scheduledAt: `${day}T02:15:00.000Z`,
+				startedAt: `${day}T02:15:01.000Z`,
+				completedAt: `${day}T02:16:00.000Z`,
+			},
+			sql: { ...template.payload.sql, objectKey: sqlObjectKey },
+		}),
+	)
+
+	const now = new Date(`${day}T12:00:00.000Z`)
+	const [status] = await collectDayStatuses(env, now)
+	assert.equal(status?.d1Present, false)
+	assert.equal(status?.d1Verified, false)
+	assert.equal(status?.d1Restorable, false)
+	assert.ok(
+		status?.warnings.includes('kody-jobs: D1 manifest missing'),
+		status?.warnings.join('; '),
+	)
+
+	const fetcher = vi.spyOn(globalThis, 'fetch')
+	fetcher.mockResolvedValue(identityEnvelope(1_000))
+	const html = await renderDashboard(env, { now })
+	assert.match(html, /kody-jobs: D1 manifest missing/)
+	assert.match(html, /<td class="bad">unverified<\/td>/)
+	assert.match(html, /<td class="bad">no<\/td>/)
+})

--- a/packages/backup-control-plane/control-plane-ui.ts
+++ b/packages/backup-control-plane/control-plane-ui.ts
@@ -541,6 +541,8 @@ export function renderRestoreStatusPage(input: {
 	status: string
 	progress?: ProductionRestoreProgress | null
 }): string {
+	const notes = input.progress?.notes ?? []
+	const warnings = input.progress?.warnings ?? []
 	const details = input.progress
 		? JSON.stringify(input.progress, null, 2)
 		: 'No progress payload yet.'
@@ -551,6 +553,16 @@ export function renderRestoreStatusPage(input: {
 </header>
 <section class="panel danger">
 	<div class="kv"><span>Status</span><strong>${escapeHtml(input.status)}</strong></div>
+	${
+		notes.length > 0
+			? `<div class="kv"><span>Not in this backup day</span><span>${escapeHtml(notes.join('; '))}</span></div>`
+			: ''
+	}
+	${
+		warnings.length > 0
+			? `<div class="kv"><span>Warnings</span><span class="bad">${escapeHtml(warnings.join('; '))}</span></div>`
+			: ''
+	}
 	<pre>${escapeHtml(details)}</pre>
 	<p>
 		<a class="button" href="/restore-status?id=${encodeURIComponent(input.instanceId)}">Refresh</a>

--- a/packages/backup-control-plane/control-plane-ui.ts
+++ b/packages/backup-control-plane/control-plane-ui.ts
@@ -187,6 +187,9 @@ export async function collectDayStatuses(
 				sourceManifest = await readManifest(env.BACKUP_BUCKET, d1Key)
 				if (sourceManifest === null) {
 					d1Present = false
+					d1Verified = false
+					d1Restorable = false
+					warnings.push(`${label}D1 manifest missing`)
 					continue
 				}
 				sourceVerified = await verifyBackupManifestSignature(
@@ -196,11 +199,13 @@ export async function collectDayStatuses(
 				d1Verified =
 					d1Verified === false ? false : sourceVerified ? true : false
 				if (!sourceVerified) {
+					d1Restorable = false
 					warnings.push(`${label}D1 manifest signature invalid`)
 				}
 			} catch {
 				d1Verified = null
 				d1Present = false
+				d1Restorable = false
 				warnings.push(`${label}D1 manifest unreadable`)
 				continue
 			}

--- a/packages/backup-control-plane/control-plane-ui.ts
+++ b/packages/backup-control-plane/control-plane-ui.ts
@@ -5,7 +5,12 @@ import {
 	stagingSummaryKey,
 } from '@kody-internal/shared/backup-staging.ts'
 
-import { isBackupEnabled, utcDay, backupPayload } from './backup-policy.ts'
+import {
+	backupPayload,
+	configuredSourceDatabases,
+	isBackupEnabled,
+	utcDay,
+} from './backup-policy.ts'
 import { type BackupEnvironment, type BackupManifest } from './backup-types.ts'
 import { getD1Database } from './d1-import-api.ts'
 import { verifyBackupFullManifestSignature } from './full-manifest-signing.ts'
@@ -16,7 +21,6 @@ import { type ProductionRestoreProgress } from './production-restore.ts'
 import { type RestoreConfirmToken } from './restore-confirm-token.ts'
 import { readFullManifest } from './seal-full-backup.ts'
 import { readSqlRestorability } from './sql-statement-stats.ts'
-import { type EnqueueResult } from './workflow-trigger.ts'
 
 const DASHBOARD_DAY_COUNT = 14
 
@@ -166,65 +170,83 @@ export async function collectDayStatuses(
 		date.setUTCDate(date.getUTCDate() - offset)
 		const day = utcDay(date)
 		const warnings: Array<string> = []
-		const d1Key = backupPayload(
-			env,
-			new Date(`${day}T12:00:00.000Z`),
-		).manifestKey
-		let d1Present = false
+		const sources = configuredSourceDatabases(env)
+		let d1Present = sources.length > 0
 		let d1Verified: boolean | null = null
 		let d1Restorable: boolean | null = null
-		let d1Manifest: BackupManifest | null = null
-		try {
-			d1Manifest = await readManifest(env.BACKUP_BUCKET, d1Key)
-			d1Present = d1Manifest !== null
-			if (d1Manifest !== null) {
-				d1Verified = await verifyBackupManifestSignature(env, d1Manifest)
-				if (!d1Verified) warnings.push('D1 manifest signature invalid')
-			}
-		} catch {
-			d1Verified = null
-			warnings.push('D1 manifest unreadable')
-		}
-		if (d1Manifest !== null && d1Verified === true) {
+		for (const source of sources) {
+			const d1Key = backupPayload(
+				env,
+				new Date(`${day}T12:00:00.000Z`),
+				source,
+			).manifestKey
+			const label = sources.length === 1 ? '' : `${source.name}: `
+			let sourceManifest: BackupManifest | null = null
+			let sourceVerified = false
 			try {
-				const restorability = await readSqlRestorability(
-					env.BACKUP_BUCKET,
-					day,
-					d1Manifest.payload.sql.objectKey,
+				sourceManifest = await readManifest(env.BACKUP_BUCKET, d1Key)
+				if (sourceManifest === null) {
+					d1Present = false
+					continue
+				}
+				sourceVerified = await verifyBackupManifestSignature(
+					env,
+					sourceManifest,
 				)
-				switch (restorability.kind) {
-					case 'restorable':
-						d1Restorable = true
-						break
-					case 'unrestorable':
-						d1Restorable = false
-						warnings.push(
-							'D1 SQL contains oversized statements and cannot be restored',
-						)
-						break
-					case 'legacy-unknown':
-						warnings.push(
-							'D1 restorability unknown: legacy backup has no SQL stats',
-						)
-						break
-					case 'missing':
-						d1Restorable = false
-						warnings.push(
-							'D1 is not restorable: required SQL stats are missing',
-						)
-						break
-					case 'corrupt':
-						d1Restorable = false
-						warnings.push('D1 is not restorable: SQL stats are unreadable')
-						break
-					default: {
-						const exhaustive: never = restorability
-						throw exhaustive
-					}
+				d1Verified =
+					d1Verified === false ? false : sourceVerified ? true : false
+				if (!sourceVerified) {
+					warnings.push(`${label}D1 manifest signature invalid`)
 				}
 			} catch {
-				d1Restorable = false
-				warnings.push('D1 is not restorable: SQL stats lookup failed')
+				d1Verified = null
+				d1Present = false
+				warnings.push(`${label}D1 manifest unreadable`)
+				continue
+			}
+			if (sourceManifest !== null && sourceVerified) {
+				try {
+					const restorability = await readSqlRestorability(
+						env.BACKUP_BUCKET,
+						day,
+						sourceManifest.payload.sql.objectKey,
+					)
+					switch (restorability.kind) {
+						case 'restorable':
+							if (d1Restorable !== false) d1Restorable = true
+							break
+						case 'unrestorable':
+							d1Restorable = false
+							warnings.push(
+								`${label}D1 SQL contains oversized statements and cannot be restored`,
+							)
+							break
+						case 'legacy-unknown':
+							warnings.push(
+								`${label}D1 restorability unknown: legacy backup has no SQL stats`,
+							)
+							break
+						case 'missing':
+							d1Restorable = false
+							warnings.push(
+								`${label}D1 is not restorable: required SQL stats are missing`,
+							)
+							break
+						case 'corrupt':
+							d1Restorable = false
+							warnings.push(
+								`${label}D1 is not restorable: SQL stats are unreadable`,
+							)
+							break
+						default: {
+							const exhaustive: never = restorability
+							throw exhaustive
+						}
+					}
+				} catch {
+					d1Restorable = false
+					warnings.push(`${label}D1 is not restorable: SQL stats lookup failed`)
+				}
 			}
 		}
 
@@ -268,17 +290,24 @@ export async function renderDashboard(
 ): Promise<string> {
 	const now = options.now ?? new Date()
 	const enabled = isBackupEnabled(env)
-	let sourceSizeHtml = `<span class="warn">unavailable</span>`
-	try {
-		const meta = await getD1Database({
-			accountId: env.SOURCE_ACCOUNT_ID,
-			databaseId: env.SOURCE_DATABASE_ID,
-			token: env.CLOUDFLARE_API_TOKEN,
-		})
-		sourceSizeHtml = `<strong>${escapeHtml(String(meta.fileSize))} bytes</strong>`
-	} catch (error) {
-		const message = error instanceof Error ? error.message : 'lookup failed'
-		sourceSizeHtml = `<span class="bad">${escapeHtml(message)}</span>`
+	const sources = configuredSourceDatabases(env)
+	const sourceSizeParts: Array<string> = []
+	for (const source of sources) {
+		try {
+			const meta = await getD1Database({
+				accountId: env.SOURCE_ACCOUNT_ID,
+				databaseId: source.id,
+				token: env.CLOUDFLARE_API_TOKEN,
+			})
+			sourceSizeParts.push(
+				`<div class="kv"><span>${escapeHtml(source.name)} file_size</span><strong>${escapeHtml(String(meta.fileSize))} bytes</strong></div>`,
+			)
+		} catch (error) {
+			const message = error instanceof Error ? error.message : 'lookup failed'
+			sourceSizeParts.push(
+				`<div class="kv"><span>${escapeHtml(source.name)} file_size</span><span class="bad">${escapeHtml(message)}</span></div>`,
+			)
+		}
 	}
 	const escrowPresent =
 		(await env.BACKUP_BUCKET.head(backupEscrowSecretStoreKeyKey)) !== null
@@ -316,9 +345,13 @@ ${options.flashHtml ?? ''}
 	<h2>Source identity</h2>
 	<div class="grid">
 		<div class="kv"><span>SOURCE_ACCOUNT_ID</span><strong>${escapeHtml(env.SOURCE_ACCOUNT_ID)}</strong></div>
-		<div class="kv"><span>SOURCE_DATABASE_ID</span><strong>${escapeHtml(env.SOURCE_DATABASE_ID)}</strong></div>
-		<div class="kv"><span>SOURCE_DATABASE_NAME</span><strong>${escapeHtml(env.SOURCE_DATABASE_NAME)}</strong></div>
-		<div class="kv"><span>Live D1 file_size</span>${sourceSizeHtml}</div>
+		${sources
+			.map(
+				(source) =>
+					`<div class="kv"><span>${escapeHtml(source.name)}</span><strong>${escapeHtml(source.id)}</strong></div>`,
+			)
+			.join('\n\t\t')}
+		${sourceSizeParts.join('\n\t\t')}
 		<div class="kv"><span>BUILD_COMMIT</span><strong>${escapeHtml(env.BUILD_COMMIT)}</strong></div>
 		<div class="kv"><span>Escrow blob</span><strong class="${escrowPresent ? 'ok' : 'warn'}">${escrowPresent ? 'present' : 'missing'}</strong></div>
 	</div>
@@ -359,13 +392,23 @@ ${options.flashHtml ?? ''}
 			<label>Day
 				<input type="text" name="day" placeholder="YYYY-MM-DD" required pattern="\\d{4}-\\d{2}-\\d{2}"/>
 			</label>
+			<label>Database
+				<select name="database">
+					${sources
+						.map(
+							(source) =>
+								`<option value="${escapeHtml(source.name)}">${escapeHtml(source.name)}</option>`,
+						)
+						.join('')}
+				</select>
+			</label>
 			<button type="submit">Run isolated restore drill</button>
 		</form>
 	</div>
 </section>
 <section class="panel danger">
 	<h2>Production restore (dangerous)</h2>
-	<p>This path imports SQL into the configured production D1 and then restores sealed durable stores through the primary worker. Use only during an approved incident.</p>
+	<p>This path imports SQL into every configured production D1 (APP_DB then JOBS_DB) and then restores sealed durable stores through the primary worker. Use only during an approved incident.</p>
 	<form method="post" action="/actions/restore/prepare" class="actions" onsubmit="return confirm('Prepare a PRODUCTION restore confirmation for this day?');">
 		<label>Day
 			<input type="text" name="day" placeholder="YYYY-MM-DD" required pattern="\\d{4}-\\d{2}-\\d{2}"/>
@@ -393,10 +436,7 @@ export function renderMessagePage(
 	return layout(title, body, { danger: options?.danger })
 }
 
-export function renderEnqueueResult(
-	day: string,
-	result: EnqueueResult,
-): string {
+export function renderEnqueueResult(day: string, result: string): string {
 	return renderMessagePage(
 		'D1 backup enqueue',
 		`Backup workflow for ${day}: ${result}.`,
@@ -417,6 +457,8 @@ export function renderDrillReport(report: DrillReport): string {
 		.join(', ')
 	const details = [
 		`day=${report.day}`,
+		`sourceDatabaseName=${report.sourceDatabaseName}`,
+		`sourceDatabaseId=${report.sourceDatabaseId}`,
 		`databaseName=${report.databaseName}`,
 		`databaseId=${report.databaseId ?? 'n/a'}`,
 		`quickCheck=${report.quickCheck ?? 'n/a'}`,

--- a/packages/backup-control-plane/control-plane-ui.ts
+++ b/packages/backup-control-plane/control-plane-ui.ts
@@ -203,7 +203,7 @@ export async function collectDayStatuses(
 					warnings.push(`${label}D1 manifest signature invalid`)
 				}
 			} catch {
-				d1Verified = null
+				d1Verified = false
 				d1Present = false
 				d1Restorable = false
 				warnings.push(`${label}D1 manifest unreadable`)

--- a/packages/backup-control-plane/freshness-check.ts
+++ b/packages/backup-control-plane/freshness-check.ts
@@ -10,6 +10,8 @@ import {
 	BackupError,
 	assertConfiguredIdentity,
 	backupPayload,
+	bindSourceDatabase,
+	configuredSourceDatabases,
 	isBookmarkObjectKey,
 	safeLog,
 } from './backup-policy.ts'
@@ -28,7 +30,7 @@ function latestExpectedDate(scheduledAt: Date): Date {
 	return expected
 }
 
-export async function checkFreshness(
+async function checkOneSourceFreshness(
 	env: BackupEnvironment,
 	scheduledAt: Date,
 	apiOptions: ApiOptions = {},
@@ -52,6 +54,8 @@ export async function checkFreshness(
 				event: 'freshness-stale',
 				status: 'stale-success',
 				day: payload.day,
+				databaseId: env.SOURCE_DATABASE_ID,
+				databaseName: env.SOURCE_DATABASE_NAME,
 				manifestKey: payload.manifestKey,
 				errorCode: error.code,
 			})
@@ -89,6 +93,8 @@ export async function checkFreshness(
 						event: 'backup-stats-legacy-missing',
 						status: 'stale-success',
 						day: payload.day,
+						databaseId: env.SOURCE_DATABASE_ID,
+						databaseName: env.SOURCE_DATABASE_NAME,
 						objectKey: manifest.payload.sql.objectKey,
 					})
 					break
@@ -141,6 +147,8 @@ export async function checkFreshness(
 					: 'freshness-success',
 		status: stale ? 'stale-success' : 'success',
 		day: payload.day,
+		databaseId: env.SOURCE_DATABASE_ID,
+		databaseName: env.SOURCE_DATABASE_NAME,
 		objectKey: manifest?.payload.sql.objectKey,
 		manifestKey: payload.manifestKey,
 		ageHours,
@@ -149,4 +157,32 @@ export async function checkFreshness(
 		oversizedStatementCount: unrestorableStats?.oversizedStatementCount,
 	})
 	return !stale
+}
+
+export async function checkFreshness(
+	env: BackupEnvironment,
+	scheduledAt: Date,
+	apiOptions: ApiOptions = {},
+): Promise<boolean> {
+	const sources = configuredSourceDatabases(env)
+	const results: Array<boolean> = []
+	const errors: Array<unknown> = []
+	for (const source of sources) {
+		try {
+			results.push(
+				await checkOneSourceFreshness(
+					bindSourceDatabase(env, source),
+					scheduledAt,
+					apiOptions,
+				),
+			)
+		} catch (error) {
+			errors.push(error)
+		}
+	}
+	if (errors.length === 1) throw errors[0]
+	if (errors.length > 1) {
+		throw new AggregateError(errors, 'One or more D1 freshness checks failed.')
+	}
+	return results.every(Boolean)
 }

--- a/packages/backup-control-plane/production-restore.node.test.ts
+++ b/packages/backup-control-plane/production-restore.node.test.ts
@@ -6,6 +6,7 @@ import { sealedFullManifestKey } from '@kody-internal/shared/backup-staging.ts'
 import { test, vi } from 'vitest'
 
 import {
+	ACCOUNT_ID,
 	DATABASE_ID,
 	MemoryBucket,
 	badSqlStatsFixture,
@@ -14,7 +15,12 @@ import {
 	manifest,
 	signedManifest,
 } from './backup-control-plane-test-support.ts'
-import { BackupError, backupPayload } from './backup-policy.ts'
+import {
+	BackupError,
+	backupPayload,
+	bindSourceDatabase,
+	objectKeyForBookmark,
+} from './backup-policy.ts'
 import { d1ImportForeignKeysOffPrefix } from './d1-import-api.ts'
 import { signBackupFullManifest } from './full-manifest-signing.ts'
 import { putImmutableManifest } from './immutable-storage.ts'
@@ -201,4 +207,238 @@ test('production restore refuses SQL with oversized statement stats', async () =
 			error.code === 'backup-unrestorable-statements',
 	)
 	assert.equal(fetchCalls, 0)
+})
+
+const JOBS_DATABASE_ID = '44444444-4444-4444-8444-444444444444'
+
+function configureJobsDatabase(
+	env: ReturnType<typeof environment>,
+): ReturnType<typeof environment> {
+	env.SOURCE_DATABASES = JSON.stringify([
+		{ id: env.SOURCE_DATABASE_ID, name: env.SOURCE_DATABASE_NAME },
+		{ id: JOBS_DATABASE_ID, name: 'kody-jobs' },
+	])
+	env.ALLOWED_SOURCE_DATABASE_IDS = `${env.SOURCE_DATABASE_ID},${JOBS_DATABASE_ID}`
+	return env
+}
+
+async function putJobsRestoreManifest(
+	bucket: MemoryBucket,
+	env: ReturnType<typeof environment>,
+	day: string,
+	options: { putSql?: boolean } = {},
+) {
+	const jobsEnv = bindSourceDatabase(env, {
+		id: JOBS_DATABASE_ID,
+		name: 'kody-jobs',
+	})
+	const jobsPayload = backupPayload(jobsEnv, new Date(`${day}T12:00:00.000Z`))
+	const sqlBody = 'CREATE TABLE jobs(id INTEGER);\n'
+	const sqlObjectKey = objectKeyForBookmark(
+		jobsPayload.objectPrefix,
+		'bookmark-1',
+	)
+	if (options.putSql !== false) {
+		await bucket.put(sqlObjectKey, sqlBody)
+	}
+	const dayManifest = signedManifest({
+		...manifest({
+			bytes: sqlBody.length,
+			sha256: sha256Text(sqlBody),
+			r2Etag: createHash('md5').update(sqlBody).digest('hex'),
+		}).payload,
+		source: {
+			accountId: ACCOUNT_ID,
+			databaseId: JOBS_DATABASE_ID,
+			databaseName: 'kody-jobs',
+		},
+		sql: {
+			objectKey: sqlObjectKey,
+			bytes: sqlBody.length,
+			sha256: sha256Text(sqlBody),
+			r2Etag: createHash('md5').update(sqlBody).digest('hex'),
+		},
+	})
+	await putImmutableManifest(
+		bucket as unknown as R2Bucket,
+		jobsPayload.manifestKey,
+		dayManifest,
+	)
+	const stored = await bucket.get(jobsPayload.manifestKey)
+	return {
+		manifestKey: jobsPayload.manifestKey,
+		sqlObjectKey,
+		storedText: await stored!.text(),
+	}
+}
+
+test('production restore of a single-database sealed day restores APP_DB only', async () => {
+	const consoleError = vi.spyOn(console, 'error')
+	consoleError.mockImplementation(() => undefined)
+	const bucket = new MemoryBucket()
+	const { env, day, preparedImportMd5 } = await seedSealedRestoreDay(bucket)
+	configureJobsDatabase(env)
+	let exportCalls = 0
+	const importedDatabaseIds: Array<string> = []
+	const sql = 'CREATE TABLE safety(id INTEGER);\n'
+	const progress = await runProductionRestore(
+		env,
+		{ day, requestedAt: `${day}T12:00:00.000Z` },
+		{
+			now: new Date(`${day}T12:00:00.000Z`),
+			sleep: async () => undefined,
+			maxPollAttempts: 3,
+			pollDelayMs: 1,
+			fetcher: async (input, init) => {
+				const url = String(input)
+				if (url.includes('api.cloudflare.com') && url.includes('/export')) {
+					exportCalls += 1
+					return exportCalls === 1
+						? exportEnvelope('active')
+						: exportEnvelope('complete')
+				}
+				if (url.includes('download.example')) {
+					return new Response(sql, {
+						headers: { 'content-length': String(sql.length) },
+					})
+				}
+				if (url.includes('/import')) {
+					const body = JSON.parse(String(init?.body ?? '{}')) as {
+						action?: string
+					}
+					if (body.action === 'init') {
+						const match = /\/d1\/database\/([^/]+)\/import/.exec(url)
+						if (match?.[1]) importedDatabaseIds.push(match[1])
+						return Response.json({
+							success: true,
+							result: {
+								upload_url: 'https://upload.example/sql',
+								filename: 'import.sql',
+							},
+						})
+					}
+					if (body.action === 'ingest') {
+						return Response.json({
+							success: true,
+							result: { at_bookmark: 'import-1', type: 'import' },
+						})
+					}
+					return Response.json({
+						success: true,
+						result: { status: 'complete', success: true, type: 'import' },
+					})
+				}
+				if (url.includes('upload.example')) {
+					return new Response(null, {
+						status: 200,
+						headers: { etag: `"${preparedImportMd5}"` },
+					})
+				}
+				if (url.includes('/__maintenance/dr-restore')) {
+					return Response.json({
+						done: true,
+						progress: { step: 'done' },
+						warnings: [],
+					})
+				}
+				throw new Error(`unexpected fetch ${url}`)
+			},
+		},
+	)
+	assert.equal(progress.phase, 'complete')
+	assert.deepEqual(importedDatabaseIds, [DATABASE_ID])
+	assert.equal(exportCalls, 2)
+	assert.deepEqual(progress.warnings, [
+		'JOBS_DB: not present in this backup day',
+	])
+	assert.equal(progress.safetyExports?.length, 1)
+	assert.equal(progress.safetyExports?.[0]?.databaseId, DATABASE_ID)
+})
+
+test('production restore verifies every required SQL object before importing APP_DB', async () => {
+	const consoleError = vi.spyOn(console, 'error')
+	consoleError.mockImplementation(() => undefined)
+	const bucket = new MemoryBucket()
+	const { env, day } = await seedSealedRestoreDay(bucket)
+	configureJobsDatabase(env)
+	const jobs = await putJobsRestoreManifest(bucket, env, day, { putSql: false })
+	const appManifestKey = backupPayload(
+		env,
+		new Date(`${day}T12:00:00.000Z`),
+	).manifestKey
+	const appManifestObject = await bucket.get(appManifestKey)
+	const appStoredText = await appManifestObject!.text()
+	const appManifestSha256 = sha256Text(appStoredText)
+	const full = await signBackupFullManifest(env, {
+		day,
+		d1ManifestKey: appManifestKey,
+		d1ManifestSha256: appManifestSha256,
+		d1Sources: [
+			{
+				databaseId: DATABASE_ID,
+				databaseName: env.SOURCE_DATABASE_NAME,
+				manifestKey: appManifestKey,
+				manifestSha256: appManifestSha256,
+			},
+			{
+				databaseId: JOBS_DATABASE_ID,
+				databaseName: 'kody-jobs',
+				manifestKey: jobs.manifestKey,
+				manifestSha256: sha256Text(jobs.storedText),
+			},
+		],
+		mailboxIndex: {
+			objectKey: `daily/full/${day}/mailbox-index.json`,
+			bytes: 2,
+			sha256: 'd'.repeat(64),
+		},
+		runLogIndex: {
+			objectKey: `daily/full/${day}/run-log-index.json`,
+			bytes: 2,
+			sha256: 'e'.repeat(64),
+		},
+		storageIndex: {
+			objectKey: `daily/full/${day}/storage-index.json`,
+			bytes: 2,
+			sha256: 'b'.repeat(64),
+		},
+		r2Indexes: {},
+		artifactsIndex: {
+			objectKey: `daily/full/${day}/artifacts-index.json`,
+			bytes: 2,
+			sha256: 'c'.repeat(64),
+		},
+		sealedAt: `${day}T04:00:00.000Z`,
+		buildCommit: 'abc123',
+	})
+	await bucket.put(
+		sealedFullManifestKey(day),
+		serializeBackupFullManifest(full),
+	)
+
+	let fetchCalls = 0
+	let importedAppDb = false
+	await assert.rejects(
+		runProductionRestore(
+			env,
+			{ day, requestedAt: `${day}T12:00:00.000Z` },
+			{
+				fetcher: async (input) => {
+					fetchCalls += 1
+					const url = String(input)
+					if (url.includes(`/d1/database/${DATABASE_ID}/import`)) {
+						importedAppDb = true
+					}
+					throw new Error('restore should not start')
+				},
+			},
+		),
+		(error: unknown) =>
+			error instanceof BackupError &&
+			error.code === 'restore-sql-missing' &&
+			error.message.includes(jobs.sqlObjectKey) &&
+			error.message.includes('kody-jobs'),
+	)
+	assert.equal(fetchCalls, 0)
+	assert.equal(importedAppDb, false)
 })

--- a/packages/backup-control-plane/production-restore.node.test.ts
+++ b/packages/backup-control-plane/production-restore.node.test.ts
@@ -275,12 +275,34 @@ async function putJobsRestoreManifest(
 	}
 }
 
+function trackSqlObjectAccess(
+	bucket: MemoryBucket,
+	sqlObjectKeys: Array<string>,
+): { heads: Array<string>; gets: Array<string> } {
+	const tracked = new Set(sqlObjectKeys)
+	const heads: Array<string> = []
+	const gets: Array<string> = []
+	const originalHead = bucket.head.bind(bucket)
+	const originalGet = bucket.get.bind(bucket)
+	bucket.head = async (key: string) => {
+		if (tracked.has(key)) heads.push(key)
+		return originalHead(key)
+	}
+	bucket.get = async (key: string) => {
+		if (tracked.has(key)) gets.push(key)
+		return originalGet(key)
+	}
+	return { heads, gets }
+}
+
 test('production restore of a historical single-database day completes the workflow without failure', async () => {
 	const consoleError = vi.spyOn(console, 'error')
 	consoleError.mockImplementation(() => undefined)
 	const bucket = new MemoryBucket()
-	const { env, day, preparedImportMd5 } = await seedSealedRestoreDay(bucket)
+	const { env, day, preparedImportMd5, sqlObjectKey } =
+		await seedSealedRestoreDay(bucket)
 	configureJobsDatabase(env)
+	const sqlAccess = trackSqlObjectAccess(bucket, [sqlObjectKey])
 	let exportCalls = 0
 	const importedDatabaseIds: Array<string> = []
 	const sql = 'CREATE TABLE safety(id INTEGER);\n'
@@ -356,13 +378,15 @@ test('production restore of a historical single-database day completes the workf
 	assert.equal(restoreProgressFailsWorkflow(progress), false)
 	assert.equal(progress.safetyExports?.length, 1)
 	assert.equal(progress.safetyExports?.[0]?.databaseId, DATABASE_ID)
+	assert.deepEqual(sqlAccess.heads, [sqlObjectKey])
+	assert.deepEqual(sqlAccess.gets, [sqlObjectKey, sqlObjectKey, sqlObjectKey])
 })
 
 test('production restore verifies every required SQL object before importing APP_DB', async () => {
 	const consoleError = vi.spyOn(console, 'error')
 	consoleError.mockImplementation(() => undefined)
 	const bucket = new MemoryBucket()
-	const { env, day } = await seedSealedRestoreDay(bucket)
+	const { env, day, sqlObjectKey } = await seedSealedRestoreDay(bucket)
 	configureJobsDatabase(env)
 	const jobs = await putJobsRestoreManifest(bucket, env, day, { putSql: false })
 	const appManifestKey = backupPayload(
@@ -419,6 +443,10 @@ test('production restore verifies every required SQL object before importing APP
 		serializeBackupFullManifest(full),
 	)
 
+	const sqlAccess = trackSqlObjectAccess(bucket, [
+		sqlObjectKey,
+		jobs.sqlObjectKey,
+	])
 	let fetchCalls = 0
 	let importedAppDb = false
 	await assert.rejects(
@@ -444,4 +472,6 @@ test('production restore verifies every required SQL object before importing APP
 	)
 	assert.equal(fetchCalls, 0)
 	assert.equal(importedAppDb, false)
+	assert.deepEqual(sqlAccess.heads, [sqlObjectKey, jobs.sqlObjectKey])
+	assert.deepEqual(sqlAccess.gets, [])
 })

--- a/packages/backup-control-plane/production-restore.node.test.ts
+++ b/packages/backup-control-plane/production-restore.node.test.ts
@@ -6,6 +6,7 @@ import { sealedFullManifestKey } from '@kody-internal/shared/backup-staging.ts'
 import { test, vi } from 'vitest'
 
 import {
+	DATABASE_ID,
 	MemoryBucket,
 	badSqlStatsFixture,
 	environment,
@@ -161,7 +162,10 @@ test('runProductionRestore returns failed progress when dr-restore emits warning
 	assert.equal(progress.d1ImportComplete, true)
 	assert.equal(exportCalls, 2)
 	const safetyExportKey = progress.safetyExportKey
-	assert.equal(safetyExportKey, `pre-restore/${day}/${day}T12:00:00.000Z.sql`)
+	assert.equal(
+		safetyExportKey,
+		`pre-restore/${day}/${DATABASE_ID}/${day}T12:00:00.000Z.sql`,
+	)
 	assert.equal(progress.safetyExportBytes, sql.length)
 	assert.ok(safetyExportKey)
 	assert.ok(await bucket.head(safetyExportKey))

--- a/packages/backup-control-plane/production-restore.node.test.ts
+++ b/packages/backup-control-plane/production-restore.node.test.ts
@@ -24,7 +24,10 @@ import {
 import { d1ImportForeignKeysOffPrefix } from './d1-import-api.ts'
 import { signBackupFullManifest } from './full-manifest-signing.ts'
 import { putImmutableManifest } from './immutable-storage.ts'
-import { runProductionRestore } from './production-restore.ts'
+import {
+	runProductionRestore,
+	restoreProgressFailsWorkflow,
+} from './production-restore.ts'
 
 function sha256Text(value: string): string {
 	return createHash('sha256').update(value).digest('hex')
@@ -272,7 +275,7 @@ async function putJobsRestoreManifest(
 	}
 }
 
-test('production restore of a single-database sealed day restores APP_DB only', async () => {
+test('production restore of a historical single-database day completes the workflow without failure', async () => {
 	const consoleError = vi.spyOn(console, 'error')
 	consoleError.mockImplementation(() => undefined)
 	const bucket = new MemoryBucket()
@@ -348,9 +351,9 @@ test('production restore of a single-database sealed day restores APP_DB only', 
 	assert.equal(progress.phase, 'complete')
 	assert.deepEqual(importedDatabaseIds, [DATABASE_ID])
 	assert.equal(exportCalls, 2)
-	assert.deepEqual(progress.warnings, [
-		'JOBS_DB: not present in this backup day',
-	])
+	assert.deepEqual(progress.warnings, [])
+	assert.deepEqual(progress.notes, ['JOBS_DB: not present in this backup day'])
+	assert.equal(restoreProgressFailsWorkflow(progress), false)
 	assert.equal(progress.safetyExports?.length, 1)
 	assert.equal(progress.safetyExports?.[0]?.databaseId, DATABASE_ID)
 })

--- a/packages/backup-control-plane/production-restore.ts
+++ b/packages/backup-control-plane/production-restore.ts
@@ -2,10 +2,15 @@ import { sealedFullManifestKey } from '@kody-internal/shared/backup-staging.ts'
 
 import {
 	BackupError,
+	absentConfiguredSourceWarning,
 	backupPayload,
 	bindSourceDatabase,
 	configuredSourceDatabases,
+	declaredSourceDatabases,
+	primarySourceDatabase,
+	restoreImportOrder,
 	safeLog,
+	type SourceDatabase,
 } from './backup-policy.ts'
 import { type BackupEnvironment } from './backup-types.ts'
 import {
@@ -55,6 +60,12 @@ export type ProductionRestoreProgress = {
 	warnings: Array<string>
 	safetyExportKey?: string
 	safetyExportBytes?: number
+	safetyExports?: Array<{
+		databaseId: string
+		databaseName: string
+		objectKey: string
+		bytes: number
+	}>
 	errorCode?: string
 	errorMessage?: string
 	progress?: ProductionRestoreProgressValue
@@ -137,12 +148,88 @@ export function restoreWorkflowInstanceId(
 	return `dr-restore-${day}-${safeExpires}`
 }
 
+export type RestorableD1Source = {
+	source: SourceDatabase
+	manifestKey: string
+	sqlObjectKey: string
+	sqlBytes: number
+	sqlSha256: string
+	sqlR2Etag: string
+}
+
+async function sha256Hex(bytes: Uint8Array): Promise<string> {
+	const digest = await crypto.subtle.digest('SHA-256', bytes as BufferSource)
+	return [...new Uint8Array(digest)]
+		.map((byte) => byte.toString(16).padStart(2, '0'))
+		.join('')
+}
+
+async function verifyRequiredSqlObjects(
+	bucket: R2Bucket,
+	day: string,
+	sources: Array<RestorableD1Source>,
+): Promise<Map<string, Uint8Array>> {
+	const verified = new Map<string, Uint8Array>()
+	for (const source of sources) {
+		const head = await bucket.head(source.sqlObjectKey)
+		if (head === null) {
+			throw new BackupError(
+				'restore-sql-missing',
+				`SQL object missing for ${day} (${source.source.name}): ${source.sqlObjectKey}`,
+			)
+		}
+		if (head.size !== source.sqlBytes) {
+			throw new BackupError(
+				'restore-sql-size-mismatch',
+				`SQL object size mismatch for ${day} (${source.source.name}): ${source.sqlObjectKey}`,
+			)
+		}
+		const object = await bucket.get(source.sqlObjectKey)
+		if (object === null) {
+			throw new BackupError(
+				'restore-sql-missing',
+				`SQL object missing for ${day} (${source.source.name}): ${source.sqlObjectKey}`,
+			)
+		}
+		const bytes = new Uint8Array(await object.arrayBuffer())
+		if (bytes.byteLength !== source.sqlBytes) {
+			throw new BackupError(
+				'restore-sql-size-mismatch',
+				`SQL object size mismatch for ${day} (${source.source.name}): ${source.sqlObjectKey}`,
+			)
+		}
+		const digest = await sha256Hex(bytes)
+		if (digest !== source.sqlSha256) {
+			throw new BackupError(
+				'restore-sql-sha256-mismatch',
+				`SQL object sha256 mismatch for ${day} (${source.source.name}): ${source.sqlObjectKey}`,
+			)
+		}
+		verified.set(source.source.id, bytes)
+	}
+	return verified
+}
+
+function appendAbsentConfiguredSourceWarnings(
+	env: BackupEnvironment,
+	declared: Array<SourceDatabase>,
+	progress: ProductionRestoreProgress,
+): void {
+	const declaredIds = new Set(declared.map((source) => source.id.toLowerCase()))
+	for (const source of configuredSourceDatabases(env)) {
+		if (!declaredIds.has(source.id.toLowerCase())) {
+			progress.warnings.push(absentConfiguredSourceWarning(source))
+		}
+	}
+}
+
 export async function validateSealedDayForRestore(
 	env: BackupEnvironment,
 	day: string,
 ): Promise<{
 	fullManifestKey: string
 	d1ManifestKey: string
+	declaredSources: Array<RestorableD1Source>
 	sqlObjectKey: string
 	sqlBytes: number
 	sqlSha256: string
@@ -172,37 +259,19 @@ export async function validateSealedDayForRestore(
 			'full manifest D1 key does not match configured source',
 		)
 	}
-	const d1Manifest = await readManifest(
-		env.BACKUP_BUCKET,
-		fullManifest.payload.d1ManifestKey,
-	)
-	if (d1Manifest === null) {
-		throw new BackupError(
-			'restore-d1-manifest-missing',
-			`D1 manifest missing for ${day}`,
-		)
-	}
-	if (!(await verifyBackupManifestSignature(env, d1Manifest))) {
-		throw new BackupError(
-			'restore-d1-manifest-signature-invalid',
-			`D1 manifest signature invalid for ${day}`,
-		)
-	}
-	await assertSqlRestorable(
-		env.BACKUP_BUCKET,
-		day,
-		d1Manifest.payload.sql.objectKey,
-	)
-	for (const source of configuredSourceDatabases(env)) {
+	const declared = declaredSourceDatabases(env, fullManifest.payload.d1Sources)
+	const restorableSources: Array<RestorableD1Source> = []
+	for (const source of declared) {
 		const sourceEnv = bindSourceDatabase(env, source)
+		const declaredEntry = fullManifest.payload.d1Sources?.find(
+			(entry) => entry.databaseId.toLowerCase() === source.id.toLowerCase(),
+		)
 		const sourcePayload = backupPayload(
 			sourceEnv,
 			new Date(`${day}T12:00:00.000Z`),
 		)
-		const sourceManifest = await readManifest(
-			env.BACKUP_BUCKET,
-			sourcePayload.manifestKey,
-		)
+		const manifestKey = declaredEntry?.manifestKey ?? sourcePayload.manifestKey
+		const sourceManifest = await readManifest(env.BACKUP_BUCKET, manifestKey)
 		if (sourceManifest === null) {
 			throw new BackupError(
 				'restore-d1-manifest-missing',
@@ -220,14 +289,33 @@ export async function validateSealedDayForRestore(
 			day,
 			sourceManifest.payload.sql.objectKey,
 		)
+		restorableSources.push({
+			source,
+			manifestKey,
+			sqlObjectKey: sourceManifest.payload.sql.objectKey,
+			sqlBytes: sourceManifest.payload.sql.bytes,
+			sqlSha256: sourceManifest.payload.sql.sha256,
+			sqlR2Etag: sourceManifest.payload.sql.r2Etag,
+		})
+	}
+	const primary = restorableSources.find(
+		(entry) =>
+			entry.source.id.toLowerCase() === env.SOURCE_DATABASE_ID.toLowerCase(),
+	)
+	if (primary === undefined) {
+		throw new BackupError(
+			'restore-d1-source-not-configured',
+			'sealed D1 sources do not include the primary database',
+		)
 	}
 	return {
 		fullManifestKey,
 		d1ManifestKey: fullManifest.payload.d1ManifestKey,
-		sqlObjectKey: d1Manifest.payload.sql.objectKey,
-		sqlBytes: d1Manifest.payload.sql.bytes,
-		sqlSha256: d1Manifest.payload.sql.sha256,
-		sqlR2Etag: d1Manifest.payload.sql.r2Etag,
+		declaredSources: restorableSources,
+		sqlObjectKey: primary.sqlObjectKey,
+		sqlBytes: primary.sqlBytes,
+		sqlSha256: primary.sqlSha256,
+		sqlR2Etag: primary.sqlR2Etag,
 	}
 }
 
@@ -314,8 +402,23 @@ export async function capturePreRestoreSafetyExport(
 		maxPollAttempts?: number
 		pollDelayMs?: number
 	} = {},
-): Promise<{ objectKey: string; bytes: number }> {
-	const sources = configuredSourceDatabases(env)
+	sources: Array<SourceDatabase> = configuredSourceDatabases(env),
+): Promise<{
+	objectKey: string
+	bytes: number
+	exports: Array<{
+		databaseId: string
+		databaseName: string
+		objectKey: string
+		bytes: number
+	}>
+}> {
+	const exports: Array<{
+		databaseId: string
+		databaseName: string
+		objectKey: string
+		bytes: number
+	}> = []
 	let primary: { objectKey: string; bytes: number } | undefined
 	for (const source of sources) {
 		const captured = await captureOneSourceSafetyExport(
@@ -324,6 +427,12 @@ export async function capturePreRestoreSafetyExport(
 			now,
 			options,
 		)
+		exports.push({
+			databaseId: source.id,
+			databaseName: source.name,
+			objectKey: captured.objectKey,
+			bytes: captured.bytes,
+		})
 		if (source.id.toLowerCase() === env.SOURCE_DATABASE_ID.toLowerCase()) {
 			primary = captured
 		}
@@ -334,7 +443,7 @@ export async function capturePreRestoreSafetyExport(
 			'pre-restore safety export missed the primary database',
 		)
 	}
-	return primary
+	return { objectKey: primary.objectKey, bytes: primary.bytes, exports }
 }
 
 async function captureOneSourceSafetyExport(
@@ -433,13 +542,11 @@ export async function runProductionRestore(
 	try {
 		await publish()
 		const validated = await validateSealedDayForRestore(env, payload.day)
-		const sqlHead = await env.BACKUP_BUCKET.head(validated.sqlObjectKey)
-		if (sqlHead === null) {
-			throw new BackupError(
-				'restore-sql-missing',
-				`SQL object missing for ${payload.day}`,
-			)
-		}
+		const verifiedSql = await verifyRequiredSqlObjects(
+			env.BACKUP_BUCKET,
+			payload.day,
+			validated.declaredSources,
+		)
 
 		progress.phase = 'capturing-safety-export'
 		await publish()
@@ -453,9 +560,11 @@ export async function runProductionRestore(
 			payload.day,
 			options.now ?? new Date(),
 			options,
+			validated.declaredSources.map((entry) => entry.source),
 		)
 		progress.safetyExportKey = safety.objectKey
 		progress.safetyExportBytes = safety.bytes
+		progress.safetyExports = safety.exports
 		await publish()
 		safeLog({
 			event: 'production-restore-safety-export-complete',
@@ -473,39 +582,27 @@ export async function runProductionRestore(
 			day: payload.day,
 			objectKey: validated.sqlObjectKey,
 		})
-		for (const source of configuredSourceDatabases(env)) {
-			const sourceEnv = bindSourceDatabase(env, source)
-			const sourcePayload = backupPayload(
-				sourceEnv,
-				new Date(`${payload.day}T12:00:00.000Z`),
+		const importOrder = restoreImportOrder(
+			validated.declaredSources.map((entry) => entry.source),
+			primarySourceDatabase(env),
+		)
+		for (const source of importOrder) {
+			const restorable = validated.declaredSources.find(
+				(entry) => entry.source.id.toLowerCase() === source.id.toLowerCase(),
 			)
-			const sourceManifest = await readManifest(
-				env.BACKUP_BUCKET,
-				sourcePayload.manifestKey,
-			)
-			if (sourceManifest === null) {
+			const sqlBytes = verifiedSql.get(source.id)
+			if (restorable === undefined || sqlBytes === undefined) {
 				throw new BackupError(
-					'restore-d1-manifest-missing',
-					`D1 manifest missing for ${payload.day} (${source.name})`,
+					'restore-sql-missing',
+					`SQL object missing for ${payload.day} (${source.name})`,
 				)
 			}
 			await importSqlIntoD1({
 				accountId: env.SOURCE_ACCOUNT_ID,
 				databaseId: source.id,
 				token: env.CLOUDFLARE_API_TOKEN,
-				sourceMd5Etag: sourceManifest.payload.sql.r2Etag,
-				loadSqlBody: async () => {
-					const sqlObject = await env.BACKUP_BUCKET.get(
-						sourceManifest.payload.sql.objectKey,
-					)
-					if (sqlObject?.body == null) {
-						throw new BackupError(
-							'restore-sql-missing',
-							`SQL object missing for ${payload.day} (${source.name})`,
-						)
-					}
-					return sqlObject.body
-				},
+				sourceMd5Etag: restorable.sqlR2Etag,
+				loadSqlBody: async () => sqlBytes,
 				options,
 			})
 		}
@@ -539,6 +636,11 @@ export async function runProductionRestore(
 					progress.phase = 'failed'
 					progress.errorCode = 'dr-restore-warnings'
 					progress.errorMessage = `dr-restore completed with ${String(progress.warnings.length)} warning(s)`
+					appendAbsentConfiguredSourceWarnings(
+						env,
+						validated.declaredSources.map((entry) => entry.source),
+						progress,
+					)
 					await publish()
 					safeLog({
 						event: 'production-restore-failure',
@@ -548,6 +650,11 @@ export async function runProductionRestore(
 					})
 					return progress
 				}
+				appendAbsentConfiguredSourceWarnings(
+					env,
+					validated.declaredSources.map((entry) => entry.source),
+					progress,
+				)
 				progress.phase = 'complete'
 				await publish()
 				safeLog({

--- a/packages/backup-control-plane/production-restore.ts
+++ b/packages/backup-control-plane/production-restore.ts
@@ -1,6 +1,12 @@
 import { sealedFullManifestKey } from '@kody-internal/shared/backup-staging.ts'
 
-import { BackupError, backupPayload, safeLog } from './backup-policy.ts'
+import {
+	BackupError,
+	backupPayload,
+	bindSourceDatabase,
+	configuredSourceDatabases,
+	safeLog,
+} from './backup-policy.ts'
 import { type BackupEnvironment } from './backup-types.ts'
 import {
 	awaitExportReady,
@@ -187,6 +193,34 @@ export async function validateSealedDayForRestore(
 		day,
 		d1Manifest.payload.sql.objectKey,
 	)
+	for (const source of configuredSourceDatabases(env)) {
+		const sourceEnv = bindSourceDatabase(env, source)
+		const sourcePayload = backupPayload(
+			sourceEnv,
+			new Date(`${day}T12:00:00.000Z`),
+		)
+		const sourceManifest = await readManifest(
+			env.BACKUP_BUCKET,
+			sourcePayload.manifestKey,
+		)
+		if (sourceManifest === null) {
+			throw new BackupError(
+				'restore-d1-manifest-missing',
+				`D1 manifest missing for ${day} (${source.name})`,
+			)
+		}
+		if (!(await verifyBackupManifestSignature(sourceEnv, sourceManifest))) {
+			throw new BackupError(
+				'restore-d1-manifest-signature-invalid',
+				`D1 manifest signature invalid for ${day} (${source.name})`,
+			)
+		}
+		await assertSqlRestorable(
+			env.BACKUP_BUCKET,
+			day,
+			sourceManifest.payload.sql.objectKey,
+		)
+	}
 	return {
 		fullManifestKey,
 		d1ManifestKey: fullManifest.payload.d1ManifestKey,
@@ -281,6 +315,37 @@ export async function capturePreRestoreSafetyExport(
 		pollDelayMs?: number
 	} = {},
 ): Promise<{ objectKey: string; bytes: number }> {
+	const sources = configuredSourceDatabases(env)
+	let primary: { objectKey: string; bytes: number } | undefined
+	for (const source of sources) {
+		const captured = await captureOneSourceSafetyExport(
+			bindSourceDatabase(env, source),
+			day,
+			now,
+			options,
+		)
+		if (source.id.toLowerCase() === env.SOURCE_DATABASE_ID.toLowerCase()) {
+			primary = captured
+		}
+	}
+	if (primary === undefined) {
+		throw new BackupError(
+			'pre-restore-download-failed',
+			'pre-restore safety export missed the primary database',
+		)
+	}
+	return primary
+}
+
+async function captureOneSourceSafetyExport(
+	env: BackupEnvironment,
+	day: string,
+	now: Date,
+	options: ApiOptions & {
+		maxPollAttempts?: number
+		pollDelayMs?: number
+	},
+): Promise<{ objectKey: string; bytes: number }> {
 	const fetcher = options.fetcher ?? fetch
 	const sleep =
 		options.sleep ?? ((milliseconds) => scheduler.wait(milliseconds))
@@ -314,7 +379,7 @@ export async function capturePreRestoreSafetyExport(
 		)
 	}
 	const contentLength = download.headers.get('content-length')
-	const objectKey = `pre-restore/${day}/${now.toISOString()}.sql`
+	const objectKey = `pre-restore/${day}/${env.SOURCE_DATABASE_ID}/${now.toISOString()}.sql`
 	if (contentLength !== null && /^\d+$/.test(contentLength)) {
 		const bytes = Number(contentLength)
 		if (!Number.isSafeInteger(bytes) || bytes <= 0) {
@@ -408,23 +473,42 @@ export async function runProductionRestore(
 			day: payload.day,
 			objectKey: validated.sqlObjectKey,
 		})
-		await importSqlIntoD1({
-			accountId: env.SOURCE_ACCOUNT_ID,
-			databaseId: env.SOURCE_DATABASE_ID,
-			token: env.CLOUDFLARE_API_TOKEN,
-			sourceMd5Etag: validated.sqlR2Etag,
-			loadSqlBody: async () => {
-				const sqlObject = await env.BACKUP_BUCKET.get(validated.sqlObjectKey)
-				if (sqlObject?.body == null) {
-					throw new BackupError(
-						'restore-sql-missing',
-						`SQL object missing for ${payload.day}`,
+		for (const source of configuredSourceDatabases(env)) {
+			const sourceEnv = bindSourceDatabase(env, source)
+			const sourcePayload = backupPayload(
+				sourceEnv,
+				new Date(`${payload.day}T12:00:00.000Z`),
+			)
+			const sourceManifest = await readManifest(
+				env.BACKUP_BUCKET,
+				sourcePayload.manifestKey,
+			)
+			if (sourceManifest === null) {
+				throw new BackupError(
+					'restore-d1-manifest-missing',
+					`D1 manifest missing for ${payload.day} (${source.name})`,
+				)
+			}
+			await importSqlIntoD1({
+				accountId: env.SOURCE_ACCOUNT_ID,
+				databaseId: source.id,
+				token: env.CLOUDFLARE_API_TOKEN,
+				sourceMd5Etag: sourceManifest.payload.sql.r2Etag,
+				loadSqlBody: async () => {
+					const sqlObject = await env.BACKUP_BUCKET.get(
+						sourceManifest.payload.sql.objectKey,
 					)
-				}
-				return sqlObject.body
-			},
-			options,
-		})
+					if (sqlObject?.body == null) {
+						throw new BackupError(
+							'restore-sql-missing',
+							`SQL object missing for ${payload.day} (${source.name})`,
+						)
+					}
+					return sqlObject.body
+				},
+				options,
+			})
+		}
 		progress.d1ImportComplete = true
 		progress.phase = 'restoring-stores'
 		await publish()

--- a/packages/backup-control-plane/production-restore.ts
+++ b/packages/backup-control-plane/production-restore.ts
@@ -158,19 +158,43 @@ export type RestorableD1Source = {
 	sqlR2Etag: string
 }
 
-async function sha256Hex(bytes: Uint8Array): Promise<string> {
-	const digest = await crypto.subtle.digest('SHA-256', bytes as BufferSource)
-	return [...new Uint8Array(digest)]
+function sha256HexFromBuffer(buffer: ArrayBuffer): string {
+	return [...new Uint8Array(buffer)]
 		.map((byte) => byte.toString(16).padStart(2, '0'))
 		.join('')
+}
+
+async function sha256ReadableStream(
+	body: ReadableStream<Uint8Array>,
+): Promise<{ bytes: number; sha256: string }> {
+	const digest = new (
+		crypto as unknown as { DigestStream: typeof DigestStream }
+	).DigestStream('SHA-256')
+	const writer = digest.getWriter()
+	const reader = body.getReader()
+	try {
+		for (;;) {
+			const { done, value } = await reader.read()
+			if (done) break
+			if (value === undefined) continue
+			await writer.write(value)
+		}
+		await writer.close()
+	} catch (error) {
+		await writer.abort(error).catch(() => undefined)
+		throw error
+	}
+	return {
+		bytes: Number(digest.bytesWritten),
+		sha256: sha256HexFromBuffer(await digest.digest),
+	}
 }
 
 async function verifyRequiredSqlObjects(
 	bucket: R2Bucket,
 	day: string,
 	sources: Array<RestorableD1Source>,
-): Promise<Map<string, Uint8Array>> {
-	const verified = new Map<string, Uint8Array>()
+): Promise<void> {
 	for (const source of sources) {
 		const head = await bucket.head(source.sqlObjectKey)
 		if (head === null) {
@@ -185,30 +209,29 @@ async function verifyRequiredSqlObjects(
 				`SQL object size mismatch for ${day} (${source.source.name}): ${source.sqlObjectKey}`,
 			)
 		}
+	}
+	for (const source of sources) {
 		const object = await bucket.get(source.sqlObjectKey)
-		if (object === null) {
+		if (object?.body == null) {
 			throw new BackupError(
 				'restore-sql-missing',
 				`SQL object missing for ${day} (${source.source.name}): ${source.sqlObjectKey}`,
 			)
 		}
-		const bytes = new Uint8Array(await object.arrayBuffer())
-		if (bytes.byteLength !== source.sqlBytes) {
+		const digest = await sha256ReadableStream(object.body)
+		if (digest.bytes !== source.sqlBytes) {
 			throw new BackupError(
 				'restore-sql-size-mismatch',
 				`SQL object size mismatch for ${day} (${source.source.name}): ${source.sqlObjectKey}`,
 			)
 		}
-		const digest = await sha256Hex(bytes)
-		if (digest !== source.sqlSha256) {
+		if (digest.sha256 !== source.sqlSha256) {
 			throw new BackupError(
 				'restore-sql-sha256-mismatch',
 				`SQL object sha256 mismatch for ${day} (${source.source.name}): ${source.sqlObjectKey}`,
 			)
 		}
-		verified.set(source.source.id, bytes)
 	}
-	return verified
 }
 
 function appendAbsentConfiguredSourceNotes(
@@ -550,7 +573,7 @@ export async function runProductionRestore(
 	try {
 		await publish()
 		const validated = await validateSealedDayForRestore(env, payload.day)
-		const verifiedSql = await verifyRequiredSqlObjects(
+		await verifyRequiredSqlObjects(
 			env.BACKUP_BUCKET,
 			payload.day,
 			validated.declaredSources,
@@ -598,8 +621,7 @@ export async function runProductionRestore(
 			const restorable = validated.declaredSources.find(
 				(entry) => entry.source.id.toLowerCase() === source.id.toLowerCase(),
 			)
-			const sqlBytes = verifiedSql.get(source.id)
-			if (restorable === undefined || sqlBytes === undefined) {
+			if (restorable === undefined) {
 				throw new BackupError(
 					'restore-sql-missing',
 					`SQL object missing for ${payload.day} (${source.name})`,
@@ -610,7 +632,16 @@ export async function runProductionRestore(
 				databaseId: source.id,
 				token: env.CLOUDFLARE_API_TOKEN,
 				sourceMd5Etag: restorable.sqlR2Etag,
-				loadSqlBody: async () => sqlBytes,
+				loadSqlBody: async () => {
+					const sqlObject = await env.BACKUP_BUCKET.get(restorable.sqlObjectKey)
+					if (sqlObject?.body == null) {
+						throw new BackupError(
+							'restore-sql-missing',
+							`SQL object missing for ${payload.day} (${source.name}): ${restorable.sqlObjectKey}`,
+						)
+					}
+					return sqlObject.body
+				},
 				options,
 			})
 		}

--- a/packages/backup-control-plane/production-restore.ts
+++ b/packages/backup-control-plane/production-restore.ts
@@ -2,7 +2,7 @@ import { sealedFullManifestKey } from '@kody-internal/shared/backup-staging.ts'
 
 import {
 	BackupError,
-	absentConfiguredSourceWarning,
+	absentConfiguredSourceNote,
 	backupPayload,
 	bindSourceDatabase,
 	configuredSourceDatabases,
@@ -58,6 +58,7 @@ export type ProductionRestoreProgress = {
 	storeRestoreComplete: boolean
 	storeIterations: number
 	warnings: Array<string>
+	notes: Array<string>
 	safetyExportKey?: string
 	safetyExportBytes?: number
 	safetyExports?: Array<{
@@ -210,7 +211,7 @@ async function verifyRequiredSqlObjects(
 	return verified
 }
 
-function appendAbsentConfiguredSourceWarnings(
+function appendAbsentConfiguredSourceNotes(
 	env: BackupEnvironment,
 	declared: Array<SourceDatabase>,
 	progress: ProductionRestoreProgress,
@@ -218,9 +219,15 @@ function appendAbsentConfiguredSourceWarnings(
 	const declaredIds = new Set(declared.map((source) => source.id.toLowerCase()))
 	for (const source of configuredSourceDatabases(env)) {
 		if (!declaredIds.has(source.id.toLowerCase())) {
-			progress.warnings.push(absentConfiguredSourceWarning(source))
+			progress.notes.push(absentConfiguredSourceNote(source))
 		}
 	}
+}
+
+export function restoreProgressFailsWorkflow(
+	progress: ProductionRestoreProgress,
+): boolean {
+	return progress.phase === 'failed' || progress.warnings.length > 0
 }
 
 export async function validateSealedDayForRestore(
@@ -535,6 +542,7 @@ export async function runProductionRestore(
 		storeRestoreComplete: false,
 		storeIterations: 0,
 		warnings: [],
+		notes: [],
 	}
 	const publish = async () => {
 		await options.onProgress?.(progress)
@@ -636,7 +644,7 @@ export async function runProductionRestore(
 					progress.phase = 'failed'
 					progress.errorCode = 'dr-restore-warnings'
 					progress.errorMessage = `dr-restore completed with ${String(progress.warnings.length)} warning(s)`
-					appendAbsentConfiguredSourceWarnings(
+					appendAbsentConfiguredSourceNotes(
 						env,
 						validated.declaredSources.map((entry) => entry.source),
 						progress,
@@ -650,7 +658,7 @@ export async function runProductionRestore(
 					})
 					return progress
 				}
-				appendAbsentConfiguredSourceWarnings(
+				appendAbsentConfiguredSourceNotes(
 					env,
 					validated.declaredSources.map((entry) => entry.source),
 					progress,

--- a/packages/backup-control-plane/readme.md
+++ b/packages/backup-control-plane/readme.md
@@ -14,24 +14,25 @@ The schedule and key policy use UTC exclusively:
 
 Each export object is immutable and bookmark-derived:
 `<tier>/d1/<database-uuid>/<yyyy-mm-dd>/backup-<encoded-bookmark>.sql`. The day
-has one canonical immutable `manifest.json`, which records the selected object
-key. If a process crashes after writing SQL but before its manifest, a later
-Workflow-step retry reuses the cached export bookmark and therefore inspects the
-same object before constructing the absent canonical manifest. The original
-one-hour signed URL returned by the durable export step is never used for
-transfer. On every execution of the retryable upload callback, the runtime polls
-D1 with the cached bookmark and requires a complete response for that same
-bookmark, obtaining a fresh signed URL; the upload stream-verifies exact byte
-count and SHA-256 against R2 while writing. Finalization deliberately does
-**not** poll D1 again: expired poll results can only be refreshed by starting a
-new export of a _newer_ database state, whose bytes legitimately differ from the
-stored object whenever production wrote anything in between (this exact mismatch
-made roughly every other nightly backup fail terminally with
-`existing-object-source-mismatch` before 2026-07-27). Instead, finalization
-re-reads the stored object and requires its size, R2 ETag, and full SHA-256 to
-match the durable upload-step result (`stored-object-mismatch` /
-`stored-object-missing` fail closed), then signs and writes the manifest in the
-same Workflow step. An existing manifest must match that object exactly.
+has one canonical immutable `manifest.json` per database, which records that
+source's id, name, SQL key, byte count, and sha256. If a process crashes after
+writing SQL but before its manifest, a later Workflow-step retry reuses the
+cached export bookmark and therefore inspects the same object before
+constructing the absent canonical manifest. The original one-hour signed URL
+returned by the durable export step is never used for transfer. On every
+execution of the retryable upload callback, the runtime polls D1 with the cached
+bookmark and requires a complete response for that same bookmark, obtaining a
+fresh signed URL; the upload stream-verifies exact byte count and SHA-256
+against R2 while writing. Finalization deliberately does **not** poll D1 again:
+expired poll results can only be refreshed by starting a new export of a _newer_
+database state, whose bytes legitimately differ from the stored object whenever
+production wrote anything in between (this exact mismatch made roughly every
+other nightly backup fail terminally with `existing-object-source-mismatch`
+before 2026-07-27). Instead, finalization re-reads the stored object and
+requires its size, R2 ETag, and full SHA-256 to match the durable upload-step
+result (`stored-object-mismatch` / `stored-object-missing` fail closed), then
+signs and writes the manifest in the same Workflow step. An existing manifest
+must match that object exactly.
 
 While streaming the upload, the runtime also measures SQL statement lengths
 (quote-aware semicolon splitting). D1's import path rejects statements above its
@@ -115,19 +116,23 @@ treats invalid signatures or key configuration as stale. Set
 is base64-encoded Ed25519 PKCS#8 private key material and must never appear in
 Wrangler config, logs, manifests, evidence, or signed URLs.
 
-The 02:15 UTC trigger normally creates the day's deterministic instance.
-Freshness uses the previous UTC day before 02:15 and the current day from 02:15
-onward, so the 02:45 tick cannot report yesterday as success for a failed
-current backup. Freshness ticks from 02:45 through 05:45 UTC use the same
-deterministic id and canonical 02:15 payload to create a missed instance or
-restart an errored or terminated instance. Active and complete instances are
-left alone, and no retry tick outside that bounded window creates an instance.
-Freshness inspection and enqueue/restart run as independent settled lanes, so a
-transient D1 metadata failure cannot skip the approved-window recovery attempt;
-the scheduled event still fails afterward to preserve alerting. Exhausting the
-120-poll export window is terminal for that Workflow execution; the next
-approved tick restarts it with fresh Workflow step state and a new export rather
-than replaying the cached pending poll sequence.
+The 02:15 UTC trigger normally creates the day's deterministic instance for
+every entry in `SOURCE_DATABASES` (APP_DB `kody` and JOBS_DB `kody-jobs`;
+instance id `d1-backup-<databaseId>-<day>`). When `SOURCE_DATABASES` is unset,
+only `SOURCE_DATABASE_ID` is exported. Freshness uses the previous UTC day
+before 02:15 and the current day from 02:15 onward, so the 02:45 tick cannot
+report yesterday as success for a failed current backup. Freshness ticks from
+02:45 through 05:45 UTC use the same deterministic ids and canonical 02:15
+payloads to create a missed instance or restart an errored or terminated
+instance. Active and complete instances are left alone, and no retry tick
+outside that bounded window creates an instance. Freshness inspection and
+enqueue/restart run as independent settled lanes, so a transient D1 metadata
+failure cannot skip the approved-window recovery attempt; the scheduled event
+still fails afterward to preserve alerting. Exhausting the 120-poll export
+window is terminal for that Workflow execution; the next approved tick restarts
+it with fresh Workflow step state and a new export rather than replaying the
+cached pending poll sequence. Hourly freshness is stale unless every configured
+database is fresh.
 
 ## Deploy
 

--- a/packages/backup-control-plane/restore-drill.node.test.ts
+++ b/packages/backup-control-plane/restore-drill.node.test.ts
@@ -73,3 +73,12 @@ test('restore drill refuses SQL with oversized statement stats before import', a
 	)
 	assert.equal(fetchCalls, 0)
 })
+
+test('restore drill rejects an unknown --database selector', async () => {
+	const env = environment()
+	await assert.rejects(
+		runRestoreDrill(env, '2026-07-31', { database: 'kody-jobs' }),
+		(error: unknown) =>
+			error instanceof BackupError && error.code === 'unknown-source-database',
+	)
+})

--- a/packages/backup-control-plane/restore-drill.ts
+++ b/packages/backup-control-plane/restore-drill.ts
@@ -1,4 +1,10 @@
-import { BackupError, backupPayload, safeLog } from './backup-policy.ts'
+import {
+	BackupError,
+	backupPayload,
+	bindSourceDatabase,
+	resolveSourceDatabase,
+	safeLog,
+} from './backup-policy.ts'
 import { type BackupEnvironment } from './backup-types.ts'
 import {
 	createD1Database,
@@ -13,6 +19,8 @@ import { assertSqlRestorable } from './sql-statement-stats.ts'
 
 export type DrillReport = {
 	day: string
+	sourceDatabaseName: string
+	sourceDatabaseId: string
 	databaseName: string
 	databaseId: string | null
 	keptForInspection: boolean
@@ -73,12 +81,15 @@ export async function runRestoreDrill(
 	options: ApiOptions & {
 		maxPollAttempts?: number
 		pollDelayMs?: number
+		database?: string
 	} = {},
 ): Promise<DrillReport> {
 	assertDrillAccountIsolated(env)
 	const token = requireDrillToken(env)
 	const accountId = env.DRILL_ACCOUNT_ID.trim()
-	const payload = backupPayload(env, new Date(`${day}T12:00:00.000Z`))
+	const source = resolveSourceDatabase(env, options.database)
+	const sourceEnv = bindSourceDatabase(env, source)
+	const payload = backupPayload(sourceEnv, new Date(`${day}T12:00:00.000Z`))
 	const manifest = await readManifest(env.BACKUP_BUCKET, payload.manifestKey)
 	if (manifest === null) {
 		throw new BackupError(
@@ -86,7 +97,7 @@ export async function runRestoreDrill(
 			`D1 manifest missing for ${day}`,
 		)
 	}
-	if (!(await verifyBackupManifestSignature(env, manifest))) {
+	if (!(await verifyBackupManifestSignature(sourceEnv, manifest))) {
 		throw new BackupError(
 			'drill-manifest-signature-invalid',
 			`D1 manifest signature invalid for ${day}`,
@@ -102,6 +113,8 @@ export async function runRestoreDrill(
 	const databaseName = `kody-dr-drill-${day}-${randomHex(3)}`
 	const report: DrillReport = {
 		day,
+		sourceDatabaseName: source.name,
+		sourceDatabaseId: source.id,
 		databaseName,
 		databaseId: null,
 		keptForInspection: false,
@@ -115,6 +128,8 @@ export async function runRestoreDrill(
 		event: 'restore-drill-started',
 		status: 'success',
 		day,
+		databaseId: source.id,
+		databaseName: source.name,
 		objectKey: sqlObjectKey,
 	})
 
@@ -193,6 +208,8 @@ export async function runRestoreDrill(
 			event: 'restore-drill-success',
 			status: 'success',
 			day,
+			databaseId: source.id,
+			databaseName: source.name,
 		})
 		return report
 	} catch (error) {
@@ -205,6 +222,8 @@ export async function runRestoreDrill(
 			event: 'restore-drill-failure',
 			status: 'failure',
 			day,
+			databaseId: source.id,
+			databaseName: source.name,
 			errorCode: report.errorCode,
 		})
 		return report

--- a/packages/backup-control-plane/restore-workflow.ts
+++ b/packages/backup-control-plane/restore-workflow.ts
@@ -10,6 +10,7 @@ import { BackupError, workflowBackupErrorMessage } from './backup-policy.ts'
 import { type BackupEnvironment } from './backup-types.ts'
 import {
 	runProductionRestore,
+	restoreProgressFailsWorkflow,
 	type ProductionRestorePayload,
 	type ProductionRestoreProgress,
 } from './production-restore.ts'
@@ -38,7 +39,8 @@ export class ProductionDrRestoreWorkflow extends WorkflowEntrypoint<
 			)
 			// Persist progress (including warnings) as step output, then fail the
 			// workflow instance when restore finished with any dr-restore warnings.
-			if (progress.phase === 'failed' || progress.warnings.length > 0) {
+			// Informational notes (undeclared historical databases) are not failures.
+			if (restoreProgressFailsWorkflow(progress)) {
 				const code = progress.errorCode ?? 'dr-restore-warnings'
 				throw new NonRetryableError(
 					workflowBackupErrorMessage({

--- a/packages/backup-control-plane/seal-full-backup.node.test.ts
+++ b/packages/backup-control-plane/seal-full-backup.node.test.ts
@@ -418,3 +418,31 @@ test('sealFullBackupDay is incomplete when the 501st referenced blob is missing'
 	})
 	assert.equal(await bucket.head(sealedFullManifestKey(day)), null)
 })
+
+test('sealFullBackupDay requires a restorable manifest for every SOURCE_DATABASES entry', async () => {
+	const consoleError = vi.spyOn(console, 'error')
+	consoleError.mockImplementation(() => undefined)
+	const bucket = new MemoryBucket()
+	const seeded = await seedCompleteDay(bucket)
+	const jobsId = '44444444-4444-4444-8444-444444444444'
+	seeded.env.SOURCE_DATABASES = JSON.stringify([
+		{
+			id: seeded.env.SOURCE_DATABASE_ID,
+			name: seeded.env.SOURCE_DATABASE_NAME,
+		},
+		{ id: jobsId, name: 'kody-jobs' },
+	])
+	seeded.env.ALLOWED_SOURCE_DATABASE_IDS = `${seeded.env.SOURCE_DATABASE_ID},${jobsId}`
+	const result = await sealFullBackupDay(
+		seeded.env,
+		seeded.day,
+		new Date(`${seeded.day}T04:00:00.000Z`),
+	)
+	assert.deepEqual(result, {
+		kind: 'incomplete',
+		day: seeded.day,
+		reason: 'd1-manifest-missing',
+	})
+	assert.equal(await bucket.head(sealedFullManifestKey(seeded.day)), null)
+	assert.equal(consoleError.mock.calls.length, 1)
+})

--- a/packages/backup-control-plane/seal-full-backup.node.test.ts
+++ b/packages/backup-control-plane/seal-full-backup.node.test.ts
@@ -25,7 +25,12 @@ import {
 	putSqlStatsFixture,
 	signedManifest,
 } from './backup-control-plane-test-support.ts'
-import { BackupError, backupPayload } from './backup-policy.ts'
+import {
+	BackupError,
+	backupPayload,
+	bindSourceDatabase,
+	objectKeyForBookmark,
+} from './backup-policy.ts'
 import { putImmutableManifest } from './immutable-storage.ts'
 import { readFullManifest, sealFullBackupDay } from './seal-full-backup.ts'
 
@@ -205,6 +210,15 @@ test('sealFullBackupDay seals a complete day and is idempotent', async () => {
 			`daily/full/${day}/mailbox/${encodeURIComponent('user-owner-1')}.ndjson`,
 		),
 	)
+	assert.equal(sealed?.payload.d1Sources?.length, 1)
+	assert.equal(
+		sealed?.payload.d1Sources?.[0]?.databaseId,
+		env.SOURCE_DATABASE_ID,
+	)
+	assert.equal(
+		sealed?.payload.d1Sources?.[0]?.manifestKey,
+		backupPayload(env, new Date(`${day}T12:00:00.000Z`)).manifestKey,
+	)
 
 	const second = await sealFullBackupDay(
 		env,
@@ -367,9 +381,10 @@ test('sealFullBackupDay refuses missing or unrestorable SQL stats before sealing
 			new Date(`${sealedDay.day}T04:01:00.000Z`),
 		),
 		{
-			kind: 'incomplete',
+			kind: 'sealed',
 			day: sealedDay.day,
-			reason: 'backup-unrestorable-statements',
+			manifestKey: sealedFullManifestKey(sealedDay.day),
+			alreadySealed: true,
 		},
 	)
 })
@@ -445,4 +460,124 @@ test('sealFullBackupDay requires a restorable manifest for every SOURCE_DATABASE
 	})
 	assert.equal(await bucket.head(sealedFullManifestKey(seeded.day)), null)
 	assert.equal(consoleError.mock.calls.length, 1)
+})
+
+test('sealFullBackupDay short-circuits already-sealed days before checking sources', async () => {
+	const bucket = new MemoryBucket()
+	const seeded = await seedCompleteDay(bucket)
+	const first = await sealFullBackupDay(
+		seeded.env,
+		seeded.day,
+		new Date(`${seeded.day}T04:00:00.000Z`),
+	)
+	assert.equal(first.kind, 'sealed')
+	if (first.kind !== 'sealed') return
+	assert.equal(first.alreadySealed, false)
+
+	const jobsId = '44444444-4444-4444-8444-444444444444'
+	seeded.env.SOURCE_DATABASES = JSON.stringify([
+		{
+			id: seeded.env.SOURCE_DATABASE_ID,
+			name: seeded.env.SOURCE_DATABASE_NAME,
+		},
+		{ id: jobsId, name: 'kody-jobs' },
+	])
+	seeded.env.ALLOWED_SOURCE_DATABASE_IDS = `${seeded.env.SOURCE_DATABASE_ID},${jobsId}`
+	const second = await sealFullBackupDay(
+		seeded.env,
+		seeded.day,
+		new Date(`${seeded.day}T04:01:00.000Z`),
+	)
+	assert.deepEqual(second, {
+		kind: 'sealed',
+		day: seeded.day,
+		manifestKey: sealedFullManifestKey(seeded.day),
+		alreadySealed: true,
+	})
+})
+
+test('sealFullBackupDay records every configured source when sealing a new day', async () => {
+	const bucket = new MemoryBucket()
+	const seeded = await seedCompleteDay(bucket)
+	const jobsId = '44444444-4444-4444-8444-444444444444'
+	seeded.env.SOURCE_DATABASES = JSON.stringify([
+		{
+			id: seeded.env.SOURCE_DATABASE_ID,
+			name: seeded.env.SOURCE_DATABASE_NAME,
+		},
+		{ id: jobsId, name: 'kody-jobs' },
+	])
+	seeded.env.ALLOWED_SOURCE_DATABASE_IDS = `${seeded.env.SOURCE_DATABASE_ID},${jobsId}`
+	const jobsEnv = bindSourceDatabase(seeded.env, {
+		id: jobsId,
+		name: 'kody-jobs',
+	})
+	const jobsPayload = backupPayload(
+		jobsEnv,
+		new Date(`${seeded.day}T12:00:00.000Z`),
+	)
+	const jobsSql = 'CREATE TABLE jobs(id INTEGER);\n'
+	const jobsSqlKey = objectKeyForBookmark(
+		jobsPayload.objectPrefix,
+		'bookmark-1',
+	)
+	await bucket.put(jobsSqlKey, jobsSql)
+	const template = manifest({
+		bytes: jobsSql.length,
+		sha256: sha256Text(jobsSql),
+		r2Etag: createHash('md5').update(jobsSql).digest('hex'),
+	})
+	await putImmutableManifest(
+		bucket as unknown as R2Bucket,
+		jobsPayload.manifestKey,
+		signedManifest({
+			...template.payload,
+			source: {
+				...template.payload.source,
+				databaseId: jobsId,
+				databaseName: 'kody-jobs',
+			},
+			export: {
+				...template.payload.export,
+				scheduledAt: `${seeded.day}T02:15:00.000Z`,
+				startedAt: `${seeded.day}T02:15:01.000Z`,
+				completedAt: `${seeded.day}T02:16:00.000Z`,
+			},
+			sql: { ...template.payload.sql, objectKey: jobsSqlKey },
+		}),
+	)
+	const result = await sealFullBackupDay(
+		seeded.env,
+		seeded.day,
+		new Date(`${seeded.day}T04:00:00.000Z`),
+	)
+	assert.equal(result.kind, 'sealed')
+	if (result.kind !== 'sealed') return
+	assert.equal(result.alreadySealed, false)
+	const sealed = await readFullManifest(
+		bucket as unknown as R2Bucket,
+		sealedFullManifestKey(seeded.day),
+	)
+	assert.deepEqual(
+		sealed?.payload.d1Sources?.map((source) => ({
+			databaseId: source.databaseId,
+			databaseName: source.databaseName,
+			manifestKey: source.manifestKey,
+		})),
+		[
+			{
+				databaseId: seeded.env.SOURCE_DATABASE_ID,
+				databaseName: seeded.env.SOURCE_DATABASE_NAME,
+				manifestKey: backupPayload(
+					seeded.env,
+					new Date(`${seeded.day}T12:00:00.000Z`),
+				).manifestKey,
+			},
+			{
+				databaseId: jobsId,
+				databaseName: 'kody-jobs',
+				manifestKey: jobsPayload.manifestKey,
+			},
+		],
+	)
 })

--- a/packages/backup-control-plane/seal-full-backup.ts
+++ b/packages/backup-control-plane/seal-full-backup.ts
@@ -1,6 +1,7 @@
 import {
 	parseBackupFullManifest,
 	serializeBackupFullManifest,
+	type BackupFullD1Source,
 	type BackupFullFileRef,
 	type BackupFullManifest,
 } from '@kody-internal/shared/backup-full-manifest.ts'
@@ -485,25 +486,6 @@ export async function sealFullBackupDay(
 	assertBackupDay(day)
 	const manifestKey = sealedFullManifestKey(day)
 	const existing = await readFullManifest(env.BACKUP_BUCKET, manifestKey)
-
-	for (const source of configuredSourceDatabases(env)) {
-		const sourceResult = await assertSourceDayRestorable(
-			bindSourceDatabase(env, source),
-			day,
-		)
-		if (sourceResult.kind === 'incomplete') {
-			return incompleteForSqlStats(day, sourceResult.reason)
-		}
-	}
-
-	const d1Payload = backupPayload(env, new Date(`${day}T12:00:00.000Z`))
-	const d1Manifest = await readManifest(
-		env.BACKUP_BUCKET,
-		d1Payload.manifestKey,
-	)
-	if (d1Manifest === null) {
-		return { kind: 'incomplete', day, reason: 'd1-manifest-missing' }
-	}
 	if (existing !== null) {
 		if (!(await verifyBackupFullManifestSignature(env, existing))) {
 			throw new BackupError(
@@ -525,12 +507,43 @@ export async function sealFullBackupDay(
 		})
 		return { kind: 'sealed', day, manifestKey, alreadySealed: true }
 	}
-	const d1ManifestObject = await env.BACKUP_BUCKET.get(d1Payload.manifestKey)
-	if (d1ManifestObject === null) {
+
+	const d1Sources: Array<BackupFullD1Source> = []
+	for (const source of configuredSourceDatabases(env)) {
+		const sourceEnv = bindSourceDatabase(env, source)
+		const sourceResult = await assertSourceDayRestorable(sourceEnv, day)
+		if (sourceResult.kind === 'incomplete') {
+			return incompleteForSqlStats(day, sourceResult.reason)
+		}
+		const sourcePayload = backupPayload(
+			sourceEnv,
+			new Date(`${day}T12:00:00.000Z`),
+		)
+		const sourceManifestObject = await env.BACKUP_BUCKET.get(
+			sourcePayload.manifestKey,
+		)
+		if (sourceManifestObject === null) {
+			return { kind: 'incomplete', day, reason: 'd1-manifest-missing' }
+		}
+		const sourceManifestBytes = new Uint8Array(
+			await sourceManifestObject.arrayBuffer(),
+		)
+		d1Sources.push({
+			databaseId: source.id,
+			databaseName: source.name,
+			manifestKey: sourcePayload.manifestKey,
+			manifestSha256: await sha256Bytes(sourceManifestBytes),
+		})
+	}
+
+	const d1Payload = backupPayload(env, new Date(`${day}T12:00:00.000Z`))
+	const primarySource = d1Sources.find(
+		(source) => source.manifestKey === d1Payload.manifestKey,
+	)
+	if (primarySource === undefined) {
 		return { kind: 'incomplete', day, reason: 'd1-manifest-missing' }
 	}
-	const d1ManifestBytes = new Uint8Array(await d1ManifestObject.arrayBuffer())
-	const d1ManifestSha256 = await sha256Bytes(d1ManifestBytes)
+	const d1ManifestSha256 = primarySource.manifestSha256
 
 	let summary: StagingSummary
 	try {
@@ -654,6 +667,7 @@ export async function sealFullBackupDay(
 		day,
 		d1ManifestKey: d1Payload.manifestKey,
 		d1ManifestSha256,
+		d1Sources,
 		mailboxIndex: sealedMailboxIndex,
 		runLogIndex: sealedRunLogIndex,
 		storageIndex: toSealedRef(day, summary.storageIndex),

--- a/packages/backup-control-plane/seal-full-backup.ts
+++ b/packages/backup-control-plane/seal-full-backup.ts
@@ -25,6 +25,8 @@ import { isRecord } from '@kody-internal/shared/is-record.ts'
 import {
 	BackupError,
 	backupPayload,
+	bindSourceDatabase,
+	configuredSourceDatabases,
 	errorCode,
 	safeLog,
 	utcDay,
@@ -416,6 +418,55 @@ export type SealDayResult =
 	| { kind: 'sealed'; day: string; manifestKey: string; alreadySealed: boolean }
 	| { kind: 'incomplete'; day: string; reason: string }
 
+async function assertSourceDayRestorable(
+	env: BackupEnvironment,
+	day: string,
+): Promise<{ kind: 'ok' } | { kind: 'incomplete'; reason: string }> {
+	const d1Payload = backupPayload(env, new Date(`${day}T12:00:00.000Z`))
+	const d1Manifest = await readManifest(
+		env.BACKUP_BUCKET,
+		d1Payload.manifestKey,
+	)
+	if (d1Manifest === null) {
+		return { kind: 'incomplete', reason: 'd1-manifest-missing' }
+	}
+	if (!(await verifyBackupManifestSignature(env, d1Manifest))) {
+		throw new BackupError(
+			'd1-manifest-signature-invalid',
+			`D1 manifest signature invalid for ${day}`,
+		)
+	}
+	const restorability = await readSqlRestorability(
+		env.BACKUP_BUCKET,
+		day,
+		d1Manifest.payload.sql.objectKey,
+	)
+	switch (restorability.kind) {
+		case 'restorable':
+			return { kind: 'ok' }
+		case 'legacy-unknown':
+			safeLog({
+				event: 'backup-stats-legacy-missing',
+				status: 'stale-success',
+				day,
+				databaseId: env.SOURCE_DATABASE_ID,
+				databaseName: env.SOURCE_DATABASE_NAME,
+				objectKey: d1Manifest.payload.sql.objectKey,
+			})
+			return { kind: 'ok' }
+		case 'unrestorable':
+			return { kind: 'incomplete', reason: 'backup-unrestorable-statements' }
+		case 'missing':
+			return { kind: 'incomplete', reason: 'backup-sql-stats-missing' }
+		case 'corrupt':
+			return { kind: 'incomplete', reason: 'backup-sql-stats-corrupt' }
+		default: {
+			const exhaustive: never = restorability
+			throw exhaustive
+		}
+	}
+}
+
 function incompleteForSqlStats(day: string, reason: string): SealDayResult {
 	safeLog({
 		event: 'full-backup-seal-skipped',
@@ -435,6 +486,16 @@ export async function sealFullBackupDay(
 	const manifestKey = sealedFullManifestKey(day)
 	const existing = await readFullManifest(env.BACKUP_BUCKET, manifestKey)
 
+	for (const source of configuredSourceDatabases(env)) {
+		const sourceResult = await assertSourceDayRestorable(
+			bindSourceDatabase(env, source),
+			day,
+		)
+		if (sourceResult.kind === 'incomplete') {
+			return incompleteForSqlStats(day, sourceResult.reason)
+		}
+	}
+
 	const d1Payload = backupPayload(env, new Date(`${day}T12:00:00.000Z`))
 	const d1Manifest = await readManifest(
 		env.BACKUP_BUCKET,
@@ -442,39 +503,6 @@ export async function sealFullBackupDay(
 	)
 	if (d1Manifest === null) {
 		return { kind: 'incomplete', day, reason: 'd1-manifest-missing' }
-	}
-	if (!(await verifyBackupManifestSignature(env, d1Manifest))) {
-		throw new BackupError(
-			'd1-manifest-signature-invalid',
-			`D1 manifest signature invalid for ${day}`,
-		)
-	}
-	const restorability = await readSqlRestorability(
-		env.BACKUP_BUCKET,
-		day,
-		d1Manifest.payload.sql.objectKey,
-	)
-	switch (restorability.kind) {
-		case 'restorable':
-			break
-		case 'legacy-unknown':
-			safeLog({
-				event: 'backup-stats-legacy-missing',
-				status: 'stale-success',
-				day,
-				objectKey: d1Manifest.payload.sql.objectKey,
-			})
-			break
-		case 'unrestorable':
-			return incompleteForSqlStats(day, 'backup-unrestorable-statements')
-		case 'missing':
-			return incompleteForSqlStats(day, 'backup-sql-stats-missing')
-		case 'corrupt':
-			return incompleteForSqlStats(day, 'backup-sql-stats-corrupt')
-		default: {
-			const exhaustive: never = restorability
-			throw exhaustive
-		}
 	}
 	if (existing !== null) {
 		if (!(await verifyBackupFullManifestSignature(env, existing))) {

--- a/packages/backup-control-plane/worker.ts
+++ b/packages/backup-control-plane/worker.ts
@@ -3,6 +3,7 @@ import { runFreshnessAndRetry } from './freshness-retry.ts'
 import {
 	BackupError,
 	backupPayload,
+	configuredSourceDatabases,
 	errorCode,
 	isBackupEnabled,
 	safeLog,
@@ -45,59 +46,91 @@ async function triggerBackup(
 	env: BackupEnvironment,
 	scheduledAt: Date,
 ): Promise<void> {
-	const payload = backupPayload(env, scheduledAt)
-	const instanceId = workflowInstanceId(env.SOURCE_DATABASE_ID, payload.day)
-	const result = await enqueueBackup(
-		env.BACKUP_WORKFLOW,
-		env.SOURCE_DATABASE_ID,
-		payload,
-	)
-	safeLog({
-		event: enqueueEvent(result),
-		status: 'success',
-		day: payload.day,
-		instanceId,
-		manifestKey: payload.manifestKey,
-	})
+	const errors: Array<unknown> = []
+	for (const source of configuredSourceDatabases(env)) {
+		const payload = backupPayload(env, scheduledAt, source)
+		const instanceId = workflowInstanceId(source.id, payload.day)
+		try {
+			const result = await enqueueBackup(
+				env.BACKUP_WORKFLOW,
+				source.id,
+				payload,
+			)
+			safeLog({
+				event: enqueueEvent(result),
+				status: 'success',
+				day: payload.day,
+				instanceId,
+				databaseId: source.id,
+				databaseName: source.name,
+				manifestKey: payload.manifestKey,
+			})
+		} catch (error) {
+			errors.push(error)
+		}
+	}
+	if (errors.length === 1) throw errors[0]
+	if (errors.length > 1) {
+		throw new AggregateError(errors, 'One or more D1 backup enqueues failed.')
+	}
 }
 
 async function retryBackup(
 	env: BackupEnvironment,
 	scheduledAt: Date,
 ): Promise<void> {
-	const payload = backupPayload(env, primaryBackupTimeForDay(scheduledAt))
-	const result = await enqueueBackupRetry(
-		env.BACKUP_WORKFLOW,
-		env.SOURCE_DATABASE_ID,
-		payload,
-		scheduledAt,
-	)
-	switch (result) {
-		case 'outside-window':
-		case 'duplicate':
-			return
-		case 'created':
-			safeLog({
-				event: 'backup-catch-up-enqueued',
-				status: 'success',
-				day: payload.day,
-				instanceId: workflowInstanceId(env.SOURCE_DATABASE_ID, payload.day),
-				manifestKey: payload.manifestKey,
-			})
-			return
-		case 'restarted':
-			safeLog({
-				event: 'backup-restarted',
-				status: 'success',
-				day: payload.day,
-				instanceId: workflowInstanceId(env.SOURCE_DATABASE_ID, payload.day),
-				manifestKey: payload.manifestKey,
-			})
-			return
-		default: {
-			const exhaustive: never = result
-			throw exhaustive
+	const errors: Array<unknown> = []
+	for (const source of configuredSourceDatabases(env)) {
+		const payload = backupPayload(
+			env,
+			primaryBackupTimeForDay(scheduledAt),
+			source,
+		)
+		try {
+			const result = await enqueueBackupRetry(
+				env.BACKUP_WORKFLOW,
+				source.id,
+				payload,
+				scheduledAt,
+			)
+			switch (result) {
+				case 'outside-window':
+				case 'duplicate':
+					break
+				case 'created':
+					safeLog({
+						event: 'backup-catch-up-enqueued',
+						status: 'success',
+						day: payload.day,
+						instanceId: workflowInstanceId(source.id, payload.day),
+						databaseId: source.id,
+						databaseName: source.name,
+						manifestKey: payload.manifestKey,
+					})
+					break
+				case 'restarted':
+					safeLog({
+						event: 'backup-restarted',
+						status: 'success',
+						day: payload.day,
+						instanceId: workflowInstanceId(source.id, payload.day),
+						databaseId: source.id,
+						databaseName: source.name,
+						manifestKey: payload.manifestKey,
+					})
+					break
+				default: {
+					const exhaustive: never = result
+					throw exhaustive
+				}
+			}
+		} catch (error) {
+			errors.push(error)
 		}
+	}
+	if (errors.length === 1) throw errors[0]
+	if (errors.length > 1) {
+		throw new AggregateError(errors, 'One or more D1 backup retries failed.')
 	}
 }
 

--- a/packages/backup-control-plane/wrangler.jsonc
+++ b/packages/backup-control-plane/wrangler.jsonc
@@ -38,8 +38,12 @@
 		"SOURCE_ACCOUNT_ID": "a99ee2e72728dd52902ef288b7b1447d",
 		"SOURCE_DATABASE_ID": "8c1014d1-6b41-4695-a0a2-159071f0f919",
 		"SOURCE_DATABASE_NAME": "kody",
+		// Nightly export list. `kody-jobs` UUID is the production D1 named
+		// `kody-jobs` (JOBS_DB); deploy resolves it by name in
+		// tools/ci/jobs-worker-resources.ts (`jobs_d1_database_id`).
+		"SOURCE_DATABASES": "[{\"id\":\"8c1014d1-6b41-4695-a0a2-159071f0f919\",\"name\":\"kody\"},{\"id\":\"5410331e-4d25-47e4-a1e5-a248f7cc764c\",\"name\":\"kody-jobs\"}]",
 		"ALLOWED_SOURCE_ACCOUNT_IDS": "a99ee2e72728dd52902ef288b7b1447d",
-		"ALLOWED_SOURCE_DATABASE_IDS": "8c1014d1-6b41-4695-a0a2-159071f0f919",
+		"ALLOWED_SOURCE_DATABASE_IDS": "8c1014d1-6b41-4695-a0a2-159071f0f919,5410331e-4d25-47e4-a1e5-a248f7cc764c",
 		"BUILD_COMMIT": "REPLACE_AT_DEPLOY_TIME",
 		// Non-secret provenance. The matching PKCS#8 private key is a Worker secret.
 		"BACKUP_MANIFEST_SIGNING_KEY_ID": "kody-dr-2026-07",

--- a/packages/shared/src/backup-full-manifest.node.test.ts
+++ b/packages/shared/src/backup-full-manifest.node.test.ts
@@ -120,6 +120,55 @@ test('parseBackupFullManifest accepts a signed envelope and rejects shape drift'
 	).toBe(backupFullManifestLegacySchemaVersion)
 })
 
+test('parseBackupFullManifest accepts declared d1Sources and keeps historical payloads valid', () => {
+	const payload = samplePayload()
+	expect(
+		parseBackupFullManifest(signedManifest(payload)).payload.d1Sources,
+	).toBe(undefined)
+	const d1Sources = [
+		{
+			databaseId: '22222222-2222-4222-8222-222222222222',
+			databaseName: 'kody',
+			manifestKey: payload.d1ManifestKey,
+			manifestSha256: 'a'.repeat(64),
+		},
+		{
+			databaseId: '44444444-4444-4444-8444-444444444444',
+			databaseName: 'kody-jobs',
+			manifestKey:
+				'daily/d1/44444444-4444-4444-8444-444444444444/2026-07-22/manifest.json',
+			manifestSha256: 'b'.repeat(64),
+		},
+	]
+	const withSources = signedManifest({ ...payload, d1Sources })
+	expect(parseBackupFullManifest(withSources).payload.d1Sources).toEqual(
+		d1Sources,
+	)
+
+	expect(() =>
+		parseBackupFullManifest(signedManifest({ ...payload, d1Sources: [] })),
+	).toThrow(/invalid versioned shape/)
+	expect(() =>
+		parseBackupFullManifest(
+			signedManifest({
+				...payload,
+				d1Sources: [
+					{
+						...d1Sources[0]!,
+						manifestKey: 'daily/d1/other/2026-07-22/manifest.json',
+					},
+				],
+			}),
+		),
+	).toThrow(/invalid signed values/)
+	expect(() =>
+		parseBackupFullManifest({
+			...withSources,
+			payload: { ...withSources.payload, extra: true },
+		}),
+	).toThrow(/invalid versioned shape/)
+})
+
 test('full-manifest parse/sign/verify round-trip with Ed25519', async () => {
 	const { privateKey, publicKey } = generateKeyPairSync('ed25519')
 	const payload = samplePayload()

--- a/packages/shared/src/backup-full-manifest.ts
+++ b/packages/shared/src/backup-full-manifest.ts
@@ -12,10 +12,18 @@ export type BackupFullFileRef = {
 	sha256: string
 }
 
+export type BackupFullD1Source = {
+	databaseId: string
+	databaseName: string
+	manifestKey: string
+	manifestSha256: string
+}
+
 type BackupFullManifestPayloadBase = {
 	day: string
 	d1ManifestKey: string
 	d1ManifestSha256: string
+	d1Sources?: Array<BackupFullD1Source>
 	storageIndex: BackupFullFileRef
 	r2Indexes: Partial<Record<BackupR2BucketLabel, BackupFullFileRef>>
 	artifactsIndex: BackupFullFileRef
@@ -56,7 +64,16 @@ export type BackupFullManifest =
 const dayPattern = /^\d{4}-\d{2}-\d{2}$/
 const sha256Pattern = /^[0-9a-f]{64}$/
 const keyIdPattern = /^[a-z0-9]+(?:-[a-z0-9]+)*$/
+const databaseIdPattern =
+	/^(?:[0-9a-f]{32}|[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})$/i
 const knownR2Labels = new Set<string>(['email-blobs', 'community-assets'])
+const optionalPayloadKeys = ['d1Sources'] as const
+const d1SourceKeys = [
+	'databaseId',
+	'databaseName',
+	'manifestKey',
+	'manifestSha256',
+] as const
 
 function hasExactKeys(
 	value: Record<string, unknown>,
@@ -68,6 +85,18 @@ function hasExactKeys(
 		actual.length === sortedExpected.length &&
 		actual.every((key, index) => key === sortedExpected[index])
 	)
+}
+
+function hasRequiredKeys(
+	value: Record<string, unknown>,
+	required: ReadonlyArray<string>,
+	optional: ReadonlyArray<string> = [],
+): boolean {
+	const allowed = new Set([...required, ...optional])
+	if (!required.every((key) => Object.hasOwn(value, key))) {
+		return false
+	}
+	return Object.keys(value).every((key) => allowed.has(key))
 }
 
 function isNonemptyString(value: unknown): value is string {
@@ -94,6 +123,54 @@ function isR2Indexes(
 		if (!knownR2Labels.has(key) || !isFileRef(entry)) return false
 	}
 	return true
+}
+
+function parseBackupFullD1Sources(
+	value: unknown,
+	d1ManifestKey: string,
+): Array<BackupFullD1Source> {
+	if (!Array.isArray(value) || value.length === 0) {
+		throw new Error('full backup manifest has an invalid versioned shape')
+	}
+	const sources: Array<BackupFullD1Source> = []
+	const ids = new Set<string>()
+	const names = new Set<string>()
+	const manifestKeys = new Set<string>()
+	for (const entry of value) {
+		if (
+			!isRecord(entry) ||
+			!hasExactKeys(entry, d1SourceKeys) ||
+			typeof entry.databaseId !== 'string' ||
+			!databaseIdPattern.test(entry.databaseId) ||
+			!isNonemptyString(entry.databaseName) ||
+			!isNonemptyString(entry.manifestKey) ||
+			typeof entry.manifestSha256 !== 'string' ||
+			!sha256Pattern.test(entry.manifestSha256)
+		) {
+			throw new Error('full backup manifest contains invalid signed values')
+		}
+		const id = entry.databaseId.toLowerCase()
+		if (
+			ids.has(id) ||
+			names.has(entry.databaseName) ||
+			manifestKeys.has(entry.manifestKey)
+		) {
+			throw new Error('full backup manifest contains invalid signed values')
+		}
+		ids.add(id)
+		names.add(entry.databaseName)
+		manifestKeys.add(entry.manifestKey)
+		sources.push({
+			databaseId: entry.databaseId,
+			databaseName: entry.databaseName,
+			manifestKey: entry.manifestKey,
+			manifestSha256: entry.manifestSha256,
+		})
+	}
+	if (!sources.some((source) => source.manifestKey === d1ManifestKey)) {
+		throw new Error('full backup manifest contains invalid signed values')
+	}
+	return sources
 }
 
 export function parseBackupFullManifest(value: unknown): BackupFullManifest {
@@ -132,7 +209,7 @@ export function parseBackupFullManifest(value: unknown): BackupFullManifest {
 		(value.schemaVersion !== backupFullManifestLegacySchemaVersion &&
 			value.schemaVersion !== backupFullManifestSchemaVersion) ||
 		!isRecord(value.payload) ||
-		!hasExactKeys(value.payload, payloadKeys) ||
+		!hasRequiredKeys(value.payload, payloadKeys, optionalPayloadKeys) ||
 		value.payload.schemaVersion !== value.schemaVersion ||
 		!isRecord(value.payload.signing) ||
 		!hasExactKeys(value.payload.signing, ['algorithm', 'keyId']) ||
@@ -165,6 +242,12 @@ export function parseBackupFullManifest(value: unknown): BackupFullManifest {
 		value.signature.value.length === 0
 	) {
 		throw new Error('full backup manifest contains invalid signed values')
+	}
+	if (Object.hasOwn(value.payload, 'd1Sources')) {
+		parseBackupFullD1Sources(
+			value.payload.d1Sources,
+			value.payload.d1ManifestKey,
+		)
 	}
 	return value as BackupFullManifest
 }

--- a/tools/disaster-recovery/canonical-readiness-signatures.node.test.ts
+++ b/tools/disaster-recovery/canonical-readiness-signatures.node.test.ts
@@ -42,6 +42,10 @@ const sourceIdentity = {
 	accountId: '0123456789abcdef0123456789abcdef',
 	resourceId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
 }
+const jobsSourceIdentity = {
+	accountId: '0123456789abcdef0123456789abcdef',
+	resourceId: 'cccccccc-cccc-4ccc-8ccc-cccccccccccc',
+}
 const destinationIdentity = {
 	accountId: 'fedcba9876543210fedcba9876543210',
 	resourceId: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
@@ -60,7 +64,11 @@ const restoreProvenance = {
 	trustedBaselineSha256: '4'.repeat(64),
 }
 
-function detailsFor(kind: AppKind): EvidenceDetailsByKind[AppKind] {
+function detailsFor(
+	kind: AppKind,
+	identity = sourceIdentity,
+	provenance = restoreProvenance,
+): EvidenceDetailsByKind[AppKind] {
 	switch (kind) {
 		case 'inventory':
 			return { inventorySha256: '1'.repeat(64), itemCount: 1 }
@@ -77,16 +85,16 @@ function detailsFor(kind: AppKind): EvidenceDetailsByKind[AppKind] {
 			return { checksPassed: 5, contractVersion: '2026-07-22' }
 		case 'd1-size-ceiling-check':
 			return {
-				...restoreProvenance,
+				...provenance,
 				ceilingBytes: 4_500_000_000,
 				measuredBytes: 1024,
 				monitoredAt: performedAt,
-				sourceAccountId: sourceIdentity.accountId,
-				sourceDatabaseUuid: sourceIdentity.resourceId,
+				sourceAccountId: identity.accountId,
+				sourceDatabaseUuid: identity.resourceId,
 			}
 		case 'd1-restore-drill':
 			return {
-				...restoreProvenance,
+				...provenance,
 				foreignKeyViolations: 0,
 				quickCheck: 'ok',
 				restoredDatabaseUuid: destinationIdentity.resourceId,
@@ -126,6 +134,14 @@ function signEnvelope(
 	}
 }
 
+const jobsRestoreProvenance = {
+	...restoreProvenance,
+	backupManifestSha256: '5'.repeat(64),
+	sourceDatabaseName: 'kody-jobs',
+	sqlSha256: '6'.repeat(64),
+	trustedBaselineId: 'jobs-baseline-2026',
+}
+
 async function createFixture(
 	directory: string,
 	privateKey: KeyObject,
@@ -135,55 +151,78 @@ async function createFixture(
 	evidencePath: string
 }> {
 	const envelopes: Array<SignedEvidenceEnvelope> = []
-	const artifacts: Array<Record<string, unknown>> = []
-	for (const kind of appKinds) {
-		const uri = `${kind}.json`
-		const content: EvidenceContent = {
-			changeId: 'CHG-APP-DB-RESTORE',
-			destinationIdentity: destinationFor(kind),
-			details: detailsFor(kind),
+	async function writeResource(input: {
+		changeId: string
+		prefix: string
+		resourceId: 'APP_DB' | 'JOBS_DB'
+		identity: { accountId: string; resourceId: string }
+		provenance: typeof restoreProvenance
+	}): Promise<Record<string, unknown>> {
+		const artifacts: Array<Record<string, unknown>> = []
+		for (const kind of appKinds) {
+			const uri = `${input.prefix}${kind}.json`
+			const content: EvidenceContent = {
+				changeId: input.changeId,
+				destinationIdentity: destinationFor(kind),
+				details: detailsFor(kind, input.identity, input.provenance),
+				expiresAt,
+				kind,
+				outcome: 'passed',
+				performedAt,
+				resourceId: input.resourceId,
+				sourceIdentity: input.identity,
+				systemVersion: 'kody-build-2026.07.22',
+				uri,
+				verifierIdentity: 'recovery-verifier@example.test',
+			}
+			const envelope = signEnvelope(content, privateKey)
+			const bytes = Buffer.from(JSON.stringify(envelope))
+			await writeFile(path.join(directory, uri), bytes)
+			envelopes.push(envelope)
+			artifacts.push({
+				changeId: content.changeId,
+				destinationIdentity: content.destinationIdentity,
+				expiresAt: content.expiresAt,
+				kind: content.kind,
+				outcome: content.outcome,
+				performedAt: content.performedAt,
+				sha256: sha256(bytes),
+				sourceIdentity: content.sourceIdentity,
+				systemVersion: content.systemVersion,
+				type: 'application/vnd.kody.readiness-evidence+json',
+				uri: content.uri,
+				verifierIdentity: content.verifierIdentity,
+			})
+		}
+		return {
+			artifacts,
+			changeId: input.changeId,
 			expiresAt,
-			kind,
-			outcome: 'passed',
 			performedAt,
-			resourceId: 'APP_DB',
-			sourceIdentity,
+			resourceId: input.resourceId,
+			schemaVersion: 1,
 			systemVersion: 'kody-build-2026.07.22',
-			uri,
 			verifierIdentity: 'recovery-verifier@example.test',
 		}
-		const envelope = signEnvelope(content, privateKey)
-		const bytes = Buffer.from(JSON.stringify(envelope))
-		await writeFile(path.join(directory, uri), bytes)
-		envelopes.push(envelope)
-		artifacts.push({
-			changeId: content.changeId,
-			destinationIdentity: content.destinationIdentity,
-			expiresAt: content.expiresAt,
-			kind: content.kind,
-			outcome: content.outcome,
-			performedAt: content.performedAt,
-			sha256: sha256(bytes),
-			sourceIdentity: content.sourceIdentity,
-			systemVersion: content.systemVersion,
-			type: 'application/vnd.kody.readiness-evidence+json',
-			uri: content.uri,
-			verifierIdentity: content.verifierIdentity,
-		})
 	}
+	const evidence = [
+		await writeResource({
+			changeId: 'CHG-APP-DB-RESTORE',
+			prefix: '',
+			resourceId: 'APP_DB',
+			identity: sourceIdentity,
+			provenance: restoreProvenance,
+		}),
+		await writeResource({
+			changeId: 'CHG-JOBS-DB-RESTORE',
+			prefix: 'jobs-db-',
+			resourceId: 'JOBS_DB',
+			identity: jobsSourceIdentity,
+			provenance: jobsRestoreProvenance,
+		}),
+	]
 	return {
-		evidence: [
-			{
-				artifacts,
-				changeId: 'CHG-APP-DB-RESTORE',
-				expiresAt,
-				performedAt,
-				resourceId: 'APP_DB',
-				schemaVersion: 1,
-				systemVersion: 'kody-build-2026.07.22',
-				verifierIdentity: 'recovery-verifier@example.test',
-			},
-		],
+		evidence,
 		envelopes,
 		evidencePath: path.join(directory, 'evidence.json'),
 	}
@@ -228,6 +267,11 @@ async function isD1Ready(
 				databaseId: trustedSource.resourceId,
 				databaseName: restoreProvenance.sourceDatabaseName,
 			},
+			{
+				accountId: jobsSourceIdentity.accountId,
+				databaseId: jobsSourceIdentity.resourceId,
+				databaseName: jobsRestoreProvenance.sourceDatabaseName,
+			},
 		],
 		[
 			{
@@ -240,6 +284,20 @@ async function isD1Ready(
 				},
 				baseline: {
 					schemaSha256: restoreProvenance.schemaSha256,
+					migrationNames,
+					isolationChecks,
+				},
+			},
+			{
+				id: jobsRestoreProvenance.trustedBaselineId,
+				canonicalSha256: jobsRestoreProvenance.trustedBaselineSha256,
+				source: {
+					accountId: jobsSourceIdentity.accountId,
+					databaseId: jobsSourceIdentity.resourceId,
+					databaseName: jobsRestoreProvenance.sourceDatabaseName,
+				},
+				baseline: {
+					schemaSha256: jobsRestoreProvenance.schemaSha256,
 					migrationNames,
 					isolationChecks,
 				},
@@ -336,6 +394,7 @@ test('signed expiry rejects index-only extension, invalid timestamps, and code-a
 		}
 		reSignedRecord.expiresAt = extendedExpiresAt
 		for (const envelope of fixture.envelopes) {
+			if (envelope.content.resourceId !== 'APP_DB') continue
 			const extendedEnvelope = signEnvelope(
 				{ ...envelope.content, expiresAt: extendedExpiresAt },
 				privateKey,
@@ -595,6 +654,7 @@ test('signed D1 provenance, restore isolation, and account identities fail close
 				throw new Error('fixture is malformed')
 			}
 			for (const envelope of fixture.envelopes) {
+				if (envelope.content.resourceId !== 'APP_DB') continue
 				if (envelope.content.destinationIdentity === null) continue
 				const content: EvidenceContent =
 					envelope.content.kind === 'd1-restore-drill'
@@ -663,6 +723,7 @@ test('signed D1 provenance, restore isolation, and account identities fail close
 			}
 			let affectedEnvelopeCount = 0
 			for (const envelope of fixture.envelopes) {
+				if (envelope.content.resourceId !== 'APP_DB') continue
 				const content = structuredClone(envelope.content)
 				let affected = false
 				if (identity === 'source') {

--- a/tools/disaster-recovery/d1-restore-drill-cli.ts
+++ b/tools/disaster-recovery/d1-restore-drill-cli.ts
@@ -25,6 +25,9 @@ const drillTokenEnvironmentVariable = 'CLOUDFLARE_D1_DRILL_EDIT_TOKEN'
 const applicationMigrationsDirectory = fileURLToPath(
 	new URL('../../packages/worker/migrations/', import.meta.url),
 )
+const jobsMigrationsDirectory = fileURLToPath(
+	new URL('../../packages/jobs-worker/migrations/', import.meta.url),
+)
 export const restoreTrustRegistryPath = fileURLToPath(
 	new URL('./trusted-d1-restore-identities.json', import.meta.url),
 )
@@ -43,6 +46,7 @@ type CliArguments = {
 	postForwardBaselineId?: string
 	targetAccountId: string
 	targetName: string
+	database?: string
 	execute: boolean
 	applyForwardMigrations: boolean
 }
@@ -53,6 +57,7 @@ export function parseArguments(argv: ReadonlyArray<string>): CliArguments {
 	const valuedArguments = new Set([
 		'--backup',
 		'--baseline-id',
+		'--database',
 		'--manifest',
 		'--manifest-sha256',
 		'--post-forward-baseline-id',
@@ -92,6 +97,7 @@ export function parseArguments(argv: ReadonlyArray<string>): CliArguments {
 		postForwardBaselineId: values.get('--post-forward-baseline-id'),
 		targetAccountId: required('--target-account-id'),
 		targetName: required('--target-name'),
+		database: values.get('--database'),
 		execute: switches.has('--execute'),
 		applyForwardMigrations: switches.has('--apply-forward-migrations'),
 	}
@@ -455,6 +461,29 @@ export async function createD1DrillTarget(input: {
 	}
 }
 
+export function migrationsDirectoryForDatabase(databaseName: string): string {
+	return databaseName === 'kody-jobs'
+		? jobsMigrationsDirectory
+		: applicationMigrationsDirectory
+}
+
+export function assertRequestedDatabase(
+	databaseName: string,
+	databaseId: string,
+	requested: string | undefined,
+): void {
+	if (requested === undefined || requested.trim() === '') return
+	const selector = requested.trim()
+	if (
+		selector !== databaseName &&
+		selector.toLowerCase() !== databaseId.toLowerCase()
+	) {
+		throw new Error(
+			`--database ${selector} does not match manifest source ${databaseName}`,
+		)
+	}
+}
+
 export function createAdapters(
 	token: string,
 	targetAccountId: string,
@@ -504,6 +533,14 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
 		args.manifestSha256,
 		manifestPublicKeyRegistry,
 	)
+	assertRequestedDatabase(
+		manifest.payload.source.databaseName,
+		manifest.payload.source.databaseId,
+		args.database,
+	)
+	const migrationsDirectory = migrationsDirectoryForDatabase(
+		manifest.payload.source.databaseName,
+	)
 	await withStagedBackupFile(
 		args.backupPath,
 		{
@@ -535,7 +572,12 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
 					applyForwardMigrations: args.applyForwardMigrations,
 					dryRun: !args.execute,
 				},
-				createAdapters(token, args.targetAccountId),
+				createAdapters(token, args.targetAccountId, async (input) =>
+					writeTemporaryD1RestoreConfig({
+						...input,
+						migrationsDirectory,
+					}),
+				),
 			)
 			if (result.dryRun) console.log(JSON.stringify(result, null, 2))
 			else console.log('Live-created target passed all restore-drill checks.')

--- a/tools/disaster-recovery/readiness-assessment.ts
+++ b/tools/disaster-recovery/readiness-assessment.ts
@@ -279,7 +279,7 @@ function artifactMatchesEnvelope(
 		content.expiresAt === artifact.expiresAt
 	if (!metadataMatches) return false
 	if (
-		resourceId === 'APP_DB' &&
+		(resourceId === 'APP_DB' || resourceId === 'JOBS_DB') &&
 		(content.kind === 'source-credential-check' ||
 			content.kind === 'destination-credential-check')
 	) {
@@ -348,7 +348,7 @@ export function assessCanonicalReadiness(
 					)
 				}
 			}
-			if (contract.id === 'APP_DB') {
+			if (contract.id === 'APP_DB' || contract.id === 'JOBS_DB') {
 				const restoreArtifact = evidence.artifacts.find(
 					(artifact) => artifact.kind === 'd1-restore-drill',
 				)
@@ -382,7 +382,7 @@ export function assessCanonicalReadiness(
 					)
 					if (!trustedSource) {
 						failures.push(
-							'APP_DB: signed source identity/name is not a checked production source',
+							`${contract.id}: signed source identity/name is not a checked production source`,
 						)
 					}
 					const provenanceKeys = [
@@ -399,7 +399,7 @@ export function assessCanonicalReadiness(
 					for (const key of provenanceKeys) {
 						if (restoreDetails[key] !== sizeDetails[key]) {
 							failures.push(
-								`APP_DB: signed restore ${key} does not match source evidence`,
+								`${contract.id}: signed restore ${key} does not match source evidence`,
 							)
 						}
 					}
@@ -425,7 +425,7 @@ export function assessCanonicalReadiness(
 							restoreDetails.isolationBaselineSha256
 					) {
 						failures.push(
-							'APP_DB: signed restore baseline provenance is not checked or does not match',
+							`${contract.id}: signed restore baseline provenance is not checked or does not match`,
 						)
 					}
 				}

--- a/tools/disaster-recovery/readiness-contracts.ts
+++ b/tools/disaster-recovery/readiness-contracts.ts
@@ -12,6 +12,7 @@ export type CanonicalResourceId =
 	| 'COMMUNITY_ASSETS'
 	| 'COMMUNITY_ICONS'
 	| 'EMAIL_BLOBS'
+	| 'JOBS_DB'
 	| 'OAUTH'
 	| 'QUEUES_WORKFLOWS'
 	| 'SECRET_STORE_KEY'
@@ -208,6 +209,21 @@ export const canonicalContracts = [
 			'complete checksummed D1 SQL export',
 			'migration and sqlite schema parity evidence',
 			'foreign-key, integrity, sequence, and two-user isolation evidence',
+		],
+		excludes: ['production overwrite', 'Time Travel', 'automatic cutover'],
+	},
+	{
+		id: 'JOBS_DB',
+		requiredFor: 'd1-only',
+		transfer: 'd1-logical-import',
+		requiredEvidenceKinds: [
+			...commonEvidenceKinds,
+			'd1-size-ceiling-check',
+			'd1-restore-drill',
+		],
+		includes: [
+			'complete checksummed kody-jobs D1 SQL export',
+			'jobs and archived_job_artifacts table evidence',
 		],
 		excludes: ['production overwrite', 'Time Travel', 'automatic cutover'],
 	},

--- a/tools/disaster-recovery/readiness-evidence-schema.ts
+++ b/tools/disaster-recovery/readiness-evidence-schema.ts
@@ -355,7 +355,8 @@ export function parseSignedEvidenceEnvelope(
 	if (
 		!sourceIdentity ||
 		destinationIdentity === undefined ||
-		(input.content.resourceId === 'APP_DB' &&
+		((input.content.resourceId === 'APP_DB' ||
+			input.content.resourceId === 'JOBS_DB') &&
 			(!cloudflareAccountIdPattern.test(sourceIdentity.accountId) ||
 				(destinationIdentity !== null &&
 					!cloudflareAccountIdPattern.test(destinationIdentity.accountId)))) ||

--- a/tools/disaster-recovery/readme.md
+++ b/tools/disaster-recovery/readme.md
@@ -90,7 +90,8 @@ node tools/disaster-recovery/d1-restore-drill-cli.ts \
   --backup backup.sql \
   --baseline-id approved-production-baseline \
   --target-account-id isolated-drill-account-id \
-  --target-name app-db-restore-drill
+  --target-name app-db-restore-drill \
+  --database kody
 ```
 
 This is a dry run. Inspect its ordered commands. Add `--execute` only for the
@@ -98,11 +99,14 @@ isolated target account after setting `CLOUDFLARE_D1_DRILL_EDIT_TOKEN` to a
 drill-only D1 Edit token for that account. The token is used for live creation,
 import, and checks and is never printed. `--apply-forward-migrations` is
 rejected unless `--post-forward-baseline-id approved-post-forward-baseline` is
-also supplied. After target creation the tool writes a temporary Wrangler config
-binding `D1_RESTORE_TARGET` to the returned UUID/name and pointing
-`migrations_dir` at `packages/worker/migrations`; import, checks, and migrations
-all use that config. The local config is removed afterward. The tool never
-deletes, binds, cuts over, or modifies production.
+also supplied. `--database` selects the production source (`kody` or
+`kody-jobs`, or that database's UUID) and must match the signed manifest source.
+After target creation the tool writes a temporary Wrangler config binding
+`D1_RESTORE_TARGET` to the returned UUID/name and pointing `migrations_dir` at
+`packages/worker/migrations` (APP_DB) or `packages/jobs-worker/migrations`
+(`kody-jobs`); import, checks, and migrations all use that config. The local
+config is removed afterward. The tool never deletes, binds, cuts over, or
+modifies production.
 
 ## Canonical readiness
 
@@ -112,7 +116,7 @@ verifier, change, system/build version, performed timestamp, freshness interval,
 and artifact metadata. The index `expiresAt` must exactly match every artifact's
 metadata and signed content. Every resource requires inventory,
 source/destination credential checks, support and contract checks, plus its
-resource-specific drill evidence. APP_DB additionally requires a
+resource-specific drill evidence. APP_DB and JOBS_DB additionally require a
 `d1-size-ceiling-check` whose measured bytes are strictly below a ceiling no
 greater than 4,500,000,000 bytes.
 
@@ -136,7 +140,7 @@ baseline/source registries. The restored UUID must equal
 `destinationIdentity.resourceId`; destination account and resource identities
 must both differ from the source.
 
-Every APP_DB signed `sourceIdentity.accountId` and non-null
+Every APP_DB and JOBS_DB signed `sourceIdentity.accountId` and non-null
 `destinationIdentity.accountId` must be a canonical Cloudflare account ID:
 exactly 32 lowercase ASCII hexadecimal characters. Whitespace, uppercase,
 wrong-length, non-hex, and Unicode-lookalike values are rejected without

--- a/tools/disaster-recovery/restore-trust-and-verification.node.test.ts
+++ b/tools/disaster-recovery/restore-trust-and-verification.node.test.ts
@@ -11,7 +11,9 @@ import {
 	verifyRows,
 } from './d1-restore-drill.ts'
 import {
+	assertRequestedDatabase,
 	manifestPublicKeyRegistryPath,
+	migrationsDirectoryForDatabase,
 	parseArguments,
 	restoreBaselineRegistryPath,
 	restoreTrustRegistryPath,
@@ -271,6 +273,11 @@ test('restore trust registry is exact, pins the reviewed identities, and cannot 
 				databaseId: '8c1014d1-6b41-4695-a0a2-159071f0f919',
 				databaseName: 'kody',
 			},
+			{
+				accountId: 'a99ee2e72728dd52902ef288b7b1447d',
+				databaseId: '5410331e-4d25-47e4-a1e5-a248f7cc764c',
+				databaseName: 'kody-jobs',
+			},
 		],
 		drillTargets: [
 			{
@@ -357,4 +364,51 @@ test('restore trust registry is exact, pins the reviewed identities, and cannot 
 			'kody-drill',
 		]),
 	).toThrow('Unknown argument: --allowlist')
+})
+
+test('restore-drill --database selects a configured source and jobs migrations', () => {
+	const parsed = parseArguments([
+		'--manifest',
+		'manifest.json',
+		'--manifest-sha256',
+		'0'.repeat(64),
+		'--backup',
+		'backup.sql',
+		'--baseline-id',
+		'production-baseline-2026',
+		'--target-account-id',
+		targetAccountId,
+		'--target-name',
+		'kody-jobs-drill',
+		'--database',
+		'kody-jobs',
+	])
+	expect(parsed.database).toBe('kody-jobs')
+	expect(() =>
+		assertRequestedDatabase(
+			'kody-jobs',
+			'5410331e-4d25-47e4-a1e5-a248f7cc764c',
+			'kody-jobs',
+		),
+	).not.toThrow()
+	expect(() =>
+		assertRequestedDatabase(
+			'kody-jobs',
+			'5410331e-4d25-47e4-a1e5-a248f7cc764c',
+			'5410331e-4d25-47e4-a1e5-a248f7cc764c',
+		),
+	).not.toThrow()
+	expect(() =>
+		assertRequestedDatabase(
+			'kody',
+			'8c1014d1-6b41-4695-a0a2-159071f0f919',
+			'kody-jobs',
+		),
+	).toThrow('--database kody-jobs does not match manifest source kody')
+	expect(migrationsDirectoryForDatabase('kody')).toMatch(
+		/packages\/worker\/migrations\/?$/,
+	)
+	expect(migrationsDirectoryForDatabase('kody-jobs')).toMatch(
+		/packages\/jobs-worker\/migrations\/?$/,
+	)
 })

--- a/tools/disaster-recovery/trusted-d1-restore-identities.json
+++ b/tools/disaster-recovery/trusted-d1-restore-identities.json
@@ -5,6 +5,11 @@
 			"accountId": "a99ee2e72728dd52902ef288b7b1447d",
 			"databaseId": "8c1014d1-6b41-4695-a0a2-159071f0f919",
 			"databaseName": "kody"
+		},
+		{
+			"accountId": "a99ee2e72728dd52902ef288b7b1447d",
+			"databaseId": "5410331e-4d25-47e4-a1e5-a248f7cc764c",
+			"databaseName": "kody-jobs"
 		}
 	],
 	"drillTargets": [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop every user's scheduled-job definitions from being the one durable store with no backup.

## Why

The backup control plane exported exactly one database (APP_DB). `JOBS_DB` (`kody-jobs`, the jobs worker's own D1 holding `jobs` and `archived_job_artifacts`) was neither backed up nor listed as accepted loss, and `disaster-recovery.md` still described re-arming jobs "from D1" as if they lived in APP_DB. Found by the 2026-09-01 launch audit.

## Summary

- Control plane: `SOURCE_DATABASES` (JSON `[{ id, name }]`) replaces the single-database assumption; nightly and UI-triggered exports enqueue one `ProductionD1BackupWorkflow` per configured database (`d1-backup-<databaseId>-<day>`). `SOURCE_DATABASE_ID` / `_NAME` remain the APP_DB fallback. `ALLOWED_SOURCE_DATABASE_IDS` now lists both ids.
- `kody-jobs` production UUID `5410331e-4d25-47e4-a1e5-a248f7cc764c` — not in the committed jobs-worker config (name-only binding); deploy resolves it by name in `tools/ci/jobs-worker-resources.ts`, which is where the value was taken from.
- Restore drill and readiness CLIs take `--database kody | kody-jobs` (UI select likewise); production restore imports both databases.
- Restore claim verified in code before documenting it: `JobManager.syncAlarm → getNextRunnableJob → jobsStore(env.JOBS_DB)`; the jobs-worker watchdog re-arms overdue users from that table.
- Docs: `disaster-recovery.md` (what is backed up, per-store RPO, restore procedure, accepted-loss list corrected), `environment-variables.md`, control-plane readme, DR tooling readme.

### Operator steps
Redeploy the control plane so the new vars go live: `npm run backup:deploy` (or the `deploy-backup-control-plane` action). No new secrets. Run one drill per database afterwards and log both in the DR evidence table.

### Left for a follow-up (called out, not hidden)
Schema-v2 manifests record id, name, SQL bytes, and sha256 but not row counts; the sealed full-manifest `d1ManifestKey` still points at APP_DB only; jobs exports still sign against the APP_DB `TRUSTED_RESTORE_BASELINE_*`; the restore UI confirmation still types the APP_DB name. None block nightly coverage of `kody-jobs`.

## Testing

`npm run typecheck` (incl. control-plane tsconfig), `lint`, `format:check`, `backup:build` (dry-run with both vars), `docs:check-temporal`, `deploy-guardrails:check`; node: 12 files / 59 tests across control-plane policy, runtime, restore drill, seal, freshness, and DR tooling (allowlist must include the jobs id).

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends</b> disaster-recovery control plane (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `a89a32eb` · **Head:** `HEAD`

**Classification:** extends — the backup workflow fans out per database; no product-worker code changes.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `dr-backups` | ops | extends — multi-database export, drill, restore |
| `d1-jobs-db` | storage | composes — now an export source |

### Change flow

```mermaid
sequenceDiagram
	participant cron as control-plane nightly
	participant wf as ProductionD1BackupWorkflow
	participant appDb as APP_DB (kody)
	participant jobsDb as JOBS_DB (kody-jobs)
	participant r2 as kody-production-backups
	cron->>wf: enqueue d1-backup-<APP_DB id>-<day>
	cron->>wf: enqueue d1-backup-<JOBS_DB id>-<day>
	wf->>appDb: export SQL
	wf->>jobsDb: export SQL
	wf->>r2: write objects + signed manifest per database
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b0f6a92a-81cd-4157-8b60-188c83ca84c0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b0f6a92a-81cd-4157-8b60-188c83ca84c0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added backup and restore support for multiple databases, including the jobs database.
  * Added per-database backup status, manifest details, freshness checks, and restore progress.
  * Added database selection to restore drills in the dashboard and CLI.
  * Restores now import databases in the required order and rebuild job alarms from restored data.
  * Added safety exports and notes for databases absent from historical backups.

* **Documentation**
  * Updated disaster-recovery, environment-variable, and restore-drill guidance for multi-database recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->