### PR TITLE
docs: record Stripe dashboard dunning settings next to billing env vars

### DIFF
--- a/docs/contributing/environment-variables.md
+++ b/docs/contributing/environment-variables.md
@@ -295,6 +295,16 @@ off-portal; the Stripe Billing Portal configuration
 $12/$120 and Pro $49/$480
 checkout prices.
 
+Dashboard-side dunning (not an environment variable, recorded here so it
+survives re-provisioning): the production Stripe account has every customer
+email under Settings → Billing → Subscriptions and emails → "Email notifications
+and customer management" enabled (trial-ending reminder, upcoming renewals,
+expiring cards, failed card payments, failed bank-debit payments), and "Manage
+failed payments" cancels the subscription when all retries fail. Kody also sends
+its own past-due and payment-failed emails (`billing/subscription-sync.ts`,
+`billing/stripe-webhooks.ts`), deduplicated so one failed charge is not two Kody
+emails; the Stripe email is additive and carries the card-update link.
+
 See [`architecture/entitlements.md`](./architecture/entitlements.md) (Billing).
 
 ## MCP OIDC ID token signing


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes item 5 of #1092 (Stripe dunning).

The code side already shipped: `billing/subscription-sync.ts` sends a past-due email and `billing/stripe-webhooks.ts` sends a payment-failed email, deduplicated so one failed charge is not two Kody emails. What remained was the dashboard side, which Kent enabled on 2026-09-07 (all five customer emails under Settings → Billing → Subscriptions and emails, and "cancel the subscription" when all retries fail).

This records those dashboard settings in `docs/contributing/environment-variables.md` under the Stripe billing section so they survive re-provisioning, as the issue asked.

Docs-only. `format:check`, `docs:check-temporal`, and `docs:check-decisions` pass locally.

## System recap

Risk: low. Documentation only; no primitive touched.

```mermaid
flowchart LR
  A[Stripe dashboard dunning toggles] -->|recorded in| B[docs/contributing/environment-variables.md]
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-49e62064-0c0f-4805-958b-eb169a46613d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-49e62064-0c0f-4805-958b-eb169a46613d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated billing documentation with details about Stripe payment-retry behavior and subscription cancellation after unsuccessful retries.
  - Clarified the payment notifications customers may receive, including past-due and payment-failed emails, plus the Stripe message containing the card-update link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->