### PR TITLE
Add Teams/Enterprise invite on the pricing page

### DIFF
--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -114,4 +114,7 @@ test('smoke test covers shell, auth redirect, and login', async ({ page }) => {
 	await expect(
 		page.getByRole('heading', { name: 'Pro', exact: true }),
 	).toBeVisible()
+	await expect(
+		page.getByRole('heading', { name: 'Teams / Enterprise', exact: true }),
+	).toBeVisible()
 })

--- a/packages/worker/client/routes/pricing.tsx
+++ b/packages/worker/client/routes/pricing.tsx
@@ -210,6 +210,29 @@ export function PricingRoute(handle: Handle) {
 						</p>
 						{renderPaidPlanCta(isSignedIn)}
 					</section>
+
+					{/*
+					 * Invite-only strip, not a fourth SKU. No price, no Max
+					 * column, no feature-matrix cells — Teams/Enterprise and
+					 * Max stay manual.
+					 */}
+					<section
+						aria-labelledby="plan-teams"
+						mix={[css(teamsInviteCss), reveal(240)]}
+					>
+						<div>
+							<h2 id="plan-teams" mix={css(planTitleCss)}>
+								Teams / Enterprise
+							</h2>
+							<p mix={css(teamsInviteCopyCss)}>
+								Running Kody across a team or with higher needs? Email us —
+								we&rsquo;re shaping that offering and want to hear your needs.
+							</p>
+						</div>
+						<a href="mailto:kody@kody.codes" mix={css(teamsInviteButtonCss)}>
+							Email us
+						</a>
+					</section>
 				</div>
 
 				<section aria-labelledby="limits-title" mix={css(limitsCss)}>
@@ -441,6 +464,40 @@ const planPillButtonCss = {
 const planGhostButtonCss = {
 	...getGhostButtonCss(),
 	...planButtonSizeCss,
+}
+
+const teamsInviteCss = {
+	...getSurfaceCardCss(),
+	gridColumn: '1 / -1',
+	display: 'flex',
+	flexDirection: 'row' as const,
+	alignItems: 'center',
+	justifyContent: 'space-between',
+	gap: '1.2rem',
+	textAlign: 'left' as const,
+	borderRadius: `calc(${radius.card} + 4px)`,
+	padding: 'clamp(1.5rem, 3vw, 2rem)',
+	'@media (max-width: 680px)': {
+		flexDirection: 'column' as const,
+		alignItems: 'stretch',
+		textAlign: 'center' as const,
+	},
+}
+
+const teamsInviteCopyCss = {
+	...planCopyCss,
+	marginTop: '0.55rem',
+	maxWidth: '62ch',
+}
+
+const teamsInviteButtonCss = {
+	...getGhostButtonCss(),
+	...planButtonSizeCss,
+	marginTop: 0,
+	flexShrink: 0,
+	'@media (max-width: 680px)': {
+		marginTop: '0.4rem',
+	},
 }
 
 /* One honest table, no marketing checkmarks. Spec-sheet measure — narrow

--- a/packages/worker/src/app/ssr-render-pricing.node.test.ts
+++ b/packages/worker/src/app/ssr-render-pricing.node.test.ts
@@ -85,6 +85,12 @@ test('renderAppPage renders the redesigned pricing page', async () => {
 	const html = await response.text()
 	expect(html).toContain('Standard')
 	expect(html).toContain('Pro')
+	expect(html).toContain('Teams / Enterprise')
+	expect(html).toContain(
+		'Running Kody across a team or with higher needs? Email us —',
+	)
+	expect(html).toContain('shaping that offering and want to hear your needs.')
+	expect(html).toContain('mailto:kody@kody.codes')
 	const count = new Intl.NumberFormat('en-US')
 	expect(html).toContain(count.format(planLimits.free.maxRepos))
 	expect(html).toContain(count.format(planLimits.standard.maxRepos))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Give teams and higher-need accounts a public way to reach us from `/pricing` without inventing a purchasable Teams/Enterprise SKU or putting Max on the comparison table.

## Why

Kody is shaping a team/enterprise offering. The pricing page should invite that conversation while Free/Standard/Pro stay the only public plans. Max stays invite-only and manual.

## Summary

- Footer strip under Free/Standard/Pro (full-width under the three cards, not a fourth priced column).
- Exact copy: "Running Kody across a team or with higher needs? Email us — we're shaping that offering and want to hear your needs."
- CTA: `mailto:kody@kody.codes` with an "Email us" button.
- No public SKU, no Teams/Enterprise or Max column in the comparison table.
- Verified public `planLimits` / `/pricing` table still match the #2099 ladder (Free/Standard/Pro: execute 100/150/750 hard daily, UWD 50/350/2000, DO rows 0.5B/5B/20B, jobs 5/15/75, intervals 15m/15m/5m). No drift; no limit-number changes in this PR.

## Testing

- Pre-push: `test:node` (2702) and `test:workers` (334) passed, including `ssr-render-pricing.node.test.ts` (Teams copy + mailto + public table values).
- Local origin `GET /pricing` (CLOUDFLARE_ENV=test, port 3847): 200, exact blurb, `mailto:kody@kody.codes`, ladder numbers present as table cells (`>100<` / `>150<` / `>750<`, `0.5B` / `5B` / `20B`, `2,000`, `15 minutes` / `5 minutes`).
- Browser walkthrough on that origin: three plan cards, Teams/Enterprise strip, Email us mailto, comparison table only Free/Standard/Pro.

![Free, Standard, and Pro cards with the Teams/Enterprise invite strip](https://cursor.com/artifacts/c/art-c44bf002-c0d4-421b-989a-e3162586ea0b)

![Public comparison table showing the post-2099 Free/Standard/Pro ladder](https://cursor.com/artifacts/c/art-cf350557-ce4e-483b-909a-b1453aff4c6f)

<a href="https://cursor.com/agents/bc-64ab2d7f-5823-41e3-9281-44ba1646fed5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpricing_teams_enterprise_invite.mp4"><img src="https://cursor.com/artifacts/c/art-c1855370-9cd9-4508-a064-e3ed2e799d8a" alt="pricing_teams_enterprise_invite.mp4" /></a>

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `0fb16adc` · **Head:** `f88bafc4`

**Classification:** composes — no primitives added or changed; this PR adds marketing copy and a mailto on the existing `/pricing` route.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `app-ui` | surfaces | composes — Teams/Enterprise invite strip on `/pricing` |

Unmatched path: `e2e/smoke.spec.ts` (heading check only).

### Change flow

Anonymous `/pricing` still renders Free/Standard/Pro from `planLimits`. This PR adds a full-width invite strip with a mailto under those cards.

```mermaid
sequenceDiagram
	actor Visitor
	participant appUi as app-ui
	Visitor->>appUi: GET /pricing
	appUi-->>Visitor: Free Standard Pro from planLimits
	appUi-->>Visitor: Teams/Enterprise strip plus mailto:kody@kody.codes
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-64ab2d7f-5823-41e3-9281-44ba1646fed5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-64ab2d7f-5823-41e3-9281-44ba1646fed5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an invite-only **Teams / Enterprise** section to the pricing page.
  - Included descriptive messaging and an **Email us** contact link for enterprise inquiries.
  - Added responsive styling for the new pricing card across screen sizes.

- **Tests**
  - Added coverage confirming the new section, contact prompt, and email link appear correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->