### PR TITLE
Fix HEAD-ahead badge to compare against the runtime pin

### DIFF
--- a/packages/worker/src/app/community-data.node.test.ts
+++ b/packages/worker/src/app/community-data.node.test.ts
@@ -25,6 +25,7 @@ const mockModule = vi.hoisted(() => ({
 	listCommunityForksByListingIdsAndUser: vi.fn(),
 	getCommunityListingById: vi.fn(),
 	getEntitySourceById: vi.fn(),
+	resolveCachedArtifactSourceHead: vi.fn(),
 	listSavedPackagesByKodyIds: vi.fn(),
 	listSavedPackagesByIds: vi.fn(),
 	getMcpUserPackageScope: vi.fn(),
@@ -63,6 +64,11 @@ vi.mock('#worker/community/repo.ts', () => ({
 vi.mock('#worker/repo/entity-sources.ts', () => ({
 	getEntitySourceById: (...args: Array<unknown>) =>
 		mockModule.getEntitySourceById(...args),
+}))
+
+vi.mock('#worker/repo/artifact-head-cache.ts', () => ({
+	resolveCachedArtifactSourceHead: (...args: Array<unknown>) =>
+		mockModule.resolveCachedArtifactSourceHead(...args),
 }))
 
 vi.mock('#worker/community/profile-repo.ts', () => ({
@@ -345,6 +351,54 @@ test('community detail overlays viewerInstall for forked listings and omits it w
 	expect(ahead?.viewerInstall?.listingAheadPrompt?.length ?? 0).toBeGreaterThan(
 		0,
 	)
+})
+
+test('sourceAhead compares HEAD to the runtime pin, not the community catalog snapshot', async () => {
+	resetDataCacheForTests()
+	mockModule.readAuthenticatedAppUser.mockResolvedValue(null)
+	mockModule.getCommunityListingWithAggregates.mockResolvedValue(sampleListing)
+	mockModule.getCommunityListingById.mockResolvedValue(sampleListing)
+	mockModule.getUserSocialRowByUsername.mockResolvedValue({
+		profile_visibility: 'public',
+		stable_user_id: 'owner-mcp-id',
+	})
+	mockModule.listCommunityForksByListingIdsAndUser.mockResolvedValue([])
+	mockModule.listSavedPackagesByKodyIds.mockResolvedValue([])
+	mockModule.listSavedPackagesByIds.mockResolvedValue([])
+	mockModule.getMcpUserPackageScope.mockResolvedValue('viewer')
+	const runtimePin = 'cccccccccccccccccccccccccccccccccccccccc'
+	const unpublishedHead = 'dddddddddddddddddddddddddddddddddddddddd'
+	mockModule.getEntitySourceById.mockResolvedValue({
+		repo_id: 'repo-1',
+		published_commit: runtimePin,
+	})
+	mockModule.resolveCachedArtifactSourceHead.mockResolvedValue({
+		branch: 'main',
+		commit: runtimePin,
+	})
+
+	const published = await loadCommunityDetailData(
+		{} as Env,
+		new Request('https://example.com/community/listing-github-published'),
+		'listing-github',
+	)
+	expect(published?.listing.sourceAhead).toBeUndefined()
+	expect(published?.listing.headCommit).toBeUndefined()
+	expect(published?.listing.pinnedCommit).toBe(sampleListing.pinnedCommit)
+	expect(published?.listing.pinnedCommit).not.toBe(runtimePin)
+
+	resetDataCacheForTests()
+	mockModule.resolveCachedArtifactSourceHead.mockResolvedValue({
+		branch: 'main',
+		commit: unpublishedHead,
+	})
+	const aheadOfRuntime = await loadCommunityDetailData(
+		{} as Env,
+		new Request('https://example.com/community/listing-github-runtime-ahead'),
+		'listing-github',
+	)
+	expect(aheadOfRuntime?.listing.sourceAhead).toBe(true)
+	expect(aheadOfRuntime?.listing.headCommit).toBe(unpublishedHead)
 })
 
 test('community index is memoized per request and forwards newest sort to loaders', async () => {

--- a/packages/worker/src/app/community-data.ts
+++ b/packages/worker/src/app/community-data.ts
@@ -291,14 +291,16 @@ export function loadCommunityDetailData(
 }
 
 /**
- * The public listing with aggregates and the Artifacts repo behind it. Cached
- * as one unit so a warm isolate answers the listing half of a page without
- * touching D1. The owner's profile visibility is deliberately not in here: it
- * is a privacy control and stays a fresh read on every request.
+ * The public listing with aggregates, the Artifacts repo behind it, and the
+ * package runtime pin. Cached as one unit so a warm isolate answers the
+ * listing half of a page without touching D1. The owner's profile visibility
+ * is deliberately not in here: it is a privacy control and stays a fresh
+ * read on every request.
  */
 type CommunityDetailPublicData = {
 	listing: PublicCommunityListing
 	sourceRepoId: string | null
+	publishedCommit: string | null
 }
 
 function loadCommunityDetailPublicData(
@@ -324,6 +326,7 @@ function loadCommunityDetailPublicData(
 					return {
 						listing: toPublicCommunityListing(row),
 						sourceRepoId: source?.repo_id ?? null,
+						publishedCommit: source?.published_commit ?? null,
 					}
 				},
 				request,
@@ -335,12 +338,18 @@ function loadCommunityDetailPublicData(
  * Overlay the repo's current default-branch HEAD on the listing. HEAD is
  * best-effort: a failed lookup still renders the page with the fallback
  * branch name, and a listing without a source row is returned untouched.
+ *
+ * Compare HEAD to the package runtime pin, not `listing.pinnedCommit`. The
+ * catalog snapshot only moves on community republish; `published_commit`
+ * moves on every package publish. Mixing those made the Code tab claim
+ * HEAD was unpublished after Publish HEAD already showed no changes.
  */
 async function withSourceHead(
 	env: Env,
 	request: Request,
 	listing: PublicCommunityListing,
 	sourceRepoId: string | null,
+	publishedCommit: string | null,
 ): Promise<PublicCommunityListing> {
 	if (!sourceRepoId) return listing
 	try {
@@ -349,10 +358,11 @@ async function withSourceHead(
 		})
 		const defaultBranch = head.branch?.trim() || fallbackDefaultBranchName
 		const headCommit = head.commit
+		const publishedPin = publishedCommit?.trim() || listing.pinnedCommit
 		return {
 			...listing,
 			defaultBranch,
-			...(headCommit && headCommit !== listing.pinnedCommit
+			...(headCommit && headCommit !== publishedPin
 				? { headCommit, sourceAhead: true }
 				: {}),
 		}
@@ -372,12 +382,12 @@ async function loadCommunityDetailDataUncached(
 		listingId,
 	)
 	if (!publicData) return null
-	const { listing, sourceRepoId } = publicData
+	const { listing, sourceRepoId, publishedCommit } = publicData
 
 	// HEAD lives in Artifacts, the owner row in D1, and the viewer in the
 	// session cookie; none of the three reads needs another.
 	const [sourceAheadListing, ownerRow, user] = await Promise.all([
-		withSourceHead(env, request, listing, sourceRepoId),
+		withSourceHead(env, request, listing, sourceRepoId, publishedCommit),
 		getUserSocialRowByUsername(env.APP_DB, listing.ownerUsername),
 		readOptionalAuthenticatedAppUser(request, env),
 	])

--- a/packages/worker/src/app/handlers/community-detail.frame.node.test.ts
+++ b/packages/worker/src/app/handlers/community-detail.frame.node.test.ts
@@ -232,7 +232,10 @@ test('owner source-ahead badge links to the published-vs-HEAD approve-publish pa
 	const headCommit = 'ffffffffffffffffffffffffffffffffffffffff'
 	mockModule.getCommunityListingWithAggregates.mockResolvedValue(sampleListing)
 	mockModule.getCommunityListingById.mockResolvedValue(sampleListing)
-	mockModule.getEntitySourceById.mockResolvedValue({ repo_id: 'repo-1' })
+	mockModule.getEntitySourceById.mockResolvedValue({
+		repo_id: 'repo-1',
+		published_commit: sampleListing.pinnedCommit,
+	})
 	mockModule.resolveArtifactSourceHead.mockResolvedValue({
 		branch: 'main',
 		commit: headCommit,
@@ -278,7 +281,10 @@ test('owner source-ahead badge links to the published-vs-HEAD approve-publish pa
 test('visitor source-ahead badge is not a publish link', async () => {
 	mockModule.getCommunityListingWithAggregates.mockResolvedValue(sampleListing)
 	mockModule.getCommunityListingById.mockResolvedValue(sampleListing)
-	mockModule.getEntitySourceById.mockResolvedValue({ repo_id: 'repo-1' })
+	mockModule.getEntitySourceById.mockResolvedValue({
+		repo_id: 'repo-1',
+		published_commit: sampleListing.pinnedCommit,
+	})
 	mockModule.resolveArtifactSourceHead.mockResolvedValue({
 		branch: 'main',
 		commit: 'ffffffffffffffffffffffffffffffffffffffff',
@@ -305,6 +311,49 @@ test('visitor source-ahead badge is not a publish link', async () => {
 	expect(html).toContain('data-testid="community-detail-source-ahead-badge"')
 	expect(html).toMatch(
 		/<span[^>]*data-testid="community-detail-source-ahead-badge"/,
+	)
+	expect(html).not.toContain('approve-publish')
+	expect(mockModule.getSavedPackageByKodyId).not.toHaveBeenCalled()
+})
+
+test('source-ahead badge stays off when HEAD matches the runtime pin but not the catalog snapshot', async () => {
+	const runtimePin = 'cccccccccccccccccccccccccccccccccccccccc'
+	mockModule.getCommunityListingWithAggregates.mockResolvedValue(sampleListing)
+	mockModule.getCommunityListingById.mockResolvedValue(sampleListing)
+	mockModule.getEntitySourceById.mockResolvedValue({
+		repo_id: 'repo-1',
+		published_commit: runtimePin,
+	})
+	mockModule.resolveArtifactSourceHead.mockResolvedValue({
+		branch: 'main',
+		commit: runtimePin,
+	})
+	mockModule.readAuthenticatedAppUser.mockResolvedValue({
+		mcpUser: { userId: 'owner-mcp-id', username: 'kentcdodds' },
+		roles: [],
+	})
+	mockModule.listCommunityForksByListingIdsAndUser.mockResolvedValue([])
+	mockModule.listSavedPackagesByKodyIds.mockResolvedValue([])
+	mockModule.listSavedPackagesByIds.mockResolvedValue([])
+	mockModule.getSavedPackageByKodyId.mockResolvedValue({ id: 'pkg-1' })
+	mockModule.getMcpUserPackageScope.mockResolvedValue('kentcdodds')
+	mockModule.getUserSocialRowByUsername.mockResolvedValue({
+		profile_visibility: 'public',
+		stable_user_id: 'owner-mcp-id',
+	})
+
+	const handler = createCommunityDetailHandler(env)
+	const response = await handler.handler({
+		request: new Request('https://example.com/community/listing-1', {
+			headers: { 'x-remix-target': 'community-detail' },
+		}),
+		params: { listingId: 'listing-1' },
+		url: new URL('https://example.com/community/listing-1'),
+	} as never)
+	const html = await response.text()
+	expect(sampleListing.pinnedCommit).not.toBe(runtimePin)
+	expect(html).not.toContain(
+		'data-testid="community-detail-source-ahead-badge"',
 	)
 	expect(html).not.toContain('approve-publish')
 	expect(mockModule.getSavedPackageByKodyId).not.toHaveBeenCalled()

--- a/packages/worker/universal/community-public-types.ts
+++ b/packages/worker/universal/community-public-types.ts
@@ -50,7 +50,11 @@ export type PublicCommunityListing = {
 	defaultBranch?: string
 	/** Default-branch HEAD SHA when it differs from the package runtime pin. */
 	headCommit?: string | null
-	/** True when default-branch HEAD is ahead of `pinnedCommit` (package publish). */
+	/**
+	 * True when default-branch HEAD differs from the package runtime pin,
+	 * not the community catalog snapshot (`pinnedCommit`). Runtime publish
+	 * can advance the pin without a community republish.
+	 */
 	sourceAhead?: boolean
 	publishedAt: string
 	ownerUsername: string


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Make the package Code tab’s **HEAD ahead of published** badge agree with the Publish HEAD page.

## Why

On `@kentcdodds/kody-issue-triage`, the Code tab linked to Publish HEAD even though that page showed the same SHA on both sides and **No unpublished changes**.

Production listing JSON still shows the mismatch:

- Catalog snapshot (`pinnedCommit`): `db110beb93c1366cb8748baf399ab79c1c880a8c` (community publish 2026-08-21)
- Default-branch HEAD: `70e692592c585682eb65c769101e6a3ba55cd8d2`
- Community icon URL is already at `70e69259…` because package publish refreshes the icon from the **runtime** pin
- `sourceAhead: true` because the badge compared HEAD to the catalog snapshot

Package publish advances `published_commit` without rewriting the community listing pin. Publish HEAD already compared against the runtime pin, so it correctly said there was nothing to publish.

## Summary

- Overlay `sourceAhead` by comparing Artifacts HEAD to `entity_sources.published_commit`, falling back to `listing.pinnedCommit` only when the source has no runtime pin
- Keep the catalog snapshot for forks / listing-ahead; do not use it as “last package publish”
- Tests cover HEAD matching the runtime pin while the catalog snapshot lags, and HEAD actually unpublished relative to the runtime pin

## Testing

- `npm run test:push` (node-unit 2601 passed, workers-unit 327 passed) on the pre-push hook
- Focused coverage in `community-data.node.test.ts` and `community-detail.frame.node.test.ts`
- Production listing JSON for `kody-issue-triage` confirms HEAD `70e69259…` vs catalog pin `db110beb…` with `sourceAhead: true`

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `6d4a0350` · **Head:** `4a2dddb2`

**Classification:** extends — the community detail overlay now treats the package runtime pin as “published” instead of the catalog snapshot.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | extends — `sourceAhead` compares HEAD to `published_commit` |
| `community-listings` | assistant | extends — Code-tab badge no longer lies after a runtime-only publish |

### Change flow

The Code tab and Publish HEAD now use the same pin, so a runtime publish that does not republish the catalog no longer looks unpublished.

```mermaid
sequenceDiagram
	actor Owner
	participant appUi as app-ui
	participant artifacts as artifacts-source
	participant d1AppDb as d1-app-db
	Owner->>appUi: open /@user/kodyId
	appUi->>artifacts: resolve default-branch HEAD
	appUi->>d1AppDb: read published_commit (was listing.pinnedCommit)
	alt HEAD equals published_commit
		appUi-->>Owner: no HEAD-ahead badge
	else HEAD differs
		appUi-->>Owner: badge links to approve-publish
		Owner->>appUi: Publish HEAD
		appUi->>d1AppDb: compare pending SHA to published_commit
	end
```

### Before / after

```diff
- sourceAhead = HEAD !== listing.pinnedCommit
+ sourceAhead = HEAD !== (published_commit || listing.pinnedCommit)
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-45537967-cb36-4ed4-b204-7c5f597a68ac?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-45537967-cb36-4ed4-b204-7c5f597a68ac&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

