### PR TITLE
Make footer nav responsive with multi-column links

### DIFF
--- a/packages/worker/client/site-footer.tsx
+++ b/packages/worker/client/site-footer.tsx
@@ -56,9 +56,12 @@ const footerInnerCss = {
 	gap: '1.2rem 2rem',
 	fontSize: '0.92rem',
 	color: colors.textMuted,
-	'@media (max-width: 720px)': {
+	/* Stack before the inline nav would crowd the brand/tagline row — same idea
+	   as the header's nav breakpoint, tuned for footer link count. */
+	'@media (max-width: 960px)': {
 		gridTemplateColumns: '1fr',
 		justifyItems: 'center',
+		textAlign: 'center',
 	},
 }
 
@@ -82,37 +85,34 @@ const taglineCss = {
 }
 
 const footerNavCss = {
-	display: 'flex',
-	gap: '1.4rem',
+	display: 'grid',
+	gridTemplateColumns: 'repeat(auto-fill, minmax(6.5rem, auto))',
+	gap: '0.45rem 1.4rem',
+	justifyContent: 'end',
 	justifySelf: 'end',
-	'@media (max-width: 720px)': {
-		justifySelf: 'center',
-	},
+	maxWidth: '34rem',
 	'& a': {
 		color: colors.textMuted,
 		textDecoration: 'none',
-		whiteSpace: 'nowrap' as const,
-		flexShrink: 0,
+		textAlign: 'center' as const,
 		// Same fast color ease as the header nav — one voice for nav links.
 		transition: `color ${transitions.fast}`,
 	},
 	'& a:hover': { color: colors.text },
-	/* Stacked on phones: the links in a row sit close enough to mis-tap, and
-	   the column gives each one a comfortable target without the 44px minimum
-	   the header menu needs (these are the last thing on the page, not the
-	   primary nav). Centred to match the rest of the stacked footer. */
-	'@media (max-width: 560px)': {
-		flexDirection: 'column' as const,
-		alignItems: 'center',
-		gap: '0.2rem',
+	'@media (max-width: 960px)': {
+		justifySelf: 'center',
+		justifyContent: 'center',
+		width: 'min(100%, 28rem)',
+		gridTemplateColumns: 'repeat(3, minmax(0, 1fr))',
 		'& a': {
 			display: 'flex',
 			alignItems: 'center',
+			justifyContent: 'center',
 			minHeight: '40px',
-			paddingInline: '0.75rem',
-			color: colors.textMuted,
-			textDecoration: 'none',
-			transition: `color ${transitions.fast}`,
 		},
+	},
+	'@media (max-width: 480px)': {
+		width: 'min(100%, 18rem)',
+		gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
 	},
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Keep the site footer usable at every viewport width so footer links never clip off-screen.

## Why

On mid-width and mobile viewports the footer nav stayed in a single non-wrapping row. Links overflowed the viewport instead of wrapping into columns, which made narrow layouts especially awkward.

## Summary

- Switch footer nav from a nowrap flex row to a wrapping CSS grid
- Stack brand / tagline / nav earlier (`960px`) so the link block has full width
- Use three columns on tablets and two on phones, with larger tap targets when stacked

## Testing

- Pre-push: `test:node` and `test:workers` (via `test:push`)
- Manual UI check of `/support` footer at wide, mid, and narrow viewports (in progress)

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `30947a74` · **Head:** `d55a76a9`

**Classification:** extends — footer layout behavior in `app-ui` changes from a single overflow row to a responsive multi-column grid.

### Primitives touched

| Primitive | Group    | Impact                                                                 |
| --------- | -------- | ---------------------------------------------------------------------- |
| `app-ui`  | surfaces | extends — `SiteFooter` nav wraps into 2–3 columns instead of overflow |

### Change flow

Browser app renders the site footer; this PR only changes how footer links lay out across viewport widths.

```mermaid
sequenceDiagram
	actor User
	participant appUi as app-ui
	User->>appUi: open marketing page (e.g. /support)
	appUi-->>User: SiteFooter nav uses wrapping grid (2–3 cols when narrow)
	Note over appUi: no route/data/auth changes
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c93461b2-18fe-4436-bb54-a96355edd2ae?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c93461b2-18fe-4436-bb54-a96355edd2ae&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

