### PR TITLE
Render package README relative images on community pages

### DIFF
--- a/.agents/skills/control-kody/references/features/community.md
+++ b/.agents/skills/control-kody/references/features/community.md
@@ -35,7 +35,8 @@ node tools/control-kody.ts request GET /community.json --skip-login
   private ones.
 - README `![alt](./docs/poster.png)` images render from
   `/@owner/kody-id/assets/…` (or `/community/:listingId/assets/…` when the
-  `kody.id` is a reserved ingress segment). Remote image URLs stay links.
+  `kody.id` is a reserved ingress segment) only when the viewed markdown is the
+  published or pinned commit. Remote image URLs stay links.
 - Package settings 404 for anyone who is not the owner.
 - Official `@kody/*` listings skip the install confirm; third-party listings ask
   once (`acknowledged: true` or the install endpoint responds `409`).

--- a/.agents/skills/control-kody/references/features/community.md
+++ b/.agents/skills/control-kody/references/features/community.md
@@ -33,6 +33,9 @@ node tools/control-kody.ts request GET /community.json --skip-login
   graph, bookmark-star, or social timeline.
 - Files and tree URLs are public read for listed packages and owner-only for
   private ones.
+- README `![alt](./docs/poster.png)` images render from
+  `/@owner/kody-id/assets/…` (or `/community/:listingId/assets/…` when the
+  `kody.id` is a reserved ingress segment). Remote image URLs stay links.
 - Package settings 404 for anyone who is not the owner.
 - Official `@kody/*` listings skip the install confirm; third-party listings ask
   once (`acknowledged: true` or the install endpoint responds `409`).

--- a/.agents/skills/control-kody/references/features/packages.md
+++ b/.agents/skills/control-kody/references/features/packages.md
@@ -7,9 +7,10 @@ Repo-backed saved packages: list, detail, files, approve-publish.
 `/@username` lists your packages, including private and unpublished packages
 when you view your own profile. Each package lives at `/@username/:kodyId`
 (README), `/@username/:kodyId/tree/:ref` (files), `/@username/:kodyId/assets/…`
-(README-relative images), `/@username/:kodyId/settings` (lock, visibility,
-delete), and `/@username/:kodyId/approve-publish` (published-vs-HEAD review).
-Legacy `/account/packages` HTML URLs only redirect to these canonical pages.
+(README-relative images from the published or pinned commit),
+`/@username/:kodyId/settings` (lock, visibility, delete), and
+`/@username/:kodyId/approve-publish` (published-vs-HEAD review). Legacy
+`/account/packages` HTML URLs only redirect to these canonical pages.
 
 ## Drive it
 

--- a/.agents/skills/control-kody/references/features/packages.md
+++ b/.agents/skills/control-kody/references/features/packages.md
@@ -6,10 +6,10 @@ Repo-backed saved packages: list, detail, files, approve-publish.
 
 `/@username` lists your packages, including private and unpublished packages
 when you view your own profile. Each package lives at `/@username/:kodyId`
-(README), `/@username/:kodyId/tree/:ref` (files), `/@username/:kodyId/settings`
-(lock, visibility, delete), and `/@username/:kodyId/approve-publish`
-(published-vs-HEAD review). Legacy `/account/packages` HTML URLs only redirect
-to these canonical pages.
+(README), `/@username/:kodyId/tree/:ref` (files), `/@username/:kodyId/assets/…`
+(README-relative images), `/@username/:kodyId/settings` (lock, visibility,
+delete), and `/@username/:kodyId/approve-publish` (published-vs-HEAD review).
+Legacy `/account/packages` HTML URLs only redirect to these canonical pages.
 
 ## Drive it
 

--- a/docs/contributing/security.md
+++ b/docs/contributing/security.md
@@ -52,10 +52,11 @@ package-app surfaces:
    URLs with `/@...` user-scope paths and `/packages/...` package-app mount
    paths refused on any host so a README can never point viewers at hosted
    package endpoints. `<img>` is emitted only for in-repo relative image paths
-   rewritten to that package's first-party `/assets/` route (published package
-   bytes, sniffed type, size-capped). Remote and other author-chosen URLs stay
-   links. Never render third-party markdown via an HTML string, `innerHTML`, or
-   a markdown-to-HTML renderer.
+   rewritten to that package's first-party `/assets/` route (published or pinned
+   package bytes, sniffed type, size-capped) and only when the viewed markdown
+   is that same commit. Remote and other author-chosen URLs stay links. Never
+   render third-party markdown via an HTML string, `innerHTML`, or a
+   markdown-to-HTML renderer.
 9. **Package code never receives first-party credentials, and never executes on
    the app origin in production.** Every request handed to package code goes
    through `createPackageCodeRequest`

--- a/docs/contributing/security.md
+++ b/docs/contributing/security.md
@@ -48,12 +48,14 @@ package-app surfaces:
    READMEs (and any future third-party-authored markdown shown on first-party
    pages) must go through `packages/worker/client/markdown-view.tsx`, which
    builds JSX from an allowlist of `marked` lexer tokens: raw HTML renders as
-   escaped text, no resource-loading elements are ever emitted (images become
-   links), and links are restricted to absolute `http:`/`https:`/`mailto:` URLs
-   with `/@...` user-scope paths and `/packages/...` package-app mount paths
-   refused on any host so a README can never point viewers at hosted package
-   endpoints. Never render third-party markdown via an HTML string, `innerHTML`,
-   or a markdown-to-HTML renderer.
+   escaped text, and links are restricted to absolute `http:`/`https:`/`mailto:`
+   URLs with `/@...` user-scope paths and `/packages/...` package-app mount
+   paths refused on any host so a README can never point viewers at hosted
+   package endpoints. `<img>` is emitted only for in-repo relative image paths
+   rewritten to that package's first-party `/assets/` route (published package
+   bytes, sniffed type, size-capped). Remote and other author-chosen URLs stay
+   links. Never render third-party markdown via an HTML string, `innerHTML`, or
+   a markdown-to-HTML renderer.
 9. **Package code never receives first-party credentials, and never executes on
    the app origin in production.** Every request handed to package code goes
    through `createPackageCodeRequest`

--- a/packages/worker/client/markdown-view.node.test.ts
+++ b/packages/worker/client/markdown-view.node.test.ts
@@ -118,6 +118,58 @@ test('markdown safety escapes raw HTML, never emits images, and drops unsafe lin
 	expect(html).toContain('https://example.com/auto</a>')
 })
 
+test('package README imageBaseHref emits img only for in-repo relative images', async () => {
+	const markdown = [
+		'![poster](./docs/poster.png)',
+		'',
+		'![nested](poster.png)',
+		'',
+		'![remote](https://img.example/badge.svg)',
+		'',
+		'![escape](../secret.png)',
+		'',
+		'![code](./src/index.ts)',
+	].join('\n')
+
+	const withAssets = await renderToString(
+		jsx('div', {
+			children: renderMarkdownNodes(markdown, {
+				imageBaseHref: '/@kody/doom/assets',
+				imageFromDirectory: '',
+			}),
+		}),
+	)
+	expect(withAssets).toContain(
+		'<img src="/@kody/doom/assets/docs/poster.png" alt="poster"',
+	)
+	expect(withAssets).toContain(
+		'<img src="/@kody/doom/assets/poster.png" alt="nested"',
+	)
+	expect(withAssets).not.toContain('<img src="https://img.example')
+	expect(withAssets).toContain(
+		'<a href="https://img.example/badge.svg" target="_blank" rel="noopener noreferrer nofollow ugc">remote</a>',
+	)
+	expect(withAssets).toContain('<span>escape</span>')
+	expect(withAssets).not.toContain('secret.png')
+	expect(withAssets).not.toContain('src/index.ts')
+
+	const fromDocs = await renderToString(
+		jsx('div', {
+			children: renderMarkdownNodes('![poster](./poster.png)', {
+				imageBaseHref: '/@kody/doom/assets',
+				imageFromDirectory: 'docs',
+			}),
+		}),
+	)
+	expect(fromDocs).toContain(
+		'<img src="/@kody/doom/assets/docs/poster.png" alt="poster"',
+	)
+
+	const defaultPolicy = await renderMarkdown('![poster](./docs/poster.png)')
+	expect(defaultPolicy).not.toContain('<img')
+	expect(defaultPolicy).toContain('<span>poster</span>')
+})
+
 test('first-party render options keep authored heading levels and drop the ugc rel', async () => {
 	const markdown = [
 		'# Top',

--- a/packages/worker/client/markdown-view.tsx
+++ b/packages/worker/client/markdown-view.tsx
@@ -11,11 +11,13 @@
  * - Fenced code paints pre-tokenized highlight data as JSX text and
  *   inline styles — never `innerHTML` — so highlighting cannot introduce
  *   markup. Missing tokens fall back to escaped plaintext.
- * - No resource-loading elements are emitted (`<img>`, `<iframe>`, media,
- *   etc.), so a README can never make a viewer's browser issue requests —
- *   including to hosted package endpoints (`/@username/packages/*` and the
- *   per-user subdomain mount `/packages/*`), which execute author-controlled
- *   code. Images render as plain links instead.
+ * - Resource-loading elements are not emitted by default (`<img>`,
+ *   `<iframe>`, media, etc.). Community READMEs may opt in to `<img>` only
+ *   for in-repo relative paths rewritten to this package's first-party
+ *   `/assets/` route. Remote, protocol-relative, and user-scope URLs stay
+ *   links (or plain text) so a README cannot hotlink arbitrary hosts or
+ *   point the browser at hosted package endpoints (`/@username/packages/*`
+ *   and `/packages/*`), which execute author-controlled code.
  * - Links must be absolute `http:`/`https:`/`mailto:` URLs. Relative URLs
  *   (which would resolve against this origin) and URLs whose path points at a
  *   hosted package surface (`/@...` or `/packages/...`) render as plain text.
@@ -38,6 +40,10 @@ import {
 	markdownTableCss,
 	mergeCss,
 } from '#universal/styles/style-primitives.ts'
+import {
+	joinPackageReadmeImageHref,
+	resolvePackageReadmeImagePath,
+} from '#universal/package-readme-images.ts'
 import {
 	colors,
 	radius,
@@ -79,6 +85,17 @@ export type RenderMarkdownOptions = {
 	 * `code` tokens. Missing or mismatched entries fall back to plaintext.
 	 */
 	fences?: Array<HighlightedCode>
+	/**
+	 * First-party `/assets/` prefix for this package. When set, relative
+	 * markdown images (`./docs/poster.png`) become `<img>` tags pointing at
+	 * that prefix. Empty keeps the default "images are links" policy.
+	 */
+	imageBaseHref?: string
+	/**
+	 * Directory of the markdown file, used to resolve `./` image hrefs.
+	 * Root READMEs leave this empty.
+	 */
+	imageFromDirectory?: string
 }
 
 type ResolvedRenderOptions = Required<Omit<RenderMarkdownOptions, 'fences'>> & {
@@ -92,6 +109,8 @@ const defaultRenderOptions = {
 	linkPolicy: 'untrusted' as const,
 	copyCodeBlocks: false,
 	fences: [] as Array<HighlightedCode>,
+	imageBaseHref: '',
+	imageFromDirectory: '',
 }
 
 /**
@@ -216,6 +235,19 @@ function decodeCharacterReferences(value: string): string {
 			return namedEntities[entity.toLowerCase()] ?? match
 		},
 	)
+}
+
+function resolveMarkdownImageSrc(
+	href: string,
+	options: ResolvedRenderOptions,
+): string | null {
+	if (!options.imageBaseHref) return null
+	const relativePath = resolvePackageReadmeImagePath(
+		href,
+		options.imageFromDirectory,
+	)
+	if (!relativePath) return null
+	return joinPackageReadmeImageHref(options.imageBaseHref, relativePath)
 }
 
 function renderLink(
@@ -385,10 +417,15 @@ function renderToken(
 				renderTokens(token.tokens, options),
 				options,
 			)
-		case 'image':
-			// Never emit <img>: auto-loading author-chosen URLs is exactly what
-			// this renderer exists to prevent. Offer the image as a link instead.
+		case 'image': {
+			const imageSrc = resolveMarkdownImageSrc(token.href, options)
+			if (imageSrc) {
+				return <img key={key} src={imageSrc} alt={token.text} />
+			}
+			// Remote / unsafe hrefs stay links (or plain text). Auto-loading
+			// author-chosen URLs is exactly what this renderer exists to prevent.
 			return renderLink(key, token.href, token.text || token.href, options)
+		}
 		case 'html':
 			// Comment-only tokens carry author/agent notes (guides embed agent
 			// steering in HTML comments); showing them as literal text would
@@ -507,6 +544,14 @@ const markdownCss = mergeCss(markdownTableCss, {
 	'& a': {
 		color: colors.primaryText,
 		textDecoration: 'underline',
+	},
+	'& img': {
+		display: 'block',
+		maxWidth: '100%',
+		height: 'auto',
+		margin: `${spacing.sm} 0`,
+		borderRadius: radius.md,
+		border: `1px solid ${colors.border}`,
 	},
 	'& hr': {
 		border: 'none',

--- a/packages/worker/client/package-files-explorer.tsx
+++ b/packages/worker/client/package-files-explorer.tsx
@@ -13,6 +13,7 @@ import {
 	listPackageFilesChildren,
 	packageFileLanguageLabel,
 } from '#universal/package-files.ts'
+import { directoryOfPackageFilePath } from '#universal/package-readme-images.ts'
 import { renderPackageRepoChrome } from '#universal/package-repo-nav.tsx'
 import { type PackageFilesLoaderData } from '#universal/loader-data.ts'
 import {
@@ -96,7 +97,7 @@ export function PackageFilesExplorer(
 	return () => {
 		const { data } = handle.props
 		syncExpanded(data.selectedPath, data.kind === 'directory')
-		const contentKey = `${data.selectedPath}\n${data.contentPath ?? ''}`
+		const contentKey = `${data.selectedPath}\n${data.contentPath ?? ''}\n${data.imageBaseHref ?? ''}`
 		if (contentFor !== contentKey) {
 			contentFor = contentKey
 			contentNode = renderContent(data)
@@ -376,6 +377,8 @@ function renderContent(data: PackageFilesLoaderData): RemixNode {
 				<div mix={css(markdownCss)} data-testid="package-files-markdown">
 					{renderMarkdownNodes(body, {
 						fences: data.contentFences,
+						imageBaseHref: data.imageBaseHref ?? undefined,
+						imageFromDirectory: directoryOfPackageFilePath(data.contentPath),
 					})}
 				</div>
 			) : (
@@ -839,6 +842,14 @@ const markdownCss = {
 	},
 	'& td code': {
 		whiteSpace: 'nowrap' as const,
+	},
+	'& img': {
+		display: 'block',
+		maxWidth: '100%',
+		height: 'auto',
+		margin: '1.15rem 0 0',
+		borderRadius: radius.md,
+		border: `1px solid ${colors.border}`,
 	},
 }
 

--- a/packages/worker/client/routes/community-detail-shared.ts
+++ b/packages/worker/client/routes/community-detail-shared.ts
@@ -29,6 +29,7 @@ export type CommunityDetailApiPayload = {
 	readmeContent: string | null
 	readmeFences?: Array<HighlightedCode>
 	hasAgentsDocs?: boolean
+	imageBaseHref?: string | null
 	ownerPackage: AccountPackageDetail | null
 	username: string
 	kodyId: string
@@ -62,6 +63,7 @@ export type CommunityShellSnapshot = {
 	readmeContent: string | null
 	readmeFences?: Array<HighlightedCode> | undefined
 	hasAgentsDocs: boolean
+	imageBaseHref: string | null
 	ownerPackage: AccountPackageDetail | null
 	username: string
 	kodyId: string
@@ -261,6 +263,7 @@ export async function communityDetailRouteLoader(
 				payload.readmeContent ?? payload.listing?.readmeContent ?? null,
 			readmeFences: payload.readmeFences,
 			hasAgentsDocs: payload.hasAgentsDocs === true,
+			imageBaseHref: payload.imageBaseHref ?? null,
 			viewerInstall: payload.viewerInstall,
 			ownerPackage: payload.ownerPackage,
 			username: payload.username,

--- a/packages/worker/client/routes/community-detail.tsx
+++ b/packages/worker/client/routes/community-detail.tsx
@@ -1,7 +1,6 @@
 import { Frame, type Handle, type RemixNode, css } from 'remix/ui'
 import { routes } from '#universal/routes.ts'
 import { getPackageTreeHref } from '#universal/package-files.ts'
-import { getCommunityPackageAssetBaseHref } from '#universal/package-readme-images.ts'
 import { COMMUNITY_DETAIL_TARGET } from '#universal/community-frame-constants.ts'
 import {
 	listenToRouterNavigation,
@@ -65,6 +64,7 @@ export function CommunityDetailRoute(handle: Handle) {
 	let readmeContent: string | null = null
 	let readmeFences: Array<HighlightedCode> = []
 	let hasAgentsDocs = false
+	let readmeImageBaseHref: string | null = null
 	let username = ''
 	let kodyId = ''
 	let shellStatus: 'loading' | 'ready' | 'error' = 'loading'
@@ -127,6 +127,7 @@ export function CommunityDetailRoute(handle: Handle) {
 		readmeContent = snapshot.readmeContent
 		readmeFences = snapshot.readmeFences ?? []
 		hasAgentsDocs = snapshot.hasAgentsDocs
+		readmeImageBaseHref = snapshot.imageBaseHref
 		username = snapshot.username
 		kodyId = snapshot.kodyId
 		reportState = 'idle'
@@ -192,6 +193,7 @@ export function CommunityDetailRoute(handle: Handle) {
 						payload.readmeContent ?? payload.listing?.readmeContent ?? null,
 					readmeFences: payload.readmeFences,
 					hasAgentsDocs: payload.hasAgentsDocs === true,
+					imageBaseHref: payload.imageBaseHref ?? null,
 					ownerPackage: payload.ownerPackage,
 					username: payload.username,
 					kodyId:
@@ -511,15 +513,6 @@ export function CommunityDetailRoute(handle: Handle) {
 						relativePath: 'AGENTS.md',
 					})
 				: null
-		const readmeImageBaseHref =
-			username && kodyId
-				? getCommunityPackageAssetBaseHref({
-						listingId,
-						ownerUsername: username,
-						kodyId,
-					})
-				: null
-
 		return (
 			<article
 				mix={[css(detailArticleCss), on('click', handleCommunityInstallClick)]}

--- a/packages/worker/client/routes/community-detail.tsx
+++ b/packages/worker/client/routes/community-detail.tsx
@@ -1,6 +1,7 @@
 import { Frame, type Handle, type RemixNode, css } from 'remix/ui'
 import { routes } from '#universal/routes.ts'
 import { getPackageTreeHref } from '#universal/package-files.ts'
+import { getCommunityPackageAssetBaseHref } from '#universal/package-readme-images.ts'
 import { COMMUNITY_DETAIL_TARGET } from '#universal/community-frame-constants.ts'
 import {
 	listenToRouterNavigation,
@@ -82,12 +83,22 @@ export function CommunityDetailRoute(handle: Handle) {
 	// the rendered README per markdown string (same policy as MarkdownView).
 	let renderedForReadme: string | null = null
 	let renderedForReadmeFences: Array<HighlightedCode> | undefined
+	let renderedForReadmeImageBase: string | null = null
 	let renderedReadme: Array<RemixNode> = []
 
-	function renderReadme(markdown: string, fences?: Array<HighlightedCode>) {
-		if (renderedForReadme !== markdown || renderedForReadmeFences !== fences) {
+	function renderReadme(
+		markdown: string,
+		fences: Array<HighlightedCode> | undefined,
+		imageBaseHref: string | null,
+	) {
+		if (
+			renderedForReadme !== markdown ||
+			renderedForReadmeFences !== fences ||
+			renderedForReadmeImageBase !== imageBaseHref
+		) {
 			renderedForReadme = markdown
 			renderedForReadmeFences = fences
+			renderedForReadmeImageBase = imageBaseHref
 			// Third-party README in the page's prose voice: authored `##`
 			// sections land on h3 (DESIGN.md's "h3 subheads"; publishing
 			// requires a `## Intent` section), the page keeps its h1, and the
@@ -95,6 +106,7 @@ export function CommunityDetailRoute(handle: Handle) {
 			renderedReadme = renderMarkdownNodes(markdown, {
 				headingOffset: 1,
 				fences,
+				imageBaseHref: imageBaseHref ?? undefined,
 			})
 		}
 		return renderedReadme
@@ -499,6 +511,14 @@ export function CommunityDetailRoute(handle: Handle) {
 						relativePath: 'AGENTS.md',
 					})
 				: null
+		const readmeImageBaseHref =
+			username && kodyId
+				? getCommunityPackageAssetBaseHref({
+						listingId,
+						ownerUsername: username,
+						kodyId,
+					})
+				: null
 
 		return (
 			<article
@@ -525,7 +545,11 @@ export function CommunityDetailRoute(handle: Handle) {
 
 						{readmeContent
 							? renderReadmeSection(
-									renderReadme(readmeContent, readmeFences),
+									renderReadme(
+										readmeContent,
+										readmeFences,
+										readmeImageBaseHref,
+									),
 									agentsDocsHref,
 								)
 							: renderEmptyReadme(agentsDocsHref)}

--- a/packages/worker/src/app/handlers/community-detail.tsx
+++ b/packages/worker/src/app/handlers/community-detail.tsx
@@ -319,6 +319,7 @@ export function createCommunityPackageHandler(env: Env) {
 						usedListingReadme: Boolean(page.listing.listing.readmeContent),
 						sourceId: page.ownerPackage?.sourceId,
 						publishedCommit: page.ownerPackage?.publishedCommit,
+						pinnedCommit: page.listing.listing.pinnedCommit,
 					}),
 				])
 				return renderAppPage({
@@ -550,6 +551,7 @@ export function createCommunityPackageApiHandler(env: Env) {
 					usedListingReadme: Boolean(page.listing?.listing?.readmeContent),
 					sourceId: page.ownerPackage?.sourceId,
 					publishedCommit: page.ownerPackage?.publishedCommit,
+					pinnedCommit: page.listing?.listing?.pinnedCommit,
 				}),
 			])
 			return jsonResponse(

--- a/packages/worker/src/app/handlers/community-detail.tsx
+++ b/packages/worker/src/app/handlers/community-detail.tsx
@@ -7,6 +7,7 @@ import { loadPackagePage } from '#app/package-page.ts'
 import {
 	loadOwnerPackageReadme,
 	loadPackagePageHasAgentsDocs,
+	resolvePackagePageReadmeImageBaseHref,
 } from '#app/package-files-data.ts'
 import { resolveCanonicalListingPath } from '#app/community-package-route.ts'
 import { REMIX_FRAME_TARGET_HEADER } from '#universal/frame-constants.ts'
@@ -94,7 +95,7 @@ async function renderCommunityListingPage(input: {
 	}
 
 	const serverTiming: Array<ServerTimingEntry> = []
-	const [readmeFences, hasAgentsDocs] = await Promise.all([
+	const [readmeFences, hasAgentsDocs, imageBaseHref] = await Promise.all([
 		highlightReadmeFences(
 			input.env,
 			detail.listing.readmeContent,
@@ -112,6 +113,14 @@ async function renderCommunityListingPage(input: {
 				}),
 			input.request,
 		),
+		resolvePackagePageReadmeImageBaseHref({
+			env: input.env,
+			request: input.request,
+			listingId: input.listingId,
+			ownerUsername: detail.username,
+			kodyId: detail.listing.kodyId,
+			usedListingReadme: true,
+		}),
 	])
 
 	return renderAppPage({
@@ -132,6 +141,7 @@ async function renderCommunityListingPage(input: {
 				readmeContent: detail.listing.readmeContent,
 				readmeFences,
 				hasAgentsDocs,
+				imageBaseHref,
 				viewerInstall: detail.viewerInstall,
 				ownerPackage: detail.ownerPackage,
 				username: detail.username,
@@ -277,7 +287,7 @@ export function createCommunityPackageHandler(env: Env) {
 
 			if (page.listing?.listing) {
 				const serverTiming: Array<ServerTimingEntry> = []
-				const [readme, hasAgentsDocs] = await Promise.all([
+				const [readme, hasAgentsDocs, imageBaseHref] = await Promise.all([
 					readmeForPackagePage(
 						{
 							env,
@@ -300,6 +310,16 @@ export function createCommunityPackageHandler(env: Env) {
 							}),
 						request,
 					),
+					resolvePackagePageReadmeImageBaseHref({
+						env,
+						request,
+						listingId: page.listing.listing.id,
+						ownerUsername: page.username,
+						kodyId: page.kodyId,
+						usedListingReadme: Boolean(page.listing.listing.readmeContent),
+						sourceId: page.ownerPackage?.sourceId,
+						publishedCommit: page.ownerPackage?.publishedCommit,
+					}),
 				])
 				return renderAppPage({
 					request,
@@ -319,6 +339,7 @@ export function createCommunityPackageHandler(env: Env) {
 							readmeContent: readme.readmeContent,
 							readmeFences: readme.readmeFences,
 							hasAgentsDocs,
+							imageBaseHref,
 							viewerInstall: page.listing.viewerInstall,
 							ownerPackage: page.ownerPackage,
 							username: page.username,
@@ -336,7 +357,7 @@ export function createCommunityPackageHandler(env: Env) {
 			}
 
 			const serverTiming: Array<ServerTimingEntry> = []
-			const [readme, hasAgentsDocs] = await Promise.all([
+			const [readme, hasAgentsDocs, imageBaseHref] = await Promise.all([
 				readmeForPackagePage(
 					{
 						env,
@@ -359,6 +380,15 @@ export function createCommunityPackageHandler(env: Env) {
 						}),
 					request,
 				),
+				resolvePackagePageReadmeImageBaseHref({
+					env,
+					request,
+					ownerUsername: page.username,
+					kodyId: page.kodyId,
+					usedListingReadme: false,
+					sourceId: page.ownerPackage.sourceId,
+					publishedCommit: page.ownerPackage.publishedCommit,
+				}),
 			])
 			return renderAppPage({
 				request,
@@ -379,6 +409,7 @@ export function createCommunityPackageHandler(env: Env) {
 						readmeContent: readme.readmeContent,
 						readmeFences: readme.readmeFences,
 						hasAgentsDocs,
+						imageBaseHref,
 						viewerInstall: null,
 						ownerPackage: page.ownerPackage,
 						username: page.username,
@@ -408,7 +439,7 @@ export function createCommunityDetailApiHandler(env: Env) {
 			}
 
 			const serverTiming: Array<ServerTimingEntry> = []
-			const [readmeFences, hasAgentsDocs] = await Promise.all([
+			const [readmeFences, hasAgentsDocs, imageBaseHref] = await Promise.all([
 				highlightReadmeFences(env, detail.listing.readmeContent, serverTiming),
 				recordServerTiming(
 					'agents-docs',
@@ -422,6 +453,14 @@ export function createCommunityDetailApiHandler(env: Env) {
 						}),
 					request,
 				),
+				resolvePackagePageReadmeImageBaseHref({
+					env,
+					request,
+					listingId,
+					ownerUsername: detail.username,
+					kodyId: detail.listing.kodyId,
+					usedListingReadme: true,
+				}),
 			])
 			return jsonResponse(
 				request,
@@ -432,6 +471,7 @@ export function createCommunityDetailApiHandler(env: Env) {
 					isPrivate: false,
 					readmeFences,
 					hasAgentsDocs,
+					imageBaseHref,
 				},
 				200,
 				serverTiming,
@@ -478,7 +518,7 @@ export function createCommunityPackageApiHandler(env: Env) {
 			}
 
 			const serverTiming: Array<ServerTimingEntry> = []
-			const [readme, hasAgentsDocs] = await Promise.all([
+			const [readme, hasAgentsDocs, imageBaseHref] = await Promise.all([
 				readmeForPackagePage(
 					{
 						env,
@@ -501,6 +541,16 @@ export function createCommunityPackageApiHandler(env: Env) {
 						}),
 					request,
 				),
+				resolvePackagePageReadmeImageBaseHref({
+					env,
+					request,
+					listingId: page.listing?.listing?.id,
+					ownerUsername: page.username,
+					kodyId: page.kodyId,
+					usedListingReadme: Boolean(page.listing?.listing?.readmeContent),
+					sourceId: page.ownerPackage?.sourceId,
+					publishedCommit: page.ownerPackage?.publishedCommit,
+				}),
 			])
 			return jsonResponse(
 				request,
@@ -516,6 +566,7 @@ export function createCommunityPackageApiHandler(env: Env) {
 					readmeContent: readme.readmeContent,
 					readmeFences: readme.readmeFences,
 					hasAgentsDocs,
+					imageBaseHref,
 					ownerPackage: page.ownerPackage,
 					username: page.username,
 					kodyId: page.kodyId,
@@ -578,6 +629,7 @@ export function createCommunityPackageSettingsHandler(env: Env) {
 						featured: false,
 						readmeContent: null,
 						hasAgentsDocs: false,
+						imageBaseHref: null,
 						viewerInstall: null,
 						ownerPackage: page.ownerPackage,
 						username: page.username,

--- a/packages/worker/src/app/handlers/package-readme-assets.node.test.ts
+++ b/packages/worker/src/app/handlers/package-readme-assets.node.test.ts
@@ -1,0 +1,175 @@
+import { expect, test, vi } from 'vitest'
+import { consoleError } from '#worker/test-support/console-spies.ts'
+import { tinyPngBytes } from '#worker/test-support/images-binding.ts'
+import { type CommunityListingRecord } from '#worker/community/types.ts'
+
+const mocks = vi.hoisted(() => ({
+	resolveCommunityPackageUrl: vi.fn<() => Promise<unknown>>(),
+	getCommunityListingById: vi.fn<() => Promise<unknown>>(),
+	getEntitySourceById: vi.fn<() => Promise<unknown>>(),
+	readArtifactFileAtCommit: vi.fn<() => Promise<unknown>>(),
+	loadPackagePage: vi.fn<() => Promise<unknown>>(),
+}))
+
+vi.mock('#worker/community/package-url.ts', () => ({
+	resolveCommunityPackageUrl: (...args: Array<unknown>) =>
+		mocks.resolveCommunityPackageUrl(...args),
+}))
+
+vi.mock('#worker/community/repo.ts', () => ({
+	getCommunityListingById: (...args: Array<unknown>) =>
+		mocks.getCommunityListingById(...args),
+}))
+
+vi.mock('#worker/repo/entity-sources.ts', () => ({
+	getEntitySourceById: (...args: Array<unknown>) =>
+		mocks.getEntitySourceById(...args),
+}))
+
+vi.mock('#worker/repo/artifact-file.ts', () => ({
+	readArtifactFileAtCommit: (...args: Array<unknown>) =>
+		mocks.readArtifactFileAtCommit(...args),
+}))
+
+vi.mock('#app/package-page.ts', () => ({
+	loadPackagePage: (...args: Array<unknown>) => mocks.loadPackagePage(...args),
+}))
+
+const {
+	createCommunityDetailAssetHandler,
+	createCommunityPackageAssetHandler,
+} = await import('./package-readme-assets.ts')
+
+const listing = {
+	id: 'listing-1',
+	ownerUserId: 'owner-1',
+	packageId: 'package-1',
+	sourceId: 'source-1',
+	kodyId: 'doom',
+	name: '@kody/doom',
+	description: 'DOOM',
+	tags: [],
+	category: 'integrations',
+	searchText: null,
+	readmeContent: null,
+	license: 'MIT',
+	pinnedCommit: 'abc123',
+	iconCommit: 'abc123',
+	status: 'active',
+	trustedCommit: null,
+	trustedAt: null,
+	trusted: false,
+	featuredAt: null,
+	featured: false,
+	createdAt: '2026-07-10T00:00:00.000Z',
+	updatedAt: '2026-07-10T00:00:00.000Z',
+	publishedAt: '2026-07-10T00:00:00.000Z',
+} satisfies CommunityListingRecord
+
+function callPackageHandler(input: {
+	username?: string
+	kodyId?: string
+	relativePath?: string
+}) {
+	const username = input.username ?? 'kody'
+	const kodyId = input.kodyId ?? 'doom'
+	const relativePath = input.relativePath ?? 'docs/poster.png'
+	const handler = createCommunityPackageAssetHandler({ APP_DB: {} } as Env)
+	const url = `https://kody.codes/@${username}/${kodyId}/assets/${relativePath}`
+	return handler.handler({
+		request: new Request(url),
+		params: { username, kodyId, relativePath },
+		url: new URL(url),
+	} as never)
+}
+
+function callListingHandler(relativePath = 'docs/poster.png') {
+	const handler = createCommunityDetailAssetHandler({ APP_DB: {} } as Env)
+	const url = `https://kody.codes/community/${listing.id}/assets/${relativePath}`
+	return handler.handler({
+		request: new Request(url),
+		params: { listingId: listing.id, relativePath },
+		url: new URL(url),
+	} as never)
+}
+
+test('package README asset handlers serve published image bytes and refuse unsafe paths', async () => {
+	mocks.resolveCommunityPackageUrl.mockResolvedValue({
+		kind: 'listing',
+		listingId: listing.id,
+		username: 'kody',
+		kodyId: 'doom',
+	})
+	mocks.getCommunityListingById.mockResolvedValue(listing)
+	mocks.getEntitySourceById.mockResolvedValue({ repo_id: 'repo-1' })
+	mocks.readArtifactFileAtCommit.mockResolvedValue(tinyPngBytes)
+
+	const response = await callPackageHandler({})
+	expect(response.status).toBe(200)
+	expect(response.headers.get('Content-Type')).toBe('image/png')
+	expect(response.headers.get('Cache-Control')).toBe('public, max-age=3600')
+	expect(response.headers.get('X-Content-Type-Options')).toBe('nosniff')
+	expect(response.headers.get('Cross-Origin-Resource-Policy')).toBe(
+		'same-origin',
+	)
+	expect(new Uint8Array(await response.arrayBuffer())).toEqual(tinyPngBytes)
+	expect(mocks.readArtifactFileAtCommit).toHaveBeenCalledWith(
+		expect.objectContaining({
+			repoId: 'repo-1',
+			commit: listing.pinnedCommit,
+			filePath: 'docs/poster.png',
+		}),
+	)
+
+	const listingResponse = await callListingHandler()
+	expect(listingResponse.status).toBe(200)
+	expect(listingResponse.headers.get('Content-Type')).toBe('image/png')
+
+	expect(
+		(await callPackageHandler({ relativePath: '../secret.png' })).status,
+	).toBe(404)
+	expect(
+		(await callPackageHandler({ relativePath: 'src/index.ts' })).status,
+	).toBe(404)
+	expect((await callPackageHandler({ kodyId: 'packages' })).status).toBe(404)
+
+	mocks.readArtifactFileAtCommit.mockResolvedValue(
+		new TextEncoder().encode('not-an-image'),
+	)
+	expect((await callPackageHandler({})).status).toBe(404)
+
+	consoleError.mockImplementation(() => {})
+	mocks.readArtifactFileAtCommit.mockRejectedValue(new Error('git down'))
+	expect((await callPackageHandler({})).status).toBe(404)
+	expect(consoleError).toHaveBeenCalledWith(
+		'package-readme-asset-load-failed',
+		listing.sourceId,
+		'docs/poster.png',
+		expect.any(Error),
+	)
+
+	mocks.resolveCommunityPackageUrl.mockResolvedValue(null)
+	mocks.loadPackagePage.mockResolvedValue({
+		kind: 'page',
+		ownerPackage: { sourceId: 'owner-source', publishedCommit: 'def456' },
+		viewerIsOwner: true,
+	})
+	mocks.getEntitySourceById.mockResolvedValue({ repo_id: 'owner-repo' })
+	mocks.readArtifactFileAtCommit.mockResolvedValue(tinyPngBytes)
+	const privateResponse = await callPackageHandler({})
+	expect(privateResponse.status).toBe(200)
+	expect(privateResponse.headers.get('Cache-Control')).toBe('private, no-store')
+	expect(mocks.readArtifactFileAtCommit).toHaveBeenCalledWith(
+		expect.objectContaining({
+			repoId: 'owner-repo',
+			commit: 'def456',
+		}),
+	)
+
+	mocks.loadPackagePage.mockResolvedValue({
+		kind: 'page',
+		ownerPackage: { sourceId: 'owner-source', publishedCommit: 'def456' },
+		viewerIsOwner: false,
+	})
+	expect((await callPackageHandler({})).status).toBe(404)
+})

--- a/packages/worker/src/app/handlers/package-readme-assets.node.test.ts
+++ b/packages/worker/src/app/handlers/package-readme-assets.node.test.ts
@@ -2,12 +2,15 @@ import { expect, test, vi } from 'vitest'
 import { consoleError } from '#worker/test-support/console-spies.ts'
 import { tinyPngBytes } from '#worker/test-support/images-binding.ts'
 import { type CommunityListingRecord } from '#worker/community/types.ts'
+import { bytesToLatin1String } from '#universal/package-file-media.ts'
 
 const mocks = vi.hoisted(() => ({
 	resolveCommunityPackageUrl: vi.fn<() => Promise<unknown>>(),
 	getCommunityListingById: vi.fn<() => Promise<unknown>>(),
 	getEntitySourceById: vi.fn<() => Promise<unknown>>(),
 	readArtifactFileAtCommit: vi.fn<() => Promise<unknown>>(),
+	readPublishedSourceSnapshot: vi.fn<() => Promise<unknown>>(),
+	readCommunitySnapshot: vi.fn<() => Promise<unknown>>(),
 	loadPackagePage: vi.fn<() => Promise<unknown>>(),
 }))
 
@@ -29,6 +32,16 @@ vi.mock('#worker/repo/entity-sources.ts', () => ({
 vi.mock('#worker/repo/artifact-file.ts', () => ({
 	readArtifactFileAtCommit: (...args: Array<unknown>) =>
 		mocks.readArtifactFileAtCommit(...args),
+}))
+
+vi.mock('#worker/package-runtime/published-runtime-artifacts.ts', () => ({
+	readPublishedSourceSnapshot: (...args: Array<unknown>) =>
+		mocks.readPublishedSourceSnapshot(...args),
+}))
+
+vi.mock('#worker/community/snapshot.ts', () => ({
+	readCommunitySnapshot: (...args: Array<unknown>) =>
+		mocks.readCommunitySnapshot(...args),
 }))
 
 vi.mock('#app/package-page.ts', () => ({
@@ -74,7 +87,10 @@ function callPackageHandler(input: {
 	const username = input.username ?? 'kody'
 	const kodyId = input.kodyId ?? 'doom'
 	const relativePath = input.relativePath ?? 'docs/poster.png'
-	const handler = createCommunityPackageAssetHandler({ APP_DB: {} } as Env)
+	const handler = createCommunityPackageAssetHandler({
+		APP_DB: {},
+		BUNDLE_ARTIFACTS_KV: {},
+	} as Env)
 	const url = `https://kody.codes/@${username}/${kodyId}/assets/${relativePath}`
 	return handler.handler({
 		request: new Request(url),
@@ -84,7 +100,10 @@ function callPackageHandler(input: {
 }
 
 function callListingHandler(relativePath = 'docs/poster.png') {
-	const handler = createCommunityDetailAssetHandler({ APP_DB: {} } as Env)
+	const handler = createCommunityDetailAssetHandler({
+		APP_DB: {},
+		BUNDLE_ARTIFACTS_KV: {},
+	} as Env)
 	const url = `https://kody.codes/community/${listing.id}/assets/${relativePath}`
 	return handler.handler({
 		request: new Request(url),
@@ -103,6 +122,8 @@ test('package README asset handlers serve published image bytes and refuse unsaf
 	mocks.getCommunityListingById.mockResolvedValue(listing)
 	mocks.getEntitySourceById.mockResolvedValue({ repo_id: 'repo-1' })
 	mocks.readArtifactFileAtCommit.mockResolvedValue(tinyPngBytes)
+	mocks.readPublishedSourceSnapshot.mockResolvedValue(null)
+	mocks.readCommunitySnapshot.mockResolvedValue(null)
 
 	const response = await callPackageHandler({})
 	expect(response.status).toBe(200)
@@ -147,6 +168,26 @@ test('package README asset handlers serve published image bytes and refuse unsaf
 		'docs/poster.png',
 		expect.any(Error),
 	)
+
+	mocks.readPublishedSourceSnapshot.mockResolvedValue({
+		files: { 'docs/poster.png': bytesToLatin1String(tinyPngBytes) },
+	})
+	const snapshotResponse = await callPackageHandler({})
+	expect(snapshotResponse.status).toBe(200)
+	expect(new Uint8Array(await snapshotResponse.arrayBuffer())).toEqual(
+		tinyPngBytes,
+	)
+
+	mocks.readPublishedSourceSnapshot.mockResolvedValue(null)
+	mocks.readCommunitySnapshot.mockResolvedValue({
+		files: { 'docs/poster.png': bytesToLatin1String(tinyPngBytes) },
+	})
+	const listingSnapshotResponse = await callListingHandler()
+	expect(listingSnapshotResponse.status).toBe(200)
+	expect(new Uint8Array(await listingSnapshotResponse.arrayBuffer())).toEqual(
+		tinyPngBytes,
+	)
+	mocks.readCommunitySnapshot.mockResolvedValue(null)
 
 	mocks.resolveCommunityPackageUrl.mockResolvedValue(null)
 	mocks.loadPackagePage.mockResolvedValue({

--- a/packages/worker/src/app/handlers/package-readme-assets.ts
+++ b/packages/worker/src/app/handlers/package-readme-assets.ts
@@ -4,12 +4,11 @@ import { resolveCommunityPackageUrl } from '#worker/community/package-url.ts'
 import { getCommunityListingById } from '#worker/community/repo.ts'
 import {
 	buildPackageReadmeAssetHeaders,
+	loadPackageReadmeAssetBytes,
 	packageReadmeAssetCacheControl,
 	packageReadmeAssetPrivateCacheControl,
 	sniffPackageReadmeImageContentType,
 } from '#worker/community/package-readme-asset.ts'
-import { getEntitySourceById } from '#worker/repo/entity-sources.ts'
-import { readArtifactFileAtCommit } from '#worker/repo/artifact-file.ts'
 import {
 	isPackageReadmeImagePath,
 	resolvePackageReadmeImagePath,
@@ -31,27 +30,16 @@ async function servePublishedPackageReadmeAsset(input: {
 	commit: string
 	relativePath: string
 	cacheControl: string
+	listingId?: string | null
 }) {
 	if (!isPackageReadmeImagePath(input.relativePath)) return notFound()
-	const source = await getEntitySourceById(input.env.APP_DB, input.sourceId)
-	if (!source?.repo_id || !input.commit) return notFound()
-	let bytes: Uint8Array | null
-	try {
-		bytes = await readArtifactFileAtCommit({
-			env: input.env,
-			repoId: source.repo_id,
-			commit: input.commit,
-			filePath: input.relativePath,
-		})
-	} catch (error) {
-		console.error(
-			'package-readme-asset-load-failed',
-			input.sourceId,
-			input.relativePath,
-			error,
-		)
-		return notFound()
-	}
+	const bytes = await loadPackageReadmeAssetBytes({
+		env: input.env,
+		sourceId: input.sourceId,
+		commit: input.commit,
+		relativePath: input.relativePath,
+		listingId: input.listingId,
+	})
 	if (!bytes) return notFound()
 	const contentType = sniffPackageReadmeImageContentType(
 		bytes,
@@ -92,6 +80,7 @@ export function createCommunityPackageAssetHandler(env: Env) {
 					sourceId: listing.sourceId,
 					commit: listing.pinnedCommit,
 					relativePath,
+					listingId: listing.id,
 					cacheControl: packageReadmeAssetCacheControl,
 				})
 			}
@@ -134,6 +123,7 @@ export function createCommunityDetailAssetHandler(env: Env) {
 				sourceId: listing.sourceId,
 				commit: listing.pinnedCommit,
 				relativePath,
+				listingId: listing.id,
 				cacheControl: packageReadmeAssetCacheControl,
 			})
 		},

--- a/packages/worker/src/app/handlers/package-readme-assets.ts
+++ b/packages/worker/src/app/handlers/package-readme-assets.ts
@@ -1,0 +1,141 @@
+import { type Action } from 'remix/router'
+import { loadPackagePage } from '#app/package-page.ts'
+import { resolveCommunityPackageUrl } from '#worker/community/package-url.ts'
+import { getCommunityListingById } from '#worker/community/repo.ts'
+import {
+	buildPackageReadmeAssetHeaders,
+	packageReadmeAssetCacheControl,
+	packageReadmeAssetPrivateCacheControl,
+	sniffPackageReadmeImageContentType,
+} from '#worker/community/package-readme-asset.ts'
+import { getEntitySourceById } from '#worker/repo/entity-sources.ts'
+import { readArtifactFileAtCommit } from '#worker/repo/artifact-file.ts'
+import {
+	isPackageReadmeImagePath,
+	resolvePackageReadmeImagePath,
+} from '#universal/package-readme-images.ts'
+import { isReservedPackageFilesKodyId } from '#universal/package-files.ts'
+import { type routes } from '#universal/routes.ts'
+
+function notFound() {
+	return new Response('Not found', { status: 404 })
+}
+
+function selectedAssetPath(relativePath: string | undefined) {
+	return resolvePackageReadmeImagePath(relativePath ?? '', '')
+}
+
+async function servePublishedPackageReadmeAsset(input: {
+	env: Env
+	sourceId: string
+	commit: string
+	relativePath: string
+	cacheControl: string
+}) {
+	if (!isPackageReadmeImagePath(input.relativePath)) return notFound()
+	const source = await getEntitySourceById(input.env.APP_DB, input.sourceId)
+	if (!source?.repo_id || !input.commit) return notFound()
+	let bytes: Uint8Array | null
+	try {
+		bytes = await readArtifactFileAtCommit({
+			env: input.env,
+			repoId: source.repo_id,
+			commit: input.commit,
+			filePath: input.relativePath,
+		})
+	} catch (error) {
+		console.error(
+			'package-readme-asset-load-failed',
+			input.sourceId,
+			input.relativePath,
+			error,
+		)
+		return notFound()
+	}
+	if (!bytes) return notFound()
+	const contentType = sniffPackageReadmeImageContentType(
+		bytes,
+		input.relativePath,
+	)
+	if (!contentType) return notFound()
+	return new Response(Uint8Array.from(bytes), {
+		headers: buildPackageReadmeAssetHeaders({
+			contentType,
+			byteLength: bytes.byteLength,
+			etag: `"${input.commit}:${input.relativePath}:${bytes.byteLength}"`,
+			cacheControl: input.cacheControl,
+		}),
+	})
+}
+
+export function createCommunityPackageAssetHandler(env: Env) {
+	return {
+		middleware: [],
+		async handler({ request, params }) {
+			if (isReservedPackageFilesKodyId(params.kodyId)) return notFound()
+			const relativePath = selectedAssetPath(params.relativePath)
+			if (!relativePath) return notFound()
+
+			const publicTarget = await resolveCommunityPackageUrl({
+				db: env.APP_DB,
+				username: params.username,
+				kodyId: params.kodyId,
+			})
+			if (publicTarget) {
+				const listing = await getCommunityListingById(env.APP_DB, {
+					listingId: publicTarget.listingId,
+					includeDelisted: false,
+				})
+				if (!listing) return notFound()
+				return servePublishedPackageReadmeAsset({
+					env,
+					sourceId: listing.sourceId,
+					commit: listing.pinnedCommit,
+					relativePath,
+					cacheControl: packageReadmeAssetCacheControl,
+				})
+			}
+
+			const page = await loadPackagePage({
+				env,
+				request,
+				username: params.username,
+				kodyId: params.kodyId,
+			})
+			if (page.kind !== 'page' || !page.ownerPackage || !page.viewerIsOwner) {
+				return notFound()
+			}
+			return servePublishedPackageReadmeAsset({
+				env,
+				sourceId: page.ownerPackage.sourceId,
+				commit: page.ownerPackage.publishedCommit ?? '',
+				relativePath,
+				cacheControl: packageReadmeAssetPrivateCacheControl,
+			})
+		},
+	} satisfies Action<typeof routes.communityPackageAsset>
+}
+
+export function createCommunityDetailAssetHandler(env: Env) {
+	return {
+		middleware: [],
+		async handler({ params }) {
+			const relativePath = selectedAssetPath(params.relativePath)
+			if (!relativePath) return notFound()
+
+			const listing = await getCommunityListingById(env.APP_DB, {
+				listingId: params.listingId,
+				includeDelisted: false,
+			})
+			if (!listing) return notFound()
+
+			return servePublishedPackageReadmeAsset({
+				env,
+				sourceId: listing.sourceId,
+				commit: listing.pinnedCommit,
+				relativePath,
+				cacheControl: packageReadmeAssetCacheControl,
+			})
+		},
+	} satisfies Action<typeof routes.communityDetailAsset>
+}

--- a/packages/worker/src/app/package-files-data.node.test.ts
+++ b/packages/worker/src/app/package-files-data.node.test.ts
@@ -237,4 +237,39 @@ test('package page README images follow the pin, not unpublished HEAD', async ()
 			publishedCommit: 'abc123',
 		}),
 	).toBe(null)
+
+	mockModule.resolveArtifactSourceHead.mockResolvedValue({
+		branch: 'main',
+		commit: 'published-ahead',
+	})
+	expect(
+		await resolvePackagePageReadmeImageBaseHref({
+			env,
+			request,
+			listingId: 'listing-1',
+			ownerUsername: 'kentcdodds',
+			kodyId: 'sentry',
+			usedListingReadme: false,
+			sourceId: 'src-1',
+			publishedCommit: 'published-ahead',
+			pinnedCommit: 'abc123',
+		}),
+	).toBe(null)
+	mockModule.resolveArtifactSourceHead.mockResolvedValue({
+		branch: 'main',
+		commit: 'abc123',
+	})
+	expect(
+		await resolvePackagePageReadmeImageBaseHref({
+			env,
+			request,
+			listingId: 'listing-1',
+			ownerUsername: 'kentcdodds',
+			kodyId: 'sentry',
+			usedListingReadme: false,
+			sourceId: 'src-1',
+			publishedCommit: 'published-ahead',
+			pinnedCommit: 'abc123',
+		}),
+	).toBe('/@kentcdodds/sentry/assets')
 })

--- a/packages/worker/src/app/package-files-data.node.test.ts
+++ b/packages/worker/src/app/package-files-data.node.test.ts
@@ -52,8 +52,11 @@ vi.mock('#app/highlight-code.ts', () => ({
 		mockModule.highlightSnippets(...args),
 }))
 
-const { loadCommunityPackageFilesData, loadPackagePageHasAgentsDocs } =
-	await import('./package-files-data.ts')
+const {
+	loadCommunityPackageFilesData,
+	loadPackagePageHasAgentsDocs,
+	resolvePackagePageReadmeImageBaseHref,
+} = await import('./package-files-data.ts')
 
 const env = { APP_DB: {}, BUNDLE_ARTIFACTS_KV: {} } as Env
 const listing = {
@@ -118,6 +121,34 @@ test('listed package tree marks the owner so Settings stays on the chrome', asyn
 	})
 })
 
+test('listed package tree omits imageBaseHref when HEAD is not the pin', async () => {
+	mockModule.getCommunityListingById.mockResolvedValue(listing)
+	mockModule.getEntitySourceById.mockResolvedValue({
+		repo_id: 'repo-1',
+		published_commit: 'abc123',
+	})
+	mockModule.resolveArtifactSourceHead.mockResolvedValue({
+		branch: 'main',
+		commit: 'deadbeef',
+	})
+	mockModule.readPublishedSourceSnapshot.mockResolvedValue({
+		files: { 'README.md': '![poster](./docs/poster.png)\n' },
+	})
+	mockModule.readAuthenticatedAppUser.mockResolvedValue(null)
+
+	const ahead = await loadCommunityPackageFilesData({
+		env,
+		request: new Request('https://example.com/@kentcdodds/sentry/tree/main'),
+		listingId: 'listing-1',
+		selectedPath: '',
+		ref: 'main',
+	})
+	expect(ahead).toMatchObject({
+		ok: true,
+		imageBaseHref: null,
+	})
+})
+
 test('package page reports AGENTS.md only when a non-empty root file exists', async () => {
 	mockModule.readCommunitySnapshot.mockResolvedValue({
 		files: { 'README.md': '# Sentry\n' },
@@ -157,4 +188,53 @@ test('package page reports AGENTS.md only when a non-empty root file exists', as
 			viewerIsOwner: false,
 		}),
 	).toBe(false)
+})
+
+test('package page README images follow the pin, not unpublished HEAD', async () => {
+	const request = new Request('https://example.com/@kentcdodds/sentry')
+	expect(
+		await resolvePackagePageReadmeImageBaseHref({
+			env,
+			request,
+			listingId: 'listing-1',
+			ownerUsername: 'kentcdodds',
+			kodyId: 'sentry',
+			usedListingReadme: true,
+			sourceId: 'src-1',
+			publishedCommit: 'abc123',
+		}),
+	).toBe('/@kentcdodds/sentry/assets')
+
+	mockModule.getEntitySourceById.mockResolvedValue({ repo_id: 'repo-1' })
+	mockModule.resolveArtifactSourceHead.mockResolvedValue({
+		branch: 'main',
+		commit: 'abc123',
+	})
+	expect(
+		await resolvePackagePageReadmeImageBaseHref({
+			env,
+			request,
+			ownerUsername: 'kentcdodds',
+			kodyId: 'sentry',
+			usedListingReadme: false,
+			sourceId: 'src-1',
+			publishedCommit: 'abc123',
+		}),
+	).toBe('/@kentcdodds/sentry/assets')
+
+	mockModule.resolveArtifactSourceHead.mockResolvedValue({
+		branch: 'main',
+		commit: 'deadbeef',
+	})
+	expect(
+		await resolvePackagePageReadmeImageBaseHref({
+			env,
+			request,
+			ownerUsername: 'kentcdodds',
+			kodyId: 'sentry',
+			usedListingReadme: false,
+			sourceId: 'src-1',
+			publishedCommit: 'abc123',
+		}),
+	).toBe(null)
 })

--- a/packages/worker/src/app/package-files-data.node.test.ts
+++ b/packages/worker/src/app/package-files-data.node.test.ts
@@ -100,6 +100,7 @@ test('listed package tree marks the owner so Settings stays on the chrome', asyn
 		isPrivate: false,
 		backHref: '/@kentcdodds/sentry',
 		filesBasePath: '/@kentcdodds/sentry/tree/main',
+		imageBaseHref: '/@kentcdodds/sentry/assets',
 	})
 
 	mockModule.readAuthenticatedAppUser.mockResolvedValue(null)

--- a/packages/worker/src/app/package-files-data.ts
+++ b/packages/worker/src/app/package-files-data.ts
@@ -31,6 +31,7 @@ import { readArtifactSourceSnapshot } from '#worker/repo/artifact-source-snapsho
 import { recordServerTiming } from '#worker/request-context.ts'
 import { getEntitySourceById } from '#worker/repo/entity-sources.ts'
 import { findRootPackageDoc } from '#worker/repo/required-package-docs.ts'
+import { getCommunityPackageAssetBaseHref } from '#universal/package-readme-images.ts'
 
 export function readPackageFilesSelectedPath(requestUrl: string) {
 	const url = new URL(requestUrl, 'http://localhost')
@@ -49,6 +50,7 @@ async function toLoaderData(input: {
 	kodyId?: string
 	viewerIsOwner?: boolean
 	isPrivate?: boolean
+	listingId?: string | null
 }): Promise<PackageFilesLoaderData> {
 	const content = input.view.content
 	const language = input.view.language
@@ -90,6 +92,11 @@ async function toLoaderData(input: {
 		kodyId: input.kodyId,
 		viewerIsOwner: input.viewerIsOwner,
 		isPrivate: input.isPrivate,
+		imageBaseHref: getCommunityPackageAssetBaseHref({
+			listingId: input.listingId,
+			ownerUsername: input.username,
+			kodyId: input.kodyId,
+		}),
 	}
 }
 
@@ -189,6 +196,7 @@ export async function loadCommunityPackageFilesData(input: {
 		kodyId: listing.kodyId,
 		viewerIsOwner: viewerUserId === listing.ownerUserId,
 		isPrivate: false,
+		listingId: listing.id,
 	})
 }
 

--- a/packages/worker/src/app/package-files-data.ts
+++ b/packages/worker/src/app/package-files-data.ts
@@ -31,7 +31,10 @@ import { readArtifactSourceSnapshot } from '#worker/repo/artifact-source-snapsho
 import { recordServerTiming } from '#worker/request-context.ts'
 import { getEntitySourceById } from '#worker/repo/entity-sources.ts'
 import { findRootPackageDoc } from '#worker/repo/required-package-docs.ts'
-import { getCommunityPackageAssetBaseHref } from '#universal/package-readme-images.ts'
+import {
+	getCommunityPackageAssetBaseHref,
+	getCommunityPackageAssetBaseHrefForViewedCommit,
+} from '#universal/package-readme-images.ts'
 
 export function readPackageFilesSelectedPath(requestUrl: string) {
 	const url = new URL(requestUrl, 'http://localhost')
@@ -51,6 +54,8 @@ async function toLoaderData(input: {
 	viewerIsOwner?: boolean
 	isPrivate?: boolean
 	listingId?: string | null
+	viewedCommit?: string | null
+	assetCommit?: string | null
 }): Promise<PackageFilesLoaderData> {
 	const content = input.view.content
 	const language = input.view.language
@@ -92,10 +97,12 @@ async function toLoaderData(input: {
 		kodyId: input.kodyId,
 		viewerIsOwner: input.viewerIsOwner,
 		isPrivate: input.isPrivate,
-		imageBaseHref: getCommunityPackageAssetBaseHref({
+		imageBaseHref: getCommunityPackageAssetBaseHrefForViewedCommit({
 			listingId: input.listingId,
 			ownerUsername: input.username,
 			kodyId: input.kodyId,
+			viewedCommit: input.viewedCommit,
+			assetCommit: input.assetCommit,
 		}),
 	}
 }
@@ -197,6 +204,8 @@ export async function loadCommunityPackageFilesData(input: {
 		viewerIsOwner: viewerUserId === listing.ownerUserId,
 		isPrivate: false,
 		listingId: listing.id,
+		viewedCommit: resolvedCommit,
+		assetCommit: listing.pinnedCommit,
 	})
 }
 
@@ -399,6 +408,8 @@ export async function loadAccountPackageFilesData(input: {
 		kodyId: record.kodyId,
 		viewerIsOwner: true,
 		isPrivate: record.isPrivate,
+		viewedCommit: resolved.commit,
+		assetCommit: source?.published_commit ?? '',
 	})
 }
 
@@ -490,6 +501,48 @@ export async function loadPackagePageHasAgentsDocs(input: {
 		return findRootPackageDoc(loaded.files, 'AGENTS.md') != null
 	} catch {
 		return false
+	}
+}
+
+/**
+ * README `<img>` opt-in. Listing README is the pin `/assets/` serves.
+ * Owner current-source README only opts in when HEAD is that pin.
+ */
+export async function resolvePackagePageReadmeImageBaseHref(input: {
+	env: Env
+	request: Request
+	listingId?: string | null
+	ownerUsername: string
+	kodyId: string
+	usedListingReadme: boolean
+	sourceId?: string | null
+	publishedCommit?: string | null
+}) {
+	if (input.usedListingReadme) {
+		return getCommunityPackageAssetBaseHref({
+			listingId: input.listingId,
+			ownerUsername: input.ownerUsername,
+			kodyId: input.kodyId,
+		})
+	}
+	const publishedCommit = input.publishedCommit?.trim() ?? ''
+	if (!publishedCommit || !input.sourceId) return null
+	const source = await getEntitySourceById(input.env.APP_DB, input.sourceId)
+	if (!source?.repo_id) return null
+	try {
+		const head = await resolveCachedArtifactSourceHead(
+			input.env,
+			source.repo_id,
+			{ request: input.request },
+		)
+		return getCommunityPackageAssetBaseHrefForViewedCommit({
+			ownerUsername: input.ownerUsername,
+			kodyId: input.kodyId,
+			viewedCommit: head.commit,
+			assetCommit: publishedCommit,
+		})
+	} catch {
+		return null
 	}
 }
 

--- a/packages/worker/src/app/package-files-data.ts
+++ b/packages/worker/src/app/package-files-data.ts
@@ -506,7 +506,9 @@ export async function loadPackagePageHasAgentsDocs(input: {
 
 /**
  * README `<img>` opt-in. Listing README is the pin `/assets/` serves.
- * Owner current-source README only opts in when HEAD is that pin.
+ * Owner current-source README only opts in when HEAD is that same blob:
+ * listing pin when the package is listed (public `/assets/` reads the pin),
+ * otherwise the owner's published commit.
  */
 export async function resolvePackagePageReadmeImageBaseHref(input: {
 	env: Env
@@ -517,6 +519,7 @@ export async function resolvePackagePageReadmeImageBaseHref(input: {
 	usedListingReadme: boolean
 	sourceId?: string | null
 	publishedCommit?: string | null
+	pinnedCommit?: string | null
 }) {
 	if (input.usedListingReadme) {
 		return getCommunityPackageAssetBaseHref({
@@ -525,8 +528,9 @@ export async function resolvePackagePageReadmeImageBaseHref(input: {
 			kodyId: input.kodyId,
 		})
 	}
-	const publishedCommit = input.publishedCommit?.trim() ?? ''
-	if (!publishedCommit || !input.sourceId) return null
+	const assetCommit =
+		input.pinnedCommit?.trim() || input.publishedCommit?.trim() || ''
+	if (!assetCommit || !input.sourceId) return null
 	const source = await getEntitySourceById(input.env.APP_DB, input.sourceId)
 	if (!source?.repo_id) return null
 	try {
@@ -539,7 +543,7 @@ export async function resolvePackagePageReadmeImageBaseHref(input: {
 			ownerUsername: input.ownerUsername,
 			kodyId: input.kodyId,
 			viewedCommit: head.commit,
-			assetCommit: publishedCommit,
+			assetCommit,
 		})
 	} catch {
 		return null

--- a/packages/worker/src/app/router-specificity.node.test.ts
+++ b/packages/worker/src/app/router-specificity.node.test.ts
@@ -43,6 +43,14 @@ test('router prefers static nested paths and package files over dynamic siblings
 		createStubHandler('community-files'),
 	)
 	router.get(
+		routePattern(routes.communityPackageAsset),
+		createStubHandler('community-assets'),
+	)
+	router.get(
+		routePattern(routes.communityDetailAsset),
+		createStubHandler('listing-uuid-assets'),
+	)
+	router.get(
 		routePattern(routes.communityPackageApprovePublish),
 		createStubHandler('community-approve-publish'),
 	)
@@ -112,6 +120,24 @@ test('router prefers static nested paths and package files over dynamic siblings
 			)
 		).text(),
 	).toBe('community-files')
+	expect(
+		await (
+			await router.fetch(
+				new Request(
+					'http://localhost/@kentcdodds/devin/assets/docs/poster.png',
+				),
+			)
+		).text(),
+	).toBe('community-assets')
+	expect(
+		await (
+			await router.fetch(
+				new Request(
+					'http://localhost/community/550e8400-e29b-41d4-a716-446655440000/assets/docs/poster.png',
+				),
+			)
+		).text(),
+	).toBe('listing-uuid-assets')
 	expect(
 		await (
 			await router.fetch(

--- a/packages/worker/src/app/router.ts
+++ b/packages/worker/src/app/router.ts
@@ -175,6 +175,10 @@ import {
 } from '#app/handlers/community-detail.tsx'
 import { createCommunityFeatureApiPostHandler } from '#app/handlers/community-feature.ts'
 import { createCommunityIconHandler } from '#app/handlers/community-icon.ts'
+import {
+	createCommunityDetailAssetHandler,
+	createCommunityPackageAssetHandler,
+} from '#app/handlers/package-readme-assets.ts'
 import { createIntegrationLogoHandler } from '#app/handlers/integration-logo.ts'
 import { createProviderMarkLogoHandler } from '#app/handlers/provider-mark-logo.ts'
 import { createMcpServerLogoHandler } from '#app/handlers/mcp-server-logo.ts'
@@ -500,6 +504,8 @@ export function createAppRouter(env: Env) {
 			communityPackageFiles: createCommunityPackageFilesHandler(env),
 			communityPackageTree: createCommunityPackageTreeHandler(env),
 			communityPackageFilesApi: createCommunityPackageFilesApiHandler(env),
+			communityPackageAsset: createCommunityPackageAssetHandler(env),
+			communityDetailAsset: createCommunityDetailAssetHandler(env),
 			communityDetailIcon: createCommunityIconHandler(env),
 			integrationLogo: createIntegrationLogoHandler(env),
 			providerMarkLogo: createProviderMarkLogoHandler(env),

--- a/packages/worker/src/community/package-readme-asset.node.test.ts
+++ b/packages/worker/src/community/package-readme-asset.node.test.ts
@@ -1,0 +1,73 @@
+import { expect, test } from 'vitest'
+import {
+	tinyPngBytes,
+	tinyWebpBytes,
+} from '#worker/test-support/images-binding.ts'
+import {
+	buildPackageReadmeAssetHeaders,
+	packageReadmeAssetSvgContentSecurityPolicy,
+	sniffPackageReadmeImageContentType,
+} from './package-readme-asset.ts'
+import { packageReadmeImageMaxBytes } from '#universal/package-readme-images.ts'
+
+const tinyGifBytes = Uint8Array.from([
+	0x47, 0x49, 0x46, 0x38, 0x39, 0x61, 0x01, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
+])
+const tinyJpegBytes = Uint8Array.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10])
+const svgBytes = new TextEncoder().encode(
+	'<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1"></svg>',
+)
+
+test('package README image sniffing requires matching magic bytes and size', () => {
+	expect(
+		sniffPackageReadmeImageContentType(tinyPngBytes, 'docs/poster.png'),
+	).toBe('image/png')
+	expect(sniffPackageReadmeImageContentType(tinyJpegBytes, 'shot.jpg')).toBe(
+		'image/jpeg',
+	)
+	expect(sniffPackageReadmeImageContentType(tinyWebpBytes, 'icon.webp')).toBe(
+		'image/webp',
+	)
+	expect(sniffPackageReadmeImageContentType(tinyGifBytes, 'spin.gif')).toBe(
+		'image/gif',
+	)
+	expect(sniffPackageReadmeImageContentType(svgBytes, 'diagram.svg')).toBe(
+		'image/svg+xml',
+	)
+	expect(
+		sniffPackageReadmeImageContentType(tinyPngBytes, 'docs/poster.jpg'),
+	).toBe(null)
+	expect(
+		sniffPackageReadmeImageContentType(
+			new TextEncoder().encode('console.log(1)'),
+			'docs/poster.png',
+		),
+	).toBe(null)
+	expect(
+		sniffPackageReadmeImageContentType(
+			new TextEncoder().encode('<svg><script>alert(1)</script></svg>'),
+			'evil.svg',
+		),
+	).toBe(null)
+	expect(
+		sniffPackageReadmeImageContentType(new Uint8Array(0), 'empty.png'),
+	).toBe(null)
+	expect(
+		sniffPackageReadmeImageContentType(
+			new Uint8Array(packageReadmeImageMaxBytes + 1),
+			'huge.png',
+		),
+	).toBe(null)
+
+	const headers = buildPackageReadmeAssetHeaders({
+		contentType: 'image/svg+xml',
+		byteLength: svgBytes.byteLength,
+		etag: '"abc:diagram.svg:1"',
+		cacheControl: 'public, max-age=3600',
+	})
+	expect(headers['Content-Security-Policy']).toBe(
+		packageReadmeAssetSvgContentSecurityPolicy,
+	)
+	expect(headers['Cross-Origin-Resource-Policy']).toBe('same-origin')
+	expect(headers['X-Content-Type-Options']).toBe('nosniff')
+})

--- a/packages/worker/src/community/package-readme-asset.ts
+++ b/packages/worker/src/community/package-readme-asset.ts
@@ -1,4 +1,9 @@
+import { snapshotStringToBytes } from '#universal/package-file-media.ts'
 import { packageReadmeImageMaxBytes } from '#universal/package-readme-images.ts'
+import { readPublishedSourceSnapshot } from '#worker/package-runtime/published-runtime-artifacts.ts'
+import { readArtifactFileAtCommit } from '#worker/repo/artifact-file.ts'
+import { getEntitySourceById } from '#worker/repo/entity-sources.ts'
+import { readCommunitySnapshot } from './snapshot.ts'
 
 export const packageReadmeAssetCacheControl = 'public, max-age=3600'
 export const packageReadmeAssetPrivateCacheControl = 'private, no-store'
@@ -76,6 +81,79 @@ export function sniffPackageReadmeImageContentType(
 		default:
 			return null
 	}
+}
+
+async function readPackageReadmeAssetSnapshotBytes(input: {
+	env: Env
+	sourceId: string
+	commit: string
+	relativePath: string
+	listingId?: string | null
+}) {
+	if (!input.env.BUNDLE_ARTIFACTS_KV) return null
+	try {
+		const published = await readPublishedSourceSnapshot({
+			env: input.env,
+			sourceId: input.sourceId,
+			publishedCommit: input.commit,
+		})
+		const publishedFile = published?.files[input.relativePath]
+		if (publishedFile != null) {
+			return snapshotStringToBytes(publishedFile, input.relativePath)
+		}
+	} catch {
+		// Fall through to the listing pin snapshot.
+	}
+	const listingId = input.listingId?.trim()
+	if (!listingId) return null
+	try {
+		const listing = await readCommunitySnapshot(
+			input.env.BUNDLE_ARTIFACTS_KV,
+			listingId,
+		)
+		const listingFile = listing?.files[input.relativePath]
+		if (listingFile != null) {
+			return snapshotStringToBytes(listingFile, input.relativePath)
+		}
+	} catch {
+		return null
+	}
+	return null
+}
+
+/**
+ * Published or pinned image bytes. Prefer the git blob so rasters stay
+ * byte-accurate; fall back to the published or listing snapshot the way
+ * `/raw/` does when that blob is missing.
+ */
+export async function loadPackageReadmeAssetBytes(input: {
+	env: Env
+	sourceId: string
+	commit: string
+	relativePath: string
+	listingId?: string | null
+}) {
+	if (!input.commit) return null
+	const source = await getEntitySourceById(input.env.APP_DB, input.sourceId)
+	if (source?.repo_id) {
+		try {
+			const bytes = await readArtifactFileAtCommit({
+				env: input.env,
+				repoId: source.repo_id,
+				commit: input.commit,
+				filePath: input.relativePath,
+			})
+			if (bytes) return bytes
+		} catch (error) {
+			console.error(
+				'package-readme-asset-load-failed',
+				input.sourceId,
+				input.relativePath,
+				error,
+			)
+		}
+	}
+	return await readPackageReadmeAssetSnapshotBytes(input)
 }
 
 export function buildPackageReadmeAssetHeaders(input: {

--- a/packages/worker/src/community/package-readme-asset.ts
+++ b/packages/worker/src/community/package-readme-asset.ts
@@ -1,0 +1,101 @@
+import { packageReadmeImageMaxBytes } from '#universal/package-readme-images.ts'
+
+export const packageReadmeAssetCacheControl = 'public, max-age=3600'
+export const packageReadmeAssetPrivateCacheControl = 'private, no-store'
+export const packageReadmeAssetSvgContentSecurityPolicy =
+	"default-src 'none'; sandbox"
+
+export type PackageReadmeImageContentType =
+	| 'image/png'
+	| 'image/jpeg'
+	| 'image/webp'
+	| 'image/gif'
+	| 'image/svg+xml'
+
+function readAscii(bytes: Uint8Array, offset: number, length: number) {
+	return String.fromCharCode(...bytes.subarray(offset, offset + length))
+}
+
+function hasPrefix(bytes: Uint8Array, prefix: ReadonlyArray<number>) {
+	return (
+		bytes.byteLength >= prefix.length &&
+		prefix.every((byte, index) => bytes[index] === byte)
+	)
+}
+
+function extensionOfPath(path: string) {
+	const name = path.split('/').pop() ?? ''
+	const separator = name.lastIndexOf('.')
+	if (separator <= 0 || separator === name.length - 1) return ''
+	return name.slice(separator + 1).toLowerCase()
+}
+
+function isSvgMarkup(bytes: Uint8Array) {
+	const text = new TextDecoder('utf-8', { fatal: false })
+		.decode(bytes)
+		.replace(/^\uFEFF/, '')
+		.trimStart()
+	if (!text.startsWith('<svg') && !text.startsWith('<?xml')) return false
+	if (/<script[\s>]/i.test(text)) return false
+	return /<svg[\s>]/i.test(text)
+}
+
+/**
+ * Require both an allowlisted extension and matching magic bytes so a
+ * renamed `.js` or HTML file cannot be served as an image.
+ */
+export function sniffPackageReadmeImageContentType(
+	bytes: Uint8Array,
+	path: string,
+): PackageReadmeImageContentType | null {
+	if (bytes.byteLength === 0 || bytes.byteLength > packageReadmeImageMaxBytes) {
+		return null
+	}
+	const extension = extensionOfPath(path)
+	switch (extension) {
+		case 'png':
+			return hasPrefix(bytes, [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
+				? 'image/png'
+				: null
+		case 'jpg':
+		case 'jpeg':
+			return hasPrefix(bytes, [0xff, 0xd8, 0xff]) ? 'image/jpeg' : null
+		case 'webp':
+			return bytes.byteLength >= 12 &&
+				readAscii(bytes, 0, 4) === 'RIFF' &&
+				readAscii(bytes, 8, 4) === 'WEBP'
+				? 'image/webp'
+				: null
+		case 'gif':
+			return hasPrefix(bytes, [0x47, 0x49, 0x46, 0x38, 0x37, 0x61]) ||
+				hasPrefix(bytes, [0x47, 0x49, 0x46, 0x38, 0x39, 0x61])
+				? 'image/gif'
+				: null
+		case 'svg':
+			return isSvgMarkup(bytes) ? 'image/svg+xml' : null
+		default:
+			return null
+	}
+}
+
+export function buildPackageReadmeAssetHeaders(input: {
+	contentType: PackageReadmeImageContentType
+	byteLength: number
+	etag: string
+	cacheControl: string
+}) {
+	const headers: Record<string, string> = {
+		'Cache-Control': input.cacheControl,
+		'Content-Length': String(input.byteLength),
+		'Content-Type': input.contentType,
+		'Cross-Origin-Resource-Policy': 'same-origin',
+		ETag: input.etag,
+		'X-Content-Type-Options': 'nosniff',
+	}
+	if (input.contentType === 'image/svg+xml') {
+		headers['Content-Security-Policy'] =
+			packageReadmeAssetSvgContentSecurityPolicy
+		headers['Content-Type'] = 'image/svg+xml; charset=utf-8'
+	}
+	return headers
+}

--- a/packages/worker/src/user-namespace-routes.node.test.ts
+++ b/packages/worker/src/user-namespace-routes.node.test.ts
@@ -48,6 +48,10 @@ test('machine namespaces claim only their multi-segment paths', () => {
 		mount: 'username-path',
 	})
 	expect(parsePackageAppPath('/@kody/devin')).toBeNull()
+	expect(
+		isNamespacedAppEndpointPath('/@kody/doom/assets/docs/poster.png'),
+	).toBe(false)
+	expect(parsePackageAppPath('/@kody/doom/assets/docs/poster.png')).toBeNull()
 
 	expect(
 		communityPackageMatcher.match(new URL('https://example.com/@kody/devin'))

--- a/packages/worker/universal/loader-data.ts
+++ b/packages/worker/universal/loader-data.ts
@@ -212,6 +212,7 @@ type CommunityDetailShellLoaderData = {
 	readmeContent: string | null
 	readmeFences?: Array<HighlightedCode>
 	hasAgentsDocs: boolean
+	imageBaseHref: string | null
 	viewerInstall: ViewerListingInstall | null
 	ownerPackage: AccountPackageDetail | null
 	username: string

--- a/packages/worker/universal/loader-data.ts
+++ b/packages/worker/universal/loader-data.ts
@@ -195,6 +195,7 @@ export type PackageFilesLoaderData = {
 	kodyId?: string
 	viewerIsOwner?: boolean
 	isPrivate?: boolean
+	imageBaseHref?: string | null
 }
 
 /** SSR-embedded shell data for client-only regions on the detail page. */

--- a/packages/worker/universal/package-readme-images.node.test.ts
+++ b/packages/worker/universal/package-readme-images.node.test.ts
@@ -1,0 +1,72 @@
+import { expect, test } from 'vitest'
+import {
+	directoryOfPackageFilePath,
+	getCommunityPackageAssetBaseHref,
+	getCommunityPackageAssetHref,
+	isPackageReadmeImagePath,
+	joinPackageReadmeImageHref,
+	resolvePackageReadmeImagePath,
+} from './package-readme-images.ts'
+
+test('package README image paths stay inside the repo and reject remote hrefs', () => {
+	expect(resolvePackageReadmeImagePath('./docs/poster.png')).toBe(
+		'docs/poster.png',
+	)
+	expect(resolvePackageReadmeImagePath('docs/poster.png')).toBe(
+		'docs/poster.png',
+	)
+	expect(resolvePackageReadmeImagePath('/docs/poster.png')).toBe(
+		'docs/poster.png',
+	)
+	expect(resolvePackageReadmeImagePath('./poster.png', 'docs')).toBe(
+		'docs/poster.png',
+	)
+	expect(resolvePackageReadmeImagePath('../poster.png', 'docs')).toBe(null)
+	expect(resolvePackageReadmeImagePath('https://evil.example/x.png')).toBe(null)
+	expect(resolvePackageReadmeImagePath('//evil.example/x.png')).toBe(null)
+	expect(resolvePackageReadmeImagePath('javascript:alert(1)')).toBe(null)
+	expect(resolvePackageReadmeImagePath('data:image/png;base64,aaaa')).toBe(null)
+	expect(resolvePackageReadmeImagePath('./docs/poster.png?raw=1')).toBe(null)
+	expect(resolvePackageReadmeImagePath('./README.md')).toBe(null)
+	expect(resolvePackageReadmeImagePath('./docs/app.js')).toBe(null)
+	expect(isPackageReadmeImagePath('docs/poster.png')).toBe(true)
+	expect(isPackageReadmeImagePath('docs/poster.PNG')).toBe(true)
+	expect(isPackageReadmeImagePath('src/index.ts')).toBe(false)
+	expect(directoryOfPackageFilePath('README.md')).toBe('')
+	expect(directoryOfPackageFilePath('docs/README.md')).toBe('docs')
+})
+
+test('package README asset hrefs use the third-segment noun and reserved-id fallback', () => {
+	expect(
+		getCommunityPackageAssetHref({
+			listingId: 'listing-1',
+			ownerUsername: 'kody',
+			kodyId: 'doom',
+			relativePath: 'docs/poster.png',
+		}),
+	).toBe('/@kody/doom/assets/docs/poster.png')
+	expect(
+		getCommunityPackageAssetBaseHref({
+			ownerUsername: 'kody',
+			kodyId: 'doom',
+		}),
+	).toBe('/@kody/doom/assets')
+	expect(
+		getCommunityPackageAssetHref({
+			listingId: 'listing-1',
+			ownerUsername: 'kody',
+			kodyId: 'packages',
+			relativePath: 'docs/poster.png',
+		}),
+	).toBe('/community/listing-1/assets/docs/poster.png')
+	expect(
+		getCommunityPackageAssetHref({
+			ownerUsername: 'kody',
+			kodyId: 'packages',
+			relativePath: 'docs/poster.png',
+		}),
+	).toBe(null)
+	expect(
+		joinPackageReadmeImageHref('/@kody/doom/assets', 'docs/poster.png'),
+	).toBe('/@kody/doom/assets/docs/poster.png')
+})

--- a/packages/worker/universal/package-readme-images.node.test.ts
+++ b/packages/worker/universal/package-readme-images.node.test.ts
@@ -2,7 +2,9 @@ import { expect, test } from 'vitest'
 import {
 	directoryOfPackageFilePath,
 	getCommunityPackageAssetBaseHref,
+	getCommunityPackageAssetBaseHrefForViewedCommit,
 	getCommunityPackageAssetHref,
+	packageReadmeAssetCommitMatchesView,
 	isPackageReadmeImagePath,
 	joinPackageReadmeImageHref,
 	resolvePackageReadmeImagePath,
@@ -69,4 +71,33 @@ test('package README asset hrefs use the third-segment noun and reserved-id fall
 	expect(
 		joinPackageReadmeImageHref('/@kody/doom/assets', 'docs/poster.png'),
 	).toBe('/@kody/doom/assets/docs/poster.png')
+})
+
+test('package README images opt in only when the viewed commit is the asset pin', () => {
+	expect(packageReadmeAssetCommitMatchesView('abc1234', 'abc1234')).toBe(true)
+	expect(packageReadmeAssetCommitMatchesView('abc1234def', 'abc1234')).toBe(
+		true,
+	)
+	expect(packageReadmeAssetCommitMatchesView('abc1234', 'abc1234def')).toBe(
+		true,
+	)
+	expect(packageReadmeAssetCommitMatchesView('deadbeef', 'abc1234')).toBe(false)
+	expect(packageReadmeAssetCommitMatchesView('', 'abc1234')).toBe(false)
+	expect(packageReadmeAssetCommitMatchesView('abc1234', '')).toBe(false)
+	expect(
+		getCommunityPackageAssetBaseHrefForViewedCommit({
+			ownerUsername: 'kody',
+			kodyId: 'doom',
+			viewedCommit: 'abc1234',
+			assetCommit: 'abc1234',
+		}),
+	).toBe('/@kody/doom/assets')
+	expect(
+		getCommunityPackageAssetBaseHrefForViewedCommit({
+			ownerUsername: 'kody',
+			kodyId: 'doom',
+			viewedCommit: 'deadbeef',
+			assetCommit: 'abc1234',
+		}),
+	).toBe(null)
 })

--- a/packages/worker/universal/package-readme-images.ts
+++ b/packages/worker/universal/package-readme-images.ts
@@ -108,6 +108,39 @@ export function getCommunityPackageAssetBaseHref(input: {
 	return getCommunityPackageAssetHref(input)
 }
 
+/**
+ * `/assets/` only reads the published or pinned blob. Opt in to `<img>`
+ * only when the markdown being viewed is that same revision, including
+ * abbreviated SHA prefixes used by tree URLs.
+ */
+export function packageReadmeAssetCommitMatchesView(
+	viewedCommit: string | null | undefined,
+	assetCommit: string | null | undefined,
+) {
+	const viewed = viewedCommit?.trim() ?? ''
+	const asset = assetCommit?.trim() ?? ''
+	if (!viewed || !asset) return false
+	return (
+		viewed === asset || viewed.startsWith(asset) || asset.startsWith(viewed)
+	)
+}
+
+/** Asset prefix when the viewed tree commit is the published/pinned one. */
+export function getCommunityPackageAssetBaseHrefForViewedCommit(input: {
+	listingId?: string | null
+	ownerUsername?: string | null
+	kodyId?: string | null
+	viewedCommit?: string | null
+	assetCommit?: string | null
+}) {
+	if (
+		!packageReadmeAssetCommitMatchesView(input.viewedCommit, input.assetCommit)
+	) {
+		return null
+	}
+	return getCommunityPackageAssetBaseHref(input)
+}
+
 export function joinPackageReadmeImageHref(
 	imageBaseHref: string,
 	relativePath: string,

--- a/packages/worker/universal/package-readme-images.ts
+++ b/packages/worker/universal/package-readme-images.ts
@@ -1,0 +1,116 @@
+import { routes } from '#universal/routes.ts'
+import {
+	isReservedPackageFilesKodyId,
+	joinPackageFilesPath,
+	normalizePackageFilesPath,
+} from '#universal/package-files.ts'
+
+export const packageReadmeImageMaxBytes = 2 * 1024 * 1024
+
+const packageReadmeImageExtensions = [
+	'png',
+	'jpg',
+	'jpeg',
+	'webp',
+	'gif',
+	'svg',
+] as const
+
+const packageReadmeImageExtensionSet = new Set<string>(
+	packageReadmeImageExtensions,
+)
+
+function extensionOfPath(path: string) {
+	const name = path.split('/').pop() ?? ''
+	const separator = name.lastIndexOf('.')
+	if (separator <= 0 || separator === name.length - 1) return ''
+	return name.slice(separator + 1).toLowerCase()
+}
+
+/** True when the repo-relative path is a README-servable image file. */
+export function isPackageReadmeImagePath(path: string) {
+	return packageReadmeImageExtensionSet.has(extensionOfPath(path))
+}
+
+/**
+ * Directory that owns a file path (`docs/README.md` → `docs`). Empty for a
+ * root file so `./poster.png` stays at the package root.
+ */
+export function directoryOfPackageFilePath(path: string | null | undefined) {
+	if (!path) return ''
+	const lastSlash = path.lastIndexOf('/')
+	return lastSlash === -1 ? '' : path.slice(0, lastSlash)
+}
+
+/**
+ * Resolve a markdown image href against a package file directory.
+ * Only in-repo relative paths with an allowlisted image extension pass.
+ * Protocols, `//`, query/hash, and `..` traversal fail closed.
+ */
+export function resolvePackageReadmeImagePath(
+	href: string,
+	fromDirectory = '',
+): string | null {
+	const trimmed = href.trim()
+	if (!trimmed) return null
+	if (/^[a-zA-Z][a-zA-Z+\-.]*:/.test(trimmed)) return null
+	if (trimmed.startsWith('//')) return null
+	if (trimmed.includes('?') || trimmed.includes('#')) return null
+	const combined = trimmed.startsWith('/')
+		? trimmed
+		: fromDirectory
+			? `${fromDirectory}/${trimmed}`
+			: trimmed
+	const normalized = normalizePackageFilesPath(combined)
+	if (!normalized || !isPackageReadmeImagePath(normalized)) return null
+	return normalized
+}
+
+export function getCommunityPackageAssetHref(input: {
+	listingId?: string | null
+	ownerUsername?: string | null
+	kodyId?: string | null
+	relativePath?: string
+}) {
+	const relativePath = input.relativePath?.trim() || undefined
+	if (
+		input.ownerUsername &&
+		input.kodyId &&
+		!isReservedPackageFilesKodyId(input.kodyId)
+	) {
+		return relativePath
+			? routes.communityPackageAsset.href({
+					username: input.ownerUsername,
+					kodyId: input.kodyId,
+					relativePath,
+				})
+			: routes.communityPackageAsset.href({
+					username: input.ownerUsername,
+					kodyId: input.kodyId,
+				})
+	}
+	const listingId = input.listingId?.trim()
+	if (!listingId) return null
+	return relativePath
+		? routes.communityDetailAsset.href({
+				listingId,
+				relativePath,
+			})
+		: routes.communityDetailAsset.href({ listingId })
+}
+
+/** Prefix used as `imageBaseHref` for README markdown in this package. */
+export function getCommunityPackageAssetBaseHref(input: {
+	listingId?: string | null
+	ownerUsername?: string | null
+	kodyId?: string | null
+}) {
+	return getCommunityPackageAssetHref(input)
+}
+
+export function joinPackageReadmeImageHref(
+	imageBaseHref: string,
+	relativePath: string,
+) {
+	return joinPackageFilesPath(imageBaseHref, relativePath)
+}

--- a/packages/worker/universal/routes.ts
+++ b/packages/worker/universal/routes.ts
@@ -181,6 +181,7 @@ export const routes = route({
 	communityDetailApi: '/community/:listingId.json',
 	communityDetailFiles: '/community/:listingId/files(/*relativePath)',
 	communityDetailFilesApi: '/community/:listingId/files.json',
+	communityDetailAsset: '/community/:listingId/assets(/*relativePath)',
 	communityDetailIcon: '/community/:listingId/icon/:iconCommit',
 	communityDetailOgImage: '/community/:listingId/og.png',
 	communityReportApiPost: post('/community/:listingId/report.json'),
@@ -195,6 +196,9 @@ export const routes = route({
 	communityPackage: '/@:username/:kodyId',
 	communityPackageFiles: '/@:username/:kodyId/files(/*relativePath)',
 	communityPackageTree: '/@:username/:kodyId/tree/:ref(/*relativePath)',
+	// First-party bytes for README-relative images. Third-segment noun so
+	// `/@:username/packages/…` stays the hosted package-app mount.
+	communityPackageAsset: '/@:username/:kodyId/assets(/*relativePath)',
 	communityPackageSettings: '/@:username/:kodyId/settings',
 	communityPackageApprovePublish: '/@:username/:kodyId/approve-publish',
 	// JSON companion lives under `/profiles/…` with the other username-keyed

--- a/packages/worker/universal/styles/style-primitives.ts
+++ b/packages/worker/universal/styles/style-primitives.ts
@@ -516,6 +516,14 @@ export const proseCss = {
 		textDecorationThickness: '1.5px',
 		textUnderlineOffset: '3px',
 	},
+	'& img': {
+		display: 'block',
+		maxWidth: '100%',
+		height: 'auto',
+		margin: '1.15rem 0 0',
+		borderRadius: radius.md,
+		border: `1px solid ${colors.border}`,
+	},
 	'& p': {
 		margin: '1.15rem 0 0',
 		maxWidth: '62ch',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Package README posters and other in-repo markdown images should show on public package pages (`/@owner/kody-id`), the way authors write them.

## Why

Kent (via Patch): inline images in published package READMEs do not render. Repro: https://kody.codes/@kody/doom — `![…](./docs/poster.png)` near the top should show the poster. The safe markdown renderer never emitted `<img>` (images became links), and relative hrefs were dropped.

## Summary

- Relative README images (`./docs/poster.png`, `docs/poster.png`, `/docs/poster.png`) resolve to a first-party `/assets/` URL for that package.
- New routes: `/@:username/:kodyId/assets(/*relativePath)` and `/community/:listingId/assets(/*relativePath)` (listing-uuid fallback when `kody.id` is a reserved ingress segment). Coexists with `/raw/:ref/…` from #2177 for tree media previews.
- The asset handler serves published/pinned package bytes only. Prefer the git blob; if that misses, fall back to the published or listing snapshot the same way `/raw/` does. Extension + magic-byte sniff, 2 MiB cap, `nosniff`, same-origin CORP. SVG gets a sandbox CSP. Remote / `javascript:` / `data:` / traversal hrefs stay links, not images.
- `<img>` opt-in only when the viewed README commit equals the blob `/assets/` serves. Listing README is the pin. Owner fallback README is the published snapshot, so listed fallback opts in only when published equals the pin (HEAD matching the pin is not enough). Unlisted owner pages opt in against published.
- Same rewrite on the files explorer when it renders markdown at the pin.
- Default markdown policy is unchanged: without `imageBaseHref`, images are still not emitted.

## Testing

- Focused node tests: path resolver, sniff/size, asset handlers (git plus snapshot fallback), commit-match opt-in (published vs pin), markdown renderer img allowlist, router specificity for both `/assets/` and `/raw/`.
- Local `test:push` on `9354566d`: 934 node files and 94 workers files green.
- Preview (earlier head): signed in as seed user, `/@user-me/readme-poster` README and files explorer render with no broken images; asset path/type traversal 404s. Custom SVG publish is blocked on preview Artifacts `account not found`.
- After deploy: confirm `GET /@kody/doom` README contains `<img src="/@kody/doom/assets/docs/poster.png">` and that asset URL returns `image/png`.

## System changes

Extends `app-ui` (markdown may emit `<img>` for rewritten package assets) and `community-listings` (serves listing/package image bytes). Medium risk: untrusted-content renderer contract change, tightly allowlisted. This turn does not squash-merge (medium risk).

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `51540f89` · **Head:** `9354566d`

**Classification:** extends — README markdown can emit same-origin `<img>` for in-repo assets; community listings gain a first-party `/assets/` byte route.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | extends — safe markdown renderer + `/assets/` routes |
| `community-listings` | assistant | extends — serve published listing/package image bytes |

### Change flow

A community package page rewrites README-relative images to a first-party asset URL, then serves published repo bytes with type and size guards.

```mermaid
sequenceDiagram
	actor Visitor
	participant appUi as app-ui
	participant communityListings as community-listings
	Visitor->>appUi: GET /@kody/doom
	appUi->>appUi: render README ![poster](./docs/poster.png) as img src /@kody/doom/assets/docs/poster.png
	Visitor->>appUi: GET /@kody/doom/assets/docs/poster.png
	appUi->>communityListings: resolve listing and pinned commit
	alt git blob present
		communityListings-->>appUi: pin bytes from artifact repo
	else git miss
		communityListings-->>appUi: pin bytes from published or listing snapshot
	end
	appUi-->>Visitor: image/png after sniff and 2 MiB cap
```

### Before / after

**Before:** `![poster](./docs/poster.png)` rendered as a non-link `<span>` (relative hrefs are refused). Remote `https://…` images became outbound links. No package asset route.

**After:** In-repo relative images become `<img src="/@owner/kody-id/assets/…">` when the viewed README commit is the blob `/assets/` serves (listing pin, or owner published commit when those match). Handler prefers the git blob and falls back to the published or listing snapshot, sniffs png/jpeg/webp/gif/svg, and rejects traversal, scripts-in-svg, oversized files, and reserved `kody.id` ingress collisions. Files-explorer markdown at HEAD-ahead stays links. Remote hrefs stay links. Tree media previews stay on `/raw/:ref/…`.

### Invariants

Untrusted markdown still cannot point `<img>` or links at hosted package-app paths (`/@…/packages/…`, `/packages/…`). Asset responses are first-party, `X-Content-Type-Options: nosniff`, and `Cross-Origin-Resource-Policy: same-origin`.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bf599333-39a9-4843-b850-1f5404b929bb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bf599333-39a9-4843-b850-1f5404b929bb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * README images can render from safe, repository-relative files when enabled.
  * Images are served through secure first-party asset URLs with responsive styling.
  * Community and package pages support README image assets, including private package access controls.
  * Headings can support unique deep-link IDs where enabled.

* **Bug Fixes**
  * Images load only when the README matches the published or pinned commit.
  * Unsafe, remote, unsupported, oversized, or unavailable images continue to render as links or text.

* **Documentation**
  * Clarified README image URL behavior for published and pinned content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->