### PR TITLE
fix(runtime): keep late-bound kody.mcp tools callable

### DIFF
--- a/packages/worker/src/package-runtime/runtime-isolation.node.test.ts
+++ b/packages/worker/src/package-runtime/runtime-isolation.node.test.ts
@@ -408,3 +408,73 @@ test('destructured kody.mcp tools resolve against the calling run', async () => 
 		})
 	})
 })
+
+test('kody.mcp.home.sonos_list_players stays callable when the current run throws on get', async () => {
+	await withRuntimeIsolationCleanup(async ({ writeRuntimeFile }) => {
+		const sharedStorage = new AsyncLocalStorage<unknown>()
+		;(globalThis as unknown as Record<symbol, unknown>)[
+			Symbol.for('kody.runtimeStorage')
+		] = sharedStorage
+		const url = await writeRuntimeFile()
+		const mod = (await import(url)) as RuntimeModule & {
+			kody: {
+				mcp: Record<string, Record<string, (args: unknown) => Promise<unknown>>>
+			}
+		}
+
+		const unavailableMessage =
+			'The MCP server "home" is not connected. Kody cannot use this server until it reconnects.'
+		const throwingHome = new Proxy(
+			{},
+			{
+				get(_target, property) {
+					if (property === 'sonos_list_players') {
+						throw new Error(unavailableMessage)
+					}
+					return undefined
+				},
+				getOwnPropertyDescriptor(_target, property) {
+					if (property === 'sonos_list_players') {
+						throw new Error(unavailableMessage)
+					}
+					return undefined
+				},
+			},
+		)
+
+		await expect(
+			sharedStorage.run(
+				{ kody: { mcp: { home: throwingHome } } },
+				async () => await mod.kody.mcp.home.sonos_list_players({}),
+			),
+		).rejects.toThrow(unavailableMessage)
+
+		const captured = await sharedStorage.run(
+			{ kody: { mcp: { home: throwingHome } } },
+			async () => mod.kody.mcp.home.sonos_list_players,
+		)
+
+		const result = await sharedStorage.run(
+			{
+				kody: {
+					mcp: {
+						home: {
+							async sonos_list_players() {
+								return { players: ['Kitchen'] }
+							},
+						},
+					},
+				},
+			},
+			async () => ({
+				viaPath: await mod.kody.mcp.home.sonos_list_players({}),
+				viaCaptured: await captured({}),
+			}),
+		)
+
+		expect(result).toEqual({
+			viaPath: { players: ['Kitchen'] },
+			viaCaptured: { players: ['Kitchen'] },
+		})
+	})
+})

--- a/packages/worker/src/package-runtime/runtime-source-modules.ts
+++ b/packages/worker/src/package-runtime/runtime-source-modules.ts
@@ -131,18 +131,31 @@ function __kodyReadRuntimeNestedValue(exportName, path) {
 	return current;
 }
 
+function __kodyApplyRuntimeNestedValue(exportName, path, args) {
+	const nestedExportName = exportName + '.' + path.map(String).join('.');
+	const parentPath = path.slice(0, -1);
+	const property = path[path.length - 1];
+	const currentParent =
+		parentPath.length === 0
+			? __kodyReadRuntimeExport(exportName)
+			: __kodyReadRuntimeNestedValue(exportName, parentPath);
+	const currentValue = currentParent?.[property];
+	if (typeof currentValue !== 'function') {
+		throw new Error(
+			\`kody:runtime export "\${nestedExportName}" is not callable in this execution context.\`,
+		);
+	}
+	return currentValue.apply(currentParent, args);
+}
+
 function __kodyBindRuntimeNestedValue(exportName, path, property, value) {
-	const nestedExportName = exportName + '.' + [...path, property].map(String).join('.');
 	if (typeof value === 'function') {
 		return function (...args) {
-			const currentParent = __kodyReadRuntimeNestedValue(exportName, path);
-			const currentValue = currentParent?.[property];
-			if (typeof currentValue !== 'function') {
-				throw new Error(
-					\`kody:runtime export "\${nestedExportName}" is not callable in this execution context.\`,
-				);
-			}
-			return currentValue.apply(currentParent, args);
+			return __kodyApplyRuntimeNestedValue(
+				exportName,
+				[...path, property],
+				args,
+			);
 		};
 	}
 	if (value != null && typeof value === 'object') {
@@ -155,6 +168,9 @@ function __kodyBindRuntimeNestedValue(exportName, path, property, value) {
 // current run's mcp proxy omits home (or throws on [[Get]]), bind a
 // late-bound nested proxy instead of undefined so a later run can still
 // resolve home.bond_shade_set_position against that run's kody.mcp.
+// Placeholders must also be callable: a disconnected/empty catalog throws
+// on tool [[Get]], and returning a plain object made
+// \`kody.mcp.home.sonos_list_players(...)\` fail as "is not a function".
 function __kodyLateBoundNestedPropertyDescriptor(exportName, path, property) {
 	return {
 		configurable: true,
@@ -164,9 +180,20 @@ function __kodyLateBoundNestedPropertyDescriptor(exportName, path, property) {
 	};
 }
 
+function __kodyReadRuntimeNestedParent(exportName, path) {
+	try {
+		return __kodyReadRuntimeNestedValue(exportName, path);
+	} catch {
+		return undefined;
+	}
+}
+
 function __kodyCreateRuntimeNestedObjectProxy(exportName, path) {
 	const nestedExportName = exportName + '.' + path.map(String).join('.');
-	return new Proxy({}, {
+	const applyCurrent = function (...args) {
+		return __kodyApplyRuntimeNestedValue(exportName, path, args);
+	};
+	return new Proxy(applyCurrent, {
 		get(_target, property) {
 			const inspectionValue = __kodyRuntimeProxyInspectionValue(
 				nestedExportName,
@@ -175,7 +202,7 @@ function __kodyCreateRuntimeNestedObjectProxy(exportName, path) {
 			if (inspectionValue !== undefined || __kodyIsRuntimeProxyInspectionProperty(property)) {
 				return inspectionValue;
 			}
-			const parent = __kodyReadRuntimeNestedValue(exportName, path);
+			const parent = __kodyReadRuntimeNestedParent(exportName, path);
 			if (parent == null) {
 				return __kodyCreateRuntimeNestedObjectProxy(
 					exportName,
@@ -208,13 +235,13 @@ function __kodyCreateRuntimeNestedObjectProxy(exportName, path) {
 			if (__kodyIsRuntimeProxyInspectionProperty(property)) return false;
 			const currentRuntime = __kodyRuntimeStorage.getStore();
 			if (currentRuntime?.[exportName] == null) return false;
-			const parent = __kodyReadRuntimeNestedValue(exportName, path);
+			const parent = __kodyReadRuntimeNestedParent(exportName, path);
 			return parent != null && property in parent;
 		},
 		ownKeys() {
 			const currentRuntime = __kodyRuntimeStorage.getStore();
 			if (currentRuntime?.[exportName] == null) return [];
-			const parent = __kodyReadRuntimeNestedValue(exportName, path);
+			const parent = __kodyReadRuntimeNestedParent(exportName, path);
 			return parent == null ? [] : Reflect.ownKeys(parent);
 		},
 		getOwnPropertyDescriptor(_target, property) {
@@ -227,7 +254,7 @@ function __kodyCreateRuntimeNestedObjectProxy(exportName, path) {
 					property,
 				);
 			}
-			const parent = __kodyReadRuntimeNestedValue(exportName, path);
+			const parent = __kodyReadRuntimeNestedParent(exportName, path);
 			if (parent == null) {
 				return __kodyLateBoundNestedPropertyDescriptor(
 					exportName,
@@ -278,6 +305,9 @@ function __kodyCreateRuntimeNestedObjectProxy(exportName, path) {
 					value,
 				),
 			};
+		},
+		apply(_target, _thisArg, args) {
+			return applyCurrent(...args);
 		},
 	});
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop `sonos-house` Sitting Room piano workflows from crashing with `kody.mcp.home.sonos_list_players is not a function` when the current run's MCP catalog throws on tool `[[Get]]`.

## Why

`start-soft-piano` only queues `workflows.create` for `./automations/sitting-room-piano/start`. The durable workflow then calls `kody.mcp["home"].sonos_list_players({})` through `kody:runtime`.

PR #1537 made known `kody.mcp` servers destructurable. PR #1561 late-bound a *missing* server as an object proxy so bundler `const { home } = kody.mcp` would not bind `undefined`. When `home` exists but the tool `[[Get]]` throws — disconnected home, empty snapshot, advertised server with no capabilities — that placeholder was still a plain object. Calling it produced TypeError `kody.mcp.home.sonos_list_players is not a function` (20 workflow retries) instead of dispatching or a clear unavailable/unknown-tool error.

## Summary

- Nested `kody:runtime` late-bind placeholders use a function-target Proxy with an `apply` trap.
- Calling a placeholder re-resolves `kody.mcp.home.sonos_list_players` against the calling run.
- Parent-path `[[Get]]` throws no longer leak out of get/GOPD; they late-bind the next segment the same way.
- Isolation test covers the throwing-get member call and a captured placeholder that succeeds on a later run.

## Testing

- `npx vitest` via `test:push` (node-unit + workers-unit): 810 + 91 files passed, including the new runtime-isolation case.
- Typecheck ran on commit.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `03fd8354` · **Head:** `24deb8e6`

**Classification:** extends — `kody:runtime` nested late-bind placeholders are now callable so a throwing MCP tool `[[Get]]` still resolves at call time.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `package-runtime` | runtime | extends — nested `kody.mcp` placeholders use a function-target Proxy and re-resolve `apply` against the calling run |

### Change flow

Package workflows call `kody.mcp.home.sonos_list_players(...)` through `kody:runtime`. A disconnected or empty catalog throws on tool `[[Get]]`; the placeholder is now callable and retries the current run.

```mermaid
sequenceDiagram
	actor Workflow as sitting-room-piano/start
	participant packageRuntime as package-runtime
	participant mcpServer as mcp-server
	Workflow->>packageRuntime: kody.mcp.home.sonos_list_players({})
	packageRuntime->>mcpServer: [[Get]] sonos_list_players
	alt tool is a function on this run
		mcpServer-->>packageRuntime: async tool
		packageRuntime-->>Workflow: late-bound call
	else [[Get]] throws or is undefined
		mcpServer-->>packageRuntime: throw / missing
		packageRuntime-->>Workflow: callable nested placeholder
		Workflow->>packageRuntime: apply placeholder
		packageRuntime->>mcpServer: re-resolve against calling run
	end
```

### Before / after

**Before:** throwing tool `[[Get]]` bound a plain object → `kody.mcp.home.sonos_list_players is not a function`.  
**After:** the placeholder is callable; the call either dispatches the current run's tool or rethrows the underlying unavailable/unknown error.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-43a03f9c-65c3-4872-9959-a25cd50a0576?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-43a03f9c-65c3-4872-9959-a25cd50a0576&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when accessing nested runtime services during temporary availability or lookup errors.
  * Previously captured service references can now remain callable across subsequent runs.
  * Calls to unavailable services now fail gracefully with a clear unavailable-server message.
  * Nested service proxies support invocation even when the underlying service becomes available later.

* **Tests**
  * Added coverage for service references captured during runtime failures and invoked successfully afterward.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->