### PR TITLE
Add a dedicated /connect/secrets page for host approval

### DIFF
--- a/.agents/skills/control-kody/references/features/secrets.md
+++ b/.agents/skills/control-kody/references/features/secrets.md
@@ -5,8 +5,8 @@ User, session, and package secret rows. Host approval and package grants.
 ## How to get there
 
 `/account/secrets` → new `/account/secrets/new` → detail under
-`/account/secrets/{user|session|package}/…`. Approve lane:
-`/account/secrets/approve`.
+`/account/secrets/{user|session|package}/…`. Package grant lane:
+`/account/secrets/approve`. Host approval: `/connect/secrets`.
 
 ## Drive it
 

--- a/docs/contributing/secret-host-approval.md
+++ b/docs/contributing/secret-host-approval.md
@@ -18,10 +18,11 @@ Those policies must not be created, widened, or modified by:
 Allowed outbound hosts may only be changed through the authenticated account
 admin UI.
 
-In this repo, that means the user must approve host access through the account
-secrets experience, such as `/account/secrets` and the focused approval route at
-`/account/secrets/approve`. Host approvals from a connect flow use the same page
-with an "Allow access" card.
+In this repo, that means the user must approve host access through the
+authenticated **`/connect/secrets`** page (query params `name` / `names` and
+`hosts`). The account secrets editor at `/account/secrets` can still show an
+"Allow access" card for older single-host links. Package grants stay on
+`/account/secrets/approve`.
 
 ## What agents should assume
 
@@ -40,9 +41,10 @@ target host is not already approved for that secret, the correct behavior is:
 4. Retry only after the user approves it.
 
 The same stop-and-surface rule applies to package secret access denies. When
-several user secrets need the same package approved, prefer the bulk approval
-URL (`/account/secrets/approve?package_id=...&names=...`) over one link per
-secret. Agents must never auto-approve package access.
+several secrets or hosts need approval together, prefer the bulk host approval
+URL (`/connect/secrets?names=...&hosts=...`) or the bulk package approval URL
+(`/account/secrets/approve?package_id=...&names=...`) over one link per secret.
+Agents must never auto-approve host or package access.
 
 ## What agents must not do
 

--- a/docs/guides/account-secret-setup.md
+++ b/docs/guides/account-secret-setup.md
@@ -55,8 +55,8 @@ so the user can paste immediately.
 
 - Saving a secret does **not** approve outbound hosts.
 - The account form prefills the requested hosts and packages for review.
-- Host and package approvals are handled in the authenticated account secrets UI
-  after the secret is saved.
+- Host approval uses the dedicated **`/connect/secrets`** page (`name` / `names`
+  and `hosts`). Package grants use `/account/secrets/approve`.
 
 ## Package approval URLs (after a package exists)
 

--- a/docs/use/secrets-and-values.md
+++ b/docs/use/secrets-and-values.md
@@ -114,10 +114,17 @@ returned strings.
 ## Host approval
 
 If a request fails because a host is not approved for that secret, use the
-approval path the error provides (typically in the web app). Saving a secret
-does not by itself approve new hosts. Self-authored and adopted packages do not
-skip this gate: an empty host allowlist blocks secret-bearing fetch even when
-package read/use is automatic.
+approval path the error provides. Host approval lives on the dedicated
+**`/connect/secrets`** page — the same kind of focused page as
+**`/connect/oauth`**. A link looks like
+`/connect/secrets?name=cloudflareToken&hosts=api.cloudflare.com`. When several
+hosts (or several secrets) need approval together, Kody can send one link with
+comma-separated **`names`** and **`hosts`**. That page lists every host and
+approves them in one click.
+
+Saving a secret does not by itself approve new hosts. Self-authored and adopted
+packages do not skip this gate: an empty host allowlist blocks secret-bearing
+fetch even when package read/use is automatic.
 
 ## Package approval
 

--- a/packages/worker/client/app.tsx
+++ b/packages/worker/client/app.tsx
@@ -218,7 +218,8 @@ export function App(handle: Handle<AppProps>) {
 			currentPathname === '/signup' ||
 			currentPathname === '/login' ||
 			currentPathname === '/oauth/authorize' ||
-			currentPathname === '/connect/oauth'
+			currentPathname === '/connect/oauth' ||
+			currentPathname === '/connect/secrets'
 
 		return (
 			<AppLoaderDataProvider loaderData={handle.props.loaderData}>

--- a/packages/worker/client/lazy-route.tsx
+++ b/packages/worker/client/lazy-route.tsx
@@ -347,7 +347,11 @@ registerPreloadPatterns(
 )
 
 registerPreloadPatterns(
-	[routePattern(routes.connectOauth), oauthPaths.authorize],
+	[
+		routePattern(routes.connectOauth),
+		routePattern(routes.connectSecrets),
+		oauthPaths.authorize,
+	],
 	{
 		name: 'onboarding-area',
 		load: onboardingArea.load,

--- a/packages/worker/client/routes/account-approval-shared.node.test.ts
+++ b/packages/worker/client/routes/account-approval-shared.node.test.ts
@@ -32,6 +32,14 @@ test('buildHostApprovalRequestUrl maps secret approval links and rejects invalid
 	).toBe(
 		'/account/secrets.json?package_id=pkg-1&selected=package%3A%3Apkg-1%3A%3AsigningSecret',
 	)
+	expect(
+		buildHostApprovalRequestUrl(
+			'https://example.com/connect/secrets?name=cloudflareToken&hosts=api.cloudflare.com,dash.cloudflare.com',
+			'https://example.com',
+		),
+	).toBe(
+		'/account/secrets.json?name=cloudflareToken&hosts=api.cloudflare.com,dash.cloudflare.com',
+	)
 	expect(() =>
 		buildHostApprovalRequestUrl('/account/secrets?allowed-host=slack.com'),
 	).toThrow('Invalid approval link.')

--- a/packages/worker/client/routes/account-approval-shared.ts
+++ b/packages/worker/client/routes/account-approval-shared.ts
@@ -9,6 +9,7 @@ export type ApprovalView = {
 	names: Array<string>
 	scope: ApprovalScope
 	requestedHost: string
+	requestedHosts: Array<string>
 	currentAllowedHosts: Array<string>
 	requestedPackageId: string | null
 	currentAllowedPackages: Array<string>
@@ -32,11 +33,15 @@ export function buildHostApprovalRequestUrl(
 	baseUrl = 'http://localhost',
 ) {
 	const approvalPageUrl = new URL(approvalUrl, baseUrl)
+	const requestUrl = new URL(accountSecretsApiPath, baseUrl)
+	if (approvalPageUrl.pathname === '/connect/secrets') {
+		requestUrl.search = approvalPageUrl.search
+		return `${requestUrl.pathname}${requestUrl.search}`
+	}
 	const parsedPath = parseAccountSecretPath(approvalPageUrl.pathname)
 	if (!parsedPath) {
 		throw new Error('Invalid approval link.')
 	}
-	const requestUrl = new URL(accountSecretsApiPath, baseUrl)
 	requestUrl.search = approvalPageUrl.search
 	requestUrl.searchParams.set('selected', parsedPath.id)
 	return `${requestUrl.pathname}${requestUrl.search}`

--- a/packages/worker/client/routes/account-secrets-approval.tsx
+++ b/packages/worker/client/routes/account-secrets-approval.tsx
@@ -91,13 +91,35 @@ export function renderSecretApprovalCard(props: {
 						) : null}
 					</div>
 				) : (
-					<p mix={css({ margin: 0, color: colors.textMuted })}>
-						Let Kody use this connection at{' '}
-						<strong mix={css({ color: colors.text })}>
-							{approvalCard.requestedHost}
-						</strong>
-						.
-					</p>
+					<div mix={css({ display: 'grid', gap: spacing.xs })}>
+						<p mix={css({ margin: 0, color: colors.textMuted })}>
+							{approvalHosts(approvalCard).length > 1
+								? 'Let Kody use this secret at these hosts.'
+								: 'Let Kody use this connection at '}
+							{approvalHosts(approvalCard).length === 1 ? (
+								<strong mix={css({ color: colors.text })}>
+									{approvalHosts(approvalCard)[0]}
+								</strong>
+							) : null}
+							{approvalHosts(approvalCard).length === 1 ? '.' : null}
+						</p>
+						{approvalHosts(approvalCard).length > 1 ? (
+							<ul
+								mix={css({
+									margin: 0,
+									paddingLeft: spacing.lg,
+									display: 'grid',
+									gap: spacing.xs,
+								})}
+							>
+								{approvalHosts(approvalCard).map((host) => (
+									<li key={host}>
+										<strong mix={css({ color: colors.text })}>{host}</strong>
+									</li>
+								))}
+							</ul>
+						) : null}
+					</div>
 				)}
 				{approvalCard.requestedPackageId ? (
 					approvalCard.names.length > 1 ? null : (
@@ -159,9 +181,11 @@ export function renderSecretApprovalCard(props: {
 				>
 					{approvalCard.requestedPackageId && approvalCard.names.length > 1
 						? `Approve all (${approvalCard.names.length})`
-						: approvalCard.requestedHost && !approvalCard.requestedPackageId
-							? 'Allow access'
-							: 'Approve'}
+						: approvalHosts(approvalCard).length > 1
+							? `Allow all ${approvalHosts(approvalCard).length} hosts`
+							: approvalCard.requestedHost && !approvalCard.requestedPackageId
+								? 'Allow access'
+								: 'Approve'}
 				</button>
 				<button
 					type="button"
@@ -176,6 +200,11 @@ export function renderSecretApprovalCard(props: {
 			</div>
 		</section>
 	)
+}
+
+function approvalHosts(approvalCard: ApprovalView) {
+	if (approvalCard.requestedHosts.length > 0) return approvalCard.requestedHosts
+	return approvalCard.requestedHost ? [approvalCard.requestedHost] : []
 }
 
 export function renderAlreadyAddedNotice(items: Array<string>) {

--- a/packages/worker/client/routes/account-secrets-shared.ts
+++ b/packages/worker/client/routes/account-secrets-shared.ts
@@ -177,15 +177,15 @@ function buildSecretsHref(pathname: string, search: string) {
 	return `${pathname}${search}`
 }
 
-function readRequestedHost(href: string) {
+function readRequestedHosts(href: string) {
 	const url = new URL(href, 'http://localhost')
-	const value = url.searchParams.get('allowed-host')
-	return value?.trim() ? value.trim() : null
-}
-
-function normalizeSingleAllowedHost(host: string | null) {
-	if (!host) return null
-	return normalizeAllowedHosts([host])[0] ?? null
+	const values = [
+		...url.searchParams.getAll('hosts'),
+		...url.searchParams.getAll('host'),
+		...url.searchParams.getAll('allowed-host'),
+		...url.searchParams.getAll('allowedHosts'),
+	]
+	return normalizeAllowedHosts(values.flatMap((value) => value.split(',')))
 }
 
 export function getAlreadyAddedNotice(input: {
@@ -194,9 +194,7 @@ export function getAlreadyAddedNotice(input: {
 	approval: ApprovalView | null
 	formatPackageId: (packageId: string) => string
 }) {
-	const requestedHost = normalizeSingleAllowedHost(
-		readRequestedHost(input.href),
-	)
+	const requestedHosts = readRequestedHosts(input.href)
 	const requestedPackageId =
 		new URL(input.href, 'http://localhost').searchParams
 			.get('package_id')
@@ -224,10 +222,18 @@ export function getAlreadyAddedNotice(input: {
 				).sort((left, right) => left.localeCompare(right))
 			: []
 	const items: Array<string> = []
+	const alreadyAllowedHosts = requestedHosts.filter((host) =>
+		allowedHosts.includes(host),
+	)
 	const hostAlreadyAdded =
-		requestedHost != null && allowedHosts.includes(requestedHost)
+		requestedHosts.length > 0 &&
+		alreadyAllowedHosts.length === requestedHosts.length
 	if (hostAlreadyAdded) {
-		items.push(`Host ${requestedHost} is already in allowed hosts.`)
+		items.push(
+			requestedHosts.length === 1
+				? `Host ${requestedHosts[0]} is already in allowed hosts.`
+				: `Hosts ${requestedHosts.join(', ')} are already in allowed hosts.`,
+		)
 	}
 	const packageAlreadyAdded =
 		requestedPackageId != null && allowedPackageIds.includes(requestedPackageId)
@@ -272,7 +278,10 @@ export function buildBaseSecretsHref(search = '') {
 
 export function getDataRefreshKey(href: string) {
 	const url = new URL(href, 'http://localhost')
-	const requestedHost = url.searchParams.get('allowed-host') ?? ''
+	const requestedHost = [
+		url.searchParams.get('allowed-host') ?? '',
+		url.searchParams.get('hosts') ?? '',
+	].join(',')
 	const requestedPackageId = url.searchParams.get('package_id') ?? ''
 	const requestedNames = [
 		...url.searchParams.getAll('names'),

--- a/packages/worker/client/routes/connect-oauth.tsx
+++ b/packages/worker/client/routes/connect-oauth.tsx
@@ -11,10 +11,7 @@ import {
 import { isConnectOauthCallbackUrl } from '#universal/oauth-connect.ts'
 import { readCurrentRouterHref } from '#client/client-router.tsx'
 import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
-import {
-	buildHostApprovalRequestUrl,
-	submitApprovalRequest,
-} from '#client/routes/account-approval-shared.ts'
+import { submitApprovalRequest } from '#client/routes/account-approval-shared.ts'
 import { ProviderMark } from '#client/provider-icons.tsx'
 import {
 	pageDescriptionCss,
@@ -170,20 +167,24 @@ export function ConnectOauthRoute(handle: Handle) {
 		if (approvingAllHosts || hostApprovalLinks.length === 0) return
 		approvingAllHosts = true
 		update()
-		const remainingLinks = [...hostApprovalLinks]
 		try {
-			for (const link of remainingLinks) {
-				const requestUrl = buildHostApprovalRequestUrl(
-					link.approvalUrl,
-					window.location.origin,
-				)
-				await submitApprovalRequest('approve', requestUrl)
-				hostApprovalLinks = hostApprovalLinks.filter(
-					(entry) =>
-						entry.secretName !== link.secretName || entry.host !== link.host,
-				)
-				update()
-			}
+			const names = Array.from(
+				new Set(hostApprovalLinks.map((link) => link.secretName)),
+			)
+			const hosts = Array.from(
+				new Set(hostApprovalLinks.map((link) => link.host)),
+			)
+			const requestUrl = new URL(
+				'/account/secrets.json',
+				window.location.origin,
+			)
+			requestUrl.searchParams.set('names', names.join(','))
+			requestUrl.searchParams.set('hosts', hosts.join(','))
+			await submitApprovalRequest(
+				'approve',
+				`${requestUrl.pathname}${requestUrl.search}`,
+			)
+			hostApprovalLinks = []
 			setStatus('All hosts approved.', 'info')
 		} catch (error) {
 			setStatus(

--- a/packages/worker/client/routes/connect-secrets.node.test.ts
+++ b/packages/worker/client/routes/connect-secrets.node.test.ts
@@ -1,0 +1,56 @@
+import { expect, test } from 'vitest'
+import { isConnectSecretsAlreadyAllowed } from './connect-secrets.tsx'
+
+const secret = {
+	id: 'user:googleAccessToken',
+	name: 'googleAccessToken',
+	scope: 'user' as const,
+	description: '',
+	packageId: null,
+	packageTitle: null,
+	allowedHosts: ['oauth2.googleapis.com'],
+	allowedPackages: [],
+	createdAt: '2026-01-01T00:00:00.000Z',
+	updatedAt: '2026-01-01T00:00:00.000Z',
+	expiresAt: null,
+	ttlMs: null,
+}
+
+const approval = {
+	name: 'googleAccessToken',
+	names: ['googleAccessToken'],
+	scope: 'user' as const,
+	requestedHost: 'gmail.googleapis.com',
+	requestedHosts: ['gmail.googleapis.com', 'oauth2.googleapis.com'],
+	requestedPackageId: null,
+	currentAllowedHosts: ['oauth2.googleapis.com'],
+	currentAllowedPackages: [],
+}
+
+test('connect secrets is already allowed only when every listed secret is present and every host is granted', () => {
+	expect(
+		isConnectSecretsAlreadyAllowed({
+			secrets: [secret],
+			approval,
+		}),
+	).toBe(false)
+
+	expect(
+		isConnectSecretsAlreadyAllowed({
+			secrets: [
+				{
+					...secret,
+					allowedHosts: ['gmail.googleapis.com', 'oauth2.googleapis.com'],
+				},
+			],
+			approval,
+		}),
+	).toBe(true)
+
+	expect(
+		isConnectSecretsAlreadyAllowed({
+			secrets: [],
+			approval,
+		}),
+	).toBe(false)
+})

--- a/packages/worker/client/routes/connect-secrets.tsx
+++ b/packages/worker/client/routes/connect-secrets.tsx
@@ -1,0 +1,302 @@
+import { type AccountSecretsLoaderData } from '#universal/loader-data.ts'
+import { type Handle, css } from 'remix/ui'
+import { on } from '#client/event-mixin.ts'
+import { readCurrentRouterHref } from '#client/client-router.tsx'
+import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
+import {
+	type ApprovalAction,
+	type ApprovalView,
+	accountSecretsApiPath,
+	submitApprovalRequest,
+} from '#client/routes/account-approval-shared.ts'
+import {
+	type RouteLoaderResult,
+	routeLoaderRedirect,
+} from '#client/route-loader.ts'
+import { colors, spacing } from '#universal/styles/tokens.ts'
+import {
+	cardCss,
+	getPrimaryButtonCss,
+	getSecondaryButtonCss,
+	pageDescriptionCss,
+	pageEyebrowCss,
+	pageHeaderCss,
+	pageTitleCss,
+	stackedPageCss,
+} from '#universal/styles/style-primitives.ts'
+import { routes } from '#universal/routes.ts'
+
+const connectSecretsPageCss = {
+	...stackedPageCss,
+	maxWidth: '32rem',
+	margin: '0 auto',
+}
+
+const connectSecretsHeaderCss = {
+	...pageHeaderCss,
+	justifyItems: 'center',
+	textAlign: 'center' as const,
+}
+
+const connectSecretsPrimaryButtonCss = getPrimaryButtonCss({
+	size: 'lg',
+	weight: 'semibold',
+})
+
+const connectSecretsSecondaryButtonCss = getSecondaryButtonCss({
+	size: 'lg',
+	weight: 'semibold',
+})
+
+export async function connectSecretsRouteLoader(
+	url: URL,
+	signal: AbortSignal,
+): Promise<RouteLoaderResult> {
+	const requestUrl = new URL(accountSecretsApiPath, url.origin)
+	requestUrl.search = url.search
+	const response = await fetch(`${requestUrl.pathname}${requestUrl.search}`, {
+		headers: { Accept: 'application/json' },
+		credentials: 'include',
+		signal,
+	})
+	if (response.status === 401) {
+		return routeLoaderRedirect('/login')
+	}
+	const payload = (await response.json().catch(() => null)) as
+		| (AccountSecretsLoaderData & { error?: string })
+		| null
+	if (!response.ok || !payload?.ok) {
+		return {
+			accountSecrets: {
+				ok: true,
+				email: '',
+				packageOptions: [],
+				packages: [],
+				secrets: [],
+				selectedSecret: null,
+				approval: null,
+				approvalError:
+					payload?.error || 'Unable to load this approval request.',
+			},
+		}
+	}
+	return { accountSecrets: payload }
+}
+
+export function ConnectSecretsRoute(handle: Handle) {
+	let data: AccountSecretsLoaderData | null = null
+	let submittingAction: ApprovalAction | null = null
+	let message: string | null = null
+	let completed: ApprovalAction | null = null
+
+	function getCurrentHref() {
+		return readCurrentRouterHref(handle)
+	}
+
+	function applyRouteLoaderData(href: string) {
+		const routeData = tryConsumeRouteLoaderData(handle, 'accountSecrets', href)
+		if (!routeData) return false
+		data = routeData
+		return true
+	}
+
+	async function submitApproval(action: ApprovalAction) {
+		if (submittingAction != null || !data?.approval) return
+		submittingAction = action
+		message = null
+		handle.update()
+		try {
+			const currentUrl = new URL(getCurrentHref(), 'http://localhost')
+			const requestUrl = new URL(accountSecretsApiPath, currentUrl)
+			requestUrl.search = currentUrl.search
+			const payload = await submitApprovalRequest<
+				AccountSecretsLoaderData & { error?: string; ok?: boolean }
+			>(action, `${requestUrl.pathname}${requestUrl.search}`)
+			if (!payload) return
+			data = payload
+			completed = action
+			submittingAction = null
+			handle.update()
+		} catch (error) {
+			submittingAction = null
+			message =
+				error instanceof Error ? error.message : 'Unable to process approval.'
+			handle.update()
+		}
+	}
+
+	return () => {
+		const currentHref = getCurrentHref()
+		applyRouteLoaderData(currentHref)
+		const approval = data?.approval ?? null
+		const pendingPairs = approval
+			? collectPendingHostPairs(data?.secrets ?? [], approval)
+			: []
+		const alreadyAllowed =
+			Boolean(approval) && pendingPairs.length === 0 && completed !== 'reject'
+		const hosts = approval?.requestedHosts?.length
+			? approval.requestedHosts
+			: approval?.requestedHost
+				? [approval.requestedHost]
+				: []
+		const names = approval?.names.length ? approval.names : []
+
+		return (
+			<section mix={css(connectSecretsPageCss)} data-testid="connect-secrets">
+				<header mix={css(connectSecretsHeaderCss)}>
+					<span mix={css(pageEyebrowCss)}>Allow secret hosts</span>
+					<h1 mix={css(pageTitleCss)}>
+						{completed === 'approve' || alreadyAllowed
+							? 'Access allowed'
+							: completed === 'reject'
+								? 'Request rejected'
+								: 'Allow this secret at these hosts'}
+					</h1>
+					<p mix={css(pageDescriptionCss)}>
+						{completed === 'approve' || alreadyAllowed
+							? 'Kody can send this saved secret to the hosts below.'
+							: completed === 'reject'
+								? 'No hosts were added. You can approve later from this same link.'
+								: approval
+									? 'Kody only sends a saved secret to hosts you approve. Saving a secret does not do this automatically.'
+									: 'Open an approval link from Kody to allow a saved secret at a host.'}
+					</p>
+				</header>
+
+				{data?.approvalError ? (
+					<section
+						mix={css({
+							...cardCss,
+							border: `1px solid ${colors.danger}`,
+						})}
+						data-testid="connect-secrets-error"
+					>
+						<p mix={css({ margin: 0, color: colors.danger })}>
+							{data.approvalError}
+						</p>
+					</section>
+				) : null}
+
+				{message ? (
+					<p mix={css({ margin: 0, color: colors.danger })}>{message}</p>
+				) : null}
+
+				{approval && hosts.length > 0 ? (
+					<section mix={css(cardCss)} data-testid="connect-secrets-card">
+						<div mix={css({ display: 'grid', gap: spacing.sm })}>
+							<div mix={css({ display: 'grid', gap: spacing.xs })}>
+								<span mix={css({ color: colors.textMuted })}>
+									{names.length === 1 ? 'Secret' : 'Secrets'}
+								</span>
+								<ul
+									mix={css({
+										margin: 0,
+										paddingLeft: spacing.lg,
+										display: 'grid',
+										gap: spacing.xs,
+									})}
+								>
+									{names.map((name) => (
+										<li key={name}>
+											<code>{name}</code>
+										</li>
+									))}
+								</ul>
+							</div>
+							<div mix={css({ display: 'grid', gap: spacing.xs })}>
+								<span mix={css({ color: colors.textMuted })}>
+									{hosts.length === 1 ? 'Host' : 'Hosts'}
+								</span>
+								<ul
+									mix={css({
+										margin: 0,
+										paddingLeft: spacing.lg,
+										display: 'grid',
+										gap: spacing.xs,
+									})}
+								>
+									{hosts.map((host) => (
+										<li key={host}>
+											<strong mix={css({ color: colors.text })}>{host}</strong>
+										</li>
+									))}
+								</ul>
+							</div>
+						</div>
+						{completed === 'approve' ||
+						alreadyAllowed ||
+						completed === 'reject' ? (
+							<a
+								href={routes.accountSecrets.href()}
+								mix={css(connectSecretsSecondaryButtonCss)}
+							>
+								Back to secrets
+							</a>
+						) : (
+							<div
+								mix={css({
+									display: 'flex',
+									gap: spacing.sm,
+									flexWrap: 'wrap',
+								})}
+							>
+								<button
+									type="button"
+									disabled={submittingAction != null}
+									mix={[
+										on('click', () => {
+											void submitApproval('approve')
+										}),
+										css(connectSecretsPrimaryButtonCss),
+									]}
+								>
+									{submittingAction === 'approve'
+										? 'Allowing access…'
+										: hosts.length > 1
+											? `Allow all ${hosts.length} hosts`
+											: 'Allow access'}
+								</button>
+								<button
+									type="button"
+									disabled={submittingAction != null}
+									mix={[
+										on('click', () => {
+											void submitApproval('reject')
+										}),
+										css(connectSecretsSecondaryButtonCss),
+									]}
+								>
+									Reject
+								</button>
+							</div>
+						)}
+					</section>
+				) : null}
+			</section>
+		)
+	}
+}
+
+function collectPendingHostPairs(
+	secrets: AccountSecretsLoaderData['secrets'],
+	approval: ApprovalView,
+) {
+	const hosts = approval.requestedHosts.length
+		? approval.requestedHosts
+		: approval.requestedHost
+			? [approval.requestedHost]
+			: []
+	const pairs: Array<{ name: string; host: string }> = []
+	for (const name of approval.names) {
+		const secret = secrets.find(
+			(item) => item.name === name && item.scope === approval.scope,
+		)
+		if (!secret) continue
+		for (const host of hosts) {
+			if (!secret.allowedHosts.includes(host)) {
+				pairs.push({ name, host })
+			}
+		}
+	}
+	return pairs
+}

--- a/packages/worker/client/routes/connect-secrets.tsx
+++ b/packages/worker/client/routes/connect-secrets.tsx
@@ -129,11 +129,13 @@ export function ConnectSecretsRoute(handle: Handle) {
 		const currentHref = getCurrentHref()
 		applyRouteLoaderData(currentHref)
 		const approval = data?.approval ?? null
-		const pendingPairs = approval
-			? collectPendingHostPairs(data?.secrets ?? [], approval)
-			: []
 		const alreadyAllowed =
-			Boolean(approval) && pendingPairs.length === 0 && completed !== 'reject'
+			approval != null &&
+			completed !== 'reject' &&
+			isConnectSecretsAlreadyAllowed({
+				secrets: data?.secrets ?? [],
+				approval,
+			})
 		const hosts = approval?.requestedHosts?.length
 			? approval.requestedHosts
 			: approval?.requestedHost
@@ -275,6 +277,19 @@ export function ConnectSecretsRoute(handle: Handle) {
 			</section>
 		)
 	}
+}
+
+export function isConnectSecretsAlreadyAllowed(input: {
+	secrets: AccountSecretsLoaderData['secrets']
+	approval: ApprovalView
+}) {
+	const pendingPairs = collectPendingHostPairs(input.secrets, input.approval)
+	if (pendingPairs.length > 0) return false
+	return input.approval.names.every((name) =>
+		input.secrets.some(
+			(item) => item.name === name && item.scope === input.approval.scope,
+		),
+	)
 }
 
 function collectPendingHostPairs(

--- a/packages/worker/client/routes/index.tsx
+++ b/packages/worker/client/routes/index.tsx
@@ -315,6 +315,10 @@ export const clientRouteLoaders: Record<string, RouteLoader> = {
 		onboardingArea,
 		(m) => m.connectOauthRouteLoader,
 	),
+	[routePattern(routes.connectSecrets)]: lazyRouteLoader(
+		onboardingArea,
+		(m) => m.connectSecretsRouteLoader,
+	),
 	[routePattern(routes.pendingVerification)]: lazyRouteLoader(
 		authArea,
 		(m) => m.pendingVerificationRouteLoader,
@@ -577,6 +581,9 @@ export const clientRoutes = {
 	),
 	[routePattern(routes.connectOauth)]: (
 		<LazyOnboardingRoute render={(m) => <m.ConnectOauthRoute />} />
+	),
+	[routePattern(routes.connectSecrets)]: (
+		<LazyOnboardingRoute render={(m) => <m.ConnectSecretsRoute />} />
 	),
 	[oauthPaths.authorize]: (
 		<LazyOnboardingRoute render={(m) => <m.OAuthAuthorizeRoute />} />

--- a/packages/worker/client/routes/onboarding-area.ts
+++ b/packages/worker/client/routes/onboarding-area.ts
@@ -1,4 +1,8 @@
 export { ConnectOauthRoute, connectOauthRouteLoader } from './connect-oauth.tsx'
+export {
+	ConnectSecretsRoute,
+	connectSecretsRouteLoader,
+} from './connect-secrets.tsx'
 export { OnboardingRoute, onboardingRouteLoader } from './onboarding.tsx'
 export {
 	OAuthAuthorizeRoute,

--- a/packages/worker/src/app/account-secrets-data.ts
+++ b/packages/worker/src/app/account-secrets-data.ts
@@ -12,9 +12,9 @@ import {
 	resolveSecret,
 } from '#mcp/secrets/service.ts'
 import { type SecretScope } from '#mcp/secrets/types.ts'
+import { normalizeBulkHostApprovalHosts } from '#mcp/secrets/host-approval.ts'
 import { normalizeBulkPackageSecretApprovalNames } from '#mcp/secrets/package-approval-url.ts'
 import { listSavedPackagesByUserId } from '#worker/package-registry/repo.ts'
-import { normalizeAllowedHosts } from '#mcp/secrets/allowed-hosts.ts'
 
 type AuthenticatedUser = NonNullable<
 	Awaited<ReturnType<typeof readAuthenticatedAppUser>>
@@ -59,6 +59,7 @@ type SecretApprovalView = {
 	names: Array<string>
 	scope: SecretScope
 	requestedHost: string
+	requestedHosts: Array<string>
 	requestedPackageId: string | null
 	currentAllowedHosts: Array<string>
 	currentAllowedPackages: Array<string>
@@ -109,9 +110,11 @@ async function buildAccountSecretsPayload(input: {
 	savedPackages?: Array<SavedPackageSummary>
 }): Promise<AccountSecretsLoaderData> {
 	const url = new URL(input.request.url)
-	const requestedApprovalHost = readApprovalHost(url)
+	const requestedApprovalHosts = readApprovalHosts(url)
 	const requestedPackageId = readRequestedPackageId(url)
 	const requestedSecretNames = readRequestedSecretNames(url)
+	const requestedHostScope = readHostApprovalScope(url)
+	const requestedHostStorageContext = getHostApprovalStorageContext(url)
 	const savedPackages =
 		input.savedPackages ??
 		(await listSavedPackagesByUserId(input.env.APP_DB, {
@@ -135,7 +138,9 @@ async function buildAccountSecretsPayload(input: {
 
 	let approval: SecretApprovalView | null = null
 	let approvalError: string | null = null
-	const hasApprovalTarget = Boolean(requestedApprovalHost || requestedPackageId)
+	const hasApprovalTarget = Boolean(
+		requestedApprovalHosts.length > 0 || requestedPackageId,
+	)
 	const hasApprovalSubject = Boolean(
 		input.selectedSecretId || requestedSecretNames.length > 0,
 	)
@@ -145,9 +150,11 @@ async function buildAccountSecretsPayload(input: {
 				env: input.env,
 				userId: input.user.mcpUser.userId,
 				secretId: input.selectedSecretId ?? null,
-				requestedHost: requestedApprovalHost,
+				requestedHosts: requestedApprovalHosts,
 				requestedPackageId,
 				requestedSecretNames,
+				requestedHostScope,
+				requestedHostStorageContext,
 				savedPackageIds: new Set(savedPackages.map((entry) => entry.id)),
 			})
 		} catch (error) {
@@ -223,6 +230,13 @@ type ResolvedSecretApproval =
 			storageContext: StorageContext | null
 	  }
 	| {
+			kind: 'host_bulk'
+			names: Array<string>
+			hosts: Array<string>
+			scope: SecretScope
+			storageContext: StorageContext | null
+	  }
+	| {
 			kind: 'package'
 			name: string
 			scope: SecretScope
@@ -239,14 +253,17 @@ type ResolvedSecretApproval =
 
 function resolveApprovalRequest(input: {
 	secretId: string | null
-	requestedHost: string | null
+	requestedHosts: Array<string>
 	requestedPackageId: string | null
 	requestedSecretNames?: Array<string>
+	requestedHostScope?: SecretScope
+	requestedHostStorageContext?: StorageContext | null
 }): ResolvedSecretApproval {
 	const requestedSecretNames = normalizeBulkPackageSecretApprovalNames(
 		input.requestedSecretNames ?? [],
 	)
-	if (input.requestedHost && input.requestedPackageId) {
+	const requestedHosts = normalizeBulkHostApprovalHosts(input.requestedHosts)
+	if (requestedHosts.length > 0 && input.requestedPackageId) {
 		throw new Error('Approval request contains both host and package.')
 	}
 	if (requestedSecretNames.length > 0) {
@@ -255,18 +272,24 @@ function resolveApprovalRequest(input: {
 				'Approval request cannot combine selected secret and names list.',
 			)
 		}
-		if (!input.requestedPackageId) {
-			throw new Error('Bulk secret approval requires a package_id.')
+		if (input.requestedPackageId) {
+			return {
+				kind: 'package_bulk',
+				names: requestedSecretNames,
+				scope: 'user',
+				packageId: input.requestedPackageId,
+				storageContext: null,
+			}
 		}
-		if (input.requestedHost) {
-			throw new Error('Bulk secret approval does not support host approval.')
+		if (requestedHosts.length === 0) {
+			throw new Error('Bulk secret approval requires a package_id or hosts.')
 		}
 		return {
-			kind: 'package_bulk',
+			kind: 'host_bulk',
 			names: requestedSecretNames,
-			scope: 'user',
-			packageId: input.requestedPackageId,
-			storageContext: null,
+			hosts: requestedHosts,
+			scope: input.requestedHostScope ?? 'user',
+			storageContext: input.requestedHostStorageContext ?? null,
 		}
 	}
 	const parsed = input.secretId ? parseAccountSecretId(input.secretId) : null
@@ -286,8 +309,8 @@ function resolveApprovalRequest(input: {
 			storageContext,
 		}
 	}
-	if (input.requestedHost) {
-		const [requestedHost] = normalizeAllowedHosts([input.requestedHost])
+	if (requestedHosts.length === 1) {
+		const requestedHost = requestedHosts[0]
 		if (!requestedHost) {
 			throw new Error('Invalid approval request host.')
 		}
@@ -299,6 +322,15 @@ function resolveApprovalRequest(input: {
 			storageContext,
 		}
 	}
+	if (requestedHosts.length > 1) {
+		return {
+			kind: 'host_bulk',
+			names: [parsed.name],
+			hosts: requestedHosts,
+			scope: parsed.scope,
+			storageContext,
+		}
+	}
 	throw new Error('Approval request is missing a host or package.')
 }
 
@@ -306,16 +338,20 @@ async function resolveSecretApprovalView(input: {
 	env: Env
 	userId: string
 	secretId: string | null
-	requestedHost: string | null
+	requestedHosts: Array<string>
 	requestedPackageId: string | null
 	requestedSecretNames: Array<string>
+	requestedHostScope: SecretScope
+	requestedHostStorageContext: StorageContext | null
 	savedPackageIds: Set<string>
 }) {
 	const approval = resolveApprovalRequest({
 		secretId: input.secretId,
-		requestedHost: input.requestedHost,
+		requestedHosts: input.requestedHosts,
 		requestedPackageId: input.requestedPackageId,
 		requestedSecretNames: input.requestedSecretNames,
+		requestedHostScope: input.requestedHostScope,
+		requestedHostStorageContext: input.requestedHostStorageContext,
 	})
 	if (approval.kind === 'package_bulk') {
 		if (!input.savedPackageIds.has(approval.packageId)) {
@@ -351,6 +387,7 @@ async function resolveSecretApprovalView(input: {
 				names: foundNames,
 				scope: 'user',
 				requestedHost: '',
+				requestedHosts: [],
 				requestedPackageId: approval.packageId,
 				currentAllowedHosts: [],
 				currentAllowedPackages: [approval.packageId],
@@ -363,7 +400,40 @@ async function resolveSecretApprovalView(input: {
 			names: pendingNames,
 			scope: 'user',
 			requestedHost: '',
+			requestedHosts: [],
 			requestedPackageId: approval.packageId,
+			currentAllowedHosts: firstSecret?.allowedHosts ?? [],
+			currentAllowedPackages: firstSecret?.allowedPackages ?? [],
+		} satisfies SecretApprovalView
+	}
+	if (approval.kind === 'host_bulk') {
+		const secrets = await listSecrets({
+			env: input.env,
+			userId: input.userId,
+			scope: approval.scope,
+			storageContext: approval.storageContext,
+			includeIntegrationOwned: true,
+		})
+		const byName = new Map(
+			secrets
+				.filter((secret) => secret.scope === approval.scope)
+				.map((secret) => [secret.name, secret]),
+		)
+		const foundNames: Array<string> = []
+		for (const name of approval.names) {
+			if (byName.has(name)) foundNames.push(name)
+		}
+		if (foundNames.length === 0) {
+			throw new Error('None of the listed secrets were found.')
+		}
+		const firstSecret = byName.get(foundNames[0] ?? '')
+		return {
+			name: foundNames[0] ?? '',
+			names: foundNames,
+			scope: approval.scope,
+			requestedHost: approval.hosts[0] ?? '',
+			requestedHosts: approval.hosts,
+			requestedPackageId: null,
 			currentAllowedHosts: firstSecret?.allowedHosts ?? [],
 			currentAllowedPackages: firstSecret?.allowedPackages ?? [],
 		} satisfies SecretApprovalView
@@ -392,6 +462,7 @@ async function resolveSecretApprovalView(input: {
 		names: [approval.name],
 		scope: approval.scope,
 		requestedHost: approval.kind === 'host' ? approval.requestedHost : '',
+		requestedHosts: approval.kind === 'host' ? [approval.requestedHost] : [],
 		requestedPackageId: approval.kind === 'package' ? approval.packageId : null,
 		currentAllowedHosts: secret.allowedHosts,
 		currentAllowedPackages: secret.allowedPackages,
@@ -517,9 +588,50 @@ export function getSecretContextForAccountSecret(input: {
 	}
 }
 
-function readApprovalHost(url: URL) {
-	const value = url.searchParams.get('allowed-host')
-	return value?.trim() ? value.trim() : null
+function readApprovalHosts(url: URL) {
+	const values = [
+		...url.searchParams.getAll('hosts'),
+		...url.searchParams.getAll('host'),
+		...url.searchParams.getAll('allowed-host'),
+		...url.searchParams.getAll('allowedHosts'),
+	]
+	return normalizeBulkHostApprovalHosts(
+		values.flatMap((value) => value.split(',')),
+	)
+}
+
+function readHostApprovalScope(url: URL): SecretScope {
+	const value = url.searchParams.get('scope')?.trim()
+	switch (value) {
+		case 'package':
+		case 'session':
+		case 'user':
+			return value
+		default:
+			return 'user'
+	}
+}
+
+function getHostApprovalStorageContext(url: URL): StorageContext | null {
+	const scope = readHostApprovalScope(url)
+	switch (scope) {
+		case 'package': {
+			const packageId = url.searchParams.get('packageId')?.trim()
+			if (!packageId) return null
+			return { sessionId: null, appId: null, packageId }
+		}
+		case 'session': {
+			const sessionId = url.searchParams.get('sessionId')?.trim()
+			if (!sessionId) return null
+			return { sessionId, appId: null, packageId: null }
+		}
+		case 'user':
+			return null
+		default: {
+			const _exhaustive: never = scope
+			return _exhaustive
+		}
+	}
 }
 
 function readRequestedPackageId(url: URL) {
@@ -537,6 +649,13 @@ function readRequestedSecretNames(url: URL) {
 	)
 }
 
-export { resolveApprovalRequest, toPackageOptions, listAccountSecrets }
+export {
+	getHostApprovalStorageContext,
+	listAccountSecrets,
+	readApprovalHosts,
+	readHostApprovalScope,
+	resolveApprovalRequest,
+	toPackageOptions,
+}
 
 export { buildAccountSecretsPayload }

--- a/packages/worker/src/app/agent-discovery.ts
+++ b/packages/worker/src/app/agent-discovery.ts
@@ -52,6 +52,7 @@ const robotsDisallowPaths = [
 	'/__maintenance',
 	'/webhooks',
 	'/connect/oauth',
+	'/connect/secrets',
 ] as const
 
 export type AgentSkillDefinition = {

--- a/packages/worker/src/app/handlers/account-secrets.node.test.ts
+++ b/packages/worker/src/app/handlers/account-secrets.node.test.ts
@@ -134,10 +134,15 @@ vi.mock('#mcp/secrets/allowed-hosts.ts', async (importOriginal) => {
 	}
 })
 
-vi.mock('#mcp/secrets/host-approval.ts', () => ({
-	buildSecretHostApprovalUrl: (...args: Array<unknown>) =>
-		mockModule.buildSecretHostApprovalUrl(...args),
-}))
+vi.mock('#mcp/secrets/host-approval.ts', async (importOriginal) => {
+	const actual =
+		await importOriginal<typeof import('#mcp/secrets/host-approval.ts')>()
+	return {
+		...actual,
+		buildSecretHostApprovalUrl: (...args: Array<unknown>) =>
+			mockModule.buildSecretHostApprovalUrl(...args),
+	}
+})
 
 vi.mock('#mcp/secrets/service.ts', () => ({
 	saveSecret: (...args: Array<unknown>) => mockModule.saveSecret(...args),
@@ -707,6 +712,70 @@ test('host approval view and approve persist normalized hosts for the selected s
 			scope: 'user',
 			allowedHosts: ['api.cloudflare.com', 'api.github.com'],
 			storageContext: { sessionId: null, appId: null, packageId: null },
+		}),
+	)
+})
+
+test('host bulk approval adds every requested host to each listed secret', async () => {
+	mockModule.setSecretAllowedHosts.mockClear()
+	const secret = {
+		name: 'cloudflareToken',
+		scope: 'user' as const,
+		description: 'Cloudflare token',
+		packageId: null,
+		allowedHosts: ['api.github.com'],
+		allowedPackages: [],
+		createdAt: new Date(0).toISOString(),
+		updatedAt: new Date(0).toISOString(),
+		expiresAt: null,
+		ttlMs: null,
+	}
+	mockModule.listSecrets.mockResolvedValue([secret])
+	mockModule.listSavedPackagesByUserId.mockResolvedValue([])
+	mockModule.listPackageSecretsByPackageIds.mockResolvedValue(new Map())
+
+	const handler = createAccountSecretsApiHandler(createEnv())
+	const viewResponse = await handler.handler({
+		request: new Request(
+			'https://example.com/account/secrets.json?names=cloudflareToken&hosts=api.cloudflare.com,dash.cloudflare.com',
+			{ method: 'GET' },
+		),
+		params: {},
+	} as never)
+	expect(viewResponse.status).toBe(200)
+	await expect(viewResponse.json()).resolves.toMatchObject({
+		ok: true,
+		approval: {
+			name: 'cloudflareToken',
+			names: ['cloudflareToken'],
+			requestedHost: 'api.cloudflare.com',
+			requestedHosts: ['api.cloudflare.com', 'dash.cloudflare.com'],
+			requestedPackageId: null,
+		},
+	})
+
+	const approveResponse = await handler.handler({
+		request: new Request(
+			'https://example.com/account/secrets.json?names=cloudflareToken&hosts=api.cloudflare.com,dash.cloudflare.com',
+			{
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ action: 'approve' }),
+			},
+		),
+		params: {},
+	} as never)
+	expect(approveResponse.status).toBe(200)
+	await expect(approveResponse.json()).resolves.toMatchObject({ ok: true })
+	expect(mockModule.setSecretAllowedHosts).toHaveBeenCalledWith(
+		expect.objectContaining({
+			name: 'cloudflareToken',
+			scope: 'user',
+			allowedHosts: [
+				'api.cloudflare.com',
+				'api.github.com',
+				'dash.cloudflare.com',
+			],
 		}),
 	)
 })

--- a/packages/worker/src/app/handlers/account-secrets.ts
+++ b/packages/worker/src/app/handlers/account-secrets.ts
@@ -7,10 +7,13 @@ import {
 	parseAccountSecretId,
 } from '@kody-internal/shared/account-secret-route.ts'
 import {
+	getHostApprovalStorageContext,
 	getSecretContextForAccountSecret,
 	listAccountSecrets,
 	loadAccountSecretsData,
 	readAccountSecretsSelectedSecretId,
+	readApprovalHosts,
+	readHostApprovalScope,
 	resolveApprovalRequest,
 	toPackageOptions,
 } from '#app/account-secrets-data.ts'
@@ -866,11 +869,6 @@ function readTokenField(
 	return typeof value === 'string' && value.trim() ? value.trim() : null
 }
 
-function readApprovalHost(url: URL) {
-	const value = url.searchParams.get('allowed-host')
-	return value?.trim() ? value.trim() : null
-}
-
 function readRequestedPackageId(url: URL) {
 	const value = url.searchParams.get('package_id')
 	return value?.trim() ? value.trim() : null
@@ -896,9 +894,11 @@ async function handleApprovalAction(input: {
 		const url = new URL(input.request.url)
 		const approval = resolveApprovalRequest({
 			secretId: readAccountSecretsSelectedSecretId(input.request.url),
-			requestedHost: readApprovalHost(url),
+			requestedHosts: readApprovalHosts(url),
 			requestedPackageId: readRequestedPackageId(url),
 			requestedSecretNames: readRequestedSecretNames(url),
+			requestedHostScope: readHostApprovalScope(url),
+			requestedHostStorageContext: getHostApprovalStorageContext(url),
 		})
 
 		if (approval.kind === 'package_bulk') {
@@ -1038,6 +1038,55 @@ async function handleApprovalAction(input: {
 				})
 			}
 
+			const payload = await loadAccountSecretsData({
+				request: input.request,
+				env: input.env,
+				user: input.user,
+				selectedSecretId: readAccountSecretsSelectedSecretId(input.request.url),
+			})
+			return jsonResponse(payload)
+		}
+
+		if (approval.kind === 'host_bulk') {
+			if (input.action === 'approve') {
+				const current = await listSecrets({
+					env: input.env,
+					userId: input.user.mcpUser.userId,
+					scope: approval.scope,
+					storageContext: approval.storageContext,
+					includeIntegrationOwned: true,
+				})
+				const byName = new Map(
+					current
+						.filter((item) => item.scope === approval.scope)
+						.map((item) => [item.name, item]),
+				)
+				const missingNames: Array<string> = []
+				for (const name of approval.names) {
+					const secret = byName.get(name)
+					if (!secret) {
+						missingNames.push(name)
+						continue
+					}
+					await setSecretAllowedHosts({
+						env: input.env,
+						userId: input.user.mcpUser.userId,
+						name,
+						scope: approval.scope,
+						allowedHosts: normalizeAllowedHosts([
+							...secret.allowedHosts,
+							...approval.hosts,
+						]),
+						storageContext: approval.storageContext,
+					})
+				}
+				if (missingNames.length === approval.names.length) {
+					return jsonResponse(
+						{ ok: false, error: 'None of the listed secrets were found.' },
+						404,
+					)
+				}
+			}
 			const payload = await loadAccountSecretsData({
 				request: input.request,
 				env: input.env,

--- a/packages/worker/src/app/handlers/connect-secrets.node.test.ts
+++ b/packages/worker/src/app/handlers/connect-secrets.node.test.ts
@@ -1,0 +1,73 @@
+import { expect, test, vi } from 'vitest'
+import { RequestContext } from 'remix/router'
+import { createConnectSecretsHandler } from '#app/handlers/connect-secrets.ts'
+
+const mockModule = vi.hoisted(() => ({
+	requireAuthenticatedPageUser: vi.fn<() => Promise<unknown>>(),
+	loadAccountSecretsData: vi.fn<() => Promise<unknown>>(),
+	renderAppPage: vi.fn<(input: unknown) => Promise<Response>>(),
+}))
+
+vi.mock('#app/page-auth.ts', () => ({
+	requireAuthenticatedPageUser: (...args: Array<unknown>) =>
+		mockModule.requireAuthenticatedPageUser(...args),
+}))
+
+vi.mock('#app/account-secrets-data.ts', () => ({
+	loadAccountSecretsData: (...args: Array<unknown>) =>
+		mockModule.loadAccountSecretsData(...args),
+}))
+
+vi.mock('#app/ssr-render.tsx', () => ({
+	renderAppPage: (input: unknown) => mockModule.renderAppPage(input),
+}))
+
+test('connect secrets page requires a signed-in user and embeds approval data', async () => {
+	const env = {} as Env
+	mockModule.requireAuthenticatedPageUser.mockResolvedValue(
+		Response.redirect(
+			'https://example.com/login?redirectTo=%2Fconnect%2Fsecrets',
+			302,
+		),
+	)
+	const unauthenticated = await createConnectSecretsHandler(env).handler(
+		new RequestContext(new Request('https://example.com/connect/secrets')),
+	)
+	expect(unauthenticated.status).toBe(302)
+	expect(unauthenticated.headers.get('location')).toContain('/login')
+
+	const user = { mcpUser: { userId: 'user-1' } }
+	const accountSecrets = {
+		ok: true,
+		approval: {
+			name: 'cloudflareToken',
+			names: ['cloudflareToken'],
+			requestedHosts: ['api.cloudflare.com'],
+		},
+		approvalError: null,
+	}
+	mockModule.requireAuthenticatedPageUser.mockResolvedValue(user)
+	mockModule.loadAccountSecretsData.mockResolvedValue(accountSecrets)
+	mockModule.renderAppPage.mockResolvedValue(new Response('ok'))
+
+	const response = await createConnectSecretsHandler(env).handler(
+		new RequestContext(
+			new Request(
+				'https://example.com/connect/secrets?name=cloudflareToken&hosts=api.cloudflare.com',
+			),
+		),
+	)
+	expect(response.status).toBe(200)
+	expect(mockModule.loadAccountSecretsData).toHaveBeenCalledWith(
+		expect.objectContaining({
+			env,
+			user,
+		}),
+	)
+	expect(mockModule.renderAppPage).toHaveBeenCalledWith(
+		expect.objectContaining({
+			title: 'Allow secret hosts',
+			loaderData: { accountSecrets },
+		}),
+	)
+})

--- a/packages/worker/src/app/handlers/connect-secrets.ts
+++ b/packages/worker/src/app/handlers/connect-secrets.ts
@@ -1,0 +1,29 @@
+import { type Action } from 'remix/router'
+import { loadAccountSecretsData } from '#app/account-secrets-data.ts'
+import { requireAuthenticatedPageUser } from '#app/page-auth.ts'
+import { renderAppPage } from '#app/ssr-render.tsx'
+import { type routes } from '#universal/routes.ts'
+
+export function createConnectSecretsHandler(env: Env) {
+	return {
+		middleware: [],
+		async handler({ request }) {
+			const user = await requireAuthenticatedPageUser(request, env)
+			if (user instanceof Response) {
+				return user
+			}
+
+			const accountSecrets = await loadAccountSecretsData({
+				request,
+				env,
+				user,
+			})
+			return renderAppPage({
+				request,
+				env,
+				title: 'Allow secret hosts',
+				loaderData: { accountSecrets },
+			})
+		},
+	} satisfies Action<typeof routes.connectSecrets>
+}

--- a/packages/worker/src/app/router.ts
+++ b/packages/worker/src/app/router.ts
@@ -151,6 +151,7 @@ import {
 	createAuthProvidersApiHandler,
 } from '#app/handlers/auth-provider.ts'
 import { createConnectOauthHandler } from '#app/handlers/connect-oauth.ts'
+import { createConnectSecretsHandler } from '#app/handlers/connect-secrets.ts'
 import {
 	createCommunityApiHandler,
 	createCommunityHandler,
@@ -486,6 +487,7 @@ export function createAppRouter(env: Env) {
 			webhookIngress: createWebhookIngressHandler(env),
 			stripeWebhook: createStripeWebhookHandler(env),
 			connectOauth: createConnectOauthHandler(env),
+			connectSecrets: createConnectSecretsHandler(env),
 			auth: createAuthHandler(env),
 			authProvidersApi: createAuthProvidersApiHandler(env),
 			authProviderStart: createAuthProviderStartHandler(env),

--- a/packages/worker/src/app/ssr-render-connect-secrets.node.test.ts
+++ b/packages/worker/src/app/ssr-render-connect-secrets.node.test.ts
@@ -1,0 +1,151 @@
+import { expect, test } from 'vitest'
+import {
+	createAuthCookie,
+	setAuthSessionSecret,
+	type AuthSession,
+} from '#app/auth-session.ts'
+import { resetDataCacheForTests } from '#app/data-cache.ts'
+import { renderAppPage } from '#app/ssr-render.tsx'
+import { executePreparedD1Batch } from '#worker/test-support/d1-prepared-batch.ts'
+import { testOidcSigningEnv } from '#worker/test-support/oidc-signing-env.ts'
+import { testStableUserIdFromEmail } from '#worker/test-support/stable-user-id.ts'
+
+const testCookieSecret = 'test-cookie-secret-0123456789abcdef0123456789'
+
+function createUserTestDb() {
+	function createStatement(query: string, params: Array<unknown> = []) {
+		const normalizedQuery = query.replace(/\s+/g, ' ').trim().toLowerCase()
+		const executeAll = async () => {
+			if (
+				normalizedQuery.startsWith('select') &&
+				normalizedQuery.includes('from "users"') &&
+				/"stable_user_id"\s*=/.test(normalizedQuery)
+			) {
+				if (params[0] === testStableUserIdFromEmail('user@example.com')) {
+					return {
+						results: [
+							{
+								id: 1,
+								email: 'user@example.com',
+								username: 'account-user',
+								password_hash: 'unused',
+								stable_user_id: testStableUserIdFromEmail('user@example.com'),
+								created_at: new Date(0).toISOString(),
+								updated_at: new Date(0).toISOString(),
+							},
+						],
+						meta: { changes: 0, last_row_id: 0 },
+					}
+				}
+			}
+			return {
+				results: [],
+				meta: { changes: 0, last_row_id: 0 },
+			}
+		}
+		return {
+			query,
+			bind(...nextParams: Array<unknown>) {
+				return createStatement(query, nextParams)
+			},
+			async all() {
+				return executeAll()
+			},
+			async first() {
+				const result = await executeAll()
+				return result.results[0] ?? null
+			},
+			async run() {
+				return { meta: { changes: 0, last_row_id: 0 } }
+			},
+		}
+	}
+
+	return {
+		prepare(query: string) {
+			return createStatement(query)
+		},
+		async batch(statements: Array<{ query?: string }>) {
+			return await executePreparedD1Batch(statements)
+		},
+		async exec() {
+			return
+		},
+	} as unknown as D1Database
+}
+
+test('renderAppPage server-renders the dedicated connect-secrets approval page', async () => {
+	resetDataCacheForTests()
+	setAuthSessionSecret(testCookieSecret)
+	const env = {
+		COOKIE_SECRET: testCookieSecret,
+		SECRET_STORE_KEY: 'LOCAL_TEST_SECRET_STORE_KEY_32_CHARS_MINIMUM',
+		...testOidcSigningEnv,
+		APP_DB: createUserTestDb(),
+		BUNDLE_ARTIFACTS_KV: {},
+		JOB_MANAGER: {},
+		STORAGE_RUNNER: {},
+		PACKAGE_REALTIME_SESSION: {},
+		MCP_CLIENT_HUB: {},
+	} as unknown as Env
+	const cookie = await createAuthCookie(
+		{
+			stableUserId: testStableUserIdFromEmail('user@example.com'),
+			email: 'user@example.com',
+			rememberMe: false,
+		} satisfies AuthSession,
+		false,
+	)
+
+	const connectSecretsResponse = await renderAppPage({
+		request: new Request(
+			'https://example.com/connect/secrets?name=googleAccessToken&hosts=gmail.googleapis.com,oauth2.googleapis.com',
+			{ headers: { Cookie: cookie } },
+		),
+		env,
+		loaderData: {
+			accountSecrets: {
+				ok: true,
+				email: 'user@example.com',
+				packageOptions: [],
+				packages: [],
+				secrets: [
+					{
+						id: 'user:googleAccessToken',
+						name: 'googleAccessToken',
+						scope: 'user',
+						description: '',
+						packageId: null,
+						packageTitle: null,
+						allowedHosts: ['oauth2.googleapis.com'],
+						allowedPackages: [],
+						createdAt: '2026-01-01T00:00:00.000Z',
+						updatedAt: '2026-01-01T00:00:00.000Z',
+						expiresAt: null,
+						ttlMs: null,
+					},
+				],
+				selectedSecret: null,
+				approval: {
+					name: 'googleAccessToken',
+					names: ['googleAccessToken'],
+					scope: 'user',
+					requestedHost: 'gmail.googleapis.com',
+					requestedHosts: ['gmail.googleapis.com', 'oauth2.googleapis.com'],
+					requestedPackageId: null,
+					currentAllowedHosts: ['oauth2.googleapis.com'],
+					currentAllowedPackages: [],
+				},
+				approvalError: null,
+			},
+		},
+	})
+	expect(connectSecretsResponse.status).toBe(200)
+	const connectSecretsHtml = await connectSecretsResponse.text()
+	expect(connectSecretsHtml).toContain('data-testid="connect-secrets"')
+	expect(connectSecretsHtml).toContain('Allow this secret at these hosts')
+	expect(connectSecretsHtml).toContain('gmail.googleapis.com')
+	expect(connectSecretsHtml).toContain('oauth2.googleapis.com')
+	expect(connectSecretsHtml).toContain('Allow all 2 hosts')
+	expect(connectSecretsHtml).not.toContain('New secret')
+})

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -1559,6 +1559,7 @@ test('renderAppPage server-renders simplified integration and secret-approval pa
 					names: ['googleAccessToken'],
 					scope: 'user',
 					requestedHost: 'gmail.googleapis.com',
+					requestedHosts: ['gmail.googleapis.com'],
 					requestedPackageId: null,
 					currentAllowedHosts: ['oauth2.googleapis.com'],
 					currentAllowedPackages: [],
@@ -1574,6 +1575,58 @@ test('renderAppPage server-renders simplified integration and secret-approval pa
 	expect(approvalHtml).toContain('gmail.googleapis.com')
 	expect(approvalHtml).toContain('data-testid="secret-approval-advanced"')
 	expect(approvalHtml).not.toContain('Approve secret access')
+
+	const connectSecretsResponse = await renderAppPage({
+		request: new Request(
+			'https://example.com/connect/secrets?name=googleAccessToken&hosts=gmail.googleapis.com,oauth2.googleapis.com',
+			{ headers: { Cookie: cookie } },
+		),
+		env,
+		loaderData: {
+			accountSecrets: {
+				ok: true,
+				email: 'user@example.com',
+				packageOptions: [],
+				packages: [],
+				secrets: [
+					{
+						id: 'user:googleAccessToken',
+						name: 'googleAccessToken',
+						scope: 'user',
+						description: '',
+						packageId: null,
+						packageTitle: null,
+						allowedHosts: ['oauth2.googleapis.com'],
+						allowedPackages: [],
+						createdAt: '2026-01-01T00:00:00.000Z',
+						updatedAt: '2026-01-01T00:00:00.000Z',
+						expiresAt: null,
+						ttlMs: null,
+					},
+				],
+				selectedSecret: null,
+				approval: {
+					name: 'googleAccessToken',
+					names: ['googleAccessToken'],
+					scope: 'user',
+					requestedHost: 'gmail.googleapis.com',
+					requestedHosts: ['gmail.googleapis.com', 'oauth2.googleapis.com'],
+					requestedPackageId: null,
+					currentAllowedHosts: ['oauth2.googleapis.com'],
+					currentAllowedPackages: [],
+				},
+				approvalError: null,
+			},
+		},
+	})
+	expect(connectSecretsResponse.status).toBe(200)
+	const connectSecretsHtml = await readResponseText(connectSecretsResponse)
+	expect(connectSecretsHtml).toContain('data-testid="connect-secrets"')
+	expect(connectSecretsHtml).toContain('Allow this secret at these hosts')
+	expect(connectSecretsHtml).toContain('gmail.googleapis.com')
+	expect(connectSecretsHtml).toContain('oauth2.googleapis.com')
+	expect(connectSecretsHtml).toContain('Allow all 2 hosts')
+	expect(connectSecretsHtml).not.toContain('New secret')
 })
 
 test('renderAppPage renders the redesigned pricing page', async () => {

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -1575,58 +1575,6 @@ test('renderAppPage server-renders simplified integration and secret-approval pa
 	expect(approvalHtml).toContain('gmail.googleapis.com')
 	expect(approvalHtml).toContain('data-testid="secret-approval-advanced"')
 	expect(approvalHtml).not.toContain('Approve secret access')
-
-	const connectSecretsResponse = await renderAppPage({
-		request: new Request(
-			'https://example.com/connect/secrets?name=googleAccessToken&hosts=gmail.googleapis.com,oauth2.googleapis.com',
-			{ headers: { Cookie: cookie } },
-		),
-		env,
-		loaderData: {
-			accountSecrets: {
-				ok: true,
-				email: 'user@example.com',
-				packageOptions: [],
-				packages: [],
-				secrets: [
-					{
-						id: 'user:googleAccessToken',
-						name: 'googleAccessToken',
-						scope: 'user',
-						description: '',
-						packageId: null,
-						packageTitle: null,
-						allowedHosts: ['oauth2.googleapis.com'],
-						allowedPackages: [],
-						createdAt: '2026-01-01T00:00:00.000Z',
-						updatedAt: '2026-01-01T00:00:00.000Z',
-						expiresAt: null,
-						ttlMs: null,
-					},
-				],
-				selectedSecret: null,
-				approval: {
-					name: 'googleAccessToken',
-					names: ['googleAccessToken'],
-					scope: 'user',
-					requestedHost: 'gmail.googleapis.com',
-					requestedHosts: ['gmail.googleapis.com', 'oauth2.googleapis.com'],
-					requestedPackageId: null,
-					currentAllowedHosts: ['oauth2.googleapis.com'],
-					currentAllowedPackages: [],
-				},
-				approvalError: null,
-			},
-		},
-	})
-	expect(connectSecretsResponse.status).toBe(200)
-	const connectSecretsHtml = await readResponseText(connectSecretsResponse)
-	expect(connectSecretsHtml).toContain('data-testid="connect-secrets"')
-	expect(connectSecretsHtml).toContain('Allow this secret at these hosts')
-	expect(connectSecretsHtml).toContain('gmail.googleapis.com')
-	expect(connectSecretsHtml).toContain('oauth2.googleapis.com')
-	expect(connectSecretsHtml).toContain('Allow all 2 hosts')
-	expect(connectSecretsHtml).not.toContain('New secret')
 })
 
 test('renderAppPage renders the redesigned pricing page', async () => {

--- a/packages/worker/src/mcp/executor.node.test.ts
+++ b/packages/worker/src/mcp/executor.node.test.ts
@@ -1384,6 +1384,7 @@ test('executor maps secret errors, formats guidance, extracts raw content, and t
 	)
 	expect(getExecutionErrorDetails(hostBatchError)).toMatchObject({
 		kind: 'host_approval_required_batch',
+		bulkApprovalUrl: null,
 		missingApprovals: [
 			{
 				secretName: 'cloudflareToken',

--- a/packages/worker/src/mcp/executor.ts
+++ b/packages/worker/src/mcp/executor.ts
@@ -1090,6 +1090,7 @@ export type ExecutionErrorDetails =
 				host: string
 				approvalUrl: string
 			}>
+			bulkApprovalUrl: string | null
 			suggestedAction: {
 				type: 'approve_secret_host'
 			}
@@ -1389,9 +1390,11 @@ export function getExecutionErrorDetails(
 		return {
 			kind: 'host_approval_required_batch',
 			message,
-			nextStep:
-				'Ask the user whether they want to approve these hosts for the listed secrets in the account web UI, then retry after approval.',
-			missingApprovals: hostApprovalBatch,
+			nextStep: hostApprovalBatch.bulkApprovalUrl
+				? 'Send the user the bulk secret host approval link, wait for them to approve, then retry.'
+				: 'Ask the user whether they want to approve these hosts for the listed secrets in the account web UI, then retry after approval.',
+			missingApprovals: hostApprovalBatch.entries,
+			bulkApprovalUrl: hostApprovalBatch.bulkApprovalUrl,
 			suggestedAction: {
 				type: 'approve_secret_host',
 			},

--- a/packages/worker/src/mcp/fetch-gateway.node.test.ts
+++ b/packages/worker/src/mcp/fetch-gateway.node.test.ts
@@ -86,15 +86,18 @@ test('fetch gateway blocks or expands secret placeholders based on host approval
 	} catch (error) {
 		const message = getErrorMessage(error)
 		const approvals = parseHostApprovalRequiredBatchMessage(message)
-		expect(approvals).toEqual([
-			expect.objectContaining({
-				secretName: 'spotifyRefreshToken',
-				host: 'example.com',
-				approvalUrl: expect.stringMatching(
-					/\/account\/secrets\/user\/spotifyRefreshToken\?allowed-host=example\.com$/,
-				),
-			}),
-		])
+		expect(approvals).toEqual({
+			entries: [
+				expect.objectContaining({
+					secretName: 'spotifyRefreshToken',
+					host: 'example.com',
+					approvalUrl: expect.stringMatching(
+						/\/connect\/secrets\?name=spotifyRefreshToken&hosts=example\.com$/,
+					),
+				}),
+			],
+			bulkApprovalUrl: null,
+		})
 	} finally {
 		blockedResolveSpy.mockRestore()
 	}
@@ -209,12 +212,15 @@ test('fetch gateway expands secret placeholders in URL paths after Request seria
 		const approvals = parseHostApprovalRequiredBatchMessage(
 			getErrorMessage(error),
 		)
-		expect(approvals).toEqual([
-			expect.objectContaining({
-				secretName: 'telegramBotToken',
-				host: 'api.telegram.org',
-			}),
-		])
+		expect(approvals).toEqual({
+			entries: [
+				expect.objectContaining({
+					secretName: 'telegramBotToken',
+					host: 'api.telegram.org',
+				}),
+			],
+			bulkApprovalUrl: null,
+		})
 	} finally {
 		blockedResolveSpy.mockRestore()
 	}
@@ -793,8 +799,8 @@ test('fetch gateway derives Basic Auth header and enforces host approval', async
 					getErrorMessage(error),
 				)
 				return (
-					approvals?.[0]?.secretName === blockedSecretName &&
-					approvals?.[0]?.host === 'api-m.paypal.com'
+					approvals?.entries[0]?.secretName === blockedSecretName &&
+					approvals?.entries[0]?.host === 'api-m.paypal.com'
 				)
 			})
 		}

--- a/packages/worker/src/mcp/fetch-gateway.node.test.ts
+++ b/packages/worker/src/mcp/fetch-gateway.node.test.ts
@@ -226,6 +226,73 @@ test('fetch gateway expands secret placeholders in URL paths after Request seria
 	}
 })
 
+test('fetch gateway bulk host approval uses the secret scope, not the package runtime context', async () => {
+	const packageProps = {
+		...props,
+		storageContext: {
+			sessionId: null,
+			appId: 'pkg-1',
+			packageId: 'pkg-1',
+			storageId: 'pkg-1',
+		},
+	}
+	const packageSpy = vi
+		.spyOn(packageRepo, 'getSavedPackageById')
+		.mockResolvedValue({
+			id: 'pkg-1',
+			userId: 'user-123',
+			kodyId: 'example-package',
+			name: '@user/example-package',
+			description: '',
+			tags: [],
+			searchText: null,
+			hasApp: false,
+			hidden: false,
+			isPrivate: false,
+			sourceId: 'source-1',
+			createdAt: '2026-01-01T00:00:00.000Z',
+			updatedAt: '2026-01-01T00:00:00.000Z',
+		})
+	const forkSpy = vi
+		.spyOn(communityRepo, 'getCommunityForkByForkedPackageId')
+		.mockResolvedValue(null)
+	const resolveSpy = vi
+		.spyOn(secretService, 'resolveSecret')
+		.mockResolvedValue({
+			found: true,
+			value: 'secret-value',
+			scope: 'user',
+			allowedHosts: [],
+			allowedPackages: ['pkg-1'],
+		})
+	try {
+		await expandSecretPlaceholders({
+			request: new Request('https://api.example.com/v1', {
+				headers: {
+					Authorization: 'Bearer {{secret:accessToken|scope=user}}',
+					'X-Refresh': '{{secret:refreshToken|scope=user}}',
+				},
+			}),
+			props: packageProps,
+			env,
+		})
+		throw new Error('Expected host approval error.')
+	} catch (error) {
+		const approvals = parseHostApprovalRequiredBatchMessage(
+			getErrorMessage(error),
+		)
+		expect(approvals?.bulkApprovalUrl).toBe(
+			'https://example.com/connect/secrets?names=accessToken%2CrefreshToken&hosts=api.example.com',
+		)
+		expect(approvals?.bulkApprovalUrl).not.toContain('scope=package')
+		expect(approvals?.entries[0]?.approvalUrl).not.toContain('scope=package')
+	} finally {
+		packageSpy.mockRestore()
+		forkSpy.mockRestore()
+		resolveSpy.mockRestore()
+	}
+})
+
 test('fetch gateway requires package approval before resolving user secrets', async () => {
 	const request = () =>
 		new Request('https://example.com/api', {

--- a/packages/worker/src/mcp/fetch-gateway.ts
+++ b/packages/worker/src/mcp/fetch-gateway.ts
@@ -25,6 +25,7 @@ import {
 import { createUnresolvedSecretMessage } from '#mcp/secrets/unresolved-secret.ts'
 import { normalizeHost } from '#mcp/secrets/allowed-hosts.ts'
 import { resolveSecret, type ResolvedSecret } from '#mcp/secrets/service.ts'
+import { type SecretScope } from '#mcp/secrets/types.ts'
 import { assertPackageCanAccessResolvedSecret } from '#mcp/secrets/package-access.ts'
 import { findIntegrationOwningSecretName } from '#worker/integrations/owned-secret-names.ts'
 import { assertCanUseIntegration } from '#worker/integrations/package-access.ts'
@@ -467,17 +468,20 @@ export async function expandSecretPlaceholders(input: {
 			resolvedSecrets,
 		})
 		if (missingApprovals.length > 0) {
-			const bulkApprovalUrl = buildSecretHostBulkApprovalUrlIfNeeded({
-				baseUrl: input.props.baseUrl,
-				names: missingApprovals.map((entry) => entry.secretName),
-				hosts: missingApprovals.map((entry) => entry.host),
-				scope: input.props.storageContext?.packageId
-					? 'package'
-					: input.props.storageContext?.sessionId
-						? 'session'
-						: 'user',
+			const bulkScope = readBulkHostApprovalScope({
+				missingApprovals,
+				resolvedSecrets,
 				storageContext: input.props.storageContext,
 			})
+			const bulkApprovalUrl = bulkScope
+				? buildSecretHostBulkApprovalUrlIfNeeded({
+						baseUrl: input.props.baseUrl,
+						names: missingApprovals.map((entry) => entry.secretName),
+						hosts: missingApprovals.map((entry) => entry.host),
+						scope: bulkScope.scope,
+						storageContext: bulkScope.storageContext,
+					})
+				: null
 			throw new Error(
 				createHostSecretAccessDeniedBatchMessage(missingApprovals, {
 					bulkApprovalUrl,
@@ -574,6 +578,37 @@ async function collectHostApprovalEntries(input: {
 	return entries.filter(
 		(entry): entry is NonNullable<typeof entry> => entry != null,
 	)
+}
+
+function readBulkHostApprovalScope(input: {
+	missingApprovals: Array<{ secretName: string }>
+	resolvedSecrets: Array<{
+		referenced: ReferencedSecret
+		resolved: ResolvedSecret
+	}>
+	storageContext: StorageContext | null
+}): { scope: SecretScope; storageContext: StorageContext | null } | null {
+	const scopes = input.missingApprovals.map((entry) => {
+		const match = input.resolvedSecrets.find(
+			(item) => item.referenced.name === entry.secretName,
+		)
+		return match?.resolved.scope ?? match?.referenced.scope ?? 'user'
+	})
+	const unique = new Set(scopes)
+	if (unique.size !== 1) return null
+	const scope = scopes[0]
+	if (!scope) return null
+	switch (scope) {
+		case 'user':
+			return { scope, storageContext: null }
+		case 'package':
+		case 'session':
+			return { scope, storageContext: input.storageContext }
+		default: {
+			const _exhaustive: never = scope
+			return _exhaustive
+		}
+	}
 }
 
 function readRequestedHost(url: string) {

--- a/packages/worker/src/mcp/fetch-gateway.ts
+++ b/packages/worker/src/mcp/fetch-gateway.ts
@@ -1,6 +1,9 @@
 import { bytesToBase64 } from '@kody-internal/shared/base64.ts'
 import { WorkerEntrypoint } from 'cloudflare:workers'
-import { buildSecretHostApprovalUrl } from '#mcp/secrets/host-approval.ts'
+import {
+	buildSecretHostApprovalUrl,
+	buildSecretHostBulkApprovalUrlIfNeeded,
+} from '#mcp/secrets/host-approval.ts'
 import {
 	buildBasicAuthSecretPlaceholderFromReference,
 	buildSecretPlaceholder,
@@ -464,8 +467,21 @@ export async function expandSecretPlaceholders(input: {
 			resolvedSecrets,
 		})
 		if (missingApprovals.length > 0) {
+			const bulkApprovalUrl = buildSecretHostBulkApprovalUrlIfNeeded({
+				baseUrl: input.props.baseUrl,
+				names: missingApprovals.map((entry) => entry.secretName),
+				hosts: missingApprovals.map((entry) => entry.host),
+				scope: input.props.storageContext?.packageId
+					? 'package'
+					: input.props.storageContext?.sessionId
+						? 'session'
+						: 'user',
+				storageContext: input.props.storageContext,
+			})
 			throw new Error(
-				createHostSecretAccessDeniedBatchMessage(missingApprovals),
+				createHostSecretAccessDeniedBatchMessage(missingApprovals, {
+					bulkApprovalUrl,
+				}),
 			)
 		}
 	}

--- a/packages/worker/src/mcp/secrets/errors.node.test.ts
+++ b/packages/worker/src/mcp/secrets/errors.node.test.ts
@@ -43,7 +43,22 @@ test('secret error message helpers parse auth, missing-secret, and approval payl
 		parseHostApprovalRequiredBatchMessage(
 			createHostSecretAccessDeniedBatchMessage(hostEntries),
 		),
-	).toEqual(hostEntries)
+	).toEqual({
+		entries: hostEntries,
+		bulkApprovalUrl: null,
+	})
+	expect(
+		parseHostApprovalRequiredBatchMessage(
+			createHostSecretAccessDeniedBatchMessage(hostEntries, {
+				bulkApprovalUrl:
+					'https://example.com/connect/secrets?names=cloudflareToken,githubToken&hosts=api.cloudflare.com,api.github.com',
+			}),
+		),
+	).toEqual({
+		entries: hostEntries,
+		bulkApprovalUrl:
+			'https://example.com/connect/secrets?names=cloudflareToken,githubToken&hosts=api.cloudflare.com,api.github.com',
+	})
 
 	const scopeUnavailableMessage = createSecretScopeUnavailableMessage([
 		{

--- a/packages/worker/src/mcp/secrets/errors.ts
+++ b/packages/worker/src/mcp/secrets/errors.ts
@@ -85,8 +85,13 @@ export type PackageApprovalEntry = {
 
 export function createHostSecretAccessDeniedBatchMessage(
 	entries: Array<HostApprovalEntry>,
+	options: { bulkApprovalUrl?: string | null } = {},
 ) {
-	const payload = JSON.stringify(entries)
+	const bulkApprovalUrl = options.bulkApprovalUrl?.trim() || null
+	const payload = JSON.stringify({
+		entries,
+		...(bulkApprovalUrl ? { bulkApprovalUrl } : {}),
+	})
 	return `${hostBatchDeniedPrefix} ${payload}`
 }
 
@@ -113,30 +118,52 @@ export function createPackageSecretAccessDeniedBatchMessage(
 	return `${packageBatchDeniedPrefix} ${payload}`
 }
 
-export function parseHostApprovalRequiredBatchMessage(message: string) {
+function parseHostApprovalEntries(value: unknown) {
+	if (!Array.isArray(value)) return []
+	const entries: Array<HostApprovalEntry> = []
+	for (const entry of value) {
+		if (!entry || typeof entry !== 'object') continue
+		if (
+			typeof entry.secretName !== 'string' ||
+			typeof entry.host !== 'string' ||
+			typeof entry.approvalUrl !== 'string'
+		) {
+			continue
+		}
+		entries.push({
+			secretName: entry.secretName,
+			host: entry.host,
+			approvalUrl: entry.approvalUrl,
+		})
+	}
+	return entries
+}
+
+export function parseHostApprovalRequiredBatchMessage(message: string): {
+	entries: Array<HostApprovalEntry>
+	bulkApprovalUrl: string | null
+} | null {
 	if (!message.startsWith(hostBatchDeniedPrefix)) return null
 	const raw = message.slice(hostBatchDeniedPrefix.length).trim()
 	if (!raw) return null
 	try {
 		const parsed = JSON.parse(raw)
-		if (!Array.isArray(parsed)) return null
-		const entries: Array<HostApprovalEntry> = []
-		for (const entry of parsed) {
-			if (!entry || typeof entry !== 'object') continue
-			if (
-				typeof entry.secretName !== 'string' ||
-				typeof entry.host !== 'string' ||
-				typeof entry.approvalUrl !== 'string'
-			) {
-				continue
-			}
-			entries.push({
-				secretName: entry.secretName,
-				host: entry.host,
-				approvalUrl: entry.approvalUrl,
-			})
+		if (Array.isArray(parsed)) {
+			const entries = parseHostApprovalEntries(parsed)
+			return entries.length > 0 ? { entries, bulkApprovalUrl: null } : null
 		}
-		return entries.length > 0 ? entries : null
+		if (!parsed || typeof parsed !== 'object') return null
+		const entries = parseHostApprovalEntries(
+			'entries' in parsed ? parsed.entries : null,
+		)
+		if (entries.length === 0) return null
+		const bulkApprovalUrl =
+			'bulkApprovalUrl' in parsed &&
+			typeof parsed.bulkApprovalUrl === 'string' &&
+			parsed.bulkApprovalUrl.trim()
+				? parsed.bulkApprovalUrl.trim()
+				: null
+		return { entries, bulkApprovalUrl }
 	} catch {
 		return null
 	}

--- a/packages/worker/src/mcp/secrets/host-approval.node.test.ts
+++ b/packages/worker/src/mcp/secrets/host-approval.node.test.ts
@@ -1,0 +1,64 @@
+import { expect, test } from 'vitest'
+import {
+	buildSecretHostApprovalUrl,
+	buildSecretHostBulkApprovalUrl,
+	buildSecretHostBulkApprovalUrlIfNeeded,
+} from './host-approval.ts'
+
+test('host approval URLs use /connect/secrets and support multiple hosts', () => {
+	expect(
+		buildSecretHostApprovalUrl({
+			baseUrl: 'https://example.com',
+			name: 'cloudflareToken',
+			scope: 'user',
+			requestedHost: 'API.Cloudflare.com',
+			storageContext: null,
+		}),
+	).toBe(
+		'https://example.com/connect/secrets?name=cloudflareToken&hosts=api.cloudflare.com',
+	)
+
+	expect(
+		buildSecretHostBulkApprovalUrl({
+			baseUrl: 'https://example.com',
+			names: ['accessToken', 'refreshToken'],
+			hosts: ['api.example.com', 'oauth.example.com', 'api.example.com'],
+		}),
+	).toBe(
+		'https://example.com/connect/secrets?names=accessToken%2CrefreshToken&hosts=api.example.com%2Coauth.example.com',
+	)
+
+	expect(
+		buildSecretHostBulkApprovalUrl({
+			baseUrl: 'https://example.com',
+			names: ['signingSecret'],
+			hosts: ['hooks.example.com'],
+			scope: 'package',
+			storageContext: {
+				sessionId: null,
+				appId: null,
+				packageId: 'pkg-1',
+			},
+		}),
+	).toBe(
+		'https://example.com/connect/secrets?name=signingSecret&hosts=hooks.example.com&scope=package&packageId=pkg-1',
+	)
+
+	expect(
+		buildSecretHostBulkApprovalUrlIfNeeded({
+			baseUrl: 'https://example.com',
+			names: ['onlyOne'],
+			hosts: ['api.example.com'],
+		}),
+	).toBeNull()
+
+	expect(
+		buildSecretHostBulkApprovalUrlIfNeeded({
+			baseUrl: 'https://example.com',
+			names: ['onlyOne'],
+			hosts: ['api.example.com', 'oauth.example.com'],
+		}),
+	).toBe(
+		'https://example.com/connect/secrets?name=onlyOne&hosts=api.example.com%2Coauth.example.com',
+	)
+})

--- a/packages/worker/src/mcp/secrets/host-approval.ts
+++ b/packages/worker/src/mcp/secrets/host-approval.ts
@@ -1,10 +1,14 @@
-import {
-	buildAccountSecretPath,
-	joinOriginAndEncodedPath,
-} from '@kody-internal/shared/account-secret-route.ts'
 import { type StorageContext } from '#mcp/storage.ts'
-import { normalizeHost } from './allowed-hosts.ts'
+import { normalizeAllowedHosts } from './allowed-hosts.ts'
+import { normalizeBulkPackageSecretApprovalNames } from './package-approval-url.ts'
 import { type SecretScope } from './types.ts'
+
+const connectSecretsPath = '/connect/secrets'
+const maxBulkHostApprovalHosts = 20
+
+export function normalizeBulkHostApprovalHosts(hosts: Array<string>) {
+	return normalizeAllowedHosts(hosts).slice(0, maxBulkHostApprovalHosts)
+}
 
 export function buildSecretHostApprovalUrl(input: {
 	baseUrl: string
@@ -13,13 +17,93 @@ export function buildSecretHostApprovalUrl(input: {
 	requestedHost: string
 	storageContext: StorageContext | null
 }) {
-	const secretPath = buildAccountSecretPath({
-		name: input.name,
+	return buildSecretHostBulkApprovalUrl({
+		baseUrl: input.baseUrl,
+		names: [input.name],
+		hosts: [input.requestedHost],
 		scope: input.scope,
-		packageId: input.storageContext?.packageId ?? null,
-		sessionId: input.storageContext?.sessionId ?? null,
+		storageContext: input.storageContext,
 	})
-	const search = new URLSearchParams()
-	search.set('allowed-host', normalizeHost(input.requestedHost))
-	return `${joinOriginAndEncodedPath(input.baseUrl, secretPath)}?${search}`
+}
+
+export function buildSecretHostBulkApprovalUrl(input: {
+	baseUrl: string
+	names: Array<string>
+	hosts: Array<string>
+	scope?: SecretScope
+	storageContext?: StorageContext | null
+}) {
+	const names = normalizeBulkPackageSecretApprovalNames(input.names)
+	const hosts = normalizeBulkHostApprovalHosts(input.hosts)
+	if (names.length === 0) {
+		throw new Error('At least one secret name is required for host approval.')
+	}
+	if (hosts.length === 0) {
+		throw new Error('At least one host is required for host approval.')
+	}
+	const url = new URL(connectSecretsPath, input.baseUrl)
+	if (names.length === 1) {
+		url.searchParams.set('name', names[0] ?? '')
+	} else {
+		url.searchParams.set('names', names.join(','))
+	}
+	url.searchParams.set('hosts', hosts.join(','))
+	applyHostApprovalScopeParams(url, input.scope ?? 'user', input.storageContext)
+	return url.toString()
+}
+
+export function buildSecretHostBulkApprovalUrlIfNeeded(input: {
+	baseUrl: string
+	names: Array<string>
+	hosts: Array<string>
+	scope?: SecretScope
+	storageContext?: StorageContext | null
+}) {
+	const names = normalizeBulkPackageSecretApprovalNames(input.names)
+	const hosts = normalizeBulkHostApprovalHosts(input.hosts)
+	if (names.length < 2 && hosts.length < 2) return null
+	return buildSecretHostBulkApprovalUrl({
+		baseUrl: input.baseUrl,
+		names,
+		hosts,
+		scope: input.scope,
+		storageContext: input.storageContext,
+	})
+}
+
+function applyHostApprovalScopeParams(
+	url: URL,
+	scope: SecretScope,
+	storageContext: StorageContext | null | undefined,
+) {
+	switch (scope) {
+		case 'user':
+			return
+		case 'package': {
+			const packageId = storageContext?.packageId
+			if (!packageId) {
+				throw new Error(
+					'storageContext.packageId is required for package-scope host approvals.',
+				)
+			}
+			url.searchParams.set('scope', 'package')
+			url.searchParams.set('packageId', packageId)
+			return
+		}
+		case 'session': {
+			const sessionId = storageContext?.sessionId
+			if (!sessionId) {
+				throw new Error(
+					'storageContext.sessionId is required for session-scope host approvals.',
+				)
+			}
+			url.searchParams.set('scope', 'session')
+			url.searchParams.set('sessionId', sessionId)
+			return
+		}
+		default: {
+			const _exhaustive: never = scope
+			throw new Error(`Unsupported host approval scope: ${String(_exhaustive)}`)
+		}
+	}
 }

--- a/packages/worker/universal/document-head.ts
+++ b/packages/worker/universal/document-head.ts
@@ -386,6 +386,7 @@ const routeDocumentHeads = {
 		const provider = loaderData?.connectOauth?.provider?.trim()
 		return titleOnly(provider ? `Connect ${provider}` : 'Connect an account')
 	},
+	[routePattern(routes.connectSecrets)]: titleOnly('Allow secret hosts'),
 	[oauthPaths.authorize]: titleOnly('Authorize access'),
 	[oauthPaths.callback]: titleOnly('OAuth callback'),
 } as const satisfies Record<string, DocumentHeadResolver>

--- a/packages/worker/universal/loader-data.ts
+++ b/packages/worker/universal/loader-data.ts
@@ -1369,6 +1369,7 @@ export type AccountSecretsLoaderData = {
 		names: Array<string>
 		scope: 'package' | 'session' | 'user'
 		requestedHost: string
+		requestedHosts: Array<string>
 		requestedPackageId: string | null
 		currentAllowedHosts: Array<string>
 		currentAllowedPackages: Array<string>

--- a/packages/worker/universal/routes.ts
+++ b/packages/worker/universal/routes.ts
@@ -12,6 +12,7 @@ export const routes = route({
 	securityTxt: '/.well-known/security.txt',
 	openaiAppsChallenge: '/.well-known/openai-apps-challenge',
 	connectOauth: '/connect/oauth',
+	connectSecrets: '/connect/secrets',
 	integrationLogo: '/integrations/logos/:integrationSlug',
 	providerMarkLogo: '/integrations/provider-marks/:slug',
 	accountIntegrations: '/account/integrations',

--- a/tools/control-kody/feature-catalog.ts
+++ b/tools/control-kody/feature-catalog.ts
@@ -106,7 +106,7 @@ export const featureCatalog: ReadonlyArray<Feature> = [
 		id: 'secrets',
 		title: 'Secrets',
 		file: 'secrets.md',
-		paths: ['/account/secrets'],
+		paths: ['/account/secrets', '/connect/secrets'],
 		apis: ['/account/secrets.json'],
 	},
 	{
@@ -249,6 +249,7 @@ export const requiredHtmlPrefixes = [
 	'/account',
 	'/admin',
 	'/connect/oauth',
+	'/connect/secrets',
 	'/community',
 	'/@:username',
 ] as const


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Give host approval its own focused page so a user can allow a saved secret at one or more hosts in a single click, the same way `/connect/oauth` is a dedicated connect surface instead of the full integrations list.

## Why

Agents already stop and surface an approval link when a secret-bearing fetch hits an unapproved host. Those links went to the secret editor (`/account/secrets/user/:name?allowed-host=…`), which is the wrong page for a “allow this host” decision — especially when several hosts or secrets need approval together.

## Summary

- New authenticated route `/connect/secrets` (`name` / `names` + `hosts` / `host` / `allowed-host`).
- One Allow click adds every listed host to each listed secret (`host_bulk` on `POST /account/secrets.json`).
- Agent-facing `buildSecretHostApprovalUrl` now points here. Multi-secret / multi-host denies include a `bulkApprovalUrl`.
- Existing secret-detail `?allowed-host=` links still work. Package grants stay on `/account/secrets/approve`.
- `/connect/oauth` “Allow access” is now one POST with `names` + `hosts` instead of sequential per-link approvals.
- Follow-up: Allow stays visible when listed secrets are missing from the editable list; bulk URLs use the secret's own scope, not the package runtime context.

## Testing

- `tsc` worker client + worker typecheck: pass
- `slop-ratchet:check`: pass (connect-secrets SSR case moved out of the 2000-line file)
- Pre-push: `vitest` node-unit 2648 passed, workers-unit 330 passed
- Preview / browser pass after the latest deploy

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `7d227f89` · **Head:** `bba1df50`

**Classification:** extends — new `/connect/secrets` app route and a `host_bulk` approval contract; MCP deny payloads now carry a bulk approval URL keyed to the secret's own scope.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `app-ui` | surfaces | extends — new `/connect/secrets` route, handler, and focused approval card; `ApprovalView.requestedHosts` |
| `mcp-server` | surfaces | extends — host-approval URLs move to `/connect/secrets`; batch deny JSON includes `bulkApprovalUrl` from the secret scope |

Unmatched paths are docs and the control-kody feature map for `/connect/secrets`.

### Change flow

A blocked secret-bearing fetch now sends the user to `/connect/secrets`, where one Allow click writes every listed host onto each listed secret.

```mermaid
sequenceDiagram
	actor User
	participant mcpServer as mcp-server
	participant appUi as app-ui
	mcpServer->>mcpServer: fetch-gateway builds /connect/secrets bulkApprovalUrl
	mcpServer->>User: host_approval_required_batch with bulkApprovalUrl
	User->>appUi: GET /connect/secrets?names=…&hosts=…
	appUi->>appUi: loadAccountSecretsData resolves host_bulk
	User->>appUi: Allow all N hosts
	appUi->>appUi: POST /account/secrets.json host_bulk approve
	Note over appUi: setSecretAllowedHosts for each name and host
```

### Before / after

| Surface | Before | After |
| ------- | ------ | ----- |
| Single-host agent link | `/account/secrets/user/:name?allowed-host=host` | `/connect/secrets?name=:name&hosts=host` |
| Multi-host / multi-secret | one link per pair | `/connect/secrets?names=a,b&hosts=x,y` |
| Batch deny payload | JSON array of entries | `{ entries, bulkApprovalUrl }` (old array still parses) |

### Invariants

`no-secrets-in-chat` is unchanged: the new page lists secret names and hosts only, never values. Host allowlists still change only through the authenticated account UI.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a3a3e0e8-1a79-4216-91f9-7b9d76947e9e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a3a3e0e8-1a79-4216-91f9-7b9d76947e9e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated `/connect/secrets` page for reviewing and approving secret host access.
  * Added bulk approval for multiple secrets and hosts, including “Allow all” actions.
  * Approval links now support multiple hosts and provide consolidated access guidance.
  * Unauthenticated visitors are redirected to sign in before approving access.

* **Documentation**
  * Updated secret approval guidance for host approvals, package grants, and legacy links.
  * Added instructions for bulk approvals and clarified that agents cannot approve access automatically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->