### PR TITLE
Fix homepage testimonials marquee snapping at wrap

### DIFF
--- a/packages/worker/client/routes/landing-testimonials-carousel.node.test.ts
+++ b/packages/worker/client/routes/landing-testimonials-carousel.node.test.ts
@@ -5,6 +5,7 @@ import { expect, test } from 'vitest'
 import {
 	PARKED_TRANSFORM,
 	canPauseOnHover,
+	isTestimonialsLanePaused,
 	listLanePlacements,
 	parkUnusedLaneCards,
 	placeLaneCard,
@@ -131,6 +132,25 @@ test('narrow swipe moves the leading card off the origin instead of pinning it',
 		canPauseOnHover((query) => ({
 			matches: query === '(hover: hover) and (pointer: fine)',
 		})),
+	).toBe(true)
+
+	const idle = {
+		inView: true,
+		userNudging: false,
+		focus: false,
+		hover: false,
+		matchesHover: false,
+		matchesFocusWithin: false,
+		hoverCapable: false,
+	}
+	expect(isTestimonialsLanePaused(idle)).toBe(false)
+	expect(isTestimonialsLanePaused({ ...idle, focus: true })).toBe(true)
+	expect(isTestimonialsLanePaused({ ...idle, hover: true })).toBe(false)
+	expect(isTestimonialsLanePaused({ ...idle, matchesFocusWithin: true })).toBe(
+		false,
+	)
+	expect(
+		isTestimonialsLanePaused({ ...idle, hoverCapable: true, hover: true }),
 	).toBe(true)
 })
 

--- a/packages/worker/client/routes/landing-testimonials-carousel.node.test.ts
+++ b/packages/worker/client/routes/landing-testimonials-carousel.node.test.ts
@@ -127,3 +127,27 @@ test('narrow swipe moves the leading card off the origin instead of pinning it',
 		})),
 	).toBe(true)
 })
+
+test('an exiting card stays on the negative lane instead of snapping to the origin', () => {
+	const stride = 500
+	const cardWidth = 480
+	const viewportWidth = 1200
+	const offset = Math.round(cardWidth * 0.75)
+
+	const placements = listLanePlacements({
+		count: 4,
+		stride,
+		cardWidth,
+		offset,
+		viewportWidth,
+	})
+	const leading = placements.filter((placement) => placement.itemIndex === 0)
+	expect(leading.some((placement) => placement.x === 0)).toBe(false)
+	expect(leading).toContainEqual({ itemIndex: 0, x: -offset, seam: false })
+	expect(placements.find((placement) => placement.itemIndex === 1)?.x).toBe(
+		stride - offset,
+	)
+	expect(
+		largestVisibleHole(placements, viewportWidth, cardWidth),
+	).toBeLessThanOrEqual(stride - cardWidth)
+})

--- a/packages/worker/client/routes/landing-testimonials-carousel.node.test.ts
+++ b/packages/worker/client/routes/landing-testimonials-carousel.node.test.ts
@@ -1,7 +1,13 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { expect, test } from 'vitest'
 import {
+	PARKED_TRANSFORM,
 	canPauseOnHover,
 	listLanePlacements,
+	parkUnusedLaneCards,
+	placeLaneCard,
 	wrapPagerIndex,
 	wrapUnitInterval,
 } from './landing-testimonials-motion.ts'
@@ -150,4 +156,73 @@ test('an exiting card stays on the negative lane instead of snapping to the orig
 	expect(
 		largestVisibleHole(placements, viewportWidth, cardWidth),
 	).toBeLessThanOrEqual(stride - cardWidth)
+
+	const cards = [0, 1, 2, 3].map(() => ({
+		hidden: false,
+		style: { transform: '' },
+	}))
+	const clone = { hidden: false, style: { transform: '' } }
+	const used = new Set<(typeof cards)[number] | typeof clone>()
+	for (const placement of placements) {
+		const source = cards[placement.itemIndex]
+		if (!source) continue
+		const node = placement.seam ? clone : source
+		placeLaneCard(node, placement.x)
+		used.add(node)
+	}
+	parkUnusedLaneCards(cards, used)
+	parkUnusedLaneCards([clone], used)
+
+	expect(cards[0]?.hidden).toBe(false)
+	expect(cards[0]?.style.transform).toBe(`translate3d(${-offset}px, 0, 0)`)
+	expect(cards[0]?.style.transform).not.toBe('')
+	expect(cards[0]?.style.transform).not.toBe(PARKED_TRANSFORM)
+	for (const card of cards) {
+		if (used.has(card)) continue
+		expect(card.hidden).toBe(true)
+		expect(card.style.transform).toBe(PARKED_TRANSFORM)
+	}
+	if (!used.has(clone)) {
+		expect(clone.hidden).toBe(true)
+		expect(clone.style.transform).toBe(PARKED_TRANSFORM)
+	}
+})
+
+test('unused cards keep a parked transform instead of snapping to the origin', () => {
+	const onStage = {
+		hidden: true,
+		style: { transform: PARKED_TRANSFORM },
+	}
+	const exiting = {
+		hidden: false,
+		style: { transform: 'translate3d(-360px, 0, 0)' },
+	}
+	const clone = {
+		hidden: false,
+		style: { transform: 'translate3d(1640px, 0, 0)' },
+	}
+	placeLaneCard(onStage, 140)
+	parkUnusedLaneCards([onStage, exiting], new Set([onStage]))
+	parkUnusedLaneCards([clone], new Set())
+
+	expect(onStage.hidden).toBe(false)
+	expect(onStage.style.transform).toBe('translate3d(140px, 0, 0)')
+	expect(exiting.hidden).toBe(true)
+	expect(exiting.style.transform).toBe(PARKED_TRANSFORM)
+	expect(exiting.style.transform).not.toBe('')
+	expect(clone.hidden).toBe(true)
+	expect(clone.style.transform).toBe(PARKED_TRANSFORM)
+})
+
+test('virtual [hidden] cards override author display flex', () => {
+	const css = readFileSync(
+		path.resolve(
+			path.dirname(fileURLToPath(import.meta.url)),
+			'../../public/styles.css',
+		),
+		'utf8',
+	)
+	expect(css).toMatch(
+		/\.landing-testimonials-track\.is-virtual\s+\.landing-testimonial-card\[hidden\]\s*\{[^}]*display:\s*none/,
+	)
 })

--- a/packages/worker/client/routes/landing-testimonials-carousel.tsx
+++ b/packages/worker/client/routes/landing-testimonials-carousel.tsx
@@ -9,7 +9,7 @@ import {
 } from '#universal/landing-testimonials.ts'
 import {
 	TESTIMONIALS_LAP_MS,
-	canPauseOnHover,
+	isTestimonialsLanePaused,
 	listLanePlacements,
 	parkUnusedLaneCards,
 	placeLaneCard,
@@ -165,16 +165,14 @@ function armTestimonialsMotion(scroller: HTMLElement, signal: AbortSignal) {
 	let dragging = false
 
 	function isPaused() {
-		if (!inView || userNudging) return true
-		// Touch and window-resize leave `:hover` / `:focus-within` stuck on
-		// the strip. Only fine pointers get a hover/focus pause.
-		if (!canPauseOnHover()) return false
-		return (
-			hover ||
-			focus ||
-			scroller.matches(':hover') ||
-			scroller.matches(':focus-within')
-		)
+		return isTestimonialsLanePaused({
+			inView,
+			userNudging,
+			focus,
+			hover,
+			matchesHover: scroller.matches(':hover'),
+			matchesFocusWithin: scroller.matches(':focus-within'),
+		})
 	}
 
 	function realCards() {

--- a/packages/worker/client/routes/landing-testimonials-carousel.tsx
+++ b/packages/worker/client/routes/landing-testimonials-carousel.tsx
@@ -11,14 +11,14 @@ import {
 	TESTIMONIALS_LAP_MS,
 	canPauseOnHover,
 	listLanePlacements,
+	parkUnusedLaneCards,
+	placeLaneCard,
 	wrapPagerIndex,
 	wrapUnitInterval,
 } from './landing-testimonials-motion.ts'
 
 const USER_NUDGE_RESUME_MS = 500
 const DRAG_THRESHOLD_PX = 8
-/** Off-stage park if `[hidden]` loses to `display: flex` (see styles.css). */
-const PARKED_TRANSFORM = 'translate3d(-200vw, 0, 0)'
 
 /**
  * Homepage testimonials strip. SSR and the first client render paint the
@@ -264,23 +264,11 @@ function armTestimonialsMotion(scroller: HTMLElement, signal: AbortSignal) {
 			const node = placement.seam
 				? takeSeamClone(source, placement.itemIndex, seamSlot++)
 				: source
-			node.hidden = false
-			node.style.transform = `translate3d(${placement.x}px, 0, 0)`
+			placeLaneCard(node, placement.x)
 			used.add(node)
 		}
-		for (const card of sources) {
-			if (used.has(card)) continue
-			parkCard(card)
-		}
-		for (const clone of seamClones) {
-			if (used.has(clone)) continue
-			parkCard(clone)
-		}
-	}
-
-	function parkCard(node: HTMLElement) {
-		node.hidden = true
-		node.style.transform = PARKED_TRANSFORM
+		parkUnusedLaneCards(sources, used)
+		parkUnusedLaneCards(seamClones, used)
 	}
 
 	function markUserNudge() {

--- a/packages/worker/client/routes/landing-testimonials-carousel.tsx
+++ b/packages/worker/client/routes/landing-testimonials-carousel.tsx
@@ -17,6 +17,8 @@ import {
 
 const USER_NUDGE_RESUME_MS = 500
 const DRAG_THRESHOLD_PX = 8
+/** Off-stage park if `[hidden]` loses to `display: flex` (see styles.css). */
+const PARKED_TRANSFORM = 'translate3d(-200vw, 0, 0)'
 
 /**
  * Homepage testimonials strip. SSR and the first client render paint the
@@ -268,14 +270,17 @@ function armTestimonialsMotion(scroller: HTMLElement, signal: AbortSignal) {
 		}
 		for (const card of sources) {
 			if (used.has(card)) continue
-			card.hidden = true
-			card.style.transform = ''
+			parkCard(card)
 		}
-		for (const [index, clone] of seamClones.entries()) {
+		for (const clone of seamClones) {
 			if (used.has(clone)) continue
-			clone.hidden = true
-			if (index >= seamSlot) clone.style.transform = ''
+			parkCard(clone)
 		}
+	}
+
+	function parkCard(node: HTMLElement) {
+		node.hidden = true
+		node.style.transform = PARKED_TRANSFORM
 	}
 
 	function markUserNudge() {

--- a/packages/worker/client/routes/landing-testimonials-motion.ts
+++ b/packages/worker/client/routes/landing-testimonials-motion.ts
@@ -14,8 +14,9 @@ export function wrapPagerIndex(index: number, count: number) {
 }
 
 /**
- * Hover/focus pause is desktop-only. Coarse pointers and window-resize
- * leave `:hover` stuck on the strip, which freezes the lane.
+ * Hover pause is desktop-only. Coarse pointers and window-resize leave
+ * `:hover` stuck on the strip, which freezes the lane. Keyboard `focus`
+ * still pauses on every pointer class.
  */
 export function canPauseOnHover(
 	query: (query: string) => { matches: boolean } = (mediaQuery) =>
@@ -24,6 +25,20 @@ export function canPauseOnHover(
 			: { matches: false },
 ) {
 	return query('(hover: hover) and (pointer: fine)').matches
+}
+
+export function isTestimonialsLanePaused(input: {
+	inView: boolean
+	userNudging: boolean
+	focus: boolean
+	hover: boolean
+	matchesHover: boolean
+	matchesFocusWithin: boolean
+	hoverCapable?: boolean
+}) {
+	if (!input.inView || input.userNudging || input.focus) return true
+	if (!(input.hoverCapable ?? canPauseOnHover())) return false
+	return input.hover || input.matchesHover || input.matchesFocusWithin
 }
 
 export function wrapUnitInterval(value: number, period: number) {

--- a/packages/worker/client/routes/landing-testimonials-motion.ts
+++ b/packages/worker/client/routes/landing-testimonials-motion.ts
@@ -32,6 +32,35 @@ export function wrapUnitInterval(value: number, period: number) {
 	return next < 0 ? next + period : next
 }
 
+/** Off-stage park if `[hidden]` loses to `display: flex` (see styles.css). */
+export const PARKED_TRANSFORM = 'translate3d(-200vw, 0, 0)'
+
+export type ParkableLaneCard = {
+	hidden: HTMLElement['hidden']
+	style: Pick<CSSStyleDeclaration, 'transform'>
+}
+
+export function placeLaneCard(node: ParkableLaneCard, x: number) {
+	node.hidden = false
+	node.style.transform = `translate3d(${x}px, 0, 0)`
+}
+
+export function parkLaneCard(node: ParkableLaneCard) {
+	node.hidden = true
+	node.style.transform = PARKED_TRANSFORM
+}
+
+/** Hide and park every card that is not in this frame's used set. */
+export function parkUnusedLaneCards<T extends ParkableLaneCard>(
+	nodes: Iterable<T>,
+	used: ReadonlySet<T>,
+) {
+	for (const node of nodes) {
+		if (used.has(node)) continue
+		parkLaneCard(node)
+	}
+}
+
 /**
  * Visible + overscan placements on a circular lane.
  *


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Make the homepage testimonials strip loop without a visible snap or overlapping card when a quote wraps off the left edge.

## Why

Unused virtual-lane cards could stay painted at the grid origin. Author `display: flex` beats the UA `[hidden]` rule, so a recycled quote jumped back onto the strip (and overlapped the card that should have been leading) instead of staying off-stage. `#2066` landed the CSS `display: none` override; this branch parks unused cards off-stage so a `[hidden]` miss still cannot snap to `x = 0`.

## Summary

- Park unused source cards and seam clones at `-200vw` instead of clearing `transform`.
- Extract place/park helpers and assert unused cards stay hidden with the parked transform.
- Pause the lane on keyboard `focus` even on coarse pointers; keep hover and `:focus-within` capability-gated so a stuck hover cannot freeze the strip.
- Rebased onto `main` (keeps `#2066` mobile hide / hover-pause coverage).

## Testing

- `vitest run --project node-unit packages/worker/client/routes/landing-testimonials-carousel.node.test.ts`
- `test:push` (node-unit + workers-unit) on push
- Local homepage at `http://127.0.0.1:3742/#testimonials-title`: 96 virtual-lane samples over 24s, two wraps, zero overlaps, hidden cards `display: none`
- Browser recording of the strip scrolling through wraps without a snap

![Testimonials strip after a wrap](https://cursor.com/artifacts/c/art-0911f656-9deb-4fc4-9bf7-c561d427ad47)

<a href="https://cursor.com/agents/bc-cac5f3fc-297b-4fd2-9d02-674ee23a0b48/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftestimonials_marquee_smooth_wrap.mp4"><img src="https://cursor.com/artifacts/c/art-adb85497-d494-4cb2-bba6-1585ed3735b8" alt="testimonials_marquee_smooth_wrap.mp4" /></a>

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `1f90bb62` · **Head:** `f9c89768`

**Classification:** composes — no primitives added or changed; this PR parks unused homepage testimonials lane cards off-stage.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `app-ui` | surfaces | composes — unused lane cards are parked off-stage; keyboard focus pauses the lane |

### Change flow

The enhance-only testimonials lane parks recycled cards so a wrap cannot paint at the grid origin.

```mermaid
sequenceDiagram
	actor Visitor
	participant appUi as app-ui
	Visitor->>appUi: load homepage testimonials strip
	appUi->>appUi: arm virtual lane and requestAnimationFrame
	appUi->>appUi: hide unused cards and park them off-stage
	Note over appUi: parked transform keeps recycled quotes off the origin if hidden loses to flex
	Visitor->>appUi: keyboard focus on a testimonial link
	appUi->>appUi: pause the lane even on coarse pointers
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cac5f3fc-297b-4fd2-9d02-674ee23a0b48?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cac5f3fc-297b-4fd2-9d02-674ee23a0b48&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved testimonials carousel positioning so cards leaving the visible lane retain the correct off-screen placement.
  * Ensured unused cards and seam clones are consistently hidden and moved off stage.
  * Fixed virtual testimonial cards being displayed when author styling uses flex layouts.
  * Improved carousel pausing when the lane is focused, hovered, or otherwise not actively visible.

* **Tests**
  * Added regression coverage for card positioning, parking, pause behavior, seam clones, and hidden-card styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->