### PR TITLE
Return a table of contents for oversized official guides

### DIFF
--- a/docs/contributing/documentation.md
+++ b/docs/contributing/documentation.md
@@ -23,7 +23,9 @@ the client-route and node-test file-size allowlists and rejects decorative
 `========` / `----------` comment banners. `kody-custom/no-tautological-absence`
 rejects vanished-copy `not.toContain` leftovers in tests during `npm run lint`.
 `npm run knip` fails on unused files, exports, and types against the configured
-entrypoints. These run as part of `npm run validate`.
+entrypoints. `kody-custom/no-oversized-guide-section` rejects official guide
+headings that exceed the search response budget. These run as part of
+`npm run validate`.
 
 Docs-like product copy follows the same rule: MCP server instructions, tool and
 schema descriptions, and user-visible UI strings should not read like release

--- a/docs/contributing/oxlint-js-plugins.md
+++ b/docs/contributing/oxlint-js-plugins.md
@@ -70,11 +70,11 @@ spawning the linter for every case.
 `kody-custom/no-oversized-guide-section` walks official guides under
 `docs/guides/` (not `README.md`) and reports on
 `packages/worker/src/guides/catalog.ts` when a requestable heading (`##` or
-deeper) exceeds the search response budget (`maxChars` in
-`packages/worker/src/mcp/tools/search-constants.ts`). Helpers live in
-`guide-section-budget.js` so `tools/oxlint/guide-section-budget.node.test.ts`
-can assert the parser against the runtime heading code without spawning oxlint
-for every case.
+deeper) exceeds the search body budget: `maxChars` minus the `{id}:guide` entity
+header and mode line. Helpers live in `guide-section-budget.js` so
+`tools/oxlint/guide-section-budget.node.test.ts` can assert the parser and
+budget against the runtime heading and header code without spawning oxlint for
+every case.
 
 Repo-wide syntactic bans that do not need a custom visitor live in the same
 config as built-in rules: `typescript/no-explicit-any` and

--- a/docs/contributing/oxlint-js-plugins.md
+++ b/docs/contributing/oxlint-js-plugins.md
@@ -67,6 +67,15 @@ reports on the current test file.
 `tools/oxlint/tautological-absence.node.test.ts` asserts the heuristic without
 spawning the linter for every case.
 
+`kody-custom/no-oversized-guide-section` walks official guides under
+`docs/guides/` (not `README.md`) and reports on
+`packages/worker/src/guides/catalog.ts` when a requestable heading (`##` or
+deeper) exceeds the search response budget (`maxChars` in
+`packages/worker/src/mcp/tools/search-constants.ts`). Helpers live in
+`guide-section-budget.js` so `tools/oxlint/guide-section-budget.node.test.ts`
+can assert the parser against the runtime heading code without spawning oxlint
+for every case.
+
 Repo-wide syntactic bans that do not need a custom visitor live in the same
 config as built-in rules: `typescript/no-explicit-any` and
 `eslint/no-warning-comments` for `TODO` / `FIXME` / `HACK`. The Remix `on()`

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -8,7 +8,8 @@ bundled into origin and `kody-platform` at build time so web `/guides` and
 guide deploys upload those two scripts and skip runtime and jobs:
 
 - **`search({ entity: "{id}:guide" })`** over MCP — pass the stable frontmatter
-  `id` (for example `package_authoring:guide`)
+  `id` (for example `package_authoring:guide`). Oversized guides return a table
+  of contents; open a heading with `{id}:guide#{slug}`
 - **`/guides`** on the web — Work with Kody index (Start here + more guides)
 - **`/guides/connect`** — connection (provider) walkthrough index
 - **Raw markdown** — `/guides/<slug>.md`, `/guides.md`, `/guides/connect.md`, or

--- a/docs/use/search.md
+++ b/docs/use/search.md
@@ -115,9 +115,10 @@ bundled body as the web `/guides` pages) when it fits the search response
 budget. Oversized guides return a table of contents instead of truncating
 mid-document. Open one heading with `"{id}:guide#{slug}"` (for example
 `package_subscriptions:guide#repo.pushed`). Official guide headings themselves
-must fit that budget (`kody-custom/no-oversized-guide-section`). Capability
-entities additionally include a ready-to-run **execute** snippet plus
-`inputTypeDefinition` / `outputTypeDefinition`.
+must fit the remaining budget after the search entity header
+(`kody-custom/no-oversized-guide-section`). Capability entities additionally
+include a ready-to-run **execute** snippet plus `inputTypeDefinition` /
+`outputTypeDefinition`.
 
 Pass an **array of 1–10 entity refs** when you need several related details at
 once (for example a create/poll MCP pair). Each ref resolves independently:

--- a/docs/use/search.md
+++ b/docs/use/search.md
@@ -114,9 +114,10 @@ To inspect one hit, call **search** again with **`entity`** set to
 bundled body as the web `/guides` pages) when it fits the search response
 budget. Oversized guides return a table of contents instead of truncating
 mid-document. Open one heading with `"{id}:guide#{slug}"` (for example
-`package_subscriptions:guide#repo.pushed`). Capability entities additionally
-include a ready-to-run **execute** snippet plus `inputTypeDefinition` /
-`outputTypeDefinition`.
+`package_subscriptions:guide#repo.pushed`). Official guide headings themselves
+must fit that budget (`kody-custom/no-oversized-guide-section`). Capability
+entities additionally include a ready-to-run **execute** snippet plus
+`inputTypeDefinition` / `outputTypeDefinition`.
 
 Pass an **array of 1–10 entity refs** when you need several related details at
 once (for example a create/poll MCP pair). Each ref resolves independently:

--- a/docs/use/search.md
+++ b/docs/use/search.md
@@ -110,8 +110,11 @@ a tight size budget does not drop them.
 
 To inspect one hit, call **search** again with **`entity`** set to
 `"{id}:{type}"` where **`type`** is `capability`, `guide`, `integration`,
-`package`, or `secret`. Guide entities return the full official markdown (the
-same bundled body as the web `/guides` pages). Capability entities additionally
+`package`, or `secret`. Guide entities return the official markdown (the same
+bundled body as the web `/guides` pages) when it fits the search response
+budget. Oversized guides return a table of contents instead of truncating
+mid-document. Open one heading with `"{id}:guide#{slug}"` (for example
+`package_subscriptions:guide#repo.pushed`). Capability entities additionally
 include a ready-to-run **execute** snippet plus `inputTypeDefinition` /
 `outputTypeDefinition`.
 
@@ -123,6 +126,7 @@ every ref fails, the tool returns an error result.
 Examples:
 
 - `package_authoring:guide`
+- `package_subscriptions:guide#repo.pushed`
 - `["package_authoring:guide", "package_lifecycle:guide"]`
 - `codingGuideGet:capability`
 - `["mcp:linear:create_issue:capability", "mcp:linear:get_issue:capability"]`
@@ -133,10 +137,11 @@ Examples:
 - `githubPat:secret`
 
 Official guides are first-class entities. Ranked search can return `{id}:guide`
-hits; `search({ entity: "package_authoring:guide" })` returns the full bundled
-markdown. Prefer that over executing `codingGuideGet` just to read a guide.
-`codingGuideGet` is for execute-module code that needs the body
-programmatically.
+hits; `search({ entity: "package_authoring:guide" })` returns the bundled
+markdown, or a contents index when that file exceeds the response budget. Prefer
+that over executing `codingGuideGet` just to read a guide. `codingGuideGet` is
+for execute-module code that needs the body programmatically and accepts the
+same optional `section` heading.
 
 There is **no separate `detail` flag** on search. Deeper inspection uses
 **`entity`**, not a different mode of the same ranked query.

--- a/packages/worker/src/guides/document-sections.node.test.ts
+++ b/packages/worker/src/guides/document-sections.node.test.ts
@@ -1,0 +1,120 @@
+import { expect, test } from 'vitest'
+
+import {
+	findDocumentHeading,
+	formatDocumentContents,
+	parseDocumentHeadings,
+	resolveMarkdownDocument,
+	slugifyDocumentHeading,
+} from './document-sections.ts'
+
+const sample = `# Title
+
+Intro paragraph.
+
+## Manifest shape
+
+Manifest details.
+
+### Handler guidance
+
+Handler details.
+
+## \`repo.pushed\`
+
+Repo payload.
+
+\`\`\`md
+## Fake heading in a fence
+\`\`\`
+
+## Filters on package-emitted topics
+
+Filter rules.
+`
+
+test('document sections parse headings, skip fences, and resolve by slug or title', () => {
+	expect(slugifyDocumentHeading('`repo.pushed`')).toBe('repo.pushed')
+	expect(slugifyDocumentHeading('Filters on package-emitted topics')).toBe(
+		'filters-on-package-emitted-topics',
+	)
+
+	const headings = parseDocumentHeadings(sample)
+	expect(headings.map((heading) => heading.slug)).toEqual([
+		'title',
+		'manifest-shape',
+		'handler-guidance',
+		'repo.pushed',
+		'filters-on-package-emitted-topics',
+	])
+	expect(
+		headings.some((heading) => heading.title.includes('Fake heading')),
+	).toBe(false)
+
+	const repo = findDocumentHeading(headings, 'repo.pushed')
+	expect(repo?.title).toBe('`repo.pushed`')
+	expect(findDocumentHeading(headings, 'Repo.pushed')?.slug).toBe('repo.pushed')
+	expect(
+		findDocumentHeading(headings, 'Filters on package-emitted topics')?.slug,
+	).toBe('filters-on-package-emitted-topics')
+	expect(findDocumentHeading(headings, 'missing-section')).toBeNull()
+
+	const full = resolveMarkdownDocument({
+		markdown: sample,
+		maxChars: 10_000,
+		entityRef: 'demo:guide',
+	})
+	expect(full.mode).toBe('full')
+	expect(full.markdown).toBe(sample)
+
+	const toc = resolveMarkdownDocument({
+		markdown: sample,
+		maxChars: 80,
+		entityRef: 'demo:guide',
+	})
+	expect(toc.mode).toBe('toc')
+	expect(toc.markdown).toContain('## Contents')
+	expect(toc.markdown).toContain('demo:guide#repo.pushed')
+	expect(toc.markdown).not.toContain('Repo payload.')
+	expect(toc.markdown).not.toContain('Fake heading in a fence')
+
+	const section = resolveMarkdownDocument({
+		markdown: sample,
+		maxChars: 80,
+		entityRef: 'demo:guide',
+		section: 'repo.pushed',
+	})
+	expect(section.mode).toBe('section')
+	expect(section.markdown).toContain('## `repo.pushed`')
+	expect(section.markdown).toContain('Repo payload.')
+	expect(section.markdown).not.toContain('Filter rules.')
+	expect(section.selected?.slug).toBe('repo.pushed')
+
+	expect(() =>
+		resolveMarkdownDocument({
+			markdown: sample,
+			maxChars: 80,
+			entityRef: 'demo:guide',
+			section: 'not-a-heading',
+		}),
+	).toThrow(/Unknown section "not-a-heading" for demo:guide/)
+
+	const contents = formatDocumentContents({
+		headings,
+		entityRef: 'demo:guide',
+	})
+	expect(contents).toContain(
+		'  - `Handler guidance` — `demo:guide#handler-guidance`',
+	)
+
+	const oversizedSection = `${'#'.repeat(2)} Only heading\n\n${'x'.repeat(400)}`
+	const truncated = resolveMarkdownDocument({
+		markdown: oversizedSection,
+		maxChars: 160,
+		entityRef: 'demo:guide',
+		section: 'only-heading',
+	})
+	expect(truncated.mode).toBe('section')
+	expect(truncated.markdown).toContain('--- TRUNCATED ---')
+	expect(truncated.markdown.length).toBeLessThanOrEqual(160)
+})

--- a/packages/worker/src/guides/document-sections.node.test.ts
+++ b/packages/worker/src/guides/document-sections.node.test.ts
@@ -118,3 +118,20 @@ test('document sections parse headings, skip fences, and resolve by slug or titl
 	expect(truncated.markdown).toContain('--- TRUNCATED ---')
 	expect(truncated.markdown.length).toBeLessThanOrEqual(160)
 })
+
+test('document sections keep info-string fence lines inside the open block', () => {
+	const nestedFence = [
+		'# Title',
+		'',
+		'```',
+		'```js',
+		'## Nested info-string fence',
+		'```',
+		'',
+		'## Real',
+		'',
+	].join('\n')
+	expect(
+		parseDocumentHeadings(nestedFence).map((heading) => heading.slug),
+	).toEqual(['title', 'real'])
+})

--- a/packages/worker/src/guides/document-sections.ts
+++ b/packages/worker/src/guides/document-sections.ts
@@ -1,0 +1,247 @@
+export type DocumentHeading = {
+	level: number
+	title: string
+	slug: string
+	start: number
+	end: number
+}
+
+export type ResolvedDocumentSection = {
+	mode: 'full' | 'toc' | 'section'
+	markdown: string
+	headings: Array<DocumentHeading>
+	selected: DocumentHeading | null
+}
+
+const headingLinePattern = /^(#{1,6})\s+(.+?)\s*$/
+const fencedBlockPattern = /^(`{3,}|~{3,})/
+
+export function slugifyDocumentHeading(title: string) {
+	return normalizeHeadingKey(title)
+		.replace(/[^\p{L}\p{N}._-]+/gu, '-')
+		.replace(/-+/g, '-')
+		.replace(/^-+|-+$/g, '')
+}
+
+export function parseDocumentHeadings(
+	markdown: string,
+): Array<DocumentHeading> {
+	const lines = markdown.split('\n')
+	const parsed: Array<Omit<DocumentHeading, 'end' | 'slug'>> = []
+	let fence: string | null = null
+
+	for (let index = 0; index < lines.length; index += 1) {
+		const line = lines[index] ?? ''
+		const fenceMatch = line.match(fencedBlockPattern)
+		if (fenceMatch) {
+			const marker = fenceMatch[1] ?? ''
+			if (fence == null) {
+				fence = marker
+			} else if (marker[0] === fence[0] && marker.length >= fence.length) {
+				fence = null
+			}
+			continue
+		}
+		if (fence != null) continue
+
+		const headingMatch = line.match(headingLinePattern)
+		if (!headingMatch) continue
+		const marks = headingMatch[1] ?? ''
+		const rawTitle = headingMatch[2] ?? ''
+		parsed.push({
+			level: marks.length,
+			title: rawTitle.replace(/\s+#+\s*$/, '').trim(),
+			start: index,
+		})
+	}
+
+	const usedSlugs = new Map<string, number>()
+	return parsed.map((heading, index) => {
+		const nextSameOrHigher = parsed
+			.slice(index + 1)
+			.find((candidate) => candidate.level <= heading.level)
+		const baseSlug = slugifyDocumentHeading(heading.title) || 'section'
+		const seen = usedSlugs.get(baseSlug) ?? 0
+		usedSlugs.set(baseSlug, seen + 1)
+		return {
+			...heading,
+			slug: seen === 0 ? baseSlug : `${baseSlug}-${String(seen + 1)}`,
+			end: nextSameOrHigher?.start ?? lines.length,
+		}
+	})
+}
+
+export function findDocumentHeading(
+	headings: ReadonlyArray<DocumentHeading>,
+	section: string,
+) {
+	const requested = decodeSectionFragment(section)
+	if (!requested) return null
+	const requestedSlug = slugifyDocumentHeading(requested)
+	return (
+		headings.find((heading) => heading.slug === requested) ??
+		headings.find((heading) => heading.slug === requestedSlug) ??
+		headings.find(
+			(heading) => normalizeHeadingKey(heading.title) === requested,
+		) ??
+		headings.find(
+			(heading) =>
+				normalizeHeadingKey(heading.title) === normalizeHeadingKey(requested),
+		) ??
+		null
+	)
+}
+
+export function formatDocumentContents(input: {
+	headings: ReadonlyArray<DocumentHeading>
+	entityRef: string
+	parent?: DocumentHeading | null
+}) {
+	const requestable = requestableHeadings(input.headings, input.parent)
+	const lines = [
+		'## Contents',
+		'',
+		input.parent
+			? `Section ${formatHeadingLabel(input.parent.title)} is larger than the search response budget. Open a subsection:`
+			: 'This document is larger than the search response budget. Open one section:',
+		'',
+		...requestable.map((heading) => {
+			const indent = '  '.repeat(Math.max(0, heading.level - 2))
+			return `${indent}- ${formatHeadingLabel(heading.title)} — \`${input.entityRef}#${heading.slug}\``
+		}),
+		'',
+		`Request a section with \`search({ entity: "${input.entityRef}#${requestable[0]?.slug ?? 'section-slug'}" })\`.`,
+	]
+	return lines.join('\n')
+}
+
+export function resolveMarkdownDocument(input: {
+	markdown: string
+	maxChars: number
+	entityRef: string
+	section?: string
+}): ResolvedDocumentSection {
+	const headings = parseDocumentHeadings(input.markdown)
+	if (input.section != null) {
+		const selected = findDocumentHeading(headings, input.section)
+		if (!selected) {
+			const available = requestableHeadings(headings)
+				.map((heading) => heading.slug)
+				.join(', ')
+			throw new Error(
+				`Unknown section ${JSON.stringify(input.section)} for ${input.entityRef}. Available: ${available || 'none'}.`,
+			)
+		}
+		return resolveSelectedSection({
+			markdown: input.markdown,
+			maxChars: input.maxChars,
+			entityRef: input.entityRef,
+			headings,
+			selected,
+		})
+	}
+
+	if (input.markdown.length <= input.maxChars) {
+		return {
+			mode: 'full',
+			markdown: input.markdown,
+			headings,
+			selected: null,
+		}
+	}
+
+	return {
+		mode: 'toc',
+		markdown: formatDocumentContents({
+			headings,
+			entityRef: input.entityRef,
+		}),
+		headings,
+		selected: null,
+	}
+}
+
+function resolveSelectedSection(input: {
+	markdown: string
+	maxChars: number
+	entityRef: string
+	headings: Array<DocumentHeading>
+	selected: DocumentHeading
+}): ResolvedDocumentSection {
+	const lines = input.markdown.split('\n')
+	const sectionMarkdown = lines
+		.slice(input.selected.start, input.selected.end)
+		.join('\n')
+		.trim()
+	if (sectionMarkdown.length <= input.maxChars) {
+		return {
+			mode: 'section',
+			markdown: sectionMarkdown,
+			headings: input.headings,
+			selected: input.selected,
+		}
+	}
+
+	const childHeadings = requestableHeadings(input.headings, input.selected)
+	if (childHeadings.length === 0) {
+		const footer =
+			'\n\n--- TRUNCATED ---\nThis section is larger than the search response budget and has no subsections.'
+		const budget = Math.max(0, input.maxChars - footer.length)
+		return {
+			mode: 'section',
+			markdown: `${sectionMarkdown.slice(0, budget)}${footer}`,
+			headings: input.headings,
+			selected: input.selected,
+		}
+	}
+
+	return {
+		mode: 'toc',
+		markdown: formatDocumentContents({
+			headings: input.headings,
+			entityRef: input.entityRef,
+			parent: input.selected,
+		}),
+		headings: input.headings,
+		selected: input.selected,
+	}
+}
+
+function requestableHeadings(
+	headings: ReadonlyArray<DocumentHeading>,
+	parent?: DocumentHeading | null,
+) {
+	if (parent) {
+		return headings.filter(
+			(heading) =>
+				heading.start > parent.start &&
+				heading.start < parent.end &&
+				heading.level > parent.level,
+		)
+	}
+	const belowTitle = headings.filter((heading) => heading.level >= 2)
+	return belowTitle.length > 0 ? belowTitle : [...headings]
+}
+
+function formatHeadingLabel(title: string) {
+	return /[`*_[\]]/.test(title) ? title : `\`${title}\``
+}
+
+function decodeSectionFragment(section: string) {
+	const trimmed = section.trim()
+	if (!trimmed) return ''
+	try {
+		return normalizeHeadingKey(decodeURIComponent(trimmed.replace(/\+/g, ' ')))
+	} catch {
+		return normalizeHeadingKey(trimmed)
+	}
+}
+
+function normalizeHeadingKey(value: string) {
+	return value
+		.replace(/[`*_~]/g, '')
+		.replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')
+		.replace(/\s+/g, ' ')
+		.trim()
+		.toLowerCase()
+}

--- a/packages/worker/src/guides/document-sections.ts
+++ b/packages/worker/src/guides/document-sections.ts
@@ -37,7 +37,11 @@ export function parseDocumentHeadings(
 			const marker = fenceMatch[1] ?? ''
 			if (fence == null) {
 				fence = marker
-			} else if (marker[0] === fence[0] && marker.length >= fence.length) {
+			} else if (
+				marker[0] === fence[0] &&
+				marker.length >= fence.length &&
+				line.slice(marker.length).trim() === ''
+			) {
 				fence = null
 			}
 			continue

--- a/packages/worker/src/mcp/capabilities/coding/kody-official-guide.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/coding/kody-official-guide.node.test.ts
@@ -18,10 +18,27 @@ test('codingGuideGet serves every bundled guide without frontmatter', async () =
 			ctx,
 		)
 		expect(result.title).toBe(guide.title)
-		// Body is served without the frontmatter block and starts at the
-		// authored heading.
+		// Body is served without the frontmatter block. Oversized guides
+		// return a contents index instead of the full authored markdown.
 		expect(result.body.startsWith('#')).toBe(true)
 		expect(result.body).not.toContain('\n---\nid:')
 		expect(result.body.length).toBeGreaterThan(200)
+		if (guide.body.length > 24_000) {
+			expect(result.bodyMode).toBe('toc')
+			expect(result.body).toContain('## Contents')
+			expect(result.body).not.toBe(guide.body)
+		} else {
+			expect(result.bodyMode).toBe('full')
+			expect(result.body).toBe(guide.body)
+		}
 	}
+
+	const section = await kodyOfficialGuideCapability.handler(
+		{ guide: 'package_subscriptions', section: 'repo.pushed' },
+		ctx,
+	)
+	expect(section.bodyMode).toBe('section')
+	expect(section.section?.slug).toBe('repo.pushed')
+	expect(section.body).toContain('type RepoPushedEvent')
+	expect(section.body).not.toContain('type FleetEntitlementCrossedEvent')
 })

--- a/packages/worker/src/mcp/capabilities/coding/kody-official-guide.ts
+++ b/packages/worker/src/mcp/capabilities/coding/kody-official-guide.ts
@@ -2,6 +2,8 @@ import { z } from 'zod'
 import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { type CapabilityContext } from '#mcp/capabilities/types.ts'
+import { maxChars } from '#mcp/tools/search-constants.ts'
+import { resolveMarkdownDocument } from '#worker/guides/document-sections.ts'
 import {
 	guideMetadataList,
 	importGuideCatalog,
@@ -29,7 +31,7 @@ const knownGuideIds = new Set(guideMetadataList.map((guide) => guide.id))
 function buildCapabilityDescription(): string {
 	return [
 		'Load an official Kody guide from execute-module code (markdown, bundled from the kody repository).',
-		'Prefer `search({ entity: "{id}:guide" })` to read a guide — do not execute this capability just to load documentation.',
+		'Prefer `search({ entity: "{id}:guide" })` to read a guide — do not execute this capability just to load documentation. Oversized guides return a table of contents; pass `section` or use `{id}:guide#{slug}` on search.',
 		'This capability stays available for execute-module code that needs the markdown body programmatically.',
 		'The `guide` input lists each available id. Discover guides with `search({ query: "… guide" })`.',
 	].join('\n')
@@ -49,6 +51,13 @@ const guideFieldSchema = z
 
 const inputSchema = z.object({
 	guide: guideFieldSchema,
+	section: z
+		.string()
+		.min(1)
+		.optional()
+		.describe(
+			'Optional heading title or slug. Oversized guides return a table of contents until a section is requested.',
+		),
 })
 
 const outputSchema = z.object({
@@ -56,7 +65,30 @@ const outputSchema = z.object({
 	body: z
 		.string()
 		.describe(
-			'Markdown body bundled from the repository guide file (official, versioned with the deployment).',
+			'Markdown body, a heading section, or a table of contents when the bundled guide exceeds the search response budget.',
+		),
+	bodyMode: z
+		.enum(['full', 'toc', 'section'])
+		.describe(
+			'Whether body is the full guide, a contents index, or one requested heading.',
+		),
+	section: z
+		.object({
+			title: z.string(),
+			slug: z.string(),
+		})
+		.nullable()
+		.describe('The resolved heading when bodyMode is section.'),
+	sections: z
+		.array(
+			z.object({
+				title: z.string(),
+				slug: z.string(),
+				level: z.number().int(),
+			}),
+		)
+		.describe(
+			'Headings that can be requested with section or {id}:guide#{slug}.',
 		),
 })
 
@@ -83,9 +115,29 @@ export const kodyOfficialGuideCapability = defineDomainCapability(
 			if (!guide) {
 				throw new Error(`Unknown Kody guide "${args.guide}".`)
 			}
+			const resolved = resolveMarkdownDocument({
+				markdown: guide.body,
+				maxChars,
+				entityRef: `${guide.id}:guide`,
+				...(args.section ? { section: args.section } : {}),
+			})
 			return {
 				title: guide.title,
-				body: guide.body,
+				body: resolved.markdown,
+				bodyMode: resolved.mode,
+				section: resolved.selected
+					? {
+							title: resolved.selected.title,
+							slug: resolved.selected.slug,
+						}
+					: null,
+				sections: resolved.headings
+					.filter((heading) => heading.level >= 2)
+					.map((heading) => ({
+						title: heading.title,
+						slug: heading.slug,
+						level: heading.level,
+					})),
 			}
 		},
 	},

--- a/packages/worker/src/mcp/instructions/base-server-fragments.ts
+++ b/packages/worker/src/mcp/instructions/base-server-fragments.ts
@@ -6,7 +6,7 @@ https://github.com/kentcdodds/kody/tree/main/docs/use`
 export const quickStartInstructions = `Start here
 - Almost every task: \`search({ query })\` first; pass \`domain\` to narrow (domain ids listed below).
 - One-off work / smoke tests: \`execute\`. Durable reusable behavior: a package (after \`communitySearch\` when nothing in-account fits).
-- Official guides: \`search({ entity: "{id}:guide" })\` for a known id (\`package_authoring\`, \`package_lifecycle\`, \`integration_bootstrap\`, \`oauth\`, or a resolved \`provider_<slug>\`). Discover with \`search({ query: "… guide" })\`, then open that exact entity ref. Skip \`codingGuideGet\` unless execute-module code needs the markdown body.
+- Official guides: \`search({ entity: "{id}:guide" })\` for a known id (\`package_authoring\`, \`package_lifecycle\`, \`integration_bootstrap\`, \`oauth\`, or a resolved \`provider_<slug>\`). Discover with \`search({ query: "… guide" })\`, then open that exact entity ref. Oversized guides return a table of contents; open a heading with \`{id}:guide#{slug}\`. Skip \`codingGuideGet\` unless execute-module code needs the markdown body.
 - Blockers the signed-in human must clear (expired OAuth, expired secrets, MCP reconnects): \`waitingSummary\` or \`/account/waiting\`.`
 
 export const packageLifecycleInstructions = `Package lifecycle (primary mental model):

--- a/packages/worker/src/mcp/tools/guide-search-budget.ts
+++ b/packages/worker/src/mcp/tools/guide-search-budget.ts
@@ -1,0 +1,55 @@
+export const guideContentsModeLine =
+	'- Contents: oversized guide; open a heading with `{id}:guide#{slug}`'
+
+export function guideSectionModeLine(slug: string) {
+	return `- Section: \`${slug}\``
+}
+
+export function buildGuideDetailHeaderLines(input: {
+	id: string
+	description: string
+	category: string
+	slug: string
+	provider?: string | null
+	lastVerified?: string | null
+}) {
+	return [
+		`# Guide — \`${input.id}\``,
+		'',
+		input.description,
+		'',
+		'## Summary',
+		'',
+		`- Entity: \`${input.id}:guide\``,
+		`- Category: \`${input.category}\``,
+		`- Web: \`/guides/${input.slug}\``,
+		...(input.provider ? [`- Provider: ${input.provider}`] : []),
+		...(input.lastVerified
+			? [`- Last verified: \`${input.lastVerified}\``]
+			: []),
+	]
+}
+
+/**
+ * Characters left for the guide body, heading, or TOC after the search
+ * entity header and mode line. Must stay in sync with
+ * `tools/oxlint/guide-section-budget.js`.
+ */
+export function guideSearchBodyBudget(input: {
+	id: string
+	description: string
+	category: string
+	slug: string
+	provider?: string | null
+	lastVerified?: string | null
+	section?: string
+	maxChars: number
+}) {
+	const header = buildGuideDetailHeaderLines(input).join('\n')
+	const mode = Math.max(
+		guideContentsModeLine.length,
+		guideSectionModeLine(input.section ?? 'section').length,
+	)
+	// header + "\n" + mode + "\n\n" + body
+	return Math.max(0, input.maxChars - header.length - mode - 3)
+}

--- a/packages/worker/src/mcp/tools/search-constants.ts
+++ b/packages/worker/src/mcp/tools/search-constants.ts
@@ -1,6 +1,8 @@
 export const charsPerToken = 4
 export const maxTokens = 6_000
 export const maxChars = maxTokens * charsPerToken
+// Official-guide heading sections must stay under `maxChars`. The checker is
+// `kody-custom/no-oversized-guide-section` (`tools/oxlint/guide-section-budget.js`).
 export const defaultSearchLimit = 15
 export const domainBrowseDefaultLimit = 100
 export const defaultMaxResponseSize = 4_000

--- a/packages/worker/src/mcp/tools/search-constants.ts
+++ b/packages/worker/src/mcp/tools/search-constants.ts
@@ -1,8 +1,7 @@
 export const charsPerToken = 4
 export const maxTokens = 6_000
+/** Official-guide heading sections must stay under this budget (`kody-custom/no-oversized-guide-section`). */
 export const maxChars = maxTokens * charsPerToken
-// Official-guide heading sections must stay under `maxChars`. The checker is
-// `kody-custom/no-oversized-guide-section` (`tools/oxlint/guide-section-budget.js`).
 export const defaultSearchLimit = 15
 export const domainBrowseDefaultLimit = 100
 export const defaultMaxResponseSize = 4_000

--- a/packages/worker/src/mcp/tools/search-descriptors.ts
+++ b/packages/worker/src/mcp/tools/search-descriptors.ts
@@ -73,7 +73,7 @@ export function buildRecommendedNextStep(
 		return `Inspect integration detail with \`search({ entity: "${topMatch.integrationName}:integration" })\` and then run a minimal authenticated \`execute\` smoke test before building or calling integration-backed code.`
 	}
 	if (topMatch?.type === 'guide') {
-		return `Open the official guide with \`search({ entity: "${topMatch.id}:guide" })\` to read the full markdown.`
+		return `Open the official guide with \`search({ entity: "${topMatch.id}:guide" })\`. Oversized guides return a table of contents; open a heading with \`{id}:guide#{slug}\`.`
 	}
 	if (topMatch?.type === 'capability') {
 		const accessor = buildKodyCapabilityAccessor(topMatch)

--- a/packages/worker/src/mcp/tools/search-detail.node.test.ts
+++ b/packages/worker/src/mcp/tools/search-detail.node.test.ts
@@ -199,6 +199,31 @@ test('resolveEntityDetail loads official guides without a signed-in user', async
 	expect(detail.body.startsWith('#')).toBe(true)
 	expect(detail.title.length).toBeGreaterThan(0)
 
+	const sectionDetail = await resolveEntityDetail({
+		agent,
+		callerContext: agent.getCallerContext(),
+		userId: null,
+		username: null,
+		entity: 'package_subscriptions:guide#repo.pushed',
+		searchRows: emptySearchRows() as never,
+	})
+	expect(sectionDetail).toMatchObject({
+		type: 'guide',
+		id: 'package_subscriptions',
+		section: 'repo.pushed',
+	})
+
+	await expect(
+		resolveEntityDetail({
+			agent,
+			callerContext: agent.getCallerContext(),
+			userId: null,
+			username: null,
+			entity: 'search_docs:capability#repo.pushed',
+			searchRows: emptySearchRows() as never,
+		}),
+	).rejects.toThrow(/Section fragments are only supported on guide entities/)
+
 	await expect(
 		resolveEntityDetail({
 			agent,

--- a/packages/worker/src/mcp/tools/search-detail.ts
+++ b/packages/worker/src/mcp/tools/search-detail.ts
@@ -29,6 +29,11 @@ export async function resolveEntityDetail(input: {
 	searchRows: SearchRowsAndRegistry
 }) {
 	const ref = parseEntityRef(input.entity)
+	if (ref.section && ref.type !== 'guide') {
+		throw new McpCallerError(
+			'Section fragments are only supported on guide entities. Use "{id}:guide#{heading}".',
+		)
+	}
 	if (ref.type === 'capability') {
 		const spec = input.searchRows.registry.capabilitySpecs[ref.id]
 		if (!spec) {
@@ -64,6 +69,7 @@ export async function resolveEntityDetail(input: {
 			category: guide.category,
 			provider: guide.provider,
 			lastVerified: guide.lastVerified,
+			...(ref.section ? { section: ref.section } : {}),
 		}
 	}
 

--- a/packages/worker/src/mcp/tools/search-entity-plugins/guide.node.test.ts
+++ b/packages/worker/src/mcp/tools/search-entity-plugins/guide.node.test.ts
@@ -137,7 +137,57 @@ test('guide search entities rank advertised docs and open full markdown on entit
 		type: 'guide',
 		entityRef: 'package_authoring:guide',
 		body: loaded!.body,
+		bodyMode: 'full',
+		section: null,
 	})
+
+	const subscriptions =
+		guides.find((guide) => guide.id === 'package_subscriptions') ?? null
+	expect(subscriptions).not.toBeNull()
+	const subscriptionsDetail = formatEntityDetailMarkdown({
+		type: 'guide',
+		id: subscriptions!.id,
+		title: subscriptions!.title,
+		description: subscriptions!.summary,
+		body: subscriptions!.body,
+		slug: subscriptions!.slug,
+		category: subscriptions!.category,
+		provider: subscriptions!.provider,
+		lastVerified: subscriptions!.lastVerified,
+	})
+	expect(subscriptionsDetail.structured).toMatchObject({
+		type: 'guide',
+		bodyMode: 'toc',
+		section: null,
+	})
+	expect(subscriptionsDetail.markdown).toContain('## Contents')
+	expect(subscriptionsDetail.markdown).toContain(
+		'package_subscriptions:guide#repo.pushed',
+	)
+	expect(subscriptionsDetail.markdown).not.toContain('type RepoPushedEvent')
+
+	const repoSection = formatEntityDetailMarkdown({
+		type: 'guide',
+		id: subscriptions!.id,
+		title: subscriptions!.title,
+		description: subscriptions!.summary,
+		body: subscriptions!.body,
+		slug: subscriptions!.slug,
+		category: subscriptions!.category,
+		provider: subscriptions!.provider,
+		lastVerified: subscriptions!.lastVerified,
+		section: 'repo.pushed',
+	})
+	expect(repoSection.structured).toMatchObject({
+		type: 'guide',
+		bodyMode: 'section',
+		entityRef: 'package_subscriptions:guide#repo.pushed',
+		section: { slug: 'repo.pushed' },
+	})
+	expect(repoSection.markdown).toContain('type RepoPushedEvent')
+	expect(repoSection.markdown).not.toContain(
+		'type FleetEntitlementCrossedEvent',
+	)
 
 	expect(
 		buildSearchableEntityDescriptors({

--- a/packages/worker/src/mcp/tools/search-entity-plugins/guide.ts
+++ b/packages/worker/src/mcp/tools/search-entity-plugins/guide.ts
@@ -1,9 +1,12 @@
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
+import { McpCallerError } from '#mcp/caller-error.ts'
 import { guideMetadataList } from '#worker/guide-catalog-modules.ts'
+import { resolveMarkdownDocument } from '#worker/guides/document-sections.ts'
 import { type GuideMetadata } from '#worker/guides/guide-types.ts'
 import { lexicalScore } from '#worker/vectorize/scoring.ts'
 
 import { type SearchEntityPlugin } from '../search-entity-plugin.ts'
+import { maxChars } from '../search-constants.ts'
 import { buildEntityRef, buildGuideUsage } from '../search-format-helpers.ts'
 import { buildCandidateBaseScore } from '../search-scoring.ts'
 import {
@@ -143,7 +146,7 @@ export const guideSearchEntityPlugin = {
 	},
 	formatEntityDetail(detail) {
 		const entityRef = buildEntityRef(detail.id, 'guide')
-		const lines = [
+		const headerLines = [
 			`# Guide — \`${detail.id}\``,
 			'',
 			detail.description,
@@ -157,25 +160,82 @@ export const guideSearchEntityPlugin = {
 			...(detail.lastVerified
 				? [`- Last verified: \`${detail.lastVerified}\``]
 				: []),
-			'',
-			detail.body,
 		]
+		const header = headerLines.join('\n')
+		let resolved
+		try {
+			resolved = resolveMarkdownDocument({
+				markdown: detail.body,
+				maxChars: Math.max(0, maxChars - header.length - 2),
+				entityRef,
+				...(detail.section ? { section: detail.section } : {}),
+			})
+		} catch (error) {
+			throw new McpCallerError(
+				error instanceof Error ? error.message : String(error),
+				{ cause: error },
+			)
+		}
+		const selectedRef = resolved.selected
+			? buildEntityRef(detail.id, 'guide', resolved.selected.slug)
+			: entityRef
+		const modeLines = guideDetailModeLines(resolved)
+		const bodyLines = [...headerLines, ...modeLines, '', resolved.markdown]
 		return {
-			markdown: lines.join('\n'),
+			markdown: bodyLines.join('\n'),
 			structured: {
 				kind: 'entity',
 				type: 'guide',
 				id: detail.id,
-				entityRef,
+				entityRef: selectedRef,
 				title: detail.title,
 				description: detail.description,
-				usage: buildGuideUsage(detail.id),
+				usage: resolved.selected
+					? `search({ entity: ${JSON.stringify(selectedRef)} })`
+					: buildGuideUsage(detail.id),
 				category: detail.category,
 				slug: detail.slug,
-				body: detail.body,
+				body: resolved.markdown,
+				bodyMode: resolved.mode,
+				section: resolved.selected
+					? {
+							title: resolved.selected.title,
+							slug: resolved.selected.slug,
+						}
+					: null,
+				sections: resolved.headings
+					.filter((heading) => heading.level >= 2)
+					.map((heading) => ({
+						title: heading.title,
+						slug: heading.slug,
+						level: heading.level,
+						entityRef: buildEntityRef(detail.id, 'guide', heading.slug),
+					})),
 				provider: detail.provider,
 				lastVerified: detail.lastVerified,
 			},
 		}
 	},
 } satisfies SearchEntityPlugin<'guide'>
+
+function guideDetailModeLines(resolved: {
+	mode: 'full' | 'toc' | 'section'
+	selected: { slug: string } | null
+}) {
+	switch (resolved.mode) {
+		case 'full':
+			return []
+		case 'toc':
+			return [
+				'- Contents: oversized guide; open a heading with `{id}:guide#{slug}`',
+			]
+		case 'section':
+			return resolved.selected
+				? [`- Section: \`${resolved.selected.slug}\``]
+				: []
+		default: {
+			const exhaustive: never = resolved.mode
+			throw new Error(`Unsupported guide detail mode: ${exhaustive}`)
+		}
+	}
+}

--- a/packages/worker/src/mcp/tools/search-entity-plugins/guide.ts
+++ b/packages/worker/src/mcp/tools/search-entity-plugins/guide.ts
@@ -7,6 +7,12 @@ import { lexicalScore } from '#worker/vectorize/scoring.ts'
 
 import { type SearchEntityPlugin } from '../search-entity-plugin.ts'
 import { maxChars } from '../search-constants.ts'
+import {
+	buildGuideDetailHeaderLines,
+	guideContentsModeLine,
+	guideSearchBodyBudget,
+	guideSectionModeLine,
+} from '../guide-search-budget.ts'
 import { buildEntityRef, buildGuideUsage } from '../search-format-helpers.ts'
 import { buildCandidateBaseScore } from '../search-scoring.ts'
 import {
@@ -146,27 +152,15 @@ export const guideSearchEntityPlugin = {
 	},
 	formatEntityDetail(detail) {
 		const entityRef = buildEntityRef(detail.id, 'guide')
-		const headerLines = [
-			`# Guide — \`${detail.id}\``,
-			'',
-			detail.description,
-			'',
-			'## Summary',
-			'',
-			`- Entity: \`${entityRef}\``,
-			`- Category: \`${detail.category}\``,
-			`- Web: \`/guides/${detail.slug}\``,
-			...(detail.provider ? [`- Provider: ${detail.provider}`] : []),
-			...(detail.lastVerified
-				? [`- Last verified: \`${detail.lastVerified}\``]
-				: []),
-		]
-		const header = headerLines.join('\n')
+		const headerLines = buildGuideDetailHeaderLines(detail)
 		let resolved
 		try {
 			resolved = resolveMarkdownDocument({
 				markdown: detail.body,
-				maxChars: Math.max(0, maxChars - header.length - 2),
+				maxChars: guideSearchBodyBudget({
+					...detail,
+					maxChars,
+				}),
 				entityRef,
 				...(detail.section ? { section: detail.section } : {}),
 			})
@@ -226,12 +220,10 @@ function guideDetailModeLines(resolved: {
 		case 'full':
 			return []
 		case 'toc':
-			return [
-				'- Contents: oversized guide; open a heading with `{id}:guide#{slug}`',
-			]
+			return [guideContentsModeLine]
 		case 'section':
 			return resolved.selected
-				? [`- Section: \`${resolved.selected.slug}\``]
+				? [guideSectionModeLine(resolved.selected.slug)]
 				: []
 		default: {
 			const exhaustive: never = resolved.mode

--- a/packages/worker/src/mcp/tools/search-format-helpers.ts
+++ b/packages/worker/src/mcp/tools/search-format-helpers.ts
@@ -21,8 +21,13 @@ export function buildPackageHostedUrl(input: {
 	return resolveHostedPackageAppUrl(input)
 }
 
-export function buildEntityRef(id: string, type: SearchEntityType) {
-	return `${id}:${type}`
+export function buildEntityRef(
+	id: string,
+	type: SearchEntityType,
+	section?: string,
+) {
+	const ref = `${id}:${type}`
+	return section ? `${ref}#${section}` : ref
 }
 
 export function buildCapabilityUsage(spec: {
@@ -132,6 +137,16 @@ function isSearchEntityRefType(type: string): type is SearchEntityType {
 	return (searchEntityRefTypes as ReadonlyArray<string>).includes(type)
 }
 
+function decodeEntitySection(raw: string) {
+	const trimmed = raw.trim()
+	if (!trimmed) return undefined
+	try {
+		return decodeURIComponent(trimmed.replace(/\+/g, ' ')).trim() || undefined
+	} catch {
+		return trimmed
+	}
+}
+
 function formatOneLineSummary(value: string, maxLength = 180) {
 	const summary = value.replace(/\s+/g, ' ').trim()
 	if (summary.length <= maxLength) return summary
@@ -160,16 +175,24 @@ export function formatPackageSchedule(
 export function parseEntityRef(entity: string): {
 	id: string
 	type: SearchEntityType
+	section?: string
 } {
 	const trimmed = entity.trim()
-	const separator = trimmed.lastIndexOf(':')
-	if (separator <= 0 || separator === trimmed.length - 1) {
+	const hash = trimmed.lastIndexOf('#')
+	const colon = trimmed.lastIndexOf(':')
+	const hasSectionFragment = hash > colon && colon > 0
+	const section = hasSectionFragment
+		? decodeEntitySection(trimmed.slice(hash + 1))
+		: undefined
+	const withoutSection = hasSectionFragment ? trimmed.slice(0, hash) : trimmed
+	const separator = withoutSection.lastIndexOf(':')
+	if (separator <= 0 || separator === withoutSection.length - 1) {
 		throw new McpCallerError(
 			`Entity must use the format "{id}:{type}" where type is ${formatSearchEntityRefTypeList()}.`,
 		)
 	}
-	const id = trimmed.slice(0, separator).trim()
-	const type = trimmed.slice(separator + 1).trim()
+	const id = withoutSection.slice(0, separator).trim()
+	const type = withoutSection.slice(separator + 1).trim()
 	if (!isSearchEntityRefType(type)) {
 		throw new McpCallerError(
 			`Entity type must be one of: ${formatSearchEntityRefTypeList()}.`,
@@ -178,7 +201,12 @@ export function parseEntityRef(entity: string): {
 	if (!id) {
 		throw new McpCallerError('Entity id must not be empty.')
 	}
-	return { id, type }
+	if (hasSectionFragment && !section) {
+		throw new McpCallerError(
+			'Section fragment after "{id}:{type}#" must not be empty.',
+		)
+	}
+	return section ? { id, type, section } : { id, type }
 }
 
 export function formatList(items: Array<string>) {

--- a/packages/worker/src/mcp/tools/search-format-types.ts
+++ b/packages/worker/src/mcp/tools/search-format-types.ts
@@ -292,6 +292,17 @@ export type SearchEntityDetailStructured =
 			category: 'platform' | 'provider'
 			slug: string
 			body: string
+			bodyMode: 'full' | 'toc' | 'section'
+			section: {
+				title: string
+				slug: string
+			} | null
+			sections: Array<{
+				title: string
+				slug: string
+				level: number
+				entityRef: string
+			}>
 			provider: string | null
 			lastVerified: string | null
 	  }
@@ -407,6 +418,7 @@ export type SearchEntityDetail =
 			category: 'platform' | 'provider'
 			provider: string | null
 			lastVerified: string | null
+			section?: string
 	  }
 	| {
 			type: 'package'

--- a/packages/worker/src/mcp/tools/search-format.node.test.ts
+++ b/packages/worker/src/mcp/tools/search-format.node.test.ts
@@ -87,6 +87,14 @@ test('search formatting keeps entity refs and generates safe, runnable usage sni
 		id: 'package_authoring',
 		type: 'guide',
 	})
+	expect(parseEntityRef('package_subscriptions:guide#repo.pushed')).toEqual({
+		id: 'package_subscriptions',
+		type: 'guide',
+		section: 'repo.pushed',
+	})
+	expect(() => parseEntityRef('package_subscriptions:guide#')).toThrow(
+		/Section fragment/,
+	)
 
 	const structuredMatches = toSlimStructuredMatches({
 		baseUrl: 'http://localhost',

--- a/packages/worker/src/mcp/tools/search-tool-definition.ts
+++ b/packages/worker/src/mcp/tools/search-tool-definition.ts
@@ -15,7 +15,7 @@ Find built-in capabilities, official guides, saved packages, integrations, and s
 
 **query** — compact ranked markdown + structured matches. Empty or broad queries return a domain index; search again with a more specific query. Domain ids appear on capability hits.
 
-**entity: "{id}:{type}"** — detail for one hit (\`capability\` | \`guide\` | \`integration\` | \`package\` | \`secret\`), or 1–10 refs. Guide detail is the full markdown. Capability detail includes an execute snippet.
+**entity: "{id}:{type}"** — detail for one hit (\`capability\` | \`guide\` | \`integration\` | \`package\` | \`secret\`), or 1–10 refs. Guide detail is the full markdown when it fits the response budget; oversized guides return a table of contents. Open a heading with \`{id}:guide#{slug}\` (for example \`package_subscriptions:guide#repo.pushed\`). Capability detail includes an execute snippet.
 
 Example arguments:
 - \`{ "query": "send a message" }\`
@@ -49,7 +49,7 @@ export const searchToolInputSchema = {
 		])
 		.optional()
 		.describe(
-			'Optional exact entity reference "{id}:{type}" (capability, guide, integration, package, or secret), or an array of 1–10 refs to batch related detail lookups.',
+			'Optional exact entity reference "{id}:{type}" (capability, guide, integration, package, or secret), or an array of 1–10 refs to batch related detail lookups. Guide refs accept "#{heading}" to open one section.',
 		),
 	domain: z
 		.string()

--- a/tools/oxlint/guide-section-budget.js
+++ b/tools/oxlint/guide-section-budget.js
@@ -1,0 +1,157 @@
+import { readdirSync, readFileSync } from 'node:fs'
+import path from 'node:path'
+import { cwd as processCwd } from 'node:process'
+
+/**
+ * Must match `maxChars` in
+ * `packages/worker/src/mcp/tools/search-constants.ts`.
+ */
+export const maxGuideSectionChars = 6_000 * 4
+
+const headingLinePattern = /^(#{1,6})\s+(.+?)\s*$/
+const fencedBlockPattern = /^(`{3,}|~{3,})/
+const officialGuideFilePattern = /\.md$/
+const skipGuideNames = new Set(['README.md'])
+
+export function stripGuideFrontmatter(raw) {
+	const normalized = raw.replace(/^\uFEFF/, '').replace(/\r\n/g, '\n')
+	if (!normalized.startsWith('---\n')) return normalized
+	const endIndex = normalized.indexOf('\n---\n', 4)
+	if (endIndex === -1) return normalized
+	return normalized.slice(endIndex + '\n---\n'.length).replace(/^\n/, '')
+}
+
+export function slugifyDocumentHeading(title) {
+	return normalizeHeadingKey(title)
+		.replace(/[^\p{L}\p{N}._-]+/gu, '-')
+		.replace(/-+/g, '-')
+		.replace(/^-+|-+$/g, '')
+}
+
+export function parseDocumentHeadings(markdown) {
+	const lines = markdown.split('\n')
+	const parsed = []
+	let fence = null
+
+	for (let index = 0; index < lines.length; index += 1) {
+		const line = lines[index] ?? ''
+		const fenceMatch = line.match(fencedBlockPattern)
+		if (fenceMatch) {
+			const marker = fenceMatch[1] ?? ''
+			if (fence == null) {
+				fence = marker
+			} else if (marker[0] === fence[0] && marker.length >= fence.length) {
+				fence = null
+			}
+			continue
+		}
+		if (fence != null) continue
+
+		const headingMatch = line.match(headingLinePattern)
+		if (!headingMatch) continue
+		const marks = headingMatch[1] ?? ''
+		const rawTitle = headingMatch[2] ?? ''
+		parsed.push({
+			level: marks.length,
+			title: rawTitle.replace(/\s+#+\s*$/, '').trim(),
+			start: index,
+		})
+	}
+
+	const usedSlugs = new Map()
+	return parsed.map((heading, index) => {
+		const nextSameOrHigher = parsed
+			.slice(index + 1)
+			.find((candidate) => candidate.level <= heading.level)
+		const baseSlug = slugifyDocumentHeading(heading.title) || 'section'
+		const seen = usedSlugs.get(baseSlug) ?? 0
+		usedSlugs.set(baseSlug, seen + 1)
+		return {
+			...heading,
+			slug: seen === 0 ? baseSlug : `${baseSlug}-${String(seen + 1)}`,
+			end: nextSameOrHigher?.start ?? lines.length,
+		}
+	})
+}
+
+export function findOversizedDocumentSections(
+	markdown,
+	limit = maxGuideSectionChars,
+) {
+	const headings = parseDocumentHeadings(markdown)
+	const lines = markdown.split('\n')
+	const requestable = headings.filter((heading) => heading.level >= 2)
+	const toCheck = requestable.length > 0 ? requestable : headings
+	if (toCheck.length === 0 && markdown.length > limit) {
+		return [
+			{
+				slug: '(document)',
+				title: '(document)',
+				level: 0,
+				chars: markdown.length,
+				limit,
+			},
+		]
+	}
+	return toCheck
+		.map((heading) => {
+			const chars = lines.slice(heading.start, heading.end).join('\n').length
+			return {
+				slug: heading.slug,
+				title: heading.title,
+				level: heading.level,
+				chars,
+				limit,
+			}
+		})
+		.filter((section) => section.chars > section.limit)
+}
+
+export function findOversizedOfficialGuideSections(
+	root = processCwd(),
+	limit = maxGuideSectionChars,
+) {
+	const guidesDir = path.join(root, 'docs/guides')
+	const overflows = []
+	for (const file of listOfficialGuideFiles(guidesDir)) {
+		const raw = readFileSync(file, 'utf8')
+		const body = stripGuideFrontmatter(raw)
+		const relative = path.relative(root, file).replaceAll('\\', '/')
+		for (const section of findOversizedDocumentSections(body, limit)) {
+			overflows.push({ file: relative, ...section })
+		}
+	}
+	return overflows
+}
+
+export function isOfficialGuideCatalogFile(filename, cwd = processCwd()) {
+	const relative =
+		typeof filename === 'string' && path.isAbsolute(filename)
+			? path.relative(cwd, filename).replaceAll('\\', '/')
+			: String(filename ?? '').replaceAll('\\', '/')
+	return relative === 'packages/worker/src/guides/catalog.ts'
+}
+
+function listOfficialGuideFiles(dir) {
+	const files = []
+	for (const entry of readdirSync(dir, { withFileTypes: true })) {
+		const next = path.join(dir, entry.name)
+		if (entry.isDirectory()) {
+			files.push(...listOfficialGuideFiles(next))
+			continue
+		}
+		if (!officialGuideFilePattern.test(entry.name)) continue
+		if (skipGuideNames.has(entry.name)) continue
+		files.push(next)
+	}
+	return files
+}
+
+function normalizeHeadingKey(value) {
+	return value
+		.replace(/[`*_~]/g, '')
+		.replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')
+		.replace(/\s+/g, ' ')
+		.trim()
+		.toLowerCase()
+}

--- a/tools/oxlint/guide-section-budget.js
+++ b/tools/oxlint/guide-section-budget.js
@@ -7,6 +7,8 @@ import { cwd as processCwd } from 'node:process'
  * `packages/worker/src/mcp/tools/search-constants.ts`.
  */
 export const maxGuideSectionChars = 6_000 * 4
+export const guideContentsModeLine =
+	'- Contents: oversized guide; open a heading with `{id}:guide#{slug}`'
 
 const headingLinePattern = /^(#{1,6})\s+(.+?)\s*$/
 const fencedBlockPattern = /^(`{3,}|~{3,})/
@@ -14,11 +16,50 @@ const officialGuideFilePattern = /\.md$/
 const skipGuideNames = new Set(['README.md'])
 
 export function stripGuideFrontmatter(raw) {
-	const normalized = raw.replace(/^\uFEFF/, '').replace(/\r\n/g, '\n')
-	if (!normalized.startsWith('---\n')) return normalized
-	const endIndex = normalized.indexOf('\n---\n', 4)
-	if (endIndex === -1) return normalized
-	return normalized.slice(endIndex + '\n---\n'.length).replace(/^\n/, '')
+	return parseGuideLintSource(raw).body
+}
+
+export function parseGuideLintMetadata(raw, slug) {
+	const parsed = parseGuideLintSource(raw)
+	return {
+		id: parsed.fields.get('id') || slug,
+		description: parsed.fields.get('summary') || '',
+		category: parsed.fields.get('category') || 'platform',
+		slug,
+		provider: parsed.fields.get('provider') ?? null,
+		lastVerified: parsed.fields.get('lastVerified') ?? null,
+	}
+}
+
+export function guideSectionModeLine(slug) {
+	return `- Section: \`${slug}\``
+}
+
+export function buildGuideDetailHeaderLines(input) {
+	return [
+		`# Guide — \`${input.id}\``,
+		'',
+		input.description,
+		'',
+		'## Summary',
+		'',
+		`- Entity: \`${input.id}:guide\``,
+		`- Category: \`${input.category}\``,
+		`- Web: \`/guides/${input.slug}\``,
+		...(input.provider ? [`- Provider: ${input.provider}`] : []),
+		...(input.lastVerified
+			? [`- Last verified: \`${input.lastVerified}\``]
+			: []),
+	]
+}
+
+export function guideSearchBodyBudget(input, maxChars = maxGuideSectionChars) {
+	const header = buildGuideDetailHeaderLines(input).join('\n')
+	const mode = Math.max(
+		guideContentsModeLine.length,
+		guideSectionModeLine(input.section ?? 'section').length,
+	)
+	return Math.max(0, maxChars - header.length - mode - 3)
 }
 
 export function slugifyDocumentHeading(title) {
@@ -78,30 +119,36 @@ export function findOversizedDocumentSections(
 	markdown,
 	limit = maxGuideSectionChars,
 ) {
+	const limitFor = typeof limit === 'function' ? limit : () => limit
 	const headings = parseDocumentHeadings(markdown)
 	const lines = markdown.split('\n')
 	const requestable = headings.filter((heading) => heading.level >= 2)
 	const toCheck = requestable.length > 0 ? requestable : headings
-	if (toCheck.length === 0 && markdown.length > limit) {
-		return [
-			{
-				slug: '(document)',
-				title: '(document)',
-				level: 0,
-				chars: markdown.length,
-				limit,
-			},
-		]
+	if (toCheck.length === 0) {
+		const documentLimit = limitFor({ slug: '(document)', title: '(document)' })
+		if (markdown.length > documentLimit) {
+			return [
+				{
+					slug: '(document)',
+					title: '(document)',
+					level: 0,
+					chars: markdown.length,
+					limit: documentLimit,
+				},
+			]
+		}
+		return []
 	}
 	return toCheck
 		.map((heading) => {
 			const chars = lines.slice(heading.start, heading.end).join('\n').length
+			const sectionLimit = limitFor(heading)
 			return {
 				slug: heading.slug,
 				title: heading.title,
 				level: heading.level,
 				chars,
-				limit,
+				limit: sectionLimit,
 			}
 		})
 		.filter((section) => section.chars > section.limit)
@@ -109,15 +156,19 @@ export function findOversizedDocumentSections(
 
 export function findOversizedOfficialGuideSections(
 	root = processCwd(),
-	limit = maxGuideSectionChars,
+	maxChars = maxGuideSectionChars,
 ) {
 	const guidesDir = path.join(root, 'docs/guides')
 	const overflows = []
 	for (const file of listOfficialGuideFiles(guidesDir)) {
 		const raw = readFileSync(file, 'utf8')
+		const slug = path.basename(file, '.md')
+		const meta = parseGuideLintMetadata(raw, slug)
 		const body = stripGuideFrontmatter(raw)
 		const relative = path.relative(root, file).replaceAll('\\', '/')
-		for (const section of findOversizedDocumentSections(body, limit)) {
+		for (const section of findOversizedDocumentSections(body, (heading) =>
+			guideSearchBodyBudget({ ...meta, section: heading.slug }, maxChars),
+		)) {
 			overflows.push({ file: relative, ...section })
 		}
 	}
@@ -145,6 +196,50 @@ function listOfficialGuideFiles(dir) {
 		files.push(next)
 	}
 	return files
+}
+
+function parseGuideLintSource(raw) {
+	const normalized = raw.replace(/^\uFEFF/, '').replace(/\r\n/g, '\n')
+	if (!normalized.startsWith('---\n')) {
+		return { fields: new Map(), body: normalized }
+	}
+	const endIndex = normalized.indexOf('\n---\n', 4)
+	if (endIndex === -1) {
+		return { fields: new Map(), body: normalized }
+	}
+	const frontmatterBlock = normalized.slice(4, endIndex)
+	const body = normalized.slice(endIndex + '\n---\n'.length).replace(/^\n/, '')
+	const fields = new Map()
+	let currentKey = null
+	const currentParts = []
+
+	function commitCurrentKey() {
+		if (currentKey === null) return
+		fields.set(currentKey, currentParts.join(' ').trim())
+		currentKey = null
+		currentParts.length = 0
+	}
+
+	for (const line of frontmatterBlock.split('\n')) {
+		if (line.trim() === '') continue
+		const indentedContinuation = /^(?: {2}|\t)\s*(.*)$/.exec(line)
+		if (indentedContinuation && currentKey !== null) {
+			const part = indentedContinuation[1]?.trim()
+			if (part) currentParts.push(part)
+			continue
+		}
+		const colonIndex = line.indexOf(':')
+		if (colonIndex === -1) continue
+		commitCurrentKey()
+		currentKey = line.slice(0, colonIndex).trim()
+		const inlineValue = line.slice(colonIndex + 1).trim()
+		if (inlineValue) {
+			currentParts.push(inlineValue)
+			commitCurrentKey()
+		}
+	}
+	commitCurrentKey()
+	return { fields, body }
 }
 
 function normalizeHeadingKey(value) {

--- a/tools/oxlint/guide-section-budget.js
+++ b/tools/oxlint/guide-section-budget.js
@@ -81,7 +81,11 @@ export function parseDocumentHeadings(markdown) {
 			const marker = fenceMatch[1] ?? ''
 			if (fence == null) {
 				fence = marker
-			} else if (marker[0] === fence[0] && marker.length >= fence.length) {
+			} else if (
+				marker[0] === fence[0] &&
+				marker.length >= fence.length &&
+				line.slice(marker.length).trim() === ''
+			) {
 				fence = null
 			}
 			continue

--- a/tools/oxlint/guide-section-budget.node.test.ts
+++ b/tools/oxlint/guide-section-budget.node.test.ts
@@ -43,6 +43,26 @@ test('guide section budget matches search maxChars, header reserve, and heading 
 		slugifyRuntimeHeading('`repo.pushed`'),
 	)
 
+	const nestedFence = [
+		'# Title',
+		'',
+		'```',
+		'```js',
+		'## Nested info-string fence',
+		'```',
+		'',
+		'## Real',
+		'',
+	].join('\n')
+	expect(
+		parseDocumentHeadings(nestedFence).map((heading) => heading.slug),
+	).toEqual(parseRuntimeHeadings(nestedFence).map((heading) => heading.slug))
+	expect(
+		parseDocumentHeadings(nestedFence).some((heading) =>
+			heading.title.includes('Nested info-string'),
+		),
+	).toBe(false)
+
 	const raw = await readFile(
 		path.join(repoRoot, 'docs/guides/package-subscriptions.md'),
 		'utf8',

--- a/tools/oxlint/guide-section-budget.node.test.ts
+++ b/tools/oxlint/guide-section-budget.node.test.ts
@@ -1,0 +1,109 @@
+import { spawnSync } from 'node:child_process'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { expect, test } from 'vitest'
+import { maxChars } from '../../packages/worker/src/mcp/tools/search-constants.ts'
+import {
+	parseDocumentHeadings as parseRuntimeHeadings,
+	slugifyDocumentHeading as slugifyRuntimeHeading,
+} from '../../packages/worker/src/guides/document-sections.ts'
+// @ts-expect-error - the oxlint helper is plain JS with no type declarations.
+import {
+	findOversizedDocumentSections,
+	findOversizedOfficialGuideSections,
+	isOfficialGuideCatalogFile,
+	maxGuideSectionChars,
+	parseDocumentHeadings,
+	slugifyDocumentHeading,
+	stripGuideFrontmatter,
+} from './guide-section-budget.js'
+
+const repoRoot = path.resolve(import.meta.dirname, '../..')
+
+test('guide section budget matches search maxChars and the runtime heading parser', async () => {
+	expect(maxGuideSectionChars).toBe(maxChars)
+	expect(slugifyDocumentHeading('`repo.pushed`')).toBe(
+		slugifyRuntimeHeading('`repo.pushed`'),
+	)
+
+	const subscriptions = stripGuideFrontmatter(
+		await readFile(
+			path.join(repoRoot, 'docs/guides/package-subscriptions.md'),
+			'utf8',
+		),
+	)
+	expect(
+		parseDocumentHeadings(subscriptions).map((heading) => heading.slug),
+	).toEqual(parseRuntimeHeadings(subscriptions).map((heading) => heading.slug))
+
+	expect(findOversizedOfficialGuideSections(repoRoot)).toEqual([])
+	expect(
+		isOfficialGuideCatalogFile(
+			path.join(repoRoot, 'packages/worker/src/guides/catalog.ts'),
+			repoRoot,
+		),
+	).toBe(true)
+	expect(
+		isOfficialGuideCatalogFile('docs/guides/package-subscriptions.md'),
+	).toBe(false)
+})
+
+test('oversized official guide sections fail the budget helper and oxlint rule', async () => {
+	const fixture = [
+		'---',
+		'id: oversized_fixture',
+		'title: Oversized fixture',
+		'summary: Fixture',
+		'category: platform',
+		'---',
+		'',
+		'# Title',
+		'',
+		'## Fits',
+		'',
+		'Short.',
+		'',
+		'## Too long',
+		'',
+		'x'.repeat(maxGuideSectionChars + 1),
+		'',
+	].join('\n')
+
+	expect(stripGuideFrontmatter(fixture).startsWith('# Title')).toBe(true)
+	expect(
+		findOversizedDocumentSections(stripGuideFrontmatter(fixture)).map(
+			(section) => section.slug,
+		),
+	).toEqual(['too-long'])
+
+	const cwd = await mkdtemp(path.join(os.tmpdir(), 'guide-section-budget-'))
+	try {
+		await mkdir(path.join(cwd, 'docs/guides'), { recursive: true })
+		await writeFile(path.join(cwd, 'docs/guides/oversized-fixture.md'), fixture)
+		await writeFile(
+			path.join(cwd, 'docs/guides/README.md'),
+			'# Guides\n\nIndex pages are not official guide entities.\n',
+		)
+		expect(findOversizedOfficialGuideSections(cwd)).toEqual([
+			expect.objectContaining({
+				file: 'docs/guides/oversized-fixture.md',
+				slug: 'too-long',
+				chars: expect.any(Number),
+				limit: maxGuideSectionChars,
+			}),
+		])
+	} finally {
+		await rm(cwd, { recursive: true, force: true })
+	}
+
+	const result = spawnSync(
+		path.join(repoRoot, 'node_modules', 'oxlint', 'bin', 'oxlint'),
+		['packages/worker/src/guides/catalog.ts'],
+		{ cwd: repoRoot, encoding: 'utf8' },
+	)
+	expect(result.stdout + result.stderr).not.toContain(
+		'no-oversized-guide-section',
+	)
+	expect(result.status).toBe(0)
+})

--- a/tools/oxlint/guide-section-budget.node.test.ts
+++ b/tools/oxlint/guide-section-budget.node.test.ts
@@ -3,39 +3,87 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 import { expect, test } from 'vitest'
-import { maxChars } from '../../packages/worker/src/mcp/tools/search-constants.ts'
+import { parseGuideMarkdown } from '../../packages/worker/src/guides/parse-frontmatter.ts'
 import {
 	parseDocumentHeadings as parseRuntimeHeadings,
 	slugifyDocumentHeading as slugifyRuntimeHeading,
 } from '../../packages/worker/src/guides/document-sections.ts'
+import { maxChars } from '../../packages/worker/src/mcp/tools/search-constants.ts'
+import {
+	buildGuideDetailHeaderLines as buildRuntimeHeaderLines,
+	guideContentsModeLine as runtimeContentsModeLine,
+	guideSearchBodyBudget as runtimeSearchBodyBudget,
+	guideSectionModeLine as runtimeSectionModeLine,
+} from '../../packages/worker/src/mcp/tools/guide-search-budget.ts'
 // @ts-expect-error - the oxlint helper is plain JS with no type declarations.
 import {
+	buildGuideDetailHeaderLines,
 	findOversizedDocumentSections,
 	findOversizedOfficialGuideSections,
+	guideContentsModeLine,
+	guideSearchBodyBudget,
+	guideSectionModeLine,
 	isOfficialGuideCatalogFile,
 	maxGuideSectionChars,
 	parseDocumentHeadings,
+	parseGuideLintMetadata,
 	slugifyDocumentHeading,
 	stripGuideFrontmatter,
 } from './guide-section-budget.js'
 
 const repoRoot = path.resolve(import.meta.dirname, '../..')
 
-test('guide section budget matches search maxChars and the runtime heading parser', async () => {
+test('guide section budget matches search maxChars, header reserve, and heading parser', async () => {
 	expect(maxGuideSectionChars).toBe(maxChars)
+	expect(guideContentsModeLine).toBe(runtimeContentsModeLine)
+	expect(guideSectionModeLine('repo.pushed')).toBe(
+		runtimeSectionModeLine('repo.pushed'),
+	)
 	expect(slugifyDocumentHeading('`repo.pushed`')).toBe(
 		slugifyRuntimeHeading('`repo.pushed`'),
 	)
 
-	const subscriptions = stripGuideFrontmatter(
-		await readFile(
-			path.join(repoRoot, 'docs/guides/package-subscriptions.md'),
-			'utf8',
-		),
+	const raw = await readFile(
+		path.join(repoRoot, 'docs/guides/package-subscriptions.md'),
+		'utf8',
+	)
+	const parsed = parseGuideMarkdown('package-subscriptions', raw)
+	const lintMeta = parseGuideLintMetadata(raw, 'package-subscriptions')
+	expect(lintMeta).toMatchObject({
+		id: parsed.id,
+		description: parsed.summary,
+		category: parsed.category,
+		slug: parsed.slug,
+	})
+	expect(buildGuideDetailHeaderLines(lintMeta)).toEqual(
+		buildRuntimeHeaderLines({
+			id: parsed.id,
+			description: parsed.summary,
+			category: parsed.category,
+			slug: parsed.slug,
+			provider: parsed.provider,
+			lastVerified: parsed.lastVerified,
+		}),
 	)
 	expect(
-		parseDocumentHeadings(subscriptions).map((heading) => heading.slug),
-	).toEqual(parseRuntimeHeadings(subscriptions).map((heading) => heading.slug))
+		guideSearchBodyBudget({ ...lintMeta, section: 'repo.pushed' }),
+	).toBeLessThan(maxChars)
+	expect(guideSearchBodyBudget({ ...lintMeta, section: 'repo.pushed' })).toBe(
+		runtimeSearchBodyBudget({
+			id: parsed.id,
+			description: parsed.summary,
+			category: parsed.category,
+			slug: parsed.slug,
+			provider: parsed.provider,
+			lastVerified: parsed.lastVerified,
+			section: 'repo.pushed',
+			maxChars,
+		}),
+	)
+
+	expect(
+		parseDocumentHeadings(parsed.body).map((heading) => heading.slug),
+	).toEqual(parseRuntimeHeadings(parsed.body).map((heading) => heading.slug))
 
 	expect(findOversizedOfficialGuideSections(repoRoot)).toEqual([])
 	expect(
@@ -49,7 +97,7 @@ test('guide section budget matches search maxChars and the runtime heading parse
 	).toBe(false)
 })
 
-test('oversized official guide sections fail the budget helper and oxlint rule', async () => {
+test('oversized official guide sections fail the header-aware budget and oxlint rule', async () => {
 	const fixture = [
 		'---',
 		'id: oversized_fixture',
@@ -69,6 +117,25 @@ test('oversized official guide sections fail the budget helper and oxlint rule',
 		'x'.repeat(maxGuideSectionChars + 1),
 		'',
 	].join('\n')
+	const headerAwareLimit = guideSearchBodyBudget(
+		parseGuideLintMetadata(fixture, 'oversized-fixture'),
+		maxGuideSectionChars,
+	)
+	const justOverHeaderBudget = [
+		'---',
+		'id: header_budget_fixture',
+		'title: Header budget fixture',
+		'summary: A long enough summary to shrink the remaining body budget.',
+		'category: platform',
+		'---',
+		'',
+		'# Title',
+		'',
+		'## Almost',
+		'',
+		'y'.repeat(headerAwareLimit + 80),
+		'',
+	].join('\n')
 
 	expect(stripGuideFrontmatter(fixture).startsWith('# Title')).toBe(true)
 	expect(
@@ -82,17 +149,33 @@ test('oversized official guide sections fail the budget helper and oxlint rule',
 		await mkdir(path.join(cwd, 'docs/guides'), { recursive: true })
 		await writeFile(path.join(cwd, 'docs/guides/oversized-fixture.md'), fixture)
 		await writeFile(
+			path.join(cwd, 'docs/guides/header-budget-fixture.md'),
+			justOverHeaderBudget,
+		)
+		await writeFile(
 			path.join(cwd, 'docs/guides/README.md'),
 			'# Guides\n\nIndex pages are not official guide entities.\n',
 		)
-		expect(findOversizedOfficialGuideSections(cwd)).toEqual([
-			expect.objectContaining({
-				file: 'docs/guides/oversized-fixture.md',
-				slug: 'too-long',
-				chars: expect.any(Number),
-				limit: maxGuideSectionChars,
-			}),
-		])
+		const overflows = findOversizedOfficialGuideSections(cwd)
+		expect(overflows).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					file: 'docs/guides/oversized-fixture.md',
+					slug: 'too-long',
+					chars: expect.any(Number),
+					limit: expect.any(Number),
+				}),
+				expect.objectContaining({
+					file: 'docs/guides/header-budget-fixture.md',
+					slug: 'almost',
+				}),
+			]),
+		)
+		const headerAware = overflows.find(
+			(section) => section.file === 'docs/guides/header-budget-fixture.md',
+		)
+		expect(headerAware?.limit).toBeLessThan(maxGuideSectionChars)
+		expect(headerAware?.chars).toBeLessThanOrEqual(maxGuideSectionChars)
 	} finally {
 		await rm(cwd, { recursive: true, force: true })
 	}

--- a/tools/oxlint/local-plugin.js
+++ b/tools/oxlint/local-plugin.js
@@ -289,12 +289,12 @@ const noOversizedGuideSectionRule = {
 		type: 'problem',
 		docs: {
 			description:
-				'Reject official guide sections that exceed the search response budget so {id}:guide#{slug} can return the full heading.',
+				'Reject official guide sections that exceed the search body budget (maxChars minus the entity header) so {id}:guide#{slug} can return the full heading.',
 		},
 		schema: [],
 		messages: {
 			oversizedSection:
-				'Official guide section "{{file}}#{{slug}}" is {{chars}} characters (limit {{limit}}). Split the heading or move detail so search({ entity: "{id}:guide#{slug}" }) can return the full section.',
+				'Official guide section "{{file}}#{{slug}}" is {{chars}} characters (limit {{limit}} after the search entity header). Split the heading or move detail so search({ entity: "{id}:guide#{slug}" }) can return the full section.',
 		},
 	},
 	createOnce(context) {

--- a/tools/oxlint/local-plugin.js
+++ b/tools/oxlint/local-plugin.js
@@ -1,4 +1,8 @@
 import {
+	findOversizedOfficialGuideSections,
+	isOfficialGuideCatalogFile,
+} from './guide-section-budget.js'
+import {
 	findTautologicalAbsenceMatches,
 	isTestPath,
 	loadTautologicalAbsenceCorpus,
@@ -271,6 +275,52 @@ function tautologicalAbsenceCorpusFor() {
 	return tautologicalAbsenceCorpus
 }
 
+let officialGuideSectionOverflows = null
+
+function officialGuideSectionOverflowsFor() {
+	if (!officialGuideSectionOverflows) {
+		officialGuideSectionOverflows = findOversizedOfficialGuideSections()
+	}
+	return officialGuideSectionOverflows
+}
+
+const noOversizedGuideSectionRule = {
+	meta: {
+		type: 'problem',
+		docs: {
+			description:
+				'Reject official guide sections that exceed the search response budget so {id}:guide#{slug} can return the full heading.',
+		},
+		schema: [],
+		messages: {
+			oversizedSection:
+				'Official guide section "{{file}}#{{slug}}" is {{chars}} characters (limit {{limit}}). Split the heading or move detail so search({ entity: "{id}:guide#{slug}" }) can return the full section.',
+		},
+	},
+	createOnce(context) {
+		return {
+			Program(node) {
+				// createOnce cannot read context.filename at setup. Official
+				// guides are markdown, so this visitor reports on the catalog
+				// TypeScript haystack after walking docs/guides/.
+				if (!isOfficialGuideCatalogFile(context.filename)) return
+				for (const overflow of officialGuideSectionOverflowsFor()) {
+					context.report({
+						node,
+						messageId: 'oversizedSection',
+						data: {
+							file: overflow.file,
+							slug: overflow.slug,
+							chars: String(overflow.chars),
+							limit: String(overflow.limit),
+						},
+					})
+				}
+			},
+		}
+	},
+}
+
 const noTautologicalAbsenceRule = {
 	meta: {
 		type: 'problem',
@@ -383,6 +433,7 @@ const plugin = {
 		'enforce-import-boundaries': enforceImportBoundariesRule,
 		'no-example-identifier': noExampleIdentifierRule,
 		'no-literal-frame-src': noLiteralFrameSrcRule,
+		'no-oversized-guide-section': noOversizedGuideSectionRule,
 		'no-tautological-absence': noTautologicalAbsenceRule,
 		'prefer-loader-data-types': preferLoaderDataTypesRule,
 	},

--- a/tools/oxlint/oxlint-rules.json
+++ b/tools/oxlint/oxlint-rules.json
@@ -41,6 +41,7 @@
 		"kody-custom/enforce-import-boundaries": "error",
 		"kody-custom/no-example-identifier": "error",
 		"kody-custom/no-literal-frame-src": "error",
+		"kody-custom/no-oversized-guide-section": "error",
 		"kody-custom/no-tautological-absence": "error",
 		"kody-custom/prefer-loader-data-types": "error",
 		"typescript/no-explicit-any": "error",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Agents reading official guides over search should get a usable index when a document exceeds the response budget, then open one heading instead of losing the back half of the file. Official-guide headings themselves must stay under that remaining budget.

## Why

`package_subscriptions:guide` is ~13.4k tokens. Search entity detail hard-truncates at 6,000 tokens, so production `search({ entity })` cut mid-sentence in `integration.auth.succeeded` and hid `repo.pushed` and every later topic. `maxResponseSize` cannot raise that ceiling. A lint rule keeps new headings from recreating that overflow, including the search entity header that search subtracts before resolving a section.

## Summary

- Oversized official guides return a table of contents instead of mid-document truncation
- Agents open a heading with `{id}:guide#{slug}` (for example `package_subscriptions:guide#repo.pushed`)
- `codingGuideGet` accepts the same optional `section` and uses the same budget/TOC contract
- Short guides still return the full bundled markdown
- `kody-custom/no-oversized-guide-section` rejects official-guide `##`+ headings over the remaining search body budget (`maxChars` minus the `{id}:guide` header and mode line)
- Fenced `##` lines stay ignored even when a block contains an inner ` ```js ` line

## Testing

- Focused node tests for heading parse, TOC, section lookup, nested info-string fences, `parseEntityRef` fragments, `codingGuideGet`, and `package_subscriptions` TOC/`repo.pushed`
- `tools/oxlint/guide-section-budget.node.test.ts`: parser and header-budget parity with runtime, fixture overflow, current `docs/guides` clean, oxlint on `catalog.ts` clean
- `test:push` green: 2874 node + 341 workers
- Preview `https://kody-pr-2155.kody-a99.workers.dev` at merge SHA `10ca004c` (TOC head `fa04812a`): health/login/session smoke, `/guides/package-subscriptions` 200

## System changes

Extends MCP search guide detail and `codingGuideGet`. Adds `kody-custom/no-oversized-guide-section` so requestable official-guide headings cannot exceed the search body budget. No new primitive.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `24678cd5` · **Head:** `f6c69544`

**Classification:** extends — search guide entity detail and `codingGuideGet` return a contents index when bundled markdown exceeds the response budget, accept a heading slug to load one section, and lint rejects official-guide headings that would overflow the remaining body budget after the search header.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `mcp-server` | surfaces | extends — `{id}:guide#{slug}` entity refs, TOC instead of mid-document truncation, and a shared header-aware body budget |
| `capability-registry` | assistant | extends — `codingGuideGet` accepts `section` and uses the same budget/TOC contract |

Unmatched paths: `packages/worker/src/guides/document-sections.ts` (heading parse/TOC helper), `tools/oxlint/guide-section-budget.js` plus `kody-custom/no-oversized-guide-section`, and usage/guide docs.

### Change flow

Oversized official guides no longer truncate mid-sentence. Search returns a contents index, a follow-up `{id}:guide#{slug}` loads one heading, and lint fails if that heading exceeds the remaining budget after the entity header.

```mermaid
sequenceDiagram
	actor Agent
	participant mcpServer as mcp-server
	participant capabilityRegistry as capability-registry
	Agent->>mcpServer: search entity package_subscriptions:guide
	mcpServer->>mcpServer: resolveMarkdownDocument over header-aware budget
	mcpServer-->>Agent: TOC with package_subscriptions:guide#repo.pushed
	Agent->>mcpServer: search entity package_subscriptions:guide#repo.pushed
	mcpServer-->>Agent: repo.pushed section markdown
	opt execute-module code
	Agent->>capabilityRegistry: codingGuideGet section repo.pushed
	capabilityRegistry-->>Agent: same section body
	end
	Note over mcpServer: kody-custom/no-oversized-guide-section uses maxChars minus the search header
```

### Before / after

**Before:** `search({ entity: "package_subscriptions:guide" })` sliced at 24,000 characters inside `integration.auth.succeeded`. `maxResponseSize` could not raise that ceiling. Guide headings had no size checker.

**After:** the same call returns a contents index. `search({ entity: "package_subscriptions:guide#repo.pushed" })` and `codingGuideGet({ guide, section })` return that heading. Short guides still return the full body. `kody-custom/no-oversized-guide-section` fails lint when a requestable official-guide heading exceeds the remaining search body budget.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-285ffb0f-a1ce-4582-afd4-d6a365ded401?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-285ffb0f-a1ce-4582-afd4-d6a365ded401&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Guide searches return full content when it fits, or a table of contents for oversized guides.
  - Open a specific guide section using the `{id}:guide#{slug}` format.
  - Guide results identify whether content is full, a table of contents, or a selected section.
  - Section navigation is supported by search and programmatic guide retrieval.
  - Section fragments are accepted only for guide entities.

- **Documentation**
  - Updated guide discovery and search guidance with oversized-guide behavior and section navigation examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->