### PR TITLE
Eager onboarding SSR, chip prefetch, and mobile testimonial hide

### DIFF
--- a/packages/worker/client/client-router.node.test.ts
+++ b/packages/worker/client/client-router.node.test.ts
@@ -7,6 +7,7 @@ import {
 	navigate,
 	navigationTimeoutMs,
 	persistentShellNavSelector,
+	prefetchRouteHrefs,
 	registerClientRoutes,
 	registerRouteLoaders,
 	Router,
@@ -15,6 +16,10 @@ import {
 	shouldUseViewTransition,
 	type RouteLoader,
 } from './client-router.tsx'
+import {
+	abortIntentPrefetch,
+	takePrefetchedRouteResult,
+} from './intent-prefetch.ts'
 import { communityArea } from './lazy-route.tsx'
 import { routePattern } from '#universal/route-pattern.ts'
 import { routes } from '#universal/routes.ts'
@@ -416,6 +421,59 @@ test('a navigation that exceeds the timeout falls back to a full document naviga
 		registerRouteLoaders({})
 		vi.clearAllTimers()
 		vi.useRealTimers()
+		globalThis.window = previousWindow
+	}
+})
+
+test('prefetchRouteHrefs warms every registered destination so click skips a cold loader', async () => {
+	abortIntentPrefetch()
+	const previousWindow = globalThis.window
+	globalThis.window = {
+		location: {
+			href: 'https://kody.local/onboarding/step-2',
+			origin: 'https://kody.local',
+			pathname: '/onboarding/step-2',
+			search: '',
+			hash: '',
+		},
+	} as unknown as Window & typeof globalThis
+
+	const calls: Array<string> = []
+	const payload = { onboarding: { ok: true } as never }
+	const loader: RouteLoader = async (url) => {
+		calls.push(`${url.pathname}${url.search}`)
+		return payload
+	}
+	registerRouteLoaders({
+		[routePattern(routes.onboardingStep2Service)]: loader,
+		[routePattern(routes.onboardingStep1Agent)]: loader,
+	})
+
+	try {
+		prefetchRouteHrefs([
+			'/onboarding/step-2',
+			'/onboarding/step-2/notion',
+			'/onboarding/step-2/linear',
+			'/onboarding/step-1/cursor',
+			'/community',
+		])
+		expect(calls).toEqual(['/onboarding/step-2/notion'])
+		await Promise.resolve()
+
+		const notion = takePrefetchedRouteResult('/onboarding/step-2/notion')
+		expect(notion).not.toBeNull()
+		await expect(notion).resolves.toEqual(payload)
+		expect(
+			takePrefetchedRouteResult('/onboarding/step-2/linear'),
+		).not.toBeNull()
+		expect(
+			takePrefetchedRouteResult('/onboarding/step-1/cursor'),
+		).not.toBeNull()
+		expect(takePrefetchedRouteResult('/community')).toBeNull()
+		expect(calls).toHaveLength(1)
+	} finally {
+		abortIntentPrefetch()
+		registerRouteLoaders({})
 		globalThis.window = previousWindow
 	}
 })

--- a/packages/worker/client/client-router.tsx
+++ b/packages/worker/client/client-router.tsx
@@ -2,11 +2,13 @@ import { type Handle } from 'remix/ui'
 import { createMultiMatcher } from 'remix/route-pattern/match'
 import { type AppLoaderData } from '#universal/loader-data.ts'
 import { isOnboardingPagePath } from '#universal/onboarding-process.ts'
+import { clearOnboardingPayloadCache } from '#client/routes/onboarding-payload.ts'
 import { applyDocumentHead } from './document-head.ts'
 import { installFileDropNavigationGuard } from './file-drop-navigation.ts'
 import {
 	abortIntentPrefetch,
 	prefetchRouteOnIntent,
+	prefetchRoutesOnRender,
 	takePrefetchedRouteResult,
 } from './intent-prefetch.ts'
 import {
@@ -455,6 +457,57 @@ function runIntentPrefetch(destination: URL) {
 }
 
 /**
+ * Render prefetch for a list of same-origin hrefs. Destinations that share a
+ * loader share one request. Remix 3 in this repo has no `<Link prefetch>` —
+ * this is the client-router equivalent of `prefetch="render"`.
+ */
+export function prefetchRouteHrefs(hrefs: ReadonlyArray<string>): void {
+	const groups = new Map<RouteLoader, Array<string>>()
+	const seen = new Set<string>()
+	const currentPath = getCurrentPathWithSearchAndHash()
+
+	for (const href of hrefs) {
+		const destination = new URL(href, prefetchBaseHref())
+		if (
+			typeof window !== 'undefined' &&
+			destination.origin !== window.location.origin
+		) {
+			continue
+		}
+		const destinationPath = getPathWithSearchAndHashFromUrl(destination)
+		if (seen.has(destinationPath)) continue
+		seen.add(destinationPath)
+		if (destinationPath === currentPath) continue
+		if (destinationPath === activeNavigationPath) continue
+		void preloadClientRouteModules(
+			`${destination.pathname}${destination.search}`,
+		).catch(() => {
+			// Speculative; navigation handles real failures.
+		})
+		const loader = matchRouteLoader(destination)
+		if (!loader) continue
+		const group = groups.get(loader) ?? []
+		group.push(destinationPath)
+		groups.set(loader, group)
+	}
+
+	for (const [loader, groupHrefs] of groups) {
+		prefetchRoutesOnRender(
+			groupHrefs,
+			loader,
+			(href) => new URL(href, prefetchBaseHref()),
+		)
+	}
+}
+
+function prefetchBaseHref() {
+	if (typeof window !== 'undefined' && window.location?.href) {
+		return window.location.href
+	}
+	return clientRouteOrigin
+}
+
+/**
  * Hovers shorter than this are treated as the mouse passing through, not
  * intent to navigate, so sweeping across a nav list does not fire a
  * speculative request per link crossed.
@@ -839,6 +892,7 @@ async function submitFormThroughRouter(details: FormSubmitDetails) {
 	// navigation — including a hover timer that has not fired yet.
 	cancelHoverIntent()
 	abortIntentPrefetch()
+	clearOnboardingPayloadCache()
 
 	// Participate in the latest-wins navigation chain: a newer navigation
 	// aborts this submission's follow-up redirect navigation so a late

--- a/packages/worker/client/intent-prefetch.node.test.ts
+++ b/packages/worker/client/intent-prefetch.node.test.ts
@@ -3,6 +3,7 @@ import {
 	abortIntentPrefetch,
 	maxPrefetchAgeMs,
 	prefetchRouteOnIntent,
+	prefetchRoutesOnRender,
 	takePrefetchedRouteResult,
 } from './intent-prefetch.ts'
 import { type RouteLoader, routeLoaderRedirect } from './route-loader.ts'
@@ -124,4 +125,52 @@ test('settled intent prefetches expire and restart on the next intent', async ()
 
 	abortIntentPrefetch()
 	vi.useRealTimers()
+})
+
+test('render prefetch keeps every chip warm so click adopts without a cold loader', async () => {
+	abortIntentPrefetch()
+	const deferred = createDeferredLoader()
+	prefetchRoutesOnRender(
+		[
+			'/onboarding/step-2/notion',
+			'/onboarding/step-2/linear',
+			'/onboarding/step-2/not-listed',
+		],
+		deferred.loader,
+	)
+	expect(deferred.calls).toHaveLength(1)
+
+	prefetchRoutesOnRender(
+		['/onboarding/step-2/notion', '/onboarding/step-2/linear'],
+		deferred.loader,
+	)
+	expect(deferred.calls).toHaveLength(1)
+
+	const payload = { onboarding: { ok: true } as never }
+	deferred.resolve(payload)
+	await Promise.resolve()
+
+	expect(takePrefetchedRouteResult('/onboarding/step-2/github')).toBeNull()
+	expect(deferred.calls).toHaveLength(1)
+
+	const notion = takePrefetchedRouteResult('/onboarding/step-2/notion')
+	expect(notion).not.toBeNull()
+	await expect(notion).resolves.toEqual(payload)
+	expect(takePrefetchedRouteResult('/onboarding/step-2/notion')).toBeNull()
+	expect(deferred.calls).toHaveLength(1)
+
+	const linear = takePrefetchedRouteResult('/onboarding/step-2/linear')
+	expect(linear).not.toBeNull()
+	await expect(linear).resolves.toEqual(payload)
+	expect(deferred.calls).toHaveLength(1)
+
+	prefetchRouteOnIntent(
+		'/onboarding/step-2/not-listed',
+		deferred.loader,
+		new URL('https://kody.local/onboarding/step-2/not-listed'),
+	)
+	expect(deferred.calls).toHaveLength(1)
+	expect(
+		takePrefetchedRouteResult('/onboarding/step-2/not-listed'),
+	).not.toBeNull()
 })

--- a/packages/worker/client/intent-prefetch.node.test.ts
+++ b/packages/worker/client/intent-prefetch.node.test.ts
@@ -1,6 +1,7 @@
 import { expect, test, vi } from 'vitest'
 import {
 	abortIntentPrefetch,
+	discardRenderPrefetches,
 	maxPrefetchAgeMs,
 	prefetchRouteOnIntent,
 	prefetchRoutesOnRender,
@@ -173,4 +174,18 @@ test('render prefetch keeps every chip warm so click adopts without a cold loade
 	expect(
 		takePrefetchedRouteResult('/onboarding/step-2/not-listed'),
 	).not.toBeNull()
+})
+
+test('discardRenderPrefetches drops chip snapshots so a later click cannot rewind', async () => {
+	abortIntentPrefetch()
+	const deferred = createDeferredLoader()
+	prefetchRoutesOnRender(
+		['/onboarding/step-2/notion', '/onboarding/step-2/linear'],
+		deferred.loader,
+	)
+	deferred.resolve({ onboarding: { ok: true } as never })
+	await Promise.resolve()
+	discardRenderPrefetches()
+	expect(takePrefetchedRouteResult('/onboarding/step-2/notion')).toBeNull()
+	expect(takePrefetchedRouteResult('/onboarding/step-2/linear')).toBeNull()
 })

--- a/packages/worker/client/intent-prefetch.ts
+++ b/packages/worker/client/intent-prefetch.ts
@@ -28,16 +28,69 @@ type PrefetchSlot = {
 	controller: AbortController
 	settledAt: number | null
 	failed: boolean
+	retainRequest: boolean
 }
 
 // Single slot: the latest intent wins, mirroring the router's latest-wins
 // navigation semantics and keeping at most one speculative request in flight.
 let slot: PrefetchSlot | null = null
 
+// Render prefetch: many destinations can stay warm at once (chip lists).
+// A new href does not abort siblings. Shared fetches set `retainRequest` so
+// adopting one destination cannot cancel the warmup the others still need.
+const renderSlots = new Map<string, PrefetchSlot>()
+
+function isUsablePrefetch(current: PrefetchSlot | null | undefined) {
+	if (!current || current.failed) return false
+	if (current.settledAt === null) return true
+	return monotonicNow() - current.settledAt <= maxPrefetchAgeMs
+}
+
+function attachSettleHandlers(records: ReadonlyArray<PrefetchSlot>) {
+	const [first] = records
+	if (!first) return
+	first.promise.then(
+		() => {
+			const settledAt = monotonicNow()
+			for (const record of records) record.settledAt = settledAt
+		},
+		() => {
+			const settledAt = monotonicNow()
+			for (const record of records) {
+				record.settledAt = settledAt
+				record.failed = true
+			}
+		},
+	)
+}
+
+function consumePrefetchSlot(
+	current: PrefetchSlot,
+	signal?: AbortSignal,
+): Promise<RouteLoaderResult> | null {
+	if (current.failed) return null
+	if (
+		current.settledAt !== null &&
+		monotonicNow() - current.settledAt > maxPrefetchAgeMs
+	) {
+		return null
+	}
+	// Shared render warmups must outlive one navigation: aborting the fetch
+	// would leave the remaining chip slots with a cancelled promise.
+	if (!current.retainRequest) {
+		signal?.addEventListener('abort', () => current.controller.abort(), {
+			once: true,
+		})
+	}
+	return current.promise
+}
+
 /**
  * Starts (or reuses) a speculative loader run for a link the user showed
  * intent for. Re-invoking for the same href while the previous run is in
  * flight or still fresh is a no-op; a different href aborts the previous run.
+ * A fresh render-prefetch for the same href is also a no-op — hover must not
+ * replace a list warmup that click still needs.
  */
 export function prefetchRouteOnIntent(
 	href: string,
@@ -45,14 +98,8 @@ export function prefetchRouteOnIntent(
 	url: URL,
 ): void {
 	const normalized = normalizePrefetchHref(href)
-	if (slot && slot.href === normalized && !slot.failed) {
-		if (
-			slot.settledAt === null ||
-			monotonicNow() - slot.settledAt <= maxPrefetchAgeMs
-		) {
-			return
-		}
-	}
+	if (isUsablePrefetch(renderSlots.get(normalized))) return
+	if (isUsablePrefetch(slot) && slot?.href === normalized) return
 
 	slot?.controller.abort()
 	const controller = new AbortController()
@@ -62,59 +109,102 @@ export function prefetchRouteOnIntent(
 		controller,
 		settledAt: null,
 		failed: false,
+		retainRequest: false,
 	}
 	slot = nextSlot
-	nextSlot.promise.then(
-		() => {
-			nextSlot.settledAt = monotonicNow()
-		},
-		() => {
-			nextSlot.settledAt = monotonicNow()
-			nextSlot.failed = true
-		},
-	)
+	attachSettleHandlers([nextSlot])
+}
+
+/**
+ * Warms many destinations at once so a rendered list can be click-ready.
+ * Destinations that share `loader` share one request — onboarding chips all
+ * hit the same payload. Already-fresh hrefs are left alone.
+ */
+export function prefetchRoutesOnRender(
+	hrefs: ReadonlyArray<string>,
+	loader: RouteLoader,
+	urlForHref: (href: string) => URL = (href) => new URL(href, routerHrefOrigin),
+): void {
+	const needed: Array<string> = []
+	const seen = new Set<string>()
+	for (const href of hrefs) {
+		const normalized = normalizePrefetchHref(href)
+		if (seen.has(normalized)) continue
+		seen.add(normalized)
+		if (isUsablePrefetch(renderSlots.get(normalized))) continue
+		if (isUsablePrefetch(slot) && slot?.href === normalized) continue
+		needed.push(normalized)
+	}
+	if (needed.length === 0) return
+
+	const firstHref = needed[0]
+	if (!firstHref) return
+	const controller = new AbortController()
+	const promise = loader(urlForHref(firstHref), controller.signal)
+	const records = needed.map((href) => {
+		const record: PrefetchSlot = {
+			href,
+			promise,
+			controller,
+			settledAt: null,
+			failed: false,
+			retainRequest: needed.length > 1,
+		}
+		renderSlots.set(href, record)
+		return record
+	})
+	attachSettleHandlers(records)
 }
 
 /**
  * Consumes the prefetched loader result for `href`. Returns the in-flight or
  * fresh settled promise, or `null` when there is no usable prefetch (wrong
  * href, expired, or failed — failures let the navigation retry the loader).
- * Consumption is one-shot. A mismatched href also aborts and clears the slot:
- * the user navigated somewhere other than the prefetched link, so the
- * speculative result must not survive to be adopted by a later navigation.
- * When `signal` aborts (a superseding navigation), a still-running prefetch
- * request is aborted with it.
+ * Consumption is one-shot per href. A hover-intent miss aborts that slot so
+ * it cannot be adopted later; other render-warmed destinations stay. When
+ * `signal` aborts a non-shared prefetch, the in-flight request is cancelled.
  */
 export function takePrefetchedRouteResult(
 	href: string,
 	signal?: AbortSignal,
 ): Promise<RouteLoaderResult> | null {
-	if (!slot) return null
-	if (slot.href !== normalizePrefetchHref(href)) {
-		abortIntentPrefetch()
-		return null
+	const normalized = normalizePrefetchHref(href)
+
+	if (slot && slot.href === normalized) {
+		const current = slot
+		slot = null
+		return consumePrefetchSlot(current, signal)
 	}
 
-	const current = slot
-	slot = null
-	if (current.failed) return null
-	if (
-		current.settledAt !== null &&
-		monotonicNow() - current.settledAt > maxPrefetchAgeMs
-	) {
-		return null
+	const rendered = renderSlots.get(normalized)
+	if (rendered) {
+		renderSlots.delete(normalized)
+		return consumePrefetchSlot(rendered, signal)
 	}
-	signal?.addEventListener('abort', () => current.controller.abort(), {
-		once: true,
-	})
-	return current.promise
+
+	// Navigating away from the hover-intent destination drops that slot so it
+	// cannot be adopted later. Render-warmed siblings stay — the list is still
+	// one click away.
+	if (slot) {
+		slot.controller.abort()
+		slot = null
+	}
+	return null
 }
 
 /**
- * Aborts and clears any pending intent prefetch. Called after form POST
- * mutations so speculative pre-mutation data is never shown, and by tests.
+ * Aborts and clears every speculative prefetch (hover-intent and render).
+ * Called after form POST mutations so pre-mutation data is never shown, and
+ * by tests.
  */
 export function abortIntentPrefetch(): void {
 	slot?.controller.abort()
 	slot = null
+	const aborted = new Set<AbortController>()
+	for (const record of renderSlots.values()) {
+		if (aborted.has(record.controller)) continue
+		aborted.add(record.controller)
+		record.controller.abort()
+	}
+	renderSlots.clear()
 }

--- a/packages/worker/client/intent-prefetch.ts
+++ b/packages/worker/client/intent-prefetch.ts
@@ -193,6 +193,15 @@ export function takePrefetchedRouteResult(
 }
 
 /**
+ * Drop render-prefetch snapshots without aborting in-flight requests.
+ * Live onboarding polls write a fresher `/onboarding.json` into the payload
+ * cache; chip clicks must not adopt the first-paint loader result after that.
+ */
+export function discardRenderPrefetches(): void {
+	renderSlots.clear()
+}
+
+/**
  * Aborts and clears every speculative prefetch (hover-intent and render).
  * Called after form POST mutations so pre-mutation data is never shown, and
  * by tests.

--- a/packages/worker/client/lazy-route.node.test.ts
+++ b/packages/worker/client/lazy-route.node.test.ts
@@ -19,6 +19,12 @@ const eagerPatterns = new Set([
 	routePattern(routes.home),
 	routePattern(routes.profile),
 	oauthPaths.callback,
+	routePattern(routes.onboarding),
+	routePattern(routes.onboardingStep1),
+	routePattern(routes.onboardingStep1Agent),
+	routePattern(routes.onboardingStep2),
+	routePattern(routes.onboardingStep2Service),
+	routePattern(routes.onboardingStep3),
 ])
 
 function concretePathForPattern(pattern: string) {

--- a/packages/worker/client/lazy-route.tsx
+++ b/packages/worker/client/lazy-route.tsx
@@ -347,16 +347,7 @@ registerPreloadPatterns(
 )
 
 registerPreloadPatterns(
-	[
-		routePattern(routes.onboarding),
-		routePattern(routes.onboardingStep1),
-		routePattern(routes.onboardingStep1Agent),
-		routePattern(routes.onboardingStep2),
-		routePattern(routes.onboardingStep2Service),
-		routePattern(routes.onboardingStep3),
-		routePattern(routes.connectOauth),
-		oauthPaths.authorize,
-	],
+	[routePattern(routes.connectOauth), oauthPaths.authorize],
 	{
 		name: 'onboarding-area',
 		load: onboardingArea.load,

--- a/packages/worker/client/routes/index.tsx
+++ b/packages/worker/client/routes/index.tsx
@@ -22,6 +22,7 @@ import { oauthPaths } from '#universal/oauth-paths.ts'
 import { routePattern } from '#universal/route-pattern.ts'
 import { routes } from '#universal/routes.ts'
 import { HomeRoute, homeRouteLoader } from './home.tsx'
+import { OnboardingRoute, onboardingRouteLoader } from './onboarding.tsx'
 import { OAuthCallbackRoute } from './oauth-callback.tsx'
 import { ProfileRoute, profileRouteLoader } from './profile.tsx'
 
@@ -304,30 +305,12 @@ export const clientRouteLoaders: Record<string, RouteLoader> = {
 		onboardingArea,
 		(m) => m.oauthAuthorizeRouteLoader,
 	),
-	[routePattern(routes.onboarding)]: lazyRouteLoader(
-		onboardingArea,
-		(m) => m.onboardingRouteLoader,
-	),
-	[routePattern(routes.onboardingStep1)]: lazyRouteLoader(
-		onboardingArea,
-		(m) => m.onboardingRouteLoader,
-	),
-	[routePattern(routes.onboardingStep1Agent)]: lazyRouteLoader(
-		onboardingArea,
-		(m) => m.onboardingRouteLoader,
-	),
-	[routePattern(routes.onboardingStep2)]: lazyRouteLoader(
-		onboardingArea,
-		(m) => m.onboardingRouteLoader,
-	),
-	[routePattern(routes.onboardingStep2Service)]: lazyRouteLoader(
-		onboardingArea,
-		(m) => m.onboardingRouteLoader,
-	),
-	[routePattern(routes.onboardingStep3)]: lazyRouteLoader(
-		onboardingArea,
-		(m) => m.onboardingRouteLoader,
-	),
+	[routePattern(routes.onboarding)]: onboardingRouteLoader,
+	[routePattern(routes.onboardingStep1)]: onboardingRouteLoader,
+	[routePattern(routes.onboardingStep1Agent)]: onboardingRouteLoader,
+	[routePattern(routes.onboardingStep2)]: onboardingRouteLoader,
+	[routePattern(routes.onboardingStep2Service)]: onboardingRouteLoader,
+	[routePattern(routes.onboardingStep3)]: onboardingRouteLoader,
 	[routePattern(routes.connectOauth)]: lazyRouteLoader(
 		onboardingArea,
 		(m) => m.connectOauthRouteLoader,
@@ -550,24 +533,12 @@ export const clientRoutes = {
 	[routePattern(routes.login)]: (
 		<LazyAuthRoute render={(m) => <m.LoginRoute />} />
 	),
-	[routePattern(routes.onboarding)]: (
-		<LazyOnboardingRoute render={(m) => <m.OnboardingRoute />} />
-	),
-	[routePattern(routes.onboardingStep1)]: (
-		<LazyOnboardingRoute render={(m) => <m.OnboardingRoute />} />
-	),
-	[routePattern(routes.onboardingStep1Agent)]: (
-		<LazyOnboardingRoute render={(m) => <m.OnboardingRoute />} />
-	),
-	[routePattern(routes.onboardingStep2)]: (
-		<LazyOnboardingRoute render={(m) => <m.OnboardingRoute />} />
-	),
-	[routePattern(routes.onboardingStep2Service)]: (
-		<LazyOnboardingRoute render={(m) => <m.OnboardingRoute />} />
-	),
-	[routePattern(routes.onboardingStep3)]: (
-		<LazyOnboardingRoute render={(m) => <m.OnboardingRoute />} />
-	),
+	[routePattern(routes.onboarding)]: <OnboardingRoute />,
+	[routePattern(routes.onboardingStep1)]: <OnboardingRoute />,
+	[routePattern(routes.onboardingStep1Agent)]: <OnboardingRoute />,
+	[routePattern(routes.onboardingStep2)]: <OnboardingRoute />,
+	[routePattern(routes.onboardingStep2Service)]: <OnboardingRoute />,
+	[routePattern(routes.onboardingStep3)]: <OnboardingRoute />,
 	[routePattern(routes.pendingVerification)]: (
 		<LazyAuthRoute render={(m) => <m.PendingVerificationRoute />} />
 	),

--- a/packages/worker/client/routes/landing-testimonials-carousel.node.test.ts
+++ b/packages/worker/client/routes/landing-testimonials-carousel.node.test.ts
@@ -116,13 +116,11 @@ test('narrow swipe moves the leading card off the origin instead of pinning it',
 	const leading = swiped.filter((placement) => placement.itemIndex === 0)
 	expect(leading).toContainEqual({ itemIndex: 0, x: -80, seam: false })
 	expect(leading.some((placement) => placement.x === 0)).toBe(false)
-	expect(largestVisibleHole(swiped, viewportWidth, cardWidth)).toBeLessThanOrEqual(
-		stride - cardWidth,
-	)
-
 	expect(
-		canPauseOnHover(() => ({ matches: false })),
-	).toBe(false)
+		largestVisibleHole(swiped, viewportWidth, cardWidth),
+	).toBeLessThanOrEqual(stride - cardWidth)
+
+	expect(canPauseOnHover(() => ({ matches: false }))).toBe(false)
 	expect(
 		canPauseOnHover((query) => ({
 			matches: query === '(hover: hover) and (pointer: fine)',

--- a/packages/worker/client/routes/landing-testimonials-carousel.node.test.ts
+++ b/packages/worker/client/routes/landing-testimonials-carousel.node.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from 'vitest'
 import {
+	canPauseOnHover,
 	listLanePlacements,
 	wrapPagerIndex,
 	wrapUnitInterval,
@@ -89,4 +90,42 @@ test('lane placements wrap with a seam copy instead of leaving a hole', () => {
 		stride - cardWidth,
 	)
 	expect(wide.length).toBeLessThanOrEqual(count + 2)
+})
+
+test('narrow swipe moves the leading card off the origin instead of pinning it', () => {
+	const stride = 320
+	const cardWidth = 308
+	const viewportWidth = 375
+
+	const atRest = listLanePlacements({
+		count: 4,
+		stride,
+		cardWidth,
+		offset: 0,
+		viewportWidth,
+	})
+	expect(atRest).toContainEqual({ itemIndex: 0, x: 0, seam: false })
+
+	const swiped = listLanePlacements({
+		count: 4,
+		stride,
+		cardWidth,
+		offset: 80,
+		viewportWidth,
+	})
+	const leading = swiped.filter((placement) => placement.itemIndex === 0)
+	expect(leading).toContainEqual({ itemIndex: 0, x: -80, seam: false })
+	expect(leading.some((placement) => placement.x === 0)).toBe(false)
+	expect(largestVisibleHole(swiped, viewportWidth, cardWidth)).toBeLessThanOrEqual(
+		stride - cardWidth,
+	)
+
+	expect(
+		canPauseOnHover(() => ({ matches: false })),
+	).toBe(false)
+	expect(
+		canPauseOnHover((query) => ({
+			matches: query === '(hover: hover) and (pointer: fine)',
+		})),
+	).toBe(true)
 })

--- a/packages/worker/client/routes/landing-testimonials-carousel.tsx
+++ b/packages/worker/client/routes/landing-testimonials-carousel.tsx
@@ -9,6 +9,7 @@ import {
 } from '#universal/landing-testimonials.ts'
 import {
 	TESTIMONIALS_LAP_MS,
+	canPauseOnHover,
 	listLanePlacements,
 	wrapPagerIndex,
 	wrapUnitInterval,
@@ -162,11 +163,13 @@ function armTestimonialsMotion(scroller: HTMLElement, signal: AbortSignal) {
 	let dragging = false
 
 	function isPaused() {
+		if (!inView || userNudging) return true
+		// Touch and window-resize leave `:hover` / `:focus-within` stuck on
+		// the strip. Only fine pointers get a hover/focus pause.
+		if (!canPauseOnHover()) return false
 		return (
-			!inView ||
 			hover ||
 			focus ||
-			userNudging ||
 			scroller.matches(':hover') ||
 			scroller.matches(':focus-within')
 		)
@@ -397,7 +400,8 @@ function armTestimonialsMotion(scroller: HTMLElement, signal: AbortSignal) {
 	scroller.addEventListener('pointercancel', onPointerUp, { signal })
 	scroller.addEventListener(
 		'pointerenter',
-		() => {
+		(event) => {
+			if (event.pointerType !== 'mouse') return
 			hover = true
 		},
 		{ signal },

--- a/packages/worker/client/routes/landing-testimonials-motion.ts
+++ b/packages/worker/client/routes/landing-testimonials-motion.ts
@@ -13,6 +13,19 @@ export function wrapPagerIndex(index: number, count: number) {
 	return ((index % count) + count) % count
 }
 
+/**
+ * Hover/focus pause is desktop-only. Coarse pointers and window-resize
+ * leave `:hover` stuck on the strip, which freezes the lane.
+ */
+export function canPauseOnHover(
+	query: (query: string) => { matches: boolean } = (mediaQuery) =>
+		typeof matchMedia === 'function'
+			? matchMedia(mediaQuery)
+			: { matches: false },
+) {
+	return query('(hover: hover) and (pointer: fine)').matches
+}
+
 export function wrapUnitInterval(value: number, period: number) {
 	if (period <= 0) return 0
 	const next = value % period

--- a/packages/worker/client/routes/onboarding-agent-chooser-session.node.test.ts
+++ b/packages/worker/client/routes/onboarding-agent-chooser-session.node.test.ts
@@ -13,7 +13,10 @@ import {
 	type OnboardingAgentChooserPick,
 } from './onboarding-mcp-clients.ts'
 import { emptyOnboardingSessionMilestones } from '#universal/onboarding-process.ts'
-import { type OnboardingPayload } from './onboarding-payload.ts'
+import {
+	clearOnboardingPayloadCache,
+	type OnboardingPayload,
+} from './onboarding-payload.ts'
 
 const originalWindow = Object.getOwnPropertyDescriptor(globalThis, 'window')
 const originalSessionStorage = Object.getOwnPropertyDescriptor(
@@ -80,6 +83,7 @@ const anonymousOnboardingPayload = {
 
 async function loadSelectionStep(pathname = '/onboarding/step-1') {
 	const originalFetch = globalThis.fetch
+	clearOnboardingPayloadCache()
 	globalThis.fetch = (async () =>
 		Response.json(anonymousOnboardingPayload)) as typeof fetch
 	try {
@@ -89,6 +93,7 @@ async function loadSelectionStep(pathname = '/onboarding/step-1') {
 		)
 	} finally {
 		globalThis.fetch = originalFetch
+		clearOnboardingPayloadCache()
 	}
 }
 

--- a/packages/worker/client/routes/onboarding-mcp-client-tabs.tsx
+++ b/packages/worker/client/routes/onboarding-mcp-client-tabs.tsx
@@ -295,7 +295,11 @@ export function OnboardingMcpClientTabs(
 		const chooser = handle.props.chooser ?? canonicalOnboardingAgentChooser()
 		const search = handle.props.search ?? ''
 		handle.queueTask(() => {
-			const hrefs = onboardingAgentPickerPrefetchHrefs(selectedAgent, chooser)
+			const hrefs = onboardingAgentPickerPrefetchHrefs(
+				selectedAgent,
+				chooser,
+				search,
+			)
 			const key = hrefs.join('\0')
 			if (key === warmedKey) return
 			warmedKey = key

--- a/packages/worker/client/routes/onboarding-mcp-client-tabs.tsx
+++ b/packages/worker/client/routes/onboarding-mcp-client-tabs.tsx
@@ -1,4 +1,5 @@
 import { type Handle, css } from 'remix/ui'
+import { prefetchRouteHrefs } from '#client/client-router.tsx'
 import {
 	type McpClientKind,
 	type OnboardingAgentChooserPick,
@@ -33,6 +34,7 @@ import {
 	renderPanelContent,
 	renderPanelWarning,
 } from './onboarding-mcp-client-panels.tsx'
+import { onboardingAgentPickerPrefetchHrefs } from './onboarding-picker-prefetch.ts'
 
 type OnboardingMcpClientTabsProps = {
 	mcpServerUrl: string
@@ -286,11 +288,19 @@ function renderAgentAuthHint(
 export function OnboardingMcpClientTabs(
 	handle: Handle<OnboardingMcpClientTabsProps>,
 ) {
+	let warmedKey = ''
 	return () => {
 		const { mcpServerUrl, highlights } = handle.props
 		const selectedAgent = handle.props.selectedAgent ?? null
 		const chooser = handle.props.chooser ?? canonicalOnboardingAgentChooser()
 		const search = handle.props.search ?? ''
+		handle.queueTask(() => {
+			const hrefs = onboardingAgentPickerPrefetchHrefs(selectedAgent, chooser)
+			const key = hrefs.join('\0')
+			if (key === warmedKey) return
+			warmedKey = key
+			prefetchRouteHrefs(hrefs)
+		})
 
 		if (!selectedAgent) {
 			return (

--- a/packages/worker/client/routes/onboarding-payload.node.test.ts
+++ b/packages/worker/client/routes/onboarding-payload.node.test.ts
@@ -59,3 +59,87 @@ test('onboarding payload fetch coalesces in flight and reuses the warm cache', a
 		clearOnboardingPayloadCache()
 	}
 })
+
+test('fresh fetch skips the warm cache so progress polls see live milestones', async () => {
+	clearOnboardingPayloadCache()
+	const originalFetch = globalThis.fetch
+	const calls: Array<string> = []
+	const stale = { ...payload, hasMcpClient: false }
+	const live = { ...payload, hasMcpClient: true }
+	const bodies = [stale, live]
+	globalThis.fetch = ((input: RequestInfo | URL) => {
+		calls.push(String(input))
+		const body = bodies.shift() ?? live
+		return Promise.resolve(Response.json(body))
+	}) as typeof fetch
+
+	try {
+		await expect(fetchOnboardingPayload()).resolves.toEqual(stale)
+		await expect(fetchOnboardingPayload()).resolves.toEqual(stale)
+		expect(calls).toHaveLength(1)
+		await expect(
+			fetchOnboardingPayload(undefined, { fresh: true }),
+		).resolves.toEqual(live)
+		expect(calls).toHaveLength(2)
+	} finally {
+		globalThis.fetch = originalFetch
+		clearOnboardingPayloadCache()
+	}
+})
+
+test('clearing the cache aborts the in-flight request so it cannot rewrite progress', async () => {
+	clearOnboardingPayloadCache()
+	const originalFetch = globalThis.fetch
+	const calls: Array<string> = []
+	const controllers: Array<AbortController> = []
+	let resolveStale!: (value: Response) => void
+	let resolveFresh!: (value: Response) => void
+	const stale = { ...payload, hasMcpClient: false }
+	const live = { ...payload, hasMcpClient: true }
+	globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+		calls.push(String(input))
+		if (init?.signal instanceof AbortSignal) {
+			const controller = new AbortController()
+			init.signal.addEventListener(
+				'abort',
+				() => {
+					controller.abort()
+				},
+				{ once: true },
+			)
+			controllers.push(controller)
+		}
+		return new Promise<Response>((resolve, reject) => {
+			if (calls.length === 1) {
+				resolveStale = resolve
+				controllers.at(-1)?.signal.addEventListener(
+					'abort',
+					() => {
+						reject(new DOMException('Aborted', 'AbortError'))
+					},
+					{ once: true },
+				)
+				return
+			}
+			resolveFresh = resolve
+		})
+	}) as typeof fetch
+
+	try {
+		const first = fetchOnboardingPayload()
+		expect(calls).toHaveLength(1)
+		clearOnboardingPayloadCache()
+		await expect(first).rejects.toMatchObject({ name: 'AbortError' })
+
+		const second = fetchOnboardingPayload()
+		expect(calls).toHaveLength(2)
+		resolveStale(Response.json(stale))
+		resolveFresh(Response.json(live))
+		await expect(second).resolves.toEqual(live)
+		await expect(fetchOnboardingPayload()).resolves.toEqual(live)
+		expect(calls).toHaveLength(2)
+	} finally {
+		globalThis.fetch = originalFetch
+		clearOnboardingPayloadCache()
+	}
+})

--- a/packages/worker/client/routes/onboarding-payload.node.test.ts
+++ b/packages/worker/client/routes/onboarding-payload.node.test.ts
@@ -1,0 +1,61 @@
+import { expect, test } from 'vitest'
+import { emptyOnboardingSessionMilestones } from '#universal/onboarding-process.ts'
+import {
+	clearOnboardingPayloadCache,
+	fetchOnboardingPayload,
+	type OnboardingPayload,
+} from './onboarding-payload.ts'
+
+const payload = {
+	ok: true,
+	loggedIn: false,
+	username: null,
+	mcpServerUrl: 'https://example.com/mcp',
+	setupPrompt: '',
+	discoveryPrompt: '',
+	persistPrompt: '',
+	milestones: emptyOnboardingSessionMilestones,
+	hasMcpClient: false,
+	emailVerified: false,
+	needsOnboarding: true,
+	featuredListings: [],
+	featuredMcpServers: [],
+	customMcpServers: [],
+	persistedPackageKodyId: null,
+	checklist: null,
+} satisfies OnboardingPayload
+
+test('onboarding payload fetch coalesces in flight and reuses the warm cache', async () => {
+	clearOnboardingPayloadCache()
+	const originalFetch = globalThis.fetch
+	let resolveResponse!: (value: Response) => void
+	const calls: Array<string> = []
+	globalThis.fetch = ((input: RequestInfo | URL) => {
+		calls.push(String(input))
+		return new Promise<Response>((resolve) => {
+			resolveResponse = resolve
+		})
+	}) as typeof fetch
+
+	try {
+		const first = fetchOnboardingPayload()
+		const second = fetchOnboardingPayload()
+		expect(calls).toEqual(['/onboarding.json'])
+		resolveResponse(Response.json(payload))
+		await expect(first).resolves.toEqual(payload)
+		await expect(second).resolves.toEqual(payload)
+		expect(calls).toHaveLength(1)
+
+		await expect(fetchOnboardingPayload()).resolves.toEqual(payload)
+		expect(calls).toHaveLength(1)
+
+		clearOnboardingPayloadCache()
+		const third = fetchOnboardingPayload()
+		expect(calls).toHaveLength(2)
+		resolveResponse(Response.json(payload))
+		await third
+	} finally {
+		globalThis.fetch = originalFetch
+		clearOnboardingPayloadCache()
+	}
+})

--- a/packages/worker/client/routes/onboarding-payload.ts
+++ b/packages/worker/client/routes/onboarding-payload.ts
@@ -52,38 +52,45 @@ type OnboardingPayloadCache = {
 }
 
 let inFlight: Promise<OnboardingPayload | null> | null = null
+let inFlightController: AbortController | null = null
 let cache: OnboardingPayloadCache | null = null
+let loadGeneration = 0
 
 function monotonicNow() {
 	return performance.now()
 }
 
+/**
+ * Drop the settled payload and any in-flight `/onboarding.json` so a form
+ * POST cannot be followed by pre-mutation progress. Late completions of
+ * the aborted request must not rewrite `cache`.
+ */
 export function clearOnboardingPayloadCache() {
 	cache = null
+	loadGeneration += 1
+	inFlightController?.abort()
+	inFlightController = null
+	inFlight = null
 }
 
-async function loadOnboardingPayload() {
+async function loadOnboardingPayload(generation: number, signal: AbortSignal) {
 	const response = await fetch(onboardingApiPath, {
 		headers: { Accept: 'application/json' },
 		credentials: 'include',
+		signal,
 	})
 	const payload = await readJson<OnboardingPayload>(response)
 	if (!response.ok || !payload?.ok) return null
-	cache = { payload, at: monotonicNow() }
+	if (generation === loadGeneration) {
+		cache = { payload, at: monotonicNow() }
+	}
 	return payload
 }
 
-export async function fetchOnboardingPayload(signal?: AbortSignal) {
-	if (cache && monotonicNow() - cache.at <= onboardingPayloadCacheTtlMs) {
-		if (signal?.aborted) throw new DOMException('Aborted', 'AbortError')
-		return cache.payload
-	}
-	if (!inFlight) {
-		inFlight = loadOnboardingPayload().finally(() => {
-			inFlight = null
-		})
-	}
-	const shared = inFlight
+function adoptSharedPayload(
+	shared: Promise<OnboardingPayload | null>,
+	signal?: AbortSignal,
+) {
 	if (!signal) return shared
 	if (signal.aborted) throw new DOMException('Aborted', 'AbortError')
 	return new Promise<OnboardingPayload | null>((resolve, reject) => {
@@ -102,4 +109,33 @@ export async function fetchOnboardingPayload(signal?: AbortSignal) {
 			},
 		)
 	})
+}
+
+export async function fetchOnboardingPayload(
+	signal?: AbortSignal,
+	options?: { fresh?: boolean },
+) {
+	const fresh = options?.fresh === true
+	if (
+		!fresh &&
+		cache &&
+		monotonicNow() - cache.at <= onboardingPayloadCacheTtlMs
+	) {
+		if (signal?.aborted) throw new DOMException('Aborted', 'AbortError')
+		return cache.payload
+	}
+	if (!inFlight) {
+		const generation = loadGeneration
+		const controller = new AbortController()
+		inFlightController = controller
+		inFlight = loadOnboardingPayload(generation, controller.signal).finally(
+			() => {
+				if (inFlightController === controller) {
+					inFlightController = null
+					inFlight = null
+				}
+			},
+		)
+	}
+	return adoptSharedPayload(inFlight, signal)
 }

--- a/packages/worker/client/routes/onboarding-payload.ts
+++ b/packages/worker/client/routes/onboarding-payload.ts
@@ -39,13 +39,67 @@ export type OnboardingPayload = {
 
 export const onboardingApiPath = '/onboarding.json'
 
-export async function fetchOnboardingPayload(signal?: AbortSignal) {
+/**
+ * Chip navigations and render prefetch all hit this payload. Keep one
+ * in-flight request and reuse a short-lived result so a picker cannot
+ * stampede `/onboarding.json` on a loaded Vite origin.
+ */
+export const onboardingPayloadCacheTtlMs = 30_000
+
+type OnboardingPayloadCache = {
+	payload: OnboardingPayload
+	at: number
+}
+
+let inFlight: Promise<OnboardingPayload | null> | null = null
+let cache: OnboardingPayloadCache | null = null
+
+function monotonicNow() {
+	return performance.now()
+}
+
+export function clearOnboardingPayloadCache() {
+	cache = null
+}
+
+async function loadOnboardingPayload() {
 	const response = await fetch(onboardingApiPath, {
 		headers: { Accept: 'application/json' },
 		credentials: 'include',
-		signal,
 	})
 	const payload = await readJson<OnboardingPayload>(response)
 	if (!response.ok || !payload?.ok) return null
+	cache = { payload, at: monotonicNow() }
 	return payload
+}
+
+export async function fetchOnboardingPayload(signal?: AbortSignal) {
+	if (cache && monotonicNow() - cache.at <= onboardingPayloadCacheTtlMs) {
+		if (signal?.aborted) throw new DOMException('Aborted', 'AbortError')
+		return cache.payload
+	}
+	if (!inFlight) {
+		inFlight = loadOnboardingPayload().finally(() => {
+			inFlight = null
+		})
+	}
+	const shared = inFlight
+	if (!signal) return shared
+	if (signal.aborted) throw new DOMException('Aborted', 'AbortError')
+	return new Promise<OnboardingPayload | null>((resolve, reject) => {
+		const onAbort = () => {
+			reject(new DOMException('Aborted', 'AbortError'))
+		}
+		signal.addEventListener('abort', onAbort, { once: true })
+		void shared.then(
+			(value) => {
+				signal.removeEventListener('abort', onAbort)
+				resolve(value)
+			},
+			(error: unknown) => {
+				signal.removeEventListener('abort', onAbort)
+				reject(error)
+			},
+		)
+	})
 }

--- a/packages/worker/client/routes/onboarding-picker-prefetch.node.test.ts
+++ b/packages/worker/client/routes/onboarding-picker-prefetch.node.test.ts
@@ -67,3 +67,39 @@ test('step 1 and step 2 pickers prefetch every rendered chip and never community
 	expect(serviceHrefs).not.toContain('/community')
 	expect(serviceHtml).not.toContain('href="/community"')
 })
+
+test('picker prefetch hrefs keep the rendered search so redirectTo clicks stay warm', async () => {
+	const search = '?redirectTo=%2Faccount'
+	const chooser = canonicalOnboardingAgentChooser()
+	const agentHrefs = onboardingAgentPickerPrefetchHrefs(null, chooser, search)
+	const agentHtml = await renderToString(
+		jsx(OnboardingMcpClientTabs, {
+			mcpServerUrl: defaultKodyMcpUrl,
+			search,
+		}),
+	)
+	expect(chipHrefsFromHtml(agentHtml, 'onboarding-agent-')).toEqual(agentHrefs)
+	expect(agentHrefs).toContain(`/onboarding/step-1/cursor${search}`)
+	expect(
+		onboardingAgentPickerPrefetchHrefs('other', chooser, search)[0],
+	).toMatch(/\?redirectTo=%2Faccount$/)
+
+	const featuredIds = ['notion'] as const
+	const overflowIds = ['github'] as const
+	const serviceHrefs = onboardingServicePickerPrefetchHrefs(
+		featuredIds,
+		overflowIds,
+		search,
+	)
+	const serviceHtml = await renderToString(
+		jsx(OnboardingServicePicker, {
+			featuredIds,
+			overflowIds,
+			search,
+		}),
+	)
+	expect(chipHrefsFromHtml(serviceHtml, 'onboarding-service-')).toEqual(
+		serviceHrefs,
+	)
+	expect(serviceHrefs[0]).toBe(`/onboarding/step-2/notion${search}`)
+})

--- a/packages/worker/client/routes/onboarding-picker-prefetch.node.test.ts
+++ b/packages/worker/client/routes/onboarding-picker-prefetch.node.test.ts
@@ -1,0 +1,69 @@
+import { jsx } from 'remix/ui/jsx-runtime'
+import { renderToString } from 'remix/ui/server'
+import { expect, test } from 'vitest'
+import { canonicalOnboardingAgentChooser } from '#universal/onboarding-mcp-clients.ts'
+import { OnboardingMcpClientTabs } from './onboarding-mcp-client-tabs.tsx'
+import { defaultKodyMcpUrl } from './onboarding-mcp-clients.ts'
+import {
+	onboardingAgentPickerPrefetchHrefs,
+	onboardingServicePickerPrefetchHrefs,
+} from './onboarding-picker-prefetch.ts'
+import { OnboardingServicePicker } from './onboarding-service-picker.tsx'
+
+function chipHrefsFromHtml(html: string, testIdPrefix: string) {
+	return [
+		...html.matchAll(
+			new RegExp(
+				`href="(/onboarding/[^"]+)"[^>]*data-testid="${testIdPrefix}[^"]*"`,
+				'g',
+			),
+		),
+	].map((match) => match[1] ?? '')
+}
+
+test('step 1 and step 2 pickers prefetch every rendered chip and never community', async () => {
+	const chooser = canonicalOnboardingAgentChooser()
+	const agentHrefs = onboardingAgentPickerPrefetchHrefs(null, chooser)
+	const agentHtml = await renderToString(
+		jsx(OnboardingMcpClientTabs, { mcpServerUrl: defaultKodyMcpUrl }),
+	)
+	expect(chipHrefsFromHtml(agentHtml, 'onboarding-agent-')).toEqual(agentHrefs)
+	expect(agentHrefs).toContain('/onboarding/step-1/cursor')
+	expect(agentHrefs).toContain('/onboarding/step-1/not-listed')
+	expect(agentHrefs).toContain('/onboarding/step-1/chatgpt')
+	expect(agentHrefs).not.toContain('/community')
+	expect(onboardingAgentPickerPrefetchHrefs('cursor', chooser)).toEqual([])
+
+	const featuredIds = ['notion', 'linear'] as const
+	const overflowIds = ['github'] as const
+	const serviceHrefs = onboardingServicePickerPrefetchHrefs(
+		featuredIds,
+		overflowIds,
+	)
+	const serviceHtml = await renderToString(
+		jsx(OnboardingServicePicker, {
+			featuredIds,
+			overflowIds,
+		}),
+	)
+	expect(chipHrefsFromHtml(serviceHtml, 'onboarding-service-')).toEqual(
+		serviceHrefs,
+	)
+	expect(serviceHrefs).toEqual([
+		'/onboarding/step-2/notion',
+		'/onboarding/step-2/linear',
+		'/onboarding/step-2/github',
+		'/onboarding/step-2/google',
+		'/onboarding/step-2/slack',
+		'/onboarding/step-2/discord',
+		'/onboarding/step-2/spotify',
+		'/onboarding/step-2/x',
+		'/onboarding/step-2/asana',
+		'/onboarding/step-2/dropbox',
+		'/onboarding/step-2/linkedin',
+		'/onboarding/step-2/zoom',
+		'/onboarding/step-2/not-listed',
+	])
+	expect(serviceHrefs).not.toContain('/community')
+	expect(serviceHtml).not.toContain('href="/community"')
+})

--- a/packages/worker/client/routes/onboarding-picker-prefetch.ts
+++ b/packages/worker/client/routes/onboarding-picker-prefetch.ts
@@ -25,17 +25,18 @@ import {
 export function onboardingAgentPickerPrefetchHrefs(
 	selectedAgent: McpClientKind | null,
 	chooser: OnboardingAgentChooserPick = canonicalOnboardingAgentChooser(),
+	search = '',
 ): Array<string> {
 	if (!selectedAgent) {
 		const ids: Array<McpClientKind> = [
 			...onboardingPickerAgentIds(chooser),
 			'other',
 		]
-		return ids.map((id) => onboardingAgentHref(id))
+		return ids.map((id) => onboardingAgentHref(id, search))
 	}
 	if (selectedAgent === 'other') {
 		return onboardingNotListedAgentIds(chooser).map((entry) =>
-			onboardingAgentHref(entry.id),
+			onboardingAgentHref(entry.id, search),
 		)
 	}
 	return []
@@ -49,6 +50,7 @@ export function onboardingAgentPickerPrefetchHrefs(
 export function onboardingServicePickerPrefetchHrefs(
 	featuredIds: ReadonlyArray<OnboardingFeaturedMcpServerId>,
 	overflowIds: ReadonlyArray<OnboardingFeaturedMcpServerId>,
+	search = '',
 ): Array<string> {
 	const overflowChoices = overflowIds.flatMap((id) => {
 		const server = onboardingFeaturedMcpServerById(id)
@@ -61,5 +63,5 @@ export function onboardingServicePickerPrefetchHrefs(
 		...onboardingNotListedPromptServices.map((service) => service.id),
 		onboardingNotListedServiceId,
 	]
-	return ids.map((id) => onboardingServiceHref(id))
+	return ids.map((id) => onboardingServiceHref(id, search))
 }

--- a/packages/worker/client/routes/onboarding-picker-prefetch.ts
+++ b/packages/worker/client/routes/onboarding-picker-prefetch.ts
@@ -1,0 +1,65 @@
+import {
+	type OnboardingAgentChooserPick,
+	type McpClientKind,
+	canonicalOnboardingAgentChooser,
+	onboardingNotListedAgentIds,
+	onboardingPickerAgentIds,
+} from '#universal/onboarding-mcp-clients.ts'
+import {
+	type OnboardingFeaturedMcpServerId,
+	type OnboardingServiceChoice,
+	onboardingFeaturedMcpServerById,
+	onboardingNotListedPromptServices,
+	onboardingNotListedServiceId,
+} from '#universal/onboarding-mcp-chooser.ts'
+import {
+	onboardingAgentHref,
+	onboardingServiceHref,
+} from '#universal/onboarding-process.ts'
+
+/**
+ * Destinations for every Step 1 chip currently on screen. The main picker
+ * includes Not listed (`/onboarding/step-1/not-listed`). Extra named hosts
+ * only appear after that choice, so they are not warmed on the first grid.
+ */
+export function onboardingAgentPickerPrefetchHrefs(
+	selectedAgent: McpClientKind | null,
+	chooser: OnboardingAgentChooserPick = canonicalOnboardingAgentChooser(),
+): Array<string> {
+	if (!selectedAgent) {
+		const ids: Array<McpClientKind> = [
+			...onboardingPickerAgentIds(chooser),
+			'other',
+		]
+		return ids.map((id) => onboardingAgentHref(id))
+	}
+	if (selectedAgent === 'other') {
+		return onboardingNotListedAgentIds(chooser).map((entry) =>
+			onboardingAgentHref(entry.id),
+		)
+	}
+	return []
+}
+
+/**
+ * Destinations for every Step 2 chip: featured, Show more remotes, prompt
+ * flavors, and Not listed. Explore packages (`/community`) is not a chip
+ * and is omitted until a service is selected.
+ */
+export function onboardingServicePickerPrefetchHrefs(
+	featuredIds: ReadonlyArray<OnboardingFeaturedMcpServerId>,
+	overflowIds: ReadonlyArray<OnboardingFeaturedMcpServerId>,
+): Array<string> {
+	const overflowChoices = overflowIds.flatMap((id) => {
+		const server = onboardingFeaturedMcpServerById(id)
+		if (!server) return []
+		return [server.id]
+	})
+	const ids: Array<OnboardingServiceChoice> = [
+		...featuredIds,
+		...overflowChoices,
+		...onboardingNotListedPromptServices.map((service) => service.id),
+		onboardingNotListedServiceId,
+	]
+	return ids.map((id) => onboardingServiceHref(id))
+}

--- a/packages/worker/client/routes/onboarding-service-chooser-session.node.test.ts
+++ b/packages/worker/client/routes/onboarding-service-chooser-session.node.test.ts
@@ -13,7 +13,10 @@ import {
 	type OnboardingServiceChooserPick,
 } from '#universal/onboarding-mcp-chooser.ts'
 import { emptyOnboardingSessionMilestones } from '#universal/onboarding-process.ts'
-import { type OnboardingPayload } from './onboarding-payload.ts'
+import {
+	clearOnboardingPayloadCache,
+	type OnboardingPayload,
+} from './onboarding-payload.ts'
 
 const originalWindow = Object.getOwnPropertyDescriptor(globalThis, 'window')
 const originalSessionStorage = Object.getOwnPropertyDescriptor(
@@ -80,6 +83,7 @@ const anonymousOnboardingPayload = {
 
 async function loadSelectionStep(pathname = '/onboarding/step-2') {
 	const originalFetch = globalThis.fetch
+	clearOnboardingPayloadCache()
 	globalThis.fetch = (async () =>
 		Response.json(anonymousOnboardingPayload)) as typeof fetch
 	try {
@@ -89,6 +93,7 @@ async function loadSelectionStep(pathname = '/onboarding/step-2') {
 		)
 	} finally {
 		globalThis.fetch = originalFetch
+		clearOnboardingPayloadCache()
 	}
 }
 

--- a/packages/worker/client/routes/onboarding-service-picker.tsx
+++ b/packages/worker/client/routes/onboarding-service-picker.tsx
@@ -129,6 +129,7 @@ export function OnboardingServicePicker(
 			const hrefs = onboardingServicePickerPrefetchHrefs(
 				featuredIds,
 				overflowIds,
+				search,
 			)
 			const key = hrefs.join('\0')
 			if (key === warmedKey) return

--- a/packages/worker/client/routes/onboarding-service-picker.tsx
+++ b/packages/worker/client/routes/onboarding-service-picker.tsx
@@ -1,4 +1,5 @@
 import { type Handle, css } from 'remix/ui'
+import { prefetchRouteHrefs } from '#client/client-router.tsx'
 import { isKnownProviderIconId, ProviderIcon } from '#client/provider-icons.tsx'
 import {
 	type OnboardingFeaturedMcpServerId,
@@ -20,6 +21,7 @@ import {
 	typography,
 } from '#universal/styles/tokens.ts'
 import { hoverMq } from '#universal/styles/style-primitives.ts'
+import { onboardingServicePickerPrefetchHrefs } from './onboarding-picker-prefetch.ts'
 
 export function ServicePickerMark(
 	handle: Handle<{
@@ -119,9 +121,20 @@ export function OnboardingServicePicker(
 		search?: string
 	}>,
 ) {
+	let warmedKey = ''
 	return () => {
 		const { featuredIds, overflowIds } = handle.props
 		const search = handle.props.search ?? ''
+		handle.queueTask(() => {
+			const hrefs = onboardingServicePickerPrefetchHrefs(
+				featuredIds,
+				overflowIds,
+			)
+			const key = hrefs.join('\0')
+			if (key === warmedKey) return
+			warmedKey = key
+			prefetchRouteHrefs(hrefs)
+		})
 		const overflowChips = overflowIds.flatMap((id) => {
 			const server = onboardingFeaturedMcpServerById(id)
 			if (!server) return []

--- a/packages/worker/client/routes/onboarding.tsx
+++ b/packages/worker/client/routes/onboarding.tsx
@@ -204,7 +204,9 @@ export function OnboardingRoute(handle: Handle) {
 
 	async function refreshOnboardingAfterInstall() {
 		try {
-			const payload = await fetchOnboardingPayload(handle.signal)
+			const payload = await fetchOnboardingPayload(handle.signal, {
+				fresh: true,
+			})
 			if (handle.signal.aborted || !payload) return
 			applyPayload(payload)
 			flushPendingAdvanceToAccess(false)
@@ -299,7 +301,9 @@ export function OnboardingRoute(handle: Handle) {
 		if (!isOnboardingPath(readCurrentRouterHref(handle))) return
 		pollInFlight = true
 		try {
-			const payload = await fetchOnboardingPayload(handle.signal)
+			const payload = await fetchOnboardingPayload(handle.signal, {
+				fresh: true,
+			})
 			if (handle.signal.aborted || !payload) return
 			const nextMilestones =
 				payload.milestones ?? emptyOnboardingSessionMilestones

--- a/packages/worker/client/routes/onboarding.tsx
+++ b/packages/worker/client/routes/onboarding.tsx
@@ -438,9 +438,6 @@ export function OnboardingRoute(handle: Handle) {
 					</p>
 				</header>
 
-				{status === 'loading' ? (
-					<p mix={css(loadingCss)}>Loading onboarding…</p>
-				) : null}
 				{message ? (
 					<p mix={css(errorMessageCss)} role="alert">
 						{message}
@@ -539,11 +536,6 @@ const onboardHeadCss = {
 		fontSize: '1.08rem',
 		maxWidth: '52ch',
 	},
-}
-
-const loadingCss = {
-	margin: 'clamp(2.2rem, 5vw, 3.2rem) 0 0',
-	color: colors.textMuted,
 }
 
 const errorMessageCss = {

--- a/packages/worker/client/routes/onboarding.tsx
+++ b/packages/worker/client/routes/onboarding.tsx
@@ -5,10 +5,7 @@ import { createRouteLoadLatch } from '#client/route-load-latch.ts'
 import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
 import { consumeStaleNavigationData } from '#client/navigation-data.ts'
 import { readRouterSearch } from '#client/router-location.tsx'
-import {
-	type AccountStatus,
-	readJson,
-} from '#client/routes/account-approval-shared.ts'
+import { type AccountStatus } from '#client/routes/account-approval-shared.ts'
 import {
 	routeLoaderRedirect,
 	type RouteLoaderResult,
@@ -33,7 +30,6 @@ import {
 } from '#universal/onboarding-process.ts'
 import {
 	fetchOnboardingPayload,
-	onboardingApiPath,
 	type OnboardingPayload,
 } from '#client/routes/onboarding-payload.ts'
 import {
@@ -97,13 +93,8 @@ export async function onboardingRouteLoader(
 	signal: AbortSignal,
 ): Promise<RouteLoaderResult> {
 	const redirectTo = normalizeRedirectTo(url.searchParams.get('redirectTo'))
-	const response = await fetch(onboardingApiPath, {
-		headers: { Accept: 'application/json' },
-		credentials: 'include',
-		signal,
-	})
-	const payload = await readJson<OnboardingPayload>(response)
-	if (!response.ok || !payload?.ok) {
+	const payload = await fetchOnboardingPayload(signal)
+	if (!payload) {
 		throw new Error('Unable to load onboarding.')
 	}
 	if (payload.loggedIn && !payload.emailVerified) {
@@ -258,14 +249,9 @@ export function OnboardingRoute(handle: Handle) {
 		const href = readCurrentRouterHref(handle)
 		const redirectTo = readOnboardingRedirectTo(handle)
 		try {
-			const response = await fetch(onboardingApiPath, {
-				headers: { Accept: 'application/json' },
-				credentials: 'include',
-				signal,
-			})
+			const payload = await fetchOnboardingPayload(signal)
 			if (signal.aborted) return
-			const payload = await readJson<OnboardingPayload>(response)
-			if (!response.ok || !payload?.ok) {
+			if (!payload) {
 				throw new Error('Unable to load onboarding.')
 			}
 			if (payload.loggedIn && !payload.emailVerified) {

--- a/packages/worker/client/routes/onboarding.tsx
+++ b/packages/worker/client/routes/onboarding.tsx
@@ -1,6 +1,7 @@
 import { type Handle, css, ref } from 'remix/ui'
 import { normalizeRedirectTo } from '#universal/safe-redirect.ts'
 import { navigate, readCurrentRouterHref } from '#client/client-router.tsx'
+import { discardRenderPrefetches } from '#client/intent-prefetch.ts'
 import { createRouteLoadLatch } from '#client/route-load-latch.ts'
 import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
 import { consumeStaleNavigationData } from '#client/navigation-data.ts'
@@ -18,6 +19,7 @@ import { routes } from '#universal/routes.ts'
 import {
 	isOnboardingPagePath,
 	onboardingIndexRedirectHref,
+	onboardingSessionMilestones,
 	onboardingSessionMilestonesComplete,
 	onboardingSessionMilestonesEqual,
 	onboardingStepPaths,
@@ -75,6 +77,17 @@ type OnboardingStep = OnboardingWizardStepNumber
 
 function isOnboardingPath(href: string) {
 	return isOnboardingPagePath(new URL(href, 'http://localhost').pathname)
+}
+
+function retainOnboardingMilestones(
+	current: OnboardingSessionMilestoneState,
+	incoming: OnboardingSessionMilestoneState,
+): OnboardingSessionMilestoneState {
+	const next = { ...incoming }
+	for (const item of onboardingSessionMilestones) {
+		next[item.id] = current[item.id] || incoming[item.id]
+	}
+	return next
 }
 
 function readOnboardingLocation(href: string) {
@@ -135,21 +148,33 @@ export function OnboardingRoute(handle: Handle) {
 	let panelAnimationArmed = false
 	const loadLatch = createRouteLoadLatch()
 
-	function applyPayload(payload: OnboardingPayload) {
+	function applyPayload(
+		payload: OnboardingPayload,
+		source: 'live' | 'snapshot' = 'snapshot',
+	) {
 		const wasConnected = hasMcpClient
+		const incomingMilestones =
+			payload.milestones ?? emptyOnboardingSessionMilestones
 		loggedIn = payload.loggedIn
 		mcpServerUrl = payload.mcpServerUrl
 		mcpHighlights = payload.mcpHighlights ?? {}
 		discoveryPrompt = payload.discoveryPrompt
-		milestones = payload.milestones ?? emptyOnboardingSessionMilestones
-		hasMcpClient = payload.hasMcpClient
+		milestones =
+			source === 'snapshot'
+				? retainOnboardingMilestones(milestones, incomingMilestones)
+				: incomingMilestones
+		hasMcpClient =
+			source === 'snapshot'
+				? hasMcpClient || payload.hasMcpClient
+				: payload.hasMcpClient
 		status = 'ready'
 		message = null
+		if (source === 'live') discardRenderPrefetches()
 		if (!initializedStep) {
 			initializedStep = true
 			return
 		}
-		if (!wasConnected && payload.hasMcpClient) {
+		if (!wasConnected && hasMcpClient) {
 			panelAnimationArmed = true
 			pendingAdvanceToAccess = true
 		}
@@ -208,7 +233,7 @@ export function OnboardingRoute(handle: Handle) {
 				fresh: true,
 			})
 			if (handle.signal.aborted || !payload) return
-			applyPayload(payload)
+			applyPayload(payload, 'live')
 			flushPendingAdvanceToAccess(false)
 			handle.update()
 		} catch {
@@ -262,7 +287,7 @@ export function OnboardingRoute(handle: Handle) {
 				)
 				return
 			}
-			applyPayload(payload)
+			applyPayload(payload, 'live')
 			flushPendingAdvanceToAccess(false)
 			if (!agentChooser) agentChooser = resolveOnboardingAgentChooser()
 			if (!serviceChooser) serviceChooser = resolveOnboardingServiceChooser()
@@ -313,7 +338,7 @@ export function OnboardingRoute(handle: Handle) {
 			) {
 				return
 			}
-			applyPayload(payload)
+			applyPayload(payload, 'live')
 			flushPendingAdvanceToAccess(false)
 			handle.update()
 		} catch {

--- a/packages/worker/public/styles.css
+++ b/packages/worker/public/styles.css
@@ -1782,6 +1782,15 @@ html.is-settled {
 		flex: none;
 	}
 
+	/* Author `display: flex` above beats the UA `[hidden]` rule. Unused
+	   virtual cards would stay painted at the grid origin — a stuck
+	   leading card while the rest of the lane translates past it. */
+	html.js
+		.landing-testimonials-track.is-virtual
+		.landing-testimonial-card[hidden] {
+		display: none;
+	}
+
 	html.js .landing-testimonial-person {
 		margin-top: auto;
 		padding-top: 1.35rem;

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -544,6 +544,8 @@ test('SSR HTML routes render page content and embedded loader data', async () =>
 	expect(anonymousOnboardingHtml).toContain(
 		'data-testid="onboarding-agent-picker"',
 	)
+	expect(anonymousOnboardingHtml).not.toContain('Loading onboarding')
+	expect(anonymousOnboardingHtml).not.toContain('Loading page')
 	expect(anonymousOnboardingHtml).toContain('data-testid="onboarding-step-2"')
 	expect(anonymousOnboardingHtml).toContain('href="/onboarding/step-2"')
 	expect(anonymousOnboardingHtml).not.toContain('href="/onboarding/step-3"')


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Make first-run onboarding and the homepage testimonial strip feel instant and correct: SSR should ship the real wizard, chip clicks should reuse one warmed payload, and unused mobile cards should stay unpainted.

## Why

After #2060 the two-step wizard still arrived as a lazy “Loading onboarding…” placeholder, picker chips each cold-loaded `/onboarding.json`, and the homepage testimonial lane froze on mobile because author `display: flex` beat `[hidden]` and coarse pointers left `:hover` stuck.

## Summary

- Register `/onboarding` and `/onboarding/step-*` as eager client routes so SSR HTML includes the real step UI instead of the lazy-area fallback.
- Render-prefetch every on-screen Step 1 / Step 2 chip destination (including `redirectTo` search). Destinations that share a loader share one request; `/onboarding.json` is coalesced with a short-lived cache for chip clicks.
- Progress polls and OAuth-done refresh bypass that cache (`fresh: true`). Form POST aborts the in-flight request so it cannot rewrite milestones.
- After a live poll/refresh, drop render-prefetch snapshots and retain `hasMcpClient` plus completed milestones so a chip click cannot rewind progress or bounce the user to bare step-2.
- Homepage testimonials: unused virtual cards use `display: none` so they cannot paint at the grid origin. Hover/focus pause is desktop-only (`hover: hover` and `pointer: fine`).

Rebased onto `main` after #2064 (`/@username` public catalog). Eager-pattern test keeps both profile and onboarding routes. Vite HMR leftovers are not in this branch.

## Testing

- Pre-push after rebase: node-unit 2613 / workers-unit 327.
- Focused payload + prefetch tests for cache invalidation, fresh polls, search-preserving hrefs, and discarded render snapshots.
- Preview `kody-pr-2066` as `me@kentcdodds.com`: `/onboarding.json` 200, `/onboarding` 302, step-1 / step-2 / notion / cursor / home 200. SSR HTML has the agent picker and no “Loading onboarding” / “Loading page”.
- UI pass: step-1 agent picker and Cursor install panel, step-2 discovery prompt (seed user has no MCP client — expected), homepage testimonials animating.
- Static oxfmt wrap. Bugbot cache / in-flight / rewind findings addressed. Rebase conflict was only the eager-pattern set.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `401b886f` · **Head:** `cc93cdd2`

**Classification:** extends — client-router prefetch, onboarding payload cache, and eager wizard routes change `app-ui` behavior. No new primitives.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | extends — eager onboarding routes, render prefetch, coalesced `/onboarding.json`, testimonial hide and hover-pause |

Unmatched path: `packages/worker/public/styles.css` (testimonial `[hidden]` override for the same `app-ui` surface).

### Change flow

SSR of `/onboarding/step-*` now ships `OnboardingRoute` in the origin bundle. Chip render prefetch coalesces one `/onboarding.json`. Live polls bypass that cache and drop first-paint snapshots. Unused mobile testimonial cards stay unpainted.

```mermaid
sequenceDiagram
	actor User
	participant appUi as app-ui
	User->>appUi: GET /onboarding/step-1
	Note over appUi: eager OnboardingRoute in SSR HTML, no Loading onboarding placeholder
	appUi->>appUi: prefetchRouteHrefs for on-screen chips including search
	appUi->>appUi: coalesce GET /onboarding.json
	User->>appUi: click chip
	appUi-->>User: adopt warmed shared payload
	appUi->>appUi: poll and OAuth refresh fetch fresh payload
	Note over appUi: discard render snapshots, retain hasMcpClient and milestones
	Note over appUi: form POST aborts in-flight /onboarding.json
	User->>appUi: view homepage testimonials
	Note over appUi: unused virtual cards display none, hover-pause desktop only
```

### Before / after

| Surface | Before | After |
| --- | --- | --- |
| Wizard SSR | Lazy area → “Loading onboarding…” | Eager `OnboardingRoute` in first HTML |
| Chip click | Cold `/onboarding.json` per destination | One shared in-flight request plus 30s cache |
| Progress poll | Same 30s cache hid new milestones | `fresh: true` hits `/onboarding.json` |
| Chip after poll | First-paint snapshot rewound progress | Snapshots discarded, progress retained |
| Form POST | In-flight fetch could rewrite cache | Abort + generation so late writes drop |
| Testimonials (mobile) | `[hidden]` still painted (`display:flex`) | `display: none` on unused virtual cards |
| Testimonials pause | `:hover` / `:focus-within` on any pointer | Desktop fine-pointer only |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-57fef667-0bc1-4734-ab99-074b6df23e3c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-57fef667-0bc1-4734-ab99-074b6df23e3c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Onboarding pickers now preload likely next-step destinations for faster navigation.
  - Onboarding data requests are reused briefly to reduce duplicate loading, with fresh data available when needed.
  - Onboarding pages now render their content directly during navigation.

- **Bug Fixes**
  - Testimonial carousel pausing and movement now behave correctly across pointer devices and narrow screens.
  - Hidden carousel cards no longer appear visually.
  - Onboarding route loading is more reliable and avoids unnecessary loading states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->