### PR TITLE
Return packagePublishExternalPush phase_timings on success

### DIFF
--- a/docs/contributing/packages-and-manifests.md
+++ b/docs/contributing/packages-and-manifests.md
@@ -605,7 +605,11 @@ When publish succeeds, `packagePublishExternalPush` decorates the response with
 bundle artifact dependency metadata references the published package.
 `already_published` responses include the same summary when the published commit
 is available. The stale count compares each dependent artifact's captured
-dependency commit to the current published commit.
+dependency commit to the current published commit. Successful `published` and
+`already_published` results also include `phase_timings` (`clone_ms`,
+`checks_typecheck_ms`, `checks_bundle_ms`, `rebuild_ms`, `dependents_ms`,
+`total_ms`). Omitted keys did not run. `dispatched` includes
+`phase_timings.total_ms` as time-to-dispatch.
 
 This summary is visibility only. Do not add automatic fanout republishing to the
 publish path. Agents should inspect and republish dependent packages only when

--- a/docs/use/packages.md
+++ b/docs/use/packages.md
@@ -701,11 +701,18 @@ publish checks run.
    this package. Stale entries mean the dependent bundle captured a dependency
    commit that differs from the current published commit. Kody does not
    automatically republish those dependents; inspect and republish only the ones
-   whose static snapshot should reference the current published commit. When an
-   interactive publish exceeds the inline budget (~35s), the tool returns
+   whose static snapshot should reference the current published commit. Those
+   same success results include `phase_timings` with optional millisecond fields
+   `clone_ms`, `checks_typecheck_ms`, `checks_bundle_ms`, `rebuild_ms`,
+   `dependents_ms`, and `total_ms`. Omitted keys did not run on that attempt.
+   `checks_bundle_ms` is the publish bundle-check; `rebuild_ms` is the later
+   artifact rebuild — they stay separate. Read `phase_timings` on the capability
+   result; it is not available from `runList` or Cloudflare Log Explorer. When
+   an interactive publish exceeds the inline budget (~35s), the tool returns
    `status: "dispatched"` with a `workflow_id` instead of hanging until the host
-   times out. Poll `workflowRunList` with that `workflow_id` until the run
-   finishes; do not retry the same publish while the run is active.
+   times out. `dispatched` includes `phase_timings.total_ms` as
+   time-to-dispatch. Poll `workflowRunList` with that `workflow_id` until the
+   run finishes; do not retry the same publish while the run is active.
 
 Dynamic package invocation is different from static bundled imports. When a
 runtime feature invokes another package dynamically through the package

--- a/packages/worker/src/mcp/capabilities/packages/publish-external-push.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/packages/publish-external-push.node.test.ts
@@ -195,6 +195,11 @@ test('publishExternalPush publishes HEAD and rebuilds bundle artifacts per targe
 	expect(publishedResult.status).toBe('published')
 	expect(publishedResult).toEqual(
 		expect.objectContaining({
+			phase_timings: {
+				rebuild_ms: expect.any(Number),
+				dependents_ms: expect.any(Number),
+				total_ms: expect.any(Number),
+			},
 			hosted_app_url: 'https://user.packages.kody.test/packages/demo-package',
 			test_hints: {
 				app: 'packageAppFetch({ kody_id: "demo-package" })',
@@ -276,6 +281,80 @@ test('publishExternalPush publishes HEAD and rebuilds bundle artifacts per targe
 	)
 })
 
+test('publishExternalPush returns forwarded clone and check timings without collapsing bundle and rebuild', async () => {
+	setupDefaultMocks()
+	mockModule.resolveArtifactSourceHead.mockResolvedValue({
+		branch: 'main',
+		commit: 'commit-new',
+	})
+	mockModule.publishFromExternalRef.mockResolvedValue({
+		status: 'published',
+		previous_commit: 'commit-old',
+		published_commit: 'commit-new',
+		manifest: {},
+		checks: [{ kind: 'manifest', ok: true, message: 'ok' }],
+		phase_timings: {
+			clone_ms: 11,
+			checks_typecheck_ms: 22,
+			checks_bundle_ms: 33,
+		},
+	})
+
+	const published = await publishExternalPushCapability.handler(
+		{ package_id: 'package-1' },
+		createContext(),
+	)
+	expect(published.status).toBe('published')
+	if (published.status !== 'published') {
+		throw new Error('expected published')
+	}
+	expect(published.phase_timings).toEqual({
+		clone_ms: 11,
+		checks_typecheck_ms: 22,
+		checks_bundle_ms: 33,
+		rebuild_ms: expect.any(Number),
+		dependents_ms: expect.any(Number),
+		total_ms: expect.any(Number),
+	})
+	expect(published.phase_timings.rebuild_ms).toBeGreaterThanOrEqual(0)
+	expect(published.phase_timings.dependents_ms).toBeGreaterThanOrEqual(0)
+	expect(published.phase_timings.total_ms).toBeGreaterThanOrEqual(0)
+	expect(published.phase_timings.checks_bundle_ms).toBe(33)
+
+	setupDefaultMocks()
+	mockModule.resolveArtifactSourceHead.mockResolvedValue({
+		branch: 'main',
+		commit: 'commit-old',
+	})
+	mockModule.publishFromExternalRef.mockResolvedValue({
+		status: 'already_published',
+		published_commit: 'commit-old',
+		phase_timings: { clone_ms: 7 },
+	})
+
+	const alreadyPublished = await publishExternalPushCapability.handler(
+		{ package_id: 'package-1' },
+		createContext(),
+	)
+	expect(alreadyPublished).toEqual(
+		expect.objectContaining({
+			status: 'already_published',
+			published_commit: 'commit-old',
+			phase_timings: {
+				clone_ms: 7,
+				rebuild_ms: expect.any(Number),
+				dependents_ms: expect.any(Number),
+				total_ms: expect.any(Number),
+			},
+		}),
+	)
+	if (alreadyPublished.status !== 'already_published') {
+		throw new Error('expected already_published')
+	}
+	expect(alreadyPublished.phase_timings.checks_typecheck_ms).toBeUndefined()
+	expect(alreadyPublished.phase_timings.checks_bundle_ms).toBeUndefined()
+})
+
 test('publishExternalPush handles already_published branches, stale dependents, and rebuild failures', async () => {
 	const targets = [
 		{
@@ -318,6 +397,11 @@ test('publishExternalPush handles already_published branches, stale dependents, 
 			items: [],
 		}),
 		pending_secret_package_approvals: null,
+		phase_timings: {
+			rebuild_ms: expect.any(Number),
+			dependents_ms: expect.any(Number),
+			total_ms: expect.any(Number),
+		},
 	})
 	expect(mockModule.rebuildPublishedPackageArtifact).toHaveBeenCalledWith({
 		sourceId: 'source-1',
@@ -651,6 +735,9 @@ test('budget exhaustion returns a dispatched handle and background re-entry skip
 		idempotency_key: ['user-1', ...expectedParts].join(':'),
 		run_status: 'queued',
 		message: 'dispatched',
+		phase_timings: {
+			total_ms: expect.any(Number),
+		},
 	})
 	expect(mockModule.publishFromExternalRef).not.toHaveBeenCalled()
 	expect(mockModule.runWithDurableEscalation).toHaveBeenCalledWith(
@@ -776,6 +863,11 @@ test('publishExternalPush recovers from transient Durable Object resets', async 
 			items: [],
 		}),
 		pending_secret_package_approvals: null,
+		phase_timings: {
+			rebuild_ms: expect.any(Number),
+			dependents_ms: expect.any(Number),
+			total_ms: expect.any(Number),
+		},
 	})
 
 	setupDefaultMocks()

--- a/packages/worker/src/mcp/capabilities/packages/publish-external-push.ts
+++ b/packages/worker/src/mcp/capabilities/packages/publish-external-push.ts
@@ -30,7 +30,12 @@ import {
 import { repoSessionRpc } from '#worker/repo/repo-session-rpc.ts'
 import { resolveArtifactSourceHead } from '#worker/repo/artifacts.ts'
 import { rebuildPublishedPackageArtifactsViaRepoSession } from '#mcp/capabilities/repo/package-artifact-rebuild.ts'
-import { timePublishExternalPushPhase } from '#worker/repo/publish-phase-timing.ts'
+import {
+	mergePublishPhaseTimings,
+	timePublishExternalPushPhase,
+	withPublishAttemptTotalMs,
+	type PublishPhaseTimings,
+} from '#worker/repo/publish-phase-timing.ts'
 import { destructiveOverwriteConfirmationDescription } from '#worker/repo/source-safety-policy.ts'
 import {
 	buildPendingPackageSecretApprovalsSummary,
@@ -243,6 +248,61 @@ const packageTestHintsSchema = z.object({
 		.optional(),
 })
 
+const publishPhaseTimingsSchema = z
+	.object({
+		clone_ms: z
+			.number()
+			.int()
+			.nonnegative()
+			.optional()
+			.describe(
+				'Milliseconds spent cloning Artifacts HEAD into the publish workspace. Omitted when this attempt did not clone.',
+			),
+		checks_typecheck_ms: z
+			.number()
+			.int()
+			.nonnegative()
+			.optional()
+			.describe(
+				'Milliseconds spent in the publish typecheck phase. Omitted when typecheck did not run (for example already_published).',
+			),
+		checks_bundle_ms: z
+			.number()
+			.int()
+			.nonnegative()
+			.optional()
+			.describe(
+				'Milliseconds spent in the publish bundle-check phase. Distinct from rebuild_ms. Omitted when bundle check did not run.',
+			),
+		rebuild_ms: z
+			.number()
+			.int()
+			.nonnegative()
+			.optional()
+			.describe(
+				'Milliseconds spent rebuilding published package artifacts after checks, or confirming they match this commit. Distinct from checks_bundle_ms.',
+			),
+		dependents_ms: z
+			.number()
+			.int()
+			.nonnegative()
+			.optional()
+			.describe(
+				'Milliseconds spent indexing static dependents, hosted app URL, test hints, and pending secret approvals.',
+			),
+		total_ms: z
+			.number()
+			.int()
+			.nonnegative()
+			.optional()
+			.describe(
+				'Milliseconds from the start of this publish attempt until the result was ready. On status dispatched, this is time-to-dispatch.',
+			),
+	})
+	.describe(
+		'Coarse packagePublishExternalPush phase timings in milliseconds. Field names are stable. Omitted keys mean that phase did not run in this result. checks_bundle_ms and rebuild_ms stay separate.',
+	)
+
 const outputSchema = z.discriminatedUnion('status', [
 	z.object({
 		status: z.literal('already_published'),
@@ -251,6 +311,7 @@ const outputSchema = z.discriminatedUnion('status', [
 		test_hints: packageTestHintsSchema.optional(),
 		static_dependents: staticDependentsSchema,
 		pending_secret_package_approvals: pendingPackageSecretApprovalsSchema,
+		phase_timings: publishPhaseTimingsSchema,
 	}),
 	z.object({
 		status: z.literal('not_fast_forward'),
@@ -290,6 +351,7 @@ const outputSchema = z.discriminatedUnion('status', [
 		test_hints: packageTestHintsSchema.optional(),
 		static_dependents: staticDependentsSchema,
 		pending_secret_package_approvals: pendingPackageSecretApprovalsSchema,
+		phase_timings: publishPhaseTimingsSchema,
 	}),
 	z.object({
 		status: z.literal('dispatched'),
@@ -298,10 +360,26 @@ const outputSchema = z.discriminatedUnion('status', [
 		idempotency_key: z.string(),
 		run_status: z.string().nullable(),
 		message: z.string(),
+		phase_timings: publishPhaseTimingsSchema,
 	}),
 ])
 
 type PublishExternalPushResult = z.infer<typeof outputSchema>
+
+function buildPublishPhaseTimings(input: {
+	startedAt: number
+	fromPublish?: PublishPhaseTimings
+	rebuildMs: number
+	dependentsMs: number
+}): PublishPhaseTimings {
+	return withPublishAttemptTotalMs(
+		mergePublishPhaseTimings(input.fromPublish, {
+			rebuild_ms: input.rebuildMs,
+			dependents_ms: input.dependentsMs,
+		}),
+		input.startedAt,
+	)
+}
 
 function readPackageTestHintsFromManifest(input: {
 	manifest: unknown
@@ -638,6 +716,12 @@ async function runExternalPublishAttempt(input: {
 					static_dependents: alreadyPublishedExtras.static_dependents,
 					pending_secret_package_approvals:
 						alreadyPublishedExtras.pending_secret_package_approvals,
+					phase_timings: buildPublishPhaseTimings({
+						startedAt: publishStartedAt,
+						fromPublish: result.phase_timings,
+						rebuildMs,
+						dependentsMs,
+					}),
 				}
 			}
 			if (result.status === 'locked') {
@@ -740,6 +824,12 @@ async function runExternalPublishAttempt(input: {
 				static_dependents: publishedExtras.static_dependents,
 				pending_secret_package_approvals:
 					publishedExtras.pending_secret_package_approvals,
+				phase_timings: buildPublishPhaseTimings({
+					startedAt: publishStartedAt,
+					fromPublish: result.phase_timings,
+					rebuildMs,
+					dependentsMs,
+				}),
 			} as const
 		} catch (error) {
 			assertNotAborted(input.signal)
@@ -778,7 +868,7 @@ export const publishExternalPushCapability = defineDomainCapability(
 	{
 		name: 'packagePublishExternalPush',
 		description:
-			'Publish the current Artifacts git HEAD for a saved package after a packageGetGitRemote clone/edit/push workflow and server-side checks pass. Non-fast-forward publishes require explicit destructive overwrite confirmation and a verified restorable backup snapshot. Published and already_published responses include hosted_app_url when the package declares an app, plus bounded static dependent metadata so agents can decide whether stale kody:@ bundled snapshots need inspection or dependent republish; Kody does not republish dependents automatically. Common cases return the full synchronous result. If the publish exceeds the inline budget (~35s), the work is dispatched once to a durable workflow (idempotent per acting caller plus the full semantic publish input, including force/overwrite flags) and this capability returns status dispatched with a workflow_id to poll via workflowRunList instead of hanging until an opaque execute timeout.',
+			'Publish the current Artifacts git HEAD for a saved package after a packageGetGitRemote clone/edit/push workflow and server-side checks pass. Non-fast-forward publishes require explicit destructive overwrite confirmation and a verified restorable backup snapshot. Published and already_published responses include hosted_app_url when the package declares an app, plus bounded static dependent metadata so agents can decide whether stale kody:@ bundled snapshots need inspection or dependent republish; Kody does not republish dependents automatically. Those success results also include phase_timings with optional millisecond fields clone_ms, checks_typecheck_ms, checks_bundle_ms, rebuild_ms, dependents_ms, and total_ms — omitted keys did not run; checks_bundle_ms and rebuild_ms stay separate. Common cases return the full synchronous result. If the publish exceeds the inline budget (~35s), the work is dispatched once to a durable workflow (idempotent per acting caller plus the full semantic publish input, including force/overwrite flags) and this capability returns status dispatched with a workflow_id to poll via workflowRunList instead of hanging until an opaque execute timeout. dispatched includes phase_timings.total_ms as time-to-dispatch.',
 		keywords: ['package', 'publish', 'git', 'artifacts', 'external', 'push'],
 		readOnly: false,
 		idempotent: true,
@@ -848,6 +938,7 @@ export const publishExternalPushCapability = defineDomainCapability(
 				allow_force: args.allow_force,
 				confirm_destructive_overwrite: args.confirm_destructive_overwrite,
 			}
+			const escalateStartedAt = Date.now()
 			const outcome = await runWithDurableEscalation({
 				env: ctx.env,
 				userId: user.userId,
@@ -873,7 +964,10 @@ export const publishExternalPushCapability = defineDomainCapability(
 				case 'completed':
 					return outcome.value
 				case 'dispatched':
-					return outcome.handle
+					return {
+						...outcome.handle,
+						phase_timings: withPublishAttemptTotalMs({}, escalateStartedAt),
+					}
 				case 'failed':
 					throw new Error(outcome.error)
 				default: {

--- a/packages/worker/src/repo/checks.node.test.ts
+++ b/packages/worker/src/repo/checks.node.test.ts
@@ -38,6 +38,7 @@ import {
 	isolatedBundleChunkSize,
 } from './isolated-check-phases.ts'
 import { maxRepoSourceFileBytes } from './large-file-policy.ts'
+import { type PublishPhaseTimings } from './publish-phase-timing.ts'
 
 type MockSnapshot = {
 	read: ReturnType<typeof vi.fn>
@@ -160,6 +161,7 @@ async function runPackageJobTypecheckChecks(
 	files: Map<string, string>,
 	options?: {
 		getSemanticDiagnostics?: ReturnType<typeof vi.fn>
+		phaseTimings?: PublishPhaseTimings
 	},
 ) {
 	setupDefaultBundleMocks()
@@ -190,6 +192,7 @@ async function runPackageJobTypecheckChecks(
 		},
 		manifestPath: 'package.json',
 		sourceRoot: '/',
+		...(options?.phaseTimings ? { phaseTimings: options.phaseTimings } : {}),
 	})
 
 	return { result, typeScriptFileSystem, getSemanticDiagnostics }
@@ -402,6 +405,31 @@ test('runRepoChecks strips repo-session workspace prefixes from package snapshot
 	expect(getSemanticDiagnostics).toHaveBeenCalledWith(
 		'.__kody_repo_module_check__.ts',
 	)
+})
+
+test('runRepoChecks records typecheck and bundle phase timings when a collector is provided', async () => {
+	const phaseTimings: PublishPhaseTimings = {}
+	const { result } = await runPackageJobTypecheckChecks(
+		new Map<string, string>([
+			[
+				'package.json',
+				createPackageManifest({
+					packageName: '@kody/phase-timings',
+					kodyId: 'phase-timings',
+					description: 'Records publish check phase timings',
+				}),
+			],
+			['src/index.ts', 'export default async () => ({ ok: true })\n'],
+		]),
+		{ phaseTimings },
+	)
+	expect(result.ok).toBe(true)
+	expect(phaseTimings).toEqual({
+		checks_typecheck_ms: expect.any(Number),
+		checks_bundle_ms: expect.any(Number),
+	})
+	expect(phaseTimings.checks_typecheck_ms).toBeGreaterThanOrEqual(0)
+	expect(phaseTimings.checks_bundle_ms).toBeGreaterThanOrEqual(0)
 })
 
 test('runRepoChecks typechecks package-owned jobs (kody:runtime imports, emits, and ESM entrypoints)', async () => {

--- a/packages/worker/src/repo/checks.ts
+++ b/packages/worker/src/repo/checks.ts
@@ -63,7 +63,10 @@ import {
 	maxRepoSourceFileBytes,
 } from './large-file-policy.ts'
 import { normalizeRepoWorkspacePath } from './manifest.ts'
-import { timePublishExternalPushPhase } from './publish-phase-timing.ts'
+import {
+	timePublishExternalPushPhase,
+	type PublishPhaseTimings,
+} from './publish-phase-timing.ts'
 
 export type RepoCheckKind =
 	| 'manifest'
@@ -1099,6 +1102,7 @@ export async function runRepoChecks(input: {
 	baseUrl?: string
 	userId?: string
 	expectedPackageScope?: string
+	phaseTimings?: PublishPhaseTimings
 }): Promise<RepoCheckRunResult> {
 	const manifestContent = await input.workspace.readFile(input.manifestPath)
 	if (manifestContent == null) {
@@ -1350,7 +1354,7 @@ export async function runRepoChecks(input: {
 	try {
 		const runTypecheckPhase = async (): Promise<RepoCheckResult> => {
 			const { value } = await timePublishExternalPushPhase(
-				{ phase: 'checks/typecheck' },
+				{ phase: 'checks/typecheck', timings: input.phaseTimings },
 				async () => {
 					if (missingCallableTypecheckTargets.length > 0) {
 						return {
@@ -1406,7 +1410,7 @@ export async function runRepoChecks(input: {
 			message: string
 		}> => {
 			const { value } = await timePublishExternalPushPhase(
-				{ phase: 'checks/bundle' },
+				{ phase: 'checks/bundle', timings: input.phaseTimings },
 				async () => {
 					if (missingBundleTargets.length > 0) {
 						return {

--- a/packages/worker/src/repo/external-publish.node.test.ts
+++ b/packages/worker/src/repo/external-publish.node.test.ts
@@ -113,6 +113,7 @@ test('publishes an external fast-forward ref after checks pass', async () => {
 		},
 	})
 
+	const phaseTimings = { clone_ms: 9 }
 	const published = await publishFromExternalRef({
 		env: { APP_DB: {} } as Env,
 		sourceId: 'source-1',
@@ -122,9 +123,13 @@ test('publishes an external fast-forward ref after checks pass', async () => {
 		workspace: workspace(),
 		files: { 'package.json': '{}' },
 		baseUrl: 'https://kody.test',
+		phaseTimings,
 	})
 
 	expect(published.status).toBe('published')
+	expect(mockModule.runRepoChecks).toHaveBeenCalledWith(
+		expect.objectContaining({ phaseTimings }),
+	)
 	expect(mockModule.updateEntitySource).toHaveBeenCalledWith(
 		expect.anything(),
 		expect.objectContaining({

--- a/packages/worker/src/repo/external-publish.ts
+++ b/packages/worker/src/repo/external-publish.ts
@@ -12,6 +12,7 @@ import {
 } from '#worker/package-runtime/published-runtime-artifacts.ts'
 import { getEntitySourceById, updateEntitySource } from './entity-sources.ts'
 import { runRepoChecks } from './checks.ts'
+import { type PublishPhaseTimings } from './publish-phase-timing.ts'
 import {
 	type EntitySourceRow,
 	type RepoExternalPublishResult,
@@ -178,6 +179,7 @@ export async function publishFromExternalRef(input: {
 	rebuildPackageArtifacts?: boolean
 	expectedPackageScope?: string
 	allowLockedPublish?: boolean
+	phaseTimings?: PublishPhaseTimings
 }): Promise<RepoExternalPublishResult> {
 	const source = await getEntitySourceById(input.env.APP_DB, input.sourceId)
 	if (!source || source.user_id !== input.userId) {
@@ -225,6 +227,7 @@ export async function publishFromExternalRef(input: {
 		baseUrl: input.baseUrl,
 		userId: input.userId,
 		expectedPackageScope: input.expectedPackageScope,
+		phaseTimings: input.phaseTimings,
 	})
 	const runId = input.runId ?? crypto.randomUUID()
 	if (!checks.ok) {

--- a/packages/worker/src/repo/publish-phase-timing.node.test.ts
+++ b/packages/worker/src/repo/publish-phase-timing.node.test.ts
@@ -1,6 +1,14 @@
 import { expect, test } from 'vitest'
 import { consoleInfo } from '#worker/test-support/console-spies.ts'
-import { timePublishExternalPushPhase } from './publish-phase-timing.ts'
+import {
+	attachPublishPhaseTimings,
+	mergePublishPhaseTimings,
+	publishPhaseTimingField,
+	recordPublishPhaseTiming,
+	timePublishExternalPushPhase,
+	withPublishAttemptTotalMs,
+	type PublishPhaseTimings,
+} from './publish-phase-timing.ts'
 
 test('timePublishExternalPushPhase logs duration for success and failure', async () => {
 	const { value, durationMs } = await timePublishExternalPushPhase(
@@ -29,4 +37,66 @@ test('timePublishExternalPushPhase logs duration for success and failure', async
 	expect(consoleInfo).toHaveBeenCalledWith(
 		expect.stringContaining('"phase":"clone"'),
 	)
+})
+
+test('timePublishExternalPushPhase records stable capability field names', async () => {
+	const timings: PublishPhaseTimings = {}
+	await timePublishExternalPushPhase(
+		{ phase: 'checks/typecheck', timings },
+		async () => {
+			await new Promise((resolve) => setTimeout(resolve, 1))
+			return 'ok'
+		},
+	)
+	expect(timings).toEqual({
+		checks_typecheck_ms: expect.any(Number),
+	})
+	expect(timings.checks_typecheck_ms).toBeGreaterThanOrEqual(0)
+
+	recordPublishPhaseTiming(timings, 'checks/bundle', 12)
+	recordPublishPhaseTiming(timings, 'rebuild', 34)
+	expect(publishPhaseTimingField('clone')).toBe('clone_ms')
+	expect(timings).toEqual({
+		checks_typecheck_ms: expect.any(Number),
+		checks_bundle_ms: 12,
+		rebuild_ms: 34,
+	})
+})
+
+test('merge and attach keep check-bundle and rebuild separate', () => {
+	const merged = withPublishAttemptTotalMs(
+		mergePublishPhaseTimings(
+			{ clone_ms: 5, checks_bundle_ms: 40 },
+			{ rebuild_ms: 90, dependents_ms: 3 },
+		),
+		100,
+		250,
+	)
+	expect(merged).toEqual({
+		clone_ms: 5,
+		checks_bundle_ms: 40,
+		rebuild_ms: 90,
+		dependents_ms: 3,
+		total_ms: 150,
+	})
+
+	expect(
+		attachPublishPhaseTimings(
+			{ status: 'already_published', published_commit: 'commit-1' },
+			{ clone_ms: 8 },
+		),
+	).toEqual({
+		status: 'already_published',
+		published_commit: 'commit-1',
+		phase_timings: { clone_ms: 8 },
+	})
+	expect(
+		attachPublishPhaseTimings(
+			{ status: 'checks_failed', run_id: 'run-1' },
+			{ clone_ms: 8 },
+		),
+	).toEqual({
+		status: 'checks_failed',
+		run_id: 'run-1',
+	})
 })

--- a/packages/worker/src/repo/publish-phase-timing.ts
+++ b/packages/worker/src/repo/publish-phase-timing.ts
@@ -9,6 +9,98 @@ export const publishExternalPushPhaseNames = [
 export type PublishExternalPushPhase =
 	(typeof publishExternalPushPhaseNames)[number]
 
+/**
+ * Stable capability-result field names for coarse
+ * `packagePublishExternalPush` phase timings. Omitted keys mean that phase
+ * did not run on this result. `checks_bundle_ms` and `rebuild_ms` stay
+ * separate.
+ */
+export const publishPhaseTimingFields = [
+	'clone_ms',
+	'checks_typecheck_ms',
+	'checks_bundle_ms',
+	'rebuild_ms',
+	'dependents_ms',
+	'total_ms',
+] as const
+
+export type PublishPhaseTimingField = (typeof publishPhaseTimingFields)[number]
+
+export type PublishPhaseTimings = {
+	[K in PublishPhaseTimingField]?: number
+}
+
+export function publishPhaseTimingField(
+	phase: PublishExternalPushPhase,
+): Exclude<PublishPhaseTimingField, 'total_ms'> {
+	switch (phase) {
+		case 'clone':
+			return 'clone_ms'
+		case 'checks/typecheck':
+			return 'checks_typecheck_ms'
+		case 'checks/bundle':
+			return 'checks_bundle_ms'
+		case 'rebuild':
+			return 'rebuild_ms'
+		case 'dependents':
+			return 'dependents_ms'
+		default: {
+			const exhaustive: never = phase
+			throw new Error(`Unexpected publish phase: ${String(exhaustive)}`)
+		}
+	}
+}
+
+export function recordPublishPhaseTiming(
+	timings: PublishPhaseTimings,
+	phase: PublishExternalPushPhase,
+	durationMs: number,
+) {
+	timings[publishPhaseTimingField(phase)] = durationMs
+}
+
+export function mergePublishPhaseTimings(
+	...parts: Array<PublishPhaseTimings | undefined>
+): PublishPhaseTimings {
+	const merged: PublishPhaseTimings = {}
+	for (const part of parts) {
+		if (!part) continue
+		for (const field of publishPhaseTimingFields) {
+			const value = part[field]
+			if (value !== undefined) {
+				merged[field] = value
+			}
+		}
+	}
+	return merged
+}
+
+export function withPublishAttemptTotalMs(
+	timings: PublishPhaseTimings,
+	startedAt: number,
+	endedAt = Date.now(),
+): PublishPhaseTimings {
+	return {
+		...timings,
+		total_ms: Math.max(0, endedAt - startedAt),
+	}
+}
+
+export function attachPublishPhaseTimings<
+	T extends { status: string; phase_timings?: PublishPhaseTimings },
+>(result: T, phaseTimings: PublishPhaseTimings): T {
+	if (result.status !== 'already_published' && result.status !== 'published') {
+		return result
+	}
+	if (Object.keys(phaseTimings).length === 0) {
+		return result
+	}
+	return {
+		...result,
+		phase_timings: phaseTimings,
+	}
+}
+
 export function logPublishExternalPushPhase(input: {
 	phase: PublishExternalPushPhase
 	durationMs: number
@@ -33,6 +125,7 @@ export async function timePublishExternalPushPhase<T>(
 		phase: PublishExternalPushPhase
 		sourceId?: string
 		publishedCommit?: string
+		timings?: PublishPhaseTimings
 	},
 	work: () => Promise<T>,
 ): Promise<{ value: T; durationMs: number }> {
@@ -47,6 +140,9 @@ export async function timePublishExternalPushPhase<T>(
 				? { publishedCommit: input.publishedCommit }
 				: {}),
 		})
+		if (input.timings) {
+			recordPublishPhaseTiming(input.timings, input.phase, durationMs)
+		}
 		return durationMs
 	}
 	try {

--- a/packages/worker/src/repo/repo-session-do-publish.node.test.ts
+++ b/packages/worker/src/repo/repo-session-do-publish.node.test.ts
@@ -489,6 +489,14 @@ test('publishFromExternalRef checks fast-forward ancestry through ephemeral clon
 	})
 
 	expect(result.status).toBe('published')
+	expect(result).toEqual(
+		expect.objectContaining({
+			status: 'published',
+			phase_timings: expect.objectContaining({
+				clone_ms: expect.any(Number),
+			}),
+		}),
+	)
 	expect(mockModule.workspaceGlob).not.toHaveBeenCalled()
 	expect(isAncestorCommit).toHaveBeenCalledWith({
 		ancestor: 'commit-old',
@@ -1018,6 +1026,9 @@ test('already_published external publish refreshes the snapshot from the in-memo
 		status: 'already_published',
 		published_commit: 'commit-new',
 		force_artifact_rebuild: false,
+		phase_timings: {
+			clone_ms: expect.any(Number),
+		},
 	})
 	expect(mockModule.updateEntitySource).not.toHaveBeenCalled()
 	expect(mockModule.runRepoChecks).not.toHaveBeenCalled()
@@ -1104,6 +1115,9 @@ test('already_published external publish skips snapshot rewrite and force rebuil
 		status: 'already_published',
 		published_commit: 'commit-new',
 		force_artifact_rebuild: false,
+		phase_timings: {
+			clone_ms: expect.any(Number),
+		},
 	})
 	expect(collectFiles).toHaveBeenCalledTimes(1)
 	expect(mockModule.writePublishedSourceSnapshot).not.toHaveBeenCalled()
@@ -1184,6 +1198,9 @@ test('already_published external publish invalidates leftovers on snapshot misma
 		status: 'already_published',
 		published_commit: 'commit-new',
 		force_artifact_rebuild: true,
+		phase_timings: {
+			clone_ms: expect.any(Number),
+		},
 	})
 	expect(mockModule.deletePublishedArtifactsForSource).not.toHaveBeenCalled()
 	expect(mockModule.writePublishedSourceSnapshot).toHaveBeenCalledWith(

--- a/packages/worker/src/repo/repo-session-do.ts
+++ b/packages/worker/src/repo/repo-session-do.ts
@@ -107,7 +107,11 @@ import {
 	externalPublishWorkspaceDir,
 	isWorkspaceSqliteTooBigMessage,
 } from './external-publish-clone.ts'
-import { timePublishExternalPushPhase } from './publish-phase-timing.ts'
+import {
+	attachPublishPhaseTimings,
+	timePublishExternalPushPhase,
+	type PublishPhaseTimings,
+} from './publish-phase-timing.ts'
 import {
 	buildRepoSessionWorkspaceName,
 	measureRepoSessionWorkspaceBlobBytes,
@@ -2935,12 +2939,13 @@ class RepoSessionBase extends DurableObject<Env> {
 			scope: 'read',
 		})
 		const targetBranch = sourceInfo?.defaultBranch ?? defaultSessionBranch
+		const phaseTimings: PublishPhaseTimings = {}
 		let publishClone: Awaited<ReturnType<typeof cloneExternalPublishWorkspace>>
 		try {
 			// In-memory clone: publish verification does not need the session
 			// Durable Object workspace (KODY-CLOUDFLARE-57).
 			;({ value: publishClone } = await timePublishExternalPushPhase(
-				{ phase: 'clone', sourceId: source.id },
+				{ phase: 'clone', sourceId: source.id, timings: phaseTimings },
 				async () => {
 					const cloned = await cloneExternalPublishWorkspace({
 						remote: sourceAccess.remote,
@@ -3004,6 +3009,7 @@ class RepoSessionBase extends DurableObject<Env> {
 			rebuildPackageArtifacts: input.rebuildPackageArtifacts ?? true,
 			expectedPackageScope: input.expectedPackageScope,
 			allowLockedPublish: input.allowLockedPublish,
+			phaseTimings,
 		})
 		if (publishResult.status === 'already_published') {
 			// D1 stays a no-op (overlapping inline + durable escalation). Rewrite
@@ -3068,10 +3074,13 @@ class RepoSessionBase extends DurableObject<Env> {
 				})
 				throw error
 			}
-			return {
-				...publishResult,
-				force_artifact_rebuild: forceArtifactRebuild,
-			}
+			return attachPublishPhaseTimings(
+				{
+					...publishResult,
+					force_artifact_rebuild: forceArtifactRebuild,
+				},
+				phaseTimings,
+			)
 		} else if (publishResult.status === 'published') {
 			try {
 				const sourceWriteAccess = await ensureArtifactRepoRemote({
@@ -3125,7 +3134,7 @@ class RepoSessionBase extends DurableObject<Env> {
 				})
 			}
 		}
-		return publishResult
+		return attachPublishPhaseTimings(publishResult, phaseTimings)
 	}
 }
 

--- a/packages/worker/src/repo/types.ts
+++ b/packages/worker/src/repo/types.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod'
 import { type AuthoredPackageJson } from '#worker/package-registry/types.ts'
 import { type ServerTimingEntry } from '#worker/server-timing.ts'
+import { type PublishPhaseTimings } from './publish-phase-timing.ts'
 
 export const entityKindValues = ['job', 'package', 'repo'] as const
 export type EntityKind = (typeof entityKindValues)[number]
@@ -344,6 +345,7 @@ export type RepoExternalPublishResult =
 			 * cannot keep serving. Omit / false when the snapshot already matches.
 			 */
 			force_artifact_rebuild?: boolean
+			phase_timings?: PublishPhaseTimings
 	  }
 	| {
 			status: 'not_fast_forward'
@@ -364,6 +366,7 @@ export type RepoExternalPublishResult =
 			published_commit: string
 			manifest: AuthoredPackageJson
 			checks: NonNullable<RepoSessionCheckStatus['results']>
+			phase_timings?: PublishPhaseTimings
 	  }
 	| {
 			status: 'locked'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Give agents coarse `packagePublishExternalPush` phase timings on the capability JSON they already get, so publish-latency probes no longer depend on worker logs or empty `runList` rows.

## Why

#2084 added structured logs/progress for `clone`, `checks/typecheck`, `checks/bundle`, `rebuild`, and `dependents`, but production agents cannot see those clocks: the capability response had no timing fields, package `runList` is empty, publish notes do not carry timings, and CF Log Explorer from MCP cannot read the worker datasets.

## Summary

- Reuse the existing `publish-phase-timing` collector from #2084.
- Thread clone/typecheck/bundle durations through the RepoSession publish RPC.
- Attach `phase_timings` on `published` and `already_published` (and `total_ms` on `dispatched` as time-to-dispatch).
- Stable fields: `clone_ms`, `checks_typecheck_ms`, `checks_bundle_ms`, `rebuild_ms`, `dependents_ms`, `total_ms`. Omitted keys did not run. `checks_bundle_ms` and `rebuild_ms` stay separate.
- No rebuild/check-behavior change, no escalation-budget change, no dependent fan-out.

## Testing

- Local `npm run validate` exit 0 (format, lint, typecheck, node, workers, e2e, mcp, docs).
- Focused node-unit: `publish-external-push` + `publish-phase-timing` (12 tests) covering `published`, `already_published`, and forwarded clone/check clocks without collapsing bundle vs rebuild.
- Push hook: `test:node` 2663 passed, `test:workers` 330 passed.
- Bugbot: no new issues on `2b2d55e5`.
- Preview https://kody-pr-2085.kody-a99.workers.dev: `/health` is the merge of `2b2d55e5`, seed login works, `GET /account/packages.json` 200, `/mcp` 401 without OAuth (expected). `phase_timings` is on the MCP capability result, not an HTML route.

## How agents read timings

Call `packagePublishExternalPush`. On `published` / `already_published`, read `result.phase_timings`. Omitted keys did not run. `dispatched` has `phase_timings.total_ms` as time-to-dispatch.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `4a8b7107` · **Head:** `2b2d55e5`

**Classification:** extends — `packagePublishExternalPush` output contract and the RepoSession publish RPC now carry coarse phase timings. No new primitive.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `saved-packages` | assistant | extends — capability JSON gains `phase_timings` |
| `repo-sessions` | runtime | extends — clone/check clocks return on publish RPC |

### Change flow

Agents read `phase_timings` on the `packagePublishExternalPush` result. The RepoSession hop records clone and check phases, then the capability adds rebuild, dependents, and total.

```mermaid
sequenceDiagram
	actor Agent
	participant savedPackages as saved-packages
	participant repoSessions as repo-sessions
	Agent->>savedPackages: packagePublishExternalPush
	savedPackages->>repoSessions: publishFromExternalRef collects clone and check ms
	repoSessions-->>savedPackages: published or already_published plus phase_timings
	Note over savedPackages: add rebuild_ms, dependents_ms, total_ms
	savedPackages-->>Agent: result.phase_timings on the capability JSON
```

### Before / after

```text
before: { status: "published", published_commit, static_dependents, ... }
after:  { status: "published", ..., phase_timings: { clone_ms?, checks_typecheck_ms?, checks_bundle_ms?, rebuild_ms?, dependents_ms?, total_ms? } }
```

`dispatched` includes `{ phase_timings: { total_ms } }` as time-to-dispatch.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-040d0644-9ed2-481a-a43e-4c6974f17547?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-040d0644-9ed2-481a-a43e-4c6974f17547&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Package publishing results now include optional phase timing metrics for cloning, checks, rebuilding, dependents, and total duration.
  - Dispatched publishing results report the total time taken to dispatch the workflow.
  - Timing fields distinguish bundle checks from the subsequent artifact rebuild.

- **Documentation**
  - Updated package publishing guidance to explain timing fields, omitted phases, and where timing data is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->