### PR TITLE
Clarify privacy wording: embeddings run, chat-model loop does not

### DIFF
--- a/docs/guides/first-win.md
+++ b/docs/guides/first-win.md
@@ -174,8 +174,9 @@ appear, the authorization did not finish — send them back to `/onboarding` to
 reconnect.
 
 **Nothing seems to happen on its own.** That is by design. Kody stores mail,
-memories, credentials, and code; it makes no inference calls of its own. Every
-step in this loop happens because an agent asked for it.
+memories, credentials, and code; it does not run its own chat-model agent loop.
+Search indexing uses a small embedding model. Every step in this loop happens
+because an agent asked for it.
 
 ## Try it
 

--- a/docs/guides/what-is-kody.md
+++ b/docs/guides/what-is-kody.md
@@ -42,9 +42,11 @@ inspect, and each version converts to the Apache License 2.0 after two years.
 You do not chat with Kody directly: you connect the AI agent you already use
 (Claude, ChatGPT, Cursor, Codex, or any other MCP-capable host) to your Kody
 account, and that agent gains durable capabilities that outlive the conversation
-and keep running while your computer is off. Kody makes no inference calls of
-its own — your agent supplies the intelligence; Kody supplies memory,
-credentials, saved code, schedules, and execution.
+and keep running while your computer is off. Kody does not run its own
+chat-model agent loop or bill for chat tokens — your agent supplies the
+intelligence; Kody supplies memory, credentials, saved code, schedules, and
+execution. Search and indexing use a small embedding model; that is not a chat
+model and is not billed as inference.
 
 ## The agent reasons. Kody keeps it honest.
 

--- a/docs/use/privacy.md
+++ b/docs/use/privacy.md
@@ -73,14 +73,22 @@ Kody fetches data from a connected service only to fulfill a request you, or a
 job you saved, just made. Content a package or job persists (for example a saved
 summary) stays in your account under the same isolation rules. Kody does not
 sell that data, use it for advertising, share it with other Kody users, or use
-it to train a Kody model. Kody makes no inference calls of its own.
+it to train a Kody model. Kody does not run its own chat-model agent loop and
+does not bill for chat tokens. Search and indexing do call Cloudflare Workers AI
+for embeddings: the search query, plus indexed text for builtin capabilities,
+saved packages (manifest search fields, not full source), memories (subject,
+summary, details, and tags), jobs (name, description, and schedule), and public
+community listings (name, description, tags, and a short readme snippet). Secret
+values and OAuth tokens are never sent to that model. Connected-account provider
+content is embedded only if it was first saved as one of those indexed records.
 
 **Share, transfer, and disclose.** Provider data leaves your isolated account
-only to Cloudflare, which hosts the application, database, object storage, and
-network; the MCP host you connected (for example ChatGPT, Claude, or Cursor),
-when that host asks Kody to act and receives the result; the provider itself,
-when Kody calls its API with your token; and disclosure required by law. Kody
-does not hand connected-account data to other customers or advertisers.
+only to Cloudflare, which hosts the application, database, object storage,
+network, and Workers AI embeddings; the MCP host you connected (for example
+ChatGPT, Claude, or Cursor), when that host asks Kody to act and receives the
+result; the provider itself, when Kody calls its API with your token; and
+disclosure required by law. Kody does not hand connected-account data to other
+customers or advertisers.
 
 **Protection.** Tokens and OAuth grants are encrypted at rest, isolated per
 user, and sent only to hosts you approved. The admin role cannot read secret
@@ -292,7 +300,7 @@ Kody uses these subprocessors to run the hosted service. They process only the
 data needed for their role:
 
 - Cloudflare — application hosting, database, object storage, email delivery,
-  security, and network infrastructure
+  security, network infrastructure, and Workers AI embeddings for search
 - Stripe — paid subscriptions, billing, and payment records
 - Kit — waitlist and product email subscriptions when you submit your email for
   those purposes

--- a/docs/use/privacy.md
+++ b/docs/use/privacy.md
@@ -102,7 +102,8 @@ Docs, Sheets, Gmail send, Contacts, Tasks, YouTube, and any other Google scopes
 you grant. Kody uses Google user data only to fulfill your request or saved job.
 Kody stores Google OAuth tokens encrypted on that Google connection and does not
 use Google user data for advertising. Kody shares, transfers, or discloses
-Google user data only with Cloudflare (hosting), the MCP host you connected when
+Google user data only with Cloudflare (hosting, including Workers AI embeddings
+for content first saved as an indexed record), the MCP host you connected when
 it asks Kody to act, Google when Kody calls Google APIs on your behalf, and when
 required by law.
 

--- a/packages/worker/client/routes/privacy.tsx
+++ b/packages/worker/client/routes/privacy.tsx
@@ -98,16 +98,26 @@ export function PrivacyRoute(_handle: Handle) {
 					(for example a saved summary) stays in your account under the same
 					isolation rules. Kody does not sell that data, use it for advertising,
 					share it with other Kody users, or use it to train a Kody model. Kody
-					makes no inference calls of its own.
+					does not run its own chat-model agent loop and does not bill for chat
+					tokens. Search and indexing do call Cloudflare Workers AI for
+					embeddings: the search query, plus indexed text for builtin
+					capabilities, saved packages (manifest search fields, not full
+					source), memories (subject, summary, details, and tags), jobs (name,
+					description, and schedule), and public community listings (name,
+					description, tags, and a short readme snippet). Secret values and
+					OAuth tokens are never sent to that model. Connected-account provider
+					content is embedded only if it was first saved as one of those indexed
+					records.
 				</p>
 				<p mix={css(descriptionCss)}>
 					<strong>Share, transfer, and disclose.</strong> Provider data leaves
 					your isolated account only to Cloudflare, which hosts the application,
-					database, object storage, and network; the MCP host you connected (for
-					example ChatGPT, Claude, or Cursor), when that host asks Kody to act
-					and receives the result; the provider itself, when Kody calls its API
-					with your token; and disclosure required by law. Kody does not hand
-					connected-account data to other customers or advertisers.
+					database, object storage, network, and Workers AI embeddings; the MCP
+					host you connected (for example ChatGPT, Claude, or Cursor), when that
+					host asks Kody to act and receives the result; the provider itself,
+					when Kody calls its API with your token; and disclosure required by
+					law. Kody does not hand connected-account data to other customers or
+					advertisers.
 				</p>
 				<p mix={css(descriptionCss)}>
 					<strong>Protection.</strong> Tokens and OAuth grants are encrypted at
@@ -361,7 +371,8 @@ export function PrivacyRoute(_handle: Handle) {
 				<ul mix={css(listCss)}>
 					<li>
 						Cloudflare — application hosting, database, object storage, email
-						delivery, security, and network infrastructure
+						delivery, security, network infrastructure, and Workers AI
+						embeddings for search
 					</li>
 					<li>Stripe — paid subscriptions, billing, and payment records</li>
 					<li>

--- a/packages/worker/client/routes/privacy.tsx
+++ b/packages/worker/client/routes/privacy.tsx
@@ -134,9 +134,10 @@ export function PrivacyRoute(_handle: Handle) {
 					fulfill your request or saved job. Kody stores Google OAuth tokens
 					encrypted on that Google connection and does not use Google user data
 					for advertising. Kody shares, transfers, or discloses Google user data
-					only with Cloudflare (hosting), the MCP host you connected when it
-					asks Kody to act, Google when Kody calls Google APIs on your behalf,
-					and when required by law.
+					only with Cloudflare (hosting, including Workers AI embeddings for
+					content first saved as an indexed record), the MCP host you connected
+					when it asks Kody to act, Google when Kody calls Google APIs on your
+					behalf, and when required by law.
 				</p>
 			</section>
 

--- a/packages/worker/src/app/handlers/guides.node.test.ts
+++ b/packages/worker/src/app/handlers/guides.node.test.ts
@@ -256,6 +256,38 @@ test('provider and platform guide markdown details stay stable', async () => {
 	expect(missingApi.status).toBe(404)
 })
 
+test('what-is-kody and first-win distinguish chat-model inference from embeddings', async () => {
+	const whatIsKody = await callHandler(
+		createGuideDetailMarkdownHandler(env) as never,
+		{
+			request: new Request('https://kody.example/guides/what-is-kody.md'),
+			params: { slug: 'what-is-kody' },
+		},
+	)
+	expect(whatIsKody.status).toBe(200)
+	const whatIsKodyBody = (await whatIsKody.text()).replace(/\s+/g, ' ')
+	expect(whatIsKodyBody).toContain(
+		'does not run its own chat-model agent loop or bill for chat tokens',
+	)
+	expect(whatIsKodyBody).toContain(
+		'Search and indexing use a small embedding model',
+	)
+
+	const firstWin = await callHandler(
+		createGuideDetailMarkdownHandler(env) as never,
+		{
+			request: new Request('https://kody.example/guides/first-win.md'),
+			params: { slug: 'first-win' },
+		},
+	)
+	expect(firstWin.status).toBe(200)
+	const firstWinBody = (await firstWin.text()).replace(/\s+/g, ' ')
+	expect(firstWinBody).toContain(
+		'it does not run its own chat-model agent loop',
+	)
+	expect(firstWinBody).toContain('Search indexing uses a small embedding model')
+})
+
 test('interactive guide JSON includes walkthrough highlight tokens', async () => {
 	const howKodyWorksSnippets = uniqueHighlightSnippets(
 		collectHowKodyWorksSnippets(),

--- a/packages/worker/src/app/ssr-render-privacy.node.test.ts
+++ b/packages/worker/src/app/ssr-render-privacy.node.test.ts
@@ -1,0 +1,123 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { expect, test } from 'vitest'
+import { setAuthSessionSecret } from '#app/auth-session.ts'
+import { resetDataCacheForTests } from '#app/data-cache.ts'
+import { createPrivacyHandler } from '#app/handlers/privacy.ts'
+import { executePreparedD1Batch } from '#worker/test-support/d1-prepared-batch.ts'
+import { testOidcSigningEnv } from '#worker/test-support/oidc-signing-env.ts'
+
+const testCookieSecret = 'test-cookie-secret-0123456789abcdef0123456789'
+
+const privacyDocPath = resolve(
+	import.meta.dirname,
+	'../../../../docs/use/privacy.md',
+)
+
+function flatten(text: string) {
+	return text.replace(/\s+/g, ' ')
+}
+
+function createAnonymousTestDb() {
+	function createStatement(query: string) {
+		const normalizedQuery = query.replace(/\s+/g, ' ').trim().toLowerCase()
+		const executeAll = async () => {
+			if (
+				normalizedQuery.includes('from feature_flags') ||
+				normalizedQuery.includes('from feature_flag_user_overrides')
+			) {
+				return {
+					results: [],
+					meta: { changes: 0, last_row_id: 0 },
+				}
+			}
+			return {
+				results: [],
+				meta: { changes: 0, last_row_id: 0 },
+			}
+		}
+		return {
+			query,
+			bind() {
+				return createStatement(query)
+			},
+			async all() {
+				return executeAll()
+			},
+			async first() {
+				const result = await executeAll()
+				return result.results[0] ?? null
+			},
+			async run() {
+				return { meta: { changes: 0, last_row_id: 0 } }
+			},
+		}
+	}
+
+	return {
+		prepare(query: string) {
+			return createStatement(query)
+		},
+		async batch(statements: Array<{ query?: string }>) {
+			return await executePreparedD1Batch(statements)
+		},
+		async exec() {
+			return
+		},
+	} as unknown as D1Database
+}
+
+test('privacy page and usage doc distinguish chat-model inference from embeddings', async () => {
+	resetDataCacheForTests()
+	setAuthSessionSecret(testCookieSecret)
+	const env = {
+		COOKIE_SECRET: testCookieSecret,
+		SECRET_STORE_KEY: 'LOCAL_TEST_SECRET_STORE_KEY_32_CHARS_MINIMUM',
+		...testOidcSigningEnv,
+		APP_DB: createAnonymousTestDb(),
+		BUNDLE_ARTIFACTS_KV: {},
+		JOB_MANAGER: {},
+		STORAGE_RUNNER: {},
+		PACKAGE_REALTIME_SESSION: {},
+		MCP_CLIENT_HUB: {},
+	} as unknown as Env
+
+	const response = await createPrivacyHandler(env).handler({
+		request: new Request('https://example.com/privacy'),
+	} as never)
+
+	expect(response.status).toBe(200)
+	const html = flatten(await response.text())
+	expect(html).toContain('<title>Privacy</title>')
+	expect(html).toContain('does not run its own chat-model agent loop')
+	expect(html).toContain('does not bill for chat tokens')
+	expect(html).toContain('Cloudflare Workers AI')
+	expect(html).toContain('embeddings')
+	expect(html).toContain('manifest search fields, not full source')
+	expect(html).toContain('memories (subject, summary, details, and tags)')
+	expect(html).toContain('Secret values and OAuth tokens are never sent')
+	expect(html).toContain(
+		'Connected-account provider content is embedded only if it was first saved',
+	)
+	expect(html).toContain('Workers AI embeddings for search')
+	expect(html).toContain('train a Kody model')
+	expect(html).toContain('SECRET_STORE_KEY')
+
+	const privacyDoc = flatten(readFileSync(privacyDocPath, 'utf8'))
+	expect(privacyDoc).toContain(
+		'does not run its own chat-model agent loop and does not bill for chat tokens',
+	)
+	expect(privacyDoc).toContain(
+		'Search and indexing do call Cloudflare Workers AI for embeddings',
+	)
+	expect(privacyDoc).toContain('manifest search fields, not full source')
+	expect(privacyDoc).toContain(
+		'Connected-account provider content is embedded only if it was first saved as one of those indexed records.',
+	)
+	expect(privacyDoc).toContain(
+		'network infrastructure, and Workers AI embeddings for search',
+	)
+	expect(privacyDoc).toContain(
+		'network, and Workers AI embeddings; the MCP host you connected',
+	)
+})

--- a/packages/worker/src/app/ssr-render-privacy.node.test.ts
+++ b/packages/worker/src/app/ssr-render-privacy.node.test.ts
@@ -102,6 +102,9 @@ test('privacy page and usage doc distinguish chat-model inference from embedding
 	expect(html).toContain('Workers AI embeddings for search')
 	expect(html).toContain('train a Kody model')
 	expect(html).toContain('SECRET_STORE_KEY')
+	expect(html).toContain(
+		'Cloudflare (hosting, including Workers AI embeddings for content first saved as an indexed record)',
+	)
 
 	const privacyDoc = flatten(readFileSync(privacyDocPath, 'utf8'))
 	expect(privacyDoc).toContain(
@@ -119,5 +122,8 @@ test('privacy page and usage doc distinguish chat-model inference from embedding
 	)
 	expect(privacyDoc).toContain(
 		'network, and Workers AI embeddings; the MCP host you connected',
+	)
+	expect(privacyDoc).toContain(
+		'Cloudflare (hosting, including Workers AI embeddings for content first saved as an indexed record)',
 	)
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Make the public privacy policy match what the code actually does before launch: Kody does not run a chat-model agent loop or bill chat tokens, but search and indexing do call Cloudflare Workers AI for embeddings.

## Why

`docs/use/privacy.md` and `/privacy` said “Kody makes no inference calls of its own.” That contradicts `packages/worker/src/vectorize/embedding.ts` (`@cf/baai/bge-small-en-v1.5` via `runtime.AI.run`) and the FAQ, which already qualifies search indexing. Launch copy that claims zero inference is false.

## Summary

- Replaced the absolute “no inference calls” sentence on the privacy source and rendered `/privacy` page with the chat-loop vs embedding distinction.
- Documented the embedding input scope from code: search query plus indexed text for builtin capabilities, saved packages (manifest search fields, not full source), memories, jobs, and public community listings. Secret values and OAuth tokens are never sent. Provider content is embedded only if it was first saved as one of those records.
- Qualified Cloudflare’s existing subprocessor / share path with Workers AI embeddings, including the Google restatement so it does not look narrower than the general rule.
- Aligned the contradictory launch guides (`what-is-kody`, `first-win`). Left FAQ, pricing, and home to the signup-copy sibling.
- Added render + markdown tests that pin the distinction on `/privacy`, `docs/use/privacy.md`, and the two guides.

## Testing

- Focused node tests for privacy render + guide markdown
- Docs checkers + local `npm run validate`
- Pre-push node/workers
- Preview then **live** `https://kody.codes/privacy` after production deploy
- `control-kody health --origin https://kody.codes --sha 1c74729` (live SHA; includes #2150)

## System changes

Low risk, composes `app-ui`. Copy-only; no runtime models, telemetry, billing, or data-path changes.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `af8f4c3e` · **Head:** `92ec94e5`

**Classification:** composes — no primitives added or changed; this PR rewrites privacy and guide copy to match existing embedding calls.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `app-ui` | surfaces | composes — `/privacy` and guide markdown copy only |

Unmatched paths: `docs/use/privacy.md`, `docs/guides/what-is-kody.md`, `docs/guides/first-win.md` (usage/guide sources rendered by existing `app-ui` routes).

### Change flow

A visitor or agent reads `/privacy` or a launch guide. The copy now states the chat-loop vs embedding distinction that `embedding.ts` already implements.

```mermaid
sequenceDiagram
	actor Reader
	participant appUi as app-ui
	participant workersAi as Cloudflare Workers AI
	Reader->>appUi: GET /privacy or launch guide
	appUi-->>Reader: chat-model loop is not billed
	appUi-->>Reader: search indexing embeds query and indexed text
	Note over appUi: secrets and OAuth tokens are never sent
	Note over workersAi: unchanged @cf/baai/bge-small-en-v1.5 path
```

### Invariants

Per-user isolation, encrypted secrets/OAuth, operator-vs-application-admin boundary, and existing share/subprocessor qualifications are unchanged.

</details>

<!-- system-recap:end -->

## Conductor report

- **Track:** P1.6 privacy inference wording
- **STATUS:** shipped
- **Shipped:** https://github.com/kentcdodds/kody/pull/2150 squash-merged as `eeaee38`
- **Evidence:** live `https://kody.codes/privacy` (production SHA `1c74729`, one commit after `eeaee38`) contains the chat-loop vs embedding copy, Google parenthetical, and no “makes no inference calls of its own”
- **Remains:** none for this track. Cloudflare Workers AI retention/training language was not invented; Kent can add it if legal wants it
- **Out of scope:** FAQ / pricing / home (signup-copy sibling); runtime models; telemetry; billing; credentials

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6fc08063-7d3f-4336-9098-cb8764fd037d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6fc08063-7d3f-4336-9098-cb8764fd037d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified that Kody does not run its own chat-model agent loop or bill for chat tokens.
  - Explained that search and indexing use a separate embedding model.
  - Updated privacy information to describe indexed data, Cloudflare Workers AI usage, and protected information such as secrets, OAuth tokens, and unsaved provider content.

- **Tests**
  - Added coverage verifying guide and privacy-page content accurately distinguishes chat-model inference from embeddings and reflects data-handling and billing details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->