### PR TITLE
Add opt-in timestamp and delivery-id replay protection for package webhooks

### DIFF
--- a/docs/contributing/architecture/run-records.md
+++ b/docs/contributing/architecture/run-records.md
@@ -249,7 +249,9 @@ instead of replaying.
   writes; the current schema in
   `packages/worker/migrations/0001-squashed-init.sql` has no D1
   `package_invocations` table. Only keys claimed in this DO ledger can replay; a
-  redelivery for an unknown key executes fresh.
+  redelivery for an unknown key executes fresh. Delivery-id webhook replays pass
+  `idempotencyParamsHash: 'ignore'` so the ledger returns the retained response
+  by key even when `receivedAt` (and the rest of the hashed params) differ.
 - Account export pages ledger rows through the same `run_records` section cursor
   (runs first, then ledger rows, then dedicated unpruned state); account
   deletion purges them with `clearAll` (every DO table, then schema

--- a/docs/contributing/architecture/webhooks.md
+++ b/docs/contributing/architecture/webhooks.md
@@ -39,8 +39,11 @@ is rotated.
 - `toleranceSeconds` — optional; defaults to 300 when `timestampHeader` is set
 - `deliveryIdHeader` — unique delivery id; dispatches use
   `sha256(userId + packageId + webhookName + deliveryId)` as the
-  package-invocation idempotency key so the RunLog keyed ledger dedupes replays
-  without re-running the export
+  package-invocation idempotency key. The keyed ledger matches that key alone
+  (`idempotencyParamsHash: 'ignore'`): retries change `receivedAt` (and often
+  headers), and a later body for the same id is still that delivery. A different
+  delivery id hashes to a different key, so it cannot reuse another event's
+  acknowledgement.
 
 Declaring a webhook does **not** open ingress. A minted URL secret in D1 does.
 

--- a/docs/contributing/architecture/webhooks.md
+++ b/docs/contributing/architecture/webhooks.md
@@ -16,10 +16,31 @@ inboxes, declared alongside other package surfaces in
 
 Packages declare webhooks as an array under `kody.webhooks`. Each entry has a
 slug `name`, an `export` that must exist in `package.json#exports`, optional
-`responseMode` (`ack` default / `sync`), and optional HMAC `verification` that
-references a secret-store name (`secretName`) — never an inline secret. Parsing
-and export existence checks live in `parseAuthoredPackageJson` /
+`responseMode` (`ack` default / `sync`), optional HMAC `verification` that
+references a secret-store name (`secretName`) — never an inline secret — and
+optional `replay` for timestamp windows and delivery-id dedupe. Parsing and
+export existence checks live in `parseAuthoredPackageJson` /
 `listPackageWebhooks` (`packages/worker/src/package-registry/`).
+
+HMAC `verification` signs the raw body by default (`signedPayload` omitted or
+`'body'`). Set `signedPayload` to `'timestamp.body'` when the provider HMAC
+covers `` `${timestamp}.${rawBody}` `` (Stripe). Replay protection is
+**opt-in**: body-only HMAC without `replay` does not bind a timestamp or
+delivery id, so a captured signed payload can be replayed until the URL secret
+is rotated.
+
+`replay` fields:
+
+- `timestampHeader` — header that carries the timestamp (required with
+  `timestampFormat`)
+- `timestampFormat` — `unix-seconds` | `unix-millis` | `iso-8601` |
+  `stripe-signature` (`stripe-signature` reads `t=<unix>` from a Stripe-style
+  header). Unknown formats fail publish-time validation.
+- `toleranceSeconds` — optional; defaults to 300 when `timestampHeader` is set
+- `deliveryIdHeader` — unique delivery id; dispatches use
+  `sha256(userId + packageId + webhookName + deliveryId)` as the
+  package-invocation idempotency key so the RunLog keyed ledger dedupes replays
+  without re-running the export
 
 Declaring a webhook does **not** open ingress. A minted URL secret in D1 does.
 
@@ -43,6 +64,11 @@ Route: `POST /@:username/webhooks/:packageKodyId/:webhookName/:urlSecret`
 6. When verification is declared, resolve `secretName` from the owner's secret
    store (user/package scope via package storage context). Missing secret or
    HMAC mismatch → **401**, with a clear delivery-log error for missing secrets.
+   When `replay.timestampHeader` is declared, a missing, unparseable, or stale
+   timestamp is rejected with the same generic **401** before dispatch (and
+   before any run record that implies acceptance). When
+   `replay.deliveryIdHeader` is declared, a missing id is rejected the same way;
+   present ids become the invocation idempotency key.
 7. Dispatch via `invokePackageExport` with a synthetic internal token scoped to
    the owning user / package / export, `source: 'webhook'`.
 8. `ack`: await enqueue to `kody-webhook-dispatch`, then return **202**. The

--- a/docs/contributing/security.md
+++ b/docs/contributing/security.md
@@ -553,3 +553,8 @@ change to these decisions here so future agents do not relitigate them.
   decision, restated as invariant 10 above: it holds only while both halves
   hold, so revisit if any mutating endpoint starts accepting cross-site form
   posts or `SameSite=None`.
+- **Package inbound webhook replay protection is opt-in.** HMAC over the raw
+  body without a `replay` declaration does not bind a timestamp or delivery id,
+  so a captured signed payload can be replayed until the URL secret is rotated.
+  Authors opt in per webhook with `replay.timestampHeader` and/or
+  `replay.deliveryIdHeader`.

--- a/docs/use/webhooks.md
+++ b/docs/use/webhooks.md
@@ -49,6 +49,12 @@ Rules:
 - `verification.secretName` references a **named secret in your secret store** —
   never an inline secret value. The platform resolves it at delivery time; if
   the secret is missing, the delivery is rejected and logged.
+- `verification.signedPayload` is `'body'` (default) or `'timestamp.body'`. Use
+  `'timestamp.body'` when the provider HMAC covers
+  `` `${timestamp}.${rawBody}` ``.
+- `replay` is optional. Without it, body-only HMAC is **replayable**: anyone who
+  observes one legitimate signed delivery can POST it again. Opt in per webhook
+  with a timestamp window and/or a unique delivery id.
 
 Declaring a webhook does **not** open ingress by itself.
 
@@ -142,6 +148,55 @@ export async function handleSentryWebhook(input) {
 	"prefix": "sha256="
 }
 ```
+
+GitHub HMAC covers the raw body only. Add `replay.deliveryIdHeader` so a
+replayed `X-GitHub-Delivery` is acknowledged without running the export again:
+
+```json
+{
+	"name": "github",
+	"export": "./handle-github-webhook",
+	"verification": {
+		"type": "hmac-sha256",
+		"header": "x-hub-signature-256",
+		"secretName": "githubWebhookSecret",
+		"encoding": "hex",
+		"prefix": "sha256="
+	},
+	"replay": {
+		"deliveryIdHeader": "X-GitHub-Delivery"
+	}
+}
+```
+
+### Stripe
+
+Stripe signs `` `${t}.${rawBody}` `` and sends both the unix timestamp and HMAC
+in `Stripe-Signature`. Declare `signedPayload: "timestamp.body"` and a timestamp
+window:
+
+```json
+{
+	"name": "stripe",
+	"export": "./handle-stripe-webhook",
+	"verification": {
+		"type": "hmac-sha256",
+		"header": "Stripe-Signature",
+		"secretName": "stripeWebhookSecret",
+		"encoding": "hex",
+		"signedPayload": "timestamp.body"
+	},
+	"replay": {
+		"timestampHeader": "Stripe-Signature",
+		"timestampFormat": "stripe-signature",
+		"toleranceSeconds": 300
+	}
+}
+```
+
+`stripe-signature` reads `t=<unix>` from the header. Deliveries whose timestamp
+is missing, unparseable, or older than `toleranceSeconds` (default 300) are
+rejected with the same generic 401 as a bad HMAC.
 
 ## Lifecycle
 

--- a/packages/worker/src/mcp/capabilities/webhooks/shared.ts
+++ b/packages/worker/src/mcp/capabilities/webhooks/shared.ts
@@ -20,6 +20,18 @@ export const webhookVerificationPublicSchema = z
 		secretName: z.string(),
 		encoding: z.enum(['hex', 'base64']),
 		prefix: z.string().optional(),
+		signedPayload: z.enum(['body', 'timestamp.body']).optional(),
+	})
+	.nullable()
+
+export const webhookReplayPublicSchema = z
+	.object({
+		timestampHeader: z.string().optional(),
+		timestampFormat: z
+			.enum(['unix-seconds', 'unix-millis', 'iso-8601', 'stripe-signature'])
+			.optional(),
+		toleranceSeconds: z.number().int().optional(),
+		deliveryIdHeader: z.string().optional(),
 	})
 	.nullable()
 
@@ -32,6 +44,7 @@ export const listedWebhookSchema = z.object({
 	description: z.string().nullable(),
 	response_mode: z.enum(['ack', 'sync']),
 	verification: webhookVerificationPublicSchema,
+	replay: webhookReplayPublicSchema,
 	minted: z
 		.boolean()
 		.describe('True when a URL secret has been minted for this webhook.'),
@@ -91,6 +104,7 @@ export function toListedWebhookCapability(webhook: {
 	description: string | null
 	responseMode: 'ack' | 'sync'
 	verification: z.infer<typeof webhookVerificationPublicSchema>
+	replay?: z.infer<typeof webhookReplayPublicSchema>
 	minted: boolean
 	enabled: boolean | null
 	createdAt: string | null
@@ -105,6 +119,7 @@ export function toListedWebhookCapability(webhook: {
 		description: webhook.description,
 		response_mode: webhook.responseMode,
 		verification: webhook.verification,
+		replay: webhook.replay ?? null,
 		minted: webhook.minted,
 		enabled: webhook.enabled,
 		created_at: webhook.createdAt,

--- a/packages/worker/src/mcp/tools/search-entity-plugins/package.ts
+++ b/packages/worker/src/mcp/tools/search-entity-plugins/package.ts
@@ -507,6 +507,13 @@ export const packageSearchEntityPlugin = {
 			key,
 			name: retriever.name,
 		}))
+		const webhooks = (detail.manifest.kody.webhooks ?? []).map((webhook) => ({
+			name: webhook.name,
+			exportName: webhook.export,
+			responseMode: webhook.responseMode ?? 'ack',
+			replay: webhook.replay ?? null,
+			signedPayload: webhook.verification?.signedPayload ?? null,
+		}))
 		const appEntry = detail.manifest.kody.app?.entry ?? null
 		const readmeIntent = buildPackageReadmeIntent({
 			files: detail.files,
@@ -561,6 +568,27 @@ export const packageSearchEntityPlugin = {
 				),
 			)
 		}
+		if (webhooks.length > 0) {
+			lines.push(
+				'',
+				'## Webhooks',
+				'',
+				...webhooks.map((webhook) => {
+					const replayParts = [
+						webhook.signedPayload ? `signed ${webhook.signedPayload}` : null,
+						webhook.replay?.timestampHeader
+							? `timestamp ${webhook.replay.timestampHeader}${webhook.replay.timestampFormat ? ` ${webhook.replay.timestampFormat}` : ''}`
+							: null,
+						webhook.replay?.deliveryIdHeader
+							? `delivery ${webhook.replay.deliveryIdHeader}`
+							: null,
+					].filter((value): value is string => value != null)
+					const replaySuffix =
+						replayParts.length > 0 ? ` (${replayParts.join(', ')})` : ''
+					return `- ${formatMarkdownInlineCode(webhook.name)} → ${formatMarkdownInlineCode(webhook.exportName)} (${webhook.responseMode}${replaySuffix})`
+				}),
+			)
+		}
 		if (readmeIntent) {
 			lines.push(
 				'',
@@ -598,6 +626,7 @@ export const packageSearchEntityPlugin = {
 				exports: exportDetails,
 				jobs,
 				retrievers,
+				webhooks,
 				readmeIntent,
 				followUp,
 				listingAhead: detail.listingAhead,

--- a/packages/worker/src/mcp/tools/search-format-types.ts
+++ b/packages/worker/src/mcp/tools/search-format-types.ts
@@ -328,6 +328,22 @@ export type SearchEntityDetailStructured =
 				key: string
 				name: string
 			}>
+			webhooks: Array<{
+				name: string
+				exportName: string
+				responseMode: 'ack' | 'sync'
+				replay: {
+					timestampHeader?: string
+					timestampFormat?:
+						| 'unix-seconds'
+						| 'unix-millis'
+						| 'iso-8601'
+						| 'stripe-signature'
+					toleranceSeconds?: number
+					deliveryIdHeader?: string
+				} | null
+				signedPayload: 'body' | 'timestamp.body' | null
+			}>
 			readmeIntent: {
 				path: string
 				content: string

--- a/packages/worker/src/package-invocations/common.ts
+++ b/packages/worker/src/package-invocations/common.ts
@@ -33,6 +33,16 @@ export type PackageInvocationRequest = {
 	 * failure only. External HTTP token invocations still require a key.
 	 */
 	idempotencyKey: string | null
+	/**
+	 * `'ignore'` matches the ledger by key alone and returns the retained
+	 * response as stored (no `idempotency.replayed` marker). Used only by
+	 * delivery-id webhook replays: retries change `receivedAt` (and often
+	 * headers), and the same delivery id is the same event even when the
+	 * body bytes differ. The key already binds
+	 * `userId + packageId + webhookName + deliveryId`, so a different
+	 * delivery cannot reuse another event's acknowledgement.
+	 */
+	idempotencyParamsHash?: 'ignore'
 	source?: string | null
 	topic?: string | null
 }

--- a/packages/worker/src/package-invocations/http-invoke.ts
+++ b/packages/worker/src/package-invocations/http-invoke.ts
@@ -292,5 +292,8 @@ export async function invokePackageExportWithToolFactories(input: {
 	return await invokeSavedPackageModule({
 		...shared,
 		idempotencyKey,
+		...(input.request.idempotencyParamsHash === 'ignore'
+			? { idempotencyParamsHash: 'ignore' as const }
+			: {}),
 	})
 }

--- a/packages/worker/src/package-invocations/idempotency.ts
+++ b/packages/worker/src/package-invocations/idempotency.ts
@@ -64,8 +64,12 @@ export function resolveExistingInvocation(input: {
 	record: ResolvableInvocationRecord
 	requestHash: string
 	idempotencyKey: string
+	paramsHash?: 'include' | 'ignore'
 }): PackageInvocationStoredResponse {
-	if (input.record.requestHash !== input.requestHash) {
+	if (
+		input.paramsHash !== 'ignore' &&
+		input.record.requestHash !== input.requestHash
+	) {
 		return buildJsonErrorResponse({
 			status: 409,
 			code: 'idempotency_mismatch',
@@ -84,6 +88,9 @@ export function resolveExistingInvocation(input: {
 		})
 	}
 	if (input.record.storedResponse) {
+		if (input.paramsHash === 'ignore') {
+			return input.record.storedResponse
+		}
 		return markStoredResponseAsReplayed(input.record.storedResponse)
 	}
 	return buildIdempotencyResponseUnavailable({

--- a/packages/worker/src/package-invocations/idempotent-module-invocation.ts
+++ b/packages/worker/src/package-invocations/idempotent-module-invocation.ts
@@ -83,6 +83,7 @@ export async function invokeSavedPackageModule(input: {
 	moduleSelector: PackageModuleSelector
 	params?: Record<string, unknown>
 	idempotencyKey: string
+	idempotencyParamsHash?: 'ignore'
 	source: string | null
 	topic: string | null
 	notFoundCode: 'export_not_found' | 'subscription_not_found'
@@ -103,7 +104,7 @@ export async function invokeSavedPackageModule(input: {
 	const requestHash = await createRequestHash({
 		packageId: input.savedPackage.id,
 		exportName: input.invocationName,
-		params: input.params,
+		params: input.idempotencyParamsHash === 'ignore' ? undefined : input.params,
 		source: input.source,
 		topic: input.topic,
 	})
@@ -119,6 +120,8 @@ export async function invokeSavedPackageModule(input: {
 			record: toResolvableLedgerRecord(record),
 			requestHash,
 			idempotencyKey: input.idempotencyKey,
+			paramsHash:
+				input.idempotencyParamsHash === 'ignore' ? 'ignore' : 'include',
 		})
 	const buildLookupFailedResponse = () =>
 		buildJsonErrorResponse({

--- a/packages/worker/src/package-invocations/service.node.test.ts
+++ b/packages/worker/src/package-invocations/service.node.test.ts
@@ -409,6 +409,49 @@ test('invokePackageExport enforces idempotency replay, mismatch, corruption, and
 		},
 	})
 
+	const ignoreCallsBefore =
+		repoMockModule.runBundledModuleWithRegistry.mock.calls.length
+	const ignoreFirst = await invokePackageExport({
+		env: createEnv(db),
+		baseUrl: 'https://kody.dev',
+		token: createToken(),
+		request: {
+			packageIdOrKodyId: 'discord-gateway',
+			exportName: 'dispatch-message-created',
+			params: { content: 'hi', receivedAt: '2026-01-01T00:00:00.000Z' },
+			idempotencyKey: 'evt-delivery-ignore',
+			idempotencyParamsHash: 'ignore',
+			source: 'discord-gateway',
+			topic: 'discord.message.created',
+		},
+	})
+	const ignoreReplay = await invokePackageExport({
+		env: createEnv(db),
+		baseUrl: 'https://kody.dev',
+		token: createToken(),
+		request: {
+			packageIdOrKodyId: 'discord-gateway',
+			exportName: 'dispatch-message-created',
+			params: {
+				content: 'different',
+				receivedAt: '2026-01-01T00:00:01.000Z',
+			},
+			idempotencyKey: 'evt-delivery-ignore',
+			idempotencyParamsHash: 'ignore',
+			source: 'discord-gateway',
+			topic: 'discord.message.created',
+		},
+	})
+	expect(ignoreFirst.status).toBe(200)
+	expect(ignoreReplay.status).toBe(200)
+	expect(ignoreReplay.body).toEqual(ignoreFirst.body)
+	expect(ignoreReplay.body).not.toMatchObject({
+		idempotency: { replayed: true },
+	})
+	expect(repoMockModule.runBundledModuleWithRegistry.mock.calls.length).toBe(
+		ignoreCallsBefore + 1,
+	)
+
 	const corruptFirst = await invokePackageExport({
 		env: createEnv(db),
 		baseUrl: 'https://kody.dev',
@@ -449,7 +492,7 @@ test('invokePackageExport enforces idempotency replay, mismatch, corruption, and
 			replayed: false,
 		},
 	})
-	expect(repoMockModule.runBundledModuleWithRegistry).toHaveBeenCalledTimes(3)
+	expect(repoMockModule.runBundledModuleWithRegistry).toHaveBeenCalledTimes(4)
 
 	const failingDb = createDatabase({ failClaim: true })
 	seedPackageResolution()

--- a/packages/worker/src/package-registry/manifest.node.test.ts
+++ b/packages/worker/src/package-registry/manifest.node.test.ts
@@ -280,6 +280,20 @@ test('parseAuthoredPackageJson accepts kody.webhooks and rejects unknown exports
 				secretName: 'sentryWebhookSecret',
 				encoding: 'hex',
 			},
+			replay: null,
+		},
+	])
+	expect(manifest.kody.webhooks).toEqual([
+		{
+			name: 'sentry',
+			export: './handle-sentry-webhook',
+			responseMode: 'ack',
+			verification: {
+				type: 'hmac-sha256',
+				header: 'sentry-hook-signature',
+				secretName: 'sentryWebhookSecret',
+				encoding: 'hex',
+			},
 		},
 	])
 
@@ -350,6 +364,86 @@ test('parseAuthoredPackageJson accepts kody.webhooks and rejects unknown exports
 			manifestPath: 'package.json',
 		}),
 	).toThrow(/header/)
+})
+
+test('parseAuthoredPackageJson accepts webhook replay fields and rejects unknown timestampFormat', () => {
+	const stripe = parseAuthoredPackageJson({
+		content: JSON.stringify({
+			name: '@kentcdodds/stripe-bridge',
+			exports: {
+				'./handle-stripe-webhook': './src/handle-stripe-webhook.ts',
+			},
+			kody: {
+				id: 'stripe-bridge',
+				description: 'Stripe bridge',
+				webhooks: [
+					{
+						name: 'stripe',
+						export: './handle-stripe-webhook',
+						verification: {
+							type: 'hmac-sha256',
+							header: 'Stripe-Signature',
+							secretName: 'stripeWebhookSecret',
+							encoding: 'hex',
+							signedPayload: 'timestamp.body',
+						},
+						replay: {
+							timestampHeader: 'Stripe-Signature',
+							timestampFormat: 'stripe-signature',
+							toleranceSeconds: 300,
+						},
+					},
+				],
+			},
+		}),
+		manifestPath: 'package.json',
+	})
+	expect(buildPackageSearchProjection(stripe).webhooks).toEqual([
+		{
+			name: 'stripe',
+			exportName: './handle-stripe-webhook',
+			description: null,
+			responseMode: 'ack',
+			verification: {
+				type: 'hmac-sha256',
+				header: 'Stripe-Signature',
+				secretName: 'stripeWebhookSecret',
+				encoding: 'hex',
+				signedPayload: 'timestamp.body',
+			},
+			replay: {
+				timestampHeader: 'Stripe-Signature',
+				timestampFormat: 'stripe-signature',
+				toleranceSeconds: 300,
+			},
+		},
+	])
+
+	expect(() =>
+		parseAuthoredPackageJson({
+			content: JSON.stringify({
+				name: '@kentcdodds/stripe-bridge',
+				exports: {
+					'./handle-stripe-webhook': './src/handle-stripe-webhook.ts',
+				},
+				kody: {
+					id: 'stripe-bridge',
+					description: 'Stripe bridge',
+					webhooks: [
+						{
+							name: 'stripe',
+							export: './handle-stripe-webhook',
+							replay: {
+								timestampHeader: 'X-Timestamp',
+								timestampFormat: 'rfc-2822',
+							},
+						},
+					],
+				},
+			}),
+			manifestPath: 'package.json',
+		}),
+	).toThrow(/Unknown webhook replay timestampFormat "rfc-2822"/)
 })
 
 test('parseAuthoredPackageJson rejects unsupported or invalid kody manifest extensions', () => {

--- a/packages/worker/src/package-registry/manifest.ts
+++ b/packages/worker/src/package-registry/manifest.ts
@@ -272,6 +272,17 @@ export type PackageWebhookManifestEntry = {
 		secretName: string
 		encoding: 'hex' | 'base64'
 		prefix?: string
+		signedPayload?: 'body' | 'timestamp.body'
+	} | null
+	replay: {
+		timestampHeader?: string
+		timestampFormat?:
+			| 'unix-seconds'
+			| 'unix-millis'
+			| 'iso-8601'
+			| 'stripe-signature'
+		toleranceSeconds?: number
+		deliveryIdHeader?: string
 	} | null
 }
 
@@ -292,6 +303,25 @@ export function listPackageWebhooks(
 						encoding: webhook.verification.encoding,
 						...(webhook.verification.prefix !== undefined
 							? { prefix: webhook.verification.prefix }
+							: {}),
+						...(webhook.verification.signedPayload !== undefined
+							? { signedPayload: webhook.verification.signedPayload }
+							: {}),
+					}
+				: null,
+			replay: webhook.replay
+				? {
+						...(webhook.replay.timestampHeader !== undefined
+							? { timestampHeader: webhook.replay.timestampHeader }
+							: {}),
+						...(webhook.replay.timestampFormat !== undefined
+							? { timestampFormat: webhook.replay.timestampFormat }
+							: {}),
+						...(webhook.replay.toleranceSeconds !== undefined
+							? { toleranceSeconds: webhook.replay.toleranceSeconds }
+							: {}),
+						...(webhook.replay.deliveryIdHeader !== undefined
+							? { deliveryIdHeader: webhook.replay.deliveryIdHeader }
 							: {}),
 					}
 				: null,
@@ -1427,6 +1457,15 @@ export function buildPackageSearchDocument(
 			webhook.description ?? '',
 			webhook.responseMode,
 			webhook.verification ? `verify:${webhook.verification.header}` : '',
+			webhook.verification?.signedPayload
+				? `signed:${webhook.verification.signedPayload}`
+				: '',
+			webhook.replay?.timestampHeader
+				? `replay-timestamp:${webhook.replay.timestampHeader}:${webhook.replay.timestampFormat ?? ''}`
+				: '',
+			webhook.replay?.deliveryIdHeader
+				? `replay-delivery:${webhook.replay.deliveryIdHeader}`
+				: '',
 		]
 			.filter((value) => value.length > 0)
 			.join(' '),

--- a/packages/worker/src/package-registry/types.ts
+++ b/packages/worker/src/package-registry/types.ts
@@ -58,25 +58,92 @@ export type PackageSubscriptionDefinition = z.infer<
 /** RFC 9110 token characters for HTTP field names. */
 const httpFieldNamePattern = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/
 
+export const webhookSignedPayloadValues = ['body', 'timestamp.body'] as const
+export type WebhookSignedPayload = (typeof webhookSignedPayloadValues)[number]
+
+export const webhookTimestampFormatValues = [
+	'unix-seconds',
+	'unix-millis',
+	'iso-8601',
+	'stripe-signature',
+] as const
+export type WebhookTimestampFormat =
+	(typeof webhookTimestampFormatValues)[number]
+
 export const packageWebhookVerificationSchema = z.object({
 	type: z.enum(['hmac-sha256', 'hmac-sha1']),
 	header: z.string().regex(httpFieldNamePattern),
 	secretName: z.string().min(1),
 	encoding: z.enum(['hex', 'base64']),
 	prefix: z.string().optional(),
+	signedPayload: z.enum(webhookSignedPayloadValues).optional(),
 })
 
 export type PackageWebhookVerification = z.infer<
 	typeof packageWebhookVerificationSchema
 >
 
-export const packageWebhookDefinitionSchema = z.object({
-	name: z.string().regex(kodyPackageIdPattern),
-	export: z.string().min(1),
-	description: z.string().min(1).optional(),
-	responseMode: z.enum(['ack', 'sync']).optional(),
-	verification: packageWebhookVerificationSchema.optional(),
-})
+const webhookTimestampFormatSchema = z.string().superRefine((value, ctx) => {
+	if (
+		!(webhookTimestampFormatValues as ReadonlyArray<string>).includes(value)
+	) {
+		ctx.addIssue({
+			code: 'custom',
+			message: `Unknown webhook replay timestampFormat "${value}". Expected one of: ${webhookTimestampFormatValues.join(', ')}.`,
+		})
+	}
+}) as z.ZodType<WebhookTimestampFormat>
+
+export const packageWebhookReplaySchema = z
+	.object({
+		timestampHeader: z.string().regex(httpFieldNamePattern).optional(),
+		timestampFormat: webhookTimestampFormatSchema.optional(),
+		toleranceSeconds: z.number().int().positive().max(86_400).optional(),
+		deliveryIdHeader: z.string().regex(httpFieldNamePattern).optional(),
+	})
+	.superRefine((replay, ctx) => {
+		if (replay.timestampHeader && replay.timestampFormat === undefined) {
+			ctx.addIssue({
+				code: 'custom',
+				path: ['timestampFormat'],
+				message:
+					'replay.timestampFormat is required when timestampHeader is set.',
+			})
+		}
+		if (replay.timestampFormat !== undefined && !replay.timestampHeader) {
+			ctx.addIssue({
+				code: 'custom',
+				path: ['timestampHeader'],
+				message:
+					'replay.timestampHeader is required when timestampFormat is set.',
+			})
+		}
+	})
+
+export type PackageWebhookReplay = z.infer<typeof packageWebhookReplaySchema>
+
+export const packageWebhookDefinitionSchema = z
+	.object({
+		name: z.string().regex(kodyPackageIdPattern),
+		export: z.string().min(1),
+		description: z.string().min(1).optional(),
+		responseMode: z.enum(['ack', 'sync']).optional(),
+		verification: packageWebhookVerificationSchema.optional(),
+		replay: packageWebhookReplaySchema.optional(),
+	})
+	.superRefine((webhook, ctx) => {
+		if (
+			webhook.verification?.signedPayload === 'timestamp.body' &&
+			!webhook.replay?.timestampHeader
+		) {
+			ctx.addIssue({
+				code: 'custom',
+				path: ['verification', 'signedPayload'],
+				message:
+					'verification.signedPayload "timestamp.body" requires replay.timestampHeader.',
+			})
+		}
+	})
 
 export type PackageWebhookDefinition = z.infer<
 	typeof packageWebhookDefinitionSchema

--- a/packages/worker/src/webhooks/crypto.node.test.ts
+++ b/packages/worker/src/webhooks/crypto.node.test.ts
@@ -1,8 +1,13 @@
 import { expect, test } from 'vitest'
 import {
+	buildWebhookDeliveryIdempotencyKey,
+	buildWebhookTimestampBodyPayload,
 	computeWebhookHmacSignature,
 	generateWebhookUrlSecret,
 	hashWebhookUrlSecret,
+	isWebhookTimestampWithinTolerance,
+	parseWebhookReplayTimestamp,
+	providedWebhookHmacValues,
 	verifyWebhookHmacSignature,
 	webhookUrlSecretMatches,
 } from './crypto.ts'
@@ -69,4 +74,135 @@ test('HMAC signatures cover GitHub-style prefixed hex and raw hex', async () => 
 			provided: sentry,
 		}),
 	).toBe(true)
+})
+
+test('webhook replay timestamps parse unix, iso, and stripe formats and reject missing or junk values', async () => {
+	const bodyText = '{"ok":true}'
+	const body = new TextEncoder().encode(bodyText).buffer as ArrayBuffer
+	const unixSeconds = 1_780_000_000
+	expect(
+		parseWebhookReplayTimestamp({
+			headerValue: String(unixSeconds),
+			format: 'unix-seconds',
+		}),
+	).toEqual({
+		ok: true,
+		timestampMs: unixSeconds * 1000,
+		timestampToken: String(unixSeconds),
+	})
+	expect(
+		parseWebhookReplayTimestamp({
+			headerValue: String(unixSeconds * 1000),
+			format: 'unix-millis',
+		}),
+	).toEqual({
+		ok: true,
+		timestampMs: unixSeconds * 1000,
+		timestampToken: String(unixSeconds * 1000),
+	})
+	expect(
+		parseWebhookReplayTimestamp({
+			headerValue: '2026-09-02T18:00:00.000Z',
+			format: 'iso-8601',
+		}),
+	).toEqual({
+		ok: true,
+		timestampMs: Date.parse('2026-09-02T18:00:00.000Z'),
+		timestampToken: '2026-09-02T18:00:00.000Z',
+	})
+	expect(
+		parseWebhookReplayTimestamp({
+			headerValue: `t=${unixSeconds},v1=abc`,
+			format: 'stripe-signature',
+		}),
+	).toEqual({
+		ok: true,
+		timestampMs: unixSeconds * 1000,
+		timestampToken: String(unixSeconds),
+	})
+	expect(
+		parseWebhookReplayTimestamp({
+			headerValue: null,
+			format: 'unix-seconds',
+		}),
+	).toEqual({ ok: false, reason: 'missing' })
+	expect(
+		parseWebhookReplayTimestamp({
+			headerValue: 'not-a-time',
+			format: 'iso-8601',
+		}),
+	).toEqual({ ok: false, reason: 'unparseable' })
+	expect(
+		isWebhookTimestampWithinTolerance({
+			timestampMs: unixSeconds * 1000,
+			nowMs: unixSeconds * 1000 + 299_000,
+			toleranceSeconds: 300,
+		}),
+	).toBe(true)
+	expect(
+		isWebhookTimestampWithinTolerance({
+			timestampMs: unixSeconds * 1000,
+			nowMs: unixSeconds * 1000 + 301_000,
+			toleranceSeconds: 300,
+		}),
+	).toBe(false)
+
+	const timestampPayload = buildWebhookTimestampBodyPayload({
+		timestampToken: String(unixSeconds),
+		body,
+	})
+	const timestampBodySignature = await computeWebhookHmacSignature({
+		algorithm: 'hmac-sha256',
+		secret: 'whsec_test',
+		body: timestampPayload,
+		encoding: 'hex',
+	})
+	expect(
+		await verifyWebhookHmacSignature({
+			algorithm: 'hmac-sha256',
+			secret: 'whsec_test',
+			body,
+			encoding: 'hex',
+			provided: timestampBodySignature,
+		}),
+	).toBe(false)
+	expect(
+		await verifyWebhookHmacSignature({
+			algorithm: 'hmac-sha256',
+			secret: 'whsec_test',
+			body: timestampPayload,
+			encoding: 'hex',
+			provided: timestampBodySignature,
+		}),
+	).toBe(true)
+	expect(
+		providedWebhookHmacValues({
+			provided: `t=${unixSeconds},v1=${timestampBodySignature}`,
+			verificationHeader: 'Stripe-Signature',
+			timestampHeader: 'Stripe-Signature',
+			timestampFormat: 'stripe-signature',
+		}),
+	).toEqual([timestampBodySignature])
+
+	const firstKey = await buildWebhookDeliveryIdempotencyKey({
+		userId: 'user-1',
+		packageId: 'pkg-1',
+		webhookName: 'github',
+		deliveryId: 'delivery-1',
+	})
+	const sameKey = await buildWebhookDeliveryIdempotencyKey({
+		userId: 'user-1',
+		packageId: 'pkg-1',
+		webhookName: 'github',
+		deliveryId: 'delivery-1',
+	})
+	const otherKey = await buildWebhookDeliveryIdempotencyKey({
+		userId: 'user-1',
+		packageId: 'pkg-1',
+		webhookName: 'github',
+		deliveryId: 'delivery-2',
+	})
+	expect(firstKey).toBe(sameKey)
+	expect(firstKey).not.toBe(otherKey)
+	expect(firstKey).toMatch(/^[0-9a-f]{64}$/)
 })

--- a/packages/worker/src/webhooks/crypto.ts
+++ b/packages/worker/src/webhooks/crypto.ts
@@ -8,9 +8,11 @@ import { timingSafeEqualString } from '#worker/maintenance-handler.ts'
 import {
 	type WebhookHmacAlgorithm,
 	type WebhookSignatureEncoding,
+	type WebhookTimestampFormat,
 } from './types.ts'
 
 const urlSecretBytes = 32
+const unixIntegerPattern = /^\d+$/
 
 export async function hashWebhookUrlSecret(secret: string) {
 	return sha256Hex(secret)
@@ -94,4 +96,147 @@ export async function verifyWebhookHmacSignature(input: {
 		prefix: input.prefix,
 	})
 	return timingSafeEqualString(expected, input.provided.trim())
+}
+
+export function extractStripeSignatureParts(header: string): {
+	timestampToken: string
+	v1Signatures: Array<string>
+} | null {
+	let timestampToken: string | null = null
+	const v1Signatures: Array<string> = []
+	for (const part of header.split(',')) {
+		const separator = part.indexOf('=')
+		if (separator <= 0) continue
+		const key = part.slice(0, separator).trim()
+		const value = part.slice(separator + 1).trim()
+		if (!value) continue
+		if (key === 't' && unixIntegerPattern.test(value)) {
+			timestampToken = value
+			continue
+		}
+		if (key === 'v1') {
+			v1Signatures.push(value)
+		}
+	}
+	if (timestampToken == null) return null
+	return { timestampToken, v1Signatures }
+}
+
+export function buildWebhookTimestampBodyPayload(input: {
+	timestampToken: string
+	body: ArrayBuffer
+}): ArrayBuffer {
+	const prefix = new TextEncoder().encode(`${input.timestampToken}.`)
+	const bodyBytes = new Uint8Array(input.body)
+	const combined = new Uint8Array(prefix.byteLength + bodyBytes.byteLength)
+	combined.set(prefix, 0)
+	combined.set(bodyBytes, prefix.byteLength)
+	return combined.buffer
+}
+
+export async function buildWebhookDeliveryIdempotencyKey(input: {
+	userId: string
+	packageId: string
+	webhookName: string
+	deliveryId: string
+}) {
+	return sha256Hex(
+		`${input.userId}${input.packageId}${input.webhookName}${input.deliveryId}`,
+	)
+}
+
+export function isWebhookTimestampWithinTolerance(input: {
+	timestampMs: number
+	nowMs: number
+	toleranceSeconds: number
+}) {
+	return (
+		Math.abs(input.nowMs - input.timestampMs) <= input.toleranceSeconds * 1000
+	)
+}
+
+export type ParsedWebhookReplayTimestamp =
+	| { ok: true; timestampMs: number; timestampToken: string }
+	| { ok: false; reason: 'missing' | 'unparseable' }
+
+export function parseWebhookReplayTimestamp(input: {
+	headerValue: string | null
+	format: WebhookTimestampFormat
+}): ParsedWebhookReplayTimestamp {
+	const header = input.headerValue?.trim() ?? ''
+	if (!header) return { ok: false, reason: 'missing' }
+
+	switch (input.format) {
+		case 'unix-seconds': {
+			if (!unixIntegerPattern.test(header)) {
+				return { ok: false, reason: 'unparseable' }
+			}
+			const seconds = Number(header)
+			if (!Number.isSafeInteger(seconds)) {
+				return { ok: false, reason: 'unparseable' }
+			}
+			return {
+				ok: true,
+				timestampMs: seconds * 1000,
+				timestampToken: header,
+			}
+		}
+		case 'unix-millis': {
+			if (!unixIntegerPattern.test(header)) {
+				return { ok: false, reason: 'unparseable' }
+			}
+			const millis = Number(header)
+			if (!Number.isSafeInteger(millis)) {
+				return { ok: false, reason: 'unparseable' }
+			}
+			return { ok: true, timestampMs: millis, timestampToken: header }
+		}
+		case 'iso-8601': {
+			const timestampMs = Date.parse(header)
+			if (!Number.isFinite(timestampMs)) {
+				return { ok: false, reason: 'unparseable' }
+			}
+			return { ok: true, timestampMs, timestampToken: header }
+		}
+		case 'stripe-signature': {
+			const parsed = extractStripeSignatureParts(header)
+			if (!parsed) return { ok: false, reason: 'unparseable' }
+			const seconds = Number(parsed.timestampToken)
+			if (!Number.isSafeInteger(seconds)) {
+				return { ok: false, reason: 'unparseable' }
+			}
+			return {
+				ok: true,
+				timestampMs: seconds * 1000,
+				timestampToken: parsed.timestampToken,
+			}
+		}
+		default: {
+			const exhaustive: never = input.format
+			throw new Error(
+				`Unhandled webhook timestamp format: ${String(exhaustive)}`,
+			)
+		}
+	}
+}
+
+export function providedWebhookHmacValues(input: {
+	provided: string
+	verificationHeader: string
+	timestampHeader?: string
+	timestampFormat?: WebhookTimestampFormat
+}): Array<string> {
+	const trimmed = input.provided.trim()
+	if (
+		input.timestampFormat === 'stripe-signature' &&
+		input.timestampHeader &&
+		input.verificationHeader.toLowerCase() ===
+			input.timestampHeader.toLowerCase()
+	) {
+		const parsed = extractStripeSignatureParts(input.provided)
+		if (parsed && parsed.v1Signatures.length > 0) {
+			return parsed.v1Signatures
+		}
+	}
+	return [trimmed]
 }

--- a/packages/worker/src/webhooks/delivery.ts
+++ b/packages/worker/src/webhooks/delivery.ts
@@ -70,6 +70,7 @@ export async function dispatchWebhookInvocation(input: {
 	exportName: string
 	params: WebhookExportParams
 	idempotencyKey: string
+	idempotencyParamsHash?: 'ignore'
 }) {
 	return await invokePackageExport({
 		env: input.env,
@@ -85,6 +86,9 @@ export async function dispatchWebhookInvocation(input: {
 			exportName: input.exportName,
 			params: input.params,
 			idempotencyKey: input.idempotencyKey,
+			...(input.idempotencyParamsHash === 'ignore'
+				? { idempotencyParamsHash: 'ignore' as const }
+				: {}),
 			source: 'webhook',
 			topic: `webhook:${input.packageKodyId}:${input.endpoint.webhookName}`,
 		},

--- a/packages/worker/src/webhooks/dispatch-queue-producer.ts
+++ b/packages/worker/src/webhooks/dispatch-queue-producer.ts
@@ -20,6 +20,7 @@ export type WebhookDispatchQueueMessage = {
 	exportName: string
 	params: WebhookExportParams
 	idempotencyKey: string
+	idempotencyParamsHash?: 'ignore'
 	deliveryId: string
 	payloadBytes: number
 	receivedAt: string
@@ -39,6 +40,7 @@ export function createWebhookDispatchQueueMessage(input: {
 	exportName: string
 	params: WebhookExportParams
 	idempotencyKey: string
+	idempotencyParamsHash?: 'ignore'
 	deliveryId: string
 	payloadBytes: number
 	receivedAt: string
@@ -55,6 +57,9 @@ export function createWebhookDispatchQueueMessage(input: {
 			},
 		},
 		idempotencyKey: input.idempotencyKey,
+		...(input.idempotencyParamsHash === 'ignore'
+			? { idempotencyParamsHash: 'ignore' as const }
+			: {}),
 		deliveryId: input.deliveryId,
 		payloadBytes: input.payloadBytes,
 		receivedAt: input.receivedAt,
@@ -136,6 +141,13 @@ export function parseWebhookDispatchQueueMessage(
 			return null
 		}
 	}
+	const idempotencyParamsHash = message['idempotencyParamsHash']
+	if (
+		idempotencyParamsHash !== undefined &&
+		idempotencyParamsHash !== 'ignore'
+	) {
+		return null
+	}
 	return {
 		endpoint: {
 			id,
@@ -147,6 +159,9 @@ export function parseWebhookDispatchQueueMessage(
 		exportName,
 		params: params as WebhookExportParams,
 		idempotencyKey,
+		...(idempotencyParamsHash === 'ignore'
+			? { idempotencyParamsHash: 'ignore' as const }
+			: {}),
 		deliveryId,
 		payloadBytes,
 		receivedAt,

--- a/packages/worker/src/webhooks/dispatch-queue.node.test.ts
+++ b/packages/worker/src/webhooks/dispatch-queue.node.test.ts
@@ -176,8 +176,43 @@ test('webhook queue parser rejects malformed isolation and delivery fields', () 
 	expect(
 		parseWebhookDispatchQueueMessage({ ...message, params: [] }),
 	).toBeNull()
+	expect(
+		parseWebhookDispatchQueueMessage({
+			...message,
+			idempotencyParamsHash: 'include',
+		}),
+	).toBeNull()
+	const withIgnore = {
+		...message,
+		idempotencyParamsHash: 'ignore' as const,
+	}
+	expect(parseWebhookDispatchQueueMessage(withIgnore)).toEqual(withIgnore)
 	expect(getWebhookDispatchQueueMessageBytes(message)).toBeLessThan(
 		webhookDispatchQueueMessageMaxBytes,
+	)
+})
+
+test('queue dispatch forwards delivery-id params-hash ignore', async () => {
+	mocks.dispatchWebhookInvocation.mockReset()
+	mocks.recordWebhookDelivery.mockReset()
+	mocks.dispatchWebhookInvocation.mockResolvedValue({
+		status: 200,
+		body: { ok: true, result: { handled: true } },
+	})
+	mocks.recordWebhookDelivery.mockResolvedValue(undefined)
+	const message = {
+		...createMessage(),
+		idempotencyParamsHash: 'ignore' as const,
+	}
+
+	await expect(processWebhookDispatch(message, {} as Env)).resolves.toBe(
+		'terminal',
+	)
+	expect(mocks.dispatchWebhookInvocation).toHaveBeenCalledWith(
+		expect.objectContaining({
+			idempotencyKey: message.idempotencyKey,
+			idempotencyParamsHash: 'ignore',
+		}),
 	)
 })
 

--- a/packages/worker/src/webhooks/dispatch-queue.ts
+++ b/packages/worker/src/webhooks/dispatch-queue.ts
@@ -39,6 +39,9 @@ export async function processWebhookDispatch(
 		exportName: message.exportName,
 		params: message.params,
 		idempotencyKey: message.idempotencyKey,
+		...(message.idempotencyParamsHash === 'ignore'
+			? { idempotencyParamsHash: 'ignore' as const }
+			: {}),
 	})
 	const errorCode = readInvocationErrorCode(response.body)
 	if (errorCode && retryableInvocationErrorCodes.has(errorCode)) return 'retry'

--- a/packages/worker/src/webhooks/http.ts
+++ b/packages/worker/src/webhooks/http.ts
@@ -11,8 +11,13 @@ import { listPackageWebhooks } from '#worker/package-registry/manifest.ts'
 import { getSavedPackageByKodyId } from '#worker/package-registry/repo.ts'
 import { loadPackageManifestBySourceId } from '#worker/package-registry/source.ts'
 import {
-	webhookUrlSecretMatches,
+	buildWebhookDeliveryIdempotencyKey,
+	buildWebhookTimestampBodyPayload,
+	isWebhookTimestampWithinTolerance,
+	parseWebhookReplayTimestamp,
+	providedWebhookHmacValues,
 	verifyWebhookHmacSignature,
+	webhookUrlSecretMatches,
 } from './crypto.ts'
 import {
 	dispatchWebhookInvocation,
@@ -34,6 +39,7 @@ import { collectSafeWebhookHeaders } from './headers.ts'
 import { buildWebhookExportParams } from './params.ts'
 import { getWebhookEndpointByKey } from './repo.ts'
 import {
+	webhookDefaultReplayToleranceSeconds,
 	webhookMaxPayloadBytes,
 	webhookRateLimitConfig,
 	webhookSyncInvocationTimeoutMs,
@@ -144,6 +150,29 @@ function unauthorizedSignatureResponse() {
 		},
 		{ status: 401 },
 	)
+}
+
+async function rejectUnauthorizedSignature(input: {
+	env: Env
+	endpoint: Parameters<typeof recordWebhookDelivery>[0]['endpoint']
+	kodyId: string
+	error: string
+	payloadBytes: number
+	startedAt: string
+	waitUntil?: (promise: Promise<unknown>) => void
+}) {
+	await recordWebhookDelivery({
+		env: input.env,
+		endpoint: input.endpoint,
+		kodyId: input.kodyId,
+		outcome: 'rejected',
+		httpStatus: 401,
+		error: input.error,
+		payloadBytes: input.payloadBytes,
+		startedAt: input.startedAt,
+		waitUntil: input.waitUntil,
+	})
+	return unauthorizedSignatureResponse()
 }
 
 function dispatchUnavailableResponse() {
@@ -356,22 +385,62 @@ export async function handleWebhookIngressRequest(
 	) as ArrayBuffer
 	const bodyText = new TextDecoder().decode(bodyBytes)
 
+	const rejectUnauthorized = (error: string) =>
+		rejectUnauthorizedSignature({
+			env,
+			endpoint,
+			kodyId: savedPackage.kodyId,
+			error,
+			payloadBytes: bodyBytes.byteLength,
+			startedAt: receivedAt,
+			waitUntil,
+		})
+
+	let replayTimestampToken: string | undefined
+	if (declared.replay?.timestampHeader) {
+		const timestampFormat = declared.replay.timestampFormat
+		if (!timestampFormat) {
+			return rejectUnauthorized('invalid_timestamp')
+		}
+		const parsedTimestamp = parseWebhookReplayTimestamp({
+			headerValue: request.headers.get(declared.replay.timestampHeader),
+			format: timestampFormat,
+		})
+		if (!parsedTimestamp.ok) {
+			return rejectUnauthorized(
+				parsedTimestamp.reason === 'missing'
+					? 'missing_timestamp'
+					: 'invalid_timestamp',
+			)
+		}
+		const toleranceSeconds =
+			declared.replay.toleranceSeconds ?? webhookDefaultReplayToleranceSeconds
+		if (
+			!isWebhookTimestampWithinTolerance({
+				timestampMs: parsedTimestamp.timestampMs,
+				nowMs: Date.parse(receivedAt),
+				toleranceSeconds,
+			})
+		) {
+			return rejectUnauthorized('timestamp_outside_tolerance')
+		}
+		replayTimestampToken = parsedTimestamp.timestampToken
+	}
+
+	if (declared.replay?.deliveryIdHeader) {
+		const deliveryIdValue = request.headers
+			.get(declared.replay.deliveryIdHeader)
+			?.trim()
+		if (!deliveryIdValue) {
+			return rejectUnauthorized('missing_delivery_id')
+		}
+	}
+
 	if (declared.verification) {
 		const headerName = declared.verification.header
 		const provided = request.headers.get(headerName)
 		if (!provided) {
-			await recordWebhookDelivery({
-				env,
-				endpoint,
-				kodyId: savedPackage.kodyId,
-				outcome: 'rejected',
-				httpStatus: 401,
-				error: 'missing_signature',
-				payloadBytes: bodyBytes.byteLength,
-				startedAt: receivedAt,
-				waitUntil,
-			})
-			return unauthorizedSignatureResponse()
+			return rejectUnauthorized('missing_signature')
 		}
 		const resolved = await resolveSecret({
 			env,
@@ -384,47 +453,58 @@ export async function handleWebhookIngressRequest(
 			},
 		})
 		if (!resolved.found || !resolved.value) {
-			await recordWebhookDelivery({
-				env,
-				endpoint,
-				kodyId: savedPackage.kodyId,
-				outcome: 'rejected',
-				httpStatus: 401,
-				error: `verification_secret_missing:${declared.verification.secretName}`,
-				payloadBytes: bodyBytes.byteLength,
-				startedAt: receivedAt,
-				waitUntil,
-			})
-			return unauthorizedSignatureResponse()
+			return rejectUnauthorized(
+				`verification_secret_missing:${declared.verification.secretName}`,
+			)
 		}
-		const valid = await verifyWebhookHmacSignature({
-			algorithm: declared.verification.type,
-			secret: resolved.value,
-			body: bodyBuffer,
-			encoding: declared.verification.encoding,
-			prefix: declared.verification.prefix,
-			provided,
-		})
-		if (!valid) {
-			await recordWebhookDelivery({
-				env,
-				endpoint,
-				kodyId: savedPackage.kodyId,
-				outcome: 'rejected',
-				httpStatus: 401,
-				error: 'invalid_signature',
-				payloadBytes: bodyBytes.byteLength,
-				startedAt: receivedAt,
-				waitUntil,
+		const signedPayload = declared.verification.signedPayload ?? 'body'
+		let hmacPayload = bodyBuffer
+		if (signedPayload === 'timestamp.body') {
+			if (!replayTimestampToken) {
+				return rejectUnauthorized('invalid_timestamp')
+			}
+			hmacPayload = buildWebhookTimestampBodyPayload({
+				timestampToken: replayTimestampToken,
+				body: bodyBuffer,
 			})
-			return unauthorizedSignatureResponse()
+		}
+		const providedValues = providedWebhookHmacValues({
+			provided,
+			verificationHeader: headerName,
+			timestampHeader: declared.replay?.timestampHeader,
+			timestampFormat: declared.replay?.timestampFormat,
+		})
+		let valid = false
+		for (const candidate of providedValues) {
+			if (
+				await verifyWebhookHmacSignature({
+					algorithm: declared.verification.type,
+					secret: resolved.value,
+					body: hmacPayload,
+					encoding: declared.verification.encoding,
+					prefix: declared.verification.prefix,
+					provided: candidate,
+				})
+			) {
+				valid = true
+				break
+			}
+		}
+		if (!valid) {
+			return rejectUnauthorized('invalid_signature')
 		}
 	}
 
-	const safeHeaders = collectSafeWebhookHeaders(
-		request,
-		declared.verification ? [declared.verification.header] : [],
-	)
+	const extraAllowedHeaders = [
+		...(declared.verification ? [declared.verification.header] : []),
+		...(declared.replay?.timestampHeader
+			? [declared.replay.timestampHeader]
+			: []),
+		...(declared.replay?.deliveryIdHeader
+			? [declared.replay.deliveryIdHeader]
+			: []),
+	]
+	const safeHeaders = collectSafeWebhookHeaders(request, extraAllowedHeaders)
 	const params = buildWebhookExportParams({
 		packageKodyId: savedPackage.kodyId,
 		webhookName: route.webhookName,
@@ -434,7 +514,17 @@ export async function handleWebhookIngressRequest(
 		headers: safeHeaders,
 	})
 	const deliveryId = crypto.randomUUID()
-	const idempotencyKey = `webhook:${endpoint.id}:${deliveryId}`
+	const providerDeliveryId = declared.replay?.deliveryIdHeader
+		? request.headers.get(declared.replay.deliveryIdHeader)?.trim()
+		: undefined
+	const idempotencyKey = providerDeliveryId
+		? await buildWebhookDeliveryIdempotencyKey({
+				userId: endpoint.userId,
+				packageId: endpoint.packageId,
+				webhookName: endpoint.webhookName,
+				deliveryId: providerDeliveryId,
+			})
+		: `webhook:${endpoint.id}:${deliveryId}`
 
 	if (declared.responseMode === 'ack') {
 		let message = createWebhookDispatchQueueMessage({

--- a/packages/worker/src/webhooks/http.ts
+++ b/packages/worker/src/webhooks/http.ts
@@ -525,6 +525,16 @@ export async function handleWebhookIngressRequest(
 				deliveryId: providerDeliveryId,
 			})
 		: `webhook:${endpoint.id}:${deliveryId}`
+	// Delivery-id keys identify the event, not the HTTP attempt. Provider
+	// retries change `receivedAt` and often headers; the same delivery id is
+	// still that event even when body bytes differ. Matching the ledger by
+	// key alone (`idempotencyParamsHash: 'ignore'`) returns the original
+	// acknowledgement instead of hashing those volatile fields. A different
+	// delivery id cannot reuse another event's ack because the key already
+	// binds userId + packageId + webhookName + deliveryId.
+	const idempotencyParamsHash = providerDeliveryId
+		? ('ignore' as const)
+		: undefined
 
 	if (declared.responseMode === 'ack') {
 		let message = createWebhookDispatchQueueMessage({
@@ -538,6 +548,7 @@ export async function handleWebhookIngressRequest(
 			exportName: declared.exportName,
 			params,
 			idempotencyKey,
+			...(idempotencyParamsHash ? { idempotencyParamsHash } : {}),
 			deliveryId,
 			payloadBytes: bodyBytes.byteLength,
 			receivedAt,
@@ -627,6 +638,7 @@ export async function handleWebhookIngressRequest(
 				exportName: declared.exportName,
 				params,
 				idempotencyKey,
+				...(idempotencyParamsHash ? { idempotencyParamsHash } : {}),
 			}),
 			webhookSyncInvocationTimeoutMs,
 		)

--- a/packages/worker/src/webhooks/http.workers.test.ts
+++ b/packages/worker/src/webhooks/http.workers.test.ts
@@ -1,6 +1,12 @@
 import { env } from 'cloudflare:workers'
 import { createExecutionContext, waitOnExecutionContext } from 'cloudflare:test'
 import { expect, test, vi } from 'vitest'
+import { type PackageInvocationRequest } from '#worker/package-invocations/common.ts'
+import {
+	createRequestHash,
+	resolveExistingInvocation,
+	type ResolvableInvocationRecord,
+} from '#worker/package-invocations/idempotency.ts'
 import type * as PackageInvocationServiceModule from '#worker/package-invocations/service.ts'
 import { clearRunRecords, listRunRecords } from '#worker/run-records/service.ts'
 import { silenceExpectedConsoleWarns } from '#worker/test-support/console-spies.ts'
@@ -50,6 +56,57 @@ vi.mock('./dispatch-queue-producer.ts', async () => {
 			mocks.enqueueWebhookDispatch(...args),
 	}
 })
+
+function createHashedIdempotencyExportMock() {
+	const ledger = new Map<string, ResolvableInvocationRecord>()
+	let exportInvocations = 0
+	const implementation = async (input: {
+		request: PackageInvocationRequest
+	}) => {
+		const key = input.request.idempotencyKey
+		if (!key) {
+			exportInvocations += 1
+			return {
+				status: 200,
+				body: { ok: true, result: { handled: true } },
+			}
+		}
+		const ignoreParams = input.request.idempotencyParamsHash === 'ignore'
+		const requestHash = await createRequestHash({
+			packageId: input.request.packageIdOrKodyId,
+			exportName: input.request.exportName,
+			params: ignoreParams ? undefined : input.request.params,
+			source: input.request.source ?? null,
+			topic: input.request.topic ?? null,
+		})
+		const existing = ledger.get(key)
+		if (existing) {
+			return resolveExistingInvocation({
+				record: existing,
+				requestHash,
+				idempotencyKey: key,
+				paramsHash: ignoreParams ? 'ignore' : 'include',
+			})
+		}
+		exportInvocations += 1
+		const response = {
+			status: 200,
+			body: { ok: true, result: { handled: true } },
+		}
+		ledger.set(key, {
+			requestHash,
+			status: 'completed',
+			storedResponse: response,
+		})
+		return response
+	}
+	return {
+		implementation,
+		get exportInvocations() {
+			return exportInvocations
+		},
+	}
+}
 
 async function ensureSchema(db: D1Database) {
 	await db
@@ -833,32 +890,9 @@ test('opt-in webhook replay protection rejects stale timestamps and dedupes deli
 		encoding: 'hex',
 		prefix: 'sha256=',
 	})
-	const ledger = new Map<string, { status: number; body: unknown }>()
-	let exportInvocations = 0
+	const exportMock = createHashedIdempotencyExportMock()
 	mocks.invokePackageExport.mockReset()
-	mocks.invokePackageExport.mockImplementation(
-		async (input: {
-			request: { idempotencyKey: string; params?: unknown }
-		}) => {
-			const existing = ledger.get(input.request.idempotencyKey)
-			if (existing) {
-				return {
-					status: existing.status,
-					body: {
-						...(existing.body as Record<string, unknown>),
-						idempotency: { replayed: true },
-					},
-				}
-			}
-			exportInvocations += 1
-			const response = {
-				status: 200,
-				body: { ok: true, result: { handled: true } },
-			}
-			ledger.set(input.request.idempotencyKey, response)
-			return response
-		},
-	)
+	mocks.invokePackageExport.mockImplementation(exportMock.implementation)
 
 	const firstGithub = await postWebhook({
 		packageKodyId: 'sentry-bridge',
@@ -874,6 +908,8 @@ test('opt-in webhook replay protection rejects stale timestamps and dedupes deli
 	expect(firstGithub.status).toBe(200)
 	expect(firstGithubBody).toEqual({ ok: true, result: { handled: true } })
 
+	await new Promise((resolve) => setTimeout(resolve, 10))
+
 	const replayedGithub = await postWebhook({
 		packageKodyId: 'sentry-bridge',
 		webhookName: 'github',
@@ -885,23 +921,58 @@ test('opt-in webhook replay protection rejects stale timestamps and dedupes deli
 		},
 	})
 	expect(replayedGithub.status).toBe(200)
-	expect(await replayedGithub.json()).toEqual({
-		ok: true,
-		result: { handled: true },
-		idempotency: { replayed: true },
-	})
-	expect(exportInvocations).toBe(1)
+	expect(await replayedGithub.json()).toEqual(firstGithubBody)
+	expect(exportMock.exportInvocations).toBe(1)
 	expect(mocks.invokePackageExport).toHaveBeenCalledTimes(2)
 	const firstCall = mocks.invokePackageExport.mock.calls[0]?.[0] as
-		| { request: { idempotencyKey: string } }
+		| {
+				request: {
+					idempotencyKey: string
+					idempotencyParamsHash?: 'ignore'
+					params: { webhook: { receivedAt: string } }
+				}
+		  }
 		| undefined
 	const secondCall = mocks.invokePackageExport.mock.calls[1]?.[0] as
-		| { request: { idempotencyKey: string } }
+		| {
+				request: {
+					idempotencyKey: string
+					idempotencyParamsHash?: 'ignore'
+					params: { webhook: { receivedAt: string } }
+				}
+		  }
 		| undefined
 	expect(firstCall?.request.idempotencyKey).toBe(
 		secondCall?.request.idempotencyKey,
 	)
 	expect(firstCall?.request.idempotencyKey).not.toMatch(/^webhook:/)
+	expect(firstCall?.request.idempotencyParamsHash).toBe('ignore')
+	expect(secondCall?.request.idempotencyParamsHash).toBe('ignore')
+	expect(firstCall?.request.params.webhook.receivedAt).not.toBe(
+		secondCall?.request.params.webhook.receivedAt,
+	)
+
+	const otherGithubBody = JSON.stringify({ ref: 'refs/heads/other' })
+	const otherGithubSignature = await computeWebhookHmacSignature({
+		algorithm: 'hmac-sha256',
+		secret: 'hmac-shared-secret',
+		body: encodeBody(otherGithubBody),
+		encoding: 'hex',
+		prefix: 'sha256=',
+	})
+	const differentBodyReplay = await postWebhook({
+		packageKodyId: 'sentry-bridge',
+		webhookName: 'github',
+		urlSecret,
+		body: otherGithubBody,
+		headers: {
+			'x-hub-signature-256': otherGithubSignature,
+			'x-github-delivery': 'delivery-abc',
+		},
+	})
+	expect(differentBodyReplay.status).toBe(200)
+	expect(await differentBodyReplay.json()).toEqual(firstGithubBody)
+	expect(exportMock.exportInvocations).toBe(1)
 
 	const missingDeliveryId = await postWebhook({
 		packageKodyId: 'sentry-bridge',
@@ -911,5 +982,5 @@ test('opt-in webhook replay protection rejects stale timestamps and dedupes deli
 		headers: { 'x-hub-signature-256': githubSignature },
 	})
 	expect(missingDeliveryId.status).toBe(401)
-	expect(exportInvocations).toBe(1)
+	expect(exportMock.exportInvocations).toBe(1)
 })

--- a/packages/worker/src/webhooks/http.workers.test.ts
+++ b/packages/worker/src/webhooks/http.workers.test.ts
@@ -5,7 +5,11 @@ import type * as PackageInvocationServiceModule from '#worker/package-invocation
 import { clearRunRecords, listRunRecords } from '#worker/run-records/service.ts'
 import { silenceExpectedConsoleWarns } from '#worker/test-support/console-spies.ts'
 import { createStableUserIdFromEmail } from '#worker/user-id.ts'
-import { computeWebhookHmacSignature, hashWebhookUrlSecret } from './crypto.ts'
+import {
+	buildWebhookTimestampBodyPayload,
+	computeWebhookHmacSignature,
+	hashWebhookUrlSecret,
+} from './crypto.ts'
 import type * as DispatchQueueProducerModule from './dispatch-queue-producer.ts'
 import { handleWebhookIngressRequest } from './http.ts'
 
@@ -160,7 +164,18 @@ function declareWebhook(input: {
 		secretName: string
 		encoding: 'hex'
 		prefix?: string
+		signedPayload?: 'body' | 'timestamp.body'
 	} | null
+	replay?: {
+		timestampHeader?: string
+		timestampFormat?:
+			| 'unix-seconds'
+			| 'unix-millis'
+			| 'iso-8601'
+			| 'stripe-signature'
+		toleranceSeconds?: number
+		deliveryIdHeader?: string
+	}
 }) {
 	mocks.loadPackageManifestBySourceId.mockResolvedValue({
 		manifest: {
@@ -177,6 +192,7 @@ function declareWebhook(input: {
 						export: './handle-sentry-webhook',
 						responseMode: input.responseMode ?? 'ack',
 						...(input.verification ? { verification: input.verification } : {}),
+						...(input.replay ? { replay: input.replay } : {}),
 					},
 				],
 			},
@@ -586,4 +602,314 @@ test('webhook delivery records explicit rejected and failed outcomes', async () 
 		outcome: 'failed',
 		httpStatus: 502,
 	})
+})
+
+function encodeBody(text: string) {
+	const bytes = new TextEncoder().encode(text)
+	return bytes.buffer.slice(
+		bytes.byteOffset,
+		bytes.byteOffset + bytes.byteLength,
+	) as ArrayBuffer
+}
+
+test('opt-in webhook replay protection rejects stale timestamps and dedupes delivery ids', async () => {
+	silenceExpectedConsoleWarns(['activation-run-record-failed'])
+	await ensureSchema(env.APP_DB)
+	await env.APP_DB.prepare(`DELETE FROM webhook_endpoints`).run()
+	await env.APP_DB.prepare(`DELETE FROM saved_packages`).run()
+	await env.APP_DB.prepare(`DELETE FROM users`).run()
+
+	const userId = await seedOwner()
+	await clearRunRecords({ env, userId })
+	const urlSecret = 'url-secret-plain'
+	await mintWebhook({
+		userId,
+		webhookName: 'stripe',
+		urlSecret,
+		id: 'mint-stripe',
+	})
+	await mintWebhook({
+		userId,
+		webhookName: 'github',
+		urlSecret,
+		id: 'mint-github',
+	})
+	await mintWebhook({
+		userId,
+		webhookName: 'unix',
+		urlSecret,
+		id: 'mint-unix',
+	})
+
+	mocks.resolveSecret.mockResolvedValue({
+		found: true,
+		value: 'hmac-shared-secret',
+		scope: 'user',
+		allowedHosts: [],
+		allowedPackages: [],
+	})
+	mocks.enqueueWebhookDispatch.mockReset()
+	mocks.enqueueWebhookDispatch.mockResolvedValue(undefined)
+
+	const body = JSON.stringify({ event: 'invoice.paid' })
+	const bodyBuffer = encodeBody(body)
+	const nowSeconds = Math.floor(Date.now() / 1000)
+	const stripePayload = buildWebhookTimestampBodyPayload({
+		timestampToken: String(nowSeconds),
+		body: bodyBuffer,
+	})
+	const stripeV1 = await computeWebhookHmacSignature({
+		algorithm: 'hmac-sha256',
+		secret: 'hmac-shared-secret',
+		body: stripePayload,
+		encoding: 'hex',
+	})
+	const bodyOnlySignature = await computeWebhookHmacSignature({
+		algorithm: 'hmac-sha256',
+		secret: 'hmac-shared-secret',
+		body: bodyBuffer,
+		encoding: 'hex',
+	})
+
+	declareWebhook({
+		name: 'stripe',
+		responseMode: 'ack',
+		verification: {
+			type: 'hmac-sha256',
+			header: 'stripe-signature',
+			secretName: 'stripeWebhookSecret',
+			encoding: 'hex',
+			signedPayload: 'timestamp.body',
+		},
+		replay: {
+			timestampHeader: 'Stripe-Signature',
+			timestampFormat: 'stripe-signature',
+			toleranceSeconds: 300,
+		},
+	})
+
+	const acceptedStripe = await postWebhook({
+		packageKodyId: 'sentry-bridge',
+		webhookName: 'stripe',
+		urlSecret,
+		body,
+		headers: { 'stripe-signature': `t=${nowSeconds},v1=${stripeV1}` },
+	})
+	expect(acceptedStripe.status).toBe(202)
+	expect(await acceptedStripe.json()).toEqual({ ok: true })
+
+	const staleStripe = await postWebhook({
+		packageKodyId: 'sentry-bridge',
+		webhookName: 'stripe',
+		urlSecret,
+		body,
+		headers: {
+			'stripe-signature': `t=${nowSeconds - 1000},v1=${await computeWebhookHmacSignature(
+				{
+					algorithm: 'hmac-sha256',
+					secret: 'hmac-shared-secret',
+					body: buildWebhookTimestampBodyPayload({
+						timestampToken: String(nowSeconds - 1000),
+						body: bodyBuffer,
+					}),
+					encoding: 'hex',
+				},
+			)}`,
+		},
+	})
+	expect(staleStripe.status).toBe(401)
+	expect(await staleStripe.json()).toEqual({
+		ok: false,
+		error: {
+			code: 'invalid_signature',
+			message: 'Webhook signature verification failed.',
+		},
+	})
+
+	const missingTimestamp = await postWebhook({
+		packageKodyId: 'sentry-bridge',
+		webhookName: 'stripe',
+		urlSecret,
+		body,
+	})
+	expect(missingTimestamp.status).toBe(401)
+
+	const bodyOnlyAgainstTimestampPayload = await postWebhook({
+		packageKodyId: 'sentry-bridge',
+		webhookName: 'stripe',
+		urlSecret,
+		body,
+		headers: { 'stripe-signature': `t=${nowSeconds},v1=${bodyOnlySignature}` },
+	})
+	expect(bodyOnlyAgainstTimestampPayload.status).toBe(401)
+
+	declareWebhook({
+		name: 'unix',
+		replay: {
+			timestampHeader: 'X-Timestamp',
+			timestampFormat: 'unix-seconds',
+		},
+	})
+	expect(
+		(
+			await postWebhook({
+				packageKodyId: 'sentry-bridge',
+				webhookName: 'unix',
+				urlSecret,
+				body,
+				headers: { 'x-timestamp': String(nowSeconds) },
+			})
+		).status,
+	).toBe(202)
+	expect(
+		(
+			await postWebhook({
+				packageKodyId: 'sentry-bridge',
+				webhookName: 'unix',
+				urlSecret,
+				body,
+				headers: { 'x-timestamp': String(nowSeconds * 1000) },
+			})
+		).status,
+	).toBe(401)
+
+	declareWebhook({
+		name: 'unix',
+		replay: {
+			timestampHeader: 'X-Timestamp',
+			timestampFormat: 'unix-millis',
+		},
+	})
+	expect(
+		(
+			await postWebhook({
+				packageKodyId: 'sentry-bridge',
+				webhookName: 'unix',
+				urlSecret,
+				body,
+				headers: { 'x-timestamp': String(Date.now()) },
+			})
+		).status,
+	).toBe(202)
+
+	declareWebhook({
+		name: 'unix',
+		replay: {
+			timestampHeader: 'X-Timestamp',
+			timestampFormat: 'iso-8601',
+		},
+	})
+	expect(
+		(
+			await postWebhook({
+				packageKodyId: 'sentry-bridge',
+				webhookName: 'unix',
+				urlSecret,
+				body,
+				headers: { 'x-timestamp': new Date().toISOString() },
+			})
+		).status,
+	).toBe(202)
+
+	declareWebhook({
+		name: 'github',
+		responseMode: 'sync',
+		verification: {
+			type: 'hmac-sha256',
+			header: 'x-hub-signature-256',
+			secretName: 'githubWebhookSecret',
+			encoding: 'hex',
+			prefix: 'sha256=',
+		},
+		replay: {
+			deliveryIdHeader: 'X-GitHub-Delivery',
+		},
+	})
+	const githubBody = JSON.stringify({ ref: 'refs/heads/main' })
+	const githubSignature = await computeWebhookHmacSignature({
+		algorithm: 'hmac-sha256',
+		secret: 'hmac-shared-secret',
+		body: encodeBody(githubBody),
+		encoding: 'hex',
+		prefix: 'sha256=',
+	})
+	const ledger = new Map<string, { status: number; body: unknown }>()
+	let exportInvocations = 0
+	mocks.invokePackageExport.mockReset()
+	mocks.invokePackageExport.mockImplementation(
+		async (input: {
+			request: { idempotencyKey: string; params?: unknown }
+		}) => {
+			const existing = ledger.get(input.request.idempotencyKey)
+			if (existing) {
+				return {
+					status: existing.status,
+					body: {
+						...(existing.body as Record<string, unknown>),
+						idempotency: { replayed: true },
+					},
+				}
+			}
+			exportInvocations += 1
+			const response = {
+				status: 200,
+				body: { ok: true, result: { handled: true } },
+			}
+			ledger.set(input.request.idempotencyKey, response)
+			return response
+		},
+	)
+
+	const firstGithub = await postWebhook({
+		packageKodyId: 'sentry-bridge',
+		webhookName: 'github',
+		urlSecret,
+		body: githubBody,
+		headers: {
+			'x-hub-signature-256': githubSignature,
+			'x-github-delivery': 'delivery-abc',
+		},
+	})
+	const firstGithubBody = await firstGithub.json()
+	expect(firstGithub.status).toBe(200)
+	expect(firstGithubBody).toEqual({ ok: true, result: { handled: true } })
+
+	const replayedGithub = await postWebhook({
+		packageKodyId: 'sentry-bridge',
+		webhookName: 'github',
+		urlSecret,
+		body: githubBody,
+		headers: {
+			'x-hub-signature-256': githubSignature,
+			'x-github-delivery': 'delivery-abc',
+		},
+	})
+	expect(replayedGithub.status).toBe(200)
+	expect(await replayedGithub.json()).toEqual({
+		ok: true,
+		result: { handled: true },
+		idempotency: { replayed: true },
+	})
+	expect(exportInvocations).toBe(1)
+	expect(mocks.invokePackageExport).toHaveBeenCalledTimes(2)
+	const firstCall = mocks.invokePackageExport.mock.calls[0]?.[0] as
+		| { request: { idempotencyKey: string } }
+		| undefined
+	const secondCall = mocks.invokePackageExport.mock.calls[1]?.[0] as
+		| { request: { idempotencyKey: string } }
+		| undefined
+	expect(firstCall?.request.idempotencyKey).toBe(
+		secondCall?.request.idempotencyKey,
+	)
+	expect(firstCall?.request.idempotencyKey).not.toMatch(/^webhook:/)
+
+	const missingDeliveryId = await postWebhook({
+		packageKodyId: 'sentry-bridge',
+		webhookName: 'github',
+		urlSecret,
+		body: githubBody,
+		headers: { 'x-hub-signature-256': githubSignature },
+	})
+	expect(missingDeliveryId.status).toBe(401)
+	expect(exportInvocations).toBe(1)
 })

--- a/packages/worker/src/webhooks/service.ts
+++ b/packages/worker/src/webhooks/service.ts
@@ -27,6 +27,7 @@ export type ListedWebhook = {
 	description: string | null
 	responseMode: 'ack' | 'sync'
 	verification: PackageWebhookManifestEntry['verification']
+	replay: PackageWebhookManifestEntry['replay']
 	minted: boolean
 	enabled: boolean | null
 	createdAt: string | null
@@ -161,6 +162,7 @@ export async function listWebhooksForUser(input: {
 				description: webhook.description,
 				responseMode: webhook.responseMode,
 				verification: webhook.verification,
+				replay: webhook.replay,
 				minted: mint !== undefined,
 				enabled: mint?.enabled ?? null,
 				createdAt: mint?.createdAt ?? null,

--- a/packages/worker/src/webhooks/types.ts
+++ b/packages/worker/src/webhooks/types.ts
@@ -4,13 +4,31 @@ export type WebhookHmacAlgorithm = 'hmac-sha256' | 'hmac-sha1'
 
 export type WebhookSignatureEncoding = 'hex' | 'base64'
 
+export type WebhookSignedPayload = 'body' | 'timestamp.body'
+
+export type WebhookTimestampFormat =
+	| 'unix-seconds'
+	| 'unix-millis'
+	| 'iso-8601'
+	| 'stripe-signature'
+
 export type WebhookVerificationConfig = {
 	type: WebhookHmacAlgorithm
 	header: string
 	secretName: string
 	encoding: WebhookSignatureEncoding
 	prefix?: string
+	signedPayload?: WebhookSignedPayload
 }
+
+export type WebhookReplayConfig = {
+	timestampHeader?: string
+	timestampFormat?: WebhookTimestampFormat
+	toleranceSeconds?: number
+	deliveryIdHeader?: string
+}
+
+export const webhookDefaultReplayToleranceSeconds = 300
 
 /** Minted URL state for a declared package webhook. */
 export type WebhookEndpointRecord = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Let package authors declare replay protection for inbound webhooks in the way their provider actually signs, without changing behavior for any existing declaration.

## Why

Inbound webhook verification was HMAC over the raw body only, so an observed signed delivery could be replayed indefinitely and re-trigger package code with side effects. Providers differ (Stripe/Slack sign a timestamp; GitHub sends a unique delivery id; many send neither), so a mandatory scheme would break real integrations. From the 2026-09-01 audit.

## Summary

New optional fields on `package.json#kody.webhooks[*]`; every existing manifest parses and verifies exactly as before:

- `replay.timestampHeader` + `replay.timestampFormat` (`unix-seconds` | `unix-millis` | `iso-8601` | `stripe-signature`, which parses `t=` out of the Stripe header) with `replay.toleranceSeconds` (default 300). Missing, unparseable, or stale timestamps are rejected before dispatch with the same generic `401` a bad HMAC gets.
- `replay.deliveryIdHeader`: the dispatch idempotency key becomes `sha256(userId + packageId + webhookName + deliveryId)` so the existing RunLog keyed ledger dedupes replays and returns the original acknowledgement without re-running the export.
- `verification.signedPayload: 'body' | 'timestamp.body'` (default `'body'`) for Stripe-style `${t}.${body}` signatures.
- Publish-time validation rejects unknown formats with an actionable message; `search` entity detail and package detail surface the new fields.
- Docs: `architecture/webhooks.md`, `docs/use/webhooks.md` (Stripe and GitHub worked examples; explicit note that body-only HMAC without `replay` is replayable), `security.md` residual-risk bullet.

## Testing

`npm run typecheck`, `lint`, `format:check`, `docs:check-temporal`; node: `webhooks/` + `package-registry/manifest` + `types` — 6 files / 17 tests (existing fixtures byte-for-byte unchanged, each timestamp format in/out of tolerance, missing header when declared, `timestamp.body` accept/reject, unknown format rejected at publish); workers: `webhooks/http.workers.test.ts` — 4 tests including delivery-id dedupe (export invoked once).

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends</b> inbound webhooks (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `3c63022a` · **Head:** `HEAD`

**Classification:** extends — additive manifest fields and verification steps; default path unchanged.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `webhooks` | surfaces | extends — opt-in timestamp tolerance and delivery-id dedupe |
| `package-manifest` | features | extends — new optional fields, publish validation |
| `run-records` | storage | composes — existing keyed idempotency ledger |

### Change flow

```mermaid
sequenceDiagram
	participant provider as Provider
	participant hook as POST /@user/webhooks/…
	participant ledger as RunLog idempotency ledger
	participant pkg as package export
	provider->>hook: body + signature (+ timestamp / delivery id)
	hook->>hook: parse timestamp per declared format; reject if missing/stale (401)
	hook->>hook: HMAC over body or timestamp.body per declaration
	alt deliveryIdHeader declared
		hook->>ledger: key = sha256(user+package+webhook+deliveryId)
		ledger-->>hook: retained ack on replay (export not re-run)
	end
	hook->>pkg: dispatch (first delivery only)
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b0f6a92a-81cd-4157-8b60-188c83ca84c0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b0f6a92a-81cd-4157-8b60-188c83ca84c0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

