### PR TITLE
Ignore publish git-notes when fanning out repo.pushed

### DIFF
--- a/docs/contributing/setup-manifest.md
+++ b/docs/contributing/setup-manifest.md
@@ -47,8 +47,9 @@ This project uses the following resources:
   - The production consumer batches at most 10 messages for 5 seconds, retries
     three times, and routes exhausted messages to the dedicated dead-letter
     queue. Consumers filter by `ARTIFACTS_NAMESPACE` and ignore session fork
-    repos plus session workspace branch pushes (`sessions/<id>`). Mapped package
-    topics: `repo.pushed`, `repo.created`, `repo.deleted`.
+    repos, session workspace branch pushes (`sessions/<id>`), and publish
+    git-notes (`refs/notes/commits`). Mapped package topics: `repo.pushed`,
+    `repo.created`, `repo.deleted`.
 - Cloudflare Queue for durable platform-feedback subscription dispatch
   - Producer binding: `PLATFORM_FEEDBACK_DISPATCH_QUEUE`
   - Queue: `kody-platform-feedback-dispatch`

--- a/docs/guides/package-subscriptions.md
+++ b/docs/guides/package-subscriptions.md
@@ -676,12 +676,14 @@ run-error strings for connection health.
 When Cloudflare Artifacts reports commits pushed to a Kody-managed Artifacts
 repo (plain repo, package, or job source), Kody dispatches `repo.pushed` to
 packages saved by that same user that declare the topic. Delivery is durable via
-the `kody-artifacts-repo-events` Queue (with DLQ). Session fork repos and
-session workspace branch pushes (`sessions/<id>`) never emit — opening a repo
-session git-pushes that ref, and delivering it as `repo.pushed` would let a
-handler that opens another session loop. Events for other `ARTIFACTS_NAMESPACE`
-values are ignored. Handlers that only care about default branch content should
-still check `push.ref`.
+the `kody-artifacts-repo-events` Queue (with DLQ). Session fork repos, session
+workspace branch pushes (`sessions/<id>`), and publish git-notes
+(`refs/notes/commits`) never emit. Opening a repo session git-pushes the session
+ref, and delivering it as `repo.pushed` would let a handler that opens another
+session loop. Publish attaches a metadata note after the source-branch push;
+that second git update is not a content push. Events for other
+`ARTIFACTS_NAMESPACE` values are ignored. Handlers that only care about default
+branch content should still check `push.ref`.
 
 Handlers receive a metadata-first payload:
 

--- a/docs/use/packages.md
+++ b/docs/use/packages.md
@@ -435,10 +435,10 @@ is metadata-first (server id/name/state, `account_url`). See the
 
 Artifacts-backed plain repos, packages, and job sources also emit `repo.pushed`,
 `repo.created`, and `repo.deleted` when Cloudflare Artifacts reports those
-lifecycle events. Session workspace branch pushes (`sessions/<id>`) do not fan
-out. See [Plain repos](./repos.md) and the
-[package subscriptions guide](../guides/package-subscriptions.md) for payloads
-and the distinction between live HEAD and package publish.
+lifecycle events. Session workspace branch pushes (`sessions/<id>`) and publish
+git-notes (`refs/notes/commits`) do not fan out. See [Plain repos](./repos.md)
+and the [package subscriptions guide](../guides/package-subscriptions.md) for
+payloads and the distinction between live HEAD and package publish.
 
 ## Package webhooks
 

--- a/docs/use/repos.md
+++ b/docs/use/repos.md
@@ -83,8 +83,8 @@ wrappers use the same event type with `source.type === "artifacts.repo"`.
 
 Declare handlers under `package.json#kody.subscriptions`. Delivery is same-user
 only: packages saved by the entity owner that declare the topic receive the
-event. Session fork Artifacts repos and session workspace branch pushes
-(`sessions/<id>`) never fan out.
+event. Session fork Artifacts repos, session workspace branch pushes
+(`sessions/<id>`), and publish git-notes (`refs/notes/commits`) never fan out.
 
 `repo.pushed` is the primary automation hook (for example resyncing a projection
 after a git-lane push to a plain repo). For packages and jobs, a push updates

--- a/packages/worker/src/repo/artifacts-events.node.test.ts
+++ b/packages/worker/src/repo/artifacts-events.node.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from 'vitest'
 import {
+	isPublishGitNotesRef,
 	isSessionArtifactRepoName,
 	isSessionBranchRef,
 	parseCloudflareArtifactsRepoEvent,
@@ -138,4 +139,10 @@ test('artifacts event helpers parse envelopes, reject unknowns, and detect sessi
 	).toBe(true)
 	expect(isSessionBranchRef('refs/heads/main')).toBe(false)
 	expect(isSessionBranchRef('refs/heads/session-notes')).toBe(false)
+
+	expect(isPublishGitNotesRef('refs/notes/commits')).toBe(true)
+	expect(isPublishGitNotesRef('notes/commits')).toBe(true)
+	expect(isPublishGitNotesRef('refs/notes/reviews')).toBe(true)
+	expect(isPublishGitNotesRef('refs/heads/main')).toBe(false)
+	expect(isPublishGitNotesRef('refs/heads/notes/commits')).toBe(false)
 })

--- a/packages/worker/src/repo/artifacts-events.ts
+++ b/packages/worker/src/repo/artifacts-events.ts
@@ -147,3 +147,13 @@ export function isSessionBranchRef(ref: string) {
 		: ref
 	return branch.startsWith('sessions/')
 }
+
+/**
+ * Publish git-notes (`refs/notes/commits` and other notes refs). Publish
+ * attaches a metadata note after the source-branch push; those updates must
+ * not fan out as a second `repo.pushed`.
+ */
+export function isPublishGitNotesRef(ref: string) {
+	const notesRef = ref.startsWith('refs/') ? ref.slice('refs/'.length) : ref
+	return notesRef.startsWith('notes/')
+}

--- a/packages/worker/src/repo/package-subscriptions.node.test.ts
+++ b/packages/worker/src/repo/package-subscriptions.node.test.ts
@@ -211,6 +211,18 @@ test('processCloudflareArtifactsRepoEvent ignores, unmatched, and dispatches by 
 		},
 	})
 	expect(sessionBranch.outcome).toBe('ignored')
+
+	const publishNotes = await processCloudflareArtifactsRepoEvent({
+		env,
+		body: {
+			...pushedEvent,
+			payload: {
+				...pushedEvent.payload,
+				ref: 'refs/notes/commits',
+			},
+		},
+	})
+	expect(publishNotes.outcome).toBe('ignored')
 	// Ignored events never touch the cached HEAD.
 	expect(mocks.applyArtifactSourcePushToHeadCache).not.toHaveBeenCalled()
 

--- a/packages/worker/src/repo/package-subscriptions.ts
+++ b/packages/worker/src/repo/package-subscriptions.ts
@@ -14,6 +14,7 @@ import { getArtifactsNamespace } from './artifacts.ts'
 import {
 	type CloudflareArtifactsRepoEvent,
 	type RepoSubscriptionTopic,
+	isPublishGitNotesRef,
 	isSessionArtifactRepoName,
 	isSessionBranchRef,
 	parseCloudflareArtifactsRepoEvent,
@@ -406,7 +407,8 @@ export async function processCloudflareArtifactsRepoEvent(input: {
 	}
 	if (
 		providerEvent.type === 'cf.artifacts.repo.pushed' &&
-		isSessionBranchRef(providerEvent.payload.ref)
+		(isSessionBranchRef(providerEvent.payload.ref) ||
+			isPublishGitNotesRef(providerEvent.payload.ref))
 	) {
 		return { outcome: 'ignored', providerEvent }
 	}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop `repo.pushed` from double-dispatching the same subscriber after a package (or repo) publish.

## Why

Publish already pushes the source branch, then attaches a metadata note on `refs/notes/commits`. Cloudflare Artifacts reports both as `cf.artifacts.repo.pushed`. Session workspace branches were already ignored; notes were not. Idempotency keys include `after` + `ref`, so the note push is a second real invocation — typically 2–5 seconds later, after artifact rebuild.

Grouped platform feedback: `bug:repo-pushed-dispatches-twice-per-package-publish-to-the-same-subscriber`.

Two secondary observations from that report are out of scope here:

- `repo.pushed` for package publishes (not only plain repos) is the documented contract.
- Whether `@kody/skills` should declare `repo.pushed` unconditionally is a package-default product call, not this fan-out bug.

## Summary

- Ignore publish git-notes refs (`refs/notes/*`) in `processCloudflareArtifactsRepoEvent`, same class as session-branch ignores.
- Cover the helper and the ignore path in the existing node tests.
- Garden the usage / subscriptions / setup-manifest docs to describe the current ignore set.

## Testing

- Rebased onto `main` @ `5d4a0437` (`#2116`, `#2118`) with no conflicts.
- `CI=1 npm run test:node` after rebase — 876 files, 2771 tests passed (push hook).
- `CI=1 npm run test:workers` after rebase — 94 files, 337 tests passed (push hook).
- CodeRabbit asked to reset mocks and also assert no subscriber dispatch on the notes ignore. Skipped: the same test already asserts `applyArtifactSourcePushToHeadCache` was not called after both ignore cases, and dispatch only runs after an entity-source match that ignore never reaches. That is a test-style nit, not a missing contract.
- No preview UI pass: this is Artifacts queue fan-out, not a rendered route.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends repo-sessions</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `5d4a0437` · **Head:** `0732d8af`

**Classification:** extends — `repo.pushed` fan-out now drops publish git-notes the same way it already drops session workspace branches.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `repo-sessions` | runtime | extends — ignore `refs/notes/*` before subscription dispatch |

### Change flow

A package publish still emits two Artifacts push events. Only the source-branch push fans out.

```mermaid
sequenceDiagram
	actor Artifacts
	participant repoSessions as repo-sessions
	Artifacts->>repoSessions: cf.artifacts.repo.pushed on source branch
	repoSessions->>repoSessions: dispatch repo.pushed to same-user subscribers
	Artifacts->>repoSessions: cf.artifacts.repo.pushed on refs/notes/commits
	repoSessions->>repoSessions: ignore publish git-notes refs
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1511a02c-af0e-4833-a8ef-809277f41cc9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1511a02c-af0e-4833-a8ef-809277f41cc9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified that publish Git notes (`refs/notes/commits`) do not trigger repository lifecycle event fan-out.
  - Documented that these metadata updates are not content pushes.

- **Bug Fixes**
  - Repository push events for publish Git notes are now ignored, preventing unnecessary event dispatches and cache updates.

- **Tests**
  - Added coverage for valid publish Git notes references and excluded repository events, helping ensure metadata-only updates remain excluded from lifecycle processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->