### PR TITLE
Enrich MCP OAuth post-callback settle errors

### DIFF
--- a/docs/contributing/architecture/mcp-client-servers.md
+++ b/docs/contributing/architecture/mcp-client-servers.md
@@ -95,13 +95,16 @@ the `/mcp` endpoint (where Kody is the server) and complements MCP servers
    `connected` / `discovering` to "Discovering tools" only while that work is
    still in flight; when `last_error` is present it says "Tool discovery didn't
    finish" instead of echoing the raw `"connected"` state. Used or missing OAuth
-   `state` on the callback, and connections that are already settling toward
-   `ready`, recover without surfacing an internal state error: the hub restarts
-   authorization when needed, or accepts the in-flight connection. Origin and
-   redirect-URI rejection messages are enriched with Kody's `oauthClientOrigin`
-   and `oauthCallbackUrl`. Reconnect uses the same recovery path (invalidate
-   unusable tokens and request a fresh authorization URL). The account page
-   offers Reconnect when automatic recovery cannot finish.
+   `state` on the callback recover without surfacing an internal state error:
+   the hub restarts authorization when needed. A Back/replay while the
+   connection is still `connected`, `discovering`, or `connecting` keeps the
+   existing tokens and retries discovery when the transport is `connected`, but
+   it does not report `auth=success` or clear `last_error` until the connection
+   is `ready`. Origin and redirect-URI rejection messages are enriched with
+   Kody's `oauthClientOrigin` and `oauthCallbackUrl`. Reconnect uses the same
+   recovery path (invalidate unusable tokens and request a fresh authorization
+   URL). The account page offers Reconnect when automatic recovery cannot
+   finish.
 6. The route redirects to `/account/mcp-servers/:serverId?auth=success|error`
    when the callback resolves to a server (including failures), or
    `/account/mcp-servers?auth=error` when it does not, for user feedback. Tokens

--- a/docs/contributing/architecture/mcp-client-servers.md
+++ b/docs/contributing/architecture/mcp-client-servers.md
@@ -19,18 +19,21 @@ the `/mcp` endpoint (where Kody is the server) and complements MCP servers
   `purgeForAccountDeletion`.
 - **D1 `mcp_server_settings` table**
   (`packages/worker/migrations/0001-squashed-init.sql`, usage columns in
-  `0031-mcp-server-package-usage.sql`) — user-scoped metadata (id, name, url,
-  enabled, `usage_mode` / `allowed_packages_json`, plus optional favicon
-  columns). D1 answers "which servers does this user have enabled" without
-  waking the DO; the DO owns live connection state and tokens. `usage_mode` is
-  `any` (execute plus every package) or `packages` (only the listed saved
-  package ids; execute is denied). Account-page loads fetch the
-  registrable-domain favicon of `url` with the same HTTPS pipeline as user-lane
-  OAuth apps and store a raster under `user-mcp-server-logos/{userId}/{id}/`.
-  The signed-in owner loads it from `/account/mcp-servers/logos/:serverId`.
-  Display order matches OAuth integrations: operator-curated provider mark
-  (matched by server name or `url` host), then auto-favicon, then the letter
-  fallback.
+  `0031-mcp-server-package-usage.sql`, `last_error` in
+  `0054-mcp-server-last-error.sql`) — user-scoped metadata (id, name, url,
+  enabled, `usage_mode` / `allowed_packages_json`, optional favicon columns, and
+  a sanitized `last_error` JSON blob for incomplete post-IdP settle). D1 answers
+  "which servers does this user have enabled" without waking the DO; the DO owns
+  live connection state and tokens. Live `connectionError` on the hub is
+  ephemeral, so an IdP-success / not-ready settle writes `last_error` and the
+  account UI shows it under Status. `usage_mode` is `any` (execute plus every
+  package) or `packages` (only the listed saved package ids; execute is denied).
+  Account-page loads fetch the registrable-domain favicon of `url` with the same
+  HTTPS pipeline as user-lane OAuth apps and store a raster under
+  `user-mcp-server-logos/{userId}/{id}/`. The signed-in owner loads it from
+  `/account/mcp-servers/logos/:serverId`. Display order matches OAuth
+  integrations: operator-curated provider mark (matched by server name or `url`
+  host), then auto-favicon, then the letter fallback.
 - **Hub client with snapshot cache**
   (`packages/worker/src/mcp-client/hub-client.ts`) — worker-side facade over the
   DO stub. Snapshots are cached per user for 30 seconds and invalidated on every
@@ -80,15 +83,23 @@ the `/mcp` endpoint (where Kody is the server) and complements MCP servers
    DO, and the SDK exchanges the code (matching the `state` parameter to the
    pending authorization) and establishes the connection.
 5. The hub only treats the callback as successful when the connection reaches
-   `ready`. If the Agents SDK reports `authSuccess` but the connection stays in
-   `authenticating` (including the stuck case with no stored auth URL after the
-   SDK clears it), the hub retries establish/discover and otherwise redirects
-   with `auth=error` and a concrete reason. Used or missing OAuth `state` on the
-   callback, and connections that are already settling toward `ready`, recover
-   without surfacing an internal state error: the hub restarts authorization
-   when needed, or accepts the in-flight connection. Origin and redirect-URI
-   rejection messages are enriched with Kody's `oauthClientOrigin` and
-   `oauthCallbackUrl`. Reconnect uses the same recovery path (invalidate
+   `ready`. After the SDK accepts the authorization code, the hub establishes
+   the connection and, if the transport is `connected`, runs
+   `discoverIfConnected` the same way add/reconnect do. If that settle does not
+   reach `ready`, the callback fails with a sanitized reason that includes the
+   observable phase (`token exchange`, `resource metadata`, `mcp initialize`,
+   `server/discover`, or `tools/list`), HTTP status and a short body snippet
+   when present, the MCP / resource / authorization-server URLs without query
+   secrets, and an attempt id for log grep. The same payload is stored on
+   `mcp_server_settings.last_error` and shown under Status. The account UI maps
+   `connected` / `discovering` to "Discovering tools" only while that work is
+   still in flight; when `last_error` is present it says "Tool discovery didn't
+   finish" instead of echoing the raw `"connected"` state. Used or missing OAuth
+   `state` on the callback, and connections that are already settling toward
+   `ready`, recover without surfacing an internal state error: the hub restarts
+   authorization when needed, or accepts the in-flight connection. Origin and
+   redirect-URI rejection messages are enriched with Kody's `oauthClientOrigin`
+   and `oauthCallbackUrl`. Reconnect uses the same recovery path (invalidate
    unusable tokens and request a fresh authorization URL). The account page
    offers Reconnect when automatic recovery cannot finish.
 6. The route redirects to `/account/mcp-servers/:serverId?auth=success|error`

--- a/docs/contributing/architecture/mcp-client-servers.md
+++ b/docs/contributing/architecture/mcp-client-servers.md
@@ -94,10 +94,14 @@ the `/mcp` endpoint (where Kody is the server) and complements MCP servers
    `mcp_server_settings.last_error` and shown under Status. The account UI maps
    `connected` / `discovering` to "Discovering tools" only while that work is
    still in flight; when `last_error` is present it says "Tool discovery didn't
-   finish" instead of echoing the raw `"connected"` state. Used or missing OAuth
-   `state` on the callback recover without surfacing an internal state error:
-   the hub restarts authorization when needed. A Back/replay while the
-   connection is still `connected`, `discovering`, or `connecting` keeps the
+   finish" instead of echoing the raw `"connected"` state. After
+   `discoverIfConnected` times out still on `connected` or `discovering` (add,
+   reconnect, refresh, or OAuth settle), the hub treats that as a failed
+   discover and writes the same durable `last_error` (`server/discover` or
+   `tools/list`, attempt id, MCP URL) so Status cannot stay silent. Used or
+   missing OAuth `state` on the callback recover without surfacing an internal
+   state error: the hub restarts authorization when needed. A Back/replay while
+   the connection is still `connected`, `discovering`, or `connecting` keeps the
    existing tokens and retries discovery when the transport is `connected`, but
    it does not report `auth=success` or clear `last_error` until the connection
    is `ready`. Origin and redirect-URI rejection messages are enriched with

--- a/docs/use/mcp-client-servers.md
+++ b/docs/use/mcp-client-servers.md
@@ -26,7 +26,9 @@ This is the inverse of [connecting your agent to Kody](./connect-your-agent.md)
    show up in `search` under a `mcp:<name>` domain. If the identity provider
    approved access but tools never appear, Status on
    `/account/mcp-servers/:serverId` shows the last sanitized settle error
-   (phase, HTTP status, URLs, and an attempt id). Reconnect from that page.
+   (phase, HTTP status, URLs, and an attempt id). The same durable error is
+   written when add, reconnect, or refresh times out still discovering tools.
+   Reconnect from that page.
 
 If a server is authenticating, failed, or disconnected, [Waiting](./waiting.md)
 lists it and links to `/account/mcp-servers/:id`. `waitingSummary` returns the

--- a/docs/use/mcp-client-servers.md
+++ b/docs/use/mcp-client-servers.md
@@ -23,7 +23,10 @@ This is the inverse of [connecting your agent to Kody](./connect-your-agent.md)
 3. If the server needs OAuth, Kody returns an authorization link. Open it, sign
    in at the provider, and approve access.
 4. Confirm with `mcpServerList` (or refresh the account page). Connected tools
-   show up in `search` under a `mcp:<name>` domain.
+   show up in `search` under a `mcp:<name>` domain. If the identity provider
+   approved access but tools never appear, Status on
+   `/account/mcp-servers/:serverId` shows the last sanitized settle error
+   (phase, HTTP status, URLs, and an attempt id). Reconnect from that page.
 
 If a server is authenticating, failed, or disconnected, [Waiting](./waiting.md)
 lists it and links to `/account/mcp-servers/:id`. `waitingSummary` returns the

--- a/docs/use/mcp-client-servers.md
+++ b/docs/use/mcp-client-servers.md
@@ -13,8 +13,10 @@ This is the inverse of [connecting your agent to Kody](./connect-your-agent.md)
 
 1. Open [`/account/mcp-servers`](https://kody.codes/account/mcp-servers), or ask
    your agent to use `mcpServerAdd` with a short kebab-case `name` and the
-   server `url` (https required).
-2. If the server authenticates with a static bearer token (or other
+   server `url` (https required). PostHog's documented endpoint is
+   `https://mcp.posthog.com/mcp` — the site root redirects to docs and will not
+   finish tool discovery. Kody rewrites that exact origin to `/mcp`.
+2. If the server authenticates with a static bearer token (or other))
    Authorization scheme), paste it in the optional Bearer token field — or pass
    `bearerToken` to `mcpServerAdd`. Bare tokens are sent as
    `Authorization: Bearer <token>`; scheme-prefixed values and full

--- a/docs/use/troubleshooting.md
+++ b/docs/use/troubleshooting.md
@@ -97,12 +97,14 @@ signed in, user-scoped package results are empty.
 
 If tools from a connected MCP server appear missing, open
 [`/account/mcp-servers`](./mcp-client-servers.md) (or ask `mcpServerList`) and
-confirm the server is connected and authorized. When **Usage** is **Specific
-packages only**, ad hoc execute and other packages cannot see or call
-`kody.mcp["server-name"]` — only granted packages can. Home automation is a
-normal outbound MCP server (`kody.mcp["home"]`). See
-[Connect remote MCP servers](./mcp-client-servers.md) and
-[Lock an MCP server to a package](../guides/locked-mcp-server.md).
+confirm the server is connected and authorized. If authorization finished at the
+identity provider but Status stays on tool discovery, the Status field shows the
+last sanitized settle error (phase, HTTP status, URLs, and an attempt id).
+Reconnect from that page. When **Usage** is **Specific packages only**, ad hoc
+execute and other packages cannot see or call `kody.mcp["server-name"]` — only
+granted packages can. Home automation is a normal outbound MCP server
+(`kody.mcp["home"]`). See [Connect remote MCP servers](./mcp-client-servers.md)
+and [Lock an MCP server to a package](../guides/locked-mcp-server.md).
 
 After a password reset or an in-account password change, reconnect the MCP host:
 Kody revokes OAuth grants and rejects access tokens issued at or before the

--- a/docs/use/troubleshooting.md
+++ b/docs/use/troubleshooting.md
@@ -98,11 +98,12 @@ signed in, user-scoped package results are empty.
 If tools from a connected MCP server appear missing, open
 [`/account/mcp-servers`](./mcp-client-servers.md) (or ask `mcpServerList`) and
 confirm the server is connected and authorized. If authorization finished at the
-identity provider but Status stays on tool discovery, the Status field shows the
-last sanitized settle error (phase, HTTP status, URLs, and an attempt id).
-Reconnect from that page. When **Usage** is **Specific packages only**, ad hoc
-execute and other packages cannot see or call `kody.mcp["server-name"]` — only
-granted packages can. Home automation is a normal outbound MCP server
+identity provider but Status stays on tool discovery — or add, reconnect, or
+refresh times out before tools appear — the Status field shows the last
+sanitized settle error (phase, HTTP status, URLs, and an attempt id). Reconnect
+from that page. When **Usage** is **Specific packages only**, ad hoc execute and
+other packages cannot see or call `kody.mcp["server-name"]` — only granted
+packages can. Home automation is a normal outbound MCP server
 (`kody.mcp["home"]`). See [Connect remote MCP servers](./mcp-client-servers.md)
 and [Lock an MCP server to a package](../guides/locked-mcp-server.md).
 

--- a/packages/shared/src/mcp-servers.node.test.ts
+++ b/packages/shared/src/mcp-servers.node.test.ts
@@ -5,6 +5,7 @@ import {
 	mcpServerBearerTokenMaxLength,
 	normalizeMcpServerBearerToken,
 	normalizeMcpServerName,
+	normalizeKnownMcpServerUrl,
 	validateMcpServerUrl,
 } from './mcp-servers.ts'
 
@@ -30,6 +31,23 @@ test('MCP server URLs require https except for loopback hosts', () => {
 	expect(validateMcpServerUrl('').ok).toBe(false)
 	expect(validateMcpServerUrl('not a url').ok).toBe(false)
 	expect(validateMcpServerUrl('http://example.com/mcp').ok).toBe(false)
+
+	expect(normalizeKnownMcpServerUrl('https://mcp.posthog.com')).toBe(
+		'https://mcp.posthog.com/mcp',
+	)
+	expect(normalizeKnownMcpServerUrl('https://mcp.posthog.com/')).toBe(
+		'https://mcp.posthog.com/mcp',
+	)
+	expect(validateMcpServerUrl('https://mcp.posthog.com')).toEqual({
+		ok: true,
+		url: 'https://mcp.posthog.com/mcp',
+	})
+	expect(normalizeKnownMcpServerUrl('https://mcp.posthog.com/mcp')).toBe(
+		'https://mcp.posthog.com/mcp',
+	)
+	expect(normalizeKnownMcpServerUrl('https://mcp.example.com')).toBe(
+		'https://mcp.example.com',
+	)
 })
 
 test('MCP server bearer tokens normalize to Authorization header values', () => {

--- a/packages/shared/src/mcp-servers.ts
+++ b/packages/shared/src/mcp-servers.ts
@@ -19,6 +19,30 @@ export function isValidMcpServerName(name: string): boolean {
 }
 
 const loopbackHostnames = new Set(['localhost', '127.0.0.1', '[::1]'])
+const posthogMcpEndpoint = 'https://mcp.posthog.com/mcp'
+
+/**
+ * Rewrite a few documented vendor roots that are not MCP endpoints.
+ * PostHog's site origin 302s to docs; the resource is `/mcp`.
+ */
+export function normalizeKnownMcpServerUrl(url: string): string {
+	const trimmed = url.trim()
+	try {
+		const parsed = new URL(trimmed)
+		if (
+			parsed.protocol === 'https:' &&
+			parsed.hostname === 'mcp.posthog.com' &&
+			(parsed.pathname === '' || parsed.pathname === '/') &&
+			parsed.search === '' &&
+			parsed.hash === ''
+		) {
+			return posthogMcpEndpoint
+		}
+	} catch {
+		return trimmed
+	}
+	return trimmed
+}
 
 /**
  * Remote MCP servers must be reachable over HTTP(S). Plain HTTP is only
@@ -31,7 +55,7 @@ export function validateMcpServerUrl(url: string): {
 	url?: string
 	error?: string
 } {
-	const trimmed = url.trim()
+	const trimmed = normalizeKnownMcpServerUrl(url)
 	if (!trimmed) {
 		return { ok: false, error: 'Server URL is required.' }
 	}

--- a/packages/worker/client/routes/account-mcp-servers-detail.tsx
+++ b/packages/worker/client/routes/account-mcp-servers-detail.tsx
@@ -237,9 +237,20 @@ export function renderMcpServerDetail(props: McpServerDetailProps) {
 					{
 						label: 'Status',
 						value: (
-							<span mix={css({ color: stateColor(server) })}>
-								{stateLabel(server)}
-							</span>
+							<div
+								mix={css({
+									display: 'grid',
+									gap: spacing.xs,
+									color: stateColor(server),
+								})}
+							>
+								<span>{stateLabel(server)}</span>
+								{server.error ? (
+									<AccountManagementMessage tone="error">
+										{server.error}
+									</AccountManagementMessage>
+								) : null}
+							</div>
 						),
 					},
 					{
@@ -274,12 +285,6 @@ export function renderMcpServerDetail(props: McpServerDetailProps) {
 					{server.url}
 				</code>
 			</div>
-
-			{server.error ? (
-				<AccountManagementMessage tone="error">
-					{server.error}
-				</AccountManagementMessage>
-			) : null}
 
 			{server.state === 'authenticating' && !server.authUrl ? (
 				<AccountManagementMessage tone="info">

--- a/packages/worker/client/routes/account-mcp-servers-forms.tsx
+++ b/packages/worker/client/routes/account-mcp-servers-forms.tsx
@@ -193,6 +193,10 @@ export function renderAddMcpServerForm(props: AddMcpServerFormProps) {
 						css(accountInputCss),
 					]}
 				/>
+				<span mix={css(descriptionCss)}>
+					Use the MCP endpoint path, not the vendor&apos;s marketing site.
+					PostHog is https://mcp.posthog.com/mcp.
+				</span>
 			</label>
 
 			<label mix={css(fieldCss)}>

--- a/packages/worker/client/routes/account-mcp-servers-shared.node.test.ts
+++ b/packages/worker/client/routes/account-mcp-servers-shared.node.test.ts
@@ -1,0 +1,49 @@
+import { expect, test } from 'vitest'
+import {
+	readOAuthResultFromHref,
+	stateColor,
+	stateLabel,
+} from './account-mcp-servers-shared.tsx'
+import { colors } from '#universal/styles/tokens.ts'
+
+test('Status labels stay consistent with post-IdP tool-discovery errors', () => {
+	expect(
+		stateLabel({
+			state: 'connected',
+			enabled: true,
+			error: null,
+		}),
+	).toBe('Discovering tools')
+	expect(
+		stateLabel({
+			state: 'connected',
+			enabled: true,
+			error:
+				"Authorization completed at the identity provider, but tool discovery didn't finish (phase server/discover, id attempt-1).",
+		}),
+	).toBe("Tool discovery didn't finish")
+	expect(
+		stateLabel({
+			state: 'discovering',
+			enabled: true,
+			error: 'HTTP 403 insufficient_scope',
+		}),
+	).toBe("Tool discovery didn't finish")
+	expect(
+		stateColor({
+			state: 'connected',
+			enabled: true,
+			error: "tool discovery didn't finish",
+		}),
+	).toBe(colors.error)
+
+	const banner = readOAuthResultFromHref(
+		'/account/mcp-servers/server-1?auth=error&reason=' +
+			encodeURIComponent(
+				"Authorization completed at the identity provider, but tool discovery didn't finish (phase server/discover, id attempt-1).",
+			),
+	)
+	expect(banner?.tone).toBe('error')
+	expect(banner?.message).toContain("tool discovery didn't finish")
+	expect(banner?.message).not.toContain('still "connected"')
+})

--- a/packages/worker/client/routes/account-mcp-servers-shared.tsx
+++ b/packages/worker/client/routes/account-mcp-servers-shared.tsx
@@ -101,9 +101,12 @@ export function filterServers(
 }
 
 export function stateLabel(
-	server: Pick<McpServerListItem, 'state' | 'enabled'>,
+	server: Pick<McpServerListItem, 'state' | 'enabled' | 'error'>,
 ) {
 	if (!server.enabled) return 'Disabled'
+	if (isIncompleteToolDiscovery(server)) {
+		return "Tool discovery didn't finish"
+	}
 	switch (server.state) {
 		case 'ready':
 			return 'Connected'
@@ -122,19 +125,29 @@ export function stateLabel(
 }
 
 export function stateColor(
-	server: Pick<McpServerListItem, 'state' | 'enabled'>,
+	server: Pick<McpServerListItem, 'state' | 'enabled' | 'error'>,
 ) {
 	if (!server.enabled) return colors.textMuted
+	if (isIncompleteToolDiscovery(server) || server.state === 'failed') {
+		return colors.error
+	}
 	switch (server.state) {
 		case 'ready':
 			return colors.primary
-		case 'failed':
-			return colors.error
 		case 'authenticating':
 			return colors.textMuted
 		default:
 			return colors.textMuted
 	}
+}
+
+function isIncompleteToolDiscovery(
+	server: Pick<McpServerListItem, 'state' | 'error'>,
+) {
+	return (
+		Boolean(server.error) &&
+		(server.state === 'connected' || server.state === 'discovering')
+	)
 }
 
 export function readOAuthResultFromHref(href: string): {

--- a/packages/worker/migrations/0054-mcp-server-last-error.sql
+++ b/packages/worker/migrations/0054-mcp-server-last-error.sql
@@ -1,0 +1,4 @@
+-- Durable, sanitized lastError for incomplete MCP OAuth settle (post-IdP).
+-- Live hub connectionError is ephemeral; this column survives reloads so
+-- /account/mcp-servers can show the failure under Status.
+ALTER TABLE mcp_server_settings ADD COLUMN last_error TEXT;

--- a/packages/worker/src/app/handlers/account-mcp-servers.node.test.ts
+++ b/packages/worker/src/app/handlers/account-mcp-servers.node.test.ts
@@ -310,6 +310,46 @@ test('MCP servers API lists, adds, reconnects, disables, and deletes with user s
 		callbackUrl: 'https://example.com/account/mcp-servers/oauth/callback',
 	})
 
+	mockModule.reconnectServer.mockResolvedValueOnce({
+		serverId: 'server-1',
+		state: 'connected',
+		authUrl: null,
+		error:
+			"Authorization completed at the identity provider, but tool discovery didn't finish (phase server/discover, mcp https://mcp.example.com/mcp, id attempt-reconnect).",
+		toolCount: 0,
+		lastError: {
+			message:
+				"Authorization completed at the identity provider, but tool discovery didn't finish (phase server/discover, mcp https://mcp.example.com/mcp, id attempt-reconnect).",
+			phase: 'server/discover',
+			httpStatus: null,
+			httpBodySnippet: null,
+			mcpEndpoint: 'https://mcp.example.com/mcp',
+			resource: null,
+			authServer: null,
+			attemptId: 'attempt-reconnect',
+			at: '2026-09-08T00:00:00.000Z',
+		},
+	})
+	const hungReconnect = await handler.handler({
+		request: new Request('https://example.com/account/mcp-servers.json', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ action: 'reconnect', id: 'server-1' }),
+		}),
+		params: {},
+	} as never)
+	expect(hungReconnect.status).toBe(200)
+	expect(mockModule.setMcpServerLastError).toHaveBeenCalledWith(
+		expect.objectContaining({
+			userId: 'stable-user-1',
+			id: 'server-1',
+			lastError: expect.objectContaining({
+				phase: 'server/discover',
+				attemptId: 'attempt-reconnect',
+			}),
+		}),
+	)
+
 	const disableResponse = await handler.handler({
 		request: new Request('https://example.com/account/mcp-servers.json', {
 			method: 'POST',

--- a/packages/worker/src/app/handlers/account-mcp-servers.node.test.ts
+++ b/packages/worker/src/app/handlers/account-mcp-servers.node.test.ts
@@ -83,6 +83,7 @@ const mockModule = vi.hoisted(() => ({
 		allowedPackageIds: ['pkg-drafts'],
 	})),
 	deleteMcpServer: vi.fn(async () => true),
+	setMcpServerLastError: vi.fn(async () => true),
 	getCachedMcpClientHubSnapshot: vi.fn(async () => ({
 		servers: [
 			{
@@ -106,6 +107,7 @@ const mockModule = vi.hoisted(() => ({
 		authError: null,
 		serverName: 'linear',
 		authorizationNeeded: false,
+		lastError: null,
 	})),
 	reconnectServer: vi.fn(async () => ({
 		serverId: 'server-1',
@@ -155,6 +157,8 @@ vi.mock('#worker/mcp-client/settings-service.ts', () => ({
 		mockModule.setMcpServerUsage(...args),
 	deleteMcpServer: (...args: Array<unknown>) =>
 		mockModule.deleteMcpServer(...args),
+	setMcpServerLastError: (...args: Array<unknown>) =>
+		mockModule.setMcpServerLastError(...args),
 	resolveMcpServerOAuthClientUrls: (input: {
 		env: { APP_BASE_URL?: string | null }
 		requestUrl?: string | URL | null
@@ -198,6 +202,13 @@ vi.mock('#worker/mcp-client/hub-client.ts', () => ({
 			mockModule.handleOAuthCallback(...args),
 		reconnectServer: (...args: Array<unknown>) =>
 			mockModule.reconnectServer(...args),
+		refreshServer: vi.fn(async () => ({
+			serverId: 'server-1',
+			state: 'ready',
+			authUrl: null,
+			error: null,
+			toolCount: 2,
+		})),
 	}),
 }))
 
@@ -374,6 +385,13 @@ test('MCP servers OAuth callback redirects with the auth outcome', async () => {
 	expect(successLocation.pathname).toBe('/account/mcp-servers/server-1')
 	expect(successLocation.searchParams.get('auth')).toBe('success')
 	expect(successLocation.searchParams.get('server')).toBe('linear')
+	expect(mockModule.setMcpServerLastError).toHaveBeenCalledWith(
+		expect.objectContaining({
+			userId: 'stable-user-1',
+			id: 'server-1',
+			lastError: null,
+		}),
+	)
 
 	const onboardingReturnResponse = await handler.handler({
 		request: new Request(
@@ -486,4 +504,51 @@ test('MCP servers OAuth callback redirects with the auth outcome', async () => {
 	expect(unknownRecoveryLocation.pathname).toBe('/account/mcp-servers')
 	expect(unknownRecoveryLocation.searchParams.get('auth')).toBe('retry')
 	expect(unknownRecoveryLocation.searchParams.has('reason')).toBe(false)
+
+	mockModule.handleOAuthCallback.mockResolvedValueOnce({
+		serverId: 'server-1',
+		authSuccess: false,
+		authError:
+			"Authorization completed at the identity provider, but tool discovery didn't finish (phase server/discover, mcp https://mcp.example.com/mcp, id attempt-1). Reconnect it from /account/mcp-servers.",
+		serverName: 'linear',
+		authorizationNeeded: false,
+		lastError: {
+			message:
+				"Authorization completed at the identity provider, but tool discovery didn't finish (phase server/discover, mcp https://mcp.example.com/mcp, id attempt-1). Reconnect it from /account/mcp-servers.",
+			phase: 'server/discover',
+			httpStatus: null,
+			httpBodySnippet: null,
+			mcpEndpoint: 'https://mcp.example.com/mcp',
+			resource: null,
+			authServer: null,
+			attemptId: 'attempt-1',
+			at: '2026-09-08T00:00:00.000Z',
+		},
+	})
+	const settleFailureResponse = await handler.handler({
+		request: new Request(
+			'https://example.com/account/mcp-servers/oauth/callback?code=abc&state=ok.server-1',
+		),
+		params: {},
+	} as never)
+	const settleFailureLocation = new URL(
+		settleFailureResponse.headers.get('Location') ?? '',
+	)
+	expect(settleFailureLocation.searchParams.get('auth')).toBe('error')
+	expect(settleFailureLocation.searchParams.get('reason')).toContain(
+		"tool discovery didn't finish",
+	)
+	expect(settleFailureLocation.searchParams.get('reason')).not.toContain(
+		'still "connected"',
+	)
+	expect(mockModule.setMcpServerLastError).toHaveBeenCalledWith(
+		expect.objectContaining({
+			userId: 'stable-user-1',
+			id: 'server-1',
+			lastError: expect.objectContaining({
+				phase: 'server/discover',
+				attemptId: 'attempt-1',
+			}),
+		}),
+	)
 })

--- a/packages/worker/src/app/handlers/account-mcp-servers.ts
+++ b/packages/worker/src/app/handlers/account-mcp-servers.ts
@@ -300,6 +300,13 @@ async function handleConnectionAction(input: {
 			id: setting.id,
 			lastError: null,
 		}).catch(() => {})
+	} else if (result.lastError) {
+		await setMcpServerLastError({
+			env: input.env,
+			userId: input.user.mcpUser.userId,
+			id: setting.id,
+			lastError: result.lastError,
+		}).catch(() => {})
 	}
 	const payload = await loadAccountMcpServersData({
 		env: input.env,

--- a/packages/worker/src/app/handlers/account-mcp-servers.ts
+++ b/packages/worker/src/app/handlers/account-mcp-servers.ts
@@ -188,7 +188,7 @@ export function createAccountMcpServersOauthCallbackHandler(env: Env) {
 				if (lastError) lastError = { ...lastError, message: authError }
 			}
 
-			if (serverId && authSuccess) {
+			if (serverId && authSuccess && !lastError) {
 				await setMcpServerLastError({
 					env,
 					userId: user.mcpUser.userId,

--- a/packages/worker/src/app/handlers/account-mcp-servers.ts
+++ b/packages/worker/src/app/handlers/account-mcp-servers.ts
@@ -23,8 +23,10 @@ import {
 	getMcpServerSettingById,
 	resolveMcpServerOAuthClientUrls,
 	setMcpServerEnabled,
+	setMcpServerLastError,
 	setMcpServerUsage,
 } from '#worker/mcp-client/settings-service.ts'
+import { type McpServerLastError } from '#worker/mcp-client/types.ts'
 
 type AuthenticatedUser = NonNullable<
 	Awaited<ReturnType<typeof readAuthenticatedAppUser>>
@@ -161,6 +163,7 @@ export function createAccountMcpServersOauthCallbackHandler(env: Env) {
 			let serverName: string | null = null
 			let serverId: string | null = null
 			let authorizationNeeded = false
+			let lastError: McpServerLastError | null = null
 			const oauth = resolveMcpServerOAuthClientUrls({
 				env,
 				requestUrl: request.url,
@@ -175,12 +178,30 @@ export function createAccountMcpServersOauthCallbackHandler(env: Env) {
 				serverName = outcome.serverName
 				serverId = outcome.serverId
 				authorizationNeeded = outcome.authorizationNeeded
+				lastError = outcome.lastError
 			} catch (error) {
 				authError = getErrorMessage(error)
 			}
 
 			if (authError) {
 				authError = enrichMcpOAuthProviderError(authError, oauth)
+				if (lastError) lastError = { ...lastError, message: authError }
+			}
+
+			if (serverId && authSuccess) {
+				await setMcpServerLastError({
+					env,
+					userId: user.mcpUser.userId,
+					id: serverId,
+					lastError: null,
+				}).catch(() => {})
+			} else if (serverId && lastError && !authorizationNeeded) {
+				await setMcpServerLastError({
+					env,
+					userId: user.mcpUser.userId,
+					id: serverId,
+					lastError,
+				}).catch(() => {})
 			}
 
 			const returnToOnboarding =
@@ -262,17 +283,23 @@ async function handleConnectionAction(input: {
 		env: input.env,
 		userId: input.user.mcpUser.userId,
 	})
-	if (input.kind === 'reconnect') {
-		const oauth = resolveMcpServerOAuthClientUrls({
+	const result =
+		input.kind === 'reconnect'
+			? await hub.reconnectServer({
+					serverId: setting.id,
+					callbackUrl: resolveMcpServerOAuthClientUrls({
+						env: input.env,
+						requestUrl: input.request.url,
+					}).callbackUrl,
+				})
+			: await hub.refreshServer({ serverId: setting.id })
+	if (result.state === 'ready') {
+		await setMcpServerLastError({
 			env: input.env,
-			requestUrl: input.request.url,
-		})
-		await hub.reconnectServer({
-			serverId: setting.id,
-			callbackUrl: oauth.callbackUrl,
-		})
-	} else {
-		await hub.refreshServer({ serverId: setting.id })
+			userId: input.user.mcpUser.userId,
+			id: setting.id,
+			lastError: null,
+		}).catch(() => {})
 	}
 	const payload = await loadAccountMcpServersData({
 		env: input.env,

--- a/packages/worker/src/mcp-client/hub-oauth-recovery.node.test.ts
+++ b/packages/worker/src/mcp-client/hub-oauth-recovery.node.test.ts
@@ -38,8 +38,8 @@ type FakeManager = {
 	rows: Array<FakeServerRow>
 	mcpConnections: Record<string, FakeConnection>
 	connectCount: number
-	connectBehavior: 'oauth' | 'ready' | 'disconnected'
-	connectBehaviors: Array<'oauth' | 'ready' | 'disconnected'>
+	connectBehavior: 'oauth' | 'ready' | 'disconnected' | 'connected'
+	connectBehaviors: Array<'oauth' | 'ready' | 'disconnected' | 'connected'>
 	registerFailuresRemaining: number
 	callbackMatches: boolean
 	callbackResult: {
@@ -116,8 +116,9 @@ vi.mock('agents/mcp/client', () => ({
 		rows: Array<FakeServerRow> = []
 		mcpConnections: Record<string, FakeConnection> = {}
 		connectCount = 0
-		connectBehavior: 'oauth' | 'ready' | 'disconnected' = 'oauth'
-		connectBehaviors: Array<'oauth' | 'ready' | 'disconnected'> = []
+		connectBehavior: 'oauth' | 'ready' | 'disconnected' | 'connected' = 'oauth'
+		connectBehaviors: Array<'oauth' | 'ready' | 'disconnected' | 'connected'> =
+			[]
 		registerFailuresRemaining = 0
 		callbackMatches = true
 		callbackResult = {
@@ -191,6 +192,11 @@ vi.mock('agents/mcp/client', () => ({
 				this.connectBehaviors.shift() ?? this.connectBehavior
 			if (connectBehavior === 'ready') {
 				connection.connectionState = 'ready'
+				connection.connectionError = null
+				return { state: 'connected' }
+			}
+			if (connectBehavior === 'connected') {
+				connection.connectionState = 'connected'
 				connection.connectionError = null
 				return { state: 'connected' }
 			}
@@ -782,4 +788,51 @@ test('replayed unusable callback after incomplete settle reports lastError inste
 	expect(manager.connectCount).toBe(0)
 	expect(manager.rows[0]?.client_id).toBe('client-1')
 	expect(values.get(tokenKey)).toEqual({ access_token: 'still-valid' })
+})
+
+test('add, reconnect, and refresh treat a discover timeout as a durable lastError', async () => {
+	consoleWarn.mockImplementation(() => {})
+	const { state } = createDurableObjectState()
+	const hub = new McpClientHub(state, {} as Env)
+	const manager = mockModule.manager
+	if (!manager) throw new Error('Fake manager was not constructed.')
+	const callbackUrl = 'https://kody.codes/account/mcp-servers/oauth/callback'
+	manager.connectBehavior = 'connected'
+
+	const added = await hub.addServer({
+		serverId: 'server-1',
+		name: 'mediarss',
+		url: 'https://mediarss.example/mcp',
+		callbackUrl,
+	})
+	expect(added.state).toBe('connected')
+	expect(added.lastError?.phase).toBe('server/discover')
+	expect(added.lastError?.mcpEndpoint).toBe('https://mediarss.example/mcp')
+	expect(added.lastError?.attemptId).toBeTruthy()
+	expect(added.error).toContain("tool discovery didn't finish")
+	expect(added.error).toContain('phase server/discover')
+	expect(manager.mcpConnections['server-1']?.connectionError).toBe(added.error)
+
+	const connection = manager.mcpConnections['server-1']
+	if (!connection) throw new Error('Fake connection was not seeded.')
+	connection.connectionState = 'discovering'
+	connection.connectionError = null
+	const refreshed = await hub.refreshServer({ serverId: 'server-1' })
+	expect(refreshed.state).toBe('discovering')
+	expect(refreshed.lastError?.phase).toBe('tools/list')
+	expect(refreshed.error).toContain("tool discovery didn't finish")
+	expect(refreshed.error).toContain('phase tools/list')
+
+	connection.connectionState = 'disconnected'
+	connection.connectionError = null
+	manager.connectBehavior = 'connected'
+	const reconnected = await hub.reconnectServer({
+		serverId: 'server-1',
+		callbackUrl,
+	})
+	expect(reconnected.state).toBe('connected')
+	expect(reconnected.lastError?.phase).toBe('server/discover')
+	expect(reconnected.lastError?.mcpEndpoint).toBe(
+		'https://mediarss.example/mcp',
+	)
 })

--- a/packages/worker/src/mcp-client/hub-oauth-recovery.node.test.ts
+++ b/packages/worker/src/mcp-client/hub-oauth-recovery.node.test.ts
@@ -1,4 +1,5 @@
 import { expect, test, vi } from 'vitest'
+import { consoleWarn } from '#worker/test-support/console-spies.ts'
 import type * as CloudflareWorkers from 'cloudflare:workers'
 
 type FakeServerRow = {
@@ -463,6 +464,7 @@ test('replayed unusable callbacks leave past-OAuth server credentials intact', a
 			authError: null,
 			serverName: 'mediarss',
 			authorizationNeeded: false,
+			lastError: null,
 		})
 	}
 	expect(manager.connectCount).toBe(0)
@@ -672,4 +674,61 @@ test('handleOAuthCallback reports success after observe recovers a previously re
 	})
 	expect(result.authSuccess).toBe(true)
 	expect(result.authorizationNeeded).toBe(false)
+	expect(result.lastError).toBeNull()
+})
+
+test('handleOAuthCallback reports a durable tool-discovery lastError when IdP succeeds but settle stays connected', async () => {
+	consoleWarn.mockImplementation(() => {})
+	const { state, values } = createDurableObjectState()
+	const hub = new McpClientHub(state, {} as Env)
+	const manager = mockModule.manager
+	if (!manager) throw new Error('Fake manager was not constructed.')
+	const callbackUrl = 'https://kody.codes/account/mcp-servers/oauth/callback'
+	seedServer({
+		manager,
+		callbackUrl,
+		clientId: 'client-1',
+		authUrl: 'https://auth.example/authorize?state=ok.server-1',
+	})
+	const connection = manager.mcpConnections['server-1']
+	if (!connection) throw new Error('Fake connection was not seeded.')
+	manager.callbackMatches = true
+	manager.callbackResult = { serverId: 'server-1', authSuccess: true }
+	connection.connectionState = 'connected'
+	connection.connectionError = null
+	values.set('/Kody/server-1/oauth_discovery', {
+		resource: 'https://mcp.posthog.com/',
+		authorization_servers: ['https://auth.posthog.com/?client_secret=hidden'],
+	})
+
+	const result = await hub.handleOAuthCallback({
+		url: `${callbackUrl}?code=abc&state=ok.server-1`,
+		callbackUrl,
+	})
+
+	expect(result.authSuccess).toBe(false)
+	expect(result.authorizationNeeded).toBe(false)
+	expect(result.lastError?.phase).toBe('server/discover')
+	expect(result.lastError?.mcpEndpoint).toBe('https://mediarss.example/mcp')
+	expect(result.lastError?.resource).toBe('https://mcp.posthog.com/')
+	expect(result.lastError?.authServer).toBe('https://auth.posthog.com/')
+	expect(result.authError).toContain("tool discovery didn't finish")
+	expect(result.authError).toContain('phase server/discover')
+	expect(result.authError).not.toContain('still "connected"')
+	expect(result.authError).not.toContain('client_secret')
+	expect(JSON.stringify(result.lastError)).not.toContain('hidden')
+	expect(consoleWarn).toHaveBeenCalledWith(
+		'mcp oauth callback settle incomplete',
+		expect.objectContaining({
+			attemptId: result.lastError?.attemptId,
+			serverId: 'server-1',
+			phase: 'server/discover',
+			mcpEndpoint: 'https://mediarss.example/mcp',
+			resource: 'https://mcp.posthog.com/',
+			authServer: 'https://auth.posthog.com/',
+		}),
+	)
+	const logged = JSON.stringify(consoleWarn.mock.calls)
+	expect(logged).not.toContain('hidden')
+	expect(logged).not.toContain('client_secret')
 })

--- a/packages/worker/src/mcp-client/hub-oauth-recovery.node.test.ts
+++ b/packages/worker/src/mcp-client/hub-oauth-recovery.node.test.ts
@@ -718,6 +718,10 @@ test('handleOAuthCallback reports a durable tool-discovery lastError when IdP su
 	expect(result.lastError?.authServer).toBe('https://auth.posthog.com/')
 	expect(result.authError).toContain("tool discovery didn't finish")
 	expect(result.authError).toContain('phase server/discover')
+	expect(result.authError).toContain(`id ${result.lastError?.attemptId}`)
+	expect(result.authError?.match(/authorization completed/gi)?.length).toBe(1)
+	expect(result.authError?.match(/\bphase\s/g)?.length).toBe(1)
+	expect(result.authError?.match(/\bid\s/g)?.length).toBe(1)
 	expect(result.authError).not.toContain('still "connected"')
 	expect(result.authError).not.toContain('client_secret')
 	expect(JSON.stringify(result.lastError)).not.toContain('hidden')
@@ -811,17 +815,31 @@ test('add, reconnect, and refresh treat a discover timeout as a durable lastErro
 	expect(added.lastError?.attemptId).toBeTruthy()
 	expect(added.error).toContain("tool discovery didn't finish")
 	expect(added.error).toContain('phase server/discover')
+	expect(added.error).toContain(`id ${added.lastError?.attemptId}`)
+	expect(added.error?.match(/\bid\s/g)?.length).toBe(1)
 	expect(manager.mcpConnections['server-1']?.connectionError).toBe(added.error)
+	expect(consoleWarn).toHaveBeenCalledWith(
+		'mcp discover timeout incomplete',
+		expect.objectContaining({
+			attemptId: added.lastError?.attemptId,
+			serverId: 'server-1',
+			phase: 'server/discover',
+		}),
+	)
 
 	const connection = manager.mcpConnections['server-1']
 	if (!connection) throw new Error('Fake connection was not seeded.')
+	const addedAttemptId = added.lastError?.attemptId
 	connection.connectionState = 'discovering'
-	connection.connectionError = null
 	const refreshed = await hub.refreshServer({ serverId: 'server-1' })
 	expect(refreshed.state).toBe('discovering')
 	expect(refreshed.lastError?.phase).toBe('tools/list')
+	expect(refreshed.lastError?.attemptId).toBeTruthy()
+	expect(refreshed.lastError?.attemptId).not.toBe(addedAttemptId)
 	expect(refreshed.error).toContain("tool discovery didn't finish")
 	expect(refreshed.error).toContain('phase tools/list')
+	expect(refreshed.error).toContain(`id ${refreshed.lastError?.attemptId}`)
+	expect(refreshed.error?.match(/\bid\s/g)?.length).toBe(1)
 
 	connection.connectionState = 'disconnected'
 	connection.connectionError = null

--- a/packages/worker/src/mcp-client/hub-oauth-recovery.node.test.ts
+++ b/packages/worker/src/mcp-client/hub-oauth-recovery.node.test.ts
@@ -452,21 +452,19 @@ test('replayed unusable callbacks leave past-OAuth server credentials intact', a
 	const tokenKey = '/Kody/server-1/client-1/token'
 	values.set(tokenKey, { access_token: 'still-valid' })
 
-	for (const pastOAuthState of ['connecting', 'ready']) {
-		connection.connectionState = pastOAuthState
-		const outcome = await hub.handleOAuthCallback({
-			url: `${callbackUrl}?code=abc&state=used.server-1`,
-			callbackUrl,
-		})
-		expect(outcome).toEqual({
-			serverId: 'server-1',
-			authSuccess: true,
-			authError: null,
-			serverName: 'mediarss',
-			authorizationNeeded: false,
-			lastError: null,
-		})
-	}
+	connection.connectionState = 'ready'
+	const readyOutcome = await hub.handleOAuthCallback({
+		url: `${callbackUrl}?code=abc&state=used.server-1`,
+		callbackUrl,
+	})
+	expect(readyOutcome).toEqual({
+		serverId: 'server-1',
+		authSuccess: true,
+		authError: null,
+		serverName: 'mediarss',
+		authorizationNeeded: false,
+		lastError: null,
+	})
 	expect(manager.connectCount).toBe(0)
 	expect(manager.rows[0]?.client_id).toBe('client-1')
 	expect(values.get(tokenKey)).toEqual({ access_token: 'still-valid' })
@@ -731,4 +729,57 @@ test('handleOAuthCallback reports a durable tool-discovery lastError when IdP su
 	const logged = JSON.stringify(consoleWarn.mock.calls)
 	expect(logged).not.toContain('hidden')
 	expect(logged).not.toContain('client_secret')
+})
+
+test('replayed unusable callback after incomplete settle reports lastError instead of fake success', async () => {
+	consoleWarn.mockImplementation(() => {})
+	const { state, values } = createDurableObjectState()
+	const hub = new McpClientHub(state, {} as Env)
+	const manager = mockModule.manager
+	if (!manager) throw new Error('Fake manager was not constructed.')
+	const callbackUrl = 'https://kody.codes/account/mcp-servers/oauth/callback'
+	seedServer({
+		manager,
+		callbackUrl,
+		clientId: 'client-1',
+		authUrl: 'https://auth.example/authorize?state=used.server-1',
+	})
+	manager.callbackMatches = false
+	const connection = manager.mcpConnections['server-1']
+	if (!connection) throw new Error('Fake connection was not seeded.')
+	manager.rows[0]!.auth_url = null
+	const tokenKey = '/Kody/server-1/client-1/token'
+	values.set(tokenKey, { access_token: 'still-valid' })
+	values.set('/Kody/server-1/oauth_discovery', {
+		resource: 'https://mcp.posthog.com/',
+		authorization_servers: ['https://auth.posthog.com/'],
+	})
+
+	for (const inFlightState of ['connected', 'discovering', 'connecting']) {
+		connection.connectionState = inFlightState
+		connection.connectionError = null
+		const outcome = await hub.handleOAuthCallback({
+			url: `${callbackUrl}?code=abc&state=used.server-1`,
+			callbackUrl,
+		})
+		expect(outcome.authSuccess).toBe(false)
+		expect(outcome.authorizationNeeded).toBe(false)
+		expect(outcome.lastError).toMatchObject({
+			mcpEndpoint: 'https://mediarss.example/mcp',
+			resource: 'https://mcp.posthog.com/',
+			authServer: 'https://auth.posthog.com/',
+		})
+		expect(outcome.authError).toBeTruthy()
+		expect(outcome.authError).not.toContain('still "connected"')
+		if (inFlightState === 'connecting') {
+			expect(outcome.lastError?.phase).toBe('mcp initialize')
+			expect(outcome.authError).toContain('did not become ready')
+		} else {
+			expect(outcome.authError).toContain("tool discovery didn't finish")
+		}
+	}
+
+	expect(manager.connectCount).toBe(0)
+	expect(manager.rows[0]?.client_id).toBe('client-1')
+	expect(values.get(tokenKey)).toEqual({ access_token: 'still-valid' })
 })

--- a/packages/worker/src/mcp-client/hub.ts
+++ b/packages/worker/src/mcp-client/hub.ts
@@ -14,6 +14,9 @@ import {
 } from './oauth-callback-outcome.ts'
 import {
 	buildIncompleteDiscoverLastError,
+	isFormattedMcpOAuthSettleMessage,
+	isIncompleteDiscoverState,
+	readAttemptIdFromSettleMessage,
 	readOAuthDiscoveryUrls,
 } from './oauth-settle-error.ts'
 import {
@@ -80,6 +83,7 @@ class McpClientHubBase extends DurableObject<Env> {
 	private readonly manager: MCPClientManager
 	private readonly lifecycle: Lifecycle<Env>
 	private restored: Promise<void> | null = null
+	private readonly lastDiscoverErrors = new Map<string, McpServerLastError>()
 
 	constructor(state: DurableObjectState, env: Env) {
 		super(state, env)
@@ -377,12 +381,15 @@ class McpClientHubBase extends DurableObject<Env> {
 			})
 			let connection = this.buildConnectResult(serverId)
 			let settleError: string | null = null
+			let settleLastError: McpServerLastError | null = null
 			if (isStuckMcpAuthenticatingWithoutAuthUrl(connection)) {
 				connection = await this.recoverStuckAuthenticating(serverId)
 				settleError = connection.error
+				settleLastError = connection.lastError ?? null
 			} else if (connection.state === 'connected') {
 				connection = await this.discoverAfterOAuthEstablish(serverId)
 				settleError = connection.error
+				settleLastError = connection.lastError ?? null
 			}
 			if (serverName) {
 				await this.observeServer({
@@ -396,6 +403,7 @@ class McpClientHubBase extends DurableObject<Env> {
 				serverId,
 				serverName,
 				settleError,
+				settleLastError,
 			})
 		}
 		return await this.resolveOAuthCallbackOutcome({
@@ -433,11 +441,13 @@ class McpClientHubBase extends DurableObject<Env> {
 			// Back/replay after an incomplete settle used to wipe the durable
 			// reason and redirect with auth=success.
 			let settleError: string | null = null
+			let settleLastError: McpServerLastError | null = null
 			if (existingConnection.state === 'connected') {
 				const discovered = await this.discoverAfterOAuthEstablish(
 					input.serverId,
 				)
 				settleError = discovered.error
+				settleLastError = discovered.lastError ?? null
 			}
 			return await this.resolveOAuthCallbackOutcome({
 				sdkAuthSuccess: true,
@@ -445,6 +455,7 @@ class McpClientHubBase extends DurableObject<Env> {
 				serverId: input.serverId,
 				serverName,
 				settleError,
+				settleLastError,
 			})
 		}
 		try {
@@ -579,10 +590,17 @@ class McpClientHubBase extends DurableObject<Env> {
 	 * auth URL. Needed when SQL `auth_url` was cleared on callback success but
 	 * the live connection never reached `ready`.
 	 */
+	private clearIncompleteDiscoverStamp(serverId: string) {
+		const connection = this.manager.mcpConnections[serverId]
+		if (connection) connection.connectionError = null
+		this.lastDiscoverErrors.delete(serverId)
+	}
+
 	private async runDiscoverIfConnected(serverId: string): Promise<{
 		result: McpServerConnectResult
 		lastError: McpServerLastError | null
 	}> {
+		this.clearIncompleteDiscoverStamp(serverId)
 		let discoverError: string | null = null
 		try {
 			await this.manager.discoverIfConnected(serverId, {
@@ -607,15 +625,45 @@ class McpClientHubBase extends DurableObject<Env> {
 	} {
 		const result = this.buildConnectResult(serverId)
 		const connection = this.manager.mcpConnections[serverId]
+		if (!isIncompleteDiscoverState(result.state)) {
+			if (result.state === 'ready') this.clearIncompleteDiscoverStamp(serverId)
+			else this.lastDiscoverErrors.delete(serverId)
+			return {
+				result: {
+					...result,
+					error:
+						result.state === 'ready' ? null : (result.error ?? discoverError),
+					lastError: null,
+				},
+				lastError: null,
+			}
+		}
+
 		const alreadyStamped = Boolean(connection?.connectionError)
-		const error = alreadyStamped ? null : (result.error ?? discoverError)
+		if (alreadyStamped && discoverError == null) {
+			const existing =
+				this.lastDiscoverErrors.get(serverId) ??
+				this.rebuildStampedDiscoverLastError(serverId, result)
+			if (existing) {
+				this.lastDiscoverErrors.set(serverId, existing)
+				return {
+					result: {
+						...result,
+						error: existing.message,
+						lastError: existing,
+					},
+					lastError: existing,
+				}
+			}
+		}
+
 		const row = this.manager
 			.listServers()
 			.find((server) => server.id === serverId)
 		const lastError = buildIncompleteDiscoverLastError({
 			state: result.state,
 			authUrl: result.authUrl,
-			error,
+			error: alreadyStamped ? discoverError : (result.error ?? discoverError),
 			mcpEndpoint: row?.server_url ?? null,
 		})
 		if (!lastError) {
@@ -628,27 +676,40 @@ class McpClientHubBase extends DurableObject<Env> {
 				lastError: null,
 			}
 		}
-		if (connection && !alreadyStamped) {
-			connection.connectionError = lastError.message
-			console.warn('mcp discover timeout incomplete', {
-				attemptId: lastError.attemptId,
-				serverId,
-				phase: lastError.phase,
-				state: result.state,
-				mcpEndpoint: lastError.mcpEndpoint,
-			})
-		}
-		const message = alreadyStamped
-			? (result.error ?? lastError.message)
-			: lastError.message
+		if (connection) connection.connectionError = lastError.message
+		console.warn('mcp discover timeout incomplete', {
+			attemptId: lastError.attemptId,
+			serverId,
+			phase: lastError.phase,
+			state: result.state,
+			mcpEndpoint: lastError.mcpEndpoint,
+		})
+		this.lastDiscoverErrors.set(serverId, lastError)
 		return {
 			result: {
 				...this.buildConnectResult(serverId),
-				error: message,
-				lastError: { ...lastError, message },
+				error: lastError.message,
+				lastError,
 			},
-			lastError: { ...lastError, message },
+			lastError,
 		}
+	}
+
+	private rebuildStampedDiscoverLastError(
+		serverId: string,
+		result: McpServerConnectResult,
+	): McpServerLastError | null {
+		const row = this.manager
+			.listServers()
+			.find((server) => server.id === serverId)
+		return buildIncompleteDiscoverLastError({
+			state: result.state,
+			authUrl: result.authUrl,
+			error: null,
+			mcpEndpoint: row?.server_url ?? null,
+			attemptId:
+				readAttemptIdFromSettleMessage(result.error) ?? crypto.randomUUID(),
+		})
 	}
 
 	private async discoverAfterOAuthEstablish(
@@ -663,8 +724,8 @@ class McpClientHubBase extends DurableObject<Env> {
 		serverId: string | null
 		serverName: string | null
 		settleError?: string | null
+		settleLastError?: McpServerLastError | null
 	}): Promise<McpServerOAuthCallbackOutcome> {
-		const attemptId = crypto.randomUUID()
 		const connection = input.serverId
 			? this.buildConnectResult(input.serverId)
 			: null
@@ -676,6 +737,14 @@ class McpClientHubBase extends DurableObject<Env> {
 					.listServers()
 					.find((server) => server.id === input.serverId)
 			: null
+		const stamped = input.settleLastError
+		const connectionError = connection?.error ?? input.settleError ?? null
+		const alreadyFormatted =
+			Boolean(stamped) || isFormattedMcpOAuthSettleMessage(connectionError)
+		const attemptId =
+			stamped?.attemptId ??
+			readAttemptIdFromSettleMessage(connectionError) ??
+			crypto.randomUUID()
 		const outcome = resolveMcpOAuthCallbackOutcome({
 			sdkAuthSuccess: input.sdkAuthSuccess,
 			sdkAuthError: input.sdkAuthError,
@@ -685,14 +754,19 @@ class McpClientHubBase extends DurableObject<Env> {
 			connection: connection
 				? {
 						...connection,
-						error: connection.error ?? input.settleError ?? null,
-						mcpEndpoint: row?.server_url ?? null,
-						resource: discovery.resource,
-						authServer: discovery.authServer,
+						error: alreadyFormatted ? null : connectionError,
+						httpStatus: stamped?.httpStatus ?? null,
+						httpBodySnippet: stamped?.httpBodySnippet ?? null,
+						mcpEndpoint: row?.server_url ?? stamped?.mcpEndpoint ?? null,
+						resource: discovery.resource ?? stamped?.resource ?? null,
+						authServer: discovery.authServer ?? stamped?.authServer ?? null,
 					}
 				: null,
 		})
-		if (outcome.lastError) {
+		if (outcome.lastError && input.serverId) {
+			const live = this.manager.mcpConnections[input.serverId]
+			if (live) live.connectionError = outcome.lastError.message
+			this.lastDiscoverErrors.set(input.serverId, outcome.lastError)
 			console.warn('mcp oauth callback settle incomplete', {
 				attemptId: outcome.lastError.attemptId,
 				serverId: outcome.serverId,

--- a/packages/worker/src/mcp-client/hub.ts
+++ b/packages/worker/src/mcp-client/hub.ts
@@ -12,6 +12,7 @@ import {
 	isStuckMcpAuthenticatingWithoutAuthUrl,
 	resolveMcpOAuthCallbackOutcome,
 } from './oauth-callback-outcome.ts'
+import { readOAuthDiscoveryUrls } from './oauth-settle-error.ts'
 import {
 	outboundMcpClientOptions,
 	reconnectMcpServerOptions,
@@ -349,6 +350,7 @@ class McpClientHubBase extends DurableObject<Env> {
 				authError: oauthRecoveryMessage,
 				serverName: null,
 				authorizationNeeded: true,
+				lastError: null,
 			}
 		}
 		const result = await this.manager.handleCallbackRequest(request)
@@ -374,8 +376,13 @@ class McpClientHubBase extends DurableObject<Env> {
 				timeout: connectionSettleTimeoutMs,
 			})
 			let connection = this.buildConnectResult(serverId)
+			let settleError: string | null = null
 			if (isStuckMcpAuthenticatingWithoutAuthUrl(connection)) {
 				connection = await this.recoverStuckAuthenticating(serverId)
+				settleError = connection.error
+			} else if (connection.state === 'connected') {
+				connection = await this.discoverAfterOAuthEstablish(serverId)
+				settleError = connection.error
 			}
 			if (serverName) {
 				await this.observeServer({
@@ -383,20 +390,19 @@ class McpClientHubBase extends DurableObject<Env> {
 					serverName,
 				})
 			}
-			return resolveMcpOAuthCallbackOutcome({
+			return await this.resolveOAuthCallbackOutcome({
 				sdkAuthSuccess: true,
 				sdkAuthError: result.authError ?? null,
 				serverId,
 				serverName,
-				connection: this.buildConnectResult(serverId),
+				settleError,
 			})
 		}
-		return resolveMcpOAuthCallbackOutcome({
+		return await this.resolveOAuthCallbackOutcome({
 			sdkAuthSuccess: result.authSuccess,
 			sdkAuthError: result.authError ?? null,
 			serverId,
 			serverName,
-			connection: serverId ? this.buildConnectResult(serverId) : null,
 		})
 	}
 
@@ -428,6 +434,7 @@ class McpClientHubBase extends DurableObject<Env> {
 				authError: null,
 				serverName,
 				authorizationNeeded: false,
+				lastError: null,
 			}
 		}
 		try {
@@ -439,6 +446,7 @@ class McpClientHubBase extends DurableObject<Env> {
 					authError: null,
 					serverName,
 					authorizationNeeded: false,
+					lastError: null,
 				}
 			}
 		} catch {
@@ -450,6 +458,7 @@ class McpClientHubBase extends DurableObject<Env> {
 			authError: oauthRecoveryMessage,
 			serverName,
 			authorizationNeeded: true,
+			lastError: null,
 		}
 	}
 
@@ -562,6 +571,93 @@ class McpClientHubBase extends DurableObject<Env> {
 	 * auth URL. Needed when SQL `auth_url` was cleared on callback success but
 	 * the live connection never reached `ready`.
 	 */
+	private async discoverAfterOAuthEstablish(
+		serverId: string,
+	): Promise<McpServerConnectResult> {
+		let discoverError: string | null = null
+		try {
+			await this.manager.discoverIfConnected(serverId, {
+				timeoutMs: discoverTimeoutMs,
+			})
+		} catch (error) {
+			discoverError = error instanceof Error ? error.message : String(error)
+		}
+		const result = this.buildConnectResult(serverId)
+		return {
+			...result,
+			error: result.error ?? discoverError,
+		}
+	}
+
+	private async resolveOAuthCallbackOutcome(input: {
+		sdkAuthSuccess: boolean
+		sdkAuthError: string | null
+		serverId: string | null
+		serverName: string | null
+		settleError?: string | null
+	}): Promise<McpServerOAuthCallbackOutcome> {
+		const attemptId = crypto.randomUUID()
+		const connection = input.serverId
+			? this.buildConnectResult(input.serverId)
+			: null
+		const discovery = input.serverId
+			? await this.readOAuthDiscoveryUrls(input.serverId)
+			: { resource: null, authServer: null }
+		const row = input.serverId
+			? this.manager
+					.listServers()
+					.find((server) => server.id === input.serverId)
+			: null
+		const outcome = resolveMcpOAuthCallbackOutcome({
+			sdkAuthSuccess: input.sdkAuthSuccess,
+			sdkAuthError: input.sdkAuthError,
+			serverId: input.serverId,
+			serverName: input.serverName,
+			attemptId,
+			connection: connection
+				? {
+						...connection,
+						error: connection.error ?? input.settleError ?? null,
+						mcpEndpoint: row?.server_url ?? null,
+						resource: discovery.resource,
+						authServer: discovery.authServer,
+					}
+				: null,
+		})
+		if (outcome.lastError) {
+			console.warn('mcp oauth callback settle incomplete', {
+				attemptId: outcome.lastError.attemptId,
+				serverId: outcome.serverId,
+				phase: outcome.lastError.phase,
+				state: connection?.state ?? null,
+				httpStatus: outcome.lastError.httpStatus,
+				mcpEndpoint: outcome.lastError.mcpEndpoint,
+				resource: outcome.lastError.resource,
+				authServer: outcome.lastError.authServer,
+			})
+		}
+		return outcome
+	}
+
+	private async readOAuthDiscoveryUrls(serverId: string): Promise<{
+		resource: string | null
+		authServer: string | null
+	}> {
+		const prefix = `/${mcpClientName}/${serverId}/`
+		const entries = await this.ctx.storage.list({ prefix })
+		for (const [key, value] of entries) {
+			if (
+				!key.endsWith('/oauth_discovery') &&
+				!key.includes('oauth_discovery')
+			) {
+				continue
+			}
+			const parsed = readOAuthDiscoveryUrls(value)
+			if (parsed.resource || parsed.authServer) return parsed
+		}
+		return { resource: null, authServer: null }
+	}
+
 	private async recoverStuckAuthenticating(
 		serverId: string,
 	): Promise<McpServerConnectResult> {

--- a/packages/worker/src/mcp-client/hub.ts
+++ b/packages/worker/src/mcp-client/hub.ts
@@ -428,14 +428,24 @@ class McpClientHubBase extends DurableObject<Env> {
 			existingConnection.state === 'discovering' ||
 			existingConnection.state === 'connecting'
 		) {
-			return {
-				serverId: input.serverId,
-				authSuccess: true,
-				authError: null,
-				serverName,
-				authorizationNeeded: false,
-				lastError: null,
+			// IdP already succeeded. Keep tokens, but do not claim callback
+			// success or clear lastError until the connection is ready. A
+			// Back/replay after an incomplete settle used to wipe the durable
+			// reason and redirect with auth=success.
+			let settleError: string | null = null
+			if (existingConnection.state === 'connected') {
+				const discovered = await this.discoverAfterOAuthEstablish(
+					input.serverId,
+				)
+				settleError = discovered.error
 			}
+			return await this.resolveOAuthCallbackOutcome({
+				sdkAuthSuccess: true,
+				sdkAuthError: null,
+				serverId: input.serverId,
+				serverName,
+				settleError,
+			})
 		}
 		try {
 			const connection = await this.restartServerAuthorization(input)

--- a/packages/worker/src/mcp-client/hub.ts
+++ b/packages/worker/src/mcp-client/hub.ts
@@ -12,7 +12,10 @@ import {
 	isStuckMcpAuthenticatingWithoutAuthUrl,
 	resolveMcpOAuthCallbackOutcome,
 } from './oauth-callback-outcome.ts'
-import { readOAuthDiscoveryUrls } from './oauth-settle-error.ts'
+import {
+	buildIncompleteDiscoverLastError,
+	readOAuthDiscoveryUrls,
+} from './oauth-settle-error.ts'
 import {
 	outboundMcpClientOptions,
 	reconnectMcpServerOptions,
@@ -35,6 +38,7 @@ import {
 	type McpClientHubSnapshot,
 	type McpServerConnectResult,
 	type McpServerConnectionState,
+	type McpServerLastError,
 	type McpServerOAuthCallbackOutcome,
 	type McpServerSnapshot,
 	type McpServerToolDescriptor,
@@ -235,15 +239,13 @@ class McpClientHubBase extends DurableObject<Env> {
 		this.clearSessionBeforeConnect(input.serverId)
 		const connected = await this.manager.connectToServer(input.serverId)
 		if (connected.state === 'connected') {
-			await this.manager.discoverIfConnected(input.serverId, {
-				timeoutMs: discoverTimeoutMs,
-			})
+			await this.runDiscoverIfConnected(input.serverId)
 		}
 		await this.observeServer({
 			serverId: input.serverId,
 			serverName: input.name,
 		})
-		return this.buildConnectResult(input.serverId)
+		return this.finalizeConnectResult(input.serverId)
 	}
 
 	/**
@@ -272,7 +274,7 @@ class McpClientHubBase extends DurableObject<Env> {
 				serverName: row.name,
 			})
 		}
-		return this.buildConnectResult(input.serverId)
+		return this.finalizeConnectResult(input.serverId)
 	}
 
 	/** Re-discover tools for a connected server. */
@@ -283,9 +285,7 @@ class McpClientHubBase extends DurableObject<Env> {
 		await this.manager.waitForConnections({
 			timeout: connectionSettleTimeoutMs,
 		})
-		await this.manager.discoverIfConnected(input.serverId, {
-			timeoutMs: discoverTimeoutMs,
-		})
+		await this.runDiscoverIfConnected(input.serverId)
 		const row = this.manager
 			.listServers()
 			.find((server) => server.id === input.serverId)
@@ -295,7 +295,7 @@ class McpClientHubBase extends DurableObject<Env> {
 				serverName: row.name,
 			})
 		}
-		return this.buildConnectResult(input.serverId)
+		return this.finalizeConnectResult(input.serverId)
 	}
 
 	async removeServer(input: { serverId: string }): Promise<void> {
@@ -554,9 +554,7 @@ class McpClientHubBase extends DurableObject<Env> {
 		this.clearSessionBeforeConnect(input.serverId)
 		const result = await this.manager.connectToServer(input.serverId)
 		if (result.state === 'connected') {
-			await this.manager.discoverIfConnected(input.serverId, {
-				timeoutMs: discoverTimeoutMs,
-			})
+			return (await this.runDiscoverIfConnected(input.serverId)).result
 		}
 		return this.buildConnectResult(input.serverId)
 	}
@@ -581,9 +579,10 @@ class McpClientHubBase extends DurableObject<Env> {
 	 * auth URL. Needed when SQL `auth_url` was cleared on callback success but
 	 * the live connection never reached `ready`.
 	 */
-	private async discoverAfterOAuthEstablish(
-		serverId: string,
-	): Promise<McpServerConnectResult> {
+	private async runDiscoverIfConnected(serverId: string): Promise<{
+		result: McpServerConnectResult
+		lastError: McpServerLastError | null
+	}> {
 		let discoverError: string | null = null
 		try {
 			await this.manager.discoverIfConnected(serverId, {
@@ -592,11 +591,70 @@ class McpClientHubBase extends DurableObject<Env> {
 		} catch (error) {
 			discoverError = error instanceof Error ? error.message : String(error)
 		}
+		return this.applyIncompleteDiscoverFailure(serverId, discoverError)
+	}
+
+	private finalizeConnectResult(serverId: string): McpServerConnectResult {
+		return this.applyIncompleteDiscoverFailure(serverId, null).result
+	}
+
+	private applyIncompleteDiscoverFailure(
+		serverId: string,
+		discoverError: string | null,
+	): {
+		result: McpServerConnectResult
+		lastError: McpServerLastError | null
+	} {
 		const result = this.buildConnectResult(serverId)
-		return {
-			...result,
-			error: result.error ?? discoverError,
+		const connection = this.manager.mcpConnections[serverId]
+		const alreadyStamped = Boolean(connection?.connectionError)
+		const error = alreadyStamped ? null : (result.error ?? discoverError)
+		const row = this.manager
+			.listServers()
+			.find((server) => server.id === serverId)
+		const lastError = buildIncompleteDiscoverLastError({
+			state: result.state,
+			authUrl: result.authUrl,
+			error,
+			mcpEndpoint: row?.server_url ?? null,
+		})
+		if (!lastError) {
+			return {
+				result: {
+					...result,
+					error: result.error ?? discoverError,
+					lastError: null,
+				},
+				lastError: null,
+			}
 		}
+		if (connection && !alreadyStamped) {
+			connection.connectionError = lastError.message
+			console.warn('mcp discover timeout incomplete', {
+				attemptId: lastError.attemptId,
+				serverId,
+				phase: lastError.phase,
+				state: result.state,
+				mcpEndpoint: lastError.mcpEndpoint,
+			})
+		}
+		const message = alreadyStamped
+			? (result.error ?? lastError.message)
+			: lastError.message
+		return {
+			result: {
+				...this.buildConnectResult(serverId),
+				error: message,
+				lastError: { ...lastError, message },
+			},
+			lastError: { ...lastError, message },
+		}
+	}
+
+	private async discoverAfterOAuthEstablish(
+		serverId: string,
+	): Promise<McpServerConnectResult> {
+		return (await this.runDiscoverIfConnected(serverId)).result
 	}
 
 	private async resolveOAuthCallbackOutcome(input: {
@@ -686,9 +744,7 @@ class McpClientHubBase extends DurableObject<Env> {
 		this.clearSessionBeforeConnect(serverId)
 		const result = await this.manager.connectToServer(serverId)
 		if (result.state === 'connected') {
-			await this.manager.discoverIfConnected(serverId, {
-				timeoutMs: discoverTimeoutMs,
-			})
+			return (await this.runDiscoverIfConnected(serverId)).result
 		}
 		return this.buildConnectResult(serverId)
 	}

--- a/packages/worker/src/mcp-client/mcp-server-logo.node.test.ts
+++ b/packages/worker/src/mcp-client/mcp-server-logo.node.test.ts
@@ -92,6 +92,7 @@ async function provisionServer(harness: ReturnType<typeof createHarness>) {
 		favicon_source_host: null,
 		usage_mode: 'any' as const,
 		allowedPackageIds: [],
+		last_error: null,
 	}
 	await insertMcpServerSettingRow({ db: harness.db, row })
 	return row

--- a/packages/worker/src/mcp-client/oauth-callback-outcome.node.test.ts
+++ b/packages/worker/src/mcp-client/oauth-callback-outcome.node.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from 'vitest'
 import {
+	describeIncompleteMcpOAuthConnection,
 	isStuckMcpAuthenticatingWithoutAuthUrl,
 	resolveMcpOAuthCallbackOutcome,
 } from './oauth-callback-outcome.ts'
@@ -11,6 +12,7 @@ test('OAuth callback outcome requires a ready connection after SDK success', () 
 			sdkAuthError: null,
 			serverId: 'server-1',
 			serverName: 'recipe-keeper',
+			attemptId: 'attempt-ready',
 			connection: {
 				state: 'ready',
 				authUrl: null,
@@ -23,6 +25,7 @@ test('OAuth callback outcome requires a ready connection after SDK success', () 
 		authError: null,
 		serverName: 'recipe-keeper',
 		authorizationNeeded: false,
+		lastError: null,
 	})
 
 	const stuckAuthenticating = resolveMcpOAuthCallbackOutcome({
@@ -30,6 +33,7 @@ test('OAuth callback outcome requires a ready connection after SDK success', () 
 		sdkAuthError: null,
 		serverId: 'server-1',
 		serverName: 'recipe-keeper',
+		attemptId: 'attempt-auth',
 		connection: {
 			state: 'authenticating',
 			authUrl: null,
@@ -38,6 +42,7 @@ test('OAuth callback outcome requires a ready connection after SDK success', () 
 	})
 	expect(stuckAuthenticating.authSuccess).toBe(false)
 	expect(stuckAuthenticating.authError).toBeTruthy()
+	expect(stuckAuthenticating.lastError?.phase).toBe('token exchange')
 	expect(
 		isStuckMcpAuthenticatingWithoutAuthUrl({
 			state: 'authenticating',
@@ -57,18 +62,23 @@ test('OAuth callback outcome requires a ready connection after SDK success', () 
 			sdkAuthError: null,
 			serverId: 'server-1',
 			serverName: 'recipe-keeper',
+			attemptId: 'attempt-token',
 			connection: {
 				state: 'failed',
 				authUrl: null,
 				error: 'Token exchange failed.',
 			},
 		}),
-	).toEqual({
+	).toMatchObject({
 		serverId: 'server-1',
 		authSuccess: false,
-		authError: 'Token exchange failed.',
+		authError: expect.stringContaining('token exchange failed'),
 		serverName: 'recipe-keeper',
 		authorizationNeeded: false,
+		lastError: expect.objectContaining({
+			phase: 'token exchange',
+			attemptId: 'attempt-token',
+		}),
 	})
 
 	expect(
@@ -89,5 +99,50 @@ test('OAuth callback outcome requires a ready connection after SDK success', () 
 		authError: 'Invalid state',
 		serverName: 'recipe-keeper',
 		authorizationNeeded: false,
+		lastError: null,
 	})
+})
+
+test('IdP success with connected state and null connection.error is a tool-discovery lastError', () => {
+	const outcome = resolveMcpOAuthCallbackOutcome({
+		sdkAuthSuccess: true,
+		sdkAuthError: null,
+		serverId: 'server-posthog',
+		serverName: 'posthog',
+		attemptId: 'attempt-adam',
+		connection: {
+			state: 'connected',
+			authUrl: null,
+			error: null,
+			mcpEndpoint: 'https://mcp.posthog.com/mcp?code=secret-token',
+			resource: 'https://mcp.posthog.com/',
+			authServer: 'https://auth.posthog.com/?client_secret=hidden',
+		},
+	})
+
+	expect(outcome.authSuccess).toBe(false)
+	expect(outcome.lastError).toMatchObject({
+		phase: 'server/discover',
+		attemptId: 'attempt-adam',
+		mcpEndpoint: 'https://mcp.posthog.com/mcp',
+		resource: 'https://mcp.posthog.com/',
+		authServer: 'https://auth.posthog.com/',
+	})
+	expect(outcome.authError).toBe(outcome.lastError?.message)
+	expect(outcome.authError).toContain("tool discovery didn't finish")
+	expect(outcome.authError).toContain('phase server/discover')
+	expect(outcome.authError).toContain('id attempt-adam')
+	expect(outcome.authError).not.toContain('still "connected"')
+	expect(outcome.authError).not.toContain('secret-token')
+	expect(outcome.authError).not.toContain('client_secret')
+
+	const discovering = describeIncompleteMcpOAuthConnection({
+		state: 'discovering',
+		authUrl: null,
+		error: null,
+		attemptId: 'attempt-discovering',
+	})
+	expect(discovering).toContain("tool discovery didn't finish")
+	expect(discovering).toContain('phase tools/list')
+	expect(discovering).not.toContain('still "discovering"')
 })

--- a/packages/worker/src/mcp-client/oauth-callback-outcome.node.test.ts
+++ b/packages/worker/src/mcp-client/oauth-callback-outcome.node.test.ts
@@ -135,6 +135,29 @@ test('IdP success with connected state and null connection.error is a tool-disco
 	expect(outcome.authError).not.toContain('still "connected"')
 	expect(outcome.authError).not.toContain('secret-token')
 	expect(outcome.authError).not.toContain('client_secret')
+	expect(outcome.authError?.match(/authorization completed/gi)?.length).toBe(1)
+	expect(outcome.authError?.match(/\bphase\s/g)?.length).toBe(1)
+
+	const alreadyFormatted = resolveMcpOAuthCallbackOutcome({
+		sdkAuthSuccess: true,
+		sdkAuthError: null,
+		serverId: 'server-posthog',
+		serverName: 'posthog',
+		attemptId: 'attempt-adam',
+		connection: {
+			state: 'connected',
+			authUrl: null,
+			error: outcome.authError,
+			mcpEndpoint: 'https://mcp.posthog.com/mcp',
+			resource: 'https://mcp.posthog.com/',
+			authServer: 'https://auth.posthog.com/',
+		},
+	})
+	expect(
+		alreadyFormatted.authError?.match(/authorization completed/gi)?.length,
+	).toBe(1)
+	expect(alreadyFormatted.authError?.match(/\bphase\s/g)?.length).toBe(1)
+	expect(alreadyFormatted.lastError?.attemptId).toBe('attempt-adam')
 
 	const discovering = describeIncompleteMcpOAuthConnection({
 		state: 'discovering',

--- a/packages/worker/src/mcp-client/oauth-callback-outcome.ts
+++ b/packages/worker/src/mcp-client/oauth-callback-outcome.ts
@@ -1,7 +1,26 @@
 import {
+	buildMcpServerLastError,
+	inferMcpOAuthSettlePhase,
+	parseHttpStatusFromMcpError,
+	sanitizeMcpErrorSnippet,
+	sanitizePublicUrl,
+	type McpServerLastError,
+} from './oauth-settle-error.ts'
+import {
 	type McpServerConnectionState,
 	type McpServerOAuthCallbackOutcome,
 } from './types.ts'
+
+export type McpOAuthCallbackConnection = {
+	state: McpServerConnectionState
+	authUrl: string | null
+	error: string | null
+	mcpEndpoint?: string | null
+	resource?: string | null
+	authServer?: string | null
+	httpStatus?: number | null
+	httpBodySnippet?: string | null
+}
 
 /**
  * Decide the user-facing OAuth callback outcome from the Agents SDK result
@@ -18,11 +37,8 @@ export function resolveMcpOAuthCallbackOutcome(input: {
 	sdkAuthError: string | null
 	serverId: string | null
 	serverName: string | null
-	connection: {
-		state: McpServerConnectionState
-		authUrl: string | null
-		error: string | null
-	} | null
+	connection: McpOAuthCallbackConnection | null
+	attemptId?: string | null
 }): McpServerOAuthCallbackOutcome {
 	const { serverId, serverName } = input
 
@@ -33,6 +49,7 @@ export function resolveMcpOAuthCallbackOutcome(input: {
 			authError: input.sdkAuthError ?? 'Authorization failed.',
 			serverName,
 			authorizationNeeded: false,
+			lastError: null,
 		}
 	}
 
@@ -44,6 +61,7 @@ export function resolveMcpOAuthCallbackOutcome(input: {
 				'Authorization completed, but Kody lost the MCP server connection. Try reconnecting from /account/mcp-servers.',
 			serverName,
 			authorizationNeeded: false,
+			lastError: null,
 		}
 	}
 
@@ -54,31 +72,54 @@ export function resolveMcpOAuthCallbackOutcome(input: {
 			authError: null,
 			serverName,
 			authorizationNeeded: false,
+			lastError: null,
 		}
 	}
 
+	const lastError = buildIncompleteMcpOAuthLastError({
+		connection: input.connection,
+		attemptId: input.attemptId,
+	})
 	return {
 		serverId,
 		authSuccess: false,
-		authError:
-			input.connection.error ??
-			describeIncompleteMcpOAuthConnection(input.connection),
+		authError: lastError.message,
 		serverName,
 		authorizationNeeded: false,
+		lastError,
 	}
 }
 
-export function describeIncompleteMcpOAuthConnection(connection: {
-	state: McpServerConnectionState
-	authUrl: string | null
-}): string {
-	if (connection.state === 'authenticating' && connection.authUrl) {
-		return 'Authorization completed at the identity provider, but the MCP server still requires authorization. Open the authorization link again from /account/mcp-servers.'
-	}
-	if (connection.state === 'authenticating') {
-		return 'Authorization completed, but Kody could not finish connecting. Reconnect the server from /account/mcp-servers and approve access once more.'
-	}
-	return `Authorization completed at the identity provider, but the MCP server is still "${connection.state}". Reconnect it from /account/mcp-servers.`
+export function describeIncompleteMcpOAuthConnection(
+	connection: McpOAuthCallbackConnection & { attemptId?: string | null },
+): string {
+	return buildIncompleteMcpOAuthLastError({
+		connection,
+		attemptId: connection.attemptId,
+	}).message
+}
+
+function buildIncompleteMcpOAuthLastError(input: {
+	connection: McpOAuthCallbackConnection
+	attemptId?: string | null
+}): McpServerLastError {
+	const error = input.connection.error
+	return buildMcpServerLastError({
+		state: input.connection.state,
+		authUrl: input.connection.authUrl,
+		error,
+		phase: inferMcpOAuthSettlePhase({
+			state: input.connection.state,
+			error,
+		}),
+		httpStatus:
+			input.connection.httpStatus ?? parseHttpStatusFromMcpError(error),
+		httpBodySnippet: sanitizeMcpErrorSnippet(input.connection.httpBodySnippet),
+		mcpEndpoint: sanitizePublicUrl(input.connection.mcpEndpoint),
+		resource: sanitizePublicUrl(input.connection.resource),
+		authServer: sanitizePublicUrl(input.connection.authServer),
+		attemptId: input.attemptId?.trim() || crypto.randomUUID(),
+	})
 }
 
 /**

--- a/packages/worker/src/mcp-client/oauth-settle-error.node.test.ts
+++ b/packages/worker/src/mcp-client/oauth-settle-error.node.test.ts
@@ -25,6 +25,18 @@ test('settle error helpers sanitize secrets and keep observable phases', () => {
 		),
 	).not.toContain('secret-token')
 	expect(
+		sanitizeMcpErrorSnippet(
+			'{"access_token":"secret-token","refresh_token":"rt-secret","client_secret":"cs-secret"}',
+		),
+	).toBe(
+		'{"access_token":"[redacted]","refresh_token":"[redacted]","client_secret":"[redacted]"}',
+	)
+	expect(
+		sanitizeMcpErrorSnippet(
+			'{ "access_token" : "secret-token", "refresh_token" : "rt-secret" }',
+		),
+	).not.toMatch(/secret-token|rt-secret/)
+	expect(
 		parseHttpStatusFromMcpError('upstream HTTP 403: missing audience'),
 	).toBe(403)
 	expect(

--- a/packages/worker/src/mcp-client/oauth-settle-error.node.test.ts
+++ b/packages/worker/src/mcp-client/oauth-settle-error.node.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from 'vitest'
 import {
+	buildIncompleteDiscoverLastError,
 	buildMcpServerLastError,
 	inferMcpOAuthSettlePhase,
 	parseHttpStatusFromMcpError,
@@ -57,6 +58,30 @@ test('settle error helpers sanitize secrets and keep observable phases', () => {
 			error: 'Protected resource metadata HTTP 401',
 		}),
 	).toBe('resource metadata')
+	expect(
+		buildIncompleteDiscoverLastError({
+			state: 'connected',
+			mcpEndpoint: 'https://mcp.example/mcp',
+			attemptId: 'attempt-discover',
+		})?.phase,
+	).toBe('server/discover')
+	expect(
+		buildIncompleteDiscoverLastError({
+			state: 'discovering',
+			mcpEndpoint: 'https://mcp.example/mcp',
+			attemptId: 'attempt-tools',
+		}),
+	).toMatchObject({
+		phase: 'tools/list',
+		attemptId: 'attempt-tools',
+		mcpEndpoint: 'https://mcp.example/mcp',
+	})
+	expect(
+		buildIncompleteDiscoverLastError({
+			state: 'ready',
+			mcpEndpoint: 'https://mcp.example/mcp',
+		}),
+	).toBeNull()
 
 	const lastError = buildMcpServerLastError({
 		state: 'connected',

--- a/packages/worker/src/mcp-client/oauth-settle-error.node.test.ts
+++ b/packages/worker/src/mcp-client/oauth-settle-error.node.test.ts
@@ -1,0 +1,82 @@
+import { expect, test } from 'vitest'
+import {
+	buildMcpServerLastError,
+	inferMcpOAuthSettlePhase,
+	parseHttpStatusFromMcpError,
+	parseStoredMcpServerLastError,
+	readOAuthDiscoveryUrls,
+	sanitizeMcpErrorSnippet,
+	sanitizePublicUrl,
+	stringifyMcpServerLastError,
+} from './oauth-settle-error.ts'
+
+test('settle error helpers sanitize secrets and keep observable phases', () => {
+	expect(sanitizePublicUrl('https://mcp.example/mcp?code=abc#frag')).toBe(
+		'https://mcp.example/mcp',
+	)
+	expect(
+		sanitizeMcpErrorSnippet(
+			'HTTP 403 Forbidden Bearer secret-token access_token=abc eyJhbGciOiJIUzI1NiJ9.aaa.bbb',
+		),
+	).toContain('Bearer [redacted]')
+	expect(
+		sanitizeMcpErrorSnippet(
+			'HTTP 403 Forbidden Bearer secret-token access_token=abc',
+		),
+	).not.toContain('secret-token')
+	expect(
+		parseHttpStatusFromMcpError('upstream HTTP 403: missing audience'),
+	).toBe(403)
+	expect(
+		inferMcpOAuthSettlePhase({
+			state: 'connected',
+			error: null,
+		}),
+	).toBe('server/discover')
+	expect(
+		inferMcpOAuthSettlePhase({
+			state: 'discovering',
+			error: null,
+		}),
+	).toBe('tools/list')
+	expect(
+		inferMcpOAuthSettlePhase({
+			state: 'failed',
+			error: 'Protected resource metadata HTTP 401',
+		}),
+	).toBe('resource metadata')
+
+	const lastError = buildMcpServerLastError({
+		state: 'connected',
+		authUrl: null,
+		error: 'HTTP 403 insufficient_scope access_token=leak',
+		httpBodySnippet: 'insufficient_scope',
+		mcpEndpoint: 'https://mcp.example/mcp?token=abc',
+		resource: 'https://mcp.example/',
+		authServer: 'https://auth.example/',
+		attemptId: 'attempt-1',
+		at: '2026-09-08T00:00:00.000Z',
+	})
+	expect(lastError.message).toContain('HTTP 403')
+	expect(lastError.message).toContain('phase server/discover')
+	expect(lastError.message).not.toContain('access_token=leak')
+	expect(lastError.mcpEndpoint).toBe('https://mcp.example/mcp')
+
+	const stored = parseStoredMcpServerLastError(
+		stringifyMcpServerLastError(lastError),
+	)
+	expect(stored).toEqual(lastError)
+	expect(parseStoredMcpServerLastError('plain leftover')).toMatchObject({
+		message: 'plain leftover',
+		phase: null,
+	})
+	expect(
+		readOAuthDiscoveryUrls({
+			resource: 'https://mcp.example/?code=abc',
+			authorization_servers: ['https://auth.example/?client_secret=x'],
+		}),
+	).toEqual({
+		resource: 'https://mcp.example/',
+		authServer: 'https://auth.example/',
+	})
+})

--- a/packages/worker/src/mcp-client/oauth-settle-error.node.test.ts
+++ b/packages/worker/src/mcp-client/oauth-settle-error.node.test.ts
@@ -2,9 +2,12 @@ import { expect, test } from 'vitest'
 import {
 	buildIncompleteDiscoverLastError,
 	buildMcpServerLastError,
+	formatMcpOAuthSettleErrorMessage,
 	inferMcpOAuthSettlePhase,
+	isFormattedMcpOAuthSettleMessage,
 	parseHttpStatusFromMcpError,
 	parseStoredMcpServerLastError,
+	readAttemptIdFromSettleMessage,
 	readOAuthDiscoveryUrls,
 	sanitizeMcpErrorSnippet,
 	sanitizePublicUrl,
@@ -116,4 +119,27 @@ test('settle error helpers sanitize secrets and keep observable phases', () => {
 		resource: 'https://mcp.example/',
 		authServer: 'https://auth.example/',
 	})
+
+	const formatted = formatMcpOAuthSettleErrorMessage({
+		state: 'connected',
+		authUrl: null,
+		mcpEndpoint: 'https://mcp.example/mcp',
+		attemptId: '11111111-1111-4111-8111-111111111111',
+	})
+	expect(isFormattedMcpOAuthSettleMessage(formatted)).toBe(true)
+	expect(readAttemptIdFromSettleMessage(formatted)).toBe(
+		'11111111-1111-4111-8111-111111111111',
+	)
+	const wrapped = formatMcpOAuthSettleErrorMessage({
+		state: 'connected',
+		authUrl: null,
+		error: formatted,
+		mcpEndpoint: 'https://mcp.example/mcp',
+		resource: 'https://mcp.example/',
+		attemptId: '11111111-1111-4111-8111-111111111111',
+	})
+	expect(wrapped.match(/authorization completed/gi)?.length).toBe(1)
+	expect(wrapped.match(/\bphase\s/g)?.length).toBe(1)
+	expect(wrapped.match(/\bid\s/g)?.length).toBe(1)
+	expect(wrapped).toContain('id 11111111-1111-4111-8111-111111111111')
 })

--- a/packages/worker/src/mcp-client/oauth-settle-error.ts
+++ b/packages/worker/src/mcp-client/oauth-settle-error.ts
@@ -1,0 +1,404 @@
+import {
+	type McpOAuthSettlePhase,
+	type McpServerConnectionState,
+	type McpServerLastError,
+} from './types.ts'
+
+export type { McpOAuthSettlePhase, McpServerLastError }
+
+const httpStatusPattern =
+	/\b(?:HTTP(?:\s+status(?:\s+code)?)?|status(?:\s+code)?)\s*[:=]?\s*(\d{3})\b/i
+const httpStatusWordPattern =
+	/\b(\d{3})\s+(?:Forbidden|Unauthorized|Not Found|Bad Request|Internal Server Error|Too Many Requests|Service Unavailable)\b/i
+const bearerPattern = /\bBearer\s+\S+/gi
+const assignmentSecretPattern =
+	/\b(?:access_token|refresh_token|id_token|client_secret|authorization|password|secret|api[_-]?key|code)\s*[:=]\s*\S+/gi
+const jwtLikePattern =
+	/\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b/g
+
+export const mcpServerLastErrorBodySnippetLimit = 160
+
+export function sanitizePublicUrl(
+	value: string | null | undefined,
+): string | null {
+	if (!value) return null
+	try {
+		const url = new URL(value)
+		url.username = ''
+		url.password = ''
+		url.search = ''
+		url.hash = ''
+		return url.href
+	} catch {
+		return null
+	}
+}
+
+export function sanitizeMcpErrorSnippet(
+	value: string | null | undefined,
+	limit = mcpServerLastErrorBodySnippetLimit,
+): string | null {
+	if (!value) return null
+	const redacted = value
+		.replaceAll(bearerPattern, 'Bearer [redacted]')
+		.replaceAll(assignmentSecretPattern, (match) => {
+			const separator = match.includes('=') ? '=' : ':'
+			const key = match.split(/[:=]/)[0]?.trim() ?? 'secret'
+			return `${key}${separator}[redacted]`
+		})
+		.replaceAll(jwtLikePattern, '[redacted]')
+		.replaceAll(/\s+/g, ' ')
+		.trim()
+	if (!redacted) return null
+	if (redacted.length <= limit) return redacted
+	return `${redacted.slice(0, limit)}…`
+}
+
+export function parseHttpStatusFromMcpError(
+	value: string | null | undefined,
+): number | null {
+	if (!value) return null
+	const labeled = value.match(httpStatusPattern)
+	const word = labeled ?? value.match(httpStatusWordPattern)
+	if (!word?.[1]) return null
+	const status = Number(word[1])
+	return status >= 100 && status <= 599 ? status : null
+}
+
+export function inferMcpOAuthSettlePhase(input: {
+	state: McpServerConnectionState
+	error?: string | null
+}): McpOAuthSettlePhase | null {
+	const error = input.error?.toLowerCase() ?? ''
+	if (
+		error.includes('resource metadata') ||
+		error.includes('oauth-protected-resource') ||
+		error.includes('protected resource')
+	) {
+		return 'resource metadata'
+	}
+	if (
+		error.includes('token exchange') ||
+		error.includes('invalid_grant') ||
+		error.includes('unauthorized_client')
+	) {
+		return 'token exchange'
+	}
+	if (
+		error.includes('initialize') ||
+		error.includes('unsupportedprotocolversion') ||
+		error.includes('-32022')
+	) {
+		return 'mcp initialize'
+	}
+	if (error.includes('tools/list')) return 'tools/list'
+	if (error.includes('server/discover') || error.includes('discover')) {
+		return 'server/discover'
+	}
+
+	switch (input.state) {
+		case 'authenticating':
+			return 'token exchange'
+		case 'connecting':
+			return 'mcp initialize'
+		case 'connected':
+			return 'server/discover'
+		case 'discovering':
+			return 'tools/list'
+		case 'failed':
+		case 'disconnected':
+		case 'ready':
+			return null
+		default: {
+			const exhaustive: never = input.state
+			throw new Error(`Unhandled MCP connection state: ${String(exhaustive)}`)
+		}
+	}
+}
+
+export function formatMcpOAuthSettleErrorMessage(input: {
+	state: McpServerConnectionState
+	authUrl: string | null
+	error?: string | null
+	phase?: McpOAuthSettlePhase | null
+	httpStatus?: number | null
+	httpBodySnippet?: string | null
+	mcpEndpoint?: string | null
+	resource?: string | null
+	authServer?: string | null
+	attemptId?: string | null
+}): string {
+	const phase =
+		input.phase ??
+		inferMcpOAuthSettlePhase({
+			state: input.state,
+			error: input.error,
+		})
+	const details = formatMcpOAuthSettleDetails({
+		phase,
+		httpStatus: input.httpStatus ?? parseHttpStatusFromMcpError(input.error),
+		httpBodySnippet: sanitizeMcpErrorSnippet(input.httpBodySnippet),
+		mcpEndpoint: sanitizePublicUrl(input.mcpEndpoint),
+		resource: sanitizePublicUrl(input.resource),
+		authServer: sanitizePublicUrl(input.authServer),
+		attemptId: input.attemptId?.trim() || null,
+	})
+	const lead = describeIncompleteMcpOAuthLead({
+		state: input.state,
+		authUrl: input.authUrl,
+		error: sanitizeMcpErrorSnippet(input.error, 240),
+		phase,
+	})
+	const reconnect = reconnectHint(input.state, input.authUrl)
+	if (details && reconnect) return `${lead} (${details}). ${reconnect}`
+	if (details) return `${lead} (${details}).`
+	if (reconnect) return `${lead}. ${reconnect}`
+	return `${lead}.`
+}
+
+export function buildMcpServerLastError(input: {
+	state: McpServerConnectionState
+	authUrl: string | null
+	error?: string | null
+	phase?: McpOAuthSettlePhase | null
+	httpStatus?: number | null
+	httpBodySnippet?: string | null
+	mcpEndpoint?: string | null
+	resource?: string | null
+	authServer?: string | null
+	attemptId: string
+	at?: string
+}): McpServerLastError {
+	const phase =
+		input.phase ??
+		inferMcpOAuthSettlePhase({
+			state: input.state,
+			error: input.error,
+		})
+	const httpStatus =
+		input.httpStatus ?? parseHttpStatusFromMcpError(input.error)
+	const httpBodySnippet = sanitizeMcpErrorSnippet(
+		input.httpBodySnippet ??
+			(httpStatus && input.error && !input.httpBodySnippet
+				? input.error
+				: null),
+	)
+	return {
+		message: formatMcpOAuthSettleErrorMessage({
+			...input,
+			phase,
+			httpStatus,
+			httpBodySnippet,
+		}),
+		phase,
+		httpStatus,
+		httpBodySnippet,
+		mcpEndpoint: sanitizePublicUrl(input.mcpEndpoint),
+		resource: sanitizePublicUrl(input.resource),
+		authServer: sanitizePublicUrl(input.authServer),
+		attemptId: input.attemptId,
+		at: input.at ?? new Date().toISOString(),
+	}
+}
+
+export function parseStoredMcpServerLastError(
+	value: string | null | undefined,
+): McpServerLastError | null {
+	if (!value) return null
+	const trimmed = value.trim()
+	if (!trimmed) return null
+	try {
+		const parsed: unknown = JSON.parse(trimmed)
+		if (!parsed || typeof parsed !== 'object') {
+			return lastErrorFromMessage(trimmed)
+		}
+		const record = parsed as Record<string, unknown>
+		const message =
+			typeof record['message'] === 'string' ? record['message'].trim() : ''
+		if (!message) return lastErrorFromMessage(trimmed)
+		return {
+			message,
+			phase: parseStoredPhase(record['phase']),
+			httpStatus:
+				typeof record['httpStatus'] === 'number' &&
+				Number.isInteger(record['httpStatus'])
+					? record['httpStatus']
+					: null,
+			httpBodySnippet:
+				typeof record['httpBodySnippet'] === 'string'
+					? sanitizeMcpErrorSnippet(record['httpBodySnippet'])
+					: null,
+			mcpEndpoint: sanitizePublicUrl(
+				typeof record['mcpEndpoint'] === 'string'
+					? record['mcpEndpoint']
+					: null,
+			),
+			resource: sanitizePublicUrl(
+				typeof record['resource'] === 'string' ? record['resource'] : null,
+			),
+			authServer: sanitizePublicUrl(
+				typeof record['authServer'] === 'string' ? record['authServer'] : null,
+			),
+			attemptId:
+				typeof record['attemptId'] === 'string' && record['attemptId'].trim()
+					? record['attemptId'].trim()
+					: 'unknown',
+			at:
+				typeof record['at'] === 'string' && record['at'].trim()
+					? record['at'].trim()
+					: new Date(0).toISOString(),
+		}
+	} catch {
+		return lastErrorFromMessage(trimmed)
+	}
+}
+
+export function stringifyMcpServerLastError(
+	lastError: McpServerLastError | null,
+): string | null {
+	if (!lastError) return null
+	return JSON.stringify({
+		message: lastError.message,
+		phase: lastError.phase,
+		httpStatus: lastError.httpStatus,
+		httpBodySnippet: lastError.httpBodySnippet,
+		mcpEndpoint: lastError.mcpEndpoint,
+		resource: lastError.resource,
+		authServer: lastError.authServer,
+		attemptId: lastError.attemptId,
+		at: lastError.at,
+	})
+}
+
+export function mcpServerLastErrorDisplayMessage(
+	lastError: McpServerLastError | null,
+): string | null {
+	return lastError?.message ?? null
+}
+
+function lastErrorFromMessage(message: string): McpServerLastError {
+	return {
+		message: sanitizeMcpErrorSnippet(message, 500) ?? message,
+		phase: null,
+		httpStatus: parseHttpStatusFromMcpError(message),
+		httpBodySnippet: sanitizeMcpErrorSnippet(message),
+		mcpEndpoint: null,
+		resource: null,
+		authServer: null,
+		attemptId: 'unknown',
+		at: new Date(0).toISOString(),
+	}
+}
+
+function parseStoredPhase(value: unknown): McpOAuthSettlePhase | null {
+	if (value === 'token exchange') return 'token exchange'
+	if (value === 'resource metadata') return 'resource metadata'
+	if (value === 'mcp initialize') return 'mcp initialize'
+	if (value === 'server/discover') return 'server/discover'
+	if (value === 'tools/list') return 'tools/list'
+	return null
+}
+
+function describeIncompleteMcpOAuthLead(input: {
+	state: McpServerConnectionState
+	authUrl: string | null
+	error: string | null
+	phase: McpOAuthSettlePhase | null
+}): string {
+	if (input.error) {
+		return `Authorization completed at the identity provider, but ${decapitalizeLead(input.error)}`
+	}
+	if (input.state === 'authenticating' && input.authUrl) {
+		return 'Authorization completed at the identity provider, but the MCP server still requires authorization'
+	}
+	if (input.state === 'authenticating') {
+		return 'Authorization completed, but Kody could not finish connecting'
+	}
+	if (
+		input.state === 'connected' ||
+		input.state === 'discovering' ||
+		input.phase === 'server/discover' ||
+		input.phase === 'tools/list'
+	) {
+		return "Authorization completed at the identity provider, but tool discovery didn't finish"
+	}
+	return 'Authorization completed at the identity provider, but the MCP server did not become ready'
+}
+
+function reconnectHint(
+	state: McpServerConnectionState,
+	authUrl: string | null,
+) {
+	if (state === 'authenticating' && authUrl) {
+		return 'Open the authorization link again from /account/mcp-servers.'
+	}
+	if (state === 'authenticating') {
+		return 'Reconnect the server from /account/mcp-servers and approve access once more.'
+	}
+	return 'Reconnect it from /account/mcp-servers.'
+}
+
+function formatMcpOAuthSettleDetails(input: {
+	phase: McpOAuthSettlePhase | null
+	httpStatus: number | null
+	httpBodySnippet: string | null
+	mcpEndpoint: string | null
+	resource: string | null
+	authServer: string | null
+	attemptId: string | null
+}): string {
+	const parts: Array<string> = []
+	if (input.phase) parts.push(`phase ${input.phase}`)
+	if (input.httpStatus != null) {
+		parts.push(
+			input.httpBodySnippet
+				? `HTTP ${input.httpStatus}: ${input.httpBodySnippet}`
+				: `HTTP ${input.httpStatus}`,
+		)
+	} else if (input.httpBodySnippet) {
+		parts.push(input.httpBodySnippet)
+	}
+	if (input.mcpEndpoint) parts.push(`mcp ${input.mcpEndpoint}`)
+	if (input.resource) parts.push(`resource ${input.resource}`)
+	if (input.authServer) parts.push(`auth ${input.authServer}`)
+	if (input.attemptId) parts.push(`id ${input.attemptId}`)
+	return parts.join(', ')
+}
+
+function decapitalizeLead(value: string) {
+	return value.replace(/^[A-Z]/, (letter) => letter.toLowerCase())
+}
+
+export function readOAuthDiscoveryUrls(value: unknown): {
+	resource: string | null
+	authServer: string | null
+} {
+	if (!value || typeof value !== 'object') {
+		return { resource: null, authServer: null }
+	}
+	const record = value as Record<string, unknown>
+	const resource = firstString(
+		record['resource'],
+		record['audience'],
+		record['resource_url'],
+	)
+	const authorizationServers = record['authorization_servers']
+	const authServer = Array.isArray(authorizationServers)
+		? firstString(...authorizationServers)
+		: firstString(
+				record['authorization_server'],
+				record['issuer'],
+				record['authorization_endpoint'],
+			)
+	return {
+		resource: sanitizePublicUrl(resource),
+		authServer: sanitizePublicUrl(authServer),
+	}
+}
+
+function firstString(...values: Array<unknown>) {
+	for (const value of values) {
+		if (typeof value === 'string' && value.trim()) return value.trim()
+	}
+	return null
+}

--- a/packages/worker/src/mcp-client/oauth-settle-error.ts
+++ b/packages/worker/src/mcp-client/oauth-settle-error.ts
@@ -11,8 +11,16 @@ const httpStatusPattern =
 const httpStatusWordPattern =
 	/\b(\d{3})\s+(?:Forbidden|Unauthorized|Not Found|Bad Request|Internal Server Error|Too Many Requests|Service Unavailable)\b/i
 const bearerPattern = /\bBearer\s+\S+/gi
-const assignmentSecretPattern =
-	/\b(?:access_token|refresh_token|id_token|client_secret|authorization|password|secret|api[_-]?key|code)\s*[:=]\s*\S+/gi
+const secretFieldNames =
+	'access_token|refresh_token|id_token|client_secret|authorization|password|secret|api[_-]?key|code'
+const jsonQuotedSecretPattern = new RegExp(
+	`"(${secretFieldNames})"\\s*:\\s*"(?:\\\\.|[^"\\\\])*"`,
+	'gi',
+)
+const assignmentSecretPattern = new RegExp(
+	`\\b(?:${secretFieldNames})\\s*[:=]\\s*\\S+`,
+	'gi',
+)
 const jwtLikePattern =
 	/\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b/g
 
@@ -39,8 +47,12 @@ export function sanitizeMcpErrorSnippet(
 	limit = mcpServerLastErrorBodySnippetLimit,
 ): string | null {
 	if (!value) return null
+	jsonQuotedSecretPattern.lastIndex = 0
+	assignmentSecretPattern.lastIndex = 0
+	bearerPattern.lastIndex = 0
 	const redacted = value
 		.replaceAll(bearerPattern, 'Bearer [redacted]')
+		.replaceAll(jsonQuotedSecretPattern, '"$1":"[redacted]"')
 		.replaceAll(assignmentSecretPattern, (match) => {
 			const separator = match.includes('=') ? '=' : ':'
 			const key = match.split(/[:=]/)[0]?.trim() ?? 'secret'

--- a/packages/worker/src/mcp-client/oauth-settle-error.ts
+++ b/packages/worker/src/mcp-client/oauth-settle-error.ts
@@ -128,6 +128,33 @@ export function inferMcpOAuthSettlePhase(input: {
 	}
 }
 
+const settleAttemptIdPattern =
+	/\bid\s+([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\b/i
+
+export function isFormattedMcpOAuthSettleMessage(
+	value: string | null | undefined,
+): boolean {
+	if (!value) return false
+	return (
+		/authorization completed/i.test(value) &&
+		/\bphase\s/.test(value) &&
+		/\bid\s/.test(value)
+	)
+}
+
+export function readAttemptIdFromSettleMessage(
+	value: string | null | undefined,
+): string | null {
+	if (!value) return null
+	return value.match(settleAttemptIdPattern)?.[1] ?? null
+}
+
+function rawMcpSettleError(
+	value: string | null | undefined,
+): string | null | undefined {
+	return isFormattedMcpOAuthSettleMessage(value) ? null : value
+}
+
 export function formatMcpOAuthSettleErrorMessage(input: {
 	state: McpServerConnectionState
 	authUrl: string | null
@@ -140,15 +167,16 @@ export function formatMcpOAuthSettleErrorMessage(input: {
 	authServer?: string | null
 	attemptId?: string | null
 }): string {
+	const error = rawMcpSettleError(input.error)
 	const phase =
 		input.phase ??
 		inferMcpOAuthSettlePhase({
 			state: input.state,
-			error: input.error,
+			error,
 		})
 	const details = formatMcpOAuthSettleDetails({
 		phase,
-		httpStatus: input.httpStatus ?? parseHttpStatusFromMcpError(input.error),
+		httpStatus: input.httpStatus ?? parseHttpStatusFromMcpError(error),
 		httpBodySnippet: sanitizeMcpErrorSnippet(input.httpBodySnippet),
 		mcpEndpoint: sanitizePublicUrl(input.mcpEndpoint),
 		resource: sanitizePublicUrl(input.resource),
@@ -158,7 +186,7 @@ export function formatMcpOAuthSettleErrorMessage(input: {
 	const lead = describeIncompleteMcpOAuthLead({
 		state: input.state,
 		authUrl: input.authUrl,
-		error: sanitizeMcpErrorSnippet(input.error, 240),
+		error: sanitizeMcpErrorSnippet(error, 240),
 		phase,
 	})
 	const reconnect = reconnectHint(input.state, input.authUrl)
@@ -208,23 +236,22 @@ export function buildMcpServerLastError(input: {
 	attemptId: string
 	at?: string
 }): McpServerLastError {
+	const error = rawMcpSettleError(input.error)
 	const phase =
 		input.phase ??
 		inferMcpOAuthSettlePhase({
 			state: input.state,
-			error: input.error,
+			error,
 		})
-	const httpStatus =
-		input.httpStatus ?? parseHttpStatusFromMcpError(input.error)
+	const httpStatus = input.httpStatus ?? parseHttpStatusFromMcpError(error)
 	const httpBodySnippet = sanitizeMcpErrorSnippet(
 		input.httpBodySnippet ??
-			(httpStatus && input.error && !input.httpBodySnippet
-				? input.error
-				: null),
+			(httpStatus && error && !input.httpBodySnippet ? error : null),
 	)
 	return {
 		message: formatMcpOAuthSettleErrorMessage({
 			...input,
+			error,
 			phase,
 			httpStatus,
 			httpBodySnippet,

--- a/packages/worker/src/mcp-client/oauth-settle-error.ts
+++ b/packages/worker/src/mcp-client/oauth-settle-error.ts
@@ -168,6 +168,33 @@ export function formatMcpOAuthSettleErrorMessage(input: {
 	return `${lead}.`
 }
 
+export function isIncompleteDiscoverState(
+	state: McpServerConnectionState,
+): boolean {
+	return state === 'connected' || state === 'discovering'
+}
+
+export function buildIncompleteDiscoverLastError(input: {
+	state: McpServerConnectionState
+	authUrl?: string | null
+	error?: string | null
+	mcpEndpoint?: string | null
+	resource?: string | null
+	authServer?: string | null
+	attemptId?: string | null
+}): McpServerLastError | null {
+	if (!isIncompleteDiscoverState(input.state)) return null
+	return buildMcpServerLastError({
+		state: input.state,
+		authUrl: input.authUrl ?? null,
+		error: input.error,
+		mcpEndpoint: input.mcpEndpoint,
+		resource: input.resource,
+		authServer: input.authServer,
+		attemptId: input.attemptId?.trim() || crypto.randomUUID(),
+	})
+}
+
 export function buildMcpServerLastError(input: {
 	state: McpServerConnectionState
 	authUrl: string | null

--- a/packages/worker/src/mcp-client/settings-repo.node.test.ts
+++ b/packages/worker/src/mcp-client/settings-repo.node.test.ts
@@ -1,0 +1,86 @@
+import { DatabaseSync } from 'node:sqlite'
+import { expect, test } from 'vitest'
+import { applyAllMigrations as applyRepositoryMigrations } from '#worker/test-support/apply-all-migrations.ts'
+import { createD1FromSqlite } from '#worker/test-support/create-d1-from-sqlite.ts'
+import { stringifyMcpServerLastError } from './oauth-settle-error.ts'
+import {
+	getMcpServerSettingRowById,
+	insertMcpServerSettingRow,
+	updateMcpServerSettingLastErrorRow,
+} from './settings-repo.ts'
+
+const migrationsDirectory = new URL('../../migrations/', import.meta.url)
+
+test('mcp_server_settings last_error persists sanitized JSON for the owning user only', async () => {
+	const sqlite = new DatabaseSync(':memory:')
+	applyRepositoryMigrations(sqlite, migrationsDirectory)
+	const db = createD1FromSqlite(sqlite)
+	await insertMcpServerSettingRow({
+		db,
+		row: {
+			id: 'server-1',
+			user_id: 'user-1',
+			name: 'posthog',
+			url: 'https://mcp.posthog.com/mcp',
+			enabled: true,
+			logo_key: null,
+			logo_content_type: null,
+			logo_source: null,
+			favicon_source_host: null,
+			usage_mode: 'any',
+			allowedPackageIds: [],
+			last_error: null,
+		},
+	})
+
+	const lastError = stringifyMcpServerLastError({
+		message:
+			"Authorization completed at the identity provider, but tool discovery didn't finish (phase server/discover, id attempt-1).",
+		phase: 'server/discover',
+		httpStatus: 403,
+		httpBodySnippet: 'insufficient_scope',
+		mcpEndpoint: 'https://mcp.posthog.com/mcp',
+		resource: 'https://mcp.posthog.com/',
+		authServer: 'https://auth.posthog.com/',
+		attemptId: 'attempt-1',
+		at: '2026-09-08T00:00:00.000Z',
+	})
+
+	expect(
+		await updateMcpServerSettingLastErrorRow({
+			db,
+			userId: 'user-2',
+			id: 'server-1',
+			lastError,
+		}),
+	).toBe(false)
+	expect(
+		await updateMcpServerSettingLastErrorRow({
+			db,
+			userId: 'user-1',
+			id: 'server-1',
+			lastError,
+		}),
+	).toBe(true)
+
+	const stored = await getMcpServerSettingRowById({
+		db,
+		userId: 'user-1',
+		id: 'server-1',
+	})
+	expect(stored?.last_error).toBe(lastError)
+	expect(stored?.last_error).not.toContain('access_token')
+
+	await updateMcpServerSettingLastErrorRow({
+		db,
+		userId: 'user-1',
+		id: 'server-1',
+		lastError: null,
+	})
+	const cleared = await getMcpServerSettingRowById({
+		db,
+		userId: 'user-1',
+		id: 'server-1',
+	})
+	expect(cleared?.last_error).toBeNull()
+})

--- a/packages/worker/src/mcp-client/settings-repo.ts
+++ b/packages/worker/src/mcp-client/settings-repo.ts
@@ -12,7 +12,7 @@ import {
 } from './usage-mode.ts'
 
 const selectColumns =
-	'id, user_id, name, url, enabled, created_at, updated_at, logo_key, logo_content_type, logo_source, favicon_source_host, usage_mode, allowed_packages_json'
+	'id, user_id, name, url, enabled, created_at, updated_at, logo_key, logo_content_type, logo_source, favicon_source_host, usage_mode, allowed_packages_json, last_error'
 
 export async function listMcpServerSettingRows(input: {
 	db: D1Database
@@ -165,6 +165,26 @@ export async function updateMcpServerSettingUsageRow(input: {
 	return (result.meta.changes ?? 0) > 0
 }
 
+export async function updateMcpServerSettingLastErrorRow(input: {
+	db: D1Database
+	userId: string
+	id: string
+	lastError: string | null
+	updatedAt?: string
+}): Promise<boolean> {
+	const now = new Date().toISOString()
+	const result = await input.db
+		.prepare(
+			`UPDATE mcp_server_settings
+			SET last_error = ?,
+				updated_at = ?
+			WHERE user_id = ? AND id = ?`,
+		)
+		.bind(input.lastError, input.updatedAt ?? now, input.userId, input.id)
+		.run()
+	return (result.meta.changes ?? 0) > 0
+}
+
 export async function deleteMcpServerSettingRow(input: {
 	db: D1Database
 	userId: string
@@ -210,5 +230,6 @@ function mapMcpServerSettingRow(
 				? null
 				: String(row['allowed_packages_json']),
 		),
+		last_error: row['last_error'] == null ? null : String(row['last_error']),
 	}
 }

--- a/packages/worker/src/mcp-client/settings-service.node.test.ts
+++ b/packages/worker/src/mcp-client/settings-service.node.test.ts
@@ -214,6 +214,50 @@ test('addMcpServer forwards bearer tokens as Authorization headers to the hub', 
 	expect(JSON.stringify(insertedRow)).not.toContain('secret-token')
 })
 
+test('addMcpServer persists lastError when discover times out still connected', async () => {
+	clearEnabledMcpServerRefsCacheForTests()
+	mockModule.getMcpServerSettingRowByName.mockResolvedValue(null)
+	mockModule.insertMcpServerSettingRow.mockResolvedValue(undefined)
+	mockModule.updateMcpServerSettingLastErrorRow.mockResolvedValue(true)
+	const lastError = {
+		message:
+			"Authorization completed at the identity provider, but tool discovery didn't finish (phase server/discover, mcp https://mcp.example.com/mcp, id attempt-add).",
+		phase: 'server/discover' as const,
+		httpStatus: null,
+		httpBodySnippet: null,
+		mcpEndpoint: 'https://mcp.example.com/mcp',
+		resource: null,
+		authServer: null,
+		attemptId: 'attempt-add',
+		at: '2026-09-08T00:00:00.000Z',
+	}
+	mockModule.hubClient.addServer.mockResolvedValue({
+		serverId: 'ignored',
+		state: 'connected',
+		authUrl: null,
+		error: lastError.message,
+		toolCount: 0,
+		lastError,
+	})
+
+	const result = await addMcpServer({
+		env: { APP_DB: {} } as Env,
+		userId: 'user-1',
+		name: 'posthog',
+		url: 'https://mcp.example.com/mcp',
+		baseUrl: 'https://kody.codes',
+	})
+
+	expect(result.connection.lastError?.phase).toBe('server/discover')
+	expect(result.setting.lastError).toContain("tool discovery didn't finish")
+	expect(mockModule.updateMcpServerSettingLastErrorRow).toHaveBeenCalledWith(
+		expect.objectContaining({
+			userId: 'user-1',
+			lastError: expect.stringContaining('"phase":"server/discover"'),
+		}),
+	)
+})
+
 test('MCP server usage lock hides the server from execute and grants a package', async () => {
 	clearEnabledMcpServerRefsCacheForTests()
 	const env = { APP_DB: {} } as Env

--- a/packages/worker/src/mcp-client/settings-service.node.test.ts
+++ b/packages/worker/src/mcp-client/settings-service.node.test.ts
@@ -9,6 +9,7 @@ const mockModule = vi.hoisted(() => ({
 	deleteMcpServerSettingRow: vi.fn(),
 	listMcpServerSettingRows: vi.fn(),
 	updateMcpServerSettingUsageRow: vi.fn(),
+	updateMcpServerSettingLastErrorRow: vi.fn(),
 	getSavedPackageById: vi.fn(),
 	hubClient: {
 		addServer: vi.fn(),
@@ -33,6 +34,8 @@ vi.mock('./settings-repo.ts', () => ({
 		mockModule.listMcpServerSettingRows(...args),
 	updateMcpServerSettingUsageRow: (...args: Array<unknown>) =>
 		mockModule.updateMcpServerSettingUsageRow(...args),
+	updateMcpServerSettingLastErrorRow: (...args: Array<unknown>) =>
+		mockModule.updateMcpServerSettingLastErrorRow(...args),
 }))
 
 vi.mock('#worker/package-registry/repo.ts', () => ({
@@ -71,6 +74,7 @@ function createSettingRow(input: { id: string; enabled?: boolean }) {
 		favicon_source_host: null,
 		usage_mode: 'any' as const,
 		allowedPackageIds: [],
+		last_error: null,
 	}
 }
 

--- a/packages/worker/src/mcp-client/settings-service.ts
+++ b/packages/worker/src/mcp-client/settings-service.ts
@@ -274,6 +274,15 @@ export async function addMcpServer(input: {
 		throw error
 	}
 	invalidateEnabledMcpServerRefsCache({ userId: input.userId })
+	if (connection.lastError) {
+		await setMcpServerLastError({
+			env: input.env,
+			userId: input.userId,
+			id: row.id,
+			lastError: connection.lastError,
+		})
+		row.last_error = stringifyMcpServerLastError(connection.lastError)
+	}
 	await scheduleMcpServerFaviconFill({
 		db: input.env.APP_DB,
 		env: input.env,

--- a/packages/worker/src/mcp-client/settings-service.ts
+++ b/packages/worker/src/mcp-client/settings-service.ts
@@ -274,6 +274,9 @@ export async function addMcpServer(input: {
 		throw error
 	}
 	invalidateEnabledMcpServerRefsCache({ userId: input.userId })
+	const lastErrorJson = connection.lastError
+		? stringifyMcpServerLastError(connection.lastError)
+		: null
 	if (connection.lastError) {
 		await setMcpServerLastError({
 			env: input.env,
@@ -281,7 +284,6 @@ export async function addMcpServer(input: {
 			id: row.id,
 			lastError: connection.lastError,
 		})
-		row.last_error = stringifyMcpServerLastError(connection.lastError)
 	}
 	await scheduleMcpServerFaviconFill({
 		db: input.env.APP_DB,
@@ -291,7 +293,10 @@ export async function addMcpServer(input: {
 		waitUntil: input.waitUntil,
 	})
 	return {
-		setting: toMetadata(row),
+		setting: toMetadata({
+			...row,
+			last_error: lastErrorJson,
+		}),
 		connection,
 	}
 }

--- a/packages/worker/src/mcp-client/settings-service.ts
+++ b/packages/worker/src/mcp-client/settings-service.ts
@@ -19,6 +19,11 @@ import { createMcpClientHubClient } from './hub-client.ts'
 import { scheduleMcpServerFaviconFill } from './mcp-server-favicon.ts'
 import { deleteMcpServerLogoAsset } from './mcp-server-logo.ts'
 import {
+	mcpServerLastErrorDisplayMessage,
+	parseStoredMcpServerLastError,
+	stringifyMcpServerLastError,
+} from './oauth-settle-error.ts'
+import {
 	filterEnabledMcpServerRefsForCaller,
 	type EnabledMcpServerRef,
 } from './package-access.ts'
@@ -29,6 +34,7 @@ import {
 	insertMcpServerSettingRow,
 	listEnabledMcpServerSettingRows,
 	listMcpServerSettingRows,
+	updateMcpServerSettingLastErrorRow,
 	updateMcpServerSettingRow,
 	updateMcpServerSettingUsageRow,
 } from './settings-repo.ts'
@@ -36,7 +42,10 @@ import {
 	type McpServerSettingMetadata,
 	type McpServerSettingRow,
 } from './settings-types.ts'
-import { type McpServerConnectResult } from './types.ts'
+import {
+	type McpServerConnectResult,
+	type McpServerLastError,
+} from './types.ts'
 import {
 	normalizeMcpServerUsageMode,
 	type McpServerUsageMode,
@@ -87,6 +96,9 @@ function toMetadata(row: McpServerSettingRow): McpServerSettingMetadata {
 		faviconSourceHost: row.favicon_source_host,
 		usageMode: row.usage_mode,
 		allowedPackageIds: [...row.allowedPackageIds],
+		lastError: mcpServerLastErrorDisplayMessage(
+			parseStoredMcpServerLastError(row.last_error),
+		),
 	}
 }
 
@@ -232,6 +244,7 @@ export async function addMcpServer(input: {
 		favicon_source_host: null,
 		usage_mode: 'any',
 		allowedPackageIds: [],
+		last_error: null,
 	} satisfies McpServerSettingRow
 
 	const hub = createMcpClientHubClient({
@@ -433,5 +446,19 @@ export async function lockMcpServerToPackage(input: {
 		id: input.id,
 		usageMode: 'packages',
 		allowedPackageIds,
+	})
+}
+
+export async function setMcpServerLastError(input: {
+	env: Pick<Env, 'APP_DB'>
+	userId: string
+	id: string
+	lastError: McpServerLastError | null
+}): Promise<boolean> {
+	return updateMcpServerSettingLastErrorRow({
+		db: input.env.APP_DB,
+		userId: input.userId,
+		id: input.id,
+		lastError: stringifyMcpServerLastError(input.lastError),
 	})
 }

--- a/packages/worker/src/mcp-client/settings-types.ts
+++ b/packages/worker/src/mcp-client/settings-types.ts
@@ -16,6 +16,7 @@ export type McpServerSettingRow = {
 	favicon_source_host: string | null
 	usage_mode: McpServerUsageMode
 	allowedPackageIds: Array<string>
+	last_error: string | null
 }
 
 export type McpServerSettingMetadata = {
@@ -31,4 +32,5 @@ export type McpServerSettingMetadata = {
 	faviconSourceHost: string | null
 	usageMode: McpServerUsageMode
 	allowedPackageIds: Array<string>
+	lastError: string | null
 }

--- a/packages/worker/src/mcp-client/types.ts
+++ b/packages/worker/src/mcp-client/types.ts
@@ -73,6 +73,7 @@ export type McpServerConnectResult = {
 	authUrl: string | null
 	error: string | null
 	toolCount: number
+	lastError?: McpServerLastError | null
 }
 
 export type McpServerOAuthCallbackOutcome = {

--- a/packages/worker/src/mcp-client/types.ts
+++ b/packages/worker/src/mcp-client/types.ts
@@ -12,6 +12,29 @@ export type McpServerConnectionState =
 	| 'disconnected'
 
 /**
+ * Observable post-IdP settle stages. Names match handshake / discovery
+ * methods this repo already uses.
+ */
+export type McpOAuthSettlePhase =
+	| 'token exchange'
+	| 'resource metadata'
+	| 'mcp initialize'
+	| 'server/discover'
+	| 'tools/list'
+
+export type McpServerLastError = {
+	message: string
+	phase: McpOAuthSettlePhase | null
+	httpStatus: number | null
+	httpBodySnippet: string | null
+	mcpEndpoint: string | null
+	resource: string | null
+	authServer: string | null
+	attemptId: string
+	at: string
+}
+
+/**
  * Tool metadata from a connected MCP server.
  *
  * Schemas use codemode's JSON Schema shape (JSONSchema7) so they line up with
@@ -58,4 +81,5 @@ export type McpServerOAuthCallbackOutcome = {
 	authError: string | null
 	serverName: string | null
 	authorizationNeeded: boolean
+	lastError: McpServerLastError | null
 }

--- a/packages/worker/src/mcp/capabilities/mcp-servers/mcp-server-list.ts
+++ b/packages/worker/src/mcp/capabilities/mcp-servers/mcp-server-list.ts
@@ -28,7 +28,7 @@ export const mcpServerListCapability = defineDomainCapability(
 	{
 		name: 'mcpServerList',
 		description:
-			"List the signed-in user's saved MCP servers with live connection status, pending OAuth authUrls, discovered tool names, and package usage (any context vs locked to listed packages).",
+			"List the signed-in user's saved MCP servers with live connection status, pending OAuth authUrls, discovered tool names, durable lastError when post-IdP settle did not reach ready, and package usage (any context vs locked to listed packages).",
 		keywords: [
 			'mcp',
 			'server',

--- a/packages/worker/src/mcp/capabilities/mcp-servers/shared.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/mcp-servers/shared.node.test.ts
@@ -33,6 +33,7 @@ function setting(
 		faviconSourceHost: null,
 		usageMode: 'any',
 		allowedPackageIds: [],
+		lastError: null,
 		...overrides,
 	}
 }
@@ -94,4 +95,40 @@ test('buildMcpServerStatusView defaults missing usage to any context', () => {
 	expect(view.usageMode).toBe('any')
 	expect(view.allowedPackageIds).toEqual([])
 	expect(view.connected).toBe(false)
+})
+
+test('buildMcpServerStatusView surfaces durable lastError when live connection error is missing', () => {
+	const lastError =
+		"Authorization completed at the identity provider, but tool discovery didn't finish (phase server/discover, id attempt-1)."
+	const hung = buildMcpServerStatusView({
+		setting: setting({ lastError }),
+		snapshot: {
+			serverId: 'server-1',
+			name: 'ha',
+			url: 'https://example.com/mcp',
+			state: 'connected',
+			authUrl: null,
+			error: null,
+			instructions: null,
+			tools: [],
+		},
+	})
+	expect(hung.connected).toBe(false)
+	expect(hung.error).toBe(lastError)
+
+	const ready = buildMcpServerStatusView({
+		setting: setting({ lastError }),
+		snapshot: {
+			serverId: 'server-1',
+			name: 'ha',
+			url: 'https://example.com/mcp',
+			state: 'ready',
+			authUrl: null,
+			error: null,
+			instructions: null,
+			tools: [{ name: 'ping', inputSchema: { type: 'object' } }],
+		},
+	})
+	expect(ready.connected).toBe(true)
+	expect(ready.error).toBeNull()
 })

--- a/packages/worker/src/mcp/capabilities/mcp-servers/shared.ts
+++ b/packages/worker/src/mcp/capabilities/mcp-servers/shared.ts
@@ -38,7 +38,9 @@ export function buildMcpServerStatusView(input: {
 }): McpServerStatusView {
 	const { setting, snapshot } = input
 	const connected = snapshot?.state === 'ready'
-	const rawError = snapshot?.error ?? null
+	const rawError = connected
+		? null
+		: (snapshot?.error ?? setting.lastError ?? null)
 	const error =
 		rawError && input.oauthCallbackUrl && input.oauthClientOrigin
 			? enrichMcpOAuthProviderError(rawError, {

--- a/tools/migration-ledger.json
+++ b/tools/migration-ledger.json
@@ -215,6 +215,10 @@
 		{
 			"filename": "0053-user-tips-email-opt-outs.sql",
 			"sha256": "47c028697bc21976963cd1a0bf5825d3d48b7ba2640f93c7192e31d192aa2ea2"
+		},
+		{
+			"filename": "0054-mcp-server-last-error.sql",
+			"sha256": "6d160921b0689856a618233616ebc0fbc9955966cb1149ff1c611568c6dad5de"
 		}
 	]
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

When a remote MCP server finishes identity-provider OAuth or bearer connect but Kody never reaches `ready`, the account UI and ops should get a sanitized, durable reason they can act on — without Network-tab archaeology or leaked tokens.

## Why

Adam (PostHog MCP) completed IdP OAuth, then Status stuck on “Discovering tools” with a null live error. Bearer-token connects to the same host can hang the same way. Bare `https://mcp.posthog.com` 302s to docs; the documented resource is `https://mcp.posthog.com/mcp`. Related: #1462, #1464.

## Summary

- Incomplete post-IdP settle errors include an observable phase (`token exchange`, `resource metadata`, `mcp initialize`, `server/discover`, `tools/list`), HTTP status + short body snippet when available, MCP / resource / auth-server URLs with query secrets stripped, and an attempt id for log grep.
- The main callback path runs `discoverIfConnected` after establish when the transport is `connected` (production main is missing this).
- After `discoverIfConnected` times out still `connected` or `discovering`, add, reconnect, refresh, and OAuth settle treat that as failed and write durable `last_error` (`server/discover` or `tools/list`, attempt id, MCP URL). Status cannot stay silent “Discovering tools” with a null error.
- Structured `last_error` JSON is stored on `mcp_server_settings` and shown under Status. Ready connections hide and clear it.
- Status wording: in-flight `connected`/`discovering` stays “Discovering tools”; with a lastError it becomes “Tool discovery didn't finish”.
- Used-state / Back replay no longer reports `auth=success` or clears `last_error`.
- Quoted JSON credential fields are redacted before `last_error` is stored or shown.
- Bare `https://mcp.posthog.com` / `https://mcp.posthog.com/` normalize to `https://mcp.posthog.com/mcp` on add.
- Discover lastError is formatted once: OAuth settle does not wrap the stamped message again, finalize reuses the same attempt id, and a later add/reconnect/refresh restamps instead of keeping the first reason.

## Testing

- Focused node tests for the Adam-like case, used-state replay, discover-timeout lastError on add/reconnect/refresh, PostHog origin rewrite, quoted JSON secret redaction, D1 persist, Status labels, callback persist/clear, single-wrap settle messages, and refresh restamp without clearing `connectionError`.
- `npm run typecheck` and `npm run migrations:check` on commit.
- `test:node` (2884) and `test:workers` (341) on the wrap-fix push.
- Preview `kody-pr-2157` as `me@kentcdodds.com`: `/account/mcp-servers` lists `settle-error-probe` as Connection failed; add form shows the PostHog `/mcp` hint.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `27f0e6c6` · **Head:** `7e968ef4`

**Classification:** extends — OAuth callback settle, D1 `last_error`, discover-timeout failure, and account Status contract change. No new primitives.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `mcp-client-servers` | assistant | extends — discover-after-establish, discover-timeout lastError on add/reconnect/refresh/OAuth, durable lastError, PostHog origin rewrite, single-wrap settle message |
| `app-ui` | surfaces | extends — Status label, lastError under Status, add-form endpoint hint |
| `d1-app-db` | storage | extends — `mcp_server_settings.last_error` |

### Change flow

IdP callback settle or add/reconnect/refresh either reaches ready or writes a sanitized lastError when discover times out.

```mermaid
sequenceDiagram
	actor User
	participant appUi as app-ui
	participant mcpClientServers as mcp-client-servers
	participant d1AppDb as d1-app-db
	User->>appUi: IdP redirect, add, reconnect, or refresh
	appUi->>mcpClientServers: handleOAuthCallback or discoverIfConnected
	alt settle reaches ready
		mcpClientServers->>d1AppDb: clear last_error
		mcpClientServers-->>appUi: auth=success or ready snapshot
	else discover times out still connected or discovering
		mcpClientServers->>d1AppDb: write last_error with phase attempt id MCP URL
		mcpClientServers-->>appUi: Status Tool discovery did not finish
	else used-state replay while still in flight
		mcpClientServers->>mcpClientServers: keep tokens, retry discover if connected
		mcpClientServers-->>appUi: redirect auth=error, do not clear last_error
	end
```

### Before / after

| Surface | Before | After |
| --- | --- | --- |
| Banner | still `"connected"` | authorized at IdP, but tool discovery didn't finish (phase…, HTTP…, id…) |
| Status | Discovering tools with no durable reason | Tool discovery didn't finish + lastError under Status |
| Discover timeout | silent Discovering tools | lastError `server/discover` or `tools/list` on add, reconnect, refresh, OAuth |
| PostHog origin | `https://mcp.posthog.com` 302s to docs | rewritten to `https://mcp.posthog.com/mcp` |
| D1 | no lastError | `mcp_server_settings.last_error` JSON |
| Used-state replay | auth=success and lastError cleared | lastError kept until ready |
| Settle message | discover stamp wrapped again on OAuth outcome | one lead, one phase, one attempt id |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f1561ba6-2a6f-416d-ada6-1e6103281fee?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f1561ba6-2a6f-416d-ada6-1e6103281fee&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MCP server OAuth and tool-discovery failures now persist and remain visible after reloads.
  * Account pages show “Tool discovery didn’t finish” with sanitized error details and reconnect guidance.
  * Successful reconnections clear stored errors, while OAuth recovery retries discovery until the server is ready.
  * PostHog’s MCP endpoint is recognized automatically when its site root is entered.
  * MCP server forms now clarify which endpoint URL to enter.

* **Documentation**
  * Added troubleshooting guidance for incomplete tool discovery and reconnecting servers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->