### PR TITLE
Prefer oldest stranded DR staging day in catch-up

### DIFF
--- a/docs/contributing/disaster-recovery.md
+++ b/docs/contributing/disaster-recovery.md
@@ -93,7 +93,7 @@ Nightly */5 ticks 00:30–06:10 UTC           02:15 UTC: D1 export Workflow
   / StorageRunner / R2 / artifacts      →    APP_DB and JOBS_DB)
   into staging/{day}/...                    Hourly: D1 freshness + catch-up
 Daytime */15 ticks: staging catch-up        Hourly: seal complete days
-  resume a stranded day (≤2 days back)      Admin UI: drill / production restore
+  resume oldest stranded day (≤2 days)      Admin UI: drill / production restore
 06:15 UTC: staging watchdog → Sentry
 ```
 
@@ -194,12 +194,13 @@ Contract: `packages/shared/src/backup-staging.ts`.
      00:30–06:10 window can hold ends with `exporter/progress.json` but no
      `exporter/summary.json` (a _stranded day_; first hit live on 2026-08-07).
      Outside the nightly window, one tick every 15 minutes scans today plus the
-     previous 2 days for progress-without-summary and resumes the most recent
+     previous 2 days for progress-without-summary and resumes the oldest
      stranded day under the normal ~20 s budget and progress lease until its
-     summary is written. Catch-up is resume-only: a day that never staged
-     progress is not started fresh (its dumps would contain current data, not
-     that day's). Data staged during catch-up is read at resume time; a slightly
-     newer dump is preferred over an unsealable day.
+     summary is written, so yesterday can finish and seal before today's
+     catch-up consumes the daytime budget. Catch-up is resume-only: a day that
+     never staged progress is not started fresh (its dumps would contain current
+     data, not that day's). Data staged during catch-up is read at resume time;
+     a slightly newer dump is preferred over an unsealable day.
    - **Resumable phase state** — `exporter/progress.json` contains phase
      cursors, counters, bounded index-entry tails, and conditional-write
      revision data. Mailbox, selected RunLog, and StorageRunner dump pages plus
@@ -664,7 +665,7 @@ the correctness spec and incident-only fallback:
 | When (UTC)                       | Who               | What                                                                                                                           |
 | -------------------------------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------------ |
 | `*/5` during 00:30–06:10         | Production worker | Stage Mailbox, selected RunLog state, and other non-D1 stores for the current UTC day (cheap no-op once complete)              |
-| Every 15 min outside 00:30–06:10 | Production worker | Staging catch-up: resume the most recent stranded day (progress without summary, today − ≤2 days); cheap no-op otherwise       |
+| Every 15 min outside 00:30–06:10 | Production worker | Staging catch-up: resume the oldest stranded day (progress without summary, today − ≤2 days); cheap no-op otherwise            |
 | 06:15                            | Production worker | Staging watchdog: a missing `exporter/summary.json` for today, or an earlier stranded day, fails the lane → Sentry             |
 | 02:15                            | Control plane     | Primary D1 export Workflow per configured database (APP_DB and JOBS_DB)                                                        |
 | 02:45–05:45 hourly               | Control plane     | Catch-up create/restart of same-day D1 Workflows                                                                               |
@@ -676,7 +677,9 @@ Failure mode: the nightly exporter hard-stops when the window closes, so a night
 with too much work leaves `staging/{day}/exporter/progress.json` without
 `exporter/summary.json`. The 06:15 watchdog pages; without a summary the day can
 never seal. Daytime catch-up ticks (table above) normally finish the day
-automatically within a few hours, and the hourly control-plane seal (3-day
+automatically within a few hours. When more than one day in the lookback is
+stranded, catch-up finishes the oldest first so yesterday can seal before
+today's ticks consume the daytime budget. The hourly control-plane seal (3-day
 lookback) then seals it — no operator action needed.
 
 Operate manually when catch-up is stuck, the day has already fallen outside the

--- a/packages/shared/src/jobs/scheduled-lanes.ts
+++ b/packages/shared/src/jobs/scheduled-lanes.ts
@@ -148,10 +148,11 @@ export function shouldRunDrExportCron(now: Date) {
 
 /**
  * Daytime catch-up cadence: outside the nightly window, one tick every 15
- * minutes resumes a stranded day until its summary is written. A single tick
- * still spends at most the normal ~20 s budget, so daytime blast radius is
- * bounded while a stranded night finishes within a few hours. Ticks with no
- * stranded day exit after two cheap HEAD-style checks per lookback day.
+ * minutes resumes the oldest stranded day in the lookback until its summary
+ * is written. A single tick still spends at most the normal ~20 s budget,
+ * so daytime blast radius is bounded while a stranded night finishes within
+ * a few hours. Ticks with no stranded day exit after two cheap HEAD-style
+ * checks per lookback day.
  */
 export function shouldRunDrExportCatchUpCron(now: Date) {
 	if (shouldRunDrExportCron(now)) return false

--- a/packages/worker/src/dr/exporter-schedule.ts
+++ b/packages/worker/src/dr/exporter-schedule.ts
@@ -22,10 +22,11 @@ export const drExportCatchUpLookbackDays = 2
 
 /**
  * Daytime catch-up cadence: outside the nightly window, one tick every 15
- * minutes resumes a stranded day until its summary is written. A single tick
- * still spends at most the normal ~20 s budget, so daytime blast radius is
- * bounded while a stranded night finishes within a few hours. Ticks with no
- * stranded day exit after two cheap HEAD-style checks per lookback day.
+ * minutes resumes the oldest stranded day in the lookback until its summary
+ * is written. A single tick still spends at most the normal ~20 s budget,
+ * so daytime blast radius is bounded while a stranded night finishes within
+ * a few hours. Ticks with no stranded day exit after two cheap HEAD-style
+ * checks per lookback day.
  */
 export function shouldRunDrExportCatchUpCron(now: Date) {
 	if (shouldRunDrExportCron(now)) return false

--- a/packages/worker/src/dr/exporter.node.test.ts
+++ b/packages/worker/src/dr/exporter.node.test.ts
@@ -608,6 +608,98 @@ test('daytime catch-up resumes a stranded previous day until its summary is writ
 	}
 })
 
+test('catch-up prefers the oldest stranded day in the lookback', async () => {
+	storageMocks.exportStorage.mockReset()
+	storageMocks.exportStorage.mockResolvedValue({
+		entries: [],
+		truncated: false,
+		nextStartAfter: null,
+		pageSize: 250,
+		estimatedBytes: 0,
+	})
+	mailboxMocks.exportMailbox.mockReset()
+	mailboxMocks.exportMailbox.mockResolvedValue({
+		rows: [],
+		truncated: false,
+		nextStartAfter: null,
+	})
+	runLogMocks.exportRuns.mockReset()
+	runLogMocks.exportRuns.mockResolvedValue({
+		runs: [],
+		logs: [],
+		packageInvocations: [],
+		workflowProjections: [],
+		jobRunObservability: [],
+		packageRunSuccesses: [],
+		activationMilestones: [],
+		truncated: false,
+		nextStartAfter: null,
+	})
+	const { client } = createMemoryS3()
+	const now = new Date('2026-07-23T12:00:00.000Z')
+	const env = {
+		DR_EXPORT_ENABLED: 'true',
+		DR_BACKUP_ACCOUNT_ID: 'acct',
+		DR_BACKUP_BUCKET_NAME: 'bucket',
+		DR_BACKUP_ACCESS_KEY_ID: 'key',
+		DR_BACKUP_SECRET_ACCESS_KEY: 'secret',
+		APP_DB: createDb({}),
+		EMAIL_BLOBS: createR2({}),
+		COMMUNITY_ASSETS: createR2({}),
+		BUNDLE_ARTIFACTS_KV: { get: async () => null },
+		STORAGE_RUNNER: {},
+	} as unknown as Env
+	for (const day of ['2026-07-20', '2026-07-21', '2026-07-22', '2026-07-23']) {
+		await client.put(
+			`staging/${day}/exporter/progress.json`,
+			JSON.stringify(__testOnlyCreateInitialProgress(day, now)),
+		)
+	}
+
+	const oldestInLookback = await runDrExportTick({
+		env,
+		now,
+		timeBudgetMs: 60_000,
+		s3: client,
+	})
+	expect(oldestInLookback).toMatchObject({
+		day: '2026-07-21',
+		mode: 'catch-up',
+		skipped: false,
+		summaryWritten: true,
+	})
+	expect(await client.getText(stagingSummaryKey('2026-07-20'))).toBeNull()
+	expect(await client.getText(stagingSummaryKey('2026-07-21'))).not.toBeNull()
+	expect(await client.getText(stagingSummaryKey('2026-07-22'))).toBeNull()
+	expect(await client.getText(stagingSummaryKey('2026-07-23'))).toBeNull()
+
+	const yesterday = await runDrExportTick({
+		env,
+		now: new Date('2026-07-23T12:15:00.000Z'),
+		timeBudgetMs: 60_000,
+		s3: client,
+	})
+	expect(yesterday).toMatchObject({
+		day: '2026-07-22',
+		mode: 'catch-up',
+		summaryWritten: true,
+	})
+	expect(await client.getText(stagingSummaryKey('2026-07-23'))).toBeNull()
+
+	const today = await runDrExportTick({
+		env,
+		now: new Date('2026-07-23T12:30:00.000Z'),
+		timeBudgetMs: 60_000,
+		s3: client,
+	})
+	expect(today).toMatchObject({
+		day: '2026-07-23',
+		mode: 'catch-up',
+		summaryWritten: true,
+	})
+	expect(await client.getText(stagingSummaryKey('2026-07-20'))).toBeNull()
+})
+
 test('catch-up honors an active progress lease and resumes after it expires', async () => {
 	storageMocks.exportStorage.mockReset()
 	storageMocks.exportStorage.mockResolvedValue({
@@ -1621,12 +1713,14 @@ test('watchdog stays loud when an earlier day is stranded despite catch-up', asy
 	} as unknown as Env
 	const now = new Date('2026-07-23T06:15:00.000Z')
 	const { client } = createMemoryS3()
-	// Tonight finished, but the day before is still progress-without-summary.
+	// Tonight finished, but earlier days are still progress-without-summary.
+	// The page lists oldest first — the same order catch-up resumes.
 	await client.put(stagingSummaryKey('2026-07-23'), '{}')
 	await client.put('staging/2026-07-22/exporter/progress.json', '{}')
+	await client.put('staging/2026-07-21/exporter/progress.json', '{}')
 	await expect(
 		runDrExportWatchdogTick({ env, now, s3: client }),
-	).rejects.toThrow(/catch-up is stuck.*2026-07-22/)
+	).rejects.toThrow(/catch-up is stuck.*2026-07-21, 2026-07-22/)
 
 	// A previous day with neither progress nor summary (for example before DR
 	// enablement) is not stranded.

--- a/packages/worker/src/dr/exporter.ts
+++ b/packages/worker/src/dr/exporter.ts
@@ -211,19 +211,21 @@ function utcDayMinus(day: string, daysBack: number) {
 }
 
 /**
- * Most recent day (today first) whose staging has progress but no completion
- * summary — a night the exporter started and never finished because the
- * window closed. Days with neither object never started (for example before
- * DR enablement) and are deliberately not eligible: catch-up resumes staged
- * work, it never starts a fresh past-day export whose dumps would actually
- * contain current data.
+ * Oldest day in the lookback (furthest back first, then toward today) whose
+ * staging has progress but no completion summary — a night the exporter
+ * started and never finished because the window closed. Preferring the
+ * oldest stranded day lets yesterday finish and seal before today's
+ * catch-up ticks consume the daytime budget. Days with neither object
+ * never started (for example before DR enablement) and are deliberately
+ * not eligible: catch-up resumes staged work, it never starts a fresh
+ * past-day export whose dumps would actually contain current data.
  */
 async function findStrandedStagingDay(input: {
 	s3: DrBackupS3Client
 	today: string
 	lookbackDays: number
 }): Promise<string | null> {
-	for (let offset = 0; offset <= input.lookbackDays; offset += 1) {
+	for (let offset = input.lookbackDays; offset >= 0; offset -= 1) {
 		const candidate = utcDayMinus(input.today, offset)
 		if ((await input.s3.head(stagingSummaryKey(candidate))).exists) continue
 		if ((await input.s3.head(stagingProgressKey(candidate))).exists) {
@@ -1492,8 +1494,9 @@ export type DrExportWatchdogResult = {
  * reports the failure to Sentry — an incomplete night is otherwise silent
  * (the exporter just stops getting ticks when the window closes). Also throws
  * when an earlier day within the catch-up lookback is still stranded
- * (progress without summary), so a stuck catch-up stays loud once per day
- * instead of failing silently forever.
+ * (progress without summary). Catch-up prefers the oldest stranded day, so
+ * an earlier day still missing a summary at 06:15 means catch-up is stuck
+ * and should stay loud once per day instead of failing silently forever.
  */
 export async function runDrExportWatchdogTick(input: {
 	env: Env
@@ -1522,7 +1525,7 @@ export async function runDrExportWatchdogTick(input: {
 	const s3 = input.s3 ?? createDrBackupS3Client(config)
 	const summary = await s3.getText(stagingSummaryKey(day))
 	const strandedPreviousDays: Array<string> = []
-	for (let offset = 1; offset <= drExportCatchUpLookbackDays; offset += 1) {
+	for (let offset = drExportCatchUpLookbackDays; offset >= 1; offset -= 1) {
 		const candidate = utcDayMinus(day, offset)
 		if ((await s3.head(stagingSummaryKey(candidate))).exists) continue
 		if ((await s3.head(stagingProgressKey(candidate))).exists) {
@@ -1556,7 +1559,7 @@ export async function runDrExportWatchdogTick(input: {
 		}
 	}
 	throw new Error(
-		`DR staging summary missing for ${day} after the export window closed (progress phase=${phase}${detail}). The night's non-D1 backup is incomplete and the day cannot be sealed. Daytime catch-up ticks will resume it; if it stays stranded, finish it via POST /__maintenance/dr-export.${strandedDetail}`,
+		`DR staging summary missing for ${day} after the export window closed (progress phase=${phase}${detail}). The night's non-D1 backup is incomplete and the day cannot be sealed. Daytime catch-up ticks resume the oldest stranded day in the lookback first; if a day stays stranded, finish it via POST /__maintenance/dr-export.${strandedDetail}`,
 	)
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop daytime DR staging catch-up from starving an older stranded day when today is also progress-without-summary, so yesterday can finish and seal.

## Why

`findStrandedStagingDay` scanned from offset 0 (today) upward. When a night ran out of window and today’s export also started and stranded, every daytime tick resumed today. Yesterday never got `exporter/summary.json`, so the control plane could not hourly-seal `daily/full/{day}/manifest.json` and the 24h sealed-full SLA broke (live Sep 2026: last sealed full was 2026-09-05 while 2026-09-06 and 2026-09-07 stayed unsealed).

Catch-up is still resume-only: a day with no `progress.json` is not started fresh.

## Summary

- Scan the catch-up lookback oldest-first (`lookbackDays` down to 0) and resume that stranded day
- 06:15 watchdog lists earlier stranded days oldest-first and says catch-up will finish those before today
- Docs and comments no longer say “most recent”
- Unit test: today + yesterday + 2-days-ago stranded, plus a day outside lookback — catch-up finishes oldest-in-lookback, then yesterday, then today

## Testing

- `npx vitest run --project node-unit packages/worker/src/dr/exporter.node.test.ts` — 17 passed
- Pre-push hook: `test:node` (2842) and `test:workers` (341) passed
- `npm run validate` after the PR is up

## System changes

Extends `backup-control-plane` catch-up selection only. Seal logic, S3 layout, and maintenance endpoints are unchanged.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `af8f4c3e` · **Head:** `12e130a1`

**Classification:** extends — catch-up now prefers the oldest progress-without-summary day in the lookback instead of today-first.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `backup-control-plane` | storage | extends — daytime catch-up and 06:15 watchdog scan oldest stranded day first |

### Change flow

Daytime catch-up resumes the oldest stranded staging day in the lookback so yesterday can write `exporter/summary.json` and seal before today’s ticks consume the budget.

```mermaid
sequenceDiagram
	actor Cron
	participant backupControlPlane as backup-control-plane
	Cron->>backupControlPlane: daytime catch-up tick
	backupControlPlane->>backupControlPlane: scan lookback oldest-first for progress without summary
	Note over backupControlPlane: resume-only, never start a fresh past day
	alt yesterday and today both stranded
		backupControlPlane->>backupControlPlane: resume yesterday until exporter/summary.json
	else only today stranded
		backupControlPlane->>backupControlPlane: resume today
	end
	Cron->>backupControlPlane: 06:15 watchdog
	backupControlPlane->>backupControlPlane: list earlier stranded days oldest-first
```

### Invariants

Per-user isolation is unchanged. Catch-up remains resume-only.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6c7a6884-0454-4baf-a06c-764ca78f2724?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6c7a6884-0454-4baf-a06c-764ca78f2724&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Behavior Updates**
  - Daytime staging catch-up now resumes stranded days from oldest to newest within the lookback window.
  - When multiple days are stranded, older days are completed and sealed before newer days consume the daytime catch-up budget.
  - Watchdog reporting now lists stranded days in oldest-first order.

- **Documentation**
  - Updated the disaster-recovery runbook and scheduling guidance to reflect the revised catch-up order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->