### PR TITLE
Stop local Vite HMR from reporting as production Sentry

### DIFF
--- a/docs/contributing/architecture/request-lifecycle.md
+++ b/docs/contributing/architecture/request-lifecycle.md
@@ -450,12 +450,13 @@ current traffic).
 
 The client bundle initializes `@sentry/browser` from a `kody:sentry` meta tag
 that `ssr-document.tsx` renders when `SENTRY_DSN` is configured (the DSN is a
-publishable client key). Capture is errors plus **error-only Session Replay**:
-`replaysSessionSampleRate` is `0` and `replaysOnErrorSampleRate` is `1`, so
-nothing is recorded to Sentry unless an error occurs, and replays mask all text
-and block all media (`packages/worker/client/sentry-client.ts`) because Kody
-sessions contain personal content. Envelopes are sent through the same-origin
-`POST /sentry-tunnel` route
+publishable client key), except under `WRANGLER_IS_LOCAL_DEV` so Vite HMR noise
+does not report as production. Capture is errors plus **error-only Session
+Replay**: `replaysSessionSampleRate` is `0` and `replaysOnErrorSampleRate` is
+`1`, so nothing is recorded to Sentry unless an error occurs, and replays mask
+all text and block all media (`packages/worker/client/sentry-client.ts`) because
+Kody sessions contain personal content. Envelopes are sent through the
+same-origin `POST /sentry-tunnel` route
 (`packages/worker/src/app/handlers/sentry-tunnel.ts`), which only forwards
 envelopes whose DSN matches the Worker's own `SENTRY_DSN` — this keeps the
 first-party CSP at `connect-src 'self'`. Because that DSN is public, the route

--- a/packages/worker/client/router-location.node.test.ts
+++ b/packages/worker/client/router-location.node.test.ts
@@ -1,0 +1,49 @@
+import { expect, test } from 'vitest'
+import { type Handle } from 'remix/ui'
+import {
+	readRouterPathname,
+	readRouterSearch,
+	readRouterUrl,
+	readSsrRouterUrl,
+	RouterLocationProvider,
+} from './router-location.tsx'
+
+function stubHandle(location: unknown) {
+	return {
+		context: {
+			get(provider: unknown) {
+				if (provider === RouterLocationProvider) return location
+				return undefined
+			},
+		},
+	} as Pick<Handle, 'context'>
+}
+
+test('readRouterUrl uses provider context and falls back when HMR drops it', () => {
+	const previousWindow = globalThis.window
+	expect(readRouterUrl(stubHandle({ url: '/account', ssrUrl: '/' }))).toBe(
+		'/account',
+	)
+	expect(readSsrRouterUrl(stubHandle({ url: '/account', ssrUrl: '/' }))).toBe(
+		'/',
+	)
+	expect(readRouterUrl(stubHandle(undefined))).toBe('/')
+	expect(readSsrRouterUrl(stubHandle(undefined))).toBe('/')
+
+	globalThis.window = {
+		location: {
+			pathname: '/onboarding/step-2',
+			search: '?provider=square',
+			hash: '',
+		},
+	} as Window & typeof globalThis
+	try {
+		expect(readRouterUrl(stubHandle(undefined))).toBe(
+			'/onboarding/step-2?provider=square',
+		)
+		expect(readRouterPathname(stubHandle(undefined))).toBe('/onboarding/step-2')
+		expect(readRouterSearch(stubHandle(undefined))).toBe('?provider=square')
+	} finally {
+		globalThis.window = previousWindow
+	}
+})

--- a/packages/worker/client/router-location.tsx
+++ b/packages/worker/client/router-location.tsx
@@ -42,12 +42,24 @@ export function RouterLocationProvider(
 	return () => handle.props.children
 }
 
+function readRouterLocation(
+	handle: Pick<Handle, 'context'>,
+): RouterLocationValue {
+	const location = handle.context.get(RouterLocationProvider)
+	if (location) return location
+	// Vite HMR can swap the provider function identity so `context.get`
+	// returns undefined mid-render (KODY-6T / KODY-6Z). Fall back to the
+	// current client URL instead of throwing.
+	const url = getClientUrl()
+	return { url, ssrUrl: url }
+}
+
 export function readRouterUrl(handle: Pick<Handle, 'context'>) {
-	return handle.context.get(RouterLocationProvider).url
+	return readRouterLocation(handle).url
 }
 
 export function readSsrRouterUrl(handle: Pick<Handle, 'context'>) {
-	return handle.context.get(RouterLocationProvider).ssrUrl
+	return readRouterLocation(handle).ssrUrl
 }
 
 export function readRouterPathname(handle: Pick<Handle, 'context'>) {

--- a/packages/worker/client/sentry-browser-filters.node.test.ts
+++ b/packages/worker/client/sentry-browser-filters.node.test.ts
@@ -918,3 +918,111 @@ test('browser Sentry filters drop Turnstile client load and challenge failures (
 		}),
 	).not.toBeNull()
 })
+
+test('browser Sentry filters drop local Vite HMR and loopback frame-resolve 500s (KODY-6Z)', () => {
+	expect(
+		filterBrowserSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'Error',
+						value: 'Frame resolve failed (500) for http://localhost:3742/',
+						stacktrace: {
+							frames: [
+								{
+									function: 'Object.resolveFrame',
+									filename: '/packages/worker/client/entry.tsx',
+									absPath:
+										'http://localhost:3742/packages/worker/client/entry.tsx',
+								},
+							],
+						},
+					},
+				],
+			},
+		}),
+	).toBeNull()
+	expect(
+		filterBrowserSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'TypeError',
+						value: "Cannot read properties of undefined (reading 'url')",
+						stacktrace: {
+							frames: [
+								{
+									function: 'Object.callComponentRenderForHmr',
+									filename:
+										'/node_modules/.vite/deps/remix_ui-hmr_runtime_browser.js',
+									absPath:
+										'http://localhost:3742/node_modules/.vite/deps/remix_ui-hmr_runtime_browser.js',
+								},
+							],
+						},
+					},
+				],
+			},
+		}),
+	).toBeNull()
+	expect(
+		filterBrowserSentryEvent(
+			{
+				exception: {
+					values: [{ type: 'Error', value: 'Client hydration error' }],
+				},
+			},
+			Object.assign(
+				new Error('Frame resolve failed (500) for http://127.0.0.1:3742/'),
+				{
+					stack:
+						'Error: Frame resolve failed (500) for http://127.0.0.1:3742/\n    at Object.resolveFrame (http://127.0.0.1:3742/packages/worker/client/entry.tsx:80:11)',
+				},
+			),
+		),
+	).toBeNull()
+	// Production homepage SSR 500s must stay visible.
+	expect(
+		filterBrowserSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'Error',
+						value: 'Frame resolve failed (500) for https://kody.codes/',
+						stacktrace: {
+							frames: [
+								{
+									function: 'Object.resolveFrame',
+									filename: '../client/entry.tsx',
+									absPath: 'https://kody.codes/client-entry.js',
+								},
+							],
+						},
+					},
+				],
+			},
+		}),
+	).not.toBeNull()
+	// Production readRouterUrl crashes must stay visible.
+	expect(
+		filterBrowserSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'TypeError',
+						value: "Cannot read properties of undefined (reading 'url')",
+						stacktrace: {
+							frames: [
+								{
+									function: 'readRouterUrl',
+									filename: '../client/router-location.tsx',
+									absPath: 'https://kody.codes/assets/entry-abc.js',
+								},
+							],
+						},
+					},
+				],
+			},
+		}),
+	).not.toBeNull()
+})

--- a/packages/worker/client/sentry-browser-filters.ts
+++ b/packages/worker/client/sentry-browser-filters.ts
@@ -1036,6 +1036,78 @@ export function isResolveFrameFetchNetworkError(error: unknown) {
 	)
 }
 
+/**
+ * Local `npm run dev` Vite / wrangler sessions (KODY-6Z, KODY-6T, KODY-6Y).
+ * Production wrangler vars copy `SENTRY_ENVIRONMENT=production` into local
+ * Vite, so HMR identity/CSS-binding crashes report as production. Match only
+ * loopback frame URLs, Vite HMR runtime tokens, or `Frame resolve failed`
+ * for a loopback `src` — production `kody.codes` resolveFrame 500s stay
+ * visible.
+ */
+const loopbackHttpUrlPattern =
+	/https?:\/\/(?:localhost|127\.0\.0\.1|\[::1\])(?::\d+)?(?:[/?#]|$)/i
+const viteDevStackTokenPattern =
+	/\/\.vite\/|remix_ui-hmr|callComponentRenderForHmr/i
+const frameResolveLoopbackMessagePattern =
+	/^Frame resolve failed \(\d+\) for https?:\/\/(?:localhost|127\.0\.0\.1|\[::1\])/i
+
+function isLocalViteDevFrameResolveMessage(message: string) {
+	return frameResolveLoopbackMessagePattern.test(
+		message.trim().replace(/^Error:\s*/i, ''),
+	)
+}
+
+function stackTextLooksLikeLocalViteDev(text: string) {
+	return (
+		loopbackHttpUrlPattern.test(text) || viteDevStackTokenPattern.test(text)
+	)
+}
+
+export function isLocalViteDevError(error: unknown) {
+	if (typeof error === 'string') {
+		return isLocalViteDevFrameResolveMessage(error)
+	}
+	if (typeof error !== 'object' || error === null) return false
+	const message =
+		'message' in error && typeof error.message === 'string' ? error.message : ''
+	const stack =
+		'stack' in error && typeof error.stack === 'string' ? error.stack : ''
+	if (isLocalViteDevFrameResolveMessage(message)) return true
+	return stackTextLooksLikeLocalViteDev(stack)
+}
+
+export function isLocalViteDevSentryEvent(
+	event: SentryErrorEventLike,
+	originalException?: unknown,
+) {
+	if (isLocalViteDevError(originalException)) return true
+	if (
+		sentryEventMessages(event).some(
+			(message) =>
+				typeof message === 'string' &&
+				isLocalViteDevFrameResolveMessage(message),
+		)
+	) {
+		return true
+	}
+	if (sentryEventStackFrameUrls(event).some(stackTextLooksLikeLocalViteDev)) {
+		return true
+	}
+	return sentryEventStackFrameFunctions(event).some(
+		(name) =>
+			name.includes('callComponentRenderForHmr') ||
+			name.includes('remix_ui-hmr'),
+	)
+}
+
+export function filterLocalViteDevSentryEvent<T extends SentryErrorEventLike>(
+	event: T,
+	originalException?: unknown,
+): T | null {
+	if (isLocalViteDevSentryEvent(event, originalException)) return null
+	return event
+}
+
 export function filterResolveFrameFetchNetworkSentryEvent<
 	T extends SentryErrorEventLike,
 >(event: T, originalException?: unknown): T | null {
@@ -1208,6 +1280,9 @@ export function filterBrowserSentryEvent<T extends SentryErrorEventLike>(
 	if (
 		filterResolveFrameFetchNetworkSentryEvent(event, originalException) === null
 	) {
+		return null
+	}
+	if (filterLocalViteDevSentryEvent(event, originalException) === null) {
 		return null
 	}
 	if (

--- a/packages/worker/client/sentry-client.ts
+++ b/packages/worker/client/sentry-client.ts
@@ -4,6 +4,7 @@ import {
 	isCloudflareTurnstileClientError,
 	isFirefoxDomPermissionDeniedError,
 	isMetaMaskWalletNoAccountError,
+	isLocalViteDevError,
 	isResolveFrameFetchNetworkError,
 	isSyntaxHighlightCoreDynamicImportFailureError,
 } from '#client/sentry-browser-filters.ts'
@@ -57,6 +58,7 @@ function shouldIgnoreBufferedError(error: unknown) {
 		isMetaMaskWalletNoAccountError(error) ||
 		isSyntaxHighlightCoreDynamicImportFailureError(error) ||
 		isResolveFrameFetchNetworkError(error) ||
+		isLocalViteDevError(error) ||
 		isCloudflareTurnstileClientError(error)
 	)
 }

--- a/packages/worker/client/sentry-init.ts
+++ b/packages/worker/client/sentry-init.ts
@@ -42,12 +42,13 @@ export function initBrowserSentry(config: SentryClientConfig) {
 		// TypeErrors, injected unguarded `meta[property='og:type']` probes
 		// from `global code`, and optional Shiki `syntax-highlight-core`
 		// dynamic import fetch failures, and resolveFrame fetch network
-		// TypeErrors) — see filterBrowserSentryEvent /
+		// TypeErrors, and local Vite / wrangler HMR loopback sessions)
+		// — see filterBrowserSentryEvent /
 		// KODY-CLOUDFLARE-23 / KODY-CLOUDFLARE-3Q / KODY-CLOUDFLARE-3S /
 		// KODY-CLOUDFLARE-3X / KODY-CLOUDFLARE-43 / KODY-CLOUDFLARE-46 /
 		// KODY-CLOUDFLARE-4F / KODY-CLOUDFLARE-5C / KODY-CLOUDFLARE-5K /
 		// KODY-CLOUDFLARE-5W / KODY-CLOUDFLARE-5X / KODY-CLOUDFLARE-5Y /
-		// KODY-CLOUDFLARE-64 /
+		// KODY-CLOUDFLARE-64 / KODY-6Z /
 		// issues 7639685398, 7648833360, 7648833403, 7653117289, 7655189301,
 		// 7658961865, 7659616372, 7660258027, 7662064169, 7677729361,
 		// 7682968915, 7687920474, 7689579030, 7690163947, 7696001937.

--- a/packages/worker/src/app/ssr-render.tsx
+++ b/packages/worker/src/app/ssr-render.tsx
@@ -20,10 +20,7 @@ import { getInlineStylesheet } from '#app/inline-stylesheet.ts'
 import { SsrDocument } from '#app/ssr-document.tsx'
 import { openDocumentStream } from '#app/ssr-document-stream.ts'
 import { preloadClientRouteModules } from '#client/lazy-route.tsx'
-import {
-	SENTRY_TUNNEL_PATH,
-	type SentryClientConfig,
-} from '#universal/sentry-config.ts'
+import { buildSsrSentryClientConfig } from '#universal/sentry-config.ts'
 import '#app/frame-registrations.ts'
 import { resolveRegisteredFrameHtml } from '#app/frame-registry.ts'
 import { collectServerTiming } from '#worker/request-context.ts'
@@ -113,15 +110,12 @@ export async function renderAppPage(input: RenderAppPageInput) {
 		documentHead.title = title
 	}
 	const parsedEnv = getEnv(env)
-	const sentryDsn = parsedEnv.SENTRY_DSN?.trim()
-	const sentryConfig: SentryClientConfig | null = sentryDsn
-		? {
-				dsn: sentryDsn,
-				environment: parsedEnv.SENTRY_ENVIRONMENT?.trim() || 'development',
-				release: parsedEnv.APP_COMMIT_SHA ?? null,
-				tunnel: SENTRY_TUNNEL_PATH,
-			}
-		: null
+	const sentryConfig = buildSsrSentryClientConfig({
+		dsn: parsedEnv.SENTRY_DSN,
+		environment: parsedEnv.SENTRY_ENVIRONMENT,
+		release: parsedEnv.APP_COMMIT_SHA,
+		localDev: parsedEnv.WRANGLER_IS_LOCAL_DEV === 'true',
+	})
 	const fathomSiteId = parsedEnv.FATHOM_SITE_ID?.trim() || null
 
 	const response = await pushServerTiming(serverTiming, 'ssr', async () => {

--- a/packages/worker/universal/sentry-config.node.test.ts
+++ b/packages/worker/universal/sentry-config.node.test.ts
@@ -1,5 +1,9 @@
 import { expect, test } from 'vitest'
-import { parseSentryClientConfig } from '#universal/sentry-config.ts'
+import {
+	buildSsrSentryClientConfig,
+	parseSentryClientConfig,
+	SENTRY_TUNNEL_PATH,
+} from '#universal/sentry-config.ts'
 
 test('parseSentryClientConfig accepts complete configs and rejects unsafe tunnels', () => {
 	expect(
@@ -55,4 +59,43 @@ test('parseSentryClientConfig accepts complete configs and rejects unsafe tunnel
 			}),
 		),
 	).toBeNull()
+})
+
+test('buildSsrSentryClientConfig skips local Vite and missing DSN, keeps deployed configs', () => {
+	expect(
+		buildSsrSentryClientConfig({
+			dsn: 'https://key@o1.ingest.sentry.io/2',
+			environment: 'production',
+			release: 'abc123',
+			localDev: true,
+		}),
+	).toBeNull()
+	expect(
+		buildSsrSentryClientConfig({
+			dsn: '   ',
+			environment: 'production',
+		}),
+	).toBeNull()
+	expect(
+		buildSsrSentryClientConfig({
+			dsn: 'https://key@o1.ingest.sentry.io/2',
+			environment: 'production',
+			release: 'abc123',
+		}),
+	).toEqual({
+		dsn: 'https://key@o1.ingest.sentry.io/2',
+		environment: 'production',
+		release: 'abc123',
+		tunnel: SENTRY_TUNNEL_PATH,
+	})
+	expect(
+		buildSsrSentryClientConfig({
+			dsn: 'https://key@o1.ingest.sentry.io/2',
+		}),
+	).toEqual({
+		dsn: 'https://key@o1.ingest.sentry.io/2',
+		environment: 'development',
+		release: null,
+		tunnel: SENTRY_TUNNEL_PATH,
+	})
 })

--- a/packages/worker/universal/sentry-config.ts
+++ b/packages/worker/universal/sentry-config.ts
@@ -17,6 +17,30 @@ export type SentryClientConfig = {
 	tunnel: string
 }
 
+/**
+ * SSR client-Sentry payload. Local `npm run dev` copies production
+ * `SENTRY_ENVIRONMENT` into wrangler vars and often has `SENTRY_DSN` in
+ * `.env`, so Vite HMR crashes would report as production (KODY-6Z). Skip
+ * the meta tag when `WRANGLER_IS_LOCAL_DEV` is set — the browser SDK already
+ * no-ops when the tag is absent.
+ */
+export function buildSsrSentryClientConfig(input: {
+	dsn?: string | null
+	environment?: string | null
+	release?: string | null
+	localDev?: boolean
+}): SentryClientConfig | null {
+	if (input.localDev) return null
+	const dsn = input.dsn?.trim()
+	if (!dsn) return null
+	return {
+		dsn,
+		environment: input.environment?.trim() || 'development',
+		release: input.release ?? null,
+		tunnel: SENTRY_TUNNEL_PATH,
+	}
+}
+
 export function parseSentryClientConfig(
 	content: string | null | undefined,
 ): SentryClientConfig | null {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Keep Vite HMR crashes from local `npm run dev` out of the production Sentry project, and stop those HMR identity swaps from throwing in `readRouterUrl`.

## Why

[KODY-6Z](https://kent-c-dodds-tech-llc.sentry.io/issues/7712789047/) (`Frame resolve failed (500) for http://localhost:3742/`) is a client hydration error from Electron against local Vite. Breadcrumbs show HMR of `home.tsx` / `app.tsx`, then `readRouterUrl` reading `.url` of undefined, then Remix reloading the frame into a 500. The event is tagged `environment=production` because local wrangler copies production `SENTRY_ENVIRONMENT` and `.env` often has `SENTRY_DSN`.

Same class as unresolved siblings KODY-6Y / KODY-6T (`readRouterUrl`), KODY-6W / KODY-6V (HMR CSS bindings), and KODY-6X (localhost `/account/packages`).

## Summary

- Skip the `kody:sentry` meta tag when `WRANGLER_IS_LOCAL_DEV` is set, so the browser SDK no-ops in `npm run dev`.
- Drop leftover loopback / Vite HMR browser events (`/.vite/`, `callComponentRenderForHmr`, `Frame resolve failed` for localhost). Production `https://kody.codes/` frame-resolve 500s stay visible.
- `readRouterUrl` / `readSsrRouterUrl` fall back to the current client URL when provider context is missing after an HMR identity swap.

## Testing

- `npx vitest run` on `sentry-config`, `sentry-browser-filters`, and `router-location` node suites.
- `npm run validate` (exit 0).

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `10a4f563` · **Head:** `d489a7b1`

**Classification:** composes — no primitives added or changed; this PR wires a local-dev skip and a narrow browser filter onto existing client Sentry, and hardens `readRouterUrl` when Remix context is missing.

### Primitives touched

| Primitive | Group    | Impact                                                                 |
| --------- | -------- | ---------------------------------------------------------------------- |
| `app-ui`  | surfaces | composes — local-dev Sentry skip, Vite/loopback filter, context fallback |

### Change flow

Local Vite HMR used to initialize production client Sentry and throw when the router-location provider identity swapped. This PR skips the meta tag in local wrangler, drops leftover loopback/HMR events, and falls back to `window.location`.

```mermaid
sequenceDiagram
	actor Dev as local browser
	participant appUi as app-ui
	participant sentry as Sentry
	Dev->>appUi: Vite HMR on localhost
	appUi->>appUi: skip kody:sentry meta when WRANGLER_IS_LOCAL_DEV
	appUi->>appUi: readRouterUrl falls back if context missing
	opt leftover inited SDK
		appUi->>appUi: beforeSend drops loopback or Vite HMR frames
	end
	appUi-->>sentry: no production event
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dc27e57d-543e-4964-87ee-f60cdf84795c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dc27e57d-543e-4964-87ee-f60cdf84795c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved router URL handling with safer fallbacks when provider context is unavailable.
  - Reduced reporting of local development and hot-reload errors as production issues.
  - Disabled Sentry configuration for local development and invalid or blank DSNs.

- **Documentation**
  - Clarified browser error monitoring, session replay masking, and filtered development errors.

- **Tests**
  - Added coverage for router URL fallbacks, Sentry filtering, and SSR monitoring configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->