### PR TITLE
Expand inbound webhooks so first-party invoke callers can migrate

### DIFF
--- a/docs/contributing/architecture/index.md
+++ b/docs/contributing/architecture/index.md
@@ -100,6 +100,9 @@ smoke does not prove MCP execute health.
 - [Values retirement runbook](./values-retirement-runbook.md): absorb values
   into memories, package storage, repos, secrets, and integrations
   ([ADR 0022](../decisions/0022-retire-values-primitive.md)).
+- [Invocation-token retirement runbook](./invocation-token-retirement-runbook.md):
+  drain HTTP invocation tokens after inbound webhooks cover first-party callers
+  ([ADR 0048](../decisions/0048-webhooks-replace-invocation-tokens.md)).
 - [Cleanup after migrations](../cleanup-after-migrations.md): drop leftovers in
   the same change when safe; otherwise open a GitHub issue.
 - [Primitives map](./primitives.yaml): stable taxonomy of system primitives and
@@ -112,7 +115,8 @@ smoke does not prove MCP execute health.
   with `npm run primitives:check`.
 - [Inbound webhooks](./webhooks.md): user-owned `POST /@:username/webhooks/...`
   ingress that dispatches to a bound saved-package export (HMAC verification,
-  ack/sync modes, delivery history via run records).
+  ack/sync or params input, caller Idempotency-Key, delivery history via run
+  records).
 - [MCP client servers](./mcp-client-servers.md): user-added remote MCP servers
   Kody connects to as a client (per-user hub Durable Object, OAuth flow, and
   `kody.mcp[...]` capability synthesis). Local-network systems reach Kody the

--- a/docs/contributing/architecture/invocation-token-retirement-runbook.md
+++ b/docs/contributing/architecture/invocation-token-retirement-runbook.md
@@ -13,7 +13,8 @@ per-declaration `rateLimitPerMinute` (default 60, max 600). Token UI, MCP
 `POST /@:user/api/package-invocations/…` path still exist. Do not send fleet
 email from this runbook.
 
-This change does **not** drop token tables.
+This change does **not** drop token tables. Tracker:
+[Cleanup #2038](https://github.com/kentcdodds/kody/issues/2038).
 
 ## Destination map
 

--- a/docs/contributing/architecture/invocation-token-retirement-runbook.md
+++ b/docs/contributing/architecture/invocation-token-retirement-runbook.md
@@ -1,0 +1,74 @@
+# Invocation-token retirement runbook
+
+Executable plan for draining HTTP package invocation tokens after inbound
+webhooks cover the invoke jobs (ADR
+[0048](../decisions/0048-webhooks-replace-invocation-tokens.md)). Modeled on the
+[values retirement runbook](./values-retirement-runbook.md).
+
+## Status
+
+Webhooks accept caller `Idempotency-Key`, `inputMode: "params"`, and a
+per-declaration `rateLimitPerMinute` (default 60, max 600). Token UI, MCP
+`packageGet.tokens`, token setup URLs, and the
+`POST /@:user/api/package-invocations/…` path still exist. Do not send fleet
+email from this runbook.
+
+This change does **not** drop token tables.
+
+## Destination map
+
+| Job                                      | Destination                                                                                                |
+| ---------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| Vendor POST (Sentry, GitHub, Stripe)     | Inbound webhooks, `inputMode: "request"`, optional HMAC + `replay`                                         |
+| First-party trusted client (gateway/CLI) | Inbound webhooks, `inputMode: "params"`, `Idempotency-Key`, `sync` or `ack`, one webhook per export        |
+| Multi-export / `*` token                 | One webhook declaration per export the client actually calls — no wildcard URL                             |
+| Author composition                       | Static `import` / `import(specifier)` / workflows ([0037](../decisions/0037-no-author-packages-invoke.md)) |
+
+Known first-party callers to migrate (operator account; follow-up, not this
+change):
+
+- `@kentcdodds/discord` — `./dispatch-message-created`,
+  `./dispatch-message-reaction-add`
+- `@kentcdodds/youtube-livestream-vod-manager` — `./process-video`
+- `@kentcdodds/bluesky` and `@kentcdodds/linkedin` — create/delete/get exports
+- `@kentcdodds/weekly-site-perf` — root `.` export
+- `@kentcdodds/raycast` — one webhook per export the extension calls (not `*`)
+
+## Remaining work
+
+1. Migrate the live invoke-token callers above to minted webhook URLs.
+2. Unadvertise tokens: remove token UI, MCP guides, `packageGet.tokens`, and
+   setup URLs after the soak (follow-up PR).
+3. Keep the HTTP token path as an unadvertised drain until leftover rows are 0.
+4. Drop `package_invocation_tokens` (and related columns) only after the count
+   below is 0. Do not drop tables in the same deploy that first hides the UI.
+
+Re-query leftover counts before the unadvertise PR and again before the
+table-drop PR:
+
+```sql
+SELECT
+	(SELECT COUNT(*) FROM package_invocation_tokens WHERE revoked_at IS NULL) AS active_tokens,
+	(SELECT COUNT(*) FROM package_invocation_tokens) AS token_rows,
+	(SELECT COUNT(DISTINCT user_id) FROM package_invocation_tokens) AS users_with_tokens;
+```
+
+Confirm the table name against current migrations before running this in
+production.
+
+## What not to do
+
+- Do not add `*` webhook URLs or a multi-export ingress path.
+- Do not keep tokens because webhooks exist. Webhooks are the knock.
+- Do not delete token tables in the capability PR.
+- Do not send user email as part of the drain.
+- Do not change the internal `invokePackageExport` host path webhooks already
+  use (synthetic token, `source: 'webhook'`).
+
+## Related
+
+- [0048 — Inbound HTTP is webhooks; invocation tokens drain](../decisions/0048-webhooks-replace-invocation-tokens.md)
+- [0037 — No author-facing `packages.invoke`](../decisions/0037-no-author-packages-invoke.md)
+- [0026 — Package-owned invocation tokens](../decisions/0026-package-owned-invocation-tokens.md)
+- [Inbound webhooks](./webhooks.md)
+- [Cleanup after migrations](../cleanup-after-migrations.md)

--- a/docs/contributing/architecture/webhooks.md
+++ b/docs/contributing/architecture/webhooks.md
@@ -55,10 +55,11 @@ export's first argument is the parsed JSON object. When that object has a
 `params` property that is itself a JSON object, the platform unwraps it
 (invoke-token envelope). `Idempotency-Key` (or JSON `idempotencyKey` in params
 mode) maps to the same package-invocation ledger with payload hashing
-(`include`): same key + same first argument replays; mismatch and in-progress
-are **409**. Request-mode caller keys hash the JSON body so `receivedAt` does
-not break retries. Delivery-id keys stay `ignore`. HMAC stays optional; the URL
-secret is enough for a trusted client.
+(`include`): same key + same first argument replays. On `sync`, mismatch and
+in-progress are **409**. `ack` returns **202** after enqueue; the queue consumer
+applies the same ledger asynchronously. Request-mode caller keys hash the JSON
+body so `receivedAt` does not break retries. Delivery-id keys stay `ignore`.
+HMAC stays optional; the URL secret is enough for a trusted client.
 
 `rateLimitPerMinute` overrides the default 60/min ceiling per minted endpoint.
 600/min is the documented maximum for gateway fan-in. The limiter still bounds a
@@ -80,9 +81,11 @@ Route: `POST /@:username/webhooks/:packageKodyId/:webhookName/:urlSecret`
    **not** record delivery history (avoids log-flush DoS and rate-limit side
    channels).
 4. Constant-time compare the URL secret against `url_secret_hash` (SHA-256).
-5. After a matching URL secret and a live declaration, enforce per-webhook rate
-   limit (declared `rateLimitPerMinute`, default 60, max 600) → **429** (no
-   delivery history on the limited path); payload cap 1 MB → **413**.
+5. After a matching URL secret, enforce per-webhook rate limit (declared
+   `rateLimitPerMinute` when the name is still live, otherwise the default 60,
+   max 600) → **429** (no delivery history on the limited path). Missing
+   declaration after republish rename/remove still **404**s and records a
+   rejected delivery, but only after that limit. Payload cap 1 MB → **413**.
 6. When verification is declared, resolve `secretName` from the owner's secret
    store (user/package scope via package storage context). Missing secret or
    HMAC mismatch → **401**, with a clear delivery-log error for missing secrets.
@@ -110,7 +113,10 @@ Route: `POST /@:username/webhooks/:packageKodyId/:webhookName/:urlSecret`
 Ack messages carry the accepted delivery id, idempotency key, scoped endpoint
 identity, export name, and already-authenticated payload (inline `body`, or a
 user-scoped KV key when the body was spilled). Queue retries reuse that exact
-idempotency key. Transient ledger lookup/terminal-persistence failures and
+idempotency key. Request-mode caller `Idempotency-Key` messages set
+`callerIdempotency` so the consumer hashes the JSON body (same as sync).
+Unique-key ack claims omit that flag and hash the `{ webhook, request }`
+envelope. Transient ledger lookup/terminal-persistence failures and
 still-in-progress replays are retried; terminal package errors are recorded and
 acknowledged. A missing spilled body is a terminal failure
 (`ack_queue_payload_missing`). The package export sandbox retains its normal

--- a/docs/contributing/architecture/webhooks.md
+++ b/docs/contributing/architecture/webhooks.md
@@ -8,19 +8,24 @@ bound saved-package export. End-user setup lives in
 
 Package-invocation HTTP endpoints require `Authorization: Bearer`. Many webhook
 providers cannot set custom Authorization headers. Webhook endpoints are the
-credential-in-URL sibling of per-user [email](../../use/email-primitives.md)
-inboxes, declared alongside other package surfaces in
-`package.json#kody.webhooks` (same family as `kody.subscriptions`).
+external HTTP knock: credential-in-URL sibling of per-user
+[email](../../use/email-primitives.md) inboxes, declared alongside other package
+surfaces in `package.json#kody.webhooks` (same family as `kody.subscriptions`).
+First-party trusted clients use the same path (URL secret, no Bearer).
+Invocation tokens are an unadvertised drain; see
+[0048](../decisions/0048-webhooks-replace-invocation-tokens.md).
 
 ## Manifest contract
 
 Packages declare webhooks as an array under `kody.webhooks`. Each entry has a
-slug `name`, an `export` that must exist in `package.json#exports`, optional
-`responseMode` (`ack` default / `sync`), optional HMAC `verification` that
-references a secret-store name (`secretName`) — never an inline secret — and
-optional `replay` for timestamp windows and delivery-id dedupe. Parsing and
-export existence checks live in `parseAuthoredPackageJson` /
-`listPackageWebhooks` (`packages/worker/src/package-registry/`).
+slug `name`, an `export` that must exist in `package.json#exports` (one name ↔
+one export; no `*`), optional `responseMode` (`ack` default / `sync`), optional
+`inputMode` (`request` default / `params`), optional `rateLimitPerMinute`
+(default 60, max 600), optional HMAC `verification` that references a
+secret-store name (`secretName`) — never an inline secret — and optional
+`replay` for timestamp windows and delivery-id dedupe. Parsing and export
+existence checks live in `parseAuthoredPackageJson` / `listPackageWebhooks`
+(`packages/worker/src/package-registry/`).
 
 HMAC `verification` signs the raw body by default (`signedPayload` omitted or
 `'body'`). Set `signedPayload` to `'timestamp.body'` when the provider HMAC
@@ -45,6 +50,20 @@ is rotated.
   delivery id hashes to a different key, so it cannot reuse another event's
   acknowledgement.
 
+`inputMode: "params"` is the first-party trusted-client contract. The bound
+export's first argument is the parsed JSON object. When that object has a
+`params` property that is itself a JSON object, the platform unwraps it
+(invoke-token envelope). `Idempotency-Key` (or JSON `idempotencyKey` in params
+mode) maps to the same package-invocation ledger with payload hashing
+(`include`): same key + same first argument replays; mismatch and in-progress
+are **409**. Request-mode caller keys hash the JSON body so `receivedAt` does
+not break retries. Delivery-id keys stay `ignore`. HMAC stays optional; the URL
+secret is enough for a trusted client.
+
+`rateLimitPerMinute` overrides the default 60/min ceiling per minted endpoint.
+600/min is the documented maximum for gateway fan-in. The limiter still bounds a
+leaked URL.
+
 Declaring a webhook does **not** open ingress. A minted URL secret in D1 does.
 
 ## Ingress path
@@ -61,9 +80,9 @@ Route: `POST /@:username/webhooks/:packageKodyId/:webhookName/:urlSecret`
    **not** record delivery history (avoids log-flush DoS and rate-limit side
    channels).
 4. Constant-time compare the URL secret against `url_secret_hash` (SHA-256).
-5. After a matching URL secret, enforce per-webhook rate limit (~60/min) →
-   **429** (no delivery history on the limited path); payload cap 1 MB →
-   **413**.
+5. After a matching URL secret and a live declaration, enforce per-webhook rate
+   limit (declared `rateLimitPerMinute`, default 60, max 600) → **429** (no
+   delivery history on the limited path); payload cap 1 MB → **413**.
 6. When verification is declared, resolve `secretName` from the owner's secret
    store (user/package scope via package storage context). Missing secret or
    HMAC mismatch → **401**, with a clear delivery-log error for missing secrets.

--- a/docs/contributing/decisions/0037-no-author-packages-invoke.md
+++ b/docs/contributing/decisions/0037-no-author-packages-invoke.md
@@ -23,9 +23,9 @@ Authors do not get `packages.invoke`.
   until that helper is deleted
   ([#1750](https://github.com/kentcdodds/kody/issues/1750)).
 - Exactly-once → workflows. Do not keep a keyed invoke beside them.
-- External callers → HTTP invocation tokens
-  (`POST /@:user/api/package-invocations/…`). That path stays. It is not
-  `packages.invoke`. The ingress half is revisited by
+- External callers → inbound webhooks. HTTP invocation tokens
+  (`POST /@:user/api/package-invocations/…`) remain only as an unadvertised
+  drain. That path is not `packages.invoke`. See
   [0048](./0048-webhooks-replace-invocation-tokens.md).
 
 The `kody:runtime` helper stays quarantined for a soak so already-published

--- a/docs/contributing/decisions/0037-no-author-packages-invoke.md
+++ b/docs/contributing/decisions/0037-no-author-packages-invoke.md
@@ -25,7 +25,8 @@ Authors do not get `packages.invoke`.
 - Exactly-once → workflows. Do not keep a keyed invoke beside them.
 - External callers → HTTP invocation tokens
   (`POST /@:user/api/package-invocations/…`). That path stays. It is not
-  `packages.invoke`.
+  `packages.invoke`. The ingress half is revisited by
+  [0048](./0048-webhooks-replace-invocation-tokens.md).
 
 The `kody:runtime` helper stays quarantined for a soak so already-published
 packages do not break, then the folder is deleted.

--- a/docs/contributing/decisions/0048-webhooks-replace-invocation-tokens.md
+++ b/docs/contributing/decisions/0048-webhooks-replace-invocation-tokens.md
@@ -1,0 +1,40 @@
+# 0048 — Inbound HTTP is webhooks; invocation tokens drain
+
+- **Status:** accepted
+- **Date:** 2026-09-03
+
+## Context
+
+[0037](./0037-no-author-packages-invoke.md) kept HTTP invocation tokens
+(`POST /@:user/api/package-invocations/…`) as the external knock after dropping
+author-facing `packages.invoke`. First-party callers on the operator account
+(Discord gateway, YouTube WebSub, Bluesky/LinkedIn launch, weekly-site-perf,
+Raycast) still use those tokens. Inbound webhooks already cover vendor POST
+(Sentry/Stripe/GitHub) with a URL secret and optional HMAC, but they did not
+accept caller `Idempotency-Key`, pass JSON as the export first argument, or
+allow a burst ceiling above ~60/min.
+
+A second HTTP grant (`*` tokens, Bearer, invoke envelope) next to webhooks is
+the values-shaped leftover: two knocks for one job. Webhooks already bind one
+declared name to one export. There is no product need for a multi-export URL.
+
+## Decision
+
+Webhooks are the only advertised external HTTP knock. Invocation tokens become
+an unadvertised drain after webhooks cover the invoke jobs (caller
+`Idempotency-Key`, `inputMode: "params"`, configurable rate limit with a
+documented max). Do not add `*` / multi-export webhook URLs. Do not delete token
+tables, UI, or MCP token copy in the same change that makes webhooks capable.
+
+The
+[invocation-token retirement runbook](../architecture/invocation-token-retirement-runbook.md)
+is the executable plan: values-style soak, then drop when leftover token rows
+are 0.
+
+## Consequences
+
+Trusted clients mint a webhook URL, declare one webhook per export they call,
+and POST JSON with `Idempotency-Key`. Vendor HMAC handlers stay on default
+`inputMode: "request"`. Agents stop seeing invocation tokens as the way in once
+the drain is unadvertised. Revisit only if a first-party caller cannot express
+its invoke shape as one webhook per export plus the params/idempotency contract.

--- a/docs/contributing/decisions/index.md
+++ b/docs/contributing/decisions/index.md
@@ -60,7 +60,8 @@ Open these before proposing a new primitive, surface, or storage home.
   — static import, `import(specifier)`, or workflows; HTTP-token ingress is
   [0048](./0048-webhooks-replace-invocation-tokens.md)
 - [0048 — Inbound HTTP is webhooks; invocation tokens drain](./0048-webhooks-replace-invocation-tokens.md)
-  — no `*` webhook URLs; tokens unadvertise after leftover rows are 0
+  — no `*` webhook URLs; token surfaces unadvertise after the soak; the HTTP
+  token path drains until leftover rows are 0
 - [0015 — Wait on Skills over MCP; serve skill content via packages](./0015-skills-over-mcp-wait.md)
 - [0017 — Hosted package apps use per-user subdomains; same-owner isolation deferred](./0017-per-user-package-app-subdomains.md)
 - [0020 — Repo sessions spill Workspace objects to R2; do not adopt `@cloudflare/computer`](./0020-repo-session-workspace-r2-not-computer.md)

--- a/docs/contributing/decisions/index.md
+++ b/docs/contributing/decisions/index.md
@@ -57,7 +57,10 @@ Open these before proposing a new primitive, surface, or storage home.
   — supersedes 0035 and the remaining execute-live half of 0014; fork, then use
   the copy
 - [0037 — No author-facing `packages.invoke`](./0037-no-author-packages-invoke.md)
-  — static import, `import(specifier)`, or workflows; HTTP tokens stay
+  — static import, `import(specifier)`, or workflows; HTTP-token ingress is
+  [0048](./0048-webhooks-replace-invocation-tokens.md)
+- [0048 — Inbound HTTP is webhooks; invocation tokens drain](./0048-webhooks-replace-invocation-tokens.md)
+  — no `*` webhook URLs; tokens unadvertise after leftover rows are 0
 - [0015 — Wait on Skills over MCP; serve skill content via packages](./0015-skills-over-mcp-wait.md)
 - [0017 — Hosted package apps use per-user subdomains; same-owner isolation deferred](./0017-per-user-package-app-subdomains.md)
 - [0020 — Repo sessions spill Workspace objects to R2; do not adopt `@cloudflare/computer`](./0020-repo-session-workspace-r2-not-computer.md)

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -60,7 +60,9 @@ style, tests, MCP capabilities, and runtime architecture.
 - [`packages.invoke` prefix migration](./package-invoke-prefix-migration.md)
   (soak telemetry for the quarantined helper leftover)
 - [Public packages](./community-packages.md)
-- [External package invocation API](./package-invocation-api.md)
+- [External package invocation API](./package-invocation-api.md) (unadvertised
+  drain; first-party HTTP is [inbound webhooks](../use/webhooks.md))
+- [Invocation-token retirement runbook](./architecture/invocation-token-retirement-runbook.md)
 - [Adding capabilities](./adding-capabilities.md)
 - [Search entity plugins](./search-entity-plugins.md) (plugin module + registry,
   result/detail unions, list markdown, detail routing, public type lists)

--- a/docs/contributing/package-invocation-api.md
+++ b/docs/contributing/package-invocation-api.md
@@ -3,6 +3,10 @@
 Use this API when a trusted external service should invoke a saved package
 export inside Kody without going through the interactive MCP transport.
 
+New first-party callers should use [inbound webhooks](../use/webhooks.md)
+(`inputMode: "params"`, `Idempotency-Key`, minted URL, no Bearer). This page
+documents the invocation-token drain that still works.
+
 A stable webhook proxy is a representative caller:
 
 1. the external proxy owns the provider-specific connection or webhook ingress

--- a/docs/use/webhooks.md
+++ b/docs/use/webhooks.md
@@ -240,9 +240,11 @@ Arrays and non-objects are **400** `invalid_params`. Default
 
 Send **`Idempotency-Key`** (standard header). In `params` mode, JSON
 `idempotencyKey` is accepted when the header is absent. Same key + same payload
-replays the stored result; a different payload is **409**
-`idempotency_mismatch`; an in-progress key is **409** `invocation_in_progress`.
-This works without HMAC — the URL secret is the credential.
+replays the stored result. On `sync`, a different payload is **409**
+`idempotency_mismatch` and an in-progress key is **409**
+`invocation_in_progress`. `ack` still returns **202** after enqueue; the
+consumer records the ledger outcome. This works without HMAC — the URL secret is
+the credential.
 
 Caller keys use the same package-invocation idempotency ledger as
 `replay.deliveryIdHeader`. Delivery-id keys still match by id alone (vendor

--- a/docs/use/webhooks.md
+++ b/docs/use/webhooks.md
@@ -5,9 +5,13 @@ Kody inbound webhooks are **package-centered**: you declare them in
 provider (Sentry, GitHub, Stripe, or any generic sender) at that URL. Each
 delivery invokes the bound package export.
 
-This is the HTTP sibling of [email primitives](./email-primitives.md). Unlike
-[package invocation bearer tokens](../contributing/package-invocation-api.md),
-webhook URLs work with providers that cannot set custom `Authorization` headers.
+This is the HTTP sibling of [email primitives](./email-primitives.md). Webhooks
+are the external HTTP knock: vendor providers (Sentry, GitHub, Stripe) and
+first-party trusted clients (gateway proxies, CLIs) both POST to a minted URL.
+[Package invocation bearer tokens](../contributing/package-invocation-api.md)
+remain as an unadvertised drain; new callers use webhooks.
+
+There is no `*` / multi-export URL. One declared webhook name binds one export.
 
 Treat every minted URL as a **credential**. The URL secret is returned only on
 mint/rotate and is never stored in plaintext.
@@ -44,17 +48,24 @@ Rules:
 
 - `name` is a slug unique within the package.
 - `export` must reference a declared `package.json#exports` entry (validated at
-  save/publish).
+  save/publish). One webhook name ↔ one export. There is no wildcard export.
 - `responseMode` is `ack` (default) or `sync`.
+- `inputMode` is `request` (default) or `params`. Vendor handlers stay on
+  `request`. First-party trusted clients that send invoke-shaped JSON use
+  `params` (see [Trusted clients](#trusted-clients)).
+- `rateLimitPerMinute` is optional. Default **60**. Maximum **600** (gateway
+  fan-in). A leaked URL is still bounded; there is no unlimited setting.
 - `verification.secretName` references a **named secret in your secret store** —
   never an inline secret value. The platform resolves it at delivery time; if
-  the secret is missing, the delivery is rejected and logged.
+  the secret is missing, the delivery is rejected and logged. First-party
+  trusted clients omit `verification` and rely on the URL secret.
 - `verification.signedPayload` is `'body'` (default) or `'timestamp.body'`. Use
   `'timestamp.body'` when the provider HMAC covers
   `` `${timestamp}.${rawBody}` ``.
 - `replay` is optional. Without it, body-only HMAC is **replayable**: anyone who
   observes one legitimate signed delivery can POST it again. Opt in per webhook
-  with a timestamp window and/or a unique delivery id.
+  with a timestamp window and/or a unique delivery id. Trusted clients send
+  `Idempotency-Key` instead of `replay.deliveryIdHeader`.
 
 Declaring a webhook does **not** open ingress by itself.
 
@@ -81,7 +92,8 @@ delivery history also appears under [Activity](./activity.md)
 - Unknown / unminted / disabled / renamed-away / wrong secret → **404** (no
   distinction).
 - Payload > **1 MB** → **413**.
-- About **60 requests/minute** per minted webhook → **429**.
+- Rate limit per minted webhook → **429**. Default **60**/min; override with
+  `rateLimitPerMinute` up to **600**.
 - `ack`: **202** `{ "ok": true }` after Kody durably queues the delivery; the
   export runs in the background. Bodies use the same **1 MB** cap as sync;
   oversized queue messages spill to ephemeral storage until the consumer runs. A
@@ -197,6 +209,49 @@ window:
 `stripe-signature` reads `t=<unix>` from the header. Deliveries whose timestamp
 is missing, unparseable, or older than `toleranceSeconds` (default 300) are
 rejected with the same generic 401 as a bad HMAC.
+
+## Trusted clients
+
+A first-party caller (Discord gateway proxy, YouTube WebSub worker, Raycast
+extension, social-launch client) mints a webhook URL and POSTs JSON. No
+`Authorization: Bearer`. One webhook per export they actually call.
+
+```json
+{
+	"name": "message-created",
+	"export": "./dispatch-message-created",
+	"responseMode": "sync",
+	"inputMode": "params",
+	"rateLimitPerMinute": 600
+}
+```
+
+Use `sync` when the caller needs the export JSON (or a **409** idempotency
+conflict). Use `ack` when the caller only needs acceptance; the queue consumer
+applies the same idempotency ledger.
+
+`inputMode: "params"` passes a JSON object as the export's **first argument**,
+matching invocation-token `params`. If the body is the invoke envelope
+(`{ "params": { … }, "idempotencyKey": "…" }`), the platform unwraps `params`. A
+top-level JSON object without a `params` object is the first argument as-is.
+Arrays and non-objects are **400** `invalid_params`. Default
+`inputMode: "request"` is unchanged: the export still receives
+`{ webhook, request }`.
+
+Send **`Idempotency-Key`** (standard header). In `params` mode, JSON
+`idempotencyKey` is accepted when the header is absent. Same key + same payload
+replays the stored result; a different payload is **409**
+`idempotency_mismatch`; an in-progress key is **409** `invocation_in_progress`.
+This works without HMAC — the URL secret is the credential.
+
+Caller keys use the same package-invocation idempotency ledger as
+`replay.deliveryIdHeader`. Delivery-id keys still match by id alone (vendor
+retries change `receivedAt`). Caller keys hash the payload: in `params` mode
+that is the export first argument; in `request` mode it is the JSON body so
+`receivedAt` does not break retries.
+
+Do not declare a `*` webhook. A client that calls several exports gets one
+webhook declaration per export.
 
 ## Lifecycle
 

--- a/packages/worker/src/mcp/capabilities/webhooks/shared.ts
+++ b/packages/worker/src/mcp/capabilities/webhooks/shared.ts
@@ -43,6 +43,8 @@ export const listedWebhookSchema = z.object({
 	export_name: z.string(),
 	description: z.string().nullable(),
 	response_mode: z.enum(['ack', 'sync']),
+	input_mode: z.enum(['request', 'params']),
+	rate_limit_per_minute: z.number().int(),
 	verification: webhookVerificationPublicSchema,
 	replay: webhookReplayPublicSchema,
 	minted: z
@@ -103,6 +105,8 @@ export function toListedWebhookCapability(webhook: {
 	exportName: string
 	description: string | null
 	responseMode: 'ack' | 'sync'
+	inputMode: 'request' | 'params'
+	rateLimitPerMinute: number
 	verification: z.infer<typeof webhookVerificationPublicSchema>
 	replay?: z.infer<typeof webhookReplayPublicSchema>
 	minted: boolean
@@ -118,6 +122,8 @@ export function toListedWebhookCapability(webhook: {
 		export_name: webhook.exportName,
 		description: webhook.description,
 		response_mode: webhook.responseMode,
+		input_mode: webhook.inputMode,
+		rate_limit_per_minute: webhook.rateLimitPerMinute,
 		verification: webhook.verification,
 		replay: webhook.replay ?? null,
 		minted: webhook.minted,

--- a/packages/worker/src/mcp/capabilities/webhooks/webhook-capabilities.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/webhooks/webhook-capabilities.node.test.ts
@@ -70,6 +70,8 @@ test('webhook capabilities expose mint once and never leak secrets on list', asy
 			exportName: './handle-sentry-webhook',
 			description: null,
 			responseMode: 'ack',
+			inputMode: 'request',
+			rateLimitPerMinute: 60,
 			verification: {
 				type: 'hmac-sha256',
 				header: 'sentry-hook-signature',

--- a/packages/worker/src/mcp/tools/search-entity-plugins/package.ts
+++ b/packages/worker/src/mcp/tools/search-entity-plugins/package.ts
@@ -20,6 +20,7 @@ import {
 import { buildPackageImportSpecifier } from '#worker/package-registry/package-import-specifier.ts'
 import { buildPackageReadmeIntent } from '#worker/package-registry/package-readme.ts'
 import { savedPackageVectorId } from '#worker/package-registry/repo.ts'
+import { webhookDefaultRateLimitPerMinute } from '#worker/package-registry/types.ts'
 
 import { maxFusedPackageCandidates } from '../search-constants.ts'
 import { type SearchEntityPlugin } from '../search-entity-plugin.ts'
@@ -511,6 +512,9 @@ export const packageSearchEntityPlugin = {
 			name: webhook.name,
 			exportName: webhook.export,
 			responseMode: webhook.responseMode ?? 'ack',
+			inputMode: webhook.inputMode ?? 'request',
+			rateLimitPerMinute:
+				webhook.rateLimitPerMinute ?? webhookDefaultRateLimitPerMinute,
 			replay: webhook.replay ?? null,
 			signedPayload: webhook.verification?.signedPayload ?? null,
 		}))
@@ -585,7 +589,14 @@ export const packageSearchEntityPlugin = {
 					].filter((value): value is string => value != null)
 					const replaySuffix =
 						replayParts.length > 0 ? ` (${replayParts.join(', ')})` : ''
-					return `- ${formatMarkdownInlineCode(webhook.name)} → ${formatMarkdownInlineCode(webhook.exportName)} (${webhook.responseMode}${replaySuffix})`
+					const modeParts = [
+						webhook.responseMode,
+						webhook.inputMode === 'params' ? 'params' : null,
+						webhook.rateLimitPerMinute !== webhookDefaultRateLimitPerMinute
+							? `${webhook.rateLimitPerMinute}/min`
+							: null,
+					].filter((value): value is string => value != null)
+					return `- ${formatMarkdownInlineCode(webhook.name)} → ${formatMarkdownInlineCode(webhook.exportName)} (${modeParts.join(', ')}${replaySuffix})`
 				}),
 			)
 		}

--- a/packages/worker/src/mcp/tools/search-format-types.ts
+++ b/packages/worker/src/mcp/tools/search-format-types.ts
@@ -332,6 +332,8 @@ export type SearchEntityDetailStructured =
 				name: string
 				exportName: string
 				responseMode: 'ack' | 'sync'
+				inputMode: 'request' | 'params'
+				rateLimitPerMinute: number
 				replay: {
 					timestampHeader?: string
 					timestampFormat?:

--- a/packages/worker/src/package-invocations/common.ts
+++ b/packages/worker/src/package-invocations/common.ts
@@ -43,6 +43,12 @@ export type PackageInvocationRequest = {
 	 * delivery cannot reuse another event's acknowledgement.
 	 */
 	idempotencyParamsHash?: 'ignore'
+	/**
+	 * When set, the ledger hashes this object instead of `params`. Webhook
+	 * request-mode caller keys use it so `receivedAt` (and other volatile
+	 * envelope fields) do not turn a retry into `idempotency_mismatch`.
+	 */
+	idempotencyHashParams?: Record<string, unknown>
 	source?: string | null
 	topic?: string | null
 }

--- a/packages/worker/src/package-invocations/http-invoke.ts
+++ b/packages/worker/src/package-invocations/http-invoke.ts
@@ -295,5 +295,8 @@ export async function invokePackageExportWithToolFactories(input: {
 		...(input.request.idempotencyParamsHash === 'ignore'
 			? { idempotencyParamsHash: 'ignore' as const }
 			: {}),
+		...(input.request.idempotencyHashParams
+			? { idempotencyHashParams: input.request.idempotencyHashParams }
+			: {}),
 	})
 }

--- a/packages/worker/src/package-invocations/idempotent-module-invocation.ts
+++ b/packages/worker/src/package-invocations/idempotent-module-invocation.ts
@@ -84,6 +84,7 @@ export async function invokeSavedPackageModule(input: {
 	params?: Record<string, unknown>
 	idempotencyKey: string
 	idempotencyParamsHash?: 'ignore'
+	idempotencyHashParams?: Record<string, unknown>
 	source: string | null
 	topic: string | null
 	notFoundCode: 'export_not_found' | 'subscription_not_found'
@@ -104,7 +105,10 @@ export async function invokeSavedPackageModule(input: {
 	const requestHash = await createRequestHash({
 		packageId: input.savedPackage.id,
 		exportName: input.invocationName,
-		params: input.idempotencyParamsHash === 'ignore' ? undefined : input.params,
+		params:
+			input.idempotencyParamsHash === 'ignore'
+				? undefined
+				: (input.idempotencyHashParams ?? input.params),
 		source: input.source,
 		topic: input.topic,
 	})

--- a/packages/worker/src/package-registry/manifest.node.test.ts
+++ b/packages/worker/src/package-registry/manifest.node.test.ts
@@ -274,6 +274,8 @@ test('parseAuthoredPackageJson accepts kody.webhooks and rejects unknown exports
 			exportName: './handle-sentry-webhook',
 			description: null,
 			responseMode: 'ack',
+			inputMode: 'request',
+			rateLimitPerMinute: 60,
 			verification: {
 				type: 'hmac-sha256',
 				header: 'sentry-hook-signature',
@@ -364,6 +366,84 @@ test('parseAuthoredPackageJson accepts kody.webhooks and rejects unknown exports
 			manifestPath: 'package.json',
 		}),
 	).toThrow(/header/)
+
+	const trusted = parseAuthoredPackageJson({
+		content: JSON.stringify({
+			name: '@kentcdodds/discord',
+			exports: {
+				'./dispatch-message-created': './src/dispatch-message-created.ts',
+			},
+			kody: {
+				id: 'discord',
+				description: 'Discord gateway proxy',
+				webhooks: [
+					{
+						name: 'message-created',
+						export: './dispatch-message-created',
+						responseMode: 'sync',
+						inputMode: 'params',
+						rateLimitPerMinute: 600,
+					},
+				],
+			},
+		}),
+		manifestPath: 'package.json',
+	})
+	expect(buildPackageSearchProjection(trusted).webhooks).toEqual([
+		{
+			name: 'message-created',
+			exportName: './dispatch-message-created',
+			description: null,
+			responseMode: 'sync',
+			inputMode: 'params',
+			rateLimitPerMinute: 600,
+			verification: null,
+			replay: null,
+		},
+	])
+
+	expect(() =>
+		parseAuthoredPackageJson({
+			content: JSON.stringify({
+				name: '@kentcdodds/discord',
+				exports: {
+					'./dispatch-message-created': './src/dispatch-message-created.ts',
+				},
+				kody: {
+					id: 'discord',
+					description: 'Discord gateway proxy',
+					webhooks: [
+						{
+							name: 'message-created',
+							export: './dispatch-message-created',
+							rateLimitPerMinute: 601,
+						},
+					],
+				},
+			}),
+			manifestPath: 'package.json',
+		}),
+	).toThrow(/rateLimitPerMinute/)
+
+	expect(() =>
+		parseAuthoredPackageJson({
+			content: JSON.stringify({
+				name: '@kentcdodds/raycast',
+				exports: { './search': './src/search.ts' },
+				kody: {
+					id: 'raycast',
+					description: 'Raycast',
+					webhooks: [
+						{
+							name: 'star',
+							export: '*',
+						},
+					],
+				},
+			}),
+			manifestPath: 'package.json',
+		}),
+	).toThrow(/export "\*"/)
 })
 
 test('parseAuthoredPackageJson accepts webhook replay fields and rejects unknown timestampFormat', () => {
@@ -404,6 +484,8 @@ test('parseAuthoredPackageJson accepts webhook replay fields and rejects unknown
 			exportName: './handle-stripe-webhook',
 			description: null,
 			responseMode: 'ack',
+			inputMode: 'request',
+			rateLimitPerMinute: 60,
 			verification: {
 				type: 'hmac-sha256',
 				header: 'Stripe-Signature',

--- a/packages/worker/src/package-registry/manifest.ts
+++ b/packages/worker/src/package-registry/manifest.ts
@@ -4,6 +4,7 @@ import { z } from 'zod'
 import { parseModuleSource, type ModuleAstNode } from '#worker/module-source.ts'
 import {
 	authoredPackageJsonSchema,
+	webhookDefaultRateLimitPerMinute,
 	type AuthoredPackageJson,
 	type PackageExportTarget,
 	type PackageRetrieverScope,
@@ -266,6 +267,8 @@ export type PackageWebhookManifestEntry = {
 	exportName: string
 	description: string | null
 	responseMode: 'ack' | 'sync'
+	inputMode: 'request' | 'params'
+	rateLimitPerMinute: number
 	verification: {
 		type: 'hmac-sha256' | 'hmac-sha1'
 		header: string
@@ -295,6 +298,9 @@ export function listPackageWebhooks(
 			exportName: normalizePackageExportKey(webhook.export),
 			description: webhook.description?.trim() || null,
 			responseMode: webhook.responseMode ?? 'ack',
+			inputMode: webhook.inputMode ?? 'request',
+			rateLimitPerMinute:
+				webhook.rateLimitPerMinute ?? webhookDefaultRateLimitPerMinute,
 			verification: webhook.verification
 				? {
 						type: webhook.verification.type,
@@ -1456,6 +1462,10 @@ export function buildPackageSearchDocument(
 			webhook.exportName,
 			webhook.description ?? '',
 			webhook.responseMode,
+			webhook.inputMode === 'params' ? 'input:params' : '',
+			webhook.rateLimitPerMinute !== webhookDefaultRateLimitPerMinute
+				? `rate:${webhook.rateLimitPerMinute}`
+				: '',
 			webhook.verification ? `verify:${webhook.verification.header}` : '',
 			webhook.verification?.signedPayload
 				? `signed:${webhook.verification.signedPayload}`

--- a/packages/worker/src/package-registry/types.ts
+++ b/packages/worker/src/package-registry/types.ts
@@ -122,12 +122,25 @@ export const packageWebhookReplaySchema = z
 
 export type PackageWebhookReplay = z.infer<typeof packageWebhookReplaySchema>
 
+export const webhookInputModeValues = ['request', 'params'] as const
+export type WebhookInputMode = (typeof webhookInputModeValues)[number]
+
+export const webhookDefaultRateLimitPerMinute = 60
+export const webhookMaxRateLimitPerMinute = 600
+
 export const packageWebhookDefinitionSchema = z
 	.object({
 		name: z.string().regex(kodyPackageIdPattern),
 		export: z.string().min(1),
 		description: z.string().min(1).optional(),
 		responseMode: z.enum(['ack', 'sync']).optional(),
+		inputMode: z.enum(webhookInputModeValues).optional(),
+		rateLimitPerMinute: z
+			.number()
+			.int()
+			.min(1)
+			.max(webhookMaxRateLimitPerMinute)
+			.optional(),
 		verification: packageWebhookVerificationSchema.optional(),
 		replay: packageWebhookReplaySchema.optional(),
 	})

--- a/packages/worker/src/webhooks/delivery.ts
+++ b/packages/worker/src/webhooks/delivery.ts
@@ -4,7 +4,6 @@ import { recordRunRecord } from '#worker/run-records/service.ts'
 import {
 	type WebhookDeliveryOutcome,
 	type WebhookEndpointRecord,
-	type WebhookExportParams,
 } from './types.ts'
 
 export async function recordWebhookDelivery(input: {
@@ -68,9 +67,10 @@ export async function dispatchWebhookInvocation(input: {
 	>
 	packageKodyId: string
 	exportName: string
-	params: WebhookExportParams
+	params: Record<string, unknown>
 	idempotencyKey: string
 	idempotencyParamsHash?: 'ignore'
+	idempotencyHashParams?: Record<string, unknown>
 }) {
 	return await invokePackageExport({
 		env: input.env,
@@ -88,6 +88,9 @@ export async function dispatchWebhookInvocation(input: {
 			idempotencyKey: input.idempotencyKey,
 			...(input.idempotencyParamsHash === 'ignore'
 				? { idempotencyParamsHash: 'ignore' as const }
+				: {}),
+			...(input.idempotencyHashParams
+				? { idempotencyHashParams: input.idempotencyHashParams }
 				: {}),
 			source: 'webhook',
 			topic: `webhook:${input.packageKodyId}:${input.endpoint.webhookName}`,

--- a/packages/worker/src/webhooks/dispatch-queue-producer.ts
+++ b/packages/worker/src/webhooks/dispatch-queue-producer.ts
@@ -22,6 +22,8 @@ export type WebhookDispatchQueueMessage = {
 	inputMode?: 'params'
 	idempotencyKey: string
 	idempotencyParamsHash?: 'ignore'
+	/** Request-mode caller Idempotency-Key: hash the JSON body, not the envelope. */
+	callerIdempotency?: true
 	deliveryId: string
 	payloadBytes: number
 	receivedAt: string
@@ -43,6 +45,7 @@ export function createWebhookDispatchQueueMessage(input: {
 	inputMode?: 'params'
 	idempotencyKey: string
 	idempotencyParamsHash?: 'ignore'
+	callerIdempotency?: true
 	deliveryId: string
 	payloadBytes: number
 	receivedAt: string
@@ -63,6 +66,7 @@ export function createWebhookDispatchQueueMessage(input: {
 		...(input.idempotencyParamsHash === 'ignore'
 			? { idempotencyParamsHash: 'ignore' as const }
 			: {}),
+		...(input.callerIdempotency ? { callerIdempotency: true as const } : {}),
 		deliveryId: input.deliveryId,
 		payloadBytes: input.payloadBytes,
 		receivedAt: input.receivedAt,
@@ -155,6 +159,10 @@ export function parseWebhookDispatchQueueMessage(
 	if (inputMode !== undefined && inputMode !== 'params') {
 		return null
 	}
+	const callerIdempotency = message['callerIdempotency']
+	if (callerIdempotency !== undefined && callerIdempotency !== true) {
+		return null
+	}
 	return {
 		endpoint: {
 			id,
@@ -170,6 +178,7 @@ export function parseWebhookDispatchQueueMessage(
 		...(idempotencyParamsHash === 'ignore'
 			? { idempotencyParamsHash: 'ignore' as const }
 			: {}),
+		...(callerIdempotency === true ? { callerIdempotency: true as const } : {}),
 		deliveryId,
 		payloadBytes,
 		receivedAt,

--- a/packages/worker/src/webhooks/dispatch-queue-producer.ts
+++ b/packages/worker/src/webhooks/dispatch-queue-producer.ts
@@ -19,6 +19,7 @@ export type WebhookDispatchQueueMessage = {
 	packageKodyId: string
 	exportName: string
 	params: WebhookExportParams
+	inputMode?: 'params'
 	idempotencyKey: string
 	idempotencyParamsHash?: 'ignore'
 	deliveryId: string
@@ -39,6 +40,7 @@ export function createWebhookDispatchQueueMessage(input: {
 	packageKodyId: string
 	exportName: string
 	params: WebhookExportParams
+	inputMode?: 'params'
 	idempotencyKey: string
 	idempotencyParamsHash?: 'ignore'
 	deliveryId: string
@@ -56,6 +58,7 @@ export function createWebhookDispatchQueueMessage(input: {
 				json: null,
 			},
 		},
+		...(input.inputMode === 'params' ? { inputMode: 'params' as const } : {}),
 		idempotencyKey: input.idempotencyKey,
 		...(input.idempotencyParamsHash === 'ignore'
 			? { idempotencyParamsHash: 'ignore' as const }
@@ -148,6 +151,10 @@ export function parseWebhookDispatchQueueMessage(
 	) {
 		return null
 	}
+	const inputMode = message['inputMode']
+	if (inputMode !== undefined && inputMode !== 'params') {
+		return null
+	}
 	return {
 		endpoint: {
 			id,
@@ -158,6 +165,7 @@ export function parseWebhookDispatchQueueMessage(
 		packageKodyId,
 		exportName,
 		params: params as WebhookExportParams,
+		...(inputMode === 'params' ? { inputMode: 'params' as const } : {}),
 		idempotencyKey,
 		...(idempotencyParamsHash === 'ignore'
 			? { idempotencyParamsHash: 'ignore' as const }

--- a/packages/worker/src/webhooks/dispatch-queue.node.test.ts
+++ b/packages/worker/src/webhooks/dispatch-queue.node.test.ts
@@ -5,12 +5,14 @@ import {
 	processWebhookDispatch,
 } from './dispatch-queue.ts'
 import {
+	createWebhookDispatchQueueMessage,
 	getWebhookDispatchQueueMessageBytes,
 	parseWebhookDispatchQueueMessage,
 	webhookDispatchPayloadKvKey,
 	webhookDispatchQueueMessageMaxBytes,
 	type WebhookDispatchQueueMessage,
 } from './dispatch-queue-producer.ts'
+import { parseWebhookJsonBody } from './params.ts'
 
 const mocks = vi.hoisted(() => ({
 	dispatchWebhookInvocation: vi.fn(),
@@ -57,6 +59,31 @@ function createMessage(): WebhookDispatchQueueMessage {
 		payloadBytes: 17,
 		receivedAt: '2026-08-08T12:00:00.000Z',
 	}
+}
+
+function hydrateParsedDispatchMessage(
+	message: WebhookDispatchQueueMessage,
+): WebhookDispatchQueueMessage {
+	return {
+		...message,
+		params: {
+			...message.params,
+			request: {
+				...message.params.request,
+				json: parseWebhookJsonBody(message.params.request.body),
+			},
+		},
+	}
+}
+
+function queuedDispatchMessage(
+	input: Parameters<typeof createWebhookDispatchQueueMessage>[0],
+): WebhookDispatchQueueMessage {
+	const parsed = parseWebhookDispatchQueueMessage(
+		createWebhookDispatchQueueMessage(input),
+	)
+	if (!parsed) throw new Error('expected serialized queue message to parse')
+	return hydrateParsedDispatchMessage(parsed)
 }
 
 function createQueueMessage(id: string, body: unknown) {
@@ -200,6 +227,19 @@ test('webhook queue parser rejects malformed isolation and delivery fields', () 
 			inputMode: 'request',
 		}),
 	).toBeNull()
+	const withCallerIdempotency = {
+		...message,
+		callerIdempotency: true as const,
+	}
+	expect(parseWebhookDispatchQueueMessage(withCallerIdempotency)).toEqual(
+		withCallerIdempotency,
+	)
+	expect(
+		parseWebhookDispatchQueueMessage({
+			...message,
+			callerIdempotency: false,
+		}),
+	).toBeNull()
 	expect(getWebhookDispatchQueueMessageBytes(message)).toBeLessThan(
 		webhookDispatchQueueMessageMaxBytes,
 	)
@@ -214,14 +254,22 @@ test('queue dispatch unwraps params-mode first args and hashes request-mode call
 	})
 	mocks.recordWebhookDelivery.mockResolvedValue(undefined)
 
-	const paramsMode = {
-		...createMessage(),
-		inputMode: 'params' as const,
-	}
-	paramsMode.params.request.json = {
+	const paramsEnvelope = JSON.stringify({
 		params: { messageId: 'm-1' },
 		idempotencyKey: 'evt-1',
-	}
+	})
+	const paramsMode = queuedDispatchMessage({
+		...createMessage(),
+		inputMode: 'params',
+		params: {
+			...createMessage().params,
+			request: {
+				...createMessage().params.request,
+				body: paramsEnvelope,
+				json: { ignored: true },
+			},
+		},
+	})
 	await expect(processWebhookDispatch(paramsMode, {} as Env)).resolves.toBe(
 		'terminal',
 	)
@@ -231,14 +279,54 @@ test('queue dispatch unwraps params-mode first args and hashes request-mode call
 		}),
 	)
 
-	const requestMode = createMessage()
-	await expect(processWebhookDispatch(requestMode, {} as Env)).resolves.toBe(
-		'terminal',
-	)
+	const uniqueKeyRequestMode = queuedDispatchMessage(createMessage())
+	await expect(
+		processWebhookDispatch(uniqueKeyRequestMode, {} as Env),
+	).resolves.toBe('terminal')
 	expect(mocks.dispatchWebhookInvocation).toHaveBeenLastCalledWith(
 		expect.objectContaining({
-			params: requestMode.params,
+			params: uniqueKeyRequestMode.params,
+		}),
+	)
+	expect(mocks.dispatchWebhookInvocation.mock.lastCall?.[0]).not.toHaveProperty(
+		'idempotencyHashParams',
+	)
+
+	const callerKeyRequestMode = queuedDispatchMessage({
+		...createMessage(),
+		callerIdempotency: true,
+		idempotencyKey: 'caller-evt-1',
+	})
+	await expect(
+		processWebhookDispatch(callerKeyRequestMode, {} as Env),
+	).resolves.toBe('terminal')
+	expect(mocks.dispatchWebhookInvocation).toHaveBeenLastCalledWith(
+		expect.objectContaining({
+			params: callerKeyRequestMode.params,
 			idempotencyHashParams: { event: 'error' },
+		}),
+	)
+
+	const invalidParamsMode = queuedDispatchMessage({
+		...createMessage(),
+		inputMode: 'params',
+		params: {
+			...createMessage().params,
+			request: {
+				...createMessage().params.request,
+				body: '["not","an","object"]',
+				json: { ignored: true },
+			},
+		},
+	})
+	await expect(
+		processWebhookDispatch(invalidParamsMode, {} as Env),
+	).resolves.toBe('terminal')
+	expect(mocks.recordWebhookDelivery).toHaveBeenLastCalledWith(
+		expect.objectContaining({
+			outcome: 'rejected',
+			httpStatus: 400,
+			error: 'invalid_params',
 		}),
 	)
 })

--- a/packages/worker/src/webhooks/dispatch-queue.node.test.ts
+++ b/packages/worker/src/webhooks/dispatch-queue.node.test.ts
@@ -187,8 +187,59 @@ test('webhook queue parser rejects malformed isolation and delivery fields', () 
 		idempotencyParamsHash: 'ignore' as const,
 	}
 	expect(parseWebhookDispatchQueueMessage(withIgnore)).toEqual(withIgnore)
+	const withParamsMode = {
+		...message,
+		inputMode: 'params' as const,
+	}
+	expect(parseWebhookDispatchQueueMessage(withParamsMode)).toEqual(
+		withParamsMode,
+	)
+	expect(
+		parseWebhookDispatchQueueMessage({
+			...message,
+			inputMode: 'request',
+		}),
+	).toBeNull()
 	expect(getWebhookDispatchQueueMessageBytes(message)).toBeLessThan(
 		webhookDispatchQueueMessageMaxBytes,
+	)
+})
+
+test('queue dispatch unwraps params-mode first args and hashes request-mode caller keys', async () => {
+	mocks.dispatchWebhookInvocation.mockReset()
+	mocks.recordWebhookDelivery.mockReset()
+	mocks.dispatchWebhookInvocation.mockResolvedValue({
+		status: 200,
+		body: { ok: true, result: { handled: true } },
+	})
+	mocks.recordWebhookDelivery.mockResolvedValue(undefined)
+
+	const paramsMode = {
+		...createMessage(),
+		inputMode: 'params' as const,
+	}
+	paramsMode.params.request.json = {
+		params: { messageId: 'm-1' },
+		idempotencyKey: 'evt-1',
+	}
+	await expect(processWebhookDispatch(paramsMode, {} as Env)).resolves.toBe(
+		'terminal',
+	)
+	expect(mocks.dispatchWebhookInvocation).toHaveBeenCalledWith(
+		expect.objectContaining({
+			params: { messageId: 'm-1' },
+		}),
+	)
+
+	const requestMode = createMessage()
+	await expect(processWebhookDispatch(requestMode, {} as Env)).resolves.toBe(
+		'terminal',
+	)
+	expect(mocks.dispatchWebhookInvocation).toHaveBeenLastCalledWith(
+		expect.objectContaining({
+			params: requestMode.params,
+			idempotencyHashParams: { event: 'error' },
+		}),
 	)
 })
 

--- a/packages/worker/src/webhooks/dispatch-queue.ts
+++ b/packages/worker/src/webhooks/dispatch-queue.ts
@@ -43,14 +43,14 @@ function resolveWebhookDispatchInvocation(
 	return {
 		ok: true,
 		params: message.params,
-		...(message.idempotencyParamsHash === 'ignore'
-			? {}
-			: {
+		...(message.callerIdempotency
+			? {
 					idempotencyHashParams: buildWebhookCallerIdempotencyHashParams({
 						json: message.params.request.json,
 						bodyText: message.params.request.body,
 					}),
-				}),
+				}
+			: {}),
 	}
 }
 
@@ -72,7 +72,7 @@ export async function processWebhookDispatch(
 			env,
 			endpoint: message.endpoint,
 			kodyId: message.packageKodyId,
-			outcome: 'failed',
+			outcome: 'rejected',
 			httpStatus: 400,
 			error: resolved.code,
 			payloadBytes: message.payloadBytes,

--- a/packages/worker/src/webhooks/dispatch-queue.ts
+++ b/packages/worker/src/webhooks/dispatch-queue.ts
@@ -12,6 +12,10 @@ import {
 	parseWebhookDispatchQueueMessage,
 	type WebhookDispatchQueueMessage,
 } from './dispatch-queue-producer.ts'
+import {
+	buildWebhookCallerIdempotencyHashParams,
+	resolveWebhookParamsModeFirstArg,
+} from './params.ts'
 
 const webhookDispatchRetryDelaySeconds = 30
 const retryableInvocationErrorCodes = new Set([
@@ -19,6 +23,36 @@ const retryableInvocationErrorCodes = new Set([
 	'idempotency_persistence_failed',
 	'invocation_in_progress',
 ])
+
+function resolveWebhookDispatchInvocation(
+	message: WebhookDispatchQueueMessage,
+):
+	| {
+			ok: true
+			params: Record<string, unknown>
+			idempotencyHashParams?: Record<string, unknown>
+	  }
+	| { ok: false; code: 'invalid_params' } {
+	if (message.inputMode === 'params') {
+		const resolved = resolveWebhookParamsModeFirstArg(
+			message.params.request.json,
+		)
+		if (!resolved.ok) return resolved
+		return { ok: true, params: resolved.params }
+	}
+	return {
+		ok: true,
+		params: message.params,
+		...(message.idempotencyParamsHash === 'ignore'
+			? {}
+			: {
+					idempotencyHashParams: buildWebhookCallerIdempotencyHashParams({
+						json: message.params.request.json,
+						bodyText: message.params.request.body,
+					}),
+				}),
+	}
+}
 
 function readInvocationErrorCode(body: unknown): string | null {
 	if (!body || typeof body !== 'object' || Array.isArray(body)) return null
@@ -32,15 +66,34 @@ export async function processWebhookDispatch(
 	message: WebhookDispatchQueueMessage,
 	env: Env,
 ): Promise<'terminal' | 'retry'> {
+	const resolved = resolveWebhookDispatchInvocation(message)
+	if (!resolved.ok) {
+		await recordWebhookDelivery({
+			env,
+			endpoint: message.endpoint,
+			kodyId: message.packageKodyId,
+			outcome: 'failed',
+			httpStatus: 400,
+			error: resolved.code,
+			payloadBytes: message.payloadBytes,
+			invocationId: message.deliveryId,
+			startedAt: message.receivedAt,
+			requirePersistence: true,
+		})
+		return 'terminal'
+	}
 	const response = await dispatchWebhookInvocation({
 		env,
 		endpoint: message.endpoint,
 		packageKodyId: message.packageKodyId,
 		exportName: message.exportName,
-		params: message.params,
+		params: resolved.params,
 		idempotencyKey: message.idempotencyKey,
 		...(message.idempotencyParamsHash === 'ignore'
 			? { idempotencyParamsHash: 'ignore' as const }
+			: {}),
+		...(resolved.idempotencyHashParams
+			? { idempotencyHashParams: resolved.idempotencyHashParams }
 			: {}),
 	})
 	const errorCode = readInvocationErrorCode(response.body)

--- a/packages/worker/src/webhooks/http.ts
+++ b/packages/worker/src/webhooks/http.ts
@@ -36,12 +36,18 @@ import {
 	storeWebhookDispatchPayload,
 } from './dispatch-payload-store.ts'
 import { collectSafeWebhookHeaders } from './headers.ts'
-import { buildWebhookExportParams } from './params.ts'
+import {
+	buildWebhookCallerIdempotencyHashParams,
+	buildWebhookExportParams,
+	readWebhookCallerIdempotencyKey,
+	resolveWebhookParamsModeFirstArg,
+} from './params.ts'
 import { getWebhookEndpointByKey } from './repo.ts'
 import {
 	webhookDefaultReplayToleranceSeconds,
+	webhookIdempotencyKeyHeader,
 	webhookMaxPayloadBytes,
-	webhookRateLimitConfig,
+	webhookRateLimitConfigFor,
 	webhookSyncInvocationTimeoutMs,
 } from './types.ts'
 
@@ -136,6 +142,20 @@ function rateLimitedResponse(retryAfterSeconds: number) {
 				'Retry-After': String(retryAfterSeconds),
 			},
 		},
+	)
+}
+
+function invalidParamsResponse() {
+	return jsonResponse(
+		{
+			ok: false,
+			error: {
+				code: 'invalid_params',
+				message:
+					'inputMode "params" requires a JSON object body. When the body has a params object, that object is the export argument.',
+			},
+		},
+		{ status: 400 },
 	)
 }
 
@@ -296,15 +316,6 @@ export async function handleWebhookIngressRequest(
 		return notFoundResponse()
 	}
 
-	const rateLimit = await checkRateLimit(
-		env.APP_DB,
-		`webhook:user:${endpoint.userId}:endpoint:${endpoint.id}`,
-		webhookRateLimitConfig,
-	)
-	if (!rateLimit.allowed) {
-		return rateLimitedResponse(rateLimit.retryAfterSeconds ?? 60)
-	}
-
 	const baseUrl = getAppBaseUrl({ env, requestUrl: request.url })
 	let declared
 	try {
@@ -361,6 +372,15 @@ export async function handleWebhookIngressRequest(
 			},
 			{ status: 409 },
 		)
+	}
+
+	const rateLimit = await checkRateLimit(
+		env.APP_DB,
+		`webhook:user:${endpoint.userId}:endpoint:${endpoint.id}`,
+		webhookRateLimitConfigFor(declared.rateLimitPerMinute),
+	)
+	if (!rateLimit.allowed) {
+		return rateLimitedResponse(rateLimit.retryAfterSeconds ?? 60)
 	}
 
 	const bodyResult = await readBodyWithCap(request, webhookMaxPayloadBytes)
@@ -503,9 +523,10 @@ export async function handleWebhookIngressRequest(
 		...(declared.replay?.deliveryIdHeader
 			? [declared.replay.deliveryIdHeader]
 			: []),
+		webhookIdempotencyKeyHeader,
 	]
 	const safeHeaders = collectSafeWebhookHeaders(request, extraAllowedHeaders)
-	const params = buildWebhookExportParams({
+	const requestParams = buildWebhookExportParams({
 		packageKodyId: savedPackage.kodyId,
 		webhookName: route.webhookName,
 		request,
@@ -513,18 +534,45 @@ export async function handleWebhookIngressRequest(
 		receivedAt,
 		headers: safeHeaders,
 	})
+	const paramsMode =
+		declared.inputMode === 'params'
+			? resolveWebhookParamsModeFirstArg(requestParams.request.json)
+			: null
+	if (paramsMode && !paramsMode.ok) {
+		await recordWebhookDelivery({
+			env,
+			endpoint,
+			kodyId: savedPackage.kodyId,
+			outcome: 'rejected',
+			httpStatus: 400,
+			error: 'invalid_params',
+			payloadBytes: bodyBytes.byteLength,
+			startedAt: receivedAt,
+			waitUntil,
+		})
+		return invalidParamsResponse()
+	}
+	const exportParams = paramsMode?.ok ? paramsMode.params : requestParams
 	const deliveryId = crypto.randomUUID()
-	const providerDeliveryId = declared.replay?.deliveryIdHeader
-		? request.headers.get(declared.replay.deliveryIdHeader)?.trim()
-		: undefined
-	const idempotencyKey = providerDeliveryId
-		? await buildWebhookDeliveryIdempotencyKey({
-				userId: endpoint.userId,
-				packageId: endpoint.packageId,
-				webhookName: endpoint.webhookName,
-				deliveryId: providerDeliveryId,
-			})
-		: `webhook:${endpoint.id}:${deliveryId}`
+	const callerIdempotencyKey = readWebhookCallerIdempotencyKey({
+		request,
+		json: requestParams.request.json,
+		allowBodyKey: declared.inputMode === 'params',
+	})
+	const providerDeliveryId =
+		!callerIdempotencyKey && declared.replay?.deliveryIdHeader
+			? request.headers.get(declared.replay.deliveryIdHeader)?.trim()
+			: undefined
+	const idempotencyKey = callerIdempotencyKey
+		? callerIdempotencyKey
+		: providerDeliveryId
+			? await buildWebhookDeliveryIdempotencyKey({
+					userId: endpoint.userId,
+					packageId: endpoint.packageId,
+					webhookName: endpoint.webhookName,
+					deliveryId: providerDeliveryId,
+				})
+			: `webhook:${endpoint.id}:${deliveryId}`
 	// Delivery-id keys identify the event, not the HTTP attempt. Provider
 	// retries change `receivedAt` and often headers; the same delivery id is
 	// still that event even when body bytes differ. Matching the ledger by
@@ -532,9 +580,21 @@ export async function handleWebhookIngressRequest(
 	// acknowledgement instead of hashing those volatile fields. A different
 	// delivery id cannot reuse another event's ack because the key already
 	// binds userId + packageId + webhookName + deliveryId.
+	//
+	// Caller Idempotency-Key (and params-mode JSON idempotencyKey) use the
+	// standard include-hash ledger: same key + same payload replays; a
+	// different payload is 409. Request-mode caller keys hash the JSON body
+	// (not the envelope) so receivedAt does not break retries.
 	const idempotencyParamsHash = providerDeliveryId
 		? ('ignore' as const)
 		: undefined
+	const idempotencyHashParams =
+		callerIdempotencyKey && declared.inputMode !== 'params'
+			? buildWebhookCallerIdempotencyHashParams({
+					json: requestParams.request.json,
+					bodyText,
+				})
+			: undefined
 
 	if (declared.responseMode === 'ack') {
 		let message = createWebhookDispatchQueueMessage({
@@ -546,7 +606,10 @@ export async function handleWebhookIngressRequest(
 			},
 			packageKodyId: savedPackage.kodyId,
 			exportName: declared.exportName,
-			params,
+			params: requestParams,
+			...(declared.inputMode === 'params'
+				? { inputMode: 'params' as const }
+				: {}),
 			idempotencyKey,
 			...(idempotencyParamsHash ? { idempotencyParamsHash } : {}),
 			deliveryId,
@@ -636,12 +699,29 @@ export async function handleWebhookIngressRequest(
 				endpoint,
 				packageKodyId: savedPackage.kodyId,
 				exportName: declared.exportName,
-				params,
+				params: exportParams,
 				idempotencyKey,
 				...(idempotencyParamsHash ? { idempotencyParamsHash } : {}),
+				...(idempotencyHashParams ? { idempotencyHashParams } : {}),
 			}),
 			webhookSyncInvocationTimeoutMs,
 		)
+		if (response.status === 409) {
+			await recordWebhookDelivery({
+				env,
+				endpoint,
+				kodyId: savedPackage.kodyId,
+				outcome: 'rejected',
+				httpStatus: 409,
+				error: `invocation_status_409`,
+				payloadBytes: bodyBytes.byteLength,
+				invocationId: deliveryId,
+				result: readWebhookInvocationResult(response.body),
+				startedAt: receivedAt,
+				waitUntil,
+			})
+			return jsonResponse(response.body, { status: 409 })
+		}
 		const ok = response.status >= 200 && response.status < 300
 		await recordWebhookDelivery({
 			env,

--- a/packages/worker/src/webhooks/http.ts
+++ b/packages/worker/src/webhooks/http.ts
@@ -331,7 +331,19 @@ export async function handleWebhookIngressRequest(
 	} catch {
 		declared = undefined
 	}
+
+	const rateLimit = await checkRateLimit(
+		env.APP_DB,
+		`webhook:user:${endpoint.userId}:endpoint:${endpoint.id}`,
+		webhookRateLimitConfigFor(declared?.rateLimitPerMinute),
+	)
+	if (!rateLimit.allowed) {
+		return rateLimitedResponse(rateLimit.retryAfterSeconds ?? 60)
+	}
+
 	// Republished package removed/renamed the webhook → deactivate ingress.
+	// Rate-limit first so a minted-but-undeclared URL cannot flush delivery
+	// history without bound.
 	if (!declared) {
 		await recordWebhookDelivery({
 			env,
@@ -372,15 +384,6 @@ export async function handleWebhookIngressRequest(
 			},
 			{ status: 409 },
 		)
-	}
-
-	const rateLimit = await checkRateLimit(
-		env.APP_DB,
-		`webhook:user:${endpoint.userId}:endpoint:${endpoint.id}`,
-		webhookRateLimitConfigFor(declared.rateLimitPerMinute),
-	)
-	if (!rateLimit.allowed) {
-		return rateLimitedResponse(rateLimit.retryAfterSeconds ?? 60)
 	}
 
 	const bodyResult = await readBodyWithCap(request, webhookMaxPayloadBytes)
@@ -612,6 +615,7 @@ export async function handleWebhookIngressRequest(
 				: {}),
 			idempotencyKey,
 			...(idempotencyParamsHash ? { idempotencyParamsHash } : {}),
+			...(callerIdempotencyKey ? { callerIdempotency: true as const } : {}),
 			deliveryId,
 			payloadBytes: bodyBytes.byteLength,
 			receivedAt,

--- a/packages/worker/src/webhooks/http.workers.test.ts
+++ b/packages/worker/src/webhooks/http.workers.test.ts
@@ -215,6 +215,8 @@ async function mintWebhook(input: {
 function declareWebhook(input: {
 	name: string
 	responseMode?: 'ack' | 'sync'
+	inputMode?: 'request' | 'params'
+	rateLimitPerMinute?: number
 	verification?: {
 		type: 'hmac-sha256'
 		header: string
@@ -248,6 +250,10 @@ function declareWebhook(input: {
 						name: input.name,
 						export: './handle-sentry-webhook',
 						responseMode: input.responseMode ?? 'ack',
+						...(input.inputMode ? { inputMode: input.inputMode } : {}),
+						...(input.rateLimitPerMinute !== undefined
+							? { rateLimitPerMinute: input.rateLimitPerMinute }
+							: {}),
 						...(input.verification ? { verification: input.verification } : {}),
 						...(input.replay ? { replay: input.replay } : {}),
 					},
@@ -983,4 +989,236 @@ test('opt-in webhook replay protection rejects stale timestamps and dedupes deli
 	})
 	expect(missingDeliveryId.status).toBe(401)
 	expect(exportMock.exportInvocations).toBe(1)
+})
+
+test('first-party trusted webhooks accept Idempotency-Key, params mode, and a higher rate limit', async () => {
+	silenceExpectedConsoleWarns(['activation-run-record-failed'])
+	await ensureSchema(env.APP_DB)
+	await env.APP_DB.prepare(`DELETE FROM webhook_endpoints`).run()
+	await env.APP_DB.prepare(`DELETE FROM saved_packages`).run()
+	await env.APP_DB.prepare(`DELETE FROM users`).run()
+
+	const userId = await seedOwner()
+	await clearRunRecords({ env, userId })
+	const urlSecret = 'trusted-url-secret'
+	await mintWebhook({
+		userId,
+		webhookName: 'message-created',
+		urlSecret,
+		id: 'mint-params',
+	})
+	await mintWebhook({
+		userId,
+		webhookName: 'burst',
+		urlSecret,
+		id: 'mint-burst',
+	})
+	await mintWebhook({
+		userId,
+		webhookName: 'vendor',
+		urlSecret,
+		id: 'mint-vendor',
+	})
+
+	declareWebhook({
+		name: 'message-created',
+		responseMode: 'sync',
+		inputMode: 'params',
+	})
+	const exportMock = createHashedIdempotencyExportMock()
+	mocks.invokePackageExport.mockReset()
+	mocks.invokePackageExport.mockImplementation(exportMock.implementation)
+
+	const envelopeBody = JSON.stringify({
+		params: { messageId: 'm-1', content: 'hello' },
+		idempotencyKey: 'evt-discord-1',
+	})
+	const first = await postWebhook({
+		packageKodyId: 'sentry-bridge',
+		webhookName: 'message-created',
+		urlSecret,
+		body: envelopeBody,
+	})
+	expect(first.status).toBe(200)
+	expect(await first.json()).toEqual({ ok: true, result: { handled: true } })
+	expect(exportMock.exportInvocations).toBe(1)
+	const firstCall = mocks.invokePackageExport.mock.calls[0]?.[0] as {
+		request: {
+			params: Record<string, unknown>
+			idempotencyKey: string
+			idempotencyParamsHash?: 'ignore'
+			idempotencyHashParams?: Record<string, unknown>
+		}
+	}
+	expect(firstCall.request.params).toEqual({
+		messageId: 'm-1',
+		content: 'hello',
+	})
+	expect(firstCall.request.idempotencyKey).toBe('evt-discord-1')
+	expect(firstCall.request.idempotencyParamsHash).toBeUndefined()
+	expect(firstCall.request.idempotencyHashParams).toBeUndefined()
+
+	const replay = await postWebhook({
+		packageKodyId: 'sentry-bridge',
+		webhookName: 'message-created',
+		urlSecret,
+		body: envelopeBody,
+		headers: { 'Idempotency-Key': 'evt-discord-1' },
+	})
+	expect(replay.status).toBe(200)
+	expect(await replay.json()).toMatchObject({
+		ok: true,
+		result: { handled: true },
+		idempotency: { replayed: true },
+	})
+	expect(exportMock.exportInvocations).toBe(1)
+
+	const mismatch = await postWebhook({
+		packageKodyId: 'sentry-bridge',
+		webhookName: 'message-created',
+		urlSecret,
+		body: JSON.stringify({
+			params: { messageId: 'm-1', content: 'different' },
+			idempotencyKey: 'evt-discord-1',
+		}),
+	})
+	expect(mismatch.status).toBe(409)
+	expect(await mismatch.json()).toMatchObject({
+		ok: false,
+		error: { code: 'idempotency_mismatch' },
+	})
+	expect(exportMock.exportInvocations).toBe(1)
+
+	mocks.invokePackageExport.mockImplementationOnce(async () => ({
+		status: 409,
+		body: {
+			ok: false,
+			error: { code: 'invocation_in_progress' },
+		},
+	}))
+	const inProgress = await postWebhook({
+		packageKodyId: 'sentry-bridge',
+		webhookName: 'message-created',
+		urlSecret,
+		body: JSON.stringify({
+			params: { messageId: 'm-9' },
+			idempotencyKey: 'evt-in-progress',
+		}),
+	})
+	expect(inProgress.status).toBe(409)
+	expect(await inProgress.json()).toMatchObject({
+		ok: false,
+		error: { code: 'invocation_in_progress' },
+	})
+
+	const directBody = JSON.stringify({ videoId: 'v-1' })
+	const direct = await postWebhook({
+		packageKodyId: 'sentry-bridge',
+		webhookName: 'message-created',
+		urlSecret,
+		body: directBody,
+		headers: { 'Idempotency-Key': 'evt-direct-1' },
+	})
+	expect(direct.status).toBe(200)
+	const directCall = mocks.invokePackageExport.mock.calls.at(-1)?.[0] as {
+		request: { params: Record<string, unknown>; idempotencyKey: string }
+	}
+	expect(directCall.request.params).toEqual({ videoId: 'v-1' })
+	expect(directCall.request.idempotencyKey).toBe('evt-direct-1')
+
+	const invalidParams = await postWebhook({
+		packageKodyId: 'sentry-bridge',
+		webhookName: 'message-created',
+		urlSecret,
+		body: JSON.stringify(['not', 'an', 'object']),
+	})
+	expect(invalidParams.status).toBe(400)
+	expect(await invalidParams.json()).toMatchObject({
+		ok: false,
+		error: { code: 'invalid_params' },
+	})
+
+	declareWebhook({
+		name: 'burst',
+		responseMode: 'ack',
+		inputMode: 'params',
+		rateLimitPerMinute: 2,
+	})
+	mocks.enqueueWebhookDispatch.mockReset()
+	mocks.enqueueWebhookDispatch.mockResolvedValue(undefined)
+	expect(
+		(
+			await postWebhook({
+				packageKodyId: 'sentry-bridge',
+				webhookName: 'burst',
+				urlSecret,
+				body: JSON.stringify({ n: 1 }),
+				headers: { 'Idempotency-Key': 'burst-1' },
+			})
+		).status,
+	).toBe(202)
+	expect(
+		(
+			await postWebhook({
+				packageKodyId: 'sentry-bridge',
+				webhookName: 'burst',
+				urlSecret,
+				body: JSON.stringify({ n: 2 }),
+				headers: { 'Idempotency-Key': 'burst-2' },
+			})
+		).status,
+	).toBe(202)
+	const limited = await postWebhook({
+		packageKodyId: 'sentry-bridge',
+		webhookName: 'burst',
+		urlSecret,
+		body: JSON.stringify({ n: 3 }),
+		headers: { 'Idempotency-Key': 'burst-3' },
+	})
+	expect(limited.status).toBe(429)
+	expect(mocks.enqueueWebhookDispatch).toHaveBeenCalledTimes(2)
+
+	declareWebhook({
+		name: 'vendor',
+		responseMode: 'sync',
+		verification: {
+			type: 'hmac-sha256',
+			header: 'x-hub-signature-256',
+			secretName: 'githubWebhookSecret',
+			encoding: 'hex',
+			prefix: 'sha256=',
+		},
+	})
+	mocks.resolveSecret.mockResolvedValue({
+		found: true,
+		value: 'hmac-shared-secret',
+		scope: 'user',
+		allowedHosts: [],
+		allowedPackages: [],
+	})
+	const vendorBody = JSON.stringify({ ref: 'refs/heads/main' })
+	const vendorSignature = await computeWebhookHmacSignature({
+		algorithm: 'hmac-sha256',
+		secret: 'hmac-shared-secret',
+		body: encodeBody(vendorBody),
+		encoding: 'hex',
+		prefix: 'sha256=',
+	})
+	const vendor = await postWebhook({
+		packageKodyId: 'sentry-bridge',
+		webhookName: 'vendor',
+		urlSecret,
+		body: vendorBody,
+		headers: { 'x-hub-signature-256': vendorSignature },
+	})
+	expect(vendor.status).toBe(200)
+	const vendorCall = mocks.invokePackageExport.mock.calls.at(-1)?.[0] as {
+		request: {
+			params: { webhook: { name: string }; request: { json: unknown } }
+		}
+	}
+	expect(vendorCall.request.params.webhook.name).toBe('vendor')
+	expect(vendorCall.request.params.request.json).toEqual({
+		ref: 'refs/heads/main',
+	})
 })

--- a/packages/worker/src/webhooks/http.workers.test.ts
+++ b/packages/worker/src/webhooks/http.workers.test.ts
@@ -1,6 +1,7 @@
 import { env } from 'cloudflare:workers'
 import { createExecutionContext, waitOnExecutionContext } from 'cloudflare:test'
 import { expect, test, vi } from 'vitest'
+import { checkRateLimit } from '#app/rate-limit.ts'
 import { type PackageInvocationRequest } from '#worker/package-invocations/common.ts'
 import {
 	createRequestHash,
@@ -18,6 +19,7 @@ import {
 } from './crypto.ts'
 import type * as DispatchQueueProducerModule from './dispatch-queue-producer.ts'
 import { handleWebhookIngressRequest } from './http.ts'
+import { webhookRateLimitConfig } from './types.ts'
 
 const mocks = vi.hoisted(() => ({
 	enqueueWebhookDispatch: vi.fn(),
@@ -1177,6 +1179,35 @@ test('first-party trusted webhooks accept Idempotency-Key, params mode, and a hi
 	})
 	expect(limited.status).toBe(429)
 	expect(mocks.enqueueWebhookDispatch).toHaveBeenCalledTimes(2)
+	const burstEnqueue = mocks.enqueueWebhookDispatch.mock.calls[0]?.[0] as {
+		message: { callerIdempotency?: true }
+	}
+	expect(burstEnqueue.message.callerIdempotency).toBe(true)
+
+	await mintWebhook({
+		userId,
+		webhookName: 'retired',
+		urlSecret,
+		id: 'mint-retired',
+	})
+	const retiredKey = `webhook:user:${userId}:endpoint:mint-retired`
+	await checkRateLimit(env.APP_DB, retiredKey, webhookRateLimitConfig)
+	const now = Math.floor(Date.now() / 1000)
+	await env.APP_DB.batch(
+		Array.from({ length: webhookRateLimitConfig.maxRequests - 1 }, () =>
+			env.APP_DB.prepare(
+				`INSERT INTO _rate_limits (key, ts) VALUES (?, ?)`,
+			).bind(retiredKey, now),
+		),
+	)
+	const retiredLimited = await postWebhook({
+		packageKodyId: 'sentry-bridge',
+		webhookName: 'retired',
+		urlSecret,
+		body: JSON.stringify({ n: 1 }),
+	})
+	expect(retiredLimited.status).toBe(429)
+	expect(await listDeliveries(userId, 'retired')).toEqual([])
 
 	declareWebhook({
 		name: 'vendor',

--- a/packages/worker/src/webhooks/params.node.test.ts
+++ b/packages/worker/src/webhooks/params.node.test.ts
@@ -1,0 +1,91 @@
+import { expect, test } from 'vitest'
+import {
+	buildWebhookCallerIdempotencyHashParams,
+	readWebhookCallerIdempotencyKey,
+	resolveWebhookParamsModeFirstArg,
+} from './params.ts'
+
+test('params-mode first-arg unwrap and caller Idempotency-Key resolution', () => {
+	expect(resolveWebhookParamsModeFirstArg(null)).toEqual({
+		ok: false,
+		code: 'invalid_params',
+	})
+	expect(resolveWebhookParamsModeFirstArg(['event'])).toEqual({
+		ok: false,
+		code: 'invalid_params',
+	})
+	expect(resolveWebhookParamsModeFirstArg('event')).toEqual({
+		ok: false,
+		code: 'invalid_params',
+	})
+
+	const direct = { messageId: 'm-1', content: 'hello' }
+	expect(resolveWebhookParamsModeFirstArg(direct)).toEqual({
+		ok: true,
+		params: direct,
+	})
+
+	const envelope = {
+		params: { messageId: 'm-2', content: 'invoke' },
+		idempotencyKey: 'evt-2',
+		source: 'discord-gateway',
+	}
+	expect(resolveWebhookParamsModeFirstArg(envelope)).toEqual({
+		ok: true,
+		params: { messageId: 'm-2', content: 'invoke' },
+	})
+	expect(
+		resolveWebhookParamsModeFirstArg({
+			params: 'not-an-object',
+			other: true,
+		}),
+	).toEqual({
+		ok: true,
+		params: { params: 'not-an-object', other: true },
+	})
+
+	const headerRequest = new Request('https://test.kody.dev/hook', {
+		method: 'POST',
+		headers: { 'Idempotency-Key': ' header-key ' },
+		body: JSON.stringify({ idempotencyKey: 'body-key', params: { n: 1 } }),
+	})
+	expect(
+		readWebhookCallerIdempotencyKey({
+			request: headerRequest,
+			json: { idempotencyKey: 'body-key', params: { n: 1 } },
+			allowBodyKey: true,
+		}),
+	).toBe('header-key')
+
+	const bodyRequest = new Request('https://test.kody.dev/hook', {
+		method: 'POST',
+		body: '{}',
+	})
+	expect(
+		readWebhookCallerIdempotencyKey({
+			request: bodyRequest,
+			json: { idempotencyKey: '  body-only  ', params: { n: 1 } },
+			allowBodyKey: true,
+		}),
+	).toBe('body-only')
+	expect(
+		readWebhookCallerIdempotencyKey({
+			request: bodyRequest,
+			json: { idempotencyKey: 'body-only', params: { n: 1 } },
+			allowBodyKey: false,
+		}),
+	).toBeNull()
+
+	expect(
+		buildWebhookCallerIdempotencyHashParams({
+			json: { event: 'push' },
+			bodyText: '{"event":"push"}',
+		}),
+	).toEqual({ event: 'push' })
+	expect(
+		buildWebhookCallerIdempotencyHashParams({
+			json: null,
+			bodyText: 'not-json',
+		}),
+	).toEqual({ body: 'not-json' })
+})

--- a/packages/worker/src/webhooks/params.ts
+++ b/packages/worker/src/webhooks/params.ts
@@ -1,4 +1,7 @@
-import { type WebhookExportParams } from './types.ts'
+import {
+	webhookIdempotencyKeyHeader,
+	type WebhookExportParams,
+} from './types.ts'
 
 export function parseWebhookJsonBody(text: string): unknown | null {
 	const trimmed = text.trim()
@@ -8,6 +11,55 @@ export function parseWebhookJsonBody(text: string): unknown | null {
 	} catch {
 		return null
 	}
+}
+
+export function isWebhookJsonObject(
+	value: unknown,
+): value is Record<string, unknown> {
+	return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+export type WebhookParamsModeResolution =
+	| { ok: true; params: Record<string, unknown> }
+	| { ok: false; code: 'invalid_params' }
+
+/**
+ * `inputMode: "params"` first argument. The parsed JSON object is the export
+ * argument. When that object has a `params` property that is itself a JSON
+ * object, the platform unwraps it so invoke-token callers can POST the same
+ * `{ params, idempotencyKey }` envelope.
+ */
+export function resolveWebhookParamsModeFirstArg(
+	json: unknown,
+): WebhookParamsModeResolution {
+	if (!isWebhookJsonObject(json)) {
+		return { ok: false, code: 'invalid_params' }
+	}
+	const nested = json['params']
+	if (isWebhookJsonObject(nested)) {
+		return { ok: true, params: nested }
+	}
+	return { ok: true, params: json }
+}
+
+export function readWebhookCallerIdempotencyKey(input: {
+	request: Request
+	json: unknown
+	allowBodyKey: boolean
+}): string | null {
+	const header = input.request.headers.get(webhookIdempotencyKeyHeader)?.trim()
+	if (header) return header
+	if (!input.allowBodyKey || !isWebhookJsonObject(input.json)) return null
+	const key = input.json['idempotencyKey']
+	return typeof key === 'string' && key.trim() ? key.trim() : null
+}
+
+export function buildWebhookCallerIdempotencyHashParams(input: {
+	json: unknown
+	bodyText: string
+}): Record<string, unknown> {
+	if (isWebhookJsonObject(input.json)) return input.json
+	return { body: input.bodyText }
 }
 
 export function buildWebhookExportParams(input: {

--- a/packages/worker/src/webhooks/service.node.test.ts
+++ b/packages/worker/src/webhooks/service.node.test.ts
@@ -138,6 +138,8 @@ test('mint/list/rotate/enable/disable webhooks are package-centered and user-sco
 	expect(listedBefore).toHaveLength(1)
 	expect(listedBefore[0]?.minted).toBe(false)
 	expect(listedBefore[0]?.verification?.secretName).toBe('sentryWebhookSecret')
+	expect(listedBefore[0]?.inputMode).toBe('request')
+	expect(listedBefore[0]?.rateLimitPerMinute).toBe(60)
 
 	const minted = await mintWebhookUrlForUser({
 		env,

--- a/packages/worker/src/webhooks/service.ts
+++ b/packages/worker/src/webhooks/service.ts
@@ -26,6 +26,8 @@ export type ListedWebhook = {
 	exportName: string
 	description: string | null
 	responseMode: 'ack' | 'sync'
+	inputMode: 'request' | 'params'
+	rateLimitPerMinute: number
 	verification: PackageWebhookManifestEntry['verification']
 	replay: PackageWebhookManifestEntry['replay']
 	minted: boolean
@@ -161,6 +163,8 @@ export async function listWebhooksForUser(input: {
 				exportName: webhook.exportName,
 				description: webhook.description,
 				responseMode: webhook.responseMode,
+				inputMode: webhook.inputMode,
+				rateLimitPerMinute: webhook.rateLimitPerMinute,
 				verification: webhook.verification,
 				replay: webhook.replay,
 				minted: mint !== undefined,

--- a/packages/worker/src/webhooks/types.ts
+++ b/packages/worker/src/webhooks/types.ts
@@ -1,4 +1,11 @@
+import {
+	webhookDefaultRateLimitPerMinute as defaultRateLimitPerMinute,
+	webhookMaxRateLimitPerMinute as maxRateLimitPerMinute,
+} from '#worker/package-registry/types.ts'
+
 export type WebhookResponseMode = 'ack' | 'sync'
+
+export type WebhookInputMode = 'request' | 'params'
 
 export type WebhookHmacAlgorithm = 'hmac-sha256' | 'hmac-sha1'
 
@@ -74,9 +81,20 @@ export type WebhookExportParams = {
 
 export const webhookMaxPayloadBytes = 1 * 1024 * 1024
 export const webhookDeliveriesRetainedPerEndpoint = 50
+export const webhookDefaultRateLimitPerMinute = defaultRateLimitPerMinute
+export const webhookMaxRateLimitPerMinute = maxRateLimitPerMinute
+export const webhookRateLimitWindowSeconds = 60
 export const webhookRateLimitConfig = {
-	maxRequests: 60,
-	windowSeconds: 60,
+	maxRequests: webhookDefaultRateLimitPerMinute,
+	windowSeconds: webhookRateLimitWindowSeconds,
 } as const
+export const webhookIdempotencyKeyHeader = 'Idempotency-Key'
+
+export function webhookRateLimitConfigFor(perMinute?: number) {
+	return {
+		maxRequests: perMinute ?? webhookDefaultRateLimitPerMinute,
+		windowSeconds: webhookRateLimitWindowSeconds,
+	}
+}
 export const webhookSyncInvocationTimeoutMs = 30_000
 export const webhookDeliveryErrorMaxLength = 500


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Give inbound webhooks the minimum first-party contract that today's package invocation tokens already have, so trusted clients can leave Bearer tokens without a `*` / multi-export URL. Vendor HMAC webhooks stay the default.

## Why

Invocation tokens are the remaining external HTTP knock next to webhooks. Live first-party callers (Discord gateway, YouTube WebSub, Bluesky/LinkedIn launch, weekly-site-perf, Raycast) need caller idempotency, JSON-as-params, and a burst ceiling above ~60/min. Webhooks already bind one declared name to one export. This PR makes that path capable and records the drain (ADR 0048 + runbook). Token UI, MCP token copy, fleet email, and Kent's package migrations stay follow-ups.

## Summary

- Accept standard `Idempotency-Key` (and JSON `idempotencyKey` in `params` mode). Same key + same payload replays the package-invocation ledger; mismatch and in-progress return **409** on `sync`. Works without HMAC.
- Add `inputMode: "request" | "params"` (default `request`). `params` passes the JSON object as the export first argument and unwraps an invoke `{ params, idempotencyKey }` envelope.
- Add `rateLimitPerMinute` (default 60, max 600) per declaration. Leaked-URL DoS stays bounded. Minted-but-undeclared names use the default 60/min limit before writing delivery history.
- No `*` webhook URLs. One webhook name ↔ one export.
- Docs: trusted-client pattern in `docs/use/webhooks.md` and architecture webhooks. ADR 0048 + invocation-token retirement runbook. Token tables/UI/docs are not removed.

## Testing

- Focused node-unit: webhook params helpers, dispatch queue (unique-key vs caller-key hashing, serialized params-mode unwrap), manifest parse, webhook MCP list, service list defaults.
- Focused workers-unit: first-party Idempotency-Key / params mode / rate-limit override, undeclared minted URL at the default ceiling, plus existing HMAC vendor path.
- `test:push` (node-unit + workers-unit) green on push.
- `npm run validate` green locally on the first-party-invoke commit; review-fix commit passed typecheck + focused webhook tests + `test:push`.

## Out of scope

- Removing token UI, MCP guides, `packageGet.tokens`, token setup URLs
- Fleet email
- Migrating Kent's Discord/YouTube/etc. packages
- Changing the internal `invokePackageExport` host path (synthetic token, `source: 'webhook'`) beyond optional `idempotencyHashParams` so request-mode caller keys can hash the JSON body

## Follow-up leftovers

Token UI/docs/tables wait on a values-style soak (leftover token rows = 0). Runbook: `docs/contributing/architecture/invocation-token-retirement-runbook.md`. Tracker: https://github.com/kentcdodds/kody/issues/2038

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `64aaade6` · **Head:** `79e7d9fb`

**Classification:** extends — inbound webhooks gain caller idempotency, params input, and a bounded rate-limit override; saved-package manifests accept the new fields. No primitive added.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `webhooks` | assistant | extends — `Idempotency-Key`, `inputMode`, `rateLimitPerMinute`; undeclared minted URLs stay rate-limited; ack unique-key retries hash the envelope |
| `saved-packages` | assistant | extends — manifest schema + `listPackageWebhooks` defaults |
| `mcp-server` | surfaces | composes — search/list expose the new declaration fields |

Unmatched but related: `packages/worker/src/package-invocations/*` gains optional `idempotencyHashParams` so request-mode caller keys hash the JSON body instead of the volatile `{ webhook, request }` envelope.

### Change flow

A trusted client POSTs a minted webhook URL; params mode plus Idempotency-Key hit the same invoke ledger vendors already use for delivery ids.

```mermaid
sequenceDiagram
	actor TrustedClient
	participant webhooks as webhooks
	participant savedPackages as saved-packages
	participant invokeLedger as package-invocations
	TrustedClient->>webhooks: POST minted URL + Idempotency-Key
	webhooks->>savedPackages: listPackageWebhooks inputMode and rateLimitPerMinute
	webhooks->>webhooks: rate limit after secret match declared or default 60
	alt undeclared minted name
		webhooks-->>TrustedClient: 404 after default limit no unbounded delivery log
	else inputMode params
		webhooks->>invokeLedger: first arg JSON object include-hash
	else request mode plus caller key
		webhooks->>invokeLedger: envelope plus idempotencyHashParams body
		Note over webhooks: ack queue sets callerIdempotency
	else unique-key ack retry
		webhooks->>invokeLedger: hash webhook request envelope
	else deliveryIdHeader
		webhooks->>invokeLedger: hashed delivery id ignore-hash
	end
	invokeLedger-->>webhooks: 200 replay or 409 mismatch or in-progress
	webhooks-->>TrustedClient: sync JSON or ack 202
```

### Before / after

| | Before | After |
| --- | --- | --- |
| First-party HTTP | Bearer invocation token, `{ params, idempotencyKey }` | Minted webhook URL, `inputMode: "params"`, `Idempotency-Key` |
| Rate limit | Fixed ~60/min after secret match | Default 60 (including undeclared minted names), max 600 per declaration |
| Ack unique-key retry | Hash `{ webhook, request }` envelope | Unchanged; only caller keys hash the JSON body |
| Vendor HMAC | `{ webhook, request }` | Unchanged default `inputMode: "request"` |
| Wildcard | Token `*` export allowlist | No `*` webhook; one name per export |

### Invariants

Per-user isolation is unchanged: URL secret is still scoped to `(user_id, package_id, webhook_name)`. Caller keys share the existing per-user invoke ledger (`tokenId` is `internal:webhook:{endpointId}`).

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-56b6448d-eb13-4d52-bb37-9ffe1735b46a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-56b6448d-eb13-4d52-bb37-9ffe1735b46a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added trusted-client webhook support with `params` input mode and `Idempotency-Key` handling.
  - Added configurable per-webhook rate limits from 1–600 requests per minute, defaulting to 60.
  - Webhook listings and search results now show input mode and non-default rate limits.
  - Improved idempotency handling for retries, mismatches, and in-progress invocations.
  - `ack` deliveries now return 202 after enqueueing, while synchronous conflicts return 409.

- **Documentation**
  - Updated webhook guidance and architecture decisions, including invocation-token drain and retirement procedures.
  - Clarified webhook export, authentication, delivery, and rate-limit rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->