### PR TITLE
Move Join the Discord below the onboarding wizard

### DIFF
--- a/packages/worker/client/routes/onboarding.tsx
+++ b/packages/worker/client/routes/onboarding.tsx
@@ -466,20 +466,6 @@ export function OnboardingRoute(handle: Handle) {
 					<h1 data-rise style={{ '--rise': '0' }}>
 						Get started with <em>Kody</em>
 					</h1>
-					<p
-						data-rise
-						style={{ '--rise': '1' }}
-						mix={css(discordInviteWrapCss)}
-					>
-						<a
-							href={routes.discord.href()}
-							mix={css(discordInviteLinkCss)}
-							data-testid="onboarding-join-discord"
-						>
-							<ProviderIcon providerId="discord" size="1.1em" />
-							Join the Discord
-						</a>
-					</p>
 				</header>
 
 				{message ? (
@@ -549,6 +535,17 @@ export function OnboardingRoute(handle: Handle) {
 							: null}
 					</>
 				) : null}
+
+				<p data-rise style={{ '--rise': '1' }} mix={css(discordInviteWrapCss)}>
+					<a
+						href={routes.discord.href()}
+						mix={css(discordInviteLinkCss)}
+						data-testid="onboarding-join-discord"
+					>
+						<ProviderIcon providerId="discord" size="1.1em" />
+						Join the Discord
+					</a>
+				</p>
 			</section>
 		)
 	}
@@ -593,12 +590,6 @@ const onboardHeadCss = {
 		fontStyle: 'normal',
 		color: colors.primaryText,
 	},
-	'& > p': {
-		margin: '0.9rem 0 0',
-		color: colors.textMuted,
-		fontSize: '1.08rem',
-		maxWidth: '52ch',
-	},
 }
 
 const errorMessageCss = {
@@ -608,7 +599,7 @@ const errorMessageCss = {
 
 /* Nested surfaces step down to the page ground so they read as wells. */
 const discordInviteWrapCss = {
-	margin: '1rem 0 0',
+	margin: 'clamp(2rem, 4.5vw, 2.8rem) 0 0',
 }
 
 const discordInviteLinkCss = {

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -571,6 +571,9 @@ test('SSR HTML routes render page content and embedded loader data', async () =>
 	expect(anonymousOnboardingHtml.indexOf('onboarding-steps-nav')).toBeLessThan(
 		anonymousOnboardingHtml.indexOf('onboarding-agent-picker'),
 	)
+	expect(
+		anonymousOnboardingHtml.indexOf('onboarding-agent-picker'),
+	).toBeLessThan(anonymousOnboardingHtml.indexOf('onboarding-join-discord'))
 
 	const anonymousAccountResponse = await runHtmlHandler(
 		createAccountHandler(env),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Put the onboarding Discord invite below the step wizard so the first thing after the title is the wizard itself.

## Why

The invite sat between “Get started with Kody” and the stepper, so it competed with the steps before you even started them.

## Summary

- Move “Join the Discord” out of the onboarding header and render it after the wizard.
- Drop unused header paragraph styles that only existed for that invite.
- Assert SSR HTML order: stepper, then agent picker, then the Discord invite.

## Testing

- `npm run test:push` (node 2875, workers 341)
- SSR onboarding HTML order assertion in `ssr-render.node.test.ts`

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `27f0e6c6` · **Head:** `6c3dd807`

**Classification:** composes — no primitives added or changed; this PR reorders existing onboarding markup.

### Primitives touched

| Primitive | Group    | Impact   |
| --------- | -------- | -------- |
| `app-ui`  | surfaces | composes |

### Change flow

Anonymous `/onboarding/step-1` still renders the same heading, stepper, and Discord invite. The invite now comes after the wizard in the HTML instead of between the title and the stepper.

```mermaid
sequenceDiagram
	actor User
	participant appUi as app-ui
	User->>appUi: GET /onboarding/step-1
	appUi-->>User: heading, then wizard, then Join the Discord
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a5f488d8-35eb-4633-b2c9-d1b8ff7e25cd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a5f488d8-35eb-4633-b2c9-d1b8ff7e25cd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The Discord invitation is now visible throughout the onboarding flow, regardless of status.
  - Improved spacing separates the invitation from the onboarding content.

- **Bug Fixes**
  - Corrected the rendered onboarding element order to ensure the agent picker appears before the Discord invitation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->