### PR TITLE
Skip the post-hydration session refetch and embed the search query once

### DIFF
--- a/packages/worker/client/app.node.test.ts
+++ b/packages/worker/client/app.node.test.ts
@@ -1,0 +1,143 @@
+import { expect, test, vi } from 'vitest'
+import { type Handle } from 'remix/ui'
+import { App } from './app.tsx'
+import * as clientRouter from './client-router.tsx'
+import { RouterLocationProvider } from './router-location.tsx'
+import * as session from './session.ts'
+
+const signedInSession: session.SessionInfo = {
+	email: 'kody@example.com',
+	emailVerified: true,
+	emailVerificationDelivery: null,
+	username: 'kody',
+	avatarUrl: null,
+	roles: ['user'],
+	permissions: [],
+	featureFlags: {
+		'demo-indicator': false,
+		'compact-mcp-server-instructions': false,
+	},
+}
+
+async function flushQueuedTasks(
+	queuedTasks: Array<(signal?: AbortSignal) => unknown>,
+) {
+	while (queuedTasks.length > 0) {
+		const tasks = queuedTasks.splice(0)
+		await Promise.all(tasks.map((task) => task(new AbortController().signal)))
+	}
+}
+
+function mountApp(input: {
+	embeddedSession?: session.SessionInfo | null
+	navigationListeners: Array<() => void>
+}) {
+	const queuedTasks: Array<(signal?: AbortSignal) => unknown> = []
+	const abort = new AbortController()
+	vi.spyOn(clientRouter, 'listenToRouterNavigation').mockImplementation(
+		(_handle, listener) => {
+			input.navigationListeners.push(listener)
+		},
+	)
+	vi.spyOn(clientRouter, 'listenToRouterNavigationEnd').mockImplementation(
+		() => {},
+	)
+	vi.spyOn(clientRouter, 'listenToRouterMutations').mockImplementation(() => {})
+
+	App({
+		props:
+			input.embeddedSession === undefined
+				? {}
+				: { embeddedSession: input.embeddedSession },
+		signal: abort.signal,
+		context: {
+			get(provider: unknown) {
+				if (provider === RouterLocationProvider) {
+					return { url: '/', ssrUrl: '/' }
+				}
+				throw new Error('context not available')
+			},
+			set() {},
+		},
+		queueTask(task: (signal?: AbortSignal) => unknown) {
+			queuedTasks.push(task)
+		},
+		update: vi.fn(() => Promise.resolve(abort.signal)),
+	} as unknown as Handle<{ embeddedSession?: session.SessionInfo | null }>)
+
+	return { abort, queuedTasks }
+}
+
+test('App skips the post-hydration /session fetch when the document embedded a session, fetches when it did not, and still refreshes after the navigation throttle', async () => {
+	const previousDocument = globalThis.document
+	const previousWindow = globalThis.window
+	const fetchSpy = vi
+		.spyOn(session, 'fetchSessionInfo')
+		.mockResolvedValue(signedInSession)
+
+	globalThis.document = {
+		addEventListener: vi.fn(),
+		referrer: '',
+	} as unknown as Document
+	globalThis.window = {
+		location: {
+			href: 'https://kody.local/',
+			pathname: '/',
+			search: '',
+			hash: '',
+		},
+		history: { state: null, replaceState: vi.fn() },
+		addEventListener: vi.fn(),
+	} as unknown as Window & typeof globalThis
+
+	const aborts: Array<AbortController> = []
+	try {
+		vi.useFakeTimers()
+		vi.setSystemTime(new Date('2026-09-02T18:00:00.000Z'))
+
+		const embeddedNavigations: Array<() => void> = []
+		const embedded = mountApp({
+			embeddedSession: signedInSession,
+			navigationListeners: embeddedNavigations,
+		})
+		aborts.push(embedded.abort)
+		await flushQueuedTasks(embedded.queuedTasks)
+		expect(fetchSpy).not.toHaveBeenCalled()
+
+		for (const listener of embeddedNavigations) listener()
+		await flushQueuedTasks(embedded.queuedTasks)
+		expect(fetchSpy).not.toHaveBeenCalled()
+
+		vi.setSystemTime(new Date('2026-09-02T18:00:30.000Z'))
+		for (const listener of embeddedNavigations) listener()
+		await flushQueuedTasks(embedded.queuedTasks)
+		expect(fetchSpy).toHaveBeenCalledTimes(1)
+
+		session.queueSessionRefresh()
+		await flushQueuedTasks(embedded.queuedTasks)
+		expect(fetchSpy).toHaveBeenCalledTimes(2)
+
+		const anonymousNavigations: Array<() => void> = []
+		const anonymous = mountApp({
+			embeddedSession: null,
+			navigationListeners: anonymousNavigations,
+		})
+		aborts.push(anonymous.abort)
+		await flushQueuedTasks(anonymous.queuedTasks)
+		expect(fetchSpy).toHaveBeenCalledTimes(2)
+
+		const missingNavigations: Array<() => void> = []
+		const missing = mountApp({
+			navigationListeners: missingNavigations,
+		})
+		aborts.push(missing.abort)
+		await flushQueuedTasks(missing.queuedTasks)
+		expect(fetchSpy).toHaveBeenCalledTimes(3)
+	} finally {
+		for (const abort of aborts) abort.abort()
+		vi.useRealTimers()
+		vi.restoreAllMocks()
+		globalThis.document = previousDocument
+		globalThis.window = previousWindow
+	}
+})

--- a/packages/worker/client/app.tsx
+++ b/packages/worker/client/app.tsx
@@ -118,9 +118,6 @@ export function App(handle: Handle<AppProps>) {
 		queueSessionRefresh()
 	}
 
-	// Always revalidate after hydration: the embedded session renders the
-	// first paint without a flash ('ready' status keeps the refresh silent),
-	// but auth may have changed since the document was rendered.
 	if (typeof document !== 'undefined') {
 		setSessionRefreshHandler(queueSessionRefresh)
 		// Capture UTMs from any landing URL before homepage CTAs rewrite them.
@@ -138,9 +135,13 @@ export function App(handle: Handle<AppProps>) {
 		}
 		// Fathom loads deferred; retry briefly so OAuth ?accountCreated=1 is not dropped.
 		scheduleConsumeAccountCreatedFathomSignal()
-		handle.queueTask(() => {
-			queueSessionRefresh()
-		})
+		if (handle.props.embeddedSession === undefined) {
+			handle.queueTask(() => {
+				queueSessionRefresh()
+			})
+		} else {
+			lastSessionRefreshAt = Date.now()
+		}
 		listenToRouterNavigation(handle, () => {
 			currentPathname = readRouterPathname(handle)
 			queueThrottledSessionRefresh()

--- a/packages/worker/src/mcp/memory/memory-search.node.test.ts
+++ b/packages/worker/src/mcp/memory/memory-search.node.test.ts
@@ -1,6 +1,7 @@
-import { expect, test } from 'vitest'
+import { expect, test, vi } from 'vitest'
 import { consoleWarn } from '#worker/test-support/console-spies.ts'
-import { searchMemories } from './memory-search.ts'
+import * as embedding from '#worker/vectorize/embedding.ts'
+import { queryMemoryVectorIds, searchMemories } from './memory-search.ts'
 import { type McpMemoryRow } from './types.ts'
 
 function row(
@@ -66,4 +67,41 @@ test('searchMemories fail-closes on foreign rows and keeps Vectorize misses lexi
 		vectorRankedIds: ['mem-weak'],
 	})
 	expect(foreign.matches).toEqual([])
+})
+
+test('queryMemoryVectorIds uses a shared embedText instead of embedding the query again', async () => {
+	const embedSpy = vi
+		.spyOn(embedding, 'embedTextForVectorize')
+		.mockRejectedValue(new Error('should not embed again'))
+	const embedTexts: Array<string> = []
+	const embedText = async (text: string) => {
+		embedTexts.push(text)
+		return [0.4, 0.5, 0.6]
+	}
+	const queried: Array<Array<number>> = []
+	const env = {
+		SENTRY_ENVIRONMENT: 'production',
+		CAPABILITY_VECTOR_INDEX: {
+			async query(values: Array<number>) {
+				queried.push(values)
+				return { matches: [] }
+			},
+		},
+	} as unknown as Env
+
+	try {
+		await queryMemoryVectorIds({
+			env,
+			query: 'summarize inbox threads',
+			userId: 'user-1',
+			statuses: ['active'],
+			topK: 5,
+			embedText,
+		})
+		expect(embedSpy).not.toHaveBeenCalled()
+		expect(embedTexts).toEqual(['summarize inbox threads'])
+		expect(queried).toEqual([[0.4, 0.5, 0.6]])
+	} finally {
+		embedSpy.mockRestore()
+	}
 })

--- a/packages/worker/src/mcp/memory/memory-search.ts
+++ b/packages/worker/src/mcp/memory/memory-search.ts
@@ -3,6 +3,7 @@ import {
 	embedTextForVectorize,
 	getCapabilityVectorIndex,
 	isCapabilitySearchOffline,
+	type EmbedTextFn,
 } from '#worker/vectorize/embedding.ts'
 import {
 	CAPABILITY_SEARCH_RRF_K,
@@ -42,10 +43,13 @@ export async function queryMemoryVectorIds(input: {
 	statuses: ReadonlyArray<McpMemoryRow['status']>
 	category?: string | null
 	topK: number
+	embedText?: EmbedTextFn
 }): Promise<Array<string>> {
 	const index = getCapabilityVectorIndex(input.env)
 	if (!index || !input.userId) return []
-	const queryVector = await embedTextForVectorize(input.env, input.query)
+	const queryVector = await (
+		input.embedText ?? ((text) => embedTextForVectorize(input.env, text))
+	)(input.query)
 	const vectorMatches = await index.query(queryVector, {
 		topK: input.topK,
 		namespace: userVectorNamespace(input.userId),
@@ -76,6 +80,7 @@ export async function searchMemories(input: {
 	category?: string | null
 	rows: Array<McpMemoryRow>
 	vectorRankedIds?: ReadonlyArray<string>
+	embedText?: EmbedTextFn
 }): Promise<{ matches: Array<MemorySearchMatch>; offline: boolean }> {
 	const query = input.query.trim()
 	const offline = isCapabilitySearchOffline(input.env)
@@ -117,7 +122,9 @@ export async function searchMemories(input: {
 		vectorOrder = sortIdsByScore(ids, (id) => similarityById[id]!)
 	} else {
 		const index = getCapabilityVectorIndex(input.env)!
-		const queryVector = await embedTextForVectorize(input.env, query)
+		const queryVector = await (
+			input.embedText ?? ((text) => embedTextForVectorize(input.env, text))
+		)(query)
 		const topK = Math.min(Math.max(ids.length, input.limit * 5), 100)
 		const vectorMatches = await index.query(queryVector, {
 			topK,

--- a/packages/worker/src/mcp/memory/service.ts
+++ b/packages/worker/src/mcp/memory/service.ts
@@ -1,7 +1,10 @@
 import { getErrorMessage } from '@kody-internal/shared/error-message.ts'
 import { withAccountWriteLease } from '#worker/account/deletion-state.ts'
 import { type StorageContext } from '#mcp/storage.ts'
-import { isCapabilitySearchOffline } from '#worker/vectorize/embedding.ts'
+import {
+	isCapabilitySearchOffline,
+	type EmbedTextFn,
+} from '#worker/vectorize/embedding.ts'
 import {
 	acknowledgeSurfacedMemoryWrites,
 	deleteMemory as deleteMemoryRow,
@@ -111,6 +114,7 @@ type MemorySearchInput = MemoryOwnerContext & {
 	includeDeleted?: boolean
 	conversationId?: string | null
 	includeSuppressedInConversation?: boolean
+	embedText?: EmbedTextFn
 }
 
 type MemoryVerifyInput = MemoryOwnerContext & {
@@ -471,6 +475,7 @@ export async function searchMemoryRecords(input: MemorySearchInput): Promise<{
 					Math.max(memoryLexicalCandidateLimit, targetLimit * 5),
 					memoryVectorTopKCap,
 				),
+				...(input.embedText ? { embedText: input.embedText } : {}),
 			}),
 		])
 		vectorRankedIds = rankedIds
@@ -500,6 +505,7 @@ export async function searchMemoryRecords(input: MemorySearchInput): Promise<{
 		category,
 		rows: filteredRows,
 		...(vectorRankedIds ? { vectorRankedIds } : {}),
+		...(input.embedText ? { embedText: input.embedText } : {}),
 	})
 	const filtered = await filterSuppressedMatches({
 		db: input.env.APP_DB,

--- a/packages/worker/src/mcp/tools/memory-tool-context.ts
+++ b/packages/worker/src/mcp/tools/memory-tool-context.ts
@@ -6,6 +6,7 @@ import {
 } from '#mcp/memory/service.ts'
 import { type MemoryRecord } from '#mcp/memory/types.ts'
 import { type PackageRetrieverSurfaceResult } from '#worker/package-retrievers/types.ts'
+import { type EmbedTextFn } from '#worker/vectorize/embedding.ts'
 import {
 	escapeMarkdownText,
 	formatMarkdownInlineCode,
@@ -62,6 +63,7 @@ async function loadAutomaticMemories(input: {
 	conversationId: string
 	limit?: number
 	acknowledgeSurfaced?: boolean
+	embedText?: EmbedTextFn
 }) {
 	const result = await searchMemoryRecords({
 		env: input.env,
@@ -76,6 +78,7 @@ async function loadAutomaticMemories(input: {
 		// collapsed `dedupe_key` pair can still fill the second slot.
 		limit: Math.max(input.limit ?? 5, automaticMemorySurfaceLimit * 2 + 1),
 		includeSuppressedInConversation: true,
+		...(input.embedText ? { embedText: input.embedText } : {}),
 	})
 	const memories = selectAutomaticMemories(result.matches)
 	return {
@@ -124,6 +127,7 @@ export async function loadRelevantMemoriesForTool(input: {
 	} | null
 	limit?: number
 	acknowledgeSurfaced?: boolean
+	embedText?: EmbedTextFn
 }): Promise<MemoryToolSummary | null> {
 	const userId = input.callerContext.user?.userId ?? null
 	if (!userId) return null
@@ -138,6 +142,7 @@ export async function loadRelevantMemoriesForTool(input: {
 			conversationId: input.conversationId,
 			limit: input.limit,
 			acknowledgeSurfaced: input.acknowledgeSurfaced,
+			...(input.embedText ? { embedText: input.embedText } : {}),
 		}),
 		runContextPackageRetrievers({
 			env: input.env as Env,

--- a/packages/worker/src/mcp/tools/search-core.ts
+++ b/packages/worker/src/mcp/tools/search-core.ts
@@ -3,6 +3,7 @@ import {
 	deterministicEmbedding,
 	embedTextForVectorize,
 	isCapabilitySearchOffline,
+	type EmbedTextFn,
 } from '#worker/vectorize/embedding.ts'
 import { type getCapabilityRegistryForContext } from '#mcp/capabilities/registry.ts'
 import { type PackageRetrieverSurfaceResult } from '#worker/package-retrievers/types.ts'
@@ -172,6 +173,7 @@ export async function searchUnified(input: {
 	retrieverResults?: Array<PackageRetrieverSurfaceResult>
 	/** Optional capability domain id; scopes ranked results to that domain's capabilities. */
 	domain?: string
+	embedText?: EmbedTextFn
 }): Promise<SearchUnifiedResult> {
 	const offline = isCapabilitySearchOffline(input.env)
 	const query = input.query.trim()
@@ -288,7 +290,9 @@ export async function searchUnified(input: {
 	const queryEmbedding = deterministicEmbedding(intent.normalizedQuery)
 	const sharedQueryVector = offline
 		? queryEmbedding
-		: await embedTextForVectorize(input.env, intent.normalizedQuery)
+		: await (
+				input.embedText ?? ((text) => embedTextForVectorize(input.env, text))
+			)(intent.normalizedQuery)
 	const queryEmbeddingMs = elapsedMs(queryEmbeddingStart)
 
 	const candidateResults = await Promise.all(

--- a/packages/worker/src/mcp/tools/search-domain-overview.node.test.ts
+++ b/packages/worker/src/mcp/tools/search-domain-overview.node.test.ts
@@ -3,6 +3,7 @@ import { buildCapabilityRegistry } from '#mcp/capabilities/build-capability-regi
 import {
 	buildDomainIndexMatches,
 	buildDomainOverviewMatches,
+	searchQueryUsesRankingEmbedding,
 } from './search-domain-overview.ts'
 import { understandSearchQuery } from './understand-search-query.ts'
 
@@ -113,4 +114,20 @@ test('domain overviews cover named, plural, exploratory, and non-collapse cases'
 			capabilitySpecs: registry.capabilitySpecs,
 		}),
 	).toBeNull()
+})
+
+test('searchQueryUsesRankingEmbedding skips overviews and empty index queries', () => {
+	expect(searchQueryUsesRankingEmbedding({ query: '' })).toBe(false)
+	expect(searchQueryUsesRankingEmbedding({ query: '   ' })).toBe(false)
+	expect(searchQueryUsesRankingEmbedding({ query: 'what can kody do' })).toBe(
+		false,
+	)
+	expect(searchQueryUsesRankingEmbedding({ query: 'skills' })).toBe(true)
+	expect(
+		searchQueryUsesRankingEmbedding({
+			query: 'what can kody do',
+			domain: 'email',
+		}),
+	).toBe(true)
+	expect(searchQueryUsesRankingEmbedding({ query: 'the the the' })).toBe(true)
 })

--- a/packages/worker/src/mcp/tools/search-domain-overview.ts
+++ b/packages/worker/src/mcp/tools/search-domain-overview.ts
@@ -8,6 +8,7 @@ import { buildDomainIndexMatches } from './search-domain-index.ts'
 import {
 	type SearchIntent,
 	extractSearchTokens,
+	understandSearchQuery,
 } from './understand-search-query.ts'
 
 /**
@@ -82,6 +83,20 @@ function singularizeToken(token: string): string {
 		return token.slice(0, -1)
 	}
 	return token
+}
+
+export function searchQueryUsesRankingEmbedding(input: {
+	query: string
+	domain?: string
+}): boolean {
+	const query = input.query.trim()
+	if (!query) return false
+	if (input.domain?.trim()) return true
+	const intent = understandSearchQuery({ query, entities: [] })
+	if (intent.meaningfulTokens.length === 0) return true
+	return intent.meaningfulTokens.some(
+		(token) => !explorationQueryTokens.has(token),
+	)
 }
 
 /**

--- a/packages/worker/src/mcp/tools/search-execution.node.test.ts
+++ b/packages/worker/src/mcp/tools/search-execution.node.test.ts
@@ -3,6 +3,10 @@ import {
 	createExecuteExecutor,
 	runWithDynamicWorkerEvaluationBudget,
 } from '#mcp/executor.ts'
+import {
+	CAPABILITY_EMBEDDING_DIMENSIONS,
+	deterministicEmbedding,
+} from '#worker/vectorize/embedding.ts'
 
 const mockModule = vi.hoisted(() => {
 	function createEmptySearchUnifiedResult() {
@@ -213,4 +217,138 @@ test('executeSearchList shares one dynamic-worker budget across memory and searc
 	expect(state.maxActive).toBe(4)
 	expect(mockModule.loadRelevantMemoriesForTool).toHaveBeenCalledTimes(1)
 	expect(mockModule.runPackageRetrievers).toHaveBeenCalledTimes(1)
+})
+
+test('executeSearchList embeds each distinct text once and starts the query embedding before rows resolve', async () => {
+	const embedTexts: Array<string> = []
+	let releaseRows: () => void = () => {}
+	const rowsGate = new Promise<void>((resolve) => {
+		releaseRows = resolve
+	})
+	mockModule.loadSearchRowsAndRegistry.mockImplementation(async () => {
+		await rowsGate
+		return {
+			packageRows: [],
+			userSecretRows: [],
+			userValueRows: [],
+			userIntegrationRows: [],
+			warnings: [],
+			registry: { capabilitySpecs: {} },
+		}
+	})
+	mockModule.loadRelevantMemoriesForTool.mockImplementation(
+		async (input: { embedText?: (text: string) => Promise<Array<number>> }) => {
+			await input.embedText?.('skills')
+			return {
+				memories: [],
+				retrieverResults: [],
+				retrieverWarnings: [],
+				suppressedCount: 0,
+				retrievalQuery: 'skills',
+			}
+		},
+	)
+	mockModule.searchUnified.mockImplementation(
+		async (input: { embedText?: (text: string) => Promise<Array<number>> }) => {
+			await input.embedText?.('skills')
+			return mockModule.createEmptySearchUnifiedResult()
+		},
+	)
+	mockModule.runPackageRetrievers.mockResolvedValue({
+		results: [],
+		warnings: [],
+	})
+
+	const env = {
+		SENTRY_ENVIRONMENT: 'production',
+		AI: {
+			async run(...args: Array<unknown>) {
+				const input = args[1] as { text?: unknown }
+				const batch = Array.isArray(input.text)
+					? input.text.map(String)
+					: [String(input.text ?? '')]
+				embedTexts.push(...batch)
+				return {
+					data: batch.map((text) => deterministicEmbedding(text)),
+					shape: [batch.length, CAPABILITY_EMBEDDING_DIMENSIONS],
+				}
+			},
+		},
+		CAPABILITY_VECTOR_INDEX: {
+			async query() {
+				return { matches: [] }
+			},
+		},
+		APP_DB: {},
+	} as unknown as Env
+
+	const searchPromise = executeSearchList({
+		env,
+		callerContext: {
+			baseUrl: 'https://example.com',
+			user: {
+				userId: 'user-1',
+				email: 'user@example.com',
+				displayName: 'User',
+				username: 'user',
+			},
+		} as never,
+		conversationId: 'conv-embed-once',
+		query: 'skills',
+		memoryQuery: 'skills',
+		limit: 15,
+		userId: 'user-1',
+		includeHiddenPackages: false,
+	})
+
+	await expect.poll(() => embedTexts).toEqual(['skills'])
+	releaseRows()
+	await searchPromise
+	expect(embedTexts).toEqual(['skills'])
+
+	embedTexts.length = 0
+	mockModule.loadSearchRowsAndRegistry.mockImplementation(async () => ({
+		packageRows: [],
+		userSecretRows: [],
+		userValueRows: [],
+		userIntegrationRows: [],
+		warnings: [],
+		registry: { capabilitySpecs: {} },
+	}))
+	mockModule.loadRelevantMemoriesForTool.mockImplementation(
+		async (input: {
+			embedText?: (text: string) => Promise<Array<number>>
+			memoryContext?: { query?: string }
+		}) => {
+			await input.embedText?.(input.memoryContext?.query ?? 'draft an email')
+			return {
+				memories: [],
+				retrieverResults: [],
+				retrieverWarnings: [],
+				suppressedCount: 0,
+				retrievalQuery: 'draft an email',
+			}
+		},
+	)
+
+	await executeSearchList({
+		env,
+		callerContext: {
+			baseUrl: 'https://example.com',
+			user: {
+				userId: 'user-1',
+				email: 'user@example.com',
+				displayName: 'User',
+				username: 'user',
+			},
+		} as never,
+		conversationId: 'conv-embed-distinct',
+		query: 'skills',
+		memoryContext: { query: 'draft an email' },
+		limit: 15,
+		userId: 'user-1',
+		includeHiddenPackages: false,
+	})
+
+	expect([...embedTexts].sort()).toEqual(['draft an email', 'skills'])
 })

--- a/packages/worker/src/mcp/tools/search-execution.node.test.ts
+++ b/packages/worker/src/mcp/tools/search-execution.node.test.ts
@@ -352,3 +352,165 @@ test('executeSearchList embeds each distinct text once and starts the query embe
 
 	expect([...embedTexts].sort()).toEqual(['draft an email', 'skills'])
 })
+
+function emptySearchRows() {
+	return {
+		packageRows: [],
+		userSecretRows: [],
+		userValueRows: [],
+		userIntegrationRows: [],
+		warnings: [],
+		registry: { capabilitySpecs: {} },
+	}
+}
+
+function signedInSearchCaller() {
+	return {
+		baseUrl: 'https://example.com',
+		user: {
+			userId: 'user-1',
+			email: 'user@example.com',
+			displayName: 'User',
+			username: 'user',
+		},
+	} as never
+}
+
+test('executeSearchList does not leak an unhandled rejection when the ranking embedding fails during row load', async () => {
+	const unhandled: Array<unknown> = []
+	const onUnhandled = (reason: unknown) => {
+		unhandled.push(reason)
+	}
+	process.on('unhandledRejection', onUnhandled)
+	try {
+		let releaseRows = () => {}
+		const rowsGate = new Promise<void>((resolve) => {
+			releaseRows = resolve
+		})
+		let resolveEmbedStarted = () => {}
+		const embedStarted = new Promise<void>((resolve) => {
+			resolveEmbedStarted = resolve
+		})
+		const embeddingError = new Error('Workers AI unavailable')
+		mockModule.loadSearchRowsAndRegistry.mockImplementation(async () => {
+			await rowsGate
+			return emptySearchRows()
+		})
+		mockModule.loadRelevantMemoriesForTool.mockResolvedValue({
+			memories: [],
+			retrieverResults: [],
+			retrieverWarnings: [],
+			suppressedCount: 0,
+			retrievalQuery: 'skills',
+		})
+		mockModule.searchUnified.mockImplementation(
+			async (input: {
+				embedText?: (text: string) => Promise<Array<number>>
+				query: string
+			}) => {
+				await input.embedText?.(input.query)
+				return mockModule.createEmptySearchUnifiedResult()
+			},
+		)
+		mockModule.runPackageRetrievers.mockResolvedValue({
+			results: [],
+			warnings: [],
+		})
+
+		const env = {
+			SENTRY_ENVIRONMENT: 'production',
+			AI: {
+				async run() {
+					resolveEmbedStarted()
+					throw embeddingError
+				},
+			},
+			CAPABILITY_VECTOR_INDEX: {
+				async query() {
+					return { matches: [] }
+				},
+			},
+			APP_DB: {},
+		} as unknown as Env
+
+		const searchPromise = executeSearchList({
+			env,
+			callerContext: signedInSearchCaller(),
+			conversationId: 'conv-embed-reject',
+			query: 'skills',
+			memoryQuery: 'skills',
+			limit: 15,
+			userId: 'user-1',
+			includeHiddenPackages: false,
+		})
+
+		await embedStarted
+		await Promise.resolve()
+		await Promise.resolve()
+		expect(unhandled).toEqual([])
+		releaseRows()
+		await expect(searchPromise).rejects.toThrow('Workers AI unavailable')
+		await Promise.resolve()
+		await Promise.resolve()
+		expect(unhandled).toEqual([])
+	} finally {
+		process.off('unhandledRejection', onUnhandled)
+	}
+})
+
+test('executeSearchList does not prefetch an embedding for domain-overview or index queries', async () => {
+	let aiRunCount = 0
+	mockModule.loadSearchRowsAndRegistry.mockResolvedValue(emptySearchRows())
+	mockModule.loadRelevantMemoriesForTool.mockResolvedValue({
+		memories: [],
+		retrieverResults: [],
+		retrieverWarnings: [],
+		suppressedCount: 0,
+		retrievalQuery: 'what can kody do',
+	})
+	mockModule.searchUnified.mockImplementation(async () =>
+		mockModule.createEmptySearchUnifiedResult(),
+	)
+	mockModule.runPackageRetrievers.mockResolvedValue({
+		results: [],
+		warnings: [],
+	})
+
+	const env = {
+		SENTRY_ENVIRONMENT: 'production',
+		AI: {
+			async run() {
+				aiRunCount += 1
+				throw new Error('Workers AI should not run for overview search')
+			},
+		},
+		CAPABILITY_VECTOR_INDEX: {
+			async query() {
+				return { matches: [] }
+			},
+		},
+		APP_DB: {},
+	} as unknown as Env
+
+	await executeSearchList({
+		env,
+		callerContext: signedInSearchCaller(),
+		conversationId: 'conv-embed-overview',
+		query: 'what can kody do',
+		limit: 15,
+		userId: 'user-1',
+		includeHiddenPackages: false,
+	})
+	expect(aiRunCount).toBe(0)
+
+	await executeSearchList({
+		env,
+		callerContext: signedInSearchCaller(),
+		conversationId: 'conv-embed-index',
+		query: '',
+		limit: 15,
+		userId: 'user-1',
+		includeHiddenPackages: false,
+	})
+	expect(aiRunCount).toBe(0)
+})

--- a/packages/worker/src/mcp/tools/search-execution.ts
+++ b/packages/worker/src/mcp/tools/search-execution.ts
@@ -4,6 +4,10 @@ import { buildMemoryRetrievalQuery } from '#mcp/tools/memory-tool-context.ts'
 import { getPackageAppBaseUrl } from '#worker/app-base-url.ts'
 import { resolvePublicUsername } from '#worker/identity/user-lookup.ts'
 import { runPackageRetrievers } from '#worker/package-retrievers/service.ts'
+import {
+	createTextEmbeddingCache,
+	isCapabilitySearchOffline,
+} from '#worker/vectorize/embedding.ts'
 
 import { resolvePackageIdentitySearch } from './package-search-identity.ts'
 import { buildExactPackageSearchResult, searchUnified } from './search-core.ts'
@@ -21,6 +25,7 @@ import {
 } from './search-types.ts'
 import { type SearchToolArgs } from './search-tool-definition.ts'
 import { queryMatchesSynthesizedProvider } from './search-provider-overview.ts'
+import { normalizeSearchText } from './understand-search-query.ts'
 
 export type SearchListExecutionResult = {
 	result: SearchUnifiedResult
@@ -108,6 +113,18 @@ async function executeSearchListWithinBudget(
 	const shouldEnrichMemory =
 		(Boolean(input.query) || Boolean(memoryContextRetrievalQuery)) &&
 		(!identityResolution.recognized || identityMatchesProvider)
+	const willRankSearch = !(
+		identityResolution.recognized && !identityMatchesProvider
+	)
+	const embeddingCache = createTextEmbeddingCache(input.env)
+	const normalizedQuery = normalizeSearchText(input.query).trim()
+	if (
+		willRankSearch &&
+		normalizedQuery &&
+		!isCapabilitySearchOffline(input.env)
+	) {
+		void embeddingCache.embedText(normalizedQuery)
+	}
 	const memoryLaunch = shouldEnrichMemory
 		? launchSearchMemoryEnrichment({
 				env: input.env,
@@ -115,6 +132,7 @@ async function executeSearchListWithinBudget(
 				conversationId: input.conversationId,
 				query: input.memoryQuery,
 				memoryContext: input.memoryContext,
+				embedText: embeddingCache.embedText,
 			})
 		: null
 	const memoryEnrichmentPromise = memoryLaunch?.promise ?? Promise.resolve(null)
@@ -193,6 +211,7 @@ async function executeSearchListWithinBudget(
 		registry: searchRows.registry,
 		optionalRows: searchRows,
 		retrieverResults: retrieverRun.results,
+		embedText: embeddingCache.embedText,
 		...(domainFilter ? { domain: domainFilter } : {}),
 	})
 	capabilityGuidance = result.guidance

--- a/packages/worker/src/mcp/tools/search-execution.ts
+++ b/packages/worker/src/mcp/tools/search-execution.ts
@@ -11,6 +11,7 @@ import {
 
 import { resolvePackageIdentitySearch } from './package-search-identity.ts'
 import { buildExactPackageSearchResult, searchUnified } from './search-core.ts'
+import { searchQueryUsesRankingEmbedding } from './search-domain-overview.ts'
 import { loadSearchRowsAndRegistry } from './search-loaders.ts'
 import {
 	launchSearchMemoryEnrichment,
@@ -120,10 +121,14 @@ async function executeSearchListWithinBudget(
 	const normalizedQuery = normalizeSearchText(input.query).trim()
 	if (
 		willRankSearch &&
+		searchQueryUsesRankingEmbedding({
+			query: input.query,
+			domain: domainFilter,
+		}) &&
 		normalizedQuery &&
 		!isCapabilitySearchOffline(input.env)
 	) {
-		void embeddingCache.embedText(normalizedQuery)
+		void embeddingCache.embedText(normalizedQuery).catch(() => {})
 	}
 	const memoryLaunch = shouldEnrichMemory
 		? launchSearchMemoryEnrichment({

--- a/packages/worker/src/mcp/tools/search-memory.ts
+++ b/packages/worker/src/mcp/tools/search-memory.ts
@@ -5,6 +5,7 @@ import {
 	loadRelevantMemoriesForTool,
 	type MemoryToolSummary,
 } from '#mcp/tools/memory-tool-context.ts'
+import { type EmbedTextFn } from '#worker/vectorize/embedding.ts'
 
 import {
 	SEARCH_MEMORY_ENRICHMENT_BUDGET_MS,
@@ -32,6 +33,7 @@ export function launchSearchMemoryEnrichment(input: {
 	conversationId: string
 	query?: string
 	memoryContext?: z.infer<typeof memoryContextInputField>
+	embedText?: EmbedTextFn
 }): {
 	promise: Promise<MemoryToolSummary | null>
 	launchedAtMs: number
@@ -49,6 +51,7 @@ export function launchSearchMemoryEnrichment(input: {
 		conversationId: input.conversationId,
 		memoryContext,
 		acknowledgeSurfaced: false,
+		...(input.embedText ? { embedText: input.embedText } : {}),
 	})
 	void promise.catch(() => {})
 	return { promise, launchedAtMs }

--- a/packages/worker/src/mcp/tools/search.node.test.ts
+++ b/packages/worker/src/mcp/tools/search.node.test.ts
@@ -4,6 +4,7 @@ import { McpCallerError } from '#mcp/caller-error.ts'
 import { buildCapabilityRegistry } from '#mcp/capabilities/build-capability-registry.ts'
 import {
 	CAPABILITY_EMBEDDING_DIMENSIONS,
+	createTextEmbeddingCache,
 	deterministicEmbedding,
 } from '#worker/vectorize/embedding.ts'
 import { filterCapabilityRegistryForCaller } from '#mcp/capabilities/access-control.ts'
@@ -1834,4 +1835,91 @@ test('searchUnified ranks platform (built-in) package rows and drops unmarked fo
 	expect(consoleWarn).toHaveBeenCalledWith(
 		expect.stringContaining('row userId mismatch'),
 	)
+})
+
+test('searchUnified embeds each distinct query text once online and never calls Workers AI offline', async () => {
+	const embedTexts: Array<string> = []
+	const offline = await searchUnified({
+		env: {} as Env,
+		query: 'summarize inbox threads',
+		limit: 5,
+		userId: 'user-1',
+		registry: buildCapabilityRegistry([]),
+		optionalRows: emptyOptionalSearchRows,
+	})
+	expect(offline.offline).toBe(true)
+	expect(embedTexts).toEqual([])
+
+	const onlineEnv = {
+		SENTRY_ENVIRONMENT: 'production',
+		AI: {
+			async run(...args: Array<unknown>) {
+				const input = args[1] as { text?: unknown }
+				const batch = Array.isArray(input.text)
+					? input.text.map(String)
+					: [String(input.text ?? '')]
+				embedTexts.push(...batch)
+				return {
+					data: batch.map((text) => deterministicEmbedding(text)),
+					shape: [batch.length, CAPABILITY_EMBEDDING_DIMENSIONS],
+				}
+			},
+		},
+		CAPABILITY_VECTOR_INDEX: {
+			async query() {
+				return { matches: [] }
+			},
+		},
+	} as unknown as Env
+	const cache = createTextEmbeddingCache(onlineEnv)
+	const first = await searchUnified({
+		env: onlineEnv,
+		query: 'summarize inbox threads',
+		limit: 5,
+		userId: 'user-1',
+		registry: buildCapabilityRegistry([]),
+		optionalRows: {
+			...emptyOptionalSearchRows,
+			packageRows: [
+				leanPackage(
+					'pkg-inbox',
+					'user-1',
+					'inbox-summarizer',
+					'summarize inbox threads',
+				),
+			],
+		},
+		embedText: cache.embedText,
+	})
+	const second = await searchUnified({
+		env: onlineEnv,
+		query: 'summarize inbox threads',
+		limit: 5,
+		userId: 'user-1',
+		registry: buildCapabilityRegistry([]),
+		optionalRows: {
+			...emptyOptionalSearchRows,
+			packageRows: [
+				leanPackage(
+					'pkg-inbox',
+					'user-1',
+					'inbox-summarizer',
+					'summarize inbox threads',
+				),
+			],
+		},
+		embedText: cache.embedText,
+	})
+
+	expect(first.offline).toBe(false)
+	expect(second.offline).toBe(false)
+	expect(embedTexts).toEqual(['summarize inbox threads'])
+	expect(first.matches.map((match) => match.type)).toEqual(
+		second.matches.map((match) => match.type),
+	)
+	expect(
+		first.matches.some(
+			(match) => match.type === 'package' && match.packageId === 'pkg-inbox',
+		),
+	).toBe(true)
 })

--- a/packages/worker/src/vectorize/embedding.node.test.ts
+++ b/packages/worker/src/vectorize/embedding.node.test.ts
@@ -4,6 +4,7 @@ import {
 	CAPABILITY_EMBEDDING_DIMENSIONS,
 	CAPABILITY_EMBEDDING_MAX_INPUT_CHARS,
 	CAPABILITY_EMBEDDING_MODEL,
+	createTextEmbeddingCache,
 	deterministicEmbedding,
 	embedTextsForVectorize,
 } from './embedding.ts'
@@ -169,4 +170,27 @@ test('embedding wrapper rejects mismatched Workers AI dimensions', async () => {
 	await expect(embedTextsForVectorize(env, ['alpha'])).rejects.toThrow(
 		/shape mismatch/,
 	)
+})
+
+test('createTextEmbeddingCache embeds each distinct text once and shares the pending promise', async () => {
+	const texts: Array<Array<string>> = []
+	const env = aiEnv(async (...args) => {
+		const input = args[1] as { text?: Array<string> }
+		texts.push([...(input.text ?? [])])
+		return {
+			data: (input.text ?? []).map((text) => deterministicEmbedding(text)),
+			shape: [input.text?.length ?? 0, CAPABILITY_EMBEDDING_DIMENSIONS],
+		}
+	})
+	const cache = createTextEmbeddingCache(env)
+
+	const [first, again, other] = await Promise.all([
+		cache.embedText('summarize inbox threads'),
+		cache.embedText('summarize inbox threads'),
+		cache.embedText('draft an email'),
+	])
+
+	expect(texts).toEqual([['summarize inbox threads'], ['draft an email']])
+	expect(first).toEqual(again)
+	expect(first).not.toEqual(other)
 })

--- a/packages/worker/src/vectorize/embedding.ts
+++ b/packages/worker/src/vectorize/embedding.ts
@@ -81,6 +81,23 @@ export async function embedTextForVectorize(
 	return rows[0]!
 }
 
+export type EmbedTextFn = (text: string) => Promise<Array<number>>
+
+export function createTextEmbeddingCache(env: Env): {
+	embedText: EmbedTextFn
+} {
+	const pending = new Map<string, Promise<Array<number>>>()
+	return {
+		embedText(text) {
+			const cached = pending.get(text)
+			if (cached) return cached
+			const promise = embedTextForVectorize(env, text)
+			pending.set(text, promise)
+			return promise
+		},
+	}
+}
+
 export async function embedTextsForVectorize(
 	env: Env,
 	texts: ReadonlyArray<string>,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Remove two pieces of pure waste on hot paths.

## Why

From the 2026-09-01 performance audit: the client re-fetched `/session` immediately after every hydration even though the SSR document embedded the session (a repeat of the auth D1 reads for signed-in users; an extra Worker invocation per page view for anonymous ones), and one `search` call paid two sequential Workers AI embedding calls (memory retrieval embedded the same normalized query that ranking embedded again afterwards, and ranking waited for row loading before starting its embedding).

## Summary

- `client/app.tsx`: when the document carries an embedded session (a value or explicit `null`), the immediate `/session` fetch is skipped and the 30 s throttle clock starts; a missing embedded session keeps the old behavior. Client navigations still refresh after the throttle; `queueSessionRefresh()` (login/logout/profile) still bypasses it.
- Search: `executeSearchList` starts `embedText(normalizedQuery)` as soon as it knows it will rank, in parallel with `loadSearchRowsAndRegistry`; a per-call embedding cache keyed by text is shared with memory retrieval. Same text → one Workers AI call; distinct texts → one each. Offline/`WRANGLER_IS_LOCAL_DEV` still uses the deterministic embedding and never calls Workers AI; ranking output is unchanged on the existing fixtures.

Measured on the online fixture: same-text search 2 sequential embedding calls → 1, started before row loading resolves.

## Testing

`npm run typecheck`, `lint`, `format:check`; node: search/memory/embedding suites (75 tests) and the client suites (145 tests) all pass; `CI=1 npm run test:mcp` (real wrangler, OAuth, search, execute) 5/5.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `3c63022a` · **Head:** `HEAD`

**Classification:** composes — ordering and caching changes inside `search` and the client session bootstrap; no contract changes.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `mcp-search` | surfaces | composes — one embedding per distinct text, started early |
| `app-ui` | surfaces | composes — no redundant `/session` after hydration |

### Change flow

```mermaid
sequenceDiagram
	participant host as MCP host
	participant search as search tool
	participant ai as Workers AI embed
	participant rows as rows + registry
	participant vec as Vectorize
	host->>search: search({ query })
	par
		search->>ai: embed(normalizedQuery) (once, cached per call)
	and
		search->>rows: loadSearchRowsAndRegistry
	end
	search->>vec: query with the shared vector (ranking + memory retrieval)
	search-->>host: ranked results
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b0f6a92a-81cd-4157-8b60-188c83ca84c0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b0f6a92a-81cd-4157-8b60-188c83ca84c0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

