### PR TITLE
Link HEAD-ahead badge to a published-vs-HEAD review and publish page

### DIFF
--- a/docs/use/community-packages.md
+++ b/docs/use/community-packages.md
@@ -73,8 +73,9 @@ The detail page opens with the README. The facts row shows **Version** from
 cards), plus license, last publish date, and the pinned commit. Next to
 **Featured** (when present) a pill says **Install**, **Installed**, **Forked**,
 or **Fork outdated**. When default-branch HEAD is newer than the last package
-publish, a **HEAD ahead of published** badge appears. You can also ask your
-agent to use `communitySearch` or `communityGet`.
+publish, a **HEAD ahead of published** badge appears. Owners click that badge to
+review the unpublished file diff and publish HEAD. You can also ask your agent
+to use `communitySearch` or `communityGet`.
 
 ## Forking a listing
 

--- a/docs/use/packages.md
+++ b/docs/use/packages.md
@@ -569,9 +569,18 @@ When an agent pushes or saves a locked package, the commit still lands on
 Artifacts HEAD. Publish tools then return **`locked`** with an
 **`approval_url`** that names that commit:
 `/account/packages/:packageId/approve-publish?commit=<sha>`. Opening that URL
-and clicking **Promote this commit** runs the real publish (checks, bundle
+shows a file-by-file diff of the current published tree versus that commit.
+Clicking **Promote this commit** runs the real publish (checks, bundle
 artifacts, projections) for that SHA. Promoting one commit does not unlock the
 package.
+
+Unlocked packages use the same review page. When default-branch HEAD is newer
+than the last publish, the package Code tab shows a **HEAD ahead of published**
+badge. Owners click it to open
+`/account/packages/:packageId/approve-publish?commit=<HEAD>` and publish that
+SHA with **Publish HEAD**. Visitors see the badge but not the link. The
+five-minute reconcile job still auto-publishes unlocked packages; this page is
+the explicit website path.
 
 Fleet package-codemod apply does the same HEAD write on locked packages: the
 transform commits and pushes so you can review it the next time you publish. It

--- a/docs/use/packages.md
+++ b/docs/use/packages.md
@@ -577,10 +577,10 @@ package.
 Unlocked packages use the same review page. When default-branch HEAD is newer
 than the last publish, the package Code tab shows a **HEAD ahead of published**
 badge. Owners click it to open
-`/account/packages/:packageId/approve-publish?commit=<HEAD>` and publish that
-SHA with **Publish HEAD**. Visitors see the badge but not the link. The
-five-minute reconcile job still auto-publishes unlocked packages; this page is
-the explicit website path.
+`/account/packages/:packageId/approve-publish?commit=<sha>`, where `<sha>` is
+the resolved default-branch HEAD, and publish that SHA with **Publish HEAD**.
+Visitors see the badge but not the link. The five-minute reconcile job still
+auto-publishes unlocked packages; this page is the explicit website path.
 
 Fleet package-codemod apply does the same HEAD write on locked packages: the
 transform commits and pushes so you can review it the next time you publish. It

--- a/packages/worker/client/routes/account-package-approve-publish.node.test.ts
+++ b/packages/worker/client/routes/account-package-approve-publish.node.test.ts
@@ -24,6 +24,17 @@ const loaderData: AccountPackageApprovePublishLoaderData = {
 	alreadyPublished: false,
 	filesHref: '/@kodykoala/gmail-drafts/tree/main',
 	packageHref: '/@kodykoala/gmail-drafts',
+	diff: {
+		files: [
+			{
+				path: 'README.md',
+				status: 'modified',
+				patch:
+					'--- a/README.md\n+++ b/README.md\n@@ -1 +1 @@\n-# Drafts\n+# Gmail drafts\n',
+			},
+		],
+		omittedCount: 0,
+	},
 }
 
 test('approve-publish SSR renders the promote card without a browser location', async () => {
@@ -49,4 +60,28 @@ test('approve-publish SSR renders the promote card without a browser location', 
 	expect(html).toContain('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
 	expect(html).toContain('Promote this commit')
 	expect(html).toContain('Browse published files')
+	expect(html).toContain('data-testid="package-publish-diff"')
+	expect(html).toContain('README.md')
+	expect(html).toContain('# Gmail drafts')
+})
+
+test('unlocked approve-publish SSR offers Publish HEAD', async () => {
+	const html = await renderToString(
+		jsx(RouterLocationProvider, {
+			url: approvePublishHref,
+			children: jsx(AppLoaderDataProvider, {
+				loaderData: {
+					accountPackageApprovePublish: {
+						...loaderData,
+						package: { ...loaderData.package, lockedAt: null },
+					},
+				},
+				children: jsx(AccountPackageApprovePublishRoute, {}),
+			}),
+		}),
+	)
+
+	expect(html).toContain('Publish HEAD')
+	expect(html).toContain('data-testid="approve-package-publish"')
+	expect(html).not.toContain('Promote this commit')
 })

--- a/packages/worker/client/routes/account-package-approve-publish.tsx
+++ b/packages/worker/client/routes/account-package-approve-publish.tsx
@@ -183,8 +183,16 @@ export function AccountPackageApprovePublishRoute(handle: Handle) {
 		return (
 			<AccountManagementShell>
 				<AccountPageHeader
-					title="Approve package publish"
-					description="Review the commit, then promote it to the live published pointer. The package stays locked."
+					title={
+						payload?.package.lockedAt
+							? 'Approve package publish'
+							: 'Publish HEAD'
+					}
+					description={
+						payload?.package.lockedAt
+							? 'Review the files that changed since the last publish, then promote this commit. The package stays locked.'
+							: 'Review the files that changed since the last publish, then publish default-branch HEAD. Runtime keeps using the published commit until you do.'
+					}
 					currentHref={currentHref}
 				/>
 				{message ? (
@@ -242,7 +250,9 @@ export function AccountPackageApprovePublishRoute(handle: Handle) {
 									),
 								},
 								{
-									label: 'Commit to promote',
+									label: payload.package.lockedAt
+										? 'Commit to promote'
+										: 'HEAD to publish',
 									value: payload.pendingCommit ? (
 										<IdValue
 											value={payload.pendingCommit}
@@ -284,8 +294,12 @@ export function AccountPackageApprovePublishRoute(handle: Handle) {
 										]}
 									>
 										{status === 'promoting'
-											? 'Promoting…'
-											: 'Promote this commit'}
+											? payload.package.lockedAt
+												? 'Promoting…'
+												: 'Publishing…'
+											: payload.package.lockedAt
+												? 'Promote this commit'
+												: 'Publish HEAD'}
 									</button>
 									<a
 										href={payload.packageHref}
@@ -310,9 +324,92 @@ export function AccountPackageApprovePublishRoute(handle: Handle) {
 								Browse published files
 							</a>
 						</div>
+						<section
+							data-testid="package-publish-diff"
+							mix={css({ display: 'grid', gap: spacing.sm })}
+						>
+							<h3
+								mix={css({
+									margin: 0,
+									fontSize: typography.fontSize.base,
+									fontWeight: typography.fontWeight.semibold,
+									color: colors.text,
+								})}
+							>
+								{payload.alreadyPublished
+									? 'No unpublished changes'
+									: payload.diff.files.length === 0
+										? 'Could not load a file diff for these commits'
+										: `${payload.diff.files.length} file${payload.diff.files.length === 1 ? '' : 's'} changed`}
+							</h3>
+							{payload.diff.omittedCount > 0 ? (
+								<p mix={css({ margin: 0, color: colors.textMuted })}>
+									{payload.diff.omittedCount} more file
+									{payload.diff.omittedCount === 1 ? '' : 's'} omitted.
+								</p>
+							) : null}
+							{payload.diff.files.map((file) => (
+								<details
+									key={file.path}
+									data-testid="package-publish-diff-file"
+									data-status={file.status}
+									mix={css(diffFileCss)}
+								>
+									<summary mix={css(diffSummaryCss)}>
+										<span mix={css(diffStatusCss)}>{file.status}</span>
+										<code>{file.path}</code>
+									</summary>
+									{file.patch ? (
+										<pre mix={css(diffPatchCss)}>{file.patch}</pre>
+									) : (
+										<p mix={css({ margin: 0, color: colors.textMuted })}>
+											Preview unavailable for this file.
+										</p>
+									)}
+								</details>
+							))}
+						</section>
 					</section>
 				) : null}
 			</AccountManagementShell>
 		)
 	}
+}
+
+const diffFileCss = {
+	margin: 0,
+	borderRadius: '0.55rem',
+	border: `1px solid ${colors.border}`,
+	backgroundColor: colors.background,
+}
+
+const diffSummaryCss = {
+	display: 'flex',
+	alignItems: 'center',
+	gap: spacing.xs,
+	padding: `${spacing.xs} ${spacing.sm}`,
+	cursor: 'pointer',
+	color: colors.text,
+	'& code': {
+		font: `500 0.85rem/1.3 ${typography.fontFamilyMono}`,
+	},
+}
+
+const diffStatusCss = {
+	flexShrink: 0,
+	fontSize: typography.fontSize.xs,
+	fontWeight: typography.fontWeight.semibold,
+	textTransform: 'uppercase' as const,
+	letterSpacing: '0.04em',
+	color: colors.textMuted,
+}
+
+const diffPatchCss = {
+	margin: 0,
+	padding: spacing.sm,
+	overflowX: 'auto' as const,
+	borderTop: `1px solid ${colors.border}`,
+	font: `400 0.78rem/1.45 ${typography.fontFamilyMono}`,
+	whiteSpace: 'pre-wrap' as const,
+	color: colors.text,
 }

--- a/packages/worker/src/app/account-package-publish-lock.node.test.ts
+++ b/packages/worker/src/app/account-package-publish-lock.node.test.ts
@@ -339,3 +339,40 @@ test('approve-publish loads unpublished HEAD from Artifacts when KV has no snaps
 	if (!failedPending.ok) throw new Error('expected loader success')
 	expect(failedPending.diff).toEqual({ files: [], omittedCount: 0 })
 })
+
+test('approve-publish does not treat pending files as added when the published tree is unresolved', async () => {
+	mockModule.getSavedPackageById.mockResolvedValue(unlockedPackage)
+	mockModule.getEntitySourceById.mockResolvedValue({
+		id: 'source-1',
+		user_id: 'user-1',
+		entity_kind: 'package',
+		entity_id: 'pkg-1',
+		repo_id: 'repo-1',
+		published_commit: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+		manifest_path: 'package.json',
+		source_root: '/',
+	})
+	mockModule.loadPublicTreeFiles.mockResolvedValue({
+		files: {},
+		fromListingSnapshot: false,
+	})
+	mockModule.readArtifactTreeAtCommit.mockImplementation(
+		async (input: { commit: string }) => {
+			if (input.commit === 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa') {
+				throw new Error('published fetch failed')
+			}
+			return { 'README.md': '# head\n' }
+		},
+	)
+
+	const loaded = await loadAccountPackageApprovePublishData({
+		env: { APP_DB: {} } as Env,
+		request: new Request(
+			'https://example.com/account/packages/pkg-1/approve-publish?commit=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+		),
+		user: user as never,
+		packageId: 'pkg-1',
+	})
+	if (!loaded.ok) throw new Error('expected loader success')
+	expect(loaded.diff).toEqual({ files: [], omittedCount: 0 })
+})

--- a/packages/worker/src/app/account-package-publish-lock.node.test.ts
+++ b/packages/worker/src/app/account-package-publish-lock.node.test.ts
@@ -376,3 +376,41 @@ test('approve-publish does not treat pending files as added when the published t
 	if (!loaded.ok) throw new Error('expected loader success')
 	expect(loaded.diff).toEqual({ files: [], omittedCount: 0 })
 })
+
+test('approve-publish does not treat published files as removed when HEAD is missing', async () => {
+	mockModule.getSavedPackageById.mockResolvedValue(unlockedPackage)
+	mockModule.getEntitySourceById.mockResolvedValue({
+		id: 'source-1',
+		user_id: 'user-1',
+		entity_kind: 'package',
+		entity_id: 'pkg-1',
+		repo_id: 'repo-1',
+		published_commit: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+		manifest_path: 'package.json',
+		source_root: '/',
+	})
+	mockModule.resolveArtifactSourceHead.mockResolvedValue({ commit: null })
+	mockModule.loadPublicTreeFiles.mockImplementation(
+		async (input: { commit: string | null }) => {
+			if (input.commit === 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa') {
+				return {
+					files: { 'README.md': '# published\n' },
+					fromListingSnapshot: false,
+				}
+			}
+			return { files: {}, fromListingSnapshot: false }
+		},
+	)
+
+	const loaded = await loadAccountPackageApprovePublishData({
+		env: { APP_DB: {} } as Env,
+		request: new Request(
+			'https://example.com/account/packages/pkg-1/approve-publish',
+		),
+		user: user as never,
+		packageId: 'pkg-1',
+	})
+	if (!loaded.ok) throw new Error('expected loader success')
+	expect(loaded.pendingCommit).toBeNull()
+	expect(loaded.diff).toEqual({ files: [], omittedCount: 0 })
+})

--- a/packages/worker/src/app/account-package-publish-lock.node.test.ts
+++ b/packages/worker/src/app/account-package-publish-lock.node.test.ts
@@ -11,6 +11,7 @@ const mockModule = vi.hoisted(() => ({
 		files: {},
 		fromListingSnapshot: false,
 	})),
+	readArtifactTreeAtCommit: vi.fn(async () => ({})),
 	getAppBaseUrl: () => 'https://example.com',
 }))
 
@@ -39,6 +40,11 @@ vi.mock('#worker/repo/artifacts.ts', () => ({
 vi.mock('#app/package-files-data.ts', () => ({
 	loadPublicTreeFiles: (...args: Array<unknown>) =>
 		mockModule.loadPublicTreeFiles(...args),
+}))
+
+vi.mock('#worker/repo/artifact-file.ts', () => ({
+	readArtifactTreeAtCommit: (...args: Array<unknown>) =>
+		mockModule.readArtifactTreeAtCommit(...args),
 }))
 
 vi.mock('#worker/repo/repo-session-rpc.ts', () => ({
@@ -257,4 +263,79 @@ test('website lock and unlock write locked_at and approve-publish promotes a nam
 		},
 		diff: { files: [], omittedCount: 0 },
 	})
+})
+
+test('approve-publish loads unpublished HEAD from Artifacts when KV has no snapshot', async () => {
+	mockModule.getSavedPackageById.mockResolvedValue(unlockedPackage)
+	mockModule.getEntitySourceById.mockResolvedValue({
+		id: 'source-1',
+		user_id: 'user-1',
+		entity_kind: 'package',
+		entity_id: 'pkg-1',
+		repo_id: 'repo-1',
+		published_commit: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+		manifest_path: 'package.json',
+		source_root: '/',
+	})
+	mockModule.loadPublicTreeFiles.mockImplementation(
+		async (input: { commit: string | null }) => {
+			if (input.commit === 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa') {
+				return {
+					files: { 'README.md': '# published\n' },
+					fromListingSnapshot: false,
+				}
+			}
+			return { files: {}, fromListingSnapshot: false }
+		},
+	)
+	mockModule.readArtifactTreeAtCommit.mockImplementation(
+		async (input: { commit: string }) => {
+			if (input.commit === 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb') {
+				return { 'README.md': '# head\n' }
+			}
+			return {}
+		},
+	)
+
+	const loaded = await loadAccountPackageApprovePublishData({
+		env: { APP_DB: {} } as Env,
+		request: new Request(
+			'https://example.com/account/packages/pkg-1/approve-publish?commit=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+		),
+		user: user as never,
+		packageId: 'pkg-1',
+	})
+	expect(loaded).toMatchObject({
+		ok: true,
+		publishedCommit: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+		pendingCommit: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+	})
+	if (!loaded.ok) throw new Error('expected loader success')
+	expect(loaded.diff.files).toEqual([
+		{
+			path: 'README.md',
+			status: 'modified',
+			patch: expect.stringContaining('+# head'),
+		},
+	])
+	expect(mockModule.readArtifactTreeAtCommit).toHaveBeenCalledWith(
+		expect.objectContaining({
+			repoId: 'repo-1',
+			commit: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+		}),
+	)
+
+	mockModule.readArtifactTreeAtCommit.mockRejectedValue(
+		new Error('fetch failed'),
+	)
+	const failedPending = await loadAccountPackageApprovePublishData({
+		env: { APP_DB: {} } as Env,
+		request: new Request(
+			'https://example.com/account/packages/pkg-1/approve-publish?commit=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+		),
+		user: user as never,
+		packageId: 'pkg-1',
+	})
+	if (!failedPending.ok) throw new Error('expected loader success')
+	expect(failedPending.diff).toEqual({ files: [], omittedCount: 0 })
 })

--- a/packages/worker/src/app/account-package-publish-lock.node.test.ts
+++ b/packages/worker/src/app/account-package-publish-lock.node.test.ts
@@ -7,6 +7,10 @@ const mockModule = vi.hoisted(() => ({
 	getEntitySourceById: vi.fn(),
 	resolveArtifactSourceHead: vi.fn(),
 	publishFromExternalRef: vi.fn(),
+	loadPublicTreeFiles: vi.fn(async () => ({
+		files: {},
+		fromListingSnapshot: false,
+	})),
 	getAppBaseUrl: () => 'https://example.com',
 }))
 
@@ -30,6 +34,11 @@ vi.mock('#worker/repo/entity-sources.ts', () => ({
 vi.mock('#worker/repo/artifacts.ts', () => ({
 	resolveArtifactSourceHead: (...args: Array<unknown>) =>
 		mockModule.resolveArtifactSourceHead(...args),
+}))
+
+vi.mock('#app/package-files-data.ts', () => ({
+	loadPublicTreeFiles: (...args: Array<unknown>) =>
+		mockModule.loadPublicTreeFiles(...args),
 }))
 
 vi.mock('#worker/repo/repo-session-rpc.ts', () => ({
@@ -210,11 +219,17 @@ test('website lock and unlock write locked_at and approve-publish promotes a nam
 			commit: 'abc1234',
 		},
 	})
-	expect(unlockedApprove?.status).toBe(400)
-	await expect(unlockedApprove?.json()).resolves.toMatchObject({
-		ok: false,
-		error: 'This package is not locked.',
-	})
+	expect(unlockedApprove?.status).toBe(200)
+	expect(mockModule.publishFromExternalRef).toHaveBeenLastCalledWith(
+		expect.objectContaining({
+			sourceId: 'source-1',
+			userId: 'user-1',
+			newCommit: 'abc1234',
+		}),
+	)
+	expect(
+		mockModule.publishFromExternalRef.mock.calls.at(-1)?.[0],
+	).not.toHaveProperty('allowLockedPublish')
 	mockModule.getSavedPackageById.mockResolvedValue(lockedPackage)
 
 	mockModule.getSavedPackageById.mockResolvedValue(lockedPackage)
@@ -240,5 +255,6 @@ test('website lock and unlock write locked_at and approve-publish promotes a nam
 			id: 'pkg-1',
 			lockedAt: '2026-08-28T12:00:00.000Z',
 		},
+		diff: { files: [], omittedCount: 0 },
 	})
 })

--- a/packages/worker/src/app/account-package-publish-lock.ts
+++ b/packages/worker/src/app/account-package-publish-lock.ts
@@ -1,6 +1,12 @@
+import { loadAccountPackagesData } from '#app/account-packages-data.ts'
+import { type readAuthenticatedAppUser } from '#app/authenticated-user.ts'
+import { loadPublicTreeFiles } from '#app/package-files-data.ts'
+import { buildPublishCommitDiff } from '#app/package-publish-diff.ts'
+import { readTrimmedStringOrEmpty } from '#app/request-body.ts'
 import { type AccountPackageApprovePublishLoaderData } from '#universal/loader-data.ts'
 import { getPackageTreeHref } from '#universal/package-files.ts'
 import { routes } from '#universal/routes.ts'
+import { getAppBaseUrl } from '#worker/app-base-url.ts'
 import { jsonResponse } from '#worker/json-response.ts'
 import {
 	isGitCommitSha,
@@ -13,10 +19,6 @@ import {
 import { resolveArtifactSourceHead } from '#worker/repo/artifacts.ts'
 import { getEntitySourceById } from '#worker/repo/entity-sources.ts'
 import { repoSessionRpc } from '#worker/repo/repo-session-rpc.ts'
-import { getAppBaseUrl } from '#worker/app-base-url.ts'
-import { loadAccountPackagesData } from '#app/account-packages-data.ts'
-import { type readAuthenticatedAppUser } from '#app/authenticated-user.ts'
-import { readTrimmedStringOrEmpty } from '#app/request-body.ts'
 
 type AuthenticatedUser = NonNullable<
 	Awaited<ReturnType<typeof readAuthenticatedAppUser>>
@@ -58,6 +60,30 @@ export async function loadAccountPackageApprovePublishData(input: {
 		pendingCommit = head.commit
 	}
 	const publishedCommit = source.published_commit
+	const alreadyPublished =
+		pendingCommit != null &&
+		publishedCommit != null &&
+		pendingCommit === publishedCommit
+	const [publishedFiles, pendingFiles] = alreadyPublished
+		? [{ files: {} }, { files: {} }]
+		: await Promise.all([
+				loadPublicTreeFiles({
+					env: input.env,
+					request: input.request,
+					sourceId: source.id,
+					sourceRepoId: source.repo_id,
+					commit: publishedCommit,
+					pinnedCommit: publishedCommit ?? '',
+				}),
+				loadPublicTreeFiles({
+					env: input.env,
+					request: input.request,
+					sourceId: source.id,
+					sourceRepoId: source.repo_id,
+					commit: pendingCommit,
+					pinnedCommit: publishedCommit ?? '',
+				}),
+			])
 	return {
 		ok: true,
 		email: input.user.email,
@@ -70,10 +96,7 @@ export async function loadAccountPackageApprovePublishData(input: {
 		},
 		publishedCommit,
 		pendingCommit,
-		alreadyPublished:
-			pendingCommit != null &&
-			publishedCommit != null &&
-			pendingCommit === publishedCommit,
+		alreadyPublished,
 		filesHref: getPackageTreeHref({
 			username: input.user.username,
 			kodyId: savedPackage.kodyId,
@@ -82,6 +105,7 @@ export async function loadAccountPackageApprovePublishData(input: {
 			username: input.user.username,
 			kodyId: savedPackage.kodyId,
 		}),
+		diff: buildPublishCommitDiff(publishedFiles.files, pendingFiles.files),
 	}
 }
 
@@ -151,12 +175,7 @@ export async function handleAccountPackagePublishLockAction(input: {
 			400,
 		)
 	}
-	if (!isSavedPackageLocked(savedPackage.lockedAt)) {
-		return jsonResponse(
-			{ ok: false, error: 'This package is not locked.' },
-			400,
-		)
-	}
+	const locked = isSavedPackageLocked(savedPackage.lockedAt)
 	const source = await getEntitySourceById(
 		input.env.APP_DB,
 		savedPackage.sourceId,
@@ -173,7 +192,7 @@ export async function handleAccountPackagePublishLockAction(input: {
 		sourceId: source.id,
 		userId,
 		newCommit: commit,
-		allowLockedPublish: true,
+		...(locked ? { allowLockedPublish: true } : {}),
 		baseUrl: getAppBaseUrl({
 			env: input.env,
 			requestUrl: input.request.url,

--- a/packages/worker/src/app/account-package-publish-lock.ts
+++ b/packages/worker/src/app/account-package-publish-lock.ts
@@ -16,6 +16,7 @@ import {
 	getSavedPackageById,
 	setSavedPackageLockedAt,
 } from '#worker/package-registry/repo.ts'
+import { readArtifactTreeAtCommit } from '#worker/repo/artifact-file.ts'
 import { resolveArtifactSourceHead } from '#worker/repo/artifacts.ts'
 import { getEntitySourceById } from '#worker/repo/entity-sources.ts'
 import { repoSessionRpc } from '#worker/repo/repo-session-rpc.ts'
@@ -65,25 +66,31 @@ export async function loadAccountPackageApprovePublishData(input: {
 		publishedCommit != null &&
 		pendingCommit === publishedCommit
 	const [publishedFiles, pendingFiles] = alreadyPublished
-		? [{ files: {} }, { files: {} }]
+		? [
+				{ files: {}, resolved: true },
+				{ files: {}, resolved: true },
+			]
 		: await Promise.all([
-				loadPublicTreeFiles({
+				loadPublishCompareTree({
 					env: input.env,
 					request: input.request,
 					sourceId: source.id,
 					sourceRepoId: source.repo_id,
 					commit: publishedCommit,
-					pinnedCommit: publishedCommit ?? '',
 				}),
-				loadPublicTreeFiles({
+				loadPublishCompareTree({
 					env: input.env,
 					request: input.request,
 					sourceId: source.id,
 					sourceRepoId: source.repo_id,
 					commit: pendingCommit,
-					pinnedCommit: publishedCommit ?? '',
 				}),
 			])
+	const pendingMissing =
+		pendingCommit != null &&
+		!pendingFiles.resolved &&
+		publishedFiles.resolved &&
+		Object.keys(publishedFiles.files).length > 0
 	return {
 		ok: true,
 		email: input.user.email,
@@ -105,7 +112,42 @@ export async function loadAccountPackageApprovePublishData(input: {
 			username: input.user.username,
 			kodyId: savedPackage.kodyId,
 		}),
-		diff: buildPublishCommitDiff(publishedFiles.files, pendingFiles.files),
+		diff: pendingMissing
+			? { files: [], omittedCount: 0 }
+			: buildPublishCommitDiff(publishedFiles.files, pendingFiles.files),
+	}
+}
+
+async function loadPublishCompareTree(input: {
+	env: Env
+	request: Request
+	sourceId: string
+	sourceRepoId: string | null
+	commit: string | null
+}): Promise<{ files: Record<string, string>; resolved: boolean }> {
+	if (!input.commit) return { files: {}, resolved: false }
+	const publicTree = await loadPublicTreeFiles({
+		env: input.env,
+		request: input.request,
+		sourceId: input.sourceId,
+		sourceRepoId: input.sourceRepoId,
+		commit: input.commit,
+		pinnedCommit: input.commit,
+	})
+	if (Object.keys(publicTree.files).length > 0) {
+		return { files: publicTree.files, resolved: true }
+	}
+	if (!input.sourceRepoId) return { files: {}, resolved: false }
+	try {
+		const files = await readArtifactTreeAtCommit({
+			env: input.env,
+			repoId: input.sourceRepoId,
+			commit: input.commit,
+		})
+		if (files == null) return { files: {}, resolved: false }
+		return { files, resolved: true }
+	} catch {
+		return { files: {}, resolved: false }
 	}
 }
 

--- a/packages/worker/src/app/account-package-publish-lock.ts
+++ b/packages/worker/src/app/account-package-publish-lock.ts
@@ -86,11 +86,8 @@ export async function loadAccountPackageApprovePublishData(input: {
 					commit: pendingCommit,
 				}),
 			])
-	const pendingMissing =
-		pendingCommit != null &&
-		!pendingFiles.resolved &&
-		publishedFiles.resolved &&
-		Object.keys(publishedFiles.files).length > 0
+	const unpublishedCompare = publishedCommit != null && !publishedFiles.resolved
+	const pendingMissing = pendingCommit != null && !pendingFiles.resolved
 	return {
 		ok: true,
 		email: input.user.email,
@@ -112,9 +109,10 @@ export async function loadAccountPackageApprovePublishData(input: {
 			username: input.user.username,
 			kodyId: savedPackage.kodyId,
 		}),
-		diff: pendingMissing
-			? { files: [], omittedCount: 0 }
-			: buildPublishCommitDiff(publishedFiles.files, pendingFiles.files),
+		diff:
+			unpublishedCompare || pendingMissing
+				? { files: [], omittedCount: 0 }
+				: buildPublishCommitDiff(publishedFiles.files, pendingFiles.files),
 	}
 }
 

--- a/packages/worker/src/app/account-package-publish-lock.ts
+++ b/packages/worker/src/app/account-package-publish-lock.ts
@@ -87,7 +87,7 @@ export async function loadAccountPackageApprovePublishData(input: {
 				}),
 			])
 	const unpublishedCompare = publishedCommit != null && !publishedFiles.resolved
-	const pendingMissing = pendingCommit != null && !pendingFiles.resolved
+	const pendingMissing = !pendingFiles.resolved
 	return {
 		ok: true,
 		email: input.user.email,

--- a/packages/worker/src/app/community-detail-content.node.test.ts
+++ b/packages/worker/src/app/community-detail-content.node.test.ts
@@ -1,5 +1,8 @@
 import { expect, test } from 'vitest'
-import { renderCommunityDetailContentHtml } from '#app/community-detail-content.tsx'
+import {
+	buildSourceAheadPublishHref,
+	renderCommunityDetailContentHtml,
+} from '#app/community-detail-content.tsx'
 import { type PublicCommunityListing } from '#universal/community-public-types.ts'
 
 const sampleListing = {
@@ -78,6 +81,28 @@ test('community detail head covers install, installed, and listing-ahead badges'
 	})
 	expect(sourceAheadHtml).toContain(
 		'data-testid="community-detail-source-ahead-badge"',
+	)
+	expect(sourceAheadHtml).toMatch(
+		/<span[^>]*data-testid="community-detail-source-ahead-badge"/,
+	)
+	expect(sourceAheadHtml).not.toContain('approve-publish')
+
+	const ownerAheadHref =
+		'/account/packages/pkg-1/approve-publish?commit=deadbeefdeadbeefdeadbeefdeadbeefdeadbeef'
+	const ownerAheadHtml = await renderCommunityDetailContentHtml({
+		...detailBase,
+		listing: {
+			...sampleListing,
+			sourceAhead: true,
+			headCommit: 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+		},
+		viewerIsOwner: true,
+		loggedIn: true,
+		publishCompareHref: ownerAheadHref,
+	})
+	expect(ownerAheadHtml).toContain(`href="${ownerAheadHref}"`)
+	expect(ownerAheadHtml).toMatch(
+		/<a[^>]*data-testid="community-detail-source-ahead-badge"/,
 	)
 
 	const ownInstalledHtml = await renderCommunityDetailContentHtml({
@@ -179,4 +204,27 @@ test('package chrome is shared for public listings and private owner packages', 
 	expect(privateHtml).not.toContain('data-testid="community-detail-forks"')
 	expect(privateHtml).not.toContain('data-testid="community-listing-category"')
 	expect(privateHtml).toContain('Local notes.')
+})
+
+test('buildSourceAheadPublishHref names the HEAD commit when present', () => {
+	expect(
+		buildSourceAheadPublishHref({
+			packageId: 'pkg-1',
+			headCommit: 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+		}),
+	).toBe(
+		'/account/packages/pkg-1/approve-publish?commit=deadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+	)
+	expect(
+		buildSourceAheadPublishHref({
+			packageId: 'pkg-1',
+			headCommit: null,
+		}),
+	).toBe('/account/packages/pkg-1/approve-publish')
+	expect(
+		buildSourceAheadPublishHref({
+			packageId: '',
+			headCommit: 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+		}),
+	).toBeNull()
 })

--- a/packages/worker/src/app/community-detail-content.tsx
+++ b/packages/worker/src/app/community-detail-content.tsx
@@ -22,7 +22,9 @@ import {
 	getPackageTreeHref,
 } from '#universal/package-files.ts'
 import { renderPackageRepoChrome } from '#universal/package-repo-nav.tsx'
+import { routes } from '#universal/routes.ts'
 import { colors } from '#universal/styles/tokens.ts'
+import { buildPackagePublishApprovalPath } from '#worker/package-registry/package-publish-lock.ts'
 
 /**
  * Server-rendered package head (the `community-detail` frame): GitHub-style
@@ -41,6 +43,7 @@ export type CommunityDetailContentProps = {
 	viewerIsOwner: boolean
 	returnTo: string
 	treeRef?: string
+	publishCompareHref?: string | null
 }
 
 export function CommunityDetailContent(
@@ -57,6 +60,7 @@ export function CommunityDetailContent(
 		viewerIsOwner,
 		returnTo,
 		treeRef,
+		publishCompareHref,
 	} = handle.props
 
 	const filesHref = getPackageTreeHref({
@@ -84,13 +88,24 @@ export function CommunityDetailContent(
 					<CommunityListingIcon listing={listing} size="detail" />
 					<div mix={css(listingBadgeGroupCss)}>
 						{listing.sourceAhead ? (
-							<span
-								data-testid="community-detail-source-ahead-badge"
-								title="Default-branch HEAD is newer than the last package publish. Source at HEAD is already public; runtime still uses the published commit."
-								mix={css(badgeCss)}
-							>
-								HEAD ahead of published
-							</span>
+							publishCompareHref ? (
+								<a
+									href={publishCompareHref}
+									data-testid="community-detail-source-ahead-badge"
+									title="Review the unpublished HEAD changes, then publish them."
+									mix={css(badgeLinkCss)}
+								>
+									HEAD ahead of published
+								</a>
+							) : (
+								<span
+									data-testid="community-detail-source-ahead-badge"
+									title="Default-branch HEAD is newer than the last package publish. Source at HEAD is already public; runtime still uses the published commit."
+									mix={css(badgeCss)}
+								>
+									HEAD ahead of published
+								</span>
+							)
 						) : null}
 						{listing.featured ? (
 							<span
@@ -228,6 +243,31 @@ const badgeCss = {
 	backgroundColor: colors.surface,
 	border: `1px solid ${colors.border}`,
 	color: colors.textMuted,
+}
+
+const badgeLinkCss = {
+	...badgeCss,
+	textDecoration: 'none',
+	'&:hover': {
+		color: colors.text,
+		borderColor: colors.textMuted,
+	},
+}
+
+export function buildSourceAheadPublishHref(input: {
+	packageId: string | null | undefined
+	headCommit: string | null | undefined
+}) {
+	if (!input.packageId) return null
+	if (input.headCommit) {
+		return buildPackagePublishApprovalPath({
+			packageId: input.packageId,
+			commit: input.headCommit,
+		})
+	}
+	return routes.accountPackageApprovePublish.href({
+		packageId: input.packageId,
+	})
 }
 
 const filesLinkRowCss = {

--- a/packages/worker/src/app/frames/community-detail.ts
+++ b/packages/worker/src/app/frames/community-detail.ts
@@ -1,13 +1,44 @@
+import { readAuthenticatedAppUser } from '#app/authenticated-user.ts'
 import { loadCommunityDetailData } from '#app/community-data.ts'
+import {
+	buildSourceAheadPublishHref,
+	renderCommunityDetailContentHtml,
+} from '#app/community-detail-content.tsx'
 import { resolveCommunityListingRoute } from '#app/community-package-route.ts'
-import { loadPackagePage } from '#app/package-page.ts'
-import { renderCommunityDetailContentHtml } from '#app/community-detail-content.tsx'
-import { COMMUNITY_DETAIL_TARGET } from '#universal/community-frame-constants.ts'
 import { registerFrame } from '#app/frame-registry.ts'
+import { loadPackagePage } from '#app/package-page.ts'
+import { type PublicCommunityListing } from '#app/community-public.ts'
+import { COMMUNITY_DETAIL_TARGET } from '#universal/community-frame-constants.ts'
 import { routes } from '#universal/routes.ts'
+import { getSavedPackageByKodyId } from '#worker/package-registry/repo.ts'
 import { createMatcher } from 'remix/route-pattern/match'
 
 const communityPackageMatcher = createMatcher(routes.communityPackage.pattern)
+
+async function resolvePublishCompareHref(input: {
+	env: Env
+	request: Request
+	viewerIsOwner: boolean
+	listing: PublicCommunityListing | null
+	packageId?: string | null
+}) {
+	if (!input.viewerIsOwner || !input.listing?.sourceAhead) return null
+	let packageId = input.packageId ?? null
+	if (!packageId) {
+		const user = await readAuthenticatedAppUser(input.request, input.env)
+		if (user) {
+			const ownerPackage = await getSavedPackageByKodyId(input.env.APP_DB, {
+				userId: user.mcpUser.userId,
+				kodyId: input.listing.kodyId,
+			})
+			packageId = ownerPackage?.id ?? null
+		}
+	}
+	return buildSourceAheadPublishHref({
+		packageId,
+		headCommit: input.listing.headCommit,
+	})
+}
 
 registerFrame(COMMUNITY_DETAIL_TARGET, {
 	routes: [routes.communityPackage, routes.communityDetail],
@@ -21,19 +52,25 @@ registerFrame(COMMUNITY_DETAIL_TARGET, {
 				kodyId: packageParams.kodyId,
 			})
 			if (page.kind !== 'page') return ''
+			const listing = page.listing?.listing ?? null
 			return renderCommunityDetailContentHtml({
-				listing: page.listing?.listing ?? null,
+				listing,
 				username: page.username,
 				kodyId: page.kodyId,
 				description:
-					page.listing?.listing?.description ??
-					page.ownerPackage?.description ??
-					'',
+					listing?.description ?? page.ownerPackage?.description ?? '',
 				isPrivate: page.ownerPackage?.isPrivate ?? false,
 				ownerProfilePublic: page.listing?.ownerProfilePublic ?? true,
 				loggedIn: page.loggedIn,
 				viewerIsOwner: page.viewerIsOwner,
 				returnTo: url.pathname,
+				publishCompareHref: await resolvePublishCompareHref({
+					env,
+					request,
+					viewerIsOwner: page.viewerIsOwner,
+					listing,
+					packageId: page.ownerPackage?.id,
+				}),
 			})
 		}
 
@@ -57,6 +94,12 @@ registerFrame(COMMUNITY_DETAIL_TARGET, {
 			loggedIn: detail.loggedIn,
 			viewerIsOwner: detail.viewerIsOwner,
 			returnTo: url.pathname,
+			publishCompareHref: await resolvePublishCompareHref({
+				env,
+				request,
+				viewerIsOwner: detail.viewerIsOwner,
+				listing: detail.listing,
+			}),
 		})
 	},
 })

--- a/packages/worker/src/app/handlers/community-detail.frame.node.test.ts
+++ b/packages/worker/src/app/handlers/community-detail.frame.node.test.ts
@@ -13,6 +13,7 @@ const mockModule = vi.hoisted(() => ({
 	resolveArtifactSourceHead: vi.fn(),
 	listSavedPackagesByKodyIds: vi.fn(),
 	listSavedPackagesByIds: vi.fn(),
+	getSavedPackageByKodyId: vi.fn(),
 	getMcpUserPackageScope: vi.fn(),
 }))
 
@@ -56,6 +57,8 @@ vi.mock('#worker/package-registry/repo.ts', () => ({
 		mockModule.listSavedPackagesByKodyIds(...args),
 	listSavedPackagesByIds: (...args: Array<unknown>) =>
 		mockModule.listSavedPackagesByIds(...args),
+	getSavedPackageByKodyId: (...args: Array<unknown>) =>
+		mockModule.getSavedPackageByKodyId(...args),
 }))
 
 vi.mock('#worker/package-registry/user-scope.ts', () => ({
@@ -99,6 +102,7 @@ const env = {} as Env
 // in-isolate listing cache must not carry one test's answer into the next.
 beforeEach(() => {
 	resetDataCacheForTests()
+	mockModule.getSavedPackageByKodyId.mockReset()
 })
 
 test('community detail handler returns bare detail frame HTML for target header', async () => {
@@ -222,4 +226,86 @@ test('community detail browse-files uses the looked-up default branch', async ()
 	expect(html).toContain('href="/@kentcdodds/github-triage/tree/release"')
 	expect(html).not.toContain('href="/@kentcdodds/github-triage/tree/HEAD"')
 	expect(html).not.toContain('href="/@kentcdodds/github-triage/tree/main"')
+})
+
+test('owner source-ahead badge links to the published-vs-HEAD approve-publish page', async () => {
+	const headCommit = 'ffffffffffffffffffffffffffffffffffffffff'
+	mockModule.getCommunityListingWithAggregates.mockResolvedValue(sampleListing)
+	mockModule.getCommunityListingById.mockResolvedValue(sampleListing)
+	mockModule.getEntitySourceById.mockResolvedValue({ repo_id: 'repo-1' })
+	mockModule.resolveArtifactSourceHead.mockResolvedValue({
+		branch: 'main',
+		commit: headCommit,
+	})
+	mockModule.readAuthenticatedAppUser.mockResolvedValue({
+		mcpUser: { userId: 'owner-mcp-id', username: 'kentcdodds' },
+		roles: [],
+	})
+	mockModule.listCommunityForksByListingIdsAndUser.mockResolvedValue([])
+	mockModule.listSavedPackagesByKodyIds.mockResolvedValue([])
+	mockModule.listSavedPackagesByIds.mockResolvedValue([])
+	mockModule.getSavedPackageByKodyId.mockResolvedValue({ id: 'pkg-1' })
+	mockModule.getMcpUserPackageScope.mockResolvedValue('kentcdodds')
+	mockModule.getUserSocialRowByUsername.mockResolvedValue({
+		profile_visibility: 'public',
+		stable_user_id: 'owner-mcp-id',
+	})
+
+	const handler = createCommunityDetailHandler(env)
+	const response = await handler.handler({
+		request: new Request('https://example.com/community/listing-1', {
+			headers: { 'x-remix-target': 'community-detail' },
+		}),
+		params: { listingId: 'listing-1' },
+		url: new URL('https://example.com/community/listing-1'),
+	} as never)
+	const html = await response.text()
+	expect(html).toContain(
+		`href="/account/packages/pkg-1/approve-publish?commit=${headCommit}"`,
+	)
+	expect(html).toMatch(
+		/<a[^>]*data-testid="community-detail-source-ahead-badge"/,
+	)
+	expect(mockModule.getSavedPackageByKodyId).toHaveBeenCalledWith(
+		undefined,
+		expect.objectContaining({
+			userId: 'owner-mcp-id',
+			kodyId: 'github-triage',
+		}),
+	)
+})
+
+test('visitor source-ahead badge is not a publish link', async () => {
+	mockModule.getCommunityListingWithAggregates.mockResolvedValue(sampleListing)
+	mockModule.getCommunityListingById.mockResolvedValue(sampleListing)
+	mockModule.getEntitySourceById.mockResolvedValue({ repo_id: 'repo-1' })
+	mockModule.resolveArtifactSourceHead.mockResolvedValue({
+		branch: 'main',
+		commit: 'ffffffffffffffffffffffffffffffffffffffff',
+	})
+	mockModule.readAuthenticatedAppUser.mockResolvedValue(null)
+	mockModule.listCommunityForksByListingIdsAndUser.mockResolvedValue([])
+	mockModule.listSavedPackagesByKodyIds.mockResolvedValue([])
+	mockModule.listSavedPackagesByIds.mockResolvedValue([])
+	mockModule.getMcpUserPackageScope.mockResolvedValue('viewer')
+	mockModule.getUserSocialRowByUsername.mockResolvedValue({
+		profile_visibility: 'public',
+		stable_user_id: 'owner-mcp-id',
+	})
+
+	const handler = createCommunityDetailHandler(env)
+	const response = await handler.handler({
+		request: new Request('https://example.com/community/listing-1', {
+			headers: { 'x-remix-target': 'community-detail' },
+		}),
+		params: { listingId: 'listing-1' },
+		url: new URL('https://example.com/community/listing-1'),
+	} as never)
+	const html = await response.text()
+	expect(html).toContain('data-testid="community-detail-source-ahead-badge"')
+	expect(html).toMatch(
+		/<span[^>]*data-testid="community-detail-source-ahead-badge"/,
+	)
+	expect(html).not.toContain('approve-publish')
+	expect(mockModule.getSavedPackageByKodyId).not.toHaveBeenCalled()
 })

--- a/packages/worker/src/app/package-files-data.ts
+++ b/packages/worker/src/app/package-files-data.ts
@@ -242,7 +242,7 @@ async function resolvePublicTreeCommit(input: {
 	}
 }
 
-function loadPublicTreeFiles(input: {
+export function loadPublicTreeFiles(input: {
 	env: Env
 	request: Request
 	listingId?: string | null

--- a/packages/worker/src/app/package-publish-diff.node.test.ts
+++ b/packages/worker/src/app/package-publish-diff.node.test.ts
@@ -1,0 +1,46 @@
+import { expect, test } from 'vitest'
+import { buildPublishCommitDiff } from '#app/package-publish-diff.ts'
+
+test('buildPublishCommitDiff classifies added, removed, and modified files', () => {
+	const diff = buildPublishCommitDiff(
+		{
+			'README.md': '# Hello\n',
+			'gone.ts': 'export const gone = true\n',
+			'same.ts': 'export const same = 1\n',
+		},
+		{
+			'README.md': '# Hello world\n',
+			'new.ts': 'export const added = true\n',
+			'same.ts': 'export const same = 1\n',
+		},
+	)
+
+	expect(diff.omittedCount).toBe(0)
+	expect(diff.files.map((file) => [file.path, file.status])).toEqual([
+		['gone.ts', 'removed'],
+		['new.ts', 'added'],
+		['README.md', 'modified'],
+	])
+	expect(diff.files[0]?.patch).toContain('-export const gone = true')
+	expect(diff.files[1]?.patch).toContain('+export const added = true')
+	expect(diff.files[2]?.patch).toContain('-# Hello')
+	expect(diff.files[2]?.patch).toContain('+# Hello world')
+})
+
+test('buildPublishCommitDiff omits identical trees and binary or oversized files', () => {
+	expect(buildPublishCommitDiff({ 'a.ts': 'one' }, { 'a.ts': 'one' })).toEqual({
+		files: [],
+		omittedCount: 0,
+	})
+
+	const huge = 'x'.repeat(80_001)
+	const binary = 'ok\0nope'
+	const diff = buildPublishCommitDiff(
+		{ 'huge.txt': 'old', 'bin.dat': 'plain' },
+		{ 'huge.txt': huge, 'bin.dat': binary },
+	)
+	expect(diff.files).toEqual([
+		{ path: 'bin.dat', status: 'modified', patch: null },
+		{ path: 'huge.txt', status: 'modified', patch: null },
+	])
+})

--- a/packages/worker/src/app/package-publish-diff.node.test.ts
+++ b/packages/worker/src/app/package-publish-diff.node.test.ts
@@ -17,14 +17,14 @@ test('buildPublishCommitDiff classifies added, removed, and modified files', () 
 
 	expect(diff.omittedCount).toBe(0)
 	expect(diff.files.map((file) => [file.path, file.status])).toEqual([
+		['README.md', 'modified'],
 		['gone.ts', 'removed'],
 		['new.ts', 'added'],
-		['README.md', 'modified'],
 	])
-	expect(diff.files[0]?.patch).toContain('-export const gone = true')
-	expect(diff.files[1]?.patch).toContain('+export const added = true')
-	expect(diff.files[2]?.patch).toContain('-# Hello')
-	expect(diff.files[2]?.patch).toContain('+# Hello world')
+	expect(diff.files[0]?.patch).toContain('-# Hello')
+	expect(diff.files[0]?.patch).toContain('+# Hello world')
+	expect(diff.files[1]?.patch).toContain('-export const gone = true')
+	expect(diff.files[2]?.patch).toContain('+export const added = true')
 })
 
 test('buildPublishCommitDiff omits identical trees and binary or oversized files', () => {
@@ -42,5 +42,31 @@ test('buildPublishCommitDiff omits identical trees and binary or oversized files
 	expect(diff.files).toEqual([
 		{ path: 'bin.dat', status: 'modified', patch: null },
 		{ path: 'huge.txt', status: 'modified', patch: null },
+	])
+})
+
+test('buildPublishCommitDiff uses code-unit path order and own-property reads', () => {
+	const diff = buildPublishCommitDiff(
+		{
+			'é.md': 'old accent',
+			'z.md': 'old z',
+		},
+		{
+			'A.md': 'new A',
+			'é.md': 'new accent',
+		},
+	)
+	expect(diff.files.map((file) => file.path)).toEqual(['A.md', 'z.md', 'é.md'])
+
+	const inheritedName = buildPublishCommitDiff(
+		Object.fromEntries([['toString', 'old']]) as Record<string, string>,
+		{},
+	)
+	expect(inheritedName.files).toEqual([
+		{
+			path: 'toString',
+			status: 'removed',
+			patch: expect.stringContaining('-old'),
+		},
 	])
 })

--- a/packages/worker/src/app/package-publish-diff.node.test.ts
+++ b/packages/worker/src/app/package-publish-diff.node.test.ts
@@ -43,6 +43,25 @@ test('buildPublishCommitDiff omits identical trees and binary or oversized files
 		{ path: 'bin.dat', status: 'modified', patch: null },
 		{ path: 'huge.txt', status: 'modified', patch: null },
 	])
+
+	const iconA = new TextDecoder('latin1').decode(
+		Uint8Array.from([0x89, 0x50, 0x4e, 0x47, 0, 1]),
+	)
+	const iconB = new TextDecoder('latin1').decode(
+		Uint8Array.from([0x89, 0x50, 0x4e, 0x47, 0, 2]),
+	)
+	expect(
+		buildPublishCommitDiff(
+			{ 'community-icon.png': iconA },
+			{ 'community-icon.png': iconA },
+		),
+	).toEqual({ files: [], omittedCount: 0 })
+	expect(
+		buildPublishCommitDiff(
+			{ 'community-icon.png': iconA },
+			{ 'community-icon.png': iconB },
+		).files,
+	).toEqual([{ path: 'community-icon.png', status: 'modified', patch: null }])
 })
 
 test('buildPublishCommitDiff uses code-unit path order and own-property reads', () => {

--- a/packages/worker/src/app/package-publish-diff.ts
+++ b/packages/worker/src/app/package-publish-diff.ts
@@ -1,0 +1,98 @@
+import { createTwoFilesPatch } from 'diff'
+
+export type PublishCommitDiffFileStatus = 'added' | 'removed' | 'modified'
+
+export type PublishCommitDiffFile = {
+	path: string
+	status: PublishCommitDiffFileStatus
+	patch: string | null
+}
+
+export type PublishCommitDiff = {
+	files: Array<PublishCommitDiffFile>
+	omittedCount: number
+}
+
+export const publishCommitDiffMaxFiles = 40
+const publishCommitDiffMaxFileChars = 80_000
+
+function isPreviewableFileContent(content: string) {
+	if (content.includes('\0')) return false
+	return content.length <= publishCommitDiffMaxFileChars
+}
+
+function comparePaths(left: string, right: string) {
+	return left.localeCompare(right)
+}
+
+function buildFilePatch(input: {
+	path: string
+	publishedContent: string
+	pendingContent: string
+}) {
+	if (
+		!isPreviewableFileContent(input.publishedContent) ||
+		!isPreviewableFileContent(input.pendingContent)
+	) {
+		return null
+	}
+	return createTwoFilesPatch(
+		`a/${input.path}`,
+		`b/${input.path}`,
+		input.publishedContent,
+		input.pendingContent,
+	)
+}
+
+export function buildPublishCommitDiff(
+	publishedFiles: Record<string, string>,
+	pendingFiles: Record<string, string>,
+): PublishCommitDiff {
+	const paths = new Set([
+		...Object.keys(publishedFiles),
+		...Object.keys(pendingFiles),
+	])
+	const changed: Array<PublishCommitDiffFile> = []
+	for (const path of [...paths].sort(comparePaths)) {
+		const publishedContent = publishedFiles[path]
+		const pendingContent = pendingFiles[path]
+		if (publishedContent === pendingContent) continue
+		if (publishedContent == null) {
+			changed.push({
+				path,
+				status: 'added',
+				patch: buildFilePatch({
+					path,
+					publishedContent: '',
+					pendingContent: pendingContent ?? '',
+				}),
+			})
+			continue
+		}
+		if (pendingContent == null) {
+			changed.push({
+				path,
+				status: 'removed',
+				patch: buildFilePatch({
+					path,
+					publishedContent,
+					pendingContent: '',
+				}),
+			})
+			continue
+		}
+		changed.push({
+			path,
+			status: 'modified',
+			patch: buildFilePatch({
+				path,
+				publishedContent,
+				pendingContent,
+			}),
+		})
+	}
+	return {
+		files: changed.slice(0, publishCommitDiffMaxFiles),
+		omittedCount: Math.max(0, changed.length - publishCommitDiffMaxFiles),
+	}
+}

--- a/packages/worker/src/app/package-publish-diff.ts
+++ b/packages/worker/src/app/package-publish-diff.ts
@@ -22,7 +22,13 @@ function isPreviewableFileContent(content: string) {
 }
 
 function comparePaths(left: string, right: string) {
-	return left.localeCompare(right)
+	if (left < right) return -1
+	if (left > right) return 1
+	return 0
+}
+
+function ownFileContent(files: Record<string, string>, path: string) {
+	return Object.hasOwn(files, path) ? files[path] : undefined
 }
 
 function buildFilePatch(input: {
@@ -54,10 +60,12 @@ export function buildPublishCommitDiff(
 	])
 	const changed: Array<PublishCommitDiffFile> = []
 	for (const path of [...paths].sort(comparePaths)) {
-		const publishedContent = publishedFiles[path]
-		const pendingContent = pendingFiles[path]
+		const hasPublished = Object.hasOwn(publishedFiles, path)
+		const hasPending = Object.hasOwn(pendingFiles, path)
+		const publishedContent = ownFileContent(publishedFiles, path)
+		const pendingContent = ownFileContent(pendingFiles, path)
 		if (publishedContent === pendingContent) continue
-		if (publishedContent == null) {
+		if (!hasPublished) {
 			changed.push({
 				path,
 				status: 'added',
@@ -69,13 +77,13 @@ export function buildPublishCommitDiff(
 			})
 			continue
 		}
-		if (pendingContent == null) {
+		if (!hasPending) {
 			changed.push({
 				path,
 				status: 'removed',
 				patch: buildFilePatch({
 					path,
-					publishedContent,
+					publishedContent: publishedContent ?? '',
 					pendingContent: '',
 				}),
 			})
@@ -86,8 +94,8 @@ export function buildPublishCommitDiff(
 			status: 'modified',
 			patch: buildFilePatch({
 				path,
-				publishedContent,
-				pendingContent,
+				publishedContent: publishedContent ?? '',
+				pendingContent: pendingContent ?? '',
 			}),
 		})
 	}

--- a/packages/worker/src/repo/artifact-file.node.test.ts
+++ b/packages/worker/src/repo/artifact-file.node.test.ts
@@ -229,6 +229,18 @@ test('readArtifactTreeAtCommit walks the fetched commit tree', async () => {
 					content: async () => new TextEncoder().encode('not proto\n'),
 				},
 			])
+			await input.map('community-icon.png', [
+				{
+					type: async () => 'blob',
+					content: async () => Uint8Array.from([0x89, 0x50, 0x4e, 0x47, 0, 1]),
+				},
+			])
+			await input.map('other-icon.png', [
+				{
+					type: async () => 'blob',
+					content: async () => Uint8Array.from([0x89, 0x50, 0x4e, 0x47, 0, 2]),
+				},
+			])
 		},
 	)
 
@@ -240,6 +252,13 @@ test('readArtifactTreeAtCommit walks the fetched commit tree', async () => {
 	expect(tree?.['README.md']).toBe('# Hello\n')
 	expect(Object.hasOwn(tree ?? {}, '__proto__')).toBe(true)
 	expect(tree?.['__proto__']).toBe('not proto\n')
+	expect(tree?.['community-icon.png']).not.toBe(tree?.['other-icon.png'])
+	expect(tree?.['community-icon.png']).toBe(
+		new TextDecoder('latin1').decode(
+			Uint8Array.from([0x89, 0x50, 0x4e, 0x47, 0, 1]),
+		),
+	)
+	expect(tree?.['community-icon.png']).toContain('\0')
 	expect(mocks.TREE).toHaveBeenCalledWith({
 		ref: 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
 	})

--- a/packages/worker/src/repo/artifact-file.node.test.ts
+++ b/packages/worker/src/repo/artifact-file.node.test.ts
@@ -12,6 +12,8 @@ const mocks = vi.hoisted(() => ({
 	walk: vi.fn(),
 	TREE: vi.fn((input: { ref: string }) => input),
 	resolveExistingArtifactSourceRepo: vi.fn(),
+	isLoopbackArtifactsRemote: vi.fn(() => false),
+	readArtifactSourceSnapshot: vi.fn(),
 }))
 
 vi.mock('isomorphic-git', () => ({
@@ -30,11 +32,17 @@ vi.mock('./artifacts.ts', () => {
 		buildArtifactsGitAuth: () => ({ username: 'x', password: 'token' }),
 		buildAuthenticatedArtifactsRemote: ({ remote }: { remote: string }) =>
 			remote,
-		isLoopbackArtifactsRemote: () => false,
+		isLoopbackArtifactsRemote: (...args: Array<unknown>) =>
+			mocks.isLoopbackArtifactsRemote(...args),
 		resolveExistingArtifactSourceRepo: (...args: Array<unknown>) =>
 			mocks.resolveExistingArtifactSourceRepo(...args),
 	}
 })
+
+vi.mock('./artifact-source-snapshot.ts', () => ({
+	readArtifactSourceSnapshot: (...args: Array<unknown>) =>
+		mocks.readArtifactSourceSnapshot(...args),
+}))
 
 test('reads binary artifact files from an exact pinned commit', async () => {
 	const bytes = Uint8Array.from([0x89, 0x50, 0x4e, 0x47])
@@ -180,6 +188,7 @@ test('retries packfile corruption on readBlob after fetch and does not retry mis
 })
 
 test('readArtifactTreeAtCommit walks the fetched commit tree', async () => {
+	mocks.isLoopbackArtifactsRemote.mockReturnValue(false)
 	mocks.resolveExistingArtifactSourceRepo.mockResolvedValue({
 		info: vi.fn(async () => ({
 			remote: 'https://artifacts.example.test/package.git',
@@ -214,16 +223,23 @@ test('readArtifactTreeAtCommit walks the fetched commit tree', async () => {
 					content: async () => new TextEncoder().encode('# Hello\n'),
 				},
 			])
+			await input.map('__proto__', [
+				{
+					type: async () => 'blob',
+					content: async () => new TextEncoder().encode('not proto\n'),
+				},
+			])
 		},
 	)
 
-	await expect(
-		readArtifactTreeAtCommit({
-			env: {} as Env,
-			repoId: 'package-1',
-			commit: 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
-		}),
-	).resolves.toEqual({ 'README.md': '# Hello\n' })
+	const tree = await readArtifactTreeAtCommit({
+		env: {} as Env,
+		repoId: 'package-1',
+		commit: 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+	})
+	expect(tree?.['README.md']).toBe('# Hello\n')
+	expect(Object.hasOwn(tree ?? {}, '__proto__')).toBe(true)
+	expect(tree?.['__proto__']).toBe('not proto\n')
 	expect(mocks.TREE).toHaveBeenCalledWith({
 		ref: 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
 	})
@@ -233,4 +249,32 @@ test('readArtifactTreeAtCommit walks the fetched commit tree', async () => {
 			depth: 1,
 		}),
 	)
+})
+
+test('readArtifactTreeAtCommit returns null when a loopback snapshot is missing', async () => {
+	mocks.isLoopbackArtifactsRemote.mockReturnValue(true)
+	mocks.resolveExistingArtifactSourceRepo.mockResolvedValue({
+		info: vi.fn(async () => ({
+			remote: 'http://127.0.0.1/package.git',
+			defaultBranch: 'main',
+		})),
+	})
+	mocks.readArtifactSourceSnapshot.mockResolvedValueOnce(null)
+	await expect(
+		readArtifactTreeAtCommit({
+			env: {} as Env,
+			repoId: 'package-1',
+			commit: 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+		}),
+	).resolves.toBeNull()
+
+	mocks.readArtifactSourceSnapshot.mockResolvedValueOnce({ files: {} })
+	await expect(
+		readArtifactTreeAtCommit({
+			env: {} as Env,
+			repoId: 'package-1',
+			commit: 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+		}),
+	).resolves.toEqual({})
+	mocks.isLoopbackArtifactsRemote.mockReturnValue(false)
 })

--- a/packages/worker/src/repo/artifact-file.node.test.ts
+++ b/packages/worker/src/repo/artifact-file.node.test.ts
@@ -1,11 +1,16 @@
 import { expect, test, vi } from 'vitest'
-import { readArtifactFileAtCommit } from './artifact-file.ts'
+import {
+	readArtifactFileAtCommit,
+	readArtifactTreeAtCommit,
+} from './artifact-file.ts'
 
 const mocks = vi.hoisted(() => ({
 	addRemote: vi.fn(),
 	fetch: vi.fn(),
 	init: vi.fn(),
 	readBlob: vi.fn(),
+	walk: vi.fn(),
+	TREE: vi.fn((input: { ref: string }) => input),
 	resolveExistingArtifactSourceRepo: vi.fn(),
 }))
 
@@ -15,6 +20,8 @@ vi.mock('isomorphic-git', () => ({
 		fetch: (...args: Array<unknown>) => mocks.fetch(...args),
 		init: (...args: Array<unknown>) => mocks.init(...args),
 		readBlob: (...args: Array<unknown>) => mocks.readBlob(...args),
+		walk: (...args: Array<unknown>) => mocks.walk(...args),
+		TREE: (...args: Array<unknown>) => mocks.TREE(...args),
 	},
 }))
 
@@ -170,4 +177,60 @@ test('retries packfile corruption on readBlob after fetch and does not retry mis
 
 	expect(mocks.fetch).toHaveBeenCalledTimes(1)
 	expect(mocks.readBlob).toHaveBeenCalledTimes(1)
+})
+
+test('readArtifactTreeAtCommit walks the fetched commit tree', async () => {
+	mocks.resolveExistingArtifactSourceRepo.mockResolvedValue({
+		info: vi.fn(async () => ({
+			remote: 'https://artifacts.example.test/package.git',
+			defaultBranch: 'main',
+		})),
+		createToken: vi.fn(async () => ({
+			plaintext: 'token',
+		})),
+	})
+	mocks.fetch.mockReset()
+	mocks.fetch.mockResolvedValue(undefined)
+	mocks.walk.mockImplementation(
+		async (input: {
+			map: (
+				filepath: string,
+				entries: Array<{
+					type: () => Promise<string>
+					content: () => Promise<Uint8Array>
+				} | null>,
+			) => Promise<void>
+		}) => {
+			await input.map('.', [null])
+			await input.map('src', [
+				{
+					type: async () => 'tree',
+					content: async () => new Uint8Array(),
+				},
+			])
+			await input.map('README.md', [
+				{
+					type: async () => 'blob',
+					content: async () => new TextEncoder().encode('# Hello\n'),
+				},
+			])
+		},
+	)
+
+	await expect(
+		readArtifactTreeAtCommit({
+			env: {} as Env,
+			repoId: 'package-1',
+			commit: 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+		}),
+	).resolves.toEqual({ 'README.md': '# Hello\n' })
+	expect(mocks.TREE).toHaveBeenCalledWith({
+		ref: 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+	})
+	expect(mocks.fetch).toHaveBeenCalledWith(
+		expect.objectContaining({
+			ref: 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+			depth: 1,
+		}),
+	)
 })

--- a/packages/worker/src/repo/artifact-file.ts
+++ b/packages/worker/src/repo/artifact-file.ts
@@ -214,7 +214,10 @@ export async function readArtifactTreeAtCommit(input: {
 
 function decodeArtifactBlob(content: Uint8Array | string) {
 	if (typeof content === 'string') return content
-	if (content.includes(0)) return '\0'
+	// Null-byte blobs stay byte-for-byte (latin1) so two binaries remain
+	// distinguishable. The publish diff still skips a text patch when the
+	// decoded string includes `\0`.
+	if (content.includes(0)) return new TextDecoder('latin1').decode(content)
 	return new TextDecoder().decode(content)
 }
 

--- a/packages/worker/src/repo/artifact-file.ts
+++ b/packages/worker/src/repo/artifact-file.ts
@@ -152,7 +152,7 @@ export async function readArtifactTreeAtCommit(input: {
 			repoId: input.repoId,
 			commit: input.commit,
 		})
-		return snapshot?.files ?? {}
+		return snapshot?.files ?? null
 	}
 
 	const token = await repo.createToken('read', 300)
@@ -188,7 +188,7 @@ export async function readArtifactTreeAtCommit(input: {
 					return auth
 				},
 			})
-			const files: Record<string, string> = {}
+			const files = Object.create(null) as Record<string, string>
 			await git.walk({
 				fs: workspace.fs,
 				dir: workspace.dir,

--- a/packages/worker/src/repo/artifact-file.ts
+++ b/packages/worker/src/repo/artifact-file.ts
@@ -128,6 +128,96 @@ export async function readFirstArtifactFileAtCommit(input: {
 	}
 }
 
+/**
+ * Whole-tree read of one Artifacts commit. Production has no KV snapshot for
+ * unpublished HEAD, so approve-publish uses this shallow fetch + walk.
+ */
+export async function readArtifactTreeAtCommit(input: {
+	env: Env
+	repoId: string
+	commit: string
+}): Promise<Record<string, string> | null> {
+	const repo = await resolveExistingArtifactSourceRepo(input.env, input.repoId)
+	if (!repo) {
+		throw new Error(`Artifact repo "${input.repoId}" was not found.`)
+	}
+	const info = await repo.info()
+	if (!info?.remote) {
+		throw new Error('Artifact repo remote URL is unavailable.')
+	}
+
+	if (isLoopbackArtifactsRemote(info.remote)) {
+		const snapshot = await readArtifactSourceSnapshot({
+			env: input.env,
+			repoId: input.repoId,
+			commit: input.commit,
+		})
+		return snapshot?.files ?? {}
+	}
+
+	const token = await repo.createToken('read', 300)
+	const remote = buildAuthenticatedArtifactsRemote({
+		remote: info.remote,
+		token: token.plaintext,
+	})
+	const auth = buildArtifactsGitAuth({ token: token.plaintext })
+	const { git, http } = await loadIsomorphicGit()
+	try {
+		return await runArtifactsGitWithRetry(async () => {
+			const workspace = createEphemeralGitWorkspace()
+			await git.init({
+				fs: workspace.fs,
+				dir: workspace.dir,
+			})
+			await git.addRemote({
+				fs: workspace.fs,
+				dir: workspace.dir,
+				remote: 'origin',
+				url: remote,
+			})
+			await git.fetch({
+				fs: workspace.fs,
+				http,
+				dir: workspace.dir,
+				remote: 'origin',
+				ref: input.commit,
+				depth: 1,
+				singleBranch: true,
+				tags: false,
+				onAuth() {
+					return auth
+				},
+			})
+			const files: Record<string, string> = {}
+			await git.walk({
+				fs: workspace.fs,
+				dir: workspace.dir,
+				trees: [git.TREE({ ref: input.commit })],
+				map: async (filepath, [entry]) => {
+					if (!entry || filepath === '.') return
+					if ((await entry.type()) !== 'blob') return
+					const content = await entry.content()
+					if (content == null) return
+					files[filepath] = decodeArtifactBlob(content)
+				},
+			})
+			return files
+		})
+	} catch (error) {
+		throw wrapArtifactsGitHttpError({
+			operation: 'git fetch',
+			remote: info.remote,
+			error,
+		})
+	}
+}
+
+function decodeArtifactBlob(content: Uint8Array | string) {
+	if (typeof content === 'string') return content
+	if (content.includes(0)) return '\0'
+	return new TextDecoder().decode(content)
+}
+
 function isMissingArtifactFileError(error: unknown) {
 	if (
 		error instanceof Error &&

--- a/packages/worker/universal/loader-data.ts
+++ b/packages/worker/universal/loader-data.ts
@@ -1247,6 +1247,12 @@ export type AccountPackageDetail = AccountPackageListItem & {
 	publishedCommit: string | null
 }
 
+export type AccountPackagePublishDiffFile = {
+	path: string
+	status: 'added' | 'removed' | 'modified'
+	patch: string | null
+}
+
 export type AccountPackageApprovePublishLoaderData = {
 	ok: true
 	email: string
@@ -1262,6 +1268,10 @@ export type AccountPackageApprovePublishLoaderData = {
 	alreadyPublished: boolean
 	filesHref: string
 	packageHref: string
+	diff: {
+		files: Array<AccountPackagePublishDiffFile>
+		omittedCount: number
+	}
 }
 
 export type AccountPackagesSort = 'updated' | 'created' | 'name'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Give package owners a one-click path from **HEAD ahead of published** to a published-vs-HEAD file diff and a button that publishes that HEAD commit.

## Why

The badge already told owners that Artifacts HEAD had unpublished work, but it was inert. The only website promote flow lived on the locked-package approval URL, and that route 400ed when the package was unlocked. Owners who wanted to publish HEAD from the Code tab had no review surface.

## Summary

- Owner-only: the **HEAD ahead of published** badge links to `/account/packages/:packageId/approve-publish?commit=<sha>`. Visitors still see a static pill.
- That page now shows a file-by-file unified diff of the last published tree versus the pending commit (capped at 40 files; binary and oversized files skip the patch).
- Unpublished HEAD is loaded from Artifacts (`readArtifactTreeAtCommit`). The published KV snapshot does not contain that tree. If either comparison commit is unresolved — including a missing HEAD SHA — the page shows no file list instead of a fake add/delete of the other side.
- Binary blobs keep byte identity (latin1 decode) so changed icons are not collapsed to a shared `\\0` sentinel.
- Locked packages still **Promote this commit** (and stay locked). Unlocked packages get **Publish HEAD**. Both call the same `publishFromExternalRef` path; `allowLockedPublish` is set only when the package is locked.
- Docs: [Packages → Publish lock](docs/use/packages.md#publish-lock) and [Public packages](docs/use/community-packages.md).

## Testing

- `vitest` node-unit: `package-publish-diff`, `account-package-publish-lock`, `account-package-approve-publish`, `community-detail-content`, `community-detail.frame`, `artifact-file`
- Pre-push: full `test:node` (2405) and `test:workers` (320)
- Pre-commit typecheck and oxlint/oxfmt
- Preview [kody-pr-2003](https://kody-pr-2003.kody-a99.workers.dev) on `d71ce696`: health/login smoke, empty packages list, missing-id approve-publish 404. Data-backed HEAD-ahead UI still blocked — seed has no create-package JSON path ([#2006](https://github.com/kentcdodds/kody/issues/2006))

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `5a0ca0b0` · **Head:** `62f69ba9`

**Classification:** extends — approve-publish now loads a published-vs-HEAD file diff (unpublished side from Artifacts) and accepts an unlocked **Publish HEAD**; the listing badge becomes an owner link.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `app-ui` | surfaces | extends — owner badge links to approve-publish; that page renders a file diff and a Publish HEAD / Promote button |
| `community-listings` | assistant | extends — Code-tab **HEAD ahead of published** is a link for owners |
| `repo-sessions` | runtime | extends — `readArtifactTreeAtCommit` shallow-fetches an unpublished SHA and walks the tree; binary blobs keep identity |
| `saved-packages` | assistant | composes — same `publishFromExternalRef` promote path; unlocked approve-publish no longer 400s |

### Change flow

Owners open the Code-tab badge, review the published-vs-HEAD tree, and publish that SHA from the existing approve-publish route.

```mermaid
sequenceDiagram
	actor Owner
	participant appUi as app-ui
	participant communityListings as community-listings
	participant repoSessions as repo-sessions
	participant savedPackages as saved-packages
	Owner->>communityListings: open /@owner/kodyId with sourceAhead
	communityListings->>appUi: owner badge href to approve-publish?commit=sha
	Owner->>appUi: open approve-publish
	appUi->>appUi: load published tree from KV snapshot
	appUi->>repoSessions: readArtifactTreeAtCommit unpublished SHA
	repoSessions-->>appUi: pending file map
	appUi-->>Owner: file-by-file unified diff
	Owner->>appUi: Publish HEAD or Promote this commit
	appUi->>savedPackages: publishFromExternalRef (allowLockedPublish only if locked)
	savedPackages-->>appUi: published
	appUi-->>Owner: redirect to package page
```

### Before / after

| Surface | Before | After |
| ------- | ------ | ----- |
| Code-tab badge | Static span for everyone | Owner `<a>` to approve-publish; visitors keep the span |
| `/approve-publish` when unlocked | 400 | 200 + **Publish HEAD** |
| `/approve-publish` pending tree | KV miss → empty → every published file looks removed | Artifacts shallow-fetch + walk |
| Unresolved tree | Fake full add/delete | Empty diff (including missing HEAD) |
| Binary blobs in the tree | All null-byte files became `'\\0'` | Latin1 decode keeps distinct bytes; patch still skipped |
| `/approve-publish` body | Metadata only | Metadata + file diff (max 40) |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d2e9331f-8e81-48a9-8bb2-55b7442a5065?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d2e9331f-8e81-48a9-8bb2-55b7442a5065&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Package owners can review file-by-file differences between published content and pending changes before publishing.
  * Owners can publish the latest default-branch HEAD for unlocked packages.
  * The “HEAD ahead of published” badge links owners to the review page; visitors see a non-clickable badge.
  * Review pages indicate added, removed, and modified files, including available text patches and omitted-file counts.
* **Documentation**
  * Updated package and community package guidance to describe publish reviews, file comparisons, and publishing HEAD.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->