### PR TITLE
Size Step 3 Connected logos to the surrounding text

### DIFF
--- a/packages/worker/client/routes/onboarding-mcp-client-tabs.tsx
+++ b/packages/worker/client/routes/onboarding-mcp-client-tabs.tsx
@@ -56,16 +56,20 @@ type OnboardingMcpClientTabsProps = {
 	greyedReason?: string | null
 }
 
-function AgentMarkIcon(handle: Handle<{ icon: string | null }>) {
+function AgentMarkIcon(
+	handle: Handle<{ icon: string | null; size?: 'picker' | 'inline' }>,
+) {
 	return () => {
+		const inline = handle.props.size === 'inline'
 		if (!handle.props.icon) {
 			return (
 				<svg
 					viewBox="0 0 24 24"
-					width="22"
-					height="22"
+					width={inline ? undefined : 22}
+					height={inline ? undefined : 22}
 					fill="currentColor"
 					aria-hidden="true"
+					mix={inline ? css(pickerIconImgInlineCss) : undefined}
 				>
 					<circle cx="6" cy="12" r="1.6" />
 					<circle cx="12" cy="12" r="1.6" />
@@ -77,9 +81,9 @@ function AgentMarkIcon(handle: Handle<{ icon: string | null }>) {
 			<img
 				src={`/images/icons/${handle.props.icon}.svg`}
 				alt=""
-				width={28}
-				height={28}
-				mix={css(pickerIconImgCss)}
+				width={inline ? undefined : 28}
+				height={inline ? undefined : 28}
+				mix={css(inline ? pickerIconImgInlineCss : pickerIconImgCss)}
 			/>
 		)
 	}
@@ -101,16 +105,17 @@ export function AgentPickerMark(
 				mix={css(size === 'inline' ? pickerMarkInlineCss : pickerMarkCss)}
 				aria-hidden="true"
 				data-testid={handle.props.testId}
+				data-mark-size={size}
 			>
 				{desktopIcon === mobileIcon ? (
-					<AgentMarkIcon icon={desktopIcon} />
+					<AgentMarkIcon icon={desktopIcon} size={size} />
 				) : (
 					<>
 						<span mix={css(onboardingViewportCss('desktop-only', 'grid'))}>
-							<AgentMarkIcon icon={desktopIcon} />
+							<AgentMarkIcon icon={desktopIcon} size={size} />
 						</span>
 						<span mix={css(onboardingViewportCss('mobile-only', 'grid'))}>
-							<AgentMarkIcon icon={mobileIcon} />
+							<AgentMarkIcon icon={mobileIcon} size={size} />
 						</span>
 					</>
 				)}
@@ -602,18 +607,25 @@ const pickerMarkInlineCss = {
 	flex: 'none',
 	width: '1em',
 	height: '1em',
+	overflow: 'hidden',
 	verticalAlign: '-0.125em',
 	color: colors.text,
-	'& img, & svg': {
-		width: '1em',
-		height: '1em',
-	},
 }
 
 const pickerIconImgCss = {
 	display: 'block',
 	width: '1.75rem',
 	height: '1.75rem',
+	objectFit: 'contain' as const,
+	'@media (prefers-color-scheme: dark)': {
+		filter: 'invert(1)',
+	},
+}
+
+const pickerIconImgInlineCss = {
+	display: 'block',
+	width: '1em',
+	height: '1em',
 	objectFit: 'contain' as const,
 	'@media (prefers-color-scheme: dark)': {
 		filter: 'invert(1)',

--- a/packages/worker/client/routes/onboarding-wizard-panels.node.test.ts
+++ b/packages/worker/client/routes/onboarding-wizard-panels.node.test.ts
@@ -245,6 +245,12 @@ test('step 3 greys the first-agent ecosystem and folds in a portability proof', 
 	expect(labeled).toContain('/images/icons/chatgpt.svg')
 	expect(labeled).toContain('/images/icons/cursor.svg')
 	expect(labeled).toContain('/images/icons/githubcopilot.svg')
+	const connectedLine = labeled.match(
+		/data-testid="onboarding-connected-agents"[\s\S]*?<\/p>/,
+	)?.[0]
+	expect(connectedLine).toContain('data-mark-size="inline"')
+	expect(connectedLine).not.toContain('width="28"')
+	expect(connectedLine).not.toContain('height="28"')
 	expect(labeled).toContain('data-greyed-reason="same-ecosystem"')
 	expect(labeled).toContain('data-greyed-reason="connected"')
 	expect(labeled).toContain('data-testid="onboarding-agent-gemini"')


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Make the Step 3 Connected-line agent logos match the surrounding text size, instead of overflowing the 1em box and covering the first letters of each name.

## Why

#2138 added logos on the Connected line and reserved a `1em` mark box, but `AgentMarkIcon` still painted the picker image at `28px` / `1.75rem`. The wrapper reserved text-sized space; the image spilled onto the label.

## Summary

- `AgentMarkIcon` now takes `size?: 'picker' | 'inline'`
- Inline marks drop the `width={28}` attributes and use `1em \u00d7 1em` image CSS
- The inline mark wrapper clips overflow
- The existing picker cards stay at `28px`
- The Step 3 render test asserts the Connected-line HTML has `data-mark-size="inline"` and no `width="28"` / `height="28"`

## Testing

- Pre-push: node-unit (2796) and workers-unit (341)
- CI: Validate, Node, Workers, Static, MCP, E2E, CLA green
- Bugbot: success
- Remix `renderToString` of the Step 3 panel: Connected-line images have no `width="28"`; CSS is `width/height: 1em`
- Playwright on that SSR HTML: Connected-line font-size `16px`; Copilot/Devin/Claude logos `16\u00d716` with `0` overflow

## System changes

`app-ui` only. Composes the existing inline mark size; no new primitives.

<!-- system-recap:start -->

<details>
<summary>System recap \u2014 <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap \u00b7 **Base:** `main` @ `16a53c07` \u00b7 **Head:** `9c97987e`

**Classification:** composes \u2014 `size="inline"` already existed on the Connected line; this PR makes the inner icon honor that size instead of leaking picker `28px` / `1.75rem` styles.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `app-ui` | surfaces | composes \u2014 inline Connected logos use `1em` image CSS |

### Change flow

Step 3 renders each connected host with an inline mark; the mark now sizes the image to the surrounding font.

```mermaid
sequenceDiagram
	actor User
	participant appUi as app-ui
	User->>appUi: open /onboarding/step-3
	appUi->>appUi: render Connected line with AgentPickerMark size inline
	Note over appUi: img uses 1em by 1em, no width 28
	appUi-->>User: logos sit beside labels at text size
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-68ee8fec-a4e6-47d2-97af-1980bcad8369?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-68ee8fec-a4e6-47d2-97af-1980bcad8369&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added inline sizing support for agent icons, allowing them to scale with surrounding text.
  * Agent markers now expose their selected display size for improved UI consistency.

* **Bug Fixes**
  * Updated connected-agent displays to use responsive inline icon dimensions instead of fixed sizing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->