### PR TITLE
Fix account deletion: source job vector ids from JOBS and abort when Stripe cancellation fails

### DIFF
--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -47,15 +47,21 @@ Account deletion is implemented in `packages/worker/src/app/account-deletion.ts`
 and is intentionally inventory driven. Before inventory it durably sets
 `users.deleting_at`; browser, MCP, package-invocation, and job mutation
 boundaries then reject writes, while the deletion route can still authenticate
-the marked account for retry. The operation performs idempotent out-of-band and
-OAuth cleanup. Any critical cleanup failure preserves D1, the marker, and the
-user row for retry. Only after cleanup succeeds does one atomic D1 batch delete
-or clear all user rows and the `users` row. Each step records deleted counts,
-updated counts for cleared references, and warnings so the HTTP response states
-what was removed and what needs operator attention. Re-running the operation is
-safe: missing rows, missing KV keys, missing vectors, deleted Artifacts repos,
-and already-cleared Durable Objects are treated as successful no-ops or
-warning-only failures.
+the marked account for retry. Before any destructive step it cancels every
+active or trialing Stripe subscription; if Stripe cannot confirm cancellation
+the deletion fails with `AccountDeletionBillingError`, the marker is released,
+and the account is retained (like an inventory failure) so the customer is never
+billed for an account that no longer exists. Already-canceled or missing
+subscriptions count as canceled, so retries are idempotent. Stripe customer
+deletion stays a best-effort warning after cleanup. The operation then performs
+idempotent out-of-band and OAuth cleanup. Any critical cleanup failure preserves
+D1, the marker, and the user row for retry. Only after cleanup succeeds does one
+atomic D1 batch delete or clear all user rows and the `users` row. Each step
+records deleted counts, updated counts for cleared references, and warnings so
+the HTTP response states what was removed and what needs operator attention.
+Re-running the operation is safe: missing rows, missing KV keys, missing
+vectors, deleted Artifacts repos, and already-cleared Durable Objects are
+treated as successful no-ops or warning-only failures.
 
 All four dedicated `system_email_*` graph tables are intentionally excluded from
 account deletion. They are operator-owned mail for reserved platform addresses,

--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -91,9 +91,14 @@ Deletion must cover these user-owned surfaces:
   conversation state, raw-fetch state, and transport storage before revoking
   OAuth grants.
 - **Vectorize:** memory, job, and saved-package vector ids are derived from D1
-  rows and removed with `deleteByIds`. Matching `vector_embed_fingerprints` rows
-  are deleted by `vector_id` on those writes; account deletion clears remaining
-  rows for that `user_id`.
+  rows and removed with `deleteByIds`. Each surface in
+  `accountUserOwnedVectorizeSurfaces` declares its row source: memory and
+  saved-package ids come from `APP_DB` tables, while job ids come from the jobs
+  worker over the `JOBS` binding (`listJobIdsForUser`, live plus archived job
+  ids) because `APP_DB` has no `jobs` table (ADR 0016). Inventory fails rather
+  than skipping when `JOBS` is unbound. Matching `vector_embed_fingerprints`
+  rows are deleted by `vector_id` on those writes; account deletion clears
+  remaining rows for that `user_id`.
 - **R2:** raw USER email MIME and attachment blobs in `EMAIL_BLOBS` are
   inventoried by `Mailbox.listBlobReferences`; the Mailbox store derives raw
   keys from owner/message ids and emits only canonical external-attachment keys.

--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -48,20 +48,21 @@ and is intentionally inventory driven. Before inventory it durably sets
 `users.deleting_at`; browser, MCP, package-invocation, and job mutation
 boundaries then reject writes, while the deletion route can still authenticate
 the marked account for retry. Before any destructive step it cancels every
-active or trialing Stripe subscription; if Stripe cannot confirm cancellation
-the deletion fails with `AccountDeletionBillingError`, the marker is released,
-and the account is retained (like an inventory failure) so the customer is never
-billed for an account that no longer exists. Already-canceled or missing
-subscriptions count as canceled, so retries are idempotent. Stripe customer
-deletion stays a best-effort warning after cleanup. The operation then performs
-idempotent out-of-band and OAuth cleanup. Any critical cleanup failure preserves
-D1, the marker, and the user row for retry. Only after cleanup succeeds does one
-atomic D1 batch delete or clear all user rows and the `users` row. Each step
-records deleted counts, updated counts for cleared references, and warnings so
-the HTTP response states what was removed and what needs operator attention.
-Re-running the operation is safe: missing rows, missing KV keys, missing
-vectors, deleted Artifacts repos, and already-cleared Durable Objects are
-treated as successful no-ops or warning-only failures.
+Stripe subscription that can still bill (active, trialing, past_due, unpaid,
+paused, or incomplete); if Stripe cannot confirm cancellation the deletion fails
+with `AccountDeletionBillingError`, the marker is released, and the account is
+retained (like an inventory failure) so the customer is never billed for an
+account that no longer exists. Already-canceled or missing subscriptions count
+as canceled, so retries are idempotent. Stripe customer deletion stays a
+best-effort warning after cleanup. The operation then performs idempotent
+out-of-band and OAuth cleanup. Any critical cleanup failure preserves D1, the
+marker, and the user row for retry. Only after cleanup succeeds does one atomic
+D1 batch delete or clear all user rows and the `users` row. Each step records
+deleted counts, updated counts for cleared references, and warnings so the HTTP
+response states what was removed and what needs operator attention. Re-running
+the operation is safe: missing rows, missing KV keys, missing vectors, deleted
+Artifacts repos, and already-cleared Durable Objects are treated as successful
+no-ops or warning-only failures.
 
 All four dedicated `system_email_*` graph tables are intentionally excluded from
 account deletion. They are operator-owned mail for reserved platform addresses,

--- a/packages/jobs-worker/src/service.node.test.ts
+++ b/packages/jobs-worker/src/service.node.test.ts
@@ -1,0 +1,97 @@
+import { DatabaseSync } from "node:sqlite";
+import { expect, test } from "vitest";
+import { applyAllMigrations } from "#worker/test-support/apply-all-migrations.ts";
+import { createD1FromSqlite } from "#worker/test-support/create-d1-from-sqlite.ts";
+import { type JobsWorkerEnv } from "./env.ts";
+import { JobsService } from "./service.ts";
+
+function createJobsDb() {
+  const sqlite = new DatabaseSync(":memory:");
+  applyAllMigrations(sqlite, new URL("../migrations/", import.meta.url));
+  return { sqlite, db: createD1FromSqlite(sqlite) };
+}
+
+function insertJob(
+  sqlite: DatabaseSync,
+  input: { id: string; userId: string },
+) {
+  sqlite
+    .prepare(
+      `INSERT INTO jobs (
+				id, user_id, name, source_id, storage_id, schedule_json, timezone,
+				caller_context_json, created_at, updated_at, next_run_at
+			) VALUES (?, ?, ?, 'src-1', ?, '{}', 'UTC', '{}', ?, ?, ?)`,
+    )
+    .run(
+      input.id,
+      input.userId,
+      `name-${input.id}`,
+      `job:${input.id}`,
+      "2026-09-01T00:00:00.000Z",
+      "2026-09-01T00:00:00.000Z",
+      "2026-09-02T00:00:00.000Z",
+    );
+}
+
+function insertArchivedArtifact(
+  sqlite: DatabaseSync,
+  input: { id: string; jobId: string; userId: string },
+) {
+  sqlite
+    .prepare(
+      `INSERT INTO archived_job_artifacts (
+				id, job_id, user_id, source_id, published_commit, storage_id,
+				retain_until, created_at, updated_at
+			) VALUES (?, ?, ?, 'src-1', 'abc123', ?, ?, ?, ?)`,
+    )
+    .run(
+      input.id,
+      input.jobId,
+      input.userId,
+      `job:${input.jobId}`,
+      "2026-10-01T00:00:00.000Z",
+      "2026-09-01T00:00:00.000Z",
+      "2026-09-01T00:00:00.000Z",
+    );
+}
+
+function createService(db: D1Database) {
+  const env = { JOBS_DB: db } as unknown as JobsWorkerEnv;
+  return new JobsService({ props: {} } as never, env);
+}
+
+test("listJobIdsForUser returns the user’s live and archived job ids from the jobs D1 only", async () => {
+  const { sqlite, db } = createJobsDb();
+  insertJob(sqlite, { id: "job-1", userId: "user-aaa" });
+  insertJob(sqlite, { id: "job-2", userId: "user-aaa" });
+  insertJob(sqlite, { id: "job-3", userId: "user-bbb" });
+  // A job that was deleted by retention and archived keeps its id here so a
+  // leftover vector can still be swept; a still-live job that is also
+  // archived must not be listed twice.
+  insertArchivedArtifact(sqlite, {
+    id: "aja-1",
+    jobId: "job-archived",
+    userId: "user-aaa",
+  });
+  insertArchivedArtifact(sqlite, {
+    id: "aja-2",
+    jobId: "job-2",
+    userId: "user-aaa",
+  });
+  insertArchivedArtifact(sqlite, {
+    id: "aja-3",
+    jobId: "job-other-archived",
+    userId: "user-bbb",
+  });
+
+  const service = createService(db);
+  await expect(
+    service.listJobIdsForUser({ userId: "user-aaa" }),
+  ).resolves.toEqual(["job-1", "job-2", "job-archived"]);
+  await expect(
+    service.listJobIdsForUser({ userId: "user-bbb" }),
+  ).resolves.toEqual(["job-3", "job-other-archived"]);
+  await expect(
+    service.listJobIdsForUser({ userId: "user-none" }),
+  ).resolves.toEqual([]);
+});

--- a/packages/jobs-worker/src/service.node.test.ts
+++ b/packages/jobs-worker/src/service.node.test.ts
@@ -1,97 +1,97 @@
-import { DatabaseSync } from "node:sqlite";
-import { expect, test } from "vitest";
-import { applyAllMigrations } from "#worker/test-support/apply-all-migrations.ts";
-import { createD1FromSqlite } from "#worker/test-support/create-d1-from-sqlite.ts";
-import { type JobsWorkerEnv } from "./env.ts";
-import { JobsService } from "./service.ts";
+import { DatabaseSync } from 'node:sqlite'
+import { expect, test } from 'vitest'
+import { applyAllMigrations } from '#worker/test-support/apply-all-migrations.ts'
+import { createD1FromSqlite } from '#worker/test-support/create-d1-from-sqlite.ts'
+import { type JobsWorkerEnv } from './env.ts'
+import { JobsService } from './service.ts'
 
 function createJobsDb() {
-  const sqlite = new DatabaseSync(":memory:");
-  applyAllMigrations(sqlite, new URL("../migrations/", import.meta.url));
-  return { sqlite, db: createD1FromSqlite(sqlite) };
+	const sqlite = new DatabaseSync(':memory:')
+	applyAllMigrations(sqlite, new URL('../migrations/', import.meta.url))
+	return { sqlite, db: createD1FromSqlite(sqlite) }
 }
 
 function insertJob(
-  sqlite: DatabaseSync,
-  input: { id: string; userId: string },
+	sqlite: DatabaseSync,
+	input: { id: string; userId: string },
 ) {
-  sqlite
-    .prepare(
-      `INSERT INTO jobs (
+	sqlite
+		.prepare(
+			`INSERT INTO jobs (
 				id, user_id, name, source_id, storage_id, schedule_json, timezone,
 				caller_context_json, created_at, updated_at, next_run_at
 			) VALUES (?, ?, ?, 'src-1', ?, '{}', 'UTC', '{}', ?, ?, ?)`,
-    )
-    .run(
-      input.id,
-      input.userId,
-      `name-${input.id}`,
-      `job:${input.id}`,
-      "2026-09-01T00:00:00.000Z",
-      "2026-09-01T00:00:00.000Z",
-      "2026-09-02T00:00:00.000Z",
-    );
+		)
+		.run(
+			input.id,
+			input.userId,
+			`name-${input.id}`,
+			`job:${input.id}`,
+			'2026-09-01T00:00:00.000Z',
+			'2026-09-01T00:00:00.000Z',
+			'2026-09-02T00:00:00.000Z',
+		)
 }
 
 function insertArchivedArtifact(
-  sqlite: DatabaseSync,
-  input: { id: string; jobId: string; userId: string },
+	sqlite: DatabaseSync,
+	input: { id: string; jobId: string; userId: string },
 ) {
-  sqlite
-    .prepare(
-      `INSERT INTO archived_job_artifacts (
+	sqlite
+		.prepare(
+			`INSERT INTO archived_job_artifacts (
 				id, job_id, user_id, source_id, published_commit, storage_id,
 				retain_until, created_at, updated_at
 			) VALUES (?, ?, ?, 'src-1', 'abc123', ?, ?, ?, ?)`,
-    )
-    .run(
-      input.id,
-      input.jobId,
-      input.userId,
-      `job:${input.jobId}`,
-      "2026-10-01T00:00:00.000Z",
-      "2026-09-01T00:00:00.000Z",
-      "2026-09-01T00:00:00.000Z",
-    );
+		)
+		.run(
+			input.id,
+			input.jobId,
+			input.userId,
+			`job:${input.jobId}`,
+			'2026-10-01T00:00:00.000Z',
+			'2026-09-01T00:00:00.000Z',
+			'2026-09-01T00:00:00.000Z',
+		)
 }
 
 function createService(db: D1Database) {
-  const env = { JOBS_DB: db } as unknown as JobsWorkerEnv;
-  return new JobsService({ props: {} } as never, env);
+	const env = { JOBS_DB: db } as unknown as JobsWorkerEnv
+	return new JobsService({ props: {} } as never, env)
 }
 
-test("listJobIdsForUser returns the user’s live and archived job ids from the jobs D1 only", async () => {
-  const { sqlite, db } = createJobsDb();
-  insertJob(sqlite, { id: "job-1", userId: "user-aaa" });
-  insertJob(sqlite, { id: "job-2", userId: "user-aaa" });
-  insertJob(sqlite, { id: "job-3", userId: "user-bbb" });
-  // A job that was deleted by retention and archived keeps its id here so a
-  // leftover vector can still be swept; a still-live job that is also
-  // archived must not be listed twice.
-  insertArchivedArtifact(sqlite, {
-    id: "aja-1",
-    jobId: "job-archived",
-    userId: "user-aaa",
-  });
-  insertArchivedArtifact(sqlite, {
-    id: "aja-2",
-    jobId: "job-2",
-    userId: "user-aaa",
-  });
-  insertArchivedArtifact(sqlite, {
-    id: "aja-3",
-    jobId: "job-other-archived",
-    userId: "user-bbb",
-  });
+test('listJobIdsForUser returns the user’s live and archived job ids from the jobs D1 only', async () => {
+	const { sqlite, db } = createJobsDb()
+	insertJob(sqlite, { id: 'job-1', userId: 'user-aaa' })
+	insertJob(sqlite, { id: 'job-2', userId: 'user-aaa' })
+	insertJob(sqlite, { id: 'job-3', userId: 'user-bbb' })
+	// A job that was deleted by retention and archived keeps its id here so a
+	// leftover vector can still be swept; a still-live job that is also
+	// archived must not be listed twice.
+	insertArchivedArtifact(sqlite, {
+		id: 'aja-1',
+		jobId: 'job-archived',
+		userId: 'user-aaa',
+	})
+	insertArchivedArtifact(sqlite, {
+		id: 'aja-2',
+		jobId: 'job-2',
+		userId: 'user-aaa',
+	})
+	insertArchivedArtifact(sqlite, {
+		id: 'aja-3',
+		jobId: 'job-other-archived',
+		userId: 'user-bbb',
+	})
 
-  const service = createService(db);
-  await expect(
-    service.listJobIdsForUser({ userId: "user-aaa" }),
-  ).resolves.toEqual(["job-1", "job-2", "job-archived"]);
-  await expect(
-    service.listJobIdsForUser({ userId: "user-bbb" }),
-  ).resolves.toEqual(["job-3", "job-other-archived"]);
-  await expect(
-    service.listJobIdsForUser({ userId: "user-none" }),
-  ).resolves.toEqual([]);
-});
+	const service = createService(db)
+	await expect(
+		service.listJobIdsForUser({ userId: 'user-aaa' }),
+	).resolves.toEqual(['job-1', 'job-2', 'job-archived'])
+	await expect(
+		service.listJobIdsForUser({ userId: 'user-bbb' }),
+	).resolves.toEqual(['job-3', 'job-other-archived'])
+	await expect(
+		service.listJobIdsForUser({ userId: 'user-none' }),
+	).resolves.toEqual([])
+})

--- a/packages/jobs-worker/src/service.ts
+++ b/packages/jobs-worker/src/service.ts
@@ -1,19 +1,19 @@
-import { type McpCallerContext } from '@kody-internal/shared/chat.ts'
-import { type JobManagerDebugState } from '@kody-internal/shared/jobs/manager-debug.ts'
+import { type McpCallerContext } from "@kody-internal/shared/chat.ts";
+import { type JobManagerDebugState } from "@kody-internal/shared/jobs/manager-debug.ts";
 import {
-	type JobsServiceContract,
-	type JobsHostContract,
-} from '@kody-internal/shared/jobs/rpc.ts'
-import { type ArchivedJobArtifactRecord } from '@kody-internal/shared/jobs/archived-artifacts-repo.ts'
-import { type JobRow } from '@kody-internal/shared/jobs/repo.ts'
+  type JobsServiceContract,
+  type JobsHostContract,
+} from "@kody-internal/shared/jobs/rpc.ts";
+import { type ArchivedJobArtifactRecord } from "@kody-internal/shared/jobs/archived-artifacts-repo.ts";
+import { type JobRow } from "@kody-internal/shared/jobs/repo.ts";
 import {
-	type JobRecord,
-	type JobRepoCheckPolicy,
-} from '@kody-internal/shared/jobs/types.ts'
-import { WorkerEntrypoint } from 'cloudflare:workers'
-import { type JobsWorkerEnv } from './env.ts'
-import { jobManagerStub } from './manager.ts'
-import { jobsStore } from './store.ts'
+  type JobRecord,
+  type JobRepoCheckPolicy,
+} from "@kody-internal/shared/jobs/types.ts";
+import { WorkerEntrypoint } from "cloudflare:workers";
+import { type JobsWorkerEnv } from "./env.ts";
+import { jobManagerStub } from "./manager.ts";
+import { jobsStore } from "./store.ts";
 
 /**
  * `JobsService` — the coarse-grained RPC surface the main worker reaches
@@ -24,215 +24,219 @@ import { jobsStore } from './store.ts'
  * resolves it from the authenticated session/caller context).
  */
 export class JobsService
-	extends WorkerEntrypoint<JobsWorkerEnv>
-	implements JobsServiceContract
+  extends WorkerEntrypoint<JobsWorkerEnv>
+  implements JobsServiceContract
 {
-	async insertJob(input: {
-		userId: string
-		job: JobRecord
-		callerContextJson: string
-	}): Promise<void> {
-		await jobsStore(this.env).insertJob(input)
-	}
+  async insertJob(input: {
+    userId: string;
+    job: JobRecord;
+    callerContextJson: string;
+  }): Promise<void> {
+    await jobsStore(this.env).insertJob(input);
+  }
 
-	async updateJob(input: {
-		userId: string
-		job: JobRecord
-		callerContextJson: string
-	}): Promise<boolean> {
-		return jobsStore(this.env).updateJob(input)
-	}
+  async updateJob(input: {
+    userId: string;
+    job: JobRecord;
+    callerContextJson: string;
+  }): Promise<boolean> {
+    return jobsStore(this.env).updateJob(input);
+  }
 
-	async getJobById(input: {
-		userId: string
-		jobId: string
-	}): Promise<JobRow | null> {
-		return jobsStore(this.env).getJobById(input)
-	}
+  async getJobById(input: {
+    userId: string;
+    jobId: string;
+  }): Promise<JobRow | null> {
+    return jobsStore(this.env).getJobById(input);
+  }
 
-	async listJobsForUser(input: { userId: string }): Promise<Array<JobRow>> {
-		return jobsStore(this.env).listJobsForUser(input)
-	}
+  async listJobsForUser(input: { userId: string }): Promise<Array<JobRow>> {
+    return jobsStore(this.env).listJobsForUser(input);
+  }
 
-	async listJobsPage(input: {
-		afterId: string | null
-		limit: number
-	}): Promise<Array<JobRow>> {
-		return jobsStore(this.env).listJobsPage(input)
-	}
+  async listJobsPage(input: {
+    afterId: string | null;
+    limit: number;
+  }): Promise<Array<JobRow>> {
+    return jobsStore(this.env).listJobsPage(input);
+  }
 
-	async listDueJobs(input: {
-		userId: string
-		nowIso: string
-	}): Promise<Array<JobRow>> {
-		return jobsStore(this.env).listDueJobs(input)
-	}
+  async listDueJobs(input: {
+    userId: string;
+    nowIso: string;
+  }): Promise<Array<JobRow>> {
+    return jobsStore(this.env).listDueJobs(input);
+  }
 
-	async getNextRunnableJob(input: {
-		userId: string
-		nowIso: string
-	}): Promise<JobRow | null> {
-		return jobsStore(this.env).getNextRunnableJob(input)
-	}
+  async getNextRunnableJob(input: {
+    userId: string;
+    nowIso: string;
+  }): Promise<JobRow | null> {
+    return jobsStore(this.env).getNextRunnableJob(input);
+  }
 
-	async claimJob(input: {
-		userId: string
-		jobId: string
-		nowMs: number
-		claimToken: string
-	}): Promise<JobRow | null> {
-		return jobsStore(this.env).claimJob(input)
-	}
+  async claimJob(input: {
+    userId: string;
+    jobId: string;
+    nowMs: number;
+    claimToken: string;
+  }): Promise<JobRow | null> {
+    return jobsStore(this.env).claimJob(input);
+  }
 
-	async finalizeClaimedJob(input: {
-		userId: string
-		job: JobRecord
-		claimToken: string
-		scheduledFor: string
-	}): Promise<boolean> {
-		return jobsStore(this.env).finalizeClaimedJob(input)
-	}
+  async finalizeClaimedJob(input: {
+    userId: string;
+    job: JobRecord;
+    claimToken: string;
+    scheduledFor: string;
+  }): Promise<boolean> {
+    return jobsStore(this.env).finalizeClaimedJob(input);
+  }
 
-	async retryClaimedJob(input: {
-		userId: string
-		jobId: string
-		claimToken: string
-		nextRunAt: string
-	}): Promise<boolean> {
-		return jobsStore(this.env).retryClaimedJob(input)
-	}
+  async retryClaimedJob(input: {
+    userId: string;
+    jobId: string;
+    claimToken: string;
+    nextRunAt: string;
+  }): Promise<boolean> {
+    return jobsStore(this.env).retryClaimedJob(input);
+  }
 
-	async refreshPackageJobIdentity(input: {
-		userId: string
-		jobId: string
-		sourceId: string
-		publishedCommit: string | null
-		callerContextJson: string
-		updatedAt: string
-	}): Promise<boolean> {
-		return jobsStore(this.env).refreshPackageJobIdentity(input)
-	}
+  async refreshPackageJobIdentity(input: {
+    userId: string;
+    jobId: string;
+    sourceId: string;
+    publishedCommit: string | null;
+    callerContextJson: string;
+    updatedAt: string;
+  }): Promise<boolean> {
+    return jobsStore(this.env).refreshPackageJobIdentity(input);
+  }
 
-	async deleteJob(input: { userId: string; jobId: string }): Promise<boolean> {
-		return jobsStore(this.env).deleteJob(input)
-	}
+  async deleteJob(input: { userId: string; jobId: string }): Promise<boolean> {
+    return jobsStore(this.env).deleteJob(input);
+  }
 
-	async disableExpiredJobsForUser(input: {
-		userId: string
-		nowIso: string
-	}): Promise<number> {
-		return jobsStore(this.env).disableExpiredJobsForUser(input)
-	}
+  async disableExpiredJobsForUser(input: {
+    userId: string;
+    nowIso: string;
+  }): Promise<number> {
+    return jobsStore(this.env).disableExpiredJobsForUser(input);
+  }
 
-	async listJobRetentionCandidates(input: {
-		afterId: string | null
-		limit: number
-	}): Promise<Array<JobRow>> {
-		return jobsStore(this.env).listJobRetentionCandidates(input)
-	}
+  async listJobRetentionCandidates(input: {
+    afterId: string | null;
+    limit: number;
+  }): Promise<Array<JobRow>> {
+    return jobsStore(this.env).listJobRetentionCandidates(input);
+  }
 
-	async upsertArchivedJobArtifact(input: {
-		jobId: string
-		userId: string
-		sourceId: string
-		publishedCommit: string
-		storageId: string
-		retainUntil: string
-	}): Promise<string> {
-		return jobsStore(this.env).upsertArchivedJobArtifact(input)
-	}
+  async upsertArchivedJobArtifact(input: {
+    jobId: string;
+    userId: string;
+    sourceId: string;
+    publishedCommit: string;
+    storageId: string;
+    retainUntil: string;
+  }): Promise<string> {
+    return jobsStore(this.env).upsertArchivedJobArtifact(input);
+  }
 
-	async listArchivedJobArtifactsDueBefore(input: {
-		retainUntil: string
-		limit?: number
-	}): Promise<Array<ArchivedJobArtifactRecord>> {
-		return jobsStore(this.env).listArchivedJobArtifactsDueBefore(input)
-	}
+  async listArchivedJobArtifactsDueBefore(input: {
+    retainUntil: string;
+    limit?: number;
+  }): Promise<Array<ArchivedJobArtifactRecord>> {
+    return jobsStore(this.env).listArchivedJobArtifactsDueBefore(input);
+  }
 
-	async deleteArchivedJobArtifact(input: { id: string }): Promise<void> {
-		await jobsStore(this.env).deleteArchivedJobArtifact(input)
-	}
+  async deleteArchivedJobArtifact(input: { id: string }): Promise<void> {
+    await jobsStore(this.env).deleteArchivedJobArtifact(input);
+  }
 
-	async countJobsForUser(input: { userId: string }): Promise<number> {
-		return jobsStore(this.env).countJobsForUser(input)
-	}
+  async countJobsForUser(input: { userId: string }): Promise<number> {
+    return jobsStore(this.env).countJobsForUser(input);
+  }
 
-	async sumJobsStorageBytesForUser(input: { userId: string }): Promise<number> {
-		return jobsStore(this.env).sumJobsStorageBytesForUser(input)
-	}
+  async sumJobsStorageBytesForUser(input: { userId: string }): Promise<number> {
+    return jobsStore(this.env).sumJobsStorageBytesForUser(input);
+  }
 
-	async listJobStorageIdsForUser(input: {
-		userId: string
-	}): Promise<Array<string>> {
-		return jobsStore(this.env).listJobStorageIdsForUser(input)
-	}
+  async listJobIdsForUser(input: { userId: string }): Promise<Array<string>> {
+    return jobsStore(this.env).listJobIdsForUser(input);
+  }
 
-	async listArchivedJobArtifactsForUser(input: {
-		userId: string
-	}): Promise<Array<ArchivedJobArtifactRecord>> {
-		return jobsStore(this.env).listArchivedJobArtifactsForUser(input)
-	}
+  async listJobStorageIdsForUser(input: {
+    userId: string;
+  }): Promise<Array<string>> {
+    return jobsStore(this.env).listJobStorageIdsForUser(input);
+  }
 
-	async listAllJobStorageOwners(): Promise<
-		Array<{ userId: string; storageId: string }>
-	> {
-		return jobsStore(this.env).listAllJobStorageOwners()
-	}
+  async listArchivedJobArtifactsForUser(input: {
+    userId: string;
+  }): Promise<Array<ArchivedJobArtifactRecord>> {
+    return jobsStore(this.env).listArchivedJobArtifactsForUser(input);
+  }
 
-	async getJobInsights(): Promise<{ total: number; enabled: number }> {
-		return jobsStore(this.env).getJobInsights()
-	}
+  async listAllJobStorageOwners(): Promise<
+    Array<{ userId: string; storageId: string }>
+  > {
+    return jobsStore(this.env).listAllJobStorageOwners();
+  }
 
-	async purgeUserJobsData(input: { userId: string }): Promise<void> {
-		await jobsStore(this.env).purgeUserJobsData(input)
-	}
+  async getJobInsights(): Promise<{ total: number; enabled: number }> {
+    return jobsStore(this.env).getJobInsights();
+  }
 
-	async syncAlarm(input: {
-		userId: string
-	}): Promise<{ ok: true; userId: string; nextRunAt: string | null }> {
-		return jobManagerStub(this.env, input.userId).syncAlarm({
-			userId: input.userId,
-			source: 'rpc',
-		})
-	}
+  async purgeUserJobsData(input: { userId: string }): Promise<void> {
+    await jobsStore(this.env).purgeUserJobsData(input);
+  }
 
-	async getDebugState(input: {
-		userId: string
-	}): Promise<JobManagerDebugState> {
-		return jobManagerStub(this.env, input.userId).getDebugState(input)
-	}
+  async syncAlarm(input: {
+    userId: string;
+  }): Promise<{ ok: true; userId: string; nextRunAt: string | null }> {
+    return jobManagerStub(this.env, input.userId).syncAlarm({
+      userId: input.userId,
+      source: "rpc",
+    });
+  }
 
-	async exportUser(input: { userId: string }): Promise<JobManagerDebugState> {
-		return jobManagerStub(this.env, input.userId).exportUser(input)
-	}
+  async getDebugState(input: {
+    userId: string;
+  }): Promise<JobManagerDebugState> {
+    return jobManagerStub(this.env, input.userId).getDebugState(input);
+  }
 
-	/**
-	 * Account-deletion hook: removes every jobs-database row for the user and
-	 * purges the JobManager Durable Object storage (including its alarm).
-	 */
-	async purgeUser(input: {
-		userId: string
-	}): Promise<{ ok: true; userId: string; purged: boolean }> {
-		const userId = input.userId.trim()
-		if (!userId) {
-			throw new Error('Jobs purge requires a non-empty userId.')
-		}
-		await jobsStore(this.env).purgeUserJobsData({ userId })
-		await jobManagerStub(this.env, userId).purgeUser({ userId })
-		return { ok: true as const, userId, purged: true }
-	}
+  async exportUser(input: { userId: string }): Promise<JobManagerDebugState> {
+    return jobManagerStub(this.env, input.userId).exportUser(input);
+  }
 
-	async runJobNow(input: {
-		userId: string
-		jobId: string
-		callerContext?: McpCallerContext | null
-		repoCheckPolicyOverride?: JobRepoCheckPolicy | null
-	}): Promise<Awaited<ReturnType<JobsHostContract['runJobNow']>>> {
-		return jobManagerStub(this.env, input.userId).runNow({
-			userId: input.userId,
-			jobId: input.jobId,
-			callerContext: input.callerContext ?? null,
-			repoCheckPolicyOverride: input.repoCheckPolicyOverride ?? null,
-		})
-	}
+  /**
+   * Account-deletion hook: removes every jobs-database row for the user and
+   * purges the JobManager Durable Object storage (including its alarm).
+   */
+  async purgeUser(input: {
+    userId: string;
+  }): Promise<{ ok: true; userId: string; purged: boolean }> {
+    const userId = input.userId.trim();
+    if (!userId) {
+      throw new Error("Jobs purge requires a non-empty userId.");
+    }
+    await jobsStore(this.env).purgeUserJobsData({ userId });
+    await jobManagerStub(this.env, userId).purgeUser({ userId });
+    return { ok: true as const, userId, purged: true };
+  }
+
+  async runJobNow(input: {
+    userId: string;
+    jobId: string;
+    callerContext?: McpCallerContext | null;
+    repoCheckPolicyOverride?: JobRepoCheckPolicy | null;
+  }): Promise<Awaited<ReturnType<JobsHostContract["runJobNow"]>>> {
+    return jobManagerStub(this.env, input.userId).runNow({
+      userId: input.userId,
+      jobId: input.jobId,
+      callerContext: input.callerContext ?? null,
+      repoCheckPolicyOverride: input.repoCheckPolicyOverride ?? null,
+    });
+  }
 }

--- a/packages/jobs-worker/src/service.ts
+++ b/packages/jobs-worker/src/service.ts
@@ -1,19 +1,19 @@
-import { type McpCallerContext } from "@kody-internal/shared/chat.ts";
-import { type JobManagerDebugState } from "@kody-internal/shared/jobs/manager-debug.ts";
+import { type McpCallerContext } from '@kody-internal/shared/chat.ts'
+import { type JobManagerDebugState } from '@kody-internal/shared/jobs/manager-debug.ts'
 import {
-  type JobsServiceContract,
-  type JobsHostContract,
-} from "@kody-internal/shared/jobs/rpc.ts";
-import { type ArchivedJobArtifactRecord } from "@kody-internal/shared/jobs/archived-artifacts-repo.ts";
-import { type JobRow } from "@kody-internal/shared/jobs/repo.ts";
+	type JobsServiceContract,
+	type JobsHostContract,
+} from '@kody-internal/shared/jobs/rpc.ts'
+import { type ArchivedJobArtifactRecord } from '@kody-internal/shared/jobs/archived-artifacts-repo.ts'
+import { type JobRow } from '@kody-internal/shared/jobs/repo.ts'
 import {
-  type JobRecord,
-  type JobRepoCheckPolicy,
-} from "@kody-internal/shared/jobs/types.ts";
-import { WorkerEntrypoint } from "cloudflare:workers";
-import { type JobsWorkerEnv } from "./env.ts";
-import { jobManagerStub } from "./manager.ts";
-import { jobsStore } from "./store.ts";
+	type JobRecord,
+	type JobRepoCheckPolicy,
+} from '@kody-internal/shared/jobs/types.ts'
+import { WorkerEntrypoint } from 'cloudflare:workers'
+import { type JobsWorkerEnv } from './env.ts'
+import { jobManagerStub } from './manager.ts'
+import { jobsStore } from './store.ts'
 
 /**
  * `JobsService` — the coarse-grained RPC surface the main worker reaches
@@ -24,219 +24,219 @@ import { jobsStore } from "./store.ts";
  * resolves it from the authenticated session/caller context).
  */
 export class JobsService
-  extends WorkerEntrypoint<JobsWorkerEnv>
-  implements JobsServiceContract
+	extends WorkerEntrypoint<JobsWorkerEnv>
+	implements JobsServiceContract
 {
-  async insertJob(input: {
-    userId: string;
-    job: JobRecord;
-    callerContextJson: string;
-  }): Promise<void> {
-    await jobsStore(this.env).insertJob(input);
-  }
+	async insertJob(input: {
+		userId: string
+		job: JobRecord
+		callerContextJson: string
+	}): Promise<void> {
+		await jobsStore(this.env).insertJob(input)
+	}
 
-  async updateJob(input: {
-    userId: string;
-    job: JobRecord;
-    callerContextJson: string;
-  }): Promise<boolean> {
-    return jobsStore(this.env).updateJob(input);
-  }
+	async updateJob(input: {
+		userId: string
+		job: JobRecord
+		callerContextJson: string
+	}): Promise<boolean> {
+		return jobsStore(this.env).updateJob(input)
+	}
 
-  async getJobById(input: {
-    userId: string;
-    jobId: string;
-  }): Promise<JobRow | null> {
-    return jobsStore(this.env).getJobById(input);
-  }
+	async getJobById(input: {
+		userId: string
+		jobId: string
+	}): Promise<JobRow | null> {
+		return jobsStore(this.env).getJobById(input)
+	}
 
-  async listJobsForUser(input: { userId: string }): Promise<Array<JobRow>> {
-    return jobsStore(this.env).listJobsForUser(input);
-  }
+	async listJobsForUser(input: { userId: string }): Promise<Array<JobRow>> {
+		return jobsStore(this.env).listJobsForUser(input)
+	}
 
-  async listJobsPage(input: {
-    afterId: string | null;
-    limit: number;
-  }): Promise<Array<JobRow>> {
-    return jobsStore(this.env).listJobsPage(input);
-  }
+	async listJobsPage(input: {
+		afterId: string | null
+		limit: number
+	}): Promise<Array<JobRow>> {
+		return jobsStore(this.env).listJobsPage(input)
+	}
 
-  async listDueJobs(input: {
-    userId: string;
-    nowIso: string;
-  }): Promise<Array<JobRow>> {
-    return jobsStore(this.env).listDueJobs(input);
-  }
+	async listDueJobs(input: {
+		userId: string
+		nowIso: string
+	}): Promise<Array<JobRow>> {
+		return jobsStore(this.env).listDueJobs(input)
+	}
 
-  async getNextRunnableJob(input: {
-    userId: string;
-    nowIso: string;
-  }): Promise<JobRow | null> {
-    return jobsStore(this.env).getNextRunnableJob(input);
-  }
+	async getNextRunnableJob(input: {
+		userId: string
+		nowIso: string
+	}): Promise<JobRow | null> {
+		return jobsStore(this.env).getNextRunnableJob(input)
+	}
 
-  async claimJob(input: {
-    userId: string;
-    jobId: string;
-    nowMs: number;
-    claimToken: string;
-  }): Promise<JobRow | null> {
-    return jobsStore(this.env).claimJob(input);
-  }
+	async claimJob(input: {
+		userId: string
+		jobId: string
+		nowMs: number
+		claimToken: string
+	}): Promise<JobRow | null> {
+		return jobsStore(this.env).claimJob(input)
+	}
 
-  async finalizeClaimedJob(input: {
-    userId: string;
-    job: JobRecord;
-    claimToken: string;
-    scheduledFor: string;
-  }): Promise<boolean> {
-    return jobsStore(this.env).finalizeClaimedJob(input);
-  }
+	async finalizeClaimedJob(input: {
+		userId: string
+		job: JobRecord
+		claimToken: string
+		scheduledFor: string
+	}): Promise<boolean> {
+		return jobsStore(this.env).finalizeClaimedJob(input)
+	}
 
-  async retryClaimedJob(input: {
-    userId: string;
-    jobId: string;
-    claimToken: string;
-    nextRunAt: string;
-  }): Promise<boolean> {
-    return jobsStore(this.env).retryClaimedJob(input);
-  }
+	async retryClaimedJob(input: {
+		userId: string
+		jobId: string
+		claimToken: string
+		nextRunAt: string
+	}): Promise<boolean> {
+		return jobsStore(this.env).retryClaimedJob(input)
+	}
 
-  async refreshPackageJobIdentity(input: {
-    userId: string;
-    jobId: string;
-    sourceId: string;
-    publishedCommit: string | null;
-    callerContextJson: string;
-    updatedAt: string;
-  }): Promise<boolean> {
-    return jobsStore(this.env).refreshPackageJobIdentity(input);
-  }
+	async refreshPackageJobIdentity(input: {
+		userId: string
+		jobId: string
+		sourceId: string
+		publishedCommit: string | null
+		callerContextJson: string
+		updatedAt: string
+	}): Promise<boolean> {
+		return jobsStore(this.env).refreshPackageJobIdentity(input)
+	}
 
-  async deleteJob(input: { userId: string; jobId: string }): Promise<boolean> {
-    return jobsStore(this.env).deleteJob(input);
-  }
+	async deleteJob(input: { userId: string; jobId: string }): Promise<boolean> {
+		return jobsStore(this.env).deleteJob(input)
+	}
 
-  async disableExpiredJobsForUser(input: {
-    userId: string;
-    nowIso: string;
-  }): Promise<number> {
-    return jobsStore(this.env).disableExpiredJobsForUser(input);
-  }
+	async disableExpiredJobsForUser(input: {
+		userId: string
+		nowIso: string
+	}): Promise<number> {
+		return jobsStore(this.env).disableExpiredJobsForUser(input)
+	}
 
-  async listJobRetentionCandidates(input: {
-    afterId: string | null;
-    limit: number;
-  }): Promise<Array<JobRow>> {
-    return jobsStore(this.env).listJobRetentionCandidates(input);
-  }
+	async listJobRetentionCandidates(input: {
+		afterId: string | null
+		limit: number
+	}): Promise<Array<JobRow>> {
+		return jobsStore(this.env).listJobRetentionCandidates(input)
+	}
 
-  async upsertArchivedJobArtifact(input: {
-    jobId: string;
-    userId: string;
-    sourceId: string;
-    publishedCommit: string;
-    storageId: string;
-    retainUntil: string;
-  }): Promise<string> {
-    return jobsStore(this.env).upsertArchivedJobArtifact(input);
-  }
+	async upsertArchivedJobArtifact(input: {
+		jobId: string
+		userId: string
+		sourceId: string
+		publishedCommit: string
+		storageId: string
+		retainUntil: string
+	}): Promise<string> {
+		return jobsStore(this.env).upsertArchivedJobArtifact(input)
+	}
 
-  async listArchivedJobArtifactsDueBefore(input: {
-    retainUntil: string;
-    limit?: number;
-  }): Promise<Array<ArchivedJobArtifactRecord>> {
-    return jobsStore(this.env).listArchivedJobArtifactsDueBefore(input);
-  }
+	async listArchivedJobArtifactsDueBefore(input: {
+		retainUntil: string
+		limit?: number
+	}): Promise<Array<ArchivedJobArtifactRecord>> {
+		return jobsStore(this.env).listArchivedJobArtifactsDueBefore(input)
+	}
 
-  async deleteArchivedJobArtifact(input: { id: string }): Promise<void> {
-    await jobsStore(this.env).deleteArchivedJobArtifact(input);
-  }
+	async deleteArchivedJobArtifact(input: { id: string }): Promise<void> {
+		await jobsStore(this.env).deleteArchivedJobArtifact(input)
+	}
 
-  async countJobsForUser(input: { userId: string }): Promise<number> {
-    return jobsStore(this.env).countJobsForUser(input);
-  }
+	async countJobsForUser(input: { userId: string }): Promise<number> {
+		return jobsStore(this.env).countJobsForUser(input)
+	}
 
-  async sumJobsStorageBytesForUser(input: { userId: string }): Promise<number> {
-    return jobsStore(this.env).sumJobsStorageBytesForUser(input);
-  }
+	async sumJobsStorageBytesForUser(input: { userId: string }): Promise<number> {
+		return jobsStore(this.env).sumJobsStorageBytesForUser(input)
+	}
 
-  async listJobIdsForUser(input: { userId: string }): Promise<Array<string>> {
-    return jobsStore(this.env).listJobIdsForUser(input);
-  }
+	async listJobIdsForUser(input: { userId: string }): Promise<Array<string>> {
+		return jobsStore(this.env).listJobIdsForUser(input)
+	}
 
-  async listJobStorageIdsForUser(input: {
-    userId: string;
-  }): Promise<Array<string>> {
-    return jobsStore(this.env).listJobStorageIdsForUser(input);
-  }
+	async listJobStorageIdsForUser(input: {
+		userId: string
+	}): Promise<Array<string>> {
+		return jobsStore(this.env).listJobStorageIdsForUser(input)
+	}
 
-  async listArchivedJobArtifactsForUser(input: {
-    userId: string;
-  }): Promise<Array<ArchivedJobArtifactRecord>> {
-    return jobsStore(this.env).listArchivedJobArtifactsForUser(input);
-  }
+	async listArchivedJobArtifactsForUser(input: {
+		userId: string
+	}): Promise<Array<ArchivedJobArtifactRecord>> {
+		return jobsStore(this.env).listArchivedJobArtifactsForUser(input)
+	}
 
-  async listAllJobStorageOwners(): Promise<
-    Array<{ userId: string; storageId: string }>
-  > {
-    return jobsStore(this.env).listAllJobStorageOwners();
-  }
+	async listAllJobStorageOwners(): Promise<
+		Array<{ userId: string; storageId: string }>
+	> {
+		return jobsStore(this.env).listAllJobStorageOwners()
+	}
 
-  async getJobInsights(): Promise<{ total: number; enabled: number }> {
-    return jobsStore(this.env).getJobInsights();
-  }
+	async getJobInsights(): Promise<{ total: number; enabled: number }> {
+		return jobsStore(this.env).getJobInsights()
+	}
 
-  async purgeUserJobsData(input: { userId: string }): Promise<void> {
-    await jobsStore(this.env).purgeUserJobsData(input);
-  }
+	async purgeUserJobsData(input: { userId: string }): Promise<void> {
+		await jobsStore(this.env).purgeUserJobsData(input)
+	}
 
-  async syncAlarm(input: {
-    userId: string;
-  }): Promise<{ ok: true; userId: string; nextRunAt: string | null }> {
-    return jobManagerStub(this.env, input.userId).syncAlarm({
-      userId: input.userId,
-      source: "rpc",
-    });
-  }
+	async syncAlarm(input: {
+		userId: string
+	}): Promise<{ ok: true; userId: string; nextRunAt: string | null }> {
+		return jobManagerStub(this.env, input.userId).syncAlarm({
+			userId: input.userId,
+			source: 'rpc',
+		})
+	}
 
-  async getDebugState(input: {
-    userId: string;
-  }): Promise<JobManagerDebugState> {
-    return jobManagerStub(this.env, input.userId).getDebugState(input);
-  }
+	async getDebugState(input: {
+		userId: string
+	}): Promise<JobManagerDebugState> {
+		return jobManagerStub(this.env, input.userId).getDebugState(input)
+	}
 
-  async exportUser(input: { userId: string }): Promise<JobManagerDebugState> {
-    return jobManagerStub(this.env, input.userId).exportUser(input);
-  }
+	async exportUser(input: { userId: string }): Promise<JobManagerDebugState> {
+		return jobManagerStub(this.env, input.userId).exportUser(input)
+	}
 
-  /**
-   * Account-deletion hook: removes every jobs-database row for the user and
-   * purges the JobManager Durable Object storage (including its alarm).
-   */
-  async purgeUser(input: {
-    userId: string;
-  }): Promise<{ ok: true; userId: string; purged: boolean }> {
-    const userId = input.userId.trim();
-    if (!userId) {
-      throw new Error("Jobs purge requires a non-empty userId.");
-    }
-    await jobsStore(this.env).purgeUserJobsData({ userId });
-    await jobManagerStub(this.env, userId).purgeUser({ userId });
-    return { ok: true as const, userId, purged: true };
-  }
+	/**
+	 * Account-deletion hook: removes every jobs-database row for the user and
+	 * purges the JobManager Durable Object storage (including its alarm).
+	 */
+	async purgeUser(input: {
+		userId: string
+	}): Promise<{ ok: true; userId: string; purged: boolean }> {
+		const userId = input.userId.trim()
+		if (!userId) {
+			throw new Error('Jobs purge requires a non-empty userId.')
+		}
+		await jobsStore(this.env).purgeUserJobsData({ userId })
+		await jobManagerStub(this.env, userId).purgeUser({ userId })
+		return { ok: true as const, userId, purged: true }
+	}
 
-  async runJobNow(input: {
-    userId: string;
-    jobId: string;
-    callerContext?: McpCallerContext | null;
-    repoCheckPolicyOverride?: JobRepoCheckPolicy | null;
-  }): Promise<Awaited<ReturnType<JobsHostContract["runJobNow"]>>> {
-    return jobManagerStub(this.env, input.userId).runNow({
-      userId: input.userId,
-      jobId: input.jobId,
-      callerContext: input.callerContext ?? null,
-      repoCheckPolicyOverride: input.repoCheckPolicyOverride ?? null,
-    });
-  }
+	async runJobNow(input: {
+		userId: string
+		jobId: string
+		callerContext?: McpCallerContext | null
+		repoCheckPolicyOverride?: JobRepoCheckPolicy | null
+	}): Promise<Awaited<ReturnType<JobsHostContract['runJobNow']>>> {
+		return jobManagerStub(this.env, input.userId).runNow({
+			userId: input.userId,
+			jobId: input.jobId,
+			callerContext: input.callerContext ?? null,
+			repoCheckPolicyOverride: input.repoCheckPolicyOverride ?? null,
+		})
+	}
 }

--- a/packages/shared/src/jobs/repo.ts
+++ b/packages/shared/src/jobs/repo.ts
@@ -1,229 +1,229 @@
-import { parseJsonWithFallback } from '../json-parsing.ts'
-import { createJobStorageId } from './storage-id.ts'
-import { type JobRecord, type PersistedJobCallerContext } from './types.ts'
+import { parseJsonWithFallback } from "../json-parsing.ts";
+import { createJobStorageId } from "./storage-id.ts";
+import { type JobRecord, type PersistedJobCallerContext } from "./types.ts";
 
 type JobRowRecord = {
-	id: string
-	user_id: string
-	name: string
-	source_id: string
-	published_commit: string | null
-	repo_check_policy_json: string | null
-	storage_id: string | null
-	params_json: string | null
-	schedule_json: string
-	timezone: string
-	enabled: number
-	kill_switch_enabled: number
-	preserved: number
-	expires_at: string | null
-	caller_context_json: string
-	created_at: string
-	updated_at: string
-	last_run_at: string | null
-	last_run_status: JobRecord['lastRunStatus'] | null
-	next_run_at: string
-	claim_token: string | null
-	running_since: string | null
-	lease_expires_at: string | null
-	claimed_scheduled_for: string | null
-	retry_scheduled_for: string | null
-	retry_count: number
-	last_completed_scheduled_for: string | null
-}
+  id: string;
+  user_id: string;
+  name: string;
+  source_id: string;
+  published_commit: string | null;
+  repo_check_policy_json: string | null;
+  storage_id: string | null;
+  params_json: string | null;
+  schedule_json: string;
+  timezone: string;
+  enabled: number;
+  kill_switch_enabled: number;
+  preserved: number;
+  expires_at: string | null;
+  caller_context_json: string;
+  created_at: string;
+  updated_at: string;
+  last_run_at: string | null;
+  last_run_status: JobRecord["lastRunStatus"] | null;
+  next_run_at: string;
+  claim_token: string | null;
+  running_since: string | null;
+  lease_expires_at: string | null;
+  claimed_scheduled_for: string | null;
+  retry_scheduled_for: string | null;
+  retry_count: number;
+  last_completed_scheduled_for: string | null;
+};
 
 export type JobRow = JobRowRecord & {
-	record: JobRecord
-	callerContextJson: string
-	callerContext: PersistedJobCallerContext | null
-	schedulerWakeAt: string
-}
+  record: JobRecord;
+  callerContextJson: string;
+  callerContext: PersistedJobCallerContext | null;
+  schedulerWakeAt: string;
+};
 
 function serializeJob(job: JobRecord) {
-	return {
-		id: job.id,
-		name: job.name,
-		source_id: job.sourceId,
-		published_commit: job.publishedCommit ?? null,
-		repo_check_policy_json: job.repoCheckPolicy
-			? JSON.stringify(job.repoCheckPolicy)
-			: null,
-		storage_id: job.storageId,
-		params_json: job.params ? JSON.stringify(job.params) : null,
-		schedule_json: JSON.stringify(job.schedule),
-		timezone: job.timezone,
-		enabled: job.enabled ? 1 : 0,
-		kill_switch_enabled: job.killSwitchEnabled ? 1 : 0,
-		preserved: job.preserved ? 1 : 0,
-		expires_at: job.expiresAt ?? null,
-		created_at: job.createdAt,
-		updated_at: job.updatedAt,
-		last_run_at: job.lastRunAt ?? null,
-		last_run_status: job.lastRunStatus ?? null,
-		next_run_at: job.nextRunAt,
-	}
+  return {
+    id: job.id,
+    name: job.name,
+    source_id: job.sourceId,
+    published_commit: job.publishedCommit ?? null,
+    repo_check_policy_json: job.repoCheckPolicy
+      ? JSON.stringify(job.repoCheckPolicy)
+      : null,
+    storage_id: job.storageId,
+    params_json: job.params ? JSON.stringify(job.params) : null,
+    schedule_json: JSON.stringify(job.schedule),
+    timezone: job.timezone,
+    enabled: job.enabled ? 1 : 0,
+    kill_switch_enabled: job.killSwitchEnabled ? 1 : 0,
+    preserved: job.preserved ? 1 : 0,
+    expires_at: job.expiresAt ?? null,
+    created_at: job.createdAt,
+    updated_at: job.updatedAt,
+    last_run_at: job.lastRunAt ?? null,
+    last_run_status: job.lastRunStatus ?? null,
+    next_run_at: job.nextRunAt,
+  };
 }
 
 function mapRow(row: Record<string, unknown>): JobRow {
-	const jobId = String(row['id'])
-	const rawStorageId = row['storage_id']
-	const storageId =
-		rawStorageId == null ? createJobStorageId(jobId) : String(rawStorageId)
-	const record: JobRecord = {
-		version: 1,
-		id: jobId,
-		userId: String(row['user_id']),
-		name: String(row['name']),
-		sourceId: String(row['source_id']),
-		publishedCommit:
-			row['published_commit'] == null ? null : String(row['published_commit']),
-		repoCheckPolicy: parseJsonWithFallback<
-			JobRecord['repoCheckPolicy'] | undefined
-		>(
-			row['repo_check_policy_json'] == null
-				? null
-				: String(row['repo_check_policy_json']),
-			undefined,
-		),
-		storageId,
-		params: parseJsonWithFallback<Record<string, unknown> | undefined>(
-			row['params_json'] == null ? null : String(row['params_json']),
-			undefined,
-		),
-		schedule: parseJsonWithFallback<JobRecord['schedule']>(
-			String(row['schedule_json']),
-			{
-				type: 'once',
-				runAt: String(row['next_run_at']),
-			},
-		),
-		timezone: String(row['timezone']),
-		enabled: Number(row['enabled']) === 1,
-		killSwitchEnabled: Number(row['kill_switch_enabled']) === 1,
-		preserved: Number(row['preserved'] ?? 0) === 1,
-		expiresAt: row['expires_at'] == null ? null : String(row['expires_at']),
-		createdAt: String(row['created_at']),
-		updatedAt: String(row['updated_at']),
-		lastRunAt:
-			row['last_run_at'] == null ? undefined : String(row['last_run_at']),
-		lastRunStatus:
-			row['last_run_status'] == null
-				? undefined
-				: (String(row['last_run_status']) as JobRecord['lastRunStatus']),
-		lastRunError: undefined,
-		lastDurationMs: undefined,
-		nextRunAt: String(row['next_run_at']),
-		runCount: 0,
-		successCount: 0,
-		errorCount: 0,
-	}
-	return {
-		id: record.id,
-		user_id: String(row['user_id']),
-		name: record.name,
-		source_id: record.sourceId,
-		published_commit: record.publishedCommit ?? null,
-		repo_check_policy_json:
-			row['repo_check_policy_json'] == null
-				? null
-				: String(row['repo_check_policy_json']),
-		storage_id: record.storageId,
-		params_json: row['params_json'] == null ? null : String(row['params_json']),
-		schedule_json: String(row['schedule_json']),
-		timezone: record.timezone,
-		enabled: record.enabled ? 1 : 0,
-		kill_switch_enabled: record.killSwitchEnabled ? 1 : 0,
-		preserved: record.preserved ? 1 : 0,
-		expires_at: record.expiresAt,
-		caller_context_json: String(row['caller_context_json']),
-		created_at: record.createdAt,
-		updated_at: record.updatedAt,
-		last_run_at: record.lastRunAt ?? null,
-		last_run_status: record.lastRunStatus ?? null,
-		next_run_at: record.nextRunAt,
-		claim_token: row['claim_token'] == null ? null : String(row['claim_token']),
-		running_since:
-			row['running_since'] == null ? null : String(row['running_since']),
-		lease_expires_at:
-			row['lease_expires_at'] == null ? null : String(row['lease_expires_at']),
-		claimed_scheduled_for:
-			row['claimed_scheduled_for'] == null
-				? null
-				: String(row['claimed_scheduled_for']),
-		retry_scheduled_for:
-			row['retry_scheduled_for'] == null
-				? null
-				: String(row['retry_scheduled_for']),
-		retry_count: Number(row['retry_count']) || 0,
-		last_completed_scheduled_for:
-			row['last_completed_scheduled_for'] == null
-				? null
-				: String(row['last_completed_scheduled_for']),
-		record,
-		callerContextJson: String(row['caller_context_json']),
-		callerContext: parseJsonWithFallback<PersistedJobCallerContext | null>(
-			row['caller_context_json'] == null
-				? null
-				: String(row['caller_context_json']),
-			null,
-		),
-		schedulerWakeAt:
-			row['scheduler_wake_at'] == null
-				? record.nextRunAt
-				: String(row['scheduler_wake_at']),
-	}
+  const jobId = String(row["id"]);
+  const rawStorageId = row["storage_id"];
+  const storageId =
+    rawStorageId == null ? createJobStorageId(jobId) : String(rawStorageId);
+  const record: JobRecord = {
+    version: 1,
+    id: jobId,
+    userId: String(row["user_id"]),
+    name: String(row["name"]),
+    sourceId: String(row["source_id"]),
+    publishedCommit:
+      row["published_commit"] == null ? null : String(row["published_commit"]),
+    repoCheckPolicy: parseJsonWithFallback<
+      JobRecord["repoCheckPolicy"] | undefined
+    >(
+      row["repo_check_policy_json"] == null
+        ? null
+        : String(row["repo_check_policy_json"]),
+      undefined,
+    ),
+    storageId,
+    params: parseJsonWithFallback<Record<string, unknown> | undefined>(
+      row["params_json"] == null ? null : String(row["params_json"]),
+      undefined,
+    ),
+    schedule: parseJsonWithFallback<JobRecord["schedule"]>(
+      String(row["schedule_json"]),
+      {
+        type: "once",
+        runAt: String(row["next_run_at"]),
+      },
+    ),
+    timezone: String(row["timezone"]),
+    enabled: Number(row["enabled"]) === 1,
+    killSwitchEnabled: Number(row["kill_switch_enabled"]) === 1,
+    preserved: Number(row["preserved"] ?? 0) === 1,
+    expiresAt: row["expires_at"] == null ? null : String(row["expires_at"]),
+    createdAt: String(row["created_at"]),
+    updatedAt: String(row["updated_at"]),
+    lastRunAt:
+      row["last_run_at"] == null ? undefined : String(row["last_run_at"]),
+    lastRunStatus:
+      row["last_run_status"] == null
+        ? undefined
+        : (String(row["last_run_status"]) as JobRecord["lastRunStatus"]),
+    lastRunError: undefined,
+    lastDurationMs: undefined,
+    nextRunAt: String(row["next_run_at"]),
+    runCount: 0,
+    successCount: 0,
+    errorCount: 0,
+  };
+  return {
+    id: record.id,
+    user_id: String(row["user_id"]),
+    name: record.name,
+    source_id: record.sourceId,
+    published_commit: record.publishedCommit ?? null,
+    repo_check_policy_json:
+      row["repo_check_policy_json"] == null
+        ? null
+        : String(row["repo_check_policy_json"]),
+    storage_id: record.storageId,
+    params_json: row["params_json"] == null ? null : String(row["params_json"]),
+    schedule_json: String(row["schedule_json"]),
+    timezone: record.timezone,
+    enabled: record.enabled ? 1 : 0,
+    kill_switch_enabled: record.killSwitchEnabled ? 1 : 0,
+    preserved: record.preserved ? 1 : 0,
+    expires_at: record.expiresAt,
+    caller_context_json: String(row["caller_context_json"]),
+    created_at: record.createdAt,
+    updated_at: record.updatedAt,
+    last_run_at: record.lastRunAt ?? null,
+    last_run_status: record.lastRunStatus ?? null,
+    next_run_at: record.nextRunAt,
+    claim_token: row["claim_token"] == null ? null : String(row["claim_token"]),
+    running_since:
+      row["running_since"] == null ? null : String(row["running_since"]),
+    lease_expires_at:
+      row["lease_expires_at"] == null ? null : String(row["lease_expires_at"]),
+    claimed_scheduled_for:
+      row["claimed_scheduled_for"] == null
+        ? null
+        : String(row["claimed_scheduled_for"]),
+    retry_scheduled_for:
+      row["retry_scheduled_for"] == null
+        ? null
+        : String(row["retry_scheduled_for"]),
+    retry_count: Number(row["retry_count"]) || 0,
+    last_completed_scheduled_for:
+      row["last_completed_scheduled_for"] == null
+        ? null
+        : String(row["last_completed_scheduled_for"]),
+    record,
+    callerContextJson: String(row["caller_context_json"]),
+    callerContext: parseJsonWithFallback<PersistedJobCallerContext | null>(
+      row["caller_context_json"] == null
+        ? null
+        : String(row["caller_context_json"]),
+      null,
+    ),
+    schedulerWakeAt:
+      row["scheduler_wake_at"] == null
+        ? record.nextRunAt
+        : String(row["scheduler_wake_at"]),
+  };
 }
 
 export async function insertJobRow(input: {
-	db: D1Database
-	userId: string
-	job: JobRecord
-	callerContextJson: string
+  db: D1Database;
+  userId: string;
+  job: JobRecord;
+  callerContextJson: string;
 }) {
-	const serialized = serializeJob(input.job)
-	await input.db
-		.prepare(
-			`INSERT INTO jobs (
+  const serialized = serializeJob(input.job);
+  await input.db
+    .prepare(
+      `INSERT INTO jobs (
 				id, user_id, name, source_id, published_commit, repo_check_policy_json, storage_id, params_json, schedule_json, timezone, enabled,
 				kill_switch_enabled, preserved, expires_at, caller_context_json, created_at, updated_at,
 				last_run_at, last_run_status, next_run_at
 			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		)
-		.bind(
-			serialized.id,
-			input.userId,
-			serialized.name,
-			serialized.source_id,
-			serialized.published_commit,
-			serialized.repo_check_policy_json,
-			serialized.storage_id,
-			serialized.params_json,
-			serialized.schedule_json,
-			serialized.timezone,
-			serialized.enabled,
-			serialized.kill_switch_enabled,
-			serialized.preserved,
-			serialized.expires_at,
-			input.callerContextJson,
-			serialized.created_at,
-			serialized.updated_at,
-			serialized.last_run_at,
-			serialized.last_run_status,
-			serialized.next_run_at,
-		)
-		.run()
+    )
+    .bind(
+      serialized.id,
+      input.userId,
+      serialized.name,
+      serialized.source_id,
+      serialized.published_commit,
+      serialized.repo_check_policy_json,
+      serialized.storage_id,
+      serialized.params_json,
+      serialized.schedule_json,
+      serialized.timezone,
+      serialized.enabled,
+      serialized.kill_switch_enabled,
+      serialized.preserved,
+      serialized.expires_at,
+      input.callerContextJson,
+      serialized.created_at,
+      serialized.updated_at,
+      serialized.last_run_at,
+      serialized.last_run_status,
+      serialized.next_run_at,
+    )
+    .run();
 }
 
 export async function updateJobRow(input: {
-	db: D1Database
-	userId: string
-	job: JobRecord
-	callerContextJson: string
+  db: D1Database;
+  userId: string;
+  job: JobRecord;
+  callerContextJson: string;
 }) {
-	const serialized = serializeJob(input.job)
-	const result = await input.db
-		.prepare(
-			`UPDATE jobs SET
+  const serialized = serializeJob(input.job);
+  const result = await input.db
+    .prepare(
+      `UPDATE jobs SET
 				name = ?, source_id = ?, published_commit = ?, repo_check_policy_json = ?, storage_id = ?, params_json = ?, schedule_json = ?, timezone = ?,
 				enabled = ?, kill_switch_enabled = ?, preserved = ?, expires_at = ?, caller_context_json = ?, updated_at = ?,
 				last_run_at = ?, last_run_status = ?,
@@ -232,55 +232,55 @@ export async function updateJobRow(input: {
 				claimed_scheduled_for = NULL, retry_scheduled_for = NULL,
 				retry_count = 0
 			WHERE id = ? AND user_id = ?`,
-		)
-		.bind(
-			serialized.name,
-			serialized.source_id,
-			serialized.published_commit,
-			serialized.repo_check_policy_json,
-			serialized.storage_id,
-			serialized.params_json,
-			serialized.schedule_json,
-			serialized.timezone,
-			serialized.enabled,
-			serialized.kill_switch_enabled,
-			serialized.preserved,
-			serialized.expires_at,
-			input.callerContextJson,
-			serialized.updated_at,
-			serialized.last_run_at,
-			serialized.last_run_status,
-			serialized.next_run_at,
-			serialized.id,
-			input.userId,
-		)
-		.run()
-	return (result.meta.changes ?? 0) > 0
+    )
+    .bind(
+      serialized.name,
+      serialized.source_id,
+      serialized.published_commit,
+      serialized.repo_check_policy_json,
+      serialized.storage_id,
+      serialized.params_json,
+      serialized.schedule_json,
+      serialized.timezone,
+      serialized.enabled,
+      serialized.kill_switch_enabled,
+      serialized.preserved,
+      serialized.expires_at,
+      input.callerContextJson,
+      serialized.updated_at,
+      serialized.last_run_at,
+      serialized.last_run_status,
+      serialized.next_run_at,
+      serialized.id,
+      input.userId,
+    )
+    .run();
+  return (result.meta.changes ?? 0) > 0;
 }
 
 export async function getJobRowById(
-	db: D1Database,
-	userId: string,
-	jobId: string,
+  db: D1Database,
+  userId: string,
+  jobId: string,
 ): Promise<JobRow | null> {
-	const result = await db
-		.prepare(`SELECT * FROM jobs WHERE id = ? AND user_id = ?`)
-		.bind(jobId, userId)
-		.first<Record<string, unknown>>()
-	return result ? mapRow(result) : null
+  const result = await db
+    .prepare(`SELECT * FROM jobs WHERE id = ? AND user_id = ?`)
+    .bind(jobId, userId)
+    .first<Record<string, unknown>>();
+  return result ? mapRow(result) : null;
 }
 
 export async function listJobRowsByUserId(
-	db: D1Database,
-	userId: string,
+  db: D1Database,
+  userId: string,
 ): Promise<Array<JobRow>> {
-	const { results } = await db
-		.prepare(
-			`SELECT * FROM jobs WHERE user_id = ? ORDER BY next_run_at ASC, name ASC`,
-		)
-		.bind(userId)
-		.all<Record<string, unknown>>()
-	return (results ?? []).map(mapRow)
+  const { results } = await db
+    .prepare(
+      `SELECT * FROM jobs WHERE user_id = ? ORDER BY next_run_at ASC, name ASC`,
+    )
+    .bind(userId)
+    .all<Record<string, unknown>>();
+  return (results ?? []).map(mapRow);
 }
 
 /**
@@ -289,33 +289,33 @@ export async function listJobRowsByUserId(
  * post-run alarm resync schedules a near-immediate follow-up wake whenever
  * more due jobs remain, so backlogs drain across successive alarms.
  */
-export const maxDueJobsPerAlarm = 25
+export const maxDueJobsPerAlarm = 25;
 
 // Keyset-paged listing across all users, used by maintenance reindex so a
 // single query never loads the whole table. Pass the last row id of the
 // previous page (or null for the first page).
 export async function listJobRowsPage(
-	db: D1Database,
-	input: {
-		afterId: string | null
-		limit: number
-	},
+  db: D1Database,
+  input: {
+    afterId: string | null;
+    limit: number;
+  },
 ): Promise<Array<JobRow>> {
-	const { results } = await db
-		.prepare(`SELECT * FROM jobs WHERE id > ? ORDER BY id LIMIT ?`)
-		.bind(input.afterId ?? '', input.limit)
-		.all<Record<string, unknown>>()
-	return (results ?? []).map(mapRow)
+  const { results } = await db
+    .prepare(`SELECT * FROM jobs WHERE id > ? ORDER BY id LIMIT ?`)
+    .bind(input.afterId ?? "", input.limit)
+    .all<Record<string, unknown>>();
+  return (results ?? []).map(mapRow);
 }
 
 export async function listDueJobRows(
-	db: D1Database,
-	userId: string,
-	nowIso: string,
+  db: D1Database,
+  userId: string,
+  nowIso: string,
 ): Promise<Array<JobRow>> {
-	const { results } = await db
-		.prepare(
-			`SELECT * FROM jobs
+  const { results } = await db
+    .prepare(
+      `SELECT * FROM jobs
 			WHERE user_id = ?
 				AND enabled = 1
 				AND kill_switch_enabled = 0
@@ -332,10 +332,10 @@ export async function listDueJobRows(
 				)
 			ORDER BY next_run_at ASC, name ASC
 			LIMIT ?`,
-		)
-		.bind(userId, nowIso, nowIso, nowIso, maxDueJobsPerAlarm)
-		.all<Record<string, unknown>>()
-	return (results ?? []).map(mapRow)
+    )
+    .bind(userId, nowIso, nowIso, nowIso, maxDueJobsPerAlarm)
+    .all<Record<string, unknown>>();
+  return (results ?? []).map(mapRow);
 }
 
 /**
@@ -345,17 +345,17 @@ export async function listDueJobRows(
  * lost or drifted while due work remained claimable.
  */
 export async function listSilentlyOverdueJobRowsPage(
-	db: D1Database,
-	input: {
-		overdueBeforeIso: string
-		nowIso: string
-		afterId: string | null
-		limit: number
-	},
+  db: D1Database,
+  input: {
+    overdueBeforeIso: string;
+    nowIso: string;
+    afterId: string | null;
+    limit: number;
+  },
 ): Promise<Array<JobRow>> {
-	const { results } = await db
-		.prepare(
-			`SELECT * FROM jobs
+  const { results } = await db
+    .prepare(
+      `SELECT * FROM jobs
 			WHERE id > ?
 				AND enabled = 1
 				AND kill_switch_enabled = 0
@@ -372,16 +372,16 @@ export async function listSilentlyOverdueJobRowsPage(
 				)
 			ORDER BY id ASC
 			LIMIT ?`,
-		)
-		.bind(
-			input.afterId ?? '',
-			input.nowIso,
-			input.overdueBeforeIso,
-			input.nowIso,
-			input.limit,
-		)
-		.all<Record<string, unknown>>()
-	return (results ?? []).map(mapRow)
+    )
+    .bind(
+      input.afterId ?? "",
+      input.nowIso,
+      input.overdueBeforeIso,
+      input.nowIso,
+      input.limit,
+    )
+    .all<Record<string, unknown>>();
+  return (results ?? []).map(mapRow);
 }
 
 /**
@@ -390,16 +390,16 @@ export async function listSilentlyOverdueJobRowsPage(
  * due selection and claims never pick them up again until next_run_at moves.
  */
 export async function listStuckSkippedJobRowsPage(
-	db: D1Database,
-	input: {
-		nowIso: string
-		afterId: string | null
-		limit: number
-	},
+  db: D1Database,
+  input: {
+    nowIso: string;
+    afterId: string | null;
+    limit: number;
+  },
 ): Promise<Array<JobRow>> {
-	const { results } = await db
-		.prepare(
-			`SELECT * FROM jobs
+  const { results } = await db
+    .prepare(
+      `SELECT * FROM jobs
 			WHERE id > ?
 				AND enabled = 1
 				AND kill_switch_enabled = 0
@@ -409,22 +409,22 @@ export async function listStuckSkippedJobRowsPage(
 				AND last_completed_scheduled_for = COALESCE(retry_scheduled_for, next_run_at)
 			ORDER BY id ASC
 			LIMIT ?`,
-		)
-		.bind(input.afterId ?? '', input.nowIso, input.limit)
-		.all<Record<string, unknown>>()
-	return (results ?? []).map(mapRow)
+    )
+    .bind(input.afterId ?? "", input.nowIso, input.limit)
+    .all<Record<string, unknown>>();
+  return (results ?? []).map(mapRow);
 }
 
 export async function advanceStuckSkippedJobNextRunAt(input: {
-	db: D1Database
-	userId: string
-	jobId: string
-	nextRunAt: string
-	updatedAt: string
+  db: D1Database;
+  userId: string;
+  jobId: string;
+  nextRunAt: string;
+  updatedAt: string;
 }): Promise<boolean> {
-	const result = await input.db
-		.prepare(
-			`UPDATE jobs SET
+  const result = await input.db
+    .prepare(
+      `UPDATE jobs SET
 				next_run_at = ?,
 				updated_at = ?,
 				retry_scheduled_for = NULL,
@@ -436,26 +436,26 @@ export async function advanceStuckSkippedJobNextRunAt(input: {
 				AND last_completed_scheduled_for IS NOT NULL
 				AND last_completed_scheduled_for = COALESCE(retry_scheduled_for, next_run_at)
 				AND next_run_at != ?`,
-		)
-		.bind(
-			input.nextRunAt,
-			input.updatedAt,
-			input.jobId,
-			input.userId,
-			input.nextRunAt,
-		)
-		.run()
-	return (result.meta.changes ?? 0) > 0
+    )
+    .bind(
+      input.nextRunAt,
+      input.updatedAt,
+      input.jobId,
+      input.userId,
+      input.nextRunAt,
+    )
+    .run();
+  return (result.meta.changes ?? 0) > 0;
 }
 
 export async function getNextRunnableJobRow(
-	db: D1Database,
-	userId: string,
-	nowIso = new Date().toISOString(),
+  db: D1Database,
+  userId: string,
+  nowIso = new Date().toISOString(),
 ): Promise<JobRow | null> {
-	const result = await db
-		.prepare(
-			`SELECT jobs.*,
+  const result = await db
+    .prepare(
+      `SELECT jobs.*,
 				CASE
 					WHEN claim_token IS NOT NULL
 						AND lease_expires_at IS NOT NULL
@@ -477,10 +477,10 @@ export async function getNextRunnableJobRow(
 				)
 			ORDER BY scheduler_wake_at ASC, name ASC
 			LIMIT 1`,
-		)
-		.bind(nowIso, userId, nowIso)
-		.first<Record<string, unknown>>()
-	return result ? mapRow(result) : null
+    )
+    .bind(nowIso, userId, nowIso)
+    .first<Record<string, unknown>>();
+  return result ? mapRow(result) : null;
 }
 
 /**
@@ -488,22 +488,22 @@ export async function getNextRunnableJobRow(
  * sandbox's default 90-second maximum runtime. A single conditional D1 write
  * is the ownership boundary; reading due rows alone never grants ownership.
  */
-export const jobExecutionLeaseMs = 10 * 60 * 1_000
+export const jobExecutionLeaseMs = 10 * 60 * 1_000;
 
 export async function claimJobRow(input: {
-	db: D1Database
-	userId: string
-	jobId: string
-	now: Date
-	claimToken: string
+  db: D1Database;
+  userId: string;
+  jobId: string;
+  now: Date;
+  claimToken: string;
 }): Promise<JobRow | null> {
-	const nowIso = input.now.toISOString()
-	const leaseExpiresAt = new Date(
-		input.now.valueOf() + jobExecutionLeaseMs,
-	).toISOString()
-	const result = await input.db
-		.prepare(
-			`UPDATE jobs SET
+  const nowIso = input.now.toISOString();
+  const leaseExpiresAt = new Date(
+    input.now.valueOf() + jobExecutionLeaseMs,
+  ).toISOString();
+  const result = await input.db
+    .prepare(
+      `UPDATE jobs SET
 				claim_token = ?,
 				running_since = ?,
 				lease_expires_at = ?,
@@ -524,64 +524,64 @@ export async function claimJobRow(input: {
 					OR last_completed_scheduled_for != COALESCE(retry_scheduled_for, next_run_at)
 				)
 			RETURNING *`,
-		)
-		.bind(
-			input.claimToken,
-			nowIso,
-			leaseExpiresAt,
-			input.jobId,
-			input.userId,
-			nowIso,
-			nowIso,
-			nowIso,
-		)
-		.first<Record<string, unknown>>()
-	return result ? mapRow(result) : null
+    )
+    .bind(
+      input.claimToken,
+      nowIso,
+      leaseExpiresAt,
+      input.jobId,
+      input.userId,
+      nowIso,
+      nowIso,
+      nowIso,
+    )
+    .first<Record<string, unknown>>();
+  return result ? mapRow(result) : null;
 }
 
 export async function finalizeClaimedJobRow(input: {
-	db: D1Database
-	userId: string
-	job: JobRecord
-	claimToken: string
-	scheduledFor: string
+  db: D1Database;
+  userId: string;
+  job: JobRecord;
+  claimToken: string;
+  scheduledFor: string;
 }): Promise<boolean> {
-	const serialized = serializeJob(input.job)
-	const result = await input.db
-		.prepare(
-			`UPDATE jobs SET
+  const serialized = serializeJob(input.job);
+  const result = await input.db
+    .prepare(
+      `UPDATE jobs SET
 				enabled = ?, updated_at = ?, last_run_at = ?, last_run_status = ?,
 				next_run_at = ?,
 				claim_token = NULL, running_since = NULL, lease_expires_at = NULL,
 				claimed_scheduled_for = NULL, retry_scheduled_for = NULL,
 				retry_count = 0, last_completed_scheduled_for = ?
 			WHERE id = ? AND user_id = ? AND claim_token = ?`,
-		)
-		.bind(
-			serialized.enabled,
-			serialized.updated_at,
-			serialized.last_run_at,
-			serialized.last_run_status,
-			serialized.next_run_at,
-			input.scheduledFor,
-			serialized.id,
-			input.userId,
-			input.claimToken,
-		)
-		.run()
-	return (result.meta.changes ?? 0) > 0
+    )
+    .bind(
+      serialized.enabled,
+      serialized.updated_at,
+      serialized.last_run_at,
+      serialized.last_run_status,
+      serialized.next_run_at,
+      input.scheduledFor,
+      serialized.id,
+      input.userId,
+      input.claimToken,
+    )
+    .run();
+  return (result.meta.changes ?? 0) > 0;
 }
 
 export async function retryClaimedJobRow(input: {
-	db: D1Database
-	userId: string
-	jobId: string
-	claimToken: string
-	nextRunAt: string
+  db: D1Database;
+  userId: string;
+  jobId: string;
+  claimToken: string;
+  nextRunAt: string;
 }): Promise<boolean> {
-	const result = await input.db
-		.prepare(
-			`UPDATE jobs SET
+  const result = await input.db
+    .prepare(
+      `UPDATE jobs SET
 				next_run_at = ?,
 				updated_at = ?,
 				retry_scheduled_for = claimed_scheduled_for,
@@ -591,16 +591,16 @@ export async function retryClaimedJobRow(input: {
 				lease_expires_at = NULL,
 				claimed_scheduled_for = NULL
 			WHERE id = ? AND user_id = ? AND claim_token = ?`,
-		)
-		.bind(
-			input.nextRunAt,
-			new Date().toISOString(),
-			input.jobId,
-			input.userId,
-			input.claimToken,
-		)
-		.run()
-	return (result.meta.changes ?? 0) > 0
+    )
+    .bind(
+      input.nextRunAt,
+      new Date().toISOString(),
+      input.jobId,
+      input.userId,
+      input.claimToken,
+    )
+    .run();
+  return (result.meta.changes ?? 0) > 0;
 }
 
 /**
@@ -608,42 +608,42 @@ export async function retryClaimedJobRow(input: {
  * scheduler claim or recomputing the next occurrence.
  */
 export async function refreshPackageJobRowIdentity(input: {
-	db: D1Database
-	userId: string
-	jobId: string
-	sourceId: string
-	publishedCommit: string | null
-	callerContextJson: string
-	updatedAt: string
+  db: D1Database;
+  userId: string;
+  jobId: string;
+  sourceId: string;
+  publishedCommit: string | null;
+  callerContextJson: string;
+  updatedAt: string;
 }) {
-	const result = await input.db
-		.prepare(
-			`UPDATE jobs SET
+  const result = await input.db
+    .prepare(
+      `UPDATE jobs SET
 				source_id = ?, published_commit = ?, caller_context_json = ?, updated_at = ?
 			WHERE id = ? AND user_id = ?`,
-		)
-		.bind(
-			input.sourceId,
-			input.publishedCommit,
-			input.callerContextJson,
-			input.updatedAt,
-			input.jobId,
-			input.userId,
-		)
-		.run()
-	return (result.meta.changes ?? 0) > 0
+    )
+    .bind(
+      input.sourceId,
+      input.publishedCommit,
+      input.callerContextJson,
+      input.updatedAt,
+      input.jobId,
+      input.userId,
+    )
+    .run();
+  return (result.meta.changes ?? 0) > 0;
 }
 
 export async function deleteJobRow(
-	db: D1Database,
-	userId: string,
-	jobId: string,
+  db: D1Database,
+  userId: string,
+  jobId: string,
 ): Promise<boolean> {
-	const result = await db
-		.prepare(`DELETE FROM jobs WHERE id = ? AND user_id = ?`)
-		.bind(jobId, userId)
-		.run()
-	return (result.meta.changes ?? 0) > 0
+  const result = await db
+    .prepare(`DELETE FROM jobs WHERE id = ? AND user_id = ?`)
+    .bind(jobId, userId)
+    .run();
+  return (result.meta.changes ?? 0) > 0;
 }
 
 /**
@@ -652,23 +652,23 @@ export async function deleteJobRow(
  * `preserved`. Returns the number of rows flipped to enabled = 0.
  */
 export async function disableExpiredJobRowsForUser(input: {
-	db: D1Database
-	userId: string
-	nowIso: string
+  db: D1Database;
+  userId: string;
+  nowIso: string;
 }): Promise<number> {
-	const result = await input.db
-		.prepare(
-			`UPDATE jobs SET
+  const result = await input.db
+    .prepare(
+      `UPDATE jobs SET
 				enabled = 0,
 				updated_at = ?
 			WHERE user_id = ?
 				AND enabled = 1
 				AND expires_at IS NOT NULL
 				AND expires_at <= ?`,
-		)
-		.bind(input.nowIso, input.userId, input.nowIso)
-		.run()
-	return result.meta.changes ?? 0
+    )
+    .bind(input.nowIso, input.userId, input.nowIso)
+    .run();
+  return result.meta.changes ?? 0;
 }
 
 /**
@@ -676,7 +676,7 @@ export async function disableExpiredJobRowsForUser(input: {
  * backlog cannot exhaust the Worker CPU budget. Remaining candidates are
  * picked up on subsequent hourly runs.
  */
-export const maxJobRetentionCandidatesPerRun = 100
+export const maxJobRetentionCandidatesPerRun = 100;
 
 /**
  * Candidate scan for the platform job retention sweeper. Excludes preserved,
@@ -689,15 +689,15 @@ export const maxJobRetentionCandidatesPerRun = 100
  * deletes shrink that set across hourly ticks.
  */
 export async function listJobRetentionCandidateRows(
-	db: D1Database,
-	input: {
-		afterId: string | null
-		limit: number
-	},
+  db: D1Database,
+  input: {
+    afterId: string | null;
+    limit: number;
+  },
 ): Promise<Array<JobRow>> {
-	const { results } = await db
-		.prepare(
-			`SELECT * FROM jobs
+  const { results } = await db
+    .prepare(
+      `SELECT * FROM jobs
 			WHERE preserved = 0
 				AND id NOT LIKE 'package-job:%'
 				AND id > ?
@@ -715,21 +715,21 @@ export async function listJobRetentionCandidateRows(
 				)
 			ORDER BY id ASC
 			LIMIT ?`,
-		)
-		.bind(input.afterId ?? '', input.limit)
-		.all<Record<string, unknown>>()
-	return (results ?? []).map(mapRow)
+    )
+    .bind(input.afterId ?? "", input.limit)
+    .all<Record<string, unknown>>();
+  return (results ?? []).map(mapRow);
 }
 
 export async function countJobRowsForUser(
-	db: D1Database,
-	userId: string,
+  db: D1Database,
+  userId: string,
 ): Promise<number> {
-	const row = await db
-		.prepare(`SELECT COUNT(*) AS count FROM jobs WHERE user_id = ?`)
-		.bind(userId)
-		.first<{ count: number }>()
-	return Number(row?.count ?? 0)
+  const row = await db
+    .prepare(`SELECT COUNT(*) AS count FROM jobs WHERE user_id = ?`)
+    .bind(userId)
+    .first<{ count: number }>();
+  return Number(row?.count ?? 0);
 }
 
 /**
@@ -738,46 +738,57 @@ export async function countJobRowsForUser(
  * jobs database counts toward the D1 storage quota.
  */
 export async function sumJobRowsStorageBytesForUser(
-	db: D1Database,
-	userId: string,
+  db: D1Database,
+  userId: string,
 ): Promise<number> {
-	const columns = [
-		'name',
-		'params_json',
-		'schedule_json',
-		'timezone',
-		'caller_context_json',
-		'last_run_status',
-		'source_id',
-		'published_commit',
-		'storage_id',
-	]
-	const expression = columns
-		.map((column) => `length(CAST(COALESCE(${column}, '') AS BLOB))`)
-		.join(' + ')
-	const row = await db
-		.prepare(
-			`SELECT COALESCE(SUM(${expression}), 0) AS count
+  const columns = [
+    "name",
+    "params_json",
+    "schedule_json",
+    "timezone",
+    "caller_context_json",
+    "last_run_status",
+    "source_id",
+    "published_commit",
+    "storage_id",
+  ];
+  const expression = columns
+    .map((column) => `length(CAST(COALESCE(${column}, '') AS BLOB))`)
+    .join(" + ");
+  const row = await db
+    .prepare(
+      `SELECT COALESCE(SUM(${expression}), 0) AS count
 			FROM jobs
 			WHERE user_id = ?`,
-		)
-		.bind(userId)
-		.first<{ count: number }>()
-	return Number(row?.count ?? 0)
+    )
+    .bind(userId)
+    .first<{ count: number }>();
+  return Number(row?.count ?? 0);
+}
+
+export async function listJobIdRowsForUser(
+  db: D1Database,
+  userId: string,
+): Promise<Array<string>> {
+  const { results } = await db
+    .prepare(`SELECT id FROM jobs WHERE user_id = ? ORDER BY id ASC`)
+    .bind(userId)
+    .all<{ id: string }>();
+  return (results ?? []).map((row) => row.id);
 }
 
 export async function listJobStorageIdRowsForUser(
-	db: D1Database,
-	userId: string,
+  db: D1Database,
+  userId: string,
 ): Promise<Array<string>> {
-	const { results } = await db
-		.prepare(
-			`SELECT storage_id AS storageId FROM jobs
+  const { results } = await db
+    .prepare(
+      `SELECT storage_id AS storageId FROM jobs
 			WHERE user_id = ? AND storage_id IS NOT NULL`,
-		)
-		.bind(userId)
-		.all<{ storageId: string }>()
-	return (results ?? []).map((row) => row.storageId)
+    )
+    .bind(userId)
+    .all<{ storageId: string }>();
+  return (results ?? []).map((row) => row.storageId);
 }
 
 /**
@@ -785,25 +796,25 @@ export async function listJobStorageIdRowsForUser(
  * Operator-level DR inventory only — not for user-facing paths.
  */
 export async function listAllJobStorageOwnerRows(
-	db: D1Database,
+  db: D1Database,
 ): Promise<Array<{ userId: string; storageId: string }>> {
-	const { results } = await db
-		.prepare(
-			`SELECT user_id AS userId, storage_id AS storageId
+  const { results } = await db
+    .prepare(
+      `SELECT user_id AS userId, storage_id AS storageId
 			FROM jobs WHERE storage_id IS NOT NULL`,
-		)
-		.all<{ userId: string; storageId: string }>()
-	return results ?? []
+    )
+    .all<{ userId: string; storageId: string }>();
+  return results ?? [];
 }
 
 export async function getJobRowInsights(
-	db: D1Database,
+  db: D1Database,
 ): Promise<{ total: number; enabled: number }> {
-	const row = await db
-		.prepare(`SELECT COUNT(*) AS total, SUM(enabled) AS enabled FROM jobs`)
-		.first<{ total: number; enabled: number | null }>()
-	return {
-		total: Number(row?.total ?? 0),
-		enabled: Number(row?.enabled ?? 0),
-	}
+  const row = await db
+    .prepare(`SELECT COUNT(*) AS total, SUM(enabled) AS enabled FROM jobs`)
+    .first<{ total: number; enabled: number | null }>();
+  return {
+    total: Number(row?.total ?? 0),
+    enabled: Number(row?.enabled ?? 0),
+  };
 }

--- a/packages/shared/src/jobs/repo.ts
+++ b/packages/shared/src/jobs/repo.ts
@@ -1,229 +1,229 @@
-import { parseJsonWithFallback } from "../json-parsing.ts";
-import { createJobStorageId } from "./storage-id.ts";
-import { type JobRecord, type PersistedJobCallerContext } from "./types.ts";
+import { parseJsonWithFallback } from '../json-parsing.ts'
+import { createJobStorageId } from './storage-id.ts'
+import { type JobRecord, type PersistedJobCallerContext } from './types.ts'
 
 type JobRowRecord = {
-  id: string;
-  user_id: string;
-  name: string;
-  source_id: string;
-  published_commit: string | null;
-  repo_check_policy_json: string | null;
-  storage_id: string | null;
-  params_json: string | null;
-  schedule_json: string;
-  timezone: string;
-  enabled: number;
-  kill_switch_enabled: number;
-  preserved: number;
-  expires_at: string | null;
-  caller_context_json: string;
-  created_at: string;
-  updated_at: string;
-  last_run_at: string | null;
-  last_run_status: JobRecord["lastRunStatus"] | null;
-  next_run_at: string;
-  claim_token: string | null;
-  running_since: string | null;
-  lease_expires_at: string | null;
-  claimed_scheduled_for: string | null;
-  retry_scheduled_for: string | null;
-  retry_count: number;
-  last_completed_scheduled_for: string | null;
-};
+	id: string
+	user_id: string
+	name: string
+	source_id: string
+	published_commit: string | null
+	repo_check_policy_json: string | null
+	storage_id: string | null
+	params_json: string | null
+	schedule_json: string
+	timezone: string
+	enabled: number
+	kill_switch_enabled: number
+	preserved: number
+	expires_at: string | null
+	caller_context_json: string
+	created_at: string
+	updated_at: string
+	last_run_at: string | null
+	last_run_status: JobRecord['lastRunStatus'] | null
+	next_run_at: string
+	claim_token: string | null
+	running_since: string | null
+	lease_expires_at: string | null
+	claimed_scheduled_for: string | null
+	retry_scheduled_for: string | null
+	retry_count: number
+	last_completed_scheduled_for: string | null
+}
 
 export type JobRow = JobRowRecord & {
-  record: JobRecord;
-  callerContextJson: string;
-  callerContext: PersistedJobCallerContext | null;
-  schedulerWakeAt: string;
-};
+	record: JobRecord
+	callerContextJson: string
+	callerContext: PersistedJobCallerContext | null
+	schedulerWakeAt: string
+}
 
 function serializeJob(job: JobRecord) {
-  return {
-    id: job.id,
-    name: job.name,
-    source_id: job.sourceId,
-    published_commit: job.publishedCommit ?? null,
-    repo_check_policy_json: job.repoCheckPolicy
-      ? JSON.stringify(job.repoCheckPolicy)
-      : null,
-    storage_id: job.storageId,
-    params_json: job.params ? JSON.stringify(job.params) : null,
-    schedule_json: JSON.stringify(job.schedule),
-    timezone: job.timezone,
-    enabled: job.enabled ? 1 : 0,
-    kill_switch_enabled: job.killSwitchEnabled ? 1 : 0,
-    preserved: job.preserved ? 1 : 0,
-    expires_at: job.expiresAt ?? null,
-    created_at: job.createdAt,
-    updated_at: job.updatedAt,
-    last_run_at: job.lastRunAt ?? null,
-    last_run_status: job.lastRunStatus ?? null,
-    next_run_at: job.nextRunAt,
-  };
+	return {
+		id: job.id,
+		name: job.name,
+		source_id: job.sourceId,
+		published_commit: job.publishedCommit ?? null,
+		repo_check_policy_json: job.repoCheckPolicy
+			? JSON.stringify(job.repoCheckPolicy)
+			: null,
+		storage_id: job.storageId,
+		params_json: job.params ? JSON.stringify(job.params) : null,
+		schedule_json: JSON.stringify(job.schedule),
+		timezone: job.timezone,
+		enabled: job.enabled ? 1 : 0,
+		kill_switch_enabled: job.killSwitchEnabled ? 1 : 0,
+		preserved: job.preserved ? 1 : 0,
+		expires_at: job.expiresAt ?? null,
+		created_at: job.createdAt,
+		updated_at: job.updatedAt,
+		last_run_at: job.lastRunAt ?? null,
+		last_run_status: job.lastRunStatus ?? null,
+		next_run_at: job.nextRunAt,
+	}
 }
 
 function mapRow(row: Record<string, unknown>): JobRow {
-  const jobId = String(row["id"]);
-  const rawStorageId = row["storage_id"];
-  const storageId =
-    rawStorageId == null ? createJobStorageId(jobId) : String(rawStorageId);
-  const record: JobRecord = {
-    version: 1,
-    id: jobId,
-    userId: String(row["user_id"]),
-    name: String(row["name"]),
-    sourceId: String(row["source_id"]),
-    publishedCommit:
-      row["published_commit"] == null ? null : String(row["published_commit"]),
-    repoCheckPolicy: parseJsonWithFallback<
-      JobRecord["repoCheckPolicy"] | undefined
-    >(
-      row["repo_check_policy_json"] == null
-        ? null
-        : String(row["repo_check_policy_json"]),
-      undefined,
-    ),
-    storageId,
-    params: parseJsonWithFallback<Record<string, unknown> | undefined>(
-      row["params_json"] == null ? null : String(row["params_json"]),
-      undefined,
-    ),
-    schedule: parseJsonWithFallback<JobRecord["schedule"]>(
-      String(row["schedule_json"]),
-      {
-        type: "once",
-        runAt: String(row["next_run_at"]),
-      },
-    ),
-    timezone: String(row["timezone"]),
-    enabled: Number(row["enabled"]) === 1,
-    killSwitchEnabled: Number(row["kill_switch_enabled"]) === 1,
-    preserved: Number(row["preserved"] ?? 0) === 1,
-    expiresAt: row["expires_at"] == null ? null : String(row["expires_at"]),
-    createdAt: String(row["created_at"]),
-    updatedAt: String(row["updated_at"]),
-    lastRunAt:
-      row["last_run_at"] == null ? undefined : String(row["last_run_at"]),
-    lastRunStatus:
-      row["last_run_status"] == null
-        ? undefined
-        : (String(row["last_run_status"]) as JobRecord["lastRunStatus"]),
-    lastRunError: undefined,
-    lastDurationMs: undefined,
-    nextRunAt: String(row["next_run_at"]),
-    runCount: 0,
-    successCount: 0,
-    errorCount: 0,
-  };
-  return {
-    id: record.id,
-    user_id: String(row["user_id"]),
-    name: record.name,
-    source_id: record.sourceId,
-    published_commit: record.publishedCommit ?? null,
-    repo_check_policy_json:
-      row["repo_check_policy_json"] == null
-        ? null
-        : String(row["repo_check_policy_json"]),
-    storage_id: record.storageId,
-    params_json: row["params_json"] == null ? null : String(row["params_json"]),
-    schedule_json: String(row["schedule_json"]),
-    timezone: record.timezone,
-    enabled: record.enabled ? 1 : 0,
-    kill_switch_enabled: record.killSwitchEnabled ? 1 : 0,
-    preserved: record.preserved ? 1 : 0,
-    expires_at: record.expiresAt,
-    caller_context_json: String(row["caller_context_json"]),
-    created_at: record.createdAt,
-    updated_at: record.updatedAt,
-    last_run_at: record.lastRunAt ?? null,
-    last_run_status: record.lastRunStatus ?? null,
-    next_run_at: record.nextRunAt,
-    claim_token: row["claim_token"] == null ? null : String(row["claim_token"]),
-    running_since:
-      row["running_since"] == null ? null : String(row["running_since"]),
-    lease_expires_at:
-      row["lease_expires_at"] == null ? null : String(row["lease_expires_at"]),
-    claimed_scheduled_for:
-      row["claimed_scheduled_for"] == null
-        ? null
-        : String(row["claimed_scheduled_for"]),
-    retry_scheduled_for:
-      row["retry_scheduled_for"] == null
-        ? null
-        : String(row["retry_scheduled_for"]),
-    retry_count: Number(row["retry_count"]) || 0,
-    last_completed_scheduled_for:
-      row["last_completed_scheduled_for"] == null
-        ? null
-        : String(row["last_completed_scheduled_for"]),
-    record,
-    callerContextJson: String(row["caller_context_json"]),
-    callerContext: parseJsonWithFallback<PersistedJobCallerContext | null>(
-      row["caller_context_json"] == null
-        ? null
-        : String(row["caller_context_json"]),
-      null,
-    ),
-    schedulerWakeAt:
-      row["scheduler_wake_at"] == null
-        ? record.nextRunAt
-        : String(row["scheduler_wake_at"]),
-  };
+	const jobId = String(row['id'])
+	const rawStorageId = row['storage_id']
+	const storageId =
+		rawStorageId == null ? createJobStorageId(jobId) : String(rawStorageId)
+	const record: JobRecord = {
+		version: 1,
+		id: jobId,
+		userId: String(row['user_id']),
+		name: String(row['name']),
+		sourceId: String(row['source_id']),
+		publishedCommit:
+			row['published_commit'] == null ? null : String(row['published_commit']),
+		repoCheckPolicy: parseJsonWithFallback<
+			JobRecord['repoCheckPolicy'] | undefined
+		>(
+			row['repo_check_policy_json'] == null
+				? null
+				: String(row['repo_check_policy_json']),
+			undefined,
+		),
+		storageId,
+		params: parseJsonWithFallback<Record<string, unknown> | undefined>(
+			row['params_json'] == null ? null : String(row['params_json']),
+			undefined,
+		),
+		schedule: parseJsonWithFallback<JobRecord['schedule']>(
+			String(row['schedule_json']),
+			{
+				type: 'once',
+				runAt: String(row['next_run_at']),
+			},
+		),
+		timezone: String(row['timezone']),
+		enabled: Number(row['enabled']) === 1,
+		killSwitchEnabled: Number(row['kill_switch_enabled']) === 1,
+		preserved: Number(row['preserved'] ?? 0) === 1,
+		expiresAt: row['expires_at'] == null ? null : String(row['expires_at']),
+		createdAt: String(row['created_at']),
+		updatedAt: String(row['updated_at']),
+		lastRunAt:
+			row['last_run_at'] == null ? undefined : String(row['last_run_at']),
+		lastRunStatus:
+			row['last_run_status'] == null
+				? undefined
+				: (String(row['last_run_status']) as JobRecord['lastRunStatus']),
+		lastRunError: undefined,
+		lastDurationMs: undefined,
+		nextRunAt: String(row['next_run_at']),
+		runCount: 0,
+		successCount: 0,
+		errorCount: 0,
+	}
+	return {
+		id: record.id,
+		user_id: String(row['user_id']),
+		name: record.name,
+		source_id: record.sourceId,
+		published_commit: record.publishedCommit ?? null,
+		repo_check_policy_json:
+			row['repo_check_policy_json'] == null
+				? null
+				: String(row['repo_check_policy_json']),
+		storage_id: record.storageId,
+		params_json: row['params_json'] == null ? null : String(row['params_json']),
+		schedule_json: String(row['schedule_json']),
+		timezone: record.timezone,
+		enabled: record.enabled ? 1 : 0,
+		kill_switch_enabled: record.killSwitchEnabled ? 1 : 0,
+		preserved: record.preserved ? 1 : 0,
+		expires_at: record.expiresAt,
+		caller_context_json: String(row['caller_context_json']),
+		created_at: record.createdAt,
+		updated_at: record.updatedAt,
+		last_run_at: record.lastRunAt ?? null,
+		last_run_status: record.lastRunStatus ?? null,
+		next_run_at: record.nextRunAt,
+		claim_token: row['claim_token'] == null ? null : String(row['claim_token']),
+		running_since:
+			row['running_since'] == null ? null : String(row['running_since']),
+		lease_expires_at:
+			row['lease_expires_at'] == null ? null : String(row['lease_expires_at']),
+		claimed_scheduled_for:
+			row['claimed_scheduled_for'] == null
+				? null
+				: String(row['claimed_scheduled_for']),
+		retry_scheduled_for:
+			row['retry_scheduled_for'] == null
+				? null
+				: String(row['retry_scheduled_for']),
+		retry_count: Number(row['retry_count']) || 0,
+		last_completed_scheduled_for:
+			row['last_completed_scheduled_for'] == null
+				? null
+				: String(row['last_completed_scheduled_for']),
+		record,
+		callerContextJson: String(row['caller_context_json']),
+		callerContext: parseJsonWithFallback<PersistedJobCallerContext | null>(
+			row['caller_context_json'] == null
+				? null
+				: String(row['caller_context_json']),
+			null,
+		),
+		schedulerWakeAt:
+			row['scheduler_wake_at'] == null
+				? record.nextRunAt
+				: String(row['scheduler_wake_at']),
+	}
 }
 
 export async function insertJobRow(input: {
-  db: D1Database;
-  userId: string;
-  job: JobRecord;
-  callerContextJson: string;
+	db: D1Database
+	userId: string
+	job: JobRecord
+	callerContextJson: string
 }) {
-  const serialized = serializeJob(input.job);
-  await input.db
-    .prepare(
-      `INSERT INTO jobs (
+	const serialized = serializeJob(input.job)
+	await input.db
+		.prepare(
+			`INSERT INTO jobs (
 				id, user_id, name, source_id, published_commit, repo_check_policy_json, storage_id, params_json, schedule_json, timezone, enabled,
 				kill_switch_enabled, preserved, expires_at, caller_context_json, created_at, updated_at,
 				last_run_at, last_run_status, next_run_at
 			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-    )
-    .bind(
-      serialized.id,
-      input.userId,
-      serialized.name,
-      serialized.source_id,
-      serialized.published_commit,
-      serialized.repo_check_policy_json,
-      serialized.storage_id,
-      serialized.params_json,
-      serialized.schedule_json,
-      serialized.timezone,
-      serialized.enabled,
-      serialized.kill_switch_enabled,
-      serialized.preserved,
-      serialized.expires_at,
-      input.callerContextJson,
-      serialized.created_at,
-      serialized.updated_at,
-      serialized.last_run_at,
-      serialized.last_run_status,
-      serialized.next_run_at,
-    )
-    .run();
+		)
+		.bind(
+			serialized.id,
+			input.userId,
+			serialized.name,
+			serialized.source_id,
+			serialized.published_commit,
+			serialized.repo_check_policy_json,
+			serialized.storage_id,
+			serialized.params_json,
+			serialized.schedule_json,
+			serialized.timezone,
+			serialized.enabled,
+			serialized.kill_switch_enabled,
+			serialized.preserved,
+			serialized.expires_at,
+			input.callerContextJson,
+			serialized.created_at,
+			serialized.updated_at,
+			serialized.last_run_at,
+			serialized.last_run_status,
+			serialized.next_run_at,
+		)
+		.run()
 }
 
 export async function updateJobRow(input: {
-  db: D1Database;
-  userId: string;
-  job: JobRecord;
-  callerContextJson: string;
+	db: D1Database
+	userId: string
+	job: JobRecord
+	callerContextJson: string
 }) {
-  const serialized = serializeJob(input.job);
-  const result = await input.db
-    .prepare(
-      `UPDATE jobs SET
+	const serialized = serializeJob(input.job)
+	const result = await input.db
+		.prepare(
+			`UPDATE jobs SET
 				name = ?, source_id = ?, published_commit = ?, repo_check_policy_json = ?, storage_id = ?, params_json = ?, schedule_json = ?, timezone = ?,
 				enabled = ?, kill_switch_enabled = ?, preserved = ?, expires_at = ?, caller_context_json = ?, updated_at = ?,
 				last_run_at = ?, last_run_status = ?,
@@ -232,55 +232,55 @@ export async function updateJobRow(input: {
 				claimed_scheduled_for = NULL, retry_scheduled_for = NULL,
 				retry_count = 0
 			WHERE id = ? AND user_id = ?`,
-    )
-    .bind(
-      serialized.name,
-      serialized.source_id,
-      serialized.published_commit,
-      serialized.repo_check_policy_json,
-      serialized.storage_id,
-      serialized.params_json,
-      serialized.schedule_json,
-      serialized.timezone,
-      serialized.enabled,
-      serialized.kill_switch_enabled,
-      serialized.preserved,
-      serialized.expires_at,
-      input.callerContextJson,
-      serialized.updated_at,
-      serialized.last_run_at,
-      serialized.last_run_status,
-      serialized.next_run_at,
-      serialized.id,
-      input.userId,
-    )
-    .run();
-  return (result.meta.changes ?? 0) > 0;
+		)
+		.bind(
+			serialized.name,
+			serialized.source_id,
+			serialized.published_commit,
+			serialized.repo_check_policy_json,
+			serialized.storage_id,
+			serialized.params_json,
+			serialized.schedule_json,
+			serialized.timezone,
+			serialized.enabled,
+			serialized.kill_switch_enabled,
+			serialized.preserved,
+			serialized.expires_at,
+			input.callerContextJson,
+			serialized.updated_at,
+			serialized.last_run_at,
+			serialized.last_run_status,
+			serialized.next_run_at,
+			serialized.id,
+			input.userId,
+		)
+		.run()
+	return (result.meta.changes ?? 0) > 0
 }
 
 export async function getJobRowById(
-  db: D1Database,
-  userId: string,
-  jobId: string,
+	db: D1Database,
+	userId: string,
+	jobId: string,
 ): Promise<JobRow | null> {
-  const result = await db
-    .prepare(`SELECT * FROM jobs WHERE id = ? AND user_id = ?`)
-    .bind(jobId, userId)
-    .first<Record<string, unknown>>();
-  return result ? mapRow(result) : null;
+	const result = await db
+		.prepare(`SELECT * FROM jobs WHERE id = ? AND user_id = ?`)
+		.bind(jobId, userId)
+		.first<Record<string, unknown>>()
+	return result ? mapRow(result) : null
 }
 
 export async function listJobRowsByUserId(
-  db: D1Database,
-  userId: string,
+	db: D1Database,
+	userId: string,
 ): Promise<Array<JobRow>> {
-  const { results } = await db
-    .prepare(
-      `SELECT * FROM jobs WHERE user_id = ? ORDER BY next_run_at ASC, name ASC`,
-    )
-    .bind(userId)
-    .all<Record<string, unknown>>();
-  return (results ?? []).map(mapRow);
+	const { results } = await db
+		.prepare(
+			`SELECT * FROM jobs WHERE user_id = ? ORDER BY next_run_at ASC, name ASC`,
+		)
+		.bind(userId)
+		.all<Record<string, unknown>>()
+	return (results ?? []).map(mapRow)
 }
 
 /**
@@ -289,33 +289,33 @@ export async function listJobRowsByUserId(
  * post-run alarm resync schedules a near-immediate follow-up wake whenever
  * more due jobs remain, so backlogs drain across successive alarms.
  */
-export const maxDueJobsPerAlarm = 25;
+export const maxDueJobsPerAlarm = 25
 
 // Keyset-paged listing across all users, used by maintenance reindex so a
 // single query never loads the whole table. Pass the last row id of the
 // previous page (or null for the first page).
 export async function listJobRowsPage(
-  db: D1Database,
-  input: {
-    afterId: string | null;
-    limit: number;
-  },
+	db: D1Database,
+	input: {
+		afterId: string | null
+		limit: number
+	},
 ): Promise<Array<JobRow>> {
-  const { results } = await db
-    .prepare(`SELECT * FROM jobs WHERE id > ? ORDER BY id LIMIT ?`)
-    .bind(input.afterId ?? "", input.limit)
-    .all<Record<string, unknown>>();
-  return (results ?? []).map(mapRow);
+	const { results } = await db
+		.prepare(`SELECT * FROM jobs WHERE id > ? ORDER BY id LIMIT ?`)
+		.bind(input.afterId ?? '', input.limit)
+		.all<Record<string, unknown>>()
+	return (results ?? []).map(mapRow)
 }
 
 export async function listDueJobRows(
-  db: D1Database,
-  userId: string,
-  nowIso: string,
+	db: D1Database,
+	userId: string,
+	nowIso: string,
 ): Promise<Array<JobRow>> {
-  const { results } = await db
-    .prepare(
-      `SELECT * FROM jobs
+	const { results } = await db
+		.prepare(
+			`SELECT * FROM jobs
 			WHERE user_id = ?
 				AND enabled = 1
 				AND kill_switch_enabled = 0
@@ -332,10 +332,10 @@ export async function listDueJobRows(
 				)
 			ORDER BY next_run_at ASC, name ASC
 			LIMIT ?`,
-    )
-    .bind(userId, nowIso, nowIso, nowIso, maxDueJobsPerAlarm)
-    .all<Record<string, unknown>>();
-  return (results ?? []).map(mapRow);
+		)
+		.bind(userId, nowIso, nowIso, nowIso, maxDueJobsPerAlarm)
+		.all<Record<string, unknown>>()
+	return (results ?? []).map(mapRow)
 }
 
 /**
@@ -345,17 +345,17 @@ export async function listDueJobRows(
  * lost or drifted while due work remained claimable.
  */
 export async function listSilentlyOverdueJobRowsPage(
-  db: D1Database,
-  input: {
-    overdueBeforeIso: string;
-    nowIso: string;
-    afterId: string | null;
-    limit: number;
-  },
+	db: D1Database,
+	input: {
+		overdueBeforeIso: string
+		nowIso: string
+		afterId: string | null
+		limit: number
+	},
 ): Promise<Array<JobRow>> {
-  const { results } = await db
-    .prepare(
-      `SELECT * FROM jobs
+	const { results } = await db
+		.prepare(
+			`SELECT * FROM jobs
 			WHERE id > ?
 				AND enabled = 1
 				AND kill_switch_enabled = 0
@@ -372,16 +372,16 @@ export async function listSilentlyOverdueJobRowsPage(
 				)
 			ORDER BY id ASC
 			LIMIT ?`,
-    )
-    .bind(
-      input.afterId ?? "",
-      input.nowIso,
-      input.overdueBeforeIso,
-      input.nowIso,
-      input.limit,
-    )
-    .all<Record<string, unknown>>();
-  return (results ?? []).map(mapRow);
+		)
+		.bind(
+			input.afterId ?? '',
+			input.nowIso,
+			input.overdueBeforeIso,
+			input.nowIso,
+			input.limit,
+		)
+		.all<Record<string, unknown>>()
+	return (results ?? []).map(mapRow)
 }
 
 /**
@@ -390,16 +390,16 @@ export async function listSilentlyOverdueJobRowsPage(
  * due selection and claims never pick them up again until next_run_at moves.
  */
 export async function listStuckSkippedJobRowsPage(
-  db: D1Database,
-  input: {
-    nowIso: string;
-    afterId: string | null;
-    limit: number;
-  },
+	db: D1Database,
+	input: {
+		nowIso: string
+		afterId: string | null
+		limit: number
+	},
 ): Promise<Array<JobRow>> {
-  const { results } = await db
-    .prepare(
-      `SELECT * FROM jobs
+	const { results } = await db
+		.prepare(
+			`SELECT * FROM jobs
 			WHERE id > ?
 				AND enabled = 1
 				AND kill_switch_enabled = 0
@@ -409,22 +409,22 @@ export async function listStuckSkippedJobRowsPage(
 				AND last_completed_scheduled_for = COALESCE(retry_scheduled_for, next_run_at)
 			ORDER BY id ASC
 			LIMIT ?`,
-    )
-    .bind(input.afterId ?? "", input.nowIso, input.limit)
-    .all<Record<string, unknown>>();
-  return (results ?? []).map(mapRow);
+		)
+		.bind(input.afterId ?? '', input.nowIso, input.limit)
+		.all<Record<string, unknown>>()
+	return (results ?? []).map(mapRow)
 }
 
 export async function advanceStuckSkippedJobNextRunAt(input: {
-  db: D1Database;
-  userId: string;
-  jobId: string;
-  nextRunAt: string;
-  updatedAt: string;
+	db: D1Database
+	userId: string
+	jobId: string
+	nextRunAt: string
+	updatedAt: string
 }): Promise<boolean> {
-  const result = await input.db
-    .prepare(
-      `UPDATE jobs SET
+	const result = await input.db
+		.prepare(
+			`UPDATE jobs SET
 				next_run_at = ?,
 				updated_at = ?,
 				retry_scheduled_for = NULL,
@@ -436,26 +436,26 @@ export async function advanceStuckSkippedJobNextRunAt(input: {
 				AND last_completed_scheduled_for IS NOT NULL
 				AND last_completed_scheduled_for = COALESCE(retry_scheduled_for, next_run_at)
 				AND next_run_at != ?`,
-    )
-    .bind(
-      input.nextRunAt,
-      input.updatedAt,
-      input.jobId,
-      input.userId,
-      input.nextRunAt,
-    )
-    .run();
-  return (result.meta.changes ?? 0) > 0;
+		)
+		.bind(
+			input.nextRunAt,
+			input.updatedAt,
+			input.jobId,
+			input.userId,
+			input.nextRunAt,
+		)
+		.run()
+	return (result.meta.changes ?? 0) > 0
 }
 
 export async function getNextRunnableJobRow(
-  db: D1Database,
-  userId: string,
-  nowIso = new Date().toISOString(),
+	db: D1Database,
+	userId: string,
+	nowIso = new Date().toISOString(),
 ): Promise<JobRow | null> {
-  const result = await db
-    .prepare(
-      `SELECT jobs.*,
+	const result = await db
+		.prepare(
+			`SELECT jobs.*,
 				CASE
 					WHEN claim_token IS NOT NULL
 						AND lease_expires_at IS NOT NULL
@@ -477,10 +477,10 @@ export async function getNextRunnableJobRow(
 				)
 			ORDER BY scheduler_wake_at ASC, name ASC
 			LIMIT 1`,
-    )
-    .bind(nowIso, userId, nowIso)
-    .first<Record<string, unknown>>();
-  return result ? mapRow(result) : null;
+		)
+		.bind(nowIso, userId, nowIso)
+		.first<Record<string, unknown>>()
+	return result ? mapRow(result) : null
 }
 
 /**
@@ -488,22 +488,22 @@ export async function getNextRunnableJobRow(
  * sandbox's default 90-second maximum runtime. A single conditional D1 write
  * is the ownership boundary; reading due rows alone never grants ownership.
  */
-export const jobExecutionLeaseMs = 10 * 60 * 1_000;
+export const jobExecutionLeaseMs = 10 * 60 * 1_000
 
 export async function claimJobRow(input: {
-  db: D1Database;
-  userId: string;
-  jobId: string;
-  now: Date;
-  claimToken: string;
+	db: D1Database
+	userId: string
+	jobId: string
+	now: Date
+	claimToken: string
 }): Promise<JobRow | null> {
-  const nowIso = input.now.toISOString();
-  const leaseExpiresAt = new Date(
-    input.now.valueOf() + jobExecutionLeaseMs,
-  ).toISOString();
-  const result = await input.db
-    .prepare(
-      `UPDATE jobs SET
+	const nowIso = input.now.toISOString()
+	const leaseExpiresAt = new Date(
+		input.now.valueOf() + jobExecutionLeaseMs,
+	).toISOString()
+	const result = await input.db
+		.prepare(
+			`UPDATE jobs SET
 				claim_token = ?,
 				running_since = ?,
 				lease_expires_at = ?,
@@ -524,64 +524,64 @@ export async function claimJobRow(input: {
 					OR last_completed_scheduled_for != COALESCE(retry_scheduled_for, next_run_at)
 				)
 			RETURNING *`,
-    )
-    .bind(
-      input.claimToken,
-      nowIso,
-      leaseExpiresAt,
-      input.jobId,
-      input.userId,
-      nowIso,
-      nowIso,
-      nowIso,
-    )
-    .first<Record<string, unknown>>();
-  return result ? mapRow(result) : null;
+		)
+		.bind(
+			input.claimToken,
+			nowIso,
+			leaseExpiresAt,
+			input.jobId,
+			input.userId,
+			nowIso,
+			nowIso,
+			nowIso,
+		)
+		.first<Record<string, unknown>>()
+	return result ? mapRow(result) : null
 }
 
 export async function finalizeClaimedJobRow(input: {
-  db: D1Database;
-  userId: string;
-  job: JobRecord;
-  claimToken: string;
-  scheduledFor: string;
+	db: D1Database
+	userId: string
+	job: JobRecord
+	claimToken: string
+	scheduledFor: string
 }): Promise<boolean> {
-  const serialized = serializeJob(input.job);
-  const result = await input.db
-    .prepare(
-      `UPDATE jobs SET
+	const serialized = serializeJob(input.job)
+	const result = await input.db
+		.prepare(
+			`UPDATE jobs SET
 				enabled = ?, updated_at = ?, last_run_at = ?, last_run_status = ?,
 				next_run_at = ?,
 				claim_token = NULL, running_since = NULL, lease_expires_at = NULL,
 				claimed_scheduled_for = NULL, retry_scheduled_for = NULL,
 				retry_count = 0, last_completed_scheduled_for = ?
 			WHERE id = ? AND user_id = ? AND claim_token = ?`,
-    )
-    .bind(
-      serialized.enabled,
-      serialized.updated_at,
-      serialized.last_run_at,
-      serialized.last_run_status,
-      serialized.next_run_at,
-      input.scheduledFor,
-      serialized.id,
-      input.userId,
-      input.claimToken,
-    )
-    .run();
-  return (result.meta.changes ?? 0) > 0;
+		)
+		.bind(
+			serialized.enabled,
+			serialized.updated_at,
+			serialized.last_run_at,
+			serialized.last_run_status,
+			serialized.next_run_at,
+			input.scheduledFor,
+			serialized.id,
+			input.userId,
+			input.claimToken,
+		)
+		.run()
+	return (result.meta.changes ?? 0) > 0
 }
 
 export async function retryClaimedJobRow(input: {
-  db: D1Database;
-  userId: string;
-  jobId: string;
-  claimToken: string;
-  nextRunAt: string;
+	db: D1Database
+	userId: string
+	jobId: string
+	claimToken: string
+	nextRunAt: string
 }): Promise<boolean> {
-  const result = await input.db
-    .prepare(
-      `UPDATE jobs SET
+	const result = await input.db
+		.prepare(
+			`UPDATE jobs SET
 				next_run_at = ?,
 				updated_at = ?,
 				retry_scheduled_for = claimed_scheduled_for,
@@ -591,16 +591,16 @@ export async function retryClaimedJobRow(input: {
 				lease_expires_at = NULL,
 				claimed_scheduled_for = NULL
 			WHERE id = ? AND user_id = ? AND claim_token = ?`,
-    )
-    .bind(
-      input.nextRunAt,
-      new Date().toISOString(),
-      input.jobId,
-      input.userId,
-      input.claimToken,
-    )
-    .run();
-  return (result.meta.changes ?? 0) > 0;
+		)
+		.bind(
+			input.nextRunAt,
+			new Date().toISOString(),
+			input.jobId,
+			input.userId,
+			input.claimToken,
+		)
+		.run()
+	return (result.meta.changes ?? 0) > 0
 }
 
 /**
@@ -608,42 +608,42 @@ export async function retryClaimedJobRow(input: {
  * scheduler claim or recomputing the next occurrence.
  */
 export async function refreshPackageJobRowIdentity(input: {
-  db: D1Database;
-  userId: string;
-  jobId: string;
-  sourceId: string;
-  publishedCommit: string | null;
-  callerContextJson: string;
-  updatedAt: string;
+	db: D1Database
+	userId: string
+	jobId: string
+	sourceId: string
+	publishedCommit: string | null
+	callerContextJson: string
+	updatedAt: string
 }) {
-  const result = await input.db
-    .prepare(
-      `UPDATE jobs SET
+	const result = await input.db
+		.prepare(
+			`UPDATE jobs SET
 				source_id = ?, published_commit = ?, caller_context_json = ?, updated_at = ?
 			WHERE id = ? AND user_id = ?`,
-    )
-    .bind(
-      input.sourceId,
-      input.publishedCommit,
-      input.callerContextJson,
-      input.updatedAt,
-      input.jobId,
-      input.userId,
-    )
-    .run();
-  return (result.meta.changes ?? 0) > 0;
+		)
+		.bind(
+			input.sourceId,
+			input.publishedCommit,
+			input.callerContextJson,
+			input.updatedAt,
+			input.jobId,
+			input.userId,
+		)
+		.run()
+	return (result.meta.changes ?? 0) > 0
 }
 
 export async function deleteJobRow(
-  db: D1Database,
-  userId: string,
-  jobId: string,
+	db: D1Database,
+	userId: string,
+	jobId: string,
 ): Promise<boolean> {
-  const result = await db
-    .prepare(`DELETE FROM jobs WHERE id = ? AND user_id = ?`)
-    .bind(jobId, userId)
-    .run();
-  return (result.meta.changes ?? 0) > 0;
+	const result = await db
+		.prepare(`DELETE FROM jobs WHERE id = ? AND user_id = ?`)
+		.bind(jobId, userId)
+		.run()
+	return (result.meta.changes ?? 0) > 0
 }
 
 /**
@@ -652,23 +652,23 @@ export async function deleteJobRow(
  * `preserved`. Returns the number of rows flipped to enabled = 0.
  */
 export async function disableExpiredJobRowsForUser(input: {
-  db: D1Database;
-  userId: string;
-  nowIso: string;
+	db: D1Database
+	userId: string
+	nowIso: string
 }): Promise<number> {
-  const result = await input.db
-    .prepare(
-      `UPDATE jobs SET
+	const result = await input.db
+		.prepare(
+			`UPDATE jobs SET
 				enabled = 0,
 				updated_at = ?
 			WHERE user_id = ?
 				AND enabled = 1
 				AND expires_at IS NOT NULL
 				AND expires_at <= ?`,
-    )
-    .bind(input.nowIso, input.userId, input.nowIso)
-    .run();
-  return result.meta.changes ?? 0;
+		)
+		.bind(input.nowIso, input.userId, input.nowIso)
+		.run()
+	return result.meta.changes ?? 0
 }
 
 /**
@@ -676,7 +676,7 @@ export async function disableExpiredJobRowsForUser(input: {
  * backlog cannot exhaust the Worker CPU budget. Remaining candidates are
  * picked up on subsequent hourly runs.
  */
-export const maxJobRetentionCandidatesPerRun = 100;
+export const maxJobRetentionCandidatesPerRun = 100
 
 /**
  * Candidate scan for the platform job retention sweeper. Excludes preserved,
@@ -689,15 +689,15 @@ export const maxJobRetentionCandidatesPerRun = 100;
  * deletes shrink that set across hourly ticks.
  */
 export async function listJobRetentionCandidateRows(
-  db: D1Database,
-  input: {
-    afterId: string | null;
-    limit: number;
-  },
+	db: D1Database,
+	input: {
+		afterId: string | null
+		limit: number
+	},
 ): Promise<Array<JobRow>> {
-  const { results } = await db
-    .prepare(
-      `SELECT * FROM jobs
+	const { results } = await db
+		.prepare(
+			`SELECT * FROM jobs
 			WHERE preserved = 0
 				AND id NOT LIKE 'package-job:%'
 				AND id > ?
@@ -715,21 +715,21 @@ export async function listJobRetentionCandidateRows(
 				)
 			ORDER BY id ASC
 			LIMIT ?`,
-    )
-    .bind(input.afterId ?? "", input.limit)
-    .all<Record<string, unknown>>();
-  return (results ?? []).map(mapRow);
+		)
+		.bind(input.afterId ?? '', input.limit)
+		.all<Record<string, unknown>>()
+	return (results ?? []).map(mapRow)
 }
 
 export async function countJobRowsForUser(
-  db: D1Database,
-  userId: string,
+	db: D1Database,
+	userId: string,
 ): Promise<number> {
-  const row = await db
-    .prepare(`SELECT COUNT(*) AS count FROM jobs WHERE user_id = ?`)
-    .bind(userId)
-    .first<{ count: number }>();
-  return Number(row?.count ?? 0);
+	const row = await db
+		.prepare(`SELECT COUNT(*) AS count FROM jobs WHERE user_id = ?`)
+		.bind(userId)
+		.first<{ count: number }>()
+	return Number(row?.count ?? 0)
 }
 
 /**
@@ -738,57 +738,57 @@ export async function countJobRowsForUser(
  * jobs database counts toward the D1 storage quota.
  */
 export async function sumJobRowsStorageBytesForUser(
-  db: D1Database,
-  userId: string,
+	db: D1Database,
+	userId: string,
 ): Promise<number> {
-  const columns = [
-    "name",
-    "params_json",
-    "schedule_json",
-    "timezone",
-    "caller_context_json",
-    "last_run_status",
-    "source_id",
-    "published_commit",
-    "storage_id",
-  ];
-  const expression = columns
-    .map((column) => `length(CAST(COALESCE(${column}, '') AS BLOB))`)
-    .join(" + ");
-  const row = await db
-    .prepare(
-      `SELECT COALESCE(SUM(${expression}), 0) AS count
+	const columns = [
+		'name',
+		'params_json',
+		'schedule_json',
+		'timezone',
+		'caller_context_json',
+		'last_run_status',
+		'source_id',
+		'published_commit',
+		'storage_id',
+	]
+	const expression = columns
+		.map((column) => `length(CAST(COALESCE(${column}, '') AS BLOB))`)
+		.join(' + ')
+	const row = await db
+		.prepare(
+			`SELECT COALESCE(SUM(${expression}), 0) AS count
 			FROM jobs
 			WHERE user_id = ?`,
-    )
-    .bind(userId)
-    .first<{ count: number }>();
-  return Number(row?.count ?? 0);
+		)
+		.bind(userId)
+		.first<{ count: number }>()
+	return Number(row?.count ?? 0)
 }
 
 export async function listJobIdRowsForUser(
-  db: D1Database,
-  userId: string,
+	db: D1Database,
+	userId: string,
 ): Promise<Array<string>> {
-  const { results } = await db
-    .prepare(`SELECT id FROM jobs WHERE user_id = ? ORDER BY id ASC`)
-    .bind(userId)
-    .all<{ id: string }>();
-  return (results ?? []).map((row) => row.id);
+	const { results } = await db
+		.prepare(`SELECT id FROM jobs WHERE user_id = ? ORDER BY id ASC`)
+		.bind(userId)
+		.all<{ id: string }>()
+	return (results ?? []).map((row) => row.id)
 }
 
 export async function listJobStorageIdRowsForUser(
-  db: D1Database,
-  userId: string,
+	db: D1Database,
+	userId: string,
 ): Promise<Array<string>> {
-  const { results } = await db
-    .prepare(
-      `SELECT storage_id AS storageId FROM jobs
+	const { results } = await db
+		.prepare(
+			`SELECT storage_id AS storageId FROM jobs
 			WHERE user_id = ? AND storage_id IS NOT NULL`,
-    )
-    .bind(userId)
-    .all<{ storageId: string }>();
-  return (results ?? []).map((row) => row.storageId);
+		)
+		.bind(userId)
+		.all<{ storageId: string }>()
+	return (results ?? []).map((row) => row.storageId)
 }
 
 /**
@@ -796,25 +796,25 @@ export async function listJobStorageIdRowsForUser(
  * Operator-level DR inventory only — not for user-facing paths.
  */
 export async function listAllJobStorageOwnerRows(
-  db: D1Database,
+	db: D1Database,
 ): Promise<Array<{ userId: string; storageId: string }>> {
-  const { results } = await db
-    .prepare(
-      `SELECT user_id AS userId, storage_id AS storageId
+	const { results } = await db
+		.prepare(
+			`SELECT user_id AS userId, storage_id AS storageId
 			FROM jobs WHERE storage_id IS NOT NULL`,
-    )
-    .all<{ userId: string; storageId: string }>();
-  return results ?? [];
+		)
+		.all<{ userId: string; storageId: string }>()
+	return results ?? []
 }
 
 export async function getJobRowInsights(
-  db: D1Database,
+	db: D1Database,
 ): Promise<{ total: number; enabled: number }> {
-  const row = await db
-    .prepare(`SELECT COUNT(*) AS total, SUM(enabled) AS enabled FROM jobs`)
-    .first<{ total: number; enabled: number | null }>();
-  return {
-    total: Number(row?.total ?? 0),
-    enabled: Number(row?.enabled ?? 0),
-  };
+	const row = await db
+		.prepare(`SELECT COUNT(*) AS total, SUM(enabled) AS enabled FROM jobs`)
+		.first<{ total: number; enabled: number | null }>()
+	return {
+		total: Number(row?.total ?? 0),
+		enabled: Number(row?.enabled ?? 0),
+	}
 }

--- a/packages/shared/src/jobs/store.ts
+++ b/packages/shared/src/jobs/store.ts
@@ -1,34 +1,35 @@
 import {
-	deleteArchivedJobArtifact,
-	listAllArchivedJobArtifactStorageOwnerRows,
-	listArchivedJobArtifactsDueBefore,
-	listArchivedJobArtifactsForUser,
-	upsertArchivedJobArtifact,
-	type ArchivedJobArtifactRecord,
-} from './archived-artifacts-repo.ts'
+  deleteArchivedJobArtifact,
+  listAllArchivedJobArtifactStorageOwnerRows,
+  listArchivedJobArtifactsDueBefore,
+  listArchivedJobArtifactsForUser,
+  upsertArchivedJobArtifact,
+  type ArchivedJobArtifactRecord,
+} from "./archived-artifacts-repo.ts";
 import {
-	claimJobRow,
-	countJobRowsForUser,
-	deleteJobRow,
-	disableExpiredJobRowsForUser,
-	finalizeClaimedJobRow,
-	getJobRowById,
-	getJobRowInsights,
-	getNextRunnableJobRow,
-	insertJobRow,
-	listAllJobStorageOwnerRows,
-	listDueJobRows,
-	listJobRetentionCandidateRows,
-	listJobRowsByUserId,
-	listJobRowsPage,
-	listJobStorageIdRowsForUser,
-	refreshPackageJobRowIdentity,
-	retryClaimedJobRow,
-	sumJobRowsStorageBytesForUser,
-	updateJobRow,
-	type JobRow,
-} from './repo.ts'
-import { type JobRecord } from './types.ts'
+  claimJobRow,
+  countJobRowsForUser,
+  deleteJobRow,
+  disableExpiredJobRowsForUser,
+  finalizeClaimedJobRow,
+  getJobRowById,
+  getJobRowInsights,
+  getNextRunnableJobRow,
+  insertJobRow,
+  listAllJobStorageOwnerRows,
+  listDueJobRows,
+  listJobIdRowsForUser,
+  listJobRetentionCandidateRows,
+  listJobRowsByUserId,
+  listJobRowsPage,
+  listJobStorageIdRowsForUser,
+  refreshPackageJobRowIdentity,
+  retryClaimedJobRow,
+  sumJobRowsStorageBytesForUser,
+  updateJobRow,
+  type JobRow,
+} from "./repo.ts";
+import { type JobRecord } from "./types.ts";
 
 /**
  * Coarse-grained jobs-data contract between the main worker and the jobs
@@ -44,173 +45,193 @@ import { type JobRecord } from './types.ts'
  * invariants of the underlying repo queries.
  */
 export type JobsStore = {
-	insertJob(input: {
-		userId: string
-		job: JobRecord
-		callerContextJson: string
-	}): Promise<void>
-	updateJob(input: {
-		userId: string
-		job: JobRecord
-		callerContextJson: string
-	}): Promise<boolean>
-	getJobById(input: { userId: string; jobId: string }): Promise<JobRow | null>
-	listJobsForUser(input: { userId: string }): Promise<Array<JobRow>>
-	listJobsPage(input: {
-		afterId: string | null
-		limit: number
-	}): Promise<Array<JobRow>>
-	listDueJobs(input: { userId: string; nowIso: string }): Promise<Array<JobRow>>
-	getNextRunnableJob(input: {
-		userId: string
-		nowIso: string
-	}): Promise<JobRow | null>
-	claimJob(input: {
-		userId: string
-		jobId: string
-		nowMs: number
-		claimToken: string
-	}): Promise<JobRow | null>
-	finalizeClaimedJob(input: {
-		userId: string
-		job: JobRecord
-		claimToken: string
-		scheduledFor: string
-	}): Promise<boolean>
-	retryClaimedJob(input: {
-		userId: string
-		jobId: string
-		claimToken: string
-		nextRunAt: string
-	}): Promise<boolean>
-	refreshPackageJobIdentity(input: {
-		userId: string
-		jobId: string
-		sourceId: string
-		publishedCommit: string | null
-		callerContextJson: string
-		updatedAt: string
-	}): Promise<boolean>
-	deleteJob(input: { userId: string; jobId: string }): Promise<boolean>
-	disableExpiredJobsForUser(input: {
-		userId: string
-		nowIso: string
-	}): Promise<number>
-	listJobRetentionCandidates(input: {
-		afterId: string | null
-		limit: number
-	}): Promise<Array<JobRow>>
-	upsertArchivedJobArtifact(input: {
-		jobId: string
-		userId: string
-		sourceId: string
-		publishedCommit: string
-		storageId: string
-		retainUntil: string
-	}): Promise<string>
-	listArchivedJobArtifactsDueBefore(input: {
-		retainUntil: string
-		limit?: number
-	}): Promise<Array<ArchivedJobArtifactRecord>>
-	deleteArchivedJobArtifact(input: { id: string }): Promise<void>
-	countJobsForUser(input: { userId: string }): Promise<number>
-	/**
-	 * Text-byte estimate of the user's job rows for the D1 storage quota
-	 * (mirrors the main worker's per-table storage byte formula).
-	 */
-	sumJobsStorageBytesForUser(input: { userId: string }): Promise<number>
-	/** Storage ids referenced by the user's jobs and archived artifacts. */
-	listJobStorageIdsForUser(input: { userId: string }): Promise<Array<string>>
-	listArchivedJobArtifactsForUser(input: {
-		userId: string
-	}): Promise<Array<ArchivedJobArtifactRecord>>
-	/**
-	 * Platform-wide (userId, storageId) pairs across jobs and archived
-	 * artifacts. Operator-level DR inventory only — never expose on
-	 * user-facing paths.
-	 */
-	listAllJobStorageOwners(): Promise<
-		Array<{ userId: string; storageId: string }>
-	>
-	/** Platform-wide job totals for admin insights. */
-	getJobInsights(): Promise<{ total: number; enabled: number }>
-	/** Deletes every job and archived-artifact row for the user. */
-	purgeUserJobsData(input: { userId: string }): Promise<void>
-}
+  insertJob(input: {
+    userId: string;
+    job: JobRecord;
+    callerContextJson: string;
+  }): Promise<void>;
+  updateJob(input: {
+    userId: string;
+    job: JobRecord;
+    callerContextJson: string;
+  }): Promise<boolean>;
+  getJobById(input: { userId: string; jobId: string }): Promise<JobRow | null>;
+  listJobsForUser(input: { userId: string }): Promise<Array<JobRow>>;
+  listJobsPage(input: {
+    afterId: string | null;
+    limit: number;
+  }): Promise<Array<JobRow>>;
+  listDueJobs(input: {
+    userId: string;
+    nowIso: string;
+  }): Promise<Array<JobRow>>;
+  getNextRunnableJob(input: {
+    userId: string;
+    nowIso: string;
+  }): Promise<JobRow | null>;
+  claimJob(input: {
+    userId: string;
+    jobId: string;
+    nowMs: number;
+    claimToken: string;
+  }): Promise<JobRow | null>;
+  finalizeClaimedJob(input: {
+    userId: string;
+    job: JobRecord;
+    claimToken: string;
+    scheduledFor: string;
+  }): Promise<boolean>;
+  retryClaimedJob(input: {
+    userId: string;
+    jobId: string;
+    claimToken: string;
+    nextRunAt: string;
+  }): Promise<boolean>;
+  refreshPackageJobIdentity(input: {
+    userId: string;
+    jobId: string;
+    sourceId: string;
+    publishedCommit: string | null;
+    callerContextJson: string;
+    updatedAt: string;
+  }): Promise<boolean>;
+  deleteJob(input: { userId: string; jobId: string }): Promise<boolean>;
+  disableExpiredJobsForUser(input: {
+    userId: string;
+    nowIso: string;
+  }): Promise<number>;
+  listJobRetentionCandidates(input: {
+    afterId: string | null;
+    limit: number;
+  }): Promise<Array<JobRow>>;
+  upsertArchivedJobArtifact(input: {
+    jobId: string;
+    userId: string;
+    sourceId: string;
+    publishedCommit: string;
+    storageId: string;
+    retainUntil: string;
+  }): Promise<string>;
+  listArchivedJobArtifactsDueBefore(input: {
+    retainUntil: string;
+    limit?: number;
+  }): Promise<Array<ArchivedJobArtifactRecord>>;
+  deleteArchivedJobArtifact(input: { id: string }): Promise<void>;
+  countJobsForUser(input: { userId: string }): Promise<number>;
+  /**
+   * Text-byte estimate of the user's job rows for the D1 storage quota
+   * (mirrors the main worker's per-table storage byte formula).
+   */
+  sumJobsStorageBytesForUser(input: { userId: string }): Promise<number>;
+  /**
+   * Job ids owned by the user, for deriving job vector ids during account
+   * deletion. Vectors are only written for live `jobs` rows; archived
+   * artifact `job_id`s are included as an idempotent superset so a vector
+   * whose row was already deleted (but whose vector delete failed) is still
+   * swept.
+   */
+  listJobIdsForUser(input: { userId: string }): Promise<Array<string>>;
+  /** Storage ids referenced by the user's jobs and archived artifacts. */
+  listJobStorageIdsForUser(input: { userId: string }): Promise<Array<string>>;
+  listArchivedJobArtifactsForUser(input: {
+    userId: string;
+  }): Promise<Array<ArchivedJobArtifactRecord>>;
+  /**
+   * Platform-wide (userId, storageId) pairs across jobs and archived
+   * artifacts. Operator-level DR inventory only — never expose on
+   * user-facing paths.
+   */
+  listAllJobStorageOwners(): Promise<
+    Array<{ userId: string; storageId: string }>
+  >;
+  /** Platform-wide job totals for admin insights. */
+  getJobInsights(): Promise<{ total: number; enabled: number }>;
+  /** Deletes every job and archived-artifact row for the user. */
+  purgeUserJobsData(input: { userId: string }): Promise<void>;
+};
 
 /** D1-backed {@link JobsStore} used by the jobs worker (and dev/test fallback). */
 export function createD1JobsStore(db: D1Database): JobsStore {
-	return {
-		insertJob: async (input) => {
-			await insertJobRow({ db, ...input })
-		},
-		updateJob: (input) => updateJobRow({ db, ...input }),
-		getJobById: (input) => getJobRowById(db, input.userId, input.jobId),
-		listJobsForUser: (input) => listJobRowsByUserId(db, input.userId),
-		listJobsPage: (input) => listJobRowsPage(db, input),
-		listDueJobs: (input) => listDueJobRows(db, input.userId, input.nowIso),
-		getNextRunnableJob: (input) =>
-			getNextRunnableJobRow(db, input.userId, input.nowIso),
-		claimJob: (input) =>
-			claimJobRow({
-				db,
-				userId: input.userId,
-				jobId: input.jobId,
-				now: new Date(input.nowMs),
-				claimToken: input.claimToken,
-			}),
-		finalizeClaimedJob: (input) => finalizeClaimedJobRow({ db, ...input }),
-		retryClaimedJob: (input) => retryClaimedJobRow({ db, ...input }),
-		refreshPackageJobIdentity: (input) =>
-			refreshPackageJobRowIdentity({ db, ...input }),
-		deleteJob: (input) => deleteJobRow(db, input.userId, input.jobId),
-		disableExpiredJobsForUser: (input) =>
-			disableExpiredJobRowsForUser({ db, ...input }),
-		listJobRetentionCandidates: (input) =>
-			listJobRetentionCandidateRows(db, input),
-		upsertArchivedJobArtifact: (input) =>
-			upsertArchivedJobArtifact({ db, ...input }),
-		listArchivedJobArtifactsDueBefore: (input) =>
-			listArchivedJobArtifactsDueBefore(db, input.retainUntil, input.limit),
-		deleteArchivedJobArtifact: async (input) => {
-			await deleteArchivedJobArtifact(db, input.id)
-		},
-		countJobsForUser: (input) => countJobRowsForUser(db, input.userId),
-		sumJobsStorageBytesForUser: (input) =>
-			sumJobRowsStorageBytesForUser(db, input.userId),
-		listJobStorageIdsForUser: async (input) => {
-			const [jobIds, archived] = await Promise.all([
-				listJobStorageIdRowsForUser(db, input.userId),
-				listArchivedJobArtifactsForUser(db, input.userId),
-			])
-			return Array.from(
-				new Set([
-					...jobIds,
-					...archived
-						.map((artifact) => artifact.storageId)
-						.filter((storageId) => storageId.length > 0),
-				]),
-			)
-		},
-		listArchivedJobArtifactsForUser: (input) =>
-			listArchivedJobArtifactsForUser(db, input.userId),
-		listAllJobStorageOwners: async () => {
-			const [jobRows, archivedRows] = await Promise.all([
-				listAllJobStorageOwnerRows(db),
-				listAllArchivedJobArtifactStorageOwnerRows(db),
-			])
-			return [...jobRows, ...archivedRows]
-		},
-		getJobInsights: () => getJobRowInsights(db),
-		purgeUserJobsData: async (input) => {
-			await db
-				.prepare(`DELETE FROM archived_job_artifacts WHERE user_id = ?`)
-				.bind(input.userId)
-				.run()
-			await db
-				.prepare(`DELETE FROM jobs WHERE user_id = ?`)
-				.bind(input.userId)
-				.run()
-		},
-	}
+  return {
+    insertJob: async (input) => {
+      await insertJobRow({ db, ...input });
+    },
+    updateJob: (input) => updateJobRow({ db, ...input }),
+    getJobById: (input) => getJobRowById(db, input.userId, input.jobId),
+    listJobsForUser: (input) => listJobRowsByUserId(db, input.userId),
+    listJobsPage: (input) => listJobRowsPage(db, input),
+    listDueJobs: (input) => listDueJobRows(db, input.userId, input.nowIso),
+    getNextRunnableJob: (input) =>
+      getNextRunnableJobRow(db, input.userId, input.nowIso),
+    claimJob: (input) =>
+      claimJobRow({
+        db,
+        userId: input.userId,
+        jobId: input.jobId,
+        now: new Date(input.nowMs),
+        claimToken: input.claimToken,
+      }),
+    finalizeClaimedJob: (input) => finalizeClaimedJobRow({ db, ...input }),
+    retryClaimedJob: (input) => retryClaimedJobRow({ db, ...input }),
+    refreshPackageJobIdentity: (input) =>
+      refreshPackageJobRowIdentity({ db, ...input }),
+    deleteJob: (input) => deleteJobRow(db, input.userId, input.jobId),
+    disableExpiredJobsForUser: (input) =>
+      disableExpiredJobRowsForUser({ db, ...input }),
+    listJobRetentionCandidates: (input) =>
+      listJobRetentionCandidateRows(db, input),
+    upsertArchivedJobArtifact: (input) =>
+      upsertArchivedJobArtifact({ db, ...input }),
+    listArchivedJobArtifactsDueBefore: (input) =>
+      listArchivedJobArtifactsDueBefore(db, input.retainUntil, input.limit),
+    deleteArchivedJobArtifact: async (input) => {
+      await deleteArchivedJobArtifact(db, input.id);
+    },
+    countJobsForUser: (input) => countJobRowsForUser(db, input.userId),
+    sumJobsStorageBytesForUser: (input) =>
+      sumJobRowsStorageBytesForUser(db, input.userId),
+    listJobIdsForUser: async (input) => {
+      const [jobIds, archived] = await Promise.all([
+        listJobIdRowsForUser(db, input.userId),
+        listArchivedJobArtifactsForUser(db, input.userId),
+      ]);
+      return Array.from(
+        new Set([...jobIds, ...archived.map((artifact) => artifact.jobId)]),
+      );
+    },
+    listJobStorageIdsForUser: async (input) => {
+      const [jobIds, archived] = await Promise.all([
+        listJobStorageIdRowsForUser(db, input.userId),
+        listArchivedJobArtifactsForUser(db, input.userId),
+      ]);
+      return Array.from(
+        new Set([
+          ...jobIds,
+          ...archived
+            .map((artifact) => artifact.storageId)
+            .filter((storageId) => storageId.length > 0),
+        ]),
+      );
+    },
+    listArchivedJobArtifactsForUser: (input) =>
+      listArchivedJobArtifactsForUser(db, input.userId),
+    listAllJobStorageOwners: async () => {
+      const [jobRows, archivedRows] = await Promise.all([
+        listAllJobStorageOwnerRows(db),
+        listAllArchivedJobArtifactStorageOwnerRows(db),
+      ]);
+      return [...jobRows, ...archivedRows];
+    },
+    getJobInsights: () => getJobRowInsights(db),
+    purgeUserJobsData: async (input) => {
+      await db
+        .prepare(`DELETE FROM archived_job_artifacts WHERE user_id = ?`)
+        .bind(input.userId)
+        .run();
+      await db
+        .prepare(`DELETE FROM jobs WHERE user_id = ?`)
+        .bind(input.userId)
+        .run();
+    },
+  };
 }

--- a/packages/shared/src/jobs/store.ts
+++ b/packages/shared/src/jobs/store.ts
@@ -1,35 +1,35 @@
 import {
-  deleteArchivedJobArtifact,
-  listAllArchivedJobArtifactStorageOwnerRows,
-  listArchivedJobArtifactsDueBefore,
-  listArchivedJobArtifactsForUser,
-  upsertArchivedJobArtifact,
-  type ArchivedJobArtifactRecord,
-} from "./archived-artifacts-repo.ts";
+	deleteArchivedJobArtifact,
+	listAllArchivedJobArtifactStorageOwnerRows,
+	listArchivedJobArtifactsDueBefore,
+	listArchivedJobArtifactsForUser,
+	upsertArchivedJobArtifact,
+	type ArchivedJobArtifactRecord,
+} from './archived-artifacts-repo.ts'
 import {
-  claimJobRow,
-  countJobRowsForUser,
-  deleteJobRow,
-  disableExpiredJobRowsForUser,
-  finalizeClaimedJobRow,
-  getJobRowById,
-  getJobRowInsights,
-  getNextRunnableJobRow,
-  insertJobRow,
-  listAllJobStorageOwnerRows,
-  listDueJobRows,
-  listJobIdRowsForUser,
-  listJobRetentionCandidateRows,
-  listJobRowsByUserId,
-  listJobRowsPage,
-  listJobStorageIdRowsForUser,
-  refreshPackageJobRowIdentity,
-  retryClaimedJobRow,
-  sumJobRowsStorageBytesForUser,
-  updateJobRow,
-  type JobRow,
-} from "./repo.ts";
-import { type JobRecord } from "./types.ts";
+	claimJobRow,
+	countJobRowsForUser,
+	deleteJobRow,
+	disableExpiredJobRowsForUser,
+	finalizeClaimedJobRow,
+	getJobRowById,
+	getJobRowInsights,
+	getNextRunnableJobRow,
+	insertJobRow,
+	listAllJobStorageOwnerRows,
+	listDueJobRows,
+	listJobIdRowsForUser,
+	listJobRetentionCandidateRows,
+	listJobRowsByUserId,
+	listJobRowsPage,
+	listJobStorageIdRowsForUser,
+	refreshPackageJobRowIdentity,
+	retryClaimedJobRow,
+	sumJobRowsStorageBytesForUser,
+	updateJobRow,
+	type JobRow,
+} from './repo.ts'
+import { type JobRecord } from './types.ts'
 
 /**
  * Coarse-grained jobs-data contract between the main worker and the jobs
@@ -45,193 +45,190 @@ import { type JobRecord } from "./types.ts";
  * invariants of the underlying repo queries.
  */
 export type JobsStore = {
-  insertJob(input: {
-    userId: string;
-    job: JobRecord;
-    callerContextJson: string;
-  }): Promise<void>;
-  updateJob(input: {
-    userId: string;
-    job: JobRecord;
-    callerContextJson: string;
-  }): Promise<boolean>;
-  getJobById(input: { userId: string; jobId: string }): Promise<JobRow | null>;
-  listJobsForUser(input: { userId: string }): Promise<Array<JobRow>>;
-  listJobsPage(input: {
-    afterId: string | null;
-    limit: number;
-  }): Promise<Array<JobRow>>;
-  listDueJobs(input: {
-    userId: string;
-    nowIso: string;
-  }): Promise<Array<JobRow>>;
-  getNextRunnableJob(input: {
-    userId: string;
-    nowIso: string;
-  }): Promise<JobRow | null>;
-  claimJob(input: {
-    userId: string;
-    jobId: string;
-    nowMs: number;
-    claimToken: string;
-  }): Promise<JobRow | null>;
-  finalizeClaimedJob(input: {
-    userId: string;
-    job: JobRecord;
-    claimToken: string;
-    scheduledFor: string;
-  }): Promise<boolean>;
-  retryClaimedJob(input: {
-    userId: string;
-    jobId: string;
-    claimToken: string;
-    nextRunAt: string;
-  }): Promise<boolean>;
-  refreshPackageJobIdentity(input: {
-    userId: string;
-    jobId: string;
-    sourceId: string;
-    publishedCommit: string | null;
-    callerContextJson: string;
-    updatedAt: string;
-  }): Promise<boolean>;
-  deleteJob(input: { userId: string; jobId: string }): Promise<boolean>;
-  disableExpiredJobsForUser(input: {
-    userId: string;
-    nowIso: string;
-  }): Promise<number>;
-  listJobRetentionCandidates(input: {
-    afterId: string | null;
-    limit: number;
-  }): Promise<Array<JobRow>>;
-  upsertArchivedJobArtifact(input: {
-    jobId: string;
-    userId: string;
-    sourceId: string;
-    publishedCommit: string;
-    storageId: string;
-    retainUntil: string;
-  }): Promise<string>;
-  listArchivedJobArtifactsDueBefore(input: {
-    retainUntil: string;
-    limit?: number;
-  }): Promise<Array<ArchivedJobArtifactRecord>>;
-  deleteArchivedJobArtifact(input: { id: string }): Promise<void>;
-  countJobsForUser(input: { userId: string }): Promise<number>;
-  /**
-   * Text-byte estimate of the user's job rows for the D1 storage quota
-   * (mirrors the main worker's per-table storage byte formula).
-   */
-  sumJobsStorageBytesForUser(input: { userId: string }): Promise<number>;
-  /**
-   * Job ids owned by the user, for deriving job vector ids during account
-   * deletion. Vectors are only written for live `jobs` rows; archived
-   * artifact `job_id`s are included as an idempotent superset so a vector
-   * whose row was already deleted (but whose vector delete failed) is still
-   * swept.
-   */
-  listJobIdsForUser(input: { userId: string }): Promise<Array<string>>;
-  /** Storage ids referenced by the user's jobs and archived artifacts. */
-  listJobStorageIdsForUser(input: { userId: string }): Promise<Array<string>>;
-  listArchivedJobArtifactsForUser(input: {
-    userId: string;
-  }): Promise<Array<ArchivedJobArtifactRecord>>;
-  /**
-   * Platform-wide (userId, storageId) pairs across jobs and archived
-   * artifacts. Operator-level DR inventory only — never expose on
-   * user-facing paths.
-   */
-  listAllJobStorageOwners(): Promise<
-    Array<{ userId: string; storageId: string }>
-  >;
-  /** Platform-wide job totals for admin insights. */
-  getJobInsights(): Promise<{ total: number; enabled: number }>;
-  /** Deletes every job and archived-artifact row for the user. */
-  purgeUserJobsData(input: { userId: string }): Promise<void>;
-};
+	insertJob(input: {
+		userId: string
+		job: JobRecord
+		callerContextJson: string
+	}): Promise<void>
+	updateJob(input: {
+		userId: string
+		job: JobRecord
+		callerContextJson: string
+	}): Promise<boolean>
+	getJobById(input: { userId: string; jobId: string }): Promise<JobRow | null>
+	listJobsForUser(input: { userId: string }): Promise<Array<JobRow>>
+	listJobsPage(input: {
+		afterId: string | null
+		limit: number
+	}): Promise<Array<JobRow>>
+	listDueJobs(input: { userId: string; nowIso: string }): Promise<Array<JobRow>>
+	getNextRunnableJob(input: {
+		userId: string
+		nowIso: string
+	}): Promise<JobRow | null>
+	claimJob(input: {
+		userId: string
+		jobId: string
+		nowMs: number
+		claimToken: string
+	}): Promise<JobRow | null>
+	finalizeClaimedJob(input: {
+		userId: string
+		job: JobRecord
+		claimToken: string
+		scheduledFor: string
+	}): Promise<boolean>
+	retryClaimedJob(input: {
+		userId: string
+		jobId: string
+		claimToken: string
+		nextRunAt: string
+	}): Promise<boolean>
+	refreshPackageJobIdentity(input: {
+		userId: string
+		jobId: string
+		sourceId: string
+		publishedCommit: string | null
+		callerContextJson: string
+		updatedAt: string
+	}): Promise<boolean>
+	deleteJob(input: { userId: string; jobId: string }): Promise<boolean>
+	disableExpiredJobsForUser(input: {
+		userId: string
+		nowIso: string
+	}): Promise<number>
+	listJobRetentionCandidates(input: {
+		afterId: string | null
+		limit: number
+	}): Promise<Array<JobRow>>
+	upsertArchivedJobArtifact(input: {
+		jobId: string
+		userId: string
+		sourceId: string
+		publishedCommit: string
+		storageId: string
+		retainUntil: string
+	}): Promise<string>
+	listArchivedJobArtifactsDueBefore(input: {
+		retainUntil: string
+		limit?: number
+	}): Promise<Array<ArchivedJobArtifactRecord>>
+	deleteArchivedJobArtifact(input: { id: string }): Promise<void>
+	countJobsForUser(input: { userId: string }): Promise<number>
+	/**
+	 * Text-byte estimate of the user's job rows for the D1 storage quota
+	 * (mirrors the main worker's per-table storage byte formula).
+	 */
+	sumJobsStorageBytesForUser(input: { userId: string }): Promise<number>
+	/**
+	 * Job ids owned by the user, for deriving job vector ids during account
+	 * deletion. Vectors are only written for live `jobs` rows; archived
+	 * artifact `job_id`s are included as an idempotent superset so a vector
+	 * whose row was already deleted (but whose vector delete failed) is still
+	 * swept.
+	 */
+	listJobIdsForUser(input: { userId: string }): Promise<Array<string>>
+	/** Storage ids referenced by the user's jobs and archived artifacts. */
+	listJobStorageIdsForUser(input: { userId: string }): Promise<Array<string>>
+	listArchivedJobArtifactsForUser(input: {
+		userId: string
+	}): Promise<Array<ArchivedJobArtifactRecord>>
+	/**
+	 * Platform-wide (userId, storageId) pairs across jobs and archived
+	 * artifacts. Operator-level DR inventory only — never expose on
+	 * user-facing paths.
+	 */
+	listAllJobStorageOwners(): Promise<
+		Array<{ userId: string; storageId: string }>
+	>
+	/** Platform-wide job totals for admin insights. */
+	getJobInsights(): Promise<{ total: number; enabled: number }>
+	/** Deletes every job and archived-artifact row for the user. */
+	purgeUserJobsData(input: { userId: string }): Promise<void>
+}
 
 /** D1-backed {@link JobsStore} used by the jobs worker (and dev/test fallback). */
 export function createD1JobsStore(db: D1Database): JobsStore {
-  return {
-    insertJob: async (input) => {
-      await insertJobRow({ db, ...input });
-    },
-    updateJob: (input) => updateJobRow({ db, ...input }),
-    getJobById: (input) => getJobRowById(db, input.userId, input.jobId),
-    listJobsForUser: (input) => listJobRowsByUserId(db, input.userId),
-    listJobsPage: (input) => listJobRowsPage(db, input),
-    listDueJobs: (input) => listDueJobRows(db, input.userId, input.nowIso),
-    getNextRunnableJob: (input) =>
-      getNextRunnableJobRow(db, input.userId, input.nowIso),
-    claimJob: (input) =>
-      claimJobRow({
-        db,
-        userId: input.userId,
-        jobId: input.jobId,
-        now: new Date(input.nowMs),
-        claimToken: input.claimToken,
-      }),
-    finalizeClaimedJob: (input) => finalizeClaimedJobRow({ db, ...input }),
-    retryClaimedJob: (input) => retryClaimedJobRow({ db, ...input }),
-    refreshPackageJobIdentity: (input) =>
-      refreshPackageJobRowIdentity({ db, ...input }),
-    deleteJob: (input) => deleteJobRow(db, input.userId, input.jobId),
-    disableExpiredJobsForUser: (input) =>
-      disableExpiredJobRowsForUser({ db, ...input }),
-    listJobRetentionCandidates: (input) =>
-      listJobRetentionCandidateRows(db, input),
-    upsertArchivedJobArtifact: (input) =>
-      upsertArchivedJobArtifact({ db, ...input }),
-    listArchivedJobArtifactsDueBefore: (input) =>
-      listArchivedJobArtifactsDueBefore(db, input.retainUntil, input.limit),
-    deleteArchivedJobArtifact: async (input) => {
-      await deleteArchivedJobArtifact(db, input.id);
-    },
-    countJobsForUser: (input) => countJobRowsForUser(db, input.userId),
-    sumJobsStorageBytesForUser: (input) =>
-      sumJobRowsStorageBytesForUser(db, input.userId),
-    listJobIdsForUser: async (input) => {
-      const [jobIds, archived] = await Promise.all([
-        listJobIdRowsForUser(db, input.userId),
-        listArchivedJobArtifactsForUser(db, input.userId),
-      ]);
-      return Array.from(
-        new Set([...jobIds, ...archived.map((artifact) => artifact.jobId)]),
-      );
-    },
-    listJobStorageIdsForUser: async (input) => {
-      const [jobIds, archived] = await Promise.all([
-        listJobStorageIdRowsForUser(db, input.userId),
-        listArchivedJobArtifactsForUser(db, input.userId),
-      ]);
-      return Array.from(
-        new Set([
-          ...jobIds,
-          ...archived
-            .map((artifact) => artifact.storageId)
-            .filter((storageId) => storageId.length > 0),
-        ]),
-      );
-    },
-    listArchivedJobArtifactsForUser: (input) =>
-      listArchivedJobArtifactsForUser(db, input.userId),
-    listAllJobStorageOwners: async () => {
-      const [jobRows, archivedRows] = await Promise.all([
-        listAllJobStorageOwnerRows(db),
-        listAllArchivedJobArtifactStorageOwnerRows(db),
-      ]);
-      return [...jobRows, ...archivedRows];
-    },
-    getJobInsights: () => getJobRowInsights(db),
-    purgeUserJobsData: async (input) => {
-      await db
-        .prepare(`DELETE FROM archived_job_artifacts WHERE user_id = ?`)
-        .bind(input.userId)
-        .run();
-      await db
-        .prepare(`DELETE FROM jobs WHERE user_id = ?`)
-        .bind(input.userId)
-        .run();
-    },
-  };
+	return {
+		insertJob: async (input) => {
+			await insertJobRow({ db, ...input })
+		},
+		updateJob: (input) => updateJobRow({ db, ...input }),
+		getJobById: (input) => getJobRowById(db, input.userId, input.jobId),
+		listJobsForUser: (input) => listJobRowsByUserId(db, input.userId),
+		listJobsPage: (input) => listJobRowsPage(db, input),
+		listDueJobs: (input) => listDueJobRows(db, input.userId, input.nowIso),
+		getNextRunnableJob: (input) =>
+			getNextRunnableJobRow(db, input.userId, input.nowIso),
+		claimJob: (input) =>
+			claimJobRow({
+				db,
+				userId: input.userId,
+				jobId: input.jobId,
+				now: new Date(input.nowMs),
+				claimToken: input.claimToken,
+			}),
+		finalizeClaimedJob: (input) => finalizeClaimedJobRow({ db, ...input }),
+		retryClaimedJob: (input) => retryClaimedJobRow({ db, ...input }),
+		refreshPackageJobIdentity: (input) =>
+			refreshPackageJobRowIdentity({ db, ...input }),
+		deleteJob: (input) => deleteJobRow(db, input.userId, input.jobId),
+		disableExpiredJobsForUser: (input) =>
+			disableExpiredJobRowsForUser({ db, ...input }),
+		listJobRetentionCandidates: (input) =>
+			listJobRetentionCandidateRows(db, input),
+		upsertArchivedJobArtifact: (input) =>
+			upsertArchivedJobArtifact({ db, ...input }),
+		listArchivedJobArtifactsDueBefore: (input) =>
+			listArchivedJobArtifactsDueBefore(db, input.retainUntil, input.limit),
+		deleteArchivedJobArtifact: async (input) => {
+			await deleteArchivedJobArtifact(db, input.id)
+		},
+		countJobsForUser: (input) => countJobRowsForUser(db, input.userId),
+		sumJobsStorageBytesForUser: (input) =>
+			sumJobRowsStorageBytesForUser(db, input.userId),
+		listJobIdsForUser: async (input) => {
+			const [jobIds, archived] = await Promise.all([
+				listJobIdRowsForUser(db, input.userId),
+				listArchivedJobArtifactsForUser(db, input.userId),
+			])
+			return Array.from(
+				new Set([...jobIds, ...archived.map((artifact) => artifact.jobId)]),
+			)
+		},
+		listJobStorageIdsForUser: async (input) => {
+			const [jobIds, archived] = await Promise.all([
+				listJobStorageIdRowsForUser(db, input.userId),
+				listArchivedJobArtifactsForUser(db, input.userId),
+			])
+			return Array.from(
+				new Set([
+					...jobIds,
+					...archived
+						.map((artifact) => artifact.storageId)
+						.filter((storageId) => storageId.length > 0),
+				]),
+			)
+		},
+		listArchivedJobArtifactsForUser: (input) =>
+			listArchivedJobArtifactsForUser(db, input.userId),
+		listAllJobStorageOwners: async () => {
+			const [jobRows, archivedRows] = await Promise.all([
+				listAllJobStorageOwnerRows(db),
+				listAllArchivedJobArtifactStorageOwnerRows(db),
+			])
+			return [...jobRows, ...archivedRows]
+		},
+		getJobInsights: () => getJobRowInsights(db),
+		purgeUserJobsData: async (input) => {
+			await db
+				.prepare(`DELETE FROM archived_job_artifacts WHERE user_id = ?`)
+				.bind(input.userId)
+				.run()
+			await db
+				.prepare(`DELETE FROM jobs WHERE user_id = ?`)
+				.bind(input.userId)
+				.run()
+		},
+	}
 }

--- a/packages/worker/src/account/unverified-account-purge.node.test.ts
+++ b/packages/worker/src/account/unverified-account-purge.node.test.ts
@@ -14,6 +14,7 @@ import * as AccountDeletion from '#app/account-deletion.ts'
 import * as DeletionState from '#worker/account/deletion-state.ts'
 import { AccountDeletionWritersActiveError } from '#worker/account/deletion-state.ts'
 import {
+	AccountDeletionBillingError,
 	AccountDeletionCleanupError,
 	AccountDeletionInventoryError,
 	type AccountDeletionResult,
@@ -530,6 +531,57 @@ test('failure details redact email addresses before they reach outcomes, audit r
 	expect(redactEmailAddresses('call kody@kody.codes or a@b.co now')).toBe(
 		'call <email> or <email> now',
 	)
+})
+
+test('a Stripe cancellation failure is a pre-cleanup failure: fence released, account retained, retried next run', async () => {
+	const deleteUserAccount = vi.spyOn(AccountDeletion, 'deleteUserAccount')
+	consoleWarn.mockImplementation(() => {})
+	const { sqlite, db } = createAppDb()
+	const audit = createAuditDb()
+	const billing = await seedUser(db, {
+		username: 'billing-failure',
+		email: 'billing-failure@example.com',
+		createdAt: daysAgo(12),
+	})
+	deleteUserAccount.mockImplementationOnce(async () => {
+		throw new AccountDeletionBillingError([
+			'Stripe subscription sub_1 could not be canceled: Stripe API request failed with HTTP 503.',
+		])
+	})
+
+	const result = await pruneUnverifiedAccounts({
+		env: createPurgeEnv(db, audit.db),
+		now,
+	})
+
+	expect(result).toEqual({
+		scanned: 1,
+		purged: 0,
+		failed: 1,
+		timeBudgetExhausted: false,
+		outcomes: [
+			{
+				stableUserId: billing.stableUserId,
+				ageDays: 12,
+				outcome: 'failed',
+				error:
+					'AccountDeletionBillingError: Stripe subscription sub_1 could not be canceled: Stripe API request failed with HTTP 503.',
+				warnings: [
+					'Stripe subscription sub_1 could not be canceled: Stripe API request failed with HTTP 503.',
+				],
+			},
+		],
+	})
+	expect(usernames(sqlite)).toEqual(['billing-failure'])
+	expect(deletingAt(sqlite, 'billing-failure')).toBeNull()
+
+	deleteUserAccount.mockClear()
+	const retry = await pruneUnverifiedAccounts({
+		env: createPurgeEnv(db, audit.db),
+		now,
+	})
+	expect(retry).toMatchObject({ scanned: 1, purged: 1, failed: 0 })
+	expect(usernames(sqlite)).toEqual([])
 })
 
 test('a failed failure-audit write is logged and does not stop the rest of the batch', async () => {

--- a/packages/worker/src/account/unverified-account-purge.ts
+++ b/packages/worker/src/account/unverified-account-purge.ts
@@ -8,6 +8,7 @@ import {
 	abortAccountDeleting,
 } from '#worker/account/deletion-state.ts'
 import {
+	AccountDeletionBillingError,
 	AccountDeletionCleanupError,
 	AccountDeletionInventoryError,
 	deleteUserAccount,
@@ -130,6 +131,9 @@ function deletionFailureWarnings(error: unknown) {
 	if (error instanceof AccountDeletionInventoryError) {
 		return error.inventoryErrors.map(redactEmailAddresses)
 	}
+	if (error instanceof AccountDeletionBillingError) {
+		return error.billingErrors.map(redactEmailAddresses)
+	}
 	return []
 }
 
@@ -204,6 +208,7 @@ function reportPurgeFailureToSentry(input: {
 function isPreCleanupDeletionFailure(error: unknown) {
 	return (
 		error instanceof AccountDeletionInventoryError ||
+		error instanceof AccountDeletionBillingError ||
 		error instanceof AccountDeletionWritersActiveError
 	)
 }

--- a/packages/worker/src/account/user-owned-surfaces.ts
+++ b/packages/worker/src/account/user-owned-surfaces.ts
@@ -1,372 +1,383 @@
 export type UserOwnedDurableObjectSurface = {
-	id:
-		| 'job_manager'
-		| 'storage_runner'
-		| 'repo_session'
-		| 'mcp_client_hub'
-		| 'package_realtime_session'
-		| 'run_log'
-		| 'user_meter'
-		| 'stripe_plan_refresh'
-		| 'mailbox'
-		| 'repo_session_index'
-		| 'mcp'
-	binding: string
-	/** Result key used in AccountDeletionResult.clearedDurableObjects when purged */
-	deletionResultKey: string | null
-	export: 'include' | 'exclude'
-	excludeReason?: string
-	notes?: string
-}
+  id:
+    | "job_manager"
+    | "storage_runner"
+    | "repo_session"
+    | "mcp_client_hub"
+    | "package_realtime_session"
+    | "run_log"
+    | "user_meter"
+    | "stripe_plan_refresh"
+    | "mailbox"
+    | "repo_session_index"
+    | "mcp";
+  binding: string;
+  /** Result key used in AccountDeletionResult.clearedDurableObjects when purged */
+  deletionResultKey: string | null;
+  export: "include" | "exclude";
+  excludeReason?: string;
+  notes?: string;
+};
+
+/**
+ * Where the D1 rows that own a vector surface live. `app_db` surfaces are
+ * enumerated with `SELECT id FROM {table} WHERE user_id = ?` against APP_DB;
+ * `jobs_rpc` rows live in the jobs worker's dedicated D1 (ADR 0016) and are
+ * enumerated through the JOBS service binding (`listJobIdsForUser`). APP_DB
+ * has no `jobs` table since migration 0010.
+ */
+export type UserOwnedVectorizeSource =
+  | { kind: "app_db"; table: "mcp_memories" | "saved_packages" }
+  | { kind: "jobs_rpc" };
 
 export type UserOwnedVectorizeSurface = {
-	id: 'memory' | 'job' | 'saved_package'
-	sourceTable: 'mcp_memories' | 'jobs' | 'saved_packages'
-	/** Exported as derivedData.vectorize note; never exported as vectors */
-	export: 'rebuild_from_d1'
-}
+  id: "memory" | "job" | "saved_package";
+  source: UserOwnedVectorizeSource;
+  /** Exported as derivedData.vectorize note; never exported as vectors */
+  export: "rebuild_from_d1";
+};
 
 export type UserOwnedKvKeyScheme = {
-	id:
-		| 'published_bundle_artifact_kv_key'
-		| 'source_snapshot'
-		| 'source_manifest_snapshot'
-		| 'community_snapshot'
-		| 'community_icon_derived_cache'
-		| 'usage_rollup_derived_cache'
-		| 'artifact_head_derived_cache'
-		| 'package_retriever_manifest'
-		| 'package_retriever_index_entry'
-		| 'package_retriever_index_prefix'
-		| 'webhook_dispatch_payload'
-	binding: 'BUNDLE_ARTIFACTS_KV'
-	sourceTable?: string
-	sourceColumn?: string
-	prefixTemplate?: string
-	retention?: string
-	notes?: string
-}
+  id:
+    | "published_bundle_artifact_kv_key"
+    | "source_snapshot"
+    | "source_manifest_snapshot"
+    | "community_snapshot"
+    | "community_icon_derived_cache"
+    | "usage_rollup_derived_cache"
+    | "artifact_head_derived_cache"
+    | "package_retriever_manifest"
+    | "package_retriever_index_entry"
+    | "package_retriever_index_prefix"
+    | "webhook_dispatch_payload";
+  binding: "BUNDLE_ARTIFACTS_KV";
+  sourceTable?: string;
+  sourceColumn?: string;
+  prefixTemplate?: string;
+  retention?: string;
+  notes?: string;
+};
 
 export type UserOwnedR2Surface = {
-	id:
-		| 'email_raw_mime'
-		| 'email_attachment_storage_key'
-		| 'community_icon'
-		| 'user_avatar'
-	binding: 'EMAIL_BLOBS' | 'COMMUNITY_ASSETS'
-	sourceTable: string
-	sourceColumn?: string
-	keyTemplate?: string
-	export: 'chunked_bytes'
-	notes?: string
-}
+  id:
+    | "email_raw_mime"
+    | "email_attachment_storage_key"
+    | "community_icon"
+    | "user_avatar";
+  binding: "EMAIL_BLOBS" | "COMMUNITY_ASSETS";
+  sourceTable: string;
+  sourceColumn?: string;
+  keyTemplate?: string;
+  export: "chunked_bytes";
+  notes?: string;
+};
 
 export type UserOwnedArtifactSurface = {
-	id: 'entity_sources'
-	sourceTable: string
-	repoColumn: string
-	notes: string
-}
+  id: "entity_sources";
+  sourceTable: string;
+  repoColumn: string;
+  notes: string;
+};
 
 export const accountUserOwnedDurableObjectSurfaces: ReadonlyArray<UserOwnedDurableObjectSurface> =
-	[
-		{
-			id: 'job_manager',
-			binding: 'JOBS',
-			deletionResultKey: 'jobManagers',
-			export: 'include',
-			notes:
-				'Job manager state lives in the jobs worker (ADR 0016) and is reached through the JOBS service binding; it is included in account export.',
-		},
-		{
-			id: 'storage_runner',
-			binding: 'STORAGE_RUNNER',
-			deletionResultKey: 'storageRunners',
-			export: 'include',
-		},
-		{
-			id: 'repo_session',
-			binding: 'REPO_SESSION',
-			deletionResultKey: 'repoSessions',
-			export: 'exclude',
-			excludeReason:
-				'Ephemeral editing workspace, including REPO_SESSION_BLOBS spill purged with the session Durable Object. Canonical repo-backed source is exported as Artifacts repo pointers via entity_sources; session catalog metadata is exported from RepoSessionIndex.',
-		},
-		{
-			id: 'mcp_client_hub',
-			binding: 'MCP_CLIENT_HUB',
-			deletionResultKey: 'mcpClientHubs',
-			export: 'exclude',
-			excludeReason:
-				'MCP client hub state can include OAuth tokens and SDK registrations that are non-portable; it is purged during account deletion instead of exported.',
-		},
-		{
-			id: 'package_realtime_session',
-			binding: 'PACKAGE_REALTIME_SESSION',
-			deletionResultKey: 'packageRealtimeSessions',
-			export: 'exclude',
-			excludeReason:
-				'Ephemeral live websocket/session state. Durable app storage is exported through StorageRunner buckets.',
-		},
-		{
-			id: 'run_log',
-			binding: 'RUN_LOG',
-			deletionResultKey: 'runLogs',
-			export: 'include',
-			notes:
-				'Per-user RunLog DO (RUN_LOG binding; idFromName(userId)). Sole runtime authority for pruned run history (runs + run_logs), the keyed package-invocation idempotency ledger, and dedicated state: workflow_projections (binding_name, typically DYNAMIC_CALLABLE_WORKFLOWS; terminal rows age-prune after 90 days), job_run_observability (terminal outcomes/counters; D1 jobs keeps schedule + last_run_at/last_run_status for retention only), package_run_successes, and activation_milestones. There are no D1 tables workflow_runs, user_package_run_successes, or user_activation_milestones (pre-drop Time Travel bookmark 0000116d-000000d2-000050bd-c7ecd5892a189df7cda145af746bc9c9 on database 8c1014d1-6b41-4695-a0a2-159071f0f919). Run history self-prunes (~30 days / 2,000 runs); job/activation dedicated tables are never pruned. Account deletion clearAll deletes every DO table and reinitializes schema. Account export pages all tables through the run_records section (runs first, then ledger, then dedicated phases).',
-		},
-		{
-			id: 'user_meter',
-			binding: 'USER_METER',
-			deletionResultKey: 'userMeters',
-			export: 'include',
-			notes:
-				'Per-user daily entitlement counters, storage-byte state, and deletion-fence/write-lease state (one DO per stable userId). Daily counters and storage bytes are authoritative in UserMeter; users has no d1_storage_bytes mirror columns, and the reconcile lane sweeps users by stable_user_id keyset from the platform-owned d1_storage_reconcile_cursor row. UserMeter is the sole lease authority: all callers (including email paths) supply USER_METER via env; acquireWriteLease writes to the DO only and countActiveWriteLeases is a direct DO COUNT (no paging). There is no D1 account_write_leases table; D1 users.deleting_at remains the permanent point gate and account_write_lease_repairs remains the admin repair audit log. Self-prunes stale UTC-day rows inside the DO rather than through a retention cron lane; account deletion purge clears counters, storage-byte state, and write leases while preserving an existing deleting tombstone during cleanup, then origin drops that tombstone after the D1 user row is deleted so the email-derived stable_user_id can be reused; account export pages counters through the user_meter section via exportCounters and includes authoritative storageBytesState and sanitized deletionState without raw lease token/holder on the first page only.',
-		},
-		{
-			id: 'stripe_plan_refresh',
-			binding: 'STRIPE_PLAN_REFRESH',
-			deletionResultKey: 'stripePlanRefreshes',
-			export: 'exclude',
-			excludeReason:
-				'Ephemeral one-shot Stripe reconciliation alarm state. Billing columns remain canonical in D1 and are included in the users export.',
-			notes:
-				'One alarm object per stable userId. Account deletion cancels the alarm and clears its stored owner id.',
-		},
-		{
-			id: 'mailbox',
-			binding: 'MAILBOX',
-			deletionResultKey: 'mailboxes',
-			export: 'include',
-			notes:
-				'Per-user authoritative email metadata and R2-reference inventory (MAILBOX binding; idFromName(userId)). Account export pages the sole USER email graph through exportMailbox. Account deletion lists Mailbox blob references before deleting R2 objects and purging the DO; D1 retains only thin provider, due-work, alert, and configuration rows.',
-		},
-		{
-			id: 'repo_session_index',
-			binding: 'REPO_SESSION_INDEX',
-			deletionResultKey: 'repoSessionIndexes',
-			export: 'include',
-			notes:
-				'Per-user repo session catalog (REPO_SESSION_INDEX binding; idFromName(userId)). Authority for session rows, active counts, conversation resume, export, and deletion inventory. Workspace bytes stay in per-session RepoSession DOs. D1 keeps only the thin repo_session_due_owners hint plus the storage-bucket inventory cursor.',
-		},
-		{
-			id: 'mcp',
-			binding: 'MCP',
-			deletionResultKey: 'mcpAgentSessions',
-			export: 'exclude',
-			excludeReason:
-				'Session-keyed by the MCP SDK and not globally enumerable; durable user data is carried by D1 and user-scoped stores instead.',
-			notes:
-				'Session DO ids are indexed by user in mcp_agent_sessions and purged during account deletion.',
-		},
-	] as const
+  [
+    {
+      id: "job_manager",
+      binding: "JOBS",
+      deletionResultKey: "jobManagers",
+      export: "include",
+      notes:
+        "Job manager state lives in the jobs worker (ADR 0016) and is reached through the JOBS service binding; it is included in account export.",
+    },
+    {
+      id: "storage_runner",
+      binding: "STORAGE_RUNNER",
+      deletionResultKey: "storageRunners",
+      export: "include",
+    },
+    {
+      id: "repo_session",
+      binding: "REPO_SESSION",
+      deletionResultKey: "repoSessions",
+      export: "exclude",
+      excludeReason:
+        "Ephemeral editing workspace, including REPO_SESSION_BLOBS spill purged with the session Durable Object. Canonical repo-backed source is exported as Artifacts repo pointers via entity_sources; session catalog metadata is exported from RepoSessionIndex.",
+    },
+    {
+      id: "mcp_client_hub",
+      binding: "MCP_CLIENT_HUB",
+      deletionResultKey: "mcpClientHubs",
+      export: "exclude",
+      excludeReason:
+        "MCP client hub state can include OAuth tokens and SDK registrations that are non-portable; it is purged during account deletion instead of exported.",
+    },
+    {
+      id: "package_realtime_session",
+      binding: "PACKAGE_REALTIME_SESSION",
+      deletionResultKey: "packageRealtimeSessions",
+      export: "exclude",
+      excludeReason:
+        "Ephemeral live websocket/session state. Durable app storage is exported through StorageRunner buckets.",
+    },
+    {
+      id: "run_log",
+      binding: "RUN_LOG",
+      deletionResultKey: "runLogs",
+      export: "include",
+      notes:
+        "Per-user RunLog DO (RUN_LOG binding; idFromName(userId)). Sole runtime authority for pruned run history (runs + run_logs), the keyed package-invocation idempotency ledger, and dedicated state: workflow_projections (binding_name, typically DYNAMIC_CALLABLE_WORKFLOWS; terminal rows age-prune after 90 days), job_run_observability (terminal outcomes/counters; D1 jobs keeps schedule + last_run_at/last_run_status for retention only), package_run_successes, and activation_milestones. There are no D1 tables workflow_runs, user_package_run_successes, or user_activation_milestones (pre-drop Time Travel bookmark 0000116d-000000d2-000050bd-c7ecd5892a189df7cda145af746bc9c9 on database 8c1014d1-6b41-4695-a0a2-159071f0f919). Run history self-prunes (~30 days / 2,000 runs); job/activation dedicated tables are never pruned. Account deletion clearAll deletes every DO table and reinitializes schema. Account export pages all tables through the run_records section (runs first, then ledger, then dedicated phases).",
+    },
+    {
+      id: "user_meter",
+      binding: "USER_METER",
+      deletionResultKey: "userMeters",
+      export: "include",
+      notes:
+        "Per-user daily entitlement counters, storage-byte state, and deletion-fence/write-lease state (one DO per stable userId). Daily counters and storage bytes are authoritative in UserMeter; users has no d1_storage_bytes mirror columns, and the reconcile lane sweeps users by stable_user_id keyset from the platform-owned d1_storage_reconcile_cursor row. UserMeter is the sole lease authority: all callers (including email paths) supply USER_METER via env; acquireWriteLease writes to the DO only and countActiveWriteLeases is a direct DO COUNT (no paging). There is no D1 account_write_leases table; D1 users.deleting_at remains the permanent point gate and account_write_lease_repairs remains the admin repair audit log. Self-prunes stale UTC-day rows inside the DO rather than through a retention cron lane; account deletion purge clears counters, storage-byte state, and write leases while preserving an existing deleting tombstone during cleanup, then origin drops that tombstone after the D1 user row is deleted so the email-derived stable_user_id can be reused; account export pages counters through the user_meter section via exportCounters and includes authoritative storageBytesState and sanitized deletionState without raw lease token/holder on the first page only.",
+    },
+    {
+      id: "stripe_plan_refresh",
+      binding: "STRIPE_PLAN_REFRESH",
+      deletionResultKey: "stripePlanRefreshes",
+      export: "exclude",
+      excludeReason:
+        "Ephemeral one-shot Stripe reconciliation alarm state. Billing columns remain canonical in D1 and are included in the users export.",
+      notes:
+        "One alarm object per stable userId. Account deletion cancels the alarm and clears its stored owner id.",
+    },
+    {
+      id: "mailbox",
+      binding: "MAILBOX",
+      deletionResultKey: "mailboxes",
+      export: "include",
+      notes:
+        "Per-user authoritative email metadata and R2-reference inventory (MAILBOX binding; idFromName(userId)). Account export pages the sole USER email graph through exportMailbox. Account deletion lists Mailbox blob references before deleting R2 objects and purging the DO; D1 retains only thin provider, due-work, alert, and configuration rows.",
+    },
+    {
+      id: "repo_session_index",
+      binding: "REPO_SESSION_INDEX",
+      deletionResultKey: "repoSessionIndexes",
+      export: "include",
+      notes:
+        "Per-user repo session catalog (REPO_SESSION_INDEX binding; idFromName(userId)). Authority for session rows, active counts, conversation resume, export, and deletion inventory. Workspace bytes stay in per-session RepoSession DOs. D1 keeps only the thin repo_session_due_owners hint plus the storage-bucket inventory cursor.",
+    },
+    {
+      id: "mcp",
+      binding: "MCP",
+      deletionResultKey: "mcpAgentSessions",
+      export: "exclude",
+      excludeReason:
+        "Session-keyed by the MCP SDK and not globally enumerable; durable user data is carried by D1 and user-scoped stores instead.",
+      notes:
+        "Session DO ids are indexed by user in mcp_agent_sessions and purged during account deletion.",
+    },
+  ] as const;
 
 export const accountUserOwnedVectorizeSurfaces: ReadonlyArray<UserOwnedVectorizeSurface> =
-	[
-		{
-			id: 'memory',
-			sourceTable: 'mcp_memories',
-			export: 'rebuild_from_d1',
-		},
-		{ id: 'job', sourceTable: 'jobs', export: 'rebuild_from_d1' },
-		{
-			id: 'saved_package',
-			sourceTable: 'saved_packages',
-			export: 'rebuild_from_d1',
-		},
-	] as const
+  [
+    {
+      id: "memory",
+      source: { kind: "app_db", table: "mcp_memories" },
+      export: "rebuild_from_d1",
+    },
+    { id: "job", source: { kind: "jobs_rpc" }, export: "rebuild_from_d1" },
+    {
+      id: "saved_package",
+      source: { kind: "app_db", table: "saved_packages" },
+      export: "rebuild_from_d1",
+    },
+  ] as const;
 
 export const accountUserOwnedKvKeySchemes: ReadonlyArray<UserOwnedKvKeyScheme> =
-	[
-		{
-			id: 'published_bundle_artifact_kv_key',
-			binding: 'BUNDLE_ARTIFACTS_KV',
-			sourceTable: 'published_bundle_artifacts',
-			sourceColumn: 'kv_key',
-			prefixTemplate: 'bundle-artifact:v1:',
-		},
-		{
-			id: 'source_snapshot',
-			binding: 'BUNDLE_ARTIFACTS_KV',
-			prefixTemplate: 'source-snapshot:v1:{sourceId}:',
-		},
-		{
-			id: 'source_manifest_snapshot',
-			binding: 'BUNDLE_ARTIFACTS_KV',
-			prefixTemplate: 'source-manifest-snapshot:v1:{sourceId}:',
-		},
-		{
-			id: 'community_snapshot',
-			binding: 'BUNDLE_ARTIFACTS_KV',
-			prefixTemplate: 'community-snapshot:v1:',
-		},
-		{
-			id: 'community_icon_derived_cache',
-			binding: 'BUNDLE_ARTIFACTS_KV',
-			prefixTemplate: 'derived-cache:v1:community-icon:v3:{listingId}:',
-			notes:
-				'Derived cache key from derivedCacheKeyPrefix + buildCommunityIconCacheKey. Account deletion also prefixes historical community-icon:v1 and community-icon:v2 keys.',
-		},
-		{
-			id: 'usage_rollup_derived_cache',
-			binding: 'BUNDLE_ARTIFACTS_KV',
-			prefixTemplate: 'derived-cache:v1:usage-rollups:user:{userId}:',
-			retention:
-				'Expires through the KV expirationTtl written by the cachified adapter; the configured retention is five minutes.',
-			notes:
-				'Short-lived derived admin read model. Immediate account-deletion cleanup is optional because KV enforces the TTL.',
-		},
-		{
-			id: 'artifact_head_derived_cache',
-			binding: 'BUNDLE_ARTIFACTS_KV',
-			prefixTemplate: 'derived-cache:v1:artifact-head:v1:{namespace}:{repoId}',
-			retention:
-				'Expires through the KV expirationTtl written by the cachified adapter; retention is at most 65 minutes (5 minute TTL plus 1 hour stale-while-revalidate).',
-			notes:
-				'Default-branch HEAD of an Artifacts repo for package pages (buildArtifactSourceHeadCacheKey). Holds a branch name and commit hash only. Immediate account-deletion cleanup is optional because KV enforces the TTL and the repo id stops resolving once entity_sources is gone.',
-		},
-		{
-			id: 'package_retriever_manifest',
-			binding: 'BUNDLE_ARTIFACTS_KV',
-			prefixTemplate: 'package-retriever-manifest:v1:{userId}:{packageId}:',
-			notes: 'Deleted by deleteAllPackageRetrieverCacheEntriesForUser.',
-		},
-		{
-			id: 'package_retriever_index_entry',
-			binding: 'BUNDLE_ARTIFACTS_KV',
-			prefixTemplate:
-				'package-retriever-index-entry:v1:{userId}:{scope}:{packageId}:',
-			notes: 'Deleted by deleteAllPackageRetrieverCacheEntriesForUser.',
-		},
-		{
-			id: 'webhook_dispatch_payload',
-			binding: 'BUNDLE_ARTIFACTS_KV',
-			prefixTemplate: 'webhook-dispatch-payload:v1:{userId}:',
-			retention:
-				'Expires through the KV expirationTtl written at store time; retention is 24 hours.',
-			notes:
-				'Short-lived ack-mode webhook body spill so Cloudflare Queue messages stay under 128 KB. Immediate account-deletion cleanup is optional because KV enforces the TTL. The consumer deletes the key after a terminal delivery.',
-		},
-	] as const
+  [
+    {
+      id: "published_bundle_artifact_kv_key",
+      binding: "BUNDLE_ARTIFACTS_KV",
+      sourceTable: "published_bundle_artifacts",
+      sourceColumn: "kv_key",
+      prefixTemplate: "bundle-artifact:v1:",
+    },
+    {
+      id: "source_snapshot",
+      binding: "BUNDLE_ARTIFACTS_KV",
+      prefixTemplate: "source-snapshot:v1:{sourceId}:",
+    },
+    {
+      id: "source_manifest_snapshot",
+      binding: "BUNDLE_ARTIFACTS_KV",
+      prefixTemplate: "source-manifest-snapshot:v1:{sourceId}:",
+    },
+    {
+      id: "community_snapshot",
+      binding: "BUNDLE_ARTIFACTS_KV",
+      prefixTemplate: "community-snapshot:v1:",
+    },
+    {
+      id: "community_icon_derived_cache",
+      binding: "BUNDLE_ARTIFACTS_KV",
+      prefixTemplate: "derived-cache:v1:community-icon:v3:{listingId}:",
+      notes:
+        "Derived cache key from derivedCacheKeyPrefix + buildCommunityIconCacheKey. Account deletion also prefixes historical community-icon:v1 and community-icon:v2 keys.",
+    },
+    {
+      id: "usage_rollup_derived_cache",
+      binding: "BUNDLE_ARTIFACTS_KV",
+      prefixTemplate: "derived-cache:v1:usage-rollups:user:{userId}:",
+      retention:
+        "Expires through the KV expirationTtl written by the cachified adapter; the configured retention is five minutes.",
+      notes:
+        "Short-lived derived admin read model. Immediate account-deletion cleanup is optional because KV enforces the TTL.",
+    },
+    {
+      id: "artifact_head_derived_cache",
+      binding: "BUNDLE_ARTIFACTS_KV",
+      prefixTemplate: "derived-cache:v1:artifact-head:v1:{namespace}:{repoId}",
+      retention:
+        "Expires through the KV expirationTtl written by the cachified adapter; retention is at most 65 minutes (5 minute TTL plus 1 hour stale-while-revalidate).",
+      notes:
+        "Default-branch HEAD of an Artifacts repo for package pages (buildArtifactSourceHeadCacheKey). Holds a branch name and commit hash only. Immediate account-deletion cleanup is optional because KV enforces the TTL and the repo id stops resolving once entity_sources is gone.",
+    },
+    {
+      id: "package_retriever_manifest",
+      binding: "BUNDLE_ARTIFACTS_KV",
+      prefixTemplate: "package-retriever-manifest:v1:{userId}:{packageId}:",
+      notes: "Deleted by deleteAllPackageRetrieverCacheEntriesForUser.",
+    },
+    {
+      id: "package_retriever_index_entry",
+      binding: "BUNDLE_ARTIFACTS_KV",
+      prefixTemplate:
+        "package-retriever-index-entry:v1:{userId}:{scope}:{packageId}:",
+      notes: "Deleted by deleteAllPackageRetrieverCacheEntriesForUser.",
+    },
+    {
+      id: "webhook_dispatch_payload",
+      binding: "BUNDLE_ARTIFACTS_KV",
+      prefixTemplate: "webhook-dispatch-payload:v1:{userId}:",
+      retention:
+        "Expires through the KV expirationTtl written at store time; retention is 24 hours.",
+      notes:
+        "Short-lived ack-mode webhook body spill so Cloudflare Queue messages stay under 128 KB. Immediate account-deletion cleanup is optional because KV enforces the TTL. The consumer deletes the key after a terminal delivery.",
+    },
+  ] as const;
 
 export const accountUserOwnedR2Surfaces: ReadonlyArray<UserOwnedR2Surface> = [
-	{
-		id: 'email_raw_mime',
-		binding: 'EMAIL_BLOBS',
-		sourceTable: 'Mailbox.email_messages',
-		sourceColumn: 'id',
-		keyTemplate: 'email-raw:v1:{userId}/{messageId}',
-		export: 'chunked_bytes',
-		notes:
-			'Authoritative references come from Mailbox.listBlobReferences; canonical key generated by emailRawMimeKey.',
-	},
-	{
-		id: 'email_attachment_storage_key',
-		binding: 'EMAIL_BLOBS',
-		sourceTable: 'Mailbox.email_attachments',
-		sourceColumn: 'storage_key',
-		keyTemplate: 'email-attachment:v1:{userId}/{messageId}/{attachmentId}',
-		export: 'chunked_bytes',
-		notes:
-			'Authoritative owner-safe references come from Mailbox.listBlobReferences.',
-	},
-	{
-		id: 'community_icon',
-		binding: 'COMMUNITY_ASSETS',
-		sourceTable: 'community_listings',
-		keyTemplate: 'community-icon:v3/{listingId}/{commit}/asset',
-		export: 'chunked_bytes',
-		notes:
-			'Current fitted WebP derivative. Account deletion also removes historical community-icon:v1 and community-icon:v2 prefixes.',
-	},
-	{
-		id: 'user_avatar',
-		binding: 'COMMUNITY_ASSETS',
-		sourceTable: 'users',
-		sourceColumn: 'avatar_key',
-		export: 'chunked_bytes',
-	},
-] as const
+  {
+    id: "email_raw_mime",
+    binding: "EMAIL_BLOBS",
+    sourceTable: "Mailbox.email_messages",
+    sourceColumn: "id",
+    keyTemplate: "email-raw:v1:{userId}/{messageId}",
+    export: "chunked_bytes",
+    notes:
+      "Authoritative references come from Mailbox.listBlobReferences; canonical key generated by emailRawMimeKey.",
+  },
+  {
+    id: "email_attachment_storage_key",
+    binding: "EMAIL_BLOBS",
+    sourceTable: "Mailbox.email_attachments",
+    sourceColumn: "storage_key",
+    keyTemplate: "email-attachment:v1:{userId}/{messageId}/{attachmentId}",
+    export: "chunked_bytes",
+    notes:
+      "Authoritative owner-safe references come from Mailbox.listBlobReferences.",
+  },
+  {
+    id: "community_icon",
+    binding: "COMMUNITY_ASSETS",
+    sourceTable: "community_listings",
+    keyTemplate: "community-icon:v3/{listingId}/{commit}/asset",
+    export: "chunked_bytes",
+    notes:
+      "Current fitted WebP derivative. Account deletion also removes historical community-icon:v1 and community-icon:v2 prefixes.",
+  },
+  {
+    id: "user_avatar",
+    binding: "COMMUNITY_ASSETS",
+    sourceTable: "users",
+    sourceColumn: "avatar_key",
+    export: "chunked_bytes",
+  },
+] as const;
 
 export const accountUserOwnedArtifactSurfaces: ReadonlyArray<UserOwnedArtifactSurface> =
-	[
-		{
-			id: 'entity_sources',
-			sourceTable: 'entity_sources',
-			repoColumn: 'repo_id',
-			notes:
-				'Cloudflare Artifacts repos cleaned by cleanupAllUserArtifactRepos.',
-		},
-	] as const
+  [
+    {
+      id: "entity_sources",
+      sourceTable: "entity_sources",
+      repoColumn: "repo_id",
+      notes:
+        "Cloudflare Artifacts repos cleaned by cleanupAllUserArtifactRepos.",
+    },
+  ] as const;
 
 const accountExportExcludedDurableObjectDisplayNames: Readonly<
-	Record<
-		'mcp' | 'repo_session' | 'package_realtime_session' | 'stripe_plan_refresh',
-		string
-	>
+  Record<
+    "mcp" | "repo_session" | "package_realtime_session" | "stripe_plan_refresh",
+    string
+  >
 > = {
-	mcp: 'MCP',
-	repo_session: 'RepoSession',
-	package_realtime_session: 'PackageRealtimeSession',
-	stripe_plan_refresh: 'StripePlanRefresh',
-} as const
+  mcp: "MCP",
+  repo_session: "RepoSession",
+  package_realtime_session: "PackageRealtimeSession",
+  stripe_plan_refresh: "StripePlanRefresh",
+} as const;
 
 export function getAccountExportExcludedDurableObjects(): Array<{
-	name: string
-	reason: string
+  name: string;
+  reason: string;
 }> {
-	return (
-		[
-			'mcp',
-			'repo_session',
-			'package_realtime_session',
-			'stripe_plan_refresh',
-		] satisfies Array<
-			keyof typeof accountExportExcludedDurableObjectDisplayNames
-		>
-	).map((id) => {
-		const surface = accountUserOwnedDurableObjectSurfaces.find(
-			(candidate) => candidate.id === id,
-		)
-		if (!surface || surface.export !== 'exclude' || !surface.excludeReason) {
-			throw new Error(`Missing account export durable object exclusion: ${id}`)
-		}
-		return {
-			name: accountExportExcludedDurableObjectDisplayNames[id],
-			reason: surface.excludeReason,
-		}
-	})
+  return (
+    [
+      "mcp",
+      "repo_session",
+      "package_realtime_session",
+      "stripe_plan_refresh",
+    ] satisfies Array<
+      keyof typeof accountExportExcludedDurableObjectDisplayNames
+    >
+  ).map((id) => {
+    const surface = accountUserOwnedDurableObjectSurfaces.find(
+      (candidate) => candidate.id === id,
+    );
+    if (!surface || surface.export !== "exclude" || !surface.excludeReason) {
+      throw new Error(`Missing account export durable object exclusion: ${id}`);
+    }
+    return {
+      name: accountExportExcludedDurableObjectDisplayNames[id],
+      reason: surface.excludeReason,
+    };
+  });
 }
 
 export function getAccountDeletionDurableObjectResultKeys(): ReadonlyArray<string> {
-	return accountUserOwnedDurableObjectSurfaces
-		.map((surface) => surface.deletionResultKey)
-		.filter((key): key is string => key !== null)
+  return accountUserOwnedDurableObjectSurfaces
+    .map((surface) => surface.deletionResultKey)
+    .filter((key): key is string => key !== null);
 }
 
 export function getAccountUserOwnedSurfaceCoverage(): {
-	durableObjectIds: ReadonlySet<string>
-	vectorizeIds: ReadonlySet<string>
-	kvSchemeIds: ReadonlySet<string>
-	r2SurfaceIds: ReadonlySet<string>
-	artifactSurfaceIds: ReadonlySet<string>
+  durableObjectIds: ReadonlySet<string>;
+  vectorizeIds: ReadonlySet<string>;
+  kvSchemeIds: ReadonlySet<string>;
+  r2SurfaceIds: ReadonlySet<string>;
+  artifactSurfaceIds: ReadonlySet<string>;
 } {
-	return {
-		durableObjectIds: new Set(
-			accountUserOwnedDurableObjectSurfaces.map((surface) => surface.id),
-		),
-		vectorizeIds: new Set(
-			accountUserOwnedVectorizeSurfaces.map((surface) => surface.id),
-		),
-		kvSchemeIds: new Set(
-			accountUserOwnedKvKeySchemes.map((scheme) => scheme.id),
-		),
-		r2SurfaceIds: new Set(
-			accountUserOwnedR2Surfaces.map((surface) => surface.id),
-		),
-		artifactSurfaceIds: new Set(
-			accountUserOwnedArtifactSurfaces.map((surface) => surface.id),
-		),
-	}
+  return {
+    durableObjectIds: new Set(
+      accountUserOwnedDurableObjectSurfaces.map((surface) => surface.id),
+    ),
+    vectorizeIds: new Set(
+      accountUserOwnedVectorizeSurfaces.map((surface) => surface.id),
+    ),
+    kvSchemeIds: new Set(
+      accountUserOwnedKvKeySchemes.map((scheme) => scheme.id),
+    ),
+    r2SurfaceIds: new Set(
+      accountUserOwnedR2Surfaces.map((surface) => surface.id),
+    ),
+    artifactSurfaceIds: new Set(
+      accountUserOwnedArtifactSurfaces.map((surface) => surface.id),
+    ),
+  };
 }

--- a/packages/worker/src/account/user-owned-surfaces.ts
+++ b/packages/worker/src/account/user-owned-surfaces.ts
@@ -1,23 +1,23 @@
 export type UserOwnedDurableObjectSurface = {
-  id:
-    | "job_manager"
-    | "storage_runner"
-    | "repo_session"
-    | "mcp_client_hub"
-    | "package_realtime_session"
-    | "run_log"
-    | "user_meter"
-    | "stripe_plan_refresh"
-    | "mailbox"
-    | "repo_session_index"
-    | "mcp";
-  binding: string;
-  /** Result key used in AccountDeletionResult.clearedDurableObjects when purged */
-  deletionResultKey: string | null;
-  export: "include" | "exclude";
-  excludeReason?: string;
-  notes?: string;
-};
+	id:
+		| 'job_manager'
+		| 'storage_runner'
+		| 'repo_session'
+		| 'mcp_client_hub'
+		| 'package_realtime_session'
+		| 'run_log'
+		| 'user_meter'
+		| 'stripe_plan_refresh'
+		| 'mailbox'
+		| 'repo_session_index'
+		| 'mcp'
+	binding: string
+	/** Result key used in AccountDeletionResult.clearedDurableObjects when purged */
+	deletionResultKey: string | null
+	export: 'include' | 'exclude'
+	excludeReason?: string
+	notes?: string
+}
 
 /**
  * Where the D1 rows that own a vector surface live. `app_db` surfaces are
@@ -27,357 +27,357 @@ export type UserOwnedDurableObjectSurface = {
  * has no `jobs` table since migration 0010.
  */
 export type UserOwnedVectorizeSource =
-  | { kind: "app_db"; table: "mcp_memories" | "saved_packages" }
-  | { kind: "jobs_rpc" };
+	| { kind: 'app_db'; table: 'mcp_memories' | 'saved_packages' }
+	| { kind: 'jobs_rpc' }
 
 export type UserOwnedVectorizeSurface = {
-  id: "memory" | "job" | "saved_package";
-  source: UserOwnedVectorizeSource;
-  /** Exported as derivedData.vectorize note; never exported as vectors */
-  export: "rebuild_from_d1";
-};
+	id: 'memory' | 'job' | 'saved_package'
+	source: UserOwnedVectorizeSource
+	/** Exported as derivedData.vectorize note; never exported as vectors */
+	export: 'rebuild_from_d1'
+}
 
 export type UserOwnedKvKeyScheme = {
-  id:
-    | "published_bundle_artifact_kv_key"
-    | "source_snapshot"
-    | "source_manifest_snapshot"
-    | "community_snapshot"
-    | "community_icon_derived_cache"
-    | "usage_rollup_derived_cache"
-    | "artifact_head_derived_cache"
-    | "package_retriever_manifest"
-    | "package_retriever_index_entry"
-    | "package_retriever_index_prefix"
-    | "webhook_dispatch_payload";
-  binding: "BUNDLE_ARTIFACTS_KV";
-  sourceTable?: string;
-  sourceColumn?: string;
-  prefixTemplate?: string;
-  retention?: string;
-  notes?: string;
-};
+	id:
+		| 'published_bundle_artifact_kv_key'
+		| 'source_snapshot'
+		| 'source_manifest_snapshot'
+		| 'community_snapshot'
+		| 'community_icon_derived_cache'
+		| 'usage_rollup_derived_cache'
+		| 'artifact_head_derived_cache'
+		| 'package_retriever_manifest'
+		| 'package_retriever_index_entry'
+		| 'package_retriever_index_prefix'
+		| 'webhook_dispatch_payload'
+	binding: 'BUNDLE_ARTIFACTS_KV'
+	sourceTable?: string
+	sourceColumn?: string
+	prefixTemplate?: string
+	retention?: string
+	notes?: string
+}
 
 export type UserOwnedR2Surface = {
-  id:
-    | "email_raw_mime"
-    | "email_attachment_storage_key"
-    | "community_icon"
-    | "user_avatar";
-  binding: "EMAIL_BLOBS" | "COMMUNITY_ASSETS";
-  sourceTable: string;
-  sourceColumn?: string;
-  keyTemplate?: string;
-  export: "chunked_bytes";
-  notes?: string;
-};
+	id:
+		| 'email_raw_mime'
+		| 'email_attachment_storage_key'
+		| 'community_icon'
+		| 'user_avatar'
+	binding: 'EMAIL_BLOBS' | 'COMMUNITY_ASSETS'
+	sourceTable: string
+	sourceColumn?: string
+	keyTemplate?: string
+	export: 'chunked_bytes'
+	notes?: string
+}
 
 export type UserOwnedArtifactSurface = {
-  id: "entity_sources";
-  sourceTable: string;
-  repoColumn: string;
-  notes: string;
-};
+	id: 'entity_sources'
+	sourceTable: string
+	repoColumn: string
+	notes: string
+}
 
 export const accountUserOwnedDurableObjectSurfaces: ReadonlyArray<UserOwnedDurableObjectSurface> =
-  [
-    {
-      id: "job_manager",
-      binding: "JOBS",
-      deletionResultKey: "jobManagers",
-      export: "include",
-      notes:
-        "Job manager state lives in the jobs worker (ADR 0016) and is reached through the JOBS service binding; it is included in account export.",
-    },
-    {
-      id: "storage_runner",
-      binding: "STORAGE_RUNNER",
-      deletionResultKey: "storageRunners",
-      export: "include",
-    },
-    {
-      id: "repo_session",
-      binding: "REPO_SESSION",
-      deletionResultKey: "repoSessions",
-      export: "exclude",
-      excludeReason:
-        "Ephemeral editing workspace, including REPO_SESSION_BLOBS spill purged with the session Durable Object. Canonical repo-backed source is exported as Artifacts repo pointers via entity_sources; session catalog metadata is exported from RepoSessionIndex.",
-    },
-    {
-      id: "mcp_client_hub",
-      binding: "MCP_CLIENT_HUB",
-      deletionResultKey: "mcpClientHubs",
-      export: "exclude",
-      excludeReason:
-        "MCP client hub state can include OAuth tokens and SDK registrations that are non-portable; it is purged during account deletion instead of exported.",
-    },
-    {
-      id: "package_realtime_session",
-      binding: "PACKAGE_REALTIME_SESSION",
-      deletionResultKey: "packageRealtimeSessions",
-      export: "exclude",
-      excludeReason:
-        "Ephemeral live websocket/session state. Durable app storage is exported through StorageRunner buckets.",
-    },
-    {
-      id: "run_log",
-      binding: "RUN_LOG",
-      deletionResultKey: "runLogs",
-      export: "include",
-      notes:
-        "Per-user RunLog DO (RUN_LOG binding; idFromName(userId)). Sole runtime authority for pruned run history (runs + run_logs), the keyed package-invocation idempotency ledger, and dedicated state: workflow_projections (binding_name, typically DYNAMIC_CALLABLE_WORKFLOWS; terminal rows age-prune after 90 days), job_run_observability (terminal outcomes/counters; D1 jobs keeps schedule + last_run_at/last_run_status for retention only), package_run_successes, and activation_milestones. There are no D1 tables workflow_runs, user_package_run_successes, or user_activation_milestones (pre-drop Time Travel bookmark 0000116d-000000d2-000050bd-c7ecd5892a189df7cda145af746bc9c9 on database 8c1014d1-6b41-4695-a0a2-159071f0f919). Run history self-prunes (~30 days / 2,000 runs); job/activation dedicated tables are never pruned. Account deletion clearAll deletes every DO table and reinitializes schema. Account export pages all tables through the run_records section (runs first, then ledger, then dedicated phases).",
-    },
-    {
-      id: "user_meter",
-      binding: "USER_METER",
-      deletionResultKey: "userMeters",
-      export: "include",
-      notes:
-        "Per-user daily entitlement counters, storage-byte state, and deletion-fence/write-lease state (one DO per stable userId). Daily counters and storage bytes are authoritative in UserMeter; users has no d1_storage_bytes mirror columns, and the reconcile lane sweeps users by stable_user_id keyset from the platform-owned d1_storage_reconcile_cursor row. UserMeter is the sole lease authority: all callers (including email paths) supply USER_METER via env; acquireWriteLease writes to the DO only and countActiveWriteLeases is a direct DO COUNT (no paging). There is no D1 account_write_leases table; D1 users.deleting_at remains the permanent point gate and account_write_lease_repairs remains the admin repair audit log. Self-prunes stale UTC-day rows inside the DO rather than through a retention cron lane; account deletion purge clears counters, storage-byte state, and write leases while preserving an existing deleting tombstone during cleanup, then origin drops that tombstone after the D1 user row is deleted so the email-derived stable_user_id can be reused; account export pages counters through the user_meter section via exportCounters and includes authoritative storageBytesState and sanitized deletionState without raw lease token/holder on the first page only.",
-    },
-    {
-      id: "stripe_plan_refresh",
-      binding: "STRIPE_PLAN_REFRESH",
-      deletionResultKey: "stripePlanRefreshes",
-      export: "exclude",
-      excludeReason:
-        "Ephemeral one-shot Stripe reconciliation alarm state. Billing columns remain canonical in D1 and are included in the users export.",
-      notes:
-        "One alarm object per stable userId. Account deletion cancels the alarm and clears its stored owner id.",
-    },
-    {
-      id: "mailbox",
-      binding: "MAILBOX",
-      deletionResultKey: "mailboxes",
-      export: "include",
-      notes:
-        "Per-user authoritative email metadata and R2-reference inventory (MAILBOX binding; idFromName(userId)). Account export pages the sole USER email graph through exportMailbox. Account deletion lists Mailbox blob references before deleting R2 objects and purging the DO; D1 retains only thin provider, due-work, alert, and configuration rows.",
-    },
-    {
-      id: "repo_session_index",
-      binding: "REPO_SESSION_INDEX",
-      deletionResultKey: "repoSessionIndexes",
-      export: "include",
-      notes:
-        "Per-user repo session catalog (REPO_SESSION_INDEX binding; idFromName(userId)). Authority for session rows, active counts, conversation resume, export, and deletion inventory. Workspace bytes stay in per-session RepoSession DOs. D1 keeps only the thin repo_session_due_owners hint plus the storage-bucket inventory cursor.",
-    },
-    {
-      id: "mcp",
-      binding: "MCP",
-      deletionResultKey: "mcpAgentSessions",
-      export: "exclude",
-      excludeReason:
-        "Session-keyed by the MCP SDK and not globally enumerable; durable user data is carried by D1 and user-scoped stores instead.",
-      notes:
-        "Session DO ids are indexed by user in mcp_agent_sessions and purged during account deletion.",
-    },
-  ] as const;
+	[
+		{
+			id: 'job_manager',
+			binding: 'JOBS',
+			deletionResultKey: 'jobManagers',
+			export: 'include',
+			notes:
+				'Job manager state lives in the jobs worker (ADR 0016) and is reached through the JOBS service binding; it is included in account export.',
+		},
+		{
+			id: 'storage_runner',
+			binding: 'STORAGE_RUNNER',
+			deletionResultKey: 'storageRunners',
+			export: 'include',
+		},
+		{
+			id: 'repo_session',
+			binding: 'REPO_SESSION',
+			deletionResultKey: 'repoSessions',
+			export: 'exclude',
+			excludeReason:
+				'Ephemeral editing workspace, including REPO_SESSION_BLOBS spill purged with the session Durable Object. Canonical repo-backed source is exported as Artifacts repo pointers via entity_sources; session catalog metadata is exported from RepoSessionIndex.',
+		},
+		{
+			id: 'mcp_client_hub',
+			binding: 'MCP_CLIENT_HUB',
+			deletionResultKey: 'mcpClientHubs',
+			export: 'exclude',
+			excludeReason:
+				'MCP client hub state can include OAuth tokens and SDK registrations that are non-portable; it is purged during account deletion instead of exported.',
+		},
+		{
+			id: 'package_realtime_session',
+			binding: 'PACKAGE_REALTIME_SESSION',
+			deletionResultKey: 'packageRealtimeSessions',
+			export: 'exclude',
+			excludeReason:
+				'Ephemeral live websocket/session state. Durable app storage is exported through StorageRunner buckets.',
+		},
+		{
+			id: 'run_log',
+			binding: 'RUN_LOG',
+			deletionResultKey: 'runLogs',
+			export: 'include',
+			notes:
+				'Per-user RunLog DO (RUN_LOG binding; idFromName(userId)). Sole runtime authority for pruned run history (runs + run_logs), the keyed package-invocation idempotency ledger, and dedicated state: workflow_projections (binding_name, typically DYNAMIC_CALLABLE_WORKFLOWS; terminal rows age-prune after 90 days), job_run_observability (terminal outcomes/counters; D1 jobs keeps schedule + last_run_at/last_run_status for retention only), package_run_successes, and activation_milestones. There are no D1 tables workflow_runs, user_package_run_successes, or user_activation_milestones (pre-drop Time Travel bookmark 0000116d-000000d2-000050bd-c7ecd5892a189df7cda145af746bc9c9 on database 8c1014d1-6b41-4695-a0a2-159071f0f919). Run history self-prunes (~30 days / 2,000 runs); job/activation dedicated tables are never pruned. Account deletion clearAll deletes every DO table and reinitializes schema. Account export pages all tables through the run_records section (runs first, then ledger, then dedicated phases).',
+		},
+		{
+			id: 'user_meter',
+			binding: 'USER_METER',
+			deletionResultKey: 'userMeters',
+			export: 'include',
+			notes:
+				'Per-user daily entitlement counters, storage-byte state, and deletion-fence/write-lease state (one DO per stable userId). Daily counters and storage bytes are authoritative in UserMeter; users has no d1_storage_bytes mirror columns, and the reconcile lane sweeps users by stable_user_id keyset from the platform-owned d1_storage_reconcile_cursor row. UserMeter is the sole lease authority: all callers (including email paths) supply USER_METER via env; acquireWriteLease writes to the DO only and countActiveWriteLeases is a direct DO COUNT (no paging). There is no D1 account_write_leases table; D1 users.deleting_at remains the permanent point gate and account_write_lease_repairs remains the admin repair audit log. Self-prunes stale UTC-day rows inside the DO rather than through a retention cron lane; account deletion purge clears counters, storage-byte state, and write leases while preserving an existing deleting tombstone during cleanup, then origin drops that tombstone after the D1 user row is deleted so the email-derived stable_user_id can be reused; account export pages counters through the user_meter section via exportCounters and includes authoritative storageBytesState and sanitized deletionState without raw lease token/holder on the first page only.',
+		},
+		{
+			id: 'stripe_plan_refresh',
+			binding: 'STRIPE_PLAN_REFRESH',
+			deletionResultKey: 'stripePlanRefreshes',
+			export: 'exclude',
+			excludeReason:
+				'Ephemeral one-shot Stripe reconciliation alarm state. Billing columns remain canonical in D1 and are included in the users export.',
+			notes:
+				'One alarm object per stable userId. Account deletion cancels the alarm and clears its stored owner id.',
+		},
+		{
+			id: 'mailbox',
+			binding: 'MAILBOX',
+			deletionResultKey: 'mailboxes',
+			export: 'include',
+			notes:
+				'Per-user authoritative email metadata and R2-reference inventory (MAILBOX binding; idFromName(userId)). Account export pages the sole USER email graph through exportMailbox. Account deletion lists Mailbox blob references before deleting R2 objects and purging the DO; D1 retains only thin provider, due-work, alert, and configuration rows.',
+		},
+		{
+			id: 'repo_session_index',
+			binding: 'REPO_SESSION_INDEX',
+			deletionResultKey: 'repoSessionIndexes',
+			export: 'include',
+			notes:
+				'Per-user repo session catalog (REPO_SESSION_INDEX binding; idFromName(userId)). Authority for session rows, active counts, conversation resume, export, and deletion inventory. Workspace bytes stay in per-session RepoSession DOs. D1 keeps only the thin repo_session_due_owners hint plus the storage-bucket inventory cursor.',
+		},
+		{
+			id: 'mcp',
+			binding: 'MCP',
+			deletionResultKey: 'mcpAgentSessions',
+			export: 'exclude',
+			excludeReason:
+				'Session-keyed by the MCP SDK and not globally enumerable; durable user data is carried by D1 and user-scoped stores instead.',
+			notes:
+				'Session DO ids are indexed by user in mcp_agent_sessions and purged during account deletion.',
+		},
+	] as const
 
 export const accountUserOwnedVectorizeSurfaces: ReadonlyArray<UserOwnedVectorizeSurface> =
-  [
-    {
-      id: "memory",
-      source: { kind: "app_db", table: "mcp_memories" },
-      export: "rebuild_from_d1",
-    },
-    { id: "job", source: { kind: "jobs_rpc" }, export: "rebuild_from_d1" },
-    {
-      id: "saved_package",
-      source: { kind: "app_db", table: "saved_packages" },
-      export: "rebuild_from_d1",
-    },
-  ] as const;
+	[
+		{
+			id: 'memory',
+			source: { kind: 'app_db', table: 'mcp_memories' },
+			export: 'rebuild_from_d1',
+		},
+		{ id: 'job', source: { kind: 'jobs_rpc' }, export: 'rebuild_from_d1' },
+		{
+			id: 'saved_package',
+			source: { kind: 'app_db', table: 'saved_packages' },
+			export: 'rebuild_from_d1',
+		},
+	] as const
 
 export const accountUserOwnedKvKeySchemes: ReadonlyArray<UserOwnedKvKeyScheme> =
-  [
-    {
-      id: "published_bundle_artifact_kv_key",
-      binding: "BUNDLE_ARTIFACTS_KV",
-      sourceTable: "published_bundle_artifacts",
-      sourceColumn: "kv_key",
-      prefixTemplate: "bundle-artifact:v1:",
-    },
-    {
-      id: "source_snapshot",
-      binding: "BUNDLE_ARTIFACTS_KV",
-      prefixTemplate: "source-snapshot:v1:{sourceId}:",
-    },
-    {
-      id: "source_manifest_snapshot",
-      binding: "BUNDLE_ARTIFACTS_KV",
-      prefixTemplate: "source-manifest-snapshot:v1:{sourceId}:",
-    },
-    {
-      id: "community_snapshot",
-      binding: "BUNDLE_ARTIFACTS_KV",
-      prefixTemplate: "community-snapshot:v1:",
-    },
-    {
-      id: "community_icon_derived_cache",
-      binding: "BUNDLE_ARTIFACTS_KV",
-      prefixTemplate: "derived-cache:v1:community-icon:v3:{listingId}:",
-      notes:
-        "Derived cache key from derivedCacheKeyPrefix + buildCommunityIconCacheKey. Account deletion also prefixes historical community-icon:v1 and community-icon:v2 keys.",
-    },
-    {
-      id: "usage_rollup_derived_cache",
-      binding: "BUNDLE_ARTIFACTS_KV",
-      prefixTemplate: "derived-cache:v1:usage-rollups:user:{userId}:",
-      retention:
-        "Expires through the KV expirationTtl written by the cachified adapter; the configured retention is five minutes.",
-      notes:
-        "Short-lived derived admin read model. Immediate account-deletion cleanup is optional because KV enforces the TTL.",
-    },
-    {
-      id: "artifact_head_derived_cache",
-      binding: "BUNDLE_ARTIFACTS_KV",
-      prefixTemplate: "derived-cache:v1:artifact-head:v1:{namespace}:{repoId}",
-      retention:
-        "Expires through the KV expirationTtl written by the cachified adapter; retention is at most 65 minutes (5 minute TTL plus 1 hour stale-while-revalidate).",
-      notes:
-        "Default-branch HEAD of an Artifacts repo for package pages (buildArtifactSourceHeadCacheKey). Holds a branch name and commit hash only. Immediate account-deletion cleanup is optional because KV enforces the TTL and the repo id stops resolving once entity_sources is gone.",
-    },
-    {
-      id: "package_retriever_manifest",
-      binding: "BUNDLE_ARTIFACTS_KV",
-      prefixTemplate: "package-retriever-manifest:v1:{userId}:{packageId}:",
-      notes: "Deleted by deleteAllPackageRetrieverCacheEntriesForUser.",
-    },
-    {
-      id: "package_retriever_index_entry",
-      binding: "BUNDLE_ARTIFACTS_KV",
-      prefixTemplate:
-        "package-retriever-index-entry:v1:{userId}:{scope}:{packageId}:",
-      notes: "Deleted by deleteAllPackageRetrieverCacheEntriesForUser.",
-    },
-    {
-      id: "webhook_dispatch_payload",
-      binding: "BUNDLE_ARTIFACTS_KV",
-      prefixTemplate: "webhook-dispatch-payload:v1:{userId}:",
-      retention:
-        "Expires through the KV expirationTtl written at store time; retention is 24 hours.",
-      notes:
-        "Short-lived ack-mode webhook body spill so Cloudflare Queue messages stay under 128 KB. Immediate account-deletion cleanup is optional because KV enforces the TTL. The consumer deletes the key after a terminal delivery.",
-    },
-  ] as const;
+	[
+		{
+			id: 'published_bundle_artifact_kv_key',
+			binding: 'BUNDLE_ARTIFACTS_KV',
+			sourceTable: 'published_bundle_artifacts',
+			sourceColumn: 'kv_key',
+			prefixTemplate: 'bundle-artifact:v1:',
+		},
+		{
+			id: 'source_snapshot',
+			binding: 'BUNDLE_ARTIFACTS_KV',
+			prefixTemplate: 'source-snapshot:v1:{sourceId}:',
+		},
+		{
+			id: 'source_manifest_snapshot',
+			binding: 'BUNDLE_ARTIFACTS_KV',
+			prefixTemplate: 'source-manifest-snapshot:v1:{sourceId}:',
+		},
+		{
+			id: 'community_snapshot',
+			binding: 'BUNDLE_ARTIFACTS_KV',
+			prefixTemplate: 'community-snapshot:v1:',
+		},
+		{
+			id: 'community_icon_derived_cache',
+			binding: 'BUNDLE_ARTIFACTS_KV',
+			prefixTemplate: 'derived-cache:v1:community-icon:v3:{listingId}:',
+			notes:
+				'Derived cache key from derivedCacheKeyPrefix + buildCommunityIconCacheKey. Account deletion also prefixes historical community-icon:v1 and community-icon:v2 keys.',
+		},
+		{
+			id: 'usage_rollup_derived_cache',
+			binding: 'BUNDLE_ARTIFACTS_KV',
+			prefixTemplate: 'derived-cache:v1:usage-rollups:user:{userId}:',
+			retention:
+				'Expires through the KV expirationTtl written by the cachified adapter; the configured retention is five minutes.',
+			notes:
+				'Short-lived derived admin read model. Immediate account-deletion cleanup is optional because KV enforces the TTL.',
+		},
+		{
+			id: 'artifact_head_derived_cache',
+			binding: 'BUNDLE_ARTIFACTS_KV',
+			prefixTemplate: 'derived-cache:v1:artifact-head:v1:{namespace}:{repoId}',
+			retention:
+				'Expires through the KV expirationTtl written by the cachified adapter; retention is at most 65 minutes (5 minute TTL plus 1 hour stale-while-revalidate).',
+			notes:
+				'Default-branch HEAD of an Artifacts repo for package pages (buildArtifactSourceHeadCacheKey). Holds a branch name and commit hash only. Immediate account-deletion cleanup is optional because KV enforces the TTL and the repo id stops resolving once entity_sources is gone.',
+		},
+		{
+			id: 'package_retriever_manifest',
+			binding: 'BUNDLE_ARTIFACTS_KV',
+			prefixTemplate: 'package-retriever-manifest:v1:{userId}:{packageId}:',
+			notes: 'Deleted by deleteAllPackageRetrieverCacheEntriesForUser.',
+		},
+		{
+			id: 'package_retriever_index_entry',
+			binding: 'BUNDLE_ARTIFACTS_KV',
+			prefixTemplate:
+				'package-retriever-index-entry:v1:{userId}:{scope}:{packageId}:',
+			notes: 'Deleted by deleteAllPackageRetrieverCacheEntriesForUser.',
+		},
+		{
+			id: 'webhook_dispatch_payload',
+			binding: 'BUNDLE_ARTIFACTS_KV',
+			prefixTemplate: 'webhook-dispatch-payload:v1:{userId}:',
+			retention:
+				'Expires through the KV expirationTtl written at store time; retention is 24 hours.',
+			notes:
+				'Short-lived ack-mode webhook body spill so Cloudflare Queue messages stay under 128 KB. Immediate account-deletion cleanup is optional because KV enforces the TTL. The consumer deletes the key after a terminal delivery.',
+		},
+	] as const
 
 export const accountUserOwnedR2Surfaces: ReadonlyArray<UserOwnedR2Surface> = [
-  {
-    id: "email_raw_mime",
-    binding: "EMAIL_BLOBS",
-    sourceTable: "Mailbox.email_messages",
-    sourceColumn: "id",
-    keyTemplate: "email-raw:v1:{userId}/{messageId}",
-    export: "chunked_bytes",
-    notes:
-      "Authoritative references come from Mailbox.listBlobReferences; canonical key generated by emailRawMimeKey.",
-  },
-  {
-    id: "email_attachment_storage_key",
-    binding: "EMAIL_BLOBS",
-    sourceTable: "Mailbox.email_attachments",
-    sourceColumn: "storage_key",
-    keyTemplate: "email-attachment:v1:{userId}/{messageId}/{attachmentId}",
-    export: "chunked_bytes",
-    notes:
-      "Authoritative owner-safe references come from Mailbox.listBlobReferences.",
-  },
-  {
-    id: "community_icon",
-    binding: "COMMUNITY_ASSETS",
-    sourceTable: "community_listings",
-    keyTemplate: "community-icon:v3/{listingId}/{commit}/asset",
-    export: "chunked_bytes",
-    notes:
-      "Current fitted WebP derivative. Account deletion also removes historical community-icon:v1 and community-icon:v2 prefixes.",
-  },
-  {
-    id: "user_avatar",
-    binding: "COMMUNITY_ASSETS",
-    sourceTable: "users",
-    sourceColumn: "avatar_key",
-    export: "chunked_bytes",
-  },
-] as const;
+	{
+		id: 'email_raw_mime',
+		binding: 'EMAIL_BLOBS',
+		sourceTable: 'Mailbox.email_messages',
+		sourceColumn: 'id',
+		keyTemplate: 'email-raw:v1:{userId}/{messageId}',
+		export: 'chunked_bytes',
+		notes:
+			'Authoritative references come from Mailbox.listBlobReferences; canonical key generated by emailRawMimeKey.',
+	},
+	{
+		id: 'email_attachment_storage_key',
+		binding: 'EMAIL_BLOBS',
+		sourceTable: 'Mailbox.email_attachments',
+		sourceColumn: 'storage_key',
+		keyTemplate: 'email-attachment:v1:{userId}/{messageId}/{attachmentId}',
+		export: 'chunked_bytes',
+		notes:
+			'Authoritative owner-safe references come from Mailbox.listBlobReferences.',
+	},
+	{
+		id: 'community_icon',
+		binding: 'COMMUNITY_ASSETS',
+		sourceTable: 'community_listings',
+		keyTemplate: 'community-icon:v3/{listingId}/{commit}/asset',
+		export: 'chunked_bytes',
+		notes:
+			'Current fitted WebP derivative. Account deletion also removes historical community-icon:v1 and community-icon:v2 prefixes.',
+	},
+	{
+		id: 'user_avatar',
+		binding: 'COMMUNITY_ASSETS',
+		sourceTable: 'users',
+		sourceColumn: 'avatar_key',
+		export: 'chunked_bytes',
+	},
+] as const
 
 export const accountUserOwnedArtifactSurfaces: ReadonlyArray<UserOwnedArtifactSurface> =
-  [
-    {
-      id: "entity_sources",
-      sourceTable: "entity_sources",
-      repoColumn: "repo_id",
-      notes:
-        "Cloudflare Artifacts repos cleaned by cleanupAllUserArtifactRepos.",
-    },
-  ] as const;
+	[
+		{
+			id: 'entity_sources',
+			sourceTable: 'entity_sources',
+			repoColumn: 'repo_id',
+			notes:
+				'Cloudflare Artifacts repos cleaned by cleanupAllUserArtifactRepos.',
+		},
+	] as const
 
 const accountExportExcludedDurableObjectDisplayNames: Readonly<
-  Record<
-    "mcp" | "repo_session" | "package_realtime_session" | "stripe_plan_refresh",
-    string
-  >
+	Record<
+		'mcp' | 'repo_session' | 'package_realtime_session' | 'stripe_plan_refresh',
+		string
+	>
 > = {
-  mcp: "MCP",
-  repo_session: "RepoSession",
-  package_realtime_session: "PackageRealtimeSession",
-  stripe_plan_refresh: "StripePlanRefresh",
-} as const;
+	mcp: 'MCP',
+	repo_session: 'RepoSession',
+	package_realtime_session: 'PackageRealtimeSession',
+	stripe_plan_refresh: 'StripePlanRefresh',
+} as const
 
 export function getAccountExportExcludedDurableObjects(): Array<{
-  name: string;
-  reason: string;
+	name: string
+	reason: string
 }> {
-  return (
-    [
-      "mcp",
-      "repo_session",
-      "package_realtime_session",
-      "stripe_plan_refresh",
-    ] satisfies Array<
-      keyof typeof accountExportExcludedDurableObjectDisplayNames
-    >
-  ).map((id) => {
-    const surface = accountUserOwnedDurableObjectSurfaces.find(
-      (candidate) => candidate.id === id,
-    );
-    if (!surface || surface.export !== "exclude" || !surface.excludeReason) {
-      throw new Error(`Missing account export durable object exclusion: ${id}`);
-    }
-    return {
-      name: accountExportExcludedDurableObjectDisplayNames[id],
-      reason: surface.excludeReason,
-    };
-  });
+	return (
+		[
+			'mcp',
+			'repo_session',
+			'package_realtime_session',
+			'stripe_plan_refresh',
+		] satisfies Array<
+			keyof typeof accountExportExcludedDurableObjectDisplayNames
+		>
+	).map((id) => {
+		const surface = accountUserOwnedDurableObjectSurfaces.find(
+			(candidate) => candidate.id === id,
+		)
+		if (!surface || surface.export !== 'exclude' || !surface.excludeReason) {
+			throw new Error(`Missing account export durable object exclusion: ${id}`)
+		}
+		return {
+			name: accountExportExcludedDurableObjectDisplayNames[id],
+			reason: surface.excludeReason,
+		}
+	})
 }
 
 export function getAccountDeletionDurableObjectResultKeys(): ReadonlyArray<string> {
-  return accountUserOwnedDurableObjectSurfaces
-    .map((surface) => surface.deletionResultKey)
-    .filter((key): key is string => key !== null);
+	return accountUserOwnedDurableObjectSurfaces
+		.map((surface) => surface.deletionResultKey)
+		.filter((key): key is string => key !== null)
 }
 
 export function getAccountUserOwnedSurfaceCoverage(): {
-  durableObjectIds: ReadonlySet<string>;
-  vectorizeIds: ReadonlySet<string>;
-  kvSchemeIds: ReadonlySet<string>;
-  r2SurfaceIds: ReadonlySet<string>;
-  artifactSurfaceIds: ReadonlySet<string>;
+	durableObjectIds: ReadonlySet<string>
+	vectorizeIds: ReadonlySet<string>
+	kvSchemeIds: ReadonlySet<string>
+	r2SurfaceIds: ReadonlySet<string>
+	artifactSurfaceIds: ReadonlySet<string>
 } {
-  return {
-    durableObjectIds: new Set(
-      accountUserOwnedDurableObjectSurfaces.map((surface) => surface.id),
-    ),
-    vectorizeIds: new Set(
-      accountUserOwnedVectorizeSurfaces.map((surface) => surface.id),
-    ),
-    kvSchemeIds: new Set(
-      accountUserOwnedKvKeySchemes.map((scheme) => scheme.id),
-    ),
-    r2SurfaceIds: new Set(
-      accountUserOwnedR2Surfaces.map((surface) => surface.id),
-    ),
-    artifactSurfaceIds: new Set(
-      accountUserOwnedArtifactSurfaces.map((surface) => surface.id),
-    ),
-  };
+	return {
+		durableObjectIds: new Set(
+			accountUserOwnedDurableObjectSurfaces.map((surface) => surface.id),
+		),
+		vectorizeIds: new Set(
+			accountUserOwnedVectorizeSurfaces.map((surface) => surface.id),
+		),
+		kvSchemeIds: new Set(
+			accountUserOwnedKvKeySchemes.map((scheme) => scheme.id),
+		),
+		r2SurfaceIds: new Set(
+			accountUserOwnedR2Surfaces.map((surface) => surface.id),
+		),
+		artifactSurfaceIds: new Set(
+			accountUserOwnedArtifactSurfaces.map((surface) => surface.id),
+		),
+	}
 }

--- a/packages/worker/src/app/account-deletion.node.test.ts
+++ b/packages/worker/src/app/account-deletion.node.test.ts
@@ -1,1204 +1,1341 @@
-import { quoteSqlIdentifier } from '@kody-internal/shared/sql-literals.ts'
-import { DatabaseSync } from 'node:sqlite'
-import { expect, test, vi } from 'vitest'
-import * as stripeClient from '#worker/billing/stripe-client.ts'
+import { quoteSqlIdentifier } from "@kody-internal/shared/sql-literals.ts";
+import { DatabaseSync } from "node:sqlite";
+import { expect, test, vi } from "vitest";
+import * as stripeClient from "#worker/billing/stripe-client.ts";
 import {
-	AccountDeletionCleanupError,
-	AccountDeletionInventoryError,
-	deleteUserAccount,
-	getAccountDeletionD1UserColumnCoverage,
-} from './account-deletion.ts'
-import { AccountDeletionWritersActiveError } from '#worker/account/deletion-state.ts'
-import { userMeterRpc } from '#worker/entitlements/user-meter-client.ts'
-import { accountUserDataExcludedOwnerIds } from '#worker/account/data-targets.ts'
-import { jobVectorId } from '#mcp/jobs-vectorize.ts'
-import { consoleError } from '#worker/test-support/console-spies.ts'
-import { createInMemoryUserMeterEnv } from '#worker/test-support/user-meter.ts'
+  AccountDeletionCleanupError,
+  AccountDeletionInventoryError,
+  deleteUserAccount,
+  getAccountDeletionD1UserColumnCoverage,
+} from "./account-deletion.ts";
+import { AccountDeletionWritersActiveError } from "#worker/account/deletion-state.ts";
+import { userMeterRpc } from "#worker/entitlements/user-meter-client.ts";
+import { accountUserDataExcludedOwnerIds } from "#worker/account/data-targets.ts";
+import { jobVectorId } from "#mcp/jobs-vectorize.ts";
+import { consoleError } from "#worker/test-support/console-spies.ts";
+import { createInMemoryUserMeterEnv } from "#worker/test-support/user-meter.ts";
 import {
-	insertRepoSession,
-	listRepoSessionsByUser,
-} from '#worker/repo/repo-sessions.ts'
-import { applyAllMigrations } from '#worker/test-support/apply-all-migrations.ts'
+  insertRepoSession,
+  listRepoSessionsByUser,
+} from "#worker/repo/repo-sessions.ts";
+import { applyAllMigrations } from "#worker/test-support/apply-all-migrations.ts";
+import { createD1FromSqlite } from "#worker/test-support/create-d1-from-sqlite.ts";
+import { accountUserOwnedVectorizeSurfaces } from "#worker/account/user-owned-surfaces.ts";
 import {
-	createTestDb,
-	createJobsBindingStub,
-	createSuccessfulDeletionEnv,
-} from '#worker/test-support/account-deletion.ts'
+  createTestDb,
+  createJobsBindingStub,
+  createSuccessfulDeletionEnv,
+} from "#worker/test-support/account-deletion.ts";
 
-test('account deletion D1 coverage includes every live user-owned schema column', () => {
-	const migrationsDir = new URL('../../migrations/', import.meta.url)
-	const db = new DatabaseSync(':memory:')
-	applyAllMigrations(db, migrationsDir)
-	const tables = db
-		.prepare(
-			`SELECT name
+const appMigrationsDir = new URL("../../migrations/", import.meta.url);
+
+function listSqliteTables(db: DatabaseSync) {
+  return (
+    db
+      .prepare(
+        `SELECT name
+				FROM sqlite_schema
+				WHERE type = 'table' AND name NOT LIKE 'sqlite_%'
+				ORDER BY name`,
+      )
+      .all() as Array<{ name: string }>
+  ).map((row) => row.name);
+}
+
+test("vectorize surface sources match the migrated APP_DB schema", () => {
+  const db = new DatabaseSync(":memory:");
+  applyAllMigrations(db, appMigrationsDir);
+  const tables = new Set(listSqliteTables(db));
+
+  // Jobs moved to the jobs worker's D1 (migration 0010 dropped the APP_DB
+  // copies), so the job surface must be sourced over the JOBS binding rather
+  // than an APP_DB table scan.
+  expect(tables.has("jobs")).toBe(false);
+  for (const surface of accountUserOwnedVectorizeSurfaces) {
+    switch (surface.source.kind) {
+      case "app_db": {
+        expect(
+          tables.has(surface.source.table),
+          `vectorize surface ${surface.id} reads APP_DB table ${surface.source.table}, which the migrated schema does not define`,
+        ).toBe(true);
+        break;
+      }
+      case "jobs_rpc": {
+        expect(surface.id).toBe("job");
+        break;
+      }
+      default: {
+        const unknownSource: never = surface.source;
+        throw new Error(
+          `Unknown vectorize source: ${JSON.stringify(unknownSource)}`,
+        );
+      }
+    }
+  }
+});
+
+test("deleteUserAccount enumerates job vectors through JOBS against the real post-0010 APP_DB schema", async () => {
+  const sqlite = new DatabaseSync(":memory:");
+  applyAllMigrations(sqlite, appMigrationsDir);
+  expect(listSqliteTables(sqlite)).not.toContain("jobs");
+  const db = createD1FromSqlite(sqlite);
+  const userId = "user-post-0010";
+  const inserted = await db
+    .prepare(
+      `INSERT INTO users (
+				username, email, password_hash, stable_user_id,
+				email_verified_at, account_type, created_at
+			) VALUES ('post0010', 'post0010@example.com', 'hash', ?, ?, 'person', ?)`,
+    )
+    .bind(userId, "2026-09-01T00:00:00.000Z", "2026-09-01T00:00:00.000Z")
+    .run();
+  const dbUserId = Number(inserted.meta.last_row_id);
+  await db
+    .prepare(
+      `INSERT INTO mcp_memories (id, user_id, subject, summary)
+			VALUES ('mem-post-0010', ?, 'subject', 'summary')`,
+    )
+    .bind(userId)
+    .run();
+
+  const deleteVectorsMock = vi.fn(async () => undefined);
+  const listJobIdsForUser = vi.fn(async (_input: { userId: string }) => [
+    "job-live-1",
+    "job-live-2",
+  ]);
+  const purgeJobsUser = vi.fn(async (input: { userId: string }) => ({
+    ok: true as const,
+    userId: input.userId,
+    purged: true,
+  }));
+  const env = createSuccessfulDeletionEnv(db, {
+    CAPABILITY_VECTOR_INDEX: { deleteByIds: deleteVectorsMock },
+    JOBS: {
+      listJobIdsForUser,
+      listJobStorageIdsForUser: async () => [] as Array<string>,
+      purgeUser: purgeJobsUser,
+    },
+  } as unknown as Partial<Env>);
+
+  const result = await deleteUserAccount({ env, dbUserId, mcpUserId: userId });
+
+  expect(listJobIdsForUser).toHaveBeenCalledWith({ userId });
+  expect(deleteVectorsMock).toHaveBeenCalledWith([
+    "memory_mem-post-0010",
+    jobVectorId("job-live-1"),
+    jobVectorId("job-live-2"),
+  ]);
+  expect(result.deletedVectors).toBe(3);
+  expect(purgeJobsUser).toHaveBeenCalledWith({ userId });
+  expect(result.warnings).toEqual([]);
+  expect(sqlite.prepare(`SELECT COUNT(*) AS count FROM users`).get()).toEqual({
+    count: 0,
+  });
+  expect(
+    sqlite.prepare(`SELECT COUNT(*) AS count FROM mcp_memories`).get(),
+  ).toEqual({ count: 0 });
+});
+
+test("deleteUserAccount fails inventory loudly when JOBS is unbound instead of scanning APP_DB for jobs", async () => {
+  const { db, rows } = createTestDb({
+    users: [{ id: 1, email: "a@example.com" }],
+  });
+  const env = createSuccessfulDeletionEnv(db, {
+    JOBS: undefined,
+  } as unknown as Partial<Env>);
+
+  await expect(
+    deleteUserAccount({ env, dbUserId: 1, mcpUserId: "user-aaa" }),
+  ).rejects.toSatisfy(
+    (error: unknown) =>
+      error instanceof AccountDeletionInventoryError &&
+      error.inventoryErrors.some((message) =>
+        message.includes(
+          "JOBS service binding is required to enumerate job vector ids",
+        ),
+      ),
+  );
+  expect(rows.users).toEqual([
+    expect.objectContaining({ id: 1, deleting_at: null }),
+  ]);
+});
+
+test("account deletion D1 coverage includes every live user-owned schema column", () => {
+  const migrationsDir = new URL("../../migrations/", import.meta.url);
+  const db = new DatabaseSync(":memory:");
+  applyAllMigrations(db, migrationsDir);
+  const tables = db
+    .prepare(
+      `SELECT name
 			FROM sqlite_schema
 			WHERE type = 'table' AND name NOT LIKE 'sqlite_%'
 			ORDER BY name`,
-		)
-		.all() as Array<{ name: string }>
-	const liveUserColumns = new Set<string>()
-	for (const table of tables) {
-		const columns = db
-			.prepare(`PRAGMA table_info(${quoteSqlIdentifier(table.name)})`)
-			.all() as Array<{ name: string }>
-		for (const column of columns) {
-			if (column.name === 'user_id' || column.name.endsWith('_user_id')) {
-				liveUserColumns.add(`${table.name}.${column.name}`)
-			}
-		}
-	}
-	const coveredColumns = getAccountDeletionD1UserColumnCoverage()
-	const missing = [...liveUserColumns].filter(
-		(column) => !coveredColumns.has(column),
-	)
-	const stale = [...coveredColumns].filter(
-		(column) => !liveUserColumns.has(column),
-	)
-	expect(
-		missing,
-		'user-owned D1 columns missing from account deletion',
-	).toEqual([])
-	expect(stale, 'account deletion references stale D1 columns').toEqual([])
-})
+    )
+    .all() as Array<{ name: string }>;
+  const liveUserColumns = new Set<string>();
+  for (const table of tables) {
+    const columns = db
+      .prepare(`PRAGMA table_info(${quoteSqlIdentifier(table.name)})`)
+      .all() as Array<{ name: string }>;
+    for (const column of columns) {
+      if (column.name === "user_id" || column.name.endsWith("_user_id")) {
+        liveUserColumns.add(`${table.name}.${column.name}`);
+      }
+    }
+  }
+  const coveredColumns = getAccountDeletionD1UserColumnCoverage();
+  const missing = [...liveUserColumns].filter(
+    (column) => !coveredColumns.has(column),
+  );
+  const stale = [...coveredColumns].filter(
+    (column) => !liveUserColumns.has(column),
+  );
+  expect(
+    missing,
+    "user-owned D1 columns missing from account deletion",
+  ).toEqual([]);
+  expect(stale, "account deletion references stale D1 columns").toEqual([]);
+});
 
-test('account deletion preserves operator-owned system email configuration', async () => {
-	expect(
-		accountUserDataExcludedOwnerIds.some(
-			(exclusion) => exclusion.ownerId === 'system:email',
-		),
-	).toBe(true)
+test("account deletion preserves operator-owned system email configuration", async () => {
+  expect(
+    accountUserDataExcludedOwnerIds.some(
+      (exclusion) => exclusion.ownerId === "system:email",
+    ),
+  ).toBe(true);
 
-	const { db, rows } = createTestDb({
-		users: [{ id: 1, email: 'user@example.com' }],
-		email_inboxes: [
-			{ id: 'user-inbox', user_id: 'user-aaa' },
-			{ id: 'system-inbox', user_id: 'system:email' },
-		],
-		email_inbox_addresses: [
-			{ id: 'user-address', user_id: 'user-aaa' },
-			{ id: 'system-address', user_id: 'system:email' },
-		],
-	})
+  const { db, rows } = createTestDb({
+    users: [{ id: 1, email: "user@example.com" }],
+    email_inboxes: [
+      { id: "user-inbox", user_id: "user-aaa" },
+      { id: "system-inbox", user_id: "system:email" },
+    ],
+    email_inbox_addresses: [
+      { id: "user-address", user_id: "user-aaa" },
+      { id: "system-address", user_id: "system:email" },
+    ],
+  });
 
-	await deleteUserAccount({
-		env: createSuccessfulDeletionEnv(db),
-		dbUserId: 1,
-		mcpUserId: 'user-aaa',
-	})
+  await deleteUserAccount({
+    env: createSuccessfulDeletionEnv(db),
+    dbUserId: 1,
+    mcpUserId: "user-aaa",
+  });
 
-	expect(rows.email_inboxes).toEqual([
-		{ id: 'system-inbox', user_id: 'system:email' },
-	])
-	expect(rows.email_inbox_addresses).toEqual([
-		{ id: 'system-address', user_id: 'system:email' },
-	])
-})
+  expect(rows.email_inboxes).toEqual([
+    { id: "system-inbox", user_id: "system:email" },
+  ]);
+  expect(rows.email_inbox_addresses).toEqual([
+    { id: "system-address", user_id: "system:email" },
+  ]);
+});
 
-test('deleteUserAccount cascades user-scoped rows for the requested user', async () => {
-	const userAaa = 'user-aaa'
-	const userBbb = 'user-bbb'
-	const packageJobId =
-		'package-job:b2fda105-005a-4e2b-9f22-1513b6752da2:event-runner'
-	const { db, rows } = createTestDb({
-		users: [
-			{
-				id: 1,
-				email: 'a@example.com',
-				avatar_key: 'user-avatars/user-aaa/abc123.png',
-			},
-			{ id: 2, email: 'b@example.com' },
-		],
-		jobs: [
-			{ id: 'job-1', user_id: userAaa, storage_id: 'job:job-1' },
-			{ id: 'job-2', user_id: userAaa, storage_id: null },
-			{ id: packageJobId, user_id: userAaa, storage_id: null },
-			{ id: 'job-3', user_id: userBbb, storage_id: 'job:job-3' },
-		],
-		user_storage_buckets: [
-			{
-				user_id: userAaa,
-				storage_id: 'exec:run-2',
-				kind: 'execute',
-			},
-			{
-				user_id: userAaa,
-				storage_id: 'repo-session:rs-1',
-				kind: 'repo_session',
-			},
-			{
-				user_id: userBbb,
-				storage_id: 'package:pkg-2',
-				kind: 'package',
-			},
-		],
-		mcp_memories: [
-			{ id: 'mem-1', user_id: userAaa },
-			{ id: 'mem-2', user_id: userBbb },
-		],
-		secret_buckets: [{ id: 'sb-1', user_id: userAaa }],
-		secret_entries: [{ bucket_id: 'sb-1', name: 's', user_id: 'unused' }],
-		value_buckets: [{ id: 'vb-1', user_id: userAaa }],
-		value_entries: [{ bucket_id: 'vb-1', name: 'v', user_id: 'unused' }],
-		mcp_agent_sessions: [
-			{ do_id: 'do-user-a', user_id: userAaa },
-			{ do_id: 'do-user-b', user_id: userBbb },
-		],
-		saved_packages: [
-			{
-				id: 'pkg-1',
-				user_id: userAaa,
-				kody_id: 'demo',
-				source_id: 'src-1',
-				has_app: 1,
-			},
-			{
-				id: 'pkg-2',
-				user_id: userBbb,
-				kody_id: 'other',
-				source_id: 'src-2',
-				has_app: 0,
-			},
-		],
-		published_bundle_artifacts: [
-			{ id: 'pba-1', user_id: userAaa, kv_key: 'bundle-artifact:v1:src-1' },
-			{ id: 'pba-2', user_id: userBbb, kv_key: 'bundle-artifact:v1:src-2' },
-		],
-		archived_job_artifacts: [
-			{ id: 'aja-1', user_id: userAaa, storage_id: 'job:archived-1' },
-		],
-		entity_sources: [
-			{ id: 'src-1', user_id: userAaa, published_commit: 'abc123' },
-			{ id: 'src-2', user_id: userBbb, published_commit: 'def456' },
-		],
-		password_resets: [
-			{ id: 1, user_id: 1 },
-			{ id: 2, user_id: 1 },
-			{ id: 3, user_id: 2 },
-		],
-		user_roles: [
-			{ user_id: 1, role_id: 1 },
-			{ user_id: 2, role_id: 2 },
-		],
-		passkeys: [
-			{ id: 'pk-1', user_id: 1 },
-			{ id: 'pk-2', user_id: 2 },
-		],
-		verifications: [
-			{ id: 1, type: '2fa', target: '1' },
-			{ id: 2, type: '2fa', target: '2' },
-		],
-		mcp_user_server_instructions: [{ user_id: userAaa }],
-		package_invocation_tokens: [{ id: 'pit-1', user_id: userAaa }],
-		agent_package_conversation_uses: [
-			{
-				user_id: userAaa,
-				package_id: 'pkg-1',
-				conversation_id: 'conv-1',
-			},
-		],
-		mcp_memory_conversation_suppressions: [
-			{ user_id: userAaa, conversation_id: 'c1', memory_id: 'mem-1' },
-		],
-		email_inboxes: [{ id: 'in-1', user_id: userAaa }],
-		email_inbox_addresses: [{ id: 'ia-1', user_id: userAaa }],
-		email_sender_identities: [{ id: 'ei-1', user_id: userAaa }],
-		platform_feedback: [
-			{
-				id: 'feedback-submitted-by-a',
-				submitter_user_id: userAaa,
-				submitter_username: 'user-a',
-				submitter_email: 'a@example.com',
-				reviewed_by_user_id: userBbb,
-				reviewed_at: '2026-07-05',
-				admin_note: 'Reviewed by B.',
-			},
-			{
-				id: 'feedback-reviewed-by-a',
-				submitter_user_id: userBbb,
-				submitter_username: 'user-b',
-				submitter_email: 'b@example.com',
-				reviewed_by_user_id: userAaa,
-				reviewed_at: '2026-07-05',
-				admin_note: 'Private admin note from A.',
-			},
-			{
-				id: 'feedback-unrelated',
-				submitter_user_id: userBbb,
-				submitter_username: 'user-b',
-				submitter_email: 'b@example.com',
-				reviewed_by_user_id: userBbb,
-				reviewed_at: '2026-07-05',
-				admin_note: 'Reviewed by B.',
-			},
-		],
-		community_listings: [
-			{
-				id: 'listing-1',
-				owner_user_id: userAaa,
-				pinned_commit: 'commit-1',
-				source_id: 'src-1',
-			},
-			{ id: 'listing-2', owner_user_id: userBbb, pinned_commit: 'commit-2' },
-		],
-		community_forks: [
-			{ id: 'fork-1', listing_id: 'listing-1', forker_user_id: userBbb },
-			{ id: 'fork-2', listing_id: 'listing-2', forker_user_id: userAaa },
-			{ id: 'fork-3', listing_id: 'listing-2', forker_user_id: userBbb },
-		],
-		community_ratings: [
-			{ id: 'rating-1', listing_id: 'listing-1', user_id: userBbb },
-			{ id: 'rating-2', listing_id: 'listing-2', user_id: userAaa },
-			{ id: 'rating-3', listing_id: 'listing-2', user_id: userBbb },
-		],
-		community_activity_events: [
-			{
-				id: 'evt-1',
-				actor_user_id: userAaa,
-				event_type: 'listing_published',
-				listing_id: 'listing-2',
-			},
-			{
-				id: 'evt-2',
-				actor_user_id: userBbb,
-				event_type: 'listing_updated',
-				listing_id: 'listing-1',
-			},
-			{
-				id: 'evt-3',
-				actor_user_id: userBbb,
-				event_type: 'listing_published',
-				listing_id: 'listing-2',
-			},
-		],
-		community_reports: [
-			{
-				id: 'report-1',
-				listing_id: 'listing-1',
-				listing_owner_user_id: userAaa,
-				reporter_user_id: userBbb,
-				resolved_by_user_id: null,
-			},
-			{
-				id: 'report-2',
-				listing_id: 'listing-2',
-				listing_owner_user_id: userBbb,
-				reporter_user_id: userAaa,
-				resolved_by_user_id: null,
-			},
-			{
-				id: 'report-3',
-				listing_id: 'listing-2',
-				listing_owner_user_id: userBbb,
-				reporter_user_id: userBbb,
-				resolved_by_user_id: userAaa,
-			},
-		],
-		community_bans: [
-			{ user_id: userAaa, banned_by_user_id: userBbb },
-			{ user_id: userBbb, banned_by_user_id: userAaa },
-		],
-		package_codemod_run_items: [
-			{
-				id: 'codemod-item-1',
-				run_id: 'codemod-run-1',
-				user_id: userAaa,
-				package_id: 'pkg-1',
-				kody_id: 'demo',
-				status: 'applied',
-			},
-			{
-				id: 'codemod-item-2',
-				run_id: 'codemod-run-2',
-				user_id: userBbb,
-				package_id: 'pkg-2',
-				kody_id: 'demo-b',
-				status: 'applied',
-			},
-		],
-		package_codemod_runs: [
-			{
-				id: 'codemod-run-1',
-				codemod_id: '0001-ambient-storage-to-package-storage',
-				mode: 'apply',
-				scope_user_id: userAaa,
-				initiated_by_user_id: userAaa,
-				filters_json: JSON.stringify({ userIds: [userAaa, userBbb] }),
-				status: 'completed',
-			},
-			{
-				id: 'codemod-run-fleet',
-				codemod_id: '0001-ambient-storage-to-package-storage',
-				mode: 'scan',
-				scope_user_id: null,
-				initiated_by_user_id: userBbb,
-				filters_json: JSON.stringify({ userIds: [userAaa] }),
-				status: 'completed',
-			},
-			{
-				id: 'codemod-run-2',
-				codemod_id: '0001-ambient-storage-to-package-storage',
-				mode: 'apply',
-				scope_user_id: userBbb,
-				initiated_by_user_id: userBbb,
-				filters_json: JSON.stringify({ userIds: [userBbb] }),
-				status: 'completed',
-			},
-		],
-	})
+test("deleteUserAccount cascades user-scoped rows for the requested user", async () => {
+  const userAaa = "user-aaa";
+  const userBbb = "user-bbb";
+  const packageJobId =
+    "package-job:b2fda105-005a-4e2b-9f22-1513b6752da2:event-runner";
+  const { db, rows } = createTestDb({
+    users: [
+      {
+        id: 1,
+        email: "a@example.com",
+        avatar_key: "user-avatars/user-aaa/abc123.png",
+      },
+      { id: 2, email: "b@example.com" },
+    ],
+    jobs: [
+      { id: "job-1", user_id: userAaa, storage_id: "job:job-1" },
+      { id: "job-2", user_id: userAaa, storage_id: null },
+      { id: packageJobId, user_id: userAaa, storage_id: null },
+      { id: "job-3", user_id: userBbb, storage_id: "job:job-3" },
+    ],
+    user_storage_buckets: [
+      {
+        user_id: userAaa,
+        storage_id: "exec:run-2",
+        kind: "execute",
+      },
+      {
+        user_id: userAaa,
+        storage_id: "repo-session:rs-1",
+        kind: "repo_session",
+      },
+      {
+        user_id: userBbb,
+        storage_id: "package:pkg-2",
+        kind: "package",
+      },
+    ],
+    mcp_memories: [
+      { id: "mem-1", user_id: userAaa },
+      { id: "mem-2", user_id: userBbb },
+    ],
+    secret_buckets: [{ id: "sb-1", user_id: userAaa }],
+    secret_entries: [{ bucket_id: "sb-1", name: "s", user_id: "unused" }],
+    value_buckets: [{ id: "vb-1", user_id: userAaa }],
+    value_entries: [{ bucket_id: "vb-1", name: "v", user_id: "unused" }],
+    mcp_agent_sessions: [
+      { do_id: "do-user-a", user_id: userAaa },
+      { do_id: "do-user-b", user_id: userBbb },
+    ],
+    saved_packages: [
+      {
+        id: "pkg-1",
+        user_id: userAaa,
+        kody_id: "demo",
+        source_id: "src-1",
+        has_app: 1,
+      },
+      {
+        id: "pkg-2",
+        user_id: userBbb,
+        kody_id: "other",
+        source_id: "src-2",
+        has_app: 0,
+      },
+    ],
+    published_bundle_artifacts: [
+      { id: "pba-1", user_id: userAaa, kv_key: "bundle-artifact:v1:src-1" },
+      { id: "pba-2", user_id: userBbb, kv_key: "bundle-artifact:v1:src-2" },
+    ],
+    archived_job_artifacts: [
+      { id: "aja-1", user_id: userAaa, storage_id: "job:archived-1" },
+    ],
+    entity_sources: [
+      { id: "src-1", user_id: userAaa, published_commit: "abc123" },
+      { id: "src-2", user_id: userBbb, published_commit: "def456" },
+    ],
+    password_resets: [
+      { id: 1, user_id: 1 },
+      { id: 2, user_id: 1 },
+      { id: 3, user_id: 2 },
+    ],
+    user_roles: [
+      { user_id: 1, role_id: 1 },
+      { user_id: 2, role_id: 2 },
+    ],
+    passkeys: [
+      { id: "pk-1", user_id: 1 },
+      { id: "pk-2", user_id: 2 },
+    ],
+    verifications: [
+      { id: 1, type: "2fa", target: "1" },
+      { id: 2, type: "2fa", target: "2" },
+    ],
+    mcp_user_server_instructions: [{ user_id: userAaa }],
+    package_invocation_tokens: [{ id: "pit-1", user_id: userAaa }],
+    agent_package_conversation_uses: [
+      {
+        user_id: userAaa,
+        package_id: "pkg-1",
+        conversation_id: "conv-1",
+      },
+    ],
+    mcp_memory_conversation_suppressions: [
+      { user_id: userAaa, conversation_id: "c1", memory_id: "mem-1" },
+    ],
+    email_inboxes: [{ id: "in-1", user_id: userAaa }],
+    email_inbox_addresses: [{ id: "ia-1", user_id: userAaa }],
+    email_sender_identities: [{ id: "ei-1", user_id: userAaa }],
+    platform_feedback: [
+      {
+        id: "feedback-submitted-by-a",
+        submitter_user_id: userAaa,
+        submitter_username: "user-a",
+        submitter_email: "a@example.com",
+        reviewed_by_user_id: userBbb,
+        reviewed_at: "2026-07-05",
+        admin_note: "Reviewed by B.",
+      },
+      {
+        id: "feedback-reviewed-by-a",
+        submitter_user_id: userBbb,
+        submitter_username: "user-b",
+        submitter_email: "b@example.com",
+        reviewed_by_user_id: userAaa,
+        reviewed_at: "2026-07-05",
+        admin_note: "Private admin note from A.",
+      },
+      {
+        id: "feedback-unrelated",
+        submitter_user_id: userBbb,
+        submitter_username: "user-b",
+        submitter_email: "b@example.com",
+        reviewed_by_user_id: userBbb,
+        reviewed_at: "2026-07-05",
+        admin_note: "Reviewed by B.",
+      },
+    ],
+    community_listings: [
+      {
+        id: "listing-1",
+        owner_user_id: userAaa,
+        pinned_commit: "commit-1",
+        source_id: "src-1",
+      },
+      { id: "listing-2", owner_user_id: userBbb, pinned_commit: "commit-2" },
+    ],
+    community_forks: [
+      { id: "fork-1", listing_id: "listing-1", forker_user_id: userBbb },
+      { id: "fork-2", listing_id: "listing-2", forker_user_id: userAaa },
+      { id: "fork-3", listing_id: "listing-2", forker_user_id: userBbb },
+    ],
+    community_ratings: [
+      { id: "rating-1", listing_id: "listing-1", user_id: userBbb },
+      { id: "rating-2", listing_id: "listing-2", user_id: userAaa },
+      { id: "rating-3", listing_id: "listing-2", user_id: userBbb },
+    ],
+    community_activity_events: [
+      {
+        id: "evt-1",
+        actor_user_id: userAaa,
+        event_type: "listing_published",
+        listing_id: "listing-2",
+      },
+      {
+        id: "evt-2",
+        actor_user_id: userBbb,
+        event_type: "listing_updated",
+        listing_id: "listing-1",
+      },
+      {
+        id: "evt-3",
+        actor_user_id: userBbb,
+        event_type: "listing_published",
+        listing_id: "listing-2",
+      },
+    ],
+    community_reports: [
+      {
+        id: "report-1",
+        listing_id: "listing-1",
+        listing_owner_user_id: userAaa,
+        reporter_user_id: userBbb,
+        resolved_by_user_id: null,
+      },
+      {
+        id: "report-2",
+        listing_id: "listing-2",
+        listing_owner_user_id: userBbb,
+        reporter_user_id: userAaa,
+        resolved_by_user_id: null,
+      },
+      {
+        id: "report-3",
+        listing_id: "listing-2",
+        listing_owner_user_id: userBbb,
+        reporter_user_id: userBbb,
+        resolved_by_user_id: userAaa,
+      },
+    ],
+    community_bans: [
+      { user_id: userAaa, banned_by_user_id: userBbb },
+      { user_id: userBbb, banned_by_user_id: userAaa },
+    ],
+    package_codemod_run_items: [
+      {
+        id: "codemod-item-1",
+        run_id: "codemod-run-1",
+        user_id: userAaa,
+        package_id: "pkg-1",
+        kody_id: "demo",
+        status: "applied",
+      },
+      {
+        id: "codemod-item-2",
+        run_id: "codemod-run-2",
+        user_id: userBbb,
+        package_id: "pkg-2",
+        kody_id: "demo-b",
+        status: "applied",
+      },
+    ],
+    package_codemod_runs: [
+      {
+        id: "codemod-run-1",
+        codemod_id: "0001-ambient-storage-to-package-storage",
+        mode: "apply",
+        scope_user_id: userAaa,
+        initiated_by_user_id: userAaa,
+        filters_json: JSON.stringify({ userIds: [userAaa, userBbb] }),
+        status: "completed",
+      },
+      {
+        id: "codemod-run-fleet",
+        codemod_id: "0001-ambient-storage-to-package-storage",
+        mode: "scan",
+        scope_user_id: null,
+        initiated_by_user_id: userBbb,
+        filters_json: JSON.stringify({ userIds: [userAaa] }),
+        status: "completed",
+      },
+      {
+        id: "codemod-run-2",
+        codemod_id: "0001-ambient-storage-to-package-storage",
+        mode: "apply",
+        scope_user_id: userBbb,
+        initiated_by_user_id: userBbb,
+        filters_json: JSON.stringify({ userIds: [userBbb] }),
+        status: "completed",
+      },
+    ],
+  });
 
-	const deletedKvKeys: Array<string> = []
-	const kvStoreKeys = [
-		'source-snapshot:v1:src-1:abc123',
-		'source-manifest-snapshot:v1:src-1:abc123',
-		'source-snapshot:v1:src-1:old456',
-		'source-manifest-snapshot:v1:src-1:old456',
-		'derived-cache:v1:community-icon:v1:listing-1:commit-1',
-		'derived-cache:v1:community-icon:v1:listing-1:abc123',
-		'derived-cache:v1:community-icon:v1:listing-1:historical',
-		'derived-cache:v1:community-icon:v2:listing-1:commit-1',
-		'derived-cache:v1:community-icon:v2:listing-1:abc123',
-		'derived-cache:v1:community-icon:v3:listing-1:commit-1',
-		'derived-cache:v1:community-icon:v3:listing-1:abc123',
-		'source-snapshot:v1:src-2:def456',
-		`package-codemod-revert:${userAaa}:item-1`,
-		`package-codemod-revert:${userAaa}:item-2`,
-		`package-codemod-revert:${userBbb}:item-other`,
-		'package-retriever-manifest:v1:user-aaa:pkg-1:abc123',
-		'package-retriever-index-entry:v1:user-aaa:search:pkg-1:notes',
-		'package-retriever-index-entry:v1:user-aaa:context:pkg-1:notes',
-		'package-retriever-index-entry:v1:user-bbb:search:pkg-2:notes',
-		'platform-settings:v1:reserved-usernames',
-		'platform-settings:v1:signup-mode',
-		'public-code-runs:v2',
-	]
-	const kv = {
-		async get(key: string) {
-			return kvStoreKeys.includes(key) ? '{}' : null
-		},
-		async delete(key: string) {
-			deletedKvKeys.push(key)
-		},
-		async list(options?: { prefix?: string; cursor?: string }) {
-			const prefix = options?.prefix ?? ''
-			const matchingKeys = kvStoreKeys
-				.filter((key) => key.startsWith(prefix))
-				.sort()
-			if (prefix === 'derived-cache:v1:community-icon:v1:listing-1:') {
-				const start = options?.cursor
-					? Number(options.cursor.replace('icon-page-', '')) - 1
-					: 0
-				const page = matchingKeys.slice(start, start + 1)
-				return {
-					keys: page.map((name) => ({ name })),
-					list_complete: start + page.length >= matchingKeys.length,
-					...(start + page.length < matchingKeys.length
-						? { cursor: `icon-page-${start + 2}` }
-						: {}),
-				}
-			}
-			return {
-				keys: matchingKeys.map((name) => ({ name })),
-				list_complete: true,
-				cursor: undefined,
-			}
-		},
-	} as unknown as KVNamespace
+  const deletedKvKeys: Array<string> = [];
+  const kvStoreKeys = [
+    "source-snapshot:v1:src-1:abc123",
+    "source-manifest-snapshot:v1:src-1:abc123",
+    "source-snapshot:v1:src-1:old456",
+    "source-manifest-snapshot:v1:src-1:old456",
+    "derived-cache:v1:community-icon:v1:listing-1:commit-1",
+    "derived-cache:v1:community-icon:v1:listing-1:abc123",
+    "derived-cache:v1:community-icon:v1:listing-1:historical",
+    "derived-cache:v1:community-icon:v2:listing-1:commit-1",
+    "derived-cache:v1:community-icon:v2:listing-1:abc123",
+    "derived-cache:v1:community-icon:v3:listing-1:commit-1",
+    "derived-cache:v1:community-icon:v3:listing-1:abc123",
+    "source-snapshot:v1:src-2:def456",
+    `package-codemod-revert:${userAaa}:item-1`,
+    `package-codemod-revert:${userAaa}:item-2`,
+    `package-codemod-revert:${userBbb}:item-other`,
+    "package-retriever-manifest:v1:user-aaa:pkg-1:abc123",
+    "package-retriever-index-entry:v1:user-aaa:search:pkg-1:notes",
+    "package-retriever-index-entry:v1:user-aaa:context:pkg-1:notes",
+    "package-retriever-index-entry:v1:user-bbb:search:pkg-2:notes",
+    "platform-settings:v1:reserved-usernames",
+    "platform-settings:v1:signup-mode",
+    "public-code-runs:v2",
+  ];
+  const kv = {
+    async get(key: string) {
+      return kvStoreKeys.includes(key) ? "{}" : null;
+    },
+    async delete(key: string) {
+      deletedKvKeys.push(key);
+    },
+    async list(options?: { prefix?: string; cursor?: string }) {
+      const prefix = options?.prefix ?? "";
+      const matchingKeys = kvStoreKeys
+        .filter((key) => key.startsWith(prefix))
+        .sort();
+      if (prefix === "derived-cache:v1:community-icon:v1:listing-1:") {
+        const start = options?.cursor
+          ? Number(options.cursor.replace("icon-page-", "")) - 1
+          : 0;
+        const page = matchingKeys.slice(start, start + 1);
+        return {
+          keys: page.map((name) => ({ name })),
+          list_complete: start + page.length >= matchingKeys.length,
+          ...(start + page.length < matchingKeys.length
+            ? { cursor: `icon-page-${start + 2}` }
+            : {}),
+        };
+      }
+      return {
+        keys: matchingKeys.map((name) => ({ name })),
+        list_complete: true,
+        cursor: undefined,
+      };
+    },
+  } as unknown as KVNamespace;
 
-	const deletedEmailBlobKeys: Array<string> = []
-	const mailboxCleanupOrder: Array<string> = []
-	const emailBlobKeys = new Set([
-		'email-raw:v1:user-aaa/em-1',
-		'email-raw:v1:user-aaa/em-2',
-		'email-raw:v1:user-bbb/em-3',
-	])
-	const emailBlobs = {
-		async list(options?: { prefix?: string }) {
-			return {
-				objects: [...emailBlobKeys]
-					.filter((key) => key.startsWith(options?.prefix ?? ''))
-					.map((key) => ({ key })),
-				delimitedPrefixes: [],
-				truncated: false as const,
-			}
-		},
-		async delete(keys: string | Array<string>) {
-			mailboxCleanupOrder.push('delete-email-blob')
-			for (const key of Array.isArray(keys) ? keys : [keys]) {
-				deletedEmailBlobKeys.push(key)
-				emailBlobKeys.delete(key)
-			}
-		},
-	} as unknown as R2Bucket
-	const deletedCommunityAssetKeys: Array<string> = []
-	const communityAssetKeys = new Set([
-		'user-avatars/user-aaa/abc123.png',
-		'user-avatars/user-aaa/old.png',
-		'user-avatars/user-bbb/other.png',
-		'community-icon:v1/listing-1/abc123/asset',
-		'community-icon:v1/listing-1/commit-1/asset',
-		'community-icon:v1/listing-1/historical/asset',
-		'community-icon:v2/listing-1/abc123/asset',
-		'community-icon:v2/listing-1/commit-1/asset',
-		'community-icon:v1/listing-2/other/asset',
-	])
-	const communityAssets = {
-		async list(options?: { prefix?: string; cursor?: string }) {
-			const matching = [...communityAssetKeys]
-				.filter(
-					(key) =>
-						key.startsWith(options?.prefix ?? '') &&
-						(!options?.cursor || key > options.cursor),
-				)
-				.sort()
-			const page = matching.slice(0, 1)
-			return {
-				objects: page.map((key) => ({ key })),
-				delimitedPrefixes: [],
-				...(matching.length > page.length
-					? { truncated: true as const, cursor: page[0]! }
-					: { truncated: false as const }),
-			}
-		},
-		async delete(keys: string | Array<string>) {
-			for (const key of Array.isArray(keys) ? keys : [keys]) {
-				deletedCommunityAssetKeys.push(key)
-				communityAssetKeys.delete(key)
-			}
-		},
-	} as unknown as R2Bucket
+  const deletedEmailBlobKeys: Array<string> = [];
+  const mailboxCleanupOrder: Array<string> = [];
+  const emailBlobKeys = new Set([
+    "email-raw:v1:user-aaa/em-1",
+    "email-raw:v1:user-aaa/em-2",
+    "email-raw:v1:user-bbb/em-3",
+  ]);
+  const emailBlobs = {
+    async list(options?: { prefix?: string }) {
+      return {
+        objects: [...emailBlobKeys]
+          .filter((key) => key.startsWith(options?.prefix ?? ""))
+          .map((key) => ({ key })),
+        delimitedPrefixes: [],
+        truncated: false as const,
+      };
+    },
+    async delete(keys: string | Array<string>) {
+      mailboxCleanupOrder.push("delete-email-blob");
+      for (const key of Array.isArray(keys) ? keys : [keys]) {
+        deletedEmailBlobKeys.push(key);
+        emailBlobKeys.delete(key);
+      }
+    },
+  } as unknown as R2Bucket;
+  const deletedCommunityAssetKeys: Array<string> = [];
+  const communityAssetKeys = new Set([
+    "user-avatars/user-aaa/abc123.png",
+    "user-avatars/user-aaa/old.png",
+    "user-avatars/user-bbb/other.png",
+    "community-icon:v1/listing-1/abc123/asset",
+    "community-icon:v1/listing-1/commit-1/asset",
+    "community-icon:v1/listing-1/historical/asset",
+    "community-icon:v2/listing-1/abc123/asset",
+    "community-icon:v2/listing-1/commit-1/asset",
+    "community-icon:v1/listing-2/other/asset",
+  ]);
+  const communityAssets = {
+    async list(options?: { prefix?: string; cursor?: string }) {
+      const matching = [...communityAssetKeys]
+        .filter(
+          (key) =>
+            key.startsWith(options?.prefix ?? "") &&
+            (!options?.cursor || key > options.cursor),
+        )
+        .sort();
+      const page = matching.slice(0, 1);
+      return {
+        objects: page.map((key) => ({ key })),
+        delimitedPrefixes: [],
+        ...(matching.length > page.length
+          ? { truncated: true as const, cursor: page[0]! }
+          : { truncated: false as const }),
+      };
+    },
+    async delete(keys: string | Array<string>) {
+      for (const key of Array.isArray(keys) ? keys : [keys]) {
+        deletedCommunityAssetKeys.push(key);
+        communityAssetKeys.delete(key);
+      }
+    },
+  } as unknown as R2Bucket;
 
-	const clearStorageMock = vi.fn(async () => ({ ok: true as const }))
-	const clearRunLogMock = vi.fn(async () => ({ ok: true as const }))
-	const purgeUserMeterMock = vi.fn(async () => ({ ok: true as const }))
-	const purgeStripePlanRefreshMock = vi.fn(async () => ({ ok: true as const }))
-	const stripePlanRefreshIdFromNameMock = vi.fn(
-		(name: string) => name as unknown as DurableObjectId,
-	)
-	const purgeMailboxMock = vi.fn(async () => {
-		mailboxCleanupOrder.push('purge-mailbox')
-		return { ok: true as const }
-	})
-	const listBlobReferencesMock = vi.fn(
-		async ({ startAfter }: { startAfter?: string | null }) => {
-			mailboxCleanupOrder.push('list-blob-references')
-			if (startAfter == null) {
-				return {
-					references: [
-						{
-							kind: 'raw_mime' as const,
-							key: 'email-raw:v1:user-aaa/em-1',
-							messageId: 'em-1',
-							attachmentId: null,
-						},
-						{
-							kind: 'raw_mime' as const,
-							key: 'email-raw:v1:user-aaa/em-2',
-							messageId: 'em-2',
-							attachmentId: null,
-						},
-					],
-					nextStartAfter: null,
-					truncated: false as const,
-				}
-			}
-			return {
-				references: [],
-				nextStartAfter: null,
-				truncated: false as const,
-			}
-		},
-	)
-	const jobsBindingStub = createJobsBindingStub(db)
-	const purgeJobManagerMock = vi.fn((input: { userId: string }) =>
-		jobsBindingStub.purgeUser(input),
-	)
-	const purgeRepoSessionMock = vi.fn(async () => ({ ok: true as const }))
-	const purgeMcpClientHubMock = vi.fn(async () => undefined)
-	const purgeMcpAgentSessionMock = vi.fn(async () => undefined)
-	const doFetchMock = vi.fn(async () => Response.json({ ok: true }))
-	const deleteVectorsMock = vi.fn(async () => undefined)
-	const userMeter = createInMemoryUserMeterEnv()
-	const env = createSuccessfulDeletionEnv(db, {
-		BUNDLE_ARTIFACTS_KV: kv,
-		COMMUNITY_ASSETS: communityAssets,
-		EMAIL_BLOBS: emailBlobs,
-		CAPABILITY_VECTOR_INDEX: {
-			deleteByIds: deleteVectorsMock,
-		},
-		STORAGE_RUNNER: {
-			idFromName: (name: string) => name as unknown as DurableObjectId,
-			get: () => ({ clearStorage: clearStorageMock }),
-		},
-		RUN_LOG: {
-			idFromName: (name: string) => name as unknown as DurableObjectId,
-			get: () => ({
-				clearAll: clearRunLogMock,
-				listStorageIds: async () => [] as Array<string>,
-			}),
-		},
-		USER_METER: {
-			idFromName: (name: string) => userMeter.env.USER_METER!.idFromName(name),
-			get: (id: DurableObjectId) => ({
-				...userMeter.env.USER_METER!.get(id),
-				purge: async () => purgeUserMeterMock(),
-			}),
-		},
-		STRIPE_PLAN_REFRESH: {
-			idFromName: stripePlanRefreshIdFromNameMock,
-			get: () => ({ purgeUser: purgeStripePlanRefreshMock }),
-		},
-		MAILBOX: {
-			idFromName: (name: string) => name as unknown as DurableObjectId,
-			get: () => ({
-				listBlobReferences: listBlobReferencesMock,
-				purge: purgeMailboxMock,
-			}),
-		},
-		JOBS: createJobsBindingStub(db, {
-			purgeUser: purgeJobManagerMock as unknown,
-		}),
-		REPO_SESSION: {
-			idFromName: (name: string) => name as unknown as DurableObjectId,
-			get: () => ({ purgeSession: purgeRepoSessionMock }),
-		},
-		MCP_CLIENT_HUB: {
-			idFromName: (name: string) => name as unknown as DurableObjectId,
-			get: () => ({ purgeForAccountDeletion: purgeMcpClientHubMock }),
-		},
-		MCP_OBJECT: {
-			idFromString: (id: string) => id as unknown as DurableObjectId,
-			get: () => ({
-				purgeForAccountDeletion: purgeMcpAgentSessionMock,
-			}),
-		},
-		PACKAGE_REALTIME_SESSION: {
-			idFromName: (name: string) => name as unknown as DurableObjectId,
-			get: () => ({ fetch: doFetchMock }),
-		},
-	})
-	await insertRepoSession(env, {
-		id: 'rs-1',
-		user_id: userAaa,
-		source_id: 'src-1',
-		source_repo_id: '',
-		session_branch: 'sessions/rs-1',
-		source_branch: 'main',
-		base_commit: 'abc123',
-		source_root: '/',
-		conversation_id: null,
-		status: 'active',
-		expires_at: null,
-		last_checkpoint_at: null,
-		last_checkpoint_commit: null,
-		last_check_run_id: null,
-		last_check_tree_hash: null,
-		created_at: '2026-07-05T00:00:00.000Z',
-		updated_at: '2026-07-05T00:00:00.000Z',
-	})
+  const clearStorageMock = vi.fn(async () => ({ ok: true as const }));
+  const clearRunLogMock = vi.fn(async () => ({ ok: true as const }));
+  const purgeUserMeterMock = vi.fn(async () => ({ ok: true as const }));
+  const purgeStripePlanRefreshMock = vi.fn(async () => ({ ok: true as const }));
+  const stripePlanRefreshIdFromNameMock = vi.fn(
+    (name: string) => name as unknown as DurableObjectId,
+  );
+  const purgeMailboxMock = vi.fn(async () => {
+    mailboxCleanupOrder.push("purge-mailbox");
+    return { ok: true as const };
+  });
+  const listBlobReferencesMock = vi.fn(
+    async ({ startAfter }: { startAfter?: string | null }) => {
+      mailboxCleanupOrder.push("list-blob-references");
+      if (startAfter == null) {
+        return {
+          references: [
+            {
+              kind: "raw_mime" as const,
+              key: "email-raw:v1:user-aaa/em-1",
+              messageId: "em-1",
+              attachmentId: null,
+            },
+            {
+              kind: "raw_mime" as const,
+              key: "email-raw:v1:user-aaa/em-2",
+              messageId: "em-2",
+              attachmentId: null,
+            },
+          ],
+          nextStartAfter: null,
+          truncated: false as const,
+        };
+      }
+      return {
+        references: [],
+        nextStartAfter: null,
+        truncated: false as const,
+      };
+    },
+  );
+  const jobsBindingStub = createJobsBindingStub(db);
+  const purgeJobManagerMock = vi.fn((input: { userId: string }) =>
+    jobsBindingStub.purgeUser(input),
+  );
+  const purgeRepoSessionMock = vi.fn(async () => ({ ok: true as const }));
+  const purgeMcpClientHubMock = vi.fn(async () => undefined);
+  const purgeMcpAgentSessionMock = vi.fn(async () => undefined);
+  const doFetchMock = vi.fn(async () => Response.json({ ok: true }));
+  const deleteVectorsMock = vi.fn(async () => undefined);
+  const userMeter = createInMemoryUserMeterEnv();
+  const env = createSuccessfulDeletionEnv(db, {
+    BUNDLE_ARTIFACTS_KV: kv,
+    COMMUNITY_ASSETS: communityAssets,
+    EMAIL_BLOBS: emailBlobs,
+    CAPABILITY_VECTOR_INDEX: {
+      deleteByIds: deleteVectorsMock,
+    },
+    STORAGE_RUNNER: {
+      idFromName: (name: string) => name as unknown as DurableObjectId,
+      get: () => ({ clearStorage: clearStorageMock }),
+    },
+    RUN_LOG: {
+      idFromName: (name: string) => name as unknown as DurableObjectId,
+      get: () => ({
+        clearAll: clearRunLogMock,
+        listStorageIds: async () => [] as Array<string>,
+      }),
+    },
+    USER_METER: {
+      idFromName: (name: string) => userMeter.env.USER_METER!.idFromName(name),
+      get: (id: DurableObjectId) => ({
+        ...userMeter.env.USER_METER!.get(id),
+        purge: async () => purgeUserMeterMock(),
+      }),
+    },
+    STRIPE_PLAN_REFRESH: {
+      idFromName: stripePlanRefreshIdFromNameMock,
+      get: () => ({ purgeUser: purgeStripePlanRefreshMock }),
+    },
+    MAILBOX: {
+      idFromName: (name: string) => name as unknown as DurableObjectId,
+      get: () => ({
+        listBlobReferences: listBlobReferencesMock,
+        purge: purgeMailboxMock,
+      }),
+    },
+    JOBS: createJobsBindingStub(db, {
+      purgeUser: purgeJobManagerMock as unknown,
+    }),
+    REPO_SESSION: {
+      idFromName: (name: string) => name as unknown as DurableObjectId,
+      get: () => ({ purgeSession: purgeRepoSessionMock }),
+    },
+    MCP_CLIENT_HUB: {
+      idFromName: (name: string) => name as unknown as DurableObjectId,
+      get: () => ({ purgeForAccountDeletion: purgeMcpClientHubMock }),
+    },
+    MCP_OBJECT: {
+      idFromString: (id: string) => id as unknown as DurableObjectId,
+      get: () => ({
+        purgeForAccountDeletion: purgeMcpAgentSessionMock,
+      }),
+    },
+    PACKAGE_REALTIME_SESSION: {
+      idFromName: (name: string) => name as unknown as DurableObjectId,
+      get: () => ({ fetch: doFetchMock }),
+    },
+  });
+  await insertRepoSession(env, {
+    id: "rs-1",
+    user_id: userAaa,
+    source_id: "src-1",
+    source_repo_id: "",
+    session_branch: "sessions/rs-1",
+    source_branch: "main",
+    base_commit: "abc123",
+    source_root: "/",
+    conversation_id: null,
+    status: "active",
+    expires_at: null,
+    last_checkpoint_at: null,
+    last_checkpoint_commit: null,
+    last_check_run_id: null,
+    last_check_tree_hash: null,
+    created_at: "2026-07-05T00:00:00.000Z",
+    updated_at: "2026-07-05T00:00:00.000Z",
+  });
 
-	// password_resets.user_id is the database integer id; the deletion
-	// service must use the dbUserId (1) to clear the deleted user's reset
-	// tokens while leaving the other user's tokens in place.
-	const result = await deleteUserAccount({
-		env,
-		dbUserId: 1,
-		mcpUserId: userAaa,
-	})
+  // password_resets.user_id is the database integer id; the deletion
+  // service must use the dbUserId (1) to clear the deleted user's reset
+  // tokens while leaving the other user's tokens in place.
+  const result = await deleteUserAccount({
+    env,
+    dbUserId: 1,
+    mcpUserId: userAaa,
+  });
 
-	// Cross-user data is preserved.
-	expect(rows.jobs).toEqual([
-		{ id: 'job-3', user_id: userBbb, storage_id: 'job:job-3' },
-	])
-	expect(rows.mcp_memories).toEqual([{ id: 'mem-2', user_id: userBbb }])
-	expect(rows.saved_packages).toEqual([
-		{
-			id: 'pkg-2',
-			user_id: userBbb,
-			kody_id: 'other',
-			source_id: 'src-2',
-			has_app: 0,
-		},
-	])
-	expect(rows.mcp_agent_sessions).toEqual([
-		{ do_id: 'do-user-b', user_id: userBbb },
-	])
-	expect(rows.published_bundle_artifacts).toEqual([
-		{ id: 'pba-2', user_id: userBbb, kv_key: 'bundle-artifact:v1:src-2' },
-	])
-	expect(rows.password_resets).toEqual([{ id: 3, user_id: 2 }])
-	expect(rows.user_roles).toEqual([{ user_id: 2, role_id: 2 }])
-	expect(rows.passkeys).toEqual([{ id: 'pk-2', user_id: 2 }])
-	expect(rows.verifications).toEqual([{ id: 2, type: '2fa', target: '2' }])
+  // Cross-user data is preserved.
+  expect(rows.jobs).toEqual([
+    { id: "job-3", user_id: userBbb, storage_id: "job:job-3" },
+  ]);
+  expect(rows.mcp_memories).toEqual([{ id: "mem-2", user_id: userBbb }]);
+  expect(rows.saved_packages).toEqual([
+    {
+      id: "pkg-2",
+      user_id: userBbb,
+      kody_id: "other",
+      source_id: "src-2",
+      has_app: 0,
+    },
+  ]);
+  expect(rows.mcp_agent_sessions).toEqual([
+    { do_id: "do-user-b", user_id: userBbb },
+  ]);
+  expect(rows.published_bundle_artifacts).toEqual([
+    { id: "pba-2", user_id: userBbb, kv_key: "bundle-artifact:v1:src-2" },
+  ]);
+  expect(rows.password_resets).toEqual([{ id: 3, user_id: 2 }]);
+  expect(rows.user_roles).toEqual([{ user_id: 2, role_id: 2 }]);
+  expect(rows.passkeys).toEqual([{ id: "pk-2", user_id: 2 }]);
+  expect(rows.verifications).toEqual([{ id: 2, type: "2fa", target: "2" }]);
 
-	// User-scoped data is removed.
-	expect(rows.secret_buckets).toEqual([])
-	expect(rows.secret_entries).toEqual([])
-	expect(rows.value_buckets).toEqual([])
-	expect(rows.value_entries).toEqual([])
-	expect(rows.archived_job_artifacts).toEqual([])
-	expect(rows.entity_sources).toEqual([
-		{ id: 'src-2', user_id: userBbb, published_commit: 'def456' },
-	])
-	await expect(listRepoSessionsByUser(env, userAaa)).resolves.toEqual([])
-	expect(deletedEmailBlobKeys.sort()).toEqual([
-		'email-raw:v1:user-aaa/em-1',
-		'email-raw:v1:user-aaa/em-2',
-	])
-	expect(rows.platform_feedback).toEqual([
-		{
-			id: 'feedback-reviewed-by-a',
-			submitter_user_id: userBbb,
-			submitter_username: 'user-b',
-			submitter_email: 'b@example.com',
-			reviewed_by_user_id: null,
-			reviewed_at: null,
-			admin_note: null,
-		},
-		{
-			id: 'feedback-unrelated',
-			submitter_user_id: userBbb,
-			submitter_username: 'user-b',
-			submitter_email: 'b@example.com',
-			reviewed_by_user_id: userBbb,
-			reviewed_at: '2026-07-05',
-			admin_note: 'Reviewed by B.',
-		},
-	])
-	expect(rows.user_storage_buckets).toEqual([
-		{
-			user_id: userBbb,
-			storage_id: 'package:pkg-2',
-			kind: 'package',
-		},
-	])
-	expect(rows.community_listings).toEqual([
-		{ id: 'listing-2', owner_user_id: userBbb, pinned_commit: 'commit-2' },
-	])
-	expect(rows.community_forks).toEqual([
-		{ id: 'fork-3', listing_id: 'listing-2', forker_user_id: userBbb },
-	])
-	expect(rows.community_ratings).toEqual([
-		{ id: 'rating-3', listing_id: 'listing-2', user_id: userBbb },
-	])
-	expect(rows.community_activity_events).toEqual([
-		{
-			id: 'evt-3',
-			actor_user_id: userBbb,
-			event_type: 'listing_published',
-			listing_id: 'listing-2',
-		},
-	])
-	expect(rows.community_reports).toEqual([
-		{
-			id: 'report-3',
-			listing_id: 'listing-2',
-			listing_owner_user_id: userBbb,
-			reporter_user_id: userBbb,
-			resolved_by_user_id: null,
-			resolved_at: null,
-			resolution_note: null,
-		},
-	])
-	expect(rows.community_bans).toEqual([
-		{ user_id: userBbb, banned_by_user_id: 'deleted-user' },
-	])
-	expect(rows.package_codemod_run_items).toEqual([
-		{
-			id: 'codemod-item-2',
-			run_id: 'codemod-run-2',
-			user_id: userBbb,
-			package_id: 'pkg-2',
-			kody_id: 'demo-b',
-			status: 'applied',
-		},
-	])
-	expect(rows.package_codemod_runs).toEqual([
-		{
-			id: 'codemod-run-1',
-			codemod_id: '0001-ambient-storage-to-package-storage',
-			mode: 'apply',
-			scope_user_id: 'deleted-user',
-			initiated_by_user_id: 'deleted-user',
-			filters_json: JSON.stringify({ userIds: ['deleted-user', userBbb] }),
-			status: 'completed',
-		},
-		{
-			id: 'codemod-run-fleet',
-			codemod_id: '0001-ambient-storage-to-package-storage',
-			mode: 'scan',
-			scope_user_id: null,
-			initiated_by_user_id: userBbb,
-			filters_json: JSON.stringify({ userIds: ['deleted-user'] }),
-			status: 'completed',
-		},
-		{
-			id: 'codemod-run-2',
-			codemod_id: '0001-ambient-storage-to-package-storage',
-			mode: 'apply',
-			scope_user_id: userBbb,
-			initiated_by_user_id: userBbb,
-			filters_json: JSON.stringify({ userIds: [userBbb] }),
-			status: 'completed',
-		},
-	])
-	for (const run of rows.package_codemod_runs ?? []) {
-		expect(String(run['filters_json'])).not.toContain(userAaa)
-	}
-	expect(rows.users).toEqual([
-		{ id: 2, email: 'b@example.com', stable_user_id: 'user-bbb' },
-	])
-	expect(result.deletedRowCounts.password_resets).toBe(2)
-	expect(result.deletedRowCounts.user_roles).toBe(1)
+  // User-scoped data is removed.
+  expect(rows.secret_buckets).toEqual([]);
+  expect(rows.secret_entries).toEqual([]);
+  expect(rows.value_buckets).toEqual([]);
+  expect(rows.value_entries).toEqual([]);
+  expect(rows.archived_job_artifacts).toEqual([]);
+  expect(rows.entity_sources).toEqual([
+    { id: "src-2", user_id: userBbb, published_commit: "def456" },
+  ]);
+  await expect(listRepoSessionsByUser(env, userAaa)).resolves.toEqual([]);
+  expect(deletedEmailBlobKeys.sort()).toEqual([
+    "email-raw:v1:user-aaa/em-1",
+    "email-raw:v1:user-aaa/em-2",
+  ]);
+  expect(rows.platform_feedback).toEqual([
+    {
+      id: "feedback-reviewed-by-a",
+      submitter_user_id: userBbb,
+      submitter_username: "user-b",
+      submitter_email: "b@example.com",
+      reviewed_by_user_id: null,
+      reviewed_at: null,
+      admin_note: null,
+    },
+    {
+      id: "feedback-unrelated",
+      submitter_user_id: userBbb,
+      submitter_username: "user-b",
+      submitter_email: "b@example.com",
+      reviewed_by_user_id: userBbb,
+      reviewed_at: "2026-07-05",
+      admin_note: "Reviewed by B.",
+    },
+  ]);
+  expect(rows.user_storage_buckets).toEqual([
+    {
+      user_id: userBbb,
+      storage_id: "package:pkg-2",
+      kind: "package",
+    },
+  ]);
+  expect(rows.community_listings).toEqual([
+    { id: "listing-2", owner_user_id: userBbb, pinned_commit: "commit-2" },
+  ]);
+  expect(rows.community_forks).toEqual([
+    { id: "fork-3", listing_id: "listing-2", forker_user_id: userBbb },
+  ]);
+  expect(rows.community_ratings).toEqual([
+    { id: "rating-3", listing_id: "listing-2", user_id: userBbb },
+  ]);
+  expect(rows.community_activity_events).toEqual([
+    {
+      id: "evt-3",
+      actor_user_id: userBbb,
+      event_type: "listing_published",
+      listing_id: "listing-2",
+    },
+  ]);
+  expect(rows.community_reports).toEqual([
+    {
+      id: "report-3",
+      listing_id: "listing-2",
+      listing_owner_user_id: userBbb,
+      reporter_user_id: userBbb,
+      resolved_by_user_id: null,
+      resolved_at: null,
+      resolution_note: null,
+    },
+  ]);
+  expect(rows.community_bans).toEqual([
+    { user_id: userBbb, banned_by_user_id: "deleted-user" },
+  ]);
+  expect(rows.package_codemod_run_items).toEqual([
+    {
+      id: "codemod-item-2",
+      run_id: "codemod-run-2",
+      user_id: userBbb,
+      package_id: "pkg-2",
+      kody_id: "demo-b",
+      status: "applied",
+    },
+  ]);
+  expect(rows.package_codemod_runs).toEqual([
+    {
+      id: "codemod-run-1",
+      codemod_id: "0001-ambient-storage-to-package-storage",
+      mode: "apply",
+      scope_user_id: "deleted-user",
+      initiated_by_user_id: "deleted-user",
+      filters_json: JSON.stringify({ userIds: ["deleted-user", userBbb] }),
+      status: "completed",
+    },
+    {
+      id: "codemod-run-fleet",
+      codemod_id: "0001-ambient-storage-to-package-storage",
+      mode: "scan",
+      scope_user_id: null,
+      initiated_by_user_id: userBbb,
+      filters_json: JSON.stringify({ userIds: ["deleted-user"] }),
+      status: "completed",
+    },
+    {
+      id: "codemod-run-2",
+      codemod_id: "0001-ambient-storage-to-package-storage",
+      mode: "apply",
+      scope_user_id: userBbb,
+      initiated_by_user_id: userBbb,
+      filters_json: JSON.stringify({ userIds: [userBbb] }),
+      status: "completed",
+    },
+  ]);
+  for (const run of rows.package_codemod_runs ?? []) {
+    expect(String(run["filters_json"])).not.toContain(userAaa);
+  }
+  expect(rows.users).toEqual([
+    { id: 2, email: "b@example.com", stable_user_id: "user-bbb" },
+  ]);
+  expect(result.deletedRowCounts.password_resets).toBe(2);
+  expect(result.deletedRowCounts.user_roles).toBe(1);
 
-	// Out-of-band stores for the deleted user were cleared.
-	expect(deleteVectorsMock).toHaveBeenCalledWith([
-		'memory_mem-1',
-		'job_job-1',
-		'job_job-2',
-		jobVectorId(packageJobId),
-		'package_pkg-1',
-	])
-	expect(clearStorageMock).toHaveBeenCalledTimes(3)
-	expect(purgeJobManagerMock).toHaveBeenCalledTimes(1)
-	expect(purgeRepoSessionMock).toHaveBeenCalledWith({
-		sessionId: 'rs-1',
-		userId: userAaa,
-	})
-	expect(doFetchMock).toHaveBeenCalledTimes(1)
+  // Out-of-band stores for the deleted user were cleared.
+  expect(deleteVectorsMock).toHaveBeenCalledWith([
+    "memory_mem-1",
+    "job_job-1",
+    "job_job-2",
+    jobVectorId(packageJobId),
+    "package_pkg-1",
+  ]);
+  expect(clearStorageMock).toHaveBeenCalledTimes(3);
+  expect(purgeJobManagerMock).toHaveBeenCalledTimes(1);
+  expect(purgeRepoSessionMock).toHaveBeenCalledWith({
+    sessionId: "rs-1",
+    userId: userAaa,
+  });
+  expect(doFetchMock).toHaveBeenCalledTimes(1);
 
-	// Bundle KV keys for the deleted user were removed; the other user's keys
-	// remain in storage.
-	expect(deletedKvKeys.sort()).toEqual([
-		'bundle-artifact:v1:src-1',
-		'community-snapshot:v1:listing-1',
-		'derived-cache:v1:community-icon:v1:listing-1:abc123',
-		'derived-cache:v1:community-icon:v1:listing-1:commit-1',
-		'derived-cache:v1:community-icon:v1:listing-1:historical',
-		'derived-cache:v1:community-icon:v2:listing-1:abc123',
-		'derived-cache:v1:community-icon:v2:listing-1:commit-1',
-		'derived-cache:v1:community-icon:v3:listing-1:abc123',
-		'derived-cache:v1:community-icon:v3:listing-1:commit-1',
-		`package-codemod-revert:${userAaa}:item-1`,
-		`package-codemod-revert:${userAaa}:item-2`,
-		'package-retriever-index-entry:v1:user-aaa:context:pkg-1:notes',
-		'package-retriever-index-entry:v1:user-aaa:search:pkg-1:notes',
-		'package-retriever-manifest:v1:user-aaa:pkg-1:abc123',
-		'source-manifest-snapshot:v1:src-1:abc123',
-		'source-manifest-snapshot:v1:src-1:old456',
-		'source-snapshot:v1:src-1:abc123',
-		'source-snapshot:v1:src-1:old456',
-	])
-	expect(deletedKvKeys).not.toContain(
-		'package-retriever-index-entry:v1:user-bbb:search:pkg-2:notes',
-	)
-	expect(deletedKvKeys).not.toContain(
-		`package-codemod-revert:${userBbb}:item-other`,
-	)
-	expect(deletedKvKeys).not.toContain('platform-settings:v1:reserved-usernames')
-	expect(deletedKvKeys).not.toContain('platform-settings:v1:signup-mode')
-	expect(deletedKvKeys).not.toContain('public-code-runs:v2')
+  // Bundle KV keys for the deleted user were removed; the other user's keys
+  // remain in storage.
+  expect(deletedKvKeys.sort()).toEqual([
+    "bundle-artifact:v1:src-1",
+    "community-snapshot:v1:listing-1",
+    "derived-cache:v1:community-icon:v1:listing-1:abc123",
+    "derived-cache:v1:community-icon:v1:listing-1:commit-1",
+    "derived-cache:v1:community-icon:v1:listing-1:historical",
+    "derived-cache:v1:community-icon:v2:listing-1:abc123",
+    "derived-cache:v1:community-icon:v2:listing-1:commit-1",
+    "derived-cache:v1:community-icon:v3:listing-1:abc123",
+    "derived-cache:v1:community-icon:v3:listing-1:commit-1",
+    `package-codemod-revert:${userAaa}:item-1`,
+    `package-codemod-revert:${userAaa}:item-2`,
+    "package-retriever-index-entry:v1:user-aaa:context:pkg-1:notes",
+    "package-retriever-index-entry:v1:user-aaa:search:pkg-1:notes",
+    "package-retriever-manifest:v1:user-aaa:pkg-1:abc123",
+    "source-manifest-snapshot:v1:src-1:abc123",
+    "source-manifest-snapshot:v1:src-1:old456",
+    "source-snapshot:v1:src-1:abc123",
+    "source-snapshot:v1:src-1:old456",
+  ]);
+  expect(deletedKvKeys).not.toContain(
+    "package-retriever-index-entry:v1:user-bbb:search:pkg-2:notes",
+  );
+  expect(deletedKvKeys).not.toContain(
+    `package-codemod-revert:${userBbb}:item-other`,
+  );
+  expect(deletedKvKeys).not.toContain(
+    "platform-settings:v1:reserved-usernames",
+  );
+  expect(deletedKvKeys).not.toContain("platform-settings:v1:signup-mode");
+  expect(deletedKvKeys).not.toContain("public-code-runs:v2");
 
-	// Result accounting captures the per-table counts. Job rows are purged
-	// through the JOBS service (ADR 0016), so they are not counted here.
-	expect(result.deletedRowCounts.jobs).toBeUndefined()
-	expect(result.deletedRowCounts.users).toBe(1)
-	expect(result.deletedRowCounts.user_storage_buckets).toBe(2)
-	expect(result.deletedRowCounts.community_listings).toBe(1)
-	expect(result.deletedRowCounts.community_forks).toBe(2)
-	expect(result.deletedRowCounts.community_ratings).toBe(2)
-	expect(result.deletedRowCounts.community_activity_events).toBe(2)
-	expect(result.deletedRowCounts.community_reports).toBe(2)
-	expect(result.updatedRowCounts.community_reports).toBe(1)
-	expect(result.deletedRowCounts.community_bans).toBe(1)
-	expect(result.updatedRowCounts.community_bans).toBe(1)
-	expect(result.deletedRowCounts.platform_feedback).toBe(1)
-	expect(result.updatedRowCounts.platform_feedback).toBe(1)
-	expect(result.deletedKvKeys).toBe(18)
-	expect(result.deletedCommunityAssets).toBe(7)
-	expect(result.deletedEmailBlobs).toBe(2)
-	// Prefix sweeps remove current and historical assets without crossing users.
-	expect(deletedCommunityAssetKeys.sort()).toEqual([
-		'community-icon:v1/listing-1/abc123/asset',
-		'community-icon:v1/listing-1/commit-1/asset',
-		'community-icon:v1/listing-1/historical/asset',
-		'community-icon:v2/listing-1/abc123/asset',
-		'community-icon:v2/listing-1/commit-1/asset',
-		'user-avatars/user-aaa/abc123.png',
-		'user-avatars/user-aaa/old.png',
-	])
-	expect(communityAssetKeys).toEqual(
-		new Set([
-			'community-icon:v1/listing-2/other/asset',
-			'user-avatars/user-bbb/other.png',
-		]),
-	)
-	expect(result.deletedVectors).toBe(5)
-	expect(result.clearedDurableObjects).toMatchObject({
-		storageRunners: 3,
-		runLogs: 1,
-		userMeters: 1,
-		stripePlanRefreshes: 1,
-		mailboxes: 1,
-		jobManagers: 1,
-		repoSessions: 1,
-		// The MCP client hub is purged even when the user has no
-		// mcp_server_settings rows, since the hub DO can still hold OAuth
-		// tokens from failed or removed registrations.
-		mcpClientHubs: 1,
-		mcpAgentSessions: 1,
-		packageRealtimeSessions: 1,
-	})
-	expect(clearRunLogMock).toHaveBeenCalledTimes(1)
-	expect(purgeUserMeterMock).toHaveBeenCalledTimes(1)
-	expect(stripePlanRefreshIdFromNameMock).toHaveBeenCalledWith(userAaa)
-	expect(purgeStripePlanRefreshMock).toHaveBeenCalledWith({ userId: userAaa })
-	expect(listBlobReferencesMock).toHaveBeenCalledTimes(1)
-	expect(purgeMailboxMock).toHaveBeenCalledTimes(1)
-	expect(mailboxCleanupOrder[0]).toBe('list-blob-references')
-	expect(mailboxCleanupOrder.indexOf('delete-email-blob')).toBeGreaterThan(
-		mailboxCleanupOrder.indexOf('list-blob-references'),
-	)
-	expect(mailboxCleanupOrder.indexOf('purge-mailbox')).toBeGreaterThan(
-		mailboxCleanupOrder.lastIndexOf('delete-email-blob'),
-	)
-	expect(purgeMcpClientHubMock).toHaveBeenCalledTimes(1)
-	expect(purgeMcpAgentSessionMock).toHaveBeenCalledWith({
-		userId: userAaa,
-	})
-	expect(result.warnings).toEqual([])
-})
+  // Result accounting captures the per-table counts. Job rows are purged
+  // through the JOBS service (ADR 0016), so they are not counted here.
+  expect(result.deletedRowCounts.jobs).toBeUndefined();
+  expect(result.deletedRowCounts.users).toBe(1);
+  expect(result.deletedRowCounts.user_storage_buckets).toBe(2);
+  expect(result.deletedRowCounts.community_listings).toBe(1);
+  expect(result.deletedRowCounts.community_forks).toBe(2);
+  expect(result.deletedRowCounts.community_ratings).toBe(2);
+  expect(result.deletedRowCounts.community_activity_events).toBe(2);
+  expect(result.deletedRowCounts.community_reports).toBe(2);
+  expect(result.updatedRowCounts.community_reports).toBe(1);
+  expect(result.deletedRowCounts.community_bans).toBe(1);
+  expect(result.updatedRowCounts.community_bans).toBe(1);
+  expect(result.deletedRowCounts.platform_feedback).toBe(1);
+  expect(result.updatedRowCounts.platform_feedback).toBe(1);
+  expect(result.deletedKvKeys).toBe(18);
+  expect(result.deletedCommunityAssets).toBe(7);
+  expect(result.deletedEmailBlobs).toBe(2);
+  // Prefix sweeps remove current and historical assets without crossing users.
+  expect(deletedCommunityAssetKeys.sort()).toEqual([
+    "community-icon:v1/listing-1/abc123/asset",
+    "community-icon:v1/listing-1/commit-1/asset",
+    "community-icon:v1/listing-1/historical/asset",
+    "community-icon:v2/listing-1/abc123/asset",
+    "community-icon:v2/listing-1/commit-1/asset",
+    "user-avatars/user-aaa/abc123.png",
+    "user-avatars/user-aaa/old.png",
+  ]);
+  expect(communityAssetKeys).toEqual(
+    new Set([
+      "community-icon:v1/listing-2/other/asset",
+      "user-avatars/user-bbb/other.png",
+    ]),
+  );
+  expect(result.deletedVectors).toBe(5);
+  expect(result.clearedDurableObjects).toMatchObject({
+    storageRunners: 3,
+    runLogs: 1,
+    userMeters: 1,
+    stripePlanRefreshes: 1,
+    mailboxes: 1,
+    jobManagers: 1,
+    repoSessions: 1,
+    // The MCP client hub is purged even when the user has no
+    // mcp_server_settings rows, since the hub DO can still hold OAuth
+    // tokens from failed or removed registrations.
+    mcpClientHubs: 1,
+    mcpAgentSessions: 1,
+    packageRealtimeSessions: 1,
+  });
+  expect(clearRunLogMock).toHaveBeenCalledTimes(1);
+  expect(purgeUserMeterMock).toHaveBeenCalledTimes(1);
+  expect(stripePlanRefreshIdFromNameMock).toHaveBeenCalledWith(userAaa);
+  expect(purgeStripePlanRefreshMock).toHaveBeenCalledWith({ userId: userAaa });
+  expect(listBlobReferencesMock).toHaveBeenCalledTimes(1);
+  expect(purgeMailboxMock).toHaveBeenCalledTimes(1);
+  expect(mailboxCleanupOrder[0]).toBe("list-blob-references");
+  expect(mailboxCleanupOrder.indexOf("delete-email-blob")).toBeGreaterThan(
+    mailboxCleanupOrder.indexOf("list-blob-references"),
+  );
+  expect(mailboxCleanupOrder.indexOf("purge-mailbox")).toBeGreaterThan(
+    mailboxCleanupOrder.lastIndexOf("delete-email-blob"),
+  );
+  expect(purgeMcpClientHubMock).toHaveBeenCalledTimes(1);
+  expect(purgeMcpAgentSessionMock).toHaveBeenCalledWith({
+    userId: userAaa,
+  });
+  expect(result.warnings).toEqual([]);
+});
 
-test('account deletion preserves Mailbox references and retry marker when R2 deletion fails', async () => {
-	const { db, rows } = createTestDb({
-		users: [{ id: 1, email: 'a@example.com', stable_user_id: 'user-aaa' }],
-	})
-	const purgeMailbox = vi.fn(async () => ({ ok: true as const }))
-	const deleteEmailBlob = vi.fn(async () => {
-		throw new Error('email R2 delete unavailable')
-	})
-	const listBlobReferences = vi.fn(async () => ({
-		references: [
-			{
-				kind: 'raw_mime' as const,
-				key: 'email-raw:v1:user-aaa/message-1',
-				messageId: 'message-1',
-				attachmentId: null,
-			},
-		],
-		nextStartAfter: null,
-		truncated: false as const,
-	}))
-	const env = createSuccessfulDeletionEnv(db, {
-		EMAIL_BLOBS: {
-			async list() {
-				return {
-					objects: [{ key: 'email-raw:v1:user-aaa/message-1' }],
-					delimitedPrefixes: [],
-					truncated: false,
-				}
-			},
-			delete: deleteEmailBlob,
-		} as unknown as R2Bucket,
-		MAILBOX: {
-			idFromName: (name: string) => name as unknown as DurableObjectId,
-			get: () => ({
-				listBlobReferences,
-				purge: purgeMailbox,
-			}),
-		} as unknown as DurableObjectNamespace,
-	})
+test("account deletion preserves Mailbox references and retry marker when R2 deletion fails", async () => {
+  const { db, rows } = createTestDb({
+    users: [{ id: 1, email: "a@example.com", stable_user_id: "user-aaa" }],
+  });
+  const purgeMailbox = vi.fn(async () => ({ ok: true as const }));
+  const deleteEmailBlob = vi.fn(async () => {
+    throw new Error("email R2 delete unavailable");
+  });
+  const listBlobReferences = vi.fn(async () => ({
+    references: [
+      {
+        kind: "raw_mime" as const,
+        key: "email-raw:v1:user-aaa/message-1",
+        messageId: "message-1",
+        attachmentId: null,
+      },
+    ],
+    nextStartAfter: null,
+    truncated: false as const,
+  }));
+  const env = createSuccessfulDeletionEnv(db, {
+    EMAIL_BLOBS: {
+      async list() {
+        return {
+          objects: [{ key: "email-raw:v1:user-aaa/message-1" }],
+          delimitedPrefixes: [],
+          truncated: false,
+        };
+      },
+      delete: deleteEmailBlob,
+    } as unknown as R2Bucket,
+    MAILBOX: {
+      idFromName: (name: string) => name as unknown as DurableObjectId,
+      get: () => ({
+        listBlobReferences,
+        purge: purgeMailbox,
+      }),
+    } as unknown as DurableObjectNamespace,
+  });
 
-	await expect(
-		deleteUserAccount({
-			env,
-			dbUserId: 1,
-			mcpUserId: 'user-aaa',
-		}),
-	).rejects.toSatisfy(
-		(error: unknown) =>
-			error instanceof AccountDeletionCleanupError &&
-			error.cleanupErrors.some((warning) =>
-				warning.includes('email R2 delete unavailable'),
-			),
-	)
-	expect(listBlobReferences).toHaveBeenCalledTimes(1)
-	expect(deleteEmailBlob).toHaveBeenCalled()
-	expect(purgeMailbox).not.toHaveBeenCalled()
-	expect(rows.users).toEqual([
-		expect.objectContaining({
-			id: 1,
-			stable_user_id: 'user-aaa',
-			deleting_at: expect.any(String),
-		}),
-	])
+  await expect(
+    deleteUserAccount({
+      env,
+      dbUserId: 1,
+      mcpUserId: "user-aaa",
+    }),
+  ).rejects.toSatisfy(
+    (error: unknown) =>
+      error instanceof AccountDeletionCleanupError &&
+      error.cleanupErrors.some((warning) =>
+        warning.includes("email R2 delete unavailable"),
+      ),
+  );
+  expect(listBlobReferences).toHaveBeenCalledTimes(1);
+  expect(deleteEmailBlob).toHaveBeenCalled();
+  expect(purgeMailbox).not.toHaveBeenCalled();
+  expect(rows.users).toEqual([
+    expect.objectContaining({
+      id: 1,
+      stable_user_id: "user-aaa",
+      deleting_at: expect.any(String),
+    }),
+  ]);
 
-	const { db: unrelatedDb } = createTestDb({
-		users: [{ id: 1, email: 'b@example.com', stable_user_id: 'user-bbb' }],
-	})
-	const purgeAfterUnrelatedFailure = vi.fn(async () => ({ ok: true as const }))
-	const unrelatedFailureEnv = createSuccessfulDeletionEnv(unrelatedDb, {
-		OAUTH_PROVIDER: undefined,
-		MAILBOX: {
-			idFromName: (name: string) => name as unknown as DurableObjectId,
-			get: () => ({
-				listBlobReferences: async () => ({
-					references: [],
-					nextStartAfter: null,
-					truncated: false as const,
-				}),
-				purge: purgeAfterUnrelatedFailure,
-			}),
-		} as unknown as DurableObjectNamespace,
-	})
-	await expect(
-		deleteUserAccount({
-			env: unrelatedFailureEnv,
-			dbUserId: 1,
-			mcpUserId: 'user-bbb',
-		}),
-	).rejects.toBeInstanceOf(AccountDeletionCleanupError)
-	expect(purgeAfterUnrelatedFailure).not.toHaveBeenCalled()
-})
+  const { db: unrelatedDb } = createTestDb({
+    users: [{ id: 1, email: "b@example.com", stable_user_id: "user-bbb" }],
+  });
+  const purgeAfterUnrelatedFailure = vi.fn(async () => ({ ok: true as const }));
+  const unrelatedFailureEnv = createSuccessfulDeletionEnv(unrelatedDb, {
+    OAUTH_PROVIDER: undefined,
+    MAILBOX: {
+      idFromName: (name: string) => name as unknown as DurableObjectId,
+      get: () => ({
+        listBlobReferences: async () => ({
+          references: [],
+          nextStartAfter: null,
+          truncated: false as const,
+        }),
+        purge: purgeAfterUnrelatedFailure,
+      }),
+    } as unknown as DurableObjectNamespace,
+  });
+  await expect(
+    deleteUserAccount({
+      env: unrelatedFailureEnv,
+      dbUserId: 1,
+      mcpUserId: "user-bbb",
+    }),
+  ).rejects.toBeInstanceOf(AccountDeletionCleanupError);
+  expect(purgeAfterUnrelatedFailure).not.toHaveBeenCalled();
+});
 
-test('account deletion cancels Stripe billing and remains non-blocking on Stripe failures', async () => {
-	const listSubscriptions = vi.spyOn(stripeClient, 'listSubscriptions')
-	const cancelSubscription = vi.spyOn(stripeClient, 'cancelSubscription')
-	const deleteCustomer = vi.spyOn(stripeClient, 'deleteCustomer')
-	try {
-		listSubscriptions.mockResolvedValue([
-			{
-				id: 'sub_active',
-				status: 'active',
-				cancel_at: null,
-				items: { data: [{ price: { id: 'price_pro' } }] },
-			},
-			{
-				id: 'sub_trialing',
-				status: 'trialing',
-				cancel_at: null,
-				items: { data: [{ price: { id: 'price_pro' } }] },
-			},
-			{
-				id: 'sub_canceled',
-				status: 'canceled',
-				cancel_at: null,
-				items: { data: [{ price: { id: 'price_pro' } }] },
-			},
-		])
-		cancelSubscription.mockResolvedValue(undefined)
-		deleteCustomer.mockResolvedValue(undefined)
-		const { db, rows } = createTestDb({
-			users: [
-				{
-					id: 1,
-					email: 'pro@example.com',
-					stable_user_id: 'user-pro',
-					stripe_customer_id: 'cus_pro',
-				},
-			],
-		})
+test("account deletion cancels Stripe billing and remains non-blocking on Stripe failures", async () => {
+  const listSubscriptions = vi.spyOn(stripeClient, "listSubscriptions");
+  const cancelSubscription = vi.spyOn(stripeClient, "cancelSubscription");
+  const deleteCustomer = vi.spyOn(stripeClient, "deleteCustomer");
+  try {
+    listSubscriptions.mockResolvedValue([
+      {
+        id: "sub_active",
+        status: "active",
+        cancel_at: null,
+        items: { data: [{ price: { id: "price_pro" } }] },
+      },
+      {
+        id: "sub_trialing",
+        status: "trialing",
+        cancel_at: null,
+        items: { data: [{ price: { id: "price_pro" } }] },
+      },
+      {
+        id: "sub_canceled",
+        status: "canceled",
+        cancel_at: null,
+        items: { data: [{ price: { id: "price_pro" } }] },
+      },
+    ]);
+    cancelSubscription.mockResolvedValue(undefined);
+    deleteCustomer.mockResolvedValue(undefined);
+    const { db, rows } = createTestDb({
+      users: [
+        {
+          id: 1,
+          email: "pro@example.com",
+          stable_user_id: "user-pro",
+          stripe_customer_id: "cus_pro",
+        },
+      ],
+    });
 
-		const result = await deleteUserAccount({
-			env: createSuccessfulDeletionEnv(db),
-			dbUserId: 1,
-			mcpUserId: 'user-pro',
-		})
+    const result = await deleteUserAccount({
+      env: createSuccessfulDeletionEnv(db),
+      dbUserId: 1,
+      mcpUserId: "user-pro",
+    });
 
-		expect(listSubscriptions).toHaveBeenCalledWith(
-			expect.any(Object),
-			'cus_pro',
-		)
-		expect(cancelSubscription).toHaveBeenCalledTimes(2)
-		expect(cancelSubscription).toHaveBeenCalledWith(
-			expect.any(Object),
-			'sub_active',
-		)
-		expect(cancelSubscription).toHaveBeenCalledWith(
-			expect.any(Object),
-			'sub_trialing',
-		)
-		expect(deleteCustomer).toHaveBeenCalledWith(expect.any(Object), 'cus_pro')
-		expect(rows.users).toEqual([])
-		expect(result.warnings).toEqual([])
+    expect(listSubscriptions).toHaveBeenCalledWith(
+      expect.any(Object),
+      "cus_pro",
+    );
+    expect(cancelSubscription).toHaveBeenCalledTimes(2);
+    expect(cancelSubscription).toHaveBeenCalledWith(
+      expect.any(Object),
+      "sub_active",
+    );
+    expect(cancelSubscription).toHaveBeenCalledWith(
+      expect.any(Object),
+      "sub_trialing",
+    );
+    expect(deleteCustomer).toHaveBeenCalledWith(expect.any(Object), "cus_pro");
+    expect(rows.users).toEqual([]);
+    expect(result.warnings).toEqual([]);
 
-		listSubscriptions.mockRejectedValue(
-			new Error('Stripe subscriptions unavailable'),
-		)
-		deleteCustomer.mockRejectedValue(new Error('Stripe customer unavailable'))
-		cancelSubscription.mockClear()
-		consoleError.mockImplementation(() => {})
-		const { db: failureDb, rows: failureRows } = createTestDb({
-			users: [
-				{
-					id: 2,
-					email: 'failure@example.com',
-					stable_user_id: 'user-stripe-failure',
-					stripe_customer_id: 'cus_failure',
-				},
-			],
-		})
+    listSubscriptions.mockRejectedValue(
+      new Error("Stripe subscriptions unavailable"),
+    );
+    deleteCustomer.mockRejectedValue(new Error("Stripe customer unavailable"));
+    cancelSubscription.mockClear();
+    consoleError.mockImplementation(() => {});
+    const { db: failureDb, rows: failureRows } = createTestDb({
+      users: [
+        {
+          id: 2,
+          email: "failure@example.com",
+          stable_user_id: "user-stripe-failure",
+          stripe_customer_id: "cus_failure",
+        },
+      ],
+    });
 
-		const failureResult = await deleteUserAccount({
-			env: createSuccessfulDeletionEnv(failureDb),
-			dbUserId: 2,
-			mcpUserId: 'user-stripe-failure',
-		})
+    const failureResult = await deleteUserAccount({
+      env: createSuccessfulDeletionEnv(failureDb),
+      dbUserId: 2,
+      mcpUserId: "user-stripe-failure",
+    });
 
-		expect(deleteCustomer).toHaveBeenLastCalledWith(
-			expect.any(Object),
-			'cus_failure',
-		)
-		expect(cancelSubscription).not.toHaveBeenCalled()
-		expect(failureRows.users).toEqual([])
-		expect(failureResult.warnings).toEqual([
-			expect.stringContaining('Stripe customer cleanup failed'),
-		])
-		expect(consoleError).toHaveBeenCalledOnce()
-		expect(consoleError).toHaveBeenCalledWith(
-			'account_deletion_stripe_cleanup_failed',
-			expect.objectContaining({
-				userId: 'user-stripe-failure',
-				error: expect.any(AggregateError),
-			}),
-		)
+    expect(deleteCustomer).toHaveBeenLastCalledWith(
+      expect.any(Object),
+      "cus_failure",
+    );
+    expect(cancelSubscription).not.toHaveBeenCalled();
+    expect(failureRows.users).toEqual([]);
+    expect(failureResult.warnings).toEqual([
+      expect.stringContaining("Stripe customer cleanup failed"),
+    ]);
+    expect(consoleError).toHaveBeenCalledOnce();
+    expect(consoleError).toHaveBeenCalledWith(
+      "account_deletion_stripe_cleanup_failed",
+      expect.objectContaining({
+        userId: "user-stripe-failure",
+        error: expect.any(AggregateError),
+      }),
+    );
 
-		listSubscriptions.mockClear()
-		deleteCustomer.mockClear()
-		const { db: freeDb, rows: freeRows } = createTestDb({
-			users: [
-				{
-					id: 3,
-					email: 'free@example.com',
-					stable_user_id: 'user-free',
-					stripe_customer_id: null,
-				},
-			],
-		})
-		await deleteUserAccount({
-			env: createSuccessfulDeletionEnv(freeDb),
-			dbUserId: 3,
-			mcpUserId: 'user-free',
-		})
-		expect(listSubscriptions).not.toHaveBeenCalled()
-		expect(deleteCustomer).not.toHaveBeenCalled()
-		expect(freeRows.users).toEqual([])
-	} finally {
-		listSubscriptions.mockRestore()
-		cancelSubscription.mockRestore()
-		deleteCustomer.mockRestore()
-		consoleError.mockReset()
-	}
-})
+    listSubscriptions.mockClear();
+    deleteCustomer.mockClear();
+    const { db: freeDb, rows: freeRows } = createTestDb({
+      users: [
+        {
+          id: 3,
+          email: "free@example.com",
+          stable_user_id: "user-free",
+          stripe_customer_id: null,
+        },
+      ],
+    });
+    await deleteUserAccount({
+      env: createSuccessfulDeletionEnv(freeDb),
+      dbUserId: 3,
+      mcpUserId: "user-free",
+    });
+    expect(listSubscriptions).not.toHaveBeenCalled();
+    expect(deleteCustomer).not.toHaveBeenCalled();
+    expect(freeRows.users).toEqual([]);
+  } finally {
+    listSubscriptions.mockRestore();
+    cancelSubscription.mockRestore();
+    deleteCustomer.mockRestore();
+    consoleError.mockReset();
+  }
+});
 
-test('deleteUserAccount drops the UserMeter tombstone after the user row is gone', async () => {
-	const { db, rows } = createTestDb({
-		users: [{ id: 1, email: 'a@example.com' }],
-	})
-	const env = createSuccessfulDeletionEnv(db)
-	const meter = userMeterRpc({ env, userId: 'user-aaa' })
-	await meter.markDeleting({ deletingAt: '2026-08-31 15:22:12' })
+test("deleteUserAccount drops the UserMeter tombstone after the user row is gone", async () => {
+  const { db, rows } = createTestDb({
+    users: [{ id: 1, email: "a@example.com" }],
+  });
+  const env = createSuccessfulDeletionEnv(db);
+  const meter = userMeterRpc({ env, userId: "user-aaa" });
+  await meter.markDeleting({ deletingAt: "2026-08-31 15:22:12" });
 
-	await deleteUserAccount({
-		env,
-		dbUserId: 1,
-		mcpUserId: 'user-aaa',
-	})
+  await deleteUserAccount({
+    env,
+    dbUserId: 1,
+    mcpUserId: "user-aaa",
+  });
 
-	expect(rows.users).toEqual([])
-	expect(await meter.readDeletionState()).toEqual({ deletingAt: null })
-})
+  expect(rows.users).toEqual([]);
+  expect(await meter.readDeletionState()).toEqual({ deletingAt: null });
+});
 
-test('deleteUserAccount clears the deletion fence when writers are still active', async () => {
-	const { db, rows } = createTestDb({
-		users: [{ id: 1, email: 'a@example.com' }],
-	})
-	const env = createSuccessfulDeletionEnv(db)
-	const meter = userMeterRpc({ env, userId: 'user-aaa' })
-	await meter.acquireWriteLease({
-		token: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
-		holder: 'test:signup',
-		acquiredAt: '2026-08-31 15:00:00',
-	})
+test("deleteUserAccount clears the deletion fence when writers are still active", async () => {
+  const { db, rows } = createTestDb({
+    users: [{ id: 1, email: "a@example.com" }],
+  });
+  const env = createSuccessfulDeletionEnv(db);
+  const meter = userMeterRpc({ env, userId: "user-aaa" });
+  await meter.acquireWriteLease({
+    token: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+    holder: "test:signup",
+    acquiredAt: "2026-08-31 15:00:00",
+  });
 
-	await expect(
-		deleteUserAccount({
-			env,
-			dbUserId: 1,
-			mcpUserId: 'user-aaa',
-		}),
-	).rejects.toBeInstanceOf(AccountDeletionWritersActiveError)
-	expect(rows.users).toEqual([
-		expect.objectContaining({
-			id: 1,
-			stable_user_id: 'user-aaa',
-			deleting_at: null,
-		}),
-	])
-	expect(await meter.readDeletionState()).toEqual({ deletingAt: null })
-})
+  await expect(
+    deleteUserAccount({
+      env,
+      dbUserId: 1,
+      mcpUserId: "user-aaa",
+    }),
+  ).rejects.toBeInstanceOf(AccountDeletionWritersActiveError);
+  expect(rows.users).toEqual([
+    expect.objectContaining({
+      id: 1,
+      stable_user_id: "user-aaa",
+      deleting_at: null,
+    }),
+  ]);
+  expect(await meter.readDeletionState()).toEqual({ deletingAt: null });
+});
 
-test('deleteUserAccount clears the deletion fence when inventory cannot be collected', async () => {
-	const { db, rows } = createTestDb(
-		{
-			users: [{ id: 1, email: 'a@example.com' }],
-		},
-		{ failSelectContaining: 'from mcp_memories' },
-	)
-	const env = createSuccessfulDeletionEnv(db)
-	const meter = userMeterRpc({ env, userId: 'user-aaa' })
+test("deleteUserAccount clears the deletion fence when inventory cannot be collected", async () => {
+  const { db, rows } = createTestDb(
+    {
+      users: [{ id: 1, email: "a@example.com" }],
+    },
+    { failSelectContaining: "from mcp_memories" },
+  );
+  const env = createSuccessfulDeletionEnv(db);
+  const meter = userMeterRpc({ env, userId: "user-aaa" });
 
-	await expect(
-		deleteUserAccount({
-			env,
-			dbUserId: 1,
-			mcpUserId: 'user-aaa',
-		}),
-	).rejects.toBeInstanceOf(AccountDeletionInventoryError)
-	expect(rows.users).toEqual([
-		expect.objectContaining({
-			id: 1,
-			stable_user_id: 'user-aaa',
-			deleting_at: null,
-		}),
-	])
-	expect(await meter.readDeletionState()).toEqual({ deletingAt: null })
-})
+  await expect(
+    deleteUserAccount({
+      env,
+      dbUserId: 1,
+      mcpUserId: "user-aaa",
+    }),
+  ).rejects.toBeInstanceOf(AccountDeletionInventoryError);
+  expect(rows.users).toEqual([
+    expect.objectContaining({
+      id: 1,
+      stable_user_id: "user-aaa",
+      deleting_at: null,
+    }),
+  ]);
+  expect(await meter.readDeletionState()).toEqual({ deletingAt: null });
+});
 
-test('deleteUserAccount keeps an existing fence when writers are still active', async () => {
-	const { db, rows } = createTestDb({
-		users: [
-			{
-				id: 1,
-				email: 'a@example.com',
-				deleting_at: '2026-08-31 15:22:12',
-			},
-		],
-	})
-	const env = createSuccessfulDeletionEnv(db)
-	const meter = userMeterRpc({ env, userId: 'user-aaa' })
-	await meter.acquireWriteLease({
-		token: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
-		holder: 'test:cleanup-retry',
-		acquiredAt: '2026-08-31 15:23:00',
-	})
-	await meter.markDeleting({ deletingAt: '2026-08-31 15:22:12' })
+test("deleteUserAccount keeps an existing fence when writers are still active", async () => {
+  const { db, rows } = createTestDb({
+    users: [
+      {
+        id: 1,
+        email: "a@example.com",
+        deleting_at: "2026-08-31 15:22:12",
+      },
+    ],
+  });
+  const env = createSuccessfulDeletionEnv(db);
+  const meter = userMeterRpc({ env, userId: "user-aaa" });
+  await meter.acquireWriteLease({
+    token: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+    holder: "test:cleanup-retry",
+    acquiredAt: "2026-08-31 15:23:00",
+  });
+  await meter.markDeleting({ deletingAt: "2026-08-31 15:22:12" });
 
-	await expect(
-		deleteUserAccount({
-			env,
-			dbUserId: 1,
-			mcpUserId: 'user-aaa',
-		}),
-	).rejects.toBeInstanceOf(AccountDeletionWritersActiveError)
-	expect(rows.users).toEqual([
-		expect.objectContaining({
-			id: 1,
-			stable_user_id: 'user-aaa',
-			deleting_at: '2026-08-31 15:22:12',
-		}),
-	])
-	expect(await meter.readDeletionState()).toEqual({
-		deletingAt: '2026-08-31 15:22:12',
-	})
-})
+  await expect(
+    deleteUserAccount({
+      env,
+      dbUserId: 1,
+      mcpUserId: "user-aaa",
+    }),
+  ).rejects.toBeInstanceOf(AccountDeletionWritersActiveError);
+  expect(rows.users).toEqual([
+    expect.objectContaining({
+      id: 1,
+      stable_user_id: "user-aaa",
+      deleting_at: "2026-08-31 15:22:12",
+    }),
+  ]);
+  expect(await meter.readDeletionState()).toEqual({
+    deletingAt: "2026-08-31 15:22:12",
+  });
+});

--- a/packages/worker/src/app/account-deletion.node.test.ts
+++ b/packages/worker/src/app/account-deletion.node.test.ts
@@ -1,1341 +1,1339 @@
-import { quoteSqlIdentifier } from "@kody-internal/shared/sql-literals.ts";
-import { DatabaseSync } from "node:sqlite";
-import { expect, test, vi } from "vitest";
-import * as stripeClient from "#worker/billing/stripe-client.ts";
+import { quoteSqlIdentifier } from '@kody-internal/shared/sql-literals.ts'
+import { DatabaseSync } from 'node:sqlite'
+import { expect, test, vi } from 'vitest'
+import * as stripeClient from '#worker/billing/stripe-client.ts'
 import {
-  AccountDeletionCleanupError,
-  AccountDeletionInventoryError,
-  deleteUserAccount,
-  getAccountDeletionD1UserColumnCoverage,
-} from "./account-deletion.ts";
-import { AccountDeletionWritersActiveError } from "#worker/account/deletion-state.ts";
-import { userMeterRpc } from "#worker/entitlements/user-meter-client.ts";
-import { accountUserDataExcludedOwnerIds } from "#worker/account/data-targets.ts";
-import { jobVectorId } from "#mcp/jobs-vectorize.ts";
-import { consoleError } from "#worker/test-support/console-spies.ts";
-import { createInMemoryUserMeterEnv } from "#worker/test-support/user-meter.ts";
+	AccountDeletionCleanupError,
+	AccountDeletionInventoryError,
+	deleteUserAccount,
+	getAccountDeletionD1UserColumnCoverage,
+} from './account-deletion.ts'
+import { AccountDeletionWritersActiveError } from '#worker/account/deletion-state.ts'
+import { userMeterRpc } from '#worker/entitlements/user-meter-client.ts'
+import { accountUserDataExcludedOwnerIds } from '#worker/account/data-targets.ts'
+import { jobVectorId } from '#mcp/jobs-vectorize.ts'
+import { consoleError } from '#worker/test-support/console-spies.ts'
+import { createInMemoryUserMeterEnv } from '#worker/test-support/user-meter.ts'
 import {
-  insertRepoSession,
-  listRepoSessionsByUser,
-} from "#worker/repo/repo-sessions.ts";
-import { applyAllMigrations } from "#worker/test-support/apply-all-migrations.ts";
-import { createD1FromSqlite } from "#worker/test-support/create-d1-from-sqlite.ts";
-import { accountUserOwnedVectorizeSurfaces } from "#worker/account/user-owned-surfaces.ts";
+	insertRepoSession,
+	listRepoSessionsByUser,
+} from '#worker/repo/repo-sessions.ts'
+import { applyAllMigrations } from '#worker/test-support/apply-all-migrations.ts'
+import { createD1FromSqlite } from '#worker/test-support/create-d1-from-sqlite.ts'
+import { accountUserOwnedVectorizeSurfaces } from '#worker/account/user-owned-surfaces.ts'
 import {
-  createTestDb,
-  createJobsBindingStub,
-  createSuccessfulDeletionEnv,
-} from "#worker/test-support/account-deletion.ts";
+	createTestDb,
+	createJobsBindingStub,
+	createSuccessfulDeletionEnv,
+} from '#worker/test-support/account-deletion.ts'
 
-const appMigrationsDir = new URL("../../migrations/", import.meta.url);
+const appMigrationsDir = new URL('../../migrations/', import.meta.url)
 
 function listSqliteTables(db: DatabaseSync) {
-  return (
-    db
-      .prepare(
-        `SELECT name
+	return (
+		db
+			.prepare(
+				`SELECT name
 				FROM sqlite_schema
 				WHERE type = 'table' AND name NOT LIKE 'sqlite_%'
 				ORDER BY name`,
-      )
-      .all() as Array<{ name: string }>
-  ).map((row) => row.name);
+			)
+			.all() as Array<{ name: string }>
+	).map((row) => row.name)
 }
 
-test("vectorize surface sources match the migrated APP_DB schema", () => {
-  const db = new DatabaseSync(":memory:");
-  applyAllMigrations(db, appMigrationsDir);
-  const tables = new Set(listSqliteTables(db));
+test('vectorize surface sources match the migrated APP_DB schema', () => {
+	const db = new DatabaseSync(':memory:')
+	applyAllMigrations(db, appMigrationsDir)
+	const tables = new Set(listSqliteTables(db))
 
-  // Jobs moved to the jobs worker's D1 (migration 0010 dropped the APP_DB
-  // copies), so the job surface must be sourced over the JOBS binding rather
-  // than an APP_DB table scan.
-  expect(tables.has("jobs")).toBe(false);
-  for (const surface of accountUserOwnedVectorizeSurfaces) {
-    switch (surface.source.kind) {
-      case "app_db": {
-        expect(
-          tables.has(surface.source.table),
-          `vectorize surface ${surface.id} reads APP_DB table ${surface.source.table}, which the migrated schema does not define`,
-        ).toBe(true);
-        break;
-      }
-      case "jobs_rpc": {
-        expect(surface.id).toBe("job");
-        break;
-      }
-      default: {
-        const unknownSource: never = surface.source;
-        throw new Error(
-          `Unknown vectorize source: ${JSON.stringify(unknownSource)}`,
-        );
-      }
-    }
-  }
-});
+	// Jobs moved to the jobs worker's D1 (migration 0010 dropped the APP_DB
+	// copies), so the job surface must be sourced over the JOBS binding rather
+	// than an APP_DB table scan.
+	expect(tables.has('jobs')).toBe(false)
+	for (const surface of accountUserOwnedVectorizeSurfaces) {
+		switch (surface.source.kind) {
+			case 'app_db': {
+				expect(
+					tables.has(surface.source.table),
+					`vectorize surface ${surface.id} reads APP_DB table ${surface.source.table}, which the migrated schema does not define`,
+				).toBe(true)
+				break
+			}
+			case 'jobs_rpc': {
+				expect(surface.id).toBe('job')
+				break
+			}
+			default: {
+				const unknownSource: never = surface.source
+				throw new Error(
+					`Unknown vectorize source: ${JSON.stringify(unknownSource)}`,
+				)
+			}
+		}
+	}
+})
 
-test("deleteUserAccount enumerates job vectors through JOBS against the real post-0010 APP_DB schema", async () => {
-  const sqlite = new DatabaseSync(":memory:");
-  applyAllMigrations(sqlite, appMigrationsDir);
-  expect(listSqliteTables(sqlite)).not.toContain("jobs");
-  const db = createD1FromSqlite(sqlite);
-  const userId = "user-post-0010";
-  const inserted = await db
-    .prepare(
-      `INSERT INTO users (
+test('deleteUserAccount enumerates job vectors through JOBS against the real post-0010 APP_DB schema', async () => {
+	const sqlite = new DatabaseSync(':memory:')
+	applyAllMigrations(sqlite, appMigrationsDir)
+	expect(listSqliteTables(sqlite)).not.toContain('jobs')
+	const db = createD1FromSqlite(sqlite)
+	const userId = 'user-post-0010'
+	const inserted = await db
+		.prepare(
+			`INSERT INTO users (
 				username, email, password_hash, stable_user_id,
 				email_verified_at, account_type, created_at
 			) VALUES ('post0010', 'post0010@example.com', 'hash', ?, ?, 'person', ?)`,
-    )
-    .bind(userId, "2026-09-01T00:00:00.000Z", "2026-09-01T00:00:00.000Z")
-    .run();
-  const dbUserId = Number(inserted.meta.last_row_id);
-  await db
-    .prepare(
-      `INSERT INTO mcp_memories (id, user_id, subject, summary)
+		)
+		.bind(userId, '2026-09-01T00:00:00.000Z', '2026-09-01T00:00:00.000Z')
+		.run()
+	const dbUserId = Number(inserted.meta.last_row_id)
+	await db
+		.prepare(
+			`INSERT INTO mcp_memories (id, user_id, subject, summary)
 			VALUES ('mem-post-0010', ?, 'subject', 'summary')`,
-    )
-    .bind(userId)
-    .run();
+		)
+		.bind(userId)
+		.run()
 
-  const deleteVectorsMock = vi.fn(async () => undefined);
-  const listJobIdsForUser = vi.fn(async (_input: { userId: string }) => [
-    "job-live-1",
-    "job-live-2",
-  ]);
-  const purgeJobsUser = vi.fn(async (input: { userId: string }) => ({
-    ok: true as const,
-    userId: input.userId,
-    purged: true,
-  }));
-  const env = createSuccessfulDeletionEnv(db, {
-    CAPABILITY_VECTOR_INDEX: { deleteByIds: deleteVectorsMock },
-    JOBS: {
-      listJobIdsForUser,
-      listJobStorageIdsForUser: async () => [] as Array<string>,
-      purgeUser: purgeJobsUser,
-    },
-  } as unknown as Partial<Env>);
+	const deleteVectorsMock = vi.fn(async () => undefined)
+	const listJobIdsForUser = vi.fn(async (_input: { userId: string }) => [
+		'job-live-1',
+		'job-live-2',
+	])
+	const purgeJobsUser = vi.fn(async (input: { userId: string }) => ({
+		ok: true as const,
+		userId: input.userId,
+		purged: true,
+	}))
+	const env = createSuccessfulDeletionEnv(db, {
+		CAPABILITY_VECTOR_INDEX: { deleteByIds: deleteVectorsMock },
+		JOBS: {
+			listJobIdsForUser,
+			listJobStorageIdsForUser: async () => [] as Array<string>,
+			purgeUser: purgeJobsUser,
+		},
+	} as unknown as Partial<Env>)
 
-  const result = await deleteUserAccount({ env, dbUserId, mcpUserId: userId });
+	const result = await deleteUserAccount({ env, dbUserId, mcpUserId: userId })
 
-  expect(listJobIdsForUser).toHaveBeenCalledWith({ userId });
-  expect(deleteVectorsMock).toHaveBeenCalledWith([
-    "memory_mem-post-0010",
-    jobVectorId("job-live-1"),
-    jobVectorId("job-live-2"),
-  ]);
-  expect(result.deletedVectors).toBe(3);
-  expect(purgeJobsUser).toHaveBeenCalledWith({ userId });
-  expect(result.warnings).toEqual([]);
-  expect(sqlite.prepare(`SELECT COUNT(*) AS count FROM users`).get()).toEqual({
-    count: 0,
-  });
-  expect(
-    sqlite.prepare(`SELECT COUNT(*) AS count FROM mcp_memories`).get(),
-  ).toEqual({ count: 0 });
-});
+	expect(listJobIdsForUser).toHaveBeenCalledWith({ userId })
+	expect(deleteVectorsMock).toHaveBeenCalledWith([
+		'memory_mem-post-0010',
+		jobVectorId('job-live-1'),
+		jobVectorId('job-live-2'),
+	])
+	expect(result.deletedVectors).toBe(3)
+	expect(purgeJobsUser).toHaveBeenCalledWith({ userId })
+	expect(result.warnings).toEqual([])
+	expect(sqlite.prepare(`SELECT COUNT(*) AS count FROM users`).get()).toEqual({
+		count: 0,
+	})
+	expect(
+		sqlite.prepare(`SELECT COUNT(*) AS count FROM mcp_memories`).get(),
+	).toEqual({ count: 0 })
+})
 
-test("deleteUserAccount fails inventory loudly when JOBS is unbound instead of scanning APP_DB for jobs", async () => {
-  const { db, rows } = createTestDb({
-    users: [{ id: 1, email: "a@example.com" }],
-  });
-  const env = createSuccessfulDeletionEnv(db, {
-    JOBS: undefined,
-  } as unknown as Partial<Env>);
+test('deleteUserAccount fails inventory loudly when JOBS is unbound instead of scanning APP_DB for jobs', async () => {
+	const { db, rows } = createTestDb({
+		users: [{ id: 1, email: 'a@example.com' }],
+	})
+	const env = createSuccessfulDeletionEnv(db, {
+		JOBS: undefined,
+	} as unknown as Partial<Env>)
 
-  await expect(
-    deleteUserAccount({ env, dbUserId: 1, mcpUserId: "user-aaa" }),
-  ).rejects.toSatisfy(
-    (error: unknown) =>
-      error instanceof AccountDeletionInventoryError &&
-      error.inventoryErrors.some((message) =>
-        message.includes(
-          "JOBS service binding is required to enumerate job vector ids",
-        ),
-      ),
-  );
-  expect(rows.users).toEqual([
-    expect.objectContaining({ id: 1, deleting_at: null }),
-  ]);
-});
+	await expect(
+		deleteUserAccount({ env, dbUserId: 1, mcpUserId: 'user-aaa' }),
+	).rejects.toSatisfy(
+		(error: unknown) =>
+			error instanceof AccountDeletionInventoryError &&
+			error.inventoryErrors.some((message) =>
+				message.includes(
+					'JOBS service binding is required to enumerate job vector ids',
+				),
+			),
+	)
+	expect(rows.users).toEqual([
+		expect.objectContaining({ id: 1, deleting_at: null }),
+	])
+})
 
-test("account deletion D1 coverage includes every live user-owned schema column", () => {
-  const migrationsDir = new URL("../../migrations/", import.meta.url);
-  const db = new DatabaseSync(":memory:");
-  applyAllMigrations(db, migrationsDir);
-  const tables = db
-    .prepare(
-      `SELECT name
+test('account deletion D1 coverage includes every live user-owned schema column', () => {
+	const migrationsDir = new URL('../../migrations/', import.meta.url)
+	const db = new DatabaseSync(':memory:')
+	applyAllMigrations(db, migrationsDir)
+	const tables = db
+		.prepare(
+			`SELECT name
 			FROM sqlite_schema
 			WHERE type = 'table' AND name NOT LIKE 'sqlite_%'
 			ORDER BY name`,
-    )
-    .all() as Array<{ name: string }>;
-  const liveUserColumns = new Set<string>();
-  for (const table of tables) {
-    const columns = db
-      .prepare(`PRAGMA table_info(${quoteSqlIdentifier(table.name)})`)
-      .all() as Array<{ name: string }>;
-    for (const column of columns) {
-      if (column.name === "user_id" || column.name.endsWith("_user_id")) {
-        liveUserColumns.add(`${table.name}.${column.name}`);
-      }
-    }
-  }
-  const coveredColumns = getAccountDeletionD1UserColumnCoverage();
-  const missing = [...liveUserColumns].filter(
-    (column) => !coveredColumns.has(column),
-  );
-  const stale = [...coveredColumns].filter(
-    (column) => !liveUserColumns.has(column),
-  );
-  expect(
-    missing,
-    "user-owned D1 columns missing from account deletion",
-  ).toEqual([]);
-  expect(stale, "account deletion references stale D1 columns").toEqual([]);
-});
+		)
+		.all() as Array<{ name: string }>
+	const liveUserColumns = new Set<string>()
+	for (const table of tables) {
+		const columns = db
+			.prepare(`PRAGMA table_info(${quoteSqlIdentifier(table.name)})`)
+			.all() as Array<{ name: string }>
+		for (const column of columns) {
+			if (column.name === 'user_id' || column.name.endsWith('_user_id')) {
+				liveUserColumns.add(`${table.name}.${column.name}`)
+			}
+		}
+	}
+	const coveredColumns = getAccountDeletionD1UserColumnCoverage()
+	const missing = [...liveUserColumns].filter(
+		(column) => !coveredColumns.has(column),
+	)
+	const stale = [...coveredColumns].filter(
+		(column) => !liveUserColumns.has(column),
+	)
+	expect(
+		missing,
+		'user-owned D1 columns missing from account deletion',
+	).toEqual([])
+	expect(stale, 'account deletion references stale D1 columns').toEqual([])
+})
 
-test("account deletion preserves operator-owned system email configuration", async () => {
-  expect(
-    accountUserDataExcludedOwnerIds.some(
-      (exclusion) => exclusion.ownerId === "system:email",
-    ),
-  ).toBe(true);
+test('account deletion preserves operator-owned system email configuration', async () => {
+	expect(
+		accountUserDataExcludedOwnerIds.some(
+			(exclusion) => exclusion.ownerId === 'system:email',
+		),
+	).toBe(true)
 
-  const { db, rows } = createTestDb({
-    users: [{ id: 1, email: "user@example.com" }],
-    email_inboxes: [
-      { id: "user-inbox", user_id: "user-aaa" },
-      { id: "system-inbox", user_id: "system:email" },
-    ],
-    email_inbox_addresses: [
-      { id: "user-address", user_id: "user-aaa" },
-      { id: "system-address", user_id: "system:email" },
-    ],
-  });
+	const { db, rows } = createTestDb({
+		users: [{ id: 1, email: 'user@example.com' }],
+		email_inboxes: [
+			{ id: 'user-inbox', user_id: 'user-aaa' },
+			{ id: 'system-inbox', user_id: 'system:email' },
+		],
+		email_inbox_addresses: [
+			{ id: 'user-address', user_id: 'user-aaa' },
+			{ id: 'system-address', user_id: 'system:email' },
+		],
+	})
 
-  await deleteUserAccount({
-    env: createSuccessfulDeletionEnv(db),
-    dbUserId: 1,
-    mcpUserId: "user-aaa",
-  });
+	await deleteUserAccount({
+		env: createSuccessfulDeletionEnv(db),
+		dbUserId: 1,
+		mcpUserId: 'user-aaa',
+	})
 
-  expect(rows.email_inboxes).toEqual([
-    { id: "system-inbox", user_id: "system:email" },
-  ]);
-  expect(rows.email_inbox_addresses).toEqual([
-    { id: "system-address", user_id: "system:email" },
-  ]);
-});
+	expect(rows.email_inboxes).toEqual([
+		{ id: 'system-inbox', user_id: 'system:email' },
+	])
+	expect(rows.email_inbox_addresses).toEqual([
+		{ id: 'system-address', user_id: 'system:email' },
+	])
+})
 
-test("deleteUserAccount cascades user-scoped rows for the requested user", async () => {
-  const userAaa = "user-aaa";
-  const userBbb = "user-bbb";
-  const packageJobId =
-    "package-job:b2fda105-005a-4e2b-9f22-1513b6752da2:event-runner";
-  const { db, rows } = createTestDb({
-    users: [
-      {
-        id: 1,
-        email: "a@example.com",
-        avatar_key: "user-avatars/user-aaa/abc123.png",
-      },
-      { id: 2, email: "b@example.com" },
-    ],
-    jobs: [
-      { id: "job-1", user_id: userAaa, storage_id: "job:job-1" },
-      { id: "job-2", user_id: userAaa, storage_id: null },
-      { id: packageJobId, user_id: userAaa, storage_id: null },
-      { id: "job-3", user_id: userBbb, storage_id: "job:job-3" },
-    ],
-    user_storage_buckets: [
-      {
-        user_id: userAaa,
-        storage_id: "exec:run-2",
-        kind: "execute",
-      },
-      {
-        user_id: userAaa,
-        storage_id: "repo-session:rs-1",
-        kind: "repo_session",
-      },
-      {
-        user_id: userBbb,
-        storage_id: "package:pkg-2",
-        kind: "package",
-      },
-    ],
-    mcp_memories: [
-      { id: "mem-1", user_id: userAaa },
-      { id: "mem-2", user_id: userBbb },
-    ],
-    secret_buckets: [{ id: "sb-1", user_id: userAaa }],
-    secret_entries: [{ bucket_id: "sb-1", name: "s", user_id: "unused" }],
-    value_buckets: [{ id: "vb-1", user_id: userAaa }],
-    value_entries: [{ bucket_id: "vb-1", name: "v", user_id: "unused" }],
-    mcp_agent_sessions: [
-      { do_id: "do-user-a", user_id: userAaa },
-      { do_id: "do-user-b", user_id: userBbb },
-    ],
-    saved_packages: [
-      {
-        id: "pkg-1",
-        user_id: userAaa,
-        kody_id: "demo",
-        source_id: "src-1",
-        has_app: 1,
-      },
-      {
-        id: "pkg-2",
-        user_id: userBbb,
-        kody_id: "other",
-        source_id: "src-2",
-        has_app: 0,
-      },
-    ],
-    published_bundle_artifacts: [
-      { id: "pba-1", user_id: userAaa, kv_key: "bundle-artifact:v1:src-1" },
-      { id: "pba-2", user_id: userBbb, kv_key: "bundle-artifact:v1:src-2" },
-    ],
-    archived_job_artifacts: [
-      { id: "aja-1", user_id: userAaa, storage_id: "job:archived-1" },
-    ],
-    entity_sources: [
-      { id: "src-1", user_id: userAaa, published_commit: "abc123" },
-      { id: "src-2", user_id: userBbb, published_commit: "def456" },
-    ],
-    password_resets: [
-      { id: 1, user_id: 1 },
-      { id: 2, user_id: 1 },
-      { id: 3, user_id: 2 },
-    ],
-    user_roles: [
-      { user_id: 1, role_id: 1 },
-      { user_id: 2, role_id: 2 },
-    ],
-    passkeys: [
-      { id: "pk-1", user_id: 1 },
-      { id: "pk-2", user_id: 2 },
-    ],
-    verifications: [
-      { id: 1, type: "2fa", target: "1" },
-      { id: 2, type: "2fa", target: "2" },
-    ],
-    mcp_user_server_instructions: [{ user_id: userAaa }],
-    package_invocation_tokens: [{ id: "pit-1", user_id: userAaa }],
-    agent_package_conversation_uses: [
-      {
-        user_id: userAaa,
-        package_id: "pkg-1",
-        conversation_id: "conv-1",
-      },
-    ],
-    mcp_memory_conversation_suppressions: [
-      { user_id: userAaa, conversation_id: "c1", memory_id: "mem-1" },
-    ],
-    email_inboxes: [{ id: "in-1", user_id: userAaa }],
-    email_inbox_addresses: [{ id: "ia-1", user_id: userAaa }],
-    email_sender_identities: [{ id: "ei-1", user_id: userAaa }],
-    platform_feedback: [
-      {
-        id: "feedback-submitted-by-a",
-        submitter_user_id: userAaa,
-        submitter_username: "user-a",
-        submitter_email: "a@example.com",
-        reviewed_by_user_id: userBbb,
-        reviewed_at: "2026-07-05",
-        admin_note: "Reviewed by B.",
-      },
-      {
-        id: "feedback-reviewed-by-a",
-        submitter_user_id: userBbb,
-        submitter_username: "user-b",
-        submitter_email: "b@example.com",
-        reviewed_by_user_id: userAaa,
-        reviewed_at: "2026-07-05",
-        admin_note: "Private admin note from A.",
-      },
-      {
-        id: "feedback-unrelated",
-        submitter_user_id: userBbb,
-        submitter_username: "user-b",
-        submitter_email: "b@example.com",
-        reviewed_by_user_id: userBbb,
-        reviewed_at: "2026-07-05",
-        admin_note: "Reviewed by B.",
-      },
-    ],
-    community_listings: [
-      {
-        id: "listing-1",
-        owner_user_id: userAaa,
-        pinned_commit: "commit-1",
-        source_id: "src-1",
-      },
-      { id: "listing-2", owner_user_id: userBbb, pinned_commit: "commit-2" },
-    ],
-    community_forks: [
-      { id: "fork-1", listing_id: "listing-1", forker_user_id: userBbb },
-      { id: "fork-2", listing_id: "listing-2", forker_user_id: userAaa },
-      { id: "fork-3", listing_id: "listing-2", forker_user_id: userBbb },
-    ],
-    community_ratings: [
-      { id: "rating-1", listing_id: "listing-1", user_id: userBbb },
-      { id: "rating-2", listing_id: "listing-2", user_id: userAaa },
-      { id: "rating-3", listing_id: "listing-2", user_id: userBbb },
-    ],
-    community_activity_events: [
-      {
-        id: "evt-1",
-        actor_user_id: userAaa,
-        event_type: "listing_published",
-        listing_id: "listing-2",
-      },
-      {
-        id: "evt-2",
-        actor_user_id: userBbb,
-        event_type: "listing_updated",
-        listing_id: "listing-1",
-      },
-      {
-        id: "evt-3",
-        actor_user_id: userBbb,
-        event_type: "listing_published",
-        listing_id: "listing-2",
-      },
-    ],
-    community_reports: [
-      {
-        id: "report-1",
-        listing_id: "listing-1",
-        listing_owner_user_id: userAaa,
-        reporter_user_id: userBbb,
-        resolved_by_user_id: null,
-      },
-      {
-        id: "report-2",
-        listing_id: "listing-2",
-        listing_owner_user_id: userBbb,
-        reporter_user_id: userAaa,
-        resolved_by_user_id: null,
-      },
-      {
-        id: "report-3",
-        listing_id: "listing-2",
-        listing_owner_user_id: userBbb,
-        reporter_user_id: userBbb,
-        resolved_by_user_id: userAaa,
-      },
-    ],
-    community_bans: [
-      { user_id: userAaa, banned_by_user_id: userBbb },
-      { user_id: userBbb, banned_by_user_id: userAaa },
-    ],
-    package_codemod_run_items: [
-      {
-        id: "codemod-item-1",
-        run_id: "codemod-run-1",
-        user_id: userAaa,
-        package_id: "pkg-1",
-        kody_id: "demo",
-        status: "applied",
-      },
-      {
-        id: "codemod-item-2",
-        run_id: "codemod-run-2",
-        user_id: userBbb,
-        package_id: "pkg-2",
-        kody_id: "demo-b",
-        status: "applied",
-      },
-    ],
-    package_codemod_runs: [
-      {
-        id: "codemod-run-1",
-        codemod_id: "0001-ambient-storage-to-package-storage",
-        mode: "apply",
-        scope_user_id: userAaa,
-        initiated_by_user_id: userAaa,
-        filters_json: JSON.stringify({ userIds: [userAaa, userBbb] }),
-        status: "completed",
-      },
-      {
-        id: "codemod-run-fleet",
-        codemod_id: "0001-ambient-storage-to-package-storage",
-        mode: "scan",
-        scope_user_id: null,
-        initiated_by_user_id: userBbb,
-        filters_json: JSON.stringify({ userIds: [userAaa] }),
-        status: "completed",
-      },
-      {
-        id: "codemod-run-2",
-        codemod_id: "0001-ambient-storage-to-package-storage",
-        mode: "apply",
-        scope_user_id: userBbb,
-        initiated_by_user_id: userBbb,
-        filters_json: JSON.stringify({ userIds: [userBbb] }),
-        status: "completed",
-      },
-    ],
-  });
+test('deleteUserAccount cascades user-scoped rows for the requested user', async () => {
+	const userAaa = 'user-aaa'
+	const userBbb = 'user-bbb'
+	const packageJobId =
+		'package-job:b2fda105-005a-4e2b-9f22-1513b6752da2:event-runner'
+	const { db, rows } = createTestDb({
+		users: [
+			{
+				id: 1,
+				email: 'a@example.com',
+				avatar_key: 'user-avatars/user-aaa/abc123.png',
+			},
+			{ id: 2, email: 'b@example.com' },
+		],
+		jobs: [
+			{ id: 'job-1', user_id: userAaa, storage_id: 'job:job-1' },
+			{ id: 'job-2', user_id: userAaa, storage_id: null },
+			{ id: packageJobId, user_id: userAaa, storage_id: null },
+			{ id: 'job-3', user_id: userBbb, storage_id: 'job:job-3' },
+		],
+		user_storage_buckets: [
+			{
+				user_id: userAaa,
+				storage_id: 'exec:run-2',
+				kind: 'execute',
+			},
+			{
+				user_id: userAaa,
+				storage_id: 'repo-session:rs-1',
+				kind: 'repo_session',
+			},
+			{
+				user_id: userBbb,
+				storage_id: 'package:pkg-2',
+				kind: 'package',
+			},
+		],
+		mcp_memories: [
+			{ id: 'mem-1', user_id: userAaa },
+			{ id: 'mem-2', user_id: userBbb },
+		],
+		secret_buckets: [{ id: 'sb-1', user_id: userAaa }],
+		secret_entries: [{ bucket_id: 'sb-1', name: 's', user_id: 'unused' }],
+		value_buckets: [{ id: 'vb-1', user_id: userAaa }],
+		value_entries: [{ bucket_id: 'vb-1', name: 'v', user_id: 'unused' }],
+		mcp_agent_sessions: [
+			{ do_id: 'do-user-a', user_id: userAaa },
+			{ do_id: 'do-user-b', user_id: userBbb },
+		],
+		saved_packages: [
+			{
+				id: 'pkg-1',
+				user_id: userAaa,
+				kody_id: 'demo',
+				source_id: 'src-1',
+				has_app: 1,
+			},
+			{
+				id: 'pkg-2',
+				user_id: userBbb,
+				kody_id: 'other',
+				source_id: 'src-2',
+				has_app: 0,
+			},
+		],
+		published_bundle_artifacts: [
+			{ id: 'pba-1', user_id: userAaa, kv_key: 'bundle-artifact:v1:src-1' },
+			{ id: 'pba-2', user_id: userBbb, kv_key: 'bundle-artifact:v1:src-2' },
+		],
+		archived_job_artifacts: [
+			{ id: 'aja-1', user_id: userAaa, storage_id: 'job:archived-1' },
+		],
+		entity_sources: [
+			{ id: 'src-1', user_id: userAaa, published_commit: 'abc123' },
+			{ id: 'src-2', user_id: userBbb, published_commit: 'def456' },
+		],
+		password_resets: [
+			{ id: 1, user_id: 1 },
+			{ id: 2, user_id: 1 },
+			{ id: 3, user_id: 2 },
+		],
+		user_roles: [
+			{ user_id: 1, role_id: 1 },
+			{ user_id: 2, role_id: 2 },
+		],
+		passkeys: [
+			{ id: 'pk-1', user_id: 1 },
+			{ id: 'pk-2', user_id: 2 },
+		],
+		verifications: [
+			{ id: 1, type: '2fa', target: '1' },
+			{ id: 2, type: '2fa', target: '2' },
+		],
+		mcp_user_server_instructions: [{ user_id: userAaa }],
+		package_invocation_tokens: [{ id: 'pit-1', user_id: userAaa }],
+		agent_package_conversation_uses: [
+			{
+				user_id: userAaa,
+				package_id: 'pkg-1',
+				conversation_id: 'conv-1',
+			},
+		],
+		mcp_memory_conversation_suppressions: [
+			{ user_id: userAaa, conversation_id: 'c1', memory_id: 'mem-1' },
+		],
+		email_inboxes: [{ id: 'in-1', user_id: userAaa }],
+		email_inbox_addresses: [{ id: 'ia-1', user_id: userAaa }],
+		email_sender_identities: [{ id: 'ei-1', user_id: userAaa }],
+		platform_feedback: [
+			{
+				id: 'feedback-submitted-by-a',
+				submitter_user_id: userAaa,
+				submitter_username: 'user-a',
+				submitter_email: 'a@example.com',
+				reviewed_by_user_id: userBbb,
+				reviewed_at: '2026-07-05',
+				admin_note: 'Reviewed by B.',
+			},
+			{
+				id: 'feedback-reviewed-by-a',
+				submitter_user_id: userBbb,
+				submitter_username: 'user-b',
+				submitter_email: 'b@example.com',
+				reviewed_by_user_id: userAaa,
+				reviewed_at: '2026-07-05',
+				admin_note: 'Private admin note from A.',
+			},
+			{
+				id: 'feedback-unrelated',
+				submitter_user_id: userBbb,
+				submitter_username: 'user-b',
+				submitter_email: 'b@example.com',
+				reviewed_by_user_id: userBbb,
+				reviewed_at: '2026-07-05',
+				admin_note: 'Reviewed by B.',
+			},
+		],
+		community_listings: [
+			{
+				id: 'listing-1',
+				owner_user_id: userAaa,
+				pinned_commit: 'commit-1',
+				source_id: 'src-1',
+			},
+			{ id: 'listing-2', owner_user_id: userBbb, pinned_commit: 'commit-2' },
+		],
+		community_forks: [
+			{ id: 'fork-1', listing_id: 'listing-1', forker_user_id: userBbb },
+			{ id: 'fork-2', listing_id: 'listing-2', forker_user_id: userAaa },
+			{ id: 'fork-3', listing_id: 'listing-2', forker_user_id: userBbb },
+		],
+		community_ratings: [
+			{ id: 'rating-1', listing_id: 'listing-1', user_id: userBbb },
+			{ id: 'rating-2', listing_id: 'listing-2', user_id: userAaa },
+			{ id: 'rating-3', listing_id: 'listing-2', user_id: userBbb },
+		],
+		community_activity_events: [
+			{
+				id: 'evt-1',
+				actor_user_id: userAaa,
+				event_type: 'listing_published',
+				listing_id: 'listing-2',
+			},
+			{
+				id: 'evt-2',
+				actor_user_id: userBbb,
+				event_type: 'listing_updated',
+				listing_id: 'listing-1',
+			},
+			{
+				id: 'evt-3',
+				actor_user_id: userBbb,
+				event_type: 'listing_published',
+				listing_id: 'listing-2',
+			},
+		],
+		community_reports: [
+			{
+				id: 'report-1',
+				listing_id: 'listing-1',
+				listing_owner_user_id: userAaa,
+				reporter_user_id: userBbb,
+				resolved_by_user_id: null,
+			},
+			{
+				id: 'report-2',
+				listing_id: 'listing-2',
+				listing_owner_user_id: userBbb,
+				reporter_user_id: userAaa,
+				resolved_by_user_id: null,
+			},
+			{
+				id: 'report-3',
+				listing_id: 'listing-2',
+				listing_owner_user_id: userBbb,
+				reporter_user_id: userBbb,
+				resolved_by_user_id: userAaa,
+			},
+		],
+		community_bans: [
+			{ user_id: userAaa, banned_by_user_id: userBbb },
+			{ user_id: userBbb, banned_by_user_id: userAaa },
+		],
+		package_codemod_run_items: [
+			{
+				id: 'codemod-item-1',
+				run_id: 'codemod-run-1',
+				user_id: userAaa,
+				package_id: 'pkg-1',
+				kody_id: 'demo',
+				status: 'applied',
+			},
+			{
+				id: 'codemod-item-2',
+				run_id: 'codemod-run-2',
+				user_id: userBbb,
+				package_id: 'pkg-2',
+				kody_id: 'demo-b',
+				status: 'applied',
+			},
+		],
+		package_codemod_runs: [
+			{
+				id: 'codemod-run-1',
+				codemod_id: '0001-ambient-storage-to-package-storage',
+				mode: 'apply',
+				scope_user_id: userAaa,
+				initiated_by_user_id: userAaa,
+				filters_json: JSON.stringify({ userIds: [userAaa, userBbb] }),
+				status: 'completed',
+			},
+			{
+				id: 'codemod-run-fleet',
+				codemod_id: '0001-ambient-storage-to-package-storage',
+				mode: 'scan',
+				scope_user_id: null,
+				initiated_by_user_id: userBbb,
+				filters_json: JSON.stringify({ userIds: [userAaa] }),
+				status: 'completed',
+			},
+			{
+				id: 'codemod-run-2',
+				codemod_id: '0001-ambient-storage-to-package-storage',
+				mode: 'apply',
+				scope_user_id: userBbb,
+				initiated_by_user_id: userBbb,
+				filters_json: JSON.stringify({ userIds: [userBbb] }),
+				status: 'completed',
+			},
+		],
+	})
 
-  const deletedKvKeys: Array<string> = [];
-  const kvStoreKeys = [
-    "source-snapshot:v1:src-1:abc123",
-    "source-manifest-snapshot:v1:src-1:abc123",
-    "source-snapshot:v1:src-1:old456",
-    "source-manifest-snapshot:v1:src-1:old456",
-    "derived-cache:v1:community-icon:v1:listing-1:commit-1",
-    "derived-cache:v1:community-icon:v1:listing-1:abc123",
-    "derived-cache:v1:community-icon:v1:listing-1:historical",
-    "derived-cache:v1:community-icon:v2:listing-1:commit-1",
-    "derived-cache:v1:community-icon:v2:listing-1:abc123",
-    "derived-cache:v1:community-icon:v3:listing-1:commit-1",
-    "derived-cache:v1:community-icon:v3:listing-1:abc123",
-    "source-snapshot:v1:src-2:def456",
-    `package-codemod-revert:${userAaa}:item-1`,
-    `package-codemod-revert:${userAaa}:item-2`,
-    `package-codemod-revert:${userBbb}:item-other`,
-    "package-retriever-manifest:v1:user-aaa:pkg-1:abc123",
-    "package-retriever-index-entry:v1:user-aaa:search:pkg-1:notes",
-    "package-retriever-index-entry:v1:user-aaa:context:pkg-1:notes",
-    "package-retriever-index-entry:v1:user-bbb:search:pkg-2:notes",
-    "platform-settings:v1:reserved-usernames",
-    "platform-settings:v1:signup-mode",
-    "public-code-runs:v2",
-  ];
-  const kv = {
-    async get(key: string) {
-      return kvStoreKeys.includes(key) ? "{}" : null;
-    },
-    async delete(key: string) {
-      deletedKvKeys.push(key);
-    },
-    async list(options?: { prefix?: string; cursor?: string }) {
-      const prefix = options?.prefix ?? "";
-      const matchingKeys = kvStoreKeys
-        .filter((key) => key.startsWith(prefix))
-        .sort();
-      if (prefix === "derived-cache:v1:community-icon:v1:listing-1:") {
-        const start = options?.cursor
-          ? Number(options.cursor.replace("icon-page-", "")) - 1
-          : 0;
-        const page = matchingKeys.slice(start, start + 1);
-        return {
-          keys: page.map((name) => ({ name })),
-          list_complete: start + page.length >= matchingKeys.length,
-          ...(start + page.length < matchingKeys.length
-            ? { cursor: `icon-page-${start + 2}` }
-            : {}),
-        };
-      }
-      return {
-        keys: matchingKeys.map((name) => ({ name })),
-        list_complete: true,
-        cursor: undefined,
-      };
-    },
-  } as unknown as KVNamespace;
+	const deletedKvKeys: Array<string> = []
+	const kvStoreKeys = [
+		'source-snapshot:v1:src-1:abc123',
+		'source-manifest-snapshot:v1:src-1:abc123',
+		'source-snapshot:v1:src-1:old456',
+		'source-manifest-snapshot:v1:src-1:old456',
+		'derived-cache:v1:community-icon:v1:listing-1:commit-1',
+		'derived-cache:v1:community-icon:v1:listing-1:abc123',
+		'derived-cache:v1:community-icon:v1:listing-1:historical',
+		'derived-cache:v1:community-icon:v2:listing-1:commit-1',
+		'derived-cache:v1:community-icon:v2:listing-1:abc123',
+		'derived-cache:v1:community-icon:v3:listing-1:commit-1',
+		'derived-cache:v1:community-icon:v3:listing-1:abc123',
+		'source-snapshot:v1:src-2:def456',
+		`package-codemod-revert:${userAaa}:item-1`,
+		`package-codemod-revert:${userAaa}:item-2`,
+		`package-codemod-revert:${userBbb}:item-other`,
+		'package-retriever-manifest:v1:user-aaa:pkg-1:abc123',
+		'package-retriever-index-entry:v1:user-aaa:search:pkg-1:notes',
+		'package-retriever-index-entry:v1:user-aaa:context:pkg-1:notes',
+		'package-retriever-index-entry:v1:user-bbb:search:pkg-2:notes',
+		'platform-settings:v1:reserved-usernames',
+		'platform-settings:v1:signup-mode',
+		'public-code-runs:v2',
+	]
+	const kv = {
+		async get(key: string) {
+			return kvStoreKeys.includes(key) ? '{}' : null
+		},
+		async delete(key: string) {
+			deletedKvKeys.push(key)
+		},
+		async list(options?: { prefix?: string; cursor?: string }) {
+			const prefix = options?.prefix ?? ''
+			const matchingKeys = kvStoreKeys
+				.filter((key) => key.startsWith(prefix))
+				.sort()
+			if (prefix === 'derived-cache:v1:community-icon:v1:listing-1:') {
+				const start = options?.cursor
+					? Number(options.cursor.replace('icon-page-', '')) - 1
+					: 0
+				const page = matchingKeys.slice(start, start + 1)
+				return {
+					keys: page.map((name) => ({ name })),
+					list_complete: start + page.length >= matchingKeys.length,
+					...(start + page.length < matchingKeys.length
+						? { cursor: `icon-page-${start + 2}` }
+						: {}),
+				}
+			}
+			return {
+				keys: matchingKeys.map((name) => ({ name })),
+				list_complete: true,
+				cursor: undefined,
+			}
+		},
+	} as unknown as KVNamespace
 
-  const deletedEmailBlobKeys: Array<string> = [];
-  const mailboxCleanupOrder: Array<string> = [];
-  const emailBlobKeys = new Set([
-    "email-raw:v1:user-aaa/em-1",
-    "email-raw:v1:user-aaa/em-2",
-    "email-raw:v1:user-bbb/em-3",
-  ]);
-  const emailBlobs = {
-    async list(options?: { prefix?: string }) {
-      return {
-        objects: [...emailBlobKeys]
-          .filter((key) => key.startsWith(options?.prefix ?? ""))
-          .map((key) => ({ key })),
-        delimitedPrefixes: [],
-        truncated: false as const,
-      };
-    },
-    async delete(keys: string | Array<string>) {
-      mailboxCleanupOrder.push("delete-email-blob");
-      for (const key of Array.isArray(keys) ? keys : [keys]) {
-        deletedEmailBlobKeys.push(key);
-        emailBlobKeys.delete(key);
-      }
-    },
-  } as unknown as R2Bucket;
-  const deletedCommunityAssetKeys: Array<string> = [];
-  const communityAssetKeys = new Set([
-    "user-avatars/user-aaa/abc123.png",
-    "user-avatars/user-aaa/old.png",
-    "user-avatars/user-bbb/other.png",
-    "community-icon:v1/listing-1/abc123/asset",
-    "community-icon:v1/listing-1/commit-1/asset",
-    "community-icon:v1/listing-1/historical/asset",
-    "community-icon:v2/listing-1/abc123/asset",
-    "community-icon:v2/listing-1/commit-1/asset",
-    "community-icon:v1/listing-2/other/asset",
-  ]);
-  const communityAssets = {
-    async list(options?: { prefix?: string; cursor?: string }) {
-      const matching = [...communityAssetKeys]
-        .filter(
-          (key) =>
-            key.startsWith(options?.prefix ?? "") &&
-            (!options?.cursor || key > options.cursor),
-        )
-        .sort();
-      const page = matching.slice(0, 1);
-      return {
-        objects: page.map((key) => ({ key })),
-        delimitedPrefixes: [],
-        ...(matching.length > page.length
-          ? { truncated: true as const, cursor: page[0]! }
-          : { truncated: false as const }),
-      };
-    },
-    async delete(keys: string | Array<string>) {
-      for (const key of Array.isArray(keys) ? keys : [keys]) {
-        deletedCommunityAssetKeys.push(key);
-        communityAssetKeys.delete(key);
-      }
-    },
-  } as unknown as R2Bucket;
+	const deletedEmailBlobKeys: Array<string> = []
+	const mailboxCleanupOrder: Array<string> = []
+	const emailBlobKeys = new Set([
+		'email-raw:v1:user-aaa/em-1',
+		'email-raw:v1:user-aaa/em-2',
+		'email-raw:v1:user-bbb/em-3',
+	])
+	const emailBlobs = {
+		async list(options?: { prefix?: string }) {
+			return {
+				objects: [...emailBlobKeys]
+					.filter((key) => key.startsWith(options?.prefix ?? ''))
+					.map((key) => ({ key })),
+				delimitedPrefixes: [],
+				truncated: false as const,
+			}
+		},
+		async delete(keys: string | Array<string>) {
+			mailboxCleanupOrder.push('delete-email-blob')
+			for (const key of Array.isArray(keys) ? keys : [keys]) {
+				deletedEmailBlobKeys.push(key)
+				emailBlobKeys.delete(key)
+			}
+		},
+	} as unknown as R2Bucket
+	const deletedCommunityAssetKeys: Array<string> = []
+	const communityAssetKeys = new Set([
+		'user-avatars/user-aaa/abc123.png',
+		'user-avatars/user-aaa/old.png',
+		'user-avatars/user-bbb/other.png',
+		'community-icon:v1/listing-1/abc123/asset',
+		'community-icon:v1/listing-1/commit-1/asset',
+		'community-icon:v1/listing-1/historical/asset',
+		'community-icon:v2/listing-1/abc123/asset',
+		'community-icon:v2/listing-1/commit-1/asset',
+		'community-icon:v1/listing-2/other/asset',
+	])
+	const communityAssets = {
+		async list(options?: { prefix?: string; cursor?: string }) {
+			const matching = [...communityAssetKeys]
+				.filter(
+					(key) =>
+						key.startsWith(options?.prefix ?? '') &&
+						(!options?.cursor || key > options.cursor),
+				)
+				.sort()
+			const page = matching.slice(0, 1)
+			return {
+				objects: page.map((key) => ({ key })),
+				delimitedPrefixes: [],
+				...(matching.length > page.length
+					? { truncated: true as const, cursor: page[0]! }
+					: { truncated: false as const }),
+			}
+		},
+		async delete(keys: string | Array<string>) {
+			for (const key of Array.isArray(keys) ? keys : [keys]) {
+				deletedCommunityAssetKeys.push(key)
+				communityAssetKeys.delete(key)
+			}
+		},
+	} as unknown as R2Bucket
 
-  const clearStorageMock = vi.fn(async () => ({ ok: true as const }));
-  const clearRunLogMock = vi.fn(async () => ({ ok: true as const }));
-  const purgeUserMeterMock = vi.fn(async () => ({ ok: true as const }));
-  const purgeStripePlanRefreshMock = vi.fn(async () => ({ ok: true as const }));
-  const stripePlanRefreshIdFromNameMock = vi.fn(
-    (name: string) => name as unknown as DurableObjectId,
-  );
-  const purgeMailboxMock = vi.fn(async () => {
-    mailboxCleanupOrder.push("purge-mailbox");
-    return { ok: true as const };
-  });
-  const listBlobReferencesMock = vi.fn(
-    async ({ startAfter }: { startAfter?: string | null }) => {
-      mailboxCleanupOrder.push("list-blob-references");
-      if (startAfter == null) {
-        return {
-          references: [
-            {
-              kind: "raw_mime" as const,
-              key: "email-raw:v1:user-aaa/em-1",
-              messageId: "em-1",
-              attachmentId: null,
-            },
-            {
-              kind: "raw_mime" as const,
-              key: "email-raw:v1:user-aaa/em-2",
-              messageId: "em-2",
-              attachmentId: null,
-            },
-          ],
-          nextStartAfter: null,
-          truncated: false as const,
-        };
-      }
-      return {
-        references: [],
-        nextStartAfter: null,
-        truncated: false as const,
-      };
-    },
-  );
-  const jobsBindingStub = createJobsBindingStub(db);
-  const purgeJobManagerMock = vi.fn((input: { userId: string }) =>
-    jobsBindingStub.purgeUser(input),
-  );
-  const purgeRepoSessionMock = vi.fn(async () => ({ ok: true as const }));
-  const purgeMcpClientHubMock = vi.fn(async () => undefined);
-  const purgeMcpAgentSessionMock = vi.fn(async () => undefined);
-  const doFetchMock = vi.fn(async () => Response.json({ ok: true }));
-  const deleteVectorsMock = vi.fn(async () => undefined);
-  const userMeter = createInMemoryUserMeterEnv();
-  const env = createSuccessfulDeletionEnv(db, {
-    BUNDLE_ARTIFACTS_KV: kv,
-    COMMUNITY_ASSETS: communityAssets,
-    EMAIL_BLOBS: emailBlobs,
-    CAPABILITY_VECTOR_INDEX: {
-      deleteByIds: deleteVectorsMock,
-    },
-    STORAGE_RUNNER: {
-      idFromName: (name: string) => name as unknown as DurableObjectId,
-      get: () => ({ clearStorage: clearStorageMock }),
-    },
-    RUN_LOG: {
-      idFromName: (name: string) => name as unknown as DurableObjectId,
-      get: () => ({
-        clearAll: clearRunLogMock,
-        listStorageIds: async () => [] as Array<string>,
-      }),
-    },
-    USER_METER: {
-      idFromName: (name: string) => userMeter.env.USER_METER!.idFromName(name),
-      get: (id: DurableObjectId) => ({
-        ...userMeter.env.USER_METER!.get(id),
-        purge: async () => purgeUserMeterMock(),
-      }),
-    },
-    STRIPE_PLAN_REFRESH: {
-      idFromName: stripePlanRefreshIdFromNameMock,
-      get: () => ({ purgeUser: purgeStripePlanRefreshMock }),
-    },
-    MAILBOX: {
-      idFromName: (name: string) => name as unknown as DurableObjectId,
-      get: () => ({
-        listBlobReferences: listBlobReferencesMock,
-        purge: purgeMailboxMock,
-      }),
-    },
-    JOBS: createJobsBindingStub(db, {
-      purgeUser: purgeJobManagerMock as unknown,
-    }),
-    REPO_SESSION: {
-      idFromName: (name: string) => name as unknown as DurableObjectId,
-      get: () => ({ purgeSession: purgeRepoSessionMock }),
-    },
-    MCP_CLIENT_HUB: {
-      idFromName: (name: string) => name as unknown as DurableObjectId,
-      get: () => ({ purgeForAccountDeletion: purgeMcpClientHubMock }),
-    },
-    MCP_OBJECT: {
-      idFromString: (id: string) => id as unknown as DurableObjectId,
-      get: () => ({
-        purgeForAccountDeletion: purgeMcpAgentSessionMock,
-      }),
-    },
-    PACKAGE_REALTIME_SESSION: {
-      idFromName: (name: string) => name as unknown as DurableObjectId,
-      get: () => ({ fetch: doFetchMock }),
-    },
-  });
-  await insertRepoSession(env, {
-    id: "rs-1",
-    user_id: userAaa,
-    source_id: "src-1",
-    source_repo_id: "",
-    session_branch: "sessions/rs-1",
-    source_branch: "main",
-    base_commit: "abc123",
-    source_root: "/",
-    conversation_id: null,
-    status: "active",
-    expires_at: null,
-    last_checkpoint_at: null,
-    last_checkpoint_commit: null,
-    last_check_run_id: null,
-    last_check_tree_hash: null,
-    created_at: "2026-07-05T00:00:00.000Z",
-    updated_at: "2026-07-05T00:00:00.000Z",
-  });
+	const clearStorageMock = vi.fn(async () => ({ ok: true as const }))
+	const clearRunLogMock = vi.fn(async () => ({ ok: true as const }))
+	const purgeUserMeterMock = vi.fn(async () => ({ ok: true as const }))
+	const purgeStripePlanRefreshMock = vi.fn(async () => ({ ok: true as const }))
+	const stripePlanRefreshIdFromNameMock = vi.fn(
+		(name: string) => name as unknown as DurableObjectId,
+	)
+	const purgeMailboxMock = vi.fn(async () => {
+		mailboxCleanupOrder.push('purge-mailbox')
+		return { ok: true as const }
+	})
+	const listBlobReferencesMock = vi.fn(
+		async ({ startAfter }: { startAfter?: string | null }) => {
+			mailboxCleanupOrder.push('list-blob-references')
+			if (startAfter == null) {
+				return {
+					references: [
+						{
+							kind: 'raw_mime' as const,
+							key: 'email-raw:v1:user-aaa/em-1',
+							messageId: 'em-1',
+							attachmentId: null,
+						},
+						{
+							kind: 'raw_mime' as const,
+							key: 'email-raw:v1:user-aaa/em-2',
+							messageId: 'em-2',
+							attachmentId: null,
+						},
+					],
+					nextStartAfter: null,
+					truncated: false as const,
+				}
+			}
+			return {
+				references: [],
+				nextStartAfter: null,
+				truncated: false as const,
+			}
+		},
+	)
+	const jobsBindingStub = createJobsBindingStub(db)
+	const purgeJobManagerMock = vi.fn((input: { userId: string }) =>
+		jobsBindingStub.purgeUser(input),
+	)
+	const purgeRepoSessionMock = vi.fn(async () => ({ ok: true as const }))
+	const purgeMcpClientHubMock = vi.fn(async () => undefined)
+	const purgeMcpAgentSessionMock = vi.fn(async () => undefined)
+	const doFetchMock = vi.fn(async () => Response.json({ ok: true }))
+	const deleteVectorsMock = vi.fn(async () => undefined)
+	const userMeter = createInMemoryUserMeterEnv()
+	const env = createSuccessfulDeletionEnv(db, {
+		BUNDLE_ARTIFACTS_KV: kv,
+		COMMUNITY_ASSETS: communityAssets,
+		EMAIL_BLOBS: emailBlobs,
+		CAPABILITY_VECTOR_INDEX: {
+			deleteByIds: deleteVectorsMock,
+		},
+		STORAGE_RUNNER: {
+			idFromName: (name: string) => name as unknown as DurableObjectId,
+			get: () => ({ clearStorage: clearStorageMock }),
+		},
+		RUN_LOG: {
+			idFromName: (name: string) => name as unknown as DurableObjectId,
+			get: () => ({
+				clearAll: clearRunLogMock,
+				listStorageIds: async () => [] as Array<string>,
+			}),
+		},
+		USER_METER: {
+			idFromName: (name: string) => userMeter.env.USER_METER!.idFromName(name),
+			get: (id: DurableObjectId) => ({
+				...userMeter.env.USER_METER!.get(id),
+				purge: async () => purgeUserMeterMock(),
+			}),
+		},
+		STRIPE_PLAN_REFRESH: {
+			idFromName: stripePlanRefreshIdFromNameMock,
+			get: () => ({ purgeUser: purgeStripePlanRefreshMock }),
+		},
+		MAILBOX: {
+			idFromName: (name: string) => name as unknown as DurableObjectId,
+			get: () => ({
+				listBlobReferences: listBlobReferencesMock,
+				purge: purgeMailboxMock,
+			}),
+		},
+		JOBS: createJobsBindingStub(db, {
+			purgeUser: purgeJobManagerMock as unknown,
+		}),
+		REPO_SESSION: {
+			idFromName: (name: string) => name as unknown as DurableObjectId,
+			get: () => ({ purgeSession: purgeRepoSessionMock }),
+		},
+		MCP_CLIENT_HUB: {
+			idFromName: (name: string) => name as unknown as DurableObjectId,
+			get: () => ({ purgeForAccountDeletion: purgeMcpClientHubMock }),
+		},
+		MCP_OBJECT: {
+			idFromString: (id: string) => id as unknown as DurableObjectId,
+			get: () => ({
+				purgeForAccountDeletion: purgeMcpAgentSessionMock,
+			}),
+		},
+		PACKAGE_REALTIME_SESSION: {
+			idFromName: (name: string) => name as unknown as DurableObjectId,
+			get: () => ({ fetch: doFetchMock }),
+		},
+	})
+	await insertRepoSession(env, {
+		id: 'rs-1',
+		user_id: userAaa,
+		source_id: 'src-1',
+		source_repo_id: '',
+		session_branch: 'sessions/rs-1',
+		source_branch: 'main',
+		base_commit: 'abc123',
+		source_root: '/',
+		conversation_id: null,
+		status: 'active',
+		expires_at: null,
+		last_checkpoint_at: null,
+		last_checkpoint_commit: null,
+		last_check_run_id: null,
+		last_check_tree_hash: null,
+		created_at: '2026-07-05T00:00:00.000Z',
+		updated_at: '2026-07-05T00:00:00.000Z',
+	})
 
-  // password_resets.user_id is the database integer id; the deletion
-  // service must use the dbUserId (1) to clear the deleted user's reset
-  // tokens while leaving the other user's tokens in place.
-  const result = await deleteUserAccount({
-    env,
-    dbUserId: 1,
-    mcpUserId: userAaa,
-  });
+	// password_resets.user_id is the database integer id; the deletion
+	// service must use the dbUserId (1) to clear the deleted user's reset
+	// tokens while leaving the other user's tokens in place.
+	const result = await deleteUserAccount({
+		env,
+		dbUserId: 1,
+		mcpUserId: userAaa,
+	})
 
-  // Cross-user data is preserved.
-  expect(rows.jobs).toEqual([
-    { id: "job-3", user_id: userBbb, storage_id: "job:job-3" },
-  ]);
-  expect(rows.mcp_memories).toEqual([{ id: "mem-2", user_id: userBbb }]);
-  expect(rows.saved_packages).toEqual([
-    {
-      id: "pkg-2",
-      user_id: userBbb,
-      kody_id: "other",
-      source_id: "src-2",
-      has_app: 0,
-    },
-  ]);
-  expect(rows.mcp_agent_sessions).toEqual([
-    { do_id: "do-user-b", user_id: userBbb },
-  ]);
-  expect(rows.published_bundle_artifacts).toEqual([
-    { id: "pba-2", user_id: userBbb, kv_key: "bundle-artifact:v1:src-2" },
-  ]);
-  expect(rows.password_resets).toEqual([{ id: 3, user_id: 2 }]);
-  expect(rows.user_roles).toEqual([{ user_id: 2, role_id: 2 }]);
-  expect(rows.passkeys).toEqual([{ id: "pk-2", user_id: 2 }]);
-  expect(rows.verifications).toEqual([{ id: 2, type: "2fa", target: "2" }]);
+	// Cross-user data is preserved.
+	expect(rows.jobs).toEqual([
+		{ id: 'job-3', user_id: userBbb, storage_id: 'job:job-3' },
+	])
+	expect(rows.mcp_memories).toEqual([{ id: 'mem-2', user_id: userBbb }])
+	expect(rows.saved_packages).toEqual([
+		{
+			id: 'pkg-2',
+			user_id: userBbb,
+			kody_id: 'other',
+			source_id: 'src-2',
+			has_app: 0,
+		},
+	])
+	expect(rows.mcp_agent_sessions).toEqual([
+		{ do_id: 'do-user-b', user_id: userBbb },
+	])
+	expect(rows.published_bundle_artifacts).toEqual([
+		{ id: 'pba-2', user_id: userBbb, kv_key: 'bundle-artifact:v1:src-2' },
+	])
+	expect(rows.password_resets).toEqual([{ id: 3, user_id: 2 }])
+	expect(rows.user_roles).toEqual([{ user_id: 2, role_id: 2 }])
+	expect(rows.passkeys).toEqual([{ id: 'pk-2', user_id: 2 }])
+	expect(rows.verifications).toEqual([{ id: 2, type: '2fa', target: '2' }])
 
-  // User-scoped data is removed.
-  expect(rows.secret_buckets).toEqual([]);
-  expect(rows.secret_entries).toEqual([]);
-  expect(rows.value_buckets).toEqual([]);
-  expect(rows.value_entries).toEqual([]);
-  expect(rows.archived_job_artifacts).toEqual([]);
-  expect(rows.entity_sources).toEqual([
-    { id: "src-2", user_id: userBbb, published_commit: "def456" },
-  ]);
-  await expect(listRepoSessionsByUser(env, userAaa)).resolves.toEqual([]);
-  expect(deletedEmailBlobKeys.sort()).toEqual([
-    "email-raw:v1:user-aaa/em-1",
-    "email-raw:v1:user-aaa/em-2",
-  ]);
-  expect(rows.platform_feedback).toEqual([
-    {
-      id: "feedback-reviewed-by-a",
-      submitter_user_id: userBbb,
-      submitter_username: "user-b",
-      submitter_email: "b@example.com",
-      reviewed_by_user_id: null,
-      reviewed_at: null,
-      admin_note: null,
-    },
-    {
-      id: "feedback-unrelated",
-      submitter_user_id: userBbb,
-      submitter_username: "user-b",
-      submitter_email: "b@example.com",
-      reviewed_by_user_id: userBbb,
-      reviewed_at: "2026-07-05",
-      admin_note: "Reviewed by B.",
-    },
-  ]);
-  expect(rows.user_storage_buckets).toEqual([
-    {
-      user_id: userBbb,
-      storage_id: "package:pkg-2",
-      kind: "package",
-    },
-  ]);
-  expect(rows.community_listings).toEqual([
-    { id: "listing-2", owner_user_id: userBbb, pinned_commit: "commit-2" },
-  ]);
-  expect(rows.community_forks).toEqual([
-    { id: "fork-3", listing_id: "listing-2", forker_user_id: userBbb },
-  ]);
-  expect(rows.community_ratings).toEqual([
-    { id: "rating-3", listing_id: "listing-2", user_id: userBbb },
-  ]);
-  expect(rows.community_activity_events).toEqual([
-    {
-      id: "evt-3",
-      actor_user_id: userBbb,
-      event_type: "listing_published",
-      listing_id: "listing-2",
-    },
-  ]);
-  expect(rows.community_reports).toEqual([
-    {
-      id: "report-3",
-      listing_id: "listing-2",
-      listing_owner_user_id: userBbb,
-      reporter_user_id: userBbb,
-      resolved_by_user_id: null,
-      resolved_at: null,
-      resolution_note: null,
-    },
-  ]);
-  expect(rows.community_bans).toEqual([
-    { user_id: userBbb, banned_by_user_id: "deleted-user" },
-  ]);
-  expect(rows.package_codemod_run_items).toEqual([
-    {
-      id: "codemod-item-2",
-      run_id: "codemod-run-2",
-      user_id: userBbb,
-      package_id: "pkg-2",
-      kody_id: "demo-b",
-      status: "applied",
-    },
-  ]);
-  expect(rows.package_codemod_runs).toEqual([
-    {
-      id: "codemod-run-1",
-      codemod_id: "0001-ambient-storage-to-package-storage",
-      mode: "apply",
-      scope_user_id: "deleted-user",
-      initiated_by_user_id: "deleted-user",
-      filters_json: JSON.stringify({ userIds: ["deleted-user", userBbb] }),
-      status: "completed",
-    },
-    {
-      id: "codemod-run-fleet",
-      codemod_id: "0001-ambient-storage-to-package-storage",
-      mode: "scan",
-      scope_user_id: null,
-      initiated_by_user_id: userBbb,
-      filters_json: JSON.stringify({ userIds: ["deleted-user"] }),
-      status: "completed",
-    },
-    {
-      id: "codemod-run-2",
-      codemod_id: "0001-ambient-storage-to-package-storage",
-      mode: "apply",
-      scope_user_id: userBbb,
-      initiated_by_user_id: userBbb,
-      filters_json: JSON.stringify({ userIds: [userBbb] }),
-      status: "completed",
-    },
-  ]);
-  for (const run of rows.package_codemod_runs ?? []) {
-    expect(String(run["filters_json"])).not.toContain(userAaa);
-  }
-  expect(rows.users).toEqual([
-    { id: 2, email: "b@example.com", stable_user_id: "user-bbb" },
-  ]);
-  expect(result.deletedRowCounts.password_resets).toBe(2);
-  expect(result.deletedRowCounts.user_roles).toBe(1);
+	// User-scoped data is removed.
+	expect(rows.secret_buckets).toEqual([])
+	expect(rows.secret_entries).toEqual([])
+	expect(rows.value_buckets).toEqual([])
+	expect(rows.value_entries).toEqual([])
+	expect(rows.archived_job_artifacts).toEqual([])
+	expect(rows.entity_sources).toEqual([
+		{ id: 'src-2', user_id: userBbb, published_commit: 'def456' },
+	])
+	await expect(listRepoSessionsByUser(env, userAaa)).resolves.toEqual([])
+	expect(deletedEmailBlobKeys.sort()).toEqual([
+		'email-raw:v1:user-aaa/em-1',
+		'email-raw:v1:user-aaa/em-2',
+	])
+	expect(rows.platform_feedback).toEqual([
+		{
+			id: 'feedback-reviewed-by-a',
+			submitter_user_id: userBbb,
+			submitter_username: 'user-b',
+			submitter_email: 'b@example.com',
+			reviewed_by_user_id: null,
+			reviewed_at: null,
+			admin_note: null,
+		},
+		{
+			id: 'feedback-unrelated',
+			submitter_user_id: userBbb,
+			submitter_username: 'user-b',
+			submitter_email: 'b@example.com',
+			reviewed_by_user_id: userBbb,
+			reviewed_at: '2026-07-05',
+			admin_note: 'Reviewed by B.',
+		},
+	])
+	expect(rows.user_storage_buckets).toEqual([
+		{
+			user_id: userBbb,
+			storage_id: 'package:pkg-2',
+			kind: 'package',
+		},
+	])
+	expect(rows.community_listings).toEqual([
+		{ id: 'listing-2', owner_user_id: userBbb, pinned_commit: 'commit-2' },
+	])
+	expect(rows.community_forks).toEqual([
+		{ id: 'fork-3', listing_id: 'listing-2', forker_user_id: userBbb },
+	])
+	expect(rows.community_ratings).toEqual([
+		{ id: 'rating-3', listing_id: 'listing-2', user_id: userBbb },
+	])
+	expect(rows.community_activity_events).toEqual([
+		{
+			id: 'evt-3',
+			actor_user_id: userBbb,
+			event_type: 'listing_published',
+			listing_id: 'listing-2',
+		},
+	])
+	expect(rows.community_reports).toEqual([
+		{
+			id: 'report-3',
+			listing_id: 'listing-2',
+			listing_owner_user_id: userBbb,
+			reporter_user_id: userBbb,
+			resolved_by_user_id: null,
+			resolved_at: null,
+			resolution_note: null,
+		},
+	])
+	expect(rows.community_bans).toEqual([
+		{ user_id: userBbb, banned_by_user_id: 'deleted-user' },
+	])
+	expect(rows.package_codemod_run_items).toEqual([
+		{
+			id: 'codemod-item-2',
+			run_id: 'codemod-run-2',
+			user_id: userBbb,
+			package_id: 'pkg-2',
+			kody_id: 'demo-b',
+			status: 'applied',
+		},
+	])
+	expect(rows.package_codemod_runs).toEqual([
+		{
+			id: 'codemod-run-1',
+			codemod_id: '0001-ambient-storage-to-package-storage',
+			mode: 'apply',
+			scope_user_id: 'deleted-user',
+			initiated_by_user_id: 'deleted-user',
+			filters_json: JSON.stringify({ userIds: ['deleted-user', userBbb] }),
+			status: 'completed',
+		},
+		{
+			id: 'codemod-run-fleet',
+			codemod_id: '0001-ambient-storage-to-package-storage',
+			mode: 'scan',
+			scope_user_id: null,
+			initiated_by_user_id: userBbb,
+			filters_json: JSON.stringify({ userIds: ['deleted-user'] }),
+			status: 'completed',
+		},
+		{
+			id: 'codemod-run-2',
+			codemod_id: '0001-ambient-storage-to-package-storage',
+			mode: 'apply',
+			scope_user_id: userBbb,
+			initiated_by_user_id: userBbb,
+			filters_json: JSON.stringify({ userIds: [userBbb] }),
+			status: 'completed',
+		},
+	])
+	for (const run of rows.package_codemod_runs ?? []) {
+		expect(String(run['filters_json'])).not.toContain(userAaa)
+	}
+	expect(rows.users).toEqual([
+		{ id: 2, email: 'b@example.com', stable_user_id: 'user-bbb' },
+	])
+	expect(result.deletedRowCounts.password_resets).toBe(2)
+	expect(result.deletedRowCounts.user_roles).toBe(1)
 
-  // Out-of-band stores for the deleted user were cleared.
-  expect(deleteVectorsMock).toHaveBeenCalledWith([
-    "memory_mem-1",
-    "job_job-1",
-    "job_job-2",
-    jobVectorId(packageJobId),
-    "package_pkg-1",
-  ]);
-  expect(clearStorageMock).toHaveBeenCalledTimes(3);
-  expect(purgeJobManagerMock).toHaveBeenCalledTimes(1);
-  expect(purgeRepoSessionMock).toHaveBeenCalledWith({
-    sessionId: "rs-1",
-    userId: userAaa,
-  });
-  expect(doFetchMock).toHaveBeenCalledTimes(1);
+	// Out-of-band stores for the deleted user were cleared.
+	expect(deleteVectorsMock).toHaveBeenCalledWith([
+		'memory_mem-1',
+		'job_job-1',
+		'job_job-2',
+		jobVectorId(packageJobId),
+		'package_pkg-1',
+	])
+	expect(clearStorageMock).toHaveBeenCalledTimes(3)
+	expect(purgeJobManagerMock).toHaveBeenCalledTimes(1)
+	expect(purgeRepoSessionMock).toHaveBeenCalledWith({
+		sessionId: 'rs-1',
+		userId: userAaa,
+	})
+	expect(doFetchMock).toHaveBeenCalledTimes(1)
 
-  // Bundle KV keys for the deleted user were removed; the other user's keys
-  // remain in storage.
-  expect(deletedKvKeys.sort()).toEqual([
-    "bundle-artifact:v1:src-1",
-    "community-snapshot:v1:listing-1",
-    "derived-cache:v1:community-icon:v1:listing-1:abc123",
-    "derived-cache:v1:community-icon:v1:listing-1:commit-1",
-    "derived-cache:v1:community-icon:v1:listing-1:historical",
-    "derived-cache:v1:community-icon:v2:listing-1:abc123",
-    "derived-cache:v1:community-icon:v2:listing-1:commit-1",
-    "derived-cache:v1:community-icon:v3:listing-1:abc123",
-    "derived-cache:v1:community-icon:v3:listing-1:commit-1",
-    `package-codemod-revert:${userAaa}:item-1`,
-    `package-codemod-revert:${userAaa}:item-2`,
-    "package-retriever-index-entry:v1:user-aaa:context:pkg-1:notes",
-    "package-retriever-index-entry:v1:user-aaa:search:pkg-1:notes",
-    "package-retriever-manifest:v1:user-aaa:pkg-1:abc123",
-    "source-manifest-snapshot:v1:src-1:abc123",
-    "source-manifest-snapshot:v1:src-1:old456",
-    "source-snapshot:v1:src-1:abc123",
-    "source-snapshot:v1:src-1:old456",
-  ]);
-  expect(deletedKvKeys).not.toContain(
-    "package-retriever-index-entry:v1:user-bbb:search:pkg-2:notes",
-  );
-  expect(deletedKvKeys).not.toContain(
-    `package-codemod-revert:${userBbb}:item-other`,
-  );
-  expect(deletedKvKeys).not.toContain(
-    "platform-settings:v1:reserved-usernames",
-  );
-  expect(deletedKvKeys).not.toContain("platform-settings:v1:signup-mode");
-  expect(deletedKvKeys).not.toContain("public-code-runs:v2");
+	// Bundle KV keys for the deleted user were removed; the other user's keys
+	// remain in storage.
+	expect(deletedKvKeys.sort()).toEqual([
+		'bundle-artifact:v1:src-1',
+		'community-snapshot:v1:listing-1',
+		'derived-cache:v1:community-icon:v1:listing-1:abc123',
+		'derived-cache:v1:community-icon:v1:listing-1:commit-1',
+		'derived-cache:v1:community-icon:v1:listing-1:historical',
+		'derived-cache:v1:community-icon:v2:listing-1:abc123',
+		'derived-cache:v1:community-icon:v2:listing-1:commit-1',
+		'derived-cache:v1:community-icon:v3:listing-1:abc123',
+		'derived-cache:v1:community-icon:v3:listing-1:commit-1',
+		`package-codemod-revert:${userAaa}:item-1`,
+		`package-codemod-revert:${userAaa}:item-2`,
+		'package-retriever-index-entry:v1:user-aaa:context:pkg-1:notes',
+		'package-retriever-index-entry:v1:user-aaa:search:pkg-1:notes',
+		'package-retriever-manifest:v1:user-aaa:pkg-1:abc123',
+		'source-manifest-snapshot:v1:src-1:abc123',
+		'source-manifest-snapshot:v1:src-1:old456',
+		'source-snapshot:v1:src-1:abc123',
+		'source-snapshot:v1:src-1:old456',
+	])
+	expect(deletedKvKeys).not.toContain(
+		'package-retriever-index-entry:v1:user-bbb:search:pkg-2:notes',
+	)
+	expect(deletedKvKeys).not.toContain(
+		`package-codemod-revert:${userBbb}:item-other`,
+	)
+	expect(deletedKvKeys).not.toContain('platform-settings:v1:reserved-usernames')
+	expect(deletedKvKeys).not.toContain('platform-settings:v1:signup-mode')
+	expect(deletedKvKeys).not.toContain('public-code-runs:v2')
 
-  // Result accounting captures the per-table counts. Job rows are purged
-  // through the JOBS service (ADR 0016), so they are not counted here.
-  expect(result.deletedRowCounts.jobs).toBeUndefined();
-  expect(result.deletedRowCounts.users).toBe(1);
-  expect(result.deletedRowCounts.user_storage_buckets).toBe(2);
-  expect(result.deletedRowCounts.community_listings).toBe(1);
-  expect(result.deletedRowCounts.community_forks).toBe(2);
-  expect(result.deletedRowCounts.community_ratings).toBe(2);
-  expect(result.deletedRowCounts.community_activity_events).toBe(2);
-  expect(result.deletedRowCounts.community_reports).toBe(2);
-  expect(result.updatedRowCounts.community_reports).toBe(1);
-  expect(result.deletedRowCounts.community_bans).toBe(1);
-  expect(result.updatedRowCounts.community_bans).toBe(1);
-  expect(result.deletedRowCounts.platform_feedback).toBe(1);
-  expect(result.updatedRowCounts.platform_feedback).toBe(1);
-  expect(result.deletedKvKeys).toBe(18);
-  expect(result.deletedCommunityAssets).toBe(7);
-  expect(result.deletedEmailBlobs).toBe(2);
-  // Prefix sweeps remove current and historical assets without crossing users.
-  expect(deletedCommunityAssetKeys.sort()).toEqual([
-    "community-icon:v1/listing-1/abc123/asset",
-    "community-icon:v1/listing-1/commit-1/asset",
-    "community-icon:v1/listing-1/historical/asset",
-    "community-icon:v2/listing-1/abc123/asset",
-    "community-icon:v2/listing-1/commit-1/asset",
-    "user-avatars/user-aaa/abc123.png",
-    "user-avatars/user-aaa/old.png",
-  ]);
-  expect(communityAssetKeys).toEqual(
-    new Set([
-      "community-icon:v1/listing-2/other/asset",
-      "user-avatars/user-bbb/other.png",
-    ]),
-  );
-  expect(result.deletedVectors).toBe(5);
-  expect(result.clearedDurableObjects).toMatchObject({
-    storageRunners: 3,
-    runLogs: 1,
-    userMeters: 1,
-    stripePlanRefreshes: 1,
-    mailboxes: 1,
-    jobManagers: 1,
-    repoSessions: 1,
-    // The MCP client hub is purged even when the user has no
-    // mcp_server_settings rows, since the hub DO can still hold OAuth
-    // tokens from failed or removed registrations.
-    mcpClientHubs: 1,
-    mcpAgentSessions: 1,
-    packageRealtimeSessions: 1,
-  });
-  expect(clearRunLogMock).toHaveBeenCalledTimes(1);
-  expect(purgeUserMeterMock).toHaveBeenCalledTimes(1);
-  expect(stripePlanRefreshIdFromNameMock).toHaveBeenCalledWith(userAaa);
-  expect(purgeStripePlanRefreshMock).toHaveBeenCalledWith({ userId: userAaa });
-  expect(listBlobReferencesMock).toHaveBeenCalledTimes(1);
-  expect(purgeMailboxMock).toHaveBeenCalledTimes(1);
-  expect(mailboxCleanupOrder[0]).toBe("list-blob-references");
-  expect(mailboxCleanupOrder.indexOf("delete-email-blob")).toBeGreaterThan(
-    mailboxCleanupOrder.indexOf("list-blob-references"),
-  );
-  expect(mailboxCleanupOrder.indexOf("purge-mailbox")).toBeGreaterThan(
-    mailboxCleanupOrder.lastIndexOf("delete-email-blob"),
-  );
-  expect(purgeMcpClientHubMock).toHaveBeenCalledTimes(1);
-  expect(purgeMcpAgentSessionMock).toHaveBeenCalledWith({
-    userId: userAaa,
-  });
-  expect(result.warnings).toEqual([]);
-});
+	// Result accounting captures the per-table counts. Job rows are purged
+	// through the JOBS service (ADR 0016), so they are not counted here.
+	expect(result.deletedRowCounts.jobs).toBeUndefined()
+	expect(result.deletedRowCounts.users).toBe(1)
+	expect(result.deletedRowCounts.user_storage_buckets).toBe(2)
+	expect(result.deletedRowCounts.community_listings).toBe(1)
+	expect(result.deletedRowCounts.community_forks).toBe(2)
+	expect(result.deletedRowCounts.community_ratings).toBe(2)
+	expect(result.deletedRowCounts.community_activity_events).toBe(2)
+	expect(result.deletedRowCounts.community_reports).toBe(2)
+	expect(result.updatedRowCounts.community_reports).toBe(1)
+	expect(result.deletedRowCounts.community_bans).toBe(1)
+	expect(result.updatedRowCounts.community_bans).toBe(1)
+	expect(result.deletedRowCounts.platform_feedback).toBe(1)
+	expect(result.updatedRowCounts.platform_feedback).toBe(1)
+	expect(result.deletedKvKeys).toBe(18)
+	expect(result.deletedCommunityAssets).toBe(7)
+	expect(result.deletedEmailBlobs).toBe(2)
+	// Prefix sweeps remove current and historical assets without crossing users.
+	expect(deletedCommunityAssetKeys.sort()).toEqual([
+		'community-icon:v1/listing-1/abc123/asset',
+		'community-icon:v1/listing-1/commit-1/asset',
+		'community-icon:v1/listing-1/historical/asset',
+		'community-icon:v2/listing-1/abc123/asset',
+		'community-icon:v2/listing-1/commit-1/asset',
+		'user-avatars/user-aaa/abc123.png',
+		'user-avatars/user-aaa/old.png',
+	])
+	expect(communityAssetKeys).toEqual(
+		new Set([
+			'community-icon:v1/listing-2/other/asset',
+			'user-avatars/user-bbb/other.png',
+		]),
+	)
+	expect(result.deletedVectors).toBe(5)
+	expect(result.clearedDurableObjects).toMatchObject({
+		storageRunners: 3,
+		runLogs: 1,
+		userMeters: 1,
+		stripePlanRefreshes: 1,
+		mailboxes: 1,
+		jobManagers: 1,
+		repoSessions: 1,
+		// The MCP client hub is purged even when the user has no
+		// mcp_server_settings rows, since the hub DO can still hold OAuth
+		// tokens from failed or removed registrations.
+		mcpClientHubs: 1,
+		mcpAgentSessions: 1,
+		packageRealtimeSessions: 1,
+	})
+	expect(clearRunLogMock).toHaveBeenCalledTimes(1)
+	expect(purgeUserMeterMock).toHaveBeenCalledTimes(1)
+	expect(stripePlanRefreshIdFromNameMock).toHaveBeenCalledWith(userAaa)
+	expect(purgeStripePlanRefreshMock).toHaveBeenCalledWith({ userId: userAaa })
+	expect(listBlobReferencesMock).toHaveBeenCalledTimes(1)
+	expect(purgeMailboxMock).toHaveBeenCalledTimes(1)
+	expect(mailboxCleanupOrder[0]).toBe('list-blob-references')
+	expect(mailboxCleanupOrder.indexOf('delete-email-blob')).toBeGreaterThan(
+		mailboxCleanupOrder.indexOf('list-blob-references'),
+	)
+	expect(mailboxCleanupOrder.indexOf('purge-mailbox')).toBeGreaterThan(
+		mailboxCleanupOrder.lastIndexOf('delete-email-blob'),
+	)
+	expect(purgeMcpClientHubMock).toHaveBeenCalledTimes(1)
+	expect(purgeMcpAgentSessionMock).toHaveBeenCalledWith({
+		userId: userAaa,
+	})
+	expect(result.warnings).toEqual([])
+})
 
-test("account deletion preserves Mailbox references and retry marker when R2 deletion fails", async () => {
-  const { db, rows } = createTestDb({
-    users: [{ id: 1, email: "a@example.com", stable_user_id: "user-aaa" }],
-  });
-  const purgeMailbox = vi.fn(async () => ({ ok: true as const }));
-  const deleteEmailBlob = vi.fn(async () => {
-    throw new Error("email R2 delete unavailable");
-  });
-  const listBlobReferences = vi.fn(async () => ({
-    references: [
-      {
-        kind: "raw_mime" as const,
-        key: "email-raw:v1:user-aaa/message-1",
-        messageId: "message-1",
-        attachmentId: null,
-      },
-    ],
-    nextStartAfter: null,
-    truncated: false as const,
-  }));
-  const env = createSuccessfulDeletionEnv(db, {
-    EMAIL_BLOBS: {
-      async list() {
-        return {
-          objects: [{ key: "email-raw:v1:user-aaa/message-1" }],
-          delimitedPrefixes: [],
-          truncated: false,
-        };
-      },
-      delete: deleteEmailBlob,
-    } as unknown as R2Bucket,
-    MAILBOX: {
-      idFromName: (name: string) => name as unknown as DurableObjectId,
-      get: () => ({
-        listBlobReferences,
-        purge: purgeMailbox,
-      }),
-    } as unknown as DurableObjectNamespace,
-  });
+test('account deletion preserves Mailbox references and retry marker when R2 deletion fails', async () => {
+	const { db, rows } = createTestDb({
+		users: [{ id: 1, email: 'a@example.com', stable_user_id: 'user-aaa' }],
+	})
+	const purgeMailbox = vi.fn(async () => ({ ok: true as const }))
+	const deleteEmailBlob = vi.fn(async () => {
+		throw new Error('email R2 delete unavailable')
+	})
+	const listBlobReferences = vi.fn(async () => ({
+		references: [
+			{
+				kind: 'raw_mime' as const,
+				key: 'email-raw:v1:user-aaa/message-1',
+				messageId: 'message-1',
+				attachmentId: null,
+			},
+		],
+		nextStartAfter: null,
+		truncated: false as const,
+	}))
+	const env = createSuccessfulDeletionEnv(db, {
+		EMAIL_BLOBS: {
+			async list() {
+				return {
+					objects: [{ key: 'email-raw:v1:user-aaa/message-1' }],
+					delimitedPrefixes: [],
+					truncated: false,
+				}
+			},
+			delete: deleteEmailBlob,
+		} as unknown as R2Bucket,
+		MAILBOX: {
+			idFromName: (name: string) => name as unknown as DurableObjectId,
+			get: () => ({
+				listBlobReferences,
+				purge: purgeMailbox,
+			}),
+		} as unknown as DurableObjectNamespace,
+	})
 
-  await expect(
-    deleteUserAccount({
-      env,
-      dbUserId: 1,
-      mcpUserId: "user-aaa",
-    }),
-  ).rejects.toSatisfy(
-    (error: unknown) =>
-      error instanceof AccountDeletionCleanupError &&
-      error.cleanupErrors.some((warning) =>
-        warning.includes("email R2 delete unavailable"),
-      ),
-  );
-  expect(listBlobReferences).toHaveBeenCalledTimes(1);
-  expect(deleteEmailBlob).toHaveBeenCalled();
-  expect(purgeMailbox).not.toHaveBeenCalled();
-  expect(rows.users).toEqual([
-    expect.objectContaining({
-      id: 1,
-      stable_user_id: "user-aaa",
-      deleting_at: expect.any(String),
-    }),
-  ]);
+	await expect(
+		deleteUserAccount({
+			env,
+			dbUserId: 1,
+			mcpUserId: 'user-aaa',
+		}),
+	).rejects.toSatisfy(
+		(error: unknown) =>
+			error instanceof AccountDeletionCleanupError &&
+			error.cleanupErrors.some((warning) =>
+				warning.includes('email R2 delete unavailable'),
+			),
+	)
+	expect(listBlobReferences).toHaveBeenCalledTimes(1)
+	expect(deleteEmailBlob).toHaveBeenCalled()
+	expect(purgeMailbox).not.toHaveBeenCalled()
+	expect(rows.users).toEqual([
+		expect.objectContaining({
+			id: 1,
+			stable_user_id: 'user-aaa',
+			deleting_at: expect.any(String),
+		}),
+	])
 
-  const { db: unrelatedDb } = createTestDb({
-    users: [{ id: 1, email: "b@example.com", stable_user_id: "user-bbb" }],
-  });
-  const purgeAfterUnrelatedFailure = vi.fn(async () => ({ ok: true as const }));
-  const unrelatedFailureEnv = createSuccessfulDeletionEnv(unrelatedDb, {
-    OAUTH_PROVIDER: undefined,
-    MAILBOX: {
-      idFromName: (name: string) => name as unknown as DurableObjectId,
-      get: () => ({
-        listBlobReferences: async () => ({
-          references: [],
-          nextStartAfter: null,
-          truncated: false as const,
-        }),
-        purge: purgeAfterUnrelatedFailure,
-      }),
-    } as unknown as DurableObjectNamespace,
-  });
-  await expect(
-    deleteUserAccount({
-      env: unrelatedFailureEnv,
-      dbUserId: 1,
-      mcpUserId: "user-bbb",
-    }),
-  ).rejects.toBeInstanceOf(AccountDeletionCleanupError);
-  expect(purgeAfterUnrelatedFailure).not.toHaveBeenCalled();
-});
+	const { db: unrelatedDb } = createTestDb({
+		users: [{ id: 1, email: 'b@example.com', stable_user_id: 'user-bbb' }],
+	})
+	const purgeAfterUnrelatedFailure = vi.fn(async () => ({ ok: true as const }))
+	const unrelatedFailureEnv = createSuccessfulDeletionEnv(unrelatedDb, {
+		OAUTH_PROVIDER: undefined,
+		MAILBOX: {
+			idFromName: (name: string) => name as unknown as DurableObjectId,
+			get: () => ({
+				listBlobReferences: async () => ({
+					references: [],
+					nextStartAfter: null,
+					truncated: false as const,
+				}),
+				purge: purgeAfterUnrelatedFailure,
+			}),
+		} as unknown as DurableObjectNamespace,
+	})
+	await expect(
+		deleteUserAccount({
+			env: unrelatedFailureEnv,
+			dbUserId: 1,
+			mcpUserId: 'user-bbb',
+		}),
+	).rejects.toBeInstanceOf(AccountDeletionCleanupError)
+	expect(purgeAfterUnrelatedFailure).not.toHaveBeenCalled()
+})
 
-test("account deletion cancels Stripe billing and remains non-blocking on Stripe failures", async () => {
-  const listSubscriptions = vi.spyOn(stripeClient, "listSubscriptions");
-  const cancelSubscription = vi.spyOn(stripeClient, "cancelSubscription");
-  const deleteCustomer = vi.spyOn(stripeClient, "deleteCustomer");
-  try {
-    listSubscriptions.mockResolvedValue([
-      {
-        id: "sub_active",
-        status: "active",
-        cancel_at: null,
-        items: { data: [{ price: { id: "price_pro" } }] },
-      },
-      {
-        id: "sub_trialing",
-        status: "trialing",
-        cancel_at: null,
-        items: { data: [{ price: { id: "price_pro" } }] },
-      },
-      {
-        id: "sub_canceled",
-        status: "canceled",
-        cancel_at: null,
-        items: { data: [{ price: { id: "price_pro" } }] },
-      },
-    ]);
-    cancelSubscription.mockResolvedValue(undefined);
-    deleteCustomer.mockResolvedValue(undefined);
-    const { db, rows } = createTestDb({
-      users: [
-        {
-          id: 1,
-          email: "pro@example.com",
-          stable_user_id: "user-pro",
-          stripe_customer_id: "cus_pro",
-        },
-      ],
-    });
+test('account deletion cancels Stripe billing and remains non-blocking on Stripe failures', async () => {
+	const listSubscriptions = vi.spyOn(stripeClient, 'listSubscriptions')
+	const cancelSubscription = vi.spyOn(stripeClient, 'cancelSubscription')
+	const deleteCustomer = vi.spyOn(stripeClient, 'deleteCustomer')
+	try {
+		listSubscriptions.mockResolvedValue([
+			{
+				id: 'sub_active',
+				status: 'active',
+				cancel_at: null,
+				items: { data: [{ price: { id: 'price_pro' } }] },
+			},
+			{
+				id: 'sub_trialing',
+				status: 'trialing',
+				cancel_at: null,
+				items: { data: [{ price: { id: 'price_pro' } }] },
+			},
+			{
+				id: 'sub_canceled',
+				status: 'canceled',
+				cancel_at: null,
+				items: { data: [{ price: { id: 'price_pro' } }] },
+			},
+		])
+		cancelSubscription.mockResolvedValue(undefined)
+		deleteCustomer.mockResolvedValue(undefined)
+		const { db, rows } = createTestDb({
+			users: [
+				{
+					id: 1,
+					email: 'pro@example.com',
+					stable_user_id: 'user-pro',
+					stripe_customer_id: 'cus_pro',
+				},
+			],
+		})
 
-    const result = await deleteUserAccount({
-      env: createSuccessfulDeletionEnv(db),
-      dbUserId: 1,
-      mcpUserId: "user-pro",
-    });
+		const result = await deleteUserAccount({
+			env: createSuccessfulDeletionEnv(db),
+			dbUserId: 1,
+			mcpUserId: 'user-pro',
+		})
 
-    expect(listSubscriptions).toHaveBeenCalledWith(
-      expect.any(Object),
-      "cus_pro",
-    );
-    expect(cancelSubscription).toHaveBeenCalledTimes(2);
-    expect(cancelSubscription).toHaveBeenCalledWith(
-      expect.any(Object),
-      "sub_active",
-    );
-    expect(cancelSubscription).toHaveBeenCalledWith(
-      expect.any(Object),
-      "sub_trialing",
-    );
-    expect(deleteCustomer).toHaveBeenCalledWith(expect.any(Object), "cus_pro");
-    expect(rows.users).toEqual([]);
-    expect(result.warnings).toEqual([]);
+		expect(listSubscriptions).toHaveBeenCalledWith(
+			expect.any(Object),
+			'cus_pro',
+		)
+		expect(cancelSubscription).toHaveBeenCalledTimes(2)
+		expect(cancelSubscription).toHaveBeenCalledWith(
+			expect.any(Object),
+			'sub_active',
+		)
+		expect(cancelSubscription).toHaveBeenCalledWith(
+			expect.any(Object),
+			'sub_trialing',
+		)
+		expect(deleteCustomer).toHaveBeenCalledWith(expect.any(Object), 'cus_pro')
+		expect(rows.users).toEqual([])
+		expect(result.warnings).toEqual([])
 
-    listSubscriptions.mockRejectedValue(
-      new Error("Stripe subscriptions unavailable"),
-    );
-    deleteCustomer.mockRejectedValue(new Error("Stripe customer unavailable"));
-    cancelSubscription.mockClear();
-    consoleError.mockImplementation(() => {});
-    const { db: failureDb, rows: failureRows } = createTestDb({
-      users: [
-        {
-          id: 2,
-          email: "failure@example.com",
-          stable_user_id: "user-stripe-failure",
-          stripe_customer_id: "cus_failure",
-        },
-      ],
-    });
+		listSubscriptions.mockRejectedValue(
+			new Error('Stripe subscriptions unavailable'),
+		)
+		deleteCustomer.mockRejectedValue(new Error('Stripe customer unavailable'))
+		cancelSubscription.mockClear()
+		consoleError.mockImplementation(() => {})
+		const { db: failureDb, rows: failureRows } = createTestDb({
+			users: [
+				{
+					id: 2,
+					email: 'failure@example.com',
+					stable_user_id: 'user-stripe-failure',
+					stripe_customer_id: 'cus_failure',
+				},
+			],
+		})
 
-    const failureResult = await deleteUserAccount({
-      env: createSuccessfulDeletionEnv(failureDb),
-      dbUserId: 2,
-      mcpUserId: "user-stripe-failure",
-    });
+		const failureResult = await deleteUserAccount({
+			env: createSuccessfulDeletionEnv(failureDb),
+			dbUserId: 2,
+			mcpUserId: 'user-stripe-failure',
+		})
 
-    expect(deleteCustomer).toHaveBeenLastCalledWith(
-      expect.any(Object),
-      "cus_failure",
-    );
-    expect(cancelSubscription).not.toHaveBeenCalled();
-    expect(failureRows.users).toEqual([]);
-    expect(failureResult.warnings).toEqual([
-      expect.stringContaining("Stripe customer cleanup failed"),
-    ]);
-    expect(consoleError).toHaveBeenCalledOnce();
-    expect(consoleError).toHaveBeenCalledWith(
-      "account_deletion_stripe_cleanup_failed",
-      expect.objectContaining({
-        userId: "user-stripe-failure",
-        error: expect.any(AggregateError),
-      }),
-    );
+		expect(deleteCustomer).toHaveBeenLastCalledWith(
+			expect.any(Object),
+			'cus_failure',
+		)
+		expect(cancelSubscription).not.toHaveBeenCalled()
+		expect(failureRows.users).toEqual([])
+		expect(failureResult.warnings).toEqual([
+			expect.stringContaining('Stripe customer cleanup failed'),
+		])
+		expect(consoleError).toHaveBeenCalledOnce()
+		expect(consoleError).toHaveBeenCalledWith(
+			'account_deletion_stripe_cleanup_failed',
+			expect.objectContaining({
+				userId: 'user-stripe-failure',
+				error: expect.any(AggregateError),
+			}),
+		)
 
-    listSubscriptions.mockClear();
-    deleteCustomer.mockClear();
-    const { db: freeDb, rows: freeRows } = createTestDb({
-      users: [
-        {
-          id: 3,
-          email: "free@example.com",
-          stable_user_id: "user-free",
-          stripe_customer_id: null,
-        },
-      ],
-    });
-    await deleteUserAccount({
-      env: createSuccessfulDeletionEnv(freeDb),
-      dbUserId: 3,
-      mcpUserId: "user-free",
-    });
-    expect(listSubscriptions).not.toHaveBeenCalled();
-    expect(deleteCustomer).not.toHaveBeenCalled();
-    expect(freeRows.users).toEqual([]);
-  } finally {
-    listSubscriptions.mockRestore();
-    cancelSubscription.mockRestore();
-    deleteCustomer.mockRestore();
-    consoleError.mockReset();
-  }
-});
+		listSubscriptions.mockClear()
+		deleteCustomer.mockClear()
+		const { db: freeDb, rows: freeRows } = createTestDb({
+			users: [
+				{
+					id: 3,
+					email: 'free@example.com',
+					stable_user_id: 'user-free',
+					stripe_customer_id: null,
+				},
+			],
+		})
+		await deleteUserAccount({
+			env: createSuccessfulDeletionEnv(freeDb),
+			dbUserId: 3,
+			mcpUserId: 'user-free',
+		})
+		expect(listSubscriptions).not.toHaveBeenCalled()
+		expect(deleteCustomer).not.toHaveBeenCalled()
+		expect(freeRows.users).toEqual([])
+	} finally {
+		listSubscriptions.mockRestore()
+		cancelSubscription.mockRestore()
+		deleteCustomer.mockRestore()
+		consoleError.mockReset()
+	}
+})
 
-test("deleteUserAccount drops the UserMeter tombstone after the user row is gone", async () => {
-  const { db, rows } = createTestDb({
-    users: [{ id: 1, email: "a@example.com" }],
-  });
-  const env = createSuccessfulDeletionEnv(db);
-  const meter = userMeterRpc({ env, userId: "user-aaa" });
-  await meter.markDeleting({ deletingAt: "2026-08-31 15:22:12" });
+test('deleteUserAccount drops the UserMeter tombstone after the user row is gone', async () => {
+	const { db, rows } = createTestDb({
+		users: [{ id: 1, email: 'a@example.com' }],
+	})
+	const env = createSuccessfulDeletionEnv(db)
+	const meter = userMeterRpc({ env, userId: 'user-aaa' })
+	await meter.markDeleting({ deletingAt: '2026-08-31 15:22:12' })
 
-  await deleteUserAccount({
-    env,
-    dbUserId: 1,
-    mcpUserId: "user-aaa",
-  });
+	await deleteUserAccount({
+		env,
+		dbUserId: 1,
+		mcpUserId: 'user-aaa',
+	})
 
-  expect(rows.users).toEqual([]);
-  expect(await meter.readDeletionState()).toEqual({ deletingAt: null });
-});
+	expect(rows.users).toEqual([])
+	expect(await meter.readDeletionState()).toEqual({ deletingAt: null })
+})
 
-test("deleteUserAccount clears the deletion fence when writers are still active", async () => {
-  const { db, rows } = createTestDb({
-    users: [{ id: 1, email: "a@example.com" }],
-  });
-  const env = createSuccessfulDeletionEnv(db);
-  const meter = userMeterRpc({ env, userId: "user-aaa" });
-  await meter.acquireWriteLease({
-    token: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
-    holder: "test:signup",
-    acquiredAt: "2026-08-31 15:00:00",
-  });
+test('deleteUserAccount clears the deletion fence when writers are still active', async () => {
+	const { db, rows } = createTestDb({
+		users: [{ id: 1, email: 'a@example.com' }],
+	})
+	const env = createSuccessfulDeletionEnv(db)
+	const meter = userMeterRpc({ env, userId: 'user-aaa' })
+	await meter.acquireWriteLease({
+		token: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+		holder: 'test:signup',
+		acquiredAt: '2026-08-31 15:00:00',
+	})
 
-  await expect(
-    deleteUserAccount({
-      env,
-      dbUserId: 1,
-      mcpUserId: "user-aaa",
-    }),
-  ).rejects.toBeInstanceOf(AccountDeletionWritersActiveError);
-  expect(rows.users).toEqual([
-    expect.objectContaining({
-      id: 1,
-      stable_user_id: "user-aaa",
-      deleting_at: null,
-    }),
-  ]);
-  expect(await meter.readDeletionState()).toEqual({ deletingAt: null });
-});
+	await expect(
+		deleteUserAccount({
+			env,
+			dbUserId: 1,
+			mcpUserId: 'user-aaa',
+		}),
+	).rejects.toBeInstanceOf(AccountDeletionWritersActiveError)
+	expect(rows.users).toEqual([
+		expect.objectContaining({
+			id: 1,
+			stable_user_id: 'user-aaa',
+			deleting_at: null,
+		}),
+	])
+	expect(await meter.readDeletionState()).toEqual({ deletingAt: null })
+})
 
-test("deleteUserAccount clears the deletion fence when inventory cannot be collected", async () => {
-  const { db, rows } = createTestDb(
-    {
-      users: [{ id: 1, email: "a@example.com" }],
-    },
-    { failSelectContaining: "from mcp_memories" },
-  );
-  const env = createSuccessfulDeletionEnv(db);
-  const meter = userMeterRpc({ env, userId: "user-aaa" });
+test('deleteUserAccount clears the deletion fence when inventory cannot be collected', async () => {
+	const { db, rows } = createTestDb(
+		{
+			users: [{ id: 1, email: 'a@example.com' }],
+		},
+		{ failSelectContaining: 'from mcp_memories' },
+	)
+	const env = createSuccessfulDeletionEnv(db)
+	const meter = userMeterRpc({ env, userId: 'user-aaa' })
 
-  await expect(
-    deleteUserAccount({
-      env,
-      dbUserId: 1,
-      mcpUserId: "user-aaa",
-    }),
-  ).rejects.toBeInstanceOf(AccountDeletionInventoryError);
-  expect(rows.users).toEqual([
-    expect.objectContaining({
-      id: 1,
-      stable_user_id: "user-aaa",
-      deleting_at: null,
-    }),
-  ]);
-  expect(await meter.readDeletionState()).toEqual({ deletingAt: null });
-});
+	await expect(
+		deleteUserAccount({
+			env,
+			dbUserId: 1,
+			mcpUserId: 'user-aaa',
+		}),
+	).rejects.toBeInstanceOf(AccountDeletionInventoryError)
+	expect(rows.users).toEqual([
+		expect.objectContaining({
+			id: 1,
+			stable_user_id: 'user-aaa',
+			deleting_at: null,
+		}),
+	])
+	expect(await meter.readDeletionState()).toEqual({ deletingAt: null })
+})
 
-test("deleteUserAccount keeps an existing fence when writers are still active", async () => {
-  const { db, rows } = createTestDb({
-    users: [
-      {
-        id: 1,
-        email: "a@example.com",
-        deleting_at: "2026-08-31 15:22:12",
-      },
-    ],
-  });
-  const env = createSuccessfulDeletionEnv(db);
-  const meter = userMeterRpc({ env, userId: "user-aaa" });
-  await meter.acquireWriteLease({
-    token: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
-    holder: "test:cleanup-retry",
-    acquiredAt: "2026-08-31 15:23:00",
-  });
-  await meter.markDeleting({ deletingAt: "2026-08-31 15:22:12" });
+test('deleteUserAccount keeps an existing fence when writers are still active', async () => {
+	const { db, rows } = createTestDb({
+		users: [
+			{
+				id: 1,
+				email: 'a@example.com',
+				deleting_at: '2026-08-31 15:22:12',
+			},
+		],
+	})
+	const env = createSuccessfulDeletionEnv(db)
+	const meter = userMeterRpc({ env, userId: 'user-aaa' })
+	await meter.acquireWriteLease({
+		token: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+		holder: 'test:cleanup-retry',
+		acquiredAt: '2026-08-31 15:23:00',
+	})
+	await meter.markDeleting({ deletingAt: '2026-08-31 15:22:12' })
 
-  await expect(
-    deleteUserAccount({
-      env,
-      dbUserId: 1,
-      mcpUserId: "user-aaa",
-    }),
-  ).rejects.toBeInstanceOf(AccountDeletionWritersActiveError);
-  expect(rows.users).toEqual([
-    expect.objectContaining({
-      id: 1,
-      stable_user_id: "user-aaa",
-      deleting_at: "2026-08-31 15:22:12",
-    }),
-  ]);
-  expect(await meter.readDeletionState()).toEqual({
-    deletingAt: "2026-08-31 15:22:12",
-  });
-});
+	await expect(
+		deleteUserAccount({
+			env,
+			dbUserId: 1,
+			mcpUserId: 'user-aaa',
+		}),
+	).rejects.toBeInstanceOf(AccountDeletionWritersActiveError)
+	expect(rows.users).toEqual([
+		expect.objectContaining({
+			id: 1,
+			stable_user_id: 'user-aaa',
+			deleting_at: '2026-08-31 15:22:12',
+		}),
+	])
+	expect(await meter.readDeletionState()).toEqual({
+		deletingAt: '2026-08-31 15:22:12',
+	})
+})

--- a/packages/worker/src/app/account-deletion.node.test.ts
+++ b/packages/worker/src/app/account-deletion.node.test.ts
@@ -3,6 +3,7 @@ import { DatabaseSync } from 'node:sqlite'
 import { expect, test, vi } from 'vitest'
 import * as stripeClient from '#worker/billing/stripe-client.ts'
 import {
+	AccountDeletionBillingError,
 	AccountDeletionCleanupError,
 	AccountDeletionInventoryError,
 	deleteUserAccount,
@@ -1096,42 +1097,51 @@ test('account deletion preserves Mailbox references and retry marker when R2 del
 	expect(purgeAfterUnrelatedFailure).not.toHaveBeenCalled()
 })
 
-test('account deletion cancels Stripe billing and remains non-blocking on Stripe failures', async () => {
+function stripeSubscription(id: string, status: string) {
+	return {
+		id,
+		status,
+		cancel_at: null,
+		items: { data: [{ price: { id: 'price_pro' } }] },
+	}
+}
+
+function createStripeUserDb(input: {
+	id: number
+	stableUserId: string
+	customerId: string | null
+}) {
+	return createTestDb({
+		users: [
+			{
+				id: input.id,
+				email: `${input.stableUserId}@example.com`,
+				stable_user_id: input.stableUserId,
+				stripe_customer_id: input.customerId,
+			},
+		],
+		mcp_memories: [
+			{ id: `mem-${input.stableUserId}`, user_id: input.stableUserId },
+		],
+	})
+}
+
+test('account deletion cancels Stripe billing before cleanup and keeps customer deletion best-effort', async () => {
 	const listSubscriptions = vi.spyOn(stripeClient, 'listSubscriptions')
 	const cancelSubscription = vi.spyOn(stripeClient, 'cancelSubscription')
 	const deleteCustomer = vi.spyOn(stripeClient, 'deleteCustomer')
 	try {
 		listSubscriptions.mockResolvedValue([
-			{
-				id: 'sub_active',
-				status: 'active',
-				cancel_at: null,
-				items: { data: [{ price: { id: 'price_pro' } }] },
-			},
-			{
-				id: 'sub_trialing',
-				status: 'trialing',
-				cancel_at: null,
-				items: { data: [{ price: { id: 'price_pro' } }] },
-			},
-			{
-				id: 'sub_canceled',
-				status: 'canceled',
-				cancel_at: null,
-				items: { data: [{ price: { id: 'price_pro' } }] },
-			},
+			stripeSubscription('sub_active', 'active'),
+			stripeSubscription('sub_trialing', 'trialing'),
+			stripeSubscription('sub_canceled', 'canceled'),
 		])
 		cancelSubscription.mockResolvedValue(undefined)
 		deleteCustomer.mockResolvedValue(undefined)
-		const { db, rows } = createTestDb({
-			users: [
-				{
-					id: 1,
-					email: 'pro@example.com',
-					stable_user_id: 'user-pro',
-					stripe_customer_id: 'cus_pro',
-				},
-			],
+		const { db, rows } = createStripeUserDb({
+			id: 1,
+			stableUserId: 'user-pro',
+			customerId: 'cus_pro',
 		})
 
 		const result = await deleteUserAccount({
@@ -1140,6 +1150,7 @@ test('account deletion cancels Stripe billing and remains non-blocking on Stripe
 			mcpUserId: 'user-pro',
 		})
 
+		expect(listSubscriptions).toHaveBeenCalledTimes(1)
 		expect(listSubscriptions).toHaveBeenCalledWith(
 			expect.any(Object),
 			'cus_pro',
@@ -1157,58 +1168,54 @@ test('account deletion cancels Stripe billing and remains non-blocking on Stripe
 		expect(rows.users).toEqual([])
 		expect(result.warnings).toEqual([])
 
-		listSubscriptions.mockRejectedValue(
-			new Error('Stripe subscriptions unavailable'),
-		)
+		// Customer deletion after a successful cancel stays warning-only: nothing
+		// bills a customer with no billable subscription.
+		listSubscriptions.mockResolvedValue([
+			stripeSubscription('sub_active', 'active'),
+		])
 		deleteCustomer.mockRejectedValue(new Error('Stripe customer unavailable'))
 		cancelSubscription.mockClear()
 		consoleError.mockImplementation(() => {})
-		const { db: failureDb, rows: failureRows } = createTestDb({
-			users: [
-				{
-					id: 2,
-					email: 'failure@example.com',
-					stable_user_id: 'user-stripe-failure',
-					stripe_customer_id: 'cus_failure',
-				},
-			],
-		})
+		const { db: customerFailureDb, rows: customerFailureRows } =
+			createStripeUserDb({
+				id: 2,
+				stableUserId: 'user-customer-failure',
+				customerId: 'cus_failure',
+			})
 
-		const failureResult = await deleteUserAccount({
-			env: createSuccessfulDeletionEnv(failureDb),
+		const customerFailureResult = await deleteUserAccount({
+			env: createSuccessfulDeletionEnv(customerFailureDb),
 			dbUserId: 2,
-			mcpUserId: 'user-stripe-failure',
+			mcpUserId: 'user-customer-failure',
 		})
 
+		expect(cancelSubscription).toHaveBeenCalledWith(
+			expect.any(Object),
+			'sub_active',
+		)
 		expect(deleteCustomer).toHaveBeenLastCalledWith(
 			expect.any(Object),
 			'cus_failure',
 		)
-		expect(cancelSubscription).not.toHaveBeenCalled()
-		expect(failureRows.users).toEqual([])
-		expect(failureResult.warnings).toEqual([
+		expect(customerFailureRows.users).toEqual([])
+		expect(customerFailureResult.warnings).toEqual([
 			expect.stringContaining('Stripe customer cleanup failed'),
 		])
 		expect(consoleError).toHaveBeenCalledOnce()
 		expect(consoleError).toHaveBeenCalledWith(
 			'account_deletion_stripe_cleanup_failed',
 			expect.objectContaining({
-				userId: 'user-stripe-failure',
-				error: expect.any(AggregateError),
+				userId: 'user-customer-failure',
+				error: expect.any(Error),
 			}),
 		)
 
 		listSubscriptions.mockClear()
 		deleteCustomer.mockClear()
-		const { db: freeDb, rows: freeRows } = createTestDb({
-			users: [
-				{
-					id: 3,
-					email: 'free@example.com',
-					stable_user_id: 'user-free',
-					stripe_customer_id: null,
-				},
-			],
+		const { db: freeDb, rows: freeRows } = createStripeUserDb({
+			id: 3,
+			stableUserId: 'user-free',
+			customerId: null,
 		})
 		await deleteUserAccount({
 			env: createSuccessfulDeletionEnv(freeDb),
@@ -1223,6 +1230,170 @@ test('account deletion cancels Stripe billing and remains non-blocking on Stripe
 		cancelSubscription.mockRestore()
 		deleteCustomer.mockRestore()
 		consoleError.mockReset()
+	}
+})
+
+test('a failed Stripe cancellation retains the account, releases the fence, and touches nothing else', async () => {
+	const listSubscriptions = vi.spyOn(stripeClient, 'listSubscriptions')
+	const cancelSubscription = vi.spyOn(stripeClient, 'cancelSubscription')
+	const deleteCustomer = vi.spyOn(stripeClient, 'deleteCustomer')
+	consoleError.mockImplementation(() => {})
+	try {
+		const cases: Array<{
+			name: string
+			stableUserId: string
+			arrange: () => void
+			expectedBillingErrors: Array<string>
+		}> = [
+			{
+				name: 'listing fails',
+				stableUserId: 'user-list-fails',
+				arrange: () => {
+					listSubscriptions.mockRejectedValue(
+						new Error('Stripe subscriptions unavailable'),
+					)
+				},
+				expectedBillingErrors: [
+					'Stripe subscriptions could not be listed: Stripe subscriptions unavailable',
+				],
+			},
+			{
+				name: 'cancel is rejected and the subscription stays active',
+				stableUserId: 'user-cancel-fails',
+				arrange: () => {
+					listSubscriptions.mockResolvedValue([
+						stripeSubscription('sub_active', 'active'),
+					])
+					cancelSubscription.mockRejectedValue(
+						new Error('Stripe cancel rejected'),
+					)
+				},
+				expectedBillingErrors: [
+					'Stripe subscription sub_active could not be canceled: Stripe cancel rejected',
+				],
+			},
+		]
+		for (const testCase of cases) {
+			listSubscriptions.mockReset()
+			cancelSubscription.mockReset()
+			deleteCustomer.mockReset()
+			deleteCustomer.mockResolvedValue(undefined)
+			testCase.arrange()
+			const deleteVectorsMock = vi.fn(async () => undefined)
+			const { db, rows } = createStripeUserDb({
+				id: 1,
+				stableUserId: testCase.stableUserId,
+				customerId: 'cus_billing',
+			})
+			const env = createSuccessfulDeletionEnv(db, {
+				CAPABILITY_VECTOR_INDEX: { deleteByIds: deleteVectorsMock },
+			} as unknown as Partial<Env>)
+			const meter = userMeterRpc({ env, userId: testCase.stableUserId })
+
+			await expect(
+				deleteUserAccount({
+					env,
+					dbUserId: 1,
+					mcpUserId: testCase.stableUserId,
+				}),
+				testCase.name,
+			).rejects.toSatisfy(
+				(error: unknown) =>
+					error instanceof AccountDeletionBillingError &&
+					JSON.stringify(error.billingErrors) ===
+						JSON.stringify(testCase.expectedBillingErrors),
+			)
+
+			// Nothing destructive ran and the account is usable again.
+			expect(deleteVectorsMock, testCase.name).not.toHaveBeenCalled()
+			expect(deleteCustomer, testCase.name).not.toHaveBeenCalled()
+			expect(rows.users, testCase.name).toEqual([
+				expect.objectContaining({
+					id: 1,
+					stable_user_id: testCase.stableUserId,
+					stripe_customer_id: 'cus_billing',
+					deleting_at: null,
+				}),
+			])
+			expect(rows.mcp_memories, testCase.name).toEqual([
+				{ id: `mem-${testCase.stableUserId}`, user_id: testCase.stableUserId },
+			])
+			expect(await meter.readDeletionState(), testCase.name).toEqual({
+				deletingAt: null,
+			})
+			expect(consoleError).toHaveBeenCalledWith(
+				'account_deletion_billing_cancel_failed',
+				{
+					userId: testCase.stableUserId,
+					billingErrors: testCase.expectedBillingErrors,
+				},
+			)
+		}
+	} finally {
+		listSubscriptions.mockRestore()
+		cancelSubscription.mockRestore()
+		deleteCustomer.mockRestore()
+		consoleError.mockReset()
+	}
+})
+
+test('a subscription that is already canceled counts as canceled so retried deletions proceed', async () => {
+	const listSubscriptions = vi.spyOn(stripeClient, 'listSubscriptions')
+	const cancelSubscription = vi.spyOn(stripeClient, 'cancelSubscription')
+	const deleteCustomer = vi.spyOn(stripeClient, 'deleteCustomer')
+	try {
+		deleteCustomer.mockResolvedValue(undefined)
+
+		// Retry after an earlier attempt already canceled everything: Stripe
+		// lists the subscription as canceled, so nothing is canceled again.
+		listSubscriptions.mockResolvedValue([
+			stripeSubscription('sub_old', 'canceled'),
+		])
+		const { db: retryDb, rows: retryRows } = createStripeUserDb({
+			id: 1,
+			stableUserId: 'user-retry',
+			customerId: 'cus_retry',
+		})
+		const retryResult = await deleteUserAccount({
+			env: createSuccessfulDeletionEnv(retryDb),
+			dbUserId: 1,
+			mcpUserId: 'user-retry',
+		})
+		expect(cancelSubscription).not.toHaveBeenCalled()
+		expect(retryRows.users).toEqual([])
+		expect(retryResult.warnings).toEqual([])
+
+		// The cancel call errors (for example Stripe raced the cancellation) but
+		// a fresh listing shows the subscription is no longer billable.
+		listSubscriptions
+			.mockReset()
+			.mockResolvedValueOnce([stripeSubscription('sub_racing', 'active')])
+			.mockResolvedValueOnce([stripeSubscription('sub_racing', 'canceled')])
+		cancelSubscription.mockRejectedValue(
+			new Error('Stripe API request failed with HTTP 400.'),
+		)
+		const { db: raceDb, rows: raceRows } = createStripeUserDb({
+			id: 2,
+			stableUserId: 'user-race',
+			customerId: 'cus_race',
+		})
+		const raceResult = await deleteUserAccount({
+			env: createSuccessfulDeletionEnv(raceDb),
+			dbUserId: 2,
+			mcpUserId: 'user-race',
+		})
+		expect(cancelSubscription).toHaveBeenCalledWith(
+			expect.any(Object),
+			'sub_racing',
+		)
+		expect(listSubscriptions).toHaveBeenCalledTimes(2)
+		expect(raceRows.users).toEqual([])
+		expect(raceResult.warnings).toEqual([])
+		expect(deleteCustomer).toHaveBeenCalledWith(expect.any(Object), 'cus_race')
+	} finally {
+		listSubscriptions.mockRestore()
+		cancelSubscription.mockRestore()
+		deleteCustomer.mockRestore()
 	}
 })
 

--- a/packages/worker/src/app/account-deletion.node.test.ts
+++ b/packages/worker/src/app/account-deletion.node.test.ts
@@ -1134,7 +1134,14 @@ test('account deletion cancels Stripe billing before cleanup and keeps customer 
 		listSubscriptions.mockResolvedValue([
 			stripeSubscription('sub_active', 'active'),
 			stripeSubscription('sub_trialing', 'trialing'),
+			// Dunning and paused states can still invoice or resume, so they
+			// must be canceled too; only terminal states are skipped.
+			stripeSubscription('sub_past_due', 'past_due'),
+			stripeSubscription('sub_unpaid', 'unpaid'),
+			stripeSubscription('sub_paused', 'paused'),
+			stripeSubscription('sub_incomplete', 'incomplete'),
 			stripeSubscription('sub_canceled', 'canceled'),
+			stripeSubscription('sub_expired', 'incomplete_expired'),
 		])
 		cancelSubscription.mockResolvedValue(undefined)
 		deleteCustomer.mockResolvedValue(undefined)
@@ -1155,15 +1162,17 @@ test('account deletion cancels Stripe billing before cleanup and keeps customer 
 			expect.any(Object),
 			'cus_pro',
 		)
-		expect(cancelSubscription).toHaveBeenCalledTimes(2)
-		expect(cancelSubscription).toHaveBeenCalledWith(
-			expect.any(Object),
+		expect(cancelSubscription).toHaveBeenCalledTimes(6)
+		expect(
+			cancelSubscription.mock.calls.map(([, subscriptionId]) => subscriptionId),
+		).toEqual([
 			'sub_active',
-		)
-		expect(cancelSubscription).toHaveBeenCalledWith(
-			expect.any(Object),
 			'sub_trialing',
-		)
+			'sub_past_due',
+			'sub_unpaid',
+			'sub_paused',
+			'sub_incomplete',
+		])
 		expect(deleteCustomer).toHaveBeenCalledWith(expect.any(Object), 'cus_pro')
 		expect(rows.users).toEqual([])
 		expect(result.warnings).toEqual([])

--- a/packages/worker/src/app/account-deletion.ts
+++ b/packages/worker/src/app/account-deletion.ts
@@ -1,974 +1,968 @@
-import { getErrorMessage } from "@kody-internal/shared/error-message.ts";
+import { getErrorMessage } from '@kody-internal/shared/error-message.ts'
 import {
-  type OAuthGrantHelpers,
-  revokeAllOAuthGrantsBestEffort,
-} from "#worker/oauth-grants.ts";
+	type OAuthGrantHelpers,
+	revokeAllOAuthGrantsBestEffort,
+} from '#worker/oauth-grants.ts'
 import {
-  cancelSubscription,
-  deleteCustomer,
-  listSubscriptions,
-} from "#worker/billing/stripe-client.ts";
-import { purgeStripePlanRefreshForUser } from "#worker/billing/stripe-plan-refresh-client.ts";
-import { storageRunnerRpc } from "#worker/storage-runner.ts";
-import { purgeJobManagerForUser } from "#worker/jobs/manager-client.ts";
-import { jobsService } from "#worker/jobs/jobs-data.ts";
-import { jobVectorId } from "#mcp/jobs-vectorize.ts";
-import { memoryVectorId } from "#mcp/memory/memory-vectorize.ts";
-import { savedPackageVectorId } from "#worker/package-registry/repo.ts";
-import { getCapabilityVectorIndex } from "#worker/vectorize/embedding.ts";
-import { cleanupAllUserArtifactRepos } from "#worker/repo/artifact-repo-cleanup.ts";
-import { repoSessionRpc } from "#worker/repo/repo-session-rpc.ts";
-import { mcpClientHubDurableObjectName } from "#worker/user-scoped-durable-object-name.ts";
-import { packageRealtimeSessionRpc } from "#worker/package-runtime/realtime-session.ts";
-import { clearRunRecords } from "#worker/run-records/service.ts";
+	cancelSubscription,
+	deleteCustomer,
+	listSubscriptions,
+} from '#worker/billing/stripe-client.ts'
+import { purgeStripePlanRefreshForUser } from '#worker/billing/stripe-plan-refresh-client.ts'
+import { storageRunnerRpc } from '#worker/storage-runner.ts'
+import { purgeJobManagerForUser } from '#worker/jobs/manager-client.ts'
+import { jobsService } from '#worker/jobs/jobs-data.ts'
+import { jobVectorId } from '#mcp/jobs-vectorize.ts'
+import { memoryVectorId } from '#mcp/memory/memory-vectorize.ts'
+import { savedPackageVectorId } from '#worker/package-registry/repo.ts'
+import { getCapabilityVectorIndex } from '#worker/vectorize/embedding.ts'
+import { cleanupAllUserArtifactRepos } from '#worker/repo/artifact-repo-cleanup.ts'
+import { repoSessionRpc } from '#worker/repo/repo-session-rpc.ts'
+import { mcpClientHubDurableObjectName } from '#worker/user-scoped-durable-object-name.ts'
+import { packageRealtimeSessionRpc } from '#worker/package-runtime/realtime-session.ts'
+import { clearRunRecords } from '#worker/run-records/service.ts'
 import {
-  userMeterNamespace,
-  userMeterRpc,
-} from "#worker/entitlements/user-meter-client.ts";
-import { mailboxRpc } from "#worker/email/mailbox-client.ts";
-import { repoSessionIndexRpc } from "#worker/repo/repo-session-index-client.ts";
-import { listRepoSessionsByUser } from "#worker/repo/repo-sessions.ts";
-import { listAccountUserStorageIds } from "#worker/account/user-inventory.ts";
+	userMeterNamespace,
+	userMeterRpc,
+} from '#worker/entitlements/user-meter-client.ts'
+import { mailboxRpc } from '#worker/email/mailbox-client.ts'
+import { repoSessionIndexRpc } from '#worker/repo/repo-session-index-client.ts'
+import { listRepoSessionsByUser } from '#worker/repo/repo-sessions.ts'
+import { listAccountUserStorageIds } from '#worker/account/user-inventory.ts'
 import {
-  deleteOwnedMcpOauthClients,
-  listOwnedUserMcpOauthClientIds,
-} from "#app/account-mcp-oauth-clients.ts";
+	deleteOwnedMcpOauthClients,
+	listOwnedUserMcpOauthClientIds,
+} from '#app/account-mcp-oauth-clients.ts'
 import {
-  accountUserDataTargets,
-  buildUserScopedDeleteOrUpdateSql,
-  buildUserScopedTargetMatch,
-  getAccountD1UserColumnCoverage,
-} from "#worker/account/data-targets.ts";
+	accountUserDataTargets,
+	buildUserScopedDeleteOrUpdateSql,
+	buildUserScopedTargetMatch,
+	getAccountD1UserColumnCoverage,
+} from '#worker/account/data-targets.ts'
 import {
-  accountUserOwnedVectorizeSurfaces,
-  getAccountDeletionDurableObjectResultKeys,
-  type UserOwnedVectorizeSource,
-} from "#worker/account/user-owned-surfaces.ts";
+	accountUserOwnedVectorizeSurfaces,
+	getAccountDeletionDurableObjectResultKeys,
+	type UserOwnedVectorizeSource,
+} from '#worker/account/user-owned-surfaces.ts'
 import {
-  collectAccountR2Inventory,
-  type AccountCommunityListingSnapshot,
-  type AccountR2ObjectRef,
-} from "#worker/account/r2-inventory.ts";
+	collectAccountR2Inventory,
+	type AccountCommunityListingSnapshot,
+	type AccountR2ObjectRef,
+} from '#worker/account/r2-inventory.ts'
 import {
-  deleteAccountCommunityAssetPrefixes,
-  deleteAccountEmailBlobPrefixes,
-} from "#app/account-r2-prefix-cleanup.ts";
+	deleteAccountCommunityAssetPrefixes,
+	deleteAccountEmailBlobPrefixes,
+} from '#app/account-r2-prefix-cleanup.ts'
 import {
-  listMcpAgentSessionsForUser,
-  type McpAgentSession,
-} from "#mcp/session-registry.ts";
+	listMcpAgentSessionsForUser,
+	type McpAgentSession,
+} from '#mcp/session-registry.ts'
 import {
-  AccountDeletionWritersActiveError,
-  abortAccountDeleting,
-  clearUserMeterDeletionTombstone,
-  markAccountDeleting,
-} from "#worker/account/deletion-state.ts";
+	AccountDeletionWritersActiveError,
+	abortAccountDeleting,
+	clearUserMeterDeletionTombstone,
+	markAccountDeleting,
+} from '#worker/account/deletion-state.ts'
 import {
-  buildPublishedSourceManifestSnapshotKvKey,
-  buildPublishedSourceSnapshotKvKey,
-} from "#worker/package-runtime/published-runtime-artifacts.ts";
-import { deleteAllPackageRetrieverCacheEntriesForUser } from "#worker/package-retrievers/manifest-cache.ts";
-import { buildCommunitySnapshotKvKey } from "#worker/community/snapshot.ts";
+	buildPublishedSourceManifestSnapshotKvKey,
+	buildPublishedSourceSnapshotKvKey,
+} from '#worker/package-runtime/published-runtime-artifacts.ts'
+import { deleteAllPackageRetrieverCacheEntriesForUser } from '#worker/package-retrievers/manifest-cache.ts'
+import { buildCommunitySnapshotKvKey } from '#worker/community/snapshot.ts'
 import {
-  communityIconKvListingPrefixes,
-  buildCommunityIconCacheKey,
-} from "#worker/community/community-icon.ts";
-import { derivedCacheKeyPrefix } from "#worker/kv-cachified.ts";
+	communityIconKvListingPrefixes,
+	buildCommunityIconCacheKey,
+} from '#worker/community/community-icon.ts'
+import { derivedCacheKeyPrefix } from '#worker/kv-cachified.ts'
 import {
-  maybeRemoveDiscordGuildRoles,
-  summarizeDiscordGuildRoleSync,
-} from "#worker/discord/guild-role.ts";
+	maybeRemoveDiscordGuildRoles,
+	summarizeDiscordGuildRoleSync,
+} from '#worker/discord/guild-role.ts'
 
 // Imported manually instead of via `@cloudflare/workers-oauth-provider` so
 // node-only unit tests can require this module without dragging in
 // `cloudflare:workers` (the OAuth provider package re-exports through that
 // runtime symbol). The shape mirrors the subset of OAuthHelpers we use.
 type OAuthHelpersShape = OAuthGrantHelpers & {
-  deleteClient?(clientId: string): Promise<unknown>;
-};
+	deleteClient?(clientId: string): Promise<unknown>
+}
 
 type AccountDeletionEnv = Env & {
-  OAUTH_PROVIDER?: OAuthHelpersShape;
-};
+	OAUTH_PROVIDER?: OAuthHelpersShape
+}
 
 export type AccountDeletionResult = {
-  deletedRowCounts: Record<string, number>;
-  updatedRowCounts: Record<string, number>;
-  deletedKvKeys: number;
-  deletedCommunityAssets: number;
-  deletedEmailBlobs: number;
-  deletedArtifactRepos: number;
-  revokedOAuthGrants: number;
-  clearedDurableObjects: Record<string, number>;
-  deletedVectors: number;
-  warnings: Array<string>;
-};
+	deletedRowCounts: Record<string, number>
+	updatedRowCounts: Record<string, number>
+	deletedKvKeys: number
+	deletedCommunityAssets: number
+	deletedEmailBlobs: number
+	deletedArtifactRepos: number
+	revokedOAuthGrants: number
+	clearedDurableObjects: Record<string, number>
+	deletedVectors: number
+	warnings: Array<string>
+}
 
 export function getAccountDeletionD1UserColumnCoverage() {
-  return getAccountD1UserColumnCoverage();
+	return getAccountD1UserColumnCoverage()
 }
 
 type UserSourceSnapshot = {
-  sourceId: string;
-  publishedCommit: string | null;
-};
+	sourceId: string
+	publishedCommit: string | null
+}
 
 type UserSavedPackageSnapshot = {
-  id: string;
-  kodyId: string;
-  sourceId: string;
-  hasApp: boolean;
-};
+	id: string
+	kodyId: string
+	sourceId: string
+	hasApp: boolean
+}
 
 type UserRepoSessionSnapshot = {
-  id: string;
-};
+	id: string
+}
 
 type UserMcpServerSnapshot = {
-  id: string;
-};
+	id: string
+}
 
 type UserDeletionInventory = {
-  stripeCustomerId: string | null;
-  vectorIds: Array<string>;
-  storageIds: Array<string>;
-  bundleKvKeys: Array<string>;
-  r2Objects: Array<AccountR2ObjectRef>;
-  sourceSnapshots: Array<UserSourceSnapshot>;
-  savedPackages: Array<UserSavedPackageSnapshot>;
-  repoSessions: Array<UserRepoSessionSnapshot>;
-  mcpServers: Array<UserMcpServerSnapshot>;
-  mcpAgentSessions: Array<McpAgentSession>;
-  communityListings: Array<AccountCommunityListingSnapshot>;
-};
+	stripeCustomerId: string | null
+	vectorIds: Array<string>
+	storageIds: Array<string>
+	bundleKvKeys: Array<string>
+	r2Objects: Array<AccountR2ObjectRef>
+	sourceSnapshots: Array<UserSourceSnapshot>
+	savedPackages: Array<UserSavedPackageSnapshot>
+	repoSessions: Array<UserRepoSessionSnapshot>
+	mcpServers: Array<UserMcpServerSnapshot>
+	mcpAgentSessions: Array<McpAgentSession>
+	communityListings: Array<AccountCommunityListingSnapshot>
+}
 
 const stripeSubscriptionStatusesCanceledOnAccountDeletion = new Set([
-  "active",
-  "trialing",
-]);
+	'active',
+	'trialing',
+])
 
 export class AccountDeletionInventoryError extends Error {
-  readonly inventoryErrors: ReadonlyArray<string>;
+	readonly inventoryErrors: ReadonlyArray<string>
 
-  constructor(inventoryErrors: ReadonlyArray<string>) {
-    super("Account deletion inventory could not be collected safely.");
-    this.name = "AccountDeletionInventoryError";
-    this.inventoryErrors = [...inventoryErrors];
-  }
+	constructor(inventoryErrors: ReadonlyArray<string>) {
+		super('Account deletion inventory could not be collected safely.')
+		this.name = 'AccountDeletionInventoryError'
+		this.inventoryErrors = [...inventoryErrors]
+	}
 }
 
 export class AccountDeletionCleanupError extends Error {
-  readonly cleanupErrors: ReadonlyArray<string>;
-  readonly partialResult: AccountDeletionResult;
+	readonly cleanupErrors: ReadonlyArray<string>
+	readonly partialResult: AccountDeletionResult
 
-  constructor(
-    cleanupErrors: ReadonlyArray<string>,
-    partialResult: AccountDeletionResult,
-  ) {
-    super("Account deletion cleanup could not complete safely.");
-    this.name = "AccountDeletionCleanupError";
-    this.cleanupErrors = [...cleanupErrors];
-    this.partialResult = partialResult;
-  }
+	constructor(
+		cleanupErrors: ReadonlyArray<string>,
+		partialResult: AccountDeletionResult,
+	) {
+		super('Account deletion cleanup could not complete safely.')
+		this.name = 'AccountDeletionCleanupError'
+		this.cleanupErrors = [...cleanupErrors]
+		this.partialResult = partialResult
+	}
 }
 
 function uniqueStrings(values: Iterable<string | null | undefined>) {
-  return Array.from(
-    new Set(
-      Array.from(values)
-        .map((value) => value?.trim() ?? "")
-        .filter((value) => value.length > 0),
-    ),
-  );
+	return Array.from(
+		new Set(
+			Array.from(values)
+				.map((value) => value?.trim() ?? '')
+				.filter((value) => value.length > 0),
+		),
+	)
 }
 
 const vectorIdBuildersBySurfaceId = {
-  memory: memoryVectorId,
-  job: jobVectorId,
-  saved_package: savedPackageVectorId,
-} as const;
+	memory: memoryVectorId,
+	job: jobVectorId,
+	saved_package: savedPackageVectorId,
+} as const
 
 async function listUserVectorSourceRowIds(
-  env: Env,
-  userId: string,
-  source: UserOwnedVectorizeSource,
+	env: Env,
+	userId: string,
+	source: UserOwnedVectorizeSource,
 ): Promise<Array<string>> {
-  switch (source.kind) {
-    case "app_db": {
-      const rows = await env.APP_DB.prepare(
-        `SELECT id FROM ${source.table} WHERE user_id = ?`,
-      )
-        .bind(userId)
-        .all<{ id: string }>();
-      return (rows.results ?? []).map((row) => row.id);
-    }
-    case "jobs_rpc": {
-      const jobs = jobsService(env);
-      if (!jobs) {
-        throw new Error(
-          "JOBS service binding is required to enumerate job vector ids (jobs live in the jobs worker D1, not APP_DB).",
-        );
-      }
-      return jobs.listJobIdsForUser({ userId });
-    }
-    default: {
-      const unknownSource: never = source;
-      throw new Error(
-        `Unknown vectorize surface source: ${JSON.stringify(unknownSource)}`,
-      );
-    }
-  }
+	switch (source.kind) {
+		case 'app_db': {
+			const rows = await env.APP_DB.prepare(
+				`SELECT id FROM ${source.table} WHERE user_id = ?`,
+			)
+				.bind(userId)
+				.all<{ id: string }>()
+			return (rows.results ?? []).map((row) => row.id)
+		}
+		case 'jobs_rpc': {
+			const jobs = jobsService(env)
+			if (!jobs) {
+				throw new Error(
+					'JOBS service binding is required to enumerate job vector ids (jobs live in the jobs worker D1, not APP_DB).',
+				)
+			}
+			return jobs.listJobIdsForUser({ userId })
+		}
+		default: {
+			const unknownSource: never = source
+			throw new Error(
+				`Unknown vectorize surface source: ${JSON.stringify(unknownSource)}`,
+			)
+		}
+	}
 }
 
 async function listUserVectorIds(env: Env, userId: string) {
-  const ids: Array<string> = [];
-  for (const surface of accountUserOwnedVectorizeSurfaces) {
-    const buildId = vectorIdBuildersBySurfaceId[surface.id];
-    const rowIds = await listUserVectorSourceRowIds(
-      env,
-      userId,
-      surface.source,
-    );
-    for (const rowId of rowIds) {
-      ids.push(buildId(rowId));
-    }
-  }
-  return ids;
+	const ids: Array<string> = []
+	for (const surface of accountUserOwnedVectorizeSurfaces) {
+		const buildId = vectorIdBuildersBySurfaceId[surface.id]
+		const rowIds = await listUserVectorSourceRowIds(env, userId, surface.source)
+		for (const rowId of rowIds) {
+			ids.push(buildId(rowId))
+		}
+	}
+	return ids
 }
 
 async function getUserStripeCustomerId(env: Env, dbUserId: number) {
-  const row = await env.APP_DB.prepare(
-    `SELECT stripe_customer_id FROM users WHERE id = ?`,
-  )
-    .bind(dbUserId)
-    .first<{ stripe_customer_id: string | null }>();
-  return row?.stripe_customer_id?.trim() || null;
+	const row = await env.APP_DB.prepare(
+		`SELECT stripe_customer_id FROM users WHERE id = ?`,
+	)
+		.bind(dbUserId)
+		.first<{ stripe_customer_id: string | null }>()
+	return row?.stripe_customer_id?.trim() || null
 }
 
 async function listUserStorageIds(env: Env, userId: string) {
-  return await listAccountUserStorageIds({
-    env,
-    userId,
-  });
+	return await listAccountUserStorageIds({
+		env,
+		userId,
+	})
 }
 
 async function listUserSourceSnapshots(env: Env, userId: string) {
-  const sourceRows = await env.APP_DB.prepare(
-    `SELECT id, published_commit
+	const sourceRows = await env.APP_DB.prepare(
+		`SELECT id, published_commit
 		FROM entity_sources
 		WHERE user_id = ?`,
-  )
-    .bind(userId)
-    .all<{ id: string; published_commit: string | null }>();
-  return (sourceRows.results ?? []).map((row) => ({
-    sourceId: row.id,
-    publishedCommit: row.published_commit,
-  }));
+	)
+		.bind(userId)
+		.all<{ id: string; published_commit: string | null }>()
+	return (sourceRows.results ?? []).map((row) => ({
+		sourceId: row.id,
+		publishedCommit: row.published_commit,
+	}))
 }
 
 async function listUserSavedPackages(env: Env, userId: string) {
-  const rows = await env.APP_DB.prepare(
-    `SELECT id, kody_id, source_id, has_app
+	const rows = await env.APP_DB.prepare(
+		`SELECT id, kody_id, source_id, has_app
 		FROM saved_packages
 		WHERE user_id = ?`,
-  )
-    .bind(userId)
-    .all<{
-      id: string;
-      kody_id: string;
-      source_id: string;
-      has_app: number | string | boolean;
-    }>();
-  return (rows.results ?? []).map((row) => ({
-    id: row.id,
-    kodyId: row.kody_id,
-    sourceId: row.source_id,
-    hasApp: row.has_app === 1 || row.has_app === "1" || row.has_app === true,
-  }));
+	)
+		.bind(userId)
+		.all<{
+			id: string
+			kody_id: string
+			source_id: string
+			has_app: number | string | boolean
+		}>()
+	return (rows.results ?? []).map((row) => ({
+		id: row.id,
+		kodyId: row.kody_id,
+		sourceId: row.source_id,
+		hasApp: row.has_app === 1 || row.has_app === '1' || row.has_app === true,
+	}))
 }
 
 async function listUserRepoSessions(env: Env, userId: string) {
-  if (!env.REPO_SESSION_INDEX) {
-    throw new Error(
-      "REPO_SESSION_INDEX binding is required for account deletion.",
-    );
-  }
-  return (await listRepoSessionsByUser(env, userId)).map((row) => ({
-    id: row.id,
-  }));
+	if (!env.REPO_SESSION_INDEX) {
+		throw new Error(
+			'REPO_SESSION_INDEX binding is required for account deletion.',
+		)
+	}
+	return (await listRepoSessionsByUser(env, userId)).map((row) => ({
+		id: row.id,
+	}))
 }
 
 async function listUserMcpServers(env: Env, userId: string) {
-  const rows = await env.APP_DB.prepare(
-    `SELECT id
+	const rows = await env.APP_DB.prepare(
+		`SELECT id
 		FROM mcp_server_settings
 		WHERE user_id = ?`,
-  )
-    .bind(userId)
-    .all<{ id: string }>();
-  return (rows.results ?? []).map((row) => ({ id: row.id }));
+	)
+		.bind(userId)
+		.all<{ id: string }>()
+	return (rows.results ?? []).map((row) => ({ id: row.id }))
 }
 
 async function listUserBundleKvKeys(input: {
-  env: Env;
-  userId: string;
-  sourceSnapshots: ReadonlyArray<UserSourceSnapshot>;
-  communityListings: ReadonlyArray<AccountCommunityListingSnapshot>;
+	env: Env
+	userId: string
+	sourceSnapshots: ReadonlyArray<UserSourceSnapshot>
+	communityListings: ReadonlyArray<AccountCommunityListingSnapshot>
 }) {
-  const published = await input.env.APP_DB.prepare(
-    `SELECT kv_key FROM published_bundle_artifacts WHERE user_id = ?`,
-  )
-    .bind(input.userId)
-    .all<{ kv_key: string }>();
-  return uniqueStrings([
-    ...(published.results ?? []).map((row) => row.kv_key),
-    ...input.sourceSnapshots.flatMap((source) =>
-      source.publishedCommit
-        ? [
-            buildPublishedSourceSnapshotKvKey({
-              sourceId: source.sourceId,
-              publishedCommit: source.publishedCommit,
-            }),
-            buildPublishedSourceManifestSnapshotKvKey({
-              sourceId: source.sourceId,
-              publishedCommit: source.publishedCommit,
-            }),
-          ]
-        : [],
-    ),
-    ...input.communityListings.flatMap((listing) => [
-      buildCommunitySnapshotKvKey(listing.id),
-      derivedCacheKeyPrefix +
-        buildCommunityIconCacheKey({
-          listingId: listing.id,
-          commit: listing.pinnedCommit,
-        }),
-      derivedCacheKeyPrefix +
-        buildCommunityIconCacheKey({
-          listingId: listing.id,
-          commit: listing.iconCommit,
-        }),
-    ]),
-  ]);
+	const published = await input.env.APP_DB.prepare(
+		`SELECT kv_key FROM published_bundle_artifacts WHERE user_id = ?`,
+	)
+		.bind(input.userId)
+		.all<{ kv_key: string }>()
+	return uniqueStrings([
+		...(published.results ?? []).map((row) => row.kv_key),
+		...input.sourceSnapshots.flatMap((source) =>
+			source.publishedCommit
+				? [
+						buildPublishedSourceSnapshotKvKey({
+							sourceId: source.sourceId,
+							publishedCommit: source.publishedCommit,
+						}),
+						buildPublishedSourceManifestSnapshotKvKey({
+							sourceId: source.sourceId,
+							publishedCommit: source.publishedCommit,
+						}),
+					]
+				: [],
+		),
+		...input.communityListings.flatMap((listing) => [
+			buildCommunitySnapshotKvKey(listing.id),
+			derivedCacheKeyPrefix +
+				buildCommunityIconCacheKey({
+					listingId: listing.id,
+					commit: listing.pinnedCommit,
+				}),
+			derivedCacheKeyPrefix +
+				buildCommunityIconCacheKey({
+					listingId: listing.id,
+					commit: listing.iconCommit,
+				}),
+		]),
+	])
 }
 
 async function collectUserDeletionInventory(input: {
-  env: Env;
-  userId: string;
-  dbUserId: number;
-  warnings: Array<string>;
+	env: Env
+	userId: string
+	dbUserId: number
+	warnings: Array<string>
 }): Promise<UserDeletionInventory> {
-  const inventoryErrors: Array<string> = [];
-  const recordInventoryError = (label: string, error: unknown) => {
-    const warning = `Failed to enumerate ${label}: ${getErrorMessage(error)}`;
-    input.warnings.push(warning);
-    inventoryErrors.push(warning);
-  };
-  const [
-    stripeCustomerId,
-    vectorIds,
-    storageIds,
-    r2Inventory,
-    sourceSnapshots,
-    savedPackages,
-    repoSessions,
-    mcpServers,
-    mcpAgentSessions,
-  ] = await Promise.all([
-    getUserStripeCustomerId(input.env, input.dbUserId).catch((error) => {
-      recordInventoryError("Stripe customer id", error);
-      return null;
-    }),
-    listUserVectorIds(input.env, input.userId).catch((error) => {
-      recordInventoryError("vector ids", error);
-      return [] as Array<string>;
-    }),
-    listUserStorageIds(input.env, input.userId).catch((error) => {
-      recordInventoryError("storage ids", error);
-      return [] as Array<string>;
-    }),
-    collectAccountR2Inventory({
-      env: input.env,
-      userId: input.userId,
-      dbUserId: input.dbUserId,
-    }).catch((error) => {
-      recordInventoryError("R2 objects", error);
-      return {
-        objects: [] as Array<AccountR2ObjectRef>,
-        communityListings: [] as Array<AccountCommunityListingSnapshot>,
-      };
-    }),
-    listUserSourceSnapshots(input.env, input.userId).catch((error) => {
-      recordInventoryError("source snapshots", error);
-      return [] as Array<UserSourceSnapshot>;
-    }),
-    listUserSavedPackages(input.env, input.userId).catch((error) => {
-      recordInventoryError("saved packages", error);
-      return [] as Array<UserSavedPackageSnapshot>;
-    }),
-    listUserRepoSessions(input.env, input.userId).catch((error) => {
-      recordInventoryError("repo sessions", error);
-      return [] as Array<UserRepoSessionSnapshot>;
-    }),
-    listUserMcpServers(input.env, input.userId).catch((error) => {
-      recordInventoryError("MCP servers", error);
-      return [] as Array<UserMcpServerSnapshot>;
-    }),
-    listMcpAgentSessionsForUser(input.env.APP_DB, input.userId).catch(
-      (error) => {
-        recordInventoryError("MCP agent sessions", error);
-        return [] as Array<McpAgentSession>;
-      },
-    ),
-  ]);
-  const bundleKvKeys = await listUserBundleKvKeys({
-    env: input.env,
-    userId: input.userId,
-    sourceSnapshots,
-    communityListings: r2Inventory.communityListings,
-  }).catch((error) => {
-    recordInventoryError("bundle KV keys", error);
-    return [] as Array<string>;
-  });
-  if (inventoryErrors.length > 0) {
-    throw new AccountDeletionInventoryError(inventoryErrors);
-  }
-  return {
-    stripeCustomerId,
-    vectorIds,
-    storageIds,
-    bundleKvKeys,
-    r2Objects: r2Inventory.objects,
-    sourceSnapshots,
-    savedPackages,
-    repoSessions,
-    mcpServers,
-    mcpAgentSessions,
-    communityListings: r2Inventory.communityListings,
-  };
+	const inventoryErrors: Array<string> = []
+	const recordInventoryError = (label: string, error: unknown) => {
+		const warning = `Failed to enumerate ${label}: ${getErrorMessage(error)}`
+		input.warnings.push(warning)
+		inventoryErrors.push(warning)
+	}
+	const [
+		stripeCustomerId,
+		vectorIds,
+		storageIds,
+		r2Inventory,
+		sourceSnapshots,
+		savedPackages,
+		repoSessions,
+		mcpServers,
+		mcpAgentSessions,
+	] = await Promise.all([
+		getUserStripeCustomerId(input.env, input.dbUserId).catch((error) => {
+			recordInventoryError('Stripe customer id', error)
+			return null
+		}),
+		listUserVectorIds(input.env, input.userId).catch((error) => {
+			recordInventoryError('vector ids', error)
+			return [] as Array<string>
+		}),
+		listUserStorageIds(input.env, input.userId).catch((error) => {
+			recordInventoryError('storage ids', error)
+			return [] as Array<string>
+		}),
+		collectAccountR2Inventory({
+			env: input.env,
+			userId: input.userId,
+			dbUserId: input.dbUserId,
+		}).catch((error) => {
+			recordInventoryError('R2 objects', error)
+			return {
+				objects: [] as Array<AccountR2ObjectRef>,
+				communityListings: [] as Array<AccountCommunityListingSnapshot>,
+			}
+		}),
+		listUserSourceSnapshots(input.env, input.userId).catch((error) => {
+			recordInventoryError('source snapshots', error)
+			return [] as Array<UserSourceSnapshot>
+		}),
+		listUserSavedPackages(input.env, input.userId).catch((error) => {
+			recordInventoryError('saved packages', error)
+			return [] as Array<UserSavedPackageSnapshot>
+		}),
+		listUserRepoSessions(input.env, input.userId).catch((error) => {
+			recordInventoryError('repo sessions', error)
+			return [] as Array<UserRepoSessionSnapshot>
+		}),
+		listUserMcpServers(input.env, input.userId).catch((error) => {
+			recordInventoryError('MCP servers', error)
+			return [] as Array<UserMcpServerSnapshot>
+		}),
+		listMcpAgentSessionsForUser(input.env.APP_DB, input.userId).catch(
+			(error) => {
+				recordInventoryError('MCP agent sessions', error)
+				return [] as Array<McpAgentSession>
+			},
+		),
+	])
+	const bundleKvKeys = await listUserBundleKvKeys({
+		env: input.env,
+		userId: input.userId,
+		sourceSnapshots,
+		communityListings: r2Inventory.communityListings,
+	}).catch((error) => {
+		recordInventoryError('bundle KV keys', error)
+		return [] as Array<string>
+	})
+	if (inventoryErrors.length > 0) {
+		throw new AccountDeletionInventoryError(inventoryErrors)
+	}
+	return {
+		stripeCustomerId,
+		vectorIds,
+		storageIds,
+		bundleKvKeys,
+		r2Objects: r2Inventory.objects,
+		sourceSnapshots,
+		savedPackages,
+		repoSessions,
+		mcpServers,
+		mcpAgentSessions,
+		communityListings: r2Inventory.communityListings,
+	}
 }
 
 async function cancelSubscriptionsAndDeleteStripeCustomer(input: {
-  env: Env;
-  customerId: string;
+	env: Env
+	customerId: string
 }) {
-  const failures: Array<unknown> = [];
-  try {
-    const subscriptions = await listSubscriptions(input.env, input.customerId);
-    for (const subscription of subscriptions) {
-      if (
-        !stripeSubscriptionStatusesCanceledOnAccountDeletion.has(
-          subscription.status,
-        )
-      ) {
-        continue;
-      }
-      try {
-        await cancelSubscription(input.env, subscription.id);
-      } catch (error) {
-        failures.push(error);
-      }
-    }
-  } catch (error) {
-    failures.push(error);
-  }
+	const failures: Array<unknown> = []
+	try {
+		const subscriptions = await listSubscriptions(input.env, input.customerId)
+		for (const subscription of subscriptions) {
+			if (
+				!stripeSubscriptionStatusesCanceledOnAccountDeletion.has(
+					subscription.status,
+				)
+			) {
+				continue
+			}
+			try {
+				await cancelSubscription(input.env, subscription.id)
+			} catch (error) {
+				failures.push(error)
+			}
+		}
+	} catch (error) {
+		failures.push(error)
+	}
 
-  // Customer deletion is still attempted when listing or canceling a
-  // subscription fails. Stripe customer deletion also cancels active
-  // subscriptions, so this is the most important final cleanup attempt.
-  try {
-    await deleteCustomer(input.env, input.customerId);
-  } catch (error) {
-    failures.push(error);
-  }
+	// Customer deletion is still attempted when listing or canceling a
+	// subscription fails. Stripe customer deletion also cancels active
+	// subscriptions, so this is the most important final cleanup attempt.
+	try {
+		await deleteCustomer(input.env, input.customerId)
+	} catch (error) {
+		failures.push(error)
+	}
 
-  if (failures.length > 0) {
-    throw new AggregateError(
-      failures,
-      `Stripe account cleanup encountered ${failures.length} failure(s).`,
-    );
-  }
+	if (failures.length > 0) {
+		throw new AggregateError(
+			failures,
+			`Stripe account cleanup encountered ${failures.length} failure(s).`,
+		)
+	}
 }
 
 async function clearStorageRunners(input: {
-  env: Env;
-  userId: string;
-  storageIds: ReadonlyArray<string>;
-  warnings: Array<string>;
+	env: Env
+	userId: string
+	storageIds: ReadonlyArray<string>
+	warnings: Array<string>
 }): Promise<number> {
-  let cleared = 0;
-  for (const storageId of input.storageIds) {
-    try {
-      const stub = storageRunnerRpc({
-        env: input.env,
-        userId: input.userId,
-        storageId,
-      });
-      await stub.clearStorage();
-      cleared += 1;
-    } catch (error) {
-      const message = getErrorMessage(error);
-      input.warnings.push(
-        `Storage runner clear failed for ${storageId}: ${message}`,
-      );
-    }
-  }
-  return cleared;
+	let cleared = 0
+	for (const storageId of input.storageIds) {
+		try {
+			const stub = storageRunnerRpc({
+				env: input.env,
+				userId: input.userId,
+				storageId,
+			})
+			await stub.clearStorage()
+			cleared += 1
+		} catch (error) {
+			const message = getErrorMessage(error)
+			input.warnings.push(
+				`Storage runner clear failed for ${storageId}: ${message}`,
+			)
+		}
+	}
+	return cleared
 }
 
 async function clearRunLog(input: {
-  env: Env;
-  userId: string;
-  warnings: Array<string>;
+	env: Env
+	userId: string
+	warnings: Array<string>
 }): Promise<number> {
-  try {
-    if (!(input.env as Partial<Env>).RUN_LOG) {
-      input.warnings.push(
-        "RUN_LOG binding was unavailable; the user run log Durable Object was not purged.",
-      );
-      return 0;
-    }
-    await clearRunRecords({ env: input.env, userId: input.userId });
-    return 1;
-  } catch (error) {
-    const message = getErrorMessage(error);
-    input.warnings.push(`Run log clear failed: ${message}`);
-    return 0;
-  }
+	try {
+		if (!(input.env as Partial<Env>).RUN_LOG) {
+			input.warnings.push(
+				'RUN_LOG binding was unavailable; the user run log Durable Object was not purged.',
+			)
+			return 0
+		}
+		await clearRunRecords({ env: input.env, userId: input.userId })
+		return 1
+	} catch (error) {
+		const message = getErrorMessage(error)
+		input.warnings.push(`Run log clear failed: ${message}`)
+		return 0
+	}
 }
 
 async function purgeUserMeter(input: {
-  env: Env;
-  userId: string;
-  warnings: Array<string>;
+	env: Env
+	userId: string
+	warnings: Array<string>
 }): Promise<number> {
-  try {
-    if (!userMeterNamespace(input.env)) {
-      input.warnings.push(
-        "USER_METER binding was unavailable; the user meter Durable Object was not purged.",
-      );
-      return 0;
-    }
-    await userMeterRpc({ env: input.env, userId: input.userId }).purge();
-    return 1;
-  } catch (error) {
-    const message = getErrorMessage(error);
-    input.warnings.push(`User meter purge failed: ${message}`);
-    return 0;
-  }
+	try {
+		if (!userMeterNamespace(input.env)) {
+			input.warnings.push(
+				'USER_METER binding was unavailable; the user meter Durable Object was not purged.',
+			)
+			return 0
+		}
+		await userMeterRpc({ env: input.env, userId: input.userId }).purge()
+		return 1
+	} catch (error) {
+		const message = getErrorMessage(error)
+		input.warnings.push(`User meter purge failed: ${message}`)
+		return 0
+	}
 }
 
 async function purgeStripePlanRefresh(input: {
-  env: Env;
-  userId: string;
-  warnings: Array<string>;
+	env: Env
+	userId: string
+	warnings: Array<string>
 }): Promise<number> {
-  try {
-    const result = await purgeStripePlanRefreshForUser({
-      env: input.env,
-      userId: input.userId,
-    });
-    if (!result.purged) {
-      input.warnings.push(
-        "STRIPE_PLAN_REFRESH binding was unavailable; the user Stripe refresh alarm was not purged.",
-      );
-    }
-    return result.purged ? 1 : 0;
-  } catch (error) {
-    const message = getErrorMessage(error);
-    input.warnings.push(`Stripe plan refresh purge failed: ${message}`);
-    return 0;
-  }
+	try {
+		const result = await purgeStripePlanRefreshForUser({
+			env: input.env,
+			userId: input.userId,
+		})
+		if (!result.purged) {
+			input.warnings.push(
+				'STRIPE_PLAN_REFRESH binding was unavailable; the user Stripe refresh alarm was not purged.',
+			)
+		}
+		return result.purged ? 1 : 0
+	} catch (error) {
+		const message = getErrorMessage(error)
+		input.warnings.push(`Stripe plan refresh purge failed: ${message}`)
+		return 0
+	}
 }
 
 async function purgeMailbox(input: {
-  env: Env;
-  userId: string;
-  warnings: Array<string>;
+	env: Env
+	userId: string
+	warnings: Array<string>
 }): Promise<number> {
-  try {
-    await mailboxRpc({ env: input.env, userId: input.userId }).purge({
-      ownerId: input.userId,
-    });
-    return 1;
-  } catch (error) {
-    const message = getErrorMessage(error);
-    input.warnings.push(`Mailbox purge failed: ${message}`);
-    return 0;
-  }
+	try {
+		await mailboxRpc({ env: input.env, userId: input.userId }).purge({
+			ownerId: input.userId,
+		})
+		return 1
+	} catch (error) {
+		const message = getErrorMessage(error)
+		input.warnings.push(`Mailbox purge failed: ${message}`)
+		return 0
+	}
 }
 
 async function purgeJobManager(input: {
-  env: Env;
-  userId: string;
-  warnings: Array<string>;
+	env: Env
+	userId: string
+	warnings: Array<string>
 }): Promise<number> {
-  try {
-    const result = await purgeJobManagerForUser({
-      env: input.env,
-      userId: input.userId,
-    });
-    if (!result.purged) {
-      input.warnings.push(
-        "JOBS service binding was unavailable; the user scheduler Durable Object was not purged.",
-      );
-    }
-    return result.purged ? 1 : 0;
-  } catch (error) {
-    const message = getErrorMessage(error);
-    input.warnings.push(`Job manager purge failed: ${message}`);
-    return 0;
-  }
+	try {
+		const result = await purgeJobManagerForUser({
+			env: input.env,
+			userId: input.userId,
+		})
+		if (!result.purged) {
+			input.warnings.push(
+				'JOBS service binding was unavailable; the user scheduler Durable Object was not purged.',
+			)
+		}
+		return result.purged ? 1 : 0
+	} catch (error) {
+		const message = getErrorMessage(error)
+		input.warnings.push(`Job manager purge failed: ${message}`)
+		return 0
+	}
 }
 
 async function purgeRepoSessions(input: {
-  env: Env;
-  userId: string;
-  sessions: ReadonlyArray<UserRepoSessionSnapshot>;
-  warnings: Array<string>;
+	env: Env
+	userId: string
+	sessions: ReadonlyArray<UserRepoSessionSnapshot>
+	warnings: Array<string>
 }): Promise<number> {
-  let purged = 0;
-  for (const session of input.sessions) {
-    try {
-      await repoSessionRpc(input.env, session.id).purgeSession({
-        sessionId: session.id,
-        userId: input.userId,
-      });
-      purged += 1;
-    } catch (error) {
-      const message = getErrorMessage(error);
-      input.warnings.push(
-        `Repo session purge failed for ${session.id}: ${message}`,
-      );
-    }
-  }
-  return purged;
+	let purged = 0
+	for (const session of input.sessions) {
+		try {
+			await repoSessionRpc(input.env, session.id).purgeSession({
+				sessionId: session.id,
+				userId: input.userId,
+			})
+			purged += 1
+		} catch (error) {
+			const message = getErrorMessage(error)
+			input.warnings.push(
+				`Repo session purge failed for ${session.id}: ${message}`,
+			)
+		}
+	}
+	return purged
 }
 
 async function purgeRepoSessionIndex(input: {
-  env: Env;
-  userId: string;
-  warnings: Array<string>;
+	env: Env
+	userId: string
+	warnings: Array<string>
 }): Promise<number> {
-  try {
-    await repoSessionIndexRpc({
-      env: input.env,
-      userId: input.userId,
-    }).purge({ ownerId: input.userId });
-    return 1;
-  } catch (error) {
-    const message = getErrorMessage(error);
-    input.warnings.push(`Repo session index purge failed: ${message}`);
-    return 0;
-  }
+	try {
+		await repoSessionIndexRpc({
+			env: input.env,
+			userId: input.userId,
+		}).purge({ ownerId: input.userId })
+		return 1
+	} catch (error) {
+		const message = getErrorMessage(error)
+		input.warnings.push(`Repo session index purge failed: ${message}`)
+		return 0
+	}
 }
 
 async function purgeMcpClientHub(input: {
-  env: Env;
-  userId: string;
-  warnings: Array<string>;
+	env: Env
+	userId: string
+	warnings: Array<string>
 }): Promise<number> {
-  // Always purge, even when no mcp_server_settings rows remain: the hub DO
-  // can still hold OAuth tokens and SDK registrations (for example after a
-  // failed add), and those must not survive account deletion.
-  const namespace = input.env.MCP_CLIENT_HUB;
-  if (!namespace) {
-    input.warnings.push(
-      "MCP_CLIENT_HUB binding was unavailable; the MCP client hub was not purged.",
-    );
-    return 0;
-  }
-  try {
-    const stub = namespace.get(
-      namespace.idFromName(mcpClientHubDurableObjectName(input.userId)),
-    ) as unknown as {
-      purgeForAccountDeletion: () => Promise<void>;
-    };
-    await stub.purgeForAccountDeletion();
-    return 1;
-  } catch (error) {
-    const message = getErrorMessage(error);
-    input.warnings.push(`MCP client hub purge failed: ${message}`);
-    return 0;
-  }
+	// Always purge, even when no mcp_server_settings rows remain: the hub DO
+	// can still hold OAuth tokens and SDK registrations (for example after a
+	// failed add), and those must not survive account deletion.
+	const namespace = input.env.MCP_CLIENT_HUB
+	if (!namespace) {
+		input.warnings.push(
+			'MCP_CLIENT_HUB binding was unavailable; the MCP client hub was not purged.',
+		)
+		return 0
+	}
+	try {
+		const stub = namespace.get(
+			namespace.idFromName(mcpClientHubDurableObjectName(input.userId)),
+		) as unknown as {
+			purgeForAccountDeletion: () => Promise<void>
+		}
+		await stub.purgeForAccountDeletion()
+		return 1
+	} catch (error) {
+		const message = getErrorMessage(error)
+		input.warnings.push(`MCP client hub purge failed: ${message}`)
+		return 0
+	}
 }
 
 async function purgeMcpAgentSessions(input: {
-  env: Env;
-  userId: string;
-  sessions: ReadonlyArray<McpAgentSession>;
-  warnings: Array<string>;
+	env: Env
+	userId: string
+	sessions: ReadonlyArray<McpAgentSession>
+	warnings: Array<string>
 }) {
-  const namespace = input.env.MCP_OBJECT;
-  if (!namespace) {
-    if (input.sessions.length > 0) {
-      input.warnings.push(
-        `MCP_OBJECT binding was unavailable; ${input.sessions.length} MCP agent session(s) were not purged.`,
-      );
-    }
-    return 0;
-  }
-  let purged = 0;
-  for (const session of input.sessions) {
-    try {
-      const stub = namespace.get(
-        namespace.idFromString(session.doId),
-      ) as unknown as {
-        purgeForAccountDeletion: (payload: { userId: string }) => Promise<void>;
-      };
-      await stub.purgeForAccountDeletion({ userId: input.userId });
-      purged += 1;
-    } catch (error) {
-      input.warnings.push(
-        `MCP agent session purge failed for ${session.doId}: ${getErrorMessage(error)}`,
-      );
-    }
-  }
-  return purged;
+	const namespace = input.env.MCP_OBJECT
+	if (!namespace) {
+		if (input.sessions.length > 0) {
+			input.warnings.push(
+				`MCP_OBJECT binding was unavailable; ${input.sessions.length} MCP agent session(s) were not purged.`,
+			)
+		}
+		return 0
+	}
+	let purged = 0
+	for (const session of input.sessions) {
+		try {
+			const stub = namespace.get(
+				namespace.idFromString(session.doId),
+			) as unknown as {
+				purgeForAccountDeletion: (payload: { userId: string }) => Promise<void>
+			}
+			await stub.purgeForAccountDeletion({ userId: input.userId })
+			purged += 1
+		} catch (error) {
+			input.warnings.push(
+				`MCP agent session purge failed for ${session.doId}: ${getErrorMessage(error)}`,
+			)
+		}
+	}
+	return purged
 }
 
 async function purgePackageRealtimeSessions(input: {
-  env: Env;
-  userId: string;
-  packages: ReadonlyArray<UserSavedPackageSnapshot>;
-  warnings: Array<string>;
+	env: Env
+	userId: string
+	packages: ReadonlyArray<UserSavedPackageSnapshot>
+	warnings: Array<string>
 }): Promise<number> {
-  let purged = 0;
-  for (const savedPackage of input.packages.filter((pkg) => pkg.hasApp)) {
-    try {
-      await packageRealtimeSessionRpc({
-        env: input.env,
-        userId: input.userId,
-        packageId: savedPackage.id,
-        kodyId: savedPackage.kodyId,
-        sourceId: savedPackage.sourceId,
-        baseUrl: "https://account-deletion.invalid",
-      }).purge();
-      purged += 1;
-    } catch (error) {
-      const message = getErrorMessage(error);
-      input.warnings.push(
-        `Package realtime session purge failed for ${savedPackage.id}: ${message}`,
-      );
-    }
-  }
-  return purged;
+	let purged = 0
+	for (const savedPackage of input.packages.filter((pkg) => pkg.hasApp)) {
+		try {
+			await packageRealtimeSessionRpc({
+				env: input.env,
+				userId: input.userId,
+				packageId: savedPackage.id,
+				kodyId: savedPackage.kodyId,
+				sourceId: savedPackage.sourceId,
+				baseUrl: 'https://account-deletion.invalid',
+			}).purge()
+			purged += 1
+		} catch (error) {
+			const message = getErrorMessage(error)
+			input.warnings.push(
+				`Package realtime session purge failed for ${savedPackage.id}: ${message}`,
+			)
+		}
+	}
+	return purged
 }
 
 async function deleteVectorsByIds(input: {
-  env: Env;
-  ids: ReadonlyArray<string>;
-  warnings: Array<string>;
+	env: Env
+	ids: ReadonlyArray<string>
+	warnings: Array<string>
 }): Promise<number> {
-  if (input.ids.length === 0) return 0;
-  const index = getCapabilityVectorIndex(input.env);
-  if (!index) {
-    input.warnings.push(
-      `CAPABILITY_VECTOR_INDEX binding was unavailable; ${input.ids.length} user vector(s) were not removed.`,
-    );
-    return 0;
-  }
-  let deleted = 0;
-  const batchSize = 100;
-  for (let offset = 0; offset < input.ids.length; offset += batchSize) {
-    const batch = input.ids.slice(offset, offset + batchSize);
-    try {
-      await index.deleteByIds(batch);
-      deleted += batch.length;
-    } catch (error) {
-      const message = getErrorMessage(error);
-      input.warnings.push(`Vectorize deleteByIds batch failed: ${message}`);
-    }
-  }
-  return deleted;
+	if (input.ids.length === 0) return 0
+	const index = getCapabilityVectorIndex(input.env)
+	if (!index) {
+		input.warnings.push(
+			`CAPABILITY_VECTOR_INDEX binding was unavailable; ${input.ids.length} user vector(s) were not removed.`,
+		)
+		return 0
+	}
+	let deleted = 0
+	const batchSize = 100
+	for (let offset = 0; offset < input.ids.length; offset += batchSize) {
+		const batch = input.ids.slice(offset, offset + batchSize)
+		try {
+			await index.deleteByIds(batch)
+			deleted += batch.length
+		} catch (error) {
+			const message = getErrorMessage(error)
+			input.warnings.push(`Vectorize deleteByIds batch failed: ${message}`)
+		}
+	}
+	return deleted
 }
 
 async function deleteKvKeys(input: {
-  kv: KVNamespace;
-  keys: ReadonlyArray<string>;
-  warnings: Array<string>;
+	kv: KVNamespace
+	keys: ReadonlyArray<string>
+	warnings: Array<string>
 }): Promise<number> {
-  let deleted = 0;
-  for (const key of input.keys) {
-    try {
-      await input.kv.delete(key);
-      deleted += 1;
-    } catch (error) {
-      const message = getErrorMessage(error);
-      input.warnings.push(`KV delete failed for ${key}: ${message}`);
-    }
-  }
-  return deleted;
+	let deleted = 0
+	for (const key of input.keys) {
+		try {
+			await input.kv.delete(key)
+			deleted += 1
+		} catch (error) {
+			const message = getErrorMessage(error)
+			input.warnings.push(`KV delete failed for ${key}: ${message}`)
+		}
+	}
+	return deleted
 }
 
 async function deleteR2Objects(input: {
-  blobs: R2Bucket;
-  keys: ReadonlyArray<string>;
-  label: string;
-  warnings: Array<string>;
+	blobs: R2Bucket
+	keys: ReadonlyArray<string>
+	label: string
+	warnings: Array<string>
 }): Promise<{ deleted: number; complete: boolean }> {
-  let deleted = 0;
-  let complete = true;
-  for (const key of input.keys) {
-    try {
-      await input.blobs.delete(key);
-      deleted += 1;
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      input.warnings.push(
-        `${input.label} delete failed for ${key}: ${message}`,
-      );
-      complete = false;
-    }
-  }
-  return { deleted, complete };
+	let deleted = 0
+	let complete = true
+	for (const key of input.keys) {
+		try {
+			await input.blobs.delete(key)
+			deleted += 1
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error)
+			input.warnings.push(`${input.label} delete failed for ${key}: ${message}`)
+			complete = false
+		}
+	}
+	return { deleted, complete }
 }
 
 type AccountEmailCleanupOutcome = {
-  deletedEmailBlobs: number;
-  emailCleanupComplete: boolean;
-};
+	deletedEmailBlobs: number
+	emailCleanupComplete: boolean
+}
 
 async function cleanupAccountEmailBlobs(input: {
-  env: Env;
-  userId: string;
-  r2Objects: ReadonlyArray<AccountR2ObjectRef>;
-  warnings: Array<string>;
+	env: Env
+	userId: string
+	r2Objects: ReadonlyArray<AccountR2ObjectRef>
+	warnings: Array<string>
 }): Promise<AccountEmailCleanupOutcome> {
-  const emailBlobs = input.env.EMAIL_BLOBS;
-  if (!emailBlobs) {
-    input.warnings.push(
-      "EMAIL_BLOBS binding was unavailable; email objects were not removed.",
-    );
-    return { deletedEmailBlobs: 0, emailCleanupComplete: false };
-  }
+	const emailBlobs = input.env.EMAIL_BLOBS
+	if (!emailBlobs) {
+		input.warnings.push(
+			'EMAIL_BLOBS binding was unavailable; email objects were not removed.',
+		)
+		return { deletedEmailBlobs: 0, emailCleanupComplete: false }
+	}
 
-  let deletedEmailBlobs = 0;
-  let emailCleanupComplete = true;
-  try {
-    deletedEmailBlobs = await deleteAccountEmailBlobPrefixes({
-      bucket: emailBlobs,
-      stableUserId: input.userId,
-    });
-  } catch (error) {
-    input.warnings.push(getErrorMessage(error));
-    emailCleanupComplete = false;
-  }
-  const exactDeletes = await deleteR2Objects({
-    blobs: emailBlobs,
-    keys: input.r2Objects
-      .filter((object) => object.binding === "EMAIL_BLOBS")
-      .filter(
-        (object) =>
-          !object.key.startsWith(`email-raw:v1:${input.userId}/`) &&
-          !object.key.startsWith(`email-attachment:v1:${input.userId}/`),
-      )
-      .map((object) => object.key),
-    label: "Email blob",
-    warnings: input.warnings,
-  });
-  deletedEmailBlobs += exactDeletes.deleted;
-  return {
-    deletedEmailBlobs,
-    emailCleanupComplete: emailCleanupComplete && exactDeletes.complete,
-  };
+	let deletedEmailBlobs = 0
+	let emailCleanupComplete = true
+	try {
+		deletedEmailBlobs = await deleteAccountEmailBlobPrefixes({
+			bucket: emailBlobs,
+			stableUserId: input.userId,
+		})
+	} catch (error) {
+		input.warnings.push(getErrorMessage(error))
+		emailCleanupComplete = false
+	}
+	const exactDeletes = await deleteR2Objects({
+		blobs: emailBlobs,
+		keys: input.r2Objects
+			.filter((object) => object.binding === 'EMAIL_BLOBS')
+			.filter(
+				(object) =>
+					!object.key.startsWith(`email-raw:v1:${input.userId}/`) &&
+					!object.key.startsWith(`email-attachment:v1:${input.userId}/`),
+			)
+			.map((object) => object.key),
+		label: 'Email blob',
+		warnings: input.warnings,
+	})
+	deletedEmailBlobs += exactDeletes.deleted
+	return {
+		deletedEmailBlobs,
+		emailCleanupComplete: emailCleanupComplete && exactDeletes.complete,
+	}
 }
 
 async function listKvKeysByPrefix(input: {
-  kv: KVNamespace;
-  prefixes: ReadonlyArray<string>;
-  warnings: Array<string>;
+	kv: KVNamespace
+	prefixes: ReadonlyArray<string>
+	warnings: Array<string>
 }) {
-  const keys = new Set<string>();
-  if (typeof input.kv.list !== "function") return keys;
-  for (const prefix of input.prefixes) {
-    let cursor: string | undefined;
-    do {
-      try {
-        const result = await input.kv.list({
-          prefix,
-          cursor,
-        });
-        for (const key of result.keys) {
-          keys.add(key.name);
-        }
-        cursor = result.list_complete ? undefined : result.cursor;
-      } catch (error) {
-        const message = getErrorMessage(error);
-        input.warnings.push(
-          `KV prefix listing failed for ${prefix}: ${message}`,
-        );
-        cursor = undefined;
-      }
-    } while (cursor);
-  }
-  return keys;
+	const keys = new Set<string>()
+	if (typeof input.kv.list !== 'function') return keys
+	for (const prefix of input.prefixes) {
+		let cursor: string | undefined
+		do {
+			try {
+				const result = await input.kv.list({
+					prefix,
+					cursor,
+				})
+				for (const key of result.keys) {
+					keys.add(key.name)
+				}
+				cursor = result.list_complete ? undefined : result.cursor
+			} catch (error) {
+				const message = getErrorMessage(error)
+				input.warnings.push(
+					`KV prefix listing failed for ${prefix}: ${message}`,
+				)
+				cursor = undefined
+			}
+		} while (cursor)
+	}
+	return keys
 }
 
 async function deleteRetrieverCache(input: {
-  env: Env;
-  userId: string;
-  warnings: Array<string>;
+	env: Env
+	userId: string
+	warnings: Array<string>
 }) {
-  try {
-    return await deleteAllPackageRetrieverCacheEntriesForUser({
-      env: input.env,
-      userId: input.userId,
-    });
-  } catch (error) {
-    const message = getErrorMessage(error);
-    input.warnings.push(`Package retriever KV cleanup failed: ${message}`);
-    return 0;
-  }
+	try {
+		return await deleteAllPackageRetrieverCacheEntriesForUser({
+			env: input.env,
+			userId: input.userId,
+		})
+	} catch (error) {
+		const message = getErrorMessage(error)
+		input.warnings.push(`Package retriever KV cleanup failed: ${message}`)
+		return 0
+	}
 }
 
 async function deleteUserScopedRowsAndUser(input: {
-  env: Env;
-  mcpUserId: string;
-  dbUserId: number;
+	env: Env
+	mcpUserId: string
+	dbUserId: number
 }): Promise<{
-  deletedRowCounts: Record<string, number>;
-  updatedRowCounts: Record<string, number>;
+	deletedRowCounts: Record<string, number>
+	updatedRowCounts: Record<string, number>
 }> {
-  const deletedRowCounts: Record<string, number> = {};
-  const updatedRowCounts: Record<string, number> = {};
-  function recordDeleted(tableName: string, changes: number | undefined) {
-    deletedRowCounts[tableName] =
-      (deletedRowCounts[tableName] ?? 0) + (changes ?? 0);
-  }
-  function recordUpdated(tableName: string, changes: number | undefined) {
-    updatedRowCounts[tableName] =
-      (updatedRowCounts[tableName] ?? 0) + (changes ?? 0);
-  }
-  const operations = accountUserDataTargets.map((target) => {
-    const match = buildUserScopedTargetMatch({
-      target,
-      mcpUserId: input.mcpUserId,
-      dbUserId: input.dbUserId,
-    });
-    const { sql, params } = buildUserScopedDeleteOrUpdateSql(match);
-    return {
-      match,
-      statement: input.env.APP_DB.prepare(sql).bind(...params),
-    };
-  });
-  const userStatement = input.env.APP_DB.prepare(
-    `DELETE FROM users WHERE id = ?`,
-  ).bind(input.dbUserId);
-  const results = await input.env.APP_DB.batch([
-    ...operations.map((operation) => operation.statement),
-    userStatement,
-  ]);
-  for (const [index, operation] of operations.entries()) {
-    const changes = results[index]?.meta.changes;
-    if (operation.match.mutation.kind === "delete") {
-      recordDeleted(operation.match.table, changes);
-    } else {
-      recordUpdated(operation.match.table, changes);
-    }
-  }
-  deletedRowCounts.users = results.at(-1)?.meta.changes ?? 0;
-  return { deletedRowCounts, updatedRowCounts };
+	const deletedRowCounts: Record<string, number> = {}
+	const updatedRowCounts: Record<string, number> = {}
+	function recordDeleted(tableName: string, changes: number | undefined) {
+		deletedRowCounts[tableName] =
+			(deletedRowCounts[tableName] ?? 0) + (changes ?? 0)
+	}
+	function recordUpdated(tableName: string, changes: number | undefined) {
+		updatedRowCounts[tableName] =
+			(updatedRowCounts[tableName] ?? 0) + (changes ?? 0)
+	}
+	const operations = accountUserDataTargets.map((target) => {
+		const match = buildUserScopedTargetMatch({
+			target,
+			mcpUserId: input.mcpUserId,
+			dbUserId: input.dbUserId,
+		})
+		const { sql, params } = buildUserScopedDeleteOrUpdateSql(match)
+		return {
+			match,
+			statement: input.env.APP_DB.prepare(sql).bind(...params),
+		}
+	})
+	const userStatement = input.env.APP_DB.prepare(
+		`DELETE FROM users WHERE id = ?`,
+	).bind(input.dbUserId)
+	const results = await input.env.APP_DB.batch([
+		...operations.map((operation) => operation.statement),
+		userStatement,
+	])
+	for (const [index, operation] of operations.entries()) {
+		const changes = results[index]?.meta.changes
+		if (operation.match.mutation.kind === 'delete') {
+			recordDeleted(operation.match.table, changes)
+		} else {
+			recordUpdated(operation.match.table, changes)
+		}
+	}
+	deletedRowCounts.users = results.at(-1)?.meta.changes ?? 0
+	return { deletedRowCounts, updatedRowCounts }
 }
 
 /**
@@ -986,338 +980,338 @@ async function deleteUserScopedRowsAndUser(input: {
  *   4. Atomically delete user-scoped D1 rows and the user row in one batch.
  */
 export async function deleteUserAccount(input: {
-  env: AccountDeletionEnv;
-  dbUserId: number;
-  mcpUserId: string;
+	env: AccountDeletionEnv
+	dbUserId: number
+	mcpUserId: string
 }): Promise<AccountDeletionResult> {
-  const marked = await markAccountDeleting({
-    db: input.env.APP_DB,
-    dbUserId: input.dbUserId,
-    env: input.env,
-  });
-  if (marked.leaseCount > 0) {
-    if (marked.created) {
-      await abortAccountDeleting({
-        db: input.env.APP_DB,
-        dbUserId: input.dbUserId,
-        env: input.env,
-        expectedDeletingAt: marked.deletingAt,
-      });
-    }
-    throw new AccountDeletionWritersActiveError(marked.leaseCount);
-  }
-  const warnings: Array<string> = [];
-  const clearedDurableObjects: Record<string, number> = {};
-  for (const key of getAccountDeletionDurableObjectResultKeys()) {
-    clearedDurableObjects[key] = 0;
-  }
-  const result: AccountDeletionResult = {
-    deletedRowCounts: {},
-    updatedRowCounts: {},
-    deletedKvKeys: 0,
-    deletedCommunityAssets: 0,
-    deletedEmailBlobs: 0,
-    deletedArtifactRepos: 0,
-    revokedOAuthGrants: 0,
-    clearedDurableObjects,
-    deletedVectors: 0,
-    warnings,
-  };
+	const marked = await markAccountDeleting({
+		db: input.env.APP_DB,
+		dbUserId: input.dbUserId,
+		env: input.env,
+	})
+	if (marked.leaseCount > 0) {
+		if (marked.created) {
+			await abortAccountDeleting({
+				db: input.env.APP_DB,
+				dbUserId: input.dbUserId,
+				env: input.env,
+				expectedDeletingAt: marked.deletingAt,
+			})
+		}
+		throw new AccountDeletionWritersActiveError(marked.leaseCount)
+	}
+	const warnings: Array<string> = []
+	const clearedDurableObjects: Record<string, number> = {}
+	for (const key of getAccountDeletionDurableObjectResultKeys()) {
+		clearedDurableObjects[key] = 0
+	}
+	const result: AccountDeletionResult = {
+		deletedRowCounts: {},
+		updatedRowCounts: {},
+		deletedKvKeys: 0,
+		deletedCommunityAssets: 0,
+		deletedEmailBlobs: 0,
+		deletedArtifactRepos: 0,
+		revokedOAuthGrants: 0,
+		clearedDurableObjects,
+		deletedVectors: 0,
+		warnings,
+	}
 
-  let inventory: UserDeletionInventory;
-  try {
-    inventory = await collectUserDeletionInventory({
-      env: input.env,
-      userId: input.mcpUserId,
-      dbUserId: input.dbUserId,
-      warnings,
-    });
-  } catch (error) {
-    if (error instanceof AccountDeletionInventoryError && marked.created) {
-      await abortAccountDeleting({
-        db: input.env.APP_DB,
-        dbUserId: input.dbUserId,
-        env: input.env,
-        expectedDeletingAt: marked.deletingAt,
-      });
-    }
-    throw error;
-  }
+	let inventory: UserDeletionInventory
+	try {
+		inventory = await collectUserDeletionInventory({
+			env: input.env,
+			userId: input.mcpUserId,
+			dbUserId: input.dbUserId,
+			warnings,
+		})
+	} catch (error) {
+		if (error instanceof AccountDeletionInventoryError && marked.created) {
+			await abortAccountDeleting({
+				db: input.env.APP_DB,
+				dbUserId: input.dbUserId,
+				env: input.env,
+				expectedDeletingAt: marked.deletingAt,
+			})
+		}
+		throw error
+	}
 
-  result.deletedVectors = await deleteVectorsByIds({
-    env: input.env,
-    ids: inventory.vectorIds,
-    warnings,
-  });
+	result.deletedVectors = await deleteVectorsByIds({
+		env: input.env,
+		ids: inventory.vectorIds,
+		warnings,
+	})
 
-  result.deletedArtifactRepos = await cleanupAllUserArtifactRepos({
-    env: input.env,
-    userId: input.mcpUserId,
-    warnings,
-  }).catch((error) => {
-    const message = getErrorMessage(error);
-    warnings.push(`Artifact repo cleanup failed unexpectedly: ${message}`);
-    return 0;
-  });
+	result.deletedArtifactRepos = await cleanupAllUserArtifactRepos({
+		env: input.env,
+		userId: input.mcpUserId,
+		warnings,
+	}).catch((error) => {
+		const message = getErrorMessage(error)
+		warnings.push(`Artifact repo cleanup failed unexpectedly: ${message}`)
+		return 0
+	})
 
-  result.clearedDurableObjects.repoSessions = await purgeRepoSessions({
-    env: input.env,
-    userId: input.mcpUserId,
-    sessions: inventory.repoSessions,
-    warnings,
-  });
-  result.clearedDurableObjects.repoSessionIndexes = await purgeRepoSessionIndex(
-    {
-      env: input.env,
-      userId: input.mcpUserId,
-      warnings,
-    },
-  );
-  result.clearedDurableObjects.mcpClientHubs = await purgeMcpClientHub({
-    env: input.env,
-    userId: input.mcpUserId,
-    warnings,
-  });
-  result.clearedDurableObjects.mcpAgentSessions = await purgeMcpAgentSessions({
-    env: input.env,
-    userId: input.mcpUserId,
-    sessions: inventory.mcpAgentSessions,
-    warnings,
-  });
-  result.clearedDurableObjects.packageRealtimeSessions =
-    await purgePackageRealtimeSessions({
-      env: input.env,
-      userId: input.mcpUserId,
-      packages: inventory.savedPackages,
-      warnings,
-    });
-  result.clearedDurableObjects.storageRunners = await clearStorageRunners({
-    env: input.env,
-    userId: input.mcpUserId,
-    storageIds: inventory.storageIds,
-    warnings,
-  });
-  result.clearedDurableObjects.runLogs = await clearRunLog({
-    env: input.env,
-    userId: input.mcpUserId,
-    warnings,
-  });
-  result.clearedDurableObjects.userMeters = await purgeUserMeter({
-    env: input.env,
-    userId: input.mcpUserId,
-    warnings,
-  });
-  result.clearedDurableObjects.stripePlanRefreshes =
-    await purgeStripePlanRefresh({
-      env: input.env,
-      userId: input.mcpUserId,
-      warnings,
-    });
-  if (input.env.BUNDLE_ARTIFACTS_KV) {
-    const sourceSnapshotKeys = await listKvKeysByPrefix({
-      kv: input.env.BUNDLE_ARTIFACTS_KV,
-      prefixes: [
-        ...inventory.sourceSnapshots.flatMap((source) => [
-          `source-snapshot:v1:${source.sourceId}:`,
-          `source-manifest-snapshot:v1:${source.sourceId}:`,
-        ]),
-        ...inventory.communityListings.flatMap((listing) =>
-          communityIconKvListingPrefixes(listing.id),
-        ),
-        // Package-codemod apply snapshots are user-namespaced in KV
-        // (`package-codemod-revert:{userId}:{itemId}`). D1 run items are
-        // deleted separately; purge the orphaned revert trees here rather
-        // than waiting on the 90-day TTL.
-        `package-codemod-revert:${input.mcpUserId}:`,
-      ],
-      warnings,
-    });
-    result.deletedKvKeys =
-      (await deleteKvKeys({
-        kv: input.env.BUNDLE_ARTIFACTS_KV,
-        keys: Array.from(
-          new Set([...inventory.bundleKvKeys, ...sourceSnapshotKeys]),
-        ),
-        warnings,
-      })) +
-      (await deleteRetrieverCache({
-        env: input.env,
-        userId: input.mcpUserId,
-        warnings,
-      }));
-  } else if (
-    inventory.bundleKvKeys.length > 0 ||
-    inventory.savedPackages.length > 0
-  ) {
-    warnings.push(
-      `BUNDLE_ARTIFACTS_KV binding was unavailable; ${inventory.bundleKvKeys.length} bundle/source/community key(s) and retriever cache entries for ${inventory.savedPackages.length} package(s) referenced by the deleted user were not removed and must be cleaned up manually.`,
-    );
-  }
+	result.clearedDurableObjects.repoSessions = await purgeRepoSessions({
+		env: input.env,
+		userId: input.mcpUserId,
+		sessions: inventory.repoSessions,
+		warnings,
+	})
+	result.clearedDurableObjects.repoSessionIndexes = await purgeRepoSessionIndex(
+		{
+			env: input.env,
+			userId: input.mcpUserId,
+			warnings,
+		},
+	)
+	result.clearedDurableObjects.mcpClientHubs = await purgeMcpClientHub({
+		env: input.env,
+		userId: input.mcpUserId,
+		warnings,
+	})
+	result.clearedDurableObjects.mcpAgentSessions = await purgeMcpAgentSessions({
+		env: input.env,
+		userId: input.mcpUserId,
+		sessions: inventory.mcpAgentSessions,
+		warnings,
+	})
+	result.clearedDurableObjects.packageRealtimeSessions =
+		await purgePackageRealtimeSessions({
+			env: input.env,
+			userId: input.mcpUserId,
+			packages: inventory.savedPackages,
+			warnings,
+		})
+	result.clearedDurableObjects.storageRunners = await clearStorageRunners({
+		env: input.env,
+		userId: input.mcpUserId,
+		storageIds: inventory.storageIds,
+		warnings,
+	})
+	result.clearedDurableObjects.runLogs = await clearRunLog({
+		env: input.env,
+		userId: input.mcpUserId,
+		warnings,
+	})
+	result.clearedDurableObjects.userMeters = await purgeUserMeter({
+		env: input.env,
+		userId: input.mcpUserId,
+		warnings,
+	})
+	result.clearedDurableObjects.stripePlanRefreshes =
+		await purgeStripePlanRefresh({
+			env: input.env,
+			userId: input.mcpUserId,
+			warnings,
+		})
+	if (input.env.BUNDLE_ARTIFACTS_KV) {
+		const sourceSnapshotKeys = await listKvKeysByPrefix({
+			kv: input.env.BUNDLE_ARTIFACTS_KV,
+			prefixes: [
+				...inventory.sourceSnapshots.flatMap((source) => [
+					`source-snapshot:v1:${source.sourceId}:`,
+					`source-manifest-snapshot:v1:${source.sourceId}:`,
+				]),
+				...inventory.communityListings.flatMap((listing) =>
+					communityIconKvListingPrefixes(listing.id),
+				),
+				// Package-codemod apply snapshots are user-namespaced in KV
+				// (`package-codemod-revert:{userId}:{itemId}`). D1 run items are
+				// deleted separately; purge the orphaned revert trees here rather
+				// than waiting on the 90-day TTL.
+				`package-codemod-revert:${input.mcpUserId}:`,
+			],
+			warnings,
+		})
+		result.deletedKvKeys =
+			(await deleteKvKeys({
+				kv: input.env.BUNDLE_ARTIFACTS_KV,
+				keys: Array.from(
+					new Set([...inventory.bundleKvKeys, ...sourceSnapshotKeys]),
+				),
+				warnings,
+			})) +
+			(await deleteRetrieverCache({
+				env: input.env,
+				userId: input.mcpUserId,
+				warnings,
+			}))
+	} else if (
+		inventory.bundleKvKeys.length > 0 ||
+		inventory.savedPackages.length > 0
+	) {
+		warnings.push(
+			`BUNDLE_ARTIFACTS_KV binding was unavailable; ${inventory.bundleKvKeys.length} bundle/source/community key(s) and retriever cache entries for ${inventory.savedPackages.length} package(s) referenced by the deleted user were not removed and must be cleaned up manually.`,
+		)
+	}
 
-  try {
-    result.deletedCommunityAssets = await deleteAccountCommunityAssetPrefixes({
-      bucket: input.env.COMMUNITY_ASSETS,
-      stableUserId: input.mcpUserId,
-      listingIds: inventory.communityListings.map((listing) => listing.id),
-    });
-  } catch (error) {
-    warnings.push(getErrorMessage(error));
-  }
-  const emailCleanup = await cleanupAccountEmailBlobs({
-    env: input.env,
-    userId: input.mcpUserId,
-    r2Objects: inventory.r2Objects,
-    warnings,
-  });
-  result.deletedEmailBlobs = emailCleanup.deletedEmailBlobs;
+	try {
+		result.deletedCommunityAssets = await deleteAccountCommunityAssetPrefixes({
+			bucket: input.env.COMMUNITY_ASSETS,
+			stableUserId: input.mcpUserId,
+			listingIds: inventory.communityListings.map((listing) => listing.id),
+		})
+	} catch (error) {
+		warnings.push(getErrorMessage(error))
+	}
+	const emailCleanup = await cleanupAccountEmailBlobs({
+		env: input.env,
+		userId: input.mcpUserId,
+		r2Objects: inventory.r2Objects,
+		warnings,
+	})
+	result.deletedEmailBlobs = emailCleanup.deletedEmailBlobs
 
-  const discordConnection = await input.env.APP_DB.prepare(
-    `SELECT provider_id FROM oauth_connections
+	const discordConnection = await input.env.APP_DB.prepare(
+		`SELECT provider_id FROM oauth_connections
 		 WHERE user_id = ? AND provider_name = 'discord'`,
-  )
-    .bind(input.dbUserId)
-    .first<{ provider_id: string }>()
-    .catch((error) => {
-      warnings.push(
-        `Discord connection lookup failed: ${getErrorMessage(error)}`,
-      );
-      return null;
-    });
-  if (discordConnection?.provider_id) {
-    const discordRoleCleanup = await maybeRemoveDiscordGuildRoles({
-      env: input.env,
-      discordUserId: discordConnection.provider_id,
-    });
-    const discordRoleResult = summarizeDiscordGuildRoleSync(discordRoleCleanup);
-    if (
-      discordRoleResult.status === "error" ||
-      discordRoleResult.status === "forbidden"
-    ) {
-      warnings.push(
-        discordRoleResult.status === "error"
-          ? `Discord role cleanup failed: ${discordRoleResult.message}`
-          : "Discord role cleanup was forbidden.",
-      );
-    }
-  }
+	)
+		.bind(input.dbUserId)
+		.first<{ provider_id: string }>()
+		.catch((error) => {
+			warnings.push(
+				`Discord connection lookup failed: ${getErrorMessage(error)}`,
+			)
+			return null
+		})
+	if (discordConnection?.provider_id) {
+		const discordRoleCleanup = await maybeRemoveDiscordGuildRoles({
+			env: input.env,
+			discordUserId: discordConnection.provider_id,
+		})
+		const discordRoleResult = summarizeDiscordGuildRoleSync(discordRoleCleanup)
+		if (
+			discordRoleResult.status === 'error' ||
+			discordRoleResult.status === 'forbidden'
+		) {
+			warnings.push(
+				discordRoleResult.status === 'error'
+					? `Discord role cleanup failed: ${discordRoleResult.message}`
+					: 'Discord role cleanup was forbidden.',
+			)
+		}
+	}
 
-  const helpers = input.env.OAUTH_PROVIDER;
-  if (helpers) {
-    if (helpers.deleteClient) {
-      const deleteClient = helpers.deleteClient;
-      await deleteOwnedMcpOauthClients({
-        db: input.env.APP_DB,
-        helpers: {
-          async deleteClient(clientId) {
-            await deleteClient(clientId);
-          },
-        },
-        userId: input.dbUserId,
-        warnings,
-      });
-    } else {
-      const ownedClientIds = await listOwnedUserMcpOauthClientIds(
-        input.env.APP_DB,
-        input.dbUserId,
-      );
-      if (ownedClientIds.length > 0) {
-        warnings.push(
-          "OAuth provider does not support client deletion; MCP OAuth clients were not removed.",
-        );
-      }
-    }
-    try {
-      result.revokedOAuthGrants = await revokeAllOAuthGrantsBestEffort({
-        helpers,
-        userId: input.mcpUserId,
-        warnings,
-      });
-    } catch (error) {
-      const message = getErrorMessage(error);
-      warnings.push(`OAuth grant revocation failed unexpectedly: ${message}`);
-    }
-  } else {
-    warnings.push(
-      "OAuth provider binding was unavailable; OAuth grants were not revoked.",
-    );
-  }
+	const helpers = input.env.OAUTH_PROVIDER
+	if (helpers) {
+		if (helpers.deleteClient) {
+			const deleteClient = helpers.deleteClient
+			await deleteOwnedMcpOauthClients({
+				db: input.env.APP_DB,
+				helpers: {
+					async deleteClient(clientId) {
+						await deleteClient(clientId)
+					},
+				},
+				userId: input.dbUserId,
+				warnings,
+			})
+		} else {
+			const ownedClientIds = await listOwnedUserMcpOauthClientIds(
+				input.env.APP_DB,
+				input.dbUserId,
+			)
+			if (ownedClientIds.length > 0) {
+				warnings.push(
+					'OAuth provider does not support client deletion; MCP OAuth clients were not removed.',
+				)
+			}
+		}
+		try {
+			result.revokedOAuthGrants = await revokeAllOAuthGrantsBestEffort({
+				helpers,
+				userId: input.mcpUserId,
+				warnings,
+			})
+		} catch (error) {
+			const message = getErrorMessage(error)
+			warnings.push(`OAuth grant revocation failed unexpectedly: ${message}`)
+		}
+	} else {
+		warnings.push(
+			'OAuth provider binding was unavailable; OAuth grants were not revoked.',
+		)
+	}
 
-  // Keep Mailbox metadata while the account remains deletion-fenced so a retry
-  // can re-enumerate authoritative email keys. The typed email phase prevents
-  // an unrelated warning-list refactor from purging after incomplete email
-  // cleanup; the existing all-surfaces policy additionally requires no warning.
-  if (emailCleanup.emailCleanupComplete && warnings.length === 0) {
-    result.clearedDurableObjects.mailboxes = await purgeMailbox({
-      env: input.env,
-      userId: input.mcpUserId,
-      warnings,
-    });
-  }
+	// Keep Mailbox metadata while the account remains deletion-fenced so a retry
+	// can re-enumerate authoritative email keys. The typed email phase prevents
+	// an unrelated warning-list refactor from purging after incomplete email
+	// cleanup; the existing all-surfaces policy additionally requires no warning.
+	if (emailCleanup.emailCleanupComplete && warnings.length === 0) {
+		result.clearedDurableObjects.mailboxes = await purgeMailbox({
+			env: input.env,
+			userId: input.mcpUserId,
+			warnings,
+		})
+	}
 
-  if (warnings.length > 0) {
-    throw new AccountDeletionCleanupError(warnings, result);
-  }
+	if (warnings.length > 0) {
+		throw new AccountDeletionCleanupError(warnings, result)
+	}
 
-  // Jobs data lives in the jobs worker's database (ADR 0016), so it cannot
-  // join the atomic APP_DB deletion below. Purge it fail-closed here, after
-  // every best-effort cleanup succeeded; a failure aborts before the user row
-  // is removed so a retry can purge again (purgeUser is idempotent).
-  result.clearedDurableObjects.jobManagers = await purgeJobManager({
-    env: input.env,
-    userId: input.mcpUserId,
-    warnings,
-  });
-  if (warnings.length > 0) {
-    throw new AccountDeletionCleanupError(warnings, result);
-  }
+	// Jobs data lives in the jobs worker's database (ADR 0016), so it cannot
+	// join the atomic APP_DB deletion below. Purge it fail-closed here, after
+	// every best-effort cleanup succeeded; a failure aborts before the user row
+	// is removed so a retry can purge again (purgeUser is idempotent).
+	result.clearedDurableObjects.jobManagers = await purgeJobManager({
+		env: input.env,
+		userId: input.mcpUserId,
+		warnings,
+	})
+	if (warnings.length > 0) {
+		throw new AccountDeletionCleanupError(warnings, result)
+	}
 
-  if (inventory.stripeCustomerId) {
-    try {
-      await cancelSubscriptionsAndDeleteStripeCustomer({
-        env: input.env,
-        customerId: inventory.stripeCustomerId,
-      });
-    } catch (error) {
-      const warning = `Stripe customer cleanup failed during account deletion: ${getErrorMessage(error)}`;
-      warnings.push(warning);
-      console.error("account_deletion_stripe_cleanup_failed", {
-        userId: input.mcpUserId,
-        error,
-      });
-    }
-  }
+	if (inventory.stripeCustomerId) {
+		try {
+			await cancelSubscriptionsAndDeleteStripeCustomer({
+				env: input.env,
+				customerId: inventory.stripeCustomerId,
+			})
+		} catch (error) {
+			const warning = `Stripe customer cleanup failed during account deletion: ${getErrorMessage(error)}`
+			warnings.push(warning)
+			console.error('account_deletion_stripe_cleanup_failed', {
+				userId: input.mcpUserId,
+				error,
+			})
+		}
+	}
 
-  try {
-    const d1Cleanup = await deleteUserScopedRowsAndUser({
-      env: input.env,
-      mcpUserId: input.mcpUserId,
-      dbUserId: input.dbUserId,
-    });
-    result.deletedRowCounts = {
-      ...result.deletedRowCounts,
-      ...d1Cleanup.deletedRowCounts,
-    };
-    result.updatedRowCounts = d1Cleanup.updatedRowCounts;
-  } catch (error) {
-    const failure = `Atomic D1 account deletion failed: ${getErrorMessage(error)}`;
-    warnings.push(failure);
-    throw new AccountDeletionCleanupError(warnings, result);
-  }
+	try {
+		const d1Cleanup = await deleteUserScopedRowsAndUser({
+			env: input.env,
+			mcpUserId: input.mcpUserId,
+			dbUserId: input.dbUserId,
+		})
+		result.deletedRowCounts = {
+			...result.deletedRowCounts,
+			...d1Cleanup.deletedRowCounts,
+		}
+		result.updatedRowCounts = d1Cleanup.updatedRowCounts
+	} catch (error) {
+		const failure = `Atomic D1 account deletion failed: ${getErrorMessage(error)}`
+		warnings.push(failure)
+		throw new AccountDeletionCleanupError(warnings, result)
+	}
 
-  // The D1 user row is gone, so a later signup with the same email is a new
-  // account. Drop the UserMeter tombstone `purge()` restored; leaving it
-  // would fence every write (including `/mcp`) for that hashed stable id.
-  try {
-    await clearUserMeterDeletionTombstone({
-      env: input.env,
-      stableUserId: input.mcpUserId,
-    });
-  } catch (error) {
-    console.error("account_deletion_user_meter_tombstone_clear_failed", {
-      userId: input.mcpUserId,
-      error,
-    });
-  }
+	// The D1 user row is gone, so a later signup with the same email is a new
+	// account. Drop the UserMeter tombstone `purge()` restored; leaving it
+	// would fence every write (including `/mcp`) for that hashed stable id.
+	try {
+		await clearUserMeterDeletionTombstone({
+			env: input.env,
+			stableUserId: input.mcpUserId,
+		})
+	} catch (error) {
+		console.error('account_deletion_user_meter_tombstone_clear_failed', {
+			userId: input.mcpUserId,
+			error,
+		})
+	}
 
-  return result;
+	return result
 }

--- a/packages/worker/src/app/account-deletion.ts
+++ b/packages/worker/src/app/account-deletion.ts
@@ -7,6 +7,7 @@ import {
 	cancelSubscription,
 	deleteCustomer,
 	listSubscriptions,
+	type StripeSubscription,
 } from '#worker/billing/stripe-client.ts'
 import { purgeStripePlanRefreshForUser } from '#worker/billing/stripe-plan-refresh-client.ts'
 import { storageRunnerRpc } from '#worker/storage-runner.ts'
@@ -154,6 +155,22 @@ export class AccountDeletionInventoryError extends Error {
 		super('Account deletion inventory could not be collected safely.')
 		this.name = 'AccountDeletionInventoryError'
 		this.inventoryErrors = [...inventoryErrors]
+	}
+}
+
+/**
+ * Active Stripe subscriptions could not be canceled. Raised before any
+ * destructive cleanup, like {@link AccountDeletionInventoryError}: the
+ * deletion fence is released and the account is retained so the user keeps
+ * billing-portal access and can retry.
+ */
+export class AccountDeletionBillingError extends Error {
+	readonly billingErrors: ReadonlyArray<string>
+
+	constructor(billingErrors: ReadonlyArray<string>) {
+		super('Account deletion could not cancel the active Stripe subscription.')
+		this.name = 'AccountDeletionBillingError'
+		this.billingErrors = [...billingErrors]
 	}
 }
 
@@ -444,45 +461,90 @@ async function collectUserDeletionInventory(input: {
 	}
 }
 
-async function cancelSubscriptionsAndDeleteStripeCustomer(input: {
+function isStripeSubscriptionBillable(subscription: StripeSubscription) {
+	return stripeSubscriptionStatusesCanceledOnAccountDeletion.has(
+		subscription.status,
+	)
+}
+
+/**
+ * Cancels every active/trialing subscription and throws
+ * {@link AccountDeletionBillingError} when any is still billable afterwards.
+ * Runs before any destructive cleanup so a Stripe outage retains the account
+ * instead of leaving a paying customer with no account or portal access.
+ *
+ * Idempotent across retries: subscriptions Stripe already reports as
+ * `canceled` are skipped, `cancelSubscription` treats `resource_missing` as
+ * canceled, and a cancel that errors is re-verified against a fresh listing
+ * (a subscription that flipped to canceled in between counts as success).
+ */
+async function cancelActiveStripeSubscriptions(input: {
 	env: Env
 	customerId: string
-}) {
-	const failures: Array<unknown> = []
+}): Promise<number> {
+	let subscriptions: Array<StripeSubscription>
 	try {
-		const subscriptions = await listSubscriptions(input.env, input.customerId)
-		for (const subscription of subscriptions) {
-			if (
-				!stripeSubscriptionStatusesCanceledOnAccountDeletion.has(
-					subscription.status,
-				)
-			) {
-				continue
-			}
-			try {
-				await cancelSubscription(input.env, subscription.id)
-			} catch (error) {
-				failures.push(error)
-			}
-		}
+		subscriptions = await listSubscriptions(input.env, input.customerId)
 	} catch (error) {
-		failures.push(error)
+		throw new AccountDeletionBillingError([
+			`Stripe subscriptions could not be listed: ${getErrorMessage(error)}`,
+		])
 	}
+	const billable = subscriptions.filter(isStripeSubscriptionBillable)
+	if (billable.length === 0) return 0
 
-	// Customer deletion is still attempted when listing or canceling a
-	// subscription fails. Stripe customer deletion also cancels active
-	// subscriptions, so this is the most important final cleanup attempt.
+	const failures: Array<string> = []
+	let canceled = 0
+	for (const subscription of billable) {
+		try {
+			await cancelSubscription(input.env, subscription.id)
+			canceled += 1
+		} catch (error) {
+			failures.push(
+				`Stripe subscription ${subscription.id} could not be canceled: ${getErrorMessage(error)}`,
+			)
+		}
+	}
+	if (failures.length === 0) return canceled
+
+	let stillBillable: Array<StripeSubscription>
+	try {
+		stillBillable = (
+			await listSubscriptions(input.env, input.customerId)
+		).filter(isStripeSubscriptionBillable)
+	} catch (error) {
+		throw new AccountDeletionBillingError([
+			...failures,
+			`Stripe subscriptions could not be re-verified: ${getErrorMessage(error)}`,
+		])
+	}
+	if (stillBillable.length > 0) {
+		throw new AccountDeletionBillingError(failures)
+	}
+	return billable.length
+}
+
+/**
+ * Best-effort Stripe customer deletion after every subscription is already
+ * canceled (see {@link cancelActiveStripeSubscriptions}). Failure here is a
+ * warning only: nothing bills a customer with no billable subscription, and a
+ * deleted Kody account has no path back to this customer id.
+ */
+async function deleteStripeCustomer(input: {
+	env: Env
+	customerId: string
+	userId: string
+	warnings: Array<string>
+}) {
 	try {
 		await deleteCustomer(input.env, input.customerId)
 	} catch (error) {
-		failures.push(error)
-	}
-
-	if (failures.length > 0) {
-		throw new AggregateError(
-			failures,
-			`Stripe account cleanup encountered ${failures.length} failure(s).`,
-		)
+		const warning = `Stripe customer cleanup failed during account deletion: ${getErrorMessage(error)}`
+		input.warnings.push(warning)
+		console.error('account_deletion_stripe_cleanup_failed', {
+			userId: input.userId,
+			error,
+		})
 	}
 }
 
@@ -973,11 +1035,13 @@ async function deleteUserScopedRowsAndUser(input: {
  * The cleanup ordering is:
  *   1. Pre-collect identifiers we need (vector ids, storage ids, KV keys,
  *      repo/session/package ids) while their owning rows still exist.
- *   2. Idempotent cleanup of out-of-band stores and OAuth grants.
- *   3. Abort while preserving D1 inventory and the user row if any critical
+ *   2. Cancel active Stripe subscriptions. Like inventory, a failure here
+ *      releases the deletion fence and retains the account untouched.
+ *   3. Idempotent cleanup of out-of-band stores and OAuth grants.
+ *   4. Abort while preserving D1 inventory and the user row if any critical
  *      cleanup failed. The five-minute usage-rollup derived cache is the sole
  *      TTL-owned omission and does not participate in this gate.
- *   4. Atomically delete user-scoped D1 rows and the user row in one batch.
+ *   5. Atomically delete user-scoped D1 rows and the user row in one batch.
  */
 export async function deleteUserAccount(input: {
 	env: AccountDeletionEnv
@@ -1036,6 +1100,35 @@ export async function deleteUserAccount(input: {
 			})
 		}
 		throw error
+	}
+
+	// Billing is a precondition of deletion, checked before anything
+	// destructive: if Stripe cannot confirm every subscription is canceled the
+	// account (and its portal access) must survive so the customer is not
+	// billed for an account that no longer exists.
+	if (inventory.stripeCustomerId) {
+		try {
+			await cancelActiveStripeSubscriptions({
+				env: input.env,
+				customerId: inventory.stripeCustomerId,
+			})
+		} catch (error) {
+			if (error instanceof AccountDeletionBillingError) {
+				console.error('account_deletion_billing_cancel_failed', {
+					userId: input.mcpUserId,
+					billingErrors: error.billingErrors,
+				})
+				if (marked.created) {
+					await abortAccountDeleting({
+						db: input.env.APP_DB,
+						dbUserId: input.dbUserId,
+						env: input.env,
+						expectedDeletingAt: marked.deletingAt,
+					})
+				}
+			}
+			throw error
+		}
 	}
 
 	result.deletedVectors = await deleteVectorsByIds({
@@ -1266,19 +1359,12 @@ export async function deleteUserAccount(input: {
 	}
 
 	if (inventory.stripeCustomerId) {
-		try {
-			await cancelSubscriptionsAndDeleteStripeCustomer({
-				env: input.env,
-				customerId: inventory.stripeCustomerId,
-			})
-		} catch (error) {
-			const warning = `Stripe customer cleanup failed during account deletion: ${getErrorMessage(error)}`
-			warnings.push(warning)
-			console.error('account_deletion_stripe_cleanup_failed', {
-				userId: input.mcpUserId,
-				error,
-			})
-		}
+		await deleteStripeCustomer({
+			env: input.env,
+			customerId: inventory.stripeCustomerId,
+			userId: input.mcpUserId,
+			warnings,
+		})
 	}
 
 	try {

--- a/packages/worker/src/app/account-deletion.ts
+++ b/packages/worker/src/app/account-deletion.ts
@@ -1,938 +1,974 @@
-import { getErrorMessage } from '@kody-internal/shared/error-message.ts'
+import { getErrorMessage } from "@kody-internal/shared/error-message.ts";
 import {
-	type OAuthGrantHelpers,
-	revokeAllOAuthGrantsBestEffort,
-} from '#worker/oauth-grants.ts'
+  type OAuthGrantHelpers,
+  revokeAllOAuthGrantsBestEffort,
+} from "#worker/oauth-grants.ts";
 import {
-	cancelSubscription,
-	deleteCustomer,
-	listSubscriptions,
-} from '#worker/billing/stripe-client.ts'
-import { purgeStripePlanRefreshForUser } from '#worker/billing/stripe-plan-refresh-client.ts'
-import { storageRunnerRpc } from '#worker/storage-runner.ts'
-import { purgeJobManagerForUser } from '#worker/jobs/manager-client.ts'
-import { jobVectorId } from '#mcp/jobs-vectorize.ts'
-import { memoryVectorId } from '#mcp/memory/memory-vectorize.ts'
-import { savedPackageVectorId } from '#worker/package-registry/repo.ts'
-import { getCapabilityVectorIndex } from '#worker/vectorize/embedding.ts'
-import { cleanupAllUserArtifactRepos } from '#worker/repo/artifact-repo-cleanup.ts'
-import { repoSessionRpc } from '#worker/repo/repo-session-rpc.ts'
-import { mcpClientHubDurableObjectName } from '#worker/user-scoped-durable-object-name.ts'
-import { packageRealtimeSessionRpc } from '#worker/package-runtime/realtime-session.ts'
-import { clearRunRecords } from '#worker/run-records/service.ts'
+  cancelSubscription,
+  deleteCustomer,
+  listSubscriptions,
+} from "#worker/billing/stripe-client.ts";
+import { purgeStripePlanRefreshForUser } from "#worker/billing/stripe-plan-refresh-client.ts";
+import { storageRunnerRpc } from "#worker/storage-runner.ts";
+import { purgeJobManagerForUser } from "#worker/jobs/manager-client.ts";
+import { jobsService } from "#worker/jobs/jobs-data.ts";
+import { jobVectorId } from "#mcp/jobs-vectorize.ts";
+import { memoryVectorId } from "#mcp/memory/memory-vectorize.ts";
+import { savedPackageVectorId } from "#worker/package-registry/repo.ts";
+import { getCapabilityVectorIndex } from "#worker/vectorize/embedding.ts";
+import { cleanupAllUserArtifactRepos } from "#worker/repo/artifact-repo-cleanup.ts";
+import { repoSessionRpc } from "#worker/repo/repo-session-rpc.ts";
+import { mcpClientHubDurableObjectName } from "#worker/user-scoped-durable-object-name.ts";
+import { packageRealtimeSessionRpc } from "#worker/package-runtime/realtime-session.ts";
+import { clearRunRecords } from "#worker/run-records/service.ts";
 import {
-	userMeterNamespace,
-	userMeterRpc,
-} from '#worker/entitlements/user-meter-client.ts'
-import { mailboxRpc } from '#worker/email/mailbox-client.ts'
-import { repoSessionIndexRpc } from '#worker/repo/repo-session-index-client.ts'
-import { listRepoSessionsByUser } from '#worker/repo/repo-sessions.ts'
-import { listAccountUserStorageIds } from '#worker/account/user-inventory.ts'
+  userMeterNamespace,
+  userMeterRpc,
+} from "#worker/entitlements/user-meter-client.ts";
+import { mailboxRpc } from "#worker/email/mailbox-client.ts";
+import { repoSessionIndexRpc } from "#worker/repo/repo-session-index-client.ts";
+import { listRepoSessionsByUser } from "#worker/repo/repo-sessions.ts";
+import { listAccountUserStorageIds } from "#worker/account/user-inventory.ts";
 import {
-	deleteOwnedMcpOauthClients,
-	listOwnedUserMcpOauthClientIds,
-} from '#app/account-mcp-oauth-clients.ts'
+  deleteOwnedMcpOauthClients,
+  listOwnedUserMcpOauthClientIds,
+} from "#app/account-mcp-oauth-clients.ts";
 import {
-	accountUserDataTargets,
-	buildUserScopedDeleteOrUpdateSql,
-	buildUserScopedTargetMatch,
-	getAccountD1UserColumnCoverage,
-} from '#worker/account/data-targets.ts'
+  accountUserDataTargets,
+  buildUserScopedDeleteOrUpdateSql,
+  buildUserScopedTargetMatch,
+  getAccountD1UserColumnCoverage,
+} from "#worker/account/data-targets.ts";
 import {
-	accountUserOwnedVectorizeSurfaces,
-	getAccountDeletionDurableObjectResultKeys,
-} from '#worker/account/user-owned-surfaces.ts'
+  accountUserOwnedVectorizeSurfaces,
+  getAccountDeletionDurableObjectResultKeys,
+  type UserOwnedVectorizeSource,
+} from "#worker/account/user-owned-surfaces.ts";
 import {
-	collectAccountR2Inventory,
-	type AccountCommunityListingSnapshot,
-	type AccountR2ObjectRef,
-} from '#worker/account/r2-inventory.ts'
+  collectAccountR2Inventory,
+  type AccountCommunityListingSnapshot,
+  type AccountR2ObjectRef,
+} from "#worker/account/r2-inventory.ts";
 import {
-	deleteAccountCommunityAssetPrefixes,
-	deleteAccountEmailBlobPrefixes,
-} from '#app/account-r2-prefix-cleanup.ts'
+  deleteAccountCommunityAssetPrefixes,
+  deleteAccountEmailBlobPrefixes,
+} from "#app/account-r2-prefix-cleanup.ts";
 import {
-	listMcpAgentSessionsForUser,
-	type McpAgentSession,
-} from '#mcp/session-registry.ts'
+  listMcpAgentSessionsForUser,
+  type McpAgentSession,
+} from "#mcp/session-registry.ts";
 import {
-	AccountDeletionWritersActiveError,
-	abortAccountDeleting,
-	clearUserMeterDeletionTombstone,
-	markAccountDeleting,
-} from '#worker/account/deletion-state.ts'
+  AccountDeletionWritersActiveError,
+  abortAccountDeleting,
+  clearUserMeterDeletionTombstone,
+  markAccountDeleting,
+} from "#worker/account/deletion-state.ts";
 import {
-	buildPublishedSourceManifestSnapshotKvKey,
-	buildPublishedSourceSnapshotKvKey,
-} from '#worker/package-runtime/published-runtime-artifacts.ts'
-import { deleteAllPackageRetrieverCacheEntriesForUser } from '#worker/package-retrievers/manifest-cache.ts'
-import { buildCommunitySnapshotKvKey } from '#worker/community/snapshot.ts'
+  buildPublishedSourceManifestSnapshotKvKey,
+  buildPublishedSourceSnapshotKvKey,
+} from "#worker/package-runtime/published-runtime-artifacts.ts";
+import { deleteAllPackageRetrieverCacheEntriesForUser } from "#worker/package-retrievers/manifest-cache.ts";
+import { buildCommunitySnapshotKvKey } from "#worker/community/snapshot.ts";
 import {
-	communityIconKvListingPrefixes,
-	buildCommunityIconCacheKey,
-} from '#worker/community/community-icon.ts'
-import { derivedCacheKeyPrefix } from '#worker/kv-cachified.ts'
+  communityIconKvListingPrefixes,
+  buildCommunityIconCacheKey,
+} from "#worker/community/community-icon.ts";
+import { derivedCacheKeyPrefix } from "#worker/kv-cachified.ts";
 import {
-	maybeRemoveDiscordGuildRoles,
-	summarizeDiscordGuildRoleSync,
-} from '#worker/discord/guild-role.ts'
+  maybeRemoveDiscordGuildRoles,
+  summarizeDiscordGuildRoleSync,
+} from "#worker/discord/guild-role.ts";
 
 // Imported manually instead of via `@cloudflare/workers-oauth-provider` so
 // node-only unit tests can require this module without dragging in
 // `cloudflare:workers` (the OAuth provider package re-exports through that
 // runtime symbol). The shape mirrors the subset of OAuthHelpers we use.
 type OAuthHelpersShape = OAuthGrantHelpers & {
-	deleteClient?(clientId: string): Promise<unknown>
-}
+  deleteClient?(clientId: string): Promise<unknown>;
+};
 
 type AccountDeletionEnv = Env & {
-	OAUTH_PROVIDER?: OAuthHelpersShape
-}
+  OAUTH_PROVIDER?: OAuthHelpersShape;
+};
 
 export type AccountDeletionResult = {
-	deletedRowCounts: Record<string, number>
-	updatedRowCounts: Record<string, number>
-	deletedKvKeys: number
-	deletedCommunityAssets: number
-	deletedEmailBlobs: number
-	deletedArtifactRepos: number
-	revokedOAuthGrants: number
-	clearedDurableObjects: Record<string, number>
-	deletedVectors: number
-	warnings: Array<string>
-}
+  deletedRowCounts: Record<string, number>;
+  updatedRowCounts: Record<string, number>;
+  deletedKvKeys: number;
+  deletedCommunityAssets: number;
+  deletedEmailBlobs: number;
+  deletedArtifactRepos: number;
+  revokedOAuthGrants: number;
+  clearedDurableObjects: Record<string, number>;
+  deletedVectors: number;
+  warnings: Array<string>;
+};
 
 export function getAccountDeletionD1UserColumnCoverage() {
-	return getAccountD1UserColumnCoverage()
+  return getAccountD1UserColumnCoverage();
 }
 
 type UserSourceSnapshot = {
-	sourceId: string
-	publishedCommit: string | null
-}
+  sourceId: string;
+  publishedCommit: string | null;
+};
 
 type UserSavedPackageSnapshot = {
-	id: string
-	kodyId: string
-	sourceId: string
-	hasApp: boolean
-}
+  id: string;
+  kodyId: string;
+  sourceId: string;
+  hasApp: boolean;
+};
 
 type UserRepoSessionSnapshot = {
-	id: string
-}
+  id: string;
+};
 
 type UserMcpServerSnapshot = {
-	id: string
-}
+  id: string;
+};
 
 type UserDeletionInventory = {
-	stripeCustomerId: string | null
-	vectorIds: Array<string>
-	storageIds: Array<string>
-	bundleKvKeys: Array<string>
-	r2Objects: Array<AccountR2ObjectRef>
-	sourceSnapshots: Array<UserSourceSnapshot>
-	savedPackages: Array<UserSavedPackageSnapshot>
-	repoSessions: Array<UserRepoSessionSnapshot>
-	mcpServers: Array<UserMcpServerSnapshot>
-	mcpAgentSessions: Array<McpAgentSession>
-	communityListings: Array<AccountCommunityListingSnapshot>
-}
+  stripeCustomerId: string | null;
+  vectorIds: Array<string>;
+  storageIds: Array<string>;
+  bundleKvKeys: Array<string>;
+  r2Objects: Array<AccountR2ObjectRef>;
+  sourceSnapshots: Array<UserSourceSnapshot>;
+  savedPackages: Array<UserSavedPackageSnapshot>;
+  repoSessions: Array<UserRepoSessionSnapshot>;
+  mcpServers: Array<UserMcpServerSnapshot>;
+  mcpAgentSessions: Array<McpAgentSession>;
+  communityListings: Array<AccountCommunityListingSnapshot>;
+};
 
 const stripeSubscriptionStatusesCanceledOnAccountDeletion = new Set([
-	'active',
-	'trialing',
-])
+  "active",
+  "trialing",
+]);
 
 export class AccountDeletionInventoryError extends Error {
-	readonly inventoryErrors: ReadonlyArray<string>
+  readonly inventoryErrors: ReadonlyArray<string>;
 
-	constructor(inventoryErrors: ReadonlyArray<string>) {
-		super('Account deletion inventory could not be collected safely.')
-		this.name = 'AccountDeletionInventoryError'
-		this.inventoryErrors = [...inventoryErrors]
-	}
+  constructor(inventoryErrors: ReadonlyArray<string>) {
+    super("Account deletion inventory could not be collected safely.");
+    this.name = "AccountDeletionInventoryError";
+    this.inventoryErrors = [...inventoryErrors];
+  }
 }
 
 export class AccountDeletionCleanupError extends Error {
-	readonly cleanupErrors: ReadonlyArray<string>
-	readonly partialResult: AccountDeletionResult
+  readonly cleanupErrors: ReadonlyArray<string>;
+  readonly partialResult: AccountDeletionResult;
 
-	constructor(
-		cleanupErrors: ReadonlyArray<string>,
-		partialResult: AccountDeletionResult,
-	) {
-		super('Account deletion cleanup could not complete safely.')
-		this.name = 'AccountDeletionCleanupError'
-		this.cleanupErrors = [...cleanupErrors]
-		this.partialResult = partialResult
-	}
+  constructor(
+    cleanupErrors: ReadonlyArray<string>,
+    partialResult: AccountDeletionResult,
+  ) {
+    super("Account deletion cleanup could not complete safely.");
+    this.name = "AccountDeletionCleanupError";
+    this.cleanupErrors = [...cleanupErrors];
+    this.partialResult = partialResult;
+  }
 }
 
 function uniqueStrings(values: Iterable<string | null | undefined>) {
-	return Array.from(
-		new Set(
-			Array.from(values)
-				.map((value) => value?.trim() ?? '')
-				.filter((value) => value.length > 0),
-		),
-	)
+  return Array.from(
+    new Set(
+      Array.from(values)
+        .map((value) => value?.trim() ?? "")
+        .filter((value) => value.length > 0),
+    ),
+  );
 }
 
 const vectorIdBuildersBySurfaceId = {
-	memory: memoryVectorId,
-	job: jobVectorId,
-	saved_package: savedPackageVectorId,
-} as const
+  memory: memoryVectorId,
+  job: jobVectorId,
+  saved_package: savedPackageVectorId,
+} as const;
+
+async function listUserVectorSourceRowIds(
+  env: Env,
+  userId: string,
+  source: UserOwnedVectorizeSource,
+): Promise<Array<string>> {
+  switch (source.kind) {
+    case "app_db": {
+      const rows = await env.APP_DB.prepare(
+        `SELECT id FROM ${source.table} WHERE user_id = ?`,
+      )
+        .bind(userId)
+        .all<{ id: string }>();
+      return (rows.results ?? []).map((row) => row.id);
+    }
+    case "jobs_rpc": {
+      const jobs = jobsService(env);
+      if (!jobs) {
+        throw new Error(
+          "JOBS service binding is required to enumerate job vector ids (jobs live in the jobs worker D1, not APP_DB).",
+        );
+      }
+      return jobs.listJobIdsForUser({ userId });
+    }
+    default: {
+      const unknownSource: never = source;
+      throw new Error(
+        `Unknown vectorize surface source: ${JSON.stringify(unknownSource)}`,
+      );
+    }
+  }
+}
 
 async function listUserVectorIds(env: Env, userId: string) {
-	const ids: Array<string> = []
-	for (const surface of accountUserOwnedVectorizeSurfaces) {
-		const rows = await env.APP_DB.prepare(
-			`SELECT id FROM ${surface.sourceTable} WHERE user_id = ?`,
-		)
-			.bind(userId)
-			.all<{ id: string }>()
-		const buildId = vectorIdBuildersBySurfaceId[surface.id]
-		for (const row of rows.results ?? []) {
-			ids.push(buildId(row.id))
-		}
-	}
-	return ids
+  const ids: Array<string> = [];
+  for (const surface of accountUserOwnedVectorizeSurfaces) {
+    const buildId = vectorIdBuildersBySurfaceId[surface.id];
+    const rowIds = await listUserVectorSourceRowIds(
+      env,
+      userId,
+      surface.source,
+    );
+    for (const rowId of rowIds) {
+      ids.push(buildId(rowId));
+    }
+  }
+  return ids;
 }
 
 async function getUserStripeCustomerId(env: Env, dbUserId: number) {
-	const row = await env.APP_DB.prepare(
-		`SELECT stripe_customer_id FROM users WHERE id = ?`,
-	)
-		.bind(dbUserId)
-		.first<{ stripe_customer_id: string | null }>()
-	return row?.stripe_customer_id?.trim() || null
+  const row = await env.APP_DB.prepare(
+    `SELECT stripe_customer_id FROM users WHERE id = ?`,
+  )
+    .bind(dbUserId)
+    .first<{ stripe_customer_id: string | null }>();
+  return row?.stripe_customer_id?.trim() || null;
 }
 
 async function listUserStorageIds(env: Env, userId: string) {
-	return await listAccountUserStorageIds({
-		env,
-		userId,
-	})
+  return await listAccountUserStorageIds({
+    env,
+    userId,
+  });
 }
 
 async function listUserSourceSnapshots(env: Env, userId: string) {
-	const sourceRows = await env.APP_DB.prepare(
-		`SELECT id, published_commit
+  const sourceRows = await env.APP_DB.prepare(
+    `SELECT id, published_commit
 		FROM entity_sources
 		WHERE user_id = ?`,
-	)
-		.bind(userId)
-		.all<{ id: string; published_commit: string | null }>()
-	return (sourceRows.results ?? []).map((row) => ({
-		sourceId: row.id,
-		publishedCommit: row.published_commit,
-	}))
+  )
+    .bind(userId)
+    .all<{ id: string; published_commit: string | null }>();
+  return (sourceRows.results ?? []).map((row) => ({
+    sourceId: row.id,
+    publishedCommit: row.published_commit,
+  }));
 }
 
 async function listUserSavedPackages(env: Env, userId: string) {
-	const rows = await env.APP_DB.prepare(
-		`SELECT id, kody_id, source_id, has_app
+  const rows = await env.APP_DB.prepare(
+    `SELECT id, kody_id, source_id, has_app
 		FROM saved_packages
 		WHERE user_id = ?`,
-	)
-		.bind(userId)
-		.all<{
-			id: string
-			kody_id: string
-			source_id: string
-			has_app: number | string | boolean
-		}>()
-	return (rows.results ?? []).map((row) => ({
-		id: row.id,
-		kodyId: row.kody_id,
-		sourceId: row.source_id,
-		hasApp: row.has_app === 1 || row.has_app === '1' || row.has_app === true,
-	}))
+  )
+    .bind(userId)
+    .all<{
+      id: string;
+      kody_id: string;
+      source_id: string;
+      has_app: number | string | boolean;
+    }>();
+  return (rows.results ?? []).map((row) => ({
+    id: row.id,
+    kodyId: row.kody_id,
+    sourceId: row.source_id,
+    hasApp: row.has_app === 1 || row.has_app === "1" || row.has_app === true,
+  }));
 }
 
 async function listUserRepoSessions(env: Env, userId: string) {
-	if (!env.REPO_SESSION_INDEX) {
-		throw new Error(
-			'REPO_SESSION_INDEX binding is required for account deletion.',
-		)
-	}
-	return (await listRepoSessionsByUser(env, userId)).map((row) => ({
-		id: row.id,
-	}))
+  if (!env.REPO_SESSION_INDEX) {
+    throw new Error(
+      "REPO_SESSION_INDEX binding is required for account deletion.",
+    );
+  }
+  return (await listRepoSessionsByUser(env, userId)).map((row) => ({
+    id: row.id,
+  }));
 }
 
 async function listUserMcpServers(env: Env, userId: string) {
-	const rows = await env.APP_DB.prepare(
-		`SELECT id
+  const rows = await env.APP_DB.prepare(
+    `SELECT id
 		FROM mcp_server_settings
 		WHERE user_id = ?`,
-	)
-		.bind(userId)
-		.all<{ id: string }>()
-	return (rows.results ?? []).map((row) => ({ id: row.id }))
+  )
+    .bind(userId)
+    .all<{ id: string }>();
+  return (rows.results ?? []).map((row) => ({ id: row.id }));
 }
 
 async function listUserBundleKvKeys(input: {
-	env: Env
-	userId: string
-	sourceSnapshots: ReadonlyArray<UserSourceSnapshot>
-	communityListings: ReadonlyArray<AccountCommunityListingSnapshot>
+  env: Env;
+  userId: string;
+  sourceSnapshots: ReadonlyArray<UserSourceSnapshot>;
+  communityListings: ReadonlyArray<AccountCommunityListingSnapshot>;
 }) {
-	const published = await input.env.APP_DB.prepare(
-		`SELECT kv_key FROM published_bundle_artifacts WHERE user_id = ?`,
-	)
-		.bind(input.userId)
-		.all<{ kv_key: string }>()
-	return uniqueStrings([
-		...(published.results ?? []).map((row) => row.kv_key),
-		...input.sourceSnapshots.flatMap((source) =>
-			source.publishedCommit
-				? [
-						buildPublishedSourceSnapshotKvKey({
-							sourceId: source.sourceId,
-							publishedCommit: source.publishedCommit,
-						}),
-						buildPublishedSourceManifestSnapshotKvKey({
-							sourceId: source.sourceId,
-							publishedCommit: source.publishedCommit,
-						}),
-					]
-				: [],
-		),
-		...input.communityListings.flatMap((listing) => [
-			buildCommunitySnapshotKvKey(listing.id),
-			derivedCacheKeyPrefix +
-				buildCommunityIconCacheKey({
-					listingId: listing.id,
-					commit: listing.pinnedCommit,
-				}),
-			derivedCacheKeyPrefix +
-				buildCommunityIconCacheKey({
-					listingId: listing.id,
-					commit: listing.iconCommit,
-				}),
-		]),
-	])
+  const published = await input.env.APP_DB.prepare(
+    `SELECT kv_key FROM published_bundle_artifacts WHERE user_id = ?`,
+  )
+    .bind(input.userId)
+    .all<{ kv_key: string }>();
+  return uniqueStrings([
+    ...(published.results ?? []).map((row) => row.kv_key),
+    ...input.sourceSnapshots.flatMap((source) =>
+      source.publishedCommit
+        ? [
+            buildPublishedSourceSnapshotKvKey({
+              sourceId: source.sourceId,
+              publishedCommit: source.publishedCommit,
+            }),
+            buildPublishedSourceManifestSnapshotKvKey({
+              sourceId: source.sourceId,
+              publishedCommit: source.publishedCommit,
+            }),
+          ]
+        : [],
+    ),
+    ...input.communityListings.flatMap((listing) => [
+      buildCommunitySnapshotKvKey(listing.id),
+      derivedCacheKeyPrefix +
+        buildCommunityIconCacheKey({
+          listingId: listing.id,
+          commit: listing.pinnedCommit,
+        }),
+      derivedCacheKeyPrefix +
+        buildCommunityIconCacheKey({
+          listingId: listing.id,
+          commit: listing.iconCommit,
+        }),
+    ]),
+  ]);
 }
 
 async function collectUserDeletionInventory(input: {
-	env: Env
-	userId: string
-	dbUserId: number
-	warnings: Array<string>
+  env: Env;
+  userId: string;
+  dbUserId: number;
+  warnings: Array<string>;
 }): Promise<UserDeletionInventory> {
-	const inventoryErrors: Array<string> = []
-	const recordInventoryError = (label: string, error: unknown) => {
-		const warning = `Failed to enumerate ${label}: ${getErrorMessage(error)}`
-		input.warnings.push(warning)
-		inventoryErrors.push(warning)
-	}
-	const [
-		stripeCustomerId,
-		vectorIds,
-		storageIds,
-		r2Inventory,
-		sourceSnapshots,
-		savedPackages,
-		repoSessions,
-		mcpServers,
-		mcpAgentSessions,
-	] = await Promise.all([
-		getUserStripeCustomerId(input.env, input.dbUserId).catch((error) => {
-			recordInventoryError('Stripe customer id', error)
-			return null
-		}),
-		listUserVectorIds(input.env, input.userId).catch((error) => {
-			recordInventoryError('vector ids', error)
-			return [] as Array<string>
-		}),
-		listUserStorageIds(input.env, input.userId).catch((error) => {
-			recordInventoryError('storage ids', error)
-			return [] as Array<string>
-		}),
-		collectAccountR2Inventory({
-			env: input.env,
-			userId: input.userId,
-			dbUserId: input.dbUserId,
-		}).catch((error) => {
-			recordInventoryError('R2 objects', error)
-			return {
-				objects: [] as Array<AccountR2ObjectRef>,
-				communityListings: [] as Array<AccountCommunityListingSnapshot>,
-			}
-		}),
-		listUserSourceSnapshots(input.env, input.userId).catch((error) => {
-			recordInventoryError('source snapshots', error)
-			return [] as Array<UserSourceSnapshot>
-		}),
-		listUserSavedPackages(input.env, input.userId).catch((error) => {
-			recordInventoryError('saved packages', error)
-			return [] as Array<UserSavedPackageSnapshot>
-		}),
-		listUserRepoSessions(input.env, input.userId).catch((error) => {
-			recordInventoryError('repo sessions', error)
-			return [] as Array<UserRepoSessionSnapshot>
-		}),
-		listUserMcpServers(input.env, input.userId).catch((error) => {
-			recordInventoryError('MCP servers', error)
-			return [] as Array<UserMcpServerSnapshot>
-		}),
-		listMcpAgentSessionsForUser(input.env.APP_DB, input.userId).catch(
-			(error) => {
-				recordInventoryError('MCP agent sessions', error)
-				return [] as Array<McpAgentSession>
-			},
-		),
-	])
-	const bundleKvKeys = await listUserBundleKvKeys({
-		env: input.env,
-		userId: input.userId,
-		sourceSnapshots,
-		communityListings: r2Inventory.communityListings,
-	}).catch((error) => {
-		recordInventoryError('bundle KV keys', error)
-		return [] as Array<string>
-	})
-	if (inventoryErrors.length > 0) {
-		throw new AccountDeletionInventoryError(inventoryErrors)
-	}
-	return {
-		stripeCustomerId,
-		vectorIds,
-		storageIds,
-		bundleKvKeys,
-		r2Objects: r2Inventory.objects,
-		sourceSnapshots,
-		savedPackages,
-		repoSessions,
-		mcpServers,
-		mcpAgentSessions,
-		communityListings: r2Inventory.communityListings,
-	}
+  const inventoryErrors: Array<string> = [];
+  const recordInventoryError = (label: string, error: unknown) => {
+    const warning = `Failed to enumerate ${label}: ${getErrorMessage(error)}`;
+    input.warnings.push(warning);
+    inventoryErrors.push(warning);
+  };
+  const [
+    stripeCustomerId,
+    vectorIds,
+    storageIds,
+    r2Inventory,
+    sourceSnapshots,
+    savedPackages,
+    repoSessions,
+    mcpServers,
+    mcpAgentSessions,
+  ] = await Promise.all([
+    getUserStripeCustomerId(input.env, input.dbUserId).catch((error) => {
+      recordInventoryError("Stripe customer id", error);
+      return null;
+    }),
+    listUserVectorIds(input.env, input.userId).catch((error) => {
+      recordInventoryError("vector ids", error);
+      return [] as Array<string>;
+    }),
+    listUserStorageIds(input.env, input.userId).catch((error) => {
+      recordInventoryError("storage ids", error);
+      return [] as Array<string>;
+    }),
+    collectAccountR2Inventory({
+      env: input.env,
+      userId: input.userId,
+      dbUserId: input.dbUserId,
+    }).catch((error) => {
+      recordInventoryError("R2 objects", error);
+      return {
+        objects: [] as Array<AccountR2ObjectRef>,
+        communityListings: [] as Array<AccountCommunityListingSnapshot>,
+      };
+    }),
+    listUserSourceSnapshots(input.env, input.userId).catch((error) => {
+      recordInventoryError("source snapshots", error);
+      return [] as Array<UserSourceSnapshot>;
+    }),
+    listUserSavedPackages(input.env, input.userId).catch((error) => {
+      recordInventoryError("saved packages", error);
+      return [] as Array<UserSavedPackageSnapshot>;
+    }),
+    listUserRepoSessions(input.env, input.userId).catch((error) => {
+      recordInventoryError("repo sessions", error);
+      return [] as Array<UserRepoSessionSnapshot>;
+    }),
+    listUserMcpServers(input.env, input.userId).catch((error) => {
+      recordInventoryError("MCP servers", error);
+      return [] as Array<UserMcpServerSnapshot>;
+    }),
+    listMcpAgentSessionsForUser(input.env.APP_DB, input.userId).catch(
+      (error) => {
+        recordInventoryError("MCP agent sessions", error);
+        return [] as Array<McpAgentSession>;
+      },
+    ),
+  ]);
+  const bundleKvKeys = await listUserBundleKvKeys({
+    env: input.env,
+    userId: input.userId,
+    sourceSnapshots,
+    communityListings: r2Inventory.communityListings,
+  }).catch((error) => {
+    recordInventoryError("bundle KV keys", error);
+    return [] as Array<string>;
+  });
+  if (inventoryErrors.length > 0) {
+    throw new AccountDeletionInventoryError(inventoryErrors);
+  }
+  return {
+    stripeCustomerId,
+    vectorIds,
+    storageIds,
+    bundleKvKeys,
+    r2Objects: r2Inventory.objects,
+    sourceSnapshots,
+    savedPackages,
+    repoSessions,
+    mcpServers,
+    mcpAgentSessions,
+    communityListings: r2Inventory.communityListings,
+  };
 }
 
 async function cancelSubscriptionsAndDeleteStripeCustomer(input: {
-	env: Env
-	customerId: string
+  env: Env;
+  customerId: string;
 }) {
-	const failures: Array<unknown> = []
-	try {
-		const subscriptions = await listSubscriptions(input.env, input.customerId)
-		for (const subscription of subscriptions) {
-			if (
-				!stripeSubscriptionStatusesCanceledOnAccountDeletion.has(
-					subscription.status,
-				)
-			) {
-				continue
-			}
-			try {
-				await cancelSubscription(input.env, subscription.id)
-			} catch (error) {
-				failures.push(error)
-			}
-		}
-	} catch (error) {
-		failures.push(error)
-	}
+  const failures: Array<unknown> = [];
+  try {
+    const subscriptions = await listSubscriptions(input.env, input.customerId);
+    for (const subscription of subscriptions) {
+      if (
+        !stripeSubscriptionStatusesCanceledOnAccountDeletion.has(
+          subscription.status,
+        )
+      ) {
+        continue;
+      }
+      try {
+        await cancelSubscription(input.env, subscription.id);
+      } catch (error) {
+        failures.push(error);
+      }
+    }
+  } catch (error) {
+    failures.push(error);
+  }
 
-	// Customer deletion is still attempted when listing or canceling a
-	// subscription fails. Stripe customer deletion also cancels active
-	// subscriptions, so this is the most important final cleanup attempt.
-	try {
-		await deleteCustomer(input.env, input.customerId)
-	} catch (error) {
-		failures.push(error)
-	}
+  // Customer deletion is still attempted when listing or canceling a
+  // subscription fails. Stripe customer deletion also cancels active
+  // subscriptions, so this is the most important final cleanup attempt.
+  try {
+    await deleteCustomer(input.env, input.customerId);
+  } catch (error) {
+    failures.push(error);
+  }
 
-	if (failures.length > 0) {
-		throw new AggregateError(
-			failures,
-			`Stripe account cleanup encountered ${failures.length} failure(s).`,
-		)
-	}
+  if (failures.length > 0) {
+    throw new AggregateError(
+      failures,
+      `Stripe account cleanup encountered ${failures.length} failure(s).`,
+    );
+  }
 }
 
 async function clearStorageRunners(input: {
-	env: Env
-	userId: string
-	storageIds: ReadonlyArray<string>
-	warnings: Array<string>
+  env: Env;
+  userId: string;
+  storageIds: ReadonlyArray<string>;
+  warnings: Array<string>;
 }): Promise<number> {
-	let cleared = 0
-	for (const storageId of input.storageIds) {
-		try {
-			const stub = storageRunnerRpc({
-				env: input.env,
-				userId: input.userId,
-				storageId,
-			})
-			await stub.clearStorage()
-			cleared += 1
-		} catch (error) {
-			const message = getErrorMessage(error)
-			input.warnings.push(
-				`Storage runner clear failed for ${storageId}: ${message}`,
-			)
-		}
-	}
-	return cleared
+  let cleared = 0;
+  for (const storageId of input.storageIds) {
+    try {
+      const stub = storageRunnerRpc({
+        env: input.env,
+        userId: input.userId,
+        storageId,
+      });
+      await stub.clearStorage();
+      cleared += 1;
+    } catch (error) {
+      const message = getErrorMessage(error);
+      input.warnings.push(
+        `Storage runner clear failed for ${storageId}: ${message}`,
+      );
+    }
+  }
+  return cleared;
 }
 
 async function clearRunLog(input: {
-	env: Env
-	userId: string
-	warnings: Array<string>
+  env: Env;
+  userId: string;
+  warnings: Array<string>;
 }): Promise<number> {
-	try {
-		if (!(input.env as Partial<Env>).RUN_LOG) {
-			input.warnings.push(
-				'RUN_LOG binding was unavailable; the user run log Durable Object was not purged.',
-			)
-			return 0
-		}
-		await clearRunRecords({ env: input.env, userId: input.userId })
-		return 1
-	} catch (error) {
-		const message = getErrorMessage(error)
-		input.warnings.push(`Run log clear failed: ${message}`)
-		return 0
-	}
+  try {
+    if (!(input.env as Partial<Env>).RUN_LOG) {
+      input.warnings.push(
+        "RUN_LOG binding was unavailable; the user run log Durable Object was not purged.",
+      );
+      return 0;
+    }
+    await clearRunRecords({ env: input.env, userId: input.userId });
+    return 1;
+  } catch (error) {
+    const message = getErrorMessage(error);
+    input.warnings.push(`Run log clear failed: ${message}`);
+    return 0;
+  }
 }
 
 async function purgeUserMeter(input: {
-	env: Env
-	userId: string
-	warnings: Array<string>
+  env: Env;
+  userId: string;
+  warnings: Array<string>;
 }): Promise<number> {
-	try {
-		if (!userMeterNamespace(input.env)) {
-			input.warnings.push(
-				'USER_METER binding was unavailable; the user meter Durable Object was not purged.',
-			)
-			return 0
-		}
-		await userMeterRpc({ env: input.env, userId: input.userId }).purge()
-		return 1
-	} catch (error) {
-		const message = getErrorMessage(error)
-		input.warnings.push(`User meter purge failed: ${message}`)
-		return 0
-	}
+  try {
+    if (!userMeterNamespace(input.env)) {
+      input.warnings.push(
+        "USER_METER binding was unavailable; the user meter Durable Object was not purged.",
+      );
+      return 0;
+    }
+    await userMeterRpc({ env: input.env, userId: input.userId }).purge();
+    return 1;
+  } catch (error) {
+    const message = getErrorMessage(error);
+    input.warnings.push(`User meter purge failed: ${message}`);
+    return 0;
+  }
 }
 
 async function purgeStripePlanRefresh(input: {
-	env: Env
-	userId: string
-	warnings: Array<string>
+  env: Env;
+  userId: string;
+  warnings: Array<string>;
 }): Promise<number> {
-	try {
-		const result = await purgeStripePlanRefreshForUser({
-			env: input.env,
-			userId: input.userId,
-		})
-		if (!result.purged) {
-			input.warnings.push(
-				'STRIPE_PLAN_REFRESH binding was unavailable; the user Stripe refresh alarm was not purged.',
-			)
-		}
-		return result.purged ? 1 : 0
-	} catch (error) {
-		const message = getErrorMessage(error)
-		input.warnings.push(`Stripe plan refresh purge failed: ${message}`)
-		return 0
-	}
+  try {
+    const result = await purgeStripePlanRefreshForUser({
+      env: input.env,
+      userId: input.userId,
+    });
+    if (!result.purged) {
+      input.warnings.push(
+        "STRIPE_PLAN_REFRESH binding was unavailable; the user Stripe refresh alarm was not purged.",
+      );
+    }
+    return result.purged ? 1 : 0;
+  } catch (error) {
+    const message = getErrorMessage(error);
+    input.warnings.push(`Stripe plan refresh purge failed: ${message}`);
+    return 0;
+  }
 }
 
 async function purgeMailbox(input: {
-	env: Env
-	userId: string
-	warnings: Array<string>
+  env: Env;
+  userId: string;
+  warnings: Array<string>;
 }): Promise<number> {
-	try {
-		await mailboxRpc({ env: input.env, userId: input.userId }).purge({
-			ownerId: input.userId,
-		})
-		return 1
-	} catch (error) {
-		const message = getErrorMessage(error)
-		input.warnings.push(`Mailbox purge failed: ${message}`)
-		return 0
-	}
+  try {
+    await mailboxRpc({ env: input.env, userId: input.userId }).purge({
+      ownerId: input.userId,
+    });
+    return 1;
+  } catch (error) {
+    const message = getErrorMessage(error);
+    input.warnings.push(`Mailbox purge failed: ${message}`);
+    return 0;
+  }
 }
 
 async function purgeJobManager(input: {
-	env: Env
-	userId: string
-	warnings: Array<string>
+  env: Env;
+  userId: string;
+  warnings: Array<string>;
 }): Promise<number> {
-	try {
-		const result = await purgeJobManagerForUser({
-			env: input.env,
-			userId: input.userId,
-		})
-		if (!result.purged) {
-			input.warnings.push(
-				'JOBS service binding was unavailable; the user scheduler Durable Object was not purged.',
-			)
-		}
-		return result.purged ? 1 : 0
-	} catch (error) {
-		const message = getErrorMessage(error)
-		input.warnings.push(`Job manager purge failed: ${message}`)
-		return 0
-	}
+  try {
+    const result = await purgeJobManagerForUser({
+      env: input.env,
+      userId: input.userId,
+    });
+    if (!result.purged) {
+      input.warnings.push(
+        "JOBS service binding was unavailable; the user scheduler Durable Object was not purged.",
+      );
+    }
+    return result.purged ? 1 : 0;
+  } catch (error) {
+    const message = getErrorMessage(error);
+    input.warnings.push(`Job manager purge failed: ${message}`);
+    return 0;
+  }
 }
 
 async function purgeRepoSessions(input: {
-	env: Env
-	userId: string
-	sessions: ReadonlyArray<UserRepoSessionSnapshot>
-	warnings: Array<string>
+  env: Env;
+  userId: string;
+  sessions: ReadonlyArray<UserRepoSessionSnapshot>;
+  warnings: Array<string>;
 }): Promise<number> {
-	let purged = 0
-	for (const session of input.sessions) {
-		try {
-			await repoSessionRpc(input.env, session.id).purgeSession({
-				sessionId: session.id,
-				userId: input.userId,
-			})
-			purged += 1
-		} catch (error) {
-			const message = getErrorMessage(error)
-			input.warnings.push(
-				`Repo session purge failed for ${session.id}: ${message}`,
-			)
-		}
-	}
-	return purged
+  let purged = 0;
+  for (const session of input.sessions) {
+    try {
+      await repoSessionRpc(input.env, session.id).purgeSession({
+        sessionId: session.id,
+        userId: input.userId,
+      });
+      purged += 1;
+    } catch (error) {
+      const message = getErrorMessage(error);
+      input.warnings.push(
+        `Repo session purge failed for ${session.id}: ${message}`,
+      );
+    }
+  }
+  return purged;
 }
 
 async function purgeRepoSessionIndex(input: {
-	env: Env
-	userId: string
-	warnings: Array<string>
+  env: Env;
+  userId: string;
+  warnings: Array<string>;
 }): Promise<number> {
-	try {
-		await repoSessionIndexRpc({
-			env: input.env,
-			userId: input.userId,
-		}).purge({ ownerId: input.userId })
-		return 1
-	} catch (error) {
-		const message = getErrorMessage(error)
-		input.warnings.push(`Repo session index purge failed: ${message}`)
-		return 0
-	}
+  try {
+    await repoSessionIndexRpc({
+      env: input.env,
+      userId: input.userId,
+    }).purge({ ownerId: input.userId });
+    return 1;
+  } catch (error) {
+    const message = getErrorMessage(error);
+    input.warnings.push(`Repo session index purge failed: ${message}`);
+    return 0;
+  }
 }
 
 async function purgeMcpClientHub(input: {
-	env: Env
-	userId: string
-	warnings: Array<string>
+  env: Env;
+  userId: string;
+  warnings: Array<string>;
 }): Promise<number> {
-	// Always purge, even when no mcp_server_settings rows remain: the hub DO
-	// can still hold OAuth tokens and SDK registrations (for example after a
-	// failed add), and those must not survive account deletion.
-	const namespace = input.env.MCP_CLIENT_HUB
-	if (!namespace) {
-		input.warnings.push(
-			'MCP_CLIENT_HUB binding was unavailable; the MCP client hub was not purged.',
-		)
-		return 0
-	}
-	try {
-		const stub = namespace.get(
-			namespace.idFromName(mcpClientHubDurableObjectName(input.userId)),
-		) as unknown as {
-			purgeForAccountDeletion: () => Promise<void>
-		}
-		await stub.purgeForAccountDeletion()
-		return 1
-	} catch (error) {
-		const message = getErrorMessage(error)
-		input.warnings.push(`MCP client hub purge failed: ${message}`)
-		return 0
-	}
+  // Always purge, even when no mcp_server_settings rows remain: the hub DO
+  // can still hold OAuth tokens and SDK registrations (for example after a
+  // failed add), and those must not survive account deletion.
+  const namespace = input.env.MCP_CLIENT_HUB;
+  if (!namespace) {
+    input.warnings.push(
+      "MCP_CLIENT_HUB binding was unavailable; the MCP client hub was not purged.",
+    );
+    return 0;
+  }
+  try {
+    const stub = namespace.get(
+      namespace.idFromName(mcpClientHubDurableObjectName(input.userId)),
+    ) as unknown as {
+      purgeForAccountDeletion: () => Promise<void>;
+    };
+    await stub.purgeForAccountDeletion();
+    return 1;
+  } catch (error) {
+    const message = getErrorMessage(error);
+    input.warnings.push(`MCP client hub purge failed: ${message}`);
+    return 0;
+  }
 }
 
 async function purgeMcpAgentSessions(input: {
-	env: Env
-	userId: string
-	sessions: ReadonlyArray<McpAgentSession>
-	warnings: Array<string>
+  env: Env;
+  userId: string;
+  sessions: ReadonlyArray<McpAgentSession>;
+  warnings: Array<string>;
 }) {
-	const namespace = input.env.MCP_OBJECT
-	if (!namespace) {
-		if (input.sessions.length > 0) {
-			input.warnings.push(
-				`MCP_OBJECT binding was unavailable; ${input.sessions.length} MCP agent session(s) were not purged.`,
-			)
-		}
-		return 0
-	}
-	let purged = 0
-	for (const session of input.sessions) {
-		try {
-			const stub = namespace.get(
-				namespace.idFromString(session.doId),
-			) as unknown as {
-				purgeForAccountDeletion: (payload: { userId: string }) => Promise<void>
-			}
-			await stub.purgeForAccountDeletion({ userId: input.userId })
-			purged += 1
-		} catch (error) {
-			input.warnings.push(
-				`MCP agent session purge failed for ${session.doId}: ${getErrorMessage(error)}`,
-			)
-		}
-	}
-	return purged
+  const namespace = input.env.MCP_OBJECT;
+  if (!namespace) {
+    if (input.sessions.length > 0) {
+      input.warnings.push(
+        `MCP_OBJECT binding was unavailable; ${input.sessions.length} MCP agent session(s) were not purged.`,
+      );
+    }
+    return 0;
+  }
+  let purged = 0;
+  for (const session of input.sessions) {
+    try {
+      const stub = namespace.get(
+        namespace.idFromString(session.doId),
+      ) as unknown as {
+        purgeForAccountDeletion: (payload: { userId: string }) => Promise<void>;
+      };
+      await stub.purgeForAccountDeletion({ userId: input.userId });
+      purged += 1;
+    } catch (error) {
+      input.warnings.push(
+        `MCP agent session purge failed for ${session.doId}: ${getErrorMessage(error)}`,
+      );
+    }
+  }
+  return purged;
 }
 
 async function purgePackageRealtimeSessions(input: {
-	env: Env
-	userId: string
-	packages: ReadonlyArray<UserSavedPackageSnapshot>
-	warnings: Array<string>
+  env: Env;
+  userId: string;
+  packages: ReadonlyArray<UserSavedPackageSnapshot>;
+  warnings: Array<string>;
 }): Promise<number> {
-	let purged = 0
-	for (const savedPackage of input.packages.filter((pkg) => pkg.hasApp)) {
-		try {
-			await packageRealtimeSessionRpc({
-				env: input.env,
-				userId: input.userId,
-				packageId: savedPackage.id,
-				kodyId: savedPackage.kodyId,
-				sourceId: savedPackage.sourceId,
-				baseUrl: 'https://account-deletion.invalid',
-			}).purge()
-			purged += 1
-		} catch (error) {
-			const message = getErrorMessage(error)
-			input.warnings.push(
-				`Package realtime session purge failed for ${savedPackage.id}: ${message}`,
-			)
-		}
-	}
-	return purged
+  let purged = 0;
+  for (const savedPackage of input.packages.filter((pkg) => pkg.hasApp)) {
+    try {
+      await packageRealtimeSessionRpc({
+        env: input.env,
+        userId: input.userId,
+        packageId: savedPackage.id,
+        kodyId: savedPackage.kodyId,
+        sourceId: savedPackage.sourceId,
+        baseUrl: "https://account-deletion.invalid",
+      }).purge();
+      purged += 1;
+    } catch (error) {
+      const message = getErrorMessage(error);
+      input.warnings.push(
+        `Package realtime session purge failed for ${savedPackage.id}: ${message}`,
+      );
+    }
+  }
+  return purged;
 }
 
 async function deleteVectorsByIds(input: {
-	env: Env
-	ids: ReadonlyArray<string>
-	warnings: Array<string>
+  env: Env;
+  ids: ReadonlyArray<string>;
+  warnings: Array<string>;
 }): Promise<number> {
-	if (input.ids.length === 0) return 0
-	const index = getCapabilityVectorIndex(input.env)
-	if (!index) {
-		input.warnings.push(
-			`CAPABILITY_VECTOR_INDEX binding was unavailable; ${input.ids.length} user vector(s) were not removed.`,
-		)
-		return 0
-	}
-	let deleted = 0
-	const batchSize = 100
-	for (let offset = 0; offset < input.ids.length; offset += batchSize) {
-		const batch = input.ids.slice(offset, offset + batchSize)
-		try {
-			await index.deleteByIds(batch)
-			deleted += batch.length
-		} catch (error) {
-			const message = getErrorMessage(error)
-			input.warnings.push(`Vectorize deleteByIds batch failed: ${message}`)
-		}
-	}
-	return deleted
+  if (input.ids.length === 0) return 0;
+  const index = getCapabilityVectorIndex(input.env);
+  if (!index) {
+    input.warnings.push(
+      `CAPABILITY_VECTOR_INDEX binding was unavailable; ${input.ids.length} user vector(s) were not removed.`,
+    );
+    return 0;
+  }
+  let deleted = 0;
+  const batchSize = 100;
+  for (let offset = 0; offset < input.ids.length; offset += batchSize) {
+    const batch = input.ids.slice(offset, offset + batchSize);
+    try {
+      await index.deleteByIds(batch);
+      deleted += batch.length;
+    } catch (error) {
+      const message = getErrorMessage(error);
+      input.warnings.push(`Vectorize deleteByIds batch failed: ${message}`);
+    }
+  }
+  return deleted;
 }
 
 async function deleteKvKeys(input: {
-	kv: KVNamespace
-	keys: ReadonlyArray<string>
-	warnings: Array<string>
+  kv: KVNamespace;
+  keys: ReadonlyArray<string>;
+  warnings: Array<string>;
 }): Promise<number> {
-	let deleted = 0
-	for (const key of input.keys) {
-		try {
-			await input.kv.delete(key)
-			deleted += 1
-		} catch (error) {
-			const message = getErrorMessage(error)
-			input.warnings.push(`KV delete failed for ${key}: ${message}`)
-		}
-	}
-	return deleted
+  let deleted = 0;
+  for (const key of input.keys) {
+    try {
+      await input.kv.delete(key);
+      deleted += 1;
+    } catch (error) {
+      const message = getErrorMessage(error);
+      input.warnings.push(`KV delete failed for ${key}: ${message}`);
+    }
+  }
+  return deleted;
 }
 
 async function deleteR2Objects(input: {
-	blobs: R2Bucket
-	keys: ReadonlyArray<string>
-	label: string
-	warnings: Array<string>
+  blobs: R2Bucket;
+  keys: ReadonlyArray<string>;
+  label: string;
+  warnings: Array<string>;
 }): Promise<{ deleted: number; complete: boolean }> {
-	let deleted = 0
-	let complete = true
-	for (const key of input.keys) {
-		try {
-			await input.blobs.delete(key)
-			deleted += 1
-		} catch (error) {
-			const message = error instanceof Error ? error.message : String(error)
-			input.warnings.push(`${input.label} delete failed for ${key}: ${message}`)
-			complete = false
-		}
-	}
-	return { deleted, complete }
+  let deleted = 0;
+  let complete = true;
+  for (const key of input.keys) {
+    try {
+      await input.blobs.delete(key);
+      deleted += 1;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      input.warnings.push(
+        `${input.label} delete failed for ${key}: ${message}`,
+      );
+      complete = false;
+    }
+  }
+  return { deleted, complete };
 }
 
 type AccountEmailCleanupOutcome = {
-	deletedEmailBlobs: number
-	emailCleanupComplete: boolean
-}
+  deletedEmailBlobs: number;
+  emailCleanupComplete: boolean;
+};
 
 async function cleanupAccountEmailBlobs(input: {
-	env: Env
-	userId: string
-	r2Objects: ReadonlyArray<AccountR2ObjectRef>
-	warnings: Array<string>
+  env: Env;
+  userId: string;
+  r2Objects: ReadonlyArray<AccountR2ObjectRef>;
+  warnings: Array<string>;
 }): Promise<AccountEmailCleanupOutcome> {
-	const emailBlobs = input.env.EMAIL_BLOBS
-	if (!emailBlobs) {
-		input.warnings.push(
-			'EMAIL_BLOBS binding was unavailable; email objects were not removed.',
-		)
-		return { deletedEmailBlobs: 0, emailCleanupComplete: false }
-	}
+  const emailBlobs = input.env.EMAIL_BLOBS;
+  if (!emailBlobs) {
+    input.warnings.push(
+      "EMAIL_BLOBS binding was unavailable; email objects were not removed.",
+    );
+    return { deletedEmailBlobs: 0, emailCleanupComplete: false };
+  }
 
-	let deletedEmailBlobs = 0
-	let emailCleanupComplete = true
-	try {
-		deletedEmailBlobs = await deleteAccountEmailBlobPrefixes({
-			bucket: emailBlobs,
-			stableUserId: input.userId,
-		})
-	} catch (error) {
-		input.warnings.push(getErrorMessage(error))
-		emailCleanupComplete = false
-	}
-	const exactDeletes = await deleteR2Objects({
-		blobs: emailBlobs,
-		keys: input.r2Objects
-			.filter((object) => object.binding === 'EMAIL_BLOBS')
-			.filter(
-				(object) =>
-					!object.key.startsWith(`email-raw:v1:${input.userId}/`) &&
-					!object.key.startsWith(`email-attachment:v1:${input.userId}/`),
-			)
-			.map((object) => object.key),
-		label: 'Email blob',
-		warnings: input.warnings,
-	})
-	deletedEmailBlobs += exactDeletes.deleted
-	return {
-		deletedEmailBlobs,
-		emailCleanupComplete: emailCleanupComplete && exactDeletes.complete,
-	}
+  let deletedEmailBlobs = 0;
+  let emailCleanupComplete = true;
+  try {
+    deletedEmailBlobs = await deleteAccountEmailBlobPrefixes({
+      bucket: emailBlobs,
+      stableUserId: input.userId,
+    });
+  } catch (error) {
+    input.warnings.push(getErrorMessage(error));
+    emailCleanupComplete = false;
+  }
+  const exactDeletes = await deleteR2Objects({
+    blobs: emailBlobs,
+    keys: input.r2Objects
+      .filter((object) => object.binding === "EMAIL_BLOBS")
+      .filter(
+        (object) =>
+          !object.key.startsWith(`email-raw:v1:${input.userId}/`) &&
+          !object.key.startsWith(`email-attachment:v1:${input.userId}/`),
+      )
+      .map((object) => object.key),
+    label: "Email blob",
+    warnings: input.warnings,
+  });
+  deletedEmailBlobs += exactDeletes.deleted;
+  return {
+    deletedEmailBlobs,
+    emailCleanupComplete: emailCleanupComplete && exactDeletes.complete,
+  };
 }
 
 async function listKvKeysByPrefix(input: {
-	kv: KVNamespace
-	prefixes: ReadonlyArray<string>
-	warnings: Array<string>
+  kv: KVNamespace;
+  prefixes: ReadonlyArray<string>;
+  warnings: Array<string>;
 }) {
-	const keys = new Set<string>()
-	if (typeof input.kv.list !== 'function') return keys
-	for (const prefix of input.prefixes) {
-		let cursor: string | undefined
-		do {
-			try {
-				const result = await input.kv.list({
-					prefix,
-					cursor,
-				})
-				for (const key of result.keys) {
-					keys.add(key.name)
-				}
-				cursor = result.list_complete ? undefined : result.cursor
-			} catch (error) {
-				const message = getErrorMessage(error)
-				input.warnings.push(
-					`KV prefix listing failed for ${prefix}: ${message}`,
-				)
-				cursor = undefined
-			}
-		} while (cursor)
-	}
-	return keys
+  const keys = new Set<string>();
+  if (typeof input.kv.list !== "function") return keys;
+  for (const prefix of input.prefixes) {
+    let cursor: string | undefined;
+    do {
+      try {
+        const result = await input.kv.list({
+          prefix,
+          cursor,
+        });
+        for (const key of result.keys) {
+          keys.add(key.name);
+        }
+        cursor = result.list_complete ? undefined : result.cursor;
+      } catch (error) {
+        const message = getErrorMessage(error);
+        input.warnings.push(
+          `KV prefix listing failed for ${prefix}: ${message}`,
+        );
+        cursor = undefined;
+      }
+    } while (cursor);
+  }
+  return keys;
 }
 
 async function deleteRetrieverCache(input: {
-	env: Env
-	userId: string
-	warnings: Array<string>
+  env: Env;
+  userId: string;
+  warnings: Array<string>;
 }) {
-	try {
-		return await deleteAllPackageRetrieverCacheEntriesForUser({
-			env: input.env,
-			userId: input.userId,
-		})
-	} catch (error) {
-		const message = getErrorMessage(error)
-		input.warnings.push(`Package retriever KV cleanup failed: ${message}`)
-		return 0
-	}
+  try {
+    return await deleteAllPackageRetrieverCacheEntriesForUser({
+      env: input.env,
+      userId: input.userId,
+    });
+  } catch (error) {
+    const message = getErrorMessage(error);
+    input.warnings.push(`Package retriever KV cleanup failed: ${message}`);
+    return 0;
+  }
 }
 
 async function deleteUserScopedRowsAndUser(input: {
-	env: Env
-	mcpUserId: string
-	dbUserId: number
+  env: Env;
+  mcpUserId: string;
+  dbUserId: number;
 }): Promise<{
-	deletedRowCounts: Record<string, number>
-	updatedRowCounts: Record<string, number>
+  deletedRowCounts: Record<string, number>;
+  updatedRowCounts: Record<string, number>;
 }> {
-	const deletedRowCounts: Record<string, number> = {}
-	const updatedRowCounts: Record<string, number> = {}
-	function recordDeleted(tableName: string, changes: number | undefined) {
-		deletedRowCounts[tableName] =
-			(deletedRowCounts[tableName] ?? 0) + (changes ?? 0)
-	}
-	function recordUpdated(tableName: string, changes: number | undefined) {
-		updatedRowCounts[tableName] =
-			(updatedRowCounts[tableName] ?? 0) + (changes ?? 0)
-	}
-	const operations = accountUserDataTargets.map((target) => {
-		const match = buildUserScopedTargetMatch({
-			target,
-			mcpUserId: input.mcpUserId,
-			dbUserId: input.dbUserId,
-		})
-		const { sql, params } = buildUserScopedDeleteOrUpdateSql(match)
-		return {
-			match,
-			statement: input.env.APP_DB.prepare(sql).bind(...params),
-		}
-	})
-	const userStatement = input.env.APP_DB.prepare(
-		`DELETE FROM users WHERE id = ?`,
-	).bind(input.dbUserId)
-	const results = await input.env.APP_DB.batch([
-		...operations.map((operation) => operation.statement),
-		userStatement,
-	])
-	for (const [index, operation] of operations.entries()) {
-		const changes = results[index]?.meta.changes
-		if (operation.match.mutation.kind === 'delete') {
-			recordDeleted(operation.match.table, changes)
-		} else {
-			recordUpdated(operation.match.table, changes)
-		}
-	}
-	deletedRowCounts.users = results.at(-1)?.meta.changes ?? 0
-	return { deletedRowCounts, updatedRowCounts }
+  const deletedRowCounts: Record<string, number> = {};
+  const updatedRowCounts: Record<string, number> = {};
+  function recordDeleted(tableName: string, changes: number | undefined) {
+    deletedRowCounts[tableName] =
+      (deletedRowCounts[tableName] ?? 0) + (changes ?? 0);
+  }
+  function recordUpdated(tableName: string, changes: number | undefined) {
+    updatedRowCounts[tableName] =
+      (updatedRowCounts[tableName] ?? 0) + (changes ?? 0);
+  }
+  const operations = accountUserDataTargets.map((target) => {
+    const match = buildUserScopedTargetMatch({
+      target,
+      mcpUserId: input.mcpUserId,
+      dbUserId: input.dbUserId,
+    });
+    const { sql, params } = buildUserScopedDeleteOrUpdateSql(match);
+    return {
+      match,
+      statement: input.env.APP_DB.prepare(sql).bind(...params),
+    };
+  });
+  const userStatement = input.env.APP_DB.prepare(
+    `DELETE FROM users WHERE id = ?`,
+  ).bind(input.dbUserId);
+  const results = await input.env.APP_DB.batch([
+    ...operations.map((operation) => operation.statement),
+    userStatement,
+  ]);
+  for (const [index, operation] of operations.entries()) {
+    const changes = results[index]?.meta.changes;
+    if (operation.match.mutation.kind === "delete") {
+      recordDeleted(operation.match.table, changes);
+    } else {
+      recordUpdated(operation.match.table, changes);
+    }
+  }
+  deletedRowCounts.users = results.at(-1)?.meta.changes ?? 0;
+  return { deletedRowCounts, updatedRowCounts };
 }
 
 /**
@@ -950,338 +986,338 @@ async function deleteUserScopedRowsAndUser(input: {
  *   4. Atomically delete user-scoped D1 rows and the user row in one batch.
  */
 export async function deleteUserAccount(input: {
-	env: AccountDeletionEnv
-	dbUserId: number
-	mcpUserId: string
+  env: AccountDeletionEnv;
+  dbUserId: number;
+  mcpUserId: string;
 }): Promise<AccountDeletionResult> {
-	const marked = await markAccountDeleting({
-		db: input.env.APP_DB,
-		dbUserId: input.dbUserId,
-		env: input.env,
-	})
-	if (marked.leaseCount > 0) {
-		if (marked.created) {
-			await abortAccountDeleting({
-				db: input.env.APP_DB,
-				dbUserId: input.dbUserId,
-				env: input.env,
-				expectedDeletingAt: marked.deletingAt,
-			})
-		}
-		throw new AccountDeletionWritersActiveError(marked.leaseCount)
-	}
-	const warnings: Array<string> = []
-	const clearedDurableObjects: Record<string, number> = {}
-	for (const key of getAccountDeletionDurableObjectResultKeys()) {
-		clearedDurableObjects[key] = 0
-	}
-	const result: AccountDeletionResult = {
-		deletedRowCounts: {},
-		updatedRowCounts: {},
-		deletedKvKeys: 0,
-		deletedCommunityAssets: 0,
-		deletedEmailBlobs: 0,
-		deletedArtifactRepos: 0,
-		revokedOAuthGrants: 0,
-		clearedDurableObjects,
-		deletedVectors: 0,
-		warnings,
-	}
+  const marked = await markAccountDeleting({
+    db: input.env.APP_DB,
+    dbUserId: input.dbUserId,
+    env: input.env,
+  });
+  if (marked.leaseCount > 0) {
+    if (marked.created) {
+      await abortAccountDeleting({
+        db: input.env.APP_DB,
+        dbUserId: input.dbUserId,
+        env: input.env,
+        expectedDeletingAt: marked.deletingAt,
+      });
+    }
+    throw new AccountDeletionWritersActiveError(marked.leaseCount);
+  }
+  const warnings: Array<string> = [];
+  const clearedDurableObjects: Record<string, number> = {};
+  for (const key of getAccountDeletionDurableObjectResultKeys()) {
+    clearedDurableObjects[key] = 0;
+  }
+  const result: AccountDeletionResult = {
+    deletedRowCounts: {},
+    updatedRowCounts: {},
+    deletedKvKeys: 0,
+    deletedCommunityAssets: 0,
+    deletedEmailBlobs: 0,
+    deletedArtifactRepos: 0,
+    revokedOAuthGrants: 0,
+    clearedDurableObjects,
+    deletedVectors: 0,
+    warnings,
+  };
 
-	let inventory: UserDeletionInventory
-	try {
-		inventory = await collectUserDeletionInventory({
-			env: input.env,
-			userId: input.mcpUserId,
-			dbUserId: input.dbUserId,
-			warnings,
-		})
-	} catch (error) {
-		if (error instanceof AccountDeletionInventoryError && marked.created) {
-			await abortAccountDeleting({
-				db: input.env.APP_DB,
-				dbUserId: input.dbUserId,
-				env: input.env,
-				expectedDeletingAt: marked.deletingAt,
-			})
-		}
-		throw error
-	}
+  let inventory: UserDeletionInventory;
+  try {
+    inventory = await collectUserDeletionInventory({
+      env: input.env,
+      userId: input.mcpUserId,
+      dbUserId: input.dbUserId,
+      warnings,
+    });
+  } catch (error) {
+    if (error instanceof AccountDeletionInventoryError && marked.created) {
+      await abortAccountDeleting({
+        db: input.env.APP_DB,
+        dbUserId: input.dbUserId,
+        env: input.env,
+        expectedDeletingAt: marked.deletingAt,
+      });
+    }
+    throw error;
+  }
 
-	result.deletedVectors = await deleteVectorsByIds({
-		env: input.env,
-		ids: inventory.vectorIds,
-		warnings,
-	})
+  result.deletedVectors = await deleteVectorsByIds({
+    env: input.env,
+    ids: inventory.vectorIds,
+    warnings,
+  });
 
-	result.deletedArtifactRepos = await cleanupAllUserArtifactRepos({
-		env: input.env,
-		userId: input.mcpUserId,
-		warnings,
-	}).catch((error) => {
-		const message = getErrorMessage(error)
-		warnings.push(`Artifact repo cleanup failed unexpectedly: ${message}`)
-		return 0
-	})
+  result.deletedArtifactRepos = await cleanupAllUserArtifactRepos({
+    env: input.env,
+    userId: input.mcpUserId,
+    warnings,
+  }).catch((error) => {
+    const message = getErrorMessage(error);
+    warnings.push(`Artifact repo cleanup failed unexpectedly: ${message}`);
+    return 0;
+  });
 
-	result.clearedDurableObjects.repoSessions = await purgeRepoSessions({
-		env: input.env,
-		userId: input.mcpUserId,
-		sessions: inventory.repoSessions,
-		warnings,
-	})
-	result.clearedDurableObjects.repoSessionIndexes = await purgeRepoSessionIndex(
-		{
-			env: input.env,
-			userId: input.mcpUserId,
-			warnings,
-		},
-	)
-	result.clearedDurableObjects.mcpClientHubs = await purgeMcpClientHub({
-		env: input.env,
-		userId: input.mcpUserId,
-		warnings,
-	})
-	result.clearedDurableObjects.mcpAgentSessions = await purgeMcpAgentSessions({
-		env: input.env,
-		userId: input.mcpUserId,
-		sessions: inventory.mcpAgentSessions,
-		warnings,
-	})
-	result.clearedDurableObjects.packageRealtimeSessions =
-		await purgePackageRealtimeSessions({
-			env: input.env,
-			userId: input.mcpUserId,
-			packages: inventory.savedPackages,
-			warnings,
-		})
-	result.clearedDurableObjects.storageRunners = await clearStorageRunners({
-		env: input.env,
-		userId: input.mcpUserId,
-		storageIds: inventory.storageIds,
-		warnings,
-	})
-	result.clearedDurableObjects.runLogs = await clearRunLog({
-		env: input.env,
-		userId: input.mcpUserId,
-		warnings,
-	})
-	result.clearedDurableObjects.userMeters = await purgeUserMeter({
-		env: input.env,
-		userId: input.mcpUserId,
-		warnings,
-	})
-	result.clearedDurableObjects.stripePlanRefreshes =
-		await purgeStripePlanRefresh({
-			env: input.env,
-			userId: input.mcpUserId,
-			warnings,
-		})
-	if (input.env.BUNDLE_ARTIFACTS_KV) {
-		const sourceSnapshotKeys = await listKvKeysByPrefix({
-			kv: input.env.BUNDLE_ARTIFACTS_KV,
-			prefixes: [
-				...inventory.sourceSnapshots.flatMap((source) => [
-					`source-snapshot:v1:${source.sourceId}:`,
-					`source-manifest-snapshot:v1:${source.sourceId}:`,
-				]),
-				...inventory.communityListings.flatMap((listing) =>
-					communityIconKvListingPrefixes(listing.id),
-				),
-				// Package-codemod apply snapshots are user-namespaced in KV
-				// (`package-codemod-revert:{userId}:{itemId}`). D1 run items are
-				// deleted separately; purge the orphaned revert trees here rather
-				// than waiting on the 90-day TTL.
-				`package-codemod-revert:${input.mcpUserId}:`,
-			],
-			warnings,
-		})
-		result.deletedKvKeys =
-			(await deleteKvKeys({
-				kv: input.env.BUNDLE_ARTIFACTS_KV,
-				keys: Array.from(
-					new Set([...inventory.bundleKvKeys, ...sourceSnapshotKeys]),
-				),
-				warnings,
-			})) +
-			(await deleteRetrieverCache({
-				env: input.env,
-				userId: input.mcpUserId,
-				warnings,
-			}))
-	} else if (
-		inventory.bundleKvKeys.length > 0 ||
-		inventory.savedPackages.length > 0
-	) {
-		warnings.push(
-			`BUNDLE_ARTIFACTS_KV binding was unavailable; ${inventory.bundleKvKeys.length} bundle/source/community key(s) and retriever cache entries for ${inventory.savedPackages.length} package(s) referenced by the deleted user were not removed and must be cleaned up manually.`,
-		)
-	}
+  result.clearedDurableObjects.repoSessions = await purgeRepoSessions({
+    env: input.env,
+    userId: input.mcpUserId,
+    sessions: inventory.repoSessions,
+    warnings,
+  });
+  result.clearedDurableObjects.repoSessionIndexes = await purgeRepoSessionIndex(
+    {
+      env: input.env,
+      userId: input.mcpUserId,
+      warnings,
+    },
+  );
+  result.clearedDurableObjects.mcpClientHubs = await purgeMcpClientHub({
+    env: input.env,
+    userId: input.mcpUserId,
+    warnings,
+  });
+  result.clearedDurableObjects.mcpAgentSessions = await purgeMcpAgentSessions({
+    env: input.env,
+    userId: input.mcpUserId,
+    sessions: inventory.mcpAgentSessions,
+    warnings,
+  });
+  result.clearedDurableObjects.packageRealtimeSessions =
+    await purgePackageRealtimeSessions({
+      env: input.env,
+      userId: input.mcpUserId,
+      packages: inventory.savedPackages,
+      warnings,
+    });
+  result.clearedDurableObjects.storageRunners = await clearStorageRunners({
+    env: input.env,
+    userId: input.mcpUserId,
+    storageIds: inventory.storageIds,
+    warnings,
+  });
+  result.clearedDurableObjects.runLogs = await clearRunLog({
+    env: input.env,
+    userId: input.mcpUserId,
+    warnings,
+  });
+  result.clearedDurableObjects.userMeters = await purgeUserMeter({
+    env: input.env,
+    userId: input.mcpUserId,
+    warnings,
+  });
+  result.clearedDurableObjects.stripePlanRefreshes =
+    await purgeStripePlanRefresh({
+      env: input.env,
+      userId: input.mcpUserId,
+      warnings,
+    });
+  if (input.env.BUNDLE_ARTIFACTS_KV) {
+    const sourceSnapshotKeys = await listKvKeysByPrefix({
+      kv: input.env.BUNDLE_ARTIFACTS_KV,
+      prefixes: [
+        ...inventory.sourceSnapshots.flatMap((source) => [
+          `source-snapshot:v1:${source.sourceId}:`,
+          `source-manifest-snapshot:v1:${source.sourceId}:`,
+        ]),
+        ...inventory.communityListings.flatMap((listing) =>
+          communityIconKvListingPrefixes(listing.id),
+        ),
+        // Package-codemod apply snapshots are user-namespaced in KV
+        // (`package-codemod-revert:{userId}:{itemId}`). D1 run items are
+        // deleted separately; purge the orphaned revert trees here rather
+        // than waiting on the 90-day TTL.
+        `package-codemod-revert:${input.mcpUserId}:`,
+      ],
+      warnings,
+    });
+    result.deletedKvKeys =
+      (await deleteKvKeys({
+        kv: input.env.BUNDLE_ARTIFACTS_KV,
+        keys: Array.from(
+          new Set([...inventory.bundleKvKeys, ...sourceSnapshotKeys]),
+        ),
+        warnings,
+      })) +
+      (await deleteRetrieverCache({
+        env: input.env,
+        userId: input.mcpUserId,
+        warnings,
+      }));
+  } else if (
+    inventory.bundleKvKeys.length > 0 ||
+    inventory.savedPackages.length > 0
+  ) {
+    warnings.push(
+      `BUNDLE_ARTIFACTS_KV binding was unavailable; ${inventory.bundleKvKeys.length} bundle/source/community key(s) and retriever cache entries for ${inventory.savedPackages.length} package(s) referenced by the deleted user were not removed and must be cleaned up manually.`,
+    );
+  }
 
-	try {
-		result.deletedCommunityAssets = await deleteAccountCommunityAssetPrefixes({
-			bucket: input.env.COMMUNITY_ASSETS,
-			stableUserId: input.mcpUserId,
-			listingIds: inventory.communityListings.map((listing) => listing.id),
-		})
-	} catch (error) {
-		warnings.push(getErrorMessage(error))
-	}
-	const emailCleanup = await cleanupAccountEmailBlobs({
-		env: input.env,
-		userId: input.mcpUserId,
-		r2Objects: inventory.r2Objects,
-		warnings,
-	})
-	result.deletedEmailBlobs = emailCleanup.deletedEmailBlobs
+  try {
+    result.deletedCommunityAssets = await deleteAccountCommunityAssetPrefixes({
+      bucket: input.env.COMMUNITY_ASSETS,
+      stableUserId: input.mcpUserId,
+      listingIds: inventory.communityListings.map((listing) => listing.id),
+    });
+  } catch (error) {
+    warnings.push(getErrorMessage(error));
+  }
+  const emailCleanup = await cleanupAccountEmailBlobs({
+    env: input.env,
+    userId: input.mcpUserId,
+    r2Objects: inventory.r2Objects,
+    warnings,
+  });
+  result.deletedEmailBlobs = emailCleanup.deletedEmailBlobs;
 
-	const discordConnection = await input.env.APP_DB.prepare(
-		`SELECT provider_id FROM oauth_connections
+  const discordConnection = await input.env.APP_DB.prepare(
+    `SELECT provider_id FROM oauth_connections
 		 WHERE user_id = ? AND provider_name = 'discord'`,
-	)
-		.bind(input.dbUserId)
-		.first<{ provider_id: string }>()
-		.catch((error) => {
-			warnings.push(
-				`Discord connection lookup failed: ${getErrorMessage(error)}`,
-			)
-			return null
-		})
-	if (discordConnection?.provider_id) {
-		const discordRoleCleanup = await maybeRemoveDiscordGuildRoles({
-			env: input.env,
-			discordUserId: discordConnection.provider_id,
-		})
-		const discordRoleResult = summarizeDiscordGuildRoleSync(discordRoleCleanup)
-		if (
-			discordRoleResult.status === 'error' ||
-			discordRoleResult.status === 'forbidden'
-		) {
-			warnings.push(
-				discordRoleResult.status === 'error'
-					? `Discord role cleanup failed: ${discordRoleResult.message}`
-					: 'Discord role cleanup was forbidden.',
-			)
-		}
-	}
+  )
+    .bind(input.dbUserId)
+    .first<{ provider_id: string }>()
+    .catch((error) => {
+      warnings.push(
+        `Discord connection lookup failed: ${getErrorMessage(error)}`,
+      );
+      return null;
+    });
+  if (discordConnection?.provider_id) {
+    const discordRoleCleanup = await maybeRemoveDiscordGuildRoles({
+      env: input.env,
+      discordUserId: discordConnection.provider_id,
+    });
+    const discordRoleResult = summarizeDiscordGuildRoleSync(discordRoleCleanup);
+    if (
+      discordRoleResult.status === "error" ||
+      discordRoleResult.status === "forbidden"
+    ) {
+      warnings.push(
+        discordRoleResult.status === "error"
+          ? `Discord role cleanup failed: ${discordRoleResult.message}`
+          : "Discord role cleanup was forbidden.",
+      );
+    }
+  }
 
-	const helpers = input.env.OAUTH_PROVIDER
-	if (helpers) {
-		if (helpers.deleteClient) {
-			const deleteClient = helpers.deleteClient
-			await deleteOwnedMcpOauthClients({
-				db: input.env.APP_DB,
-				helpers: {
-					async deleteClient(clientId) {
-						await deleteClient(clientId)
-					},
-				},
-				userId: input.dbUserId,
-				warnings,
-			})
-		} else {
-			const ownedClientIds = await listOwnedUserMcpOauthClientIds(
-				input.env.APP_DB,
-				input.dbUserId,
-			)
-			if (ownedClientIds.length > 0) {
-				warnings.push(
-					'OAuth provider does not support client deletion; MCP OAuth clients were not removed.',
-				)
-			}
-		}
-		try {
-			result.revokedOAuthGrants = await revokeAllOAuthGrantsBestEffort({
-				helpers,
-				userId: input.mcpUserId,
-				warnings,
-			})
-		} catch (error) {
-			const message = getErrorMessage(error)
-			warnings.push(`OAuth grant revocation failed unexpectedly: ${message}`)
-		}
-	} else {
-		warnings.push(
-			'OAuth provider binding was unavailable; OAuth grants were not revoked.',
-		)
-	}
+  const helpers = input.env.OAUTH_PROVIDER;
+  if (helpers) {
+    if (helpers.deleteClient) {
+      const deleteClient = helpers.deleteClient;
+      await deleteOwnedMcpOauthClients({
+        db: input.env.APP_DB,
+        helpers: {
+          async deleteClient(clientId) {
+            await deleteClient(clientId);
+          },
+        },
+        userId: input.dbUserId,
+        warnings,
+      });
+    } else {
+      const ownedClientIds = await listOwnedUserMcpOauthClientIds(
+        input.env.APP_DB,
+        input.dbUserId,
+      );
+      if (ownedClientIds.length > 0) {
+        warnings.push(
+          "OAuth provider does not support client deletion; MCP OAuth clients were not removed.",
+        );
+      }
+    }
+    try {
+      result.revokedOAuthGrants = await revokeAllOAuthGrantsBestEffort({
+        helpers,
+        userId: input.mcpUserId,
+        warnings,
+      });
+    } catch (error) {
+      const message = getErrorMessage(error);
+      warnings.push(`OAuth grant revocation failed unexpectedly: ${message}`);
+    }
+  } else {
+    warnings.push(
+      "OAuth provider binding was unavailable; OAuth grants were not revoked.",
+    );
+  }
 
-	// Keep Mailbox metadata while the account remains deletion-fenced so a retry
-	// can re-enumerate authoritative email keys. The typed email phase prevents
-	// an unrelated warning-list refactor from purging after incomplete email
-	// cleanup; the existing all-surfaces policy additionally requires no warning.
-	if (emailCleanup.emailCleanupComplete && warnings.length === 0) {
-		result.clearedDurableObjects.mailboxes = await purgeMailbox({
-			env: input.env,
-			userId: input.mcpUserId,
-			warnings,
-		})
-	}
+  // Keep Mailbox metadata while the account remains deletion-fenced so a retry
+  // can re-enumerate authoritative email keys. The typed email phase prevents
+  // an unrelated warning-list refactor from purging after incomplete email
+  // cleanup; the existing all-surfaces policy additionally requires no warning.
+  if (emailCleanup.emailCleanupComplete && warnings.length === 0) {
+    result.clearedDurableObjects.mailboxes = await purgeMailbox({
+      env: input.env,
+      userId: input.mcpUserId,
+      warnings,
+    });
+  }
 
-	if (warnings.length > 0) {
-		throw new AccountDeletionCleanupError(warnings, result)
-	}
+  if (warnings.length > 0) {
+    throw new AccountDeletionCleanupError(warnings, result);
+  }
 
-	// Jobs data lives in the jobs worker's database (ADR 0016), so it cannot
-	// join the atomic APP_DB deletion below. Purge it fail-closed here, after
-	// every best-effort cleanup succeeded; a failure aborts before the user row
-	// is removed so a retry can purge again (purgeUser is idempotent).
-	result.clearedDurableObjects.jobManagers = await purgeJobManager({
-		env: input.env,
-		userId: input.mcpUserId,
-		warnings,
-	})
-	if (warnings.length > 0) {
-		throw new AccountDeletionCleanupError(warnings, result)
-	}
+  // Jobs data lives in the jobs worker's database (ADR 0016), so it cannot
+  // join the atomic APP_DB deletion below. Purge it fail-closed here, after
+  // every best-effort cleanup succeeded; a failure aborts before the user row
+  // is removed so a retry can purge again (purgeUser is idempotent).
+  result.clearedDurableObjects.jobManagers = await purgeJobManager({
+    env: input.env,
+    userId: input.mcpUserId,
+    warnings,
+  });
+  if (warnings.length > 0) {
+    throw new AccountDeletionCleanupError(warnings, result);
+  }
 
-	if (inventory.stripeCustomerId) {
-		try {
-			await cancelSubscriptionsAndDeleteStripeCustomer({
-				env: input.env,
-				customerId: inventory.stripeCustomerId,
-			})
-		} catch (error) {
-			const warning = `Stripe customer cleanup failed during account deletion: ${getErrorMessage(error)}`
-			warnings.push(warning)
-			console.error('account_deletion_stripe_cleanup_failed', {
-				userId: input.mcpUserId,
-				error,
-			})
-		}
-	}
+  if (inventory.stripeCustomerId) {
+    try {
+      await cancelSubscriptionsAndDeleteStripeCustomer({
+        env: input.env,
+        customerId: inventory.stripeCustomerId,
+      });
+    } catch (error) {
+      const warning = `Stripe customer cleanup failed during account deletion: ${getErrorMessage(error)}`;
+      warnings.push(warning);
+      console.error("account_deletion_stripe_cleanup_failed", {
+        userId: input.mcpUserId,
+        error,
+      });
+    }
+  }
 
-	try {
-		const d1Cleanup = await deleteUserScopedRowsAndUser({
-			env: input.env,
-			mcpUserId: input.mcpUserId,
-			dbUserId: input.dbUserId,
-		})
-		result.deletedRowCounts = {
-			...result.deletedRowCounts,
-			...d1Cleanup.deletedRowCounts,
-		}
-		result.updatedRowCounts = d1Cleanup.updatedRowCounts
-	} catch (error) {
-		const failure = `Atomic D1 account deletion failed: ${getErrorMessage(error)}`
-		warnings.push(failure)
-		throw new AccountDeletionCleanupError(warnings, result)
-	}
+  try {
+    const d1Cleanup = await deleteUserScopedRowsAndUser({
+      env: input.env,
+      mcpUserId: input.mcpUserId,
+      dbUserId: input.dbUserId,
+    });
+    result.deletedRowCounts = {
+      ...result.deletedRowCounts,
+      ...d1Cleanup.deletedRowCounts,
+    };
+    result.updatedRowCounts = d1Cleanup.updatedRowCounts;
+  } catch (error) {
+    const failure = `Atomic D1 account deletion failed: ${getErrorMessage(error)}`;
+    warnings.push(failure);
+    throw new AccountDeletionCleanupError(warnings, result);
+  }
 
-	// The D1 user row is gone, so a later signup with the same email is a new
-	// account. Drop the UserMeter tombstone `purge()` restored; leaving it
-	// would fence every write (including `/mcp`) for that hashed stable id.
-	try {
-		await clearUserMeterDeletionTombstone({
-			env: input.env,
-			stableUserId: input.mcpUserId,
-		})
-	} catch (error) {
-		console.error('account_deletion_user_meter_tombstone_clear_failed', {
-			userId: input.mcpUserId,
-			error,
-		})
-	}
+  // The D1 user row is gone, so a later signup with the same email is a new
+  // account. Drop the UserMeter tombstone `purge()` restored; leaving it
+  // would fence every write (including `/mcp`) for that hashed stable id.
+  try {
+    await clearUserMeterDeletionTombstone({
+      env: input.env,
+      stableUserId: input.mcpUserId,
+    });
+  } catch (error) {
+    console.error("account_deletion_user_meter_tombstone_clear_failed", {
+      userId: input.mcpUserId,
+      error,
+    });
+  }
 
-	return result
+  return result;
 }

--- a/packages/worker/src/app/account-deletion.ts
+++ b/packages/worker/src/app/account-deletion.ts
@@ -143,9 +143,19 @@ type UserDeletionInventory = {
 	communityListings: Array<AccountCommunityListingSnapshot>
 }
 
+/**
+ * Every Stripe status that can still produce an invoice or resume billing.
+ * Only `canceled` and `incomplete_expired` are terminal; `past_due`, `unpaid`,
+ * and `paused` keep dunning or can be resumed, and `incomplete` can still
+ * activate when the first payment succeeds.
+ */
 const stripeSubscriptionStatusesCanceledOnAccountDeletion = new Set([
 	'active',
 	'trialing',
+	'past_due',
+	'unpaid',
+	'paused',
+	'incomplete',
 ])
 
 export class AccountDeletionInventoryError extends Error {
@@ -468,7 +478,8 @@ function isStripeSubscriptionBillable(subscription: StripeSubscription) {
 }
 
 /**
- * Cancels every active/trialing subscription and throws
+ * Cancels every subscription that can still bill (see
+ * `stripeSubscriptionStatusesCanceledOnAccountDeletion`) and throws
  * {@link AccountDeletionBillingError} when any is still billable afterwards.
  * Runs before any destructive cleanup so a Stripe outage retains the account
  * instead of leaving a paying customer with no account or portal access.

--- a/packages/worker/src/app/handlers/account-delete.node.test.ts
+++ b/packages/worker/src/app/handlers/account-delete.node.test.ts
@@ -3,7 +3,10 @@ import { RequestContext } from 'remix/router'
 import type * as AccountDeletion from '#app/account-deletion.ts'
 import { setAuthSessionSecret } from '#app/auth-session.ts'
 import { accountDeletionConfirmationPhrase } from '#universal/account-deletion-confirmation.ts'
-import { auditEventSummaries } from '#worker/test-support/audit-log-spy.ts'
+import {
+	auditEventSummaries,
+	logAuditEventSpy,
+} from '#worker/test-support/audit-log-spy.ts'
 
 const mocks = vi.hoisted(() => ({
 	readAuthenticatedAppUserForDeletion: vi.fn(),
@@ -45,6 +48,7 @@ vi.mock('@kody-internal/shared/password-hash.ts', () => ({
 }))
 
 const { createAccountDeleteHandler } = await import('./account-delete.ts')
+const { AccountDeletionBillingError } = await import('#app/account-deletion.ts')
 
 const testCookieSecret = 'test-cookie-secret-0123456789abcdef0123456789'
 
@@ -170,4 +174,37 @@ test('account deletion requires GOODBYE KODY, password when one exists, and emit
 		'account_delete:success',
 		'account_delete:success',
 	])
+})
+
+test('a Stripe cancellation failure keeps the session and tells the user the subscription was not canceled', async () => {
+	mocks.readAuthenticatedAppUserForDeletion.mockResolvedValue(signedInUser)
+	mocks.findOne.mockResolvedValue({
+		id: 7,
+		password_hash: 'oauth_created_no_usable_password',
+	})
+	mocks.deleteUserAccount.mockClear()
+	mocks.scheduleUserDeletedEvent.mockClear()
+	mocks.deleteUserAccount.mockRejectedValueOnce(
+		new AccountDeletionBillingError([
+			'Stripe subscription sub_1 could not be canceled: HTTP 503',
+		]),
+	)
+
+	const response = await requestDelete({
+		confirmation: accountDeletionConfirmationPhrase,
+	})
+
+	expect(response.status).toBe(503)
+	expect(await response.json()).toEqual({
+		error:
+			'We could not cancel your subscription, so your account was not deleted. Try again in a few minutes or contact support.',
+	})
+	expect(response.headers.get('Set-Cookie')).toBeNull()
+	expect(mocks.scheduleUserDeletedEvent).not.toHaveBeenCalled()
+	expect(auditEventSummaries()).toEqual(['account_delete:failure'])
+	expect(logAuditEventSpy.mock.calls.at(-1)?.[0]).toMatchObject({
+		action: 'account_delete',
+		result: 'failure',
+		reason: 'billing_cancel_failed',
+	})
 })

--- a/packages/worker/src/app/handlers/account-delete.ts
+++ b/packages/worker/src/app/handlers/account-delete.ts
@@ -9,6 +9,7 @@ import { destroyAuthCookie, isSecureRequest } from '#app/auth-session.ts'
 import { isAccountDeletionConfirmation } from '#universal/account-deletion-confirmation.ts'
 import { type routes } from '#universal/routes.ts'
 import {
+	AccountDeletionBillingError,
 	AccountDeletionCleanupError,
 	AccountDeletionInventoryError,
 	deleteUserAccount,
@@ -29,6 +30,31 @@ function readDeleteRequestFields(body: unknown) {
 			typeof record.confirmation === 'string' ? record.confirmation : null,
 		password: typeof record.password === 'string' ? record.password : null,
 	}
+}
+
+type AccountDeletionFailure =
+	| AccountDeletionInventoryError
+	| AccountDeletionBillingError
+	| AccountDeletionCleanupError
+	| AccountDeletionWritersActiveError
+
+function accountDeletionFailureReason(error: AccountDeletionFailure) {
+	if (error instanceof AccountDeletionWritersActiveError)
+		return 'writers_active'
+	if (error instanceof AccountDeletionInventoryError) {
+		return 'inventory_incomplete'
+	}
+	if (error instanceof AccountDeletionBillingError) {
+		return 'billing_cancel_failed'
+	}
+	return 'cleanup_incomplete'
+}
+
+function accountDeletionFailureMessage(error: AccountDeletionFailure) {
+	if (error instanceof AccountDeletionBillingError) {
+		return 'We could not cancel your subscription, so your account was not deleted. Try again in a few minutes or contact support.'
+	}
+	return 'Account deletion could not complete safely. Try again later.'
 }
 
 export function createAccountDeleteHandler(env: Env) {
@@ -125,6 +151,7 @@ export function createAccountDeleteHandler(env: Env) {
 				if (
 					!(
 						error instanceof AccountDeletionInventoryError ||
+						error instanceof AccountDeletionBillingError ||
 						error instanceof AccountDeletionCleanupError ||
 						error instanceof AccountDeletionWritersActiveError
 					)
@@ -139,18 +166,10 @@ export function createAccountDeleteHandler(env: Env) {
 					email: user.email,
 					ip: requestIp,
 					path: url.pathname,
-					reason:
-						error instanceof AccountDeletionWritersActiveError
-							? 'writers_active'
-							: error instanceof AccountDeletionInventoryError
-								? 'inventory_incomplete'
-								: 'cleanup_incomplete',
+					reason: accountDeletionFailureReason(error),
 				})
 				return Response.json(
-					{
-						error:
-							'Account deletion could not complete safely. Try again later.',
-					},
+					{ error: accountDeletionFailureMessage(error) },
 					{ status: 503 },
 				)
 			}

--- a/packages/worker/src/billing/stripe-client.node.test.ts
+++ b/packages/worker/src/billing/stripe-client.node.test.ts
@@ -243,6 +243,32 @@ test('stripe client immediately cancels subscriptions and deletes customers', as
 		expect(JSON.stringify(consoleError.mock.calls)).not.toContain(
 			'cus_sensitive_identifier',
 		)
+
+		// Canceling a subscription Stripe no longer knows is idempotent success;
+		// any other API failure still surfaces with its Stripe error code.
+		fetchMock.mockResolvedValueOnce(
+			jsonResponse(
+				{
+					error: {
+						code: 'resource_missing',
+						message: 'No such subscription: sub_gone',
+					},
+				},
+				404,
+			),
+		)
+		await expect(cancelSubscription(env, 'sub_gone')).resolves.toBeUndefined()
+		fetchMock.mockResolvedValueOnce(
+			jsonResponse(
+				{ error: { code: 'rate_limit', message: 'Too many requests' } },
+				429,
+			),
+		)
+		await expect(cancelSubscription(env, 'sub_busy')).rejects.toMatchObject({
+			name: 'StripeApiError',
+			status: 429,
+			code: 'rate_limit',
+		})
 	} finally {
 		vi.unstubAllGlobals()
 		consoleError.mockReset()

--- a/packages/worker/src/billing/stripe-client.ts
+++ b/packages/worker/src/billing/stripe-client.ts
@@ -21,11 +21,26 @@ const defaultStripeApiBaseUrl = 'https://api.stripe.com'
 
 export class StripeApiError extends Error {
 	readonly status: number
-	constructor(message: string, options: { status: number; cause?: unknown }) {
+	/** Stripe `error.code` (for example `resource_missing`) when the body had one. */
+	readonly code: string | null
+	constructor(
+		message: string,
+		options: { status: number; code?: string | null; cause?: unknown },
+	) {
 		super(message, { cause: options.cause })
 		this.name = 'StripeApiError'
 		this.status = options.status
+		this.code = options.code ?? null
 	}
+}
+
+const stripeErrorBodySchema = object({
+	error: object({ code: optional(string()) }),
+})
+
+function readStripeErrorCode(body: unknown): string | null {
+	const parsed = parseSafe(stripeErrorBodySchema, body)
+	return parsed.success ? (parsed.value.error.code ?? null) : null
 }
 
 export class BillingNotConfiguredError extends Error {
@@ -167,7 +182,7 @@ async function stripeRequest(
 		})
 		throw new StripeApiError(
 			`Stripe API request failed with HTTP ${response.status}.`,
-			{ status: response.status },
+			{ status: response.status, code: readStripeErrorCode(body) },
 		)
 	}
 
@@ -320,6 +335,10 @@ export async function listSubscriptions(
  * Immediately cancels a subscription. Account deletion intentionally does not
  * use cancel_at_period_end because the user is relinquishing portal access and
  * all account state.
+ *
+ * Idempotent: a subscription Stripe no longer knows (`resource_missing`) is
+ * treated as canceled so a retried account deletion does not fail on a
+ * subscription an earlier attempt already removed.
  */
 export async function cancelSubscription(
 	env: StripeEnv,
@@ -329,10 +348,18 @@ export async function cancelSubscription(
 	if (!trimmed) {
 		throw new StripeApiError('Subscription id is required.', { status: 400 })
 	}
-	const body = await stripeRequest(env, {
-		method: 'DELETE',
-		path: `/v1/subscriptions/${encodeURIComponent(trimmed)}`,
-	})
+	let body: unknown
+	try {
+		body = await stripeRequest(env, {
+			method: 'DELETE',
+			path: `/v1/subscriptions/${encodeURIComponent(trimmed)}`,
+		})
+	} catch (error) {
+		if (error instanceof StripeApiError && error.code === 'resource_missing') {
+			return
+		}
+		throw error
+	}
 	const parsed = parseSafe(canceledSubscriptionSchema, body)
 	if (!parsed.success || parsed.value.status !== 'canceled') {
 		throw new StripeApiError('Unexpected Stripe canceled subscription shape.', {

--- a/packages/worker/src/test-support/account-deletion.ts
+++ b/packages/worker/src/test-support/account-deletion.ts
@@ -1,602 +1,600 @@
-import { type deleteUserAccount } from "#worker/app/account-deletion.ts";
-import { createInMemoryUserMeterEnv } from "#worker/test-support/user-meter.ts";
-import { createInMemoryRepoSessionIndexEnv } from "#worker/test-support/repo-session-index.ts";
+import { type deleteUserAccount } from '#worker/app/account-deletion.ts'
+import { createInMemoryUserMeterEnv } from '#worker/test-support/user-meter.ts'
+import { createInMemoryRepoSessionIndexEnv } from '#worker/test-support/repo-session-index.ts'
 
-export type RowMap = Record<string, Array<Record<string, unknown>>>;
+export type RowMap = Record<string, Array<Record<string, unknown>>>
 
 export function createTestDb(
-  initial: RowMap,
-  options?: {
-    failSelectContaining?: string;
-    failRunContaining?: string;
-    onSelect?: (query: string) => Promise<void>;
-  },
+	initial: RowMap,
+	options?: {
+		failSelectContaining?: string
+		failRunContaining?: string
+		onSelect?: (query: string) => Promise<void>
+	},
 ): {
-  db: D1Database;
-  rows: RowMap;
+	db: D1Database
+	rows: RowMap
 } {
-  const rows: RowMap = {};
-  for (const [key, value] of Object.entries(initial)) {
-    rows[key] = value.map((row) => {
-      const copy = { ...row };
-      if (
-        key === "users" &&
-        (copy["stable_user_id"] == null || copy["stable_user_id"] === "")
-      ) {
-        const id = Number(copy["id"]);
-        if (id === 1) copy["stable_user_id"] = "user-aaa";
-        else if (id === 2) copy["stable_user_id"] = "user-bbb";
-      }
-      return copy;
-    });
-  }
+	const rows: RowMap = {}
+	for (const [key, value] of Object.entries(initial)) {
+		rows[key] = value.map((row) => {
+			const copy = { ...row }
+			if (
+				key === 'users' &&
+				(copy['stable_user_id'] == null || copy['stable_user_id'] === '')
+			) {
+				const id = Number(copy['id'])
+				if (id === 1) copy['stable_user_id'] = 'user-aaa'
+				else if (id === 2) copy['stable_user_id'] = 'user-bbb'
+			}
+			return copy
+		})
+	}
 
-  function deleteByPredicate(
-    table: string,
-    predicate: (row: Record<string, unknown>) => boolean,
-  ) {
-    const remaining: Array<Record<string, unknown>> = [];
-    let removed = 0;
-    for (const row of rows[table] ?? []) {
-      if (predicate(row)) {
-        removed += 1;
-        continue;
-      }
-      remaining.push(row);
-    }
-    rows[table] = remaining;
-    return removed;
-  }
+	function deleteByPredicate(
+		table: string,
+		predicate: (row: Record<string, unknown>) => boolean,
+	) {
+		const remaining: Array<Record<string, unknown>> = []
+		let removed = 0
+		for (const row of rows[table] ?? []) {
+			if (predicate(row)) {
+				removed += 1
+				continue
+			}
+			remaining.push(row)
+		}
+		rows[table] = remaining
+		return removed
+	}
 
-  function selectIds(
-    table: string,
-    where: (row: Record<string, unknown>) => boolean,
-  ) {
-    return (rows[table] ?? []).filter(where).map((row) => row["id"]);
-  }
+	function selectIds(
+		table: string,
+		where: (row: Record<string, unknown>) => boolean,
+	) {
+		return (rows[table] ?? []).filter(where).map((row) => row['id'])
+	}
 
-  const db = {
-    prepare(query: string) {
-      const trimmed = query.replace(/\s+/g, " ").trim();
-      const lower = trimmed.toLowerCase();
-      return {
-        bind(...params: Array<unknown>) {
-          return {
-            async all<T>() {
-              await options?.onSelect?.(lower);
-              if (
-                options?.failSelectContaining &&
-                lower.includes(options.failSelectContaining)
-              ) {
-                throw new Error("simulated inventory read failure");
-              }
-              let results: Array<unknown> = [];
-              const userId = params[0] as string;
-              if (
-                lower ===
-                "select client_id from user_mcp_oauth_clients where user_id = ?"
-              ) {
-                const numericId = Number(params[0]);
-                results = (rows.user_mcp_oauth_clients ?? [])
-                  .filter((row) => Number(row["user_id"]) === numericId)
-                  .map((row) => ({ client_id: row["client_id"] }));
-                return { results: results as Array<T>, meta: { changes: 0 } };
-              }
-              if (
-                lower ===
-                "select deleting_at from users where stable_user_id = ?"
-              ) {
-                results = (rows.users ?? [])
-                  .filter((row) => row["stable_user_id"] === userId)
-                  .map((row) => ({
-                    deleting_at: row["deleting_at"] ?? null,
-                  }));
-                return { results: results as Array<T>, meta: { changes: 0 } };
-              }
-              if (lower === "select stable_user_id from users where id = ?") {
-                const numericId = Number(params[0]);
-                results = (rows.users ?? [])
-                  .filter((row) => Number(row["id"]) === numericId)
-                  .map((row) => ({
-                    stable_user_id: row["stable_user_id"],
-                  }));
-                return { results: results as Array<T>, meta: { changes: 0 } };
-              }
-              if (
-                lower ===
-                "select stable_user_id, deleting_at from users where id = ?"
-              ) {
-                const numericId = Number(params[0]);
-                results = (rows.users ?? [])
-                  .filter((row) => Number(row["id"]) === numericId)
-                  .map((row) => ({
-                    stable_user_id: row["stable_user_id"],
-                    deleting_at: row["deleting_at"] ?? null,
-                  }));
-                return { results: results as Array<T>, meta: { changes: 0 } };
-              }
-              if (
-                lower ===
-                "select id from saved_packages where user_id = ? and has_app = 1"
-              ) {
-                results = (rows.saved_packages ?? [])
-                  .filter(
-                    (row) =>
-                      row["user_id"] === userId &&
-                      (row["has_app"] === 1 ||
-                        row["has_app"] === "1" ||
-                        row["has_app"] === true),
-                  )
-                  .map((row) => ({ id: row["id"] }));
-                return { results: results as Array<T>, meta: { changes: 0 } };
-              }
-              if (
-                lower ===
-                "select id, published_commit from entity_sources where user_id = ?"
-              ) {
-                results = (rows.entity_sources ?? [])
-                  .filter((row) => row["user_id"] === userId)
-                  .map((row) => ({
-                    id: row["id"],
-                    published_commit: row["published_commit"] ?? null,
-                  }));
-                return { results: results as Array<T>, meta: { changes: 0 } };
-              }
-              if (
-                lower ===
-                "select id, kody_id, source_id, has_app from saved_packages where user_id = ?"
-              ) {
-                results = (rows.saved_packages ?? [])
-                  .filter((row) => row["user_id"] === userId)
-                  .map((row) => ({
-                    id: row["id"],
-                    kody_id: row["kody_id"],
-                    source_id: row["source_id"],
-                    has_app: row["has_app"],
-                  }));
-                return { results: results as Array<T>, meta: { changes: 0 } };
-              }
-              if (
-                lower ===
-                "select do_id from mcp_agent_sessions where user_id = ? order by do_id"
-              ) {
-                results = (rows.mcp_agent_sessions ?? [])
-                  .filter((row) => row["user_id"] === userId)
-                  .map((row) => ({ do_id: row["do_id"] }));
-                return { results: results as Array<T>, meta: { changes: 0 } };
-              }
-              if (
-                lower.includes(
-                  "select storage_id as storageid from user_storage_buckets",
-                )
-              ) {
-                results = (rows.user_storage_buckets ?? [])
-                  .filter(
-                    (row) =>
-                      row["user_id"] === userId &&
-                      (!lower.includes("kind <> 'repo_session'") ||
-                        row["kind"] !== "repo_session"),
-                  )
-                  .map((row) => ({ storageId: row["storage_id"] }))
-                  .sort((left, right) =>
-                    String(left.storageId).localeCompare(
-                      String(right.storageId),
-                    ),
-                  );
-                return { results: results as Array<T>, meta: { changes: 0 } };
-              }
-              if (
-                lower.includes("from community_listings") &&
-                lower.includes("entity_sources.published_commit")
-              ) {
-                results = (rows.community_listings ?? [])
-                  .filter((row) => row["owner_user_id"] === userId)
-                  .map((row, index) => {
-                    const source = (rows.entity_sources ?? []).find(
-                      (sourceRow) =>
-                        sourceRow["id"] === row["source_id"] &&
-                        sourceRow["user_id"] === row["owner_user_id"],
-                    );
-                    return {
-                      account_r2_rowid: index + 1,
-                      id: row["id"],
-                      pinned_commit: row["pinned_commit"],
-                      source_published_commit:
-                        source?.["published_commit"] ?? null,
-                    };
-                  });
-                return { results: results as Array<T>, meta: { changes: 0 } };
-              }
-              const m = lower.match(/^select id from (\w+) where user_id = \?/);
-              if (m) {
-                const table = m[1] as string;
-                results = (rows[table] ?? [])
-                  .filter((row) => row["user_id"] === userId)
-                  .map((row) => ({ id: row["id"] }));
-                return { results: results as Array<T>, meta: { changes: 0 } };
-              }
-              const storageMatch = lower.match(
-                /^select storage_id from (\w+) where user_id = \? and storage_id is not null/,
-              );
-              if (storageMatch) {
-                const table = storageMatch[1] as string;
-                results = (rows[table] ?? [])
-                  .filter(
-                    (row) =>
-                      row["user_id"] === userId && row["storage_id"] != null,
-                  )
-                  .map((row) => ({ storage_id: row["storage_id"] }));
-                return { results: results as Array<T>, meta: { changes: 0 } };
-              }
-              const kvMatch = lower.match(
-                /^select kv_key from (\w+) where user_id = \?/,
-              );
-              if (kvMatch) {
-                const table = kvMatch[1] as string;
-                results = (rows[table] ?? [])
-                  .filter((row) => row["user_id"] === userId)
-                  .map((row) => ({ kv_key: row["kv_key"] }));
-                return { results: results as Array<T>, meta: { changes: 0 } };
-              }
-              if (lower === "select avatar_key from users where id = ?") {
-                const numericId = Number(params[0]);
-                results = (rows.users ?? [])
-                  .filter((row) => Number(row["id"]) === numericId)
-                  .map((row) => ({
-                    avatar_key: row["avatar_key"] ?? null,
-                  }));
-                return { results: results as Array<T>, meta: { changes: 0 } };
-              }
-              if (
-                lower === "select stripe_customer_id from users where id = ?"
-              ) {
-                const numericId = Number(params[0]);
-                results = (rows.users ?? [])
-                  .filter((row) => Number(row["id"]) === numericId)
-                  .map((row) => ({
-                    stripe_customer_id: row["stripe_customer_id"] ?? null,
-                  }));
-                return { results: results as Array<T>, meta: { changes: 0 } };
-              }
-              return { results: [] as Array<T>, meta: { changes: 0 } };
-            },
-            async first<T>() {
-              const result = await this.all<T>();
-              return (result.results[0] ?? null) as T | null;
-            },
-            async run() {
-              if (
-                options?.failRunContaining &&
-                lower.includes(options.failRunContaining)
-              ) {
-                throw new Error("simulated atomic D1 failure");
-              }
-              const userId = params[0] as string | number;
-              if (
-                lower ===
-                "update users set deleting_at = ?, updated_at = ? where id = ? and deleting_at is null"
-              ) {
-                let changed = 0;
-                for (const row of rows.users ?? []) {
-                  if (row["id"] !== params[2]) continue;
-                  if (row["deleting_at"] != null) continue;
-                  row["deleting_at"] = params[0];
-                  row["updated_at"] = params[1];
-                  changed += 1;
-                }
-                return { meta: { changes: changed } };
-              }
-              if (
-                lower ===
-                "update users set deleting_at = null, updated_at = ? where id = ? and deleting_at = ?"
-              ) {
-                let changed = 0;
-                for (const row of rows.users ?? []) {
-                  if (row["id"] !== params[1]) continue;
-                  if (row["deleting_at"] !== params[2]) continue;
-                  row["deleting_at"] = null;
-                  row["updated_at"] = params[0];
-                  changed += 1;
-                }
-                return { meta: { changes: changed } };
-              }
-              if (
-                lower ===
-                "update users set deleting_at = null, updated_at = ? where id = ?"
-              ) {
-                let changed = 0;
-                for (const row of rows.users ?? []) {
-                  if (row["id"] !== params[1]) continue;
-                  row["deleting_at"] = null;
-                  row["updated_at"] = params[0];
-                  changed += 1;
-                }
-                return { meta: { changes: changed } };
-              }
-              const nullColumnMatch = lower.match(
-                /^update (\w+) set ((?:\w+ = null)(?:, \w+ = null)*) where (\w+) = \?$/,
-              );
-              if (nullColumnMatch) {
-                const table = nullColumnMatch[1] as string;
-                const assignments = nullColumnMatch[2]!
-                  .split(", ")
-                  .map((part) => part.replace(" = null", ""));
-                const matchColumn = nullColumnMatch[3] as string;
-                let changed = 0;
-                for (const row of rows[table] ?? []) {
-                  if (row[matchColumn] !== userId) continue;
-                  for (const column of assignments) {
-                    row[column] = null;
-                  }
-                  changed += 1;
-                }
-                return { meta: { changes: changed } };
-              }
-              const replaceJsonMatch = lower.match(
-                /^update (\w+) set (\w+) = replace\(\2, \?, \?\) where \2 like \?$/,
-              );
-              if (replaceJsonMatch) {
-                const table = replaceJsonMatch[1] as string;
-                const column = replaceJsonMatch[2] as string;
-                const search = String(params[0]);
-                const replacement = String(params[1]);
-                const likePattern = String(params[2]);
-                const needle = likePattern.replace(/^%/, "").replace(/%$/, "");
-                let changed = 0;
-                for (const row of rows[table] ?? []) {
-                  const current = row[column];
-                  if (typeof current !== "string") continue;
-                  if (!current.includes(needle)) continue;
-                  row[column] = current.split(search).join(replacement);
-                  changed += 1;
-                }
-                return { meta: { changes: changed } };
-              }
-              const replaceColumnMatch = lower.match(
-                /^update (\w+) set (\w+) = \? where (\w+) = \?$/,
-              );
-              if (replaceColumnMatch) {
-                const table = replaceColumnMatch[1] as string;
-                const setColumn = replaceColumnMatch[2] as string;
-                const matchColumn = replaceColumnMatch[3] as string;
-                let changed = 0;
-                for (const row of rows[table] ?? []) {
-                  if (row[matchColumn] !== params[1]) continue;
-                  row[setColumn] = params[0];
-                  changed += 1;
-                }
-                return { meta: { changes: changed } };
-              }
-              const userColumnsMatch = lower.match(
-                /^delete from (\w+) where ((?:\w+ = \?)(?: or \w+ = \?)*)$/,
-              );
-              if (userColumnsMatch) {
-                const table = userColumnsMatch[1] as string;
-                const columns = userColumnsMatch[2]!
-                  .split(" or ")
-                  .map((part) => part.replace(" = ?", ""));
-                const removed = deleteByPredicate(table, (row) =>
-                  columns.some(
-                    (column, index) => row[column] === params[index],
-                  ),
-                );
-                return { meta: { changes: removed } };
-              }
-              const userIdMatch = lower.match(
-                /^delete from (\w+) where user_id = \?/,
-              );
-              if (userIdMatch) {
-                const table = userIdMatch[1] as string;
-                const removed = deleteByPredicate(
-                  table,
-                  (row) => row["user_id"] === userId,
-                );
-                return { meta: { changes: removed } };
-              }
-              const bucketParentMatch = lower.match(
-                /^delete from (\w+) where bucket_id in \( select id from (\w+) where user_id = \? \)/,
-              );
-              if (bucketParentMatch) {
-                const childTable = bucketParentMatch[1] as string;
-                const parentTable = bucketParentMatch[2] as string;
-                const parentIds = new Set(
-                  selectIds(parentTable, (row) => row["user_id"] === userId),
-                );
-                const removed = deleteByPredicate(childTable, (row) =>
-                  parentIds.has(row["bucket_id"]),
-                );
-                return { meta: { changes: removed } };
-              }
-              const communityListingChildMatch = lower.match(
-                /^delete from (\w+) where (\w+) in \( select id from community_listings where owner_user_id = \? \)/,
-              );
-              if (communityListingChildMatch) {
-                const table = communityListingChildMatch[1] as string;
-                const listingColumn = communityListingChildMatch[2] as string;
-                const listingIds = new Set(
-                  selectIds(
-                    "community_listings",
-                    (row) => row["owner_user_id"] === userId,
-                  ),
-                );
-                const removed = deleteByPredicate(table, (row) =>
-                  listingIds.has(row[listingColumn]),
-                );
-                return { meta: { changes: removed } };
-              }
-              const usersMatch = lower.match(
-                /^delete from users where id = \?/,
-              );
-              if (usersMatch) {
-                const removed = deleteByPredicate(
-                  "users",
-                  (row) => row["id"] === userId,
-                );
-                return { meta: { changes: removed } };
-              }
-              return { meta: { changes: 0 } };
-            },
-          };
-        },
-      };
-    },
-    async batch(
-      statements: Array<{ run: () => Promise<{ meta: { changes: number } }> }>,
-    ) {
-      const snapshot = structuredClone(rows);
-      try {
-        const results = [];
-        for (const statement of statements) {
-          results.push(await statement.run());
-        }
-        return results;
-      } catch (error) {
-        for (const key of Object.keys(rows)) delete rows[key];
-        Object.assign(rows, snapshot);
-        throw error;
-      }
-    },
-  } as unknown as D1Database;
+	const db = {
+		prepare(query: string) {
+			const trimmed = query.replace(/\s+/g, ' ').trim()
+			const lower = trimmed.toLowerCase()
+			return {
+				bind(...params: Array<unknown>) {
+					return {
+						async all<T>() {
+							await options?.onSelect?.(lower)
+							if (
+								options?.failSelectContaining &&
+								lower.includes(options.failSelectContaining)
+							) {
+								throw new Error('simulated inventory read failure')
+							}
+							let results: Array<unknown> = []
+							const userId = params[0] as string
+							if (
+								lower ===
+								'select client_id from user_mcp_oauth_clients where user_id = ?'
+							) {
+								const numericId = Number(params[0])
+								results = (rows.user_mcp_oauth_clients ?? [])
+									.filter((row) => Number(row['user_id']) === numericId)
+									.map((row) => ({ client_id: row['client_id'] }))
+								return { results: results as Array<T>, meta: { changes: 0 } }
+							}
+							if (
+								lower ===
+								'select deleting_at from users where stable_user_id = ?'
+							) {
+								results = (rows.users ?? [])
+									.filter((row) => row['stable_user_id'] === userId)
+									.map((row) => ({
+										deleting_at: row['deleting_at'] ?? null,
+									}))
+								return { results: results as Array<T>, meta: { changes: 0 } }
+							}
+							if (lower === 'select stable_user_id from users where id = ?') {
+								const numericId = Number(params[0])
+								results = (rows.users ?? [])
+									.filter((row) => Number(row['id']) === numericId)
+									.map((row) => ({
+										stable_user_id: row['stable_user_id'],
+									}))
+								return { results: results as Array<T>, meta: { changes: 0 } }
+							}
+							if (
+								lower ===
+								'select stable_user_id, deleting_at from users where id = ?'
+							) {
+								const numericId = Number(params[0])
+								results = (rows.users ?? [])
+									.filter((row) => Number(row['id']) === numericId)
+									.map((row) => ({
+										stable_user_id: row['stable_user_id'],
+										deleting_at: row['deleting_at'] ?? null,
+									}))
+								return { results: results as Array<T>, meta: { changes: 0 } }
+							}
+							if (
+								lower ===
+								'select id from saved_packages where user_id = ? and has_app = 1'
+							) {
+								results = (rows.saved_packages ?? [])
+									.filter(
+										(row) =>
+											row['user_id'] === userId &&
+											(row['has_app'] === 1 ||
+												row['has_app'] === '1' ||
+												row['has_app'] === true),
+									)
+									.map((row) => ({ id: row['id'] }))
+								return { results: results as Array<T>, meta: { changes: 0 } }
+							}
+							if (
+								lower ===
+								'select id, published_commit from entity_sources where user_id = ?'
+							) {
+								results = (rows.entity_sources ?? [])
+									.filter((row) => row['user_id'] === userId)
+									.map((row) => ({
+										id: row['id'],
+										published_commit: row['published_commit'] ?? null,
+									}))
+								return { results: results as Array<T>, meta: { changes: 0 } }
+							}
+							if (
+								lower ===
+								'select id, kody_id, source_id, has_app from saved_packages where user_id = ?'
+							) {
+								results = (rows.saved_packages ?? [])
+									.filter((row) => row['user_id'] === userId)
+									.map((row) => ({
+										id: row['id'],
+										kody_id: row['kody_id'],
+										source_id: row['source_id'],
+										has_app: row['has_app'],
+									}))
+								return { results: results as Array<T>, meta: { changes: 0 } }
+							}
+							if (
+								lower ===
+								'select do_id from mcp_agent_sessions where user_id = ? order by do_id'
+							) {
+								results = (rows.mcp_agent_sessions ?? [])
+									.filter((row) => row['user_id'] === userId)
+									.map((row) => ({ do_id: row['do_id'] }))
+								return { results: results as Array<T>, meta: { changes: 0 } }
+							}
+							if (
+								lower.includes(
+									'select storage_id as storageid from user_storage_buckets',
+								)
+							) {
+								results = (rows.user_storage_buckets ?? [])
+									.filter(
+										(row) =>
+											row['user_id'] === userId &&
+											(!lower.includes("kind <> 'repo_session'") ||
+												row['kind'] !== 'repo_session'),
+									)
+									.map((row) => ({ storageId: row['storage_id'] }))
+									.sort((left, right) =>
+										String(left.storageId).localeCompare(
+											String(right.storageId),
+										),
+									)
+								return { results: results as Array<T>, meta: { changes: 0 } }
+							}
+							if (
+								lower.includes('from community_listings') &&
+								lower.includes('entity_sources.published_commit')
+							) {
+								results = (rows.community_listings ?? [])
+									.filter((row) => row['owner_user_id'] === userId)
+									.map((row, index) => {
+										const source = (rows.entity_sources ?? []).find(
+											(sourceRow) =>
+												sourceRow['id'] === row['source_id'] &&
+												sourceRow['user_id'] === row['owner_user_id'],
+										)
+										return {
+											account_r2_rowid: index + 1,
+											id: row['id'],
+											pinned_commit: row['pinned_commit'],
+											source_published_commit:
+												source?.['published_commit'] ?? null,
+										}
+									})
+								return { results: results as Array<T>, meta: { changes: 0 } }
+							}
+							const m = lower.match(/^select id from (\w+) where user_id = \?/)
+							if (m) {
+								const table = m[1] as string
+								results = (rows[table] ?? [])
+									.filter((row) => row['user_id'] === userId)
+									.map((row) => ({ id: row['id'] }))
+								return { results: results as Array<T>, meta: { changes: 0 } }
+							}
+							const storageMatch = lower.match(
+								/^select storage_id from (\w+) where user_id = \? and storage_id is not null/,
+							)
+							if (storageMatch) {
+								const table = storageMatch[1] as string
+								results = (rows[table] ?? [])
+									.filter(
+										(row) =>
+											row['user_id'] === userId && row['storage_id'] != null,
+									)
+									.map((row) => ({ storage_id: row['storage_id'] }))
+								return { results: results as Array<T>, meta: { changes: 0 } }
+							}
+							const kvMatch = lower.match(
+								/^select kv_key from (\w+) where user_id = \?/,
+							)
+							if (kvMatch) {
+								const table = kvMatch[1] as string
+								results = (rows[table] ?? [])
+									.filter((row) => row['user_id'] === userId)
+									.map((row) => ({ kv_key: row['kv_key'] }))
+								return { results: results as Array<T>, meta: { changes: 0 } }
+							}
+							if (lower === 'select avatar_key from users where id = ?') {
+								const numericId = Number(params[0])
+								results = (rows.users ?? [])
+									.filter((row) => Number(row['id']) === numericId)
+									.map((row) => ({
+										avatar_key: row['avatar_key'] ?? null,
+									}))
+								return { results: results as Array<T>, meta: { changes: 0 } }
+							}
+							if (
+								lower === 'select stripe_customer_id from users where id = ?'
+							) {
+								const numericId = Number(params[0])
+								results = (rows.users ?? [])
+									.filter((row) => Number(row['id']) === numericId)
+									.map((row) => ({
+										stripe_customer_id: row['stripe_customer_id'] ?? null,
+									}))
+								return { results: results as Array<T>, meta: { changes: 0 } }
+							}
+							return { results: [] as Array<T>, meta: { changes: 0 } }
+						},
+						async first<T>() {
+							const result = await this.all<T>()
+							return (result.results[0] ?? null) as T | null
+						},
+						async run() {
+							if (
+								options?.failRunContaining &&
+								lower.includes(options.failRunContaining)
+							) {
+								throw new Error('simulated atomic D1 failure')
+							}
+							const userId = params[0] as string | number
+							if (
+								lower ===
+								'update users set deleting_at = ?, updated_at = ? where id = ? and deleting_at is null'
+							) {
+								let changed = 0
+								for (const row of rows.users ?? []) {
+									if (row['id'] !== params[2]) continue
+									if (row['deleting_at'] != null) continue
+									row['deleting_at'] = params[0]
+									row['updated_at'] = params[1]
+									changed += 1
+								}
+								return { meta: { changes: changed } }
+							}
+							if (
+								lower ===
+								'update users set deleting_at = null, updated_at = ? where id = ? and deleting_at = ?'
+							) {
+								let changed = 0
+								for (const row of rows.users ?? []) {
+									if (row['id'] !== params[1]) continue
+									if (row['deleting_at'] !== params[2]) continue
+									row['deleting_at'] = null
+									row['updated_at'] = params[0]
+									changed += 1
+								}
+								return { meta: { changes: changed } }
+							}
+							if (
+								lower ===
+								'update users set deleting_at = null, updated_at = ? where id = ?'
+							) {
+								let changed = 0
+								for (const row of rows.users ?? []) {
+									if (row['id'] !== params[1]) continue
+									row['deleting_at'] = null
+									row['updated_at'] = params[0]
+									changed += 1
+								}
+								return { meta: { changes: changed } }
+							}
+							const nullColumnMatch = lower.match(
+								/^update (\w+) set ((?:\w+ = null)(?:, \w+ = null)*) where (\w+) = \?$/,
+							)
+							if (nullColumnMatch) {
+								const table = nullColumnMatch[1] as string
+								const assignments = nullColumnMatch[2]!
+									.split(', ')
+									.map((part) => part.replace(' = null', ''))
+								const matchColumn = nullColumnMatch[3] as string
+								let changed = 0
+								for (const row of rows[table] ?? []) {
+									if (row[matchColumn] !== userId) continue
+									for (const column of assignments) {
+										row[column] = null
+									}
+									changed += 1
+								}
+								return { meta: { changes: changed } }
+							}
+							const replaceJsonMatch = lower.match(
+								/^update (\w+) set (\w+) = replace\(\2, \?, \?\) where \2 like \?$/,
+							)
+							if (replaceJsonMatch) {
+								const table = replaceJsonMatch[1] as string
+								const column = replaceJsonMatch[2] as string
+								const search = String(params[0])
+								const replacement = String(params[1])
+								const likePattern = String(params[2])
+								const needle = likePattern.replace(/^%/, '').replace(/%$/, '')
+								let changed = 0
+								for (const row of rows[table] ?? []) {
+									const current = row[column]
+									if (typeof current !== 'string') continue
+									if (!current.includes(needle)) continue
+									row[column] = current.split(search).join(replacement)
+									changed += 1
+								}
+								return { meta: { changes: changed } }
+							}
+							const replaceColumnMatch = lower.match(
+								/^update (\w+) set (\w+) = \? where (\w+) = \?$/,
+							)
+							if (replaceColumnMatch) {
+								const table = replaceColumnMatch[1] as string
+								const setColumn = replaceColumnMatch[2] as string
+								const matchColumn = replaceColumnMatch[3] as string
+								let changed = 0
+								for (const row of rows[table] ?? []) {
+									if (row[matchColumn] !== params[1]) continue
+									row[setColumn] = params[0]
+									changed += 1
+								}
+								return { meta: { changes: changed } }
+							}
+							const userColumnsMatch = lower.match(
+								/^delete from (\w+) where ((?:\w+ = \?)(?: or \w+ = \?)*)$/,
+							)
+							if (userColumnsMatch) {
+								const table = userColumnsMatch[1] as string
+								const columns = userColumnsMatch[2]!
+									.split(' or ')
+									.map((part) => part.replace(' = ?', ''))
+								const removed = deleteByPredicate(table, (row) =>
+									columns.some(
+										(column, index) => row[column] === params[index],
+									),
+								)
+								return { meta: { changes: removed } }
+							}
+							const userIdMatch = lower.match(
+								/^delete from (\w+) where user_id = \?/,
+							)
+							if (userIdMatch) {
+								const table = userIdMatch[1] as string
+								const removed = deleteByPredicate(
+									table,
+									(row) => row['user_id'] === userId,
+								)
+								return { meta: { changes: removed } }
+							}
+							const bucketParentMatch = lower.match(
+								/^delete from (\w+) where bucket_id in \( select id from (\w+) where user_id = \? \)/,
+							)
+							if (bucketParentMatch) {
+								const childTable = bucketParentMatch[1] as string
+								const parentTable = bucketParentMatch[2] as string
+								const parentIds = new Set(
+									selectIds(parentTable, (row) => row['user_id'] === userId),
+								)
+								const removed = deleteByPredicate(childTable, (row) =>
+									parentIds.has(row['bucket_id']),
+								)
+								return { meta: { changes: removed } }
+							}
+							const communityListingChildMatch = lower.match(
+								/^delete from (\w+) where (\w+) in \( select id from community_listings where owner_user_id = \? \)/,
+							)
+							if (communityListingChildMatch) {
+								const table = communityListingChildMatch[1] as string
+								const listingColumn = communityListingChildMatch[2] as string
+								const listingIds = new Set(
+									selectIds(
+										'community_listings',
+										(row) => row['owner_user_id'] === userId,
+									),
+								)
+								const removed = deleteByPredicate(table, (row) =>
+									listingIds.has(row[listingColumn]),
+								)
+								return { meta: { changes: removed } }
+							}
+							const usersMatch = lower.match(/^delete from users where id = \?/)
+							if (usersMatch) {
+								const removed = deleteByPredicate(
+									'users',
+									(row) => row['id'] === userId,
+								)
+								return { meta: { changes: removed } }
+							}
+							return { meta: { changes: 0 } }
+						},
+					}
+				},
+			}
+		},
+		async batch(
+			statements: Array<{ run: () => Promise<{ meta: { changes: number } }> }>,
+		) {
+			const snapshot = structuredClone(rows)
+			try {
+				const results = []
+				for (const statement of statements) {
+					results.push(await statement.run())
+				}
+				return results
+			} catch (error) {
+				for (const key of Object.keys(rows)) delete rows[key]
+				Object.assign(rows, snapshot)
+				throw error
+			}
+		},
+	} as unknown as D1Database
 
-  return { db, rows };
+	return { db, rows }
 }
 
 // Mimics the jobs worker's JobsService against the test db: job-id and
 // storage-id listing and purgeUser all operate on the fixture's jobs tables
 // (which stand in for the jobs worker's own D1; production APP_DB has none).
 export function createJobsBindingStub(
-  db: D1Database,
-  overrides: Record<string, unknown> = {},
+	db: D1Database,
+	overrides: Record<string, unknown> = {},
 ) {
-  async function listStorageIds(table: string, userId: string) {
-    const { results } = await db
-      .prepare(
-        `SELECT storage_id FROM ${table} WHERE user_id = ? AND storage_id IS NOT NULL`,
-      )
-      .bind(userId)
-      .all<{ storage_id: string }>();
-    return (results ?? []).map((row) => row.storage_id);
-  }
-  return {
-    listJobIdsForUser: async (input: { userId: string }) => {
-      const { results } = await db
-        .prepare(`SELECT id FROM jobs WHERE user_id = ?`)
-        .bind(input.userId)
-        .all<{ id: string }>();
-      return (results ?? []).map((row) => row.id);
-    },
-    listJobStorageIdsForUser: async (input: { userId: string }) => [
-      ...(await listStorageIds("jobs", input.userId)),
-      ...(await listStorageIds("archived_job_artifacts", input.userId)),
-    ],
-    purgeUser: async (input: { userId: string }) => {
-      await db
-        .prepare(`DELETE FROM archived_job_artifacts WHERE user_id = ?`)
-        .bind(input.userId)
-        .run();
-      await db
-        .prepare(`DELETE FROM jobs WHERE user_id = ?`)
-        .bind(input.userId)
-        .run();
-      return { ok: true as const, userId: input.userId, purged: true };
-    },
-    ...overrides,
-  };
+	async function listStorageIds(table: string, userId: string) {
+		const { results } = await db
+			.prepare(
+				`SELECT storage_id FROM ${table} WHERE user_id = ? AND storage_id IS NOT NULL`,
+			)
+			.bind(userId)
+			.all<{ storage_id: string }>()
+		return (results ?? []).map((row) => row.storage_id)
+	}
+	return {
+		listJobIdsForUser: async (input: { userId: string }) => {
+			const { results } = await db
+				.prepare(`SELECT id FROM jobs WHERE user_id = ?`)
+				.bind(input.userId)
+				.all<{ id: string }>()
+			return (results ?? []).map((row) => row.id)
+		},
+		listJobStorageIdsForUser: async (input: { userId: string }) => [
+			...(await listStorageIds('jobs', input.userId)),
+			...(await listStorageIds('archived_job_artifacts', input.userId)),
+		],
+		purgeUser: async (input: { userId: string }) => {
+			await db
+				.prepare(`DELETE FROM archived_job_artifacts WHERE user_id = ?`)
+				.bind(input.userId)
+				.run()
+			await db
+				.prepare(`DELETE FROM jobs WHERE user_id = ?`)
+				.bind(input.userId)
+				.run()
+			return { ok: true as const, userId: input.userId, purged: true }
+		},
+		...overrides,
+	}
 }
 
 export function createSuccessfulDeletionEnv(
-  db: D1Database,
-  overrides: Partial<Env> & {
-    OAUTH_PROVIDER?: {
-      listUserGrants: (
-        userId: string,
-        options: { cursor: string | undefined },
-      ) => Promise<{
-        items: Array<{ id: string; clientId: string }>;
-        cursor: string | undefined;
-      }>;
-      revokeGrant: (grantId: string, userId: string) => Promise<unknown>;
-    };
-  } = {},
+	db: D1Database,
+	overrides: Partial<Env> & {
+		OAUTH_PROVIDER?: {
+			listUserGrants: (
+				userId: string,
+				options: { cursor: string | undefined },
+			) => Promise<{
+				items: Array<{ id: string; clientId: string }>
+				cursor: string | undefined
+			}>
+			revokeGrant: (grantId: string, userId: string) => Promise<unknown>
+		}
+	} = {},
 ) {
-  const durableObjectId = (name: string) => name as unknown as DurableObjectId;
-  const fetchOk = async () => Response.json({ ok: true });
-  const userMeter = createInMemoryUserMeterEnv();
-  const repoSessionIndex = createInMemoryRepoSessionIndexEnv(db);
-  return {
-    APP_DB: db,
-    CAPABILITY_VECTOR_INDEX: {
-      deleteByIds: async () => undefined,
-    },
-    STORAGE_RUNNER: {
-      idFromName: durableObjectId,
-      get: () => ({ clearStorage: async () => ({ ok: true as const }) }),
-    },
-    RUN_LOG: {
-      idFromName: durableObjectId,
-      get: () => ({
-        clearAll: async () => ({ ok: true as const }),
-        listStorageIds: async () => [] as Array<string>,
-      }),
-    },
-    USER_METER: userMeter.env.USER_METER,
-    STRIPE_PLAN_REFRESH: {
-      idFromName: durableObjectId,
-      get: () => ({ purgeUser: async () => ({ ok: true as const }) }),
-    },
-    MAILBOX: {
-      idFromName: durableObjectId,
-      get: () => ({
-        listBlobReferences: async () => ({
-          references: [],
-          nextStartAfter: null,
-          truncated: false as const,
-        }),
-        purge: async () => ({ ok: true as const }),
-      }),
-    },
-    JOBS: createJobsBindingStub(db),
-    REPO_SESSION: {
-      idFromName: durableObjectId,
-      get: () => ({ purgeSession: async () => ({ ok: true as const }) }),
-    },
-    REPO_SESSION_INDEX: repoSessionIndex.REPO_SESSION_INDEX,
-    MCP_CLIENT_HUB: {
-      idFromName: durableObjectId,
-      get: () => ({ purgeForAccountDeletion: async () => undefined }),
-    },
-    PACKAGE_REALTIME_SESSION: {
-      idFromName: durableObjectId,
-      get: () => ({ fetch: fetchOk }),
-    },
-    COMMUNITY_ASSETS: {
-      async list() {
-        return {
-          objects: [],
-          delimitedPrefixes: [],
-          truncated: false as const,
-        };
-      },
-      delete: async () => undefined,
-    },
-    EMAIL_BLOBS: {
-      async list() {
-        return {
-          objects: [],
-          delimitedPrefixes: [],
-          truncated: false as const,
-        };
-      },
-      delete: async () => undefined,
-    },
-    OAUTH_PROVIDER: {
-      async listUserGrants() {
-        return { items: [], cursor: undefined };
-      },
-      async revokeGrant() {
-        return undefined;
-      },
-    },
-    ...overrides,
-  } as unknown as Parameters<typeof deleteUserAccount>[0]["env"];
+	const durableObjectId = (name: string) => name as unknown as DurableObjectId
+	const fetchOk = async () => Response.json({ ok: true })
+	const userMeter = createInMemoryUserMeterEnv()
+	const repoSessionIndex = createInMemoryRepoSessionIndexEnv(db)
+	return {
+		APP_DB: db,
+		CAPABILITY_VECTOR_INDEX: {
+			deleteByIds: async () => undefined,
+		},
+		STORAGE_RUNNER: {
+			idFromName: durableObjectId,
+			get: () => ({ clearStorage: async () => ({ ok: true as const }) }),
+		},
+		RUN_LOG: {
+			idFromName: durableObjectId,
+			get: () => ({
+				clearAll: async () => ({ ok: true as const }),
+				listStorageIds: async () => [] as Array<string>,
+			}),
+		},
+		USER_METER: userMeter.env.USER_METER,
+		STRIPE_PLAN_REFRESH: {
+			idFromName: durableObjectId,
+			get: () => ({ purgeUser: async () => ({ ok: true as const }) }),
+		},
+		MAILBOX: {
+			idFromName: durableObjectId,
+			get: () => ({
+				listBlobReferences: async () => ({
+					references: [],
+					nextStartAfter: null,
+					truncated: false as const,
+				}),
+				purge: async () => ({ ok: true as const }),
+			}),
+		},
+		JOBS: createJobsBindingStub(db),
+		REPO_SESSION: {
+			idFromName: durableObjectId,
+			get: () => ({ purgeSession: async () => ({ ok: true as const }) }),
+		},
+		REPO_SESSION_INDEX: repoSessionIndex.REPO_SESSION_INDEX,
+		MCP_CLIENT_HUB: {
+			idFromName: durableObjectId,
+			get: () => ({ purgeForAccountDeletion: async () => undefined }),
+		},
+		PACKAGE_REALTIME_SESSION: {
+			idFromName: durableObjectId,
+			get: () => ({ fetch: fetchOk }),
+		},
+		COMMUNITY_ASSETS: {
+			async list() {
+				return {
+					objects: [],
+					delimitedPrefixes: [],
+					truncated: false as const,
+				}
+			},
+			delete: async () => undefined,
+		},
+		EMAIL_BLOBS: {
+			async list() {
+				return {
+					objects: [],
+					delimitedPrefixes: [],
+					truncated: false as const,
+				}
+			},
+			delete: async () => undefined,
+		},
+		OAUTH_PROVIDER: {
+			async listUserGrants() {
+				return { items: [], cursor: undefined }
+			},
+			async revokeGrant() {
+				return undefined
+			},
+		},
+		...overrides,
+	} as unknown as Parameters<typeof deleteUserAccount>[0]['env']
 }

--- a/packages/worker/src/test-support/account-deletion.ts
+++ b/packages/worker/src/test-support/account-deletion.ts
@@ -1,592 +1,602 @@
-import { type deleteUserAccount } from '#worker/app/account-deletion.ts'
-import { createInMemoryUserMeterEnv } from '#worker/test-support/user-meter.ts'
-import { createInMemoryRepoSessionIndexEnv } from '#worker/test-support/repo-session-index.ts'
+import { type deleteUserAccount } from "#worker/app/account-deletion.ts";
+import { createInMemoryUserMeterEnv } from "#worker/test-support/user-meter.ts";
+import { createInMemoryRepoSessionIndexEnv } from "#worker/test-support/repo-session-index.ts";
 
-export type RowMap = Record<string, Array<Record<string, unknown>>>
+export type RowMap = Record<string, Array<Record<string, unknown>>>;
 
 export function createTestDb(
-	initial: RowMap,
-	options?: {
-		failSelectContaining?: string
-		failRunContaining?: string
-		onSelect?: (query: string) => Promise<void>
-	},
+  initial: RowMap,
+  options?: {
+    failSelectContaining?: string;
+    failRunContaining?: string;
+    onSelect?: (query: string) => Promise<void>;
+  },
 ): {
-	db: D1Database
-	rows: RowMap
+  db: D1Database;
+  rows: RowMap;
 } {
-	const rows: RowMap = {}
-	for (const [key, value] of Object.entries(initial)) {
-		rows[key] = value.map((row) => {
-			const copy = { ...row }
-			if (
-				key === 'users' &&
-				(copy['stable_user_id'] == null || copy['stable_user_id'] === '')
-			) {
-				const id = Number(copy['id'])
-				if (id === 1) copy['stable_user_id'] = 'user-aaa'
-				else if (id === 2) copy['stable_user_id'] = 'user-bbb'
-			}
-			return copy
-		})
-	}
+  const rows: RowMap = {};
+  for (const [key, value] of Object.entries(initial)) {
+    rows[key] = value.map((row) => {
+      const copy = { ...row };
+      if (
+        key === "users" &&
+        (copy["stable_user_id"] == null || copy["stable_user_id"] === "")
+      ) {
+        const id = Number(copy["id"]);
+        if (id === 1) copy["stable_user_id"] = "user-aaa";
+        else if (id === 2) copy["stable_user_id"] = "user-bbb";
+      }
+      return copy;
+    });
+  }
 
-	function deleteByPredicate(
-		table: string,
-		predicate: (row: Record<string, unknown>) => boolean,
-	) {
-		const remaining: Array<Record<string, unknown>> = []
-		let removed = 0
-		for (const row of rows[table] ?? []) {
-			if (predicate(row)) {
-				removed += 1
-				continue
-			}
-			remaining.push(row)
-		}
-		rows[table] = remaining
-		return removed
-	}
+  function deleteByPredicate(
+    table: string,
+    predicate: (row: Record<string, unknown>) => boolean,
+  ) {
+    const remaining: Array<Record<string, unknown>> = [];
+    let removed = 0;
+    for (const row of rows[table] ?? []) {
+      if (predicate(row)) {
+        removed += 1;
+        continue;
+      }
+      remaining.push(row);
+    }
+    rows[table] = remaining;
+    return removed;
+  }
 
-	function selectIds(
-		table: string,
-		where: (row: Record<string, unknown>) => boolean,
-	) {
-		return (rows[table] ?? []).filter(where).map((row) => row['id'])
-	}
+  function selectIds(
+    table: string,
+    where: (row: Record<string, unknown>) => boolean,
+  ) {
+    return (rows[table] ?? []).filter(where).map((row) => row["id"]);
+  }
 
-	const db = {
-		prepare(query: string) {
-			const trimmed = query.replace(/\s+/g, ' ').trim()
-			const lower = trimmed.toLowerCase()
-			return {
-				bind(...params: Array<unknown>) {
-					return {
-						async all<T>() {
-							await options?.onSelect?.(lower)
-							if (
-								options?.failSelectContaining &&
-								lower.includes(options.failSelectContaining)
-							) {
-								throw new Error('simulated inventory read failure')
-							}
-							let results: Array<unknown> = []
-							const userId = params[0] as string
-							if (
-								lower ===
-								'select client_id from user_mcp_oauth_clients where user_id = ?'
-							) {
-								const numericId = Number(params[0])
-								results = (rows.user_mcp_oauth_clients ?? [])
-									.filter((row) => Number(row['user_id']) === numericId)
-									.map((row) => ({ client_id: row['client_id'] }))
-								return { results: results as Array<T>, meta: { changes: 0 } }
-							}
-							if (
-								lower ===
-								'select deleting_at from users where stable_user_id = ?'
-							) {
-								results = (rows.users ?? [])
-									.filter((row) => row['stable_user_id'] === userId)
-									.map((row) => ({
-										deleting_at: row['deleting_at'] ?? null,
-									}))
-								return { results: results as Array<T>, meta: { changes: 0 } }
-							}
-							if (lower === 'select stable_user_id from users where id = ?') {
-								const numericId = Number(params[0])
-								results = (rows.users ?? [])
-									.filter((row) => Number(row['id']) === numericId)
-									.map((row) => ({
-										stable_user_id: row['stable_user_id'],
-									}))
-								return { results: results as Array<T>, meta: { changes: 0 } }
-							}
-							if (
-								lower ===
-								'select stable_user_id, deleting_at from users where id = ?'
-							) {
-								const numericId = Number(params[0])
-								results = (rows.users ?? [])
-									.filter((row) => Number(row['id']) === numericId)
-									.map((row) => ({
-										stable_user_id: row['stable_user_id'],
-										deleting_at: row['deleting_at'] ?? null,
-									}))
-								return { results: results as Array<T>, meta: { changes: 0 } }
-							}
-							if (
-								lower ===
-								'select id from saved_packages where user_id = ? and has_app = 1'
-							) {
-								results = (rows.saved_packages ?? [])
-									.filter(
-										(row) =>
-											row['user_id'] === userId &&
-											(row['has_app'] === 1 ||
-												row['has_app'] === '1' ||
-												row['has_app'] === true),
-									)
-									.map((row) => ({ id: row['id'] }))
-								return { results: results as Array<T>, meta: { changes: 0 } }
-							}
-							if (
-								lower ===
-								'select id, published_commit from entity_sources where user_id = ?'
-							) {
-								results = (rows.entity_sources ?? [])
-									.filter((row) => row['user_id'] === userId)
-									.map((row) => ({
-										id: row['id'],
-										published_commit: row['published_commit'] ?? null,
-									}))
-								return { results: results as Array<T>, meta: { changes: 0 } }
-							}
-							if (
-								lower ===
-								'select id, kody_id, source_id, has_app from saved_packages where user_id = ?'
-							) {
-								results = (rows.saved_packages ?? [])
-									.filter((row) => row['user_id'] === userId)
-									.map((row) => ({
-										id: row['id'],
-										kody_id: row['kody_id'],
-										source_id: row['source_id'],
-										has_app: row['has_app'],
-									}))
-								return { results: results as Array<T>, meta: { changes: 0 } }
-							}
-							if (
-								lower ===
-								'select do_id from mcp_agent_sessions where user_id = ? order by do_id'
-							) {
-								results = (rows.mcp_agent_sessions ?? [])
-									.filter((row) => row['user_id'] === userId)
-									.map((row) => ({ do_id: row['do_id'] }))
-								return { results: results as Array<T>, meta: { changes: 0 } }
-							}
-							if (
-								lower.includes(
-									'select storage_id as storageid from user_storage_buckets',
-								)
-							) {
-								results = (rows.user_storage_buckets ?? [])
-									.filter(
-										(row) =>
-											row['user_id'] === userId &&
-											(!lower.includes("kind <> 'repo_session'") ||
-												row['kind'] !== 'repo_session'),
-									)
-									.map((row) => ({ storageId: row['storage_id'] }))
-									.sort((left, right) =>
-										String(left.storageId).localeCompare(
-											String(right.storageId),
-										),
-									)
-								return { results: results as Array<T>, meta: { changes: 0 } }
-							}
-							if (
-								lower.includes('from community_listings') &&
-								lower.includes('entity_sources.published_commit')
-							) {
-								results = (rows.community_listings ?? [])
-									.filter((row) => row['owner_user_id'] === userId)
-									.map((row, index) => {
-										const source = (rows.entity_sources ?? []).find(
-											(sourceRow) =>
-												sourceRow['id'] === row['source_id'] &&
-												sourceRow['user_id'] === row['owner_user_id'],
-										)
-										return {
-											account_r2_rowid: index + 1,
-											id: row['id'],
-											pinned_commit: row['pinned_commit'],
-											source_published_commit:
-												source?.['published_commit'] ?? null,
-										}
-									})
-								return { results: results as Array<T>, meta: { changes: 0 } }
-							}
-							const m = lower.match(/^select id from (\w+) where user_id = \?/)
-							if (m) {
-								const table = m[1] as string
-								results = (rows[table] ?? [])
-									.filter((row) => row['user_id'] === userId)
-									.map((row) => ({ id: row['id'] }))
-								return { results: results as Array<T>, meta: { changes: 0 } }
-							}
-							const storageMatch = lower.match(
-								/^select storage_id from (\w+) where user_id = \? and storage_id is not null/,
-							)
-							if (storageMatch) {
-								const table = storageMatch[1] as string
-								results = (rows[table] ?? [])
-									.filter(
-										(row) =>
-											row['user_id'] === userId && row['storage_id'] != null,
-									)
-									.map((row) => ({ storage_id: row['storage_id'] }))
-								return { results: results as Array<T>, meta: { changes: 0 } }
-							}
-							const kvMatch = lower.match(
-								/^select kv_key from (\w+) where user_id = \?/,
-							)
-							if (kvMatch) {
-								const table = kvMatch[1] as string
-								results = (rows[table] ?? [])
-									.filter((row) => row['user_id'] === userId)
-									.map((row) => ({ kv_key: row['kv_key'] }))
-								return { results: results as Array<T>, meta: { changes: 0 } }
-							}
-							if (lower === 'select avatar_key from users where id = ?') {
-								const numericId = Number(params[0])
-								results = (rows.users ?? [])
-									.filter((row) => Number(row['id']) === numericId)
-									.map((row) => ({
-										avatar_key: row['avatar_key'] ?? null,
-									}))
-								return { results: results as Array<T>, meta: { changes: 0 } }
-							}
-							if (
-								lower === 'select stripe_customer_id from users where id = ?'
-							) {
-								const numericId = Number(params[0])
-								results = (rows.users ?? [])
-									.filter((row) => Number(row['id']) === numericId)
-									.map((row) => ({
-										stripe_customer_id: row['stripe_customer_id'] ?? null,
-									}))
-								return { results: results as Array<T>, meta: { changes: 0 } }
-							}
-							return { results: [] as Array<T>, meta: { changes: 0 } }
-						},
-						async first<T>() {
-							const result = await this.all<T>()
-							return (result.results[0] ?? null) as T | null
-						},
-						async run() {
-							if (
-								options?.failRunContaining &&
-								lower.includes(options.failRunContaining)
-							) {
-								throw new Error('simulated atomic D1 failure')
-							}
-							const userId = params[0] as string | number
-							if (
-								lower ===
-								'update users set deleting_at = ?, updated_at = ? where id = ? and deleting_at is null'
-							) {
-								let changed = 0
-								for (const row of rows.users ?? []) {
-									if (row['id'] !== params[2]) continue
-									if (row['deleting_at'] != null) continue
-									row['deleting_at'] = params[0]
-									row['updated_at'] = params[1]
-									changed += 1
-								}
-								return { meta: { changes: changed } }
-							}
-							if (
-								lower ===
-								'update users set deleting_at = null, updated_at = ? where id = ? and deleting_at = ?'
-							) {
-								let changed = 0
-								for (const row of rows.users ?? []) {
-									if (row['id'] !== params[1]) continue
-									if (row['deleting_at'] !== params[2]) continue
-									row['deleting_at'] = null
-									row['updated_at'] = params[0]
-									changed += 1
-								}
-								return { meta: { changes: changed } }
-							}
-							if (
-								lower ===
-								'update users set deleting_at = null, updated_at = ? where id = ?'
-							) {
-								let changed = 0
-								for (const row of rows.users ?? []) {
-									if (row['id'] !== params[1]) continue
-									row['deleting_at'] = null
-									row['updated_at'] = params[0]
-									changed += 1
-								}
-								return { meta: { changes: changed } }
-							}
-							const nullColumnMatch = lower.match(
-								/^update (\w+) set ((?:\w+ = null)(?:, \w+ = null)*) where (\w+) = \?$/,
-							)
-							if (nullColumnMatch) {
-								const table = nullColumnMatch[1] as string
-								const assignments = nullColumnMatch[2]!
-									.split(', ')
-									.map((part) => part.replace(' = null', ''))
-								const matchColumn = nullColumnMatch[3] as string
-								let changed = 0
-								for (const row of rows[table] ?? []) {
-									if (row[matchColumn] !== userId) continue
-									for (const column of assignments) {
-										row[column] = null
-									}
-									changed += 1
-								}
-								return { meta: { changes: changed } }
-							}
-							const replaceJsonMatch = lower.match(
-								/^update (\w+) set (\w+) = replace\(\2, \?, \?\) where \2 like \?$/,
-							)
-							if (replaceJsonMatch) {
-								const table = replaceJsonMatch[1] as string
-								const column = replaceJsonMatch[2] as string
-								const search = String(params[0])
-								const replacement = String(params[1])
-								const likePattern = String(params[2])
-								const needle = likePattern.replace(/^%/, '').replace(/%$/, '')
-								let changed = 0
-								for (const row of rows[table] ?? []) {
-									const current = row[column]
-									if (typeof current !== 'string') continue
-									if (!current.includes(needle)) continue
-									row[column] = current.split(search).join(replacement)
-									changed += 1
-								}
-								return { meta: { changes: changed } }
-							}
-							const replaceColumnMatch = lower.match(
-								/^update (\w+) set (\w+) = \? where (\w+) = \?$/,
-							)
-							if (replaceColumnMatch) {
-								const table = replaceColumnMatch[1] as string
-								const setColumn = replaceColumnMatch[2] as string
-								const matchColumn = replaceColumnMatch[3] as string
-								let changed = 0
-								for (const row of rows[table] ?? []) {
-									if (row[matchColumn] !== params[1]) continue
-									row[setColumn] = params[0]
-									changed += 1
-								}
-								return { meta: { changes: changed } }
-							}
-							const userColumnsMatch = lower.match(
-								/^delete from (\w+) where ((?:\w+ = \?)(?: or \w+ = \?)*)$/,
-							)
-							if (userColumnsMatch) {
-								const table = userColumnsMatch[1] as string
-								const columns = userColumnsMatch[2]!
-									.split(' or ')
-									.map((part) => part.replace(' = ?', ''))
-								const removed = deleteByPredicate(table, (row) =>
-									columns.some(
-										(column, index) => row[column] === params[index],
-									),
-								)
-								return { meta: { changes: removed } }
-							}
-							const userIdMatch = lower.match(
-								/^delete from (\w+) where user_id = \?/,
-							)
-							if (userIdMatch) {
-								const table = userIdMatch[1] as string
-								const removed = deleteByPredicate(
-									table,
-									(row) => row['user_id'] === userId,
-								)
-								return { meta: { changes: removed } }
-							}
-							const bucketParentMatch = lower.match(
-								/^delete from (\w+) where bucket_id in \( select id from (\w+) where user_id = \? \)/,
-							)
-							if (bucketParentMatch) {
-								const childTable = bucketParentMatch[1] as string
-								const parentTable = bucketParentMatch[2] as string
-								const parentIds = new Set(
-									selectIds(parentTable, (row) => row['user_id'] === userId),
-								)
-								const removed = deleteByPredicate(childTable, (row) =>
-									parentIds.has(row['bucket_id']),
-								)
-								return { meta: { changes: removed } }
-							}
-							const communityListingChildMatch = lower.match(
-								/^delete from (\w+) where (\w+) in \( select id from community_listings where owner_user_id = \? \)/,
-							)
-							if (communityListingChildMatch) {
-								const table = communityListingChildMatch[1] as string
-								const listingColumn = communityListingChildMatch[2] as string
-								const listingIds = new Set(
-									selectIds(
-										'community_listings',
-										(row) => row['owner_user_id'] === userId,
-									),
-								)
-								const removed = deleteByPredicate(table, (row) =>
-									listingIds.has(row[listingColumn]),
-								)
-								return { meta: { changes: removed } }
-							}
-							const usersMatch = lower.match(/^delete from users where id = \?/)
-							if (usersMatch) {
-								const removed = deleteByPredicate(
-									'users',
-									(row) => row['id'] === userId,
-								)
-								return { meta: { changes: removed } }
-							}
-							return { meta: { changes: 0 } }
-						},
-					}
-				},
-			}
-		},
-		async batch(
-			statements: Array<{ run: () => Promise<{ meta: { changes: number } }> }>,
-		) {
-			const snapshot = structuredClone(rows)
-			try {
-				const results = []
-				for (const statement of statements) {
-					results.push(await statement.run())
-				}
-				return results
-			} catch (error) {
-				for (const key of Object.keys(rows)) delete rows[key]
-				Object.assign(rows, snapshot)
-				throw error
-			}
-		},
-	} as unknown as D1Database
+  const db = {
+    prepare(query: string) {
+      const trimmed = query.replace(/\s+/g, " ").trim();
+      const lower = trimmed.toLowerCase();
+      return {
+        bind(...params: Array<unknown>) {
+          return {
+            async all<T>() {
+              await options?.onSelect?.(lower);
+              if (
+                options?.failSelectContaining &&
+                lower.includes(options.failSelectContaining)
+              ) {
+                throw new Error("simulated inventory read failure");
+              }
+              let results: Array<unknown> = [];
+              const userId = params[0] as string;
+              if (
+                lower ===
+                "select client_id from user_mcp_oauth_clients where user_id = ?"
+              ) {
+                const numericId = Number(params[0]);
+                results = (rows.user_mcp_oauth_clients ?? [])
+                  .filter((row) => Number(row["user_id"]) === numericId)
+                  .map((row) => ({ client_id: row["client_id"] }));
+                return { results: results as Array<T>, meta: { changes: 0 } };
+              }
+              if (
+                lower ===
+                "select deleting_at from users where stable_user_id = ?"
+              ) {
+                results = (rows.users ?? [])
+                  .filter((row) => row["stable_user_id"] === userId)
+                  .map((row) => ({
+                    deleting_at: row["deleting_at"] ?? null,
+                  }));
+                return { results: results as Array<T>, meta: { changes: 0 } };
+              }
+              if (lower === "select stable_user_id from users where id = ?") {
+                const numericId = Number(params[0]);
+                results = (rows.users ?? [])
+                  .filter((row) => Number(row["id"]) === numericId)
+                  .map((row) => ({
+                    stable_user_id: row["stable_user_id"],
+                  }));
+                return { results: results as Array<T>, meta: { changes: 0 } };
+              }
+              if (
+                lower ===
+                "select stable_user_id, deleting_at from users where id = ?"
+              ) {
+                const numericId = Number(params[0]);
+                results = (rows.users ?? [])
+                  .filter((row) => Number(row["id"]) === numericId)
+                  .map((row) => ({
+                    stable_user_id: row["stable_user_id"],
+                    deleting_at: row["deleting_at"] ?? null,
+                  }));
+                return { results: results as Array<T>, meta: { changes: 0 } };
+              }
+              if (
+                lower ===
+                "select id from saved_packages where user_id = ? and has_app = 1"
+              ) {
+                results = (rows.saved_packages ?? [])
+                  .filter(
+                    (row) =>
+                      row["user_id"] === userId &&
+                      (row["has_app"] === 1 ||
+                        row["has_app"] === "1" ||
+                        row["has_app"] === true),
+                  )
+                  .map((row) => ({ id: row["id"] }));
+                return { results: results as Array<T>, meta: { changes: 0 } };
+              }
+              if (
+                lower ===
+                "select id, published_commit from entity_sources where user_id = ?"
+              ) {
+                results = (rows.entity_sources ?? [])
+                  .filter((row) => row["user_id"] === userId)
+                  .map((row) => ({
+                    id: row["id"],
+                    published_commit: row["published_commit"] ?? null,
+                  }));
+                return { results: results as Array<T>, meta: { changes: 0 } };
+              }
+              if (
+                lower ===
+                "select id, kody_id, source_id, has_app from saved_packages where user_id = ?"
+              ) {
+                results = (rows.saved_packages ?? [])
+                  .filter((row) => row["user_id"] === userId)
+                  .map((row) => ({
+                    id: row["id"],
+                    kody_id: row["kody_id"],
+                    source_id: row["source_id"],
+                    has_app: row["has_app"],
+                  }));
+                return { results: results as Array<T>, meta: { changes: 0 } };
+              }
+              if (
+                lower ===
+                "select do_id from mcp_agent_sessions where user_id = ? order by do_id"
+              ) {
+                results = (rows.mcp_agent_sessions ?? [])
+                  .filter((row) => row["user_id"] === userId)
+                  .map((row) => ({ do_id: row["do_id"] }));
+                return { results: results as Array<T>, meta: { changes: 0 } };
+              }
+              if (
+                lower.includes(
+                  "select storage_id as storageid from user_storage_buckets",
+                )
+              ) {
+                results = (rows.user_storage_buckets ?? [])
+                  .filter(
+                    (row) =>
+                      row["user_id"] === userId &&
+                      (!lower.includes("kind <> 'repo_session'") ||
+                        row["kind"] !== "repo_session"),
+                  )
+                  .map((row) => ({ storageId: row["storage_id"] }))
+                  .sort((left, right) =>
+                    String(left.storageId).localeCompare(
+                      String(right.storageId),
+                    ),
+                  );
+                return { results: results as Array<T>, meta: { changes: 0 } };
+              }
+              if (
+                lower.includes("from community_listings") &&
+                lower.includes("entity_sources.published_commit")
+              ) {
+                results = (rows.community_listings ?? [])
+                  .filter((row) => row["owner_user_id"] === userId)
+                  .map((row, index) => {
+                    const source = (rows.entity_sources ?? []).find(
+                      (sourceRow) =>
+                        sourceRow["id"] === row["source_id"] &&
+                        sourceRow["user_id"] === row["owner_user_id"],
+                    );
+                    return {
+                      account_r2_rowid: index + 1,
+                      id: row["id"],
+                      pinned_commit: row["pinned_commit"],
+                      source_published_commit:
+                        source?.["published_commit"] ?? null,
+                    };
+                  });
+                return { results: results as Array<T>, meta: { changes: 0 } };
+              }
+              const m = lower.match(/^select id from (\w+) where user_id = \?/);
+              if (m) {
+                const table = m[1] as string;
+                results = (rows[table] ?? [])
+                  .filter((row) => row["user_id"] === userId)
+                  .map((row) => ({ id: row["id"] }));
+                return { results: results as Array<T>, meta: { changes: 0 } };
+              }
+              const storageMatch = lower.match(
+                /^select storage_id from (\w+) where user_id = \? and storage_id is not null/,
+              );
+              if (storageMatch) {
+                const table = storageMatch[1] as string;
+                results = (rows[table] ?? [])
+                  .filter(
+                    (row) =>
+                      row["user_id"] === userId && row["storage_id"] != null,
+                  )
+                  .map((row) => ({ storage_id: row["storage_id"] }));
+                return { results: results as Array<T>, meta: { changes: 0 } };
+              }
+              const kvMatch = lower.match(
+                /^select kv_key from (\w+) where user_id = \?/,
+              );
+              if (kvMatch) {
+                const table = kvMatch[1] as string;
+                results = (rows[table] ?? [])
+                  .filter((row) => row["user_id"] === userId)
+                  .map((row) => ({ kv_key: row["kv_key"] }));
+                return { results: results as Array<T>, meta: { changes: 0 } };
+              }
+              if (lower === "select avatar_key from users where id = ?") {
+                const numericId = Number(params[0]);
+                results = (rows.users ?? [])
+                  .filter((row) => Number(row["id"]) === numericId)
+                  .map((row) => ({
+                    avatar_key: row["avatar_key"] ?? null,
+                  }));
+                return { results: results as Array<T>, meta: { changes: 0 } };
+              }
+              if (
+                lower === "select stripe_customer_id from users where id = ?"
+              ) {
+                const numericId = Number(params[0]);
+                results = (rows.users ?? [])
+                  .filter((row) => Number(row["id"]) === numericId)
+                  .map((row) => ({
+                    stripe_customer_id: row["stripe_customer_id"] ?? null,
+                  }));
+                return { results: results as Array<T>, meta: { changes: 0 } };
+              }
+              return { results: [] as Array<T>, meta: { changes: 0 } };
+            },
+            async first<T>() {
+              const result = await this.all<T>();
+              return (result.results[0] ?? null) as T | null;
+            },
+            async run() {
+              if (
+                options?.failRunContaining &&
+                lower.includes(options.failRunContaining)
+              ) {
+                throw new Error("simulated atomic D1 failure");
+              }
+              const userId = params[0] as string | number;
+              if (
+                lower ===
+                "update users set deleting_at = ?, updated_at = ? where id = ? and deleting_at is null"
+              ) {
+                let changed = 0;
+                for (const row of rows.users ?? []) {
+                  if (row["id"] !== params[2]) continue;
+                  if (row["deleting_at"] != null) continue;
+                  row["deleting_at"] = params[0];
+                  row["updated_at"] = params[1];
+                  changed += 1;
+                }
+                return { meta: { changes: changed } };
+              }
+              if (
+                lower ===
+                "update users set deleting_at = null, updated_at = ? where id = ? and deleting_at = ?"
+              ) {
+                let changed = 0;
+                for (const row of rows.users ?? []) {
+                  if (row["id"] !== params[1]) continue;
+                  if (row["deleting_at"] !== params[2]) continue;
+                  row["deleting_at"] = null;
+                  row["updated_at"] = params[0];
+                  changed += 1;
+                }
+                return { meta: { changes: changed } };
+              }
+              if (
+                lower ===
+                "update users set deleting_at = null, updated_at = ? where id = ?"
+              ) {
+                let changed = 0;
+                for (const row of rows.users ?? []) {
+                  if (row["id"] !== params[1]) continue;
+                  row["deleting_at"] = null;
+                  row["updated_at"] = params[0];
+                  changed += 1;
+                }
+                return { meta: { changes: changed } };
+              }
+              const nullColumnMatch = lower.match(
+                /^update (\w+) set ((?:\w+ = null)(?:, \w+ = null)*) where (\w+) = \?$/,
+              );
+              if (nullColumnMatch) {
+                const table = nullColumnMatch[1] as string;
+                const assignments = nullColumnMatch[2]!
+                  .split(", ")
+                  .map((part) => part.replace(" = null", ""));
+                const matchColumn = nullColumnMatch[3] as string;
+                let changed = 0;
+                for (const row of rows[table] ?? []) {
+                  if (row[matchColumn] !== userId) continue;
+                  for (const column of assignments) {
+                    row[column] = null;
+                  }
+                  changed += 1;
+                }
+                return { meta: { changes: changed } };
+              }
+              const replaceJsonMatch = lower.match(
+                /^update (\w+) set (\w+) = replace\(\2, \?, \?\) where \2 like \?$/,
+              );
+              if (replaceJsonMatch) {
+                const table = replaceJsonMatch[1] as string;
+                const column = replaceJsonMatch[2] as string;
+                const search = String(params[0]);
+                const replacement = String(params[1]);
+                const likePattern = String(params[2]);
+                const needle = likePattern.replace(/^%/, "").replace(/%$/, "");
+                let changed = 0;
+                for (const row of rows[table] ?? []) {
+                  const current = row[column];
+                  if (typeof current !== "string") continue;
+                  if (!current.includes(needle)) continue;
+                  row[column] = current.split(search).join(replacement);
+                  changed += 1;
+                }
+                return { meta: { changes: changed } };
+              }
+              const replaceColumnMatch = lower.match(
+                /^update (\w+) set (\w+) = \? where (\w+) = \?$/,
+              );
+              if (replaceColumnMatch) {
+                const table = replaceColumnMatch[1] as string;
+                const setColumn = replaceColumnMatch[2] as string;
+                const matchColumn = replaceColumnMatch[3] as string;
+                let changed = 0;
+                for (const row of rows[table] ?? []) {
+                  if (row[matchColumn] !== params[1]) continue;
+                  row[setColumn] = params[0];
+                  changed += 1;
+                }
+                return { meta: { changes: changed } };
+              }
+              const userColumnsMatch = lower.match(
+                /^delete from (\w+) where ((?:\w+ = \?)(?: or \w+ = \?)*)$/,
+              );
+              if (userColumnsMatch) {
+                const table = userColumnsMatch[1] as string;
+                const columns = userColumnsMatch[2]!
+                  .split(" or ")
+                  .map((part) => part.replace(" = ?", ""));
+                const removed = deleteByPredicate(table, (row) =>
+                  columns.some(
+                    (column, index) => row[column] === params[index],
+                  ),
+                );
+                return { meta: { changes: removed } };
+              }
+              const userIdMatch = lower.match(
+                /^delete from (\w+) where user_id = \?/,
+              );
+              if (userIdMatch) {
+                const table = userIdMatch[1] as string;
+                const removed = deleteByPredicate(
+                  table,
+                  (row) => row["user_id"] === userId,
+                );
+                return { meta: { changes: removed } };
+              }
+              const bucketParentMatch = lower.match(
+                /^delete from (\w+) where bucket_id in \( select id from (\w+) where user_id = \? \)/,
+              );
+              if (bucketParentMatch) {
+                const childTable = bucketParentMatch[1] as string;
+                const parentTable = bucketParentMatch[2] as string;
+                const parentIds = new Set(
+                  selectIds(parentTable, (row) => row["user_id"] === userId),
+                );
+                const removed = deleteByPredicate(childTable, (row) =>
+                  parentIds.has(row["bucket_id"]),
+                );
+                return { meta: { changes: removed } };
+              }
+              const communityListingChildMatch = lower.match(
+                /^delete from (\w+) where (\w+) in \( select id from community_listings where owner_user_id = \? \)/,
+              );
+              if (communityListingChildMatch) {
+                const table = communityListingChildMatch[1] as string;
+                const listingColumn = communityListingChildMatch[2] as string;
+                const listingIds = new Set(
+                  selectIds(
+                    "community_listings",
+                    (row) => row["owner_user_id"] === userId,
+                  ),
+                );
+                const removed = deleteByPredicate(table, (row) =>
+                  listingIds.has(row[listingColumn]),
+                );
+                return { meta: { changes: removed } };
+              }
+              const usersMatch = lower.match(
+                /^delete from users where id = \?/,
+              );
+              if (usersMatch) {
+                const removed = deleteByPredicate(
+                  "users",
+                  (row) => row["id"] === userId,
+                );
+                return { meta: { changes: removed } };
+              }
+              return { meta: { changes: 0 } };
+            },
+          };
+        },
+      };
+    },
+    async batch(
+      statements: Array<{ run: () => Promise<{ meta: { changes: number } }> }>,
+    ) {
+      const snapshot = structuredClone(rows);
+      try {
+        const results = [];
+        for (const statement of statements) {
+          results.push(await statement.run());
+        }
+        return results;
+      } catch (error) {
+        for (const key of Object.keys(rows)) delete rows[key];
+        Object.assign(rows, snapshot);
+        throw error;
+      }
+    },
+  } as unknown as D1Database;
 
-	return { db, rows }
+  return { db, rows };
 }
 
-// Mimics the jobs worker's JobsService against the test db: storage-id
-// listing and purgeUser both operate on the fixture's jobs tables.
+// Mimics the jobs worker's JobsService against the test db: job-id and
+// storage-id listing and purgeUser all operate on the fixture's jobs tables
+// (which stand in for the jobs worker's own D1; production APP_DB has none).
 export function createJobsBindingStub(
-	db: D1Database,
-	overrides: Record<string, unknown> = {},
+  db: D1Database,
+  overrides: Record<string, unknown> = {},
 ) {
-	async function listStorageIds(table: string, userId: string) {
-		const { results } = await db
-			.prepare(
-				`SELECT storage_id FROM ${table} WHERE user_id = ? AND storage_id IS NOT NULL`,
-			)
-			.bind(userId)
-			.all<{ storage_id: string }>()
-		return (results ?? []).map((row) => row.storage_id)
-	}
-	return {
-		listJobStorageIdsForUser: async (input: { userId: string }) => [
-			...(await listStorageIds('jobs', input.userId)),
-			...(await listStorageIds('archived_job_artifacts', input.userId)),
-		],
-		purgeUser: async (input: { userId: string }) => {
-			await db
-				.prepare(`DELETE FROM archived_job_artifacts WHERE user_id = ?`)
-				.bind(input.userId)
-				.run()
-			await db
-				.prepare(`DELETE FROM jobs WHERE user_id = ?`)
-				.bind(input.userId)
-				.run()
-			return { ok: true as const, userId: input.userId, purged: true }
-		},
-		...overrides,
-	}
+  async function listStorageIds(table: string, userId: string) {
+    const { results } = await db
+      .prepare(
+        `SELECT storage_id FROM ${table} WHERE user_id = ? AND storage_id IS NOT NULL`,
+      )
+      .bind(userId)
+      .all<{ storage_id: string }>();
+    return (results ?? []).map((row) => row.storage_id);
+  }
+  return {
+    listJobIdsForUser: async (input: { userId: string }) => {
+      const { results } = await db
+        .prepare(`SELECT id FROM jobs WHERE user_id = ?`)
+        .bind(input.userId)
+        .all<{ id: string }>();
+      return (results ?? []).map((row) => row.id);
+    },
+    listJobStorageIdsForUser: async (input: { userId: string }) => [
+      ...(await listStorageIds("jobs", input.userId)),
+      ...(await listStorageIds("archived_job_artifacts", input.userId)),
+    ],
+    purgeUser: async (input: { userId: string }) => {
+      await db
+        .prepare(`DELETE FROM archived_job_artifacts WHERE user_id = ?`)
+        .bind(input.userId)
+        .run();
+      await db
+        .prepare(`DELETE FROM jobs WHERE user_id = ?`)
+        .bind(input.userId)
+        .run();
+      return { ok: true as const, userId: input.userId, purged: true };
+    },
+    ...overrides,
+  };
 }
 
 export function createSuccessfulDeletionEnv(
-	db: D1Database,
-	overrides: Partial<Env> & {
-		OAUTH_PROVIDER?: {
-			listUserGrants: (
-				userId: string,
-				options: { cursor: string | undefined },
-			) => Promise<{
-				items: Array<{ id: string; clientId: string }>
-				cursor: string | undefined
-			}>
-			revokeGrant: (grantId: string, userId: string) => Promise<unknown>
-		}
-	} = {},
+  db: D1Database,
+  overrides: Partial<Env> & {
+    OAUTH_PROVIDER?: {
+      listUserGrants: (
+        userId: string,
+        options: { cursor: string | undefined },
+      ) => Promise<{
+        items: Array<{ id: string; clientId: string }>;
+        cursor: string | undefined;
+      }>;
+      revokeGrant: (grantId: string, userId: string) => Promise<unknown>;
+    };
+  } = {},
 ) {
-	const durableObjectId = (name: string) => name as unknown as DurableObjectId
-	const fetchOk = async () => Response.json({ ok: true })
-	const userMeter = createInMemoryUserMeterEnv()
-	const repoSessionIndex = createInMemoryRepoSessionIndexEnv(db)
-	return {
-		APP_DB: db,
-		CAPABILITY_VECTOR_INDEX: {
-			deleteByIds: async () => undefined,
-		},
-		STORAGE_RUNNER: {
-			idFromName: durableObjectId,
-			get: () => ({ clearStorage: async () => ({ ok: true as const }) }),
-		},
-		RUN_LOG: {
-			idFromName: durableObjectId,
-			get: () => ({
-				clearAll: async () => ({ ok: true as const }),
-				listStorageIds: async () => [] as Array<string>,
-			}),
-		},
-		USER_METER: userMeter.env.USER_METER,
-		STRIPE_PLAN_REFRESH: {
-			idFromName: durableObjectId,
-			get: () => ({ purgeUser: async () => ({ ok: true as const }) }),
-		},
-		MAILBOX: {
-			idFromName: durableObjectId,
-			get: () => ({
-				listBlobReferences: async () => ({
-					references: [],
-					nextStartAfter: null,
-					truncated: false as const,
-				}),
-				purge: async () => ({ ok: true as const }),
-			}),
-		},
-		JOBS: createJobsBindingStub(db),
-		REPO_SESSION: {
-			idFromName: durableObjectId,
-			get: () => ({ purgeSession: async () => ({ ok: true as const }) }),
-		},
-		REPO_SESSION_INDEX: repoSessionIndex.REPO_SESSION_INDEX,
-		MCP_CLIENT_HUB: {
-			idFromName: durableObjectId,
-			get: () => ({ purgeForAccountDeletion: async () => undefined }),
-		},
-		PACKAGE_REALTIME_SESSION: {
-			idFromName: durableObjectId,
-			get: () => ({ fetch: fetchOk }),
-		},
-		COMMUNITY_ASSETS: {
-			async list() {
-				return {
-					objects: [],
-					delimitedPrefixes: [],
-					truncated: false as const,
-				}
-			},
-			delete: async () => undefined,
-		},
-		EMAIL_BLOBS: {
-			async list() {
-				return {
-					objects: [],
-					delimitedPrefixes: [],
-					truncated: false as const,
-				}
-			},
-			delete: async () => undefined,
-		},
-		OAUTH_PROVIDER: {
-			async listUserGrants() {
-				return { items: [], cursor: undefined }
-			},
-			async revokeGrant() {
-				return undefined
-			},
-		},
-		...overrides,
-	} as unknown as Parameters<typeof deleteUserAccount>[0]['env']
+  const durableObjectId = (name: string) => name as unknown as DurableObjectId;
+  const fetchOk = async () => Response.json({ ok: true });
+  const userMeter = createInMemoryUserMeterEnv();
+  const repoSessionIndex = createInMemoryRepoSessionIndexEnv(db);
+  return {
+    APP_DB: db,
+    CAPABILITY_VECTOR_INDEX: {
+      deleteByIds: async () => undefined,
+    },
+    STORAGE_RUNNER: {
+      idFromName: durableObjectId,
+      get: () => ({ clearStorage: async () => ({ ok: true as const }) }),
+    },
+    RUN_LOG: {
+      idFromName: durableObjectId,
+      get: () => ({
+        clearAll: async () => ({ ok: true as const }),
+        listStorageIds: async () => [] as Array<string>,
+      }),
+    },
+    USER_METER: userMeter.env.USER_METER,
+    STRIPE_PLAN_REFRESH: {
+      idFromName: durableObjectId,
+      get: () => ({ purgeUser: async () => ({ ok: true as const }) }),
+    },
+    MAILBOX: {
+      idFromName: durableObjectId,
+      get: () => ({
+        listBlobReferences: async () => ({
+          references: [],
+          nextStartAfter: null,
+          truncated: false as const,
+        }),
+        purge: async () => ({ ok: true as const }),
+      }),
+    },
+    JOBS: createJobsBindingStub(db),
+    REPO_SESSION: {
+      idFromName: durableObjectId,
+      get: () => ({ purgeSession: async () => ({ ok: true as const }) }),
+    },
+    REPO_SESSION_INDEX: repoSessionIndex.REPO_SESSION_INDEX,
+    MCP_CLIENT_HUB: {
+      idFromName: durableObjectId,
+      get: () => ({ purgeForAccountDeletion: async () => undefined }),
+    },
+    PACKAGE_REALTIME_SESSION: {
+      idFromName: durableObjectId,
+      get: () => ({ fetch: fetchOk }),
+    },
+    COMMUNITY_ASSETS: {
+      async list() {
+        return {
+          objects: [],
+          delimitedPrefixes: [],
+          truncated: false as const,
+        };
+      },
+      delete: async () => undefined,
+    },
+    EMAIL_BLOBS: {
+      async list() {
+        return {
+          objects: [],
+          delimitedPrefixes: [],
+          truncated: false as const,
+        };
+      },
+      delete: async () => undefined,
+    },
+    OAUTH_PROVIDER: {
+      async listUserGrants() {
+        return { items: [], cursor: undefined };
+      },
+      async revokeGrant() {
+        return undefined;
+      },
+    },
+    ...overrides,
+  } as unknown as Parameters<typeof deleteUserAccount>[0]["env"];
 }

--- a/packages/worker/src/test-support/create-d1-from-sqlite.ts
+++ b/packages/worker/src/test-support/create-d1-from-sqlite.ts
@@ -1,4 +1,4 @@
-import { type DatabaseSync } from 'node:sqlite'
+import { type DatabaseSync, type SQLInputValue } from 'node:sqlite'
 
 export type CreateD1FromSqliteOptions = {
 	/**
@@ -42,7 +42,9 @@ export function createD1FromSqlite(
 	function createPreparedStatement(query: string) {
 		return {
 			query,
-			bind(...params: Array<unknown>) {
+			// D1's `bind` accepts `unknown`; callers in tests pass SQLite-compatible
+			// scalars, so narrow once here for `node:sqlite`'s typed statements.
+			bind(...params: Array<SQLInputValue>) {
 				assertBindingCount(params)
 				return {
 					query,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Every production account deletion (self-service and the unverified-account purge, #1991/#2018) has been failing at the inventory step:

```
AccountDeletionInventoryError: Failed to enumerate vector ids: D1_ERROR: no such table: jobs: SQLITE_ERROR
```

Confirmed live today via `adminUnverifiedAccountPurgeRun`: all three eligible accounts failed with exactly this error. `listUserVectorIds` scanned `SELECT id FROM jobs WHERE user_id = ?` on `APP_DB` for the `job` vectorize surface. Jobs moved to the jobs worker's D1 behind the `JOBS` binding (ADR 0016) and migration `0010-drop-jobs-tables.sql` dropped the APP_DB copy; tests passed only because fixtures kept a `jobs` table next to APP_DB. Failure mode was safe (fence released, nothing half-deleted), but no account could be deleted.

A second, pre-existing issue in the same path (raised by CodeRabbit on #2025): a failed Stripe subscription cancellation was logged as a cleanup warning while the user row was still deleted, which could leave a live subscription billing a customer with no account.

## Fix 1: job vector inventory

- New jobs-worker RPC `listJobIdsForUser({ userId })` on `JobsStore` / `JobsService` (live job ids ∪ archived-artifact job ids; vectors are only written for live rows, the superset keeps the sweep idempotent). Mirrors the existing `listJobStorageIdsForUser`.
- `UserOwnedVectorizeSurface.sourceTable` is replaced with an explicit `source: { kind: 'app_db', table } | { kind: 'jobs_rpc' }` discriminant; account deletion resolves it with an exhaustive `switch` (`never` default). The job surface goes over `JOBS`; inventory fails with a clear error if `JOBS` is unbound rather than silently skipping.
- Audited other consumers: the vector reindex path already uses `jobsData(env)` (JOBS RPC); no remaining APP_DB reader of `jobs`.

## Fix 2: Stripe cancellation is a precondition of deletion

- New `AccountDeletionBillingError`, a sibling of `AccountDeletionInventoryError`. `cancelActiveStripeSubscriptions` runs after inventory and before the first destructive step; it cancels every `active`/`trialing` subscription and throws if listing fails or any subscription is still billable. On that error the fence is released and nothing is deleted.
- Idempotent: subscriptions already `canceled` are skipped; a cancel that errors is re-verified against a fresh listing; `resource_missing` counts as canceled (`StripeApiError` now carries Stripe's `error.code`).
- `deleteStripeCustomer` stays best-effort (nothing bills a customer with no billable subscription).
- Self-service `POST /account/delete` returns **503** `{ "error": "We could not cancel your subscription, so your account was not deleted. Try again in a few minutes or contact support." }`, session intact, account fully usable; audit `account_delete:failure` reason `billing_cancel_failed`. The purge lane treats it as a pre-cleanup failure (fence released, retried next run).

## Tests

- `deleteUserAccount` against the real migrated APP_DB schema (no `jobs` table): inventory succeeds, job vector ids from the JOBS stub are deleted, user row removed. Fails against the pre-fix code with the production error.
- `JOBS` unbound → `AccountDeletionInventoryError` with the explicit message; fence cleared.
- Schema-drift guard: every `app_db` surface table must exist in the migrated APP_DB schema, and `jobs` must not.
- Jobs-worker RPC test for `listJobIdsForUser` against a migrated jobs D1.
- Billing: list failure and rejected cancel → `AccountDeletionBillingError`, no vectors/customer deleted, rows intact, fence cleared; already-canceled and racing-cancel → deletion proceeds; customer-delete failure stays warning-only. Handler 503 + message, no cookie, no lifecycle event. Purge lane retries on next run. `stripe-client`: `resource_missing` resolves.

## Deploy ordering

No flag needed: `deploy.yml`'s `🚀 Deploy to production` job `needs: deploy-jobs-worker`, so the callee (jobs worker, new RPC) deploys before the caller (origin) in the same run.

## Docs

`docs/contributing/architecture/data-storage.md` account-deletion section lists the per-surface inventory sources and the billing precondition.

## Reviewer note

Commit 2 only reverts accidental prettier formatting from commit 1; squash-merge.

Validation at `423bf87d`: format, typecheck, lint, knip, `test:node` 813 files / 2479 tests.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b0f6a92a-81cd-4157-8b60-188c83ca84c0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b0f6a92a-81cd-4157-8b60-188c83ca84c0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Account deletion now cancels active or trial subscriptions before removing account data.
  * If cancellation cannot be confirmed, deletion stops safely, the account is retained, and retrying is supported.
  * Already-canceled or missing subscriptions no longer block deletion retries.
  * Account cleanup now includes vector data associated with both active and archived jobs.
  * Stripe customer cleanup remains best-effort after account data removal.

* **Documentation**
  * Updated account-deletion guidance to describe billing cancellation and data inventory behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->