### PR TITLE
Isolate the migration checker test's scratch git repo from hook GIT_* env

### DIFF
--- a/tools/check-migrations.node.test.ts
+++ b/tools/check-migrations.node.test.ts
@@ -22,6 +22,12 @@ import {
 	type TrustedMigrationHistory,
 } from './check-migrations.ts'
 
+function withoutInheritedGitEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+	return Object.fromEntries(
+		Object.entries(env).filter(([key]) => !key.startsWith('GIT_')),
+	)
+}
+
 const historicalPair0009 = [
 	'0009-secret-allowed-hosts.sql',
 	'0009-ui-artifact-parameters.sql',
@@ -332,11 +338,16 @@ test(
 		const checkerPath = fileURLToPath(
 			new URL('./check-migrations.ts', import.meta.url),
 		)
+		// Husky exports GIT_DIR / GIT_INDEX_FILE / GIT_WORK_TREE into hook
+		// processes. Without stripping them, `git init` and `git add` here
+		// would target the real repository instead of the scratch one.
+		const scratchGitEnv = withoutInheritedGitEnv(process.env)
 		const runGit = (...args: Array<string>) =>
 			execFileSync('git', args, {
 				cwd: tempRoot,
 				encoding: 'utf8',
 				stdio: 'pipe',
+				env: scratchGitEnv,
 			})
 
 		try {
@@ -395,7 +406,7 @@ test(
 				cwd: tempRoot,
 				encoding: 'utf8',
 				env: {
-					...process.env,
+					...scratchGitEnv,
 					GITHUB_BASE_REF: '',
 					GITHUB_REF_NAME: 'main',
 					MIGRATION_VALIDATION_BASE: '',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

`tools/check-migrations.node.test.ts` bootstraps a scratch git repository under `os.tmpdir()` and runs `git init` / `git config user.name 'Migration Test'` / `git add .` / `git commit` in it. Those child processes inherited the parent environment.

When the test runs inside a husky hook (`npm run test:push` from `pre-push`), git has exported `GIT_DIR` (and `GIT_INDEX_FILE`) for the hook. With those set, the scratch commands ignore `cwd` and operate on the real repository:

- `git init` re-initialised the shared `.git` and, because the cwd was not the work tree, flipped `core.bare = true`
- `git config user.name/user.email` landed in the shared `.git/config`, so later commits on every worktree were authored as `Migration Test <migration-test@example.com>` and failed the CLA check
- `git add .` from the scratch root staged deletions of ~3000 tracked files into the pushing worktree's index; one merge commit built on that index deleted the repository contents

## What

`runGit` and the checker spawn now use a copy of `process.env` with every `GIT_*` variable removed, so the scratch repo is the only repo they can touch.

## Verification

Repro on a throwaway repo, running only the git-init test with `GIT_DIR=/tmp/victim/.git GIT_INDEX_FILE=/tmp/victim/.git/index`:

```
BEFORE fix victim: user.name=[Migration Test] bare=[false] staged=44
AFTER  fix victim: user.name=[]               bare=[false] staged=0
```

`npx vitest run --project node-unit tools/check-migrations.node.test.ts`: 11 passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b0f6a92a-81cd-4157-8b60-188c83ca84c0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b0f6a92a-81cd-4157-8b60-188c83ca84c0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved migration validation reliability by isolating checks from inherited Git environment settings.
  - Validation now runs consistently in temporary repositories, including when local Git hooks or related environment configuration are present.
  - No user-facing functionality or public APIs changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->