### PR TITLE
Ignore publish git-note pushes in repo.pushed fan-out

### DIFF
--- a/docs/contributing/setup-manifest.md
+++ b/docs/contributing/setup-manifest.md
@@ -47,8 +47,9 @@ This project uses the following resources:
   - The production consumer batches at most 10 messages for 5 seconds, retries
     three times, and routes exhausted messages to the dedicated dead-letter
     queue. Consumers filter by `ARTIFACTS_NAMESPACE` and ignore session fork
-    repos plus session workspace branch pushes (`sessions/<id>`). Mapped package
-    topics: `repo.pushed`, `repo.created`, `repo.deleted`.
+    repos, session workspace branch pushes (`sessions/<id>`), and publish git
+    notes (`refs/notes/commits`). Mapped package topics: `repo.pushed`,
+    `repo.created`, `repo.deleted`.
 - Cloudflare Queue for durable platform-feedback subscription dispatch
   - Producer binding: `PLATFORM_FEEDBACK_DISPATCH_QUEUE`
   - Queue: `kody-platform-feedback-dispatch`

--- a/docs/guides/package-subscriptions.md
+++ b/docs/guides/package-subscriptions.md
@@ -676,12 +676,14 @@ run-error strings for connection health.
 When Cloudflare Artifacts reports commits pushed to a Kody-managed Artifacts
 repo (plain repo, package, or job source), Kody dispatches `repo.pushed` to
 packages saved by that same user that declare the topic. Delivery is durable via
-the `kody-artifacts-repo-events` Queue (with DLQ). Session fork repos and
-session workspace branch pushes (`sessions/<id>`) never emit — opening a repo
-session git-pushes that ref, and delivering it as `repo.pushed` would let a
-handler that opens another session loop. Events for other `ARTIFACTS_NAMESPACE`
-values are ignored. Handlers that only care about default branch content should
-still check `push.ref`.
+the `kody-artifacts-repo-events` Queue (with DLQ). Session fork repos, session
+workspace branch pushes (`sessions/<id>`), and publish git notes
+(`refs/notes/commits`) never emit. Opening a repo session git-pushes the session
+ref; each publish force-pushes a notes ref after the source-branch update.
+Delivering those as `repo.pushed` would loop a handler that opens another
+session, or invoke subscribers twice per publish. Events for other
+`ARTIFACTS_NAMESPACE` values are ignored. Handlers that only care about default
+branch content should still check `push.ref`.
 
 Handlers receive a metadata-first payload:
 

--- a/docs/use/packages.md
+++ b/docs/use/packages.md
@@ -435,10 +435,10 @@ is metadata-first (server id/name/state, `account_url`). See the
 
 Artifacts-backed plain repos, packages, and job sources also emit `repo.pushed`,
 `repo.created`, and `repo.deleted` when Cloudflare Artifacts reports those
-lifecycle events. Session workspace branch pushes (`sessions/<id>`) do not fan
-out. See [Plain repos](./repos.md) and the
-[package subscriptions guide](../guides/package-subscriptions.md) for payloads
-and the distinction between live HEAD and package publish.
+lifecycle events. Session workspace branch pushes (`sessions/<id>`) and publish
+git notes (`refs/notes/commits`) do not fan out. See [Plain repos](./repos.md)
+and the [package subscriptions guide](../guides/package-subscriptions.md) for
+payloads and the distinction between live HEAD and package publish.
 
 ## Package webhooks
 

--- a/docs/use/repos.md
+++ b/docs/use/repos.md
@@ -83,8 +83,8 @@ wrappers use the same event type with `source.type === "artifacts.repo"`.
 
 Declare handlers under `package.json#kody.subscriptions`. Delivery is same-user
 only: packages saved by the entity owner that declare the topic receive the
-event. Session fork Artifacts repos and session workspace branch pushes
-(`sessions/<id>`) never fan out.
+event. Session fork Artifacts repos, session workspace branch pushes
+(`sessions/<id>`), and publish git notes (`refs/notes/commits`) never fan out.
 
 `repo.pushed` is the primary automation hook (for example resyncing a projection
 after a git-lane push to a plain repo). For packages and jobs, a push updates

--- a/packages/worker/src/repo/artifacts-events.node.test.ts
+++ b/packages/worker/src/repo/artifacts-events.node.test.ts
@@ -1,5 +1,7 @@
 import { expect, test } from 'vitest'
 import {
+	isIgnoredRepoPushedRef,
+	isPublishNotesRef,
 	isSessionArtifactRepoName,
 	isSessionBranchRef,
 	parseCloudflareArtifactsRepoEvent,
@@ -138,4 +140,17 @@ test('artifacts event helpers parse envelopes, reject unknowns, and detect sessi
 	).toBe(true)
 	expect(isSessionBranchRef('refs/heads/main')).toBe(false)
 	expect(isSessionBranchRef('refs/heads/session-notes')).toBe(false)
+
+	expect(isPublishNotesRef('refs/notes/commits')).toBe(true)
+	expect(isPublishNotesRef('notes/commits')).toBe(true)
+	expect(isPublishNotesRef('refs/notes/kody')).toBe(true)
+	expect(isPublishNotesRef('refs/heads/main')).toBe(false)
+	expect(isPublishNotesRef('refs/heads/notes/commits')).toBe(false)
+	expect(isIgnoredRepoPushedRef('refs/notes/commits')).toBe(true)
+	expect(
+		isIgnoredRepoPushedRef(
+			'refs/heads/sessions/f3da2ca724024325b290a21318c6b353-14bcbfbb49c94cf782dc0ebc5971a4cd',
+		),
+	).toBe(true)
+	expect(isIgnoredRepoPushedRef('refs/heads/main')).toBe(false)
 })

--- a/packages/worker/src/repo/artifacts-events.ts
+++ b/packages/worker/src/repo/artifacts-events.ts
@@ -147,3 +147,19 @@ export function isSessionBranchRef(ref: string) {
 		: ref
 	return branch.startsWith('sessions/')
 }
+
+/**
+ * Publish git notes (`refs/notes/commits` and other `refs/notes/*`). Each
+ * package or repo publish force-pushes this bookkeeping ref after the
+ * source-branch push. Fan-out would invoke `repo.pushed` subscribers twice
+ * for one user-facing publish.
+ */
+export function isPublishNotesRef(ref: string) {
+	const normalized = ref.startsWith('refs/') ? ref.slice('refs/'.length) : ref
+	return normalized.startsWith('notes/')
+}
+
+/** Internal bookkeeping refs that must not fan out as `repo.pushed`. */
+export function isIgnoredRepoPushedRef(ref: string) {
+	return isSessionBranchRef(ref) || isPublishNotesRef(ref)
+}

--- a/packages/worker/src/repo/package-subscriptions.node.test.ts
+++ b/packages/worker/src/repo/package-subscriptions.node.test.ts
@@ -211,6 +211,18 @@ test('processCloudflareArtifactsRepoEvent ignores, unmatched, and dispatches by 
 		},
 	})
 	expect(sessionBranch.outcome).toBe('ignored')
+
+	const publishNotes = await processCloudflareArtifactsRepoEvent({
+		env,
+		body: {
+			...pushedEvent,
+			payload: {
+				...pushedEvent.payload,
+				ref: 'refs/notes/commits',
+			},
+		},
+	})
+	expect(publishNotes.outcome).toBe('ignored')
 	// Ignored events never touch the cached HEAD.
 	expect(mocks.applyArtifactSourcePushToHeadCache).not.toHaveBeenCalled()
 

--- a/packages/worker/src/repo/package-subscriptions.ts
+++ b/packages/worker/src/repo/package-subscriptions.ts
@@ -14,8 +14,8 @@ import { getArtifactsNamespace } from './artifacts.ts'
 import {
 	type CloudflareArtifactsRepoEvent,
 	type RepoSubscriptionTopic,
+	isIgnoredRepoPushedRef,
 	isSessionArtifactRepoName,
-	isSessionBranchRef,
 	parseCloudflareArtifactsRepoEvent,
 	repoCreatedTopic,
 	repoDeletedTopic,
@@ -406,7 +406,7 @@ export async function processCloudflareArtifactsRepoEvent(input: {
 	}
 	if (
 		providerEvent.type === 'cf.artifacts.repo.pushed' &&
-		isSessionBranchRef(providerEvent.payload.ref)
+		isIgnoredRepoPushedRef(providerEvent.payload.ref)
 	) {
 		return { outcome: 'ignored', providerEvent }
 	}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop invoking `repo.pushed` subscribers twice for one package or repo publish.

## Why

Each publish already git-pushes the source branch, then force-pushes `refs/notes/commits` as publish bookkeeping. Cloudflare Artifacts delivers both as `cf.artifacts.repo.pushed`. Session workspace branches were already ignored so they cannot loop; notes refs were not, so the same subscriber ran twice a few seconds apart with no shared session.

## Summary

- Ignore `refs/notes/*` (and unprefixed `notes/*`) in Artifacts `repo.pushed` fan-out, next to the existing session-branch ignore.
- Document that notes refs never emit, matching the session-branch contract.
- Cover the helper and the queue processor ignore path in the existing node-unit suites.

Out of scope for this fingerprint: `repo.pushed` still fires for package and job sources as well as plain repos (documented). Handlers that only want plain repos keep filtering on `repo.entity_kind`.

## Testing

- `npx vitest run --project node-unit packages/worker/src/repo/artifacts-events.node.test.ts packages/worker/src/repo/package-subscriptions.node.test.ts` — 2 files, 3 tests passed
- Pre-commit worker typecheck passed
- Push hook: `test:node` 872 files / 2753 tests, `test:workers` 94 files / 336 tests

No UI surface. Preview login smoke would not exercise Artifacts note-push fan-out.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `c3607405` · **Head:** `34e016de`

**Classification:** extends — `repo.pushed` fan-out now ignores publish git-note refs the same way it already ignores session workspace branches.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `repo-sessions` | runtime | extends — publish notes ref no longer fans out as `repo.pushed` |

### Change flow

A publish still pushes the source branch (one subscriber invocation), then force-pushes `refs/notes/commits`. The notes event is acknowledged and dropped.

```mermaid
sequenceDiagram
	actor Publisher
	participant repoSessions as repo-sessions
	Publisher->>repoSessions: publish package or repo
	repoSessions->>repoSessions: push source branch, fan out repo.pushed
	repoSessions->>repoSessions: force-push refs/notes/commits
	Note over repoSessions: ignore notes ref, no second dispatch
```

### Before / after

| Ref | Before | After |
| --- | --- | --- |
| `refs/heads/main` | dispatch | dispatch |
| `refs/heads/sessions/<id>` | ignore | ignore |
| `refs/notes/commits` | dispatch | ignore |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a0bdec6c-51c4-48af-8513-bbb290b318ff?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a0bdec6c-51c4-48af-8513-bbb290b318ff&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Publish Git notes and session workspace branch pushes no longer trigger package repository lifecycle events, preventing duplicate or unintended notifications.

* **Documentation**
  * Clarified which repository refs are excluded from package subscriptions and repository lifecycle processing.
  * Documented the behavior of publish Git notes and their relationship to package publishing.

* **Tests**
  * Added coverage confirming ignored refs are excluded while regular branch pushes continue to be processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->