### PR TITLE
Guard preview cleanup deletes behind the preview naming scheme

### DIFF
--- a/docs/contributing/setup/preview-deploys.md
+++ b/docs/contributing/setup/preview-deploys.md
@@ -55,6 +55,16 @@ access, so the repo must define a `PREVIEW_ENVIRONMENT_ADMIN_TOKEN` Actions
 secret with a token that has that permission. Cleanup intentionally fails when
 that secret is missing or under-scoped so permission regressions are visible.
 
+Every Cloudflare delete in `tools/ci/preview-resources.ts` (Workers, D1, KV,
+R2, Queues and their consumers) first passes through
+`assertPreviewResourceName(name, kind)`, which throws unless the name matches
+`^kody-(pr-<number>|branch-<slug>)(-<segment>)*$`. Production names (`kody`,
+`kody-platform`, `kody-audit`, `kody-webhook-dispatch`, ...) and the shared
+`kody-preview*` names never match, so a bug or an empty PR number cannot compute
+a production name and delete it. `npm run deploy-guardrails:check` fails if a
+destructive call in that script is not preceded by the guard in the same
+function.
+
 The production deploy workflow can also be started manually from GitHub Actions
 via **Run workflow** on `main`. The manual path verifies that the selected
 commit is the current `origin/main` HEAD before it deploys.

--- a/docs/contributing/setup/preview-deploys.md
+++ b/docs/contributing/setup/preview-deploys.md
@@ -55,8 +55,8 @@ access, so the repo must define a `PREVIEW_ENVIRONMENT_ADMIN_TOKEN` Actions
 secret with a token that has that permission. Cleanup intentionally fails when
 that secret is missing or under-scoped so permission regressions are visible.
 
-Every Cloudflare delete in `tools/ci/preview-resources.ts` (Workers, D1, KV,
-R2, Queues and their consumers) first passes through
+Every Cloudflare delete in `tools/ci/preview-resources.ts` (Workers, D1, KV, R2,
+Queues and their consumers) first passes through
 `assertPreviewResourceName(name, kind)`, which throws unless the name matches
 `^kody-(pr-<number>|branch-<slug>)(-<segment>)*$`. Production names (`kody`,
 `kody-platform`, `kody-audit`, `kody-webhook-dispatch`, ...) and the shared

--- a/tools/check-deploy-guardrails.node.test.ts
+++ b/tools/check-deploy-guardrails.node.test.ts
@@ -1,8 +1,11 @@
+import { readFile } from 'node:fs/promises'
 import { expect, test } from 'vitest'
 import {
 	checkDeployGuardrails,
 	checkDurableObjectConfig,
+	checkPreviewCleanupSource,
 	checkWorkflowSource,
+	defaultPreviewResourcesScriptPath,
 	type DurableObjectBaseline,
 	type DurableObjectDeletionAllowlist,
 } from './check-deploy-guardrails.ts'
@@ -383,6 +386,179 @@ jobs:
 	expect(
 		checkWorkflowSource('bypassable.yml', bypassableMixedWorkflow),
 	).toEqual([expect.stringContaining('outside a job explicitly restricted')])
+})
+
+const guardedCleanupScript = `import {
+	deleteWorkerScript,
+	removeCloudflareQueueConsumers,
+	runWrangler,
+} from './resource-utils.ts'
+
+export function assertPreviewResourceName(name: string, kind: string) {
+	if (!/^kody-pr-\\d+(?:-[a-z0-9]+)*$/.test(name)) {
+		throw new Error(\`Refusing to delete \${kind} "\${name}"\`)
+	}
+}
+
+function deletePreviewWorkerScript(name: string) {
+	assertPreviewResourceName(name, 'worker')
+	deleteWorkerScript({ name, dryRun: false })
+}
+
+async function removePreviewQueueConsumers(name: string) {
+	// Comments mentioning 'delete' or --force are not call sites.
+	assertPreviewResourceName(name, 'queue')
+	await removeCloudflareQueueConsumers({ name })
+}
+
+function deletePreviewD1Database(name: string) {
+	assertPreviewResourceName(name, 'd1')
+	const exists = runWrangler(['d1', 'list', '--json'])
+	if (!exists) return
+	runWrangler(['d1', 'delete', name, '--skip-confirmation'])
+}
+
+async function deletePreviewQueue(queueId: string, name: string) {
+	assertPreviewResourceName(name, 'queue')
+	await cloudflareApiRequest({
+		pathname: \`/queues/\${queueId}\`,
+		method: 'DELETE',
+	})
+}
+`
+
+test('preview cleanup guard accepts a script whose deletes all follow the name guard', () => {
+	expect(
+		checkPreviewCleanupSource('preview-resources.ts', guardedCleanupScript),
+	).toEqual([])
+})
+
+test('preview cleanup guard flags each delete call site that is not preceded by the guard', () => {
+	const unguardedWorkerDelete = guardedCleanupScript.replace(
+		"\tassertPreviewResourceName(name, 'worker')\n",
+		'',
+	)
+	expect(
+		checkPreviewCleanupSource('preview-resources.ts', unguardedWorkerDelete),
+	).toEqual([
+		expect.stringMatching(
+			/preview-resources\.ts:14 performs a destructive Cloudflare operation without a preceding assertPreviewResourceName\(name, kind\) call in the same function: deleteWorkerScript\(/,
+		),
+	])
+
+	const unguardedWranglerDelete = guardedCleanupScript.replace(
+		"\tassertPreviewResourceName(name, 'd1')\n",
+		'',
+	)
+	expect(
+		checkPreviewCleanupSource('preview-resources.ts', unguardedWranglerDelete),
+	).toEqual([
+		expect.stringContaining(
+			"runWrangler(['d1', 'delete', name, '--skip-confirmation'])",
+		),
+	])
+
+	const unguardedRestDelete = guardedCleanupScript.replace(
+		"\tassertPreviewResourceName(name, 'queue')\n\tawait cloudflareApiRequest",
+		'\tawait cloudflareApiRequest',
+	)
+	expect(
+		checkPreviewCleanupSource('preview-resources.ts', unguardedRestDelete),
+	).toEqual([expect.stringContaining("method: 'DELETE'")])
+
+	// A guard in a different function does not cover this one.
+	const guardMovedToCaller = guardedCleanupScript.replace(
+		"async function removePreviewQueueConsumers(name: string) {\n\t// Comments mentioning 'delete' or --force are not call sites.\n\tassertPreviewResourceName(name, 'queue')\n",
+		"function checkFirst(name: string) {\n\tassertPreviewResourceName(name, 'queue')\n}\n\nasync function removePreviewQueueConsumers(name: string) {\n\tcheckFirst(name)\n",
+	)
+	expect(
+		checkPreviewCleanupSource('preview-resources.ts', guardMovedToCaller),
+	).toEqual([expect.stringContaining('removeCloudflareQueueConsumers(')])
+
+	// A newly imported destructive helper is covered without editing the check.
+	const newDestructiveImport = guardedCleanupScript
+		.replace(
+			'\tdeleteWorkerScript,\n',
+			'\tdeleteWorkerScript,\n\tpurgeCache as purgeEverything,\n',
+		)
+		.replace(
+			'function deletePreviewWorkerScript(name: string) {\n',
+			'function purgeAll(name: string) {\n\tpurgeEverything({ name })\n}\n\nfunction deletePreviewWorkerScript(name: string) {\n',
+		)
+	expect(
+		checkPreviewCleanupSource('preview-resources.ts', newDestructiveImport),
+	).toEqual([expect.stringContaining('purgeEverything({ name })')])
+
+	// Deleting at module top level has no enclosing function to guard it.
+	const topLevelDelete = `${guardedCleanupScript}\ndeleteWorkerScript({ name: 'kody', dryRun: false })\n`
+	expect(
+		checkPreviewCleanupSource('preview-resources.ts', topLevelDelete),
+	).toEqual([expect.stringContaining('outside any function')])
+})
+
+test('preview cleanup guard fails closed when the guard or the deletes disappear', () => {
+	expect(
+		checkPreviewCleanupSource(
+			'preview-resources.ts',
+			"import { deleteWorkerScript } from './resource-utils.ts'\n\nfunction cleanup() {\n\tdeleteWorkerScript({ name: 'kody-pr-1', dryRun: false })\n}\n",
+		),
+	).toEqual([
+		expect.stringContaining('does not define assertPreviewResourceName()'),
+	])
+
+	const noDeletes = `export function assertPreviewResourceName(name: string) {
+	if (!name) throw new Error('bad')
+}
+
+function cleanup(name: string) {
+	assertPreviewResourceName(name)
+}
+`
+	expect(checkPreviewCleanupSource('preview-resources.ts', noDeletes)).toEqual([
+		expect.stringContaining('found no destructive Cloudflare operations'),
+	])
+
+	const definedButNeverCalled = `import { deleteWorkerScript } from './resource-utils.ts'
+
+export function assertPreviewResourceName(name: string) {
+	if (!name) throw new Error('bad')
+}
+
+function cleanup() {
+	deleteWorkerScript({ name: 'kody-pr-1', dryRun: false })
+}
+`
+	expect(
+		checkPreviewCleanupSource('preview-resources.ts', definedButNeverCalled),
+	).toEqual([
+		expect.stringContaining('without a preceding assertPreviewResourceName'),
+		expect.stringContaining('never calls assertPreviewResourceName()'),
+	])
+})
+
+test('the committed preview cleanup script routes every delete through the name guard', async () => {
+	const source = await readFile(defaultPreviewResourcesScriptPath, 'utf8')
+	expect(
+		checkPreviewCleanupSource(defaultPreviewResourcesScriptPath, source),
+	).toEqual([])
+	// Removing any single guard call must be caught, so no delete depends on
+	// a guard placed elsewhere.
+	const guardCalls = [
+		...source.matchAll(/^\tassertPreviewResourceName\(.*\)\n/gm),
+	]
+	expect(guardCalls.length).toBeGreaterThanOrEqual(6)
+	for (const guardCall of guardCalls) {
+		const withoutGuard =
+			source.slice(0, guardCall.index) +
+			source.slice(guardCall.index + guardCall[0].length)
+		expect(
+			checkPreviewCleanupSource(
+				defaultPreviewResourcesScriptPath,
+				withoutGuard,
+			),
+			`removing ${guardCall[0].trim()} went unnoticed`,
+		).not.toEqual([])
+	}
 })
 
 test('current repository deploy configuration passes the guardrails', async () => {

--- a/tools/check-deploy-guardrails.ts
+++ b/tools/check-deploy-guardrails.ts
@@ -14,6 +14,12 @@ export const defaultDurableObjectDeletionAllowlistPath = path.join(
 	'do-deletion-allowlist.json',
 )
 export const defaultWorkflowDirectory = path.join('.github', 'workflows')
+export const defaultPreviewResourcesScriptPath = path.join(
+	'tools',
+	'ci',
+	'preview-resources.ts',
+)
+export const previewResourceGuardName = 'assertPreviewResourceName'
 
 type ProtectedMigration = {
 	tag: string
@@ -502,10 +508,157 @@ export function checkWorkflowSource(
 	return errors
 }
 
+/**
+ * Markers that a source line performs (or spells out the arguments of) a
+ * destructive Cloudflare operation: a `wrangler ... delete` argument, the
+ * confirmation-skipping flags, or a REST `DELETE`.
+ */
+const destructiveScriptLinePattern =
+	/'delete'|"delete"|'DELETE'|"DELETE"|--force\b|--skip-confirmation\b/
+
+const destructiveImportedIdentifierPattern =
+	/^(?:delete|remove|destroy|purge|drop)[A-Z]/
+
+const topLevelFunctionStartPattern =
+	/^(?:export\s+)?(?:(?:async\s+)?function\s*\*?\s*[A-Za-z_$][\w$]*|const\s+[A-Za-z_$][\w$]*\s*=\s*(?:async\s*)?(?:\([^)]*\)|[A-Za-z_$][\w$]*)\s*=>)/
+
+/**
+ * Names imported from other modules that look destructive
+ * (`deleteWorkerScript`, `removeCloudflareQueueConsumers`, ...). Derived from
+ * the import statements so a newly imported delete helper is covered without
+ * touching this checker.
+ */
+function collectDestructiveImportedIdentifiers(source: string): Array<string> {
+	const identifiers = new Set<string>()
+	for (const match of source.matchAll(
+		/import\s*(?:type\s*)?\{([^}]*)\}\s*from\s*['"][^'"]+['"]/g,
+	)) {
+		for (const specifier of (match[1] ?? '').split(',')) {
+			const trimmed = specifier.trim().replace(/^type\s+/, '')
+			if (!trimmed) continue
+			const localName =
+				trimmed
+					.split(/\s+as\s+/)
+					.at(-1)
+					?.trim() ?? ''
+			if (destructiveImportedIdentifierPattern.test(localName)) {
+				identifiers.add(localName)
+			}
+		}
+	}
+	return [...identifiers]
+}
+
+function isDestructiveScriptLine(
+	code: string,
+	destructiveIdentifiers: ReadonlyArray<string>,
+): boolean {
+	if (destructiveScriptLinePattern.test(code)) return true
+	return destructiveIdentifiers.some((identifier) =>
+		new RegExp(`\\b${identifier}\\s*\\(`).test(code),
+	)
+}
+
+function stripLineComment(line: string): string {
+	const trimmed = line.trim()
+	if (trimmed.startsWith('//') || trimmed.startsWith('*')) return ''
+	return line
+}
+
+/**
+ * Every destructive Cloudflare operation in the preview cleanup script must be
+ * preceded, inside the same top-level function, by a call to the preview name
+ * guard. Cleanup runs automatically when a PR closes, so this is the code
+ * review gate that keeps a new delete code path from bypassing the guard.
+ */
+export function checkPreviewCleanupSource(
+	scriptPath: string,
+	source: string,
+): Array<string> {
+	const errors: Array<string> = []
+	const lines = source.split('\n')
+	const guardDefinitionPattern = new RegExp(
+		`function\\s+${previewResourceGuardName}\\s*\\(`,
+	)
+	const guardCallPattern = new RegExp(`\\b${previewResourceGuardName}\\s*\\(`)
+	const destructiveIdentifiers = collectDestructiveImportedIdentifiers(source)
+
+	if (!lines.some((line) => guardDefinitionPattern.test(line))) {
+		errors.push(
+			`${scriptPath}: does not define ${previewResourceGuardName}(); the preview cleanup name guard must live in this script and wrap every delete.`,
+		)
+		return errors
+	}
+
+	let insideImport = false
+	let destructiveSiteCount = 0
+	let guardCallCount = 0
+	let enclosingFunctionStart: number | null = null
+	let guardSeenInEnclosingFunction = false
+
+	for (const [lineIndex, rawLine] of lines.entries()) {
+		if (insideImport) {
+			if (/\bfrom\s*['"][^'"]+['"]/.test(rawLine)) insideImport = false
+			continue
+		}
+		if (/^import\b/.test(rawLine) && !/\bfrom\s*['"][^'"]+['"]/.test(rawLine)) {
+			insideImport = true
+			continue
+		}
+		if (/^import\b/.test(rawLine)) continue
+
+		if (topLevelFunctionStartPattern.test(rawLine)) {
+			enclosingFunctionStart = lineIndex
+			guardSeenInEnclosingFunction = false
+		} else if (/^\}\s*$/.test(rawLine)) {
+			// A bare column-0 closer ends the current top-level function (the
+			// formatter indents nested closers, and a destructured parameter
+			// list continues with `}: {` or `}) {`).
+			enclosingFunctionStart = null
+			guardSeenInEnclosingFunction = false
+		}
+
+		const code = stripLineComment(rawLine)
+		if (!code) continue
+
+		if (guardCallPattern.test(code) && !guardDefinitionPattern.test(code)) {
+			guardCallCount += 1
+			guardSeenInEnclosingFunction = true
+		}
+
+		if (!isDestructiveScriptLine(code, destructiveIdentifiers)) continue
+		destructiveSiteCount += 1
+		if (enclosingFunctionStart === null) {
+			errors.push(
+				`${scriptPath}:${String(lineIndex + 1)} performs a destructive Cloudflare operation outside any function: ${code.trim()}. Wrap it in a function that calls ${previewResourceGuardName}(name, kind) first.`,
+			)
+			continue
+		}
+		if (!guardSeenInEnclosingFunction) {
+			errors.push(
+				`${scriptPath}:${String(lineIndex + 1)} performs a destructive Cloudflare operation without a preceding ${previewResourceGuardName}(name, kind) call in the same function: ${code.trim()}. Every preview cleanup delete must validate the resource name against the preview naming scheme first.`,
+			)
+		}
+	}
+
+	if (destructiveSiteCount === 0) {
+		errors.push(
+			`${scriptPath}: found no destructive Cloudflare operations; the preview cleanup guard check no longer recognizes this script's delete calls and must be updated.`,
+		)
+	}
+	if (guardCallCount === 0) {
+		errors.push(
+			`${scriptPath}: never calls ${previewResourceGuardName}(); every preview cleanup delete must route through the name guard.`,
+		)
+	}
+	return errors
+}
+
 export async function checkDeployGuardrails(
 	baselinePath = defaultDurableObjectBaselinePath,
 	allowlistPath = defaultDurableObjectDeletionAllowlistPath,
 	workflowDirectory = defaultWorkflowDirectory,
+	previewResourcesScriptPath = defaultPreviewResourcesScriptPath,
 ): Promise<DeployGuardrailCheckResult> {
 	const baseline = JSON.parse(
 		await readFile(baselinePath, 'utf8'),
@@ -541,6 +694,13 @@ export async function checkDeployGuardrails(
 		)
 	}
 
+	errors.push(
+		...checkPreviewCleanupSource(
+			previewResourcesScriptPath,
+			await readFile(previewResourcesScriptPath, 'utf8'),
+		),
+	)
+
 	return { ok: errors.length === 0, errors }
 }
 
@@ -555,7 +715,7 @@ export async function main(): Promise<void> {
 		return
 	}
 	console.log(
-		'Deploy guardrails ok: Durable Object history/bindings and workflow deletion policy are protected.',
+		'Deploy guardrails ok: Durable Object history/bindings, workflow deletion policy, and preview cleanup name guard are protected.',
 	)
 }
 

--- a/tools/ci/preview-resources.node.test.ts
+++ b/tools/ci/preview-resources.node.test.ts
@@ -1,0 +1,320 @@
+import * as childProcess from 'node:child_process'
+import { readFile } from 'node:fs/promises'
+import { consoleError } from '#worker/test-support/console-spies.ts'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import {
+	assertPreviewResourceName,
+	buildPreviewResourceNames,
+	cleanupPreviewResources,
+	deletePreviewD1Database,
+	deletePreviewKvNamespace,
+	deletePreviewQueue,
+	deletePreviewR2Bucket,
+	deletePreviewWorkerScript,
+	previewResourceNamePattern,
+	removePreviewQueueConsumers,
+	type PreviewResourceKind,
+} from './preview-resources.ts'
+import { parseJsonc } from './resource-utils.ts'
+
+// Never launch a real wrangler from this suite: a guard regression must show
+// up as an unexpected mock call, not as a Cloudflare API request.
+vi.mock('node:child_process', async (importOriginal) => {
+	const actual = await importOriginal<typeof childProcess>()
+	return {
+		...actual,
+		spawnSync: vi.fn(() => ({ status: 1, stdout: '', stderr: '' })),
+	}
+})
+
+const spawnSync = vi.mocked(childProcess.spawnSync)
+const fetchMock = vi.fn<typeof fetch>()
+
+beforeEach(() => {
+	vi.stubGlobal('fetch', fetchMock)
+	vi.stubEnv('CLOUDFLARE_ACCOUNT_ID', 'test-account')
+	vi.stubEnv('CLOUDFLARE_API_TOKEN', 'test-token')
+})
+
+afterEach(() => {
+	vi.unstubAllGlobals()
+	vi.unstubAllEnvs()
+})
+
+const wranglerConfigPaths = [
+	'packages/worker/wrangler.jsonc',
+	'packages/runtime-worker/wrangler.jsonc',
+	'packages/platform-worker/wrangler.jsonc',
+	'packages/jobs-worker/wrangler.jsonc',
+	'packages/highlight-worker/wrangler.jsonc',
+	'packages/status/wrangler.jsonc',
+]
+
+const resourceNameKeys = new Set([
+	'name',
+	'database_name',
+	'bucket_name',
+	'queue',
+	'dead_letter_queue',
+	'title',
+	'script_name',
+	'service',
+	'from_script',
+])
+
+function collectResourceNames(
+	value: unknown,
+	names = new Set<string>(),
+): Set<string> {
+	if (Array.isArray(value)) {
+		for (const entry of value) collectResourceNames(entry, names)
+		return names
+	}
+	if (!value || typeof value !== 'object') return names
+	for (const [key, child] of Object.entries(value)) {
+		if (resourceNameKeys.has(key) && typeof child === 'string') {
+			names.add(child)
+		}
+		collectResourceNames(child, names)
+	}
+	return names
+}
+
+async function readCommittedResourceNames() {
+	const names = new Set<string>()
+	for (const configPath of wranglerConfigPaths) {
+		const config = parseJsonc<unknown>(await readFile(configPath, 'utf8'))
+		for (const name of collectResourceNames(config)) names.add(name)
+	}
+	return [...names]
+}
+
+// Names production-resources.ts and the deploy workflow derive at deploy time
+// rather than committing to a wrangler config.
+const derivedProductionNames = [
+	'kody',
+	'kody-platform',
+	'kody-runtime',
+	'kody-jobs',
+	'kody-db',
+	'kody-production',
+	'kody-production-backups',
+	'kody-production-d1-backups',
+	'kody-oauth',
+	'kody-bundle-artifacts',
+	'kody-email-delivery-events',
+	'kody-artifacts-lifecycle-events',
+	'kody-nx-cache',
+]
+
+const nonPreviewNames = [
+	'',
+	' ',
+	'kody-pr-',
+	'kody-pr-preview',
+	'kody-pr-42x',
+	'kody-pr-42-',
+	'kody-pr-42--db',
+	'kody-pr-42-DB',
+	'kody-pr-42.db',
+	'kody-branch-',
+	'kody-branch-Feature',
+	'kody-preview',
+	'kody-preview-audit',
+	'kody-preview-jobs',
+	'kody-preview-webhook-dispatch',
+	'kody-test-webhook-dispatch',
+	'pr-42',
+	'other-pr-42',
+	'kody-pr-42\n',
+	'kody\nkody-pr-42',
+]
+
+const acceptedWorkerNames = ['kody-pr-42', 'kody-branch-feature-x-y2']
+
+function guardAccepts(name: string, kind: PreviewResourceKind) {
+	try {
+		assertPreviewResourceName(name, kind)
+		return true
+	} catch {
+		return false
+	}
+}
+
+/** Names the guard lets through; every entry is a guard bug. */
+function namesAcceptedByGuard(names: ReadonlyArray<string>) {
+	return names.filter((name) => guardAccepts(name, 'worker'))
+}
+
+/** Preview names the guard refuses; every entry would break cleanup. */
+function namesRejectedByGuard(
+	entries: ReadonlyArray<readonly [string, PreviewResourceKind]>,
+) {
+	return entries
+		.filter(([name, kind]) => !guardAccepts(name, kind))
+		.map(([name]) => name)
+}
+
+describe('assertPreviewResourceName', () => {
+	test('rejects every committed production and shared resource name', async () => {
+		const committed = await readCommittedResourceNames()
+		expect(committed.length).toBeGreaterThan(20)
+		expect(committed).toContain('kody')
+		expect(committed).toContain('kody-audit')
+		expect(committed).toContain('kody-community-assets')
+		expect(committed).toContain('kody-webhook-dispatch')
+		expect(committed).toContain('kody-scheduled-dispatch')
+		expect(
+			namesAcceptedByGuard([...committed, ...derivedProductionNames]),
+		).toEqual([])
+		expect(() => assertPreviewResourceName('kody', 'worker')).toThrow(
+			'Refusing to delete worker "kody": it does not match the preview resource naming scheme',
+		)
+	})
+
+	test('rejects names outside the kody-pr-<number> / kody-branch-<slug> scheme', () => {
+		expect(
+			nonPreviewNames.filter((name) => previewResourceNamePattern.test(name)),
+		).toEqual([])
+		expect(namesAcceptedByGuard(nonPreviewNames)).toEqual([])
+		expect(() => assertPreviewResourceName('kody-pr-preview', 'd1')).toThrow(
+			'Refusing to delete d1 "kody-pr-preview"',
+		)
+	})
+
+	test('accepts every derived preview name kind for PR and branch previews', () => {
+		for (const workerName of acceptedWorkerNames) {
+			const derived = buildPreviewResourceNames(workerName)
+			const accepted: Array<[string, PreviewResourceKind]> = [
+				[workerName, 'worker'],
+				[`${workerName}-runtime`, 'worker'],
+				[`${workerName}-platform`, 'worker'],
+				[`${workerName}-jobs`, 'worker'],
+				[`${workerName}-highlight`, 'worker'],
+				[`${workerName}-mock-cloudflare`, 'worker'],
+				[derived.d1DatabaseName, 'd1'],
+				[derived.auditD1DatabaseName, 'd1'],
+				[derived.oauthKvTitle, 'kv'],
+				[derived.bundleArtifactsKvTitle, 'kv'],
+				[derived.communityAssetsBucketName, 'r2'],
+				[derived.emailBlobsBucketName, 'r2'],
+				[derived.repoSessionBlobsBucketName, 'r2'],
+				[derived.webhookDispatchQueueName, 'queue'],
+				[derived.webhookDispatchDeadLetterQueueName, 'queue'],
+			]
+			expect(namesRejectedByGuard(accepted)).toEqual([])
+		}
+		expect(buildPreviewResourceNames('kody-pr-42')).toEqual({
+			d1DatabaseName: 'kody-pr-42-db',
+			auditD1DatabaseName: 'kody-pr-42-audit-db',
+			oauthKvTitle: 'kody-pr-42-oauth-kv',
+			bundleArtifactsKvTitle: 'kody-pr-42-bundle-artifacts-kv',
+			communityAssetsBucketName: 'kody-pr-42-community-assets',
+			emailBlobsBucketName: 'kody-pr-42-email-blobs',
+			repoSessionBlobsBucketName: 'kody-pr-42-repo-session-blobs',
+			webhookDispatchQueueName: 'kody-pr-42-webhook-dispatch',
+			webhookDispatchDeadLetterQueueName: 'kody-pr-42-webhook-dispatch-dlq',
+		})
+	})
+
+	test('accepts names truncated to the 63-character Cloudflare limit', () => {
+		// The workflow caps the slug at 32 characters; the longest suffix
+		// (-bundle-artifacts-kv) pushes a max-length branch name past 63.
+		const workerName = `kody-branch-${'a1'.repeat(15)}-z`
+		expect(workerName).toHaveLength(44)
+		const derived = buildPreviewResourceNames(workerName)
+		expect(derived.bundleArtifactsKvTitle.length).toBeLessThanOrEqual(63)
+		expect(derived.bundleArtifactsKvTitle).not.toContain(workerName)
+		expect(derived.bundleArtifactsKvTitle).toMatch(
+			/^kody-branch-[a-z0-9]+-bundle-artifacts-kv$/,
+		)
+		expect(
+			namesRejectedByGuard(
+				Object.values(derived).map((name) => [name, 'kv'] as const),
+			),
+		).toEqual([])
+	})
+})
+
+describe('preview cleanup delete path', () => {
+	const queueClient = {
+		accountId: 'test-account',
+		apiToken: 'test-token',
+		dryRun: false,
+	}
+
+	test('cleanupPreviewResources refuses a production worker name before any wrangler or REST call', async () => {
+		for (const workerName of ['kody', 'kody-platform', 'kody-runtime', '']) {
+			await expect(
+				cleanupPreviewResources({ workerName, dryRun: false }),
+			).rejects.toThrow('does not match the preview resource naming scheme')
+		}
+		expect(spawnSync).not.toHaveBeenCalled()
+		expect(fetchMock).not.toHaveBeenCalled()
+	})
+
+	test('cleanupPreviewResources refuses a production worker name even in dry-run', async () => {
+		await expect(
+			cleanupPreviewResources({ workerName: 'kody', dryRun: true }),
+		).rejects.toThrow('Refusing to delete queue "kody-webhook-dispatch"')
+		expect(consoleError).not.toHaveBeenCalled()
+	})
+
+	test('each guarded delete throws with the offending name and kind before reaching Cloudflare', async () => {
+		expect(() =>
+			deletePreviewWorkerScript({ name: 'kody-platform', dryRun: false }),
+		).toThrow('Refusing to delete worker "kody-platform"')
+		expect(() =>
+			deletePreviewD1Database({ name: 'kody', dryRun: false }),
+		).toThrow('Refusing to delete d1 "kody"')
+		expect(() =>
+			deletePreviewD1Database({ name: 'kody-audit', dryRun: false }),
+		).toThrow('Refusing to delete d1 "kody-audit"')
+		expect(() =>
+			deletePreviewKvNamespace({ title: 'kody-oauth', dryRun: false }),
+		).toThrow('Refusing to delete kv "kody-oauth"')
+		expect(() =>
+			deletePreviewR2Bucket({ name: 'kody-community-assets', dryRun: false }),
+		).toThrow('Refusing to delete r2 "kody-community-assets"')
+		await expect(
+			deletePreviewQueue({ ...queueClient, name: 'kody-webhook-dispatch' }),
+		).rejects.toThrow('Refusing to delete queue "kody-webhook-dispatch"')
+		await expect(
+			removePreviewQueueConsumers({
+				...queueClient,
+				name: 'kody-email-delivery',
+			}),
+		).rejects.toThrow('Refusing to delete queue "kody-email-delivery"')
+		expect(spawnSync).not.toHaveBeenCalled()
+		expect(fetchMock).not.toHaveBeenCalled()
+	})
+
+	test('dry-run cleanup of a PR preview walks every resource without touching Cloudflare', async () => {
+		consoleError.mockImplementation(() => {})
+		await cleanupPreviewResources({ workerName: 'kody-pr-42', dryRun: true })
+		const logged = consoleError.mock.calls.map(([message]) => String(message))
+		expect(logged).toEqual(
+			expect.arrayContaining([
+				'[dry-run] remove Queue consumers: kody-pr-42-webhook-dispatch',
+				'[dry-run] remove Queue consumers: kody-pr-42-webhook-dispatch-dlq',
+				'[dry-run] delete Worker script: kody-pr-42-runtime',
+				'[dry-run] delete Worker script: kody-pr-42-platform',
+				'[dry-run] delete Worker script: kody-pr-42',
+				'[dry-run] delete Worker script: kody-pr-42-jobs',
+				'[dry-run] delete Worker script: kody-pr-42-highlight',
+				'[dry-run] delete Worker script: kody-pr-42-mock-cloudflare',
+				'[dry-run] delete Queue: kody-pr-42-webhook-dispatch',
+				'[dry-run] delete Queue: kody-pr-42-webhook-dispatch-dlq',
+				'[dry-run] delete R2 bucket: kody-pr-42-community-assets',
+				'[dry-run] delete R2 bucket: kody-pr-42-email-blobs',
+				'[dry-run] delete R2 bucket: kody-pr-42-repo-session-blobs',
+				'[dry-run] delete KV namespace: kody-pr-42-bundle-artifacts-kv',
+				'[dry-run] delete KV namespace: kody-pr-42-oauth-kv',
+				'[dry-run] delete D1 database: kody-pr-42-audit-db',
+				'[dry-run] delete D1 database: kody-pr-42-db',
+			]),
+		)
+		expect(spawnSync).not.toHaveBeenCalled()
+		expect(fetchMock).not.toHaveBeenCalled()
+	})
+})

--- a/tools/ci/preview-resources.ts
+++ b/tools/ci/preview-resources.ts
@@ -16,8 +16,43 @@ import {
 	truncateWithSuffix,
 	writeGeneratedWranglerConfig,
 } from './resource-utils.ts'
+import { isExecutedDirectly } from '../node-runtime.ts'
 
 type Command = 'ensure' | 'cleanup'
+
+export type PreviewResourceKind = 'worker' | 'd1' | 'kv' | 'r2' | 'queue'
+
+/**
+ * Every preview resource name derives from the worker name the preview
+ * workflow resolves (`kody-pr-<number>` for pull requests, `kody-branch-<slug>`
+ * for manual branch previews) plus a lowercase kebab suffix: `-runtime`,
+ * `-platform`, `-jobs`, `-highlight`, `-mock-<service>`, `-db`, `-audit-db`,
+ * `-oauth-kv`, `-bundle-artifacts-kv`, `-community-assets`, `-email-blobs`,
+ * `-repo-session-blobs`, `-webhook-dispatch`, `-webhook-dispatch-dlq`
+ * (`truncateWithSuffix` may shorten the base but keeps this shape). Production
+ * names (`kody`, `kody-platform`, `kody-runtime`, `kody-jobs`, `kody-audit`,
+ * `kody-oauth`, `kody-webhook-dispatch`, ...) and the shared preview-env names
+ * (`kody-preview*`) never carry a `-pr-<number>` or `-branch-<slug>` segment.
+ */
+export const previewResourceNamePattern =
+	/^kody-(?:pr-\d+|branch-[a-z0-9]+)(?:-[a-z0-9]+)*$/
+
+/**
+ * Hard guard for every destructive operation in this script. Cleanup runs
+ * automatically when a PR closes, so a bug or a mis-set env var (for example
+ * an empty PR number) must never be able to compute a production resource
+ * name and delete it. Call this immediately before each delete.
+ */
+export function assertPreviewResourceName(
+	name: string,
+	kind: PreviewResourceKind,
+) {
+	if (!previewResourceNamePattern.test(name)) {
+		throw new Error(
+			`Refusing to delete ${kind} "${name}": it does not match the preview resource naming scheme ${String(previewResourceNamePattern)}. Preview cleanup only deletes kody-pr-<number>* and kody-branch-<slug>* resources.`,
+		)
+	}
+}
 
 type CliOptions = {
 	workerName: string
@@ -93,7 +128,7 @@ function parseArgs(argv: Array<string>): {
 	return { command, options }
 }
 
-function buildPreviewResourceNames(workerName: string) {
+export function buildPreviewResourceNames(workerName: string) {
 	const maxLen = 63
 	const d1Suffix = '-db'
 	const auditD1Suffix = '-audit-db'
@@ -194,7 +229,14 @@ function ensureD1Database({
 	return { name, id: created.uuid }
 }
 
-function deleteD1Database({ name, dryRun }: { name: string; dryRun: boolean }) {
+export function deletePreviewD1Database({
+	name,
+	dryRun,
+}: {
+	name: string
+	dryRun: boolean
+}) {
+	assertPreviewResourceName(name, 'd1')
 	if (dryRun) {
 		console.error(`[dry-run] delete D1 database: ${name}`)
 		return
@@ -250,13 +292,14 @@ function ensureKvNamespace({
 	return { title, id: created.id }
 }
 
-function deleteKvNamespace({
+export function deletePreviewKvNamespace({
 	title,
 	dryRun,
 }: {
 	title: string
 	dryRun: boolean
 }) {
+	assertPreviewResourceName(title, 'kv')
 	if (dryRun) {
 		console.error(`[dry-run] delete KV namespace: ${title}`)
 		return
@@ -283,6 +326,40 @@ function deleteKvNamespace({
 		fail(`Failed to delete KV namespace: ${title}`)
 	}
 	console.error(`Deleted KV namespace: ${title} (${existing.id})`)
+}
+
+export function deletePreviewWorkerScript({
+	name,
+	dryRun,
+}: {
+	name: string
+	dryRun: boolean
+}) {
+	assertPreviewResourceName(name, 'worker')
+	deleteWorkerScript({ name, dryRun })
+}
+
+export function deletePreviewR2Bucket({
+	name,
+	dryRun,
+}: {
+	name: string
+	dryRun: boolean
+}) {
+	assertPreviewResourceName(name, 'r2')
+	deleteR2Bucket({ name, dryRun })
+}
+
+type PreviewQueueInput = Parameters<typeof deleteCloudflareQueue>[0]
+
+export async function removePreviewQueueConsumers(input: PreviewQueueInput) {
+	assertPreviewResourceName(input.name, 'queue')
+	await removeCloudflareQueueConsumers(input)
+}
+
+export async function deletePreviewQueue(input: PreviewQueueInput) {
+	assertPreviewResourceName(input.name, 'queue')
+	await deleteCloudflareQueue(input)
 }
 
 async function ensurePreviewResources(options: CliOptions) {
@@ -433,20 +510,22 @@ function listMockServerNames() {
 function deletePreviewWorkers(workerName: string, dryRun: boolean) {
 	// Runtime and platform bind each other's Durable Object classes, so
 	// delete those scripts before the origin worker.
-	deleteWorkerScript({ name: `${workerName}-runtime`, dryRun })
-	deleteWorkerScript({ name: `${workerName}-platform`, dryRun })
-	deleteWorkerScript({ name: workerName, dryRun })
-	deleteWorkerScript({ name: `${workerName}-jobs`, dryRun })
-	deleteWorkerScript({ name: `${workerName}-highlight`, dryRun })
+	deletePreviewWorkerScript({ name: `${workerName}-runtime`, dryRun })
+	deletePreviewWorkerScript({ name: `${workerName}-platform`, dryRun })
+	deletePreviewWorkerScript({ name: workerName, dryRun })
+	deletePreviewWorkerScript({ name: `${workerName}-jobs`, dryRun })
+	deletePreviewWorkerScript({ name: `${workerName}-highlight`, dryRun })
 	for (const service of listMockServerNames()) {
-		deleteWorkerScript({
+		deletePreviewWorkerScript({
 			name: `${workerName}-mock-${service}`,
 			dryRun,
 		})
 	}
 }
 
-async function cleanupPreviewResources(options: CliOptions) {
+export type PreviewCleanupOptions = Pick<CliOptions, 'workerName' | 'dryRun'>
+
+export async function cleanupPreviewResources(options: PreviewCleanupOptions) {
 	const {
 		d1DatabaseName,
 		auditD1DatabaseName,
@@ -474,30 +553,42 @@ async function cleanupPreviewResources(options: CliOptions) {
 	// registered as a queue consumer (code 10064), and a queue cannot be
 	// deleted while a Worker still binds it as a producer (400 "still
 	// referenced by a binding in a Worker"). So: consumers → Workers → queues.
-	await removeCloudflareQueueConsumers({
+	await removePreviewQueueConsumers({
 		...queueClient,
 		name: webhookDispatchQueueName,
 	})
-	await removeCloudflareQueueConsumers({
+	await removePreviewQueueConsumers({
 		...queueClient,
 		name: webhookDispatchDeadLetterQueueName,
 	})
 	deletePreviewWorkers(options.workerName, options.dryRun)
-	await deleteCloudflareQueue({
+	await deletePreviewQueue({
 		...queueClient,
 		name: webhookDispatchQueueName,
 	})
-	await deleteCloudflareQueue({
+	await deletePreviewQueue({
 		...queueClient,
 		name: webhookDispatchDeadLetterQueueName,
 	})
-	deleteR2Bucket({ name: communityAssetsBucketName, dryRun: options.dryRun })
-	deleteR2Bucket({ name: emailBlobsBucketName, dryRun: options.dryRun })
-	deleteR2Bucket({ name: repoSessionBlobsBucketName, dryRun: options.dryRun })
-	deleteKvNamespace({ title: bundleArtifactsKvTitle, dryRun: options.dryRun })
-	deleteKvNamespace({ title: oauthKvTitle, dryRun: options.dryRun })
-	deleteD1Database({ name: auditD1DatabaseName, dryRun: options.dryRun })
-	deleteD1Database({ name: d1DatabaseName, dryRun: options.dryRun })
+	deletePreviewR2Bucket({
+		name: communityAssetsBucketName,
+		dryRun: options.dryRun,
+	})
+	deletePreviewR2Bucket({ name: emailBlobsBucketName, dryRun: options.dryRun })
+	deletePreviewR2Bucket({
+		name: repoSessionBlobsBucketName,
+		dryRun: options.dryRun,
+	})
+	deletePreviewKvNamespace({
+		title: bundleArtifactsKvTitle,
+		dryRun: options.dryRun,
+	})
+	deletePreviewKvNamespace({ title: oauthKvTitle, dryRun: options.dryRun })
+	deletePreviewD1Database({
+		name: auditD1DatabaseName,
+		dryRun: options.dryRun,
+	})
+	deletePreviewD1Database({ name: d1DatabaseName, dryRun: options.dryRun })
 }
 
 async function main() {
@@ -517,4 +608,6 @@ async function main() {
 	await cleanupPreviewResources(options)
 }
 
-await main()
+if (isExecutedDirectly(import.meta.url)) {
+	await main()
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`tools/ci/preview-resources.ts cleanup` runs automatically when a PR closes and deletes Workers, D1, KV, R2, and Queues by *computed* name. Nothing prevented a bug or a mis-set env var (e.g. an empty PR number) from computing a production name and deleting it — `tools/check-deploy-guardrails.ts` only scanned workflow YAML.

This adds one hard guard, `assertPreviewResourceName(name, kind)`, called immediately before every destructive operation in that script, plus a static guardrail check that fails CI if any destructive call site is not preceded by the guard.

## Naming scheme (derived from `preview.yml` + `buildPreviewResourceNames`)

```
^kody-(?:pr-\d+|branch-[a-z0-9]+)(?:-[a-z0-9]+)*$
```

- Worker base: `kody-pr-<number>` (pull_request / dispatch target=pr) or `kody-branch-<slug>` (dispatch target=branch; slug is lower-kebab, ≤32 chars).
- Derived: `-runtime`, `-platform`, `-jobs`, `-highlight`, `-mock-<service>`, `-db`, `-audit-db`, `-oauth-kv`, `-bundle-artifacts-kv`, `-community-assets`, `-email-blobs`, `-repo-session-blobs`, `-webhook-dispatch`, `-webhook-dispatch-dlq` (and `truncateWithSuffix` 63-char shortening keeps the shape).
- Rejected: `kody`, `kody-platform`, `kody-runtime`, `kody-jobs`, `kody-db`, `kody-audit`, `kody-oauth`, `kody-bundle-artifacts`, `kody-*-dispatch`, `kody-email-delivery`, `kody-scheduled-dispatch`, `kody-production*`, all `kody-preview*` / `kody-test*` shared names, `kody-pr-preview` (the empty-slug fallback), and anything else.

## Call sites covered (all in `tools/ci/preview-resources.ts`)

| Destructive primitive | Guarded wrapper | Kind |
| --- | --- | --- |
| `wrangler d1 delete <name> --skip-confirmation` | `deletePreviewD1Database` | `d1` |
| `wrangler kv namespace delete --namespace-id … --skip-confirmation` | `deletePreviewKvNamespace` | `kv` |
| `deleteWorkerScript` (`wrangler delete <name> --force`) ×6 names incl. mocks | `deletePreviewWorkerScript` | `worker` |
| `deleteR2Bucket` (`wrangler r2 bucket delete`) ×3 | `deletePreviewR2Bucket` | `r2` |
| `removeCloudflareQueueConsumers` (REST `DELETE` consumers) ×2 | `removePreviewQueueConsumers` | `queue` |
| `deleteCloudflareQueue` (REST `DELETE` queue) ×2 | `deletePreviewQueue` | `queue` |

`main()` is now gated behind `isExecutedDirectly` so the module is importable in tests; the CLI invocation in `preview.yml` is unchanged.

## Guardrail check

`checkPreviewCleanupSource` in `tools/check-deploy-guardrails.ts` treats a line as destructive when it calls an imported `delete*/remove*/destroy*/purge*/drop*` identifier (derived from the file's imports), or contains `'delete'`, `'DELETE'`, `--force`, or `--skip-confirmation`. Each such line must be preceded by an `assertPreviewResourceName(` call inside the same top-level function. It fails closed when the guard is not defined, never called, or when zero destructive sites are recognised.

## Tests

- `tools/ci/preview-resources.node.test.ts` (new): every resource name in the six wrangler configs + derived production names is rejected; every preview name kind is accepted (PR and branch, incl. 63-char truncation); `cleanupPreviewResources` and each guarded wrapper throw for production names **before** `spawnSync` or `fetch` is invoked (both mocked, asserted not called); dry-run of `kody-pr-42` walks all 17 operations.
- `tools/check-deploy-guardrails.node.test.ts`: synthetic guarded/unguarded scripts for each detection path, fail-closed cases, and a mutation test proving that removing any single guard call from the committed script is caught.

## Validation

`npm run typecheck`, `npm run lint`, `npm run deploy-guardrails:check`, `npm run format:check`, `npm run slop-ratchet:check`, `npm run docs:check-temporal` pass; `npx vitest run --project node-unit tools/ci tools/check-deploy-guardrails` → 16 files, 88 tests passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b0f6a92a-81cd-4157-8b60-188c83ca84c0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b0f6a92a-81cd-4157-8b60-188c83ca84c0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Added safeguards to preview cleanup operations to prevent deletion of production or shared Cloudflare resources.
  - Preview cleanup now targets only resources matching approved pull request or branch naming patterns.
  - Validation covers Workers, D1, KV, R2, Queues, and queue consumers.

- **Documentation**
  - Updated preview deployment setup guidance to explain cleanup safeguards and validation checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->