### PR TITLE
Price compute overage invoices from active Standard overlays

### DIFF
--- a/docs/contributing/architecture/entitlements.md
+++ b/docs/contributing/architecture/entitlements.md
@@ -117,7 +117,7 @@ Standard/Pro/max and Stripe was not touched. There is no existing helper that
 extends a remaining Stripe period, and mutating `trial_end` / period end is
 payment-adjacent.
 
-`getUserEntitlement` overlays Standard through
+`getUserEntitlement` and compute-overage invoicing overlay Standard through
 `resolveEffectivePlanWithSecondAgentGift` while `expires_at` is in the future
 and the base rank is still below Standard. The gift never lowers a paid or
 manual grant. Expiry is read-time (no sweeper). Authorize completion and
@@ -158,8 +158,8 @@ referrer. An unverified party holds the qualifying invoice id on the pending
 row; email verification retries the grant. `/account/billing` shows the share
 link and simple referrer status.
 
-`getUserEntitlement` overlays Standard through the later of the second-agent
-gift and this referral credit.
+`getUserEntitlement` and compute-overage invoicing overlay Standard through the
+later of the second-agent gift and this referral credit.
 
 ### `max` plan limits
 
@@ -265,9 +265,12 @@ off is a hard gate — a per-user on override cannot charge. A percentage
 rollout is still globally on. Amounts below
 Stripe's $0.50
 USD minimum are recorded as `skip_below_minimum`, not invoiced. Includes are
-resolved from the plan and ladder at invoice time (UTC days 1–3); there is no
-month-end plan snapshot. D1 evaluation failures fail closed (no charges).
-Execute is a hard daily cap with no overage
+resolved from the effective plan and ladder at invoice time (UTC days 1–3),
+including an unexpired second-agent gift or referral Standard credit (the later
+of the two expiry columns, same helper as `getUserEntitlement`). There is no
+month-end plan snapshot; a plan or overlay that is expired when the job runs
+prices the prior month against the then-current includes. D1 evaluation failures
+fail closed (no charges). Execute is a hard daily cap with no overage
 (`computeMeteringPolicy.executeCallsPerDay`) — an execute overage would
 double-charge the same burn as unique worker days. Durable Object duration is
 unmetered; a later duration rate should stay list plus a thin markup. Overage is
@@ -610,15 +613,16 @@ wrapper and always returns a `PlanName`:
 1. Returns `free` when `userId` is absent (no warn).
 2. Returns `free` without touching D1 when `userId` is not a 64-char hex string
    (test fixtures and non-account ids).
-3. When email is present: reads
-   `SELECT plan, stripe_plan FROM users WHERE email = ? AND stable_user_id = ?`
-   and returns `resolveEffectivePlan(parseStoredPlanName(plan), stripe_plan)`. A
-   mismatched email/stable-id pair or missing row returns `free` (no warn).
-4. When email is absent/blank: reverse-resolves
-   `SELECT plan, stripe_plan FROM users WHERE stable_user_id = ?` so
-   package-job, workflow, webhook, and other background contexts that persist
-   `email: ''` still enforce the account's real plan. Missing rows return
-   `free`.
+3. When email is present: reads `plan`, `stripe_plan`, `entitlement_ladder`, and
+   the two Standard overlay expiry columns where
+   `email = ? AND stable_user_id = ?`, then returns
+   `resolveEffectivePlanWithSecondAgentGift` with `laterIsoTimestamp` of those
+   expiries. A mismatched email/stable-id pair or missing row returns `free` (no
+   warn).
+4. When email is absent/blank: reverse-resolves the same columns by
+   `stable_user_id` so package-job, workflow, webhook, and other background
+   contexts that persist `email: ''` still enforce the account's real plan.
+   Missing rows return `free`.
 
 Interactive surfaces still carry email (app sessions expose
 `user.mcpUser.email`, MCP caller contexts expose

--- a/packages/worker/src/billing/compute-overage-invoices.node.test.ts
+++ b/packages/worker/src/billing/compute-overage-invoices.node.test.ts
@@ -24,6 +24,8 @@ type Candidate = {
 	stripe_plan: string | null
 	entitlement_ladder: string | null
 	stripe_customer_id: string | null
+	second_agent_standard_gift_expires_at?: string | null
+	referral_standard_credit_expires_at?: string | null
 	uniqueWorkerDays: number
 	durableObjectRowsRead?: number
 }
@@ -132,7 +134,7 @@ function createBillingDb(input: {
 								,
 								,
 								,
-								,
+								totalCents,
 								disposition,
 								status,
 								,
@@ -148,6 +150,7 @@ function createBillingDb(input: {
 								userId,
 								month,
 								uniqueWorkerDays,
+								totalCents,
 								disposition,
 								status,
 								invoiceId,
@@ -697,4 +700,195 @@ test('ledger stores actual usage, not the include allotment', async () => {
 		status: 'skip_zero',
 		uniqueWorkerDays: 12,
 	})
+})
+
+test('invoice job prices includes from invoice-time Standard overlays', async () => {
+	const fetchStub = stripeInvoiceFetchStub({ createId: 'in_overlay_1' })
+	vi.stubGlobal('fetch', fetchStub)
+	try {
+		const invoiceNow = new Date('2026-09-02T12:00:00.000Z')
+		const activeThroughCatchUp = '2026-09-04T00:00:00.000Z'
+		const expiredAtMonthBoundary = '2026-09-01T00:00:00.000Z'
+		const expiredInPriorMonth = '2026-08-15T00:00:00.000Z'
+		const standardIncludeDays = planLimits.standard.maxUniqueWorkerDaysPerMonth
+		const overlayUser = (input: {
+			id: number
+			prefix: string
+			plan: string
+			stripePlan: string | null
+			ladder?: string
+			customerId: string | null
+			giftExpiresAt?: string | null
+			referralExpiresAt?: string | null
+			uniqueWorkerDays?: number
+		}): Candidate => ({
+			id: input.id,
+			stable_user_id: input.prefix.padEnd(64, '0'),
+			plan: input.plan,
+			stripe_plan: input.stripePlan,
+			entitlement_ladder: input.ladder ?? 'public',
+			stripe_customer_id: input.customerId,
+			second_agent_standard_gift_expires_at: input.giftExpiresAt ?? null,
+			referral_standard_credit_expires_at: input.referralExpiresAt ?? null,
+			uniqueWorkerDays: input.uniqueWorkerDays ?? standardIncludeDays,
+			durableObjectRowsRead: 0,
+		})
+
+		const { db, inserts } = createBillingDb({
+			candidates: [
+				overlayUser({
+					id: 21,
+					prefix: '01',
+					plan: 'free',
+					stripePlan: null,
+					customerId: 'cus_gift_active',
+					giftExpiresAt: activeThroughCatchUp,
+				}),
+				overlayUser({
+					id: 22,
+					prefix: '02',
+					plan: 'free',
+					stripePlan: null,
+					customerId: null,
+					giftExpiresAt: activeThroughCatchUp,
+				}),
+				overlayUser({
+					id: 23,
+					prefix: '03',
+					plan: 'free',
+					stripePlan: null,
+					customerId: 'cus_gift_expired',
+					giftExpiresAt: expiredInPriorMonth,
+				}),
+				overlayUser({
+					id: 24,
+					prefix: '04',
+					plan: 'free',
+					stripePlan: null,
+					customerId: null,
+					giftExpiresAt: expiredInPriorMonth,
+				}),
+				overlayUser({
+					id: 25,
+					prefix: '05',
+					plan: 'free',
+					stripePlan: null,
+					customerId: 'cus_referral_active',
+					referralExpiresAt: activeThroughCatchUp,
+				}),
+				overlayUser({
+					id: 26,
+					prefix: '06',
+					plan: 'free',
+					stripePlan: null,
+					customerId: 'cus_referral_expired',
+					referralExpiresAt: expiredInPriorMonth,
+				}),
+				overlayUser({
+					id: 27,
+					prefix: '07',
+					plan: 'free',
+					stripePlan: null,
+					customerId: 'cus_later_referral',
+					giftExpiresAt: expiredInPriorMonth,
+					referralExpiresAt: activeThroughCatchUp,
+				}),
+				overlayUser({
+					id: 28,
+					prefix: '08',
+					plan: 'free',
+					stripePlan: null,
+					customerId: 'cus_month_boundary',
+					giftExpiresAt: expiredAtMonthBoundary,
+				}),
+				overlayUser({
+					id: 29,
+					prefix: '09',
+					plan: 'standard',
+					stripePlan: 'standard',
+					customerId: 'cus_paid_standard',
+					giftExpiresAt: expiredInPriorMonth,
+					referralExpiresAt: expiredInPriorMonth,
+				}),
+				overlayUser({
+					id: 30,
+					prefix: '10',
+					plan: 'pro',
+					stripePlan: 'pro',
+					customerId: 'cus_paid_pro',
+					giftExpiresAt: activeThroughCatchUp,
+				}),
+				overlayUser({
+					id: 31,
+					prefix: '11',
+					plan: 'pro',
+					stripePlan: 'pro',
+					ladder: 'legacy',
+					customerId: 'cus_legacy',
+					giftExpiresAt: expiredInPriorMonth,
+					uniqueWorkerDays: planLimits.pro.maxUniqueWorkerDaysPerMonth + 100,
+				}),
+			],
+		})
+		const byPrefix = (prefix: string) =>
+			inserts.findLast((row) => row.userId === prefix.padEnd(64, '0'))
+		const result = await runComputeOverageBilling({
+			env: { APP_DB: db, STRIPE_SECRET_KEY: 'sk_test' } as Env,
+			now: invoiceNow,
+		})
+
+		expect(result).toMatchObject({
+			status: 'completed',
+			month: '2026-08',
+			scanned: 11,
+			invoiced: 3,
+			softBlocked: 1,
+			skippedLegacy: 1,
+		})
+		expect(byPrefix('01')).toMatchObject({
+			status: 'skip_zero',
+			totalCents: 0,
+		})
+		expect(byPrefix('02')).toMatchObject({
+			status: 'skip_zero',
+			totalCents: 0,
+		})
+		expect(byPrefix('03')).toMatchObject({
+			status: 'invoiced',
+			totalCents: 75,
+		})
+		expect(byPrefix('04')).toMatchObject({
+			status: 'soft_block',
+			totalCents: 75,
+		})
+		expect(byPrefix('05')).toMatchObject({
+			status: 'skip_zero',
+			totalCents: 0,
+		})
+		expect(byPrefix('06')).toMatchObject({
+			status: 'invoiced',
+			totalCents: 75,
+		})
+		expect(byPrefix('07')).toMatchObject({
+			status: 'skip_zero',
+			totalCents: 0,
+		})
+		expect(byPrefix('08')).toMatchObject({
+			status: 'invoiced',
+			totalCents: 75,
+		})
+		expect(byPrefix('09')).toMatchObject({
+			status: 'skip_zero',
+			totalCents: 0,
+		})
+		expect(byPrefix('10')).toMatchObject({
+			status: 'skip_zero',
+			totalCents: 0,
+		})
+		expect(byPrefix('11')).toMatchObject({
+			status: 'skip_legacy',
+		})
+	} finally {
+		vi.unstubAllGlobals()
+	}
 })

--- a/packages/worker/src/billing/compute-overage-invoices.ts
+++ b/packages/worker/src/billing/compute-overage-invoices.ts
@@ -8,9 +8,11 @@
  * get a UTC-month invoice and so this PR does not require new Stripe
  * price ids.
  *
- * Includes are resolved from the plan and ladder at invoice time (UTC
- * days 1–3). There is no month-end plan snapshot; a plan change before
- * the job runs prices the prior month against the current includes.
+ * Includes are resolved from the effective plan and ladder at invoice
+ * time (UTC days 1–3), including an unexpired second-agent gift or
+ * referral Standard credit. There is no month-end plan snapshot; a plan
+ * or overlay change before the job runs prices the prior month against
+ * the current includes.
  */
 import {
 	computeMonthlyOverage,
@@ -23,10 +25,11 @@ import {
 import {
 	parseEntitlementLadder,
 	parseStoredPlanName,
-	resolveEffectivePlan,
 	type EntitlementLadder,
 	type PlanName,
 } from '#universal/plans.ts'
+import { laterIsoTimestamp } from '#universal/referral-program.ts'
+import { resolveEffectivePlanWithSecondAgentGift } from '#universal/second-agent-standard-gift.ts'
 import { isBillingConfigured } from './billing-config.ts'
 import { isComputeOverageChargingEnabled } from './compute-overage-charging.ts'
 import {
@@ -78,6 +81,8 @@ type OverageUserRow = {
 	stripe_plan: string | null
 	entitlement_ladder: string | null
 	stripe_customer_id: string | null
+	second_agent_standard_gift_expires_at: string | null
+	referral_standard_credit_expires_at: string | null
 }
 
 type LedgerLookupRow = {
@@ -209,7 +214,9 @@ async function listOverageCandidates(input: {
 	const rows = await input.db
 		.prepare(
 			`SELECT DISTINCT u.id, u.stable_user_id, u.plan, u.stripe_plan,
-				u.entitlement_ladder, u.stripe_customer_id
+				u.entitlement_ladder, u.stripe_customer_id,
+				u.second_agent_standard_gift_expires_at,
+				u.referral_standard_credit_expires_at
 			 FROM users u
 			 LEFT JOIN usage_rollups r
 				ON r.user_id = u.stable_user_id
@@ -253,9 +260,14 @@ async function invoiceOneUserIfNeeded(input: {
 		return existing.status as ComputeOverageInvoiceStatus
 	}
 
-	const plan = resolveEffectivePlan(
+	const plan = resolveEffectivePlanWithSecondAgentGift(
 		parseStoredPlanName(input.user.plan),
 		input.user.stripe_plan,
+		laterIsoTimestamp(
+			input.user.second_agent_standard_gift_expires_at,
+			input.user.referral_standard_credit_expires_at,
+		),
+		input.now,
 	)
 	const ladder = parseEntitlementLadder(input.user.entitlement_ladder)
 	const usage = await readMonthlyComputeUsage({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Make compute-overage invoices charge the same included unique-worker-day and rows-read allotment that Account usage and entitlement enforcement already promise when a Free account has an active second-agent gift or referral Standard credit.

## Why

`compute-overage-invoices` selected only `plan`, `stripe_plan`, `entitlement_ladder`, and `stripe_customer_id`, then called `resolveEffectivePlan`. Entitlements and `/account` usage already compose `resolveEffectivePlanWithSecondAgentGift` with `laterIsoTimestamp` of the two overlay expiry columns. A public-ladder Free account with an active Standard overlay, 350 unique worker days, and zero rows-read showed **$0** on Account and **75 cents** at invoice time (300 days × $0.0025). With a Stripe customer that disposition is `invoice`; without one it is `soft_block`.

The currently audited active overlay had **no Stripe customer**, so this PR does not claim existing charges. Billing still runs UTC days 1–3 against invoice-time plan semantics (no month-end snapshot). Next cycle is October 1.

## Summary

- Select `second_agent_standard_gift_expires_at` and `referral_standard_credit_expires_at` with the overage candidate query.
- Resolve includes through the same later-overlay helper entitlements already use, evaluated at the job clock.
- Preserve paid Standard/Pro, legacy `no_cut_no_bill`, expired-overlay Free (customer → invoice 75¢, no customer → `soft_block`), and invoice-time month-boundary expiry.
- Garden entitlements docs so the promise / entitlement / invoice contract matches.

No Stripe charges, refunds, invoice edits, plan mutations, or charging-flag workarounds.

## Testing

- Added a regression covering active/expired second-agent gift, active/expired referral credit, later-of-two overlays, paid Standard/Pro, no-customer soft-block, legacy skip, and a Sept 1 expiry billed on Sept 2.
- `npx vitest run --project node-unit packages/worker/src/billing/compute-overage-invoices.node.test.ts` — 12 passed.
- `test:push` after rebase onto current `main`: 2843 node + 341 workers passed.

## System changes

Extends Stripe billing include resolution so invoice-time plan includes unexpired Standard overlays. Medium risk: money path, but no new primitive and no mutation of existing invoices.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `8a926d23` · **Head:** `1f13cb7d`

**Classification:** extends — compute-overage invoicing now prices includes from the same invoice-time Standard overlay entitlements already enforce.

### Primitives touched

| Primitive      | Group | Impact                                                                 |
| -------------- | ----- | ---------------------------------------------------------------------- |
| `billing`      | auth  | extends — invoice includes honor unexpired gift/referral Standard overlays |
| `entitlements` | auth  | composes — docs and call shape match `getUserEntitlement`              |

### Change flow

The monthly overage job reads overlay expiry columns and resolves the later unexpired Standard overlay before include math.

```mermaid
sequenceDiagram
	actor Job
	participant billing as billing
	participant entitlements as entitlements
	Job->>billing: runComputeOverageBilling on UTC days 1-3
	billing->>entitlements: laterIsoTimestamp of gift and referral expiries
	entitlements->>billing: resolveEffectivePlanWithSecondAgentGift at invoice now
	Note over billing: Includes follow the invoice-time effective plan
	billing->>billing: computeMonthlyOverage and disposition
```

### Before / after

| Case | Before | After |
| ---- | ------ | ----- |
| Free + active overlay, 350 UWD, customer | invoice 75¢ | `skip_zero` $0 |
| Free + active overlay, 350 UWD, no customer | `soft_block` 75¢ | `skip_zero` $0 |
| Free + expired overlay, 350 UWD, customer | invoice 75¢ | invoice 75¢ |
| Paid Standard/Pro or legacy | unchanged | unchanged |

### Invariants

Per-user isolation is unchanged. Existing invoices are not charged, refunded, or rewritten. Invoice-time plan semantics stay: no historical month-end snapshot.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-18d07d3b-1450-47ab-a672-89c7588a5654?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-18d07d3b-1450-47ab-a672-89c7588a5654&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Billing**
  - Compute-overage invoices now apply eligible Standard-plan benefits, including second-agent gifts and referral credits, when determining overage pricing.
  - Benefits are evaluated at invoice time and apply only while active, including correct handling of expiration at catch-up and month boundaries.
  - When multiple benefits are active, the later expiration date determines eligibility.

- **Documentation**
  - Updated entitlements documentation to clarify how Standard-plan overlays affect compute-overage invoicing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->