### PR TITLE
Remove “This is how the world sees you.” from the profile

### DIFF
--- a/packages/worker/client/routes/profile-identity.node.test.ts
+++ b/packages/worker/client/routes/profile-identity.node.test.ts
@@ -30,7 +30,7 @@ test('profile identity renders the person in HTML and keeps guest CTAs honest', 
 	expect(ownHtml).toContain('Joined March 1, 2026')
 	expect(ownHtml).toContain('Edit profile')
 	expect(ownHtml).toContain(`href="${routes.account.href()}"`)
-	expect(ownHtml).toContain('This is how the world sees you.')
+	expect(ownHtml).not.toContain('This is how the world sees you.')
 	expect(ownHtml).not.toContain('Connect your agent')
 	expect(ownHtml).not.toContain('data-testid="profile-guest-cta"')
 	expect(ownHtml).not.toContain('data-testid="profile-private-badge"')

--- a/packages/worker/client/routes/profile-identity.tsx
+++ b/packages/worker/client/routes/profile-identity.tsx
@@ -57,7 +57,6 @@ export function renderProfileIdentity(shell: ProfileShellLoaderData) {
 						<a href={routes.account.href()} mix={css(getGhostButtonCss())}>
 							Edit profile
 						</a>
-						<p mix={css(selfHintCss)}>This is how the world sees you.</p>
 					</div>
 				) : null}
 				{!shell.loggedIn
@@ -161,12 +160,6 @@ const actionsCss = {
 	gap: spacing.sm,
 	justifyItems: 'start',
 	marginTop: spacing.xs,
-}
-
-const selfHintCss = {
-	margin: 0,
-	color: colors.textMuted,
-	fontSize: typography.fontSize.sm,
 }
 
 const guestCtaCss = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop telling the signed-in owner “This is how the world sees you.” on their public profile.

## Why

The owner already knows they are looking at their own page. The line adds nothing next to Edit profile.

## Summary

- Drop the self-hint paragraph from the profile identity header.
- Keep Edit profile.
- Assert the copy is gone in the identity unit test.

## Testing

- `npm run test:push` on push (node 2671, workers 330).
- Browser: signed-in `/@jane` shows Edit profile and does not show the hint.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `11f4022b` · **Head:** `6832e05a`

**Classification:** composes — no primitives added or changed; this PR removes owner-only copy from the existing profile header.

### Primitives touched

| Primitive | Group    | Impact   |
| --------- | -------- | -------- |
| `app-ui`  | surfaces | composes |

### Change flow

The owner profile header keeps Edit profile and omits the self hint.

```mermaid
sequenceDiagram
	actor Owner
	participant appUi as app-ui
	Owner->>appUi: GET /@username as self
	appUi-->>Owner: identity with Edit profile, no self hint
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a5f488d8-35eb-4633-b2c9-d1b8ff7e25cd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a5f488d8-35eb-4633-b2c9-d1b8ff7e25cd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI Changes**
  - Removed the “This is how the world sees you.” hint from the public self-profile view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->