### PR TITLE
Delete unused C1 exports and C2 re-export shims

### DIFF
--- a/packages/backup-control-plane/backup-types.ts
+++ b/packages/backup-control-plane/backup-types.ts
@@ -50,8 +50,6 @@ export type ScheduledBackupWorkflowPayload =
 
 export type BackupPayload = ScheduledBackupPayload
 
-export type BackupRuntimePayload = BackupPayload | LegacyScheduledBackupPayload
-
 export interface ExportReady {
 	kind: 'complete'
 	bookmark: string

--- a/packages/status/provider-incidents.ts
+++ b/packages/status/provider-incidents.ts
@@ -27,7 +27,6 @@ export const relevantCloudflareComponentNames = [
 const relevantNameSet = new Set<string>(relevantCloudflareComponentNames)
 
 export const providerIncidentFetchTimeoutMs = 2500
-export const providerIncidentCacheTtlMs = 60_000
 /** Keep a slightly stale cache across one missed cron tick / flaky API. */
 export const providerIncidentCacheStaleMs = 5 * 60_000
 

--- a/packages/worker/client/charts/chart-theme.ts
+++ b/packages/worker/client/charts/chart-theme.ts
@@ -16,18 +16,6 @@ export const chartColor = {
 	teal: '#14b8a6',
 } as const
 
-export const chartSeriesColors = [
-	chartColor.blue,
-	chartColor.emerald,
-	chartColor.amber,
-	chartColor.violet,
-	chartColor.rose,
-	chartColor.cyan,
-	chartColor.lime,
-	chartColor.fuchsia,
-	chartColor.teal,
-] as const
-
 export const chartGridStroke =
 	'color-mix(in srgb, var(--color-border) 55%, transparent)'
 

--- a/packages/worker/client/document-head.ts
+++ b/packages/worker/client/document-head.ts
@@ -7,13 +7,6 @@ import {
 } from '#universal/document-head.ts'
 import { type AppLoaderData } from '#universal/loader-data.ts'
 
-export {
-	DEFAULT_DOCUMENT_TITLE,
-	NOT_FOUND_DOCUMENT_TITLE,
-	resolveDocumentHead,
-	resolveDocumentTitle,
-} from '#universal/document-head.ts'
-
 function removeManagedHeadNodes(head: HTMLHeadElement) {
 	for (const node of head.querySelectorAll(`[${DOCUMENT_HEAD_ATTR}]`)) {
 		node.remove()

--- a/packages/worker/client/fork-outdated-copy.ts
+++ b/packages/worker/client/fork-outdated-copy.ts
@@ -4,8 +4,6 @@ import {
 	COPY_PROMPT_SELECTOR,
 } from '#universal/fork-outdated-copy-button.tsx'
 
-export const FORK_OUTDATED_COPY_BUTTON_SELECTOR = COPY_PROMPT_SELECTOR
-
 type CopyPromptButtonEl = {
 	dataset: {
 		copyText?: string

--- a/packages/worker/client/mcp-oauth-popup.ts
+++ b/packages/worker/client/mcp-oauth-popup.ts
@@ -3,7 +3,6 @@ import {
 	mcpOAuthMessageType,
 	mcpOAuthPopupName,
 	mcpOAuthReturnCookie,
-	mcpOAuthReturnOnboarding,
 	readMcpOAuthDoneMessage,
 	type McpOAuthDoneMessage,
 } from '#universal/mcp-oauth-return.ts'
@@ -34,26 +33,6 @@ function publishOnboardingMcpOAuthDone(outcome: McpOAuthDoneMessage) {
 	if (typeof window === 'undefined') return
 	if (!window.opener || window.opener.closed) return
 	window.opener.postMessage(outcome, window.location.origin)
-}
-
-/**
- * Remember that this authorize flow started on onboarding, then open the
- * provider page in a named popup so the callback tab can close itself.
- * `window.name` survives provider COOP, which often severs `window.opener`.
- */
-export function openOnboardingMcpOAuthPopup(authUrl: string) {
-	document.cookie = mcpOAuthReturnCookie({
-		value: mcpOAuthReturnOnboarding,
-		secure: window.location.protocol === 'https:',
-	})
-	const popup = window.open(
-		authUrl,
-		mcpOAuthPopupName,
-		'popup,width=560,height=780',
-	)
-	if (popup == null) {
-		window.location.assign(authUrl)
-	}
 }
 
 /** Drop the onboarding return marker so a later account authorize stays put. */

--- a/packages/worker/client/provider-icons.tsx
+++ b/packages/worker/client/provider-icons.tsx
@@ -365,10 +365,6 @@ const knownProviderIconIds = [
 
 export type ProviderIconId = (typeof knownProviderIconIds)[number]
 
-export function isKnownProviderIconId(id: string): id is ProviderIconId {
-	return (knownProviderIconIds as ReadonlyArray<string>).includes(id)
-}
-
 const providerIconRenderers: Record<
 	ProviderIconId,
 	(size: string) => JSX.Element

--- a/packages/worker/client/routes/account-management-components.tsx
+++ b/packages/worker/client/routes/account-management-components.tsx
@@ -153,12 +153,6 @@ type AccountManagementShellProps = {
 export const accountManagementNarrowMq = '@media (max-width: 860px)'
 const accountNavMq = accountManagementNarrowMq
 
-/**
- * List/detail panes need more room than the nav rail. Between the nav collapse
- * and this width the 200px rail is still out, so two content columns crush.
- */
-export const accountManagementStackMq = '@media (max-width: 1100px)'
-
 /** Prototype `.account` section rhythm: margin between blocks in the content column. */
 const accountSectionGap = 'clamp(2rem, 4vw, 2.75rem)'
 

--- a/packages/worker/client/routes/email-verification-prompt.tsx
+++ b/packages/worker/client/routes/email-verification-prompt.tsx
@@ -15,10 +15,7 @@ import {
 	mutedLinkCss,
 } from '#universal/styles/style-primitives.ts'
 
-export {
-	buildPendingVerificationPath,
-	pendingVerificationPath,
-} from '#client/routes/pending-verification-path.ts'
+export { buildPendingVerificationPath } from '#client/routes/pending-verification-path.ts'
 
 export const resendVerificationApiPath = '/account/resend-verification.json'
 

--- a/packages/worker/client/routes/onboarding-checklist.tsx
+++ b/packages/worker/client/routes/onboarding-checklist.tsx
@@ -38,14 +38,6 @@ export function getFirstUndoneChecklistItemLabel(
 	return undone ? onboardingChecklistItemLabels[undone.id] : null
 }
 
-/** True when the derived checklist marks the given item done. */
-export function isOnboardingChecklistItemDone(
-	checklist: OnboardingChecklistLoaderData | null | undefined,
-	id: OnboardingChecklistItemId,
-): boolean {
-	return checklist?.items.some((item) => item.id === id && item.done) ?? false
-}
-
 type OnboardingChecklistCardProps = {
 	checklist: OnboardingChecklistLoaderData
 	onDismissed?: () => void

--- a/packages/worker/client/social-sign-in.ts
+++ b/packages/worker/client/social-sign-in.ts
@@ -30,17 +30,6 @@ export function buildProviderStartPath(
 	return query ? `/auth/${providerId}?${query}` : `/auth/${providerId}`
 }
 
-/**
- * Returns the enabled providers, or null when the request failed — callers
- * must not treat a transient failure as "no providers configured".
- */
-export async function fetchEnabledAuthProviders(
-	signal?: AbortSignal,
-): Promise<Array<AuthProviderInfo> | null> {
-	const config = await fetchPublicAuthConfig(signal)
-	return config?.providers ?? null
-}
-
 export async function fetchPublicAuthConfig(
 	signal?: AbortSignal,
 ): Promise<PublicAuthConfig | null> {

--- a/packages/worker/universal/fork-outdated-copy-button.tsx
+++ b/packages/worker/universal/fork-outdated-copy-button.tsx
@@ -11,13 +11,11 @@ import {
 	typography,
 } from '#universal/styles/tokens.ts'
 
-export const COPY_PROMPT_ATTRIBUTE = 'data-copy-prompt'
 export const COPY_PROMPT_SELECTOR = '[data-copy-prompt]'
 export const FORK_OUTDATED_COPY_TOOLTIP = 'Click to copy an update prompt'
 export const FORKED_COPY_TOOLTIP =
 	'Click to copy a prompt to finish adapting this fork'
 export const COPY_PROMPT_COPIED_TOOLTIP = 'Copied'
-export const FORK_OUTDATED_COPIED_TOOLTIP = COPY_PROMPT_COPIED_TOOLTIP
 
 type CopyPromptPillInput = {
 	label: string

--- a/packages/worker/universal/google-oauth-transcript.ts
+++ b/packages/worker/universal/google-oauth-transcript.ts
@@ -8,14 +8,6 @@ import {
 	type TranscriptAct,
 } from './interactive-guide-transcript.ts'
 
-export type {
-	TranscriptAct,
-	TranscriptFile,
-	TranscriptInput,
-	TranscriptLine,
-	TranscriptTool,
-} from './interactive-guide-transcript.ts'
-
 const conversationId = '8g4q1n6m2s9t'
 
 const askMemoryContext = {

--- a/packages/worker/universal/highlight-cache-header.ts
+++ b/packages/worker/universal/highlight-cache-header.ts
@@ -1,3 +1,1 @@
 export const highlightCacheHeaderName = 'x-kody-highlight-cache'
-
-export type HighlightCacheHeader = 'hit' | 'miss'

--- a/packages/worker/universal/how-kody-works-transcript.ts
+++ b/packages/worker/universal/how-kody-works-transcript.ts
@@ -9,14 +9,7 @@ import {
 	type TranscriptAct,
 } from './interactive-guide-transcript.ts'
 
-export {
-	transcriptFileLang,
-	type TranscriptAct,
-	type TranscriptFile,
-	type TranscriptInput,
-	type TranscriptLine,
-	type TranscriptTool,
-} from './interactive-guide-transcript.ts'
+export { transcriptFileLang } from './interactive-guide-transcript.ts'
 
 const whatShippedSource = `import { packageStorage } from 'kody:runtime'
 

--- a/packages/worker/universal/landing-testimonials.ts
+++ b/packages/worker/universal/landing-testimonials.ts
@@ -55,8 +55,6 @@ export const landingTestimonials = [
 	},
 ] as const satisfies ReadonlyArray<LandingTestimonial>
 
-export type LandingTestimonialEntry = (typeof landingTestimonials)[number]
-
 /** Fisher–Yates shuffle. Pass `random` in tests for a deterministic draw. */
 export function shuffleTestimonials<T>(
 	items: ReadonlyArray<T>,

--- a/packages/worker/universal/loader-data.ts
+++ b/packages/worker/universal/loader-data.ts
@@ -13,7 +13,6 @@ import { type OnboardingChecklistItemId } from '#universal/onboarding-checklist-
 import {
 	type OnboardingCustomMcpServer,
 	type OnboardingFeaturedMcpServer,
-	type OnboardingFeaturedMcpServerId,
 } from '#universal/onboarding-mcp-chooser.ts'
 import {
 	type SignupMode,
@@ -47,12 +46,7 @@ import { type FleetPackageErrorRateConcentration } from '#universal/fleet-packag
 
 export type { ProfileVisibility }
 export type { AdminFeatureFlag }
-export type { OnboardingChecklistItemId }
-export type {
-	OnboardingCustomMcpServer,
-	OnboardingFeaturedMcpServer,
-	OnboardingFeaturedMcpServerId,
-}
+export type { OnboardingCustomMcpServer, OnboardingFeaturedMcpServer }
 
 export type BlogPostSummaryLoaderData = {
 	slug: string
@@ -1587,13 +1581,6 @@ export type AccountWorkflowsLoaderData = {
 	workflows: Array<AccountWorkflowListItem>
 	selectedWorkflow: AccountWorkflowDetail | null
 	selectedWorkflowId: string | null
-}
-
-export type {
-	AccountActivityStatusFilter,
-	AccountActivitySurfaceFilter,
-	AccountActivityTriageFilter,
-	AccountActivityViewFilter,
 }
 
 export type AccountActivityRunListItem = {

--- a/packages/worker/universal/onboarding-mcp-chooser.ts
+++ b/packages/worker/universal/onboarding-mcp-chooser.ts
@@ -46,61 +46,6 @@ export const onboardingFeaturedMcpServerIds = [
 export type OnboardingFeaturedMcpServerId =
 	(typeof onboardingFeaturedMcpServerIds)[number]
 
-/**
- * Extra Show more chips on `/onboarding/step-2`. Each one is a real
- * `/onboarding/step-2/:service` selection that flavors the copyable prompt.
- * They are not a connect wizard and they are not hosted OAuth. Official MCP
- * remotes stay off this list.
- */
-export const onboardingNotListedPromptServices = [
-	{ id: 'google', label: 'Google' },
-	{ id: 'slack', label: 'Slack' },
-	{ id: 'discord', label: 'Discord' },
-	{ id: 'spotify', label: 'Spotify' },
-	{ id: 'x', label: 'x.com' },
-	{ id: 'asana', label: 'Asana' },
-	{ id: 'dropbox', label: 'Dropbox' },
-	{ id: 'linkedin', label: 'LinkedIn' },
-	{ id: 'zoom', label: 'Zoom' },
-] as const
-
-export type OnboardingNotListedPromptServiceId =
-	(typeof onboardingNotListedPromptServices)[number]['id']
-
-export const onboardingNotListedServiceId = 'not-listed' as const
-
-export type OnboardingServiceChoice =
-	| OnboardingFeaturedMcpServerId
-	| OnboardingNotListedPromptServiceId
-	| typeof onboardingNotListedServiceId
-
-export function isOnboardingServiceChoice(
-	value: string | null,
-): value is OnboardingServiceChoice {
-	if (value == null) return false
-	if (value === onboardingNotListedServiceId) return true
-	if (
-		(onboardingFeaturedMcpServerIds as ReadonlyArray<string>).includes(value)
-	) {
-		return true
-	}
-	return onboardingNotListedPromptServices.some(
-		(service) => service.id === value,
-	)
-}
-
-export function onboardingServiceLabel(id: OnboardingServiceChoice): string {
-	if (id === onboardingNotListedServiceId) return 'Not listed'
-	const server = onboardingFeaturedMcpServers.find(
-		(candidate) => candidate.id === id,
-	)
-	if (server) return server.label
-	const byo = onboardingNotListedPromptServices.find(
-		(candidate) => candidate.id === id,
-	)
-	return byo?.label ?? id
-}
-
 export type OnboardingFeaturedMcpServerOption = {
 	id: OnboardingFeaturedMcpServerId
 	name: string
@@ -362,50 +307,6 @@ export function formatOnboardingFeaturedMcpAddHint(): string {
 		.join(', ')
 }
 
-export function onboardingFeaturedMcpServerById(
-	id: string,
-): OnboardingFeaturedMcpServerOption | null {
-	return onboardingFeaturedMcpServers.find((server) => server.id === id) ?? null
-}
-
-/**
- * Repo icons for catalog chips that are not in `ProviderIcon`. Do not invent
- * lookalikes — missing files fall through to a letter mark.
- */
-const onboardingServiceImageIconIds = [
-	'airtable',
-	'cloudflare',
-	'cloudinary',
-	'intercom',
-	'monday',
-	'neon',
-	'netlify',
-	'paypal',
-	'plaid',
-	'prisma',
-	'resend',
-	'square',
-	'supabase',
-	'workos',
-] as const
-
-export function onboardingServiceImageIconSrc(id: string): string | null {
-	if (!(onboardingServiceImageIconIds as ReadonlyArray<string>).includes(id)) {
-		return null
-	}
-	return `/images/icons/${id}.svg`
-}
-
-function isPermutation(
-	actual: ReadonlyArray<OnboardingFeaturedMcpServerId>,
-	expected: ReadonlyArray<OnboardingFeaturedMcpServerId>,
-) {
-	if (actual.length !== expected.length) return false
-	const expectedIds = new Set(expected)
-	if (new Set(actual).size !== expectedIds.size) return false
-	return actual.every((id) => expectedIds.has(id))
-}
-
 export function pickOnboardingServiceChooser(
 	randomInt: OnboardingRandomInt = randomOnboardingInt,
 ): OnboardingServiceChooserPick {
@@ -429,20 +330,6 @@ export function canonicalOnboardingServiceChooser(): OnboardingServiceChooserPic
 		featured: onboardingFeaturedMcpServerIds.slice(0, slotCount),
 		overflow: onboardingFeaturedMcpServerIds.slice(slotCount),
 	}
-}
-
-export function isValidOnboardingServiceChooserPick(
-	value: OnboardingServiceChooserPick,
-): boolean {
-	const slotCount = Math.min(
-		onboardingFeaturedMcpSlotCount,
-		onboardingFeaturedMcpServerIds.length,
-	)
-	if (value.featured.length !== slotCount) return false
-	return isPermutation(
-		[...value.featured, ...value.overflow],
-		onboardingFeaturedMcpServerIds,
-	)
 }
 
 export function normalizeOnboardingMcpServerUrl(url: string): string {

--- a/packages/worker/universal/onboarding-mcp-clients.ts
+++ b/packages/worker/universal/onboarding-mcp-clients.ts
@@ -202,13 +202,6 @@ export function isValidOnboardingAgentChooserPick(
 	)
 }
 
-export function onboardingFeaturedIdsFromChooser(
-	chooser: OnboardingAgentChooserPick,
-	surface: OnboardingAgentSurface,
-): ReadonlyArray<McpClientKind> {
-	return surface === 'mobile' ? chooser.mobileFeatured : chooser.desktopFeatured
-}
-
 export type OnboardingAgentViewport = 'desktop-only' | 'mobile-only' | 'both'
 
 export function onboardingAgentViewport(
@@ -264,13 +257,6 @@ export function onboardingViewportCss(
 		display: 'none',
 		[onboardingMobileAgentMq]: { display: shownDisplay },
 	}
-}
-
-export function onboardingMoreIdsFromChooser(
-	chooser: OnboardingAgentChooserPick,
-	surface: OnboardingAgentSurface,
-): ReadonlyArray<McpClientKind> {
-	return surface === 'mobile' ? chooser.mobileMore : chooser.desktopMore
 }
 
 export function onboardingAgentLabel(

--- a/packages/worker/universal/onboarding-process.ts
+++ b/packages/worker/universal/onboarding-process.ts
@@ -56,31 +56,26 @@ export const onboardingChecklistItems = [
 	{
 		id: 'verify-email',
 		label: 'Verify your email',
-		searchLabel: 'verify your email',
 		href: '/pending-verification',
 	},
 	{
 		id: 'connect-agent',
 		label: 'Connect your agent',
-		searchLabel: 'connect your agent',
 		wizardStep: 1,
 	},
 	{
 		id: 'give-access',
 		label: 'Make something useful',
-		searchLabel: 'make something useful',
 		wizardStep: 2,
 	},
 	{
 		id: 'connect-second-agent',
 		label: 'Connect a second agent',
-		searchLabel: 'connect a second agent',
 		wizardStep: 3,
 	},
 	{
 		id: 'install-starter',
 		label: 'Persist your first package',
-		searchLabel: 'persist your first package',
 		profile: true,
 	},
 ] as const
@@ -97,27 +92,10 @@ export const onboardingChecklistItemLabels = Object.fromEntries(
 	onboardingChecklistItems.map((item) => [item.id, item.label]),
 ) as Record<OnboardingChecklistItemId, string>
 
-export const onboardingChecklistSearchLabels = Object.fromEntries(
-	onboardingChecklistItems.map((item) => [item.id, item.searchLabel]),
-) as Record<OnboardingChecklistItemId, string>
-
-/**
- * Optional email → reply → memories loop. Not a wizard step. The climax guide
- * and next-step path here are what `onboarding-process.node.test.ts` requires
- * `docs/guides/first-win.md` to name.
- */
-export const firstWinAlignment = {
-	guideSlug: 'first-win',
-	climaxGuideSlug: 'quick-example',
-	prerequisiteWizardStep: 1,
-	nextWizardStep: 2,
-} as const
-
 export const onboardingUnconnectedNotice =
 	'Your agent cannot do anything in Kody yet.'
 
 /** Agent-retrievable first-run guide (bundled + `search({ entity })`). */
-export const onboardingGuideSlug = 'onboarding'
 export const onboardingGuideEntity = 'onboarding:guide'
 export const onboardingGuideHref = '/guides/onboarding'
 

--- a/packages/worker/universal/styles/style-primitives.ts
+++ b/packages/worker/universal/styles/style-primitives.ts
@@ -598,67 +598,6 @@ export const proseCss = {
 	},
 }
 
-/** Display-face section heading (the redesign's `section h2` voice). */
-export const sectionHeadingCss = {
-	margin: 0,
-	fontSize: 'clamp(1.9rem, 3.8vw, 2.8rem)',
-	fontWeight: 730,
-	letterSpacing: '-0.025em',
-	lineHeight: 1.08,
-	'@media (max-width: 800px)': {
-		fontSize: '2rem',
-	},
-}
-
-type BrandChipCssOptions = {
-	/**
-	 * `/images/icons/<name>.svg` brand mark, drawn in the chip's own ink via
-	 * a CSS mask so it works in both themes. Omit for a plain text chip.
-	 */
-	iconHref?: string
-	/** Dashed, muted trailing chip ("…and one thermostat"). */
-	muted?: boolean
-}
-
-/**
- * Pill chip for brand/host clouds (landing pitch hosts, world cloud,
- * onboarding wayfinding). Icon comes from a real SVG asset referenced with a
- * plain url() mask — never a data URI.
- */
-export function getBrandChipCss(options: BrandChipCssOptions = {}) {
-	return {
-		display: 'inline-flex',
-		alignItems: 'center',
-		gap: '0.55em',
-		fontSize: '0.95rem',
-		fontWeight: 550,
-		color: options.muted ? colors.textMuted : colors.text,
-		backgroundColor: options.muted ? 'transparent' : colors.surface,
-		border: `1px ${options.muted ? 'dashed' : 'solid'} ${colors.border}`,
-		borderRadius: radius.full,
-		padding: '0.45rem 1rem',
-		...(options.iconHref
-			? {
-					'&::before': {
-						content: '""',
-						width: '1.05em',
-						height: '1.05em',
-						flex: 'none',
-						background: 'currentColor',
-						maskImage: `url('${options.iconHref}')`,
-						maskPosition: 'center',
-						maskSize: 'contain',
-						maskRepeat: 'no-repeat',
-						WebkitMaskImage: `url('${options.iconHref}')`,
-						WebkitMaskPosition: 'center',
-						WebkitMaskSize: 'contain',
-						WebkitMaskRepeat: 'no-repeat',
-					},
-				}
-			: {}),
-	}
-}
-
 type SurfaceCardCssOptions = {
 	interactive?: boolean
 }
@@ -1026,12 +965,6 @@ export const textareaCss = {
 	...inputCss,
 	resize: 'vertical' as const,
 	minHeight: '7rem',
-}
-
-export const compactInputCss = {
-	...inputCss,
-	padding: `${spacing.xs} ${spacing.sm}`,
-	fontSize: typography.fontSize.sm,
 }
 
 export const listCss = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Delete the HIGH-confidence unused exports from [Legacy Reaper #2123](https://github.com/kentcdodds/kody/issues/2123) cluster C1 (dead declarations) and C2 (unused re-export shim lines). Shrink the knip exports/types backlog without changing runtime behavior.

## Why

Track C’s 2026-09-07 scan found 27 zero-reference exports and ~14 unused re-export statements. Those names had no importers anywhere in the tree. Leaving them around is noise for knip, reviewers, and later leftover-reaper tracks.

## Summary

- **C1:** removed unused exports (and now-unreferenced helper bodies) from onboarding chooser/clients/process, checklist, fork-outdated copy, style primitives, status incidents, charts, MCP OAuth popup, provider icons, account management, social sign-in, backup types, highlight-cache header, and landing testimonials.
- **C2:** removed unused re-export lines only — `client/document-head.ts` document-title helpers, transcript type re-exports on google-oauth / how-kody-works, `loader-data.ts` type re-exports, and `pendingVerificationPath` from `email-verification-prompt.tsx`. Source modules stay.
- **Skipped (siblings):** `formatPackageTokenExportChoiceLabel` (#2038), C3 loader-data duplicate types, C4 sentry-browser-filters, C5 mechanical de-export, Track A files / PR #2124, leftover gates.

Each name was re-verified with repo-wide `rg` before deletion. If anything imported it, it was kept.

## Testing

- `git push` ran `test:node` (2781) and `test:workers` (337) green.
- Local `npm run validate` green (typecheck, lint, node/workers/mcp unit, Playwright e2e).
- `npx knip --include exports,types` no longer flags the deleted C1/C2 names.

## Conductor report

- **Track:** D (implement C1 + C2 re-export shims)
- **Conductor agent id:** `bc-c4625e8c-be74-474b-bddc-5853ee533d7b`
- **This agent id:** `bc-544b95e0-c9df-447c-ba49-2fe0a674e1fb`
- **Issue:** #2123
- **Out of scope leftovers:** C3 per-name loader-data duplicates, C5 ~225 in-file-only de-exports, C4 sentry-browser-filters (waits on Track A / #2124), `formatPackageTokenExportChoiceLabel` (#2038), leftover gates (values, createJob, tokens, dual-write, platform OAuth, crypto v1, MCP lane, compact-mcp).

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `8ae50549` · **Head:** `d4abf836`

**Classification:** composes — no primitives added or changed; this PR deletes unused exports and unused re-export lines. Call sites and source modules are unchanged.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | composes — unused client/universal exports and shim lines removed |
| `backup-control-plane` | storage | composes — unused `BackupRuntimePayload` type removed |
| `status-page` | surfaces | composes — unused `providerIncidentCacheTtlMs` constant removed |

### Change flow

Knip-flagged C1/C2 names are deleted in place. Live helpers and source modules keep serving callers.

```mermaid
sequenceDiagram
	participant appUi as app-ui
	participant backupControlPlane as backup-control-plane
	participant statusPage as status-page
	Note over appUi: delete C1 dead export bodies and C2 re-export shims
	Note over backupControlPlane: delete unused BackupRuntimePayload type
	Note over statusPage: delete unused providerIncidentCacheTtlMs
	appUi->>appUi: keep source modules and live helpers
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-544b95e0-c9df-447c-ba49-2fe0a674e1fb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-544b95e0-c9df-447c-ba49-2fe0a674e1fb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

