### PR TITLE
Describe MCP authorize as one full-access grant

### DIFF
--- a/docs/contributing/architecture/authentication.md
+++ b/docs/contributing/architecture/authentication.md
@@ -693,7 +693,11 @@ routed from `packages/worker/src/index.ts`.
   `http://127.0.0.1:43742/callback` so the CLI can use SEP-991 instead of
   deprecated DCR.
 - Supported scopes: `openid`, `profile`, `email` (additive; `openid` enables ID
-  tokens and the UserInfo endpoint)
+  tokens and the UserInfo endpoint). These are OIDC identity claims, not a
+  permission menu. MCP access is one grant: a valid token for this origin's
+  `/mcp` audience receives the full assistant. `/oauth/authorize` describes that
+  grant in plain language and keeps the OIDC names in a technical disclosure.
+  See [0049](../decisions/0049-no-mcp-capability-oauth-scopes.md).
 - Kody's MCP authorization server is an **OAuth 2.1 + OpenID Connect
   Authorization Code** provider with CIMD and RFC 9728 resource metadata. Issuer
   is the app origin (`getAppBaseUrl`). `sub` is the account `stable_user_id`. ID
@@ -739,6 +743,9 @@ Token lifetimes are set on the `OAuthProvider` in
 - Requires `Authorization: Bearer <token>`
 - Token is validated via OAuth provider helpers (`unwrapToken`)
 - Audience must match the app origin or `<origin>/mcp`
+- Token OIDC scopes are not checked for MCP capability access. Audience,
+  identity, email verification, suspension, and password-change gates apply; the
+  token is then the full assistant
 - Requests without a Bearer token return `401` with `WWW-Authenticate` carrying
   RFC 9728 `resource_metadata` (and scopes). RFC 6750 omits `error` when
   credentials are absent

--- a/docs/contributing/decisions/0049-no-mcp-capability-oauth-scopes.md
+++ b/docs/contributing/decisions/0049-no-mcp-capability-oauth-scopes.md
@@ -1,0 +1,37 @@
+# 0049: No MCP capability OAuth scopes
+
+- **Status:** accepted
+- **Date:** 2026-09-04
+
+## Context
+
+`/oauth/authorize` listed requested OIDC scopes (`openid`, `profile`, `email`)
+as if they were a permission menu. Those strings are live as identity claims:
+`openid` enables ID tokens and UserInfo, `email` and `profile` add claims. MCP
+does not consult them. A valid bearer token for this origin's `/mcp` audience
+receives the full assistant (`search`, `execute`, secrets, packages, email,
+memories, connected services).
+
+Project intent does not optimize for fine-grained permission delegation inside
+one account. Most MCP hosts request whatever discovery advertises and assume
+full access.
+
+## Decision
+
+Do not add capability-level MCP OAuth scopes. Connecting an agent is one grant:
+full access to that user's assistant.
+
+Keep `openid`, `profile`, and `email` as OIDC identity claims.
+`/oauth/authorize` describes the real grant in plain language and keeps those
+scope names in a technical disclosure.
+
+## Consequences
+
+Consent copy must not look like a GitHub or Google picker. RFC 9728
+`scopes_supported` remains the OIDC trio. Do not advertise a fake `mcp` or
+`kody` resource scope until a revisit actually needs a second credential class.
+
+**Revisit-if** a second class of MCP credential must be weaker than the owner's
+assistant (for example a read-only host, or a token that cannot `execute`), and
+that need cannot be met by a separate primitive (package-owned webhooks, package
+apps).

--- a/docs/contributing/decisions/index.md
+++ b/docs/contributing/decisions/index.md
@@ -100,6 +100,9 @@ Open these before proposing a new primitive, surface, or storage home.
 - [0047 — One Vectorize index with per-user namespaces until 5,000 users](./0047-vectorize-per-user-namespaces-until-5k-users.md)
   — no sharding or metadata-only filtering before 5k accounts; the shard shape
   is pre-decided for when it is needed
+- [0049 — No MCP capability OAuth scopes](./0049-no-mcp-capability-oauth-scopes.md)
+  — connecting an agent is one grant; `openid` / `profile` / `email` stay
+  identity claims, not a permission menu
 
 ## Historical / UI / implementation
 

--- a/docs/use/connect-your-agent.md
+++ b/docs/use/connect-your-agent.md
@@ -23,7 +23,8 @@ agent — you do not need every host on day one.
    local origins use that deployment's MCP URL (`https://<this-host>/mcp`). On
    [kody.codes](https://kody.codes) the MCP URL is `https://kody.codes/mcp`.
 4. Complete the OAuth flow when the host opens it. Sign in to Kody if needed,
-   then approve access.
+   then approve access. Approving gives that agent full access to this Kody
+   account — not a limited permission set.
 
 Your account email must be verified before authorize can finish or MCP can run.
 If authorize asks you to verify, keep that tab open, finish verification (from

--- a/packages/worker/client/routes/oauth-authorize.tsx
+++ b/packages/worker/client/routes/oauth-authorize.tsx
@@ -144,23 +144,19 @@ function renderOauthAuthorizeGrant(input: {
 					mix={css(nativeDisclosureCss)}
 				>
 					<summary>Identity claims on the token</summary>
-					<p mix={css(descriptionCss)}>
-						These OAuth scopes are identity claims. They do not limit what the
-						assistant can do.
-					</p>
-					<p
-						mix={css({
-							...descriptionCss,
-							display: 'flex',
-							flexWrap: 'wrap',
-							gap: `${spacing.xs} ${spacing.sm}`,
-						})}
-					>
-						{input.scopes.flatMap((scope, index) => [
-							index > 0 ? ' ' : null,
-							<code key={scope}>{scope}</code>,
-						])}
-					</p>
+					{/* nativeDisclosureCss grids each direct details child. */}
+					<div>
+						<p mix={css(descriptionCss)}>
+							These OAuth scopes are identity claims. They do not limit what the
+							assistant can do.
+						</p>
+						<p mix={css(descriptionCss)}>
+							{input.scopes.flatMap((scope, index) => [
+								index > 0 ? ' ' : null,
+								<code key={scope}>{scope}</code>,
+							])}
+						</p>
+					</div>
 				</details>
 			) : null}
 		</section>

--- a/packages/worker/client/routes/oauth-authorize.tsx
+++ b/packages/worker/client/routes/oauth-authorize.tsx
@@ -129,12 +129,16 @@ function renderOauthAuthorizeGrant(input: {
 						These OAuth scopes are identity claims. They do not limit what the
 						assistant can do.
 					</p>
-					<p mix={css(descriptionCss)}>
-						{input.scopes.map((scope, index) => (
-							<span key={scope}>
-								{index > 0 ? ', ' : null}
-								<code>{scope}</code>
-							</span>
+					<p
+						mix={css({
+							...descriptionCss,
+							display: 'flex',
+							flexWrap: 'wrap',
+							gap: `${spacing.xs} ${spacing.sm}`,
+						})}
+					>
+						{input.scopes.map((scope) => (
+							<code key={scope}>{scope}</code>
 						))}
 					</p>
 				</details>
@@ -503,7 +507,9 @@ export function OAuthAuthorizeRoute(handle: Handle) {
 						{clientLabel} wants to access your kody account.
 					</p>
 				</header>
-				{renderOauthAuthorizeGrant({ clientLabel, scopes })}
+				{status === 'ready'
+					? renderOauthAuthorizeGrant({ clientLabel, scopes })
+					: null}
 				{isLoggedIn ? (
 					<section mix={css(insetCardCss)}>
 						<p

--- a/packages/worker/client/routes/oauth-authorize.tsx
+++ b/packages/worker/client/routes/oauth-authorize.tsx
@@ -41,6 +41,7 @@ import {
 	insetCardCss,
 	inputCss,
 	mutedLinkCss,
+	nativeDisclosureCss,
 	pageDescriptionCss,
 	pageEyebrowCss,
 	pageHeaderCss,
@@ -104,6 +105,42 @@ export async function oauthAuthorizeRouteLoader(
 			requireCredentials: payload.requireCredentials === true,
 		},
 	}
+}
+
+function renderOauthAuthorizeGrant(input: {
+	clientLabel: string
+	scopes: ReadonlyArray<string>
+}) {
+	return (
+		<section data-testid="oauth-authorize-grant" mix={css(cardCss)}>
+			<h2 mix={css(sectionTitleCss)}>This agent gets full access</h2>
+			<p mix={css(descriptionCss)}>
+				Approving lets {input.clientLabel} use everything in this Kody account:
+				packages, memories, secrets, email, connected services, and anything
+				else your assistant can do.
+			</p>
+			{input.scopes.length > 0 ? (
+				<details
+					data-testid="oauth-authorize-oidc-scopes"
+					mix={css(nativeDisclosureCss)}
+				>
+					<summary>Identity claims on the token</summary>
+					<p mix={css(descriptionCss)}>
+						These OAuth scopes are identity claims. They do not limit what the
+						assistant can do.
+					</p>
+					<p mix={css(descriptionCss)}>
+						{input.scopes.map((scope, index) => (
+							<span key={scope}>
+								{index > 0 ? ', ' : null}
+								<code>{scope}</code>
+							</span>
+						))}
+					</p>
+				</details>
+			) : null}
+		</section>
+	)
 }
 
 export function OAuthAuthorizeRoute(handle: Handle) {
@@ -423,8 +460,6 @@ export function OAuthAuthorizeRoute(handle: Handle) {
 		}
 		const clientLabel = info?.client?.name ?? 'Unknown client'
 		const scopes = info?.scopes ?? []
-		const scopeLabel =
-			scopes.length > 0 ? scopes.join(', ') : 'No scopes requested.'
 		const sessionEmail = session?.email ?? ''
 		const sessionDisplayName = getSessionDisplayName(session)
 		const isSessionReady = sessionStatus === 'ready'
@@ -468,10 +503,7 @@ export function OAuthAuthorizeRoute(handle: Handle) {
 						{clientLabel} wants to access your kody account.
 					</p>
 				</header>
-				<section mix={css(cardCss)}>
-					<p mix={css(sectionTitleCss)}>Requested scopes</p>
-					<p mix={css(descriptionCss)}>{scopeLabel}</p>
-				</section>
+				{renderOauthAuthorizeGrant({ clientLabel, scopes })}
 				{isLoggedIn ? (
 					<section mix={css(insetCardCss)}>
 						<p

--- a/packages/worker/client/routes/oauth-authorize.tsx
+++ b/packages/worker/client/routes/oauth-authorize.tsx
@@ -61,6 +61,25 @@ type OAuthAuthorizeStatus = 'idle' | 'loading' | 'ready' | 'error'
 type OAuthAuthorizeMessage = { type: 'error' | 'info'; text: string }
 type OAuthAuthorizeDecision = 'approve' | 'deny' | 'reset-client'
 
+function oauthAuthorizeAccessLead(
+	status: OAuthAuthorizeStatus,
+	clientLabel: string,
+) {
+	switch (status) {
+		case 'ready':
+			return `${clientLabel} wants to access your kody account.`
+		case 'idle':
+		case 'loading':
+			return 'Loading authorization details…'
+		case 'error':
+			return null
+		default: {
+			const exhaustive: never = status
+			return exhaustive
+		}
+	}
+}
+
 function getSearchParams(handle: Handle) {
 	return new URLSearchParams(readRouterSearch(handle))
 }
@@ -137,9 +156,10 @@ function renderOauthAuthorizeGrant(input: {
 							gap: `${spacing.xs} ${spacing.sm}`,
 						})}
 					>
-						{input.scopes.map((scope) => (
-							<code key={scope}>{scope}</code>
-						))}
+						{input.scopes.flatMap((scope, index) => [
+							index > 0 ? ' ' : null,
+							<code key={scope}>{scope}</code>,
+						])}
 					</p>
 				</details>
 			) : null}
@@ -488,6 +508,7 @@ export function OAuthAuthorizeRoute(handle: Handle) {
 		const resetClientDisabled =
 			Boolean(submittingDecision) || isSessionLoading || !isLoggedIn
 		const formReady = status === 'ready' && !isSessionLoading
+		const accessLead = oauthAuthorizeAccessLead(status, clientLabel)
 		const authorizeLabel = submittingDecision
 			? 'Submitting...'
 			: isLoggedIn
@@ -503,9 +524,9 @@ export function OAuthAuthorizeRoute(handle: Handle) {
 				<header mix={css(headerCss)}>
 					<span mix={css(eyebrowCss)}>Kody secure connection</span>
 					<h1 mix={css(pageTitleCss)}>Authorize access</h1>
-					<p mix={css(pageDescriptionCss)}>
-						{clientLabel} wants to access your kody account.
-					</p>
+					{accessLead ? (
+						<p mix={css(pageDescriptionCss)}>{accessLead}</p>
+					) : null}
 				</header>
 				{status === 'ready'
 					? renderOauthAuthorizeGrant({ clientLabel, scopes })
@@ -561,9 +582,6 @@ export function OAuthAuthorizeRoute(handle: Handle) {
 							Deny
 						</button>
 					</div>
-				) : null}
-				{status === 'loading' ? (
-					<p mix={css(descriptionCss)}>Loading authorization details…</p>
 				) : null}
 				{message ? (
 					<p

--- a/packages/worker/client/routes/oauth-authorize.tsx
+++ b/packages/worker/client/routes/oauth-authorize.tsx
@@ -150,11 +150,19 @@ function renderOauthAuthorizeGrant(input: {
 							These OAuth scopes are identity claims. They do not limit what the
 							assistant can do.
 						</p>
-						<p mix={css(descriptionCss)}>
-							{input.scopes.flatMap((scope, index) => [
-								index > 0 ? ' ' : null,
-								<code key={scope}>{scope}</code>,
-							])}
+						<p
+							mix={css({
+								...descriptionCss,
+								display: 'flex',
+								flexWrap: 'wrap',
+								columnGap: spacing.md,
+								rowGap: spacing.xs,
+								alignItems: 'baseline',
+							})}
+						>
+							{input.scopes.map((scope) => (
+								<code key={scope}>{scope}</code>
+							))}
 						</p>
 					</div>
 				</details>

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -902,6 +902,7 @@ test('renderAppPage configures session secret and server-renders oauth authorize
 	expect(anonymousHtml).toContain('data-testid="oauth-authorize-oidc-scopes"')
 	expect(anonymousHtml).toContain('<code>profile</code>')
 	expect(anonymousHtml).toContain('<code>email</code>')
+	expect(anonymousHtml).not.toContain(', <code>email</code>')
 
 	setAuthSessionSecret(testCookieSecret)
 	const cookie = await createAuthCookie(

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -902,7 +902,6 @@ test('renderAppPage configures session secret and server-renders oauth authorize
 	expect(anonymousHtml).toContain('data-testid="oauth-authorize-oidc-scopes"')
 	expect(anonymousHtml).toContain('<code>profile</code>')
 	expect(anonymousHtml).toContain('<code>email</code>')
-	expect(anonymousHtml).toMatch(/<\/code>\s+<code>email<\/code>/)
 	expect(anonymousHtml).not.toContain(', <code>email</code>')
 	expect(anonymousHtml).not.toContain('Unknown client')
 	expect(anonymousHtml).not.toContain('Loading authorization details')

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -896,6 +896,12 @@ test('renderAppPage configures session secret and server-renders oauth authorize
 	const anonymousHtml = await readResponseText(anonymousResponse)
 	expect(anonymousHtml).not.toContain('OAuth authorization failed')
 	expect(anonymousHtml).not.toContain('href="/images/hero/kody-base.webp"')
+	expect(anonymousHtml).not.toContain('Requested scopes')
+	expect(anonymousHtml).not.toContain('No scopes requested.')
+	expect(anonymousHtml).toContain('data-testid="oauth-authorize-grant"')
+	expect(anonymousHtml).toContain('data-testid="oauth-authorize-oidc-scopes"')
+	expect(anonymousHtml).toContain('<code>profile</code>')
+	expect(anonymousHtml).toContain('<code>email</code>')
 
 	setAuthSessionSecret(testCookieSecret)
 	const cookie = await createAuthCookie(

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -902,7 +902,10 @@ test('renderAppPage configures session secret and server-renders oauth authorize
 	expect(anonymousHtml).toContain('data-testid="oauth-authorize-oidc-scopes"')
 	expect(anonymousHtml).toContain('<code>profile</code>')
 	expect(anonymousHtml).toContain('<code>email</code>')
+	expect(anonymousHtml).toMatch(/<\/code>\s+<code>email<\/code>/)
 	expect(anonymousHtml).not.toContain(', <code>email</code>')
+	expect(anonymousHtml).not.toContain('Unknown client')
+	expect(anonymousHtml).not.toContain('Loading authorization details')
 
 	setAuthSessionSecret(testCookieSecret)
 	const cookie = await createAuthCookie(

--- a/packages/worker/src/mcp-oauth-scopes.ts
+++ b/packages/worker/src/mcp-oauth-scopes.ts
@@ -1,2 +1,6 @@
-/** Scopes supported by Kody's MCP OAuth / OIDC authorization server. */
+/**
+ * OIDC identity scopes advertised by Kody's MCP authorization server.
+ * MCP access is one grant (not a permission menu); see
+ * docs/contributing/decisions/0049-no-mcp-capability-oauth-scopes.md.
+ */
 export const mcpOauthScopes: Array<string> = ['openid', 'profile', 'email']


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Make the agent-connect approve page tell the truth: connecting an MCP host is one full-access grant to this Kody account, not a permission picker.

## Why

`/oauth/authorize` listed live OIDC scopes (`openid`, `profile`, `email`) as **Requested scopes**. Those strings are identity claims on the token. MCP does not consult them — a valid token for this origin's `/mcp` audience is the whole assistant. The page looked like a GitHub/Google picker the person cannot even edit.

## Summary

- The approve page states that the agent gets full access to this Kody account.
- Requested OIDC scopes sit under **Identity claims on the token**, with copy that they do not limit the assistant.
- ADR [0049](docs/contributing/decisions/0049-no-mcp-capability-oauth-scopes.md) records the no: do not add capability-level MCP OAuth scopes.
- Architecture and Get started docs describe the same grant.
- Grant card and client-name header wait until authorize-info is ready.
- Identity claim names stay on one line with a 1rem gap so they read as separate chips, not `profileemail`.

## Testing

- `ssr-render.node.test.ts` asserts the grant card and OIDC disclosure render, that **Requested scopes** is gone, and that a ready authorize page does not flash **Unknown client**.
- `test:node` + `test:workers` on push.
- Local authorize as `jane@example.com`: `profile` and `email` share a y-coordinate with a 16px column gap.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `298c2803` · **Head:** `a1a4a57e`

**Classification:** extends — `/oauth/authorize` consent copy and layout change on `app-ui`. MCP OAuth protocol and token enforcement are unchanged.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `app-ui` | surfaces | extends — authorize page describes the real grant instead of listing OIDC scopes as a permission menu |

Unmatched paths: `mcp-oauth-scopes.ts` (comment only), authentication / Get started docs, and ADR 0049. Those document existing `mcp-oauth` behavior; they do not change token issuance or `/mcp` gates.

### Change flow

An MCP host still requests OIDC scopes. The authorize page now presents full assistant access as the grant, and keeps those scope names in a disclosure.

```mermaid
sequenceDiagram
	actor User
	participant host as MCP host
	participant mcpOauth as mcp-oauth
	participant appUi as app-ui
	User->>host: connect Kody
	host->>mcpOauth: GET /oauth/authorize with OIDC scopes
	mcpOauth->>appUi: authorize-info client and scopes
	Note over appUi: grant card is full assistant access
	appUi->>User: OIDC names in identity-claims disclosure
	User->>appUi: Approve connection
	appUi->>mcpOauth: completeAuthorization
	mcpOauth-->>host: token still one MCP grant
```

### Invariants

Per-user isolation is unchanged. Connecting an agent is still one credential for that user's assistant, not a capability allowlist.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ebba177b-eaab-4f81-99fc-4f0386b965ba?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ebba177b-eaab-4f81-99fc-4f0386b965ba&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the OAuth approval experience to show that connected agents receive full account access.
  * Identity-related scopes are displayed as informational details rather than permission selections.
* **Documentation**
  * Clarified OAuth and MCP access behavior, authentication requirements, and scope semantics.
  * Added a decision record documenting the single-grant MCP access model.
* **Tests**
  * Added coverage confirming the updated OAuth approval page content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->