### PR TITLE
fix(sentry): drop Durable Object queue overload blips (KODY-6J)

### DIFF
--- a/packages/worker/src/sentry-options.node.test.ts
+++ b/packages/worker/src/sentry-options.node.test.ts
@@ -8,6 +8,8 @@ import {
 	durableObjectCodeUpdatedResetMessage,
 	durableObjectInstanceInactiveCloseMessage,
 	durableObjectIsolateMemoryResetMessage,
+	durableObjectOverloadedRequestsQueuedTooLongMessage,
+	durableObjectOverloadedTooManyRequestsQueuedMessage,
 	durableObjectSqliteOutOfMemoryMessage,
 	durableObjectStorageOperationTimeoutResetMessage,
 	executorSandboxTimeoutMessage,
@@ -592,4 +594,38 @@ test('filterSentryEvent drops expected platform and caller noise and keeps real 
 		},
 	}
 	expect(filterSentryEvent(unrelatedDoFailure)).toBe(unrelatedDoFailure)
+
+	// Bare Cloudflare DO queue saturation (KODY-6J). One representative form
+	// per family, plus an `Error:`-prefixed variant and a missing trailing
+	// period. Wrapped recovery failures must stay visible.
+	expect(
+		filterSentryEvent({
+			exception: {
+				values: [
+					{ value: durableObjectOverloadedRequestsQueuedTooLongMessage },
+				],
+			},
+		}),
+	).toBeNull()
+	expect(
+		filterSentryEvent({
+			exception: {
+				values: [
+					{
+						value: `Error: ${durableObjectOverloadedTooManyRequestsQueuedMessage.replace(/\.$/, '')}`,
+					},
+				],
+			},
+		}),
+	).toBeNull()
+	const wrappedDoOverload = {
+		exception: {
+			values: [
+				{
+					value: `serveMcp could not recover after retries: ${durableObjectOverloadedRequestsQueuedTooLongMessage}`,
+				},
+			],
+		},
+	}
+	expect(filterSentryEvent(wrappedDoOverload)).toBe(wrappedDoOverload)
 })

--- a/packages/worker/src/sentry-options.ts
+++ b/packages/worker/src/sentry-options.ts
@@ -304,6 +304,64 @@ export function filterDurableObjectIsolateResetSentryEvent(event: ErrorEvent) {
 }
 
 /**
+ * Cloudflare Durable Object queue saturation when a single instance cannot keep
+ * up with incoming RPC/fetch work. Four exact platform phrasings (see DO
+ * troubleshooting docs). Not an application defect — the DO input gate is
+ * saturated. Same Sentry-drop class as D1 queue overload blips; unlike isolate
+ * resets, Cloudflare marks these `.overloaded` and recommends not retrying into
+ * a hot queue. Match only these bare platform strings (optional `Error:`
+ * prefix / trailing period) so wrapped recovery messages stay visible.
+ */
+export const durableObjectOverloadedRequestsQueuedTooLongMessage =
+	'Durable Object is overloaded. Requests queued for too long.'
+
+export const durableObjectOverloadedTooManyRequestsQueuedMessage =
+	'Durable Object is overloaded. Too many requests queued.'
+
+export const durableObjectOverloadedTooMuchDataQueuedMessage =
+	'Durable Object is overloaded. Too much data queued.'
+
+export const durableObjectOverloadedTooManyRequestsTenSecondWindowMessage =
+	'Durable Object is overloaded. Too many requests for the same object within a 10 second window.'
+
+const durableObjectOverloadedMessages = [
+	durableObjectOverloadedRequestsQueuedTooLongMessage,
+	durableObjectOverloadedTooManyRequestsQueuedMessage,
+	durableObjectOverloadedTooMuchDataQueuedMessage,
+	durableObjectOverloadedTooManyRequestsTenSecondWindowMessage,
+] as const
+
+function normalizeDurableObjectOverloadedMessage(message: string) {
+	const withoutErrorPrefix = message.trim().replace(/^Error:\s*/i, '')
+	return withoutErrorPrefix.endsWith('.')
+		? withoutErrorPrefix
+		: `${withoutErrorPrefix}.`
+}
+
+export function isDurableObjectOverloadedMessage(message: string) {
+	const normalized = normalizeDurableObjectOverloadedMessage(message)
+	return durableObjectOverloadedMessages.some(
+		(expected) => normalized === expected,
+	)
+}
+
+export function isDurableObjectOverloadedSentryEvent(event: ErrorEvent) {
+	const messages = sentryEventMessages(event).filter(
+		(message): message is string =>
+			typeof message === 'string' && message.trim().length > 0,
+	)
+	return (
+		messages.length > 0 &&
+		messages.every((message) => isDurableObjectOverloadedMessage(message))
+	)
+}
+
+export function filterDurableObjectOverloadedSentryEvent(event: ErrorEvent) {
+	if (!isDurableObjectOverloadedSentryEvent(event)) return event
+	return null
+}
+
+/**
  * Bare Cloudflare platform "internal error" with no support reference and no
  * app context. Observed on `repoOpenSession` when Durable Object / Artifacts
  * infrastructure fails opaquely (KODY-CLOUDFLARE-4H). Distinct from D1/DO
@@ -432,6 +490,7 @@ export function filterSentryEvent(event: ErrorEvent, hint?: EventHint) {
 	if (filterIntegrationTokenRefreshCallerSentryEvent(event) === null)
 		return null
 	if (filterDurableObjectIsolateResetSentryEvent(event) === null) return null
+	if (filterDurableObjectOverloadedSentryEvent(event) === null) return null
 	if (filterCloudflareOpaqueInternalErrorSentryEvent(event) === null)
 		return null
 	if (filterArtifactsGitTransientHttpErrorSentryEvent(event) === null)
@@ -484,7 +543,9 @@ export function buildSentryOptions(env: Env): CloudflareOptions {
 		// SQLITE_NOMEM, deploy-time code updates, blockConcurrencyWhile
 		// timeouts, DO storage operation timeouts, and DO storage object-reset
 		// with a support reference) are dropped the same way — see
-		// filterDurableObjectIsolateResetSentryEvent.
+		// filterDurableObjectIsolateResetSentryEvent. Bare Durable Object queue
+		// saturation strings ("… overloaded. Requests queued for too long", etc.)
+		// are dropped the same way — see filterDurableObjectOverloadedSentryEvent.
 		// Exact opaque Cloudflare "An internal error occurred." (and Artifacts
 		// INTERNAL_ERROR wording) with no support reference are dropped the
 		// same way — see filterCloudflareOpaqueInternalErrorSentryEvent.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop Sentry from opening issues for transient Cloudflare Durable Object queue saturation on `/mcp`.

## Why

KODY-6J reports `Error: Durable Object is overloaded. Requests queued for too long.` during MCP `serveMcp` → `withAccountWriteLease` → UserMeter/Agents DO RPC. This is Cloudflare's documented DO overload class (single-threaded instance cannot keep up), not an application defect. D1's analogous queue overload strings are already filtered in `beforeSend`; DO overload was missing.

## Summary

- Add `filterDurableObjectOverloadedSentryEvent` matching Cloudflare's four exact DO queue-saturation platform strings.
- Wire it into `filterSentryEvent` / `buildSentryOptions` comments.
- Unit tests pin drop vs keep for bare, prefixed, and wrapped messages.

## Testing

- `npm run test:node -- packages/worker/src/sentry-options.node.test.ts`
- Pre-push: `npm run test:node` + `npm run test:workers` (green)

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` · **Head:** `cbd7a55e`

**Classification:** composes — extends Sentry `beforeSend` filtering only; no runtime behavior change.

### Primitives touched

| Primitive    | Group    | Impact   |
| ------------ | -------- | -------- |
| `mcp-server` | surfaces | composes |

### Change flow

Sentry `beforeSend` drops bare Cloudflare DO queue-saturation strings before they open issues on `/mcp`.

```mermaid
sequenceDiagram
	participant mcpServer as mcp-server
	participant sentry as Sentry beforeSend
	mcpServer->>sentry: auto-capture DO overload error
	sentry->>sentry: filterDurableObjectOverloadedSentryEvent drops bare platform string
```

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-183724c0-de77-4063-af36-7ecba21b419d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-183724c0-de77-4063-af36-7ecba21b419d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Reduced Sentry noise by filtering standalone Durable Object overload events caused by queue saturation.
  - Continued reporting overload errors when they include additional recovery or contextual information.
  - Recognized common overload message variations, including prefixed errors and missing punctuation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->