### PR TITLE
Match user ids in JSON columns with instr() and bound every D1 LIKE pattern to 50 bytes

### DIFF
--- a/packages/worker/src/account/data-targets.node.test.ts
+++ b/packages/worker/src/account/data-targets.node.test.ts
@@ -132,9 +132,9 @@ test('shared user-scoped target match SQL is identical for deletion and export s
 	const replaceJsonMatch = matchFor(samples[6]!)
 	expect(replaceJsonMatch).toEqual({
 		table: 'package_codemod_runs',
-		whereSql: 'filters_json LIKE ?',
-		qualifiedWhereSql: 'package_codemod_runs.filters_json LIKE ?',
-		params: ['%"user-aaa"%'],
+		whereSql: 'instr(filters_json, ?) > 0',
+		qualifiedWhereSql: 'instr(package_codemod_runs.filters_json, ?) > 0',
+		params: ['"user-aaa"'],
 		mutation: {
 			kind: 'replace_json_string',
 			column: 'filters_json',
@@ -145,8 +145,8 @@ test('shared user-scoped target match SQL is identical for deletion and export s
 	expect(buildUserScopedDeleteOrUpdateSql(replaceJsonMatch)).toEqual({
 		sql: `UPDATE package_codemod_runs
 						SET filters_json = REPLACE(filters_json, ?, ?)
-						WHERE filters_json LIKE ?`,
-		params: ['"user-aaa"', '"deleted-user"', '%"user-aaa"%'],
+						WHERE instr(filters_json, ?) > 0`,
+		params: ['"user-aaa"', '"deleted-user"', '"user-aaa"'],
 	})
 
 	expect(matchFor(samples[7]!).qualifiedWhereSql).toBe(
@@ -257,6 +257,27 @@ test('operator-owned tables are explicit deletion/export exclusions', () => {
 			),
 		),
 	)
+})
+
+test('account deletion statements never bind a LIKE or GLOB pattern (D1 caps patterns at 50 bytes)', () => {
+	// A stable user id is 64 hex chars; wrapped in quotes and wildcards it is
+	// 68 bytes, which D1 rejects with "LIKE or GLOB pattern too complex". The
+	// production purge lane failed on exactly this until the JSON-column
+	// target switched to instr().
+	const stableUserId = 'f'.repeat(64)
+	for (const target of accountUserDataTargets) {
+		const match = buildUserScopedTargetMatch({
+			target,
+			mcpUserId: stableUserId,
+			dbUserId: 1,
+		})
+		const { sql, params } = buildUserScopedDeleteOrUpdateSql(match)
+		expect(sql).not.toMatch(/\b(LIKE|GLOB)\b/iu)
+		for (const param of params) {
+			if (typeof param !== 'string') continue
+			expect(param.startsWith('%') || param.endsWith('%')).toBe(false)
+		}
+	}
 })
 
 test('final schema drops entitlement_daily_counters without stale inventory coverage', () => {

--- a/packages/worker/src/account/data-targets.ts
+++ b/packages/worker/src/account/data-targets.ts
@@ -640,11 +640,14 @@ export function buildUserScopedTargetMatch(input: {
 		case 'replace_user_id_in_json_column': {
 			const quotedUserId = `"${input.mcpUserId}"`
 			const quotedReplacement = `"${target.value}"`
+			// D1 caps LIKE/GLOB patterns at 50 bytes ("LIKE or GLOB pattern too
+			// complex"); a quoted 64-hex stable user id is 66. instr() has no
+			// such limit and matches the same substring.
 			return {
 				table,
-				whereSql: `${target.column} LIKE ?`,
-				qualifiedWhereSql: `${table}.${target.column} LIKE ?`,
-				params: [`%${quotedUserId}%`],
+				whereSql: `instr(${target.column}, ?) > 0`,
+				qualifiedWhereSql: `instr(${table}.${target.column}, ?) > 0`,
+				params: [quotedUserId],
 				mutation: {
 					kind: 'replace_json_string',
 					column: target.column,

--- a/packages/worker/src/admin/users-data.ts
+++ b/packages/worker/src/admin/users-data.ts
@@ -1,3 +1,4 @@
+import { d1ContainsLikePattern } from '#worker/d1-like-pattern.ts'
 import { utcSqliteTimestamp } from '@kody-internal/shared/date-keys.ts'
 import { readPagination } from '#worker/query-params.ts'
 // Type-only: the admin payload envelopes are the app/client wire contract and
@@ -172,10 +173,6 @@ function readAdminUserListFilters(url: URL): AdminUserListFilters {
 	}
 }
 
-function escapeLikePattern(value: string) {
-	return value.replace(/[\\%_]/g, (char) => `\\${char}`)
-}
-
 /**
  * Build the WHERE clause shared by the page query and its COUNT so the
  * reported total always matches the filtered result set.
@@ -187,7 +184,7 @@ function buildAdminUserListWhereClause(
 	const conditions: Array<string> = []
 	const params: Array<string> = []
 	if (filters.query) {
-		const pattern = `%${escapeLikePattern(filters.query)}%`
+		const pattern = d1ContainsLikePattern(filters.query)
 		conditions.push(`(username LIKE ? ESCAPE '\\' OR email LIKE ? ESCAPE '\\')`)
 		params.push(pattern, pattern)
 	}

--- a/packages/worker/src/community/profile-repo.ts
+++ b/packages/worker/src/community/profile-repo.ts
@@ -1,3 +1,4 @@
+import { d1ContainsLikePattern } from '#worker/d1-like-pattern.ts'
 import { chunkArray } from '@kody-internal/shared/chunk.ts'
 import { utcSqliteTimestamp } from '@kody-internal/shared/date-keys.ts'
 import { parseTagsJson } from '@kody-internal/shared/tags-json.ts'
@@ -338,7 +339,7 @@ export async function listPublicProfilePackages(
 	const tokens = extractCommunityListingLikeTokens(input.query ?? '')
 	if (tokens.length > 0) {
 		const tokenClauses = tokens.map((token) => {
-			const pattern = `%${token}%`
+			const pattern = d1ContainsLikePattern(token, { escape: false })
 			const columnClauses = publicPackageSearchColumns.map((column) => {
 				bindings.push(pattern)
 				return `${column} LIKE ?`

--- a/packages/worker/src/community/repo.ts
+++ b/packages/worker/src/community/repo.ts
@@ -1,3 +1,4 @@
+import { d1ContainsLikePattern } from '#worker/d1-like-pattern.ts'
 import { chunkArray } from '@kody-internal/shared/chunk.ts'
 import { parseTagsJson } from '@kody-internal/shared/tags-json.ts'
 import {
@@ -611,7 +612,7 @@ export async function listCommunityListingCandidates(
 	const tokens = extractCommunityListingLikeTokens(input.query ?? '')
 	if (tokens.length > 0) {
 		const tokenClauses = tokens.map((token) => {
-			const pattern = `%${token}%`
+			const pattern = d1ContainsLikePattern(token, { escape: false })
 			const columnClauses = communityListingSearchTextColumns.map((column) => {
 				bindings.push(pattern)
 				return `community_listings.${column} LIKE ?`

--- a/packages/worker/src/d1-like-pattern.node.test.ts
+++ b/packages/worker/src/d1-like-pattern.node.test.ts
@@ -1,0 +1,38 @@
+import { expect, test } from 'vitest'
+import {
+	d1ContainsLikePattern,
+	d1MaxLikePatternBytes,
+	escapeLikePattern,
+} from './d1-like-pattern.ts'
+
+const byteLength = (value: string) => new TextEncoder().encode(value).length
+
+test('short queries are escaped and wrapped in wildcards', () => {
+	expect(d1ContainsLikePattern('kody')).toBe('%kody%')
+	expect(d1ContainsLikePattern('50%_off\\')).toBe('%50\\%\\_off\\\\%')
+	expect(d1ContainsLikePattern('a_b', { escape: false })).toBe('%a_b%')
+	expect(escapeLikePattern('%_\\')).toBe('\\%\\_\\\\')
+})
+
+test('long queries are trimmed to fit the D1 pattern limit', () => {
+	const stableUserId = 'f'.repeat(64)
+	const pattern = d1ContainsLikePattern(`"${stableUserId}"`)
+	expect(byteLength(pattern)).toBeLessThanOrEqual(d1MaxLikePatternBytes)
+	expect(pattern.startsWith('%"f')).toBe(true)
+	expect(pattern.endsWith('%')).toBe(true)
+
+	const emoji = d1ContainsLikePattern('🙂'.repeat(40))
+	expect(byteLength(emoji)).toBeLessThanOrEqual(d1MaxLikePatternBytes)
+	// Never split a multi-byte character.
+	expect(emoji).toMatch(/^%(🙂)*%$/u)
+})
+
+test('trimming never leaves a dangling escape before the closing wildcard', () => {
+	// 47 characters then an escaped percent: the trim lands right after the
+	// backslash, which must be dropped along with its escaped character.
+	const value = `${'a'.repeat(47)}%`
+	const pattern = d1ContainsLikePattern(value)
+	expect(byteLength(pattern)).toBeLessThanOrEqual(d1MaxLikePatternBytes)
+	expect(pattern).toBe(`%${'a'.repeat(47)}%`)
+	expect(pattern.endsWith('\\%')).toBe(false)
+})

--- a/packages/worker/src/d1-like-pattern.node.test.ts
+++ b/packages/worker/src/d1-like-pattern.node.test.ts
@@ -25,6 +25,12 @@ test('long queries are trimmed to fit the D1 pattern limit', () => {
 	expect(byteLength(emoji)).toBeLessThanOrEqual(d1MaxLikePatternBytes)
 	// Never split a multi-byte character.
 	expect(emoji).toMatch(/^%(🙂)*%$/u)
+
+	// A 45-byte ASCII prefix followed by a supplementary character: the trim
+	// lands inside the surrogate pair and must drop the whole code point.
+	const surrogateEdge = d1ContainsLikePattern(`${'a'.repeat(45)}🙂🙂`)
+	expect(surrogateEdge).toBe(`%${'a'.repeat(45)}%`)
+	expect(surrogateEdge.isWellFormed()).toBe(true)
 })
 
 test('trimming never leaves a dangling escape before the closing wildcard', () => {

--- a/packages/worker/src/d1-like-pattern.ts
+++ b/packages/worker/src/d1-like-pattern.ts
@@ -26,9 +26,14 @@ function utf8ByteLength(value: string) {
  * never splitting a multi-byte character.
  */
 function fitEscapedValue(value: string, budgetBytes: number) {
+	// Trim whole code points: slicing UTF-16 units can leave an unpaired
+	// surrogate, which TextEncoder counts as a 3-byte replacement and the
+	// resulting pattern would never match.
+	const codePoints = Array.from(value)
 	let result = value
-	while (result.length > 0 && utf8ByteLength(result) > budgetBytes) {
-		result = result.slice(0, -1)
+	while (codePoints.length > 0 && utf8ByteLength(result) > budgetBytes) {
+		codePoints.pop()
+		result = codePoints.join('')
 	}
 	// Dropping the character after a backslash would leave an escape that
 	// swallows the closing `%`; drop the backslash as well.

--- a/packages/worker/src/d1-like-pattern.ts
+++ b/packages/worker/src/d1-like-pattern.ts
@@ -1,0 +1,58 @@
+/**
+ * Cloudflare D1 rejects LIKE / GLOB patterns longer than 50 bytes with
+ * `D1_ERROR: LIKE or GLOB pattern too complex` (SQLite's
+ * SQLITE_MAX_LIKE_PATTERN_LENGTH is lowered from its 50,000 default). A user
+ * query or a 64-hex stable user id wrapped in `%…%` crosses that easily, so
+ * every bound LIKE pattern is built here and trimmed to fit.
+ *
+ * Use `instr(column, ?) > 0` instead when matching a fixed substring that may
+ * exceed the budget on its own (see `account/data-targets.ts`).
+ */
+export const d1MaxLikePatternBytes = 50
+
+const likeEscapePattern = /[\\%_]/g
+
+export function escapeLikePattern(value: string) {
+	return value.replace(likeEscapePattern, (char) => `\\${char}`)
+}
+
+function utf8ByteLength(value: string) {
+	return new TextEncoder().encode(value).length
+}
+
+/**
+ * Trim `value` (already escaped) so that `%${value}%` fits in
+ * `d1MaxLikePatternBytes`, never ending on a dangling escape backslash and
+ * never splitting a multi-byte character.
+ */
+function fitEscapedValue(value: string, budgetBytes: number) {
+	let result = value
+	while (result.length > 0 && utf8ByteLength(result) > budgetBytes) {
+		result = result.slice(0, -1)
+	}
+	// Dropping the character after a backslash would leave an escape that
+	// swallows the closing `%`; drop the backslash as well.
+	let trailingBackslashes = 0
+	for (let index = result.length - 1; index >= 0; index -= 1) {
+		if (result[index] !== '\\') break
+		trailingBackslashes += 1
+	}
+	if (trailingBackslashes % 2 === 1) {
+		result = result.slice(0, -1)
+	}
+	return result
+}
+
+/**
+ * `%value%` contains-pattern for `LIKE ? ESCAPE '\'`, escaped and trimmed to
+ * D1's pattern limit. Callers that want a raw (unescaped) token, such as the
+ * `[a-z0-9]+` community tokens, pass `{ escape: false }`.
+ */
+export function d1ContainsLikePattern(
+	value: string,
+	options: { escape?: boolean } = {},
+) {
+	const escaped = options.escape === false ? value : escapeLikePattern(value)
+	const budget = d1MaxLikePatternBytes - 2
+	return `%${fitEscapedValue(escaped, budget)}%`
+}

--- a/packages/worker/src/package-registry/repo.ts
+++ b/packages/worker/src/package-registry/repo.ts
@@ -1,3 +1,4 @@
+import { d1ContainsLikePattern } from '#worker/d1-like-pattern.ts'
 import { chunkArray } from '@kody-internal/shared/chunk.ts'
 import { parseTagsJson } from '@kody-internal/shared/tags-json.ts'
 import { isCommunityListingAhead } from '#universal/community-listing-ahead.ts'
@@ -502,10 +503,6 @@ export async function listSavedPackageCommunityProvenanceByIds(
 export type SavedPackageSearchSort = 'updated' | 'created' | 'name'
 
 /** Escape LIKE wildcards so user queries match literally. */
-function escapeLikePattern(value: string) {
-	return value.replaceAll(/[\\%_]/g, (character) => `\\${character}`)
-}
-
 function savedPackageSearchOrderBy(sort: SavedPackageSearchSort) {
 	switch (sort) {
 		case 'updated':
@@ -540,7 +537,7 @@ export async function searchSavedPackagesByUserId(
 	const params: Array<unknown> = [input.userId]
 	const query = input.query?.trim() ?? ''
 	if (query) {
-		const pattern = `%${escapeLikePattern(query.toLowerCase())}%`
+		const pattern = d1ContainsLikePattern(query.toLowerCase())
 		conditions.push(
 			`(LOWER(name) LIKE ? ESCAPE '\\'
 				OR LOWER(kody_id) LIKE ? ESCAPE '\\'

--- a/packages/worker/src/test-support/account-deletion.ts
+++ b/packages/worker/src/test-support/account-deletion.ts
@@ -333,15 +333,14 @@ export function createTestDb(
 								return { meta: { changes: changed } }
 							}
 							const replaceJsonMatch = lower.match(
-								/^update (\w+) set (\w+) = replace\(\2, \?, \?\) where \2 like \?$/,
+								/^update (\w+) set (\w+) = replace\(\2, \?, \?\) where instr\(\2, \?\) > 0$/,
 							)
 							if (replaceJsonMatch) {
 								const table = replaceJsonMatch[1] as string
 								const column = replaceJsonMatch[2] as string
 								const search = String(params[0])
 								const replacement = String(params[1])
-								const likePattern = String(params[2])
-								const needle = likePattern.replace(/^%/, '').replace(/%$/, '')
+								const needle = String(params[2])
 								let changed = 0
 								for (const row of rows[table] ?? []) {
 									const current = row[column]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

After #2029 deployed, the production purge got through inventory, billing, and OAuth cleanup and then failed at the atomic D1 step:

```
AccountDeletionCleanupError: Atomic D1 account deletion failed: D1_ERROR: LIKE or GLOB pattern too complex: SQLITE_ERROR
```

D1 lowers SQLite's `SQLITE_MAX_LIKE_PATTERN_LENGTH` to 50 bytes. The `replace_user_id_in_json_column` target in `account/data-targets.ts` bound `%"<stable_user_id>"%`, which is 68 bytes for a 64-hex id. Neither `node:sqlite` nor the hand-rolled fake D1 enforces that limit, so every test passed while every production deletion failed at the last step.

The same class of bug exists on user-facing search paths: `savedPackages` search, community listing/profile search, and the admin user filter all bind `%<user query>%`, so a query longer than 48 bytes returns a D1 error instead of results.

## What

- `account/data-targets.ts`: the JSON-column target now matches with `instr(column, ?) > 0` (no pattern limit, same substring semantics); the fake D1 in `test-support/account-deletion.ts` recognises the new shape.
- New `packages/worker/src/d1-like-pattern.ts`: `d1ContainsLikePattern(value, { escape })` escapes `\ % _` and trims the value so `%value%` fits in `d1MaxLikePatternBytes` (50), without splitting a multi-byte character or leaving a dangling escape. Replaces the two duplicated `escapeLikePattern` helpers.
- `package-registry/repo.ts`, `admin/users-data.ts`, `community/repo.ts`, `community/profile-repo.ts` build their patterns through it.

## Tests

- `d1-like-pattern.node.test.ts`: escaping, byte-bounded trimming (64-hex id, emoji), dangling-escape handling.
- `data-targets.node.test.ts`: new guard that no account-deletion statement uses `LIKE`/`GLOB` or binds a `%`-wrapped parameter, driven with a 64-hex stable user id.
- Existing deletion, export, retention, purge, community, package-registry, and admin suites pass (32 files / 168 tests in the affected set). Typecheck, lint, knip pass.

## After deploy

Run `adminUnverifiedAccountPurgeRun` against the remaining fenced account and confirm the first `unverified_account_purged` audit row.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b0f6a92a-81cd-4157-8b60-188c83ca84c0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b0f6a92a-81cd-4157-8b60-188c83ca84c0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved search handling across user, community, profile, and saved-package listings, including queries containing special characters.
  - Long search terms are now safely processed within database limits without breaking multi-byte characters.
  - Improved account data updates for records containing long user identifiers, preventing failures caused by database pattern limits.

- **Tests**
  - Added coverage for search-pattern escaping, length limits, Unicode handling, and account data updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->