### PR TITLE
Link the header avatar to the public profile

### DIFF
--- a/docs/use/waiting.md
+++ b/docs/use/waiting.md
@@ -1,7 +1,8 @@
 # Waiting
 
 Waiting is the current-state queue of things only **you** can clear. Open
-**`/account/waiting`** while signed in — the header avatar lands here.
+**`/account/waiting`** from Account while signed in. The header avatar goes to
+your public profile (`/@username`).
 
 Items are derived from live account state. They disappear when the gate clears.
 There is no read/unread mark, archive, or notification table.

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -33,11 +33,11 @@ test('smoke test covers shell, auth redirect, and login', async ({ page }) => {
 	await page.getByRole('button', { name: 'Sign in', exact: true }).click()
 
 	await expect(page).toHaveURL(/\/account$/)
-	// Header avatar is labeled Waiting plus the username so it does not
-	// collide with the "Kody" brand link.
+	// Header avatar links to the public profile and is labeled @username so
+	// it does not collide with the "Kody" brand link.
 	await expect(
 		page.getByRole('navigation', { name: 'Main' }).getByRole('link', {
-			name: `Waiting — ${primaryTestUser.username}`,
+			name: `@${primaryTestUser.username}`,
 		}),
 	).toBeVisible()
 	await expect(
@@ -78,7 +78,7 @@ test('smoke test covers shell, auth redirect, and login', async ({ page }) => {
 	await expect(page.getByRole('button', { name: 'Log out' })).not.toBeVisible()
 	await expect(
 		page.getByRole('link', {
-			name: `Waiting — ${primaryTestUser.username}`,
+			name: `@${primaryTestUser.username}`,
 		}),
 	).not.toBeVisible()
 

--- a/packages/worker/client/app.tsx
+++ b/packages/worker/client/app.tsx
@@ -267,6 +267,7 @@ export function App(handle: Handle<AppProps>) {
 							<SiteHeader
 								loggedIn={isLoggedIn}
 								displayName={sessionDisplayName}
+								username={session?.username ?? ''}
 								avatarUrl={session?.avatarUrl ?? null}
 								showAdminLink={showAdminLink}
 								showDemoIndicator={isLoggedIn && showDemoIndicator}

--- a/packages/worker/client/site-header.node.test.ts
+++ b/packages/worker/client/site-header.node.test.ts
@@ -51,6 +51,7 @@ test('logged-in avatar and mobile menu go to the public profile with the usernam
 	expect(html).toContain('aria-label="@ada"')
 	expect(html).toContain('data-testid="site-header-profile"')
 	expect(html).toContain('data-testid="site-header-profile-menu"')
+	expect(html).toMatch(/site-header-profile-menu[\s\S]*?>ada</)
 	expect(html).not.toContain('Waiting')
 	expect(html).not.toContain('/account/waiting')
 })

--- a/packages/worker/client/site-header.node.test.ts
+++ b/packages/worker/client/site-header.node.test.ts
@@ -1,5 +1,7 @@
 import { expect, test, vi } from 'vitest'
-import { dismissOpenPopoverPanel } from './site-header.tsx'
+import { jsx } from 'remix/ui/jsx-runtime'
+import { renderToString } from 'remix/ui/server'
+import { dismissOpenPopoverPanel, SiteHeader } from './site-header.tsx'
 
 test('dismissOpenPopoverPanel hides open popovers and no-ops when unavailable or closed', () => {
 	const unavailableMatches = vi.fn(() => {
@@ -29,4 +31,26 @@ test('dismissOpenPopoverPanel hides open popovers and no-ops when unavailable or
 	} as unknown as HTMLElement
 	dismissOpenPopoverPanel(closedPanel)
 	expect(closedHidePopover).not.toHaveBeenCalled()
+})
+
+test('logged-in avatar and mobile menu go to the public profile with the username', async () => {
+	const html = await renderToString(
+		jsx(SiteHeader, {
+			loggedIn: true,
+			displayName: 'Ada Lovelace',
+			username: 'ada',
+			avatarUrl: null,
+			showAdminLink: false,
+			showDemoIndicator: false,
+			loginHref: '/login',
+			currentPathname: '/account',
+		}),
+	)
+
+	expect(html).toContain('href="/@ada"')
+	expect(html).toContain('aria-label="@ada"')
+	expect(html).toContain('data-testid="site-header-profile"')
+	expect(html).toContain('data-testid="site-header-profile-menu"')
+	expect(html).not.toContain('Waiting')
+	expect(html).not.toContain('/account/waiting')
 })

--- a/packages/worker/client/site-header.tsx
+++ b/packages/worker/client/site-header.tsx
@@ -210,6 +210,7 @@ export function SiteHeader(handle: Handle<SiteHeaderProps>) {
 									{profileHref ? (
 										<a
 											href={profileHref}
+											aria-label={`@${handle.props.username}`}
 											aria-current={profileAriaCurrent}
 											data-testid="site-header-profile-menu"
 											mix={css(menuProfileLinkCss)}

--- a/packages/worker/client/site-header.tsx
+++ b/packages/worker/client/site-header.tsx
@@ -2,6 +2,7 @@ import { type Handle, css } from 'remix/ui'
 import { listenToRouterNavigation } from '#client/client-router.tsx'
 import { on } from '#client/event-mixin.ts'
 import { UserAvatar } from '#universal/user-avatar.tsx'
+import { routes } from '#universal/routes.ts'
 import {
 	colors,
 	radius,
@@ -19,6 +20,7 @@ import {
 export type SiteHeaderProps = {
 	loggedIn: boolean
 	displayName: string
+	username: string
 	avatarUrl: string | null
 	showAdminLink: boolean
 	showDemoIndicator: boolean
@@ -83,90 +85,23 @@ export function SiteHeader(handle: Handle<SiteHeaderProps>) {
 		handle.update()
 	}
 
-	return () => (
-		<header class="site-header" mix={css(headerCss)}>
-			<nav aria-label="Main" mix={css(navCss)}>
-				<a href="/" mix={css(brandCss)}>
-					<img src="/images/kody-mark.png" alt="" width={34} height={34} />
-					<span>Kody</span>
-				</a>
-				<div mix={css(navLinksCss)}>
-					{marketingLinks.map((link) => (
-						<a
-							key={link.href}
-							href={link.href}
-							aria-current={ariaCurrent(
-								handle.props.currentPathname,
-								link.href,
-							)}
-						>
-							{link.label}
-						</a>
-					))}
-					{handle.props.showAdminLink ? (
-						<a
-							href="/admin/users"
-							aria-current={ariaCurrent(
-								handle.props.currentPathname,
-								'/admin/users',
-							)}
-						>
-							Admin
-						</a>
-					) : null}
-				</div>
-				<div mix={css(navActionsCss)}>
-					{handle.props.loggedIn ? (
-						<>
-							<a
-								href="/account/waiting"
-								aria-label={`Waiting — ${handle.props.displayName}`}
-								aria-current={ariaCurrent(
-									handle.props.currentPathname,
-									'/account/waiting',
-								)}
-								data-testid="site-header-waiting"
-								mix={css(navUserAvatarCss)}
-							>
-								<UserAvatar
-									displayName={handle.props.displayName}
-									avatarUrl={handle.props.avatarUrl}
-									size={32}
-									variant="well"
-								/>
-							</a>
-							{handle.props.showDemoIndicator ? (
-								<span data-testid="demo-indicator" mix={css(demoIndicatorCss)}>
-									Demo
-								</span>
-							) : null}
-						</>
-					) : (
-						<a href={handle.props.loginHref} mix={css(navLoginCss)}>
-							Log in
-						</a>
-					)}
-				</div>
-				<button
-					type="button"
-					popovertarget={menuPanelId}
-					aria-label="Menu"
-					aria-expanded={menuOpen ? 'true' : 'false'}
-					data-open={menuOpen ? '' : undefined}
-					mix={css(menuToggleCss)}
-				>
-					<span aria-hidden="true" mix={css(burgerCss)}>
-						<span />
-						<span />
-						<span />
-					</span>
-				</button>
-				<div
-					id={menuPanelId}
-					popover
-					mix={[css(menuPanelCss), on('toggle', onMenuToggle)]}
-				>
-					<div mix={css(menuGroupCss)}>
+	return () => {
+		const profileHref = handle.props.username
+			? routes.profile.href({ username: handle.props.username })
+			: null
+		const profileAriaCurrent =
+			profileHref && handle.props.currentPathname === profileHref
+				? ('page' as const)
+				: undefined
+
+		return (
+			<header class="site-header" mix={css(headerCss)}>
+				<nav aria-label="Main" mix={css(navCss)}>
+					<a href="/" mix={css(brandCss)}>
+						<img src="/images/kody-mark.png" alt="" width={34} height={34} />
+						<span>Kody</span>
+					</a>
+					<div mix={css(navLinksCss)}>
 						{marketingLinks.map((link) => (
 							<a
 								key={link.href}
@@ -191,47 +126,124 @@ export function SiteHeader(handle: Handle<SiteHeaderProps>) {
 							</a>
 						) : null}
 					</div>
-					<div mix={css(menuGroupCss)}>
+					<div mix={css(navActionsCss)}>
 						{handle.props.loggedIn ? (
 							<>
-								<a
-									href="/account/waiting"
-									aria-label={`Waiting — ${handle.props.displayName}`}
-									aria-current={ariaCurrent(
-										handle.props.currentPathname,
-										'/account/waiting',
-									)}
-									data-testid="site-header-waiting-menu"
-									mix={css(menuWaitingLinkCss)}
-								>
-									<UserAvatar
-										displayName={handle.props.displayName}
-										avatarUrl={handle.props.avatarUrl}
-										size={32}
-										variant="well"
-									/>
-									Waiting
-								</a>
-								<a
-									href="/account"
-									aria-current={
-										handle.props.currentPathname === '/account'
-											? 'page'
-											: undefined
-									}
-									data-testid="site-header-account-menu"
-								>
-									Account
-								</a>
+								{profileHref ? (
+									<a
+										href={profileHref}
+										aria-label={`@${handle.props.username}`}
+										aria-current={profileAriaCurrent}
+										data-testid="site-header-profile"
+										mix={css(navUserAvatarCss)}
+									>
+										<UserAvatar
+											displayName={handle.props.displayName}
+											avatarUrl={handle.props.avatarUrl}
+											size={32}
+											variant="well"
+										/>
+									</a>
+								) : null}
+								{handle.props.showDemoIndicator ? (
+									<span
+										data-testid="demo-indicator"
+										mix={css(demoIndicatorCss)}
+									>
+										Demo
+									</span>
+								) : null}
 							</>
 						) : (
-							<a href={handle.props.loginHref}>Log in</a>
+							<a href={handle.props.loginHref} mix={css(navLoginCss)}>
+								Log in
+							</a>
 						)}
 					</div>
-				</div>
-			</nav>
-		</header>
-	)
+					<button
+						type="button"
+						popovertarget={menuPanelId}
+						aria-label="Menu"
+						aria-expanded={menuOpen ? 'true' : 'false'}
+						data-open={menuOpen ? '' : undefined}
+						mix={css(menuToggleCss)}
+					>
+						<span aria-hidden="true" mix={css(burgerCss)}>
+							<span />
+							<span />
+							<span />
+						</span>
+					</button>
+					<div
+						id={menuPanelId}
+						popover
+						mix={[css(menuPanelCss), on('toggle', onMenuToggle)]}
+					>
+						<div mix={css(menuGroupCss)}>
+							{marketingLinks.map((link) => (
+								<a
+									key={link.href}
+									href={link.href}
+									aria-current={ariaCurrent(
+										handle.props.currentPathname,
+										link.href,
+									)}
+								>
+									{link.label}
+								</a>
+							))}
+							{handle.props.showAdminLink ? (
+								<a
+									href="/admin/users"
+									aria-current={ariaCurrent(
+										handle.props.currentPathname,
+										'/admin/users',
+									)}
+								>
+									Admin
+								</a>
+							) : null}
+						</div>
+						<div mix={css(menuGroupCss)}>
+							{handle.props.loggedIn ? (
+								<>
+									{profileHref ? (
+										<a
+											href={profileHref}
+											aria-current={profileAriaCurrent}
+											data-testid="site-header-profile-menu"
+											mix={css(menuProfileLinkCss)}
+										>
+											<UserAvatar
+												displayName={handle.props.displayName}
+												avatarUrl={handle.props.avatarUrl}
+												size={32}
+												variant="well"
+											/>
+											{handle.props.username}
+										</a>
+									) : null}
+									<a
+										href="/account"
+										aria-current={
+											handle.props.currentPathname === '/account'
+												? 'page'
+												: undefined
+										}
+										data-testid="site-header-account-menu"
+									>
+										Account
+									</a>
+								</>
+							) : (
+								<a href={handle.props.loginHref}>Log in</a>
+							)}
+						</div>
+					</div>
+				</nav>
+			</header>
+		)
+	}
 }
 
 const headerCss = {
@@ -462,7 +474,7 @@ const navUserAvatarCss = {
 	'&:hover': { color: colors.text },
 }
 
-const menuWaitingLinkCss = {
+const menuProfileLinkCss = {
 	gap: '0.65rem',
 }
 

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -389,10 +389,11 @@ test('SSR HTML routes render page content and embedded loader data', async () =>
 	expect(accountResponse.status).toBe(200)
 	const accountHtml = await readResponseText(accountResponse)
 	expect(accountHtml).toContain('aria-label="Account sections"')
-	expect(accountHtml).toContain('data-testid="site-header-waiting"')
+	expect(accountHtml).toContain('data-testid="site-header-profile"')
 	expect(accountHtml).toContain('data-testid="site-header-account-menu"')
-	expect(accountHtml).toContain('href="/account/waiting"')
-	expect(accountHtml).toContain('Waiting — account-user')
+	expect(accountHtml).toContain('href="/@account-user"')
+	expect(accountHtml).toContain('aria-label="@account-user"')
+	expect(accountHtml).not.toContain('data-testid="site-header-waiting"')
 	const accountProps = readAppRootProps(accountHtml)
 	expect(accountProps.loaderData?.accountProfile).toEqual({
 		ok: true,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

The signed-in header avatar should take you to your public profile (`/@username`), and the mobile menu should show your username instead of Waiting.

## Why

The avatar used to land on `/account/waiting`. That made the chrome look like a notification inbox, and the mobile menu labeled the same control “Waiting.” The profile page is the public identity surface; Waiting stays under Account.

## Summary

- Desktop avatar links to `routes.profile` (`/@username`) with `aria-label="@username"` so it does not collide with the Kody brand link
- Mobile menu shows the username next to the avatar, not “Waiting”
- Account remains in the menu; Waiting is still `/account/waiting` from Account nav
- `aria-current` on the profile link is an exact match only, so `/@user/pkg` does not mark the avatar as current

## Testing

- Node: `site-header.node.test.ts`, `ssr-render.node.test.ts`
- E2E smoke looks for the `@username` header link
- Pre-push: `test:node` (2600) and `test:workers` (327) green
- Local origin as `jane@example.com`:
  - Authenticated home HTML has `href="/@jane"`, `aria-label="@jane"`, `data-testid="site-header-profile"`, and menu text `jane` (not Waiting)
  - Browser: login → click avatar → `/@jane`; 390px menu shows **jane**, not Waiting

![Signed-in account header with Jane avatar](https://cursor.com/artifacts/c/art-36b77cc7-ce3e-4a84-b536-2f09330136ed)
![Public profile at /@jane after clicking the header avatar](https://cursor.com/artifacts/c/art-ed5821b8-f463-4b80-a345-9ad877423d28)
![Mobile menu showing jane next to the avatar, not Waiting](https://cursor.com/artifacts/c/art-ea533631-2311-46db-bf5d-5c8c2cc9cc36)
<a href="https://cursor.com/agents/bc-a5f488d8-35eb-4633-b2c9-d1b8ff7e25cd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fheader_avatar_opens_profile.mp4"><img src="https://cursor.com/artifacts/c/art-9be1caa4-5f7b-4016-8fa9-2bca1fb91112" alt="header_avatar_opens_profile.mp4" /></a>

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `8c2195c4` · **Head:** `ecebea15`

**Classification:** composes — no primitives added or changed; the header wires the existing public profile route.

### Primitives touched

| Primitive | Group    | Impact                                                         |
| --------- | -------- | -------------------------------------------------------------- |
| `app-ui`  | surfaces | composes — header avatar and mobile menu go to `routes.profile` |

### Change flow

A signed-in click on the header avatar (or the mobile-menu username) now targets the public profile instead of Waiting.

```mermaid
sequenceDiagram
	actor user as Signed-in user
	participant header as app-ui SiteHeader
	participant profile as routes.profile
	user->>header: click avatar or menu username
	header->>profile: GET /@:username
	profile-->>user: public profile page
```

### Before / after

**Before:** avatar `href="/account/waiting"`, mobile menu label “Waiting”.

**After:** avatar and menu `href="/@username"`, menu label is the username, `aria-label="@username"`.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a5f488d8-35eb-4633-b2c9-d1b8ff7e25cd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a5f488d8-35eb-4633-b2c9-d1b8ff7e25cd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

