### PR TITLE
Cut over weekly site-perf Action to inbound webhook URL

### DIFF
--- a/.github/workflows/weekly-site-perf.yml
+++ b/.github/workflows/weekly-site-perf.yml
@@ -43,8 +43,7 @@ jobs:
 
       - name: 🚀 Invoke weekly-site-perf package
         env:
-          KODY_PACKAGE_INVOCATION_TOKEN:
-            ${{ secrets.KODY_PACKAGE_INVOCATION_TOKEN }}
+          KODY_WEBHOOK_URL_RUN: ${{ secrets.KODY_WEBHOOK_URL_RUN }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run:
           node tools/site-perf/invoke-site-perf-package.ts site-perf-report.json

--- a/docs/contributing/architecture/invocation-token-retirement-runbook.md
+++ b/docs/contributing/architecture/invocation-token-retirement-runbook.md
@@ -33,7 +33,6 @@ change):
   `./dispatch-message-reaction-add`
 - `@kentcdodds/youtube-livestream-vod-manager` — `./process-video`
 - `@kentcdodds/bluesky` and `@kentcdodds/linkedin` — create/delete/get exports
-- `@kentcdodds/weekly-site-perf` — root `.` export
 - `@kentcdodds/raycast` — one webhook per export the extension calls (not `*`)
 
 ## Remaining work

--- a/docs/contributing/setup-manifest.md
+++ b/docs/contributing/setup-manifest.md
@@ -582,13 +582,15 @@ Configure these GitHub Actions secrets and variables for workflows:
 - `STRIPE_WEBHOOK_SECRET` (optional GitHub / Worker secret; Stripe endpoint
   signing secret (`whsec_...`) for platform billing webhooks at
   `POST /webhooks/stripe`. Production deploy syncs it when set.)
-- `KODY_PACKAGE_INVOCATION_TOKEN` (optional GitHub **secret**; weekly site-perf
-  workflow only. When a `needs-fix` verdict is recorded,
+- `KODY_WEBHOOK_URL_RUN` (optional GitHub **secret**; weekly site-perf workflow
+  only. When a `needs-fix` verdict is recorded,
   [`.github/workflows/weekly-site-perf.yml`](../../.github/workflows/weekly-site-perf.yml)
-  uses it to `POST` the unadvertised invocation-token drain at
-  `https://kody.codes/@kentcdodds/api/package-invocations/weekly-site-perf/__root__`.
-  Not a Worker secret; the weekly job skips invoke when this is unset. New
-  first-party callers mint a webhook URL.)
+  `POST`s this minted inbound webhook URL for `@kentcdodds/weekly-site-perf`
+  webhook `run` (`inputMode: "params"`, `responseMode: "sync"`). The value is
+  the Kody user secret `weeklySitePerfWebhookRun`
+  (https://kody.codes/account/secrets/user/weeklySitePerfWebhookRun); Kent
+  copies it into GitHub. Agents never paste the URL. Not a Worker secret; the
+  weekly job skips invoke when this is unset.)
 - `SENTRY_AUTH_TOKEN` (optional GitHub **secret**; Sentry auth token with
   `project:releases` / source map upload permissions — used only by CI to run
   `npm run sentry:upload-sourcemaps` after deploy)
@@ -679,12 +681,15 @@ How to get/set each value:
     ID.
   - Store that value as the preview GitHub Actions secret so preview deploys
     sync a different worker secret than production.
-- `KODY_PACKAGE_INVOCATION_TOKEN` (optional)
-  - Existing repository secret for the weekly site-perf soak drain. New callers
-    mint a webhook URL on `@kentcdodds/weekly-site-perf` instead of creating a
-    bearer token. Rotate the leftover token with `POST /account/packages.json`
-    (`action: "update-token"`). The weekly workflow uses this secret only to
-    invoke that package; it is not synced to the Worker.
+- `KODY_WEBHOOK_URL_RUN` (optional)
+  - Minted inbound webhook URL for `@kentcdodds/weekly-site-perf` webhook `run`.
+  - Kent copies the value from the Kody user secret `weeklySitePerfWebhookRun`
+    at https://kody.codes/account/secrets/user/weeklySitePerfWebhookRun into the
+    GitHub Actions repository secret `KODY_WEBHOOK_URL_RUN`. Agents never paste
+    the URL.
+  - The weekly workflow uses this secret only to invoke that package; it is not
+    synced to the Worker. Rotate with `webhookUrlRotate`, then update both the
+    Kody user secret and this GitHub secret.
 - `SENTRY_DSN` (optional)
   - In Sentry: create a project, copy the DSN, and add it as the repository
     secret `SENTRY_DSN`. Production and preview deploy workflows sync it with

--- a/docs/contributing/weekly-site-perf.md
+++ b/docs/contributing/weekly-site-perf.md
@@ -36,10 +36,10 @@ that issue (and the older `actionable` / `human review` titles).
 
 ## Kody package invoke
 
-When the verdict is `needs-fix` and `KODY_PACKAGE_INVOCATION_TOKEN` is set, the
-same job `POST`s
-`https://kody.codes/@kentcdodds/api/package-invocations/weekly-site-perf/__root__`
-with the report. See [package invocation API](./package-invocation-api.md).
+When the verdict is `needs-fix` and `KODY_WEBHOOK_URL_RUN` is set, the same job
+`POST`s that minted webhook URL with a params-mode JSON body and an
+`Idempotency-Key` header. There is no `Authorization` header; the URL is the
+credential. See [inbound webhooks](../use/webhooks.md).
 
 The `weekly-site-perf` package owns the agent prompt and calls `createAgent`
 from `@kentcdodds/cursor`. The Cursor API key stays a Kody secret on that Cursor
@@ -47,20 +47,23 @@ package. The agent implements an obvious local fix when it can, follows
 [`.agents/skills/ship-pr/SKILL.md`](../../.agents/skills/ship-pr/SKILL.md), or
 leaves the tracking issue open when a human should decide.
 
-The live Action uses the unadvertised invocation-token drain for
-`@kentcdodds/weekly-site-perf`. Store the raw bearer as the repository (or org)
-secret `KODY_PACKAGE_INVOCATION_TOKEN`. Rotate it with
-`POST /account/packages.json` (`action: "update-token"`). New first-party
-callers mint a webhook (`inputMode: "params"`, `Idempotency-Key`). See
-[setup manifest](./setup-manifest.md) and
-[inbound webhooks](../use/webhooks.md).
+`@kentcdodds/weekly-site-perf` declares webhook `run` (`inputMode: "params"`,
+`responseMode: "sync"`) on the root `.` export. The live Action reads the minted
+URL from the repository (or org) secret `KODY_WEBHOOK_URL_RUN`. Kent copies that
+value from the Kody user secret `weeklySitePerfWebhookRun` at
+https://kody.codes/account/secrets/user/weeklySitePerfWebhookRun. Agents never
+paste the URL. Rotate with `webhookUrlRotate`, then update both the Kody user
+secret and the GitHub secret. See [setup manifest](./setup-manifest.md).
 
 If the secret is unset, the workflow still measures and upserts the issue. It
 skips the invoke so the weekly job stays green.
 
 Retries of the same GitHub run reuse
-`idempotencyKey: weekly-site-perf:<GITHUB_RUN_ID>`. A successful invoke that
-returns an agent URL comments it on the open needs-fix issue.
+`Idempotency-Key: weekly-site-perf:<GITHUB_RUN_ID>` (and the same
+`idempotencyKey` in the JSON body). A successful sync invoke that returns an
+agent URL comments it on the open needs-fix issue. `409 invocation_in_progress`
+counts as launched; `409 idempotency_mismatch` and other non-2xx responses fail
+the step.
 
 ## What the homepage already does
 

--- a/tools/site-perf/invoke-site-perf-package.node.test.ts
+++ b/tools/site-perf/invoke-site-perf-package.node.test.ts
@@ -2,8 +2,6 @@ import { expect, test } from 'vitest'
 import { type SitePerfReport } from './collect.ts'
 import {
 	buildInvokeBody,
-	defaultInvokeSource,
-	defaultInvokeUrl,
 	invokeSitePerfPackage,
 	shouldInvokeSitePerfPackage,
 } from './invoke-site-perf-package.ts'
@@ -28,7 +26,9 @@ const needsFixReport: SitePerfReport = {
 	verdict: 'needs-fix',
 }
 
-test('invoke gates on needs-fix and a token, and builds an idempotent body', async () => {
+const exampleWebhookUrl = 'https://example.test/webhooks/weekly-site-perf/run'
+
+test('invoke gates on needs-fix and a webhook URL, and builds a params body', async () => {
 	expect(
 		shouldInvokeSitePerfPackage({ ...needsFixReport, verdict: 'ok' }),
 	).toBe(false)
@@ -47,7 +47,6 @@ test('invoke gates on needs-fix and a token, and builds an idempotent body', asy
 			startingRef: 'main',
 		},
 		idempotencyKey: 'weekly-site-perf:99',
-		source: defaultInvokeSource,
 	})
 
 	const fetchImpl = async () => {
@@ -56,7 +55,7 @@ test('invoke gates on needs-fix and a token, and builds an idempotent body', asy
 	expect(
 		await invokeSitePerfPackage({
 			report: { ...needsFixReport, verdict: 'ok' },
-			token: 'token',
+			webhookUrl: exampleWebhookUrl,
 			repository: 'kentcdodds/kody',
 			startingRef: 'main',
 			runId: '1',
@@ -66,21 +65,38 @@ test('invoke gates on needs-fix and a token, and builds an idempotent body', asy
 	expect(
 		await invokeSitePerfPackage({
 			report: needsFixReport,
-			token: undefined,
+			webhookUrl: undefined,
 			repository: 'kentcdodds/kody',
 			startingRef: 'main',
 			runId: '1',
 			fetchImpl,
 		}),
-	).toEqual({ skipped: 'missing-token' })
+	).toEqual({ skipped: 'missing-webhook-url' })
+	expect(
+		await invokeSitePerfPackage({
+			report: needsFixReport,
+			webhookUrl: '',
+			repository: 'kentcdodds/kody',
+			startingRef: 'main',
+			runId: '1',
+			fetchImpl,
+		}),
+	).toEqual({ skipped: 'missing-webhook-url' })
 })
 
-test('invoke posts the report, treats replay/in-progress as launched, and surfaces API errors', async () => {
-	const calls: Array<{ url: string; auth: string | null; body: unknown }> = []
+test('invoke posts params to the webhook URL, treats replay/in-progress as launched, and surfaces API errors', async () => {
+	const calls: Array<{
+		url: string
+		auth: string | null
+		idempotencyKey: string | null
+		body: unknown
+	}> = []
 	const fetchImpl: typeof fetch = async (url, init) => {
+		const headers = new Headers(init?.headers)
 		calls.push({
 			url: String(url),
-			auth: new Headers(init?.headers).get('Authorization'),
+			auth: headers.get('Authorization'),
+			idempotencyKey: headers.get('Idempotency-Key'),
 			body: JSON.parse(String(init?.body)),
 		})
 		return new Response(
@@ -100,7 +116,7 @@ test('invoke posts the report, treats replay/in-progress as launched, and surfac
 
 	const invoked = await invokeSitePerfPackage({
 		report: needsFixReport,
-		token: 'kody_test',
+		webhookUrl: exampleWebhookUrl,
 		repository: 'kentcdodds/kody',
 		startingRef: 'main',
 		runId: '77',
@@ -108,14 +124,17 @@ test('invoke posts the report, treats replay/in-progress as launched, and surfac
 	})
 	expect(calls).toEqual([
 		{
-			url: defaultInvokeUrl,
-			auth: 'Bearer kody_test',
-			body: buildInvokeBody({
-				report: needsFixReport,
-				repository: 'kentcdodds/kody',
-				startingRef: 'main',
-				runId: '77',
-			}),
+			url: exampleWebhookUrl,
+			auth: null,
+			idempotencyKey: 'weekly-site-perf:77',
+			body: {
+				params: {
+					report: needsFixReport,
+					repository: 'kentcdodds/kody',
+					startingRef: 'main',
+				},
+				idempotencyKey: 'weekly-site-perf:77',
+			},
 		},
 	])
 	expect(invoked).toEqual({
@@ -132,7 +151,7 @@ test('invoke posts the report, treats replay/in-progress as launched, and surfac
 
 	const replayed = await invokeSitePerfPackage({
 		report: needsFixReport,
-		token: 'kody_test',
+		webhookUrl: exampleWebhookUrl,
 		repository: 'kentcdodds/kody',
 		startingRef: 'main',
 		runId: '77',
@@ -150,7 +169,7 @@ test('invoke posts the report, treats replay/in-progress as launched, and surfac
 
 	const inProgress = await invokeSitePerfPackage({
 		report: needsFixReport,
-		token: 'kody_test',
+		webhookUrl: exampleWebhookUrl,
 		repository: 'kentcdodds/kody',
 		startingRef: 'main',
 		runId: '77',
@@ -168,12 +187,30 @@ test('invoke posts the report, treats replay/in-progress as launched, and surfac
 	await expect(
 		invokeSitePerfPackage({
 			report: needsFixReport,
-			token: 'kody_test',
+			webhookUrl: exampleWebhookUrl,
+			repository: 'kentcdodds/kody',
+			startingRef: 'main',
+			runId: '88',
+			fetchImpl: async () =>
+				new Response(
+					JSON.stringify({
+						ok: false,
+						error: { code: 'idempotency_mismatch' },
+					}),
+					{ status: 409 },
+				),
+		}),
+	).rejects.toThrow(/Kody webhook idempotency mismatch/)
+
+	await expect(
+		invokeSitePerfPackage({
+			report: needsFixReport,
+			webhookUrl: exampleWebhookUrl,
 			repository: 'kentcdodds/kody',
 			startingRef: 'main',
 			runId: '88',
 			fetchImpl: async () =>
 				new Response('upstream unavailable', { status: 503 }),
 		}),
-	).rejects.toThrow(/Kody package invocation 503/)
+	).rejects.toThrow(/Kody webhook 503/)
 })

--- a/tools/site-perf/invoke-site-perf-package.ts
+++ b/tools/site-perf/invoke-site-perf-package.ts
@@ -4,11 +4,6 @@ import { isExecutedDirectly } from '../node-runtime.ts'
 import { type SitePerfReport } from './collect.ts'
 import { needsFixTitle } from './upsert-github-issue.ts'
 
-export const defaultInvokeUrl =
-	'https://kody.codes/@kentcdodds/api/package-invocations/weekly-site-perf/__root__'
-
-export const defaultInvokeSource = 'weekly-site-perf'
-
 export function shouldInvokeSitePerfPackage(report: SitePerfReport) {
 	return report.verdict === 'needs-fix'
 }
@@ -18,7 +13,6 @@ export function buildInvokeBody(input: {
 	repository: string
 	startingRef: string
 	runId: string
-	source?: string
 }) {
 	return {
 		params: {
@@ -27,12 +21,11 @@ export function buildInvokeBody(input: {
 			startingRef: input.startingRef,
 		},
 		idempotencyKey: `weekly-site-perf:${input.runId}`,
-		source: input.source ?? defaultInvokeSource,
 	}
 }
 
 export type InvokeSitePerfPackageResult =
-	| { skipped: 'ok' | 'missing-token' }
+	| { skipped: 'ok' | 'missing-webhook-url' }
 	| {
 			invoked: true
 			replayed?: true
@@ -57,33 +50,28 @@ function agentUrlFromResult(result: unknown): string | undefined {
 
 export async function invokeSitePerfPackage(input: {
 	report: SitePerfReport
-	token: string | undefined
+	webhookUrl: string | undefined
 	repository: string
 	startingRef: string
 	runId: string
-	invokeUrl?: string
-	source?: string
 	fetchImpl?: typeof fetch
 }): Promise<InvokeSitePerfPackageResult> {
 	if (!shouldInvokeSitePerfPackage(input.report)) {
 		return { skipped: 'ok' }
 	}
-	if (!input.token) {
-		return { skipped: 'missing-token' }
+	if (!input.webhookUrl) {
+		return { skipped: 'missing-webhook-url' }
 	}
 
 	const body = buildInvokeBody(input)
-	const response = await (input.fetchImpl ?? fetch)(
-		input.invokeUrl ?? defaultInvokeUrl,
-		{
-			method: 'POST',
-			headers: {
-				Authorization: `Bearer ${input.token}`,
-				'Content-Type': 'application/json',
-			},
-			body: JSON.stringify(body),
+	const response = await (input.fetchImpl ?? fetch)(input.webhookUrl, {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+			'Idempotency-Key': body.idempotencyKey,
 		},
-	)
+		body: JSON.stringify(body),
+	})
 
 	const detail = await response.text()
 	let payload: {
@@ -108,15 +96,13 @@ export async function invokeSitePerfPackage(input: {
 		}
 		if (payload.error?.code === 'idempotency_mismatch') {
 			throw new Error(
-				`Kody package invocation idempotency mismatch: ${detail.slice(0, 2000)}`,
+				`Kody webhook idempotency mismatch: ${detail.slice(0, 2000)}`,
 			)
 		}
 	}
 
 	if (!response.ok) {
-		throw new Error(
-			`Kody package invocation ${response.status}: ${detail.slice(0, 2000)}`,
-		)
+		throw new Error(`Kody webhook ${response.status}: ${detail.slice(0, 2000)}`)
 	}
 
 	return {
@@ -169,12 +155,10 @@ export async function main(argv = process.argv.slice(2)) {
 	) as SitePerfReport
 	const result = await invokeSitePerfPackage({
 		report,
-		token: process.env.KODY_PACKAGE_INVOCATION_TOKEN,
+		webhookUrl: process.env.KODY_WEBHOOK_URL_RUN,
 		repository: process.env.GITHUB_REPOSITORY ?? 'kentcdodds/kody',
 		startingRef: process.env.SITE_PERF_STARTING_REF ?? 'main',
 		runId: process.env.GITHUB_RUN_ID ?? 'local',
-		invokeUrl: process.env.KODY_PACKAGE_INVOKE_URL,
-		source: process.env.KODY_PACKAGE_INVOKE_SOURCE,
 	})
 	process.stdout.write(`${JSON.stringify(result)}\n`)
 	if (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Point the weekly site-perf GitHub Action at a minted inbound package webhook so it no longer uses the unadvertised package-invocation Bearer drain.

## Why

Inbound webhooks are the advertised external HTTP knock ([0048](https://github.com/kentcdodds/kody/blob/main/docs/contributing/decisions/0048-webhooks-replace-invocation-tokens.md)). `@kentcdodds/weekly-site-perf` already declares webhook `run` (`inputMode: params`, `responseMode: sync`) on the root `.` export. This PR is the Action-side cutover.

## Operator step (required for the next live invoke)

Kent must create or update the GitHub Actions repository secret **`KODY_WEBHOOK_URL_RUN`**.

- Copy the value from the Kody user secret **`weeklySitePerfWebhookRun`**: https://kody.codes/account/secrets/user/weeklySitePerfWebhookRun
- Kent copies it. Agents never paste the URL or token.
- After this ships, the leftover GitHub secret `KODY_PACKAGE_INVOCATION_TOKEN` is unused and can be deleted.

Until `KODY_WEBHOOK_URL_RUN` is set, the weekly job still measures and upserts the tracking issue; it skips the package invoke so the job stays green.

## Summary

- [`.github/workflows/weekly-site-perf.yml`](.github/workflows/weekly-site-perf.yml) reads `secrets.KODY_WEBHOOK_URL_RUN` instead of `KODY_PACKAGE_INVOCATION_TOKEN`.
- [`tools/site-perf/invoke-site-perf-package.ts`](tools/site-perf/invoke-site-perf-package.ts) `POST`s that minted URL with `{ "params": { report, repository, startingRef }, "idempotencyKey": "weekly-site-perf:<runId>" }` and an `Idempotency-Key` header. No `Authorization` header. No hardcoded `package-invocations` URL.
- Sync behavior is unchanged: the Action still needs the export JSON (agent URL). `409 invocation_in_progress` counts as launched; `409 idempotency_mismatch` and other non-2xx fail the step.
- Docs in `docs/contributing/weekly-site-perf.md` and `docs/contributing/setup-manifest.md` describe the webhook secret. The retirement runbook no longer lists weekly-site-perf as a leftover token caller.

## Testing

- `npx vitest run --project node-unit tools/site-perf/invoke-site-perf-package.node.test.ts` — 2 passed
- Pre-push hook: `test:node` (2529) and `test:workers` (326) passed
- Pre-commit: format, oxlint, typecheck, migrations check

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `c06a8685` · **Head:** `d56d8ab2`

**Classification:** composes — no primitives added or changed; this PR rewires the weekly site-perf GitHub Action onto an existing inbound webhook.

### Primitives touched

| Primitive  | Group     | Impact                                                                                          |
| ---------- | --------- | ----------------------------------------------------------------------------------------------- |
| `webhooks` | assistant | composes — caller only (classifier unmatched; no `packages/worker/src/webhooks/` code in this diff) |

Unmatched paths are the Action, invoke helper, and contributing docs.

### Change flow

The weekly job POSTs a minted webhook URL (`KODY_WEBHOOK_URL_RUN`) instead of Bearer `package-invocations`.

```mermaid
sequenceDiagram
	actor weeklyJob as Weekly site-perf Action
	participant webhooks as webhooks
	weeklyJob->>webhooks: POST minted URL with params JSON + Idempotency-Key
	alt 200 sync export
		webhooks-->>weeklyJob: export JSON including agent URL
	else 409 invocation_in_progress
		webhooks-->>weeklyJob: treat as launched
	else 409 idempotency_mismatch or other non-2xx
		webhooks-->>weeklyJob: fail the step
	end
```

### Before / after

|                | Before                                         | After                                              |
| -------------- | ---------------------------------------------- | -------------------------------------------------- |
| Credential     | `Authorization: Bearer` from GH secret         | minted webhook URL from `KODY_WEBHOOK_URL_RUN`     |
| Target         | hardcoded `/api/package-invocations/…/__root__` | secret URL (`/@…/webhooks/weekly-site-perf/run/…`) |
| Body           | invoke envelope with `params` + `source`       | `{ "params": { … }, "idempotencyKey": "…" }`       |
| Idempotency    | JSON `idempotencyKey` only                     | `Idempotency-Key` header + JSON `idempotencyKey`   |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2e6700a3-1b09-4922-8a43-f6e76aff8853?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2e6700a3-1b09-4922-8a43-f6e76aff8853&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Weekly site-performance checks now invoke Kody through a webhook URL instead of bearer-token authentication.
  - Requests include idempotency information, improving retry handling and preventing duplicate invocations.
  - Successful synchronous runs can post the resulting agent URL to the related open issue.
  - Missing webhook configuration continues to skip invocation safely; invocation errors are reported for unsuccessful responses.

- **Documentation**
  - Updated setup and contributor guidance with webhook configuration, secret handling, rotation, request behavior, and troubleshooting details.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->