### PR TITLE
Keep Shiki off the homepage chrome graph

### DIFF
--- a/packages/worker/client/app.tsx
+++ b/packages/worker/client/app.tsx
@@ -7,7 +7,8 @@ import {
 	handleForkOutdatedCopyPointerOut,
 } from './fork-outdated-copy.ts'
 import { clientRouteLoaders, clientRoutes } from './routes/index.tsx'
-import { getSlugFromPathname } from './routes/blog-post.tsx'
+// Path-only helper: importing blog-post.tsx would pull Shiki onto `/`.
+import { getSlugFromPathname } from './routes/blog-post-path.ts'
 import { isCommunityListingPathname } from './routes/community-detail-shared.ts'
 import {
 	listenToRouterMutations,

--- a/packages/worker/client/routes/blog-post-path.node.test.ts
+++ b/packages/worker/client/routes/blog-post-path.node.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from 'vitest'
+import { getSlugFromPathname } from './blog-post-path.ts'
+
+test('blog post paths are /blog/:slug only, not listing, feeds, or APIs', () => {
+	expect(getSlugFromPathname('/blog/hello-world')).toBe('hello-world')
+	expect(getSlugFromPathname('/blog/hello-world/')).toBe('hello-world')
+	expect(getSlugFromPathname('/blog/early%20kody%20users')).toBe(
+		'early kody users',
+	)
+
+	expect(getSlugFromPathname('/blog')).toBeNull()
+	expect(getSlugFromPathname('/blog/')).toBeNull()
+	expect(getSlugFromPathname('/')).toBeNull()
+	expect(getSlugFromPathname('/pricing')).toBeNull()
+
+	expect(getSlugFromPathname('/blog/rss.xml')).toBeNull()
+	expect(getSlugFromPathname('/blog/hello-world.json')).toBeNull()
+	expect(getSlugFromPathname('/blog/nested/slug')).toBeNull()
+	expect(getSlugFromPathname('/blog/foo%2Fbar')).toBeNull()
+	expect(getSlugFromPathname('/blog/hello%2Ejson')).toBeNull()
+	expect(getSlugFromPathname('/blog/%')).toBeNull()
+})

--- a/packages/worker/client/routes/blog-post-path.ts
+++ b/packages/worker/client/routes/blog-post-path.ts
@@ -1,0 +1,25 @@
+import { routes } from '#universal/routes.ts'
+
+/**
+ * Post slug for `/blog/:slug` only. The `/blog` listing, `rss.xml`, `.json`
+ * APIs, and nested paths are not posts. The shell calls this to classify
+ * every pathname, so it must stay a tiny module — importing `blog-post.tsx`
+ * would pull Shiki onto `/`.
+ */
+export function getSlugFromPathname(pathname: string) {
+	const prefix = `${routes.blog.href()}/`
+	if (!pathname.startsWith(prefix)) return null
+	let slug: string
+	try {
+		slug = decodeURIComponent(pathname.slice(prefix.length).replace(/\/$/, ''))
+	} catch {
+		// Malformed percent-encoding (`/blog/%`) throws. The shell calls this to
+		// classify every pathname, so a throw here would take the whole page
+		// down instead of just missing a post.
+		return null
+	}
+	// Dots mark non-post paths under /blog (rss.xml, .json APIs); real post
+	// slugs are kebab-case and never contain one.
+	if (!slug || slug.includes('/') || slug.includes('.')) return null
+	return slug
+}

--- a/packages/worker/client/routes/blog-post.tsx
+++ b/packages/worker/client/routes/blog-post.tsx
@@ -32,6 +32,7 @@ import {
 	pageHeadCss,
 	proseCss,
 } from '#universal/styles/style-primitives.ts'
+import { getSlugFromPathname } from './blog-post-path.ts'
 
 /**
  * Blog post, ported from the redesign prototype (`landing/blog-post.html`).
@@ -44,24 +45,6 @@ import {
  * frontmatter (`placeholder`, default true) until a human review turns it
  * off.
  */
-
-export function getSlugFromPathname(pathname: string) {
-	const prefix = `${routes.blog.href()}/`
-	if (!pathname.startsWith(prefix)) return null
-	let slug: string
-	try {
-		slug = decodeURIComponent(pathname.slice(prefix.length).replace(/\/$/, ''))
-	} catch {
-		// Malformed percent-encoding (`/blog/%`) throws. The shell calls this to
-		// classify every pathname, so a throw here would take the whole page
-		// down instead of just missing a post.
-		return null
-	}
-	// Dots mark non-post paths under /blog (rss.xml, .json APIs); real post
-	// slugs are kebab-case and never contain one.
-	if (!slug || slug.includes('/') || slug.includes('.')) return null
-	return slug
-}
 
 function isBlogPostPath(href: string) {
 	return (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop the homepage from modulepreloading Shiki. Weekly `site-perf` still reports `shiki-on-home` on production after #2166.

## Why

`#2166` lazy-loaded onboarding, but `app.tsx` still imported `blog-post.tsx` only for `getSlugFromPathname`. That file pulls `markdown-view` → `syntax-highlight`, so every `/` document still preloads `syntax-highlight-*.js`.

Production on `ab07b020` (2026-09-08):

- HTML **123.5 KB** (was 132 KB; under the 130 KB budget)
- Anonymous onboarding JSON no longer ships featured MCP servers
- Verdict still **`needs-fix`**: `shiki-on-home` (53 modulepreloads, including `syntax-highlight-7oSur3w1.js`)

## Summary

- Move `getSlugFromPathname` into `blog-post-path.ts` so the app shell can classify `/blog/:slug` without importing the post route
- Keep the same decode / nested-path / `rss.xml` rules
- Cover those cases in a node unit test

## Testing

- `npx vitest run packages/worker/client/routes/blog-post-path.node.test.ts --project node-unit`
- Pre-push: `test:node` 2942 passed, `test:workers` 341 passed
- Production `control-kody health --origin https://kody.codes --sha ab07b020e78b1c7e853dc0f2f6a531c2c6c2fa2d` is ok
- `npm run site-perf -- --url https://kody.codes/ --json` still `needs-fix` for `shiki-on-home` until this deploys

## System changes

Follow-up to #2166. Low risk: path helper extract only.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `daf07d6d` · **Head:** `f92b0bd2`

**Classification:** composes — no primitives added or changed; the app shell classifies blog paths through a tiny helper instead of the post route.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `app-ui` | surfaces | composes — chrome imports `blog-post-path.ts` instead of `blog-post.tsx` |

### Change flow

Homepage chrome classifies `/blog/:slug` without loading Shiki.

```mermaid
sequenceDiagram
	actor visitor as Visitor
	participant appUi as app-ui
	visitor->>appUi: GET /
	appUi->>appUi: classify pathname with blog-post-path
	Note over appUi: no import of blog-post.tsx so syntax-highlight stays off /
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-37f8639b-8a61-4a07-a70a-92e3a420656f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-37f8639b-8a61-4a07-a70a-92e3a420656f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved blog URL handling for trailing slashes and URL-encoded post slugs.
  - Invalid, nested, feed, API, and malformed blog paths are now safely ignored instead of causing page errors.
- **Performance**
  - Reduced unnecessary code loaded on the homepage, helping improve initial page loading performance.
- **Reliability**
  - Added coverage for valid and invalid blog URL patterns to help prevent routing regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->