### PR TITLE
Deliver user-inbox plus-tags even when the tag is a reserved system local

### DIFF
--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -291,11 +291,13 @@ The schema is defined by migrations in `packages/worker/migrations/`:
   UserMeter `storage_bytes_state` (schema v4) drives storage-byte enforcement;
   see [Entitlements](./entitlements.md#usermeter). Inbound email routing does
   not reverse-resolve stable ids — it uses the indexed username lookup
-  (`findPublicUserIdentityByUsername`). Contextless paths resolve stable ids
-  with one indexed point read on `users.stable_user_id` (for example
-  `findUserAccountByStableUserId`). Person accounts that stay unverified for
-  seven days (`email_verified_at` is null, no `oauth_connections` row) are
-  deleted by the hourly `unverified_account_purge` lane through the
+  (`findPublicUserIdentityByUsername`) on the RFC 5233 base local
+  (`resolveInboundMailboxRoute`). Plus-tags on user inbox hosts are aliases for
+  that username, including tags that spell a reserved system local. Contextless
+  paths resolve stable ids with one indexed point read on `users.stable_user_id`
+  (for example `findUserAccountByStableUserId`). Person accounts that stay
+  unverified for seven days (`email_verified_at` is null, no `oauth_connections`
+  row) are deleted by the hourly `unverified_account_purge` lane through the
   inventory-driven account-deletion path, which releases the username,
   `{username}.kody.run` subdomain, `{username}@` mail local, and
   `stable_user_id`. Each candidate is claimed with an atomic `UPDATE` that

--- a/docs/contributing/security.md
+++ b/docs/contributing/security.md
@@ -218,7 +218,11 @@ cannot become package-app subdomains or inbound mailboxes. Operators add or
 unreserve names at runtime through `platform-settings:v1:reserved-usernames`
 without a deploy; system-email locals and `kody`-prefixed built-in names stay
 permanently locked. Signup, username change, admin user creation, and social
-username generation consult the effective set (built-in plus KV).
+username generation consult the effective set (built-in plus KV). Inbound
+mailbox routing (`resolveInboundMailboxRoute`) uses only the RFC 5233 base local
+with `isPermanentlyReservedUsername` / `isSystemEmailLocal` — never the plus-tag
+and never the claim-denylist substring matcher — so `alice+kody@inbox…` is user
+mail for `alice`.
 
 A new claim fails when the case-insensitive (lowercase-trimmed) username is an
 exact reserved token or when the hyphen/underscore-stripped form equals a

--- a/docs/use/email-primitives.md
+++ b/docs/use/email-primitives.md
@@ -18,9 +18,15 @@ platform-assigned sender address.
   `{username}+{tag}@<platform domain>` routes to `{username}`'s inbox (and
   `support+{tag}@<apex>` to the corresponding system inbox). The base local part
   — everything before the first `+` — is what routes, so a tag can never bypass
-  the reserved or unknown-username checks. The full tagged address is preserved
-  in the stored message's `to_addresses`, so a package subscribing to
-  `email.message.received` can dispatch on the tag (for example, only handle
+  the reserved or unknown-username checks. Plus-tags on the user inbox host
+  (`inbox.kody.codes`, `inbox.heykody.*`, and any `getAcceptedUserEmailDomains`
+  host) are user-inbox aliases, not reserved system locals: `you+kody@inbox…`,
+  `you+support@inbox…`, and `you+admin@inbox…` deliver to `you` the same way
+  `you+patch@inbox…` does. `kody@inbox…` with no plus (the username itself is
+  the reserved local) still rejects. System inboxes stay on the apex only
+  (`kody@kody.codes` and the other `systemEmailLocals`). The full tagged address
+  is preserved in the stored message's `to_addresses`, so a package subscribing
+  to `email.message.received` can dispatch on the tag (for example, only handle
   mail addressed to `{username}+invoices@...`).
 - Mail to unknown usernames is rejected, and the app's apex domain is never a
   user inbox: user mail lives exclusively on the configured platform domain (the

--- a/packages/worker/src/email/address.node.test.ts
+++ b/packages/worker/src/email/address.node.test.ts
@@ -28,6 +28,13 @@ test('email address helpers normalize mailbox strings', () => {
 		base: 'kentcdodds',
 		subaddress: 'billing',
 	})
+	expect(normalizeEmailAddress('kentcdodds+kody@inbox.kody.codes')).toBe(
+		'kentcdodds+kody@inbox.kody.codes',
+	)
+	expect(splitEmailLocalPart('kentcdodds+kody')).toEqual({
+		base: 'kentcdodds',
+		subaddress: 'kody',
+	})
 	expect(splitEmailLocalPart('kentcdodds+a+b')).toEqual({
 		base: 'kentcdodds',
 		subaddress: 'a+b',

--- a/packages/worker/src/email/inbound-mailbox-route.node.test.ts
+++ b/packages/worker/src/email/inbound-mailbox-route.node.test.ts
@@ -1,0 +1,104 @@
+import { expect, test } from 'vitest'
+import {
+	builtInReservedUsernameList,
+	isPermanentlyReservedUsername,
+	usernameCollidesWithReservedNames,
+} from '#worker/identity/reserved-usernames.ts'
+import { normalizeEmailAddress, splitEmailLocalPart } from './address.ts'
+import { resolveInboundMailboxRoute } from './inbound-mailbox-route.ts'
+import { systemEmailLocals } from './system-email.ts'
+
+const userDomain = 'inbox.kody.codes'
+const heykodyUserDomain = 'inbox.heykody.app'
+const systemDomain = 'kody.codes'
+
+function routeFor(envelopeTo: string) {
+	return resolveInboundMailboxRoute({
+		envelopeTo,
+		acceptedUserDomains: [userDomain, heykodyUserDomain],
+		acceptedSystemDomains: [systemDomain],
+		systemDomain,
+	})
+}
+
+test('plus tags on user inbox hosts are never reserved system locals', () => {
+	expect(normalizeEmailAddress('kentcdodds+kody@inbox.kody.codes')).toBe(
+		'kentcdodds+kody@inbox.kody.codes',
+	)
+	expect(normalizeEmailAddress('Kent <alice+Kody@Inbox.Kody.CODES>')).toBe(
+		'alice+kody@inbox.kody.codes',
+	)
+	expect(splitEmailLocalPart('kentcdodds+kody')).toEqual({
+		base: 'kentcdodds',
+		subaddress: 'kody',
+	})
+	expect(splitEmailLocalPart('alice+patch')).toEqual({
+		base: 'alice',
+		subaddress: 'patch',
+	})
+
+	// The username-claim denylist substring-matches brand/system roots, so
+	// the full tagged local looks reserved. Inbound routing must not use
+	// that matcher on the tagged local or the plus-tag.
+	expect(
+		usernameCollidesWithReservedNames(
+			'alice+kody',
+			builtInReservedUsernameList,
+		),
+	).toBe(true)
+	expect(isPermanentlyReservedUsername('alice')).toBe(false)
+	expect(isPermanentlyReservedUsername('alice+kody')).toBe(false)
+
+	expect(routeFor('alice+kody@inbox.kody.codes')).toEqual({
+		kind: 'user',
+		recipient: 'alice+kody@inbox.kody.codes',
+		username: 'alice',
+	})
+	expect(routeFor('alice+patch@inbox.kody.codes')).toEqual({
+		kind: 'user',
+		recipient: 'alice+patch@inbox.kody.codes',
+		username: 'alice',
+	})
+	expect(routeFor('Alice+Support@inbox.heykody.app')).toEqual({
+		kind: 'user',
+		recipient: 'alice+support@inbox.heykody.app',
+		username: 'alice',
+	})
+
+	for (const tag of systemEmailLocals) {
+		expect(routeFor(`alice+${tag}@${userDomain}`)).toEqual({
+			kind: 'user',
+			recipient: `alice+${tag}@${userDomain}`,
+			username: 'alice',
+		})
+	}
+
+	expect(routeFor(`kody@${systemDomain}`)).toEqual({
+		kind: 'system',
+		recipient: `kody@${systemDomain}`,
+		localBase: 'kody',
+		systemDomain,
+	})
+	expect(routeFor(`support+ticket-123@${systemDomain}`)).toEqual({
+		kind: 'system',
+		recipient: `support+ticket-123@${systemDomain}`,
+		localBase: 'support',
+		systemDomain,
+	})
+	expect(routeFor(`kody@${userDomain}`)).toEqual({
+		kind: 'reject',
+		reason: 'This address is reserved for system mail.',
+	})
+	expect(routeFor(`kody+tag@${userDomain}`)).toEqual({
+		kind: 'reject',
+		reason: 'This address is reserved for system mail.',
+	})
+	expect(routeFor(`alice@${systemDomain}`)).toEqual({
+		kind: 'reject',
+		reason: 'Unknown Kody email address.',
+	})
+	expect(routeFor('not-an-address')).toEqual({
+		kind: 'reject',
+		reason: 'Invalid recipient address.',
+	})
+})

--- a/packages/worker/src/email/inbound-mailbox-route.ts
+++ b/packages/worker/src/email/inbound-mailbox-route.ts
@@ -1,0 +1,82 @@
+import { isPermanentlyReservedUsername } from '#worker/identity/reserved-usernames.ts'
+import { normalizeEmailAddress, splitEmailLocalPart } from './address.ts'
+import { isSystemEmailLocal, type SystemEmailLocal } from './system-email.ts'
+
+export type InboundMailboxRoute =
+	| {
+			kind: 'reject'
+			reason: string
+	  }
+	| {
+			kind: 'system'
+			recipient: string
+			localBase: SystemEmailLocal
+			systemDomain: string
+	  }
+	| {
+			kind: 'user'
+			recipient: string
+			username: string
+	  }
+
+/**
+ * Classify an inbound envelope recipient as operator system mail, user
+ * inbox mail, or a permanent reject.
+ *
+ * RFC 5233 plus-tags are stripped before reserved, system-local, and
+ * username matching. `user+kody@inbox…` (and `+support`, `+admin`, …) is
+ * user mail for `user` when that username exists — never the reserved
+ * apex local `kody`. The plus-tag is not consulted for those checks.
+ * Callers keep the full tagged `recipient` on stored `to_addresses`.
+ *
+ * Do not reuse the username-claim denylist
+ * (`usernameCollidesWithReservedNames` / `isReservedUsername`) on a
+ * tagged local: that matcher substring-matches brand/system roots, so
+ * `alice+kody` would look reserved even though the mailbox owner is
+ * `alice`.
+ */
+export function resolveInboundMailboxRoute(input: {
+	envelopeTo: string
+	acceptedUserDomains: ReadonlyArray<string>
+	acceptedSystemDomains: ReadonlyArray<string>
+	systemDomain: string | null
+}): InboundMailboxRoute {
+	const recipient = normalizeEmailAddress(input.envelopeTo)
+	if (!recipient) {
+		return { kind: 'reject', reason: 'Invalid recipient address.' }
+	}
+	if (
+		input.acceptedUserDomains.length === 0 &&
+		input.acceptedSystemDomains.length === 0
+	) {
+		return { kind: 'reject', reason: 'Email routing is not configured.' }
+	}
+
+	const atIndex = recipient.lastIndexOf('@')
+	const localPart = recipient.slice(0, atIndex)
+	const recipientDomain = recipient.slice(atIndex + 1)
+	const { base: localBase } = splitEmailLocalPart(localPart)
+
+	if (
+		input.systemDomain &&
+		input.acceptedSystemDomains.includes(recipientDomain) &&
+		isSystemEmailLocal(localBase)
+	) {
+		return {
+			kind: 'system',
+			recipient,
+			localBase,
+			systemDomain: input.systemDomain,
+		}
+	}
+	if (!input.acceptedUserDomains.includes(recipientDomain)) {
+		return { kind: 'reject', reason: 'Unknown Kody email address.' }
+	}
+	if (isPermanentlyReservedUsername(localBase)) {
+		return {
+			kind: 'reject',
+			reason: 'This address is reserved for system mail.',
+		}
+	}
+	return { kind: 'user', recipient, username: localBase }
+}

--- a/packages/worker/src/email/inbound.ts
+++ b/packages/worker/src/email/inbound.ts
@@ -1,4 +1,3 @@
-import { isPermanentlyReservedUsername } from '#worker/identity/reserved-usernames.ts'
 import { withAccountWriteLease } from '#worker/account/deletion-state.ts'
 import { findPublicUserIdentityByUsername } from '#worker/identity/user-lookup.ts'
 import { isEntitlementLimitError } from '#worker/entitlements/errors.ts'
@@ -13,11 +12,7 @@ import {
 	estimateEntitlementStorageEntryBytes,
 } from '#worker/entitlements/service.ts'
 import { recordUsage } from '#worker/usage/record-usage.ts'
-import {
-	normalizeEmailAddress,
-	normalizeSubject,
-	splitEmailLocalPart,
-} from './address.ts'
+import { normalizeEmailAddress, normalizeSubject } from './address.ts'
 import { ensureDefaultEmailInbox } from './default-inbox.ts'
 import { evaluateEmailSenderRules } from './sender-rules.ts'
 import {
@@ -50,6 +45,7 @@ import {
 	scheduleInboundRejectedTerminalWork,
 	type InboundMailboxEnv,
 } from './inbound-mailbox.ts'
+import { resolveInboundMailboxRoute } from './inbound-mailbox-route.ts'
 import {
 	countInternalUserEmailMessages,
 	getInternalEmailMessageById,
@@ -64,7 +60,6 @@ import {
 	storeIdempotentInboundEmail,
 } from './service.ts'
 import { handleSystemInboundEmail } from './system-inbound-email.ts'
-import { isSystemEmailLocal } from './system-email.ts'
 
 /**
  * Rejection audit writes are best-effort (the SMTP reject already happened),
@@ -171,63 +166,45 @@ export async function handleInboundEmail(
 		InboundMailboxEnv,
 	ctx?: ExecutionContext,
 ) {
-	const recipient = normalizeEmailAddress(message.to)
-	if (!recipient) {
-		message.setReject('Invalid recipient address.')
-		return
-	}
-
 	// Inbound accepts the canonical domains plus any LEGACY_*_EMAIL_DOMAINS;
 	// mail on those addresses resolves to the same inboxes. Outbound
 	// (senders, alert lanes) always uses the canonical domains only.
 	const acceptedUserDomains = getAcceptedUserEmailDomains(inputEnv)
 	const acceptedSystemDomains = getAcceptedSystemEmailDomains(inputEnv)
 	const systemDomain = getSystemEmailDomain(inputEnv)
-	if (acceptedUserDomains.length === 0 && acceptedSystemDomains.length === 0) {
-		message.setReject('Email routing is not configured.')
-		return
+	const route = resolveInboundMailboxRoute({
+		envelopeTo: message.to,
+		acceptedUserDomains,
+		acceptedSystemDomains,
+		systemDomain,
+	})
+	switch (route.kind) {
+		case 'reject':
+			message.setReject(route.reason)
+			return
+		case 'system':
+			await handleSystemInboundEmail({
+				message,
+				env: inputEnv,
+				recipient: route.recipient,
+				localPart: route.localBase,
+				// Replies and threading always use the canonical system domain,
+				// even when the message arrived on a legacy one.
+				systemDomain: route.systemDomain,
+				ctx,
+			})
+			return
+		case 'user':
+			break
+		default: {
+			const exhaustive: never = route
+			throw new Error(
+				`Unsupported inbound mailbox route: ${String(exhaustive)}`,
+			)
+		}
 	}
-
-	const atIndex = recipient.lastIndexOf('@')
-	const localPart = recipient.slice(0, atIndex)
-	const recipientDomain = recipient.slice(atIndex + 1)
-	// RFC 5233 subaddressing: `user+tag@...` routes like `user@...`. The
-	// full tagged address stays visible in the stored message's
-	// to_addresses, so automations (for example email.message.received
-	// package handlers) can dispatch on the tag.
-	const { base: localBase } = splitEmailLocalPart(localPart)
-	// Operator-owned system inboxes live on the apex domain, next to the
-	// kody@<apex> transactional sender whose replies they receive. User mail
-	// lives exclusively on the user subdomain; all other apex mail rejects.
-	if (
-		systemDomain &&
-		acceptedSystemDomains.includes(recipientDomain) &&
-		isSystemEmailLocal(localBase)
-	) {
-		await handleSystemInboundEmail({
-			message,
-			env: inputEnv,
-			recipient,
-			localPart: localBase,
-			// Replies and threading always use the canonical system domain,
-			// even when the message arrived on a legacy one.
-			systemDomain,
-			ctx,
-		})
-		return
-	}
-	if (!acceptedUserDomains.includes(recipientDomain)) {
-		message.setReject('Unknown Kody email address.')
-		return
-	}
-	// Permanently reserved locals (system inboxes, kody-prefixed names,
-	// reply-token aliases) are never user mail, even on the user subdomain.
-	// Other reserved names may be unreserved and claimed; delivery follows
-	// live account ownership below.
-	if (isPermanentlyReservedUsername(localBase)) {
-		message.setReject('This address is reserved for system mail.')
-		return
-	}
+	const recipient = route.recipient
+	const localBase = route.username
 	// Provisioning always records the canonical address (first accepted
 	// domain), even when the message arrived on a legacy domain.
 	const platformDomain = acceptedUserDomains[0]

--- a/packages/worker/src/email/system-email.workers.test.ts
+++ b/packages/worker/src/email/system-email.workers.test.ts
@@ -290,6 +290,100 @@ test('user-subdomain mail delivers to a live unreserved built-in username and re
 	})
 })
 
+test('user-inbox plus-tags including reserved system locals store to the user mailbox', async () => {
+	await ensureEmailTestSchema(env.APP_DB)
+	await ensureUsageRollupsTestSchema(env.APP_DB)
+	const username = `plustag-${crypto.randomUUID().slice(0, 8)}`
+	const email = `${username}@example.com`
+	const userId = await createStableUserIdFromEmail(email)
+	await seedVerifiedAccount({ email, username })
+
+	const kodyTagged = buildInboundMessage({
+		to: `${username}+kody@${userDomain}`,
+		subject: 'User plus-tag kody',
+	})
+	await handleInboundEmail(kodyTagged, createInboundEnv())
+	expect(kodyTagged.rejectedReason).toBeNull()
+
+	const patchTagged = buildInboundMessage({
+		to: `${username}+patch@${userDomain}`,
+		subject: 'User plus-tag patch',
+	})
+	await handleInboundEmail(patchTagged, createInboundEnv())
+	expect(patchTagged.rejectedReason).toBeNull()
+
+	const supportTagged = buildInboundMessage({
+		to: `${username}+support@${userDomain}`,
+		subject: 'User plus-tag support',
+	})
+	await handleInboundEmail(supportTagged, createInboundEnv())
+	expect(supportTagged.rejectedReason).toBeNull()
+
+	const stored = await mailboxRpc({ env, userId }).listMessages({
+		direction: 'inbound',
+		limit: 10,
+	})
+	expect(stored.messages).toEqual(
+		expect.arrayContaining([
+			expect.objectContaining({
+				subject: 'User plus-tag kody',
+				toAddresses: [`${username}+kody@${userDomain}`],
+				direction: 'inbound',
+				processingStatus: 'stored',
+			}),
+			expect.objectContaining({
+				subject: 'User plus-tag patch',
+				toAddresses: [`${username}+patch@${userDomain}`],
+				direction: 'inbound',
+				processingStatus: 'stored',
+			}),
+			expect.objectContaining({
+				subject: 'User plus-tag support',
+				toAddresses: [`${username}+support@${userDomain}`],
+				direction: 'inbound',
+				processingStatus: 'stored',
+			}),
+		]),
+	)
+	expect(stored.messages).toHaveLength(3)
+	expect(
+		await listSystemEmailMessages({
+			db: env.APP_DB,
+			limit: 10,
+		}),
+	).toEqual([])
+
+	const apexSystem = buildInboundMessage({
+		to: `kody@${systemDomain}`,
+		subject: 'Apex system still works',
+	})
+	await handleInboundEmail(apexSystem, createInboundEnv())
+	expect(apexSystem.rejectedReason).toBeNull()
+	expect(
+		await listSystemEmailMessages({
+			db: env.APP_DB,
+			limit: 10,
+		}),
+	).toEqual([
+		expect.objectContaining({
+			subject: 'Apex system still works',
+			toAddresses: [`kody@${systemDomain}`],
+		}),
+	])
+	expect(
+		(await mailboxRpc({ env, userId }).listMessages({ limit: 10 })).messages,
+	).toHaveLength(3)
+
+	const reservedUsername = buildInboundMessage({
+		to: `kody@${userDomain}`,
+		subject: 'Reserved username is not a user claim',
+	})
+	await handleInboundEmail(reservedUsername, createInboundEnv())
+	expect(reservedUsername.rejectedReason).toBe(
+		'This address is reserved for system mail.',
+	)
+})
+
 async function readSystemDailyReceiveCount(localPart: string) {
 	const row = await env.APP_DB.prepare(
 		`SELECT count FROM system_email_daily_counters


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Make plus-addressed user inbox mail (`username+<anytag>@inbox…`) deliver to that username’s inbox even when the tag spells a reserved system local such as `kody` or `support`.

## Why

Kent mailed `kentcdodds+kody@inbox.kody.codes` (Gmail SENT `1a068245d4e8cd63`, 2026-09-03 ~10:40am America/Denver). It never stored in his user inbox, never bounced, never fired `email.message.received`, and did not land in `adminSystemEmailList`. `kentcdodds+patch@inbox.kody.codes` stored the day before. No inbound to `+kody` has ever stored.

## Summary

- Extract `resolveInboundMailboxRoute` so reserved/system/username matching uses only the RFC 5233 **base** local. The plus-tag is never consulted.
- `alice+kody@inbox…` / `alice+support@inbox…` / `alice+patch@inbox…` route to user `alice`. The full tagged address stays on stored `to_addresses`.
- `kody@kody.codes` (and `support+tag@apex`) still go to operator system mail.
- `kody@inbox…` (no plus) still rejects as a reserved username.
- Docs state the trap: the username-claim denylist substring-matches `kody` inside `alice+kody`, so inbound must not reuse that matcher on a tagged local.

## Testing

- `vitest` node-unit: `inbound-mailbox-route.node.test.ts`, `address.node.test.ts`
- `vitest` workers-unit: plus-tag store path in `system-email.workers.test.ts` (plus the existing reserved-local suite)
- Pre-push gate: `test:node` 2479 passed, `test:workers` 322 passed
- Preview (seed `user-me`): https://kody-pr-2026.kody-a99.workers.dev/account/email — `GET /account/email.json` 200, inbox `user-me@inbox.kody-pr-2026.kody-a99.workers.dev`. Preview cannot mint inbound mail; routing proof is the worker tests.
- Production evidence (read-only): Email Routing on `kody.codes` is a single catch-all to `kody-production` (no `+kody` drop rule). `emailMessageSearch` / `adminSystemEmailList` confirm the incident mail is not stored or quarantined. Did not send mail and did not attempt recovery.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `d24d5b08` · **Head:** `153a268d`

**Classification:** extends — inbound mailbox matching is a named helper with an explicit plus-tag contract; system vs user routing behavior is locked by tests.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `email` | assistant | extends — envelope matching uses the RFC 5233 base only; plus-tags on user inbox hosts are never reserved system locals |

### Change flow

Inbound Email Routing still delivers the original envelope recipient to origin. Classification now goes through `resolveInboundMailboxRoute` before Mailbox or the system graph.

```mermaid
sequenceDiagram
	actor Sender
	participant email as email
	participant mailboxDo as mailbox-do
	participant d1AppDb as d1-app-db
	Sender->>email: RCPT TO user+kody@inbox…
	Note over email: resolveInboundMailboxRoute uses base user only
	email->>mailboxDo: store inbound for username user
	email->>d1AppDb: username lookup on base local
	Note over mailboxDo: to_addresses keeps user+kody@inbox…
```

### Before / after

| Envelope | Before (easy to get wrong) | After |
| -------- | -------------------------- | ----- |
| `user+kody@inbox…` | Claim denylist substring-matches `kody` on the tagged local | User inbox for `user` |
| `user+patch@inbox…` | User inbox | User inbox (unchanged) |
| `kody@kody.codes` | System inbox | System inbox |
| `kody@inbox…` | Reserved reject | Reserved reject |

### Invariants

Per-user isolation is unchanged: delivery is still keyed by the live username owner. Plus-tags do not create a second mailbox and do not cross into operator system mail.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-be1a4c4d-31a3-44d8-ba78-57c0a9d4c9e4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-be1a4c4d-31a3-44d8-ba78-57c0a9d4c9e4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

