### PR TITLE
Keep the footer nav in a two-row five-column grid

### DIFF
--- a/packages/worker/client/site-footer.node.test.ts
+++ b/packages/worker/client/site-footer.node.test.ts
@@ -4,7 +4,7 @@ import { expect, test } from 'vitest'
 import { SiteFooter } from '#client/site-footer.tsx'
 import { pageGutter } from '#universal/styles/style-primitives.ts'
 
-test('site footer nav wraps into columns instead of clipping or a single ladder', async () => {
+test('site footer nav uses a two-row five-column grid, then stacked auto-fit', async () => {
 	const html = await renderToString(
 		jsx(SiteFooter, { loggedIn: true, loginHref: '/login' }),
 	)
@@ -13,7 +13,8 @@ test('site footer nav wraps into columns instead of clipping or a single ladder'
 	expect(html).toContain('href="/account"')
 	expect(html).toContain('Make it portable.')
 	expect(html).toContain(pageGutter)
-	expect(html).toContain('flex-wrap: wrap')
+	expect(html).toContain('repeat(5, max-content)')
+	expect(html).not.toContain('flex-wrap: wrap')
 	expect(html).toContain(
 		'repeat(auto-fit, minmax(min(100%, 7.5rem), max-content))',
 	)

--- a/packages/worker/client/site-footer.node.test.ts
+++ b/packages/worker/client/site-footer.node.test.ts
@@ -18,7 +18,8 @@ test('site footer nav uses a two-row five-column grid, then stacked auto-fit', a
 	expect(html).toContain(
 		'repeat(auto-fit, minmax(min(100%, 7.5rem), max-content))',
 	)
-	expect(html).toContain('@media (max-width: 720px)')
+	expect(html).toContain('@media (max-width: 900px)')
+	expect(html).not.toContain('@media (max-width: 720px)')
 	expect(html).not.toContain('flex-shrink: 0')
 	expect(html).not.toContain('flex-direction: column')
 	expect(html).not.toContain('@media (max-width: 560px)')

--- a/packages/worker/client/site-footer.tsx
+++ b/packages/worker/client/site-footer.tsx
@@ -49,6 +49,10 @@ const footerCss = {
 	viewTransitionName: 'site-footer',
 }
 
+const footerLinkColumnMin = '7.5rem'
+/* Stay stacked until the 5-column nav fits beside brand + tagline. */
+const footerStackMq = '@media (max-width: 900px)'
+
 const footerInnerCss = {
 	maxWidth: layoutMaxWidths.extended,
 	marginInline: 'auto',
@@ -60,7 +64,7 @@ const footerInnerCss = {
 	gap: '1.2rem 2rem',
 	fontSize: '0.92rem',
 	color: colors.textMuted,
-	'@media (max-width: 720px)': {
+	[footerStackMq]: {
 		gridTemplateColumns: '1fr',
 		justifyItems: 'center',
 	},
@@ -85,8 +89,6 @@ const taglineCss = {
 	fontOpticalSizing: 'auto' as const,
 }
 
-const footerLinkColumnMin = '7.5rem'
-
 const footerNavCss = {
 	/* Wide footer: a two-row, five-column row-major grid, not flex-wrap.
 	   Wrapping left the first few links on one row and stacked the rest. */
@@ -107,7 +109,7 @@ const footerNavCss = {
 	/* Stacked footer: wrap into as many columns as the inner measure holds
 	   instead of one 10-row ladder or a nowrap row that clips. auto-fit with
 	   min(100%, …) collapses to a single column before it overflows. */
-	'@media (max-width: 720px)': {
+	[footerStackMq]: {
 		display: 'grid',
 		width: '100%',
 		gridTemplateColumns: `repeat(auto-fit, minmax(min(100%, ${footerLinkColumnMin}), max-content))`,

--- a/packages/worker/client/site-footer.tsx
+++ b/packages/worker/client/site-footer.tsx
@@ -88,11 +88,14 @@ const taglineCss = {
 const footerLinkColumnMin = '7.5rem'
 
 const footerNavCss = {
-	display: 'flex',
-	flexWrap: 'wrap' as const,
-	gap: '0.5rem 1.4rem',
+	/* Wide footer: a two-row, five-column row-major grid, not flex-wrap.
+	   Wrapping left the first few links on one row and stacked the rest. */
+	display: 'grid',
+	gridTemplateColumns: 'repeat(5, max-content)',
+	columnGap: '1.4rem',
+	rowGap: '0.35rem',
 	justifySelf: 'end',
-	justifyContent: 'flex-end',
+	justifyContent: 'end',
 	'& a': {
 		color: colors.textMuted,
 		textDecoration: 'none',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop the site footer nav from wrapping into a mixed one-row / stacked layout at mid widths. Keep the two-row, five-column grid as the wide end state.

## Why

`flex-wrap` left Community and Discord on a single row while Guides through Account stacked in pairs beside them. That mid-width wrap looks worse than the compact two-row grid the same links already use when the footer is a bit narrower.

## Summary

- Wide footer nav is `repeat(5, max-content)` so ten links fill two rows of five (Community → FAQ, then Support → Account / Log in).
- Stacked `auto-fit` columns now apply through `900px` so the 5-column grid only appears when it fits beside brand + tagline (it overflowed just above the old 720px cutover).
- Unit test asserts the five-column grid, the 900px stack breakpoint, and that `flex-wrap: wrap` is gone.

## Testing

- `npx vitest run packages/worker/client/site-footer.node.test.ts`
- `npm run test:push` (node-unit + workers-unit) on push
- Preview `https://kody-pr-2036.kody-a99.workers.dev/support` as `me@kentcdodds.com`: mid width should be a clean 2×5 grid, not mixed wrap; phone width stays stacked auto-fit

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `509acb34` · **Head:** `28b47aeb`

**Classification:** extends — `app-ui` site footer nav layout changes from wrapping flex to a fixed two-row, five-column grid, and the stacked breakpoint moves to 900px.

### Primitives touched

| Primitive | Group    | Impact                                                                 |
| --------- | -------- | ---------------------------------------------------------------------- |
| `app-ui`  | surfaces | extends — wide footer nav is a 5-column grid; stacked layout to 900px |

### Change flow

Public pages still render `SiteFooter`; only the nav layout rules change.

```mermaid
sequenceDiagram
	actor visitor as Visitor
	participant appUi as app-ui
	visitor->>appUi: load public page with SiteFooter
	appUi-->>visitor: viewport over 900px uses repeat(5, max-content)
	Note over appUi: max-width 900px still auto-fit stacked columns
```

### Before / after

```text
before (wide): display:flex; flex-wrap:wrap
after  (wide): display:grid; grid-template-columns: repeat(5, max-content)
before (stack): @media (max-width: 720px) auto-fit columns
after  (stack): @media (max-width: 900px) auto-fit columns
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a5f488d8-35eb-4633-b2c9-d1b8ff7e25cd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a5f488d8-35eb-4633-b2c9-d1b8ff7e25cd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the site footer navigation to use a two-row, five-column grid layout on wide screens.
  * Improved spacing between navigation columns and rows.
  * Adjusted navigation alignment within the footer.
  * Updated responsive behavior so the footer switches to a stacked layout at 900px and below.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->