### PR TITLE
Keep stored YouTube banner CTAs off-site

### DIFF
--- a/docs/contributing/architecture/site-banners.md
+++ b/docs/contributing/architecture/site-banners.md
@@ -54,12 +54,15 @@ row so the strip spans the viewport. `card` stays inset. Each look reserves a
 
 ## Images and in-site video
 
-Banners can show a first-party image and a CTA. A YouTube watch URL or
-`/?youtubeId=<id>` CTA derives `/youtube-thumb/<id>` when `imageUrl` is empty.
-Raw `i.ytimg.com` URLs are rewritten to that same-origin path so CSP can keep
-`img-src` first-party. The admin form has a paste helper that fills
-`ctaHref=/?youtubeId=<id>` and the thumb path. Operators create and enable
-content in D1.
+Banners can show a first-party image and a CTA. Stored `ctaHref` and
+`secondaryHref` values render as stored: an absolute YouTube (or other https)
+URL stays off-site, including playlist query params. A stored `/?youtubeId=<id>`
+path still opens the on-site overlay. A YouTube watch URL or `/?youtubeId=<id>`
+CTA derives `/youtube-thumb/<id>` when `imageUrl` is empty. Raw `i.ytimg.com`
+URLs are rewritten to that same-origin path so CSP can keep `img-src`
+first-party. The admin form has a paste helper that fills
+`ctaHref=/?youtubeId=<id>` and the thumb path when the operator wants the
+overlay. Operators create and enable content in D1.
 
 In-site playback is the site-wide `/?youtubeId=` overlay, not a banner-only
 player. See [YouTube watch overlay](./youtube-watch.md).

--- a/docs/contributing/architecture/youtube-watch.md
+++ b/docs/contributing/architecture/youtube-watch.md
@@ -1,7 +1,8 @@
 # YouTube watch overlay
 
 Site-wide `/?youtubeId=<id>` player for allowlisted YouTube videos. Banners can
-point at it.
+point at it by storing that relative href. Absolute YouTube watch URLs on a
+banner stay external and do not get rewritten to `/?youtubeId=`.
 
 ## Surfaces
 
@@ -52,7 +53,7 @@ document loads, so they still resolve playlist ids.
 
 ## Code
 
-- Parse / rewrite: `packages/worker/universal/youtube-watch.ts`
+- Parse / thumb rewrite: `packages/worker/universal/youtube-watch.ts`
 - Allowlist: `packages/worker/src/app/youtube-watch-allowlist.ts`
 - SSR snapshot: `packages/worker/src/app/youtube-watch-ssr.ts`
 - Thumb proxy: `packages/worker/src/app/handlers/youtube-thumb.ts`

--- a/packages/worker/client/routes/admin-banners-shared.node.test.ts
+++ b/packages/worker/client/routes/admin-banners-shared.node.test.ts
@@ -82,22 +82,25 @@ test('applyYoutubeWatchToBannerDraft fills CTA and first-party thumb', () => {
 	})
 })
 
-test('draftToPreview fills untitled copy and first-party watch URLs', () => {
+test('draftToPreview keeps stored CTAs and derives first-party thumbs', () => {
 	const videoId = 'QA0xYMAMjEg'
+	const playlistWatchUrl = `https://www.youtube.com/watch?v=${videoId}&list=PLV5CVI1eNcJhP4nrJt85L7PxHjebFpDfY`
 	const draft = {
 		...emptyDraft(),
 		body: 'Optional body',
-		ctaHref: `https://www.youtube.com/watch?v=${videoId}`,
+		ctaHref: playlistWatchUrl,
 		ctaLabel: 'Watch',
+		secondaryHref: `/?youtubeId=${videoId}`,
+		secondaryLabel: 'On-site player',
 	}
 	expect(draftToPreview(draft, 'promo')).toEqual({
 		id: 'preview-promo',
 		title: 'Untitled banner',
 		body: 'Optional body',
-		ctaHref: `/?youtubeId=${videoId}`,
+		ctaHref: playlistWatchUrl,
 		ctaLabel: 'Watch',
-		secondaryHref: null,
-		secondaryLabel: null,
+		secondaryHref: `/?youtubeId=${videoId}`,
+		secondaryLabel: 'On-site player',
 		severity: draft.severity,
 		look: 'promo',
 		icon: 'play',

--- a/packages/worker/client/routes/admin-banners-shared.ts
+++ b/packages/worker/client/routes/admin-banners-shared.ts
@@ -12,7 +12,6 @@ import {
 import {
 	parseYoutubeVideoId,
 	resolveSiteBannerImageUrl,
-	rewriteBannerHrefForYoutubeWatch,
 	youtubeThumbPath,
 	youtubeWatchHref,
 } from '#universal/youtube-watch.ts'
@@ -175,11 +174,9 @@ export function draftToPreview(
 		id: draft.id ?? `preview-${look}`,
 		title: draft.title.trim() || 'Untitled banner',
 		body: draft.body,
-		ctaHref: rewriteBannerHrefForYoutubeWatch(draft.ctaHref.trim() || null),
+		ctaHref: draft.ctaHref.trim() || null,
 		ctaLabel: draft.ctaLabel.trim() || null,
-		secondaryHref: rewriteBannerHrefForYoutubeWatch(
-			draft.secondaryHref.trim() || null,
-		),
+		secondaryHref: draft.secondaryHref.trim() || null,
 		secondaryLabel: draft.secondaryLabel.trim() || null,
 		severity: draft.severity,
 		look,

--- a/packages/worker/client/site-banner-editor.tsx
+++ b/packages/worker/client/site-banner-editor.tsx
@@ -2,10 +2,7 @@ import { type Handle, css } from 'remix/ui'
 import { on } from '#client/event-mixin.ts'
 import { accountInputCss } from '#client/routes/account-management-components.tsx'
 import { type BannerDraft } from '#client/routes/admin-banners-shared.ts'
-import {
-	resolveSiteBannerImageUrl,
-	rewriteBannerHrefForYoutubeWatch,
-} from '#universal/youtube-watch.ts'
+import { resolveSiteBannerImageUrl } from '#universal/youtube-watch.ts'
 import {
 	fieldLabelCss,
 	getGhostButtonCss,
@@ -114,9 +111,6 @@ export function SiteBannerEditor(
 			ctaHref: draft.ctaHref.trim() || null,
 			secondaryHref: draft.secondaryHref.trim() || null,
 		})
-		const ctaHref = rewriteBannerHrefForYoutubeWatch(
-			draft.ctaHref.trim() || null,
-		)
 		const showSecondary =
 			Boolean(draft.ctaLabel) ||
 			Boolean(draft.secondaryLabel) ||
@@ -315,7 +309,7 @@ export function SiteBannerEditor(
 						</span>
 						<input
 							value={draft.ctaHref}
-							placeholder={ctaHref ?? '/?youtubeId=… or /path'}
+							placeholder="/?youtubeId=… or https://…"
 							mix={[
 								css(railInputCss),
 								on('input', (event) => {

--- a/packages/worker/universal/site-banners.node.test.ts
+++ b/packages/worker/universal/site-banners.node.test.ts
@@ -372,14 +372,40 @@ test('public client candidates drop targeted user ids and unmatched audiences', 
 	).toBe('Just you')
 })
 
-test('public banner views rewrite YouTube CTAs and derive first-party thumbs', () => {
+test('public banner views keep stored CTAs and derive first-party thumbs', () => {
 	const videoId = 'QA0xYMAMjEg'
-	const view = toSiteBannerView(
+	const playlistWatchUrl = `https://www.youtube.com/watch?v=${videoId}&list=PLV5CVI1eNcJhP4nrJt85L7PxHjebFpDfY`
+	const onSiteWatchHref = `/?youtubeId=${videoId}`
+	const externalView = toSiteBannerView(
 		banner({
-			ctaHref: `https://www.youtube.com/watch?v=${videoId}`,
+			ctaHref: playlistWatchUrl,
+			secondaryHref: `https://youtu.be/${videoId}`,
 			imageUrl: null,
 		}),
 	)
-	expect(view.ctaHref).toBe(`/?youtubeId=${videoId}`)
-	expect(view.imageUrl).toBe(`/youtube-thumb/${videoId}`)
+	expect(externalView.ctaHref).toBe(playlistWatchUrl)
+	expect(externalView.secondaryHref).toBe(`https://youtu.be/${videoId}`)
+	expect(externalView.imageUrl).toBe(`/youtube-thumb/${videoId}`)
+
+	const onSiteView = toSiteBannerView(
+		banner({
+			ctaHref: onSiteWatchHref,
+			imageUrl: null,
+		}),
+	)
+	expect(onSiteView.ctaHref).toBe(onSiteWatchHref)
+	expect(onSiteView.imageUrl).toBe(`/youtube-thumb/${videoId}`)
+
+	const selected = resolveVisibleSiteBanner({
+		candidates: [
+			banner({
+				ctaHref: playlistWatchUrl,
+				imageUrl: null,
+			}),
+		],
+		dismissedIds: [],
+		pathname: '/',
+		viewer: guestViewer,
+	})
+	expect(selected?.ctaHref).toBe(playlistWatchUrl)
 })

--- a/packages/worker/universal/site-banners.ts
+++ b/packages/worker/universal/site-banners.ts
@@ -1,7 +1,6 @@
 import { parsePlanName, planNames, type PlanName } from '#universal/plans.ts'
 import {
 	resolveSiteBannerImageUrl,
-	rewriteBannerHrefForYoutubeWatch,
 	youtubeThumbPath,
 	youtubeWatchHref,
 	youtubeWatchSampleVideoId,
@@ -380,9 +379,9 @@ export function toSiteBannerView(
 		id: banner.id,
 		title: banner.title,
 		body: banner.body,
-		ctaHref: rewriteBannerHrefForYoutubeWatch(banner.ctaHref),
+		ctaHref: banner.ctaHref,
 		ctaLabel: banner.ctaLabel,
-		secondaryHref: rewriteBannerHrefForYoutubeWatch(banner.secondaryHref),
+		secondaryHref: banner.secondaryHref,
 		secondaryLabel: banner.secondaryLabel,
 		severity: banner.severity,
 		look: lookOverride ?? banner.look,

--- a/packages/worker/universal/youtube-watch.node.test.ts
+++ b/packages/worker/universal/youtube-watch.node.test.ts
@@ -8,7 +8,6 @@ import {
 	parseYoutubeVideoIdList,
 	parseYoutubeWatchSearch,
 	resolveSiteBannerImageUrl,
-	rewriteBannerHrefForYoutubeWatch,
 	stripYoutubeWatchSearch,
 	youtubeNocookieEmbedUrl,
 	youtubeThumbPath,
@@ -113,19 +112,7 @@ test('allowlist merge includes playlist, extra ids, and banner hrefs', () => {
 	).toEqual([videoId])
 })
 
-test('banner hrefs and images rewrite YouTube hosts to first-party watch/thumb paths', () => {
-	expect(
-		rewriteBannerHrefForYoutubeWatch(
-			`https://www.youtube.com/watch?v=${videoId}`,
-		),
-	).toBe(`/?youtubeId=${videoId}`)
-	expect(rewriteBannerHrefForYoutubeWatch('/blog?youtubeId=abc')).toBe(
-		'/blog?youtubeId=abc',
-	)
-	expect(
-		rewriteBannerHrefForYoutubeWatch(`https://example.test/?video=${videoId}`),
-	).toBe(`https://example.test/?video=${videoId}`)
-	expect(rewriteBannerHrefForYoutubeWatch('/pricing')).toBe('/pricing')
+test('banner images rewrite YouTube hosts to first-party thumb paths', () => {
 	expect(
 		resolveSiteBannerImageUrl({
 			imageUrl: null,

--- a/packages/worker/universal/youtube-watch.ts
+++ b/packages/worker/universal/youtube-watch.ts
@@ -164,15 +164,6 @@ export function mergeYoutubeWatchAllowlist(input: {
 	])
 }
 
-export function rewriteBannerHrefForYoutubeWatch(
-	href: string | null,
-): string | null {
-	if (!href) return null
-	if (href.startsWith('/')) return href
-	const videoId = parseYoutubeVideoId(href)
-	return videoId ? youtubeWatchHref(videoId) : href
-}
-
 export function resolveSiteBannerImageUrl(banner: {
 	imageUrl: string | null
 	ctaHref: string | null


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Let operators store an absolute YouTube watch URL (including playlist params) as the announcement banner primary CTA, and have the live site open that URL off-site instead of rewriting it to the on-site `/?youtubeId=` player.

## Why

The homepage banner CTA on https://kody.codes/ still rendered as `/?youtubeId=QA0xYMAMjEg` even though `adminBannerSave` already stored:

`https://www.youtube.com/watch?v=QA0xYMAMjEg&list=PLV5CVI1eNcJhP4nrJt85L7PxHjebFpDfY`

SSR `#rmx-data` showed the stored URL on `siteBanner.candidates[0].ctaHref`, then `toSiteBannerView` rewrote `siteBanner.banner.ctaHref` (and the visible `<a>`) to the overlay path. Launch-day intent is: Watch the video opens YouTube with the playlist.

## Summary

- Removed `rewriteBannerHrefForYoutubeWatch`, which coerced youtube.com / youtu.be watch URLs into `/?youtubeId=<id>` and dropped `&list=`.
- Public banner views, admin preview, and the editor now render stored `ctaHref` / `secondaryHref` unchanged.
- `/?youtubeId=` still works when the operator (or the admin paste helper) sets that form, and when someone lands on that URL directly.
- First-party `/youtube-thumb/` derivation from YouTube URLs is unchanged.

## Testing

- Focused node-unit: `youtube-watch`, `site-banners`, `admin-banners-shared`, `youtube-watch-overlay` — 23 passed.
- Pre-push: `test:node` 2941 passed, `test:workers` 341 passed.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `daf07d6d` · **Head:** `8ce7891a`

**Classification:** extends — public site-banner views no longer coerce YouTube watch URLs into the on-site `/?youtubeId=` overlay.

### Primitives touched

| Primitive | Group    | Impact                                                          |
| --------- | -------- | --------------------------------------------------------------- |
| `app-ui`  | surfaces | extends — banner CTA and secondary hrefs render as stored       |

### Change flow

SSR banner selection keeps an operator-stored YouTube playlist URL on the visible CTA.

```mermaid
sequenceDiagram
	actor Operator
	participant appUi as app-ui
	Operator->>appUi: adminBannerSave ctaHref youtube.com/watch with list
	Note over appUi: stored href stays absolute
	appUi->>appUi: toSiteBannerView without YouTube rewrite
	appUi-->>Operator: banner CTA opens YouTube off-site
```

### Before / after

```
before: stored https://www.youtube.com/watch?v=ID&list=PL… → rendered /?youtubeId=ID
after:  stored https://www.youtube.com/watch?v=ID&list=PL… → rendered unchanged
        stored /?youtubeId=ID → still the on-site overlay
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d0f0611e-9cbc-4b52-8bdf-6b6dee6509e0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d0f0611e-9cbc-4b52-8bdf-6b6dee6509e0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * YouTube banner call-to-action links now preserve their original external or on-site URLs, including playlist and short-link formats.
  * Secondary banner actions correctly retain their configured labels and links.
  * YouTube banner images continue to generate the appropriate thumbnails and embed URLs.

* **Documentation**
  * Clarified banner URL handling, playlist parameters, and YouTube overlay behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->