### PR TITLE
Wait for Remix hydration before admin RBAC Assign clicks

### DIFF
--- a/e2e/admin-rbac.spec.ts
+++ b/e2e/admin-rbac.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from './playwright-utils.ts'
+import { expect, test, waitForClientHydration } from './playwright-utils.ts'
 
 test('admin RBAC controls access, role assignment, and privacy boundaries', async ({
 	page,
@@ -98,6 +98,9 @@ test('admin RBAC controls access, role assignment, and privacy boundaries', asyn
 
 	await page.goto(`/admin/users?q=rbac-${runId}`)
 	await page.getByRole('link', { name: memberUser.username }).click()
+	// Assign is type="button" + on('click'). Without hydration the click is a
+	// silent no-op and waitForResponse burns the 60s CI test timeout.
+	await waitForClientHydration(page)
 	const roleSelect = page.getByLabel('Role', { exact: true })
 	await roleSelect.selectOption('admin')
 	const assignRoleResponse = page.waitForResponse((response) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop the `admin-rbac` Playwright spec from flaking on CI when Assign is clicked before Remix hydration.

## Why

Validate run [33982542652](https://github.com/kentcdodds/kody/actions/runs/33982542652) failed the first E2E attempt, then passed on retry.

`e2e/admin-rbac.spec.ts` timed out at `page.waitForResponse` after `selectOption('admin')`. The Assign control is `type="button"` with an `on('click')` mixin (`admin-users-detail.tsx`). `waitForClientHydration` already documents that clicking a JS-only button before `data-hydrated` is a silent no-op — the same race `#1628` / `#1949` fixed in the two-factor and passkey specs.

Playwright recovered on retry (1 flaky, 9 passed). Nx then failed the job with `Misconfigured remote cache endpoint: Unexpected response status: 500`, which is why the workflow attempt itself failed. This PR fixes the test race, not the Nx cache 500.

No other open PR or live agent is fixing this flake.

## Summary

- Wait for `waitForClientHydration` after opening the user detail and before Role/Assign.
- Keep the existing `POST /admin/users.json` `assign_role` wait so cookies are not cleared mid-mutation.

## Testing

- `npx playwright test e2e/admin-rbac.spec.ts` (local, after PR open)
- CI Validate on this PR

## System recap

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `a1c4d0a7` · **Head:** `8b4b297f`

**Classification:** composes — Playwright spec only. No primitive code roots changed.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| _(none)_ | — | unmatched path `e2e/admin-rbac.spec.ts` |

### Change flow

The spec waits for Remix hydration before the JS-only Assign click so the role POST is actually sent.

```mermaid
sequenceDiagram
	actor Test as playwright
	participant appUi as app-ui
	Test->>appUi: open /admin/users user detail
	Test->>appUi: wait for html data-hydrated
	Test->>appUi: select Role admin and click Assign
	appUi-->>Test: POST /admin/users.json assign_role
```

### Before / after

| | Before | After |
| --- | --- | --- |
| Assign click | Can be a silent no-op pre-hydration, so `waitForResponse` hits the 60s timeout | Hydration is observed first, then Role/Assign |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8c4d4508-efb0-4ffc-ab00-223f98e5d773?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8c4d4508-efb0-4ffc-ab00-223f98e5d773&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved end-to-end test reliability by waiting for the page to finish loading before interacting with role assignment controls.
  - Preserved existing test behavior while preventing interactions from being missed during client-side initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->