### PR TITLE
Make footer nav wrap and use columns on small screens

### DIFF
--- a/packages/worker/client/site-footer.node.test.ts
+++ b/packages/worker/client/site-footer.node.test.ts
@@ -1,0 +1,30 @@
+import { jsx } from 'remix/ui/jsx-runtime'
+import { renderToString } from 'remix/ui/server'
+import { expect, test } from 'vitest'
+import { SiteFooter } from '#client/site-footer.tsx'
+import { pageGutter } from '#universal/styles/style-primitives.ts'
+
+test('site footer nav wraps into columns instead of clipping or a single ladder', async () => {
+	const html = await renderToString(
+		jsx(SiteFooter, { loggedIn: true, loginHref: '/login' }),
+	)
+
+	expect(html).toContain('aria-label="Footer"')
+	expect(html).toContain('href="/account"')
+	expect(html).toContain('Make it portable.')
+	expect(html).toContain(pageGutter)
+	expect(html).toContain('flex-wrap: wrap')
+	expect(html).toContain(
+		'repeat(auto-fit, minmax(min(100%, 7.5rem), max-content))',
+	)
+	expect(html).toContain('@media (max-width: 720px)')
+	expect(html).not.toContain('flex-shrink: 0')
+	expect(html).not.toContain('flex-direction: column')
+	expect(html).not.toContain('@media (max-width: 560px)')
+
+	const loggedOut = await renderToString(
+		jsx(SiteFooter, { loggedIn: false, loginHref: '/login?next=%2Fsupport' }),
+	)
+	expect(loggedOut).toContain('href="/login?next=%2Fsupport"')
+	expect(loggedOut).not.toContain('href="/account"')
+})

--- a/packages/worker/client/site-footer.tsx
+++ b/packages/worker/client/site-footer.tsx
@@ -1,6 +1,9 @@
 import { type Handle, css } from 'remix/ui'
 import { colors, transitions, typography } from '#universal/styles/tokens.ts'
-import { layoutMaxWidths } from '#universal/styles/style-primitives.ts'
+import {
+	layoutMaxWidths,
+	pageGutter,
+} from '#universal/styles/style-primitives.ts'
 
 export type SiteFooterProps = {
 	loggedIn: boolean
@@ -49,7 +52,8 @@ const footerCss = {
 const footerInnerCss = {
 	maxWidth: layoutMaxWidths.extended,
 	marginInline: 'auto',
-	padding: '2.2rem clamp(1.25rem, 4vw, 2.5rem)',
+	paddingBlock: '2.2rem',
+	paddingInline: pageGutter,
 	display: 'grid',
 	gridTemplateColumns: '1fr auto 1fr',
 	alignItems: 'center',
@@ -81,38 +85,39 @@ const taglineCss = {
 	fontOpticalSizing: 'auto' as const,
 }
 
+const footerLinkColumnMin = '7.5rem'
+
 const footerNavCss = {
 	display: 'flex',
-	gap: '1.4rem',
+	flexWrap: 'wrap' as const,
+	gap: '0.5rem 1.4rem',
 	justifySelf: 'end',
-	'@media (max-width: 720px)': {
-		justifySelf: 'center',
-	},
+	justifyContent: 'flex-end',
 	'& a': {
 		color: colors.textMuted,
 		textDecoration: 'none',
 		whiteSpace: 'nowrap' as const,
-		flexShrink: 0,
 		// Same fast color ease as the header nav — one voice for nav links.
 		transition: `color ${transitions.fast}`,
 	},
 	'& a:hover': { color: colors.text },
-	/* Stacked on phones: the links in a row sit close enough to mis-tap, and
-	   the column gives each one a comfortable target without the 44px minimum
-	   the header menu needs (these are the last thing on the page, not the
-	   primary nav). Centred to match the rest of the stacked footer. */
-	'@media (max-width: 560px)': {
-		flexDirection: 'column' as const,
-		alignItems: 'center',
-		gap: '0.2rem',
+	/* Stacked footer: wrap into as many columns as the inner measure holds
+	   instead of one 10-row ladder or a nowrap row that clips. auto-fit with
+	   min(100%, …) collapses to a single column before it overflows. */
+	'@media (max-width: 720px)': {
+		display: 'grid',
+		width: '100%',
+		gridTemplateColumns: `repeat(auto-fit, minmax(min(100%, ${footerLinkColumnMin}), max-content))`,
+		justifySelf: 'center',
+		justifyContent: 'center',
+		columnGap: '1.25rem',
+		rowGap: '0.15rem',
 		'& a': {
 			display: 'flex',
 			alignItems: 'center',
+			justifyContent: 'center',
 			minHeight: '40px',
 			paddingInline: '0.75rem',
-			color: colors.textMuted,
-			textDecoration: 'none',
-			transition: `color ${transitions.fast}`,
 		},
 	},
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Footer nav links should stay fully visible at every viewport: wrap instead of clipping, and sit in multiple columns when the footer stacks — not one 10-row ladder.

## Why

On a mid-width window the links were a `nowrap` row in the right third of the footer, so Privacy/Account ran off the edge. Below 560px they became a single centered column with 40px tap targets, which made a short page like `/support` feel footer-heavy.

## Summary

- Wide footer: the nav `flex-wrap`s in its column instead of shrinking to overflow.
- Stacked footer (≤720px): `auto-fit` grid columns so phones get two or three columns, and a very narrow pane can still collapse to one without clipping.
- Horizontal padding uses `pageGutter` like the rest of the page chrome.

## Testing

- Node unit: `site-footer.node.test.ts` pins wrap/grid CSS and logged-in vs logged-out last link.
- Preview `https://kody-pr-2030.kody-a99.workers.dev/support` in device mode: 375px is two columns with all ten links; 560px is three columns; 900px wraps instead of clipping.

![375px footer: two columns, all links visible](https://cursor.com/artifacts/c/art-d9384164-32e7-4ecf-bea7-c4d6d2c5c424)
![560px footer: three columns](https://cursor.com/artifacts/c/art-d80fac65-8178-47ae-a76a-2294f793e575)
![900px footer: links wrap, Privacy and Terms not clipped](https://cursor.com/artifacts/c/art-e38291e9-73a0-4dc9-8ae3-c86e75dafbe8)
<a href="https://cursor.com/agents/bc-a5f488d8-35eb-4633-b2c9-d1b8ff7e25cd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpreview_footer_nav_responsive_viewports.mp4"><img src="https://cursor.com/artifacts/c/art-dba67865-1010-493d-8397-28fca262aa28" alt="preview_footer_nav_responsive_viewports.mp4" /></a>

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `0bacaab5` · **Head:** `3000b20c`

**Classification:** extends — site footer nav wrapping and stacked-column layout.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `app-ui` | surfaces | extends — footer nav wraps and auto-fits into columns instead of clipping or a single ladder |

### Change flow

Footer link layout by viewport: wrap in the wide three-column footer; multi-column grid when the footer stacks.

```mermaid
flowchart TB
	user[User resizes /support]
	user --> wide["viewport > 720px"]
	user --> stacked["viewport ≤ 720px"]
	wide -->|"app-ui SiteFooter"| wrap["flex-wrap in the right 1fr column"]
	stacked -->|"app-ui SiteFooter"| grid["auto-fit minmax(min(100%, 7.5rem), max-content)"]
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a5f488d8-35eb-4633-b2c9-d1b8ff7e25cd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a5f488d8-35eb-4633-b2c9-d1b8ff7e25cd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated footer spacing to align with shared page layout standards.
  * Improved desktop footer navigation wrapping and alignment.
  * Enhanced mobile footer navigation with responsive multi-column link layouts.

* **Tests**
  * Added coverage for footer responsiveness, navigation wrapping, key content, and signed-in versus signed-out links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->