### PR TITLE
Group connected agents by name with logos and newest-first sort

### DIFF
--- a/.agents/skills/control-kody/references/features/account.md
+++ b/.agents/skills/control-kody/references/features/account.md
@@ -34,8 +34,9 @@ node tools/control-kody.ts request GET /account/connected-agents.json
 
 - Seed users start empty. Profile fields exist; packages/secrets/jobs do not
   until you create them.
-- Connected agents lists inbound OAuth hosts (best-effort labels and revoke).
-  That list is not `users.mcp_client_name` and not minted MCP OAuth clients.
+- Connected agents lists inbound OAuth hosts grouped by display name (logos for
+  known kinds, newest-first, best-effort labels, per-`clientId` revoke). That
+  list is not `users.mcp_client_name` and not minted MCP OAuth clients.
 - Former-address release is `POST /account/email-claim-release.json`, then
   confirm at `/verify-email-claim-release`. It drops the claim without reminting
   `users.stable_user_id`.

--- a/.agents/skills/control-kody/references/features/onboarding.md
+++ b/.agents/skills/control-kody/references/features/onboarding.md
@@ -37,6 +37,6 @@ node tools/control-kody.ts preview -- \
   leftover instead of killing it mid-reload. Do not dump one onboarding
   component to static HTML.
 - Step 3 completion is unique inbound OAuth `clientId`s ≥ 2, not raw grant
-  count. Account → Connected agents is the labeled inbound list. That first
-  cross also records the one-time 14-day Standard gift
-  (`secondAgentStandardGift` on `/onboarding.json`).
+  count. Account → Connected agents is the grouped inbound list (logos for known
+  kinds, newest-first). That first cross also records the one-time 14-day
+  Standard gift (`secondAgentStandardGift` on `/onboarding.json`).

--- a/docs/contributing/architecture/authentication.md
+++ b/docs/contributing/architecture/authentication.md
@@ -671,14 +671,19 @@ routed from `packages/worker/src/index.ts`.
   → Advanced). That page is user-minted clients, not inbound host grants.
   Account → Connected agents lists inbound grants from `listUserGrants` (paged)
   joined with `lookupClient` for a best-effort label, authorized time, and
-  revoke. Onboarding Step 3 completion is unique `clientId`s ≥ 2, not raw grant
-  count and not `users.mcp_client_name`. `user_mcp_oauth_clients` stores the
-  account-owned metadata. The provider stores the secret hash in `OAUTH_KV` via
-  `env.OAUTH_PROVIDER.createClient()`. List and revoke are scoped to the owning
-  `user_id`. The plaintext secret is shown once and never written to D1. MCP
-  `2026-07-28` deprecates RFC 7591 dynamic registration in favor of CIMD, so
-  both stay enabled: clients without a pre-registered credential that do not use
-  CIMD register via `/oauth/register`. Failed CIMD fetches throw
+  revoke. The account UI groups those unique `clientId`s by display name, shows
+  a public icon when the host kind already has an SVG, and sorts newest-first.
+  Timestamps are grant `createdAt` (connected time). The provider grant summary
+  has no last-used / last-accessed field, and recording MCP activity per
+  connection would need new persistence, so the page does not invent a
+  last-heard time. Onboarding Step 3 completion is unique `clientId`s ≥ 2, not
+  raw grant count and not `users.mcp_client_name`. `user_mcp_oauth_clients`
+  stores the account-owned metadata. The provider stores the secret hash in
+  `OAUTH_KV` via `env.OAUTH_PROVIDER.createClient()`. List and revoke are scoped
+  to the owning `user_id`. The plaintext secret is shown once and never written
+  to D1. MCP `2026-07-28` deprecates RFC 7591 dynamic registration in favor of
+  CIMD, so both stay enabled: clients without a pre-registered credential that
+  do not use CIMD register via `/oauth/register`. Failed CIMD fetches throw
   `CimdFetchError`: authorize maps that to an unknown-client page, and the token
   endpoint still returns generic `invalid_client`. Any DCR retry after that is
   the client's own recovery, not a server-side fallback. CIMD metadata fetches

--- a/docs/contributing/architecture/onboarding.md
+++ b/docs/contributing/architecture/onboarding.md
@@ -34,8 +34,9 @@ the connected label stays "You've connected a second agent." When the
 second-agent Standard gift is active, that status adds "Standard is free for 2
 weeks." Step 3 copy advertises "Connect a second agent and get Standard free for
 2 weeks." Same-ecosystem greying stays picker UX only. Account → Connected
-agents lists those inbound hosts with best-effort labels and revoke. That list
-is not `users.mcp_client_name` (first-touch) and not
+agents lists those inbound hosts grouped by display name, with public logos for
+known kinds, newest-first sort, best-effort labels, and per-`clientId` revoke.
+That list is not `users.mcp_client_name` (first-touch) and not
 `/account/mcp-oauth-clients` (user-minted confidential clients).
 
 `first-win` is not a wizard step and is not a checklist item. Signed-in

--- a/packages/worker/client/routes/account-connected-agents-panel.node.test.ts
+++ b/packages/worker/client/routes/account-connected-agents-panel.node.test.ts
@@ -1,0 +1,70 @@
+import { type Handle } from 'remix/ui'
+import { renderToString } from 'remix/ui/server'
+import { expect, test } from 'vitest'
+import { createAccountConnectedAgents } from './account-connected-agents-panel.tsx'
+
+test('connected agents panel groups same-name hosts, shows logos, and keeps revoke inside details', async () => {
+	const panel = createAccountConnectedAgents({
+		update() {},
+	} as Handle)
+	panel.applyPayload({
+		ok: true,
+		agents: [
+			{
+				clientId: 'cursor-old',
+				grantIds: ['grant-old'],
+				label: 'Cursor',
+				kind: 'cursor',
+				connectedAt: '2024-01-01T00:00:00.000Z',
+			},
+			{
+				clientId: 'cursor-new',
+				grantIds: ['grant-new'],
+				label: 'Cursor',
+				kind: 'cursor',
+				connectedAt: '2024-06-01T00:00:00.000Z',
+			},
+			{
+				clientId: 'https://chatgpt.com/oauth/client.json',
+				grantIds: ['grant-chatgpt'],
+				label: 'ChatGPT.com',
+				kind: 'chatgpt',
+				connectedAt: '2024-03-01T00:00:00.000Z',
+			},
+			{
+				clientId: 'opaque-client-id-abcdefghijklmnopqrstuvwxyz',
+				grantIds: ['grant-acme'],
+				label: 'Acme Agent',
+				kind: null,
+				connectedAt: '2024-05-01T00:00:00.000Z',
+			},
+		],
+	})
+
+	const html = await renderToString(panel.render())
+	expect(html).toContain('data-testid="connected-agent-group"')
+	expect(html).toContain('/images/icons/cursor.svg')
+	expect(html).toContain('/images/icons/chatgpt.svg')
+	expect(html).toContain('data-testid="connected-agent-mark-fallback"')
+	expect(html).toContain('2 connections')
+
+	const groupOrder = [...html.matchAll(/data-agent-label="([^"]+)"/g)].map(
+		(match) => match[1],
+	)
+	expect(groupOrder).toEqual(['Cursor', 'Acme Agent', 'ChatGPT.com'])
+
+	const cursorBlock = html.slice(
+		html.indexOf('data-agent-label="Cursor"'),
+		html.indexOf('data-agent-label="Acme Agent"'),
+	)
+	expect(cursorBlock).toContain('<details')
+	expect(cursorBlock).toContain('<summary')
+	expect(cursorBlock.indexOf('cursor-new')).toBeLessThan(
+		cursorBlock.indexOf('cursor-old'),
+	)
+	expect(cursorBlock).toContain('aria-label="Revoke Cursor (cursor-n…)"')
+	expect(cursorBlock).toContain('aria-label="Revoke Cursor (cursor-o…)"')
+	expect(cursorBlock).not.toContain('Confirm revoke')
+	expect(html).toContain('aria-label="Revoke ChatGPT.com"')
+	expect(html).toContain('aria-label="Revoke Acme Agent"')
+})

--- a/packages/worker/client/routes/account-connected-agents-panel.node.test.ts
+++ b/packages/worker/client/routes/account-connected-agents-panel.node.test.ts
@@ -25,11 +25,18 @@ test('connected agents panel groups same-name hosts, shows logos, and keeps revo
 				connectedAt: '2024-06-01T00:00:00.000Z',
 			},
 			{
-				clientId: 'https://chatgpt.com/oauth/client.json',
-				grantIds: ['grant-chatgpt'],
+				clientId: 'https://chatgpt.com/oauth/vG3/client.json',
+				grantIds: ['grant-chatgpt-old'],
 				label: 'ChatGPT.com',
 				kind: 'chatgpt',
 				connectedAt: '2024-03-01T00:00:00.000Z',
+			},
+			{
+				clientId: 'https://chatgpt.com/oauth/vG4/client.json',
+				grantIds: ['grant-chatgpt-new'],
+				label: 'ChatGPT.com',
+				kind: 'chatgpt',
+				connectedAt: '2024-04-01T00:00:00.000Z',
 			},
 			{
 				clientId: 'opaque-client-id-abcdefghijklmnopqrstuvwxyz',
@@ -65,6 +72,15 @@ test('connected agents panel groups same-name hosts, shows logos, and keeps revo
 	expect(cursorBlock).toContain('aria-label="Revoke Cursor (cursor-n…)"')
 	expect(cursorBlock).toContain('aria-label="Revoke Cursor (cursor-o…)"')
 	expect(cursorBlock).not.toContain('Confirm revoke')
-	expect(html).toContain('aria-label="Revoke ChatGPT.com"')
+	const chatgptBlock = html.slice(
+		html.indexOf('data-agent-label="ChatGPT.com"'),
+	)
+	expect(chatgptBlock).toContain(
+		'aria-label="Revoke ChatGPT.com (chatgpt.com · vG4)"',
+	)
+	expect(chatgptBlock).toContain(
+		'aria-label="Revoke ChatGPT.com (chatgpt.com · vG3)"',
+	)
+	expect(chatgptBlock.indexOf('vG4')).toBeLessThan(chatgptBlock.indexOf('vG3'))
 	expect(html).toContain('aria-label="Revoke Acme Agent"')
 })

--- a/packages/worker/client/routes/account-connected-agents-panel.tsx
+++ b/packages/worker/client/routes/account-connected-agents-panel.tsx
@@ -7,11 +7,23 @@ import {
 	TimestampValue,
 } from '#client/routes/account-management-components.tsx'
 import {
+	groupConnectedAgents,
+	truncateClientIdLabel,
+} from '#universal/connected-mcp-agents.ts'
+import {
 	type AccountConnectedAgentListItem,
 	type AccountConnectedAgentsLoaderData,
 } from '#universal/loader-data.ts'
-import { colors, spacing, typography } from '#universal/styles/tokens.ts'
-import { getDangerPillCss } from '#universal/styles/style-primitives.ts'
+import {
+	colors,
+	radius,
+	spacing,
+	typography,
+} from '#universal/styles/tokens.ts'
+import {
+	getDangerPillCss,
+	getLogoWellCss,
+} from '#universal/styles/style-primitives.ts'
 
 export function createAccountConnectedAgents(handle: Handle) {
 	let agents: Array<AccountConnectedAgentListItem> = []
@@ -75,10 +87,11 @@ export function createAccountConnectedAgents(handle: Handle) {
 	return {
 		applyPayload,
 		render() {
+			const groups = groupConnectedAgents(agents)
 			return (
 				<AccountManagementPanel
 					title="Connected agents"
-					description="AI hosts that have authorized against this Kody account. Labels are best-effort from the host name or redirect."
+					description="AI hosts that have authorized against this Kody account. Same-named hosts are grouped. Labels are best-effort from the host name or redirect."
 					ariaLabel="Connected agents"
 				>
 					{message ? (
@@ -92,7 +105,7 @@ export function createAccountConnectedAgents(handle: Handle) {
 							{message.text}
 						</p>
 					) : null}
-					{agents.length > 0 ? (
+					{groups.length > 0 ? (
 						<ul
 							aria-busy={busy ? 'true' : undefined}
 							mix={css({
@@ -103,28 +116,39 @@ export function createAccountConnectedAgents(handle: Handle) {
 								gap: spacing.md,
 							})}
 						>
-							{agents.map((agent) => {
-								const revokeCheck = getRevokeCheck(agent.clientId)
-								return (
-									<li
-										key={agent.clientId}
-										mix={css({
-											display: 'flex',
-											justifyContent: 'space-between',
-											alignItems: 'center',
-											gap: spacing.md,
-											flexWrap: 'wrap',
-										})}
-									>
-										<span mix={css({ display: 'grid', gap: spacing.xs })}>
+							{groups.map((group) => (
+								<li
+									key={group.label}
+									data-testid="connected-agent-group"
+									data-agent-label={group.label}
+								>
+									<details mix={css(groupDetailsCss)}>
+										<summary mix={css(groupSummaryCss)}>
+											<ConnectedAgentMark icon={group.icon} />
 											<span
 												mix={css({
 													fontWeight: typography.fontWeight.medium,
 													color: colors.text,
 												})}
 											>
-												{agent.label}
+												{group.label}
 											</span>
+											{group.members.length > 1 ? (
+												<>
+													<span
+														aria-hidden="true"
+														mix={css({
+															color: colors.textMuted,
+															fontSize: typography.fontSize.sm,
+														})}
+													>
+														({group.members.length})
+													</span>
+													<span class="visually-hidden">
+														{`${group.members.length} connections`}
+													</span>
+												</>
+											) : null}
 											<span
 												mix={css({
 													color: colors.textMuted,
@@ -133,35 +157,99 @@ export function createAccountConnectedAgents(handle: Handle) {
 											>
 												Connected{' '}
 												<TimestampValue
-													value={agent.connectedAt}
+													value={group.connectedAt}
 													fallback="at an unknown time"
 												/>
 											</span>
-										</span>
-										<button
-											type="button"
-											disabled={busy}
-											aria-label={
-												revokeCheck.doubleCheck
-													? `Confirm revoke ${agent.label}`
-													: `Revoke ${agent.label}`
-											}
-											mix={[
-												css(dangerButtonCss),
-												...revokeCheck.getButtonMix({
-													on: {
-														click: () => {
-															void revokeAgent(agent.clientId)
-														},
-													},
-												}),
-											]}
+										</summary>
+										<ul
+											mix={css({
+												listStyle: 'none',
+												padding: 0,
+												margin: 0,
+												display: 'grid',
+												gap: spacing.sm,
+											})}
 										>
-											{revokeCheck.doubleCheck ? 'Confirm revoke' : 'Revoke'}
-										</button>
-									</li>
-								)
-							})}
+											{group.members.map((agent) => {
+												const revokeCheck = getRevokeCheck(agent.clientId)
+												const connectionLabel = truncateClientIdLabel(
+													agent.clientId,
+												)
+												const revokeName =
+													group.members.length > 1
+														? `${agent.label} (${connectionLabel})`
+														: agent.label
+												return (
+													<li
+														key={agent.clientId}
+														data-testid="connected-agent-connection"
+														data-client-id={agent.clientId}
+														mix={css({
+															display: 'flex',
+															justifyContent: 'space-between',
+															alignItems: 'center',
+															gap: spacing.md,
+															flexWrap: 'wrap',
+															paddingInlineStart: spacing.lg,
+														})}
+													>
+														<span
+															mix={css({ display: 'grid', gap: spacing.xs })}
+														>
+															<code
+																title={agent.clientId}
+																mix={css({
+																	color: colors.text,
+																	fontSize: typography.fontSize.sm,
+																	overflowWrap: 'anywhere',
+																})}
+															>
+																{connectionLabel}
+															</code>
+															<span
+																mix={css({
+																	color: colors.textMuted,
+																	fontSize: typography.fontSize.sm,
+																})}
+															>
+																Connected{' '}
+																<TimestampValue
+																	value={agent.connectedAt}
+																	fallback="at an unknown time"
+																/>
+															</span>
+														</span>
+														<button
+															type="button"
+															disabled={busy}
+															aria-label={
+																revokeCheck.doubleCheck
+																	? `Confirm revoke ${revokeName}`
+																	: `Revoke ${revokeName}`
+															}
+															mix={[
+																css(dangerButtonCss),
+																...revokeCheck.getButtonMix({
+																	on: {
+																		click: () => {
+																			void revokeAgent(agent.clientId)
+																		},
+																	},
+																}),
+															]}
+														>
+															{revokeCheck.doubleCheck
+																? 'Confirm revoke'
+																: 'Revoke'}
+														</button>
+													</li>
+												)
+											})}
+										</ul>
+									</details>
+								</li>
+							))}
 						</ul>
 					) : (
 						<p mix={css({ color: colors.textMuted, margin: 0 })}>
@@ -173,6 +261,70 @@ export function createAccountConnectedAgents(handle: Handle) {
 			)
 		},
 	}
+}
+
+function ConnectedAgentMark(handle: Handle<{ icon: string | null }>) {
+	return () => {
+		if (!handle.props.icon) {
+			return (
+				<span
+					aria-hidden="true"
+					data-testid="connected-agent-mark-fallback"
+					mix={css({
+						display: 'grid',
+						placeItems: 'center',
+						flex: 'none',
+						width: '1.75rem',
+						height: '1.75rem',
+						color: colors.textMuted,
+					})}
+				>
+					<svg
+						viewBox="0 0 24 24"
+						width="18"
+						height="18"
+						fill="currentColor"
+						aria-hidden="true"
+					>
+						<circle cx="6" cy="12" r="1.6" />
+						<circle cx="12" cy="12" r="1.6" />
+						<circle cx="18" cy="12" r="1.6" />
+					</svg>
+				</span>
+			)
+		}
+		return (
+			<span
+				aria-hidden="true"
+				mix={css(getLogoWellCss({ size: '1.75rem', radius: radius.md }))}
+			>
+				<img
+					src={`/images/icons/${handle.props.icon}.svg`}
+					alt=""
+					width={20}
+					height={20}
+					mix={css({
+						display: 'block',
+						width: '1.15rem',
+						height: '1.15rem',
+						objectFit: 'contain',
+					})}
+				/>
+			</span>
+		)
+	}
+}
+
+const groupDetailsCss = {
+	'&[open] > summary': { marginBottom: spacing.sm },
+}
+
+const groupSummaryCss = {
+	display: 'flex',
+	alignItems: 'center',
+	gap: spacing.sm,
+	cursor: 'pointer',
+	flexWrap: 'wrap' as const,
 }
 
 const dangerButtonCss = getDangerPillCss({ size: 'sm' })

--- a/packages/worker/client/routes/account-connected-agents-panel.tsx
+++ b/packages/worker/client/routes/account-connected-agents-panel.tsx
@@ -7,8 +7,8 @@ import {
 	TimestampValue,
 } from '#client/routes/account-management-components.tsx'
 import {
+	connectedAgentConnectionLabel,
 	groupConnectedAgents,
-	truncateClientIdLabel,
 } from '#universal/connected-mcp-agents.ts'
 import {
 	type AccountConnectedAgentListItem,
@@ -173,7 +173,7 @@ export function createAccountConnectedAgents(handle: Handle) {
 										>
 											{group.members.map((agent) => {
 												const revokeCheck = getRevokeCheck(agent.clientId)
-												const connectionLabel = truncateClientIdLabel(
+												const connectionLabel = connectedAgentConnectionLabel(
 													agent.clientId,
 												)
 												const revokeName =

--- a/packages/worker/universal/connected-mcp-agents.node.test.ts
+++ b/packages/worker/universal/connected-mcp-agents.node.test.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url'
 import { expect, test } from 'vitest'
 import {
 	type ConnectedMcpAgent,
+	connectedAgentConnectionLabel,
 	connectedAgentIconName,
 	countUniqueOAuthClientIds,
 	groupConnectedAgents,
@@ -101,6 +102,20 @@ test('inbound labels prefer a known kind, then clientName, then hostname, then a
 	expect(
 		truncateClientIdLabel('opaque-client-id-abcdefghijklmnopqrstuvwxyz'),
 	).toBe('opaque-c…')
+	expect(
+		connectedAgentConnectionLabel('https://chatgpt.com/oauth/vG3/client.json'),
+	).toBe('chatgpt.com · vG3')
+	expect(
+		connectedAgentConnectionLabel(
+			'https://chatgpt.com/oauth/vG4-MLZWUV83/client.json',
+		),
+	).toBe('chatgpt.com · vG4-MLZW…')
+	expect(connectedAgentConnectionLabel('cursor-old')).toBe('cursor-o…')
+	expect(
+		connectedAgentConnectionLabel('https://chatgpt.com/oauth/vG3/client.json'),
+	).not.toBe(
+		connectedAgentConnectionLabel('https://chatgpt.com/oauth/vG4/client.json'),
+	)
 })
 
 test('grant createdAt unix seconds become an ISO timestamp', () => {

--- a/packages/worker/universal/connected-mcp-agents.node.test.ts
+++ b/packages/worker/universal/connected-mcp-agents.node.test.ts
@@ -1,12 +1,25 @@
+import { existsSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { expect, test } from 'vitest'
 import {
+	type ConnectedMcpAgent,
+	connectedAgentIconName,
 	countUniqueOAuthClientIds,
+	groupConnectedAgents,
 	hasSecondConnectedMcpClient,
 	labelInboundMcpClient,
+	latestConnectedAt,
 	oauthGrantCreatedAtIso,
 	truncateClientIdLabel,
 	uniqueOAuthClientIds,
 } from './connected-mcp-agents.ts'
+import { mcpClientTabs } from './onboarding-mcp-clients.ts'
+
+const iconDirectory = join(
+	dirname(fileURLToPath(import.meta.url)),
+	'../public/images/icons',
+)
 
 test('unique client counting treats two grants for the same client as one', () => {
 	expect(
@@ -97,4 +110,96 @@ test('grant createdAt unix seconds become an ISO timestamp', () => {
 	)
 	expect(oauthGrantCreatedAtIso(undefined)).toBeNull()
 	expect(oauthGrantCreatedAtIso(Number.NaN)).toBeNull()
+})
+
+test('known inbound kinds map to existing public icon SVGs; unknown kinds have no logo', () => {
+	expect(connectedAgentIconName('chatgpt')).toBe('chatgpt')
+	expect(connectedAgentIconName('claude-desktop')).toBe('claude')
+	expect(connectedAgentIconName('claude-code')).toBe('claudecode')
+	expect(connectedAgentIconName('codex')).toBe('codex')
+	expect(connectedAgentIconName('cursor')).toBe('cursor')
+	expect(connectedAgentIconName('devin')).toBe('devin')
+	for (const tab of mcpClientTabs) {
+		const icon = connectedAgentIconName(tab.id)
+		if (tab.id === 'other') {
+			expect(icon).toBeNull()
+			continue
+		}
+		expect(icon).toEqual(expect.any(String))
+		expect(existsSync(join(iconDirectory, `${icon}.svg`))).toBe(true)
+	}
+	expect(connectedAgentIconName(null)).toBeNull()
+})
+
+test('connected agents group by display name and sort newest-first at group and member level', () => {
+	expect(latestConnectedAt([null, undefined, ''])).toBeNull()
+	expect(
+		latestConnectedAt([
+			'2023-11-14T22:13:20.000Z',
+			null,
+			'2024-01-01T00:00:00.000Z',
+		]),
+	).toBe('2024-01-01T00:00:00.000Z')
+
+	const olderCursor: ConnectedMcpAgent = {
+		clientId: 'cursor-old',
+		label: 'Cursor',
+		kind: 'cursor',
+		connectedAt: '2024-01-01T00:00:00.000Z',
+	}
+	const newerCursor: ConnectedMcpAgent = {
+		clientId: 'cursor-new',
+		label: 'Cursor',
+		kind: 'cursor',
+		connectedAt: '2024-06-01T00:00:00.000Z',
+	}
+	const chatgpt: ConnectedMcpAgent = {
+		clientId: 'https://chatgpt.com/oauth/client.json',
+		label: 'ChatGPT.com',
+		kind: 'chatgpt',
+		connectedAt: '2024-03-01T00:00:00.000Z',
+	}
+	const unknown: ConnectedMcpAgent = {
+		clientId: 'opaque-client-id-abcdefghijklmnopqrstuvwxyz',
+		label: 'Acme Agent',
+		kind: null,
+		connectedAt: '2024-05-01T00:00:00.000Z',
+	}
+	const undated: ConnectedMcpAgent = {
+		clientId: 'undated',
+		label: 'Acme Agent',
+		kind: null,
+		connectedAt: null,
+	}
+
+	const groups = groupConnectedAgents([
+		olderCursor,
+		chatgpt,
+		undated,
+		newerCursor,
+		unknown,
+	])
+	expect(groups.map((group) => group.label)).toEqual([
+		'Cursor',
+		'Acme Agent',
+		'ChatGPT.com',
+	])
+	expect(groups[0]).toMatchObject({
+		kind: 'cursor',
+		icon: 'cursor',
+		connectedAt: '2024-06-01T00:00:00.000Z',
+		members: [newerCursor, olderCursor],
+	})
+	expect(groups[1]).toMatchObject({
+		kind: null,
+		icon: null,
+		connectedAt: '2024-05-01T00:00:00.000Z',
+		members: [unknown, undated],
+	})
+	expect(groups[2]).toMatchObject({
+		kind: 'chatgpt',
+		icon: 'chatgpt',
+		connectedAt: '2024-03-01T00:00:00.000Z',
+		members: [chatgpt],
+	})
 })

--- a/packages/worker/universal/connected-mcp-agents.node.test.ts
+++ b/packages/worker/universal/connected-mcp-agents.node.test.ts
@@ -109,12 +109,21 @@ test('inbound labels prefer a known kind, then clientName, then hostname, then a
 		connectedAgentConnectionLabel(
 			'https://chatgpt.com/oauth/vG4-MLZWUV83/client.json',
 		),
-	).toBe('chatgpt.com · vG4-MLZW…')
+	).toBe('chatgpt.com · vG4-MLZWUV83')
 	expect(connectedAgentConnectionLabel('cursor-old')).toBe('cursor-o…')
 	expect(
 		connectedAgentConnectionLabel('https://chatgpt.com/oauth/vG3/client.json'),
 	).not.toBe(
 		connectedAgentConnectionLabel('https://chatgpt.com/oauth/vG4/client.json'),
+	)
+	expect(
+		connectedAgentConnectionLabel(
+			'https://chatgpt.com/oauth/vG4-MLZWUV83/client.json',
+		),
+	).not.toBe(
+		connectedAgentConnectionLabel(
+			'https://chatgpt.com/oauth/vG4-MLZWUV84/client.json',
+		),
 	)
 })
 

--- a/packages/worker/universal/connected-mcp-agents.ts
+++ b/packages/worker/universal/connected-mcp-agents.ts
@@ -126,6 +126,33 @@ export function truncateClientIdLabel(clientId: string) {
 	return `${trimmed.slice(0, truncatedClientIdLength)}…`
 }
 
+/**
+ * Distinguish one inbound client inside a same-name group. URL clientIds
+ * (CIMD) share an `https://` prefix, so the first eight characters are not
+ * unique — use hostname plus a path token instead.
+ */
+export function connectedAgentConnectionLabel(clientId: string) {
+	const trimmed = clientId.trim()
+	const fromUrl = connectionLabelFromClientUrl(trimmed)
+	return fromUrl ?? truncateClientIdLabel(trimmed)
+}
+
+function connectionLabelFromClientUrl(clientId: string) {
+	try {
+		const url = new URL(clientId)
+		const hostname = url.hostname.toLowerCase()
+		if (!hostname) return null
+		const hint = url.pathname
+			.split('/')
+			.filter((part) => part && part !== 'client.json' && part !== 'client')
+			.at(-1)
+		if (hint) return `${hostname} · ${truncateClientIdLabel(hint)}`
+		return hostname
+	} catch {
+		return null
+	}
+}
+
 export function connectedAgentIconName(
 	kind: McpClientKind | null,
 ): string | null {

--- a/packages/worker/universal/connected-mcp-agents.ts
+++ b/packages/worker/universal/connected-mcp-agents.ts
@@ -8,6 +8,7 @@
 import {
 	type McpClientKind,
 	mcpClientById,
+	onboardingAgentIconName,
 } from '#universal/onboarding-mcp-clients.ts'
 
 export type InboundMcpClientSignals = {
@@ -28,6 +29,16 @@ export type ConnectedMcpAgent = {
 	label: string
 	kind: McpClientKind | null
 	connectedAt: string | null
+}
+
+export type ConnectedAgentGroup<
+	T extends ConnectedMcpAgent = ConnectedMcpAgent,
+> = {
+	label: string
+	kind: McpClientKind | null
+	icon: string | null
+	connectedAt: string | null
+	members: Array<T>
 }
 
 const truncatedClientIdLength = 8
@@ -113,6 +124,85 @@ export function truncateClientIdLabel(clientId: string) {
 	const trimmed = clientId.trim()
 	if (trimmed.length <= truncatedClientIdLength) return trimmed
 	return `${trimmed.slice(0, truncatedClientIdLength)}…`
+}
+
+export function connectedAgentIconName(
+	kind: McpClientKind | null,
+): string | null {
+	if (!kind) return null
+	return onboardingAgentIconName(kind)
+}
+
+export function latestConnectedAt(
+	timestamps: ReadonlyArray<string | null | undefined>,
+): string | null {
+	let latest: string | null = null
+	for (const value of timestamps) {
+		if (!value) continue
+		if (latest === null || value > latest) latest = value
+	}
+	return latest
+}
+
+export function groupConnectedAgents<T extends ConnectedMcpAgent>(
+	agents: ReadonlyArray<T>,
+): Array<ConnectedAgentGroup<T>> {
+	const byLabel = new Map<string, Array<T>>()
+	for (const agent of agents) {
+		const existing = byLabel.get(agent.label)
+		if (existing) existing.push(agent)
+		else byLabel.set(agent.label, [agent])
+	}
+
+	const groups = new Array<ConnectedAgentGroup<T>>()
+	for (const [label, members] of byLabel) {
+		const sortedMembers = [...members].sort(compareConnectedAgentMembers)
+		const kind = kindForConnectedAgentGroup(sortedMembers)
+		groups.push({
+			label,
+			kind,
+			icon: connectedAgentIconName(kind),
+			connectedAt: latestConnectedAt(
+				sortedMembers.map((member) => member.connectedAt),
+			),
+			members: sortedMembers,
+		})
+	}
+	groups.sort(compareConnectedAgentGroups)
+	return groups
+}
+
+function kindForConnectedAgentGroup(
+	members: ReadonlyArray<ConnectedMcpAgent>,
+): McpClientKind | null {
+	for (const member of members) {
+		if (member.kind && connectedAgentIconName(member.kind)) {
+			return member.kind
+		}
+	}
+	return members[0]?.kind ?? null
+}
+
+function compareConnectedAgentMembers(
+	left: ConnectedMcpAgent,
+	right: ConnectedMcpAgent,
+) {
+	const byTime = compareNewestFirst(left.connectedAt, right.connectedAt)
+	if (byTime !== 0) return byTime
+	return left.clientId.localeCompare(right.clientId)
+}
+
+function compareConnectedAgentGroups(
+	left: ConnectedAgentGroup,
+	right: ConnectedAgentGroup,
+) {
+	const byTime = compareNewestFirst(left.connectedAt, right.connectedAt)
+	if (byTime !== 0) return byTime
+	return left.label.localeCompare(right.label)
+}
+
+function compareNewestFirst(left: string | null, right: string | null) {
+	return (right ?? '').localeCompare(left ?? '')
 }
 
 export function labelInboundMcpClient(

--- a/packages/worker/universal/connected-mcp-agents.ts
+++ b/packages/worker/universal/connected-mcp-agents.ts
@@ -146,7 +146,9 @@ function connectionLabelFromClientUrl(clientId: string) {
 			.split('/')
 			.filter((part) => part && part !== 'client.json' && part !== 'client')
 			.at(-1)
-		if (hint) return `${hostname} · ${truncateClientIdLabel(hint)}`
+		// Keep the full path token. Prefix truncation collides on CIMD ids
+		// that share an eight-character start (vG4-MLZWUV83 vs vG4-MLZWUV84).
+		if (hint) return `${hostname} · ${hint}`
 		return hostname
 	} catch {
 		return null


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Make Account → Connected agents scannable when the same host (especially Cursor) appears as multiple inbound OAuth clients.

## Why

The list was a flat row per unique `clientId`, so several Cursor grants showed as identical “Cursor · Connected … · Revoke” lines with no logo. Kent asked for grouping by display name, public logos we already have, newest-first sort, and a real last-heard signal only if one exists.

## Summary

- Group unique inbound `clientId`s by display name in native `<details>` rows.
- Collapsed summary: logo (if the kind already has a public SVG) + name + count when `> 1` + most-recent connected time.
- Expanded: each connection with a distinguishable connection label, its own connected time, and the existing double-check revoke (still `POST` by `clientId`).
- CIMD / URL `clientId`s use hostname plus the full path token (`chatgpt.com · vG4-MLZWUV83`) so they do not collapse to `https://…` or collide on a shared eight-character prefix.
- Sort groups and members newest-first (`max` of members’ `connectedAt`).
- Reuse `onboardingAgentIconName` for logos (`chatgpt`, `claude`, `claudecode`, `codex`, `cursor`, `devin`, plus the other kinds that already have SVGs). Unknown hosts get the generic three-dot mark — no new brand assets.
- **Last-heard:** `@cloudflare/workers-oauth-provider` `Grant` / `GrantSummary` expose `createdAt` (and optional `expiresAt` / `redirectUri` / `metadata`) only. Tokens have `createdAt` / `expiresAt`, not last-used. There is no helper to update grant metadata, and recording MCP activity per connection would need new persistence. The UI therefore shows connected/`createdAt` time and does not invent “Last active”.

## Testing

- `npm run test:node` for grouping/sort/logo helpers, URL connection labels, and the panel render test.
- `test:push` node + workers unit on the uniqueness fix.
- Preview pass as the seeded user (empty grants — grouping/revoke-with-data covered by unit tests).

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `d687cca6` · **Head:** `92ab5733`

**Classification:** extends — Account Connected agents changes how inbound OAuth clients are presented (grouped details, logos, newest-first). Revoke and grant listing stay the same.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `app-ui` | surfaces | extends — grouped details UI, icon mapping, newest-first sort, distinguishable connection labels |

### Change flow

Account Connected agents still loads the flat unique-`clientId` list, then the client groups that list for display and keeps revoke on the existing API.

```mermaid
sequenceDiagram
	actor User
	participant appUi as app-ui
	User->>appUi: open Account Connected agents
	appUi-->>User: group by label with logos and newest-first sort
	User->>appUi: expand details and confirm revoke
	appUi->>appUi: POST /account/connected-agents.json by clientId
	appUi-->>User: remaining groups after revoke
```

### Before / after

```text
before: flat row per clientId (duplicate Cursor labels, no logo)
after:  details per display name, logo when SVG exists, newest-first, revoke inside
        URL clientIds labeled as hostname plus the full path token
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7842e2ac-5690-40b4-a92b-2939b61a0dbe?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7842e2ac-5690-40b4-a92b-2939b61a0dbe&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Redesigned the Connected agents panel to group connections by name, display recognizable icons, show connection counts, and organize individual connections in expandable sections.
  - Connections and groups are sorted newest first.
  - Per-connection revoke controls remain available, with clearer identification when multiple connections share a name.
  - Unknown agent types now use a fallback visual treatment.

- **Documentation**
  - Updated account, onboarding, and authentication documentation to reflect the Connected agents experience.

- **Tests**
  - Added coverage for grouping, sorting, icons, fallback visuals, and revoke controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->