### PR TITLE
Accept in-workspace repo `..` paths and drop expected CIMD Sentry noise

### DIFF
--- a/packages/worker/src/mcp/observability.node.test.ts
+++ b/packages/worker/src/mcp/observability.node.test.ts
@@ -362,9 +362,25 @@ test('logMcpEvent keeps sandbox and caller failures off Sentry and still reports
 				'Token refresh was rejected. (integrationTokenRefresh caller state)',
 			),
 		})
+
+		// Disallowed repo path (KODY-6P). Plain Error from DO RPC, including
+		// the pre-normalization wording still in flight.
+		logMcpEvent({
+			...callerFailureBase,
+			capabilityName: 'repoEditFiles',
+			domain: 'repo',
+			capabilitySource: 'builtin',
+			failurePhase: 'handler',
+			errorName: 'Error',
+			errorMessage:
+				'Repo path "src/../exports/self-test.ts" is not allowed: paths cannot contain ".." or ".git" segments.',
+			cause: new Error(
+				'Repo path "src/../exports/self-test.ts" is not allowed: paths cannot contain ".." or ".git" segments.',
+			),
+		})
 	})
 
-	expect(payloads).toHaveLength(21)
+	expect(payloads).toHaveLength(22)
 	expect(JSON.parse(payloads[0]!)).toMatchObject({
 		tool: 'execute',
 		outcome: 'failure',

--- a/packages/worker/src/mcp/observability.ts
+++ b/packages/worker/src/mcp/observability.ts
@@ -10,6 +10,7 @@ import { PackageScopeAccessError } from '#worker/package-registry/package-owner.
 import { isRepoLargeFileMessage } from '#worker/repo/large-file-policy.ts'
 import {
 	isGitPushNotFastForwardMessage,
+	isRepoDisallowedPathMessage,
 	isRepoSearchInvalidRegexMessage,
 	isRepoSessionInactiveMessage,
 	isRepoSessionNotFoundMessage,
@@ -152,17 +153,19 @@ function isCallerFailure(payload: McpObservabilityPayload, cause?: unknown) {
 	) {
 		return true
 	}
-	// Published / inactive / missing repo sessions and invalid repoSearch
-	// regexes are thrown inside the RepoSession Durable Object as plain Errors.
-	// Match the stable phrases so they stay out of Sentry even when a
-	// capability forgets to re-wrap as McpCallerError.
+	// Published / inactive / missing repo sessions, invalid repoSearch
+	// regexes, and disallowed repo paths are thrown inside the RepoSession
+	// Durable Object as plain Errors. Match the stable phrases so they stay
+	// out of Sentry even when a capability forgets to re-wrap as
+	// McpCallerError.
 	if (
 		getErrorCauseChain(cause).some(
 			(entry) =>
 				entry instanceof Error &&
 				(isRepoSessionInactiveMessage(entry.message) ||
 					isRepoSessionNotFoundMessage(entry.message) ||
-					isRepoSearchInvalidRegexMessage(entry.message)),
+					isRepoSearchInvalidRegexMessage(entry.message) ||
+					isRepoDisallowedPathMessage(entry.message)),
 		)
 	) {
 		return true

--- a/packages/worker/src/oauth-cimd-error.ts
+++ b/packages/worker/src/oauth-cimd-error.ts
@@ -1,0 +1,18 @@
+/**
+ * CIMD lookup failures the OAuth provider already maps to unknown-client /
+ * invalid_client. Probe traffic, mistyped client_id URLs, ChatGPT's
+ * path-less `/oauth/client.json`, and metadata fetch timeouts are caller or
+ * upstream outcomes — not platform defects. Keep the exact prefixes so
+ * wrapped recovery messages stay Sentry-visible.
+ */
+export const cimdMetadataResolutionFailedMessagePrefix =
+	'CIMD metadata resolution failed ('
+
+export const cimdFetchFailedMessagePrefix = 'CIMD fetch failed for '
+
+export function isCimdUnknownClientSentryMessage(message: string) {
+	return (
+		message.startsWith(cimdMetadataResolutionFailedMessagePrefix) ||
+		message.startsWith(cimdFetchFailedMessagePrefix)
+	)
+}

--- a/packages/worker/src/oauth-handlers.ts
+++ b/packages/worker/src/oauth-handlers.ts
@@ -1,5 +1,4 @@
 import { jsonResponse } from '#worker/json-response.ts'
-import * as Sentry from '@sentry/cloudflare'
 import {
 	type AuthRequest,
 	CimdFetchError,
@@ -284,7 +283,6 @@ async function resolveAuthRequest(
 		return { authRequest, client }
 	} catch (error) {
 		if (isCimdMetadataResolutionError(error)) {
-			Sentry.captureException(error)
 			return { error: 'Unknown OAuth client.' }
 		}
 		const message =

--- a/packages/worker/src/oauth-handlers.workers.test.ts
+++ b/packages/worker/src/oauth-handlers.workers.test.ts
@@ -1021,6 +1021,9 @@ test('worker entrypoint treats a failed ChatGPT CIMD fetch as an unknown client'
 
 		const authorizeInfoUrl = new URL('https://heykody.dev/oauth/authorize-info')
 		authorizeInfoUrl.search = authorizeUrl.search
+		const captureException = vi
+			.spyOn(Sentry, 'captureException')
+			.mockImplementation(() => undefined)
 		const response = await workerFetch(new Request(authorizeInfoUrl))
 		expect(response.status).toBe(400)
 		await expect(response.json()).resolves.toMatchObject({
@@ -1030,6 +1033,8 @@ test('worker entrypoint treats a failed ChatGPT CIMD fetch as an unknown client'
 		expect(consoleWarn.mock.calls.flat().join(' ')).toContain(
 			'CIMD fetch failed',
 		)
+		expect(captureException).not.toHaveBeenCalled()
+		captureException.mockRestore()
 	} finally {
 		globalThis.fetch = originalFetch
 	}

--- a/packages/worker/src/oauth-provider-options.ts
+++ b/packages/worker/src/oauth-provider-options.ts
@@ -2,7 +2,6 @@
 // `{ type X }` import would keep a side-effect import of the provider (and its
 // `cloudflare:workers` dependency) on the platform/runtime startup path.
 import type * as WorkersOAuthProvider from '@cloudflare/workers-oauth-provider'
-import * as Sentry from '@sentry/cloudflare'
 import { oauthPaths } from '#universal/oauth-paths.ts'
 import { mcpOauthScopes } from '#worker/mcp-oauth-scopes.ts'
 
@@ -50,17 +49,10 @@ export const sharedOAuthProviderOptions = {
 	// advertises `<origin>/mcp` so discovery matches that audience.
 	// Provider default onError logs every structured OAuth error via console.warn.
 	// Keep those responses on the wire without duplicating them into worker logs /
-	// test console guards. CIMD fetch failures stay generic on the wire and are
-	// reported here for Sentry; unexpected throws still reach fetch catch + Sentry.
-	onError: (error) => {
-		if (error.internal?.category === 'client-id-metadata-document') {
-			Sentry.captureException(
-				new Error(
-					`CIMD metadata resolution failed (${error.internal.reason}): ${error.description}`,
-				),
-			)
-		}
-	},
+	// test console guards. CIMD lookup failures stay generic on the wire
+	// (unknown-client / invalid_client); they are caller or upstream outcomes,
+	// not platform defects. Unexpected throws still reach fetch catch + Sentry.
+	onError: () => {},
 	// 0.10+ defaults allowPlainPKCE to false (S256-only) while still allowing
 	// confidential clients to omit PKCE. Do not set allowPlainPKCE: true. App
 	// layer getPkceValidationError remains defense in depth. See

--- a/packages/worker/src/repo/repo-session-caller-error.ts
+++ b/packages/worker/src/repo/repo-session-caller-error.ts
@@ -82,6 +82,41 @@ export function isRepoSearchInvalidRegexMessage(message: string) {
 	return message.startsWith(repoSearchInvalidRegexMessagePrefix)
 }
 
+/**
+ * Stable phrase from `resolveRepoWorkspacePath` when a caller path escapes
+ * the session workspace or names a `.git` segment. Subclass identity does
+ * not survive Durable Object RPC. Also match the pre-normalization wording
+ * so in-flight events from the old "reject any `..`" guard stay off Sentry.
+ */
+export const repoDisallowedPathMessagePhrase =
+	'is not allowed for repo session paths'
+
+export const repoLegacyDisallowedPathMessagePhrase =
+	'paths cannot contain ".." or ".git" segments'
+
+export function isRepoDisallowedPathMessage(message: string) {
+	return (
+		message.includes(repoDisallowedPathMessagePhrase) ||
+		message.includes(repoLegacyDisallowedPathMessagePhrase)
+	)
+}
+
+export function buildRepoDisallowedPathMessage(
+	path: string,
+	reason: 'escape' | 'git',
+) {
+	switch (reason) {
+		case 'escape':
+			return `Repo path "${path}" ${repoDisallowedPathMessagePhrase}: resolved path leaves the session workspace.`
+		case 'git':
+			return `Repo path "${path}" ${repoDisallowedPathMessagePhrase}: paths cannot contain ".git" segments.`
+		default: {
+			const exhaustive: never = reason
+			throw new Error(`Unsupported repo path denial: ${String(exhaustive)}`)
+		}
+	}
+}
+
 export function buildRepoSearchInvalidRegexCallerMessage(
 	compileMessage: string,
 ) {

--- a/packages/worker/src/repo/repo-session-do.node.test.ts
+++ b/packages/worker/src/repo/repo-session-do.node.test.ts
@@ -719,6 +719,22 @@ test('applyEdits rejects batches mixing structural and content edits on the same
 			],
 		}),
 	).rejects.toThrow(/cannot combine a delete\/move/)
+
+	// in-workspace `..` aliases must collide after normalization.
+	await expect(
+		repoSession.applyEdits({
+			sessionId: 'session-1',
+			userId: 'user-1',
+			edits: [
+				{
+					kind: 'write',
+					path: 'src/../exports/a.ts',
+					content: 'export const a = 2\n',
+				},
+				{ kind: 'delete', path: 'exports/a.ts' },
+			],
+		}),
+	).rejects.toThrow(/cannot combine a delete\/move/)
 	expect(mockModule.workspaceRm).not.toHaveBeenCalled()
 })
 

--- a/packages/worker/src/repo/repo-session-do.ts
+++ b/packages/worker/src/repo/repo-session-do.ts
@@ -964,13 +964,10 @@ class RepoSessionBase extends DurableObject<Env> {
 		// that touches the same path from both sides has ambiguous,
 		// order-dependent results (a write can be silently discarded). Reject
 		// those batches outright: callers split them into separate calls.
-		// Comparison keys strip `./` prefixes and leading slashes so aliased
-		// spellings of one path still collide.
+		// Comparison keys use the resolved workspace path so aliased
+		// spellings (`./src/a.ts`, `src/../exports/a.ts`) still collide.
 		const editConflictKey = (path: string) =>
-			path
-				.trim()
-				.replace(/^(\.\/)+/, '')
-				.replace(/^\/+/, '')
+			resolveRepoWorkspacePath(path, repoSessionWorkspacePrefix)
 		const contentEditConflictKeys = new Set(
 			contentEdits.map((edit) => editConflictKey(edit.path)).filter(Boolean),
 		)

--- a/packages/worker/src/repo/repo-session-tree.node.test.ts
+++ b/packages/worker/src/repo/repo-session-tree.node.test.ts
@@ -1,0 +1,61 @@
+import { expect, test } from 'vitest'
+import { isRepoDisallowedPathMessage } from './repo-session-caller-error.ts'
+import { resolveRepoWorkspacePath } from './repo-session-tree.ts'
+
+const workspacePrefix = '/session'
+
+test('resolveRepoWorkspacePath keeps in-workspace .. and rejects escapes and .git', () => {
+	expect(
+		resolveRepoWorkspacePath('src/../exports/self-test.ts', workspacePrefix),
+	).toBe('/session/exports/self-test.ts')
+	expect(
+		resolveRepoWorkspacePath(
+			'/session/src/../exports/self-test.ts',
+			workspacePrefix,
+		),
+	).toBe('/session/exports/self-test.ts')
+	expect(
+		resolveRepoWorkspacePath('exports/self-test.ts', workspacePrefix),
+	).toBe('/session/exports/self-test.ts')
+	expect(resolveRepoWorkspacePath('src/./lib/index.ts', workspacePrefix)).toBe(
+		'/session/src/lib/index.ts',
+	)
+	expect(resolveRepoWorkspacePath('.', workspacePrefix)).toBe(workspacePrefix)
+	expect(resolveRepoWorkspacePath(workspacePrefix, workspacePrefix)).toBe(
+		workspacePrefix,
+	)
+
+	expect(() => resolveRepoWorkspacePath('../secrets', workspacePrefix)).toThrow(
+		'Repo path "../secrets" is not allowed for repo session paths: resolved path leaves the session workspace.',
+	)
+	expect(() =>
+		resolveRepoWorkspacePath('/session/../etc/passwd', workspacePrefix),
+	).toThrow(
+		'Repo path "/session/../etc/passwd" is not allowed for repo session paths: resolved path leaves the session workspace.',
+	)
+	expect(() =>
+		resolveRepoWorkspacePath('src/.git/config', workspacePrefix),
+	).toThrow(
+		'Repo path "src/.git/config" is not allowed for repo session paths: paths cannot contain ".git" segments.',
+	)
+	expect(() =>
+		resolveRepoWorkspacePath('src/foo/../.git/config', workspacePrefix),
+	).toThrow(
+		'Repo path "src/foo/../.git/config" is not allowed for repo session paths: paths cannot contain ".git" segments.',
+	)
+	expect(() => resolveRepoWorkspacePath('   ', workspacePrefix)).toThrow(
+		'A non-empty repo path is required.',
+	)
+
+	expect(
+		isRepoDisallowedPathMessage(
+			'Repo path "src/../exports/self-test.ts" is not allowed: paths cannot contain ".." or ".git" segments.',
+		),
+	).toBe(true)
+	expect(
+		isRepoDisallowedPathMessage(
+			'Repo path "src/.git/config" is not allowed for repo session paths: paths cannot contain ".git" segments.',
+		),
+	).toBe(true)
+	expect(isRepoDisallowedPathMessage('Source "abc" was not found.')).toBe(false)
+})

--- a/packages/worker/src/repo/repo-session-tree.ts
+++ b/packages/worker/src/repo/repo-session-tree.ts
@@ -1,3 +1,4 @@
+import { buildRepoDisallowedPathMessage } from './repo-session-caller-error.ts'
 import {
 	type EntitySourceRow,
 	type RepoSessionInfoResult,
@@ -35,6 +36,37 @@ function normalizeUnknownTreeChild(
 	}
 }
 
+type ResolvedWorkspaceSegments =
+	| { ok: true; segments: Array<string> }
+	| { ok: false; reason: 'escape' | 'git' }
+
+function resolveWorkspaceRelativeSegments(
+	path: string,
+	workspacePrefix: string,
+): ResolvedWorkspaceSegments {
+	const relative =
+		path === workspacePrefix
+			? ''
+			: path.startsWith(`${workspacePrefix}/`)
+				? path.slice(workspacePrefix.length + 1)
+				: null
+	if (relative === null) {
+		return { ok: false, reason: 'escape' }
+	}
+	const resolved: Array<string> = []
+	for (const segment of relative.split('/')) {
+		if (segment === '' || segment === '.') continue
+		if (segment === '..') {
+			if (resolved.length === 0) return { ok: false, reason: 'escape' }
+			resolved.pop()
+			continue
+		}
+		if (segment === '.git') return { ok: false, reason: 'git' }
+		resolved.push(segment)
+	}
+	return { ok: true, segments: resolved }
+}
+
 export function resolveRepoWorkspacePath(
 	path: string,
 	workspacePrefix: string,
@@ -44,21 +76,20 @@ export function resolveRepoWorkspacePath(
 		throw new Error('A non-empty repo path is required.')
 	}
 	// User-supplied paths must stay inside the session workspace and out of
-	// git internals: `..` segments escape the prefix and `.git` writes corrupt
-	// the session repository.
-	const segments = trimmed.split('/')
-	if (segments.includes('..') || segments.includes('.git')) {
-		throw new Error(
-			`Repo path "${trimmed}" is not allowed: paths cannot contain ".." or ".git" segments.`,
-		)
+	// git internals. Resolve `.` / `..` first so in-workspace forms such as
+	// `src/../exports/self-test.ts` work, then reject anything that leaves the
+	// prefix or names a `.git` segment.
+	const joined =
+		trimmed === workspacePrefix || trimmed.startsWith(`${workspacePrefix}/`)
+			? trimmed
+			: `${workspacePrefix}/${trimmed.replace(/^\/+/, '')}`
+	const resolved = resolveWorkspaceRelativeSegments(joined, workspacePrefix)
+	if (!resolved.ok) {
+		throw new Error(buildRepoDisallowedPathMessage(trimmed, resolved.reason))
 	}
-	if (
-		trimmed === workspacePrefix ||
-		trimmed.startsWith(`${workspacePrefix}/`)
-	) {
-		return trimmed
-	}
-	return `${workspacePrefix}/${trimmed.replace(/^\/+/, '')}`
+	return resolved.segments.length === 0
+		? workspacePrefix
+		: `${workspacePrefix}/${resolved.segments.join('/')}`
 }
 
 export function toExternalRepoPath(path: string, workspacePrefix: string) {

--- a/packages/worker/src/sentry-options.node.test.ts
+++ b/packages/worker/src/sentry-options.node.test.ts
@@ -628,4 +628,42 @@ test('filterSentryEvent drops expected platform and caller noise and keeps real 
 		},
 	}
 	expect(filterSentryEvent(wrappedDoOverload)).toBe(wrappedDoOverload)
+
+	// Expected CIMD unknown-client outcomes (KODY-6K / KODY-6M). Bare
+	// prefixes drop; wrapped recovery stays visible.
+	expect(
+		filterSentryEvent({
+			exception: {
+				values: [
+					{
+						value:
+							'CIMD metadata resolution failed (metadata_resolution_failed): Client not found',
+					},
+				],
+			},
+		}),
+	).toBeNull()
+	expect(
+		filterSentryEvent({
+			exception: {
+				values: [
+					{
+						value:
+							'CIMD fetch failed for https://chatgpt.com/oauth/client.json: Failed to fetch client metadata: HTTP 404',
+					},
+				],
+			},
+		}),
+	).toBeNull()
+	const wrappedCimdFailure = {
+		exception: {
+			values: [
+				{
+					value:
+						'authorize could not recover after CIMD fetch failed for https://chatgpt.com/oauth/client.json: Failed to fetch client metadata: HTTP 404',
+				},
+			],
+		},
+	}
+	expect(filterSentryEvent(wrappedCimdFailure)).toBe(wrappedCimdFailure)
 })

--- a/packages/worker/src/sentry-options.node.test.ts
+++ b/packages/worker/src/sentry-options.node.test.ts
@@ -666,4 +666,18 @@ test('filterSentryEvent drops expected platform and caller noise and keeps real 
 		},
 	}
 	expect(filterSentryEvent(wrappedCimdFailure)).toBe(wrappedCimdFailure)
+	const recoveryWithCimdCause = {
+		exception: {
+			values: [
+				{
+					value: 'authorize could not recover after a CIMD metadata lookup.',
+				},
+				{
+					value:
+						'CIMD fetch failed for https://chatgpt.com/oauth/client.json: Failed to fetch client metadata: HTTP 404',
+				},
+			],
+		},
+	}
+	expect(filterSentryEvent(recoveryWithCimdCause)).toBe(recoveryWithCimdCause)
 })

--- a/packages/worker/src/sentry-options.ts
+++ b/packages/worker/src/sentry-options.ts
@@ -488,9 +488,13 @@ export function filterMcpAgentSessionDestroyedAbortSentryEvent(
  * `CimdFetchError` so wrapped recovery messages stay visible.
  */
 export function isCimdUnknownClientSentryEvent(event: ErrorEvent) {
-	return sentryEventMessages(event).some(
-		(message) =>
-			typeof message === 'string' && isCimdUnknownClientSentryMessage(message),
+	const messages = sentryEventMessages(event).filter(
+		(message): message is string =>
+			typeof message === 'string' && message.trim().length > 0,
+	)
+	return (
+		messages.length > 0 &&
+		messages.every((message) => isCimdUnknownClientSentryMessage(message))
 	)
 }
 

--- a/packages/worker/src/sentry-options.ts
+++ b/packages/worker/src/sentry-options.ts
@@ -2,6 +2,7 @@ import { type CloudflareOptions } from '@sentry/cloudflare'
 import { type ErrorEvent, type EventHint } from '@sentry/core'
 import { getErrorCauseChain } from '@kody-internal/shared/error-message.ts'
 import { isRetryableD1LockSentryEvent } from './d1-retry.ts'
+import { isCimdUnknownClientSentryMessage } from './oauth-cimd-error.ts'
 import { isEntitlementLimitError } from './entitlements/errors.ts'
 import { isIntegrationTokenRefreshCallerMessage } from './integrations/token-refresh.ts'
 import { isArtifactsGitTransientErrorMessage } from './repo/artifacts-git-retry.ts'
@@ -479,6 +480,25 @@ export function filterMcpAgentSessionDestroyedAbortSentryEvent(
 	return null
 }
 
+/**
+ * CIMD metadata lookup failures the OAuth provider already maps to
+ * unknown-client / invalid_client (KODY-6K / KODY-6M). Probe traffic,
+ * mistyped client_id URLs, and upstream 404 / timeout are not platform
+ * defects. Match only the bare prefixes emitted by `onError` and
+ * `CimdFetchError` so wrapped recovery messages stay visible.
+ */
+export function isCimdUnknownClientSentryEvent(event: ErrorEvent) {
+	return sentryEventMessages(event).some(
+		(message) =>
+			typeof message === 'string' && isCimdUnknownClientSentryMessage(message),
+	)
+}
+
+export function filterCimdUnknownClientSentryEvent(event: ErrorEvent) {
+	if (!isCimdUnknownClientSentryEvent(event)) return event
+	return null
+}
+
 export function filterSentryEvent(event: ErrorEvent, hint?: EventHint) {
 	// Marker first: primary mechanism for user-authored failures.
 	if (filterUserCodeErrorSentryEvent(event, hint) === null) return null
@@ -497,6 +517,7 @@ export function filterSentryEvent(event: ErrorEvent, hint?: EventHint) {
 		return null
 	if (filterMcpAgentSessionDestroyedAbortSentryEvent(event) === null)
 		return null
+	if (filterCimdUnknownClientSentryEvent(event) === null) return null
 	return event
 }
 
@@ -555,7 +576,10 @@ export function buildSentryOptions(env: Env): CloudflareOptions {
 		// retries — see filterArtifactsGitTransientHttpErrorSentryEvent.
 		// Bare Durable Object abort token `destroyed` from Agents MCP session
 		// teardown (`ctx.abort("destroyed")`) is dropped the same way — see
-		// filterMcpAgentSessionDestroyedAbortSentryEvent.
+		// filterMcpAgentSessionDestroyedAbortSentryEvent. Expected CIMD
+		// unknown-client outcomes (missing document, HTTP 404, metadata fetch
+		// timeout) are dropped the same way — see
+		// filterCimdUnknownClientSentryEvent.
 		beforeSend: filterSentryEvent,
 	}
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Close the Sentry backfill around KODY-6N by finishing the two unrelated siblings that are still real: repo path `..` denials (KODY-6P) and expected CIMD unknown-client captures (KODY-6K / KODY-6M).

KODY-6N itself is already fixed and deployed by #2032 (survive inbound mail up to 25 MiB). Production `/health` is on `a3495976`, which contains that commit. This PR does not touch inbound mail.

## Why

- **KODY-6P:** `repoEditFiles` rejected `src/../exports/self-test.ts` before joining `/session`, so a path that stays inside the workspace became a platform Sentry issue.
- **KODY-6K / KODY-6M:** CIMD metadata misses (`Client not found`, ChatGPT `https://chatgpt.com/oauth/client.json` HTTP 404, fetch timeouts) already map to unknown-client / invalid_client. Capturing them opened recurring Sentry issues.

## Summary

- Resolve `.` / `..` in repo session paths, then reject only workspace escapes and `.git` segments.
- Detect `repoEditFiles` delete/move/write conflicts using the resolved workspace path so aliases cannot bypass the batch guard.
- Treat remaining path denials as MCP caller failures (including the pre-normalization wording still in flight).
- Stop capturing expected CIMD lookup failures and drop those prefixes in `beforeSend` only when every exception message is a bare CIMD miss.

## Testing

- `vitest` node-unit: repo path resolver, applyEdits alias conflicts, MCP observability caller-failure, Sentry `beforeSend` (including recovery + inner CIMD cause).
- `vitest` workers-unit: ChatGPT-shaped CIMD fetch failure still returns unknown-client and no longer calls `captureException`.
- Local `npm run validate` passed (e2e 10/10).

## System changes

Extends `repo-sessions` path resolution (medium). CIMD / Sentry changes compose existing OAuth unknown-client behavior.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `a3495976` · **Head:** `099c7949`

**Classification:** extends — repo session paths now normalize in-workspace `..`; OAuth CIMD unknown-client handling is unchanged on the wire.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `repo-sessions` | runtime | extends — normalize `.` / `..` under `/session`, still reject escapes and `.git`; conflict keys use the resolved path |
| `mcp-server` | surfaces | composes — path denials stay on `mcp-event` via caller-failure match |
| `mcp-oauth` | auth | composes — stop Sentry capture; authorize/token still return unknown-client |
| `app-sessions` | auth | composes — same `resolveAuthRequest` unknown-client mapping, no capture |

Unmatched observability: `sentry-options.ts` drops a CIMD event only when every exception message is a bare unknown-client prefix.

### Change flow

`repoEditFiles` now accepts in-workspace `src/../exports/…` and still rejects escapes.

```mermaid
sequenceDiagram
	actor Agent
	participant mcpServer as mcp-server
	participant repoSessions as repo-sessions
	Agent->>mcpServer: repoEditFiles path src/../exports/self-test.ts
	mcpServer->>repoSessions: resolveRepoWorkspacePath
	repoSessions-->>mcpServer: /session/exports/self-test.ts
	Note over repoSessions: escape or .git still throws caller-failure
	Note over repoSessions: delete/move/write conflicts use resolved paths
```

CIMD misses stay unknown-client and leave Sentry.

```mermaid
sequenceDiagram
	actor Client
	participant mcpOauth as mcp-oauth
	participant sentryOptions as sentry-options
	Client->>mcpOauth: /oauth/authorize or /oauth/token with CIMD client_id
	mcpOauth-->>Client: unknown-client / invalid_client
	mcpOauth-->>sentryOptions: no capture; beforeSend drops leftover prefixes
```

### Invariants

Workspace paths must remain under `/session` and must not name a `.git` segment. Per-user repo isolation is unchanged.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-501a84fe-e8e0-4f3e-8fdd-def39a203b16?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-501a84fe-e8e0-4f3e-8fdd-def39a203b16&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Repository paths now correctly resolve `.` and `..` segments within the workspace while blocking paths that escape the workspace or access `.git`.
  * Edit conflicts are detected consistently when different path forms resolve to the same workspace location.
  * OAuth client lookup failures continue to return a generic “Unknown OAuth client” response without being reported as platform errors.
  * Expected repository path denials and OAuth metadata lookup failures are more accurately classified, reducing unnecessary error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->