### PR TITLE
Hide the waiting error-rate card after Activity triage

### DIFF
--- a/.agents/skills/control-kody/references/features/waiting.md
+++ b/.agents/skills/control-kody/references/features/waiting.md
@@ -24,3 +24,5 @@ node tools/control-kody.ts preview -- \
 
 - Empty is the common seed state. Create the pending grant or locked package
   through the same JSON APIs the UI uses before asserting copy.
+- The error-rate card counts **open** Activity errors in the last 7 days.
+  Ignored and resolved runs do not keep it on Waiting.

--- a/docs/use/waiting.md
+++ b/docs/use/waiting.md
@@ -21,7 +21,8 @@ Typical items:
 - review a locked package (published code stays put until you promote or unlock)
 - confirm a pending email change
 - a plan resource at its cap
-- an elevated error rate (one card that points at Activity)
+- an elevated **open** error rate (one card that points at Activity; ignored and
+  resolved runs do not keep it around)
 - unfinished onboarding steps, unless you dismissed the checklist
 
 Vendor outages, operator work, and other people's queues do not appear here.

--- a/packages/worker/src/app/account-activity-data.ts
+++ b/packages/worker/src/app/account-activity-data.ts
@@ -17,6 +17,7 @@ import {
 	runRecordRetentionDays,
 } from '#worker/run-records/types.ts'
 import {
+	accountActivitySummaryWindowMs,
 	readAccountActivityFilters,
 	statusFilterToRunStatus,
 	surfaceFilterToRunSurface,
@@ -108,7 +109,6 @@ export type AccountActivityLoaderData = {
 }
 
 const accountActivityBasePath = '/account/activity'
-const summaryWindowMs = 7 * 24 * 60 * 60 * 1000
 const defaultPageSize = 25
 
 export function readAccountActivitySelectedRunId(
@@ -188,7 +188,7 @@ async function toDetail(
 }
 
 function summarySince(now: Date) {
-	return new Date(now.getTime() - summaryWindowMs).toISOString()
+	return new Date(now.getTime() - accountActivitySummaryWindowMs).toISOString()
 }
 
 export async function loadAccountActivityData(input: {

--- a/packages/worker/src/mcp/capabilities/account/waiting-summary.ts
+++ b/packages/worker/src/mcp/capabilities/account/waiting-summary.ts
@@ -22,7 +22,7 @@ export const waitingSummaryCapability = defineDomainCapability(
 	{
 		name: 'waitingSummary',
 		description:
-			'List things currently waiting on the signed-in human: email verification, OAuth reconnects, expired secrets, MCP reconnects, locked-package publishes, plan caps, and unfinished setup. This is a current-state queue, not run history — use runSummary for Activity. Vendor outages do not appear here.',
+			'List things currently waiting on the signed-in human: email verification, OAuth reconnects, expired secrets, MCP reconnects, locked-package publishes, plan caps, unfinished setup, and an elevated open-error rate that still needs Activity triage. Ignored and resolved Activity errors do not keep that card around. This is a current-state queue, not run history — use runSummary for Activity. Vendor outages do not appear here.',
 		keywords: [
 			'waiting',
 			'inbox',

--- a/packages/worker/src/mcp/waiting/derive-waiting.node.test.ts
+++ b/packages/worker/src/mcp/waiting/derive-waiting.node.test.ts
@@ -1,6 +1,25 @@
-import { expect, test } from 'vitest'
+import { expect, test, vi } from 'vitest'
 import { createMemoryKvNamespace } from '#worker/test-support/memory-kv.ts'
+import { accountActivitySummaryWindowMs } from '#universal/account-activity-filters.ts'
+import { buildWaitingItems } from '#universal/waiting.ts'
 import { collectWaitingSignals } from './derive-waiting.ts'
+
+const mockModule = vi.hoisted(() => ({
+	summarizeRunRecords: vi.fn(async () => ({
+		since: new Date(0).toISOString(),
+		total: 0,
+		errors: 0,
+		ignored: 0,
+		resolved: 0,
+		running: 0,
+		bySurface: [],
+	})),
+}))
+
+vi.mock('#worker/run-records/service.ts', () => ({
+	summarizeRunRecords: (...args: Array<unknown>) =>
+		mockModule.summarizeRunRecords(...args),
+}))
 
 function createStubDb() {
 	return {
@@ -60,4 +79,55 @@ test('waiting signals read MCP OAuth grants from OAUTH_KV when the provider help
 		user,
 	})
 	expect(noOAuthSurface.onboardingRemaining).toContain('connect-agent')
+})
+
+test('waiting error-rate card uses open Activity errors, not monthly rollups', async () => {
+	const now = new Date('2026-09-05T00:00:00.000Z')
+	const env = { APP_DB: createStubDb() } as Env
+
+	mockModule.summarizeRunRecords.mockResolvedValueOnce({
+		since: new Date(
+			now.getTime() - accountActivitySummaryWindowMs,
+		).toISOString(),
+		total: 162103,
+		errors: 0,
+		ignored: 800,
+		resolved: 407,
+		running: 0,
+		bySurface: [],
+	})
+	const triaged = await collectWaitingSignals({ env, user, now })
+	expect(mockModule.summarizeRunRecords).toHaveBeenCalledWith({
+		env,
+		userId: user.stableUserId,
+		since: new Date(
+			now.getTime() - accountActivitySummaryWindowMs,
+		).toISOString(),
+	})
+	expect(triaged.errorRate).toEqual({ errorCount: 0, eventCount: 162103 })
+	expect(buildWaitingItems(triaged).map((item) => item.kind)).not.toContain(
+		'error-rate',
+	)
+
+	mockModule.summarizeRunRecords.mockResolvedValueOnce({
+		since: new Date(
+			now.getTime() - accountActivitySummaryWindowMs,
+		).toISOString(),
+		total: 20,
+		errors: 12,
+		ignored: 0,
+		resolved: 0,
+		running: 0,
+		bySurface: [],
+	})
+	const open = await collectWaitingSignals({ env, user, now })
+	expect(open.errorRate).toEqual({ errorCount: 12, eventCount: 20 })
+	expect(
+		buildWaitingItems(open).find((item) => item.id === 'error-rate'),
+	).toEqual(
+		expect.objectContaining({
+			title: 'Error rate is elevated',
+			href: '/account/activity',
+		}),
+	)
 })

--- a/packages/worker/src/mcp/waiting/derive-waiting.ts
+++ b/packages/worker/src/mcp/waiting/derive-waiting.ts
@@ -1,4 +1,3 @@
-import { utcMonthKey } from '@kody-internal/shared/date-keys.ts'
 import {
 	deriveOnboardingChecklist,
 	readOnboardingChecklistDismissed,
@@ -13,6 +12,8 @@ import { readEntitlementUsageSnapshot } from '#worker/entitlements/usage-snapsho
 import { getUserPlan } from '#worker/entitlements/service.ts'
 import { isSavedPackageLocked } from '#worker/package-registry/package-publish-lock.ts'
 import { listJoinedIntegrations } from '#worker/integrations/service.ts'
+import { summarizeRunRecords } from '#worker/run-records/service.ts'
+import { accountActivitySummaryWindowMs } from '#universal/account-activity-filters.ts'
 import {
 	buildWaitingItems,
 	isUnexpiredEpochMs,
@@ -271,17 +272,19 @@ async function collectPendingEmailChange(env: Env, userId: number, now: Date) {
 
 async function collectErrorRate(env: Env, userId: string, now: Date) {
 	try {
-		const month = utcMonthKey(now)
-		const row = await env.APP_DB.prepare(
-			`SELECT SUM(event_count) AS event_count, SUM(error_count) AS error_count
-			 FROM usage_rollups
-			 WHERE user_id = ? AND month = ?`,
-		)
-			.bind(userId, month)
-			.first<{ event_count: number | null; error_count: number | null }>()
+		// Count open (untriaged) Activity errors in the same 7-day window as
+		// `/account/activity`. Monthly usage_rollups never drop when the user
+		// ignores or resolves a run, so they cannot be the Waiting gate.
+		const summary = await summarizeRunRecords({
+			env,
+			userId,
+			since: new Date(
+				now.getTime() - accountActivitySummaryWindowMs,
+			).toISOString(),
+		})
 		return {
-			errorCount: Number(row?.error_count ?? 0),
-			eventCount: Number(row?.event_count ?? 0),
+			errorCount: summary.errors,
+			eventCount: summary.total,
 		}
 	} catch {
 		return null

--- a/packages/worker/universal/account-activity-filters.node.test.ts
+++ b/packages/worker/universal/account-activity-filters.node.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from 'vitest'
 import {
+	accountActivitySummaryWindowMs,
 	activityEmptyLabel,
 	buildActivitySearch,
 	readAccountActivityFilters,
@@ -8,6 +9,7 @@ import {
 } from './account-activity-filters.ts'
 
 test('activity URL defaults stay on open errors and recent runs flip to all history', () => {
+	expect(accountActivitySummaryWindowMs).toBe(7 * 24 * 60 * 60 * 1000)
 	expect(
 		readAccountActivityFilters('https://example.com/account/activity'),
 	).toEqual({

--- a/packages/worker/universal/account-activity-filters.ts
+++ b/packages/worker/universal/account-activity-filters.ts
@@ -3,6 +3,9 @@
  * Client and server parse the same query so defaults cannot drift.
  */
 
+/** Activity summary / default list window. Waiting uses the same bound. */
+export const accountActivitySummaryWindowMs = 7 * 24 * 60 * 60 * 1000
+
 export const accountActivityViewFilterValues = ['errors', 'recent'] as const
 
 export type AccountActivityViewFilter =

--- a/packages/worker/universal/waiting.node.test.ts
+++ b/packages/worker/universal/waiting.node.test.ts
@@ -31,6 +31,9 @@ test('waiting items are a current-state you-queue and skip noise', () => {
 	expect(isElevatedUserErrorRate({ errorCount: 5, eventCount: 20 })).toBe(true)
 	expect(isElevatedUserErrorRate({ errorCount: 4, eventCount: 10 })).toBe(false)
 	expect(isElevatedUserErrorRate({ errorCount: 5, eventCount: 40 })).toBe(false)
+	expect(isElevatedUserErrorRate({ errorCount: 0, eventCount: 162103 })).toBe(
+		false,
+	)
 
 	const now = new Date('2026-08-31T00:00:00.000Z')
 	expect(isUnexpiredEpochMs(now.getTime() + 1, now)).toBe(true)
@@ -90,6 +93,12 @@ test('waiting items are a current-state you-queue and skip noise', () => {
 	expect(items.find((item) => item.id === 'mcp-server:srv-ready')).toBe(
 		undefined,
 	)
+	expect(items.find((item) => item.id === 'error-rate')).toMatchObject({
+		title: 'Error rate is elevated',
+		why: '12 of 20 recent runs failed and still need triage. Activity is where you handle those errors.',
+		doLabel: 'Open Activity',
+		href: '/account/activity',
+	})
 
 	const notion = items.find((item) => item.id === 'mcp-server:srv-auth')
 	expect(notion).toMatchObject({
@@ -125,6 +134,12 @@ test('waiting items are a current-state you-queue and skip noise', () => {
 		onboardingRemaining: ['connect-agent'],
 	})
 	expect(emptyAfterDismiss).toEqual([])
+
+	const allErrorsTriaged = buildWaitingItems({
+		...emptySignals,
+		errorRate: { errorCount: 0, eventCount: 162103 },
+	})
+	expect(allErrorsTriaged).toEqual([])
 
 	const connectionHealth = buildWaitingItems({
 		...emptySignals,

--- a/packages/worker/universal/waiting.ts
+++ b/packages/worker/universal/waiting.ts
@@ -98,6 +98,7 @@ export type WaitingSignals = {
 	expiredSecrets: Array<WaitingExpiredSecretSignal>
 	lockedPackages: Array<WaitingLockedPackageSignal>
 	pendingEmailChange: string | null
+	/** Open (untriaged) Activity errors vs runs in the Activity window. */
 	errorRate: { errorCount: number; eventCount: number } | null
 	entitlementCaps: Array<WaitingEntitlementCapSignal>
 }
@@ -250,7 +251,7 @@ export function buildWaitingItems(signals: WaitingSignals): Array<WaitingItem> {
 			id: 'error-rate',
 			kind: 'error-rate',
 			title: 'Error rate is elevated',
-			why: `${signals.errorRate.errorCount} of ${signals.errorRate.eventCount} recent runs failed. Activity is where you triage those errors.`,
+			why: `${signals.errorRate.errorCount} of ${signals.errorRate.eventCount} recent runs failed and still need triage. Activity is where you handle those errors.`,
 			who: 'you',
 			doLabel: 'Open Activity',
 			href: routes.accountActivity.href(),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Waiting should not nag you about an elevated error rate after every Activity error is already ignored or resolved.

## Why

The “Error rate is elevated” card counted monthly `usage_rollups` totals. Those never drop when you ignore or resolve a run in Activity, so a finished triage queue still looked like 1207 of 162103 recent runs needed you.

Waiting is a current-state gate. Activity is where you triage. Once nothing is open, that card should leave.

## Summary

- Waiting now counts **open** (untriaged) Activity errors via `summarizeRunRecords`, in the same 7-day window as `/account/activity`
- Ignored and resolved runs no longer keep the card around
- Shared `accountActivitySummaryWindowMs` so Activity and Waiting cannot drift
- Copy: failed runs “still need triage”

## Testing

- Node: `waiting.node.test.ts` (0 of 162103 open errors → no card)
- Node: `derive-waiting.node.test.ts` (mocked summary with ignored/resolved vs 12 open of 20)
- Pre-push: `test:node` (2605) and `test:workers` (327) green

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `401b886f` · **Head:** `3934e53f`

**Classification:** extends — Waiting’s error-rate gate now follows Activity triage instead of monthly usage rollups.

### Primitives touched

| Primitive    | Group    | Impact                                                                 |
| ------------ | -------- | ---------------------------------------------------------------------- |
| `app-ui`     | surfaces | extends — error-rate waiting item uses open Activity errors            |
| `mcp-server` | surfaces | extends — `deriveWaitingItems` / `waitingSummary` share that gate      |
| `run-records`| storage  | composes — `summarizeRunRecords` open-error counts                     |

### Change flow

A waiting request used to read monthly D1 rollups. It now asks run-records for open errors in Activity’s 7-day window.

```mermaid
sequenceDiagram
	actor user as Signed-in user
	participant appUi as app-ui
	participant mcpServer as mcp-server
	participant runRecords as run-records
	user->>appUi: GET /account/waiting
	appUi->>mcpServer: deriveWaitingItems
	mcpServer->>runRecords: summarizeRunRecords open errors last 7 days
	runRecords-->>mcpServer: errors 0 when ignored or resolved
	mcpServer-->>appUi: omit error-rate card
	appUi-->>user: waiting empty of triaged failures
```

### Before / after

**Before:** `usage_rollups` `error_count` for the UTC month, including ignored and resolved runs.

**After:** `summarizeRunRecords.errors` (open only) over `accountActivitySummaryWindowMs`.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a5f488d8-35eb-4633-b2c9-d1b8ff7e25cd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a5f488d8-35eb-4633-b2c9-d1b8ff7e25cd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Waiting cards now use open Activity errors from the last 7 days to calculate elevated error rates.
  * Ignored or resolved errors no longer keep an item in the Waiting inbox.
  * Error-rate messaging now directs users to Activity for triage.

* **Documentation**
  * Clarified Waiting inbox behavior, including the seven-day window and conditions for displaying error-rate cards.

* **Tests**
  * Added coverage for error-rate calculations and Waiting item visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->