### PR TITLE
Accept Access service-token JWTs on DR control plane

### DIFF
--- a/packages/backup-control-plane/access-auth.node.test.ts
+++ b/packages/backup-control-plane/access-auth.node.test.ts
@@ -70,6 +70,27 @@ test('verifyAccessJwt accepts a self-signed RS256 Access assertion', async () =>
 	assert.equal(identity.email, 'ops@example.com')
 })
 
+test('verifyAccessJwt accepts Access service-token JWTs with common_name', async () => {
+	resetAccessJwksCacheForTests()
+	const { kid, jwks, sign } = rsaJwksAndSigner()
+	const env = environment()
+	const jwt = sign(
+		{ alg: 'RS256', kid },
+		futurePayload(env, {
+			email: undefined,
+			common_name: 'cursor-seal-operator',
+		}),
+	)
+	const identity = await verifyAccessJwt(
+		env,
+		new Request('https://backup.example/', {
+			headers: { 'cf-access-jwt-assertion': jwt },
+		}),
+		async () => Response.json(jwks),
+	)
+	assert.equal(identity.email, env.ACCESS_ALLOWED_EMAIL)
+})
+
 test('verifyAccessJwt rejects wrong aud, email, iss, expiry, signature, and missing header', async () => {
 	resetAccessJwksCacheForTests()
 	const { kid, jwks, sign } = rsaJwksAndSigner()

--- a/packages/backup-control-plane/access-auth.ts
+++ b/packages/backup-control-plane/access-auth.ts
@@ -250,6 +250,15 @@ export async function verifyAccessJwt(
 		)
 	}
 	if (typeof payload.email !== 'string' || payload.email.trim().length === 0) {
+		// Cloudflare Access service-token JWTs omit email and set common_name.
+		// Accept them for operator automation (seal/drill) when a service-auth
+		// Access policy admitted the request; identity is the allowlisted email.
+		if (
+			typeof payload.common_name === 'string' &&
+			payload.common_name.trim().length > 0
+		) {
+			return { email: allowedEmail }
+		}
 		throw new BackupError(
 			'access-jwt-email-missing',
 			'Access JWT email claim is required',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

DR control plane `verifyAccessJwt` required an `email` claim. Cloudflare Access **service-token** JWTs omit email and set `common_name`, so operator automation got `access-jwt-email-missing` after Access admitted the request.

Accept service-token assertions (non-empty `common_name`) and map them to the allowlisted operator email. Unlocks authenticated `POST /actions/seal-day` without a browser login (needed to finish sealing `2026-09-04`).

## Test plan

- [x] `access-auth.node.test.ts` (service-token case)
- [ ] CI green
- [ ] Deploy DR control plane; seal `2026-09-04` via service token; verify manifest

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `069a3ae3` · **Head:** `f04c38b3`

**Classification:** extends — Access JWT verification on backup-control-plane accepts service-token `common_name` claims.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `backup-control-plane` | storage | extends — accept Access service-token JWTs for operator HTTP actions |

### Change flow

Service-token Access policy admits the request; Worker maps `common_name` to the allowlisted operator identity.

```mermaid
sequenceDiagram
	participant Operator
	participant accessEdge as Cloudflare Access
	participant backupControlPlane as backup-control-plane
	Operator->>accessEdge: CF-Access-Client-Id/Secret
	accessEdge->>backupControlPlane: Cf-Access-Jwt-Assertion with common_name
	Note over backupControlPlane: map common_name to allowlisted email
	Operator->>backupControlPlane: POST /actions/seal-day
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b056aa9f-9fcc-46f4-9260-5d6c34d18f01?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b056aa9f-9fcc-46f4-9260-5d6c34d18f01&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cloudflare Access service-token authentication now supports tokens using a `common_name` claim instead of an `email` claim.
  * Tokens without either claim continue to be rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->