### PR TITLE
Cover metered StorageRunner RPC on the production factory path

### DIFF
--- a/docs/contributing/architecture/usage-metering.md
+++ b/docs/contributing/architecture/usage-metering.md
@@ -80,10 +80,14 @@ inbox) has no owning user and is not metered.
 
 `createMeteredDurableObjectStub` must not wrap the RpcStub as the Proxy target.
 Cloudflare RPC binds stub methods to the receiver; a Proxy-of-stub is not a
-valid RPC receiver, so every StorageRunner call — including `packageStorage()`
-get of a missing key — throws "Proxy could not be serialized because it is not a
-valid RPC receiver type". The wrapper is a plain-object Proxy that `Reflect.get`
-/ `Reflect.apply`s against the original stub.
+valid RPC receiver, so every StorageRunner call throws "Proxy could not be
+serialized because it is not a valid RPC receiver type". That includes
+`packageStorage()` get of a missing key on export, subscription, job, and
+execute — `storageRunnerRpc` is the only production call site, so one broken
+wrapper fails every surface that touches package storage. The wrapper is a
+plain-object Proxy that `Reflect.get` / `Reflect.apply`s against the original
+stub. Local and workers-unit `env` omit `USAGE_EVENTS`, which skips the wrapper;
+tests that need the production path bind a stub Analytics Engine dataset.
 
 ### `package_static_call`: statically imported package export calls
 

--- a/packages/worker/src/package-runtime/package-storage.workers.test.ts
+++ b/packages/worker/src/package-runtime/package-storage.workers.test.ts
@@ -218,6 +218,35 @@ function packageBucketRunner(userId: string, packageId: string) {
 	})
 }
 
+async function withUsageEventsBinding<T>(run: () => Promise<T>) {
+	const previousUsageEvents = env.USAGE_EVENTS
+	Object.defineProperty(env, 'USAGE_EVENTS', {
+		configurable: true,
+		enumerable: true,
+		writable: true,
+		value: { writeDataPoint() {} },
+	})
+	if (!env.USAGE_EVENTS) {
+		throw new Error(
+			'Failed to bind a stub USAGE_EVENTS dataset on the workers env.',
+		)
+	}
+	try {
+		return await run()
+	} finally {
+		if (previousUsageEvents === undefined) {
+			Reflect.deleteProperty(env, 'USAGE_EVENTS')
+		} else {
+			Object.defineProperty(env, 'USAGE_EVENTS', {
+				configurable: true,
+				enumerable: true,
+				writable: true,
+				value: previousUsageEvents,
+			})
+		}
+	}
+}
+
 test(
 	'statically imported package code reads its own bucket from an ad hoc execute call',
 	{ timeout: 90_000 },
@@ -469,6 +498,71 @@ test(
 				owner: 'inner-bucket',
 			},
 			outerBucketId: buildPackageStorageId(outerPackageId),
+		})
+	},
+)
+
+test(
+	'packageStorage get/set stay callable when StorageRunner metering is enabled',
+	{ timeout: 90_000 },
+	async () => {
+		silenceIncidentalRuntimeWarnings()
+		await ensureSavedPackageArtifactSchema()
+		const userId = `user-${crypto.randomUUID()}`
+		const packageId = `pkg-${crypto.randomUUID()}`
+		// Local workers env omits USAGE_EVENTS, so storageRunnerRpc returns
+		// the raw RpcStub. Bind a stub dataset on the real env — do not
+		// wrap env in a Proxy, because createExecuteExecutor passes env
+		// into the Dynamic Worker. Production wraps the StorageRunner stub
+		// when Analytics Engine is bound; that wrapper must stay a
+		// plain-object Proxy or every packageStorage() call — including get
+		// of a missing key on export and subscription — throws the RPC
+		// receiver serialization error.
+		await withUsageEventsBinding(async () => {
+			const bundle = await buildKodyModuleBundle({
+				env,
+				baseUrl: 'https://kody.dev',
+				userId,
+				sourceFiles: {
+					'entry.ts': [
+						"import { packageStorage } from 'kody:runtime'",
+						'export default async function main() {',
+						'\tconst bucket = packageStorage()',
+						"\tconst missing = await bucket.get('missing-key')",
+						"\tawait bucket.set('note', 'plain')",
+						"\tconst note = await bucket.get('note')",
+						'\tconst listed = await bucket.list()',
+						'\treturn {',
+						'\t\tmissing,',
+						'\t\tnote,',
+						'\t\tkeys: listed.entries.map((entry) => entry.key),',
+						'\t}',
+						'}',
+					].join('\n'),
+				},
+				entryPoint: 'entry.ts',
+				rootPackageId: packageId,
+			})
+			const result = await runBundledModuleWithRegistry(
+				env,
+				createCallerContext(userId),
+				bundle,
+				undefined,
+				{
+					skipCapabilityRegistry: true,
+					packageContext: {
+						packageId,
+						kodyId: 'metered-storage',
+						sourceId: `source-${packageId}`,
+					},
+				},
+			)
+			expect(result.error).toBeUndefined()
+			expect(result.result).toEqual({
+				missing: null,
+				note: 'plain',
+				keys: ['note'],
+			})
 		})
 	},
 )

--- a/packages/worker/src/storage-runner.workers.test.ts
+++ b/packages/worker/src/storage-runner.workers.test.ts
@@ -638,6 +638,62 @@ test('metered StorageRunner RpcStub get/set/list/delete stay callable and reject
 		key: 'ok',
 		deleted: true,
 	})
+
+	// Production call sites go through storageRunnerRpc, which wraps the
+	// stub only when env.USAGE_EVENTS is bound. Local workers env omits
+	// that binding, so the factory path must be forced here — otherwise
+	// this suite never sees the metered Proxy that production uses on
+	// every export / subscription / job StorageRunner call.
+	const meteredEnv = new Proxy(env, {
+		get(target, prop, receiver) {
+			if (prop === 'USAGE_EVENTS') {
+				return { writeDataPoint() {} }
+			}
+			return Reflect.get(target, prop, receiver)
+		},
+	})
+	const factoryUserId = `storage-metered-factory-${crypto.randomUUID()}`
+	const factoryRunner = storageRunnerRpc({
+		env: meteredEnv,
+		userId: factoryUserId,
+		storageId: createExecuteStorageId(),
+	})
+	await expect(
+		factoryRunner.getValue({ key: 'missing-via-factory' }),
+	).resolves.toEqual({
+		key: 'missing-via-factory',
+		value: null,
+	})
+	await expect(
+		factoryRunner.sqlQuery({
+			query: 'create table if not exists metered_t (id integer primary key)',
+			writable: true,
+		}),
+	).resolves.toMatchObject({
+		columns: expect.any(Array),
+		rows: expect.any(Array),
+	})
+	const factoryTools = createStorageKodyTools({
+		env: meteredEnv,
+		userId: factoryUserId,
+		storageId: createExecuteStorageId(),
+		writable: true,
+	})
+	await expect(
+		factoryTools.storageGet({ key: 'factory-fresh-missing' }),
+	).resolves.toEqual({
+		key: 'factory-fresh-missing',
+		value: null,
+	})
+	await expect(
+		factoryTools.storageSet({ key: 'factory-ok', value: { saved: true } }),
+	).resolves.toEqual({ ok: true, key: 'factory-ok' })
+	await expect(factoryTools.storageGet({ key: 'factory-ok' })).resolves.toEqual(
+		{
+			key: 'factory-ok',
+			value: { saved: true },
+		},
+	)
 })
 
 test('clearStorage during account-deletion purge must not recreate ownership rows', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Keep `packageStorage()` and every other StorageRunner call working in production when observe-only DO GB-s metering is on — and make sure the next wrapper regression fails a workers test on the path Kent actually saw (export / subscription), not only a direct stub wrap.

## Why

Kent's Discord `#reports` tonight were this error, count ×3-ish, surface `export`, owners including `discord` and `hrv-air-quality-automation`:

```
Proxy could not be serialized because it is not a valid RPC receiver type. The Proxy must emulate either a plain object or an RpcTarget, as indicated by the Proxy's prototype chain.
```

**Root cause (verified, not a second wrapping path):** this is residual from #2103, already fixed by #2107. Not a new export-only bug.

Evidence:

- #2103 (`0fb16adc`, 2026-09-06 13:03 MT) wrapped StorageRunner RpcStubs in `createMeteredDurableObjectStub` with the stub as the Proxy target. Cloudflare RPC then bound methods to that Proxy.
- Production `/health` now serves `e408cfd` (#2108, includes #2107), deployed 2026-09-06 22:12 UTC.
- Kent's Activity has **11** matching errors, all between **20:30–21:22 UTC** (after #2103, until #2107):
  - export: `discord` `./handle-decision-reaction`, `hrv-air-quality-automation` `./handle-reaction`, `apartment-thermostat-automation` `./handle-reaction`
  - subscription: `grok-bot` `email.message.received` ×7, `event-notifier` `integration.auth.succeeded`
- **0** matching errors after 21:22:30 UTC. `grok-bot` `email.message.received` succeeded at 21:32. Sentry has no unresolved `Proxy could not be serialized` / `valid RPC receiver` issues in 14d.
- `storageRunnerRpc` is the only production `createMeteredDurableObjectStub` call site. UserMeter, Mailbox, RunLog, and RepoSessionIndex stay unwrapped. There is no second Proxy-of-stub on export.

Local workers `env` omits `USAGE_EVENTS`, so `createMeteredDurableObjectStub` is a no-op and the existing `packageStorage()` suites never saw the production wrapper. That is how #2103 shipped.

## Summary

- No production RPC change — #2107 already rebinds methods to the real stub via a plain-object Proxy.
- Workers test: `storageRunnerRpc` + `createStorageKodyTools` with a stub `USAGE_EVENTS` (missing-key get, SQL, set/get).
- Workers test: `packageStorage()` get of a missing key through `runBundledModuleWithRegistry` with metering enabled (export-like package context).
- Docs: the invariant applies to every StorageRunner surface, and tests must bind Analytics Engine to exercise the wrapper.

## Testing

- `npm run test:push` on this branch (865 node + 336 workers, including the new cases).
- Production Activity + `/health` SHA review above. No browser/UI change.

## System changes

Low risk: tests and docs only. Composes existing `durable-storage` / `package-runtime` / `usage-metering`. Does not change metering or RPC behavior.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `e408cfd3` · **Head:** `2285fc77`

**Classification:** composes — no primitives added or changed; this PR adds workers coverage and documents the existing RpcStub wrapper invariant.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `package-runtime` | runtime | composes — workers test for `packageStorage()` with metering on |
| `durable-storage` | assistant | composes — workers test for `storageRunnerRpc` with `USAGE_EVENTS` |
| `usage-metering` | storage | composes — docs only, existing `createMeteredDurableObjectStub` invariant |

### Change flow

A package export that calls `packageStorage()` goes through `storageRunnerRpc`, which wraps the StorageRunner stub only when Analytics Engine is bound. The new tests force that binding and assert a missing-key get still works.

```mermaid
sequenceDiagram
	actor PackageExport
	participant packageRuntime as package-runtime
	participant durableStorage as durable-storage
	participant usageMetering as usage-metering
	PackageExport->>packageRuntime: packageStorage get missing key
	packageRuntime->>durableStorage: storageRunnerRpc with USAGE_EVENTS bound
	durableStorage->>usageMetering: createMeteredDurableObjectStub plain-object Proxy
	usageMetering->>durableStorage: Reflect.apply method on real RpcStub
	durableStorage-->>PackageExport: value null, no RPC receiver error
```

### Invariants

Per-user isolation is unchanged. UserMeter, Mailbox, RunLog, and RepoSessionIndex stay unwrapped so admin usage reads do not inflate `durable_object_gb_seconds`.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-adda3a98-0554-4181-b7d5-4b0a5516046e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-adda3a98-0554-4181-b7d5-4b0a5516046e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added end-to-end coverage for metered package storage reads, writes, and listing, including missing-key handling.
  - Added coverage for storage runner and tool clients using usage-event tracking, including SQL and storage operations.
  - Improved test setup and cleanup for usage-event bindings.

- **Documentation**
  - Clarified package-storage metering behavior across export, subscription, job, and execution surfaces.
  - Documented local and worker test environments and when usage-event bindings are required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->