### PR TITLE
Grey already-connected onboarding Step 3 hosts

### DIFF
--- a/packages/worker/client/routes/onboarding-mcp-client-tabs.tsx
+++ b/packages/worker/client/routes/onboarding-mcp-client-tabs.tsx
@@ -17,6 +17,10 @@ import {
 	openClawMcpLoginCommand,
 	openCodeMcpAuthCommand,
 } from '#client/routes/onboarding-mcp-clients.ts'
+import {
+	type OnboardingSecondAgentDisableReason,
+	onboardingSecondAgentDisableHint,
+} from '#universal/onboarding-agent-ecosystems.ts'
 import { onboardingAgentHref } from '#universal/onboarding-process.ts'
 import {
 	colors,
@@ -45,6 +49,10 @@ type OnboardingMcpClientTabsProps = {
 	agentHref?: (agent: McpClientKind | null, search?: string) => string
 	pickerLede?: string
 	greyedAgents?: ReadonlyArray<McpClientKind>
+	greyedReasons?: Partial<
+		Record<McpClientKind, OnboardingSecondAgentDisableReason>
+	>
+	greyedTitles?: Partial<Record<McpClientKind, string>>
 	greyedReason?: string | null
 }
 
@@ -81,14 +89,16 @@ export function AgentPickerMark(
 	handle: Handle<{
 		agent: McpClientKind
 		testId?: string
+		size?: 'picker' | 'inline'
 	}>,
 ) {
 	return () => {
 		const desktopIcon = onboardingAgentIconName(handle.props.agent, 'desktop')
 		const mobileIcon = onboardingAgentIconName(handle.props.agent, 'mobile')
+		const size = handle.props.size ?? 'picker'
 		return (
 			<span
-				mix={css(pickerMarkCss)}
+				mix={css(size === 'inline' ? pickerMarkInlineCss : pickerMarkCss)}
 				aria-hidden="true"
 				data-testid={handle.props.testId}
 			>
@@ -300,6 +310,8 @@ export function OnboardingMcpClientTabs(
 		const search = handle.props.search ?? ''
 		const agentHref = handle.props.agentHref ?? onboardingAgentHref
 		const greyedAgents = handle.props.greyedAgents ?? []
+		const greyedReasons = handle.props.greyedReasons ?? {}
+		const greyedTitles = handle.props.greyedTitles ?? {}
 		handle.queueTask(() => {
 			const hrefs = onboardingAgentPickerPrefetchHrefs(
 				selectedAgent,
@@ -326,6 +338,8 @@ export function OnboardingMcpClientTabs(
 						search={search}
 						agentHref={agentHref}
 						greyedAgents={greyedAgents}
+						greyedReasons={greyedReasons}
+						greyedTitles={greyedTitles}
 						greyedReason={handle.props.greyedReason ?? null}
 					/>
 				</div>
@@ -347,6 +361,8 @@ export function OnboardingMcpClientTabs(
 						search={search}
 						agentHref={agentHref}
 						greyedAgents={greyedAgents}
+						greyedReasons={greyedReasons}
+						greyedTitles={greyedTitles}
 						greyedReason={handle.props.greyedReason ?? null}
 					/>
 					<p mix={css(pickerLedeCss)} id="onboarding-agent-not-listed-generic">
@@ -437,6 +453,10 @@ function AgentPickerGrid(
 		search: string
 		agentHref: (agent: McpClientKind | null, search?: string) => string
 		greyedAgents: ReadonlyArray<McpClientKind>
+		greyedReasons: Partial<
+			Record<McpClientKind, OnboardingSecondAgentDisableReason>
+		>
+		greyedTitles: Partial<Record<McpClientKind, string>>
 		greyedReason: string | null
 	}>,
 ) {
@@ -450,21 +470,26 @@ function AgentPickerGrid(
 						: entry.viewport
 				const shown = viewport === 'none' ? 'both' : viewport
 				const greyed = handle.props.greyedAgents.includes(id)
+				const reason = handle.props.greyedReasons[id] ?? 'same-ecosystem'
+				const title = handle.props.greyedTitles[id] ?? handle.props.greyedReason
 				return (
 					<li key={id} mix={css(onboardingViewportCss(shown, 'list-item'))}>
 						{greyed ? (
 							<span
 								data-testid={`onboarding-agent-${id}`}
 								data-greyed="true"
+								data-greyed-reason={reason}
 								aria-disabled="true"
-								title={handle.props.greyedReason ?? undefined}
+								title={title ?? undefined}
 								mix={css(pickerCardGreyedCss)}
 							>
 								<AgentPickerMark agent={id} />
 								<strong>
 									<AgentSurfaceLabel agent={id} />
 								</strong>
-								<span mix={css(greyedHintCss)}>Same ecosystem</span>
+								<span mix={css(greyedHintCss)}>
+									{onboardingSecondAgentDisableHint(reason)}
+								</span>
 							</span>
 						) : (
 							<a
@@ -569,6 +594,20 @@ const pickerMarkCss = {
 	width: '1.75rem',
 	height: '1.75rem',
 	color: colors.text,
+}
+
+const pickerMarkInlineCss = {
+	display: 'inline-grid',
+	placeItems: 'center',
+	flex: 'none',
+	width: '1em',
+	height: '1em',
+	verticalAlign: '-0.125em',
+	color: colors.text,
+	'& img, & svg': {
+		width: '1em',
+		height: '1em',
+	},
 }
 
 const pickerIconImgCss = {

--- a/packages/worker/client/routes/onboarding-picker-prefetch.node.test.ts
+++ b/packages/worker/client/routes/onboarding-picker-prefetch.node.test.ts
@@ -46,7 +46,14 @@ test('step 3 picker prefetch uses second-agent hrefs and keeps search', async ()
 			search,
 			agentHref: onboardingSecondAgentHref,
 			greyedAgents: ['chatgpt', 'codex'],
-			greyedReason: 'Same ecosystem as Codex',
+			greyedReasons: {
+				chatgpt: 'same-ecosystem',
+				codex: 'same-ecosystem',
+			},
+			greyedTitles: {
+				chatgpt: 'Same ecosystem as Codex',
+				codex: 'Same ecosystem as Codex',
+			},
 		}),
 	)
 	expect(hrefs).toContain(`/onboarding/step-3/cursor${search}`)

--- a/packages/worker/client/routes/onboarding-wizard-panels.node.test.ts
+++ b/packages/worker/client/routes/onboarding-wizard-panels.node.test.ts
@@ -261,4 +261,25 @@ test('step 3 greys the first-agent ecosystem and folds in a portability proof', 
 	expect(labeled).toContain('href="/onboarding/step-3/grok-bot"')
 	expect(labeled).toContain('href="/onboarding/step-3/not-listed"')
 	expect(labeled).toContain('Same ecosystem')
+
+	const notListed = await renderToString(
+		renderSecondAgentPanel({
+			entrance: css({}),
+			activeStep: 3,
+			onSelectStep() {},
+			loggedIn: true,
+			hasSecondMcpClient: false,
+			connectedAgents: [{ label: 'Zephyr' }, { label: 'Kody' }],
+			firstAgent: 'other',
+			selectedAgent: null,
+			selectedAgentLabel: null,
+			agentChooser: null,
+			mcpServerUrl: defaultKodyMcpUrl,
+			mcpHighlights: {},
+		}),
+	)
+	expect(notListed).toContain('href="/onboarding/step-3/not-listed"')
+	expect(notListed).toContain('data-testid="onboarding-agent-other"')
+	expect(notListed).toContain('data-agent-kind="unknown"')
+	expect(notListed).not.toContain('data-greyed="true"')
 })

--- a/packages/worker/client/routes/onboarding-wizard-panels.node.test.ts
+++ b/packages/worker/client/routes/onboarding-wizard-panels.node.test.ts
@@ -51,7 +51,7 @@ function accessPanel(selected: {
 }
 
 function secondAgentPanel(selected: {
-	firstAgent: 'codex' | 'cursor' | null
+	firstAgent: 'codex' | 'cursor' | 'gemini' | null
 	agent: 'claude-code' | null
 	label: string | null
 	loggedIn?: boolean
@@ -60,6 +60,18 @@ function secondAgentPanel(selected: {
 	search?: string
 	accessWinMemorySubject?: string | null
 	persistedPackageName?: string | null
+	connectedAgents?: Array<{
+		label: string
+		kind?:
+			| 'chatgpt'
+			| 'claude-desktop'
+			| 'codex'
+			| 'copilot'
+			| 'cursor'
+			| 'devin'
+			| 'grok'
+			| 'grok-cli'
+	}>
 }) {
 	return renderSecondAgentPanel({
 		entrance: css({}),
@@ -68,15 +80,10 @@ function secondAgentPanel(selected: {
 		loggedIn: selected.loggedIn ?? true,
 		hasSecondMcpClient: selected.hasSecondMcpClient ?? false,
 		secondAgentGiftActive: selected.secondAgentGiftActive,
+		connectedAgents: selected.connectedAgents,
 		firstAgent: selected.firstAgent,
 		selectedAgent: selected.agent,
 		selectedAgentLabel: selected.label,
-		greyedAgents:
-			selected.firstAgent === 'codex'
-				? ['chatgpt', 'codex']
-				: selected.firstAgent === 'cursor'
-					? ['cursor']
-					: [],
 		agentChooser: null,
 		mcpServerUrl: defaultKodyMcpUrl,
 		mcpHighlights: {},
@@ -210,21 +217,48 @@ test('step 3 greys the first-agent ecosystem and folds in a portability proof', 
 	)
 
 	const labeled = await renderToString(
-		renderSecondAgentPanel({
-			entrance: css({}),
-			activeStep: 3,
-			onSelectStep() {},
-			loggedIn: true,
+		secondAgentPanel({
+			firstAgent: 'gemini',
+			agent: null,
+			label: null,
 			hasSecondMcpClient: true,
-			connectedAgents: [{ label: 'Cursor' }, { label: 'Claude Desktop' }],
-			firstAgent: 'codex',
-			selectedAgent: 'claude-code',
-			selectedAgentLabel: 'Claude Code',
-			greyedAgents: ['chatgpt', 'codex'],
-			agentChooser: null,
-			mcpServerUrl: defaultKodyMcpUrl,
-			mcpHighlights: {},
+			connectedAgents: [
+				{ label: 'Devin', kind: 'devin' },
+				{ label: 'Claude Desktop', kind: 'claude-desktop' },
+				{ label: 'ChatGPT.com', kind: 'chatgpt' },
+				{ label: 'Codex', kind: 'codex' },
+				{ label: 'Cursor', kind: 'cursor' },
+				{ label: 'Grok.com', kind: 'grok' },
+				{ label: 'Kody' },
+				{ label: 'Copilot', kind: 'copilot' },
+				{ label: 'Grok CLI', kind: 'grok-cli' },
+				{ label: 'Zephyr' },
+			],
 		}),
 	)
 	expect(labeled).toContain('data-testid="onboarding-connected-agents"')
+	expect(labeled).toContain('aria-label="Connected: Devin, Claude Desktop')
+	expect(labeled).toContain('data-agent-kind="devin"')
+	expect(labeled).toContain('data-agent-kind="unknown"')
+	expect(labeled).toContain('/images/icons/devin.svg')
+	expect(labeled).toContain('/images/icons/claude.svg')
+	expect(labeled).toContain('/images/icons/chatgpt.svg')
+	expect(labeled).toContain('/images/icons/cursor.svg')
+	expect(labeled).toContain('/images/icons/githubcopilot.svg')
+	expect(labeled).toContain('data-greyed-reason="same-ecosystem"')
+	expect(labeled).toContain('data-greyed-reason="connected"')
+	expect(labeled).toContain('data-testid="onboarding-agent-gemini"')
+	expect(labeled).toContain('data-testid="onboarding-agent-cursor"')
+	expect(labeled).toContain('data-testid="onboarding-agent-chatgpt"')
+	expect(labeled).toContain('data-testid="onboarding-agent-devin"')
+	expect(labeled).not.toContain('href="/onboarding/step-3/gemini"')
+	expect(labeled).not.toContain('href="/onboarding/step-3/cursor"')
+	expect(labeled).not.toContain('href="/onboarding/step-3/chatgpt"')
+	expect(labeled).not.toContain('href="/onboarding/step-3/devin"')
+	expect(labeled).not.toContain('href="/onboarding/step-3/codex"')
+	expect(labeled).not.toContain('href="/onboarding/step-3/copilot"')
+	expect(labeled).toContain('href="/onboarding/step-3/claude-code"')
+	expect(labeled).toContain('href="/onboarding/step-3/grok-bot"')
+	expect(labeled).toContain('href="/onboarding/step-3/not-listed"')
+	expect(labeled).toContain('Same ecosystem')
 })

--- a/packages/worker/client/routes/onboarding-wizard-panels.tsx
+++ b/packages/worker/client/routes/onboarding-wizard-panels.tsx
@@ -11,6 +11,7 @@ import {
 	onboardingExplorePackagesHref,
 	onboardingPortabilityProofPrompt,
 	onboardingConnectedAgentLabelsLine,
+	onboardingConnectedListSeparator,
 	onboardingSecondAgentConnectedStatusLabel,
 	portabilityGuideHref,
 	onboardingSearchStartedLabel,
@@ -18,9 +19,11 @@ import {
 	onboardingSecondAgentHref,
 	onboardingSecondAgentLede,
 	onboardingUnconnectedNotice,
+	uniqueOnboardingConnectedAgents,
+	type OnboardingConnectedAgentListItem,
 	type OnboardingWizardStepNumber,
 } from '#universal/onboarding-process.ts'
-import { onboardingSameEcosystemDisabledReason } from '#universal/onboarding-agent-ecosystems.ts'
+import { onboardingSecondAgentGreyedPresentation } from '#universal/onboarding-agent-ecosystems.ts'
 import { buildAuthLink } from '#client/auth-links.ts'
 import {
 	AgentPickerMark,
@@ -184,11 +187,10 @@ export function renderSecondAgentPanel(
 		loggedIn: boolean
 		hasSecondMcpClient: boolean
 		secondAgentGiftActive?: boolean
-		connectedAgents?: ReadonlyArray<{ label: string }>
+		connectedAgents?: ReadonlyArray<OnboardingConnectedAgentListItem>
 		firstAgent: McpClientKind | null
 		selectedAgent: McpClientKind | null
 		selectedAgentLabel: string | null
-		greyedAgents: ReadonlyArray<McpClientKind>
 		agentChooser: OnboardingAgentChooserPick | null
 		mcpServerUrl: string
 		mcpHighlights: Record<string, HighlightedCode>
@@ -198,17 +200,19 @@ export function renderSecondAgentPanel(
 ) {
 	const firstLabel = props.firstAgent
 		? onboardingAgentLabel(props.firstAgent)
-		: 'your first agent'
-	const greyedReason = props.firstAgent
-		? onboardingSameEcosystemDisabledReason(props.firstAgent, firstLabel)
 		: null
+	const connectedAgents = props.connectedAgents ?? []
+	const greyed = onboardingSecondAgentGreyedPresentation(
+		props.firstAgent,
+		firstLabel,
+		connectedAgents,
+	)
 	const accessWinMade = onboardingAccessWinMadeLine({
 		memorySubject: props.accessWinMemorySubject,
 		packageName: props.persistedPackageName,
 	})
-	const connectedLabels = onboardingConnectedAgentLabelsLine(
-		props.connectedAgents ?? [],
-	)
+	const connectedItems = uniqueOnboardingConnectedAgents(connectedAgents)
+	const connectedLabels = onboardingConnectedAgentLabelsLine(connectedItems)
 	return (
 		<section
 			id="onboarding-step-3"
@@ -252,9 +256,30 @@ export function renderSecondAgentPanel(
 					props.secondAgentGiftActive === true,
 				),
 			})}
-			{connectedLabels ? (
-				<p mix={css(panelLedeCss)} data-testid="onboarding-connected-agents">
-					{connectedLabels}
+			{connectedItems.length > 0 ? (
+				<p
+					mix={css(connectedAgentsLineCss)}
+					data-testid="onboarding-connected-agents"
+					aria-label={connectedLabels ?? undefined}
+				>
+					<span aria-hidden="true">
+						Connected:{' '}
+						{connectedItems.map((agent, index) => (
+							<span key={agent.label}>
+								{onboardingConnectedListSeparator(index, connectedItems.length)}
+								<span
+									mix={css(connectedAgentItemCss)}
+									data-testid="onboarding-connected-agent"
+									data-agent-kind={agent.kind ?? 'unknown'}
+								>
+									{agent.kind && agent.kind !== 'other' ? (
+										<AgentPickerMark agent={agent.kind} size="inline" />
+									) : null}
+									{agent.label}
+								</span>
+							</span>
+						))}
+					</span>
 				</p>
 			) : null}
 			<OnboardingMcpClientTabs
@@ -265,8 +290,9 @@ export function renderSecondAgentPanel(
 				search={props.search ?? ''}
 				agentHref={onboardingSecondAgentHref}
 				pickerLede={onboardingSecondAgentLede}
-				greyedAgents={props.greyedAgents}
-				greyedReason={greyedReason}
+				greyedAgents={greyed.greyedAgents}
+				greyedReasons={greyed.greyedReasons}
+				greyedTitles={greyed.greyedTitles}
 			/>
 			{props.selectedAgent ? (
 				<div
@@ -512,6 +538,18 @@ const panelLedeCss = {
 	margin: 0,
 	color: colors.textMuted,
 	maxWidth: '68ch',
+}
+
+const connectedAgentsLineCss = {
+	...panelLedeCss,
+	lineHeight: 1.65,
+}
+
+const connectedAgentItemCss = {
+	display: 'inline-flex',
+	alignItems: 'center',
+	gap: '0.3em',
+	whiteSpace: 'nowrap' as const,
 }
 
 const accessWinMadeCss = {

--- a/packages/worker/client/routes/onboarding.tsx
+++ b/packages/worker/client/routes/onboarding.tsx
@@ -26,10 +26,7 @@ import {
 	parseOnboardingPathname,
 	type OnboardingWizardStepNumber,
 } from '#universal/onboarding-process.ts'
-import {
-	onboardingGreyedSecondAgents,
-	resolveOnboardingStep3SelectedAgent,
-} from '#universal/onboarding-agent-ecosystems.ts'
+import { resolveOnboardingStep3SelectedAgent } from '#universal/onboarding-agent-ecosystems.ts'
 import {
 	fetchOnboardingPayload,
 	type OnboardingPayload,
@@ -63,8 +60,9 @@ import { getGhostButtonCss } from '#universal/styles/style-primitives.ts'
  * agent · Make something useful · Connect a second agent), one surface panel
  * at a time with hand-tilted mascot art. Step 1 picks one agent. Step 2 is
  * one prompt that tells the agent to retrieve the onboarding guide. Step 3
- * looks like Step 1 and greys the same-ecosystem family, then folds in a
- * portability proof that reuses what Step 2 made.
+ * looks like Step 1 and greys the same-ecosystem family plus every already
+ * connected named host, then folds in a portability proof that reuses what
+ * Step 2 made.
  */
 
 type OnboardingStep = OnboardingWizardStepNumber
@@ -124,7 +122,8 @@ function sameConnectedAgents(
 		return (
 			current !== undefined &&
 			agent.clientId === current.clientId &&
-			agent.label === current.label
+			agent.label === current.label &&
+			agent.kind === current.kind
 		)
 	})
 }
@@ -434,7 +433,11 @@ export function OnboardingRoute(handle: Handle) {
 		const firstAgent = readRememberedOnboardingSelectedAgent()
 		const visibleSelectedAgent =
 			activeStep === 3
-				? resolveOnboardingStep3SelectedAgent(firstAgent, selectedAgent)
+				? resolveOnboardingStep3SelectedAgent(
+						firstAgent,
+						selectedAgent,
+						connectedAgents,
+					)
 				: selectedAgent
 		if (
 			activeStep === 3 &&
@@ -536,7 +539,6 @@ export function OnboardingRoute(handle: Handle) {
 									firstAgent,
 									selectedAgent: visibleSelectedAgent,
 									selectedAgentLabel,
-									greyedAgents: onboardingGreyedSecondAgents(firstAgent),
 									agentChooser,
 									mcpServerUrl,
 									mcpHighlights: mcpHighlights ?? {},

--- a/packages/worker/universal/onboarding-agent-ecosystems.node.test.ts
+++ b/packages/worker/universal/onboarding-agent-ecosystems.node.test.ts
@@ -1,10 +1,15 @@
 import { expect, test } from 'vitest'
 import {
 	isOnboardingSameEcosystemAgent,
+	listOnboardingGreyedSecondAgents,
 	onboardingAgentEcosystem,
+	onboardingConnectedChooserKinds,
 	onboardingGreyedSecondAgents,
 	onboardingSameEcosystemDisabledReason,
 	onboardingSameEcosystemAgents,
+	onboardingSecondAgentDisableHint,
+	onboardingSecondAgentDisableReason,
+	onboardingSecondAgentGreyedPresentation,
 	resolveOnboardingStep3SelectedAgent,
 } from './onboarding-agent-ecosystems.ts'
 
@@ -49,7 +54,73 @@ test('same-ecosystem greying follows vendor families, not agent kind', () => {
 	)
 })
 
-test('step 3 deep links drop same-ecosystem hosts and keep a different one', () => {
+test('step 3 greys every connected named host and keeps Not listed', () => {
+	const connected = [
+		{ kind: 'cursor' as const },
+		{ kind: 'claude-desktop' as const },
+		{ kind: 'chatgpt' as const },
+		{ kind: 'codex' as const },
+		{ kind: 'devin' as const },
+		{ kind: 'copilot' as const },
+		{ kind: 'grok' as const },
+		{ kind: 'grok-cli' as const },
+		{ kind: null },
+	]
+	expect(onboardingConnectedChooserKinds(connected)).toEqual([
+		'cursor',
+		'claude-desktop',
+		'chatgpt',
+		'codex',
+		'devin',
+		'copilot',
+		'grok',
+		'grok-cli',
+	])
+	expect(onboardingConnectedChooserKinds([{ kind: 'other' }])).toEqual([])
+
+	const greyed = listOnboardingGreyedSecondAgents('gemini', connected)
+	expect(greyed).toContainEqual({ id: 'gemini', reason: 'same-ecosystem' })
+	expect(greyed).toContainEqual({ id: 'cursor', reason: 'connected' })
+	expect(greyed).toContainEqual({ id: 'claude-desktop', reason: 'connected' })
+	expect(greyed).toContainEqual({ id: 'chatgpt', reason: 'connected' })
+	expect(greyed).toContainEqual({ id: 'devin', reason: 'connected' })
+	expect(greyed).toContainEqual({ id: 'copilot', reason: 'connected' })
+	expect(greyed.some((entry) => entry.id === 'other')).toBe(false)
+	expect(greyed.some((entry) => entry.id === 'claude-code')).toBe(false)
+	expect(greyed.some((entry) => entry.id === 'grok-bot')).toBe(false)
+	expect(
+		onboardingSecondAgentDisableReason('gemini', 'gemini', connected),
+	).toBe('same-ecosystem')
+	expect(
+		onboardingSecondAgentDisableReason('cursor', 'gemini', connected),
+	).toBe('connected')
+	expect(
+		onboardingSecondAgentDisableReason('claude-code', 'gemini', connected),
+	).toBeNull()
+	expect(onboardingSecondAgentDisableHint('connected')).toBe('Connected')
+
+	const openaiOverlap = listOnboardingGreyedSecondAgents('codex', [
+		{ kind: 'chatgpt' },
+		{ kind: 'cursor' },
+	])
+	expect(openaiOverlap).toEqual([
+		{ id: 'chatgpt', reason: 'same-ecosystem' },
+		{ id: 'codex', reason: 'same-ecosystem' },
+		{ id: 'cursor', reason: 'connected' },
+	])
+
+	const presentation = onboardingSecondAgentGreyedPresentation(
+		'codex',
+		'Codex',
+		[{ kind: 'cursor' }],
+	)
+	expect(presentation.greyedAgents).toEqual(['chatgpt', 'codex', 'cursor'])
+	expect(presentation.greyedReasons.cursor).toBe('connected')
+	expect(presentation.greyedTitles.cursor).toContain('Already connected')
+	expect(presentation.greyedTitles.chatgpt).toContain('Same ecosystem as Codex')
+})
+
+test('step 3 deep links drop greyed hosts and keep a different one', () => {
 	expect(resolveOnboardingStep3SelectedAgent('codex', 'chatgpt')).toBeNull()
 	expect(resolveOnboardingStep3SelectedAgent('codex', 'codex')).toBeNull()
 	expect(resolveOnboardingStep3SelectedAgent('codex', 'claude-code')).toBe(
@@ -57,4 +128,17 @@ test('step 3 deep links drop same-ecosystem hosts and keep a different one', () 
 	)
 	expect(resolveOnboardingStep3SelectedAgent(null, 'chatgpt')).toBe('chatgpt')
 	expect(resolveOnboardingStep3SelectedAgent('codex', null)).toBeNull()
+	expect(
+		resolveOnboardingStep3SelectedAgent('gemini', 'cursor', [
+			{ kind: 'cursor' },
+		]),
+	).toBeNull()
+	expect(
+		resolveOnboardingStep3SelectedAgent('gemini', 'claude-code', [
+			{ kind: 'cursor' },
+		]),
+	).toBe('claude-code')
+	expect(
+		resolveOnboardingStep3SelectedAgent(null, 'other', [{ kind: null }]),
+	).toBe('other')
 })

--- a/packages/worker/universal/onboarding-agent-ecosystems.node.test.ts
+++ b/packages/worker/universal/onboarding-agent-ecosystems.node.test.ts
@@ -43,7 +43,7 @@ test('same-ecosystem greying follows vendor families, not agent kind', () => {
 	])
 
 	expect(onboardingGreyedSecondAgents(null)).toEqual([])
-	expect(onboardingGreyedSecondAgents('other')).toEqual(['other'])
+	expect(onboardingGreyedSecondAgents('other')).toEqual([])
 	expect(isOnboardingSameEcosystemAgent('other', 'chatgpt')).toBe(false)
 
 	expect(onboardingSameEcosystemDisabledReason('codex', 'Codex')).toContain(
@@ -141,4 +141,6 @@ test('step 3 deep links drop greyed hosts and keep a different one', () => {
 	expect(
 		resolveOnboardingStep3SelectedAgent(null, 'other', [{ kind: null }]),
 	).toBe('other')
+	expect(resolveOnboardingStep3SelectedAgent('other', 'other')).toBe('other')
+	expect(resolveOnboardingStep3SelectedAgent('other', 'cursor')).toBe('cursor')
 })

--- a/packages/worker/universal/onboarding-agent-ecosystems.ts
+++ b/packages/worker/universal/onboarding-agent-ecosystems.ts
@@ -6,7 +6,7 @@
  * company, and not a host that is already authorized.
  *
  * `other` is an unknown vendor. It never shares a family with a named host,
- * and Not listed stays available for another unlisted connect.
+ * and Not listed stays available even when the first pick was unlisted.
  */
 
 import { type McpClientKind } from '#universal/onboarding-mcp-clients.ts'
@@ -87,7 +87,7 @@ export function listOnboardingGreyedSecondAgents(
 	connectedAgents: ReadonlyArray<OnboardingConnectedAgentKind> = [],
 ): Array<OnboardingGreyedSecondAgent> {
 	const greyed = new Map<McpClientKind, OnboardingSecondAgentDisableReason>()
-	if (firstAgent) {
+	if (firstAgent && firstAgent !== 'other') {
 		for (const id of onboardingSameEcosystemAgents(firstAgent)) {
 			greyed.set(id, 'same-ecosystem')
 		}

--- a/packages/worker/universal/onboarding-agent-ecosystems.ts
+++ b/packages/worker/universal/onboarding-agent-ecosystems.ts
@@ -1,10 +1,12 @@
 /**
  * Product rule for onboarding Step 3: grey hosts in the same vendor family
- * as the agent the person started with. The second connect must be a
- * different ecosystem so Kody's shared home is the point — not a second
- * client of the same company.
+ * as the agent the person started with, plus every named host already in
+ * the Connected list. The second connect must be a different ecosystem so
+ * Kody's shared home is the point — not a second client of the same
+ * company, and not a host that is already authorized.
  *
- * `other` is an unknown vendor. It never shares a family with a named host.
+ * `other` is an unknown vendor. It never shares a family with a named host,
+ * and Not listed stays available for another unlisted connect.
  */
 
 import { type McpClientKind } from '#universal/onboarding-mcp-clients.ts'
@@ -50,31 +52,164 @@ export function onboardingSameEcosystemAgents(
 	return onboardingAgentEcosystems[onboardingAgentEcosystem(agent)]
 }
 
+export type OnboardingSecondAgentDisableReason = 'same-ecosystem' | 'connected'
+
+export type OnboardingGreyedSecondAgent = {
+	id: McpClientKind
+	reason: OnboardingSecondAgentDisableReason
+}
+
+export type OnboardingConnectedAgentKind = {
+	kind?: McpClientKind | null
+}
+
 /**
- * Hosts Step 3 greys. Named first agents grey their vendor family.
- * `other` only greys itself — we do not know that vendor.
+ * Named chooser ids already in the Connected list. `other` / unknown
+ * (`kind: null`) stay off this set — Not listed remains a path for a new
+ * unlisted host.
  */
+export function onboardingConnectedChooserKinds(
+	connectedAgents: ReadonlyArray<OnboardingConnectedAgentKind>,
+): Array<McpClientKind> {
+	const kinds = new Set<McpClientKind>()
+	for (const agent of connectedAgents) {
+		if (agent.kind && agent.kind !== 'other') kinds.add(agent.kind)
+	}
+	return [...kinds]
+}
+
+/**
+ * Hosts Step 3 greys: the first-agent vendor family, plus every named host
+ * already in the Connected list. Same-ecosystem wins when both apply.
+ */
+export function listOnboardingGreyedSecondAgents(
+	firstAgent: McpClientKind | null,
+	connectedAgents: ReadonlyArray<OnboardingConnectedAgentKind> = [],
+): Array<OnboardingGreyedSecondAgent> {
+	const greyed = new Map<McpClientKind, OnboardingSecondAgentDisableReason>()
+	if (firstAgent) {
+		for (const id of onboardingSameEcosystemAgents(firstAgent)) {
+			greyed.set(id, 'same-ecosystem')
+		}
+	}
+	for (const id of onboardingConnectedChooserKinds(connectedAgents)) {
+		if (!greyed.has(id)) greyed.set(id, 'connected')
+	}
+	return [...greyed].map(([id, reason]) => ({ id, reason }))
+}
+
 export function onboardingGreyedSecondAgents(
 	firstAgent: McpClientKind | null,
-): ReadonlyArray<McpClientKind> {
-	if (!firstAgent) return []
-	return onboardingSameEcosystemAgents(firstAgent)
+	connectedAgents: ReadonlyArray<OnboardingConnectedAgentKind> = [],
+): Array<McpClientKind> {
+	return listOnboardingGreyedSecondAgents(firstAgent, connectedAgents).map(
+		(entry) => entry.id,
+	)
 }
 
 export function isOnboardingSameEcosystemAgent(
 	firstAgent: McpClientKind | null,
 	candidate: McpClientKind,
 ): boolean {
-	return onboardingGreyedSecondAgents(firstAgent).includes(candidate)
+	if (!firstAgent) return false
+	return onboardingSameEcosystemAgents(firstAgent).includes(candidate)
 }
 
-/** Step 3 deep links to a same-ecosystem host fall back to the picker. */
+export function onboardingSecondAgentDisableReason(
+	candidate: McpClientKind,
+	firstAgent: McpClientKind | null,
+	connectedAgents: ReadonlyArray<OnboardingConnectedAgentKind> = [],
+): OnboardingSecondAgentDisableReason | null {
+	return (
+		listOnboardingGreyedSecondAgents(firstAgent, connectedAgents).find(
+			(entry) => entry.id === candidate,
+		)?.reason ?? null
+	)
+}
+
+export function onboardingSecondAgentDisableHint(
+	reason: OnboardingSecondAgentDisableReason,
+): string {
+	switch (reason) {
+		case 'same-ecosystem':
+			return 'Same ecosystem'
+		case 'connected':
+			return 'Connected'
+		default: {
+			const exhaustive: never = reason
+			return exhaustive
+		}
+	}
+}
+
+function onboardingSecondAgentDisableTitle(
+	reason: OnboardingSecondAgentDisableReason,
+	firstAgent: McpClientKind | null,
+	firstAgentLabel: string | null,
+): string {
+	switch (reason) {
+		case 'same-ecosystem':
+			return firstAgent && firstAgentLabel
+				? onboardingSameEcosystemDisabledReason(firstAgent, firstAgentLabel)
+				: "Pick a different ecosystem so Kody's home is portable."
+		case 'connected':
+			return 'Already connected. Pick a host that is not in your Connected list.'
+		default: {
+			const exhaustive: never = reason
+			return exhaustive
+		}
+	}
+}
+
+type OnboardingSecondAgentGreyedPresentation = {
+	greyedAgents: Array<McpClientKind>
+	greyedReasons: Partial<
+		Record<McpClientKind, OnboardingSecondAgentDisableReason>
+	>
+	greyedTitles: Partial<Record<McpClientKind, string>>
+}
+
+export function onboardingSecondAgentGreyedPresentation(
+	firstAgent: McpClientKind | null,
+	firstAgentLabel: string | null,
+	connectedAgents: ReadonlyArray<OnboardingConnectedAgentKind> = [],
+): OnboardingSecondAgentGreyedPresentation {
+	const entries = listOnboardingGreyedSecondAgents(firstAgent, connectedAgents)
+	const greyedReasons: Partial<
+		Record<McpClientKind, OnboardingSecondAgentDisableReason>
+	> = {}
+	const greyedTitles: Partial<Record<McpClientKind, string>> = {}
+	for (const entry of entries) {
+		greyedReasons[entry.id] = entry.reason
+		greyedTitles[entry.id] = onboardingSecondAgentDisableTitle(
+			entry.reason,
+			firstAgent,
+			firstAgentLabel,
+		)
+	}
+	return {
+		greyedAgents: entries.map((entry) => entry.id),
+		greyedReasons,
+		greyedTitles,
+	}
+}
+
+/** Step 3 deep links to a greyed host fall back to the picker. */
 export function resolveOnboardingStep3SelectedAgent(
 	firstAgent: McpClientKind | null,
 	selectedAgent: McpClientKind | null,
+	connectedAgents: ReadonlyArray<OnboardingConnectedAgentKind> = [],
 ): McpClientKind | null {
 	if (!selectedAgent) return null
-	if (isOnboardingSameEcosystemAgent(firstAgent, selectedAgent)) return null
+	if (
+		onboardingSecondAgentDisableReason(
+			selectedAgent,
+			firstAgent,
+			connectedAgents,
+		)
+	) {
+		return null
+	}
 	return selectedAgent
 }
 

--- a/packages/worker/universal/onboarding-process.node.test.ts
+++ b/packages/worker/universal/onboarding-process.node.test.ts
@@ -7,6 +7,7 @@ import {
 	onboardingAccessSelectedLede,
 	onboardingAccessWinMadeLine,
 	onboardingConnectedAgentLabelsLine,
+	uniqueOnboardingConnectedAgents,
 	onboardingAgentHref,
 	onboardingChecklistItemHref,
 	onboardingChecklistItems,
@@ -166,10 +167,20 @@ test('step 2 is one short prompt that retrieves the onboarding guide', () => {
 	)
 	expect(
 		onboardingConnectedAgentLabelsLine([
-			{ label: 'Cursor' },
-			{ label: 'Claude Desktop' },
+			{ label: 'Cursor', kind: 'cursor' },
+			{ label: 'Claude Desktop', kind: 'claude-desktop' },
 		]),
 	).toBe('Connected: Cursor and Claude Desktop')
+	expect(
+		uniqueOnboardingConnectedAgents([
+			{ label: 'Cursor', kind: 'cursor' },
+			{ label: ' Cursor ', kind: 'cursor' },
+			{ label: 'Kody' },
+		]),
+	).toEqual([
+		{ label: 'Cursor', kind: 'cursor' },
+		{ label: 'Kody', kind: null },
+	])
 	expect(onboardingSecondAgentConnectedStatusLabel(false)).toBe(
 		"You've connected a second agent.",
 	)

--- a/packages/worker/universal/onboarding-process.ts
+++ b/packages/worker/universal/onboarding-process.ts
@@ -181,14 +181,41 @@ export function onboardingSecondAgentConnectedStatusLabel(giftActive: boolean) {
 		: onboardingSecondAgentConnectedLabel
 }
 
+export type OnboardingConnectedAgentListItem = {
+	label: string
+	kind?: McpClientKind | null
+}
+
+export function uniqueOnboardingConnectedAgents(
+	agents: ReadonlyArray<OnboardingConnectedAgentListItem>,
+): Array<{ label: string; kind: McpClientKind | null }> {
+	const seen = new Set<string>()
+	const unique = new Array<{ label: string; kind: McpClientKind | null }>()
+	for (const agent of agents) {
+		const label = agent.label.trim()
+		if (!label || seen.has(label)) continue
+		seen.add(label)
+		unique.push({ label, kind: agent.kind ?? null })
+	}
+	return unique
+}
+
+export function onboardingConnectedListSeparator(
+	index: number,
+	length: number,
+): string {
+	if (index === 0) return ''
+	if (length === 2) return ' and '
+	if (index === length - 1) return ', and '
+	return ', '
+}
+
 export function onboardingConnectedAgentLabelsLine(
-	agents: ReadonlyArray<{ label: string }>,
+	agents: ReadonlyArray<OnboardingConnectedAgentListItem>,
 ) {
-	const labels = [
-		...new Set(
-			agents.map((agent) => agent.label.trim()).filter((label) => label),
-		),
-	]
+	const labels = uniqueOnboardingConnectedAgents(agents).map(
+		(agent) => agent.label,
+	)
 	if (labels.length === 0) return null
 	if (labels.length === 1) return `Connected: ${labels[0]}`
 	if (labels.length === 2) return `Connected: ${labels[0]} and ${labels[1]}`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Step 3 should make it obvious which agents are already authorized, so the person picks a **new** host instead of re-selecting ChatGPT, Cursor, or another Connected card.

## Why

The picker only muted the first-agent vendor family (`SAME ECOSYSTEM`). The Connected line already listed Devin, ChatGPT.com, Codex, Cursor, Copilot, and others, but those cards stayed fully clickable. That hid the “connect a different host” goal.

## Summary

- Grey every named host already in the Connected list (`kind` from unique inbound clientIds), with a `CONNECTED` reason label
- Keep existing `SAME ECOSYSTEM` treatment when both apply
- Leave **Not listed** available (unknown / `other` kinds do not disable that card, including when the first pick was unlisted)
- Deep links to a greyed host still fall back to the picker
- Prefix each Connected name with its onboarding logo at text size; unknown hosts omit the mark

## Testing

- Node unit: `onboarding-agent-ecosystems`, `onboarding-process`, `onboarding-wizard-panels`, picker prefetch
- Local `npm run validate` green (format, lint, typecheck, node, workers, e2e, mcp, knip)
- Pre-push: 🧪 Node (2787) and ☁️ Workers (341) unit suites green
- Preview: `npm run control-kody -- preview` as the seeded user on `/onboarding/step-3` (seed account has no inbound MCP grants, so CONNECTED greying is covered by unit tests; the preview pass checks the live picker and same-ecosystem mute)

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `6e81d50` · **Head:** `fa1debc`

**Classification:** extends — Step 3 now disables already-connected named hosts and renders Connected-line logos. No primitives added.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `app-ui` | surfaces | extends — Step 3 chooser greying and Connected-line marks |

### Change flow

Step 3 reads the remembered first agent and inbound Connected list, then greys same-ecosystem plus already-connected named hosts.

```mermaid
sequenceDiagram
	actor User
	participant appUi as app-ui
	User->>appUi: open /onboarding/step-3
	appUi->>appUi: remember first-agent ecosystem
	appUi->>appUi: map unique inbound clientIds to Connected kinds
	Note over appUi: SAME ECOSYSTEM wins over CONNECTED
	appUi-->>User: mute greyed cards and keep Not listed
	appUi-->>User: Connected line with inline host logos
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-68ee8fec-a4e6-47d2-97af-1980bcad8369?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-68ee8fec-a4e6-47d2-97af-1980bcad8369&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Onboarding now clearly identifies agents that cannot be selected because they belong to the same ecosystem or are already connected.
  - Disabled agent cards display specific explanations and contextual titles.
  - Connected agents are shown in a structured, deduplicated list with agent icons and improved formatting.
  - Agent availability and selection now reflect all currently connected agents.

- **Bug Fixes**
  - Prevented unavailable agents from being selected through onboarding deep links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->