### PR TITLE
Fix guide chooser table wrapping the Use column

### DIFF
--- a/packages/worker/client/markdown-view.node.test.ts
+++ b/packages/worker/client/markdown-view.node.test.ts
@@ -54,6 +54,7 @@ test('renders common markdown constructs as HTML elements', async () => {
 	expect(html).toContain('start="5"')
 	expect(html).toContain('>Name</th>')
 	expect(html).toContain('>a</td>')
+	expect(html).toContain('data-markdown-table')
 	expect(html).toContain('class="shiki')
 	expect(html).toContain('const')
 	expect(html).toContain('<hr')

--- a/packages/worker/client/markdown-view.node.test.ts
+++ b/packages/worker/client/markdown-view.node.test.ts
@@ -55,6 +55,7 @@ test('renders common markdown constructs as HTML elements', async () => {
 	expect(html).toContain('>Name</th>')
 	expect(html).toContain('>a</td>')
 	expect(html).toContain('data-markdown-table')
+	expect(html).toContain('data-markdown-table-compact-last')
 	expect(html).toContain('class="shiki')
 	expect(html).toContain('const')
 	expect(html).toContain('<hr')
@@ -224,4 +225,26 @@ test('getSafeMarkdownLinkHref allowlists protocols and blocks user-scope paths',
 	expect(
 		getSafeMarkdownLinkHref('https://github.com/orgs/example/packages'),
 	).toBe('https://github.com/orgs/example/packages')
+})
+
+test('markdown tables keep last-column nowrap only when every last cell is a short label', async () => {
+	const compact = await renderMarkdown(
+		[
+			'| You want to | Use |',
+			'| --- | --- |',
+			'| Keep working code | A **package** |',
+			'| Sign in so code can act as you | An **integration** |',
+		].join('\n'),
+	)
+	expect(compact).toContain('data-markdown-table-compact-last')
+
+	const descriptive = await renderMarkdown(
+		[
+			'| File | Topic |',
+			'| --- | --- |',
+			'| oauth.md | Start here for third-party OAuth redirect URI and params |',
+		].join('\n'),
+	)
+	expect(descriptive).toContain('data-markdown-table=""')
+	expect(descriptive).not.toContain('data-markdown-table-compact-last=""')
 })

--- a/packages/worker/client/markdown-view.tsx
+++ b/packages/worker/client/markdown-view.tsx
@@ -257,6 +257,19 @@ function renderTableCell(
 	)
 }
 
+const compactLastColumnMaxChars = 40
+
+function tableLastColumnIsCompact(table: Tokens.Table): boolean {
+	const lastCells = [
+		table.header.at(-1),
+		...table.rows.map((row) => row.at(-1)),
+	]
+	return lastCells.every((cell) => {
+		const text = cell?.text.trim() ?? ''
+		return text.length > 0 && text.length <= compactLastColumnMaxChars
+	})
+}
+
 function renderToken(
 	token: Token,
 	key: number,
@@ -325,8 +338,13 @@ function renderToken(
 			)
 		case 'table': {
 			const tableToken = token as Tokens.Table
+			const compactLast = tableLastColumnIsCompact(tableToken)
 			return (
-				<div key={key} data-markdown-table="">
+				<div
+					key={key}
+					data-markdown-table=""
+					data-markdown-table-compact-last={compactLast ? '' : undefined}
+				>
 					<table>
 						<thead>
 							<tr>

--- a/packages/worker/client/markdown-view.tsx
+++ b/packages/worker/client/markdown-view.tsx
@@ -29,17 +29,21 @@
 import { lexer, type Token, type Tokens } from 'marked'
 import { type Handle, type RemixNode, css } from 'remix/ui'
 import { CopyCodeBlock } from '#client/copy-code-block.tsx'
+import { renderHighlightedCode } from '#client/syntax-highlight.tsx'
+import {
+	plainHighlightedCode,
+	type HighlightedCode,
+} from '#universal/highlighted-code.ts'
+import {
+	markdownTableCss,
+	mergeCss,
+} from '#universal/styles/style-primitives.ts'
 import {
 	colors,
 	radius,
 	spacing,
 	typography,
 } from '#universal/styles/tokens.ts'
-import { renderHighlightedCode } from '#client/syntax-highlight.tsx'
-import {
-	plainHighlightedCode,
-	type HighlightedCode,
-} from '#universal/highlighted-code.ts'
 
 const allowedLinkProtocols = new Set(['http:', 'https:', 'mailto:'])
 
@@ -322,24 +326,26 @@ function renderToken(
 		case 'table': {
 			const tableToken = token as Tokens.Table
 			return (
-				<table key={key}>
-					<thead>
-						<tr>
-							{tableToken.header.map((cell, index) =>
-								renderTableCell(cell, index, 'th', options),
-							)}
-						</tr>
-					</thead>
-					<tbody>
-						{tableToken.rows.map((row, rowIndex) => (
-							<tr key={rowIndex}>
-								{row.map((cell, cellIndex) =>
-									renderTableCell(cell, cellIndex, 'td', options),
+				<div key={key} data-markdown-table="">
+					<table>
+						<thead>
+							<tr>
+								{tableToken.header.map((cell, index) =>
+									renderTableCell(cell, index, 'th', options),
 								)}
 							</tr>
-						))}
-					</tbody>
-				</table>
+						</thead>
+						<tbody>
+							{tableToken.rows.map((row, rowIndex) => (
+								<tr key={rowIndex}>
+									{row.map((cell, cellIndex) =>
+										renderTableCell(cell, cellIndex, 'td', options),
+									)}
+								</tr>
+							))}
+						</tbody>
+					</table>
+				</div>
 			)
 		}
 		case 'strong':
@@ -435,7 +441,7 @@ export function MarkdownView(handle: Handle<MarkdownViewProps>) {
 	}
 }
 
-const markdownCss = {
+const markdownCss = mergeCss(markdownTableCss, {
 	fontSize: typography.fontSize.sm,
 	lineHeight: 1.6,
 	color: colors.text,
@@ -456,7 +462,7 @@ const markdownCss = {
 	'& h4': {
 		fontSize: typography.fontSize.base,
 	},
-	'& p, & blockquote, & pre, & table, & ul, & ol': {
+	'& p, & blockquote, & pre, & ul, & ol': {
 		margin: `${spacing.sm} 0`,
 	},
 	'& ul, & ol': {
@@ -480,19 +486,6 @@ const markdownCss = {
 	'& code': {
 		fontSize: typography.fontSize.sm,
 	},
-	'& table': {
-		borderCollapse: 'collapse' as const,
-		display: 'block',
-		overflowX: 'auto' as const,
-	},
-	'& th, & td': {
-		border: `1px solid ${colors.border}`,
-		padding: `${spacing.xs} ${spacing.sm}`,
-		textAlign: 'left' as const,
-	},
-	'& th': {
-		fontWeight: typography.fontWeight.semibold,
-	},
 	'& a': {
 		color: colors.primaryText,
 		textDecoration: 'underline',
@@ -502,4 +495,4 @@ const markdownCss = {
 		borderTop: `1px solid ${colors.border}`,
 		margin: `${spacing.lg} 0`,
 	},
-}
+})

--- a/packages/worker/client/package-files-explorer.tsx
+++ b/packages/worker/client/package-files-explorer.tsx
@@ -814,10 +814,9 @@ const markdownCss = {
 	'& > :first-child': {
 		marginTop: 0,
 	},
-	// `proseCss` styles no tables. A README table sized to the column would
-	// wrap every cell to a few characters, so it sizes to its content
-	// (`max-content`) and scrolls inside its own box instead — the block
-	// display is what lets a table overflow at all.
+	// Guide/blog `proseCss` tables keep real column layout. README files
+	// sit in a narrower explorer column, so this view still sizes to
+	// `max-content` and scrolls instead of wrapping every cell.
 	'& table': {
 		display: 'block',
 		width: 'max-content',

--- a/packages/worker/client/routes/guide-detail.tsx
+++ b/packages/worker/client/routes/guide-detail.tsx
@@ -21,6 +21,8 @@ import { renderGoogleOauthWalkthrough } from '#client/routes/google-oauth-walkth
 import { colors, radius } from '#universal/styles/tokens.ts'
 import {
 	articleMeasure,
+	getArticleBreakoutCss,
+	mergeCss,
 	pageGutter,
 	pageHeadCss,
 	proseCss,
@@ -304,7 +306,9 @@ export function GuideDetailRoute(handle: Handle) {
 						{interactiveGuideRenderers[guide.slug]?.(
 							guide.walkthroughHighlights,
 							guide.walkthroughHosts,
-						) ?? <div mix={css(proseCss)}>{renderGuideBody(guide.body)}</div>}
+						) ?? (
+							<div mix={css(guideProseCss)}>{renderGuideBody(guide.body)}</div>
+						)}
 
 						<footer mix={css(guideFootCss)}>
 							<p>
@@ -327,6 +331,10 @@ export function GuideDetailRoute(handle: Handle) {
 }
 
 /* Blog post rhythm on the 43rem measure. */
+
+const guideProseCss = mergeCss(proseCss, {
+	'& [data-markdown-table]': getArticleBreakoutCss(),
+})
 
 const guidePageCss = {
 	maxWidth: articleMeasure,

--- a/packages/worker/universal/styles/style-primitives.prose.node.test.ts
+++ b/packages/worker/universal/styles/style-primitives.prose.node.test.ts
@@ -23,3 +23,18 @@ test('prose lists wrap long inline code instead of stretching past the viewport'
 	expect(html).toContain('white-space: pre')
 	expect(html).toContain('overflow-wrap: normal')
 })
+
+test('prose tables keep column layout instead of wrapping the last cell to a sliver', async () => {
+	const html = await renderToString(
+		jsx('div', {
+			mix: css(proseCss),
+			children: 'x',
+		}),
+	)
+
+	expect(html).toContain('display: table')
+	expect(html).toContain('white-space: nowrap')
+	expect(html).toContain('overflow-wrap: break-word')
+	expect(html).toContain('overflow-x: auto')
+	expect(html).not.toContain('display: block')
+})

--- a/packages/worker/universal/styles/style-primitives.prose.node.test.ts
+++ b/packages/worker/universal/styles/style-primitives.prose.node.test.ts
@@ -33,6 +33,7 @@ test('prose tables keep column layout instead of wrapping the last cell to a sli
 	)
 
 	expect(html).toContain('display: table')
+	expect(html).toContain('[data-markdown-table-compact-last]')
 	expect(html).toContain('white-space: nowrap')
 	expect(html).toContain('overflow-wrap: break-word')
 	expect(html).toContain('overflow-x: auto')

--- a/packages/worker/universal/styles/style-primitives.ts
+++ b/packages/worker/universal/styles/style-primitives.ts
@@ -457,6 +457,48 @@ export function getLanternGlowCss(options: { maxWidth: string }) {
 	}
 }
 
+/**
+ * Markdown table layout for prose (guides, blog) and README views.
+ *
+ * The prose root uses `overflow-wrap: anywhere` so long tokens in lists can
+ * shrink. That also collapses table min-content to a character, so auto
+ * layout gives leftover space to the long first column and the last column
+ * wraps "An integration" onto two lines. Reset wrap on the table, keep the
+ * last column at content width, and scroll overflow on a wrapper — not on
+ * `display: block` tables, which skip column layout.
+ *
+ * Wrap each `<table>` in `[data-markdown-table]` (see `markdown-view.tsx`).
+ */
+export const markdownTableCss = {
+	'& [data-markdown-table]': {
+		margin: '1.15rem 0 0',
+		maxWidth: '100%',
+		overflowX: 'auto' as const,
+	},
+	'& table': {
+		display: 'table' as const,
+		width: '100%',
+		borderCollapse: 'collapse' as const,
+		overflowWrap: 'normal' as const,
+	},
+	'& th, & td': {
+		border: `1px solid ${colors.border}`,
+		padding: `${spacing.sm} ${spacing.md}`,
+		textAlign: 'left' as const,
+		verticalAlign: 'top' as const,
+		overflowWrap: 'break-word' as const,
+	},
+	'& th': {
+		fontWeight: typography.fontWeight.semibold,
+		backgroundColor: colors.surface,
+		whiteSpace: 'nowrap' as const,
+	},
+	'& th:last-child, & td:last-child': {
+		width: 'max-content',
+		whiteSpace: 'nowrap' as const,
+	},
+}
+
 export const proseCss = {
 	marginTop: 'clamp(1.8rem, 4vw, 2.5rem)',
 	minWidth: 0,
@@ -465,6 +507,7 @@ export const proseCss = {
 	// `body { overflow-x: clip }` would otherwise hide the overflow with no
 	// scrollbar. Interactive walkthroughs do not use this object.
 	overflowWrap: 'anywhere' as const,
+	...markdownTableCss,
 	'& a': {
 		color: colors.primaryText,
 		textDecorationThickness: '1.5px',

--- a/packages/worker/universal/styles/style-primitives.ts
+++ b/packages/worker/universal/styles/style-primitives.ts
@@ -464,8 +464,10 @@ export function getLanternGlowCss(options: { maxWidth: string }) {
  * shrink. That also collapses table min-content to a character, so auto
  * layout gives leftover space to the long first column and the last column
  * wraps "An integration" onto two lines. Reset wrap on the table, keep the
- * last column at content width, and scroll overflow on a wrapper — not on
- * `display: block` tables, which skip column layout.
+ * last column at content width when every last-column cell is a short
+ * label, and scroll overflow on a wrapper — not on `display: block`
+ * tables, which skip column layout. Long last-column descriptions still
+ * wrap so a chooser table does not force every prose table to scroll.
  *
  * Wrap each `<table>` in `[data-markdown-table]` (see `markdown-view.tsx`).
  */
@@ -493,10 +495,11 @@ export const markdownTableCss = {
 		backgroundColor: colors.surface,
 		whiteSpace: 'nowrap' as const,
 	},
-	'& th:last-child, & td:last-child': {
-		width: 'max-content',
-		whiteSpace: 'nowrap' as const,
-	},
+	'& [data-markdown-table-compact-last] th:last-child, & [data-markdown-table-compact-last] td:last-child':
+		{
+			width: 'max-content',
+			whiteSpace: 'nowrap' as const,
+		},
 }
 
 export const proseCss = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Make the Packages / integrations / MCP chooser table readable: the Use column should stay on one line instead of wrapping mid-phrase.

## Why

Guide prose inherits `overflow-wrap: anywhere` so long tokens in lists can shrink. That also collapses table min-content to a character. Auto layout then gives leftover space to the long first column, so “An integration” and “An MCP server” wrap. Some markdown views also used `display: block` on `<table>`, which skips column layout.

## Summary

- Shared `markdownTableCss` restores real table layout, cell borders, and overflow scrolling on `[data-markdown-table]`
- Last-column `nowrap` applies only when every last-column cell is a short label (`data-markdown-table-compact-last`), so first-party tables with a long last column still wrap
- Guide tables break out of the 43rem article when the viewport has room
- Tests pin compact vs descriptive last-column behavior

## Testing

- Node unit: `markdown-view.node.test.ts`, `style-primitives.prose.node.test.ts`
- Pre-push: `test:node` and `test:workers` green after the compact-last follow-up
- Browser on `http://localhost:3742/guides/packages-integrations-mcp`:
  - Navigated Guides → this article → scrolled to **Use this one when**
  - Desktop computed style: last column `white-space: nowrap`, 206px wide, 45px tall (one line)
  - 390px device mode: last column still `nowrap` at 153px; row height grows because the first column wraps, not because Use wraps

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `b24c84c6` · **Head:** `c75646fb`

**Classification:** extends — `app-ui` markdown table layout and guide prose CSS change so chooser tables keep a real last column.

### Primitives touched

| Primitive | Group    | Impact                                                          |
| --------- | -------- | --------------------------------------------------------------- |
| `app-ui`  | surfaces | extends — table wrap, compact-last nowrap, and guide article breakout |

### Change flow

A guide request still renders first-party markdown in `app-ui`. This PR changes how that table is wrapped and sized.

```mermaid
sequenceDiagram
	actor visitor as Visitor
	participant appUi as app-ui
	visitor->>appUi: GET /guides/packages-integrations-mcp
	appUi->>appUi: wrap table in data-markdown-table
	appUi->>appUi: nowrap last column only when every last cell is a short label
	appUi-->>visitor: chooser Use column stays on one line
```

### Before / after

**Before:** prose `overflow-wrap: anywhere` plus `display: block` tables collapsed the Use column so “An integration” wrapped. Global last-child nowrap then broke tables whose last column is a long description.

**After:** tables stay `display: table`, last-column nowrap is opt-in for compact label columns, overflow scrolls on `[data-markdown-table]`, guides break out of `articleMeasure` when the viewport has room.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a5f488d8-35eb-4633-b2c9-d1b8ff7e25cd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a5f488d8-35eb-4633-b2c9-d1b8ff7e25cd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved Markdown table presentation across guides, blogs, and README content.
  * Tables now preserve readable column layouts, support horizontal scrolling in narrow views, and prevent awkward cell wrapping.
  * Added clearer borders, spacing, header styling, and content-based sizing for improved readability.
  * Short final-column labels remain compact, while longer descriptive content continues to wrap naturally.
  * Guide tables can extend beyond the standard article width when needed, making wide tables easier to view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->