### PR TITLE
Remove pre-AAD secret ciphertext dual-read

### DIFF
--- a/docs/contributing/disaster-recovery.md
+++ b/docs/contributing/disaster-recovery.md
@@ -462,6 +462,13 @@ reindex Vectorize (`POST /__maintenance/reindex-capabilities` with
 APP_DB is not the job schedule store); recreate queues from Wrangler config; and
 expect users to reauthorize OAuth and reconnect MCP servers.
 
+After restoring a D1 export sealed before the 2026-08-17 secret format-upgrade
+pass, 2-part (`<iv>.<ciphertext>`) rows fail to decrypt on the user-facing path.
+Before serving, run `POST /__maintenance/reencrypt-secrets` until every table
+reports `remaining: 0` (see
+[Secret rotation](./secret-rotation.md#upgrading-pre-aad-2-part-ciphertexts)).
+Prefer restoring a later sealed day when one is available.
+
 ### Durable Object point-in-time recovery
 
 Use Durable Object (DO) PITR for an application bug or corruption inside one

--- a/docs/contributing/environment-variables.md
+++ b/docs/contributing/environment-variables.md
@@ -359,10 +359,12 @@ Worker secrets:
   or a pooling-only change, POST `{ "force": true }` (and omit `phases` for
   every kind) so matching fingerprints cannot skip upserts. Each call is
   time-budgeted and may return `complete: false` plus a `cursor` to resume. Use
-  the re-encrypt endpoint to rewrite remaining pre-AAD (2-part) secret
-  ciphertexts to v2 without rotating `SECRET_STORE_KEY` (see
-  [Secret rotation](./secret-rotation.md)). Local dev uses offline search while
-  `WRANGLER_IS_LOCAL_DEV` is set or the binding is missing.
+  the re-encrypt endpoint to rewrite pre-AAD (2-part) secret ciphertexts to v2
+  without rotating `SECRET_STORE_KEY` — including after restoring a D1 export
+  sealed before the 2026-08-17 format-upgrade pass (see
+  [Secret rotation](./secret-rotation.md) and
+  [Disaster recovery](./disaster-recovery.md)). Local dev uses offline search
+  while `WRANGLER_IS_LOCAL_DEV` is set or the binding is missing.
 - **`JOB_REINDEX_SECRET`** — optional Worker secret; bearer token for
   `POST /__maintenance/reindex-jobs` when you want a jobs-only Vectorize rebuild
   (without a full capability/memory/package reindex). When unset, the jobs-only

--- a/docs/contributing/secret-rotation.md
+++ b/docs/contributing/secret-rotation.md
@@ -70,22 +70,24 @@ the input) and then smoke-test unsealing offline. See
 ## Upgrading pre-AAD (2-part) ciphertexts
 
 Encrypt helpers write `v2.<iv>.<ciphertext>` bound to an AAD identity context.
-Rows that still store `<iv>.<ciphertext>` have no AAD. `decryptWithKey`
-dual-reads both shapes; user-facing reads never rewrite. The operator pass
-upgrades remaining 2-part rows in place without rotating `SECRET_STORE_KEY`.
+User-facing decrypt accepts only that shape. A 2-part payload
+(`<iv>.<ciphertext>`, no AAD) is invalid on read.
 
-`POST /__maintenance/reencrypt-secrets` (bearer `CAPABILITY_REINDEX_SECRET`).
-Operators with Actions access dispatch `.github/workflows/reencrypt-secrets.yml`
-(`dry_run` defaults to true) so the bearer never leaves GitHub Actions. Direct
-curl against `https://kody.codes` is equivalent when the secret is already on
-the operator machine.
+`POST /__maintenance/reencrypt-secrets` (bearer `CAPABILITY_REINDEX_SECRET`)
+rewrites 2-part rows in place without rotating `SECRET_STORE_KEY`. The
+maintenance path is the only decrypt that still accepts the unversioned shape,
+so a D1 export sealed before the 2026-08-17 format-upgrade pass can be restored
+and upgraded before serving. Operators with Actions access dispatch
+`.github/workflows/reencrypt-secrets.yml` (`dry_run` defaults to true) so the
+bearer never leaves GitHub Actions. Direct curl against `https://kody.codes` is
+equivalent when the secret is already on the operator machine.
 
 The pass:
 
 1. Keyset-pages `secret_entries.encrypted_value`,
    `platform_oauth_apps.client_secret_encrypted` where the payload is not
    `v2.%`.
-2. Decrypts via the existing dual-read, re-encrypts as v2 with
+2. Decrypts via the maintenance-only unversioned path, re-encrypts as v2 with
    `userSecretContext(userId)` or `platformOauthAppContext(slug)`, and writes
    back with `WHERE … AND <column> = <old>` so a concurrent user rotation wins.
 3. Counts decrypt failures and leaves those rows unchanged. The JSON result is
@@ -98,6 +100,10 @@ rows that failed decryption and stay 2-part). If `remaining` stalls and
 `decryptFailures` is non-empty after a run that did not hit the row budget,
 inspect those keys instead of looping. This is a production mutation; run it
 only after an explicit operator go-ahead.
+
+After restoring a D1 export sealed before the 2026-08-17 format-upgrade pass,
+run this pass to remaining 0 before serving. Prefer a later sealed day when one
+is available. See [Disaster recovery](./disaster-recovery.md).
 
 ## Backfilling integration-owned credentials
 

--- a/docs/contributing/security.md
+++ b/docs/contributing/security.md
@@ -526,19 +526,19 @@ guarded by a bearer secret comparison.
   versioned (`v2.<iv>.<ct>`) and bound via AES-GCM additional authenticated data
   to their purpose and owning identity (`user:<userId>` for user secrets,
   `app:<slug>` for platform OAuth client secrets), so a ciphertext copied into
-  another user's row fails to decrypt. Unversioned (2-part) ciphertexts decrypt
-  under the same KEK and upgrade to `v2` on write re-encryption, or via the
-  operator pass at `POST /__maintenance/reencrypt-secrets` (same KEK; optimistic
-  compare so a concurrent user rotation wins; decrypt failures are counted and
-  left unchanged). Leftover integration-owned OAuth values that still live only
-  in `secret_entries` are copied onto the connection/app ciphertext columns by
-  `POST /__maintenance/backfill-integration-credentials` (same bearer; writes
-  only where the ciphertext column is still null). Only `v2` provides owner
-  binding: a 2-part ciphertext carries no AAD, so a copied row would decrypt
-  until rewritten (metadata-only writes preserve the 2-part ciphertext). Row
-  swaps already require write access to the database, so this is
-  defense-in-depth, not a standing hole. Decrypt dual-reads both shapes;
-  user-facing reads never rewrite.
+  another user's row fails to decrypt. User-facing decrypt accepts only `v2`.
+  Unversioned (2-part) payloads are invalid on read. The operator pass at
+  `POST /__maintenance/reencrypt-secrets` decrypts that leftover shape with a
+  maintenance-only helper, re-encrypts as `v2` (same KEK; optimistic compare so
+  a concurrent user rotation wins; decrypt failures are counted and left
+  unchanged), and is the restore path after a D1 export sealed before the
+  2026-08-17 format-upgrade pass. Leftover integration-owned OAuth values that
+  still live only in `secret_entries` are copied onto the connection/app
+  ciphertext columns by `POST /__maintenance/backfill-integration-credentials`
+  (same bearer; writes only where the ciphertext column is still null). A 2-part
+  ciphertext carries no AAD, so a copied row would decrypt under the maintenance
+  helper until rewritten. Row swaps already require write access to the
+  database, so this is defense-in-depth, not a standing hole.
 - `SECRET_STORE_KEY` is escrowed for disaster recovery as a passphrase-sealed
   blob in the DR backup bucket (solo operator; see
   [Disaster recovery](./disaster-recovery.md) and

--- a/packages/worker/src/mcp/secrets/crypto.node.test.ts
+++ b/packages/worker/src/mcp/secrets/crypto.node.test.ts
@@ -2,19 +2,18 @@ import { expect, test, vi } from 'vitest'
 import {
 	decryptPlatformOauthClientSecret,
 	decryptSecretValue,
-	decryptStringWithPurpose,
+	decryptUnversionedCiphertext,
 	encryptSecretValue,
 	encryptPlatformOauthClientSecret,
-	encryptStringWithPurpose,
 	platformOauthAppContext,
+	secretCiphertextPurposes,
 	userSecretContext,
 } from './crypto.ts'
 
 const primaryKey = 'primary-secret-store-key-at-least-32-chars!!'
-const cookieSecret = 'cookie-secret-value-at-least-32-characters!!'
 
-test('secret and purpose-based encryption round-trip and reject wrong keys or malformed payloads', async () => {
-	const env = { COOKIE_SECRET: cookieSecret, SECRET_STORE_KEY: primaryKey }
+test('secret encryption round-trips and rejects wrong keys or malformed payloads', async () => {
+	const env = { SECRET_STORE_KEY: primaryKey }
 	const context = userSecretContext('user-1')
 	const encrypted = await encryptSecretValue(env, 'my-secret-value', context)
 	expect(encrypted.startsWith('v2.')).toBe(true)
@@ -24,7 +23,6 @@ test('secret and purpose-based encryption round-trip and reject wrong keys or ma
 
 	const wrongEnv = {
 		SECRET_STORE_KEY: 'wrong-store-key-32-chars-minimum-value-here!!',
-		COOKIE_SECRET: cookieSecret,
 	}
 	await expect(
 		decryptSecretValue(wrongEnv, encrypted, context),
@@ -32,19 +30,10 @@ test('secret and purpose-based encryption round-trip and reject wrong keys or ma
 	await expect(
 		decryptSecretValue(env, 'no-dot-separator', context),
 	).rejects.toThrow('Unable to decrypt secret value.')
-
-	const purposeEncrypted = await encryptStringWithPurpose(
-		env,
-		'test-purpose',
-		'hello',
-	)
-	expect(
-		await decryptStringWithPurpose(env, 'test-purpose', purposeEncrypted),
-	).toBe('hello')
 })
 
-test('secret AAD/versioning binds identity context, platform OAuth slugs, and still decrypts legacy payloads', async () => {
-	const env = { COOKIE_SECRET: cookieSecret, SECRET_STORE_KEY: primaryKey }
+test('secret AAD/versioning binds identity context, platform OAuth slugs, and rejects unversioned payloads', async () => {
+	const env = { SECRET_STORE_KEY: primaryKey }
 	const encrypted = await encryptSecretValue(
 		env,
 		'bound-value',
@@ -116,17 +105,24 @@ test('secret AAD/versioning binds identity context, platform OAuth slugs, and st
 			.replace(/=+$/, '')
 	const legacyPayload = `${toBase64Url(legacyIv)}.${toBase64Url(legacyCiphertext)}`
 
+	await expect(
+		decryptSecretValue(env, legacyPayload, userSecretContext('user-a')),
+	).rejects.toThrow('Unable to decrypt secret value.')
+	await expect(
+		decryptSecretValue(env, legacyPayload, userSecretContext('user-b')),
+	).rejects.toThrow('Unable to decrypt secret value.')
 	expect(
-		await decryptSecretValue(env, legacyPayload, userSecretContext('user-a')),
-	).toBe('legacy-value')
-	expect(
-		await decryptSecretValue(env, legacyPayload, userSecretContext('user-b')),
+		await decryptUnversionedCiphertext(
+			env,
+			secretCiphertextPurposes.secretStore,
+			legacyPayload,
+		),
 	).toBe('legacy-value')
 })
 
 test('secret store CryptoKey derivation is cached across encrypt and decrypt', async () => {
 	const cacheTestKey = 'cache-test-secret-store-key-32-chars-min!!'
-	const env = { COOKIE_SECRET: cookieSecret, SECRET_STORE_KEY: cacheTestKey }
+	const env = { SECRET_STORE_KEY: cacheTestKey }
 	const derivedKeys: Array<CryptoKey> = []
 	const originalImportKey = crypto.subtle.importKey.bind(crypto.subtle)
 	const importKeySpy = vi
@@ -165,7 +161,7 @@ test('secret store CryptoKey derivation is cached across encrypt and decrypt', a
 
 test('failed secret store CryptoKey derivation is not cached', async () => {
 	const failureTestKey = 'failure-test-secret-store-key-32-chars-min!'
-	const env = { COOKIE_SECRET: cookieSecret, SECRET_STORE_KEY: failureTestKey }
+	const env = { SECRET_STORE_KEY: failureTestKey }
 	let attempts = 0
 	const originalImportKey = crypto.subtle.importKey.bind(crypto.subtle)
 	const importKeySpy = vi

--- a/packages/worker/src/mcp/secrets/crypto.ts
+++ b/packages/worker/src/mcp/secrets/crypto.ts
@@ -10,9 +10,10 @@ const ivBytes = 12
  * AES-GCM ciphertext to an additional-authenticated-data (AAD) string built
  * from the purpose plus an identity context (e.g. the owning user), so a
  * ciphertext copied into another row fails to decrypt. Two-part payloads
- * (`<iv>.<ciphertext>`, no AAD) still decrypt; they upgrade to v2 whenever
- * the value is re-encrypted on write. Operators rewrite remaining 2-part rows
- * in place via `POST /__maintenance/reencrypt-secrets`.
+ * (`<iv>.<ciphertext>`, no AAD) are invalid on the user-facing decrypt path.
+ * The operator pass at `POST /__maintenance/reencrypt-secrets` can still
+ * decrypt that shape so a restored pre-upgrade D1 export can be rewritten
+ * to v2 before serving.
  */
 const ciphertextVersion = 'v2'
 
@@ -76,62 +77,50 @@ async function decryptWithKey(
 ) {
 	const parts = payload.split('.')
 	const key = await deriveEncryptionKey(keySecret, purpose)
-	if (parts.length === 3) {
-		const [version, ivPart, ciphertextPart] = parts
-		if (version !== ciphertextVersion || !ivPart || !ciphertextPart) {
-			throw new Error('Invalid encrypted secret payload.')
-		}
-		const plaintext = await crypto.subtle.decrypt(
-			{
-				name: 'AES-GCM',
-				iv: base64UrlToBytes(ivPart),
-				additionalData: buildAad(purpose, context),
-			},
-			key,
-			base64UrlToBytes(ciphertextPart),
-		)
-		return textDecoder.decode(plaintext)
+	if (parts.length !== 3) {
+		throw new Error('Invalid encrypted secret payload.')
 	}
-	if (parts.length === 2) {
-		// Legacy payload written before AAD binding existed.
-		const [ivPart, ciphertextPart] = parts
-		if (!ivPart || !ciphertextPart) {
-			throw new Error('Invalid encrypted secret payload.')
-		}
-		const plaintext = await crypto.subtle.decrypt(
-			{
-				name: 'AES-GCM',
-				iv: base64UrlToBytes(ivPart),
-			},
-			key,
-			base64UrlToBytes(ciphertextPart),
-		)
-		return textDecoder.decode(plaintext)
+	const [version, ivPart, ciphertextPart] = parts
+	if (version !== ciphertextVersion || !ivPart || !ciphertextPart) {
+		throw new Error('Invalid encrypted secret payload.')
 	}
-	throw new Error('Invalid encrypted secret payload.')
+	const plaintext = await crypto.subtle.decrypt(
+		{
+			name: 'AES-GCM',
+			iv: base64UrlToBytes(ivPart),
+			additionalData: buildAad(purpose, context),
+		},
+		key,
+		base64UrlToBytes(ciphertextPart),
+	)
+	return textDecoder.decode(plaintext)
 }
 
 /**
- * General-purpose string encryption under COOKIE_SECRET. `context` defaults to
- * empty for identity-free payloads; pass an owning identity whenever the
- * ciphertext lives in a row that could be swapped between owners.
+ * Decrypt a pre-AAD 2-part payload (`<iv>.<ciphertext>`). Used only by the
+ * operator re-encrypt pass so a restored pre-upgrade D1 export can be
+ * rewritten to v2 before serving. User-facing decrypt rejects this shape.
  */
-export async function encryptStringWithPurpose(
-	env: Pick<Env, 'COOKIE_SECRET'>,
-	purpose: string,
-	value: string,
-	context = '',
-) {
-	return encryptWithKey(env.COOKIE_SECRET, purpose, context, value)
-}
-
-export async function decryptStringWithPurpose(
-	env: Pick<Env, 'COOKIE_SECRET'>,
+async function decryptUnversionedWithKey(
+	keySecret: string,
 	purpose: string,
 	payload: string,
-	context = '',
 ) {
-	return decryptWithKey(env.COOKIE_SECRET, purpose, context, payload)
+	const parts = payload.split('.')
+	const [ivPart, ciphertextPart] = parts
+	if (parts.length !== 2 || !ivPart || !ciphertextPart) {
+		throw new Error('Invalid encrypted secret payload.')
+	}
+	const key = await deriveEncryptionKey(keySecret, purpose)
+	const plaintext = await crypto.subtle.decrypt(
+		{
+			name: 'AES-GCM',
+			iv: base64UrlToBytes(ivPart),
+		},
+		key,
+		base64UrlToBytes(ciphertextPart),
+	)
+	return textDecoder.decode(plaintext)
 }
 
 const secretStorePurpose = 'mcp-secret-store'
@@ -147,6 +136,30 @@ const platformOauthClientSecretPurpose = 'platform-oauth-client-secret'
 const userOauthAccessTokenPurpose = 'user-oauth-access-token'
 const userOauthRefreshTokenPurpose = 'user-oauth-refresh-token'
 const userOauthClientSecretPurpose = 'user-oauth-client-secret'
+
+/** Purpose strings for the maintenance-only unversioned decrypt path. */
+export const secretCiphertextPurposes = {
+	secretStore: secretStorePurpose,
+	platformOauthClientSecret: platformOauthClientSecretPurpose,
+	userOauthAccessToken: userOauthAccessTokenPurpose,
+	userOauthRefreshToken: userOauthRefreshTokenPurpose,
+	userOauthClientSecret: userOauthClientSecretPurpose,
+} as const
+
+export type SecretCiphertextPurpose =
+	(typeof secretCiphertextPurposes)[keyof typeof secretCiphertextPurposes]
+
+/**
+ * Decrypt a pre-AAD 2-part payload. Operator re-encrypt only; user-facing
+ * decrypt wrappers reject this shape.
+ */
+export async function decryptUnversionedCiphertext(
+	env: Pick<Env, 'SECRET_STORE_KEY'>,
+	purpose: SecretCiphertextPurpose,
+	payload: string,
+) {
+	return decryptUnversionedWithKey(env.SECRET_STORE_KEY, purpose, payload)
+}
 
 /** AAD context for a user-owned secret ciphertext. */
 export function userSecretContext(userId: string) {

--- a/packages/worker/src/mcp/secrets/reencrypt.ts
+++ b/packages/worker/src/mcp/secrets/reencrypt.ts
@@ -1,16 +1,13 @@
 import { runD1WithRetry } from '#worker/d1-retry.ts'
 import {
-	decryptPlatformOauthClientSecret,
-	decryptSecretValue,
-	decryptUserOauthAccessToken,
-	decryptUserOauthClientSecret,
-	decryptUserOauthRefreshToken,
+	decryptUnversionedCiphertext,
 	encryptPlatformOauthClientSecret,
 	encryptSecretValue,
 	encryptUserOauthAccessToken,
 	encryptUserOauthClientSecret,
 	encryptUserOauthRefreshToken,
 	platformOauthAppContext,
+	secretCiphertextPurposes,
 	userIntegrationCredentialContext,
 	userOauthAppCredentialContext,
 	userSecretContext,
@@ -413,9 +410,10 @@ async function updateUserOauthApp(input: {
 
 /**
  * Format-upgrade pass for pre-AAD (2-part) secret ciphertexts. Decrypts via
- * the existing dual-read, re-encrypts as v2 with the owning identity AAD, and
- * writes back with an optimistic compare so a concurrent user rotation wins.
- * Rows that fail decryption are counted and left unchanged.
+ * the maintenance-only unversioned path, re-encrypts as v2 with the owning
+ * identity AAD, and writes back with an optimistic compare so a concurrent
+ * user rotation wins. Rows that fail decryption are counted and left
+ * unchanged. User-facing decrypt rejects 2-part payloads.
  */
 export async function reencryptLegacySecretCiphertexts(
 	input: ReencryptLegacySecretCiphertextsInput,
@@ -445,10 +443,10 @@ export async function reencryptLegacySecretCiphertexts(
 				dryRun,
 				previousPayload: row.encrypted_value,
 				decrypt: () =>
-					decryptSecretValue(
+					decryptUnversionedCiphertext(
 						input.env,
+						secretCiphertextPurposes.secretStore,
 						row.encrypted_value,
-						userSecretContext(row.user_id),
 					),
 				encrypt: (plaintext) =>
 					encryptSecretValue(
@@ -500,10 +498,10 @@ export async function reencryptLegacySecretCiphertexts(
 				dryRun,
 				previousPayload: row.client_secret_encrypted,
 				decrypt: () =>
-					decryptPlatformOauthClientSecret(
+					decryptUnversionedCiphertext(
 						input.env,
+						secretCiphertextPurposes.platformOauthClientSecret,
 						row.client_secret_encrypted,
-						platformOauthAppContext(row.slug),
 					),
 				encrypt: (plaintext) =>
 					encryptPlatformOauthClientSecret(
@@ -555,13 +553,13 @@ export async function reencryptLegacySecretCiphertexts(
 				{
 					column: 'access_token_encrypted' as const,
 					payload: row.access_token_encrypted,
-					decrypt: decryptUserOauthAccessToken,
+					purpose: secretCiphertextPurposes.userOauthAccessToken,
 					encrypt: encryptUserOauthAccessToken,
 				},
 				{
 					column: 'refresh_token_encrypted' as const,
 					payload: row.refresh_token_encrypted,
-					decrypt: decryptUserOauthRefreshToken,
+					purpose: secretCiphertextPurposes.userOauthRefreshToken,
 					encrypt: encryptUserOauthRefreshToken,
 				},
 			]
@@ -573,7 +571,12 @@ export async function reencryptLegacySecretCiphertexts(
 				const outcome = await rewritePayload({
 					dryRun,
 					previousPayload,
-					decrypt: () => column.decrypt(input.env, previousPayload, context),
+					decrypt: () =>
+						decryptUnversionedCiphertext(
+							input.env,
+							column.purpose,
+							previousPayload,
+						),
 					encrypt: (plaintext) => column.encrypt(input.env, plaintext, context),
 					write: (nextPayload, previous) =>
 						updateUserIntegrationCiphertext({
@@ -631,10 +634,10 @@ export async function reencryptLegacySecretCiphertexts(
 				dryRun,
 				previousPayload: row.client_secret_encrypted,
 				decrypt: () =>
-					decryptUserOauthClientSecret(
+					decryptUnversionedCiphertext(
 						input.env,
+						secretCiphertextPurposes.userOauthClientSecret,
 						row.client_secret_encrypted,
-						userOauthAppCredentialContext(row.user_id, row.slug),
 					),
 				encrypt: (plaintext) =>
 					encryptUserOauthClientSecret(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Complete [#1489](https://github.com/kentcdodds/kody/issues/1489): retire the pre-AAD (2-part) user-facing decrypt so leftover `<iv>.<ciphertext>` payloads are invalid.

## Why

PR #1382 added v2 AAD-bound ciphertexts. Production re-encrypt ran 2026-08-17. Inventory is clear except the deleted undecryptable leftover. Dual-read is the leftover compatibility path.

## Summary

- `decryptWithKey` accepts only `v2.<iv>.<ciphertext>`. Two-part payloads fail as invalid.
- Operator `POST /__maintenance/reencrypt-secrets` keeps a maintenance-only unversioned decrypt so a D1 export sealed before the 2026-08-17 pass can still be rewritten to v2 before serving.
- Legacy crypto tests assert rejection (not successful decrypt under two contexts).
- Removed unused `encryptStringWithPurpose` / `decryptStringWithPurpose` (test-only, zero production callers).
- Documented the DR restore step: after restoring a pre-pass D1 export, re-run re-encrypt before serving.
- No `SECRET_STORE_KEY` rotation. No schema change. v2 rows unchanged.

Related: #1489 (close after this ships to production — do not auto-close on merge).

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `5fbc8ef9` · **Head:** `d1db3dd8`

**Classification:** extends — user-facing secret decrypt rejects pre-AAD 2-part payloads. The operator re-encrypt pass keeps a maintenance-only unversioned decrypt for restore.

### Primitives touched

| Primitive    | Group    | Impact                                                                 |
| ------------ | -------- | ---------------------------------------------------------------------- |
| `mcp-server` | surfaces | extends — `decryptWithKey` accepts only `v2.<iv>.<ciphertext>`         |

Unmatched paths are contributing docs (`secret-rotation`, `security`, `disaster-recovery`, `environment-variables`).

### Change flow

User-facing secret decrypt rejects 2-part ciphertext. The operator re-encrypt pass still reads that shape so a restored pre-upgrade D1 export can be rewritten to v2 before serving.

```mermaid
sequenceDiagram
	actor Operator
	participant mcpServer as mcp-server
	participant d1AppDb as d1-app-db
	mcpServer->>mcpServer: decryptWithKey rejects 2-part
	mcpServer->>d1AppDb: resolve v2 ciphertext with owner AAD
	Operator->>mcpServer: POST /__maintenance/reencrypt-secrets
	mcpServer->>mcpServer: decryptUnversionedCiphertext reads 2-part
	mcpServer->>d1AppDb: write v2 with owner AAD
```

### Before / after

| Path                         | Before                                      | After                                                      |
| ---------------------------- | ------------------------------------------- | ---------------------------------------------------------- |
| User-facing `decryptWithKey` | 2-part (`<iv>.<ct>`) decrypts without AAD   | 2-part is invalid                                          |
| Operator re-encrypt          | Used the same dual-read                     | Dedicated unversioned decrypt, then v2 write               |
| `encryptStringWithPurpose`   | Exported, test-only                         | Removed (no production callers)                            |

</details>

<!-- system-recap:end -->

## Testing

- `npx vitest run --project node-unit` on `crypto.node.test.ts` and `reencrypt.node.test.ts` (5 passed)
- Pre-push: `test:node` 2777 passed, `test:workers` 337 passed
- `npm run docs:check-temporal` passed
- Commit hook typecheck passed

## System changes

Extends `mcp-server` secret decrypt (medium). User-facing 2-part decrypt is gone. Maintenance re-encrypt remains for DR restore.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a9e7b292-332a-4408-9998-8ddcc9b4eebe?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a9e7b292-332a-4408-9998-8ddcc9b4eebe&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - User-facing decryption now accepts only versioned, authenticated ciphertexts; legacy two-part payloads are rejected.
  - Legacy encrypted values can be upgraded through the maintenance re-encryption process.

- **Documentation**
  - Added restore guidance for older database exports, including running re-encryption until no legacy values remain.
  - Clarified ciphertext formats, maintenance recovery procedures, and relevant environment variable usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->