### PR TITLE
Coast the homepage testimonials marquee after a fast swipe

### DIFF
--- a/packages/worker/client/routes/landing-testimonials-carousel.node.test.ts
+++ b/packages/worker/client/routes/landing-testimonials-carousel.node.test.ts
@@ -4,11 +4,17 @@ import { fileURLToPath } from 'node:url'
 import { expect, test } from 'vitest'
 import {
 	PARKED_TRANSFORM,
+	appendFlickSample,
 	canPauseOnHover,
+	classifyPointerIntent,
+	finishPointerGesture,
+	flickVelocityPxPerMs,
 	isTestimonialsLanePaused,
 	listLanePlacements,
 	parkUnusedLaneCards,
 	placeLaneCard,
+	shouldCoastFlick,
+	stepFlickCoast,
 	wrapPagerIndex,
 	wrapUnitInterval,
 } from './landing-testimonials-motion.ts'
@@ -232,6 +238,98 @@ test('unused cards keep a parked transform instead of snapping to the origin', (
 	expect(exiting.style.transform).not.toBe('')
 	expect(clone.hidden).toBe(true)
 	expect(clone.style.transform).toBe(PARKED_TRANSFORM)
+})
+
+test('a fast swipe coasts after release instead of freezing on the finger', () => {
+	expect(classifyPointerIntent({ dx: 2, dy: 1 })).toBe('pending')
+	expect(classifyPointerIntent({ dx: 24, dy: 4 })).toBe('drag')
+	expect(classifyPointerIntent({ dx: 4, dy: 24 })).toBe('scroll')
+
+	const flickSamples = [
+		{ t: 0, x: 300 },
+		{ t: 16, x: 240 },
+		{ t: 32, x: 170 },
+		{ t: 48, x: 90 },
+	]
+	const windowed = appendFlickSample(flickSamples, { t: 100, x: 80 })
+	expect(windowed[0]?.t).toBe(32)
+	expect(windowed).toHaveLength(3)
+	expect(flickVelocityPxPerMs(flickSamples)).toBeGreaterThan(3)
+	expect(shouldCoastFlick(0.2)).toBe(false)
+	expect(shouldCoastFlick(flickVelocityPxPerMs(flickSamples))).toBe(true)
+
+	const slowDrag = finishPointerGesture({
+		startX: 200,
+		startY: 40,
+		lastX: 140,
+		endX: 140,
+		endY: 42,
+		endT: 400,
+		samples: [
+			{ t: 0, x: 200 },
+			{ t: 400, x: 140 },
+		],
+		dragging: true,
+	})
+	expect(slowDrag.dragging).toBe(true)
+	expect(slowDrag.offsetDelta).toBe(0)
+	expect(slowDrag.coastVelocity).toBe(0)
+
+	const coalescedFlick = finishPointerGesture({
+		startX: 280,
+		startY: 20,
+		lastX: 280,
+		endX: 40,
+		endY: 28,
+		endT: 70,
+		samples: [{ t: 0, x: 280 }],
+		dragging: false,
+	})
+	expect(coalescedFlick.dragging).toBe(true)
+	expect(coalescedFlick.offsetDelta).toBe(240)
+	expect(coalescedFlick.coastVelocity).toBeGreaterThan(0)
+
+	const vertical = finishPointerGesture({
+		startX: 100,
+		startY: 20,
+		lastX: 100,
+		endX: 108,
+		endY: 140,
+		endT: 40,
+		samples: [{ t: 0, x: 100 }],
+		dragging: false,
+	})
+	expect(vertical.dragging).toBe(false)
+	expect(vertical.coastVelocity).toBe(0)
+
+	const stride = 320
+	const cardWidth = 308
+	const viewportWidth = 375
+	let offset = coalescedFlick.offsetDelta
+	let velocity = coalescedFlick.coastVelocity
+	const startOffset = offset
+	let done = false
+	for (let step = 0; step < 120 && !done; step += 1) {
+		const next = stepFlickCoast({ offset, velocity, dt: 16 })
+		offset = next.offset
+		velocity = next.velocity
+		done = next.done
+	}
+	expect(done).toBe(true)
+	expect(velocity).toBe(0)
+	expect(offset).toBeGreaterThan(startOffset + cardWidth)
+
+	const placements = listLanePlacements({
+		count: 4,
+		stride,
+		cardWidth,
+		offset,
+		viewportWidth,
+	})
+	expect(
+		largestVisibleHole(placements, viewportWidth, cardWidth),
+	).toBeLessThanOrEqual(stride - cardWidth)
+	expect(placements.some((placement) => placement.x === 0)).toBe(false)
 })
 
 test('virtual [hidden] cards override author display flex', () => {

--- a/packages/worker/client/routes/landing-testimonials-carousel.node.test.ts
+++ b/packages/worker/client/routes/landing-testimonials-carousel.node.test.ts
@@ -13,6 +13,7 @@ import {
 	listLanePlacements,
 	parkUnusedLaneCards,
 	placeLaneCard,
+	samplesForFlickVelocity,
 	shouldCoastFlick,
 	stepFlickCoast,
 	wrapPagerIndex,
@@ -288,6 +289,24 @@ test('a fast swipe coasts after release instead of freezing on the finger', () =
 	expect(coalescedFlick.dragging).toBe(true)
 	expect(coalescedFlick.offsetDelta).toBe(240)
 	expect(coalescedFlick.coastVelocity).toBeGreaterThan(0)
+
+	const delayedCoalesced = finishPointerGesture({
+		startX: 280,
+		startY: 20,
+		lastX: 280,
+		endX: 40,
+		endY: 28,
+		endT: 120,
+		samples: [{ t: 0, x: 280 }],
+		dragging: false,
+	})
+	expect(delayedCoalesced.coastVelocity).toBeGreaterThan(0)
+	expect(
+		samplesForFlickVelocity([{ t: 0, x: 280 }], { t: 120, x: 40 }),
+	).toEqual([
+		{ t: 0, x: 280 },
+		{ t: 120, x: 40 },
+	])
 
 	const vertical = finishPointerGesture({
 		startX: 100,

--- a/packages/worker/client/routes/landing-testimonials-carousel.node.test.ts
+++ b/packages/worker/client/routes/landing-testimonials-carousel.node.test.ts
@@ -330,7 +330,25 @@ test('a fast swipe coasts after release instead of freezing on the finger', () =
 			],
 			{ t: 200, x: 140 },
 		),
-	).toEqual([{ t: 200, x: 140 }])
+	).toEqual([
+		{ t: 10, x: 140 },
+		{ t: 200, x: 140 },
+	])
+
+	const delayedFlickWithMove = finishPointerGesture({
+		startX: 280,
+		startY: 20,
+		lastX: 260,
+		endX: 40,
+		endY: 28,
+		endT: 120,
+		samples: [
+			{ t: 0, x: 280 },
+			{ t: 5, x: 260 },
+		],
+		dragging: true,
+	})
+	expect(delayedFlickWithMove.coastVelocity).toBeGreaterThan(0)
 
 	const vertical = finishPointerGesture({
 		startX: 100,

--- a/packages/worker/client/routes/landing-testimonials-carousel.node.test.ts
+++ b/packages/worker/client/routes/landing-testimonials-carousel.node.test.ts
@@ -308,6 +308,30 @@ test('a fast swipe coasts after release instead of freezing on the finger', () =
 		{ t: 120, x: 40 },
 	])
 
+	const pausedRelease = finishPointerGesture({
+		startX: 200,
+		startY: 20,
+		lastX: 140,
+		endX: 140,
+		endY: 20,
+		endT: 200,
+		samples: [
+			{ t: 0, x: 200 },
+			{ t: 10, x: 140 },
+		],
+		dragging: true,
+	})
+	expect(pausedRelease.coastVelocity).toBe(0)
+	expect(
+		samplesForFlickVelocity(
+			[
+				{ t: 0, x: 200 },
+				{ t: 10, x: 140 },
+			],
+			{ t: 200, x: 140 },
+		),
+	).toEqual([{ t: 200, x: 140 }])
+
 	const vertical = finishPointerGesture({
 		startX: 100,
 		startY: 20,

--- a/packages/worker/client/routes/landing-testimonials-carousel.tsx
+++ b/packages/worker/client/routes/landing-testimonials-carousel.tsx
@@ -168,6 +168,7 @@ function armTestimonialsMotion(scroller: HTMLElement, signal: AbortSignal) {
 	let dragStartY = 0
 	let dragLastX = 0
 	let dragging = false
+	let pointerHeld = false
 	let flickSamples: Array<FlickSample> = []
 	let coastVelocity = 0
 	let suppressClick = false
@@ -302,7 +303,7 @@ function armTestimonialsMotion(scroller: HTMLElement, signal: AbortSignal) {
 		if (signal.aborted) return
 		raf = requestAnimationFrame(frame)
 		if (stride <= 0) measure()
-		if (dragging) {
+		if (pointerHeld) {
 			lastTs = 0
 			return
 		}
@@ -379,6 +380,7 @@ function armTestimonialsMotion(scroller: HTMLElement, signal: AbortSignal) {
 	function endPointerGesture(event: PointerEvent) {
 		if (pointerId !== event.pointerId) return
 		pointerId = null
+		pointerHeld = false
 		if (scroller.hasPointerCapture(event.pointerId)) {
 			scroller.releasePointerCapture(event.pointerId)
 		}
@@ -417,6 +419,7 @@ function armTestimonialsMotion(scroller: HTMLElement, signal: AbortSignal) {
 		dragStartY = event.clientY
 		dragging = false
 		suppressClick = false
+		pointerHeld = true
 		stopCoast()
 		flickSamples = []
 		recordPointerSamples(event)
@@ -432,6 +435,7 @@ function armTestimonialsMotion(scroller: HTMLElement, signal: AbortSignal) {
 			if (intent === 'pending') return
 			if (intent === 'scroll') {
 				pointerId = null
+				pointerHeld = false
 				flickSamples = []
 				return
 			}

--- a/packages/worker/client/routes/landing-testimonials-carousel.tsx
+++ b/packages/worker/client/routes/landing-testimonials-carousel.tsx
@@ -429,7 +429,6 @@ function armTestimonialsMotion(scroller: HTMLElement, signal: AbortSignal) {
 		stopCoast()
 		flickSamples = []
 		recordPointerSamples(event)
-		captureScrollerPointer(event.pointerId)
 	}
 
 	function onPointerMove(event: PointerEvent) {
@@ -504,6 +503,8 @@ function armTestimonialsMotion(scroller: HTMLElement, signal: AbortSignal) {
 	scroller.addEventListener('pointermove', onPointerMove, { signal })
 	scroller.addEventListener('pointerup', endPointerGesture, { signal })
 	scroller.addEventListener('pointercancel', endPointerGesture, { signal })
+	// Pending presses do not capture, so a tap can still click name links.
+	// Window terminals still end a lift that happens outside the fade.
 	window.addEventListener('pointerup', endPointerGesture, { signal })
 	window.addEventListener('pointercancel', endPointerGesture, { signal })
 	scroller.addEventListener('click', onClickCapture, {

--- a/packages/worker/client/routes/landing-testimonials-carousel.tsx
+++ b/packages/worker/client/routes/landing-testimonials-carousel.tsx
@@ -9,16 +9,20 @@ import {
 } from '#universal/landing-testimonials.ts'
 import {
 	TESTIMONIALS_LAP_MS,
+	appendFlickSample,
+	classifyPointerIntent,
+	finishPointerGesture,
 	isTestimonialsLanePaused,
 	listLanePlacements,
 	parkUnusedLaneCards,
 	placeLaneCard,
+	stepFlickCoast,
 	wrapPagerIndex,
 	wrapUnitInterval,
+	type FlickSample,
 } from './landing-testimonials-motion.ts'
 
 const USER_NUDGE_RESUME_MS = 500
-const DRAG_THRESHOLD_PX = 8
 
 /**
  * Homepage testimonials strip. SSR and the first client render paint the
@@ -27,7 +31,8 @@ const DRAG_THRESHOLD_PX = 8
  * so a fully exited card is recycled to the other end. A quote that
  * straddles the wrap gets a second aria-hidden copy so the lane never
  * shows a hole. Yields to hover,
- * focus-within, wheel, and pointer-drag. Reduced-motion + JS is a chevron
+ * focus-within, wheel, pointer-drag, and a flick coast after a fast
+ * swipe. Reduced-motion + JS is a chevron
  * pager (one card, no rAF). No-JS keeps a stacked static list.
  */
 export function LandingTestimonialsCarousel(_handle: Handle) {
@@ -163,6 +168,9 @@ function armTestimonialsMotion(scroller: HTMLElement, signal: AbortSignal) {
 	let dragStartY = 0
 	let dragLastX = 0
 	let dragging = false
+	let flickSamples: Array<FlickSample> = []
+	let coastVelocity = 0
+	let suppressClick = false
 
 	function isPaused() {
 		return isTestimonialsLanePaused({
@@ -278,10 +286,46 @@ function armTestimonialsMotion(scroller: HTMLElement, signal: AbortSignal) {
 		}, USER_NUDGE_RESUME_MS)
 	}
 
+	function clearUserNudge() {
+		userNudging = false
+		if (userNudgeTimer != null) {
+			clearTimeout(userNudgeTimer)
+			userNudgeTimer = null
+		}
+	}
+
+	function stopCoast() {
+		coastVelocity = 0
+	}
+
 	function frame(now: number) {
 		if (signal.aborted) return
 		raf = requestAnimationFrame(frame)
 		if (stride <= 0) measure()
+		if (dragging) {
+			lastTs = 0
+			return
+		}
+		if (coastVelocity !== 0) {
+			if (focus) {
+				stopCoast()
+				lastTs = 0
+				return
+			}
+			if (lastTs === 0) lastTs = now
+			const dt = Math.min(now - lastTs, 48)
+			lastTs = now
+			const stepped = stepFlickCoast({
+				offset,
+				velocity: coastVelocity,
+				dt,
+			})
+			offset = stepped.offset
+			coastVelocity = stepped.velocity
+			apply()
+			if (stepped.done) lastTs = 0
+			return
+		}
 		if (isPaused()) {
 			lastTs = 0
 			return
@@ -302,9 +346,68 @@ function armTestimonialsMotion(scroller: HTMLElement, signal: AbortSignal) {
 			return
 		}
 		event.preventDefault()
+		stopCoast()
 		offset += horizontal
 		markUserNudge()
 		apply()
+	}
+
+	function recordPointerSamples(event: PointerEvent) {
+		const coalesced =
+			typeof event.getCoalescedEvents === 'function'
+				? event.getCoalescedEvents()
+				: []
+		const events = coalesced.length > 0 ? coalesced : [event]
+		for (const entry of events) {
+			flickSamples = appendFlickSample(flickSamples, {
+				t: entry.timeStamp,
+				x: entry.clientX,
+			})
+		}
+	}
+
+	function beginHorizontalDrag(event: PointerEvent) {
+		dragging = true
+		suppressClick = true
+		stopCoast()
+		scroller.style.touchAction = 'none'
+		if (!scroller.hasPointerCapture(event.pointerId)) {
+			scroller.setPointerCapture(event.pointerId)
+		}
+	}
+
+	function endPointerGesture(event: PointerEvent) {
+		if (pointerId !== event.pointerId) return
+		pointerId = null
+		if (scroller.hasPointerCapture(event.pointerId)) {
+			scroller.releasePointerCapture(event.pointerId)
+		}
+		scroller.style.touchAction = ''
+		const finished = finishPointerGesture({
+			startX: dragStartX,
+			startY: dragStartY,
+			lastX: dragLastX,
+			endX: event.clientX,
+			endY: event.clientY,
+			endT: event.timeStamp,
+			samples: flickSamples,
+			dragging,
+		})
+		dragging = false
+		flickSamples = []
+		if (!finished.dragging) return
+		suppressClick = true
+		if (finished.offsetDelta !== 0) {
+			offset += finished.offsetDelta
+			apply()
+		}
+		if (finished.coastVelocity !== 0) {
+			clearUserNudge()
+			coastVelocity = finished.coastVelocity
+			lastTs = 0
+			return
+		}
+		markUserNudge()
 	}
 
 	function onPointerDown(event: PointerEvent) {
@@ -313,25 +416,26 @@ function armTestimonialsMotion(scroller: HTMLElement, signal: AbortSignal) {
 		dragStartX = dragLastX = event.clientX
 		dragStartY = event.clientY
 		dragging = false
+		suppressClick = false
+		stopCoast()
+		flickSamples = []
+		recordPointerSamples(event)
 	}
 
 	function onPointerMove(event: PointerEvent) {
 		if (pointerId !== event.pointerId) return
+		recordPointerSamples(event)
 		const dx = event.clientX - dragStartX
 		const dy = event.clientY - dragStartY
 		if (!dragging) {
-			if (
-				Math.abs(dx) < DRAG_THRESHOLD_PX &&
-				Math.abs(dy) < DRAG_THRESHOLD_PX
-			) {
-				return
-			}
-			if (Math.abs(dy) >= Math.abs(dx)) {
+			const intent = classifyPointerIntent({ dx, dy })
+			if (intent === 'pending') return
+			if (intent === 'scroll') {
 				pointerId = null
+				flickSamples = []
 				return
 			}
-			dragging = true
-			scroller.setPointerCapture(event.pointerId)
+			beginHorizontalDrag(event)
 		}
 		offset += dragLastX - event.clientX
 		dragLastX = event.clientX
@@ -339,13 +443,11 @@ function armTestimonialsMotion(scroller: HTMLElement, signal: AbortSignal) {
 		apply()
 	}
 
-	function onPointerUp(event: PointerEvent) {
-		if (pointerId !== event.pointerId) return
-		if (dragging && scroller.hasPointerCapture(event.pointerId)) {
-			scroller.releasePointerCapture(event.pointerId)
-		}
-		pointerId = null
-		dragging = false
+	function onClickCapture(event: MouseEvent) {
+		if (!suppressClick) return
+		event.preventDefault()
+		event.stopPropagation()
+		suppressClick = false
 	}
 
 	function onFocusIn(event: FocusEvent) {
@@ -387,8 +489,12 @@ function armTestimonialsMotion(scroller: HTMLElement, signal: AbortSignal) {
 	scroller.addEventListener('wheel', onWheel, { passive: false, signal })
 	scroller.addEventListener('pointerdown', onPointerDown, { signal })
 	scroller.addEventListener('pointermove', onPointerMove, { signal })
-	scroller.addEventListener('pointerup', onPointerUp, { signal })
-	scroller.addEventListener('pointercancel', onPointerUp, { signal })
+	scroller.addEventListener('pointerup', endPointerGesture, { signal })
+	scroller.addEventListener('pointercancel', endPointerGesture, { signal })
+	scroller.addEventListener('click', onClickCapture, {
+		capture: true,
+		signal,
+	})
 	scroller.addEventListener(
 		'pointerenter',
 		(event) => {
@@ -435,6 +541,7 @@ function armTestimonialsMotion(scroller: HTMLElement, signal: AbortSignal) {
 			cancelAnimationFrame(raf)
 			if (userNudgeTimer != null) clearTimeout(userNudgeTimer)
 			visibilityObserver?.disconnect()
+			scroller.style.touchAction = ''
 			teardownVirtual()
 		},
 		{ once: true },

--- a/packages/worker/client/routes/landing-testimonials-carousel.tsx
+++ b/packages/worker/client/routes/landing-testimonials-carousel.tsx
@@ -367,23 +367,29 @@ function armTestimonialsMotion(scroller: HTMLElement, signal: AbortSignal) {
 		}
 	}
 
+	function captureScrollerPointer(id: number) {
+		if (!scroller.isConnected || scroller.hasPointerCapture(id)) return
+		scroller.setPointerCapture(id)
+	}
+
+	function releaseCapturedPointer(id: number) {
+		if (!scroller.isConnected || !scroller.hasPointerCapture(id)) return
+		scroller.releasePointerCapture(id)
+	}
+
 	function beginHorizontalDrag(event: PointerEvent) {
 		dragging = true
 		suppressClick = true
 		stopCoast()
 		scroller.style.touchAction = 'none'
-		if (!scroller.hasPointerCapture(event.pointerId)) {
-			scroller.setPointerCapture(event.pointerId)
-		}
+		captureScrollerPointer(event.pointerId)
 	}
 
 	function endPointerGesture(event: PointerEvent) {
 		if (pointerId !== event.pointerId) return
 		pointerId = null
 		pointerHeld = false
-		if (scroller.hasPointerCapture(event.pointerId)) {
-			scroller.releasePointerCapture(event.pointerId)
-		}
+		releaseCapturedPointer(event.pointerId)
 		scroller.style.touchAction = ''
 		const finished = finishPointerGesture({
 			startX: dragStartX,
@@ -423,6 +429,7 @@ function armTestimonialsMotion(scroller: HTMLElement, signal: AbortSignal) {
 		stopCoast()
 		flickSamples = []
 		recordPointerSamples(event)
+		captureScrollerPointer(event.pointerId)
 	}
 
 	function onPointerMove(event: PointerEvent) {
@@ -434,9 +441,11 @@ function armTestimonialsMotion(scroller: HTMLElement, signal: AbortSignal) {
 			const intent = classifyPointerIntent({ dx, dy })
 			if (intent === 'pending') return
 			if (intent === 'scroll') {
+				const id = event.pointerId
 				pointerId = null
 				pointerHeld = false
 				flickSamples = []
+				releaseCapturedPointer(id)
 				return
 			}
 			beginHorizontalDrag(event)
@@ -495,6 +504,8 @@ function armTestimonialsMotion(scroller: HTMLElement, signal: AbortSignal) {
 	scroller.addEventListener('pointermove', onPointerMove, { signal })
 	scroller.addEventListener('pointerup', endPointerGesture, { signal })
 	scroller.addEventListener('pointercancel', endPointerGesture, { signal })
+	window.addEventListener('pointerup', endPointerGesture, { signal })
+	window.addEventListener('pointercancel', endPointerGesture, { signal })
 	scroller.addEventListener('click', onClickCapture, {
 		capture: true,
 		signal,

--- a/packages/worker/client/routes/landing-testimonials-motion.ts
+++ b/packages/worker/client/routes/landing-testimonials-motion.ts
@@ -66,8 +66,9 @@ export function flickVelocityPxPerMs(samples: ReadonlyArray<FlickSample>) {
 
 /**
  * Recent samples estimate release speed. A coalesced down/up pair can sit
- * farther apart than the window, so keep the original start if the window
- * would leave a single point and zero velocity.
+ * farther apart than the window, so keep that lone start sample. A paused
+ * drag with older points must not pair the original start with a late
+ * stationary release.
  */
 export function samplesForFlickVelocity(
 	samples: ReadonlyArray<FlickSample>,
@@ -76,6 +77,7 @@ export function samplesForFlickVelocity(
 ): Array<FlickSample> {
 	const windowed = appendFlickSample(samples, end, windowMs)
 	if (windowed.length >= 2) return windowed
+	if (samples.length !== 1) return windowed
 	const first = samples[0]
 	if (first == null) return windowed
 	return [first, end]

--- a/packages/worker/client/routes/landing-testimonials-motion.ts
+++ b/packages/worker/client/routes/landing-testimonials-motion.ts
@@ -64,6 +64,23 @@ export function flickVelocityPxPerMs(samples: ReadonlyArray<FlickSample>) {
 	return (first.x - last.x) / dt
 }
 
+/**
+ * Recent samples estimate release speed. A coalesced down/up pair can sit
+ * farther apart than the window, so keep the original start if the window
+ * would leave a single point and zero velocity.
+ */
+export function samplesForFlickVelocity(
+	samples: ReadonlyArray<FlickSample>,
+	end: FlickSample,
+	windowMs = FLICK_SAMPLE_WINDOW_MS,
+): Array<FlickSample> {
+	const windowed = appendFlickSample(samples, end, windowMs)
+	if (windowed.length >= 2) return windowed
+	const first = samples[0]
+	if (first == null) return windowed
+	return [first, end]
+}
+
 export function clampFlickVelocity(
 	velocity: number,
 	maxAbs = FLICK_MAX_VELOCITY_PX_PER_MS,
@@ -129,7 +146,7 @@ export function finishPointerGesture(input: {
 		dragging = true
 		lastX = input.startX
 	}
-	const samples = appendFlickSample(input.samples, {
+	const samples = samplesForFlickVelocity(input.samples, {
 		t: input.endT,
 		x: input.endX,
 	})

--- a/packages/worker/client/routes/landing-testimonials-motion.ts
+++ b/packages/worker/client/routes/landing-testimonials-motion.ts
@@ -65,10 +65,10 @@ export function flickVelocityPxPerMs(samples: ReadonlyArray<FlickSample>) {
 }
 
 /**
- * Recent samples estimate release speed. A coalesced down/up pair can sit
- * farther apart than the window, so keep that lone start sample. A paused
- * drag with older points must not pair the original start with a late
- * stationary release.
+ * Recent samples estimate release speed. A coalesced down/up pair, or a
+ * jump after an early move, can sit farther apart than the window. Pair
+ * the last prior sample with the release so velocity is that final hop.
+ * A pause then release has last.x near end.x, so velocity stays zero.
  */
 export function samplesForFlickVelocity(
 	samples: ReadonlyArray<FlickSample>,
@@ -77,10 +77,9 @@ export function samplesForFlickVelocity(
 ): Array<FlickSample> {
 	const windowed = appendFlickSample(samples, end, windowMs)
 	if (windowed.length >= 2) return windowed
-	if (samples.length !== 1) return windowed
-	const first = samples[0]
-	if (first == null) return windowed
-	return [first, end]
+	const last = samples.at(-1)
+	if (last == null) return windowed
+	return [last, end]
 }
 
 export function clampFlickVelocity(

--- a/packages/worker/client/routes/landing-testimonials-motion.ts
+++ b/packages/worker/client/routes/landing-testimonials-motion.ts
@@ -1,6 +1,146 @@
 /** Slow walk of one lap around the real card set. */
 export const TESTIMONIALS_LAP_MS = 45_000
 
+export const DRAG_THRESHOLD_PX = 8
+
+/** Keep only recent pointer samples so a flick velocity is not diluted. */
+export const FLICK_SAMPLE_WINDOW_MS = 80
+
+/**
+ * Minimum release speed to coast. ~0.45px/ms is a quick swipe, not a
+ * slow drag that should just stop.
+ */
+export const FLICK_MIN_VELOCITY_PX_PER_MS = 0.45
+
+/** Drop residual coast once it is slower than a crawl. */
+export const FLICK_STOP_VELOCITY_PX_PER_MS = 0.04
+
+/** Exponential decay per millisecond. A hard flick travels about 1–2 cards. */
+export const FLICK_FRICTION_PER_MS = 0.003
+
+/** Cap so a wild sample cannot sling the lane a full lap. */
+export const FLICK_MAX_VELOCITY_PX_PER_MS = 3
+
+export type FlickSample = {
+	t: number
+	x: number
+}
+
+export type PointerIntent = 'pending' | 'drag' | 'scroll'
+
+export function classifyPointerIntent(input: {
+	dx: number
+	dy: number
+	thresholdPx?: number
+}): PointerIntent {
+	const threshold = input.thresholdPx ?? DRAG_THRESHOLD_PX
+	const adx = Math.abs(input.dx)
+	const ady = Math.abs(input.dy)
+	if (adx < threshold && ady < threshold) return 'pending'
+	if (ady >= adx) return 'scroll'
+	return 'drag'
+}
+
+export function appendFlickSample(
+	samples: ReadonlyArray<FlickSample>,
+	sample: FlickSample,
+	windowMs = FLICK_SAMPLE_WINDOW_MS,
+): Array<FlickSample> {
+	const oldest = sample.t - windowMs
+	const next: Array<FlickSample> = []
+	for (const entry of samples) {
+		if (entry.t >= oldest) next.push(entry)
+	}
+	next.push(sample)
+	return next
+}
+
+export function flickVelocityPxPerMs(samples: ReadonlyArray<FlickSample>) {
+	const first = samples[0]
+	const last = samples.at(-1)
+	if (first == null || last == null) return 0
+	const dt = last.t - first.t
+	if (dt <= 0) return 0
+	return (first.x - last.x) / dt
+}
+
+export function clampFlickVelocity(
+	velocity: number,
+	maxAbs = FLICK_MAX_VELOCITY_PX_PER_MS,
+) {
+	return Math.max(-maxAbs, Math.min(maxAbs, velocity))
+}
+
+export function shouldCoastFlick(
+	velocity: number,
+	minAbs = FLICK_MIN_VELOCITY_PX_PER_MS,
+) {
+	return Math.abs(velocity) >= minAbs
+}
+
+export function stepFlickCoast(input: {
+	offset: number
+	velocity: number
+	dt: number
+}): { offset: number; velocity: number; done: boolean } {
+	const dt = Math.min(Math.max(input.dt, 0), 48)
+	if (dt === 0) {
+		return { offset: input.offset, velocity: input.velocity, done: false }
+	}
+	const velocity = input.velocity * Math.exp(-FLICK_FRICTION_PER_MS * dt)
+	if (Math.abs(velocity) < FLICK_STOP_VELOCITY_PX_PER_MS) {
+		return { offset: input.offset, velocity: 0, done: true }
+	}
+	return {
+		offset: input.offset + velocity * dt,
+		velocity,
+		done: false,
+	}
+}
+
+/**
+ * Close out a pointer gesture. Coalesced touch flicks often skip move
+ * events, so a large horizontal jump on up still counts as a drag.
+ */
+export function finishPointerGesture(input: {
+	startX: number
+	startY: number
+	lastX: number
+	endX: number
+	endY: number
+	endT: number
+	samples: ReadonlyArray<FlickSample>
+	dragging: boolean
+}): {
+	offsetDelta: number
+	dragging: boolean
+	coastVelocity: number
+} {
+	let dragging = input.dragging
+	let lastX = input.lastX
+	if (!dragging) {
+		const intent = classifyPointerIntent({
+			dx: input.endX - input.startX,
+			dy: input.endY - input.startY,
+		})
+		if (intent !== 'drag') {
+			return { offsetDelta: 0, dragging: false, coastVelocity: 0 }
+		}
+		dragging = true
+		lastX = input.startX
+	}
+	const samples = appendFlickSample(input.samples, {
+		t: input.endT,
+		x: input.endX,
+	})
+	const velocity = clampFlickVelocity(flickVelocityPxPerMs(samples))
+	return {
+		offsetDelta: lastX - input.endX,
+		dragging: true,
+		coastVelocity: shouldCoastFlick(velocity) ? velocity : 0,
+	}
+}
+
 export type LanePlacement = {
 	itemIndex: number
 	x: number


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Make the homepage testimonials strip respond to a quick mobile flick so the lane keeps moving after the finger lifts.

## Why

The virtual lane already followed a drag 1:1, then froze. A fast swipe felt dead: no inertial coast, and a coalesced touch flick with few `pointermove` events could miss the drag threshold entirely.

## Summary

- Sample recent pointer positions and treat a fast horizontal release as a flick.
- Coast the circular lane with friction until velocity drops, then resume the slow walk.
- Coalesced down/up jumps still count as a drag, including when they span longer than the sample window or include an early move sample.
- A press during coast holds the lane instead of restarting the idle walk.
- Window `pointerup`/`pointercancel` end a lift outside the fade so `pointerHeld` cannot stick. Capture stays drag-only so a tap still opens attribution links.
- Vertical pans still scroll the page. A swipe that starts on a name link does not open it.

## Testing

- `npx vitest run packages/worker/client/routes/landing-testimonials-carousel.node.test.ts` (6 passed, including paused-release no-coast and delayed flick with an extra sample)
- `npm run test:push` (844 node files / 2642 tests, 94 workers files / 330 tests)
- Local origin `http://localhost:3742/#testimonials-title` with an iPhone viewport: a touch `pointerdown`→`pointerup` flick moved cards ~250px with the finger, then coasted another ~351px over 450ms.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `825fe1a1` · **Head:** `aa45fb26`

**Classification:** composes — no primitives added or changed. This PR adds flick inertia to the existing homepage testimonials lane in `app-ui`.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `app-ui` | surfaces | composes — pointer sampling, hold, and coast on the testimonials marquee |

### Change flow

A fast swipe on the testimonials strip samples pointer velocity in the browser app and coasts the virtual lane until friction stops it.

```mermaid
sequenceDiagram
	actor Visitor
	participant appUi as app-ui
	Visitor->>appUi: pointerdown on testimonials fade
	appUi->>appUi: sample positions until pointerup
	alt release faster than flick threshold
		appUi->>appUi: coast offset with exponential friction
	else finger still down
		appUi->>appUi: hold lane until pointerup
	else lift outside while pending
		appUi->>appUi: window pointerup clears the hold
	else slow drag or vertical intent
		appUi->>appUi: stop at finger and resume slow walk
	end
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cac5f3fc-297b-4fd2-9d02-674ee23a0b48?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cac5f3fc-297b-4fd2-9d02-674ee23a0b48&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added smooth inertial scrolling to the testimonials carousel after fast horizontal swipes.
  * Improved gesture handling to distinguish carousel interaction from vertical page scrolling.
  * Preserved link clicks for simple taps while preventing accidental clicks after swipes.

* **Bug Fixes**
  * Improved carousel positioning after varied pointer gestures.
  * Ensured inertial scrolling stops cleanly without gaps or unexpected resets.

* **Tests**
  * Added coverage for gesture classification, swipe velocity, inertial movement, and final positioning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->