### PR TITLE
Move logout from the site header to the account overview

### DIFF
--- a/.agents/skills/control-kody/references/features/account.md
+++ b/.agents/skills/control-kody/references/features/account.md
@@ -1,7 +1,7 @@
 # Account hub
 
-Signed-in home: profile, export, delete, and links to the other account
-surfaces.
+Signed-in home: profile, export, logout, delete, and links to the other account
+surfaces. Logout lives at the bottom of this page, not in the site header.
 
 ## How to get there
 

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -55,10 +55,12 @@ test('smoke test covers shell, auth redirect, and login', async ({ page }) => {
 	).toBeVisible()
 	await expect(page.getByText('Failed to fetch')).not.toBeVisible()
 
-	// Log out through the top nav. The router intercepts the form POST and
-	// SPA-navigates to /login, so the shell must refresh its session state
-	// without a full document reload (regression: the throttled refresh kept
-	// the username and Log out button visible after logging out).
+	// Log out from the account overview. The router intercepts the form POST
+	// and SPA-navigates to /login, so the shell must refresh its session
+	// state without a full document reload (regression: the throttled refresh
+	// kept the username and Log out button visible after logging out).
+	await page.goto('/account')
+	await expect(page).toHaveURL(/\/account$/)
 	await page.getByRole('button', { name: 'Log out' }).click()
 	await expect(page).toHaveURL(/\/login$/)
 	// The redesigned login screen renders without the site header, so the

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -61,7 +61,14 @@ test('smoke test covers shell, auth redirect, and login', async ({ page }) => {
 	// kept the username and Log out button visible after logging out).
 	await page.goto('/account')
 	await expect(page).toHaveURL(/\/account$/)
-	await page.getByRole('button', { name: 'Log out' }).click()
+	await expect(
+		page.getByRole('navigation', { name: 'Main' }).getByRole('button', {
+			name: 'Log out',
+		}),
+	).toHaveCount(0)
+	const session = page.getByRole('region', { name: 'Session', exact: true })
+	await expect(session).toBeVisible()
+	await session.getByRole('button', { name: 'Log out' }).click()
 	await expect(page).toHaveURL(/\/login$/)
 	// The redesigned login screen renders without the site header, so the
 	// logged-out state shows the auth card instead of a header "Log in" link.

--- a/packages/worker/client/routes/account-logout-panel.tsx
+++ b/packages/worker/client/routes/account-logout-panel.tsx
@@ -1,0 +1,25 @@
+import { css } from 'remix/ui'
+import { routes } from '#universal/routes.ts'
+import { getGhostButtonCss } from '#universal/styles/style-primitives.ts'
+import { AccountManagementPanel } from '#client/routes/account-management-components.tsx'
+
+const compactGhostButtonCss = getGhostButtonCss({ size: 'sm' })
+
+export function renderAccountLogoutPanel() {
+	return (
+		<AccountManagementPanel
+			title="Session"
+			description="Sign out of this browser. Your account and data stay intact."
+		>
+			<form
+				method="post"
+				action={routes.logout.href()}
+				mix={css({ margin: 0 })}
+			>
+				<button type="submit" mix={css(compactGhostButtonCss)}>
+					Log out
+				</button>
+			</form>
+		</AccountManagementPanel>
+	)
+}

--- a/packages/worker/client/routes/account-logout-panel.tsx
+++ b/packages/worker/client/routes/account-logout-panel.tsx
@@ -10,6 +10,7 @@ export function renderAccountLogoutPanel() {
 		<AccountManagementPanel
 			title="Session"
 			description="Sign out of this browser. Your account and data stay intact."
+			ariaLabel="Session"
 		>
 			<form
 				method="post"

--- a/packages/worker/client/routes/account.tsx
+++ b/packages/worker/client/routes/account.tsx
@@ -12,7 +12,6 @@ import {
 	type ProfileVisibility,
 } from '#universal/loader-data.ts'
 import { acceptedEmailVerificationDelivery } from '#universal/email-verification-delivery.ts'
-import { routes } from '#universal/routes.ts'
 import {
 	colors,
 	radius,
@@ -31,6 +30,7 @@ import {
 	readJson,
 } from '#client/routes/account-approval-shared.ts'
 import { AccountDeletePanel } from '#client/routes/account-delete-panel.tsx'
+import { renderAccountLogoutPanel } from '#client/routes/account-logout-panel.tsx'
 import {
 	AccountManagementMessage,
 	AccountManagementPanel,
@@ -731,20 +731,7 @@ export function AccountRoute(handle: Handle) {
 					</>
 				) : null}
 
-				<AccountManagementPanel
-					title="Session"
-					description="Sign out of this browser. Your account and data stay intact."
-				>
-					<form
-						method="post"
-						action={routes.logout.href()}
-						mix={css({ margin: 0 })}
-					>
-						<button type="submit" mix={css(compactGhostButtonCss)}>
-							Log out
-						</button>
-					</form>
-				</AccountManagementPanel>
+				{renderAccountLogoutPanel()}
 
 				<AccountAvatarEditor
 					file={editorFile}

--- a/packages/worker/client/routes/account.tsx
+++ b/packages/worker/client/routes/account.tsx
@@ -12,6 +12,7 @@ import {
 	type ProfileVisibility,
 } from '#universal/loader-data.ts'
 import { acceptedEmailVerificationDelivery } from '#universal/email-verification-delivery.ts'
+import { routes } from '#universal/routes.ts'
 import {
 	colors,
 	radius,
@@ -729,6 +730,21 @@ export function AccountRoute(handle: Handle) {
 						</AccountManagementPanel>
 					</>
 				) : null}
+
+				<AccountManagementPanel
+					title="Session"
+					description="Sign out of this browser. Your account and data stay intact."
+				>
+					<form
+						method="post"
+						action={routes.logout.href()}
+						mix={css({ margin: 0 })}
+					>
+						<button type="submit" mix={css(compactGhostButtonCss)}>
+							Log out
+						</button>
+					</form>
+				</AccountManagementPanel>
 
 				<AccountAvatarEditor
 					file={editorFile}

--- a/packages/worker/client/site-header.tsx
+++ b/packages/worker/client/site-header.tsx
@@ -140,11 +140,6 @@ export function SiteHeader(handle: Handle<SiteHeaderProps>) {
 									Demo
 								</span>
 							) : null}
-							<form method="post" action="/logout" mix={css({ margin: 0 })}>
-								<button type="submit" mix={css(logOutButtonCss)}>
-									Log out
-								</button>
-							</form>
 						</>
 					) : (
 						<a href={handle.props.loginHref} mix={css(navLoginCss)}>
@@ -216,15 +211,6 @@ export function SiteHeader(handle: Handle<SiteHeaderProps>) {
 										variant="well"
 									/>
 								</a>
-								<form
-									method="post"
-									action="/logout"
-									mix={css({ margin: 0, display: 'grid' })}
-								>
-									<button type="submit" mix={css(menuLogOutCss)}>
-										Log out
-									</button>
-								</form>
 							</>
 						) : (
 							<a href={handle.props.loginHref}>Log in</a>
@@ -442,24 +428,6 @@ const menuGroupCss = {
 	},
 }
 
-const menuLogOutCss = {
-	appearance: 'none' as const,
-	minHeight: '44px',
-	padding: '0 0.85rem',
-	borderRadius: '12px',
-	border: 'none',
-	background: 'transparent',
-	textAlign: 'left' as const,
-	font: `550 1rem/1 ${typography.fontFamilyBody}`,
-	color: colors.text,
-	cursor: 'pointer',
-	transition: `background-color ${transitions.fast}`,
-	'&:active': { backgroundColor: colors.primarySoftest },
-	[hoverMq]: {
-		'&:hover': { backgroundColor: colors.primarySoftest },
-	},
-}
-
 const navLoginCss = {
 	fontWeight: 550,
 	fontSize: '0.98rem',
@@ -486,23 +454,6 @@ const menuWaitingAvatarCss = {
 	display: 'inline-flex',
 	alignItems: 'center',
 	width: 'fit-content',
-}
-
-/**
- * Logging out has to be a form POST, but the prototype's session corner is
- * two quiet text links (`.nav-user` then `.nav-login`) — a bordered pill here
- * reads as the page's main action, which logging out is not. So: the nav-link
- * treatment, with the button chrome stripped off.
- */
-const logOutButtonCss = {
-	...navLoginCss,
-	appearance: 'none' as const,
-	border: 'none',
-	background: 'transparent',
-	cursor: 'pointer',
-	// A button does not inherit the page font.
-	font: `550 0.98rem/1 ${typography.fontFamilyBody}`,
-	transition: `color ${transitions.fast}`,
 }
 
 const demoIndicatorCss = {

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -401,6 +401,7 @@ test('SSR HTML routes render page content and embedded loader data', async () =>
 	expect(accountHtml).toContain('/pending-verification')
 	expect(accountHtml).toContain('action="/logout"')
 	expect(accountHtml).toContain('Log out')
+	expect(accountHtml).toContain('aria-label="Session"')
 
 	// Two-factor and passkeys embed the same payload their .json endpoints
 	// serve, so the page server-renders its real state instead of a loading

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -399,6 +399,8 @@ test('SSR HTML routes render page content and embedded loader data', async () =>
 		checklist: null,
 	})
 	expect(accountHtml).toContain('/pending-verification')
+	expect(accountHtml).toContain('action="/logout"')
+	expect(accountHtml).toContain('Log out')
 
 	// Two-factor and passkeys embed the same payload their .json endpoints
 	// serve, so the page server-renders its real state instead of a loading
@@ -415,6 +417,7 @@ test('SSR HTML routes render page content and embedded loader data', async () =>
 		ok: true,
 		enabled: false,
 	})
+	expect(twoFactorHtml).not.toContain('action="/logout"')
 
 	const passkeysResponse = await runHtmlHandler(
 		createAccountPasskeysHandler(env),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Keep logout available, but only on the signed-in account overview — not in the global nav.

## Why

Kent asked that Kody not show logout in the nav. People should log out from the bottom of the account overview page.

## Summary

- Removed the desktop and mobile **Log out** forms from the site header.
- Added a **Session** section at the bottom of `/account` with the same `POST /logout` form and a ghost **Log out** button.
- Smoke and SSR tests assert logout lives on the overview Session region, not in the header.

## Testing

- Pre-commit typecheck passed.
- Push hook: `test:node` (2534) and `test:workers` (326) passed.
- File-size ratchet: extracted `account-logout-panel.tsx` so `account.tsx` stays under 800 lines.
- Browser: signed in as `jane@example.com`, confirmed no logout in desktop or mobile nav, Session **Log out** at the bottom of `/account`, and logout redirects to `/login`.
- After merge: production `/account` should show logout at the bottom; the header should not.

![Account header without logout](https://cursor.com/artifacts/c/art-f481d412-c1dd-4f01-b8da-72fcd12ee580)
![Session logout at the bottom of account overview](https://cursor.com/artifacts/c/art-aea85383-2ca3-4843-adc8-187a54dad34f)
![Mobile menu without logout](https://cursor.com/artifacts/c/art-4fccf381-ce77-48ca-9d7d-1c309993f18b)
![Login page after logout](https://cursor.com/artifacts/c/art-a76a2950-87c5-4375-9adc-845668103865)

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `9a23a840` · **Head:** `05289377`

**Classification:** composes — no primitives added or changed; this PR relocates an existing logout control.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `app-ui` | surfaces | composes — header loses logout; `/account` posts the same `POST /logout` |

### Change flow

Signed-in users leave the session from the account overview. The logout action and cookie destroy path are unchanged.

```mermaid
sequenceDiagram
	actor User
	participant appUi as app-ui
	participant appSessions as app-sessions
	User->>appUi: open /account
	Note over appUi: Session panel at the bottom posts to /logout
	User->>appUi: click Log out
	appUi->>appSessions: POST /logout
	appSessions-->>appUi: 302 /login and destroy session cookie
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6e74fd90-9008-4907-88e3-900469c594cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6e74fd90-9008-4907-88e3-900469c594cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Moved the **Log out** action from the site header and mobile menu to the bottom of the account overview page.
  * Added a session panel on the account page with a dedicated **Log out** button.
  * Updated sign-out coverage and page rendering checks to reflect the new location and ensure logout is unavailable on the two-factor page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->