### PR TITLE
Revoke OAuth grants over OAUTH_KV when account deletion runs outside the provider fetch

### DIFF
--- a/docs/contributing/architecture/authentication.md
+++ b/docs/contributing/architecture/authentication.md
@@ -378,8 +378,20 @@ Both are opt-in and adapted from the Epic Stack.
     `archived_job_artifacts`,
   - the user's `StorageRunner` Durable Objects via the user-scoped
     `storageRunnerRpc` stub,
-  - all OAuth grants for the user via the bound OAuth provider,
+  - all OAuth grants for the user (and the provider clients the user minted) via
+    the bound OAuth provider,
   - the user row itself last so a partial failure can be retried.
+- `env.OAUTH_PROVIDER` is injected by `@cloudflare/workers-oauth-provider` only
+  inside its own `fetch` wrapper, so it exists for `POST /account/delete` but
+  not for the hourly unverified-account purge (`JobsHost.runScheduledLane` RPC
+  on origin) or for `adminUnverifiedAccountPurgeRun` when served from the
+  sessionful `MCP` Durable Object on kody-platform. Those paths fall back to
+  `packages/worker/src/oauth-kv-helpers.ts`, which implements `listUserGrants`,
+  `revokeGrant`, and `deleteClient` directly over `OAUTH_KV` with the provider's
+  key layout (`grant:{userId}:{grantId}`, `token:{userId}:{grantId}:{tokenId}`,
+  `client:{clientId}`) and deletion order, so the KV result is identical to a
+  fetch-context revoke. Deletion only reports "OAuth grants were not revoked"
+  when both `OAUTH_PROVIDER` and `OAUTH_KV` are missing.
 - After the user row is gone, origin clears the UserMeter deletion tombstone
   `purge()` restored. `users.stable_user_id` is SHA-256 of the signup email, so
   a later account with that email reuses the same Durable Object id and must not

--- a/docs/contributing/architecture/authentication.md
+++ b/docs/contributing/architecture/authentication.md
@@ -391,7 +391,11 @@ Both are opt-in and adapted from the Epic Stack.
   key layout (`grant:{userId}:{grantId}`, `token:{userId}:{grantId}:{tokenId}`,
   `client:{clientId}`) and deletion order, so the KV result is identical to a
   fetch-context revoke. Deletion only reports "OAuth grants were not revoked"
-  when both `OAUTH_PROVIDER` and `OAUTH_KV` are missing.
+  when both `OAUTH_PROVIDER` and `OAUTH_KV` are missing. Account export's
+  `oauth_grants` section (`packages/worker/src/account/export.ts`) uses the same
+  reader for `listUserGrants`, so `accountExportManifest` /
+  `accountExportSection` served from the platform `MCP` Durable Object include
+  grant metadata too.
 - After the user row is gone, origin clears the UserMeter deletion tombstone
   `purge()` restored. `users.stable_user_id` is SHA-256 of the signup email, so
   a later account with that email reuses the same Durable Object id and must not

--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -505,7 +505,12 @@ reserved-username override, and the platform-owned
   checked-in config).
 - `OAUTH_KV` supports OAuth client and token flows without custom storage code
   in the app handlers; account deletion revokes all provider grants for the
-  user.
+  user. Outside the provider's `fetch` wrapper (scheduled purge lane, RPC
+  entrypoints, the `MCP` Durable Object on kody-platform) `env.OAUTH_PROVIDER`
+  is undefined, so `packages/worker/src/oauth-kv-helpers.ts` performs the same
+  grant, token, and client deletes directly against `OAUTH_KV` using the
+  provider's key layout. `packages/worker/src/oauth-purge.ts` models that layout
+  for the orphan/expiry sweep for the same reason.
 - `BUNDLE_ARTIFACTS_KV` keys are deleted from account deletion using D1-derived
   source ids, published commits, bundle artifact rows, community listing ids,
   and package ids.

--- a/packages/worker/src/account/export.node.test.ts
+++ b/packages/worker/src/account/export.node.test.ts
@@ -12,6 +12,7 @@ import {
 	createMigratedDb,
 	createMailboxBinding,
 } from '#worker/test-support/account-export.ts'
+import { createMemoryKvNamespace } from '#worker/test-support/memory-kv.ts'
 
 test('account export D1 coverage includes every live user-owned schema column', () => {
 	const db = new DatabaseSync(':memory:')
@@ -715,4 +716,116 @@ test('D1 export reads large tables in bounded keyset pages', async () => {
 	expect(
 		queries.some((query) => query.includes('__account_export_rowid')),
 	).toBe(false)
+})
+
+test('account export reads OAuth grant metadata from OAUTH_KV when the provider helpers are absent', async () => {
+	const { sqlite, db } = createMigratedDb()
+	sqlite.exec(`
+		INSERT INTO users (
+			id, username, email, password_hash, created_at, updated_at,
+			email_verified_at, stable_user_id
+		)
+		VALUES (
+			1, 'user-a', 'a@example.com', 'password-hash-a', '2026-07-05',
+			'2026-07-05', '2026-07-05', 'user-aaa'
+		);
+	`)
+	const storedGrant = (userId: string, grantId: string) =>
+		JSON.stringify({
+			id: grantId,
+			clientId: 'host-client',
+			userId,
+			scope: ['mcp'],
+			metadata: { label: grantId },
+			createdAt: 1_700_000_000,
+			redirectUri: 'https://host.example/callback',
+			encryptedProps: 'ciphertext',
+			refreshTokenId: 'refresh-secret',
+			refreshTokenWrappedKey: 'wrapped-key',
+			previousRefreshTokenId: 'previous-refresh-secret',
+			previousRefreshTokenWrappedKey: 'previous-wrapped-key',
+			authCodeId: 'auth-code-secret',
+			authCodeWrappedKey: 'auth-code-wrapped-key',
+			codeChallenge: 'challenge',
+			codeChallengeMethod: 'S256',
+		})
+	const { kv } = createMemoryKvNamespace({
+		'grant:user-aaa:grant-1': storedGrant('user-aaa', 'grant-1'),
+		'grant:user-aaa:grant-2': storedGrant('user-aaa', 'grant-2'),
+		'grant:user-bbb:grant-9': storedGrant('user-bbb', 'grant-9'),
+		'token:user-aaa:grant-1:tok-1': JSON.stringify({
+			id: 'tok-1',
+			grantId: 'grant-1',
+			userId: 'user-aaa',
+			wrappedEncryptionKey: 'token-wrapped-key',
+		}),
+	})
+	const env = {
+		APP_DB: db,
+		MAILBOX: createMailboxBinding(),
+		OAUTH_KV: kv,
+	} as Env
+	const expectedGrants = ['grant-1', 'grant-2'].map((id) => ({
+		id,
+		clientId: 'host-client',
+		userId: 'user-aaa',
+		scope: ['mcp'],
+		metadata: { label: id },
+		createdAt: 1_700_000_000,
+		expiresAt: undefined,
+		redirectUri: 'https://host.example/callback',
+	}))
+
+	const accountExport = await createAccountExport({
+		env,
+		dbUserId: 1,
+		mcpUserId: 'user-aaa',
+		generatedAt: '2026-07-05T00:00:00.000Z',
+	})
+	expect(accountExport.oauthGrants).toEqual(expectedGrants)
+	expect(accountExport.manifest.sections.oauth_grants?.count).toBe(2)
+	expect(accountExport.manifest.warnings).not.toEqual(
+		expect.arrayContaining([
+			expect.stringContaining('OAuth grant metadata was not exported'),
+		]),
+	)
+	expect(JSON.stringify(accountExport.oauthGrants)).not.toMatch(
+		/ciphertext|refresh-secret|wrapped-key|auth-code-secret|challenge/,
+	)
+
+	const manifest = await createAccountExportManifest({
+		env,
+		dbUserId: 1,
+		mcpUserId: 'user-aaa',
+	})
+	expect(manifest.sections.oauth_grants?.count).toBe(2)
+	expect(manifest.warnings).not.toEqual(
+		expect.arrayContaining([
+			expect.stringContaining('OAuth grant metadata was not exported'),
+		]),
+	)
+
+	const section = await readAccountExportSection({
+		env,
+		dbUserId: 1,
+		mcpUserId: 'user-aaa',
+		section: 'oauth_grants',
+	})
+	expect(section.items).toEqual(expectedGrants)
+	expect(section.warnings).not.toEqual(
+		expect.arrayContaining([
+			expect.stringContaining('OAuth grant metadata was not exported'),
+		]),
+	)
+
+	const withoutOAuthSurface = await createAccountExport({
+		env: { APP_DB: db, MAILBOX: createMailboxBinding() } as Env,
+		dbUserId: 1,
+		mcpUserId: 'user-aaa',
+		generatedAt: '2026-07-05T00:00:00.000Z',
+	})
+	expect(withoutOAuthSurface.oauthGrants).toEqual([])
+	expect(withoutOAuthSurface.manifest.warnings).toContain(
+		'OAuth provider binding and OAUTH_KV were unavailable; OAuth grant metadata was not exported.',
+	)
 })

--- a/packages/worker/src/account/export.ts
+++ b/packages/worker/src/account/export.ts
@@ -21,6 +21,7 @@ import {
 	buildPublishedSourceSnapshotKvKey,
 } from '#worker/package-runtime/published-runtime-artifacts.ts'
 import { buildCommunitySnapshotKvKey } from '#worker/community/snapshot.ts'
+import { createKvOAuthHelpers } from '#worker/oauth-kv-helpers.ts'
 import { storageRunnerRpc } from '#worker/storage-runner.ts'
 import {
 	exportRunRecords,
@@ -75,7 +76,7 @@ export type AccountExportSectionName =
 
 type OAuthGrantPage = {
 	items: Array<{ id: string; clientId: string }>
-	cursor: string | undefined
+	cursor?: string
 }
 
 type OAuthHelpersShape = {
@@ -87,6 +88,23 @@ type OAuthHelpersShape = {
 
 type AccountExportEnv = Env & {
 	OAUTH_PROVIDER?: OAuthHelpersShape
+}
+
+const oauthSurfaceUnavailableWarning =
+	'OAuth provider binding and OAUTH_KV were unavailable; OAuth grant metadata was not exported.'
+
+/**
+ * `OAUTH_PROVIDER` exists only inside the provider's `fetch` wrapper, so
+ * `accountExportManifest` / `accountExportSection` served from the sessionful
+ * `MCP` Durable Object on kody-platform read grant metadata straight from
+ * `OAUTH_KV` with the same key layout.
+ */
+function resolveOAuthGrantReader(
+	env: AccountExportEnv,
+): OAuthHelpersShape | undefined {
+	if (env.OAUTH_PROVIDER) return env.OAUTH_PROVIDER
+	if (!env.OAUTH_KV) return undefined
+	return createKvOAuthHelpers(env.OAUTH_KV)
 }
 
 type UserSourceSnapshot = {
@@ -980,11 +998,9 @@ async function countOAuthGrants(input: {
 	userId: string
 	warnings: Array<string>
 }) {
-	const helpers = input.env.OAUTH_PROVIDER
+	const helpers = resolveOAuthGrantReader(input.env)
 	if (!helpers) {
-		input.warnings.push(
-			'OAuth provider binding was unavailable; OAuth grant metadata was not exported.',
-		)
+		input.warnings.push(oauthSurfaceUnavailableWarning)
 		return 0
 	}
 	let count = 0
@@ -1243,11 +1259,9 @@ async function listOAuthGrants(input: {
 	userId: string
 	warnings: Array<string>
 }) {
-	const helpers = input.env.OAUTH_PROVIDER
+	const helpers = resolveOAuthGrantReader(input.env)
 	if (!helpers) {
-		input.warnings.push(
-			'OAuth provider binding was unavailable; OAuth grant metadata was not exported.',
-		)
+		input.warnings.push(oauthSurfaceUnavailableWarning)
 		return [] as Array<{ id: string; clientId: string }>
 	}
 	const grants: Array<{ id: string; clientId: string }> = []

--- a/packages/worker/src/app/account-deletion.node.test.ts
+++ b/packages/worker/src/app/account-deletion.node.test.ts
@@ -15,6 +15,7 @@ import { accountUserDataExcludedOwnerIds } from '#worker/account/data-targets.ts
 import { jobVectorId } from '#mcp/jobs-vectorize.ts'
 import { consoleError } from '#worker/test-support/console-spies.ts'
 import { createInMemoryUserMeterEnv } from '#worker/test-support/user-meter.ts'
+import { createMemoryKvNamespace } from '#worker/test-support/memory-kv.ts'
 import {
 	insertRepoSession,
 	listRepoSessionsByUser,
@@ -1516,4 +1517,136 @@ test('deleteUserAccount keeps an existing fence when writers are still active', 
 	expect(await meter.readDeletionState()).toEqual({
 		deletingAt: '2026-08-31 15:22:12',
 	})
+})
+
+test('deleteUserAccount revokes OAuth grants through OAUTH_KV when the provider helpers are absent', async () => {
+	const { db, rows } = createTestDb({
+		users: [{ id: 1, email: 'a@example.com', stable_user_id: 'user-aaa' }],
+		user_mcp_oauth_clients: [
+			{
+				id: 'row-1',
+				user_id: 1,
+				client_id: 'owned-client',
+				revoked_at: null,
+			},
+		],
+	})
+	const providerGrant = (userId: string, grantId: string, clientId: string) =>
+		JSON.stringify({ id: grantId, userId, clientId, scope: ['mcp'] })
+	const providerToken = (userId: string, grantId: string, tokenId: string) =>
+		JSON.stringify({ id: tokenId, userId, grantId })
+	const { kv, store } = createMemoryKvNamespace({
+		'client:owned-client': JSON.stringify({ clientId: 'owned-client' }),
+		'client:host-client': JSON.stringify({ clientId: 'host-client' }),
+		'grant:user-aaa:grant-1': providerGrant(
+			'user-aaa',
+			'grant-1',
+			'host-client',
+		),
+		'grant:user-aaa:grant-2': providerGrant(
+			'user-aaa',
+			'grant-2',
+			'host-client',
+		),
+		'token:user-aaa:grant-1:tok-1': providerToken(
+			'user-aaa',
+			'grant-1',
+			'tok-1',
+		),
+		'token:user-aaa:grant-1:tok-2': providerToken(
+			'user-aaa',
+			'grant-1',
+			'tok-2',
+		),
+		'token:user-aaa:grant-2:tok-3': providerToken(
+			'user-aaa',
+			'grant-2',
+			'tok-3',
+		),
+		'grant:user-bbb:grant-9': providerGrant(
+			'user-bbb',
+			'grant-9',
+			'host-client',
+		),
+		'token:user-bbb:grant-9:tok-9': providerToken(
+			'user-bbb',
+			'grant-9',
+			'tok-9',
+		),
+	})
+	const env = createSuccessfulDeletionEnv(db, {
+		OAUTH_PROVIDER: undefined,
+		OAUTH_KV: kv,
+	})
+
+	const result = await deleteUserAccount({
+		env,
+		dbUserId: 1,
+		mcpUserId: 'user-aaa',
+	})
+
+	expect(result.warnings).toEqual([])
+	expect(result.revokedOAuthGrants).toBe(2)
+	expect(rows.users).toEqual([])
+	expect([...store.keys()].sort()).toEqual([
+		'client:host-client',
+		'grant:user-bbb:grant-9',
+		'token:user-bbb:grant-9:tok-9',
+	])
+})
+
+test('deleteUserAccount prefers the fetch-context provider helpers over OAUTH_KV', async () => {
+	const { db } = createTestDb({
+		users: [{ id: 1, email: 'a@example.com', stable_user_id: 'user-aaa' }],
+	})
+	const { kv, store } = createMemoryKvNamespace({
+		'grant:user-aaa:grant-1': JSON.stringify({
+			id: 'grant-1',
+			userId: 'user-aaa',
+			clientId: 'host-client',
+		}),
+	})
+	const revokeGrant = vi.fn(async () => undefined)
+	const result = await deleteUserAccount({
+		env: createSuccessfulDeletionEnv(db, {
+			OAUTH_KV: kv,
+			OAUTH_PROVIDER: {
+				async listUserGrants() {
+					return {
+						items: [{ id: 'provider-grant', clientId: 'host-client' }],
+						cursor: undefined,
+					}
+				},
+				revokeGrant,
+			},
+		}),
+		dbUserId: 1,
+		mcpUserId: 'user-aaa',
+	})
+
+	expect(result.warnings).toEqual([])
+	expect(result.revokedOAuthGrants).toBe(1)
+	expect(revokeGrant).toHaveBeenCalledWith('provider-grant', 'user-aaa')
+	expect([...store.keys()]).toEqual(['grant:user-aaa:grant-1'])
+})
+
+test('deleteUserAccount reports the missing OAuth surfaces when neither provider helpers nor OAUTH_KV exist', async () => {
+	const { db, rows } = createTestDb({
+		users: [{ id: 1, email: 'a@example.com', stable_user_id: 'user-aaa' }],
+	})
+	await expect(
+		deleteUserAccount({
+			env: createSuccessfulDeletionEnv(db, { OAUTH_PROVIDER: undefined }),
+			dbUserId: 1,
+			mcpUserId: 'user-aaa',
+		}),
+	).rejects.toMatchObject({
+		name: 'AccountDeletionCleanupError',
+		cleanupErrors: [
+			'OAuth provider binding and OAUTH_KV were unavailable; OAuth grants were not revoked.',
+		],
+	})
+	expect(rows.users).toEqual([
+		expect.objectContaining({ id: 1, deleting_at: expect.any(String) }),
+	])
 })

--- a/packages/worker/src/app/account-deletion.ts
+++ b/packages/worker/src/app/account-deletion.ts
@@ -3,6 +3,7 @@ import {
 	type OAuthGrantHelpers,
 	revokeAllOAuthGrantsBestEffort,
 } from '#worker/oauth-grants.ts'
+import { createKvOAuthHelpers } from '#worker/oauth-kv-helpers.ts'
 import {
 	cancelSubscription,
 	deleteCustomer,
@@ -90,6 +91,21 @@ type OAuthHelpersShape = OAuthGrantHelpers & {
 
 type AccountDeletionEnv = Env & {
 	OAUTH_PROVIDER?: OAuthHelpersShape
+}
+
+/**
+ * `OAUTH_PROVIDER` exists only inside the provider's `fetch` wrapper
+ * (self-service `POST /account/delete`). The hourly unverified-account purge
+ * (`JobsHost.runScheduledLane` RPC) and the admin MCP capability on the
+ * platform/runtime lane run outside it, so they revoke through the same
+ * `OAUTH_KV` key layout instead.
+ */
+function resolveOAuthHelpers(
+	env: AccountDeletionEnv,
+): OAuthHelpersShape | undefined {
+	if (env.OAUTH_PROVIDER) return env.OAUTH_PROVIDER
+	if (!env.OAUTH_KV) return undefined
+	return createKvOAuthHelpers(env.OAUTH_KV)
 }
 
 export type AccountDeletionResult = {
@@ -1299,7 +1315,7 @@ export async function deleteUserAccount(input: {
 		}
 	}
 
-	const helpers = input.env.OAUTH_PROVIDER
+	const helpers = resolveOAuthHelpers(input.env)
 	if (helpers) {
 		if (helpers.deleteClient) {
 			const deleteClient = helpers.deleteClient
@@ -1336,7 +1352,7 @@ export async function deleteUserAccount(input: {
 		}
 	} else {
 		warnings.push(
-			'OAuth provider binding was unavailable; OAuth grants were not revoked.',
+			'OAuth provider binding and OAUTH_KV were unavailable; OAuth grants were not revoked.',
 		)
 	}
 

--- a/packages/worker/src/mcp/waiting/derive-waiting.node.test.ts
+++ b/packages/worker/src/mcp/waiting/derive-waiting.node.test.ts
@@ -1,0 +1,63 @@
+import { expect, test } from 'vitest'
+import { createMemoryKvNamespace } from '#worker/test-support/memory-kv.ts'
+import { collectWaitingSignals } from './derive-waiting.ts'
+
+function createStubDb() {
+	return {
+		prepare() {
+			return {
+				bind() {
+					return {
+						async first() {
+							return null
+						},
+						async all() {
+							return { results: [] }
+						},
+					}
+				},
+			}
+		},
+	} as unknown as D1Database
+}
+
+const user = {
+	userId: 11,
+	stableUserId: 'user-aaa',
+	email: 'waiting@example.com',
+	emailVerified: true,
+}
+
+test('waiting signals read MCP OAuth grants from OAUTH_KV when the provider helpers are absent', async () => {
+	const { kv } = createMemoryKvNamespace({
+		'grant:user-aaa:grant-1': JSON.stringify({
+			id: 'grant-1',
+			userId: 'user-aaa',
+			clientId: 'host-client',
+			scope: ['mcp'],
+		}),
+		'grant:user-bbb:grant-2': JSON.stringify({
+			id: 'grant-2',
+			userId: 'user-bbb',
+			clientId: 'host-client',
+			scope: ['mcp'],
+		}),
+	})
+	const connected = await collectWaitingSignals({
+		env: { APP_DB: createStubDb(), OAUTH_KV: kv } as Env,
+		user,
+	})
+	expect(connected.onboardingRemaining).not.toContain('connect-agent')
+
+	const disconnected = await collectWaitingSignals({
+		env: { APP_DB: createStubDb(), OAUTH_KV: kv } as Env,
+		user: { ...user, stableUserId: 'user-ccc' },
+	})
+	expect(disconnected.onboardingRemaining).toContain('connect-agent')
+
+	const noOAuthSurface = await collectWaitingSignals({
+		env: { APP_DB: createStubDb() } as Env,
+		user,
+	})
+	expect(noOAuthSurface.onboardingRemaining).toContain('connect-agent')
+})

--- a/packages/worker/src/mcp/waiting/derive-waiting.ts
+++ b/packages/worker/src/mcp/waiting/derive-waiting.ts
@@ -7,6 +7,7 @@ import { listSecrets } from '#mcp/secrets/service.ts'
 import { getCachedMcpClientHubServers } from '#worker/mcp-client/hub-client.ts'
 import { type McpClientHubSnapshot } from '#worker/mcp-client/types.ts'
 import { listMcpServerSettings } from '#worker/mcp-client/settings-service.ts'
+import { createKvOAuthHelpers } from '#worker/oauth-kv-helpers.ts'
 import { listSavedPackagesByUserId } from '#worker/package-registry/repo.ts'
 import { readEntitlementUsageSnapshot } from '#worker/entitlements/usage-snapshot.ts'
 import { getUserPlan } from '#worker/entitlements/service.ts'
@@ -144,8 +145,16 @@ export async function collectWaitingSignals(input: {
 	}
 }
 
+/**
+ * `OAUTH_PROVIDER` is injected only inside the provider's `fetch` wrapper on
+ * origin. The `waitingSummary` capability and search-tool waiting hints also
+ * run in the sessionful `MCP` Durable Object on kody-platform, so they read
+ * the same grants through `OAUTH_KV` there.
+ */
 async function userHasMcpOAuthGrants(env: WaitingEnv, stableUserId: string) {
-	const helpers = env.OAUTH_PROVIDER
+	const helpers =
+		env.OAUTH_PROVIDER ??
+		(env.OAUTH_KV ? createKvOAuthHelpers(env.OAUTH_KV) : undefined)
 	if (!helpers) return false
 	try {
 		const page = await helpers.listUserGrants(stableUserId)

--- a/packages/worker/src/oauth-kv-helpers.node.test.ts
+++ b/packages/worker/src/oauth-kv-helpers.node.test.ts
@@ -1,0 +1,174 @@
+import { expect, test } from 'vitest'
+import { createKvOAuthHelpers } from './oauth-kv-helpers.ts'
+import { createMemoryKvNamespace } from '#worker/test-support/memory-kv.ts'
+
+function grantRecord(input: {
+	id: string
+	userId: string
+	clientId: string
+	scope?: Array<string>
+}) {
+	return JSON.stringify({
+		id: input.id,
+		clientId: input.clientId,
+		userId: input.userId,
+		scope: input.scope ?? ['mcp'],
+		metadata: { label: input.id },
+		createdAt: 1_700_000_000,
+		encryptedProps: 'opaque',
+		authCodeId: null,
+	})
+}
+
+function tokenRecord(input: { userId: string; grantId: string; id: string }) {
+	return JSON.stringify({
+		id: input.id,
+		grantId: input.grantId,
+		userId: input.userId,
+		createdAt: 1_700_000_000,
+		expiresAt: 1_700_003_600,
+		wrappedEncryptionKey: 'opaque',
+	})
+}
+
+function seedProviderKv() {
+	return createMemoryKvNamespace({
+		'client:client-a': JSON.stringify({ clientId: 'client-a' }),
+		'client:client-b': JSON.stringify({ clientId: 'client-b' }),
+		'grant:user-aaa:grant-1': grantRecord({
+			id: 'grant-1',
+			userId: 'user-aaa',
+			clientId: 'client-a',
+			scope: ['mcp', 'profile'],
+		}),
+		'grant:user-aaa:grant-2': grantRecord({
+			id: 'grant-2',
+			userId: 'user-aaa',
+			clientId: 'client-b',
+		}),
+		'grant:user-bbb:grant-3': grantRecord({
+			id: 'grant-3',
+			userId: 'user-bbb',
+			clientId: 'client-a',
+		}),
+		'token:user-aaa:grant-1:tok-1': tokenRecord({
+			userId: 'user-aaa',
+			grantId: 'grant-1',
+			id: 'tok-1',
+		}),
+		'token:user-aaa:grant-1:tok-2': tokenRecord({
+			userId: 'user-aaa',
+			grantId: 'grant-1',
+			id: 'tok-2',
+		}),
+		'token:user-aaa:grant-2:tok-3': tokenRecord({
+			userId: 'user-aaa',
+			grantId: 'grant-2',
+			id: 'tok-3',
+		}),
+		'token:user-bbb:grant-3:tok-4': tokenRecord({
+			userId: 'user-bbb',
+			grantId: 'grant-3',
+			id: 'tok-4',
+		}),
+	})
+}
+
+test('listUserGrants returns only the user’s grants in provider summary shape and pages with cursors', async () => {
+	const { kv } = seedProviderKv()
+	const helpers = createKvOAuthHelpers(kv)
+
+	const all = await helpers.listUserGrants('user-aaa')
+	expect(all.cursor).toBeUndefined()
+	expect(all.items).toEqual([
+		{
+			id: 'grant-1',
+			clientId: 'client-a',
+			userId: 'user-aaa',
+			scope: ['mcp', 'profile'],
+			metadata: { label: 'grant-1' },
+			createdAt: 1_700_000_000,
+			expiresAt: undefined,
+			redirectUri: undefined,
+		},
+		{
+			id: 'grant-2',
+			clientId: 'client-b',
+			userId: 'user-aaa',
+			scope: ['mcp'],
+			metadata: { label: 'grant-2' },
+			createdAt: 1_700_000_000,
+			expiresAt: undefined,
+			redirectUri: undefined,
+		},
+	])
+
+	const firstPage = await helpers.listUserGrants('user-aaa', { limit: 1 })
+	expect(firstPage.items.map((grant) => grant.id)).toEqual(['grant-1'])
+	expect(firstPage.cursor).toBeDefined()
+	const secondPage = await helpers.listUserGrants('user-aaa', {
+		limit: 1,
+		cursor: firstPage.cursor,
+	})
+	expect(secondPage.items.map((grant) => grant.id)).toEqual(['grant-2'])
+	expect(secondPage.cursor).toBeUndefined()
+
+	expect((await helpers.listUserGrants('user-none')).items).toEqual([])
+})
+
+test('revokeGrant deletes the grant and every token under it and nothing of another user', async () => {
+	const { kv, store } = seedProviderKv()
+	const helpers = createKvOAuthHelpers(kv)
+
+	await helpers.revokeGrant('grant-1', 'user-aaa')
+
+	expect([...store.keys()].sort()).toEqual([
+		'client:client-a',
+		'client:client-b',
+		'grant:user-aaa:grant-2',
+		'grant:user-bbb:grant-3',
+		'token:user-aaa:grant-2:tok-3',
+		'token:user-bbb:grant-3:tok-4',
+	])
+
+	await expect(
+		helpers.revokeGrant('grant-missing', 'user-aaa'),
+	).resolves.toBeUndefined()
+})
+
+test('revokeGrant pages through more tokens than one list call returns', async () => {
+	const { kv, store } = createMemoryKvNamespace({
+		'grant:user-aaa:grant-1': grantRecord({
+			id: 'grant-1',
+			userId: 'user-aaa',
+			clientId: 'client-a',
+		}),
+	})
+	for (let index = 0; index < 1_250; index++) {
+		store.set(
+			`token:user-aaa:grant-1:tok-${String(index).padStart(4, '0')}`,
+			tokenRecord({
+				userId: 'user-aaa',
+				grantId: 'grant-1',
+				id: `tok-${index}`,
+			}),
+		)
+	}
+
+	await createKvOAuthHelpers(kv).revokeGrant('grant-1', 'user-aaa')
+
+	expect(store.size).toBe(0)
+})
+
+test('deleteClient revokes every grant issued to the client across users and removes the client key', async () => {
+	const { kv, store } = seedProviderKv()
+	const helpers = createKvOAuthHelpers(kv)
+
+	await helpers.deleteClient('client-a')
+
+	expect([...store.keys()].sort()).toEqual([
+		'client:client-b',
+		'grant:user-aaa:grant-2',
+		'token:user-aaa:grant-2:tok-3',
+	])
+})

--- a/packages/worker/src/oauth-kv-helpers.ts
+++ b/packages/worker/src/oauth-kv-helpers.ts
@@ -1,0 +1,170 @@
+import { type OAuthGrantHelpers } from '#worker/oauth-grants.ts'
+
+/**
+ * Subset of the provider's `GrantSummary` that Kody reads. Same field names as
+ * `@cloudflare/workers-oauth-provider` so callers written against the fetch
+ * context helpers see identical items here.
+ */
+export type KvOAuthGrantSummary = {
+	id: string
+	clientId: string
+	userId: string
+	scope: Array<string>
+	metadata: unknown
+	createdAt: number | undefined
+	expiresAt: number | undefined
+	redirectUri: string | undefined
+}
+
+export type KvOAuthHelpers = OAuthGrantHelpers & {
+	listUserGrants(
+		userId: string,
+		options?: { cursor?: string; limit?: number },
+	): Promise<{ items: Array<KvOAuthGrantSummary>; cursor?: string }>
+	revokeGrant(grantId: string, userId: string): Promise<void>
+	deleteClient(clientId: string): Promise<void>
+}
+
+const grantKeyPrefix = 'grant:'
+
+function grantKey(userId: string, grantId: string) {
+	return `${grantKeyPrefix}${userId}:${grantId}`
+}
+
+function tokenKeyPrefix(userId: string, grantId: string) {
+	return `token:${userId}:${grantId}:`
+}
+
+function clientKey(clientId: string) {
+	return `client:${clientId}`
+}
+
+type StoredGrant = Record<string, unknown>
+
+function isStoredGrant(value: unknown): value is StoredGrant {
+	return typeof value === 'object' && value !== null
+}
+
+function readString(record: StoredGrant, field: string) {
+	const value = record[field]
+	return typeof value === 'string' ? value : undefined
+}
+
+function readNumber(record: StoredGrant, field: string) {
+	const value = record[field]
+	return typeof value === 'number' ? value : undefined
+}
+
+/**
+ * The provider writes grants at `grant:{userId}:{grantId}`; the record's own
+ * `id`/`userId` fields match the key. Fall back to the key when a record is
+ * missing them so a malformed grant is still revocable.
+ */
+function parseGrantKey(key: string) {
+	if (!key.startsWith(grantKeyPrefix)) return undefined
+	const separator = key.indexOf(':', grantKeyPrefix.length)
+	if (separator === -1) return undefined
+	const userId = key.slice(grantKeyPrefix.length, separator)
+	const grantId = key.slice(separator + 1)
+	if (userId.length === 0 || grantId.length === 0) return undefined
+	return { userId, grantId }
+}
+
+function toGrantSummary(
+	key: string,
+	record: StoredGrant,
+): KvOAuthGrantSummary | undefined {
+	const fromKey = parseGrantKey(key)
+	const id = readString(record, 'id') ?? fromKey?.grantId
+	const userId = readString(record, 'userId') ?? fromKey?.userId
+	if (id === undefined || userId === undefined) return undefined
+	const scope = record.scope
+	return {
+		id,
+		clientId: readString(record, 'clientId') ?? '',
+		userId,
+		scope: Array.isArray(scope)
+			? scope.filter((entry): entry is string => typeof entry === 'string')
+			: [],
+		metadata: record.metadata,
+		createdAt: readNumber(record, 'createdAt'),
+		expiresAt: readNumber(record, 'expiresAt'),
+		redirectUri: readString(record, 'redirectUri'),
+	}
+}
+
+async function forEachKvPage(
+	kv: KVNamespace,
+	prefix: string,
+	visit: (
+		keys: ReadonlyArray<KVNamespaceListKey<unknown, string>>,
+	) => Promise<void>,
+) {
+	let cursor: string | undefined
+	for (;;) {
+		const page = await kv.list({ prefix, cursor })
+		await visit(page.keys)
+		if (page.list_complete) return
+		cursor = page.cursor
+	}
+}
+
+/**
+ * Grant/token/client operations over `OAUTH_KV` for code paths that run
+ * outside the provider's `fetch` wrapper (scheduled lanes, RPC entrypoints,
+ * the sessionful `MCP` Durable Object on kody-platform), where
+ * `env.OAUTH_PROVIDER` is not injected. Mirrors
+ * `@cloudflare/workers-oauth-provider`'s `OAuthHelpers`
+ * key layout and deletion order so the resulting KV state matches a
+ * fetch-context call: `revokeGrant` deletes every
+ * `token:{userId}:{grantId}:*` key and then the grant key; `deleteClient`
+ * revokes every grant (any user) issued to the client and then deletes
+ * `client:{clientId}`. The provider keeps no secondary index keys.
+ */
+export function createKvOAuthHelpers(kv: KVNamespace): KvOAuthHelpers {
+	async function revokeGrant(grantId: string, userId: string) {
+		await forEachKvPage(kv, tokenKeyPrefix(userId, grantId), async (keys) => {
+			await Promise.all(keys.map((key) => kv.delete(key.name)))
+		})
+		await kv.delete(grantKey(userId, grantId))
+	}
+
+	return {
+		async listUserGrants(userId, options) {
+			const page = await kv.list({
+				prefix: `${grantKeyPrefix}${userId}:`,
+				...(options?.limit !== undefined ? { limit: options.limit } : {}),
+				...(options?.cursor !== undefined ? { cursor: options.cursor } : {}),
+			})
+			const records = await Promise.all(
+				page.keys.map(async (key) => ({
+					key: key.name,
+					record: await kv.get(key.name, { type: 'json' }),
+				})),
+			)
+			const items = new Array<KvOAuthGrantSummary>()
+			for (const { key, record } of records) {
+				if (!isStoredGrant(record)) continue
+				const summary = toGrantSummary(key, record)
+				if (summary) items.push(summary)
+			}
+			return {
+				items,
+				cursor: page.list_complete ? undefined : page.cursor,
+			}
+		},
+		revokeGrant,
+		async deleteClient(clientId) {
+			await forEachKvPage(kv, grantKeyPrefix, async (keys) => {
+				for (const key of keys) {
+					const record = await kv.get(key.name, { type: 'json' })
+					if (!isStoredGrant(record)) continue
+					const summary = toGrantSummary(key.name, record)
+					if (summary?.clientId !== clientId) continue
+					await revokeGrant(summary.id, summary.userId)
+				}
+			})
+			await kv.delete(clientKey(clientId))
+		},
+	}
+}

--- a/packages/worker/src/oauth-kv-helpers.ts
+++ b/packages/worker/src/oauth-kv-helpers.ts
@@ -1,5 +1,3 @@
-import { type OAuthGrantHelpers } from '#worker/oauth-grants.ts'
-
 /**
  * Subset of the provider's `GrantSummary` that Kody reads. Same field names as
  * `@cloudflare/workers-oauth-provider` so callers written against the fetch
@@ -16,7 +14,12 @@ export type KvOAuthGrantSummary = {
 	redirectUri: string | undefined
 }
 
-export type KvOAuthHelpers = OAuthGrantHelpers & {
+/**
+ * Structurally satisfies `OAuthGrantHelpers` (`#worker/oauth-grants.ts`) plus
+ * the `deleteClient` that account deletion uses, so it can stand in for
+ * `env.OAUTH_PROVIDER` wherever those are consumed.
+ */
+export type KvOAuthHelpers = {
 	listUserGrants(
 		userId: string,
 		options?: { cursor?: string; limit?: number },

--- a/packages/worker/src/test-support/memory-kv.ts
+++ b/packages/worker/src/test-support/memory-kv.ts
@@ -1,0 +1,50 @@
+/**
+ * In-memory `KVNamespace` for node tests that exercise `list` pagination.
+ * Keys are listed in sorted order like the real binding. A cursor resumes
+ * after the last key it returned, so deleting a listed page (the provider's
+ * revoke loop) does not skip the next one.
+ */
+export function createMemoryKvNamespace(initial?: Record<string, string>) {
+	const store = new Map<string, string>(Object.entries(initial ?? {}))
+	const defaultListLimit = 1000
+	const namespace = {
+		async get(key: string, options?: string | { type?: string }) {
+			const raw = store.get(key)
+			if (raw === undefined) return null
+			const type = typeof options === 'string' ? options : options?.type
+			return type === 'json' ? JSON.parse(raw) : raw
+		},
+		async put(key: string, value: string) {
+			store.set(key, value)
+		},
+		async delete(key: string) {
+			store.delete(key)
+		},
+		async list(options?: {
+			prefix?: string | null
+			cursor?: string | null
+			limit?: number
+		}) {
+			const prefix = options?.prefix ?? ''
+			const after = options?.cursor
+				? Buffer.from(options.cursor, 'base64url').toString()
+				: undefined
+			const matching = [...store.keys()]
+				.filter((key) => key.startsWith(prefix))
+				.filter((key) => after === undefined || key > after)
+				.sort()
+			const limit = options?.limit ?? defaultListLimit
+			const page = matching.slice(0, limit)
+			const lastKey = page.at(-1)
+			const keys = page.map((name) => ({ name }))
+			return lastKey !== undefined && page.length < matching.length
+				? {
+						keys,
+						list_complete: false as const,
+						cursor: Buffer.from(lastKey).toString('base64url'),
+					}
+				: { keys, list_complete: true as const, cacheStatus: null }
+		},
+	}
+	return { kv: namespace as unknown as KVNamespace, store }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Problem

After #2027, production `adminUnverifiedAccountPurgeRun` gets past inventory and fails at cleanup with `AccountDeletionCleanupError: OAuth provider binding was unavailable; OAuth grants were not revoked.`

`@cloudflare/workers-oauth-provider` injects `env.OAUTH_PROVIDER` only inside its own `fetch` wrapper (`origin-handler.ts`). Account deletion also runs from the hourly scheduled lane (`JobsHost.runScheduledLane` RPC → `unverified-account-purge.ts`) and from the admin MCP capability served by the `MCP` Durable Object on kody-platform. Neither is inside that fetch, so every non-fetch deletion failed after destructive steps had already run and retried every 6 h with the same result. Self-service `POST /account/delete` was unaffected.

### Fix

- New `packages/worker/src/oauth-kv-helpers.ts`: `listUserGrants` / `revokeGrant` / `deleteClient` implemented directly over `OAUTH_KV`, mirroring the provider's key layout (`grant:{userId}:{grantId}`, `token:{userId}:{grantId}:{tokenId}`, `client:{clientId}`) and deletion order from the library source (`@cloudflare/workers-oauth-provider@0.10.3`), with cursor-paginated `kv.list`. The provider keeps no index keys, so on-disk results match a fetch-context revoke.
- `account-deletion.ts` resolves `OAUTH_PROVIDER ?? createKvOAuthHelpers(OAUTH_KV)`; the "not revoked" warning only fires when both are missing. Cleanup order unchanged.
- `mcp/waiting/derive-waiting.ts` uses the same fallback (the waiting queue's `connect-agent` probe had the same blind spot in the platform DO lane). `apply-password-change.ts` is fetch-only via its three handler callers and is unchanged.
- `account/export.ts` gets the same fallback so exports served from the platform `MCP` DO include OAuth grant metadata instead of "OAuth grant metadata was not exported." (follow-up commit).
- New `test-support/memory-kv.ts`: in-memory `KVNamespace` with sorted, key-anchored cursors so deleting a listed page does not skip the next one, matching real KV.
- Tests for the KV helpers (per-user scoping, cursor paging, >1000 tokens, cross-user `deleteClient`), KV-only deletion (zero warnings, grant/token keys gone, other user untouched), provider-preferred path, neither-present fails closed, and the waiting-signal fallback. Docs updated in `authentication.md` and `data-storage.md`.

### Validation

`typecheck`, `lint`, `knip`, `format:check`, `CI=1 test:node` (818 files / 2512 tests), workers suites for `index` and `storage-runner`, docs temporal check, slop ratchet, primitives, origin export check — all green.

### After deploy

Re-run `adminUnverifiedAccountPurgeRun` against the two fenced accounts once their 6 h backoff elapses (or wait for the hourly lane) and confirm `unverified_account_purged` audit rows appear.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b0f6a92a-81cd-4157-8b60-188c83ca84c0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b0f6a92a-81cd-4157-8b60-188c83ca84c0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Account deletion now revokes associated OAuth grants, tokens, and provider clients even when the OAuth provider is unavailable.
  * Scheduled and administrative cleanup processes now handle OAuth data consistently.
  * MCP onboarding status more accurately reflects existing OAuth grants outside the provider request context.
  * Account exports now include OAuth grant metadata when available through the OAuth storage layer, while excluding sensitive token data.

* **Documentation**
  * Expanded storage architecture guidance to explain OAuth data cleanup, export behavior, and access patterns across execution contexts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->