### PR TITLE
Fix origin Vite production deploy (CLOUDFLARE_ENV, kody-production, slim migrations)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -637,6 +637,7 @@ jobs:
         if: steps.resources.outputs.origin_deploy_mode == 'fresh'
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ENV: production
           DEPLOY_COMMIT_SHA: ${{ needs.sha-guard.outputs.deploy_sha }}
           WRANGLER_CONFIG:
             ${{ steps.resources.outputs.origin_bootstrap_wrangler_config }}
@@ -656,7 +657,7 @@ jobs:
           for attempt in $(seq 1 "$deploy_attempts"); do
             echo "Origin bootstrap deploy attempt $attempt/$deploy_attempts"
             set +e
-            npm run deploy -- --config "$WRANGLER_CONFIG" --var "APP_COMMIT_SHA:${DEPLOY_COMMIT_SHA}" 2>&1 | tee deploy-origin-bootstrap.log
+            npm run deploy -- --name kody-production --config "$WRANGLER_CONFIG" --var "APP_COMMIT_SHA:${DEPLOY_COMMIT_SHA}" 2>&1 | tee deploy-origin-bootstrap.log
             deploy_status="${PIPESTATUS[0]}"
             set -e
 
@@ -812,13 +813,19 @@ jobs:
           steps.resources.outputs.origin_deploy_mode == 'fresh'
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ENV: production
           APP_BASE_URL: ${{ vars.APP_BASE_URL }}
           DEPLOY_COMMIT_SHA: ${{ needs.sha-guard.outputs.deploy_sha }}
           APP_DEPLOY_INFO: ${{ steps.deploy_info.outputs.app_deploy_info }}
           WRANGLER_CONFIG: ${{ steps.resources.outputs.wrangler_config }}
         run: |
           set -euo pipefail
-          DEPLOY_ARGS=(--config "$WRANGLER_CONFIG" --var "APP_COMMIT_SHA:${DEPLOY_COMMIT_SHA}" --var "APP_DEPLOY_INFO:${APP_DEPLOY_INFO}")
+          # Explicit --name: Vite emits a flattened wrangler.json whose
+          # `name` is still top-level `kody`. Without this (and without
+          # wrangler-env.ts adding --env production) Wrangler uploads a
+          # new `kody` script and replays origin Durable Object migrations
+          # the slim entry does not export.
+          DEPLOY_ARGS=(--name kody-production --config "$WRANGLER_CONFIG" --var "APP_COMMIT_SHA:${DEPLOY_COMMIT_SHA}" --var "APP_DEPLOY_INFO:${APP_DEPLOY_INFO}")
 
           is_retryable_deploy_failure() {
             node tools/ci/is-retryable-deploy-failure.ts deploy.log

--- a/tools/ci/origin-production-deploy-state.node.test.ts
+++ b/tools/ci/origin-production-deploy-state.node.test.ts
@@ -243,7 +243,9 @@ test('stripOriginDurableObjectMigrations removes top-level and env migrations on
 			},
 		},
 	}
-	expect(stripOriginDurableObjectMigrations(config, 'preview')).toEqual({
+	expect(
+		stripOriginDurableObjectMigrations(structuredClone(config), 'preview'),
+	).toEqual({
 		main: './src/production-worker.ts',
 		durable_objects: { bindings: [] },
 		env: {
@@ -251,6 +253,19 @@ test('stripOriginDurableObjectMigrations removes top-level and env migrations on
 			production: {
 				migrations: [{ tag: 'v1', new_sqlite_classes: ['MCP'] }],
 			},
+		},
+	})
+	expect(
+		stripOriginDurableObjectMigrations(structuredClone(config), 'production'),
+	).toEqual({
+		main: './src/production-worker.ts',
+		durable_objects: { bindings: [] },
+		env: {
+			preview: {
+				migrations: [{ tag: 'v1', new_sqlite_classes: ['MCP'] }],
+				vars: { APP_ENV: 'preview' },
+			},
+			production: {},
 		},
 	})
 })

--- a/tools/ci/origin-production-deploy-state.ts
+++ b/tools/ci/origin-production-deploy-state.ts
@@ -576,14 +576,20 @@ export function stripOriginBindingsForLocallyOwnedClasses(
 }
 
 /**
- * Preview origin scripts never own a Durable Object class: platform and
+ * Slim origin scripts never own a Durable Object class: platform and
  * runtime create every class themselves (`new_sqlite_classes` in their
- * preview envs), so the origin's committed migration history must not
- * replay on the preview script. A fresh script would otherwise create
- * namespaces for classes the slim entry does not export (Cloudflare rejects
- * the upload), and a legacy full-entry preview would keep re-owning them.
- * Wrangler uploads no migration steps when the config declares none, which
- * leaves any already-created namespaces on a legacy script untouched.
+ * own envs), so the origin's committed migration history must not
+ * replay on the slim upload. A fresh script — or a Vite-flattened
+ * `dist/ssr/wrangler.json` that Wrangler treats as first apply — would
+ * otherwise create namespaces for classes the slim entry does not export
+ * (Cloudflare rejects the upload with 10070), and a legacy full-entry
+ * script would keep re-owning them. Wrangler uploads no migration steps
+ * when the config declares none, which leaves any already-created
+ * namespaces on a legacy script untouched.
+ *
+ * Preview always strips. Steady-state and fresh production slim uploads
+ * strip too; the full-entry bootstrap config keeps the history so
+ * `new_sqlite_classes` can create classes before transfer.
  */
 export function stripOriginDurableObjectMigrations(
 	config: Record<string, unknown>,

--- a/tools/ci/production-resources.ts
+++ b/tools/ci/production-resources.ts
@@ -23,6 +23,7 @@ import {
 	originBootstrapConfigPath,
 	planOriginProductionDeploy,
 	stripOriginBindingsForLocallyOwnedClasses,
+	stripOriginDurableObjectMigrations,
 	writeOriginBootstrapWranglerConfig,
 	type OriginProductionScriptState,
 } from './origin-production-deploy-state.ts'
@@ -791,6 +792,21 @@ async function ensureProductionResources(options: CliOptions) {
 			generatedConfig,
 			deployState.originOwnedTransferredClassNames,
 		)
+		await writeFile(
+			generatedConfigPath,
+			`${JSON.stringify(generatedConfig, null, '\t')}\n`,
+			'utf8',
+		)
+	}
+
+	// After the full-entry bootstrap clone is written. Fresh production
+	// still needs historical `new_sqlite_classes` on that bootstrap file;
+	// the slim upload that follows must not replay them.
+	if (deployPlan.originEntry === 'slim') {
+		const generatedConfig = parseJsonc<Record<string, unknown>>(
+			await readFile(generatedConfigPath, 'utf8'),
+		)
+		stripOriginDurableObjectMigrations(generatedConfig, 'production')
 		await writeFile(
 			generatedConfigPath,
 			`${JSON.stringify(generatedConfig, null, '\t')}\n`,

--- a/tools/deploy.node.test.ts
+++ b/tools/deploy.node.test.ts
@@ -1,5 +1,13 @@
 import { expect, test } from 'vitest'
-import { originViteDeployArgs, originViteWranglerConfigPath } from './deploy.ts'
+import { productionOriginScriptName } from './ci/origin-production-deploy-state.ts'
+import {
+	finalizeOriginViteWranglerConfig,
+	inferOriginDeployCloudflareEnv,
+	inferOriginDeployWorkerName,
+	isSlimOriginEntry,
+	originViteDeployArgs,
+	originViteWranglerConfigPath,
+} from './deploy.ts'
 
 test('origin Vite deploy always points Wrangler at the generated SSR config', () => {
 	expect(originViteWranglerConfigPath).toBe('dist/ssr/wrangler.json')
@@ -17,4 +25,122 @@ test('origin Vite deploy always points Wrangler at the generated SSR config', ()
 		'--var',
 		'APP_COMMIT_SHA:abc',
 	])
+})
+
+test('origin Vite deploy pins the production script name when callers omit --name', () => {
+	expect(
+		originViteDeployArgs(
+			[
+				'--config',
+				'packages/worker/wrangler-production.generated.json',
+				'--var',
+				'APP_COMMIT_SHA:abc',
+			],
+			productionOriginScriptName,
+		),
+	).toEqual([
+		'deploy',
+		'--config',
+		'dist/ssr/wrangler.json',
+		'--var',
+		'APP_COMMIT_SHA:abc',
+		'--name',
+		'kody-production',
+	])
+})
+
+test('origin Vite deploy keeps an explicit --name (preview per-PR workers)', () => {
+	expect(
+		originViteDeployArgs(
+			[
+				'--name',
+				'kody-pr-2055',
+				'--config',
+				'packages/worker/wrangler-preview.generated.json',
+			],
+			'kody-production',
+		),
+	).toEqual([
+		'deploy',
+		'--config',
+		'dist/ssr/wrangler.json',
+		'--name',
+		'kody-pr-2055',
+	])
+})
+
+test('infers CLOUDFLARE_ENV from generated origin config names', () => {
+	expect(
+		inferOriginDeployCloudflareEnv(
+			'packages/worker/wrangler-production.generated.json',
+		),
+	).toBe('production')
+	expect(
+		inferOriginDeployCloudflareEnv(
+			'packages/worker/wrangler-production-bootstrap.generated.json',
+		),
+	).toBe('production')
+	expect(
+		inferOriginDeployCloudflareEnv(
+			'packages/worker/wrangler-preview.generated.json',
+		),
+	).toBe('preview')
+	expect(
+		inferOriginDeployCloudflareEnv('packages/worker/wrangler.jsonc'),
+	).toBeUndefined()
+})
+
+test('infers the production origin script name and preserves explicit names', () => {
+	expect(inferOriginDeployWorkerName({ cloudflareEnv: 'production' })).toBe(
+		'kody-production',
+	)
+	expect(
+		inferOriginDeployWorkerName({
+			cloudflareEnv: 'production',
+			existingName: 'kody-pr-9',
+		}),
+	).toBe('kody-pr-9')
+	expect(
+		inferOriginDeployWorkerName({ cloudflareEnv: 'preview' }),
+	).toBeUndefined()
+})
+
+test('detects the slim origin entry used for Vite production/preview uploads', () => {
+	expect(isSlimOriginEntry('./src/production-worker.ts')).toBe(true)
+	expect(isSlimOriginEntry('src\\production-worker.ts')).toBe(true)
+	expect(isSlimOriginEntry('./src/index.ts')).toBe(false)
+	expect(isSlimOriginEntry(undefined)).toBe(false)
+})
+
+test('finalizeOriginViteWranglerConfig strips slim-entry Durable Object migrations', () => {
+	const config: Record<string, unknown> = {
+		name: 'kody',
+		migrations: [{ tag: 'v1', new_sqlite_classes: ['MCP'] }],
+		env: {
+			production: {
+				migrations: [{ tag: 'v1', new_sqlite_classes: ['MCP'] }],
+			},
+		},
+	}
+	expect(
+		finalizeOriginViteWranglerConfig(config, {
+			stripMigrations: true,
+			envName: 'production',
+		}),
+	).toEqual({
+		name: 'kody',
+		env: { production: {} },
+	})
+	expect(
+		finalizeOriginViteWranglerConfig(
+			{
+				name: 'kody',
+				migrations: [{ tag: 'v1', new_sqlite_classes: ['MCP'] }],
+			},
+			{ stripMigrations: false, envName: 'production' },
+		),
+	).toEqual({
+		name: 'kody',
+		migrations: [{ tag: 'v1', new_sqlite_classes: ['MCP'] }],
+	})
 })

--- a/tools/deploy.ts
+++ b/tools/deploy.ts
@@ -1,11 +1,17 @@
 import { spawnSync } from 'node:child_process'
-import { existsSync } from 'node:fs'
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import path from 'node:path'
+import {
+	productionOriginScriptName,
+	stripOriginDurableObjectMigrations,
+} from './ci/origin-production-deploy-state.ts'
+import { parseJsonc } from './ci/resource-utils.ts'
 import { isExecutedDirectly, resolveLocalBinary } from './node-runtime.ts'
 import {
 	isOriginWorkerConfigPath,
 	omitConfigFlag,
 	readConfigFlag,
+	readNameFlag,
 } from './origin-worker-config.ts'
 
 function run(
@@ -35,13 +41,52 @@ function resolveWranglerCommand() {
 
 export const originViteWranglerConfigPath = 'dist/ssr/wrangler.json'
 
-export function originViteDeployArgs(args: ReadonlyArray<string>) {
-	return [
+export function inferOriginDeployCloudflareEnv(configPath: string | undefined) {
+	const fileName =
+		(configPath ?? '').replaceAll('\\', '/').split('/').pop() ?? ''
+	if (fileName.includes('preview')) return 'preview'
+	if (fileName.includes('production')) return 'production'
+	return undefined
+}
+
+export function inferOriginDeployWorkerName(input: {
+	cloudflareEnv: string | undefined
+	existingName?: string
+}) {
+	if (input.existingName) return input.existingName
+	if (input.cloudflareEnv === 'production') return productionOriginScriptName
+	return undefined
+}
+
+export function isSlimOriginEntry(main: unknown) {
+	if (typeof main !== 'string') return false
+	return main.replaceAll('\\', '/').endsWith('production-worker.ts')
+}
+
+export function finalizeOriginViteWranglerConfig(
+	config: Record<string, unknown>,
+	input: { stripMigrations: boolean; envName: string },
+) {
+	if (input.stripMigrations) {
+		stripOriginDurableObjectMigrations(config, input.envName)
+	}
+	return config
+}
+
+export function originViteDeployArgs(
+	args: ReadonlyArray<string>,
+	workerName?: string,
+) {
+	const next = [
 		'deploy',
 		'--config',
 		originViteWranglerConfigPath,
 		...omitConfigFlag(args),
 	]
+	if (workerName && !readNameFlag(args)) {
+		next.push('--name', workerName)
+	}
+	return next
 }
 
 export async function deploy(args: ReadonlyArray<string>) {
@@ -52,9 +97,20 @@ export async function deploy(args: ReadonlyArray<string>) {
 	}
 
 	const wranglerConfigPath = configPath ?? 'packages/worker/wrangler.jsonc'
+	const cloudflareEnv =
+		process.env.CLOUDFLARE_ENV ??
+		inferOriginDeployCloudflareEnv(wranglerConfigPath)
+	const inputConfig = parseJsonc<Record<string, unknown>>(
+		readFileSync(wranglerConfigPath, 'utf8'),
+	)
+	const workerName = inferOriginDeployWorkerName({
+		cloudflareEnv,
+		existingName: readNameFlag(args),
+	})
 	run(resolveLocalBinary('vite'), ['build'], {
 		...process.env,
 		KODY_WRANGLER_CONFIG: wranglerConfigPath,
+		...(cloudflareEnv ? { CLOUDFLARE_ENV: cloudflareEnv } : {}),
 	})
 	if (!existsSync(originViteWranglerConfigPath)) {
 		console.error(
@@ -62,7 +118,21 @@ export async function deploy(args: ReadonlyArray<string>) {
 		)
 		process.exit(1)
 	}
-	run(resolveWranglerCommand(), originViteDeployArgs(args), process.env)
+	const emittedConfig = parseJsonc<Record<string, unknown>>(
+		readFileSync(originViteWranglerConfigPath, 'utf8'),
+	)
+	finalizeOriginViteWranglerConfig(emittedConfig, {
+		stripMigrations: isSlimOriginEntry(inputConfig.main),
+		envName: cloudflareEnv ?? 'production',
+	})
+	writeFileSync(
+		originViteWranglerConfigPath,
+		`${JSON.stringify(emittedConfig, null, '\t')}\n`,
+	)
+	run(resolveWranglerCommand(), originViteDeployArgs(args, workerName), {
+		...process.env,
+		...(cloudflareEnv ? { CLOUDFLARE_ENV: cloudflareEnv } : {}),
+	})
 }
 
 if (isExecutedDirectly(import.meta.url)) {

--- a/tools/origin-worker-config.node.test.ts
+++ b/tools/origin-worker-config.node.test.ts
@@ -2,7 +2,9 @@ import { expect, test } from 'vitest'
 import {
 	isOriginWorkerConfigPath,
 	omitConfigFlag,
+	omitNameFlag,
 	readConfigFlag,
+	readNameFlag,
 } from './origin-worker-config.ts'
 
 test('treats the committed worker config and generated origin configs as origin', () => {
@@ -63,4 +65,14 @@ test('reads and strips --config flags', () => {
 			'--upload-source-maps',
 		]),
 	).toEqual(['--upload-source-maps'])
+})
+
+test('reads and strips --name flags', () => {
+	expect(
+		readNameFlag(['--name', 'kody-production', '--var', 'APP_COMMIT_SHA:abc']),
+	).toBe('kody-production')
+	expect(readNameFlag(['--name=kody-pr-2055'])).toBe('kody-pr-2055')
+	expect(
+		omitNameFlag(['--name', 'kody-production', '--var', 'APP_COMMIT_SHA:abc']),
+	).toEqual(['--var', 'APP_COMMIT_SHA:abc'])
 })

--- a/tools/origin-worker-config.ts
+++ b/tools/origin-worker-config.ts
@@ -14,30 +14,52 @@ export function isOriginWorkerConfigPath(configPath: string | undefined) {
 	)
 }
 
-export function omitConfigFlag(args: ReadonlyArray<string>) {
+function omitNamedFlag(
+	args: ReadonlyArray<string>,
+	flag: '--config' | '--name',
+) {
 	const next: Array<string> = []
 	for (let index = 0; index < args.length; index += 1) {
 		const arg = args[index]
-		if (arg === '--config') {
+		if (arg === flag) {
 			index += 1
 			continue
 		}
-		if (arg.startsWith('--config=')) continue
+		if (arg.startsWith(`${flag}=`)) continue
 		next.push(arg)
 	}
 	return next
 }
 
-export function readConfigFlag(args: ReadonlyArray<string>) {
-	const inline = args.find((arg) => arg.startsWith('--config='))
+function readNamedFlag(
+	args: ReadonlyArray<string>,
+	flag: '--config' | '--name',
+) {
+	const inline = args.find((arg) => arg.startsWith(`${flag}=`))
 	if (inline) {
-		const value = inline.slice('--config='.length)
+		const value = inline.slice(`${flag}=`.length)
 		return value || undefined
 	}
-	const flagIndex = args.findIndex((arg) => arg === '--config')
+	const flagIndex = args.findIndex((arg) => arg === flag)
 	if (flagIndex >= 0) {
 		const value = args[flagIndex + 1]
 		return value || undefined
 	}
 	return undefined
+}
+
+export function omitConfigFlag(args: ReadonlyArray<string>) {
+	return omitNamedFlag(args, '--config')
+}
+
+export function readConfigFlag(args: ReadonlyArray<string>) {
+	return readNamedFlag(args, '--config')
+}
+
+export function omitNameFlag(args: ReadonlyArray<string>) {
+	return omitNamedFlag(args, '--name')
+}
+
+export function readNameFlag(args: ReadonlyArray<string>) {
+	return readNamedFlag(args, '--name')
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Unblock production after #2055: the origin Vite deploy path must upload `kody-production` with the production env bindings and must not replay historical Durable Object migrations on the slim entry.

## Why

#2055 Validate on `main` succeeded, then `🚀 Deploy to production` failed:

```
Cannot apply new-class migration to class 'MCP' that is not exported by script. [code: 10070]
```

Failed run: https://github.com/kentcdodds/kody/actions/runs/33919074027

The Pitlane Vite origin path builds `dist/ssr/wrangler.json` and deploys that file instead of going through `wrangler-env.ts`. Preview already sets `CLOUDFLARE_ENV=preview` and `--name kody-pr-<n>`, and `preview-resources.ts` strips origin DO migrations. Production did neither.

Without `CLOUDFLARE_ENV=production`, `@cloudflare/vite-plugin` resolved the **top-level** Wrangler config (name `kody`, historical `new_sqlite_classes: ["MCP"]`, almost no production bindings). Wrangler then uploaded that stub as a new `kody` script. The slim `production-worker.ts` entry does not export `MCP`, so Cloudflare rejected the migration.

Production is still on the pre-#2055 SHA (`66dbdc6b`). This is the unblocker for `/ship-pr deploy` on #2055.

## Summary

- Set `CLOUDFLARE_ENV=production` and `--name kody-production` on origin bootstrap and origin upload in `deploy.yml`.
- `tools/deploy.ts` infers that env from the generated config path, passes it to Vite and Wrangler, pins `--name kody-production` when callers omit it, and strips slim-entry DO migrations from the emitted `dist/ssr/wrangler.json`.
- `production-resources.ts` strips origin DO migrations from the slim generated config **after** writing the full-entry bootstrap clone (fresh production still needs `new_sqlite_classes` on the bootstrap file).
- Preview `--name` is preserved.

## Testing

- `npx vitest run tools/deploy.node.test.ts tools/origin-worker-config.node.test.ts tools/ci/origin-production-deploy-state.node.test.ts` — 35 passed
- Pre-push hook: `test:node` 2562 passed, `test:workers` 327 passed
- Production evidence after merge: `npm run control-kody -- health --origin https://kody.codes --sha <merge>` must match this SHA (or a descendant). Until then, do not treat #2055 as shipped.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `1f70d70f` · **Head:** `74cd3238`

**Classification:** composes — deploy-path wiring only. `production-resources.ts` is owned by `email-delivery-queue` in the taxonomy, but this PR does not change queue provisioning.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `email-delivery-queue` | storage | composes — file overlap in `production-resources.ts`; slim-origin migration strip only |

Unmatched but central: `.github/workflows/deploy.yml`, `tools/deploy.ts`, `tools/ci/origin-production-deploy-state.ts`.

### Change flow

Production origin Vite deploy now selects the production env, uploads `kody-production`, and omits slim-entry Durable Object migrations.

```mermaid
sequenceDiagram
	actor gha as GitHub Actions
	participant emailDeliveryQueue as email-delivery-queue
	participant vitePlugin as Vite Cloudflare plugin
	participant wrangler as Wrangler
	gha->>emailDeliveryQueue: ensure production resources
	emailDeliveryQueue-->>gha: slim generated config without origin DO migrations
	gha->>vitePlugin: vite build with CLOUDFLARE_ENV=production
	vitePlugin-->>gha: dist/ssr/wrangler.json from env.production
	gha->>wrangler: deploy --name kody-production --config dist/ssr/wrangler.json
	Note over wrangler: no new_sqlite_classes MCP on slim entry
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3b12fbbe-e3d1-42f7-a46d-6055986a8044?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3b12fbbe-e3d1-42f7-a46d-6055986a8044&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Deployment Improvements**
  * Production deployments now explicitly target the `kody-production` worker and Cloudflare production environment.
  * Deployment configuration automatically preserves explicitly selected worker names for preview deployments.
  * Production origin deployments now apply the appropriate migration handling for slim versus full bootstrap uploads.
  * Deployment tooling more reliably detects environment and worker targets from configuration, reducing the risk of deploying to an unintended worker.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->