### PR TITLE
Retry legacy MCP handshake when modern discovery stalls

### DIFF
--- a/docs/contributing/architecture/mcp-client-servers.md
+++ b/docs/contributing/architecture/mcp-client-servers.md
@@ -59,11 +59,11 @@ the `/mcp` endpoint (where Kody is the server) and complements MCP servers
   modern-only server (`packages/worker/src/mcp-client/restore.ts`,
   `packages/worker/src/mcp-client/reconnect.ts`). A successful catalog-timeout
   fallback is remembered per server in hub DO storage so the next restore keeps
-  `legacy`; user reconnect forgets that mark and probes `auto` again.
-  Header-mismatch, unauthenticated, and `-32022` UnsupportedProtocolVersion
-  probe outcomes are not a 2025 verdict; after OAuth the hub retries
-  `server/discover` with the token, then the same catalog-timeout legacy retry
-  if discovery still does not finish.
+  `legacy`; user reconnect or replacing the server via `addServer` forgets that
+  mark and probes `auto` again. Header-mismatch, unauthenticated, and `-32022`
+  UnsupportedProtocolVersion probe outcomes are not a 2025 verdict; after OAuth
+  the hub retries `server/discover` with the token, then the same
+  catalog-timeout legacy retry if discovery still does not finish.
 
 ## OAuth flow
 

--- a/docs/contributing/architecture/mcp-client-servers.md
+++ b/docs/contributing/architecture/mcp-client-servers.md
@@ -58,7 +58,8 @@ the `/mcp` endpoint (where Kody is the server) and complements MCP servers
   `legacy` mode cannot skip the modern probe or DELETE a session against a
   modern-only server (`packages/worker/src/mcp-client/restore.ts`,
   `packages/worker/src/mcp-client/reconnect.ts`). A successful catalog-timeout
-  fallback is remembered per server in hub DO storage so the next restore keeps
+  fallback is remembered per server in hub DO storage when that retry reaches
+  `ready` or parks on OAuth `authenticating`, so the next restore keeps
   `legacy`; user reconnect or replacing the server via `addServer` forgets that
   mark and probes `auto` again. Header-mismatch, unauthenticated, and `-32022`
   UnsupportedProtocolVersion probe outcomes are not a 2025 verdict; after OAuth

--- a/docs/contributing/architecture/mcp-client-servers.md
+++ b/docs/contributing/architecture/mcp-client-servers.md
@@ -95,26 +95,29 @@ the `/mcp` endpoint (where Kody is the server) and complements MCP servers
    observable phase (`token exchange`, `resource metadata`, `mcp initialize`,
    `server/discover`, or `tools/list`), HTTP status and a short body snippet
    when present, the MCP / resource / authorization-server URLs without query
-   secrets, and an attempt id for log grep. The same payload is stored on
-   `mcp_server_settings.last_error` and shown under Status. The account UI maps
-   `connected` / `discovering` to "Discovering tools" only while that work is
-   still in flight; when `last_error` is present it says "Tool discovery didn't
-   finish" instead of echoing the raw `"connected"` state. After
-   `discoverIfConnected` times out still on `connected` or `discovering` (add,
-   reconnect, refresh, or OAuth settle), the hub first retries the 2025
-   initialize handshake on that same server. If catalog still does not finish,
-   it writes the same durable `last_error` (`tools/list` after a catalog
-   attempt, otherwise `server/discover`, plus attempt id and MCP URL) so Status
-   cannot stay silent. Used or missing OAuth `state` on the callback recover
-   without surfacing an internal state error: the hub restarts authorization
-   when needed. A Back/replay while the connection is still `connected`,
-   `discovering`, or `connecting` keeps the existing tokens and retries
-   discovery when the transport is `connected`, but it does not report
-   `auth=success` or clear `last_error` until the connection is `ready`. Origin
-   and redirect-URI rejection messages are enriched with Kody's
-   `oauthClientOrigin` and `oauthCallbackUrl`. Reconnect uses the same recovery
-   path (invalidate unusable tokens and request a fresh authorization URL). The
-   account page offers Reconnect when automatic recovery cannot finish.
+   secrets, and an attempt id for log grep (`mcp discover timeout incomplete`,
+   `mcp discover retrying legacy handshake`,
+   `mcp oauth callback settle incomplete`). Connection episodes do not store
+   that id. The same payload is stored on `mcp_server_settings.last_error` and
+   shown under Status. The account UI maps `connected` / `discovering` to
+   "Discovering tools" only while that work is still in flight; when
+   `last_error` is present it says "Tool discovery didn't finish" instead of
+   echoing the raw `"connected"` state. After `discoverIfConnected` times out
+   still on `connected` or `discovering` (add, reconnect, refresh, or OAuth
+   settle), the hub first retries the 2025 initialize handshake on that same
+   server. If catalog still does not finish, it writes the same durable
+   `last_error` (`tools/list` after a catalog attempt, otherwise
+   `server/discover`, plus attempt id and MCP URL) so Status cannot stay silent.
+   Used or missing OAuth `state` on the callback recover without surfacing an
+   internal state error: the hub restarts authorization when needed. A
+   Back/replay while the connection is still `connected`, `discovering`, or
+   `connecting` keeps the existing tokens and retries discovery when the
+   transport is `connected`, but it does not report `auth=success` or clear
+   `last_error` until the connection is `ready`. Origin and redirect-URI
+   rejection messages are enriched with Kody's `oauthClientOrigin` and
+   `oauthCallbackUrl`. Reconnect uses the same recovery path (invalidate
+   unusable tokens and request a fresh authorization URL). The account page
+   offers Reconnect when automatic recovery cannot finish.
 6. The route redirects to `/account/mcp-servers/:serverId?auth=success|error`
    when the callback resolves to a server (including failures), or
    `/account/mcp-servers?auth=error` when it does not, for user feedback. Tokens

--- a/docs/contributing/architecture/mcp-client-servers.md
+++ b/docs/contributing/architecture/mcp-client-servers.md
@@ -48,17 +48,22 @@ the `/mcp` endpoint (where Kody is the server) and complements MCP servers
   `transport.requestInit.headers` so outbound fetches send them
   (`packages/worker/src/mcp-client/transport-headers.ts`); explicit
   `requestInit.headers` still win. Outbound connections prefer MCP `2026-07-28`
-  (`server/discover`) and fall back to the 2025 `initialize` handshake only when
-  the remote server is actually 2025-era. Restore and reconnect drop persisted
-  2025 `sessionId` / `protocolVersion` / `discoverResult` values and rewrite
-  stored `client.versionNegotiation` to `{ mode: 'auto' }` so a stored 2025
-  session or a persisted `legacy` negotiation mode cannot skip the modern probe
-  or DELETE a session against a modern-only server
-  (`packages/worker/src/mcp-client/restore.ts`,
-  `packages/worker/src/mcp-client/reconnect.ts`). Header-mismatch,
-  unauthenticated, and `-32022` UnsupportedProtocolVersion probe outcomes are
-  not a 2025 verdict; after OAuth the hub retries `server/discover` with the
-  token.
+  (`server/discover`) and fall back to the 2025 `initialize` handshake when the
+  remote server is actually 2025-era **or** when modern negotiation reaches
+  `connected` / `discovering` but catalog never becomes `ready` (same-server
+  retry with `versionNegotiation: { mode: 'legacy' }`, no hostname allowlist).
+  Restore and reconnect drop persisted 2025 `sessionId` / `protocolVersion` /
+  `discoverResult` values and rewrite stored `client.versionNegotiation` to
+  `{ mode: 'auto' }` so a stored 2025 session or an accidental persisted
+  `legacy` mode cannot skip the modern probe or DELETE a session against a
+  modern-only server (`packages/worker/src/mcp-client/restore.ts`,
+  `packages/worker/src/mcp-client/reconnect.ts`). A successful catalog-timeout
+  fallback is remembered per server in hub DO storage so the next restore keeps
+  `legacy`; user reconnect forgets that mark and probes `auto` again.
+  Header-mismatch, unauthenticated, and `-32022` UnsupportedProtocolVersion
+  probe outcomes are not a 2025 verdict; after OAuth the hub retries
+  `server/discover` with the token, then the same catalog-timeout legacy retry
+  if discovery still does not finish.
 
 ## OAuth flow
 
@@ -96,19 +101,20 @@ the `/mcp` endpoint (where Kody is the server) and complements MCP servers
    still in flight; when `last_error` is present it says "Tool discovery didn't
    finish" instead of echoing the raw `"connected"` state. After
    `discoverIfConnected` times out still on `connected` or `discovering` (add,
-   reconnect, refresh, or OAuth settle), the hub treats that as a failed
-   discover and writes the same durable `last_error` (`server/discover` or
-   `tools/list`, attempt id, MCP URL) so Status cannot stay silent. Used or
-   missing OAuth `state` on the callback recover without surfacing an internal
-   state error: the hub restarts authorization when needed. A Back/replay while
-   the connection is still `connected`, `discovering`, or `connecting` keeps the
-   existing tokens and retries discovery when the transport is `connected`, but
-   it does not report `auth=success` or clear `last_error` until the connection
-   is `ready`. Origin and redirect-URI rejection messages are enriched with
-   Kody's `oauthClientOrigin` and `oauthCallbackUrl`. Reconnect uses the same
-   recovery path (invalidate unusable tokens and request a fresh authorization
-   URL). The account page offers Reconnect when automatic recovery cannot
-   finish.
+   reconnect, refresh, or OAuth settle), the hub first retries the 2025
+   initialize handshake on that same server. If catalog still does not finish,
+   it writes the same durable `last_error` (`tools/list` after a catalog
+   attempt, otherwise `server/discover`, plus attempt id and MCP URL) so Status
+   cannot stay silent. Used or missing OAuth `state` on the callback recover
+   without surfacing an internal state error: the hub restarts authorization
+   when needed. A Back/replay while the connection is still `connected`,
+   `discovering`, or `connecting` keeps the existing tokens and retries
+   discovery when the transport is `connected`, but it does not report
+   `auth=success` or clear `last_error` until the connection is `ready`. Origin
+   and redirect-URI rejection messages are enriched with Kody's
+   `oauthClientOrigin` and `oauthCallbackUrl`. Reconnect uses the same recovery
+   path (invalidate unusable tokens and request a fresh authorization URL). The
+   account page offers Reconnect when automatic recovery cannot finish.
 6. The route redirects to `/account/mcp-servers/:serverId?auth=success|error`
    when the callback resolves to a server (including failures), or
    `/account/mcp-servers?auth=error` when it does not, for user feedback. Tokens

--- a/docs/use/mcp-client-servers.md
+++ b/docs/use/mcp-client-servers.md
@@ -29,8 +29,9 @@ This is the inverse of [connecting your agent to Kody](./connect-your-agent.md)
    approved access but tools never appear, Status on
    `/account/mcp-servers/:serverId` shows the last sanitized settle error
    (phase, HTTP status, URLs, and an attempt id). The same durable error is
-   written when add, reconnect, or refresh times out still discovering tools.
-   Reconnect from that page.
+   written when add, reconnect, or refresh times out still discovering tools
+   after Kody has also retried the older MCP handshake. Reconnect from that
+   page.
 
 If a server is authenticating, failed, or disconnected, [Waiting](./waiting.md)
 lists it and links to `/account/mcp-servers/:id`. `waitingSummary` returns the

--- a/packages/worker/src/mcp-client/hub-oauth-recovery.node.test.ts
+++ b/packages/worker/src/mcp-client/hub-oauth-recovery.node.test.ts
@@ -913,6 +913,43 @@ test('legacy retry that fails to connect keeps the catalog lastError', async () 
 	expect(added.error).toContain("tool discovery didn't finish")
 	expect(added.error).toContain('phase tools/list')
 	expect(manager.mcpConnections['server-1']?.connectionError).toBe(added.error)
+	expect(consoleWarn).toHaveBeenCalledWith(
+		'mcp discover retrying legacy handshake',
+		expect.objectContaining({
+			serverId: 'server-1',
+			attemptId: added.lastError?.attemptId,
+		}),
+	)
+})
+
+test('a later failed add does not keep a stale catalog lastError', async () => {
+	consoleWarn.mockImplementation(() => {})
+	const { state } = createDurableObjectState()
+	const hub = new McpClientHub(state, {} as Env)
+	const manager = mockModule.manager
+	if (!manager) throw new Error('Fake manager was not constructed.')
+	manager.connectBehaviors = ['connected', 'disconnected']
+	manager.connectBehavior = 'disconnected'
+
+	const timedOut = await hub.addServer({
+		serverId: 'server-1',
+		name: 'analytics',
+		url: 'https://analytics.example/mcp',
+		callbackUrl: 'https://kody.codes/account/mcp-servers/oauth/callback',
+	})
+	expect(timedOut.lastError?.phase).toBe('tools/list')
+
+	manager.connectBehaviors = []
+	manager.connectBehavior = 'disconnected'
+	const failed = await hub.addServer({
+		serverId: 'server-1',
+		name: 'analytics',
+		url: 'https://analytics.example/mcp',
+		callbackUrl: 'https://kody.codes/account/mcp-servers/oauth/callback',
+	})
+	expect(failed.state).toBe('disconnected')
+	expect(failed.lastError).toBeNull()
+	expect(failed.error).toBe('upstream closed')
 })
 
 test('healthy auto catalog stays on auto; modern-connect catalog timeout falls back to legacy and can reach ready', async () => {
@@ -962,10 +999,20 @@ test('healthy auto catalog stays on auto; modern-connect catalog timeout falls b
 		versionNegotiation: { mode: 'legacy' },
 	})
 	expect(values.get('mcp-legacy-handshake/server-1')).toBe('catalog-timeout')
-	expect(consoleWarn).toHaveBeenCalledWith(
-		'mcp discover retrying legacy handshake',
+	const timeoutCall = consoleWarn.mock.calls.find(
+		(call) => call[0] === 'mcp discover timeout incomplete',
+	)
+	const retryCall = consoleWarn.mock.calls.find(
+		(call) => call[0] === 'mcp discover retrying legacy handshake',
+	)
+	const timeoutAttemptId = (
+		timeoutCall?.[1] as { attemptId?: string } | undefined
+	)?.attemptId
+	expect(timeoutAttemptId).toBeTruthy()
+	expect(retryCall?.[1]).toEqual(
 		expect.objectContaining({
 			serverId: 'server-1',
+			attemptId: timeoutAttemptId,
 			mcpEndpoint: 'https://analytics.example/mcp',
 		}),
 	)

--- a/packages/worker/src/mcp-client/hub-oauth-recovery.node.test.ts
+++ b/packages/worker/src/mcp-client/hub-oauth-recovery.node.test.ts
@@ -1091,3 +1091,44 @@ test('replacing a server forgets the catalog-timeout legacy mark and probes auto
 	})
 	expect(values.has('mcp-legacy-handshake/server-1')).toBe(false)
 })
+
+test('legacy fallback that parks on OAuth remembers the mark and keeps it after ready', async () => {
+	consoleWarn.mockImplementation(() => {})
+	const { state, values } = createDurableObjectState()
+	const hub = new McpClientHub(state, {} as Env)
+	const manager = mockModule.manager
+	if (!manager) throw new Error('Fake manager was not constructed.')
+	manager.connectBehaviors = ['connected', 'oauth']
+	manager.connectBehavior = 'oauth'
+	manager.discoverSucceedsOn = 'never'
+
+	const added = await hub.addServer({
+		serverId: 'server-1',
+		name: 'analytics',
+		url: 'https://analytics.example/mcp',
+		callbackUrl: 'https://kody.codes/account/mcp-servers/oauth/callback',
+	})
+	expect(added.state).toBe('authenticating')
+	expect(added.authUrl).toBeTruthy()
+	expect(manager.mcpConnections['server-1']?.options.client).toEqual({
+		versionNegotiation: { mode: 'legacy' },
+	})
+	expect(values.get('mcp-legacy-handshake/server-1')).toBe('catalog-timeout')
+
+	const connection = manager.mcpConnections['server-1']
+	if (!connection) throw new Error('Fake connection was not seeded.')
+	connection.connectionState = 'connected'
+	manager.discoverSucceedsOn = 'always'
+	manager.callbackMatches = true
+	manager.callbackResult = { serverId: 'server-1', authSuccess: true }
+	const oauth = await hub.handleOAuthCallback({
+		url: 'https://kody.codes/account/mcp-servers/oauth/callback?code=abc&state=ok.server-1',
+		callbackUrl: 'https://kody.codes/account/mcp-servers/oauth/callback',
+	})
+	expect(oauth.authSuccess).toBe(true)
+	expect(oauth.lastError).toBeNull()
+	expect(manager.mcpConnections['server-1']?.options.client).toEqual({
+		versionNegotiation: { mode: 'legacy' },
+	})
+	expect(values.get('mcp-legacy-handshake/server-1')).toBe('catalog-timeout')
+})

--- a/packages/worker/src/mcp-client/hub-oauth-recovery.node.test.ts
+++ b/packages/worker/src/mcp-client/hub-oauth-recovery.node.test.ts
@@ -951,7 +951,7 @@ test('healthy auto catalog stays on auto; modern-connect catalog timeout falls b
 	const added = await hub.addServer({
 		serverId: 'server-1',
 		name: 'analytics',
-		url: 'https://analytics.example/mcp',
+		url: 'https://user:secret@analytics.example/mcp?token=abc',
 		callbackUrl,
 	})
 	expect(added.state).toBe('ready')
@@ -1007,4 +1007,40 @@ test('healthy auto catalog stays on auto; modern-connect catalog timeout falls b
 		versionNegotiation: { mode: 'legacy' },
 	})
 	expect(values.get('mcp-legacy-handshake/server-1')).toBe('catalog-timeout')
+})
+
+test('replacing a server forgets the catalog-timeout legacy mark and probes auto', async () => {
+	consoleWarn.mockImplementation(() => {})
+	const { state, values } = createDurableObjectState()
+	const hub = new McpClientHub(state, {} as Env)
+	const manager = mockModule.manager
+	if (!manager) throw new Error('Fake manager was not constructed.')
+	manager.connectBehavior = 'connected'
+	manager.discoverSucceedsOn = 'legacy'
+
+	const added = await hub.addServer({
+		serverId: 'server-1',
+		name: 'analytics',
+		url: 'https://analytics.example/mcp',
+		callbackUrl: 'https://kody.codes/account/mcp-servers/oauth/callback',
+	})
+	expect(added.state).toBe('ready')
+	expect(values.get('mcp-legacy-handshake/server-1')).toBe('catalog-timeout')
+
+	manager.discoverSucceedsOn = 'always'
+	manager.registerCount = 0
+	manager.discoverCount = 0
+	const replaced = await hub.addServer({
+		serverId: 'server-1',
+		name: 'analytics',
+		url: 'https://feeds.example/mcp',
+		callbackUrl: 'https://kody.codes/account/mcp-servers/oauth/callback',
+	})
+	expect(replaced.state).toBe('ready')
+	expect(manager.registerCount).toBe(1)
+	expect(manager.discoverCount).toBe(1)
+	expect(manager.mcpConnections['server-1']?.options.client).toEqual({
+		versionNegotiation: { mode: 'auto' },
+	})
+	expect(values.has('mcp-legacy-handshake/server-1')).toBe(false)
 })

--- a/packages/worker/src/mcp-client/hub-oauth-recovery.node.test.ts
+++ b/packages/worker/src/mcp-client/hub-oauth-recovery.node.test.ts
@@ -38,6 +38,9 @@ type FakeManager = {
 	rows: Array<FakeServerRow>
 	mcpConnections: Record<string, FakeConnection>
 	connectCount: number
+	registerCount: number
+	discoverCount: number
+	discoverSucceedsOn: 'never' | 'always' | 'legacy'
 	connectBehavior: 'oauth' | 'ready' | 'disconnected' | 'connected'
 	connectBehaviors: Array<'oauth' | 'ready' | 'disconnected' | 'connected'>
 	registerFailuresRemaining: number
@@ -116,6 +119,9 @@ vi.mock('agents/mcp/client', () => ({
 		rows: Array<FakeServerRow> = []
 		mcpConnections: Record<string, FakeConnection> = {}
 		connectCount = 0
+		registerCount = 0
+		discoverCount = 0
+		discoverSucceedsOn: 'never' | 'always' | 'legacy' = 'never'
 		connectBehavior: 'oauth' | 'ready' | 'disconnected' | 'connected' = 'oauth'
 		connectBehaviors: Array<'oauth' | 'ready' | 'disconnected' | 'connected'> =
 			[]
@@ -160,6 +166,7 @@ vi.mock('agents/mcp/client', () => ({
 				this.registerFailuresRemaining -= 1
 				throw new Error('Replacement registration failed.')
 			}
+			this.registerCount += 1
 			this.rows.push({
 				id: serverId,
 				name: options.name,
@@ -219,7 +226,26 @@ vi.mock('agents/mcp/client', () => ({
 			}
 		}
 
-		async discoverIfConnected() {}
+		async discoverIfConnected(serverId: string) {
+			this.discoverCount += 1
+			const connection = this.mcpConnections[serverId]
+			if (!connection) return
+			const negotiation = Reflect.get(
+				connection.options.client,
+				'versionNegotiation',
+			)
+			const isLegacy =
+				negotiation != null &&
+				typeof negotiation === 'object' &&
+				Reflect.get(negotiation, 'mode') === 'legacy'
+			if (
+				this.discoverSucceedsOn === 'always' ||
+				(this.discoverSucceedsOn === 'legacy' && isLegacy)
+			) {
+				connection.connectionState = 'ready'
+				connection.connectionError = null
+			}
+		}
 
 		isCallbackRequest() {
 			return this.callbackMatches
@@ -698,6 +724,7 @@ test('handleOAuthCallback reports a durable tool-discovery lastError when IdP su
 	if (!connection) throw new Error('Fake connection was not seeded.')
 	manager.callbackMatches = true
 	manager.callbackResult = { serverId: 'server-1', authSuccess: true }
+	manager.connectBehavior = 'connected'
 	connection.connectionState = 'connected'
 	connection.connectionError = null
 	values.set('/Kody/server-1/oauth_discovery', {
@@ -712,12 +739,12 @@ test('handleOAuthCallback reports a durable tool-discovery lastError when IdP su
 
 	expect(result.authSuccess).toBe(false)
 	expect(result.authorizationNeeded).toBe(false)
-	expect(result.lastError?.phase).toBe('server/discover')
+	expect(result.lastError?.phase).toBe('tools/list')
 	expect(result.lastError?.mcpEndpoint).toBe('https://mediarss.example/mcp')
 	expect(result.lastError?.resource).toBe('https://mcp.posthog.com/')
 	expect(result.lastError?.authServer).toBe('https://auth.posthog.com/')
 	expect(result.authError).toContain("tool discovery didn't finish")
-	expect(result.authError).toContain('phase server/discover')
+	expect(result.authError).toContain('phase tools/list')
 	expect(result.authError).toContain(`id ${result.lastError?.attemptId}`)
 	expect(result.authError?.match(/authorization completed/gi)?.length).toBe(1)
 	expect(result.authError?.match(/\bphase\s/g)?.length).toBe(1)
@@ -730,7 +757,7 @@ test('handleOAuthCallback reports a durable tool-discovery lastError when IdP su
 		expect.objectContaining({
 			attemptId: result.lastError?.attemptId,
 			serverId: 'server-1',
-			phase: 'server/discover',
+			phase: 'tools/list',
 			mcpEndpoint: 'https://mediarss.example/mcp',
 			resource: 'https://mcp.posthog.com/',
 			authServer: 'https://auth.posthog.com/',
@@ -755,8 +782,10 @@ test('replayed unusable callback after incomplete settle reports lastError inste
 		authUrl: 'https://auth.example/authorize?state=used.server-1',
 	})
 	manager.callbackMatches = false
-	const connection = manager.mcpConnections['server-1']
-	if (!connection) throw new Error('Fake connection was not seeded.')
+	manager.connectBehavior = 'connected'
+	if (!manager.mcpConnections['server-1']) {
+		throw new Error('Fake connection was not seeded.')
+	}
 	manager.rows[0]!.auth_url = null
 	const tokenKey = '/Kody/server-1/client-1/token'
 	values.set(tokenKey, { access_token: 'still-valid' })
@@ -766,6 +795,8 @@ test('replayed unusable callback after incomplete settle reports lastError inste
 	})
 
 	for (const inFlightState of ['connected', 'discovering', 'connecting']) {
+		const connection = manager.mcpConnections['server-1']
+		if (!connection) throw new Error('Fake connection was not seeded.')
 		connection.connectionState = inFlightState
 		connection.connectionError = null
 		const outcome = await hub.handleOAuthCallback({
@@ -789,7 +820,7 @@ test('replayed unusable callback after incomplete settle reports lastError inste
 		}
 	}
 
-	expect(manager.connectCount).toBe(0)
+	expect(manager.connectCount).toBe(1)
 	expect(manager.rows[0]?.client_id).toBe('client-1')
 	expect(values.get(tokenKey)).toEqual({ access_token: 'still-valid' })
 })
@@ -810,20 +841,27 @@ test('add, reconnect, and refresh treat a discover timeout as a durable lastErro
 		callbackUrl,
 	})
 	expect(added.state).toBe('connected')
-	expect(added.lastError?.phase).toBe('server/discover')
+	expect(added.lastError?.phase).toBe('tools/list')
 	expect(added.lastError?.mcpEndpoint).toBe('https://mediarss.example/mcp')
 	expect(added.lastError?.attemptId).toBeTruthy()
 	expect(added.error).toContain("tool discovery didn't finish")
-	expect(added.error).toContain('phase server/discover')
+	expect(added.error).toContain('phase tools/list')
 	expect(added.error).toContain(`id ${added.lastError?.attemptId}`)
 	expect(added.error?.match(/\bid\s/g)?.length).toBe(1)
 	expect(manager.mcpConnections['server-1']?.connectionError).toBe(added.error)
+	expect(consoleWarn).toHaveBeenCalledWith(
+		'mcp discover retrying legacy handshake',
+		expect.objectContaining({
+			serverId: 'server-1',
+			mcpEndpoint: 'https://mediarss.example/mcp',
+		}),
+	)
 	expect(consoleWarn).toHaveBeenCalledWith(
 		'mcp discover timeout incomplete',
 		expect.objectContaining({
 			attemptId: added.lastError?.attemptId,
 			serverId: 'server-1',
-			phase: 'server/discover',
+			phase: 'tools/list',
 		}),
 	)
 
@@ -849,8 +887,102 @@ test('add, reconnect, and refresh treat a discover timeout as a durable lastErro
 		callbackUrl,
 	})
 	expect(reconnected.state).toBe('connected')
-	expect(reconnected.lastError?.phase).toBe('server/discover')
+	expect(reconnected.lastError?.phase).toBe('tools/list')
 	expect(reconnected.lastError?.mcpEndpoint).toBe(
 		'https://mediarss.example/mcp',
 	)
+})
+
+test('healthy auto catalog stays on auto; modern-connect catalog timeout falls back to legacy and can reach ready', async () => {
+	consoleWarn.mockImplementation(() => {})
+	const callbackUrl = 'https://kody.codes/account/mcp-servers/oauth/callback'
+
+	const { state: healthyState, values: healthyValues } =
+		createDurableObjectState()
+	const healthyHub = new McpClientHub(healthyState, {} as Env)
+	const healthy = mockModule.manager
+	if (!healthy) throw new Error('Fake manager was not constructed.')
+	healthy.connectBehavior = 'connected'
+	healthy.discoverSucceedsOn = 'always'
+	const healthyAdded = await healthyHub.addServer({
+		serverId: 'server-healthy',
+		name: 'feeds',
+		url: 'https://feeds.example/mcp',
+		callbackUrl,
+	})
+	expect(healthyAdded.state).toBe('ready')
+	expect(healthyAdded.lastError ?? null).toBeNull()
+	expect(healthy.registerCount).toBe(1)
+	expect(healthy.discoverCount).toBe(1)
+	expect(healthy.mcpConnections['server-healthy']?.options.client).toEqual({
+		versionNegotiation: { mode: 'auto' },
+	})
+	expect(healthyValues.has('mcp-legacy-handshake/server-healthy')).toBe(false)
+
+	const { state, values } = createDurableObjectState()
+	const hub = new McpClientHub(state, {} as Env)
+	const manager = mockModule.manager
+	if (!manager) throw new Error('Fake manager was not constructed.')
+	manager.connectBehavior = 'connected'
+	manager.discoverSucceedsOn = 'legacy'
+
+	const added = await hub.addServer({
+		serverId: 'server-1',
+		name: 'analytics',
+		url: 'https://analytics.example/mcp',
+		callbackUrl,
+	})
+	expect(added.state).toBe('ready')
+	expect(added.lastError ?? null).toBeNull()
+	expect(manager.registerCount).toBe(2)
+	expect(manager.discoverCount).toBe(2)
+	expect(manager.mcpConnections['server-1']?.options.client).toEqual({
+		versionNegotiation: { mode: 'legacy' },
+	})
+	expect(values.get('mcp-legacy-handshake/server-1')).toBe('catalog-timeout')
+	expect(consoleWarn).toHaveBeenCalledWith(
+		'mcp discover retrying legacy handshake',
+		expect.objectContaining({
+			serverId: 'server-1',
+			mcpEndpoint: 'https://analytics.example/mcp',
+		}),
+	)
+
+	manager.discoverSucceedsOn = 'always'
+	const reconnected = await hub.reconnectServer({
+		serverId: 'server-1',
+		callbackUrl,
+	})
+	expect(reconnected.state).toBe('ready')
+	expect(manager.mcpConnections['server-1']?.options.client).toEqual({
+		versionNegotiation: { mode: 'auto' },
+	})
+	expect(values.has('mcp-legacy-handshake/server-1')).toBe(false)
+
+	manager.discoverSucceedsOn = 'legacy'
+	seedServer({
+		manager,
+		callbackUrl,
+		clientId: 'client-1',
+		authUrl: 'https://auth.example/authorize?state=ok.server-1',
+	})
+	const connection = manager.mcpConnections['server-1']
+	if (!connection) throw new Error('Fake connection was not seeded.')
+	connection.options.client = { versionNegotiation: { mode: 'auto' } }
+	connection.connectionState = 'connected'
+	manager.callbackMatches = true
+	manager.callbackResult = { serverId: 'server-1', authSuccess: true }
+	manager.registerCount = 0
+	manager.discoverCount = 0
+	const oauth = await hub.handleOAuthCallback({
+		url: `${callbackUrl}?code=abc&state=ok.server-1`,
+		callbackUrl,
+	})
+	expect(oauth.authSuccess).toBe(true)
+	expect(oauth.lastError).toBeNull()
+	expect(manager.registerCount).toBe(1)
+	expect(manager.mcpConnections['server-1']?.options.client).toEqual({
+		versionNegotiation: { mode: 'legacy' },
+	})
+	expect(values.get('mcp-legacy-handshake/server-1')).toBe('catalog-timeout')
 })

--- a/packages/worker/src/mcp-client/hub-oauth-recovery.node.test.ts
+++ b/packages/worker/src/mcp-client/hub-oauth-recovery.node.test.ts
@@ -893,6 +893,28 @@ test('add, reconnect, and refresh treat a discover timeout as a durable lastErro
 	)
 })
 
+test('legacy retry that fails to connect keeps the catalog lastError', async () => {
+	consoleWarn.mockImplementation(() => {})
+	const { state } = createDurableObjectState()
+	const hub = new McpClientHub(state, {} as Env)
+	const manager = mockModule.manager
+	if (!manager) throw new Error('Fake manager was not constructed.')
+	manager.connectBehaviors = ['connected', 'disconnected']
+	manager.connectBehavior = 'disconnected'
+
+	const added = await hub.addServer({
+		serverId: 'server-1',
+		name: 'analytics',
+		url: 'https://analytics.example/mcp',
+		callbackUrl: 'https://kody.codes/account/mcp-servers/oauth/callback',
+	})
+	expect(added.state).toBe('disconnected')
+	expect(added.lastError?.phase).toBe('tools/list')
+	expect(added.error).toContain("tool discovery didn't finish")
+	expect(added.error).toContain('phase tools/list')
+	expect(manager.mcpConnections['server-1']?.connectionError).toBe(added.error)
+})
+
 test('healthy auto catalog stays on auto; modern-connect catalog timeout falls back to legacy and can reach ready', async () => {
 	consoleWarn.mockImplementation(() => {})
 	const callbackUrl = 'https://kody.codes/account/mcp-servers/oauth/callback'

--- a/packages/worker/src/mcp-client/hub.ts
+++ b/packages/worker/src/mcp-client/hub.ts
@@ -16,6 +16,7 @@ import {
 	mcpLegacyHandshakeFallback,
 	mcpLegacyHandshakeStorageKey,
 	mcpLegacyHandshakeStoragePrefix,
+	readMcpVersionNegotiationMode,
 	shouldRetryLegacyHandshake,
 } from './legacy-handshake.ts'
 import {
@@ -151,6 +152,17 @@ class McpClientHubBase extends DurableObject<Env> {
 			mcpLegacyHandshakeStorageKey(serverId),
 			mcpLegacyHandshakeFallback,
 		)
+	}
+
+	private async rememberLegacyHandshakeIfActive(serverId: string) {
+		if (
+			readMcpVersionNegotiationMode(
+				this.manager.mcpConnections[serverId]?.options.client,
+			) !== 'legacy'
+		) {
+			return
+		}
+		await this.rememberLegacyHandshakeFallback(serverId)
 	}
 
 	private async forgetLegacyHandshakeFallback(serverId: string) {
@@ -750,6 +762,7 @@ class McpClientHubBase extends DurableObject<Env> {
 		if (connected.state !== 'connected') {
 			const result = this.buildConnectResult(serverId)
 			if (result.state === 'authenticating' && result.authUrl) {
+				await this.rememberLegacyHandshakeIfActive(serverId)
 				return { result, lastError: null }
 			}
 			return this.keepCatalogLastError(serverId, autoFailure, result.error)
@@ -759,7 +772,7 @@ class McpClientHubBase extends DurableObject<Env> {
 			attemptId: autoFailure.lastError?.attemptId,
 		})
 		if (discovered.result.state === 'ready') {
-			await this.rememberLegacyHandshakeFallback(serverId)
+			await this.rememberLegacyHandshakeIfActive(serverId)
 		}
 		return discovered
 	}
@@ -926,7 +939,11 @@ class McpClientHubBase extends DurableObject<Env> {
 	private async discoverAfterOAuthEstablish(
 		serverId: string,
 	): Promise<McpServerConnectResult> {
-		return (await this.runDiscoverIfConnected(serverId)).result
+		const result = (await this.runDiscoverIfConnected(serverId)).result
+		if (result.state === 'ready') {
+			await this.rememberLegacyHandshakeIfActive(serverId)
+		}
+		return result
 	}
 
 	private async resolveOAuthCallbackOutcome(input: {

--- a/packages/worker/src/mcp-client/hub.ts
+++ b/packages/worker/src/mcp-client/hub.ts
@@ -658,10 +658,16 @@ class McpClientHubBase extends DurableObject<Env> {
 		) {
 			return afterAuto
 		}
-		return this.retryDiscoverWithLegacyHandshake(serverId)
+		return this.retryDiscoverWithLegacyHandshake(serverId, afterAuto)
 	}
 
-	private async retryDiscoverWithLegacyHandshake(serverId: string): Promise<{
+	private async retryDiscoverWithLegacyHandshake(
+		serverId: string,
+		autoFailure: {
+			result: McpServerConnectResult
+			lastError: McpServerLastError | null
+		},
+	): Promise<{
 		result: McpServerConnectResult
 		lastError: McpServerLastError | null
 	}> {
@@ -670,9 +676,7 @@ class McpClientHubBase extends DurableObject<Env> {
 			.find((server) => server.id === serverId)
 		const existingOptions = this.manager.mcpConnections[serverId]?.options
 		if (!row || !existingOptions) {
-			return this.applyIncompleteDiscoverFailure(serverId, null, {
-				catalogAttempted: true,
-			})
+			return this.keepCatalogLastError(serverId, autoFailure, null)
 		}
 
 		console.warn('mcp discover retrying legacy handshake', {
@@ -726,20 +730,21 @@ class McpClientHubBase extends DurableObject<Env> {
 			} catch {
 				// The incomplete auto discover lastError is the user-visible outcome.
 			}
-			return this.applyIncompleteDiscoverFailure(
+			return this.keepCatalogLastError(
 				serverId,
+				autoFailure,
 				error instanceof Error ? error.message : String(error),
-				{ catalogAttempted: true },
 			)
 		}
 
 		this.clearSessionBeforeConnect(serverId)
 		const connected = await this.manager.connectToServer(serverId)
 		if (connected.state !== 'connected') {
-			return {
-				result: this.buildConnectResult(serverId),
-				lastError: null,
+			const result = this.buildConnectResult(serverId)
+			if (result.state === 'authenticating' && result.authUrl) {
+				return { result, lastError: null }
 			}
+			return this.keepCatalogLastError(serverId, autoFailure, result.error)
 		}
 		const discovered = await this.runDiscoverIfConnected(serverId, {
 			allowLegacyFallback: false,
@@ -748,6 +753,40 @@ class McpClientHubBase extends DurableObject<Env> {
 			await this.rememberLegacyHandshakeFallback(serverId)
 		}
 		return discovered
+	}
+
+	private keepCatalogLastError(
+		serverId: string,
+		autoFailure: {
+			result: McpServerConnectResult
+			lastError: McpServerLastError | null
+		},
+		discoverError: string | null,
+	): {
+		result: McpServerConnectResult
+		lastError: McpServerLastError | null
+	} {
+		const stamped = this.applyIncompleteDiscoverFailure(
+			serverId,
+			discoverError,
+			{
+				catalogAttempted: true,
+			},
+		)
+		if (stamped.lastError) return stamped
+		const lastError = autoFailure.lastError
+		if (!lastError) return stamped
+		const connection = this.manager.mcpConnections[serverId]
+		if (connection) connection.connectionError = lastError.message
+		this.lastDiscoverErrors.set(serverId, lastError)
+		return {
+			result: {
+				...this.buildConnectResult(serverId),
+				error: lastError.message,
+				lastError,
+			},
+			lastError,
+		}
 	}
 
 	private finalizeConnectResult(serverId: string): McpServerConnectResult {
@@ -765,13 +804,30 @@ class McpClientHubBase extends DurableObject<Env> {
 		const result = this.buildConnectResult(serverId)
 		const connection = this.manager.mcpConnections[serverId]
 		if (!isIncompleteDiscoverState(result.state)) {
-			if (result.state === 'ready') this.clearIncompleteDiscoverStamp(serverId)
-			else this.lastDiscoverErrors.delete(serverId)
+			if (result.state === 'ready') {
+				this.clearIncompleteDiscoverStamp(serverId)
+				return {
+					result: { ...result, error: null, lastError: null },
+					lastError: null,
+				}
+			}
+			const existing = this.lastDiscoverErrors.get(serverId)
+			if (existing && result.state !== 'authenticating') {
+				if (connection) connection.connectionError = existing.message
+				return {
+					result: {
+						...this.buildConnectResult(serverId),
+						error: existing.message,
+						lastError: existing,
+					},
+					lastError: existing,
+				}
+			}
+			this.lastDiscoverErrors.delete(serverId)
 			return {
 				result: {
 					...result,
-					error:
-						result.state === 'ready' ? null : (result.error ?? discoverError),
+					error: result.error ?? discoverError,
 					lastError: null,
 				},
 				lastError: null,

--- a/packages/worker/src/mcp-client/hub.ts
+++ b/packages/worker/src/mcp-client/hub.ts
@@ -247,6 +247,7 @@ class McpClientHubBase extends DurableObject<Env> {
 	}): Promise<McpServerConnectResult> {
 		await this.ensureRestored()
 		await this.forgetLegacyHandshakeFallback(input.serverId)
+		this.clearIncompleteDiscoverStamp(input.serverId)
 		const existing = this.manager.mcpConnections[input.serverId]
 		if (existing) {
 			await this.manager.removeServer(input.serverId)
@@ -301,6 +302,7 @@ class McpClientHubBase extends DurableObject<Env> {
 			timeout: connectionSettleTimeoutMs,
 		})
 		await this.forgetLegacyHandshakeFallback(input.serverId)
+		this.clearIncompleteDiscoverStamp(input.serverId)
 		await this.restartServerAuthorization(input)
 		const row = this.manager
 			.listServers()
@@ -632,7 +634,7 @@ class McpClientHubBase extends DurableObject<Env> {
 
 	private async runDiscoverIfConnected(
 		serverId: string,
-		options?: { allowLegacyFallback?: boolean },
+		options?: { allowLegacyFallback?: boolean; attemptId?: string | null },
 	): Promise<{
 		result: McpServerConnectResult
 		lastError: McpServerLastError | null
@@ -649,7 +651,10 @@ class McpClientHubBase extends DurableObject<Env> {
 		const afterAuto = this.applyIncompleteDiscoverFailure(
 			serverId,
 			discoverError,
-			{ catalogAttempted: true },
+			{
+				catalogAttempted: true,
+				attemptId: options?.attemptId,
+			},
 		)
 		if (
 			options?.allowLegacyFallback === false ||
@@ -683,6 +688,7 @@ class McpClientHubBase extends DurableObject<Env> {
 
 		console.warn('mcp discover retrying legacy handshake', {
 			serverId,
+			attemptId: autoFailure.lastError?.attemptId ?? null,
 			mcpEndpoint: sanitizePublicUrl(row.server_url),
 		})
 
@@ -750,6 +756,7 @@ class McpClientHubBase extends DurableObject<Env> {
 		}
 		const discovered = await this.runDiscoverIfConnected(serverId, {
 			allowLegacyFallback: false,
+			attemptId: autoFailure.lastError?.attemptId,
 		})
 		if (discovered.result.state === 'ready') {
 			await this.rememberLegacyHandshakeFallback(serverId)
@@ -773,6 +780,7 @@ class McpClientHubBase extends DurableObject<Env> {
 			discoverError,
 			{
 				catalogAttempted: true,
+				attemptId: autoFailure.lastError?.attemptId,
 			},
 		)
 		if (stamped.lastError) return stamped
@@ -798,7 +806,7 @@ class McpClientHubBase extends DurableObject<Env> {
 	private applyIncompleteDiscoverFailure(
 		serverId: string,
 		discoverError: string | null,
-		options?: { catalogAttempted?: boolean },
+		options?: { catalogAttempted?: boolean; attemptId?: string | null },
 	): {
 		result: McpServerConnectResult
 		lastError: McpServerLastError | null
@@ -863,6 +871,7 @@ class McpClientHubBase extends DurableObject<Env> {
 			error: alreadyStamped ? discoverError : (result.error ?? discoverError),
 			phase: options?.catalogAttempted ? 'tools/list' : undefined,
 			mcpEndpoint: row?.server_url ?? null,
+			attemptId: options?.attemptId,
 		})
 		if (!lastError) {
 			return {
@@ -896,7 +905,7 @@ class McpClientHubBase extends DurableObject<Env> {
 	private rebuildStampedDiscoverLastError(
 		serverId: string,
 		result: McpServerConnectResult,
-		options?: { catalogAttempted?: boolean },
+		options?: { catalogAttempted?: boolean; attemptId?: string | null },
 	): McpServerLastError | null {
 		const row = this.manager
 			.listServers()
@@ -908,7 +917,9 @@ class McpClientHubBase extends DurableObject<Env> {
 			phase: options?.catalogAttempted ? 'tools/list' : undefined,
 			mcpEndpoint: row?.server_url ?? null,
 			attemptId:
-				readAttemptIdFromSettleMessage(result.error) ?? crypto.randomUUID(),
+				options?.attemptId ??
+				readAttemptIdFromSettleMessage(result.error) ??
+				crypto.randomUUID(),
 		})
 	}
 

--- a/packages/worker/src/mcp-client/hub.ts
+++ b/packages/worker/src/mcp-client/hub.ts
@@ -24,6 +24,7 @@ import {
 	isIncompleteDiscoverState,
 	readAttemptIdFromSettleMessage,
 	readOAuthDiscoveryUrls,
+	sanitizePublicUrl,
 } from './oauth-settle-error.ts'
 import {
 	outboundMcpClientOptions,
@@ -245,6 +246,7 @@ class McpClientHubBase extends DurableObject<Env> {
 		headers?: Record<string, string>
 	}): Promise<McpServerConnectResult> {
 		await this.ensureRestored()
+		await this.forgetLegacyHandshakeFallback(input.serverId)
 		const existing = this.manager.mcpConnections[input.serverId]
 		if (existing) {
 			await this.manager.removeServer(input.serverId)
@@ -681,7 +683,7 @@ class McpClientHubBase extends DurableObject<Env> {
 
 		console.warn('mcp discover retrying legacy handshake', {
 			serverId,
-			mcpEndpoint: row.server_url,
+			mcpEndpoint: sanitizePublicUrl(row.server_url),
 		})
 
 		try {

--- a/packages/worker/src/mcp-client/hub.ts
+++ b/packages/worker/src/mcp-client/hub.ts
@@ -13,6 +13,12 @@ import {
 	resolveMcpOAuthCallbackOutcome,
 } from './oauth-callback-outcome.ts'
 import {
+	mcpLegacyHandshakeFallback,
+	mcpLegacyHandshakeStorageKey,
+	mcpLegacyHandshakeStoragePrefix,
+	shouldRetryLegacyHandshake,
+} from './legacy-handshake.ts'
+import {
 	buildIncompleteDiscoverLastError,
 	isFormattedMcpOAuthSettleMessage,
 	isIncompleteDiscoverState,
@@ -122,8 +128,32 @@ class McpClientHubBase extends DurableObject<Env> {
 	 * sessions are dropped first because start restores connections.
 	 */
 	private async restoreSanitizedConnections() {
-		sanitizeStoredMcpSessions(this.ctx.storage)
+		sanitizeStoredMcpSessions(this.ctx.storage, {
+			keepLegacyHandshakeIds: await this.readLegacyHandshakeServerIds(),
+		})
 		await this.lifecycle.start()
+	}
+
+	private async readLegacyHandshakeServerIds() {
+		const entries = await this.ctx.storage.list({
+			prefix: mcpLegacyHandshakeStoragePrefix,
+		})
+		return new Set(
+			[...entries.keys()].map((key) =>
+				key.slice(mcpLegacyHandshakeStoragePrefix.length),
+			),
+		)
+	}
+
+	private async rememberLegacyHandshakeFallback(serverId: string) {
+		await this.ctx.storage.put(
+			mcpLegacyHandshakeStorageKey(serverId),
+			mcpLegacyHandshakeFallback,
+		)
+	}
+
+	private async forgetLegacyHandshakeFallback(serverId: string) {
+		await this.ctx.storage.delete(mcpLegacyHandshakeStorageKey(serverId))
 	}
 
 	private clearSessionBeforeConnect(serverId: string) {
@@ -268,6 +298,7 @@ class McpClientHubBase extends DurableObject<Env> {
 		await this.manager.waitForConnections({
 			timeout: connectionSettleTimeoutMs,
 		})
+		await this.forgetLegacyHandshakeFallback(input.serverId)
 		await this.restartServerAuthorization(input)
 		const row = this.manager
 			.listServers()
@@ -305,9 +336,10 @@ class McpClientHubBase extends DurableObject<Env> {
 	async removeServer(input: { serverId: string }): Promise<void> {
 		await this.ensureRestored()
 		await this.manager.removeServer(input.serverId)
-		await this.ctx.storage.delete(
+		await this.ctx.storage.delete([
 			mcpConnectionEpisodeStorageKey(input.serverId),
-		)
+			mcpLegacyHandshakeStorageKey(input.serverId),
+		])
 	}
 
 	/**
@@ -596,7 +628,10 @@ class McpClientHubBase extends DurableObject<Env> {
 		this.lastDiscoverErrors.delete(serverId)
 	}
 
-	private async runDiscoverIfConnected(serverId: string): Promise<{
+	private async runDiscoverIfConnected(
+		serverId: string,
+		options?: { allowLegacyFallback?: boolean },
+	): Promise<{
 		result: McpServerConnectResult
 		lastError: McpServerLastError | null
 	}> {
@@ -609,7 +644,110 @@ class McpClientHubBase extends DurableObject<Env> {
 		} catch (error) {
 			discoverError = error instanceof Error ? error.message : String(error)
 		}
-		return this.applyIncompleteDiscoverFailure(serverId, discoverError)
+		const afterAuto = this.applyIncompleteDiscoverFailure(
+			serverId,
+			discoverError,
+			{ catalogAttempted: true },
+		)
+		if (
+			options?.allowLegacyFallback === false ||
+			!shouldRetryLegacyHandshake({
+				state: afterAuto.result.state,
+				client: this.manager.mcpConnections[serverId]?.options.client,
+			})
+		) {
+			return afterAuto
+		}
+		return this.retryDiscoverWithLegacyHandshake(serverId)
+	}
+
+	private async retryDiscoverWithLegacyHandshake(serverId: string): Promise<{
+		result: McpServerConnectResult
+		lastError: McpServerLastError | null
+	}> {
+		const row = this.manager
+			.listServers()
+			.find((server) => server.id === serverId)
+		const existingOptions = this.manager.mcpConnections[serverId]?.options
+		if (!row || !existingOptions) {
+			return this.applyIncompleteDiscoverFailure(serverId, null, {
+				catalogAttempted: true,
+			})
+		}
+
+		console.warn('mcp discover retrying legacy handshake', {
+			serverId,
+			mcpEndpoint: row.server_url,
+		})
+
+		try {
+			await this.manager.removeServer(serverId)
+			const authProvider = createMcpClientOAuthProvider(
+				this.ctx.storage,
+				row.callback_url,
+			)
+			authProvider.serverId = serverId
+			if (row.client_id) authProvider.clientId = row.client_id
+			const legacy = reconnectMcpServerOptions(existingOptions, 'legacy')
+			await this.manager.registerServer(serverId, {
+				url: row.server_url,
+				name: row.name,
+				callbackUrl: row.callback_url,
+				...(row.client_id ? { clientId: row.client_id } : {}),
+				client: legacy.client,
+				transport: withStaticTransportHeaders({
+					...legacy.transport,
+					type: legacy.transport.type ?? 'auto',
+					authProvider,
+				}),
+			})
+		} catch (error) {
+			try {
+				await this.manager.removeServer(serverId).catch(() => {})
+				const authProvider = createMcpClientOAuthProvider(
+					this.ctx.storage,
+					row.callback_url,
+				)
+				authProvider.serverId = serverId
+				if (row.client_id) authProvider.clientId = row.client_id
+				const restored = reconnectMcpServerOptions(existingOptions)
+				await this.manager.registerServer(serverId, {
+					url: row.server_url,
+					name: row.name,
+					callbackUrl: row.callback_url,
+					...(row.client_id ? { clientId: row.client_id } : {}),
+					client: restored.client,
+					transport: withStaticTransportHeaders({
+						...restored.transport,
+						type: restored.transport.type ?? 'auto',
+						authProvider,
+					}),
+				})
+			} catch {
+				// The incomplete auto discover lastError is the user-visible outcome.
+			}
+			return this.applyIncompleteDiscoverFailure(
+				serverId,
+				error instanceof Error ? error.message : String(error),
+				{ catalogAttempted: true },
+			)
+		}
+
+		this.clearSessionBeforeConnect(serverId)
+		const connected = await this.manager.connectToServer(serverId)
+		if (connected.state !== 'connected') {
+			return {
+				result: this.buildConnectResult(serverId),
+				lastError: null,
+			}
+		}
+		const discovered = await this.runDiscoverIfConnected(serverId, {
+			allowLegacyFallback: false,
+		})
+		if (discovered.result.state === 'ready') {
+			await this.rememberLegacyHandshakeFallback(serverId)
+		}
+		return discovered
 	}
 
 	private finalizeConnectResult(serverId: string): McpServerConnectResult {
@@ -619,6 +757,7 @@ class McpClientHubBase extends DurableObject<Env> {
 	private applyIncompleteDiscoverFailure(
 		serverId: string,
 		discoverError: string | null,
+		options?: { catalogAttempted?: boolean },
 	): {
 		result: McpServerConnectResult
 		lastError: McpServerLastError | null
@@ -643,7 +782,7 @@ class McpClientHubBase extends DurableObject<Env> {
 		if (alreadyStamped && discoverError == null) {
 			const existing =
 				this.lastDiscoverErrors.get(serverId) ??
-				this.rebuildStampedDiscoverLastError(serverId, result)
+				this.rebuildStampedDiscoverLastError(serverId, result, options)
 			if (existing) {
 				this.lastDiscoverErrors.set(serverId, existing)
 				return {
@@ -664,6 +803,7 @@ class McpClientHubBase extends DurableObject<Env> {
 			state: result.state,
 			authUrl: result.authUrl,
 			error: alreadyStamped ? discoverError : (result.error ?? discoverError),
+			phase: options?.catalogAttempted ? 'tools/list' : undefined,
 			mcpEndpoint: row?.server_url ?? null,
 		})
 		if (!lastError) {
@@ -698,6 +838,7 @@ class McpClientHubBase extends DurableObject<Env> {
 	private rebuildStampedDiscoverLastError(
 		serverId: string,
 		result: McpServerConnectResult,
+		options?: { catalogAttempted?: boolean },
 	): McpServerLastError | null {
 		const row = this.manager
 			.listServers()
@@ -706,6 +847,7 @@ class McpClientHubBase extends DurableObject<Env> {
 			state: result.state,
 			authUrl: result.authUrl,
 			error: null,
+			phase: options?.catalogAttempted ? 'tools/list' : undefined,
 			mcpEndpoint: row?.server_url ?? null,
 			attemptId:
 				readAttemptIdFromSettleMessage(result.error) ?? crypto.randomUUID(),
@@ -755,6 +897,7 @@ class McpClientHubBase extends DurableObject<Env> {
 				? {
 						...connection,
 						error: alreadyFormatted ? null : connectionError,
+						phase: stamped?.phase,
 						httpStatus: stamped?.httpStatus ?? null,
 						httpBodySnippet: stamped?.httpBodySnippet ?? null,
 						mcpEndpoint: row?.server_url ?? stamped?.mcpEndpoint ?? null,

--- a/packages/worker/src/mcp-client/legacy-handshake.node.test.ts
+++ b/packages/worker/src/mcp-client/legacy-handshake.node.test.ts
@@ -1,0 +1,78 @@
+import { expect, test } from 'vitest'
+import {
+	readMcpVersionNegotiationMode,
+	shouldKeepPersistedLegacyHandshake,
+	shouldRetryLegacyHandshake,
+} from './legacy-handshake.ts'
+import { reconnectMcpServerOptions } from './reconnect.ts'
+
+test('legacy handshake retry is only for auto catalog that never reaches ready', () => {
+	expect(readMcpVersionNegotiationMode(undefined)).toBe('auto')
+	expect(
+		readMcpVersionNegotiationMode({
+			versionNegotiation: { mode: 'auto' },
+		}),
+	).toBe('auto')
+	expect(
+		readMcpVersionNegotiationMode({
+			versionNegotiation: { mode: 'legacy' },
+		}),
+	).toBe('legacy')
+	expect(
+		shouldRetryLegacyHandshake({
+			state: 'connected',
+			client: { versionNegotiation: { mode: 'auto' } },
+		}),
+	).toBe(true)
+	expect(
+		shouldRetryLegacyHandshake({
+			state: 'discovering',
+			client: { versionNegotiation: { mode: 'auto' } },
+		}),
+	).toBe(true)
+	expect(
+		shouldRetryLegacyHandshake({
+			state: 'ready',
+			client: { versionNegotiation: { mode: 'auto' } },
+		}),
+	).toBe(false)
+	expect(
+		shouldRetryLegacyHandshake({
+			state: 'connected',
+			client: { versionNegotiation: { mode: 'legacy' } },
+		}),
+	).toBe(false)
+	expect(
+		shouldKeepPersistedLegacyHandshake({
+			serverId: 'analytics',
+			keepLegacyHandshakeIds: new Set(['analytics']),
+		}),
+	).toBe(true)
+	expect(
+		shouldKeepPersistedLegacyHandshake({
+			serverId: 'feeds',
+			keepLegacyHandshakeIds: new Set(['analytics']),
+		}),
+	).toBe(false)
+
+	const legacy = reconnectMcpServerOptions(
+		{
+			client: { capabilities: { elicitation: { form: {} } } },
+			transport: {
+				type: 'auto',
+				sessionId: 'stale',
+				protocolVersion: '2025-11-25',
+				headers: { Authorization: 'Bearer token' },
+			},
+		},
+		'legacy',
+	)
+	expect(legacy.client).toEqual({
+		capabilities: { elicitation: { form: {} } },
+		versionNegotiation: { mode: 'legacy' },
+	})
+	expect(legacy.transport).toEqual({
+		type: 'auto',
+		headers: { Authorization: 'Bearer token' },
+	})
+})

--- a/packages/worker/src/mcp-client/legacy-handshake.ts
+++ b/packages/worker/src/mcp-client/legacy-handshake.ts
@@ -1,0 +1,41 @@
+import { isIncompleteDiscoverState } from './oauth-settle-error.ts'
+import { type McpVersionNegotiationMode } from './reconnect.ts'
+import { type McpServerConnectionState } from './types.ts'
+
+export const mcpLegacyHandshakeStoragePrefix = 'mcp-legacy-handshake/'
+export const mcpLegacyHandshakeFallback = 'catalog-timeout' as const
+
+export function mcpLegacyHandshakeStorageKey(serverId: string) {
+	return `${mcpLegacyHandshakeStoragePrefix}${serverId}`
+}
+
+export function readMcpVersionNegotiationMode(
+	client: unknown,
+): McpVersionNegotiationMode {
+	if (!client || typeof client !== 'object') return 'auto'
+	const negotiation = Reflect.get(client, 'versionNegotiation')
+	if (!negotiation || typeof negotiation !== 'object') return 'auto'
+	return Reflect.get(negotiation, 'mode') === 'legacy' ? 'legacy' : 'auto'
+}
+
+/**
+ * Modern `auto` already completed transport + handshake (`connected` /
+ * `discovering`) but catalog never reached `ready`. Retry the same server
+ * with the 2025 `initialize` dialect instead of pinning a hostname.
+ */
+export function shouldRetryLegacyHandshake(input: {
+	state: McpServerConnectionState
+	client?: unknown
+}): boolean {
+	return (
+		readMcpVersionNegotiationMode(input.client) === 'auto' &&
+		isIncompleteDiscoverState(input.state)
+	)
+}
+
+export function shouldKeepPersistedLegacyHandshake(input: {
+	serverId: string
+	keepLegacyHandshakeIds?: ReadonlySet<string>
+}): boolean {
+	return input.keepLegacyHandshakeIds?.has(input.serverId) === true
+}

--- a/packages/worker/src/mcp-client/oauth-callback-outcome.node.test.ts
+++ b/packages/worker/src/mcp-client/oauth-callback-outcome.node.test.ts
@@ -168,4 +168,21 @@ test('IdP success with connected state and null connection.error is a tool-disco
 	expect(discovering).toContain("tool discovery didn't finish")
 	expect(discovering).toContain('phase tools/list')
 	expect(discovering).not.toContain('still "discovering"')
+
+	const catalogTimeout = resolveMcpOAuthCallbackOutcome({
+		sdkAuthSuccess: true,
+		sdkAuthError: null,
+		serverId: 'server-catalog',
+		serverName: 'analytics',
+		attemptId: 'attempt-catalog',
+		connection: {
+			state: 'connected',
+			authUrl: null,
+			error: null,
+			phase: 'tools/list',
+			mcpEndpoint: 'https://analytics.example/mcp',
+		},
+	})
+	expect(catalogTimeout.lastError?.phase).toBe('tools/list')
+	expect(catalogTimeout.authError).toContain('phase tools/list')
 })

--- a/packages/worker/src/mcp-client/oauth-callback-outcome.ts
+++ b/packages/worker/src/mcp-client/oauth-callback-outcome.ts
@@ -4,6 +4,7 @@ import {
 	parseHttpStatusFromMcpError,
 	sanitizeMcpErrorSnippet,
 	sanitizePublicUrl,
+	type McpOAuthSettlePhase,
 	type McpServerLastError,
 } from './oauth-settle-error.ts'
 import {
@@ -15,6 +16,7 @@ export type McpOAuthCallbackConnection = {
 	state: McpServerConnectionState
 	authUrl: string | null
 	error: string | null
+	phase?: McpOAuthSettlePhase | null
 	mcpEndpoint?: string | null
 	resource?: string | null
 	authServer?: string | null
@@ -108,10 +110,12 @@ function buildIncompleteMcpOAuthLastError(input: {
 		state: input.connection.state,
 		authUrl: input.connection.authUrl,
 		error,
-		phase: inferMcpOAuthSettlePhase({
-			state: input.connection.state,
-			error,
-		}),
+		phase:
+			input.connection.phase ??
+			inferMcpOAuthSettlePhase({
+				state: input.connection.state,
+				error,
+			}),
 		httpStatus:
 			input.connection.httpStatus ?? parseHttpStatusFromMcpError(error),
 		httpBodySnippet: sanitizeMcpErrorSnippet(input.connection.httpBodySnippet),

--- a/packages/worker/src/mcp-client/oauth-settle-error.node.test.ts
+++ b/packages/worker/src/mcp-client/oauth-settle-error.node.test.ts
@@ -81,6 +81,14 @@ test('settle error helpers sanitize secrets and keep observable phases', () => {
 	})
 	expect(
 		buildIncompleteDiscoverLastError({
+			state: 'connected',
+			mcpEndpoint: 'https://mcp.example/mcp',
+			attemptId: 'attempt-catalog',
+			phase: 'tools/list',
+		})?.phase,
+	).toBe('tools/list')
+	expect(
+		buildIncompleteDiscoverLastError({
 			state: 'ready',
 			mcpEndpoint: 'https://mcp.example/mcp',
 		}),

--- a/packages/worker/src/mcp-client/oauth-settle-error.ts
+++ b/packages/worker/src/mcp-client/oauth-settle-error.ts
@@ -206,6 +206,7 @@ export function buildIncompleteDiscoverLastError(input: {
 	state: McpServerConnectionState
 	authUrl?: string | null
 	error?: string | null
+	phase?: McpOAuthSettlePhase | null
 	mcpEndpoint?: string | null
 	resource?: string | null
 	authServer?: string | null
@@ -216,6 +217,7 @@ export function buildIncompleteDiscoverLastError(input: {
 		state: input.state,
 		authUrl: input.authUrl ?? null,
 		error: input.error,
+		phase: input.phase,
 		mcpEndpoint: input.mcpEndpoint,
 		resource: input.resource,
 		authServer: input.authServer,

--- a/packages/worker/src/mcp-client/outbound-era.node.test.ts
+++ b/packages/worker/src/mcp-client/outbound-era.node.test.ts
@@ -52,29 +52,64 @@ test('Kody-as-client lists tools on modern-only and 2025 initialize servers', as
 	expect(rpcMethods(legacy.recorded)).toContain('tools/list')
 })
 
+test('modern connect then catalog hang is recoverable on the same server via legacy initialize', async () => {
+	await using stalling = await startRecordedServer(
+		createModernCatalogHangHandler(),
+	)
+
+	const autoClient = await connectKodyAsClient(stalling.origin)
+	try {
+		await expect(
+			autoClient.client.listTools(undefined, { timeout: 250 }),
+		).rejects.toThrow()
+	} finally {
+		await autoClient.client.close().catch(() => undefined)
+		await autoClient.transport.close().catch(() => undefined)
+	}
+	expect(rpcMethods(stalling.recorded)).toContain('server/discover')
+	expect(rpcMethods(stalling.recorded)).toContain('tools/list')
+	expect(rpcMethods(stalling.recorded)).not.toContain('initialize')
+
+	const legacyClient = await connectKodyAsClient(stalling.origin, {
+		mode: 'legacy',
+	})
+	try {
+		const tools = await legacyClient.client.listTools()
+		expect(tools.tools.map((tool) => tool.name)).toEqual(['catalog_ping'])
+	} finally {
+		await legacyClient.client.close().catch(() => undefined)
+		await legacyClient.transport.close().catch(() => undefined)
+	}
+	expect(rpcMethods(stalling.recorded)).toContain('initialize')
+})
+
 async function connectKodyAsClient(
 	origin: string,
 	input?: {
 		headers?: Record<string, string>
 		staleSession?: { sessionId: string; protocolVersion: string }
+		mode?: 'auto' | 'legacy'
 	},
 ) {
-	const reconnected = reconnectMcpServerOptions({
-		transport: {
-			type: 'auto',
-			...input?.staleSession,
-			...(input?.headers ? { headers: input.headers } : {}),
+	const reconnected = reconnectMcpServerOptions(
+		{
+			transport: {
+				type: 'auto',
+				...input?.staleSession,
+				...(input?.headers ? { headers: input.headers } : {}),
+			},
+			discoverResult: input?.staleSession
+				? { supportedVersions: ['2025-11-25'] }
+				: undefined,
 		},
-		discoverResult: input?.staleSession
-			? { supportedVersions: ['2025-11-25'] }
-			: undefined,
-	})
+		input?.mode ?? 'auto',
+	)
 	expect(reconnected.transport.sessionId).toBeUndefined()
 	expect(reconnected.transport.protocolVersion).toBeUndefined()
 
 	const client = new Client(
 		{ name: 'Kody', version: '1.0.0' },
-		{ versionNegotiation: { mode: 'auto' } },
+		{ versionNegotiation: { mode: input?.mode ?? 'auto' } },
 	)
 	const headers = withStaticTransportHeaders(reconnected.transport)
 	const transport = new StreamableHTTPClientTransport(new URL('/mcp', origin), {
@@ -107,6 +142,75 @@ function createModernOnlyHandler() {
 			})
 		}
 		return mcpHandler.fetch(request)
+	}
+}
+
+function createModernCatalogHangHandler() {
+	let sawInitialize = false
+	return async (request: Request) => {
+		if (request.method === 'DELETE') {
+			return new Response(null, { status: 200 })
+		}
+		if (request.method !== 'POST') {
+			return new Response(null, { status: 405 })
+		}
+		const body = (await request.json()) as {
+			id?: string | number
+			method?: string
+		}
+		if (body.method === 'server/discover') {
+			return Response.json({
+				jsonrpc: '2.0',
+				id: body.id ?? null,
+				result: {
+					protocolVersion: '2026-07-28',
+					supportedVersions: ['2026-07-28'],
+					capabilities: { tools: {} },
+					serverInfo: { name: 'stalling', version: '1.0.0' },
+				},
+			})
+		}
+		if (body.method === 'initialize') {
+			sawInitialize = true
+			return Response.json(
+				{
+					jsonrpc: '2.0',
+					id: body.id ?? null,
+					result: {
+						protocolVersion: '2025-11-25',
+						capabilities: { tools: {} },
+						serverInfo: { name: 'stalling', version: '1.0.0' },
+					},
+				},
+				{ headers: { 'mcp-session-id': 'stalling-session-1' } },
+			)
+		}
+		if (body.method === 'notifications/initialized') {
+			return new Response(null, { status: 202 })
+		}
+		if (body.method === 'tools/list') {
+			if (!sawInitialize) {
+				await new Promise((resolve) => setTimeout(resolve, 400))
+				return new Response(null, { status: 504 })
+			}
+			return Response.json({
+				jsonrpc: '2.0',
+				id: body.id ?? null,
+				result: {
+					tools: [
+						{
+							name: 'catalog_ping',
+							inputSchema: { type: 'object', properties: {} },
+						},
+					],
+				},
+			})
+		}
+		return Response.json({
+			jsonrpc: '2.0',
+			id: body.id ?? null,
+			error: { code: -32601, message: 'Method not found' },
+		})
 	}
 }
 

--- a/packages/worker/src/mcp-client/reconnect.ts
+++ b/packages/worker/src/mcp-client/reconnect.ts
@@ -1,13 +1,25 @@
 import { withoutPersistedMcpSession } from './transport-session.ts'
 
+export type McpVersionNegotiationMode = 'auto' | 'legacy'
+
 export const outboundMcpVersionNegotiation = { mode: 'auto' as const }
+export const legacyMcpVersionNegotiation = { mode: 'legacy' as const }
+
+function versionNegotiationFor(
+	mode: McpVersionNegotiationMode,
+): { mode: 'auto' } | { mode: 'legacy' } {
+	return mode === 'legacy'
+		? legacyMcpVersionNegotiation
+		: outboundMcpVersionNegotiation
+}
 
 export function outboundMcpClientOptions<T extends object>(
 	existing?: T,
-): T & { versionNegotiation: { mode: 'auto' } } {
+	mode: McpVersionNegotiationMode = 'auto',
+): T & { versionNegotiation: { mode: 'auto' } | { mode: 'legacy' } } {
 	return {
 		...(existing ?? ({} as T)),
-		versionNegotiation: outboundMcpVersionNegotiation,
+		versionNegotiation: versionNegotiationFor(mode),
 	}
 }
 
@@ -16,6 +28,10 @@ export function outboundMcpClientOptions<T extends object>(
  * skips `server/discover` and DELETEs on close; a stored `discoverResult`
  * is only a modern prior when it came from a fresh probe, which reconnect
  * does not have yet.
+ *
+ * Callers that already observed a modern-connect / catalog-timeout can pass
+ * `legacy` for a same-server initialize handshake. User reconnect stays
+ * `auto` so a later modern-capable server is probed again.
  */
 export function reconnectMcpServerOptions<
 	T extends {
@@ -25,12 +41,15 @@ export function reconnectMcpServerOptions<
 	},
 >(
 	existing?: T,
+	mode: McpVersionNegotiationMode = 'auto',
 ): {
-	client: (T['client'] & object) | { versionNegotiation: { mode: 'auto' } }
+	client:
+		| (T['client'] & object)
+		| { versionNegotiation: { mode: 'auto' } | { mode: 'legacy' } }
 	transport: T['transport'] & object
 } {
 	return {
-		client: outboundMcpClientOptions(existing?.client),
+		client: outboundMcpClientOptions(existing?.client, mode),
 		transport: withoutPersistedMcpSession(existing?.transport),
 	}
 }

--- a/packages/worker/src/mcp-client/restore.node.test.ts
+++ b/packages/worker/src/mcp-client/restore.node.test.ts
@@ -99,3 +99,64 @@ test('restore and live session sanitization clears stale 2025 state and keeps fr
 		transport: {},
 	})
 })
+
+test('restore keeps catalog-timeout legacy only for remembered servers', () => {
+	const unmarked = sanitizePersistedMcpServerOptions(
+		{
+			client: { versionNegotiation: { mode: 'legacy' } },
+			transport: { type: 'auto' },
+		},
+		{
+			serverId: 'feeds',
+			keepLegacyHandshakeIds: new Set(['analytics']),
+		},
+	)
+	expect(unmarked.client).toEqual({
+		versionNegotiation: { mode: 'auto' },
+	})
+
+	const marked = sanitizePersistedMcpServerOptions(
+		{
+			client: { versionNegotiation: { mode: 'legacy' } },
+			transport: { type: 'auto' },
+		},
+		{
+			serverId: 'analytics',
+			keepLegacyHandshakeIds: new Set(['analytics']),
+		},
+	)
+	expect(marked.client).toEqual({
+		versionNegotiation: { mode: 'legacy' },
+	})
+
+	const updates: Array<{ id: string; options: string }> = []
+	sanitizeStoredMcpSessions(
+		{
+			sql: {
+				exec(query: string, ...bindings: Array<unknown>) {
+					if (query.startsWith('SELECT')) {
+						return [
+							{
+								id: 'analytics',
+								server_options: JSON.stringify({
+									client: { versionNegotiation: { mode: 'legacy' } },
+									transport: { sessionId: 'stale-2025-session' },
+								}),
+							},
+						]
+					}
+					updates.push({
+						id: String(bindings[1]),
+						options: String(bindings[0]),
+					})
+					return []
+				},
+			},
+		},
+		{ keepLegacyHandshakeIds: new Set(['analytics']) },
+	)
+	expect(JSON.parse(updates[0]?.options ?? '{}')).toEqual({
+		client: { versionNegotiation: { mode: 'legacy' } },
+		transport: {},
+	})
+})

--- a/packages/worker/src/mcp-client/restore.ts
+++ b/packages/worker/src/mcp-client/restore.ts
@@ -3,6 +3,7 @@ import {
 	classifyPersistedMcpSession,
 	shouldPersistLegacyMcpSession,
 } from './probe-outcome.ts'
+import { shouldKeepPersistedLegacyHandshake } from './legacy-handshake.ts'
 import { outboundMcpClientOptions } from './reconnect.ts'
 import {
 	isFreshModernDiscoverResult,
@@ -13,6 +14,10 @@ import {
 
 export function sanitizePersistedMcpServerOptions(
 	options: PersistedMcpServerOptions,
+	input?: {
+		serverId?: string
+		keepLegacyHandshakeIds?: ReadonlySet<string>
+	},
 ): PersistedMcpServerOptions {
 	const discoverResult = isFreshModernDiscoverResult(options.discoverResult)
 		? options.discoverResult
@@ -20,6 +25,12 @@ export function sanitizePersistedMcpServerOptions(
 	const keepLegacySession = shouldPersistLegacyMcpSession(
 		classifyPersistedMcpSession(options),
 	)
+	const keepCatalogTimeoutLegacy =
+		input?.serverId != null &&
+		shouldKeepPersistedLegacyHandshake({
+			serverId: input.serverId,
+			keepLegacyHandshakeIds: input.keepLegacyHandshakeIds,
+		})
 	const transport = withoutPersistedMcpSession(options.transport, {
 		keepModernProtocolVersion: discoverResult !== undefined,
 	})
@@ -31,7 +42,10 @@ export function sanitizePersistedMcpServerOptions(
 	}
 	const next: PersistedMcpServerOptions = {
 		...options,
-		client: outboundMcpClientOptions(options.client),
+		client: outboundMcpClientOptions(
+			options.client,
+			keepCatalogTimeoutLegacy ? 'legacy' : 'auto',
+		),
 		transport,
 	}
 	if (discoverResult !== undefined) {
@@ -66,9 +80,12 @@ export function parsePersistedMcpServerOptions(
  * `restoreConnectionsFromStorage`. A stored 2025-11-25 session skips the
  * modern probe and DELETEs on close against modern-only servers.
  */
-export function sanitizeStoredMcpSessions(storage: {
-	sql: { exec: (query: string, ...bindings: Array<unknown>) => unknown }
-}) {
+export function sanitizeStoredMcpSessions(
+	storage: {
+		sql: { exec: (query: string, ...bindings: Array<unknown>) => unknown }
+	},
+	input?: { keepLegacyHandshakeIds?: ReadonlySet<string> },
+) {
 	const rows = [
 		...asRows(
 			storage.sql.exec('SELECT id, server_options FROM cf_agents_mcp_servers'),
@@ -77,7 +94,10 @@ export function sanitizeStoredMcpSessions(storage: {
 	for (const row of rows) {
 		const parsed = parsePersistedMcpServerOptions(row.server_options)
 		if (!parsed) continue
-		const sanitized = sanitizePersistedMcpServerOptions(parsed)
+		const sanitized = sanitizePersistedMcpServerOptions(parsed, {
+			serverId: row.id,
+			keepLegacyHandshakeIds: input?.keepLegacyHandshakeIds,
+		})
 		if (JSON.stringify(sanitized) === JSON.stringify(parsed)) continue
 		storage.sql.exec(
 			'UPDATE cf_agents_mcp_servers SET server_options = ? WHERE id = ?',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Remote MCP servers that negotiate the modern Client 2.0 dialect but never finish tool catalog should still become usable, without a hostname allowlist.

## Why

After MCP OAuth (and Bearer), some remotes reach Agents state `connected` and then hang in `discoverIfConnected` (~15s). Users see Status “Tool discovery didn't finish” / phase `server/discover` (#2157). One report is PostHog (`https://mcp.posthog.com/mcp`). That is a dialect/handshake class of failure: modern `server/discover` can succeed, then catalog (`tools/list` / resources / prompts) never completes. Other clients have been special-cased onto the 2025 `initialize` path for the same class of bug. Kody should handle that generally.

Adam’s post-#2157 correlation id `69c1bd6e-7ee1-48f9-8693-123f1a7c2898` is a `lastError.attemptId` (D1 `mcp_server_settings.last_error` and Status `id …`). Connection episodes do **not** store it. Pre-this-PR, a catalog hang that Agents reverted to `connected` was tagged `server/discover`. Grep worker logs for that id on `mcp discover timeout incomplete`, `mcp discover retrying legacy handshake`, and `mcp oauth callback settle incomplete`. This PR does not pin `mcp.posthog.com`.

## Summary

- Keep first-connect / user reconnect on `versionNegotiation: { mode: 'auto' }`.
- If auto reaches `connected` or `discovering` but catalog does not become `ready`, re-register the **same** server with `mode: 'legacy'` (preserve OAuth tokens and bearer headers) and retry connect + discover.
- Remember a catalog-timeout fallback in hub DO storage when that retry reaches `ready` **or** parks on OAuth `authenticating` (and again if OAuth discovery later reaches ready on a legacy client) so restore keeps `legacy`. User reconnect or replacing the server via `addServer` forgets the mark and probes `auto` again.
- After a catalog attempt, stamp `lastError.phase` as `tools/list` even when Agents reverts to `connected` (no longer collapsed into `server/discover`).
- If the legacy retry never reaches `connected`, keep the catalog `lastError` so Status is not silent. A later add/reconnect starts from a clean stamp so a real connect failure is not overwritten.
- Catalog-timeout fallback logs a sanitized MCP endpoint and the same `attemptId` as the catalog lastError.
- Tests: healthy servers stay on `auto`; a simulated modern-connect-then-catalog-timeout server falls back to legacy and can reach `ready`; replacement forgets the mark; later failed add does not keep a stale catalog lastError; OAuth-parked fallback remembers the mark. No PostHog hostname allowlist.

## Testing

- Focused node-unit suites for handshake / hub / restore / outbound-era (green).
- Pre-push `test:node` (2892) and `test:workers` (341) green on `d2afa312`.
- Full `npm run validate` green on the first commit; re-running on this head.
- Preview: signed in as seed user, added `handshake-probe` (`https://example.com/mcp`), list/detail Status showed Connection failed, then deleted the probe.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `f21c63f9` · **Head:** `d2afa312`

**Classification:** extends — outbound MCP client handshake now retries the 2025 initialize dialect when modern negotiation connects but catalog never becomes ready.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `mcp-client-servers` | assistant | extends — same-server legacy handshake retry after catalog timeout, remembered fallback for restore including OAuth-parked retries, forgotten on reconnect or addServer replacement, `tools/list` phase after catalog attempt, catalog lastError kept if the retry cannot connect, attemptId threaded through retry logs |

### Change flow

Add, reconnect, refresh, and OAuth settle still start on `auto`. A catalog timeout on the same server now retries `legacy` before writing durable `lastError`.

```mermaid
sequenceDiagram
	actor User
	participant appUi as app-ui
	participant mcpClientServers as mcp-client-servers
	User->>appUi: add or authorize remote MCP server
	appUi->>mcpClientServers: addServer or handleOAuthCallback
	mcpClientServers->>mcpClientServers: connect with versionNegotiation auto
	alt catalog reaches ready
		mcpClientServers-->>appUi: state ready, no lastError
	else connected or discovering after catalog timeout
		mcpClientServers->>mcpClientServers: re-register same server with mode legacy
		alt legacy catalog reaches ready
			mcpClientServers->>mcpClientServers: remember catalog-timeout fallback
			mcpClientServers-->>appUi: state ready
		else legacy parks on OAuth
			mcpClientServers->>mcpClientServers: remember catalog-timeout fallback
			mcpClientServers-->>appUi: authenticating authUrl
		else retry does not connect
			mcpClientServers-->>appUi: keep catalog lastError phase tools/list
		end
	end
```

### Before / after

| Path | Before | After |
| --- | --- | --- |
| Healthy modern or 2025-era server | `auto` (unchanged) | `auto` (unchanged) |
| Modern connect, catalog hangs | `connected` + `lastError` phase `server/discover` | retry `legacy` on the same server, then `ready` or `tools/list` |
| User reconnect or addServer replace | always `auto` | still `auto` first, forgets remembered fallback |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d95f75e-0885-4e9d-b2a3-e92f1f16f6a2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d95f75e-0885-4e9d-b2a3-e92f1f16f6a2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved MCP server connection reliability by retrying with a compatible handshake when tool discovery times out.
  - Successful fallback settings are remembered across restores, while manual reconnects and server replacements retry normal negotiation.
  - OAuth-based connections now retry discovery after authentication and report more accurate timeout stages.
  - Timeout errors now identify whether failure occurred during server discovery or tool listing.

- **Documentation**
  - Clarified MCP timeout behavior and documented reconnection from the server status page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->