### PR TITLE
Add real adminInviteCreate MCP capability for launch minting

### DIFF
--- a/.agents/skills/control-kody/references/features/admin.md
+++ b/.agents/skills/control-kody/references/features/admin.md
@@ -20,9 +20,11 @@ node tools/control-kody.ts request GET /admin 403
 use it unless the change is an admin surface. The users list accepts
 `verification=stalled` for unverified person accounts whose latest signup/verify
 send is still `accepted` after 60 minutes. `/admin/invites` also sets signup
-mode (`invite` / `open` / `waitlist`). Operators run one bounded
-unverified-account purge pass with `adminUnverifiedAccountPurgeRun` (`dryRun`
-previews the next claim page; results carry stable user ids).
+mode (`invite` / `open` / `waitlist`). Operators mint or list codes from MCP
+with `adminInviteCreate` (optional bulk `codes`) and `adminInviteList`.
+Operators run one bounded unverified-account purge pass with
+`adminUnverifiedAccountPurgeRun` (`dryRun` previews the next claim page; results
+carry stable user ids).
 
 ## APIs
 

--- a/docs/contributing/adding-capabilities.md
+++ b/docs/contributing/adding-capabilities.md
@@ -243,6 +243,8 @@ rule.
 - `adminReservedUsernameRemove`
 - `adminSignupModeGet`
 - `adminSignupModeSet`
+- `adminInviteCreate`
+- `adminInviteList`
 - `adminSystemEmailList`
 - `adminSystemEmailGet`
 - `adminSystemEmailSend`

--- a/docs/contributing/architecture/authentication.md
+++ b/docs/contributing/architecture/authentication.md
@@ -169,7 +169,10 @@ when one is provided so E2E coverage can exercise the same path.
 
 Admins manage invites at `/admin/invites`. The route uses the RBAC `admin` role
 guard, not an owner-scoped content bypass. Invite creation (including optional
-plan), use, and revocation emit audit events.
+plan), use, and revocation emit audit events. Agents mint the same rows with
+`adminInviteCreate` (optional bulk `codes` with a shared `maxUses`) and
+`adminInviteList`; both are admin-only MCP capabilities that call `createInvite`
+/ `listInvites` and return invite metadata only.
 
 The same admin page can create a user directly by email for manually invited
 people. That flow calls `adminCreateUserWithPasswordSetup` in
@@ -773,8 +776,10 @@ Token lifetimes are set on the `OAuthProvider` in
 - `packages/worker/src/mcp-auth.ts` for MCP token enforcement
 - `packages/worker/src/app/auth-session.ts` for cookie format/signing
 - `packages/worker/src/app/handlers/auth.ts` for app login/signup flow
-- `packages/worker/src/app/invites.ts` and
+- `packages/worker/src/invites.ts` and
   `packages/worker/src/app/handlers/admin-invites.ts` for invite management
+- `packages/worker/src/mcp/capabilities/admin/admin-invite-create.ts` and
+  `admin-invite-list.ts` for the admin MCP mint/list path
 - `packages/worker/src/identity/admin-user-creation.ts` for admin-created
   account setup links
 - `packages/worker/src/app/email-verification.ts`,

--- a/docs/contributing/architecture/authorization.md
+++ b/docs/contributing/architecture/authorization.md
@@ -153,18 +153,19 @@ the same way).
 
 ### Where guards are used
 
-| Route / handler                        | Guard                                              |
-| -------------------------------------- | -------------------------------------------------- |
-| `GET /admin`                           | `requireUserWithRole('admin')` → redirect to users |
-| `GET /admin/users`                     | `requireUserWithRole('admin')`                     |
-| `GET /admin/users.json`                | `requireUserWithPermission('read:user:any')`       |
-| `POST /admin/users.json` (roles, plan) | `requireUserWithPermission('update:user:any')`     |
-| `GET /admin/roles`                     | `requireUserWithRole('admin')`                     |
-| `GET /admin/roles.json`                | `requireUserWithPermission('read:role:any')`       |
-| `GET /admin/invites`                   | `requireUserWithRole('admin')`                     |
-| `GET/POST /admin/invites.json`         | `requireUserWithRole('admin')`                     |
-| `GET /admin/system-email`              | `requireUserWithRole('admin')`                     |
-| `GET /admin/system-email.json`         | `requireUserWithRole('admin')`                     |
+| Route / handler                             | Guard                                              |
+| ------------------------------------------- | -------------------------------------------------- |
+| `GET /admin`                                | `requireUserWithRole('admin')` → redirect to users |
+| `GET /admin/users`                          | `requireUserWithRole('admin')`                     |
+| `GET /admin/users.json`                     | `requireUserWithPermission('read:user:any')`       |
+| `POST /admin/users.json` (roles, plan)      | `requireUserWithPermission('update:user:any')`     |
+| `GET /admin/roles`                          | `requireUserWithRole('admin')`                     |
+| `GET /admin/roles.json`                     | `requireUserWithPermission('read:role:any')`       |
+| `GET /admin/invites`                        | `requireUserWithRole('admin')`                     |
+| `GET/POST /admin/invites.json`              | `requireUserWithRole('admin')`                     |
+| `adminInviteCreate` / `adminInviteList` MCP | `requiredRole: 'admin'`                            |
+| `GET /admin/system-email`                   | `requireUserWithRole('admin')`                     |
+| `GET /admin/system-email.json`              | `requireUserWithRole('admin')`                     |
 
 Handlers: `packages/worker/src/app/handlers/admin-users.ts`,
 `packages/worker/src/app/handlers/admin-roles.ts`,

--- a/docs/contributing/architecture/primitives.yaml
+++ b/docs/contributing/architecture/primitives.yaml
@@ -153,7 +153,7 @@ primitives:
       - packages/worker/src/app/handlers/webauthn.ts
       - packages/worker/src/app/handlers/account-two-factor.ts
       - packages/worker/src/app/handlers/account-passkeys.ts
-      - packages/worker/src/app/invites.ts
+      - packages/worker/src/invites.ts
       - packages/worker/src/signup-mode-setting.ts
       - packages/worker/src/app/email-verification.ts
       - packages/worker/src/app/onboarding-data.ts

--- a/packages/worker/src/app/handlers/admin-invites.ts
+++ b/packages/worker/src/app/handlers/admin-invites.ts
@@ -23,7 +23,7 @@ import {
 	createInvite,
 	normalizeInviteCode,
 	revokeInvite,
-} from '#app/invites.ts'
+} from '#worker/invites.ts'
 import { requirePageUserWithRole } from '#app/page-auth.ts'
 import { requireUserWithRole } from '#app/permissions-server.ts'
 import { readNonEmptyTrimmedStringOrNumber } from '#app/request-body.ts'

--- a/packages/worker/src/app/handlers/auth-provider.ts
+++ b/packages/worker/src/app/handlers/auth-provider.ts
@@ -21,7 +21,7 @@ import {
 	type InviteConsumeFailureReason,
 	normalizeInviteCode,
 	releaseInviteUse,
-} from '#app/invites.ts'
+} from '#worker/invites.ts'
 import { normalizeEmail } from '#worker/identity/normalize-email.ts'
 import {
 	oauthLoginErrorMessages,

--- a/packages/worker/src/app/handlers/auth.ts
+++ b/packages/worker/src/app/handlers/auth.ts
@@ -22,7 +22,7 @@ import {
 	getInviteFailureMessage,
 	normalizeInviteCode,
 	releaseInviteUse,
-} from '#app/invites.ts'
+} from '#worker/invites.ts'
 import { normalizeEmail } from '#worker/identity/normalize-email.ts'
 import { normalizeRedirectTo } from '#universal/safe-redirect.ts'
 import { assignUserRole } from '#worker/identity/permissions-db.ts'

--- a/packages/worker/src/invites.node.test.ts
+++ b/packages/worker/src/invites.node.test.ts
@@ -201,6 +201,33 @@ test('normalizeInviteCode trims, uppercases, and rejects empty or non-string val
 	expect(normalizeInviteCode(12)).toBeNull()
 })
 
+test('createInvite maps wrapped D1 unique errors to a stable already-exists message', async () => {
+	const db = {
+		prepare() {
+			return {
+				bind() {
+					return {
+						async run() {
+							const error = new Error('D1_ERROR')
+							error.cause = new Error('UNIQUE constraint failed: invites.code')
+							throw error
+						},
+					}
+				},
+			}
+		},
+	} as unknown as D1Database
+
+	await expect(
+		createInvite({
+			db,
+			code: 'kent-friend',
+			createdBy: 7,
+			maxUses: 1,
+		}),
+	).rejects.toThrow('Invite code KENT-FRIEND already exists.')
+})
+
 test('createInvite rejects a duplicate code', async () => {
 	const db = createInviteDb()
 	await createInvite({

--- a/packages/worker/src/invites.node.test.ts
+++ b/packages/worker/src/invites.node.test.ts
@@ -4,6 +4,7 @@ import {
 	createInvite,
 	getInviteByCode,
 	listInvites,
+	normalizeInviteCode,
 	type InviteRecord,
 } from './invites.ts'
 
@@ -18,6 +19,9 @@ function createInviteDb(invites: Array<InviteFixture> = []) {
 				async run() {
 					if (normalizedQuery.startsWith('insert into invites')) {
 						const [code, createdBy, note, maxUses, expiresAt, plan] = params
+						if (records.has(String(code))) {
+							throw new Error('UNIQUE constraint failed: invites.code')
+						}
 						const invite: InviteFixture = {
 							code: String(code),
 							created_by: createdBy == null ? null : Number(createdBy),
@@ -186,6 +190,34 @@ test('createInvite stores plan and roundtrips through getInviteByCode and listIn
 			plan: 'pro',
 		}),
 	])
+})
+
+test('normalizeInviteCode trims, uppercases, and rejects empty or non-string values', () => {
+	expect(normalizeInviteCode('  kent-friend  ')).toBe('KENT-FRIEND')
+	expect(normalizeInviteCode('already-upper')).toBe('ALREADY-UPPER')
+	expect(normalizeInviteCode('')).toBeNull()
+	expect(normalizeInviteCode('   ')).toBeNull()
+	expect(normalizeInviteCode(null)).toBeNull()
+	expect(normalizeInviteCode(12)).toBeNull()
+})
+
+test('createInvite rejects a duplicate code', async () => {
+	const db = createInviteDb()
+	await createInvite({
+		db,
+		code: 'kent-friend',
+		createdBy: 7,
+		maxUses: 1,
+	})
+
+	await expect(
+		createInvite({
+			db,
+			code: 'KENT-FRIEND',
+			createdBy: 7,
+			maxUses: 1,
+		}),
+	).rejects.toThrow('Invite code KENT-FRIEND already exists.')
 })
 
 test('createInvite without plan stores free', async () => {

--- a/packages/worker/src/invites.ts
+++ b/packages/worker/src/invites.ts
@@ -87,20 +87,28 @@ export async function createInvite(input: {
 		throw new Error('Max uses must be at least 1.')
 	}
 
-	await input.db
-		.prepare(
-			`INSERT INTO invites (code, created_by, note, max_uses, expires_at, plan)
+	try {
+		await input.db
+			.prepare(
+				`INSERT INTO invites (code, created_by, note, max_uses, expires_at, plan)
 			 VALUES (?, ?, ?, ?, ?, ?)`,
-		)
-		.bind(
-			code,
-			input.createdBy,
-			input.note?.trim() ?? '',
-			input.maxUses,
-			input.expiresAt ?? null,
-			resolvePlanWrite(input.plan),
-		)
-		.run()
+			)
+			.bind(
+				code,
+				input.createdBy,
+				input.note?.trim() ?? '',
+				input.maxUses,
+				input.expiresAt ?? null,
+				resolvePlanWrite(input.plan),
+			)
+			.run()
+	} catch (error) {
+		const message = error instanceof Error ? error.message : ''
+		if (/unique constraint failed/i.test(message)) {
+			throw new Error(`Invite code ${code} already exists.`)
+		}
+		throw error
+	}
 
 	const invite = await getInviteByCode(input.db, code)
 	if (!invite) throw new Error('Invite was not created.')

--- a/packages/worker/src/invites.ts
+++ b/packages/worker/src/invites.ts
@@ -1,4 +1,5 @@
 import { resolvePlanWrite, type PlanName } from '#universal/plans.ts'
+import { getUniqueConstraintField } from '#worker/database-errors.ts'
 
 export type InviteRecord = {
 	code: string
@@ -103,8 +104,7 @@ export async function createInvite(input: {
 			)
 			.run()
 	} catch (error) {
-		const message = error instanceof Error ? error.message : ''
-		if (/unique constraint failed/i.test(message)) {
+		if (getUniqueConstraintField(error) === 'code') {
 			throw new Error(`Invite code ${code} already exists.`)
 		}
 		throw error

--- a/packages/worker/src/mcp/capabilities/admin/admin-feature-flag-override.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-feature-flag-override.ts
@@ -10,12 +10,12 @@ import {
 import {
 	adminMutationCapabilityAccess,
 	auditAdminCapabilityInvocation,
+	resolveActingAdminUserId,
 	stableUserIdSchema,
 } from './admin-shared.ts'
 import {
 	adminFeatureFlagSchema,
 	assertFeatureFlagKey,
-	resolveActingAdminUserId,
 	resolveTargetUser,
 } from './feature-flag-shared.ts'
 

--- a/packages/worker/src/mcp/capabilities/admin/admin-feature-flag-set.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-feature-flag-set.ts
@@ -9,11 +9,11 @@ import {
 import {
 	adminMutationCapabilityAccess,
 	auditAdminCapabilityInvocation,
+	resolveActingAdminUserId,
 } from './admin-shared.ts'
 import {
 	adminFeatureFlagSchema,
 	assertFeatureFlagKey,
-	resolveActingAdminUserId,
 } from './feature-flag-shared.ts'
 
 const inputSchema = z.object({

--- a/packages/worker/src/mcp/capabilities/admin/admin-invite-capabilities.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-invite-capabilities.node.test.ts
@@ -1,0 +1,220 @@
+import { DatabaseSync } from 'node:sqlite'
+import { expect, test } from 'vitest'
+import { McpCallerError } from '#mcp/caller-error.ts'
+import { createMcpCallerContext } from '#mcp/context.ts'
+import { quoteSqlString } from '@kody-internal/shared/sql-literals.ts'
+import { applyAllMigrations } from '#worker/test-support/apply-all-migrations.ts'
+import {
+	auditEventSummaries,
+	logAuditEventSpy,
+} from '#worker/test-support/audit-log-spy.ts'
+import { createD1FromSqlite } from '#worker/test-support/create-d1-from-sqlite.ts'
+import { testStableUserIdFromEmail } from '#worker/test-support/stable-user-id.ts'
+import { adminInviteCreateCapability } from './admin-invite-create.ts'
+import { adminInviteListCapability } from './admin-invite-list.ts'
+
+function createMigratedDb() {
+	const sqlite = new DatabaseSync(':memory:')
+	applyAllMigrations(
+		sqlite,
+		new URL('../../../../migrations/', import.meta.url),
+	)
+	return { sqlite, db: createD1FromSqlite(sqlite) }
+}
+
+function createContext(
+	roles: Array<string>,
+	envOverrides: Record<string, unknown> = {},
+) {
+	const adminStableUserId = testStableUserIdFromEmail('admin@example.com')
+	return {
+		env: {
+			APP_DB: {} as D1Database,
+			...envOverrides,
+		} as Env,
+		callerContext: createMcpCallerContext({
+			baseUrl: 'https://example.com',
+			user: {
+				userId: adminStableUserId,
+				email: 'admin@example.com',
+				displayName: 'admin',
+				roles,
+			},
+		}),
+		adminStableUserId,
+	}
+}
+
+function seedAdminUser(sqlite: DatabaseSync, stableUserId: string) {
+	sqlite.exec(`
+		INSERT INTO users (username, email, stable_user_id, password_hash)
+		VALUES (
+			'admin',
+			'admin@example.com',
+			${quoteSqlString(stableUserId)},
+			'oauth_created_no_usable_password'
+		);
+	`)
+}
+
+test('adminInviteCreate and adminInviteList: admin-only, normalize, bulk, audit', async () => {
+	const userCtx = createContext(['user'])
+	await expect(adminInviteListCapability.handler({}, userCtx)).rejects.toThrow(
+		'lacks required role "admin"',
+	)
+	await expect(
+		adminInviteCreateCapability.handler(
+			{ code: 'KENT-FRIEND', note: 'launch' },
+			userCtx,
+		),
+	).rejects.toThrow('lacks required role "admin"')
+	expect(logAuditEventSpy).toHaveBeenCalledWith(
+		expect.objectContaining({
+			category: 'auth',
+			action: 'mcp_capability_denied',
+			result: 'failure',
+			reason: 'role',
+		}),
+	)
+
+	const { sqlite, db } = createMigratedDb()
+	const adminCtx = createContext(['admin'], { APP_DB: db })
+	seedAdminUser(sqlite, adminCtx.adminStableUserId)
+
+	const created = await adminInviteCreateCapability.handler(
+		{ code: '  kent-friend  ', note: 'launch email', maxUses: 1 },
+		adminCtx,
+	)
+	expect(created.invite).toEqual({
+		code: 'KENT-FRIEND',
+		maxUses: 1,
+		note: 'launch email',
+		plan: 'free',
+		expiresAt: null,
+		createdAt: expect.any(String),
+	})
+	expect(created.invites).toEqual([created.invite])
+	expect(created.failed).toEqual([])
+
+	const generated = await adminInviteCreateCapability.handler({}, adminCtx)
+	expect(generated.invite.code).toMatch(/^KODY-[A-F0-9-]+$/)
+	expect(generated.invite.maxUses).toBe(1)
+	expect(generated.invite.plan).toBe('free')
+
+	const bulk = await adminInviteCreateCapability.handler(
+		{
+			note: 'shared note',
+			maxUses: 2,
+			plan: 'pro',
+			expiresAt: '2026-12-01T00:00:00.000Z',
+			codes: [
+				{ code: 'jane-friend' },
+				{ code: 'alex-friend', note: 'personal' },
+			],
+		},
+		adminCtx,
+	)
+	expect(bulk.invites).toEqual([
+		expect.objectContaining({
+			code: 'JANE-FRIEND',
+			note: 'shared note',
+			maxUses: 2,
+			plan: 'pro',
+			expiresAt: '2026-12-01T00:00:00.000Z',
+		}),
+		expect.objectContaining({
+			code: 'ALEX-FRIEND',
+			note: 'personal',
+			maxUses: 2,
+			plan: 'pro',
+		}),
+	])
+	expect(bulk.invite.code).toBe('JANE-FRIEND')
+	expect(bulk.failed).toEqual([])
+
+	await expect(
+		adminInviteCreateCapability.handler({ code: 'kent-friend' }, adminCtx),
+	).rejects.toBeInstanceOf(McpCallerError)
+	await expect(
+		adminInviteCreateCapability.handler({ code: 'kent-friend' }, adminCtx),
+	).rejects.toThrow('Invite code KENT-FRIEND already exists.')
+
+	const mixed = await adminInviteCreateCapability.handler(
+		{
+			codes: [{ code: 'kent-friend' }, { code: 'new-friend' }],
+		},
+		adminCtx,
+	)
+	expect(mixed.invites.map((invite) => invite.code)).toEqual(['NEW-FRIEND'])
+	expect(mixed.failed).toEqual([
+		{
+			code: 'KENT-FRIEND',
+			error: 'Invite code KENT-FRIEND already exists.',
+		},
+	])
+
+	await expect(
+		adminInviteCreateCapability.handler(
+			{ code: 'solo', codes: [{ code: 'bulk' }] },
+			adminCtx,
+		),
+	).rejects.toThrow('Provide either code or codes, not both.')
+	await expect(
+		adminInviteCreateCapability.handler(
+			{ codes: [{ code: 'dup-friend' }, { code: 'dup-friend' }] },
+			adminCtx,
+		),
+	).rejects.toThrow('Duplicate invite code in request: DUP-FRIEND')
+	await expect(
+		adminInviteCreateCapability.handler({ expiresAt: 'not-a-date' }, adminCtx),
+	).rejects.toThrow('expiresAt must be a valid date.')
+	await expect(
+		adminInviteCreateCapability.handler({ code: '   ' }, adminCtx),
+	).rejects.toThrow('Invite code must not be empty.')
+
+	const listed = await adminInviteListCapability.handler({}, adminCtx)
+	expect(listed.invites.map((invite) => invite.code)).toEqual(
+		expect.arrayContaining([
+			'KENT-FRIEND',
+			generated.invite.code,
+			'JANE-FRIEND',
+			'ALEX-FRIEND',
+			'NEW-FRIEND',
+		]),
+	)
+	expect(
+		listed.invites.find((invite) => invite.code === 'KENT-FRIEND'),
+	).toEqual({
+		code: 'KENT-FRIEND',
+		maxUses: 1,
+		useCount: 0,
+		note: 'launch email',
+		plan: 'free',
+		expiresAt: null,
+		revokedAt: null,
+		createdAt: expect.any(String),
+	})
+	expect(listed.invites.some((invite) => 'created_by' in invite)).toBe(false)
+
+	const signupMode = sqlite
+		.prepare(`SELECT COUNT(*) AS total FROM invites`)
+		.get() as { total: number }
+	expect(signupMode.total).toBe(5)
+
+	expect(auditEventSummaries()).toEqual(
+		expect.arrayContaining([
+			'mcp_capability_denied:failure',
+			'adminInviteCreate:success',
+			'adminInviteCreate:failure',
+			'adminInviteList:success',
+		]),
+	)
+	expect(logAuditEventSpy).toHaveBeenCalledWith(
+		expect.objectContaining({
+			category: 'admin',
+			action: 'adminInviteCreate',
+			result: 'success',
+			reason: 'invite_code=KENT-FRIEND;max_uses=1;plan=free',
+		}),
+	)
+})

--- a/packages/worker/src/mcp/capabilities/admin/admin-invite-create.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-invite-create.ts
@@ -1,0 +1,227 @@
+import { z } from 'zod'
+import { McpCallerError } from '#mcp/caller-error.ts'
+import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
+import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
+import { createInvite, normalizeInviteCode } from '#worker/invites.ts'
+import {
+	adminMutationCapabilityAccess,
+	auditAdminCapabilityInvocation,
+	planNameSchema,
+	resolveActingAdminUserId,
+} from './admin-shared.ts'
+import {
+	adminInviteCreatedSchema,
+	type AdminInviteCreated,
+	toCreatedInviteMetadata,
+} from './admin-invite-shared.ts'
+
+const bulkInviteItemSchema = z.object({
+	code: z
+		.string()
+		.min(1)
+		.describe('Custom invite code. Normalized to uppercase.'),
+	note: z
+		.string()
+		.optional()
+		.describe(
+			'Optional operator note for this code. Falls back to the shared note when omitted.',
+		),
+})
+
+const inputSchema = z.object({
+	code: z
+		.string()
+		.min(1)
+		.optional()
+		.describe(
+			'Optional custom invite code. Normalized to uppercase. When omitted, Kody generates a random KODY-... code. Do not pass this together with codes.',
+		),
+	note: z
+		.string()
+		.optional()
+		.describe(
+			'Optional operator note stored with the invite. Not shown to invitees. Shared default for bulk items that omit their own note.',
+		),
+	maxUses: z
+		.number()
+		.int()
+		.min(1)
+		.default(1)
+		.describe(
+			'Maximum number of successful signups this invite can grant. Defaults to 1.',
+		),
+	expiresAt: z
+		.string()
+		.optional()
+		.describe(
+			'Optional ISO-8601 expiration timestamp. After this time the code cannot be consumed.',
+		),
+	plan: planNameSchema
+		.optional()
+		.describe(
+			'Optional plan granted to accounts that sign up with this invite. Defaults to free.',
+		),
+	codes: z
+		.array(bulkInviteItemSchema)
+		.min(1)
+		.max(200)
+		.optional()
+		.describe(
+			'Optional bulk create. Shared maxUses, expiresAt, and plan apply to every item. Prefer this for launch batches instead of looping single creates.',
+		),
+})
+
+const failedInviteSchema = z.object({
+	code: z.string(),
+	error: z.string(),
+})
+
+const outputSchema = z.object({
+	invite: adminInviteCreatedSchema,
+	invites: z.array(adminInviteCreatedSchema),
+	failed: z.array(failedInviteSchema),
+})
+
+function parseExpiresAt(value: string | undefined) {
+	if (!value?.trim()) return null
+	const date = new Date(value)
+	if (Number.isNaN(date.getTime())) {
+		throw new McpCallerError('expiresAt must be a valid date.')
+	}
+	return date.toISOString()
+}
+
+function toInviteCreateError(error: unknown, code?: string) {
+	const message =
+		error instanceof Error ? error.message : 'Unable to create invite.'
+	if (/already exists/i.test(message)) {
+		return new McpCallerError(message, {
+			cause: error instanceof Error ? error : undefined,
+		})
+	}
+	return new McpCallerError(code ? `${message} (${code})` : message, {
+		cause: error instanceof Error ? error : undefined,
+	})
+}
+
+function resolveCreateItems(args: {
+	code?: string
+	note?: string
+	codes?: Array<{ code: string; note?: string }>
+}) {
+	if (args.codes) {
+		if (args.code) {
+			throw new McpCallerError('Provide either code or codes, not both.')
+		}
+		return args.codes.map((item) => ({
+			code: item.code,
+			note: item.note ?? args.note ?? '',
+		}))
+	}
+	return [
+		{
+			code: args.code,
+			note: args.note ?? '',
+		},
+	]
+}
+
+function assertNoDuplicateCodes(items: Array<{ code?: string; note: string }>) {
+	const seen = new Set<string>()
+	for (const item of items) {
+		const normalized = normalizeInviteCode(item.code)
+		if (!normalized) continue
+		if (seen.has(normalized)) {
+			throw new McpCallerError(
+				`Duplicate invite code in request: ${normalized}`,
+			)
+		}
+		seen.add(normalized)
+	}
+}
+
+export const adminInviteCreateCapability = defineDomainCapability(
+	capabilityDomainNames.admin,
+	{
+		...adminMutationCapabilityAccess,
+		name: 'adminInviteCreate',
+		description:
+			'Create one or many signup invite codes. Admin-only; returns invite metadata only (no secrets). Use codes for a launch batch with a shared maxUses.',
+		keywords: [
+			'admin',
+			'invite',
+			'invites',
+			'create',
+			'code',
+			'signup',
+			'friend',
+			'bulk',
+		],
+		inputSchema,
+		outputSchema,
+		async handler(args, ctx) {
+			return auditAdminCapabilityInvocation(
+				ctx,
+				'adminInviteCreate',
+				async () => {
+					const expiresAt = parseExpiresAt(args.expiresAt)
+					const items = resolveCreateItems(args)
+					assertNoDuplicateCodes(items)
+					const createdBy = await resolveActingAdminUserId(ctx)
+					const invites: Array<AdminInviteCreated> = []
+					const failed: Array<{ code: string; error: string }> = []
+
+					for (const item of items) {
+						const normalizedCode = normalizeInviteCode(item.code)
+						const requestedCode = normalizedCode ?? item.code
+						try {
+							if (item.code !== undefined && normalizedCode === null) {
+								throw new McpCallerError('Invite code must not be empty.')
+							}
+							const invite = await createInvite({
+								db: ctx.env.APP_DB,
+								code: item.code,
+								createdBy,
+								note: item.note,
+								maxUses: args.maxUses,
+								expiresAt,
+								plan: args.plan,
+							})
+							invites.push(toCreatedInviteMetadata(invite))
+						} catch (error) {
+							failed.push({
+								code: requestedCode ?? '',
+								error:
+									error instanceof Error
+										? error.message
+										: 'Unable to create invite.',
+							})
+							if (items.length === 1) {
+								throw toInviteCreateError(error, requestedCode)
+							}
+						}
+					}
+
+					const [invite] = invites
+					if (!invite) {
+						throw new McpCallerError(
+							failed[0]?.error ?? 'Unable to create invite.',
+						)
+					}
+
+					return {
+						invite,
+						invites,
+						failed,
+					}
+				},
+				{
+					successReason: ({ invite, invites, failed }) =>
+						invites.length === 1 && failed.length === 0
+							? `invite_code=${invite.code};max_uses=${invite.maxUses};plan=${invite.plan}`
+							: `count=${invites.length};max_uses=${invite.maxUses};plan=${invite.plan};failed=${failed.length}`,
+				},
+			)
+		},
+	},
+)

--- a/packages/worker/src/mcp/capabilities/admin/admin-invite-list.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-invite-list.ts
@@ -1,0 +1,44 @@
+import { z } from 'zod'
+import { listInvites } from '#worker/invites.ts'
+import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
+import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
+import { emptyCapabilityInputSchema } from '#mcp/capabilities/types.ts'
+import {
+	adminCapabilityAccess,
+	auditAdminCapabilityInvocation,
+} from './admin-shared.ts'
+import {
+	adminInviteListedSchema,
+	toListedInviteMetadata,
+} from './admin-invite-shared.ts'
+
+const outputSchema = z.object({
+	invites: z.array(adminInviteListedSchema),
+})
+
+export const adminInviteListCapability = defineDomainCapability(
+	capabilityDomainNames.admin,
+	{
+		...adminCapabilityAccess,
+		name: 'adminInviteList',
+		description:
+			'List existing signup invite codes and their use, expiry, and revocation state. Admin-only; returns invite metadata only (no secrets). Newest first, capped at 200.',
+		keywords: ['admin', 'invite', 'invites', 'list', 'code', 'signup'],
+		inputSchema: emptyCapabilityInputSchema,
+		outputSchema,
+		async handler(_args, ctx) {
+			return auditAdminCapabilityInvocation(
+				ctx,
+				'adminInviteList',
+				async () => ({
+					invites: (await listInvites(ctx.env.APP_DB)).map(
+						toListedInviteMetadata,
+					),
+				}),
+				{
+					successReason: ({ invites }) => `count=${invites.length}`,
+				},
+			)
+		},
+	},
+)

--- a/packages/worker/src/mcp/capabilities/admin/admin-invite-shared.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-invite-shared.ts
@@ -1,0 +1,39 @@
+import { z } from 'zod'
+import { type InviteRecord } from '#worker/invites.ts'
+import { parseStoredPlanName } from '#universal/plans.ts'
+import { planNameSchema } from './admin-shared.ts'
+
+export const adminInviteCreatedSchema = z.object({
+	code: z.string(),
+	maxUses: z.number().int().positive(),
+	note: z.string(),
+	plan: planNameSchema,
+	expiresAt: z.string().nullable(),
+	createdAt: z.string(),
+})
+
+export const adminInviteListedSchema = adminInviteCreatedSchema.extend({
+	useCount: z.number().int().nonnegative(),
+	revokedAt: z.string().nullable(),
+})
+
+export type AdminInviteCreated = z.infer<typeof adminInviteCreatedSchema>
+
+export function toCreatedInviteMetadata(invite: InviteRecord) {
+	return {
+		code: invite.code,
+		maxUses: invite.max_uses,
+		note: invite.note,
+		plan: parseStoredPlanName(invite.plan),
+		expiresAt: invite.expires_at,
+		createdAt: invite.created_at,
+	}
+}
+
+export function toListedInviteMetadata(invite: InviteRecord) {
+	return {
+		...toCreatedInviteMetadata(invite),
+		useCount: invite.use_count,
+		revokedAt: invite.revoked_at,
+	}
+}

--- a/packages/worker/src/mcp/capabilities/admin/admin-shared.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-shared.ts
@@ -10,7 +10,9 @@ import {
 } from '#universal/email-verification-delivery.ts'
 import { roleNames } from '#universal/permissions.ts'
 import { planNames } from '#universal/plans.ts'
+import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
 import { type CapabilityContext } from '#mcp/capabilities/types.ts'
+import { normalizeStableUserId } from '#worker/user-id.ts'
 
 export const adminCapabilityAccess = {
 	requiredRole: 'admin',
@@ -202,4 +204,23 @@ export function buildCreatedUserAuditReason(input: {
 		`target_stable_user_id=${input.stableUserId}`,
 		`target_email=${redactEmailRecipient(input.email)}`,
 	].join(';')
+}
+
+export async function resolveActingAdminUserId(
+	ctx: CapabilityContext,
+): Promise<number> {
+	const user = requireMcpUser(ctx.callerContext)
+	const stableUserId = normalizeStableUserId(user.userId)
+	if (!stableUserId) {
+		throw new Error('Authenticated admin account was not found.')
+	}
+	const row = await ctx.env.APP_DB.prepare(
+		`SELECT id FROM users WHERE stable_user_id = ?`,
+	)
+		.bind(stableUserId)
+		.first<{ id: number }>()
+	if (!row) {
+		throw new Error('Authenticated admin account was not found.')
+	}
+	return row.id
 }

--- a/packages/worker/src/mcp/capabilities/admin/domain.ts
+++ b/packages/worker/src/mcp/capabilities/admin/domain.ts
@@ -5,6 +5,8 @@ import { adminCommunityActivityListCapability } from './admin-community-activity
 import { adminFeatureFlagListCapability } from './admin-feature-flag-list.ts'
 import { adminFeatureFlagOverrideCapability } from './admin-feature-flag-override.ts'
 import { adminFeatureFlagSetCapability } from './admin-feature-flag-set.ts'
+import { adminInviteCreateCapability } from './admin-invite-create.ts'
+import { adminInviteListCapability } from './admin-invite-list.ts'
 import { adminSignupModeGetCapability } from './admin-signup-mode-get.ts'
 import { adminSignupModeSetCapability } from './admin-signup-mode-set.ts'
 import { adminPackageCodemodApplyCapability } from './admin-package-codemod-apply.ts'
@@ -64,6 +66,8 @@ export const adminDomain = defineDomain({
 		'audit',
 		'feature flags',
 		'signup mode',
+		'invite',
+		'invites',
 		'system email',
 		'platform feedback',
 		'community activity',
@@ -124,6 +128,8 @@ export const adminDomain = defineDomain({
 		adminReservedUsernameRemoveCapability,
 		adminSignupModeGetCapability,
 		adminSignupModeSetCapability,
+		adminInviteCreateCapability,
+		adminInviteListCapability,
 		adminSystemEmailListCapability,
 		adminSystemEmailGetCapability,
 		adminSystemEmailSendCapability,

--- a/packages/worker/src/mcp/capabilities/admin/feature-flag-shared.ts
+++ b/packages/worker/src/mcp/capabilities/admin/feature-flag-shared.ts
@@ -1,6 +1,4 @@
 import { z } from 'zod'
-import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
-import { type CapabilityContext } from '#mcp/capabilities/types.ts'
 import {
 	featureFlagKeys,
 	isFeatureFlagKey,
@@ -77,25 +75,6 @@ export function assertFeatureFlagKey(key: string): FeatureFlagKey {
 		)
 	}
 	return key
-}
-
-export async function resolveActingAdminUserId(
-	ctx: CapabilityContext,
-): Promise<number> {
-	const user = requireMcpUser(ctx.callerContext)
-	const stableUserId = normalizeStableUserId(user.userId)
-	if (!stableUserId) {
-		throw new Error('Authenticated admin account was not found.')
-	}
-	const row = await ctx.env.APP_DB.prepare(
-		`SELECT id FROM users WHERE stable_user_id = ?`,
-	)
-		.bind(stableUserId)
-		.first<{ id: number }>()
-	if (!row) {
-		throw new Error('Authenticated admin account was not found.')
-	}
-	return row.id
 }
 
 export async function resolveTargetUser(

--- a/packages/worker/src/mcp/capabilities/registry.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/registry.node.test.ts
@@ -105,6 +105,8 @@ test('getCapabilityRegistryForContext filters admin capabilities by current call
 	expect(adminRegistry.capabilityMap.adminMailboxMaintenance).toBeTruthy()
 	expect(adminRegistry.capabilityMap.adminSignupModeGet).toBeTruthy()
 	expect(adminRegistry.capabilityMap.adminSignupModeSet).toBeTruthy()
+	expect(adminRegistry.capabilityMap.adminInviteCreate).toBeTruthy()
+	expect(adminRegistry.capabilityMap.adminInviteList).toBeTruthy()
 	expect(
 		adminRegistry.capabilityMap.adminUserMeterStorageReconcile,
 	).toBeTruthy()
@@ -128,6 +130,8 @@ test('getCapabilityRegistryForContext filters admin capabilities by current call
 	expect(regularRegistry.capabilityMap.adminMailboxMaintenance).toBeUndefined()
 	expect(regularRegistry.capabilityMap.adminSignupModeGet).toBeUndefined()
 	expect(regularRegistry.capabilityMap.adminSignupModeSet).toBeUndefined()
+	expect(regularRegistry.capabilityMap.adminInviteCreate).toBeUndefined()
+	expect(regularRegistry.capabilityMap.adminInviteList).toBeUndefined()
 	expect(
 		regularRegistry.capabilityDomains.some((domain) => domain.name === 'admin'),
 	).toBe(false)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Give admin agents a real MCP capability to mint signup invite codes so launch emails can keep promising personal `{USERNAME}-FRIEND` codes.

## Why

`kody.adminInviteCreate` already looked like a function in execute, but the call failed with `Tool not found`. There was no registered admin invite capability. HTTP `POST /admin/invites.json` already works; Kent wants minting to go through Kody MCP, not the admin UI. This is launch-blocking for agent minting.

## Summary

- Add admin-only `adminInviteCreate` that calls `createInvite` with the actor's `users.id`, audits like other admin caps, and returns invite metadata only (code, maxUses, note, plan, expiresAt, createdAt).
- Support a bulk `codes: Array<{ code, note }>` shape (shared `maxUses` / `expiresAt` / `plan`, max 200) so launch can mint ~179 codes in one execute.
- Add `adminInviteList` for the existing `listInvites` read (newest first, cap 200).
- Move invite helpers from `#app/invites.ts` to `#worker/invites.ts` so MCP can import them without crossing the app/MCP boundary. HTTP handlers keep calling the same functions.
- Duplicate codes fail with `Invite code {CODE} already exists.`, including wrapped D1 `error.cause` unique constraints.
- Docs and registry tests list the new capabilities. Signup mode and existing invites are unchanged.

## Testing

- Focused node-unit suites for invites, admin invite capabilities, admin invites HTTP, registry, and feature-flag resolver: pass
- Pre-push hook: `test:node` (2790) and `test:workers` (341): pass
- Pre-commit: oxlint + worker typecheck + migrations check: pass

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends capability-registry</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `6e81d504` · **Head:** `2d576591`

**Classification:** extends — new admin MCP capabilities and a clearer duplicate-code error on the existing invite writer. No new primitive.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `capability-registry` | assistant | extends — registers `adminInviteCreate` and `adminInviteList` |
| `rbac` | auth | composes — `requiredRole: 'admin'` only |
| `app-sessions` | auth | extends — invite helpers move to `#worker/invites.ts` and duplicate inserts get a stable error |

### Change flow

An admin execute mints invite rows through the new capabilities and the existing invite writer. Signup mode is not on this path.

```mermaid
sequenceDiagram
	actor Admin
	participant capabilityRegistry as capability-registry
	participant rbac as rbac
	participant appSessions as app-sessions
	Admin->>capabilityRegistry: execute adminInviteCreate or adminInviteList
	capabilityRegistry->>rbac: requiredRole admin gate
	rbac->>appSessions: createInvite or listInvites
	Note over capabilityRegistry: bulk codes share maxUses, expiresAt, and plan
	Note over appSessions: returns metadata only, no secrets
```

### Before / after

**Before:** `kody.adminInviteCreate` is a phantom execute binding and fails with `Tool not found`. Only `POST /admin/invites.json` can mint.

**After:** `kody.adminInviteCreate({ code, note, maxUses })` and `kody.adminInviteCreate({ codes, maxUses })` write the same `invites` rows as HTTP. `adminInviteList` returns current codes.

### Invariants

Per-user isolation is unchanged. These capabilities stay admin-only and do not change signup mode or revoke existing invites.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a70b78f0-3a6e-4975-9a97-7aa1c4187511?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a70b78f0-3a6e-4975-9a97-7aa1c4187511&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added admin-only invite management capabilities for creating single or bulk invite codes.
  - Added invite listing with usage, expiration, plan, and revocation metadata.
  - Added support for notes, usage limits, expiration dates, plans, automatic code generation, and duplicate detection.
  - Invite operations enforce administrator access and record audit events.

- **Bug Fixes**
  - Duplicate invite codes now return a clear user-facing error.

- **Documentation**
  - Updated admin, authentication, authorization, and capability documentation for invite management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->