### PR TITLE
Speed up homepage SSR and keep Shiki off the landing bundle

### DIFF
--- a/docs/contributing/architecture/youtube-watch.md
+++ b/docs/contributing/architecture/youtube-watch.md
@@ -44,6 +44,12 @@ banner. The Atom feed is not the full catalog.
 
 Failed playlist fetches fail open: env extra ids and banner hrefs still work.
 
+SSR documents without `?youtubeId=` skip the playlist fetch. They still merge
+env extras, the sample id, and enabled-banner hrefs (from the same
+`listEnabledSiteBanners` read as the site-banner loader). `?youtubeId=` HTML and
+`/youtube-thumb/:videoId` still load playlists. Shared watch links are full
+document loads, so they still resolve playlist ids.
+
 ## Code
 
 - Parse / rewrite: `packages/worker/universal/youtube-watch.ts`

--- a/docs/contributing/weekly-site-perf.md
+++ b/docs/contributing/weekly-site-perf.md
@@ -26,8 +26,10 @@ payload, the preloaded LCP image, TTFB, and `Server-Timing` phases (`session`,
 also probes `/onboarding` and `/guides/how-kody-works` for the same timing
 snapshot. Those extra pages are observational and do not change the verdict. A
 failed extra probe is omitted so homepage classify still runs. Homepage HTML
-that lacks an app `ssr` phase is a finding. The collector then classifies
-against [`tools/site-perf/budget.json`](../../tools/site-perf/budget.json).
+that lacks an app `ssr` phase is a finding. A `syntax-highlight` modulepreload
+on `/` is a finding (Shiki belongs on guides and onboarding, not the landing
+entry). The collector then classifies against
+[`tools/site-perf/budget.json`](../../tools/site-perf/budget.json).
 
 [`.github/workflows/weekly-site-perf.yml`](../../.github/workflows/weekly-site-perf.yml)
 runs that collector on Mondays at 14:17 UTC and on `workflow_dispatch`.

--- a/packages/worker/client/lazy-route.node.test.ts
+++ b/packages/worker/client/lazy-route.node.test.ts
@@ -19,13 +19,6 @@ const eagerPatterns = new Set([
 	routePattern(routes.home),
 	routePattern(routes.profile),
 	oauthPaths.callback,
-	routePattern(routes.onboarding),
-	routePattern(routes.onboardingStep1),
-	routePattern(routes.onboardingStep1Agent),
-	routePattern(routes.onboardingStep2),
-	routePattern(routes.onboardingStep2Service),
-	routePattern(routes.onboardingStep3),
-	routePattern(routes.onboardingStep3Agent),
 ])
 
 function concretePathForPattern(pattern: string) {

--- a/packages/worker/client/lazy-route.tsx
+++ b/packages/worker/client/lazy-route.tsx
@@ -347,6 +347,13 @@ registerPreloadPatterns(
 
 registerPreloadPatterns(
 	[
+		routePattern(routes.onboarding),
+		routePattern(routes.onboardingStep1),
+		routePattern(routes.onboardingStep1Agent),
+		routePattern(routes.onboardingStep2),
+		routePattern(routes.onboardingStep2Service),
+		routePattern(routes.onboardingStep3),
+		routePattern(routes.onboardingStep3Agent),
 		routePattern(routes.connectOauth),
 		routePattern(routes.connectSecrets),
 		oauthPaths.authorize,

--- a/packages/worker/client/routes/index.tsx
+++ b/packages/worker/client/routes/index.tsx
@@ -22,7 +22,6 @@ import { oauthPaths } from '#universal/oauth-paths.ts'
 import { routePattern } from '#universal/route-pattern.ts'
 import { routes } from '#universal/routes.ts'
 import { HomeRoute, homeRouteLoader } from './home.tsx'
-import { OnboardingRoute, onboardingRouteLoader } from './onboarding.tsx'
 import { OAuthCallbackRoute } from './oauth-callback.tsx'
 import { ProfileRoute, profileRouteLoader } from './profile.tsx'
 
@@ -301,13 +300,34 @@ export const clientRouteLoaders: Record<string, RouteLoader> = {
 		onboardingArea,
 		(m) => m.oauthAuthorizeRouteLoader,
 	),
-	[routePattern(routes.onboarding)]: onboardingRouteLoader,
-	[routePattern(routes.onboardingStep1)]: onboardingRouteLoader,
-	[routePattern(routes.onboardingStep1Agent)]: onboardingRouteLoader,
-	[routePattern(routes.onboardingStep2)]: onboardingRouteLoader,
-	[routePattern(routes.onboardingStep2Service)]: onboardingRouteLoader,
-	[routePattern(routes.onboardingStep3)]: onboardingRouteLoader,
-	[routePattern(routes.onboardingStep3Agent)]: onboardingRouteLoader,
+	[routePattern(routes.onboarding)]: lazyRouteLoader(
+		onboardingArea,
+		(m) => m.onboardingRouteLoader,
+	),
+	[routePattern(routes.onboardingStep1)]: lazyRouteLoader(
+		onboardingArea,
+		(m) => m.onboardingRouteLoader,
+	),
+	[routePattern(routes.onboardingStep1Agent)]: lazyRouteLoader(
+		onboardingArea,
+		(m) => m.onboardingRouteLoader,
+	),
+	[routePattern(routes.onboardingStep2)]: lazyRouteLoader(
+		onboardingArea,
+		(m) => m.onboardingRouteLoader,
+	),
+	[routePattern(routes.onboardingStep2Service)]: lazyRouteLoader(
+		onboardingArea,
+		(m) => m.onboardingRouteLoader,
+	),
+	[routePattern(routes.onboardingStep3)]: lazyRouteLoader(
+		onboardingArea,
+		(m) => m.onboardingRouteLoader,
+	),
+	[routePattern(routes.onboardingStep3Agent)]: lazyRouteLoader(
+		onboardingArea,
+		(m) => m.onboardingRouteLoader,
+	),
 	[routePattern(routes.connectOauth)]: lazyRouteLoader(
 		onboardingArea,
 		(m) => m.connectOauthRouteLoader,
@@ -535,13 +555,27 @@ export const clientRoutes = {
 	[routePattern(routes.login)]: (
 		<LazyAuthRoute render={(m) => <m.LoginRoute />} />
 	),
-	[routePattern(routes.onboarding)]: <OnboardingRoute />,
-	[routePattern(routes.onboardingStep1)]: <OnboardingRoute />,
-	[routePattern(routes.onboardingStep1Agent)]: <OnboardingRoute />,
-	[routePattern(routes.onboardingStep2)]: <OnboardingRoute />,
-	[routePattern(routes.onboardingStep2Service)]: <OnboardingRoute />,
-	[routePattern(routes.onboardingStep3)]: <OnboardingRoute />,
-	[routePattern(routes.onboardingStep3Agent)]: <OnboardingRoute />,
+	[routePattern(routes.onboarding)]: (
+		<LazyOnboardingRoute render={(m) => <m.OnboardingRoute />} />
+	),
+	[routePattern(routes.onboardingStep1)]: (
+		<LazyOnboardingRoute render={(m) => <m.OnboardingRoute />} />
+	),
+	[routePattern(routes.onboardingStep1Agent)]: (
+		<LazyOnboardingRoute render={(m) => <m.OnboardingRoute />} />
+	),
+	[routePattern(routes.onboardingStep2)]: (
+		<LazyOnboardingRoute render={(m) => <m.OnboardingRoute />} />
+	),
+	[routePattern(routes.onboardingStep2Service)]: (
+		<LazyOnboardingRoute render={(m) => <m.OnboardingRoute />} />
+	),
+	[routePattern(routes.onboardingStep3)]: (
+		<LazyOnboardingRoute render={(m) => <m.OnboardingRoute />} />
+	),
+	[routePattern(routes.onboardingStep3Agent)]: (
+		<LazyOnboardingRoute render={(m) => <m.OnboardingRoute />} />
+	),
 	[routePattern(routes.pendingVerification)]: (
 		<LazyAuthRoute render={(m) => <m.PendingVerificationRoute />} />
 	),

--- a/packages/worker/src/app/handlers/home.node.test.ts
+++ b/packages/worker/src/app/handlers/home.node.test.ts
@@ -6,7 +6,10 @@ import {
 	type AuthSession,
 } from '#app/auth-session.ts'
 import { createHomeHandler } from '#app/handlers/home.ts'
-import { loadOnboardingData } from '#app/onboarding-data.ts'
+import {
+	loadOnboardingData,
+	loadPublicOnboardingData,
+} from '#app/onboarding-data.ts'
 import { hasResolvedRequestFeatureFlags } from '#app/request-feature-flags-cache.ts'
 import { loadSessionInfo } from '#app/session-info.ts'
 import { renderAppPage } from '#app/ssr-render.tsx'
@@ -236,4 +239,30 @@ test('authenticated home SSR prefetches flags while loading page data', async ()
 		'compute-overage-charging': true,
 	})
 	expect(counts.batchSizes).toEqual([2, 2])
+	expect(loadOnboardingData).toHaveBeenCalledWith(
+		expect.objectContaining({ featuredMcpServers: [] }),
+	)
+})
+
+test('anonymous home SSR omits the unused onboarding chooser catalog', async () => {
+	const actual = await vi.importActual<
+		typeof import('#app/onboarding-data.ts')
+	>('#app/onboarding-data.ts')
+	vi.mocked(loadPublicOnboardingData).mockImplementation(
+		actual.loadPublicOnboardingData,
+	)
+	vi.mocked(renderAppPage).mockResolvedValue(new Response('ok'))
+
+	setAuthSessionSecret(testCookieSecret)
+	const response = await createHomeHandler({
+		COOKIE_SECRET: testCookieSecret,
+	} as Env).handler(new RequestContext(new Request('https://example.com/')))
+	expect(response.status).toBe(200)
+	const input = vi.mocked(renderAppPage).mock.calls.at(-1)?.[0]
+	expect(input?.loaderData?.onboarding?.featuredMcpServers).toEqual([])
+	expect(input?.loaderData?.onboarding?.setupPrompt).toBe('')
+	expect(input?.loaderData?.onboarding?.persistPrompt).toBe('')
+	expect(input?.loaderData?.onboarding?.discoveryPrompt.length).toBeGreaterThan(
+		0,
+	)
 })

--- a/packages/worker/src/app/handlers/home.ts
+++ b/packages/worker/src/app/handlers/home.ts
@@ -37,32 +37,37 @@ export function createHomeHandler(env: Env) {
 			}
 
 			const serverTiming: Array<ServerTimingEntry> = []
-			const codeRunsWindow = await pushServerTiming(
-				serverTiming,
-				'code-runs',
-				() => loadPublicCodeRunsWindow(env),
-			)
-			const codeRuns = { ok: true as const, window: codeRunsWindow }
 			const walkthroughHosts = pickWalkthroughHosts()
-			const signupMode = await resolveSignupMode(env)
-
-			const user = await readAuthenticatedAppUser(request, env, {
-				prefetchFeatureFlags: true,
-			})
+			const [codeRunsWindow, signupMode, user] = await Promise.all([
+				pushServerTiming(serverTiming, 'code-runs', () =>
+					loadPublicCodeRunsWindow(env),
+				),
+				resolveSignupMode(env),
+				readAuthenticatedAppUser(request, env, {
+					prefetchFeatureFlags: true,
+				}),
+			])
+			const codeRuns = { ok: true as const, window: codeRunsWindow }
 			if (!user) {
-				// Anonymous visits still embed the public onboarding payload so
-				// the hero's discovery-prompt copy renders server-side instead
-				// of popping in after a client /onboarding.json fetch.
+				// Anonymous visits still embed discovery-prompt copy so the
+				// hero does not pop it in after /onboarding.json. The MCP
+				// chooser catalog and setup prompts stay off / — home does
+				// not render them, and they dominated rmx-data (~7 kB).
 				return withAgentDiscoveryLinkHeaders(
 					withVaryAccept(
 						await renderAppPage({
 							request,
 							env,
 							loaderData: {
-								onboarding: loadPublicOnboardingData({
-									env,
-									requestUrl: request.url,
-								}),
+								onboarding: {
+									...loadPublicOnboardingData({
+										env,
+										requestUrl: request.url,
+									}),
+									featuredMcpServers: [],
+									setupPrompt: '',
+									persistPrompt: '',
+								},
 								codeRuns,
 								walkthroughHosts,
 								signupMode,
@@ -80,6 +85,7 @@ export function createHomeHandler(env: Env) {
 				stableUserId: user.mcpUser.userId,
 				username: user.username,
 				emailVerified: user.emailVerified,
+				featuredMcpServers: [],
 			})
 			return withAgentDiscoveryLinkHeaders(
 				withVaryAccept(

--- a/packages/worker/src/app/site-banner-ssr.ts
+++ b/packages/worker/src/app/site-banner-ssr.ts
@@ -36,6 +36,21 @@ export function emptySiteBannerLoaderData(): SiteBannerLoaderData {
 	}
 }
 
+/** Shared enabled-banner read for SSR. Missing schema is empty, not an error. */
+export async function loadEnabledSiteBannersForSsr(
+	env: Env,
+): Promise<Array<SiteBannerRecord>> {
+	if (typeof env.APP_DB?.prepare !== 'function') return []
+	try {
+		return await listEnabledSiteBanners(env.APP_DB)
+	} catch (error) {
+		if (!isMissingSiteBannerSchema(error)) {
+			console.error('site banner list failed', error)
+		}
+		return []
+	}
+}
+
 export async function loadSiteBannerLoaderData(input: {
 	request: Request
 	env: Env

--- a/packages/worker/src/app/site-banner-ssr.ts
+++ b/packages/worker/src/app/site-banner-ssr.ts
@@ -41,6 +41,10 @@ export async function loadSiteBannerLoaderData(input: {
 	env: Env
 	session: SessionInfo | null
 	pathname: string
+	/** Shared enabled-banner list so YouTube allowlist SSR does not re-query. */
+	listedBanners?:
+		| Promise<ReadonlyArray<SiteBannerRecord>>
+		| ReadonlyArray<SiteBannerRecord>
 }): Promise<SiteBannerLoaderData> {
 	if (typeof input.env.APP_DB?.prepare !== 'function') {
 		return emptySiteBannerLoaderData()
@@ -68,6 +72,9 @@ async function loadSiteBannerLoaderDataUnsafe(input: {
 	env: Env
 	session: SessionInfo | null
 	pathname: string
+	listedBanners?:
+		| Promise<ReadonlyArray<SiteBannerRecord>>
+		| ReadonlyArray<SiteBannerRecord>
 }): Promise<SiteBannerLoaderData> {
 	const requestUrl = new URL(input.request.url)
 	const isAdmin = Boolean(input.session && userHasRole(input.session, 'admin'))
@@ -93,7 +100,10 @@ async function loadSiteBannerLoaderDataUnsafe(input: {
 
 	const listed: Array<SiteBannerRecord> = wantsPreview
 		? await listSiteBannersForAdmin(input.env.APP_DB)
-		: await listEnabledSiteBanners(input.env.APP_DB)
+		: [
+				...(await (input.listedBanners ??
+					listEnabledSiteBanners(input.env.APP_DB))),
+			]
 
 	const needsPlan =
 		Boolean(stableUserId) &&

--- a/packages/worker/src/app/ssr-render.tsx
+++ b/packages/worker/src/app/ssr-render.tsx
@@ -16,10 +16,12 @@ import { getRequestDataCacheLookup } from '#app/request-cache.ts'
 import { resolveAppPageCacheControl } from '#app/anonymous-html-cache.ts'
 import { applyFirstPartySecurityHeaders } from '#app/security-headers.ts'
 import { loadSessionInfo } from '#app/session-info.ts'
-import { loadSiteBannerLoaderData } from '#app/site-banner-ssr.ts'
+import {
+	loadEnabledSiteBannersForSsr,
+	loadSiteBannerLoaderData,
+} from '#app/site-banner-ssr.ts'
 import { loadYoutubeWatchLoaderData } from '#app/youtube-watch-ssr.ts'
 import { parseYoutubeWatchSearch } from '#universal/youtube-watch.ts'
-import { listEnabledSiteBanners } from '#worker/site-banners/service.ts'
 import { getInlineStylesheet } from '#app/inline-stylesheet.ts'
 import { SsrDocument } from '#app/ssr-document.tsx'
 import { openDocumentStream } from '#app/ssr-document-stream.ts'
@@ -98,10 +100,7 @@ export async function renderAppPage(input: RenderAppPageInput) {
 		() => loadSessionInfo(request, env),
 	)
 	const requestUrl = new URL(request.url)
-	const listedBanners =
-		typeof env.APP_DB?.prepare === 'function'
-			? listEnabledSiteBanners(env.APP_DB)
-			: Promise.resolve([])
+	const listedBanners = loadEnabledSiteBannersForSsr(env)
 	const [siteBanner, youtubeWatch] = await Promise.all([
 		pushServerTiming(serverTiming, 'siteBanner', () =>
 			loadSiteBannerLoaderData({

--- a/packages/worker/src/app/ssr-render.tsx
+++ b/packages/worker/src/app/ssr-render.tsx
@@ -18,6 +18,8 @@ import { applyFirstPartySecurityHeaders } from '#app/security-headers.ts'
 import { loadSessionInfo } from '#app/session-info.ts'
 import { loadSiteBannerLoaderData } from '#app/site-banner-ssr.ts'
 import { loadYoutubeWatchLoaderData } from '#app/youtube-watch-ssr.ts'
+import { parseYoutubeWatchSearch } from '#universal/youtube-watch.ts'
+import { listEnabledSiteBanners } from '#worker/site-banners/service.ts'
 import { getInlineStylesheet } from '#app/inline-stylesheet.ts'
 import { SsrDocument } from '#app/ssr-document.tsx'
 import { openDocumentStream } from '#app/ssr-document-stream.ts'
@@ -96,6 +98,10 @@ export async function renderAppPage(input: RenderAppPageInput) {
 		() => loadSessionInfo(request, env),
 	)
 	const requestUrl = new URL(request.url)
+	const listedBanners =
+		typeof env.APP_DB?.prepare === 'function'
+			? listEnabledSiteBanners(env.APP_DB)
+			: Promise.resolve([])
 	const [siteBanner, youtubeWatch] = await Promise.all([
 		pushServerTiming(serverTiming, 'siteBanner', () =>
 			loadSiteBannerLoaderData({
@@ -103,11 +109,14 @@ export async function renderAppPage(input: RenderAppPageInput) {
 				env,
 				session,
 				pathname: requestUrl.pathname,
+				listedBanners,
 			}),
 		),
 		pushServerTiming(serverTiming, 'youtubeWatch', () =>
 			loadYoutubeWatchLoaderData({
 				env,
+				listedBanners,
+				loadPlaylists: parseYoutubeWatchSearch(requestUrl.search) !== null,
 			}),
 		),
 	])

--- a/packages/worker/src/app/youtube-watch-allowlist.node.test.ts
+++ b/packages/worker/src/app/youtube-watch-allowlist.node.test.ts
@@ -76,3 +76,46 @@ test('resolveYoutubeWatchAllowedVideoIds always includes the look-preview sample
 	})
 	expect(ids).toEqual([videoId])
 })
+
+test('resolveYoutubeWatchAllowedVideoIds skips playlist fetch when loadPlaylists is false', async () => {
+	const ids = await resolveYoutubeWatchAllowedVideoIds({
+		env: {
+			YOUTUBE_ALLOWED_PLAYLIST_IDS: playlistId,
+			YOUTUBE_ALLOWED_VIDEO_IDS: videoId,
+		} as Env,
+		fetchImpl: async () => {
+			throw new Error('playlist fetch should not run')
+		},
+		loadPlaylists: false,
+		listedBanners: [
+			{
+				ctaHref: `/?youtubeId=${videoId}`,
+				secondaryHref: null,
+				imageUrl: null,
+			},
+		],
+	})
+	expect(ids).toEqual([videoId])
+})
+
+test('resolveYoutubeWatchAllowedVideoIds uses listedBanners instead of querying D1', async () => {
+	const bannerVideoId = 'dQw4w9wgvcQ'
+	const ids = await resolveYoutubeWatchAllowedVideoIds({
+		env: {
+			YOUTUBE_ALLOWED_PLAYLIST_IDS: 'none',
+			APP_DB: {
+				prepare() {
+					throw new Error('site_banners should not be queried')
+				},
+			},
+		} as unknown as Env,
+		listedBanners: [
+			{
+				ctaHref: `/?youtubeId=${bannerVideoId}`,
+				secondaryHref: null,
+				imageUrl: null,
+			},
+		],
+	})
+	expect(ids).toEqual([videoId, bannerVideoId])
+})

--- a/packages/worker/src/app/youtube-watch-allowlist.ts
+++ b/packages/worker/src/app/youtube-watch-allowlist.ts
@@ -7,6 +7,7 @@ import {
 	youtubePlaylistFeedUrl,
 	youtubeWatchSampleVideoId,
 } from '#universal/youtube-watch.ts'
+import { type SiteBannerRecord } from '#universal/site-banners.ts'
 import { listEnabledSiteBanners } from '#worker/site-banners/service.ts'
 
 type YoutubeWatchFetch = (
@@ -14,10 +15,25 @@ type YoutubeWatchFetch = (
 	init?: { signal?: AbortSignal },
 ) => Promise<Response>
 
+export type YoutubeWatchBannerHrefs = Pick<
+	SiteBannerRecord,
+	'ctaHref' | 'secondaryHref' | 'imageUrl'
+>
+
 export async function resolveYoutubeWatchAllowedVideoIds(input: {
 	env: Env
 	fetchImpl?: YoutubeWatchFetch
 	cache?: Cache
+	/** Reuse the SSR banner list so / does not query `site_banners` twice. */
+	listedBanners?:
+		| Promise<ReadonlyArray<YoutubeWatchBannerHrefs>>
+		| ReadonlyArray<YoutubeWatchBannerHrefs>
+	/**
+	 * Playlist Atom fetch. Default true for thumbs and `?youtubeId=` SSR.
+	 * Plain documents skip it: env extras, the sample id, and banner hrefs
+	 * still allow Watch CTAs and look-preview.
+	 */
+	loadPlaylists?: boolean
 }): Promise<Array<string>> {
 	const playlistIds = parseYoutubePlaylistIdList(
 		input.env.YOUTUBE_ALLOWED_PLAYLIST_IDS,
@@ -25,13 +41,16 @@ export async function resolveYoutubeWatchAllowedVideoIds(input: {
 	const extraVideoIds = parseYoutubeVideoIdList(
 		input.env.YOUTUBE_ALLOWED_VIDEO_IDS,
 	)
+	const loadPlaylists = input.loadPlaylists !== false
 	const [playlistVideoIds, hrefs] = await Promise.all([
-		loadPlaylistVideoIds({
-			playlistIds,
-			fetchImpl: input.fetchImpl ?? fetch,
-			cache: input.cache ?? readDefaultCache(),
-		}),
-		listEnabledBannerWatchHrefs(input.env),
+		loadPlaylists
+			? loadPlaylistVideoIds({
+					playlistIds,
+					fetchImpl: input.fetchImpl ?? fetch,
+					cache: input.cache ?? readDefaultCache(),
+				})
+			: Promise.resolve([]),
+		listEnabledBannerWatchHrefs(input.env, input.listedBanners),
 	])
 	return mergeYoutubeWatchAllowlist({
 		playlistVideoIds,
@@ -102,15 +121,18 @@ async function loadOnePlaylistVideoIds(input: {
 
 async function listEnabledBannerWatchHrefs(
 	env: Env,
+	listedBanners?:
+		| Promise<ReadonlyArray<YoutubeWatchBannerHrefs>>
+		| ReadonlyArray<YoutubeWatchBannerHrefs>,
 ): Promise<Array<string | null>> {
+	if (listedBanners) {
+		const banners = await listedBanners
+		return bannerWatchHrefs(banners)
+	}
 	if (typeof env.APP_DB?.prepare !== 'function') return []
 	try {
 		const banners = await listEnabledSiteBanners(env.APP_DB)
-		return banners.flatMap((banner) => [
-			banner.ctaHref,
-			banner.secondaryHref,
-			banner.imageUrl,
-		])
+		return bannerWatchHrefs(banners)
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error)
 		if (
@@ -122,6 +144,16 @@ async function listEnabledBannerWatchHrefs(
 		console.error('youtube watch banner href load failed', error)
 		return []
 	}
+}
+
+function bannerWatchHrefs(
+	banners: ReadonlyArray<YoutubeWatchBannerHrefs>,
+): Array<string | null> {
+	return banners.flatMap((banner) => [
+		banner.ctaHref,
+		banner.secondaryHref,
+		banner.imageUrl,
+	])
 }
 
 function readDefaultCache(): Cache | undefined {

--- a/packages/worker/src/app/youtube-watch-ssr.ts
+++ b/packages/worker/src/app/youtube-watch-ssr.ts
@@ -1,12 +1,21 @@
 import { type YoutubeWatchLoaderData } from '#universal/loader-data.ts'
-import { resolveYoutubeWatchAllowedVideoIds } from '#app/youtube-watch-allowlist.ts'
+import {
+	resolveYoutubeWatchAllowedVideoIds,
+	type YoutubeWatchBannerHrefs,
+} from '#app/youtube-watch-allowlist.ts'
 
 export async function loadYoutubeWatchLoaderData(input: {
 	env: Env
+	listedBanners?:
+		| Promise<ReadonlyArray<YoutubeWatchBannerHrefs>>
+		| ReadonlyArray<YoutubeWatchBannerHrefs>
+	loadPlaylists?: boolean
 }): Promise<YoutubeWatchLoaderData> {
 	try {
 		const allowedVideoIds = await resolveYoutubeWatchAllowedVideoIds({
 			env: input.env,
+			listedBanners: input.listedBanners,
+			loadPlaylists: input.loadPlaylists,
 		})
 		return { allowedVideoIds }
 	} catch (error) {

--- a/tools/site-perf/collect.node.test.ts
+++ b/tools/site-perf/collect.node.test.ts
@@ -48,7 +48,7 @@ test('classifySitePerf scores healthy landing signals and flags cache, LCP, Shik
 
 	const shikiAndJs = classifySitePerf({
 		url: 'https://kody.codes/',
-		html: `${healthyHtml}<link rel="modulepreload" href="/assets/syntax-highlight-core-abc.js" />`,
+		html: `${healthyHtml}<link rel="modulepreload" href="/assets/syntax-highlight-Bk0_PSZb.js" />`,
 		cacheControl: 'public, max-age=60',
 		vary: 'Cookie',
 		htmlBytes: 800,

--- a/tools/site-perf/collect.ts
+++ b/tools/site-perf/collect.ts
@@ -92,13 +92,10 @@ export function classifySitePerf(input: {
 		})
 	}
 
-	if (
-		new URL(input.url).pathname === '/' &&
-		html.includes('syntax-highlight-core')
-	) {
+	if (new URL(input.url).pathname === '/' && /syntax-highlight/.test(html)) {
 		findings.push({
 			id: 'shiki-on-home',
-			message: 'Homepage HTML preloads syntax-highlight-core (Shiki on /).',
+			message: 'Homepage HTML preloads a syntax-highlight chunk (Shiki on /).',
 		})
 	}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Make `https://kody.codes/` feel faster on the miss / logged-in path, and stop the landing document from paying for onboarding/Shiki weight that it does not render.

## Why

Production evidence (2026-09-08, anonymous `/`):

| Signal | Measured | Notes |
| --- | --- | --- |
| Cache miss TTFB | 370–479 ms | `X-Kody-Cache: MISS`, `cfWorker` ~361 ms |
| Cache hit TTFB | 64–69 ms | `X-Kody-Cache: HIT` — anonymous repeat visits are fine |
| Server-Timing (miss) | `code-runs` 72–77 ms, then `siteBanner`+`youtubeWatch` 91–94 ms | Sequential KV, then **two** `site_banners` D1 reads plus a playlist fetch |
| HTML | 132,005 B (budget 130,000) | `needs-fix` from `npm run site-perf` |
| `rmx-data` | 14,155 B | `onboarding.featuredMcpServers` alone is 7,077 B — home never renders the chooser |
| Modulepreloads | 55, including `syntax-highlight-*.js` | Onboarding was eager in the client entry |
| JS / LCP image | 196,997 B / 25,590 B | Under budget |

Kent browsing while signed in always takes the miss path (`Cache-Control: no-store`). Testimonials (Jett, Josh) added markup; they are not the TTFB story.

## Summary

- Parallelize homepage `code-runs`, signup mode, and auth instead of awaiting them in series.
- Slim homepage onboarding loader data: keep the discovery prompt, drop the MCP chooser catalog and unused setup/persist prompts (~7 kB of `rmx-data`).
- Share one `site_banners` read between the banner loader and the YouTube allowlist. Skip the playlist Atom fetch unless `?youtubeId=` is present. Thumbs and watch URLs still load playlists. Banner Watch CTAs keep working via env extras, the sample id, and banner hrefs.
- Move `/onboarding` onto the existing `onboarding-area` lazy chunk so `/` no longer modulepreloads Shiki.
- Broaden the weekly site-perf `shiki-on-home` check to any `syntax-highlight` chunk (production was shipping `syntax-highlight-Bk0_PSZb.js`, which the old `syntax-highlight-core` needle missed).

## Testing

- `vitest` node-unit + workers-unit via pre-push (`925` + `94` files).
- Focused: home handler, YouTube allowlist, lazy-route, site-perf classify, previously failing OAuth/HTML-cache workers tests.
- Production before numbers from `npm run site-perf -- --url https://kody.codes/ --json` and curl (`X-Kody-Cache`, `Server-Timing`). After deploy, re-run the same collector.

## Risk

**Medium** — extends homepage SSR and moves a critical route (onboarding) behind the existing lazy-area preload. Shared watch links are full document loads (`/?youtubeId=`), so they still fetch playlists. Client-nav from a page that never had `youtubeId` to a *playlist-only* id would not open until a full load; banner/sample ids still work.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `b21241f5` · **Head:** `9a74adad`

**Classification:** extends — homepage SSR load shape and onboarding’s client-entry contract change. No new primitives.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | extends — slimmer `/` loader data, shared banner/YouTube SSR reads, onboarding leaves the eager entry |

### Change flow

Anonymous `/` no longer waits for sequential KV then a duplicate D1 + playlist fetch, and the landing entry no longer ships onboarding/Shiki.

```mermaid
sequenceDiagram
	actor Visitor
	participant appUi as app-ui
	participant d1AppDb as d1-app-db
	Visitor->>appUi: GET /
	appUi->>appUi: Promise.all code-runs signupMode auth
	appUi->>d1AppDb: one listEnabledSiteBanners
	Note over appUi: skip playlist fetch unless youtubeId
	appUi->>appUi: slim onboarding payload no chooser catalog
	appUi-->>Visitor: HTML without syntax-highlight preload
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-37f8639b-8a61-4a07-a70a-92e3a420656f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-37f8639b-8a61-4a07-a70a-92e3a420656f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Onboarding pages now load their content on demand, with faster preloading when navigation indicates it is needed.
  - Server-rendered pages reuse site-banner data more efficiently.
  - Homepage performance checks now detect unnecessary syntax-highlighting resources and missing server-rendered app content.

- **Bug Fixes**
  - YouTube watch pages avoid unnecessary playlist loading when it is not required, while preserving valid video links.
  - Anonymous visitors no longer receive authenticated onboarding recommendations.

- **Documentation**
  - Updated guidance for YouTube watch behavior and homepage performance findings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->