### PR TITLE
Invite team-account FAQ readers to email support

### DIFF
--- a/packages/worker/client/routes/faq.tsx
+++ b/packages/worker/client/routes/faq.tsx
@@ -98,6 +98,11 @@ const faqItems: ReadonlyArray<FaqItem> = [
 					fork the installer owns.
 				</p>
 				<p>
+					Trying to run Kody across a team, or have other multi-user needs?
+					Email <a href="mailto:support@kody.codes">support@kody.codes</a> —
+					we&rsquo;re shaping that and want to hear what you need.
+				</p>
+				<p>
 					<a href={routes.community.href()}>Public packages</a>
 				</p>
 			</>

--- a/packages/worker/client/routes/legal-last-updated.ts
+++ b/packages/worker/client/routes/legal-last-updated.ts
@@ -1,2 +1,2 @@
-export const termsLastUpdated = '2026-09-04'
+export const termsLastUpdated = '2026-09-07'
 export const privacyLastUpdated = '2026-09-02'

--- a/packages/worker/client/routes/terms.tsx
+++ b/packages/worker/client/routes/terms.tsx
@@ -43,6 +43,7 @@ export function TermsRoute(_handle: Handle) {
 				<p mix={css(descriptionCss)}>
 					You are responsible for activity under your account, including agents
 					and packages you connect or run. Keep credentials and secrets private.
+					Accounts are for individual use; sharing a login is not supported.
 					Give us accurate account information, and tell us promptly if you
 					think someone else has access. You may export or delete your account
 					data from Account settings.

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -1578,6 +1578,8 @@ test('renderAppPage renders the public FAQ page for anonymous visitors', async (
 	const html = await readResponseText(response)
 	expect(html).toContain('<title>FAQ</title>')
 	expect(html).toContain('data-faq="replace-agents"')
+	expect(html).toContain('data-faq="shared-account"')
+	expect(html).toContain('mailto:support@kody.codes')
 	expect(html).toContain('<details')
 	expect(html).toContain('<summary>')
 	expect(html).toContain('href="/faq">FAQ</a>')


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Keep the FAQ’s “no shared account” answer, and invite people with real multi-user needs to email support so we can learn what to build.

## Why

Isolation is still the product. The Pricing page already asks Teams / Enterprise readers to email us. The FAQ said “no” without that invite, so people with team needs had no next step.

## Summary

- FAQ “Can my team share one Kody account?” still says no / isolation is the feature, then invites readers to email `support@kody.codes` — same spirit as Pricing, no seats product or ship date.
- Terms “Your account” adds one aligned sentence: accounts are for individual use; sharing a login is not supported.
- FAQ SSR test now asserts the shared-account item and support mailto.

## Testing

- `test:node` and `test:workers` passed on push (pre-commit hook).
- Browser verification of `/faq` and `/terms` follows this draft.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `815fcb72` · **Head:** `326d6066`

**Classification:** composes — no primitives added or changed; this PR only updates public copy on existing app-ui routes.

### Primitives touched

| Primitive | Group    | Impact   |
| --------- | -------- | -------- |
| `app-ui`  | surfaces | composes |

### Change flow

A visitor opens the FAQ shared-account answer and can email support; Terms restates individual-use accounts.

```mermaid
sequenceDiagram
	actor Visitor
	participant appUi as app-ui
	Visitor->>appUi: GET /faq
	appUi-->>Visitor: shared-account still says No, isolation is the feature
	Visitor->>appUi: click mailto support@kody.codes
	Note over appUi: Pricing-style invite, no seats product
	Visitor->>appUi: GET /terms
	appUi-->>Visitor: Your account says individual use, sharing a login is not supported
```

### Invariants

Per-user isolation is unchanged: no org tenancy or shared-team workspace is promised.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-753932f3-5dda-4860-aec8-2acb24a10851?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-753932f3-5dda-4860-aec8-2acb24a10851&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the FAQ to clarify account-sharing support and direct teams or multi-user customers to support.
  - Clarified in the terms that accounts are intended for individual use and shared logins are not supported.
  - Updated the displayed terms last-updated date to September 7, 2026.
- **Tests**
  - Added coverage ensuring the FAQ’s account-sharing guidance and support link appear in server-rendered pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->