### PR TITLE
Keep late-bound kody.mcp tools callable when MCP Get throws

### DIFF
--- a/packages/worker/src/package-runtime/runtime-isolation.node.test.ts
+++ b/packages/worker/src/package-runtime/runtime-isolation.node.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os'
 import { pathToFileURL } from 'node:url'
 import { AsyncLocalStorage } from 'node:async_hooks'
 import { expect, test } from 'vitest'
+import { createKodyRemoteProxy } from '#mcp/executor.ts'
 import { createRuntimeModuleSource } from './module-graph.ts'
 
 // The kody:runtime virtual module captures its named exports statically
@@ -405,6 +406,102 @@ test('destructured kody.mcp tools resolve against the calling run', async () => 
 		expect(result).toEqual({
 			viaHome: { run: 'second' },
 			viaTool: { run: 'second' },
+		})
+	})
+})
+
+test('kody.mcp tool calls stay callable when the current run throws on Get', async () => {
+	await withRuntimeIsolationCleanup(async ({ writeRuntimeFile }) => {
+		const sharedStorage = new AsyncLocalStorage<unknown>()
+		;(globalThis as unknown as Record<symbol, unknown>)[
+			Symbol.for('kody.runtimeStorage')
+		] = sharedStorage
+		const url = await writeRuntimeFile()
+		const mod = (await import(url)) as RuntimeModule & {
+			kody: {
+				mcp: Record<string, Record<string, (args: unknown) => Promise<unknown>>>
+			}
+		}
+		const oauthWaitingMessage =
+			'The MCP server "home" is waiting for OAuth authorization. Complete the authorization from /account/mcp-servers. Check mcpServerList for connection status.'
+
+		function authenticatingHomeRuntime() {
+			return {
+				kody: {
+					mcp: createKodyRemoteProxy({
+						entries: [
+							{
+								name: 'home',
+								status: {
+									state: 'authenticating',
+									connected: false,
+									toolCount: 0,
+									message:
+										'The MCP server "home" is waiting for OAuth authorization. Complete the authorization from /account/mcp-servers.',
+									unavailableMessage: oauthWaitingMessage,
+								},
+								capabilities: [],
+							},
+						],
+						async callTool() {
+							throw new Error('authenticating servers must not dispatch')
+						},
+					}),
+				},
+			}
+		}
+
+		await sharedStorage.run(authenticatingHomeRuntime(), async () => {
+			// createKodyRemoteProxy throws on Get; the isolate stand-in is
+			// callable and rethrows that same message on the call, not as a
+			// TypeError "is not a function".
+			expect(() => mod.kody.mcp.home.venstar_get_thermostat_info({})).toThrow(
+				oauthWaitingMessage,
+			)
+			expect(() => mod.kody.mcp.home.sonos_list_players({})).toThrow(
+				oauthWaitingMessage,
+			)
+
+			const { home } = mod.kody.mcp
+			const { venstar_get_thermostat_info } = home
+			expect(typeof venstar_get_thermostat_info).toBe('function')
+			expect(() => venstar_get_thermostat_info({})).toThrow(oauthWaitingMessage)
+		})
+
+		const captured = await sharedStorage.run(
+			authenticatingHomeRuntime(),
+			async () => {
+				const { home } = mod.kody.mcp
+				const { venstar_get_thermostat_info } = home
+				return { home, venstar_get_thermostat_info }
+			},
+		)
+
+		const result = await sharedStorage.run(
+			{
+				kody: {
+					mcp: {
+						home: {
+							async venstar_get_thermostat_info(args: unknown) {
+								return { ok: true, args }
+							},
+						},
+					},
+				},
+			},
+			async () => ({
+				viaHome: await captured.home.venstar_get_thermostat_info({
+					thermostat: 'office',
+				}),
+				viaTool: await captured.venstar_get_thermostat_info({
+					thermostat: 'office',
+				}),
+			}),
+		)
+
+		expect(result).toEqual({
+			viaHome: { ok: true, args: { thermostat: 'office' } },
+			viaTool: { ok: true, args: { thermostat: 'office' } },
 		})
 	})
 })

--- a/packages/worker/src/package-runtime/runtime-isolation.node.test.ts
+++ b/packages/worker/src/package-runtime/runtime-isolation.node.test.ts
@@ -455,6 +455,8 @@ test('kody.mcp tool calls stay callable when the current run throws on Get', asy
 			// createKodyRemoteProxy throws on Get; the isolate stand-in is
 			// callable and rethrows that same message on the call, not as a
 			// TypeError "is not a function".
+			expect(Object.keys(mod.kody.mcp)).toEqual(['home'])
+			expect(Object.keys(mod.kody.mcp.home)).toEqual([])
 			expect(() => mod.kody.mcp.home.venstar_get_thermostat_info({})).toThrow(
 				oauthWaitingMessage,
 			)
@@ -490,6 +492,8 @@ test('kody.mcp tool calls stay callable when the current run throws on Get', asy
 				},
 			},
 			async () => ({
+				serverNames: Object.keys(mod.kody.mcp),
+				toolNames: Object.keys(mod.kody.mcp.home),
 				viaHome: await captured.home.venstar_get_thermostat_info({
 					thermostat: 'office',
 				}),
@@ -500,6 +504,8 @@ test('kody.mcp tool calls stay callable when the current run throws on Get', asy
 		)
 
 		expect(result).toEqual({
+			serverNames: ['home'],
+			toolNames: ['venstar_get_thermostat_info'],
 			viaHome: { ok: true, args: { thermostat: 'office' } },
 			viaTool: { ok: true, args: { thermostat: 'office' } },
 		})

--- a/packages/worker/src/package-runtime/runtime-source-modules.ts
+++ b/packages/worker/src/package-runtime/runtime-source-modules.ts
@@ -186,7 +186,10 @@ function __kodyLateBoundNestedPropertyDescriptor(exportName, path, property) {
 
 function __kodyCreateRuntimeNestedObjectProxy(exportName, path) {
 	const nestedExportName = exportName + '.' + path.map(String).join('.');
-	return new Proxy(function () {}, {
+	// Arrow target: a normal function's non-configurable prototype must
+	// appear in [[OwnPropertyKeys]], so ownKeys that forwards only the
+	// runtime parent keys would throw on Object.keys(kody.mcp).
+	return new Proxy(() => {}, {
 		apply(_target, _thisArg, args) {
 			return __kodyApplyRuntimeNestedValue(exportName, path, args);
 		},

--- a/packages/worker/src/package-runtime/runtime-source-modules.ts
+++ b/packages/worker/src/package-runtime/runtime-source-modules.ts
@@ -132,17 +132,9 @@ function __kodyReadRuntimeNestedValue(exportName, path) {
 }
 
 function __kodyBindRuntimeNestedValue(exportName, path, property, value) {
-	const nestedExportName = exportName + '.' + [...path, property].map(String).join('.');
 	if (typeof value === 'function') {
 		return function (...args) {
-			const currentParent = __kodyReadRuntimeNestedValue(exportName, path);
-			const currentValue = currentParent?.[property];
-			if (typeof currentValue !== 'function') {
-				throw new Error(
-					\`kody:runtime export "\${nestedExportName}" is not callable in this execution context.\`,
-				);
-			}
-			return currentValue.apply(currentParent, args);
+			return __kodyApplyRuntimeNestedValue(exportName, [...path, property], args);
 		};
 	}
 	if (value != null && typeof value === 'object') {
@@ -151,10 +143,38 @@ function __kodyBindRuntimeNestedValue(exportName, path, property, value) {
 	return value;
 }
 
+function __kodyApplyRuntimeNestedValue(exportName, path, args) {
+	const nestedExportName = exportName + '.' + path.map(String).join('.');
+	const parentPath = path.slice(0, -1);
+	const property = path[path.length - 1];
+	const parent =
+		parentPath.length === 0
+			? __kodyReadRuntimeExport(exportName)
+			: __kodyReadRuntimeNestedValue(exportName, parentPath);
+	if (parent == null) {
+		throw new Error(
+			\`kody:runtime export "\${nestedExportName}" is not callable in this execution context.\`,
+		);
+	}
+	// Do not swallow Get throws: createKodyRemoteProxy raises the OAuth /
+	// disconnected message when a 0-tool server is accessed. Re-reading here
+	// surfaces that instead of TypeError "is not a function".
+	const currentValue = parent[property];
+	if (typeof currentValue !== 'function') {
+		throw new Error(
+			\`kody:runtime export "\${nestedExportName}" is not callable in this execution context.\`,
+		);
+	}
+	return currentValue.apply(parent, args);
+}
+
 // Bundler \`const { home } = kody.mcp\` uses [[GetOwnProperty]]. If the
 // current run's mcp proxy omits home (or throws on [[Get]]), bind a
 // late-bound nested proxy instead of undefined so a later run can still
 // resolve home.bond_shade_set_position against that run's kody.mcp.
+// The stand-in is callable: a same-run call re-reads the current mcp
+// proxy and surfaces its throw (OAuth waiting, unknown tool) instead of
+// TypeError "kody.mcp.home.tool is not a function".
 function __kodyLateBoundNestedPropertyDescriptor(exportName, path, property) {
 	return {
 		configurable: true,
@@ -166,7 +186,10 @@ function __kodyLateBoundNestedPropertyDescriptor(exportName, path, property) {
 
 function __kodyCreateRuntimeNestedObjectProxy(exportName, path) {
 	const nestedExportName = exportName + '.' + path.map(String).join('.');
-	return new Proxy({}, {
+	return new Proxy(function () {}, {
+		apply(_target, _thisArg, args) {
+			return __kodyApplyRuntimeNestedValue(exportName, path, args);
+		},
 		get(_target, property) {
 			const inspectionValue = __kodyRuntimeProxyInspectionValue(
 				nestedExportName,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Make package-isolate `kody.mcp` tool calls fail with the real MCP connection error (OAuth waiting, disconnected) instead of `TypeError: … is not a function`.

## Why

Jobs such as trip-conductor's `scan-trips` call `kody.mcp.home.venstar_get_thermostat_info` through the `kody:runtime` late-bound proxy. Execute already uses `createKodyRemoteProxy`, which throws `The MCP server "home" is waiting for OAuth authorization` when the server has 0 tools. The isolate wrapper swallowed that `Get` / GOPD throw and bound a non-callable object, so the same call became `kody33.mcp.home.venstar_get_thermostat_info is not a function` (also seen on `sonos_list_players`).

## Summary

- Late-bound nested `kody.mcp` stand-ins are now callable.
- A same-run call re-reads the current MCP proxy and surfaces its throw.
- A later run can still late-bind the real tool once the server is connected.
- Arrow-function proxy target so `Object.keys(kody.mcp)` does not trip the function-`prototype` ownKeys invariant.
- Regression covers the authenticating 0-tool `createKodyRemoteProxy` shape, bundler-style destructure, and reflective enumeration.

## Testing

- `npx vitest run --project node-unit` on `runtime-isolation` (7 passed)
- Push hook after the arrow-target follow-up: `test:node` 2461 passed, `test:workers` 321 passed

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `03fd8354` · **Head:** `ca719936`

**Classification:** extends — `kody:runtime` late-bound nested proxies are now callable so MCP Get throws surface as the real connection error.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `package-runtime` | runtime | extends — late-bound `kody.mcp` stand-ins are callable and rethrow the current run's MCP Get error |

### Change flow

A package job that calls `kody.mcp.home.tool()` while home is authenticating (0 tools) now gets the OAuth-waiting message instead of `TypeError: is not a function`.

```mermaid
sequenceDiagram
	actor Job as package job
	participant packageRuntime as package-runtime
	participant mcpProxy as createKodyRemoteProxy
	Job->>packageRuntime: kody.mcp.home.venstar_get_thermostat_info()
	packageRuntime->>mcpProxy: Get home.venstar_get_thermostat_info
	Note over mcpProxy: 0 tools, authUrl present
	mcpProxy-->>packageRuntime: throw OAuth waiting
	alt before
		packageRuntime-->>Job: non-callable object
		Job-->>Job: TypeError is not a function
	else after
		packageRuntime-->>Job: callable stand-in
		Job->>packageRuntime: call stand-in
		packageRuntime->>mcpProxy: re-Get tool
		mcpProxy-->>Job: throw OAuth waiting
	end
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-67c3262b-4194-4ce2-8bde-0a81de01bb9a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-67c3262b-4194-4ce2-8bde-0a81de01bb9a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where destructured MCP tools could fail with a generic “not a function” error during authentication.
  * MCP tool calls now correctly surface OAuth authentication prompts and can resolve to available implementations when the active runtime changes.
  * Improved runtime handling for nested callable tools, including preserving method context during invocation.
  * Fixed reflective enumeration of MCP servers and tools to prevent runtime errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->