### PR TITLE
Traffic-backed hourly MCP execute health

### DIFF
--- a/docs/contributing/architecture/index.md
+++ b/docs/contributing/architecture/index.md
@@ -38,7 +38,12 @@ owns the `MCP` Durable Object (`kody-platform`). Origin
 `POST /__maintenance/execute-smoke` is **origin-only**: it uses origin
 `ctx.exports` and returns `scope: "origin-only"`,
 `proves: "origin-kody-fetch-gateway"`, and `notMcpExecute: true`. A passing
-smoke does not prove MCP execute health.
+smoke does not prove MCP execute health. Authenticated MCP execute evidence is a
+timestamp-only fleet heartbeat from successful execute completion, shown on
+`status.kody.codes` with source and last-verified time. When no organic success
+landed in the previous minute, the status worker runs at most one authenticated
+`POST /__maintenance/mcp-execute-health` per hour. `GET /health` and status-page
+reads stay cheap and never trigger that execute.
 
 ## Core docs
 

--- a/docs/contributing/architecture/request-lifecycle.md
+++ b/docs/contributing/architecture/request-lifecycle.md
@@ -102,7 +102,11 @@ Requests are handled in this order:
      `POST /__maintenance/execute-smoke` is **origin-only**: it uses origin
      `ctx.exports` and returns `scope: "origin-only"`,
      `proves: "origin-kody-fetch-gateway"`, and `notMcpExecute: true`. A passing
-     smoke does not prove MCP execute health.
+     smoke does not prove MCP execute health. Authenticated execute evidence is
+     the traffic-backed heartbeat plus the hourly
+     `POST /__maintenance/mcp-execute-health` fallback (legacy `/mcp` execute
+     with a dedicated canary token). Public health and status GETs do not run
+     that probe.
 7. Public `@username` ingress handled in `packages/worker/src/index.ts` before
    the OAuth provider / app router (needs `ExecutionContext` for background
    work). Production forwards package-invocation and package-app paths to

--- a/docs/contributing/setup-manifest.md
+++ b/docs/contributing/setup-manifest.md
@@ -333,6 +333,14 @@ through the Cloudflare Email REST API (from `ALERT_EMAIL_FROM` to
 `ALERT_EMAIL_TO`, both non-secret vars in `packages/status/wrangler.jsonc`).
 Without that secret, alert sends are skipped and logged.
 
+MCP execute evidence on the status page is a timestamp-only last-success
+heartbeat from real authenticated execute completions, plus at most one hourly
+synthetic when the last organic success is older than a minute. Public status
+GETs and origin `GET /health` never trigger that execute. The optional origin
+Worker secret `MCP_EXECUTE_HEALTH_CANARY_ACCESS_TOKEN` is a dedicated canary
+OAuth access token for the synthetic; when it is unset the fallback stays
+unknown rather than impersonating a customer.
+
 An optional Worker secret `STATUS_INCIDENT_EVENT_SECRET` (synced from the
 same-named GitHub Actions secret when present) is shared with the main worker.
 On incident open or resolve the status worker POSTs metadata to

--- a/packages/status/execute-health.node.test.ts
+++ b/packages/status/execute-health.node.test.ts
@@ -1,0 +1,215 @@
+import { expect, test } from 'vitest'
+import {
+	applyExecuteHealthTick,
+	claimExecuteHealthSynthetic,
+	countExecuteHealthSynthetics,
+	decideExecuteHealthProbe,
+	deriveExecuteHealthView,
+	executeHealthOrganicFreshMs,
+	executeHealthSyntheticCooldownMs,
+} from './execute-health.ts'
+
+const hourMs = executeHealthSyntheticCooldownMs
+const minuteMs = executeHealthOrganicFreshMs
+const start = Date.parse('2026-09-07T17:00:00.000Z')
+
+function ticks(count: number, stepMs = minuteMs) {
+	return Array.from({ length: count }, (_, index) => start + index * stepMs)
+}
+
+test('fresh organic success suppresses the synthetic and stale organic triggers once', () => {
+	expect(
+		decideExecuteHealthProbe({
+			now: start + 15_000,
+			lastSuccessAt: start,
+			lastSyntheticAttemptAt: null,
+		}),
+	).toBe('skip')
+	expect(
+		decideExecuteHealthProbe({
+			now: start + minuteMs,
+			lastSuccessAt: start,
+			lastSyntheticAttemptAt: null,
+		}),
+	).toBe('run')
+	expect(
+		claimExecuteHealthSynthetic({
+			now: start + minuteMs,
+			lastSuccessAt: start,
+			lastSyntheticAttemptAt: null,
+		}),
+	).toEqual({
+		run: true,
+		lastSyntheticAttemptAt: start + minuteMs,
+	})
+})
+
+test('no traffic across many minute ticks stays at most once per hour, and success and failure both obey cooldown', () => {
+	expect(
+		countExecuteHealthSynthetics({
+			ticks: ticks(59),
+			lastSuccessAt: null,
+		}),
+	).toBe(1)
+	expect(
+		countExecuteHealthSynthetics({
+			ticks: ticks(180),
+			lastSuccessAt: null,
+		}),
+	).toBe(3)
+	expect(
+		countExecuteHealthSynthetics({
+			ticks: ticks(61),
+			lastSuccessAt: null,
+		}),
+	).toBe(2)
+
+	const afterSuccess = claimExecuteHealthSynthetic({
+		now: start,
+		lastSuccessAt: null,
+		lastSyntheticAttemptAt: null,
+	})
+	expect(afterSuccess.run).toBe(true)
+	expect(
+		decideExecuteHealthProbe({
+			now: start + minuteMs,
+			lastSuccessAt: start,
+			lastSyntheticAttemptAt: afterSuccess.lastSyntheticAttemptAt,
+		}),
+	).toBe('skip')
+	expect(
+		decideExecuteHealthProbe({
+			now: start + 30_000,
+			lastSuccessAt: null,
+			lastSyntheticAttemptAt: afterSuccess.lastSyntheticAttemptAt,
+		}),
+	).toBe('skip')
+
+	const afterFailure = claimExecuteHealthSynthetic({
+		now: start,
+		lastSuccessAt: null,
+		lastSyntheticAttemptAt: null,
+	})
+	expect(
+		decideExecuteHealthProbe({
+			now: start + hourMs - 1,
+			lastSuccessAt: null,
+			lastSyntheticAttemptAt: afterFailure.lastSyntheticAttemptAt,
+		}),
+	).toBe('skip')
+	expect(
+		decideExecuteHealthProbe({
+			now: start + hourMs,
+			lastSuccessAt: null,
+			lastSyntheticAttemptAt: afterFailure.lastSyntheticAttemptAt,
+		}),
+	).toBe('run')
+})
+
+test('concurrent ticks cannot duplicate a synthetic', () => {
+	const first = claimExecuteHealthSynthetic({
+		now: start,
+		lastSuccessAt: null,
+		lastSyntheticAttemptAt: null,
+	})
+	const second = claimExecuteHealthSynthetic({
+		now: start,
+		lastSuccessAt: null,
+		lastSyntheticAttemptAt: first.lastSyntheticAttemptAt,
+	})
+	expect(first.run).toBe(true)
+	expect(second.run).toBe(false)
+	expect(second.lastSyntheticAttemptAt).toBe(start)
+})
+
+test('stale or missing telemetry is unknown, not an outage or a fresh healthy signal', () => {
+	const missing = deriveExecuteHealthView({
+		now: start,
+		lastSuccessAt: null,
+		lastSyntheticAttemptAt: null,
+		lastSyntheticSuccessAt: null,
+		lastSyntheticError: null,
+		syntheticConfigured: true,
+	})
+	expect(missing.status).toBe('unknown')
+	expect(missing.source).toBeNull()
+	expect(missing.lastVerifiedAt).toBeNull()
+	expect(missing.detail).toMatch(/not recently exercised/i)
+	expect(missing.detail).toMatch(/not an outage/i)
+	expect(missing.detail).not.toMatch(/operational|down|outage confirmed/i)
+
+	const stale = deriveExecuteHealthView({
+		now: start + 10 * minuteMs,
+		lastSuccessAt: start,
+		lastSyntheticAttemptAt: null,
+		lastSyntheticSuccessAt: null,
+		lastSyntheticError: null,
+		syntheticConfigured: true,
+	})
+	expect(stale.status).toBe('unknown')
+	expect(stale.source).toBe('organic')
+	expect(stale.lastVerifiedAt).toBe(new Date(start).toISOString())
+	expect(stale.freshnessMs).toBe(10 * minuteMs)
+	expect(stale.detail).toMatch(/not recently exercised/i)
+})
+
+test('caller failures are not automatically a global outage, and one organic success does not hide other incidents', () => {
+	const failedSynthetic = deriveExecuteHealthView({
+		now: start + minuteMs,
+		lastSuccessAt: null,
+		lastSyntheticAttemptAt: start,
+		lastSyntheticSuccessAt: null,
+		lastSyntheticError: 'MCP execute returned isError',
+		syntheticConfigured: true,
+	})
+	expect(failedSynthetic.status).toBe('unknown')
+	expect(failedSynthetic.detail).toMatch(/not an outage/i)
+	expect(failedSynthetic.detail).toMatch(/caller-code errors/i)
+
+	const organic = deriveExecuteHealthView({
+		now: start + 5_000,
+		lastSuccessAt: start,
+		lastSyntheticAttemptAt: null,
+		lastSyntheticSuccessAt: null,
+		lastSyntheticError: null,
+		syntheticConfigured: true,
+	})
+	expect(organic.status).toBe('recent')
+	expect(organic.source).toBe('organic')
+	expect(organic.lastVerifiedAt).toBe(new Date(start).toISOString())
+	expect(organic.detail).toMatch(/organic/i)
+})
+
+test('public reads do not run a synthetic; only a claimed tick can', async () => {
+	const runSynthetic = async () => {
+		throw new Error('public status GET must not run a paid execute')
+	}
+	const skipped = await applyExecuteHealthTick({
+		now: start + 15_000,
+		lastSuccessAt: start,
+		lastSyntheticAttemptAt: null,
+		lastSyntheticSuccessAt: null,
+		lastSyntheticError: null,
+		syntheticConfigured: true,
+		runSynthetic,
+	})
+	expect(skipped.lastSyntheticAttemptAt).toBeNull()
+
+	let runs = 0
+	const ran = await applyExecuteHealthTick({
+		now: start + minuteMs,
+		lastSuccessAt: start,
+		lastSyntheticAttemptAt: null,
+		lastSyntheticSuccessAt: null,
+		lastSyntheticError: null,
+		syntheticConfigured: true,
+		runSynthetic: async () => {
+			runs += 1
+			return { ok: false, error: 'timeout' }
+		},
+	})
+	expect(runs).toBe(1)
+	expect(ran.lastSyntheticAttemptAt).toBe(start + minuteMs)
+	expect(ran.lastSyntheticError).toBe('timeout')
+	expect(ran.lastSyntheticSuccessAt).toBeNull()
+})

--- a/packages/status/execute-health.node.test.ts
+++ b/packages/status/execute-health.node.test.ts
@@ -7,6 +7,7 @@ import {
 	deriveExecuteHealthView,
 	executeHealthOrganicFreshMs,
 	executeHealthSyntheticCooldownMs,
+	mergeExecuteLastSuccess,
 } from './execute-health.ts'
 
 const hourMs = executeHealthSyntheticCooldownMs
@@ -178,6 +179,71 @@ test('caller failures are not automatically a global outage, and one organic suc
 	expect(organic.source).toBe('organic')
 	expect(organic.lastVerifiedAt).toBe(new Date(start).toISOString())
 	expect(organic.detail).toMatch(/organic/i)
+})
+
+test('stale incoming last-success does not rewind a newer stored timestamp', () => {
+	expect(mergeExecuteLastSuccess(start, start + 10_000)).toBe(start + 10_000)
+	expect(mergeExecuteLastSuccess(start + 10_000, start)).toBe(start + 10_000)
+	expect(mergeExecuteLastSuccess(null, start)).toBe(start)
+	expect(mergeExecuteLastSuccess(start, null)).toBe(start)
+	expect(mergeExecuteLastSuccess(null, null)).toBeNull()
+})
+
+test('synthetic success plus heartbeat echo stays synthetic; later organic is organic', () => {
+	const syntheticAt = start
+	const heartbeatEchoAt = start + 2_000
+	const echoed = deriveExecuteHealthView({
+		now: start + 5_000,
+		lastSuccessAt: heartbeatEchoAt,
+		lastSyntheticAttemptAt: start,
+		lastSyntheticSuccessAt: syntheticAt,
+		lastSyntheticError: null,
+		syntheticConfigured: true,
+	})
+	expect(echoed.status).toBe('recent')
+	expect(echoed.source).toBe('synthetic')
+	expect(echoed.lastVerifiedAt).toBe(new Date(heartbeatEchoAt).toISOString())
+	expect(echoed.detail).toMatch(/hourly authenticated MCP execute probe/i)
+
+	const laterOrganic = deriveExecuteHealthView({
+		now: start + 3 * minuteMs,
+		lastSuccessAt: start + 2 * minuteMs,
+		lastSyntheticAttemptAt: start,
+		lastSyntheticSuccessAt: syntheticAt,
+		lastSyntheticError: null,
+		syntheticConfigured: true,
+	})
+	expect(laterOrganic.source).toBe('organic')
+	expect(laterOrganic.lastVerifiedAt).toBe(
+		new Date(start + 2 * minuteMs).toISOString(),
+	)
+})
+
+test('unconfigured fallback does not claim the hourly budget or hide the not-configured copy', async () => {
+	let runs = 0
+	const skipped = await applyExecuteHealthTick({
+		now: start + minuteMs,
+		lastSuccessAt: null,
+		lastSyntheticAttemptAt: null,
+		lastSyntheticSuccessAt: null,
+		lastSyntheticError: null,
+		syntheticConfigured: false,
+		runSynthetic: async () => {
+			runs += 1
+			return { ok: false, error: 'not-configured' }
+		},
+	})
+	expect(runs).toBe(0)
+	expect(skipped.lastSyntheticAttemptAt).toBeNull()
+	expect(skipped.lastSyntheticError).toBeNull()
+
+	const view = deriveExecuteHealthView({
+		now: start + minuteMs,
+		...skipped,
+	})
+	expect(view.status).toBe('unknown')
+	expect(view.detail).toMatch(/not configured/i)
+	expect(view.detail).not.toMatch(/last synthetic attempt failed/i)
 })
 
 test('public reads do not run a synthetic; only a claimed tick can', async () => {

--- a/packages/status/execute-health.ts
+++ b/packages/status/execute-health.ts
@@ -1,0 +1,213 @@
+/**
+ * Traffic-backed MCP execute evidence for the public status page.
+ *
+ * Cheap per-minute probes stay as they are. A successful real MCP execute
+ * completion in the previous minute is enough positive evidence to skip a
+ * synthetic. Otherwise the status worker runs at most one authenticated
+ * MCP execute per rolling hour. Failed attempts consume that budget.
+ *
+ * Missing or stale telemetry is unknown / not recently exercised — not an
+ * outage and not proof the path is freshly healthy. One organic success
+ * does not override other measured component incidents.
+ */
+
+export const executeHealthOrganicFreshMs = 60_000
+export const executeHealthSyntheticCooldownMs = 60 * 60 * 1000
+
+export type ExecuteHealthSource = 'organic' | 'synthetic'
+export type ExecuteHealthStatus = 'recent' | 'unknown'
+
+export type ExecuteHealthSnapshot = {
+	status: ExecuteHealthStatus
+	source: ExecuteHealthSource | null
+	lastVerifiedAt: string | null
+	freshnessMs: number | null
+	detail: string
+}
+
+export type ExecuteHealthCoordinatorState = {
+	lastSuccessAt: number | null
+	lastSyntheticAttemptAt: number | null
+	lastSyntheticSuccessAt: number | null
+	lastSyntheticError: string | null
+	syntheticConfigured: boolean
+}
+
+export function decideExecuteHealthProbe(input: {
+	now: number
+	lastSuccessAt: number | null
+	lastSyntheticAttemptAt: number | null
+}): 'skip' | 'run' {
+	if (
+		input.lastSuccessAt !== null &&
+		input.now - input.lastSuccessAt < executeHealthOrganicFreshMs
+	) {
+		return 'skip'
+	}
+	if (
+		input.lastSyntheticAttemptAt !== null &&
+		input.now - input.lastSyntheticAttemptAt < executeHealthSyntheticCooldownMs
+	) {
+		return 'skip'
+	}
+	return 'run'
+}
+
+export function claimExecuteHealthSynthetic(input: {
+	now: number
+	lastSuccessAt: number | null
+	lastSyntheticAttemptAt: number | null
+}): {
+	run: boolean
+	lastSyntheticAttemptAt: number | null
+} {
+	if (decideExecuteHealthProbe(input) === 'skip') {
+		return {
+			run: false,
+			lastSyntheticAttemptAt: input.lastSyntheticAttemptAt,
+		}
+	}
+	return {
+		run: true,
+		lastSyntheticAttemptAt: input.now,
+	}
+}
+
+export function countExecuteHealthSynthetics(input: {
+	ticks: ReadonlyArray<number>
+	lastSuccessAt: number | null
+	initialLastSyntheticAttemptAt?: number | null
+}): number {
+	let lastSyntheticAttemptAt = input.initialLastSyntheticAttemptAt ?? null
+	let runs = 0
+	for (const now of input.ticks) {
+		const claim = claimExecuteHealthSynthetic({
+			now,
+			lastSuccessAt: input.lastSuccessAt,
+			lastSyntheticAttemptAt,
+		})
+		lastSyntheticAttemptAt = claim.lastSyntheticAttemptAt
+		if (claim.run) runs += 1
+	}
+	return runs
+}
+
+export async function applyExecuteHealthTick(input: {
+	now: number
+	lastSuccessAt: number | null
+	lastSyntheticAttemptAt: number | null
+	lastSyntheticSuccessAt: number | null
+	lastSyntheticError: string | null
+	syntheticConfigured: boolean
+	runSynthetic: () => Promise<{ ok: boolean; error?: string | null }>
+}): Promise<ExecuteHealthCoordinatorState> {
+	const claim = claimExecuteHealthSynthetic({
+		now: input.now,
+		lastSuccessAt: input.lastSuccessAt,
+		lastSyntheticAttemptAt: input.lastSyntheticAttemptAt,
+	})
+	if (!claim.run) {
+		return {
+			lastSuccessAt: input.lastSuccessAt,
+			lastSyntheticAttemptAt: claim.lastSyntheticAttemptAt,
+			lastSyntheticSuccessAt: input.lastSyntheticSuccessAt,
+			lastSyntheticError: input.lastSyntheticError,
+			syntheticConfigured: input.syntheticConfigured,
+		}
+	}
+	const result = await input.runSynthetic()
+	return {
+		lastSuccessAt: input.lastSuccessAt,
+		lastSyntheticAttemptAt: claim.lastSyntheticAttemptAt,
+		lastSyntheticSuccessAt: result.ok
+			? input.now
+			: input.lastSyntheticSuccessAt,
+		lastSyntheticError: result.ok ? null : (result.error ?? 'probe-failed'),
+		syntheticConfigured: input.syntheticConfigured,
+	}
+}
+
+export function deriveExecuteHealthView(
+	input: ExecuteHealthCoordinatorState & { now: number },
+): ExecuteHealthSnapshot {
+	const lastVerifiedAtMs = newerTimestamp(
+		input.lastSuccessAt,
+		input.lastSyntheticSuccessAt,
+	)
+	const source = executeHealthSource(input, lastVerifiedAtMs)
+	const freshnessMs =
+		lastVerifiedAtMs === null ? null : Math.max(0, input.now - lastVerifiedAtMs)
+	const recent =
+		freshnessMs !== null && freshnessMs < executeHealthOrganicFreshMs
+	return {
+		status: recent ? 'recent' : 'unknown',
+		source: lastVerifiedAtMs === null ? null : source,
+		lastVerifiedAt:
+			lastVerifiedAtMs === null
+				? null
+				: new Date(lastVerifiedAtMs).toISOString(),
+		freshnessMs,
+		detail: executeHealthDetail({
+			...input,
+			recent,
+			source: lastVerifiedAtMs === null ? null : source,
+			freshnessMs,
+		}),
+	}
+}
+
+function newerTimestamp(
+	left: number | null,
+	right: number | null,
+): number | null {
+	if (left === null) return right
+	if (right === null) return left
+	return Math.max(left, right)
+}
+
+function executeHealthSource(
+	input: Pick<
+		ExecuteHealthCoordinatorState,
+		'lastSuccessAt' | 'lastSyntheticSuccessAt'
+	>,
+	lastVerifiedAtMs: number | null,
+): ExecuteHealthSource | null {
+	if (lastVerifiedAtMs === null) return null
+	if (input.lastSyntheticSuccessAt === lastVerifiedAtMs) return 'synthetic'
+	if (input.lastSuccessAt === lastVerifiedAtMs) return 'organic'
+	return null
+}
+
+function executeHealthDetail(input: {
+	recent: boolean
+	source: ExecuteHealthSource | null
+	freshnessMs: number | null
+	lastSyntheticAttemptAt: number | null
+	lastSyntheticError: string | null
+	syntheticConfigured: boolean
+}): string {
+	if (input.recent && input.source === 'organic') {
+		return `Verified by organic MCP execute traffic ${formatFreshness(input.freshnessMs)}.`
+	}
+	if (input.recent && input.source === 'synthetic') {
+		return `Verified by the hourly authenticated MCP execute probe ${formatFreshness(input.freshnessMs)}.`
+	}
+	if (input.lastSyntheticError) {
+		return `Not recently exercised. Last synthetic attempt failed; missing telemetry is not an outage. Caller-code errors are not a platform outage.`
+	}
+	if (!input.syntheticConfigured) {
+		return 'Not recently exercised. Synthetic fallback is not configured. Missing telemetry is not an outage.'
+	}
+	return 'Not recently exercised. Missing or stale telemetry is not an outage and is not proof the path is freshly healthy.'
+}
+
+function formatFreshness(freshnessMs: number | null): string {
+	if (freshnessMs === null) return 'just now'
+	if (freshnessMs < 1_000) return 'just now'
+	if (freshnessMs < 60_000) {
+		const seconds = Math.floor(freshnessMs / 1_000)
+		return `${String(seconds)}s ago`
+	}
+	const minutes = Math.floor(freshnessMs / 60_000)
+	return `${String(minutes)}m ago`
+}

--- a/packages/status/execute-health.ts
+++ b/packages/status/execute-health.ts
@@ -14,8 +14,8 @@
 export const executeHealthOrganicFreshMs = 60_000
 export const executeHealthSyntheticCooldownMs = 60 * 60 * 1000
 
-export type ExecuteHealthSource = 'organic' | 'synthetic'
-export type ExecuteHealthStatus = 'recent' | 'unknown'
+type ExecuteHealthSource = 'organic' | 'synthetic'
+type ExecuteHealthStatus = 'recent' | 'unknown'
 
 export type ExecuteHealthSnapshot = {
 	status: ExecuteHealthStatus

--- a/packages/status/execute-health.ts
+++ b/packages/status/execute-health.ts
@@ -33,6 +33,13 @@ export type ExecuteHealthCoordinatorState = {
 	syntheticConfigured: boolean
 }
 
+export function mergeExecuteLastSuccess(
+	incoming: number | null,
+	stored: number | null,
+): number | null {
+	return newerTimestamp(incoming, stored)
+}
+
 export function decideExecuteHealthProbe(input: {
 	now: number
 	lastSuccessAt: number | null
@@ -101,6 +108,15 @@ export async function applyExecuteHealthTick(input: {
 	syntheticConfigured: boolean
 	runSynthetic: () => Promise<{ ok: boolean; error?: string | null }>
 }): Promise<ExecuteHealthCoordinatorState> {
+	if (!input.syntheticConfigured) {
+		return {
+			lastSuccessAt: input.lastSuccessAt,
+			lastSyntheticAttemptAt: input.lastSyntheticAttemptAt,
+			lastSyntheticSuccessAt: input.lastSyntheticSuccessAt,
+			lastSyntheticError: input.lastSyntheticError,
+			syntheticConfigured: false,
+		}
+	}
 	const claim = claimExecuteHealthSynthetic({
 		now: input.now,
 		lastSuccessAt: input.lastSuccessAt,
@@ -173,7 +189,18 @@ function executeHealthSource(
 	lastVerifiedAtMs: number | null,
 ): ExecuteHealthSource | null {
 	if (lastVerifiedAtMs === null) return null
-	if (input.lastSyntheticSuccessAt === lastVerifiedAtMs) return 'synthetic'
+	if (input.lastSyntheticSuccessAt !== null) {
+		if (input.lastSyntheticSuccessAt === lastVerifiedAtMs) return 'synthetic'
+		// The canary execute also writes the fleet heartbeat a moment later.
+		// That echo is still the synthetic, not organic traffic.
+		if (
+			input.lastSuccessAt === lastVerifiedAtMs &&
+			lastVerifiedAtMs - input.lastSyntheticSuccessAt <
+				executeHealthOrganicFreshMs
+		) {
+			return 'synthetic'
+		}
+	}
 	if (input.lastSuccessAt === lastVerifiedAtMs) return 'organic'
 	return null
 }
@@ -192,11 +219,14 @@ function executeHealthDetail(input: {
 	if (input.recent && input.source === 'synthetic') {
 		return `Verified by the hourly authenticated MCP execute probe ${formatFreshness(input.freshnessMs)}.`
 	}
+	if (
+		!input.syntheticConfigured ||
+		input.lastSyntheticError === 'not-configured'
+	) {
+		return 'Not recently exercised. Synthetic fallback is not configured. Missing telemetry is not an outage.'
+	}
 	if (input.lastSyntheticError) {
 		return `Not recently exercised. Last synthetic attempt failed; missing telemetry is not an outage. Caller-code errors are not a platform outage.`
-	}
-	if (!input.syntheticConfigured) {
-		return 'Not recently exercised. Synthetic fallback is not configured. Missing telemetry is not an outage.'
 	}
 	return 'Not recently exercised. Missing or stale telemetry is not an outage and is not proof the path is freshly healthy.'
 }

--- a/packages/status/probes.node.test.ts
+++ b/packages/status/probes.node.test.ts
@@ -63,6 +63,9 @@ function healthyRoutes(): Record<string, FakeRoute> {
 					{ id: 'kv', ok: true, latencyMs: 2 },
 					{ id: 'assets', ok: true, latencyMs: 9 },
 				],
+				executeEvidence: {
+					lastSuccessAt: '2026-09-07T17:00:00.000Z',
+				},
 			},
 		},
 	}
@@ -99,6 +102,9 @@ test('a fully healthy pass reports every component ok', async () => {
 		'def4567890abcdef1234567890abcdef12345678',
 	)
 	expect(result.jobsCommitSha).toBe('7890abcdef1234567890abcdef1234567890abcd')
+	expect(result.executeLastSuccessAt).toBe(
+		Date.parse('2026-09-07T17:00:00.000Z'),
+	)
 })
 
 test('apex 302 is not package-runtime up; jobs probe failure is not app-down', async () => {
@@ -212,6 +218,7 @@ test('probe failures isolate to the affected component and map error details', a
 	})
 	expect(outcome(componentOutcomes, 'kv')?.ok).toBe(true)
 	expect(outcome(componentOutcomes, 'assets')?.ok).toBe(true)
+	expect(componentOutcomes.executeLastSuccessAt).toBeNull()
 
 	const unreachable = healthyRoutes()
 	unreachable[`${primaryOrigin}/health`] = { error: 'connection refused' }

--- a/packages/status/probes.ts
+++ b/packages/status/probes.ts
@@ -9,7 +9,9 @@ import {
  * cover the worker surfaces (app, MCP, package runtime, jobs); the
  * `/health/components` endpoint on the main worker reports storage bindings.
  * Only product-affecting bindings become public cards (`app_db`, `kv`,
- * `assets`). Jobs is reached over a service binding (or an optional
+ * `assets`). `/health/components` may also carry timestamp-only MCP execute
+ * evidence; that field is observational and never starts a paid execute.
+ * Jobs is reached over a service binding (or an optional
  * non-public origin fallback), never through the main app and never via a
  * user-facing jobs hostname.
  */
@@ -37,6 +39,9 @@ type HealthComponentsBody = {
 		latencyMs?: number
 		error?: string
 	}>
+	executeEvidence?: {
+		lastSuccessAt?: string | null
+	}
 }
 
 const componentEndpointIds = [
@@ -269,38 +274,60 @@ async function probeJobs(
 async function probeStorageComponents(
 	fetcher: typeof fetch,
 	primaryOrigin: string,
-): Promise<Array<ProbeOutcome>> {
+): Promise<{
+	outcomes: Array<ProbeOutcome>
+	executeLastSuccessAt: number | null
+}> {
 	const result = await timedFetch(fetcher, `${primaryOrigin}/health/components`)
 	if (!result.response) {
-		return componentEndpointIds.map((component) => ({
-			component,
-			ok: false,
-			latencyMs: null,
-			detail: 'unreachable',
-		}))
+		return {
+			outcomes: componentEndpointIds.map((component) => ({
+				component,
+				ok: false,
+				latencyMs: null,
+				detail: 'unreachable',
+			})),
+			executeLastSuccessAt: null,
+		}
 	}
 	const body = await readJsonBody<HealthComponentsBody>(result.response)
 	if (!body || !Array.isArray(body.components)) {
-		return componentEndpointIds.map((component) => ({
-			component,
-			ok: false,
-			latencyMs: null,
-			detail: `HTTP ${result.response.status}`,
-		}))
-	}
-	return componentEndpointIds.map((component) => {
-		const reported = body.components?.find((entry) => entry.id === component)
-		if (!reported) {
-			return { component, ok: false, latencyMs: null, detail: 'unreported' }
-		}
 		return {
-			component,
-			ok: reported.ok === true,
-			latencyMs:
-				typeof reported.latencyMs === 'number' ? reported.latencyMs : null,
-			detail: reported.ok === true ? null : (reported.error ?? 'error'),
+			outcomes: componentEndpointIds.map((component) => ({
+				component,
+				ok: false,
+				latencyMs: null,
+				detail: `HTTP ${result.response.status}`,
+			})),
+			executeLastSuccessAt: null,
 		}
-	})
+	}
+	return {
+		outcomes: componentEndpointIds.map((component) => {
+			const reported = body.components?.find((entry) => entry.id === component)
+			if (!reported) {
+				return { component, ok: false, latencyMs: null, detail: 'unreported' }
+			}
+			return {
+				component,
+				ok: reported.ok === true,
+				latencyMs:
+					typeof reported.latencyMs === 'number' ? reported.latencyMs : null,
+				detail: reported.ok === true ? null : (reported.error ?? 'error'),
+			}
+		}),
+		executeLastSuccessAt: parseExecuteLastSuccessAt(
+			body.executeEvidence?.lastSuccessAt,
+		),
+	}
+}
+
+function parseExecuteLastSuccessAt(
+	value: string | null | undefined,
+): number | null {
+	if (!value) return null
+	const parsed = Date.parse(value)
+	return Number.isFinite(parsed) ? parsed : null
 }
 
 export type ProbeRunResult = {
@@ -308,6 +335,7 @@ export type ProbeRunResult = {
 	productionCommitSha: string | null
 	runtimeCommitSha: string | null
 	jobsCommitSha: string | null
+	executeLastSuccessAt: number | null
 }
 
 export async function runAllProbes(
@@ -328,7 +356,7 @@ export async function runAllProbes(
 		mcp,
 		packageRuntime.outcome,
 		jobs.outcome,
-		...storage,
+		...storage.outcomes,
 	]
 	const covered = new Set(outcomes.map((outcome) => outcome.component))
 	for (const component of statusComponentIds) {
@@ -346,5 +374,6 @@ export async function runAllProbes(
 		productionCommitSha: app.productionCommitSha,
 		runtimeCommitSha: packageRuntime.runtimeCommitSha,
 		jobsCommitSha: jobs.jobsCommitSha,
+		executeLastSuccessAt: storage.executeLastSuccessAt,
 	}
 }

--- a/packages/status/readme.md
+++ b/packages/status/readme.md
@@ -15,6 +15,13 @@ deploys, code, or database are broken (see decision record 0004).
     `status: "ok"`; an apex 302 is not up)
   - jobs-worker `GET /health` and `GET /health/components` over a service
     binding (no public jobs hostname; JOBS_DB rides on the Jobs component)
+  - MCP execute evidence: a successful authenticated execute completion in the
+    previous minute (read cheaply from `/health/components`) skips a synthetic.
+    Otherwise the worker runs at most one authenticated
+    `POST /__maintenance/mcp-execute-health` per rolling hour. Failed attempts
+    consume that budget. Public `/`, `/status.json`, and `/health` never trigger
+    that execute. Missing or stale telemetry is unknown, not an outage, and does
+    not change overall status or hide other incidents.
 - Public storage cards are the main-worker bindings that take the product down
   (`app_db`, `kv`, `assets`). Operator `GET /health/components` reports
   `audit_db` as well; it is not a public card and does not open incidents or

--- a/packages/status/status-page.node.test.ts
+++ b/packages/status/status-page.node.test.ts
@@ -43,6 +43,13 @@ function snapshot(overrides: Partial<StatusSnapshot> = {}): StatusSnapshot {
 		productionCommit: 'abc123def4567890abcdef1234567890abcdef12',
 		runtimeCommit: 'def4567890abcdef1234567890abcdef12345678',
 		jobsCommit: '7890abcdef1234567890abcdef1234567890abcd',
+		executeHealth: {
+			status: 'recent',
+			source: 'organic',
+			lastVerifiedAt: '2026-08-04T11:59:50.000Z',
+			freshnessMs: 10_000,
+			detail: 'Verified by organic MCP execute traffic 10s ago.',
+		},
 		...overrides,
 	}
 }
@@ -71,6 +78,11 @@ test('status page renders components, incidents, unknown state, and escapes deta
 	expect(healthy).toContain('http-equiv="refresh"')
 	expect(healthy).toContain(`href="${statusFaviconPath('operational')}"`)
 	expect(healthy).toMatch(/operational|All systems/i)
+	expect(healthy).toContain('MCP execute')
+	expect(healthy).toContain('Recently verified')
+	expect(healthy).toContain('organic traffic')
+	expect(healthy).toContain('2026-08-04T11:59:50.000Z')
+	expect(healthy).toContain('Verified by organic MCP execute traffic 10s ago.')
 
 	const down = renderStatusPage(
 		snapshot({
@@ -128,6 +140,24 @@ test('status page renders components, incidents, unknown state, and escapes deta
 	)
 	expect(unknown).toMatch(/not available|no data/i)
 	expect(unknown).toContain(`href="${statusFaviconPath('unknown')}"`)
+
+	const executeUnknown = renderStatusPage(
+		snapshot({
+			executeHealth: {
+				status: 'unknown',
+				source: null,
+				lastVerifiedAt: null,
+				freshnessMs: null,
+				detail:
+					'Not recently exercised. Missing or stale telemetry is not an outage and is not proof the path is freshly healthy.',
+			},
+		}),
+	)
+	expect(executeUnknown).toContain('Not recently exercised')
+	expect(executeUnknown).toContain('Last verified time is unknown')
+	expect(executeUnknown).toContain(
+		'Missing or stale telemetry is not an outage',
+	)
 
 	const unavailable = renderStatusUnavailablePage(
 		'Status data is temporarily unavailable.',

--- a/packages/status/status-page.ts
+++ b/packages/status/status-page.ts
@@ -7,6 +7,7 @@ import {
 } from './provider-incidents.ts'
 import {
 	type ComponentSnapshot,
+	type ExecuteHealthSnapshot,
 	type IncidentView,
 	type ProviderIncident,
 	type StatusSnapshot,
@@ -183,6 +184,31 @@ function renderDayBars(component: ComponentSnapshot): string {
 		})
 		.join('')
 	return `<div class="bars">${bars}</div>`
+}
+
+function renderExecuteHealth(executeHealth: ExecuteHealthSnapshot): string {
+	const statusLabel =
+		executeHealth.status === 'recent'
+			? 'Recently verified'
+			: 'Not recently exercised'
+	const source =
+		executeHealth.source === 'organic'
+			? 'organic traffic'
+			: executeHealth.source === 'synthetic'
+				? 'hourly synthetic'
+				: 'no source yet'
+	const verified =
+		executeHealth.lastVerifiedAt === null
+			? 'Last verified time is unknown'
+			: `Last verified ${escapeHtml(executeHealth.lastVerifiedAt)}`
+	return `<div class="card component">
+	<div class="component-header">
+		<span class="component-name"><span class="dot ${executeHealth.status === 'recent' ? 'operational' : 'unknown'}"></span>MCP execute</span>
+		<span class="component-meta">${escapeHtml(statusLabel)} · ${escapeHtml(source)}</span>
+	</div>
+	<p class="component-meta">${escapeHtml(executeHealth.detail)}</p>
+	<p class="component-meta">${verified}</p>
+</div>`
 }
 
 function renderComponent(component: ComponentSnapshot): string {
@@ -371,6 +397,7 @@ ${renderFaviconLinks(snapshot.overallStatus)}
 		<span class="component-meta">Updated ${escapeHtml(snapshot.generatedAt)}</span>
 	</header>
 	<div class="banner ${banner.kind}">${escapeHtml(banner.label)}</div>
+	${renderExecuteHealth(snapshot.executeHealth)}
 	${components}
 	${openIncidents}
 	${providerIncidents}

--- a/packages/status/status-store.ts
+++ b/packages/status/status-store.ts
@@ -38,6 +38,11 @@ import {
 	publicAuditDbRetiredMetaKey,
 	retirePublicAuditDbData,
 } from './retire-public-audit-db.ts'
+import {
+	applyExecuteHealthTick,
+	deriveExecuteHealthView,
+	type ExecuteHealthCoordinatorState,
+} from './execute-health.ts'
 import { jobsProbeOrigin, runAllProbes } from './probes.ts'
 import {
 	fetchRelevantProviderIncidents,
@@ -61,6 +66,12 @@ const providerIncidentsMetaKey = 'provider_incidents_cache'
 const productionCommitMetaKey = 'production_commit_sha'
 const runtimeCommitMetaKey = 'runtime_commit_sha'
 const jobsCommitMetaKey = 'jobs_commit_sha'
+const executeLastSuccessMetaKey = 'execute_health_last_success_at'
+const executeLastSyntheticAttemptMetaKey =
+	'execute_health_last_synthetic_attempt_at'
+const executeLastSyntheticSuccessMetaKey =
+	'execute_health_last_synthetic_success_at'
+const executeLastSyntheticErrorMetaKey = 'execute_health_last_synthetic_error'
 
 export type StatusWorkerEnv = {
 	STATUS_STORE: DurableObjectNamespace<StatusStore>
@@ -222,6 +233,93 @@ export class StatusStore extends DurableObject<StatusWorkerEnv> {
 			key,
 			value,
 		)
+	}
+
+	private deleteMeta(key: string) {
+		this.ctx.storage.sql.exec(`DELETE FROM meta WHERE key = ?`, key)
+	}
+
+	private readEpochMeta(key: string): number | null {
+		const raw = this.getMeta(key)
+		if (!raw) return null
+		const value = Number(raw)
+		return Number.isFinite(value) ? value : null
+	}
+
+	private readExecuteHealthState(
+		lastSuccessAt: number | null,
+	): ExecuteHealthCoordinatorState {
+		const storedSuccessAt = this.readEpochMeta(executeLastSuccessMetaKey)
+		return {
+			lastSuccessAt:
+				lastSuccessAt !== null &&
+				(storedSuccessAt === null || lastSuccessAt > storedSuccessAt)
+					? lastSuccessAt
+					: storedSuccessAt,
+			lastSyntheticAttemptAt: this.readEpochMeta(
+				executeLastSyntheticAttemptMetaKey,
+			),
+			lastSyntheticSuccessAt: this.readEpochMeta(
+				executeLastSyntheticSuccessMetaKey,
+			),
+			lastSyntheticError: this.getMeta(executeLastSyntheticErrorMetaKey),
+			syntheticConfigured: Boolean(
+				this.env.STATUS_INCIDENT_EVENT_SECRET?.trim(),
+			),
+		}
+	}
+
+	private writeExecuteHealthState(state: ExecuteHealthCoordinatorState) {
+		if (state.lastSuccessAt !== null) {
+			this.setMeta(executeLastSuccessMetaKey, String(state.lastSuccessAt))
+		}
+		if (state.lastSyntheticAttemptAt !== null) {
+			this.setMeta(
+				executeLastSyntheticAttemptMetaKey,
+				String(state.lastSyntheticAttemptAt),
+			)
+		}
+		if (state.lastSyntheticSuccessAt !== null) {
+			this.setMeta(
+				executeLastSyntheticSuccessMetaKey,
+				String(state.lastSyntheticSuccessAt),
+			)
+		}
+		if (state.lastSyntheticError) {
+			this.setMeta(executeLastSyntheticErrorMetaKey, state.lastSyntheticError)
+		} else {
+			this.deleteMeta(executeLastSyntheticErrorMetaKey)
+		}
+	}
+
+	private async runExecuteHealthSynthetic(): Promise<{
+		ok: boolean
+		error?: string | null
+	}> {
+		const secret = this.env.STATUS_INCIDENT_EVENT_SECRET?.trim()
+		if (!secret) {
+			return { ok: false, error: 'not-configured' }
+		}
+		const response = await fetch(
+			`${this.env.PRIMARY_ORIGIN}/__maintenance/mcp-execute-health`,
+			{
+				method: 'POST',
+				headers: {
+					Authorization: `Bearer ${secret}`,
+					'User-Agent': 'kody-status-prober',
+				},
+				redirect: 'manual',
+				signal: AbortSignal.timeout(15_000),
+			},
+		)
+		if (!response.ok) {
+			return { ok: false, error: `HTTP ${String(response.status)}` }
+		}
+		const body = (await response.json()) as { ok?: boolean }
+		if (body.ok !== true) {
+			return { ok: false, error: 'probe-failed' }
+		}
+		return { ok: true, error: null }
 	}
 
 	private loadComponentState(
@@ -532,13 +630,18 @@ export class StatusStore extends DurableObject<StatusWorkerEnv> {
 		const jobsFetcher = this.env.JOBS
 			? (this.env.JOBS.fetch.bind(this.env.JOBS) as typeof fetch)
 			: undefined
-		const { outcomes, productionCommitSha, runtimeCommitSha, jobsCommitSha } =
-			await runAllProbes({
-				primaryOrigin: this.env.PRIMARY_ORIGIN,
-				packageAppOrigin: this.env.PACKAGE_APP_ORIGIN,
-				jobsOrigin: this.env.JOBS_ORIGIN ?? jobsProbeOrigin,
-				jobsFetcher,
-			})
+		const {
+			outcomes,
+			productionCommitSha,
+			runtimeCommitSha,
+			jobsCommitSha,
+			executeLastSuccessAt,
+		} = await runAllProbes({
+			primaryOrigin: this.env.PRIMARY_ORIGIN,
+			packageAppOrigin: this.env.PACKAGE_APP_ORIGIN,
+			jobsOrigin: this.env.JOBS_ORIGIN ?? jobsProbeOrigin,
+			jobsFetcher,
+		})
 		const now = Date.now()
 		if (productionCommitSha) {
 			this.setMeta(productionCommitMetaKey, productionCommitSha)
@@ -549,9 +652,28 @@ export class StatusStore extends DurableObject<StatusWorkerEnv> {
 		if (jobsCommitSha) {
 			this.setMeta(jobsCommitMetaKey, jobsCommitSha)
 		}
+		if (executeLastSuccessAt !== null) {
+			this.setMeta(executeLastSuccessMetaKey, String(executeLastSuccessAt))
+		}
 		for (const outcome of outcomes) {
 			this.recordOutcome(outcome, now)
 		}
+		const executeState = await applyExecuteHealthTick({
+			now,
+			...this.readExecuteHealthState(executeLastSuccessAt),
+			runSynthetic: async () => {
+				try {
+					return await this.runExecuteHealthSynthetic()
+				} catch (error) {
+					return {
+						ok: false,
+						error:
+							error instanceof Error ? error.message.slice(0, 200) : 'error',
+					}
+				}
+			},
+		})
+		this.writeExecuteHealthState(executeState)
 		await this.refreshProviderIncidents(now)
 		await this.maybeSendAlert(now)
 		this.prune(now)
@@ -609,6 +731,12 @@ export class StatusStore extends DurableObject<StatusWorkerEnv> {
 			productionCommit: this.getMeta(productionCommitMetaKey),
 			runtimeCommit: this.getMeta(runtimeCommitMetaKey),
 			jobsCommit: this.getMeta(jobsCommitMetaKey),
+			executeHealth: deriveExecuteHealthView({
+				now,
+				...this.readExecuteHealthState(
+					this.readEpochMeta(executeLastSuccessMetaKey),
+				),
+			}),
 		}
 	}
 

--- a/packages/status/status-store.ts
+++ b/packages/status/status-store.ts
@@ -41,6 +41,7 @@ import {
 import {
 	applyExecuteHealthTick,
 	deriveExecuteHealthView,
+	mergeExecuteLastSuccess,
 	type ExecuteHealthCoordinatorState,
 } from './execute-health.ts'
 import { jobsProbeOrigin, runAllProbes } from './probes.ts'
@@ -251,11 +252,7 @@ export class StatusStore extends DurableObject<StatusWorkerEnv> {
 	): ExecuteHealthCoordinatorState {
 		const storedSuccessAt = this.readEpochMeta(executeLastSuccessMetaKey)
 		return {
-			lastSuccessAt:
-				lastSuccessAt !== null &&
-				(storedSuccessAt === null || lastSuccessAt > storedSuccessAt)
-					? lastSuccessAt
-					: storedSuccessAt,
+			lastSuccessAt: mergeExecuteLastSuccess(lastSuccessAt, storedSuccessAt),
 			lastSyntheticAttemptAt: this.readEpochMeta(
 				executeLastSyntheticAttemptMetaKey,
 			),
@@ -651,9 +648,6 @@ export class StatusStore extends DurableObject<StatusWorkerEnv> {
 		}
 		if (jobsCommitSha) {
 			this.setMeta(jobsCommitMetaKey, jobsCommitSha)
-		}
-		if (executeLastSuccessAt !== null) {
-			this.setMeta(executeLastSuccessMetaKey, String(executeLastSuccessAt))
 		}
 		for (const outcome of outcomes) {
 			this.recordOutcome(outcome, now)

--- a/packages/status/status-types.ts
+++ b/packages/status/status-types.ts
@@ -3,10 +3,11 @@
  * state, and the snapshot shape the public page renders.
  */
 
+import { type ExecuteHealthSnapshot } from './execute-health.ts'
 import { type IncidentRetrospective } from './retrospective.ts'
 import { type ProviderIncident } from './provider-incidents.ts'
 
-export type { ProviderIncident }
+export type { ExecuteHealthSnapshot, ProviderIncident }
 
 export const statusComponents = [
 	{ id: 'app', name: 'App & API' },
@@ -91,4 +92,9 @@ export type StatusSnapshot = {
 	runtimeCommit: string | null
 	/** Latest `commit` from jobs-worker `GET /health`. */
 	jobsCommit: string | null
+	/**
+	 * Traffic-backed MCP execute evidence. Missing or stale telemetry is
+	 * unknown, not an outage, and does not change overallStatus.
+	 */
+	executeHealth: ExecuteHealthSnapshot
 }

--- a/packages/worker/.env.example
+++ b/packages/worker/.env.example
@@ -116,6 +116,11 @@ DISCORD_CLIENT_SECRET=MOCK_DISCORD_CLIENT_SECRET
 # job vectors.
 # JOB_REINDEX_SECRET=
 
+# Dedicated canary OAuth access token for the hourly authenticated MCP
+# execute fallback (POST /__maintenance/mcp-execute-health). Organic
+# successful execute completions skip that synthetic. Leave unset locally.
+# MCP_EXECUTE_HEALTH_CANARY_ACCESS_TOKEN=
+
 # Kit (kit.com) waiting-list signup (optional Worker secret + tag/sequence ids).
 # Production /waiting-list posts create/upsert a subscriber, tag waitlist::kody,
 # and enroll them in the Kody Waitlist Welcome sequence (hello@kentcdodds.com).

--- a/packages/worker/src/app/handlers/health-components-handler.node.test.ts
+++ b/packages/worker/src/app/handlers/health-components-handler.node.test.ts
@@ -241,3 +241,17 @@ test('health components handler memoizes, coalesces in-flight work, and returns 
 		expect.any(String),
 	)
 })
+
+test('hung execute-evidence KV read fails open as unknown and does not block components', async () => {
+	consoleWarn.mockImplementation(() => {})
+	const bindings = createHealthyBindings()
+	;(
+		bindings as typeof bindings & { BUNDLE_ARTIFACTS_KV: KVNamespace }
+	).BUNDLE_ARTIFACTS_KV = {
+		get: async () => await new Promise(() => {}),
+	} as unknown as KVNamespace
+	const report = await collectHealthComponents(bindings)
+	expect(report.ok).toBe(true)
+	expect(report.executeEvidence).toEqual({ lastSuccessAt: null })
+	expect(consoleWarn).toHaveBeenCalledWith('health-execute-evidence-timeout')
+})

--- a/packages/worker/src/app/handlers/health-components-handler.node.test.ts
+++ b/packages/worker/src/app/handlers/health-components-handler.node.test.ts
@@ -6,6 +6,7 @@ import {
 	healthComponentIds,
 	type HealthComponentsReport,
 } from '#app/handlers/health-components.ts'
+import { fleetExecuteLastSuccessKvKey } from '#worker/execute-health-heartbeat.ts'
 import { consoleWarn } from '#worker/test-support/console-spies.ts'
 
 function createHealthyBindings() {
@@ -35,6 +36,21 @@ test('collectHealthComponents reports healthy, failed, and unavailable bindings'
 	expect(healthy.components.map((component) => component.id)).toEqual([
 		...healthComponentIds,
 	])
+	expect(healthy.executeEvidence).toEqual({ lastSuccessAt: null })
+
+	const lastSuccessAt = '2026-09-07T17:00:00.000Z'
+	const withEvidence = createHealthyBindings()
+	;(
+		withEvidence as typeof withEvidence & { BUNDLE_ARTIFACTS_KV: KVNamespace }
+	).BUNDLE_ARTIFACTS_KV = {
+		get: async (key: string) =>
+			key === fleetExecuteLastSuccessKvKey
+				? JSON.stringify({ at: Date.parse(lastSuccessAt) })
+				: null,
+	} as unknown as KVNamespace
+	const evidenced = await collectHealthComponents(withEvidence)
+	expect(evidenced.ok).toBe(true)
+	expect(evidenced.executeEvidence).toEqual({ lastSuccessAt })
 	for (const component of healthy.components) {
 		expect(component.ok).toBe(true)
 		expect(component.latencyMs).toBeGreaterThanOrEqual(0)
@@ -174,6 +190,7 @@ test('health components handler memoizes, coalesces in-flight work, and returns 
 	const body = (await first.json()) as HealthComponentsReport
 	expect(body.ok).toBe(true)
 	expect(body.checkedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+	expect(body.executeEvidence.lastSuccessAt).toBeNull()
 
 	let releaseFirst: (() => void) | undefined
 	const gate = new Promise<void>((resolve) => {

--- a/packages/worker/src/app/handlers/health-components.ts
+++ b/packages/worker/src/app/handlers/health-components.ts
@@ -147,17 +147,43 @@ export async function collectHealthComponents(
 				assets ? () => assets.head('health-component-probe') : null,
 			),
 		]),
-		readFleetExecuteLastSuccess({ kv: env.BUNDLE_ARTIFACTS_KV }),
+		readExecuteEvidence(env),
 	])
 	return {
 		ok: components.every((component) => component.ok),
 		commitSha: env.APP_COMMIT_SHA ?? null,
 		checkedAt: new Date().toISOString(),
 		components,
-		executeEvidence: {
-			lastSuccessAt:
-				lastSuccess === null ? null : new Date(lastSuccess.at).toISOString(),
-		},
+		executeEvidence: lastSuccess,
+	}
+}
+
+async function readExecuteEvidence(
+	env: HealthComponentsEnv,
+): Promise<HealthExecuteEvidence> {
+	let timeoutHandle: ReturnType<typeof setTimeout> | undefined
+	const timeout = new Promise<'timeout'>((resolve) => {
+		timeoutHandle = setTimeout(
+			() => resolve('timeout'),
+			componentCheckTimeoutMs,
+		)
+	})
+	try {
+		const outcome = await Promise.race([
+			readFleetExecuteLastSuccess({ kv: env.BUNDLE_ARTIFACTS_KV }),
+			timeout,
+		])
+		if (outcome === 'timeout' || outcome === null) {
+			if (outcome === 'timeout') {
+				console.warn('health-execute-evidence-timeout')
+			}
+			return { lastSuccessAt: null }
+		}
+		return { lastSuccessAt: new Date(outcome.at).toISOString() }
+	} catch {
+		return { lastSuccessAt: null }
+	} finally {
+		clearTimeout(timeoutHandle)
 	}
 }
 

--- a/packages/worker/src/app/handlers/health-components.ts
+++ b/packages/worker/src/app/handlers/health-components.ts
@@ -1,6 +1,7 @@
 import { type Action } from 'remix/router'
 import { type routes } from '#universal/routes.ts'
 import { runD1WithRetry } from '#worker/d1-retry.ts'
+import { readFleetExecuteLastSuccess } from '#worker/execute-health-heartbeat.ts'
 import { type AppEnv } from '#worker/env-schema.ts'
 
 /**
@@ -8,8 +9,10 @@ import { type AppEnv } from '#worker/env-schema.ts'
  * (`packages/status`). Each check is a cheap read against one storage binding.
  * The prober maps product-affecting bindings (`app_db`, `kv`, `assets`) onto
  * public cards; `audit_db` is on this endpoint for operators and is not a
- * public status card. Results are memoized briefly so public traffic cannot
- * amplify load on the underlying bindings.
+ * public status card. `executeEvidence` is a cheap timestamp-only read of the
+ * fleet last-success heartbeat; this handler never runs MCP execute. Results
+ * are memoized briefly so public traffic cannot amplify load on the
+ * underlying bindings.
  */
 
 const componentCheckTimeoutMs = 5_000
@@ -44,11 +47,16 @@ export type HealthComponentResult = {
 	error?: 'timeout' | 'unavailable' | 'error'
 }
 
+export type HealthExecuteEvidence = {
+	lastSuccessAt: string | null
+}
+
 export type HealthComponentsReport = {
 	ok: boolean
 	commitSha: string | null
 	checkedAt: string
 	components: Array<HealthComponentResult>
+	executeEvidence: HealthExecuteEvidence
 }
 
 type HealthComponentsEnv = {
@@ -56,6 +64,7 @@ type HealthComponentsEnv = {
 	APP_DB?: D1Database
 	AUDIT_DB?: D1Database
 	OAUTH_KV?: KVNamespace
+	BUNDLE_ARTIFACTS_KV?: KVNamespace
 	COMMUNITY_ASSETS?: R2Bucket
 }
 
@@ -107,41 +116,48 @@ export async function collectHealthComponents(
 	const auditDb = env.AUDIT_DB
 	const oauthKv = env.OAUTH_KV
 	const assets = env.COMMUNITY_ASSETS
-	const components = await Promise.all([
-		runComponentCheck(
-			'app_db',
-			appDb
-				? () =>
-						runD1WithRetry(
-							() => appDb.prepare('SELECT 1').first(),
-							d1CheckRetryOptions,
-						)
-				: null,
-		),
-		runComponentCheck(
-			'audit_db',
-			auditDb
-				? () =>
-						runD1WithRetry(
-							() => auditDb.prepare('SELECT 1').first(),
-							d1CheckRetryOptions,
-						)
-				: null,
-		),
-		runComponentCheck(
-			'kv',
-			oauthKv ? () => oauthKv.get('health-component-probe') : null,
-		),
-		runComponentCheck(
-			'assets',
-			assets ? () => assets.head('health-component-probe') : null,
-		),
+	const [components, lastSuccess] = await Promise.all([
+		Promise.all([
+			runComponentCheck(
+				'app_db',
+				appDb
+					? () =>
+							runD1WithRetry(
+								() => appDb.prepare('SELECT 1').first(),
+								d1CheckRetryOptions,
+							)
+					: null,
+			),
+			runComponentCheck(
+				'audit_db',
+				auditDb
+					? () =>
+							runD1WithRetry(
+								() => auditDb.prepare('SELECT 1').first(),
+								d1CheckRetryOptions,
+							)
+					: null,
+			),
+			runComponentCheck(
+				'kv',
+				oauthKv ? () => oauthKv.get('health-component-probe') : null,
+			),
+			runComponentCheck(
+				'assets',
+				assets ? () => assets.head('health-component-probe') : null,
+			),
+		]),
+		readFleetExecuteLastSuccess({ kv: env.BUNDLE_ARTIFACTS_KV }),
 	])
 	return {
 		ok: components.every((component) => component.ok),
 		commitSha: env.APP_COMMIT_SHA ?? null,
 		checkedAt: new Date().toISOString(),
 		components,
+		executeEvidence: {
+			lastSuccessAt:
+				lastSuccess === null ? null : new Date(lastSuccess.at).toISOString(),
+		},
 	}
 }
 

--- a/packages/worker/src/env-schema.ts
+++ b/packages/worker/src/env-schema.ts
@@ -357,6 +357,9 @@ export const EnvSchema = object({
 	// /__maintenance/status-incidents returns not-configured and the status
 	// worker skips emit (sweep polling remains the backstop).
 	STATUS_INCIDENT_EVENT_SECRET: optionalNonEmptyStringSchema,
+	// Dedicated canary OAuth access token for the hourly authenticated MCP
+	// execute fallback. Timestamp-only fleet heartbeat never stores this.
+	MCP_EXECUTE_HEALTH_CANARY_ACCESS_TOKEN: optionalNonEmptyStringSchema,
 })
 
 export type AppEnv = InferOutput<typeof EnvSchema>

--- a/packages/worker/src/execute-health-heartbeat.node.test.ts
+++ b/packages/worker/src/execute-health-heartbeat.node.test.ts
@@ -115,4 +115,25 @@ test('public evidence reads stay cheap and treat missing or invalid telemetry as
 	await expect(readFleetExecuteLastSuccess({ kv: store })).resolves.toEqual({
 		at: 1_725_000_000_000,
 	})
+	await expect(
+		readFleetExecuteLastSuccess({
+			kv: kv(JSON.stringify({ at: 8_640_000_000_000_001 })),
+		}),
+	).resolves.toBeNull()
+})
+
+test('concurrent heartbeat calls in one isolate write once', async () => {
+	let puts = 0
+	const store = kv(null, {
+		onPut() {
+			puts += 1
+		},
+	})
+	const shared = memory()
+	const now = Date.parse('2026-09-07T17:00:00.000Z')
+	await Promise.all([
+		recordFleetExecuteLastSuccess({ kv: store, now, memory: shared }),
+		recordFleetExecuteLastSuccess({ kv: store, now, memory: shared }),
+	])
+	expect(puts).toBe(1)
 })

--- a/packages/worker/src/execute-health-heartbeat.node.test.ts
+++ b/packages/worker/src/execute-health-heartbeat.node.test.ts
@@ -1,0 +1,118 @@
+import { expect, test, vi } from 'vitest'
+import { consoleWarn } from '#worker/test-support/console-spies.ts'
+import {
+	fleetExecuteHeartbeatCoalesceMs,
+	fleetExecuteLastSuccessKvKey,
+	readFleetExecuteLastSuccess,
+	recordFleetExecuteLastSuccess,
+	scheduleFleetExecuteLastSuccess,
+	type FleetExecuteHeartbeatKv,
+	type FleetExecuteHeartbeatMemory,
+} from './execute-health-heartbeat.ts'
+
+function memory(): FleetExecuteHeartbeatMemory {
+	return { lastWriteAt: 0 }
+}
+
+function kv(
+	initial?: string | null,
+	hooks?: {
+		onGet?: () => void
+		onPut?: (key: string, value: string) => void
+		getError?: Error
+		putError?: Error
+	},
+): FleetExecuteHeartbeatKv & { store: Map<string, string> } {
+	const store = new Map<string, string>()
+	if (initial) store.set(fleetExecuteLastSuccessKvKey, initial)
+	return {
+		store,
+		async get(key: string) {
+			hooks?.onGet?.()
+			if (hooks?.getError) throw hooks.getError
+			return store.get(key) ?? null
+		},
+		async put(key: string, value: string) {
+			hooks?.onPut?.(key, value)
+			if (hooks?.putError) throw hooks.putError
+			store.set(key, value)
+		},
+	}
+}
+
+test('heartbeat coalesces writes and stays fail-open so customer execute is not broken', async () => {
+	const writes: Array<string> = []
+	const store = kv(null, {
+		onPut(_key, value) {
+			writes.push(value)
+		},
+	})
+	const shared = memory()
+	const now = Date.parse('2026-09-07T17:00:00.000Z')
+
+	await recordFleetExecuteLastSuccess({
+		kv: store,
+		now,
+		memory: shared,
+	})
+	await recordFleetExecuteLastSuccess({
+		kv: store,
+		now: now + 1_000,
+		memory: shared,
+	})
+	await recordFleetExecuteLastSuccess({
+		kv: store,
+		now: now + fleetExecuteHeartbeatCoalesceMs,
+		memory: shared,
+	})
+	expect(writes).toHaveLength(2)
+	await expect(readFleetExecuteLastSuccess({ kv: store })).resolves.toEqual({
+		at: now + fleetExecuteHeartbeatCoalesceMs,
+	})
+
+	consoleWarn.mockImplementation(() => {})
+	const failing = kv(null, { putError: new Error('kv unavailable') })
+	await expect(
+		recordFleetExecuteLastSuccess({
+			kv: failing,
+			now,
+			memory: memory(),
+		}),
+	).resolves.toBeUndefined()
+	expect(consoleWarn).toHaveBeenCalledWith(
+		'fleet-execute-heartbeat-failed',
+		'kv unavailable',
+	)
+
+	const scheduled: Array<Promise<unknown>> = []
+	scheduleFleetExecuteLastSuccess({
+		waitUntil: (promise) => {
+			scheduled.push(promise)
+			throw new Error('waitUntil exploded')
+		},
+		kv: store,
+		now: now + 90_000,
+		memory: memory(),
+	})
+	expect(scheduled).toHaveLength(1)
+	expect(consoleWarn).toHaveBeenCalledWith(
+		'fleet-execute-heartbeat-schedule-failed',
+		'waitUntil exploded',
+	)
+})
+
+test('public evidence reads stay cheap and treat missing or invalid telemetry as unknown', async () => {
+	await expect(readFleetExecuteLastSuccess({})).resolves.toBeNull()
+	await expect(
+		readFleetExecuteLastSuccess({
+			kv: kv('{"nope":true}'),
+		}),
+	).resolves.toBeNull()
+	const broken = kv(null, { getError: new Error('read failed') })
+	await expect(readFleetExecuteLastSuccess({ kv: broken })).resolves.toBeNull()
+
+	const store = kv(JSON.stringify({ at: 1_725_000_000_000 }))
+	await expect(readFleetExecuteLastSuccess({ kv: store })).resolves.toEqual({
+		at: 1_725_000_000_000,
+	})
+})

--- a/packages/worker/src/execute-health-heartbeat.ts
+++ b/packages/worker/src/execute-health-heartbeat.ts
@@ -34,16 +34,24 @@ export async function recordFleetExecuteLastSuccess(input: {
 		const coalesceMs = input.coalesceMs ?? fleetExecuteHeartbeatCoalesceMs
 		const memory = input.memory ?? isolateMemory
 		if (now - memory.lastWriteAt < coalesceMs) return
-		const existing = await readFleetExecuteLastSuccess({ kv })
-		if (existing && now - existing.at < coalesceMs) {
-			memory.lastWriteAt = existing.at
-			return
-		}
-		await kv.put(
-			fleetExecuteLastSuccessKvKey,
-			JSON.stringify({ at: now } satisfies FleetExecuteLastSuccess),
-		)
+		const reservedAt = memory.lastWriteAt
+		// Reserve before the first await so concurrent isolate calls cannot
+		// all pass the coalesce check and each write KV.
 		memory.lastWriteAt = now
+		try {
+			const existing = await readFleetExecuteLastSuccess({ kv })
+			if (existing && now - existing.at < coalesceMs) {
+				memory.lastWriteAt = existing.at
+				return
+			}
+			await kv.put(
+				fleetExecuteLastSuccessKvKey,
+				JSON.stringify({ at: now } satisfies FleetExecuteLastSuccess),
+			)
+		} catch (error) {
+			memory.lastWriteAt = reservedAt
+			throw error
+		}
 	} catch (error) {
 		console.warn(
 			'fleet-execute-heartbeat-failed',
@@ -59,7 +67,11 @@ export async function readFleetExecuteLastSuccess(input: {
 		const raw = await input.kv?.get(fleetExecuteLastSuccessKvKey)
 		if (!raw) return null
 		const parsed = JSON.parse(raw) as Partial<FleetExecuteLastSuccess>
-		if (typeof parsed.at !== 'number' || !Number.isFinite(parsed.at)) {
+		if (
+			typeof parsed.at !== 'number' ||
+			!Number.isFinite(parsed.at) ||
+			Number.isNaN(new Date(parsed.at).getTime())
+		) {
 			return null
 		}
 		return { at: parsed.at }

--- a/packages/worker/src/execute-health-heartbeat.ts
+++ b/packages/worker/src/execute-health-heartbeat.ts
@@ -1,0 +1,91 @@
+/**
+ * Best-effort coalesced fleet last-success heartbeat for MCP execute.
+ *
+ * Writes a timestamp only — no user identities, code, results, or credentials.
+ * Isolate memory plus a short KV compare keep this off the hot D1 writer.
+ * Failures are swallowed so customer execute never depends on the heartbeat.
+ */
+
+export const fleetExecuteLastSuccessKvKey = 'fleet-execute-last-success:v1'
+export const fleetExecuteHeartbeatCoalesceMs = 45_000
+
+export type FleetExecuteLastSuccess = {
+	at: number
+}
+
+export type FleetExecuteHeartbeatMemory = {
+	lastWriteAt: number
+}
+
+const isolateMemory: FleetExecuteHeartbeatMemory = { lastWriteAt: 0 }
+
+export type FleetExecuteHeartbeatKv = Pick<KVNamespace, 'get' | 'put'>
+
+export async function recordFleetExecuteLastSuccess(input: {
+	kv?: FleetExecuteHeartbeatKv | null
+	now?: number
+	coalesceMs?: number
+	memory?: FleetExecuteHeartbeatMemory
+}): Promise<void> {
+	try {
+		const kv = input.kv
+		if (!kv) return
+		const now = input.now ?? Date.now()
+		const coalesceMs = input.coalesceMs ?? fleetExecuteHeartbeatCoalesceMs
+		const memory = input.memory ?? isolateMemory
+		if (now - memory.lastWriteAt < coalesceMs) return
+		const existing = await readFleetExecuteLastSuccess({ kv })
+		if (existing && now - existing.at < coalesceMs) {
+			memory.lastWriteAt = existing.at
+			return
+		}
+		await kv.put(
+			fleetExecuteLastSuccessKvKey,
+			JSON.stringify({ at: now } satisfies FleetExecuteLastSuccess),
+		)
+		memory.lastWriteAt = now
+	} catch (error) {
+		console.warn(
+			'fleet-execute-heartbeat-failed',
+			error instanceof Error ? error.message : String(error),
+		)
+	}
+}
+
+export async function readFleetExecuteLastSuccess(input: {
+	kv?: FleetExecuteHeartbeatKv | null
+}): Promise<FleetExecuteLastSuccess | null> {
+	try {
+		const raw = await input.kv?.get(fleetExecuteLastSuccessKvKey)
+		if (!raw) return null
+		const parsed = JSON.parse(raw) as Partial<FleetExecuteLastSuccess>
+		if (typeof parsed.at !== 'number' || !Number.isFinite(parsed.at)) {
+			return null
+		}
+		return { at: parsed.at }
+	} catch {
+		return null
+	}
+}
+
+export function scheduleFleetExecuteLastSuccess(input: {
+	waitUntil?: ((promise: Promise<unknown>) => void) | undefined
+	kv?: FleetExecuteHeartbeatKv | null
+	now?: number
+	memory?: FleetExecuteHeartbeatMemory
+}): void {
+	try {
+		input.waitUntil?.(
+			recordFleetExecuteLastSuccess({
+				kv: input.kv,
+				now: input.now,
+				memory: input.memory,
+			}),
+		)
+	} catch (error) {
+		console.warn(
+			'fleet-execute-heartbeat-schedule-failed',
+			error instanceof Error ? error.message : String(error),
+		)
+	}
+}

--- a/packages/worker/src/execute-health-probe.node.test.ts
+++ b/packages/worker/src/execute-health-probe.node.test.ts
@@ -100,6 +100,31 @@ test('authenticated probe uses the legacy MCP execute path and rejects caller er
 			},
 		}),
 	).rejects.toBeInstanceOf(MaintenanceFailureError)
+
+	await expect(
+		runAuthenticatedMcpExecuteHealthProbe({
+			token: 'canary-token',
+			mcpOrigin: 'https://kody.codes',
+			callMcp: async (request) => {
+				const body = (await request.clone().json()) as { method?: string }
+				if (body.method === 'initialize') {
+					return new Response(
+						JSON.stringify({ jsonrpc: '2.0', id: 1, result: {} }),
+						{
+							headers: { 'mcp-session-id': 'session-1' },
+						},
+					)
+				}
+				if (body.method === 'notifications/initialized') {
+					return new Response('Unauthorized', { status: 401 })
+				}
+				return jsonRpcResult({
+					structuredContent: { result: executeHealthProbeExpectedResult },
+					isError: false,
+				})
+			},
+		}),
+	).rejects.toBeInstanceOf(MaintenanceFailureError)
 })
 
 test('maintenance route never runs execute on GET and public callers cannot trigger it', async () => {

--- a/packages/worker/src/execute-health-probe.node.test.ts
+++ b/packages/worker/src/execute-health-probe.node.test.ts
@@ -1,0 +1,145 @@
+import { expect, test, vi } from 'vitest'
+import { MaintenanceFailureError } from './maintenance-handler.ts'
+import {
+	executeHealthMaintenancePath,
+	executeHealthProbeClientName,
+	executeHealthProbeCode,
+	executeHealthProbeExpectedResult,
+	executeHealthProbeProves,
+	executeHealthProbeScope,
+	handleExecuteHealthProbeRequest,
+	runAuthenticatedMcpExecuteHealthProbe,
+} from './execute-health-probe.ts'
+
+function jsonRpcResult(result: unknown, headers?: HeadersInit) {
+	return new Response(JSON.stringify({ jsonrpc: '2.0', id: 2, result }), {
+		status: 200,
+		headers: {
+			'Content-Type': 'application/json',
+			...headers,
+		},
+	})
+}
+
+test('authenticated probe uses the legacy MCP execute path and rejects caller errors', async () => {
+	const requests: Array<Request> = []
+	const callMcp = async (request: Request) => {
+		requests.push(request)
+		const body = (await request.clone().json()) as {
+			method?: string
+			params?: { name?: string; arguments?: { code?: string } }
+		}
+		if (body.method === 'initialize') {
+			return new Response(
+				JSON.stringify({ jsonrpc: '2.0', id: 1, result: {} }),
+				{
+					status: 200,
+					headers: {
+						'Content-Type': 'application/json',
+						'mcp-session-id': 'session-1',
+					},
+				},
+			)
+		}
+		if (body.method === 'notifications/initialized') {
+			return new Response(null, { status: 202 })
+		}
+		expect(body.method).toBe('tools/call')
+		expect(body.params?.name).toBe('execute')
+		expect(body.params?.arguments?.code).toBe(executeHealthProbeCode)
+		return jsonRpcResult({
+			structuredContent: { result: executeHealthProbeExpectedResult },
+			isError: false,
+		})
+	}
+
+	await expect(
+		runAuthenticatedMcpExecuteHealthProbe({
+			token: 'canary-token',
+			mcpOrigin: 'https://kody.codes',
+			callMcp,
+		}),
+	).resolves.toEqual({
+		result: 1,
+		scope: executeHealthProbeScope,
+		proves: executeHealthProbeProves,
+	})
+	expect(requests).toHaveLength(3)
+	expect(new URL(requests[0]?.url ?? '').pathname).toBe('/mcp')
+	expect(requests[0]?.headers.get('Authorization')).toBe('Bearer canary-token')
+	const initializeBody = (await requests[0]?.clone().json()) as {
+		params: { clientInfo: { name: string }; protocolVersion: string }
+	}
+	expect(initializeBody.params.protocolVersion).toBe('2025-06-18')
+	expect(initializeBody.params.clientInfo.name).toBe(
+		executeHealthProbeClientName,
+	)
+	expect(requests[2]?.headers.get('mcp-session-id')).toBe('session-1')
+
+	await expect(
+		runAuthenticatedMcpExecuteHealthProbe({
+			token: 'canary-token',
+			mcpOrigin: 'https://kody.codes',
+			callMcp: async (request) => {
+				const body = (await request.clone().json()) as { method?: string }
+				if (body.method === 'initialize') {
+					return new Response(
+						JSON.stringify({ jsonrpc: '2.0', id: 1, result: {} }),
+						{
+							headers: { 'mcp-session-id': 'session-1' },
+						},
+					)
+				}
+				if (body.method === 'notifications/initialized') {
+					return new Response(null, { status: 202 })
+				}
+				return jsonRpcResult({
+					structuredContent: { result: 1, error: 'boom' },
+					isError: true,
+				})
+			},
+		}),
+	).rejects.toBeInstanceOf(MaintenanceFailureError)
+})
+
+test('maintenance route never runs execute on GET and public callers cannot trigger it', async () => {
+	const fetchMcp = vi.fn(async () => new Response('should-not-run'))
+	const env = {
+		STATUS_INCIDENT_EVENT_SECRET: 'status-secret',
+		MCP_EXECUTE_HEALTH_CANARY_ACCESS_TOKEN: 'canary-token',
+		APP_BASE_URL: 'https://kody.codes',
+	}
+	const ctx = {} as ExecutionContext
+
+	const getResponse = await handleExecuteHealthProbeRequest(
+		new Request(`https://kody.codes${executeHealthMaintenancePath}`),
+		env,
+		ctx,
+		fetchMcp,
+	)
+	expect(getResponse.status).toBe(405)
+	expect(fetchMcp).not.toHaveBeenCalled()
+
+	const unauthorized = await handleExecuteHealthProbeRequest(
+		new Request(`https://kody.codes${executeHealthMaintenancePath}`, {
+			method: 'POST',
+		}),
+		env,
+		ctx,
+		fetchMcp,
+	)
+	expect(unauthorized.status).toBe(401)
+	expect(fetchMcp).not.toHaveBeenCalled()
+
+	const unconfigured = await handleExecuteHealthProbeRequest(
+		new Request(`https://kody.codes${executeHealthMaintenancePath}`, {
+			method: 'POST',
+			headers: { Authorization: 'Bearer status-secret' },
+		}),
+		{ APP_BASE_URL: 'https://kody.codes' },
+		ctx,
+		fetchMcp,
+	)
+	expect(unconfigured.status).toBe(503)
+	expect(fetchMcp).not.toHaveBeenCalled()
+})

--- a/packages/worker/src/execute-health-probe.ts
+++ b/packages/worker/src/execute-health-probe.ts
@@ -68,7 +68,7 @@ export async function runAuthenticatedMcpExecuteHealthProbe(input: {
 			params: {},
 		}),
 	)
-	if (initialized.status >= 500) {
+	if (!initialized.ok) {
 		throw new MaintenanceFailureError(
 			`Authenticated MCP execute probe initialized notification failed: HTTP ${String(initialized.status)}`,
 			{ reason: 'initialized-failed' },

--- a/packages/worker/src/execute-health-probe.ts
+++ b/packages/worker/src/execute-health-probe.ts
@@ -1,0 +1,243 @@
+import { getAppBaseUrl } from '#worker/app-base-url.ts'
+import { isRecord } from '@kody-internal/shared/is-record.ts'
+import {
+	handleSecretMaintenanceRequest,
+	MaintenanceFailureError,
+} from './maintenance-handler.ts'
+import { handleMcpRequest, mcpResourcePath } from './mcp-auth.ts'
+
+export const executeHealthMaintenancePath = '/__maintenance/mcp-execute-health'
+export const executeHealthProbeCode = 'export default async () => 1'
+export const executeHealthProbeClientName = 'kody-execute-health'
+export const executeHealthProbeScope = 'authenticated-mcp-execute' as const
+export const executeHealthProbeProves = 'platform-mcp-execute' as const
+export const executeHealthProbeExpectedResult = 1
+
+type LegacyMcpFetch = Parameters<typeof handleMcpRequest>[0]['fetchMcp']
+
+export type ExecuteHealthProbeCallMcp = (request: Request) => Promise<Response>
+
+export async function runAuthenticatedMcpExecuteHealthProbe(input: {
+	token: string
+	mcpOrigin: string
+	callMcp: ExecuteHealthProbeCallMcp
+}): Promise<{
+	result: unknown
+	scope: typeof executeHealthProbeScope
+	proves: typeof executeHealthProbeProves
+}> {
+	const token = input.token.trim()
+	if (!token) {
+		throw new MaintenanceFailureError(
+			'Execute health canary is not configured',
+			{ reason: 'not-configured' },
+		)
+	}
+	const mcpUrl = `${input.mcpOrigin}${mcpResourcePath}`
+	const initialize = await input.callMcp(
+		mcpJsonRpcRequest({
+			url: mcpUrl,
+			token,
+			id: 1,
+			method: 'initialize',
+			params: {
+				protocolVersion: '2025-06-18',
+				capabilities: {},
+				clientInfo: {
+					name: executeHealthProbeClientName,
+					version: '1.0.0',
+				},
+			},
+		}),
+	)
+	await assertMcpOk(initialize, 'initialize')
+	const sessionId = initialize.headers.get('mcp-session-id')
+	if (!sessionId) {
+		throw new MaintenanceFailureError(
+			'Authenticated MCP execute probe did not receive a session',
+			{ reason: 'missing-session' },
+		)
+	}
+
+	const initialized = await input.callMcp(
+		mcpJsonRpcRequest({
+			url: mcpUrl,
+			token,
+			sessionId,
+			method: 'notifications/initialized',
+			params: {},
+		}),
+	)
+	if (initialized.status >= 500) {
+		throw new MaintenanceFailureError(
+			`Authenticated MCP execute probe initialized notification failed: HTTP ${String(initialized.status)}`,
+			{ reason: 'initialized-failed' },
+		)
+	}
+
+	const call = await input.callMcp(
+		mcpJsonRpcRequest({
+			url: mcpUrl,
+			token,
+			sessionId,
+			id: 2,
+			method: 'tools/call',
+			params: {
+				name: 'execute',
+				arguments: {
+					code: executeHealthProbeCode,
+				},
+			},
+		}),
+	)
+	const body = await assertMcpOk(call, 'tools/call')
+	const result = readExecuteToolResult(body)
+	if (result.isError) {
+		throw new MaintenanceFailureError(
+			'Authenticated MCP execute probe returned an execute error',
+			{ reason: 'execute-error' },
+		)
+	}
+	if (result.value !== executeHealthProbeExpectedResult) {
+		throw new MaintenanceFailureError(
+			'Authenticated MCP execute probe returned an unexpected result',
+			{ reason: 'unexpected-result' },
+		)
+	}
+	return {
+		result: result.value,
+		scope: executeHealthProbeScope,
+		proves: executeHealthProbeProves,
+	}
+}
+
+export async function handleExecuteHealthProbeRequest(
+	request: Request,
+	env: {
+		APP_BASE_URL?: string
+		STATUS_INCIDENT_EVENT_SECRET?: string
+		MCP_EXECUTE_HEALTH_CANARY_ACCESS_TOKEN?: string
+	},
+	ctx: ExecutionContext,
+	fetchMcp?: LegacyMcpFetch,
+): Promise<Response> {
+	return handleSecretMaintenanceRequest({
+		request,
+		secret: env.STATUS_INCIDENT_EVENT_SECRET,
+		notConfiguredMessage: 'MCP execute health probe is not configured',
+		run: async () => {
+			const token = env.MCP_EXECUTE_HEALTH_CANARY_ACCESS_TOKEN?.trim() ?? ''
+			const mcpOrigin = getAppBaseUrl({ env, requestUrl: request.url })
+			const resolvedFetchMcp = fetchMcp ?? (await loadLegacyMcpFetch())
+			return await runAuthenticatedMcpExecuteHealthProbe({
+				token,
+				mcpOrigin,
+				callMcp: (mcpRequest) =>
+					handleMcpRequest({
+						request: mcpRequest,
+						env: env as Env,
+						ctx,
+						fetchMcp: resolvedFetchMcp,
+					}),
+			})
+		},
+	})
+}
+
+let legacyMcpFetchMemo: Promise<LegacyMcpFetch> | null = null
+
+function loadLegacyMcpFetch(): Promise<LegacyMcpFetch> {
+	legacyMcpFetchMemo ??= import('./mcp/index.ts')
+		.then(
+			({ MCP }) =>
+				MCP.serve(mcpResourcePath, { binding: 'MCP_OBJECT' })
+					.fetch as LegacyMcpFetch,
+		)
+		.catch((error: unknown) => {
+			legacyMcpFetchMemo = null
+			throw error
+		})
+	return legacyMcpFetchMemo
+}
+
+function mcpJsonRpcRequest(input: {
+	url: string
+	token: string
+	sessionId?: string
+	id?: number
+	method: string
+	params: Record<string, unknown>
+}): Request {
+	const headers = new Headers({
+		Authorization: `Bearer ${input.token}`,
+		'Content-Type': 'application/json',
+		Accept: 'application/json, text/event-stream',
+	})
+	if (input.sessionId) headers.set('Mcp-Session-Id', input.sessionId)
+	const body: Record<string, unknown> = {
+		jsonrpc: '2.0',
+		method: input.method,
+		params: input.params,
+	}
+	if (input.id !== undefined) body['id'] = input.id
+	return new Request(input.url, {
+		method: 'POST',
+		headers,
+		body: JSON.stringify(body),
+	})
+}
+
+async function assertMcpOk(response: Response, step: string) {
+	if (!response.ok) {
+		throw new MaintenanceFailureError(
+			`Authenticated MCP execute probe ${step} failed: HTTP ${String(response.status)}`,
+			{ reason: 'http-error', status: response.status },
+		)
+	}
+	const body = await readMcpJsonRpcBody(response)
+	if (isRecord(body) && body['error']) {
+		throw new MaintenanceFailureError(
+			`Authenticated MCP execute probe ${step} returned a JSON-RPC error`,
+			{ reason: 'jsonrpc-error' },
+		)
+	}
+	return body
+}
+
+async function readMcpJsonRpcBody(response: Response): Promise<unknown> {
+	const contentType = response.headers.get('content-type') ?? ''
+	const text = await response.text()
+	if (!text.trim()) return null
+	if (contentType.includes('text/event-stream')) {
+		const dataLines = text
+			.split('\n')
+			.map((line) => line.trim())
+			.filter((line) => line.startsWith('data:'))
+			.map((line) => line.slice('data:'.length).trim())
+			.filter((line) => line.length > 0 && line !== '[DONE]')
+		const last = dataLines.at(-1)
+		if (!last) return null
+		return JSON.parse(last) as unknown
+	}
+	return JSON.parse(text) as unknown
+}
+
+function readExecuteToolResult(body: unknown): {
+	value: unknown
+	isError: boolean
+} {
+	const result = isRecord(body) ? body['result'] : null
+	if (!isRecord(result)) {
+		throw new MaintenanceFailureError(
+			'Authenticated MCP execute probe returned an empty execute result',
+			{ reason: 'empty-result' },
+		)
+	}
+	const structured = isRecord(result['structuredContent'])
+		? result['structuredContent']
+		: null
+	return {
+		value: structured?.['result'],
+		isError: result['isError'] === true,
+	}
+}

--- a/packages/worker/src/mcp/tools/execute.node.test.ts
+++ b/packages/worker/src/mcp/tools/execute.node.test.ts
@@ -20,6 +20,12 @@ import { formatRawFetchHostNudge } from '#mcp/raw-fetch-host-nudge.ts'
 import type * as RunRecordsServiceModule from '#worker/run-records/service.ts'
 import { createInMemoryUserMeterEnv } from '#worker/test-support/user-meter.ts'
 
+const heartbeatMock = vi.hoisted(() => ({
+	scheduleFleetExecuteLastSuccess: vi.fn(),
+}))
+
+vi.mock('#worker/execute-health-heartbeat.ts', () => heartbeatMock)
+
 const mockModule = vi.hoisted(() => ({
 	runModuleWithRegistry: vi.fn(),
 	createExecutePackageInvokeTools: vi.fn(),
@@ -119,6 +125,7 @@ async function getExecuteRegistration(
 	agentExtras: {
 		state?: Record<string, unknown>
 		setState?: (state: Record<string, unknown>) => void
+		waitUntil?: (promise: Promise<unknown>) => void
 	} = {},
 ) {
 	vi.clearAllMocks()
@@ -1062,4 +1069,33 @@ test('execute tool attaches entitlement metadata on denials and quota, not on su
 		used: quotaLimit,
 		remaining: 0,
 	})
+})
+
+test('successful execute completion schedules a fail-open fleet heartbeat and caller errors do not', async () => {
+	const handler = await getExecuteHandler()
+	mockPerformanceSequence(1, 2)
+	mockModule.runModuleWithRegistry.mockResolvedValueOnce({
+		result: { ok: true },
+		logs: [],
+	})
+	const success = await handler({
+		code: 'export default async () => ({ ok: true })',
+		conversationId: 'conv-heartbeat-success',
+	})
+	expect(success.isError).toBe(false)
+	expect(heartbeatMock.scheduleFleetExecuteLastSuccess).toHaveBeenCalledTimes(1)
+
+	heartbeatMock.scheduleFleetExecuteLastSuccess.mockClear()
+	mockPerformanceSequence(3, 4)
+	mockModule.runModuleWithRegistry.mockResolvedValueOnce({
+		error: new Error('caller boom'),
+		logs: [],
+	})
+	const failure = await handler({
+		code: 'export default async () => { throw new Error("caller boom") }',
+		conversationId: 'conv-heartbeat-error',
+	})
+	expect(failure.isError).toBe(true)
+	expect(heartbeatMock.scheduleFleetExecuteLastSuccess).not.toHaveBeenCalled()
+	heartbeatMock.scheduleFleetExecuteLastSuccess.mockReset()
 })

--- a/packages/worker/src/mcp/tools/execute.ts
+++ b/packages/worker/src/mcp/tools/execute.ts
@@ -63,6 +63,7 @@ import {
 	type RunRecord,
 	type RunRecordHandle,
 } from '#worker/run-records/types.ts'
+import { scheduleFleetExecuteLastSuccess } from '#worker/execute-health-heartbeat.ts'
 
 export const executeTool = {
 	name: 'execute',
@@ -592,6 +593,13 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 									passthrough.structuredResult,
 									responseLimitBytes,
 								)
+					const isError = passthrough?.isError ?? false
+					if (!isError) {
+						scheduleFleetExecuteLastSuccess({
+							waitUntil,
+							kv: env.BUNDLE_ARTIFACTS_KV,
+						})
+					}
 
 					return {
 						content: prependToolMetadataContent(resolvedConversationId, [
@@ -621,7 +629,7 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 								: {}),
 							...buildMemoryStructuredContent(surfacedMemories),
 						},
-						isError: passthrough?.isError ?? false,
+						isError,
 					}
 				}
 
@@ -640,6 +648,13 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 							responseLimitBytes,
 						)
 					: limitedResult
+				const isError = markerOnlyPassthrough?.isError ?? false
+				if (!isError) {
+					scheduleFleetExecuteLastSuccess({
+						waitUntil,
+						kv: env.BUNDLE_ARTIFACTS_KV,
+					})
+				}
 
 				return {
 					content: prependToolMetadataContent(resolvedConversationId, [
@@ -673,7 +688,7 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 							: {}),
 						...buildMemoryStructuredContent(surfacedMemories),
 					},
-					isError: markerOnlyPassthrough?.isError ?? false,
+					isError,
 				}
 			}
 		},

--- a/packages/worker/src/origin-handler.ts
+++ b/packages/worker/src/origin-handler.ts
@@ -35,6 +35,10 @@ import { getRequestIp } from '#worker/audit-log.ts'
 import { discardUnreadRequestBody } from '#worker/request-body.ts'
 import { handleCapabilityReindexRequest } from './capability-maintenance.ts'
 import { handleExecuteSmokeRequest } from './execute-maintenance.ts'
+import {
+	executeHealthMaintenancePath,
+	handleExecuteHealthProbeRequest,
+} from './execute-health-probe.ts'
 import { handleJobReindexRequest } from './job-maintenance.ts'
 import { handleMemoryReindexRequest } from './memory-maintenance.ts'
 import {
@@ -240,6 +244,18 @@ const appHandler = withCors({
 			// Origin-only: proves this script's ctx.exports.KodyFetchGateway.
 			// MCP execute looks up the gateway on kody-platform.
 			return handleExecuteSmokeRequest(request, env)
+		}
+
+		if (url.pathname === executeHealthMaintenancePath) {
+			return handleExecuteHealthProbeRequest(
+				request,
+				env,
+				ctx,
+				(mcpRequest, mcpEnv, mcpContext) =>
+					loadLegacyMcpFetch().then((fetchLegacy) =>
+						fetchLegacy(mcpRequest, mcpEnv, mcpContext),
+					),
+			)
 		}
 
 		if (url.pathname === '/__maintenance/reindex-memories') {

--- a/packages/worker/src/security/public-route-hardening.workers.test.ts
+++ b/packages/worker/src/security/public-route-hardening.workers.test.ts
@@ -128,6 +128,11 @@ test('public route hardening rejects retired connector paths, unknown paths, and
 			notConfiguredMessage: 'Status incident events are not configured',
 		},
 		{
+			path: '/__maintenance/mcp-execute-health',
+			secret: env.STATUS_INCIDENT_EVENT_SECRET,
+			notConfiguredMessage: 'MCP execute health probe is not configured',
+		},
+		{
 			path: '/__maintenance/reencrypt-secrets',
 			secret: env.CAPABILITY_REINDEX_SECRET,
 			notConfiguredMessage: 'Secret re-encryption is not configured',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Give launch-day status an honest, cheap signal that authenticated MCP `execute` is actually completing, using organic traffic first and at most one tiny synthetic per hour.

## Why

Public `/health` and origin-only execute-smoke do not prove the authenticated platform MCP execute path. Analytics Engine rollups and the fleet package-error snapshot are hourly, not a minute-fresh heartbeat. We need evidence with source and last-verified time, without turning silence into an outage or letting status-page GETs start paid workers.

## Summary

- Successful MCP execute completion writes a timestamp-only coalesced fleet heartbeat (no user identities, code, results, or credentials). Heartbeat failures never fail customer execute and are not a hot D1 write.
- Cheap per-minute status probes stay as they are. `/health/components` reports the last-success timestamp and never runs execute.
- If that success is older than one minute, the status worker runs at most one authenticated `POST /__maintenance/mcp-execute-health` per rolling hour. Failed attempts consume the budget. Concurrent ticks cannot duplicate.
- Status page / `status.json` show execute evidence: source, freshness, and actual last-verified time. Missing or stale telemetry is unknown / not recently exercised, not down, and does not change overall status or hide other incidents.
- Caller-code execute errors do not write the heartbeat and are not treated as a platform outage. Activity success/error ratio is not used.

## Testing

- Focused node-unit plus `test:push` on `ef6e686d`: 903 node-unit files / 2858 tests and 94 workers-unit files / 341 tests, all passed.
- CI on this head: Static, Node, Workers, MCP, E2E, Validate green. Bugbot found no new issues. CodeRabbit completed.
- Preview `kody-pr-2154` (merge `8688a661` of `ef6e686d`), signed in as `me@kentcdodds.com`:
  - `GET /health` cheap liveness
  - `GET /health/components` has `executeEvidence.lastSuccessAt: null` (unknown, not healthy)
  - `GET /__maintenance/mcp-execute-health` 405
  - unauthenticated `POST` 503 (not configured; no paid execute)
  - `GET /mcp` 401
- Status worker is production-only. After merge, verify `https://status.kody.codes/health` SHA, `status.json` `executeHealth`, and that public GETs do not POST execute.

## Conductor report

- **Scope:** approved launch design only. No new observability primitive, no Activity ratio, no signup/billing/DR/privacy/invite-copy/scheduled-retry ownership.
- **Risk:** medium (`extends` status-page and MCP execute success).
- **Gates:** Bugbot clean on `ef6e686d`, CI green, preview proof recorded. Squash-merging under standing policy.
- **Canary:** production hourly fallback still needs `MCP_EXECUTE_HEALTH_CANARY_ACCESS_TOKEN`. Organic successes report without it. I will message Kent for that secret and will not print the value.
- **Deploy proof required:** confirm `kody-status` actually released (path filter has skipped a green main deploy before).
- **Other tracks:** did not touch scheduled-lane retries, billing, invite copy, or privacy.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `8a926d23` · **Head:** `ef6e686d`

**Classification:** extends — status-page gains execute evidence and an hourly synthetic, and MCP execute success writes a coalesced last-success heartbeat.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `status-page` | surfaces | extends — snapshot `executeHealth`, hourly single-flight synthetic |
| `mcp-server` | surfaces | extends — success completion schedules a timestamp-only heartbeat |
| `app-ui` | surfaces | extends — `/health/components` reports execute evidence, never runs execute |
| `secrets` | assistant | composes — maintenance-route hardening test only |

Unmatched paths: origin maintenance probe, heartbeat helper, env schema, and architecture docs.

### Change flow

Organic MCP execute completion writes a coalesced timestamp. The status minute tick reads it cheaply and skips or claims one hourly authenticated execute.

```mermaid
sequenceDiagram
	actor Caller
	participant mcpServer as mcp-server
	participant appUi as app-ui
	participant statusPage as status-page
	Caller->>mcpServer: authenticated execute completes
	mcpServer->>appUi: waitUntil coalesced last-success timestamp
	Note over appUi: KV timestamp only, no identities
	statusPage->>appUi: GET /health/components
	appUi-->>statusPage: executeEvidence.lastSuccessAt
	alt organic success in previous minute
		statusPage-->>statusPage: skip synthetic
	else no recent organic success
		statusPage->>appUi: POST /__maintenance/mcp-execute-health
		appUi->>mcpServer: legacy authenticated execute
		Note over statusPage: failed attempts consume the hourly budget
	end
	statusPage-->>Caller: status.json executeHealth source and lastVerifiedAt
```

### Invariants

- Public `/health`, `/`, and `/status.json` never start paid execute.
- Missing or stale telemetry is unknown, not an outage.
- One organic success does not hide other measured component incidents.
- A stale `/health/components` timestamp cannot rewind a newer stored last-success.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6baa0422-a21e-4bf8-9947-ffca05c1e69f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6baa0422-a21e-4bf8-9947-ffca05c1e69f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an “MCP execute” health card to the status page.
  - Displays verification status, source, details, and last successful verification time.
  - Successful authenticated executions provide live evidence; an authenticated fallback check runs at most hourly when evidence is stale.
  - Missing or outdated evidence appears as “unknown,” not an outage.
  - Public health and status-page requests do not trigger execution checks.

- **Documentation**
  - Updated architecture, setup, and status documentation to explain MCP execute health evidence and verification behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->