### PR TITLE
tools: control-kody package-create for preview package data

### DIFF
--- a/.agents/skills/control-kody/SKILL.md
+++ b/.agents/skills/control-kody/SKILL.md
@@ -19,6 +19,7 @@ node tools/control-kody.ts request GET /account/waiting.json
 node tools/control-kody.ts map waiting
 node tools/control-kody.ts health --sha <merge-sha>
 node tools/control-kody.ts preview -- --request 'GET /account/waiting.json' --check /account/waiting
+node tools/control-kody.ts package-create --origin <preview> --kody-id <slug> [--head-ahead]
 ```
 
 `npm run control-kody -- <command>` is the same entry.
@@ -36,7 +37,7 @@ Load **one** feature file for the surface you are changing.
 
 - Local: `jane@example.com` / `ilikecode` (non-admin)
 - Preview: `me@kentcdodds.com` / `ilikecode` (non-admin, empty until you create
-  data through JSON APIs)
+  data through JSON APIs, or `package-create` for a saved package)
 - `/admin` 403 and `/mcp` 401 are expected for those seeds
 
 ## Proof

--- a/.agents/skills/control-kody/references/features/packages.md
+++ b/.agents/skills/control-kody/references/features/packages.md
@@ -32,7 +32,10 @@ node tools/control-kody.ts preview -- \
 ```
 
 `--head-ahead` pushes one unpublished commit so the Code tab can show **HEAD
-ahead of published**. To prove delete, create a package with `package-create`,
+ahead of published**. It needs a minted Artifacts write remote. If
+`packageGetGitRemote` fails with source-safety `account not found`, the stub
+package still exists (check `/@username/:kodyId`) but HEAD-ahead cannot be
+pushed on that preview. To prove delete, create a package with `package-create`,
 then delete it and assert the empty state.
 
 ## APIs

--- a/.agents/skills/control-kody/references/features/packages.md
+++ b/.agents/skills/control-kody/references/features/packages.md
@@ -13,21 +13,32 @@ to these canonical pages.
 
 ## Drive it
 
-Preview seed has **no** packages until you create one through the JSON API the
-UI posts to (`/account/packages.json`).
+Preview seed has **no** packages until you create one. Package creation is
+MCP-only (`packageGetGitRemote({ create: true, kody_id })`). There is no create
+action on `POST /account/packages.json`. Use the CLI — logged-in preview testing
+does not require agents to hand-roll an MCP OAuth dance — the CLI does it for
+them:
+
+```bash
+npm run control-kody -- package-create --origin <preview> --kody-id <slug> [--head-ahead]
+```
+
+Then assert the pages:
 
 ```bash
 node tools/control-kody.ts preview -- \
   --request 'GET /account/packages.json' \
-  --check /@me
+  --check /@user-me
 ```
 
-To prove delete, create a package through the JSON API, then delete it and
-assert the empty state.
+`--head-ahead` pushes one unpublished commit so the Code tab can show **HEAD
+ahead of published**. To prove delete, create a package with `package-create`,
+then delete it and assert the empty state.
 
 ## APIs
 
-- `GET|POST /account/packages.json`
+- `GET|POST /account/packages.json` (list / token actions; no package-create
+  action)
 - `GET /profiles/:username/packages/:kodyId.json`
 - `GET /profiles/:username/packages/:kodyId/files.json`
 - `GET /profiles/:username/packages/:kodyId/approve-publish.json`

--- a/docs/contributing/control-kody.md
+++ b/docs/contributing/control-kody.md
@@ -12,6 +12,7 @@ npm run control-kody -- request GET /account/waiting.json
 npm run control-kody -- map waiting
 npm run control-kody -- health --sha <commit>
 npm run control-kody -- preview -- --pr 42 --check /account/waiting
+npm run control-kody -- package-create --origin <preview> --kody-id <slug> [--head-ahead]
 ```
 
 Same entry: `node tools/control-kody.ts`.
@@ -39,6 +40,16 @@ the matching feature file in the same change.
 Override with `--email` / `--password`. `--cookie-file` defaults to
 `.tmp/control-kody-cookie`. `preview` uses
 [`preview-manual-test`](./preview-manual-testing.md) and its own seed.
+
+`package-create` registers a stub saved package on a PR preview (or local
+origin) through MCP `packageGetGitRemote({ create: true, kody_id })`. It reuses
+`--origin`, `--email`, `--password`, `--cookie-file`, and `--json`. Pass
+`--kody-id <lower-kebab-slug>` (required), `--description` (optional), and
+`--head-ahead` to push one unpublished commit so the package page can show
+**HEAD ahead of published**. Do not POST a create action to
+`/account/packages.json` — that endpoint has no package-create action. Logged-in
+preview testing does not require agents to hand-roll an MCP OAuth dance — the
+CLI does it for them. The command refuses `https://kody.codes`.
 
 ## Daily garden
 

--- a/docs/contributing/preview-manual-testing.md
+++ b/docs/contributing/preview-manual-testing.md
@@ -22,7 +22,14 @@ Same thing: `node tools/preview-manual-test.ts`.
 The script signs in as the preview seed user and keeps that session. The seed
 account starts **empty** except the user row — there are no secrets, packages,
 or jobs until you create them. Create that data and assert the change as the
-same user:
+same user. For a saved package, use `package-create` (not a create action on
+`POST /account/packages.json`):
+
+```bash
+npm run control-kody -- package-create --origin <preview> --kody-id <slug> [--head-ahead]
+```
+
+JSON APIs still cover other account data:
 
 ```bash
 npm run preview:manual-test -- \
@@ -82,13 +89,16 @@ in a browser at `/login` with Email + Password and the **Sign in** button.
 
 Do not seed preview D1 from the agent VM with `tools/ci/preview-resources.ts`
 unless you are an operator with Cloudflare credentials. Create user data through
-the product JSON APIs instead (`/account/*.json` in
-`packages/worker/universal/routes.ts`). Those are the same endpoints the UI
-posts to.
+the product JSON APIs (`/account/*.json` in
+`packages/worker/universal/routes.ts`) or, for a saved package,
+`npm run control-kody -- package-create --origin <preview> --kody-id <slug> [--head-ahead]`.
+Those JSON endpoints are the same ones the UI posts to. Package creation is
+MCP-only (`packageGetGitRemote({ create: true, kody_id })`); there is no create
+action on `POST /account/packages.json`.
 
 `/mcp` stays OAuth-protected; an unauthenticated GET is 401 by design. Logged-in
-preview testing is the browser app and cookie-backed HTTP, not a full MCP OAuth
-dance.
+preview testing does not require agents to hand-roll an MCP OAuth dance — the
+CLI does it for them.
 
 ## Logged-in data and UI pass
 

--- a/tools/control-kody.node.test.ts
+++ b/tools/control-kody.node.test.ts
@@ -140,6 +140,17 @@ test('control-kody parses commands, maps every required route, and drives a seed
 			]),
 		),
 	).rejects.toThrow(/refuses to run against https:\/\/kody\.codes/)
+	await expect(
+		runCommand(
+			parseControlArgs([
+				'package-create',
+				'--kody-id',
+				'preview-pkg',
+				'--origin',
+				'https://kody.codes.',
+			]),
+		),
+	).rejects.toThrow(/refuses to run against https:\/\/kody\.codes/)
 
 	expect(credentialsForOrigin('http://localhost:3742').email).toBe(
 		localSeedEmail,

--- a/tools/control-kody.node.test.ts
+++ b/tools/control-kody.node.test.ts
@@ -23,6 +23,7 @@ import {
 	runCommand,
 	runDoctor,
 	runMapCheck,
+	usageLines,
 } from './control-kody.ts'
 import { previewSeedEmail } from './preview-manual-test.ts'
 import { featureCatalog } from './control-kody/feature-catalog.ts'
@@ -86,7 +87,59 @@ test('control-kody parses commands, maps every required route, and drives a seed
 	expect(parseControlArgs(['preview', '--', '--pr', '42']).previewArgv).toEqual(
 		['--pr', '42'],
 	)
+	expect(
+		parseControlArgs([
+			'package-create',
+			'--kody-id',
+			'preview-pkg',
+			'--description',
+			'preview fixture',
+			'--head-ahead',
+			'--origin',
+			'https://kody-pr-9.kody.workers.dev',
+			'--json',
+		]),
+	).toEqual(
+		expect.objectContaining({
+			command: 'package-create',
+			kodyId: 'preview-pkg',
+			description: 'preview fixture',
+			headAhead: true,
+			json: true,
+			origin: 'https://kody-pr-9.kody.workers.dev',
+		}),
+	)
+	expect(usageLines.join('\n')).toMatch(/package-create/)
+	expect(usageLines.join('\n')).toMatch(/--kody-id/)
+	expect(usageLines.join('\n')).toMatch(/--head-ahead/)
 	expect(() => parseControlArgs(['nope'])).toThrow(/Unknown command/)
+	await expect(
+		runCommand(
+			parseControlArgs(['package-create', '--origin', 'http://127.0.0.1:9']),
+		),
+	).rejects.toThrow(/requires --kody-id/)
+	await expect(
+		runCommand(
+			parseControlArgs([
+				'package-create',
+				'--kody-id',
+				'Not-A-Slug',
+				'--origin',
+				'http://127.0.0.1:9',
+			]),
+		),
+	).rejects.toThrow(/lower-kebab/)
+	await expect(
+		runCommand(
+			parseControlArgs([
+				'package-create',
+				'--kody-id',
+				'preview-pkg',
+				'--origin',
+				'https://kody.codes',
+			]),
+		),
+	).rejects.toThrow(/refuses to run against https:\/\/kody\.codes/)
 
 	expect(credentialsForOrigin('http://localhost:3742').email).toBe(
 		localSeedEmail,

--- a/tools/control-kody.ts
+++ b/tools/control-kody.ts
@@ -23,6 +23,12 @@ import {
 	type Feature,
 } from './control-kody/feature-catalog.ts'
 import {
+	createPreviewPackage,
+	formatPackageCreateReport,
+	isLowerKebabKodyId,
+	isProductionKodyOrigin,
+} from './control-kody/package-create.ts'
+import {
 	cookieHeaderFromSetCookie,
 	evaluateAppHealth,
 	parseSessionRequest,
@@ -42,18 +48,22 @@ const usageLines = [
 	'Drive and verify the Kody app without throwaway scripts.',
 	'',
 	'Commands:',
-	'  doctor     Check Node, Playwright browsers, hooks, and /health',
-	'  dev        Start or reuse the local origin (npm run dev:ensure)',
-	'  login      POST /auth and write a session cookie',
-	'  request    Authenticated HTTP as the current session',
-	'  preview    PR preview smoke (wraps preview:manual-test)',
-	'  health     GET /health and optionally assert commitSha',
-	'  map        List or print a Feature Map entry; --check for drift',
+	'  doctor          Check Node, Playwright browsers, hooks, and /health',
+	'  dev             Start or reuse the local origin (npm run dev:ensure)',
+	'  login           POST /auth and write a session cookie',
+	'  request         Authenticated HTTP as the current session',
+	'  preview         PR preview smoke (wraps preview:manual-test)',
+	'  health          GET /health and optionally assert commitSha',
+	'  map             List or print a Feature Map entry; --check for drift',
+	'  package-create  Create a stub saved package via MCP (preview data)',
 	'',
 	'Common options:',
 	'  --origin <url>       App origin (default: healthy local 3742-3751)',
 	'  --json               Machine-readable stdout',
 	'  --cookie-file <p>    Session Cookie header file',
+	'  --kody-id <slug>     Required for package-create (lower-kebab)',
+	'  --description <t>    Optional package-create stub description',
+	'  --head-ahead         package-create: push one unpublished commit',
 	'  --help               Print this help',
 	'',
 	'Docs: docs/contributing/control-kody.md',
@@ -67,6 +77,7 @@ export type ControlKodyCommand =
 	| 'preview'
 	| 'health'
 	| 'map'
+	| 'package-create'
 	| 'help'
 
 export type ControlKodyOptions = {
@@ -84,6 +95,9 @@ export type ControlKodyOptions = {
 	request: SessionRequestSpec | null
 	body: string | null
 	previewArgv: Array<string>
+	kodyId: string | null
+	description: string | null
+	headAhead: boolean
 }
 
 export class ControlKodyError extends Error {
@@ -133,6 +147,9 @@ export function parseControlArgs(argv: Array<string>): ControlKodyOptions {
 		request: null,
 		body: null,
 		previewArgv: [],
+		kodyId: null,
+		description: null,
+		headAhead: false,
 	}
 
 	const [command, ...rest] = argv
@@ -155,6 +172,7 @@ export function parseControlArgs(argv: Array<string>): ControlKodyOptions {
 		'preview',
 		'health',
 		'map',
+		'package-create',
 		'help',
 	]
 	if (!commands.includes(command as ControlKodyCommand)) {
@@ -256,6 +274,20 @@ function parseSharedFlags(
 			case '--body': {
 				options.body = requireValue(argv[index + 1], '--body')
 				index += 1
+				break
+			}
+			case '--kody-id': {
+				options.kodyId = requireValue(argv[index + 1], '--kody-id')
+				index += 1
+				break
+			}
+			case '--description': {
+				options.description = requireValue(argv[index + 1], '--description')
+				index += 1
+				break
+			}
+			case '--head-ahead': {
+				options.headAhead = true
 				break
 			}
 			default: {
@@ -682,6 +714,44 @@ async function runCommand(options: ControlKodyOptions) {
 			else
 				console.log(`${result.ok ? 'ok' : 'FAIL'} ${origin} ${result.detail}`)
 			return result.ok ? 0 : 1
+		}
+		case 'package-create': {
+			if (!options.kodyId) {
+				throw new ControlKodyError(
+					'package-create requires --kody-id <lower-kebab-slug>',
+				)
+			}
+			if (!isLowerKebabKodyId(options.kodyId)) {
+				throw new ControlKodyError(
+					'--kody-id must be a lower-kebab-case slug (for example "preview-pkg")',
+				)
+			}
+			const origin = await resolveOrigin(options)
+			if (isProductionKodyOrigin(origin)) {
+				throw new ControlKodyError(
+					'package-create refuses to run against https://kody.codes',
+				)
+			}
+			const defaults = credentialsForOrigin(origin)
+			const report = await createPreviewPackage({
+				origin,
+				email: options.email ?? defaults.email,
+				password: options.password ?? defaults.password,
+				kodyId: options.kodyId,
+				description: options.description,
+				headAhead: options.headAhead,
+			})
+			if (report.cookieHeader) {
+				await writeCookieFile(options.cookieFile, report.cookieHeader)
+			}
+			if (options.json) {
+				const { cookieHeader: _cookieHeader, ...publicReport } = report
+				printJson({ ...publicReport, cookieFile: options.cookieFile })
+			} else {
+				console.log(formatPackageCreateReport(report))
+				console.log(`cookie-file ${options.cookieFile}`)
+			}
+			return 0
 		}
 		case 'map': {
 			if (options.check) {

--- a/tools/control-kody/package-create.node.test.ts
+++ b/tools/control-kody/package-create.node.test.ts
@@ -1,0 +1,184 @@
+import { execFileSync } from 'node:child_process'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { expect, test } from 'vitest'
+import {
+	createPreviewPackage,
+	formatPackageCreateReport,
+	headAheadFileName,
+	isLowerKebabKodyId,
+	isProductionKodyOrigin,
+	pushHeadAheadCommit,
+	usernameFromPackageName,
+} from './package-create.ts'
+
+test('package-create builds preview URLs, reports JSON shape, and can leave HEAD ahead', async () => {
+	expect(isLowerKebabKodyId('preview-pkg')).toBe(true)
+	expect(isLowerKebabKodyId('pkg')).toBe(true)
+	expect(isLowerKebabKodyId('Not-A-Slug')).toBe(false)
+	expect(isProductionKodyOrigin('https://kody.codes')).toBe(true)
+	expect(isProductionKodyOrigin('https://kody-pr-9.kody.workers.dev')).toBe(
+		false,
+	)
+	expect(usernameFromPackageName('@user-me/preview-pkg', 'preview-pkg')).toBe(
+		'user-me',
+	)
+	expect(usernameFromPackageName('preview-pkg', 'preview-pkg')).toBeNull()
+
+	let pushedRemote: string | null = null
+	const report = await createPreviewPackage({
+		origin: 'https://kody-pr-9.kody.workers.dev',
+		email: 'me@kentcdodds.com',
+		password: 'ilikecode',
+		kodyId: 'preview-pkg',
+		description: 'preview fixture',
+		headAhead: true,
+		connect: async () => ({
+			cookieHeader: 'kody_session=abc',
+			client: {
+				async callTool(params) {
+					expect(params.name).toBe('execute')
+					const args = params.arguments as {
+						code: string
+						params: { kodyId: string; description?: string }
+					}
+					expect(args.code).toContain('packageGetGitRemote')
+					expect(args.code).toContain('packageGet')
+					expect(args.params).toEqual({
+						kodyId: 'preview-pkg',
+						description: 'preview fixture',
+					})
+					return {
+						isError: false,
+						structuredContent: {
+							result: {
+								remote: {
+									package_id: 'pkg-1',
+									kody_id: 'preview-pkg',
+									created: true,
+									authenticated_remote:
+										'https://x:token@artifacts.example/git/pkg-1',
+									git_author: {
+										name: 'Me',
+										email: 'me@kentcdodds.com',
+									},
+									setup_commands: [
+										"git config --local user.email -- 'me@kentcdodds.com'",
+										"git config --local user.name -- 'Me'",
+									],
+								},
+								detail: { name: '@user-me/preview-pkg' },
+							},
+						},
+					}
+				},
+			},
+		}),
+		pushHeadAhead: async (remote) => {
+			pushedRemote = remote.authenticated_remote
+		},
+	})
+
+	expect(report).toMatchObject({
+		ok: true,
+		packageId: 'pkg-1',
+		kodyId: 'preview-pkg',
+		name: '@user-me/preview-pkg',
+		created: true,
+		username: 'user-me',
+		packagePagePath: '/@user-me/preview-pkg',
+		accountPackagePath: '/account/packages/pkg-1',
+		packagePageUrl: 'https://kody-pr-9.kody.workers.dev/@user-me/preview-pkg',
+		accountPackageUrl:
+			'https://kody-pr-9.kody.workers.dev/account/packages/pkg-1',
+		headAhead: true,
+		cookieHeader: 'kody_session=abc',
+	})
+	expect(pushedRemote).toBe('https://x:token@artifacts.example/git/pkg-1')
+	expect(formatPackageCreateReport(report)).toBe(
+		[
+			'packageId pkg-1',
+			'kodyId preview-pkg',
+			'name @user-me/preview-pkg',
+			'package-page https://kody-pr-9.kody.workers.dev/@user-me/preview-pkg',
+			'account-page https://kody-pr-9.kody.workers.dev/account/packages/pkg-1',
+			'head-ahead pushed',
+		].join('\n'),
+	)
+
+	await expect(
+		createPreviewPackage({
+			origin: 'https://kody.codes',
+			email: 'me@kentcdodds.com',
+			password: 'ilikecode',
+			kodyId: 'preview-pkg',
+			headAhead: false,
+		}),
+	).rejects.toThrow(/refuses to run against https:\/\/kody\.codes/)
+
+	await expect(
+		createPreviewPackage({
+			origin: 'https://kody-pr-9.kody.workers.dev',
+			email: 'me@kentcdodds.com',
+			password: 'ilikecode',
+			kodyId: 'preview-pkg',
+			headAhead: false,
+			connect: async () => ({
+				cookieHeader: 'kody_session=abc',
+				client: {
+					async callTool() {
+						return {
+							isError: true,
+							content: [
+								{
+									type: 'text',
+									text: 'Saved package not found for this user.',
+								},
+							],
+							structuredContent: { error: 'missing' },
+						}
+					},
+				},
+			}),
+		}),
+	).rejects.toThrow(/execute failed: Saved package not found/)
+
+	const parent = await mkdtemp(path.join(tmpdir(), 'control-kody-head-ahead-'))
+	try {
+		const bare = path.join(parent, 'remote.git')
+		const seed = path.join(parent, 'seed')
+		execFileSync('git', ['init', '--bare', bare])
+		execFileSync('git', ['clone', '--quiet', bare, seed])
+		execFileSync('git', ['-C', seed, 'config', 'user.email', 'me@example.com'])
+		execFileSync('git', ['-C', seed, 'config', 'user.name', 'Me'])
+		await writeFile(path.join(seed, 'README.md'), 'stub\n')
+		execFileSync('git', ['-C', seed, 'add', 'README.md'])
+		execFileSync('git', ['-C', seed, 'commit', '-m', 'init'])
+		execFileSync('git', ['-C', seed, 'push', '--quiet', 'origin', 'HEAD'])
+
+		await pushHeadAheadCommit({
+			package_id: 'pkg-1',
+			kody_id: 'preview-pkg',
+			authenticated_remote: bare,
+			git_author: { name: 'Me', email: 'me@example.com' },
+			setup_commands: [
+				"git config --local user.email -- 'me@example.com'",
+				"git config --local user.name -- 'Me'",
+			],
+		})
+
+		const log = execFileSync('git', ['--git-dir', bare, 'log', '--oneline'], {
+			encoding: 'utf8',
+		})
+		expect(log).toMatch(/leave HEAD ahead of published/)
+		const show = execFileSync(
+			'git',
+			['--git-dir', bare, 'ls-tree', '-r', '--name-only', 'HEAD'],
+			{ encoding: 'utf8' },
+		)
+		expect(show).toContain(headAheadFileName)
+	} finally {
+		await rm(parent, { recursive: true, force: true })
+	}
+})

--- a/tools/control-kody/package-create.node.test.ts
+++ b/tools/control-kody/package-create.node.test.ts
@@ -18,6 +18,9 @@ test('package-create builds preview URLs, reports JSON shape, and can leave HEAD
 	expect(isLowerKebabKodyId('pkg')).toBe(true)
 	expect(isLowerKebabKodyId('Not-A-Slug')).toBe(false)
 	expect(isProductionKodyOrigin('https://kody.codes')).toBe(true)
+	expect(isProductionKodyOrigin('https://www.kody.codes')).toBe(true)
+	expect(isProductionKodyOrigin('https://kody.codes.')).toBe(true)
+	expect(isProductionKodyOrigin('https://www.kody.codes.')).toBe(true)
 	expect(isProductionKodyOrigin('https://kody-pr-9.kody.workers.dev')).toBe(
 		false,
 	)
@@ -153,6 +156,16 @@ test('package-create builds preview URLs, reports JSON shape, and can leave HEAD
 
 	await expect(
 		createPreviewPackage({
+			origin: 'https://kody.codes.',
+			email: 'me@kentcdodds.com',
+			password: 'ilikecode',
+			kodyId: 'preview-pkg',
+			headAhead: false,
+		}),
+	).rejects.toThrow(/refuses to run against https:\/\/kody\.codes/)
+
+	await expect(
+		createPreviewPackage({
 			origin: 'https://kody-pr-9.kody.workers.dev',
 			email: 'me@kentcdodds.com',
 			password: 'ilikecode',
@@ -212,6 +225,25 @@ test('package-create builds preview URLs, reports JSON shape, and can leave HEAD
 			{ encoding: 'utf8' },
 		)
 		expect(show).toContain(headAheadFileName)
+
+		await pushHeadAheadCommit({
+			package_id: 'pkg-1',
+			kody_id: 'preview-pkg',
+			authenticated_remote: bare,
+			git_author: { name: 'Me', email: 'me@example.com' },
+			setup_commands: [
+				"git config --local user.email -- 'me@example.com'",
+				"git config --local user.name -- 'Me'",
+			],
+		})
+		const logAfterRerun = execFileSync(
+			'git',
+			['--git-dir', bare, 'log', '--oneline'],
+			{ encoding: 'utf8' },
+		)
+		expect(logAfterRerun.match(/leave HEAD ahead of published/g)).toHaveLength(
+			1,
+		)
 	} finally {
 		await rm(parent, { recursive: true, force: true })
 	}

--- a/tools/control-kody/package-create.node.test.ts
+++ b/tools/control-kody/package-create.node.test.ts
@@ -37,8 +37,10 @@ test('package-create builds preview URLs, reports JSON shape, and can leave HEAD
 		connect: async () => ({
 			cookieHeader: 'kody_session=abc',
 			client: {
-				async callTool(params) {
+				async callTool(params, options) {
 					expect(params.name).toBe('execute')
+					expect(options?.timeout).toBeGreaterThan(60_000)
+					expect(options?.resetTimeoutOnProgress).toBe(true)
 					const args = params.arguments as {
 						code: string
 						params: { kodyId: string; description?: string }
@@ -48,6 +50,7 @@ test('package-create builds preview URLs, reports JSON shape, and can leave HEAD
 					expect(args.params).toEqual({
 						kodyId: 'preview-pkg',
 						description: 'preview fixture',
+						requireRemote: true,
 					})
 					return {
 						isError: false,
@@ -96,6 +99,37 @@ test('package-create builds preview URLs, reports JSON shape, and can leave HEAD
 		cookieHeader: 'kody_session=abc',
 	})
 	expect(pushedRemote).toBe('https://x:token@artifacts.example/git/pkg-1')
+	const recovered = await createPreviewPackage({
+		origin: 'https://kody-pr-9.kody.workers.dev',
+		email: 'me@kentcdodds.com',
+		password: 'ilikecode',
+		kodyId: 'preview-pkg',
+		headAhead: false,
+		connect: async () => ({
+			cookieHeader: 'kody_session=abc',
+			client: {
+				async callTool() {
+					return {
+						isError: false,
+						structuredContent: {
+							result: {
+								remote: null,
+								remoteError: 'account not found',
+								detail: {
+									package_id: 'pkg-1',
+									kody_id: 'preview-pkg',
+									name: '@user-me/preview-pkg',
+								},
+							},
+						},
+					}
+				},
+			},
+		}),
+	})
+	expect(recovered.packageId).toBe('pkg-1')
+	expect(recovered.headAhead).toBe(false)
+
 	expect(formatPackageCreateReport(report)).toBe(
 		[
 			'packageId pkg-1',

--- a/tools/control-kody/package-create.ts
+++ b/tools/control-kody/package-create.ts
@@ -15,13 +15,36 @@ export const headAheadFileName = 'preview-head-ahead.txt'
 
 const packageCreateExecuteCode = `import { kody } from 'kody:runtime'
 export default async function main(input = {}) {
-	const remote = await kody.packageGetGitRemote({
-		create: true,
-		kody_id: input.kodyId,
-		...(input.description ? { description: input.description } : {}),
-	})
-	const detail = await kody.packageGet({ package_id: remote.package_id })
-	return { remote, detail }
+	let remote = null
+	let remoteError = null
+	try {
+		remote = await kody.packageGetGitRemote({
+			create: true,
+			kody_id: input.kodyId,
+			...(input.description ? { description: input.description } : {}),
+		})
+	} catch (error) {
+		remoteError = error instanceof Error ? error.message : String(error)
+	}
+	const listed = await kody.packageList({})
+	const match = (listed.packages ?? []).find(
+		(pkg) => pkg.kody_id === input.kodyId,
+	)
+	const packageId = remote?.package_id ?? match?.package_id
+	if (!packageId) {
+		throw new Error(
+			remoteError ??
+				\`Saved package \${input.kodyId} was not found after create.\`,
+		)
+	}
+	const detail = await kody.packageGet({ package_id: packageId })
+	if (!remote && input.requireRemote) {
+		throw new Error(
+			remoteError ??
+				'packageGetGitRemote did not return a minted remote for --head-ahead.',
+		)
+	}
+	return { remote, remoteError, detail }
 }
 `
 
@@ -40,10 +63,21 @@ export type PackageCreateReport = {
 	cookieHeader: string
 }
 
-export type PackageCreateCallTool = (params: {
-	name: string
-	arguments: Record<string, unknown>
-}) => Promise<unknown>
+export type PackageCreateCallToolOptions = {
+	timeout?: number
+	resetTimeoutOnProgress?: boolean
+	maxTotalTimeout?: number
+}
+
+export type PackageCreateCallTool = (
+	params: {
+		name: string
+		arguments: Record<string, unknown>
+	},
+	options?: PackageCreateCallToolOptions,
+) => Promise<unknown>
+
+const executeCallTimeoutMs = 180_000
 
 export type PackageCreateConnection = {
 	cookieHeader: string
@@ -114,17 +148,27 @@ export async function createPreviewPackage(input: {
 	const connect = input.connect ?? connectAppMcpClient
 	const connection = await connect(input.origin, user)
 	try {
-		const params: Record<string, unknown> = { kodyId: input.kodyId }
+		const params: Record<string, unknown> = {
+			kodyId: input.kodyId,
+			requireRemote: input.headAhead,
+		}
 		if (input.description && input.description.length > 0) {
 			params.description = input.description
 		}
-		const toolResult = await connection.client.callTool({
-			name: 'execute',
-			arguments: {
-				code: packageCreateExecuteCode,
-				params,
+		const toolResult = await connection.client.callTool(
+			{
+				name: 'execute',
+				arguments: {
+					code: packageCreateExecuteCode,
+					params,
+				},
 			},
-		})
+			{
+				timeout: executeCallTimeoutMs,
+				resetTimeoutOnProgress: true,
+				maxTotalTimeout: executeCallTimeoutMs,
+			},
+		)
 		const created = readCreatedPackage(toolResult)
 		const fetchImpl = input.fetchImpl ?? fetch
 		const username =
@@ -140,6 +184,12 @@ export async function createPreviewPackage(input: {
 			)
 		}
 		if (input.headAhead) {
+			if (!created.remote) {
+				throw new Error(
+					created.remoteError ??
+						'packageGetGitRemote did not return a minted remote for --head-ahead.',
+				)
+			}
 			const push = input.pushHeadAhead ?? pushHeadAheadCommit
 			await push(created.remote)
 		}
@@ -272,43 +322,60 @@ function readCreatedPackage(toolResult: unknown) {
 	}
 	const remoteValue = Reflect.get(result, 'remote')
 	const detailValue = Reflect.get(result, 'detail')
-	if (!remoteValue || typeof remoteValue !== 'object') {
-		throw new Error('execute result is missing packageGetGitRemote payload.')
-	}
+	const remoteErrorValue = Reflect.get(result, 'remoteError')
 	if (!detailValue || typeof detailValue !== 'object') {
 		throw new Error('execute result is missing packageGet payload.')
 	}
-	const remote = remoteValue as Record<string, unknown>
 	const detail = detailValue as Record<string, unknown>
-	const packageId = readRequiredString(remote, 'package_id')
-	const kodyId = readRequiredString(remote, 'kody_id')
+	const remote =
+		remoteValue && typeof remoteValue === 'object'
+			? (remoteValue as Record<string, unknown>)
+			: null
+	const packageId = remote
+		? readRequiredString(remote, 'package_id')
+		: readRequiredString(detail, 'package_id')
+	const kodyId = remote
+		? readRequiredString(remote, 'kody_id')
+		: readRequiredString(detail, 'kody_id')
 	const name = readRequiredString(detail, 'name')
-	const authenticatedRemote = readRequiredString(remote, 'authenticated_remote')
+	const remoteError =
+		typeof remoteErrorValue === 'string' && remoteErrorValue.length > 0
+			? remoteErrorValue
+			: null
+	return {
+		packageId,
+		kodyId,
+		name,
+		created: remote?.created === true,
+		remoteError,
+		remote: remote ? readGitRemoteResult(remote, packageId, kodyId) : null,
+	}
+}
+
+function readGitRemoteResult(
+	remote: Record<string, unknown>,
+	packageId: string,
+	kodyId: string,
+): GitRemoteResult {
 	const gitAuthorValue = remote.git_author
 	if (!gitAuthorValue || typeof gitAuthorValue !== 'object') {
 		throw new Error('packageGetGitRemote result is missing git_author.')
 	}
 	const gitAuthor = gitAuthorValue as Record<string, unknown>
 	return {
-		packageId,
-		kodyId,
-		name,
+		package_id: packageId,
+		kody_id: kodyId,
 		created: remote.created === true,
-		remote: {
-			package_id: packageId,
-			kody_id: kodyId,
-			created: remote.created === true,
-			authenticated_remote: authenticatedRemote,
-			git_author: {
-				name: readRequiredString(gitAuthor, 'name'),
-				email: readRequiredString(gitAuthor, 'email'),
-			},
-			setup_commands: Array.isArray(remote.setup_commands)
-				? remote.setup_commands.filter(
-						(command): command is string => typeof command === 'string',
-					)
-				: [],
-		} satisfies GitRemoteResult,
+		authenticated_remote: readRequiredString(remote, 'authenticated_remote'),
+		git_author: {
+			name: readRequiredString(gitAuthor, 'name'),
+			email: readRequiredString(gitAuthor, 'email'),
+		},
+		setup_commands: Array.isArray(remote.setup_commands)
+			? remote.setup_commands.filter(
+					(command): command is string => typeof command === 'string',
+				)
+			: [],
 	}
 }
 

--- a/tools/control-kody/package-create.ts
+++ b/tools/control-kody/package-create.ts
@@ -91,7 +91,7 @@ export function isLowerKebabKodyId(value: string) {
 
 export function isProductionKodyOrigin(origin: string) {
 	try {
-		const hostname = new URL(origin).hostname
+		const hostname = new URL(origin).hostname.replace(/\.+$/, '')
 		return hostname === 'kody.codes' || hostname === 'www.kody.codes'
 	} catch {
 		return false
@@ -241,6 +241,8 @@ export async function pushHeadAheadCommit(remote: GitRemoteResult) {
 			'preview HEAD-ahead marker\n',
 		)
 		runGit(['add', headAheadFileName], cloneDir)
+		const staged = runGit(['status', '--porcelain'], cloneDir).trim()
+		if (!staged) return
 		runGit(['commit', '-m', 'chore: leave HEAD ahead of published'], cloneDir)
 		runGit(['push', '--quiet', 'origin', 'HEAD'], cloneDir)
 	} finally {

--- a/tools/control-kody/package-create.ts
+++ b/tools/control-kody/package-create.ts
@@ -1,0 +1,351 @@
+import { execFileSync } from 'node:child_process'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { type CallToolResult } from '@modelcontextprotocol/sdk/types.js'
+import {
+	connectAppMcpClient,
+	usernameFromEmail,
+	type AppAuthUser,
+	type FetchLike,
+} from '../mcp-oauth-client.ts'
+
+export const kodyIdPattern = /^[a-z0-9]+(?:-[a-z0-9]+)*$/
+export const headAheadFileName = 'preview-head-ahead.txt'
+
+const packageCreateExecuteCode = `import { kody } from 'kody:runtime'
+export default async function main(input = {}) {
+	const remote = await kody.packageGetGitRemote({
+		create: true,
+		kody_id: input.kodyId,
+		...(input.description ? { description: input.description } : {}),
+	})
+	const detail = await kody.packageGet({ package_id: remote.package_id })
+	return { remote, detail }
+}
+`
+
+export type PackageCreateReport = {
+	ok: true
+	packageId: string
+	kodyId: string
+	name: string
+	created: boolean
+	username: string
+	packagePagePath: string
+	accountPackagePath: string
+	packagePageUrl: string
+	accountPackageUrl: string
+	headAhead: boolean
+	cookieHeader: string
+}
+
+export type PackageCreateCallTool = (params: {
+	name: string
+	arguments: Record<string, unknown>
+}) => Promise<unknown>
+
+export type PackageCreateConnection = {
+	cookieHeader: string
+	client: { callTool: PackageCreateCallTool }
+	[Symbol.asyncDispose]?: () => Promise<void> | void
+}
+
+export function isLowerKebabKodyId(value: string) {
+	return kodyIdPattern.test(value)
+}
+
+export function isProductionKodyOrigin(origin: string) {
+	try {
+		const hostname = new URL(origin).hostname
+		return hostname === 'kody.codes' || hostname === 'www.kody.codes'
+	} catch {
+		return false
+	}
+}
+
+export function usernameFromPackageName(name: string, kodyId: string) {
+	const suffix = `/${kodyId}`
+	if (!name.startsWith('@') || !name.endsWith(suffix)) return null
+	const username = name.slice(1, name.length - suffix.length)
+	return username.length > 0 ? username : null
+}
+
+export function formatPackageCreateReport(report: PackageCreateReport) {
+	const lines = [
+		`packageId ${report.packageId}`,
+		`kodyId ${report.kodyId}`,
+		`name ${report.name}`,
+		`package-page ${report.packagePageUrl}`,
+		`account-page ${report.accountPackageUrl}`,
+	]
+	if (report.headAhead) lines.push('head-ahead pushed')
+	return lines.join('\n')
+}
+
+export async function createPreviewPackage(input: {
+	origin: string
+	email: string
+	password: string
+	kodyId: string
+	description?: string | null
+	headAhead: boolean
+	connect?: (
+		origin: string,
+		user: AppAuthUser,
+	) => Promise<PackageCreateConnection>
+	pushHeadAhead?: (remote: GitRemoteResult) => Promise<void>
+	fetchImpl?: FetchLike
+}): Promise<PackageCreateReport> {
+	if (isProductionKodyOrigin(input.origin)) {
+		throw new Error('package-create refuses to run against https://kody.codes')
+	}
+	if (!isLowerKebabKodyId(input.kodyId)) {
+		throw new Error(
+			'--kody-id must be a lower-kebab-case slug (for example "preview-pkg")',
+		)
+	}
+
+	const user: AppAuthUser = {
+		email: input.email,
+		password: input.password,
+		username: usernameFromEmail(input.email),
+	}
+	const connect = input.connect ?? connectAppMcpClient
+	const connection = await connect(input.origin, user)
+	try {
+		const params: Record<string, unknown> = { kodyId: input.kodyId }
+		if (input.description && input.description.length > 0) {
+			params.description = input.description
+		}
+		const toolResult = await connection.client.callTool({
+			name: 'execute',
+			arguments: {
+				code: packageCreateExecuteCode,
+				params,
+			},
+		})
+		const created = readCreatedPackage(toolResult)
+		const fetchImpl = input.fetchImpl ?? fetch
+		const username =
+			usernameFromPackageName(created.name, created.kodyId) ??
+			(await usernameFromProfile(
+				input.origin,
+				connection.cookieHeader,
+				fetchImpl,
+			))
+		if (!username) {
+			throw new Error(
+				`Could not derive username from package name ${JSON.stringify(created.name)}.`,
+			)
+		}
+		if (input.headAhead) {
+			const push = input.pushHeadAhead ?? pushHeadAheadCommit
+			await push(created.remote)
+		}
+		const packagePagePath = `/@${username}/${created.kodyId}`
+		const accountPackagePath = `/account/packages/${created.packageId}`
+		return {
+			ok: true,
+			packageId: created.packageId,
+			kodyId: created.kodyId,
+			name: created.name,
+			created: created.created,
+			username,
+			packagePagePath,
+			accountPackagePath,
+			packagePageUrl: `${input.origin}${packagePagePath}`,
+			accountPackageUrl: `${input.origin}${accountPackagePath}`,
+			headAhead: input.headAhead,
+			cookieHeader: connection.cookieHeader,
+		}
+	} finally {
+		await connection[Symbol.asyncDispose]?.()
+	}
+}
+
+export type GitAuthorIdentity = {
+	name: string
+	email: string
+}
+
+export type GitRemoteResult = {
+	package_id: string
+	kody_id: string
+	created?: boolean
+	authenticated_remote: string
+	git_author: GitAuthorIdentity
+	setup_commands?: Array<string>
+}
+
+export async function pushHeadAheadCommit(remote: GitRemoteResult) {
+	const parent = await mkdtemp(path.join(tmpdir(), 'control-kody-pkg-'))
+	const cloneDir = path.join(parent, remote.kody_id)
+	try {
+		const identity = gitIdentityFromRemote(remote)
+		runGit(['clone', '--quiet', remote.authenticated_remote, cloneDir])
+		runGit(['config', 'user.email', identity.email], cloneDir)
+		runGit(['config', 'user.name', identity.name], cloneDir)
+		await writeFile(
+			path.join(cloneDir, headAheadFileName),
+			'preview HEAD-ahead marker\n',
+		)
+		runGit(['add', headAheadFileName], cloneDir)
+		runGit(['commit', '-m', 'chore: leave HEAD ahead of published'], cloneDir)
+		runGit(['push', '--quiet', 'origin', 'HEAD'], cloneDir)
+	} finally {
+		await rm(parent, { recursive: true, force: true })
+	}
+}
+
+function gitIdentityFromRemote(remote: GitRemoteResult): GitAuthorIdentity {
+	const commands = remote.setup_commands ?? []
+	let email = remote.git_author.email
+	let name = remote.git_author.name
+	for (const command of commands) {
+		const emailMatch = command.match(
+			/^git config --local user\.email -- '(.+)'$/,
+		)
+		const nameMatch = command.match(/^git config --local user\.name -- '(.+)'$/)
+		if (emailMatch?.[1]) email = unquoteGitIdentity(emailMatch[1])
+		if (nameMatch?.[1]) name = unquoteGitIdentity(nameMatch[1])
+	}
+	return { name, email }
+}
+
+function unquoteGitIdentity(value: string) {
+	return value.replaceAll(`'"'"'`, `'`)
+}
+
+function runGit(args: Array<string>, cwd?: string) {
+	try {
+		return execFileSync('git', args, {
+			cwd,
+			encoding: 'utf8',
+			env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
+			stdio: ['ignore', 'pipe', 'pipe'],
+		})
+	} catch (error) {
+		const stderr =
+			error && typeof error === 'object' && 'stderr' in error
+				? String(error.stderr)
+				: error instanceof Error
+					? error.message
+					: String(error)
+		throw new Error(
+			`git ${args[0] ?? 'command'} failed: ${redactGitOutput(stderr)}`,
+		)
+	}
+}
+
+function redactGitOutput(text: string) {
+	return text.replaceAll(/\/\/([^/@\s]+):([^@/\s]+)@/g, '//***:***@')
+}
+
+async function usernameFromProfile(
+	origin: string,
+	cookieHeader: string,
+	fetchImpl: FetchLike,
+) {
+	const response = await fetchImpl(`${origin}/account/profile.json`, {
+		headers: {
+			Accept: 'application/json',
+			Cookie: cookieHeader,
+		},
+	})
+	if (!response.ok) return null
+	let body: unknown
+	try {
+		body = await response.json()
+	} catch {
+		return null
+	}
+	if (!body || typeof body !== 'object') return null
+	const username = Reflect.get(body, 'username')
+	return typeof username === 'string' && username.length > 0 ? username : null
+}
+
+function readCreatedPackage(toolResult: unknown) {
+	const result = readExecuteResult(toolResult)
+	if (!result || typeof result !== 'object') {
+		throw new Error('execute returned an unexpected package-create result.')
+	}
+	const remoteValue = Reflect.get(result, 'remote')
+	const detailValue = Reflect.get(result, 'detail')
+	if (!remoteValue || typeof remoteValue !== 'object') {
+		throw new Error('execute result is missing packageGetGitRemote payload.')
+	}
+	if (!detailValue || typeof detailValue !== 'object') {
+		throw new Error('execute result is missing packageGet payload.')
+	}
+	const remote = remoteValue as Record<string, unknown>
+	const detail = detailValue as Record<string, unknown>
+	const packageId = readRequiredString(remote, 'package_id')
+	const kodyId = readRequiredString(remote, 'kody_id')
+	const name = readRequiredString(detail, 'name')
+	const authenticatedRemote = readRequiredString(remote, 'authenticated_remote')
+	const gitAuthorValue = remote.git_author
+	if (!gitAuthorValue || typeof gitAuthorValue !== 'object') {
+		throw new Error('packageGetGitRemote result is missing git_author.')
+	}
+	const gitAuthor = gitAuthorValue as Record<string, unknown>
+	return {
+		packageId,
+		kodyId,
+		name,
+		created: remote.created === true,
+		remote: {
+			package_id: packageId,
+			kody_id: kodyId,
+			created: remote.created === true,
+			authenticated_remote: authenticatedRemote,
+			git_author: {
+				name: readRequiredString(gitAuthor, 'name'),
+				email: readRequiredString(gitAuthor, 'email'),
+			},
+			setup_commands: Array.isArray(remote.setup_commands)
+				? remote.setup_commands.filter(
+						(command): command is string => typeof command === 'string',
+					)
+				: [],
+		} satisfies GitRemoteResult,
+	}
+}
+
+function readExecuteResult(toolResult: unknown) {
+	if (!toolResult || typeof toolResult !== 'object') {
+		throw new Error('execute returned no MCP tool result.')
+	}
+	const record = toolResult as CallToolResult
+	const structured = record.structuredContent as
+		| { result?: unknown; error?: unknown }
+		| undefined
+	if (record.isError || structured?.error) {
+		const text = executeErrorText(record, structured?.error)
+		throw new Error(`execute failed: ${text}`)
+	}
+	if (structured?.result === undefined || structured.result === null) {
+		throw new Error('execute returned no result.')
+	}
+	return structured.result
+}
+
+function executeErrorText(record: CallToolResult, error: unknown) {
+	const contentText = record.content
+		?.filter((block) => block.type === 'text')
+		.map((block) => block.text)
+		.join('\n')
+		.trim()
+	if (contentText) return contentText
+	if (typeof error === 'string' && error.length > 0) return error
+	if (error !== undefined) return JSON.stringify(error)
+	return 'unknown execute error'
+}
+
+function readRequiredString(record: Record<string, unknown>, key: string) {
+	const value = record[key]
+	if (typeof value !== 'string' || value.length === 0) {
+		throw new Error(`Expected "${key}" to be a non-empty string.`)
+	}
+	return value
+}

--- a/tools/mcp-oauth-client.node.test.ts
+++ b/tools/mcp-oauth-client.node.test.ts
@@ -1,0 +1,205 @@
+import {
+	createServer,
+	type IncomingMessage,
+	type ServerResponse,
+} from 'node:http'
+import { expect, test } from 'vitest'
+import {
+	authorizeOAuthClient,
+	exchangeAuthorizationCode,
+	loginToApp,
+	mcpAccountRejectedMessage,
+	readCookieHeader,
+	readStringField,
+	registerOAuthClient,
+	usernameFromEmail,
+} from './mcp-oauth-client.ts'
+
+function readRequestBody(request: IncomingMessage) {
+	return new Promise<string>((resolve, reject) => {
+		const chunks: Array<Buffer> = []
+		request.on('data', (chunk) => {
+			chunks.push(chunk as Buffer)
+		})
+		request.on('end', () => {
+			resolve(Buffer.concat(chunks).toString('utf8'))
+		})
+		request.on('error', reject)
+	})
+}
+
+async function withMockOrigin(
+	handler: (request: IncomingMessage, response: ServerResponse) => void,
+	run: (origin: string) => Promise<void>,
+) {
+	const server = createServer(handler)
+	await new Promise<void>((resolve) => {
+		server.listen(0, '127.0.0.1', resolve)
+	})
+	const address = server.address()
+	if (!address || typeof address === 'string') {
+		throw new Error('expected TCP address')
+	}
+	try {
+		await run(`http://127.0.0.1:${address.port}`)
+	} finally {
+		await new Promise<void>((resolve, reject) => {
+			server.close((error) => {
+				if (error) reject(error)
+				else resolve()
+			})
+		})
+	}
+}
+
+test('OAuth helpers log in, register a client, authorize, and exchange a code', async () => {
+	expect(usernameFromEmail('me@kentcdodds.com')).toBe('me')
+	expect(usernameFromEmail('')).toBe('preview-user')
+	expect(readStringField({ client_id: 'cid' }, 'client_id')).toBe('cid')
+	expect(() => readStringField({ client_id: '' }, 'client_id')).toThrow(
+		/client_id/,
+	)
+	expect(mcpAccountRejectedMessage('403 email_verification_required')).toMatch(
+		/does not mark email verified via D1/,
+	)
+
+	const requests: Array<string> = []
+	await withMockOrigin(
+		(request, response) => {
+			const url = new URL(request.url ?? '/', 'http://127.0.0.1')
+			requests.push(`${request.method ?? 'GET'} ${url.pathname}`)
+			void readRequestBody(request)
+				.then((rawBody) => {
+					if (request.method === 'POST' && url.pathname === '/auth') {
+						const body = JSON.parse(rawBody) as { mode?: string }
+						if (body.mode === 'signup') {
+							response.setHeader('Content-Type', 'application/json')
+							response.end(JSON.stringify({ ok: true }))
+							return
+						}
+						response.setHeader('Set-Cookie', 'kody_session=abc; Path=/')
+						response.setHeader('Content-Type', 'application/json')
+						response.end(JSON.stringify({ ok: true }))
+						return
+					}
+					if (request.method === 'POST' && url.pathname === '/oauth/register') {
+						response.setHeader('Content-Type', 'application/json')
+						response.end(
+							JSON.stringify({
+								client_id: 'client-1',
+								client_secret: 'secret-1',
+							}),
+						)
+						return
+					}
+					if (
+						request.method === 'POST' &&
+						url.pathname === '/oauth/authorize'
+					) {
+						if (request.headers.cookie !== 'kody_session=abc') {
+							response.statusCode = 401
+							response.end('missing session')
+							return
+						}
+						if (url.searchParams.get('client_id') !== 'client-1') {
+							response.statusCode = 400
+							response.end('missing client')
+							return
+						}
+						if (!url.searchParams.get('resource')?.endsWith('/mcp')) {
+							response.statusCode = 400
+							response.end('missing resource')
+							return
+						}
+						response.setHeader('Content-Type', 'application/json')
+						response.end(
+							JSON.stringify({
+								redirectTo:
+									'http://127.0.0.1/oauth/callback?code=auth-code-1&state=kody-mcp-e2e-state',
+							}),
+						)
+						return
+					}
+					if (request.method === 'POST' && url.pathname === '/oauth/token') {
+						const body = new URLSearchParams(rawBody)
+						if (
+							body.get('code') !== 'auth-code-1' ||
+							body.get('client_id') !== 'client-1' ||
+							body.get('client_secret') !== 'secret-1' ||
+							!body.get('resource')?.endsWith('/mcp')
+						) {
+							response.statusCode = 400
+							response.end('bad token request')
+							return
+						}
+						response.setHeader('Content-Type', 'application/json')
+						response.end(JSON.stringify({ access_token: 'token-1' }))
+						return
+					}
+					response.statusCode = 404
+					response.end('missing')
+				})
+				.catch((error) => {
+					response.statusCode = 500
+					response.end(error instanceof Error ? error.message : String(error))
+				})
+		},
+		async (origin) => {
+			const cookie = await loginToApp(origin, {
+				email: 'me@kentcdodds.com',
+				username: 'user-me',
+				password: 'ilikecode',
+			})
+			expect(cookie).toBe('kody_session=abc')
+			expect(
+				readCookieHeader(
+					new Response(null, {
+						headers: { 'Set-Cookie': 'kody_session=abc; Path=/' },
+					}),
+				),
+			).toBe('kody_session=abc')
+
+			const client = await registerOAuthClient(origin, {
+				clientName: 'Kody control-kody package-create',
+			})
+			expect(client).toEqual({
+				clientId: 'client-1',
+				clientSecret: 'secret-1',
+				redirectUri: 'http://127.0.0.1/oauth/callback',
+			})
+
+			const code = await authorizeOAuthClient(origin, client, cookie)
+			expect(code).toBe('auth-code-1')
+
+			const token = await exchangeAuthorizationCode(origin, client, code)
+			expect(token).toBe('token-1')
+		},
+	)
+	expect(requests).toEqual([
+		'POST /auth',
+		'POST /auth',
+		'POST /oauth/register',
+		'POST /oauth/authorize',
+		'POST /oauth/token',
+	])
+
+	await withMockOrigin(
+		(_request, response) => {
+			response.statusCode = 403
+			response.setHeader('Content-Type', 'application/json')
+			response.end(JSON.stringify({ error: 'email_verification_required' }))
+		},
+		async (origin) => {
+			await expect(registerOAuthClient(origin)).rejects.toThrow(
+				/\/oauth\/register failed with 403/,
+			)
+			await expect(
+				loginToApp(origin, {
+					email: 'nobody@example.com',
+					username: 'nobody',
+					password: 'ilikecode',
+				}),
+			).rejects.toThrow(/Failed to authenticate/)
+		},
+	)
+})

--- a/tools/mcp-oauth-client.ts
+++ b/tools/mcp-oauth-client.ts
@@ -1,0 +1,315 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
+
+export type AppAuthUser = {
+	email: string
+	username: string
+	password: string
+}
+
+export type OAuthClientRegistration = {
+	clientId: string
+	clientSecret: string
+	redirectUri: string
+}
+
+export type McpConnection = {
+	client: Client
+	transport: StreamableHTTPClientTransport
+}
+
+export type FetchLike = typeof fetch
+
+const defaultRedirectUri = 'http://127.0.0.1/oauth/callback'
+const defaultOAuthClientName = 'Kody MCP E2E Test Client'
+const defaultMcpClientName = 'kody-mcp-e2e-client'
+
+export function usernameFromEmail(email: string) {
+	const local = email.split('@')[0]?.trim()
+	return local && local.length > 0 ? local : 'preview-user'
+}
+
+export function mcpAccountRejectedMessage(detail: string) {
+	return [
+		'MCP rejected this account.',
+		'The preview seed (me@kentcdodds.com) is already email-verified; this CLI does not mark email verified via D1.',
+		`Detail: ${detail}`,
+	].join(' ')
+}
+
+export async function loginToApp(
+	origin: string,
+	user: AppAuthUser,
+	fetchImpl: FetchLike = fetch,
+) {
+	const signupResponse = await authenticateAppUser(
+		origin,
+		user,
+		'signup',
+		fetchImpl,
+	)
+	// An already-registered email gets the same accepted body as a fresh
+	// signup but no session cookie (anti-enumeration), so only a response
+	// that actually set the session counts as a signup.
+	if (
+		signupResponse.ok &&
+		signupResponse.headers.get('Set-Cookie')?.includes('kody_session=')
+	) {
+		return readCookieHeader(signupResponse)
+	}
+
+	const loginResponse = await authenticateAppUser(
+		origin,
+		user,
+		'login',
+		fetchImpl,
+	)
+	if (!loginResponse.ok) {
+		const signupBody = await signupResponse.text()
+		const loginBody = await loginResponse.text()
+		throw new Error(
+			`Failed to authenticate test user.\nSignup: ${signupResponse.status} ${signupBody}\nLogin: ${loginResponse.status} ${loginBody}`,
+		)
+	}
+
+	return readCookieHeader(loginResponse)
+}
+
+export async function registerOAuthClient(
+	origin: string,
+	options: {
+		clientName?: string
+		redirectUri?: string
+		fetchImpl?: FetchLike
+	} = {},
+): Promise<OAuthClientRegistration> {
+	const redirectUri = options.redirectUri ?? defaultRedirectUri
+	const fetchImpl = options.fetchImpl ?? fetch
+	const payload = await fetchJson<Record<string, unknown>>(
+		origin,
+		'/oauth/register',
+		{
+			method: 'POST',
+			headers: {
+				Accept: 'application/json',
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify({
+				client_name: options.clientName ?? defaultOAuthClientName,
+				redirect_uris: [redirectUri],
+				grant_types: ['authorization_code', 'refresh_token'],
+				response_types: ['code'],
+				token_endpoint_auth_method: 'client_secret_post',
+			}),
+		},
+		fetchImpl,
+	)
+	const clientId = readStringField(payload, 'client_id')
+	const clientSecret = readStringField(payload, 'client_secret')
+	return {
+		clientId,
+		clientSecret,
+		redirectUri,
+	}
+}
+
+export async function authorizeOAuthClient(
+	origin: string,
+	client: OAuthClientRegistration,
+	cookieHeader: string,
+	fetchImpl: FetchLike = fetch,
+) {
+	const authorizeUrl = new URL('/oauth/authorize', origin)
+	const resource = new URL('/mcp', origin).toString()
+	authorizeUrl.searchParams.set('response_type', 'code')
+	authorizeUrl.searchParams.set('client_id', client.clientId)
+	authorizeUrl.searchParams.set('redirect_uri', client.redirectUri)
+	authorizeUrl.searchParams.set('scope', 'profile email')
+	authorizeUrl.searchParams.set('state', 'kody-mcp-e2e-state')
+	authorizeUrl.searchParams.set('resource', resource)
+
+	const response = await fetchImpl(authorizeUrl, {
+		method: 'POST',
+		headers: {
+			Accept: 'application/json',
+			Cookie: cookieHeader,
+			'Content-Type': 'application/x-www-form-urlencoded',
+		},
+		body: new URLSearchParams({
+			decision: 'approve',
+		}),
+	})
+	const rawBody = await response.text()
+	if (!response.ok) {
+		throw new Error(
+			`OAuth authorize request failed with ${response.status}: ${rawBody}`,
+		)
+	}
+	const payload = JSON.parse(rawBody) as Record<string, unknown>
+	const redirectTo = readStringField(payload, 'redirectTo')
+	const code = new URL(redirectTo).searchParams.get('code')
+	if (!code) {
+		throw new Error(
+			`OAuth authorize response did not include a code: ${rawBody}`,
+		)
+	}
+	return code
+}
+
+export async function exchangeAuthorizationCode(
+	origin: string,
+	client: OAuthClientRegistration,
+	code: string,
+	fetchImpl: FetchLike = fetch,
+) {
+	const resource = new URL('/mcp', origin).toString()
+	const response = await fetchImpl(new URL('/oauth/token', origin), {
+		method: 'POST',
+		headers: {
+			Accept: 'application/json',
+			'Content-Type': 'application/x-www-form-urlencoded',
+		},
+		body: new URLSearchParams({
+			grant_type: 'authorization_code',
+			code,
+			client_id: client.clientId,
+			client_secret: client.clientSecret,
+			redirect_uri: client.redirectUri,
+			resource,
+		}),
+	})
+	const rawBody = await response.text()
+	if (!response.ok) {
+		throw new Error(
+			`OAuth token exchange failed with ${response.status}: ${rawBody}`,
+		)
+	}
+	const payload = JSON.parse(rawBody) as Record<string, unknown>
+	return readStringField(payload, 'access_token')
+}
+
+export async function connectMcpClient(
+	origin: string,
+	headers: Record<string, string>,
+	options: { name?: string; version?: string } = {},
+): Promise<McpConnection> {
+	const client = new Client(
+		{
+			name: options.name ?? defaultMcpClientName,
+			version: options.version ?? '1.0.0',
+		},
+		{ capabilities: {} },
+	)
+	const transport = new StreamableHTTPClientTransport(new URL('/mcp', origin), {
+		requestInit: {
+			headers,
+		},
+	})
+	await client.connect(transport)
+	return { client, transport }
+}
+
+export async function closeMcpConnection(input: McpConnection) {
+	await input.client.close().catch(() => undefined)
+	await input.transport.terminateSession().catch(() => undefined)
+	await input.transport.close().catch(() => undefined)
+}
+
+export async function connectAppMcpClient(
+	origin: string,
+	user: AppAuthUser,
+	options: {
+		extraHeaders?: Record<string, string>
+		clientName?: string
+		fetchImpl?: FetchLike
+	} = {},
+) {
+	const fetchImpl = options.fetchImpl ?? fetch
+	const cookieHeader = await loginToApp(origin, user, fetchImpl)
+	const clientRegistration = await registerOAuthClient(origin, {
+		clientName: options.clientName,
+		fetchImpl,
+	})
+	const code = await authorizeOAuthClient(
+		origin,
+		clientRegistration,
+		cookieHeader,
+		fetchImpl,
+	)
+	const accessToken = await exchangeAuthorizationCode(
+		origin,
+		clientRegistration,
+		code,
+		fetchImpl,
+	)
+	let connection: McpConnection
+	try {
+		connection = await connectMcpClient(origin, {
+			Authorization: `Bearer ${accessToken}`,
+			...options.extraHeaders,
+		})
+	} catch (error) {
+		const detail = error instanceof Error ? error.message : String(error)
+		throw new Error(mcpAccountRejectedMessage(detail))
+	}
+	return {
+		cookieHeader,
+		client: connection.client,
+		async [Symbol.asyncDispose]() {
+			await closeMcpConnection(connection)
+		},
+	}
+}
+
+async function authenticateAppUser(
+	origin: string,
+	user: AppAuthUser,
+	mode: 'login' | 'signup',
+	fetchImpl: FetchLike,
+) {
+	return fetchImpl(new URL('/auth', origin), {
+		method: 'POST',
+		headers: {
+			Accept: 'application/json',
+			'Content-Type': 'application/json',
+		},
+		body: JSON.stringify({
+			email: user.email,
+			...(mode === 'signup' ? { username: user.username } : {}),
+			password: user.password,
+			mode,
+		}),
+	})
+}
+
+export function readCookieHeader(response: Response) {
+	const cookie = response.headers.get('Set-Cookie')
+	if (!cookie) {
+		throw new Error('Authentication response did not include a session cookie.')
+	}
+	return cookie.split(';')[0] ?? cookie
+}
+
+async function fetchJson<T = Record<string, unknown>>(
+	origin: string,
+	pathname: string,
+	init: RequestInit | undefined,
+	fetchImpl: FetchLike,
+): Promise<T> {
+	const response = await fetchImpl(new URL(pathname, origin), init)
+	const rawBody = await response.text()
+	if (!response.ok) {
+		throw new Error(
+			`Request to ${pathname} failed with ${response.status}: ${rawBody}`,
+		)
+	}
+	return JSON.parse(rawBody) as T
+}
+
+export function readStringField(record: Record<string, unknown>, key: string) {
+	const value = record[key]
+	if (typeof value !== 'string' || value.length === 0) {
+		throw new Error(`Expected "${key}" to be a non-empty string.`)
+	}
+	return value
+}

--- a/tools/mcp-oauth-client.ts
+++ b/tools/mcp-oauth-client.ts
@@ -1,3 +1,7 @@
+import {
+	Client as ModernClient,
+	StreamableHTTPClientTransport as ModernStreamableHTTPClientTransport,
+} from '@modelcontextprotocol/client'
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
 
@@ -23,6 +27,7 @@ export type FetchLike = typeof fetch
 const defaultRedirectUri = 'http://127.0.0.1/oauth/callback'
 const defaultOAuthClientName = 'Kody MCP E2E Test Client'
 const defaultMcpClientName = 'kody-mcp-e2e-client'
+const defaultControlKodyClientName = 'kody-control-kody'
 
 export function usernameFromEmail(email: string) {
 	const local = email.split('@')[0]?.trim()
@@ -242,23 +247,58 @@ export async function connectAppMcpClient(
 		code,
 		fetchImpl,
 	)
-	let connection: McpConnection
+	// Preview and production Workers are multi-isolate: the legacy
+	// sessionful SDK v1 client initializes, then hangs on the next request.
+	// Pin the stateless 2026-07-28 lane so each tool call is self-contained.
+	let client: ModernClient
+	let transport: ModernStreamableHTTPClientTransport
 	try {
-		connection = await connectMcpClient(origin, {
-			Authorization: `Bearer ${accessToken}`,
-			...options.extraHeaders,
-		})
+		const connected = await connectStatelessMcpClient(
+			origin,
+			{
+				Authorization: `Bearer ${accessToken}`,
+				...options.extraHeaders,
+			},
+			{ name: options.clientName ?? defaultControlKodyClientName },
+		)
+		client = connected.client
+		transport = connected.transport
 	} catch (error) {
 		const detail = error instanceof Error ? error.message : String(error)
 		throw new Error(mcpAccountRejectedMessage(detail))
 	}
 	return {
 		cookieHeader,
-		client: connection.client,
+		client,
 		async [Symbol.asyncDispose]() {
-			await closeMcpConnection(connection)
+			await client.close().catch(() => undefined)
+			await transport.close().catch(() => undefined)
 		},
 	}
+}
+
+export async function connectStatelessMcpClient(
+	origin: string,
+	headers: Record<string, string>,
+	options: { name?: string; version?: string } = {},
+) {
+	const client = new ModernClient(
+		{
+			name: options.name ?? defaultControlKodyClientName,
+			version: options.version ?? '1.0.0',
+		},
+		{ versionNegotiation: { mode: { pin: '2026-07-28' } } },
+	)
+	const transport = new ModernStreamableHTTPClientTransport(
+		new URL('/mcp', origin),
+		{
+			requestInit: {
+				headers,
+			},
+		},
+	)
+	await client.connect(transport)
+	return { client, transport }
 }
 
 async function authenticateAppUser(

--- a/tools/mcp-test-support.ts
+++ b/tools/mcp-test-support.ts
@@ -6,10 +6,6 @@ import path from 'node:path'
 import { setTimeout as delay } from 'node:timers/promises'
 import { type Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { type CallToolRequest } from '@modelcontextprotocol/sdk/types.js'
-import {
-	Client as ModernClient,
-	StreamableHTTPClientTransport as ModernStreamableHTTPClientTransport,
-} from '@modelcontextprotocol/client'
 import getPort from 'get-port'
 import { createTestHarness } from 'wrangler'
 import {
@@ -25,6 +21,7 @@ import {
 	authorizeOAuthClient,
 	closeMcpConnection,
 	connectMcpClient,
+	connectStatelessMcpClient,
 	exchangeAuthorizationCode,
 	loginToApp,
 	registerOAuthClient,
@@ -443,24 +440,16 @@ export async function createModernMcpClient(
 		clientRegistration,
 		code,
 	)
-	const client = new ModernClient(
-		{ name: 'kody-mcp-e2e-modern-client', version: '1.0.0' },
-		{ versionNegotiation: { mode: { pin: '2026-07-28' } } },
+	const connection = await connectStatelessMcpClient(
+		origin,
+		{ Authorization: `Bearer ${accessToken}` },
+		{ name: 'kody-mcp-e2e-modern-client' },
 	)
-	const transport = new ModernStreamableHTTPClientTransport(
-		new URL('/mcp', origin),
-		{
-			requestInit: {
-				headers: { Authorization: `Bearer ${accessToken}` },
-			},
-		},
-	)
-	await client.connect(transport)
 	return {
-		client,
+		client: connection.client,
 		async [Symbol.asyncDispose]() {
-			await client.close().catch(() => undefined)
-			await transport.close().catch(() => undefined)
+			await connection.client.close().catch(() => undefined)
+			await connection.transport.close().catch(() => undefined)
 		},
 	}
 }

--- a/tools/mcp-test-support.ts
+++ b/tools/mcp-test-support.ts
@@ -4,8 +4,7 @@ import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { setTimeout as delay } from 'node:timers/promises'
-import { Client } from '@modelcontextprotocol/sdk/client/index.js'
-import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
+import { type Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { type CallToolRequest } from '@modelcontextprotocol/sdk/types.js'
 import {
 	Client as ModernClient,
@@ -22,6 +21,15 @@ import {
 import { startCloudflareMock } from '#worker/test-support/cloudflare-mock-server.ts'
 import { ensureGuideCatalogModules } from './build-guide-catalog-modules.ts'
 import { ensureWorkerBundlerModules } from './build-worker-bundler-modules.ts'
+import {
+	authorizeOAuthClient,
+	closeMcpConnection,
+	connectMcpClient,
+	exchangeAuthorizationCode,
+	loginToApp,
+	registerOAuthClient,
+	type AppAuthUser,
+} from './mcp-oauth-client.ts'
 import { buildRoleAssignmentSql } from './seed-sql.ts'
 
 const projectRoot = process.cwd()
@@ -35,17 +43,7 @@ const defaultWaitTimeoutMs = process.env.CI ? 60_000 : 45_000
 const perAttemptFetchTimeoutMs = 5_000
 const maxPortBindRetries = 5
 
-type TestUser = {
-	email: string
-	username: string
-	password: string
-}
-
-type OAuthClientRegistration = {
-	clientId: string
-	clientSecret: string
-	redirectUri: string
-}
+type TestUser = AppAuthUser
 
 type TestCallToolParams = CallToolRequest['params'] & {
 	headers?: Record<string, string>
@@ -335,30 +333,6 @@ function isPortAlreadyInUseError(error: unknown) {
 	)
 }
 
-async function loginToApp(origin: string, user: TestUser) {
-	const signupResponse = await authenticateAppUser(origin, user, 'signup')
-	// An already-registered email gets the same accepted body as a fresh
-	// signup but no session cookie (anti-enumeration), so only a response
-	// that actually set the session counts as a signup.
-	if (
-		signupResponse.ok &&
-		signupResponse.headers.get('Set-Cookie')?.includes('kody_session=')
-	) {
-		return readCookieHeader(signupResponse)
-	}
-
-	const loginResponse = await authenticateAppUser(origin, user, 'login')
-	if (!loginResponse.ok) {
-		const signupBody = await signupResponse.text()
-		const loginBody = await loginResponse.text()
-		throw new Error(
-			`Failed to authenticate test user.\nSignup: ${signupResponse.status} ${signupBody}\nLogin: ${loginResponse.status} ${loginBody}`,
-		)
-	}
-
-	return readCookieHeader(loginResponse)
-}
-
 /**
  * Browser session cookie for authenticated app-origin fetches
  * (`Cookie: kody_session=…`). Same JSON `/auth` signup-or-login path used by
@@ -491,50 +465,6 @@ export async function createModernMcpClient(
 	}
 }
 
-async function fetchJson<T = Record<string, unknown>>(
-	origin: string,
-	pathname: string,
-	init?: RequestInit,
-): Promise<T> {
-	const response = await fetch(new URL(pathname, origin), init)
-	const rawBody = await response.text()
-	if (!response.ok) {
-		throw new Error(
-			`Request to ${pathname} failed with ${response.status}: ${rawBody}`,
-		)
-	}
-	return JSON.parse(rawBody) as T
-}
-
-async function connectMcpClient(
-	origin: string,
-	headers: Record<string, string>,
-) {
-	const client = new Client(
-		{
-			name: 'kody-mcp-e2e-client',
-			version: '1.0.0',
-		},
-		{ capabilities: {} },
-	)
-	const transport = new StreamableHTTPClientTransport(new URL('/mcp', origin), {
-		requestInit: {
-			headers,
-		},
-	})
-	await client.connect(transport)
-	return { client, transport }
-}
-
-async function closeMcpConnection(input: {
-	client: Client
-	transport: StreamableHTTPClientTransport
-}) {
-	await input.client.close().catch(() => undefined)
-	await input.transport.terminateSession().catch(() => undefined)
-	await input.transport.close().catch(() => undefined)
-}
-
 async function applyMigrations(persistDir: string) {
 	const proc = spawnProcess({
 		cmd: [
@@ -654,144 +584,4 @@ async function waitForHttpReady(input: {
 			.filter(Boolean)
 			.join('\n\n'),
 	)
-}
-
-async function authenticateAppUser(
-	origin: string,
-	user: TestUser,
-	mode: 'login' | 'signup',
-) {
-	return fetch(new URL('/auth', origin), {
-		method: 'POST',
-		headers: {
-			Accept: 'application/json',
-			'Content-Type': 'application/json',
-		},
-		body: JSON.stringify({
-			email: user.email,
-			...(mode === 'signup' ? { username: user.username } : {}),
-			password: user.password,
-			mode,
-		}),
-	})
-}
-
-function readCookieHeader(response: Response) {
-	const cookie = response.headers.get('Set-Cookie')
-	if (!cookie) {
-		throw new Error('Authentication response did not include a session cookie.')
-	}
-	return cookie.split(';')[0] ?? cookie
-}
-
-async function registerOAuthClient(
-	origin: string,
-): Promise<OAuthClientRegistration> {
-	const redirectUri = 'http://127.0.0.1/oauth/callback'
-	const payload = await fetchJson<Record<string, unknown>>(
-		origin,
-		'/oauth/register',
-		{
-			method: 'POST',
-			headers: {
-				Accept: 'application/json',
-				'Content-Type': 'application/json',
-			},
-			body: JSON.stringify({
-				client_name: 'Kody MCP E2E Test Client',
-				redirect_uris: [redirectUri],
-				grant_types: ['authorization_code', 'refresh_token'],
-				response_types: ['code'],
-				token_endpoint_auth_method: 'client_secret_post',
-			}),
-		},
-	)
-	const clientId = readStringField(payload, 'client_id')
-	const clientSecret = readStringField(payload, 'client_secret')
-	return {
-		clientId,
-		clientSecret,
-		redirectUri,
-	}
-}
-
-async function authorizeOAuthClient(
-	origin: string,
-	client: OAuthClientRegistration,
-	cookieHeader: string,
-) {
-	const authorizeUrl = new URL('/oauth/authorize', origin)
-	const resource = new URL('/mcp', origin).toString()
-	authorizeUrl.searchParams.set('response_type', 'code')
-	authorizeUrl.searchParams.set('client_id', client.clientId)
-	authorizeUrl.searchParams.set('redirect_uri', client.redirectUri)
-	authorizeUrl.searchParams.set('scope', 'profile email')
-	authorizeUrl.searchParams.set('state', 'kody-mcp-e2e-state')
-	authorizeUrl.searchParams.set('resource', resource)
-
-	const response = await fetch(authorizeUrl, {
-		method: 'POST',
-		headers: {
-			Accept: 'application/json',
-			Cookie: cookieHeader,
-			'Content-Type': 'application/x-www-form-urlencoded',
-		},
-		body: new URLSearchParams({
-			decision: 'approve',
-		}),
-	})
-	const rawBody = await response.text()
-	if (!response.ok) {
-		throw new Error(
-			`OAuth authorize request failed with ${response.status}: ${rawBody}`,
-		)
-	}
-	const payload = JSON.parse(rawBody) as Record<string, unknown>
-	const redirectTo = readStringField(payload, 'redirectTo')
-	const code = new URL(redirectTo).searchParams.get('code')
-	if (!code) {
-		throw new Error(
-			`OAuth authorize response did not include a code: ${rawBody}`,
-		)
-	}
-	return code
-}
-
-async function exchangeAuthorizationCode(
-	origin: string,
-	client: OAuthClientRegistration,
-	code: string,
-) {
-	const resource = new URL('/mcp', origin).toString()
-	const response = await fetch(new URL('/oauth/token', origin), {
-		method: 'POST',
-		headers: {
-			Accept: 'application/json',
-			'Content-Type': 'application/x-www-form-urlencoded',
-		},
-		body: new URLSearchParams({
-			grant_type: 'authorization_code',
-			code,
-			client_id: client.clientId,
-			client_secret: client.clientSecret,
-			redirect_uri: client.redirectUri,
-			resource,
-		}),
-	})
-	const rawBody = await response.text()
-	if (!response.ok) {
-		throw new Error(
-			`OAuth token exchange failed with ${response.status}: ${rawBody}`,
-		)
-	}
-	const payload = JSON.parse(rawBody) as Record<string, unknown>
-	return readStringField(payload, 'access_token')
-}
-
-function readStringField(record: Record<string, unknown>, key: string) {
-	const value = record[key]
-	if (typeof value !== 'string' || value.length === 0) {
-		throw new Error(`Expected "${key}" to be a non-empty string.`)
-	}
-	return value
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #2006.

## Intent

Give Cloud Agents a tooling-only way to create a saved package on a PR preview so they can complete the logged-in package chrome / publish lock / HEAD-ahead UI pass. No production worker change.

## Why

`POST /account/packages.json` has no create action. Package creation is MCP-only (`packageGetGitRemote({ create: true, kody_id })` → `createStubSavedPackage`). `/mcp` is OAuth-only, so agents skipped the required preview UI pass. Kent's constraint: no test/preview-only code in the production worker.

## Summary

- Extracted the pure OAuth/MCP-client helpers from `tools/mcp-test-support.ts` into `tools/mcp-oauth-client.ts` so control-kody can reuse them without importing wrangler's `createTestHarness`.
- Added `control-kody package-create --kody-id <slug> [--description] [--head-ahead]`.
- Remote origins use the stateless 2026-07-28 MCP lane (preview Workers drop sessionful SDK v1 after initialize).
- `--head-ahead` clones the minted Artifacts remote, commits one small file, pushes, and does **not** publish. A rerun on the same slug is a no-op when the marker is already committed. If Artifacts cannot mint a write remote, the stub package is still recovered via `packageList`.
- Production refusal now treats trailing-dot FQDNs (`kody.codes.`, `www.kody.codes.`) as production.
- Docs and the packages Feature Map no longer tell agents to POST a create action to `/account/packages.json`.
- Logged-in preview testing does not require agents to hand-roll an MCP OAuth dance — the CLI does it for them.

## Testing

- `npm run validate` green locally (exit 0). MCP e2e 5/5, node-unit 2798, workers-unit 341.
- Node tests: arg parsing, output shape, extracted OAuth helpers (mocked fetch), local git `--head-ahead` plus idempotent rerun, trailing-dot production origins.
- Push hook `test:push` green on `c88356bc` (node 2798, workers 341).
- Preview evidence below (from the preview of this PR). Review-feedback commit is tooling-only and does not change the create path.

## Conductor report

STATUS: blocked-merge (PR ready; conductor merges). GitHub connector is known-outage for `github-botAccessToken`. This track will not work around it.

PR: https://github.com/kentcdodds/kody/pull/2142 (ready, head `c88356bc`)

Review feedback addressed on `c88356bc`:
- Bugbot: `--head-ahead` rerun no longer fails when `preview-head-ahead.txt` is already committed.
- CodeRabbit: production hostname check strips trailing DNS root dots.

### validate

`npm run validate` local exit 0. Includes format, lint, typecheck, node, workers, e2e (10 passed), MCP e2e (5 passed).

### Preview command lines

Origin: `https://kody-pr-2142.kody-a99.workers.dev` (never `https://kody.codes`)

```bash
npm run control-kody -- package-create \
  --origin https://kody-pr-2142.kody-a99.workers.dev \
  --kody-id preview-pkg-create \
  --description 'Preview fixture for control-kody package-create' \
  --json --cookie-file .tmp/control-kody-cookie
```

Response excerpt:

```json
{
  "ok": true,
  "packageId": "731fff7a-8823-4445-a9db-f6865825c388",
  "kodyId": "preview-pkg-create",
  "name": "@user-me/preview-pkg-create",
  "username": "user-me",
  "packagePageUrl": "https://kody-pr-2142.kody-a99.workers.dev/@user-me/preview-pkg-create",
  "accountPackageUrl": "https://kody-pr-2142.kody-a99.workers.dev/account/packages/731fff7a-8823-4445-a9db-f6865825c388"
}
```

### Page checks (cookie session as me@kentcdodds.com)

```
GET /@user-me/preview-pkg-create
→ HTTP/2 200
→ <title>@user-me/preview-pkg-create</title>

GET /account/packages/731fff7a-8823-4445-a9db-f6865825c388
→ HTTP/2 302 → HTTP/2 200
→ location: /@user-me/preview-pkg-create
→ <title>@user-me/preview-pkg-create</title>
```

Second slug (create succeeded, `--head-ahead` could not push):

```bash
npm run control-kody -- package-create \
  --origin https://kody-pr-2142.kody-a99.workers.dev \
  --kody-id preview-pkg-ahead \
  --head-ahead --json
```

`packageGetGitRemote` failed minting a write remote:

```
packageGetGitRemote stopped by the production package source safety policy.
... account not found
```

The stub still landed (`c571dd8f-9adc-4411-baaf-3ea282c6c8c3`). `GET /@user-me/preview-pkg-ahead` is HTTP 200 with `<title>@user-me/preview-pkg-ahead</title>`. No **HEAD ahead of published** badge — Artifacts write remote is unavailable on this preview mock.

### Remains

- Conductor squash-merges (this track will not work around the GitHub connector outage).
- `--head-ahead` needs a working Artifacts account on the preview mock; documented in the packages Feature Map.
- After conductor merge: close #2006 and remove `friction-skipped`.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `c7449bb8` · **Head:** `c88356bc`

**Classification:** composes — no primitives added or changed; this PR wires existing MCP OAuth, execute, and cookie sessions from `tools/` and docs only.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| _(none matched)_ | — | Diff is `tools/` + contributing docs. Runtime primitives are called as-is. |

Unmatched paths: `tools/control-kody*`, `tools/mcp-oauth-client*`, `tools/mcp-test-support.ts`, Feature Map and contributing docs.

### Change flow

control-kody package-create logs in, completes MCP OAuth on the stateless 2026-07-28 lane, and calls execute `packageGetGitRemote({ create: true })`. If Artifacts cannot mint a write remote, packageList still recovers the stub. Optional `--head-ahead` pushes one unpublished commit.

```mermaid
sequenceDiagram
	actor Agent
	participant controlKody as control-kody
	participant appSessions as app-sessions
	participant mcpServer as mcp-server
	participant capabilityRegistry as capability-registry
	Agent->>controlKody: package-create --kody-id slug [--head-ahead]
	controlKody->>appSessions: POST /auth then OAuth register, authorize, token
	controlKody->>mcpServer: execute on stateless 2026-07-28 lane
	mcpServer->>capabilityRegistry: packageGetGitRemote create true
	alt Artifacts mint fails
	controlKody->>mcpServer: packageList recovers stub packageId
	end
	opt --head-ahead when remote minted
	controlKody->>controlKody: clone, commit preview-head-ahead.txt, push, no publish
	end
	controlKody-->>Agent: packageId, kodyId, name, /@username/kodyId, /account/packages/id
```

### Before / after

```text
Before: Feature Map said POST /account/packages.json creates a package (no such action).
After:  npm run control-kody -- package-create --origin <preview> --kody-id <slug> [--head-ahead]
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-80d3a14c-c144-47a0-b889-9efacfb978a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-80d3a14c-c144-47a0-b889-9efacfb978a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a `package-create` command for creating saved packages from preview environments.
  - Supports package descriptions and optionally pushing one unpublished commit ahead of the published state.
  - Includes input validation, authentication, recovery handling, clear reports, and protection against production-origin usage.
  - Improved MCP authentication and connection handling for reliable package creation.

- **Documentation**
  - Updated package, preview testing, and contributor guidance for the new workflow.
  - Clarified MCP-only package creation and prohibited direct creation through the packages JSON endpoint.
  - Added guidance for seeding preview data through product APIs or the new command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->