### PR TITLE
Review personal details before making a package public

### DIFF
--- a/docs/contributing/community-packages.md
+++ b/docs/contributing/community-packages.md
@@ -174,10 +174,12 @@ Core logic: `packages/worker/src/community/`
 | `og-image.ts`        | Community listing 1200×630 PNG on the shared `#worker/og` pipeline  |
 | `types.ts`           | Shared record types                                                 |
 
-`publishCommunityListing` has no MIT, logo, or Intent gates. It requires a
-published commit and that the owner is not community-banned. It upserts D1
-metadata including optional browse `category` from `package.json#kody.category`
-or well-known tags, and writes a SHA-keyed source snapshot.
+`publishCommunityListing` has no MIT, logo, Intent, or personal-content gates.
+Agents follow a hygiene pass in `package_authoring` before flipping public; the
+Worker does not scan or block on that review. It requires a published commit and
+that the owner is not community-banned. It upserts D1 metadata including
+optional browse `category` from `package.json#kody.category` or well-known tags,
+and writes a SHA-keyed source snapshot.
 
 `forkCommunityListing` reads the KV snapshot, rewrites `package.json` name/kody
 id to the forker's scope, scans cross-scope references, calls

--- a/docs/guides/package-authoring.md
+++ b/docs/guides/package-authoring.md
@@ -4,8 +4,9 @@ title: Package authoring guide
 summary:
   START HERE when creating or materially changing a Kody package: package
   shape, README.md Intent section, per-export JSDoc (search Purpose),
-  secret-using package approval checklist, and scope-update guidance
-  without adding new primitives.
+  personal-details hygiene before going public, secret-using package
+  approval checklist, and scope-update guidance without adding new
+  primitives.
 category: platform
 ---
 
@@ -206,7 +207,31 @@ New packages are always **private**. Visibility is a repo setting
   package appears on `/community`.
 - Private is owner-only. Going private 404s public URLs; existing forks keep
   their copies. Type the package slug to confirm (`confirm_name` for agents).
-- There are no MIT, logo, or README Intent gates to become public.
+- There are no MIT, logo, or README Intent **platform** gates to become public.
+  Agents still run a personal-details hygiene pass before flipping public
+  (below). The Worker does not scan or block on that review.
+
+### Personal-details hygiene before going public
+
+Before calling `packageUpdate` with `changes.visibility: "public"` or
+`communityPublish`, review source, README, Intent, description, tags, examples,
+and hardcoded identifiers for overly personal material.
+
+Treat as personal or too household-specific:
+
+- home addresses, private emails, phone numbers, family names
+- personal Discord or channel IDs
+- private calendar habits
+- one-off personal automation that only makes sense for one household
+- secrets, tokens, and internal-only URLs
+
+If the package is clean, proceed.
+
+If anything looks personal or hyper-specific to one person or household, **do
+not publish yet**. Tell the user what you found. Suggest how to generalize:
+parameterize identifiers, use secrets or integrations instead of hardcoded
+credentials, rename examples, strip PII, and keep a private fork for personal
+wiring. Wait for explicit go-ahead before flipping public.
 
 ## Work that does not fit a Worker isolate
 

--- a/docs/guides/package-lifecycle.md
+++ b/docs/guides/package-lifecycle.md
@@ -84,10 +84,11 @@ Deferred one-shot work uses `workflows.create({ runAt })` from `execute` or
 package runtime. See [Workflows](../use/workflows.md).
 
 Use `guide: "package_authoring"` for package shape, README `## Intent`,
-per-export JSDoc (search Purpose), visibility guidance, and the secret-using
-package approval checklist (`pending_secret_package_approvals` is non-null only
-for unadopted community-forked packages; prefer `communityForkAdopt` after
-review, or bulk approval URLs when present).
+per-export JSDoc (search Purpose), visibility guidance (personal-details hygiene
+before going public), and the secret-using package approval checklist
+(`pending_secret_package_approvals` is non-null only for unadopted
+community-forked packages; prefer `communityForkAdopt` after review, or bulk
+approval URLs when present).
 
 When the OAuth token is coarser than the intended export — Gmail can send
 whenever it can create a draft — publish a thin package that only performs the

--- a/docs/use/community-packages.md
+++ b/docs/use/community-packages.md
@@ -30,14 +30,20 @@ Ask your agent to set visibility with `packageUpdate`
 (`changes.visibility: "public"`). `communityPublish` is an alias for the same
 action.
 
-There are **no** MIT, logo, README Intent, or `package.json#private` gates.
-Tags, description, category, and an icon are optional (ranking can prefer
-filled-in cards).
+There are **no** MIT, logo, README Intent, or `package.json#private`
+**platform** gates. Tags, description, category, and an icon are optional
+(ranking can prefer filled-in cards). Agents still review the package for overly
+personal content before flipping public — see
+[Personal-details hygiene](../guides/package-authoring.md#personal-details-hygiene-before-going-public)
+in the package authoring guide. If anything looks personal or
+household-specific, the agent stops, tells you what it found, suggests how to
+generalize, and waits for explicit go-ahead. The Worker does not scan or block
+on that review.
 
 - New packages are always created **private**.
-- Making a package **public** lists it on `/community`. Type the package slug to
-  confirm (`confirm_name` for agents). Anyone can then read and fork the default
-  branch.
+- Making a package **public** lists it on `/community`. Anyone can then read and
+  fork the default branch. On the website, type the package slug to confirm.
+  Agents do not pass `confirm_name` for public; they run the hygiene pass first.
 - Making a package **private** unlists it: public URLs 404; existing forks keep
   their copies. Type the package slug to confirm (`confirm_name` for agents).
 - Deleting a package (`packageDelete` or **Delete package** on the package page)
@@ -231,7 +237,8 @@ rating, or reporting community listings.
 Use the MCP `community` domain:
 
 - `communityPublish` — alias for making a saved package public (prefer
-  `packageUpdate` with `changes.visibility: "public"`)
+  `packageUpdate` with `changes.visibility: "public"`; review personal details
+  first)
 - `communityUnpublish` — make a package private / unlist it (prefer
   `packageUpdate` with `changes.visibility: "private"` and `confirm_name`)
 - `packageDelete` — permanently delete a saved package (type the package name;

--- a/packages/worker/client/routes/account-package-owner-details.tsx
+++ b/packages/worker/client/routes/account-package-owner-details.tsx
@@ -190,7 +190,7 @@ export function AccountPackageOwnerDetails(
 				>
 					<p mix={css({ margin: 0, color: colors.textMuted })}>
 						{packageDetail.isPrivate
-							? 'Making this package public lists it on /community. Anyone can read and fork the default branch. Type the slug to confirm.'
+							? 'Making this package public lists it on /community. Anyone can read and fork the default branch. Skim source, README, and examples for personal details first, then type the slug to confirm.'
 							: 'Making this package private unlists it from /community and 404s public URLs. Existing forks keep their copies. Type the slug to confirm.'}
 					</p>
 					<label mix={css({ display: 'grid', gap: spacing.xs })}>

--- a/packages/worker/src/mcp/capabilities/community/publish.ts
+++ b/packages/worker/src/mcp/capabilities/community/publish.ts
@@ -17,7 +17,7 @@ export const communityPublishCapability = defineDomainCapability(
 	{
 		name: 'communityPublish',
 		description:
-			'Make a saved package public: default-branch HEAD becomes world-readable and forkable, and the package appears on /community. Prefer packageUpdate with changes.visibility: "public". No license, logo, or Intent gates. Runtime still uses published_commit. Listings owned by anyone are third-party code — review before forking.',
+			'Make a saved package public: default-branch HEAD becomes world-readable and forkable, and the package appears on /community. Prefer packageUpdate with changes.visibility: "public". Before calling, review the package for overly personal content (package_authoring visibility). If anything looks personal, stop, tell the user, suggest generalizing, and wait for explicit go-ahead. No license, logo, or Intent platform gates. Runtime still uses published_commit. Listings owned by anyone are third-party code — review before forking.',
 		keywords: [
 			'community',
 			'publish',

--- a/packages/worker/src/mcp/capabilities/packages/package-update.ts
+++ b/packages/worker/src/mcp/capabilities/packages/package-update.ts
@@ -42,7 +42,7 @@ const packageUpdateChangesSchema = z
 			.enum(['public', 'private'])
 			.optional()
 			.describe(
-				'Repo visibility. Public means default-branch HEAD is world-readable and forkable and the package appears on /community. Private is owner-only. Changing to private unlists the catalog entry; existing forks keep their copies.',
+				'Repo visibility. Public means default-branch HEAD is world-readable and forkable and the package appears on /community. Before setting public, review the package for overly personal content (package_authoring visibility). If anything looks personal, stop, tell the user, suggest generalizing, and wait for explicit go-ahead. Private is owner-only. Changing to private unlists the catalog entry; existing forks keep their copies.',
 			),
 	})
 	.refine(
@@ -60,7 +60,7 @@ export const packageUpdateCapability = defineDomainCapability(
 	{
 		name: 'packageUpdate',
 		description:
-			'Update mutable settings for a saved package: hidden search-discovery, publish lock (`changes.locked: true`; agents cannot unlock), and repo visibility (`changes.visibility`). Making a package public lists it on /community with full source and fork. Making it private unlists it (public URLs 404; forks keep their copies) — pass confirm_name matching the package slug after the owner typed that name. Canonical package metadata such as name, description, and tags remains derived from package.json. Visibility is not package.json#private.',
+			'Update mutable settings for a saved package: hidden search-discovery, publish lock (`changes.locked: true`; agents cannot unlock), and repo visibility (`changes.visibility`). Making a package public lists it on /community with full source and fork. Before setting visibility public, review source, README, Intent, description, tags, examples, and hardcoded identifiers for overly personal material. If anything looks personal or household-specific, do not publish yet — tell the user what you found, suggest how to generalize, and wait for explicit go-ahead. No MIT, logo, or Intent platform gates. Making it private unlists it (public URLs 404; forks keep their copies) — pass confirm_name matching the package slug after the owner typed that name. Canonical package metadata such as name, description, and tags remains derived from package.json. Visibility is not package.json#private.',
 		keywords: [
 			'package',
 			'update',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Agents about to make a Kody package public should review it for overly personal content and, if anything looks personal, stop and confirm with the user — with a concrete suggestion to generalize — instead of a new platform gate.

## Why

Public packages are world-readable and forkable. There is no MIT, logo, or Intent **platform** gate, and there should not be a personal-content scanner either. Agents already load `package_authoring` and capability detail before calling `packageUpdate` / `communityPublish`; that is the right place for a progressive hygiene pass.

## Summary

- Extend `package_authoring` visibility with a personal-details hygiene section (what to review, when to proceed, when to stop and confirm).
- Same protocol in `packageUpdate` (visibility public) and `communityPublish` descriptions. `confirm_name` for going **private** is unchanged. No new confirm field for public.
- Short settings-page hint on the existing Make public control. No new modal.
- Usage and contributing community docs keep “no MIT/logo/Intent gates” true for platform enforcement and point agents at the hygiene pass.

## Testing

- Pre-commit: format, lint, typecheck, migrations check
- Pre-push: `test:node` (2599) and `test:workers` (327)
- `npm run validate` running after this PR opens

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `6d4a0350` · **Head:** `be92880f`

**Classification:** composes — no primitives added or changed; this PR adds a
soft agent hygiene protocol in existing guide and capability descriptions.

### Primitives touched

| Primitive            | Group     | Impact                                                           |
| -------------------- | --------- | ---------------------------------------------------------------- |
| `saved-packages`     | assistant | composes — `packageUpdate` description and visibility field text |
| `community-listings` | assistant | composes — `communityPublish` description text                   |
| `app-ui`             | surfaces  | composes — settings make-public hint                             |

Unmatched docs: `package_authoring` visibility section, usage community publish
docs, package lifecycle pointer, contributing note that the Worker does not
scan personal content.

### Change flow

An agent about to flip a package public reviews it for personal details, then
either publishes or stops for explicit user go-ahead. Platform publish stays
ungated.

```mermaid
sequenceDiagram
	actor User
	actor Agent
	participant savedPackages as saved-packages
	participant communityListings as community-listings
	User->>Agent: make this package public
	Agent->>savedPackages: load packageUpdate or communityPublish detail
	Note over Agent: package_authoring personal-details hygiene pass
	alt anything looks personal or household-specific
		Agent->>User: report findings and suggest generalizing
		User->>Agent: explicit go-ahead
	end
	Agent->>savedPackages: packageUpdate visibility public
	savedPackages->>communityListings: publish listing, no new platform gate
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e2a034b2-00ca-4786-a341-32f883440bbf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e2a034b2-00ca-4786-a341-32f883440bbf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified public package visibility requirements and optional platform metadata.
  - Added guidance to review source, documentation, examples, tags, and identifiers for personal or household-specific information before publishing.
  - Added instructions to generalize or remove sensitive details and obtain explicit approval before making a package public.
  - Documented that automated workers do not perform or block on this hygiene review.

- **User Experience**
  - Added a personal-details warning to the confirmation shown when making a private package public.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->