### PR TITLE
Fix packageStorage Proxy serialization on metered StorageRunner stubs

### DIFF
--- a/docs/contributing/architecture/usage-metering.md
+++ b/docs/contributing/architecture/usage-metering.md
@@ -78,6 +78,13 @@ rejections, size rejections, entitlement rejections, and parse failures record
 rejected mail. Mail rejected before inbox resolution (unknown alias, disabled
 inbox) has no owning user and is not metered.
 
+`createMeteredDurableObjectStub` must not wrap the RpcStub as the Proxy target.
+Cloudflare RPC binds stub methods to the receiver; a Proxy-of-stub is not a
+valid RPC receiver, so every StorageRunner call — including `packageStorage()`
+get of a missing key — throws "Proxy could not be serialized because it is not a
+valid RPC receiver type". The wrapper is a plain-object Proxy that `Reflect.get`
+/ `Reflect.apply`s against the original stub.
+
 ### `package_static_call`: statically imported package export calls
 
 Static imports (`import fn from 'kody:@scope/pkg/export'`) are the default way

--- a/packages/worker/src/storage-runner.cloneable.node.test.ts
+++ b/packages/worker/src/storage-runner.cloneable.node.test.ts
@@ -1,0 +1,26 @@
+import { expect, test } from 'vitest'
+import {
+	assertCloneableStorageValue,
+	storageValueNotCloneableMessage,
+} from './storage-runner.ts'
+
+test('assertCloneableStorageValue accepts JSON values and rejects Proxies', () => {
+	expect(() => assertCloneableStorageValue(null)).not.toThrow()
+	expect(() => assertCloneableStorageValue('plain')).not.toThrow()
+	expect(() =>
+		assertCloneableStorageValue({ roster: ['cole'], count: 1 }),
+	).not.toThrow()
+	expect(() =>
+		assertCloneableStorageValue(new Date('2026-09-06T00:00:00Z')),
+	).not.toThrow()
+
+	expect(() => assertCloneableStorageValue(new Proxy({}, {}))).toThrow(
+		storageValueNotCloneableMessage,
+	)
+	expect(() => assertCloneableStorageValue(new Proxy(() => {}, {}))).toThrow(
+		storageValueNotCloneableMessage,
+	)
+	expect(() => assertCloneableStorageValue(() => 'fn')).toThrow(
+		storageValueNotCloneableMessage,
+	)
+})

--- a/packages/worker/src/storage-runner.ts
+++ b/packages/worker/src/storage-runner.ts
@@ -205,6 +205,33 @@ function normalizeStorageKey(key: string) {
 	return trimmed
 }
 
+export const storageValueNotCloneableMessage =
+	'Storage values must be structured-cloneable (plain objects, arrays, strings, numbers, booleans, null, and Dates). Proxies, functions, and other RPC-incompatible values cannot be stored.'
+
+/**
+ * Reject Proxies and other non-cloneable values on the host before the
+ * StorageRunner RPC. Passing a runtime Proxy (`kody`, `email`, `events`,
+ * or a metered stub) as a value otherwise fails at the DO boundary with
+ * "Proxy could not be serialized because it is not a valid RPC receiver
+ * type" and can make a later read of any key look broken.
+ */
+export function assertCloneableStorageValue(value: unknown) {
+	try {
+		structuredClone(value)
+	} catch (error) {
+		throw new Error(storageValueNotCloneableMessage, { cause: error })
+	}
+}
+
+function readCloneableStorageValue(value: unknown) {
+	if (value == null) return null
+	try {
+		return structuredClone(value)
+	} catch (error) {
+		throw new Error(storageValueNotCloneableMessage, { cause: error })
+	}
+}
+
 function normalizePageSize(pageSize: number | undefined) {
 	const requested =
 		typeof pageSize === 'number' && Number.isFinite(pageSize)
@@ -480,7 +507,7 @@ class StorageRunnerBase extends DurableObject<Env> {
 		const key = normalizeStorageKey(input.key)
 		return {
 			key,
-			value: (await this.ctx.storage.get(key)) ?? null,
+			value: readCloneableStorageValue(await this.ctx.storage.get(key)),
 		}
 	}
 
@@ -489,6 +516,7 @@ class StorageRunnerBase extends DurableObject<Env> {
 		value: unknown
 	}): Promise<StorageSetResult> {
 		const key = normalizeStorageKey(input.key)
+		assertCloneableStorageValue(input.value)
 		await this.ctx.storage.put(key, input.value)
 		return { ok: true, key }
 	}
@@ -533,7 +561,7 @@ class StorageRunnerBase extends DurableObject<Env> {
 				truncated = true
 				break
 			}
-			entries.push({ key, value })
+			entries.push({ key, value: readCloneableStorageValue(value) })
 			nextStartAfter = key
 		}
 		return {
@@ -677,6 +705,7 @@ export function storageRunnerRpc(input: {
 	return {
 		getValue: (payload: { key: string }) => runner.getValue(payload),
 		setValue: async (payload: { key: string; value: unknown }) => {
+			assertCloneableStorageValue(payload.value)
 			registerOwnedBucket()
 			const result = await runner.setValue(payload)
 			refreshOwnedBucketEstimate()

--- a/packages/worker/src/storage-runner.workers.test.ts
+++ b/packages/worker/src/storage-runner.workers.test.ts
@@ -15,6 +15,8 @@ import {
 import { ensureUserStorageBucketsTestSchema } from '#worker/storage-buckets/test-schema.ts'
 import { createStableUserIdFromEmail } from '#worker/user-id.ts'
 import { repoSessionRpc } from '#worker/repo/repo-session-rpc.ts'
+import { createMeteredDurableObjectStub } from '#worker/usage/durable-object-usage.ts'
+import { storageRunnerDurableObjectName } from '#worker/user-scoped-durable-object-name.ts'
 import {
 	assertStorageRunnerWriteWithinEntitlement,
 	createStorageKodyTools,
@@ -23,6 +25,7 @@ import {
 	readOnlyStorageSqlDeniedMessage,
 	StorageRunner,
 	storageRunnerRpc,
+	storageValueNotCloneableMessage,
 } from './storage-runner.ts'
 
 async function ensureStorageRunnerTestSchema() {
@@ -552,6 +555,89 @@ test('storage runner dedupes bucket registration to one D1 write per isolate', a
 	} finally {
 		env.APP_DB.prepare = originalPrepare
 	}
+})
+
+test('metered StorageRunner RpcStub get/set/list/delete stay callable and reject Proxies on write', async () => {
+	await ensureStorageRunnerTestSchema()
+	const userId = `storage-metered-${crypto.randomUUID()}`
+	const storageId = createExecuteStorageId()
+	const stub = env.STORAGE_RUNNER.get(
+		env.STORAGE_RUNNER.idFromName(
+			storageRunnerDurableObjectName(userId, storageId),
+		),
+	)
+	const runner = createMeteredDurableObjectStub({
+		env: { USAGE_EVENTS: { writeDataPoint() {} } },
+		userId,
+		doClass: 'StorageRunner',
+		stub,
+	})
+
+	await expect(runner.getValue({ key: 'missing-key' })).resolves.toEqual({
+		key: 'missing-key',
+		value: null,
+	})
+	await expect(
+		runner.setValue({ key: 'note', value: 'plain-string' }),
+	).resolves.toEqual({ ok: true, key: 'note' })
+	await expect(
+		runner.setValue({
+			key: 'roster',
+			value: { bots: ['cole'], count: 1 },
+		}),
+	).resolves.toEqual({ ok: true, key: 'roster' })
+	await expect(runner.getValue({ key: 'note' })).resolves.toEqual({
+		key: 'note',
+		value: 'plain-string',
+	})
+	await expect(runner.listValues({ pageSize: 10 })).resolves.toMatchObject({
+		entries: [
+			{ key: 'note', value: 'plain-string' },
+			{ key: 'roster', value: { bots: ['cole'], count: 1 } },
+		],
+		truncated: false,
+	})
+	await expect(runner.deleteValue({ key: 'note' })).resolves.toEqual({
+		ok: true,
+		key: 'note',
+		deleted: true,
+	})
+	await expect(runner.getValue({ key: 'note' })).resolves.toEqual({
+		key: 'note',
+		value: null,
+	})
+
+	const tools = createStorageKodyTools({
+		env,
+		userId,
+		storageId: createExecuteStorageId(),
+		writable: true,
+	})
+	await expect(tools.storageGet({ key: 'fresh-missing' })).resolves.toEqual({
+		key: 'fresh-missing',
+		value: null,
+	})
+	await expect(
+		tools.storageSet({
+			key: 'poison',
+			value: new Proxy({ leaked: true }, {}),
+		}),
+	).rejects.toThrow(storageValueNotCloneableMessage)
+	await expect(tools.storageGet({ key: 'poison' })).resolves.toEqual({
+		key: 'poison',
+		value: null,
+	})
+	await expect(
+		tools.storageSet({ key: 'ok', value: { saved: true } }),
+	).resolves.toEqual({ ok: true, key: 'ok' })
+	await expect(tools.storageList({ pageSize: 10 })).resolves.toMatchObject({
+		entries: [{ key: 'ok', value: { saved: true } }],
+	})
+	await expect(tools.storageDelete({ key: 'ok' })).resolves.toEqual({
+		ok: true,
+		key: 'ok',
+		deleted: true,
+	})
 })
 
 test('clearStorage during account-deletion purge must not recreate ownership rows', async () => {

--- a/packages/worker/src/usage/durable-object-usage.node.test.ts
+++ b/packages/worker/src/usage/durable-object-usage.node.test.ts
@@ -121,6 +121,33 @@ test('createMeteredDurableObjectStub flushes a burst that never goes idle', asyn
 	vi.useRealTimers()
 })
 
+test('createMeteredDurableObjectStub binds Rpc methods to the real stub, not the wrapper Proxy', async () => {
+	recordUsage.mockClear()
+	const stub = {
+		get ping() {
+			const receiver = this
+			return async () => {
+				if (receiver !== stub) {
+					throw new Error(
+						"Proxy could not be serialized because it is not a valid RPC receiver type. The Proxy must emulate either a plain object or an RpcTarget, as indicated by the Proxy's prototype chain.",
+					)
+				}
+				return 'pong'
+			}
+		},
+	}
+	const metered = createMeteredDurableObjectStub({
+		env: { USAGE_EVENTS: { writeDataPoint() {} } },
+		userId: 'user-1',
+		doClass: 'StorageRunner',
+		stub,
+	})
+	expect(metered).not.toBe(stub)
+	await expect(metered.ping()).resolves.toBe('pong')
+	await flushDurableObjectUsageWrites()
+	expect(recordUsage).toHaveBeenCalledTimes(1)
+})
+
 test('createMeteredDurableObjectStub is a no-op without Analytics Engine', async () => {
 	await flushDurableObjectUsageWrites()
 	recordUsage.mockClear()

--- a/packages/worker/src/usage/durable-object-usage.ts
+++ b/packages/worker/src/usage/durable-object-usage.ts
@@ -40,6 +40,12 @@ let burstStartedAt: number | null = null
  * one burst coalesce into a single write. Recording failures never surface
  * to the caller. Without `USAGE_EVENTS` the stub is returned unchanged so
  * local/test mocks that lack Analytics Engine do not attempt a D1 rollup.
+ *
+ * The wrapper must not use the RpcStub as the Proxy target or as `this` for
+ * method getters. Cloudflare RPC binds stub methods to the receiver; a
+ * Proxy-of-stub is not a valid RPC receiver and every call then throws
+ * "Proxy could not be serialized because it is not a valid RPC receiver
+ * type" — including `packageStorage()` get of a missing key.
  */
 export function createMeteredDurableObjectStub<T extends object>(input: {
 	env: UsageEnv
@@ -48,9 +54,11 @@ export function createMeteredDurableObjectStub<T extends object>(input: {
 	stub: T
 }): T {
 	if (!input.env.USAGE_EVENTS) return input.stub
-	return new Proxy(input.stub, {
-		get(target, prop, receiver) {
-			const value = Reflect.get(target, prop, receiver)
+	const stub = input.stub
+	return new Proxy({} as T, {
+		get(_target, prop) {
+			if (prop === 'then') return undefined
+			const value = Reflect.get(stub, prop, stub)
 			if (typeof value !== 'function') return value
 			return (...args: Array<unknown>) => {
 				const startedAt = Date.now()
@@ -69,7 +77,7 @@ export function createMeteredDurableObjectStub<T extends object>(input: {
 					}
 				}
 				try {
-					const result = value.apply(target, args) as unknown
+					const result = Reflect.apply(value, stub, args) as unknown
 					if (result && typeof result === 'object' && 'then' in result) {
 						return Promise.resolve(result).then(
 							(resolved) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Restore `packageStorage()` get/set/list/delete for every package after #2103, including `@kentcdodds/grok-bot` (`5bddf97f-09c7-41eb-8402-a7102432dd2e`).

## Why

Production `USAGE_EVENTS` wraps StorageRunner stubs in `createMeteredDurableObjectStub`. That helper used the RpcStub as the Proxy target, so Cloudflare bound stub methods to the wrapper. Every StorageRunner RPC then failed with:

`Proxy could not be serialized because it is not a valid RPC receiver type. The Proxy must emulate either a plain object or an RpcTarget, as indicated by the Proxy's prototype chain.`

That matches grok-bot `email.message.received` runs starting ~20:30 UTC on 2026-09-06 (about 90 minutes after #2103 landed) and a live `import list from 'kody:@kentcdodds/grok-bot/list'` reproduction. Missing-key gets failed too, so this was not corrupted DO contents.

## Summary

- Bind metered stub methods to the real RpcStub (`Reflect.get` / `Reflect.apply` on a plain-object Proxy).
- Reject Proxies and other non-cloneable values on write with a clear error instead of a DO RPC serialization failure.
- Clone values on read so one uncloneable key cannot leak across the DO boundary.
- No grok-bot storage reset: failed writes never reached the Durable Object, so pre-#2103 roster data should still be there.

## Testing

- Node: metered wrapper keeps Rpc-style getter `this` on the real stub; `assertCloneableStorageValue` accepts JSON/Dates and rejects Proxies/functions.
- Workers: real StorageRunner RpcStub through the metered wrapper — missing-key get, set string/object, list, delete; `createStorageKodyTools` rejects a Proxy write and still reads/writes afterward.
- Pre-push: `test:node` 2705 passed, `test:workers` 335 passed, worker typecheck clean.

## System changes

Medium risk: extends `usage-metering` (how StorageRunner stubs are wrapped) and `durable-storage` (cloneable write/read contract). Does not change bucket identity or isolation.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `83367d3b` · **Head:** `1eb70335`

**Classification:** extends — metered Durable Object stubs stay callable, and StorageRunner rejects non-cloneable writes.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `usage-metering` | storage | extends — `createMeteredDurableObjectStub` no longer uses the RpcStub as the Proxy target |
| `durable-storage` | assistant | extends — write-time cloneable assert, read-time structured clone |

### Change flow

`packageStorage()` RPCs go through the usage-metering wrapper onto StorageRunner. Methods stay bound to the real stub, and non-cloneable values are rejected before the DO put.

```mermaid
sequenceDiagram
	actor Package
	participant usageMetering as usage-metering
	participant durableStorage as durable-storage
	Package->>usageMetering: packageStorage get set list delete
	usageMetering->>durableStorage: Reflect.apply on real RpcStub
	Note over usageMetering: plain-object Proxy, not Proxy-of-stub
	durableStorage->>durableStorage: reject non-cloneable set values
	durableStorage-->>Package: missing-key get returns null
```

### Invariants

Per-user StorageRunner isolation is unchanged. Bucket ids and `idFromName` tuples are untouched.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-58c25a4e-d695-42f0-a1b6-86aec8bbd4c1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-58c25a4e-d695-42f0-a1b6-86aec8bbd4c1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed metered storage operations so reads, writes, listing, and deletion continue to work reliably.
  * Prevented invalid storage values, including functions and proxies, from being written; clear errors are now returned instead.
  * Ensured values returned from storage remain compatible with structured cloning.
  * Corrected metered Durable Object method handling to preserve normal RPC behavior.

* **Documentation**
  * Added guidance for correctly integrating metered Durable Object storage with RPC stubs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->