### PR TITLE
Make preview cleanup complete after a single Cloudflare failure

### DIFF
--- a/docs/contributing/setup/preview-deploys.md
+++ b/docs/contributing/setup/preview-deploys.md
@@ -13,13 +13,25 @@ setup pages.
 - Highlight worker: `<preview-worker-name>-highlight`
 - App D1 database: `<preview-worker-name>-db`
 - Audit D1 database: `<preview-worker-name>-audit-db`
-- Jobs D1 database: ensured by `jobs-worker-resources.ts` for
-  `<preview-worker-name>-jobs`
+- Jobs D1 database: shared `kody-preview-jobs` (ensured by
+  `jobs-worker-resources.ts`; not per-PR)
 - KV namespace (OAuth state): `<preview-worker-name>-oauth-kv`
 - Mock workers: `<preview-worker-name>-mock-<service>`
 
 When a PR is closed, the cleanup job deletes the preview
-app/platform/runtime/jobs Workers, mock Workers, and these resources as well.
+app/platform/runtime/jobs Workers, mock Workers, Queues, per-preview D1/KV/R2,
+and these per-PR resources. It does not delete shared names such as
+`kody-preview-jobs` or any production name.
+
+Cleanup is bounded, retry-safe, and idempotent. Transient Cloudflare 429 and 5xx
+responses (including wrangler 504 Gateway Timeout) retry with backoff inside the
+four-minute job budget. Permanent 401/403 failures are not retried. A failure on
+one resource does not skip later independent resources: the sweep finishes, then
+fails once with every leftover name. Already-missing resources count as success.
+Queue consumers are removed before Workers, and Workers before Queues, because
+those deletes depend on each other. Non-empty preview R2 buckets are emptied
+(objects deleted) before the bucket delete; leftover objects surface in the same
+aggregate failure instead of a warning.
 
 Cloudflare Workers supports version `preview_urls`, but those preview URLs are
 not available for Workers that use Durable Objects. The main app Worker binds

--- a/tools/ci/jobs-worker-resources.ts
+++ b/tools/ci/jobs-worker-resources.ts
@@ -234,6 +234,10 @@ async function ensureJobsWorkerResources(options: CliOptions) {
 
 	let workerName = baseConfig.name as string
 	if (options.envName === 'preview') {
+		// Preview JOBS_DB stays the shared `kody-preview-jobs` database from
+		// wrangler.jsonc — it is not per-PR. Preview cleanup deletes the
+		// per-preview jobs Worker (`kody-pr-<n>-jobs`) and must never delete
+		// `kody-preview-jobs` or `kody-jobs`.
 		// Per-preview jobs workers are brand new scripts: they cannot run the
 		// production script-transfer migration (from_script "kody-production"),
 		// so the

--- a/tools/ci/preview-resources.node.test.ts
+++ b/tools/ci/preview-resources.node.test.ts
@@ -454,6 +454,84 @@ test('cleanup retries a wrangler 429 then succeeds', async () => {
 	vi.unstubAllEnvs()
 })
 
+test('D1 and KV deletes treat a post-retry not-found as success', async () => {
+	consoleError.mockImplementation(() => {})
+	installCleanupEnv()
+	const fetchMock = vi
+		.fn<typeof fetch>()
+		.mockImplementation(async () => emptyQueueListResponse())
+	vi.stubGlobal('fetch', fetchMock)
+	let d1DeleteAttempts = 0
+	let kvDeleteAttempts = 0
+	spawnSync.mockImplementation((_command, args) => {
+		const argv = args as Array<string>
+		const joined = argv.join(' ')
+		if (joined.includes('d1 list')) {
+			return {
+				status: 0,
+				stdout: `${JSON.stringify([{ uuid: 'db-1', name: 'kody-pr-11-db' }])}\n`,
+				stderr: '',
+			}
+		}
+		if (joined.includes('kv namespace list')) {
+			return {
+				status: 0,
+				stdout: `${JSON.stringify([{ id: 'kv-1', title: 'kody-pr-11-oauth-kv' }])}\n`,
+				stderr: '',
+			}
+		}
+		if (joined.includes('d1 delete')) {
+			d1DeleteAttempts += 1
+			if (d1DeleteAttempts === 1) {
+				return {
+					status: 1,
+					stdout: '',
+					stderr: 'Gateway Timeout [code: 504]\n',
+				}
+			}
+			return {
+				status: 1,
+				stdout: '',
+				stderr: 'The database you tried to delete does not exist\n',
+			}
+		}
+		if (joined.includes('kv namespace delete')) {
+			kvDeleteAttempts += 1
+			if (kvDeleteAttempts === 1) {
+				return {
+					status: 1,
+					stdout: '',
+					stderr: 'Gateway Timeout [code: 504]\n',
+				}
+			}
+			return {
+				status: 1,
+				stdout: '',
+				stderr: 'The requested resource does not exist\n',
+			}
+		}
+		return alreadyMissingWrangler(argv)
+	})
+
+	await cleanupPreviewResources({
+		workerName: 'kody-pr-11',
+		dryRun: false,
+		sleep: async () => {},
+	})
+
+	expect(d1DeleteAttempts).toBe(2)
+	expect(kvDeleteAttempts).toBe(2)
+	const logged = consoleError.mock.calls.map(([message]) => String(message))
+	expect(logged).toEqual(
+		expect.arrayContaining([
+			'D1 database already deleted: kody-pr-11-db',
+			'KV namespace already deleted: kody-pr-11-oauth-kv',
+		]),
+	)
+	vi.unstubAllGlobals()
+	vi.unstubAllEnvs()
+})
+
 test('permanent queue auth failure still attempts later independent resources and aggregates leftovers', async () => {
 	consoleError.mockImplementation(() => {})
 	installCleanupEnv()

--- a/tools/ci/preview-resources.node.test.ts
+++ b/tools/ci/preview-resources.node.test.ts
@@ -646,8 +646,9 @@ test('non-empty preview R2 buckets are emptied then deleted', async () => {
 		bucketDeletes.filter((name) => name === 'kody-pr-42-email-blobs'),
 	).toEqual(['kody-pr-42-email-blobs', 'kody-pr-42-email-blobs'])
 	expect(
-		deletedObjectUrls.some((url) => url.includes('seeded%2Fblob.bin')),
+		deletedObjectUrls.some((url) => url.includes('/objects/seeded/blob.bin')),
 	).toBe(true)
+	expect(deletedObjectUrls.some((url) => url.includes('%2F'))).toBe(false)
 	expect(
 		consoleError.mock.calls.some(([message]) =>
 			String(message).includes(

--- a/tools/ci/preview-resources.node.test.ts
+++ b/tools/ci/preview-resources.node.test.ts
@@ -1,7 +1,7 @@
 import * as childProcess from 'node:child_process'
 import { readFile } from 'node:fs/promises'
 import { consoleError } from '#worker/test-support/console-spies.ts'
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { expect, test, vi } from 'vitest'
 import {
 	assertPreviewResourceName,
 	buildPreviewResourceNames,
@@ -11,6 +11,7 @@ import {
 	deletePreviewQueue,
 	deletePreviewR2Bucket,
 	deletePreviewWorkerScript,
+	listPreviewWorkerNames,
 	previewResourceNamePattern,
 	removePreviewQueueConsumers,
 	type PreviewResourceKind,
@@ -28,18 +29,63 @@ vi.mock('node:child_process', async (importOriginal) => {
 })
 
 const spawnSync = vi.mocked(childProcess.spawnSync)
-const fetchMock = vi.fn<typeof fetch>()
 
-beforeEach(() => {
-	vi.stubGlobal('fetch', fetchMock)
+function wranglerArgs(call: unknown) {
+	const args = (call as [string, Array<string>])[1] ?? []
+	return args
+}
+
+function wranglerArgList(call: unknown) {
+	return wranglerArgs(call).join(' ')
+}
+
+function alreadyMissingWrangler(args: ReadonlyArray<string>) {
+	const joined = args.join(' ')
+	if (joined.includes('d1 list')) {
+		return { status: 0, stdout: '[]\n', stderr: '' }
+	}
+	if (joined.includes('kv namespace list')) {
+		return { status: 0, stdout: '[]\n', stderr: '' }
+	}
+	if (joined.startsWith('delete ') || joined.startsWith('r2 bucket delete ')) {
+		return { status: 1, stdout: '', stderr: 'Worker not found\n' }
+	}
+	if (joined.includes('d1 delete') || joined.includes('kv namespace delete')) {
+		return { status: 1, stdout: '', stderr: 'does not exist\n' }
+	}
+	return { status: 1, stdout: '', stderr: `unexpected wrangler: ${joined}` }
+}
+
+function emptyQueueListResponse() {
+	return Response.json({
+		success: true,
+		result: [],
+		result_info: { total_pages: 1 },
+	})
+}
+
+function queueListResponse(name: string, queueId: string) {
+	return Response.json({
+		success: true,
+		result: [{ queue_id: queueId, queue_name: name }],
+		result_info: { total_pages: 1 },
+	})
+}
+
+function authForbiddenResponse() {
+	return Response.json(
+		{
+			success: false,
+			errors: [{ code: 10000, message: 'Authentication error' }],
+		},
+		{ status: 403 },
+	)
+}
+
+function installCleanupEnv() {
 	vi.stubEnv('CLOUDFLARE_ACCOUNT_ID', 'test-account')
 	vi.stubEnv('CLOUDFLARE_API_TOKEN', 'test-token')
-})
-
-afterEach(() => {
-	vi.unstubAllGlobals()
-	vi.unstubAllEnvs()
-})
+}
 
 const wranglerConfigPaths = [
 	'packages/worker/wrangler.jsonc',
@@ -89,8 +135,6 @@ async function readCommittedResourceNames() {
 	return [...names]
 }
 
-// Names production-resources.ts and the deploy workflow derive at deploy time
-// rather than committing to a wrangler config.
 const derivedProductionNames = [
 	'kody',
 	'kody-platform',
@@ -141,12 +185,10 @@ function guardAccepts(name: string, kind: PreviewResourceKind) {
 	}
 }
 
-/** Names the guard lets through; every entry is a guard bug. */
 function namesAcceptedByGuard(names: ReadonlyArray<string>) {
 	return names.filter((name) => guardAccepts(name, 'worker'))
 }
 
-/** Preview names the guard refuses; every entry would break cleanup. */
 function namesRejectedByGuard(
 	entries: ReadonlyArray<readonly [string, PreviewResourceKind]>,
 ) {
@@ -155,166 +197,491 @@ function namesRejectedByGuard(
 		.map(([name]) => name)
 }
 
-describe('assertPreviewResourceName', () => {
-	test('rejects every committed production and shared resource name', async () => {
-		const committed = await readCommittedResourceNames()
-		expect(committed.length).toBeGreaterThan(20)
-		expect(committed).toContain('kody')
-		expect(committed).toContain('kody-audit')
-		expect(committed).toContain('kody-community-assets')
-		expect(committed).toContain('kody-webhook-dispatch')
-		expect(committed).toContain('kody-scheduled-dispatch')
-		expect(
-			namesAcceptedByGuard([...committed, ...derivedProductionNames]),
-		).toEqual([])
-		expect(() => assertPreviewResourceName('kody', 'worker')).toThrow(
-			'Refusing to delete worker "kody": it does not match the preview resource naming scheme',
-		)
-	})
-
-	test('rejects names outside the kody-pr-<number> / kody-branch-<slug> scheme', () => {
-		expect(
-			nonPreviewNames.filter((name) => previewResourceNamePattern.test(name)),
-		).toEqual([])
-		expect(namesAcceptedByGuard(nonPreviewNames)).toEqual([])
-		expect(() => assertPreviewResourceName('kody-pr-preview', 'd1')).toThrow(
-			'Refusing to delete d1 "kody-pr-preview"',
-		)
-	})
-
-	test('accepts every derived preview name kind for PR and branch previews', () => {
-		for (const workerName of acceptedWorkerNames) {
-			const derived = buildPreviewResourceNames(workerName)
-			const accepted: Array<[string, PreviewResourceKind]> = [
-				[workerName, 'worker'],
-				[`${workerName}-runtime`, 'worker'],
-				[`${workerName}-platform`, 'worker'],
-				[`${workerName}-jobs`, 'worker'],
-				[`${workerName}-highlight`, 'worker'],
-				[`${workerName}-mock-cloudflare`, 'worker'],
-				[derived.d1DatabaseName, 'd1'],
-				[derived.auditD1DatabaseName, 'd1'],
-				[derived.oauthKvTitle, 'kv'],
-				[derived.bundleArtifactsKvTitle, 'kv'],
-				[derived.communityAssetsBucketName, 'r2'],
-				[derived.emailBlobsBucketName, 'r2'],
-				[derived.repoSessionBlobsBucketName, 'r2'],
-				[derived.webhookDispatchQueueName, 'queue'],
-				[derived.webhookDispatchDeadLetterQueueName, 'queue'],
-			]
-			expect(namesRejectedByGuard(accepted)).toEqual([])
-		}
-		expect(buildPreviewResourceNames('kody-pr-42')).toEqual({
-			d1DatabaseName: 'kody-pr-42-db',
-			auditD1DatabaseName: 'kody-pr-42-audit-db',
-			oauthKvTitle: 'kody-pr-42-oauth-kv',
-			bundleArtifactsKvTitle: 'kody-pr-42-bundle-artifacts-kv',
-			communityAssetsBucketName: 'kody-pr-42-community-assets',
-			emailBlobsBucketName: 'kody-pr-42-email-blobs',
-			repoSessionBlobsBucketName: 'kody-pr-42-repo-session-blobs',
-			webhookDispatchQueueName: 'kody-pr-42-webhook-dispatch',
-			webhookDispatchDeadLetterQueueName: 'kody-pr-42-webhook-dispatch-dlq',
-		})
-	})
-
-	test('accepts names truncated to the 63-character Cloudflare limit', () => {
-		// The workflow caps the slug at 32 characters; the longest suffix
-		// (-bundle-artifacts-kv) pushes a max-length branch name past 63.
-		const workerName = `kody-branch-${'a1'.repeat(15)}-z`
-		expect(workerName).toHaveLength(44)
-		const derived = buildPreviewResourceNames(workerName)
-		expect(derived.bundleArtifactsKvTitle.length).toBeLessThanOrEqual(63)
-		expect(derived.bundleArtifactsKvTitle).not.toContain(workerName)
-		expect(derived.bundleArtifactsKvTitle).toMatch(
-			/^kody-branch-[a-z0-9]+-bundle-artifacts-kv$/,
-		)
-		expect(
-			namesRejectedByGuard(
-				Object.values(derived).map((name) => [name, 'kv'] as const),
-			),
-		).toEqual([])
-	})
+test('assertPreviewResourceName rejects every committed production and shared resource name', async () => {
+	const committed = await readCommittedResourceNames()
+	expect(committed.length).toBeGreaterThan(20)
+	expect(committed).toContain('kody')
+	expect(committed).toContain('kody-audit')
+	expect(committed).toContain('kody-community-assets')
+	expect(committed).toContain('kody-webhook-dispatch')
+	expect(committed).toContain('kody-scheduled-dispatch')
+	expect(committed).toContain('kody-preview-jobs')
+	expect(
+		namesAcceptedByGuard([...committed, ...derivedProductionNames]),
+	).toEqual([])
+	expect(() => assertPreviewResourceName('kody', 'worker')).toThrow(
+		'Refusing to delete worker "kody": it does not match the preview resource naming scheme',
+	)
+	expect(() => assertPreviewResourceName('kody-preview-jobs', 'd1')).toThrow(
+		'Refusing to delete d1 "kody-preview-jobs"',
+	)
 })
 
-describe('preview cleanup delete path', () => {
+test('assertPreviewResourceName rejects names outside the kody-pr / kody-branch scheme', () => {
+	expect(
+		nonPreviewNames.filter((name) => previewResourceNamePattern.test(name)),
+	).toEqual([])
+	expect(namesAcceptedByGuard(nonPreviewNames)).toEqual([])
+	expect(() => assertPreviewResourceName('kody-pr-preview', 'd1')).toThrow(
+		'Refusing to delete d1 "kody-pr-preview"',
+	)
+})
+
+test('assertPreviewResourceName accepts every derived preview name kind', () => {
+	for (const workerName of acceptedWorkerNames) {
+		const derived = buildPreviewResourceNames(workerName)
+		const accepted: Array<[string, PreviewResourceKind]> = [
+			[workerName, 'worker'],
+			[`${workerName}-runtime`, 'worker'],
+			[`${workerName}-platform`, 'worker'],
+			[`${workerName}-jobs`, 'worker'],
+			[`${workerName}-highlight`, 'worker'],
+			[`${workerName}-mock-cloudflare`, 'worker'],
+			[derived.d1DatabaseName, 'd1'],
+			[derived.auditD1DatabaseName, 'd1'],
+			[derived.oauthKvTitle, 'kv'],
+			[derived.bundleArtifactsKvTitle, 'kv'],
+			[derived.communityAssetsBucketName, 'r2'],
+			[derived.emailBlobsBucketName, 'r2'],
+			[derived.repoSessionBlobsBucketName, 'r2'],
+			[derived.webhookDispatchQueueName, 'queue'],
+			[derived.webhookDispatchDeadLetterQueueName, 'queue'],
+		]
+		expect(namesRejectedByGuard(accepted)).toEqual([])
+	}
+	expect(buildPreviewResourceNames('kody-pr-42')).toEqual({
+		d1DatabaseName: 'kody-pr-42-db',
+		auditD1DatabaseName: 'kody-pr-42-audit-db',
+		oauthKvTitle: 'kody-pr-42-oauth-kv',
+		bundleArtifactsKvTitle: 'kody-pr-42-bundle-artifacts-kv',
+		communityAssetsBucketName: 'kody-pr-42-community-assets',
+		emailBlobsBucketName: 'kody-pr-42-email-blobs',
+		repoSessionBlobsBucketName: 'kody-pr-42-repo-session-blobs',
+		webhookDispatchQueueName: 'kody-pr-42-webhook-dispatch',
+		webhookDispatchDeadLetterQueueName: 'kody-pr-42-webhook-dispatch-dlq',
+	})
+	expect(listPreviewWorkerNames('kody-pr-42')).not.toContain(
+		'kody-preview-jobs',
+	)
+})
+
+test('assertPreviewResourceName accepts names truncated to the 63-character limit', () => {
+	const workerName = `kody-branch-${'a1'.repeat(15)}-z`
+	expect(workerName).toHaveLength(44)
+	const derived = buildPreviewResourceNames(workerName)
+	expect(derived.bundleArtifactsKvTitle.length).toBeLessThanOrEqual(63)
+	expect(derived.bundleArtifactsKvTitle).not.toContain(workerName)
+	expect(derived.bundleArtifactsKvTitle).toMatch(
+		/^kody-branch-[a-z0-9]+-bundle-artifacts-kv$/,
+	)
+	expect(
+		namesRejectedByGuard(
+			Object.values(derived).map((name) => [name, 'kv'] as const),
+		),
+	).toEqual([])
+})
+
+test('cleanupPreviewResources refuses a production worker name before any wrangler or REST call', async () => {
+	const fetchMock = vi.fn<typeof fetch>()
+	vi.stubGlobal('fetch', fetchMock)
+	installCleanupEnv()
+	for (const workerName of ['kody', 'kody-platform', 'kody-runtime', '']) {
+		await expect(
+			cleanupPreviewResources({ workerName, dryRun: false }),
+		).rejects.toThrow('does not match the preview resource naming scheme')
+	}
+	expect(spawnSync).not.toHaveBeenCalled()
+	expect(fetchMock).not.toHaveBeenCalled()
+	vi.unstubAllGlobals()
+	vi.unstubAllEnvs()
+})
+
+test('cleanupPreviewResources refuses a production worker name even in dry-run', async () => {
+	await expect(
+		cleanupPreviewResources({ workerName: 'kody', dryRun: true }),
+	).rejects.toThrow('Refusing to delete worker "kody-runtime"')
+	expect(consoleError).not.toHaveBeenCalled()
+	expect(spawnSync).not.toHaveBeenCalled()
+})
+
+test('each guarded delete throws with the offending name and kind before reaching Cloudflare', async () => {
+	const fetchMock = vi.fn<typeof fetch>()
+	vi.stubGlobal('fetch', fetchMock)
+	installCleanupEnv()
 	const queueClient = {
 		accountId: 'test-account',
 		apiToken: 'test-token',
 		dryRun: false,
 	}
+	await expect(
+		deletePreviewWorkerScript({ name: 'kody-platform', dryRun: false }),
+	).rejects.toThrow('Refusing to delete worker "kody-platform"')
+	await expect(
+		deletePreviewD1Database({ name: 'kody', dryRun: false }),
+	).rejects.toThrow('Refusing to delete d1 "kody"')
+	await expect(
+		deletePreviewD1Database({ name: 'kody-audit', dryRun: false }),
+	).rejects.toThrow('Refusing to delete d1 "kody-audit"')
+	await expect(
+		deletePreviewKvNamespace({ title: 'kody-oauth', dryRun: false }),
+	).rejects.toThrow('Refusing to delete kv "kody-oauth"')
+	await expect(
+		deletePreviewR2Bucket({ name: 'kody-community-assets', dryRun: false }),
+	).rejects.toThrow('Refusing to delete r2 "kody-community-assets"')
+	await expect(
+		deletePreviewQueue({ ...queueClient, name: 'kody-webhook-dispatch' }),
+	).rejects.toThrow('Refusing to delete queue "kody-webhook-dispatch"')
+	await expect(
+		removePreviewQueueConsumers({
+			...queueClient,
+			name: 'kody-email-delivery',
+		}),
+	).rejects.toThrow('Refusing to delete queue "kody-email-delivery"')
+	expect(spawnSync).not.toHaveBeenCalled()
+	expect(fetchMock).not.toHaveBeenCalled()
+	vi.unstubAllGlobals()
+	vi.unstubAllEnvs()
+})
 
-	test('cleanupPreviewResources refuses a production worker name before any wrangler or REST call', async () => {
-		for (const workerName of ['kody', 'kody-platform', 'kody-runtime', '']) {
-			await expect(
-				cleanupPreviewResources({ workerName, dryRun: false }),
-			).rejects.toThrow('does not match the preview resource naming scheme')
+test('dry-run cleanup of a PR preview walks every resource without touching Cloudflare', async () => {
+	consoleError.mockImplementation(() => {})
+	const fetchMock = vi.fn<typeof fetch>()
+	vi.stubGlobal('fetch', fetchMock)
+	await cleanupPreviewResources({ workerName: 'kody-pr-42', dryRun: true })
+	const logged = consoleError.mock.calls.map(([message]) => String(message))
+	expect(logged).toEqual(
+		expect.arrayContaining([
+			'[dry-run] remove Queue consumers: kody-pr-42-webhook-dispatch',
+			'[dry-run] remove Queue consumers: kody-pr-42-webhook-dispatch-dlq',
+			'[dry-run] delete Worker script: kody-pr-42-runtime',
+			'[dry-run] delete Worker script: kody-pr-42-platform',
+			'[dry-run] delete Worker script: kody-pr-42',
+			'[dry-run] delete Worker script: kody-pr-42-jobs',
+			'[dry-run] delete Worker script: kody-pr-42-highlight',
+			'[dry-run] delete Worker script: kody-pr-42-mock-cloudflare',
+			'[dry-run] delete Queue: kody-pr-42-webhook-dispatch',
+			'[dry-run] delete Queue: kody-pr-42-webhook-dispatch-dlq',
+			'[dry-run] delete R2 bucket: kody-pr-42-community-assets',
+			'[dry-run] delete R2 bucket: kody-pr-42-email-blobs',
+			'[dry-run] delete R2 bucket: kody-pr-42-repo-session-blobs',
+			'[dry-run] delete KV namespace: kody-pr-42-bundle-artifacts-kv',
+			'[dry-run] delete KV namespace: kody-pr-42-oauth-kv',
+			'[dry-run] delete D1 database: kody-pr-42-audit-db',
+			'[dry-run] delete D1 database: kody-pr-42-db',
+		]),
+	)
+	expect(logged.some((line) => line.includes('kody-preview-jobs'))).toBe(false)
+	expect(spawnSync).not.toHaveBeenCalled()
+	expect(fetchMock).not.toHaveBeenCalled()
+	vi.unstubAllGlobals()
+})
+
+test('cleanup retries a wrangler 504 then continues later independent resources', async () => {
+	consoleError.mockImplementation(() => {})
+	installCleanupEnv()
+	const fetchMock = vi
+		.fn<typeof fetch>()
+		.mockImplementation(async () => emptyQueueListResponse())
+	vi.stubGlobal('fetch', fetchMock)
+	let highlightAttempts = 0
+	spawnSync.mockImplementation((_command, args) => {
+		const argv = args as Array<string>
+		if (argv[0] === 'delete' && argv[1] === 'kody-pr-2017-highlight') {
+			highlightAttempts += 1
+			if (highlightAttempts === 1) {
+				return {
+					status: 1,
+					stdout: '',
+					stderr: 'Gateway Timeout [code: 504]\n',
+				}
+			}
+			return { status: 0, stdout: '', stderr: '' }
 		}
-		expect(spawnSync).not.toHaveBeenCalled()
-		expect(fetchMock).not.toHaveBeenCalled()
+		return alreadyMissingWrangler(argv)
 	})
 
-	test('cleanupPreviewResources refuses a production worker name even in dry-run', async () => {
-		await expect(
-			cleanupPreviewResources({ workerName: 'kody', dryRun: true }),
-		).rejects.toThrow('Refusing to delete queue "kody-webhook-dispatch"')
-		expect(consoleError).not.toHaveBeenCalled()
+	await cleanupPreviewResources({
+		workerName: 'kody-pr-2017',
+		dryRun: false,
+		sleep: async () => {},
 	})
 
-	test('each guarded delete throws with the offending name and kind before reaching Cloudflare', async () => {
-		expect(() =>
-			deletePreviewWorkerScript({ name: 'kody-platform', dryRun: false }),
-		).toThrow('Refusing to delete worker "kody-platform"')
-		expect(() =>
-			deletePreviewD1Database({ name: 'kody', dryRun: false }),
-		).toThrow('Refusing to delete d1 "kody"')
-		expect(() =>
-			deletePreviewD1Database({ name: 'kody-audit', dryRun: false }),
-		).toThrow('Refusing to delete d1 "kody-audit"')
-		expect(() =>
-			deletePreviewKvNamespace({ title: 'kody-oauth', dryRun: false }),
-		).toThrow('Refusing to delete kv "kody-oauth"')
-		expect(() =>
-			deletePreviewR2Bucket({ name: 'kody-community-assets', dryRun: false }),
-		).toThrow('Refusing to delete r2 "kody-community-assets"')
-		await expect(
-			deletePreviewQueue({ ...queueClient, name: 'kody-webhook-dispatch' }),
-		).rejects.toThrow('Refusing to delete queue "kody-webhook-dispatch"')
-		await expect(
-			removePreviewQueueConsumers({
-				...queueClient,
-				name: 'kody-email-delivery',
-			}),
-		).rejects.toThrow('Refusing to delete queue "kody-email-delivery"')
-		expect(spawnSync).not.toHaveBeenCalled()
-		expect(fetchMock).not.toHaveBeenCalled()
+	expect(highlightAttempts).toBe(2)
+	const wranglerCalls = spawnSync.mock.calls.map((call) =>
+		wranglerArgList(call),
+	)
+	expect(wranglerCalls).toContain('delete kody-pr-2017-highlight --force')
+	expect(wranglerCalls).toContain('delete kody-pr-2017-mock-cloudflare --force')
+	expect(
+		wranglerCalls.some((call) => call.startsWith('r2 bucket delete ')),
+	).toBe(true)
+	expect(wranglerCalls.some((call) => call.includes('d1 list'))).toBe(true)
+	vi.unstubAllGlobals()
+	vi.unstubAllEnvs()
+})
+
+test('cleanup retries a wrangler 429 then succeeds', async () => {
+	consoleError.mockImplementation(() => {})
+	installCleanupEnv()
+	const fetchMock = vi
+		.fn<typeof fetch>()
+		.mockImplementation(async () => emptyQueueListResponse())
+	vi.stubGlobal('fetch', fetchMock)
+	let runtimeAttempts = 0
+	spawnSync.mockImplementation((_command, args) => {
+		const argv = args as Array<string>
+		if (argv[0] === 'delete' && argv[1] === 'kody-pr-8-runtime') {
+			runtimeAttempts += 1
+			if (runtimeAttempts === 1) {
+				return {
+					status: 1,
+					stdout: '',
+					stderr: 'Cloudflare API request failed (429): Rate limited\n',
+				}
+			}
+			return { status: 0, stdout: '', stderr: '' }
+		}
+		return alreadyMissingWrangler(argv)
 	})
 
-	test('dry-run cleanup of a PR preview walks every resource without touching Cloudflare', async () => {
-		consoleError.mockImplementation(() => {})
-		await cleanupPreviewResources({ workerName: 'kody-pr-42', dryRun: true })
-		const logged = consoleError.mock.calls.map(([message]) => String(message))
-		expect(logged).toEqual(
-			expect.arrayContaining([
-				'[dry-run] remove Queue consumers: kody-pr-42-webhook-dispatch',
-				'[dry-run] remove Queue consumers: kody-pr-42-webhook-dispatch-dlq',
-				'[dry-run] delete Worker script: kody-pr-42-runtime',
-				'[dry-run] delete Worker script: kody-pr-42-platform',
-				'[dry-run] delete Worker script: kody-pr-42',
-				'[dry-run] delete Worker script: kody-pr-42-jobs',
-				'[dry-run] delete Worker script: kody-pr-42-highlight',
-				'[dry-run] delete Worker script: kody-pr-42-mock-cloudflare',
-				'[dry-run] delete Queue: kody-pr-42-webhook-dispatch',
-				'[dry-run] delete Queue: kody-pr-42-webhook-dispatch-dlq',
-				'[dry-run] delete R2 bucket: kody-pr-42-community-assets',
-				'[dry-run] delete R2 bucket: kody-pr-42-email-blobs',
-				'[dry-run] delete R2 bucket: kody-pr-42-repo-session-blobs',
-				'[dry-run] delete KV namespace: kody-pr-42-bundle-artifacts-kv',
-				'[dry-run] delete KV namespace: kody-pr-42-oauth-kv',
-				'[dry-run] delete D1 database: kody-pr-42-audit-db',
-				'[dry-run] delete D1 database: kody-pr-42-db',
-			]),
-		)
-		expect(spawnSync).not.toHaveBeenCalled()
-		expect(fetchMock).not.toHaveBeenCalled()
+	await cleanupPreviewResources({
+		workerName: 'kody-pr-8',
+		dryRun: false,
+		sleep: async () => {},
 	})
+	expect(runtimeAttempts).toBe(2)
+	vi.unstubAllGlobals()
+	vi.unstubAllEnvs()
+})
+
+test('permanent queue auth failure still attempts later independent resources and aggregates leftovers', async () => {
+	consoleError.mockImplementation(() => {})
+	installCleanupEnv()
+	const fetchMock = vi.fn<typeof fetch>().mockImplementation(async (input) => {
+		const url = String(input)
+		if (url.includes('/r2/buckets/')) {
+			return emptyQueueListResponse()
+		}
+		return authForbiddenResponse()
+	})
+	vi.stubGlobal('fetch', fetchMock)
+	const attemptedWorkers: Array<string> = []
+	spawnSync.mockImplementation((_command, args) => {
+		const argv = args as Array<string>
+		if (argv[0] === 'delete') {
+			attemptedWorkers.push(argv[1] ?? '')
+			if (argv[1] === 'kody-pr-1999-highlight') {
+				return {
+					status: 1,
+					stdout: '',
+					stderr: 'Authentication error [code: 10000]\n',
+				}
+			}
+		}
+		return alreadyMissingWrangler(argv)
+	})
+
+	await expect(
+		cleanupPreviewResources({
+			workerName: 'kody-pr-1999',
+			dryRun: false,
+			sleep: async () => {},
+		}),
+	).rejects.toThrow(/Preview cleanup failed for 5 resource\(s\)/)
+	expect(
+		attemptedWorkers.filter((name) => name === 'kody-pr-1999-highlight'),
+	).toEqual(['kody-pr-1999-highlight'])
+
+	expect(attemptedWorkers).toEqual(
+		expect.arrayContaining([
+			'kody-pr-1999-runtime',
+			'kody-pr-1999-platform',
+			'kody-pr-1999',
+			'kody-pr-1999-jobs',
+			'kody-pr-1999-highlight',
+			'kody-pr-1999-mock-cloudflare',
+		]),
+	)
+	const wranglerCalls = spawnSync.mock.calls.map((call) =>
+		wranglerArgList(call),
+	)
+	expect(
+		wranglerCalls.some((call) => call.startsWith('r2 bucket delete ')),
+	).toBe(true)
+	expect(wranglerCalls).toContain('d1 list --json')
+	expect(wranglerCalls).toContain('kv namespace list')
+	expect(fetchMock).toHaveBeenCalled()
+	vi.unstubAllGlobals()
+	vi.unstubAllEnvs()
+})
+
+test('already-missing preview resources are successful and idempotent', async () => {
+	consoleError.mockImplementation(() => {})
+	installCleanupEnv()
+	const fetchMock = vi
+		.fn<typeof fetch>()
+		.mockImplementation(async () => emptyQueueListResponse())
+	vi.stubGlobal('fetch', fetchMock)
+	spawnSync.mockImplementation((_command, args) =>
+		alreadyMissingWrangler(args as Array<string>),
+	)
+
+	await cleanupPreviewResources({
+		workerName: 'kody-pr-42',
+		dryRun: false,
+		sleep: async () => {},
+	})
+	const logged = consoleError.mock.calls.map(([message]) => String(message))
+	expect(logged).toEqual(
+		expect.arrayContaining([
+			'Queue already deleted (no consumers to remove): kody-pr-42-webhook-dispatch',
+			'Worker script already deleted: kody-pr-42',
+			'Queue already deleted: kody-pr-42-webhook-dispatch',
+			'R2 bucket already deleted: kody-pr-42-community-assets',
+			'D1 database already deleted: kody-pr-42-db',
+			'KV namespace already deleted: kody-pr-42-oauth-kv',
+		]),
+	)
+	vi.unstubAllGlobals()
+	vi.unstubAllEnvs()
+})
+
+test('cleanup preserves queue-consumer then worker then queue order', async () => {
+	consoleError.mockImplementation(() => {})
+	installCleanupEnv()
+	const events: Array<string> = []
+	const fetchMock = vi.fn<typeof fetch>().mockImplementation(async (input) => {
+		const url = String(input)
+		if (url.includes('/queues?')) {
+			events.push(`list-queues`)
+			return emptyQueueListResponse()
+		}
+		return emptyQueueListResponse()
+	})
+	vi.stubGlobal('fetch', fetchMock)
+	spawnSync.mockImplementation((_command, args) => {
+		const argv = args as Array<string>
+		if (argv[0] === 'delete') {
+			events.push(`delete-worker ${argv[1]}`)
+		}
+		if (argv[0] === 'r2') {
+			events.push(`delete-r2 ${argv[3]}`)
+		}
+		if (argv[0] === 'd1' && argv[1] === 'list') {
+			events.push('list-d1')
+		}
+		return alreadyMissingWrangler(argv)
+	})
+
+	await cleanupPreviewResources({
+		workerName: 'kody-pr-9',
+		dryRun: false,
+		sleep: async () => {},
+	})
+
+	const firstWorker = events.indexOf('delete-worker kody-pr-9-runtime')
+	const firstQueueList = events.indexOf('list-queues')
+	const firstR2 = events.findIndex((event) => event.startsWith('delete-r2 '))
+	expect(firstQueueList).toBeGreaterThanOrEqual(0)
+	expect(firstWorker).toBeGreaterThan(firstQueueList)
+	expect(firstR2).toBeGreaterThan(firstWorker)
+	expect(events.filter((event) => event === 'list-queues').length).toBe(4)
+	vi.unstubAllGlobals()
+	vi.unstubAllEnvs()
+})
+
+test('non-empty preview R2 buckets are emptied then deleted', async () => {
+	consoleError.mockImplementation(() => {})
+	installCleanupEnv()
+	const deletedObjectUrls: Array<string> = []
+	const fetchMock = vi
+		.fn<typeof fetch>()
+		.mockImplementation(async (input, init) => {
+			const url = String(input)
+			if (url.includes('/r2/buckets/') && url.includes('/objects')) {
+				if ((init?.method ?? 'GET') === 'DELETE') {
+					deletedObjectUrls.push(url)
+					return Response.json({ success: true, result: null })
+				}
+				return Response.json({
+					success: true,
+					result: [{ key: 'seeded/blob.bin' }],
+					result_info: { total_pages: 1 },
+				})
+			}
+			if (url.includes('/queues')) {
+				return emptyQueueListResponse()
+			}
+			return emptyQueueListResponse()
+		})
+	vi.stubGlobal('fetch', fetchMock)
+	const bucketDeletes: Array<string> = []
+	spawnSync.mockImplementation((_command, args) => {
+		const argv = args as Array<string>
+		if (argv[0] === 'r2' && argv[1] === 'bucket' && argv[2] === 'delete') {
+			const bucket = argv[3] ?? ''
+			bucketDeletes.push(bucket)
+			if (
+				bucket === 'kody-pr-42-email-blobs' &&
+				bucketDeletes.filter((name) => name === bucket).length === 1
+			) {
+				return {
+					status: 1,
+					stdout: '',
+					stderr: 'The bucket you tried to delete is not empty\n',
+				}
+			}
+			return { status: 0, stdout: '', stderr: '' }
+		}
+		return alreadyMissingWrangler(argv)
+	})
+
+	await cleanupPreviewResources({
+		workerName: 'kody-pr-42',
+		dryRun: false,
+		sleep: async () => {},
+	})
+
+	expect(
+		bucketDeletes.filter((name) => name === 'kody-pr-42-email-blobs'),
+	).toEqual(['kody-pr-42-email-blobs', 'kody-pr-42-email-blobs'])
+	expect(
+		deletedObjectUrls.some((url) => url.includes('seeded%2Fblob.bin')),
+	).toBe(true)
+	expect(
+		consoleError.mock.calls.some(([message]) =>
+			String(message).includes(
+				'Deleted R2 object: kody-pr-42-email-blobs/seeded/blob.bin',
+			),
+		),
+	).toBe(true)
+	vi.unstubAllGlobals()
+	vi.unstubAllEnvs()
+})
+
+test('cleanup never targets kody-preview-jobs or production names', async () => {
+	consoleError.mockImplementation(() => {})
+	installCleanupEnv()
+	const fetchMock = vi
+		.fn<typeof fetch>()
+		.mockImplementation(async () => emptyQueueListResponse())
+	vi.stubGlobal('fetch', fetchMock)
+	spawnSync.mockImplementation((_command, args) =>
+		alreadyMissingWrangler(args as Array<string>),
+	)
+
+	await cleanupPreviewResources({
+		workerName: 'kody-pr-42',
+		dryRun: false,
+		sleep: async () => {},
+	})
+	const targeted = [
+		...spawnSync.mock.calls.map((call) => wranglerArgList(call)),
+		...fetchMock.mock.calls.map(([input]) => String(input)),
+	].join('\n')
+	expect(targeted).not.toContain('kody-preview-jobs')
+	expect(targeted).not.toContain('kody-jobs')
+	expect(targeted).not.toMatch(/(?<!kody-pr-42-)kody-production/)
+	vi.unstubAllGlobals()
+	vi.unstubAllEnvs()
 })

--- a/tools/ci/preview-resources.ts
+++ b/tools/ci/preview-resources.ts
@@ -3,6 +3,7 @@ import { readFile, writeFile } from 'node:fs/promises'
 import path from 'node:path'
 
 import { defaultProductionEntryPath } from '../check-origin-production-exports.ts'
+import { isExecutedDirectly } from '../node-runtime.ts'
 import {
 	inspectOriginProductionScriptState,
 	planOriginPreviewDeploy,
@@ -11,6 +12,7 @@ import {
 	type OriginProductionScriptState,
 } from './origin-production-deploy-state.ts'
 import {
+	CloudflareResourceError,
 	deleteCloudflareQueue,
 	deleteR2Bucket,
 	deleteWorkerScript,
@@ -23,10 +25,10 @@ import {
 	parseJsonc,
 	removeCloudflareQueueConsumers,
 	runWrangler,
+	runWranglerWithRetry,
 	truncateWithSuffix,
 	writeGeneratedWranglerConfig,
 } from './resource-utils.ts'
-import { isExecutedDirectly } from '../node-runtime.ts'
 
 type Command = 'ensure' | 'cleanup'
 
@@ -42,7 +44,8 @@ export type PreviewResourceKind = 'worker' | 'd1' | 'kv' | 'r2' | 'queue'
  * (`truncateWithSuffix` may shorten the base but keeps this shape). Production
  * names (`kody`, `kody-platform`, `kody-runtime`, `kody-jobs`, `kody-audit`,
  * `kody-oauth`, `kody-webhook-dispatch`, ...) and the shared preview-env names
- * (`kody-preview*`) never carry a `-pr-<number>` or `-branch-<slug>` segment.
+ * (`kody-preview*`, including `kody-preview-jobs`) never carry a `-pr-<number>`
+ * or `-branch-<slug>` segment.
  */
 export const previewResourceNamePattern =
 	/^kody-(?:pr-\d+|branch-[a-z0-9]+)(?:-[a-z0-9]+)*$/
@@ -63,6 +66,9 @@ export function assertPreviewResourceName(
 		)
 	}
 }
+
+/** Default wall-clock budget for Cloudflare cleanup inside the 4-minute job. */
+export const previewCleanupBudgetMsDefault = 150_000
 
 type CliOptions = {
 	workerName: string
@@ -239,12 +245,20 @@ function ensureD1Database({
 	return { name, id: created.uuid }
 }
 
-export function deletePreviewD1Database({
+export async function deletePreviewD1Database({
 	name,
 	dryRun,
+	sleep,
+	maxAttempts,
+	deadlineMs,
+	now,
 }: {
 	name: string
 	dryRun: boolean
+	sleep?: (ms: number) => Promise<void>
+	maxAttempts?: number
+	deadlineMs?: number
+	now?: () => number
 }) {
 	assertPreviewResourceName(name, 'd1')
 	if (dryRun) {
@@ -258,11 +272,18 @@ export function deletePreviewD1Database({
 		return
 	}
 
-	const result = runWrangler(['d1', 'delete', name, '--skip-confirmation'], {
-		quiet: true,
-	})
+	const result = await runWranglerWithRetry(
+		['d1', 'delete', name, '--skip-confirmation'],
+		{ quiet: true, sleep, maxAttempts, deadlineMs, now },
+	)
 	if (result.status !== 0) {
-		fail(`Failed to delete D1 database: ${name}`)
+		const output =
+			`${result.stdout}${result.stderr} ${result.errorMessage}`.trim()
+		throw new CloudflareResourceError(
+			'd1',
+			name,
+			`Failed to delete D1 database: ${name}${output ? `: ${output}` : ''}`,
+		)
 	}
 	console.error(`Deleted D1 database: ${name}`)
 }
@@ -302,12 +323,20 @@ function ensureKvNamespace({
 	return { title, id: created.id }
 }
 
-export function deletePreviewKvNamespace({
+export async function deletePreviewKvNamespace({
 	title,
 	dryRun,
+	sleep,
+	maxAttempts,
+	deadlineMs,
+	now,
 }: {
 	title: string
 	dryRun: boolean
+	sleep?: (ms: number) => Promise<void>
+	maxAttempts?: number
+	deadlineMs?: number
+	now?: () => number
 }) {
 	assertPreviewResourceName(title, 'kv')
 	if (dryRun) {
@@ -321,7 +350,7 @@ export function deletePreviewKvNamespace({
 		return
 	}
 
-	const result = runWrangler(
+	const result = await runWranglerWithRetry(
 		[
 			'kv',
 			'namespace',
@@ -330,34 +359,80 @@ export function deletePreviewKvNamespace({
 			existing.id,
 			'--skip-confirmation',
 		],
-		{ quiet: true },
+		{ quiet: true, sleep, maxAttempts, deadlineMs, now },
 	)
 	if (result.status !== 0) {
-		fail(`Failed to delete KV namespace: ${title}`)
+		const output =
+			`${result.stdout}${result.stderr} ${result.errorMessage}`.trim()
+		throw new CloudflareResourceError(
+			'kv',
+			title,
+			`Failed to delete KV namespace: ${title}${output ? `: ${output}` : ''}`,
+		)
 	}
 	console.error(`Deleted KV namespace: ${title} (${existing.id})`)
 }
 
-export function deletePreviewWorkerScript({
+export async function deletePreviewWorkerScript({
 	name,
 	dryRun,
+	sleep,
+	maxAttempts,
+	deadlineMs,
+	now,
 }: {
 	name: string
 	dryRun: boolean
+	sleep?: (ms: number) => Promise<void>
+	maxAttempts?: number
+	deadlineMs?: number
+	now?: () => number
 }) {
 	assertPreviewResourceName(name, 'worker')
-	deleteWorkerScript({ name, dryRun })
+	await deleteWorkerScript({
+		name,
+		dryRun,
+		sleep,
+		maxAttempts,
+		deadlineMs,
+		now,
+	})
 }
 
-export function deletePreviewR2Bucket({
+export async function deletePreviewR2Bucket({
 	name,
 	dryRun,
+	accountId,
+	apiToken,
+	fetcher,
+	sleep,
+	maxAttempts,
+	deadlineMs,
+	now,
 }: {
 	name: string
 	dryRun: boolean
+	accountId?: string
+	apiToken?: string
+	fetcher?: typeof fetch
+	sleep?: (ms: number) => Promise<void>
+	maxAttempts?: number
+	deadlineMs?: number
+	now?: () => number
 }) {
 	assertPreviewResourceName(name, 'r2')
-	deleteR2Bucket({ name, dryRun })
+	await deleteR2Bucket({
+		name,
+		dryRun,
+		emptyIfNonEmpty: true,
+		accountId,
+		apiToken,
+		fetcher,
+		sleep,
+		maxAttempts,
+		deadlineMs,
+		now,
+	})
 }
 
 type PreviewQueueInput = Parameters<typeof deleteCloudflareQueue>[0]
@@ -557,23 +632,48 @@ function listMockServerNames() {
 	})
 }
 
-function deletePreviewWorkers(workerName: string, dryRun: boolean) {
-	// Runtime and platform bind each other's Durable Object classes, so
-	// delete those scripts before the origin worker.
-	deletePreviewWorkerScript({ name: `${workerName}-runtime`, dryRun })
-	deletePreviewWorkerScript({ name: `${workerName}-platform`, dryRun })
-	deletePreviewWorkerScript({ name: workerName, dryRun })
-	deletePreviewWorkerScript({ name: `${workerName}-jobs`, dryRun })
-	deletePreviewWorkerScript({ name: `${workerName}-highlight`, dryRun })
-	for (const service of listMockServerNames()) {
-		deletePreviewWorkerScript({
-			name: `${workerName}-mock-${service}`,
-			dryRun,
-		})
-	}
+export function listPreviewWorkerNames(workerName: string) {
+	return [
+		`${workerName}-runtime`,
+		`${workerName}-platform`,
+		workerName,
+		`${workerName}-jobs`,
+		`${workerName}-highlight`,
+		...listMockServerNames().map((service) => `${workerName}-mock-${service}`),
+	]
 }
 
-export type PreviewCleanupOptions = Pick<CliOptions, 'workerName' | 'dryRun'>
+export type PreviewCleanupFailure = {
+	resource: string
+	message: string
+}
+
+export type PreviewCleanupOptions = {
+	workerName: string
+	dryRun: boolean
+	sleep?: (ms: number) => Promise<void>
+	deadlineMs?: number
+	now?: () => number
+	fetcher?: typeof fetch
+	accountId?: string
+	apiToken?: string
+}
+
+export function formatPreviewCleanupFailure(
+	workerName: string,
+	failures: ReadonlyArray<PreviewCleanupFailure>,
+) {
+	const lines = failures.map(
+		(failure) => `  - ${failure.resource}: ${failure.message}`,
+	)
+	return [
+		`Preview cleanup failed for ${String(failures.length)} resource(s) of ${workerName}. Already-missing resources were treated as success. Re-run:`,
+		`  node tools/ci/preview-resources.ts cleanup --worker-name ${workerName}`,
+		'or the preview workflow_dispatch cleanup action targeting this PR.',
+		'Failed resources:',
+		...lines,
+	].join('\n')
+}
 
 export async function cleanupPreviewResources(options: PreviewCleanupOptions) {
 	const {
@@ -587,58 +687,137 @@ export async function cleanupPreviewResources(options: PreviewCleanupOptions) {
 		webhookDispatchQueueName,
 		webhookDispatchDeadLetterQueueName,
 	} = buildPreviewResourceNames(options.workerName)
-	const accountId = process.env.CLOUDFLARE_ACCOUNT_ID?.trim()
-	const apiToken = process.env.CLOUDFLARE_API_TOKEN?.trim()
+	const workerNames = listPreviewWorkerNames(options.workerName)
+	for (const [name, kind] of [
+		...workerNames.map((name) => [name, 'worker'] as const),
+		[d1DatabaseName, 'd1'] as const,
+		[auditD1DatabaseName, 'd1'] as const,
+		[oauthKvTitle, 'kv'] as const,
+		[bundleArtifactsKvTitle, 'kv'] as const,
+		[communityAssetsBucketName, 'r2'] as const,
+		[emailBlobsBucketName, 'r2'] as const,
+		[repoSessionBlobsBucketName, 'r2'] as const,
+		[webhookDispatchQueueName, 'queue'] as const,
+		[webhookDispatchDeadLetterQueueName, 'queue'] as const,
+	]) {
+		assertPreviewResourceName(name, kind)
+	}
+
+	const accountId =
+		options.accountId ?? process.env.CLOUDFLARE_ACCOUNT_ID?.trim()
+	const apiToken = options.apiToken ?? process.env.CLOUDFLARE_API_TOKEN?.trim()
 	if ((!accountId || !apiToken) && !options.dryRun) {
 		fail(
 			'Missing CLOUDFLARE_ACCOUNT_ID or CLOUDFLARE_API_TOKEN for Queue cleanup.',
 		)
 	}
+	const now = options.now ?? Date.now
+	const deadlineMs = options.deadlineMs ?? now() + previewCleanupBudgetMsDefault
+	const retry = {
+		sleep: options.sleep,
+		deadlineMs,
+		now,
+	}
 	const queueClient = {
 		accountId: accountId ?? 'dry-run-account',
 		apiToken: apiToken ?? 'dry-run-token',
 		dryRun: options.dryRun,
+		fetcher: options.fetcher,
+		...retry,
 	}
+	const failures: Array<PreviewCleanupFailure> = []
+
+	async function attempt(resource: string, operation: () => Promise<void>) {
+		try {
+			await operation()
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error)
+			console.error(`Cleanup failed for ${resource}: ${message}`)
+			failures.push({ resource, message })
+		}
+	}
+
 	// Order matters, both directions: a Worker cannot be deleted while it is
 	// registered as a queue consumer (code 10064), and a queue cannot be
 	// deleted while a Worker still binds it as a producer (400 "still
 	// referenced by a binding in a Worker"). So: consumers → Workers → queues.
-	await removePreviewQueueConsumers({
-		...queueClient,
-		name: webhookDispatchQueueName,
+	// Independent leftovers (R2 / KV / D1) run after that chain so a Worker
+	// 504 cannot strand them. Permanent failures are recorded and the rest
+	// of the sweep continues.
+	await attempt(`queue consumers ${webhookDispatchQueueName}`, async () => {
+		await removePreviewQueueConsumers({
+			...queueClient,
+			name: webhookDispatchQueueName,
+		})
 	})
-	await removePreviewQueueConsumers({
-		...queueClient,
-		name: webhookDispatchDeadLetterQueueName,
+	await attempt(
+		`queue consumers ${webhookDispatchDeadLetterQueueName}`,
+		async () => {
+			await removePreviewQueueConsumers({
+				...queueClient,
+				name: webhookDispatchDeadLetterQueueName,
+			})
+		},
+	)
+	for (const workerName of workerNames) {
+		await attempt(`worker ${workerName}`, async () => {
+			await deletePreviewWorkerScript({
+				name: workerName,
+				dryRun: options.dryRun,
+				...retry,
+			})
+		})
+	}
+	await attempt(`queue ${webhookDispatchQueueName}`, async () => {
+		await deletePreviewQueue({
+			...queueClient,
+			name: webhookDispatchQueueName,
+		})
 	})
-	deletePreviewWorkers(options.workerName, options.dryRun)
-	await deletePreviewQueue({
-		...queueClient,
-		name: webhookDispatchQueueName,
+	await attempt(`queue ${webhookDispatchDeadLetterQueueName}`, async () => {
+		await deletePreviewQueue({
+			...queueClient,
+			name: webhookDispatchDeadLetterQueueName,
+		})
 	})
-	await deletePreviewQueue({
-		...queueClient,
-		name: webhookDispatchDeadLetterQueueName,
-	})
-	deletePreviewR2Bucket({
-		name: communityAssetsBucketName,
-		dryRun: options.dryRun,
-	})
-	deletePreviewR2Bucket({ name: emailBlobsBucketName, dryRun: options.dryRun })
-	deletePreviewR2Bucket({
-		name: repoSessionBlobsBucketName,
-		dryRun: options.dryRun,
-	})
-	deletePreviewKvNamespace({
-		title: bundleArtifactsKvTitle,
-		dryRun: options.dryRun,
-	})
-	deletePreviewKvNamespace({ title: oauthKvTitle, dryRun: options.dryRun })
-	deletePreviewD1Database({
-		name: auditD1DatabaseName,
-		dryRun: options.dryRun,
-	})
-	deletePreviewD1Database({ name: d1DatabaseName, dryRun: options.dryRun })
+	for (const name of [
+		communityAssetsBucketName,
+		emailBlobsBucketName,
+		repoSessionBlobsBucketName,
+	]) {
+		await attempt(`r2 ${name}`, async () => {
+			await deletePreviewR2Bucket({
+				name,
+				dryRun: options.dryRun,
+				accountId,
+				apiToken,
+				fetcher: options.fetcher,
+				...retry,
+			})
+		})
+	}
+	for (const title of [bundleArtifactsKvTitle, oauthKvTitle]) {
+		await attempt(`kv ${title}`, async () => {
+			await deletePreviewKvNamespace({
+				title,
+				dryRun: options.dryRun,
+				...retry,
+			})
+		})
+	}
+	for (const name of [auditD1DatabaseName, d1DatabaseName]) {
+		await attempt(`d1 ${name}`, async () => {
+			await deletePreviewD1Database({
+				name,
+				dryRun: options.dryRun,
+				...retry,
+			})
+		})
+	}
+
+	if (failures.length > 0) {
+		throw new Error(formatPreviewCleanupFailure(options.workerName, failures))
+	}
 }
 
 async function main() {
@@ -659,5 +838,9 @@ async function main() {
 }
 
 if (isExecutedDirectly(import.meta.url)) {
-	await main()
+	try {
+		await main()
+	} catch (error) {
+		fail(error instanceof Error ? error.message : String(error))
+	}
 }

--- a/tools/ci/preview-resources.ts
+++ b/tools/ci/preview-resources.ts
@@ -19,6 +19,7 @@ import {
 	ensureCloudflareQueue,
 	ensureR2Bucket,
 	fail,
+	isWranglerNotFoundOutput,
 	listD1Databases,
 	listCloudflareQueues,
 	listKvNamespaces,
@@ -279,6 +280,10 @@ export async function deletePreviewD1Database({
 	if (result.status !== 0) {
 		const output =
 			`${result.stdout}${result.stderr} ${result.errorMessage}`.trim()
+		if (isWranglerNotFoundOutput(output)) {
+			console.error(`D1 database already deleted: ${name}`)
+			return
+		}
 		throw new CloudflareResourceError(
 			'd1',
 			name,
@@ -364,6 +369,10 @@ export async function deletePreviewKvNamespace({
 	if (result.status !== 0) {
 		const output =
 			`${result.stdout}${result.stderr} ${result.errorMessage}`.trim()
+		if (isWranglerNotFoundOutput(output)) {
+			console.error(`KV namespace already deleted: ${title}`)
+			return
+		}
 		throw new CloudflareResourceError(
 			'kv',
 			title,

--- a/tools/ci/resource-utils.node.test.ts
+++ b/tools/ci/resource-utils.node.test.ts
@@ -14,8 +14,11 @@ import {
 	ensureEmailSendingEventSubscription,
 	ensurePackageAppDnsRecords,
 	ensureR2BucketLifecycle,
+	isPermanentCloudflareAuthFailure,
 	isR2BucketAlreadyExistsOutput,
+	isR2BucketNotEmptyOutput,
 	isRetryableCloudflareApiError,
+	isRetryableCloudflareFailure,
 	isWranglerNotFoundOutput,
 	parseJsonc,
 	removeCloudflareQueueConsumers,
@@ -897,6 +900,89 @@ test('Cloudflare API requests retry gateway HTML/text blips then succeed', async
 			),
 		),
 	).toBe(false)
+	expect(
+		isRetryableCloudflareApiError(
+			new Error('Cloudflare API request failed (429): Rate limited'),
+		),
+	).toBe(true)
+	expect(isRetryableCloudflareFailure('Gateway Timeout [code: 504]')).toBe(true)
+	expect(
+		isRetryableCloudflareApiError(
+			new Error('Cloudflare API request failed (403): Authentication error'),
+		),
+	).toBe(false)
+	expect(
+		isRetryableCloudflareApiError(
+			new Error('Cloudflare API request failed (401): unauthorized'),
+		),
+	).toBe(false)
+	expect(
+		isPermanentCloudflareAuthFailure('Authentication error [code: 10000]'),
+	).toBe(true)
+	expect(
+		isR2BucketNotEmptyOutput('The bucket you tried to delete is not empty'),
+	).toBe(true)
+	expect(isR2BucketNotEmptyOutput('Authentication error [code: 10000]')).toBe(
+		false,
+	)
+})
+
+test('Cloudflare API requests retry a 429 then succeed and do not retry 403', async () => {
+	consoleError.mockImplementation(() => {})
+	const rateLimitedThenOk = vi
+		.fn<typeof fetch>()
+		.mockResolvedValueOnce(
+			Response.json(
+				{
+					success: false,
+					errors: [{ code: 10000, message: 'Rate limited' }],
+				},
+				{ status: 429 },
+			),
+		)
+		.mockResolvedValueOnce(
+			Response.json({
+				success: true,
+				result: {
+					queue_id: 'queue-429',
+					queue_name: 'kody-pr-1-webhook-dispatch',
+				},
+			}),
+		)
+	const payload = await cloudflareApiRequest({
+		accountId: 'account-1',
+		apiToken: 'token-1',
+		pathname: '/queues',
+		method: 'POST',
+		body: { queue_name: 'kody-pr-1-webhook-dispatch' },
+		fetcher: rateLimitedThenOk,
+		sleep: async () => {},
+	})
+	expect(payload.result).toEqual({
+		queue_id: 'queue-429',
+		queue_name: 'kody-pr-1-webhook-dispatch',
+	})
+	expect(rateLimitedThenOk).toHaveBeenCalledTimes(2)
+
+	const forbidden = vi.fn<typeof fetch>().mockResolvedValue(
+		Response.json(
+			{
+				success: false,
+				errors: [{ code: 10000, message: 'Authentication error' }],
+			},
+			{ status: 403 },
+		),
+	)
+	await expect(
+		cloudflareApiRequest({
+			accountId: 'account-1',
+			apiToken: 'token-1',
+			pathname: '/queues?page=1&per_page=100',
+			fetcher: forbidden,
+			sleep: async () => {},
+		}),
+	).rejects.toThrow('Cloudflare API request failed (403): Authentication error')
+	expect(forbidden).toHaveBeenCalledTimes(1)
 })
 
 test('ensureArtifactsAccountEventSubscription creates account-level lifecycle subscription', async () => {

--- a/tools/ci/resource-utils.node.test.ts
+++ b/tools/ci/resource-utils.node.test.ts
@@ -9,6 +9,8 @@ import {
 	cloudflareApiRequest,
 	deleteCloudflareQueue,
 	emailSendingEventTypes,
+	emptyR2Bucket,
+	encodeR2ObjectKey,
 	ensureArtifactsAccountEventSubscription,
 	ensureCloudflareQueue,
 	ensureEmailSendingEventSubscription,
@@ -925,6 +927,47 @@ test('Cloudflare API requests retry gateway HTML/text blips then succeed', async
 	expect(isR2BucketNotEmptyOutput('Authentication error [code: 10000]')).toBe(
 		false,
 	)
+})
+
+test('emptyR2Bucket deletes nested keys with literal slashes', async () => {
+	consoleError.mockImplementation(() => {})
+	const deletedUrls: Array<string> = []
+	const fetcher = vi
+		.fn<typeof fetch>()
+		.mockImplementation(async (input, init) => {
+			const url = String(input)
+			if ((init?.method ?? 'GET') === 'DELETE') {
+				deletedUrls.push(url)
+				return Response.json({ success: true, result: { key: 'ok' } })
+			}
+			return Response.json({
+				success: true,
+				result: [{ key: 'seeded/blob.bin' }, { key: 'path/to/weird name.bin' }],
+				result_info: { total_pages: 1 },
+			})
+		})
+
+	await emptyR2Bucket({
+		accountId: 'test-account',
+		apiToken: 'test-token',
+		name: 'kody-pr-42-email-blobs',
+		fetcher,
+	})
+
+	expect(deletedUrls).toEqual([
+		expect.stringContaining(
+			'/r2/buckets/kody-pr-42-email-blobs/objects/seeded/blob.bin',
+		),
+		expect.stringContaining(
+			'/r2/buckets/kody-pr-42-email-blobs/objects/path/to/weird%20name.bin',
+		),
+	])
+	expect(deletedUrls.some((url) => url.includes('%2F'))).toBe(false)
+	expect(encodeR2ObjectKey('seeded/blob.bin')).toBe('seeded/blob.bin')
+	expect(encodeR2ObjectKey('path/to/weird name.bin')).toBe(
+		'path/to/weird%20name.bin',
+	)
+	expect(encodeR2ObjectKey('a//b')).toBe('a//b')
 })
 
 test('Cloudflare API requests retry a 429 then succeed and do not retry 403', async () => {

--- a/tools/ci/resource-utils.ts
+++ b/tools/ci/resource-utils.ts
@@ -455,6 +455,16 @@ function readR2ObjectKey(entry: R2ObjectListEntry) {
 	return null
 }
 
+/**
+ * Cloudflare R2 Delete Object requires slashes in the key to stay literal.
+ * `encodeURIComponent` on the whole key turns `/` into `%2F` and nested
+ * preview objects then fail to delete, leaving a non-empty bucket leftover.
+ * Other reserved characters are still percent-encoded per segment.
+ */
+export function encodeR2ObjectKey(key: string) {
+	return key.split('/').map(encodeURIComponent).join('/')
+}
+
 export async function listR2BucketObjects(input: {
 	accountId: string
 	apiToken: string
@@ -536,7 +546,7 @@ export async function emptyR2Bucket(input: {
 			deadlineMs: input.deadlineMs,
 			now: input.now,
 			maxAttempts: input.maxAttempts,
-			pathname: `/r2/buckets/${encodeURIComponent(input.name)}/objects/${encodeURIComponent(key)}`,
+			pathname: `/r2/buckets/${encodeURIComponent(input.name)}/objects/${encodeR2ObjectKey(key)}`,
 			method: 'DELETE',
 		})
 		console.error(`Deleted R2 object: ${input.name}/${key}`)

--- a/tools/ci/resource-utils.ts
+++ b/tools/ci/resource-utils.ts
@@ -47,21 +47,58 @@ function sleep(ms: number) {
 	return new Promise<void>((resolve) => setTimeout(resolve, ms))
 }
 
-export function isRetryableCloudflareApiError(error: unknown) {
-	if (!(error instanceof Error)) return false
-	if (error.name === 'AbortError') return true
-	const message = error.message
+export class CloudflareResourceError extends Error {
+	readonly kind: string
+	readonly resource: string
+
+	constructor(
+		kind: string,
+		resource: string,
+		message: string,
+		options?: { cause?: unknown },
+	) {
+		super(message, options)
+		this.name = 'CloudflareResourceError'
+		this.kind = kind
+		this.resource = resource
+	}
+}
+
+/**
+ * Permanent Cloudflare auth failures must not be retried. 401/403 and
+ * wrangler "Authentication error [code: 10000]" stay in this set so a bad
+ * token cannot burn the preview cleanup budget.
+ */
+export function isPermanentCloudflareAuthFailure(message: string) {
+	return (
+		/Cloudflare API request failed \(401\)/.test(message) ||
+		/Cloudflare API request failed \(403\)/.test(message) ||
+		/authentication error/i.test(message) ||
+		/\[code:\s*10000\]/.test(message)
+	)
+}
+
+export function isRetryableCloudflareFailure(message: string) {
+	if (isPermanentCloudflareAuthFailure(message)) return false
 	return (
 		(message.includes('Malformed Cloudflare response') &&
 			!/Malformed Cloudflare response \(200\).*--/u.test(message)) ||
 		message.includes('upstream connect error') ||
 		message.includes('Cloudflare API request failed (429)') ||
 		/Cloudflare API request failed \(5\d\d\)/.test(message) ||
+		/504 Gateway Timeout/i.test(message) ||
+		/Gateway Timeout/i.test(message) ||
 		message.includes('fetch failed') ||
 		message.includes('ECONNRESET') ||
 		message.includes('ETIMEDOUT') ||
 		message.includes('socket hang up')
 	)
+}
+
+export function isRetryableCloudflareApiError(error: unknown) {
+	if (!(error instanceof Error)) return false
+	if (error.name === 'AbortError') return true
+	return isRetryableCloudflareFailure(error.message)
 }
 
 type CloudflareEventSubscription = {
@@ -104,7 +141,7 @@ function renderArg(value: string) {
 
 export function runWrangler(
 	args: Array<string>,
-	options?: { input?: string; quiet?: boolean },
+	options?: { input?: string; quiet?: boolean; timeoutMs?: number },
 ) {
 	const wranglerBin = resolveLocalBinary('wrangler')
 	const result = spawnSync(wranglerBin, args, {
@@ -112,11 +149,18 @@ export function runWrangler(
 		stdio: 'pipe',
 		input: options?.input,
 		env: process.env,
+		timeout: options?.timeoutMs,
+		killSignal: 'SIGTERM',
 	})
 
 	const status = result.status ?? 1
 	const stdout = result.stdout ?? ''
 	const stderr = result.stderr ?? ''
+	const timeoutMessage =
+		result.error?.message ??
+		(result.signal === 'SIGTERM' && options?.timeoutMs
+			? `wrangler timed out after ${String(options.timeoutMs)}ms`
+			: '')
 
 	if (!options?.quiet) {
 		const rendered = args.map(renderArg).join(' ')
@@ -132,9 +176,64 @@ export function runWrangler(
 		if (output) {
 			console.error(output)
 		}
+		if (timeoutMessage && !output.includes(timeoutMessage)) {
+			console.error(timeoutMessage)
+		}
 	}
 
-	return { status, stdout, stderr }
+	return { status, stdout, stderr, errorMessage: timeoutMessage }
+}
+
+type WranglerRetryInput = {
+	input?: string
+	quiet?: boolean
+	timeoutMs?: number
+	sleep?: (ms: number) => Promise<void>
+	maxAttempts?: number
+	deadlineMs?: number
+	now?: () => number
+}
+
+export async function runWranglerWithRetry(
+	args: Array<string>,
+	options?: WranglerRetryInput,
+) {
+	const maxAttempts = options?.maxAttempts ?? cloudflareApiRetryMaxAttempts
+	const wait = options?.sleep ?? sleep
+	const now = options?.now ?? Date.now
+	const timeoutMs = options?.timeoutMs ?? 30_000
+	let lastResult = runWrangler(args, {
+		input: options?.input,
+		quiet: options?.quiet,
+		timeoutMs,
+	})
+	for (let attempt = 1; attempt < maxAttempts; attempt += 1) {
+		if (lastResult.status === 0) return lastResult
+		const output =
+			`${lastResult.stdout}${lastResult.stderr} ${lastResult.errorMessage}`.trim()
+		const timeLeft =
+			options?.deadlineMs === undefined
+				? Number.POSITIVE_INFINITY
+				: options.deadlineMs - now()
+		if (
+			!isRetryableCloudflareFailure(output) ||
+			timeLeft < cloudflareApiRetryBaseDelayMs
+		) {
+			return lastResult
+		}
+		console.error(
+			`Retrying wrangler ${args.map(renderArg).join(' ')} (attempt ${attempt + 1}/${maxAttempts})`,
+		)
+		await wait(
+			Math.min(cloudflareApiRetryBaseDelayMs * 2 ** (attempt - 1), timeLeft),
+		)
+		lastResult = runWrangler(args, {
+			input: options?.input,
+			quiet: options?.quiet,
+			timeoutMs,
+		})
+	}
+	return lastResult
 }
 
 export function truncateWithSuffix(
@@ -153,24 +252,28 @@ export function truncateWithSuffix(
 export function listD1Databases(): Array<D1DatabaseListEntry> {
 	const result = runWrangler(['d1', 'list', '--json'], { quiet: true })
 	if (result.status !== 0) {
-		fail('Failed to list D1 databases (wrangler d1 list --json).')
+		throw new Error('Failed to list D1 databases (wrangler d1 list --json).')
 	}
 	try {
 		return JSON.parse(result.stdout) as Array<D1DatabaseListEntry>
 	} catch {
-		fail('Could not parse JSON output from wrangler d1 list --json.')
+		throw new Error('Could not parse JSON output from wrangler d1 list --json.')
 	}
 }
 
 export function listKvNamespaces(): Array<KvNamespaceListEntry> {
 	const result = runWrangler(['kv', 'namespace', 'list'], { quiet: true })
 	if (result.status !== 0) {
-		fail('Failed to list KV namespaces (wrangler kv namespace list).')
+		throw new Error(
+			'Failed to list KV namespaces (wrangler kv namespace list).',
+		)
 	}
 	try {
 		return JSON.parse(result.stdout) as Array<KvNamespaceListEntry>
 	} catch {
-		fail('Failed to parse JSON output from wrangler kv namespace list.')
+		throw new Error(
+			'Failed to parse JSON output from wrangler kv namespace list.',
+		)
 	}
 }
 
@@ -183,12 +286,20 @@ export function isWranglerNotFoundOutput(output: string) {
 	)
 }
 
-export function deleteWorkerScript({
+export async function deleteWorkerScript({
 	name,
 	dryRun,
+	sleep: wait,
+	maxAttempts,
+	deadlineMs,
+	now,
 }: {
 	name: string
 	dryRun: boolean
+	sleep?: (ms: number) => Promise<void>
+	maxAttempts?: number
+	deadlineMs?: number
+	now?: () => number
 }) {
 	if (dryRun) {
 		console.error(`[dry-run] delete Worker script: ${name}`)
@@ -198,8 +309,15 @@ export function deleteWorkerScript({
 	// Delete by script name only. Passing --config/--env makes Wrangler resolve
 	// bindings from wrangler.jsonc (including KV namespaces without ids) and
 	// can fail even when the token can delete the Worker and preview resources.
-	const result = runWrangler(['delete', name, '--force'], { quiet: true })
-	const output = `${result.stdout}${result.stderr}`.trim()
+	const result = await runWranglerWithRetry(['delete', name, '--force'], {
+		quiet: true,
+		sleep: wait,
+		maxAttempts,
+		deadlineMs,
+		now,
+	})
+	const output =
+		`${result.stdout}${result.stderr} ${result.errorMessage}`.trim()
 
 	if (result.status === 0) {
 		if (output) {
@@ -214,10 +332,11 @@ export function deleteWorkerScript({
 		return
 	}
 
-	if (output) {
-		console.error(output)
-	}
-	fail(`Failed to delete Worker script: ${name}`)
+	throw new CloudflareResourceError(
+		'worker',
+		name,
+		`Failed to delete Worker script: ${name}${output ? `: ${output}` : ''}`,
+	)
 }
 
 /**
@@ -315,35 +434,216 @@ export function ensureR2BucketLifecycle({
 	}
 }
 
-export function deleteR2Bucket({
+export function isR2BucketNotEmptyOutput(output: string) {
+	const lower = output.toLowerCase()
+	return (
+		lower.includes('not empty') ||
+		lower.includes('must be empty') ||
+		output.includes('[code: 10008]') ||
+		output.includes('[code: 10014]')
+	)
+}
+
+type R2ObjectListEntry = {
+	key?: string
+	name?: string
+}
+
+function readR2ObjectKey(entry: R2ObjectListEntry) {
+	if (typeof entry.key === 'string' && entry.key.length > 0) return entry.key
+	if (typeof entry.name === 'string' && entry.name.length > 0) return entry.name
+	return null
+}
+
+export async function listR2BucketObjects(input: {
+	accountId: string
+	apiToken: string
+	name: string
+	apiBaseUrl?: string
+	fetcher?: typeof fetch
+	sleep?: (ms: number) => Promise<void>
+	deadlineMs?: number
+	now?: () => number
+	maxAttempts?: number
+}) {
+	const objects: Array<string> = []
+	let cursor: string | undefined
+	let previousCursor: string | undefined
+	for (let page = 0; page < 50; page += 1) {
+		const search = new URLSearchParams({ per_page: '1000' })
+		if (cursor) search.set('cursor', cursor)
+		const payload = await cloudflareApiRequest<
+			Array<R2ObjectListEntry> | { objects?: Array<R2ObjectListEntry> }
+		>({
+			accountId: input.accountId,
+			apiToken: input.apiToken,
+			apiBaseUrl: input.apiBaseUrl,
+			fetcher: input.fetcher,
+			sleep: input.sleep,
+			deadlineMs: input.deadlineMs,
+			now: input.now,
+			maxAttempts: input.maxAttempts,
+			pathname: `/r2/buckets/${encodeURIComponent(input.name)}/objects?${search.toString()}`,
+		})
+		const listed = Array.isArray(payload.result)
+			? payload.result
+			: (payload.result?.objects ?? [])
+		for (const entry of listed) {
+			const key = readR2ObjectKey(entry)
+			if (key) objects.push(key)
+		}
+		previousCursor = cursor
+		cursor = payload.result_info?.cursor
+		if (!cursor || cursor === previousCursor) break
+	}
+	return objects
+}
+
+/**
+ * Delete every object in an R2 bucket. Callers must already have proven the
+ * bucket is preview-only (or otherwise safe to empty). Production and shared
+ * buckets are never emptied from this helper's call sites.
+ */
+export async function emptyR2Bucket(input: {
+	accountId: string
+	apiToken: string
+	name: string
+	apiBaseUrl?: string
+	fetcher?: typeof fetch
+	sleep?: (ms: number) => Promise<void>
+	deadlineMs?: number
+	now?: () => number
+	maxAttempts?: number
+}) {
+	let objects: Array<string>
+	try {
+		objects = await listR2BucketObjects(input)
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error)
+		if (isWranglerNotFoundOutput(message) || /\(404\)/.test(message)) {
+			console.error(`R2 bucket already deleted: ${input.name}`)
+			return 0
+		}
+		throw error
+	}
+	for (const key of objects) {
+		await cloudflareApiRequest({
+			accountId: input.accountId,
+			apiToken: input.apiToken,
+			apiBaseUrl: input.apiBaseUrl,
+			fetcher: input.fetcher,
+			sleep: input.sleep,
+			deadlineMs: input.deadlineMs,
+			now: input.now,
+			maxAttempts: input.maxAttempts,
+			pathname: `/r2/buckets/${encodeURIComponent(input.name)}/objects/${encodeURIComponent(key)}`,
+			method: 'DELETE',
+		})
+		console.error(`Deleted R2 object: ${input.name}/${key}`)
+	}
+	return objects.length
+}
+
+export async function deleteR2Bucket({
 	name,
 	dryRun,
+	emptyIfNonEmpty,
+	accountId,
+	apiToken,
+	apiBaseUrl,
+	fetcher,
+	sleep: wait,
+	maxAttempts,
+	deadlineMs,
+	now,
 }: {
 	name: string
 	dryRun: boolean
+	emptyIfNonEmpty?: boolean
+	accountId?: string
+	apiToken?: string
+	apiBaseUrl?: string
+	fetcher?: typeof fetch
+	sleep?: (ms: number) => Promise<void>
+	maxAttempts?: number
+	deadlineMs?: number
+	now?: () => number
 }) {
 	if (dryRun) {
 		console.error(`[dry-run] delete R2 bucket: ${name}`)
 		return
 	}
 
-	const result = runWrangler(['r2', 'bucket', 'delete', name], { quiet: true })
+	const retryOptions = {
+		quiet: true,
+		sleep: wait,
+		maxAttempts,
+		deadlineMs,
+		now,
+	} as const
+	const result = await runWranglerWithRetry(
+		['r2', 'bucket', 'delete', name],
+		retryOptions,
+	)
 	if (result.status === 0) {
 		console.error(`Deleted R2 bucket: ${name}`)
 		return
 	}
 
-	const output = `${result.stdout}${result.stderr}`.trim()
+	const output =
+		`${result.stdout}${result.stderr} ${result.errorMessage}`.trim()
 	if (isWranglerNotFoundOutput(output)) {
 		console.error(`R2 bucket already deleted: ${name}`)
 		return
 	}
 
-	// R2 refuses to delete non-empty buckets and wrangler has no purge
-	// command; a leftover preview bucket is preferable to a failed
-	// cleanup run, so warn instead of failing the workflow.
-	console.error(
-		`Warning: failed to delete R2 bucket ${name} (it may not be empty); it must be cleaned up manually.`,
+	if (emptyIfNonEmpty && isR2BucketNotEmptyOutput(output)) {
+		const resolvedAccountId = accountId ?? process.env.CLOUDFLARE_ACCOUNT_ID
+		const resolvedApiToken = apiToken ?? process.env.CLOUDFLARE_API_TOKEN
+		if (!resolvedAccountId || !resolvedApiToken) {
+			throw new CloudflareResourceError(
+				'r2',
+				name,
+				`Failed to empty R2 bucket ${name}: missing CLOUDFLARE_ACCOUNT_ID or CLOUDFLARE_API_TOKEN.`,
+			)
+		}
+		console.error(`R2 bucket ${name} is not empty; deleting objects first.`)
+		await emptyR2Bucket({
+			accountId: resolvedAccountId,
+			apiToken: resolvedApiToken,
+			name,
+			apiBaseUrl,
+			fetcher,
+			sleep: wait,
+			maxAttempts,
+			deadlineMs,
+			now,
+		})
+		const emptied = await runWranglerWithRetry(
+			['r2', 'bucket', 'delete', name],
+			retryOptions,
+		)
+		if (emptied.status === 0) {
+			console.error(`Deleted R2 bucket: ${name}`)
+			return
+		}
+		const emptiedOutput =
+			`${emptied.stdout}${emptied.stderr} ${emptied.errorMessage}`.trim()
+		if (isWranglerNotFoundOutput(emptiedOutput)) {
+			console.error(`R2 bucket already deleted: ${name}`)
+			return
+		}
+		throw new CloudflareResourceError(
+			'r2',
+			name,
+			`Failed to delete R2 bucket ${name} after emptying${emptiedOutput ? `: ${emptiedOutput}` : ''}`,
+		)
+	}
+
+	throw new CloudflareResourceError(
+		'r2',
+		name,
+		`Failed to delete R2 bucket ${name}${output ? `: ${output}` : ''}`,
 	)
 }
 
@@ -357,6 +657,8 @@ type CloudflareApiRequestInput = {
 	fetcher?: typeof fetch
 	sleep?: (ms: number) => Promise<void>
 	maxAttempts?: number
+	deadlineMs?: number
+	now?: () => number
 }
 
 async function cloudflareApiRequestOnce<T>(input: CloudflareApiRequestInput) {
@@ -416,19 +718,30 @@ export async function cloudflareApiRequest<T>(
 ) {
 	const maxAttempts = input.maxAttempts ?? cloudflareApiRetryMaxAttempts
 	const wait = input.sleep ?? sleep
+	const now = input.now ?? Date.now
 	let lastError: unknown
 	for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
 		try {
 			return await cloudflareApiRequestOnce<T>(input)
 		} catch (error) {
 			lastError = error
-			if (!isRetryableCloudflareApiError(error) || attempt === maxAttempts) {
+			const timeLeft =
+				input.deadlineMs === undefined
+					? Number.POSITIVE_INFINITY
+					: input.deadlineMs - now()
+			if (
+				!isRetryableCloudflareApiError(error) ||
+				attempt === maxAttempts ||
+				timeLeft < cloudflareApiRetryBaseDelayMs
+			) {
 				throw error
 			}
 			console.error(
 				`Retrying Cloudflare API ${input.method ?? 'GET'} ${input.pathname} (attempt ${attempt + 1}/${maxAttempts})`,
 			)
-			await wait(cloudflareApiRetryBaseDelayMs * 2 ** (attempt - 1))
+			await wait(
+				Math.min(cloudflareApiRetryBaseDelayMs * 2 ** (attempt - 1), timeLeft),
+			)
 		}
 	}
 	throw lastError
@@ -739,6 +1052,9 @@ export async function listCloudflareQueues(input: {
 	apiBaseUrl?: string
 	fetcher?: typeof fetch
 	sleep?: (ms: number) => Promise<void>
+	deadlineMs?: number
+	now?: () => number
+	maxAttempts?: number
 }) {
 	const queues: Array<CloudflareQueue> = []
 	let page = 1
@@ -830,6 +1146,9 @@ export async function removeCloudflareQueueConsumers(input: {
 	apiBaseUrl?: string
 	fetcher?: typeof fetch
 	sleep?: (ms: number) => Promise<void>
+	deadlineMs?: number
+	now?: () => number
+	maxAttempts?: number
 }) {
 	if (input.dryRun) {
 		console.error(`[dry-run] remove Queue consumers: ${input.name}`)
@@ -889,6 +1208,9 @@ export async function deleteCloudflareQueue(input: {
 	apiBaseUrl?: string
 	fetcher?: typeof fetch
 	sleep?: (ms: number) => Promise<void>
+	deadlineMs?: number
+	now?: () => number
+	maxAttempts?: number
 }) {
 	if (input.dryRun) {
 		console.error(`[dry-run] delete Queue: ${input.name}`)
@@ -902,6 +1224,7 @@ export async function deleteCloudflareQueue(input: {
 		return
 	}
 	const wait = input.sleep ?? sleep
+	const now = input.now ?? Date.now
 	for (let attempt = 1; ; attempt += 1) {
 		try {
 			await cloudflareApiRequest({
@@ -911,16 +1234,23 @@ export async function deleteCloudflareQueue(input: {
 			})
 			break
 		} catch (error) {
+			const timeLeft =
+				input.deadlineMs === undefined
+					? Number.POSITIVE_INFINITY
+					: input.deadlineMs - now()
 			if (
 				!isQueueStillReferencedError(error) ||
-				attempt === queueBindingReleaseMaxAttempts
+				attempt === queueBindingReleaseMaxAttempts ||
+				timeLeft < queueBindingReleaseBaseDelayMs
 			) {
 				throw error
 			}
 			console.error(
 				`Queue ${input.name} is still bound to a Worker; waiting for the binding release (attempt ${attempt + 1}/${queueBindingReleaseMaxAttempts})`,
 			)
-			await wait(queueBindingReleaseBaseDelayMs * 2 ** (attempt - 1))
+			await wait(
+				Math.min(queueBindingReleaseBaseDelayMs * 2 ** (attempt - 1), timeLeft),
+			)
 		}
 	}
 	console.error(`Deleted Queue: ${input.name} (${queue.queue_id})`)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Closed-PR preview cleanup should finish every preview-only Cloudflare resource it can, even when one delete hits a transient or permanent API error.

## Why

Verified incidents on `kentcdodds/kody`:

- Closed PRs 1999, 2004, and 2008 failed immediately while listing/removing Queue consumers (`403 Authentication error`; runs 33681858786, 33683277427, 33685497981). Current preview deploys authenticate, so this change does not assume token rotation.
- Closed PR 2017 removed its Queue consumer and four Workers, then `wrangler delete kody-pr-2017-highlight --force` returned `504 Gateway Timeout`. The process exited, so mock Workers, Queues, R2, KV, and D1 were never attempted. GitHub deployment/environment deletion still ran via `if: always()`.
- R2 deletion only warned on non-empty buckets, so a “successful” cleanup could leave old preview buckets.

`fail()` / `process.exit(1)` on the first wrangler or REST error was the fail-fast root cause. #2024 (name guards) has merged; this branch is rebased onto that `main` and keeps those guards without duplicating the checker.

## Summary

- Retry transient Cloudflare/wrangler **429** and **5xx** (including 504 Gateway Timeout) with bounded backoff inside the four-minute cleanup job.
- Do not retry permanent **401/403** / `Authentication error [code: 10000]`.
- Continue independent deletes after a permanent resource failure, then throw **one aggregate** listing every leftover and the re-run command.
- Keep **Queue consumers → Workers → Queues**, then R2 / KV / D1.
- Already-missing resources stay successful/idempotent, including D1/KV `does not exist` after a retried delete that already succeeded.
- Empty **preview-only** R2 buckets before delete; leftover objects become an aggregate failure. Never targets `kody-preview-jobs` or production names.
- Nested R2 object keys keep literal `/` on Delete Object (Cloudflare rejects `%2F`).
- `assertPreviewResourceName` (from #2024 on `main`) plus `deploy-guardrails:check` keep every delete behind `kody-pr-<n>*` / `kody-branch-<slug>*`.

## Testing

- Focused: 42 passed (`preview-resources`, `resource-utils`, `check-deploy-guardrails` node-unit), including 504-then-success, 429, permanent 403 with later resources still attempted, already-missing, D1/KV post-retry not-found, dependency order, name safety, nested R2 empty-then-delete.
- Pre-push: `test:node` 2500 passed, `test:workers` 321 passed.

Closed-PR and manual `workflow_dispatch` PR-target cleanup remain the same CLI (`preview-resources.ts cleanup --worker-name …`). Cole is deleting currently leaked resources separately; this agent does not.

**Risk:** medium (destructive Cloudflare cleanup infrastructure). User instruction: do not auto-merge medium/high. Park ready after green CI and valid review feedback.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low primitive risk; medium operational risk)</summary>

**Mode:** recap · **Base:** `main` @ `6ec72c65` · **Head:** `dbe0ae5c`

**Classification:** composes — no primitives added or changed. The classifier matched no `primitives.yaml` roots (`tools/ci/*` and setup docs are unmatched). Operational risk is medium because the job deletes Cloudflare preview resources.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| _(none)_ | — | unmatched CI / docs paths only |

### Change flow

Closed-PR cleanup retries transient Cloudflare/wrangler failures, continues after a permanent leftover, and empties preview-only R2 before delete.

```mermaid
sequenceDiagram
	actor GHA as preview.yml cleanup
	participant previewResources as preview-resources
	participant wranglerCli as wrangler / Cloudflare API
	GHA->>previewResources: cleanup --worker-name kody-pr-N
	previewResources->>previewResources: assertPreviewResourceName on every name
	previewResources->>wranglerCli: remove queue consumers
	alt transient 429 or 5xx
		wranglerCli-->>previewResources: retry with bounded backoff
	else permanent 401 or 403
		wranglerCli-->>previewResources: record leftover, continue
	end
	previewResources->>wranglerCli: delete Workers (504 no longer aborts the sweep)
	previewResources->>wranglerCli: delete Queues
	previewResources->>wranglerCli: empty preview R2 objects then delete buckets
	Note over wranglerCli,previewResources: R2 Delete Object keeps slashes literal
	previewResources->>wranglerCli: delete KV and D1
	Note over previewResources: D1/KV not-found after retry is success
	previewResources-->>GHA: one aggregate failure listing every leftover
```

### Invariants

- Per-user isolation is untouched. Cleanup never targets `kody-preview-jobs`, `kody-jobs`, or other production/shared names.
- Queue-consumer → Worker → Queue order stays required by Cloudflare dependency errors 10064 / “still referenced by a binding”.
- #2024 name guards are now on `main`; this branch rebases onto them instead of duplicating the checker.
- Nested R2 keys must not percent-encode `/` (`%2F`) on Delete Object.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d2ed435-e044-4314-8b5c-6eed7ff67cf3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d2ed435-e044-4314-8b5c-6eed7ff67cf3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

