### PR TITLE
Retry scheduled-lane D1 lock contention instead of dropping the tick

### DIFF
--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -1281,12 +1281,18 @@ cleanup, system-email retention, general retention, job retention, hourly
 usage-rollup aggregation, and bounded USER inbound Mailbox reconciliation
 (active-user discovery from the users/config index followed by owner-point
 Mailbox due-work RPCs; no shared graph scan). Each production queue message
-preserves `scheduled_lane_failed` / D1 lock-contention log and Sentry context. A
-handled lane failure is acknowledged and retried by the next cron tick. A failed
+preserves `scheduled_lane_failed` / D1 lock-contention log and Sentry context.
+D1 lock contention is replay-safe (the write did not commit) and retries on
+`kody-scheduled-dispatch` with bounded backoff (`max_retries` 3, then the
+dedicated DLQ plus a `scheduled_lane_retry_exhausted` alert). Other handled lane
+failures are acknowledged as terminal so partial external side effects are not
+replayed; the next eligible cron cadence is the next automatic attempt. A failed
 enqueue is reported and runs through the inline fallback after all sibling
 enqueue attempts finish; multiple failed enqueues fall back sequentially to
-avoid D1 lock contention. Consumer transport failures retain the configured
-retry/DLQ behavior. No failure can abort or mask a sibling invocation.
+avoid D1 lock contention. Inline fallback is one-shot and logs a non-completed
+outcome; it does not invent extra retries. Consumer transport failures retain
+the configured retry/DLQ behavior. No failure can abort or mask a sibling
+invocation.
 
 Production note:
 

--- a/docs/contributing/setup-manifest.md
+++ b/docs/contributing/setup-manifest.md
@@ -103,9 +103,11 @@ This project uses the following resources:
   - Queue: `kody-scheduled-dispatch`
   - Dead-letter queue: `kody-scheduled-dispatch-dlq`
   - The production consumer receives one lane message per invocation, permits up
-    to 16 concurrent lane invocations, retries three times, and routes exhausted
-    messages to the dedicated dead-letter queue. Production CI ensures both
-    resources.
+    to 16 concurrent lane invocations, and retries only replay-safe
+    `d1_lock_contention` outcomes three times (10s / 30s / 90s backoff) before
+    routing exhausted messages to the dedicated dead-letter queue. Other handled
+    lane failures and invalid bodies are acknowledged as terminal. Production CI
+    ensures both resources.
   - Preview and local runtimes without this production-only queue binding run
     the same registry inline so maintenance behavior remains testable.
 - Vectorize indexes for MCP capability search (`CAPABILITY_VECTOR_INDEX`)

--- a/packages/jobs-worker/src/scheduled.node.test.ts
+++ b/packages/jobs-worker/src/scheduled.node.test.ts
@@ -1,10 +1,15 @@
+import { readFile } from 'node:fs/promises'
 import { expect, test, vi } from 'vitest'
+import * as Sentry from '@sentry/cloudflare'
 import {
 	consoleError,
 	consoleWarn,
+	silenceExpectedConsoleErrors,
+	silenceExpectedConsoleWarns,
 } from '#worker/test-support/console-spies.ts'
 import {
 	getScheduledLaneCadence,
+	scheduledDispatchMaxRetries,
 	type ScheduledLaneMessage,
 } from '@kody-internal/shared/jobs/scheduled-lanes.ts'
 import { type JobsWorkerEnv } from './env.ts'
@@ -45,6 +50,20 @@ function message(
 	scheduledTime = Date.UTC(2026, 0, 1, 12, 0),
 ): ScheduledLaneMessage {
 	return { lane, scheduledTime, cron: '*/5 * * * *' }
+}
+
+function queueMessage(input: {
+	id?: string
+	body: unknown
+	attempts?: number
+}) {
+	return {
+		id: input.id ?? 'msg',
+		body: input.body,
+		attempts: input.attempts ?? 1,
+		ack: vi.fn(),
+		retry: vi.fn(),
+	}
 }
 
 test('lane routing forwards platform work to HOST, runs watchdog locally, and acks invalid queue bodies', async () => {
@@ -186,4 +205,155 @@ test('retryable D1 lock contention is distinguished from ordinary failures', asy
 			message: message('retention'),
 		}),
 	).resolves.toBe('failed')
+})
+
+test('queue consumer acks completed and terminal work, retries lock contention with backoff, and preserves scheduledTime', async () => {
+	silenceExpectedConsoleWarns([
+		'scheduled_lane_d1_lock_contention lane=retention',
+	])
+	silenceExpectedConsoleErrors([
+		'scheduled_lane_failed lane=retention',
+		'scheduled_lane_message_invalid',
+		'scheduled_lane_terminal_not_retried',
+		'scheduled_lane_retry_exhausted',
+	])
+	const captureMessage = vi.spyOn(Sentry, 'captureMessage')
+	const scheduledTime = Date.UTC(2026, 0, 1, 12, 0)
+	const retention = message('retention', scheduledTime)
+	const host = vi
+		.fn()
+		.mockResolvedValueOnce('completed')
+		.mockResolvedValueOnce('d1_lock_contention')
+		.mockResolvedValueOnce('failed')
+		.mockResolvedValueOnce('d1_lock_contention')
+	const env = createEnv({ HOST: { runScheduledLane: host } })
+
+	const completed = queueMessage({ id: 'completed', body: retention })
+	const lock = queueMessage({ id: 'lock', body: retention, attempts: 1 })
+	const failed = queueMessage({ id: 'failed', body: retention })
+	const invalid = queueMessage({
+		id: 'invalid',
+		body: { lane: 'nope' },
+	})
+	const exhausted = queueMessage({
+		id: 'exhausted',
+		body: retention,
+		attempts: scheduledDispatchMaxRetries + 1,
+	})
+
+	await handleScheduledDispatchQueue(
+		{
+			messages: [completed, lock, failed, invalid, exhausted],
+		} as unknown as MessageBatch<unknown>,
+		env,
+	)
+
+	expect(completed.ack).toHaveBeenCalledOnce()
+	expect(completed.retry).not.toHaveBeenCalled()
+
+	expect(lock.retry).toHaveBeenCalledOnce()
+	expect(lock.retry).toHaveBeenCalledWith({ delaySeconds: 10 })
+	expect(lock.ack).not.toHaveBeenCalled()
+
+	expect(failed.ack).toHaveBeenCalledOnce()
+	expect(failed.retry).not.toHaveBeenCalled()
+	expect(consoleError).toHaveBeenCalledWith(
+		'scheduled_lane_terminal_not_retried',
+		expect.objectContaining({
+			lane: 'retention',
+			scheduledTime,
+			attempts: 1,
+			outcome: 'failed',
+		}),
+	)
+
+	expect(invalid.ack).toHaveBeenCalledOnce()
+	expect(invalid.retry).not.toHaveBeenCalled()
+	expect(consoleError).toHaveBeenCalledWith(
+		'scheduled_lane_message_invalid',
+		expect.objectContaining({ queueMessageId: 'invalid' }),
+	)
+
+	expect(exhausted.retry).toHaveBeenCalledOnce()
+	expect(exhausted.retry).toHaveBeenCalledWith({ delaySeconds: 90 })
+	expect(exhausted.ack).not.toHaveBeenCalled()
+	expect(consoleError).toHaveBeenCalledWith(
+		'scheduled_lane_retry_exhausted',
+		expect.objectContaining({
+			lane: 'retention',
+			scheduledTime,
+			attempts: scheduledDispatchMaxRetries + 1,
+			outcome: 'd1_lock_contention',
+		}),
+	)
+	expect(captureMessage).toHaveBeenCalledWith(
+		'scheduled_lane_retry_exhausted lane=retention',
+	)
+
+	expect(host).toHaveBeenCalledTimes(4)
+	for (const call of host.mock.calls) {
+		expect(call[0]).toEqual(retention)
+	}
+
+	const laterLock = queueMessage({
+		id: 'later-lock',
+		body: retention,
+		attempts: 2,
+	})
+	host.mockResolvedValueOnce('d1_lock_contention')
+	await handleScheduledDispatchQueue(
+		{ messages: [laterLock] } as unknown as MessageBatch<unknown>,
+		env,
+	)
+	expect(laterLock.retry).toHaveBeenCalledWith({ delaySeconds: 30 })
+	expect(laterLock.ack).not.toHaveBeenCalled()
+})
+
+test('inline fallback keeps scheduledTime and does not invent extra lane retries', async () => {
+	silenceExpectedConsoleErrors([
+		'scheduled_lane_dispatch_failed lane=oauth_purge_expired',
+		'scheduled_lane_inline_d1_lock_contention',
+	])
+	const host = vi.fn().mockResolvedValue('d1_lock_contention')
+	const failingSend = vi.fn(async (body: ScheduledLaneMessage) => {
+		if (body.lane === 'oauth_purge_expired') {
+			throw new Error('queue unavailable')
+		}
+	})
+	const env = createEnv({
+		HOST: { runScheduledLane: host },
+		SCHEDULED_DISPATCH_QUEUE: { send: failingSend },
+	})
+	const fallbackTime = Date.UTC(2026, 0, 1, 12, 10)
+	await dispatchScheduledLanes({
+		controller: {
+			scheduledTime: fallbackTime,
+			cron: '*/5 * * * *',
+		} as ScheduledController,
+		env,
+	})
+	expect(host).toHaveBeenCalledTimes(1)
+	expect(host).toHaveBeenCalledWith({
+		lane: 'oauth_purge_expired',
+		scheduledTime: fallbackTime,
+		cron: '*/5 * * * *',
+	})
+	expect(consoleError).toHaveBeenCalledWith(
+		'scheduled_lane_inline_d1_lock_contention',
+		expect.objectContaining({
+			lane: 'oauth_purge_expired',
+			scheduledTime: fallbackTime,
+		}),
+	)
+})
+
+test('production scheduled-dispatch consumer retry bound matches the shared contract', async () => {
+	const wrangler = await readFile(
+		new URL('../wrangler.jsonc', import.meta.url),
+		'utf8',
+	)
+	const consumer = wrangler.match(
+		/"queue": "kody-scheduled-dispatch",[\s\S]*?"max_retries": (\d+),[\s\S]*?"dead_letter_queue": "kody-scheduled-dispatch-dlq"/,
+	)
+	expect(consumer?.[1]).toBe(String(scheduledDispatchMaxRetries))
 })

--- a/packages/jobs-worker/src/scheduled.ts
+++ b/packages/jobs-worker/src/scheduled.ts
@@ -4,7 +4,9 @@ import {
 	getScheduledLaneCadence,
 	isJobsWorkerLocalLane,
 	parseScheduledLaneMessage,
+	resolveScheduledLaneQueueAction,
 	type ScheduledLaneMessage,
+	type ScheduledLaneOutcome,
 } from '@kody-internal/shared/jobs/scheduled-lanes.ts'
 import { type JobsWorkerEnv } from './env.ts'
 import { runJobScheduleWatchdogTick } from './watchdog.ts'
@@ -18,7 +20,7 @@ import { runJobScheduleWatchdogTick } from './watchdog.ts'
 export async function runScheduledLaneWithFailureIsolation(input: {
 	env: JobsWorkerEnv
 	message: ScheduledLaneMessage
-}): Promise<'completed' | 'd1_lock_contention' | 'failed'> {
+}): Promise<ScheduledLaneOutcome> {
 	const scheduledAt = new Date(input.message.scheduledTime)
 	try {
 		if (isJobsWorkerLocalLane(input.message.lane)) {
@@ -60,13 +62,14 @@ export async function dispatchScheduledLanes(input: {
 	const queue = input.env.SCHEDULED_DISPATCH_QUEUE
 	if (!queue) {
 		for (const lane of lanes) {
-			await runScheduledLaneWithFailureIsolation({
+			const message = {
+				lane,
+				scheduledTime: input.controller.scheduledTime,
+				cron: input.controller.cron,
+			} satisfies ScheduledLaneMessage
+			await runInlineScheduledLane({
 				env: input.env,
-				message: {
-					lane,
-					scheduledTime: input.controller.scheduledTime,
-					cron: input.controller.cron,
-				},
+				message,
 			})
 		}
 		return
@@ -99,11 +102,25 @@ export async function dispatchScheduledLanes(input: {
 	)
 	for (const message of failedMessages) {
 		if (!message) continue
-		await runScheduledLaneWithFailureIsolation({
+		await runInlineScheduledLane({
 			env: input.env,
 			message,
 		})
 	}
+}
+
+async function runInlineScheduledLane(input: {
+	env: JobsWorkerEnv
+	message: ScheduledLaneMessage
+}) {
+	const outcome = await runScheduledLaneWithFailureIsolation(input)
+	if (outcome === 'completed') return
+	console.error(`scheduled_lane_inline_${outcome}`, {
+		lane: input.message.lane,
+		scheduledTime: input.message.scheduledTime,
+		cron: input.message.cron,
+		outcome,
+	})
 }
 
 export async function handleScheduledDispatchQueue(
@@ -119,7 +136,50 @@ export async function handleScheduledDispatchQueue(
 			queueMessage.ack()
 			continue
 		}
-		await runScheduledLaneWithFailureIsolation({ env, message })
+		const outcome = await runScheduledLaneWithFailureIsolation({
+			env,
+			message,
+		})
+		const decision = resolveScheduledLaneQueueAction({
+			outcome,
+			attempts: queueMessage.attempts,
+		})
+		if (decision.action === 'retry') {
+			if (decision.reason === 'retry_exhausted') {
+				console.error('scheduled_lane_retry_exhausted', {
+					lane: message.lane,
+					scheduledTime: message.scheduledTime,
+					cron: message.cron,
+					attempts: queueMessage.attempts,
+					outcome,
+				})
+				Sentry.withScope((scope) => {
+					scope.setTag('scheduled.lane', message.lane)
+					scope.setTag('scheduled.queue_action', 'retry_exhausted')
+					scope.setContext('scheduled', {
+						lane: message.lane,
+						scheduledTime: new Date(message.scheduledTime).toISOString(),
+						cron: message.cron,
+						attempts: queueMessage.attempts,
+						outcome,
+					})
+					Sentry.captureMessage(
+						`scheduled_lane_retry_exhausted lane=${message.lane}`,
+					)
+				})
+			}
+			queueMessage.retry({ delaySeconds: decision.delaySeconds })
+			continue
+		}
+		if (decision.reason === 'terminal_failure') {
+			console.error('scheduled_lane_terminal_not_retried', {
+				lane: message.lane,
+				scheduledTime: message.scheduledTime,
+				cron: message.cron,
+				attempts: queueMessage.attempts,
+				outcome,
+			})
+		}
 		queueMessage.ack()
 	}
 }

--- a/packages/shared/src/jobs/rpc.ts
+++ b/packages/shared/src/jobs/rpc.ts
@@ -1,6 +1,9 @@
 import { type McpCallerContext } from '../chat.ts'
 import { type JobManagerDebugState } from './manager-debug.ts'
-import { type ScheduledLaneMessage } from './scheduled-lanes.ts'
+import {
+	type ScheduledLaneMessage,
+	type ScheduledLaneOutcome,
+} from './scheduled-lanes.ts'
 import { type SchedulerJobOutcomeLog } from './scheduler-logging.ts'
 import { type JobsStore } from './store.ts'
 import {
@@ -63,7 +66,5 @@ export type JobsHostContract = {
 		repoCheckPolicyOverride?: JobRepoCheckPolicy | null
 	}): Promise<RunJobNowResult>
 	/** Execute one platform scheduled lane with failure isolation. */
-	runScheduledLane(
-		message: ScheduledLaneMessage,
-	): Promise<'completed' | 'd1_lock_contention' | 'failed'>
+	runScheduledLane(message: ScheduledLaneMessage): Promise<ScheduledLaneOutcome>
 }

--- a/packages/shared/src/jobs/scheduled-lanes.node.test.ts
+++ b/packages/shared/src/jobs/scheduled-lanes.node.test.ts
@@ -1,0 +1,81 @@
+import { expect, test } from 'vitest'
+import {
+	parseScheduledLaneMessage,
+	resolveScheduledLaneQueueAction,
+	scheduledDispatchMaxRetries,
+} from './scheduled-lanes.ts'
+
+test('queue action policy retries only lock contention, acks completed and failed, and preserves the original outcome contract', () => {
+	expect(
+		resolveScheduledLaneQueueAction({
+			outcome: 'completed',
+			attempts: 1,
+		}),
+	).toEqual({ action: 'ack', reason: 'completed' })
+	expect(
+		resolveScheduledLaneQueueAction({
+			outcome: 'failed',
+			attempts: 1,
+		}),
+	).toEqual({ action: 'ack', reason: 'terminal_failure' })
+	expect(
+		resolveScheduledLaneQueueAction({
+			outcome: 'failed',
+			attempts: scheduledDispatchMaxRetries + 1,
+		}),
+	).toEqual({ action: 'ack', reason: 'terminal_failure' })
+
+	expect(
+		resolveScheduledLaneQueueAction({
+			outcome: 'd1_lock_contention',
+			attempts: 1,
+		}),
+	).toEqual({
+		action: 'retry',
+		reason: 'transient_failure',
+		delaySeconds: 10,
+	})
+	expect(
+		resolveScheduledLaneQueueAction({
+			outcome: 'd1_lock_contention',
+			attempts: 2,
+		}),
+	).toEqual({
+		action: 'retry',
+		reason: 'transient_failure',
+		delaySeconds: 30,
+	})
+	expect(
+		resolveScheduledLaneQueueAction({
+			outcome: 'd1_lock_contention',
+			attempts: 3,
+		}),
+	).toEqual({
+		action: 'retry',
+		reason: 'transient_failure',
+		delaySeconds: 90,
+	})
+	expect(
+		resolveScheduledLaneQueueAction({
+			outcome: 'd1_lock_contention',
+			attempts: scheduledDispatchMaxRetries + 1,
+		}),
+	).toEqual({
+		action: 'retry',
+		reason: 'retry_exhausted',
+		delaySeconds: 90,
+	})
+
+	const scheduledTime = Date.UTC(2026, 0, 1, 12, 0)
+	expect(
+		parseScheduledLaneMessage({
+			lane: 'retention',
+			scheduledTime,
+			cron: '*/5 * * * *',
+		}),
+	).toEqual({
+		lane: 'retention',
+		scheduledTime,
+		cron: '*/5 * * * *',
+	})
+})

--- a/packages/shared/src/jobs/scheduled-lanes.ts
+++ b/packages/shared/src/jobs/scheduled-lanes.ts
@@ -39,6 +39,62 @@ export type ScheduledLaneMessage = {
 }
 
 /**
+ * Isolated lane results shared by the jobs-worker consumer and origin
+ * `JobsHost.runScheduledLane`. `d1_lock_contention` is the only replay-safe
+ * transient outcome: the D1 write did not commit. `failed` may include
+ * partial external side effects (alerts, billing, Kit, DR), so the queue
+ * consumer must not retry it.
+ */
+export type ScheduledLaneOutcome = 'completed' | 'd1_lock_contention' | 'failed'
+
+export const scheduledDispatchMaxRetries = 3
+const scheduledDispatchRetryBaseDelaySeconds = 10
+const scheduledDispatchRetryDelayFactor = 3
+const scheduledDispatchRetryDelayCapSeconds = 90
+
+export type ScheduledLaneQueueAction =
+	| { action: 'ack'; reason: 'completed' }
+	| { action: 'ack'; reason: 'terminal_failure' }
+	| {
+			action: 'retry'
+			reason: 'transient_failure' | 'retry_exhausted'
+			delaySeconds: number
+	  }
+
+function scheduledDispatchRetryDelaySeconds(attempts: number) {
+	return Math.min(
+		scheduledDispatchRetryBaseDelaySeconds *
+			scheduledDispatchRetryDelayFactor ** Math.max(attempts - 1, 0),
+		scheduledDispatchRetryDelayCapSeconds,
+	)
+}
+
+export function resolveScheduledLaneQueueAction(input: {
+	outcome: ScheduledLaneOutcome
+	attempts: number
+}): ScheduledLaneQueueAction {
+	switch (input.outcome) {
+		case 'completed':
+			return { action: 'ack', reason: 'completed' }
+		case 'failed':
+			return { action: 'ack', reason: 'terminal_failure' }
+		case 'd1_lock_contention':
+			return {
+				action: 'retry',
+				reason:
+					input.attempts > scheduledDispatchMaxRetries
+						? 'retry_exhausted'
+						: 'transient_failure',
+				delaySeconds: scheduledDispatchRetryDelaySeconds(input.attempts),
+			}
+		default: {
+			const exhaustive: never = input.outcome
+			throw new Error(`Unhandled scheduled lane outcome: ${String(exhaustive)}`)
+		}
+	}
+}
+
+/**
  * Lanes the jobs worker executes locally (against its own database and
  * Durable Objects). Every other lane is forwarded to the main worker's
  * `JobsHost.runScheduledLane`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Keep scheduled maintenance ticks from being dropped on transient, replay-safe D1 lock contention so hourly/gated lanes do not wait a full cadence before the next attempt.

## Why

`runScheduledLaneWithFailureIsolation` already returns `completed` / `d1_lock_contention` / `failed`, including for forwarded platform lanes. `handleScheduledDispatchQueue` ignored that outcome and always `ack()`ed. Failed or lock-contended maintenance/watchdog/aggregation ticks were therefore discarded until the next eligible cron. This does not mean customer job definitions were lost; it is the isolated scheduled-lane consumer, not the job occurrence/lease contract.

The queue already has `max_retries: 3` and `kody-scheduled-dispatch-dlq`. Those settings only fired for unhandled consumer exceptions. Handled isolation outcomes never retried.

## Summary

- Named the existing three-way lane outcome as `ScheduledLaneOutcome` on the shared `JobsHost` contract.
- Added `resolveScheduledLaneQueueAction`: retry only `d1_lock_contention` (D1 write did not commit) with 10s / 30s / 90s backoff; `retry()` again on the last attempt so Cloudflare can DLQ; ack `completed`, `failed`, and invalid bodies.
- `failed` is intentionally not retried. Lanes may have already sent alerts, billed, synced Kit, or exported DR data.
- Inline fallback (missing queue or failed `send`) stays one-shot, keeps `scheduledTime`, and logs a non-completed outcome. Preview/local have no production queue.
- Customer job occurrence/lease behavior is unchanged.

## Testing

- Local `npm run validate` passed.
- Node unit: completed ack, lock-contention retry + backoff, terminal `failed` ack + log, invalid-body ack, retry exhaustion + Sentry, inline fallback `scheduledTime` / no extra retries, wrangler `max_retries` pin.
- Preview: origin + `kody-pr-2151-jobs` `/health` ok; seed `GET /account/jobs.json` 200 with `alarm.bindingAvailable: true`.
- Production deploy [34149112151](https://github.com/kentcdodds/kody/actions/runs/34149112151): sha-guard `deploy_jobs=true` `deploy_main=true`; **Deploy jobs worker success** (uploaded `kody-jobs`, health `commit=fb1e1529`); **Deploy to production success** (uploaded `kody-production`, https://kody.codes/health `commitSha=fb1e1529`). Platform/runtime correctly skipped.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `af8f4c3e` · **Head:** `74e6fe79`

**Classification:** extends — jobs-worker scheduled dispatch now honors isolated lane outcomes instead of always acknowledging.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `scheduled-cron` | surfaces | extends — queue consumer retries only replay-safe D1 lock contention |
| `jobs-worker` | surfaces | extends — scheduled dispatch consumer and shared outcome contract |

### Change flow

A cron tick still enqueues one message per due lane. The consumer now branches on the isolated outcome instead of always acknowledging.

```mermaid
sequenceDiagram
	participant scheduledCron as scheduled-cron
	participant jobsWorker as jobs-worker
	participant queue as kody-scheduled-dispatch
	scheduledCron->>jobsWorker: cron tick preserves scheduledTime
	jobsWorker->>queue: send one message per due lane
	queue->>jobsWorker: deliver lane message
	jobsWorker->>jobsWorker: isolate outcome completed, d1_lock_contention, or failed
	alt completed
		jobsWorker->>queue: ack
	else d1_lock_contention
		jobsWorker->>queue: retry with 10s, 30s, or 90s backoff
		Note over queue: attempt 4 retry goes to kody-scheduled-dispatch-dlq
	else failed or invalid body
		jobsWorker->>queue: ack as terminal, do not replay side effects
	end
```

### Invariants

Per-user job occurrence and lease claiming are unchanged. This PR only changes isolated maintenance-lane queue ack/retry.

</details>

<!-- system-recap:end -->

## Conductor report

- **Track:** scheduled-lane retries
- **STATUS:** shipped
- **Shipped:** https://github.com/kentcdodds/kody/pull/2151 squash-merged as `fb1e1529`
- **Evidence:**
  - Unit tests + local validate
  - Bugbot clean; CI green
  - Preview jobs worker `/health` + seed `/account/jobs.json`
  - Production deploy run 34149112151: `⏰ Deploy jobs worker` **success** (not skipped), `🚀 Deploy to production` **success** (not skipped)
  - Live `kody-jobs` `/health` commit `fb1e1529`; `https://kody.codes/health` commitSha `fb1e1529`
- **Remains:** none
- **Out of scope (other agents):** compute-overage billing, DR exporter, in-flight maintenance, public copy/privacy, token scopes, live signup, customer job trigger/disable

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-560324e6-8f51-4c51-bea7-cf23fe1fe824?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-560324e6-8f51-4c51-bea7-cf23fe1fe824&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Scheduled maintenance jobs now retry replay-safe database lock contention with delays of 10, 30, and 90 seconds.
  * Exhausted retries are routed to a dead-letter queue and trigger an alert for investigation.
  * Other handled failures and invalid messages are acknowledged as terminal, preventing unnecessary repeated processing.
  * Inline fallback processing remains sequential and does not retry failed dispatches.

* **Documentation**
  * Updated architecture and setup guidance to describe scheduled maintenance retry and failure-handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->