### PR TITLE
Point /support at a better model instead of other deployments

### DIFF
--- a/e2e/support.spec.ts
+++ b/e2e/support.spec.ts
@@ -9,6 +9,10 @@ test('public support page works logged out', async ({ page }) => {
 	await expect(
 		page.getByRole('link', { name: 'support@kody.codes', exact: true }),
 	).toHaveAttribute('href', 'mailto:support@kody.codes')
+	await expect(
+		page.getByText(/try the same request with a better model/i),
+	).toBeVisible()
+	await expect(page.getByText(/other deployments/i)).not.toBeVisible()
 
 	await expect(
 		page.getByRole('navigation', { name: 'Footer' }).getByRole('link', {

--- a/packages/worker/client/routes/support.tsx
+++ b/packages/worker/client/routes/support.tsx
@@ -17,8 +17,13 @@ export function SupportRoute(_handle: Handle) {
 					<a href="mailto:support@kody.codes" mix={css(mutedLinkCss)}>
 						support@kody.codes
 					</a>
-					. Operators of other deployments use <code>support@&lt;apex&gt;</code>
 					.
+				</p>
+				<p mix={css(pageDescriptionCss)}>
+					A lot of what you experience as Kody is the agent you connected —
+					ChatGPT, Claude, Cursor, Codex, or another host. If something feels
+					off, try the same request with a better model before writing in.
+					Stronger models usually get more out of search, packages, and memory.
 				</p>
 			</header>
 


### PR DESCRIPTION
## Summary
- Drop the `support@<apex>` other-deployment line from `/support`.
- Tell people a lot of the experience is the connected agent, so try a stronger model before writing in.

## Test plan
- [ ] Open https://kody.codes/support (or the preview) logged out.
- [ ] Confirm `support@kody.codes` is still the mailto, and there is no apex/other-deployment copy.
- [ ] Confirm the better-model paragraph is visible.
- [ ] Click Support in the footer from `/` and land on `/support`.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `5142c75d7` · **Head:** `c845a9e04`

**Classification:** composes — no primitives added or changed; this PR only rewrites copy on the existing public support page.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `app-ui` | surfaces | composes — `/support` copy only |

### Change flow

A logged-out visitor hits `/support`; the Remix page still mailto's `support@kody.codes`, and now tells them to try a better connected-agent model before writing in.

```mermaid
sequenceDiagram
	actor Visitor
	participant appUi as app-ui
	Visitor->>appUi: GET /support
	appUi-->>Visitor: mailto support@kody.codes plus better-model note
```

</details>

<!-- system-recap:end -->

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **User Experience**
  * Added guidance explaining that responses may vary based on the connected agent or model.
  * Recommends trying the request with a stronger model before contacting support.
  * Removed the note referencing support addresses for other deployments.

* **Tests**
  * Updated end-to-end coverage to verify the new model guidance is visible and the removed deployment-support section is not displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->