### PR TITLE
Uncapped referral program: one Standard month each after first paid invoice

### DIFF
--- a/.agents/skills/control-kody/references/features/billing.md
+++ b/.agents/skills/control-kody/references/features/billing.md
@@ -20,8 +20,8 @@ change plans through the Stripe portal (proration). Deleting an account refunds
 unused paid subscription time automatically. `/account/usage` and `usageGet`
 include unique Dynamic Worker days and Durable Object rows-read with what-counts
 copy. Public-ladder overage uses the list rates on `/pricing`. Referral rewards
-fire on the referee's first qualifying paid Stripe invoice (not a trial); do not
-invent a paid invoice from this environment.
+fire on the referee's first qualifying paid Stripe invoice (not a trial) after
+both emails are verified; do not invent a paid invoice from this environment.
 
 ## APIs
 

--- a/.agents/skills/control-kody/references/features/billing.md
+++ b/.agents/skills/control-kody/references/features/billing.md
@@ -19,9 +19,11 @@ Do not complete a real Stripe checkout from a Cloud Agent. Existing subscribers
 change plans through the Stripe portal (proration). Deleting an account refunds
 unused paid subscription time automatically. `/account/usage` and `usageGet`
 include unique Dynamic Worker days and Durable Object rows-read with what-counts
-copy. Public-ladder overage uses the list rates on `/pricing`. Referral rewards
-fire on the referee's first qualifying paid Stripe invoice (not a trial) after
-both emails are verified; do not invent a paid invoice from this environment.
+copy. Public-ladder overage uses the list rates on `/pricing`. Referral share
+links set a one-week last-wins `kody_ref` cookie; signup persists the referrer
+then. Referral rewards fire on the referee's first qualifying paid Stripe
+invoice (not a trial) after both emails are verified; do not invent a paid
+invoice from this environment.
 
 ## APIs
 

--- a/.agents/skills/control-kody/references/features/billing.md
+++ b/.agents/skills/control-kody/references/features/billing.md
@@ -5,7 +5,8 @@ Plan, checkout, portal, and entitlement usage.
 ## How to get there
 
 `/account/billing` (success `/account/billing/success`, portal
-`/account/billing/portal`) and `/account/usage`.
+`/account/billing/portal`) and `/account/usage`. Billing also shows the
+signed-in user's referral share link and reward status.
 
 ## Drive it
 
@@ -16,7 +17,9 @@ node tools/control-kody.ts request GET /account/usage.json
 
 Do not complete a real Stripe checkout from a Cloud Agent. Existing subscribers
 change plans through the Stripe portal (proration). Deleting an account refunds
-unused paid subscription time automatically.
+unused paid subscription time automatically. Referral rewards fire on the
+referee's first qualifying paid Stripe invoice (not a trial); do not invent a
+paid invoice from this environment.
 
 ## APIs
 

--- a/docs/contributing/architecture/authentication.md
+++ b/docs/contributing/architecture/authentication.md
@@ -36,6 +36,11 @@ Session cookie behavior is implemented in
   signed out and the cookie is cleared. A cookie that omits `issuedAt` is
   rejected the same way.
 
+Referral share links set a separate last-wins `kody_ref` cookie (one week, not
+`httpOnly`) so a later `/signup?ref=` overwrites the previous referrer. Signup
+persists a `referrals` row from that cookie. See
+[Referral Standard credit](./entitlements.md#referral-standard-credit).
+
 The cookie payload stores:
 
 - `v: 2`

--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -352,7 +352,13 @@ The schema is defined by migrations in `packages/worker/migrations/`:
   14-day Standard overlay granted when unique inbound MCP OAuth `clientId`s
   first reach 2; `second_agent_standard_gift_expires_at` is set only when that
   overlay actually raises a free account (NULL means already paid / no-op). See
-  [Entitlements](./entitlements.md#second-agent-standard-gift). The
+  [Entitlements](./entitlements.md#second-agent-standard-gift).
+  `referral_standard_credit_expires_at` is the stackable Standard overlay from
+  the uncapped referral program. `referrals` stores write-once signup
+  attribution (`referrer_stable_user_id`, `referee_stable_user_id`) and the
+  invoice-gated reward ledger (`status`, `reward_invoice_id`, held invoice
+  fields while email is unverified). See
+  [Entitlements](./entitlements.md#referral-standard-credit). The
   `d1_storage_reconciliation` lane sweeps users by `stable_user_id` keyset from
   the platform-owned `d1_storage_reconcile_cursor` singleton. UserMeter
   `storage_bytes_state` (schema v4) drives storage-byte enforcement; see

--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -354,10 +354,11 @@ The schema is defined by migrations in `packages/worker/migrations/`:
   overlay actually raises a free account (NULL means already paid / no-op). See
   [Entitlements](./entitlements.md#second-agent-standard-gift).
   `referral_standard_credit_expires_at` is the stackable Standard overlay from
-  the uncapped referral program. `referrals` stores write-once signup
-  attribution (`referrer_stable_user_id`, `referee_stable_user_id`) and the
-  invoice-gated reward ledger (`status`, `reward_invoice_id`, held invoice
-  fields while email is unverified). See
+  the uncapped referral program. Pre-signup attribution lives in the last-wins
+  one-week `kody_ref` cookie. `referrals` stores the signup-time row
+  (`referrer_stable_user_id`, `referee_stable_user_id`) and the invoice-gated
+  reward ledger (`status`, `reward_invoice_id`, held invoice fields while email
+  is unverified). See
   [Entitlements](./entitlements.md#referral-standard-credit). The
   `d1_storage_reconciliation` lane sweeps users by `stable_user_id` keyset from
   the platform-owned `d1_storage_reconcile_cursor` singleton. UserMeter

--- a/docs/contributing/architecture/entitlements.md
+++ b/docs/contributing/architecture/entitlements.md
@@ -33,10 +33,11 @@ at `packages/worker/universal/plans.ts`.
   PackagedSingleClient. Enforcement goes through `getUserEntitlement`; Stripe is
   not mutated.
 - `referral-program.ts` (universal + worker) — uncapped referral Standard
-  credit. Signup writes a pending `referrals` row from `?ref=<username>`;
-  `invoice.paid` grants both parties one stacked month after the first
-  qualifying paid invoice. Enforcement composes the later overlay with the
-  second-agent gift in `getUserEntitlement`; Stripe is not mutated.
+  credit. Share links write a last-wins one-week `kody_ref` cookie; signup
+  persists a pending `referrals` row from that cookie. `invoice.paid` grants
+  both parties one stacked month after the first qualifying paid invoice.
+  Enforcement composes the later overlay with the second-agent gift in
+  `getUserEntitlement`; Stripe is not mutated.
 
 ## Plan model
 
@@ -133,28 +134,29 @@ lifecycle email or PackagedSingleClient should read: `received`, `active`, and
 
 ### Referral Standard credit
 
-Shareable signup links (`/signup?ref=<username>`) write a pending `referrals`
-row at account creation (password and OAuth). First-touch UTMs stay write-once,
-but a later share link can still fill a missing `referralCode` in the same tab
-so a homepage visit does not drop attribution. Reward runs on `invoice.paid`
-after the referee's first qualifying paid Stripe invoice (`amount_paid > 0`, not
-a $0 trial, not a compute-overage invoice). Both the referrer and the referee
-receive one stacked month (30 days) of public Standard via
-`users.referral_standard_credit_expires_at`. There is no annual or lifetime cap
-on how many months a referrer can earn. Paid subscribers stack from the later of
-an existing credit and the current paid period end so the month starts after
-paid access rather than overlapping it. Referee invoices use the latest line
-`period.end`. A failed Stripe lookup of the referrer's subscription fails the
-webhook so Stripe can retry instead of stacking from now. Email-verify leaves a
-held row pending if that lookup fails; the referrer’s later `invoice.paid`
-retries it. Stripe subscriptions are not mutated.
+Shareable signup links (`/signup?ref=<username>`) set a last-wins `kody_ref`
+cookie that expires after one week. A later share link overwrites the previous
+referrer for the rest of that window. Signup (password and OAuth) persists a
+pending `referrals` row from the cookie or a same-request share link.
+First-touch UTMs stay write-once and do not carry the referral code. Reward runs
+on `invoice.paid` after the referee's first qualifying paid Stripe invoice
+(`amount_paid > 0`, not a $0 trial, not a compute-overage invoice). Both the
+referrer and the referee receive one stacked month (30 days) of public Standard
+via `users.referral_standard_credit_expires_at`. There is no annual or lifetime
+cap on how many months a referrer can earn. Paid subscribers stack from the
+later of an existing credit and the current paid period end so the month starts
+after paid access rather than overlapping it. Referee invoices use the latest
+line `period.end`. A failed Stripe lookup of the referrer's subscription fails
+the webhook so Stripe can retry instead of stacking from now. Email-verify
+leaves a held row pending if that lookup fails; the referrer’s later
+`invoice.paid` retries it. Stripe subscriptions are not mutated.
 
 Fraud basics before a reward: both emails verified, new-account attribution only
-(write-once at signup), no self-referral, no plus-tag / Gmail-dot email
-collapse, no shared Stripe customer, and no platform-account referrer. An
-unverified party holds the qualifying invoice id on the pending row; email
-verification retries the grant. `/account/billing` shows the share link and
-simple referrer status.
+(persisted at signup from the last-wins cookie), no self-referral, no plus-tag /
+Gmail-dot email collapse, no shared Stripe customer, and no platform-account
+referrer. An unverified party holds the qualifying invoice id on the pending
+row; email verification retries the grant. `/account/billing` shows the share
+link and simple referrer status.
 
 `getUserEntitlement` overlays Standard through the later of the second-agent
 gift and this referral credit.
@@ -1058,5 +1060,6 @@ wiring are documented in
   plan writes clear `legacy` when a remaining manual Pro grant is removed
   without a paid Stripe tier.
 - `users.referral_standard_credit_expires_at` and `referrals` — uncapped
-  referral program ledger. Attribution is write-once at signup; reward is
-  invoice-gated. See [Referral Standard credit](#referral-standard-credit).
+  referral program ledger. Attribution is persisted at signup from the last-wins
+  `kody_ref` cookie; reward is invoice-gated. See
+  [Referral Standard credit](#referral-standard-credit).

--- a/docs/contributing/architecture/entitlements.md
+++ b/docs/contributing/architecture/entitlements.md
@@ -32,6 +32,11 @@ at `packages/worker/universal/plans.ts`.
   `describeSecondAgentStandardGift` is the flag for lifecycle email /
   PackagedSingleClient. Enforcement goes through `getUserEntitlement`; Stripe is
   not mutated.
+- `referral-program.ts` (universal + worker) — uncapped referral Standard
+  credit. Signup writes a pending `referrals` row from `?ref=<username>`;
+  `invoice.paid` grants both parties one stacked month after the first
+  qualifying paid invoice. Enforcement composes the later overlay with the
+  second-agent gift in `getUserEntitlement`; Stripe is not mutated.
 
 ## Plan model
 
@@ -125,6 +130,28 @@ clients are below 2 or listing failed, but still reads the persisted ledger so
 lifecycle email or PackagedSingleClient should read: `received`, `active`, and
 `status` (`none` | `active` | `expired` | `already_paid`). Onboarding loader and
 `/onboarding.json` expose that object as `secondAgentStandardGift`.
+
+### Referral Standard credit
+
+Shareable signup links (`/signup?ref=<username>`) write a pending `referrals`
+row at account creation (password and OAuth). Reward runs on `invoice.paid`
+after the referee's first qualifying paid Stripe invoice (`amount_paid > 0`, not
+a $0 trial, not a compute-overage invoice). Both the referrer and the referee
+receive one stacked month (30 days) of public Standard via
+`users.referral_standard_credit_expires_at`. There is no annual or lifetime cap
+on how many months a referrer can earn. Paid subscribers stack from the later of
+an existing credit and the current paid period end so the month starts after
+paid access rather than overlapping it. Stripe subscriptions are not mutated.
+
+Fraud basics before a reward: both emails verified, new-account attribution only
+(write-once at signup), no self-referral, no plus-tag / Gmail-dot email
+collapse, no shared Stripe customer, and no platform-account referrer. An
+unverified party holds the qualifying invoice id on the pending row; email
+verification retries the grant. `/account/billing` shows the share link and
+simple referrer status.
+
+`getUserEntitlement` overlays Standard through the later of the second-agent
+gift and this referral credit.
 
 ### `max` plan limits
 
@@ -972,6 +999,8 @@ Handled event types:
   the user by `users.stripe_customer_id` and call `refreshStripePlanForUser`
 - `invoice.payment_failed` — same customer lookup + refresh (surfaces
   `subscriptionStatus` such as `past_due` for UX; does not email users)
+- `invoice.paid` — customer lookup, then the referral reward path when the
+  invoice is the referee's first qualifying paid subscription invoice
 - Unknown event types — acknowledge `200` after process+record
 
 Idempotency uses the `stripe_webhook_events` table from
@@ -1022,3 +1051,6 @@ wiring are documented in
   the granting subscription changes plan, price, product, or interval. Admin
   plan writes clear `legacy` when a remaining manual Pro grant is removed
   without a paid Stripe tier.
+- `users.referral_standard_credit_expires_at` and `referrals` — uncapped
+  referral program ledger. Attribution is write-once at signup; reward is
+  invoice-gated. See [Referral Standard credit](#referral-standard-credit).

--- a/docs/contributing/architecture/entitlements.md
+++ b/docs/contributing/architecture/entitlements.md
@@ -134,7 +134,9 @@ lifecycle email or PackagedSingleClient should read: `received`, `active`, and
 ### Referral Standard credit
 
 Shareable signup links (`/signup?ref=<username>`) write a pending `referrals`
-row at account creation (password and OAuth). Reward runs on `invoice.paid`
+row at account creation (password and OAuth). First-touch UTMs stay write-once,
+but a later share link can still fill a missing `referralCode` in the same tab
+so a homepage visit does not drop attribution. Reward runs on `invoice.paid`
 after the referee's first qualifying paid Stripe invoice (`amount_paid > 0`, not
 a $0 trial, not a compute-overage invoice). Both the referrer and the referee
 receive one stacked month (30 days) of public Standard via

--- a/docs/contributing/architecture/entitlements.md
+++ b/docs/contributing/architecture/entitlements.md
@@ -143,7 +143,10 @@ receive one stacked month (30 days) of public Standard via
 `users.referral_standard_credit_expires_at`. There is no annual or lifetime cap
 on how many months a referrer can earn. Paid subscribers stack from the later of
 an existing credit and the current paid period end so the month starts after
-paid access rather than overlapping it. Stripe subscriptions are not mutated.
+paid access rather than overlapping it. Referee invoices use the latest line
+`period.end`. A failed Stripe lookup of the referrer's subscription fails the
+webhook so Stripe can retry instead of stacking from now. Stripe subscriptions
+are not mutated.
 
 Fraud basics before a reward: both emails verified, new-account attribution only
 (write-once at signup), no self-referral, no plus-tag / Gmail-dot email

--- a/docs/contributing/architecture/entitlements.md
+++ b/docs/contributing/architecture/entitlements.md
@@ -145,8 +145,9 @@ on how many months a referrer can earn. Paid subscribers stack from the later of
 an existing credit and the current paid period end so the month starts after
 paid access rather than overlapping it. Referee invoices use the latest line
 `period.end`. A failed Stripe lookup of the referrer's subscription fails the
-webhook so Stripe can retry instead of stacking from now. Stripe subscriptions
-are not mutated.
+webhook so Stripe can retry instead of stacking from now. Email-verify leaves a
+held row pending if that lookup fails; the referrer’s later `invoice.paid`
+retries it. Stripe subscriptions are not mutated.
 
 Fraud basics before a reward: both emails verified, new-account attribution only
 (write-once at signup), no self-referral, no plus-tag / Gmail-dot email

--- a/docs/use/privacy.md
+++ b/docs/use/privacy.md
@@ -22,16 +22,18 @@ information (email, username, optional display name and bio, and profile
 visibility), first-touch marketing attribution captured on public-site visits
 when UTM or landing context is present and associated with the account at signup
 (`utm_source` / `utm_medium` / `utm_campaign` / `utm_content` / `utm_term`,
-landing path, and referrer), first-seen activation timestamps (email verified,
-first MCP connection, first execute, first saved package), MCP client name when
-known, last-active day stamps used for return metrics, secrets, memories,
-packages and their source, jobs, email inboxes and messages, durable storage,
-MCP server configuration, OAuth grants, package invocation tokens, short-lived
-execution history (see [Activity](./activity.md)), stored community activity
-events, and any platform feedback you approve for submission. All of this
-remains scoped to your account except for content you deliberately make public
-(community listings and a public profile), the narrow admin review of approved
-platform feedback, and the community activity metadata described below.
+landing path, and referrer), referral attribution when a signup used
+`?ref=<username>` (the referred and referring stable user ids, reward status,
+and the Stripe invoice id after a paid reward), first-seen activation timestamps
+(email verified, first MCP connection, first execute, first saved package), MCP
+client name when known, last-active day stamps used for return metrics, secrets,
+memories, packages and their source, jobs, email inboxes and messages, durable
+storage, MCP server configuration, OAuth grants, package invocation tokens,
+short-lived execution history (see [Activity](./activity.md)), stored community
+activity events, and any platform feedback you approve for submission. All of
+this remains scoped to your account except for content you deliberately make
+public (community listings and a public profile), the narrow admin review of
+approved platform feedback, and the community activity metadata described below.
 
 When profile visibility is **public**, display name, bio, public package
 metadata, and public activity are visible on `/@username`. When visibility is
@@ -118,32 +120,34 @@ the same community metadata, and a metadata-only `user.created` or
 `user.deleted` event when a person account is created or self-deleted (stable
 user id, username, email, the create source or delete timestamp, the consumed
 invite code when `user.created` used one, and first-touch marketing attribution
-fields when present). Those lifecycle events omit passwords, roles, plan,
-secrets, and unrelated account content. Admin-configured notification packages
-may also receive a metadata-only `user.email_verification.failed` event when
-signup/verify mail first hits a terminal delivery failure (stable user id,
-username, email, status, `class` (`sender_block` / `other` / `null`), an admin
-user URL, and `occurred_at`). That event omits SMTP transcripts, tokens, and
+fields when present). Referral rows are account data (export and deletion) and
+are not included on those lifecycle events. Those lifecycle events omit
+passwords, roles, plan, secrets, and unrelated account content. Admin-configured
+notification packages may also receive a metadata-only
+`user.email_verification.failed` event when signup/verify mail first hits a
+terminal delivery failure (stable user id, username, email, status, `class`
+(`sender_block` / `other` / `null`), an admin user URL, and `occurred_at`). That
+event omits SMTP transcripts, tokens, and unrelated account content.
+Admin-configured notification packages may also receive a metadata-only
+`user.email_verification.stalled` event when signup/verify mail stays `accepted`
+for an hour with no Cloudflare lifecycle event (stable user id, username, email,
+`accepted_at`, stall threshold, an admin user URL, and `occurred_at`). That
+event omits SMTP transcripts, tokens, and unrelated account content.
+Admin-configured notification packages may also receive a metadata-only
+`user.email_outbound.paused` event when outbound sending is paused after a spam
+complaint or repeated bounces (stable user id, username, email, reason, bounce
+threshold when the reason is `bounced`, an admin user URL, and `occurred_at`).
+That event omits SMTP transcripts, message bodies, and unrelated account
+content. Admin-configured notification packages may also receive
+`email.system-message.sent` when operator correspondence leaves a reserved
+system sender (`kody@`, `support@`, and the other system locals). That event
+includes the recipients, subject, and sent text/HTML because outbound system
+mail is not stored on the inbound system-email graph; it is admin-only and omits
 unrelated account content. Admin-configured notification packages may also
-receive a metadata-only `user.email_verification.stalled` event when
-signup/verify mail stays `accepted` for an hour with no Cloudflare lifecycle
-event (stable user id, username, email, `accepted_at`, stall threshold, an admin
-user URL, and `occurred_at`). That event omits SMTP transcripts, tokens, and
-unrelated account content. Admin-configured notification packages may also
-receive a metadata-only `user.email_outbound.paused` event when outbound sending
-is paused after a spam complaint or repeated bounces (stable user id, username,
-email, reason, bounce threshold when the reason is `bounced`, an admin user URL,
-and `occurred_at`). That event omits SMTP transcripts, message bodies, and
-unrelated account content. Admin-configured notification packages may also
-receive `email.system-message.sent` when operator correspondence leaves a
-reserved system sender (`kody@`, `support@`, and the other system locals). That
-event includes the recipients, subject, and sent text/HTML because outbound
-system mail is not stored on the inbound system-email graph; it is admin-only
-and omits unrelated account content. Admin-configured notification packages may
-also receive metadata-only `auth.denial.burst` or `email.delivery.burst` events
-when hourly MCP auth denials or shared-domain bounce/complaint counts cross
-their thresholds (count, threshold, window, insights URL, and `observed_at`).
-Those events omit user identities, tokens, recipients, and message content.
+receive metadata-only `auth.denial.burst` or `email.delivery.burst` events when
+hourly MCP auth denials or shared-domain bounce/complaint counts cross their
+thresholds (count, threshold, window, insights URL, and `observed_at`). Those
+events omit user identities, tokens, recipients, and message content.
 Admin-configured notification packages may also receive a metadata-only
 `fleet.package_error_rate.elevated` event when package-runtime error rates rise
 (window bounds, per-metric counts and rates, public status URL, insights URL,

--- a/docs/use/privacy.md
+++ b/docs/use/privacy.md
@@ -22,27 +22,29 @@ information (email, username, optional display name and bio, and profile
 visibility), first-touch marketing attribution captured on public-site visits
 when UTM or landing context is present and associated with the account at signup
 (`utm_source` / `utm_medium` / `utm_campaign` / `utm_content` / `utm_term`,
-landing path, and referrer), referral attribution when a signup used
-`?ref=<username>` (the referred and referring stable user ids, reward status,
-and the Stripe invoice id after a paid reward), first-seen activation timestamps
-(email verified, first MCP connection, first execute, first saved package), MCP
-client name when known, last-active day stamps used for return metrics, secrets,
-memories, packages and their source, jobs, email inboxes and messages, durable
-storage, MCP server configuration, OAuth grants, package invocation tokens,
-short-lived execution history (see [Activity](./activity.md)), stored community
-activity events, and any platform feedback you approve for submission. All of
-this remains scoped to your account except for content you deliberately make
-public (community listings and a public profile), the narrow admin review of
-approved platform feedback, and the community activity metadata described below.
+landing path, and referrer), referral attribution when a signup used a
+`kody_ref` cookie from `?ref=<username>` (the referred and referring stable user
+ids, reward status, and the Stripe invoice id after a paid reward), first-seen
+activation timestamps (email verified, first MCP connection, first execute,
+first saved package), MCP client name when known, last-active day stamps used
+for return metrics, secrets, memories, packages and their source, jobs, email
+inboxes and messages, durable storage, MCP server configuration, OAuth grants,
+package invocation tokens, short-lived execution history (see
+[Activity](./activity.md)), stored community activity events, and any platform
+feedback you approve for submission. All of this remains scoped to your account
+except for content you deliberately make public (community listings and a public
+profile), the narrow admin review of approved platform feedback, and the
+community activity metadata described below.
 
 When profile visibility is **public**, display name, bio, public package
 metadata, and public activity are visible on `/@username`. When visibility is
 **private**, the public profile is not found. See
 [Public packages](./community-packages.md#public-profiles).
 
-The only cookies are the session cookie (`kody_session`) and the package-app
-session cookie on `kody.run` (`__Host-kody_pkg_session` on HTTPS,
-`kody_pkg_session` on HTTP). Short-lived cookies support two-factor
+The only cookies are the session cookie (`kody_session`), the one-week last-wins
+referral cookie (`kody_ref`) set by `/signup?ref=<username>` share links, and
+the package-app session cookie on `kody.run` (`__Host-kody_pkg_session` on
+HTTPS, `kody_pkg_session` on HTTP). Short-lived cookies support two-factor
 verification, passkey challenges, and OAuth login. Analytics (Fathom) is
 cookieless. The browser uses sessionStorage for first-touch signup attribution
 and scroll restoration, not tracking cookies.

--- a/packages/worker/client/app.tsx
+++ b/packages/worker/client/app.tsx
@@ -50,10 +50,7 @@ import {
 	captureFirstTouchAttributionFromLocation,
 	clearStoredFirstTouchAttribution,
 } from './first-touch-attribution.ts'
-import {
-	clearReferralCookie,
-	persistReferralCookieFromLocation,
-} from './referral-cookie.ts'
+import { persistReferralCookieFromLocation } from './referral-cookie.ts'
 
 registerRouteLoaders(clientRouteLoaders)
 registerClientRoutes(clientRoutes)
@@ -136,7 +133,6 @@ export function App(handle: Handle<AppProps>) {
 				new URL(window.location.href).searchParams.get('accountCreated') === '1'
 			) {
 				clearStoredFirstTouchAttribution()
-				clearReferralCookie()
 			}
 		} catch {
 			// ignore malformed locations

--- a/packages/worker/client/app.tsx
+++ b/packages/worker/client/app.tsx
@@ -50,6 +50,10 @@ import {
 	captureFirstTouchAttributionFromLocation,
 	clearStoredFirstTouchAttribution,
 } from './first-touch-attribution.ts'
+import {
+	clearReferralCookie,
+	persistReferralCookieFromLocation,
+} from './referral-cookie.ts'
 
 registerRouteLoaders(clientRouteLoaders)
 registerClientRoutes(clientRoutes)
@@ -122,7 +126,9 @@ export function App(handle: Handle<AppProps>) {
 	if (typeof document !== 'undefined') {
 		setSessionRefreshHandler(queueSessionRefresh)
 		// Capture UTMs from any landing URL before homepage CTAs rewrite them.
+		// Referral share links write a last-wins one-week cookie separately.
 		captureFirstTouchAttributionFromLocation()
+		persistReferralCookieFromLocation()
 		// New-account signal: drop tab-scoped first-touch so a later signup in
 		// this tab cannot inherit the previous visitor's campaign.
 		try {
@@ -130,6 +136,7 @@ export function App(handle: Handle<AppProps>) {
 				new URL(window.location.href).searchParams.get('accountCreated') === '1'
 			) {
 				clearStoredFirstTouchAttribution()
+				clearReferralCookie()
 			}
 		} catch {
 			// ignore malformed locations
@@ -145,6 +152,7 @@ export function App(handle: Handle<AppProps>) {
 		}
 		listenToRouterNavigation(handle, () => {
 			currentPathname = readRouterPathname(handle)
+			persistReferralCookieFromLocation()
 			queueThrottledSessionRefresh()
 			handle.update()
 		})

--- a/packages/worker/client/first-touch-attribution.node.test.ts
+++ b/packages/worker/client/first-touch-attribution.node.test.ts
@@ -1,0 +1,80 @@
+import { expect, test } from 'vitest'
+import {
+	captureFirstTouchAttributionFromLocation,
+	clearStoredFirstTouchAttribution,
+} from './first-touch-attribution.ts'
+
+const originalSessionStorage = Object.getOwnPropertyDescriptor(
+	globalThis,
+	'sessionStorage',
+)
+
+function restoreSessionStorage() {
+	if (originalSessionStorage) {
+		Object.defineProperty(globalThis, 'sessionStorage', originalSessionStorage)
+	} else {
+		Reflect.deleteProperty(globalThis, 'sessionStorage')
+	}
+}
+
+function installSessionStorage() {
+	const store = new Map<string, string>()
+	Object.defineProperty(globalThis, 'sessionStorage', {
+		configurable: true,
+		value: {
+			getItem(key: string) {
+				return store.get(key) ?? null
+			},
+			setItem(key: string, value: string) {
+				store.set(key, value)
+			},
+			removeItem(key: string) {
+				store.delete(key)
+			},
+		},
+	})
+	clearStoredFirstTouchAttribution()
+}
+
+test('later signup ref fills a missing first-touch referral code', () => {
+	try {
+		installSessionStorage()
+		const homepage = captureFirstTouchAttributionFromLocation(
+			'https://kody.codes/',
+			null,
+		)
+		expect(homepage).toEqual({
+			utmSource: null,
+			utmMedium: null,
+			utmCampaign: null,
+			utmContent: null,
+			utmTerm: null,
+			landingPath: '/',
+			referrer: null,
+			referralCode: null,
+		})
+
+		const afterShareLink = captureFirstTouchAttributionFromLocation(
+			'https://kody.codes/signup?ref=Ada',
+			null,
+		)
+		expect(afterShareLink).toEqual({
+			...homepage,
+			referralCode: 'ada',
+		})
+		expect(
+			captureFirstTouchAttributionFromLocation(
+				'https://kody.codes/signup?ref=other',
+				null,
+			),
+		).toEqual(afterShareLink)
+		expect(
+			captureFirstTouchAttributionFromLocation(
+				'https://kody.codes/signup?utm_source=youtube',
+				null,
+			),
+		).toEqual(afterShareLink)
+	} finally {
+		restoreSessionStorage()
+	}
+})

--- a/packages/worker/client/first-touch-attribution.node.test.ts
+++ b/packages/worker/client/first-touch-attribution.node.test.ts
@@ -36,7 +36,7 @@ function installSessionStorage() {
 	clearStoredFirstTouchAttribution()
 }
 
-test('later signup ref fills a missing first-touch referral code', () => {
+test('first-touch UTMs stay write-once and ignore later share links', () => {
 	try {
 		installSessionStorage()
 		const homepage = captureFirstTouchAttributionFromLocation(
@@ -51,29 +51,20 @@ test('later signup ref fills a missing first-touch referral code', () => {
 			utmTerm: null,
 			landingPath: '/',
 			referrer: null,
-			referralCode: null,
 		})
 
-		const afterShareLink = captureFirstTouchAttributionFromLocation(
-			'https://kody.codes/signup?ref=Ada',
-			null,
-		)
-		expect(afterShareLink).toEqual({
-			...homepage,
-			referralCode: 'ada',
-		})
 		expect(
 			captureFirstTouchAttributionFromLocation(
-				'https://kody.codes/signup?ref=other',
+				'https://kody.codes/signup?ref=Ada',
 				null,
 			),
-		).toEqual(afterShareLink)
+		).toEqual(homepage)
 		expect(
 			captureFirstTouchAttributionFromLocation(
 				'https://kody.codes/signup?utm_source=youtube',
 				null,
 			),
-		).toEqual(afterShareLink)
+		).toEqual(homepage)
 	} finally {
 		restoreSessionStorage()
 	}

--- a/packages/worker/client/first-touch-attribution.ts
+++ b/packages/worker/client/first-touch-attribution.ts
@@ -1,12 +1,14 @@
 /**
  * Client helper: capture first-touch UTMs from the current URL (and optional
  * document referrer) into sessionStorage so SPA navigations to /signup keep
- * them, then read them back for signup POST / OAuth start.
+ * them, then read them back for signup POST / OAuth start. A later
+ * `/signup?ref=` fills a missing referral code without overwriting UTMs.
  */
 
 import {
 	emptyFirstTouchAttribution,
 	hasFirstTouchAttribution,
+	mergeReferralCodeIntoFirstTouch,
 	parseFirstTouchAttribution,
 	type FirstTouchAttribution,
 } from '#universal/first-touch-attribution.ts'
@@ -37,9 +39,15 @@ export function captureFirstTouchAttributionFromLocation(
 	}
 
 	// Prefer existing stored first-touch over later UTMs on the same browser.
+	// Fill a missing referral code from a later `/signup?ref=` so a homepage
+	// visit in this tab does not drop the share link.
 	const existing = readStoredFirstTouchAttribution()
 	if (existing && hasFirstTouchAttribution(existing)) {
-		return existing
+		const merged = mergeReferralCodeIntoFirstTouch(existing, fromUrl)
+		if (merged.referralCode !== existing.referralCode) {
+			writeStoredFirstTouchAttribution(merged)
+		}
+		return merged
 	}
 
 	writeStoredFirstTouchAttribution(fromUrl)

--- a/packages/worker/client/first-touch-attribution.ts
+++ b/packages/worker/client/first-touch-attribution.ts
@@ -1,14 +1,13 @@
 /**
  * Client helper: capture first-touch UTMs from the current URL (and optional
  * document referrer) into sessionStorage so SPA navigations to /signup keep
- * them, then read them back for signup POST / OAuth start. A later
- * `/signup?ref=` fills a missing referral code without overwriting UTMs.
+ * them, then read them back for signup POST / OAuth start. Referral share
+ * links use the last-wins `kody_ref` cookie, not this write-once store.
  */
 
 import {
 	emptyFirstTouchAttribution,
 	hasFirstTouchAttribution,
-	mergeReferralCodeIntoFirstTouch,
 	parseFirstTouchAttribution,
 	type FirstTouchAttribution,
 } from '#universal/first-touch-attribution.ts'
@@ -39,15 +38,9 @@ export function captureFirstTouchAttributionFromLocation(
 	}
 
 	// Prefer existing stored first-touch over later UTMs on the same browser.
-	// Fill a missing referral code from a later `/signup?ref=` so a homepage
-	// visit in this tab does not drop the share link.
 	const existing = readStoredFirstTouchAttribution()
 	if (existing && hasFirstTouchAttribution(existing)) {
-		const merged = mergeReferralCodeIntoFirstTouch(existing, fromUrl)
-		if (merged.referralCode !== existing.referralCode) {
-			writeStoredFirstTouchAttribution(merged)
-		}
-		return merged
+		return existing
 	}
 
 	writeStoredFirstTouchAttribution(fromUrl)

--- a/packages/worker/client/referral-cookie.node.test.ts
+++ b/packages/worker/client/referral-cookie.node.test.ts
@@ -1,0 +1,68 @@
+import { expect, test } from 'vitest'
+import {
+	clearReferralCookie,
+	persistReferralCookieFromLocation,
+} from './referral-cookie.ts'
+import { referralCookieName } from '#universal/referral-cookie.ts'
+
+const originalDocument = Object.getOwnPropertyDescriptor(globalThis, 'document')
+
+function restoreDocument() {
+	if (originalDocument) {
+		Object.defineProperty(globalThis, 'document', originalDocument)
+	} else {
+		Reflect.deleteProperty(globalThis, 'document')
+	}
+}
+
+function installDocumentCookie() {
+	let cookie = ''
+	Object.defineProperty(globalThis, 'document', {
+		configurable: true,
+		value: {
+			get cookie() {
+				return cookie
+			},
+			set cookie(value: string) {
+				cookie = value
+			},
+		},
+	})
+}
+
+test('later share links overwrite the referral cookie for one week', () => {
+	try {
+		installDocumentCookie()
+		expect(
+			persistReferralCookieFromLocation(
+				'https://kody.codes/signup?ref=Ada',
+				false,
+			),
+		).toBe('ada')
+		expect(document.cookie).toBe(
+			`${referralCookieName}=ada; Path=/; Max-Age=604800; SameSite=Lax`,
+		)
+
+		expect(
+			persistReferralCookieFromLocation(
+				'https://kody.codes/signup?ref=KentCDodds',
+				true,
+			),
+		).toBe('kentcdodds')
+		expect(document.cookie).toBe(
+			`${referralCookieName}=kentcdodds; Path=/; Max-Age=604800; SameSite=Lax; Secure`,
+		)
+
+		expect(
+			persistReferralCookieFromLocation('https://kody.codes/signup', false),
+		).toBeNull()
+		expect(document.cookie).toContain('kentcdodds')
+
+		clearReferralCookie(false)
+		expect(document.cookie).toBe(
+			`${referralCookieName}=; Path=/; Max-Age=0; SameSite=Lax`,
+		)
+	} finally {
+		restoreDocument()
+	}
+})

--- a/packages/worker/client/referral-cookie.ts
+++ b/packages/worker/client/referral-cookie.ts
@@ -1,0 +1,34 @@
+/**
+ * Browser helper for the last-wins referral cookie. A later share link
+ * overwrites the previous referrer for the rest of the one-week window.
+ */
+
+import { serializeReferralCookie } from '#universal/referral-cookie.ts'
+import { parseReferralCode } from '#universal/referral-program.ts'
+
+export function persistReferralCookieFromLocation(
+	href: string = typeof window !== 'undefined' ? window.location.href : '',
+	secure: boolean = typeof window !== 'undefined'
+		? window.location.protocol === 'https:'
+		: false,
+): string | null {
+	let url: URL
+	try {
+		url = new URL(href, 'https://kody.codes')
+	} catch {
+		return null
+	}
+	const code = parseReferralCode({ searchParams: url.searchParams })
+	if (!code || typeof document === 'undefined') return code
+	document.cookie = serializeReferralCookie({ code, secure })
+	return code
+}
+
+export function clearReferralCookie(
+	secure: boolean = typeof window !== 'undefined'
+		? window.location.protocol === 'https:'
+		: false,
+) {
+	if (typeof document === 'undefined') return
+	document.cookie = serializeReferralCookie({ code: null, secure })
+}

--- a/packages/worker/client/routes/account-billing.tsx
+++ b/packages/worker/client/routes/account-billing.tsx
@@ -1,5 +1,6 @@
 import { type Handle, css, on } from 'remix/ui'
 import { adminGrantDiffersFromSubscription } from '#universal/account-plan-display.ts'
+import { CopyTextButton } from '#client/copy-text-button.tsx'
 import {
 	type AccountBillingLoaderData,
 	type AdminPlanName,
@@ -17,6 +18,9 @@ import {
 	type RouteLoaderResult,
 } from '#client/route-loader.ts'
 import {
+	accountFieldCss,
+	accountFieldLabelCss,
+	accountInputCss,
 	AccountManagementMessage,
 	AccountManagementPanel,
 	AccountManagementShell,
@@ -386,7 +390,7 @@ export function AccountBillingRoute(handle: Handle) {
 			<AccountManagementShell maxWidth={layoutMaxWidths.content}>
 				<AccountPageHeader
 					title="Billing"
-					description="View your plan, subscribe to Standard or Pro, and manage your Stripe subscription."
+					description="View your plan, subscribe to Standard or Pro, manage your Stripe subscription, and share your referral link."
 					currentHref={currentHref}
 				/>
 
@@ -475,6 +479,107 @@ export function AccountBillingRoute(handle: Handle) {
 								</p>
 							) : null}
 						</AccountManagementPanel>
+
+						{billing.referralProgram ? (
+							<AccountManagementPanel
+								title="Refer a friend"
+								description="Share your link. When someone new creates an account, verifies their email, and pays their first invoice, you both get one month of Standard. There is no cap."
+							>
+								<div
+									mix={css({
+										display: 'grid',
+										gap: spacing.sm,
+									})}
+								>
+									<div mix={css(accountFieldCss)}>
+										<label
+											for="referral-share-url"
+											mix={css(accountFieldLabelCss)}
+										>
+											Your referral link
+										</label>
+										<div
+											mix={css({
+												display: 'flex',
+												flexWrap: 'wrap',
+												gap: spacing.sm,
+												alignItems: 'center',
+											})}
+										>
+											<input
+												id="referral-share-url"
+												type="url"
+												readOnly
+												value={billing.referralProgram.shareUrl}
+												data-field-ring
+												mix={css({
+													...accountInputCss,
+													flex: '1 1 16rem',
+												})}
+											/>
+											<CopyTextButton
+												value={billing.referralProgram.shareUrl}
+												idleLabel="Copy link"
+												variant="ghost"
+												size="sm"
+												ariaLabel="Copy referral link"
+											/>
+										</div>
+									</div>
+									<MetadataGrid
+										items={[
+											{
+												label: 'Rewarded',
+												value: String(billing.referralProgram.rewardedCount),
+											},
+											{
+												label: 'Pending first payment',
+												value: String(billing.referralProgram.pendingCount),
+											},
+											{
+												label: 'Standard credit through',
+												value: billing.referralProgram.creditExpiresAt
+													? formatCancelDate(
+															billing.referralProgram.creditExpiresAt,
+														)
+													: 'None yet',
+											},
+										]}
+									/>
+									{billing.referralProgram.referrals.length > 0 ? (
+										<ul
+											mix={css({
+												margin: 0,
+												padding: 0,
+												listStyle: 'none',
+												display: 'grid',
+												gap: spacing.xs,
+											})}
+										>
+											{billing.referralProgram.referrals.map((item) => (
+												<li
+													key={`${item.createdAt}:${item.refereeUsername ?? 'unknown'}`}
+													mix={css(descriptionCss)}
+												>
+													{item.refereeUsername
+														? `@${item.refereeUsername}`
+														: 'A referred account'}{' '}
+													{item.status === 'rewarded'
+														? item.rewardedAt
+															? `earned you a month on ${formatCancelDate(item.rewardedAt)}`
+															: 'earned you a month'
+														: 'signed up and has not paid yet'}
+												</li>
+											))}
+										</ul>
+									) : (
+										<p mix={css(descriptionCss)}>
+											No one has used your link yet.
+										</p>
+									)}
+								</div>
+							</AccountManagementPanel>
+						) : null}
 
 						{billing.cancelAt ? (
 							<AccountManagementPanel

--- a/packages/worker/client/routes/legal-last-updated.ts
+++ b/packages/worker/client/routes/legal-last-updated.ts
@@ -1,2 +1,2 @@
 export const termsLastUpdated = '2026-09-07'
-export const privacyLastUpdated = '2026-09-02'
+export const privacyLastUpdated = '2026-09-07'

--- a/packages/worker/client/routes/login.tsx
+++ b/packages/worker/client/routes/login.tsx
@@ -20,6 +20,7 @@ import {
 	clearStoredFirstTouchAttribution,
 	readSignupFirstTouchAttribution,
 } from '#client/first-touch-attribution.ts'
+import { clearReferralCookie } from '#client/referral-cookie.ts'
 import { fathomEventNames, trackFathomEvent } from '#client/fathom-events.ts'
 import { serializeFirstTouchAttributionForTransport } from '#universal/first-touch-attribution.ts'
 import { withAccountCreatedQuery } from '#universal/fathom-events.ts'
@@ -285,6 +286,7 @@ export function LoginRoute(handle: Handle) {
 			if (mode === 'signup') {
 				const tracked = trackFathomEvent(fathomEventNames.accountCreated)
 				clearStoredFirstTouchAttribution()
+				clearReferralCookie()
 				if (typeof window !== 'undefined') {
 					const destination = resolvePasswordAuthRedirect({
 						mode,

--- a/packages/worker/client/routes/login.tsx
+++ b/packages/worker/client/routes/login.tsx
@@ -20,7 +20,6 @@ import {
 	clearStoredFirstTouchAttribution,
 	readSignupFirstTouchAttribution,
 } from '#client/first-touch-attribution.ts'
-import { clearReferralCookie } from '#client/referral-cookie.ts'
 import { fathomEventNames, trackFathomEvent } from '#client/fathom-events.ts'
 import { serializeFirstTouchAttributionForTransport } from '#universal/first-touch-attribution.ts'
 import { withAccountCreatedQuery } from '#universal/fathom-events.ts'
@@ -286,7 +285,6 @@ export function LoginRoute(handle: Handle) {
 			if (mode === 'signup') {
 				const tracked = trackFathomEvent(fathomEventNames.accountCreated)
 				clearStoredFirstTouchAttribution()
-				clearReferralCookie()
 				if (typeof window !== 'undefined') {
 					const destination = resolvePasswordAuthRedirect({
 						mode,

--- a/packages/worker/client/routes/privacy.tsx
+++ b/packages/worker/client/routes/privacy.tsx
@@ -374,8 +374,10 @@ export function PrivacyRoute(_handle: Handle) {
 					<li>Fathom — privacy-focused website traffic analytics</li>
 				</ul>
 				<p mix={css(descriptionCss)}>
-					The only cookies are the session cookie (<code>kody_session</code>)
-					and the package-app session cookie on <code>kody.run</code> (
+					The only cookies are the session cookie (<code>kody_session</code>),
+					the one-week last-wins referral cookie (<code>kody_ref</code>) set by{' '}
+					<code>/signup?ref=&lt;username&gt;</code> share links, and the
+					package-app session cookie on <code>kody.run</code> (
 					<code>__Host-kody_pkg_session</code> on HTTPS,{' '}
 					<code>kody_pkg_session</code> on HTTP). Short-lived cookies support
 					two-factor verification, passkey challenges, and OAuth login.

--- a/packages/worker/client/social-sign-in.node.test.ts
+++ b/packages/worker/client/social-sign-in.node.test.ts
@@ -22,9 +22,9 @@ test('buildProviderStartPath includes redirect, invite, and attribution query pa
 			utmTerm: null,
 			landingPath: '/signup',
 			referrer: null,
-			referralCode: null,
+			referralCode: 'ada',
 		}),
 	).toBe(
-		'/auth/github?utm_source=youtube&utm_medium=video&utm_campaign=bwk&landing_path=%2Fsignup',
+		'/auth/github?utm_source=youtube&utm_medium=video&utm_campaign=bwk&landing_path=%2Fsignup&ref=ada',
 	)
 })

--- a/packages/worker/client/social-sign-in.node.test.ts
+++ b/packages/worker/client/social-sign-in.node.test.ts
@@ -22,6 +22,7 @@ test('buildProviderStartPath includes redirect, invite, and attribution query pa
 			utmTerm: null,
 			landingPath: '/signup',
 			referrer: null,
+			referralCode: null,
 		}),
 	).toBe(
 		'/auth/github?utm_source=youtube&utm_medium=video&utm_campaign=bwk&landing_path=%2Fsignup',

--- a/packages/worker/client/social-sign-in.node.test.ts
+++ b/packages/worker/client/social-sign-in.node.test.ts
@@ -22,9 +22,8 @@ test('buildProviderStartPath includes redirect, invite, and attribution query pa
 			utmTerm: null,
 			landingPath: '/signup',
 			referrer: null,
-			referralCode: 'ada',
 		}),
 	).toBe(
-		'/auth/github?utm_source=youtube&utm_medium=video&utm_campaign=bwk&landing_path=%2Fsignup&ref=ada',
+		'/auth/github?utm_source=youtube&utm_medium=video&utm_campaign=bwk&landing_path=%2Fsignup',
 	)
 })

--- a/packages/worker/migrations/0048-referral-program.sql
+++ b/packages/worker/migrations/0048-referral-program.sql
@@ -1,0 +1,30 @@
+-- Uncapped referral program. Attribution is write-once at signup via
+-- ?ref=<username>. Reward is one Standard month (30 days) for both
+-- parties after the referee's first qualifying paid Stripe invoice.
+-- referral_standard_credit_expires_at stacks without a cap.
+
+ALTER TABLE users ADD COLUMN referral_standard_credit_expires_at TEXT;
+
+CREATE TABLE referrals (
+	id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+	referrer_stable_user_id TEXT NOT NULL,
+	referee_stable_user_id TEXT NOT NULL,
+	created_at TEXT NOT NULL,
+	status TEXT NOT NULL DEFAULT 'pending'
+		CHECK (status IN ('pending', 'rewarded', 'rejected')),
+	rewarded_at TEXT,
+	reward_invoice_id TEXT,
+	reject_reason TEXT,
+	held_invoice_id TEXT,
+	held_period_end_at TEXT
+);
+
+CREATE UNIQUE INDEX idx_referrals_referee
+	ON referrals(referee_stable_user_id);
+
+CREATE INDEX idx_referrals_referrer
+	ON referrals(referrer_stable_user_id);
+
+CREATE UNIQUE INDEX idx_referrals_reward_invoice
+	ON referrals(reward_invoice_id)
+	WHERE reward_invoice_id IS NOT NULL;

--- a/packages/worker/migrations/0048-referral-program.sql
+++ b/packages/worker/migrations/0048-referral-program.sql
@@ -16,7 +16,8 @@ CREATE TABLE referrals (
 	reward_invoice_id TEXT,
 	reject_reason TEXT,
 	held_invoice_id TEXT,
-	held_period_end_at TEXT
+	held_period_end_at TEXT,
+	credits_granted_at TEXT
 );
 
 CREATE UNIQUE INDEX idx_referrals_referee

--- a/packages/worker/src/account/data-targets.ts
+++ b/packages/worker/src/account/data-targets.ts
@@ -193,6 +193,11 @@ export const accountUserDataTargets: ReadonlyArray<UserScopedDataTarget> = [
 	{ kind: 'user_id', table: 'user_storage_buckets' },
 	{ kind: 'user_id', table: 'usage_rollups' },
 	{ kind: 'user_id', table: 'compute_overage_invoices' },
+	{
+		kind: 'user_columns',
+		table: 'referrals',
+		columns: ['referrer_stable_user_id', 'referee_stable_user_id'],
+	},
 	{ kind: 'user_id', table: 'feature_flag_exposure_rollups' },
 	{ kind: 'user_id', table: 'agent_package_conversation_uses' },
 	// Per-package codemod outcomes belong to the package owner. Delete before
@@ -782,6 +787,7 @@ export const accountExportForeignUserIdColumnsByTable: Readonly<
 		'grantee_user_id',
 		'created_by_user_id',
 	],
+	referrals: ['referrer_stable_user_id', 'referee_stable_user_id'],
 }
 
 export const accountExportRedactedForeignUserId = '[redacted]'

--- a/packages/worker/src/admin/users-data.ts
+++ b/packages/worker/src/admin/users-data.ts
@@ -16,6 +16,7 @@ import {
 	type EntitlementLadder,
 	type PlanName,
 } from '#universal/plans.ts'
+import { laterIsoTimestamp } from '#universal/referral-program.ts'
 import { resolveEffectivePlanWithSecondAgentGift } from '#universal/second-agent-standard-gift.ts'
 import {
 	chunkArray,
@@ -42,7 +43,7 @@ export const adminUserRowSelectSql = `id, stable_user_id, username, email, email
 				email_outbound_paused_at, email_verification_delivery_status, email_verification_delivery_at, email_verification_delivery_detail, email_verification_delivery_class,
 				utm_source, utm_medium, utm_campaign, utm_content, utm_term, first_touch_landing_path, first_touch_referrer,
 				first_mcp_connected_at, first_execute_at, first_search_at, first_saved_package_at, mcp_client_name, last_active_at,
-				second_agent_standard_gift_expires_at, created_at, updated_at`
+				second_agent_standard_gift_expires_at, referral_standard_credit_expires_at, created_at, updated_at`
 
 export const adminUserListItemFieldNames = [
 	'stableUserId',
@@ -473,6 +474,7 @@ type AdminUserRow = {
 	mcp_client_name: string | null
 	last_active_at: string | null
 	second_agent_standard_gift_expires_at: string | null
+	referral_standard_credit_expires_at: string | null
 	created_at: string
 	updated_at: string
 }
@@ -495,7 +497,10 @@ function toAdminUserListItem(
 		effectivePlan: resolveEffectivePlanWithSecondAgentGift(
 			manualPlan,
 			row.stripe_plan,
-			row.second_agent_standard_gift_expires_at,
+			laterIsoTimestamp(
+				row.second_agent_standard_gift_expires_at,
+				row.referral_standard_credit_expires_at,
+			),
 		),
 		entitlementLadder: parseEntitlementLadder(row.entitlement_ladder),
 		stripeCustomerLinked: Boolean(row.stripe_customer_id),

--- a/packages/worker/src/app/account-billing-data.node.test.ts
+++ b/packages/worker/src/app/account-billing-data.node.test.ts
@@ -46,13 +46,19 @@ function createBillingTestDb(input: {
 								void params
 								return {
 									plan: input.plan,
+									username: 'billing-user',
 									stable_user_id: 'stable-user-id',
 									stripe_plan: input.stripePlan ?? null,
 									stripe_customer_id: input.stripeCustomerId ?? null,
 									stripe_plan_refreshed_at: null,
+									second_agent_standard_gift_expires_at: null,
+									referral_standard_credit_expires_at: null,
 								} as T
 							}
 							return null
+						},
+						async all<T>() {
+							return { results: [] as Array<T> }
 						},
 						async run() {
 							return { success: true }
@@ -112,6 +118,16 @@ test('loadAccountBillingData refreshes Stripe status and degrades when refresh i
 	expect(data.cancelAt).toBe('2026-08-01T00:00:00.000Z')
 	expect(data.usageHref).toBe('/account/usage')
 	expect(data.purchasablePlans).toEqual(['standard', 'pro'])
+	expect(data.referralProgram).toEqual(
+		expect.objectContaining({
+			sharePath: '/signup?ref=billing-user',
+			rewardedCount: 0,
+			pendingCount: 0,
+			creditExpiresAt: null,
+			creditActive: false,
+			referrals: [],
+		}),
+	)
 	expect(refreshStripePlanForUser).toHaveBeenCalledWith(
 		expect.objectContaining({
 			userId: 9,

--- a/packages/worker/src/app/account-billing-data.ts
+++ b/packages/worker/src/app/account-billing-data.ts
@@ -1,4 +1,5 @@
 import { type AccountBillingLoaderData } from '#universal/loader-data.ts'
+import { getCanonicalAppBaseUrl } from '#worker/app-base-url.ts'
 import {
 	getPurchasablePlans,
 	isBillingConfigured,
@@ -11,7 +12,9 @@ import {
 	parseStripePlanName,
 	type PlanName,
 } from '#universal/plans.ts'
+import { laterIsoTimestamp } from '#universal/referral-program.ts'
 import { resolveEffectivePlanWithSecondAgentGift } from '#universal/second-agent-standard-gift.ts'
+import { loadReferralProgramSummary } from '#worker/entitlements/referral-program.ts'
 
 const billingErrorMessages: Record<string, string> = {
 	billing_not_configured: 'Billing is not configured on this deployment.',
@@ -57,11 +60,13 @@ export function resolveBillingNoticeMessage(
 
 type BillingUserRow = {
 	plan: string
+	username: string | null
 	stripe_plan: string | null
 	stripe_customer_id: string | null
 	stripe_plan_refreshed_at: string | null
 	stable_user_id: string
 	second_agent_standard_gift_expires_at: string | null
+	referral_standard_credit_expires_at: string | null
 }
 
 export async function loadAccountBillingData(input: {
@@ -77,8 +82,9 @@ export async function loadAccountBillingData(input: {
 	const notice = resolveBillingNoticeMessage(input.noticeCode)
 
 	const row = await input.env.APP_DB.prepare(
-		`SELECT plan, stripe_plan, stripe_customer_id, stripe_plan_refreshed_at,
-		        stable_user_id, second_agent_standard_gift_expires_at
+		`SELECT plan, username, stripe_plan, stripe_customer_id, stripe_plan_refreshed_at,
+		        stable_user_id, second_agent_standard_gift_expires_at,
+		        referral_standard_credit_expires_at
 		 FROM users
 		 WHERE id = ?`,
 	)
@@ -129,6 +135,21 @@ export async function loadAccountBillingData(input: {
 	}
 
 	const purchasablePlans = configured ? getPurchasablePlans(input.env) : []
+	const overlayExpiresAt = laterIsoTimestamp(
+		row?.second_agent_standard_gift_expires_at,
+		row?.referral_standard_credit_expires_at,
+	)
+	const origin = getCanonicalAppBaseUrl({ env: input.env })
+	const referralProgram =
+		row?.stable_user_id && row.username
+			? await loadReferralProgramSummary({
+					db: input.env.APP_DB,
+					stableUserId: row.stable_user_id,
+					username: row.username,
+					origin,
+					now,
+				})
+			: null
 
 	return {
 		ok: true,
@@ -139,7 +160,7 @@ export async function loadAccountBillingData(input: {
 		effectivePlan: resolveEffectivePlanWithSecondAgentGift(
 			manualPlan,
 			stripePlan,
-			row?.second_agent_standard_gift_expires_at,
+			overlayExpiresAt,
 			now,
 		),
 		hasStripeCustomer,
@@ -147,6 +168,7 @@ export async function loadAccountBillingData(input: {
 		subscriptionStatus,
 		purchasablePlans,
 		usageHref: '/account/usage',
+		referralProgram,
 		...(error ? { error } : {}),
 		...(notice ? { notice } : {}),
 	}

--- a/packages/worker/src/app/account-billing-data.ts
+++ b/packages/worker/src/app/account-billing-data.ts
@@ -148,6 +148,15 @@ export async function loadAccountBillingData(input: {
 					username: row.username,
 					origin,
 					now,
+				}).catch((referralError) => {
+					console.error('account_billing_referral_failed', {
+						userId: input.userId,
+						error:
+							referralError instanceof Error
+								? referralError.message
+								: String(referralError),
+					})
+					return null
 				})
 			: null
 

--- a/packages/worker/src/app/account-usage-data.ts
+++ b/packages/worker/src/app/account-usage-data.ts
@@ -3,6 +3,7 @@ import {
 	parseStoredPlanName,
 	parseStripePlanName,
 } from '#universal/plans.ts'
+import { laterIsoTimestamp } from '#universal/referral-program.ts'
 import { resolveEffectivePlanWithSecondAgentGift } from '#universal/second-agent-standard-gift.ts'
 import {
 	computeOverageUsageWarningRows,
@@ -23,6 +24,7 @@ type UsageUserRow = {
 	stable_user_id: string
 	stripe_customer_id: string | null
 	second_agent_standard_gift_expires_at: string | null
+	referral_standard_credit_expires_at: string | null
 }
 
 /**
@@ -37,7 +39,8 @@ export async function loadAccountUsageData(input: {
 	const now = input.now ?? new Date()
 	const row = await input.env.APP_DB.prepare(
 		`SELECT id, plan, stripe_plan, entitlement_ladder, stable_user_id,
-			stripe_customer_id, second_agent_standard_gift_expires_at
+			stripe_customer_id, second_agent_standard_gift_expires_at,
+			referral_standard_credit_expires_at
 		 FROM users WHERE id = ?`,
 	)
 		.bind(input.userId)
@@ -48,7 +51,10 @@ export async function loadAccountUsageData(input: {
 	const plan = resolveEffectivePlanWithSecondAgentGift(
 		manualPlan,
 		row.stripe_plan,
-		row.second_agent_standard_gift_expires_at,
+		laterIsoTimestamp(
+			row.second_agent_standard_gift_expires_at,
+			row.referral_standard_credit_expires_at,
+		),
 		now,
 	)
 	const ladder = parseEntitlementLadder(row.entitlement_ladder)

--- a/packages/worker/src/app/handlers/auth-handler.node.test.ts
+++ b/packages/worker/src/app/handlers/auth-handler.node.test.ts
@@ -574,7 +574,6 @@ test('auth handler login and signup workflow', async () => {
 			utmTerm: null,
 			landingPath: null,
 			referrer: null,
-			referralCode: null,
 		},
 	})
 
@@ -794,7 +793,6 @@ test('successful open signup schedules an admin user.created event', async () =>
 			utmTerm: null,
 			landingPath: null,
 			referrer: null,
-			referralCode: null,
 		},
 	})
 })

--- a/packages/worker/src/app/handlers/auth-handler.node.test.ts
+++ b/packages/worker/src/app/handlers/auth-handler.node.test.ts
@@ -609,6 +609,14 @@ test('auth handler login and signup workflow', async () => {
 	expect(signupContext.testDb.users.get('allowed@example.com')?.username).toBe(
 		'allowed-jane',
 	)
+	expect(
+		allowedSignupResponse.headers
+			.getSetCookie()
+			.some(
+				(cookie) =>
+					cookie.startsWith('kody_ref=') && cookie.includes('Max-Age=0'),
+			),
+	).toBe(true)
 	// The signup context has no email sender configured, so the skipped
 	// verification send logs at info level in the non-production runtime.
 	expect(consoleInfo).toHaveBeenCalledWith(

--- a/packages/worker/src/app/handlers/auth-handler.node.test.ts
+++ b/packages/worker/src/app/handlers/auth-handler.node.test.ts
@@ -574,6 +574,7 @@ test('auth handler login and signup workflow', async () => {
 			utmTerm: null,
 			landingPath: null,
 			referrer: null,
+			referralCode: null,
 		},
 	})
 
@@ -793,6 +794,7 @@ test('successful open signup schedules an admin user.created event', async () =>
 			utmTerm: null,
 			landingPath: null,
 			referrer: null,
+			referralCode: null,
 		},
 	})
 })

--- a/packages/worker/src/app/handlers/auth-provider.node.test.ts
+++ b/packages/worker/src/app/handlers/auth-provider.node.test.ts
@@ -169,6 +169,12 @@ test('github sign-in creates a verified account, then signs it back in', async (
 				cookie.startsWith('kody_oauth_login=') && cookie.includes('Max-Age=0'),
 		),
 	).toBe(true)
+	expect(
+		setCookies.some(
+			(cookie) =>
+				cookie.startsWith('kody_ref=') && cookie.includes('Max-Age=0'),
+		),
+	).toBe(true)
 
 	const user = sqlite
 		.prepare(`SELECT * FROM users WHERE email = ?`)

--- a/packages/worker/src/app/handlers/auth-provider.ts
+++ b/packages/worker/src/app/handlers/auth-provider.ts
@@ -77,7 +77,10 @@ import {
 	parseFirstTouchAttribution,
 } from '#universal/first-touch-attribution.ts'
 import { withAccountCreatedQuery } from '#universal/fathom-events.ts'
-import { resolveReferralCodeForSignup } from '#universal/referral-cookie.ts'
+import {
+	resolveReferralCodeForSignup,
+	serializeReferralCookie,
+} from '#universal/referral-cookie.ts'
 import { scheduleUserCreatedEvent } from '#worker/identity/schedule-user-lifecycle-event.ts'
 import { attributeReferralAtSignup } from '#worker/entitlements/referral-program.ts'
 import { touchLastActiveAt } from '#worker/identity/activation-stamps.ts'
@@ -463,6 +466,8 @@ export function createAuthProviderCallbackHandler(env: Env) {
 					 * so the new session must postdate that timestamp.
 					 */
 					issuedAt?: number
+					/** Drop the last-wins share cookie after a new account is created. */
+					clearReferralCookie?: boolean
 				} = {},
 			) {
 				const stableUserId = resolveUserStableId(user)
@@ -490,11 +495,15 @@ export function createAuthProviderCallbackHandler(env: Env) {
 					const verifyPath = redirectTo
 						? `/verify?redirectTo=${encodeURIComponent(redirectTo)}`
 						: '/verify'
-					return redirect(verifyPath, [
+					const cookies = [
 						verifyCookie,
 						await destroyAuthCookie(secure),
 						clearStateCookie,
-					])
+					]
+					if (options.clearReferralCookie) {
+						cookies.push(serializeReferralCookie({ code: null, secure }))
+					}
+					return redirect(verifyPath, cookies)
 				}
 
 				const sessionCookie = await createAuthCookie(
@@ -513,7 +522,11 @@ export function createAuthProviderCallbackHandler(env: Env) {
 					path: url.pathname,
 					reason: `provider=${provider}`,
 				})
-				return redirect(postLoginPath, [sessionCookie, clearStateCookie])
+				const cookies = [sessionCookie, clearStateCookie]
+				if (options.clearReferralCookie) {
+					cookies.push(serializeReferralCookie({ code: null, secure }))
+				}
+				return redirect(postLoginPath, cookies)
 			}
 
 			const connection = await db.findOne(oauthConnectionsTable, {
@@ -939,6 +952,7 @@ export function createAuthProviderCallbackHandler(env: Env) {
 				destination: withAccountCreatedQuery(
 					redirectTo ?? defaultPostVerificationRedirect,
 				),
+				clearReferralCookie: true,
 			})
 		},
 	} satisfies Action<typeof routes.authProviderCallback>

--- a/packages/worker/src/app/handlers/auth-provider.ts
+++ b/packages/worker/src/app/handlers/auth-provider.ts
@@ -77,6 +77,7 @@ import {
 	parseFirstTouchAttribution,
 } from '#universal/first-touch-attribution.ts'
 import { withAccountCreatedQuery } from '#universal/fathom-events.ts'
+import { resolveReferralCodeForSignup } from '#universal/referral-cookie.ts'
 import { scheduleUserCreatedEvent } from '#worker/identity/schedule-user-lifecycle-event.ts'
 import { attributeReferralAtSignup } from '#worker/entitlements/referral-program.ts'
 import { touchLastActiveAt } from '#worker/identity/activation-stamps.ts'
@@ -903,7 +904,10 @@ export function createAuthProviderCallbackHandler(env: Env) {
 					db: env.APP_DB,
 					refereeStableUserId: stableUserId,
 					refereeUsername: username,
-					referralCode: loginState.attribution?.referralCode,
+					referralCode: resolveReferralCodeForSignup({
+						searchParams: url.searchParams,
+						cookieHeader: request.headers.get('Cookie'),
+					}),
 				})
 			} catch (error) {
 				console.warn('referral-attribution-failed', error)

--- a/packages/worker/src/app/handlers/auth-provider.ts
+++ b/packages/worker/src/app/handlers/auth-provider.ts
@@ -78,6 +78,7 @@ import {
 } from '#universal/first-touch-attribution.ts'
 import { withAccountCreatedQuery } from '#universal/fathom-events.ts'
 import { scheduleUserCreatedEvent } from '#worker/identity/schedule-user-lifecycle-event.ts'
+import { attributeReferralAtSignup } from '#worker/entitlements/referral-program.ts'
 import { touchLastActiveAt } from '#worker/identity/activation-stamps.ts'
 import { parseLegacyHosts } from '#worker/app-legacy-redirect.ts'
 import {
@@ -896,6 +897,14 @@ export function createAuthProviderCallbackHandler(env: Env) {
 				source: 'oauth',
 				inviteCode: consumedInviteCode,
 				attribution: loginState.attribution,
+			})
+			void attributeReferralAtSignup({
+				db: env.APP_DB,
+				refereeStableUserId: stableUserId,
+				refereeUsername: username,
+				referralCode: loginState.attribution?.referralCode,
+			}).catch((error) => {
+				console.warn('referral-attribution-failed', error)
 			})
 
 			void logAuditEvent({

--- a/packages/worker/src/app/handlers/auth-provider.ts
+++ b/packages/worker/src/app/handlers/auth-provider.ts
@@ -898,14 +898,16 @@ export function createAuthProviderCallbackHandler(env: Env) {
 				inviteCode: consumedInviteCode,
 				attribution: loginState.attribution,
 			})
-			void attributeReferralAtSignup({
-				db: env.APP_DB,
-				refereeStableUserId: stableUserId,
-				refereeUsername: username,
-				referralCode: loginState.attribution?.referralCode,
-			}).catch((error) => {
+			try {
+				await attributeReferralAtSignup({
+					db: env.APP_DB,
+					refereeStableUserId: stableUserId,
+					refereeUsername: username,
+					referralCode: loginState.attribution?.referralCode,
+				})
+			} catch (error) {
 				console.warn('referral-attribution-failed', error)
-			})
+			}
 
 			void logAuditEvent({
 				db: auditDatabaseFromEnv(env),

--- a/packages/worker/src/app/handlers/auth.ts
+++ b/packages/worker/src/app/handlers/auth.ts
@@ -64,6 +64,7 @@ import {
 } from '#universal/first-touch-attribution.ts'
 import { touchLastActiveAt } from '#worker/identity/activation-stamps.ts'
 import { scheduleUserCreatedEvent } from '#worker/identity/schedule-user-lifecycle-event.ts'
+import { attributeReferralAtSignup } from '#worker/entitlements/referral-program.ts'
 
 const authModes = ['login', 'signup'] as const
 type AuthMode = (typeof authModes)[number]
@@ -608,6 +609,14 @@ export function createAuthHandler(env: Env) {
 					source: 'signup',
 					inviteCode: consumedInviteCode,
 					attribution: signupAttribution,
+				})
+				void attributeReferralAtSignup({
+					db: env.APP_DB,
+					refereeStableUserId: record.stableUserId,
+					refereeUsername: normalizedUsername,
+					referralCode: signupAttribution?.referralCode,
+				}).catch((error) => {
+					console.warn('referral-attribution-failed', error)
 				})
 
 				const cookie = await createAuthCookie(

--- a/packages/worker/src/app/handlers/auth.ts
+++ b/packages/worker/src/app/handlers/auth.ts
@@ -62,7 +62,10 @@ import {
 	firstTouchAttributionCreateFields,
 	parseFirstTouchAttribution,
 } from '#universal/first-touch-attribution.ts'
-import { resolveReferralCodeForSignup } from '#universal/referral-cookie.ts'
+import {
+	resolveReferralCodeForSignup,
+	serializeReferralCookie,
+} from '#universal/referral-cookie.ts'
 import { touchLastActiveAt } from '#worker/identity/activation-stamps.ts'
 import { scheduleUserCreatedEvent } from '#worker/identity/schedule-user-lifecycle-event.ts'
 import { attributeReferralAtSignup } from '#worker/entitlements/referral-program.ts'
@@ -626,13 +629,14 @@ export function createAuthHandler(env: Env) {
 					console.warn('referral-attribution-failed', error)
 				}
 
+				const secure = isSecureRequest(request)
 				const cookie = await createAuthCookie(
 					{
 						stableUserId: record.stableUserId,
 						email: normalizedEmail,
 						rememberMe: false,
 					},
-					isSecureRequest(request),
+					secure,
 				)
 				void logAuditEvent({
 					db: auditDatabaseFromEnv(env),
@@ -655,11 +659,13 @@ export function createAuthHandler(env: Env) {
 						reason: `invite_code=${consumedInviteCode};stable_user_id=${record.stableUserId};plan=${resolvePlanWrite(consumedInvitePlan)}`,
 					})
 				}
-				return Response.json(signupAcceptedBody(normalizedMode), {
-					headers: {
-						'Set-Cookie': cookie,
-					},
-				})
+				const headers = new Headers()
+				headers.append('Set-Cookie', cookie)
+				headers.append(
+					'Set-Cookie',
+					serializeReferralCookie({ code: null, secure }),
+				)
+				return Response.json(signupAcceptedBody(normalizedMode), { headers })
 			}
 
 			const userRecord = await db.findOne(usersTable, {

--- a/packages/worker/src/app/handlers/auth.ts
+++ b/packages/worker/src/app/handlers/auth.ts
@@ -610,14 +610,16 @@ export function createAuthHandler(env: Env) {
 					inviteCode: consumedInviteCode,
 					attribution: signupAttribution,
 				})
-				void attributeReferralAtSignup({
-					db: env.APP_DB,
-					refereeStableUserId: record.stableUserId,
-					refereeUsername: normalizedUsername,
-					referralCode: signupAttribution?.referralCode,
-				}).catch((error) => {
+				try {
+					await attributeReferralAtSignup({
+						db: env.APP_DB,
+						refereeStableUserId: record.stableUserId,
+						refereeUsername: normalizedUsername,
+						referralCode: signupAttribution?.referralCode,
+					})
+				} catch (error) {
 					console.warn('referral-attribution-failed', error)
-				})
+				}
 
 				const cookie = await createAuthCookie(
 					{

--- a/packages/worker/src/app/handlers/auth.ts
+++ b/packages/worker/src/app/handlers/auth.ts
@@ -62,6 +62,7 @@ import {
 	firstTouchAttributionCreateFields,
 	parseFirstTouchAttribution,
 } from '#universal/first-touch-attribution.ts'
+import { resolveReferralCodeForSignup } from '#universal/referral-cookie.ts'
 import { touchLastActiveAt } from '#worker/identity/activation-stamps.ts'
 import { scheduleUserCreatedEvent } from '#worker/identity/schedule-user-lifecycle-event.ts'
 import { attributeReferralAtSignup } from '#worker/entitlements/referral-program.ts'
@@ -615,7 +616,11 @@ export function createAuthHandler(env: Env) {
 						db: env.APP_DB,
 						refereeStableUserId: record.stableUserId,
 						refereeUsername: normalizedUsername,
-						referralCode: signupAttribution?.referralCode,
+						referralCode: resolveReferralCodeForSignup({
+							body:
+								typeof body === 'object' && body !== null ? body : undefined,
+							cookieHeader: request.headers.get('Cookie'),
+						}),
 					})
 				} catch (error) {
 					console.warn('referral-attribution-failed', error)

--- a/packages/worker/src/app/handlers/verify-email.node.test.ts
+++ b/packages/worker/src/app/handlers/verify-email.node.test.ts
@@ -120,8 +120,10 @@ test('verify-email sends the connect-agent mail only on newly verified accounts'
 		email: 'verified@example.com',
 		stableUserId: 'user_verified',
 	})
-	expect(maybeRewardHeldReferralAfterEmailVerified).toHaveBeenCalledWith({
-		db: expect.anything(),
-		stableUserId: 'user_verified',
-	})
+	expect(maybeRewardHeldReferralAfterEmailVerified).toHaveBeenCalledWith(
+		expect.objectContaining({
+			db: expect.anything(),
+			stableUserId: 'user_verified',
+		}),
+	)
 })

--- a/packages/worker/src/app/handlers/verify-email.node.test.ts
+++ b/packages/worker/src/app/handlers/verify-email.node.test.ts
@@ -4,6 +4,7 @@ import { verifyEmailToken } from '#app/email-verification.ts'
 import { renderAppPage } from '#app/ssr-render.tsx'
 import { sendConnectAgentEmail } from '#app/user-account-emails.ts'
 import { scheduleKitSubscriberSync } from '#worker/kit/subscriber-sync.ts'
+import { maybeRewardHeldReferralAfterEmailVerified } from '#worker/entitlements/referral-program.ts'
 
 vi.mock('#app/email-verification.ts', () => ({
 	verifyEmailToken: vi.fn(),
@@ -21,6 +22,13 @@ vi.mock('#app/user-account-emails.ts', () => ({
 
 vi.mock('#worker/kit/subscriber-sync.ts', () => ({
 	scheduleKitSubscriberSync: vi.fn(),
+}))
+
+vi.mock('#worker/entitlements/referral-program.ts', () => ({
+	maybeRewardHeldReferralAfterEmailVerified: vi.fn(async () => ({
+		outcome: 'ignored',
+		reason: 'no_held',
+	})),
 }))
 
 test('verify-email handler wires success CTA from redirectTo and rejects open redirects', async () => {
@@ -83,6 +91,7 @@ test('verify-email handler wires success CTA from redirectTo and rejects open re
 	expect(renderAppPage).toHaveBeenCalled()
 	expect(sendConnectAgentEmail).not.toHaveBeenCalled()
 	expect(scheduleKitSubscriberSync).not.toHaveBeenCalled()
+	expect(maybeRewardHeldReferralAfterEmailVerified).not.toHaveBeenCalled()
 })
 
 test('verify-email sends the connect-agent mail only on newly verified accounts', async () => {
@@ -109,6 +118,10 @@ test('verify-email sends the connect-agent mail only on newly verified accounts'
 	expect(scheduleKitSubscriberSync).toHaveBeenCalledWith({
 		env: expect.anything(),
 		email: 'verified@example.com',
+		stableUserId: 'user_verified',
+	})
+	expect(maybeRewardHeldReferralAfterEmailVerified).toHaveBeenCalledWith({
+		db: expect.anything(),
 		stableUserId: 'user_verified',
 	})
 })

--- a/packages/worker/src/app/handlers/verify-email.ts
+++ b/packages/worker/src/app/handlers/verify-email.ts
@@ -10,7 +10,9 @@ import { sendConnectAgentEmail } from '#app/user-account-emails.ts'
 import { resolveVerifyEmailSuccessCta } from '#universal/safe-redirect.ts'
 import { renderAppPage } from '#app/ssr-render.tsx'
 import { type routes } from '#universal/routes.ts'
+import { waitUntil } from 'cloudflare:workers'
 import { maybeRewardHeldReferralAfterEmailVerified } from '#worker/entitlements/referral-program.ts'
+import { latestReferrerPaidPeriodEnd } from '#worker/billing/stripe-webhooks.ts'
 
 function getVerifyEmailError(
 	reason: 'missing_token' | 'invalid_token' | 'expired_token',
@@ -85,12 +87,19 @@ export function createVerifyEmailHandler(env: Env) {
 					email: result.email,
 					stableUserId: result.stableUserId,
 				})
-				void maybeRewardHeldReferralAfterEmailVerified({
-					db: env.APP_DB,
-					stableUserId: result.stableUserId,
-				}).catch((error) => {
-					console.warn('referral-held-reward-failed', error)
-				})
+				waitUntil(
+					maybeRewardHeldReferralAfterEmailVerified({
+						db: env.APP_DB,
+						stableUserId: result.stableUserId,
+						resolveReferrerPaidPeriodEnd: (referrerStableUserId) =>
+							latestReferrerPaidPeriodEnd({
+								env,
+								referrerStableUserId,
+							}),
+					}).catch((error) => {
+						console.warn('referral-held-reward-failed', error)
+					}),
+				)
 			}
 			const cta = resolveVerifyEmailSuccessCta(
 				url.searchParams.get('redirectTo'),

--- a/packages/worker/src/app/handlers/verify-email.ts
+++ b/packages/worker/src/app/handlers/verify-email.ts
@@ -10,6 +10,7 @@ import { sendConnectAgentEmail } from '#app/user-account-emails.ts'
 import { resolveVerifyEmailSuccessCta } from '#universal/safe-redirect.ts'
 import { renderAppPage } from '#app/ssr-render.tsx'
 import { type routes } from '#universal/routes.ts'
+import { maybeRewardHeldReferralAfterEmailVerified } from '#worker/entitlements/referral-program.ts'
 
 function getVerifyEmailError(
 	reason: 'missing_token' | 'invalid_token' | 'expired_token',
@@ -83,6 +84,12 @@ export function createVerifyEmailHandler(env: Env) {
 					env,
 					email: result.email,
 					stableUserId: result.stableUserId,
+				})
+				void maybeRewardHeldReferralAfterEmailVerified({
+					db: env.APP_DB,
+					stableUserId: result.stableUserId,
+				}).catch((error) => {
+					console.warn('referral-held-reward-failed', error)
 				})
 			}
 			const cta = resolveVerifyEmailSuccessCta(

--- a/packages/worker/src/app/oauth-login-state.node.test.ts
+++ b/packages/worker/src/app/oauth-login-state.node.test.ts
@@ -16,7 +16,6 @@ test('oauth login state cookie preserves first-touch UTMs through round-trip', a
 		utmTerm: null,
 		landingPath: '/signup',
 		referrer: 'https://youtube.com/',
-		referralCode: null,
 	}
 	const cookie = await createOauthLoginStateCookie(
 		{
@@ -47,7 +46,6 @@ test('oauth login state cookie preserves first-touch UTMs through round-trip', a
 			utmTerm: null,
 			landingPath: '/signup',
 			referrer: 'https://youtube.com/',
-			referralCode: null,
 		},
 	})
 })

--- a/packages/worker/src/app/oauth-login-state.node.test.ts
+++ b/packages/worker/src/app/oauth-login-state.node.test.ts
@@ -16,6 +16,7 @@ test('oauth login state cookie preserves first-touch UTMs through round-trip', a
 		utmTerm: null,
 		landingPath: '/signup',
 		referrer: 'https://youtube.com/',
+		referralCode: null,
 	}
 	const cookie = await createOauthLoginStateCookie(
 		{
@@ -46,6 +47,7 @@ test('oauth login state cookie preserves first-touch UTMs through round-trip', a
 			utmTerm: null,
 			landingPath: '/signup',
 			referrer: 'https://youtube.com/',
+			referralCode: null,
 		},
 	})
 })

--- a/packages/worker/src/app/referral-cookie-middleware.node.test.ts
+++ b/packages/worker/src/app/referral-cookie-middleware.node.test.ts
@@ -1,0 +1,38 @@
+import { expect, test } from 'vitest'
+import { createRouter } from 'remix/router'
+import { createReferralCookieMiddleware } from './referral-cookie-middleware.ts'
+import { referralCookieName } from '#universal/referral-cookie.ts'
+
+test('referral middleware overwrites kody_ref and no-stores the response', async () => {
+	const router = createRouter({
+		middleware: [createReferralCookieMiddleware()],
+	})
+	router.get('/signup', {
+		middleware: [],
+		async handler() {
+			return new Response('signup', {
+				headers: { 'Cache-Control': 'public, max-age=60' },
+			})
+		},
+	})
+
+	const first = await router.fetch(
+		new Request('http://localhost/signup?ref=Ada'),
+	)
+	expect(await first.text()).toBe('signup')
+	expect(first.headers.get('Set-Cookie')).toBe(
+		`${referralCookieName}=ada; Path=/; Max-Age=604800; SameSite=Lax`,
+	)
+	expect(first.headers.get('Cache-Control')).toBe('no-store')
+
+	const later = await router.fetch(
+		new Request('https://kody.codes/signup?ref=KentCDodds'),
+	)
+	expect(later.headers.get('Set-Cookie')).toBe(
+		`${referralCookieName}=kentcdodds; Path=/; Max-Age=604800; SameSite=Lax; Secure`,
+	)
+
+	const untouched = await router.fetch(new Request('http://localhost/signup'))
+	expect(untouched.headers.get('Set-Cookie')).toBeNull()
+	expect(untouched.headers.get('Cache-Control')).toBe('public, max-age=60')
+})

--- a/packages/worker/src/app/referral-cookie-middleware.ts
+++ b/packages/worker/src/app/referral-cookie-middleware.ts
@@ -1,0 +1,32 @@
+import { type Middleware } from 'remix/router'
+import { isSecureRequest } from '#app/auth-session.ts'
+import { serializeReferralCookie } from '#universal/referral-cookie.ts'
+import { parseReferralCode } from '#universal/referral-program.ts'
+
+/**
+ * Last-wins `kody_ref` cookie. Any request with a valid `?ref=` / `?referral=`
+ * overwrites the previous referrer and refreshes the one-week expiry.
+ * Responses that set the cookie are `no-store` so a personalized Set-Cookie
+ * cannot enter the anonymous HTML cache.
+ */
+export function createReferralCookieMiddleware(): Middleware {
+	return async ({ request, url }, next) => {
+		const code = parseReferralCode({ searchParams: url.searchParams })
+		const response = await next()
+		if (!code) return response
+		const headers = new Headers(response.headers)
+		headers.append(
+			'Set-Cookie',
+			serializeReferralCookie({
+				code,
+				secure: isSecureRequest(request),
+			}),
+		)
+		headers.set('Cache-Control', 'no-store')
+		return new Response(response.body, {
+			status: response.status,
+			statusText: response.statusText,
+			headers,
+		})
+	}
+}

--- a/packages/worker/src/app/router.ts
+++ b/packages/worker/src/app/router.ts
@@ -259,10 +259,12 @@ import { renderAppPage } from '#app/ssr-render.tsx'
 import { routes } from '#universal/routes.ts'
 import { createAccountWriteLeaseMiddleware } from '#app/account-write-lease-middleware.ts'
 import { remixCrossOriginProtection } from '#app/cross-origin-protection.ts'
+import { createReferralCookieMiddleware } from '#app/referral-cookie-middleware.ts'
 export function createAppRouter(env: Env) {
 	const router = createRouter({
 		middleware: [
 			remixCrossOriginProtection,
+			createReferralCookieMiddleware(),
 			createAccountWriteLeaseMiddleware(env),
 		],
 		async defaultHandler({ request }) {

--- a/packages/worker/src/app/user-entitlement-warning-emails.ts
+++ b/packages/worker/src/app/user-entitlement-warning-emails.ts
@@ -23,6 +23,7 @@ import {
 	type EntitlementResource,
 	type PlanName,
 } from '#universal/plans.ts'
+import { laterIsoTimestamp } from '#universal/referral-program.ts'
 import { resolveEffectivePlanWithSecondAgentGift } from '#universal/second-agent-standard-gift.ts'
 import { observeOnlyUsageEventTypes } from '#universal/usage-event-types.ts'
 
@@ -71,6 +72,7 @@ type WarningCandidate = {
 	stripe_plan: string | null
 	entitlement_ladder: string | null
 	second_agent_standard_gift_expires_at: string | null
+	referral_standard_credit_expires_at: string | null
 }
 
 export type UserWarningResource =
@@ -204,7 +206,10 @@ async function warnOneUserIfNeeded(input: {
 	const plan = resolveEffectivePlanWithSecondAgentGift(
 		parseStoredPlanName(input.user.plan),
 		input.user.stripe_plan,
-		input.user.second_agent_standard_gift_expires_at,
+		laterIsoTimestamp(
+			input.user.second_agent_standard_gift_expires_at,
+			input.user.referral_standard_credit_expires_at,
+		),
 		input.now,
 	)
 	const ladder = parseEntitlementLadder(input.user.entitlement_ladder)
@@ -707,7 +712,8 @@ export async function listUsersForEntitlementWarningSweep(
 			db
 				.prepare(
 					`SELECT u.stable_user_id, u.email, u.plan, u.stripe_plan, u.entitlement_ladder,
-					u.second_agent_standard_gift_expires_at
+					u.second_agent_standard_gift_expires_at,
+					u.referral_standard_credit_expires_at
 				 FROM (
 					SELECT user_id, SUM(event_count) AS event_count
 					FROM usage_rollups
@@ -732,7 +738,8 @@ export async function listUsersForEntitlementWarningSweep(
 			db
 				.prepare(
 					`SELECT u.stable_user_id, u.email, u.plan, u.stripe_plan, u.entitlement_ladder,
-					u.second_agent_standard_gift_expires_at
+					u.second_agent_standard_gift_expires_at,
+					u.referral_standard_credit_expires_at
 				 FROM (
 					SELECT user_id, COUNT(*) AS stock_count
 					FROM saved_packages
@@ -751,7 +758,8 @@ export async function listUsersForEntitlementWarningSweep(
 			db
 				.prepare(
 					`SELECT u.stable_user_id, u.email, u.plan, u.stripe_plan, u.entitlement_ladder,
-					u.second_agent_standard_gift_expires_at
+					u.second_agent_standard_gift_expires_at,
+					u.referral_standard_credit_expires_at
 				 FROM (
 					SELECT sb.user_id, COUNT(*) AS stock_count
 					FROM secret_entries se
@@ -776,7 +784,8 @@ export async function listUsersForEntitlementWarningSweep(
 			db
 				.prepare(
 					`SELECT u.stable_user_id, u.email, u.plan, u.stripe_plan, u.entitlement_ladder,
-					u.second_agent_standard_gift_expires_at
+					u.second_agent_standard_gift_expires_at,
+					u.referral_standard_credit_expires_at
 				 FROM (
 					SELECT user_id, event_count
 					FROM usage_rollups
@@ -796,7 +805,8 @@ export async function listUsersForEntitlementWarningSweep(
 			db
 				.prepare(
 					`SELECT u.stable_user_id, u.email, u.plan, u.stripe_plan, u.entitlement_ladder,
-					u.second_agent_standard_gift_expires_at
+					u.second_agent_standard_gift_expires_at,
+					u.referral_standard_credit_expires_at
 				 FROM (
 					SELECT user_id, event_count
 					FROM usage_rollups

--- a/packages/worker/src/billing/stripe-client.ts
+++ b/packages/worker/src/billing/stripe-client.ts
@@ -96,6 +96,7 @@ const subscriptionSchema = object({
 	id: string(),
 	status: string(),
 	cancel_at: nullable(number()),
+	current_period_end: optional(nullable(number())),
 	metadata: optional(record(string(), string())),
 	items: object({
 		data: array(subscriptionItemSchema),

--- a/packages/worker/src/billing/stripe-client.ts
+++ b/packages/worker/src/billing/stripe-client.ts
@@ -90,6 +90,7 @@ const subscriptionItemSchema = object({
 	price: object({
 		id: string(),
 	}),
+	current_period_end: optional(nullable(number())),
 })
 
 const subscriptionSchema = object({
@@ -206,6 +207,24 @@ const creditNotePreviewSchema = object({
 
 export type StripeCheckoutSession = InferOutput<typeof checkoutSessionSchema>
 export type StripeSubscription = InferOutput<typeof subscriptionSchema>
+
+/** Newest period end from subscription items, then the top-level field. */
+export function readStripeSubscriptionPeriodEndUnix(
+	subscription: StripeSubscription,
+): number | null {
+	let latest: number | null = null
+	for (const item of subscription.items.data) {
+		const end = item.current_period_end
+		if (typeof end === 'number' && Number.isFinite(end) && end > 0) {
+			if (latest == null || end > latest) latest = end
+		}
+	}
+	const top = subscription.current_period_end
+	if (typeof top === 'number' && Number.isFinite(top) && top > 0) {
+		if (latest == null || top > latest) latest = top
+	}
+	return latest
+}
 export type StripePaidInvoice = InferOutput<typeof paidInvoiceSchema>
 export type StripeInvoiceLineItem = InferOutput<typeof invoiceLineItemSchema>
 export type StripeCreditNote = InferOutput<typeof creditNoteSchema>

--- a/packages/worker/src/billing/stripe-webhooks.ts
+++ b/packages/worker/src/billing/stripe-webhooks.ts
@@ -26,7 +26,10 @@ import {
 	linkStripeCustomerFromCheckoutSessionAttribution,
 	refreshStripePlanForStripeCustomer,
 } from './subscription-sync.ts'
-import { listSubscriptions } from './stripe-client.ts'
+import {
+	listSubscriptions,
+	readStripeSubscriptionPeriodEndUnix,
+} from './stripe-client.ts'
 import {
 	isQualifyingPaidReferralInvoice,
 	readStripeInvoiceCustomerId,
@@ -248,7 +251,7 @@ async function handleInvoicePaymentFailed(input: {
 	)
 }
 
-async function latestReferrerPaidPeriodEnd(input: {
+export async function latestReferrerPaidPeriodEnd(input: {
 	env: Env
 	referrerStableUserId: string
 }): Promise<string | null> {
@@ -265,7 +268,9 @@ async function latestReferrerPaidPeriodEnd(input: {
 		)
 		let latest: string | null = null
 		for (const subscription of subscriptions) {
-			const iso = unixSecondsToIso(subscription.current_period_end)
+			const iso = unixSecondsToIso(
+				readStripeSubscriptionPeriodEndUnix(subscription),
+			)
 			if (!iso) continue
 			if (!latest || Date.parse(iso) > Date.parse(latest)) latest = iso
 		}
@@ -287,13 +292,6 @@ async function handleInvoicePaid(input: {
 		console.error('stripe_webhook_invoice_paid_missing_ids')
 		return
 	}
-	const user = await input.env.APP_DB.prepare(
-		`SELECT stable_user_id FROM users WHERE stripe_customer_id = ?`,
-	)
-		.bind(customerId)
-		.first<{ stable_user_id: string }>()
-	if (!user?.stable_user_id) return
-
 	const subscriptionId = readStripeInvoiceSubscriptionId(input.object)
 	const qualifies = isQualifyingPaidReferralInvoice({
 		status: input.object.status,
@@ -307,6 +305,15 @@ async function handleInvoicePaid(input: {
 				: null,
 	})
 	if (!qualifies) return
+
+	const user = await input.env.APP_DB.prepare(
+		`SELECT stable_user_id FROM users WHERE stripe_customer_id = ?`,
+	)
+		.bind(customerId)
+		.first<{ stable_user_id: string }>()
+	if (!user?.stable_user_id) {
+		throw new Error('stripe_webhook_invoice_paid_user_not_linked')
+	}
 
 	const pending = await input.env.APP_DB.prepare(
 		`SELECT referrer_stable_user_id

--- a/packages/worker/src/billing/stripe-webhooks.ts
+++ b/packages/worker/src/billing/stripe-webhooks.ts
@@ -17,12 +17,22 @@ import {
 import { waitUntil } from 'cloudflare:workers'
 import { utcDayKey } from '@kody-internal/shared/date-keys.ts'
 import { sendPaymentFailedEmail } from '#app/user-account-emails.ts'
-import { isBillingConfigured } from './billing-config.ts'
+import { isBillingConfigured,selectPlanRetainingSubscriptions } from './billing-config.ts'
 import {
 	BillingLinkError,
 	linkStripeCustomerFromCheckoutSessionAttribution,
 	refreshStripePlanForStripeCustomer,
 } from './subscription-sync.ts'
+import { listSubscriptions } from './stripe-client.ts'
+import {
+	isQualifyingPaidReferralInvoice,
+	readStripeInvoiceCustomerId,
+	readStripeInvoiceId,
+	readStripeInvoicePeriodEndIso,
+	readStripeInvoiceSubscriptionId,
+	rewardReferralForPaidInvoice,
+} from '#worker/entitlements/referral-program.ts'
+import { unixSecondsToIso } from '#universal/referral-program.ts'
 import {
 	StripeWebhookSignatureError,
 	verifyStripeWebhookSignature,
@@ -235,6 +245,91 @@ async function handleInvoicePaymentFailed(input: {
 	)
 }
 
+async function latestReferrerPaidPeriodEnd(input: {
+	env: Env
+	referrerStableUserId: string
+}): Promise<string | null> {
+	const row = await input.env.APP_DB.prepare(
+		`SELECT stripe_customer_id FROM users WHERE stable_user_id = ?`,
+	)
+		.bind(input.referrerStableUserId)
+		.first<{ stripe_customer_id: string | null }>()
+	const customerId = row?.stripe_customer_id?.trim()
+	if (!customerId) return null
+	try {
+		const subscriptions = selectPlanRetainingSubscriptions(
+			await listSubscriptions(input.env, customerId),
+		)
+		let latest: string | null = null
+		for (const subscription of subscriptions) {
+			const iso = unixSecondsToIso(subscription.current_period_end)
+			if (!iso) continue
+			if (!latest || Date.parse(iso) > Date.parse(latest)) latest = iso
+		}
+		return latest
+	} catch (error) {
+		console.warn('referral-referrer-period-end-failed', error)
+		return null
+	}
+}
+
+async function handleInvoicePaid(input: {
+	env: Env
+	object: Record<string, unknown>
+	now?: Date
+}) {
+	const customerId = readStripeInvoiceCustomerId(input.object)
+	const invoiceId = readStripeInvoiceId(input.object)
+	if (!customerId || !invoiceId) {
+		console.error('stripe_webhook_invoice_paid_missing_ids')
+		return
+	}
+	const user = await input.env.APP_DB.prepare(
+		`SELECT stable_user_id FROM users WHERE stripe_customer_id = ?`,
+	)
+		.bind(customerId)
+		.first<{ stable_user_id: string }>()
+	if (!user?.stable_user_id) return
+
+	const subscriptionId = readStripeInvoiceSubscriptionId(input.object)
+	const qualifies = isQualifyingPaidReferralInvoice({
+		status: input.object.status,
+		paid: input.object.paid,
+		amount_paid: input.object.amount_paid,
+		billing_reason: input.object.billing_reason,
+		subscription: subscriptionId,
+		metadata:
+			input.object.metadata && typeof input.object.metadata === 'object'
+				? (input.object.metadata as Record<string, string>)
+				: null,
+	})
+	if (!qualifies) return
+
+	const pending = await input.env.APP_DB.prepare(
+		`SELECT referrer_stable_user_id
+		 FROM referrals
+		 WHERE referee_stable_user_id = ? AND status = 'pending'`,
+	)
+		.bind(user.stable_user_id)
+		.first<{ referrer_stable_user_id: string }>()
+	if (!pending) return
+
+	const referrerPaidPeriodEndAt = await latestReferrerPaidPeriodEnd({
+		env: input.env,
+		referrerStableUserId: pending.referrer_stable_user_id,
+	})
+
+	await rewardReferralForPaidInvoice({
+		db: input.env.APP_DB,
+		refereeStableUserId: user.stable_user_id,
+		invoiceId,
+		invoiceQualifies: true,
+		paidPeriodEndAt: readStripeInvoicePeriodEndIso(input.object),
+		referrerPaidPeriodEndAt,
+		now: input.now,
+	})
+}
+
 export async function processStripeWebhookEvent(input: {
 	env: Env
 	eventType: string
@@ -259,6 +354,13 @@ export async function processStripeWebhookEvent(input: {
 			return
 		case 'invoice.payment_failed':
 			await handleInvoicePaymentFailed({
+				env: input.env,
+				object: input.object,
+				now: input.now,
+			})
+			return
+		case 'invoice.paid':
+			await handleInvoicePaid({
 				env: input.env,
 				object: input.object,
 				now: input.now,

--- a/packages/worker/src/billing/stripe-webhooks.ts
+++ b/packages/worker/src/billing/stripe-webhooks.ts
@@ -262,23 +262,18 @@ export async function latestReferrerPaidPeriodEnd(input: {
 		.first<{ stripe_customer_id: string | null }>()
 	const customerId = row?.stripe_customer_id?.trim()
 	if (!customerId) return null
-	try {
-		const subscriptions = selectPlanRetainingSubscriptions(
-			await listSubscriptions(input.env, customerId),
+	const subscriptions = selectPlanRetainingSubscriptions(
+		await listSubscriptions(input.env, customerId),
+	)
+	let latest: string | null = null
+	for (const subscription of subscriptions) {
+		const iso = unixSecondsToIso(
+			readStripeSubscriptionPeriodEndUnix(subscription),
 		)
-		let latest: string | null = null
-		for (const subscription of subscriptions) {
-			const iso = unixSecondsToIso(
-				readStripeSubscriptionPeriodEndUnix(subscription),
-			)
-			if (!iso) continue
-			if (!latest || Date.parse(iso) > Date.parse(latest)) latest = iso
-		}
-		return latest
-	} catch (error) {
-		console.warn('referral-referrer-period-end-failed', error)
-		return null
+		if (!iso) continue
+		if (!latest || Date.parse(iso) > Date.parse(latest)) latest = iso
 	}
+	return latest
 }
 
 async function handleInvoicePaid(input: {

--- a/packages/worker/src/billing/stripe-webhooks.ts
+++ b/packages/worker/src/billing/stripe-webhooks.ts
@@ -17,7 +17,10 @@ import {
 import { waitUntil } from 'cloudflare:workers'
 import { utcDayKey } from '@kody-internal/shared/date-keys.ts'
 import { sendPaymentFailedEmail } from '#app/user-account-emails.ts'
-import { isBillingConfigured,selectPlanRetainingSubscriptions } from './billing-config.ts'
+import {
+	isBillingConfigured,
+	selectPlanRetainingSubscriptions,
+} from './billing-config.ts'
 import {
 	BillingLinkError,
 	linkStripeCustomerFromCheckoutSessionAttribution,

--- a/packages/worker/src/billing/stripe-webhooks.ts
+++ b/packages/worker/src/billing/stripe-webhooks.ts
@@ -317,22 +317,54 @@ async function handleInvoicePaid(input: {
 	)
 		.bind(user.stable_user_id)
 		.first<{ referrer_stable_user_id: string }>()
-	if (!pending) return
+	if (pending) {
+		const referrerPaidPeriodEndAt = await latestReferrerPaidPeriodEnd({
+			env: input.env,
+			referrerStableUserId: pending.referrer_stable_user_id,
+		})
+		await rewardReferralForPaidInvoice({
+			db: input.env.APP_DB,
+			refereeStableUserId: user.stable_user_id,
+			invoiceId,
+			invoiceQualifies: true,
+			paidPeriodEndAt: readStripeInvoicePeriodEndIso(input.object),
+			referrerPaidPeriodEndAt,
+			now: input.now,
+		})
+	}
+
+	const heldAsReferrer = await input.env.APP_DB.prepare(
+		`SELECT referee_stable_user_id, held_invoice_id, held_period_end_at
+		 FROM referrals
+		 WHERE referrer_stable_user_id = ?
+		   AND status = 'pending'
+		   AND held_invoice_id IS NOT NULL`,
+	)
+		.bind(user.stable_user_id)
+		.all<{
+			referee_stable_user_id: string
+			held_invoice_id: string | null
+			held_period_end_at: string | null
+		}>()
+	const heldRows = heldAsReferrer.results ?? []
+	if (heldRows.length === 0) return
 
 	const referrerPaidPeriodEndAt = await latestReferrerPaidPeriodEnd({
 		env: input.env,
-		referrerStableUserId: pending.referrer_stable_user_id,
+		referrerStableUserId: user.stable_user_id,
 	})
-
-	await rewardReferralForPaidInvoice({
-		db: input.env.APP_DB,
-		refereeStableUserId: user.stable_user_id,
-		invoiceId,
-		invoiceQualifies: true,
-		paidPeriodEndAt: readStripeInvoicePeriodEndIso(input.object),
-		referrerPaidPeriodEndAt,
-		now: input.now,
-	})
+	for (const row of heldRows) {
+		if (!row.held_invoice_id) continue
+		await rewardReferralForPaidInvoice({
+			db: input.env.APP_DB,
+			refereeStableUserId: row.referee_stable_user_id,
+			invoiceId: row.held_invoice_id,
+			invoiceQualifies: true,
+			paidPeriodEndAt: row.held_period_end_at,
+			referrerPaidPeriodEndAt,
+			now: input.now,
+		})
+	}
 }
 
 export async function processStripeWebhookEvent(input: {

--- a/packages/worker/src/billing/stripe-webhooks.workers.test.ts
+++ b/packages/worker/src/billing/stripe-webhooks.workers.test.ts
@@ -492,3 +492,41 @@ test('invoice.paid rewards both parties once and ignores $0 trial invoices', asy
 
 	vi.unstubAllGlobals()
 })
+
+test('invoice.paid returns 500 when a qualifying invoice has no linked user', async () => {
+	await ensureEntitlementTestSchema(env.APP_DB)
+	silenceExpectedConsoleErrors([
+		'stripe_webhook_process_failed',
+		'stripe_webhook_invoice_paid_user_not_linked',
+	])
+	vi.stubGlobal('fetch', async () => {
+		throw new Error('fetch should not run for an unlinked invoice.paid')
+	})
+	const result = await handleStripeWebhookRequest({
+		env: createWebhookEnv(),
+		request: await signedWebhookRequest({
+			event: {
+				id: 'evt_invoice_unlinked',
+				type: 'invoice.paid',
+				created: 1_778_000_200,
+				data: {
+					object: {
+						id: 'in_unlinked',
+						object: 'invoice',
+						customer: 'cus_not_linked_yet',
+						subscription: 'sub_unlinked',
+						status: 'paid',
+						amount_paid: 1200,
+						billing_reason: 'subscription_create',
+					},
+				},
+			},
+		}),
+		now,
+	})
+	expect(result).toEqual({
+		status: 500,
+		body: { ok: false, error: 'Failed to process Stripe webhook event.' },
+	})
+	vi.unstubAllGlobals()
+})

--- a/packages/worker/src/billing/stripe-webhooks.workers.test.ts
+++ b/packages/worker/src/billing/stripe-webhooks.workers.test.ts
@@ -530,3 +530,67 @@ test('invoice.paid returns 500 when a qualifying invoice has no linked user', as
 	})
 	vi.unstubAllGlobals()
 })
+
+test('invoice.paid returns 500 when the referrer paid period cannot be loaded', async () => {
+	silenceExpectedConsoleErrors([
+		'stripe_webhook_process_failed',
+		'stripe_api_error',
+	])
+	const referrer = await seedUser({
+		email: 'referrer-period-fail@example.com',
+		stripeCustomerId: 'cus_referrer_period_fail',
+		stripePlan: 'standard',
+	})
+	const referee = await seedUser({
+		email: 'referee-period-fail@example.com',
+		stripeCustomerId: 'cus_referee_period_fail',
+	})
+	await env.APP_DB.prepare(
+		`INSERT INTO referrals (
+			referrer_stable_user_id, referee_stable_user_id, created_at, status
+		) VALUES (?, ?, ?, 'pending')`,
+	)
+		.bind(referrer.stableUserId, referee.stableUserId, now.toISOString())
+		.run()
+	vi.stubGlobal(
+		'fetch',
+		vi.fn(async () => jsonResponse({ error: 'stripe down' }, 500)),
+	)
+
+	const result = await handleStripeWebhookRequest({
+		env: createWebhookEnv(),
+		request: await signedWebhookRequest({
+			event: {
+				id: 'evt_invoice_referrer_period_fail',
+				type: 'invoice.paid',
+				created: 1_778_000_300,
+				data: {
+					object: {
+						id: 'in_referrer_period_fail',
+						object: 'invoice',
+						customer: 'cus_referee_period_fail',
+						subscription: 'sub_referrer_period_fail',
+						status: 'paid',
+						amount_paid: 2000,
+						billing_reason: 'subscription_create',
+					},
+				},
+			},
+		}),
+		now,
+	})
+	expect(result).toEqual({
+		status: 500,
+		body: { ok: false, error: 'Failed to process Stripe webhook event.' },
+	})
+	expect(await readWebhookEvent('evt_invoice_referrer_period_fail')).toBeNull()
+	expect(
+		await env.APP_DB.prepare(
+			'SELECT status, credits_granted_at FROM referrals WHERE referee_stable_user_id = ?',
+		)
+			.bind(referee.stableUserId)
+			.first<{ status: string; credits_granted_at: string | null }>(),
+	).toEqual({ status: 'pending', credits_granted_at: null })
+
+	vi.unstubAllGlobals()
+})

--- a/packages/worker/src/billing/stripe-webhooks.workers.test.ts
+++ b/packages/worker/src/billing/stripe-webhooks.workers.test.ts
@@ -594,3 +594,83 @@ test('invoice.paid returns 500 when the referrer paid period cannot be loaded', 
 
 	vi.unstubAllGlobals()
 })
+
+test('invoice.paid for a referrer retries held outgoing referrals', async () => {
+	const referrer = await seedUser({
+		email: 'referrer-held-retry@example.com',
+		stripeCustomerId: 'cus_referrer_held_retry',
+		stripePlan: 'standard',
+	})
+	const referee = await seedUser({
+		email: 'referee-held-retry@example.com',
+		stripeCustomerId: 'cus_referee_held_retry',
+	})
+	await env.APP_DB.prepare(
+		`INSERT INTO referrals (
+			referrer_stable_user_id, referee_stable_user_id, created_at, status,
+			held_invoice_id, held_period_end_at
+		) VALUES (?, ?, ?, 'pending', 'in_held_retry', ?)`,
+	)
+		.bind(
+			referrer.stableUserId,
+			referee.stableUserId,
+			now.toISOString(),
+			'2026-08-01T00:00:00.000Z',
+		)
+		.run()
+	stubStripeFetch({
+		subscriptions: {
+			data: [
+				{
+					id: 'sub_referrer_held_retry',
+					status: 'active',
+					cancel_at: null,
+					items: {
+						data: [
+							{
+								price: { id: 'price_pro' },
+								current_period_end: 1_781_568_000,
+							},
+						],
+					},
+				},
+			],
+		},
+	})
+
+	const result = await handleStripeWebhookRequest({
+		env: createWebhookEnv(),
+		request: await signedWebhookRequest({
+			event: {
+				id: 'evt_referrer_held_retry',
+				type: 'invoice.paid',
+				created: 1_778_000_400,
+				data: {
+					object: {
+						id: 'in_referrer_own',
+						object: 'invoice',
+						customer: 'cus_referrer_held_retry',
+						subscription: 'sub_referrer_held_retry',
+						status: 'paid',
+						amount_paid: 2000,
+						billing_reason: 'subscription_cycle',
+					},
+				},
+			},
+		}),
+		now,
+	})
+	expect(result).toEqual({ status: 200, body: { ok: true } })
+	expect(
+		await env.APP_DB.prepare(
+			'SELECT status, reward_invoice_id FROM referrals WHERE referee_stable_user_id = ?',
+		)
+			.bind(referee.stableUserId)
+			.first<{ status: string; reward_invoice_id: string | null }>(),
+	).toEqual({
+		status: 'rewarded',
+		reward_invoice_id: 'in_held_retry',
+	})
+
+	vi.unstubAllGlobals()
+})

--- a/packages/worker/src/billing/stripe-webhooks.workers.test.ts
+++ b/packages/worker/src/billing/stripe-webhooks.workers.test.ts
@@ -406,7 +406,7 @@ test('invoice.paid rewards both parties once and ignores $0 trial invoices', asy
 	const trial = await handleStripeWebhookRequest({
 		env: createWebhookEnv(),
 		request: await signedWebhookRequest({ event: trialEvent }),
-		now: new Date('2026-09-07T12:00:00.000Z'),
+		now,
 	})
 	expect(trial).toEqual({ status: 200, body: { ok: true } })
 	expect(
@@ -436,7 +436,7 @@ test('invoice.paid rewards both parties once and ignores $0 trial invoices', asy
 	const paid = await handleStripeWebhookRequest({
 		env: createWebhookEnv(),
 		request: await signedWebhookRequest({ event: paidEvent }),
-		now: new Date('2026-09-07T12:00:00.000Z'),
+		now,
 	})
 	expect(paid).toEqual({ status: 200, body: { ok: true } })
 	expect(
@@ -458,7 +458,7 @@ test('invoice.paid rewards both parties once and ignores $0 trial invoices', asy
 	expect(
 		afterFirst.results.every(
 			(row) =>
-				row.referral_standard_credit_expires_at === '2026-10-07T12:00:00.000Z',
+				row.referral_standard_credit_expires_at === '2026-08-24T12:00:00.000Z',
 		),
 	).toBe(true)
 
@@ -476,7 +476,7 @@ test('invoice.paid rewards both parties once and ignores $0 trial invoices', asy
 				},
 			},
 		}),
-		now: new Date('2026-09-07T12:00:00.000Z'),
+		now,
 	})
 	expect(replay).toEqual({ status: 200, body: { ok: true } })
 	expect(

--- a/packages/worker/src/billing/stripe-webhooks.workers.test.ts
+++ b/packages/worker/src/billing/stripe-webhooks.workers.test.ts
@@ -362,3 +362,133 @@ test('stripe webhook process failure returns 500 without recording the event', a
 
 	vi.unstubAllGlobals()
 })
+
+test('invoice.paid rewards both parties once and ignores $0 trial invoices', async () => {
+	const referrer = await seedUser({
+		email: 'referrer-invoice-paid@example.com',
+	})
+	const referee = await seedUser({
+		email: 'referee-invoice-paid@example.com',
+		stripeCustomerId: 'cus_referral_invoice_paid',
+	})
+	await env.APP_DB.prepare(
+		`INSERT INTO referrals (
+			referrer_stable_user_id, referee_stable_user_id, created_at, status
+		) VALUES (?, ?, ?, 'pending')`,
+	)
+		.bind(
+			referrer.stableUserId,
+			referee.stableUserId,
+			new Date('2026-09-07T00:00:00.000Z').toISOString(),
+		)
+		.run()
+
+	vi.stubGlobal('fetch', async () => {
+		throw new Error('fetch should not run for invoice.paid')
+	})
+
+	const trialEvent = {
+		id: 'evt_invoice_trial',
+		type: 'invoice.paid',
+		created: 1_778_000_000,
+		data: {
+			object: {
+				id: 'in_trial',
+				object: 'invoice',
+				customer: 'cus_referral_invoice_paid',
+				subscription: 'sub_referral',
+				status: 'paid',
+				amount_paid: 0,
+				billing_reason: 'subscription_create',
+			},
+		},
+	}
+	const trial = await handleStripeWebhookRequest({
+		env: createWebhookEnv(),
+		request: await signedWebhookRequest({ event: trialEvent }),
+		now: new Date('2026-09-07T12:00:00.000Z'),
+	})
+	expect(trial).toEqual({ status: 200, body: { ok: true } })
+	expect(
+		await env.APP_DB.prepare(
+			'SELECT status FROM referrals WHERE referee_stable_user_id = ?',
+		)
+			.bind(referee.stableUserId)
+			.first<{ status: string }>(),
+	).toEqual({ status: 'pending' })
+
+	const paidEvent = {
+		id: 'evt_invoice_paid',
+		type: 'invoice.paid',
+		created: 1_778_000_100,
+		data: {
+			object: {
+				id: 'in_paid',
+				object: 'invoice',
+				customer: 'cus_referral_invoice_paid',
+				subscription: 'sub_referral',
+				status: 'paid',
+				amount_paid: 2000,
+				billing_reason: 'subscription_create',
+			},
+		},
+	}
+	const paid = await handleStripeWebhookRequest({
+		env: createWebhookEnv(),
+		request: await signedWebhookRequest({ event: paidEvent }),
+		now: new Date('2026-09-07T12:00:00.000Z'),
+	})
+	expect(paid).toEqual({ status: 200, body: { ok: true } })
+	expect(
+		await env.APP_DB.prepare(
+			'SELECT status, reward_invoice_id FROM referrals WHERE referee_stable_user_id = ?',
+		)
+			.bind(referee.stableUserId)
+			.first<{ status: string; reward_invoice_id: string | null }>(),
+	).toEqual({
+		status: 'rewarded',
+		reward_invoice_id: 'in_paid',
+	})
+	const afterFirst = await env.APP_DB.prepare(
+		`SELECT referral_standard_credit_expires_at FROM users WHERE id IN (?, ?)`,
+	)
+		.bind(referrer.id, referee.id)
+		.all<{ referral_standard_credit_expires_at: string }>()
+	expect(afterFirst.results).toHaveLength(2)
+	expect(
+		afterFirst.results.every(
+			(row) =>
+				row.referral_standard_credit_expires_at === '2026-10-07T12:00:00.000Z',
+		),
+	).toBe(true)
+
+	const replay = await handleStripeWebhookRequest({
+		env: createWebhookEnv(),
+		request: await signedWebhookRequest({
+			event: {
+				...paidEvent,
+				id: 'evt_invoice_paid_replay',
+				data: {
+					object: {
+						...paidEvent.data.object,
+						id: 'in_paid_later',
+					},
+				},
+			},
+		}),
+		now: new Date('2026-09-07T12:00:00.000Z'),
+	})
+	expect(replay).toEqual({ status: 200, body: { ok: true } })
+	expect(
+		await env.APP_DB.prepare(
+			'SELECT status, reward_invoice_id FROM referrals WHERE referee_stable_user_id = ?',
+		)
+			.bind(referee.stableUserId)
+			.first<{ status: string; reward_invoice_id: string | null }>(),
+	).toEqual({
+		status: 'rewarded',
+		reward_invoice_id: 'in_paid',
+	})
+
+	vi.unstubAllGlobals()
+})

--- a/packages/worker/src/db.ts
+++ b/packages/worker/src/db.ts
@@ -46,6 +46,7 @@ export const usersTable = table({
 		last_active_at: c.text(),
 		second_agent_standard_gift_granted_at: c.text(),
 		second_agent_standard_gift_expires_at: c.text(),
+		referral_standard_credit_expires_at: c.text(),
 		created_at: c.text(),
 		updated_at: c.text(),
 	},

--- a/packages/worker/src/entitlements/entitlements.node.test.ts
+++ b/packages/worker/src/entitlements/entitlements.node.test.ts
@@ -40,6 +40,7 @@ function createEntitlementsTestDb(
 			stripe_plan?: string | null
 			entitlement_ladder?: 'public' | 'legacy' | null
 			second_agent_standard_gift_expires_at?: string | null
+			referral_standard_credit_expires_at?: string | null
 			stable_user_id: string
 		}>
 		counts?: Partial<
@@ -94,7 +95,7 @@ function createEntitlementsTestDb(
 						async first<T>() {
 							if (
 								query.includes(
-									'SELECT plan, stripe_plan, entitlement_ladder, second_agent_standard_gift_expires_at FROM users',
+									'SELECT plan, stripe_plan, entitlement_ladder, second_agent_standard_gift_expires_at, referral_standard_credit_expires_at FROM users',
 								) ||
 								query.includes(
 									'SELECT plan, stripe_plan, entitlement_ladder FROM users',
@@ -128,6 +129,8 @@ function createEntitlementsTestDb(
 														user.entitlement_ladder ?? 'public',
 													second_agent_standard_gift_expires_at:
 														user.second_agent_standard_gift_expires_at ?? null,
+													referral_standard_credit_expires_at:
+														user.referral_standard_credit_expires_at ?? null,
 												}
 											: null
 									) as T | null
@@ -147,6 +150,8 @@ function createEntitlementsTestDb(
 												entitlement_ladder: user.entitlement_ladder ?? 'public',
 												second_agent_standard_gift_expires_at:
 													user.second_agent_standard_gift_expires_at ?? null,
+												referral_standard_credit_expires_at:
+													user.referral_standard_credit_expires_at ?? null,
 											}
 										: null
 								) as T | null

--- a/packages/worker/src/entitlements/referral-program.node.test.ts
+++ b/packages/worker/src/entitlements/referral-program.node.test.ts
@@ -8,6 +8,7 @@ import { getUserEntitlement } from './service.ts'
 import {
 	attributeReferralAtSignup,
 	isQualifyingPaidReferralInvoice,
+	loadReferralProgramSummary,
 	maybeRewardHeldReferralAfterEmailVerified,
 	rewardReferralForPaidInvoice,
 } from './referral-program.ts'
@@ -344,4 +345,117 @@ test('referral rewards both parties once on first paid invoice, skips trial, rej
 		status: 'rewarded',
 		reward_invoice_id: 'in_held',
 	})
+})
+
+test('held rewards release for every pending referee when the referrer verifies', async () => {
+	const sqlite = new DatabaseSync(':memory:')
+	const db = createD1FromSqlite(sqlite)
+	await ensureReferralSchema(db)
+	const referrer = await insertUser(db, {
+		email: 'held-referrer@example.com',
+		username: 'heldreferrer',
+		verified: false,
+	})
+	const first = await insertUser(db, {
+		email: 'held-one@example.com',
+		username: 'heldone',
+	})
+	const second = await insertUser(db, {
+		email: 'held-two@example.com',
+		username: 'heldtwo',
+	})
+	await attributeReferralAtSignup({
+		db,
+		refereeStableUserId: first.stableUserId,
+		refereeUsername: 'heldone',
+		referralCode: 'heldreferrer',
+		now,
+	})
+	await attributeReferralAtSignup({
+		db,
+		refereeStableUserId: second.stableUserId,
+		refereeUsername: 'heldtwo',
+		referralCode: 'heldreferrer',
+		now,
+	})
+	expect(
+		await rewardReferralForPaidInvoice({
+			db,
+			refereeStableUserId: first.stableUserId,
+			invoiceId: 'in_held_one',
+			invoiceQualifies: true,
+			now,
+		}),
+	).toEqual({ outcome: 'held_unverified' })
+	expect(
+		await rewardReferralForPaidInvoice({
+			db,
+			refereeStableUserId: second.stableUserId,
+			invoiceId: 'in_held_two',
+			invoiceQualifies: true,
+			now,
+		}),
+	).toEqual({ outcome: 'held_unverified' })
+
+	await db
+		.prepare(`UPDATE users SET email_verified_at = ? WHERE stable_user_id = ?`)
+		.bind(now.toISOString(), referrer.stableUserId)
+		.run()
+	expect(
+		await maybeRewardHeldReferralAfterEmailVerified({
+			db,
+			stableUserId: referrer.stableUserId,
+			now,
+		}),
+	).toEqual({ outcome: 'rewarded' })
+	expect(await referralRow(db, first.stableUserId)).toMatchObject({
+		status: 'rewarded',
+		reward_invoice_id: 'in_held_one',
+	})
+	expect(await referralRow(db, second.stableUserId)).toMatchObject({
+		status: 'rewarded',
+		reward_invoice_id: 'in_held_two',
+	})
+	expect(await creditExpiry(db, referrer.stableUserId)).toBe(
+		secondCreditExpiresAt,
+	)
+})
+
+test('referral billing summary counts every row, not only the displayed page', async () => {
+	const sqlite = new DatabaseSync(':memory:')
+	const db = createD1FromSqlite(sqlite)
+	await ensureReferralSchema(db)
+	const referrer = await insertUser(db, {
+		email: 'count-referrer@example.com',
+		username: 'countreferrer',
+	})
+	for (let index = 0; index < 52; index += 1) {
+		const referee = await insertUser(db, {
+			email: `count-ref-${index}@example.com`,
+			username: `countref${index}`,
+		})
+		await db
+			.prepare(
+				`INSERT INTO referrals (
+					referrer_stable_user_id, referee_stable_user_id, created_at, status
+				) VALUES (?, ?, ?, ?)`,
+			)
+			.bind(
+				referrer.stableUserId,
+				referee.stableUserId,
+				now.toISOString(),
+				index < 3 ? 'rewarded' : 'pending',
+			)
+			.run()
+	}
+	const summary = await loadReferralProgramSummary({
+		db,
+		stableUserId: referrer.stableUserId,
+		username: 'countreferrer',
+		origin: 'https://kody.codes',
+		now,
+	})
+	expect(summary.rewardedCount).toBe(3)
+	expect(summary.pendingCount).toBe(49)
+	expect(summary.referrals).toHaveLength(50)
 })

--- a/packages/worker/src/entitlements/referral-program.node.test.ts
+++ b/packages/worker/src/entitlements/referral-program.node.test.ts
@@ -9,6 +9,7 @@ import {
 	attributeReferralAtSignup,
 	isQualifyingPaidReferralInvoice,
 	loadReferralProgramSummary,
+	readStripeInvoicePeriodEndIso,
 	maybeRewardHeldReferralAfterEmailVerified,
 	rewardReferralForPaidInvoice,
 } from './referral-program.ts'
@@ -206,6 +207,16 @@ test('referral rewards both parties once on first paid invoice, skips trial, rej
 			metadata: { kody_compute_overage: '1' },
 		}),
 	).toBe(false)
+	expect(
+		readStripeInvoicePeriodEndIso({
+			lines: {
+				data: [
+					{ period: { end: 1_778_000_000 } },
+					{ period: { end: 1_780_588_800 } },
+				],
+			},
+		}),
+	).toBe('2026-06-04T16:00:00.000Z')
 
 	expect(
 		await rewardReferralForPaidInvoice({

--- a/packages/worker/src/entitlements/referral-program.node.test.ts
+++ b/packages/worker/src/entitlements/referral-program.node.test.ts
@@ -4,6 +4,7 @@ import { createD1FromSqlite } from '#worker/test-support/create-d1-from-sqlite.t
 import { testStableUserIdFromEmail } from '#worker/test-support/stable-user-id.ts'
 import { ensureUsersTestSchema } from '#worker/users-test-schema.ts'
 import { ensureReferralProgramTestSchema } from './test-schema.ts'
+import { consoleWarn } from '#worker/test-support/console-spies.ts'
 import { getUserEntitlement } from './service.ts'
 import {
 	attributeReferralAtSignup,
@@ -430,6 +431,62 @@ test('held rewards release for every pending referee when the referrer verifies'
 	expect(await creditExpiry(db, referrer.stableUserId)).toBe(
 		secondCreditExpiresAt,
 	)
+})
+
+test('held rewards stay pending when the referrer period resolver fails', async () => {
+	const sqlite = new DatabaseSync(':memory:')
+	const db = createD1FromSqlite(sqlite)
+	await ensureReferralSchema(db)
+	const referrer = await insertUser(db, {
+		email: 'held-fail-referrer@example.com',
+		username: 'heldfailref',
+		verified: false,
+	})
+	const referee = await insertUser(db, {
+		email: 'held-fail-referee@example.com',
+		username: 'heldfailree',
+	})
+	await attributeReferralAtSignup({
+		db,
+		refereeStableUserId: referee.stableUserId,
+		refereeUsername: 'heldfailree',
+		referralCode: 'heldfailref',
+		now,
+	})
+	expect(
+		await rewardReferralForPaidInvoice({
+			db,
+			refereeStableUserId: referee.stableUserId,
+			invoiceId: 'in_held_fail',
+			invoiceQualifies: true,
+			now,
+		}),
+	).toEqual({ outcome: 'held_unverified' })
+	await db
+		.prepare(`UPDATE users SET email_verified_at = ? WHERE stable_user_id = ?`)
+		.bind(now.toISOString(), referrer.stableUserId)
+		.run()
+	consoleWarn.mockImplementation(() => {})
+	expect(
+		await maybeRewardHeldReferralAfterEmailVerified({
+			db,
+			stableUserId: referrer.stableUserId,
+			resolveReferrerPaidPeriodEnd: async () => {
+				throw new Error('stripe down')
+			},
+			now,
+		}),
+	).toEqual({ outcome: 'ignored', reason: 'no_pending' })
+	expect(consoleWarn).toHaveBeenCalledWith(
+		'referral-held-referrer-period-end-failed',
+		expect.any(Error),
+	)
+	expect(await referralRow(db, referee.stableUserId)).toMatchObject({
+		status: 'pending',
+		held_invoice_id: 'in_held_fail',
+		credits_granted_at: null,
+	})
+	expect(await creditExpiry(db, referrer.stableUserId)).toBeNull()
 })
 
 test('referral billing summary counts every row, not only the displayed page', async () => {

--- a/packages/worker/src/entitlements/referral-program.node.test.ts
+++ b/packages/worker/src/entitlements/referral-program.node.test.ts
@@ -1,0 +1,347 @@
+import { DatabaseSync } from 'node:sqlite'
+import { expect, test } from 'vitest'
+import { createD1FromSqlite } from '#worker/test-support/create-d1-from-sqlite.ts'
+import { testStableUserIdFromEmail } from '#worker/test-support/stable-user-id.ts'
+import { ensureUsersTestSchema } from '#worker/users-test-schema.ts'
+import { ensureReferralProgramTestSchema } from './test-schema.ts'
+import { getUserEntitlement } from './service.ts'
+import {
+	attributeReferralAtSignup,
+	isQualifyingPaidReferralInvoice,
+	maybeRewardHeldReferralAfterEmailVerified,
+	rewardReferralForPaidInvoice,
+} from './referral-program.ts'
+
+const now = new Date('2026-09-07T12:00:00.000Z')
+const firstCreditExpiresAt = '2026-10-07T12:00:00.000Z'
+const secondCreditExpiresAt = '2026-11-06T12:00:00.000Z'
+
+async function ensureReferralSchema(db: D1Database) {
+	await ensureUsersTestSchema({
+		db,
+		columns: [
+			'email_verified_at',
+			'account_type',
+			'stripe_customer_id',
+			'stripe_plan',
+		],
+	})
+	await ensureReferralProgramTestSchema(db)
+}
+
+async function insertUser(
+	db: D1Database,
+	input: {
+		email: string
+		username?: string
+		verified?: boolean
+		plan?: string
+		stripePlan?: string | null
+		stripeCustomerId?: string | null
+		accountType?: string
+	},
+) {
+	const stableUserId = testStableUserIdFromEmail(input.email)
+	await db
+		.prepare(
+			`INSERT INTO users (
+				username, email, password_hash, stable_user_id, plan, stripe_plan,
+				stripe_customer_id, email_verified_at, account_type
+			) VALUES (?, ?, 'hash', ?, ?, ?, ?, ?, ?)`,
+		)
+		.bind(
+			input.username ?? input.email.split('@')[0],
+			input.email,
+			stableUserId,
+			input.plan ?? 'free',
+			input.stripePlan ?? null,
+			input.stripeCustomerId ?? null,
+			input.verified === false ? null : now.toISOString(),
+			input.accountType ?? 'person',
+		)
+		.run()
+	return { email: input.email, stableUserId }
+}
+
+async function creditExpiry(db: D1Database, stableUserId: string) {
+	const row = await db
+		.prepare(
+			`SELECT referral_standard_credit_expires_at
+			 FROM users WHERE stable_user_id = ?`,
+		)
+		.bind(stableUserId)
+		.first<{ referral_standard_credit_expires_at: string | null }>()
+	return row?.referral_standard_credit_expires_at ?? null
+}
+
+async function referralRow(db: D1Database, refereeStableUserId: string) {
+	return db
+		.prepare(`SELECT * FROM referrals WHERE referee_stable_user_id = ?`)
+		.bind(refereeStableUserId)
+		.first<{
+			status: string
+			reward_invoice_id: string | null
+			reject_reason: string | null
+			held_invoice_id: string | null
+		}>()
+}
+
+test('referral rewards both parties once on first paid invoice, skips trial, rejects fraud, and stacks without a cap', async () => {
+	const sqlite = new DatabaseSync(':memory:')
+	const db = createD1FromSqlite(sqlite)
+	await ensureReferralSchema(db)
+
+	const referrer = await insertUser(db, {
+		email: 'referrer@example.com',
+		username: 'referrer',
+	})
+	const referee = await insertUser(db, {
+		email: 'referee@example.com',
+		username: 'referee',
+	})
+	const unpaid = await insertUser(db, {
+		email: 'unpaid@example.com',
+		username: 'unpaid',
+	})
+	const plusTag = await insertUser(db, {
+		email: 'referrer+alt@example.com',
+		username: 'plustag',
+	})
+	const self = await insertUser(db, {
+		email: 'self@example.com',
+		username: 'selfuser',
+	})
+	const unverified = await insertUser(db, {
+		email: 'unverified@example.com',
+		username: 'unverified',
+		verified: false,
+	})
+
+	expect(
+		await attributeReferralAtSignup({
+			db,
+			refereeStableUserId: referee.stableUserId,
+			refereeUsername: 'referee',
+			referralCode: 'referrer',
+			now,
+		}),
+	).toEqual({ outcome: 'attributed' })
+	expect(
+		await attributeReferralAtSignup({
+			db,
+			refereeStableUserId: referee.stableUserId,
+			refereeUsername: 'referee',
+			referralCode: 'referrer',
+			now,
+		}),
+	).toEqual({ outcome: 'already_attributed' })
+	expect(
+		await attributeReferralAtSignup({
+			db,
+			refereeStableUserId: unpaid.stableUserId,
+			refereeUsername: 'unpaid',
+			referralCode: 'referrer',
+			now,
+		}),
+	).toEqual({ outcome: 'attributed' })
+	expect(
+		await attributeReferralAtSignup({
+			db,
+			refereeStableUserId: plusTag.stableUserId,
+			refereeUsername: 'plustag',
+			referralCode: 'referrer',
+			now,
+		}),
+	).toEqual({ outcome: 'attributed' })
+	expect(
+		await attributeReferralAtSignup({
+			db,
+			refereeStableUserId: self.stableUserId,
+			refereeUsername: 'selfuser',
+			referralCode: 'selfuser',
+			now,
+		}),
+	).toEqual({ outcome: 'ignored', reason: 'self' })
+	expect(
+		await attributeReferralAtSignup({
+			db,
+			refereeStableUserId: unverified.stableUserId,
+			refereeUsername: 'unverified',
+			referralCode: 'referrer',
+			now,
+		}),
+	).toEqual({ outcome: 'attributed' })
+	expect(
+		await attributeReferralAtSignup({
+			db,
+			refereeStableUserId: testStableUserIdFromEmail('ghost@example.com'),
+			refereeUsername: 'ghost',
+			referralCode: 'nobody',
+			now,
+		}),
+	).toEqual({ outcome: 'ignored', reason: 'unknown_referrer' })
+
+	expect(
+		isQualifyingPaidReferralInvoice({
+			status: 'paid',
+			amount_paid: 0,
+			billing_reason: 'subscription_create',
+			subscription: 'sub_trial',
+		}),
+	).toBe(false)
+	expect(
+		isQualifyingPaidReferralInvoice({
+			status: 'paid',
+			amount_paid: 1200,
+			billing_reason: 'subscription_create',
+			subscription: 'sub_paid',
+		}),
+	).toBe(true)
+	expect(
+		isQualifyingPaidReferralInvoice({
+			status: 'paid',
+			amount_paid: 250,
+			billing_reason: 'manual',
+			metadata: { kody_compute_overage: '1' },
+		}),
+	).toBe(false)
+
+	expect(
+		await rewardReferralForPaidInvoice({
+			db,
+			refereeStableUserId: unpaid.stableUserId,
+			invoiceId: 'in_trial',
+			invoiceQualifies: false,
+			now,
+		}),
+	).toEqual({ outcome: 'ignored', reason: 'invoice_unqualified' })
+	expect(await referralRow(db, unpaid.stableUserId)).toMatchObject({
+		status: 'pending',
+		reward_invoice_id: null,
+	})
+
+	const firstPaid = await rewardReferralForPaidInvoice({
+		db,
+		refereeStableUserId: referee.stableUserId,
+		invoiceId: 'in_first',
+		invoiceQualifies: true,
+		now,
+	})
+	expect(firstPaid).toEqual({ outcome: 'rewarded' })
+	expect(await creditExpiry(db, referrer.stableUserId)).toBe(
+		firstCreditExpiresAt,
+	)
+	expect(await creditExpiry(db, referee.stableUserId)).toBe(
+		firstCreditExpiresAt,
+	)
+	expect(
+		await getUserEntitlement(db, {
+			userId: referrer.stableUserId,
+			email: referrer.email,
+		}),
+	).toEqual({ plan: 'standard', ladder: 'public' })
+	expect(
+		await getUserEntitlement(db, {
+			userId: referee.stableUserId,
+			email: referee.email,
+		}),
+	).toEqual({ plan: 'standard', ladder: 'public' })
+	expect(await referralRow(db, referee.stableUserId)).toMatchObject({
+		status: 'rewarded',
+		reward_invoice_id: 'in_first',
+	})
+
+	expect(
+		await rewardReferralForPaidInvoice({
+			db,
+			refereeStableUserId: referee.stableUserId,
+			invoiceId: 'in_second_cycle',
+			invoiceQualifies: true,
+			now,
+		}),
+	).toEqual({ outcome: 'already_rewarded' })
+	expect(await creditExpiry(db, referrer.stableUserId)).toBe(
+		firstCreditExpiresAt,
+	)
+	expect(await creditExpiry(db, referee.stableUserId)).toBe(
+		firstCreditExpiresAt,
+	)
+
+	const secondReferee = await insertUser(db, {
+		email: 'referee-two@example.com',
+		username: 'refereetwo',
+	})
+	expect(
+		await attributeReferralAtSignup({
+			db,
+			refereeStableUserId: secondReferee.stableUserId,
+			refereeUsername: 'refereetwo',
+			referralCode: 'referrer',
+			now,
+		}),
+	).toEqual({ outcome: 'attributed' })
+	expect(
+		await rewardReferralForPaidInvoice({
+			db,
+			refereeStableUserId: secondReferee.stableUserId,
+			invoiceId: 'in_second_friend',
+			invoiceQualifies: true,
+			now,
+		}),
+	).toEqual({ outcome: 'rewarded' })
+	expect(await creditExpiry(db, referrer.stableUserId)).toBe(
+		secondCreditExpiresAt,
+	)
+	expect(await creditExpiry(db, secondReferee.stableUserId)).toBe(
+		firstCreditExpiresAt,
+	)
+
+	expect(
+		await rewardReferralForPaidInvoice({
+			db,
+			refereeStableUserId: plusTag.stableUserId,
+			invoiceId: 'in_plus',
+			invoiceQualifies: true,
+			now,
+		}),
+	).toEqual({ outcome: 'rejected', reason: 'same_email' })
+	expect(await referralRow(db, plusTag.stableUserId)).toMatchObject({
+		status: 'rejected',
+		reject_reason: 'same_email',
+	})
+	expect(await creditExpiry(db, plusTag.stableUserId)).toBeNull()
+
+	expect(
+		await rewardReferralForPaidInvoice({
+			db,
+			refereeStableUserId: unverified.stableUserId,
+			invoiceId: 'in_held',
+			invoiceQualifies: true,
+			now,
+		}),
+	).toEqual({ outcome: 'held_unverified' })
+	expect(await referralRow(db, unverified.stableUserId)).toMatchObject({
+		status: 'pending',
+		held_invoice_id: 'in_held',
+	})
+	expect(await creditExpiry(db, unverified.stableUserId)).toBeNull()
+
+	await db
+		.prepare(`UPDATE users SET email_verified_at = ? WHERE stable_user_id = ?`)
+		.bind(now.toISOString(), unverified.stableUserId)
+		.run()
+	expect(
+		await maybeRewardHeldReferralAfterEmailVerified({
+			db,
+			stableUserId: unverified.stableUserId,
+			now,
+		}),
+	).toEqual({ outcome: 'rewarded' })
+	expect(await creditExpiry(db, unverified.stableUserId)).toBe(
+		firstCreditExpiresAt,
+	)
+	expect(await referralRow(db, unverified.stableUserId)).toMatchObject({
+		status: 'rewarded',
+		reward_invoice_id: 'in_held',
+	})
+})

--- a/packages/worker/src/entitlements/referral-program.ts
+++ b/packages/worker/src/entitlements/referral-program.ts
@@ -444,11 +444,17 @@ export async function maybeRewardHeldReferralAfterEmailVerified(input: {
 	let last: ReferralRewardOutcome = { outcome: 'ignored', reason: 'no_pending' }
 	for (const pending of rows) {
 		if (!pending.held_invoice_id) continue
-		const referrerPaidPeriodEndAt = input.resolveReferrerPaidPeriodEnd
-			? await input.resolveReferrerPaidPeriodEnd(
-					pending.referrer_stable_user_id,
-				)
-			: (input.referrerPaidPeriodEndAt ?? null)
+		let referrerPaidPeriodEndAt: string | null
+		try {
+			referrerPaidPeriodEndAt = input.resolveReferrerPaidPeriodEnd
+				? await input.resolveReferrerPaidPeriodEnd(
+						pending.referrer_stable_user_id,
+					)
+				: (input.referrerPaidPeriodEndAt ?? null)
+		} catch (error) {
+			console.warn('referral-held-referrer-period-end-failed', error)
+			continue
+		}
 		last = await rewardReferralForPaidInvoice({
 			db: input.db,
 			refereeStableUserId: pending.referee_stable_user_id,

--- a/packages/worker/src/entitlements/referral-program.ts
+++ b/packages/worker/src/entitlements/referral-program.ts
@@ -140,6 +140,9 @@ export async function attributeReferralAtSignup(input: {
 	referralCode: string | null | undefined
 	now?: Date
 }): Promise<ReferralAttributionOutcome> {
+	if (typeof input.db.prepare !== 'function') {
+		return { outcome: 'ignored', reason: 'missing_code' }
+	}
 	const code = normalizeReferralCode(input.referralCode)
 	if (!code) return { outcome: 'ignored', reason: 'missing_code' }
 	if (code === normalizeReferralCode(input.refereeUsername)) {
@@ -277,6 +280,9 @@ export async function rewardReferralForPaidInvoice(input: {
 	referrerPaidPeriodEndAt?: string | null
 	now?: Date
 }): Promise<ReferralRewardOutcome> {
+	if (typeof input.db.prepare !== 'function') {
+		return { outcome: 'ignored', reason: 'no_pending' }
+	}
 	const now = input.now ?? new Date()
 	const pending = await input.db
 		.prepare(
@@ -360,6 +366,9 @@ export async function maybeRewardHeldReferralAfterEmailVerified(input: {
 	referrerPaidPeriodEndAt?: string | null
 	now?: Date
 }): Promise<ReferralRewardOutcome | { outcome: 'ignored'; reason: 'no_held' }> {
+	if (typeof input.db.prepare !== 'function') {
+		return { outcome: 'ignored', reason: 'no_held' }
+	}
 	const pending = await input.db
 		.prepare(
 			`SELECT id, referrer_stable_user_id, referee_stable_user_id, status,

--- a/packages/worker/src/entitlements/referral-program.ts
+++ b/packages/worker/src/entitlements/referral-program.ts
@@ -1,0 +1,449 @@
+/**
+ * Referral attribution at signup and invoice-gated Standard credit.
+ * Reward is one stacked month for both parties; there is no annual or
+ * lifetime cap on how many a referrer can earn.
+ */
+
+import { utcSqliteTimestamp } from '@kody-internal/shared/date-keys.ts'
+import { computeOverageInvoiceMetadataKey } from '#worker/billing/stripe-client.ts'
+import {
+	addReferralStandardCreditDuration,
+	isReferralStandardCreditActive,
+	laterIsoTimestamp,
+	normalizeEmailForReferralFraud,
+	normalizeReferralCode,
+	referralSharePath,
+	unixSecondsToIso,
+	type ReferralProgramListItem,
+	type ReferralProgramSummary,
+	type ReferralRejectReason,
+} from '#universal/referral-program.ts'
+
+export type ReferralAttributionOutcome =
+	| { outcome: 'attributed' }
+	| { outcome: 'ignored'; reason: 'missing_code' | 'unknown_referrer' | 'self' }
+	| { outcome: 'already_attributed' }
+
+export type ReferralRewardOutcome =
+	| { outcome: 'rewarded' }
+	| { outcome: 'held_unverified' }
+	| { outcome: 'already_rewarded' }
+	| { outcome: 'rejected'; reason: ReferralRejectReason }
+	| { outcome: 'ignored'; reason: 'no_pending' | 'invoice_unqualified' }
+
+type ReferralParty = {
+	stable_user_id: string
+	username: string
+	email: string
+	email_verified_at: string | null
+	stripe_customer_id: string | null
+	account_type: string | null
+	referral_standard_credit_expires_at: string | null
+}
+
+type PendingReferralRow = {
+	id: number
+	referrer_stable_user_id: string
+	referee_stable_user_id: string
+	status: string
+	reward_invoice_id: string | null
+	held_invoice_id: string | null
+	held_period_end_at: string | null
+}
+
+export function isQualifyingPaidReferralInvoice(invoice: {
+	status?: unknown
+	paid?: unknown
+	amount_paid?: unknown
+	billing_reason?: unknown
+	subscription?: unknown
+	metadata?: Record<string, string> | null
+}): boolean {
+	const amountPaid =
+		typeof invoice.amount_paid === 'number' ? invoice.amount_paid : Number.NaN
+	if (!Number.isFinite(amountPaid) || amountPaid <= 0) return false
+	const status = typeof invoice.status === 'string' ? invoice.status.trim() : ''
+	const paid = invoice.paid === true || status === 'paid'
+	if (!paid) return false
+	if (invoice.metadata?.[computeOverageInvoiceMetadataKey] === '1') {
+		return false
+	}
+	const reason =
+		typeof invoice.billing_reason === 'string'
+			? invoice.billing_reason.trim()
+			: ''
+	const hasSubscription =
+		typeof invoice.subscription === 'string' &&
+		invoice.subscription.trim().length > 0
+	if (reason === 'manual' && !hasSubscription) return false
+	if (reason === 'upcoming') return false
+	return true
+}
+
+export function readStripeInvoiceCustomerId(
+	object: Record<string, unknown>,
+): string | null {
+	const customer = object.customer
+	if (typeof customer === 'string' && customer.trim()) return customer.trim()
+	if (customer && typeof customer === 'object' && 'id' in customer) {
+		const id = (customer as { id?: unknown }).id
+		if (typeof id === 'string' && id.trim()) return id.trim()
+	}
+	return null
+}
+
+export function readStripeInvoiceId(
+	object: Record<string, unknown>,
+): string | null {
+	const id = object.id
+	return typeof id === 'string' && id.trim() ? id.trim() : null
+}
+
+export function readStripeInvoicePeriodEndIso(
+	object: Record<string, unknown>,
+): string | null {
+	const lines = object.lines
+	if (lines && typeof lines === 'object' && 'data' in lines) {
+		const data = (lines as { data?: unknown }).data
+		if (Array.isArray(data)) {
+			for (const line of data) {
+				if (!line || typeof line !== 'object') continue
+				const period = (line as { period?: { end?: unknown } }).period
+				const iso = unixSecondsToIso(period?.end)
+				if (iso) return iso
+			}
+		}
+	}
+	return null
+}
+
+export function readStripeInvoiceSubscriptionId(
+	object: Record<string, unknown>,
+): string | null {
+	const top = object.subscription
+	if (typeof top === 'string' && top.trim()) return top.trim()
+	const parent = object.parent
+	if (parent && typeof parent === 'object') {
+		const details = (
+			parent as { subscription_details?: { subscription?: unknown } }
+		).subscription_details
+		const nested = details?.subscription
+		if (typeof nested === 'string' && nested.trim()) return nested.trim()
+	}
+	return null
+}
+
+export async function attributeReferralAtSignup(input: {
+	db: D1Database
+	refereeStableUserId: string
+	refereeUsername: string
+	referralCode: string | null | undefined
+	now?: Date
+}): Promise<ReferralAttributionOutcome> {
+	const code = normalizeReferralCode(input.referralCode)
+	if (!code) return { outcome: 'ignored', reason: 'missing_code' }
+	if (code === normalizeReferralCode(input.refereeUsername)) {
+		return { outcome: 'ignored', reason: 'self' }
+	}
+	const referrer = await input.db
+		.prepare(
+			`SELECT stable_user_id, account_type
+			 FROM users
+			 WHERE username = ?`,
+		)
+		.bind(code)
+		.first<{ stable_user_id: string; account_type: string | null }>()
+	if (!referrer?.stable_user_id) {
+		return { outcome: 'ignored', reason: 'unknown_referrer' }
+	}
+	if (referrer.stable_user_id === input.refereeStableUserId) {
+		return { outcome: 'ignored', reason: 'self' }
+	}
+	if (referrer.account_type === 'platform') {
+		return { outcome: 'ignored', reason: 'unknown_referrer' }
+	}
+	const now = input.now ?? new Date()
+	try {
+		await input.db
+			.prepare(
+				`INSERT INTO referrals (
+					referrer_stable_user_id, referee_stable_user_id, created_at, status
+				) VALUES (?, ?, ?, 'pending')`,
+			)
+			.bind(
+				referrer.stable_user_id,
+				input.refereeStableUserId,
+				now.toISOString(),
+			)
+			.run()
+		return { outcome: 'attributed' }
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error)
+		if (/UNIQUE constraint failed/i.test(message)) {
+			return { outcome: 'already_attributed' }
+		}
+		throw error
+	}
+}
+
+async function loadParty(
+	db: D1Database,
+	stableUserId: string,
+): Promise<ReferralParty | null> {
+	return db
+		.prepare(
+			`SELECT stable_user_id, username, email, email_verified_at,
+			        stripe_customer_id, account_type,
+			        referral_standard_credit_expires_at
+			 FROM users
+			 WHERE stable_user_id = ?`,
+		)
+		.bind(stableUserId)
+		.first<ReferralParty>()
+}
+
+function rejectReasonForParties(
+	referrer: ReferralParty,
+	referee: ReferralParty,
+): ReferralRejectReason | null {
+	if (referrer.stable_user_id === referee.stable_user_id) {
+		return 'self_referral'
+	}
+	if (referrer.account_type === 'platform') {
+		return 'platform_referrer'
+	}
+	if (
+		normalizeEmailForReferralFraud(referrer.email) ===
+		normalizeEmailForReferralFraud(referee.email)
+	) {
+		return 'same_email'
+	}
+	const referrerCustomer = referrer.stripe_customer_id?.trim() || null
+	const refereeCustomer = referee.stripe_customer_id?.trim() || null
+	if (
+		referrerCustomer &&
+		refereeCustomer &&
+		referrerCustomer === refereeCustomer
+	) {
+		return 'same_stripe_customer'
+	}
+	return null
+}
+
+async function markRejected(
+	db: D1Database,
+	referralId: number,
+	reason: ReferralRejectReason,
+) {
+	await db
+		.prepare(
+			`UPDATE referrals
+			 SET status = 'rejected', reject_reason = ?, rewarded_at = NULL
+			 WHERE id = ? AND status = 'pending'`,
+		)
+		.bind(reason, referralId)
+		.run()
+}
+
+async function grantStackedCredit(input: {
+	db: D1Database
+	stableUserId: string
+	currentExpiresAt: string | null
+	paidPeriodEndAt: string | null
+	now: Date
+}) {
+	const expiresAt = addReferralStandardCreditDuration({
+		now: input.now,
+		currentExpiresAt: input.currentExpiresAt,
+		paidPeriodEndAt: input.paidPeriodEndAt,
+	}).toISOString()
+	await input.db
+		.prepare(
+			`UPDATE users
+			 SET referral_standard_credit_expires_at = ?,
+			     updated_at = ?
+			 WHERE stable_user_id = ?`,
+		)
+		.bind(expiresAt, utcSqliteTimestamp(input.now), input.stableUserId)
+		.run()
+}
+
+export async function rewardReferralForPaidInvoice(input: {
+	db: D1Database
+	refereeStableUserId: string
+	invoiceId: string
+	invoiceQualifies: boolean
+	paidPeriodEndAt?: string | null
+	referrerPaidPeriodEndAt?: string | null
+	now?: Date
+}): Promise<ReferralRewardOutcome> {
+	const now = input.now ?? new Date()
+	const pending = await input.db
+		.prepare(
+			`SELECT id, referrer_stable_user_id, referee_stable_user_id, status,
+			        reward_invoice_id, held_invoice_id, held_period_end_at
+			 FROM referrals
+			 WHERE referee_stable_user_id = ?`,
+		)
+		.bind(input.refereeStableUserId)
+		.first<PendingReferralRow>()
+	if (!pending) return { outcome: 'ignored', reason: 'no_pending' }
+	if (pending.status === 'rewarded') return { outcome: 'already_rewarded' }
+	if (pending.status !== 'pending') {
+		return { outcome: 'ignored', reason: 'no_pending' }
+	}
+	if (!input.invoiceQualifies) {
+		return { outcome: 'ignored', reason: 'invoice_unqualified' }
+	}
+
+	const [referrer, referee] = await Promise.all([
+		loadParty(input.db, pending.referrer_stable_user_id),
+		loadParty(input.db, pending.referee_stable_user_id),
+	])
+	if (!referrer || !referee) return { outcome: 'ignored', reason: 'no_pending' }
+
+	const reject = rejectReasonForParties(referrer, referee)
+	if (reject) {
+		await markRejected(input.db, pending.id, reject)
+		return { outcome: 'rejected', reason: reject }
+	}
+
+	if (!referrer.email_verified_at || !referee.email_verified_at) {
+		await input.db
+			.prepare(
+				`UPDATE referrals
+				 SET held_invoice_id = COALESCE(held_invoice_id, ?),
+				     held_period_end_at = COALESCE(held_period_end_at, ?)
+				 WHERE id = ? AND status = 'pending'`,
+			)
+			.bind(input.invoiceId, input.paidPeriodEndAt ?? null, pending.id)
+			.run()
+		return { outcome: 'held_unverified' }
+	}
+
+	const claimed = await input.db
+		.prepare(
+			`UPDATE referrals
+			 SET status = 'rewarded',
+			     rewarded_at = ?,
+			     reward_invoice_id = ?,
+			     held_invoice_id = NULL,
+			     held_period_end_at = NULL
+			 WHERE id = ? AND status = 'pending'`,
+		)
+		.bind(now.toISOString(), input.invoiceId, pending.id)
+		.run()
+	if ((claimed.meta.changes ?? 0) === 0) {
+		return { outcome: 'already_rewarded' }
+	}
+
+	await grantStackedCredit({
+		db: input.db,
+		stableUserId: referrer.stable_user_id,
+		currentExpiresAt: referrer.referral_standard_credit_expires_at,
+		paidPeriodEndAt: input.referrerPaidPeriodEndAt ?? null,
+		now,
+	})
+	await grantStackedCredit({
+		db: input.db,
+		stableUserId: referee.stable_user_id,
+		currentExpiresAt: referee.referral_standard_credit_expires_at,
+		paidPeriodEndAt: input.paidPeriodEndAt ?? null,
+		now,
+	})
+	return { outcome: 'rewarded' }
+}
+
+export async function maybeRewardHeldReferralAfterEmailVerified(input: {
+	db: D1Database
+	stableUserId: string
+	referrerPaidPeriodEndAt?: string | null
+	now?: Date
+}): Promise<ReferralRewardOutcome | { outcome: 'ignored'; reason: 'no_held' }> {
+	const pending = await input.db
+		.prepare(
+			`SELECT id, referrer_stable_user_id, referee_stable_user_id, status,
+			        reward_invoice_id, held_invoice_id, held_period_end_at
+			 FROM referrals
+			 WHERE (referee_stable_user_id = ? OR referrer_stable_user_id = ?)
+			   AND status = 'pending'
+			   AND held_invoice_id IS NOT NULL`,
+		)
+		.bind(input.stableUserId, input.stableUserId)
+		.first<PendingReferralRow>()
+	if (!pending?.held_invoice_id) {
+		return { outcome: 'ignored', reason: 'no_held' }
+	}
+	return rewardReferralForPaidInvoice({
+		db: input.db,
+		refereeStableUserId: pending.referee_stable_user_id,
+		invoiceId: pending.held_invoice_id,
+		invoiceQualifies: true,
+		paidPeriodEndAt: pending.held_period_end_at,
+		referrerPaidPeriodEndAt: input.referrerPaidPeriodEndAt,
+		now: input.now,
+	})
+}
+
+export async function loadReferralProgramSummary(input: {
+	db: D1Database
+	stableUserId: string
+	username: string
+	origin: string
+	now?: Date
+}): Promise<ReferralProgramSummary> {
+	const now = input.now ?? new Date()
+	const creditRow = await input.db
+		.prepare(
+			`SELECT referral_standard_credit_expires_at
+			 FROM users
+			 WHERE stable_user_id = ?`,
+		)
+		.bind(input.stableUserId)
+		.first<{ referral_standard_credit_expires_at: string | null }>()
+	const creditExpiresAt =
+		creditRow?.referral_standard_credit_expires_at?.trim() || null
+	const rows = await input.db
+		.prepare(
+			`SELECT r.status, r.created_at, r.rewarded_at, u.username AS referee_username
+			 FROM referrals r
+			 LEFT JOIN users u ON u.stable_user_id = r.referee_stable_user_id
+			 WHERE r.referrer_stable_user_id = ?
+			   AND r.status IN ('pending', 'rewarded')
+			 ORDER BY r.created_at DESC
+			 LIMIT 50`,
+		)
+		.bind(input.stableUserId)
+		.all<{
+			status: string
+			created_at: string
+			rewarded_at: string | null
+			referee_username: string | null
+		}>()
+	const referrals: Array<ReferralProgramListItem> = (rows.results ?? []).map(
+		(row) => ({
+			refereeUsername: row.referee_username,
+			status: row.status === 'rewarded' ? 'rewarded' : 'pending',
+			createdAt: row.created_at,
+			rewardedAt: row.rewarded_at,
+		}),
+	)
+	const sharePath = referralSharePath(input.username)
+	return {
+		sharePath,
+		shareUrl: new URL(sharePath, input.origin).toString(),
+		rewardedCount: referrals.filter((item) => item.status === 'rewarded')
+			.length,
+		pendingCount: referrals.filter((item) => item.status === 'pending').length,
+		creditExpiresAt,
+		creditActive: isReferralStandardCreditActive(creditExpiresAt, now),
+		referrals,
+	}
+}
+
+export function laterStandardOverlayExpiry(
+	giftExpiresAt: string | null | undefined,
+	referralExpiresAt: string | null | undefined,
+): string | null {
+	return laterIsoTimestamp(giftExpiresAt, referralExpiresAt)
+}

--- a/packages/worker/src/entitlements/referral-program.ts
+++ b/packages/worker/src/entitlements/referral-program.ts
@@ -104,6 +104,7 @@ export function readStripeInvoicePeriodEndIso(
 	object: Record<string, unknown>,
 ): string | null {
 	const lines = object.lines
+	const ends: Array<string> = []
 	if (lines && typeof lines === 'object' && 'data' in lines) {
 		const data = (lines as { data?: unknown }).data
 		if (Array.isArray(data)) {
@@ -111,11 +112,11 @@ export function readStripeInvoicePeriodEndIso(
 				if (!line || typeof line !== 'object') continue
 				const period = (line as { period?: { end?: unknown } }).period
 				const iso = unixSecondsToIso(period?.end)
-				if (iso) return iso
+				if (iso) ends.push(iso)
 			}
 		}
 	}
-	return null
+	return laterIsoTimestamp(...ends)
 }
 
 export function readStripeInvoiceSubscriptionId(

--- a/packages/worker/src/entitlements/referral-program.ts
+++ b/packages/worker/src/entitlements/referral-program.ts
@@ -7,12 +7,12 @@
 import { utcSqliteTimestamp } from '@kody-internal/shared/date-keys.ts'
 import { computeOverageInvoiceMetadataKey } from '#worker/billing/stripe-client.ts'
 import {
-	addReferralStandardCreditDuration,
 	isReferralStandardCreditActive,
 	laterIsoTimestamp,
 	normalizeEmailForReferralFraud,
 	normalizeReferralCode,
 	referralSharePath,
+	referralStandardCreditDurationMs,
 	unixSecondsToIso,
 	type ReferralProgramListItem,
 	type ReferralProgramSummary,
@@ -49,6 +49,7 @@ type PendingReferralRow = {
 	reward_invoice_id: string | null
 	held_invoice_id: string | null
 	held_period_end_at: string | null
+	credits_granted_at: string | null
 }
 
 export function isQualifyingPaidReferralInvoice(invoice: {
@@ -248,27 +249,44 @@ async function markRejected(
 		.run()
 }
 
-async function grantStackedCredit(input: {
+function stackReferralCreditStatement(input: {
 	db: D1Database
 	stableUserId: string
-	currentExpiresAt: string | null
 	paidPeriodEndAt: string | null
+	referralId: number
+	invoiceId: string
 	now: Date
 }) {
-	const expiresAt = addReferralStandardCreditDuration({
-		now: input.now,
-		currentExpiresAt: input.currentExpiresAt,
-		paidPeriodEndAt: input.paidPeriodEndAt,
-	}).toISOString()
-	await input.db
+	return input.db
 		.prepare(
 			`UPDATE users
-			 SET referral_standard_credit_expires_at = ?,
+			 SET referral_standard_credit_expires_at = strftime(
+			       '%Y-%m-%dT%H:%M:%fZ',
+			       max(
+			         strftime('%s', ?),
+			         COALESCE(strftime('%s', referral_standard_credit_expires_at), 0),
+			         COALESCE(strftime('%s', ?), 0)
+			       ) + ?,
+			       'unixepoch'
+			     ),
 			     updated_at = ?
-			 WHERE stable_user_id = ?`,
+			 WHERE stable_user_id = ?
+			   AND EXISTS (
+			     SELECT 1 FROM referrals
+			     WHERE id = ?
+			       AND reward_invoice_id = ?
+			       AND credits_granted_at IS NULL
+			   )`,
 		)
-		.bind(expiresAt, utcSqliteTimestamp(input.now), input.stableUserId)
-		.run()
+		.bind(
+			input.now.toISOString(),
+			input.paidPeriodEndAt ?? '1970-01-01T00:00:00.000Z',
+			referralStandardCreditDurationMs / 1000,
+			utcSqliteTimestamp(input.now),
+			input.stableUserId,
+			input.referralId,
+			input.invoiceId,
+		)
 }
 
 export async function rewardReferralForPaidInvoice(input: {
@@ -287,15 +305,18 @@ export async function rewardReferralForPaidInvoice(input: {
 	const pending = await input.db
 		.prepare(
 			`SELECT id, referrer_stable_user_id, referee_stable_user_id, status,
-			        reward_invoice_id, held_invoice_id, held_period_end_at
+			        reward_invoice_id, held_invoice_id, held_period_end_at,
+			        credits_granted_at
 			 FROM referrals
 			 WHERE referee_stable_user_id = ?`,
 		)
 		.bind(input.refereeStableUserId)
 		.first<PendingReferralRow>()
 	if (!pending) return { outcome: 'ignored', reason: 'no_pending' }
-	if (pending.status === 'rewarded') return { outcome: 'already_rewarded' }
-	if (pending.status !== 'pending') {
+	if (pending.status === 'rewarded' && pending.credits_granted_at) {
+		return { outcome: 'already_rewarded' }
+	}
+	if (pending.status !== 'pending' && pending.status !== 'rewarded') {
 		return { outcome: 'ignored', reason: 'no_pending' }
 	}
 	if (!input.invoiceQualifies) {
@@ -327,36 +348,66 @@ export async function rewardReferralForPaidInvoice(input: {
 		return { outcome: 'held_unverified' }
 	}
 
-	const claimed = await input.db
+	const rewardedAt = now.toISOString()
+	const invoiceId =
+		pending.status === 'rewarded'
+			? (pending.reward_invoice_id ?? input.invoiceId)
+			: input.invoiceId
+	await input.db.batch([
+		input.db
+			.prepare(
+				`UPDATE referrals
+				 SET status = 'rewarded',
+				     rewarded_at = COALESCE(rewarded_at, ?),
+				     reward_invoice_id = COALESCE(reward_invoice_id, ?),
+				     held_invoice_id = NULL,
+				     held_period_end_at = NULL
+				 WHERE id = ? AND (status = 'pending' OR credits_granted_at IS NULL)`,
+			)
+			.bind(rewardedAt, invoiceId, pending.id),
+		stackReferralCreditStatement({
+			db: input.db,
+			stableUserId: referrer.stable_user_id,
+			paidPeriodEndAt: input.referrerPaidPeriodEndAt ?? null,
+			referralId: pending.id,
+			invoiceId,
+			now,
+		}),
+		stackReferralCreditStatement({
+			db: input.db,
+			stableUserId: referee.stable_user_id,
+			paidPeriodEndAt: input.paidPeriodEndAt ?? null,
+			referralId: pending.id,
+			invoiceId,
+			now,
+		}),
+		input.db
+			.prepare(
+				`UPDATE referrals
+				 SET credits_granted_at = ?
+				 WHERE id = ? AND credits_granted_at IS NULL`,
+			)
+			.bind(rewardedAt, pending.id),
+	])
+	const granted = await input.db
 		.prepare(
-			`UPDATE referrals
-			 SET status = 'rewarded',
-			     rewarded_at = ?,
-			     reward_invoice_id = ?,
-			     held_invoice_id = NULL,
-			     held_period_end_at = NULL
-			 WHERE id = ? AND status = 'pending'`,
+			`SELECT credits_granted_at, reward_invoice_id
+			 FROM referrals WHERE id = ?`,
 		)
-		.bind(now.toISOString(), input.invoiceId, pending.id)
-		.run()
-	if ((claimed.meta.changes ?? 0) === 0) {
+		.bind(pending.id)
+		.first<{
+			credits_granted_at: string | null
+			reward_invoice_id: string | null
+		}>()
+	if (
+		granted?.credits_granted_at &&
+		granted.reward_invoice_id !== input.invoiceId
+	) {
 		return { outcome: 'already_rewarded' }
 	}
-
-	await grantStackedCredit({
-		db: input.db,
-		stableUserId: referrer.stable_user_id,
-		currentExpiresAt: referrer.referral_standard_credit_expires_at,
-		paidPeriodEndAt: input.referrerPaidPeriodEndAt ?? null,
-		now,
-	})
-	await grantStackedCredit({
-		db: input.db,
-		stableUserId: referee.stable_user_id,
-		currentExpiresAt: referee.referral_standard_credit_expires_at,
-		paidPeriodEndAt: input.paidPeriodEndAt ?? null,
-		now,
-	})
+	if (!granted?.credits_granted_at) {
+		return { outcome: 'already_rewarded' }
+	}
 	return { outcome: 'rewarded' }
 }
 
@@ -364,34 +415,50 @@ export async function maybeRewardHeldReferralAfterEmailVerified(input: {
 	db: D1Database
 	stableUserId: string
 	referrerPaidPeriodEndAt?: string | null
+	resolveReferrerPaidPeriodEnd?: (
+		referrerStableUserId: string,
+	) => Promise<string | null>
 	now?: Date
 }): Promise<ReferralRewardOutcome | { outcome: 'ignored'; reason: 'no_held' }> {
 	if (typeof input.db.prepare !== 'function') {
 		return { outcome: 'ignored', reason: 'no_held' }
 	}
-	const pending = await input.db
+	const held = await input.db
 		.prepare(
 			`SELECT id, referrer_stable_user_id, referee_stable_user_id, status,
-			        reward_invoice_id, held_invoice_id, held_period_end_at
+			        reward_invoice_id, held_invoice_id, held_period_end_at,
+			        credits_granted_at
 			 FROM referrals
 			 WHERE (referee_stable_user_id = ? OR referrer_stable_user_id = ?)
 			   AND status = 'pending'
-			   AND held_invoice_id IS NOT NULL`,
+			   AND held_invoice_id IS NOT NULL
+			 ORDER BY created_at ASC`,
 		)
 		.bind(input.stableUserId, input.stableUserId)
-		.first<PendingReferralRow>()
-	if (!pending?.held_invoice_id) {
+		.all<PendingReferralRow>()
+	const rows = held.results ?? []
+	if (rows.length === 0) {
 		return { outcome: 'ignored', reason: 'no_held' }
 	}
-	return rewardReferralForPaidInvoice({
-		db: input.db,
-		refereeStableUserId: pending.referee_stable_user_id,
-		invoiceId: pending.held_invoice_id,
-		invoiceQualifies: true,
-		paidPeriodEndAt: pending.held_period_end_at,
-		referrerPaidPeriodEndAt: input.referrerPaidPeriodEndAt,
-		now: input.now,
-	})
+	let last: ReferralRewardOutcome = { outcome: 'ignored', reason: 'no_pending' }
+	for (const pending of rows) {
+		if (!pending.held_invoice_id) continue
+		const referrerPaidPeriodEndAt = input.resolveReferrerPaidPeriodEnd
+			? await input.resolveReferrerPaidPeriodEnd(
+					pending.referrer_stable_user_id,
+				)
+			: (input.referrerPaidPeriodEndAt ?? null)
+		last = await rewardReferralForPaidInvoice({
+			db: input.db,
+			refereeStableUserId: pending.referee_stable_user_id,
+			invoiceId: pending.held_invoice_id,
+			invoiceQualifies: true,
+			paidPeriodEndAt: pending.held_period_end_at,
+			referrerPaidPeriodEndAt,
+			now: input.now,
+		})
+	}
+	return last
 }
 
 export async function loadReferralProgramSummary(input: {
@@ -412,23 +479,35 @@ export async function loadReferralProgramSummary(input: {
 		.first<{ referral_standard_credit_expires_at: string | null }>()
 	const creditExpiresAt =
 		creditRow?.referral_standard_credit_expires_at?.trim() || null
-	const rows = await input.db
-		.prepare(
-			`SELECT r.status, r.created_at, r.rewarded_at, u.username AS referee_username
-			 FROM referrals r
-			 LEFT JOIN users u ON u.stable_user_id = r.referee_stable_user_id
-			 WHERE r.referrer_stable_user_id = ?
-			   AND r.status IN ('pending', 'rewarded')
-			 ORDER BY r.created_at DESC
-			 LIMIT 50`,
-		)
-		.bind(input.stableUserId)
-		.all<{
-			status: string
-			created_at: string
-			rewarded_at: string | null
-			referee_username: string | null
-		}>()
+	const [rows, counts] = await Promise.all([
+		input.db
+			.prepare(
+				`SELECT r.status, r.created_at, r.rewarded_at, u.username AS referee_username
+				 FROM referrals r
+				 LEFT JOIN users u ON u.stable_user_id = r.referee_stable_user_id
+				 WHERE r.referrer_stable_user_id = ?
+				   AND r.status IN ('pending', 'rewarded')
+				 ORDER BY r.created_at DESC
+				 LIMIT 50`,
+			)
+			.bind(input.stableUserId)
+			.all<{
+				status: string
+				created_at: string
+				rewarded_at: string | null
+				referee_username: string | null
+			}>(),
+		input.db
+			.prepare(
+				`SELECT status, COUNT(*) AS total
+				 FROM referrals
+				 WHERE referrer_stable_user_id = ?
+				   AND status IN ('pending', 'rewarded')
+				 GROUP BY status`,
+			)
+			.bind(input.stableUserId)
+			.all<{ status: string; total: number }>(),
+	])
 	const referrals: Array<ReferralProgramListItem> = (rows.results ?? []).map(
 		(row) => ({
 			refereeUsername: row.referee_username,
@@ -437,13 +516,17 @@ export async function loadReferralProgramSummary(input: {
 			rewardedAt: row.rewarded_at,
 		}),
 	)
+	const countFor = (status: string) => {
+		const total = counts.results?.find((row) => row.status === status)?.total
+		const parsed = typeof total === 'number' ? total : Number(total)
+		return Number.isFinite(parsed) ? parsed : 0
+	}
 	const sharePath = referralSharePath(input.username)
 	return {
 		sharePath,
 		shareUrl: new URL(sharePath, input.origin).toString(),
-		rewardedCount: referrals.filter((item) => item.status === 'rewarded')
-			.length,
-		pendingCount: referrals.filter((item) => item.status === 'pending').length,
+		rewardedCount: countFor('rewarded'),
+		pendingCount: countFor('pending'),
 		creditExpiresAt,
 		creditActive: isReferralStandardCreditActive(creditExpiresAt, now),
 		referrals,

--- a/packages/worker/src/entitlements/service.ts
+++ b/packages/worker/src/entitlements/service.ts
@@ -8,6 +8,7 @@ import {
 	type PlanName,
 	type UserEntitlement,
 } from '#universal/plans.ts'
+import { laterIsoTimestamp } from '#universal/referral-program.ts'
 import { resolveEffectivePlanWithSecondAgentGift } from '#universal/second-agent-standard-gift.ts'
 import { countInternalUserEmailMessages } from '#worker/email/mailbox-internal-read.ts'
 import { jobsData } from '#worker/jobs/jobs-data.ts'
@@ -52,10 +53,11 @@ const publicFreeEntitlement: UserEntitlement = {
  * invalid stable ids still fail closed to public `free` without touching D1.
  *
  * Effective plan = f(manual users.plan, users.stripe_plan, unexpired
- * second-agent Standard gift): the higher-ranked of the manual grant and
- * Stripe subscription plan, then a 14-day public Standard overlay when the
- * gift is active and the base plan is still free. `legacy` ceilings apply
- * only while that marker stays set and paid access remains continuous.
+ * Standard overlays): the higher-ranked of the manual grant and Stripe
+ * subscription plan, then a public Standard overlay when the later of the
+ * second-agent gift and stacked referral credit is still active and the
+ * base plan is still free. `legacy` ceilings apply only while that marker
+ * stays set and paid access remains continuous.
  */
 export async function getUserEntitlement(
 	db: D1Database,
@@ -67,8 +69,8 @@ export async function getUserEntitlement(
 	const row = await db
 		.prepare(
 			email
-				? `SELECT plan, stripe_plan, entitlement_ladder, second_agent_standard_gift_expires_at FROM users WHERE email = ? AND stable_user_id = ?`
-				: `SELECT plan, stripe_plan, entitlement_ladder, second_agent_standard_gift_expires_at FROM users WHERE stable_user_id = ?`,
+				? `SELECT plan, stripe_plan, entitlement_ladder, second_agent_standard_gift_expires_at, referral_standard_credit_expires_at FROM users WHERE email = ? AND stable_user_id = ?`
+				: `SELECT plan, stripe_plan, entitlement_ladder, second_agent_standard_gift_expires_at, referral_standard_credit_expires_at FROM users WHERE stable_user_id = ?`,
 		)
 		.bind(...(email ? [email, input.userId] : [input.userId]))
 		.first<{
@@ -76,12 +78,16 @@ export async function getUserEntitlement(
 			stripe_plan: string | null
 			entitlement_ladder: string | null
 			second_agent_standard_gift_expires_at: string | null
+			referral_standard_credit_expires_at: string | null
 		}>()
 	if (!row) return publicFreeEntitlement
 	const plan = resolveEffectivePlanWithSecondAgentGift(
 		parseStoredPlanName(row.plan),
 		row.stripe_plan,
-		row.second_agent_standard_gift_expires_at,
+		laterIsoTimestamp(
+			row.second_agent_standard_gift_expires_at,
+			row.referral_standard_credit_expires_at,
+		),
 	)
 	return {
 		plan,

--- a/packages/worker/src/entitlements/test-schema.ts
+++ b/packages/worker/src/entitlements/test-schema.ts
@@ -8,7 +8,8 @@ import { ensureUsersTestSchema } from '#worker/users-test-schema.ts'
  * schema. Daily counters live only in UserMeter.
  *
  * Also provisions `user_storage_buckets` because entitlement suites that touch
- * StorageRunner writes register ownership through that table.
+ * StorageRunner writes register ownership through that table, and `referrals`
+ * for the invoice-gated Standard credit program.
  */
 export async function ensureEntitlementTestSchema(db: D1Database) {
 	await ensureUsersTestSchema({
@@ -46,4 +47,43 @@ export async function ensureEntitlementTestSchema(db: D1Database) {
 		)
 		.run()
 	await ensureUserStorageBucketsTestSchema(db)
+	await ensureReferralProgramTestSchema(db)
+}
+
+export async function ensureReferralProgramTestSchema(db: D1Database) {
+	await db
+		.prepare(
+			`CREATE TABLE IF NOT EXISTS referrals (
+	id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+	referrer_stable_user_id TEXT NOT NULL,
+	referee_stable_user_id TEXT NOT NULL,
+	created_at TEXT NOT NULL,
+	status TEXT NOT NULL DEFAULT 'pending',
+	rewarded_at TEXT,
+	reward_invoice_id TEXT,
+	reject_reason TEXT,
+	held_invoice_id TEXT,
+	held_period_end_at TEXT
+)`,
+		)
+		.run()
+	await db
+		.prepare(
+			`CREATE UNIQUE INDEX IF NOT EXISTS idx_referrals_referee
+			 ON referrals(referee_stable_user_id)`,
+		)
+		.run()
+	await db
+		.prepare(
+			`CREATE INDEX IF NOT EXISTS idx_referrals_referrer
+			 ON referrals(referrer_stable_user_id)`,
+		)
+		.run()
+	await db
+		.prepare(
+			`CREATE UNIQUE INDEX IF NOT EXISTS idx_referrals_reward_invoice
+			 ON referrals(reward_invoice_id)
+			 WHERE reward_invoice_id IS NOT NULL`,
+		)
+		.run()
 }

--- a/packages/worker/src/entitlements/test-schema.ts
+++ b/packages/worker/src/entitlements/test-schema.ts
@@ -16,6 +16,7 @@ export async function ensureEntitlementTestSchema(db: D1Database) {
 		db,
 		columns: [
 			'email_verified_at',
+			'account_type',
 			'stripe_customer_id',
 			'stripe_plan',
 			'stripe_price_id',

--- a/packages/worker/src/entitlements/test-schema.ts
+++ b/packages/worker/src/entitlements/test-schema.ts
@@ -64,7 +64,8 @@ export async function ensureReferralProgramTestSchema(db: D1Database) {
 	reward_invoice_id TEXT,
 	reject_reason TEXT,
 	held_invoice_id TEXT,
-	held_period_end_at TEXT
+	held_period_end_at TEXT,
+	credits_granted_at TEXT
 )`,
 		)
 		.run()

--- a/packages/worker/src/identity/user-lifecycle-subscription-event.node.test.ts
+++ b/packages/worker/src/identity/user-lifecycle-subscription-event.node.test.ts
@@ -57,6 +57,7 @@ test('user lifecycle event builders keep a metadata-only identity snapshot', () 
 				utmTerm: null,
 				landingPath: '/signup',
 				referrer: null,
+				referralCode: null,
 			},
 		}),
 	).toEqual({

--- a/packages/worker/src/identity/user-lifecycle-subscription-event.node.test.ts
+++ b/packages/worker/src/identity/user-lifecycle-subscription-event.node.test.ts
@@ -57,7 +57,6 @@ test('user lifecycle event builders keep a metadata-only identity snapshot', () 
 				utmTerm: null,
 				landingPath: '/signup',
 				referrer: null,
-				referralCode: null,
 			},
 		}),
 	).toEqual({

--- a/packages/worker/src/users-test-schema.ts
+++ b/packages/worker/src/users-test-schema.ts
@@ -97,6 +97,7 @@ const alwaysAdditiveColumns: Record<string, UsersColumnDefinition> = {
 	last_active_at: { create: 'TEXT' },
 	second_agent_standard_gift_granted_at: { create: 'TEXT' },
 	second_agent_standard_gift_expires_at: { create: 'TEXT' },
+	referral_standard_credit_expires_at: { create: 'TEXT' },
 }
 
 /**

--- a/packages/worker/universal/first-touch-attribution.node.test.ts
+++ b/packages/worker/universal/first-touch-attribution.node.test.ts
@@ -1,8 +1,10 @@
 import { expect, test } from 'vitest'
 import {
 	appendAttributionQueryParams,
+	emptyFirstTouchAttribution,
 	firstTouchAttributionToUserColumns,
 	hasFirstTouchAttribution,
+	mergeReferralCodeIntoFirstTouch,
 	parseFirstTouchAttribution,
 	serializeFirstTouchAttributionForTransport,
 } from './first-touch-attribution.ts'
@@ -100,4 +102,21 @@ test('first-touch attribution parses query and body, rejects unsafe paths, and s
 	const refParams = new URLSearchParams()
 	appendAttributionQueryParams(refParams, fromRef)
 	expect(refParams.get('ref')).toBe('kentcdodds')
+
+	const homepageFirstTouch = parseFirstTouchAttribution({
+		landingPath: '/',
+	})
+	expect(mergeReferralCodeIntoFirstTouch(homepageFirstTouch, fromRef)).toEqual({
+		...homepageFirstTouch,
+		referralCode: 'kentcdodds',
+	})
+	expect(
+		mergeReferralCodeIntoFirstTouch(fromRef, {
+			...emptyFirstTouchAttribution,
+			referralCode: 'ada',
+		}),
+	).toEqual(fromRef)
+	expect(
+		mergeReferralCodeIntoFirstTouch(homepageFirstTouch, homepageFirstTouch),
+	).toBe(homepageFirstTouch)
 })

--- a/packages/worker/universal/first-touch-attribution.node.test.ts
+++ b/packages/worker/universal/first-touch-attribution.node.test.ts
@@ -23,6 +23,7 @@ test('first-touch attribution parses query and body, rejects unsafe paths, and s
 		utmTerm: 'kody',
 		landingPath: '/signup',
 		referrer: 'https://youtube.com/watch?v=1',
+		referralCode: null,
 	})
 
 	expect(
@@ -42,6 +43,7 @@ test('first-touch attribution parses query and body, rejects unsafe paths, and s
 		utmTerm: null,
 		landingPath: '/signup',
 		referrer: null,
+		referralCode: null,
 	})
 
 	expect(
@@ -57,6 +59,7 @@ test('first-touch attribution parses query and body, rejects unsafe paths, and s
 		utmTerm: null,
 		landingPath: null,
 		referrer: null,
+		referralCode: null,
 	})
 
 	const attribution = parseFirstTouchAttribution({
@@ -83,4 +86,18 @@ test('first-touch attribution parses query and body, rejects unsafe paths, and s
 	expect(params.get('utm_source')).toBe('youtube')
 	expect(params.get('utm_medium')).toBe('video')
 	expect(params.get('landing_path')).toBe('/signup')
+
+	const fromRef = parseFirstTouchAttribution({
+		searchParams: new URLSearchParams('ref=KentCDodds'),
+		landingPath: '/signup',
+	})
+	expect(fromRef.referralCode).toBe('kentcdodds')
+	expect(hasFirstTouchAttribution(fromRef)).toBe(true)
+	expect(serializeFirstTouchAttributionForTransport(fromRef)).toEqual({
+		landingPath: '/signup',
+		referralCode: 'kentcdodds',
+	})
+	const refParams = new URLSearchParams()
+	appendAttributionQueryParams(refParams, fromRef)
+	expect(refParams.get('ref')).toBe('kentcdodds')
 })

--- a/packages/worker/universal/first-touch-attribution.node.test.ts
+++ b/packages/worker/universal/first-touch-attribution.node.test.ts
@@ -1,10 +1,8 @@
 import { expect, test } from 'vitest'
 import {
 	appendAttributionQueryParams,
-	emptyFirstTouchAttribution,
 	firstTouchAttributionToUserColumns,
 	hasFirstTouchAttribution,
-	mergeReferralCodeIntoFirstTouch,
 	parseFirstTouchAttribution,
 	serializeFirstTouchAttributionForTransport,
 } from './first-touch-attribution.ts'
@@ -25,7 +23,6 @@ test('first-touch attribution parses query and body, rejects unsafe paths, and s
 		utmTerm: 'kody',
 		landingPath: '/signup',
 		referrer: 'https://youtube.com/watch?v=1',
-		referralCode: null,
 	})
 
 	expect(
@@ -45,7 +42,6 @@ test('first-touch attribution parses query and body, rejects unsafe paths, and s
 		utmTerm: null,
 		landingPath: '/signup',
 		referrer: null,
-		referralCode: null,
 	})
 
 	expect(
@@ -61,7 +57,6 @@ test('first-touch attribution parses query and body, rejects unsafe paths, and s
 		utmTerm: null,
 		landingPath: null,
 		referrer: null,
-		referralCode: null,
 	})
 
 	const attribution = parseFirstTouchAttribution({
@@ -89,34 +84,21 @@ test('first-touch attribution parses query and body, rejects unsafe paths, and s
 	expect(params.get('utm_medium')).toBe('video')
 	expect(params.get('landing_path')).toBe('/signup')
 
-	const fromRef = parseFirstTouchAttribution({
+	const fromRefOnly = parseFirstTouchAttribution({
 		searchParams: new URLSearchParams('ref=KentCDodds'),
 		landingPath: '/signup',
 	})
-	expect(fromRef.referralCode).toBe('kentcdodds')
-	expect(hasFirstTouchAttribution(fromRef)).toBe(true)
-	expect(serializeFirstTouchAttributionForTransport(fromRef)).toEqual({
+	expect(fromRefOnly).toEqual({
+		utmSource: null,
+		utmMedium: null,
+		utmCampaign: null,
+		utmContent: null,
+		utmTerm: null,
 		landingPath: '/signup',
-		referralCode: 'kentcdodds',
+		referrer: null,
 	})
+	expect(hasFirstTouchAttribution(fromRefOnly)).toBe(true)
 	const refParams = new URLSearchParams()
-	appendAttributionQueryParams(refParams, fromRef)
-	expect(refParams.get('ref')).toBe('kentcdodds')
-
-	const homepageFirstTouch = parseFirstTouchAttribution({
-		landingPath: '/',
-	})
-	expect(mergeReferralCodeIntoFirstTouch(homepageFirstTouch, fromRef)).toEqual({
-		...homepageFirstTouch,
-		referralCode: 'kentcdodds',
-	})
-	expect(
-		mergeReferralCodeIntoFirstTouch(fromRef, {
-			...emptyFirstTouchAttribution,
-			referralCode: 'ada',
-		}),
-	).toEqual(fromRef)
-	expect(
-		mergeReferralCodeIntoFirstTouch(homepageFirstTouch, homepageFirstTouch),
-	).toBe(homepageFirstTouch)
+	appendAttributionQueryParams(refParams, fromRefOnly)
+	expect(refParams.get('ref')).toBeNull()
 })

--- a/packages/worker/universal/first-touch-attribution.ts
+++ b/packages/worker/universal/first-touch-attribution.ts
@@ -2,7 +2,11 @@
  * First-touch marketing attribution captured at signup (email or OAuth).
  * Invite codes remain the access key; these fields are the acquisition story.
  * Values are write-once on the user row — never overwrite later UTMs.
+ * `referralCode` rides along for signup attribution but is not a users UTM
+ * column — it writes a `referrals` row instead.
  */
+
+import { parseReferralCode } from '#universal/referral-program.ts'
 
 export type FirstTouchAttribution = {
 	utmSource: string | null
@@ -12,6 +16,8 @@ export type FirstTouchAttribution = {
 	utmTerm: string | null
 	landingPath: string | null
 	referrer: string | null
+	/** Username from `?ref=` / `?referral=` — not a marketing UTM column. */
+	referralCode: string | null
 }
 
 export const emptyFirstTouchAttribution: FirstTouchAttribution = {
@@ -22,6 +28,7 @@ export const emptyFirstTouchAttribution: FirstTouchAttribution = {
 	utmTerm: null,
 	landingPath: null,
 	referrer: null,
+	referralCode: null,
 }
 
 const maxAttributionValueLength = 200
@@ -70,7 +77,8 @@ export function hasFirstTouchAttribution(
 		value.utmContent != null ||
 		value.utmTerm != null ||
 		value.landingPath != null ||
-		value.referrer != null
+		value.referrer != null ||
+		value.referralCode != null
 	)
 }
 
@@ -119,6 +127,10 @@ export function parseFirstTouchAttribution(input: {
 		utmTerm: readParam('utm_term', ['utmTerm', 'utm_term']),
 		landingPath,
 		referrer,
+		referralCode: parseReferralCode({
+			searchParams: params,
+			body: fromBody,
+		}),
 	}
 }
 
@@ -138,6 +150,7 @@ export function serializeFirstTouchAttributionForTransport(
 	if (attribution.utmTerm) out.utmTerm = attribution.utmTerm
 	if (attribution.landingPath) out.landingPath = attribution.landingPath
 	if (attribution.referrer) out.referrer = attribution.referrer
+	if (attribution.referralCode) out.referralCode = attribution.referralCode
 	return out
 }
 
@@ -205,4 +218,5 @@ export function appendAttributionQueryParams(
 	if (attribution.landingPath)
 		params.set('landing_path', attribution.landingPath)
 	if (attribution.referrer) params.set('referrer', attribution.referrer)
+	if (attribution.referralCode) params.set('ref', attribution.referralCode)
 }

--- a/packages/worker/universal/first-touch-attribution.ts
+++ b/packages/worker/universal/first-touch-attribution.ts
@@ -135,6 +135,19 @@ export function parseFirstTouchAttribution(input: {
 }
 
 /**
+ * UTMs stay first-touch write-once. A later `/signup?ref=` can still fill
+ * `referralCode` when the stored first-touch has none, so a homepage visit
+ * in the same tab does not drop the share link.
+ */
+export function mergeReferralCodeIntoFirstTouch(
+	firstTouch: FirstTouchAttribution,
+	later: FirstTouchAttribution,
+): FirstTouchAttribution {
+	if (firstTouch.referralCode || !later.referralCode) return firstTouch
+	return { ...firstTouch, referralCode: later.referralCode }
+}
+
+/**
  * Flatten attribution into JSON-safe fields for the OAuth login-state cookie
  * and signup POST body (camelCase, omit nulls).
  */

--- a/packages/worker/universal/first-touch-attribution.ts
+++ b/packages/worker/universal/first-touch-attribution.ts
@@ -2,11 +2,8 @@
  * First-touch marketing attribution captured at signup (email or OAuth).
  * Invite codes remain the access key; these fields are the acquisition story.
  * Values are write-once on the user row — never overwrite later UTMs.
- * `referralCode` rides along for signup attribution but is not a users UTM
- * column — it writes a `referrals` row instead.
+ * Referral share links use a last-wins `kody_ref` cookie, not this payload.
  */
-
-import { parseReferralCode } from '#universal/referral-program.ts'
 
 export type FirstTouchAttribution = {
 	utmSource: string | null
@@ -16,8 +13,6 @@ export type FirstTouchAttribution = {
 	utmTerm: string | null
 	landingPath: string | null
 	referrer: string | null
-	/** Username from `?ref=` / `?referral=` — not a marketing UTM column. */
-	referralCode: string | null
 }
 
 export const emptyFirstTouchAttribution: FirstTouchAttribution = {
@@ -28,7 +23,6 @@ export const emptyFirstTouchAttribution: FirstTouchAttribution = {
 	utmTerm: null,
 	landingPath: null,
 	referrer: null,
-	referralCode: null,
 }
 
 const maxAttributionValueLength = 200
@@ -77,8 +71,7 @@ export function hasFirstTouchAttribution(
 		value.utmContent != null ||
 		value.utmTerm != null ||
 		value.landingPath != null ||
-		value.referrer != null ||
-		value.referralCode != null
+		value.referrer != null
 	)
 }
 
@@ -127,24 +120,7 @@ export function parseFirstTouchAttribution(input: {
 		utmTerm: readParam('utm_term', ['utmTerm', 'utm_term']),
 		landingPath,
 		referrer,
-		referralCode: parseReferralCode({
-			searchParams: params,
-			body: fromBody,
-		}),
 	}
-}
-
-/**
- * UTMs stay first-touch write-once. A later `/signup?ref=` can still fill
- * `referralCode` when the stored first-touch has none, so a homepage visit
- * in the same tab does not drop the share link.
- */
-export function mergeReferralCodeIntoFirstTouch(
-	firstTouch: FirstTouchAttribution,
-	later: FirstTouchAttribution,
-): FirstTouchAttribution {
-	if (firstTouch.referralCode || !later.referralCode) return firstTouch
-	return { ...firstTouch, referralCode: later.referralCode }
 }
 
 /**
@@ -163,7 +139,6 @@ export function serializeFirstTouchAttributionForTransport(
 	if (attribution.utmTerm) out.utmTerm = attribution.utmTerm
 	if (attribution.landingPath) out.landingPath = attribution.landingPath
 	if (attribution.referrer) out.referrer = attribution.referrer
-	if (attribution.referralCode) out.referralCode = attribution.referralCode
 	return out
 }
 
@@ -231,5 +206,4 @@ export function appendAttributionQueryParams(
 	if (attribution.landingPath)
 		params.set('landing_path', attribution.landingPath)
 	if (attribution.referrer) params.set('referrer', attribution.referrer)
-	if (attribution.referralCode) params.set('ref', attribution.referralCode)
 }

--- a/packages/worker/universal/loader-data.ts
+++ b/packages/worker/universal/loader-data.ts
@@ -28,6 +28,7 @@ import { type PublicCodeRunsWindow } from '#universal/code-runs.ts'
 import { type HighlightedCode } from '#universal/highlighted-code.ts'
 import { type WalkthroughHostPick } from '#universal/walkthrough-hosts.ts'
 import { type ConnectedMcpAgent } from '#universal/connected-mcp-agents.ts'
+import { type ReferralProgramSummary } from '#universal/referral-program.ts'
 import { type SecondAgentStandardGiftState } from '#universal/second-agent-standard-gift.ts'
 import { type OnboardingAgentChooserPick } from '#universal/onboarding-mcp-clients.ts'
 import { type EmailVerificationDelivery } from '#universal/email-verification-delivery.ts'
@@ -1922,6 +1923,7 @@ export type AccountBillingLoaderData = {
 	purchasablePlans: Array<'standard' | 'pro'>
 	/** Deep link to the account usage page (limits / consumption). */
 	usageHref: '/account/usage'
+	referralProgram: ReferralProgramSummary | null
 	error?: string
 	/** Success notice mapped from `?billing=<code>` (e.g. a completed plan change). */
 	notice?: string

--- a/packages/worker/universal/referral-cookie.node.test.ts
+++ b/packages/worker/universal/referral-cookie.node.test.ts
@@ -1,0 +1,53 @@
+import { expect, test } from 'vitest'
+import {
+	readReferralCodeFromCookie,
+	referralCookieName,
+	resolveReferralCodeForSignup,
+	serializeReferralCookie,
+} from './referral-cookie.ts'
+
+test('referral cookie last-wins, expires in one week, and signup prefers the current request', () => {
+	expect(serializeReferralCookie({ code: 'KentCDodds', secure: false })).toBe(
+		`${referralCookieName}=kentcdodds; Path=/; Max-Age=604800; SameSite=Lax`,
+	)
+	expect(serializeReferralCookie({ code: 'Ada', secure: true })).toBe(
+		`${referralCookieName}=ada; Path=/; Max-Age=604800; SameSite=Lax; Secure`,
+	)
+	expect(serializeReferralCookie({ code: 'x', secure: false })).toBe(
+		`${referralCookieName}=; Path=/; Max-Age=0; SameSite=Lax`,
+	)
+
+	expect(
+		readReferralCodeFromCookie('other=1; kody_ref=KentCDodds; theme=dark'),
+	).toBe('kentcdodds')
+	expect(readReferralCodeFromCookie('kody_ref=ada; kody_ref=KentCDodds')).toBe(
+		'kentcdodds',
+	)
+	expect(readReferralCodeFromCookie('kody_ref=not%20valid')).toBeNull()
+	expect(readReferralCodeFromCookie(null)).toBeNull()
+
+	expect(
+		resolveReferralCodeForSignup({
+			searchParams: new URLSearchParams('ref=Ada'),
+			cookieHeader: 'kody_ref=kentcdodds',
+		}),
+	).toBe('ada')
+	expect(
+		resolveReferralCodeForSignup({
+			body: { referralCode: 'Ada' },
+			cookieHeader: 'kody_ref=kentcdodds',
+		}),
+	).toBe('ada')
+	expect(
+		resolveReferralCodeForSignup({
+			searchParams: new URLSearchParams('utm_source=youtube'),
+			cookieHeader: 'kody_ref=kentcdodds',
+		}),
+	).toBe('kentcdodds')
+	expect(
+		resolveReferralCodeForSignup({
+			searchParams: new URLSearchParams(),
+			cookieHeader: null,
+		}),
+	).toBeNull()
+})

--- a/packages/worker/universal/referral-cookie.ts
+++ b/packages/worker/universal/referral-cookie.ts
@@ -1,0 +1,62 @@
+/**
+ * Last-wins referral attribution cookie. Share links (`?ref=` / `?referral=`)
+ * overwrite the previous referrer and expire after one week. Signup persists
+ * a `referrals` row from this cookie (or a same-request share link), not from
+ * first-touch UTM storage.
+ */
+
+import { parseReferralCode } from '#universal/referral-program.ts'
+
+export const referralCookieName = 'kody_ref'
+export const referralCookieMaxAgeSeconds = 7 * 24 * 60 * 60
+
+export function readReferralCodeFromCookie(
+	cookieHeader: string | null | undefined,
+): string | null {
+	if (!cookieHeader) return null
+	let latest: string | null = null
+	for (const part of cookieHeader.split(';')) {
+		const trimmed = part.trim()
+		const separator = trimmed.indexOf('=')
+		if (separator <= 0) continue
+		const name = trimmed.slice(0, separator)
+		if (name !== referralCookieName) continue
+		let raw = trimmed.slice(separator + 1)
+		try {
+			raw = decodeURIComponent(raw)
+		} catch {
+			continue
+		}
+		const normalized = parseReferralCode({ body: { ref: raw } })
+		if (normalized) latest = normalized
+	}
+	return latest
+}
+
+export function serializeReferralCookie(input: {
+	code: string | null
+	secure: boolean
+}): string {
+	const code = parseReferralCode({ body: { ref: input.code } })
+	const value = code ? encodeURIComponent(code) : ''
+	const maxAge = code ? referralCookieMaxAgeSeconds : 0
+	const secure = input.secure ? '; Secure' : ''
+	return `${referralCookieName}=${value}; Path=/; Max-Age=${maxAge}; SameSite=Lax${secure}`
+}
+
+/**
+ * Current-request share link wins over a stored cookie so a signup that
+ * lands on `/signup?ref=` (or posts `referralCode`) attributes that referrer.
+ */
+export function resolveReferralCodeForSignup(input: {
+	searchParams?: URLSearchParams | null
+	body?: unknown
+	cookieHeader?: string | null
+}): string | null {
+	return (
+		parseReferralCode({
+			searchParams: input.searchParams,
+			body: input.body,
+		}) ?? readReferralCodeFromCookie(input.cookieHeader)
+	)
+}

--- a/packages/worker/universal/referral-program.node.test.ts
+++ b/packages/worker/universal/referral-program.node.test.ts
@@ -1,0 +1,103 @@
+import { expect, test } from 'vitest'
+import { resolveEffectivePlan } from './plans.ts'
+import {
+	addReferralStandardCreditDuration,
+	laterIsoTimestamp,
+	normalizeEmailForReferralFraud,
+	normalizeReferralCode,
+	parseReferralCode,
+	referralSharePath,
+	resolveEffectivePlanWithStandardOverlays,
+	unixSecondsToIso,
+} from './referral-program.ts'
+
+const now = new Date('2026-09-07T12:00:00.000Z')
+
+test('referral codes, share links, stacking, overlays, and fraud email collapse', () => {
+	expect(normalizeReferralCode(' KentCDodds ')).toBe('kentcdodds')
+	expect(normalizeReferralCode('ab')).toBeNull()
+	expect(normalizeReferralCode('not valid')).toBeNull()
+	expect(
+		parseReferralCode({ searchParams: new URLSearchParams('ref=Ada') }),
+	).toBe('ada')
+	expect(
+		parseReferralCode({
+			body: { referralCode: 'ada', ref: 'ignored-when-first-wins' },
+		}),
+	).toBe('ada')
+	expect(
+		parseReferralCode({ searchParams: new URLSearchParams('ref=x') }),
+	).toBe(null)
+	expect(referralSharePath('KentCDodds')).toBe('/signup?ref=kentcdodds')
+	expect(referralSharePath('x')).toBe('/signup')
+
+	expect(addReferralStandardCreditDuration({ now }).toISOString()).toBe(
+		'2026-10-07T12:00:00.000Z',
+	)
+	expect(
+		addReferralStandardCreditDuration({
+			now,
+			currentExpiresAt: '2026-11-01T00:00:00.000Z',
+		}).toISOString(),
+	).toBe('2026-12-01T00:00:00.000Z')
+	expect(
+		addReferralStandardCreditDuration({
+			now,
+			currentExpiresAt: '2026-08-01T00:00:00.000Z',
+			paidPeriodEndAt: '2026-10-01T00:00:00.000Z',
+		}).toISOString(),
+	).toBe('2026-10-31T00:00:00.000Z')
+	expect(
+		addReferralStandardCreditDuration({
+			now,
+			currentExpiresAt: '2026-12-01T00:00:00.000Z',
+			paidPeriodEndAt: '2026-10-01T00:00:00.000Z',
+		}).toISOString(),
+	).toBe('2026-12-31T00:00:00.000Z')
+
+	expect(
+		laterIsoTimestamp(
+			null,
+			'2026-01-01T00:00:00.000Z',
+			'2026-02-01T00:00:00.000Z',
+		),
+	).toBe('2026-02-01T00:00:00.000Z')
+	expect(laterIsoTimestamp('not-a-date', null)).toBeNull()
+
+	expect(
+		resolveEffectivePlanWithStandardOverlays(
+			'free',
+			null,
+			'2026-10-01T00:00:00.000Z',
+			now,
+		),
+	).toBe('standard')
+	expect(
+		resolveEffectivePlanWithStandardOverlays(
+			'free',
+			'pro',
+			'2026-10-01T00:00:00.000Z',
+			now,
+		),
+	).toBe('pro')
+	expect(
+		resolveEffectivePlanWithStandardOverlays(
+			'free',
+			null,
+			'2026-08-01T00:00:00.000Z',
+			now,
+		),
+	).toBe(resolveEffectivePlan('free', null))
+
+	expect(normalizeEmailForReferralFraud('Ada+1@Gmail.com')).toBe(
+		'ada@gmail.com',
+	)
+	expect(normalizeEmailForReferralFraud('a.da@googlemail.com')).toBe(
+		'ada@gmail.com',
+	)
+	expect(normalizeEmailForReferralFraud('ada+work@example.com')).toBe(
+		'ada@example.com',
+	)
+	expect(unixSecondsToIso(1_788_782_400)).toBe('2026-09-07T12:00:00.000Z')
+	expect(unixSecondsToIso('nope')).toBeNull()
+})

--- a/packages/worker/universal/referral-program.ts
+++ b/packages/worker/universal/referral-program.ts
@@ -1,0 +1,172 @@
+/**
+ * Uncapped referral program: both parties earn one month of public Standard
+ * after the referee's first qualifying paid invoice. Enforcement composes
+ * {@link resolveEffectivePlanWithSecondAgentGift} with the later of the
+ * second-agent gift and this stackable credit.
+ */
+
+import { dnsSafeUsernamePattern } from '@kody-internal/shared/public-urls.ts'
+import {
+	isSecondAgentStandardGiftActive,
+	resolveEffectivePlanWithSecondAgentGift,
+} from '#universal/second-agent-standard-gift.ts'
+import { type PlanName } from '#universal/plans.ts'
+
+/** 30 days. Observed through grant `expires_at`, not this export alone. */
+export const referralStandardCreditDurationMs = 30 * 24 * 60 * 60 * 1000
+
+export const referralStatuses = ['pending', 'rewarded', 'rejected'] as const
+
+export type ReferralStatus = (typeof referralStatuses)[number]
+
+export const referralRejectReasons = [
+	'self_referral',
+	'same_email',
+	'same_stripe_customer',
+	'platform_referrer',
+] as const
+
+export type ReferralRejectReason = (typeof referralRejectReasons)[number]
+
+export type ReferralProgramSummary = {
+	shareUrl: string
+	sharePath: string
+	rewardedCount: number
+	pendingCount: number
+	creditExpiresAt: string | null
+	creditActive: boolean
+	referrals: Array<ReferralProgramListItem>
+}
+
+export type ReferralProgramListItem = {
+	refereeUsername: string | null
+	status: 'pending' | 'rewarded'
+	createdAt: string
+	rewardedAt: string | null
+}
+
+export function normalizeReferralCode(value: unknown): string | null {
+	if (typeof value !== 'string') return null
+	const normalized = value.trim().toLowerCase()
+	if (!normalized) return null
+	if (!dnsSafeUsernamePattern.test(normalized)) return null
+	return normalized
+}
+
+export function parseReferralCode(input: {
+	searchParams?: URLSearchParams | null
+	body?: unknown
+}): string | null {
+	const fromBody =
+		input.body && typeof input.body === 'object'
+			? (input.body as Record<string, unknown>)
+			: null
+	const params = input.searchParams ?? null
+	const candidates = [
+		params?.get('ref'),
+		params?.get('referral'),
+		fromBody?.referralCode,
+		fromBody?.ref,
+		fromBody?.referral,
+	]
+	for (const candidate of candidates) {
+		const normalized = normalizeReferralCode(candidate)
+		if (normalized) return normalized
+	}
+	return null
+}
+
+export function referralSharePath(username: string): string {
+	const code = normalizeReferralCode(username)
+	return code ? `/signup?ref=${encodeURIComponent(code)}` : '/signup'
+}
+
+export function laterIsoTimestamp(
+	...values: Array<string | null | undefined>
+): string | null {
+	let bestMs: number | null = null
+	let bestRaw: string | null = null
+	for (const value of values) {
+		const trimmed = value?.trim()
+		if (!trimmed) continue
+		const ms = Date.parse(trimmed)
+		if (!Number.isFinite(ms)) continue
+		if (bestMs == null || ms > bestMs) {
+			bestMs = ms
+			bestRaw = trimmed
+		}
+	}
+	return bestRaw
+}
+
+export function isReferralStandardCreditActive(
+	expiresAt: string | null | undefined,
+	now: Date = new Date(),
+) {
+	return isSecondAgentStandardGiftActive(expiresAt, now)
+}
+
+/**
+ * Next credit expiry: add 30 days to the latest of now, an unexpired
+ * stacked credit, and an optional paid Stripe period end so a subscriber's
+ * month starts after paid access rather than overlapping it.
+ */
+export function addReferralStandardCreditDuration(input: {
+	now: Date
+	currentExpiresAt?: string | null
+	paidPeriodEndAt?: string | null
+}): Date {
+	const candidates = [input.now.getTime()]
+	const currentMs = input.currentExpiresAt
+		? Date.parse(input.currentExpiresAt)
+		: Number.NaN
+	if (Number.isFinite(currentMs) && currentMs > input.now.getTime()) {
+		candidates.push(currentMs)
+	}
+	const periodMs = input.paidPeriodEndAt
+		? Date.parse(input.paidPeriodEndAt)
+		: Number.NaN
+	if (Number.isFinite(periodMs) && periodMs > input.now.getTime()) {
+		candidates.push(periodMs)
+	}
+	return new Date(Math.max(...candidates) + referralStandardCreditDurationMs)
+}
+
+export function resolveEffectivePlanWithStandardOverlays(
+	manualPlan: PlanName,
+	stripePlan: string | null,
+	overlayExpiresAt: string | null | undefined,
+	now: Date = new Date(),
+): PlanName {
+	return resolveEffectivePlanWithSecondAgentGift(
+		manualPlan,
+		stripePlan,
+		overlayExpiresAt,
+		now,
+	)
+}
+
+/**
+ * Collapse plus-tags and Gmail dots so `ada+1@gmail.com` and
+ * `a.da@gmail.com` cannot refer each other.
+ */
+export function normalizeEmailForReferralFraud(email: string): string {
+	const trimmed = email.trim().toLowerCase()
+	const at = trimmed.lastIndexOf('@')
+	if (at <= 0) return trimmed
+	let local = trimmed.slice(0, at)
+	const domain = trimmed.slice(at + 1)
+	const plus = local.indexOf('+')
+	if (plus >= 0) local = local.slice(0, plus)
+	if (domain === 'gmail.com' || domain === 'googlemail.com') {
+		return `${local.replaceAll('.', '')}@gmail.com`
+	}
+	return `${local}@${domain}`
+}
+
+export function unixSecondsToIso(value: unknown): string | null {
+	if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+		return null
+	}
+	return new Date(value * 1000).toISOString()
+}

--- a/tools/migration-ledger.json
+++ b/tools/migration-ledger.json
@@ -191,6 +191,10 @@
 		{
 			"filename": "0047-users-second-agent-standard-gift.sql",
 			"sha256": "c36bf33ecda407df550a712148c3c24f9938169ecb4d9a4ede9ae00d980933a0"
+		},
+		{
+			"filename": "0048-referral-program.sql",
+			"sha256": "32c0ce6dcee40a897576eebcf88b58a55c6e9d4c868d562dda5dd4e9d090528a"
 		}
 	]
 }

--- a/tools/migration-ledger.json
+++ b/tools/migration-ledger.json
@@ -194,7 +194,7 @@
 		},
 		{
 			"filename": "0048-referral-program.sql",
-			"sha256": "32c0ce6dcee40a897576eebcf88b58a55c6e9d4c868d562dda5dd4e9d090528a"
+			"sha256": "27996f6591596eca494e762e060c32cc8408652dcca0c70a65d27f0c189ab8fd"
 		}
 	]
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Let any signed-in user share a referral link. After a **new** referee verifies email and pays their **first successful Stripe invoice**, both the referrer and the referee get **one month of public Standard**. There is **no cap** on how many months a referrer can earn.

## Why

PR2 (#2122) already shipped a 14-day Standard overlay for a second connected MCP agent. This PR reuses that overlay posture for an invoice-gated, uncapped referral program instead of mutating Stripe trials, period ends, or customer balance.

## Acceptance criteria

- [x] Reward fires **once** on the referee's first qualifying paid invoice (`amount_paid > 0`, not compute-overage, not `upcoming`)
- [x] **Both** referrer and referee receive a stacked 30-day Standard credit
- [x] **No reward** on $0 trial / unpaid invoices
- [x] Fraud basics: last-wins one-week cookie, persist at signup, no self-referral, plus-tag / Gmail-dot email collapse, no shared Stripe customer, no platform-account referrer, both emails verified (hold + retry if not)
- [x] **No annual or lifetime cap** — each new rewarded referee stacks another month on the referrer
- [x] `/account/billing` shows a labeled share URL, copy control, rewarded/pending counts, credit-through date, and a short list
- [x] Docs: entitlements, data-storage, privacy, control-kody billing feature map
- [x] Pre-signup attribution is a last-wins `kody_ref` cookie (1 week). A later share link overwrites the previous referrer. A real signup persists the `referrals` row and expires the cookie on that response.

## Summary

- Attribution store: last-wins `kody_ref` cookie (1 week) from `?ref=<username>` (also `?referral=` / body `referralCode`). Username is the share code. First-touch UTMs stay write-once and do **not** carry the referral code. Signup (password and OAuth) writes the pending `referrals` row from the cookie or a same-request share link, then expires `kody_ref` on the real create response only (an existing-email 200 does not).
- Stripe hook: `invoice.paid` on `POST /webhooks/stripe`. Qualifying invoice only. Replay of a later invoice is `already_rewarded` and does not restack. A failed Stripe lookup of the referrer's paid period fails the webhook so Stripe retries. Email-verify leaves a hold pending if that lookup fails; the referrer's later `invoice.paid` retries it.
- Credit grant: atomic `pending → rewarded`, then stack `users.referral_standard_credit_expires_at` +30 days from `max(now, existing credit, paid period end)`. Referee invoices use the latest line `period.end`.
- Entitlement read: later of second-agent gift expiry and referral credit expiry, then existing `resolveEffectivePlanWithSecondAgentGift`. Stripe subscriptions are not mutated.

## Testing

- Local `test:node` 2786 / `test:workers` 341 green on push of `3f1f5309`
- Preview `1f3693b7`: `/signup?ref=user-me` sets `kody_ref=user-me; Max-Age=604800`; later `/signup?ref=Ada` overwrites to `ada`. Seed billing still shows `…/signup?ref=user-me`.
- Coverage: once-on-first-paid-invoice, both credited, trial skip, plus-tag reject, hold-until-verify, uncapped stack, last-wins cookie overwrite, real signup expires `kody_ref`, latest invoice line period, referrer Stripe lookup 500, held stays on resolver failure

## Risk / merge

**High billing risk.** Kent via Marley authorized the last-wins cookie change and a full ship-pr through production. Squash-merge after CI and valid AI review.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (high billing risk)</summary>

**Mode:** recap · **Base:** `main` @ `5fbc8ef9` · **Head:** `3f1f5309`

**Classification:** extends — no new primitive. This PR changes billing webhook handling, entitlement overlay resolution, D1 schema, signup attribution via a last-wins cookie, and the billing UI.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `billing` | auth | extends — `invoice.paid` grants referral credit |
| `entitlements` | auth | extends — stackable Standard overlay from referral credit |
| `d1-app-db` | storage | extends — `referrals` table and `users.referral_standard_credit_expires_at` |
| `app-sessions` | auth | extends — persist attribution at signup from `kody_ref` |
| `app-ui` | surfaces | extends — `/account/billing` share link, last-wins cookie, privacy copy |

### Change flow

A share link stores the latest referrer in a one-week cookie. A real signup writes the pending row and expires the cookie. The first qualifying paid invoice stacks one Standard month on both parties.

```mermaid
sequenceDiagram
	actor Referee
	participant appUi as app-ui
	participant appSessions as app-sessions
	participant d1AppDb as d1-app-db
	participant billing as billing
	participant entitlements as entitlements
	Referee->>appUi: open /signup?ref=username
	appUi->>appUi: set last-wins kody_ref cookie for one week
	Note over appUi: a later share link overwrites the cookie
	Referee->>appSessions: password or OAuth signup
	appSessions->>d1AppDb: insert pending referrals row from cookie
	appSessions->>appUi: expire kody_ref on the create response
	Note over d1AppDb: unique referee_stable_user_id
	Referee->>billing: first qualifying paid invoice.paid
	billing->>entitlements: rewardReferralForPaidInvoice
	entitlements->>d1AppDb: pending to rewarded and stack expires_at
	appUi->>d1AppDb: GET /account/billing.json referral summary
```

Referral rows stay pending until a qualifying paid invoice, then reward once.

```mermaid
stateDiagram-v2
	[*] --> pending: signup from last-wins cookie
	pending --> pending: hold invoice while email unverified
	pending --> rewarded: first paid invoice and both emails verified
	pending --> rejected: self, plus-tag, shared customer, or platform
	rewarded --> rewarded: later invoices do not restack
```

### Before / after

```text
users: + referral_standard_credit_expires_at
referrals: new ledger (pending | rewarded | rejected)
GET /account/billing.json: + referralProgram
pre-signup: last-wins kody_ref cookie (1 week), not first-touch
signup: persist referrals row and expire kody_ref on create only
```

### Invariants

- Per-user isolation: attribution and credit writes are keyed by `stable_user_id`
- Stripe money is not mutated (no `trial_end`, period-end, or customer-balance writes)
- One reward per referee (unique `referee_stable_user_id` and `reward_invoice_id`)
- Referrer stacking is uncapped across distinct rewarded referees
- Pre-signup attribution is last-wins for one week, persisted only at account creation

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-46740753-d32c-4db0-880c-cad6156a1ee6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-46740753-d32c-4db0-880c-cad6156a1ee6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a referral program where both participants can earn one month of Standard access after a qualifying paid invoice.
  * Added a billing-page referral panel with share links, copy action, reward status, credit expiry, and referral history.
  * Added referral tracking that retains the latest share link for one week and applies attribution at signup.
  * Referral credits now extend existing Standard benefits when applicable.

* **Documentation**
  * Updated billing, privacy, authentication, and architecture documentation with referral program details.

* **Bug Fixes**
  * Improved referral reward handling for email verification, retries, and duplicate payment events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->