### PR TITLE
Reserve Turnstile space to stop waitlist layout shift

### DIFF
--- a/docs/contributing/weekly-site-perf.md
+++ b/docs/contributing/weekly-site-perf.md
@@ -77,9 +77,10 @@ Auth, OAuth, and account pages never use the short CDN cache.
 
 Landing layout CSS lives in `packages/worker/public/styles.css` (`.landing-*`)
 so SSR does not emit a Remix style tag per marketing node. Hero and below-fold
-art ship `srcset` variants. The homepage waitlist loads Turnstile only when the
-form is near the viewport. Login, signup, and verify still load the widget
-immediately.
+art ship `srcset` variants. The homepage waitlist loads the Turnstile script
+only when the form is near the viewport, but the first HTML already reserves the
+300×65 host so that deferred paint cannot shift the invite section. Login,
+signup, and verify still load the widget immediately.
 
 ## Budget
 

--- a/packages/worker/client/public-form-protection.node.test.ts
+++ b/packages/worker/client/public-form-protection.node.test.ts
@@ -1,9 +1,26 @@
+import { readFileSync } from 'node:fs'
 import { expect, test, vi } from 'vitest'
 import {
 	readPublicFormProtection,
 	renderTurnstileWidgets,
 	resetTurnstileWidgets,
+	turnstileWidgetHeightPx,
+	turnstileWidgetWidthPx,
 } from '#client/public-form-protection.ts'
+
+test('styles.css reserves the managed Turnstile box and centers it on the landing waitlist', () => {
+	const css = readFileSync(
+		new URL('../public/styles.css', import.meta.url),
+		'utf8',
+	)
+	const hostBlock = css.match(/\.kody-turnstile\s*\{([^}]+)\}/)?.[1]
+	expect(hostBlock).toContain(`height: ${turnstileWidgetHeightPx}px`)
+	expect(hostBlock).toContain(`min-height: ${turnstileWidgetHeightPx}px`)
+	expect(hostBlock).toContain(`width: min(${turnstileWidgetWidthPx}px, 100%)`)
+	expect(css).toMatch(
+		/\.landing-waitlist \.kody-turnstile\s*\{[^}]*justify-self:\s*center/s,
+	)
+})
 
 type FakeContainer = HTMLElement & {
 	dataset: DOMStringMap & {

--- a/packages/worker/client/public-form-protection.ts
+++ b/packages/worker/client/public-form-protection.ts
@@ -14,6 +14,13 @@ export {
 
 export const turnstileWidgetClassName = 'kody-turnstile'
 
+/**
+ * Cloudflare's managed widget box. Keep `.kody-turnstile` in
+ * `packages/worker/public/styles.css` in sync with these values.
+ */
+export const turnstileWidgetWidthPx = 300
+export const turnstileWidgetHeightPx = 65
+
 type TurnstileApi = {
 	render(
 		container: HTMLElement,
@@ -119,8 +126,7 @@ function ensureTurnstileMount(container: HTMLElement) {
 	if (!root.querySelector('style[data-turnstile-host]')) {
 		const style = document.createElement('style')
 		style.dataset.turnstileHost = ''
-		style.textContent =
-			':host{display:block;min-height:65px;width:min(300px,100%)}[data-turnstile-mount]{min-height:65px}'
+		style.textContent = `:host{display:block;box-sizing:border-box;flex-shrink:0;height:${turnstileWidgetHeightPx}px;min-height:${turnstileWidgetHeightPx}px;width:min(${turnstileWidgetWidthPx}px,100%)}[data-turnstile-mount]{height:${turnstileWidgetHeightPx}px;min-height:${turnstileWidgetHeightPx}px}`
 		root.append(style)
 	}
 	const mount = document.createElement('div')

--- a/packages/worker/client/routes/landing-waitlist-form.node.test.ts
+++ b/packages/worker/client/routes/landing-waitlist-form.node.test.ts
@@ -8,4 +8,5 @@ test('landing waitlist idle announcer is a status region without invalid fields'
 	expect(html).toContain('role="status"')
 	expect(html).not.toContain('aria-invalid')
 	expect(html).toContain('-waitlist-status')
+	expect(html).toContain('kody-turnstile')
 })

--- a/packages/worker/client/routes/landing-waitlist-form.tsx
+++ b/packages/worker/client/routes/landing-waitlist-form.tsx
@@ -244,7 +244,14 @@ export function WaitlistForm(handle: Handle) {
 								</span>
 							</button>
 						</div>
-						{protectionArmed && turnstileSiteKey ? (
+						{/*
+						 * Reserve the managed widget box from first paint, even
+						 * before the form is near the viewport and before the
+						 * site key arrives. The challenge script still loads
+						 * lazily; only the empty 300×65 host is in the HTML.
+						 * `null` means Turnstile is off.
+						 */}
+						{turnstileSiteKey !== null ? (
 							<div class={turnstileWidgetClassName}></div>
 						) : null}
 						{status === 'error' && message ? (

--- a/packages/worker/client/waitlist-banner.node.test.ts
+++ b/packages/worker/client/waitlist-banner.node.test.ts
@@ -8,4 +8,5 @@ test('waitlist banner idle announcer is a status region without invalid fields',
 	expect(html).toContain('role="status"')
 	expect(html).not.toContain('aria-invalid')
 	expect(html).toContain('-waitlist-status')
+	expect(html).toContain('kody-turnstile')
 })

--- a/packages/worker/client/waitlist-banner.node.test.ts
+++ b/packages/worker/client/waitlist-banner.node.test.ts
@@ -10,3 +10,15 @@ test('waitlist banner idle announcer is a status region without invalid fields',
 	expect(html).toContain('-waitlist-status')
 	expect(html).toContain('kody-turnstile')
 })
+
+test('waitlist banner form wraps so Turnstile can drop under the pill', async () => {
+	const html = await renderToString(jsx(WaitlistBanner, {}))
+	const formClass = html.match(/<form class="([^"]+)"/)?.[1]?.split(/\s+/)[0]
+	expect(formClass).toBeTruthy()
+	const formRule = html.match(
+		new RegExp(
+			`\\.${formClass.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')} \\{([^}]+)\\}`,
+		),
+	)?.[1]
+	expect(formRule).toMatch(/flex-wrap:\s*wrap/)
+})

--- a/packages/worker/client/waitlist-banner.tsx
+++ b/packages/worker/client/waitlist-banner.tsx
@@ -203,7 +203,10 @@ export function WaitlistBanner(handle: Handle) {
 								 * CLS the strip when it arrives. `null` means it is off.
 								 */}
 								{turnstileSiteKey !== null ? (
-									<div class={turnstileWidgetClassName}></div>
+									<div
+										class={turnstileWidgetClassName}
+										mix={css(bannerTurnstileCss)}
+									></div>
 								) : null}
 							</form>
 							{/*
@@ -243,7 +246,7 @@ const pillPadding = '0.25rem'
 const stackMq = '@media (max-width: 720px)'
 
 const bannerPaddingY = '0.55rem'
-const bannerStackPaddingY = '0.7rem'
+const bannerStackPaddingY = '0.85rem'
 
 const bannerCss = {
 	width: '100%',
@@ -298,6 +301,13 @@ const promptCss = {
 	},
 }
 
+const bannerTurnstileCss = {
+	flex: '0 0 auto',
+	[stackMq]: {
+		alignSelf: 'center',
+	},
+}
+
 const formCss = {
 	display: 'flex',
 	alignItems: 'center',
@@ -307,7 +317,11 @@ const formCss = {
 	margin: 0,
 	minWidth: 0,
 	[stackMq]: {
+		/* Phone: the 300px widget must not sit beside the pill. Column plus a
+		   full-width pill puts Turnstile on its own centered row. */
 		width: '100%',
+		flexDirection: 'column' as const,
+		alignItems: 'center',
 	},
 }
 
@@ -315,7 +329,11 @@ const pillCss = {
 	display: 'grid',
 	gridTemplateColumns: 'minmax(0, 8.5rem) minmax(0, 12rem) auto',
 	alignItems: 'stretch',
-	width: '100%',
+	/* Never shrink beside the 300px widget: wrap to the next flex line
+	   instead of truncating placeholders to "First n". */
+	flex: '1 0 auto',
+	width: 'auto',
+	maxWidth: '100%',
 	backgroundColor: colors.surface,
 	border: `1.5px solid ${colors.fieldBorder}`,
 	borderRadius: pillRadius,
@@ -329,6 +347,9 @@ const pillCss = {
 	[stackMq]: {
 		/* Two fields across, the button spanning beneath them: keeps the strip to
 		   two rows instead of three while every placeholder stays readable. */
+		alignSelf: 'stretch',
+		flex: '1 0 auto',
+		width: '100%',
 		gridTemplateColumns: '1fr 1fr',
 		borderRadius: pillStackRadius,
 		gap: pillPadding,

--- a/packages/worker/client/waitlist-banner.tsx
+++ b/packages/worker/client/waitlist-banner.tsx
@@ -312,7 +312,6 @@ const formCss = {
 	display: 'flex',
 	alignItems: 'center',
 	justifyContent: 'center',
-	flexWrap: 'wrap' as const,
 	gap: spacing.sm,
 	margin: 0,
 	minWidth: 0,
@@ -322,6 +321,7 @@ const formCss = {
 		width: '100%',
 		flexDirection: 'column' as const,
 		alignItems: 'center',
+		gap: spacing.md,
 	},
 }
 

--- a/packages/worker/client/waitlist-banner.tsx
+++ b/packages/worker/client/waitlist-banner.tsx
@@ -336,9 +336,10 @@ const pillCss = {
 	display: 'grid',
 	gridTemplateColumns: 'minmax(0, 8.5rem) minmax(0, 12rem) auto',
 	alignItems: 'stretch',
-	/* Never shrink beside the 300px widget: wrap to the next flex line
-	   instead of truncating placeholders to "First n". */
-	flex: '1 0 auto',
+	/* Do not shrink beside the 300px widget (that truncated "First name")
+	   and do not grow when wrap leaves the pill alone on a line — grow
+	   would dump leftover space into the Join column as a wide slab. */
+	flex: '0 0 auto',
 	width: 'auto',
 	maxWidth: '100%',
 	backgroundColor: colors.surface,

--- a/packages/worker/client/waitlist-banner.tsx
+++ b/packages/worker/client/waitlist-banner.tsx
@@ -7,7 +7,12 @@ import {
 	mergeCss,
 	pageGutter,
 } from '#universal/styles/style-primitives.ts'
-import { colors, transitions, typography } from '#universal/styles/tokens.ts'
+import {
+	colors,
+	spacing,
+	transitions,
+	typography,
+} from '#universal/styles/tokens.ts'
 import { fetchPublicAuthConfig } from '#client/social-sign-in.ts'
 import { renderHoneypot } from '#client/honeypot-field.tsx'
 import {
@@ -15,6 +20,7 @@ import {
 	renderTurnstileWidgets,
 	resetTurnstileWidgets,
 	turnstileWidgetClassName,
+	turnstileWidgetHeightPx,
 } from '#client/public-form-protection.ts'
 import {
 	fieldErrorProps,
@@ -191,7 +197,12 @@ export function WaitlistBanner(handle: Handle) {
 										{isSubmitting ? 'Joining…' : 'Join'}
 									</button>
 								</div>
-								{turnstileSiteKey ? (
+								{/*
+								 * `undefined` means the site key has not loaded yet:
+								 * still paint the empty 300×65 host so Turnstile cannot
+								 * CLS the strip when it arrives. `null` means it is off.
+								 */}
+								{turnstileSiteKey !== null ? (
 									<div class={turnstileWidgetClassName}></div>
 								) : null}
 							</form>
@@ -231,19 +242,27 @@ const pillPadding = '0.25rem'
    without truncating them to nonsense. */
 const stackMq = '@media (max-width: 720px)'
 
+const bannerPaddingY = '0.55rem'
+const bannerStackPaddingY = '0.7rem'
+
 const bannerCss = {
 	width: '100%',
 	margin: 0,
+	/* Floor is the managed Turnstile box plus vertical padding so the
+	   widget can load into a slot that already fits it. Wrapping (prompt
+	   above the pill on a phone) is still allowed to grow the strip. */
+	minHeight: `calc(${turnstileWidgetHeightPx}px + (${bannerPaddingY} * 2))`,
 	/* Deliberately shallow — this sits above the header on secondary pages and
 	   should read as a quiet strip, not a second hero. */
-	padding: `0.55rem ${pageGutter}`,
+	padding: `${bannerPaddingY} ${pageGutter}`,
 	borderBottom: `1px solid ${colors.border}`,
 	/* A whisper of the accent so the strip separates from the header without
 	   competing with it. */
 	backgroundColor: colors.primarySoftest,
 	boxSizing: 'border-box' as const,
 	[stackMq]: {
-		padding: `0.7rem ${pageGutter}`,
+		padding: `${bannerStackPaddingY} ${pageGutter}`,
+		minHeight: `calc(${turnstileWidgetHeightPx}px + (${bannerStackPaddingY} * 2))`,
 	},
 }
 
@@ -281,7 +300,10 @@ const promptCss = {
 
 const formCss = {
 	display: 'flex',
-	alignItems: 'stretch',
+	alignItems: 'center',
+	justifyContent: 'center',
+	flexWrap: 'wrap' as const,
+	gap: spacing.sm,
 	margin: 0,
 	minWidth: 0,
 	[stackMq]: {

--- a/packages/worker/client/waitlist-banner.tsx
+++ b/packages/worker/client/waitlist-banner.tsx
@@ -310,11 +310,16 @@ const bannerTurnstileCss = {
 
 const formCss = {
 	display: 'flex',
+	/* Wrap, do not nowrap: the pill refuses to shrink (`flex: 1 0 auto`) and
+	   the widget is a fixed 300px. Without wrap, that row overflows between
+	   the phone column breakpoint and ~800px (iPad portrait). */
+	flexWrap: 'wrap' as const,
 	alignItems: 'center',
 	justifyContent: 'center',
 	gap: spacing.sm,
 	margin: 0,
 	minWidth: 0,
+	maxWidth: '100%',
 	[stackMq]: {
 		/* Phone: the 300px widget must not sit beside the pill. Column plus a
 		   full-width pill puts Turnstile on its own centered row. */

--- a/packages/worker/client/waitlist-banner.tsx
+++ b/packages/worker/client/waitlist-banner.tsx
@@ -21,6 +21,7 @@ import {
 	resetTurnstileWidgets,
 	turnstileWidgetClassName,
 	turnstileWidgetHeightPx,
+	turnstileWidgetWidthPx,
 } from '#client/public-form-protection.ts'
 import {
 	fieldErrorProps,
@@ -310,16 +311,17 @@ const bannerTurnstileCss = {
 
 const formCss = {
 	display: 'flex',
-	/* Wrap, do not nowrap: the pill refuses to shrink (`flex: 1 0 auto`) and
-	   the widget is a fixed 300px. Without wrap, that row overflows between
-	   the phone column breakpoint and ~800px (iPad portrait). */
+	/* Wrap children when the inner is narrower than pill + 300px widget.
+	   min-width prefers moving this form onto the next banner line over
+	   shrinking beside the prompt and overflowing (or stacking on desktop). */
 	flexWrap: 'wrap' as const,
 	alignItems: 'center',
 	justifyContent: 'center',
 	gap: spacing.sm,
 	margin: 0,
-	minWidth: 0,
+	width: 'max-content',
 	maxWidth: '100%',
+	minWidth: `min(100%, calc(${turnstileWidgetWidthPx}px + 26.5rem))`,
 	[stackMq]: {
 		/* Phone: the 300px widget must not sit beside the pill. Column plus a
 		   full-width pill puts Turnstile on its own centered row. */

--- a/packages/worker/public/styles.css
+++ b/packages/worker/public/styles.css
@@ -2050,14 +2050,24 @@ html.is-settled {
 }
 
 /*
- * Cloudflare's managed Turnstile widget is 300×65. Reserve that box on
- * every `.kody-turnstile` host so the first iframe paint and later Remix
- * re-renders cannot collapse the form.
+ * Cloudflare's managed Turnstile widget is 300×65. Reserve that exact box
+ * on every `.kody-turnstile` host from first paint so the iframe cannot
+ * shift the form, banner, or the homepage invite section. Keep these
+ * numbers in sync with `turnstileWidgetWidthPx` / `turnstileWidgetHeightPx`
+ * in public-form-protection.ts.
  */
 .kody-turnstile {
 	display: block;
-	min-height: 65px;
+	box-sizing: border-box;
+	flex-shrink: 0;
 	width: min(300px, 100%);
+	height: 65px;
+	min-height: 65px;
+}
+
+.landing-waitlist .kody-turnstile {
+	justify-self: center;
+	margin-inline: auto;
 }
 
 .landing-waitlist {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop Cloudflare Turnstile from shoving the waitlist banner and homepage invite section around when the widget loads, including on a phone or tablet.

## Why

The managed widget is 300×65, but both waitlist forms waited until the site key (and, on the homepage, a near-viewport observer) before painting the host. That late insert is a layout shift: the banner grows, the homepage widget lands flush-left under the pill, and on a narrow viewport the 300px box sits beside the form and crushes the fields into "First n". Reserving the box on first paint, stacking it under a full-width pill on phones, wrapping the banner form so the widget can drop under the pill on tablet widths, keeping the widget beside the pill on wide screens, and centering the homepage host keeps the layout stable even when the iframe arrives later.

## Summary

- Site-wide waitlist banner paints an empty 300×65 host from SSR, with a min-height that already fits the widget and a small gap before it.
- The banner form uses `flex-wrap` plus a min-width of the pill + 300px widget, so the form moves onto its own banner line instead of overflowing beside the prompt. Children wrap when the full inner is narrower than that row (about 768px / iPad portrait).
- The pill does not grow when it is alone on a wrapped line, so the Join button stays compact instead of stretching into a slab.
- Below 720px the banner form is a column: full-width pill, then a centered Turnstile with a 1rem gap. The pill no longer shrinks beside the widget.
- On wide screens the widget stays beside the pill when both fit, with `spacing.sm` gap.
- Homepage invite form reserves the same host from first paint (script still loads only when the form is near the viewport) and centers it under the pill.
- `.kody-turnstile` is a fixed 300×65 box; shadow-mount CSS stays in sync with exported size constants.

## Testing

- `vitest` node-unit: waitlist banner, landing waitlist form, and public-form-protection tests. Banner SSR HTML asserts the form rule includes `flex-wrap: wrap`.
- `test:push` (node-unit + workers-unit) on push.
- Local `CLOUDFLARE_ENV=test` origin at `/support` with a 300×65 host present:
  - 390×844: column, widget under the pill, first-name 161px, no overflow.
  - 768×1024: widget under the pill, pill 402px, Join 64px, `formOverflow` 0.
  - 800×1024 and 1280×800: widget beside the pill with 8px gap, Join 64px, no overflow.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `8c2195c4` · **Head:** `9b1b42ce`

**Classification:** composes — no primitives added or changed; this PR reserves layout space on existing waitlist UI, stacks the banner widget on phones, and wraps the banner form so the widget cannot overflow on tablet widths.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `app-ui` | surfaces | composes — waitlist banner and homepage invite form reserve the Turnstile host on first paint, the banner stacks the widget under the pill below 720px, and the banner form wraps so the 300px widget cannot overflow on tablet widths |

Unmatched paths: `packages/worker/public/styles.css` (landing `.kody-turnstile` box and homepage centering) and `docs/contributing/weekly-site-perf.md` (deferred-script note).

### Change flow

Signed-out waitlist HTML paints a reserved 300×65 host. The Turnstile iframe later fills that box instead of inserting a new row. On a phone the banner form is a column so the widget cannot crush the fields. On a tablet the form wraps so the widget drops under the pill instead of overflowing. On a wide screen the form keeps the widget beside the pill.

```mermaid
sequenceDiagram
	actor Visitor
	participant appUi as app-ui
	Visitor->>appUi: GET marketing page
	appUi->>appUi: SSR empty 300x65 kody-turnstile host
	Note over appUi: banner min-height fits the widget, homepage host is centered
	Note over appUi: below 720px banner form is a column
	Note over appUi: banner form wraps so the 300px widget can drop under the pill
	appUi-->>Visitor: HTML with reserved slot
	Visitor->>appUi: Turnstile script after config or near-viewport
	appUi->>appUi: iframe paints inside reserved box
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a3e24bda-9713-4463-9b19-ab8f5d7ea34d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a3e24bda-9713-4463-9b19-ab8f5d7ea34d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Reserved a consistent 300×65px space for Turnstile verification widgets.
  - Improved waitlist banner layout across desktop and mobile screen sizes.
  - Centered verification areas and allowed them to wrap cleanly on narrower screens.
  - Verification scripts continue loading only when forms approach the viewport.

- **Documentation**
  - Clarified homepage performance behavior, including deferred verification loading and reserved layout space.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->