### PR TITLE
Record: do not move the origin website to Pitlane Vite

### DIFF
--- a/docs/contributing/decisions/0049-no-pitlane-vite-origin.md
+++ b/docs/contributing/decisions/0049-no-pitlane-vite-origin.md
@@ -1,0 +1,45 @@
+# 0049: Do not move the origin website to Pitlane Vite
+
+- **Status:** accepted
+- **Date:** 2026-09-04
+
+## Context
+
+[Pitlane's Cloudflare deploy guide](https://pitlane.tools/deploy/cloudflare)
+composes `@pitlane/dev`'s `remix()` Vite plugin with `@cloudflare/vite-plugin`
+so `vite dev` runs SSR inside workerd, `vite build` emits `dist/client` +
+`dist/ssr`, and `wrangler deploy` ships that shape. The prompt to adopt it is
+agent friction on `npm run dev` (esbuild watcher + wrangler reload loops).
+
+Kody's origin website is not that template. SSR lives in the origin Worker
+(`origin-handler.ts` → Remix `renderToStream`), the browser bundle is a separate
+esbuild write into `packages/worker/public/` (`/client-entry.js` plus hashed
+`*-area-*.js` chunks), and local/production fleets are four scripts orchestrated
+by `wrangler-env.ts`. Hydration is a hardcoded `/client-entry.js#AppRoot`
+registry, not Pitlane's `clientEntry(import.meta.url, …)` transform.
+`@pitlane/dev@0.6` peers `remix@^3.0.0-rc.1`; this repo is on
+`remix@3.0.0-beta.10`.
+
+## Decision
+
+Do not adopt Pitlane Vite (`@pitlane/dev` + `@cloudflare/vite-plugin`) as the
+origin website's build or local-dev authority. Keep the esbuild client pipeline
+and `wrangler-env.ts` multi-worker `wrangler dev`. A client-only esbuild→Vite
+swap that still writes `packages/worker/public/` is the same no unless the
+revisit conditions below are met — it would not fix the local-server friction.
+
+## Consequences
+
+Agent local-dev pain stays a Wrangler problem (overlay-FS watch loops, assets
+races, generated-module watches, `X_LOCAL_EXPLORER`, multi-config Miniflare),
+not a website-bundler problem. Production client output, Sentry maps, and the
+preload manifest stay on the existing esbuild metafile contract.
+
+**Revisit-if** all of these are true: Remix is already on an `@pitlane/dev`
+supported prerelease for another reason; `wrangler-env.ts` (generated
+platform/runtime configs, Cloudflare API mock, persist paths,
+`CLOUDFLARE_ENV=test` watch disables) can be expressed as Vite
+`auxiliaryWorkers` without losing those behaviors; and we are ready to rewrite
+hydration, area-chunk naming, and `client-manifest.json` off the
+`/client-entry.js` contract. Until then, fix Wrangler/dev orchestration — do not
+cut the website over.

--- a/docs/contributing/decisions/index.md
+++ b/docs/contributing/decisions/index.md
@@ -100,6 +100,9 @@ Open these before proposing a new primitive, surface, or storage home.
 - [0047 — One Vectorize index with per-user namespaces until 5,000 users](./0047-vectorize-per-user-namespaces-until-5k-users.md)
   — no sharding or metadata-only filtering before 5k accounts; the shard shape
   is pre-decided for when it is needed
+- [0049 — Do not move the origin website to Pitlane Vite](./0049-no-pitlane-vite-origin.md)
+  — keep esbuild + `wrangler-env.ts`; local-dev friction is Wrangler, not the
+  client bundler
 
 ## Historical / UI / implementation
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Decide whether to move the origin Remix website onto [Pitlane’s Cloudflare Vite path](https://pitlane.tools/deploy/cloudflare) (`@pitlane/dev` + `@cloudflare/vite-plugin`) to reduce agent friction running the local server.

## Why

Investigated that cutover before changing the production client/SSR pipeline. It is **not** a drop-in, and it would not fix the local-dev pain that prompted the question. This PR records the no so the next agent does not re-litigate it without new evidence.

## Summary

- **Did not migrate.** Production still ships the existing esbuild client bundle (`/client-entry.js` + hashed `*-area-*.js`) and Wrangler-owned origin SSR.
- Added [ADR 0049](./docs/contributing/decisions/0049-no-pitlane-vite-origin.md): keep esbuild + `wrangler-env.ts`; do not adopt Pitlane as the origin build/dev authority.
- A client-only esbuild→Vite swap that still writes `packages/worker/public/` is the same no unless the ADR revisit conditions are met — it would not fix `npm run dev` friction.

### Why this is not straightforward

Pitlane assumes a greenfield Remix 3 app whose server entry **is** the Worker (`app/entry.server.tsx` default-exports a fetch handler, `vite build` emits `dist/client` + `dist/ssr`, `vite dev` owns workerd). Kody’s origin is a different shape:

| Contract | Pitlane Cloudflare guide | Kody today |
| --- | --- | --- |
| Remix | `@pitlane/dev@0.6` peers `remix@^3.0.0-rc.1` | `remix@3.0.0-beta.10` |
| Hydration | `clientEntry(import.meta.url, …)` transform | Hardcoded `/client-entry.js#AppRoot` registry |
| Client assets | Vite hashed `dist/client` + `?assets=` | esbuild → `packages/worker/public/`, `client-manifest.json` from esbuild metafile |
| Worker `main` | `app/entry.server.tsx` | `index.ts` / `production-worker.ts` (MCP, OAuth, queues, email, service bindings) |
| Local fleet | One Vite+workerd graph (`auxiliaryWorkers` optional) | `wrangler-env.ts` multi-config Miniflare (origin + platform + runtime + jobs + Cloudflare API mock) |

The documented agent friction (`dev:ensure`, overlay-FS watch loops, `X_LOCAL_EXPLORER`, `WRANGLER_DISABLE_BUNDLE_WATCH`, client-entry vs Wrangler assets race) is **Wrangler orchestration**, not the website bundler. Swapping esbuild for Vite and still writing `public/` leaves that two-process race in place. Full Pitlane ownership would require rewriting hydration, area-chunk naming, Sentry maps, preload hints, generated local configs, and the four-script deploy story — with a real chance of changing production output for no local-dev win.

**Revisit-if** (from the ADR): Remix is already on a Pitlane-supported prerelease for another reason; `wrangler-env.ts` can be expressed as Vite `auxiliaryWorkers` without losing generated configs, the Cloudflare API mock, persist paths, and `CLOUDFLARE_ENV=test` watch disables; and we are ready to rewrite hydration + `client-manifest.json` off `/client-entry.js`.

## Testing

- `npm run docs:check-decisions` (pass)
- Pre-commit typecheck + `test:push` (cached green; docs-only change)
- No production output, client bundle, or local-dev script changed

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `b3ada633` · **Head:** `632ba3ea`

**Classification:** composes — no primitives added or changed; this PR records a tooling veto in the decision index.

### Primitives touched

None. Classifier unmatched paths are `docs/contributing/decisions/0049-no-pitlane-vite-origin.md` and `docs/contributing/decisions/index.md`.

### Change flow

Agents that propose a Pitlane Vite origin cutover hit the new veto before touching the website toolchain.

```mermaid
sequenceDiagram
	actor Agent
	participant decisions as decision-records
	participant originUi as app-ui
	participant wranglerDev as wrangler-dev
	Agent->>decisions: open 0049 before proposing Pitlane Vite
	Note over decisions: no — keep esbuild + wrangler-env
	decisions-->>originUi: do not replace esbuild client pipeline
	decisions-->>wranglerDev: local-dev friction stays a Wrangler fix
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3b12fbbe-e3d1-42f7-a46d-6055986a8044?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3b12fbbe-e3d1-42f7-a46d-6055986a8044&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a decision record documenting that the origin website will remain on its current build and local development setup rather than moving to Pitlane Vite.
  - Documented the associated trade-offs and conditions that would warrant revisiting this decision.
  - Added the new decision record to the contributing documentation index.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->