### PR TITLE
Align Step 3 Connected logos to the text baseline

### DIFF
--- a/packages/worker/client/routes/onboarding-mcp-client-tabs.tsx
+++ b/packages/worker/client/routes/onboarding-mcp-client-tabs.tsx
@@ -111,10 +111,24 @@ export function AgentPickerMark(
 					<AgentMarkIcon icon={desktopIcon} size={size} />
 				) : (
 					<>
-						<span mix={css(onboardingViewportCss('desktop-only', 'grid'))}>
+						<span
+							mix={css(
+								onboardingViewportCss(
+									'desktop-only',
+									size === 'inline' ? 'inline-block' : 'grid',
+								),
+							)}
+						>
 							<AgentMarkIcon icon={desktopIcon} size={size} />
 						</span>
-						<span mix={css(onboardingViewportCss('mobile-only', 'grid'))}>
+						<span
+							mix={css(
+								onboardingViewportCss(
+									'mobile-only',
+									size === 'inline' ? 'inline-block' : 'grid',
+								),
+							)}
+						>
 							<AgentMarkIcon icon={mobileIcon} size={size} />
 						</span>
 					</>
@@ -602,13 +616,12 @@ const pickerMarkCss = {
 }
 
 const pickerMarkInlineCss = {
-	display: 'inline-grid',
-	placeItems: 'center',
-	flex: 'none',
-	width: '1em',
-	height: '1em',
+	display: 'inline-block',
+	width: '1cap',
+	height: '1cap',
 	overflow: 'hidden',
-	verticalAlign: '-0.125em',
+	verticalAlign: 'baseline',
+	marginInlineEnd: '0.25em',
 	color: colors.text,
 }
 
@@ -624,8 +637,8 @@ const pickerIconImgCss = {
 
 const pickerIconImgInlineCss = {
 	display: 'block',
-	width: '1em',
-	height: '1em',
+	width: '1cap',
+	height: '1cap',
 	objectFit: 'contain' as const,
 	'@media (prefers-color-scheme: dark)': {
 		filter: 'invert(1)',

--- a/packages/worker/client/routes/onboarding-wizard-panels.node.test.ts
+++ b/packages/worker/client/routes/onboarding-wizard-panels.node.test.ts
@@ -251,6 +251,19 @@ test('step 3 greys the first-agent ecosystem and folds in a portability proof', 
 	expect(connectedLine).toContain('data-mark-size="inline"')
 	expect(connectedLine).not.toContain('width="28"')
 	expect(connectedLine).not.toContain('height="28"')
+	const markClass = connectedLine?.match(
+		/data-mark-size="inline" class="([^"]+)"/,
+	)?.[1]
+	expect(markClass).toBeTruthy()
+	const markCss = labeled.match(
+		new RegExp(`data-rmx-style="${markClass}"[\\s\\S]*?</style>`),
+	)?.[0]
+	expect(markCss).toContain('display: inline-block')
+	expect(markCss).toContain('width: 1cap')
+	expect(markCss).toContain('height: 1cap')
+	expect(markCss).toContain('vertical-align: baseline')
+	expect(markCss).not.toContain('inline-flex')
+	expect(markCss).not.toContain('inline-grid')
 	expect(labeled).toContain('data-greyed-reason="same-ecosystem"')
 	expect(labeled).toContain('data-greyed-reason="connected"')
 	expect(labeled).toContain('data-testid="onboarding-agent-gemini"')

--- a/packages/worker/client/routes/onboarding-wizard-panels.tsx
+++ b/packages/worker/client/routes/onboarding-wizard-panels.tsx
@@ -546,9 +546,6 @@ const connectedAgentsLineCss = {
 }
 
 const connectedAgentItemCss = {
-	display: 'inline-flex',
-	alignItems: 'center',
-	gap: '0.3em',
 	whiteSpace: 'nowrap' as const,
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Make the Step 3 Connected-line logos sit in the text like extra characters: same height as the capital letters, on the same baseline as the labels.

## Why

#2145 sized the logos to `1em`, but each name was an `inline-flex` row with `align-items: center`. That centered the mark against the 1.65 line box, so the logos floated above the baseline.

## Summary

- Connected names stay in normal inline flow (no flex centering)
- Inline marks are `inline-block`, `1cap` tall, `vertical-align: baseline`
- Desktop/mobile mark wrappers also stay `inline-block` when the mark is inline
- The render test asserts those CSS values on the Connected-line mark

## Testing

- Focused `onboarding-wizard-panels.node.test.ts`
- Pre-push node-unit and workers-unit
- Playwright on the Remix SSR HTML: icon height `1cap` (~11.4px vs 12px cap-height), `imgBottomVsBaseline` is `0`

## System changes

`app-ui` only. Composes existing inline marks.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `57aeb43f` · **Head:** `23e170a0`

**Classification:** composes — CSS alignment on the existing Connected-line marks. No new primitives.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `app-ui` | surfaces | composes — inline Connected logos use `1cap` and baseline alignment |

### Change flow

Step 3 still renders each connected host with an inline mark. The mark now participates in the text run instead of a flex row.

```mermaid
sequenceDiagram
	actor User
	participant appUi as app-ui
	User->>appUi: open /onboarding/step-3
	appUi->>appUi: render Connected names in inline flow
	Note over appUi: mark is 1cap, vertical-align baseline
	appUi-->>User: logos sit on the text baseline
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-68ee8fec-a4e6-47d2-97af-1980bcad8369?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-68ee8fec-a4e6-47d2-97af-1980bcad8369&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

