### PR TITLE
fix: send package-app handoff visitors to the package page

### DIFF
--- a/packages/shared/src/public-urls.node.test.ts
+++ b/packages/shared/src/public-urls.node.test.ts
@@ -1,0 +1,28 @@
+import { expect, test } from 'vitest'
+import {
+	buildPackageAppPath,
+	buildPackageAppSubdomainPath,
+	buildPackagePagePath,
+} from './public-urls.ts'
+
+test('saved-package pages and hosted package-app mounts use different paths', () => {
+	expect(
+		buildPackagePagePath({ username: 'kentcdodds', kodyId: 'hn-pulse' }),
+	).toBe('/@kentcdodds/hn-pulse')
+	expect(
+		buildPackageAppPath({ username: 'kentcdodds', kodyId: 'hn-pulse' }),
+	).toBe('/@kentcdodds/packages/hn-pulse')
+	expect(
+		buildPackageAppPath({
+			username: 'kentcdodds',
+			kodyId: 'hn-pulse',
+			restPath: '/report',
+		}),
+	).toBe('/@kentcdodds/packages/hn-pulse/report')
+	expect(buildPackageAppSubdomainPath({ kodyId: 'hn-pulse' })).toBe(
+		'/packages/hn-pulse',
+	)
+	expect(
+		buildPackageAppSubdomainPath({ kodyId: 'hn-pulse', restPath: '/report' }),
+	).toBe('/packages/hn-pulse/report')
+})

--- a/packages/shared/src/public-urls.ts
+++ b/packages/shared/src/public-urls.ts
@@ -7,6 +7,20 @@ function buildRestPathSuffix(restPath: string | null | undefined) {
 	return trimmed ? `/${trimmed.replace(/^\/+/, '')}` : ''
 }
 
+/**
+ * Canonical saved-package page on the app origin: `/@{username}/{kodyId}`.
+ * Distinct from the hosted package-app mount, which needs a `/packages/`
+ * segment so it does not steal this two-segment public page.
+ */
+export function buildPackagePagePath(input: {
+	username: string
+	kodyId: string
+}) {
+	return `${buildUsernamePathPrefix(input.username)}/${encodeURIComponent(
+		input.kodyId.trim(),
+	)}`
+}
+
 export function buildPackageAppPath(input: {
 	username: string
 	kodyId: string

--- a/packages/worker/src/app/package-app-origin.ts
+++ b/packages/worker/src/app/package-app-origin.ts
@@ -3,12 +3,14 @@ import { createHtmlResponse } from 'remix/response/html'
 import {
 	buildPackageAppPath,
 	buildPackageAppSubdomainUrl,
+	buildPackagePagePath,
 } from '@kody-internal/shared/public-urls.ts'
 import {
 	getAppBaseUrl,
 	getPackageAppBaseUrl,
 	getPackageAppLegacySubdomainRedirect,
 	getPackageAppOriginConfigurationError,
+	joinAppUrl,
 	parsePackageAppRequestHost,
 } from '#worker/app-base-url.ts'
 import { redirectToLoginWhenUnauthenticated } from '#app/auth-redirect.ts'
@@ -252,7 +254,21 @@ async function redirectAppOriginToPackageAppOrigin(input: {
 	const user = await readAuthenticatedAppUser(request, env)
 	if (!user) return await redirectToLoginWhenUnauthenticated(request, env)
 	if (user.username !== packagePath.username) {
-		return new Response('Saved package app not found.', { status: 404 })
+		// `/@{username}/packages/{kodyId}` is the owner-only handoff mount.
+		// Everyone else belongs on the saved-package page, which is the
+		// two-segment `/@{username}/{kodyId}` route — not a 404 that reads
+		// like the package itself is missing.
+		return redirectResponse({
+			location: joinAppUrl({
+				env,
+				path: buildPackagePagePath({
+					username: packagePath.username,
+					kodyId: packagePath.kodyId,
+				}),
+				requestUrl: request.url,
+			}),
+			status: 302,
+		})
 	}
 
 	const parsedSession = await readParsedAuthSession(request)

--- a/packages/worker/src/app/package-app-origin.workers.test.ts
+++ b/packages/worker/src/app/package-app-origin.workers.test.ts
@@ -347,6 +347,17 @@ test('hosted package apps move to the owner subdomain behind a single-use handof
 	expect(
 		new URL(appOriginWithPackageCookie.headers.get('Location') ?? '').pathname,
 	).toBe('/login')
+
+	// 13. A signed-in visitor on the owner-only handoff mount is sent to the
+	// saved-package page (`/@{username}/{kodyId}`), not a "not found" 404.
+	const visitorOnHandoffMount = await workerFetch(
+		`${appOrigin}/@other-user/packages/demo/report`,
+		{ headers: { Cookie: sessionCookie } },
+	)
+	expect(visitorOnHandoffMount.status).toBe(302)
+	expect(visitorOnHandoffMount.headers.get('Location')).toBe(
+		`${appOrigin}/@other-user/demo`,
+	)
 })
 
 test('package apps stay inline on the app origin when no package-app origin is configured', async () => {

--- a/packages/worker/src/user-namespace-routes.node.test.ts
+++ b/packages/worker/src/user-namespace-routes.node.test.ts
@@ -1,9 +1,13 @@
 import { expect, test } from 'vitest'
+import { createMatcher } from 'remix/route-pattern/match'
+import { routes } from '#universal/routes.ts'
 import { parsePackageAppPath } from '#worker/package-runtime/package-app-serve.ts'
 import {
 	isNamespacedAppEndpointPath,
 	isNamespacedPackageInvocationEndpointPath,
 } from './user-namespace-routes.ts'
+
+const communityPackageMatcher = createMatcher(routes.communityPackage.pattern)
 
 test('machine namespaces claim only their multi-segment paths', () => {
 	expect(isNamespacedAppEndpointPath('/@kody/packages/devin')).toBe(true)
@@ -36,4 +40,22 @@ test('machine namespaces claim only their multi-segment paths', () => {
 		expect(isNamespacedPackageInvocationEndpointPath(pathname)).toBe(false)
 		expect(parsePackageAppPath(pathname)).toBeNull()
 	}
+
+	expect(parsePackageAppPath('/@kody/packages/devin')).toEqual({
+		username: 'kody',
+		kodyId: 'devin',
+		restPath: '/',
+		mount: 'username-path',
+	})
+	expect(parsePackageAppPath('/@kody/devin')).toBeNull()
+
+	expect(
+		communityPackageMatcher.match(new URL('https://example.com/@kody/devin'))
+			?.params,
+	).toEqual({ username: 'kody', kodyId: 'devin' })
+	expect(
+		communityPackageMatcher.match(
+			new URL('https://example.com/@kody/packages/devin'),
+		),
+	).toBeNull()
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop the hosted package-app “Continue to this app” path from showing **Saved package app not found.** when the signed-in user is not the package owner.

## Why

The interstitial Continue link goes to `/@{username}/packages/{kodyId}` on the app origin. That path is the **owner-only handoff mount** (login, mint token, send the owner to `{username}.kody.run/packages/{kodyId}`).

Kent’s hypothesis that the correct path is `/@{username}/{packageName}` is half-right: that two-segment URL is the **saved-package page** (Remix `communityPackage`), and it is the URL that resolves for everyone else. It is **not** the hosted app mount. Removing `/packages/` from the handoff URL would steal the package page and break owner session handoff (and drop in-app `restPath`).

Production check: `/@kody/hn-pulse` is 200 (package page); `/@kody/packages/hn-pulse` is the handoff entry (login when logged out); `https://kody.kody.run/hn-pulse` 404s; `https://kody.kody.run/packages/hn-pulse` is the hosted app interstitial.

The exact short 404 **Saved package app not found.** was the username-mismatch guard on the handoff mount. A signed-in visitor (for example Kent opening a `@kody` app) hit that 404. They belong on `/@{username}/{kodyId}`.

`docs/use/package-app-fetch.md` and `docs/use/packages.md` already document the hosted `/packages/<kody-id>` mount correctly, so they were left alone.

## Summary

- Keep Continue / owner handoff on `/@{username}/packages/{kodyId}` so login and in-app paths still work.
- When the signed-in user is not the owner, 302 to `/@{username}/{kodyId}` instead of 404.
- Add `buildPackagePagePath` and tests that the package page and package-app mount stay distinct.

## Testing

- `npx vitest run --project node-unit` on `public-urls` and `user-namespace-routes`
- `npx vitest run --project workers-unit` on `package-app-origin.workers.test.ts`
- Pre-push: full `test:node` (2934) and `test:workers` (341)
- Production curls of package page vs handoff vs hosted paths (see Why)

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `f1793d8a` · **Head:** `6e7963c7`

**Classification:** extends — the app-origin package-app handoff mount still starts owner handoff, but a signed-in visitor is redirected to the saved-package page instead of a 404.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | extends — non-owner `/@{username}/packages/{kodyId}` is now a 302 to `/@{username}/{kodyId}` |

Unmatched paths: `packages/shared/src/public-urls.ts` (page vs mount URL builders) and the route-match tests in `user-namespace-routes.node.test.ts`.

### Change flow

A signed-in visitor who follows Continue (or any bookmark of the handoff mount) is sent to the public package page. The owner path is unchanged.

```mermaid
sequenceDiagram
	actor Visitor
	participant appUi as app-ui
	Visitor->>appUi: GET /@owner/packages/kodyId (app origin, signed in as someone else)
	appUi-->>Visitor: 302 /@owner/kodyId
	Note over appUi: owner still gets login or handoff token
```

### Before / after

| Who | Before | After |
| --- | --- | --- |
| Owner, signed in | 302 handoff to `{user}.kody.run/packages/{id}` | unchanged |
| Visitor, signed in | 404 `Saved package app not found.` | 302 `/@{username}/{kodyId}` |
| Anyone, signed out | 302 `/login?redirectTo=.../packages/...` | unchanged |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-851a16c3-7b84-4898-b2fa-526b593e5eae?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-851a16c3-7b84-4898-b2fa-526b593e5eae&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added canonical public package page URLs using the `/{username}/{package}` format.
  * Visiting another user’s path-based package-app handoff now redirects to the corresponding saved-package page.

* **Bug Fixes**
  * Corrected routing so public package pages and hosted package apps resolve to distinct paths.

* **Tests**
  * Added coverage for URL construction, route matching, path parsing, and redirect behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->