### PR TITLE
Tighten homepage testimonials and add Early Kody users post

### DIFF
--- a/packages/worker/client/markdown-view.node.test.ts
+++ b/packages/worker/client/markdown-view.node.test.ts
@@ -154,6 +154,22 @@ test('first-party render options keep authored heading levels and drop the ugc r
 	expect(thirdParty).toContain('rel="noopener noreferrer nofollow ugc"')
 })
 
+test('first-party headingIds emit unique kebab-case heading ids', async () => {
+	const html = await renderToString(
+		jsx('div', {
+			children: renderMarkdownNodes(
+				['## Josh Tomaino', '', '## Josh Tomaino', '', '## Jett Hays'].join(
+					'\n',
+				),
+				{ headingOffset: 0, headingIds: true },
+			),
+		}),
+	)
+	expect(html).toContain('<h2 id="josh-tomaino">Josh Tomaino</h2>')
+	expect(html).toContain('<h2 id="josh-tomaino-2">Josh Tomaino</h2>')
+	expect(html).toContain('<h2 id="jett-hays">Jett Hays</h2>')
+})
+
 test('getSafeMarkdownLinkHref allowlists protocols and blocks user-scope paths', () => {
 	expect(getSafeMarkdownLinkHref('https://example.com/a')).toBe(
 		'https://example.com/a',

--- a/packages/worker/client/markdown-view.tsx
+++ b/packages/worker/client/markdown-view.tsx
@@ -79,11 +79,18 @@ export type RenderMarkdownOptions = {
 	 * `code` tokens. Missing or mismatched entries fall back to plaintext.
 	 */
 	fences?: Array<HighlightedCode>
+	/**
+	 * When true, headings get kebab-case `id` attributes (unique within one
+	 * render) so first-party posts can deep-link to a section. Off by default
+	 * so third-party READMEs do not grow extra attributes.
+	 */
+	headingIds?: boolean
 }
 
 type ResolvedRenderOptions = Required<Omit<RenderMarkdownOptions, 'fences'>> & {
 	fences: Array<HighlightedCode>
 	fenceCursor: { index: number }
+	headingSlugCounts: Map<string, number>
 }
 
 const defaultRenderOptions = {
@@ -91,6 +98,7 @@ const defaultRenderOptions = {
 	linkRel: 'noopener noreferrer nofollow ugc',
 	linkPolicy: 'untrusted' as const,
 	copyCodeBlocks: false,
+	headingIds: false,
 	fences: [] as Array<HighlightedCode>,
 }
 
@@ -173,6 +181,23 @@ function resolveMarkdownLink(
 	const safeHref = getSafeMarkdownLinkHref(href)
 	if (!safeHref) return null
 	return { href: safeHref, external: true }
+}
+
+function slugifyMarkdownHeading(text: string): string {
+	return text
+		.normalize('NFKD')
+		.replace(/[\u0300-\u036f]/g, '')
+		.toLowerCase()
+		.replace(/[^\p{L}\p{N}._-]+/gu, '-')
+		.replace(/-+/g, '-')
+		.replace(/^-+|-+$/g, '')
+}
+
+function nextHeadingId(used: Map<string, number>, text: string): string {
+	const base = slugifyMarkdownHeading(text) || 'section'
+	const seen = used.get(base) ?? 0
+	used.set(base, seen + 1)
+	return seen === 0 ? base : `${base}-${seen + 1}`
 }
 
 /** True when raw HTML consists only of comments and whitespace. */
@@ -287,7 +312,18 @@ function renderToken(
 				6,
 			)
 			const Tag = `h${level}` as 'h2' | 'h3' | 'h4' | 'h5' | 'h6'
-			return <Tag key={key}>{renderTokens(token.tokens, options)}</Tag>
+			const children = renderTokens(token.tokens, options)
+			if (!options.headingIds) {
+				return <Tag key={key}>{children}</Tag>
+			}
+			return (
+				<Tag
+					key={key}
+					id={nextHeadingId(options.headingSlugCounts, token.text)}
+				>
+					{children}
+				</Tag>
+			)
 		}
 		case 'paragraph':
 			return <p key={key}>{renderTokens(token.tokens, options)}</p>
@@ -441,6 +477,7 @@ export function renderMarkdownNodes(
 		...options,
 		fences: options?.fences ?? defaultRenderOptions.fences,
 		fenceCursor: { index: 0 },
+		headingSlugCounts: new Map(),
 	})
 }
 

--- a/packages/worker/client/routes/blog-post.tsx
+++ b/packages/worker/client/routes/blog-post.tsx
@@ -122,6 +122,7 @@ export function BlogPostRoute(handle: Handle) {
 			renderedBody = renderMarkdownNodes(body, {
 				headingOffset: 0,
 				linkRel: 'noopener noreferrer',
+				headingIds: true,
 				fences: post?.bodyFences,
 			})
 		}

--- a/packages/worker/client/routes/landing-testimonials-carousel.tsx
+++ b/packages/worker/client/routes/landing-testimonials-carousel.tsx
@@ -5,6 +5,7 @@ import {
 	landingTestimonials,
 	testimonialAttribution,
 	testimonialInitials,
+	testimonialStoryHref,
 	type LandingTestimonial,
 } from '#universal/landing-testimonials.ts'
 import {
@@ -618,6 +619,10 @@ function renderTestimonialCard(item: LandingTestimonial) {
 							<span class="landing-testimonial-title">{attribution}</span>
 						) : null}
 					</span>
+				</a>
+				<a href={testimonialStoryHref(item)} class="landing-testimonial-story">
+					Read the full story
+					<span class="visually-hidden"> from {item.name}</span>
 				</a>
 			</footer>
 		</article>

--- a/packages/worker/public/styles.css
+++ b/packages/worker/public/styles.css
@@ -1659,6 +1659,9 @@ html.is-settled {
 }
 
 .landing-testimonial-person {
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
 	margin: 1.35rem 0 0;
 }
 
@@ -1724,6 +1727,24 @@ html.is-settled {
 .landing-testimonial-title {
 	color: var(--color-text-muted);
 	font-size: 0.92rem;
+}
+
+.landing-testimonial-story {
+	margin-top: 0.75rem;
+	color: var(--color-primary-text);
+	font-size: 0.92rem;
+	font-weight: 550;
+	text-decoration: none;
+	border-radius: var(--radius-md);
+}
+
+.landing-testimonial-story:hover {
+	text-decoration: underline;
+}
+
+.landing-testimonial-story:focus-visible {
+	outline: 2.5px solid var(--color-primary);
+	outline-offset: 3px;
 }
 
 @media (prefers-reduced-motion: no-preference) {

--- a/packages/worker/src/app/handlers/landing-testimonials-ssr.node.test.ts
+++ b/packages/worker/src/app/handlers/landing-testimonials-ssr.node.test.ts
@@ -1,0 +1,110 @@
+import { expect, test } from 'vitest'
+import { setAuthSessionSecret } from '#app/auth-session.ts'
+import { resetDataCacheForTests } from '#app/data-cache.ts'
+import { createBlogPostHandler } from '#app/handlers/blog.tsx'
+import { renderAppPage } from '#app/ssr-render.tsx'
+import { getBlogPost, getReadNextBlogPost } from '#worker/blog/catalog.ts'
+import { createMemoryKv } from '#worker/test-support/auth-provider-harness.ts'
+import { executePreparedD1Batch } from '#worker/test-support/d1-prepared-batch.ts'
+import { testOidcSigningEnv } from '#worker/test-support/oidc-signing-env.ts'
+import {
+	landingTestimonials,
+	landingTestimonialsStorySlug,
+	testimonialStoryHref,
+} from '#universal/landing-testimonials.ts'
+
+const testCookieSecret = 'test-cookie-secret-0123456789abcdef0123456789'
+
+function createAnonymousTestDb() {
+	function createStatement(query: string) {
+		return {
+			query,
+			bind() {
+				return createStatement(query)
+			},
+			async all() {
+				return { results: [], meta: { changes: 0, last_row_id: 0 } }
+			},
+			async first() {
+				return null
+			},
+			async run() {
+				return { meta: { changes: 0, last_row_id: 0 } }
+			},
+		}
+	}
+
+	return {
+		prepare(query: string) {
+			return createStatement(query)
+		},
+		async batch(statements: Array<{ query?: string }>) {
+			return await executePreparedD1Batch(statements)
+		},
+		async exec() {
+			return
+		},
+	} as unknown as D1Database
+}
+
+function createTestEnv() {
+	return {
+		COOKIE_SECRET: testCookieSecret,
+		SECRET_STORE_KEY: 'LOCAL_TEST_SECRET_STORE_KEY_32_CHARS_MINIMUM',
+		...testOidcSigningEnv,
+		APP_DB: createAnonymousTestDb(),
+		BUNDLE_ARTIFACTS_KV: createMemoryKv(),
+		JOB_MANAGER: {},
+		STORAGE_RUNNER: {},
+		PACKAGE_REALTIME_SESSION: {},
+		MCP_CLIENT_HUB: {},
+	} as unknown as Env
+}
+
+test('homepage carousel SSR keeps short quotes and links to the early-users post', async () => {
+	resetDataCacheForTests()
+	setAuthSessionSecret(testCookieSecret)
+	const response = await renderAppPage({
+		request: new Request('https://example.com/'),
+		env: createTestEnv(),
+		loaderData: { signupMode: 'invite' },
+	})
+	expect(response.status).toBe(200)
+	const html = await response.text()
+
+	const josh = landingTestimonials.find(
+		(entry) => entry.name === 'Josh Tomaino',
+	)
+	const jett = landingTestimonials.find((entry) => entry.name === 'Jett Hays')
+	if (!josh || !jett) throw new Error('expected Josh and Jett testimonials')
+
+	expect(html).toContain(josh.quote)
+	expect(html).toContain(jett.quote)
+	expect(html).toContain('Read the full story')
+	expect(html).toContain(`href="${testimonialStoryHref(josh)}"`)
+	expect(html).toContain(`href="${testimonialStoryHref(jett)}"`)
+	expect(html).toContain(`href="/blog/${landingTestimonialsStorySlug}"`)
+})
+
+test('early-users blog post SSR renders approved vignettes and heading anchors', async () => {
+	resetDataCacheForTests()
+	setAuthSessionSecret(testCookieSecret)
+	const post = getBlogPost(landingTestimonialsStorySlug)
+	expect(post).toBeDefined()
+	const env = createTestEnv()
+	const response = await createBlogPostHandler(env).handler({
+		request: new Request(
+			`https://example.com/blog/${landingTestimonialsStorySlug}`,
+		),
+		params: { slug: landingTestimonialsStorySlug },
+	} as never)
+	expect(response.status).toBe(200)
+	const html = await response.text()
+
+	expect(html).toContain('Early Kody users')
+	expect(html).toContain('id="josh-tomaino"')
+	expect(html).toContain('id="jett-hays"')
+	expect(html).toContain('funnels all my tools into one secure MCP')
+	expect(html).toContain("world's most endangered species")
+	expect(getReadNextBlogPost(landingTestimonialsStorySlug)).not.toBeNull()
+})

--- a/packages/worker/src/blog/catalog.node.test.ts
+++ b/packages/worker/src/blog/catalog.node.test.ts
@@ -169,7 +169,9 @@ test('blog catalog enumerates posts with required fields and slug lookup', () =>
 	expect(earlyUsers?.title).toBe('Early Kody users')
 	expect(earlyUsers?.date).toBe('2026-09-08')
 	expect(earlyUsers?.placeholder).toBe(true)
-	const earlyUsersBody = (earlyUsers?.body ?? '').replace(/\s+/g, ' ')
+	const earlyUsersBody = (earlyUsers?.body ?? '')
+		.replaceAll(/^>\s?/gm, '')
+		.replace(/\s+/g, ' ')
 	expect(earlyUsersBody).toContain(
 		'funnels all my tools into one secure MCP I can manage myself',
 	)

--- a/packages/worker/src/blog/catalog.node.test.ts
+++ b/packages/worker/src/blog/catalog.node.test.ts
@@ -165,6 +165,20 @@ test('blog catalog enumerates posts with required fields and slug lookup', () =>
 		expect(getBlogPost(post.slug)).toEqual(post)
 	}
 
+	const earlyUsers = getBlogPost('early-kody-users')
+	expect(earlyUsers?.title).toBe('Early Kody users')
+	expect(earlyUsers?.date).toBe('2026-09-08')
+	expect(earlyUsers?.placeholder).toBe(true)
+	const earlyUsersBody = (earlyUsers?.body ?? '').replace(/\s+/g, ' ')
+	expect(earlyUsersBody).toContain(
+		'funnels all my tools into one secure MCP I can manage myself',
+	)
+	expect(earlyUsersBody).toContain(
+		"life or death for some of the world's most endangered species",
+	)
+	expect(earlyUsersBody).toContain('## Josh Tomaino')
+	expect(earlyUsersBody).toContain('## Jett Hays')
+
 	const comparison = getBlogPost('kody-vs-executor')
 	expect(comparison?.title).toBe('Kody vs Executor?')
 	expect(comparison?.date).toBe('2026-08-20')

--- a/packages/worker/src/blog/catalog.ts
+++ b/packages/worker/src/blog/catalog.ts
@@ -1,4 +1,5 @@
 import { parseBlogPostMarkdown, type BlogPost } from './parse-frontmatter.ts'
+import earlyKodyUsers from './posts/early-kody-users.md'
 import everyInstallIsAForkYouOwn from './posts/every-install-is-a-fork-you-own.md'
 import gatewaysConnectHomesAccumulate from './posts/gateways-connect-homes-accumulate.md'
 import howToTurnAgentWorkIntoSoftwareYouOwn from './posts/how-to-turn-agent-work-into-software-you-own.md'
@@ -19,6 +20,7 @@ import zeroInferenceCalls from './posts/zero-inference-calls.md'
  * generated `/blog/:slug/og.png` card.
  */
 const postSources: Array<{ slug: string; raw: string }> = [
+	{ slug: 'early-kody-users', raw: earlyKodyUsers },
 	{ slug: 'your-assistants-home', raw: yourAssistantsHome },
 	{
 		slug: 'gateways-connect-homes-accumulate',

--- a/packages/worker/src/blog/posts/early-kody-users.md
+++ b/packages/worker/src/blog/posts/early-kody-users.md
@@ -1,0 +1,37 @@
+---
+title: Early Kody users
+date: 2026-09-08
+description:
+  Longer notes from people already using Kody — not case studies, just how it
+  shows up in their work and at home.
+order: 1
+---
+
+The homepage carousel keeps quotes short. A few people have more to say than
+fits on a card. These are those notes, in their words. Not case studies. More
+will land here as folks are willing to share.
+
+## Josh Tomaino
+
+Engineering Manager, Cloverleaf.me.
+
+> Been running Kody for a while. My personal agent for my family lives on a VPS,
+> I run a local agent for work, and between my organization and myself we pay
+> for six accounts over four different providers. I don't want my personal
+> tokens spread over my work harnesses and I can't have my tokens for work
+> spread across my personal devices. Kody provides a crucial layer of
+> infrastructure that funnels all my tools into one secure MCP I can manage
+> myself, instead of me wiring up each one across different apps and
+> environments. The interoperability is the real magic - the same tools serve my
+> family agent and the work agent I run separately, no duplicate setup. It just
+> works.
+
+## Jett Hays
+
+Head of Software, Sentala.
+
+> Kody gives our agents durable and credentialed access to infrastructure.
+> Agents own deployment automation, while Kody owns the secure execution layer.
+> We operate in contested environments where a downed service could mean life or
+> death for some of the world's most endangered species. Kody helps us keep that
+> critical infrastructure running.

--- a/packages/worker/universal/landing-testimonials.node.test.ts
+++ b/packages/worker/universal/landing-testimonials.node.test.ts
@@ -1,11 +1,14 @@
 import { existsSync } from 'node:fs'
 import { join } from 'node:path'
 import { expect, test } from 'vitest'
+import { routes } from '#universal/routes.ts'
 import {
 	landingTestimonials,
+	landingTestimonialsStorySlug,
 	shuffleTestimonials,
 	testimonialAttribution,
 	testimonialInitials,
+	testimonialStoryHref,
 } from '#universal/landing-testimonials.ts'
 
 const testimonialsPhotoDir = join(
@@ -69,6 +72,29 @@ test('testimonialAttribution joins verified role and employer and omits blanks',
 	)
 	expect(testimonialAttribution({})).toBeNull()
 	expect(testimonialAttribution({ title: '', company: '' })).toBeNull()
+})
+
+test('carousel story links share the early-users post and anchor featured vignettes', () => {
+	const josh = landingTestimonials.find(
+		(entry) => entry.name === 'Josh Tomaino',
+	)
+	const jett = landingTestimonials.find((entry) => entry.name === 'Jett Hays')
+	if (!josh || !jett) {
+		throw new Error('expected Josh and Jett testimonials')
+	}
+
+	expect(josh.quote).toContain('six accounts over four providers')
+	expect(jett.quote).toContain("when downtime isn't an option")
+	expect(testimonialStoryHref(josh)).toBe('/blog/early-kody-users#josh-tomaino')
+	expect(testimonialStoryHref(jett)).toBe('/blog/early-kody-users#jett-hays')
+	expect(testimonialStoryHref({})).toBe(
+		routes.blogPost.href({ slug: landingTestimonialsStorySlug }),
+	)
+	for (const entry of landingTestimonials) {
+		expect(
+			testimonialStoryHref(entry).startsWith('/blog/early-kody-users'),
+		).toBe(true)
+	}
 })
 
 test('every hosted testimonial photo exists under public/images/testimonials', () => {

--- a/packages/worker/universal/landing-testimonials.ts
+++ b/packages/worker/universal/landing-testimonials.ts
@@ -4,6 +4,10 @@
  * empty slots; add real cleared quotes only.
  */
 
+import { routes } from '#universal/routes.ts'
+
+export const landingTestimonialsStorySlug = 'early-kody-users'
+
 export type LandingTestimonial = {
 	quote: string
 	name: string
@@ -15,26 +19,30 @@ export type LandingTestimonial = {
 	title?: string
 	/** Verified public employer — omit if unsure. */
 	company?: string
+	/** Heading id on the shared early-users post when this person has a vignette. */
+	storyAnchor?: string
 }
 
 export const landingTestimonials = [
 	{
 		quote:
-			"Been running Kody for a while. My personal agent for my family lives on a VPS, I run a local agent for work, and between my organization and myself we pay for six accounts over four different providers. I don't want my personal tokens spread over my work harnesses and I can't have my tokens for work spread across my personal devices. Kody provides a crucial layer of infrastructure that funnels all my tools into one secure MCP I can manage myself, instead of me wiring up each one across different apps and environments. The interoperability is the real magic - the same tools serve my family agent and the work agent I run separately, no duplicate setup. It just works.",
+			"Between my organization and myself we pay for six accounts over four providers. I don't want personal tokens on work harnesses or work tokens on personal devices. Kody funnels everything into one secure MCP I manage myself. The interoperability is the real magic.",
 		name: 'Josh Tomaino',
 		photo: '/images/testimonials/josh-tomaino.webp',
 		href: 'https://copyjosh.com/',
 		title: 'Engineering Manager',
 		company: 'Cloverleaf.me',
+		storyAnchor: 'josh-tomaino',
 	},
 	{
 		quote:
-			"Kody gives our agents durable and credentialed access to infrastructure. Agents own deployment automation, while Kody owns the secure execution layer. We operate in contested environments where a downed service could mean life or death for some of the world's most endangered species. Kody helps us keep that critical infrastructure running.",
+			"Kody gives our agents durable and credentialed access to infrastructure. Agents own deployment automation, while Kody owns the secure execution layer. In contested environments, that split keeps us moving when downtime isn't an option.",
 		name: 'Jett Hays',
 		photo: '/images/testimonials/jett-hays.webp',
 		href: 'https://sentala.org',
 		title: 'Head of Software',
 		company: 'Sentala',
+		storyAnchor: 'jett-hays',
 	},
 	{
 		quote:
@@ -103,4 +111,10 @@ export function testimonialAttribution(entry: {
 	)
 	if (parts.length === 0) return null
 	return parts.join(', ')
+}
+
+/** Shared early-users post, plus an in-page heading when this person has one. */
+export function testimonialStoryHref(entry: { storyAnchor?: string }): string {
+	const base = routes.blogPost.href({ slug: landingTestimonialsStorySlug })
+	return entry.storyAnchor ? `${base}#${entry.storyAnchor}` : base
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Keep homepage carousel quotes short, and give each card an honest path to a longer early-users roundup.

## Why

Josh's approved long note and Jett's prior homepage quote are too long for the carousel. The longer vignettes belong on a shared blog post, not invented case studies.

## Summary

- Shorten Josh Tomaino and Jett Hays homepage quotes to the approved carousel copy.
- Add a keyboard- and screen-reader-friendly **Read the full story** link on every card, pointing at `/blog/early-kody-users` (anchors for Josh and Jett).
- Add the **Early Kody users** post with Josh's full approved note and Jett's prior approved homepage quote. Gabriel Alegría is omitted until he says yes.
- First-party blog headings can emit ids so those anchors work.

## Testing

- `vitest` node-unit + workers-unit via pre-push (`test:push`)
- Focused suites for testimonials, blog catalog, markdown heading ids, and homepage/blog SSR
- Local wrangler `/health` did not come up in this VM (missing worker bindings); homepage and blog confirmed via SSR HTML

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `b21241f5` · **Head:** `029ef2df`

**Classification:** composes — no primitives added or changed; this PR wires
homepage testimonial cards to the existing blog catalog and turns on opt-in
heading ids for first-party posts.

### Primitives touched

| Primitive | Group    | Impact                                                                 |
| --------- | -------- | ---------------------------------------------------------------------- |
| `app-ui`  | surfaces | composes — shorter carousel quotes, story links, new catalog post      |

Unmatched paths are the blog catalog/post and landing CSS, which sit on the
same public marketing surface.

### Change flow

Homepage cards keep short quotes and link into the shared early-users post;
first-party markdown headings get ids so featured vignettes can be reached
with a hash.

```mermaid
sequenceDiagram
	actor Visitor
	participant appUi as app-ui
	Visitor->>appUi: open homepage carousel
	appUi->>appUi: render shortened Josh and Jett quotes
	Visitor->>appUi: activate Read the full story
	appUi->>appUi: GET /blog/early-kody-users#josh-tomaino
	Note over appUi: catalog post plus heading ids
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-311c3e4b-1666-4ecf-9674-fb64d88958ab?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-311c3e4b-1666-4ecf-9674-fb64d88958ab&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the “Early Kody Users” blog story featuring extended customer testimonials.
  * Added “Read the full story” links to landing-page testimonials.
  * Added deep-linkable heading anchors to the new blog post, including unique IDs for duplicate headings.
  * Updated testimonial quotes and linked featured testimonials to their corresponding story sections.
* **Tests**
  * Added coverage for testimonial links, server-rendered content, blog metadata, and heading anchor behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->