### PR TITLE
Cheap resume for partial full-backup seals

### DIFF
--- a/packages/backup-control-plane/seal-full-backup.node.test.ts
+++ b/packages/backup-control-plane/seal-full-backup.node.test.ts
@@ -263,6 +263,76 @@ test('sealFullBackupDay completes over locked partial state and duplicate index 
 	assert.equal(sealed?.payload.day, day)
 })
 
+test('sealFullBackupDay resumes a locked partial day without re-getting dump bodies', async () => {
+	// 2026-09-04 production wedge: hourly seal copied every daily/full
+	// object then timed out before writing the signed manifest. Resume must
+	// HEAD sealed keys and skip staging re-download + 10069 byte-compare for
+	// dumps whose sealed size already matches the staging index entry.
+	const bucket = new MemoryBucket()
+	bucket.enableLockPolicy()
+	const day = '2026-09-04'
+	const { env, sqlKey } = await seedCompleteDay(bucket, day)
+	await putSqlStatsFixture(bucket, day, sqlKey)
+
+	const dumpBodies = {
+		storage: '{"key":"a","valueJson":"1"}\n',
+		mailbox: '{"kind":"thread","row":{"id":"thread-1"}}\n',
+		runLog:
+			'{"kind":"activationMilestone","row":{"milestone":"package_activated"}}\n',
+	} as const
+	const sealedDumpKeys = {
+		storage: `daily/full/${day}/storage/${encodeURIComponent('user-storage-1')}.ndjson`,
+		mailbox: `daily/full/${day}/mailbox/${encodeURIComponent('user-owner-1')}.ndjson`,
+		runLog: `daily/full/${day}/run-log/${encodeURIComponent('user-owner-1')}.ndjson`,
+	} as const
+	await bucket.put(sealedDumpKeys.storage, dumpBodies.storage)
+	await bucket.put(sealedDumpKeys.mailbox, dumpBodies.mailbox)
+	await bucket.put(sealedDumpKeys.runLog, dumpBodies.runLog)
+	const putsBeforeSeal = bucket.puts.length
+
+	const stagingDumpKeys = new Set([
+		stagingStorageDumpKey(day, 'user-storage-1'),
+		stagingMailboxDumpKey(day, 'user-owner-1'),
+		stagingRunLogDumpKey(day, 'user-owner-1'),
+	])
+	const getKeys: Array<string> = []
+	const originalGet = bucket.get.bind(bucket)
+	bucket.get = async (key: string) => {
+		getKeys.push(key)
+		return originalGet(key)
+	}
+
+	const result = await sealFullBackupDay(
+		env,
+		day,
+		new Date(`${day}T20:00:00.000Z`),
+	)
+	assert.equal(result.kind, 'sealed')
+	if (result.kind !== 'sealed') return
+	assert.equal(result.alreadySealed, false)
+	assert.ok(await bucket.head(sealedFullManifestKey(day)))
+	assert.deepEqual(
+		getKeys.filter((key) => stagingDumpKeys.has(key)),
+		[],
+		'resume must not re-get dump bodies already sealed with matching size',
+	)
+	assert.equal(
+		getKeys.some((key) => Object.values(sealedDumpKeys).includes(key)),
+		false,
+		'matching sealed dump sizes must skip putImmutableBytes body compare',
+	)
+	const sealedPuts = bucket.puts
+		.slice(putsBeforeSeal)
+		.filter((entry) => entry.key.startsWith(`daily/full/${day}/`))
+	assert.equal(
+		sealedPuts.some((entry) =>
+			Object.values(sealedDumpKeys).includes(entry.key),
+		),
+		false,
+		'already-sealed dumps must not be put again under the lock policy',
+	)
+})
+
 test('sealFullBackupDay fails closed on staging storage or mailbox sha mismatches', async () => {
 	const storageBucket = new MemoryBucket()
 	const storageDay = await seedCompleteDay(storageBucket)

--- a/packages/backup-control-plane/seal-full-backup.node.test.ts
+++ b/packages/backup-control-plane/seal-full-backup.node.test.ts
@@ -316,8 +316,9 @@ test('sealFullBackupDay resumes a locked partial day without re-getting dump bod
 		[],
 		'resume must not re-get dump bodies already sealed with matching size',
 	)
+	const sealedDumpKeySet = new Set<string>(Object.values(sealedDumpKeys))
 	assert.equal(
-		getKeys.some((key) => Object.values(sealedDumpKeys).includes(key)),
+		getKeys.some((key) => sealedDumpKeySet.has(key)),
 		false,
 		'matching sealed dump sizes must skip putImmutableBytes body compare',
 	)
@@ -325,9 +326,7 @@ test('sealFullBackupDay resumes a locked partial day without re-getting dump bod
 		.slice(putsBeforeSeal)
 		.filter((entry) => entry.key.startsWith(`daily/full/${day}/`))
 	assert.equal(
-		sealedPuts.some((entry) =>
-			Object.values(sealedDumpKeys).includes(entry.key),
-		),
+		sealedPuts.some((entry) => sealedDumpKeySet.has(entry.key)),
 		false,
 		'already-sealed dumps must not be put again under the lock policy',
 	)

--- a/packages/backup-control-plane/seal-full-backup.ts
+++ b/packages/backup-control-plane/seal-full-backup.ts
@@ -409,6 +409,11 @@ function collectReferencedBlobHashes(input: {
 	return hashes
 }
 
+// 2026-09-04 had 3168 unique referenced blob hashes. Sequential HEAD at
+// ~20ms wall ≈ 63s, which matches the scheduled seal failure (~67s wall,
+// ~227ms CPU, observability "Network connection lost.") — an R2/runtime
+// drop during long sequential binding I/O, not only browser disconnect.
+// Keep this in the 20–50 range; cheap sealed-object skip alone is not enough.
 const referencedBlobHeadConcurrency = 32
 
 async function mapPool<T, R>(
@@ -446,8 +451,7 @@ async function verifyReferencedBlobs(
 	| { kind: 'ok'; blobsVerified: number }
 	| { kind: 'missing'; reason: 'blob-missing' }
 > {
-	// Hashes are already unique from collectReferencedBlobHashes; HEAD every
-	// content-addressed blob key with modest concurrency.
+	// Hashes are already unique from collectReferencedBlobHashes.
 	const heads = await mapPool(
 		hashes,
 		referencedBlobHeadConcurrency,

--- a/packages/backup-control-plane/seal-full-backup.ts
+++ b/packages/backup-control-plane/seal-full-backup.ts
@@ -180,12 +180,45 @@ async function verifyStagingFile(
 	return bytes
 }
 
+async function sealedObjectMatchesExpectedBytes(
+	bucket: R2Bucket,
+	sealedKey: string,
+	expectedBytes: number,
+): Promise<boolean> {
+	const head = await bucket.head(sealedKey)
+	return head !== null && head.size === expectedBytes
+}
+
+/**
+ * When a prior seal attempt already copied this object under the locked
+ * daily/full prefix, skip staging re-download + put/byte-compare. Size match
+ * against the staging summary/index entry is enough for resume; a first-time
+ * seal still verifies sha-256 from staging.
+ */
+async function copyStagingObjectIfNeeded(
+	bucket: R2Bucket,
+	day: string,
+	summary: StagingFileSummary,
+	contentType: string,
+): Promise<void> {
+	const sealedKey = sealedKeyForStagingObject(day, summary.objectKey)
+	if (
+		await sealedObjectMatchesExpectedBytes(bucket, sealedKey, summary.bytes)
+	) {
+		return
+	}
+	const bytes = await verifyStagingFile(bucket, summary)
+	await putImmutableBytes(bucket, sealedKey, bytes, contentType)
+}
+
 async function sealOwnerDumps(input: {
 	bucket: R2Bucket
 	day: string
 	summary: StagingFileSummary
 	kind: 'mailbox' | 'run-log'
 }): Promise<BackupFullFileRef> {
+	// Indexes stay small: always re-read staging so resume can discover dump
+	// entries even when the sealed index already exists.
 	const indexBytes = await verifyStagingFile(input.bucket, input.summary)
 	const index = parseOwnerIndex(
 		JSON.parse(new TextDecoder().decode(indexBytes)),
@@ -193,15 +226,14 @@ async function sealOwnerDumps(input: {
 		input.kind,
 	)
 	for (const entry of index.entries) {
-		const dumpBytes = await verifyStagingFile(input.bucket, {
-			objectKey: entry.objectKey,
-			bytes: entry.bytes,
-			sha256: entry.sha256,
-		})
-		await putImmutableBytes(
+		await copyStagingObjectIfNeeded(
 			input.bucket,
-			sealedKeyForStagingObject(input.day, entry.objectKey),
-			dumpBytes,
+			input.day,
+			{
+				objectKey: entry.objectKey,
+				bytes: entry.bytes,
+				sha256: entry.sha256,
+			},
 			'application/x-ndjson',
 		)
 	}
@@ -221,6 +253,12 @@ async function putImmutableBytes(
 	bytes: Uint8Array,
 	contentType: string,
 ): Promise<void> {
+	// Cheap resume: matching size under a locked key means a prior seal
+	// attempt already wrote this object — skip put and the 10069 full-body
+	// compare that would otherwise re-download every dump.
+	if (await sealedObjectMatchesExpectedBytes(bucket, key, bytes.byteLength)) {
+		return
+	}
 	// A bucket-lock rule rejects puts on existing keys with error 10069
 	// before evaluating the conditional, so a partially sealed day (or a
 	// duplicate index entry) must fall through to byte comparison instead of
@@ -371,6 +409,36 @@ function collectReferencedBlobHashes(input: {
 	return hashes
 }
 
+const referencedBlobHeadConcurrency = 32
+
+async function mapPool<T, R>(
+	items: ReadonlyArray<T>,
+	concurrency: number,
+	mapper: (item: T) => Promise<R>,
+): Promise<Array<R>> {
+	if (items.length === 0) return []
+	const limit = Math.max(1, Math.min(concurrency, items.length))
+	const results: Array<R> = new Array(items.length)
+	let nextIndex = 0
+	let firstError: unknown
+	async function worker() {
+		while (nextIndex < items.length) {
+			const index = nextIndex
+			nextIndex += 1
+			const item = items[index]
+			if (item === undefined) return
+			try {
+				results[index] = await mapper(item)
+			} catch (error) {
+				firstError ??= error
+			}
+		}
+	}
+	await Promise.all(Array.from({ length: limit }, () => worker()))
+	if (firstError !== undefined) throw firstError
+	return results
+}
+
 async function verifyReferencedBlobs(
 	bucket: R2Bucket,
 	hashes: Array<string>,
@@ -378,13 +446,15 @@ async function verifyReferencedBlobs(
 	| { kind: 'ok'; blobsVerified: number }
 	| { kind: 'missing'; reason: 'blob-missing' }
 > {
-	// Hashes are already unique from collectReferencedBlobHashes; HEAD every one.
-	for (const hash of hashes) {
-		const key = backupBlobKey(hash)
-		const head = await bucket.head(key)
-		if (head === null) {
-			return { kind: 'missing', reason: 'blob-missing' }
-		}
+	// Hashes are already unique from collectReferencedBlobHashes; HEAD every
+	// content-addressed blob key with modest concurrency.
+	const heads = await mapPool(
+		hashes,
+		referencedBlobHeadConcurrency,
+		async (hash) => bucket.head(backupBlobKey(hash)),
+	)
+	if (heads.some((head) => head === null)) {
+		return { kind: 'missing', reason: 'blob-missing' }
 	}
 	return { kind: 'ok', blobsVerified: hashes.length }
 }
@@ -559,6 +629,7 @@ export async function sealFullBackupDay(
 		throw error
 	}
 
+	// Storage index is small: always re-read staging to discover dump entries.
 	const storageIndexBytes = await verifyStagingFile(
 		env.BACKUP_BUCKET,
 		summary.storageIndex,
@@ -568,15 +639,14 @@ export async function sealFullBackupDay(
 		day,
 	)
 	for (const entry of storageIndex.entries) {
-		const dumpBytes = await verifyStagingFile(env.BACKUP_BUCKET, {
-			objectKey: entry.objectKey,
-			bytes: entry.bytes,
-			sha256: entry.sha256,
-		})
-		await putImmutableBytes(
+		await copyStagingObjectIfNeeded(
 			env.BACKUP_BUCKET,
-			sealedKeyForStagingObject(day, entry.objectKey),
-			dumpBytes,
+			day,
+			{
+				objectKey: entry.objectKey,
+				bytes: entry.bytes,
+				sha256: entry.sha256,
+			},
 			'application/x-ndjson',
 		)
 	}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Partial `daily/full/{day}/` seals (objects copied, `manifest.json` missing) were failing before writing the signed manifest.

**Root cause of later “Network connection lost.” seals (~67s wall, ~227ms CPU):** not only browser/proxy disconnect. Worker scheduled seals hit the same string. For `2026-09-04` there are **3168** unique referenced blob hashes; sequential R2 HEAD at ~20ms ≈ **63s** of binding I/O, then the runtime drops the connection. Cheap sealed-object skip alone is not enough — **parallel blob HEADs are mandatory**.

This change (control-plane only):

1. Before staging verify+put for dump bodies, `head` the sealed key and skip when `size === expected.bytes`.
2. Same size short-circuit inside `putImmutableBytes` (avoids put/10069/byte-compare).
3. Parallelize `verifyReferencedBlobs` HEADs at concurrency **32** (within 20–50).
4. Test: locked partial day with matching sealed dumps completes without re-getting dump bodies; existing 10069 partial/duplicate tests kept.

Does not change restore/drill/production-restore paths.

## Test plan

- [x] `vitest` `seal-full-backup.node.test.ts` via root node config
- [ ] CI green
- [ ] Deploy `kody-production-d1-backups` and seal `2026-09-04`
- [ ] Confirm `daily/full/2026-09-04/manifest.json` exists and dashboard shows sealed

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `10a4f563` · **Head:** `77a2e73e`

**Classification:** extends — changes full-backup seal resume behavior on the backup-control-plane Worker without adding primitives.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `backup-control-plane` | storage | extends — cheap size-based resume for already-copied sealed dumps, `putImmutableBytes` head short-circuit, parallel blob HEADs (32) |

### Change flow

Hourly or UI seal resumes a locked partial day by HEAD-skipping sealed dumps, HEADs referenced blobs concurrently, then writes the signed manifest.

```mermaid
sequenceDiagram
	actor Operator
	participant backupControlPlane as backup-control-plane
	participant backupBucket as R2 BACKUP_BUCKET
	Operator->>backupControlPlane: seal day (cron or POST /actions/seal-day)
	backupControlPlane->>backupBucket: head sealed dump keys
	Note over backupControlPlane,backupBucket: size match skips staging get and put
	backupControlPlane->>backupBucket: head referenced blobs concurrency 32
	Note over backupControlPlane,backupBucket: avoids ~63s sequential I/O drop on 3168 blobs
	backupControlPlane->>backupBucket: put signed daily/full/{day}/manifest.json
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b056aa9f-9fcc-46f4-9260-5d6c34d18f01?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b056aa9f-9fcc-46f4-9260-5d6c34d18f01&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Resuming a partially completed backup seal now avoids unnecessary downloads, verification, and rewrites when sealed data already matches the expected size.
  - Backup sealing now checks stored data more efficiently, helping reduce redundant work and improve retry performance.
  - Referenced backup data is validated more efficiently during sealing, reducing delays for larger backups.
- **Tests**
  - Added regression coverage for resuming locked, partially sealed backup days and confirming that matching sealed data is reused safely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->