### PR TITLE
Give the runtime worker its own narrower Cloudflare API token

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -531,6 +531,10 @@ jobs:
       # (Cloudflare REST capabilities). Billing (Stripe), waiting-list (Kit),
       # OAuth client credentials, and maintenance secrets stay main-only so a
       # runtime-Worker compromise cannot reach them.
+      # The runtime Worker's CLOUDFLARE_API_TOKEN comes from the narrower
+      # CLOUDFLARE_RUNTIME_API_TOKEN GitHub secret (Email Sending + Artifacts
+      # only; see docs/contributing/environment-variables.md). It falls back
+      # to the deploy token until that secret exists.
       # --env "" with --name: wrangler secret bulk still suffixes -<env>
       # even when --name is set, so --env production would write
       # COOKIE_SECRET to kody-runtime-production while deploy uploads
@@ -541,6 +545,9 @@ jobs:
           steps.resources.outputs.origin_deploy_mode == 'fresh'
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_RUNTIME_API_TOKEN:
+            ${{ secrets.CLOUDFLARE_RUNTIME_API_TOKEN ||
+            secrets.CLOUDFLARE_API_TOKEN }}
           WRANGLER_CONFIG:
             ${{ steps.runtime_config.outputs.runtime_wrangler_config }}
           COOKIE_SECRET: ${{ secrets.COOKIE_SECRET }}
@@ -552,7 +559,8 @@ jobs:
           --config "$WRANGLER_CONFIG" --set-from-env COOKIE_SECRET
           --set-from-env-optional SECRET_STORE_KEY --set-from-env-optional
           AI_GATEWAY_ID --set-from-env-optional SENTRY_DSN
-          --set-from-env-optional CLOUDFLARE_API_TOKEN
+          --set-from-env-optional
+          CLOUDFLARE_API_TOKEN=CLOUDFLARE_RUNTIME_API_TOKEN
 
       # Platform worker is trusted (same secret set as origin): MCP Durable
       # Objects execute capabilities that need OAuth, Stripe, and the rest.

--- a/docs/contributing/environment-variables.md
+++ b/docs/contributing/environment-variables.md
@@ -368,7 +368,13 @@ Optional Worker secrets/vars (see `packages/worker/src/env-schema.ts` and
   the Cloudflare Email sender. User Cloudflare API calls from authored package
   modules use saved secrets and secret-aware `fetch` (see
   `docs/contributing/packages-and-manifests.md`). Local `npm run dev` sets this
-  to the Cloudflare mock token unless `SKIP_CLOUDFLARE_MOCK=1`.
+  to the Cloudflare mock token unless `SKIP_CLOUDFLARE_MOCK=1`. Production
+  workers do not share one value: `kody-runtime` receives the narrower
+  `CLOUDFLARE_RUNTIME_API_TOKEN` GitHub secret (Email Sending + Artifacts only)
+  via
+  `--set-from-env-optional CLOUDFLARE_API_TOKEN=CLOUDFLARE_RUNTIME_API_TOKEN` in
+  `.github/workflows/deploy.yml`; see `docs/contributing/setup-manifest.md` for
+  the permission list.
 - `CLOUDFLARE_ACCOUNT_ID` — Cloudflare account id required by the Cloudflare
   Email Service REST API fallback used by local mocks and preview deploys. This
   is a Worker var (not a secret) and should match the account behind

--- a/docs/contributing/setup-manifest.md
+++ b/docs/contributing/setup-manifest.md
@@ -498,6 +498,16 @@ Configure these GitHub Actions secrets and variables for workflows:
 - `CLOUDFLARE_API_TOKEN` (Workers deploy + D1 edit access on the correct
   account; also reused for remote AI and Cloudflare API workflows that run with
   account secrets + package workflows)
+- `CLOUDFLARE_RUNTIME_API_TOKEN` (optional; the value uploaded to the
+  `kody-runtime` Worker as its `CLOUDFLARE_API_TOKEN` secret. The runtime lane
+  executes package capabilities in-process, and the only Cloudflare REST APIs
+  those reach are Email Sending (`/email/sending/send`) and Artifacts
+  (`/artifacts/namespaces/...`, including repo token minting, which has no
+  binding equivalent), so this token needs exactly
+  `Account · Email Sending · Edit` and `Account · Artifacts · Edit`. Workers AI,
+  Images, Vectorize, D1, and Queues are reached through bindings or are not used
+  by the runtime lane. When unset, the deploy falls back to
+  `CLOUDFLARE_API_TOKEN`.)
 - `CLOUDFLARE_ACCOUNT_ID` (required GitHub Actions **variable** for Cloudflare
   resource provisioning and Email Service)
 - `CLOUDFLARE_ZONE_ID` (required GitHub Actions **variable** for the zone that

--- a/tools/ci/sync-worker-secrets.node.test.ts
+++ b/tools/ci/sync-worker-secrets.node.test.ts
@@ -3,10 +3,12 @@ import { PassThrough } from 'node:stream'
 import { expect, test, vi } from 'vitest'
 import { consoleError } from '#worker/test-support/console-spies.ts'
 import {
+	buildSecrets,
 	buildSpawnEnv,
 	buildWranglerSecretBulkFlags,
 	collectSpawnedProcessOutput,
 	parseDotenv,
+	parseEnvSourceSpec,
 	retrySecretBulkUpload,
 	toDotenv,
 } from './sync-worker-secrets'
@@ -77,6 +79,52 @@ test('buildSpawnEnv preserves optional vars only when they have values', () => {
 	expect(spawnEnvWithOptionalValues.SENTRY_DSN).toBe(
 		'https://examplePublicKey@o0.ingest.sentry.io/0',
 	)
+})
+
+test('NAME=SOURCE specs upload the source variable under the worker secret name', async () => {
+	expect(parseEnvSourceSpec('SENTRY_DSN')).toEqual({
+		key: 'SENTRY_DSN',
+		sourceKey: 'SENTRY_DSN',
+	})
+	expect(
+		parseEnvSourceSpec('CLOUDFLARE_API_TOKEN=CLOUDFLARE_RUNTIME_API_TOKEN'),
+	).toEqual({
+		key: 'CLOUDFLARE_API_TOKEN',
+		sourceKey: 'CLOUDFLARE_RUNTIME_API_TOKEN',
+	})
+
+	vi.stubEnv('CLOUDFLARE_API_TOKEN', 'deploy-token')
+	vi.stubEnv('CLOUDFLARE_RUNTIME_API_TOKEN', 'runtime-token')
+	vi.stubEnv('COOKIE_SECRET', 'cookie')
+	try {
+		const secrets = await buildSecrets({
+			...baseOptions,
+			setFromEnv: ['COOKIE_SECRET'],
+			setFromEnvOptional: ['CLOUDFLARE_API_TOKEN=CLOUDFLARE_RUNTIME_API_TOKEN'],
+		})
+		expect(secrets.get('CLOUDFLARE_API_TOKEN')).toBe('runtime-token')
+		expect(secrets.get('COOKIE_SECRET')).toBe('cookie')
+		expect(secrets.has('CLOUDFLARE_RUNTIME_API_TOKEN')).toBe(false)
+
+		vi.stubEnv('CLOUDFLARE_RUNTIME_API_TOKEN', '')
+		const withoutRuntimeToken = await buildSecrets({
+			...baseOptions,
+			setFromEnvOptional: ['CLOUDFLARE_API_TOKEN=CLOUDFLARE_RUNTIME_API_TOKEN'],
+		})
+		expect(withoutRuntimeToken.has('CLOUDFLARE_API_TOKEN')).toBe(false)
+	} finally {
+		vi.unstubAllEnvs()
+	}
+
+	const spawnEnv = buildSpawnEnv(
+		{
+			...baseOptions,
+			setFromEnvOptional: ['CLOUDFLARE_API_TOKEN=CLOUDFLARE_RUNTIME_API_TOKEN'],
+		},
+		{ CLOUDFLARE_API_TOKEN: 'deploy-token', CLOUDFLARE_RUNTIME_API_TOKEN: '' },
+	)
+	expect(spawnEnv.CLOUDFLARE_API_TOKEN).toBe('deploy-token')
+	expect(spawnEnv.CLOUDFLARE_RUNTIME_API_TOKEN).toBeUndefined()
 })
 
 test('secret bulk omits empty --env so --name pins the unsuffixed script', () => {

--- a/tools/ci/sync-worker-secrets.ts
+++ b/tools/ci/sync-worker-secrets.ts
@@ -255,11 +255,31 @@ function parseSetPair(pair: string) {
 	return { key, value }
 }
 
+/**
+ * `--set-from-env NAME` reads `process.env.NAME`; `--set-from-env NAME=SOURCE`
+ * reads `process.env.SOURCE` and uploads it as the Worker secret `NAME`. The
+ * alias form lets a worker receive a different value than the variable of the
+ * same name in the deploy shell (for example a narrower `CLOUDFLARE_API_TOKEN`
+ * than the one wrangler itself authenticates with).
+ */
+export function parseEnvSourceSpec(spec: string) {
+	const separator = spec.indexOf('=')
+	if (separator === -1) {
+		return { key: spec, sourceKey: spec }
+	}
+	const key = spec.slice(0, separator).trim()
+	const sourceKey = spec.slice(separator + 1).trim()
+	if (!key || !sourceKey) {
+		fail(`Invalid --set-from-env spec "${spec}" (expected NAME or NAME=SOURCE)`)
+	}
+	return { key, sourceKey }
+}
+
 function generateHexSecret(bytes: number) {
 	return randomBytes(bytes).toString('hex')
 }
 
-async function buildSecrets(options: CliOptions) {
+export async function buildSecrets(options: CliOptions) {
 	const secrets = new Map<string, string>()
 
 	for (const path of options.dotenvPaths) {
@@ -269,16 +289,18 @@ async function buildSecrets(options: CliOptions) {
 		}
 	}
 
-	for (const key of options.setFromEnv) {
-		const value = process.env[key]
+	for (const spec of options.setFromEnv) {
+		const { key, sourceKey } = parseEnvSourceSpec(spec)
+		const value = process.env[sourceKey]
 		if (typeof value !== 'string') {
-			fail(`Missing required environment variable: ${key}`)
+			fail(`Missing required environment variable: ${sourceKey}`)
 		}
 		secrets.set(key, value)
 	}
 
-	for (const key of options.setFromEnvOptional) {
-		const value = process.env[key]
+	for (const spec of options.setFromEnvOptional) {
+		const { key, sourceKey } = parseEnvSourceSpec(spec)
+		const value = process.env[sourceKey]
 		if (typeof value === 'string' && value.length > 0) {
 			secrets.set(key, value)
 		}
@@ -323,9 +345,10 @@ export function buildSpawnEnv(
 			spawnEnv[key] = value
 		}
 	}
-	for (const key of options.setFromEnvOptional) {
-		if (spawnEnv[key] !== undefined && spawnEnv[key].length === 0) {
-			delete spawnEnv[key]
+	for (const spec of options.setFromEnvOptional) {
+		const { sourceKey } = parseEnvSourceSpec(spec)
+		if (spawnEnv[sourceKey] !== undefined && spawnEnv[sourceKey].length === 0) {
+			delete spawnEnv[sourceKey]
 		}
 	}
 	return spawnEnv


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Production syncs one `CLOUDFLARE_API_TOKEN` (the CI deploy token, with Workers/D1/Queues edit rights) into all three workers. The runtime lane executes untrusted package code, so a runtime-Worker compromise currently yields the deploy token.

## What the runtime lane actually calls with the token

Walked the static import graph from `packages/worker/src/runtime-worker.ts` (746 modules) for every module that reads `CLOUDFLARE_API_TOKEN`, uses the REST client, or hits a `api.cloudflare.com` path. The runtime executes package capabilities in-process (`getCapabilityRegistryForContext` in `run-kody-registry.ts`), so the reachable REST surface is what capabilities can hit:

| REST family | Where | Permission |
| --- | --- | --- |
| `POST /email/sending/send` | email capabilities, system/feedback emails (`app/email/cloudflare-email.ts`, REST-only, no binding) | Account · Email Sending · Edit |
| `/artifacts/namespaces/...` | repo capabilities; runtime has no `ARTIFACTS` binding, and repo token minting is REST-only even where the binding exists (`repo/artifacts.ts`) | Account · Artifacts · Edit |
| `/analytics_engine/sql` | admin feature-flag readouts only | not granted (admin UI runs on origin) |
| `/queues`, `/event_subscriptions` | legacy push-subscription cleanup on repo delete; failure is a warning, `ensureArtifactsRepoPushSubscription` has no production caller | not granted |
| Workers AI, Images, Vectorize, D1 | bindings only; no REST calls anywhere in the worker | none |

## Change

- `tools/ci/sync-worker-secrets.ts`: `--set-from-env[-optional] NAME=SOURCE` uploads `process.env.SOURCE` as Worker secret `NAME`, so the runtime worker can receive a different value than the variable wrangler authenticates with.
- `deploy.yml`: the production runtime sync uses `CLOUDFLARE_API_TOKEN=CLOUDFLARE_RUNTIME_API_TOKEN`, with `secrets.CLOUDFLARE_RUNTIME_API_TOKEN || secrets.CLOUDFLARE_API_TOKEN` so nothing changes until the new GitHub secret exists.
- Docs: `setup-manifest.md` (GitHub secret + exact permission list), `environment-variables.md`.

## Operator step

Create the GitHub Actions secret `CLOUDFLARE_RUNTIME_API_TOKEN` from an account-scoped token with `Email Sending: Edit` and `Artifacts: Edit`. The next runtime deploy picks it up.

## Verification

`tools/ci/sync-worker-secrets.node.test.ts`: 9 passed (new test covers alias parsing, upload under the target name, empty-source skip, and spawn-env handling). `docs:check-temporal`, `deploy-guardrails:check`, typecheck, lint pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b0f6a92a-81cd-4157-8b60-188c83ca84c0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b0f6a92a-81cd-4157-8b60-188c83ca84c0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Runtime worker deployments now use a narrowly scoped Cloudflare API token, with automatic fallback to the existing token when unavailable.
  * Empty optional secrets are excluded from worker deployments to prevent invalid configuration.

* **Documentation**
  * Added setup guidance for the runtime-specific Cloudflare token, including required permissions and fallback behavior.

* **Tests**
  * Added coverage for mapping environment variables to differently named worker secrets and handling empty values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->