### PR TITLE
Filter chrome-extension M_ID TypeError Sentry noise (KODY-74)

### DIFF
--- a/packages/worker/client/sentry-browser-filters.node.test.ts
+++ b/packages/worker/client/sentry-browser-filters.node.test.ts
@@ -488,6 +488,123 @@ test('browser Sentry filters drop AbortError and Firefox Xray noise and keep rea
 			exception: {
 				values: [
 					{
+						type: 'TypeError',
+						value: "Cannot read properties of undefined (reading 'M_ID')",
+						stacktrace: {
+							frames: [
+								{
+									function: 'E',
+									filename:
+										'chrome-extension://eppiocemhmnlbhjplcgkofciiegomcon/executors/200.js',
+								},
+								{
+									function: 'Y',
+									abs_path:
+										'chrome-extension://eppiocemhmnlbhjplcgkofciiegomcon/executors/200.js',
+								},
+							],
+						},
+					},
+				],
+			},
+		}),
+	).toBeNull()
+	expect(
+		filterBrowserSentryEvent(
+			{
+				exception: {
+					values: [
+						{
+							type: 'TypeError',
+							value: "Cannot read property 'M_ID' of undefined",
+							stacktrace: {
+								frames: [
+									{
+										function: 'E',
+										filename: 'chrome-extension://abcd/executors/200.js',
+									},
+								],
+							},
+						},
+					],
+				},
+			},
+			new TypeError("Cannot read property 'M_ID' of undefined"),
+		),
+	).toBeNull()
+	expect(
+		filterBrowserSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'TypeError',
+						value: "Cannot read properties of undefined (reading 'M_ID')",
+						stacktrace: {
+							frames: [
+								{
+									function: 'readSession',
+									filename: 'https://kody.codes/assets/entry.js',
+								},
+							],
+						},
+					},
+				],
+			},
+		}),
+	).not.toBeNull()
+	expect(
+		filterBrowserSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'TypeError',
+						value:
+							"TypeError: Cannot read properties of undefined (reading 'M_ID')",
+						stacktrace: {
+							frames: [
+								{
+									function: 'Y',
+									filename:
+										'chrome-extension://eppiocemhmnlbhjplcgkofciiegomcon/executors/200.js',
+								},
+								{
+									function: 'boot',
+									filename: 'https://kody.codes/assets/entry.js',
+								},
+							],
+						},
+					},
+				],
+			},
+		}),
+	).not.toBeNull()
+	expect(
+		filterBrowserSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'TypeError',
+						value: "Cannot read properties of undefined (reading 'url')",
+						stacktrace: {
+							frames: [
+								{
+									function: 'Y',
+									filename:
+										'chrome-extension://eppiocemhmnlbhjplcgkofciiegomcon/executors/200.js',
+								},
+							],
+						},
+					},
+				],
+			},
+		}),
+	).not.toBeNull()
+
+	expect(
+		filterBrowserSentryEvent({
+			exception: {
+				values: [
+					{
 						type: 'ReferenceError',
 						value: 'CONFIG is not defined',
 						stacktrace: {

--- a/packages/worker/client/sentry-browser-filters.node.test.ts
+++ b/packages/worker/client/sentry-browser-filters.node.test.ts
@@ -584,6 +584,30 @@ test('browser Sentry filters drop AbortError and Firefox Xray noise and keep rea
 				values: [
 					{
 						type: 'TypeError',
+						value: "Cannot read properties of undefined (reading 'M_ID')",
+						stacktrace: {
+							frames: [
+								{
+									function: 'Y',
+									filename:
+										'chrome-extension://eppiocemhmnlbhjplcgkofciiegomcon/executors/200.js',
+								},
+								{
+									function: 'boot',
+								},
+							],
+						},
+					},
+				],
+			},
+		}),
+	).not.toBeNull()
+	expect(
+		filterBrowserSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'TypeError',
 						value: "Cannot read properties of undefined (reading 'url')",
 						stacktrace: {
 							frames: [

--- a/packages/worker/client/sentry-browser-filters.ts
+++ b/packages/worker/client/sentry-browser-filters.ts
@@ -700,6 +700,69 @@ function filterChromeExtensionCallStackExceededSentryEvent<
 }
 
 /**
+ * Chrome extensions that inject page-context executors sometimes throw a
+ * minified TypeError reading `M_ID` on an undefined object. Sentry's generic
+ * handler captures it on the host page, but every real frame is
+ * `chrome-extension://…/executors/…`. Signature from production issue
+ * 7717003182 / KODY-74 on `/` (`Cannot read properties of undefined (reading
+ * 'M_ID')`). Kody never references `M_ID`.
+ *
+ * Match is intentionally narrow: this exact Chromium TypeError wording
+ * (optional `TypeError:` preface; older "property 'M_ID' of undefined" form)
+ * AND every reported stack frame URL is `chrome-extension:` (anonymous /
+ * native frames allowed). Never blanket-drop undefined-property TypeErrors
+ * from app code or mixed stacks that include first-party frames.
+ */
+const chromeExtensionUndefinedMIdMessage =
+	/^(?:TypeError:\s*)?(?:Cannot read properties of undefined \(reading ['"]M_ID['"]\)|Cannot read property ['"]M_ID['"] of undefined)\.?$/
+
+function isChromeExtensionUndefinedMIdMessage(message: string) {
+	return chromeExtensionUndefinedMIdMessage.test(message.trim())
+}
+
+function isChromeExtensionUndefinedMIdError(error: unknown) {
+	if (typeof error === 'string') {
+		return isChromeExtensionUndefinedMIdMessage(error)
+	}
+	if (typeof error !== 'object' || error === null) return false
+	if (!('message' in error) || typeof error.message !== 'string') return false
+	return isChromeExtensionUndefinedMIdMessage(error.message)
+}
+
+function isChromeExtensionUndefinedMIdSentryEvent(
+	event: SentryErrorEventLike,
+	originalException?: unknown,
+) {
+	const hasMIdMessage =
+		isChromeExtensionUndefinedMIdError(originalException) ||
+		event.exception?.values?.some(
+			(value) =>
+				value.type === 'TypeError' &&
+				typeof value.value === 'string' &&
+				isChromeExtensionUndefinedMIdMessage(value.value),
+		) ||
+		sentryEventMessages(event).some(
+			(message) =>
+				typeof message === 'string' &&
+				isChromeExtensionUndefinedMIdMessage(message),
+		)
+	if (!hasMIdMessage) return false
+	const frameUrls = sentryEventStackFrameUrls(event)
+	if (frameUrls.length === 0) return false
+	if (!frameUrls.some(isChromeExtensionStackFrameUrl)) return false
+	return frameUrls.every(isChromeExtensionOrAnonymousStackFrameUrl)
+}
+
+function filterChromeExtensionUndefinedMIdSentryEvent<
+	T extends SentryErrorEventLike,
+>(event: T, originalException?: unknown): T | null {
+	if (isChromeExtensionUndefinedMIdSentryEvent(event, originalException)) {
+		return null
+	}
+	return event
+}
+
+/**
  * Twitter/X iOS in-app browser chrome (`updateFooterPositions` /
  * `updateGapFiller`) references a host-page `CONFIG` global that Kody never
  * defines. WebKit reports it as an unhandled `ReferenceError` attributed to
@@ -1228,6 +1291,12 @@ export function filterBrowserSentryEvent<T extends SentryErrorEventLike>(
 			event,
 			originalException,
 		) === null
+	) {
+		return null
+	}
+	if (
+		filterChromeExtensionUndefinedMIdSentryEvent(event, originalException) ===
+		null
 	) {
 		return null
 	}

--- a/packages/worker/client/sentry-browser-filters.ts
+++ b/packages/worker/client/sentry-browser-filters.ts
@@ -38,16 +38,30 @@ function sentryEventMessages(event: SentryErrorEventLike) {
 	]
 }
 
-function sentryEventStackFrameUrls(event: SentryErrorEventLike) {
-	const urls: Array<string> = []
+function sentryEventStackFrames(event: SentryErrorEventLike) {
+	const frames: Array<SentryStackFrame> = []
 	for (const value of event.exception?.values ?? []) {
 		for (const frame of value.stacktrace?.frames ?? []) {
-			for (const candidate of [frame.abs_path, frame.absPath, frame.filename]) {
-				if (typeof candidate === 'string' && candidate.length > 0) {
-					urls.push(candidate)
-				}
-			}
+			frames.push(frame)
 		}
+	}
+	return frames
+}
+
+function stackFrameUrls(frame: SentryStackFrame) {
+	const urls: Array<string> = []
+	for (const candidate of [frame.abs_path, frame.absPath, frame.filename]) {
+		if (typeof candidate === 'string' && candidate.length > 0) {
+			urls.push(candidate)
+		}
+	}
+	return urls
+}
+
+function sentryEventStackFrameUrls(event: SentryErrorEventLike) {
+	const urls: Array<string> = []
+	for (const frame of sentryEventStackFrames(event)) {
+		urls.push(...stackFrameUrls(frame))
 	}
 	return urls
 }
@@ -747,10 +761,27 @@ function isChromeExtensionUndefinedMIdSentryEvent(
 				isChromeExtensionUndefinedMIdMessage(message),
 		)
 	if (!hasMIdMessage) return false
-	const frameUrls = sentryEventStackFrameUrls(event)
-	if (frameUrls.length === 0) return false
-	if (!frameUrls.some(isChromeExtensionStackFrameUrl)) return false
-	return frameUrls.every(isChromeExtensionOrAnonymousStackFrameUrl)
+	return isChromeExtensionOnlyReportedStack(event)
+}
+
+/**
+ * Drop-safe only when every reported frame is present and is either
+ * `chrome-extension:` or an explicit anonymous/native marker. A URL-less
+ * frame is treated as unknown (possibly first-party) and keeps the event.
+ */
+function isChromeExtensionOnlyReportedStack(event: SentryErrorEventLike) {
+	const frames = sentryEventStackFrames(event)
+	if (frames.length === 0) return false
+	let hasChromeExtension = false
+	for (const frame of frames) {
+		const urls = stackFrameUrls(frame)
+		if (urls.length === 0) return false
+		if (!urls.every(isChromeExtensionOrAnonymousStackFrameUrl)) return false
+		if (urls.some(isChromeExtensionStackFrameUrl)) {
+			hasChromeExtension = true
+		}
+	}
+	return hasChromeExtension
 }
 
 function filterChromeExtensionUndefinedMIdSentryEvent<

--- a/packages/worker/client/sentry-init.ts
+++ b/packages/worker/client/sentry-init.ts
@@ -37,7 +37,9 @@ export function initBrowserSentry(config: SentryClientConfig) {
 		// found", MetaMask inpage connect failures, MetaMask plain-object
 		// "wallet must has at least one account" rejections, Chrome
 		// extension "Client has been destroyed" with exclusively
-		// chrome-extension frames, Twitter/X in-app browser chrome `CONFIG`
+		// chrome-extension frames, Chrome extension TypeError reading
+		// `M_ID` with exclusively chrome-extension frames, Twitter/X in-app
+		// browser chrome `CONFIG`
 		// ReferenceErrors / `sendScrollEvent`→ `window.webkit.messageHandlers`
 		// TypeErrors, injected unguarded `meta[property='og:type']` probes
 		// from `global code`, and optional Shiki `syntax-highlight-core`
@@ -51,7 +53,8 @@ export function initBrowserSentry(config: SentryClientConfig) {
 		// KODY-CLOUDFLARE-64 / KODY-6Z /
 		// issues 7639685398, 7648833360, 7648833403, 7653117289, 7655189301,
 		// 7658961865, 7659616372, 7660258027, 7662064169, 7677729361,
-		// 7682968915, 7687920474, 7689579030, 7690163947, 7696001937.
+		// 7682968915, 7687920474, 7689579030, 7690163947, 7696001937,
+		// 7717003182.
 		beforeSend(event, hint) {
 			return filterBrowserSentryEvent(event, hint.originalException)
 		},


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop a visitor Chrome extension from opening production Sentry issues on `kody.codes` when its page-context executor throws a minified `TypeError` reading `M_ID`.

## Why

[KODY-74](https://kent-c-dodds-tech-llc.sentry.io/issues/7717003182/) is a handled browser `TypeError: Cannot read properties of undefined (reading 'M_ID')` whose stack is exclusively `chrome-extension://…/executors/200.js`. Kody never references `M_ID`. Existing browser filters only drop other extension signatures (MetaMask, client-destroyed, call-stack overflow, IPC wording), so this one still reached Sentry.

This is not reasonably fixable in app code. The repo idiom is a targeted client `beforeSend` filter.

## Summary

- Drop Chromium `M_ID` undefined-property TypeErrors when every reported frame is `chrome-extension:` (anonymous/native frames allowed).
- Keep the same message when any first-party, `http(s)`, or URL-less frame is present, and keep other chrome-extension TypeErrors.
- Cover the drop and keep cases in the existing composed browser-filter suite.

## Testing

- `npx vitest run packages/worker/client/sentry-browser-filters.node.test.ts`
- `npm run test:node` and `npm run test:workers` (pre-push)
- `npm run validate` (local, first revision)

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `f1793d8a` · **Head:** `8aaa60ed`

**Classification:** composes — no primitives added or changed; this PR adds a narrow `beforeSend` drop in the existing browser Sentry gate.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `app-ui` | surfaces | composes — browser Sentry filter only |

### Change flow

A visitor Chrome extension throws on the homepage; the client SDK now drops that signature before the envelope leaves the browser.

```mermaid
sequenceDiagram
	actor Visitor
	participant appUi as app-ui
	Visitor->>appUi: extension executor throws TypeError reading M_ID
	appUi->>appUi: beforeSend filterBrowserSentryEvent
	Note over appUi: drop when wording matches and every reported frame is chrome-extension
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c0cbeb7b-199e-4fa1-bafc-a476f720a64f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c0cbeb7b-199e-4fa1-bafc-a476f720a64f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved browser error reporting by filtering a known Chrome extension error from Sentry data.
  - Application errors, unrelated extension errors, production-code errors, and ambiguous stack traces continue to be reported normally.
  - Added coverage for current and legacy error message formats across event and original-error reporting paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->