### PR TITLE
Add focused entitlement metadata on MCP plan-limit denials

### DIFF
--- a/docs/contributing/architecture/entitlements.md
+++ b/docs/contributing/architecture/entitlements.md
@@ -545,6 +545,12 @@ Rules:
   if a surface must detect it). MCP execute results and UI handlers serialize
   `error.message`, so the message carries the full context even across Durable
   Object / RPC boundaries.
+- MCP `search` / `execute` tool errors that are entitlement or plan-limit
+  denials also attach a focused `structuredContent.entitlement` object built
+  from those same `details` (plus compact `used` / `remaining` on daily quota
+  resources). Ordinary successful tool returns omit `entitlement`. The object
+  never includes secrets, raw billing records, prices, or unrelated
+  entitlements. See `packages/worker/src/mcp/entitlement-metadata.ts`.
 
 ## Counting strategy
 

--- a/docs/use/execute.md
+++ b/docs/use/execute.md
@@ -265,6 +265,12 @@ Handled **execute** responses also include top-level **`timing`** metadata with
 `startedAt`, `endedAt`, and `durationMs` alongside `conversationId`. Use it for
 basic latency instrumentation around tool runs.
 
+When a call is denied by a plan limit or a daily quota, the existing error
+message and `isError: true` stay the same. Structured content also includes a
+focused **`entitlement`** object with known fields only (resource, current plan,
+limit, current usage, upgrade hint). Daily quota denials add compact `used` and
+`remaining`. Ordinary successful execute results omit `entitlement`.
+
 For memory mutations, the workflow is explicit and strict:
 
 - **Always run `metaMemoryVerify` before writing or deleting memory**

--- a/docs/use/first-steps.md
+++ b/docs/use/first-steps.md
@@ -13,6 +13,11 @@ guides load with `search({ entity: "{id}:guide" })` — not execute.
 - **Read `timing` when tool latency matters.** `search` and `execute` return
   timing metadata with `startedAt`, `endedAt`, and `durationMs` in structured
   responses.
+- **Read `entitlement` only on plan-limit or quota denials.** Those error
+  results keep the existing error text and `isError` flag, and add a focused
+  machine-readable `entitlement` object (resource, current plan, limit, current
+  usage, upgrade hint; daily quotas also include `used` / `remaining`). Ordinary
+  successful tool returns omit `entitlement`.
 - **Pass `memoryContext`** when durable user memory may matter. Kody uses it to
   surface a small set of relevant long-term memories as compact subject and
   summary one-liners. `search` also retrieves from the query string.

--- a/docs/use/search.md
+++ b/docs/use/search.md
@@ -92,6 +92,11 @@ stay off this block. At most three items, then “N more” pointing at
 and empty/broad discovery do not inject it. Matching integration hits also carry
 the reconnect `nextStep` when the last refresh was reconnectable.
 
+Plan-limit or quota denials keep the existing error text and `isError` flag and
+add a focused `entitlement` object on structured content. Ordinary successful
+search results omit `entitlement`. Search itself has no daily quota; the field
+is for the shared MCP error envelope.
+
 Search responses also return top-level **`timing`** metadata with
 **`startedAt`**, **`endedAt`**, and **`durationMs`** so hosts can reason about
 how long the ranked lookup or entity lookup took.

--- a/packages/worker/src/entitlements/entitlements.node.test.ts
+++ b/packages/worker/src/entitlements/entitlements.node.test.ts
@@ -237,6 +237,28 @@ test('job interval floor messages parse back to known plan and interval', () => 
 			'Your "free" plan cannot run jobs more often than every often. hint',
 		),
 	).toBeNull()
+	expect(
+		parseJobIntervalFloorMessage(
+			buildJobIntervalFloorMessage({
+				...details,
+				upgradeHint: '',
+			}),
+		),
+	).toEqual({
+		...details,
+		upgradeHint: '',
+	})
+	expect(
+		parseJobIntervalFloorMessage(
+			buildJobIntervalFloorMessage({
+				...details,
+				upgradeHint: 'Space this job out. Then upgrade at /account/billing.',
+			}),
+		),
+	).toEqual({
+		...details,
+		upgradeHint: 'Space this job out. Then upgrade at /account/billing.',
+	})
 })
 
 test('storage byte entry estimates support net-positive upsert deltas', () => {

--- a/packages/worker/src/entitlements/entitlements.node.test.ts
+++ b/packages/worker/src/entitlements/entitlements.node.test.ts
@@ -4,7 +4,10 @@ import {
 	EntitlementLimitError,
 	buildEntitlementLimitMessage,
 	buildEntitlementUpgradeHint,
+	buildJobIntervalFloorMessage,
+	jobIntervalFloorErrorCode,
 	parseEntitlementLimitMessage,
+	parseJobIntervalFloorMessage,
 } from './errors.ts'
 import { parseStripePlanName, planLimits } from '#universal/plans.ts'
 import {
@@ -210,6 +213,28 @@ test('entitlement limit messages always identify a known plan name', () => {
 	expect(
 		parseEntitlementLimitMessage(
 			'Plan limit reached: your "enterprise" plan allows at most 100 concurrent workflows and you currently have 100. hint',
+		),
+	).toBeNull()
+})
+
+test('job interval floor messages parse back to known plan and interval', () => {
+	const details = {
+		code: jobIntervalFloorErrorCode,
+		plan: 'free' as const,
+		minIntervalMs: planLimits.free.minJobIntervalMs,
+		upgradeHint: 'Space this job out, or upgrade at /account/billing.',
+	}
+	expect(
+		parseJobIntervalFloorMessage(buildJobIntervalFloorMessage(details)),
+	).toEqual(details)
+	expect(
+		parseJobIntervalFloorMessage(
+			'Your "enterprise" plan cannot run jobs more often than every 15 minutes. hint',
+		),
+	).toBeNull()
+	expect(
+		parseJobIntervalFloorMessage(
+			'Your "free" plan cannot run jobs more often than every often. hint',
 		),
 	).toBeNull()
 })

--- a/packages/worker/src/entitlements/errors.ts
+++ b/packages/worker/src/entitlements/errors.ts
@@ -118,7 +118,7 @@ export function parseJobIntervalFloorMessage(
 	message: string,
 ): JobIntervalFloorErrorDetails | null {
 	const match =
-		/^Your "([^"]+)" plan cannot run jobs more often than every (.+)\. (.+)$/.exec(
+		/^Your "([^"]+)" plan cannot run jobs more often than every (.*?)\. (.*)$/.exec(
 			message,
 		)
 	if (!match) return null

--- a/packages/worker/src/entitlements/errors.ts
+++ b/packages/worker/src/entitlements/errors.ts
@@ -114,6 +114,51 @@ export function buildJobIntervalFloorMessage(
 	return `Your "${details.plan}" plan cannot run jobs more often than every ${interval}. ${details.upgradeHint}`
 }
 
+export function parseJobIntervalFloorMessage(
+	message: string,
+): JobIntervalFloorErrorDetails | null {
+	const match =
+		/^Your "([^"]+)" plan cannot run jobs more often than every (.+)\. (.+)$/.exec(
+			message,
+		)
+	if (!match) return null
+	const plan = parsePlanName(match[1])
+	if (!plan) return null
+	const minIntervalMs = parseFormattedMinJobInterval(match[2] ?? '')
+	if (minIntervalMs === null) return null
+	return {
+		code: jobIntervalFloorErrorCode,
+		plan,
+		minIntervalMs,
+		upgradeHint: match[3] ?? '',
+	}
+}
+
+function parseFormattedMinJobInterval(interval: string) {
+	if (interval === 'None') return 0
+	if (interval === '1 hour') return 60 * 60 * 1000
+	if (interval === '1 minute') return 60 * 1000
+	const hours = /^(\d+) hours$/.exec(interval)
+	if (hours) {
+		const value = Number(hours[1])
+		if (!Number.isSafeInteger(value) || value < 1) return null
+		return value * 60 * 60 * 1000
+	}
+	const minutes = /^(\d+) minutes$/.exec(interval)
+	if (minutes) {
+		const value = Number(minutes[1])
+		if (!Number.isSafeInteger(value) || value < 1) return null
+		return value * 60 * 1000
+	}
+	const milliseconds = /^(\d+) ms$/.exec(interval)
+	if (milliseconds) {
+		const value = Number(milliseconds[1])
+		if (!Number.isSafeInteger(value) || value < 1) return null
+		return value
+	}
+	return null
+}
+
 export class JobIntervalFloorError extends Error {
 	readonly details: JobIntervalFloorErrorDetails
 

--- a/packages/worker/src/mcp/capabilities/meta/execute.ts
+++ b/packages/worker/src/mcp/capabilities/meta/execute.ts
@@ -5,6 +5,7 @@ import {
 	getExecutionErrorDetails,
 	limitExecutionResultValue,
 } from '#mcp/executor.ts'
+import { entitlementStructuredContent } from '#mcp/entitlement-metadata.ts'
 import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { runModuleWithRegistry } from '#mcp/run-kody-registry.ts'
@@ -40,6 +41,7 @@ const executeOutputSchema = z.object({
 	result: z.unknown().optional(),
 	error: z.string().optional(),
 	errorDetails: z.unknown().optional(),
+	entitlement: z.unknown().optional(),
 	logs: z.array(z.unknown()),
 	serverTiming: z
 		.array(
@@ -268,6 +270,7 @@ export const executeCapability = defineDomainCapability(
 					...(claimedRunHandle ? { runId: claimedRunHandle.id } : {}),
 					error: getErrorMessage(cause),
 					errorDetails: getExecutionErrorDetails(cause),
+					...entitlementStructuredContent(cause),
 					logs: [],
 				}
 			}
@@ -288,6 +291,7 @@ export const executeCapability = defineDomainCapability(
 					...(runId ? { runId } : {}),
 					error: getErrorMessage(result.error),
 					errorDetails: getExecutionErrorDetails(result.error),
+					...entitlementStructuredContent(result.error),
 					logs,
 					...(serverTiming ? { serverTiming } : {}),
 				}

--- a/packages/worker/src/mcp/capabilities/meta/execute.ts
+++ b/packages/worker/src/mcp/capabilities/meta/execute.ts
@@ -140,9 +140,7 @@ export const executeCapability = defineDomainCapability(
 							runId: existing.id,
 							replayed: true,
 							status: 'error' as const,
-							error:
-								existing.errorMessage ??
-								'Execute failed (replayed from run record).',
+							...replayedExecuteError(existing.errorMessage),
 							...(retained !== undefined ? { result: retained } : {}),
 							logs: [],
 						}
@@ -200,9 +198,7 @@ export const executeCapability = defineDomainCapability(
 							runId: claim.run.id,
 							replayed: true,
 							status: 'error' as const,
-							error:
-								claim.run.errorMessage ??
-								'Execute failed (replayed from run record).',
+							...replayedExecuteError(claim.run.errorMessage),
 							...(retained !== undefined ? { result: retained } : {}),
 							logs: [],
 						}
@@ -319,3 +315,11 @@ export const executeCapability = defineDomainCapability(
 		},
 	},
 )
+
+function replayedExecuteError(errorMessage: string | null | undefined) {
+	const error = errorMessage ?? 'Execute failed (replayed from run record).'
+	return {
+		error,
+		...entitlementStructuredContent(error),
+	}
+}

--- a/packages/worker/src/mcp/entitlement-metadata.node.test.ts
+++ b/packages/worker/src/mcp/entitlement-metadata.node.test.ts
@@ -85,6 +85,13 @@ test('entitlement metadata is only for known plan-limit and quota denials', () =
 		current: stockLimit,
 		upgradeHint: stockHint,
 	})
+	expect(toMcpEntitlementMetadata(new Error(intervalDenial.message))).toEqual({
+		code: jobIntervalFloorErrorCode,
+		resource: 'scheduled_jobs',
+		plan: 'free',
+		upgradeHint: buildJobIntervalFloorUpgradeHint(),
+		minIntervalMs: intervalMs,
+	})
 	expect(toMcpEntitlementMetadata(new Error('Boom'))).toBeUndefined()
 	expect(entitlementStructuredContent(new Error('Boom'))).toEqual({})
 })

--- a/packages/worker/src/mcp/entitlement-metadata.node.test.ts
+++ b/packages/worker/src/mcp/entitlement-metadata.node.test.ts
@@ -1,0 +1,90 @@
+import { expect, test } from 'vitest'
+import { planLimits } from '#universal/plans.ts'
+import {
+	EntitlementLimitError,
+	JobIntervalFloorError,
+	buildEntitlementUpgradeHint,
+	buildJobIntervalFloorUpgradeHint,
+	entitlementLimitErrorCode,
+	jobIntervalFloorErrorCode,
+} from '#worker/entitlements/errors.ts'
+import {
+	entitlementStructuredContent,
+	toMcpEntitlementMetadata,
+} from './entitlement-metadata.ts'
+
+test('entitlement metadata is only for known plan-limit and quota denials', () => {
+	const stockLimit = planLimits.free.maxSavedPackages
+	const stockDenial = new EntitlementLimitError({
+		resource: 'saved_packages',
+		plan: 'free',
+		limit: stockLimit,
+		current: stockLimit,
+		upgradeHint: buildEntitlementUpgradeHint('saved_packages'),
+	})
+	expect(toMcpEntitlementMetadata(stockDenial)).toEqual({
+		code: entitlementLimitErrorCode,
+		resource: 'saved_packages',
+		plan: 'free',
+		limit: stockLimit,
+		current: stockLimit,
+		upgradeHint: buildEntitlementUpgradeHint('saved_packages'),
+	})
+	expect(toMcpEntitlementMetadata(stockDenial)).not.toHaveProperty('used')
+	expect(toMcpEntitlementMetadata(stockDenial)).not.toHaveProperty('remaining')
+	const stockHint = buildEntitlementUpgradeHint('saved_packages')
+	expect(entitlementStructuredContent(stockDenial)).toEqual({
+		entitlement: {
+			code: entitlementLimitErrorCode,
+			resource: 'saved_packages',
+			plan: 'free',
+			limit: stockLimit,
+			current: stockLimit,
+			upgradeHint: stockHint,
+		},
+	})
+
+	const quotaLimit = planLimits.free.maxExecuteCallsPerDay
+	const quotaHint = buildEntitlementUpgradeHint('execute_calls_per_day')
+	const quotaDenial = new EntitlementLimitError({
+		resource: 'execute_calls_per_day',
+		plan: 'free',
+		limit: quotaLimit,
+		current: quotaLimit,
+		upgradeHint: quotaHint,
+	})
+	expect(toMcpEntitlementMetadata(quotaDenial)).toEqual({
+		code: entitlementLimitErrorCode,
+		resource: 'execute_calls_per_day',
+		plan: 'free',
+		limit: quotaLimit,
+		current: quotaLimit,
+		upgradeHint: quotaHint,
+		used: quotaLimit,
+		remaining: 0,
+	})
+
+	const intervalMs = planLimits.free.minJobIntervalMs
+	const intervalDenial = new JobIntervalFloorError({
+		plan: 'free',
+		minIntervalMs: intervalMs,
+	})
+	expect(toMcpEntitlementMetadata(intervalDenial)).toEqual({
+		code: jobIntervalFloorErrorCode,
+		resource: 'scheduled_jobs',
+		plan: 'free',
+		upgradeHint: buildJobIntervalFloorUpgradeHint(),
+		minIntervalMs: intervalMs,
+	})
+
+	expect(toMcpEntitlementMetadata(new Error(stockDenial.message))).toEqual({
+		code: entitlementLimitErrorCode,
+		resource: 'saved_packages',
+		plan: 'free',
+		limit: stockLimit,
+		current: stockLimit,
+		upgradeHint: stockHint,
+	})
+	expect(toMcpEntitlementMetadata(new Error('Boom'))).toBeUndefined()
+	expect(entitlementStructuredContent(new Error('Boom'))).toEqual({})
+})

--- a/packages/worker/src/mcp/entitlement-metadata.node.test.ts
+++ b/packages/worker/src/mcp/entitlement-metadata.node.test.ts
@@ -92,6 +92,42 @@ test('entitlement metadata is only for known plan-limit and quota denials', () =
 		upgradeHint: buildJobIntervalFloorUpgradeHint(),
 		minIntervalMs: intervalMs,
 	})
+	const multiSentenceHint =
+		'Space this job out. Then upgrade at /account/billing.'
+	expect(
+		toMcpEntitlementMetadata(
+			new Error(
+				new JobIntervalFloorError({
+					plan: 'free',
+					minIntervalMs: intervalMs,
+					upgradeHint: multiSentenceHint,
+				}).message,
+			),
+		),
+	).toEqual({
+		code: jobIntervalFloorErrorCode,
+		resource: 'scheduled_jobs',
+		plan: 'free',
+		upgradeHint: multiSentenceHint,
+		minIntervalMs: intervalMs,
+	})
+	expect(
+		toMcpEntitlementMetadata(
+			new Error(
+				new JobIntervalFloorError({
+					plan: 'free',
+					minIntervalMs: intervalMs,
+					upgradeHint: '',
+				}).message,
+			),
+		),
+	).toEqual({
+		code: jobIntervalFloorErrorCode,
+		resource: 'scheduled_jobs',
+		plan: 'free',
+		upgradeHint: '',
+		minIntervalMs: intervalMs,
+	})
 	expect(toMcpEntitlementMetadata(new Error('Boom'))).toBeUndefined()
 	expect(entitlementStructuredContent(new Error('Boom'))).toEqual({})
 })

--- a/packages/worker/src/mcp/entitlement-metadata.ts
+++ b/packages/worker/src/mcp/entitlement-metadata.ts
@@ -5,6 +5,7 @@ import {
 	isJobIntervalFloorError,
 	jobIntervalFloorErrorCode,
 	parseEntitlementLimitMessage,
+	parseJobIntervalFloorMessage,
 	type EntitlementLimitErrorDetails,
 	type JobIntervalFloorErrorDetails,
 } from '#worker/entitlements/errors.ts'
@@ -41,17 +42,14 @@ export function toMcpEntitlementMetadata(
 		return toEntitlementLimitMetadata(error.details)
 	}
 	if (isJobIntervalFloorError(error)) {
-		return {
-			code: jobIntervalFloorErrorCode,
-			resource: 'scheduled_jobs',
-			plan: error.details.plan,
-			upgradeHint: error.details.upgradeHint,
-			minIntervalMs: error.details.minIntervalMs,
-		}
+		return toJobIntervalMetadata(error.details)
 	}
 
-	const parsed = parseEntitlementLimitMessage(getErrorMessage(error))
-	if (parsed) return toEntitlementLimitMetadata(parsed)
+	const message = getErrorMessage(error)
+	const entitlementDetails = parseEntitlementLimitMessage(message)
+	if (entitlementDetails) return toEntitlementLimitMetadata(entitlementDetails)
+	const intervalDetails = parseJobIntervalFloorMessage(message)
+	if (intervalDetails) return toJobIntervalMetadata(intervalDetails)
 	return undefined
 }
 
@@ -81,5 +79,17 @@ function toEntitlementLimitMetadata(
 		...metadata,
 		used: details.current,
 		remaining: Math.max(0, details.limit - details.current),
+	}
+}
+
+function toJobIntervalMetadata(
+	details: JobIntervalFloorErrorDetails,
+): McpEntitlementMetadata {
+	return {
+		code: jobIntervalFloorErrorCode,
+		resource: 'scheduled_jobs',
+		plan: details.plan,
+		upgradeHint: details.upgradeHint,
+		minIntervalMs: details.minIntervalMs,
 	}
 }

--- a/packages/worker/src/mcp/entitlement-metadata.ts
+++ b/packages/worker/src/mcp/entitlement-metadata.ts
@@ -1,0 +1,85 @@
+import { getErrorMessage } from '@kody-internal/shared/error-message.ts'
+import {
+	entitlementLimitErrorCode,
+	isEntitlementLimitError,
+	isJobIntervalFloorError,
+	jobIntervalFloorErrorCode,
+	parseEntitlementLimitMessage,
+	type EntitlementLimitErrorDetails,
+	type JobIntervalFloorErrorDetails,
+} from '#worker/entitlements/errors.ts'
+import { isDailyEntitlementResource } from '#worker/entitlements/user-meter-do.ts'
+
+/**
+ * Focused, machine-readable entitlement fields for MCP tool structured
+ * content. Only known denial/quota fields — never secrets, prices, billing
+ * records, or unrelated entitlements. Omitted from ordinary successes.
+ */
+export type McpEntitlementMetadata =
+	| {
+			code: typeof entitlementLimitErrorCode
+			resource: EntitlementLimitErrorDetails['resource']
+			plan: EntitlementLimitErrorDetails['plan']
+			limit: number
+			current: number
+			upgradeHint: string
+			used?: number
+			remaining?: number
+	  }
+	| {
+			code: typeof jobIntervalFloorErrorCode
+			resource: 'scheduled_jobs'
+			plan: JobIntervalFloorErrorDetails['plan']
+			upgradeHint: string
+			minIntervalMs: number
+	  }
+
+export function toMcpEntitlementMetadata(
+	error: unknown,
+): McpEntitlementMetadata | undefined {
+	if (isEntitlementLimitError(error)) {
+		return toEntitlementLimitMetadata(error.details)
+	}
+	if (isJobIntervalFloorError(error)) {
+		return {
+			code: jobIntervalFloorErrorCode,
+			resource: 'scheduled_jobs',
+			plan: error.details.plan,
+			upgradeHint: error.details.upgradeHint,
+			minIntervalMs: error.details.minIntervalMs,
+		}
+	}
+
+	const parsed = parseEntitlementLimitMessage(getErrorMessage(error))
+	if (parsed) return toEntitlementLimitMetadata(parsed)
+	return undefined
+}
+
+/**
+ * Spread onto MCP `structuredContent` only when the error is an entitlement
+ * or plan-limit denial. Ordinary successes and unrelated errors stay
+ * unchanged (no `entitlement` key).
+ */
+export function entitlementStructuredContent(error: unknown) {
+	const entitlement = toMcpEntitlementMetadata(error)
+	return entitlement ? { entitlement } : {}
+}
+
+function toEntitlementLimitMetadata(
+	details: EntitlementLimitErrorDetails,
+): McpEntitlementMetadata {
+	const metadata = {
+		code: entitlementLimitErrorCode,
+		resource: details.resource,
+		plan: details.plan,
+		limit: details.limit,
+		current: details.current,
+		upgradeHint: details.upgradeHint,
+	} as const
+	if (!isDailyEntitlementResource(details.resource)) return metadata
+	return {
+		...metadata,
+		used: details.current,
+		remaining: Math.max(0, details.limit - details.current),
+	}
+}

--- a/packages/worker/src/mcp/executor.node.test.ts
+++ b/packages/worker/src/mcp/executor.node.test.ts
@@ -7,7 +7,10 @@ import {
 	createSecretScopeUnavailableMessage,
 } from '#mcp/secrets/errors.ts'
 import { createKodyProviderProxySource } from '#mcp/kody-provider-proxy-source.ts'
-import { EntitlementLimitError } from '#worker/entitlements/errors.ts'
+import {
+	EntitlementLimitError,
+	JobIntervalFloorError,
+} from '#worker/entitlements/errors.ts'
 import { createUnboundRuntimeHelperMessage } from '#worker/package-runtime/unbound-runtime-helpers.ts'
 import { createStorageEstimateReadError } from '#worker/storage-estimate-error.ts'
 import {
@@ -1516,6 +1519,29 @@ test('executor maps secret errors, formats guidance, extracts raw content, and t
 			limit: 3,
 			current: 3,
 			upgradeHint: 'Remove an old package or upgrade your plan.',
+		},
+	})
+
+	const intervalError = new JobIntervalFloorError({
+		plan: 'free',
+		minIntervalMs: 15 * 60 * 1000,
+	})
+	expect(getExecutionErrorDetails(intervalError)).toMatchObject({
+		kind: 'job_interval_floor',
+		nextStep: intervalError.details.upgradeHint,
+		suggestedAction: {
+			type: 'review_plan_limit',
+			resource: 'scheduled_jobs',
+		},
+	})
+	expect(
+		getExecutionErrorDetails(new Error(intervalError.message)),
+	).toMatchObject({
+		kind: 'job_interval_floor',
+		nextStep: intervalError.details.upgradeHint,
+		suggestedAction: {
+			type: 'review_plan_limit',
+			resource: 'scheduled_jobs',
 		},
 	})
 

--- a/packages/worker/src/mcp/executor.ts
+++ b/packages/worker/src/mcp/executor.ts
@@ -41,6 +41,7 @@ import {
 	isEntitlementLimitError,
 	isJobIntervalFloorError,
 	parseEntitlementLimitMessage,
+	parseJobIntervalFloorMessage,
 	type EntitlementLimitErrorDetails,
 } from '#worker/entitlements/errors.ts'
 import { buildIntegrationReconnectHref } from '#universal/connection-trouble.ts'
@@ -1288,6 +1289,19 @@ export function getExecutionErrorDetails(
 	const entitlementDetails = parseEntitlementLimitMessage(message)
 	if (entitlementDetails) {
 		return toEntitlementExecutionErrorDetails(message, entitlementDetails)
+	}
+
+	const intervalDetails = parseJobIntervalFloorMessage(message)
+	if (intervalDetails) {
+		return {
+			kind: 'job_interval_floor',
+			message,
+			nextStep: intervalDetails.upgradeHint,
+			suggestedAction: {
+				type: 'review_plan_limit',
+				resource: 'scheduled_jobs',
+			},
+		}
 	}
 
 	const causeMessages = getErrorCauseChain(error).map(getErrorMessage)

--- a/packages/worker/src/mcp/tools/execute.node.test.ts
+++ b/packages/worker/src/mcp/tools/execute.node.test.ts
@@ -780,6 +780,44 @@ test('execute tool replays finished keyed runs and reports in-progress without r
 		inProgress: true,
 		status: 'running',
 	})
+
+	const quotaLimit = planLimits.free.maxExecuteCallsPerDay
+	const quotaHint = buildEntitlementUpgradeHint('execute_calls_per_day')
+	const quotaMessage = buildEntitlementLimitMessage({
+		code: entitlementLimitErrorCode,
+		resource: 'execute_calls_per_day',
+		plan: 'free',
+		limit: quotaLimit,
+		current: quotaLimit,
+		upgradeHint: quotaHint,
+	})
+	mockModule.getRunRecordByIdempotencyKey.mockResolvedValueOnce({
+		...finishedRun,
+		id: 'run-quota-replay-1',
+		status: 'error',
+		errorName: 'EntitlementLimitError',
+		errorMessage: quotaMessage,
+		metadata: {},
+	})
+	mockPerformanceSequence(5, 6)
+	const quotaReplayed = await handler({
+		code: 'export default async () => ({ shouldNotRun: true })',
+		idempotencyKey: 'spawn-agent-1',
+		conversationId: 'conv-quota-replay',
+	})
+	expect(mockModule.runModuleWithRegistry).not.toHaveBeenCalled()
+	expect(quotaReplayed.isError).toBe(true)
+	expect(quotaReplayed.structuredContent.error).toBe(quotaMessage)
+	expect(quotaReplayed.structuredContent.entitlement).toEqual({
+		code: entitlementLimitErrorCode,
+		resource: 'execute_calls_per_day',
+		plan: 'free',
+		limit: quotaLimit,
+		current: quotaLimit,
+		upgradeHint: quotaHint,
+		used: quotaLimit,
+		remaining: 0,
+	})
 })
 
 test('execute tool claims a keyed run, passes the handle, and returns runId', async () => {

--- a/packages/worker/src/mcp/tools/execute.node.test.ts
+++ b/packages/worker/src/mcp/tools/execute.node.test.ts
@@ -4,9 +4,11 @@ import { expect, test, vi } from 'vitest'
 import { planLimits } from '#universal/plans.ts'
 import {
 	EntitlementLimitError,
+	JobIntervalFloorError,
 	buildEntitlementLimitMessage,
 	buildEntitlementUpgradeHint,
 	entitlementLimitErrorCode,
+	jobIntervalFloorErrorCode,
 } from '#worker/entitlements/errors.ts'
 import { createStableUserIdFromEmail } from '#worker/user-id.ts'
 import {
@@ -817,6 +819,34 @@ test('execute tool replays finished keyed runs and reports in-progress without r
 		upgradeHint: quotaHint,
 		used: quotaLimit,
 		remaining: 0,
+	})
+
+	const intervalDenial = new JobIntervalFloorError({
+		plan: 'free',
+		minIntervalMs: planLimits.free.minJobIntervalMs,
+	})
+	mockModule.getRunRecordByIdempotencyKey.mockResolvedValueOnce({
+		...finishedRun,
+		id: 'run-interval-replay-1',
+		status: 'error',
+		errorName: 'JobIntervalFloorError',
+		errorMessage: intervalDenial.message,
+		metadata: {},
+	})
+	mockPerformanceSequence(7, 8)
+	const intervalReplayed = await handler({
+		code: 'export default async () => ({ shouldNotRun: true })',
+		idempotencyKey: 'spawn-agent-1',
+		conversationId: 'conv-interval-replay',
+	})
+	expect(intervalReplayed.isError).toBe(true)
+	expect(intervalReplayed.structuredContent.error).toBe(intervalDenial.message)
+	expect(intervalReplayed.structuredContent.entitlement).toEqual({
+		code: jobIntervalFloorErrorCode,
+		resource: 'scheduled_jobs',
+		plan: 'free',
+		upgradeHint: intervalDenial.details.upgradeHint,
+		minIntervalMs: planLimits.free.minJobIntervalMs,
 	})
 })
 

--- a/packages/worker/src/mcp/tools/execute.node.test.ts
+++ b/packages/worker/src/mcp/tools/execute.node.test.ts
@@ -1,5 +1,14 @@
 import { type ContentBlock } from '@modelcontextprotocol/sdk/types.js'
+import { utcDayKey } from '@kody-internal/shared/date-keys.ts'
 import { expect, test, vi } from 'vitest'
+import { planLimits } from '#universal/plans.ts'
+import {
+	EntitlementLimitError,
+	buildEntitlementLimitMessage,
+	buildEntitlementUpgradeHint,
+	entitlementLimitErrorCode,
+} from '#worker/entitlements/errors.ts'
+import { createStableUserIdFromEmail } from '#worker/user-id.ts'
 import {
 	defaultMcpContentLimitBytes,
 	maxMcpContentBlockCount,
@@ -184,6 +193,17 @@ async function getExecuteHandler(
 			result: unknown
 			logs: Array<unknown>
 			error?: string
+			errorDetails?: unknown
+			entitlement?: {
+				code: string
+				resource: string
+				plan: string
+				limit?: number
+				current?: number
+				upgradeHint: string
+				used?: number
+				remaining?: number
+			}
 		}
 		isError: boolean
 	}>
@@ -874,5 +894,104 @@ test('execute tool threads a progress reporter when the client sends progressTok
 			progress: 1,
 			message: 'bundle time',
 		},
+	})
+})
+
+test('execute tool attaches entitlement metadata on denials and quota, not on success', async () => {
+	const successHandler = await getExecuteHandler()
+	mockPerformanceSequence(1, 2)
+	mockModule.runModuleWithRegistry.mockResolvedValueOnce({
+		result: { ok: true },
+		logs: [],
+	})
+	const success = await successHandler({
+		code: 'export default async () => ({ ok: true })',
+		conversationId: 'conv-entitlement-success',
+	})
+	expect(success.isError).toBe(false)
+	expect(success.structuredContent).toEqual({
+		conversationId: 'conv-entitlement-success',
+		timing: {
+			startedAt: expect.any(String),
+			endedAt: expect.any(String),
+			durationMs: 1,
+		},
+		returnedBytes: expect.any(Number),
+		result: { ok: true },
+		logs: [],
+	})
+	expect(success.structuredContent).not.toHaveProperty('entitlement')
+
+	const stockLimit = planLimits.free.maxSavedPackages
+	const stockHint = buildEntitlementUpgradeHint('saved_packages')
+	const stockDenial = new EntitlementLimitError({
+		resource: 'saved_packages',
+		plan: 'free',
+		limit: stockLimit,
+		current: stockLimit,
+		upgradeHint: stockHint,
+	})
+	mockPerformanceSequence(3, 4)
+	mockModule.runModuleWithRegistry.mockResolvedValueOnce({
+		error: stockDenial,
+		logs: [],
+	})
+	const denied = await successHandler({
+		code: 'export default async () => { throw stockDenial }',
+		conversationId: 'conv-entitlement-stock',
+	})
+	expect(denied.isError).toBe(true)
+	expect(denied.structuredContent.error).toBe(stockDenial.message)
+	expect(denied.structuredContent.entitlement).toEqual({
+		code: entitlementLimitErrorCode,
+		resource: 'saved_packages',
+		plan: 'free',
+		limit: stockLimit,
+		current: stockLimit,
+		upgradeHint: stockHint,
+	})
+	expect(denied.structuredContent.entitlement).not.toHaveProperty('used')
+	expect(denied.structuredContent.entitlement).not.toHaveProperty('remaining')
+
+	const quotaEmail = 'quota-metadata@example.com'
+	const quotaUserId = await createStableUserIdFromEmail(quotaEmail)
+	const quotaLimit = planLimits.free.maxExecuteCallsPerDay
+	const quotaHint = buildEntitlementUpgradeHint('execute_calls_per_day')
+	await userMeter.seed({
+		userId: quotaUserId,
+		resource: 'execute_calls_per_day',
+		day: utcDayKey(new Date()),
+		count: quotaLimit,
+	})
+	const quotaHandler = await getExecuteHandler({
+		baseUrl: 'https://example.com',
+		user: { userId: quotaUserId, email: quotaEmail },
+	})
+	mockPerformanceSequence(5, 6)
+	const quotaDenied = await quotaHandler({
+		code: 'export default async () => ({ shouldNotRun: true })',
+		conversationId: 'conv-entitlement-quota',
+	})
+	expect(mockModule.runModuleWithRegistry).not.toHaveBeenCalled()
+	expect(quotaDenied.isError).toBe(true)
+	expect(quotaDenied.structuredContent.error).toBe(
+		buildEntitlementLimitMessage({
+			code: entitlementLimitErrorCode,
+			resource: 'execute_calls_per_day',
+			plan: 'free',
+			limit: quotaLimit,
+			current: quotaLimit,
+			upgradeHint: quotaHint,
+		}),
+	)
+	expect(quotaDenied.structuredContent.entitlement).toEqual({
+		code: entitlementLimitErrorCode,
+		resource: 'execute_calls_per_day',
+		plan: 'free',
+		limit: quotaLimit,
+		current: quotaLimit,
+		upgradeHint: quotaHint,
+		used: quotaLimit,
+		remaining: 0,
 	})
 })

--- a/packages/worker/src/mcp/tools/execute.ts
+++ b/packages/worker/src/mcp/tools/execute.ts
@@ -13,6 +13,7 @@ import {
 	formatExecutionOutput,
 	getExecutionErrorDetails,
 } from '#mcp/executor.ts'
+import { entitlementStructuredContent } from '#mcp/entitlement-metadata.ts'
 import {
 	defaultMcpContentLimitBytes,
 	extractMcpPassthrough,
@@ -138,6 +139,12 @@ export const executeToolOutputSchema = {
 		.unknown()
 		.optional()
 		.describe('Structured details for sandbox errors.'),
+	entitlement: z
+		.unknown()
+		.optional()
+		.describe(
+			'Focused plan-limit or quota fields when a call is denied. Omitted from ordinary successes.',
+		),
 	logs: z
 		.array(z.unknown())
 		.optional()
@@ -255,6 +262,7 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 				const timing = finishToolTiming(timingStart)
 				const error = cause instanceof Error ? cause : new Error(String(cause))
 				const { errorName, errorMessage } = errorFields(error)
+				const errorDetails = getExecutionErrorDetails(error)
 				logMcpEvent({
 					category: 'mcp',
 					tool: 'execute',
@@ -275,6 +283,8 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 						conversationId: resolvedConversationId,
 						timing,
 						error: error.message,
+						...(errorDetails ? { errorDetails } : {}),
+						...entitlementStructuredContent(error),
 					},
 					isError: true,
 				}
@@ -488,6 +498,7 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 							returnedBytes: 0,
 							error: errorMessage,
 							errorDetails,
+							...entitlementStructuredContent(result.error),
 							logs: result.logs ?? [],
 							...(rawFetchHostNudges.length > 0
 								? { warnings: rawFetchHostNudges }
@@ -709,6 +720,8 @@ function buildKeyedExecuteLookupResponse(input: {
 	if (input.run.status === 'error') {
 		const errorMessage =
 			input.run.errorMessage ?? 'Execute failed (replayed from run record).'
+		const replayedError = new Error(errorMessage)
+		if (input.run.errorName) replayedError.name = input.run.errorName
 		return {
 			content: prependToolMetadataContent(input.conversationId, [
 				{
@@ -724,6 +737,7 @@ function buildKeyedExecuteLookupResponse(input: {
 				returnedBytes: 0,
 				error: errorMessage,
 				...(input.run.errorName ? { errorName: input.run.errorName } : {}),
+				...entitlementStructuredContent(replayedError),
 				...(retainedResult !== undefined ? { result: retainedResult } : {}),
 				logs: [] as Array<unknown>,
 			},

--- a/packages/worker/src/mcp/tools/output-schemas.node.test.ts
+++ b/packages/worker/src/mcp/tools/output-schemas.node.test.ts
@@ -47,6 +47,21 @@ test('search structured content passes advertised schema for all return paths', 
 			error: 'All entity lookups failed.',
 		},
 		{ conversationId: 'c1', timing, error: 'Provide "query".' },
+		{
+			conversationId: 'c1',
+			timing,
+			error: 'Plan limit reached.',
+			entitlement: {
+				code: 'entitlement_limit_exceeded',
+				resource: 'execute_calls_per_day',
+				plan: 'free',
+				limit: 100,
+				current: 100,
+				used: 100,
+				remaining: 0,
+				upgradeHint: 'upgrade your plan at /account/billing.',
+			},
+		},
 	]
 	for (const payload of payloads) {
 		const parsed = await searchSchema.safeParseAsync(payload)
@@ -81,6 +96,23 @@ test('execute structured content passes advertised schema for all return paths',
 			returnedBytes: 0,
 			error: 'ReferenceError: foo is not defined',
 			errorDetails: { phase: 'sandbox' },
+			logs: [],
+		},
+		{
+			conversationId: 'c1',
+			timing,
+			returnedBytes: 0,
+			error:
+				'Plan limit reached: your "free" plan allows at most 10 saved packages and you currently have 10.',
+			errorDetails: { kind: 'entitlement_limit_exceeded' },
+			entitlement: {
+				code: 'entitlement_limit_exceeded',
+				resource: 'saved_packages',
+				plan: 'free',
+				limit: 10,
+				current: 10,
+				upgradeHint: 'upgrade your plan at /account/billing.',
+			},
 			logs: [],
 		},
 		{

--- a/packages/worker/src/mcp/tools/search-tool-definition.ts
+++ b/packages/worker/src/mcp/tools/search-tool-definition.ts
@@ -114,6 +114,12 @@ export const searchToolOutputSchema = {
 		.string()
 		.optional()
 		.describe('Error summary when the search failed (isError is set).'),
+	entitlement: z
+		.unknown()
+		.optional()
+		.describe(
+			'Focused plan-limit or quota fields when a call is denied. Omitted from ordinary successes.',
+		),
 }
 
 export type SearchToolArgs = {

--- a/packages/worker/src/mcp/tools/search-tool-runner.ts
+++ b/packages/worker/src/mcp/tools/search-tool-runner.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/cloudflare'
 import { getPackageAppBaseUrl } from '#worker/app-base-url.ts'
 import { resolvePublicUsername } from '#worker/identity/user-lookup.ts'
 import { isMcpCallerError } from '#mcp/caller-error.ts'
+import { entitlementStructuredContent } from '#mcp/entitlement-metadata.ts'
 import { type McpRegistrationAgent } from '#mcp/mcp-registration-agent.ts'
 import {
 	callerContextFields,
@@ -623,6 +624,7 @@ export async function runSearchTool(input: {
 				conversationId,
 				timing,
 				error: error.message,
+				...entitlementStructuredContent(error),
 			},
 			isError: true,
 		}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Give MCP agents a stable, machine-readable `entitlement` object when a tool call is denied by a plan limit or daily quota, without changing ordinary successful tool return shapes.

## Why

Agents already see a human-readable `Plan limit reached…` string. They cannot reliably parse resource, current plan, usage, or an upgrade hint from that text, and stuffing extra fields onto every success would churn the search/execute contracts.

## Summary

- Reuse `EntitlementLimitError` / `JobIntervalFloorError` (existing codes and `details`) as the only entitlement model.
- On MCP `search` / `execute` (and `meta.execute`) **error** returns, attach `structuredContent.entitlement` with known fields only: `code`, `resource`, `plan`, `limit`, `current`, `upgradeHint`.
- Daily quota denials (`execute_calls_per_day` and the other `*_per_day` resources) also include compact `used` / `remaining`. Stock-count denials do not.
- Ordinary successful tool returns omit `entitlement`. Existing `isError` / `error` text stay the same.
- Keyed replay and sandbox-stringified errors reconstruct both plan-limit and interval-floor metadata from the persisted message, including empty or multi-sentence interval-floor hints.
- Docs state that metadata is omitted from ordinary successes.

## Testing

- `packages/worker/src/mcp/entitlement-metadata.node.test.ts` — serializer: stock denial, daily quota usage fields, interval-floor live + message parse (including empty / multi-sentence hints), unrelated errors omit the key.
- `packages/worker/src/mcp/tools/execute.node.test.ts` — execute tool: success unchanged, `saved_packages` denial, real `consumeDailyEntitlement` quota denial, keyed replay of quota and interval-floor messages.
- `packages/worker/src/entitlements/entitlements.node.test.ts` — `parseJobIntervalFloorMessage` round-trip, including empty and multi-sentence hints.
- `packages/worker/src/mcp/executor.node.test.ts` — `getExecutionErrorDetails` reconstructs interval-floor from a plain Error message.
- `packages/worker/src/mcp/tools/output-schemas.node.test.ts` — advertised schemas accept the new optional field.
- `test:node` (2474) and `test:workers` (321) passed after this revision.

Quota path that exists: daily `consumeDailyEntitlement` (representative: `execute_calls_per_day`). Search has no daily quota of its own.

Preview (`23603acd` merge, then `432795ab` pushed): `https://kody-pr-2022.kody-a99.workers.dev` — seed login, `/mcp` 401, `/admin` 403, `/account` `/account/billing` `/account/usage` 200. `/mcp` stays OAuth-only; the contract is covered by execute-tool tests.

**Review follow-up:** CodeRabbit replay gap fixed. Strict advertised Zod union skipped (deliberately loose `outputSchema`). Bugbot interval-floor stringify/replay gap fixed via `parseJobIntervalFloorMessage`. CodeRabbit greedy interval-hint parse fixed on this head.

**Risk:** medium (`extends` mcp-server contract). Left ready for Kent review; not auto-merged.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `4ad22ee0` · **Head:** `432795ab`

**Classification:** extends — MCP search/execute error structured content gains an optional `entitlement` object; successful return shapes are unchanged.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `mcp-server` | surfaces | extends — `structuredContent.entitlement` on plan-limit / quota tool errors |
| `entitlements` | auth | composes — serializer reads existing `EntitlementLimitError` / `JobIntervalFloorError` details |

### Change flow

Search and execute tool errors that are entitlement or plan-limit denials keep the existing error text and `isError`, then attach focused metadata from the thrown error. Keyed replay and sandbox-stringified errors rebuild the same object from the stored message, including empty or multi-sentence interval-floor hints.

```mermaid
sequenceDiagram
	actor Agent
	participant mcpServer as mcp-server
	participant entitlements as entitlements
	Agent->>mcpServer: tools/call search or execute
	mcpServer->>entitlements: assertWithinEntitlement or consumeDailyEntitlement
	alt ordinary success
		entitlements-->>mcpServer: allowed
		mcpServer-->>Agent: existing success shape (no entitlement key)
	else plan-limit or quota denial
		entitlements-->>mcpServer: EntitlementLimitError details
		Note over mcpServer: structuredContent.entitlement from known fields only
		mcpServer-->>Agent: isError plus entitlement (quota adds used/remaining)
	else keyed or stringified interval-floor denial
		mcpServer-->>Agent: reconstruct entitlement from persisted job-interval message
	end
```

### Before / after

**Before (quota / stock denial):** `{ error: "Plan limit reached…", isError: true }` (sandbox path also had `errorDetails`).

**After:** same `error` / `isError` / `errorDetails`, plus `entitlement: { code, resource, plan, limit, current, upgradeHint }` and, on daily quota only, `used` / `remaining`.

### Invariants

Per-user isolation is unchanged: metadata is only the denied resource for the calling user, never secrets, prices, billing records, or other entitlements.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c18aa147-3bb7-4e61-aac6-4deca175983b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c18aa147-3bb7-4e61-aac6-4deca175983b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added structured entitlement details to failed search and execute responses when plan limits, quotas, or minimum-interval rules deny a request.
  * Daily quota denials now include usage and remaining allowance information.
  * Successful requests continue to omit entitlement details.

* **Documentation**
  * Documented entitlement metadata behavior for search, execute, and getting-started workflows.

* **Tests**
  * Added coverage for entitlement metadata, quota details, error handling, and response validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->