### PR TITLE
Soften onboarding UX: Codex one-click, 1Password login, trusted @kody installs

### DIFF
--- a/docs/contributing/community-packages.md
+++ b/docs/contributing/community-packages.md
@@ -216,7 +216,8 @@ pass, `refreshSavedPackageProjection` — the same projection step
 `repoPublishSession` ends with, so declared jobs are scheduled immediately. When
 checks fail (typically cross-scope imports), the fork stays inert and the
 failing checks are returned for agent follow-up. The HTTP surface is
-`POST /community/:listingId/install.json` (authenticated); callers must send
+`POST /community/:listingId/install.json` (authenticated). Official `@kody/*`
+listings skip acknowledgement. Third-party listings must send
 `acknowledged: true` or the handler responds `409`. There is intentionally
 **no** MCP capability for install: agents must go through `communityFork` +
 repo-session review, so a prompt-injected agent cannot silently activate

--- a/docs/use/community-packages.md
+++ b/docs/use/community-packages.md
@@ -133,9 +133,12 @@ behind-upstream banner clears.
 ## One-click install
 
 Each listing detail page has an **Install** pill for signed-in users. Logged-out
-visitors get the same pill as a login link. Every public install asks for one
-generic confirm (`acknowledged: true` on
+visitors get the same pill as a login link. Official `@kody/*` listings install
+on the first click — they are first-party platform packages and skip the
+confirm. Third-party listings still ask once (`acknowledged: true` on
 `POST /community/:listingId/install.json`, or the endpoint responds `409`).
+After install, the page shows **Open package** (or **Open fork**) and **Use in
+agent** so you are not left on a dead listing.
 
 If you already have a saved package with the same slug, or a fork of that
 listing, cards and the detail page show **Installed** or **Forked** instead.

--- a/docs/use/connect-your-agent.md
+++ b/docs/use/connect-your-agent.md
@@ -75,8 +75,10 @@ you only have the MCP URL.
   under ChatGPT's 10 KB limit) — right-click Save as on the connect page, then
   upload it. The owner can edit a developer-mode app's name and logo later from
   Manage in Apps settings. ChatGPT desktop is Codex — use that entry instead.
-- **Codex** — ChatGPT desktop is Codex. After the CLI writes the shared config,
-  run `codex mcp login kody` if OAuth does not start. Manual includes
+- **Codex** — ChatGPT desktop is Codex. Get started offers **Open Codex**
+  (`codex://mcp/add?name=kody&url=<url>`) so the desktop app launches when that
+  protocol is registered. After the CLI writes the shared config, run
+  `codex mcp login kody` if OAuth does not start. Manual includes
   `codex mcp add kody --url <url>` and the shared `~/.codex/config.toml`
   `[mcp_servers.kody]` `url` entry. If Codex asks you to log in again after
   about an hour, see

--- a/packages/worker/client/routes/community-detail-install.ts
+++ b/packages/worker/client/routes/community-detail-install.ts
@@ -9,11 +9,13 @@ export type CommunityInstallClickDecision = 'ignore' | 'submit' | 'confirm'
 /**
  * The Install pill lives in the server frame, so it stays clickable while
  * the client is submitting, confirming, or waiting for a reload. Ignore
- * those clicks. Every install takes one generic confirm.
+ * those clicks. Official `@kody/*` listings install on the first click;
+ * third-party listings still take one generic confirm.
  */
 export function decideCommunityInstallClick(input: {
 	installState: CommunityInstallUiState
 	alreadyInstalled: boolean
+	official?: boolean
 }): CommunityInstallClickDecision {
 	if (input.alreadyInstalled) return 'ignore'
 	switch (input.installState) {
@@ -22,7 +24,7 @@ export function decideCommunityInstallClick(input: {
 			return 'ignore'
 		case 'idle':
 		case 'error':
-			return 'confirm'
+			return input.official ? 'submit' : 'confirm'
 		default: {
 			const exhaustive: never = input.installState
 			throw new Error(`Unhandled install state: ${String(exhaustive)}`)

--- a/packages/worker/client/routes/community-detail-sections.tsx
+++ b/packages/worker/client/routes/community-detail-sections.tsx
@@ -4,6 +4,8 @@ import {
 	ActionButtonLoader,
 	installProgressWords,
 } from '#client/action-button-loader.tsx'
+import { CopyTextButton } from '#client/copy-text-button.tsx'
+import { getCommunityPackageHrefFromName } from '#universal/community-links.ts'
 import { routes } from '#universal/routes.ts'
 import {
 	type AccountPackageDetail,
@@ -15,7 +17,6 @@ import {
 	getGhostButtonCss,
 	getPillButtonCss,
 	getSurfaceCardCss,
-	hoverMq,
 	mergeCss,
 	pageHeadCss,
 	proseCss,
@@ -113,6 +114,9 @@ export function renderInstallStrip(props: InstallStripProps) {
 			? `Installed as ${props.installOutcome.targetName}.`
 			: `Forked as ${props.installOutcome.targetName}; it needs adaptation before it can run.`
 		: ''
+	const installedPackageHref = props.installOutcome
+		? getCommunityPackageHrefFromName(props.installOutcome.targetName)
+		: null
 	return (
 		<div data-testid="community-install" mix={css(installStripCss)}>
 			<p role="status" mix={css(visuallyHiddenCss)}>
@@ -125,20 +129,19 @@ export function renderInstallStrip(props: InstallStripProps) {
 			) : null}
 			{props.installState === 'confirming' ? (
 				<div
-					mix={css(warningCardCss)}
+					mix={css(cautionCardCss)}
 					data-testid="community-install-warning"
-					role="alert"
+					role="status"
 				>
 					<p mix={css({ margin: 0 })}>
-						This is someone else&apos;s code. It can run in your account.
-						Installing creates a fork you own. It can need adaptation before it
-						can run. Confirm to continue.
+						This listing is from another account. Installing creates a fork you
+						own. It can need adaptation before it can run.
 					</p>
 					<div mix={css(buttonRowCss)}>
 						<button
 							mix={[
 								on('click', props.onConfirmInstall),
-								css(dangerPillButtonCss),
+								css(primaryPillButtonCss),
 							]}
 						>
 							Install
@@ -151,6 +154,42 @@ export function renderInstallStrip(props: InstallStripProps) {
 						>
 							Cancel
 						</button>
+					</div>
+				</div>
+			) : null}
+			{props.installOutcome ? (
+				<div
+					data-testid="community-install-next-steps"
+					mix={css(nextStepsCardCss)}
+				>
+					<p mix={css({ margin: 0 })} aria-hidden="true">
+						{installAnnouncement}
+					</p>
+					<div mix={css(buttonRowCss)}>
+						{installedPackageHref ? (
+							<a href={installedPackageHref} mix={css(primaryPillLinkCss)}>
+								{props.installOutcome.status === 'installed'
+									? 'Open package'
+									: 'Open fork'}
+							</a>
+						) : (
+							<a
+								href={routes.accountPackages.href()}
+								mix={css(primaryPillLinkCss)}
+							>
+								Open packages
+							</a>
+						)}
+						<CopyTextButton
+							value={props.installOutcome.agentPrompt}
+							idleLabel={
+								props.installOutcome.status === 'installed'
+									? 'Use in agent'
+									: 'Copy setup prompt'
+							}
+							variant="ghost"
+							size="sm"
+						/>
 					</div>
 				</div>
 			) : null}
@@ -397,22 +436,29 @@ const smallGhostButtonCss = mergeCss(getGhostButtonCss(), {
 	padding: '0.75rem 1.3rem',
 })
 
-/* The pill grammar in the danger voice for the untrusted-install confirm. */
-const dangerPillButtonCss = mergeCss(getPillButtonCss(), {
-	backgroundColor: colors.danger,
-	color: colors.onDanger,
-	[hoverMq]: {
-		'&:not(:disabled):hover': {
-			backgroundColor: colors.dangerHover,
-			color: colors.onDanger,
-			boxShadow: `0 6px 20px -8px oklch(from ${colors.danger} l c h / 0.6)`,
-		},
+const primaryPillButtonCss = getPillButtonCss()
+const primaryPillLinkCss = mergeCss(getPillButtonCss(), {
+	textDecoration: 'none',
+	display: 'inline-flex',
+	alignItems: 'center',
+})
+
+/** Gold/amber caution — same family as fork-outdated, not the danger voice. */
+const cautionAccent = 'oklch(0.72 0.14 85)'
+
+const cautionCardCss = mergeCss(getSurfaceCardCss(), {
+	marginTop: '1.2rem',
+	borderColor: cautionAccent,
+	padding: '1.1rem 1.3rem',
+	display: 'grid',
+	gap: '0.9rem',
+	'& p': {
+		fontSize: '0.95rem',
 	},
 })
 
-const warningCardCss = mergeCss(getSurfaceCardCss(), {
+const nextStepsCardCss = mergeCss(getSurfaceCardCss(), {
 	marginTop: '1.2rem',
-	borderColor: colors.danger,
 	padding: '1.1rem 1.3rem',
 	display: 'grid',
 	gap: '0.9rem',

--- a/packages/worker/client/routes/community-detail.node.test.ts
+++ b/packages/worker/client/routes/community-detail.node.test.ts
@@ -1,13 +1,22 @@
+import { renderToString } from 'remix/ui/server'
 import { expect, test } from 'vitest'
 import { decideCommunityInstallClick } from './community-detail-install.ts'
+import { renderInstallStrip } from './community-detail-sections.tsx'
 
-test('decideCommunityInstallClick covers idle confirm, ignore gates, and error retry', () => {
+test('decideCommunityInstallClick covers idle confirm, official submit, ignore gates, and error retry', () => {
 	expect(
 		decideCommunityInstallClick({
 			installState: 'idle',
 			alreadyInstalled: false,
 		}),
 	).toBe('confirm')
+	expect(
+		decideCommunityInstallClick({
+			installState: 'idle',
+			alreadyInstalled: false,
+			official: true,
+		}),
+	).toBe('submit')
 
 	expect(
 		decideCommunityInstallClick({
@@ -34,4 +43,46 @@ test('decideCommunityInstallClick covers idle confirm, ignore gates, and error r
 			alreadyInstalled: false,
 		}),
 	).toBe('confirm')
+	expect(
+		decideCommunityInstallClick({
+			installState: 'error',
+			alreadyInstalled: false,
+			official: true,
+		}),
+	).toBe('submit')
+})
+
+test('install strip shows next steps after a successful install', async () => {
+	const html = await renderToString(
+		renderInstallStrip({
+			installState: 'idle',
+			installMessage: null,
+			installOutcome: {
+				status: 'installed',
+				targetName: '@jane/notion-mcp',
+				agentPrompt: 'Call packageGet for @jane/notion-mcp.',
+				packageId: 'pkg-1',
+				failedChecks: [],
+			},
+			onConfirmInstall: () => {},
+			onCancelInstall: () => {},
+		}),
+	)
+	expect(html).toContain('data-testid="community-install-next-steps"')
+	expect(html).toContain('Installed as @jane/notion-mcp.')
+	expect(html).toContain('href="/@jane/notion-mcp"')
+	expect(html).toContain('Open package')
+	expect(html).toContain('Use in agent')
+
+	const confirmHtml = await renderToString(
+		renderInstallStrip({
+			installState: 'confirming',
+			installMessage: null,
+			installOutcome: null,
+			onConfirmInstall: () => {},
+			onCancelInstall: () => {},
+		}),
+	)
+	expect(confirmHtml).toContain('data-testid="community-install-warning"')
+	expect(confirmHtml).toContain('from another account')
 })

--- a/packages/worker/client/routes/community-detail.tsx
+++ b/packages/worker/client/routes/community-detail.tsx
@@ -357,6 +357,7 @@ export function CommunityDetailRoute(handle: Handle) {
 		const decision = decideCommunityInstallClick({
 			installState,
 			alreadyInstalled: installOutcome != null,
+			official: control.getAttribute('data-official') === 'true',
 		})
 		switch (decision) {
 			case 'ignore':

--- a/packages/worker/client/routes/login-sections.node.test.ts
+++ b/packages/worker/client/routes/login-sections.node.test.ts
@@ -32,6 +32,8 @@ test('credential errors associate the status message with email and password', a
 	expect(html).toMatch(
 		/id="auth-email"[^>]*aria-describedby="auth-form-status"/,
 	)
+	expect(html).toMatch(/id="auth-email"[^>]*type="email"/)
+	expect(html).toMatch(/id="auth-email"[^>]*autocomplete="username"/)
 	expect(html).not.toContain('id="auth-username"')
 })
 
@@ -51,6 +53,7 @@ test('username and invite errors mark only those fields', async () => {
 		}),
 	)
 	expect(usernameHtml).toMatch(/id="auth-username"[^>]*aria-invalid="true"/)
+	expect(usernameHtml).toMatch(/id="auth-email"[^>]*autocomplete="email"/)
 	expect(usernameHtml).not.toMatch(/id="auth-email"[^>]*aria-invalid/)
 
 	const inviteHtml = await renderToString(

--- a/packages/worker/client/routes/login-sections.tsx
+++ b/packages/worker/client/routes/login-sections.tsx
@@ -284,7 +284,11 @@ export function renderAuthForm(
 					name="email"
 					required
 					autoFocus={!props.isSignup}
-					autoComplete="email"
+					// Login uses username so vault entries that store the email
+					// in the username field (1Password's default) can autofill.
+					// Signup email stays email; the username field above is the
+					// Kody handle.
+					autoComplete={props.isSignup ? 'email' : 'username'}
 					placeholder="you@yourdomain.dev"
 					data-field-ring
 					{...fieldErrorProps('email', invalidFields, statusId)}

--- a/packages/worker/client/routes/onboarding-mcp-client-panels.tsx
+++ b/packages/worker/client/routes/onboarding-mcp-client-panels.tsx
@@ -2,6 +2,7 @@ import {
 	buildClaudeCodeAddCommand,
 	buildClaudeCodeMcpJson,
 	buildCodexMcpAddCommand,
+	buildCodexMcpDeepLink,
 	buildCodexMcpToml,
 	buildCopilotCliAddCommand,
 	buildCopilotCliMcpJson,
@@ -67,6 +68,7 @@ export function renderPanelContent(
 		}
 		case 'codex': {
 			const appIconUrl = buildKodyAppIconUrl(mcpServerUrl)
+			const codexDeepLink = buildCodexMcpDeepLink(mcpServerUrl)
 			const codexCommand = buildCodexMcpAddCommand(mcpServerUrl)
 			const codexToml = buildCodexMcpToml(mcpServerUrl)
 			if (surface === 'mobile') {
@@ -84,11 +86,13 @@ export function renderPanelContent(
 			}
 			return (
 				<>
+					<PrimaryActionLink href={codexDeepLink} label="Open Codex" />
 					<CopyCard
 						highlights={highlights}
 						label="codex CLI"
 						value={codexCommand}
 						copyLabel="Copy command"
+						variant="pill"
 						lang="sh"
 					/>
 					<CopyCardDetails

--- a/packages/worker/client/routes/onboarding-mcp-client-tabs.node.test.ts
+++ b/packages/worker/client/routes/onboarding-mcp-client-tabs.node.test.ts
@@ -6,6 +6,7 @@ import {
 	buildClaudeCodeAddCommand,
 	buildClaudeCodeMcpJson,
 	buildCodexMcpAddCommand,
+	buildCodexMcpDeepLink,
 	buildCodexMcpToml,
 	buildCopilotCliAddCommand,
 	buildCopilotCliMcpJson,
@@ -118,6 +119,10 @@ test('onboarding Step 1 picker selects an agent, then Not listed, and flips Grok
 		}),
 	)
 	expect(codexPreview).toContain(buildCodexMcpAddCommand(previewUrl))
+	expect(codexPreview).toContain(
+		`href="${buildCodexMcpDeepLink(previewUrl).replaceAll('&', '&amp;')}"`,
+	)
+	expect(codexPreview).toContain('>Open Codex<')
 	expect(codexPreview).not.toContain(kodyCursorMarketplaceUrl)
 
 	const grokBot = await renderToString(
@@ -205,6 +210,10 @@ test('onboarding alternative config wells collapse behind closed details', async
 		}),
 	)
 	expect(codex).toContain(buildCodexMcpAddCommand(url))
+	expect(codex).toContain(
+		`href="${buildCodexMcpDeepLink(url).replaceAll('&', '&amp;')}"`,
+	)
+	expect(codex).toContain('>Open Codex<')
 	expect(codex).toContain(buildCodexMcpToml(url))
 	expect(codex).toContain('Copy TOML')
 	expect(codex).toContain('Or merge this into')

--- a/packages/worker/client/routes/onboarding-mcp-clients.node.test.ts
+++ b/packages/worker/client/routes/onboarding-mcp-clients.node.test.ts
@@ -3,6 +3,7 @@ import {
 	buildClaudeCodeAddCommand,
 	buildClaudeCodeMcpJson,
 	buildCodexMcpAddCommand,
+	buildCodexMcpDeepLink,
 	buildCodexMcpToml,
 	buildCopilotCliAddCommand,
 	buildCopilotCliMcpJson,
@@ -126,6 +127,9 @@ test('onboarding MCP client builders emit the structured configs each host expec
 	)
 	expect(buildCodexMcpAddCommand(mcpServerUrl)).toBe(
 		`codex mcp add kody --url ${mcpServerUrl}`,
+	)
+	expect(buildCodexMcpDeepLink(mcpServerUrl)).toBe(
+		`codex://mcp/add?name=kody&url=${encodeURIComponent(mcpServerUrl)}`,
 	)
 	expect(buildOpenCodeMcpAddCommand(mcpServerUrl)).toBe(
 		`opencode mcp add kody --url ${mcpServerUrl}`,

--- a/packages/worker/src/app/community-detail-content.node.test.ts
+++ b/packages/worker/src/app/community-detail-content.node.test.ts
@@ -45,7 +45,23 @@ test('community detail head covers install, installed, and listing-ahead badges'
 	})
 	expect(installHtml).toContain('data-testid="community-detail-install"')
 	expect(installHtml).toContain('data-community-install')
+	expect(installHtml).toContain('data-official="false"')
 	expect(installHtml).toContain('data-trusted="false"')
+
+	const officialHtml = await renderCommunityDetailContentHtml({
+		...detailBase,
+		listing: {
+			...sampleListing,
+			name: '@kody/notion-mcp',
+			ownerUsername: 'kody',
+			kodyId: 'notion-mcp',
+		},
+		username: 'kody',
+		kodyId: 'notion-mcp',
+		returnTo: '/@kody/notion-mcp',
+		loggedIn: true,
+	})
+	expect(officialHtml).toContain('data-official="true"')
 
 	const agentPrompt =
 		'Call packageGet for @me/github-triage and adapt it to my needs.'

--- a/packages/worker/src/app/community-listings-content.tsx
+++ b/packages/worker/src/app/community-listings-content.tsx
@@ -22,7 +22,10 @@ import {
 	renderCopyPromptPill,
 } from '#universal/fork-outdated-copy-button.tsx'
 import { routes } from '#universal/routes.ts'
-import { getCommunityListingHref } from '#universal/community-links.ts'
+import {
+	getCommunityListingHref,
+	isOfficialCommunityListing,
+} from '#universal/community-links.ts'
 import { renderCommunityListingName } from '#universal/community-listing-name.tsx'
 import { communityStatusPillBoxCss } from '#universal/community-status-pill.ts'
 import {
@@ -355,6 +358,9 @@ export function renderCommunityViewerInstallBadge(input: {
 			type="button"
 			data-testid="community-detail-install"
 			data-community-install=""
+			data-official={
+				isOfficialCommunityListing(input.listing) ? 'true' : 'false'
+			}
 			data-trusted={input.listing.trusted ? 'true' : 'false'}
 			mix={css(communityInstallPillCss)}
 		>

--- a/packages/worker/src/app/handlers/community-install.node.test.ts
+++ b/packages/worker/src/app/handlers/community-install.node.test.ts
@@ -78,6 +78,7 @@ test('community install POST enforces gates and maps install outcomes', async ()
 
 	mockModule.getCommunityListingById.mockResolvedValue({
 		id: 'listing-1',
+		name: '@someone/demo',
 		trusted: false,
 		pinnedCommit: 'commit-1',
 	})
@@ -89,6 +90,39 @@ test('community install POST enforces gates and maps install outcomes', async ()
 	})
 	expect(mockModule.installCommunityListing).not.toHaveBeenCalled()
 
+	mockModule.getCommunityListingById.mockResolvedValue({
+		id: 'listing-official',
+		name: '@kody/notion-mcp',
+		trusted: false,
+		pinnedCommit: 'commit-1',
+	})
+	mockModule.getMcpUserPackageScope.mockResolvedValue('userb')
+	mockModule.installCommunityListing.mockResolvedValue({
+		status: 'installed',
+		forkId: 'fork-official',
+		packageId: 'package-official',
+		sourceId: 'source-official',
+		targetKodyId: 'notion-mcp',
+		targetName: '@userb/notion-mcp',
+		originCommit: 'commit-1',
+	})
+	const officialWithoutAck = await handler.handler(buildInstallRequest({}))
+	expect(officialWithoutAck.status).toBe(200)
+	expect(await officialWithoutAck.json()).toMatchObject({
+		ok: true,
+		status: 'installed',
+		targetName: '@userb/notion-mcp',
+	})
+	expect(mockModule.installCommunityListing).toHaveBeenCalledTimes(1)
+	mockModule.installCommunityListing.mockClear()
+
+	mockModule.getCommunityListingById.mockResolvedValue({
+		id: 'listing-1',
+		name: '@someone/demo',
+		trusted: false,
+		pinnedCommit: 'commit-1',
+	})
+
 	const invalidBody = await handler.handler(
 		buildInstallRequest({ acknowledged: 'yes' }),
 	)
@@ -96,7 +130,6 @@ test('community install POST enforces gates and maps install outcomes', async ()
 	expect(mockModule.installCommunityListing).not.toHaveBeenCalled()
 
 	mockModule.getMcpUserPackageScope.mockResolvedValue('userb')
-	// Community installs require an explicit acknowledgement on every listing.
 	mockModule.installCommunityListing.mockResolvedValue({
 		status: 'installed',
 		forkId: 'fork-1',

--- a/packages/worker/src/app/handlers/community-install.ts
+++ b/packages/worker/src/app/handlers/community-install.ts
@@ -7,6 +7,7 @@ import {
 	buildInstallAdaptPrompt,
 	buildInstallSuccessPrompt,
 } from '#app/community-public.ts'
+import { isOfficialCommunityListing } from '#universal/community-links.ts'
 import { type routes } from '#universal/routes.ts'
 import { CommunityActionError } from '#worker/community/errors.ts'
 import { installCommunityListing } from '#worker/community/install.ts'
@@ -23,7 +24,7 @@ const communityInstallPostSchema = z.object({
 })
 
 const thirdPartyInstallConfirmError =
-	"This is someone else's code and will run in your account. Confirm to install it."
+	'This listing is from another account. Confirm to install it.'
 
 export function createCommunityInstallApiPostHandler(env: Env) {
 	return {
@@ -54,10 +55,11 @@ export function createCommunityInstallApiPostHandler(env: Env) {
 					404,
 				)
 			}
-			// The UI shows the untrusted warning before calling this endpoint;
-			// this re-check keeps direct API calls behind the same explicit
-			// acknowledgement.
-			if (parsed.data.acknowledged !== true) {
+			// Official `@kody/*` listings are first-party and skip confirm.
+			// Third-party listings still need the explicit acknowledgement
+			// the UI shows before calling this endpoint.
+			const official = isOfficialCommunityListing({ name: listing.name })
+			if (!official && parsed.data.acknowledged !== true) {
 				return jsonResponse(
 					{
 						ok: false,

--- a/packages/worker/universal/community-links.node.test.ts
+++ b/packages/worker/universal/community-links.node.test.ts
@@ -1,5 +1,9 @@
 import { expect, test } from 'vitest'
-import { getCommunityListingHref } from '#universal/community-links.ts'
+import {
+	getCommunityListingHref,
+	getCommunityPackageHrefFromName,
+	isOfficialCommunityListing,
+} from '#universal/community-links.ts'
 
 test('community listing hrefs prefer the canonical pair and fall back to the id URL', () => {
 	expect(
@@ -31,4 +35,21 @@ test('community listing hrefs prefer the canonical pair and fall back to the id 
 			kodyId: null,
 		}),
 	).toBe('/community/listing-1')
+})
+
+test('official listings are the first-party @kody scope', () => {
+	expect(isOfficialCommunityListing({ name: '@kody/notion-mcp' })).toBe(true)
+	expect(isOfficialCommunityListing({ ownerUsername: 'kody' })).toBe(true)
+	expect(isOfficialCommunityListing({ ownerUsername: 'Kody' })).toBe(true)
+	expect(
+		isOfficialCommunityListing({
+			name: '@kentcdodds/github-triage',
+			ownerUsername: 'kentcdodds',
+		}),
+	).toBe(false)
+	expect(isOfficialCommunityListing({ name: 'unscoped' })).toBe(false)
+	expect(getCommunityPackageHrefFromName('@jane/hn-pulse')).toBe(
+		'/@jane/hn-pulse',
+	)
+	expect(getCommunityPackageHrefFromName('unscoped')).toBeNull()
 })

--- a/packages/worker/universal/community-links.ts
+++ b/packages/worker/universal/community-links.ts
@@ -8,6 +8,9 @@ export const kodyIssueTriageListingPath = '/@kentcdodds/kody-issue-triage'
 
 const scopedPackageNamePattern = /^@([a-z0-9][a-z0-9._-]*)\//
 
+/** Platform account that owns official first-party `@kody/*` listings. */
+export const officialCommunityOwnerUsername = 'kody'
+
 /**
  * Owner half of a scoped package name (`@owner/kody-id`), or null when the name
  * carries no scope. Listing names carry the owner, so surfaces that only hold a
@@ -16,6 +19,33 @@ const scopedPackageNamePattern = /^@([a-z0-9][a-z0-9._-]*)\//
 export function parseListingOwnerUsername(name: string) {
 	const match = scopedPackageNamePattern.exec(name.trim())
 	return match?.[1] ?? null
+}
+
+/**
+ * Official / first-party catalog listings (`@kody/*`). These skip the
+ * third-party install confirm — they are implicitly trusted.
+ */
+export function isOfficialCommunityListing(input: {
+	name?: string | null
+	ownerUsername?: string | null
+}) {
+	const owner =
+		input.ownerUsername?.trim().toLowerCase() ||
+		parseListingOwnerUsername(input.name ?? '') ||
+		''
+	return owner === officialCommunityOwnerUsername
+}
+
+/** Canonical `/@owner/kody-id` for a scoped package name, or null. */
+export function getCommunityPackageHrefFromName(name: string) {
+	const ownerUsername = parseListingOwnerUsername(name)
+	if (!ownerUsername) return null
+	const kodyId = name.trim().slice(`@${ownerUsername}/`.length)
+	if (!kodyId) return null
+	return routes.communityPackage.href({
+		username: ownerUsername,
+		kodyId,
+	})
 }
 
 /**

--- a/packages/worker/universal/onboarding-mcp-clients.ts
+++ b/packages/worker/universal/onboarding-mcp-clients.ts
@@ -534,6 +534,20 @@ export function buildClaudeCodeAddCommand(mcpServerUrl: string) {
 	return `claude mcp add --transport http -s user kody ${mcpServerUrl}`
 }
 
+/**
+ * Codex desktop registers `codex://` and launches on those URLs (OAuth
+ * callbacks use the same scheme). Prefill is not a documented public
+ * contract, so this opens the app with the MCP URL in the query and the
+ * CLI remains the install fallback.
+ */
+export function buildCodexMcpDeepLink(mcpServerUrl: string) {
+	const params = new URLSearchParams({
+		name: 'kody',
+		url: mcpServerUrl,
+	})
+	return `codex://mcp/add?${params}`
+}
+
 /** Codex CLI streamable HTTP add. OAuth may need `codex mcp login kody`. */
 export function buildCodexMcpAddCommand(mcpServerUrl: string) {
 	return `codex mcp add kody --url ${mcpServerUrl}`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Make first-time Codex connect, sign-in autofill, and official package install feel like Kody trusts its own path — not a copy-CLI / danger-zone detour.

## Why

Rick Terrill’s onboarding feedback: Codex only offered copy-CLI commands, 1Password failed to fill email stored as username, and official `@kody/*` installs used the same red “someone else’s code” double-check as third-party listings.

## Summary

- **Codex one-click:** Desktop Codex leads with **Open Codex** (`codex://mcp/add?name=kody&url=…`). The app launches when the protocol handler is registered. Copy CLI (now a primary pill) and TOML remain fallbacks. Mobile stays MCP URL + app icon.
- **Sign-in autofill:** Login email stays `type="email"` and `name="email"` but uses `autocomplete="username"` so 1Password vault entries that store the address in the username field can fill. Signup email stays `autocomplete="email"`.
- **Official `@kody/*` installs skip the double-check entirely.** `isOfficialCommunityListing` treats the first-party `@kody` scope as implicitly trusted. First click installs (client + `POST /community/:listingId/install.json` skip `acknowledged`). Third-party listings keep one lighter caution (amber, primary Install — not red “someone else’s code”). After install, the page shows **Open package** / **Open fork** and **Use in agent** instead of a dead listing.

## Screenshots

Preview origin: https://kody-pr-2091.kody-a99.workers.dev

**Codex one-click** (`/onboarding/step-1/codex`) — Open Codex is the primary action; CLI + TOML stay as fallbacks:

![Codex connect one-click on PR preview](https://cursor.com/artifacts/c/art-b6b1805e-b63a-4633-960a-7264b28a5481)

**Sign-in email field** — login email is focused and offered as a username-style autofill target (`autocomplete="username"`, still `type="email"` / `name="email"`):

![Login email field on PR preview](https://cursor.com/artifacts/c/art-983dc371-c1a2-4400-ac56-4c634f3a0a1c)

Signup email stays `autocomplete="email"`:

![Signup email field on PR preview](https://cursor.com/artifacts/c/art-510d4044-35ec-4bc0-a2a3-0e48860e37dc)

**Official `@kody/*` install** — first-click Install, no confirm card:

![Official @kody package install with no double-check](https://cursor.com/artifacts/c/art-5b069d8a-78b5-495b-8401-de001b86e5f7)

After that first click, next steps are **Open package** and **Use in agent**:

![Official install next steps card](https://cursor.com/artifacts/c/art-799b28da-bbf6-4578-8cf3-cbe8f3316a14)

Third-party listings still get one amber caution (not a red “someone else’s code” danger confirm):

![Third-party install amber caution](https://cursor.com/artifacts/c/art-5b9bc780-2c1f-4921-8381-0fbcbcde59ce)

Install-state shots are the same Remix render as the listing page (preview D1 has no community listings to click through). Login and Codex shots are the live preview.

## Testing

- Focused node-unit: community-links, community-detail, login-sections, onboarding MCP clients/tabs, community-install handler, community-detail-content.
- Pre-push: `test:node` (2682) and `test:workers` (330) green.
- CI: Validate (Static, Node, Workers, MCP, E2E) green. Bugbot: no issues.
- Preview: `npm run preview:manual-test` as `me@kentcdodds.com` — health/login/session, `GET /onboarding.json`, `GET /onboarding/step-1/codex` (Open Codex + `codex://mcp/add`), `GET /community.json`. HTML check: login `autocomplete="username"`.
- CodeRabbit asked to drop the `codex://` deep link as undocumented. Kept it: desktop registers the scheme; the comment in `buildCodexMcpDeepLink` already says prefill is not a public contract and the CLI remains the install fallback.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `45ab1923` · **Head:** `5d1c5883`

**Classification:** extends — official `@kody/*` listings skip the install acknowledgement that third-party listings still require.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | extends — Codex deep link, login autocomplete, official install chrome |
| `community-listings` | assistant | extends — first-party listings install without `acknowledged` |

### Change flow

Official `@kody/*` installs skip confirm; third-party listings still acknowledge once. Codex and login stay on the existing UI path.

```mermaid
sequenceDiagram
	actor User
	participant appUi as app-ui
	participant communityListings as community-listings
	User->>appUi: click Install on a listing
	appUi->>appUi: decideCommunityInstallClick official submit or confirm
	appUi->>communityListings: POST install.json
	alt official @kody listing
		communityListings->>communityListings: skip acknowledged
		communityListings-->>appUi: installed or adaptation_required
		appUi-->>User: Open package and Use in agent
	else third-party listing
		communityListings-->>appUi: 409 unless acknowledged
		appUi-->>User: lighter caution then primary Install
	end
```

### Before / after

| Surface | Before | After |
| --- | --- | --- |
| Codex desktop | Copy CLI + TOML only | Open Codex deep link, then copy CLI / TOML |
| Login email | `autocomplete="email"` | `autocomplete="username"` (`type="email"`) |
| Official install | Same confirm as third-party | First-click install, no danger copy |
| After install | Hidden status only | Open package + Use in agent |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-750f54dc-0f39-4e0d-b71d-e733b018c2e3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-750f54dc-0f39-4e0d-b71d-e733b018c2e3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Official community packages can now be installed immediately without confirmation.
  - Third-party package installs continue to require one-time acknowledgement.
  - Successful installs and forks now provide direct links to open the package or fork, plus a copyable agent prompt.
  - Added an **Open Codex** option for launching the ChatGPT desktop app during setup.

- **Usability**
  - Improved login autofill behavior for password managers.
  - Updated install warnings with clearer, less alarming styling and messaging.

- **Documentation**
  - Clarified official versus third-party install behavior and Codex setup instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->