### PR TITLE
Enable Stripe automatic tax, tax-ID collection, and promotion codes on checkout

### DIFF
--- a/docs/contributing/architecture/entitlements.md
+++ b/docs/contributing/architecture/entitlements.md
@@ -761,13 +761,18 @@ Checkout sessions are created server-side for authenticated users via
 `POST /account/billing/checkout.json` (Stripe Checkout Session, JSON body
 `{ plan: "standard" | "pro", interval?: "month" | "year" }` defaulting to
 `month`, `mode=subscription`, with a signed `client_reference_id` and
-`metadata.kody_stable_user_id`). There is no public Payment Link path — checkout
-requires a signed-in session so unauthenticated card-testing is not possible.
-`GET /account/billing/success` verifies `client_reference_id` before linking
-`users.stripe_customer_id`, then refreshes `users.stripe_plan` and renders a
-thank-you page (Discord invite; connect-your-agent when `needsOnboarding`). A
-successful `stripe_plan` write also best-effort re-syncs official Kody Discord
-Standard/Pro roles when the user has a Discord social-login connection (see
+`metadata.kody_stable_user_id`). Sessions enable Stripe automatic tax
+(`automatic_tax[enabled]`; Stripe Tax is active on the account and computes 0
+until a registration exists), tax-ID collection for business customers, and
+promotion codes; when an existing `customer` is passed, `customer_update`
+address/name are `auto` so Checkout can store what tax needs. There is no public
+Payment Link path — checkout requires a signed-in session so unauthenticated
+card-testing is not possible. `GET /account/billing/success` verifies
+`client_reference_id` before linking `users.stripe_customer_id`, then refreshes
+`users.stripe_plan` and renders a thank-you page (Discord invite;
+connect-your-agent when `needsOnboarding`). A successful `stripe_plan` write
+also best-effort re-syncs official Kody Discord Standard/Pro roles when the user
+has a Discord social-login connection (see
 [`social-login.md`](../social-login.md)). `GET /account/billing/portal` opens
 the Stripe customer portal for linked customers.
 

--- a/packages/worker/client/routes/terms.tsx
+++ b/packages/worker/client/routes/terms.tsx
@@ -131,8 +131,11 @@ export function TermsRoute(_handle: Handle) {
 					<a href="mailto:support@kody.codes" mix={css(mutedLinkCss)}>
 						support@kody.codes
 					</a>
-					. Refund requests are considered case by case. Taxes and payment
-					processor terms may also apply.
+					. Refund requests are considered case by case. Deleting your account
+					cancels any subscription immediately; unused time in the current
+					billing period is not refunded automatically. Where required by law we
+					collect sales tax or VAT at checkout, and business customers can enter
+					a tax ID there. Payment processor terms may also apply.
 				</p>
 			</section>
 

--- a/packages/worker/src/billing/stripe-client.node.test.ts
+++ b/packages/worker/src/billing/stripe-client.node.test.ts
@@ -102,6 +102,11 @@ test('stripe client request contracts for checkout, subscriptions, and portal', 
 		)
 		expect(body.get('customer_email')).toBe('user@example.com')
 		expect(body.get('customer')).toBeNull()
+		expect(body.get('automatic_tax[enabled]')).toBe('true')
+		expect(body.get('tax_id_collection[enabled]')).toBe('true')
+		expect(body.get('allow_promotion_codes')).toBe('true')
+		expect(body.get('customer_update[address]')).toBeNull()
+		expect(body.get('customer_update[name]')).toBeNull()
 	} finally {
 		vi.unstubAllGlobals()
 	}
@@ -132,6 +137,9 @@ test('stripe client request contracts for checkout, subscriptions, and portal', 
 		)
 		expect(body.get('customer')).toBe('cus_existing')
 		expect(body.get('customer_email')).toBeNull()
+		expect(body.get('customer_update[address]')).toBe('auto')
+		expect(body.get('customer_update[name]')).toBe('auto')
+		expect(body.get('automatic_tax[enabled]')).toBe('true')
 	} finally {
 		vi.unstubAllGlobals()
 	}

--- a/packages/worker/src/billing/stripe-client.ts
+++ b/packages/worker/src/billing/stripe-client.ts
@@ -248,10 +248,21 @@ export async function createCheckoutSession(
 		client_reference_id: clientReferenceId,
 		success_url: successUrl,
 		cancel_url: cancelUrl,
+		// Stripe Tax is active on the account; with no registrations it computes
+		// 0 and tracks thresholds, and once a registration exists Checkout starts
+		// collecting without a code change. Tax IDs let business customers apply
+		// reverse charge. Promotion codes cost nothing to allow.
+		'automatic_tax[enabled]': 'true',
+		'tax_id_collection[enabled]': 'true',
+		allow_promotion_codes: 'true',
 	}
 	// Stripe accepts either `customer` or `customer_email`, never both.
 	if (customerId) {
 		form.customer = customerId
+		// Automatic tax and tax-id collection on an existing customer require
+		// Checkout to be allowed to save the address and name it collects.
+		form['customer_update[address]'] = 'auto'
+		form['customer_update[name]'] = 'auto'
 	} else if (customerEmail) {
 		form.customer_email = customerEmail
 	}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Launch audit item 4.21: Checkout Sessions had no `automatic_tax`, no `tax_id_collection`, and no `allow_promotion_codes`, and the ToS did not say what happens to a subscription on account deletion.

Verified against the live Stripe account before changing anything: Stripe Tax is **active** (`/v1/tax/settings` → `status: active`, default tax code `txcd_10000000`, `tax_behavior: inferred_by_currency`, head office US) with **zero registrations**. So enabling automatic tax computes 0 everywhere today and starts collecting automatically once a registration is added; retrofitting tax onto existing subscriptions later is the painful path. Existing prices have `tax_behavior: unspecified`, which is fine because the account default resolves it.

## What

`packages/worker/src/billing/stripe-client.ts` `createCheckoutSession`:
- `automatic_tax[enabled]=true`
- `tax_id_collection[enabled]=true` (business customers can enter a VAT/GST ID for reverse charge)
- `allow_promotion_codes=true`
- When an existing `customer` is passed: `customer_update[address]=auto` and `customer_update[name]=auto`, which Stripe requires so Checkout can persist the address/name that tax and tax-ID collection need.

Account deletion still cancels immediately (deliberate; a deleted account cannot receive service). The ToS "Plans, billing, and refunds" section now says deletion cancels immediately and unused time is not refunded automatically, and that tax is collected where required with a tax-ID field at checkout. `docs/contributing/architecture/entitlements.md` documents the session flags.

## Tests

`stripe-client.node.test.ts` asserts the three flags on every session, `customer_update` present only when `customer` is passed, and absent for the `customer_email` path. Typecheck, lint, docs temporal check, and the billing/terms suites pass.

## Operator follow-up

None required for launch. When Kody crosses a nexus threshold, add the registration in Stripe Dashboard → Tax → Registrations; no code change needed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b0f6a92a-81cd-4157-8b60-188c83ca84c0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b0f6a92a-81cd-4157-8b60-188c83ca84c0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Checkout now supports automatic tax calculation and tax-ID collection for eligible business customers.
  - Customers can apply promotion codes during checkout.
  - For existing customers, checkout can update saved billing names and addresses when needed for tax purposes.

- **Documentation**
  - Updated billing documentation to reflect the expanded checkout options.
  - Clarified that deleting an account cancels subscriptions immediately without automatically refunding unused time.
  - Clarified sales tax and VAT collection requirements at checkout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->