### PR TITLE
Fix silent username Save snap-back on account profile

### DIFF
--- a/packages/worker/client/routes/account-profile-panel.node.test.ts
+++ b/packages/worker/client/routes/account-profile-panel.node.test.ts
@@ -1,0 +1,59 @@
+import { jsx } from 'remix/ui/jsx-runtime'
+import { renderToString } from 'remix/ui/server'
+import { expect, test } from 'vitest'
+import { renderAccountProfilePanel } from './account-profile-panel.tsx'
+
+function panelProps(
+	overrides: Partial<Parameters<typeof renderAccountProfilePanel>[0]> = {},
+) {
+	return {
+		email: 'jaimie@example.com',
+		emailVerified: true,
+		username: 'jklotz08',
+		draftUsername: 'jklotz',
+		draftDisplayName: 'Jaimie',
+		draftBio: '',
+		draftProfileVisibility: 'public' as const,
+		draftEmail: 'jaimie@example.com',
+		emailChangePassword: '',
+		avatarUrl: null,
+		avatarStatus: 'idle' as const,
+		isSaving: false,
+		isSendingEmailChange: false,
+		profileUnchanged: false,
+		normalizedDraftUsername: 'jklotz',
+		normalizedDraftEmail: 'jaimie@example.com',
+		emailChangeMessage: null,
+		emailChangeTone: 'info' as const,
+		emailChangeOpen: false,
+		usernameFieldError: null,
+		onProfileSubmit: () => undefined,
+		onEmailChangeSubmit: () => undefined,
+		onAvatarSelected: () => undefined,
+		onRemoveAvatar: () => undefined,
+		onDraftUsernameInput: () => undefined,
+		onDraftDisplayNameChange: () => undefined,
+		onDraftBioChange: () => undefined,
+		onDraftProfileVisibilityChange: () => undefined,
+		onDraftEmailInput: () => undefined,
+		onEmailChangePasswordInput: () => undefined,
+		...overrides,
+	}
+}
+
+test('profile panel keeps the typed username and shows a save error without success chrome', async () => {
+	const html = await renderToString(
+		jsx('div', {
+			children: renderAccountProfilePanel(
+				panelProps({
+					usernameFieldError: '`jklotz` is taken.',
+				}),
+			),
+		}),
+	)
+
+	expect(html).toContain('value="jklotz"')
+	expect(html).toContain('data-testid="account-username-error"')
+	expect(html).toContain('`jklotz` is taken.')
+	expect(html).not.toContain('Profile saved.')
+})

--- a/packages/worker/client/routes/account-profile-panel.tsx
+++ b/packages/worker/client/routes/account-profile-panel.tsx
@@ -43,6 +43,7 @@ export type AccountProfilePanelProps = {
 	emailChangeMessage: string | null
 	emailChangeTone: 'error' | 'info'
 	emailChangeOpen: boolean
+	usernameFieldError: string | null
 	onProfileSubmit: (event: SubmitEvent) => void
 	onEmailChangeSubmit: (event: SubmitEvent) => void
 	onAvatarSelected: (event: Event) => void
@@ -76,6 +77,7 @@ export function renderAccountProfilePanel(props: AccountProfilePanelProps) {
 		emailChangeMessage,
 		emailChangeTone,
 		emailChangeOpen,
+		usernameFieldError,
 		onProfileSubmit,
 		onEmailChangeSubmit,
 		onAvatarSelected,
@@ -154,14 +156,29 @@ export function renderAccountProfilePanel(props: AccountProfilePanelProps) {
 					<input
 						type="text"
 						name="username"
+						id="account-username"
 						data-field-ring
 						required
 						autoComplete="username"
 						pattern="[A-Za-z0-9][A-Za-z0-9-]{1,30}[A-Za-z0-9]"
 						title="Use 3 to 32 letters, numbers, and hyphens. Start and end with a letter or number."
 						value={draftUsername}
+						aria-invalid={usernameFieldError ? 'true' : undefined}
+						aria-describedby={
+							usernameFieldError ? 'account-username-error' : undefined
+						}
 						mix={[css(accountInputCss), on('input', onDraftUsernameInput)]}
 					/>
+					{usernameFieldError ? (
+						<p
+							id="account-username-error"
+							role="alert"
+							data-testid="account-username-error"
+							mix={css({ color: colors.error, margin: 0 })}
+						>
+							{usernameFieldError}
+						</p>
+					) : null}
 				</label>
 				<label mix={css(accountFieldCss)}>
 					<span mix={css(accountFieldLabelCss)}>Display name</span>
@@ -213,6 +230,7 @@ export function renderAccountProfilePanel(props: AccountProfilePanelProps) {
 						<input
 							type="radio"
 							name="profileVisibility"
+							value="public"
 							checked={draftProfileVisibility === 'public'}
 							mix={[
 								on('change', () => {
@@ -233,6 +251,7 @@ export function renderAccountProfilePanel(props: AccountProfilePanelProps) {
 						<input
 							type="radio"
 							name="profileVisibility"
+							value="private"
 							checked={draftProfileVisibility === 'private'}
 							mix={[
 								on('change', () => {

--- a/packages/worker/client/routes/account-profile-save.node.test.ts
+++ b/packages/worker/client/routes/account-profile-save.node.test.ts
@@ -1,0 +1,150 @@
+import { expect, test } from 'vitest'
+import {
+	interpretAccountProfileSave,
+	readApiErrorMessage,
+	readProfileFormValues,
+	usernameFormatError,
+	usernameFormatRequirements,
+} from './account-profile-save.ts'
+
+test('failed username rename shows the server reason without success chrome', () => {
+	const taken = interpretAccountProfileSave({
+		previousUsername: 'jklotz08',
+		requestedUsername: 'jklotz',
+		profileFieldsChanged: false,
+		responseOk: false,
+		payload: { ok: false, error: '`jklotz` is taken.' },
+	})
+	expect(taken).toEqual({
+		status: 'error',
+		message: '`jklotz` is taken.',
+	})
+	expect(taken.message).not.toContain('Profile saved.')
+
+	const invalid = interpretAccountProfileSave({
+		previousUsername: 'jklotz08',
+		requestedUsername: 'bad username',
+		profileFieldsChanged: false,
+		responseOk: false,
+		payload: {
+			ok: false,
+			error:
+				'Username must be 3 to 32 characters, use only letters, numbers, and hyphens, and start and end with a letter or number.',
+		},
+	})
+	expect(invalid.status).toBe('error')
+	expect(invalid.message).toContain('3 to 32 characters')
+	expect(invalid.message).not.toContain('Profile saved.')
+
+	const rewriteFailed = interpretAccountProfileSave({
+		previousUsername: 'jklotz08',
+		requestedUsername: 'jklotz',
+		profileFieldsChanged: false,
+		responseOk: false,
+		payload: {
+			ok: false,
+			error:
+				'Username was not changed because package updates failed: sync failed',
+		},
+	})
+	expect(rewriteFailed).toEqual({
+		status: 'error',
+		message:
+			'Username was not changed because package updates failed: sync failed',
+	})
+	expect(rewriteFailed.message).not.toContain('Profile saved.')
+})
+
+test('a 200 that did not persist the requested username is an error, not success', () => {
+	const result = interpretAccountProfileSave({
+		previousUsername: 'jklotz08',
+		requestedUsername: 'jklotz',
+		profileFieldsChanged: true,
+		responseOk: true,
+		payload: { ok: true, username: 'jklotz08' },
+	})
+	expect(result).toEqual({
+		status: 'error',
+		message: '`jklotz` was not saved.',
+	})
+	expect(result.message).not.toContain('Profile saved.')
+})
+
+test('successful rename reports saved and an unchanged username does not', () => {
+	expect(
+		interpretAccountProfileSave({
+			previousUsername: 'jklotz08',
+			requestedUsername: 'jklotz',
+			profileFieldsChanged: false,
+			responseOk: true,
+			payload: {
+				ok: true,
+				username: 'jklotz',
+				packageUpdateMessage: 'Updated 2 packages to the new @jklotz scope.',
+			},
+		}),
+	).toEqual({
+		status: 'saved',
+		message: 'Profile saved. Updated 2 packages to the new @jklotz scope.',
+		appliedUsername: 'jklotz',
+		usernameChanged: true,
+	})
+
+	expect(
+		interpretAccountProfileSave({
+			previousUsername: 'jklotz08',
+			requestedUsername: 'jklotz08',
+			profileFieldsChanged: false,
+			responseOk: true,
+			payload: { ok: true, username: 'jklotz08' },
+		}),
+	).toEqual({
+		status: 'noop',
+		appliedUsername: 'jklotz08',
+	})
+
+	expect(
+		interpretAccountProfileSave({
+			previousUsername: 'jklotz08',
+			requestedUsername: 'JKLOTZ08',
+			profileFieldsChanged: true,
+			responseOk: true,
+			payload: { ok: true, username: 'jklotz08' },
+		}),
+	).toMatchObject({
+		status: 'saved',
+		message: 'Profile saved.',
+		usernameChanged: false,
+	})
+})
+
+test('readApiErrorMessage accepts string or nested envelope errors', () => {
+	expect(readApiErrorMessage({ error: '`jklotz` is taken.' }, 'fallback')).toBe(
+		'`jklotz` is taken.',
+	)
+	expect(
+		readApiErrorMessage(
+			{ error: { code: 'account_deleting', message: 'Writes are disabled.' } },
+			'fallback',
+		),
+	).toBe('Writes are disabled.')
+	expect(readApiErrorMessage(null, 'Unable to save profile.')).toBe(
+		'Unable to save profile.',
+	)
+})
+
+test('username format errors stay next to the field while typing', () => {
+	expect(usernameFormatError('jklotz')).toBeNull()
+	expect(usernameFormatError('bad username')).toBe(usernameFormatRequirements)
+	expect(usernameFormatError('')).toBe('Username is required.')
+})
+
+test('readProfileFormValues keeps fallbacks when submit is not from a form', () => {
+	const fallback = {
+		username: 'jklotz08',
+		displayName: 'Old',
+		bio: '',
+		profileVisibility: 'public' as const,
+	}
+	expect(readProfileFormValues(null, fallback)).toEqual(fallback)
+})

--- a/packages/worker/client/routes/account-profile-save.ts
+++ b/packages/worker/client/routes/account-profile-save.ts
@@ -1,0 +1,135 @@
+import { dnsSafeUsernamePattern } from '@kody-internal/shared/public-urls.ts'
+import { type ProfileVisibility } from '#universal/loader-data.ts'
+
+export const usernameFormatRequirements =
+	'Use 3 to 32 letters, numbers, and hyphens. Start and end with a letter or number.'
+
+export type AccountProfileSavePayload = {
+	ok?: boolean
+	username?: string
+	error?: unknown
+	packageUpdateMessage?: string
+	communityUpdateWarning?: string
+}
+
+export type AccountProfileSaveResult =
+	| { status: 'error'; message: string }
+	| {
+			status: 'saved'
+			message: string
+			appliedUsername: string
+			usernameChanged: boolean
+	  }
+	| { status: 'noop'; appliedUsername: string }
+
+export function normalizeProfileUsername(value: unknown) {
+	return typeof value === 'string' ? value.trim().toLowerCase() : ''
+}
+
+export function readApiErrorMessage(payload: unknown, fallback: string) {
+	if (!payload || typeof payload !== 'object') return fallback
+	const error = (payload as { error?: unknown }).error
+	if (typeof error === 'string' && error.trim()) return error
+	if (error && typeof error === 'object' && 'message' in error) {
+		const message = (error as { message?: unknown }).message
+		if (typeof message === 'string' && message.trim()) return message
+	}
+	return fallback
+}
+
+export function usernameFormatError(username: string) {
+	const normalized = normalizeProfileUsername(username)
+	if (!normalized) return 'Username is required.'
+	if (!dnsSafeUsernamePattern.test(normalized)) {
+		return usernameFormatRequirements
+	}
+	return null
+}
+
+export function readProfileFormValues(
+	form: EventTarget | null,
+	fallback: {
+		username: string
+		displayName: string
+		bio: string
+		profileVisibility: ProfileVisibility
+	},
+) {
+	if (
+		typeof HTMLFormElement === 'undefined' ||
+		!(form instanceof HTMLFormElement)
+	) {
+		return fallback
+	}
+	const data = new FormData(form)
+	const username = String(data.get('username') ?? fallback.username)
+	const displayName = String(data.get('displayName') ?? fallback.displayName)
+	const bio = String(data.get('bio') ?? fallback.bio)
+	const visibilityValue = data.get('profileVisibility')
+	const profileVisibility =
+		visibilityValue === 'public' || visibilityValue === 'private'
+			? visibilityValue
+			: fallback.profileVisibility
+	return {
+		username,
+		displayName,
+		bio,
+		profileVisibility,
+	}
+}
+
+export function interpretAccountProfileSave(input: {
+	previousUsername: string
+	requestedUsername: string
+	profileFieldsChanged: boolean
+	responseOk: boolean
+	payload: AccountProfileSavePayload | null
+}): AccountProfileSaveResult {
+	const previousUsername = normalizeProfileUsername(input.previousUsername)
+	const requestedUsername = normalizeProfileUsername(input.requestedUsername)
+	const usernameChangeRequested =
+		requestedUsername !== '' && requestedUsername !== previousUsername
+	const fallbackError = usernameChangeRequested
+		? `Could not change username to \`${requestedUsername}\`.`
+		: 'Unable to save profile.'
+
+	if (!input.responseOk || !input.payload?.ok) {
+		return {
+			status: 'error',
+			message: readApiErrorMessage(input.payload, fallbackError),
+		}
+	}
+
+	const appliedUsername = normalizeProfileUsername(input.payload.username)
+	if (usernameChangeRequested && appliedUsername !== requestedUsername) {
+		return {
+			status: 'error',
+			message: readApiErrorMessage(
+				input.payload,
+				`\`${requestedUsername}\` was not saved.`,
+			),
+		}
+	}
+
+	if (!usernameChangeRequested && !input.profileFieldsChanged) {
+		return {
+			status: 'noop',
+			appliedUsername: appliedUsername || previousUsername,
+		}
+	}
+
+	const message = [
+		'Profile saved.',
+		usernameChangeRequested ? input.payload.packageUpdateMessage : null,
+		usernameChangeRequested ? input.payload.communityUpdateWarning : null,
+	]
+		.filter(Boolean)
+		.join(' ')
+
+	return {
+		status: 'saved',
+		message,
+		appliedUsername: appliedUsername || previousUsername,
+		usernameChanged: usernameChangeRequested,
+	}
+}

--- a/packages/worker/client/routes/account.tsx
+++ b/packages/worker/client/routes/account.tsx
@@ -25,6 +25,11 @@ import {
 import { queueSessionRefresh } from '#client/session.ts'
 import { toast } from '#client/toast.ts'
 import {
+	interpretAccountProfileSave,
+	readProfileFormValues,
+	usernameFormatError,
+} from '#client/routes/account-profile-save.ts'
+import {
 	type AccountStatus,
 	accountProfileApiPath,
 	readJson,
@@ -130,6 +135,7 @@ export function AccountRoute(handle: Handle) {
 	let avatarDropActive = false
 	let message: string | null = null
 	let messageTone: 'error' | 'info' = 'info'
+	let usernameSaveError: string | null = null
 	const accountConnections = createAccountConnections(handle)
 	const accountEmailClaims = createAccountEmailClaims(handle)
 	let consumedCallbackMessage = false
@@ -180,12 +186,14 @@ export function AccountRoute(handle: Handle) {
 			emailVerified = payload.emailVerified
 			emailVerificationDelivery = payload.emailVerificationDelivery ?? null
 			username = payload.username
-			draftUsername = payload.username
+			if (!usernameSaveError) {
+				draftUsername = payload.username
+				message = null
+				messageTone = 'info'
+			}
 			applyProfileFields(payload)
 			accountEmailClaims.applyCurrentEmail(payload.email)
 			status = 'ready'
-			message = null
-			messageTone = 'info'
 			loadLatch.markLoaded(href)
 			handle.update()
 		} catch (error) {
@@ -383,22 +391,51 @@ export function AccountRoute(handle: Handle) {
 	function updateDraftUsername(event: InputEvent) {
 		if (!(event.currentTarget instanceof HTMLInputElement)) return
 		draftUsername = event.currentTarget.value
+		if (usernameSaveError) usernameSaveError = null
 		handle.update()
 	}
 
 	async function handleProfileSubmit(event: SubmitEvent) {
 		event.preventDefault()
-		const nextUsername = draftUsername.trim()
+		const submitted = readProfileFormValues(event.currentTarget, {
+			username: draftUsername,
+			displayName: draftDisplayName,
+			bio: draftBio,
+			profileVisibility: draftProfileVisibility,
+		})
+		draftUsername = submitted.username
+		draftDisplayName = submitted.displayName
+		draftBio = submitted.bio
+		draftProfileVisibility = submitted.profileVisibility
+		const nextUsername = submitted.username.trim()
 		if (!nextUsername) {
-			message = 'Username is required.'
+			usernameSaveError = 'Username is required.'
+			message = usernameSaveError
 			messageTone = 'error'
 			handle.update()
 			return
 		}
 
+		const formatError = usernameFormatError(nextUsername)
+		const usernameChangeRequested =
+			nextUsername.toLowerCase() !== username.toLowerCase()
+		if (formatError && usernameChangeRequested) {
+			usernameSaveError = formatError
+			message = formatError
+			messageTone = 'error'
+			handle.update()
+			return
+		}
+
+		const profileFieldsChanged =
+			submitted.displayName !== savedDisplayName ||
+			submitted.bio !== savedBio ||
+			submitted.profileVisibility !== savedProfileVisibility
+
 		saveStatus = 'saving'
 		message = null
 		messageTone = 'info'
+		usernameSaveError = null
 		handle.update()
 
 		try {
@@ -411,9 +448,9 @@ export function AccountRoute(handle: Handle) {
 				credentials: 'include',
 				body: JSON.stringify({
 					username: nextUsername,
-					displayName: draftDisplayName,
-					bio: draftBio,
-					profileVisibility: draftProfileVisibility,
+					displayName: submitted.displayName,
+					bio: submitted.bio,
+					profileVisibility: submitted.profileVisibility,
 				}),
 			})
 			if (response.status === 401) {
@@ -429,32 +466,56 @@ export function AccountRoute(handle: Handle) {
 					communityUpdateWarning?: string
 				}
 			>(response)
-			if (!response.ok || !payload?.ok) {
-				throw new Error(payload?.error || 'Unable to save profile.')
+			const result = interpretAccountProfileSave({
+				previousUsername: username,
+				requestedUsername: nextUsername,
+				profileFieldsChanged,
+				responseOk: response.ok,
+				payload,
+			})
+			switch (result.status) {
+				case 'error':
+					usernameSaveError = usernameChangeRequested ? result.message : null
+					message = result.message
+					messageTone = 'error'
+					toast.error(result.message)
+					return
+				case 'noop':
+					message = null
+					messageTone = 'info'
+					return
+				case 'saved':
+					if (!payload) {
+						throw new Error('Unable to save profile.')
+					}
+					email = payload.email
+					emailVerified = payload.emailVerified
+					emailVerificationDelivery = payload.emailVerificationDelivery ?? null
+					username = payload.username
+					if (result.usernameChanged) {
+						draftUsername = payload.username
+					}
+					applyProfileFields(payload)
+					message = result.message
+					messageTone = payload.communityUpdateWarning ? 'error' : 'info'
+					if (result.usernameChanged) {
+						queueSessionRefresh()
+					}
+					return
+				default: {
+					const _exhaustive: never = result
+					throw new Error(
+						`Unhandled profile save status: ${String(_exhaustive)}`,
+					)
+				}
 			}
-			email = payload.email
-			emailVerified = payload.emailVerified
-			emailVerificationDelivery = payload.emailVerificationDelivery ?? null
-			username = payload.username
-			draftUsername = payload.username
-			applyProfileFields(payload)
-			const packageMessage =
-				typeof payload.packageUpdateMessage === 'string'
-					? payload.packageUpdateMessage
-					: null
-			const communityWarning =
-				typeof payload.communityUpdateWarning === 'string'
-					? payload.communityUpdateWarning
-					: null
-			message = ['Profile saved.', packageMessage, communityWarning]
-				.filter(Boolean)
-				.join(' ')
-			messageTone = communityWarning ? 'error' : 'info'
-			queueSessionRefresh()
 		} catch (error) {
-			message =
+			const errorMessage =
 				error instanceof Error ? error.message : 'Unable to save profile.'
+			if (usernameChangeRequested) usernameSaveError = errorMessage
+			message = errorMessage
 			messageTone = 'error'
+			toast.error(errorMessage)
 		} finally {
 			saveStatus = 'idle'
 			handle.update()
@@ -475,7 +536,11 @@ export function AccountRoute(handle: Handle) {
 		emailVerified = routeData.emailVerified
 		emailVerificationDelivery = routeData.emailVerificationDelivery ?? null
 		username = routeData.username
-		draftUsername = routeData.username
+		if (!usernameSaveError) {
+			draftUsername = routeData.username
+			message = null
+			messageTone = 'info'
+		}
 		applyProfileFields(routeData)
 		accountEmailClaims.applyCurrentEmail(routeData.email)
 		accountConnections.applyPayload(connectionsData)
@@ -484,8 +549,6 @@ export function AccountRoute(handle: Handle) {
 			applyOnboardingPayload(onboardingData)
 		}
 		status = 'ready'
-		message = null
-		messageTone = 'info'
 		loadLatch.markLoaded(href)
 		return true
 	}
@@ -522,6 +585,11 @@ export function AccountRoute(handle: Handle) {
 			draftDisplayName === savedDisplayName &&
 			draftBio === savedBio &&
 			draftProfileVisibility === savedProfileVisibility
+		const liveUsernameFormatError =
+			normalizedDraftUsername && normalizedDraftUsername !== username
+				? usernameFormatError(draftUsername)
+				: null
+		const usernameFieldError = usernameSaveError ?? liveUsernameFormatError
 
 		return (
 			<AccountManagementShell>
@@ -584,6 +652,7 @@ export function AccountRoute(handle: Handle) {
 							emailChangeMessage: emailClaims.emailChangeMessage,
 							emailChangeTone: emailClaims.emailChangeTone,
 							emailChangeOpen: emailClaims.emailChangeOpen,
+							usernameFieldError,
 							onProfileSubmit: handleProfileSubmit,
 							onEmailChangeSubmit: (event) => {
 								void accountEmailClaims.handleEmailChangeSubmit(event, email)

--- a/packages/worker/src/app/account-profile-data.ts
+++ b/packages/worker/src/app/account-profile-data.ts
@@ -20,6 +20,7 @@ function asProfileVisibility(
 export function buildAccountProfilePayload(
 	user: AuthenticatedUser,
 	profileFields?: {
+		username?: string | null
 		displayName?: string | null
 		bio?: string | null
 		avatarKey?: string | null
@@ -28,22 +29,23 @@ export function buildAccountProfilePayload(
 	},
 ): AccountProfileLoaderData {
 	const rawDisplayName = profileFields?.displayName
+	const username = profileFields?.username?.trim() || user.username
 	return {
 		ok: true,
 		email: user.email,
 		emailVerified: user.emailVerified,
 		emailVerificationDelivery: user.emailVerificationDelivery ?? null,
-		username: user.username,
+		username,
 		// Prefer an explicit community display name; otherwise fall back to the
 		// auth display name (username) so existing username-only clients keep a
 		// sensible value.
 		displayName:
 			rawDisplayName != null && rawDisplayName.trim().length > 0
 				? rawDisplayName.trim()
-				: user.displayName || user.username,
+				: user.displayName || username,
 		bio: profileFields?.bio ?? null,
 		avatarUrl: buildUserAvatarUrl({
-			username: user.username,
+			username,
 			avatarKey: profileFields?.avatarKey ?? null,
 		}),
 		profileVisibility: profileFields?.profileVisibility ?? 'public',
@@ -71,6 +73,7 @@ export async function loadAccountProfileData(
 	}
 
 	return buildAccountProfilePayload(user, {
+		username: row.username,
 		displayName: row.display_name,
 		bio: row.bio,
 		avatarKey: row.avatar_key,

--- a/packages/worker/src/app/handlers/account-profile.node.test.ts
+++ b/packages/worker/src/app/handlers/account-profile.node.test.ts
@@ -49,7 +49,11 @@ type TestUser = {
 	updated_at: string
 }
 
-function createProfileTestDb(initialUsers: Array<TestUser>) {
+function createProfileTestDb(
+	initialUsers: Array<TestUser>,
+	options?: { persistUsernameUpdates?: boolean },
+) {
+	const persistUsernameUpdates = options?.persistUsernameUpdates !== false
 	const users = new Map(initialUsers.map((user) => [user.id, { ...user }]))
 	const db = {
 		prepare(query: string) {
@@ -83,7 +87,9 @@ function createProfileTestDb(initialUsers: Array<TestUser>) {
 						) {
 							throw new Error('UNIQUE constraint failed: users.username')
 						}
-						user.username = String(username)
+						if (persistUsernameUpdates) {
+							user.username = String(username)
+						}
 						user.updated_at = String(updatedAt)
 						return user
 					}
@@ -454,7 +460,7 @@ test('account profile API rejects invalid or duplicate usernames', async () => {
 	expect(reservedResponse.status).toBe(400)
 	expect(await reservedResponse.json()).toEqual({
 		ok: false,
-		error: 'This username is reserved.',
+		error: '`kody` is reserved.',
 	})
 
 	const duplicateResponse = await runHandler(
@@ -468,7 +474,7 @@ test('account profile API rejects invalid or duplicate usernames', async () => {
 	expect(duplicateResponse.status).toBe(409)
 	expect(await duplicateResponse.json()).toEqual({
 		ok: false,
-		error: 'Username already registered.',
+		error: '`taken-jane` is taken.',
 	})
 	expect(testDb.users.get(1)?.username).toBe('current-user')
 	expect(mocks.updatePackagesForUsernameChange).not.toHaveBeenCalled()
@@ -482,6 +488,34 @@ test('account profile API rejects invalid or duplicate usernames', async () => {
 			reason: 'username_exists',
 		}),
 	)
+})
+
+test('account profile API does not report success when the requested username did not persist', async () => {
+	const testDb = createProfileTestDb([createUser(1, 'jklotz08')], {
+		persistUsernameUpdates: false,
+	})
+	const handler = createAccountProfileApiHandler(createEnv(testDb.db))
+
+	const response = await runHandler(
+		handler,
+		await createRequest({
+			session: {
+				stableUserId: testStableUserIdFromEmail('jklotz08@example.com'),
+				email: 'jklotz08@example.com',
+				rememberMe: false,
+			},
+			method: 'POST',
+			body: { username: 'jklotz' },
+		}),
+	)
+
+	expect(response.status).toBe(500)
+	expect(await response.json()).toEqual({
+		ok: false,
+		error: 'Username was not changed to `jklotz`.',
+	})
+	expect(testDb.users.get(1)?.username).toBe('jklotz08')
+	expect(mocks.updatePackagesForUsernameChange).not.toHaveBeenCalled()
 })
 
 test('account profile API rounds trip displayName, bio, and visibility', async () => {
@@ -642,7 +676,7 @@ test('account profile username change consults KV reserved additions and removal
 	expect(addedResponse.status).toBe(400)
 	expect(await addedResponse.json()).toEqual({
 		ok: false,
-		error: 'This username is reserved.',
+		error: '`brandnew` is reserved.',
 	})
 
 	const unreservedResponse = await runHandler(

--- a/packages/worker/src/app/handlers/account-profile.ts
+++ b/packages/worker/src/app/handlers/account-profile.ts
@@ -16,6 +16,9 @@ import { type routes } from '#universal/routes.ts'
 import {
 	getEffectiveUsernameValidationError,
 	normalizeUsername,
+	usernameNotPersistedError,
+	usernameReservedClaimError,
+	usernameTakenError,
 } from '#worker/identity/username.ts'
 import { CommunityActionError } from '#worker/community/errors.ts'
 import { retireUsername } from '#worker/community/package-url.ts'
@@ -112,7 +115,16 @@ export function createAccountProfileApiHandler(env: Env) {
 					env,
 				)
 				if (usernameError) {
-					return jsonResponse({ ok: false, error: usernameError }, 400)
+					return jsonResponse(
+						{
+							ok: false,
+							error:
+								usernameError === 'This username is reserved.'
+									? usernameReservedClaimError(username)
+									: usernameError,
+						},
+						400,
+					)
 				}
 
 				const existingUsername = await db.findOne(usersTable, {
@@ -130,7 +142,7 @@ export function createAccountProfileApiHandler(env: Env) {
 						reason: 'username_exists',
 					})
 					return jsonResponse(
-						{ ok: false, error: 'Username already registered.' },
+						{ ok: false, error: usernameTakenError(username) },
 						409,
 					)
 				}
@@ -158,11 +170,21 @@ export function createAccountProfileApiHandler(env: Env) {
 							reason: 'username_exists',
 						})
 						return jsonResponse(
-							{ ok: false, error: 'Username already registered.' },
+							{ ok: false, error: usernameTakenError(username) },
 							409,
 						)
 					}
 					throw error
+				}
+
+				const claimed = await db.findOne(usersTable, {
+					where: { id: user.userId },
+				})
+				if (!claimed || claimed.username !== username) {
+					return jsonResponse(
+						{ ok: false, error: usernameNotPersistedError(username) },
+						500,
+					)
 				}
 
 				let packageUpdate
@@ -308,8 +330,19 @@ export function createAccountProfileApiHandler(env: Env) {
 				})
 			}
 
+			const persisted = await loadAccountProfileData(nextUser, env)
+			if (usernameChanged && persisted.username !== username) {
+				return jsonResponse(
+					{
+						ok: false,
+						error: usernameNotPersistedError(username),
+					},
+					500,
+				)
+			}
+
 			return jsonResponse({
-				...(await loadAccountProfileData(nextUser, env)),
+				...persisted,
 				...usernameChangeExtras,
 			})
 		},

--- a/packages/worker/src/identity/username.ts
+++ b/packages/worker/src/identity/username.ts
@@ -17,6 +17,18 @@ export function normalizeUsername(value: unknown) {
 	return typeof value === 'string' ? value.trim().toLowerCase() : ''
 }
 
+export function usernameTakenError(username: string) {
+	return `\`${username}\` is taken.`
+}
+
+export function usernameReservedClaimError(username: string) {
+	return `\`${username}\` is reserved.`
+}
+
+export function usernameNotPersistedError(username: string) {
+	return `Username was not changed to \`${username}\`.`
+}
+
 /**
  * Every username is a valid DNS label (`dnsSafeUsernamePattern` from
  * `@kody-internal/shared/public-urls.ts`): each user owns a `{username}.`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Make account profile username Save honest: a rename that does not persist must never look like success and then snap back on refresh.

## Why

Jaimie hit this on a work account changing `jklotz08` → `jklotz` *before* her personal account existed, so the target was available. Save looked successful, then the field reverted on revisit. Rename + package-scope rewrite already exist (#793); this is the failure UX and persist-check around that path, not a new rename implementation.

The Save handler posted stale `draftUsername` state instead of the live form value, always showed **Profile saved.** on HTTP 200, and the profile payload trusted the in-memory auth username over the D1 row. A no-op or rolled-back rename could therefore look saved until the next load.

## Summary

- Read username (and other profile fields) from the submitted form so the POST matches what is on screen.
- Treat a requested rename as failure unless the persisted username matches; no success chrome for a no-op username.
- Keep the typed value, show a field-level + toast error that names the reason (taken, reserved, validation, package-rewrite rollback, persist miss).
- Re-read `users.username` after claim and before package rewrite; refuse success if the row did not change.
- Profile JSON now reports the D1 username, not a stale auth copy.
- Cheap live format check while typing. Package-scope rewrite on successful rename is unchanged.

## Testing

- Unit: taken / validation / package-rewrite failures and a 200 that did not persist the requested username never include `Profile saved.`
- Handler: named taken/reserved errors; persist-miss returns 500 and does not start package rewrite
- Push hook: node-unit + workers-unit green
- Preview `https://kody-pr-2113.kody-a99.workers.dev` as `me@kentcdodds.com`:
  - `POST /account/profile.json` `kody` → 400 `` `kody` is reserved. ``
  - `POST /account/profile.json` `bad username` → 400 format error
  - same-username display-name save → 200, username stays `user-me`
  - UI: reserved and invalid saves keep the typed value, show the named error, no Profile saved

![Reserved username error keeps kody in the field](https://cursor.com/artifacts/c/art-b55967f5-5159-434a-bda7-741cc8d23ec8)
![Invalid username format error keeps the typed value](https://cursor.com/artifacts/c/art-8b0d3750-9006-4942-8262-523b0641383a)

CodeRabbit asked to session-refresh when mixed-case `Alice` persists as `alice`. Usernames are already stored and compared lowercase, so that path is a no-op and does not need a refresh.

## System recap

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `815fcb72` · **Head:** `479d0a29`

**Classification:** extends — account profile Save now fails closed when a requested username does not persist, and surfaces that failure in the UI.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | extends — profile Save reads the live form, refuses success chrome unless the persisted username matches, and shows named field/toast errors |

### Change flow

Account profile Save posts the typed username, claims it in D1, rewrites packages only after the row matches, and shows an error if the rename did not stick.

```mermaid
sequenceDiagram
	actor User
	participant appUi as app-ui
	User->>appUi: Save profile with typed username
	appUi->>appUi: POST /account/profile.json from form values
	appUi->>appUi: Claim users.username then rewrite packages
	alt requested username did not persist
		appUi-->>User: Keep typed value and named error, no Profile saved
	else rename applied
		appUi-->>User: Profile saved plus package rewrite extras
	end
```

### Invariants

- Per-user isolation unchanged: only the signed-in user's username and packages are written.
- Successful rename still runs the existing package-scope rewrite. No skip path.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f9c9f137-55ce-4a2c-8eda-fdcdab0e0385?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f9c9f137-55ce-4a2c-8eda-fdcdab0e0385&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added username editing to account profiles with trimming, format validation, and live field-level feedback.
  - Profile updates now distinguish successful saves, unchanged values, and failed saves.
  - Added clearer messages for reserved, unavailable, or unpersisted usernames.
  - Profile data now reflects the saved username across display names and avatars.

- **Accessibility**
  - Username validation states are announced to assistive technologies through appropriate field labels and alerts.

- **Bug Fixes**
  - Prevented profile refreshes from overwriting unsaved username edits after a validation error.
  - Profile visibility selections now save with the correct values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->