### PR TITLE
Explain unique worker days on usage and limit errors

### DIFF
--- a/docs/contributing/architecture/entitlements.md
+++ b/docs/contributing/architecture/entitlements.md
@@ -187,7 +187,12 @@ overage is billed at those rates when `compute-overage-charging` is on (registry
 default: on) and `resolveComputeOverageDisposition` returns `invoice`: paid
 public Standard/Pro with a Stripe customer, or Free that already has a customer.
 Unpaid Free that exceeds includes is a soft-block (upgrade prompt on
-`/account/usage`), never a Stripe charge that would fail. Turn the flag off
+`/account/usage` and the same `whatCounts` / `howToReduce` copy on `usageGet`),
+never a Stripe charge that would fail. `usageGet` and the account usage UI
+include these monthly meters with plain-language guidance; they are not hard
+entitlement cuts. A `ComputeOverageLimitError` (`compute_overage_include_reached`)
+carries that same guidance for execute/jobs structured entitlement errors when
+a soft-block denial is raised. Turn the flag off
 globally at `/admin/feature-flags` to dry-run (ledger rows, no Stripe). Global
 off is a hard gate — a per-user on override cannot charge. A percentage
 rollout is still globally on. Amounts below

--- a/docs/contributing/architecture/usage-metering.md
+++ b/docs/contributing/architecture/usage-metering.md
@@ -165,7 +165,9 @@ Cloudflare bill unit: one unique Dynamic Worker id per user per UTC day, on
 every sandbox surface that creates a worker.
 `PlanLimits.maxUniqueWorkerDaysPerMonth` is the public included allotment shown
 on `/pricing`. It is not in `entitlementResources` and does not replace the hard
-daily `execute` / `job_run` caps. Customer-facing monthly overage is unique
+daily `execute` / `job_run` caps. `usageGet` and the account usage UI report
+this meter (and Durable Object rows-read) with `whatCounts` / `howToReduce` so
+the include is self-explanatory. Customer-facing monthly overage is unique
 worker days plus Durable Object rows-read, billed on the public ladder at
 `computeOverageRatesUsd` when `compute-overage-charging` is on. Unpaid Free is a
 soft-block, not a charge. Amounts below Stripe's $0.50 USD minimum are not

--- a/packages/worker/client/routes/account-usage.node.test.ts
+++ b/packages/worker/client/routes/account-usage.node.test.ts
@@ -12,7 +12,9 @@ function overage(
 		meters: [
 			{
 				resource: 'unique_worker_days',
-				label: 'unique worker-days',
+				label: 'Unique worker days',
+				whatCounts: 'Counts distinct Dynamic Worker isolates.',
+				howToReduce: 'Keep package code stable.',
 				current: 45,
 				include: 50,
 				percentOfLimit,

--- a/packages/worker/client/routes/account-usage.tsx
+++ b/packages/worker/client/routes/account-usage.tsx
@@ -45,12 +45,13 @@ const billingPath = '/account/billing'
 
 const entitlementGroupOrder: Array<
 	AccountUsageEntitlementConsumption['group']
-> = ['daily', 'counts', 'storage', 'limits']
+> = ['monthly', 'daily', 'counts', 'storage', 'limits']
 
 const entitlementGroupLabels: Record<
 	AccountUsageEntitlementConsumption['group'],
 	string
 > = {
+	monthly: 'Monthly compute',
 	daily: 'Daily rates',
 	counts: 'Resource counts',
 	storage: 'Storage',
@@ -60,6 +61,8 @@ const entitlementGroupLabels: Record<
 const entitlementGroupNotes: Partial<
 	Record<AccountUsageEntitlementConsumption['group'], string>
 > = {
+	monthly:
+		'Included unique worker days and Durable Object rows-read this UTC month.',
 	daily: 'Counters reset at UTC midnight.',
 }
 
@@ -392,7 +395,28 @@ export function AccountUsageRoute(handle: Handle) {
 								rows={usage.computeOverage.meters.map((item) => ({
 									id: item.resource,
 									cells: {
-										resource: item.label,
+										resource: (
+											<span mix={css({ display: 'grid', gap: spacing.xs })}>
+												<span
+													mix={css({
+														fontWeight: typography.fontWeight.medium,
+														color: colors.text,
+													})}
+												>
+													{item.label}
+												</span>
+												<span
+													mix={css({
+														fontSize: typography.fontSize.sm,
+														color: colors.textMuted,
+														lineHeight: 1.4,
+														whiteSpace: 'normal',
+													})}
+												>
+													{item.whatCounts} {item.howToReduce}
+												</span>
+											</span>
+										),
 										current: formatIntegerNumber(item.current),
 										include: formatIntegerNumber(item.include),
 										used: (

--- a/packages/worker/src/app/account-usage-data.node.test.ts
+++ b/packages/worker/src/app/account-usage-data.node.test.ts
@@ -288,10 +288,14 @@ test('unpaid Free over compute includes is a soft-block, not a charge', async ()
 	expect(data?.computeOverage.disposition).toBe('soft_block')
 	expect(data?.computeOverage.hasStripeCustomer).toBe(false)
 	expect(data?.computeOverage.totalCents).toBeGreaterThan(0)
+	const uniqueWorkerDays = data?.computeOverage.meters.find(
+		(meter) => meter.resource === 'unique_worker_days',
+	)
+	expect(uniqueWorkerDays?.overEightyPercent).toBe(true)
+	expect(uniqueWorkerDays?.whatCounts).toMatch(/Dynamic Worker isolates/)
+	expect(uniqueWorkerDays?.howToReduce).toMatch(/payment method/)
 	expect(
-		data?.computeOverage.meters.find(
-			(meter) => meter.resource === 'unique_worker_days',
-		)?.overEightyPercent,
+		data?.warnings.some((row) => row.resource === 'unique_worker_days'),
 	).toBe(true)
 })
 

--- a/packages/worker/src/app/account-usage-data.node.test.ts
+++ b/packages/worker/src/app/account-usage-data.node.test.ts
@@ -317,4 +317,39 @@ test('legacy Standard over compute includes stays unbilled', async () => {
 	})
 	expect(data?.computeOverage.legacyUnbilled).toBe(true)
 	expect(data?.computeOverage.disposition).toBe('skip_legacy')
+	const uniqueWorkerDays = data?.computeOverage.meters.find(
+		(meter) => meter.resource === 'unique_worker_days',
+	)
+	expect(uniqueWorkerDays?.howToReduce).toMatch(/not billed/)
+	expect(uniqueWorkerDays?.howToReduce).not.toMatch(/\$0\.0025/)
+	expect(uniqueWorkerDays?.howToReduce).not.toMatch(/payment method/)
+})
+
+test('legacy Standard approaching compute include stays unbilled copy', async () => {
+	const now = new Date('2026-07-25T12:00:00.000Z')
+	const { db } = createUsageTestDb({
+		userId: 23,
+		email: 'usage-legacy-approaching@example.com',
+		plan: 'standard',
+		stripePlan: 'standard',
+		entitlementLadder: 'legacy',
+		stripeCustomerId: 'cus_legacy_approaching',
+		uniqueWorkerDays: 280,
+	})
+	const data = await loadAccountUsageData({
+		env: withUsageEnv({ APP_DB: db }) as Env,
+		userId: 23,
+		now,
+	})
+	expect(data?.computeOverage.legacyUnbilled).toBe(true)
+	expect(data?.computeOverage.disposition).toBe('skip_zero')
+	const uniqueWorkerDays = data?.computeOverage.meters.find(
+		(meter) => meter.resource === 'unique_worker_days',
+	)
+	expect(uniqueWorkerDays?.current).toBe(280)
+	expect(uniqueWorkerDays?.include).toBe(350)
+	expect(uniqueWorkerDays?.overEightyPercent).toBe(true)
+	expect(uniqueWorkerDays?.howToReduce).toMatch(/not billed/)
+	expect(uniqueWorkerDays?.howToReduce).not.toMatch(/\$0\.0025/)
+	expect(uniqueWorkerDays?.howToReduce).not.toMatch(/payment method/)
 })

--- a/packages/worker/src/app/account-usage-data.ts
+++ b/packages/worker/src/app/account-usage-data.ts
@@ -1,23 +1,16 @@
-import { utcMonthKey } from '@kody-internal/shared/date-keys.ts'
-import {
-	computeMonthlyOverage,
-	computeOverageBillingPolicy,
-	computeOverageIncludePercent,
-	computeOverageWarningResourceLabels,
-	resolveComputeOverageDisposition,
-} from '#universal/compute-overage.ts'
 import {
 	parseEntitlementLadder,
 	parseStoredPlanName,
 	parseStripePlanName,
 	resolveEffectivePlan,
 } from '#universal/plans.ts'
-import { isComputeOverageChargingEnabled } from '#worker/billing/compute-overage-charging.ts'
-import { readMonthlyComputeUsage } from '#worker/billing/compute-overage-usage.ts'
+import {
+	computeOverageUsageWarningRows,
+	readAccountComputeOverage,
+} from '#worker/billing/compute-overage-account.ts'
 import { readEntitlementUsageSnapshot } from '#worker/entitlements/usage-snapshot.ts'
 import { resolveUserStableId } from '#worker/user-id.ts'
 import {
-	type AccountUsageComputeOverage,
 	type AccountUsageEntitlementConsumption,
 	type AccountUsageLoaderData,
 } from '#universal/loader-data.ts'
@@ -63,8 +56,8 @@ export async function loadAccountUsageData(input: {
 			ladder,
 			now,
 		}),
-		loadAccountComputeOverage({
-			env: input.env,
+		readAccountComputeOverage({
+			db: input.env.APP_DB,
 			userId: row.id,
 			stableUserId: usageUserId,
 			plan,
@@ -81,84 +74,26 @@ export async function loadAccountUsageData(input: {
 		stripePlan: parseStripePlanName(row.stripe_plan),
 		today: snapshot.today,
 		entitlementConsumption: snapshot.resources.map(toAccountUsageRow),
-		warnings: snapshot.warnings.map(toAccountUsageRow),
+		warnings: [
+			...computeOverageUsageWarningRows(computeOverage).map(toAccountUsageRow),
+			...snapshot.warnings.map(toAccountUsageRow),
+		],
 		computeOverage,
 	}
 }
 
-async function loadAccountComputeOverage(input: {
-	env: Env
-	userId: number
-	stableUserId: string
-	plan: ReturnType<typeof resolveEffectivePlan>
-	ladder: ReturnType<typeof parseEntitlementLadder>
-	hasStripeCustomer: boolean
-	now: Date
-}): Promise<AccountUsageComputeOverage> {
-	const month = utcMonthKey(input.now)
-	const [usage, chargingEnabled] = await Promise.all([
-		readMonthlyComputeUsage({
-			db: input.env.APP_DB,
-			stableUserId: input.stableUserId,
-			month,
-		}),
-		isComputeOverageChargingEnabled(input.env.APP_DB, input.userId),
-	])
-	const overage = computeMonthlyOverage({
-		plan: input.plan,
-		ladder: input.ladder,
-		uniqueWorkerDays: usage.uniqueWorkerDays,
-		durableObjectRowsRead: usage.durableObjectRowsRead,
-	})
-	const uniqueWorkerDayPercent =
-		computeOverageIncludePercent(
-			usage.uniqueWorkerDays,
-			overage.includedUniqueWorkerDays,
-		) ?? 0
-	const durableObjectRowsReadPercent =
-		computeOverageIncludePercent(
-			usage.durableObjectRowsRead,
-			overage.includedDurableObjectRowsRead,
-		) ?? 0
-	return {
-		meters: [
-			{
-				resource: 'unique_worker_days',
-				label: computeOverageWarningResourceLabels.unique_worker_days,
-				current: usage.uniqueWorkerDays,
-				include: overage.includedUniqueWorkerDays,
-				percentOfLimit: uniqueWorkerDayPercent,
-				overEightyPercent: uniqueWorkerDayPercent >= 0.8,
-			},
-			{
-				resource: 'durable_object_rows_read',
-				label: computeOverageWarningResourceLabels.durable_object_rows_read,
-				current: usage.durableObjectRowsRead,
-				include: overage.includedDurableObjectRowsRead,
-				percentOfLimit: durableObjectRowsReadPercent,
-				overEightyPercent: durableObjectRowsReadPercent >= 0.8,
-			},
-		],
-		disposition: resolveComputeOverageDisposition({
-			plan: input.plan,
-			ladder: input.ladder,
-			overage,
-			hasStripeCustomer: input.hasStripeCustomer,
-			chargingEnabled,
-			policy: computeOverageBillingPolicy,
-		}),
-		totalCents: overage.totalCents,
-		chargingEnabled,
-		hasStripeCustomer: input.hasStripeCustomer,
-		legacyUnbilled: overage.legacyUnbilled,
-	}
-}
-
-function toAccountUsageRow(
-	row: Awaited<
-		ReturnType<typeof readEntitlementUsageSnapshot>
-	>['resources'][number],
-): AccountUsageEntitlementConsumption {
+function toAccountUsageRow(row: {
+	resource: string
+	label: string
+	group: AccountUsageEntitlementConsumption['group']
+	kind: AccountUsageEntitlementConsumption['kind']
+	whatCounts: string
+	howToReduce: string
+	current: number
+	limit: number
+	percentOfLimit: number | null
+	overEightyPercent: boolean
+}): AccountUsageEntitlementConsumption {
 	return {
 		resource: row.resource,
 		label: row.label,

--- a/packages/worker/src/app/email/messages.ts
+++ b/packages/worker/src/app/email/messages.ts
@@ -92,11 +92,18 @@ export function buildUserEntitlementWarningEmail(input: {
 		current: number
 		limit: number
 		percentOfLimit: number
+		whatCounts?: string
+		howToReduce?: string
 	}>
 }) {
 	const lines = input.warnings.map((warning) => {
 		const percent = Math.round(warning.percentOfLimit * 100)
-		return `${warning.label} — ${warning.current.toLocaleString('en-US')} of ${warning.limit.toLocaleString('en-US')} (${percent}%).`
+		const counts = [
+			`${warning.label} — ${warning.current.toLocaleString('en-US')} of ${warning.limit.toLocaleString('en-US')} (${percent}%).`,
+			warning.whatCounts,
+			warning.howToReduce,
+		].filter((part): part is string => Boolean(part && part.trim()))
+		return counts.join(' ')
 	})
 	const copy = entitlementWarningCopy(input.kind)
 	return renderTransactionalEmail({

--- a/packages/worker/src/app/user-entitlement-warning-emails.node.test.ts
+++ b/packages/worker/src/app/user-entitlement-warning-emails.node.test.ts
@@ -732,7 +732,9 @@ test('compute include crossings mail for public and legacy without charging copy
 	const payload = sendCloudflareEmail.mock.calls[0]?.[1] as {
 		text: string
 	}
-	expect(payload.text).toContain('unique worker-days')
+	expect(payload.text).toContain('Unique worker days')
+	expect(payload.text).toContain('Dynamic Worker isolates')
+	expect(payload.text).toContain('Keep package code stable')
 	expect(
 		store.get(
 			userEntitlementWarningKvKey({

--- a/packages/worker/src/app/user-entitlement-warning-emails.ts
+++ b/packages/worker/src/app/user-entitlement-warning-emails.ts
@@ -9,7 +9,9 @@ import { readAdminEntitlementConsumption } from '#worker/admin/entitlement-consu
 import { readMonthlyComputeUsage } from '#worker/billing/compute-overage-usage.ts'
 import {
 	computeMonthlyOverage,
+	buildComputeOverageHowToReduce,
 	computeOverageIncludePercent,
+	computeOverageResourceVisibility,
 	computeOverageWarningResourceLabels,
 	computeOverageWarningResources,
 	type ComputeOverageWarningResource,
@@ -79,6 +81,8 @@ type WarningResource = {
 	current: number
 	limit: number
 	percentOfLimit: number
+	whatCounts?: string
+	howToReduce?: string
 }
 
 export type UserEntitlementWarningEmailResult =
@@ -226,6 +230,12 @@ async function warnOneUserIfNeeded(input: {
 			current: item.current,
 			limit: item.limit,
 			percentOfLimit: item.percentOfLimit,
+			...('whatCounts' in item && item.whatCounts
+				? { whatCounts: item.whatCounts }
+				: {}),
+			...('howToReduce' in item && item.howToReduce
+				? { howToReduce: item.howToReduce }
+				: {}),
 		}
 		if (item.percentOfLimit >= userEntitlementReachedThreshold) {
 			reached.push(warning)
@@ -667,12 +677,18 @@ async function readComputeOverageWarnings(input: {
 	return computeOverageWarningResources.map((resource) => {
 		const current = currentByResource[resource]
 		const limit = includeByResource[resource]
+		const percentOfLimit = computeOverageIncludePercent(current, limit) ?? 0
 		return {
 			resource,
 			label: computeOverageWarningResourceLabels[resource],
 			current,
 			limit,
-			percentOfLimit: computeOverageIncludePercent(current, limit) ?? 0,
+			percentOfLimit,
+			whatCounts: computeOverageResourceVisibility[resource].whatCounts,
+			howToReduce: buildComputeOverageHowToReduce(
+				resource,
+				overage.legacyUnbilled ? 'skip_legacy' : 'skip_zero',
+			),
 		}
 	})
 }

--- a/packages/worker/src/billing/compute-overage-account.ts
+++ b/packages/worker/src/billing/compute-overage-account.ts
@@ -1,0 +1,144 @@
+import { utcMonthKey } from '@kody-internal/shared/date-keys.ts'
+import {
+	buildComputeOverageHowToReduce,
+	computeMonthlyOverage,
+	computeOverageBillingPolicy,
+	computeOverageIncludePercent,
+	computeOverageResourceVisibility,
+	computeOverageWarningResourceLabels,
+	resolveComputeOverageDisposition,
+	type ComputeOverageDisposition,
+	type ComputeOverageWarningResource,
+} from '#universal/compute-overage.ts'
+import { type EntitlementLadder, type PlanName } from '#universal/plans.ts'
+import { type AccountUsageComputeOverage } from '#universal/loader-data.ts'
+import { isComputeOverageChargingEnabled } from './compute-overage-charging.ts'
+import { readMonthlyComputeUsage } from './compute-overage-usage.ts'
+
+export type ComputeOverageUsageRow = {
+	resource: ComputeOverageWarningResource
+	label: string
+	group: 'monthly'
+	kind: 'counter'
+	whatCounts: string
+	howToReduce: string
+	current: number
+	limit: number
+	percentOfLimit: number
+	overEightyPercent: boolean
+}
+
+export async function readAccountComputeOverage(input: {
+	db: D1Database
+	userId: number | null
+	stableUserId: string
+	plan: PlanName
+	ladder: EntitlementLadder
+	hasStripeCustomer: boolean
+	now: Date
+}): Promise<AccountUsageComputeOverage> {
+	const month = utcMonthKey(input.now)
+	const [usage, chargingEnabled] = await Promise.all([
+		readMonthlyComputeUsage({
+			db: input.db,
+			stableUserId: input.stableUserId,
+			month,
+		}),
+		isComputeOverageChargingEnabled(input.db, input.userId),
+	])
+	const overage = computeMonthlyOverage({
+		plan: input.plan,
+		ladder: input.ladder,
+		uniqueWorkerDays: usage.uniqueWorkerDays,
+		durableObjectRowsRead: usage.durableObjectRowsRead,
+	})
+	const uniqueWorkerDayPercent =
+		computeOverageIncludePercent(
+			usage.uniqueWorkerDays,
+			overage.includedUniqueWorkerDays,
+		) ?? 0
+	const durableObjectRowsReadPercent =
+		computeOverageIncludePercent(
+			usage.durableObjectRowsRead,
+			overage.includedDurableObjectRowsRead,
+		) ?? 0
+	const disposition = resolveComputeOverageDisposition({
+		plan: input.plan,
+		ladder: input.ladder,
+		overage,
+		hasStripeCustomer: input.hasStripeCustomer,
+		chargingEnabled,
+		policy: computeOverageBillingPolicy,
+	})
+	return {
+		meters: [
+			toComputeMeter({
+				resource: 'unique_worker_days',
+				current: usage.uniqueWorkerDays,
+				include: overage.includedUniqueWorkerDays,
+				percentOfLimit: uniqueWorkerDayPercent,
+				disposition,
+			}),
+			toComputeMeter({
+				resource: 'durable_object_rows_read',
+				current: usage.durableObjectRowsRead,
+				include: overage.includedDurableObjectRowsRead,
+				percentOfLimit: durableObjectRowsReadPercent,
+				disposition,
+			}),
+		],
+		disposition,
+		totalCents: overage.totalCents,
+		chargingEnabled,
+		hasStripeCustomer: input.hasStripeCustomer,
+		legacyUnbilled: overage.legacyUnbilled,
+	}
+}
+
+export function toComputeOverageUsageRows(
+	overage: AccountUsageComputeOverage,
+): Array<ComputeOverageUsageRow> {
+	return overage.meters.map((meter) => ({
+		resource: meter.resource,
+		label: meter.label,
+		group: 'monthly',
+		kind: 'counter',
+		whatCounts: meter.whatCounts,
+		howToReduce: meter.howToReduce,
+		current: meter.current,
+		limit: meter.include,
+		percentOfLimit: meter.percentOfLimit,
+		overEightyPercent: meter.overEightyPercent,
+	}))
+}
+
+export function computeOverageUsageWarningRows(
+	overage: AccountUsageComputeOverage,
+): Array<ComputeOverageUsageRow> {
+	return toComputeOverageUsageRows(overage).filter(
+		(row) => row.overEightyPercent,
+	)
+}
+
+function toComputeMeter(input: {
+	resource: ComputeOverageWarningResource
+	current: number
+	include: number
+	percentOfLimit: number
+	disposition: ComputeOverageDisposition
+}) {
+	const visibility = computeOverageResourceVisibility[input.resource]
+	return {
+		resource: input.resource,
+		label: computeOverageWarningResourceLabels[input.resource],
+		whatCounts: visibility.whatCounts,
+		howToReduce: buildComputeOverageHowToReduce(
+			input.resource,
+			input.percentOfLimit >= 1 ? input.disposition : 'skip_zero',
+		),
+		current: input.current,
+		include: input.include,
+		percentOfLimit: input.percentOfLimit,
+		overEightyPercent: input.percentOfLimit >= 0.8,
+	}
+}

--- a/packages/worker/src/billing/compute-overage-account.ts
+++ b/packages/worker/src/billing/compute-overage-account.ts
@@ -78,6 +78,7 @@ export async function readAccountComputeOverage(input: {
 				include: overage.includedUniqueWorkerDays,
 				percentOfLimit: uniqueWorkerDayPercent,
 				disposition,
+				legacyUnbilled: overage.legacyUnbilled,
 			}),
 			toComputeMeter({
 				resource: 'durable_object_rows_read',
@@ -85,6 +86,7 @@ export async function readAccountComputeOverage(input: {
 				include: overage.includedDurableObjectRowsRead,
 				percentOfLimit: durableObjectRowsReadPercent,
 				disposition,
+				legacyUnbilled: overage.legacyUnbilled,
 			}),
 		],
 		disposition,
@@ -126,6 +128,7 @@ function toComputeMeter(input: {
 	include: number
 	percentOfLimit: number
 	disposition: ComputeOverageDisposition
+	legacyUnbilled: boolean
 }) {
 	const visibility = computeOverageResourceVisibility[input.resource]
 	return {
@@ -134,7 +137,11 @@ function toComputeMeter(input: {
 		whatCounts: visibility.whatCounts,
 		howToReduce: buildComputeOverageHowToReduce(
 			input.resource,
-			input.percentOfLimit >= 1 ? input.disposition : 'skip_zero',
+			input.legacyUnbilled
+				? 'skip_legacy'
+				: input.percentOfLimit >= 1
+					? input.disposition
+					: 'skip_zero',
 		),
 		current: input.current,
 		include: input.include,

--- a/packages/worker/src/entitlements/errors.ts
+++ b/packages/worker/src/entitlements/errors.ts
@@ -1,4 +1,11 @@
 import {
+	buildComputeOverageHowToReduce,
+	computeOverageResourceVisibility,
+	computeOverageWarningResourceLabels,
+	type ComputeOverageDisposition,
+	type ComputeOverageWarningResource,
+} from '#universal/compute-overage.ts'
+import {
 	entitlementResourceLabels,
 	formatMinJobInterval,
 	parsePlanName,
@@ -157,6 +164,123 @@ function parseFormattedMinJobInterval(interval: string) {
 		return value
 	}
 	return null
+}
+
+export const computeOverageLimitErrorCode =
+	'compute_overage_include_reached' as const
+
+export type ComputeOverageLimitErrorDetails = {
+	code: typeof computeOverageLimitErrorCode
+	resource: ComputeOverageWarningResource
+	plan: PlanName
+	limit: number
+	current: number
+	whatCounts: string
+	upgradeHint: string
+	disposition: ComputeOverageDisposition
+}
+
+export function buildComputeOverageUpgradeHint(
+	resource: ComputeOverageWarningResource,
+	disposition?: ComputeOverageDisposition | null,
+) {
+	return buildComputeOverageHowToReduce(resource, disposition)
+}
+
+/**
+ * User-facing denial when an unpaid Free account is over a monthly
+ * compute include (soft-block). Paid public-ladder overage invoices
+ * instead; legacy is not cut. Enforcement points must not compose
+ * their own messages.
+ */
+export function buildComputeOverageLimitMessage(
+	details: ComputeOverageLimitErrorDetails,
+) {
+	const label = computeOverageWarningResourceLabels[details.resource]
+	return `Monthly compute include reached: your "${details.plan}" plan includes at most ${details.limit} ${label} this UTC month and you currently have ${details.current}. ${details.whatCounts} ${details.upgradeHint}`
+}
+
+export function parseComputeOverageLimitMessage(
+	message: string,
+): ComputeOverageLimitErrorDetails | null {
+	for (const [resource, label] of Object.entries(
+		computeOverageWarningResourceLabels,
+	) as Array<[ComputeOverageWarningResource, string]>) {
+		const match = new RegExp(
+			`^Monthly compute include reached: your "([^"]+)" plan includes at most (\\d+) ${escapeRegex(label)} this UTC month and you currently have (\\d+)\\. (.+)$`,
+		).exec(message)
+		if (!match) continue
+
+		const plan = parsePlanName(match[1])
+		if (!plan) return null
+		const limit = Number(match[2])
+		const current = Number(match[3])
+		if (!Number.isSafeInteger(limit) || !Number.isSafeInteger(current)) {
+			return null
+		}
+		const rest = match[4] ?? ''
+		const whatCounts = computeOverageResourceVisibility[resource].whatCounts
+		const upgradeHint = rest.startsWith(whatCounts)
+			? rest.slice(whatCounts.length).trim()
+			: rest
+		return {
+			code: computeOverageLimitErrorCode,
+			resource,
+			plan,
+			limit,
+			current,
+			whatCounts,
+			upgradeHint,
+			disposition: 'soft_block',
+		}
+	}
+	return null
+}
+
+export class ComputeOverageLimitError extends Error {
+	readonly details: ComputeOverageLimitErrorDetails
+
+	constructor(
+		details: Omit<
+			ComputeOverageLimitErrorDetails,
+			'code' | 'whatCounts' | 'upgradeHint'
+		> & {
+			whatCounts?: string
+			upgradeHint?: string
+		},
+	) {
+		const fullDetails: ComputeOverageLimitErrorDetails = {
+			code: computeOverageLimitErrorCode,
+			resource: details.resource,
+			plan: details.plan,
+			limit: details.limit,
+			current: details.current,
+			whatCounts:
+				details.whatCounts ??
+				computeOverageResourceVisibility[details.resource].whatCounts,
+			upgradeHint:
+				details.upgradeHint ??
+				buildComputeOverageUpgradeHint(details.resource, details.disposition),
+			disposition: details.disposition,
+		}
+		super(buildComputeOverageLimitMessage(fullDetails))
+		this.name = 'ComputeOverageLimitError'
+		this.details = fullDetails
+	}
+}
+
+export function isComputeOverageLimitError(
+	error: unknown,
+): error is ComputeOverageLimitError {
+	return (
+		error instanceof ComputeOverageLimitError ||
+		(error instanceof Error &&
+			'details' in error &&
+			typeof error.details === 'object' &&
+			error.details !== null &&
+			'code' in error.details &&
+			error.details.code === computeOverageLimitErrorCode)
+	)
 }
 
 export class JobIntervalFloorError extends Error {

--- a/packages/worker/src/entitlements/resource-visibility.ts
+++ b/packages/worker/src/entitlements/resource-visibility.ts
@@ -1,6 +1,11 @@
 import { type EntitlementResource } from '#universal/plans.ts'
 
-export type EntitlementResourceGroup = 'daily' | 'counts' | 'storage' | 'limits'
+export type EntitlementResourceGroup =
+	| 'monthly'
+	| 'daily'
+	| 'counts'
+	| 'storage'
+	| 'limits'
 
 export type EntitlementResourceVisibilityKind = 'counter' | 'per_unit_max'
 
@@ -8,6 +13,7 @@ export const entitlementResourceGroupLabels: Record<
 	EntitlementResourceGroup,
 	string
 > = {
+	monthly: 'Monthly compute',
 	daily: 'Daily rates',
 	counts: 'Resource counts',
 	storage: 'Storage',
@@ -17,6 +23,8 @@ export const entitlementResourceGroupLabels: Record<
 export const entitlementResourceGroupNotes: Partial<
 	Record<EntitlementResourceGroup, string>
 > = {
+	monthly:
+		'Included unique worker days and Durable Object rows-read this UTC month. Public-ladder overage invoices when a payment method is on file; unpaid Free is asked to upgrade.',
 	daily: 'Counters reset at UTC midnight.',
 }
 
@@ -149,6 +157,7 @@ export const accountUsageEntitlementResources = [
 ] as const satisfies ReadonlyArray<EntitlementResource>
 
 export const entitlementResourceGroupOrder: Array<EntitlementResourceGroup> = [
+	'monthly',
 	'daily',
 	'counts',
 	'storage',

--- a/packages/worker/src/jobs/service.ts
+++ b/packages/worker/src/jobs/service.ts
@@ -48,6 +48,7 @@ import {
 } from './types.ts'
 import { createJobStorageId, storageRunnerRpc } from '#worker/storage-runner.ts'
 import {
+	isComputeOverageLimitError,
 	isEntitlementLimitError,
 	JobIntervalFloorError,
 } from '#worker/entitlements/errors.ts'
@@ -1353,7 +1354,10 @@ export async function executeJobOnce(input: {
 				// Still return an error outcome so schedules advance, but do
 				// not emit job_run usage or else every post-limit tick
 				// inflates rollups while the UserMeter counter stays capped.
-				if (!isEntitlementLimitError(error)) {
+				if (
+					!isEntitlementLimitError(error) &&
+					!isComputeOverageLimitError(error)
+				) {
 					completedOccurrence = true
 				}
 			} finally {

--- a/packages/worker/src/mcp/capabilities/account/usage-get.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/account/usage-get.node.test.ts
@@ -31,7 +31,9 @@ function createUsageTestDb(input: {
 	plan: string
 	stripePlan?: string | null
 	entitlementLadder?: 'public' | 'legacy'
+	stripeCustomerId?: string | null
 	packageCount?: number
+	uniqueWorkerDays?: number
 }) {
 	const stableUserId = testStableUserIdFromEmail(input.email)
 	return {
@@ -43,6 +45,12 @@ function createUsageTestDb(input: {
 					bind(...params: Array<unknown>) {
 						return {
 							async first<T>() {
+								if (normalized.includes('stripe_customer_id')) {
+									return {
+										id: 1,
+										stripe_customer_id: input.stripeCustomerId ?? null,
+									} as T
+								}
 								if (
 									normalized.includes('from users') &&
 									normalized.includes('email')
@@ -69,6 +77,16 @@ function createUsageTestDb(input: {
 								return null
 							},
 							async all() {
+								if (normalized.includes('from usage_rollups')) {
+									const results = []
+									if ((input.uniqueWorkerDays ?? 0) > 0) {
+										results.push({
+											metric: 'dynamic_worker_day',
+											event_count: input.uniqueWorkerDays,
+										})
+									}
+									return { results }
+								}
 								return { results: [] }
 							},
 						}
@@ -108,7 +126,21 @@ test('usageGet returns self-scoped entitlement snapshot', async () => {
 
 	const result = await usageGetCapability.handler({}, { env, callerContext })
 	expect(result.plan).toBe('pro')
-	expect(result.resources.length).toBe(accountUsageEntitlementResources.length)
+	expect(result.resources.length).toBe(
+		accountUsageEntitlementResources.length + 2,
+	)
+	const uniqueWorkerDays = result.resources.find(
+		(row) => row.resource === 'unique_worker_days',
+	)
+	expect(uniqueWorkerDays?.label).toBe('Unique worker days')
+	expect(uniqueWorkerDays?.group).toBe('monthly')
+	expect(uniqueWorkerDays?.whatCounts).toMatch(/Dynamic Worker isolates/)
+	expect(uniqueWorkerDays?.howToReduce).toMatch(/Keep package code stable/)
+	expect(uniqueWorkerDays?.current).toBe(0)
+	expect(uniqueWorkerDays?.limit).toBe(
+		planLimits.pro.maxUniqueWorkerDaysPerMonth,
+	)
+	expect(uniqueWorkerDays?.overEightyPercent).toBe(false)
 	const saved = result.resources.find(
 		(row) => row.resource === 'saved_packages',
 	)
@@ -139,4 +171,36 @@ test('usageGet reports legacy Standard ceilings for grandfathered accounts', asy
 	)
 	expect(execute?.limit).toBe(legacyPlanLimits.standard.maxExecuteCallsPerDay)
 	expect(execute?.limit).not.toBe(planLimits.standard.maxExecuteCallsPerDay)
+})
+
+test('usageGet warns on unique worker days with whatCounts and howToReduce', async () => {
+	const email = 'uwd-usage-get@example.com'
+	const userId = testStableUserIdFromEmail(email)
+	const { db } = createUsageTestDb({
+		email,
+		plan: 'free',
+		uniqueWorkerDays: 50,
+	})
+	const env = withUsageEnv({ APP_DB: db }) as Env
+	const callerContext = createMcpCallerContext({
+		baseUrl: 'https://example.com',
+		user: { userId, email, displayName: 'Uwd' },
+	})
+
+	const result = await usageGetCapability.handler({}, { env, callerContext })
+	const uniqueWorkerDays = result.resources.find(
+		(row) => row.resource === 'unique_worker_days',
+	)
+	expect(uniqueWorkerDays?.current).toBe(50)
+	expect(uniqueWorkerDays?.limit).toBe(
+		planLimits.free.maxUniqueWorkerDaysPerMonth,
+	)
+	expect(uniqueWorkerDays?.percent).toBe(1)
+	expect(uniqueWorkerDays?.overEightyPercent).toBe(true)
+	expect(uniqueWorkerDays?.whatCounts).toMatch(/worker id \+ code/)
+	expect(uniqueWorkerDays?.howToReduce).toMatch(/saved packages or jobs/)
+	expect(uniqueWorkerDays?.howToReduce).toMatch(/payment method/)
+	expect(
+		result.warnings.some((row) => row.resource === 'unique_worker_days'),
+	).toBe(true)
 })

--- a/packages/worker/src/mcp/capabilities/account/usage-get.ts
+++ b/packages/worker/src/mcp/capabilities/account/usage-get.ts
@@ -4,13 +4,18 @@ import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
 import { emptyCapabilityInputSchema } from '#mcp/capabilities/types.ts'
 import { planNames } from '#universal/plans.ts'
+import {
+	computeOverageUsageWarningRows,
+	readAccountComputeOverage,
+	toComputeOverageUsageRows,
+} from '#worker/billing/compute-overage-account.ts'
 import { getUserEntitlement } from '#worker/entitlements/service.ts'
 import { readEntitlementUsageSnapshot } from '#worker/entitlements/usage-snapshot.ts'
 
 const usageResourceSchema = z.object({
 	resource: z.string(),
 	label: z.string(),
-	group: z.enum(['daily', 'counts', 'storage', 'limits']),
+	group: z.enum(['monthly', 'daily', 'counts', 'storage', 'limits']),
 	kind: z.enum(['counter', 'per_unit_max']),
 	whatCounts: z.string(),
 	howToReduce: z.string(),
@@ -25,8 +30,17 @@ export const usageGetCapability = defineDomainCapability(
 	{
 		name: 'usageGet',
 		description:
-			'Read the signed-in user’s entitlement usage against plan limits: per-resource current, limit, percent used, and plain-language guidance on what counts and how to reduce it.',
-		keywords: ['account', 'usage', 'quota', 'limits', 'entitlements', 'plan'],
+			'Read the signed-in user’s entitlement usage against plan limits, including monthly unique worker days (Dynamic Worker isolates) and Durable Object rows-read: per-resource current, limit, percent used, and plain-language guidance on what counts and how to reduce it.',
+		keywords: [
+			'account',
+			'usage',
+			'quota',
+			'limits',
+			'entitlements',
+			'plan',
+			'unique worker days',
+			'dynamic worker',
+		],
 		readOnly: true,
 		idempotent: true,
 		destructive: false,
@@ -45,18 +59,48 @@ export const usageGetCapability = defineDomainCapability(
 				userId: user.userId,
 				email: user.email,
 			})
-			const snapshot = await readEntitlementUsageSnapshot({
-				db,
-				env: ctx.env,
-				usageUserId: user.userId,
-				plan: entitlement.plan,
-				ladder: entitlement.ladder,
-			})
-			const mapRow = (
-				row: Awaited<
-					ReturnType<typeof readEntitlementUsageSnapshot>
-				>['resources'][number],
-			) => ({
+			const billing = await db
+				.prepare(
+					user.email
+						? `SELECT id, stripe_customer_id FROM users WHERE email = ? AND stable_user_id = ?`
+						: `SELECT id, stripe_customer_id FROM users WHERE stable_user_id = ?`,
+				)
+				.bind(
+					...(user.email
+						? [user.email.trim().toLowerCase(), user.userId]
+						: [user.userId]),
+				)
+				.first<{ id: number; stripe_customer_id: string | null }>()
+			const [snapshot, computeOverage] = await Promise.all([
+				readEntitlementUsageSnapshot({
+					db,
+					env: ctx.env,
+					usageUserId: user.userId,
+					plan: entitlement.plan,
+					ladder: entitlement.ladder,
+				}),
+				readAccountComputeOverage({
+					db,
+					userId: billing?.id ?? null,
+					stableUserId: user.userId,
+					plan: entitlement.plan,
+					ladder: entitlement.ladder,
+					hasStripeCustomer: Boolean(billing?.stripe_customer_id?.trim()),
+					now: new Date(),
+				}),
+			])
+			const mapRow = (row: {
+				resource: string
+				label: string
+				group: 'monthly' | 'daily' | 'counts' | 'storage' | 'limits'
+				kind: 'counter' | 'per_unit_max'
+				whatCounts: string
+				howToReduce: string
+				current: number
+				limit: number
+				percentOfLimit: number | null
+				overEightyPercent: boolean
+			}) => ({
 				resource: row.resource,
 				label: row.label,
 				group: row.group,
@@ -68,11 +112,18 @@ export const usageGetCapability = defineDomainCapability(
 				percent: row.percentOfLimit,
 				overEightyPercent: row.overEightyPercent,
 			})
+			const computeRows = toComputeOverageUsageRows(computeOverage)
 			return {
 				plan: snapshot.plan,
 				day: snapshot.today,
-				resources: snapshot.resources.map(mapRow),
-				warnings: snapshot.warnings.map(mapRow),
+				resources: [
+					...computeRows.map(mapRow),
+					...snapshot.resources.map(mapRow),
+				],
+				warnings: [
+					...computeOverageUsageWarningRows(computeOverage).map(mapRow),
+					...snapshot.warnings.map(mapRow),
+				],
 			}
 		},
 	},

--- a/packages/worker/src/mcp/entitlement-metadata.node.test.ts
+++ b/packages/worker/src/mcp/entitlement-metadata.node.test.ts
@@ -1,10 +1,12 @@
 import { expect, test } from 'vitest'
 import { planLimits } from '#universal/plans.ts'
 import {
+	ComputeOverageLimitError,
 	EntitlementLimitError,
 	JobIntervalFloorError,
 	buildEntitlementUpgradeHint,
 	buildJobIntervalFloorUpgradeHint,
+	computeOverageLimitErrorCode,
 	entitlementLimitErrorCode,
 	jobIntervalFloorErrorCode,
 } from '#worker/entitlements/errors.ts'
@@ -92,6 +94,37 @@ test('entitlement metadata is only for known plan-limit and quota denials', () =
 		upgradeHint: buildJobIntervalFloorUpgradeHint(),
 		minIntervalMs: intervalMs,
 	})
+	const computeDenial = new ComputeOverageLimitError({
+		resource: 'unique_worker_days',
+		plan: 'free',
+		limit: planLimits.free.maxUniqueWorkerDaysPerMonth,
+		current: planLimits.free.maxUniqueWorkerDaysPerMonth,
+		disposition: 'soft_block',
+	})
+	expect(toMcpEntitlementMetadata(computeDenial)).toEqual({
+		code: computeOverageLimitErrorCode,
+		resource: 'unique_worker_days',
+		plan: 'free',
+		limit: planLimits.free.maxUniqueWorkerDaysPerMonth,
+		current: planLimits.free.maxUniqueWorkerDaysPerMonth,
+		whatCounts: computeDenial.details.whatCounts,
+		upgradeHint: computeDenial.details.upgradeHint,
+		disposition: 'soft_block',
+	})
+	expect(computeDenial.message).toMatch(/Dynamic Worker isolates/)
+	expect(computeDenial.message).toMatch(/Keep package code stable/)
+	expect(computeDenial.message).toMatch(/payment method/)
+	expect(toMcpEntitlementMetadata(new Error(computeDenial.message))).toEqual({
+		code: computeOverageLimitErrorCode,
+		resource: 'unique_worker_days',
+		plan: 'free',
+		limit: planLimits.free.maxUniqueWorkerDaysPerMonth,
+		current: planLimits.free.maxUniqueWorkerDaysPerMonth,
+		whatCounts: computeDenial.details.whatCounts,
+		upgradeHint: computeDenial.details.upgradeHint,
+		disposition: 'soft_block',
+	})
+
 	expect(toMcpEntitlementMetadata(new Error('Boom'))).toBeUndefined()
 	expect(entitlementStructuredContent(new Error('Boom'))).toEqual({})
 })

--- a/packages/worker/src/mcp/entitlement-metadata.ts
+++ b/packages/worker/src/mcp/entitlement-metadata.ts
@@ -1,11 +1,15 @@
 import { getErrorMessage } from '@kody-internal/shared/error-message.ts'
 import {
+	computeOverageLimitErrorCode,
 	entitlementLimitErrorCode,
+	isComputeOverageLimitError,
 	isEntitlementLimitError,
 	isJobIntervalFloorError,
 	jobIntervalFloorErrorCode,
+	parseComputeOverageLimitMessage,
 	parseEntitlementLimitMessage,
 	parseJobIntervalFloorMessage,
+	type ComputeOverageLimitErrorDetails,
 	type EntitlementLimitErrorDetails,
 	type JobIntervalFloorErrorDetails,
 } from '#worker/entitlements/errors.ts'
@@ -34,12 +38,25 @@ export type McpEntitlementMetadata =
 			upgradeHint: string
 			minIntervalMs: number
 	  }
+	| {
+			code: typeof computeOverageLimitErrorCode
+			resource: ComputeOverageLimitErrorDetails['resource']
+			plan: ComputeOverageLimitErrorDetails['plan']
+			limit: number
+			current: number
+			whatCounts: string
+			upgradeHint: string
+			disposition: ComputeOverageLimitErrorDetails['disposition']
+	  }
 
 export function toMcpEntitlementMetadata(
 	error: unknown,
 ): McpEntitlementMetadata | undefined {
 	if (isEntitlementLimitError(error)) {
 		return toEntitlementLimitMetadata(error.details)
+	}
+	if (isComputeOverageLimitError(error)) {
+		return toComputeOverageLimitMetadata(error.details)
 	}
 	if (isJobIntervalFloorError(error)) {
 		return toJobIntervalMetadata(error.details)
@@ -48,6 +65,8 @@ export function toMcpEntitlementMetadata(
 	const message = getErrorMessage(error)
 	const entitlementDetails = parseEntitlementLimitMessage(message)
 	if (entitlementDetails) return toEntitlementLimitMetadata(entitlementDetails)
+	const computeDetails = parseComputeOverageLimitMessage(message)
+	if (computeDetails) return toComputeOverageLimitMetadata(computeDetails)
 	const intervalDetails = parseJobIntervalFloorMessage(message)
 	if (intervalDetails) return toJobIntervalMetadata(intervalDetails)
 	return undefined
@@ -79,6 +98,21 @@ function toEntitlementLimitMetadata(
 		...metadata,
 		used: details.current,
 		remaining: Math.max(0, details.limit - details.current),
+	}
+}
+
+function toComputeOverageLimitMetadata(
+	details: ComputeOverageLimitErrorDetails,
+): McpEntitlementMetadata {
+	return {
+		code: computeOverageLimitErrorCode,
+		resource: details.resource,
+		plan: details.plan,
+		limit: details.limit,
+		current: details.current,
+		whatCounts: details.whatCounts,
+		upgradeHint: details.upgradeHint,
+		disposition: details.disposition,
 	}
 }
 

--- a/packages/worker/src/mcp/executor.node.test.ts
+++ b/packages/worker/src/mcp/executor.node.test.ts
@@ -9,6 +9,7 @@ import {
 import { retrieverOutboundFetchDeniedMessage } from '#mcp/fetch-gateway.ts'
 import { createKodyProviderProxySource } from '#mcp/kody-provider-proxy-source.ts'
 import {
+	ComputeOverageLimitError,
 	EntitlementLimitError,
 	JobIntervalFloorError,
 } from '#worker/entitlements/errors.ts'
@@ -1553,6 +1554,40 @@ test('executor maps secret errors, formats guidance, extracts raw content, and t
 			limit: 3,
 			current: 3,
 			upgradeHint: 'Remove an old package or upgrade your plan.',
+		},
+	})
+
+	const computeOverageError = new ComputeOverageLimitError({
+		resource: 'unique_worker_days',
+		plan: 'free',
+		limit: 50,
+		current: 60,
+		disposition: 'soft_block',
+	})
+	expect(getExecutionErrorDetails(computeOverageError)).toMatchObject({
+		kind: 'compute_overage_include_reached',
+		nextStep: expect.stringMatching(/Keep package code stable/),
+		details: {
+			code: 'compute_overage_include_reached',
+			resource: 'unique_worker_days',
+			plan: 'free',
+			limit: 50,
+			current: 60,
+			disposition: 'soft_block',
+		},
+		suggestedAction: {
+			type: 'review_plan_limit',
+			resource: 'unique_worker_days',
+		},
+	})
+	expect(computeOverageError.message).toMatch(/Dynamic Worker isolates/)
+	expect(
+		getExecutionErrorDetails(new Error(computeOverageError.message)),
+	).toMatchObject({
+		kind: 'compute_overage_include_reached',
+		suggestedAction: {
+			type: 'review_plan_limit',
+			resource: 'unique_worker_days',
 		},
 	})
 

--- a/packages/worker/src/mcp/executor.ts
+++ b/packages/worker/src/mcp/executor.ts
@@ -38,10 +38,13 @@ import {
 } from '#mcp/secrets/errors.ts'
 import { type SecretScope } from '#mcp/secrets/types.ts'
 import {
+	isComputeOverageLimitError,
 	isEntitlementLimitError,
 	isJobIntervalFloorError,
+	parseComputeOverageLimitMessage,
 	parseEntitlementLimitMessage,
 	parseJobIntervalFloorMessage,
+	type ComputeOverageLimitErrorDetails,
 	type EntitlementLimitErrorDetails,
 } from '#worker/entitlements/errors.ts'
 import { buildIntegrationReconnectHref } from '#universal/connection-trouble.ts'
@@ -1194,6 +1197,16 @@ export type ExecutionErrorDetails =
 			}
 	  }
 	| {
+			kind: 'compute_overage_include_reached'
+			message: string
+			nextStep: string
+			details: ComputeOverageLimitErrorDetails
+			suggestedAction: {
+				type: 'review_plan_limit'
+				resource: ComputeOverageLimitErrorDetails['resource']
+			}
+	  }
+	| {
 			kind: 'job_interval_floor'
 			message: string
 			nextStep: string
@@ -1291,6 +1304,10 @@ export function getExecutionErrorDetails(
 		return toEntitlementExecutionErrorDetails(message, error.details)
 	}
 
+	if (isComputeOverageLimitError(error)) {
+		return toComputeOverageExecutionErrorDetails(message, error.details)
+	}
+
 	if (isJobIntervalFloorError(error)) {
 		return {
 			kind: 'job_interval_floor',
@@ -1306,6 +1323,11 @@ export function getExecutionErrorDetails(
 	const entitlementDetails = parseEntitlementLimitMessage(message)
 	if (entitlementDetails) {
 		return toEntitlementExecutionErrorDetails(message, entitlementDetails)
+	}
+
+	const computeDetails = parseComputeOverageLimitMessage(message)
+	if (computeDetails) {
+		return toComputeOverageExecutionErrorDetails(message, computeDetails)
 	}
 
 	const intervalDetails = parseJobIntervalFloorMessage(message)
@@ -1650,6 +1672,22 @@ function toEntitlementExecutionErrorDetails(
 		kind: 'entitlement_limit_exceeded',
 		message,
 		nextStep: details.upgradeHint,
+		details,
+		suggestedAction: {
+			type: 'review_plan_limit',
+			resource: details.resource,
+		},
+	}
+}
+
+function toComputeOverageExecutionErrorDetails(
+	message: string,
+	details: ComputeOverageLimitErrorDetails,
+): ExecutionErrorDetails {
+	return {
+		kind: 'compute_overage_include_reached',
+		message,
+		nextStep: `${details.whatCounts} ${details.upgradeHint}`,
 		details,
 		suggestedAction: {
 			type: 'review_plan_limit',

--- a/packages/worker/src/mcp/observability.ts
+++ b/packages/worker/src/mcp/observability.ts
@@ -3,6 +3,7 @@ import { type McpCallerContext } from '@kody-internal/shared/chat.ts'
 import { getErrorCauseChain } from '@kody-internal/shared/error-message.ts'
 import { CommunityActionError } from '#worker/community/errors.ts'
 import {
+	isComputeOverageLimitError,
 	isEntitlementLimitError,
 	isJobIntervalFloorError,
 } from '#worker/entitlements/errors.ts'
@@ -110,6 +111,7 @@ function isCallerFailure(payload: McpObservabilityPayload, cause?: unknown) {
 	if (payload.callerError) return true
 	if (isUserCodeError(cause)) return true
 	if (getErrorCauseChain(cause).some(isEntitlementLimitError)) return true
+	if (getErrorCauseChain(cause).some(isComputeOverageLimitError)) return true
 	if (getErrorCauseChain(cause).some(isJobIntervalFloorError)) return true
 	// Community preconditions (rate before fork, self-rate, banned, …) are
 	// caller-clearable; keep them on mcp-event and out of Sentry.

--- a/packages/worker/src/sentry-options.node.test.ts
+++ b/packages/worker/src/sentry-options.node.test.ts
@@ -1,5 +1,8 @@
 import { expect, test } from 'vitest'
-import { EntitlementLimitError } from './entitlements/errors.ts'
+import {
+	ComputeOverageLimitError,
+	EntitlementLimitError,
+} from './entitlements/errors.ts'
 import { isUserCodeError, UserCodeError } from './user-code-error.ts'
 import {
 	cloudflareArtifactsOpaqueInternalErrorMessage,
@@ -453,6 +456,29 @@ test('filterSentryEvent drops expected platform and caller noise and keeps real 
 		}),
 	).toBeNull()
 	expect(filterSentryEvent(entitlementEvent)).toBeNull()
+	const computeOverageError = new ComputeOverageLimitError({
+		resource: 'unique_worker_days',
+		plan: 'free',
+		limit: 50,
+		current: 60,
+		disposition: 'soft_block',
+	})
+	const computeOverageEvent = {
+		exception: {
+			values: [
+				{
+					type: 'ComputeOverageLimitError',
+					value: computeOverageError.message,
+				},
+			],
+		},
+	}
+	expect(
+		filterSentryEvent(computeOverageEvent, {
+			originalException: computeOverageError,
+		}),
+	).toBeNull()
+	expect(filterSentryEvent(computeOverageEvent)).toBeNull()
 	expect(
 		filterSentryEvent(
 			{

--- a/packages/worker/src/sentry-options.ts
+++ b/packages/worker/src/sentry-options.ts
@@ -3,7 +3,10 @@ import { type ErrorEvent, type EventHint } from '@sentry/core'
 import { getErrorCauseChain } from '@kody-internal/shared/error-message.ts'
 import { isRetryableD1LockSentryEvent } from './d1-retry.ts'
 import { isCimdUnknownClientSentryMessage } from './oauth-cimd-error.ts'
-import { isEntitlementLimitError } from './entitlements/errors.ts'
+import {
+	isComputeOverageLimitError,
+	isEntitlementLimitError,
+} from './entitlements/errors.ts'
 import { isIntegrationTokenRefreshCallerMessage } from './integrations/token-refresh.ts'
 import { isArtifactsGitTransientErrorMessage } from './repo/artifacts-git-retry.ts'
 import { isUserCodeError } from './user-code-error.ts'
@@ -48,13 +51,18 @@ export function isEntitlementLimitErrorSentryEvent(
 	hint?: EventHint,
 ) {
 	if (
-		getErrorCauseChain(hint?.originalException).some(isEntitlementLimitError)
+		getErrorCauseChain(hint?.originalException).some(
+			(error) =>
+				isEntitlementLimitError(error) || isComputeOverageLimitError(error),
+		)
 	) {
 		return true
 	}
 	return (
 		event.exception?.values?.some(
-			(value) => value.type === 'EntitlementLimitError',
+			(value) =>
+				value.type === 'EntitlementLimitError' ||
+				value.type === 'ComputeOverageLimitError',
 		) ?? false
 	)
 }

--- a/packages/worker/universal/compute-overage.node.test.ts
+++ b/packages/worker/universal/compute-overage.node.test.ts
@@ -1,8 +1,10 @@
 import { expect, test } from 'vitest'
 import {
+	buildComputeOverageHowToReduce,
 	computeMonthlyOverage,
 	computeOverageBillingPolicy,
 	computeOverageIncludePercent,
+	computeOverageResourceVisibility,
 	previousUtcMonthKey,
 	resolveComputeOverageDisposition,
 	type ComputeOverageDisposition,
@@ -252,6 +254,23 @@ test('public policy invoices paid customers, soft-blocks unpaid Free, and never 
 	for (const [label, input, expected] of cases) {
 		expect(resolveComputeOverageDisposition(input), label).toBe(expected)
 	}
+})
+
+test('unique worker days visibility explains the meter and next step', () => {
+	const visibility = computeOverageResourceVisibility.unique_worker_days
+	expect(visibility.whatCounts).toMatch(/Dynamic Worker isolates/)
+	expect(visibility.whatCounts).toMatch(/UTC day/)
+	expect(visibility.howToReduce).toMatch(/Keep package code stable/)
+	expect(visibility.howToReduce).toMatch(/saved packages or jobs/)
+	expect(
+		buildComputeOverageHowToReduce('unique_worker_days', 'soft_block'),
+	).toMatch(/add a payment method/)
+	expect(
+		buildComputeOverageHowToReduce('unique_worker_days', 'invoice'),
+	).toMatch(/\$0\.0025 per unique worker day/)
+	expect(
+		buildComputeOverageHowToReduce('unique_worker_days', 'skip_legacy'),
+	).toMatch(/not billed/)
 })
 
 test('previousUtcMonthKey walks across year boundaries', () => {

--- a/packages/worker/universal/compute-overage.ts
+++ b/packages/worker/universal/compute-overage.ts
@@ -65,9 +65,44 @@ export type ComputeOverageWarningResource =
 	(typeof computeOverageWarningResources)[number]
 
 export const computeOverageWarningResourceLabels = {
-	unique_worker_days: 'unique worker-days',
+	unique_worker_days: 'Unique worker days',
 	durable_object_rows_read: 'Durable Object rows read',
 } as const satisfies Record<ComputeOverageWarningResource, string>
+
+export type ComputeOverageResourceVisibility = {
+	group: 'monthly'
+	kind: 'counter'
+	whatCounts: string
+	howToReduce: string
+}
+
+/**
+ * Plain-language copy for account usage UI, `usageGet`, warning emails,
+ * and compute-include denials. Keep factual and terse; update when
+ * overage policy changes. Not a hard entitlement — see
+ * {@link computeMeteringPolicy} / {@link resolveComputeOverageDisposition}.
+ */
+export const computeOverageResourceVisibility = {
+	unique_worker_days: {
+		group: 'monthly',
+		kind: 'counter',
+		whatCounts:
+			'Counts distinct Cloudflare Dynamic Worker isolates (worker id + code) that run on a given UTC day, rolled up for the month. Reusing the same warm isolate typically does not add another day.',
+		howToReduce:
+			'Keep package code stable so isolates stay warm, and consolidate one-off execute runs into saved packages or jobs.',
+	},
+	durable_object_rows_read: {
+		group: 'monthly',
+		kind: 'counter',
+		whatCounts:
+			'SQLite rows read by your Durable Object package storage this UTC month.',
+		howToReduce:
+			'Read less from package storage, cache repeated queries, or upgrade your plan.',
+	},
+} as const satisfies Record<
+	ComputeOverageWarningResource,
+	ComputeOverageResourceVisibility
+>
 
 export type MonthlyComputeOverage = {
 	includedUniqueWorkerDays: number
@@ -211,6 +246,56 @@ export function resolveComputeOverageDisposition(
 		return 'skip_below_minimum'
 	}
 	return 'invoice'
+}
+
+/**
+ * Actionable reduction + billing next step for one monthly compute meter.
+ * Disposition is optional: omit it for the generic under-include prompt.
+ */
+export function buildComputeOverageHowToReduce(
+	resource: ComputeOverageWarningResource,
+	disposition?: ComputeOverageDisposition | null,
+): string {
+	const base = computeOverageResourceVisibility[resource].howToReduce
+	const billing = computeOverageBillingGuidance(resource, disposition)
+	return billing ? `${base} ${billing}` : base
+}
+
+function computeOverageBillingGuidance(
+	resource: ComputeOverageWarningResource,
+	disposition?: ComputeOverageDisposition | null,
+): string {
+	const uniqueWorkerDayRate = `$${computeOverageRatesUsd.uniqueWorkerDay}`
+	const rowsReadRate = `$${computeOverageRatesUsd.durableObjectRowsReadPerMillion} per million`
+	switch (disposition) {
+		case 'soft_block':
+			return 'Upgrade your plan or add a payment method at /account/billing. Free accounts without a payment method are asked to upgrade instead of being charged for overage.'
+		case 'invoice':
+			return resource === 'unique_worker_days'
+				? `Usage above this month's include is billed at ${uniqueWorkerDayRate} per unique worker day after the UTC month closes.`
+				: `Usage above this month's include is billed at ${rowsReadRate} rows read after the UTC month closes.`
+		case 'skip_legacy':
+			return 'Legacy Standard and Pro are not billed for this overage. Changing plan moves you onto public rates.'
+		case 'dry_run':
+			return 'Overage is being recorded but is not billed while charging is paused.'
+		case 'skip_below_minimum':
+			return resource === 'unique_worker_days'
+				? `Public-ladder overage is billed at ${uniqueWorkerDayRate} per unique worker day when a payment method is on file. Amounts below Stripe's $0.50 minimum are not invoiced.`
+				: `Public-ladder overage is billed at ${rowsReadRate} rows read when a payment method is on file. Amounts below Stripe's $0.50 minimum are not invoiced.`
+		case 'skip_zero':
+		case 'skip_audience':
+		case undefined:
+		case null:
+			return resource === 'unique_worker_days'
+				? `Upgrade your plan for a higher include, or add a payment method to continue on public-ladder overage at ${uniqueWorkerDayRate} per unique worker day.`
+				: 'Upgrade your plan for a higher include, or add a payment method to continue on public-ladder overage.'
+		default: {
+			const exhaustive: never = disposition
+			throw new Error(
+				`Unknown compute overage disposition: ${String(exhaustive)}`,
+			)
+		}
+	}
 }
 
 /** Previous UTC `YYYY-MM` for a clock instant. */

--- a/packages/worker/universal/loader-data.ts
+++ b/packages/worker/universal/loader-data.ts
@@ -1913,7 +1913,7 @@ export type AccountBillingSuccessLoaderData = {
 export type AccountUsageEntitlementConsumption = {
 	resource: string
 	label: string
-	group: 'daily' | 'counts' | 'storage' | 'limits'
+	group: 'daily' | 'counts' | 'storage' | 'limits' | 'monthly'
 	kind: 'counter' | 'per_unit_max'
 	whatCounts: string
 	howToReduce: string
@@ -1926,6 +1926,8 @@ export type AccountUsageEntitlementConsumption = {
 export type AccountUsageComputeMeter = {
 	resource: ComputeOverageWarningResource
 	label: string
+	whatCounts: string
+	howToReduce: string
 	current: number
 	include: number
 	percentOfLimit: number


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Make unique worker days (Dynamic Worker isolate metering) self-explanatory and actionable wherever people and agents see plan usage or hit a compute-include limit.

## Why

A production user hit a plan limit named roughly “unique worker days” with no explanation of what it counts or what to do. `usageGet` already explains daily/counts/storage/limits with `whatCounts` + `howToReduce`, but this monthly overage meter was missing from that snapshot. Pricing already lists Free 50 / Standard 350 / Pro 2,000 and $0.0025 overage for public-ladder accounts with a payment method — this change does not invent billing policy.

## Summary

- Shared `whatCounts` / `howToReduce` copy for unique worker days and Durable Object rows-read, including disposition-aware next steps (upgrade / add payment, expect overage invoice, legacy unbilled).
- `usageGet` includes these monthly meters with current / include / percent and 80% warnings.
- Account `/account/usage` monthly table and approaching-limits list show the same guidance.
- Warning emails include the explanation instead of a bare label.
- New `ComputeOverageLimitError` (`compute_overage_include_reached`) carries that copy in execute/jobs structured entitlement errors. Unpaid Free remains a soft-block (upgrade prompt, no charge); paid public-ladder still invoices; legacy is still not cut or billed.
- Follow-up: legacy accounts approaching include now keep unbilled copy instead of public-ladder payment-method rates.

## Testing

- Focused node tests: `usageGet`, compute-overage copy, entitlement metadata, executor error details, account usage data (including legacy approaching include), warning emails.
- Pre-push on `5b842b50`: `test:node` (2745) and `test:workers` (336) passed.
- Bugbot on `9c64daf1` found one valid issue (legacy approaching-include copy); fixed. Re-review of `5b842b50` found no new issues.
- CodeRabbit nits on `9c64daf1` skipped: UTC midnight split timestamp is insignificant; disposition round-trip is unused because execute/jobs do not throw this error; “per million rows read” is not duplicated.
- Preview `https://kody-pr-2111.kody-a99.workers.dev` serving merge of `5b842b50`. Seed user `me@kentcdodds.com`: `GET /account/usage.json` 200 with Unique worker days 0/50 plus isolate/what-counts/how-to-reduce copy; `/account/usage` UI shows Monthly compute with both meters.

![Preview /account/usage Monthly compute](https://cursor.com/artifacts/c/art-690194aa-351f-425f-9fa2-42d5ab6207da)
<a href="https://cursor.com/agents/bc-825b4cbc-d619-4d65-aac8-3d17e59d45f2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpreview_account_usage_monthly_compute.mp4"><img src="https://cursor.com/artifacts/c/art-e57c3f81-2fd4-4c03-87be-4f342cd464ab" alt="preview_account_usage_monthly_compute.mp4" /></a>

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `73834bff` · **Head:** `5b842b50`

**Classification:** extends — monthly compute meters join the existing usage-resource contract (`whatCounts` / `howToReduce` / 80% warnings) and a structured include-reached error, without adding a new primitive or changing allotments.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `entitlements` | auth | extends — visibility copy, monthly group, `ComputeOverageLimitError` |
| `mcp-server` | surfaces | extends — `usageGet` resources/warnings, execute/MCP entitlement metadata |
| `app-ui` | surfaces | extends — account usage table/warnings and user warning emails |
| `billing` | auth | extends — shared account compute-overage snapshot with guidance |
| `jobs` | assistant | composes — treat compute-include denials like other plan-limit errors |
| `account-export` | assistant | composes — `usageGet` lives under account capabilities (no export shape change) |

### Change flow

`usageGet` and the account usage page load the same monthly compute snapshot. Soft-block denials reuse that copy in structured execute errors.

```mermaid
sequenceDiagram
	actor Agent
	actor User
	participant mcpServer as mcp-server
	participant entitlements as entitlements
	participant billing as billing
	participant appUi as app-ui
	Agent->>mcpServer: usageGet
	mcpServer->>entitlements: read hard entitlement snapshot
	mcpServer->>billing: read monthly unique worker days
	billing-->>mcpServer: current, include, whatCounts, howToReduce
	mcpServer-->>Agent: resources and 80% warnings
	User->>appUi: open /account/usage
	appUi->>billing: same compute snapshot
	appUi-->>User: monthly table plus approaching list
	Note over entitlements,mcpServer: ComputeOverageLimitError carries the same guidance
```

### Before / after

```text
Before: usageGet omitted unique_worker_days. Usage UI showed a bare label and percent.
After:  usageGet + UI + emails include whatCounts/howToReduce. Limit errors use the same copy.
```

### Invariants

Per-user isolation is unchanged. Unique worker days stay out of `entitlementResources` (no hard cut). Public-ladder overage, unpaid-Free soft-block, and legacy no-cut-no-bill are unchanged.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-825b4cbc-d619-4d65-aac8-3d17e59d45f2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-825b4cbc-d619-4d65-aac8-3d17e59d45f2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Monthly compute section showing unique worker days and Durable Object rows-read usage.
  - Added plain-language explanations of what counts and how to reduce usage across usage views, APIs, and warning emails.
  - Added upgrade guidance for Free accounts approaching or exceeding included limits.
  - Added structured compute-limit error details for supported execution and job workflows, including soft-block guidance.

- **Documentation**
  - Updated architecture and usage-metering documentation with monthly compute behavior and guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->