### PR TITLE
Only link homepage testimonials that have an early-users vignette

### DIFF
--- a/packages/worker/client/routes/landing-testimonials-carousel.tsx
+++ b/packages/worker/client/routes/landing-testimonials-carousel.tsx
@@ -586,6 +586,7 @@ function renderChevron(direction: 'prev' | 'next') {
 
 function renderTestimonialCard(item: LandingTestimonial) {
 	const attribution = testimonialAttribution(item)
+	const storyHref = testimonialStoryHref(item)
 	return (
 		<article key={item.name} class="landing-testimonial-card">
 			<blockquote class="landing-testimonial-quote">
@@ -620,10 +621,12 @@ function renderTestimonialCard(item: LandingTestimonial) {
 						) : null}
 					</span>
 				</a>
-				<a href={testimonialStoryHref(item)} class="landing-testimonial-story">
-					Read the full story
-					<span class="visually-hidden"> from {item.name}</span>
-				</a>
+				{storyHref ? (
+					<a href={storyHref} class="landing-testimonial-story">
+						Read the full story
+						<span class="visually-hidden"> from {item.name}</span>
+					</a>
+				) : null}
 			</footer>
 		</article>
 	)

--- a/packages/worker/src/app/handlers/landing-testimonials-ssr.node.test.ts
+++ b/packages/worker/src/app/handlers/landing-testimonials-ssr.node.test.ts
@@ -10,7 +10,6 @@ import { testOidcSigningEnv } from '#worker/test-support/oidc-signing-env.ts'
 import {
 	landingTestimonials,
 	landingTestimonialsStorySlug,
-	testimonialStoryHref,
 } from '#universal/landing-testimonials.ts'
 
 const testCookieSecret = 'test-cookie-secret-0123456789abcdef0123456789'
@@ -61,7 +60,7 @@ function createTestEnv() {
 	} as unknown as Env
 }
 
-test('homepage carousel SSR keeps short quotes and links to the early-users post', async () => {
+test('homepage carousel SSR keeps short quotes and story links only for vignettes', async () => {
 	resetDataCacheForTests()
 	setAuthSessionSecret(testCookieSecret)
 	const response = await renderAppPage({
@@ -80,10 +79,12 @@ test('homepage carousel SSR keeps short quotes and links to the early-users post
 
 	expect(html).toContain(josh.quote)
 	expect(html).toContain(jett.quote)
+	expect(html.match(/class="landing-testimonial-story"/g)).toHaveLength(2)
+	expect(html).toContain('href="/blog/early-kody-users#josh-tomaino"')
+	expect(html).toContain('href="/blog/early-kody-users#jett-hays"')
 	expect(html).toContain('Read the full story')
-	expect(html).toContain(`href="${testimonialStoryHref(josh)}"`)
-	expect(html).toContain(`href="${testimonialStoryHref(jett)}"`)
-	expect(html).toContain(`href="/blog/${landingTestimonialsStorySlug}"`)
+	expect(html).toContain('from Josh Tomaino')
+	expect(html).toContain('from Jett Hays')
 })
 
 test('early-users blog post SSR renders approved vignettes and heading anchors', async () => {

--- a/packages/worker/universal/landing-testimonials.node.test.ts
+++ b/packages/worker/universal/landing-testimonials.node.test.ts
@@ -1,10 +1,8 @@
 import { existsSync } from 'node:fs'
 import { join } from 'node:path'
 import { expect, test } from 'vitest'
-import { routes } from '#universal/routes.ts'
 import {
 	landingTestimonials,
-	landingTestimonialsStorySlug,
 	shuffleTestimonials,
 	testimonialAttribution,
 	testimonialInitials,
@@ -74,7 +72,7 @@ test('testimonialAttribution joins verified role and employer and omits blanks',
 	expect(testimonialAttribution({ title: '', company: '' })).toBeNull()
 })
 
-test('carousel story links share the early-users post and anchor featured vignettes', () => {
+test('carousel story links opt in only when a vignette heading exists', () => {
 	const josh = landingTestimonials.find(
 		(entry) => entry.name === 'Josh Tomaino',
 	)
@@ -87,14 +85,12 @@ test('carousel story links share the early-users post and anchor featured vignet
 	expect(jett.quote).toContain("when downtime isn't an option")
 	expect(testimonialStoryHref(josh)).toBe('/blog/early-kody-users#josh-tomaino')
 	expect(testimonialStoryHref(jett)).toBe('/blog/early-kody-users#jett-hays')
-	expect(testimonialStoryHref({})).toBe(
-		routes.blogPost.href({ slug: landingTestimonialsStorySlug }),
-	)
-	for (const entry of landingTestimonials) {
-		expect(
-			testimonialStoryHref(entry).startsWith('/blog/early-kody-users'),
-		).toBe(true)
-	}
+	expect(testimonialStoryHref({})).toBeNull()
+	expect(
+		landingTestimonials
+			.filter((entry) => testimonialStoryHref(entry) != null)
+			.map((entry) => entry.name),
+	).toEqual(['Josh Tomaino', 'Jett Hays'])
 })
 
 test('every hosted testimonial photo exists under public/images/testimonials', () => {

--- a/packages/worker/universal/landing-testimonials.ts
+++ b/packages/worker/universal/landing-testimonials.ts
@@ -19,7 +19,7 @@ export type LandingTestimonial = {
 	title?: string
 	/** Verified public employer — omit if unsure. */
 	company?: string
-	/** Heading id on the shared early-users post when this person has a vignette. */
+	/** Heading id on the shared early-users post. Omit when there is no vignette. */
 	storyAnchor?: string
 }
 
@@ -113,8 +113,10 @@ export function testimonialAttribution(entry: {
 	return parts.join(', ')
 }
 
-/** Shared early-users post, plus an in-page heading when this person has one. */
-export function testimonialStoryHref(entry: { storyAnchor?: string }): string {
-	const base = routes.blogPost.href({ slug: landingTestimonialsStorySlug })
-	return entry.storyAnchor ? `${base}#${entry.storyAnchor}` : base
+/** Early-users post + heading when this person has a vignette; otherwise no link. */
+export function testimonialStoryHref(entry: {
+	storyAnchor?: string
+}): string | null {
+	if (!entry.storyAnchor) return null
+	return `${routes.blogPost.href({ slug: landingTestimonialsStorySlug })}#${entry.storyAnchor}`
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop sending every homepage carousel card to `/blog/early-kody-users` when that post only has fuller sections for Josh Tomaino and Jett Hays.

## Why

#2165 added **Read the full story** on every card. Cards without a matching heading still pointed at the post root, which looks like a full story exists for everyone.

## Summary

- `testimonialStoryHref` returns `null` unless the entry has a `storyAnchor`.
- The carousel renders the story link only when that href is present.
- Josh and Jett keep their anchored links; everyone else has no story link.
- Future vignettes opt in by adding a heading plus `storyAnchor`.

## Testing

- Pre-push: `test:node` (2941) and `test:workers` (341)
- Focused homepage SSR + testimonial unit coverage for the two-link contract

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `daf07d6d` · **Head:** `7e384331`

**Classification:** composes — no primitives added or changed; this PR gates an existing homepage link on optional testimonial data.

### Primitives touched

| Primitive | Group    | Impact                                                                 |
| --------- | -------- | ---------------------------------------------------------------------- |
| `app-ui`  | surfaces | composes — story link renders only when `storyAnchor` is set           |

### Change flow

Homepage cards still share the early-users post, but the story link is omitted when the person has no heading on that post.

```mermaid
sequenceDiagram
	actor Visitor
	participant appUi as app-ui
	Visitor->>appUi: open homepage carousel
	appUi->>appUi: resolve testimonialStoryHref from storyAnchor
	alt storyAnchor is set
		Visitor->>appUi: activate Read the full story
		appUi->>appUi: GET /blog/early-kody-users#josh-tomaino or #jett-hays
	else no vignette heading
		Note over appUi: no story link on the card
	end
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5a818da3-1cd4-4f71-8951-7061d04dd645?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5a818da3-1cd4-4f71-8951-7061d04dd645&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Testimonial carousel story links now appear only for testimonials with an associated story.
  * Testimonials without story details no longer display empty or misleading links.
  * Story links now direct users to the relevant sections for Josh Tomaino and Jett Hays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->