### PR TITLE
Mint OIDC id_tokens when /oauth/token has no injected OAUTH_PROVIDER

### DIFF
--- a/docs/contributing/architecture/authentication.md
+++ b/docs/contributing/architecture/authentication.md
@@ -703,9 +703,12 @@ routed from `packages/worker/src/index.ts`.
   fail-closed when email is unverified). RP-Initiated Logout: `/oauth/logout`.
   Token responses from `/oauth/token` gain an `id_token` when the granted scope
   includes `openid` (authorization_code and refresh_token grants; refresh omits
-  `nonce`). Implicit and Hybrid response types are not advertised or accepted.
-  Kody is not OpenID Certified. `/api/me` remains the OAuth-protected JSON
-  helper for grant props; it is not the OIDC UserInfo endpoint.
+  `nonce`). The provider handles the token path internally and does not inject
+  `env.OAUTH_PROVIDER` there (or on UserInfo/logout, which run before
+  `oauthProvider.fetch`), so those OIDC helpers come from `resolveOAuthHelpers`
+  over `OAUTH_KV`. Implicit and Hybrid response types are not advertised or
+  accepted. Kody is not OpenID Certified. `/api/me` remains the OAuth-protected
+  JSON helper for grant props; it is not the OIDC UserInfo endpoint.
 - On `/oauth/authorize`, unauthenticated users can log in inline or via top-nav
   auth links; those links preserve the full authorize URL in `redirectTo` so
   successful login returns to the original OAuth request. Password signup lands

--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -507,13 +507,14 @@ reserved-username override, and the platform-owned
   in the app handlers; account deletion revokes all provider grants for the
   user. Outside the provider's `fetch` wrapper (scheduled purge lane, RPC
   entrypoints, the `MCP` Durable Object on kody-platform) `env.OAUTH_PROVIDER`
-  is undefined, so `packages/worker/src/oauth-helpers.ts` builds the same
-  `OAuthHelpers` through the library's `getOAuthApi` (loaded on demand from the
-  pre-bundled `oauth-provider.mjs` additional module, with the provider options
-  shared from `packages/worker/src/oauth-provider-options.ts`) so grant, token,
-  and client deletes hit the same keys. `packages/worker/src/oauth-purge.ts`
-  models the provider's key layout for the orphan/expiry sweep, which the
-  library does not expose.
+  is undefined (and the token endpoint never injects it even on origin), so
+  `packages/worker/src/oauth-helpers.ts` builds the same `OAuthHelpers` through
+  the library's `getOAuthApi` (loaded on demand from the pre-bundled
+  `oauth-provider.mjs` additional module, with the provider options shared from
+  `packages/worker/src/oauth-provider-options.ts`) so grant, token, client, and
+  OIDC unwrap/lookup calls hit the same keys.
+  `packages/worker/src/oauth-purge.ts` models the provider's key layout for the
+  orphan/expiry sweep, which the library does not expose.
 - `BUNDLE_ARTIFACTS_KV` keys are deleted from account deletion using D1-derived
   source ids, published commits, bundle artifact rows, community listing ids,
   and package ids.

--- a/packages/worker/src/oauth-handlers.workers.test.ts
+++ b/packages/worker/src/oauth-handlers.workers.test.ts
@@ -1572,6 +1572,17 @@ test('worker entrypoint returns id_token when openid scope is granted', async ()
 		const code = new URL(approvalPayload.redirectTo).searchParams.get('code')
 		expect(code).toBeTruthy()
 
+		// Authorize (default handler) injects `env.OAUTH_PROVIDER` onto the
+		// shared isolate env. Production token requests are a fresh isolate
+		// and the token path never injects helpers — hide the leftover so
+		// enrichment must use `resolveOAuthHelpers` over OAUTH_KV.
+		const tokenEnv = new Proxy(env, {
+			get(target, prop, receiver) {
+				if (prop === 'OAUTH_PROVIDER') return undefined
+				return Reflect.get(target, prop, receiver)
+			},
+		}) as Env
+
 		const tokenResponse = await workerFetch(
 			new Request('https://heykody.dev/oauth/token', {
 				method: 'POST',
@@ -1585,15 +1596,32 @@ test('worker entrypoint returns id_token when openid scope is granted', async ()
 					resource: 'https://heykody.dev/mcp',
 				}),
 			}),
+			tokenEnv,
 		)
 		expect(tokenResponse.status).toBe(200)
 		const tokenPayload = (await tokenResponse.json()) as {
+			access_token?: string
 			id_token?: string
 			scope?: string
 		}
 		expect(tokenPayload.scope).toContain('openid')
 		expect(typeof tokenPayload.id_token).toBe('string')
 		expect(tokenPayload.id_token?.split('.')).toHaveLength(3)
+		expect(typeof tokenPayload.access_token).toBe('string')
+
+		const userinfoResponse = await workerFetch(
+			new Request('https://heykody.dev/oauth/userinfo', {
+				headers: {
+					Authorization: `Bearer ${tokenPayload.access_token ?? ''}`,
+				},
+			}),
+			tokenEnv,
+		)
+		expect(userinfoResponse.status).toBe(200)
+		await expect(userinfoResponse.json()).resolves.toMatchObject({
+			email,
+			email_verified: true,
+		})
 	} finally {
 		globalThis.fetch = originalFetch
 	}

--- a/packages/worker/src/oauth-helpers.ts
+++ b/packages/worker/src/oauth-helpers.ts
@@ -21,11 +21,14 @@ const inertHandler = {
  * Resolve the provider's `OAuthHelpers` for the current execution context.
  *
  * `@cloudflare/workers-oauth-provider` injects `env.OAUTH_PROVIDER` only
- * inside its own `fetch` wrapper on origin. Scheduled lanes, RPC entrypoints
- * (`JobsHost.runScheduledLane`), and capabilities served from the sessionful
- * `MCP` Durable Object on kody-platform run outside it, so they build the same
- * `OAuthHelpersImpl` through the library's `getOAuthApi` with the shared
- * options. The library loads lazily from the pre-bundled additional module
+ * inside its own `fetch` wrapper on origin, and only for the default handler
+ * and API routes — `/oauth/token` is handled internally and never gets the
+ * injection. Scheduled lanes, RPC entrypoints (`JobsHost.runScheduledLane`),
+ * OIDC UserInfo/logout (served before `oauthProvider.fetch`), token-response
+ * `id_token` enrichment (runs after that fetch returns), and capabilities
+ * served from the sessionful `MCP` Durable Object on kody-platform therefore
+ * build the same `OAuthHelpersImpl` through the library's `getOAuthApi` with
+ * the shared options. The library loads lazily from the pre-bundled additional module
  * (`tools/build-worker-bundler-modules.ts`): wrangler inlines a plain dynamic
  * `import('@cloudflare/workers-oauth-provider')` into the main module, which
  * would put it on the platform/runtime startup path, whereas the

--- a/packages/worker/src/oidc/logout.node.test.ts
+++ b/packages/worker/src/oidc/logout.node.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from 'vitest'
+import { handleOidcLogoutRequest } from '#worker/oidc/logout.ts'
+
+test('logout rejects post_logout_redirect_uri when OAuth helpers are unavailable', async () => {
+	const response = await handleOidcLogoutRequest(
+		new Request(
+			'https://heykody.dev/oauth/logout?post_logout_redirect_uri=https://evil.example/cb&client_id=client-123',
+		),
+		{} as Env,
+	)
+	expect(response.status).toBe(400)
+	expect(await response.text()).toMatch(/Invalid post_logout_redirect_uri/)
+})

--- a/packages/worker/src/oidc/logout.ts
+++ b/packages/worker/src/oidc/logout.ts
@@ -1,7 +1,4 @@
-import {
-	type ClientInfo,
-	type OAuthHelpers,
-} from '@cloudflare/workers-oauth-provider'
+import { type ClientInfo } from '@cloudflare/workers-oauth-provider'
 import {
 	destroyAuthCookie,
 	isSecureRequest,
@@ -10,9 +7,14 @@ import {
 import { getEnv } from '#app/env.ts'
 import { getAppBaseUrl } from '#worker/app-base-url.ts'
 import { verifyOidcJwtSignature } from '#worker/oidc/keys.ts'
+import { resolveOAuthHelpers } from '#worker/oauth-helpers.ts'
+
+type LogoutOAuthHelpers = {
+	lookupClient: (clientId: string) => Promise<ClientInfo | null>
+}
 
 type OAuthEnv = Env & {
-	OAUTH_PROVIDER: OAuthHelpers
+	OAUTH_PROVIDER?: LogoutOAuthHelpers
 }
 
 type LogoutParams = {
@@ -20,14 +22,6 @@ type LogoutParams = {
 	state: string | null
 	idTokenHint: string | null
 	clientId: string | null
-}
-
-function getOAuthHelpers(env: Env) {
-	const helpers = (env as OAuthEnv).OAUTH_PROVIDER
-	if (!helpers) {
-		throw new Error('OAuth provider helpers are not available.')
-	}
-	return helpers
 }
 
 function readRegisteredRedirectUris(client: ClientInfo) {
@@ -120,9 +114,11 @@ export async function handleOidcLogoutRequest(request: Request, env: Env) {
 	if (params.postLogoutRedirectUri) {
 		let allowed = false
 		if (clientId) {
-			const helpers = getOAuthHelpers(env)
+			const helpers = await resolveOAuthHelpers<LogoutOAuthHelpers>(
+				env as OAuthEnv,
+			)
 			try {
-				const client = await helpers.lookupClient(clientId)
+				const client = helpers ? await helpers.lookupClient(clientId) : null
 				if (client) {
 					allowed = isAllowedPostLogoutRedirectUri(
 						params.postLogoutRedirectUri,

--- a/packages/worker/src/oidc/token-enrichment.node.test.ts
+++ b/packages/worker/src/oidc/token-enrichment.node.test.ts
@@ -1,0 +1,93 @@
+import { expect, test } from 'vitest'
+import { enrichOAuthTokenResponse } from '#worker/oidc/token-enrichment.ts'
+import { verifyOidcJwtSignature } from '#worker/oidc/keys.ts'
+import {
+	TEST_OIDC_SIGNING_KEY_ID,
+	TEST_OIDC_SIGNING_PRIVATE_KEY_PEM,
+} from '#worker/oidc/test-signing-key.ts'
+
+function jsonResponse(body: Record<string, unknown>) {
+	return new Response(JSON.stringify(body), {
+		status: 200,
+		headers: { 'Content-Type': 'application/json' },
+	})
+}
+
+function createOidcEnv(overrides: Record<string, unknown> = {}) {
+	return {
+		OIDC_SIGNING_KEY_ID: TEST_OIDC_SIGNING_KEY_ID,
+		OIDC_SIGNING_PRIVATE_KEY_PEM: TEST_OIDC_SIGNING_PRIVATE_KEY_PEM,
+		...overrides,
+	} as unknown as Env
+}
+
+test('token enrichment mints id_token from helpers and skips when they are missing', async () => {
+	const request = new Request('https://heykody.dev/oauth/token', {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+		body: 'grant_type=authorization_code',
+	})
+	const tokenBody = {
+		access_token: 'opaque-access-token',
+		token_type: 'bearer',
+		scope: 'openid email profile',
+	}
+	const helpers = {
+		unwrapToken: async () => ({
+			scope: ['openid', 'email', 'profile'],
+			grant: {
+				clientId: 'client-123',
+				scope: ['openid', 'email', 'profile'],
+				props: {
+					userId: 'user-stable-id',
+					email: 'user@example.com',
+					username: 'test-user',
+					displayName: 'test-user',
+					authTime: 1_700_000_000,
+					nonce: 'nonce-123',
+				},
+			},
+		}),
+	}
+
+	const enriched = await enrichOAuthTokenResponse(
+		request,
+		jsonResponse(tokenBody),
+		createOidcEnv({ OAUTH_PROVIDER: helpers }),
+	)
+	expect(enriched.status).toBe(200)
+	const payload = (await enriched.json()) as {
+		access_token: string
+		id_token?: string
+	}
+	expect(payload.access_token).toBe('opaque-access-token')
+	expect(typeof payload.id_token).toBe('string')
+	const claims = await verifyOidcJwtSignature(
+		createOidcEnv(),
+		payload.id_token ?? '',
+	)
+	expect(claims).toMatchObject({
+		sub: 'user-stable-id',
+		aud: 'client-123',
+		email: 'user@example.com',
+		nonce: 'nonce-123',
+	})
+
+	// Production `/oauth/token` never injects OAUTH_PROVIDER. Missing helpers
+	// must not throw (that was KODY-6G / KODY-6Q) — return the token body.
+	const skipped = await enrichOAuthTokenResponse(
+		request,
+		jsonResponse(tokenBody),
+		createOidcEnv(),
+	)
+	expect(skipped.status).toBe(200)
+	await expect(skipped.json()).resolves.toEqual(tokenBody)
+
+	const withoutOpenid = await enrichOAuthTokenResponse(
+		request,
+		jsonResponse({ access_token: 'opaque-access-token', scope: 'profile' }),
+		createOidcEnv({ OAUTH_PROVIDER: helpers }),
+	)
+	expect(withoutOpenid.status).toBe(200)
+	await expect(withoutOpenid.json()).resolves.not.toHaveProperty('id_token')
+})

--- a/packages/worker/src/oidc/token-enrichment.ts
+++ b/packages/worker/src/oidc/token-enrichment.ts
@@ -1,16 +1,17 @@
-import { type OAuthHelpers } from '@cloudflare/workers-oauth-provider'
 import { mintIdToken, type OidcGrantProps } from '#worker/oidc/id-token.ts'
+import { resolveOAuthHelpers } from '#worker/oauth-helpers.ts'
 
-type OAuthEnv = Env & {
-	OAUTH_PROVIDER: OAuthHelpers
-}
-
-function getOAuthHelpers(env: Env) {
-	const helpers = (env as OAuthEnv).OAUTH_PROVIDER
-	if (!helpers) {
-		throw new Error('OAuth provider helpers are not available.')
-	}
-	return helpers
+type TokenEnrichmentHelpers = {
+	unwrapToken: <T = OidcGrantProps>(
+		token: string,
+	) => Promise<{
+		scope: Array<string>
+		grant: {
+			clientId: string
+			scope: Array<string>
+			props: T
+		}
+	} | null>
 }
 
 function scopeIncludesOpenid(scope: unknown) {
@@ -52,7 +53,12 @@ export async function enrichOAuthTokenResponse(
 		return response
 	}
 
-	const helpers = getOAuthHelpers(env)
+	// The provider handles `/oauth/token` internally and never injects
+	// `env.OAUTH_PROVIDER` on that path. A later authorize request in the
+	// same isolate can leave helpers on `env` (local tests), but a fresh
+	// production token request must build them through `resolveOAuthHelpers`.
+	const helpers = await resolveOAuthHelpers<TokenEnrichmentHelpers>(env)
+	if (!helpers) return response
 	const tokenSummary = await helpers.unwrapToken<OidcGrantProps>(
 		body.access_token,
 	)

--- a/packages/worker/src/oidc/userinfo.node.test.ts
+++ b/packages/worker/src/oidc/userinfo.node.test.ts
@@ -106,3 +106,16 @@ test('userinfo requires openid scope', async () => {
 		error: 'insufficient_scope',
 	})
 })
+
+test('userinfo returns 401 when OAuth helpers are unavailable', async () => {
+	const response = await handleOidcUserinfoRequest(
+		new Request('https://heykody.dev/oauth/userinfo', {
+			headers: { Authorization: 'Bearer demo-token' },
+		}),
+		createOidcEnv({ OAUTH_PROVIDER: undefined } as Partial<Env>),
+	)
+	expect(response.status).toBe(401)
+	await expect(response.json()).resolves.toMatchObject({
+		error: 'invalid_token',
+	})
+})

--- a/packages/worker/src/oidc/userinfo.ts
+++ b/packages/worker/src/oidc/userinfo.ts
@@ -1,6 +1,7 @@
 import { jsonResponse } from '#worker/json-response.ts'
 import { isAccountEmailVerified } from '#worker/identity/email-verification-state.ts'
 import { type OidcGrantProps } from '#worker/oidc/id-token.ts'
+import { resolveOAuthHelpers } from '#worker/oauth-helpers.ts'
 
 type OidcUserinfoOAuthHelpers = {
 	unwrapToken: <T = OidcGrantProps>(
@@ -16,15 +17,7 @@ type OidcUserinfoOAuthHelpers = {
 }
 
 type OAuthEnv = Env & {
-	OAUTH_PROVIDER: OidcUserinfoOAuthHelpers
-}
-
-function getOAuthHelpers(env: Env): OidcUserinfoOAuthHelpers {
-	const helpers = (env as OAuthEnv).OAUTH_PROVIDER
-	if (!helpers) {
-		throw new Error('OAuth provider helpers are not available.')
-	}
-	return helpers
+	OAUTH_PROVIDER?: OidcUserinfoOAuthHelpers
 }
 
 function readBearerToken(request: Request) {
@@ -67,7 +60,20 @@ export async function handleOidcUserinfoRequest(request: Request, env: Env) {
 		)
 	}
 
-	const helpers = getOAuthHelpers(env)
+	// UserInfo is served before `oauthProvider.fetch`, so the library never
+	// injects `env.OAUTH_PROVIDER` here. Build the same helpers over OAUTH_KV.
+	const helpers = await resolveOAuthHelpers<OidcUserinfoOAuthHelpers>(
+		env as OAuthEnv,
+	)
+	if (!helpers) {
+		return jsonResponse(
+			{
+				error: 'invalid_token',
+				error_description: 'Access token is invalid or expired.',
+			},
+			{ status: 401 },
+		)
+	}
 	const tokenSummary = await helpers.unwrapToken<OidcGrantProps>(token)
 	if (!tokenSummary) {
 		return jsonResponse(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Fix production `POST /oauth/token` (and UserInfo / logout) so OpenID Connect clients get an `id_token` instead of a 500 when the OAuth provider has not injected `env.OAUTH_PROVIDER`.

## Why

Sentry [KODY-6Q](https://kent-c-dodds-tech-llc.sentry.io/issues/7710999091/) and sibling [KODY-6G](https://kent-c-dodds-tech-llc.sentry.io/issues/7705892690/) (118 events) throw `Error: OAuth provider helpers are not available.` from `enrichOAuthTokenResponse` → `getOAuthHelpers` on `https://kody.codes/oauth/token`.

`@cloudflare/workers-oauth-provider` injects `env.OAUTH_PROVIDER` only for the default handler and API routes. The token endpoint is handled internally and never gets that injection. Authorize in the same isolate can leave helpers on `env` (why the workers test passed), but a production token request is a fresh isolate.

UserInfo and RP-initiated logout are served *before* `oauthProvider.fetch`, so they have the same gap.

## Summary

- Token enrichment, UserInfo, and logout now use `resolveOAuthHelpers` (already used by account deletion / export / waiting).
- Missing helpers no longer throw: skip `id_token` enrichment, UserInfo returns `401 invalid_token`, logout rejects an unvalidated `post_logout_redirect_uri`.
- Workers test hides leftover `OAUTH_PROVIDER` before the token request so enrichment must go through `OAUTH_KV`.
- Architecture docs note the token-path injection hole.

## Testing

- `vitest` node-unit: token-enrichment, userinfo, logout (6 tests)
- `vitest` workers-unit: `worker entrypoint returns id_token when openid scope is granted` with `OAUTH_PROVIDER` stripped
- Pre-push: `test:node` 2532 passed, `test:workers` 326 passed
- `npm run typecheck`

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `11f7d4ac` · **Head:** `c296c3ef`

**Classification:** composes — no primitives added or changed; OIDC token/userinfo/logout now call the existing `resolveOAuthHelpers` fallback that account deletion already uses.

### Primitives touched

| Primitive   | Group | Impact                                      |
| ----------- | ----- | ------------------------------------------- |
| `mcp-oauth` | auth  | composes — same helpers, more call sites    |

Unmatched paths: `oauth-helpers.ts` comment, architecture docs, workers OAuth entry test.

### Change flow

A production `POST /oauth/token` with `openid` no longer depends on a leftover `env.OAUTH_PROVIDER` from an earlier authorize in the same isolate.

```mermaid
sequenceDiagram
	actor Client
	participant mcpOauth as mcp-oauth
	participant oauthHelpers as resolveOAuthHelpers
	participant oauthKv as OAUTH_KV
	Client->>mcpOauth: POST /oauth/token (openid)
	mcpOauth->>mcpOauth: oauthProvider.fetch issues access_token
	Note over mcpOauth: token path never injects OAUTH_PROVIDER
	mcpOauth->>oauthHelpers: resolveOAuthHelpers(env)
	oauthHelpers->>oauthKv: getOAuthApi unwrapToken
	oauthHelpers-->>mcpOauth: grant props
	mcpOauth-->>Client: access_token + id_token
```

### Before / after

| Path | Before | After |
| --- | --- | --- |
| `POST /oauth/token` + `openid` | throw → 500 | `resolveOAuthHelpers` then mint `id_token` |
| `GET /oauth/userinfo` | throw if no leftover helpers | unwrap via `OAUTH_KV` or 401 |
| `GET /oauth/logout?post_logout_redirect_uri=` | throw if no leftover helpers | 400 unless lookup succeeds |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a5e44ab-c9c7-48ec-b84c-284c113d5445?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a5e44ab-c9c7-48ec-b84c-284c113d5445&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth and OpenID Connect token handling when provider bindings are unavailable.
  * UserInfo requests now return a clear `401 invalid_token` response when OAuth helpers cannot be resolved.
  * Logout redirect validation now safely rejects untrusted destinations.
  * OpenID Connect token responses continue to include ID tokens when applicable.

* **Documentation**
  * Clarified OAuth helper resolution, token handling, and shared storage behavior in architecture documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->