### PR TITLE
docs: operator-accounts fill-ins are recorded in the password manager

### DIFF
--- a/docs/contributing/environment-variables.md
+++ b/docs/contributing/environment-variables.md
@@ -295,6 +295,16 @@ off-portal; the Stripe Billing Portal configuration
 $12/$120 and Pro $49/$480
 checkout prices.
 
+Dashboard-side dunning (not an environment variable, recorded here so it
+survives re-provisioning): the production Stripe account has every customer
+email under Settings → Billing → Subscriptions and emails → "Email notifications
+and customer management" enabled (trial-ending reminder, upcoming renewals,
+expiring cards, failed card payments, failed bank-debit payments), and "Manage
+failed payments" cancels the subscription when all retries fail. Kody also sends
+its own past-due and payment-failed emails (`billing/subscription-sync.ts`,
+`billing/stripe-webhooks.ts`), deduplicated so one failed charge is not two Kody
+emails; the Stripe email is additive and carries the card-update link.
+
 See [`architecture/entitlements.md`](./architecture/entitlements.md) (Billing).
 
 ## MCP OIDC ID token signing

--- a/docs/contributing/operator-accounts.md
+++ b/docs/contributing/operator-accounts.md
@@ -248,9 +248,14 @@ administration write, used to delete `preview-<pr>` GitHub Environments.
 `@kentcdodds/weekly-site-perf` webhook `run`. Copy of the Kody user secret
 `weeklySitePerfWebhookRun`. Not a Worker secret.
 
-Operator GitHub packages (`kody:@kentcdodds/github`) use a Kody user secret
-(guide default `githubAccessToken`; the official bot lane uses
-`github-botAccessToken`). That is account-secret storage, not an Actions secret.
+Operator GitHub packages (`kody:@kentcdodds/github`) authenticate through Kody
+OAuth integrations, not secrets: `github-bot` (kody-bot, the default) and
+`github-kent` (Kent's account, explicit request only) via
+`createAuthenticatedFetch`. Tokens live encrypted on the integration row
+(#2133); there is no password-manager item to keep. Recovery is
+`/connect/oauth?provider=github-bot` signed in as the kody-bot GitHub user. The
+guide-default `githubAccessToken` user secret in the how-Kody-works transcript
+is a tutorial example, not an operator credential.
 
 Rotation: replace the Actions secret, then re-run production deploy so Worker
 secrets sync. OAuth App client secrets: **Developer Settings → OAuth Apps →
@@ -262,7 +267,7 @@ Recovery: GitHub account login for `kentcdodds` plus org/repo admin. A second
 GitHub owner is not configured in-repo. Losing the user account without a
 recovery code blocks Actions secret edits and CLA recording.
 
-`Operator to fill: GitHub OAuth App display name; password-manager entry for PREVIEW_ENVIRONMENT_ADMIN_TOKEN and github-botAccessToken.`
+`Operator to fill: GitHub OAuth App display name; password-manager entry for PREVIEW_ENVIRONMENT_ADMIN_TOKEN and the kody-bot GitHub user login.`
 
 ## Stripe
 
@@ -539,5 +544,5 @@ pass. Names only; no values.
 7. `Operator to fill: Discord application name(s) for social login vs shipped-PR bot; guild name.`
 8. `Operator to fill: Google Cloud project / OAuth client name.`
 9. `Operator to fill: X project / app name.`
-10. `Operator to fill: GitHub OAuth App display name; PREVIEW_ENVIRONMENT_ADMIN_TOKEN and github-botAccessToken item names.`
+10. `Operator to fill: GitHub OAuth App display name; PREVIEW_ENVIRONMENT_ADMIN_TOKEN item name; kody-bot GitHub user login item name.`
 11. `Operator to fill: Cursor API key / cursorApiKey item name.`

--- a/docs/contributing/operator-accounts.md
+++ b/docs/contributing/operator-accounts.md
@@ -10,8 +10,10 @@ semantics live in [environment-variables.md](./environment-variables.md). Crypto
 key rotation lives in [secret-rotation.md](./secret-rotation.md). Production
 data recovery lives in [disaster-recovery.md](./disaster-recovery.md).
 
-Dashboard-only facts the repo cannot name are marked `Operator to fill:` and
-collected in [Operator fill-in list](#operator-fill-in-list).
+Dashboard-only facts the repo cannot name (registrar, account logins, vault item
+names, dashboard object ids) live in the operator password manager, never here.
+Lines marked `Password manager:` say what is recorded there; see
+[Password manager coverage](#password-manager-coverage).
 
 ## Cloudflare
 
@@ -39,7 +41,7 @@ Retired brand hosts (`heykody.app`, `heykody.dev`, `kodyapps.dev`,
 ([0044](./decisions/0044-retired-brand-domains-stay-retired.md)). They may still
 answer as Cloudflare-level redirects. Registrar ownership is not in the repo.
 
-`Operator to fill: registrar for kody.codes, kody.run, and the retired heykody.* / kodyapps.dev zones.`
+`Password manager: registrar for kody.codes, kody.run, and the retired heykody.* / kodyapps.dev zones.`
 
 ### Workers fleet
 
@@ -267,7 +269,7 @@ Recovery: GitHub account login for `kentcdodds` plus org/repo admin. A second
 GitHub owner is not configured in-repo. Losing the user account without a
 recovery code blocks Actions secret edits and CLA recording.
 
-`Operator to fill: GitHub OAuth App display name; password-manager entry for PREVIEW_ENVIRONMENT_ADMIN_TOKEN and the kody-bot GitHub user login.`
+`Password manager: GitHub OAuth App display name; password-manager entry for PREVIEW_ENVIRONMENT_ADMIN_TOKEN and the kody-bot GitHub user login.`
 
 ## Stripe
 
@@ -328,7 +330,7 @@ Recovery: Stripe account login. Customers and subscriptions live in Stripe;
 refreshed by webhooks and `StripePlanRefresh`. Losing `STRIPE_WEBHOOK_SECRET`
 returns 503 from `/webhooks/stripe` until it is replaced.
 
-`Operator to fill: Stripe webhook endpoint id; password-manager entry for STRIPE_SECRET_KEY / STRIPE_WEBHOOK_SECRET.`
+`Password manager: Stripe webhook endpoint id; password-manager entry for STRIPE_SECRET_KEY / STRIPE_WEBHOOK_SECRET.`
 
 ## Sentry
 
@@ -362,7 +364,7 @@ project DSN public key.
 Recovery: Sentry org owner login. A missing DSN disables reporting; the app
 stays up.
 
-`Operator to fill: Sentry org slug; alert-rule destination (email / Discord webhook); password-manager entry for SENTRY_AUTH_TOKEN.`
+`Password manager: Sentry org slug; alert-rule destination (email / Discord webhook); password-manager entry for SENTRY_AUTH_TOKEN.`
 
 ## Fathom
 
@@ -378,7 +380,7 @@ Dashboard: [app.usefathom.com](https://app.usefathom.com/). No secret.
 Recovery: Fathom account login. Losing the site id only drops analytics; the app
 stays up.
 
-`Operator to fill: Fathom account login / password-manager entry.`
+`Password manager: Fathom account login / password-manager entry.`
 
 ## Kit
 
@@ -407,7 +409,7 @@ Rotation: mint a new Kit API key, update `KIT_API_KEY`, deploy. Production
 Recovery: Kit account login (`hello@kentcdodds.com` is the documented sequence
 sender). Subscriber list lives in Kit, not D1.
 
-`Operator to fill: Kit account login / password-manager entry.`
+`Password manager: Kit account login / password-manager entry.`
 
 ## Discord
 
@@ -439,7 +441,7 @@ Recovery: Discord account that owns the application and the official guild.
 Login and billing still succeed when the bot secrets are unset; join/role writes
 and shipped-PR posts skip.
 
-`Operator to fill: Discord application name(s) for social login vs shipped-PR bot; guild name; password-manager entries.`
+`Password manager: Discord application name(s) for social login vs shipped-PR bot; guild name; password-manager entries.`
 
 ## Google
 
@@ -457,7 +459,7 @@ deploy.
 Recovery: Google account that owns the Cloud project. The GitHub login button
 still works if Google is unset.
 
-`Operator to fill: Google Cloud project name / OAuth client name; password-manager entry.`
+`Password manager: Google Cloud project name / OAuth client name; password-manager entry.`
 
 ## X
 
@@ -475,7 +477,7 @@ Rotation: regenerate the OAuth 2.0 client secret, update
 Recovery: X developer account that owns the project/app. X often omits email;
 those users connect from `/account` while already signed in.
 
-`Operator to fill: X project / app name; password-manager entry.`
+`Password manager: X project / app name; password-manager entry.`
 
 ## Cursor
 
@@ -496,7 +498,7 @@ the packages that read it. No Actions secret.
 Recovery: Cursor account login for Kent. Losing the key blocks agent spawn and
 ship-pr Discord cost lookup; production Kody stays up.
 
-`Operator to fill: password-manager entry for the Cursor API key / cursorApiKey.`
+`Password manager: entry for the Cursor API key / cursorApiKey.`
 
 ## MCP Registry
 
@@ -519,7 +521,7 @@ Recovery: registrar login plus Cloudflare zone access. A registrar lockout
 without Cloudflare nameserver control still leaves DNS editable in Cloudflare
 until the registration expires.
 
-`Operator to fill: registrar name and account login for each registrable domain (kody.codes, kody.run, kentcdodds.com, retired heykody.* / kodyapps.dev).`
+`Password manager: registrar name and account login for each registrable domain (kody.codes, kody.run, kentcdodds.com, retired heykody.* / kodyapps.dev).`
 
 ## Password manager and escrow
 
@@ -528,21 +530,21 @@ GitHub Actions secret. It unwraps `escrow/secret-store-key.v1.json` in the DR
 bucket ([secret-rotation.md escrow](./secret-rotation.md#escrow),
 [disaster-recovery.md](./disaster-recovery.md)).
 
-`Operator to fill: password-manager vault / item names for SECRET_ESCROW_PASSPHRASE, SECRET_STORE_KEY, COOKIE_SECRET, OIDC private key, Cloudflare tokens, and the other secrets listed above.`
+`Password manager: vault / item names for SECRET_ESCROW_PASSPHRASE, SECRET_STORE_KEY, COOKIE_SECRET, OIDC private key, Cloudflare tokens, and the other secrets listed above.`
 
-## Operator fill-in list
+## Password manager coverage
 
-Copy these into the password manager or this page after a 10-minute dashboard
-pass. Names only; no values.
+Each of these is recorded in the operator password manager. Names only; no
+values in this repo.
 
-1. `Operator to fill: registrar for kody.codes, kody.run, kentcdodds.com, and retired heykody.* / kodyapps.dev.`
-2. `Operator to fill: password-manager vault / item names for every secret in this inventory (including SECRET_ESCROW_PASSPHRASE).`
-3. `Operator to fill: Stripe webhook endpoint id.`
-4. `Operator to fill: Sentry org slug; alert-rule destination; SENTRY_AUTH_TOKEN item name.`
-5. `Operator to fill: Fathom account login item name.`
-6. `Operator to fill: Kit account login item name.`
-7. `Operator to fill: Discord application name(s) for social login vs shipped-PR bot; guild name.`
-8. `Operator to fill: Google Cloud project / OAuth client name.`
-9. `Operator to fill: X project / app name.`
-10. `Operator to fill: GitHub OAuth App display name; PREVIEW_ENVIRONMENT_ADMIN_TOKEN item name; kody-bot GitHub user login item name.`
-11. `Operator to fill: Cursor API key / cursorApiKey item name.`
+1. `Password manager: registrar for kody.codes, kody.run, kentcdodds.com, and retired heykody.* / kodyapps.dev.`
+2. `Password manager: vault / item names for every secret in this inventory (including SECRET_ESCROW_PASSPHRASE).`
+3. `Password manager: Stripe webhook endpoint id.`
+4. `Password manager: Sentry org slug; alert-rule destination; SENTRY_AUTH_TOKEN item name.`
+5. `Password manager: Fathom account login item name.`
+6. `Password manager: Kit account login item name.`
+7. `Password manager: Discord application name(s) for social login vs shipped-PR bot; guild name.`
+8. `Password manager: Google Cloud project / OAuth client name.`
+9. `Password manager: X project / app name.`
+10. `Password manager: GitHub OAuth App display name; PREVIEW_ENVIRONMENT_ADMIN_TOKEN item name; kody-bot GitHub user login item name.`
+11. `Password manager: Cursor API key / cursorApiKey item name.`

--- a/docs/contributing/operator-accounts.md
+++ b/docs/contributing/operator-accounts.md
@@ -269,7 +269,7 @@ Recovery: GitHub account login for `kentcdodds` plus org/repo admin. A second
 GitHub owner is not configured in-repo. Losing the user account without a
 recovery code blocks Actions secret edits and CLA recording.
 
-`Password manager: GitHub OAuth App display name; password-manager entry for PREVIEW_ENVIRONMENT_ADMIN_TOKEN and the kody-bot GitHub user login.`
+`Password manager: GitHub OAuth App display name; entry for PREVIEW_ENVIRONMENT_ADMIN_TOKEN and the kody-bot GitHub user login.`
 
 ## Stripe
 
@@ -330,7 +330,7 @@ Recovery: Stripe account login. Customers and subscriptions live in Stripe;
 refreshed by webhooks and `StripePlanRefresh`. Losing `STRIPE_WEBHOOK_SECRET`
 returns 503 from `/webhooks/stripe` until it is replaced.
 
-`Password manager: Stripe webhook endpoint id; password-manager entry for STRIPE_SECRET_KEY / STRIPE_WEBHOOK_SECRET.`
+`Password manager: Stripe webhook endpoint id; entry for STRIPE_SECRET_KEY / STRIPE_WEBHOOK_SECRET.`
 
 ## Sentry
 
@@ -364,7 +364,7 @@ project DSN public key.
 Recovery: Sentry org owner login. A missing DSN disables reporting; the app
 stays up.
 
-`Password manager: Sentry org slug; alert-rule destination (email / Discord webhook); password-manager entry for SENTRY_AUTH_TOKEN.`
+`Password manager: Sentry org slug; alert-rule destination (email / Discord webhook); entry for SENTRY_AUTH_TOKEN.`
 
 ## Fathom
 
@@ -380,7 +380,7 @@ Dashboard: [app.usefathom.com](https://app.usefathom.com/). No secret.
 Recovery: Fathom account login. Losing the site id only drops analytics; the app
 stays up.
 
-`Password manager: Fathom account login / password-manager entry.`
+`Password manager: Fathom account login entry.`
 
 ## Kit
 
@@ -409,7 +409,7 @@ Rotation: mint a new Kit API key, update `KIT_API_KEY`, deploy. Production
 Recovery: Kit account login (`hello@kentcdodds.com` is the documented sequence
 sender). Subscriber list lives in Kit, not D1.
 
-`Password manager: Kit account login / password-manager entry.`
+`Password manager: Kit account login entry.`
 
 ## Discord
 
@@ -441,7 +441,7 @@ Recovery: Discord account that owns the application and the official guild.
 Login and billing still succeed when the bot secrets are unset; join/role writes
 and shipped-PR posts skip.
 
-`Password manager: Discord application name(s) for social login vs shipped-PR bot; guild name; password-manager entries.`
+`Password manager: Discord application name(s) for social login vs shipped-PR bot; guild name.`
 
 ## Google
 
@@ -459,7 +459,7 @@ deploy.
 Recovery: Google account that owns the Cloud project. The GitHub login button
 still works if Google is unset.
 
-`Password manager: Google Cloud project name / OAuth client name; password-manager entry.`
+`Password manager: Google Cloud project name / OAuth client name.`
 
 ## X
 
@@ -477,7 +477,7 @@ Rotation: regenerate the OAuth 2.0 client secret, update
 Recovery: X developer account that owns the project/app. X often omits email;
 those users connect from `/account` while already signed in.
 
-`Password manager: X project / app name; password-manager entry.`
+`Password manager: X project / app name.`
 
 ## Cursor
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes the operator half of #1092 item 4.

Kent completed the dashboard pass from the operator-account inventory (#2141, #2144) and recorded the registrar, vault item names, Stripe webhook endpoint id, Sentry org, and the app/project display names in the password manager. The doc still asked for them 24 times (`Operator to fill:`). This replaces those asks with `Password manager:` pointers stating what is held there, and turns the "Operator fill-in list" into "Password manager coverage". Still names only, no values.

Docs-only. `format:check`, `docs:check-temporal`, and `slop-ratchet:check` pass locally.

## System recap

Risk: low. Documentation only.

```mermaid
flowchart LR
  A[Operator to fill: asks] -->|Kent completed dashboard pass| B[Password manager: pointers]
```

## Conductor report

Conductor follow-through after Kent confirmed the manual fill-in work was done; no track involved.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-49e62064-0c0f-4805-958b-eb169a46613d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-49e62064-0c0f-4805-958b-eb169a46613d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

