### PR TITLE
Fix Vite HMR taking down the origin: idempotent frame registry, no truncated SSR documents, whole-graph worker reload

### DIFF
--- a/docs/contributing/architecture/request-lifecycle.md
+++ b/docs/contributing/architecture/request-lifecycle.md
@@ -180,13 +180,19 @@ whose `Accept` prefers `text/markdown` (`prefersMarkdown`) skip the store. A
 matching HTML request with no `kody_session` cookie and no `Authorization`
 header is served from that store (`X-Kody-Cache: HIT`) without running the app
 handler. A miss runs the handler and, when the response is `200` `text/html`
-with no `Set-Cookie` and already carries that Cache-Control,
-`ctx.waitUntil(caches.default.put)` stores a clone. The stored copy drops
-`Vary: Cookie` because Cloudflare's Cache API does not use `Vary` as a key (the
-lookup already excludes cookie-bearing requests). Hits restore the
-browser-facing `Vary` from the miss (`Cookie`, plus `Accept` on negotiated
-routes). Browser-facing `Cache-Control` is unchanged. `Cache-Control: no-cache`
-on the request skips the lookup so e2e can assert fresh HTML.
+with no `Set-Cookie` and already carries that Cache-Control, `ctx.waitUntil`
+buffers a clone and stores it only once the body has reached `</html>`
+(`isCompleteHtmlDocument`); a streamed document that stopped early (render
+failure, client abort) is never shared. The stored copy drops `Vary: Cookie`
+because Cloudflare's Cache API does not use `Vary` as a key (the lookup already
+excludes cookie-bearing requests). Hits restore the browser-facing `Vary` from
+the miss (`Cookie`, plus `Accept` on negotiated routes). Browser-facing
+`Cache-Control` is unchanged. `Cache-Control: no-cache` on the request skips the
+lookup so e2e can assert fresh HTML. Under `WRANGLER_IS_LOCAL_DEV=true`
+(`npm run dev`, the Playwright web server) the store is bypassed entirely:
+workerd honors `stale-while-revalidate` and persists `caches.default` under
+`.wrangler/state`, so a stored page would keep replaying for minutes after the
+edit that changed it. The `workers-unit` suite still exercises the store.
 
 The public package surfaces (`/@:username/:kodyId`,
 `/@:username/:kodyId/tree/:ref/*`, `/community/:id`, `/community/:id/files/*`)

--- a/docs/contributing/setup/local-development.md
+++ b/docs/contributing/setup/local-development.md
@@ -83,6 +83,8 @@ Prerequisites, install, and `npm run dev` notes. See the
   chain and splits Remix component identities across evaluations. Pure server
   chains (handlers, data loaders) keep the incremental update, so module-level
   registration side effects on that path must be idempotent. See
-  `tools/vite-worker-whole-graph-reload.ts`.
+  `tools/vite-worker-whole-graph-reload.ts`. The anonymous marketing HTML cache
+  (`caches.default`) is bypassed under `WRANGLER_IS_LOCAL_DEV`, so an anonymous
+  tab sees the edit on the next reload instead of a stored page.
 - Set `CLOUDFLARE_ENV` to switch Wrangler environments (defaults to
   `production`). Playwright sets this to `test`.

--- a/docs/contributing/setup/local-development.md
+++ b/docs/contributing/setup/local-development.md
@@ -75,5 +75,14 @@ Prerequisites, install, and `npm run dev` notes. See the
   [`mock-api-servers.md`](../mock-api-servers.md).
 - `npm run dev:client`, `npm run dev:vite`, and `npm run dev:worker` all start
   the same Vite origin (client + worker in one workerd graph).
+- Worker-side HMR: the browser graph hot-swaps components as usual. In the
+  Worker environments, an edit that touches a component module (or a module a
+  component module imports) reloads the whole worker graph
+  (`page reload … (whole worker graph)` in the log; requests in flight wait for
+  it), because Vite's incremental SSR update re-evaluates only the importer
+  chain and splits Remix component identities across evaluations. Pure server
+  chains (handlers, data loaders) keep the incremental update, so module-level
+  registration side effects on that path must be idempotent. See
+  `tools/vite-worker-whole-graph-reload.ts`.
 - Set `CLOUDFLARE_ENV` to switch Wrangler environments (defaults to
   `production`). Playwright sets this to `test`.

--- a/packages/worker/src/app/anonymous-html-cache.node.test.ts
+++ b/packages/worker/src/app/anonymous-html-cache.node.test.ts
@@ -46,6 +46,18 @@ test('anonymous marketing HTML is cacheable only without a session', () => {
 		vary: 'Cookie',
 	})
 
+	// Local dev: a browser-cached document would be what Vite's post-HMR page
+	// reload shows instead of the edit.
+	expect(
+		resolveAppPageCacheControl({
+			pathname: '/',
+			session: null,
+			request: request('https://example.com/'),
+			responseSetsCookie: false,
+			localDev: true,
+		}),
+	).toEqual({ cacheControl: 'no-store' })
+
 	expect(
 		resolveAppPageCacheControl({
 			pathname: '/pricing',

--- a/packages/worker/src/app/anonymous-html-cache.ts
+++ b/packages/worker/src/app/anonymous-html-cache.ts
@@ -74,7 +74,16 @@ export function resolveAppPageCacheControl(input: {
 	responseSetsCookie: boolean
 	/** Only successful documents are shared; a 404 or 401 must not outlive its cause. */
 	status?: number
+	/**
+	 * `npm run dev`: the browser serves Vite's post-HMR `location.reload()` from
+	 * its HTTP cache when the document is `public, max-age=60`, so an edit
+	 * never shows. Nothing shares anonymous HTML locally anyway.
+	 */
+	localDev?: boolean
 }): { cacheControl: string; vary?: string } {
+	if (input.localDev) {
+		return { cacheControl: 'no-store' }
+	}
 	if (input.session !== null) {
 		return { cacheControl: 'no-store' }
 	}

--- a/packages/worker/src/app/anonymous-html-edge-cache.node.test.ts
+++ b/packages/worker/src/app/anonymous-html-edge-cache.node.test.ts
@@ -6,9 +6,11 @@ import {
 import {
 	anonymousHtmlCacheAcceptHtml,
 	anonymousHtmlCacheAcceptParam,
+	buildAnonymousHtmlCacheEntry,
 	buildAnonymousHtmlCacheKey,
 	isAnonymousHtmlCacheRequest,
 	isAnonymousHtmlCacheStoreable,
+	isCompleteHtmlDocument,
 } from '#app/anonymous-html-edge-cache.ts'
 
 function htmlResponse(input: {
@@ -162,4 +164,36 @@ test('anonymous HTML Cache API stores only cookie-less 200 HTML with the shared 
 	expect(
 		isAnonymousHtmlCacheStoreable(htmlResponse({ cacheControl: 'no-store' })),
 	).toBe(false)
+})
+
+test('only a document that reached </html> counts as complete', () => {
+	// An SSR stream that failed after committing the doctype ends cleanly at
+	// 15 bytes; it must never be stored as the shared anonymous document.
+	expect(isCompleteHtmlDocument('<!DOCTYPE html>')).toBe(false)
+	expect(isCompleteHtmlDocument('')).toBe(false)
+	expect(isCompleteHtmlDocument('<!DOCTYPE html><html><body>')).toBe(false)
+	expect(
+		isCompleteHtmlDocument(
+			'<!DOCTYPE html><html><body></body></html><!-- rmx:flush document -->',
+		),
+	).toBe(true)
+	expect(isCompleteHtmlDocument('<html></HTML >')).toBe(true)
+})
+
+test('the stored entry keeps the buffered body and moves Vary aside', async () => {
+	const response = new Response('streamed', {
+		status: 200,
+		headers: {
+			'Content-Type': 'text/html; charset=utf-8',
+			'Cache-Control': anonymousHtmlCacheControl,
+			Vary: 'Cookie, Accept',
+			'X-Kody-Cache': 'MISS',
+		},
+	})
+	const entry = buildAnonymousHtmlCacheEntry(response, '<html></html>')
+	await expect(entry.text()).resolves.toBe('<html></html>')
+	expect(entry.headers.get('X-Kody-Cache')).toBeNull()
+	expect(entry.headers.get('X-Kody-Browser-Vary')).toBe('Cookie, Accept')
+	expect(entry.headers.get('Vary')).toBe('Accept')
+	expect(entry.headers.get('Cache-Control')).toBe(anonymousHtmlCacheControl)
 })

--- a/packages/worker/src/app/anonymous-html-edge-cache.node.test.ts
+++ b/packages/worker/src/app/anonymous-html-edge-cache.node.test.ts
@@ -124,6 +124,13 @@ test('anonymous HTML Cache API stores only cookie-less 200 HTML with the shared 
 	expect(
 		isAnonymousHtmlCacheRequest(new Request('http://localhost:3742/'), {}),
 	).toBe(true)
+	// `npm run dev` and the Playwright web server: a stored page would hide
+	// the next edit from an anonymous tab for the stale-while-revalidate window.
+	expect(
+		isAnonymousHtmlCacheRequest(new Request('http://localhost:3742/'), {
+			WRANGLER_IS_LOCAL_DEV: 'true',
+		}),
+	).toBe(false)
 
 	const htmlKey = buildAnonymousHtmlCacheKey(
 		new Request('https://preview.example.workers.dev/pricing?utm=1', {

--- a/packages/worker/src/app/anonymous-html-edge-cache.ts
+++ b/packages/worker/src/app/anonymous-html-edge-cache.ts
@@ -30,6 +30,11 @@ export function isAnonymousHtmlCacheRequest(
 	request: Request,
 	env: AnonymousHtmlCacheEnv,
 ) {
+	// Local dev persists caches.default under .wrangler/state and workerd
+	// honors stale-while-revalidate, so a stored document outlives the edit
+	// that changed it by minutes: the browser reload Vite triggers after an
+	// HMR update carries no `no-cache` and would replay the pre-edit page.
+	if (env.WRANGLER_IS_LOCAL_DEV === 'true') return false
 	if (request.method !== 'GET' && request.method !== 'HEAD') return false
 	if (request.headers.has('Authorization')) return false
 	if (requestHasSessionCookie(request)) return false

--- a/packages/worker/src/app/anonymous-html-edge-cache.ts
+++ b/packages/worker/src/app/anonymous-html-edge-cache.ts
@@ -88,7 +88,18 @@ function stripCookieVary(headers: Headers) {
 	else headers.set('Vary', parts.join(', '))
 }
 
-function cloneResponseForAnonymousHtmlCache(response: Response) {
+/**
+ * A streamed SSR document that fails part-way (render error, HMR mid-flight,
+ * client abort) can still end cleanly at whatever bytes were written. Only a
+ * body that reached the closing `</html>` is a document worth sharing; a
+ * shorter one served as a HIT is a blank page for every anonymous visitor
+ * until the entry expires.
+ */
+export function isCompleteHtmlDocument(html: string) {
+	return /<\/html\s*>/i.test(html)
+}
+
+export function buildAnonymousHtmlCacheEntry(response: Response, html: string) {
 	const headers = new Headers(response.headers)
 	headers.delete(anonymousHtmlEdgeCacheHeader)
 	const originalVary = headers.get('Vary')
@@ -96,11 +107,28 @@ function cloneResponseForAnonymousHtmlCache(response: Response) {
 		headers.set(browserVaryStorageHeader, originalVary)
 	}
 	stripCookieVary(headers)
-	return new Response(response.body, {
+	return new Response(html, {
 		status: response.status,
 		statusText: response.statusText,
 		headers,
 	})
+}
+
+async function storeCompleteAnonymousHtml(
+	cache: Cache,
+	cacheKey: Request,
+	response: Response,
+) {
+	// Buffer first: an errored or truncated body must never reach `put`.
+	const html = await response.text()
+	if (!isCompleteHtmlDocument(html)) {
+		console.warn('anonymous-html-cache-skip-incomplete', {
+			url: cacheKey.url,
+			bytes: html.length,
+		})
+		return
+	}
+	await cache.put(cacheKey, buildAnonymousHtmlCacheEntry(response, html))
 }
 
 function withAnonymousHtmlCacheLookup(
@@ -168,11 +196,12 @@ export async function serveAnonymousHtmlFromCache(
 		cache &&
 		isAnonymousHtmlCacheStoreable(withMiss)
 	) {
-		const stored = cloneResponseForAnonymousHtmlCache(withMiss.clone())
 		ctx.waitUntil(
-			cache.put(cacheKey, stored).catch((error: unknown) => {
-				console.debug('anonymous-html-cache-put-failed', error)
-			}),
+			storeCompleteAnonymousHtml(cache, cacheKey, withMiss.clone()).catch(
+				(error: unknown) => {
+					console.debug('anonymous-html-cache-put-failed', error)
+				},
+			),
 		)
 	}
 	return withMiss

--- a/packages/worker/src/app/anonymous-html-edge-cache.workers.test.ts
+++ b/packages/worker/src/app/anonymous-html-edge-cache.workers.test.ts
@@ -1,0 +1,109 @@
+import { createExecutionContext, waitOnExecutionContext } from 'cloudflare:test'
+import { expect, test } from 'vitest'
+import { anonymousHtmlCacheControl } from '#app/anonymous-html-cache.ts'
+import {
+	anonymousHtmlEdgeCacheHeader,
+	buildAnonymousHtmlCacheKey,
+	serveAnonymousHtmlFromCache,
+} from '#app/anonymous-html-edge-cache.ts'
+import { silenceExpectedConsoleWarns } from '#worker/test-support/console-spies.ts'
+
+const env = { APP_BASE_URL: 'https://test.kody.dev' }
+const encoder = new TextEncoder()
+const completeDocument =
+	'<!DOCTYPE html><html><body>ok</body></html><!-- rmx:flush document -->'
+
+function storeableHtml(body: BodyInit) {
+	return new Response(body, {
+		status: 200,
+		headers: {
+			'Content-Type': 'text/html; charset=utf-8',
+			'Cache-Control': anonymousHtmlCacheControl,
+			Vary: 'Cookie',
+		},
+	})
+}
+
+async function serve(request: Request, upstream: () => Response) {
+	const ctx = createExecutionContext()
+	const response = await serveAnonymousHtmlFromCache(request, env, ctx, () =>
+		Promise.resolve(upstream()),
+	)
+	const text = await response.text()
+	await waitOnExecutionContext(ctx)
+	return {
+		response,
+		text,
+		cached: await caches.default.match(
+			buildAnonymousHtmlCacheKey(request, env),
+		),
+	}
+}
+
+test('a complete anonymous document is stored and replayed', async () => {
+	const url = `https://test.kody.dev/pricing?complete=${crypto.randomUUID()}`
+	const miss = await serve(new Request(url), () =>
+		storeableHtml(completeDocument),
+	)
+	expect(miss.response.headers.get(anonymousHtmlEdgeCacheHeader)).toBe('MISS')
+	expect(miss.text).toBe(completeDocument)
+	await expect(miss.cached?.text()).resolves.toBe(completeDocument)
+
+	const hit = await serve(new Request(url), () => {
+		throw new Error('upstream must not run on a HIT')
+	})
+	expect(hit.response.headers.get(anonymousHtmlEdgeCacheHeader)).toBe('HIT')
+	expect(hit.text).toBe(completeDocument)
+})
+
+test('a 200 whose body stopped after the doctype is served once but never stored', async () => {
+	silenceExpectedConsoleWarns(['anonymous-html-cache-skip-incomplete'])
+	const url = `https://test.kody.dev/onboarding?truncated=${crypto.randomUUID()}`
+
+	// An SSR render aborted by a Vite HMR re-evaluation used to end here: a
+	// committed 200 with 15 bytes. Stored, it became a blank page for every
+	// later anonymous visit.
+	const truncated = await serve(new Request(url), () =>
+		storeableHtml('<!DOCTYPE html>'),
+	)
+	expect(truncated.response.status).toBe(200)
+	expect(truncated.text).toBe('<!DOCTYPE html>')
+	expect(truncated.cached).toBeUndefined()
+
+	const recovered = await serve(new Request(url), () =>
+		storeableHtml(completeDocument),
+	)
+	expect(recovered.response.headers.get(anonymousHtmlEdgeCacheHeader)).toBe(
+		'MISS',
+	)
+	expect(recovered.text).toBe(completeDocument)
+	await expect(recovered.cached?.text()).resolves.toBe(completeDocument)
+})
+
+test('a body that errors mid-stream is never stored', async () => {
+	const url = `https://test.kody.dev/pricing?errored=${crypto.randomUUID()}`
+	const ctx = createExecutionContext()
+	const response = await serveAnonymousHtmlFromCache(
+		new Request(url),
+		env,
+		ctx,
+		() =>
+			Promise.resolve(
+				storeableHtml(
+					new ReadableStream<Uint8Array>({
+						start(controller) {
+							controller.enqueue(encoder.encode('<!DOCTYPE html><html>'))
+							controller.error(new Error('render failed'))
+						},
+					}),
+				),
+			),
+	)
+	await expect(response.text()).rejects.toThrow('render failed')
+	await waitOnExecutionContext(ctx)
+	expect(
+		await caches.default.match(
+			buildAnonymousHtmlCacheKey(new Request(url), env),
+		),
+	).toBeUndefined()
+})

--- a/packages/worker/src/app/frame-registrations.node.test.ts
+++ b/packages/worker/src/app/frame-registrations.node.test.ts
@@ -1,0 +1,20 @@
+import { expect, test } from 'vitest'
+import { listRegisteredFrameNames } from '#app/frame-registry.ts'
+import '#app/frame-registrations.ts'
+import {
+	COMMUNITY_DETAIL_TARGET,
+	COMMUNITY_LISTINGS_TARGET,
+} from '#universal/community-frame-constants.ts'
+import { PROFILE_TARGET } from '#universal/profile-frame-constants.ts'
+
+/**
+ * `registerFrame` replaces on a repeated name so Vite HMR can re-run a frame
+ * module; that moves duplicate-name detection here. Every module imported by
+ * `frame-registrations.ts` must contribute its own distinct name, so the
+ * registered set is exactly one entry per frame module.
+ */
+test('each frame module registers a distinct frame name', () => {
+	expect(listRegisteredFrameNames().sort()).toEqual(
+		[COMMUNITY_LISTINGS_TARGET, COMMUNITY_DETAIL_TARGET, PROFILE_TARGET].sort(),
+	)
+})

--- a/packages/worker/src/app/frame-registry.node.test.ts
+++ b/packages/worker/src/app/frame-registry.node.test.ts
@@ -1,0 +1,42 @@
+import { expect, test } from 'vitest'
+import {
+	getRegisteredFrame,
+	registerFrame,
+	resolveRegisteredFrameHtml,
+} from '#app/frame-registry.ts'
+import { routes } from '#universal/routes.ts'
+
+const env = {} as Env
+const request = new Request('https://kody.local/pricing')
+
+test('re-registering a frame name replaces the renderer instead of throwing', async () => {
+	const name = `hmr-frame-${crypto.randomUUID()}`
+
+	// First evaluation of a `frames/*.ts` module.
+	registerFrame(name, {
+		routes: [routes.pricing],
+		render: () => '<p>first</p>',
+	})
+
+	// Vite HMR re-evaluates that module against the same, still-live registry
+	// map. That used to throw "Frame name already registered" from the worker
+	// entry import and take down every route until the dev server restarted.
+	expect(() =>
+		registerFrame(name, {
+			routes: [routes.pricing],
+			render: () => '<p>second</p>',
+		}),
+	).not.toThrow()
+
+	const frame = getRegisteredFrame(name)
+	expect(frame?.name).toBe(name)
+	await expect(
+		resolveRegisteredFrameHtml({
+			src: '/pricing',
+			target: name,
+			request,
+			env,
+			pageUrl: new URL(request.url),
+		}),
+	).resolves.toBe('<p>second</p>')
+})

--- a/packages/worker/src/app/frame-registry.ts
+++ b/packages/worker/src/app/frame-registry.ts
@@ -48,6 +48,18 @@ export function pathnameMatchesFrameRoute(
 	return routes.some((route) => getMatcherForRoute(route).match(url) !== null)
 }
 
+/**
+ * Registers (or re-registers) a frame renderer under `name`.
+ *
+ * Re-registration must replace, not throw: under Vite dev the Cloudflare
+ * module runner re-evaluates only the invalidated importer chain of a changed
+ * file (`frames/*.ts` → `frame-registrations.ts` → `ssr-render.tsx` → worker
+ * entry) while modules off that chain — this registry and its map — keep their
+ * state. The same frame module therefore legitimately runs again against a map
+ * that already holds its name, and the newest `render` must win so HMR serves
+ * fresh code. Name uniqueness across frame modules is a static property checked
+ * by `frame-registrations.node.test.ts`.
+ */
 export function registerFrame(
 	name: string,
 	config: {
@@ -55,10 +67,6 @@ export function registerFrame(
 		render: FrameRenderer
 	},
 ): RegisteredFrame {
-	if (framesByName.has(name)) {
-		throw new Error(`Frame name already registered: ${name}`)
-	}
-
 	const frame = {
 		name,
 		routes: config.routes,
@@ -71,6 +79,10 @@ export function registerFrame(
 
 export function getRegisteredFrame(name: string) {
 	return framesByName.get(name)
+}
+
+export function listRegisteredFrameNames() {
+	return [...framesByName.keys()]
 }
 
 export function createFrameHtmlResponse(html: string) {

--- a/packages/worker/src/app/ssr-document-stream.node.test.ts
+++ b/packages/worker/src/app/ssr-document-stream.node.test.ts
@@ -1,0 +1,79 @@
+import { expect, test } from 'vitest'
+import { openDocumentStream } from '#app/ssr-document-stream.ts'
+
+const encoder = new TextEncoder()
+
+/**
+ * Emits one chunk per pull so a trailing error lands after the consumer has
+ * read the earlier chunks, the way remix/ui's renderer fails asynchronously
+ * after enqueueing the document.
+ */
+function streamOf(
+	chunks: Array<string>,
+	options: { errorAfter?: Error; errorBeforeFirst?: Error } = {},
+) {
+	let index = 0
+	return new ReadableStream<Uint8Array>({
+		pull(controller) {
+			if (index === 0 && options.errorBeforeFirst) {
+				controller.error(options.errorBeforeFirst)
+				return
+			}
+			if (index < chunks.length) {
+				controller.enqueue(encoder.encode(chunks[index]!))
+				index += 1
+				return
+			}
+			if (options.errorAfter) controller.error(options.errorAfter)
+			else controller.close()
+		},
+	})
+}
+
+test('prepends the doctype to a rendered document', async () => {
+	const body = await openDocumentStream(
+		streamOf(['<html><body>hi</body></html>', '<!-- tail -->']),
+	)
+	await expect(new Response(body).text()).resolves.toBe(
+		'<!DOCTYPE html><html><body>hi</body></html><!-- tail -->',
+	)
+})
+
+test('rejects instead of committing a body when the render fails before its first chunk', async () => {
+	// remix/ui's renderToStream resolves the whole document before enqueueing
+	// anything, so a component throwing during SSR (a missing router context
+	// after an HMR re-evaluation, a failing loader) errors the stream here.
+	const failure = new Error('Cannot read properties of undefined')
+	await expect(
+		openDocumentStream(streamOf([], { errorBeforeFirst: failure })),
+	).rejects.toBe(failure)
+})
+
+test('rejects when the renderer closes without producing a document', async () => {
+	await expect(openDocumentStream(streamOf([]))).rejects.toThrow(
+		'SSR render produced no document',
+	)
+})
+
+test('propagates a mid-stream failure as a stream error, not a clean close', async () => {
+	const failure = new Error('frame failed')
+	const body = await openDocumentStream(
+		streamOf(['<html></html>'], { errorAfter: failure }),
+	)
+	await expect(new Response(body).text()).rejects.toBe(failure)
+})
+
+test('cancelling the body cancels the renderer', async () => {
+	let cancelledWith: unknown = null
+	const source = new ReadableStream<Uint8Array>({
+		start(controller) {
+			controller.enqueue(encoder.encode('<html>'))
+		},
+		cancel(reason) {
+			cancelledWith = reason
+		},
+	})
+	const body = await openDocumentStream(source)
+	await body.cancel('client went away')
+	expect(cancelledWith).toBe('client went away')
+})

--- a/packages/worker/src/app/ssr-document-stream.ts
+++ b/packages/worker/src/app/ssr-document-stream.ts
@@ -1,0 +1,41 @@
+const doctypeBytes = new TextEncoder().encode('<!DOCTYPE html>')
+
+/**
+ * Waits for the renderer's first chunk before handing back a body stream.
+ *
+ * `renderToStream` resolves the whole document before it enqueues anything, so
+ * a component that throws during render errors the stream before its first
+ * chunk. Reading that chunk here turns such a failure into a rejection the
+ * caller can answer with a real error response, instead of a committed `200`
+ * whose body stops after the doctype (which the browser shows as a blank page
+ * and shared caches can store). The remix/ui renderer also emits markup
+ * starting at `<html>`; without a doctype the browser parses the document in
+ * quirks mode, so the doctype is prepended once the document is known to exist.
+ */
+export async function openDocumentStream(
+	stream: ReadableStream<Uint8Array>,
+): Promise<ReadableStream<Uint8Array>> {
+	const reader = stream.getReader()
+	const first = await reader.read()
+	if (first.done) {
+		throw new Error('SSR render produced no document')
+	}
+	return new ReadableStream<Uint8Array>({
+		start(controller) {
+			controller.enqueue(doctypeBytes)
+			controller.enqueue(first.value)
+		},
+		async pull(controller) {
+			const next = await reader.read()
+			if (next.done) {
+				controller.close()
+				return
+			}
+			controller.enqueue(next.value)
+		},
+		cancel(reason) {
+			// Client disconnects cancel the body; release the renderer too.
+			return reader.cancel(reason)
+		},
+	})
+}

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -298,6 +298,19 @@ test('resolveOriginClientEntry maps Remix entry IDs onto the Vite client href', 
 		exportName: 'AppRoot',
 		preloads: [],
 	})
+	// Pitlane's dev `<HMR />` island names its own dev-server module; the client
+	// entry bundle does not export it.
+	expect(
+		resolveOriginClientEntry({
+			entryId: '/@id/__x00__pitlane:dev#HMR',
+			href: '/packages/worker/client/entry.tsx',
+			preloads: ['/packages/worker/client/routes/auth-area.ts'],
+		}),
+	).toEqual({
+		href: '/@id/__x00__pitlane:dev',
+		exportName: 'HMR',
+		preloads: [],
+	})
 })
 
 test('SSR HTML routes render page content and embedded loader data', async () => {

--- a/packages/worker/src/app/ssr-render.tsx
+++ b/packages/worker/src/app/ssr-render.tsx
@@ -39,6 +39,11 @@ import {
  * `/client-entry.js#AppRoot` while the script tag is `/assets/entry-*.js`.
  * Without this hook, `#rmx-data` tells the browser to import the deleted
  * esbuild path and hydration 404s.
+ *
+ * Only the app root lives in that entry bundle. Any other island — Pitlane's
+ * dev `<HMR />`, whose id is its own dev-server URL — must be imported from
+ * the module it names; routed through the entry it fails with "Unknown client
+ * export", the island never hydrates, and server-data revalidation is dead.
  */
 export function resolveOriginClientEntry({
 	entryId,
@@ -49,7 +54,11 @@ export function resolveOriginClientEntry({
 	href: string
 	preloads: Array<string>
 }) {
-	const exportName = entryId.split('#')[1]?.trim() || 'AppRoot'
+	const [moduleUrl = '', rawExportName] = entryId.split('#')
+	const exportName = rawExportName?.trim() || 'AppRoot'
+	if (exportName !== 'AppRoot' && moduleUrl.startsWith('/')) {
+		return { href: moduleUrl, exportName, preloads: [] }
+	}
 	return { href, exportName, preloads }
 }
 
@@ -183,6 +192,7 @@ export async function renderAppPage(input: RenderAppPageInput) {
 			request,
 			responseSetsCookie,
 			status: status ?? 200,
+			localDev: parsedEnv.WRANGLER_IS_LOCAL_DEV === 'true',
 		})
 		const headers = new Headers({
 			'Cache-Control': pageCache.cacheControl,

--- a/packages/worker/src/app/ssr-render.tsx
+++ b/packages/worker/src/app/ssr-render.tsx
@@ -18,6 +18,7 @@ import { applyFirstPartySecurityHeaders } from '#app/security-headers.ts'
 import { loadSessionInfo } from '#app/session-info.ts'
 import { getInlineStylesheet } from '#app/inline-stylesheet.ts'
 import { SsrDocument } from '#app/ssr-document.tsx'
+import { openDocumentStream } from '#app/ssr-document-stream.ts'
 import { preloadClientRouteModules } from '#client/lazy-route.tsx'
 import {
 	SENTRY_TUNNEL_PATH,
@@ -31,35 +32,6 @@ import {
 	pushServerTiming,
 	type ServerTimingEntry,
 } from '#worker/server-timing.ts'
-
-/**
- * The remix/ui stream renderer emits markup starting at `<html>`; without a
- * doctype the browser parses the document in quirks mode.
- */
-function prependDoctype(stream: ReadableStream<Uint8Array>) {
-	const { readable, writable } = new TransformStream<Uint8Array, Uint8Array>()
-	void (async () => {
-		const writer = writable.getWriter()
-		try {
-			await writer.write(new TextEncoder().encode('<!DOCTYPE html>'))
-			writer.releaseLock()
-			await stream.pipeTo(writable)
-		} catch (error) {
-			// Client disconnects abort the pipe; make sure both ends close.
-			try {
-				await stream.cancel(error)
-			} catch {
-				// Already errored or cancelled.
-			}
-			try {
-				await writable.abort(error)
-			} catch {
-				// Already aborted by pipeTo.
-			}
-		}
-	})()
-	return readable
-}
 
 /**
  * Maps a Remix `clientEntry` id onto the public Vite client module.
@@ -199,6 +171,9 @@ export async function renderAppPage(input: RenderAppPageInput) {
 				},
 			},
 		)
+		// Throws when the render fails before producing the document; the
+		// handler's catch then answers with a 500 instead of a truncated 200.
+		const body = await openDocumentStream(stream)
 
 		const responseSetsCookie =
 			Boolean(setCookie) || (extraSetCookies?.length ?? 0) > 0
@@ -228,7 +203,7 @@ export async function renderAppPage(input: RenderAppPageInput) {
 		}
 
 		return applyFirstPartySecurityHeaders(
-			new Response(prependDoctype(stream), {
+			new Response(body, {
 				status: status ?? 200,
 				headers,
 			}),

--- a/tools/vite-worker-whole-graph-reload.node.test.ts
+++ b/tools/vite-worker-whole-graph-reload.node.test.ts
@@ -1,0 +1,148 @@
+import { expect, test, vi } from 'vitest'
+import { type EnvironmentModuleNode, type HotUpdateOptions } from 'vite'
+import {
+	touchesComponentBoundary,
+	workerWholeGraphReload,
+} from './vite-worker-whole-graph-reload.ts'
+
+type FakeNode = {
+	id: string
+	isSelfAccepting: boolean | undefined
+	importers: Set<FakeNode>
+}
+
+function node(id: string, isSelfAccepting?: boolean): FakeNode {
+	return { id, isSelfAccepting, importers: new Set() }
+}
+
+function link(imported: FakeNode, importer: FakeNode) {
+	imported.importers.add(importer)
+}
+
+/** entry ← index ← origin-handler ← router ← handlers/faq ; entry accepts. */
+function serverOnlyGraph() {
+	const entry = node('\0virtual:cloudflare/worker-entry', true)
+	const index = node('/src/index.ts', false)
+	const origin = node('/src/origin-handler.ts', false)
+	const router = node('/src/app/router.ts', false)
+	const faq = node('/src/app/handlers/faq.ts', false)
+	link(index, entry)
+	link(origin, index)
+	link(router, origin)
+	link(faq, router)
+	return { entry, faq, router }
+}
+
+function asNodes(nodes: Array<FakeNode>) {
+	return nodes as unknown as Array<EnvironmentModuleNode>
+}
+
+test('a pure server importer chain keeps the incremental update', () => {
+	const { faq } = serverOnlyGraph()
+	expect(touchesComponentBoundary(asNodes([faq]))).toBe(false)
+})
+
+test('a changed component module reloads the whole graph', () => {
+	const { router } = serverOnlyGraph()
+	const onboarding = node('/client/routes/onboarding.tsx', true)
+	link(onboarding, router)
+	expect(touchesComponentBoundary(asNodes([onboarding]))).toBe(true)
+})
+
+test('a server module imported by a component module reloads the whole graph', () => {
+	const { router } = serverOnlyGraph()
+	const routerLocation = node('/client/router-location.tsx', true)
+	const routes = node('/universal/routes.ts', false)
+	link(routerLocation, router)
+	link(routes, routerLocation)
+	link(routes, router)
+	expect(touchesComponentBoundary(asNodes([routes]))).toBe(true)
+})
+
+test('cycles in the importer graph terminate', () => {
+	const a = node('/a.ts', false)
+	const b = node('/b.ts', false)
+	link(a, b)
+	link(b, a)
+	expect(touchesComponentBoundary(asNodes([a]))).toBe(false)
+})
+
+function createHookContext(environmentName: string) {
+	const send = vi.fn()
+	const info = vi.fn()
+	const context = {
+		environment: {
+			name: environmentName,
+			config: { root: '/repo' },
+			hot: { send },
+			logger: { info },
+		},
+	}
+	return { context, send, info }
+}
+
+function runHotUpdate(environmentName: string, modules: Array<FakeNode>) {
+	const plugin = workerWholeGraphReload()
+	const hook = plugin.hotUpdate
+	if (!hook || typeof hook !== 'object' || !('handler' in hook)) {
+		throw new Error('expected an object-form hotUpdate hook')
+	}
+	const { context, send, info } = createHookContext(environmentName)
+	const result = hook.handler.call(
+		context as unknown as ThisParameterType<typeof hook.handler>,
+		{
+			file: '/repo/packages/worker/client/routes/onboarding.tsx',
+			modules: asNodes(modules),
+		} as HotUpdateOptions,
+	)
+	return { result, send, info }
+}
+
+test('a component update in a worker environment becomes one whole-graph reload', () => {
+	const { router } = serverOnlyGraph()
+	const onboarding = node('/client/routes/onboarding.tsx', true)
+	link(onboarding, router)
+	const { result, send, info } = runHotUpdate('ssr', [onboarding])
+	expect(result).toEqual([])
+	expect(send).toHaveBeenCalledWith({ type: 'full-reload', path: '*' })
+	expect(info).toHaveBeenCalledWith(
+		'page reload packages/worker/client/routes/onboarding.tsx (whole worker graph)',
+		{ timestamp: true },
+	)
+})
+
+test('auxiliary worker environments reload the same way', () => {
+	const { router } = serverOnlyGraph()
+	const component = node('/runtime/panel.tsx', true)
+	link(component, router)
+	const { result, send } = runHotUpdate('kody_runtime', [component])
+	expect(result).toEqual([])
+	expect(send).toHaveBeenCalledTimes(1)
+})
+
+test("a server-only update leaves Vite's incremental update alone", () => {
+	const { faq } = serverOnlyGraph()
+	const { result, send } = runHotUpdate('ssr', [faq])
+	expect(result).toBeUndefined()
+	expect(send).not.toHaveBeenCalled()
+})
+
+test('the client environment keeps Vite component HMR', () => {
+	const onboarding = node('/client/routes/onboarding.tsx', true)
+	link(onboarding, node('/client/entry.tsx', true))
+	const { result, send } = runHotUpdate('client', [onboarding])
+	expect(result).toBeUndefined()
+	expect(send).not.toHaveBeenCalled()
+})
+
+test('a file outside the worker graph does not reload it', () => {
+	const { result, send } = runHotUpdate('ssr', [])
+	expect(result).toBeUndefined()
+	expect(send).not.toHaveBeenCalled()
+})
+
+test('applies to serve only and runs after other hotUpdate hooks', () => {
+	const plugin = workerWholeGraphReload()
+	expect(plugin.apply).toBe('serve')
+	expect(plugin.hotUpdate).toMatchObject({ order: 'post' })
+})

--- a/tools/vite-worker-whole-graph-reload.ts
+++ b/tools/vite-worker-whole-graph-reload.ts
@@ -1,0 +1,77 @@
+import path from 'node:path'
+import { type EnvironmentModuleNode, type Plugin } from 'vite'
+
+/**
+ * Reloads a Worker environment's whole module graph when an HMR update touches
+ * a component module, instead of letting Vite hot-swap it in place.
+ *
+ * Under `@cloudflare/vite-plugin` the virtual worker entry is a self-accepting
+ * HMR boundary, so a change never dead-ends into Vite's own full reload: the
+ * module runner re-imports the nearest boundary and re-evaluates only the
+ * invalidated importer chain, while every module off that chain keeps its
+ * state. `remix/ui-hmr` also instruments every component module into its own
+ * boundary. Both are fine for a browser tab and wrong for SSR: each evaluation
+ * of a component module mints new component functions, and Remix keys
+ * `handle.context` on component identity. A request rendered during the
+ * multi-stage cascade Remix's component HMR produces (update → invalidate →
+ * importer update → circular reload) mixed generations, `context.get()` came
+ * back `undefined`, and SSR failed part-way through the document.
+ *
+ * So when the changed modules or any of their importers (up to the entry) are
+ * such a boundary, this sends `full-reload`: the runner clears its evaluated
+ * modules and re-imports the entry — one consistent graph per change, the same
+ * model as a redeploy. Pure server chains (a handler, a data loader) have no
+ * component identities to split and keep Vite's cheaper incremental update;
+ * module-level side effects on that path must be idempotent (see
+ * `registerFrame`). The client environment is untouched, so browser component
+ * HMR keeps hot-swapping, and client-only files never reach a Worker
+ * environment's `hotUpdate` with modules.
+ */
+export function workerWholeGraphReload({
+	clientEnvironmentName = 'client',
+}: { clientEnvironmentName?: string } = {}): Plugin {
+	return {
+		name: 'kody-worker-whole-graph-reload',
+		apply: 'serve',
+		hotUpdate: {
+			order: 'post',
+			handler({ file, modules }) {
+				if (this.environment.name === clientEnvironmentName) return
+				if (!touchesComponentBoundary(modules)) return
+				const shortFile = path.relative(this.environment.config.root, file)
+				this.environment.logger.info(
+					`page reload ${shortFile} (whole worker graph)`,
+					{ timestamp: true },
+				)
+				this.environment.hot.send({ type: 'full-reload', path: '*' })
+				return []
+			},
+		},
+	}
+}
+
+type ModuleGraphNode = Pick<
+	EnvironmentModuleNode,
+	'id' | 'isSelfAccepting' | 'importers'
+>
+
+/**
+ * True when a changed module, or any module that would be re-evaluated because
+ * it imports one, accepts its own HMR updates. The environment entry is the
+ * one self-accepting root every chain ends at and does not count; a component
+ * module always has importers.
+ */
+export function touchesComponentBoundary(
+	modules: ReadonlyArray<ModuleGraphNode>,
+): boolean {
+	const seen = new Set<ModuleGraphNode>()
+	const queue = [...modules]
+	while (queue.length > 0) {
+		const mod = queue.pop()!
+		if (seen.has(mod)) continue
+		seen.add(mod)
+		if (mod.isSelfAccepting && mod.importers.size > 0) return true
+		for (const importer of mod.importers) queue.push(importer)
+	}
+	return false
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,6 +14,7 @@ import { writeLocalRuntimeDevConfig } from './tools/local-runtime-dev-config.ts'
 import { ensureGuideCatalogModules } from './tools/build-guide-catalog-modules.ts'
 import { ensureWorkerBundlerModules } from './tools/build-worker-bundler-modules.ts'
 import { markdownAsText } from './tools/vite-markdown-as-text.ts'
+import { workerWholeGraphReload } from './tools/vite-worker-whole-graph-reload.ts'
 
 const root = path.dirname(fileURLToPath(import.meta.url))
 const envName = process.env.CLOUDFLARE_ENV ?? 'production'
@@ -110,6 +111,7 @@ export default defineConfig(async ({ command }) => {
 				remoteBindings: false,
 				auxiliaryWorkers,
 			}),
+			workerWholeGraphReload(),
 		],
 		resolve: {
 			alias: [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

`npm run dev` after the Pitlane Vite migration (#2055, #2057) should survive a source edit: no `Frame name already registered` overlay on unrelated routes, no blank page, no blank page that sticks because a cache stored it, and the next reload shows the edit.

## Why

Both reported failures come from one property of the dev runtime. Under `@cloudflare/vite-plugin` the virtual worker entry is a self-accepting HMR boundary (and `remix/ui-hmr` makes every component module one too), so a change never dead-ends into Vite's own full reload. The module runner re-imports the nearest boundary and re-evaluates **only the invalidated importer chain**; every module off that chain keeps its state.

1. **`Frame name already registered: community-listings`** — `frames/community-listings.ts` → `frame-registrations.ts` → `ssr-render.tsx` → … → entry is the chain for anything the frame module imports (`community-data.ts`, `community-listings-content.tsx`, a shared `universal/*.tsx`). `frame-registry.ts` is off the chain, so its `Map` survives, the frame module re-runs `registerFrame`, and the throw happens inside the worker entry import — on every route, until the dev server restarts. Reproduced with a one-line edit to `community-listings-content.tsx` and to `routes/onboarding.tsx`.
2. **White screen** — a component edit triggers a three-stage cascade (`hmr update` → `hmr invalidate … changed non-component export` → importer update → `page reload … (circular import invalidate)` → `evaluatedModules.clear()`). A request rendered mid-cascade holds a mix of module generations; Remix keys `handle.context` on component identity, so `readRouterUrl` got `undefined`. `renderToStream` errors before its first chunk, but `prependDoctype` had already committed a `200` with `<!DOCTYPE html>`; the body ended cleanly at 15 bytes, `/onboarding` is a cacheable anonymous path, and `caches.default` replayed the blank page as a HIT. Reproduced by hammering `/onboarding` during the cascade (`200 15`, then HIT), and independently with a D1 error on `/community`.

Verifying the fix surfaced why a blank page "kept" serving and why edits looked ignored: in local dev the shared store is persisted under `.wrangler/state` and workerd honors `stale-while-revalidate=300`, and Chromium serves Vite's post-HMR `location.reload()` from its own HTTP cache when the document is `public, max-age=60`. Both hid every edit from an anonymous tab for minutes.

## Summary

- `registerFrame` replaces on a repeated name instead of throwing (same as remix's own `registerComponentForHmr`); name uniqueness across frame modules moves to `frame-registrations.node.test.ts`.
- `renderAppPage` awaits the renderer's first chunk (`openDocumentStream`) before building the `Response`, so a render failure is the handler's 500 rather than a truncated 200. Doctype is prepended once the document exists.
- The anonymous HTML cache buffers the storable clone and refuses any body that never reached `</html>` (`isCompleteHtmlDocument`), so a truncated document can never be stored regardless of how the Cache API treats errored bodies.
- New `tools/vite-worker-whole-graph-reload.ts`: for worker environments, when the changed modules or their importer chain include a self-accepting boundary (a component module), send `full-reload` so the runner evaluates one consistent graph per change. Pure server chains (handlers, loaders) keep Vite's incremental update: a server-only edit still answers in ~0.2s, a component edit costs one whole-graph reload (~4.5s here; the old cascade ended in the same `program reload`).
- Local dev (`WRANGLER_IS_LOCAL_DEV=true`, i.e. `npm run dev` and the Playwright web server): the shared anonymous HTML store is bypassed and SSR documents are `no-store`. Preview, production, and the `workers-unit` cache tests are unchanged.
- `resolveOriginClientEntry` no longer routes every island through `entry.tsx`: Pitlane's dev `<HMR />` island (`/@id/__x00__pitlane:dev#HMR`) imports its own module, which removes the `Unknown client export: HMR` console error on every dev page load and lets server-data revalidation run.
- Docs: local-development.md (worker HMR semantics, dev cache), request-lifecycle.md (cache admission, dev bypass).

## Testing

- New tests: `frame-registry.node.test.ts` (re-register replaces, no throw), `frame-registrations.node.test.ts` (distinct names), `ssr-document-stream.node.test.ts` (reject before first chunk, prepend doctype, mid-stream error stays an error, cancel propagates), `anonymous-html-cache.node.test.ts` (+local dev `no-store`), `anonymous-html-edge-cache.node.test.ts` (+completeness, entry headers, local-dev bypass), `anonymous-html-edge-cache.workers.test.ts` (real `caches.default`: complete stored/replayed, 15-byte doc served once and never stored, errored body never stored), `ssr-render.node.test.ts` (+Pitlane island entry), `tools/vite-worker-whole-graph-reload.node.test.ts` (graph-walk criterion + hook behavior).
- `npm run dev` (`CLOUDFLARE_ENV=production`) with request hammering during edits, before/after:
  - before: edit `routes/onboarding.tsx` → every route 500 `Frame name already registered`; first request mid-cascade → `200 15` (`readRouterUrl` undefined) and `/community` HIT replayed a 15-byte document.
  - after: `routes/onboarding.tsx` → one `page reload … (whole worker graph)`, requests at +50…+700ms all wait and return the edited document; `handlers/faq.ts` → incremental update, 33 requests all `200` with no stall; `community-data.ts` → frame module re-runs `registerFrame` without throwing, `/community` and the `x-remix-target: community-listings` frame request both render.
  - headless Chromium: after an edit the page's own reload returned the pre-edit document (`X-Kody-Cache: HIT`, then browser HTTP cache with `responseStart` 0.1ms); with the dev bypass and `no-store` it fetches the new document. A user reload shows the edit; no `Unknown client export: HMR` error.
- `npm run validate`: all jobs green except e2e, which failed only because its Vite web server raced my running `npm run dev` over the shared `wrangler-local-dev.generated.json`; e2e alone passes (10/10, twice, including after the last two commits). knip, format, lint, typecheck, docs checks re-run green after the final commits; `test:node` + `test:workers` ran in the pre-push hook.

## Follow-ups observed (not changed here)

- Remix's Navigation API listener intercepts `location.reload()` when the current entry carries `$rmx` state, so Vite's client `full-reload` becomes an in-place top-frame reload that preserves the hydrated `AppRoot` island. Combined with `remix/ui-hmr` invalidating route modules on every edit (their loader exports change identity), a component edit does not update the visible page until the user reloads. Framework-level (Remix rc.1 / Pitlane); worth an upstream issue.
- The Cloudflare Vite plugin needs `CLOUDFLARE_ENV=production` in the process environment to pick `env.production` bindings; `cli.ts` does not set it.
- `npm run migrate:local` writes to `packages/worker/.wrangler/state` while Vite persists at repo-root `.wrangler/state`, so a fresh clone needs `--persist-to .wrangler/state`.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `dd52399f` · **Head:** `8dfcd8e7`

**Classification:** extends — `app-ui` SSR response assembly, frame registry semantics, anonymous HTML cache admission, and client-entry resolution change; no primitive added. `tools/vite-worker-whole-graph-reload.ts` and `vite.config.ts` are dev-only tooling outside the primitives map.

### Primitives touched

| Primitive | Group    | Impact                                                                                                                                                                                                                                                     |
| --------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `app-ui`  | surfaces | extends — `registerFrame` replaces on repeat; `renderAppPage` commits the Response only after the first render chunk; anonymous HTML cache stores complete documents only and is bypassed in local dev (`no-store` documents); Pitlane island imports its own module |

### Change flow

An anonymous page request under Vite dev, from HMR through SSR into the shared cache.

```mermaid
sequenceDiagram
	participant vite as Vite dev server
	participant runner as Cloudflare module runner
	participant appUi as app-ui
	participant cache as caches.default
	vite->>runner: component edit → full-reload (whole worker graph)
	Note over runner: one consistent module generation per change
	vite->>runner: server-only edit → incremental entry update (unchanged)
	runner->>appUi: re-run frames/*.ts → registerFrame replaces same name
	appUi->>appUi: renderToStream → await first chunk (openDocumentStream)
	alt render throws before first chunk
		appUi-->>cache: nothing stored (handler returns 500)
	else document rendered
		appUi->>cache: buffer body, store only if it contains </html>
		Note over appUi,cache: WRANGLER_IS_LOCAL_DEV: bypass store, document is no-store
	end
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3e81439e-3b85-4ad0-b2a8-7506c6cc0f4a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3e81439e-3b85-4ad0-b2a8-7506c6cc0f4a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented incomplete or truncated HTML responses from being stored in the anonymous edge cache.
  - Local development now bypasses page caching, preventing stale pages after edits.
  - Improved server-rendered pages by ensuring valid documents include a doctype and handling stream failures more reliably.
  - Frame registrations can now be safely replaced without errors.

- **Developer Experience**
  - Component changes during Worker development trigger full graph reloads when needed, while server-only changes retain incremental updates.
  - Added documentation covering hot-module reload and local caching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->