### PR TITLE
Polish high-traffic copy, empty states, and mobile wayfinding

### DIFF
--- a/packages/worker/client/routes/account-activity.tsx
+++ b/packages/worker/client/routes/account-activity.tsx
@@ -307,7 +307,7 @@ export function AccountActivityRoute(handle: Handle) {
 
 				{status === 'loading' ? (
 					<p mix={css({ color: colors.textMuted, margin: 0 })}>
-						Loading activity...
+						Loading activity…
 					</p>
 				) : null}
 				{message ? (

--- a/packages/worker/client/routes/account-email.tsx
+++ b/packages/worker/client/routes/account-email.tsx
@@ -1,9 +1,11 @@
 import { formatNullableTimestamp } from '#client/format-timestamp.ts'
 import { type Handle, css } from 'remix/ui'
+import { readAppSession } from '#client/app-session-context.tsx'
 import { on } from '#client/event-mixin.ts'
 import { readCurrentRouterHref } from '#client/client-router.tsx'
 import { replaceLocation } from '#client/replace-location.ts'
 import { consumeStaleNavigationData } from '#client/navigation-data.ts'
+import { acceptedEmailVerificationDelivery } from '#universal/email-verification-delivery.ts'
 import { readJson } from '#client/routes/account-approval-shared.ts'
 import {
 	AccountManagementMessage,
@@ -11,16 +13,17 @@ import {
 	AccountPageHeader,
 } from '#client/routes/account-management-components.tsx'
 import {
+	renderEmailVerificationPrompt,
+	requestResendVerification,
+} from '#client/routes/email-verification-prompt.tsx'
+import {
 	RecordTable,
 	RecordTableSearch,
 	RecordTableSelect,
 	recordStampCss,
 } from '#client/routes/record-table.tsx'
 import { colors, spacing, typography } from '#universal/styles/tokens.ts'
-import {
-	cardCss,
-	getGhostButtonCss,
-} from '#universal/styles/style-primitives.ts'
+import { getGhostButtonCss } from '#universal/styles/style-primitives.ts'
 import {
 	type AccountEmailLoaderData,
 	type AccountEmailMessageDetail,
@@ -55,6 +58,10 @@ export function AccountEmailRoute(handle: Handle) {
 	let message: string | null = null
 	let messageTone: 'error' | 'info' = 'info'
 	let classifyState: ClassifyState = 'idle'
+	let resendStatus: 'idle' | 'sending' = 'idle'
+	let resendMessage: string | null = null
+	let resendTone: 'error' | 'info' = 'info'
+	let resendAccepted = false
 	let loadRequestId = 0
 	let lastLoadedDataKey = ''
 	let loadingDataKey: string | null = null
@@ -96,18 +103,40 @@ export function AccountEmailRoute(handle: Handle) {
 	function applyPayload(payload: AccountEmailLoaderData, href: string) {
 		data = payload
 		const selectedId = emailRoute.getSelection(href).selectedId
-		message = !payload.emailVerified
-			? payload.verificationMessage
-			: selectedId && !payload.selectedMessage
+		message =
+			payload.emailVerified && selectedId && !payload.selectedMessage
 				? 'Message not found.'
 				: null
-		messageTone =
-			!payload.emailVerified || (selectedId && !payload.selectedMessage)
-				? 'error'
-				: 'info'
+		messageTone = selectedId && !payload.selectedMessage ? 'error' : 'info'
 		status = 'ready'
 		lastLoadedDataKey = getDataKey(href)
 		lastFailedDataKey = null
+	}
+
+	async function handleResendVerification() {
+		resendStatus = 'sending'
+		resendMessage = null
+		resendTone = 'info'
+		handle.update()
+
+		try {
+			const result = await requestResendVerification()
+			if (!result.ok && result.unauthorized) {
+				window.location.assign('/login')
+				return
+			}
+			resendTone = result.ok ? 'info' : 'error'
+			resendMessage = result.message
+			if (result.ok) {
+				resendAccepted = true
+			}
+		} catch {
+			resendTone = 'error'
+			resendMessage = 'Unable to send the verification email.'
+		} finally {
+			resendStatus = 'idle'
+			handle.update()
+		}
 	}
 
 	async function classifySelectedMessage(
@@ -469,17 +498,31 @@ export function AccountEmailRoute(handle: Handle) {
 					</>
 				) : null}
 				{data && showUnverified ? (
-					<div mix={css({ ...cardCss, gap: spacing.sm })}>
+					<>
 						{data.inboxAddress ? (
 							<p mix={css({ margin: 0 })}>
 								Your inbox address will be <code>{data.inboxAddress}</code>{' '}
 								after verification.
 							</p>
 						) : null}
-						<p mix={css({ margin: 0, color: colors.textMuted })}>
-							Verify your account email to browse stored messages.
-						</p>
-					</div>
+						{renderEmailVerificationPrompt({
+							email: data.email,
+							description:
+								'Verify your account email to browse stored messages. MCP access and email features stay locked until this account email is verified.',
+							delivery: resendAccepted
+								? acceptedEmailVerificationDelivery()
+								: (readAppSession(handle)?.session?.emailVerificationDelivery ??
+									null),
+							resendStatus,
+							resendMessage,
+							resendTone,
+							onResend: () => {
+								void handleResendVerification()
+							},
+							secondaryHref: '/pending-verification',
+							secondaryLabel: 'Verification page',
+						})}
+					</>
 				) : null}
 			</AccountManagementShell>
 		)

--- a/packages/worker/client/routes/account-integrations.tsx
+++ b/packages/worker/client/routes/account-integrations.tsx
@@ -462,7 +462,7 @@ export function AccountIntegrationsRoute(handle: Handle) {
 
 				{status === 'loading' ? (
 					<p mix={css({ color: colors.textMuted, margin: 0 })}>
-						Loading integrations...
+						Loading integrations…
 					</p>
 				) : null}
 				{message ? (
@@ -495,7 +495,7 @@ export function AccountIntegrationsRoute(handle: Handle) {
 							countLabel={`${filteredApps.length} of ${apps.length} integrations`}
 							emptyLabel={
 								apps.length === 0
-									? 'No integrations yet. Copy a setup prompt below to get started.'
+									? 'No integrations yet.'
 									: 'No integrations match the current filters.'
 							}
 							toolbar={

--- a/packages/worker/client/routes/account-jobs-shared.ts
+++ b/packages/worker/client/routes/account-jobs-shared.ts
@@ -52,7 +52,9 @@ export function emptyJobsMessage(input: {
 	view: AccountJobsViewFilter
 	search: string
 }) {
-	if (input.totalCount === 0) return 'No scheduled jobs yet.'
+	if (input.totalCount === 0) {
+		return 'No scheduled jobs yet. Ask Kody to add one on a saved package.'
+	}
 	if (input.filteredCount > 0) return null
 	if (input.search || input.view === 'all') {
 		return 'No jobs match the current filters.'

--- a/packages/worker/client/routes/account-jobs.tsx
+++ b/packages/worker/client/routes/account-jobs.tsx
@@ -287,9 +287,7 @@ export function AccountJobsRoute(handle: Handle) {
 				/>
 
 				{status === 'loading' ? (
-					<p mix={css({ color: colors.textMuted, margin: 0 })}>
-						Loading jobs...
-					</p>
+					<p mix={css({ color: colors.textMuted, margin: 0 })}>Loading jobs…</p>
 				) : null}
 				{message ? (
 					<AccountManagementMessage
@@ -538,7 +536,7 @@ export function AccountJobsRoute(handle: Handle) {
 								: waitingForDetail
 									? renderJobDetailPlaceholder(
 											listMatch?.name ?? 'Loading job',
-											'Loading job details...',
+											'Loading job details…',
 										)
 									: showJobNotFound
 										? renderJobDetailPlaceholder(

--- a/packages/worker/client/routes/account-mcp-servers.tsx
+++ b/packages/worker/client/routes/account-mcp-servers.tsx
@@ -387,7 +387,7 @@ export function AccountMcpServersRoute(handle: Handle) {
 
 				{status === 'loading' ? (
 					<p mix={css({ color: colors.textMuted, margin: 0 })}>
-						Loading MCP servers...
+						Loading MCP servers…
 					</p>
 				) : null}
 				{message ? (

--- a/packages/worker/client/routes/account-memories.tsx
+++ b/packages/worker/client/routes/account-memories.tsx
@@ -351,7 +351,7 @@ export function AccountMemoriesRoute(handle: Handle) {
 
 				{status === 'loading' ? (
 					<p mix={css({ color: colors.textMuted, margin: 0 })}>
-						Loading memories...
+						Loading memories…
 					</p>
 				) : null}
 				{message ? (

--- a/packages/worker/client/routes/account-packages.tsx
+++ b/packages/worker/client/routes/account-packages.tsx
@@ -320,7 +320,7 @@ export function AccountPackagesRoute(handle: Handle) {
 			<AccountManagementShell>
 				<AccountPageHeader
 					title="Packages"
-					description="Browse your saved packages. Open a row to see details, change visibility, or delete the package."
+					description="Browse your saved packages. Open a row to manage visibility, publish lock, and deletion on the package page."
 					currentHref={currentHref}
 				/>
 				{status === 'loading' && lastLoadedDataKey === '' ? (

--- a/packages/worker/client/routes/account-values.tsx
+++ b/packages/worker/client/routes/account-values.tsx
@@ -377,13 +377,13 @@ export function AccountValuesRoute(handle: Handle) {
 			<AccountManagementShell>
 				<AccountPageHeader
 					title="Values"
-					description="Operator drain for leftover named rows. This route is not listed in account navigation."
+					description="Leftover named rows from an older storage model. New work uses secrets and package storage."
 					currentHref={currentHref}
 				/>
 
 				{status === 'loading' ? (
 					<p mix={css({ color: colors.textMuted, margin: 0 })}>
-						Loading values...
+						Loading values…
 					</p>
 				) : null}
 				{message ? (
@@ -454,7 +454,7 @@ export function AccountValuesRoute(handle: Handle) {
 						record={
 							isLoadingSelection ? (
 								<p mix={css({ margin: 0, color: colors.textMuted })}>
-									Loading value...
+									Loading value…
 								</p>
 							) : showEditor ? (
 								<div mix={css(recordBodyCss)}>

--- a/packages/worker/client/routes/account-waiting.tsx
+++ b/packages/worker/client/routes/account-waiting.tsx
@@ -131,6 +131,11 @@ export function AccountWaitingRoute(handle: Handle) {
 					description="Things that need you. Not a history — items leave when you clear the gate."
 					currentHref={currentHref}
 				/>
+				{status === 'loading' ? (
+					<p mix={css({ color: colors.textMuted, margin: 0 })}>
+						Loading waiting items…
+					</p>
+				) : null}
 				{status === 'error' && message ? (
 					<AccountManagementMessage tone="error">
 						{message}

--- a/packages/worker/client/routes/account-workflows.tsx
+++ b/packages/worker/client/routes/account-workflows.tsx
@@ -88,7 +88,9 @@ function emptyWorkflowsMessage(input: {
 	view: AccountWorkflowsViewFilter
 	search: string
 }) {
-	if (input.totalCount === 0) return 'No workflow runs yet.'
+	if (input.totalCount === 0) {
+		return 'No workflow runs yet. Ask Kody to create a deferred or long-running run.'
+	}
 	if (input.filteredCount > 0) return null
 	if (input.search || input.view === 'all') {
 		return 'No workflows match the current filters.'
@@ -423,7 +425,7 @@ export function AccountWorkflowsRoute(handle: Handle) {
 
 				{status === 'loading' ? (
 					<p mix={css({ color: colors.textMuted, margin: 0 })}>
-						Loading workflows...
+						Loading workflows…
 					</p>
 				) : null}
 				{message ? (
@@ -684,7 +686,7 @@ export function AccountWorkflowsRoute(handle: Handle) {
 										{listMatch?.workflowName ?? 'Loading workflow'}
 									</h2>
 									<p mix={css({ margin: 0, color: colors.textMuted })}>
-										Loading workflow details...
+										Loading workflow details…
 									</p>
 								</div>
 							) : showWorkflowNotFound ? (

--- a/packages/worker/client/routes/blog.tsx
+++ b/packages/worker/client/routes/blog.tsx
@@ -1,4 +1,5 @@
 import { type Handle, css } from 'remix/ui'
+import { on } from '#client/event-mixin.ts'
 import {
 	BLOG_AUTHOR_NAME,
 	formatBlogPostDate,
@@ -147,13 +148,27 @@ export function BlogRoute(handle: Handle) {
 					<p mix={css(listStatusCss)}>Loading posts…</p>
 				) : null}
 				{status === 'error' ? (
-					<p mix={css(listStatusCss)}>Unable to load blog posts.</p>
+					<div mix={css(listStatusCss)}>
+						<p mix={css({ margin: 0 })}>Unable to load blog posts.</p>
+						<button
+							type="button"
+							mix={[
+								css(retryButtonCss),
+								on('click', () => window.location.reload()),
+							]}
+						>
+							Try again
+						</button>
+					</div>
 				) : null}
 				{status === 'ready' && featuredPost ? (
 					<ul mix={css(postListCss)}>
 						{renderFeaturedPostItem(featuredPost)}
 						{listPosts.map((post, index) => renderPostItem(post, index + 1))}
 					</ul>
+				) : null}
+				{status === 'ready' && !featuredPost ? (
+					<p mix={css(listStatusCss)}>No posts yet.</p>
 				) : null}
 			</section>
 		)
@@ -255,6 +270,18 @@ const listStatusCss = {
 	margin: 'clamp(2rem, 5vw, 3rem) 0 0',
 	color: colors.textMuted,
 	fontSize: '0.98rem',
+}
+
+const retryButtonCss = {
+	marginTop: '0.75rem',
+	padding: 0,
+	border: 0,
+	background: 'none',
+	color: colors.primaryText,
+	font: 'inherit',
+	cursor: 'pointer',
+	textDecoration: 'underline',
+	textUnderlineOffset: '0.15em',
 }
 
 const postListCss = {

--- a/packages/worker/client/routes/community.tsx
+++ b/packages/worker/client/routes/community.tsx
@@ -97,8 +97,8 @@ export function CommunityRoute(handle: Handle) {
 							built. <em>Make it yours.</em>
 						</h1>
 						<p data-rise style={{ '--rise': '1' }} mix={css(headSubCss)}>
-							Browse packages shared by Kody users. Fork with your agent, adapt
-							them to your goals, and rate your experience.
+							Browse packages shared by Kody users. Fork with your agent and
+							adapt them to your goals.
 						</p>
 						{explainer ? (
 							<EntityExplainer copy={explainer} marginTop="1.15rem" />

--- a/packages/worker/client/routes/entity-explainer.node.test.ts
+++ b/packages/worker/client/routes/entity-explainer.node.test.ts
@@ -37,6 +37,9 @@ test('entity explainers resolve on entity pages, render collapsed, and skip sett
 	const copy = resolveEntityExplainer(routes.accountPackages.href())
 	expect(copy).not.toBeNull()
 	if (!copy) throw new Error('expected packages explainer')
+	expect(copy.paragraphs.join(' ')).toContain(
+		'open a package to change visibility, publish lock, or delete it',
+	)
 	expect(copy.learnMore?.map((link) => link.href)).toEqual([
 		comparisonHref,
 		routes.guideDetail.href({ slug: 'package-lifecycle' }),

--- a/packages/worker/client/routes/entity-explainer.tsx
+++ b/packages/worker/client/routes/entity-explainer.tsx
@@ -35,7 +35,7 @@ const entityExplainerDefinitions: Array<EntityExplainerDefinition> = [
 		match: accountSection(routes.accountPackages.href()),
 		paragraphs: [
 			'A package is reusable saved code your agent writes and improves over time. Unlike a one-off execute, it lives in a repo with a package.json and can expose exports, scheduled jobs, inbound webhooks, and even a small web app.',
-			'Use a package when work should stay invokable after the conversation ends — a daily digest, a GitHub helper, or a UI your agent hosts for you. Browse metadata here; create and edit packages through your connected agent.',
+			'Use a package when work should stay invokable after the conversation ends — a daily digest, a GitHub helper, or a UI your agent hosts for you. Browse the list here; open a package to change visibility, publish lock, or delete it. Create and edit package code through your connected agent.',
 			'Trusted clients that cannot use MCP call a package over HTTP through an inbound webhook. Declare one webhook per export, mint a URL, and POST JSON — one name binds one export.',
 			'A package is behavior, not a Slack login and not an MCP connection.',
 		],

--- a/packages/worker/client/routes/guides.tsx
+++ b/packages/worker/client/routes/guides.tsx
@@ -1,4 +1,5 @@
 import { type Handle, css } from 'remix/ui'
+import { on } from '#client/event-mixin.ts'
 import {
 	type GuidesLoaderData,
 	type GuideSummaryLoaderData,
@@ -157,7 +158,18 @@ export function GuidesRoute(handle: Handle) {
 					<p mix={css(listStatusCss)}>Loading guides…</p>
 				) : null}
 				{status === 'error' ? (
-					<p mix={css(listStatusCss)}>Unable to load guides.</p>
+					<div mix={css(listStatusCss)}>
+						<p mix={css({ margin: 0 })}>Unable to load guides.</p>
+						<button
+							type="button"
+							mix={[
+								css(retryButtonCss),
+								on('click', () => window.location.reload()),
+							]}
+						>
+							Try again
+						</button>
+					</div>
 				) : null}
 				{status === 'ready' ? (
 					<>
@@ -274,6 +286,18 @@ export const listStatusCss = {
 	margin: 'clamp(1.8rem, 4vw, 2.5rem) 0 0',
 	color: colors.textMuted,
 	fontSize: '0.98rem',
+}
+
+const retryButtonCss = {
+	marginTop: '0.75rem',
+	padding: 0,
+	border: 0,
+	background: 'none',
+	color: colors.primaryText,
+	font: 'inherit',
+	cursor: 'pointer',
+	textDecoration: 'underline',
+	textUnderlineOffset: '0.15em',
 }
 
 export const guideListCss = {

--- a/packages/worker/client/routes/oauth-authorize.tsx
+++ b/packages/worker/client/routes/oauth-authorize.tsx
@@ -525,7 +525,7 @@ export function OAuthAuthorizeRoute(handle: Handle) {
 					</div>
 				) : null}
 				{status === 'loading' ? (
-					<p mix={css(descriptionCss)}>Loading authorization details...</p>
+					<p mix={css(descriptionCss)}>Loading authorization details…</p>
 				) : null}
 				{message ? (
 					<p

--- a/packages/worker/client/routes/pricing.tsx
+++ b/packages/worker/client/routes/pricing.tsx
@@ -271,7 +271,7 @@ function renderPaidPlanCta(isSignedIn: boolean) {
 	if (isSignedIn) {
 		return (
 			<a href="/account/billing" mix={css(planGhostButtonCss)}>
-				Upgrade in settings
+				Upgrade in billing
 			</a>
 		)
 	}

--- a/packages/worker/client/routes/profile.tsx
+++ b/packages/worker/client/routes/profile.tsx
@@ -17,6 +17,7 @@ import { consumeStaleNavigationData } from '#client/navigation-data.ts'
 import { type RouteLoaderResult } from '#client/route-loader.ts'
 import { readRouterPathname } from '#client/router-location.tsx'
 import { readJson } from '#client/routes/account-approval-shared.ts'
+import { on } from '#client/event-mixin.ts'
 import { readProfileSearchQueryFromHref } from '#client/routes/profile-search.ts'
 import { colors, spacing, typography } from '#universal/styles/tokens.ts'
 import {
@@ -231,6 +232,27 @@ export function ProfileRoute(handle: Handle) {
 			)
 		}
 
+		if (shellStatus === 'error') {
+			return (
+				<section mix={css(pageCss)} data-testid="profile-load-error">
+					<p mix={css(pageDescriptionCss)} role="status">
+						Unable to load this profile.
+					</p>
+					<button
+						type="button"
+						mix={[
+							css({ ...getPrimaryButtonCss(), width: 'fit-content' }),
+							on('click', () => {
+								window.location.reload()
+							}),
+						]}
+					>
+						Try again
+					</button>
+				</section>
+			)
+		}
+
 		return (
 			<section mix={css(pageCss)}>
 				{readyShell?.isSelf ? (
@@ -246,11 +268,6 @@ export function ProfileRoute(handle: Handle) {
 
 				{shellStatus === 'loading' ? (
 					<p mix={css(pageDescriptionCss)}>Loading profile…</p>
-				) : null}
-				{shellStatus === 'error' ? (
-					<p mix={css(pageDescriptionCss)} role="status">
-						Unable to load this profile.
-					</p>
 				) : null}
 
 				<form

--- a/packages/worker/client/site-header.tsx
+++ b/packages/worker/client/site-header.tsx
@@ -202,7 +202,7 @@ export function SiteHeader(handle: Handle<SiteHeaderProps>) {
 										'/account/waiting',
 									)}
 									data-testid="site-header-waiting-menu"
-									mix={css(menuWaitingAvatarCss)}
+									mix={css(menuWaitingLinkCss)}
 								>
 									<UserAvatar
 										displayName={handle.props.displayName}
@@ -210,6 +210,18 @@ export function SiteHeader(handle: Handle<SiteHeaderProps>) {
 										size={32}
 										variant="well"
 									/>
+									Waiting
+								</a>
+								<a
+									href="/account"
+									aria-current={
+										handle.props.currentPathname === '/account'
+											? 'page'
+											: undefined
+									}
+									data-testid="site-header-account-menu"
+								>
+									Account
 								</a>
 							</>
 						) : (
@@ -450,10 +462,8 @@ const navUserAvatarCss = {
 	'&:hover': { color: colors.text },
 }
 
-const menuWaitingAvatarCss = {
-	display: 'inline-flex',
-	alignItems: 'center',
-	width: 'fit-content',
+const menuWaitingLinkCss = {
+	gap: '0.65rem',
 }
 
 const demoIndicatorCss = {

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -359,6 +359,7 @@ test('SSR HTML routes render page content and embedded loader data', async () =>
 	const accountHtml = await readResponseText(accountResponse)
 	expect(accountHtml).toContain('aria-label="Account sections"')
 	expect(accountHtml).toContain('data-testid="site-header-waiting"')
+	expect(accountHtml).toContain('data-testid="site-header-account-menu"')
 	expect(accountHtml).toContain('href="/account/waiting"')
 	expect(accountHtml).toContain('Waiting — account-user')
 	const accountProps = readAppRootProps(accountHtml)
@@ -1454,8 +1455,9 @@ test('renderAppPage server-renders simplified integration and secret-approval pa
 		},
 	})
 	const emptyHtml = await readResponseText(emptyResponse)
+	expect(emptyHtml).toContain('No integrations yet.')
 	expect(emptyHtml).toContain(
-		'No integrations yet. Copy a setup prompt below to get started.',
+		'Pick a service and copy its prompt into your agent',
 	)
 
 	const approvalResponse = await renderAppPage({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #2050

## Intent

Walk the high-traffic surfaces from the polish-pass issue and fix the obvious bad experiences an agent can catch without sitting next to Kent: copy that does not match the page, dead-end empty/error states, and an unlabeled mobile session corner.

## Why

Most polish needs a human looking at the screen. A few mismatches are checkable from the code: CTAs that name the wrong place, empty states with no next step, and explainers that disagree with the list page. Those are cheap to fix and worth shipping.

## Summary

- Packages list + explainer now agree that a row opens the package page for visibility, publish lock, and delete; code edits still go through the agent
- Community hero no longer invites web ratings the catalog cannot submit
- Pricing paid CTA says “Upgrade in billing” (it already links to `/account/billing`)
- Profile load errors hide the broken search/frame and offer Try again
- Unverified `/account/email` reuses the shared verification prompt (resend + verification page) instead of dead-end copy
- Waiting shows a loading line; jobs/workflows empty states point at asking Kody
- Mobile menu labels Waiting (with avatar) and Account instead of an unlabeled avatar
- Blog/guides error states get Try again; blog has a real empty catalog line
- Values page drops contributor jargon; loading ellipses are consistent on daily account pages

## Testing

- `npm run validate:fix`
- Pre-push: `test:node` (2537) and `test:workers` (326)
- Browser pass on local origin after this draft (desktop + ~820px mobile menu)

## Product decisions left on #2050

Avatar still goes to Waiting (not Account). Whether that stays the front door, whether community ratings should exist in the web UI, and whether `/account/values` should stay reachable are noted on the issue — not decided here.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `096dae74` · **Head:** `84900772`

**Classification:** composes — no primitives added or changed; this PR rewrites chrome and copy on existing app-ui and community-listings surfaces.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | composes — header, account pages, catalog error/empty copy |
| `community-listings` | assistant | composes — community hero no longer promises in-UI rating |

### Change flow

Signed-in chrome and account pages render existing session and JSON loaders; this PR only changes what those pages say and which recovery links they show.

```mermaid
sequenceDiagram
	actor User
	participant appUi as app-ui
	participant communityListings as community-listings
	User->>appUi: open header menu or account page
	appUi-->>User: labeled Waiting + Account; aligned ledes and empty states
	User->>communityListings: open /community
	communityListings-->>User: hero copy without a web rate CTA
	User->>appUi: unverified /account/email
	appUi-->>User: shared resend + verification-page prompt
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a79065d9-256c-4f76-a98f-9fa0703914de?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a79065d9-256c-4f76-a98f-9fa0703914de&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added email verification prompts with resend controls, delivery status, and verification-page links.
  * Added retry buttons to blog, guides, and profile error states.
  * Added clearer loading feedback while waiting items are fetched.
  * Signed-in paid-plan users can now upgrade directly through Billing.
  * Mobile navigation now includes separate Waiting and Account links.

* **Improvements**
  * Updated package, workflow, job, and storage-page guidance and empty-state messages.
  * Refined loading text and page copy for consistency.
  * Added a no-posts message for empty blogs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->