### PR TITLE
Add an Account link to the left of the desktop header avatar

### DIFF
--- a/.agents/skills/control-kody/references/features/account.md
+++ b/.agents/skills/control-kody/references/features/account.md
@@ -1,8 +1,10 @@
 # Account hub
 
 Signed-in home: profile, export, logout, delete, and links to the other account
-surfaces. Logout lives at the bottom of this page, not in the site header. The
-header avatar goes to the public profile (`/@username`).
+surfaces. Logout lives at the bottom of this page, not in the site header.
+Desktop puts an Account link in the header to the left of the avatar; narrower
+viewports keep Account in the menu panel. The header avatar goes to the public
+profile (`/@username`).
 
 ## How to get there
 

--- a/docs/use/waiting.md
+++ b/docs/use/waiting.md
@@ -1,8 +1,9 @@
 # Waiting
 
 Waiting is the current-state queue of things only **you** can clear. Open
-**`/account/waiting`** from Account while signed in. The header avatar goes to
-your public profile (`/@username`).
+**`/account/waiting`** from Account while signed in. Desktop puts Account in the
+header to the left of the avatar; the avatar goes to your public profile
+(`/@username`).
 
 Items are derived from live account state. They disappear when the gate clears.
 There is no read/unread mark, archive, or notification table.

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -34,7 +34,14 @@ test('smoke test covers shell, auth redirect, and login', async ({ page }) => {
 
 	await expect(page).toHaveURL(/\/account$/)
 	// Header avatar links to the public profile and is labeled @username so
-	// it does not collide with the "Kody" brand link.
+	// it does not collide with the "Kody" brand link. Desktop also shows
+	// Account to the left of that avatar.
+	await expect(
+		page.getByRole('navigation', { name: 'Main' }).getByRole('link', {
+			name: 'Account',
+			exact: true,
+		}),
+	).toBeVisible()
 	await expect(
 		page.getByRole('navigation', { name: 'Main' }).getByRole('link', {
 			name: `@${primaryTestUser.username}`,

--- a/packages/worker/client/site-header.node.test.ts
+++ b/packages/worker/client/site-header.node.test.ts
@@ -33,7 +33,7 @@ test('dismissOpenPopoverPanel hides open popovers and no-ops when unavailable or
 	expect(closedHidePopover).not.toHaveBeenCalled()
 })
 
-test('logged-in avatar and mobile menu go to the public profile with the username', async () => {
+test('logged-in header shows Account to the left of the profile avatar', async () => {
 	const html = await renderToString(
 		jsx(SiteHeader, {
 			loggedIn: true,
@@ -52,4 +52,35 @@ test('logged-in avatar and mobile menu go to the public profile with the usernam
 	expect(html).toContain('data-testid="site-header-profile"')
 	expect(html).toContain('data-testid="site-header-profile-menu"')
 	expect(html).toMatch(/site-header-profile-menu[\s\S]*?>ada</)
+
+	const accountTestIdAt = html.indexOf('data-testid="site-header-account"')
+	const profileTestIdAt = html.indexOf('data-testid="site-header-profile"')
+	expect(accountTestIdAt).toBeGreaterThan(-1)
+	expect(profileTestIdAt).toBeGreaterThan(accountTestIdAt)
+	const desktopAccountTag = html.slice(
+		html.lastIndexOf('<a', accountTestIdAt),
+		html.indexOf('>', accountTestIdAt) + 1,
+	)
+	expect(desktopAccountTag).toContain('href="/account"')
+	expect(desktopAccountTag).toContain('aria-current="page"')
+})
+
+test('logged-out header shows Log in without an Account link', async () => {
+	const html = await renderToString(
+		jsx(SiteHeader, {
+			loggedIn: false,
+			displayName: '',
+			username: '',
+			avatarUrl: null,
+			showAdminLink: false,
+			showDemoIndicator: false,
+			loginHref: '/login',
+			currentPathname: '/',
+		}),
+	)
+
+	expect(html).toContain('href="/login"')
+	expect(html).toContain('>Log in</a>')
+	expect(html).not.toContain('data-testid="site-header-account"')
+	expect(html).not.toContain('data-testid="site-header-account-menu"')
 })

--- a/packages/worker/client/site-header.tsx
+++ b/packages/worker/client/site-header.tsx
@@ -30,8 +30,9 @@ export type SiteHeaderProps = {
 
 /**
  * Sticky site header from the heykody.dev redesign: brand, marketing nav
- * (Community · Pricing · Blog), and the session corner. The bottom hairline
- * is a static CSS border so it paints before JS.
+ * (Community · Guides · Pricing · Blog), and the session corner (Account
+ * then the avatar on desktop). The bottom hairline is a static CSS border so
+ * it paints before JS.
  */
 const marketingLinks = [
 	{ href: '/community', label: 'Community' },
@@ -129,6 +130,17 @@ export function SiteHeader(handle: Handle<SiteHeaderProps>) {
 					<div mix={css(navActionsCss)}>
 						{handle.props.loggedIn ? (
 							<>
+								<a
+									href={routes.account.href()}
+									aria-current={ariaCurrent(
+										handle.props.currentPathname,
+										routes.account.href(),
+									)}
+									data-testid="site-header-account"
+									mix={css(navAccountCss)}
+								>
+									Account
+								</a>
 								{profileHref ? (
 									<a
 										href={profileHref}
@@ -225,12 +237,11 @@ export function SiteHeader(handle: Handle<SiteHeaderProps>) {
 										</a>
 									) : null}
 									<a
-										href="/account"
-										aria-current={
-											handle.props.currentPathname === '/account'
-												? 'page'
-												: undefined
-										}
+										href={routes.account.href()}
+										aria-current={ariaCurrent(
+											handle.props.currentPathname,
+											routes.account.href(),
+										)}
 										data-testid="site-header-account-menu"
 									>
 										Account
@@ -461,6 +472,17 @@ const navLoginCss = {
 	padding: '0.7rem 0.25rem',
 	whiteSpace: 'nowrap' as const,
 	'&:hover': { color: colors.primaryText },
+}
+
+const navAccountCss = {
+	color: colors.textMuted,
+	textDecoration: 'none',
+	fontWeight: 500,
+	fontSize: '0.98rem',
+	whiteSpace: 'nowrap' as const,
+	transition: `color ${transitions.fast}`,
+	'&:hover': { color: colors.text },
+	'&[aria-current="page"]': { color: colors.text },
 }
 
 const navUserAvatarCss = {

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -402,6 +402,7 @@ test('SSR HTML routes render page content and embedded loader data', async () =>
 	expect(accountResponse.status).toBe(200)
 	const accountHtml = await readResponseText(accountResponse)
 	expect(accountHtml).toContain('aria-label="Account sections"')
+	expect(accountHtml).toContain('data-testid="site-header-account"')
 	expect(accountHtml).toContain('data-testid="site-header-profile"')
 	expect(accountHtml).toContain('data-testid="site-header-account-menu"')
 	expect(accountHtml).toContain('href="/@account-user"')


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Give signed-in desktop visitors a direct header path to `/account` without opening the mobile menu or going through the public profile.

## Why

The desktop session corner only linked the avatar to `/@username`. Account lived in the hamburger panel, which desktop never shows. There was no way to reach the account hub from the header at a wide viewport.

## Summary

- Add an **Account** link in the desktop session corner, immediately left of the avatar.
- Keep the avatar on the public profile (`/@username`).
- Hide that session corner at the existing `820px` breakpoint; the menu panel still has Account.
- Mark Account as the current page on `/account` and its subpaths, matching the other header section links.

## Testing

- Node-unit: `site-header.node.test.ts` (Account before avatar, logged-out has no Account) and the account SSR assertion in `ssr-render.node.test.ts`
- Push hook: `npm run test:node` (2672) and `npm run test:workers` (330)
- Signed-in origin HTML as `jane@example.com`: desktop tag is `<a href="/account" … data-testid="site-header-account">` immediately before the `@jane` avatar
- Browser: desktop header shows Account left of the avatar; avatar still opens `/@jane`; at 700px Account is only in the menu panel

![Desktop header with Account left of the avatar](https://cursor.com/artifacts/c/art-a2ff2e4e-e8a4-41aa-82b8-d8990e16b488)
![Public profile still shows Account left of the avatar](https://cursor.com/artifacts/c/art-1c125b66-3d7e-4e88-987b-656186863cb2)
<a href="https://cursor.com/agents/bc-3d8f7c03-fb15-4e26-b400-1f82d4ef1d5a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdesktop_header_account_left_of_avatar.mp4"><img src="https://cursor.com/artifacts/c/art-f9303f7e-77fd-43a7-b447-b48b69386d93" alt="desktop_header_account_left_of_avatar.mp4" /></a>

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `11f4022b` · **Head:** `012e9684`

**Classification:** composes — no primitives added or changed; this PR adds a header link that already exists on the account route.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `app-ui` | surfaces | composes — desktop session-corner link to `/account` |

### Change flow

Signed-in desktop visitors reach `/account` from the header; the avatar still opens the public profile.

```mermaid
sequenceDiagram
	actor User
	participant appUi as app-ui
	User->>appUi: click Account left of the avatar
	appUi->>User: GET /account
	Note over appUi: avatar still links to /@username
```

### Before / after

| Viewport | Before | After |
| -------- | ------ | ----- |
| Desktop (`min-width: 821px`) | Avatar only in the session corner | Account, then avatar |
| Narrower | Account in the menu panel | Unchanged |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3d8f7c03-fb15-4e26-b400-1f82d4ef1d5a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3d8f7c03-fb15-4e26-b400-1f82d4ef1d5a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a **Guides** link to the marketing navigation.
  - Added a desktop **Account** link beside the profile avatar for signed-in users.
  - Kept Account accessible through the menu on narrower screens.
  - Logged-out users now see a **Log in** link without Account navigation.

- **Documentation**
  - Clarified how to access Account and Waiting pages across desktop and mobile layouts.

- **Tests**
  - Expanded coverage for header navigation, authentication states, and server-rendered Account pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->