### PR TITLE
Scroll list/detail deep links to the focused record

### DIFF
--- a/packages/worker/client/router-scroll-state.node.test.ts
+++ b/packages/worker/client/router-scroll-state.node.test.ts
@@ -22,7 +22,7 @@ test('scroll restoration history state and navigation targets follow push, pop, 
 			historyAction: 'push',
 			location: '/account/secrets',
 		}),
-	).toEqual({ type: 'top' })
+	).toEqual({ type: 'record-focus' })
 	expect(
 		getScrollRestorationTarget({
 			historyAction: 'push',
@@ -49,7 +49,7 @@ test('scroll restoration history state and navigation targets follow push, pop, 
 			historyAction: 'pop',
 			location: '/community',
 		}),
-	).toEqual({ type: 'top' })
+	).toEqual({ type: 'record-focus' })
 	expect(
 		getScrollRestorationTarget({
 			historyAction: 'load',
@@ -62,13 +62,19 @@ test('scroll restoration history state and navigation targets follow push, pop, 
 			historyAction: 'load',
 			location: '/',
 		}),
-	).toEqual({ type: 'preserve' })
+	).toEqual({ type: 'record-focus' })
 	expect(
 		getScrollRestorationTarget({
 			historyAction: 'load',
 			location: '/#invite',
 		}),
 	).toEqual({ type: 'hash', id: 'invite' })
+	expect(
+		getScrollRestorationTarget({
+			historyAction: 'load',
+			location: '/admin/users/abc',
+		}),
+	).toEqual({ type: 'record-focus' })
 })
 
 test('a clamped scroll does not replace a saved Y the document cannot reach yet', () => {

--- a/packages/worker/client/router-scroll-state.ts
+++ b/packages/worker/client/router-scroll-state.ts
@@ -25,6 +25,7 @@ export type ScrollRestorationTarget =
 	| { type: 'hash'; id: string }
 	| { type: 'position'; position: ScrollPosition }
 	| { type: 'preserve' }
+	| { type: 'record-focus' }
 	| { type: 'top' }
 
 let scrollRestorationKeyCount = 0
@@ -95,10 +96,14 @@ export function getScrollRestorationTarget(input: {
 	const hash = getScrollRestorationHash(input.location)
 	if (hash) return { type: 'hash', id: hash }
 
-	if (input.preventScrollReset || input.historyAction === 'load') {
+	if (input.preventScrollReset) {
 		return { type: 'preserve' }
 	}
-	return { type: 'top' }
+
+	// Fresh load and navigations that would otherwise jump to the top: prefer
+	// the expanded list/detail record so a deep link lands on the focused
+	// row. Apply falls back to preserve (load) or top (push/replace/pop).
+	return { type: 'record-focus' }
 }
 
 /**

--- a/packages/worker/client/routes/account-activity.tsx
+++ b/packages/worker/client/routes/account-activity.tsx
@@ -395,6 +395,7 @@ export function AccountActivityRoute(handle: Handle) {
 							mode="expand"
 							ariaLabel="Activity runs"
 							selectedId={selection.selectedId}
+							recordLoading={waitingForDetail}
 							onNavigate={() => setMessage(null)}
 							emptyLabel={emptyLabel}
 							toolbar={

--- a/packages/worker/client/routes/account-integrations.tsx
+++ b/packages/worker/client/routes/account-integrations.tsx
@@ -487,6 +487,11 @@ export function AccountIntegrationsRoute(handle: Handle) {
 							mode="expand"
 							ariaLabel="Integrations"
 							selectedId={selectedApp ? integrationListId(selectedApp) : null}
+							recordLoading={Boolean(
+								missingKind &&
+								!showIntegrationNotFound &&
+								!showConnectionNotFound,
+							)}
 							countLabel={`${filteredApps.length} of ${apps.length} integrations`}
 							emptyLabel={
 								apps.length === 0

--- a/packages/worker/client/routes/account-jobs.tsx
+++ b/packages/worker/client/routes/account-jobs.tsx
@@ -440,6 +440,7 @@ export function AccountJobsRoute(handle: Handle) {
 						mode="expand"
 						ariaLabel="Scheduled jobs"
 						selectedId={selection.selectedId}
+						recordLoading={waitingForDetail}
 						onNavigate={() => {
 							deleteJobCheck.reset()
 							setMessage(null)

--- a/packages/worker/client/routes/account-mcp-servers.tsx
+++ b/packages/worker/client/routes/account-mcp-servers.tsx
@@ -405,6 +405,12 @@ export function AccountMcpServersRoute(handle: Handle) {
 						mode="expand"
 						ariaLabel="Connected MCP servers"
 						selectedId={selection.selectedId}
+						recordLoading={Boolean(
+							selection.selectedId &&
+							!selection.isCreating &&
+							!server &&
+							!showServerNotFound,
+						)}
 						onNavigate={() => {
 							deleteServerCheck.reset()
 							setMessage(null)

--- a/packages/worker/client/routes/account-memories.tsx
+++ b/packages/worker/client/routes/account-memories.tsx
@@ -380,6 +380,7 @@ export function AccountMemoriesRoute(handle: Handle) {
 							mode="expand"
 							ariaLabel="Saved memories"
 							selectedId={selection.selectedId}
+							recordLoading={waitingForDetail}
 							onNavigate={() => {
 								deleteMode = null
 								setMessage(null)

--- a/packages/worker/client/routes/account-secrets.tsx
+++ b/packages/worker/client/routes/account-secrets.tsx
@@ -631,6 +631,12 @@ export function AccountSecretsRoute(handle: Handle) {
 					mode="expand"
 					ariaLabel="Saved secrets"
 					selectedId={activeSecretId}
+					recordLoading={Boolean(
+						selection.selectedId &&
+						!selection.isCreating &&
+						selectedSecret == null &&
+						(status === 'loading' || isRefreshingForLocationChange),
+					)}
 					countLabel={
 						status === 'ready'
 							? `${filteredSecrets.length} of ${secrets.length} shown`

--- a/packages/worker/client/routes/account-values.tsx
+++ b/packages/worker/client/routes/account-values.tsx
@@ -401,6 +401,7 @@ export function AccountValuesRoute(handle: Handle) {
 						mode="expand"
 						ariaLabel="Saved values"
 						selectedId={selection.selectedId}
+						recordLoading={isLoadingSelection}
 						onNavigate={resetSelectionState}
 						countLabel={`${filteredValues.length} of ${values.length} shown`}
 						emptyLabel={

--- a/packages/worker/client/routes/account-workflows.tsx
+++ b/packages/worker/client/routes/account-workflows.tsx
@@ -441,6 +441,7 @@ export function AccountWorkflowsRoute(handle: Handle) {
 						mode="expand"
 						ariaLabel="Workflow runs"
 						selectedId={selection.selectedId}
+						recordLoading={waitingForDetail}
 						onNavigate={() => {
 							cancelWorkflowCheck.reset()
 							setMessage(null)

--- a/packages/worker/client/routes/record-table.node.test.ts
+++ b/packages/worker/client/routes/record-table.node.test.ts
@@ -53,6 +53,7 @@ test('record table keeps container drops, row links, and expand/pane selection c
 	)
 	expect(noneWithSelection).not.toContain('data-selected="true"')
 	expect(noneWithSelection).not.toContain('should not render')
+	expect(noneWithSelection).not.toContain('data-record-focus="true"')
 
 	const expandHtml = await renderToString(
 		jsx(RecordTable, {
@@ -71,12 +72,16 @@ test('record table keeps container drops, row links, and expand/pane selection c
 	expect(expandHtml).toContain('data-prevent-scroll-reset')
 	expect(expandHtml).toContain('aria-expanded="true"')
 	expect(expandHtml).toContain('aria-expanded="false"')
+	expect(expandHtml).toContain('data-record-focus="true"')
+	expect(expandHtml).toContain('scroll-margin-top: 5.5rem')
 	const controls = /aria-controls="([^"]+)"/.exec(expandHtml)?.[1]
 	expect(controls).toBeTruthy()
 	expect(expandHtml).toContain(`id="${controls}"`)
 	expect(expandHtml).toContain('Beta record')
 	expect(expandHtml.match(/data-selected="true"/g)).toHaveLength(1)
 	expect(expandHtml.match(/data-record-row="true"/g)).toHaveLength(1)
+	expect(expandHtml.match(/data-record-focus="true"/g)).toHaveLength(1)
+	expect(expandHtml).not.toContain('data-record-focus-pending')
 
 	// Selected without a loaded record must not point assistive tech at a
 	// missing expanded region.
@@ -122,9 +127,38 @@ test('record table keeps container drops, row links, and expand/pane selection c
 	)
 	expect(orphanHtml).toContain('Orphan record')
 	expect(orphanHtml).not.toContain('data-record-row="true"')
+	expect(orphanHtml).toContain('data-record-focus="true"')
 	expect(orphanHtml.indexOf('Orphan record')).toBeGreaterThan(
 		orphanHtml.indexOf('</table>'),
 	)
+	expect(orphanHtml.indexOf('data-record-focus="true"')).toBeGreaterThan(
+		orphanHtml.indexOf('</table>'),
+	)
+
+	// Off-window selection still loading: keep retrying scroll restoration
+	// until the pane exists. A not-found selection is not pending.
+	const pendingHtml = await renderToString(
+		jsx(RecordTable, {
+			mode: 'expand',
+			ariaLabel: 'Users',
+			columns,
+			rows,
+			selectedId: 'not-in-this-window',
+			busy: true,
+		}),
+	)
+	expect(pendingHtml).toContain('data-record-focus-pending="true"')
+	expect(pendingHtml).not.toContain('data-record-focus="true"')
+	const notFoundHtml = await renderToString(
+		jsx(RecordTable, {
+			mode: 'expand',
+			ariaLabel: 'Users',
+			columns,
+			rows,
+			selectedId: 'not-in-this-window',
+		}),
+	)
+	expect(notFoundHtml).not.toContain('data-record-focus-pending')
 
 	// A not-found record has no selected row. It must still render, not vanish.
 	const missingHtml = await renderToString(

--- a/packages/worker/client/routes/record-table.node.test.ts
+++ b/packages/worker/client/routes/record-table.node.test.ts
@@ -136,8 +136,10 @@ test('record table keeps container drops, row links, and expand/pane selection c
 	)
 
 	// Off-window selection still loading: keep retrying scroll restoration
-	// until the pane exists. A not-found selection is not pending.
-	const pendingHtml = await renderToString(
+	// until the pane exists. List `busy` and detail `recordLoading` both
+	// count. A not-found selection is not pending. An in-list row already
+	// has `data-record-focus`, so it does not need the pending marker.
+	const pendingBusyHtml = await renderToString(
 		jsx(RecordTable, {
 			mode: 'expand',
 			ariaLabel: 'Users',
@@ -147,8 +149,32 @@ test('record table keeps container drops, row links, and expand/pane selection c
 			busy: true,
 		}),
 	)
-	expect(pendingHtml).toContain('data-record-focus-pending="true"')
-	expect(pendingHtml).not.toContain('data-record-focus="true"')
+	expect(pendingBusyHtml).toContain('data-record-focus-pending="true"')
+	expect(pendingBusyHtml).not.toContain('data-record-focus="true"')
+	const pendingRecordHtml = await renderToString(
+		jsx(RecordTable, {
+			mode: 'expand',
+			ariaLabel: 'Memories',
+			columns,
+			rows,
+			selectedId: 'not-in-this-window',
+			recordLoading: true,
+		}),
+	)
+	expect(pendingRecordHtml).toContain('data-record-focus-pending="true"')
+	expect(pendingRecordHtml).not.toContain('data-record-focus="true"')
+	const inListBusyHtml = await renderToString(
+		jsx(RecordTable, {
+			mode: 'expand',
+			ariaLabel: 'Users',
+			columns,
+			rows,
+			selectedId: 'b',
+			busy: true,
+		}),
+	)
+	expect(inListBusyHtml).toContain('data-record-focus="true"')
+	expect(inListBusyHtml).not.toContain('data-record-focus-pending')
 	const notFoundHtml = await renderToString(
 		jsx(RecordTable, {
 			mode: 'expand',

--- a/packages/worker/client/routes/record-table.tsx
+++ b/packages/worker/client/routes/record-table.tsx
@@ -29,7 +29,9 @@ export {
  * 434px right half of a split, and `mode` chooses where it renders rather
  * than which component the screen composes. Rows stay real anchors built
  * from `createListDetailRoute`, so the selected record stays in the URL and
- * scroll-preserving navigation continues to work.
+ * scroll-preserving navigation continues to work. The selected row (or the
+ * off-window pane) carries `data-record-focus` so a deep link can scroll to
+ * it instead of leaving the reader at the top of the list.
  *
  * Sizing is answered by container queries, not viewport breakpoints: these
  * tables live inside a 200px-railed shell, so the viewport says very little
@@ -319,6 +321,9 @@ const rowCss = {
 		backgroundColor: colors.primarySoftest,
 		boxShadow: `inset 3px 0 0 ${colors.primary}`,
 	},
+	// Same offset as `accountSectionCss`: clear the sticky site header when
+	// scroll restoration lands on this row.
+	'&[data-record-focus]': { scrollMarginTop: '5.5rem' },
 	[hoverMq]: {
 		'&:not([data-selected]):hover': { backgroundColor: colors.background },
 	},
@@ -415,6 +420,12 @@ export function RecordTable(handle: Handle<RecordTableProps>) {
 		const orphanedRecord = Boolean(
 			mode === 'expand' && handle.props.record && !expandedInTable,
 		)
+		const focusPending = Boolean(
+			selectable &&
+			selectedId != null &&
+			!handle.props.record &&
+			handle.props.busy,
+		)
 
 		const table = (
 			<table aria-label={handle.props.ariaLabel} mix={css(tableCss)}>
@@ -446,6 +457,7 @@ export function RecordTable(handle: Handle<RecordTableProps>) {
 							<tr
 								key={row.id}
 								data-selected={selected ? 'true' : undefined}
+								data-record-focus={selected ? 'true' : undefined}
 								mix={css(rowCss)}
 							>
 								{columns.map((column) => {
@@ -529,6 +541,7 @@ export function RecordTable(handle: Handle<RecordTableProps>) {
 			<section
 				aria-label={handle.props.ariaLabel}
 				aria-busy={handle.props.busy ? 'true' : undefined}
+				data-record-focus-pending={focusPending ? 'true' : undefined}
 				mix={css(shellCss)}
 			>
 				<div mix={[css(paneCss), css(cardFallbackCss)]}>
@@ -578,7 +591,12 @@ export function RecordTable(handle: Handle<RecordTableProps>) {
 					) : null}
 				</div>
 				{(mode === 'pane' || orphanedRecord) && handle.props.record ? (
-					<div mix={css(paneCss)}>{handle.props.record}</div>
+					<div
+						data-record-focus={orphanedRecord ? 'true' : undefined}
+						mix={css({ ...paneCss, scrollMarginTop: '5.5rem' })}
+					>
+						{handle.props.record}
+					</div>
 				) : null}
 			</section>
 		)

--- a/packages/worker/client/routes/record-table.tsx
+++ b/packages/worker/client/routes/record-table.tsx
@@ -158,6 +158,12 @@ type RecordTableProps = {
 	 * everything below it on every keystroke of a search that refetches.
 	 */
 	busy?: boolean
+	/**
+	 * The selected record is still being fetched. Off-window selections have
+	 * no row to mark, so this keeps `data-record-focus-pending` until the
+	 * pane exists. Not-found results must pass false (or omit it).
+	 */
+	recordLoading?: boolean
 	emptyLabel?: string
 	/** Below the table, inside its pane: the infinite-list "Load more" control. */
 	footer?: Slot
@@ -407,24 +413,27 @@ export function RecordTable(handle: Handle<RecordTableProps>) {
 		// fight to read. `pane` and `none` keep the cap, which is what keeps
 		// the record below reachable without a long scroll first.
 		const capped = mode !== 'expand'
+		const selectedRowVisible =
+			selectedId != null && rows.some((row) => row.id === selectedId)
 		// `expand` puts the record inside the row it belongs to, which only works
 		// while that row is on screen. A deep link, a filter, paging, or a
 		// not-found selection leaves a loaded record with no row to unfold under
 		// — so it falls back to a pane below the table rather than disappearing.
 		const expandedInTable = Boolean(
-			mode === 'expand' &&
-			handle.props.record &&
-			selectedId != null &&
-			rows.some((row) => row.id === selectedId),
+			mode === 'expand' && handle.props.record && selectedRowVisible,
 		)
 		const orphanedRecord = Boolean(
 			mode === 'expand' && handle.props.record && !expandedInTable,
 		)
+		// Retry scroll restoration only while an off-window selection is still
+		// loading. An in-list row already carries `data-record-focus`; a
+		// not-found id must not keep the restorer spinning.
 		const focusPending = Boolean(
 			selectable &&
 			selectedId != null &&
 			!handle.props.record &&
-			handle.props.busy,
+			!selectedRowVisible &&
+			(handle.props.recordLoading || handle.props.busy),
 		)
 
 		const table = (

--- a/packages/worker/client/scroll-restoration.tsx
+++ b/packages/worker/client/scroll-restoration.tsx
@@ -1,6 +1,9 @@
 import { addEventListeners, type Handle } from 'remix/ui'
 import {
+	isRecordFocusInViewport,
 	parseSavedScrollPositions,
+	recordFocusPendingSelector,
+	recordFocusSelector,
 	scrollRestorationStorageKey,
 	serializeSavedScrollPositions,
 } from '#universal/router-scroll-restoration.ts'
@@ -146,6 +149,34 @@ function applyWindowScroll(
 			// before falling back.
 			if (!isFinalAttempt) return false
 			if (detail.preventScrollReset) return true
+			window.scrollTo({ left: 0, top: 0, behavior: 'instant' })
+			return true
+		}
+		case 'record-focus': {
+			const element = document.querySelector(recordFocusSelector)
+			if (element) {
+				const viewportHeight =
+					window.innerHeight || document.documentElement.clientHeight
+				if (
+					!isRecordFocusInViewport(
+						element.getBoundingClientRect(),
+						viewportHeight,
+					)
+				) {
+					element.scrollIntoView({ behavior: 'instant', block: 'start' })
+				}
+				return true
+			}
+			// A selected record can land after the first paint (JSON list, or
+			// the detail payload arriving after the row). Retry only while the
+			// table says that selection is still loading — not on every page.
+			if (
+				!isFinalAttempt &&
+				document.querySelector(recordFocusPendingSelector)
+			) {
+				return false
+			}
+			if (detail.historyAction === 'load') return true
 			window.scrollTo({ left: 0, top: 0, behavior: 'instant' })
 			return true
 		}

--- a/packages/worker/src/app/ssr-document.tsx
+++ b/packages/worker/src/app/ssr-document.tsx
@@ -289,8 +289,9 @@ export function SsrDocument(handle: Handle<SsrDocumentProps>) {
 				</div>
 				{/* Blocking classic script (not type=module): restores the
 				    saved window.scrollY from sessionStorage before first paint
-				    and before hydration. CSP allows this exact script via its
-				    sha256 hash — do not add `'unsafe-inline'`. */}
+				    and before hydration, or scrolls `[data-record-focus]` into
+				    view on a list/detail deep link. CSP allows this exact
+				    script via its sha256 hash — do not add `'unsafe-inline'`. */}
 				<script innerHTML={scrollRestorationInlineScript}></script>
 				<script type="module" src={clientEntryHref}></script>
 			</body>

--- a/packages/worker/universal/router-scroll-restoration.node.test.ts
+++ b/packages/worker/universal/router-scroll-restoration.node.test.ts
@@ -4,6 +4,7 @@ import { expect, test, vi } from 'vitest'
 import {
 	getScrollRestorationInlineScript,
 	getStoredScrollY,
+	isRecordFocusInViewport,
 	parseSavedScrollPositions,
 	scrollRestorationInlineScriptCspHash,
 	serializeSavedScrollPositions,
@@ -38,8 +39,13 @@ test('sessionStorage scroll positions restore the saved Y for the current histor
 		state: { key: 'scroll-key-1' },
 		replaceState: vi.fn(),
 	}
+	const querySelector = vi.fn()
 	runInNewContext(restoreScript, {
-		window: { history, scrollTo },
+		window: { history, scrollTo, innerHeight: 800 },
+		document: {
+			querySelector,
+			documentElement: { clientHeight: 800 },
+		},
 		sessionStorage: {
 			getItem: () => stored,
 			removeItem: vi.fn(),
@@ -50,4 +56,65 @@ test('sessionStorage scroll positions restore the saved Y for the current histor
 	expect(history.scrollRestoration).toBe('manual')
 	expect(scrollTo).toHaveBeenCalledWith(0, 2000)
 	expect(history.replaceState).not.toHaveBeenCalled()
+	expect(querySelector).not.toHaveBeenCalled()
+})
+
+test('pre-hydration restore scrolls an off-screen list/detail record when no Y is saved', () => {
+	const restoreScript = getScrollRestorationInlineScript()
+	expect(restoreScript).toContain('[data-record-focus]')
+
+	const scrollTo = vi.fn()
+	const scrollIntoView = vi.fn()
+	const history = {
+		scrollRestoration: 'auto',
+		state: { key: 'scroll-key-1' },
+		replaceState: vi.fn(),
+	}
+	runInNewContext(restoreScript, {
+		window: { history, scrollTo, innerHeight: 800 },
+		document: {
+			querySelector: (selector: string) => {
+				expect(selector).toBe('[data-record-focus]')
+				return {
+					getBoundingClientRect: () => ({ top: 2400, bottom: 2480 }),
+					scrollIntoView,
+				}
+			},
+			documentElement: { clientHeight: 800 },
+		},
+		sessionStorage: {
+			getItem: () => '{}',
+			removeItem: vi.fn(),
+		},
+		console,
+		Math,
+	})
+	expect(scrollTo).not.toHaveBeenCalled()
+	expect(scrollIntoView).toHaveBeenCalledTimes(1)
+
+	scrollIntoView.mockClear()
+	runInNewContext(restoreScript, {
+		window: { history, scrollTo, innerHeight: 800 },
+		document: {
+			querySelector: () => ({
+				getBoundingClientRect: () => ({ top: 120, bottom: 160 }),
+				scrollIntoView,
+			}),
+			documentElement: { clientHeight: 800 },
+		},
+		sessionStorage: {
+			getItem: () => '{}',
+			removeItem: vi.fn(),
+		},
+		console,
+		Math,
+	})
+	expect(scrollIntoView).not.toHaveBeenCalled()
+})
+
+test('record focus is in the viewport only when it intersects the window', () => {
+	expect(isRecordFocusInViewport({ top: 40, bottom: 80 }, 800)).toBe(true)
+	expect(isRecordFocusInViewport({ top: -20, bottom: 40 }, 800)).toBe(true)
+	expect(isRecordFocusInViewport({ top: 2400, bottom: 2480 }, 800)).toBe(false)
+	expect(isRecordFocusInViewport({ top: -80, bottom: 0 }, 800)).toBe(false)
 })

--- a/packages/worker/universal/router-scroll-restoration.ts
+++ b/packages/worker/universal/router-scroll-restoration.ts
@@ -4,13 +4,35 @@
  * Mirrors React Router's `<ScrollRestoration />`: positions are a
  * `{ [historyKey]: y }` map in sessionStorage, and an inline script in the
  * SSR body applies `window.scrollTo` before paint so a refresh does not flash
- * the top of the page.
+ * the top of the page. When there is no saved Y, the same script scrolls an
+ * expanded list/detail record (`[data-record-focus]`) into view so a deep
+ * link does not strand the reader at the toolbar.
  */
 
 export const scrollRestorationStorageKey = 'kody:router-scroll-positions'
 
 /** History state field React Router uses (`window.history.state.key`). */
 export const historyStateScrollKey = 'key'
+
+/**
+ * Expanded list/detail record (the selected accordion row, or the off-window
+ * pane). RecordTable marks the focused element; scroll restoration finds it.
+ */
+export const recordFocusSelector = '[data-record-focus]'
+
+/**
+ * Selected list/detail id whose record has not rendered yet. Restoration
+ * retries while this is present so a client-loaded detail can still land on
+ * the row; it must not be set for a not-found selection or a plain list.
+ */
+export const recordFocusPendingSelector = '[data-record-focus-pending]'
+
+export function isRecordFocusInViewport(
+	rect: { top: number; bottom: number },
+	viewportHeight: number,
+): boolean {
+	return rect.bottom > 0 && rect.top < viewportHeight
+}
 
 export type SavedScrollPositions = Record<string, number>
 
@@ -64,7 +86,7 @@ export function getStoredScrollY(
  * Update the hash in the same change if you edit the script (the node test
  * fails when they drift).
  */
-export const scrollRestorationInlineScript = `(function(storageKey,restoreKey){if("scrollRestoration"in window.history){window.history.scrollRestoration="manual"}if(!window.history.state||!window.history.state.key){var key=Math.random().toString(32).slice(2);window.history.replaceState({key:key},"")}try{var positions=JSON.parse(sessionStorage.getItem(storageKey)||"{}");var storedY=positions[restoreKey||window.history.state.key];if(typeof storedY==="number"){window.scrollTo(0,storedY)}}catch(error){console.error(error);sessionStorage.removeItem(storageKey)}})(${JSON.stringify(scrollRestorationStorageKey)},null)`
+export const scrollRestorationInlineScript = `(function(storageKey,restoreKey,focusSelector){if("scrollRestoration"in window.history){window.history.scrollRestoration="manual"}if(!window.history.state||!window.history.state.key){var key=Math.random().toString(32).slice(2);window.history.replaceState({key:key},"")}try{var positions=JSON.parse(sessionStorage.getItem(storageKey)||"{}");var storedY=positions[restoreKey||window.history.state.key];if(typeof storedY==="number"){window.scrollTo(0,storedY)}else{var focus=document.querySelector(focusSelector);if(focus){var rect=focus.getBoundingClientRect();if(rect.bottom<=0||rect.top>=(window.innerHeight||document.documentElement.clientHeight)){focus.scrollIntoView()}}}}catch(error){console.error(error);sessionStorage.removeItem(storageKey)}})(${JSON.stringify(scrollRestorationStorageKey)},null,${JSON.stringify(recordFocusSelector)})`
 
 export function getScrollRestorationInlineScript() {
 	return scrollRestorationInlineScript
@@ -75,4 +97,4 @@ export function getScrollRestorationInlineScript() {
  * recomputes this so the CSP entry cannot drift from the inlined source.
  */
 export const scrollRestorationInlineScriptCspHash =
-	"'sha256-MdxEgAksnpE4HJeHgjidW/x9g+OeXkea+EM+60WWso0='"
+	"'sha256-hu1YzSN8F+E24qB5qP7wHk5dggQsLaY3kL4e8tv6jOY='"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Landing on an expanded list/detail URL (admin users, secrets, packages, and the other accordion screens) should put the focused record in view instead of leaving the reader at the top of the list.

## Why

Deep links such as `/admin/users/:stableUserId` render the selected row in the table (or the off-window pane below it), but scroll restoration kept the viewport at `y = 0`. Finding the record meant scrolling through the list by hand.

## Summary

- RecordTable marks the selected accordion row (or the off-window pane) with `data-record-focus`, and a still-loading off-window selection with `data-record-focus-pending`.
- Callers pass `recordLoading` (or list `busy`) while the selected record is in flight so restoration retries; not-found results do not.
- The pre-hydration restore script scrolls that element into view when there is no saved scroll position.
- SPA navigations that would otherwise jump to the top do the same; in-list row clicks still use `data-prevent-scroll-reset`.
- Refresh with a saved `Y` still wins over the focused record.

## Testing

- `vitest` node-unit: scroll restoration, record table, and router scroll-state suites.
- `test:push` (node-unit + workers-unit) on push.
- Preview (seeded 25 secrets as `me@kentcdodds.com`): SSR HTML for `/account/secrets/user/scrollFocus25` carries `data-record-focus="true"` on that row. Deep-link landing keeps `scrollFocus25` in view; the unfocused list starts at `scrollFocus01`.

![Deep link to scrollFocus25 is selected and in view](https://cursor.com/artifacts/c/art-5b48dfc6-3d84-41fb-9100-77715ab8151f)
![Unfocused secrets list starts at scrollFocus01](https://cursor.com/artifacts/c/art-33da490e-fc6a-4ba7-ad69-dd8a9a8d3663)
<a href="https://cursor.com/agents/bc-a5f488d8-35eb-4633-b2c9-d1b8ff7e25cd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpreview_secrets_deep_link_scrolls_to_focus-2.mp4"><img src="https://cursor.com/artifacts/c/art-9c30a709-0b10-41e7-816e-0abb8d1832b4" alt="preview_secrets_deep_link_scrolls_to_focus-2.mp4" /></a>

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `4ad22ee0` · **Head:** `fc1acf11`

**Classification:** extends — list/detail deep links now restore to the focused record instead of the top of the page.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `app-ui` | surfaces | extends — RecordTable marks the focused record; scroll restoration lands on it, retrying while `recordLoading` or list `busy` |

### Change flow

A deep link to an expanded list/detail record scrolls to that row on first paint; row clicks in the table still keep their scroll.

```mermaid
sequenceDiagram
	actor User
	participant appUi as app-ui
	User->>appUi: GET /account/secrets/:id (or any list/detail)
	appUi->>appUi: SSR RecordTable with data-record-focus
	alt off-window selection still loading
		appUi->>appUi: data-record-focus-pending until recordLoading/busy clears
	end
	appUi->>appUi: pre-paint script scrolls focused row if off-screen
	Note over appUi: saved Y on refresh still wins; row clicks keep preventScrollReset
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a5f488d8-35eb-4633-b2c9-d1b8ff7e25cd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a5f488d8-35eb-4633-b2c9-d1b8ff7e25cd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved deep-link navigation in list and detail views by automatically scrolling the selected record into view.
  * Added spacing so focused records remain visible below the sticky page header.
  * Added support for restoring focus while a selected record is still loading, including retry behavior.
* **Bug Fixes**
  * Prevented unnecessary scrolling when the selected record is already visible.
  * Preserved existing saved scroll positions during navigation and page restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->