### PR TITLE
Highlight key phrases on landing headings

### DIFF
--- a/packages/worker/client/routes/home.tsx
+++ b/packages/worker/client/routes/home.tsx
@@ -317,7 +317,7 @@ export function HomeRoute(handle: Handle) {
 
 				<section aria-labelledby="factory-title" class="landing-factory">
 					<h2 id="factory-title" class="landing-section-heading">
-						From ad hoc prompts to durable software
+						From ad hoc prompts to <em>durable software</em>
 					</h2>
 					<p class="landing-factory-lead">
 						Stop burning your tokens on the same thing over and over again. Turn
@@ -426,7 +426,7 @@ export function HomeRoute(handle: Handle) {
 				<section aria-labelledby="ecosystem-title" class="landing-ecosystem">
 					<div>
 						<h2 id="ecosystem-title" class="landing-section-heading">
-							Your own git and npm.
+							Your own <em>git</em> and <em>npm</em>.
 						</h2>
 						<p class="landing-split-copy">
 							Kody gives you a <strong>personal software ecosystem</strong>.
@@ -477,7 +477,7 @@ export function HomeRoute(handle: Handle) {
 
 				<section aria-labelledby="world-title" class="landing-world">
 					<h2 id="world-title" class="landing-section-heading">
-						It already speaks your stack
+						It already speaks <em>your stack</em>
 					</h2>
 					<p class="landing-world-lead">
 						Public packages cover the tools you live in. Browse what other
@@ -538,7 +538,7 @@ export function HomeRoute(handle: Handle) {
 						id="invite-title"
 						class="landing-section-heading landing-invite-title"
 					>
-						Give your agents a home
+						Give your agents a <em>home</em>
 					</h2>
 					{isSignedIn ? (
 						<div>

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -868,6 +868,10 @@ test('renderAppPage embeds the homepage factory-loop conversation teaser', async
 	expect(html).toContain('aria-label="Pause"')
 	expect(html).toContain('aria-label="Skip to the end"')
 	expect(html).toContain('class="landing-loop-status-dot"')
+	expect(html).toContain('From ad hoc prompts to <em>durable software</em>')
+	expect(html).toContain('Your own <em>git</em> and <em>npm</em>.')
+	expect(html).toContain('It already speaks <em>your stack</em>')
+	expect(html).toContain('Give your agents a <em>home</em>')
 })
 
 test('signup social buttons are icon-only with accessible names', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Make the landing-page pitch headings emphasize the words that carry the claim.

## Why

The home page already accents phrases like *Share*, *Nothing*, and *honest* with `<em>`. These section titles were plain, so *durable software*, *git*, *npm*, *your stack*, and *home* did not stand out.

## Summary

- Wrap those phrases in `<em>` on the existing `landing-section-heading` titles.
- Reuse the current accent color (`--color-primary-text`); no new CSS.

## Testing

- `npm run test:push` — node 2781, workers 337.
- Homepage SSR asserts the four `em` wraps on `GET /`.
- Browser check of the heading markup against `styles.css`: accent green on the emphasized words.

![Landing headings with accented phrases](https://cursor.com/artifacts/c/art-da23858a-634d-4a6a-8c5e-9d287733e78c)

<a href="https://cursor.com/agents/bc-a5f488d8-35eb-4633-b2c9-d1b8ff7e25cd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flanding_heading_accents.mp4"><img src="https://cursor.com/artifacts/c/art-02cf7081-ab12-4730-83c9-2352b4992650" alt="landing_heading_accents.mp4" /></a>

Local `npm run dev:ensure` did not reach `/health` in this Cloud Agent VM (worker bindings missing on a half-started origin). Markup was verified via SSR; color via the real landing CSS.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `8ae50549` · **Head:** `d1c82aa9`

**Classification:** composes — no primitives added or changed. Landing headings reuse the existing `<em>` accent.

### Primitives touched

| Primitive | Group    | Impact   |
| --------- | -------- | -------- |
| `app-ui`  | surfaces | composes |

### Change flow

Anonymous home headings pick up the same accent as the hero title.

```mermaid
sequenceDiagram
	actor Visitor
	participant appUi as app-ui
	Visitor->>appUi: GET /
	appUi-->>Visitor: headings with em accents on durable software, git, npm, your stack, and home
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a5f488d8-35eb-4633-b2c9-d1b8ff7e25cd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a5f488d8-35eb-4633-b2c9-d1b8ff7e25cd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Updated selected landing-page headings and subheadings with emphasized text to improve visual emphasis and readability.
- **Tests**
  - Added coverage to verify that emphasized marketing copy renders correctly on the homepage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->