### PR TITLE
Add public post-incident retrospectives to the status page

### DIFF
--- a/docs/contributing/architecture/authorization.md
+++ b/docs/contributing/architecture/authorization.md
@@ -389,9 +389,10 @@ POSTs metadata to the main worker. Fan-out of `status.incident.opened` and
 role at dispatch time. A non-admin may declare the topic but never receives it.
 The event contains the public status URL, component id, probe detail, and ISO
 timestamps. It omits probe logs, health-check bodies, user identities, secrets,
-and unrelated account content. This is operator telemetry about kody itself, not
-a user-data exception. Delivery is best-effort (no Queue); `/status.json`
-polling remains the backstop.
+and unrelated account content. Resolved incidents may also carry an optional
+operator retrospective on `/` and `/status.json`; that text is public
+operational narrative, not user data. Delivery is best-effort (no Queue);
+`/status.json` polling remains the backstop.
 
 **Admins can subscribe to fleet package-runtime error-rate elevations.** The
 hourly usage-aggregation lane compares anonymous Analytics Engine totals for

--- a/docs/contributing/decisions/0004-status-page-separate-worker.md
+++ b/docs/contributing/decisions/0004-status-page-separate-worker.md
@@ -42,10 +42,26 @@ top; do not move the status page into the main worker. The status worker
 duplicates a small amount of email-sending code rather than importing from
 `packages/worker` (import boundaries keep it dependency-free). Incident records
 are probe-derived only; manually posted incident narratives are a possible later
-addition, not built now. `status.kody.codes` is the attached canonical hostname.
+addition, not built now (see the 2026-09-02 update). `status.kody.codes` is the
+attached canonical hostname.
 
 ## Later update (2026-09-01)
 
 `status.heykody.dev` is no longer a worker custom domain or deploy healthcheck
 fallback. The status worker attaches only `status.kody.codes`. See
 [0044](./0044-retired-brand-domains-stay-retired.md).
+
+## Later update (2026-09-02)
+
+Operator-authored retrospectives are now a supported attachment on a
+probe-derived incident, not a second incident system. Probes still open and
+resolve incidents. A resolved incident may carry an optional public writeup
+(what happened, impact, timeline, cause, what we did, what we will change)
+stored on the status Durable Object and rendered on `/` and `/status.json`.
+
+The write path is `POST /__maintenance/incidents/:id/retrospective` on
+`status.kody.codes`, authenticated with the existing
+`STATUS_INCIDENT_EVENT_SECRET` bearer. It does not go through origin or
+`APP_DB`, so a down main worker cannot block a retrospective. There is no public
+unauthenticated write. Open incidents cannot receive a writeup until probes
+resolve them.

--- a/docs/contributing/environment-variables.md
+++ b/docs/contributing/environment-variables.md
@@ -352,11 +352,15 @@ Worker secrets:
   than the jobs-only endpoint so restored D1 fingerprints cannot skip an empty
   index.
 - **`STATUS_INCIDENT_EVENT_SECRET`** — optional Worker secret shared with the
-  status worker. Bearer token for `POST /__maintenance/status-incidents`, which
-  fans `status.incident.opened` / `status.incident.resolved` to admin package
-  subscriptions. When unset, the endpoint returns not-configured and the status
-  worker skips emit; packages can reconcile from public `/status.json`. Synced
-  from the GitHub Actions secret of the same name on production deploy.
+  status worker. Bearer token for origin `POST /__maintenance/status-incidents`,
+  which fans `status.incident.opened` / `status.incident.resolved` to admin
+  package subscriptions, and for status
+  `POST /__maintenance/incidents/:id/retrospective`, which attaches a public
+  writeup to a resolved probe-derived incident. When unset, the origin endpoint
+  returns not-configured, the status worker skips emit, and the retrospective
+  route returns 503; packages can reconcile open/resolve from public
+  `/status.json`. Synced from the GitHub Actions secret of the same name on
+  production deploy.
 
 ## Cloudflare API (Worker + Email)
 

--- a/docs/contributing/setup-manifest.md
+++ b/docs/contributing/setup-manifest.md
@@ -338,8 +338,13 @@ On incident open or resolve the status worker POSTs metadata to
 `https://kody.codes/__maintenance/status-incidents` so admin packages can
 subscribe to `status.incident.opened` / `status.incident.resolved`. The notify
 is fire-and-forget with a short timeout so a down or missing secret cannot stall
-probes or email. When the GitHub secret is unset, emit stays skipped; packages
-can reconcile from the public `/status.json` snapshot.
+probes or email. The same bearer authenticates
+`POST https://status.kody.codes/__maintenance/incidents/:id/retrospective`,
+which attaches an operator writeup to a resolved probe-derived incident on the
+status Durable Object. That write stays on the status worker so origin /
+`APP_DB` being down cannot block it. When the GitHub secret is unset, emit stays
+skipped and the retrospective route returns 503; packages can reconcile incident
+open/resolve from the public `/status.json` snapshot.
 
 ## Optional Cloudflare offerings
 

--- a/packages/status/readme.md
+++ b/packages/status/readme.md
@@ -44,6 +44,31 @@ subscriptions. The notify is fire-and-forget with a short timeout so a down or
 missing secret cannot stall probes or email. When the secret is unset, packages
 can reconcile from `GET /status.json`.
 
+Resolved incidents may also carry an optional operator retrospective (what
+happened, impact, timeline, cause, what we did, what we will change). Probes
+remain the source of truth for open vs resolved. The writeup is attached
+narrative, stored on `StatusStore`, and shown on the public page inside a
+`<details>` block so the incident list stays glanceable. `/status.json` includes
+`retrospective` on each incident (`null` when none is published).
+
+Publish or replace a writeup with a bearer POST to the status worker itself —
+not origin — so a down main worker cannot block it:
+
+```bash
+curl -fsS -X POST \
+  "https://status.kody.codes/__maintenance/incidents/10/retrospective" \
+  -H "Authorization: Bearer $STATUS_INCIDENT_EVENT_SECRET" \
+  -H "Content-Type: application/json" \
+  --data @packages/status/retrospectives/jobs-2026-09-02.json
+```
+
+`STATUS_INCIDENT_EVENT_SECRET` is the same Worker secret already synced from
+GitHub Actions. When it is unset, the route returns 503. Open incidents return
+409; unknown ids return 404. There is no public unauthenticated write.
+
+The 2026-09-02 Jobs incident payload lives at
+`packages/status/retrospectives/jobs-2026-09-02.json` (status incident id 10).
+
 ## Provider incidents (Cloudflare)
 
 Each cron tick also fetches Cloudflare's public Statuspage feed
@@ -64,15 +89,16 @@ suppressed based on provider status.
 
 ## Routes
 
-| Path                       | Purpose                                           |
-| -------------------------- | ------------------------------------------------- |
-| `/`                        | Public status page (HTML)                         |
-| `/status.json`             | Snapshot as JSON                                  |
-| `/health`                  | Liveness for the status worker itself             |
-| `/favicon-operational.png` | Favicon when all measured components are up       |
-| `/favicon-down.png`        | Favicon while a kody incident is open             |
-| `/favicon-unknown.png`     | Favicon when status data is unavailable           |
-| `/favicon.ico`             | 302 to the current overall-status PNG (30s cache) |
+| Path                                              | Purpose                                                                         |
+| ------------------------------------------------- | ------------------------------------------------------------------------------- |
+| `/`                                               | Public status page (HTML)                                                       |
+| `/status.json`                                    | Snapshot as JSON                                                                |
+| `POST /__maintenance/incidents/:id/retrospective` | Operator writeup on a resolved incident (bearer `STATUS_INCIDENT_EVENT_SECRET`) |
+| `/health`                                         | Liveness for the status worker itself                                           |
+| `/favicon-operational.png`                        | Favicon when all measured components are up                                     |
+| `/favicon-down.png`                               | Favicon while a kody incident is open                                           |
+| `/favicon-unknown.png`                            | Favicon when status data is unavailable                                         |
+| `/favicon.ico`                                    | 302 to the current overall-status PNG (30s cache)                               |
 
 The HTML `<link rel="icon">` (and apple-touch icon) is chosen from
 `overallStatus` on each render. The page meta-refreshes every 60 seconds, so an

--- a/packages/status/retrospective-maintenance.node.test.ts
+++ b/packages/status/retrospective-maintenance.node.test.ts
@@ -1,0 +1,174 @@
+import { expect, test } from 'vitest'
+import {
+	handleIncidentRetrospectiveRequest,
+	incidentRetrospectiveNotConfiguredMessage,
+	parseIncidentRetrospectivePath,
+	unknownStatusMaintenanceResponse,
+} from './retrospective-maintenance.ts'
+import {
+	stampIncidentRetrospective,
+	type IncidentRetrospective,
+} from './retrospective.ts'
+import { type IncidentView } from './status-types.ts'
+
+function retrospectiveRequest(input: {
+	method?: string
+	authorization?: string | null
+	body?: unknown
+}) {
+	const headers = new Headers({ 'content-type': 'application/json' })
+	if (input.authorization !== null) {
+		headers.set('authorization', input.authorization ?? 'Bearer shared-secret')
+	}
+	return new Request(
+		'https://status.kody.codes/__maintenance/incidents/10/retrospective',
+		{
+			method: input.method ?? 'POST',
+			headers,
+			body:
+				input.method === 'GET'
+					? undefined
+					: JSON.stringify(
+							input.body ?? {
+								whatHappened: 'Probes failed twice.',
+								impact: 'Jobs card went red.',
+								timeline: [{ at: '2026-09-02T21:57:54.765Z', note: 'Opened.' }],
+								cause: 'Unconfirmed.',
+								whatWeDid: 'Probes recovered.',
+								whatWeWillChange: 'Publish retrospectives.',
+							},
+						),
+		},
+	)
+}
+
+function incidentView(
+	retrospective: IncidentRetrospective | null = null,
+): IncidentView {
+	return {
+		id: 10,
+		component: 'jobs',
+		componentName: 'Jobs',
+		startedAt: '2026-09-02T21:57:54.765Z',
+		resolvedAt: '2026-09-02T22:00:51.866Z',
+		detail: 'error',
+		retrospective,
+	}
+}
+
+test('retrospective maintenance path authenticates and writes only resolved incidents', async () => {
+	expect(
+		parseIncidentRetrospectivePath('/__maintenance/incidents/10/retrospective'),
+	).toBe(10)
+	expect(
+		parseIncidentRetrospectivePath('/__maintenance/incidents/0/retrospective'),
+	).toBe(null)
+	expect(
+		parseIncidentRetrospectivePath('/__maintenance/status-incidents'),
+	).toBe(null)
+	expect(unknownStatusMaintenanceResponse().status).toBe(404)
+
+	const getResponse = await handleIncidentRetrospectiveRequest({
+		request: retrospectiveRequest({ method: 'GET' }),
+		incidentId: 10,
+		secret: 'shared-secret',
+		setRetrospective: async () => {
+			throw new Error('should not write')
+		},
+	})
+	expect(getResponse.status).toBe(405)
+
+	const unset = await handleIncidentRetrospectiveRequest({
+		request: retrospectiveRequest({}),
+		incidentId: 10,
+		secret: '  ',
+		setRetrospective: async () => {
+			throw new Error('should not write')
+		},
+	})
+	expect(unset.status).toBe(503)
+	expect(await unset.text()).toBe(incidentRetrospectiveNotConfiguredMessage)
+
+	const unauthorized = await handleIncidentRetrospectiveRequest({
+		request: retrospectiveRequest({ authorization: 'Bearer wrong' }),
+		incidentId: 10,
+		secret: 'shared-secret',
+		setRetrospective: async () => {
+			throw new Error('should not write')
+		},
+	})
+	expect(unauthorized.status).toBe(401)
+
+	const missingBearer = await handleIncidentRetrospectiveRequest({
+		request: retrospectiveRequest({ authorization: null }),
+		incidentId: 10,
+		secret: 'shared-secret',
+		setRetrospective: async () => {
+			throw new Error('should not write')
+		},
+	})
+	expect(missingBearer.status).toBe(401)
+
+	const invalidBody = await handleIncidentRetrospectiveRequest({
+		request: retrospectiveRequest({ body: { whatHappened: 'only' } }),
+		incidentId: 10,
+		secret: 'shared-secret',
+		setRetrospective: async () => {
+			throw new Error('should not write')
+		},
+	})
+	expect(invalidBody.status).toBe(400)
+	expect(await invalidBody.json()).toMatchObject({ ok: false })
+
+	const publishedAt = Date.parse('2026-09-02T22:20:00.000Z')
+	let written: IncidentRetrospective | null = null
+	const ok = await handleIncidentRetrospectiveRequest({
+		request: retrospectiveRequest({}),
+		incidentId: 10,
+		secret: 'shared-secret',
+		now: publishedAt,
+		setRetrospective: async (id, retrospective) => {
+			expect(id).toBe(10)
+			written = retrospective
+			return { ok: true, incident: incidentView(retrospective) }
+		},
+	})
+	expect(ok.status).toBe(200)
+	const okBody = (await ok.json()) as {
+		ok: boolean
+		incident: IncidentView
+	}
+	expect(okBody.ok).toBe(true)
+	expect(okBody.incident.retrospective?.publishedAt).toBe(
+		'2026-09-02T22:20:00.000Z',
+	)
+	expect(written).toEqual(
+		stampIncidentRetrospective(
+			{
+				whatHappened: 'Probes failed twice.',
+				impact: 'Jobs card went red.',
+				timeline: [{ at: '2026-09-02T21:57:54.765Z', note: 'Opened.' }],
+				cause: 'Unconfirmed.',
+				whatWeDid: 'Probes recovered.',
+				whatWeWillChange: 'Publish retrospectives.',
+			},
+			publishedAt,
+		),
+	)
+
+	const notFound = await handleIncidentRetrospectiveRequest({
+		request: retrospectiveRequest({}),
+		incidentId: 99,
+		secret: 'shared-secret',
+		setRetrospective: async () => ({ ok: false, error: 'not-found' }),
+	})
+	expect(notFound.status).toBe(404)
+
+	const openIncident = await handleIncidentRetrospectiveRequest({
+		request: retrospectiveRequest({}),
+		incidentId: 11,
+		secret: 'shared-secret',
+		setRetrospective: async () => ({ ok: false, error: 'not-resolved' }),
+	})
+	expect(openIncident.status).toBe(409)
+})

--- a/packages/status/retrospective-maintenance.ts
+++ b/packages/status/retrospective-maintenance.ts
@@ -1,0 +1,144 @@
+/**
+ * Secret-gated write for attaching a retrospective to a resolved incident.
+ * Lives on the status worker so origin / APP_DB being down cannot block it.
+ */
+
+import {
+	parseIncidentRetrospectiveInput,
+	stampIncidentRetrospective,
+	type IncidentRetrospective,
+} from './retrospective.ts'
+import { type IncidentView } from './status-types.ts'
+
+export const incidentRetrospectivePathPrefix = '/__maintenance/incidents/'
+export const incidentRetrospectivePathSuffix = '/retrospective'
+export const incidentRetrospectiveNotConfiguredMessage =
+	'Status incident retrospectives are not configured'
+
+export type SetIncidentRetrospectiveResult =
+	| { ok: true; incident: IncidentView }
+	| { ok: false; error: 'not-found' | 'not-resolved' }
+
+function readBearerToken(request: Request) {
+	const auth = request.headers.get('Authorization')?.trim()
+	return auth?.startsWith('Bearer ')
+		? auth.slice('Bearer '.length).trim()
+		: null
+}
+
+function timingSafeEqualDigests(
+	left: ArrayBuffer,
+	right: ArrayBuffer,
+): boolean {
+	if (left.byteLength !== right.byteLength) return false
+	const subtleWithTiming = crypto.subtle as SubtleCrypto & {
+		timingSafeEqual?: (a: BufferSource, b: BufferSource) => boolean
+	}
+	if (typeof subtleWithTiming.timingSafeEqual === 'function') {
+		return subtleWithTiming.timingSafeEqual(left, right)
+	}
+	const a = new Uint8Array(left)
+	const b = new Uint8Array(right)
+	let diff = 0
+	for (let index = 0; index < a.length; index += 1) {
+		diff |= a[index]! ^ b[index]!
+	}
+	return diff === 0
+}
+
+/** SHA-256 both sides, then compare digests so length does not short-circuit. */
+export async function timingSafeEqualString(
+	left: string,
+	right: string,
+): Promise<boolean> {
+	const encoder = new TextEncoder()
+	const [leftDigest, rightDigest] = await Promise.all([
+		crypto.subtle.digest('SHA-256', encoder.encode(left)),
+		crypto.subtle.digest('SHA-256', encoder.encode(right)),
+	])
+	return timingSafeEqualDigests(leftDigest, rightDigest)
+}
+
+export function parseIncidentRetrospectivePath(
+	pathname: string,
+): number | null {
+	if (
+		!pathname.startsWith(incidentRetrospectivePathPrefix) ||
+		!pathname.endsWith(incidentRetrospectivePathSuffix)
+	) {
+		return null
+	}
+	const idPart = pathname.slice(
+		incidentRetrospectivePathPrefix.length,
+		pathname.length - incidentRetrospectivePathSuffix.length,
+	)
+	if (!/^\d+$/.test(idPart)) return null
+	const id = Number(idPart)
+	if (!Number.isInteger(id) || id < 1) return null
+	return id
+}
+
+export async function handleIncidentRetrospectiveRequest(input: {
+	request: Request
+	incidentId: number
+	secret: string | null | undefined
+	now?: number
+	setRetrospective: (
+		id: number,
+		retrospective: IncidentRetrospective,
+	) => Promise<SetIncidentRetrospectiveResult>
+}): Promise<Response> {
+	if (input.request.method !== 'POST') {
+		return new Response('Method Not Allowed', { status: 405 })
+	}
+
+	const secret = input.secret?.trim()
+	if (!secret) {
+		return new Response(incidentRetrospectiveNotConfiguredMessage, {
+			status: 503,
+		})
+	}
+
+	const bearer = readBearerToken(input.request)
+	if (bearer === null || !(await timingSafeEqualString(bearer, secret))) {
+		return new Response('Unauthorized', { status: 401 })
+	}
+
+	const body = await input.request.json().catch(() => null)
+	const parsed = parseIncidentRetrospectiveInput(body)
+	if (!parsed.ok) {
+		return Response.json(
+			{ ok: false, error: parsed.message },
+			{ status: 400, headers: { 'Cache-Control': 'no-store' } },
+		)
+	}
+
+	const retrospective = stampIncidentRetrospective(
+		parsed.retrospective,
+		input.now ?? Date.now(),
+	)
+	const result = await input.setRetrospective(input.incidentId, retrospective)
+	if (!result.ok) {
+		const status = result.error === 'not-found' ? 404 : 409
+		const error =
+			result.error === 'not-found'
+				? 'incident not found'
+				: 'retrospective requires a resolved incident'
+		return Response.json(
+			{ ok: false, error },
+			{ status, headers: { 'Cache-Control': 'no-store' } },
+		)
+	}
+
+	return Response.json(
+		{ ok: true, incident: result.incident },
+		{ headers: { 'Cache-Control': 'no-store' } },
+	)
+}
+
+export function unknownStatusMaintenanceResponse(): Response {
+	return Response.json(
+		{ error: 'Unknown maintenance endpoint.' },
+		{ status: 404, headers: { 'Cache-Control': 'no-store' } },
+	)
+}

--- a/packages/status/retrospective.node.test.ts
+++ b/packages/status/retrospective.node.test.ts
@@ -1,0 +1,177 @@
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { DatabaseSync } from 'node:sqlite'
+import { fileURLToPath } from 'node:url'
+import { expect, test } from 'vitest'
+import {
+	addIncidentRetrospectiveColumnSql,
+	incidentRowToView,
+	incidentsTableHasRetrospectiveColumn,
+	parseIncidentRetrospectiveInput,
+	parseStoredIncidentRetrospective,
+	retrospectiveFieldMaxChars,
+	selectIncidentByIdSql,
+	serializeIncidentRetrospective,
+	stampIncidentRetrospective,
+	updateIncidentRetrospectiveSql,
+} from './retrospective.ts'
+
+const jobsRetrospectivePath = join(
+	dirname(fileURLToPath(import.meta.url)),
+	'retrospectives/jobs-2026-09-02.json',
+)
+
+function validInput() {
+	return {
+		whatHappened: 'Probes failed twice.',
+		impact: 'Status page showed Jobs down.',
+		timeline: [{ at: '2026-09-02T21:57:54.765Z', note: 'Incident opened.' }],
+		cause: 'Unconfirmed.',
+		whatWeDid: 'Waited for probes to recover.',
+		whatWeWillChange: 'Publish a retrospective.',
+	}
+}
+
+test('retrospective parse, store mapping, and schema upgrade keep probe incidents valid without a narrative', () => {
+	expect(parseIncidentRetrospectiveInput(null).ok).toBe(false)
+	expect(parseIncidentRetrospectiveInput('nope').ok).toBe(false)
+	expect(
+		parseIncidentRetrospectiveInput({ ...validInput(), whatHappened: '' }).ok,
+	).toBe(false)
+	expect(
+		parseIncidentRetrospectiveInput({
+			...validInput(),
+			whatHappened: 'x'.repeat(retrospectiveFieldMaxChars + 1),
+		}).ok,
+	).toBe(false)
+	expect(
+		parseIncidentRetrospectiveInput({ ...validInput(), timeline: [] }).ok,
+	).toBe(false)
+	expect(
+		parseIncidentRetrospectiveInput({
+			...validInput(),
+			timeline: [{ at: '  ', note: 'note' }],
+		}).ok,
+	).toBe(false)
+
+	const parsed = parseIncidentRetrospectiveInput({
+		...validInput(),
+		whatHappened: '  trimmed  ',
+		publishedAt: 'should-be-ignored',
+	})
+	if (!parsed.ok) throw new Error(parsed.message)
+	expect(parsed.retrospective.whatHappened).toBe('trimmed')
+	const publishedAtMs = Date.parse('2026-09-02T22:00:00.000Z')
+	const stamped = stampIncidentRetrospective(
+		parsed.retrospective,
+		publishedAtMs,
+	)
+	expect(stamped.publishedAt).toBe('2026-09-02T22:00:00.000Z')
+
+	const stored = parseStoredIncidentRetrospective(
+		serializeIncidentRetrospective(stamped),
+	)
+	expect(stored).toEqual(stamped)
+	expect(parseStoredIncidentRetrospective(null)).toBeNull()
+	expect(parseStoredIncidentRetrospective('{')).toBeNull()
+	expect(
+		parseStoredIncidentRetrospective(JSON.stringify(validInput())),
+	).toBeNull()
+
+	const withoutNarrative = incidentRowToView({
+		id: 10,
+		component: 'jobs',
+		started_at: Date.parse('2026-09-02T21:57:54.765Z'),
+		resolved_at: Date.parse('2026-09-02T22:00:51.866Z'),
+		detail: 'error',
+		retrospective: null,
+	})
+	expect(withoutNarrative).toEqual({
+		id: 10,
+		component: 'jobs',
+		componentName: 'Jobs',
+		startedAt: '2026-09-02T21:57:54.765Z',
+		resolvedAt: '2026-09-02T22:00:51.866Z',
+		detail: 'error',
+		retrospective: null,
+	})
+	expect(
+		incidentRowToView({
+			id: 99,
+			component: 'audit_db',
+			started_at: 1,
+			resolved_at: 2,
+			detail: 'retired',
+			retrospective: null,
+		}),
+	).toBeNull()
+
+	const withNarrative = incidentRowToView({
+		id: 10,
+		component: 'jobs',
+		started_at: Date.parse('2026-09-02T21:57:54.765Z'),
+		resolved_at: Date.parse('2026-09-02T22:00:51.866Z'),
+		detail: 'error',
+		retrospective: serializeIncidentRetrospective(stamped),
+	})
+	expect(withNarrative?.retrospective).toEqual(stamped)
+
+	const db = new DatabaseSync(':memory:')
+	db.exec(`
+		CREATE TABLE incidents (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			component TEXT NOT NULL,
+			started_at INTEGER NOT NULL,
+			resolved_at INTEGER,
+			detail TEXT
+		)
+	`)
+	const before = db.prepare('PRAGMA table_info(incidents)').all() as Array<{
+		name: string
+	}>
+	expect(incidentsTableHasRetrospectiveColumn(before)).toBe(false)
+	db.exec(addIncidentRetrospectiveColumnSql)
+	const after = db.prepare('PRAGMA table_info(incidents)').all() as Array<{
+		name: string
+	}>
+	expect(incidentsTableHasRetrospectiveColumn(after)).toBe(true)
+
+	db.prepare(
+		`INSERT INTO incidents (id, component, started_at, resolved_at, detail)
+		VALUES (10, 'jobs', ?, ?, 'error')`,
+	).run(
+		Date.parse('2026-09-02T21:57:54.765Z'),
+		Date.parse('2026-09-02T22:00:51.866Z'),
+	)
+	db.prepare(
+		`INSERT INTO incidents (id, component, started_at, resolved_at, detail)
+		VALUES (11, 'jobs', ?, NULL, 'error')`,
+	).run(Date.parse('2026-09-02T23:00:00.000Z'))
+
+	const resolvedUpdate = db
+		.prepare(updateIncidentRetrospectiveSql)
+		.run(serializeIncidentRetrospective(stamped), 10)
+	expect(resolvedUpdate.changes).toBe(1)
+	const openUpdate = db
+		.prepare(updateIncidentRetrospectiveSql)
+		.run(serializeIncidentRetrospective(stamped), 11)
+	expect(openUpdate.changes).toBe(0)
+
+	const loaded = db.prepare(selectIncidentByIdSql).get(10) as {
+		retrospective: string
+	}
+	expect(parseStoredIncidentRetrospective(loaded.retrospective)).toEqual(
+		stamped,
+	)
+
+	const jobsPayload = JSON.parse(
+		readFileSync(jobsRetrospectivePath, 'utf8'),
+	) as unknown
+	const jobsParsed = parseIncidentRetrospectiveInput(jobsPayload)
+	if (!jobsParsed.ok) throw new Error(jobsParsed.message)
+	expect(jobsParsed.retrospective.timeline.length).toBeGreaterThan(3)
+	expect(jobsParsed.retrospective.whatHappened).toMatch(/incident 10/i)
+	expect(jobsParsed.retrospective.cause).toMatch(/No confirmed root cause/)
+	expect(jobsParsed.retrospective.whatWeDid).toMatch(/not finishing #2010/)
+	expect(jobsParsed.retrospective.whatWeWillChange).toMatch(/Do not split/)
+})

--- a/packages/status/retrospective.ts
+++ b/packages/status/retrospective.ts
@@ -1,0 +1,270 @@
+/**
+ * Operator-authored narrative attached to a probe-derived incident.
+ * Open/resolve stays probe-driven; this is optional public writeup, not a
+ * second incident system.
+ */
+
+import {
+	isStatusComponentId,
+	statusComponentName,
+	type IncidentView,
+} from './status-types.ts'
+
+export const incidentRetrospectiveColumn = 'retrospective'
+
+export const retrospectiveFieldMaxChars = 2_000
+export const retrospectiveTimelineNoteMaxChars = 500
+export const retrospectiveTimelineAtMaxChars = 80
+export const retrospectiveTimelineMaxEntries = 24
+
+export type RetrospectiveTimelineEntry = {
+	at: string
+	note: string
+}
+
+export type IncidentRetrospectiveInput = {
+	whatHappened: string
+	impact: string
+	timeline: Array<RetrospectiveTimelineEntry>
+	cause: string
+	whatWeDid: string
+	whatWeWillChange: string
+}
+
+export type IncidentRetrospective = IncidentRetrospectiveInput & {
+	publishedAt: string
+}
+
+export type RetrospectiveParseError =
+	| 'not-object'
+	| 'invalid-field'
+	| 'empty-field'
+	| 'too-long'
+	| 'invalid-timeline'
+
+export type RetrospectiveParseResult =
+	| { ok: true; retrospective: IncidentRetrospectiveInput }
+	| { ok: false; error: RetrospectiveParseError; message: string }
+
+const requiredTextFields = [
+	'whatHappened',
+	'impact',
+	'cause',
+	'whatWeDid',
+	'whatWeWillChange',
+] as const
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+	if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+		return null
+	}
+	return value as Record<string, unknown>
+}
+
+function readTrimmedString(
+	value: unknown,
+	field: string,
+	maxChars: number,
+):
+	| { ok: true; value: string }
+	| { ok: false; result: RetrospectiveParseResult } {
+	if (typeof value !== 'string') {
+		return {
+			ok: false,
+			result: {
+				ok: false,
+				error: 'invalid-field',
+				message: `${field} must be a string`,
+			},
+		}
+	}
+	const trimmed = value.trim()
+	if (!trimmed) {
+		return {
+			ok: false,
+			result: {
+				ok: false,
+				error: 'empty-field',
+				message: `${field} must not be empty`,
+			},
+		}
+	}
+	if (trimmed.length > maxChars) {
+		return {
+			ok: false,
+			result: {
+				ok: false,
+				error: 'too-long',
+				message: `${field} must be at most ${maxChars} characters`,
+			},
+		}
+	}
+	return { ok: true, value: trimmed }
+}
+
+function parseTimeline(
+	value: unknown,
+):
+	| { ok: true; timeline: Array<RetrospectiveTimelineEntry> }
+	| { ok: false; result: RetrospectiveParseResult } {
+	if (!Array.isArray(value)) {
+		return {
+			ok: false,
+			result: {
+				ok: false,
+				error: 'invalid-timeline',
+				message: 'timeline must be an array',
+			},
+		}
+	}
+	if (value.length === 0 || value.length > retrospectiveTimelineMaxEntries) {
+		return {
+			ok: false,
+			result: {
+				ok: false,
+				error: 'invalid-timeline',
+				message: `timeline must have 1–${retrospectiveTimelineMaxEntries} entries`,
+			},
+		}
+	}
+	const timeline: Array<RetrospectiveTimelineEntry> = []
+	for (const [index, entry] of value.entries()) {
+		const record = asRecord(entry)
+		if (!record) {
+			return {
+				ok: false,
+				result: {
+					ok: false,
+					error: 'invalid-timeline',
+					message: `timeline[${index}] must be an object`,
+				},
+			}
+		}
+		const at = readTrimmedString(
+			record.at,
+			`timeline[${index}].at`,
+			retrospectiveTimelineAtMaxChars,
+		)
+		if (!at.ok) return { ok: false, result: at.result }
+		const note = readTrimmedString(
+			record.note,
+			`timeline[${index}].note`,
+			retrospectiveTimelineNoteMaxChars,
+		)
+		if (!note.ok) return { ok: false, result: note.result }
+		timeline.push({ at: at.value, note: note.value })
+	}
+	return { ok: true, timeline }
+}
+
+/** Validates an operator write body. Ignores publishedAt; the store stamps it. */
+export function parseIncidentRetrospectiveInput(
+	value: unknown,
+): RetrospectiveParseResult {
+	const record = asRecord(value)
+	if (!record) {
+		return {
+			ok: false,
+			error: 'not-object',
+			message: 'body must be an object',
+		}
+	}
+	const fields: Partial<IncidentRetrospectiveInput> = {}
+	for (const field of requiredTextFields) {
+		const parsed = readTrimmedString(
+			record[field],
+			field,
+			retrospectiveFieldMaxChars,
+		)
+		if (!parsed.ok) return parsed.result
+		fields[field] = parsed.value
+	}
+	const timeline = parseTimeline(record.timeline)
+	if (!timeline.ok) return timeline.result
+	return {
+		ok: true,
+		retrospective: {
+			whatHappened: fields.whatHappened!,
+			impact: fields.impact!,
+			timeline: timeline.timeline,
+			cause: fields.cause!,
+			whatWeDid: fields.whatWeDid!,
+			whatWeWillChange: fields.whatWeWillChange!,
+		},
+	}
+}
+
+export function stampIncidentRetrospective(
+	input: IncidentRetrospectiveInput,
+	publishedAtMs: number,
+): IncidentRetrospective {
+	return {
+		...input,
+		publishedAt: new Date(publishedAtMs).toISOString(),
+	}
+}
+
+export function serializeIncidentRetrospective(
+	retrospective: IncidentRetrospective,
+): string {
+	return JSON.stringify(retrospective)
+}
+
+/** Stored JSON that cannot be parsed is dropped so a bad write cannot 500 the page. */
+export function parseStoredIncidentRetrospective(
+	raw: string | null | undefined,
+): IncidentRetrospective | null {
+	if (typeof raw !== 'string' || !raw.trim()) return null
+	let parsed: unknown
+	try {
+		parsed = JSON.parse(raw) as unknown
+	} catch {
+		return null
+	}
+	const input = parseIncidentRetrospectiveInput(parsed)
+	if (!input.ok) return null
+	const record = asRecord(parsed)
+	const publishedAt =
+		typeof record?.publishedAt === 'string' && record.publishedAt.trim()
+			? record.publishedAt.trim()
+			: null
+	if (!publishedAt) return null
+	return { ...input.retrospective, publishedAt }
+}
+
+export function incidentsTableHasRetrospectiveColumn(
+	columns: ReadonlyArray<{ name: string }>,
+): boolean {
+	return columns.some((column) => column.name === incidentRetrospectiveColumn)
+}
+
+export const addIncidentRetrospectiveColumnSql = `ALTER TABLE incidents ADD COLUMN ${incidentRetrospectiveColumn} TEXT`
+
+export const selectIncidentByIdSql = `SELECT id, component, started_at, resolved_at, detail, retrospective
+FROM incidents WHERE id = ?`
+
+export const updateIncidentRetrospectiveSql = `UPDATE incidents SET retrospective = ?
+WHERE id = ? AND resolved_at IS NOT NULL`
+
+export type IncidentRow = {
+	id: number
+	component: string
+	started_at: number
+	resolved_at: number | null
+	detail: string | null
+	retrospective: string | null
+}
+
+export function incidentRowToView(row: IncidentRow): IncidentView | null {
+	if (!isStatusComponentId(row.component)) return null
+	return {
+		id: row.id,
+		component: row.component,
+		componentName: statusComponentName(row.component),
+		startedAt: new Date(row.started_at).toISOString(),
+		resolvedAt:
+			row.resolved_at === null ? null : new Date(row.resolved_at).toISOString(),
+		detail: row.detail,
+		retrospective: parseStoredIncidentRetrospective(row.retrospective),
+	}
+}

--- a/packages/status/retrospectives/jobs-2026-09-02.json
+++ b/packages/status/retrospectives/jobs-2026-09-02.json
@@ -1,0 +1,57 @@
+{
+	"whatHappened": "Jobs probes failed twice in a row and opened status incident 10. The public page showed Jobs as down with probe detail \"error\" for two minutes, then two successful probes resolved it. All other measured status components stayed operational.",
+	"impact": "The status page looked alarming for Jobs. Live Jobs traffic uses the JOBS service binding, not a public hostname, and recovered with the probes (2 failed samples, 2 incident minutes). App & API, MCP, package runtime, primary database, KV, and assets stayed green with zero failures that day. jobs.kody.codes returning Cloudflare error 1016 is expected and is not an outage: the jobs worker has no public hostname.",
+	"timeline": [
+		{
+			"at": "2026-09-02T20:33:50Z",
+			"note": "2:33pm MDT — last full good production deploy that included jobs, highlight, and origin (run 33680026797, sha 5a0ca0b)."
+		},
+		{
+			"at": "2026-09-02T20:48:29Z",
+			"note": "2:48pm MDT — #1994 (c0cae0c) production deploy failed at Deploy jobs worker and Deploy highlight worker with Cloudflare Authentication error [code: 10000]; origin was skipped."
+		},
+		{
+			"at": "2026-09-02T20:58:12Z",
+			"note": "2:58pm MDT — #2005 filed (PR preview wrangler d1 list hitting the same Cloudflare 10000 auth error)."
+		},
+		{
+			"at": "2026-09-02T20:58:33Z",
+			"note": "2:58pm MDT — #1999 (98c97b3) production deploy failed the same way; origin skipped."
+		},
+		{
+			"at": "2026-09-02T21:08:58Z",
+			"note": "3:08pm MDT — #2004 (3e405b5) production deploy failed the same way; origin skipped."
+		},
+		{
+			"at": "2026-09-02T21:30:15Z",
+			"note": "3:30pm MDT — #2008 merged (narrower runtime Cloudflare API token wiring)."
+		},
+		{
+			"at": "2026-09-02T21:40:06Z",
+			"note": "3:40pm MDT — #2008 production deploy uploaded the jobs worker successfully (run 33685703674, sha 4701dfb). Highlight, nx-cache, origin, and status also succeeded in that 3:32–3:43pm MDT run. That is the proof the GitHub token could deploy jobs again."
+		},
+		{
+			"at": "2026-09-02T21:57:54.765Z",
+			"note": "3:57pm MDT — Jobs incident 10 opened after two consecutive failed probes (detail: error), about 15 minutes after that jobs/origin/status redeploy finished."
+		},
+		{
+			"at": "2026-09-02T21:58:57Z",
+			"note": "3:58pm MDT — #2011 merged (skip jobs, highlight, and nx-cache deploys unless those sources change)."
+		},
+		{
+			"at": "2026-09-02T22:00:51.866Z",
+			"note": "4:00pm MDT — Jobs incident 10 resolved after two consecutive successful probes (2 incident minutes)."
+		},
+		{
+			"at": "2026-09-02T22:01:23Z",
+			"note": "4:01pm MDT — origin deploy 195f28b succeeded; jobs/highlight/nx-cache were skipped."
+		},
+		{
+			"at": "2026-09-02T22:09:46Z",
+			"note": "4:09pm MDT — origin deploy 5f9e564 (#2003) succeeded; jobs skipped. Live jobs worker commit on the status page stayed 4701dfb."
+		}
+	],
+	"cause": "No confirmed root cause. Earlier that afternoon, GitHub Actions could not deploy the jobs or highlight workers after Cloudflare API tokens were scoped down (Authentication error [code: 10000] on the Cloudflare D1 list call). An operator also rolled a Cloudflare token so the new value could be stored in GitHub; rolling invalidates the old secret immediately while already-running Workers still hold it until the next secret sync, which can cause a short API blip. The two-minute Jobs probe incident started about 15 minutes after the successful jobs/origin/status redeploy that uploaded kody-jobs (JobManager Durable Object listed in that deploy). Token-roll aftershock, deploy aftershock, and flaky probes are all still plausible. This writeup does not treat any of those as proven.",
+	"whatWeDid": "Restored jobs-worker deploys by merging #2008 and completing production run 33685703674 (sha 4701dfb), including the jobs worker at 3:40pm MDT. #2011 then stopped uploading jobs, highlight, and nx-cache unless those sources change, so later origin deploys (195f28b at 4:01pm, 5f9e564 at 4:09pm) succeeded with jobs skipped. Live Jobs via the service binding recovered with the probes. We are not finishing #2010 (split the combined token) or revoking the combined token as part of this incident.",
+	"whatWeWillChange": "Publish a short public retrospective on resolved status incidents so the page is not just the probe detail. Keep treating jobs.kody.codes 1016 as expected, not an outage. If Jobs probes flap again after a jobs-worker deploy or token roll, investigate the service-binding probe before assuming customer impact. Do not split or revoke the remaining combined Cloudflare API token because of this incident."
+}

--- a/packages/status/status-page.node.test.ts
+++ b/packages/status/status-page.node.test.ts
@@ -79,6 +79,7 @@ test('status page renders components, incidents, unknown state, and escapes deta
 					startedAt: '2026-08-04T11:00:00.000Z',
 					resolvedAt: null,
 					detail: 'timeout',
+					retrospective: null,
 				},
 			],
 		}),
@@ -98,6 +99,7 @@ test('status page renders components, incidents, unknown state, and escapes deta
 					startedAt: '2026-08-01T00:00:00.000Z',
 					resolvedAt: '2026-08-01T01:00:00.000Z',
 					detail: '<img src=x onerror=alert(1)>',
+					retrospective: null,
 				},
 			],
 		}),
@@ -190,4 +192,60 @@ test('status page renders provider incidents separately and omits them when abse
 	)
 	expect(unsafeLink).not.toContain('javascript:alert')
 	expect(unsafeLink).toContain('https://www.cloudflarestatus.com')
+})
+
+test('status page keeps resolved incidents glanceable and expands a retrospective', () => {
+	const withoutWriteup = renderStatusPage(
+		snapshot({
+			recentIncidents: [
+				{
+					id: 10,
+					component: 'jobs',
+					componentName: 'Jobs',
+					startedAt: '2026-09-02T21:57:54.765Z',
+					resolvedAt: '2026-09-02T22:00:51.866Z',
+					detail: 'error',
+					retrospective: null,
+				},
+			],
+		}),
+	)
+	expect(withoutWriteup).toContain('Jobs outage (resolved) — error')
+	expect(withoutWriteup).not.toContain('<details class="retrospective">')
+
+	const withWriteup = renderStatusPage(
+		snapshot({
+			recentIncidents: [
+				{
+					id: 10,
+					component: 'jobs',
+					componentName: 'Jobs',
+					startedAt: '2026-09-02T21:57:54.765Z',
+					resolvedAt: '2026-09-02T22:00:51.866Z',
+					detail: 'error',
+					retrospective: {
+						whatHappened: 'Two failed Jobs probes.',
+						impact: 'Status page looked alarming.',
+						timeline: [
+							{
+								at: '2026-09-02T21:57:54.765Z',
+								note: 'Opened after consecutive failures.',
+							},
+						],
+						cause: 'Unconfirmed. <script>alert(1)</script>',
+						whatWeDid: 'Probes recovered.',
+						whatWeWillChange: 'Publish retrospectives.',
+						publishedAt: '2026-09-02T22:20:00.000Z',
+					},
+				},
+			],
+		}),
+	)
+	expect(withWriteup).toContain('Jobs outage (resolved) — error')
+	expect(withWriteup).toContain('<details class="retrospective">')
+	expect(withWriteup).toContain('<summary>Retrospective</summary>')
+	expect(withWriteup).toContain('Two failed Jobs probes.')
+	expect(withWriteup).toContain('What we will change')
+	expect(withWriteup).not.toContain('<script>alert(1)</script>')
+	expect(withWriteup).toContain('&lt;script&gt;alert(1)&lt;/script&gt;')
 })

--- a/packages/status/status-page.ts
+++ b/packages/status/status-page.ts
@@ -116,6 +116,24 @@ h1 { font-size: 1.5rem; margin: 0; }
 .incident.resolved { border-left-color: var(--ok); }
 .incident-title { font-weight: 600; }
 .incident-meta { color: var(--muted); font-size: 0.85rem; }
+.retrospective { margin-top: 0.5rem; }
+.retrospective summary {
+	cursor: pointer;
+	color: var(--muted);
+	font-size: 0.85rem;
+	font-weight: 600;
+}
+.retrospective-section { margin: 0.6rem 0 0; }
+.retrospective-section h3 {
+	margin: 0 0 0.2rem;
+	font-size: 0.8rem;
+	text-transform: uppercase;
+	letter-spacing: 0.03em;
+	color: var(--muted);
+}
+.retrospective-section p,
+.retrospective-section li { margin: 0; white-space: pre-wrap; }
+.retrospective-section ol { margin: 0; padding-left: 1.1rem; }
 .provider-section {
 	margin: 2rem 0 1rem;
 	padding: 1rem 1.25rem;
@@ -194,6 +212,27 @@ function renderComponent(component: ComponentSnapshot): string {
 </div>`
 }
 
+function renderRetrospective(incident: IncidentView): string {
+	const retrospective = incident.retrospective
+	if (!retrospective) return ''
+	const timeline = retrospective.timeline
+		.map(
+			(entry) =>
+				`<li><span class="incident-meta">${escapeHtml(entry.at)}</span> — ${escapeHtml(entry.note)}</li>`,
+		)
+		.join('')
+	return `<details class="retrospective">
+	<summary>Retrospective</summary>
+	<div class="retrospective-section"><h3>What happened</h3><p>${escapeHtml(retrospective.whatHappened)}</p></div>
+	<div class="retrospective-section"><h3>Impact</h3><p>${escapeHtml(retrospective.impact)}</p></div>
+	<div class="retrospective-section"><h3>Timeline</h3><ol>${timeline}</ol></div>
+	<div class="retrospective-section"><h3>Cause</h3><p>${escapeHtml(retrospective.cause)}</p></div>
+	<div class="retrospective-section"><h3>What we did</h3><p>${escapeHtml(retrospective.whatWeDid)}</p></div>
+	<div class="retrospective-section"><h3>What we will change</h3><p>${escapeHtml(retrospective.whatWeWillChange)}</p></div>
+	<div class="incident-meta">Published ${escapeHtml(retrospective.publishedAt)}</div>
+</details>`
+}
+
 function renderIncident(incident: IncidentView): string {
 	const resolved = incident.resolvedAt !== null
 	const detail = incident.detail ? ` — ${escapeHtml(incident.detail)}` : ''
@@ -203,6 +242,7 @@ function renderIncident(incident: IncidentView): string {
 	return `<div class="incident${resolved ? ' resolved' : ''}">
 	<div class="incident-title">${escapeHtml(incident.componentName)} ${resolved ? 'outage (resolved)' : 'is down'}${detail}</div>
 	<div class="incident-meta">${timing}</div>
+	${renderRetrospective(incident)}
 </div>`
 }
 

--- a/packages/status/status-store.ts
+++ b/packages/status/status-store.ts
@@ -25,6 +25,16 @@ import {
 	type StatusIncidentEventPayload,
 } from './incident-events.ts'
 import {
+	addIncidentRetrospectiveColumnSql,
+	incidentRowToView,
+	incidentsTableHasRetrospectiveColumn,
+	selectIncidentByIdSql,
+	serializeIncidentRetrospective,
+	updateIncidentRetrospectiveSql,
+	type IncidentRetrospective,
+	type IncidentRow,
+} from './retrospective.ts'
+import {
 	publicAuditDbRetiredMetaKey,
 	retirePublicAuditDbData,
 } from './retire-public-audit-db.ts'
@@ -37,7 +47,6 @@ import {
 } from './provider-incidents.ts'
 import {
 	isStatusComponentId,
-	statusComponentName,
 	statusComponents,
 	type ComponentDayStat,
 	type ComponentSnapshot,
@@ -132,9 +141,11 @@ export class StatusStore extends DurableObject<StatusWorkerEnv> {
 				component TEXT NOT NULL,
 				started_at INTEGER NOT NULL,
 				resolved_at INTEGER,
-				detail TEXT
+				detail TEXT,
+				retrospective TEXT
 			)
 		`)
+		this.ensureIncidentRetrospectiveColumn()
 		this.ctx.storage.sql.exec(`
 			CREATE TABLE IF NOT EXISTS notifications (
 				id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -153,6 +164,14 @@ export class StatusStore extends DurableObject<StatusWorkerEnv> {
 		`)
 		this.maybeRetirePublicAuditDb()
 		this.maybeClearNonIncidentFailures()
+	}
+
+	private ensureIncidentRetrospectiveColumn() {
+		const columns = this.ctx.storage.sql
+			.exec<{ name: string }>(`PRAGMA table_info(incidents)`)
+			.toArray()
+		if (incidentsTableHasRetrospectiveColumn(columns)) return
+		this.ctx.storage.sql.exec(addIncidentRetrospectiveColumnSql)
 	}
 
 	private maybeRetirePublicAuditDb() {
@@ -538,6 +557,27 @@ export class StatusStore extends DurableObject<StatusWorkerEnv> {
 		this.prune(now)
 	}
 
+	async setIncidentRetrospective(
+		id: number,
+		retrospective: IncidentRetrospective,
+	): Promise<
+		| { ok: true; incident: IncidentView }
+		| { ok: false; error: 'not-found' | 'not-resolved' }
+	> {
+		const existing = this.loadIncidentById(id)
+		if (!existing) return { ok: false, error: 'not-found' }
+		if (existing.resolvedAt === null)
+			return { ok: false, error: 'not-resolved' }
+		this.ctx.storage.sql.exec(
+			updateIncidentRetrospectiveSql,
+			serializeIncidentRetrospective(retrospective),
+			id,
+		)
+		const updated = this.loadIncidentById(id)
+		if (!updated) return { ok: false, error: 'not-found' }
+		return { ok: true, incident: updated }
+	}
+
 	async getSnapshot(): Promise<StatusSnapshot> {
 		const now = Date.now()
 		const windowStartMs = Date.parse(
@@ -665,33 +705,23 @@ export class StatusStore extends DurableObject<StatusWorkerEnv> {
 			kind === 'open' ? 'resolved_at IS NULL' : 'resolved_at IS NOT NULL'
 		const order = kind === 'open' ? 'started_at ASC' : 'started_at DESC'
 		return this.ctx.storage.sql
-			.exec<{
-				id: number
-				component: string
-				started_at: number
-				resolved_at: number | null
-				detail: string | null
-			}>(
-				`SELECT id, component, started_at, resolved_at, detail
+			.exec<IncidentRow>(
+				`SELECT id, component, started_at, resolved_at, detail, retrospective
 				FROM incidents WHERE ${where} ORDER BY ${order} LIMIT ?`,
 				recentIncidentLimit,
 			)
 			.toArray()
 			.flatMap((row) => {
-				if (!isStatusComponentId(row.component)) return []
-				return [
-					{
-						id: row.id,
-						component: row.component,
-						componentName: statusComponentName(row.component),
-						startedAt: new Date(row.started_at).toISOString(),
-						resolvedAt:
-							row.resolved_at === null
-								? null
-								: new Date(row.resolved_at).toISOString(),
-						detail: row.detail,
-					},
-				]
+				const incident = incidentRowToView(row)
+				return incident ? [incident] : []
 			})
+	}
+
+	private loadIncidentById(id: number): IncidentView | null {
+		const row = this.ctx.storage.sql
+			.exec<IncidentRow>(selectIncidentByIdSql, id)
+			.toArray()[0]
+		if (!row) return null
+		return incidentRowToView(row)
 	}
 }

--- a/packages/status/status-types.ts
+++ b/packages/status/status-types.ts
@@ -3,6 +3,7 @@
  * state, and the snapshot shape the public page renders.
  */
 
+import { type IncidentRetrospective } from './retrospective.ts'
 import { type ProviderIncident } from './provider-incidents.ts'
 
 export type { ProviderIncident }
@@ -50,6 +51,8 @@ export type IncidentView = {
 	startedAt: string
 	resolvedAt: string | null
 	detail: string | null
+	/** Operator writeup. Null when probes opened/resolved the incident only. */
+	retrospective: IncidentRetrospective | null
 }
 
 export type ComponentDayStat = {

--- a/packages/status/worker.ts
+++ b/packages/status/worker.ts
@@ -1,4 +1,9 @@
 import { faviconIcoRedirectLocation } from './favicon.ts'
+import {
+	handleIncidentRetrospectiveRequest,
+	parseIncidentRetrospectivePath,
+	unknownStatusMaintenanceResponse,
+} from './retrospective-maintenance.ts'
 import { renderStatusPage, renderStatusUnavailablePage } from './status-page.ts'
 import { StatusStore, type StatusWorkerEnv } from './status-store.ts'
 import { type ComponentStatus } from './status-types.ts'
@@ -9,12 +14,32 @@ function getStore(env: StatusWorkerEnv) {
 	return env.STATUS_STORE.get(env.STATUS_STORE.idFromName('singleton'))
 }
 
+async function handleMaintenance(
+	request: Request,
+	env: StatusWorkerEnv,
+	pathname: string,
+): Promise<Response> {
+	const incidentId = parseIncidentRetrospectivePath(pathname)
+	if (incidentId === null) return unknownStatusMaintenanceResponse()
+	const store = getStore(env)
+	return handleIncidentRetrospectiveRequest({
+		request,
+		incidentId,
+		secret: env.STATUS_INCIDENT_EVENT_SECRET,
+		setRetrospective: (id, retrospective) =>
+			store.setIncidentRetrospective(id, retrospective),
+	})
+}
+
 export default {
 	async fetch(request, env) {
+		const url = new URL(request.url)
+		if (url.pathname.startsWith('/__maintenance/')) {
+			return handleMaintenance(request, env, url.pathname)
+		}
 		if (request.method !== 'GET' && request.method !== 'HEAD') {
 			return new Response('Method not allowed', { status: 405 })
 		}
-		const url = new URL(request.url)
 		if (url.pathname === '/health') {
 			return Response.json(
 				{ ok: true, commit: env.BUILD_COMMIT ?? null },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Give the public status page a human retrospective on a resolved incident, then publish one for today's two-minute Jobs probe incident (id 10).

## Why

ADR 0004 deferred operator-authored incident narratives. Probe records still open and resolve incidents, but `/status.json` and the page only show a short `detail` (today's Jobs incident is `"error"`). That is not enough after a real event.

## Summary

- Optional structured `retrospective` on the existing `StatusStore` incident row (what happened, impact, timeline, cause, what we did, what we will change).
- Probe open/resolve is unchanged and does not require a narrative.
- Operator write is `POST /__maintenance/incidents/:id/retrospective` on the **status** worker, bearer `STATUS_INCIDENT_EVENT_SECRET`. No origin / `APP_DB` dependency, no public unauthenticated write. Open incidents return 409.
- Public HTML keeps the one-line incident and puts the writeup in `<details>`. `/status.json` adds `retrospective` (`null` when absent).
- ADR 0004 later update (2026-09-02) records that narratives are built.
- Payload for incident 10: `packages/status/retrospectives/jobs-2026-09-02.json`.

### Post-deploy (required)

The write cannot land until this worker is live. After `deploy-status-worker` succeeds:

```bash
curl -fsS -X POST \
  "https://status.kody.codes/__maintenance/incidents/10/retrospective" \
  -H "Authorization: Bearer $STATUS_INCIDENT_EVENT_SECRET" \
  -H "Content-Type: application/json" \
  --data @packages/status/retrospectives/jobs-2026-09-02.json
```

`$STATUS_INCIDENT_EVENT_SECRET` is the existing GitHub Actions / Worker secret already synced to `kody-status`. Confirm on `GET https://status.kody.codes/status.json` that incident 10 has a non-null `retrospective`.

### Incident 10 facts checked before writing

Against live `https://status.kody.codes/status.json` and GitHub Actions / PRs on 2026-09-02:

- Incident 10: Jobs, `2026-09-02T21:57:54.765Z` → `2026-09-02T22:00:51.866Z` (3:57–4:00pm MDT), detail `error`, 2 failed probes, 2 incident minutes. Other cards 0 failures that day.
- Last full good jobs+highlight+origin deploy: 2:33pm MDT, run 33680026797, sha `5a0ca0b`.
- Failed deploys at Deploy jobs worker / Deploy highlight worker with `Authentication error [code: 10000]`, origin skipped: 2:48pm #1994 `c0cae0c`, 2:58pm #1999 `98c97b3`, 3:08pm #2004 `3e405b5`.
- #2005 filed 2:58pm MDT (preview `wrangler d1 list` 10000).
- #2008 merged 3:30pm; production run 33685703674 (`4701dfb`) 3:32–3:43pm succeeded, jobs worker 3:40pm. Live `jobsCommit` is still `4701dfb`.
- #2011 merged 3:58pm. Later origin deploys succeeded with jobs skipped: 4:01pm `195f28b`, 4:09pm `5f9e564` (#2003). (4:09pm is the Actions `created_at`, not 4:11pm.)
- Cause is stated as unconfirmed (token-roll vs deploy aftershock vs flaky probes). Does not recommend finishing #2010 or revoking the combined token.
- `jobs.kody.codes` 1016 is called out as expected, not an outage.

## Testing

- `npx vitest run packages/status/*.node.test.ts --project node-unit` — 11 files, 21 tests passed (parse/store mapping, maintenance auth, page render with/without writeup, existing probe hysteresis).
- `npx tsc --noEmit -p packages/status/tsconfig.json`
- `npm run status:build` (wrangler dry-run)
- `npm run docs:check-temporal` and `docs:check-decisions`
- Push hook `test:push` (node + workers unit)
- Local render of the Jobs payload: glanceable Past incidents line plus collapsed/expanded `<details>` writeup (all six sections).

Preview origin (`https://kody-pr-2012.kody-a99.workers.dev`) cannot host this change — status is an independent worker and deploys from `main` / workflow_dispatch only. `preview:manual-test` still ran against that preview:

- `/health` ok, `commitSha` `31e0eda` (merge of `130cf3e` into `dac76d9`)
- seed login as `me@kentcdodds.com`; `/admin` 403; `/mcp` 401
- `POST /__maintenance/incidents/10/retrospective` on the preview origin returns `404 Unknown maintenance endpoint` (correct: that write lives on `status.kody.codes`)
- Live `https://status.kody.codes/status.json` still has incident 10 with no `retrospective` until the post-deploy curl after this worker is live

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `5f9e5642` · **Head:** `130cf3e2`

**Classification:** extends — `status-page` gains an optional incident narrative and a secret-gated write on the isolated status worker.

### Primitives touched

| Primitive     | Group    | Impact                                                                 |
| ------------- | -------- | ---------------------------------------------------------------------- |
| `status-page` | surfaces | extends — optional retrospective on probe-derived incidents            |

Unmatched paths are contributing docs for that same surface (ADR 0004, setup-manifest, env vars, authorization).

### Change flow

An operator publishes a writeup to a resolved StatusStore incident; probes still own open/resolve.

```mermaid
sequenceDiagram
	actor Operator
	participant statusPage as status-page
	participant statusStore as StatusStore
	Operator->>statusPage: POST /__maintenance/incidents/:id/retrospective (Bearer STATUS_INCIDENT_EVENT_SECRET)
	statusPage->>statusStore: setIncidentRetrospective (resolved rows only)
	Note over statusStore: incidents.retrospective TEXT JSON
	statusPage-->>Operator: 200 + IncidentView
	actor Public
	Public->>statusPage: GET / or /status.json
	statusPage->>statusStore: getSnapshot
	statusStore-->>statusPage: IncidentView.retrospective or null
	statusPage-->>Public: glanceable list + details writeup
```

### Before / after

**Incident JSON**

```json
{ "id": 10, "detail": "error", "retrospective": null }
```

```json
{ "id": 10, "detail": "error", "retrospective": { "whatHappened": "…", "impact": "…", "timeline": [], "cause": "…", "whatWeDid": "…", "whatWeWillChange": "…", "publishedAt": "…" } }
```

### Invariants

Status stays off `APP_DB` and independent of origin (ADR 0004). Probe hysteresis still opens/resolves without a narrative.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-de089c77-b8d3-4fe6-aa4f-f45b228fe609?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-de089c77-b8d3-4fe6-aa4f-f45b228fe609&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Resolved status incidents can now include publicly visible operator retrospectives.
  - Retrospectives display on the status page in a collapsible section and are available through the public JSON status snapshot.
  - Authorized maintenance requests can publish writeups for resolved incidents, including impact, timeline, cause, and follow-up actions.
  - Open or unknown incidents cannot receive retrospectives.

- **Documentation**
  - Added guidance covering retrospective publishing, storage, rendering, authentication, and endpoint behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->