### PR TITLE
Make public signup copy follow invite, open, and waitlist

### DIFF
--- a/packages/worker/client/routes/blog-post.tsx
+++ b/packages/worker/client/routes/blog-post.tsx
@@ -18,6 +18,9 @@ import {
 } from '#client/route-loader.ts'
 import { readRouterPathname } from '#client/router-location.tsx'
 import { readJson } from '#client/routes/account-approval-shared.ts'
+import { fetchPublicAuthConfig } from '#client/social-sign-in.ts'
+import { publicSignupPrimaryCta } from '#universal/public-signup-copy.ts'
+import { parseSignupMode, type SignupMode } from '#universal/signup-mode.ts'
 import {
 	colors,
 	radius,
@@ -78,10 +81,13 @@ export async function blogPostRouteLoader(
 		return routeLoaderRedirect(`${url.pathname}${url.search}`)
 	}
 
-	const response = await fetch(routes.blogPostApi.href({ slug }), {
-		headers: { Accept: 'application/json' },
-		signal,
-	})
+	const [response, config] = await Promise.all([
+		fetch(routes.blogPostApi.href({ slug }), {
+			headers: { Accept: 'application/json' },
+			signal,
+		}),
+		fetchPublicAuthConfig(signal),
+	])
 	if (response.status === 404) {
 		throw new Error('Blog post not found.')
 	}
@@ -89,12 +95,16 @@ export async function blogPostRouteLoader(
 	if (!response.ok || !payload?.ok) {
 		throw new Error('Unable to load blog post.')
 	}
-	return { blogPost: payload }
+	return {
+		blogPost: payload,
+		signupMode: parseSignupMode(config?.signupMode),
+	}
 }
 
 export function BlogPostRoute(handle: Handle) {
 	let status: 'loading' | 'ready' | 'error' | 'not-found' = 'loading'
 	let post: BlogPostLoaderData | null = null
+	let signupMode: SignupMode = 'invite'
 	/** Slug that `post` / `status` currently describe; used to hide stale UI. */
 	let loadedSlug: string | null = null
 	const loadLatch = createRouteLoadLatch()
@@ -121,11 +131,15 @@ export function BlogPostRoute(handle: Handle) {
 	async function loadPost(slug: string, signal: AbortSignal) {
 		// Do not call handle.update() before the first await — see blog.tsx.
 		try {
-			const response = await fetch(routes.blogPostApi.href({ slug }), {
-				headers: { Accept: 'application/json' },
-				signal,
-			})
+			const [response, config] = await Promise.all([
+				fetch(routes.blogPostApi.href({ slug }), {
+					headers: { Accept: 'application/json' },
+					signal,
+				}),
+				fetchPublicAuthConfig(signal),
+			])
 			if (signal.aborted) return
+			signupMode = parseSignupMode(config?.signupMode)
 			if (response.status === 404) {
 				post = null
 				status = 'not-found'
@@ -158,6 +172,12 @@ export function BlogPostRoute(handle: Handle) {
 		}
 
 		const routeData = tryConsumeRouteLoaderData(handle, 'blogPost', currentHref)
+		const signupModeData = tryConsumeRouteLoaderData(
+			handle,
+			'signupMode',
+			currentHref,
+		)
+		if (signupModeData) signupMode = signupModeData
 		const appliedRouteData = Boolean(routeData?.ok)
 		if (routeData?.ok) {
 			post = routeData
@@ -204,6 +224,7 @@ export function BlogPostRoute(handle: Handle) {
 		const showError = status === 'error' && contentMatchesSlug
 		const showReady = status === 'ready' && post !== null && contentMatchesSlug
 		const showLoading = !showNotFound && !showError && !showReady
+		const signedOutCta = publicSignupPrimaryCta(signupMode)
 
 		if (showNotFound) {
 			return (
@@ -297,15 +318,19 @@ export function BlogPostRoute(handle: Handle) {
 									height={480}
 									alt=""
 								/>
-								<p>
-									Give your assistant a home of its own. Invite-only while we
-									grow the eucalyptus.
-								</p>
-								<a
-									href={`${routes.home.href()}#invite`}
-									mix={css(postCtaButtonCss)}
-								>
-									Join the waiting list
+								{signupMode === 'open' ? (
+									<p>
+										Give your assistant a home of its own. Create a free account
+										and start saving packages.
+									</p>
+								) : (
+									<p>
+										Give your assistant a home of its own. Invite-only while we
+										grow the eucalyptus.
+									</p>
+								)}
+								<a href={signedOutCta.href} mix={css(postCtaButtonCss)}>
+									{signedOutCta.label}
 								</a>
 							</div>
 						</footer>

--- a/packages/worker/client/routes/faq.tsx
+++ b/packages/worker/client/routes/faq.tsx
@@ -1,7 +1,18 @@
 import { type Handle, type RemixNode, css } from 'remix/ui'
+import { readCurrentRouterHref } from '#client/client-router.tsx'
+import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
+import { type RouteLoaderResult } from '#client/route-loader.ts'
 import { reveal } from '#client/reveal.ts'
+import { fetchPublicAuthConfig } from '#client/social-sign-in.ts'
 import { formatMinJobInterval, planLimits } from '#universal/plans.ts'
+import {
+	publicInviteSignupHref,
+	publicSignupHref,
+	publicWaitlistHref,
+	publicWaitlistSignupHref,
+} from '#universal/public-signup-copy.ts'
 import { routes } from '#universal/routes.ts'
+import { parseSignupMode, type SignupMode } from '#universal/signup-mode.ts'
 import {
 	layoutMaxWidths,
 	nativeDisclosureCss,
@@ -214,51 +225,107 @@ const faqItems: ReadonlyArray<FaqItem> = [
 			</>
 		),
 	},
-	{
-		id: 'get-started',
-		question: 'How do I get started?',
-		answer: (
-			<>
-				<p>
-					Read <a href={whatIsKodyHref}>What is Kody?</a> — it needs no account.
-					Then open <a href={routes.onboarding.href()}>Get started</a>, pick the
-					agent you want to connect, and complete OAuth.
-				</p>
-				<p>
-					This deployment may require an invite. Without a code you can join the
-					waiting list from <a href={routes.signup.href()}>Sign up</a>.
-				</p>
-			</>
-		),
-	},
 ]
 
-export function FaqRoute(_handle: Handle) {
-	return () => (
-		<section mix={css(faqCss)}>
-			<header mix={css(pageHeadCss)}>
-				<h1 data-rise style={{ '--rise': '0' }}>
-					Questions
-					<br />
-					before you <em>connect</em>.
-				</h1>
-				<p>Straight answers about what Kody is — and what it is not.</p>
-			</header>
-
-			<div mix={css(faqListCss)}>
-				{faqItems.map((item, index) => (
-					<details
-						key={item.id}
-						data-faq={item.id}
-						mix={[css(nativeDisclosureCss), reveal(index * 40)]}
-					>
-						<summary>{item.question}</summary>
-						<div>{item.answer}</div>
-					</details>
-				))}
-			</div>
-		</section>
+function renderGetStartedAnswer(signupMode: SignupMode) {
+	return (
+		<>
+			<p>
+				Read <a href={whatIsKodyHref}>What is Kody?</a> — it needs no account.
+				Then open <a href={routes.onboarding.href()}>Get started</a>, pick the
+				agent you want to connect, and complete OAuth.
+			</p>
+			{renderGetStartedSignupGuidance(signupMode)}
+		</>
 	)
+}
+
+function renderGetStartedSignupGuidance(signupMode: SignupMode) {
+	switch (signupMode) {
+		case 'open':
+			return (
+				<p>
+					Create a free account from <a href={publicSignupHref}>Sign up</a>.
+				</p>
+			)
+		case 'invite':
+			return (
+				<p>
+					Kody is invite-only. If you have a code, open{' '}
+					<a href={publicSignupHref}>Sign up</a>. Without a code you can join
+					the waiting list from the <a href={publicWaitlistHref}>home page</a>.
+				</p>
+			)
+		case 'waitlist':
+			return (
+				<p>
+					Join the waiting list from{' '}
+					<a href={publicWaitlistSignupHref}>Sign up</a>. If you have a code,{' '}
+					<a href={publicInviteSignupHref}>redeem it</a>.
+				</p>
+			)
+		default: {
+			const exhaustive: never = signupMode
+			return exhaustive
+		}
+	}
+}
+
+function getFaqItems(signupMode: SignupMode): ReadonlyArray<FaqItem> {
+	return [
+		...faqItems,
+		{
+			id: 'get-started',
+			question: 'How do I get started?',
+			answer: renderGetStartedAnswer(signupMode),
+		},
+	]
+}
+
+export async function faqRouteLoader(
+	_url: URL,
+	signal: AbortSignal,
+): Promise<RouteLoaderResult> {
+	const config = await fetchPublicAuthConfig(signal)
+	return { signupMode: parseSignupMode(config?.signupMode) }
+}
+
+export function FaqRoute(handle: Handle) {
+	let signupMode: SignupMode = 'invite'
+	return () => {
+		const href = readCurrentRouterHref(handle)
+		const loadedSignupMode = tryConsumeRouteLoaderData(
+			handle,
+			'signupMode',
+			href,
+		)
+		if (loadedSignupMode) signupMode = loadedSignupMode
+		return (
+			<section mix={css(faqCss)}>
+				<header mix={css(pageHeadCss)}>
+					<h1 data-rise style={{ '--rise': '0' }}>
+						Questions
+						<br />
+						before you <em>connect</em>.
+					</h1>
+					<p>Straight answers about what Kody is — and what it is not.</p>
+				</header>
+
+				<div mix={css(faqListCss)}>
+					{getFaqItems(signupMode).map((item, index) => (
+						<details
+							key={item.id}
+							data-faq={item.id}
+							mix={[css(nativeDisclosureCss), reveal(index * 40)]}
+						>
+							<summary>{item.question}</summary>
+							<div>{item.answer}</div>
+						</details>
+					))}
+				</div>
+			</section>
+		)
+	}
 }
 
 const faqCss = {

--- a/packages/worker/client/routes/home.tsx
+++ b/packages/worker/client/routes/home.tsx
@@ -18,7 +18,12 @@ import { reveal, revealPop } from '#client/reveal.ts'
 import { fetchPublicAuthConfig } from '#client/social-sign-in.ts'
 import { landingArtAttrs } from '#universal/landing-images.ts'
 import { homepageSignupPath } from '#universal/first-touch-attribution.ts'
-import { type SignupMode } from '#universal/signup-mode.ts'
+import {
+	publicCreateAccountLabel,
+	publicHaveCodeLabel,
+	publicJoinWaitlistLabel,
+} from '#universal/public-signup-copy.ts'
+import { parseSignupMode, type SignupMode } from '#universal/signup-mode.ts'
 import {
 	pickWalkthroughHosts,
 	type WalkthroughHostPick,
@@ -131,7 +136,7 @@ export async function homeRouteLoader(
 	const result: RouteLoaderResult = {}
 	if (onboarding) result.onboarding = onboarding
 	if (codeRuns) result.codeRuns = codeRuns
-	if (authConfig) result.signupMode = authConfig.signupMode
+	result.signupMode = parseSignupMode(authConfig?.signupMode)
 	result.walkthroughHosts = pickWalkthroughHosts()
 	return result
 }
@@ -173,7 +178,7 @@ export function HomeRoute(handle: Handle) {
 			if (signal.aborted) return
 			applyOnboardingPayload(payload)
 			applyCodeRunsPayload(codeRuns)
-			if (authConfig) signupMode = authConfig.signupMode
+			signupMode = parseSignupMode(authConfig?.signupMode)
 			if (!walkthroughHosts) walkthroughHosts = pickWalkthroughHosts()
 			loadLatch.markLoaded(href)
 			handle.update()
@@ -256,7 +261,7 @@ export function HomeRoute(handle: Handle) {
 						) : signupMode === 'open' ? (
 							<>
 								<a href={homepageSignupPath} class="landing-pill">
-									Create a free account
+									{publicCreateAccountLabel}
 								</a>
 								<a href="/login" class="landing-code-link">
 									I already have an account
@@ -265,10 +270,10 @@ export function HomeRoute(handle: Handle) {
 						) : (
 							<>
 								<a href="#invite" class="landing-pill">
-									Join the waiting list
+									{publicJoinWaitlistLabel}
 								</a>
 								<a href={homepageSignupPath} class="landing-code-link">
-									I have a code
+									{publicHaveCodeLabel}
 								</a>
 							</>
 						)}
@@ -559,7 +564,7 @@ export function HomeRoute(handle: Handle) {
 							</p>
 							<p class="landing-invite-cta">
 								<a href={homepageSignupPath} class="landing-pill">
-									Create a free account
+									{publicCreateAccountLabel}
 								</a>
 							</p>
 						</div>
@@ -572,7 +577,7 @@ export function HomeRoute(handle: Handle) {
 							<WaitlistForm />
 							<p class="landing-invite-code">
 								<a href={homepageSignupPath} class="landing-code-link">
-									I have a code
+									{publicHaveCodeLabel}
 								</a>
 							</p>
 						</>

--- a/packages/worker/client/routes/index.tsx
+++ b/packages/worker/client/routes/index.tsx
@@ -324,6 +324,10 @@ export const clientRouteLoaders: Record<string, RouteLoader> = {
 		marketingArea,
 		(m) => m.pricingRouteLoader,
 	),
+	[routePattern(routes.faq)]: lazyRouteLoader(
+		marketingArea,
+		(m) => m.faqRouteLoader,
+	),
 }
 
 export const clientRoutes = {

--- a/packages/worker/client/routes/marketing-area.ts
+++ b/packages/worker/client/routes/marketing-area.ts
@@ -1,5 +1,5 @@
 export { DiscordRoute, discordRouteLoader } from './discord.tsx'
-export { FaqRoute } from './faq.tsx'
+export { FaqRoute, faqRouteLoader } from './faq.tsx'
 export { PricingRoute, pricingRouteLoader } from './pricing.tsx'
 export { PrivacyRoute } from './privacy.tsx'
 export { SupportRoute } from './support.tsx'

--- a/packages/worker/client/routes/pricing.tsx
+++ b/packages/worker/client/routes/pricing.tsx
@@ -12,7 +12,11 @@ import {
 	planLimits,
 	type PlanLimits,
 } from '#universal/plans.ts'
-import { type SignupMode } from '#universal/signup-mode.ts'
+import {
+	publicSignupPrimaryCta,
+	type PublicSignupCta,
+} from '#universal/public-signup-copy.ts'
+import { parseSignupMode, type SignupMode } from '#universal/signup-mode.ts'
 import { colors, radius, typography } from '#universal/styles/tokens.ts'
 import {
 	getGhostButtonCss,
@@ -114,7 +118,7 @@ export async function pricingRouteLoader(
 	signal: AbortSignal,
 ): Promise<RouteLoaderResult> {
 	const config = await fetchPublicAuthConfig(signal)
-	return { signupMode: config?.signupMode ?? 'invite' }
+	return { signupMode: parseSignupMode(config?.signupMode) }
 }
 
 export function PricingRoute(handle: Handle) {
@@ -128,6 +132,7 @@ export function PricingRoute(handle: Handle) {
 			href,
 		)
 		if (loadedSignupMode) signupMode = loadedSignupMode
+		const signedOutCta = publicSignupPrimaryCta(signupMode)
 		return (
 			<section mix={css(pricingCss)}>
 				<header mix={css(pageHeadCss)}>
@@ -159,13 +164,9 @@ export function PricingRoute(handle: Handle) {
 							<a href="/account" mix={css(planPillButtonCss)}>
 								Open your account
 							</a>
-						) : signupMode === 'open' ? (
-							<a href="/signup" mix={css(planPillButtonCss)}>
-								Create a free account
-							</a>
 						) : (
-							<a href="/#invite" mix={css(planPillButtonCss)}>
-								Join the waiting list
+							<a href={signedOutCta.href} mix={css(planPillButtonCss)}>
+								{signedOutCta.label}
 							</a>
 						)}
 					</section>
@@ -190,7 +191,7 @@ export function PricingRoute(handle: Handle) {
 						<p mix={css(planCopyCss)}>
 							Same factory. More room for jobs, workflows, and daily volume.
 						</p>
-						{renderPaidPlanCta(isSignedIn)}
+						{renderPaidPlanCta(isSignedIn, signedOutCta)}
 					</section>
 
 					<section
@@ -208,7 +209,7 @@ export function PricingRoute(handle: Handle) {
 							Same factory. More room for storage, jobs, workflows, and daily
 							volume.
 						</p>
-						{renderPaidPlanCta(isSignedIn)}
+						{renderPaidPlanCta(isSignedIn, signedOutCta)}
 					</section>
 
 					{/*
@@ -300,13 +301,9 @@ export function PricingRoute(handle: Handle) {
 						<a href="/account" mix={css(limitsCtaButtonCss)}>
 							Open your account
 						</a>
-					) : signupMode === 'open' ? (
-						<a href="/signup" mix={css(limitsCtaButtonCss)}>
-							Create a free account
-						</a>
 					) : (
-						<a href="/#invite" mix={css(limitsCtaButtonCss)}>
-							Join the waiting list
+						<a href={signedOutCta.href} mix={css(limitsCtaButtonCss)}>
+							{signedOutCta.label}
 						</a>
 					)}
 				</p>
@@ -315,7 +312,7 @@ export function PricingRoute(handle: Handle) {
 	}
 }
 
-function renderPaidPlanCta(isSignedIn: boolean) {
+function renderPaidPlanCta(isSignedIn: boolean, signedOutCta: PublicSignupCta) {
 	if (isSignedIn) {
 		return (
 			<a href="/account/billing" mix={css(planGhostButtonCss)}>
@@ -324,8 +321,8 @@ function renderPaidPlanCta(isSignedIn: boolean) {
 		)
 	}
 	return (
-		<a href="/signup" mix={css(planGhostButtonCss)}>
-			Create a free account
+		<a href={signedOutCta.href} mix={css(planGhostButtonCss)}>
+			{signedOutCta.label}
 		</a>
 	)
 }

--- a/packages/worker/client/routes/public-signup-copy.node.test.ts
+++ b/packages/worker/client/routes/public-signup-copy.node.test.ts
@@ -1,0 +1,74 @@
+import { expect, test } from 'vitest'
+import { faqRouteLoader } from './faq.tsx'
+import { pricingRouteLoader } from './pricing.tsx'
+import { resolveSignupPanel } from './login-shared.ts'
+import {
+	publicInviteSignupHref,
+	publicSignupPrimaryCta,
+	publicWaitlistSignupHref,
+} from '#universal/public-signup-copy.ts'
+import { parseSignupMode } from '#universal/signup-mode.ts'
+import { routes } from '#universal/routes.ts'
+
+test('public signup destinations open the matching signup panel', () => {
+	const inviteUrl = new URL(publicInviteSignupHref, 'https://kody.codes')
+	expect(inviteUrl.pathname).toBe(routes.signup.href())
+	expect(resolveSignupPanel(inviteUrl.searchParams, 'waitlist')).toBe('invite')
+
+	const waitlistUrl = new URL(publicWaitlistSignupHref, 'https://kody.codes')
+	expect(waitlistUrl.pathname).toBe(routes.signup.href())
+	expect(resolveSignupPanel(waitlistUrl.searchParams, 'invite')).toBe(
+		'waiting-list',
+	)
+
+	expect(publicSignupPrimaryCta('open').href).toBe(routes.signup.href())
+	expect(publicSignupPrimaryCta('invite').href).toBe(
+		`${routes.home.href()}#invite`,
+	)
+	expect(publicSignupPrimaryCta('waitlist').href).toBe(
+		publicSignupPrimaryCta('invite').href,
+	)
+})
+
+test('FAQ and pricing loaders follow public auth config and fall back to invite', async () => {
+	const originalFetch = globalThis.fetch
+	const faqUrl = new URL('https://example.com/faq')
+	const pricingUrl = new URL('https://example.com/pricing')
+	const signal = new AbortController().signal
+
+	globalThis.fetch = async (input) => {
+		expect(String(input)).toContain('/auth/providers.json')
+		return Response.json({
+			ok: true,
+			signupMode: 'waitlist',
+			providers: [],
+			turnstileSiteKey: null,
+		})
+	}
+	try {
+		expect(await faqRouteLoader(faqUrl, signal)).toEqual({
+			signupMode: 'waitlist',
+		})
+		expect(await pricingRouteLoader(pricingUrl, signal)).toEqual({
+			signupMode: 'waitlist',
+		})
+	} finally {
+		globalThis.fetch = originalFetch
+	}
+
+	globalThis.fetch = async () => {
+		throw new Error('auth config unavailable')
+	}
+	try {
+		expect(await faqRouteLoader(faqUrl, signal)).toEqual({
+			signupMode: 'invite',
+		})
+		expect(await pricingRouteLoader(pricingUrl, signal)).toEqual({
+			signupMode: 'invite',
+		})
+		expect(parseSignupMode('not-a-mode')).toBe('invite')
+		expect(parseSignupMode(undefined)).toBe('invite')
+	} finally {
+		globalThis.fetch = originalFetch
+	}
+})

--- a/packages/worker/client/social-sign-in.ts
+++ b/packages/worker/client/social-sign-in.ts
@@ -1,4 +1,4 @@
-import { type SignupMode } from '#universal/signup-mode.ts'
+import { parseSignupMode, type SignupMode } from '#universal/signup-mode.ts'
 import {
 	appendAttributionQueryParams,
 	type FirstTouchAttribution,
@@ -49,10 +49,7 @@ export async function fetchPublicAuthConfig(
 				typeof (provider as AuthProviderInfo).id === 'string' &&
 				typeof (provider as AuthProviderInfo).label === 'string',
 		)
-		const signupMode: SignupMode =
-			payload.signupMode === 'open' || payload.signupMode === 'waitlist'
-				? payload.signupMode
-				: 'invite'
+		const signupMode = parseSignupMode(payload.signupMode)
 		const turnstileSiteKey =
 			typeof payload.turnstileSiteKey === 'string'
 				? payload.turnstileSiteKey

--- a/packages/worker/src/app/handlers/blog.tsx
+++ b/packages/worker/src/app/handlers/blog.tsx
@@ -3,6 +3,7 @@ import { bytesToBase64 } from '@kody-internal/shared/base64.ts'
 import { getAppBaseUrl } from '#worker/app-base-url.ts'
 import { type routes } from '#universal/routes.ts'
 import { renderAppPage } from '#app/ssr-render.tsx'
+import { resolveSignupMode } from '#app/signup-mode-setting.ts'
 import {
 	getBlogPost,
 	getReadNextBlogPost,
@@ -96,12 +97,17 @@ export function createBlogPostHandler(env: Env) {
 			}
 
 			const serverTiming: Array<ServerTimingEntry> = []
+			const [blogPost, signupMode] = await Promise.all([
+				toBlogPostLoaderData(env, post, serverTiming),
+				resolveSignupMode(env),
+			])
 			return withVaryAccept(
 				await renderAppPage({
 					request,
 					env,
 					loaderData: {
-						blogPost: await toBlogPostLoaderData(env, post, serverTiming),
+						blogPost,
+						signupMode,
 					},
 					serverTiming,
 				}),

--- a/packages/worker/src/app/handlers/faq.ts
+++ b/packages/worker/src/app/handlers/faq.ts
@@ -1,5 +1,6 @@
 import { type Action } from 'remix/router'
 import { renderAppPage } from '#app/ssr-render.tsx'
+import { resolveSignupMode } from '#app/signup-mode-setting.ts'
 import { type routes } from '#universal/routes.ts'
 
 export function createFaqHandler(env: Env) {
@@ -9,6 +10,9 @@ export function createFaqHandler(env: Env) {
 			return renderAppPage({
 				request,
 				env,
+				loaderData: {
+					signupMode: await resolveSignupMode(env),
+				},
 			})
 		},
 	} satisfies Action<typeof routes.faq>

--- a/packages/worker/src/app/public-signup-copy.node.test.ts
+++ b/packages/worker/src/app/public-signup-copy.node.test.ts
@@ -1,0 +1,299 @@
+import { expect, test } from 'vitest'
+import { setAuthSessionSecret } from '#app/auth-session.ts'
+import { resetDataCacheForTests } from '#app/data-cache.ts'
+import { createBlogPostHandler } from '#app/handlers/blog.tsx'
+import { createFaqHandler } from '#app/handlers/faq.ts'
+import { createPricingHandler } from '#app/handlers/pricing.ts'
+import { renderAppPage } from '#app/ssr-render.tsx'
+import { anonymousHtmlCacheControl } from '#app/anonymous-html-cache.ts'
+import { listBlogPosts } from '#worker/blog/catalog.ts'
+import { createMemoryKv } from '#worker/test-support/auth-provider-harness.ts'
+import { executePreparedD1Batch } from '#worker/test-support/d1-prepared-batch.ts'
+import { testOidcSigningEnv } from '#worker/test-support/oidc-signing-env.ts'
+import { homepageSignupPath } from '#universal/first-touch-attribution.ts'
+import { type SignupMode } from '#universal/signup-mode.ts'
+
+const testCookieSecret = 'test-cookie-secret-0123456789abcdef0123456789'
+
+function createAnonymousTestDb() {
+	function createStatement(query: string) {
+		const normalizedQuery = query.replace(/\s+/g, ' ').trim().toLowerCase()
+		const executeAll = async () => {
+			if (
+				normalizedQuery.includes('from feature_flags') ||
+				normalizedQuery.includes('from feature_flag_user_overrides')
+			) {
+				return {
+					results: [],
+					meta: { changes: 0, last_row_id: 0 },
+				}
+			}
+			return {
+				results: [],
+				meta: { changes: 0, last_row_id: 0 },
+			}
+		}
+		return {
+			query,
+			bind() {
+				return createStatement(query)
+			},
+			async all() {
+				return executeAll()
+			},
+			async first() {
+				const result = await executeAll()
+				return result.results[0] ?? null
+			},
+			async run() {
+				return { meta: { changes: 0, last_row_id: 0 } }
+			},
+		}
+	}
+
+	return {
+		prepare(query: string) {
+			return createStatement(query)
+		},
+		async batch(statements: Array<{ query?: string }>) {
+			return await executePreparedD1Batch(statements)
+		},
+		async exec() {
+			return
+		},
+	} as unknown as D1Database
+}
+
+function createTestEnv(signupMode?: SignupMode) {
+	return {
+		COOKIE_SECRET: testCookieSecret,
+		SECRET_STORE_KEY: 'LOCAL_TEST_SECRET_STORE_KEY_32_CHARS_MINIMUM',
+		...testOidcSigningEnv,
+		APP_DB: createAnonymousTestDb(),
+		BUNDLE_ARTIFACTS_KV: createMemoryKv(),
+		JOB_MANAGER: {},
+		STORAGE_RUNNER: {},
+		PACKAGE_REALTIME_SESSION: {},
+		MCP_CLIENT_HUB: {},
+		...(signupMode ? { SIGNUP_MODE: signupMode } : {}),
+	} as unknown as Env
+}
+
+function parseRmxData(html: string) {
+	const match = html.match(
+		/<script type="application\/json" id="rmx-data">([\s\S]*?)<\/script>/,
+	)
+	if (!match?.[1]) {
+		throw new Error('rmx-data script not found in HTML response')
+	}
+	return JSON.parse(match[1]) as {
+		h: Record<
+			string,
+			{
+				props: {
+					loaderData?: { signupMode?: SignupMode }
+				}
+			}
+		>
+	}
+}
+
+function readEmbeddedSignupMode(html: string) {
+	const rmxData = parseRmxData(html)
+	const entry = Object.values(rmxData.h)[0]
+	return entry?.props.loaderData?.signupMode
+}
+
+function faqGetStarted(html: string) {
+	return html.match(/data-faq="get-started"[\s\S]*?<\/details>/)?.[0] ?? ''
+}
+
+function namedSection(html: string, id: string) {
+	return (
+		html.match(
+			new RegExp(`<section[^>]*aria-labelledby="${id}"[\\s\\S]*?</section>`),
+		)?.[0] ?? ''
+	)
+}
+
+function anchors(html: string) {
+	return [
+		...html.matchAll(/<a\b[^>]*href="([^"]+)"[^>]*>([\s\S]*?)<\/a>/g),
+	].map(([, href, label]) => ({
+		href,
+		label: label.replace(/<[^>]+>/g, '').trim(),
+	}))
+}
+
+async function renderMarketing(path: string, signupMode?: SignupMode) {
+	resetDataCacheForTests()
+	setAuthSessionSecret(testCookieSecret)
+	const env = createTestEnv(signupMode)
+	const request = new Request(`https://example.com${path}`)
+	switch (path) {
+		case '/faq':
+			return createFaqHandler(env).handler({ request } as never)
+		case '/pricing':
+			return createPricingHandler(env).handler({ request } as never)
+		case '/':
+			return renderAppPage({
+				request,
+				env,
+				loaderData: { signupMode: signupMode ?? 'invite' },
+			})
+		default:
+			throw new Error(`unsupported path ${path}`)
+	}
+}
+
+test('FAQ, pricing, and home SSR copy follow invite, open, and waitlist destinations', async () => {
+	const inviteFaq = await (await renderMarketing('/faq', 'invite')).text()
+	const openFaq = await (await renderMarketing('/faq', 'open')).text()
+	const waitlistFaq = await (await renderMarketing('/faq', 'waitlist')).text()
+
+	expect(readEmbeddedSignupMode(inviteFaq)).toBe('invite')
+	expect(readEmbeddedSignupMode(openFaq)).toBe('open')
+	expect(readEmbeddedSignupMode(waitlistFaq)).toBe('waitlist')
+
+	const inviteStarted = faqGetStarted(inviteFaq)
+	expect(inviteStarted).toContain('Kody is invite-only')
+	expect(anchors(inviteStarted)).toEqual(
+		expect.arrayContaining([
+			expect.objectContaining({ href: '/signup', label: 'Sign up' }),
+			expect.objectContaining({ href: '/#invite', label: 'home page' }),
+		]),
+	)
+	expect(inviteStarted).not.toContain('panel=waiting-list')
+	expect(inviteStarted).not.toContain('panel=invite')
+
+	const openStarted = faqGetStarted(openFaq)
+	expect(openStarted).toContain('Create a free account from')
+	expect(anchors(openStarted)).toEqual(
+		expect.arrayContaining([
+			expect.objectContaining({ href: '/signup', label: 'Sign up' }),
+		]),
+	)
+	expect(openStarted).not.toContain('invite-only')
+	expect(openStarted).not.toContain('/#invite')
+
+	const waitlistStarted = faqGetStarted(waitlistFaq)
+	expect(waitlistStarted).toContain('Join the waiting list from')
+	expect(anchors(waitlistStarted)).toEqual(
+		expect.arrayContaining([
+			expect.objectContaining({
+				href: '/signup?panel=waiting-list',
+				label: 'Sign up',
+			}),
+			expect.objectContaining({
+				href: '/signup?panel=invite',
+				label: 'redeem it',
+			}),
+		]),
+	)
+	expect(waitlistStarted).not.toContain('invite-only')
+
+	const invitePricing = await (
+		await renderMarketing('/pricing', 'invite')
+	).text()
+	const openPricing = await (await renderMarketing('/pricing', 'open')).text()
+	const waitlistPricing = await (
+		await renderMarketing('/pricing', 'waitlist')
+	).text()
+
+	for (const planId of ['plan-free', 'plan-standard', 'plan-pro'] as const) {
+		expect(anchors(namedSection(invitePricing, planId))).toEqual(
+			expect.arrayContaining([
+				{ href: '/#invite', label: 'Join the waiting list' },
+			]),
+		)
+		expect(anchors(namedSection(openPricing, planId))).toEqual(
+			expect.arrayContaining([
+				{ href: '/signup', label: 'Create a free account' },
+			]),
+		)
+		expect(anchors(namedSection(waitlistPricing, planId))).toEqual(
+			expect.arrayContaining([
+				{ href: '/#invite', label: 'Join the waiting list' },
+			]),
+		)
+	}
+
+	const inviteHome = await (await renderMarketing('/', 'invite')).text()
+	const openHome = await (await renderMarketing('/', 'open')).text()
+	const waitlistHome = await (await renderMarketing('/', 'waitlist')).text()
+
+	expect(inviteHome).toContain('href="#invite"')
+	expect(inviteHome).toContain('Join the waiting list')
+	expect(inviteHome).toContain(homepageSignupPath.replaceAll('&', '&amp;'))
+	expect(inviteHome).toContain('I have a code')
+	expect(inviteHome).not.toContain('>Create a free account<')
+
+	expect(openHome).toContain(homepageSignupPath.replaceAll('&', '&amp;'))
+	expect(openHome).toContain('Create a free account')
+	expect(openHome).not.toContain('href="#invite"')
+	expect(openHome).not.toContain('Join the waiting list')
+
+	expect(waitlistHome).toContain('href="#invite"')
+	expect(waitlistHome).toContain('Join the waiting list')
+	expect(waitlistHome).toContain('I have a code')
+	expect(waitlistHome).not.toContain('>Create a free account<')
+})
+
+test('FAQ and pricing handlers keep anonymous cache rules while embedding signup mode', async () => {
+	resetDataCacheForTests()
+	setAuthSessionSecret(testCookieSecret)
+	const env = createTestEnv('open')
+
+	const faq = await createFaqHandler(env).handler({
+		request: new Request('https://example.com/faq'),
+	} as never)
+	const pricing = await createPricingHandler(env).handler({
+		request: new Request('https://example.com/pricing'),
+	} as never)
+
+	expect(faq.headers.get('Cache-Control')).toBe(anonymousHtmlCacheControl)
+	expect(faq.headers.get('Vary')).toBe('Cookie')
+	expect(pricing.headers.get('Cache-Control')).toBe(anonymousHtmlCacheControl)
+	expect(readEmbeddedSignupMode(await faq.text())).toBe('open')
+	expect(readEmbeddedSignupMode(await pricing.text())).toBe('open')
+})
+
+test('blog post closer follows the resolved signup mode', async () => {
+	resetDataCacheForTests()
+	setAuthSessionSecret(testCookieSecret)
+	const slug = listBlogPosts()[0]?.slug
+	expect(slug).toBeTruthy()
+	if (!slug) throw new Error('expected a catalog blog post')
+
+	const invite = await createBlogPostHandler(createTestEnv('invite')).handler({
+		request: new Request(`https://example.com/blog/${slug}`),
+		params: { slug },
+	} as never)
+	const open = await createBlogPostHandler(createTestEnv('open')).handler({
+		request: new Request(`https://example.com/blog/${slug}`),
+		params: { slug },
+	} as never)
+
+	const inviteHtml = await invite.text()
+	const openHtml = await open.text()
+	const inviteCta = inviteHtml.match(
+		/<div[^>]*>[\s\S]*Give your assistant a home[\s\S]*?<\/div>/,
+	)?.[0]
+	const openCta = openHtml.match(
+		/<div[^>]*>[\s\S]*Give your assistant a home[\s\S]*?<\/div>/,
+	)?.[0]
+
+	expect(inviteCta).toContain('Invite-only while we grow the eucalyptus')
+	expect(anchors(inviteCta ?? '')).toEqual(
+		expect.arrayContaining([
+			{ href: '/#invite', label: 'Join the waiting list' },
+		]),
+	)
+	expect(openCta).toContain('Create a free account and start saving packages')
+	expect(anchors(openCta ?? '')).toEqual(
+		expect.arrayContaining([
+			{ href: '/signup', label: 'Create a free account' },
+		]),
+	)
+	expect(openCta).not.toContain('Invite-only')
+})

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -40,6 +40,7 @@ import {
 import { getScrollRestorationInlineScript } from '#universal/router-scroll-restoration.ts'
 import type * as CommunityProfileRepo from '#worker/community/profile-repo.ts'
 import type * as PackageUrlModule from '#worker/community/package-url.ts'
+import { createMemoryKv } from '#worker/test-support/auth-provider-harness.ts'
 import { testOidcSigningEnv } from '#worker/test-support/oidc-signing-env.ts'
 
 const testCookieSecret = 'test-cookie-secret-0123456789abcdef0123456789'
@@ -218,7 +219,7 @@ function createTestEnv(db: D1Database) {
 		SECRET_STORE_KEY: 'LOCAL_TEST_SECRET_STORE_KEY_32_CHARS_MINIMUM',
 		...testOidcSigningEnv,
 		APP_DB: db,
-		BUNDLE_ARTIFACTS_KV: {},
+		BUNDLE_ARTIFACTS_KV: createMemoryKv(),
 		JOB_MANAGER: {},
 		STORAGE_RUNNER: {},
 		PACKAGE_REALTIME_SESSION: {},
@@ -1591,6 +1592,9 @@ test('renderAppPage renders the public FAQ page for anonymous visitors', async (
 	expect(html).toContain('<details')
 	expect(html).toContain('<summary>')
 	expect(html).toContain('href="/faq">FAQ</a>')
+	expect(html).toContain('data-faq="get-started"')
+	expect(html).toContain('Kody is invite-only')
+	expect(html).toContain('href="/#invite"')
 })
 
 test('renderAppPage renders the public support page for anonymous visitors', async () => {

--- a/packages/worker/universal/public-signup-copy.ts
+++ b/packages/worker/universal/public-signup-copy.ts
@@ -1,0 +1,35 @@
+import { routes } from './routes.ts'
+import { type SignupMode } from './signup-mode.ts'
+
+/**
+ * Shared public signup destinations and CTA labels. Marketing pages (home,
+ * pricing, FAQ, blog closer) consume these so invite / open / waitlist copy
+ * stays consistent. Legal privacy/terms wording is owned separately.
+ */
+export const publicWaitlistHref = `${routes.home.href()}#invite`
+export const publicSignupHref = routes.signup.href()
+export const publicInviteSignupHref = `${routes.signup.href()}?panel=invite`
+export const publicWaitlistSignupHref = `${routes.signup.href()}?panel=waiting-list`
+
+export const publicCreateAccountLabel = 'Create a free account'
+export const publicJoinWaitlistLabel = 'Join the waiting list'
+export const publicHaveCodeLabel = 'I have a code'
+
+export type PublicSignupCta = {
+	href: string
+	label: string
+}
+
+export function publicSignupPrimaryCta(mode: SignupMode): PublicSignupCta {
+	switch (mode) {
+		case 'open':
+			return { href: publicSignupHref, label: publicCreateAccountLabel }
+		case 'invite':
+		case 'waitlist':
+			return { href: publicWaitlistHref, label: publicJoinWaitlistLabel }
+		default: {
+			const exhaustive: never = mode
+			return exhaustive
+		}
+	}
+}

--- a/packages/worker/universal/signup-mode.ts
+++ b/packages/worker/universal/signup-mode.ts
@@ -14,6 +14,17 @@ export function isSignupMode(value: unknown): value is SignupMode {
 	return value === 'open' || value === 'waitlist' || value === 'invite'
 }
 
+/**
+ * Conservative public fallback: unknown or missing values resolve to invite
+ * so a stale payload cannot open signup copy.
+ */
+export function parseSignupMode(
+	value: unknown,
+	fallback: SignupMode = 'invite',
+): SignupMode {
+	return isSignupMode(value) ? value : fallback
+}
+
 export function getSignupMode(env: { SIGNUP_MODE?: SignupMode }): SignupMode {
-	return isSignupMode(env.SIGNUP_MODE) ? env.SIGNUP_MODE : 'invite'
+	return parseSignupMode(env.SIGNUP_MODE)
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Show the correct public signup copy and CTA destinations for the current invite / open / waitlist mode, ahead of launch.

## Why

Production is invite via env, and `adminSignupModeSet` can switch the live mode to open. FAQ hardcoded invite/waitlist language, pricing paid cards always said "Create a free account", and the blog closer was invite-only. Home and login already consumed the resolved mode. Those surfaces need to stay consistent without flipping production signup, changing Turnstile/auth admission, or adding a banner/admin primitive.

## Summary

- Shared public CTA destinations and labels in `#universal/public-signup-copy.ts` (legal privacy/terms wording stays with the sibling track).
- FAQ get-started copy and links now follow invite, open, and waitlist, including the right `/signup` panel and `/#invite` waitlist targets.
- Pricing free, paid, and bottom signed-out CTAs all use the same mode-aware destination.
- Blog post closer follows the same primary CTA. Home labels stay aligned without changing homepage UTM or `#invite` hash behavior.
- SSR handlers and client loaders consume existing `resolveSignupMode` / `/auth/providers.json`. Unknown payloads still fall back to invite. Anonymous cache rules are unchanged.

Out of scope: site banners (PR 2093), livestream/support redesign, privacy/terms files, production mode flip, admission/Turnstile semantics.

## Testing

- Focused node tests for FAQ / pricing / home / blog SSR copy and destinations in all three modes, plus client loader fetch + invite fallback and signup-panel URL contract.
- `npm run validate` green locally and on CI.
- Preview invite-mode HTML and browser pass on `/`, `/faq`, `/pricing`, `/blog/openclaw-2-needs-a-home`.
- Production after squash-merge: `/health` SHA `1c74729ff6b979b65384d0357893e19fa0489627`; live invite copy verified on those same routes.

## Conductor report

**Track:** launch invite-aware public copy  
**STATUS:** shipped  
**PR:** https://github.com/kentcdodds/kody/pull/2152  
**Merge:** squash `1c74729ff6b979b65384d0357893e19fa0489627`  
**Deploy:** https://github.com/kentcdodds/kody/actions/runs/34150489383  
**Health:** `kody.codes` commitSha `1c74729ff6b979b65384d0357893e19fa0489627`  
**Live pages (invite mode, unsigned):** home waitlist + I have a code; FAQ invite-only; pricing free/Standard/Pro/bottom all waitlist → `/#invite`; blog closer invite-only.  
**Held:** no production signup-mode flip; no Turnstile/admission; no banners (PR 2093); no privacy/terms; no DR / maintenance / billing / scheduling. Interactive Devin conductor cannot receive `createRun` wakeups — Discord plus this section is the report path.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `af8f4c3e` · **Head:** `3b1609d0`

**Classification:** composes — no primitives added or changed; this PR wires
existing resolved signup mode into more public marketing surfaces.

### Primitives touched

| Primitive | Group    | Impact                                                                 |
| --------- | -------- | ---------------------------------------------------------------------- |
| `app-ui`  | surfaces | composes — FAQ, pricing, home, and blog closer consume existing `signupMode` |

### Change flow

Anonymous marketing pages read the already-resolved signup mode and pick invite, open, or waitlist copy. SPA navigation uses the same public auth config.

```mermaid
sequenceDiagram
	actor Visitor
	participant appUi as app-ui
	Visitor->>appUi: GET /faq, /pricing, /blog/:slug, or /
	appUi->>appUi: resolveSignupMode from existing KV or env
	appUi-->>Visitor: embed loaderData.signupMode in SSR HTML
	Visitor->>appUi: SPA navigation to another marketing page
	appUi->>appUi: fetch /auth/providers.json
	appUi-->>Visitor: same mode-aware CTA href and label
	Note over appUi: unknown payloads fall back to invite
	Note over appUi: Cache-Control stays anonymous marketing HTML
```

### Invariants

Per-user isolation is untouched. Signup admission, Turnstile, and production `SIGNUP_MODE` are unchanged.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d9ffe120-22ee-4abb-bcd3-275ab883927c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d9ffe120-22ee-4abb-bcd3-275ab883927c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Marketing pages now adapt signup messaging and calls to action based on the available signup mode.
  * FAQ guidance varies for open signup, invite-only access, and waitlists.
  * Blog, homepage, and pricing CTAs now use mode-appropriate labels and destinations.
* **Bug Fixes**
  * Invalid or unavailable signup configuration now falls back consistently to invite-only messaging.
  * Signup links now direct visitors to the appropriate signup panel instead of fixed destinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->