### PR TITLE
ops: edge maintenance mode switch + status maintenance page (#1092 item 3)

### DIFF
--- a/docs/contributing/disaster-recovery.md
+++ b/docs/contributing/disaster-recovery.md
@@ -19,6 +19,8 @@ Primary operator surface:
   restore drill, and graduated production restore.
 - Offline CLIs under `tools/disaster-recovery/` when the UI is unavailable (see
   [Offline CLI fallback](#offline-cli-fallback)).
+- Edge maintenance mode: `npm run maintenance-mode -- on|off|status` (see
+  [Maintenance mode (edge)](#maintenance-mode-edge)).
 - Destination provisioner: `node tools/ci/backup-resources-cli.ts plan|apply`.
 
 Do not use `tools/export-d1-remote-to-sqlite.sh` as a backup or restore tool.
@@ -454,9 +456,9 @@ import init/ingest etag. Without that prelude, drills fail with errors like
    Mailbox importer below for the intended owners. Do not re-enable ingress
    unless its final response has both `"done": true` and `"verified": true`.
 
-Disable ingress / put the app in maintenance before execute. After restore:
-reindex Vectorize (`POST /__maintenance/reindex-capabilities` with
-`{ "force": true }`, omit `phases`, follow `cursor` until `complete`); let
+Put the app in [maintenance mode (edge)](#maintenance-mode-edge) before execute.
+After restore: reindex Vectorize (`POST /__maintenance/reindex-capabilities`
+with `{ "force": true }`, omit `phases`, follow `cursor` until `complete`); let
 `kody-jobs` re-arm JobManager Durable Object alarms from restored `JOBS_DB`
 (`jobs.next_run_at` via `JobManager.syncAlarm` and the jobs-worker watchdog —
 APP_DB is not the job schedule store); recreate queues from Wrangler config; and
@@ -480,11 +482,12 @@ class is covered. Deleting a Durable Object class destroys its PITR history and
 makes this procedure impossible.
 
 The operator endpoint is production-only infrastructure, is not registered on
-user, MCP, or package surfaces, and reuses `DR_RESTORE_SECRET`. Disable ingress
-or otherwise stop writes to the affected user before recovery. Supply the user's
-exact `stable_user_id`, not username, email, or a D1 numeric id. Valid `kind`
-values are `mailbox`, `run-log`, `user-meter`, and `storage-runner`;
-`storage-runner` also requires its exact storage id.
+user, MCP, or package surfaces, and reuses `DR_RESTORE_SECRET`. Put the app in
+[maintenance mode (edge)](#maintenance-mode-edge) or otherwise stop writes to
+the affected user before recovery. Supply the user's exact `stable_user_id`, not
+username, email, or a D1 numeric id. Valid `kind` values are `mailbox`,
+`run-log`, `user-meter`, and `storage-runner`; `storage-runner` also requires
+its exact storage id.
 
 1. Resolve a bookmark for the incident timestamp. Cloudflare returns the
    bookmark nearest that time:
@@ -707,6 +710,62 @@ bounded. Older unrestorable days may already have canonical and full manifests;
 immutable media is intentionally left unchanged, so freshness, dashboard, drill,
 and production-restore gates remain essential until it ages out.
 
+## Maintenance mode (edge)
+
+Origin has no request-time maintenance flag. `/__maintenance/*` on the origin
+worker is a secret-gated operator API, not a public maintenance page. Ingress is
+disabled with a Cloudflare Single Redirect on the `kody.codes` zone so the
+switch still works when the origin worker or D1 is the thing that is broken,
+flips without a deploy, and adds no cost to the request hot path.
+
+```sh
+npm run maintenance-mode -- on
+npm run maintenance-mode -- status
+npm run maintenance-mode -- off
+```
+
+`node tools/maintenance-mode.ts <on|off|status>` is the same CLI. `--zone`
+defaults to `kody.codes`. `--target` defaults to
+`https://status.kody.codes/maintenance`. `--dry-run` prints the Rulesets API
+calls without sending writes. `--json` prints machine-readable status.
+
+The token is `CLOUDFLARE_API_TOKEN` with **Zone:Read** and Zone **"Single
+Redirect" / Dynamic Redirect: Edit** on `kody.codes`. See
+[Operator accounts](./operator-accounts.md). No CI token has the redirect scope;
+do not widen an existing token. The first live `on` / `off` is an operator run
+with a token that has that scope (`--dry-run` first). The CLI adds or patches
+the `kody-maintenance-mode` rule; it does not `PUT` the whole phase entrypoint,
+so other Single Redirects on the zone stay put.
+
+What stays reachable on the apex:
+
+- `GET /health` — external uptime check. The rule expression is an exact path
+  match, so `/health/components` is redirected.
+- `/__maintenance/*` — DR restore, reindex, PITR, and other operator endpoints
+  must stay reachable while ingress is off.
+
+Everything else on `kody.codes`, including `POST /webhooks/stripe`, is a 302 to
+the status maintenance page (`preserve_query_string` false). Stripe retries on
+3xx and 5xx, so redirecting the webhook is acceptable for the restore window; it
+is not excluded.
+
+The public copy lives on the status worker (`GET /maintenance`), which does not
+depend on origin D1 or `kody.codes`.
+
+Confirm:
+
+```sh
+curl -I https://kody.codes/
+# 302 Location: https://status.kody.codes/maintenance
+curl --fail --silent --show-error --header "Accept: application/json" \
+  https://kody.codes/health
+# 200 {"ok":true,...}
+```
+
+Turn it off with `npm run maintenance-mode -- off` (the rule stays in the zone
+ruleset, disabled, so `status` can still report it). Confirm
+`curl -I https://kody.codes/` is no longer a 302 to the maintenance page.
+
 ## Offline CLI fallback
 
 The UI is the primary drill/restore path. Keep the CLIs for air-gapped or
@@ -722,6 +781,9 @@ UI-down recovery:
 - `node tools/disaster-recovery/unseal-escrow.ts` — authenticated recovery from
   a local sealed blob or the DR bucket; writes only to stdout or a new file
   outside the repository
+- `node tools/maintenance-mode.ts` — edge maintenance mode (Cloudflare Single
+  Redirect on `kody.codes`; see
+  [Maintenance mode (edge)](#maintenance-mode-edge))
 
 Details:
 [`tools/disaster-recovery/readme.md`](../../tools/disaster-recovery/readme.md).

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "preview:e2e": "node tools/prepare-e2e-env.ts && npm run migrate:e2e && WRANGLER_PERSIST_TO=.wrangler/state/e2e npm run dev:vite",
     "preview:manual-test": "node tools/preview-manual-test.ts",
     "control-kody": "node tools/control-kody.ts",
+    "maintenance-mode": "node tools/maintenance-mode.ts",
     "site-perf": "node tools/site-perf/collect.ts",
     "generate-types": "node --env-file=packages/worker/.env ./wrangler-env.ts types ./packages/worker/worker-configuration.d.ts",
     "typecheck": "nx run worker:typecheck && tsc --noEmit -p packages/backup-control-plane/tsconfig.json && tsc --noEmit -p packages/status/tsconfig.json && tsc --noEmit -p packages/jobs-worker/tsconfig.json && tsc --noEmit -p packages/highlight-worker/tsconfig.json && tsc --noEmit -p packages/nx-cache/tsconfig.json",

--- a/packages/status/status-page.node.test.ts
+++ b/packages/status/status-page.node.test.ts
@@ -1,6 +1,10 @@
 import { expect, test } from 'vitest'
 import { faviconIcoRedirectLocation, statusFaviconPath } from './favicon.ts'
-import { renderStatusPage, renderStatusUnavailablePage } from './status-page.ts'
+import {
+	renderMaintenancePage,
+	renderStatusPage,
+	renderStatusUnavailablePage,
+} from './status-page.ts'
 import {
 	statusComponents,
 	type ComponentSnapshot,
@@ -246,4 +250,13 @@ test('status page keeps resolved incidents glanceable and expands a retrospectiv
 	expect(withWriteup).toContain('Two failed Jobs probes.')
 	expect(withWriteup).not.toContain('<script>alert(1)</script>')
 	expect(withWriteup).toContain('&lt;script&gt;alert(1)&lt;/script&gt;')
+})
+
+test('maintenance page is static HTML with a link back to the status home', () => {
+	const html = renderMaintenancePage()
+	expect(html).toContain('Kody is in maintenance')
+	expect(html).toContain('We are restoring service; nothing you need to do.')
+	expect(html).toContain('href="https://status.kody.codes/"')
+	expect(html).toContain('status.kody.codes')
+	expect(html).toContain(`href="${statusFaviconPath('unknown')}"`)
 })

--- a/packages/status/status-page.ts
+++ b/packages/status/status-page.ts
@@ -294,6 +294,33 @@ function renderProviderIncidentsSection(
 </section>`
 }
 
+const statusPageUrl = 'https://status.kody.codes/'
+
+/** Static HTML for origin-edge maintenance. No Durable Object or D1. */
+export function renderMaintenancePage(): string {
+	return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Kody is in maintenance</title>
+${renderFaviconLinks('unknown')}
+<style>${pageStyles}</style>
+</head>
+<body>
+<main>
+	<header>
+		<h1>Kody is in maintenance</h1>
+	</header>
+	<div class="banner unknown">Service restore in progress</div>
+	<div class="card">
+		<p>Kody is in maintenance. We are restoring service; nothing you need to do. Check <a href="${statusPageUrl}">status.kody.codes</a> for updates.</p>
+	</div>
+</main>
+</body>
+</html>`
+}
+
 /** Controlled 503 HTML when the status Durable Object is unavailable. */
 export function renderStatusUnavailablePage(message: string): string {
 	return `<!doctype html>

--- a/packages/status/vitest.config.ts
+++ b/packages/status/vitest.config.ts
@@ -1,6 +1,15 @@
+import { resolve } from 'node:path'
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
+	resolve: {
+		alias: {
+			'cloudflare:workers': resolve(
+				import.meta.dirname,
+				'../worker/src/test-support/cloudflare-workers-stub.ts',
+			),
+		},
+	},
 	test: {
 		environment: 'node',
 		include: ['*.node.test.ts'],

--- a/packages/status/worker.node.test.ts
+++ b/packages/status/worker.node.test.ts
@@ -1,0 +1,59 @@
+import { expect, test } from 'vitest'
+import { statusFaviconPath } from './favicon.ts'
+import { type StatusWorkerEnv } from './status-store.ts'
+import worker from './worker.ts'
+
+type StatusFetch = NonNullable<ExportedHandler<StatusWorkerEnv>['fetch']>
+
+function workerRequest(url: string) {
+	return new Request(url) as Parameters<StatusFetch>[0]
+}
+
+function unusedStore(): StatusWorkerEnv['STATUS_STORE'] {
+	return {
+		idFromName() {
+			throw new Error('STATUS_STORE should not be used for /maintenance')
+		},
+		get() {
+			throw new Error('STATUS_STORE should not be used for /maintenance')
+		},
+	} as unknown as StatusWorkerEnv['STATUS_STORE']
+}
+
+function env(): StatusWorkerEnv {
+	return {
+		STATUS_STORE: unusedStore(),
+		PRIMARY_ORIGIN: 'https://kody.codes',
+		PACKAGE_APP_ORIGIN: 'https://kody.run',
+		STATUS_PAGE_URL: 'https://status.kody.codes',
+		ALERT_EMAIL_TO: 'ops@example.com',
+		ALERT_EMAIL_FROM: 'status@example.com',
+		BUILD_COMMIT: 'abc123',
+	}
+}
+
+test('GET /maintenance returns the static page without touching status storage', async () => {
+	const response = await worker.fetch(
+		workerRequest('https://status.kody.codes/maintenance'),
+		env(),
+	)
+	expect(response.status).toBe(200)
+	expect(response.headers.get('Cache-Control')).toBe('no-store')
+	expect(response.headers.get('Content-Type')).toContain('text/html')
+	const html = await response.text()
+	expect(html).toContain('Kody is in maintenance')
+	expect(html).toContain('href="https://status.kody.codes/"')
+	expect(html).toContain(`href="${statusFaviconPath('unknown')}"`)
+})
+
+test('GET /health stays independent of the maintenance page', async () => {
+	const response = await worker.fetch(
+		workerRequest('https://status.kody.codes/health'),
+		env(),
+	)
+	expect(response.status).toBe(200)
+	await expect(response.json()).resolves.toEqual({
+		ok: true,
+		commit: 'abc123',
+	})
+})

--- a/packages/status/worker.ts
+++ b/packages/status/worker.ts
@@ -4,7 +4,11 @@ import {
 	parseIncidentRetrospectivePath,
 	unknownStatusMaintenanceResponse,
 } from './retrospective-maintenance.ts'
-import { renderStatusPage, renderStatusUnavailablePage } from './status-page.ts'
+import {
+	renderMaintenancePage,
+	renderStatusPage,
+	renderStatusUnavailablePage,
+} from './status-page.ts'
 import { StatusStore, type StatusWorkerEnv } from './status-store.ts'
 import { type ComponentStatus } from './status-types.ts'
 
@@ -39,6 +43,15 @@ export default {
 		}
 		if (request.method !== 'GET' && request.method !== 'HEAD') {
 			return new Response('Method not allowed', { status: 405 })
+		}
+		if (url.pathname === '/maintenance') {
+			return new Response(renderMaintenancePage(), {
+				status: 200,
+				headers: {
+					'Content-Type': 'text/html; charset=utf-8',
+					'Cache-Control': 'no-store',
+				},
+			})
 		}
 		if (url.pathname === '/health') {
 			return Response.json(

--- a/tools/maintenance-mode.node.test.ts
+++ b/tools/maintenance-mode.node.test.ts
@@ -1,0 +1,301 @@
+import { expect, test } from 'vitest'
+import {
+	buildMaintenanceExpression,
+	buildMaintenanceRedirectRule,
+	cloudflareApiBaseUrl,
+	defaultMaintenanceTarget,
+	defaultMaintenanceZone,
+	maintenanceRuleMarker,
+	parseArgs,
+	requiredTokenScopesMessage,
+	runMaintenanceMode,
+} from './maintenance-mode.ts'
+
+const zoneId = 'zone-kody'
+const rulesetId = 'ruleset-redirects'
+const ruleId = 'rule-maintenance'
+
+function jsonResponse(body: unknown, status = 200) {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { 'Content-Type': 'application/json' },
+	})
+}
+
+function envelope<T>(result: T, status = 200) {
+	return jsonResponse({ success: true, result, errors: [] }, status)
+}
+
+function zoneLookup() {
+	return envelope([{ id: zoneId, name: defaultMaintenanceZone }])
+}
+
+function redirectRule(enabled: boolean) {
+	return {
+		id: ruleId,
+		ref: maintenanceRuleMarker,
+		description: maintenanceRuleMarker,
+		enabled,
+		expression: buildMaintenanceExpression(defaultMaintenanceZone),
+		action: 'redirect',
+		action_parameters: {
+			from_value: {
+				target_url: { value: defaultMaintenanceTarget },
+				status_code: 302,
+				preserve_query_string: false,
+			},
+		},
+	}
+}
+
+function entrypoint(rules: Array<ReturnType<typeof redirectRule>>) {
+	return envelope({
+		id: rulesetId,
+		name: 'Redirect rules ruleset',
+		kind: 'zone',
+		phase: 'http_request_dynamic_redirect',
+		rules,
+	})
+}
+
+function mockFetch(handler: (url: string, init?: RequestInit) => Response) {
+	const calls: Array<{ method: string; url: string; body: unknown }> = []
+	const fetchImpl: typeof fetch = async (input, init) => {
+		const url = String(input)
+		const method = init?.method ?? 'GET'
+		const body = init?.body ? JSON.parse(String(init.body)) : undefined
+		calls.push({ method, url, body })
+		return handler(url, init)
+	}
+	return { fetchImpl, calls }
+}
+
+test('parseArgs reads command, zone, target, dry-run, and json', () => {
+	expect(parseArgs(['status'])).toEqual({
+		command: 'status',
+		zone: defaultMaintenanceZone,
+		target: defaultMaintenanceTarget,
+		dryRun: false,
+		json: false,
+	})
+	expect(
+		parseArgs([
+			'on',
+			'--zone',
+			'example.com',
+			'--target',
+			'https://status.example.com/maintenance',
+			'--dry-run',
+			'--json',
+		]),
+	).toEqual({
+		command: 'on',
+		zone: 'example.com',
+		target: 'https://status.example.com/maintenance',
+		dryRun: true,
+		json: true,
+	})
+	expect(() => parseArgs([])).toThrow(/Usage/)
+	expect(() => parseArgs(['enable'])).toThrow(/Unknown command/)
+	expect(() => parseArgs(['on', '--nope'])).toThrow(/Unknown flag/)
+})
+
+test('buildMaintenanceRedirectRule uses a static 302 to the status page', () => {
+	expect(
+		buildMaintenanceRedirectRule({
+			zone: defaultMaintenanceZone,
+			target: defaultMaintenanceTarget,
+			enabled: true,
+		}),
+	).toEqual({
+		ref: maintenanceRuleMarker,
+		description: maintenanceRuleMarker,
+		expression: `(http.host eq "${defaultMaintenanceZone}" and not starts_with(http.request.uri.path, "/__maintenance/") and http.request.uri.path ne "/health")`,
+		action: 'redirect',
+		enabled: true,
+		action_parameters: {
+			from_value: {
+				target_url: { value: defaultMaintenanceTarget },
+				status_code: 302,
+				preserve_query_string: false,
+			},
+		},
+	})
+})
+
+test('on creates the dynamic-redirect entrypoint when the zone has none', async () => {
+	const { fetchImpl, calls } = mockFetch((url, init) => {
+		if (url.includes('/zones?name=')) return zoneLookup()
+		if (url.includes('/entrypoint')) {
+			return jsonResponse(
+				{ success: false, errors: [{ message: 'not found' }] },
+				404,
+			)
+		}
+		if ((init?.method ?? 'GET') === 'POST' && url.endsWith('/rulesets')) {
+			return envelope({
+				id: rulesetId,
+				phase: 'http_request_dynamic_redirect',
+				rules: [redirectRule(true)],
+			})
+		}
+		throw new Error(`Unexpected ${init?.method ?? 'GET'} ${url}`)
+	})
+
+	const result = await runMaintenanceMode(parseArgs(['on']), {
+		env: { CLOUDFLARE_API_TOKEN: 'token' },
+		fetch: fetchImpl,
+		log: () => {},
+	})
+
+	expect(result.exists).toBe(true)
+	expect(result.enabled).toBe(true)
+	expect(calls.map((call) => `${call.method} ${call.url}`)).toEqual([
+		`GET ${cloudflareApiBaseUrl}/zones?name=${defaultMaintenanceZone}&status=active`,
+		`GET ${cloudflareApiBaseUrl}/zones/${zoneId}/rulesets/phases/http_request_dynamic_redirect/entrypoint`,
+		`POST ${cloudflareApiBaseUrl}/zones/${zoneId}/rulesets`,
+	])
+	expect(calls[2]?.body).toEqual({
+		name: 'Redirect rules ruleset',
+		kind: 'zone',
+		phase: 'http_request_dynamic_redirect',
+		rules: [
+			buildMaintenanceRedirectRule({
+				zone: defaultMaintenanceZone,
+				target: defaultMaintenanceTarget,
+				enabled: true,
+			}),
+		],
+	})
+})
+
+test('on adds the maintenance rule to an existing redirect ruleset', async () => {
+	const { fetchImpl, calls } = mockFetch((url, init) => {
+		if (url.includes('/zones?name=')) return zoneLookup()
+		if (url.includes('/entrypoint')) return entrypoint([])
+		if (
+			(init?.method ?? 'GET') === 'POST' &&
+			url.endsWith(`/${rulesetId}/rules`)
+		) {
+			return envelope({
+				id: rulesetId,
+				rules: [redirectRule(true)],
+			})
+		}
+		throw new Error(`Unexpected ${init?.method ?? 'GET'} ${url}`)
+	})
+
+	const result = await runMaintenanceMode(parseArgs(['on']), {
+		env: { CLOUDFLARE_API_TOKEN: 'token' },
+		fetch: fetchImpl,
+		log: () => {},
+	})
+
+	expect(result.enabled).toBe(true)
+	expect(calls.at(-1)).toMatchObject({
+		method: 'POST',
+		url: `${cloudflareApiBaseUrl}/zones/${zoneId}/rulesets/${rulesetId}/rules`,
+		body: buildMaintenanceRedirectRule({
+			zone: defaultMaintenanceZone,
+			target: defaultMaintenanceTarget,
+			enabled: true,
+		}),
+	})
+})
+
+test('on enables an existing disabled maintenance rule', async () => {
+	const { fetchImpl, calls } = mockFetch((url, init) => {
+		if (url.includes('/zones?name=')) return zoneLookup()
+		if (url.includes('/entrypoint')) return entrypoint([redirectRule(false)])
+		if ((init?.method ?? 'GET') === 'PATCH' && url.endsWith(`/${ruleId}`)) {
+			return envelope({
+				id: rulesetId,
+				rules: [redirectRule(true)],
+			})
+		}
+		throw new Error(`Unexpected ${init?.method ?? 'GET'} ${url}`)
+	})
+
+	const result = await runMaintenanceMode(parseArgs(['on']), {
+		env: { CLOUDFLARE_API_TOKEN: 'token' },
+		fetch: fetchImpl,
+		log: () => {},
+	})
+
+	expect(result.enabled).toBe(true)
+	expect(calls.at(-1)).toMatchObject({
+		method: 'PATCH',
+		url: `${cloudflareApiBaseUrl}/zones/${zoneId}/rulesets/${rulesetId}/rules/${ruleId}`,
+		body: { enabled: true, ref: maintenanceRuleMarker },
+	})
+})
+
+test('off disables the existing rule and does not delete it', async () => {
+	const { fetchImpl, calls } = mockFetch((url, init) => {
+		if (url.includes('/zones?name=')) return zoneLookup()
+		if (url.includes('/entrypoint')) return entrypoint([redirectRule(true)])
+		if ((init?.method ?? 'GET') === 'PATCH' && url.endsWith(`/${ruleId}`)) {
+			return envelope({
+				id: rulesetId,
+				rules: [redirectRule(false)],
+			})
+		}
+		throw new Error(`Unexpected ${init?.method ?? 'GET'} ${url}`)
+	})
+
+	const result = await runMaintenanceMode(parseArgs(['off']), {
+		env: { CLOUDFLARE_API_TOKEN: 'token' },
+		fetch: fetchImpl,
+		log: () => {},
+	})
+
+	expect(result.exists).toBe(true)
+	expect(result.enabled).toBe(false)
+	expect(calls.some((call) => call.method === 'DELETE')).toBe(false)
+	expect(calls.at(-1)).toMatchObject({
+		method: 'PATCH',
+		url: `${cloudflareApiBaseUrl}/zones/${zoneId}/rulesets/${rulesetId}/rules/${ruleId}`,
+		body: { enabled: false },
+	})
+})
+
+test('status reports whether the rule exists and is enabled', async () => {
+	const { fetchImpl } = mockFetch((url) => {
+		if (url.includes('/zones?name=')) return zoneLookup()
+		if (url.includes('/entrypoint')) return entrypoint([redirectRule(true)])
+		throw new Error(`Unexpected GET ${url}`)
+	})
+
+	const result = await runMaintenanceMode(parseArgs(['status', '--json']), {
+		env: { CLOUDFLARE_API_TOKEN: 'token' },
+		fetch: fetchImpl,
+		log: () => {},
+	})
+
+	expect(result).toMatchObject({
+		command: 'status',
+		exists: true,
+		enabled: true,
+		zone: defaultMaintenanceZone,
+		target: defaultMaintenanceTarget,
+		rulesetId,
+		ruleId,
+	})
+})
+
+test('403 responses name the required Zone:Read and Single Redirect scopes', async () => {
+	const { fetchImpl } = mockFetch(() =>
+		jsonResponse(
+			{ success: false, errors: [{ message: 'Authentication error' }] },
+			403,
+		),
+	)
+
+	await expect(
+		runMaintenanceMode(parseArgs(['status']), {
+			env: { CLOUDFLARE_API_TOKEN: 'bad-token' },
+			fetch: fetchImpl,
+			log: () => {},
+		}),
+	).rejects.toThrow(requiredTokenScopesMessage)
+})

--- a/tools/maintenance-mode.node.test.ts
+++ b/tools/maintenance-mode.node.test.ts
@@ -70,6 +70,44 @@ function mockFetch(handler: (url: string, init?: RequestInit) => Response) {
 	return { fetchImpl, calls }
 }
 
+test('dry-run without a token prints command-specific Rulesets API calls', async () => {
+	const lines: Array<string> = []
+	const on = await runMaintenanceMode(parseArgs(['on', '--dry-run']), {
+		env: {},
+		log: (line) => lines.push(line),
+	})
+	expect(
+		on.requests.map((request) => `${request.method} ${request.url}`),
+	).toEqual([
+		`GET ${cloudflareApiBaseUrl}/zones?name=${defaultMaintenanceZone}&status=active`,
+		`GET ${cloudflareApiBaseUrl}/zones/{zone_id}/rulesets/phases/http_request_dynamic_redirect/entrypoint`,
+		`POST ${cloudflareApiBaseUrl}/zones/{zone_id}/rulesets`,
+	])
+	expect(on.requests[2]?.body).toMatchObject({
+		phase: 'http_request_dynamic_redirect',
+		rules: [{ description: maintenanceRuleMarker, enabled: true }],
+	})
+
+	const off = await runMaintenanceMode(parseArgs(['off', '--dry-run']), {
+		env: {},
+		log: () => {},
+	})
+	expect(off.requests.at(-1)).toMatchObject({
+		method: 'PATCH',
+		url: `${cloudflareApiBaseUrl}/zones/{zone_id}/rulesets/{ruleset_id}/rules/{rule_id}`,
+		body: { enabled: false },
+	})
+
+	const status = await runMaintenanceMode(parseArgs(['status', '--dry-run']), {
+		env: {},
+		log: () => {},
+	})
+	expect(status.requests.every((request) => request.method === 'GET')).toBe(
+		true,
+	)
+	expect(lines.join('\n')).toContain('POST')
+})
+
 test('parseArgs reads command, zone, target, dry-run, and json', () => {
 	expect(parseArgs(['status'])).toEqual({
 		command: 'status',

--- a/tools/maintenance-mode.node.test.ts
+++ b/tools/maintenance-mode.node.test.ts
@@ -268,6 +268,58 @@ test('on enables an existing disabled maintenance rule', async () => {
 	})
 })
 
+test('on patches an enabled rule when the target differs', async () => {
+	const staleTarget = 'https://status.kody.codes/old-maintenance'
+	const { fetchImpl, calls } = mockFetch((url, init) => {
+		if (url.includes('/zones?name=')) return zoneLookup()
+		if (url.includes('/entrypoint')) {
+			return envelope({
+				id: rulesetId,
+				name: 'Redirect rules ruleset',
+				kind: 'zone',
+				phase: 'http_request_dynamic_redirect',
+				rules: [
+					{
+						...redirectRule(true),
+						action_parameters: {
+							from_value: {
+								target_url: { value: staleTarget },
+								status_code: 302,
+								preserve_query_string: false,
+							},
+						},
+					},
+				],
+			})
+		}
+		if ((init?.method ?? 'GET') === 'PATCH' && url.endsWith(`/${ruleId}`)) {
+			return envelope({
+				id: rulesetId,
+				rules: [redirectRule(true)],
+			})
+		}
+		throw new Error(`Unexpected ${init?.method ?? 'GET'} ${url}`)
+	})
+
+	const result = await runMaintenanceMode(parseArgs(['on']), {
+		env: { CLOUDFLARE_API_TOKEN: 'token' },
+		fetch: fetchImpl,
+		log: () => {},
+	})
+
+	expect(result.target).toBe(defaultMaintenanceTarget)
+	expect(calls.at(-1)).toMatchObject({
+		method: 'PATCH',
+		url: `${cloudflareApiBaseUrl}/zones/${zoneId}/rulesets/${rulesetId}/rules/${ruleId}`,
+		body: {
+			enabled: true,
+			action_parameters: {
+				from_value: { target_url: { value: defaultMaintenanceTarget } },
+			},
+		},
+	})
+})
+
 test('off disables the existing rule and does not delete it', async () => {
 	const { fetchImpl, calls } = mockFetch((url, init) => {
 		if (url.includes('/zones?name=')) return zoneLookup()

--- a/tools/maintenance-mode.ts
+++ b/tools/maintenance-mode.ts
@@ -1,0 +1,524 @@
+import { isExecutedDirectly } from './node-runtime.ts'
+
+export const defaultMaintenanceZone = 'kody.codes'
+export const defaultMaintenanceTarget = 'https://status.kody.codes/maintenance'
+export const maintenanceRuleMarker = 'kody-maintenance-mode'
+const dynamicRedirectPhase = 'http_request_dynamic_redirect'
+export const cloudflareApiBaseUrl = 'https://api.cloudflare.com/client/v4'
+export const requiredTokenScopesMessage =
+	'This token needs Zone:Read and Zone "Single Redirect" / Dynamic Redirect: Edit on the target zone.'
+
+type MaintenanceModeCommand = 'on' | 'off' | 'status'
+
+type MaintenanceModeOptions = {
+	command: MaintenanceModeCommand
+	zone: string
+	target: string
+	dryRun: boolean
+	json: boolean
+}
+
+type PlannedApiRequest = {
+	method: 'GET' | 'POST' | 'PATCH'
+	url: string
+	body?: unknown
+}
+
+type MaintenanceModeResult = {
+	command: MaintenanceModeCommand
+	zone: string
+	target: string
+	exists: boolean
+	enabled: boolean
+	dryRun: boolean
+	requests: Array<PlannedApiRequest>
+	rulesetId?: string
+	ruleId?: string
+}
+
+type MaintenanceModeDeps = {
+	env?: NodeJS.ProcessEnv
+	fetch?: typeof fetch
+	log?: (line: string) => void
+}
+
+type CloudflareApiEnvelope<T> = {
+	success?: boolean
+	result?: T
+	errors?: Array<{ code?: number | string; message?: string }>
+}
+
+type CloudflareZone = {
+	id: string
+	name: string
+}
+
+type CloudflareRedirectRule = {
+	id?: string
+	ref?: string
+	description?: string
+	enabled?: boolean
+	expression?: string
+	action?: string
+	action_parameters?: {
+		from_value?: {
+			target_url?: { value?: string; expression?: string }
+			status_code?: number
+			preserve_query_string?: boolean
+		}
+	}
+}
+
+type CloudflareRuleset = {
+	id: string
+	name?: string
+	kind?: string
+	phase?: string
+	rules?: Array<CloudflareRedirectRule>
+}
+
+function readFlagValue(
+	argv: ReadonlyArray<string>,
+	index: number,
+	flag: string,
+) {
+	const value = argv[index + 1]
+	if (!value || value.startsWith('--')) {
+		throw new Error(`Missing value for ${flag}.`)
+	}
+	return value
+}
+
+function isMaintenanceModeCommand(
+	value: string,
+): value is MaintenanceModeCommand {
+	return value === 'on' || value === 'off' || value === 'status'
+}
+
+export function parseArgs(argv: ReadonlyArray<string>): MaintenanceModeOptions {
+	let command: MaintenanceModeCommand | null = null
+	let zone = defaultMaintenanceZone
+	let target = defaultMaintenanceTarget
+	let dryRun = false
+	let json = false
+
+	for (let index = 0; index < argv.length; index += 1) {
+		const argument = argv[index]
+		if (!argument) continue
+		if (argument === '--dry-run') {
+			dryRun = true
+			continue
+		}
+		if (argument === '--json') {
+			json = true
+			continue
+		}
+		if (argument === '--zone') {
+			zone = readFlagValue(argv, index, '--zone')
+			index += 1
+			continue
+		}
+		if (argument === '--target') {
+			target = readFlagValue(argv, index, '--target')
+			index += 1
+			continue
+		}
+		if (argument.startsWith('--')) {
+			throw new Error(`Unknown flag: ${argument}`)
+		}
+		if (command !== null) {
+			throw new Error(`Unexpected argument: ${argument}`)
+		}
+		if (!isMaintenanceModeCommand(argument)) {
+			throw new Error(`Unknown command: ${argument}. Use on, off, or status.`)
+		}
+		command = argument
+	}
+
+	if (command === null) {
+		throw new Error(
+			'Usage: maintenance-mode <on|off|status> [--zone] [--target] [--dry-run] [--json]',
+		)
+	}
+
+	return { command, zone, target, dryRun, json }
+}
+
+export function buildMaintenanceExpression(zone: string) {
+	return `(http.host eq "${zone}" and not starts_with(http.request.uri.path, "/__maintenance/") and http.request.uri.path ne "/health")`
+}
+
+export function buildMaintenanceRedirectRule(input: {
+	zone: string
+	target: string
+	enabled: boolean
+}) {
+	return {
+		ref: maintenanceRuleMarker,
+		description: maintenanceRuleMarker,
+		expression: buildMaintenanceExpression(input.zone),
+		action: 'redirect',
+		enabled: input.enabled,
+		action_parameters: {
+			from_value: {
+				target_url: { value: input.target },
+				status_code: 302,
+				preserve_query_string: false,
+			},
+		},
+	}
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+function findMaintenanceRule(
+	ruleset: CloudflareRuleset | null,
+): CloudflareRedirectRule | null {
+	if (!ruleset?.rules) return null
+	return (
+		ruleset.rules.find(
+			(rule) =>
+				rule.description?.includes(maintenanceRuleMarker) ||
+				rule.ref === maintenanceRuleMarker,
+		) ?? null
+	)
+}
+
+function ruleEnabled(rule: CloudflareRedirectRule | null) {
+	return rule?.enabled === true
+}
+
+function ruleTarget(rule: CloudflareRedirectRule | null, fallback: string) {
+	return rule?.action_parameters?.from_value?.target_url?.value ?? fallback
+}
+
+function formatAuthFailure(status: number) {
+	return `Cloudflare API request failed (${status}). ${requiredTokenScopesMessage}`
+}
+
+async function cloudflareRequest<T>(input: {
+	apiToken: string
+	method: 'GET' | 'POST' | 'PATCH'
+	pathname: string
+	body?: unknown
+	fetch: typeof fetch
+	allowNotFound?: boolean
+}): Promise<{ status: number; result: T | null }> {
+	const url = `${cloudflareApiBaseUrl}${input.pathname}`
+	const response = await input.fetch(url, {
+		method: input.method,
+		headers: {
+			Authorization: `Bearer ${input.apiToken}`,
+			Accept: 'application/json',
+			...(input.body ? { 'Content-Type': 'application/json' } : {}),
+		},
+		...(input.body ? { body: JSON.stringify(input.body) } : {}),
+	})
+	const text = await response.text()
+	if (response.status === 401 || response.status === 403) {
+		throw new Error(formatAuthFailure(response.status))
+	}
+	if (input.allowNotFound && response.status === 404) {
+		return { status: 404, result: null }
+	}
+	let parsed: unknown
+	try {
+		parsed = JSON.parse(text)
+	} catch {
+		throw new Error(
+			`Malformed Cloudflare response (${response.status}) for ${input.pathname}: ${text.trim().slice(0, 200) || '(empty body)'}`,
+		)
+	}
+	if (!isRecord(parsed)) {
+		throw new Error(
+			`Malformed Cloudflare response (${response.status}) for ${input.pathname}`,
+		)
+	}
+	const payload = parsed as CloudflareApiEnvelope<T>
+	if (
+		!response.ok ||
+		payload.success !== true ||
+		payload.result === undefined
+	) {
+		const error = payload.errors?.[0]
+		throw new Error(
+			`Cloudflare API request failed (${response.status}): ${error?.message ?? error?.code ?? input.pathname}`,
+		)
+	}
+	return { status: response.status, result: payload.result }
+}
+
+function zoneLookupPath(zone: string) {
+	return `/zones?name=${encodeURIComponent(zone)}&status=active`
+}
+
+function entrypointPath(zoneId: string) {
+	return `/zones/${encodeURIComponent(zoneId)}/rulesets/phases/${dynamicRedirectPhase}/entrypoint`
+}
+
+function rulesetsPath(zoneId: string) {
+	return `/zones/${encodeURIComponent(zoneId)}/rulesets`
+}
+
+function rulesetRulesPath(zoneId: string, rulesetId: string) {
+	return `/zones/${encodeURIComponent(zoneId)}/rulesets/${encodeURIComponent(rulesetId)}/rules`
+}
+
+function rulePath(zoneId: string, rulesetId: string, ruleId: string) {
+	return `${rulesetRulesPath(zoneId, rulesetId)}/${encodeURIComponent(ruleId)}`
+}
+
+function plannedUrl(pathname: string) {
+	return `${cloudflareApiBaseUrl}${pathname}`
+}
+
+function firstRunCreateRequests(options: MaintenanceModeOptions) {
+	const zonePlaceholder = '{zone_id}'
+	const rule = buildMaintenanceRedirectRule({
+		zone: options.zone,
+		target: options.target,
+		enabled: true,
+	})
+	return [
+		{
+			method: 'GET' as const,
+			url: plannedUrl(zoneLookupPath(options.zone)),
+		},
+		{
+			method: 'GET' as const,
+			url: plannedUrl(entrypointPath(zonePlaceholder)),
+		},
+		{
+			method: 'POST' as const,
+			url: plannedUrl(rulesetsPath(zonePlaceholder)),
+			body: {
+				name: 'Redirect rules ruleset',
+				kind: 'zone',
+				phase: dynamicRedirectPhase,
+				rules: [rule],
+			},
+		},
+	]
+}
+
+function printHumanResult(
+	result: MaintenanceModeResult,
+	log: (line: string) => void,
+) {
+	const state = result.enabled
+		? 'enabled'
+		: result.exists
+			? 'disabled'
+			: 'absent'
+	log(
+		`Maintenance mode: ${result.enabled ? 'on' : 'off'} (${state} on ${result.zone})`,
+	)
+	log(`Target: ${result.target}`)
+	if (result.dryRun) {
+		log('Dry-run: no Cloudflare writes were sent. Planned API calls:')
+		for (const request of result.requests) {
+			log(`${request.method} ${request.url}`)
+			if (request.body !== undefined) {
+				log(JSON.stringify(request.body, null, 2))
+			}
+		}
+	}
+}
+
+export async function runMaintenanceMode(
+	options: MaintenanceModeOptions,
+	deps: MaintenanceModeDeps = {},
+): Promise<MaintenanceModeResult> {
+	const env = deps.env ?? process.env
+	const fetchImpl = deps.fetch ?? fetch
+	const log = deps.log ?? console.log
+	const apiToken = env.CLOUDFLARE_API_TOKEN?.trim() ?? ''
+
+	if (!apiToken) {
+		if (!options.dryRun) {
+			throw new Error(
+				`CLOUDFLARE_API_TOKEN is required. ${requiredTokenScopesMessage}`,
+			)
+		}
+		const requests = firstRunCreateRequests(options)
+		const result: MaintenanceModeResult = {
+			command: options.command,
+			zone: options.zone,
+			target: options.target,
+			exists: false,
+			enabled: false,
+			dryRun: true,
+			requests,
+		}
+		if (options.json) log(JSON.stringify(result, null, 2))
+		else printHumanResult(result, log)
+		return result
+	}
+
+	const requests: Array<PlannedApiRequest> = []
+	const zoneLookup: PlannedApiRequest = {
+		method: 'GET',
+		url: plannedUrl(zoneLookupPath(options.zone)),
+	}
+	requests.push(zoneLookup)
+	const zones = await cloudflareRequest<Array<CloudflareZone>>({
+		apiToken,
+		method: 'GET',
+		pathname: zoneLookupPath(options.zone),
+		fetch: fetchImpl,
+	})
+	const zone = (zones.result ?? []).find((entry) => entry.name === options.zone)
+	if (!zone) {
+		throw new Error(`Cloudflare zone not found: ${options.zone}`)
+	}
+
+	const entrypointLookup: PlannedApiRequest = {
+		method: 'GET',
+		url: plannedUrl(entrypointPath(zone.id)),
+	}
+	requests.push(entrypointLookup)
+	const entrypointResponse = await cloudflareRequest<CloudflareRuleset>({
+		apiToken,
+		method: 'GET',
+		pathname: entrypointPath(zone.id),
+		fetch: fetchImpl,
+		allowNotFound: true,
+	})
+	const entrypoint = entrypointResponse.result
+	const existingRule = findMaintenanceRule(entrypoint)
+	const exists = existingRule !== null
+	const enabled = ruleEnabled(existingRule)
+	const currentTarget = ruleTarget(existingRule, options.target)
+
+	async function applyWrite(request: PlannedApiRequest) {
+		requests.push(request)
+		if (options.dryRun) return
+		const pathname = request.url.startsWith(cloudflareApiBaseUrl)
+			? request.url.slice(cloudflareApiBaseUrl.length)
+			: new URL(request.url).pathname
+		await cloudflareRequest({
+			apiToken,
+			method: request.method,
+			pathname,
+			body: request.body,
+			fetch: fetchImpl,
+		})
+	}
+
+	switch (options.command) {
+		case 'status': {
+			const result: MaintenanceModeResult = {
+				command: 'status',
+				zone: options.zone,
+				target: currentTarget,
+				exists,
+				enabled,
+				dryRun: options.dryRun,
+				requests,
+				rulesetId: entrypoint?.id,
+				ruleId: existingRule?.id,
+			}
+			if (options.json) log(JSON.stringify(result, null, 2))
+			else printHumanResult(result, log)
+			return result
+		}
+		case 'on': {
+			const rule = buildMaintenanceRedirectRule({
+				zone: options.zone,
+				target: options.target,
+				enabled: true,
+			})
+			if (!entrypoint) {
+				await applyWrite({
+					method: 'POST',
+					url: plannedUrl(rulesetsPath(zone.id)),
+					body: {
+						name: 'Redirect rules ruleset',
+						kind: 'zone',
+						phase: dynamicRedirectPhase,
+						rules: [rule],
+					},
+				})
+			} else if (!existingRule) {
+				await applyWrite({
+					method: 'POST',
+					url: plannedUrl(rulesetRulesPath(zone.id, entrypoint.id)),
+					body: rule,
+				})
+			} else if (!enabled) {
+				if (!existingRule.id) {
+					throw new Error(
+						'Maintenance redirect rule is missing an id; cannot enable it.',
+					)
+				}
+				await applyWrite({
+					method: 'PATCH',
+					url: plannedUrl(rulePath(zone.id, entrypoint.id, existingRule.id)),
+					body: { ...rule, enabled: true },
+				})
+			}
+			const result: MaintenanceModeResult = {
+				command: 'on',
+				zone: options.zone,
+				target: options.target,
+				exists: true,
+				enabled: true,
+				dryRun: options.dryRun,
+				requests,
+				rulesetId: entrypoint?.id,
+				ruleId: existingRule?.id,
+			}
+			if (options.json) log(JSON.stringify(result, null, 2))
+			else printHumanResult(result, log)
+			return result
+		}
+		case 'off': {
+			if (existingRule?.id && enabled && entrypoint) {
+				await applyWrite({
+					method: 'PATCH',
+					url: plannedUrl(rulePath(zone.id, entrypoint.id, existingRule.id)),
+					body: {
+						...buildMaintenanceRedirectRule({
+							zone: options.zone,
+							target: currentTarget,
+							enabled: false,
+						}),
+						enabled: false,
+					},
+				})
+			}
+			const result: MaintenanceModeResult = {
+				command: 'off',
+				zone: options.zone,
+				target: currentTarget,
+				exists,
+				enabled: false,
+				dryRun: options.dryRun,
+				requests,
+				rulesetId: entrypoint?.id,
+				ruleId: existingRule?.id,
+			}
+			if (options.json) log(JSON.stringify(result, null, 2))
+			else printHumanResult(result, log)
+			return result
+		}
+		default: {
+			const unexpected: never = options.command
+			throw new Error(`Unexpected command: ${String(unexpected)}`)
+		}
+	}
+}
+
+async function main(argv: ReadonlyArray<string> = process.argv.slice(2)) {
+	await runMaintenanceMode(parseArgs(argv))
+}
+
+if (isExecutedDirectly(import.meta.url)) {
+	void main().catch((error: unknown) => {
+		const message = error instanceof Error ? error.message : String(error)
+		console.error(message)
+		process.exitCode = 1
+	})
+}

--- a/tools/maintenance-mode.ts
+++ b/tools/maintenance-mode.ts
@@ -250,57 +250,90 @@ async function cloudflareRequest<T>(input: {
 	return { status: response.status, result: payload.result }
 }
 
+function pathSegment(value: string) {
+	return /^[\w{}-]+$/.test(value) ? value : encodeURIComponent(value)
+}
+
 function zoneLookupPath(zone: string) {
 	return `/zones?name=${encodeURIComponent(zone)}&status=active`
 }
 
 function entrypointPath(zoneId: string) {
-	return `/zones/${encodeURIComponent(zoneId)}/rulesets/phases/${dynamicRedirectPhase}/entrypoint`
+	return `/zones/${pathSegment(zoneId)}/rulesets/phases/${dynamicRedirectPhase}/entrypoint`
 }
 
 function rulesetsPath(zoneId: string) {
-	return `/zones/${encodeURIComponent(zoneId)}/rulesets`
+	return `/zones/${pathSegment(zoneId)}/rulesets`
 }
 
 function rulesetRulesPath(zoneId: string, rulesetId: string) {
-	return `/zones/${encodeURIComponent(zoneId)}/rulesets/${encodeURIComponent(rulesetId)}/rules`
+	return `/zones/${pathSegment(zoneId)}/rulesets/${pathSegment(rulesetId)}/rules`
 }
 
 function rulePath(zoneId: string, rulesetId: string, ruleId: string) {
-	return `${rulesetRulesPath(zoneId, rulesetId)}/${encodeURIComponent(ruleId)}`
+	return `${rulesetRulesPath(zoneId, rulesetId)}/${pathSegment(ruleId)}`
 }
 
 function plannedUrl(pathname: string) {
 	return `${cloudflareApiBaseUrl}${pathname}`
 }
 
-function firstRunCreateRequests(options: MaintenanceModeOptions) {
-	const zonePlaceholder = '{zone_id}'
-	const rule = buildMaintenanceRedirectRule({
-		zone: options.zone,
-		target: options.target,
-		enabled: true,
-	})
+function dryRunLookupRequests(zone: string) {
 	return [
 		{
 			method: 'GET' as const,
-			url: plannedUrl(zoneLookupPath(options.zone)),
+			url: plannedUrl(zoneLookupPath(zone)),
 		},
 		{
 			method: 'GET' as const,
-			url: plannedUrl(entrypointPath(zonePlaceholder)),
-		},
-		{
-			method: 'POST' as const,
-			url: plannedUrl(rulesetsPath(zonePlaceholder)),
-			body: {
-				name: 'Redirect rules ruleset',
-				kind: 'zone',
-				phase: dynamicRedirectPhase,
-				rules: [rule],
-			},
+			url: plannedUrl(entrypointPath('{zone_id}')),
 		},
 	]
+}
+
+function unauthenticatedDryRunRequests(options: MaintenanceModeOptions) {
+	const lookups = dryRunLookupRequests(options.zone)
+	switch (options.command) {
+		case 'status':
+			return lookups
+		case 'on':
+			return [
+				...lookups,
+				{
+					method: 'POST' as const,
+					url: plannedUrl(rulesetsPath('{zone_id}')),
+					body: {
+						name: 'Redirect rules ruleset',
+						kind: 'zone',
+						phase: dynamicRedirectPhase,
+						rules: [
+							buildMaintenanceRedirectRule({
+								zone: options.zone,
+								target: options.target,
+								enabled: true,
+							}),
+						],
+					},
+				},
+			]
+		case 'off':
+			return [
+				...lookups,
+				{
+					method: 'PATCH' as const,
+					url: plannedUrl(rulePath('{zone_id}', '{ruleset_id}', '{rule_id}')),
+					body: buildMaintenanceRedirectRule({
+						zone: options.zone,
+						target: options.target,
+						enabled: false,
+					}),
+				},
+			]
+		default: {
+			const unexpected: never = options.command
+			throw new Error(`Unexpected command: ${String(unexpected)}`)
+		}
+	}
 }
 
 function printHumanResult(
@@ -342,7 +375,7 @@ export async function runMaintenanceMode(
 				`CLOUDFLARE_API_TOKEN is required. ${requiredTokenScopesMessage}`,
 			)
 		}
-		const requests = firstRunCreateRequests(options)
+		const requests = unauthenticatedDryRunRequests(options)
 		const result: MaintenanceModeResult = {
 			command: options.command,
 			zone: options.zone,

--- a/tools/maintenance-mode.ts
+++ b/tools/maintenance-mode.ts
@@ -194,6 +194,25 @@ function ruleTarget(rule: CloudflareRedirectRule | null, fallback: string) {
 	return rule?.action_parameters?.from_value?.target_url?.value ?? fallback
 }
 
+function ruleNeedsUpdate(
+	existing: CloudflareRedirectRule,
+	desired: ReturnType<typeof buildMaintenanceRedirectRule>,
+) {
+	const fromValue = existing.action_parameters?.from_value
+	return (
+		existing.expression !== desired.expression ||
+		fromValue?.target_url?.value !==
+			desired.action_parameters.from_value.target_url.value ||
+		fromValue?.status_code !==
+			desired.action_parameters.from_value.status_code ||
+		fromValue?.preserve_query_string !==
+			desired.action_parameters.from_value.preserve_query_string ||
+		existing.action !== desired.action ||
+		existing.ref !== desired.ref ||
+		existing.description !== desired.description
+	)
+}
+
 function formatAuthFailure(status: number) {
 	return `Cloudflare API request failed (${status}). ${requiredTokenScopesMessage}`
 }
@@ -480,10 +499,10 @@ export async function runMaintenanceMode(
 					url: plannedUrl(rulesetRulesPath(zone.id, entrypoint.id)),
 					body: rule,
 				})
-			} else if (!enabled) {
+			} else if (!enabled || ruleNeedsUpdate(existingRule, rule)) {
 				if (!existingRule.id) {
 					throw new Error(
-						'Maintenance redirect rule is missing an id; cannot enable it.',
+						'Maintenance redirect rule is missing an id; cannot update it.',
 					)
 				}
 				await applyWrite({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Give the DR runbook a real "disable ingress" switch: a Cloudflare edge Single Redirect plus a static status-worker page, with no request-time check in the origin worker.

## Why

`docs/contributing/disaster-recovery.md` told operators to put the app in maintenance before restore, but no mechanism existed. `/__maintenance/*` is a secret-gated operator API, not a public maintenance mode. The switch has to work when the origin worker or D1 is the thing that is broken, flip without a deploy, and add zero cost to the request hot path.

## Summary

- `npm run maintenance-mode -- <on|off|status>` (`tools/maintenance-mode.ts`) creates or enables/disables a zone Single Redirect (`http_request_dynamic_redirect`) identified by `kody-maintenance-mode`. `off` disables the rule and does not delete it.
- Expression: apex `kody.codes`, excluding `/__maintenance/*` and exact `/health`. 302 to `https://status.kody.codes/maintenance` with `preserve_query_string` false.
- `POST /webhooks/stripe` is redirected on purpose: Stripe retries 3xx/5xx, so that is acceptable for the restore window.
- Status worker serves `GET /maintenance` as static HTML (200, `Cache-Control: no-store`). No origin D1 or `kody.codes` dependency.
- DR runbook now has a concrete [Maintenance mode (edge)](docs/contributing/disaster-recovery.md#maintenance-mode-edge) procedure, including token scopes and confirmation curls. Links [operator-accounts.md](docs/contributing/operator-accounts.md) (sibling track).

The CLI does **not** `PUT` the whole phase entrypoint, so other Single Redirects on the zone stay put. `on` also PATCHes an already-enabled rule when the target or expression drifted.

## Testing

- Mocked node tests: create ruleset, add rule to existing ruleset, enable existing rule, reconcile drifted target, disable without delete, status, 403 scope message, tokenless dry-run shapes.
- Status worker node tests: `GET /maintenance` is 200/`no-store` and does not touch `STATUS_STORE`; `GET /health` still 200.
- `npm run validate` green locally (format, lint, typecheck, node/workers/e2e/mcp tests, knip, status-build, docs checkers).
- `npm run maintenance-mode -- on --dry-run` (no `CLOUDFLARE_API_TOKEN` in this VM) prints the first-run Rulesets calls: zone lookup, entrypoint GET, then POST the `http_request_dynamic_redirect` ruleset with a 302 to `https://status.kody.codes/maintenance`.
- **This VM cannot run live `on`/`off`.** No Cloudflare token with Zone:Read + Single Redirect / Dynamic Redirect: Edit is present, and CI must not be given one. First live flip is an operator follow-up.

## Live evidence this PR cannot produce

No token with the redirect scope exists in CI today. Do not widen any existing token. Operator follow-up: mint a token with Zone:Read + Zone "Single Redirect" / Dynamic Redirect: Edit, then `npm run maintenance-mode -- on --dry-run` against the live zone, then a short `on` / `status` / `off` with:

```sh
curl -I https://kody.codes/
curl --fail --header "Accept: application/json" https://kody.codes/health
```

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `22b7391d` · **Head:** `3ae6406a`

**Classification:** extends — `status-page` gains a public `GET /maintenance` route. The origin worker is untouched. Ingress control is a Cloudflare Single Redirect managed by a new operator CLI.

### Primitives touched

| Primitive     | Group    | Impact                                                                 |
| ------------- | -------- | ---------------------------------------------------------------------- |
| `status-page` | surfaces | extends — static `GET /maintenance` (200, `Cache-Control: no-store`) |

Unmatched paths: `tools/maintenance-mode.ts` (operator CLI), `docs/contributing/disaster-recovery.md`.

### Change flow

An operator flips a zone-level Single Redirect. Apex visitors (except `/health` and `/__maintenance/*`) 302 to the status worker maintenance page.

```mermaid
sequenceDiagram
	actor Operator
	actor Visitor
	participant statusPage as status-page
	Operator->>Operator: npm run maintenance-mode -- on
	Note over Operator: Rulesets API writes kody-maintenance-mode Single Redirect
	Visitor->>statusPage: GET /maintenance after edge 302
	statusPage-->>Visitor: 200 static HTML, Cache-Control no-store
	Operator->>Operator: npm run maintenance-mode -- off
	Note over Operator: PATCH enabled false, rule is kept for status
```

### Before / after

| Surface                         | Before                                      | After                                                                 |
| ------------------------------- | ------------------------------------------- | --------------------------------------------------------------------- |
| DR "disable ingress"            | Sentence with no mechanism                  | `npm run maintenance-mode -- on\|off\|status`                         |
| `GET https://status.kody.codes/maintenance` | 404                                | 200 static maintenance HTML                                           |
| Origin request hot path         | unchanged                                   | unchanged (no worker flag)                                            |

</details>

<!-- system-recap:end -->

## Conductor report

- **STATUS:** in-progress (local validate green, waiting on GitHub CI + Bugbot after target-reconcile fix)
- **PR:** https://github.com/kentcdodds/kody/pull/2143 (ready)
- **Evidence:** `npm run validate` exit 0; mocked CLI + status worker tests; tokenless `--dry-run` prints Rulesets GET/POST/PATCH shapes. Live `on`/`off` not run (no Cloudflare redirect-scope token in this VM). Production `https://status.kody.codes/maintenance` check waits on merge+deploy.
- **Operator follow-up:** mint a token with Zone:Read + Single Redirect / Dynamic Redirect: Edit (do not widen CI tokens). First live dry-run then on/off/status against `kody.codes`.
- **Remains:** GitHub CI, Bugbot, ship-pr. Merge is blocked if `kody:@kentcdodds/github` fails with missing `github-botAccessToken` (conductor merges).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6bf9d008-0054-430b-bae1-48a6c5a8e224?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6bf9d008-0054-430b-bae1-48a6c5a8e224&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a standalone maintenance page with service-status messaging and a link to status updates.
  * Added maintenance mode controls to enable, disable, check status, and preview changes.
  * Added health and maintenance endpoints that remain available during maintenance.
  * Maintenance mode now reconciles existing redirect settings when they differ from the intended configuration.

* **Documentation**
  * Updated disaster-recovery procedures with maintenance-mode operations and restoration guidance.
  * Added maintenance-mode instructions to the offline command reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->