### PR TITLE
Speed up packagePublishExternalPush rebuild and already_published races

### DIFF
--- a/packages/worker/src/mcp/capabilities/packages/publish-external-push.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/packages/publish-external-push.node.test.ts
@@ -1,5 +1,5 @@
 import { expect, test, vi } from 'vitest'
-import { consoleWarn } from '#worker/test-support/console-spies.ts'
+import { consoleInfo, consoleWarn } from '#worker/test-support/console-spies.ts'
 
 const mockModule = vi.hoisted(() => ({
 	getSavedPackageById: vi.fn(),
@@ -9,6 +9,7 @@ const mockModule = vi.hoisted(() => ({
 	publishFromExternalRef: vi.fn(),
 	listPublishedPackageArtifactTargets: vi.fn(),
 	rebuildPublishedPackageArtifact: vi.fn(),
+	isPublishedPackageArtifactBuiltForCommit: vi.fn(),
 	getStaticPackageDependentsSummary: vi.fn(),
 	runWithDurableEscalation: vi.fn(),
 }))
@@ -45,6 +46,17 @@ vi.mock('#worker/package-runtime/static-package-dependents.ts', () => ({
 	getStaticPackageDependentsSummary: (...args: Array<unknown>) =>
 		mockModule.getStaticPackageDependentsSummary(...args),
 }))
+
+vi.mock('#worker/package-runtime/published-bundle-artifacts.ts', async () => {
+	const actual = await vi.importActual<
+		typeof import('#worker/package-runtime/published-bundle-artifacts.ts')
+	>('#worker/package-runtime/published-bundle-artifacts.ts')
+	return {
+		...actual,
+		isPublishedPackageArtifactBuiltForCommit: (...args: Array<unknown>) =>
+			mockModule.isPublishedPackageArtifactBuiltForCommit(...args),
+	}
+})
 
 vi.mock('#worker/repo/published-source.ts', () => ({
 	loadPublishedEntitySource: async () => {
@@ -97,6 +109,7 @@ function setupDefaultMocks() {
 			'No published bundle artifacts declare a static dependency on this package.',
 	})
 	mockModule.listPublishedPackageArtifactTargets.mockResolvedValue([])
+	mockModule.isPublishedPackageArtifactBuiltForCommit.mockResolvedValue(false)
 	mockModule.rebuildPublishedPackageArtifact.mockResolvedValue({
 		ok: true,
 		target: {
@@ -306,6 +319,63 @@ test('publishExternalPush handles already_published branches, stale dependents, 
 		}),
 		pending_secret_package_approvals: null,
 	})
+	expect(mockModule.rebuildPublishedPackageArtifact).toHaveBeenCalledWith({
+		sourceId: 'source-1',
+		userId: 'user-1',
+		publishedCommit: 'commit-old',
+		target: targets[0],
+		baseUrl: 'https://kody.test',
+	})
+	expect(
+		consoleInfo.mock.calls.some((call) =>
+			String(call[0]).includes('"phase":"rebuild"'),
+		),
+	).toBe(true)
+	expect(
+		consoleInfo.mock.calls.some((call) =>
+			String(call[0]).includes('"phase":"dependents"'),
+		),
+	).toBe(true)
+
+	setupDefaultMocks()
+	mockModule.rebuildPublishedPackageArtifact.mockClear()
+	mockModule.resolveArtifactSourceHead.mockResolvedValue({
+		branch: 'main',
+		commit: 'commit-old',
+	})
+	mockModule.publishFromExternalRef.mockResolvedValue({
+		status: 'already_published',
+		published_commit: 'commit-old',
+	})
+	mockModule.listPublishedPackageArtifactTargets.mockResolvedValue(targets)
+	mockModule.isPublishedPackageArtifactBuiltForCommit.mockResolvedValue(true)
+
+	const alreadyPublishedSkip = await publishExternalPushCapability.handler(
+		{ package_id: 'package-1' },
+		createContext(),
+	)
+	expect(alreadyPublishedSkip.status).toBe('already_published')
+	expect(mockModule.rebuildPublishedPackageArtifact).not.toHaveBeenCalled()
+
+	setupDefaultMocks()
+	mockModule.rebuildPublishedPackageArtifact.mockClear()
+	mockModule.resolveArtifactSourceHead.mockResolvedValue({
+		branch: 'main',
+		commit: 'commit-old',
+	})
+	mockModule.publishFromExternalRef.mockResolvedValue({
+		status: 'already_published',
+		published_commit: 'commit-old',
+		force_artifact_rebuild: true,
+	})
+	mockModule.listPublishedPackageArtifactTargets.mockResolvedValue(targets)
+	mockModule.isPublishedPackageArtifactBuiltForCommit.mockResolvedValue(true)
+
+	const alreadyPublishedForce = await publishExternalPushCapability.handler(
+		{ package_id: 'package-1' },
+		createContext(),
+	)
+	expect(alreadyPublishedForce.status).toBe('already_published')
 	expect(mockModule.rebuildPublishedPackageArtifact).toHaveBeenCalledWith({
 		sourceId: 'source-1',
 		userId: 'user-1',

--- a/packages/worker/src/mcp/capabilities/packages/publish-external-push.ts
+++ b/packages/worker/src/mcp/capabilities/packages/publish-external-push.ts
@@ -30,6 +30,7 @@ import {
 import { repoSessionRpc } from '#worker/repo/repo-session-rpc.ts'
 import { resolveArtifactSourceHead } from '#worker/repo/artifacts.ts'
 import { rebuildPublishedPackageArtifactsViaRepoSession } from '#mcp/capabilities/repo/package-artifact-rebuild.ts'
+import { timePublishExternalPushPhase } from '#worker/repo/publish-phase-timing.ts'
 import { destructiveOverwriteConfirmationDescription } from '#worker/repo/source-safety-policy.ts'
 import {
 	buildPendingPackageSecretApprovalsSummary,
@@ -523,9 +524,10 @@ async function runExternalPublishAttempt(input: {
 				total: maxAttempts + 1,
 				message:
 					attempt === 1
-						? 'Publishing from Artifacts HEAD — running checks and promoting the commit…'
+						? 'Publishing from Artifacts HEAD — cloning, checking, and promoting the commit…'
 						: `Publish attempt ${attempt}/${maxAttempts} — giving the repo another nudge…`,
 			})
+			const publishStartedAt = Date.now()
 			const result = await repoSessionRpc(
 				input.env,
 				sessionId,
@@ -541,64 +543,102 @@ async function runExternalPublishAttempt(input: {
 				rebuildPackageArtifacts: false,
 				expectedPackageScope: input.expectedPackageScope,
 			})
+			const publishMs = Date.now() - publishStartedAt
 			assertNotAborted(input.signal)
 			if (result.status === 'already_published') {
-				if (!result.published_commit) {
+				const publishedCommit = result.published_commit
+				if (!publishedCommit) {
 					throw new Error(
 						`Package "${input.packageId}" is already published, but no published commit is available to rebuild artifacts.`,
 					)
 				}
+				const forceRebuild = result.force_artifact_rebuild === true
 				await reportCapabilityProgress(input.reportProgress, {
 					progress: maxAttempts + 1,
 					total: maxAttempts + 1,
-					message:
-						'Already published — rebuilding artifacts so invoke stays fresh…',
+					message: forceRebuild
+						? `Already published after ${publishMs}ms — snapshot changed, rebuilding artifacts…`
+						: `Already published after ${publishMs}ms — confirming artifacts match this commit…`,
 				})
-				await rebuildPublishedPackageArtifactsViaRepoSession({
-					env: input.env,
-					rpcSessionId: sessionId,
-					sourceId: input.source.id,
-					userId: input.ownerUserId,
-					publishedCommit: result.published_commit,
-					baseUrl: input.baseUrl,
-					force: true,
-				})
-				const testHints = await getPublishedPackageTestHints({
-					env: input.env,
-					userId: input.ownerUserId,
-					sourceId: input.source.id,
-					kodyId: input.kodyId,
-					...(input.testHintPackageScope
-						? { packageScope: input.testHintPackageScope }
-						: {}),
+				const { durationMs: rebuildMs } = await timePublishExternalPushPhase(
+					{
+						phase: 'rebuild',
+						sourceId: input.source.id,
+						publishedCommit,
+					},
+					async () => {
+						await rebuildPublishedPackageArtifactsViaRepoSession({
+							env: input.env,
+							rpcSessionId: sessionId,
+							sourceId: input.source.id,
+							userId: input.ownerUserId,
+							publishedCommit,
+							baseUrl: input.baseUrl,
+							...(forceRebuild ? { force: true } : {}),
+						})
+					},
+				)
+				const { durationMs: dependentsMs, value: alreadyPublishedExtras } =
+					await timePublishExternalPushPhase(
+						{
+							phase: 'dependents',
+							sourceId: input.source.id,
+							publishedCommit,
+						},
+						async () => {
+							const testHints = await getPublishedPackageTestHints({
+								env: input.env,
+								userId: input.ownerUserId,
+								sourceId: input.source.id,
+								kodyId: input.kodyId,
+								...(input.testHintPackageScope
+									? { packageScope: input.testHintPackageScope }
+									: {}),
+							})
+							return {
+								testHints,
+								hosted_app_url: await resolvePublishedHostedAppUrl({
+									env: input.env,
+									baseUrl: input.baseUrl,
+									ownerScope: input.ownerScope,
+									ownerEmail: input.ownerEmail,
+									kodyId: input.kodyId,
+									hasApp: input.hasApp,
+								}),
+								static_dependents: await getPublishStaticDependents({
+									db: input.env.APP_DB,
+									userId: input.ownerUserId,
+									sourceId: input.source.id,
+									publishedCommit,
+								}),
+								pending_secret_package_approvals:
+									await getPendingSecretApprovalsForPublishedPackage({
+										env: input.env,
+										baseUrl: input.baseUrl,
+										userId: input.ownerUserId,
+										packageId: input.packageId,
+										kodyId: input.kodyId,
+										sourceId: input.source.id,
+									}),
+							}
+						},
+					)
+				await reportCapabilityProgress(input.reportProgress, {
+					progress: maxAttempts + 1,
+					total: maxAttempts + 1,
+					message: `Already published wrap-up — rebuild ${rebuildMs}ms, dependents ${dependentsMs}ms.`,
 				})
 				return {
-					...result,
-					hosted_app_url: await resolvePublishedHostedAppUrl({
-						env: input.env,
-						baseUrl: input.baseUrl,
-						ownerScope: input.ownerScope,
-						ownerEmail: input.ownerEmail,
-						kodyId: input.kodyId,
-						hasApp: input.hasApp,
-					}),
-					...(testHints ? { test_hints: testHints } : {}),
-					static_dependents: await getPublishStaticDependents({
-						db: input.env.APP_DB,
-						userId: input.ownerUserId,
-						sourceId: input.source.id,
-						publishedCommit: result.published_commit,
-					}),
+					status: 'already_published' as const,
+					published_commit: publishedCommit,
+					hosted_app_url: alreadyPublishedExtras.hosted_app_url,
+					...(alreadyPublishedExtras.testHints
+						? { test_hints: alreadyPublishedExtras.testHints }
+						: {}),
+					static_dependents: alreadyPublishedExtras.static_dependents,
 					pending_secret_package_approvals:
-						await getPendingSecretApprovalsForPublishedPackage({
-							env: input.env,
-							baseUrl: input.baseUrl,
-							userId: input.ownerUserId,
-							packageId: input.packageId,
-							kodyId: input.kodyId,
-							sourceId: input.source.id,
-						}),
-				} as const
+						alreadyPublishedExtras.pending_secret_package_approvals,
+				}
 			}
 			if (result.status === 'locked') {
 				const approvalUrl = buildPackagePublishApprovalUrl({
@@ -624,50 +664,82 @@ async function runExternalPublishAttempt(input: {
 			await reportCapabilityProgress(input.reportProgress, {
 				progress: maxAttempts + 1,
 				total: maxAttempts + 1,
-				message:
-					'Checks passed — rebuilding published artifacts and indexing dependents…',
+				message: `Checks passed in ${publishMs}ms — rebuilding published artifacts and indexing dependents…`,
 			})
-			await rebuildPublishedPackageArtifactsViaRepoSession({
-				env: input.env,
-				rpcSessionId: sessionId,
-				sourceId: input.source.id,
-				userId: input.ownerUserId,
-				publishedCommit: result.published_commit,
-				baseUrl: input.baseUrl,
-			})
-			const testHints = readPackageTestHintsFromManifest({
-				manifest: result.manifest,
-				kodyId: input.kodyId,
-				...(input.testHintPackageScope
-					? { packageScope: input.testHintPackageScope }
-					: {}),
+			const { durationMs: rebuildMs } = await timePublishExternalPushPhase(
+				{
+					phase: 'rebuild',
+					sourceId: input.source.id,
+					publishedCommit: result.published_commit,
+				},
+				async () => {
+					await rebuildPublishedPackageArtifactsViaRepoSession({
+						env: input.env,
+						rpcSessionId: sessionId,
+						sourceId: input.source.id,
+						userId: input.ownerUserId,
+						publishedCommit: result.published_commit,
+						baseUrl: input.baseUrl,
+					})
+				},
+			)
+			const { durationMs: dependentsMs, value: publishedExtras } =
+				await timePublishExternalPushPhase(
+					{
+						phase: 'dependents',
+						sourceId: input.source.id,
+						publishedCommit: result.published_commit,
+					},
+					async () => {
+						const testHints = readPackageTestHintsFromManifest({
+							manifest: result.manifest,
+							kodyId: input.kodyId,
+							...(input.testHintPackageScope
+								? { packageScope: input.testHintPackageScope }
+								: {}),
+						})
+						return {
+							testHints,
+							hosted_app_url: await resolvePublishedHostedAppUrl({
+								env: input.env,
+								baseUrl: input.baseUrl,
+								ownerScope: input.ownerScope,
+								ownerEmail: input.ownerEmail,
+								kodyId: input.kodyId,
+								hasApp: Boolean(testHints?.app),
+							}),
+							static_dependents: await getPublishStaticDependents({
+								db: input.env.APP_DB,
+								userId: input.ownerUserId,
+								sourceId: input.source.id,
+								publishedCommit: result.published_commit,
+							}),
+							pending_secret_package_approvals:
+								await getPendingSecretApprovalsForPublishedPackage({
+									env: input.env,
+									baseUrl: input.baseUrl,
+									userId: input.ownerUserId,
+									packageId: input.packageId,
+									kodyId: input.kodyId,
+									sourceId: input.source.id,
+								}),
+						}
+					},
+				)
+			await reportCapabilityProgress(input.reportProgress, {
+				progress: maxAttempts + 1,
+				total: maxAttempts + 1,
+				message: `Published wrap-up — rebuild ${rebuildMs}ms, dependents ${dependentsMs}ms.`,
 			})
 			return {
 				...result,
-				hosted_app_url: await resolvePublishedHostedAppUrl({
-					env: input.env,
-					baseUrl: input.baseUrl,
-					ownerScope: input.ownerScope,
-					ownerEmail: input.ownerEmail,
-					kodyId: input.kodyId,
-					hasApp: Boolean(testHints?.app),
-				}),
-				...(testHints ? { test_hints: testHints } : {}),
-				static_dependents: await getPublishStaticDependents({
-					db: input.env.APP_DB,
-					userId: input.ownerUserId,
-					sourceId: input.source.id,
-					publishedCommit: result.published_commit,
-				}),
+				hosted_app_url: publishedExtras.hosted_app_url,
+				...(publishedExtras.testHints
+					? { test_hints: publishedExtras.testHints }
+					: {}),
+				static_dependents: publishedExtras.static_dependents,
 				pending_secret_package_approvals:
-					await getPendingSecretApprovalsForPublishedPackage({
-						env: input.env,
-						baseUrl: input.baseUrl,
-						userId: input.ownerUserId,
-						packageId: input.packageId,
-						kodyId: input.kodyId,
-						sourceId: input.source.id,
-					}),
+					publishedExtras.pending_secret_package_approvals,
 			} as const
 		} catch (error) {
 			assertNotAborted(input.signal)

--- a/packages/worker/src/mcp/capabilities/repo/package-artifact-rebuild.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/repo/package-artifact-rebuild.node.test.ts
@@ -20,10 +20,16 @@ vi.mock('#worker/repo/repo-session-rpc.ts', () => ({
 	}),
 }))
 
-vi.mock('#worker/repo/isolated-artifact-rebuild.ts', () => ({
-	createIsolatedArtifactRebuildRunner: (...args: Array<unknown>) =>
-		mockModule.createIsolatedArtifactRebuildRunner(...args),
-}))
+vi.mock('#worker/repo/isolated-artifact-rebuild.ts', async () => {
+	const actual = await vi.importActual<
+		typeof import('#worker/repo/isolated-artifact-rebuild.ts')
+	>('#worker/repo/isolated-artifact-rebuild.ts')
+	return {
+		...actual,
+		createIsolatedArtifactRebuildRunner: (...args: Array<unknown>) =>
+			mockModule.createIsolatedArtifactRebuildRunner(...args),
+	}
+})
 
 vi.mock('#worker/package-runtime/published-bundle-artifacts.ts', () => ({
 	isPublishedPackageArtifactBuiltForCommit: (...args: Array<unknown>) =>
@@ -52,6 +58,42 @@ const sampleTargets = [
 		entryPoint: 'src/c.ts',
 		bundleKind: 'module' as const,
 	},
+	{
+		kind: 'module' as const,
+		artifactName: './d',
+		entryPoint: 'src/d.ts',
+		bundleKind: 'module' as const,
+	},
+	{
+		kind: 'module' as const,
+		artifactName: './e',
+		entryPoint: 'src/e.ts',
+		bundleKind: 'module' as const,
+	},
+	{
+		kind: 'module' as const,
+		artifactName: './f',
+		entryPoint: 'src/f.ts',
+		bundleKind: 'module' as const,
+	},
+	{
+		kind: 'module' as const,
+		artifactName: './g',
+		entryPoint: 'src/g.ts',
+		bundleKind: 'module' as const,
+	},
+	{
+		kind: 'module' as const,
+		artifactName: './h',
+		entryPoint: 'src/h.ts',
+		bundleKind: 'module' as const,
+	},
+	{
+		kind: 'module' as const,
+		artifactName: './i',
+		entryPoint: 'src/i.ts',
+		bundleKind: 'module' as const,
+	},
 ]
 
 function resetMocks() {
@@ -63,12 +105,13 @@ function resetMocks() {
 	mockModule.isPublishedPackageArtifactBuiltForCommit.mockResolvedValue(false)
 }
 
-test('isolated rebuild lists then stages once, fans out with bounded concurrency, and discards staging', async () => {
+test('isolated rebuild lists then stages once, chunks targets per isolate with bounded concurrency, and discards staging', async () => {
 	resetMocks()
 
 	const run = vi.fn(async () => ({
 		ok: true,
 		message: 'rebuilt',
+		results: [],
 	}))
 	const touch = vi.fn(async () => undefined)
 	const discard = vi.fn(async () => undefined)
@@ -87,7 +130,7 @@ test('isolated rebuild lists then stages once, fans out with bounded concurrency
 	let inFlight = 0
 	let maxInFlight = 0
 	const releaseGates: Array<() => void> = []
-	run.mockImplementation(async () => {
+	run.mockImplementation(async (input: { targets: typeof sampleTargets }) => {
 		inFlight += 1
 		maxInFlight = Math.max(maxInFlight, inFlight)
 		await new Promise<void>((resolve) => {
@@ -96,7 +139,15 @@ test('isolated rebuild lists then stages once, fans out with bounded concurrency
 				resolve()
 			})
 		})
-		return { ok: true, message: 'rebuilt' }
+		return {
+			ok: true,
+			message: 'rebuilt',
+			results: input.targets.map((target) => ({
+				ok: true,
+				message: 'rebuilt',
+				target,
+			})),
+		}
 	})
 
 	const rebuildPromise = rebuildPublishedPackageArtifactsViaRepoSession({
@@ -123,6 +174,8 @@ test('isolated rebuild lists then stages once, fans out with bounded concurrency
 	)
 	expect(mockModule.rebuildPublishedPackageArtifact).not.toHaveBeenCalled()
 	expect(touch).not.toHaveBeenCalled()
+	expect(run.mock.calls[0]?.[0]?.targets).toEqual(sampleTargets.slice(0, 4))
+	expect(run.mock.calls[1]?.[0]?.targets).toEqual(sampleTargets.slice(4, 8))
 
 	releaseGates.splice(0).forEach((release) => release())
 	await vi.waitFor(() => {
@@ -131,6 +184,7 @@ test('isolated rebuild lists then stages once, fans out with bounded concurrency
 	expect(touch).toHaveBeenCalledWith(
 		'repo-artifact-rebuild-staging:v1:user-1:stage-1',
 	)
+	expect(run.mock.calls[2]?.[0]?.targets).toEqual(sampleTargets.slice(8))
 	releaseGates.splice(0).forEach((release) => release())
 	await rebuildPromise
 
@@ -146,7 +200,7 @@ test('isolated rebuild lists then stages once, fans out with bounded concurrency
 			sourceId: 'source-1',
 			userId: 'user-1',
 			publishedCommit: 'commit-1',
-			target: sampleTargets[0],
+			targets: sampleTargets.slice(0, 4),
 		}),
 	)
 })
@@ -161,7 +215,7 @@ test('isolated rebuild skips already-built targets and does not stage when all a
 		discard,
 	})
 	mockModule.listPublishedPackageArtifactTargets.mockResolvedValue(
-		sampleTargets,
+		sampleTargets.slice(0, 3),
 	)
 	mockModule.stagePublishedPackageArtifactRebuild.mockResolvedValue({
 		stagingKey: 'repo-artifact-rebuild-staging:v1:user-1:stage-1',
@@ -186,7 +240,7 @@ test('isolated rebuild skips already-built targets and does not stage when all a
 
 	expect(run).toHaveBeenCalledTimes(1)
 	expect(run).toHaveBeenCalledWith(
-		expect.objectContaining({ target: sampleTargets[1] }),
+		expect.objectContaining({ targets: [sampleTargets[1]] }),
 	)
 	expect(mockModule.stagePublishedPackageArtifactRebuild).toHaveBeenCalledTimes(
 		1,
@@ -256,31 +310,30 @@ test('force rebuilds already-built targets so already_published can repair stale
 	expect(run).toHaveBeenCalledWith(
 		expect.objectContaining({
 			force: true,
-			target: sampleTargets[0],
+			targets: sampleTargets.slice(0, 4),
 		}),
 	)
 	expect(discard).toHaveBeenCalledTimes(1)
 })
 
 test('rebuild failure stops later chunks and reports succeeded versus failed for isolated and fallback paths', async () => {
-	const targets = [
-		...sampleTargets,
-		{
-			kind: 'module' as const,
-			artifactName: './d',
-			entryPoint: 'src/d.ts',
-			bundleKind: 'module' as const,
-		},
-	]
+	const targets = sampleTargets
 	const failurePattern =
-		/Succeeded: \{ kind "module", artifact "\.", entry "src\/a\.ts", bundle "module" \}\. Failed: \{ kind "module", artifact "\.\/b", entry "src\/b\.ts", bundle "module" \}: bundle b failed/
+		/Succeeded: \{ kind "module", artifact "\.", entry "src\/a\.ts", bundle "module" \}.+Failed:.+bundle b failed/
 
 	resetMocks()
-	const run = vi.fn(async (input: { target: (typeof targets)[number] }) => {
-		if (input.target.artifactName === './b') {
-			return { ok: false, message: 'bundle b failed' }
+	const run = vi.fn(async (input: { targets: typeof targets }) => {
+		return {
+			ok: input.targets.every((target) => target.artifactName !== './b'),
+			message: input.targets.some((target) => target.artifactName === './b')
+				? 'bundle b failed'
+				: 'rebuilt',
+			results: input.targets.map((target) =>
+				target.artifactName === './b'
+					? { ok: false, message: 'bundle b failed', target }
+					: { ok: true, message: 'rebuilt', target },
+			),
 		}
-		return { ok: true, message: 'rebuilt' }
 	})
 	const touch = vi.fn(async () => undefined)
 	const discard = vi.fn(async () => undefined)
@@ -309,11 +362,14 @@ test('rebuild failure stops later chunks and reports succeeded versus failed for
 	).rejects.toThrow(failurePattern)
 	expect(touch).not.toHaveBeenCalled()
 	expect(run).toHaveBeenCalledTimes(2)
-	expect(run).not.toHaveBeenCalledWith(
-		expect.objectContaining({ target: targets[2] }),
+	expect(run).toHaveBeenCalledWith(
+		expect.objectContaining({ targets: targets.slice(0, 4) }),
+	)
+	expect(run).toHaveBeenCalledWith(
+		expect.objectContaining({ targets: targets.slice(4, 8) }),
 	)
 	expect(run).not.toHaveBeenCalledWith(
-		expect.objectContaining({ target: targets[3] }),
+		expect.objectContaining({ targets: targets.slice(8) }),
 	)
 	expect(discard).toHaveBeenCalledWith(
 		'repo-artifact-rebuild-staging:v1:user-1:stage-1',
@@ -321,7 +377,9 @@ test('rebuild failure stops later chunks and reports succeeded versus failed for
 
 	resetMocks()
 	mockModule.createIsolatedArtifactRebuildRunner.mockReturnValue(null)
-	mockModule.listPublishedPackageArtifactTargets.mockResolvedValue(targets)
+	mockModule.listPublishedPackageArtifactTargets.mockResolvedValue(
+		targets.slice(0, 4),
+	)
 	mockModule.rebuildPublishedPackageArtifact.mockImplementation(
 		async (input: { target: (typeof targets)[number] }) => {
 			if (input.target.artifactName === './b') {
@@ -361,7 +419,7 @@ test('falls back to per-target session rebuild when isolated runner bindings are
 	resetMocks()
 	mockModule.createIsolatedArtifactRebuildRunner.mockReturnValue(null)
 	mockModule.listPublishedPackageArtifactTargets.mockResolvedValue(
-		sampleTargets,
+		sampleTargets.slice(0, 3),
 	)
 
 	let inFlight = 0

--- a/packages/worker/src/mcp/capabilities/repo/package-artifact-rebuild.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/repo/package-artifact-rebuild.node.test.ts
@@ -1,5 +1,6 @@
 import { expect, test, vi } from 'vitest'
 import { consoleWarn } from '#worker/test-support/console-spies.ts'
+import type * as IsolatedArtifactRebuildModule from '#worker/repo/isolated-artifact-rebuild.ts'
 
 const mockModule = vi.hoisted(() => ({
 	listPublishedPackageArtifactTargets: vi.fn(),
@@ -21,9 +22,9 @@ vi.mock('#worker/repo/repo-session-rpc.ts', () => ({
 }))
 
 vi.mock('#worker/repo/isolated-artifact-rebuild.ts', async () => {
-	const actual = await vi.importActual<
-		typeof import('#worker/repo/isolated-artifact-rebuild.ts')
-	>('#worker/repo/isolated-artifact-rebuild.ts')
+	const actual = await vi.importActual<typeof IsolatedArtifactRebuildModule>(
+		'#worker/repo/isolated-artifact-rebuild.ts',
+	)
 	return {
 		...actual,
 		createIsolatedArtifactRebuildRunner: (...args: Array<unknown>) =>

--- a/packages/worker/src/mcp/capabilities/repo/package-artifact-rebuild.ts
+++ b/packages/worker/src/mcp/capabilities/repo/package-artifact-rebuild.ts
@@ -7,7 +7,11 @@ import {
 import { isRetryableD1LockError } from '#worker/d1-retry.ts'
 import { isPublishedPackageArtifactBuiltForCommit } from '#worker/package-runtime/published-bundle-artifacts.ts'
 import { type PublishedPackageArtifactBuildTarget } from '#worker/package-runtime/package-artifact-targets.ts'
-import { createIsolatedArtifactRebuildRunner } from '#worker/repo/isolated-artifact-rebuild.ts'
+import {
+	createIsolatedArtifactRebuildRunner,
+	isolatedArtifactRebuildChunkConcurrency,
+	isolatedArtifactRebuildChunkSize,
+} from '#worker/repo/isolated-artifact-rebuild.ts'
 import { repoSessionRpc } from '#worker/repo/repo-session-rpc.ts'
 import { isDurableObjectIsolateResetMessage } from '#worker/sentry-options.ts'
 
@@ -15,10 +19,11 @@ import { isDurableObjectIsolateResetMessage } from '#worker/sentry-options.ts'
  * Same-session rebuild RPCs hit one Durable Object, which serializes
  * execution. Depth 2 pipelines the next RPC while the DO finishes the current
  * one (cuts inter-call worker round-trip idle time) without flooding the DO
- * input gate the way unbounded Promise.all would. The isolated throwaway-DO
- * path uses the same bound so fan-out stays modest.
+ * input gate the way unbounded Promise.all would. Isolated throwaway-DO
+ * rebuilds use the same concurrency cap across target chunks.
  */
-export const publishedPackageArtifactRebuildConcurrency = 2
+export const publishedPackageArtifactRebuildConcurrency =
+	isolatedArtifactRebuildChunkConcurrency
 
 /**
  * Deploy-time DO code resets, other platform isolate resets, and D1
@@ -317,42 +322,66 @@ async function rebuildPublishedPackageArtifactsViaRepoSessionOnce(input: {
 	}> = []
 
 	try {
-		const targetChunks = chunkArray(
+		const isolateChunks = chunkArray(
 			remaining,
+			isolatedArtifactRebuildChunkSize,
+		)
+		const waves = chunkArray(
+			isolateChunks,
 			publishedPackageArtifactRebuildConcurrency,
 		)
-		for (const [chunkIndex, targetChunk] of targetChunks.entries()) {
+		for (const [waveIndex, wave] of waves.entries()) {
 			if (failed.length > 0) break
-			if (chunkIndex > 0) {
+			if (waveIndex > 0) {
 				await isolatedRunner.touch(stagingKey)
 			}
 
 			const settled = await Promise.allSettled(
-				targetChunk.map(async (target) => {
+				wave.map(async (targets) => {
 					const outcome = await isolatedRunner.run({
 						stagingKey,
 						sourceId: input.sourceId,
 						userId: input.userId,
 						publishedCommit: input.publishedCommit,
-						target,
+						targets,
 						baseUrl: input.baseUrl,
 						force: input.force,
 					})
-					if (!outcome.ok) {
-						throw new Error(outcome.message)
-					}
-					return target
+					return { targets, outcome }
 				}),
 			)
 
 			for (const [index, result] of settled.entries()) {
-				const target = targetChunk[index]
-				if (!target) continue
-				if (result.status === 'fulfilled') {
-					succeeded.push(target)
+				const targets = wave[index]
+				if (!targets) continue
+				if (result.status === 'rejected') {
+					for (const target of targets) {
+						failed.push({ target, error: result.reason })
+					}
 					continue
 				}
-				failed.push({ target, error: result.reason })
+				const { outcome } = result.value
+				const targetResults = outcome.results ?? []
+				if (targetResults.length > 0) {
+					for (const targetResult of targetResults) {
+						if (targetResult.ok) {
+							succeeded.push(targetResult.target)
+							continue
+						}
+						failed.push({
+							target: targetResult.target,
+							error: new Error(targetResult.message),
+						})
+					}
+					continue
+				}
+				if (outcome.ok) {
+					succeeded.push(...targets)
+					continue
+				}
+				for (const target of targets) {
+					failed.push({ target, error: new Error(outcome.message) })
+				}
 			}
 		}
 	} finally {

--- a/packages/worker/src/package-runtime/published-bundle-artifacts.node.test.ts
+++ b/packages/worker/src/package-runtime/published-bundle-artifacts.node.test.ts
@@ -12,6 +12,7 @@ const mockModule = vi.hoisted(() => ({
 	getPublishedBundleArtifactByIdentity: vi.fn(),
 	insertPublishedBundleArtifactRow: vi.fn(),
 	readPublishedBundleArtifact: vi.fn(),
+	readPublishedSourceSnapshot: vi.fn(),
 	updatePublishedBundleArtifactRow: vi.fn(),
 	writePublishedBundleArtifact: vi.fn(),
 }))
@@ -44,6 +45,8 @@ vi.mock('./published-runtime-artifacts.ts', async () => {
 		...actual,
 		readPublishedBundleArtifact: (...args: Array<unknown>) =>
 			mockModule.readPublishedBundleArtifact(...args),
+		readPublishedSourceSnapshot: (...args: Array<unknown>) =>
+			mockModule.readPublishedSourceSnapshot(...args),
 		writePublishedBundleArtifact: (...args: Array<unknown>) =>
 			mockModule.writePublishedBundleArtifact(...args),
 	}
@@ -147,6 +150,8 @@ test('loadPublishedBundleArtifactByIdentity treats mismatched and malformed KV a
 test('isPublishedPackageArtifactBuiltForCommit requires matching row and KV artifact for the commit', async () => {
 	mockModule.getPublishedBundleArtifactByIdentity.mockReset()
 	mockModule.readPublishedBundleArtifact.mockReset()
+	mockModule.readPublishedSourceSnapshot.mockReset()
+	mockModule.readPublishedSourceSnapshot.mockResolvedValue(null)
 
 	const envWithoutKv = { APP_DB: {} } as unknown as Env
 	expect(
@@ -286,7 +291,7 @@ test('isPublishedPackageArtifactBuiltForCommit requires matching row and KV arti
 		createdAt: '2026-05-13T00:00:00.000Z',
 		updatedAt: '2026-05-13T00:00:00.000Z',
 	})
-	mockModule.readPublishedBundleArtifact.mockResolvedValueOnce({
+	mockModule.readPublishedBundleArtifact.mockResolvedValue({
 		version: 1,
 		kind: 'module',
 		artifactName: '.',
@@ -299,6 +304,46 @@ test('isPublishedPackageArtifactBuiltForCommit requires matching row and KV arti
 		dynamicDependencies: [],
 		packageContext: null,
 		createdAt: '2026-05-13T00:00:00.000Z',
+	})
+	expect(
+		await isPublishedPackageArtifactBuiltForCommit({
+			env,
+			userId: 'user-1',
+			sourceId: 'source-1',
+			publishedCommit: 'commit-1',
+			target,
+		}),
+	).toBe(true)
+
+	mockModule.readPublishedSourceSnapshot.mockResolvedValueOnce({
+		invalidateArtifactsBefore: '2026-09-05T16:00:00.000Z',
+	})
+	expect(
+		await isPublishedPackageArtifactBuiltForCommit({
+			env,
+			userId: 'user-1',
+			sourceId: 'source-1',
+			publishedCommit: 'commit-1',
+			target,
+		}),
+	).toBe(false)
+
+	mockModule.readPublishedBundleArtifact.mockResolvedValueOnce({
+		version: 1,
+		kind: 'module',
+		artifactName: '.',
+		sourceId: 'source-1',
+		publishedCommit: 'commit-1',
+		entryPoint: 'src/index.ts',
+		mainModule: 'dist/index.js',
+		modules: { 'dist/index.js': 'export default {}' },
+		dependencies: [],
+		dynamicDependencies: [],
+		packageContext: null,
+		createdAt: '2026-09-05T16:00:01.000Z',
+	})
+	mockModule.readPublishedSourceSnapshot.mockResolvedValueOnce({
+		invalidateArtifactsBefore: '2026-09-05T16:00:00.000Z',
 	})
 	expect(
 		await isPublishedPackageArtifactBuiltForCommit({

--- a/packages/worker/src/package-runtime/published-bundle-artifacts.ts
+++ b/packages/worker/src/package-runtime/published-bundle-artifacts.ts
@@ -11,6 +11,7 @@ import {
 	deletePublishedBundleArtifact,
 	hasPublishedRuntimeArtifacts,
 	readPublishedBundleArtifact,
+	readPublishedSourceSnapshot,
 	writePublishedBundleArtifact,
 } from './published-runtime-artifacts.ts'
 import {
@@ -252,8 +253,10 @@ export async function loadPublishedBundleArtifactByIdentity(input: {
 
 /**
  * True when a published bundle artifact already exists for this target
- * identity at `publishedCommit` (row + KV payload). Used to skip rebuild work
- * that would only rewrite the same commit's artifact.
+ * identity at `publishedCommit` (row + KV payload) and is not older than the
+ * snapshot's `invalidateArtifactsBefore` cutoff. Used to skip rebuild work
+ * that would only rewrite the same commit's artifact, while still repairing
+ * leftovers after a mismatched already_published snapshot rewrite.
  */
 export async function isPublishedPackageArtifactBuiltForCommit(input: {
 	env: Env
@@ -272,10 +275,32 @@ export async function isPublishedPackageArtifactBuiltForCommit(input: {
 		entryPoint: input.target.entryPoint,
 	})
 	if (!loaded?.artifact) return false
-	return (
-		loaded.row.publishedCommit === input.publishedCommit &&
-		loaded.artifact.publishedCommit === input.publishedCommit
-	)
+	if (
+		loaded.row.publishedCommit !== input.publishedCommit ||
+		loaded.artifact.publishedCommit !== input.publishedCommit
+	) {
+		return false
+	}
+	const snapshot = await readPublishedSourceSnapshot({
+		env: input.env,
+		sourceId: input.sourceId,
+		publishedCommit: input.publishedCommit,
+	})
+	const cutoff = snapshot?.invalidateArtifactsBefore
+	if (
+		cutoff &&
+		!publishedArtifactCreatedAtIsAtLeast(loaded.artifact.createdAt, cutoff)
+	) {
+		return false
+	}
+	return true
+}
+
+function publishedArtifactCreatedAtIsAtLeast(
+	createdAt: string | undefined,
+	cutoff: string,
+) {
+	return typeof createdAt === 'string' && createdAt >= cutoff
 }
 
 export async function persistPublishedPackageArtifactTarget(

--- a/packages/worker/src/package-runtime/published-runtime-artifacts.ts
+++ b/packages/worker/src/package-runtime/published-runtime-artifacts.ts
@@ -296,6 +296,25 @@ export async function loadPublishedSourceSnapshot(input: {
 	})
 }
 
+/**
+ * True when the stored snapshot file map is the same set of paths and
+ * contents as `files`. Missing snapshots never match, so callers can decide
+ * whether an already_published refresh must rewrite KV.
+ */
+export function publishedSourceSnapshotFilesMatch(
+	existing: PublishedSourceSnapshot | null | undefined,
+	files: Record<string, string>,
+) {
+	if (!existing?.files) return false
+	const existingKeys = Object.keys(existing.files)
+	const nextKeys = Object.keys(files)
+	if (existingKeys.length !== nextKeys.length) return false
+	for (const key of nextKeys) {
+		if (existing.files[key] !== files[key]) return false
+	}
+	return true
+}
+
 export async function readPublishedSourceManifestSnapshot(input: {
 	env: Env
 	sourceId: string

--- a/packages/worker/src/package-runtime/published-runtime-artifacts.ts
+++ b/packages/worker/src/package-runtime/published-runtime-artifacts.ts
@@ -65,6 +65,13 @@ export type PublishedSourceSnapshot = {
 	sourceRoot: string
 	files: Record<string, string>
 	createdAt: string
+	/**
+	 * When set, same-commit artifacts older than this timestamp are treated
+	 * as leftovers from a prior snapshot rewrite. Used so an interrupted
+	 * already_published rebuild cannot keep serving stale bundles after the
+	 * snapshot now matches HEAD.
+	 */
+	invalidateArtifactsBefore?: string
 }
 
 export type PublishedSourceManifestSnapshot = {
@@ -212,10 +219,12 @@ export async function writePublishedSourceSnapshot(input: {
 	env: Env
 	source: EntitySourceRow
 	files: Record<string, string>
+	invalidateExistingArtifacts?: boolean
 }) {
 	if (!input.source.published_commit) {
 		return null
 	}
+	const createdAt = new Date().toISOString()
 	const snapshot: PublishedSourceSnapshot = {
 		version: sourceSnapshotVersion,
 		sourceId: input.source.id,
@@ -226,7 +235,10 @@ export async function writePublishedSourceSnapshot(input: {
 		manifestPath: input.source.manifest_path,
 		sourceRoot: input.source.source_root,
 		files: input.files,
-		createdAt: new Date().toISOString(),
+		createdAt,
+		...(input.invalidateExistingArtifacts
+			? { invalidateArtifactsBefore: createdAt }
+			: {}),
 	}
 	const key = buildPublishedSourceSnapshotKvKey({
 		sourceId: input.source.id,

--- a/packages/worker/src/package-runtime/published-source-snapshot-match.node.test.ts
+++ b/packages/worker/src/package-runtime/published-source-snapshot-match.node.test.ts
@@ -1,0 +1,57 @@
+import { expect, test } from 'vitest'
+import {
+	publishedSourceSnapshotFilesMatch,
+	type PublishedSourceSnapshot,
+} from './published-runtime-artifacts.ts'
+
+function snapshotWithFiles(
+	files: Record<string, string>,
+): PublishedSourceSnapshot {
+	return {
+		version: 1,
+		sourceId: 'source-1',
+		repoId: 'repo-1',
+		entityKind: 'package',
+		entityId: 'package-1',
+		publishedCommit: 'commit-1',
+		manifestPath: 'package.json',
+		sourceRoot: '/',
+		files,
+		createdAt: '2026-09-05T00:00:00.000Z',
+	}
+}
+
+test('publishedSourceSnapshotFilesMatch requires the same paths and contents', () => {
+	const files = {
+		'package.json': '{"name":"@kody/demo"}',
+		'index.ts': 'export const ready = true\n',
+	}
+	expect(publishedSourceSnapshotFilesMatch(null, files)).toBe(false)
+	expect(
+		publishedSourceSnapshotFilesMatch(
+			snapshotWithFiles({ 'package.json': files['package.json'] }),
+			files,
+		),
+	).toBe(false)
+	expect(
+		publishedSourceSnapshotFilesMatch(
+			snapshotWithFiles({
+				...files,
+				'extra.ts': 'export const extra = true\n',
+			}),
+			files,
+		),
+	).toBe(false)
+	expect(
+		publishedSourceSnapshotFilesMatch(
+			snapshotWithFiles({
+				...files,
+				'index.ts': 'export const ready = false\n',
+			}),
+			files,
+		),
+	).toBe(false)
+	expect(
+		publishedSourceSnapshotFilesMatch(snapshotWithFiles(files), files),
+	).toBe(true)
+})

--- a/packages/worker/src/repo/checks.ts
+++ b/packages/worker/src/repo/checks.ts
@@ -63,6 +63,7 @@ import {
 	maxRepoSourceFileBytes,
 } from './large-file-policy.ts'
 import { normalizeRepoWorkspacePath } from './manifest.ts'
+import { timePublishExternalPushPhase } from './publish-phase-timing.ts'
 
 export type RepoCheckKind =
 	| 'manifest'
@@ -1348,87 +1349,100 @@ export async function runRepoChecks(input: {
 	let bundleCheckResult: { ok: boolean; message: string }
 	try {
 		const runTypecheckPhase = async (): Promise<RepoCheckResult> => {
-			if (missingCallableTypecheckTargets.length > 0) {
-				return {
-					kind: 'typecheck',
-					ok: false,
-					message: `Typecheck skipped because callable package runtime entrypoint(s) are missing from the repo session snapshot: ${missingCallableTypecheckTargets
-						.map((path) => `"${path}"`)
-						.join(', ')}.`,
-				}
-			}
-			const callableTargetsMissingDefaultExport =
-				collectEntrypointsMissingDefaultExport({
-					snapshot,
-					targets: callableTypecheckTargets,
-				})
-			if (callableTargetsMissingDefaultExport.length > 0) {
-				return {
-					kind: 'typecheck',
-					ok: false,
-					message: formatMissingDefaultExportMessage(
-						callableTargetsMissingDefaultExport,
-					),
-				}
-			}
-			if (callableTypecheckTargets.length === 0) {
-				return {
-					kind: 'typecheck',
-					ok: true,
-					message: 'No callable package runtime entrypoint(s) to typecheck.',
-				}
-			}
-			const outcome =
-				isolatedRunner && stagingKey && bundleContext
-					? await isolatedRunner.run({
-							phase: 'typecheck',
-							stagingKey,
-							userId: bundleContext.userId,
-							typecheckTargets: callableTypecheckTargets,
-						})
-					: await runPackageTypecheckLanguageService({
-							sourceFiles,
+			const { value } = await timePublishExternalPushPhase(
+				{ phase: 'checks/typecheck' },
+				async () => {
+					if (missingCallableTypecheckTargets.length > 0) {
+						return {
+							kind: 'typecheck' as const,
+							ok: false,
+							message: `Typecheck skipped because callable package runtime entrypoint(s) are missing from the repo session snapshot: ${missingCallableTypecheckTargets
+								.map((path) => `"${path}"`)
+								.join(', ')}.`,
+						}
+					}
+					const callableTargetsMissingDefaultExport =
+						collectEntrypointsMissingDefaultExport({
+							snapshot,
 							targets: callableTypecheckTargets,
 						})
-			return { kind: 'typecheck', ...outcome }
+					if (callableTargetsMissingDefaultExport.length > 0) {
+						return {
+							kind: 'typecheck' as const,
+							ok: false,
+							message: formatMissingDefaultExportMessage(
+								callableTargetsMissingDefaultExport,
+							),
+						}
+					}
+					if (callableTypecheckTargets.length === 0) {
+						return {
+							kind: 'typecheck' as const,
+							ok: true,
+							message:
+								'No callable package runtime entrypoint(s) to typecheck.',
+						}
+					}
+					const outcome =
+						isolatedRunner && stagingKey && bundleContext
+							? await isolatedRunner.run({
+									phase: 'typecheck',
+									stagingKey,
+									userId: bundleContext.userId,
+									typecheckTargets: callableTypecheckTargets,
+								})
+							: await runPackageTypecheckLanguageService({
+									sourceFiles,
+									targets: callableTypecheckTargets,
+								})
+					return { kind: 'typecheck' as const, ...outcome }
+				},
+			)
+			return value
 		}
 
 		const runBundlePhase = async (): Promise<{
 			ok: boolean
 			message: string
 		}> => {
-			if (missingBundleTargets.length > 0) {
-				return {
-					ok: false,
-					message: formatBundleCheckMessage({
-						missingEntryPoints: missingBundleTargets,
-						targetCount: bundleTargets.length,
-					}),
-				}
-			}
-			if (!bundleContext) {
-				return {
-					ok: true,
-					message: formatBundleCheckMessage({
-						missingEntryPoints: missingBundleTargets,
-						targetCount: bundleTargets.length,
-					}),
-				}
-			}
-			if (isolatedRunner && stagingKey) {
-				return await runChunkedBundleValidation({
-					runner: isolatedRunner,
-					stagingKey,
-					baseUrl: bundleContext.baseUrl,
-					userId: bundleContext.userId,
-					entryPoints: bundleTargets,
-				})
-			}
-			return await validatePackageBundles({
-				...bundleContext,
-				sourceFiles,
-				entryPoints: bundleTargets,
-			})
+			const { value } = await timePublishExternalPushPhase(
+				{ phase: 'checks/bundle' },
+				async () => {
+					if (missingBundleTargets.length > 0) {
+						return {
+							ok: false,
+							message: formatBundleCheckMessage({
+								missingEntryPoints: missingBundleTargets,
+								targetCount: bundleTargets.length,
+							}),
+						}
+					}
+					if (!bundleContext) {
+						return {
+							ok: true,
+							message: formatBundleCheckMessage({
+								missingEntryPoints: missingBundleTargets,
+								targetCount: bundleTargets.length,
+							}),
+						}
+					}
+					if (isolatedRunner && stagingKey) {
+						return await runChunkedBundleValidation({
+							runner: isolatedRunner,
+							stagingKey,
+							baseUrl: bundleContext.baseUrl,
+							userId: bundleContext.userId,
+							entryPoints: bundleTargets,
+						})
+					}
+					return await validatePackageBundles({
+						...bundleContext,
+						sourceFiles,
+						entryPoints: bundleTargets,
+					})
+				},
+			)
+			return value
 		}
 
 		// Isolated phases use separate throwaway isolates, so overlapping them

--- a/packages/worker/src/repo/isolated-artifact-rebuild.node.test.ts
+++ b/packages/worker/src/repo/isolated-artifact-rebuild.node.test.ts
@@ -46,7 +46,7 @@ test('createIsolatedArtifactRebuildRunner returns null without bindings', () => 
 	).toBeNull()
 })
 
-test('runner touches staging TTL, fans out one target per throwaway DO, and maps reset errors', async () => {
+test('runner touches staging TTL, fans out one target chunk per throwaway DO, and maps reset errors', async () => {
 	const put = vi.fn(async () => undefined)
 	const get = vi.fn(async () =>
 		JSON.stringify({ sourceFiles: { 'package.json': '{}' } }),
@@ -85,7 +85,7 @@ test('runner touches staging TTL, fans out one target per throwaway DO, and maps
 		sourceId: 'source-1',
 		userId: 'user-1',
 		publishedCommit: 'commit-1',
-		target,
+		targets: [target],
 		baseUrl: 'https://kody.test',
 	})
 	expect(outcome.ok).toBe(true)
@@ -97,7 +97,7 @@ test('runner touches staging TTL, fans out one target per throwaway DO, and maps
 		sourceId: 'source-1',
 		userId: 'user-1',
 		publishedCommit: 'commit-1',
-		target,
+		targets: [target],
 		baseUrl: 'https://kody.test',
 	})
 
@@ -111,14 +111,16 @@ test('runner touches staging TTL, fans out one target per throwaway DO, and maps
 		sourceId: 'source-1',
 		userId: 'user-1',
 		publishedCommit: 'commit-1',
-		target,
+		targets: [target],
 	})
 	expect(resetOutcome.ok).toBe(false)
 	expect(resetOutcome.message).toContain('memory or CPU limits')
 	expect(resetOutcome.message).toContain(
 		'search({ entity: "heavy_work_offload:guide" })',
 	)
-	expect(resetOutcome.target).toEqual(target)
+	expect(resetOutcome.results).toEqual([
+		expect.objectContaining({ ok: false, target }),
+	])
 
 	// Deploy resets must not be remapped to "package too large" — callers retry.
 	runIsolatedArtifactRebuild.mockRejectedValueOnce(
@@ -130,7 +132,7 @@ test('runner touches staging TTL, fans out one target per throwaway DO, and maps
 			sourceId: 'source-1',
 			userId: 'user-1',
 			publishedCommit: 'commit-1',
-			target,
+			targets: [target],
 		}),
 	).rejects.toThrow('Durable Object reset because its code was updated.')
 

--- a/packages/worker/src/repo/isolated-artifact-rebuild.ts
+++ b/packages/worker/src/repo/isolated-artifact-rebuild.ts
@@ -56,8 +56,9 @@ export type IsolatedArtifactRebuildRequest = {
 	baseUrl?: string
 	/**
 	 * Rebuild even when a same-commit artifact already exists. Used when
-	 * already_published refreshed a missing or mismatched snapshot so a
-	 * leftover same-commit bundle cannot keep serving.
+	 * already_published rewrote a mismatched snapshot. Missing-snapshot
+	 * finalize races do not force: live artifacts stay and skip if they
+	 * already match this commit.
 	 */
 	force?: boolean
 }

--- a/packages/worker/src/repo/isolated-artifact-rebuild.ts
+++ b/packages/worker/src/repo/isolated-artifact-rebuild.ts
@@ -9,7 +9,7 @@ import { isolatedRunnerResourceLimitAdvice } from './isolated-runner-limit-messa
  * Object. One large package (for example morning-briefing) could otherwise
  * push the session isolate (workspace + git state + esbuild-wasm) over the
  * Durable Object memory limit and kill the publish (same class of failure as
- * kentcdodds/kody#987 for check phases). Each target rebuild gets a brand-new
+ * kentcdodds/kody#987 for check phases). Each rebuild chunk gets a brand-new
  * DO id, so:
  *
  * - rebuilds never stack their peak memory on top of the session isolate or
@@ -21,25 +21,43 @@ import { isolatedRunnerResourceLimitAdvice } from './isolated-runner-limit-messa
  *
  * Workspace source files are staged once in KV with a short TTL (collected by
  * the session DO) and fetched by each rebuild isolate; the RPC payloads stay
- * small. The orchestrator refreshes that TTL between target chunks so large
+ * small. The orchestrator refreshes that TTL between isolate waves so large
  * packages cannot outlive the initial lease mid-fan-out.
+ *
+ * Targets are chunked per throwaway isolate (same pattern as check-phase
+ * bundle validation) so a multi-export package does not pay one cold
+ * esbuild-wasm boot per export. Chunk size stays small so one isolate does
+ * not stack toward the memory limit that motivated kentcdodds/kody#987;
+ * isolate concurrency stays capped so publish cannot stampede DO capacity.
  */
 
 export const isolatedArtifactRebuildStagingKeyPrefix =
 	'repo-artifact-rebuild-staging:v1:'
 const stagingTtlSeconds = 15 * 60
+/**
+ * Artifact targets rebuilt per throwaway isolate. Matches check-phase bundle
+ * chunking: small enough to stay far from the isolate memory limit, large
+ * enough to keep cold-boot fan-out modest for typical packages.
+ */
+export const isolatedArtifactRebuildChunkSize = 4
+/**
+ * Max throwaway isolates running rebuild chunks at once. Chunk size bounds
+ * work *inside* one isolate; this bounds how many of those isolates a single
+ * publish may start together.
+ */
+export const isolatedArtifactRebuildChunkConcurrency = 2
 
 export type IsolatedArtifactRebuildRequest = {
 	stagingKey: string
 	sourceId: string
 	userId: string
 	publishedCommit: string
-	target: PublishedPackageArtifactBuildTarget
+	targets: Array<PublishedPackageArtifactBuildTarget>
 	baseUrl?: string
 	/**
-	 * Rebuild even when a same-commit artifact already exists. Used by
-	 * `already_published` so a leftover workspace-built bundle cannot keep
-	 * serving after D1 already points at HEAD.
+	 * Rebuild even when a same-commit artifact already exists. Used when
+	 * already_published refreshed a missing or mismatched snapshot so a
+	 * leftover same-commit bundle cannot keep serving.
 	 */
 	force?: boolean
 }
@@ -62,12 +80,18 @@ export function isolatedArtifactRebuildStagingKeyBelongsToUser(input: {
 	)
 }
 
-export type IsolatedArtifactRebuildOutcome = {
+export type IsolatedArtifactRebuildTargetResult = {
 	ok: boolean
 	message: string
 	skipped?: boolean
 	kvKey?: string | null
-	target?: PublishedPackageArtifactBuildTarget
+	target: PublishedPackageArtifactBuildTarget
+}
+
+export type IsolatedArtifactRebuildOutcome = {
+	ok: boolean
+	message: string
+	results: Array<IsolatedArtifactRebuildTargetResult>
 }
 
 type IsolatedArtifactRebuildStub = {
@@ -106,6 +130,12 @@ function describeTarget(target: PublishedPackageArtifactBuildTarget) {
 	].join(', ')
 }
 
+function describeTargets(
+	targets: ReadonlyArray<PublishedPackageArtifactBuildTarget>,
+) {
+	return targets.map((target) => `{ ${describeTarget(target)} }`).join(', ')
+}
+
 /**
  * Returns a runner when the env carries the bindings the offload needs;
  * callers fall back to per-target session rebuild otherwise (unit tests and
@@ -130,9 +160,9 @@ export function createIsolatedArtifactRebuildRunner(
 			})
 		},
 		async run(request) {
-			// A fresh, user-namespaced id per target puts every heavy rebuild
-			// in its own isolate. The instance never touches its Durable Object
-			// storage, so nothing persists for the random name.
+			// A fresh, user-namespaced id per chunk puts every heavy rebuild
+			// wave in its own isolate. The instance never touches its Durable
+			// Object storage, so nothing persists for the random name.
 			const stub = namespace.get(
 				namespace.idFromName(
 					`isolated-artifact-rebuild-${request.userId}-${crypto.randomUUID()}`,
@@ -142,13 +172,18 @@ export function createIsolatedArtifactRebuildRunner(
 				return await stub.runIsolatedArtifactRebuild(request)
 			} catch (error) {
 				if (isDurableObjectResourceLimitResetError(error)) {
+					const message =
+						`Artifact rebuild for ${describeTargets(request.targets)} ` +
+						"exceeded the isolated rebuild runner's memory or CPU limits " +
+						`even on its own. ${isolatedRunnerResourceLimitAdvice()}`
 					return {
 						ok: false,
-						message:
-							`Artifact rebuild for { ${describeTarget(request.target)} } ` +
-							"exceeded the isolated rebuild runner's memory or CPU limits " +
-							`even on its own. ${isolatedRunnerResourceLimitAdvice()}`,
-						target: request.target,
+						message,
+						results: request.targets.map((target) => ({
+							ok: false,
+							message,
+							target,
+						})),
 					}
 				}
 				throw error

--- a/packages/worker/src/repo/publish-phase-timing.node.test.ts
+++ b/packages/worker/src/repo/publish-phase-timing.node.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from 'vitest'
+import { consoleInfo } from '#worker/test-support/console-spies.ts'
+import { timePublishExternalPushPhase } from './publish-phase-timing.ts'
+
+test('timePublishExternalPushPhase logs duration for success and failure', async () => {
+	const { value, durationMs } = await timePublishExternalPushPhase(
+		{
+			phase: 'rebuild',
+			sourceId: 'source-1',
+			publishedCommit: 'commit-1',
+		},
+		async () => 'done',
+	)
+	expect(value).toBe('done')
+	expect(durationMs).toBeGreaterThanOrEqual(0)
+	expect(consoleInfo).toHaveBeenCalledWith(
+		expect.stringContaining('"message":"packagePublishExternalPush phase"'),
+	)
+	expect(consoleInfo).toHaveBeenCalledWith(
+		expect.stringContaining('"phase":"rebuild"'),
+	)
+
+	consoleInfo.mockClear()
+	await expect(
+		timePublishExternalPushPhase({ phase: 'clone', sourceId: 'source-1' }, () =>
+			Promise.reject(new Error('clone failed')),
+		),
+	).rejects.toThrow('clone failed')
+	expect(consoleInfo).toHaveBeenCalledWith(
+		expect.stringContaining('"phase":"clone"'),
+	)
+})

--- a/packages/worker/src/repo/publish-phase-timing.ts
+++ b/packages/worker/src/repo/publish-phase-timing.ts
@@ -1,0 +1,59 @@
+export const publishExternalPushPhaseNames = [
+	'clone',
+	'checks/typecheck',
+	'checks/bundle',
+	'rebuild',
+	'dependents',
+] as const
+
+export type PublishExternalPushPhase =
+	(typeof publishExternalPushPhaseNames)[number]
+
+export function logPublishExternalPushPhase(input: {
+	phase: PublishExternalPushPhase
+	durationMs: number
+	sourceId?: string
+	publishedCommit?: string
+}) {
+	console.info(
+		JSON.stringify({
+			message: 'packagePublishExternalPush phase',
+			phase: input.phase,
+			durationMs: input.durationMs,
+			...(input.sourceId ? { sourceId: input.sourceId } : {}),
+			...(input.publishedCommit
+				? { publishedCommit: input.publishedCommit }
+				: {}),
+		}),
+	)
+}
+
+export async function timePublishExternalPushPhase<T>(
+	input: {
+		phase: PublishExternalPushPhase
+		sourceId?: string
+		publishedCommit?: string
+	},
+	work: () => Promise<T>,
+): Promise<{ value: T; durationMs: number }> {
+	const startedAt = Date.now()
+	const finish = () => {
+		const durationMs = Date.now() - startedAt
+		logPublishExternalPushPhase({
+			phase: input.phase,
+			durationMs,
+			...(input.sourceId ? { sourceId: input.sourceId } : {}),
+			...(input.publishedCommit
+				? { publishedCommit: input.publishedCommit }
+				: {}),
+		})
+		return durationMs
+	}
+	try {
+		const value = await work()
+		return { value, durationMs: finish() }
+	} catch (error) {
+		finish()
+		throw error
+	}
+}

--- a/packages/worker/src/repo/repo-session-do-publish.node.test.ts
+++ b/packages/worker/src/repo/repo-session-do-publish.node.test.ts
@@ -1017,29 +1017,19 @@ test('already_published external publish refreshes the snapshot from the in-memo
 	expect(result).toEqual({
 		status: 'already_published',
 		published_commit: 'commit-new',
-		force_artifact_rebuild: true,
+		force_artifact_rebuild: false,
 	})
 	expect(mockModule.updateEntitySource).not.toHaveBeenCalled()
 	expect(mockModule.runRepoChecks).not.toHaveBeenCalled()
 	expect(collectFiles).toHaveBeenCalledTimes(1)
 	expect(mockModule.loadPublishedSourceSnapshot).toHaveBeenCalledTimes(1)
-	expect(mockModule.deletePublishedArtifactsForSource).toHaveBeenCalledWith(
-		expect.objectContaining({
-			userId: 'user-1',
-			sourceId: 'source-1',
-		}),
-	)
+	expect(mockModule.deletePublishedArtifactsForSource).not.toHaveBeenCalled()
 	expect(mockModule.writePublishedSourceSnapshot).toHaveBeenCalledWith(
 		expect.objectContaining({
 			source: expect.objectContaining({ published_commit: 'commit-new' }),
 			files: cloneFiles,
+			invalidateExistingArtifacts: false,
 		}),
-	)
-	expect(
-		mockModule.deletePublishedArtifactsForSource.mock.invocationCallOrder[0],
-	).toBeLessThan(
-		mockModule.writePublishedSourceSnapshot.mock.invocationCallOrder[0] ??
-			Number.POSITIVE_INFINITY,
 	)
 })
 
@@ -1118,6 +1108,91 @@ test('already_published external publish skips snapshot rewrite and force rebuil
 	expect(collectFiles).toHaveBeenCalledTimes(1)
 	expect(mockModule.writePublishedSourceSnapshot).not.toHaveBeenCalled()
 	expect(mockModule.deletePublishedArtifactsForSource).not.toHaveBeenCalled()
+})
+
+test('already_published external publish invalidates leftovers on snapshot mismatch without deleting live artifacts', async () => {
+	restoreRepoSessionMockBaseline()
+	setCommonSessionFixtures()
+	mockModule.getEntitySourceById.mockResolvedValue({
+		id: 'source-1',
+		user_id: 'user-1',
+		repo_id: 'source-repo',
+		published_commit: 'commit-new',
+		manifest_path: 'package.json',
+		source_root: '/',
+		entity_kind: 'package',
+		entity_id: 'package-1',
+	})
+	const cloneFiles = {
+		'package.json':
+			'{"name":"@kody/demo","exports":{".":"./index.ts"},"kody":{"id":"demo","description":"Demo"}}',
+		'index.ts': 'export const fromClone = true\n',
+	}
+	mockModule.loadPublishedSourceSnapshot.mockResolvedValueOnce({
+		files: {
+			'package.json': cloneFiles['package.json'],
+			'index.ts': 'export const stale = true\n',
+		},
+	})
+	const collectFiles = vi.fn(async () => cloneFiles)
+	mockModule.cloneExternalPublishWorkspace.mockResolvedValueOnce({
+		workspace: {
+			readFile: vi.fn(async () => null),
+			glob: vi.fn(async () => []),
+		},
+		headCommit: 'commit-new',
+		dir: '/repo',
+		filesystem: {
+			readFile: vi.fn(async () => ''),
+			readFileBytes: vi.fn(async () => new Uint8Array()),
+			writeFile: vi.fn(async () => undefined),
+			writeFileBytes: vi.fn(async () => undefined),
+			rm: vi.fn(async () => undefined),
+			mkdir: vi.fn(async () => undefined),
+			readdir: vi.fn(async () => []),
+			stat: vi.fn(async () => ({
+				type: 'file' as const,
+				size: 0,
+				mtime: new Date(),
+			})),
+			lstat: vi.fn(async () => ({
+				type: 'file' as const,
+				size: 0,
+				mtime: new Date(),
+			})),
+			readlink: vi.fn(async () => ''),
+			symlink: vi.fn(async () => undefined),
+		},
+		isAncestorCommit: vi.fn(async () => true),
+		collectFiles,
+	})
+	mockModule.writePublishedSourceSnapshot.mockClear()
+	mockModule.deletePublishedArtifactsForSource.mockClear()
+
+	const repoSession = new RepoSession(createDurableObjectState(), {
+		APP_DB: {},
+		BUNDLE_ARTIFACTS_KV: {} as KVNamespace,
+	} as Env)
+	const result = await repoSession.publishFromExternalRef({
+		sessionId: 'external-publish-source-1',
+		sourceId: 'source-1',
+		userId: 'user-1',
+		newCommit: 'commit-new',
+	})
+
+	expect(result).toEqual({
+		status: 'already_published',
+		published_commit: 'commit-new',
+		force_artifact_rebuild: true,
+	})
+	expect(mockModule.deletePublishedArtifactsForSource).not.toHaveBeenCalled()
+	expect(mockModule.writePublishedSourceSnapshot).toHaveBeenCalledWith(
+		expect.objectContaining({
+			source: expect.objectContaining({ published_commit: 'commit-new' }),
+			files: cloneFiles,
+			invalidateExistingArtifacts: true,
+		}),
+	)
 })
 
 test('already_published external publish fails when snapshot refresh fails', async () => {

--- a/packages/worker/src/repo/repo-session-do-publish.node.test.ts
+++ b/packages/worker/src/repo/repo-session-do-publish.node.test.ts
@@ -626,9 +626,12 @@ test('runIsolatedArtifactRebuild loads staged files, skips built targets, and re
 		sourceId: 'source-1',
 		userId: 'user-1',
 		publishedCommit: 'commit-1',
-		target,
+		targets: [target],
 	})
-	expect(skipped).toMatchObject({ ok: true, skipped: true })
+	expect(skipped).toMatchObject({
+		ok: true,
+		results: [expect.objectContaining({ skipped: true, target })],
+	})
 	expect(kv.get).not.toHaveBeenCalled()
 	expect(
 		mockModule.persistPublishedPackageArtifactTarget,
@@ -639,14 +642,13 @@ test('runIsolatedArtifactRebuild loads staged files, skips built targets, and re
 		sourceId: 'source-1',
 		userId: 'user-1',
 		publishedCommit: 'commit-1',
-		target,
+		targets: [target],
 		baseUrl: 'https://kody.test',
 		force: true,
 	})
 	expect(forced).toMatchObject({
 		ok: true,
-		kvKey: 'kv:artifact',
-		target,
+		results: [expect.objectContaining({ kvKey: 'kv:artifact', target })],
 	})
 	expect(
 		mockModule.persistPublishedPackageArtifactTarget,
@@ -657,13 +659,12 @@ test('runIsolatedArtifactRebuild loads staged files, skips built targets, and re
 		sourceId: 'source-1',
 		userId: 'user-1',
 		publishedCommit: 'commit-1',
-		target,
+		targets: [target],
 		baseUrl: 'https://kody.test',
 	})
 	expect(rebuilt).toMatchObject({
 		ok: true,
-		kvKey: 'kv:artifact',
-		target,
+		results: [expect.objectContaining({ kvKey: 'kv:artifact', target })],
 	})
 	expect(mockModule.persistPublishedPackageArtifactTarget).toHaveBeenCalledWith(
 		expect.objectContaining({
@@ -679,7 +680,7 @@ test('runIsolatedArtifactRebuild loads staged files, skips built targets, and re
 		sourceId: 'source-1',
 		userId: 'user-1',
 		publishedCommit: 'commit-1',
-		target,
+		targets: [target],
 	})
 	expect(expired.ok).toBe(false)
 	expect(expired.message).toContain('staging data expired')
@@ -690,7 +691,7 @@ test('runIsolatedArtifactRebuild loads staged files, skips built targets, and re
 		sourceId: 'source-1',
 		userId: 'user-1',
 		publishedCommit: 'commit-1',
-		target,
+		targets: [target],
 	})
 	expect(crossUser.ok).toBe(false)
 	expect(crossUser.message).toContain('does not belong to the requesting user')
@@ -1013,16 +1014,93 @@ test('already_published external publish refreshes the snapshot from the in-memo
 	expect(result).toEqual({
 		status: 'already_published',
 		published_commit: 'commit-new',
+		force_artifact_rebuild: true,
 	})
 	expect(mockModule.updateEntitySource).not.toHaveBeenCalled()
 	expect(mockModule.runRepoChecks).not.toHaveBeenCalled()
 	expect(collectFiles).toHaveBeenCalledTimes(1)
+	expect(mockModule.loadPublishedSourceSnapshot).toHaveBeenCalledTimes(1)
 	expect(mockModule.writePublishedSourceSnapshot).toHaveBeenCalledWith(
 		expect.objectContaining({
 			source: expect.objectContaining({ published_commit: 'commit-new' }),
 			files: cloneFiles,
 		}),
 	)
+})
+
+test('already_published external publish skips snapshot rewrite and force rebuild when files already match', async () => {
+	restoreRepoSessionMockBaseline()
+	setCommonSessionFixtures()
+	mockModule.getEntitySourceById.mockResolvedValue({
+		id: 'source-1',
+		user_id: 'user-1',
+		repo_id: 'source-repo',
+		published_commit: 'commit-new',
+		manifest_path: 'package.json',
+		source_root: '/',
+		entity_kind: 'package',
+		entity_id: 'package-1',
+	})
+	const cloneFiles = {
+		'package.json':
+			'{"name":"@kody/demo","exports":{".":"./index.ts"},"kody":{"id":"demo","description":"Demo"}}',
+		'index.ts': 'export const fromClone = true\n',
+	}
+	mockModule.loadPublishedSourceSnapshot.mockResolvedValueOnce({
+		files: cloneFiles,
+	})
+	const collectFiles = vi.fn(async () => cloneFiles)
+	mockModule.cloneExternalPublishWorkspace.mockResolvedValueOnce({
+		workspace: {
+			readFile: vi.fn(async () => null),
+			glob: vi.fn(async () => []),
+		},
+		headCommit: 'commit-new',
+		dir: '/repo',
+		filesystem: {
+			readFile: vi.fn(async () => ''),
+			readFileBytes: vi.fn(async () => new Uint8Array()),
+			writeFile: vi.fn(async () => undefined),
+			writeFileBytes: vi.fn(async () => undefined),
+			rm: vi.fn(async () => undefined),
+			mkdir: vi.fn(async () => undefined),
+			readdir: vi.fn(async () => []),
+			stat: vi.fn(async () => ({
+				type: 'file' as const,
+				size: 0,
+				mtime: new Date(),
+			})),
+			lstat: vi.fn(async () => ({
+				type: 'file' as const,
+				size: 0,
+				mtime: new Date(),
+			})),
+			readlink: vi.fn(async () => ''),
+			symlink: vi.fn(async () => undefined),
+		},
+		isAncestorCommit: vi.fn(async () => true),
+		collectFiles,
+	})
+	mockModule.writePublishedSourceSnapshot.mockClear()
+
+	const repoSession = new RepoSession(createDurableObjectState(), {
+		APP_DB: {},
+		BUNDLE_ARTIFACTS_KV: {} as KVNamespace,
+	} as Env)
+	const result = await repoSession.publishFromExternalRef({
+		sessionId: 'external-publish-source-1',
+		sourceId: 'source-1',
+		userId: 'user-1',
+		newCommit: 'commit-new',
+	})
+
+	expect(result).toEqual({
+		status: 'already_published',
+		published_commit: 'commit-new',
+		force_artifact_rebuild: false,
+	})
+	expect(collectFiles).toHaveBeenCalledTimes(1)
+	expect(mockModule.writePublishedSourceSnapshot).not.toHaveBeenCalled()
 })
 
 test('already_published external publish fails when snapshot refresh fails', async () => {

--- a/packages/worker/src/repo/repo-session-do-publish.node.test.ts
+++ b/packages/worker/src/repo/repo-session-do-publish.node.test.ts
@@ -191,6 +191,8 @@ vi.mock('#worker/package-runtime/published-bundle-artifacts.ts', async () => {
 			mockModule.isPublishedPackageArtifactBuiltForCommit(...args),
 		persistPublishedPackageArtifactTarget: (...args: Array<unknown>) =>
 			mockModule.persistPublishedPackageArtifactTarget(...args),
+		deletePublishedArtifactsForSource: (...args: Array<unknown>) =>
+			mockModule.deletePublishedArtifactsForSource(...args),
 	}
 })
 
@@ -999,6 +1001,7 @@ test('already_published external publish refreshes the snapshot from the in-memo
 		collectFiles,
 	})
 	mockModule.writePublishedSourceSnapshot.mockClear()
+	mockModule.deletePublishedArtifactsForSource.mockClear()
 
 	const repoSession = new RepoSession(createDurableObjectState(), {
 		APP_DB: {},
@@ -1020,11 +1023,23 @@ test('already_published external publish refreshes the snapshot from the in-memo
 	expect(mockModule.runRepoChecks).not.toHaveBeenCalled()
 	expect(collectFiles).toHaveBeenCalledTimes(1)
 	expect(mockModule.loadPublishedSourceSnapshot).toHaveBeenCalledTimes(1)
+	expect(mockModule.deletePublishedArtifactsForSource).toHaveBeenCalledWith(
+		expect.objectContaining({
+			userId: 'user-1',
+			sourceId: 'source-1',
+		}),
+	)
 	expect(mockModule.writePublishedSourceSnapshot).toHaveBeenCalledWith(
 		expect.objectContaining({
 			source: expect.objectContaining({ published_commit: 'commit-new' }),
 			files: cloneFiles,
 		}),
+	)
+	expect(
+		mockModule.deletePublishedArtifactsForSource.mock.invocationCallOrder[0],
+	).toBeLessThan(
+		mockModule.writePublishedSourceSnapshot.mock.invocationCallOrder[0] ??
+			Number.POSITIVE_INFINITY,
 	)
 })
 
@@ -1082,6 +1097,7 @@ test('already_published external publish skips snapshot rewrite and force rebuil
 		collectFiles,
 	})
 	mockModule.writePublishedSourceSnapshot.mockClear()
+	mockModule.deletePublishedArtifactsForSource.mockClear()
 
 	const repoSession = new RepoSession(createDurableObjectState(), {
 		APP_DB: {},
@@ -1101,6 +1117,7 @@ test('already_published external publish skips snapshot rewrite and force rebuil
 	})
 	expect(collectFiles).toHaveBeenCalledTimes(1)
 	expect(mockModule.writePublishedSourceSnapshot).not.toHaveBeenCalled()
+	expect(mockModule.deletePublishedArtifactsForSource).not.toHaveBeenCalled()
 })
 
 test('already_published external publish fails when snapshot refresh fails', async () => {
@@ -1164,6 +1181,7 @@ test('already_published external publish fails when snapshot refresh fails', asy
 		}),
 	).rejects.toThrow('clone files unreadable')
 	expect(mockModule.updateEntitySource).not.toHaveBeenCalled()
+	expect(mockModule.deletePublishedArtifactsForSource).not.toHaveBeenCalled()
 	expect(consoleWarn).toHaveBeenCalledWith(
 		'already_published snapshot refresh failed',
 		expect.objectContaining({

--- a/packages/worker/src/repo/repo-session-do.node.test.ts
+++ b/packages/worker/src/repo/repo-session-do.node.test.ts
@@ -194,6 +194,8 @@ vi.mock('#worker/package-runtime/published-bundle-artifacts.ts', async () => {
 			mockModule.isPublishedPackageArtifactBuiltForCommit(...args),
 		persistPublishedPackageArtifactTarget: (...args: Array<unknown>) =>
 			mockModule.persistPublishedPackageArtifactTarget(...args),
+		deletePublishedArtifactsForSource: (...args: Array<unknown>) =>
+			mockModule.deletePublishedArtifactsForSource(...args),
 	}
 })
 

--- a/packages/worker/src/repo/repo-session-do.ts
+++ b/packages/worker/src/repo/repo-session-do.ts
@@ -39,7 +39,6 @@ import { getSavedPackageById } from '#worker/package-registry/repo.ts'
 import { type SavedPackageRecord } from '#worker/package-registry/types.ts'
 import {
 	collectPublishedPackageArtifactTargets,
-	deletePublishedArtifactsForSource,
 	isPublishedPackageArtifactBuiltForCommit,
 	persistPublishedPackageArtifactTarget,
 	type PublishedPackageArtifactBuildTarget,
@@ -3028,16 +3027,14 @@ class RepoSessionBase extends DurableObject<Env> {
 							},
 						})
 						if (!publishedSourceSnapshotFilesMatch(existingSnapshot, files)) {
-							// Drop same-commit leftovers before rewriting the
-							// snapshot. force_artifact_rebuild is only true for this
-							// request; if rebuild is interrupted, the next
-							// already_published must not treat leftover KV rows as
-							// matching HEAD.
-							await deletePublishedArtifactsForSource({
-								env: this.env,
-								userId: input.userId,
-								sourceId: source.id,
-							})
+							// Missing snapshot is the D1-finalize vs KV-write
+							// overlap: keep live artifacts and do not force.
+							// Mismatch means this commit was tagged with stale
+							// files. Rewrite the snapshot (rebuild reads it)
+							// and stamp invalidateArtifactsBefore so a later
+							// already_published cannot skip leftovers. Do not
+							// delete rows: that would take invoke offline.
+							const snapshotExisted = existingSnapshot?.files != null
 							await writePublishedSourceSnapshot({
 								env: this.env,
 								source: {
@@ -3045,8 +3042,9 @@ class RepoSessionBase extends DurableObject<Env> {
 									published_commit: publishResult.published_commit,
 								},
 								files,
+								invalidateExistingArtifacts: snapshotExisted,
 							})
-							forceArtifactRebuild = true
+							forceArtifactRebuild = snapshotExisted
 						}
 					}
 				}

--- a/packages/worker/src/repo/repo-session-do.ts
+++ b/packages/worker/src/repo/repo-session-do.ts
@@ -47,6 +47,7 @@ import {
 	hasPublishedRuntimeArtifacts,
 	loadPublishedSourceManifestSnapshot,
 	loadPublishedSourceSnapshot,
+	publishedSourceSnapshotFilesMatch,
 	writePublishedSourceSnapshot,
 } from '#worker/package-runtime/published-runtime-artifacts.ts'
 import { planRepoSessionContentEdits } from './plan-repo-session-content-edits.ts'
@@ -70,6 +71,7 @@ import {
 	isolatedArtifactRebuildStagingTtlSeconds,
 	type IsolatedArtifactRebuildOutcome,
 	type IsolatedArtifactRebuildRequest,
+	type IsolatedArtifactRebuildTargetResult,
 } from './isolated-artifact-rebuild.ts'
 import {
 	isolatedCheckStagingKeyBelongsToUser,
@@ -105,6 +107,7 @@ import {
 	externalPublishWorkspaceDir,
 	isWorkspaceSqliteTooBigMessage,
 } from './external-publish-clone.ts'
+import { timePublishExternalPushPhase } from './publish-phase-timing.ts'
 import {
 	buildRepoSessionWorkspaceName,
 	measureRepoSessionWorkspaceBlobBytes,
@@ -2290,45 +2293,69 @@ class RepoSessionBase extends DurableObject<Env> {
 	}
 
 	/**
-	 * Pure-compute entrypoint for one published-package artifact rebuild,
-	 * invoked on a throwaway Durable Object id so the rebuild's peak memory
-	 * lives in its own isolate (see isolated-artifact-rebuild.ts). It has no
-	 * session and never touches this instance's storage; the staged source
-	 * files come from a short-TTL KV entry written by
+	 * Pure-compute entrypoint for a chunk of published-package artifact
+	 * rebuilds, invoked on a throwaway Durable Object id so the rebuild's
+	 * peak memory lives in its own isolate (see isolated-artifact-rebuild.ts).
+	 * It has no session and never touches this instance's storage; the staged
+	 * source files come from a short-TTL KV entry written by
 	 * `stagePublishedPackageArtifactRebuild`.
 	 */
 	async runIsolatedArtifactRebuild(
 		input: IsolatedArtifactRebuildRequest,
 	): Promise<IsolatedArtifactRebuildOutcome> {
+		const failTargets = (
+			targets: ReadonlyArray<PublishedPackageArtifactBuildTarget>,
+			message: string,
+		): Array<IsolatedArtifactRebuildTargetResult> =>
+			targets.map((target) => ({
+				ok: false,
+				message,
+				target,
+			}))
+
 		if (
 			!isolatedArtifactRebuildStagingKeyBelongsToUser({
 				stagingKey: input.stagingKey,
 				userId: input.userId,
 			})
 		) {
+			const message =
+				'Isolated artifact rebuild staging key does not belong to the requesting user.'
 			return {
 				ok: false,
-				message:
-					'Isolated artifact rebuild staging key does not belong to the requesting user.',
-				target: input.target,
+				message,
+				results: failTargets(input.targets, message),
 			}
 		}
-		const alreadyBuilt =
-			!input.force &&
-			(await isPublishedPackageArtifactBuiltForCommit({
-				env: this.env,
-				userId: input.userId,
-				sourceId: input.sourceId,
-				publishedCommit: input.publishedCommit,
-				target: input.target,
-			}))
-		if (alreadyBuilt) {
+		const results: Array<IsolatedArtifactRebuildTargetResult> = []
+		const remaining: Array<PublishedPackageArtifactBuildTarget> = []
+		for (const target of input.targets) {
+			const alreadyBuilt =
+				!input.force &&
+				(await isPublishedPackageArtifactBuiltForCommit({
+					env: this.env,
+					userId: input.userId,
+					sourceId: input.sourceId,
+					publishedCommit: input.publishedCommit,
+					target,
+				}))
+			if (alreadyBuilt) {
+				results.push({
+					ok: true,
+					message: 'Published package artifact already built for this commit.',
+					skipped: true,
+					kvKey: null,
+					target,
+				})
+				continue
+			}
+			remaining.push(target)
+		}
+		if (remaining.length === 0) {
 			return {
 				ok: true,
-				message: 'Published package artifact already built for this commit.',
-				skipped: true,
-				kvKey: null,
-				target: input.target,
+				message: 'Published package artifacts already built for this commit.',
+				results,
 			}
 		}
 		const staged = await this.env.BUNDLE_ARTIFACTS_KV.get<{
@@ -2336,12 +2363,10 @@ class RepoSessionBase extends DurableObject<Env> {
 		}>(input.stagingKey, 'json')
 		const sourceFiles = staged?.sourceFiles
 		if (!sourceFiles) {
-			return {
-				ok: false,
-				message:
-					'Isolated artifact rebuild staging data expired or is missing; re-run the publish capability to repair artifacts.',
-				target: input.target,
-			}
+			const message =
+				'Isolated artifact rebuild staging data expired or is missing; re-run the publish capability to repair artifacts.'
+			results.push(...failTargets(remaining, message))
+			return { ok: false, message, results }
 		}
 		try {
 			const source = await this.resolvePublishSource({
@@ -2349,45 +2374,72 @@ class RepoSessionBase extends DurableObject<Env> {
 				userId: input.userId,
 			})
 			if (source.entity_kind !== 'package') {
-				return {
-					ok: false,
-					message:
-						'Published bundle artifacts can only be rebuilt for packages.',
-					target: input.target,
-				}
+				const message =
+					'Published bundle artifacts can only be rebuilt for packages.'
+				results.push(...failTargets(remaining, message))
+				return { ok: false, message, results }
 			}
 			const savedPackage = await getSavedPackageById(this.env.APP_DB, {
 				userId: input.userId,
 				packageId: source.entity_id,
 			})
 			if (!savedPackage) {
-				return {
-					ok: false,
-					message: `Saved package "${source.entity_id}" was not found.`,
-					target: input.target,
+				const message = `Saved package "${source.entity_id}" was not found.`
+				results.push(...failTargets(remaining, message))
+				return { ok: false, message, results }
+			}
+			for (const target of remaining) {
+				try {
+					const kvKey =
+						await this.persistPublishedPackageArtifactTargetFromFiles({
+							source,
+							savedPackage,
+							userId: input.userId,
+							publishedCommit: input.publishedCommit,
+							target,
+							baseUrl: input.baseUrl,
+							sourceFiles,
+						})
+					results.push({
+						ok: true,
+						message: 'Published package artifact rebuilt.',
+						kvKey,
+						target,
+					})
+				} catch (error) {
+					results.push({
+						ok: false,
+						message: getErrorMessage(error),
+						target,
+					})
 				}
 			}
-			const kvKey = await this.persistPublishedPackageArtifactTargetFromFiles({
-				source,
-				savedPackage,
-				userId: input.userId,
-				publishedCommit: input.publishedCommit,
-				target: input.target,
-				baseUrl: input.baseUrl,
-				sourceFiles,
-			})
+		} catch (error) {
+			const message = getErrorMessage(error)
+			const recorded = new Set(results.map((result) => result.target))
+			for (const target of remaining) {
+				if (recorded.has(target)) continue
+				results.push({
+					ok: false,
+					message,
+					target,
+				})
+			}
+			return { ok: false, message, results }
+		}
+
+		const failed = results.filter((result) => !result.ok)
+		if (failed.length === 0) {
 			return {
 				ok: true,
-				message: 'Published package artifact rebuilt.',
-				kvKey,
-				target: input.target,
+				message: 'Published package artifacts rebuilt.',
+				results,
 			}
-		} catch (error) {
-			return {
-				ok: false,
-				message: getErrorMessage(error),
-				target: input.target,
-			}
+		}
+		return {
+			ok: false,
+			message: failed.map((result) => result.message).join('; '),
+			results,
 		}
 	}
 
@@ -2887,23 +2939,30 @@ class RepoSessionBase extends DurableObject<Env> {
 		try {
 			// In-memory clone: publish verification does not need the session
 			// Durable Object workspace (KODY-CLOUDFLARE-57).
-			publishClone = await cloneExternalPublishWorkspace({
-				remote: sourceAccess.remote,
-				token: sourceAccess.token,
-				branch: targetBranch,
-				checkoutCommit: input.newCommit,
-			})
-			// Race protection without a second Artifacts REST HEAD resolve: the
-			// single-branch clone tip is the remote default-branch HEAD at clone
-			// time. Compare it to the worker-resolved expectedHead before publish.
-			if (input.expectedHead) {
-				const clonedHead = publishClone.headCommit
-				if (clonedHead !== input.expectedHead) {
-					throw new Error(
-						`Artifacts HEAD changed from "${input.expectedHead}" to "${clonedHead ?? 'unknown'}" before publish.`,
-					)
-				}
-			}
+			;({ value: publishClone } = await timePublishExternalPushPhase(
+				{ phase: 'clone', sourceId: source.id },
+				async () => {
+					const cloned = await cloneExternalPublishWorkspace({
+						remote: sourceAccess.remote,
+						token: sourceAccess.token,
+						branch: targetBranch,
+						checkoutCommit: input.newCommit,
+					})
+					// Race protection without a second Artifacts REST HEAD resolve:
+					// the single-branch clone tip is the remote default-branch HEAD
+					// at clone time. Compare it to the worker-resolved expectedHead
+					// before publish.
+					if (input.expectedHead) {
+						const clonedHead = cloned.headCommit
+						if (clonedHead !== input.expectedHead) {
+							throw new Error(
+								`Artifacts HEAD changed from "${input.expectedHead}" to "${clonedHead ?? 'unknown'}" before publish.`,
+							)
+						}
+					}
+					return cloned
+				},
+			))
 		} catch (error) {
 			const message = getErrorMessage(error)
 			if (message.includes('Artifacts HEAD changed from')) {
@@ -2947,10 +3006,11 @@ class RepoSessionBase extends DurableObject<Env> {
 			allowLockedPublish: input.allowLockedPublish,
 		})
 		if (publishResult.status === 'already_published') {
-			// D1 stays a no-op (overlapping inline + durable escalation). Still
-			// rewrite the KV snapshot from the just-cloned HEAD so a prior
-			// finalize that tagged the current commit with stale files cannot
-			// keep winning artifact rebuilds.
+			// D1 stays a no-op (overlapping inline + durable escalation). Rewrite
+			// the KV snapshot only when it is missing or the cloned HEAD files
+			// differ, so a prior finalize that tagged this commit with stale
+			// files cannot keep winning artifact rebuilds.
+			let forceArtifactRebuild = false
 			try {
 				if (
 					publishResult.published_commit &&
@@ -2958,14 +3018,25 @@ class RepoSessionBase extends DurableObject<Env> {
 				) {
 					const files = await publishClone.collectFiles()
 					if (typeof files[source.manifest_path] === 'string') {
-						await writePublishedSourceSnapshot({
+						const existingSnapshot = await loadPublishedSourceSnapshot({
 							env: this.env,
+							userId: input.userId,
 							source: {
 								...source,
 								published_commit: publishResult.published_commit,
 							},
-							files,
 						})
+						if (!publishedSourceSnapshotFilesMatch(existingSnapshot, files)) {
+							await writePublishedSourceSnapshot({
+								env: this.env,
+								source: {
+									...source,
+									published_commit: publishResult.published_commit,
+								},
+								files,
+							})
+							forceArtifactRebuild = true
+						}
 					}
 				}
 			} catch (error) {
@@ -2987,6 +3058,10 @@ class RepoSessionBase extends DurableObject<Env> {
 					error: getErrorMessage(error),
 				})
 				throw error
+			}
+			return {
+				...publishResult,
+				force_artifact_rebuild: forceArtifactRebuild,
 			}
 		} else if (publishResult.status === 'published') {
 			try {

--- a/packages/worker/src/repo/repo-session-do.ts
+++ b/packages/worker/src/repo/repo-session-do.ts
@@ -39,6 +39,7 @@ import { getSavedPackageById } from '#worker/package-registry/repo.ts'
 import { type SavedPackageRecord } from '#worker/package-registry/types.ts'
 import {
 	collectPublishedPackageArtifactTargets,
+	deletePublishedArtifactsForSource,
 	isPublishedPackageArtifactBuiltForCommit,
 	persistPublishedPackageArtifactTarget,
 	type PublishedPackageArtifactBuildTarget,
@@ -3027,6 +3028,16 @@ class RepoSessionBase extends DurableObject<Env> {
 							},
 						})
 						if (!publishedSourceSnapshotFilesMatch(existingSnapshot, files)) {
+							// Drop same-commit leftovers before rewriting the
+							// snapshot. force_artifact_rebuild is only true for this
+							// request; if rebuild is interrupted, the next
+							// already_published must not treat leftover KV rows as
+							// matching HEAD.
+							await deletePublishedArtifactsForSource({
+								env: this.env,
+								userId: input.userId,
+								sourceId: source.id,
+							})
 							await writePublishedSourceSnapshot({
 								env: this.env,
 								source: {

--- a/packages/worker/src/repo/types.ts
+++ b/packages/worker/src/repo/types.ts
@@ -338,6 +338,12 @@ export type RepoExternalPublishResult =
 	| {
 			status: 'already_published'
 			published_commit: string | null
+			/**
+			 * True when already_published rewrote a missing or mismatched source
+			 * snapshot. Callers must force artifact rebuild so same-commit leftovers
+			 * cannot keep serving. Omit / false when the snapshot already matches.
+			 */
+			force_artifact_rebuild?: boolean
 	  }
 	| {
 			status: 'not_fast_forward'

--- a/packages/worker/src/test-support/repo-session-do.ts
+++ b/packages/worker/src/test-support/repo-session-do.ts
@@ -165,6 +165,7 @@ export const repoSessionMockModule = (() => {
 		})),
 		isPublishedPackageArtifactBuiltForCommit: vi.fn(async () => false),
 		persistPublishedPackageArtifactTarget: vi.fn(async () => 'kv:artifact'),
+		deletePublishedArtifactsForSource: vi.fn(async () => undefined),
 		registerStorageBucketAndWait: vi.fn(async () => undefined),
 		maybeRefreshStorageBucketEstimate: vi.fn(),
 		deleteStorageBucketInventory: vi.fn(async () => true),
@@ -289,6 +290,9 @@ export function restoreRepoSessionMockBaseline() {
 	)
 	repoSessionMockModule.persistPublishedPackageArtifactTarget.mockResolvedValue(
 		'kv:artifact',
+	)
+	repoSessionMockModule.deletePublishedArtifactsForSource.mockResolvedValue(
+		undefined,
 	)
 	repoSessionMockModule.registerStorageBucketAndWait.mockClear()
 	repoSessionMockModule.maybeRefreshStorageBucketEstimate.mockClear()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Make multi-export `packagePublishExternalPush` cheaper without changing check bundling or clone strategy.

## Why

Isolated artifact rebuild still booted one throwaway Durable Object per export after checks had already bundled in chunks of 4. Escalation races also re-entered as `already_published` with `force: true`, paying a full rebuild even when snapshot and artifacts already matched HEAD.

## Summary

- Isolated rebuild now chunks like checks: 4 targets per throwaway isolate, concurrency still 2.
- `already_published` rewrites the source snapshot only when files are missing or mismatched.
- Missing snapshot (D1 finalize vs KV write race): rewrite snapshot only. Do not delete artifacts and do not force-rebuild. Matching same-commit bundles keep serving.
- Mismatch (this commit was tagged with stale files): rewrite snapshot with `invalidateArtifactsBefore`, force-rebuild this request, and treat older same-commit leftovers as not built on a later retry. Live artifacts stay until the new persist overwrites them.
- Matching artifacts are skipped. Failed finalize races still rebuild missing or invalidated same-commit bundles.
- Coarse per-phase timings (`clone`, `checks/typecheck`, `checks/bundle`, `rebuild`, `dependents`) go to structured logs and progress messages.

## Testing

- Focused node-unit on publish/rebuild/artifact suites.
- Pre-push hook on `0d9ec121`: `test:node` 2659 passed, `test:workers` 330 passed.
- Pre-commit typecheck passed.

## Explicitly deferred

- Collapsing check-bundle into rebuild / skipping check bundling
- Tree-hash skip for typecheck
- Changing Artifacts clone strategy / shallow fetch
- Adding smoke to publish
- Further shrinking durable escalation budget
- Unbounded parallel DO fan-out
- npm/node_modules caching

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `2c85940f` · **Head:** `0d9ec121`

**Classification:** extends — isolated rebuild and already_published now change repo-session and saved-package publish behavior, without adding a primitive.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `saved-packages` | assistant | extends — already_published force is snapshot-gated, phase timings reported |
| `repo-sessions` | runtime | extends — rebuild isolate takes a target chunk, snapshot compare then invalidate-on-mismatch |
| `package-runtime` | runtime | extends — snapshot file-map equality and invalidateArtifactsBefore cutoff |
| `capability-registry` | assistant | extends — rebuild orchestrator chunks isolates like checks |

### Change flow

External publish still clones and checks, then rebuilds artifacts. This PR chunks those rebuild isolates. Missing snapshots only rewrite KV. Mismatched snapshots rewrite with an invalidation cutoff so leftover same-commit bundles rebuild after an interrupt without deleting live artifacts.

```mermaid
sequenceDiagram
	actor Agent
	participant savedPackages as saved-packages
	participant repoSessions as repo-sessions
	participant packageRuntime as package-runtime
	Agent->>savedPackages: packagePublishExternalPush
	savedPackages->>repoSessions: publishFromExternalRef with timed clone and checks
	alt already_published
		repoSessions->>packageRuntime: compare cloned files to published snapshot
		packageRuntime-->>repoSessions: match or missing or mismatched
		opt snapshot missing
			repoSessions->>packageRuntime: rewrite snapshot without invalidation
			repoSessions-->>savedPackages: force_artifact_rebuild false
		end
		opt snapshot mismatched
			repoSessions->>packageRuntime: rewrite snapshot with invalidateArtifactsBefore
			repoSessions-->>savedPackages: force_artifact_rebuild true
		end
	end
	savedPackages->>repoSessions: rebuild artifacts in chunks of 4 at concurrency 2
	repoSessions-->>savedPackages: rebuilt or skipped matching same-commit targets
```

### Invariants

Per-user isolation is unchanged: staging keys stay user-namespaced, and throwaway rebuild isolates still verify key ownership before reading staged files.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-69a6c6fa-75ec-4297-bace-2a57d3bcee66?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-69a6c6fa-75ec-4297-bace-2a57d3bcee66&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added publish progress reporting with timing details for cloning, checks, artifact rebuilding, and dependent indexing.
  - Published package artifacts can now be rebuilt in parallel for faster processing.
  - Rebuild results now report success or failure for each artifact independently.

- **Bug Fixes**
  - Avoids unnecessary artifact rebuilds when published source content is unchanged.
  - Ensures stale artifacts are refreshed when snapshots change or a rebuild is explicitly forced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->