### PR TITLE
Match slim origin entry by exact basename

### DIFF
--- a/tools/deploy.node.test.ts
+++ b/tools/deploy.node.test.ts
@@ -108,6 +108,7 @@ test('infers the production origin script name and preserves explicit names', ()
 test('detects the slim origin entry used for Vite production/preview uploads', () => {
 	expect(isSlimOriginEntry('./src/production-worker.ts')).toBe(true)
 	expect(isSlimOriginEntry('src\\production-worker.ts')).toBe(true)
+	expect(isSlimOriginEntry('./src/not-production-worker.ts')).toBe(false)
 	expect(isSlimOriginEntry('./src/index.ts')).toBe(false)
 	expect(isSlimOriginEntry(undefined)).toBe(false)
 })

--- a/tools/deploy.ts
+++ b/tools/deploy.ts
@@ -60,7 +60,7 @@ export function inferOriginDeployWorkerName(input: {
 
 export function isSlimOriginEntry(main: unknown) {
 	if (typeof main !== 'string') return false
-	return main.replaceAll('\\', '/').endsWith('production-worker.ts')
+	return main.replaceAll('\\', '/').split('/').pop() === 'production-worker.ts'
 }
 
 export function finalizeOriginViteWranglerConfig(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Keep origin Vite production deploys from treating a non-slim worker entry as `production-worker.ts`.

## Why

CodeRabbit on #2057 flagged `isSlimOriginEntry`: `endsWith('production-worker.ts')` also matches `./src/not-production-worker.ts`. That would strip Durable Object migrations from a non-slim upload.

#2057 auto-merged before the basename fix landed, so this is the leftover.

## Summary

- Compare the normalized basename to `production-worker.ts` exactly.
- Add a regression assertion for `./src/not-production-worker.ts`.

## Testing

- Focused: `npx vitest run tools/deploy.node.test.ts` — 7 passed
- Local `npm run validate` — exit 0
- Bugbot triggered as kent on this PR

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `dd52399f` · **Head:** `429b2f70`

**Classification:** composes — deploy-helper filename check only; no primitive contract change.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `platform-worker` | surfaces | composes — still the reason slim origin uploads strip DO migrations |

Unmatched path: `tools/deploy.ts` (origin Vite deploy helper; not a map root).

### Change flow

Slim-entry detection now uses an exact basename so only `production-worker.ts` strips origin DO migrations.

```mermaid
sequenceDiagram
	actor ci as CI deploy
	participant deployHelper as tools/deploy.ts
	participant wranglerJson as dist/ssr/wrangler.json
	ci->>deployHelper: read emitted main
	alt basename is production-worker.ts
		deployHelper->>wranglerJson: strip origin DO migrations
	else other entry basename
		deployHelper->>wranglerJson: keep migrations
	end
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3b12fbbe-e3d1-42f7-a46d-6055986a8044?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3b12fbbe-e3d1-42f7-a46d-6055986a8044&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection of the production worker entry to avoid incorrectly matching similarly named files in other directories.

- **Tests**
  - Added coverage confirming that non-production worker entries are not identified as the production worker.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->