### PR TITLE
Render images and videos in the package files explorer

### DIFF
--- a/.agents/skills/control-kody/references/features/community.md
+++ b/.agents/skills/control-kody/references/features/community.md
@@ -8,7 +8,8 @@ the same `/@username/:kodyId` surface; visibility is the only gate.
 `/community` → `/@username/kody-id`. Human share URL: `/@username/kody-id`
 (never construct `/community/{listing_id}` for people). Files:
 `/@username/kody-id/tree/:ref` (`:ref` is the repo default-branch name, a SHA,
-or another branch — leftover `/files` and `HEAD` 301 there). Owner settings:
+or another branch — leftover `/files` and `HEAD` 301 there). Media in that tree
+previews from `/@username/kody-id/raw/:ref/…`. Owner settings:
 `/@username/kody-id/settings`. Profile: `/@username`.
 
 ## Drive it
@@ -31,8 +32,9 @@ node tools/control-kody.ts request GET /community.json --skip-login
 
 - Profiles are public catalogs (packages, ratings, forks). There is no follow
   graph, bookmark-star, or social timeline.
-- Files and tree URLs are public read for listed packages and owner-only for
-  private ones.
+- Files, tree, and raw media URLs are public read for listed packages and
+  owner-only for private ones. `/raw/` only serves allowlisted sniffed media
+  (never HTML or JS).
 - Package settings 404 for anyone who is not the owner.
 - Official `@kody/*` listings skip the install confirm; third-party listings ask
   once (`acknowledged: true` or the install endpoint responds `409`).

--- a/.agents/skills/control-kody/references/features/packages.md
+++ b/.agents/skills/control-kody/references/features/packages.md
@@ -8,8 +8,10 @@ Repo-backed saved packages: list, detail, files, approve-publish.
 when you view your own profile. Each package lives at `/@username/:kodyId`
 (README), `/@username/:kodyId/tree/:ref` (files), `/@username/:kodyId/settings`
 (lock, visibility, delete), and `/@username/:kodyId/approve-publish`
-(published-vs-HEAD review). Legacy `/account/packages` HTML URLs only redirect
-to these canonical pages.
+(published-vs-HEAD review). Opening an allowlisted image or video in the tree
+renders a preview; the bytes come from `/@username/:kodyId/raw/:ref/…` (same
+authz as the tree). Legacy `/account/packages` HTML URLs only redirect to these
+canonical pages.
 
 ## Drive it
 
@@ -44,6 +46,7 @@ then delete it and assert the empty state.
   action)
 - `GET /profiles/:username/packages/:kodyId.json`
 - `GET /profiles/:username/packages/:kodyId/files.json`
+- `GET /@:username/:kodyId/raw/:ref(/*relativePath)` (allowlisted media bytes)
 - `GET /profiles/:username/packages/:kodyId/approve-publish.json`
 - `GET /account/packages/:packageId/files.json` (404 + `redirectTo` the tree)
 - `GET|POST /account/packages/:packageId/approve-publish.json`

--- a/docs/contributing/architecture/request-lifecycle.md
+++ b/docs/contributing/architecture/request-lifecycle.md
@@ -199,8 +199,9 @@ workerd honors `stale-while-revalidate` and persists `caches.default` under
 edit that changed it. The `workers-unit` suite still exercises the store.
 
 The public package surfaces (`/@:username/:kodyId`,
-`/@:username/:kodyId/tree/:ref/*`, `/community/:id`, `/community/:id/files/*`)
-and their JSON companions (`/profiles/:username/packages/:kodyId.json`,
+`/@:username/:kodyId/tree/:ref/*`, `/@:username/:kodyId/raw/:ref/*`,
+`/community/:id`, `/community/:id/files/*`, `/community/:id/raw/*`) and their
+JSON companions (`/profiles/:username/packages/:kodyId.json`,
 `/community/:id.json`, `.../files.json`) are shared too, but with
 `public, max-age=60` and no stale-while-revalidate: an owner can unpublish or
 make a package private and nothing purges shared caches, so a stale public

--- a/docs/contributing/community-packages.md
+++ b/docs/contributing/community-packages.md
@@ -278,10 +278,12 @@ Client routes: `packages/worker/client/routes/community*`
   only as `image/svg+xml` for `<img src>` — markup is never injected. Other
   binaries show a non-preview message instead of a latin1 code dump.
 - `/@:username/:kodyId/raw/:ref(/*relativePath)` — allowlisted media bytes for
-  that preview (same authz as the tree). Listing-uuid fallback:
-  `/community/:listingId/raw(/*relativePath)`. `Content-Type` comes from the
-  extension allowlist plus a magic-byte sniff; responses are `nosniff` +
-  `Content-Disposition: inline` and never `text/html` or JavaScript.
+  that preview (same authz and tree resolution as the explorer). A hex ref that
+  only falls back to the listing pin snapshot 404s, same as the tree.
+  Listing-uuid fallback: `/community/:listingId/raw(/*relativePath)`.
+  `Content-Type` comes from the extension allowlist plus a magic-byte sniff;
+  responses are `nosniff` + `Content-Disposition: inline` and never `text/html`
+  or JavaScript.
 - `/community/:listingId` — the same page by listing id; redirects to the
   canonical URL. Metadata, ratings, README, one-click install (requires login
   and a generic confirm), fork prompt, and report link (report requires login)

--- a/docs/contributing/community-packages.md
+++ b/docs/contributing/community-packages.md
@@ -272,7 +272,16 @@ Client routes: `packages/worker/client/routes/community*`
   redirect at that URL
 - `/@:username/:kodyId/tree/:ref(/*relativePath)` — GitHub-lite source explorer
   (default-branch name from git, SHA, or another branch). `HEAD` and leftover
-  `/files` URLs 301 to `/tree/{defaultBranch}` (`main` when lookup misses)
+  `/files` URLs 301 to `/tree/{defaultBranch}` (`main` when lookup misses).
+  Allowlisted images, video, and audio preview in the blob pane via a
+  same-origin `/raw/` route (`<img>` / `<video>` / `<audio>`). SVG is served
+  only as `image/svg+xml` for `<img src>` — markup is never injected. Other
+  binaries show a non-preview message instead of a latin1 code dump.
+- `/@:username/:kodyId/raw/:ref(/*relativePath)` — allowlisted media bytes for
+  that preview (same authz as the tree). Listing-uuid fallback:
+  `/community/:listingId/raw(/*relativePath)`. `Content-Type` comes from the
+  extension allowlist plus a magic-byte sniff; responses are `nosniff` +
+  `Content-Disposition: inline` and never `text/html` or JavaScript.
 - `/community/:listingId` — the same page by listing id; redirects to the
   canonical URL. Metadata, ratings, README, one-click install (requires login
   and a generic confirm), fork prompt, and report link (report requires login)

--- a/packages/worker/client/package-files-explorer.tsx
+++ b/packages/worker/client/package-files-explorer.tsx
@@ -8,6 +8,11 @@ import { renderMarkdownNodes } from '#client/markdown-view.tsx'
 import { renderHighlightedCode } from '#client/syntax-highlight.tsx'
 import { plainHighlightedCode } from '#universal/highlighted-code.ts'
 import {
+	isPackageFilesMediaKind,
+	packageFileBaseName,
+	packageFileKindLabel,
+} from '#universal/package-file-media.ts'
+import {
 	buildPackageFilesAncestors,
 	joinPackageFilesPath,
 	listPackageFilesChildren,
@@ -36,11 +41,16 @@ function ancestorDirectories(path: string) {
 		.filter((candidate) => candidate !== path)
 }
 
-function formatBytes(value: string) {
-	const bytes = new TextEncoder().encode(value).length
+function formatBytes(bytes: number) {
 	if (bytes < 1024) return `${bytes} B`
 	if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
 	return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}
+
+function fileByteLength(data: PackageFilesLoaderData) {
+	if (typeof data.contentByteLength === 'number') return data.contentByteLength
+	if (data.content) return new TextEncoder().encode(data.content).byteLength
+	return 0
 }
 
 function countLines(value: string) {
@@ -345,6 +355,12 @@ function renderContent(data: PackageFilesLoaderData): RemixNode {
 
 	const heading = data.contentPath ?? data.selectedPath
 	const body = data.content ?? ''
+	const kindLabel =
+		packageFileKindLabel(data.contentPath, data.contentKind) ||
+		packageFileLanguageLabel(data.contentPath)
+	const byteLength = fileByteLength(data)
+	const showTextMeta =
+		Boolean(body) && !isPackageFilesMediaKind(data.contentKind)
 	return (
 		<div>
 			<div mix={css(contentToolbarCss)}>
@@ -353,16 +369,17 @@ function renderContent(data: PackageFilesLoaderData): RemixNode {
 					<h2 mix={css(contentHeadingCss)} title={heading}>
 						{heading}
 					</h2>
-					{body ? (
+					{byteLength > 0 || kindLabel ? (
 						<span mix={css(contentMetaCss)}>
-							{countLines(body)} lines · {formatBytes(body)}
-							{packageFileLanguageLabel(data.contentPath)
-								? ` · ${packageFileLanguageLabel(data.contentPath)}`
-								: ''}
+							{showTextMeta ? `${countLines(body)} lines · ` : ''}
+							{byteLength > 0 ? formatBytes(byteLength) : ''}
+							{kindLabel ? `${byteLength > 0 ? ' · ' : ''}${kindLabel}` : ''}
 						</span>
 					) : null}
 				</div>
-				{body ? (
+				{body &&
+				data.contentKind !== 'binary' &&
+				!isPackageFilesMediaKind(data.contentKind) ? (
 					<CopyTextButton
 						value={body}
 						idleLabel="Copy"
@@ -372,22 +389,99 @@ function renderContent(data: PackageFilesLoaderData): RemixNode {
 					/>
 				) : null}
 			</div>
-			{data.contentKind === 'markdown' ? (
+			{renderFilePreview(data, heading, body)}
+		</div>
+	)
+}
+
+function renderFilePreview(
+	data: PackageFilesLoaderData,
+	heading: string,
+	body: string,
+): RemixNode {
+	const contentKind = data.contentKind
+	switch (contentKind) {
+		case 'markdown':
+			return (
 				<div mix={css(markdownCss)} data-testid="package-files-markdown">
 					{renderMarkdownNodes(body, {
 						fences: data.contentFences,
 					})}
 				</div>
-			) : (
+			)
+		case 'image': {
+			if (!data.mediaHref) {
+				throw new Error(`Image preview is missing a raw href for ${heading}.`)
+			}
+			const name = packageFileBaseName(heading)
+			return (
+				<div mix={css(mediaPreviewCss)} data-testid="package-files-image">
+					{/* SVG is XSS-sensitive: preview only via <img src> to the
+					    allowlisted /raw/ route. Never inject SVG markup. */}
+					<img src={data.mediaHref} alt={name} mix={css(mediaImageCss)} />
+				</div>
+			)
+		}
+		case 'video': {
+			if (!data.mediaHref) {
+				throw new Error(`Video preview is missing a raw href for ${heading}.`)
+			}
+			return (
+				<div mix={css(mediaPreviewCss)} data-testid="package-files-video">
+					{/* oxlint-disable-next-line jsx-a11y/media-has-caption -- repo videos have no sidecar captions; filename is the accessible name */}
+					<video
+						src={data.mediaHref}
+						controls
+						preload="metadata"
+						aria-label={packageFileBaseName(heading)}
+						mix={css(mediaVideoCss)}
+					>
+						Your browser cannot play this video.
+					</video>
+				</div>
+			)
+		}
+		case 'audio': {
+			if (!data.mediaHref) {
+				throw new Error(`Audio preview is missing a raw href for ${heading}.`)
+			}
+			return (
+				<div mix={css(mediaPreviewCss)} data-testid="package-files-audio">
+					{/* oxlint-disable-next-line jsx-a11y/media-has-caption -- repo audio has no sidecar captions; filename is the accessible name */}
+					<audio
+						src={data.mediaHref}
+						controls
+						preload="metadata"
+						aria-label={packageFileBaseName(heading)}
+						mix={css(mediaAudioCss)}
+					>
+						Your browser cannot play this audio.
+					</audio>
+				</div>
+			)
+		}
+		case 'binary':
+			return (
+				<p mix={css(binaryCss)} data-testid="package-files-binary">
+					This is a binary file and cannot be previewed.
+				</p>
+			)
+		case 'code':
+		case 'text':
+		case null:
+			return (
 				<div mix={css(codeCss)} data-testid="package-files-code">
 					{renderHighlightedCode(
 						data.contentHighlighted ??
 							plainHighlightedCode(body, data.language ?? 'plaintext'),
 					)}
 				</div>
-			)}
-		</div>
-	)
+			)
+		default: {
+			const exhaustive: never = contentKind
+			throw new Error(`Unknown package file content kind: ${exhaustive}`)
+		}
+	}
 }
 
 function arrowLeftIcon() {
@@ -878,6 +972,43 @@ const codeCss = {
 		opacity: 0.65,
 		userSelect: 'none' as const,
 	},
+}
+
+const mediaPreviewCss = {
+	display: 'flex',
+	justifyContent: 'center',
+	alignItems: 'center',
+	padding: spacing.lg,
+	minHeight: '12rem',
+	backgroundColor: colors.background,
+}
+
+const mediaImageCss = {
+	display: 'block',
+	maxWidth: '100%',
+	maxHeight: '36rem',
+	height: 'auto',
+	borderRadius: radius.sm,
+}
+
+const mediaVideoCss = {
+	display: 'block',
+	width: '100%',
+	maxWidth: '40rem',
+	maxHeight: '36rem',
+	backgroundColor: colors.surface,
+}
+
+const mediaAudioCss = {
+	width: '100%',
+	maxWidth: '28rem',
+}
+
+const binaryCss = {
+	margin: 0,
+	padding: spacing.lg,
+	color: colors.textMuted,
+	fontSize: typography.fontSize.sm,
 }
 
 const emptyCss = {

--- a/packages/worker/src/app/handlers/package-files-raw.node.test.ts
+++ b/packages/worker/src/app/handlers/package-files-raw.node.test.ts
@@ -1,0 +1,173 @@
+import { expect, test, vi } from 'vitest'
+
+const mockModule = vi.hoisted(() => ({
+	loadAccessiblePackageFileRaw: vi.fn<() => Promise<unknown>>(),
+	loadCommunityPackageFileRaw: vi.fn<() => Promise<unknown>>(),
+}))
+
+vi.mock('#app/package-files-data.ts', () => ({
+	loadAccessiblePackageFileRaw: (...args: Array<unknown>) =>
+		mockModule.loadAccessiblePackageFileRaw(...args),
+	loadCommunityPackageFileRaw: (...args: Array<unknown>) =>
+		mockModule.loadCommunityPackageFileRaw(...args),
+}))
+
+const { createCommunityDetailRawHandler, createCommunityPackageRawHandler } =
+	await import('./package-files-raw.ts')
+
+const pngBytes = Uint8Array.from([
+	0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0, 1,
+])
+
+test('raw media serves allowlisted images inline and rejects binaries, HTML, and traversal', async () => {
+	const handler = createCommunityPackageRawHandler({} as Env)
+	mockModule.loadAccessiblePackageFileRaw.mockResolvedValue({
+		kind: 'ok',
+		bytes: pngBytes,
+		contentType: 'image/png',
+		filename: 'logo.png',
+		isPrivate: false,
+	})
+
+	const success = await handler.handler({
+		request: new Request(
+			'https://example.com/@owner/demo/raw/main/docs/logo.png',
+		),
+		params: {
+			username: 'owner',
+			kodyId: 'demo',
+			ref: 'main',
+			relativePath: 'docs/logo.png',
+		},
+		url: new URL('https://example.com/@owner/demo/raw/main/docs/logo.png'),
+	} as never)
+	expect(success.status).toBe(200)
+	expect(success.headers.get('Content-Type')).toBe('image/png')
+	expect(success.headers.get('Content-Disposition')).toBe(
+		'inline; filename="logo.png"',
+	)
+	expect(success.headers.get('X-Content-Type-Options')).toBe('nosniff')
+	expect(success.headers.get('Content-Security-Policy')).toContain('sandbox')
+	expect(success.headers.get('Content-Security-Policy')).toContain(
+		"default-src 'none'",
+	)
+	expect(await success.arrayBuffer()).toEqual(pngBytes.buffer)
+
+	mockModule.loadAccessiblePackageFileRaw.mockResolvedValue({
+		kind: 'not-media',
+	})
+	const binary = await handler.handler({
+		request: new Request('https://example.com/@owner/demo/raw/main/app.wasm'),
+		params: {
+			username: 'owner',
+			kodyId: 'demo',
+			ref: 'main',
+			relativePath: 'app.wasm',
+		},
+		url: new URL('https://example.com/@owner/demo/raw/main/app.wasm'),
+	} as never)
+	expect(binary.status).toBe(404)
+	expect(binary.headers.get('Content-Type')).not.toBe('application/wasm')
+
+	const traversal = await handler.handler({
+		request: new Request(
+			'https://example.com/@owner/demo/raw/main/../secret.png',
+		),
+		params: {
+			username: 'owner',
+			kodyId: 'demo',
+			ref: 'main',
+			relativePath: '../secret.png',
+		},
+		url: new URL('https://example.com/@owner/demo/raw/main/../secret.png'),
+	} as never)
+	expect(traversal.status).toBe(404)
+	expect(mockModule.loadAccessiblePackageFileRaw).not.toHaveBeenCalledWith(
+		expect.objectContaining({ selectedPath: '../secret.png' }),
+	)
+
+	mockModule.loadAccessiblePackageFileRaw.mockResolvedValue({
+		kind: 'ok',
+		bytes: new TextEncoder().encode('<html></html>'),
+		contentType: 'text/html',
+		filename: 'nope.html',
+		isPrivate: false,
+	})
+	const html = await handler.handler({
+		request: new Request('https://example.com/@owner/demo/raw/main/nope.html'),
+		params: {
+			username: 'owner',
+			kodyId: 'demo',
+			ref: 'main',
+			relativePath: 'nope.html',
+		},
+		url: new URL('https://example.com/@owner/demo/raw/main/nope.html'),
+	} as never)
+	expect(html.status).toBe(404)
+	expect(html.headers.get('Content-Type')).not.toBe('text/html')
+})
+
+test('listing raw SVG stays image/svg+xml with sandbox CSP and owner-only files stay private', async () => {
+	const handler = createCommunityDetailRawHandler({} as Env)
+	const svg = new TextEncoder().encode(
+		'<svg xmlns="http://www.w3.org/2000/svg"></svg>',
+	)
+	mockModule.loadCommunityPackageFileRaw.mockResolvedValue({
+		kind: 'ok',
+		bytes: svg,
+		contentType: 'image/svg+xml',
+		filename: 'icon.svg',
+		isPrivate: false,
+	})
+	const publicSvg = await handler.handler({
+		request: new Request(
+			'https://example.com/community/listing-1/raw/icon.svg',
+		),
+		params: { listingId: 'listing-1', relativePath: 'icon.svg' },
+		url: new URL('https://example.com/community/listing-1/raw/icon.svg'),
+	} as never)
+	expect(publicSvg.status).toBe(200)
+	expect(publicSvg.headers.get('Content-Type')).toBe('image/svg+xml')
+	expect(publicSvg.headers.get('Content-Disposition')).toContain('inline')
+	expect(publicSvg.headers.get('Content-Security-Policy')).toContain('sandbox')
+	expect(publicSvg.headers.get('Cache-Control')).toBe('public, max-age=60')
+
+	mockModule.loadAccessiblePackageFileRaw.mockResolvedValue({
+		kind: 'ok',
+		bytes: pngBytes,
+		contentType: 'image/png',
+		filename: 'logo.png',
+		isPrivate: true,
+	})
+	const privateImage = await createCommunityPackageRawHandler(
+		{} as Env,
+	).handler({
+		request: new Request('https://example.com/@owner/demo/raw/main/logo.png', {
+			headers: { Cookie: 'kody_session=abc' },
+		}),
+		params: {
+			username: 'owner',
+			kodyId: 'demo',
+			ref: 'main',
+			relativePath: 'logo.png',
+		},
+		url: new URL('https://example.com/@owner/demo/raw/main/logo.png'),
+	} as never)
+	expect(privateImage.status).toBe(200)
+	expect(privateImage.headers.get('Cache-Control')).toBe('private, no-store')
+
+	mockModule.loadAccessiblePackageFileRaw.mockResolvedValue({
+		kind: 'unauthorized',
+	})
+	const denied = await createCommunityPackageRawHandler({} as Env).handler({
+		request: new Request('https://example.com/@owner/demo/raw/main/logo.png'),
+		params: {
+			username: 'owner',
+			kodyId: 'demo',
+			ref: 'main',
+			relativePath: 'logo.png',
+		},
+		url: new URL('https://example.com/@owner/demo/raw/main/logo.png'),
+	} as never)
+	expect(denied.status).toBe(401)
+})

--- a/packages/worker/src/app/handlers/package-files-raw.ts
+++ b/packages/worker/src/app/handlers/package-files-raw.ts
@@ -1,0 +1,149 @@
+import { type Action } from 'remix/router'
+import { anonymousPersonalizedJsonCacheHeaders } from '#app/anonymous-html-cache.ts'
+import {
+	loadAccessiblePackageFileRaw,
+	loadCommunityPackageFileRaw,
+	type PackageFileRawResult,
+} from '#app/package-files-data.ts'
+import { normalizePackageFilesPath } from '#universal/package-files.ts'
+import { type routes } from '#universal/routes.ts'
+
+const rawMediaCsp = "default-src 'none'; sandbox"
+
+function rawNotFound() {
+	return new Response('Not found', {
+		status: 404,
+		headers: {
+			'Cache-Control': 'no-store',
+			'X-Content-Type-Options': 'nosniff',
+		},
+	})
+}
+
+function rawUnauthorized() {
+	return new Response('Unauthorized', {
+		status: 401,
+		headers: {
+			'Cache-Control': 'no-store',
+			'X-Content-Type-Options': 'nosniff',
+		},
+	})
+}
+
+function rawTooLarge() {
+	return new Response('File too large to preview', {
+		status: 413,
+		headers: {
+			'Cache-Control': 'no-store',
+			'X-Content-Type-Options': 'nosniff',
+		},
+	})
+}
+
+function rawMediaResponse(input: {
+	request: Request
+	result: Extract<PackageFileRawResult, { kind: 'ok' }>
+}) {
+	if (
+		input.result.contentType === 'text/html' ||
+		input.result.contentType === 'application/javascript' ||
+		input.result.contentType === 'text/javascript' ||
+		input.result.contentType === 'text/css'
+	) {
+		return rawNotFound()
+	}
+	const cache = anonymousPersonalizedJsonCacheHeaders({
+		personalized: false,
+		request: input.request,
+		visibilityGated: true,
+	})
+	const headers = new Headers(cache)
+	if (input.result.isPrivate) {
+		headers.set('Cache-Control', 'private, no-store')
+	}
+	headers.set('Content-Type', input.result.contentType)
+	headers.set(
+		'Content-Disposition',
+		`inline; filename="${input.result.filename}"`,
+	)
+	headers.set('Content-Length', String(input.result.bytes.byteLength))
+	headers.set('X-Content-Type-Options', 'nosniff')
+	headers.set('Content-Security-Policy', rawMediaCsp)
+	if (input.request.method === 'HEAD') {
+		return new Response(null, { headers })
+	}
+	const body = new Uint8Array(input.result.bytes.byteLength)
+	body.set(input.result.bytes)
+	return new Response(body.buffer, { headers })
+}
+
+function respondRaw(input: { request: Request; result: PackageFileRawResult }) {
+	switch (input.result.kind) {
+		case 'ok':
+			return rawMediaResponse({
+				request: input.request,
+				result: input.result,
+			})
+		case 'unauthorized':
+			return rawUnauthorized()
+		case 'too-large':
+			return rawTooLarge()
+		case 'not-found':
+		case 'not-media':
+			return rawNotFound()
+		default: {
+			const exhaustive: never = input.result
+			throw new Error(`Unknown package file raw result: ${exhaustive}`)
+		}
+	}
+}
+
+export function createCommunityPackageRawHandler(env: Env) {
+	return {
+		middleware: [],
+		async handler({ request, params }) {
+			if (request.method !== 'GET' && request.method !== 'HEAD') {
+				return new Response('Method not allowed', { status: 405 })
+			}
+			const selectedPath = normalizePackageFilesPath(
+				typeof params.relativePath === 'string' ? params.relativePath : '',
+			)
+			if (selectedPath == null || selectedPath === '') {
+				return rawNotFound()
+			}
+			const result = await loadAccessiblePackageFileRaw({
+				env,
+				request,
+				username: params.username,
+				kodyId: params.kodyId,
+				selectedPath,
+				ref: params.ref,
+			})
+			return respondRaw({ request, result })
+		},
+	} satisfies Action<typeof routes.communityPackageRaw>
+}
+
+export function createCommunityDetailRawHandler(env: Env) {
+	return {
+		middleware: [],
+		async handler({ request, params }) {
+			if (request.method !== 'GET' && request.method !== 'HEAD') {
+				return new Response('Method not allowed', { status: 405 })
+			}
+			const selectedPath = normalizePackageFilesPath(
+				typeof params.relativePath === 'string' ? params.relativePath : '',
+			)
+			if (selectedPath == null || selectedPath === '') {
+				return rawNotFound()
+			}
+			const result = await loadCommunityPackageFileRaw({
+				env,
+				request,
+				listingId: params.listingId,
+				selectedPath,
+			})
+			return respondRaw({ request, result })
+		},
+	} satisfies Action<typeof routes.communityDetailRaw>
+}

--- a/packages/worker/src/app/package-files-data.node.test.ts
+++ b/packages/worker/src/app/package-files-data.node.test.ts
@@ -9,6 +9,7 @@ const mockModule = vi.hoisted(() => ({
 	readAuthenticatedAppUser: vi.fn<() => Promise<unknown>>(),
 	highlightMarkdownFences: vi.fn(async () => []),
 	highlightSnippets: vi.fn(async () => []),
+	readArtifactFileAtCommit: vi.fn<() => Promise<unknown>>(),
 }))
 
 vi.mock('#worker/community/repo.ts', () => ({
@@ -52,8 +53,16 @@ vi.mock('#app/highlight-code.ts', () => ({
 		mockModule.highlightSnippets(...args),
 }))
 
-const { loadCommunityPackageFilesData, loadPackagePageHasAgentsDocs } =
-	await import('./package-files-data.ts')
+vi.mock('#worker/repo/artifact-file.ts', () => ({
+	readArtifactFileAtCommit: (...args: Array<unknown>) =>
+		mockModule.readArtifactFileAtCommit(...args),
+}))
+
+const {
+	loadCommunityPackageFileRaw,
+	loadCommunityPackageFilesData,
+	loadPackagePageHasAgentsDocs,
+} = await import('./package-files-data.ts')
 
 const env = { APP_DB: {}, BUNDLE_ARTIFACTS_KV: {} } as Env
 const listing = {
@@ -156,4 +165,96 @@ test('package page reports AGENTS.md only when a non-empty root file exists', as
 			viewerIsOwner: false,
 		}),
 	).toBe(false)
+})
+
+test('opens a png as a media preview and an unknown binary without a code dump', async () => {
+	const pngBytes = Uint8Array.from([
+		0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0, 1,
+	])
+	const png = String.fromCharCode(...pngBytes)
+	mockModule.getCommunityListingById.mockResolvedValue(listing)
+	mockModule.getEntitySourceById.mockResolvedValue({
+		repo_id: 'repo-1',
+		published_commit: 'abc123',
+	})
+	mockModule.resolveArtifactSourceHead.mockResolvedValue({
+		branch: 'main',
+		commit: 'abc123',
+	})
+	mockModule.readPublishedSourceSnapshot.mockResolvedValue({
+		files: {
+			'README.md': '# Sentry\n',
+			'logo.png': png,
+			'app.wasm': 'wasm\0module',
+		},
+	})
+	mockModule.readAuthenticatedAppUser.mockResolvedValue(null)
+	mockModule.readArtifactFileAtCommit.mockResolvedValue(pngBytes)
+
+	const image = await loadCommunityPackageFilesData({
+		env,
+		request: new Request(
+			'https://example.com/@kentcdodds/sentry/tree/main/logo.png',
+		),
+		listingId: 'listing-1',
+		selectedPath: 'logo.png',
+		ref: 'main',
+	})
+	expect(image).toMatchObject({
+		ok: true,
+		content: null,
+		contentKind: 'image',
+		mediaHref: '/@kentcdodds/sentry/raw/main/logo.png',
+		contentByteLength: pngBytes.byteLength,
+	})
+	expect(image?.content).toBeNull()
+	expect(mockModule.highlightSnippets).not.toHaveBeenCalled()
+
+	const binary = await loadCommunityPackageFilesData({
+		env,
+		request: new Request(
+			'https://example.com/@kentcdodds/sentry/tree/main/app.wasm',
+		),
+		listingId: 'listing-1',
+		selectedPath: 'app.wasm',
+		ref: 'main',
+	})
+	expect(binary).toMatchObject({
+		content: null,
+		contentKind: 'binary',
+		mediaHref: null,
+	})
+	expect(binary?.content).toBeNull()
+
+	const raw = await loadCommunityPackageFileRaw({
+		env,
+		request: new Request(
+			'https://example.com/@kentcdodds/sentry/raw/main/logo.png',
+		),
+		listingId: 'listing-1',
+		selectedPath: 'logo.png',
+		ref: 'main',
+	})
+	expect(raw).toEqual({
+		kind: 'ok',
+		bytes: pngBytes,
+		contentType: 'image/png',
+		filename: 'logo.png',
+		isPrivate: false,
+	})
+
+	mockModule.readArtifactFileAtCommit.mockResolvedValue(
+		new TextEncoder().encode('<!DOCTYPE html><script>alert(1)</script>'),
+	)
+	expect(
+		await loadCommunityPackageFileRaw({
+			env,
+			request: new Request(
+				'https://example.com/@kentcdodds/sentry/raw/main/logo.png',
+			),
+			listingId: 'listing-1',
+			selectedPath: 'logo.png',
+			ref: 'main',
+		}),
+	).toEqual({ kind: 'not-media' })
 })

--- a/packages/worker/src/app/package-files-data.node.test.ts
+++ b/packages/worker/src/app/package-files-data.node.test.ts
@@ -258,3 +258,68 @@ test('opens a png as a media preview and an unknown binary without a code dump',
 		}),
 	).toEqual({ kind: 'not-media' })
 })
+
+test('community raw 404s a hex that only has the listing pin snapshot', async () => {
+	const pngBytes = Uint8Array.from([
+		0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0, 1,
+	])
+	const png = String.fromCharCode(...pngBytes)
+	const missingHex = 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef'
+
+	mockModule.getCommunityListingById.mockResolvedValue(listing)
+	mockModule.getEntitySourceById.mockResolvedValue({
+		repo_id: 'repo-1',
+		published_commit: 'abc123',
+	})
+	mockModule.resolveArtifactSourceHead.mockResolvedValue({
+		branch: 'main',
+		commit: 'abc123',
+	})
+	mockModule.readPublishedSourceSnapshot.mockResolvedValue(null)
+	mockModule.readCommunitySnapshot.mockResolvedValue({
+		files: { 'logo.png': png },
+	})
+	mockModule.readAuthenticatedAppUser.mockResolvedValue(null)
+	mockModule.readArtifactFileAtCommit.mockResolvedValue(null)
+
+	expect(
+		await loadCommunityPackageFilesData({
+			env,
+			request: new Request(
+				`https://example.com/@kentcdodds/sentry/tree/${missingHex}/logo.png`,
+			),
+			listingId: 'listing-1',
+			selectedPath: 'logo.png',
+			ref: missingHex,
+		}),
+	).toBeNull()
+
+	expect(
+		await loadCommunityPackageFileRaw({
+			env,
+			request: new Request(
+				`https://example.com/@kentcdodds/sentry/raw/${missingHex}/logo.png`,
+			),
+			listingId: 'listing-1',
+			selectedPath: 'logo.png',
+			ref: missingHex,
+		}),
+	).toEqual({ kind: 'not-found' })
+
+	const pinRaw = await loadCommunityPackageFileRaw({
+		env,
+		request: new Request(
+			'https://example.com/@kentcdodds/sentry/raw/abc123/logo.png',
+		),
+		listingId: 'listing-1',
+		selectedPath: 'logo.png',
+		ref: 'abc123',
+	})
+	expect(pinRaw).toMatchObject({
+		kind: 'ok',
+		contentType: 'image/png',
+		filename: 'logo.png',
+		isPrivate: false,
+	})
+	expect(pinRaw.kind === 'ok' && [...pinRaw.bytes]).toEqual([...pngBytes])
+})

--- a/packages/worker/src/app/package-files-data.ts
+++ b/packages/worker/src/app/package-files-data.ts
@@ -139,44 +139,17 @@ export async function loadCommunityPackageFilesData(input: {
 
 	const ownerUsername = getOwnerUsernameFromListingName(listing.name)
 	const treeRef = input.ref?.trim() ?? ''
-	// The source row and the viewer are independent reads.
-	const [source, viewerUserId] = await Promise.all([
-		getEntitySourceById(input.env.APP_DB, listing.sourceId),
+	const [tree, viewerUserId] = await Promise.all([
+		loadCommunityListingPublicTree({
+			env: input.env,
+			request: input.request,
+			listing,
+			treeRef,
+		}),
 		readOptionalViewerUserId({ env: input.env, request: input.request }),
 	])
-	const resolved = await resolvePublicTreeCommit({
-		env: input.env,
-		request: input.request,
-		sourceRepoId: source?.repo_id ?? null,
-		publishedCommit: source?.published_commit ?? listing.pinnedCommit,
-		pinnedCommit: listing.pinnedCommit,
-		ref: treeRef,
-	})
-	const resolvedCommit = resolved.commit
-	const urlRef = isPublicTreeDefaultRefAlias(treeRef)
-		? resolved.defaultBranch
-		: treeRef
-	const loaded = await loadPublicTreeFiles({
-		env: input.env,
-		request: input.request,
-		listingId: listing.id,
-		sourceId: listing.sourceId,
-		sourceRepoId: source?.repo_id ?? null,
-		commit: resolvedCommit,
-		pinnedCommit: listing.pinnedCommit,
-	})
-	const requestedHex = /^[0-9a-f]{7,40}$/i.test(treeRef)
-	if (
-		requestedHex &&
-		loaded.fromListingSnapshot &&
-		resolvedCommit !== listing.pinnedCommit &&
-		!(
-			listing.pinnedCommit.startsWith(treeRef) ||
-			treeRef.startsWith(listing.pinnedCommit)
-		)
-	) {
-		return null
-	}
+	if (!tree) return null
+	const { loaded, urlRef } = tree
 	const files = loaded.files
 	const filesBasePath = getCommunityPackageFilesHref({
 		listingId: listing.id,
@@ -335,6 +308,68 @@ async function loadPublicTreeFilesUncached(input: {
 		}
 	}
 	return { files: {}, fromListingSnapshot: Boolean(input.listingId) }
+}
+
+function listingSnapshotMissesRequestedHex(input: {
+	treeRef: string
+	fromListingSnapshot: boolean
+	resolvedCommit: string | null
+	pinnedCommit: string
+}) {
+	if (!/^[0-9a-f]{7,40}$/i.test(input.treeRef)) return false
+	if (!input.fromListingSnapshot) return false
+	if (input.resolvedCommit === input.pinnedCommit) return false
+	return !(
+		input.pinnedCommit.startsWith(input.treeRef) ||
+		input.treeRef.startsWith(input.pinnedCommit)
+	)
+}
+
+async function loadCommunityListingPublicTree(input: {
+	env: Env
+	request: Request
+	listing: {
+		id: string
+		sourceId: string
+		pinnedCommit: string
+	}
+	treeRef: string
+}) {
+	const source = await getEntitySourceById(
+		input.env.APP_DB,
+		input.listing.sourceId,
+	)
+	const resolved = await resolvePublicTreeCommit({
+		env: input.env,
+		request: input.request,
+		sourceRepoId: source?.repo_id ?? null,
+		publishedCommit: source?.published_commit ?? input.listing.pinnedCommit,
+		pinnedCommit: input.listing.pinnedCommit,
+		ref: input.treeRef,
+	})
+	const loaded = await loadPublicTreeFiles({
+		env: input.env,
+		request: input.request,
+		listingId: input.listing.id,
+		sourceId: input.listing.sourceId,
+		sourceRepoId: source?.repo_id ?? null,
+		commit: resolved.commit,
+		pinnedCommit: input.listing.pinnedCommit,
+	})
+	if (
+		listingSnapshotMissesRequestedHex({
+			treeRef: input.treeRef,
+			fromListingSnapshot: loaded.fromListingSnapshot,
+			resolvedCommit: resolved.commit,
+			pinnedCommit: input.listing.pinnedCommit,
+		})
+	) {
+		return null
+	}
+	const urlRef = isPublicTreeDefaultRefAlias(input.treeRef)
+		? resolved.defaultBranch
+		: input.treeRef
+	return { source, resolved, loaded, urlRef }
 }
 
 export async function loadAccountPackageFilesData(input: {
@@ -620,25 +655,15 @@ export async function loadCommunityPackageFileRaw(input: {
 	})
 	if (!listing) return { kind: 'not-found' }
 
-	const source = await getEntitySourceById(input.env.APP_DB, listing.sourceId)
 	const treeRef = input.ref?.trim() ?? ''
-	const resolved = await resolvePublicTreeCommit({
+	const tree = await loadCommunityListingPublicTree({
 		env: input.env,
 		request: input.request,
-		sourceRepoId: source?.repo_id ?? null,
-		publishedCommit: source?.published_commit ?? listing.pinnedCommit,
-		pinnedCommit: listing.pinnedCommit,
-		ref: treeRef,
+		listing,
+		treeRef,
 	})
-	const loaded = await loadPublicTreeFiles({
-		env: input.env,
-		request: input.request,
-		listingId: listing.id,
-		sourceId: listing.sourceId,
-		sourceRepoId: source?.repo_id ?? null,
-		commit: resolved.commit,
-		pinnedCommit: listing.pinnedCommit,
-	})
+	if (!tree) return { kind: 'not-found' }
+	const { source, resolved, loaded } = tree
 	const media = await readPackageFileMediaBytes({
 		env: input.env,
 		files: loaded.files,

--- a/packages/worker/src/app/package-files-data.ts
+++ b/packages/worker/src/app/package-files-data.ts
@@ -7,15 +7,25 @@ import { loadPackageSourceBySourceId } from '#worker/package-registry/source.ts'
 import { readPublishedSourceSnapshot } from '#worker/package-runtime/published-runtime-artifacts.ts'
 import { getCommunityListingHref } from '#universal/community-links.ts'
 import {
+	isPackageFilesMediaKind,
+	maxPackageFilePreviewBytes,
+	safeContentDispositionFilename,
+	sniffPackageFileMedia,
+	snapshotStringToBytes,
+} from '#universal/package-file-media.ts'
+import {
 	buildPackageFilesView,
 	fallbackDefaultBranchName,
 	findDirectoryReadmePath,
 	getCommunityPackageFilesHref,
+	getCommunityPackageRawHref,
+	getPackageRawHref,
 	getPackageTreeHref,
 	isPublicTreeDefaultRefAlias,
 	normalizePackageFilesPath,
 	type PackageFilesView,
 } from '#universal/package-files.ts'
+import { readArtifactFileAtCommit } from '#worker/repo/artifact-file.ts'
 import { type PackageFilesLoaderData } from '#universal/loader-data.ts'
 import { routes } from '#universal/routes.ts'
 import { loadPackagePage } from '#app/package-page.ts'
@@ -49,10 +59,13 @@ async function toLoaderData(input: {
 	kodyId?: string
 	viewerIsOwner?: boolean
 	isPrivate?: boolean
+	mediaHref?: string | null
 }): Promise<PackageFilesLoaderData> {
-	const content = input.view.content
-	const language = input.view.language
 	const contentKind = input.view.contentKind
+	const omitText =
+		isPackageFilesMediaKind(contentKind) || contentKind === 'binary'
+	const content = omitText ? null : input.view.content
+	const language = omitText ? null : input.view.language
 	const highlightOptions = { serverTiming: input.serverTiming }
 	const contentFences =
 		contentKind === 'markdown' && content
@@ -84,6 +97,10 @@ async function toLoaderData(input: {
 		contentPath: input.view.contentPath,
 		contentKind,
 		language,
+		contentByteLength: input.view.contentByteLength,
+		mediaHref: isPackageFilesMediaKind(contentKind)
+			? (input.mediaHref ?? null)
+			: null,
 		contentFences,
 		contentHighlighted,
 		username: input.username,
@@ -189,6 +206,15 @@ export async function loadCommunityPackageFilesData(input: {
 		kodyId: listing.kodyId,
 		viewerIsOwner: viewerUserId === listing.ownerUserId,
 		isPrivate: false,
+		mediaHref: view.contentPath
+			? getCommunityPackageRawHref({
+					listingId: listing.id,
+					ownerUsername,
+					kodyId: listing.kodyId,
+					ref: urlRef,
+					relativePath: view.contentPath,
+				})
+			: null,
 	})
 }
 
@@ -391,6 +417,14 @@ export async function loadAccountPackageFilesData(input: {
 		kodyId: record.kodyId,
 		viewerIsOwner: true,
 		isPrivate: record.isPrivate,
+		mediaHref: view.contentPath
+			? getPackageRawHref({
+					username: input.username,
+					kodyId: record.kodyId,
+					ref: urlRef,
+					relativePath: view.contentPath,
+				})
+			: null,
 	})
 }
 
@@ -508,4 +542,213 @@ export async function loadOwnerPackageReadme(input: {
 	} catch {
 		return null
 	}
+}
+
+export type PackageFileRawResult =
+	| {
+			kind: 'ok'
+			bytes: Uint8Array
+			contentType: string
+			filename: string
+			isPrivate: boolean
+	  }
+	| { kind: 'not-found' }
+	| { kind: 'unauthorized' }
+	| { kind: 'not-media' }
+	| { kind: 'too-large' }
+
+async function readPackageFileMediaBytes(input: {
+	env: Env
+	files: Record<string, string>
+	filePath: string
+	sourceRepoId: string | null
+	commit: string | null
+}): Promise<
+	| { kind: 'ok'; bytes: Uint8Array; contentType: string; filename: string }
+	| { kind: 'not-found' }
+	| { kind: 'not-media' }
+	| { kind: 'too-large' }
+> {
+	if (!Object.hasOwn(input.files, input.filePath)) {
+		return { kind: 'not-found' }
+	}
+	let bytes: Uint8Array | null = null
+	if (input.sourceRepoId && input.commit) {
+		try {
+			bytes = await readArtifactFileAtCommit({
+				env: input.env,
+				repoId: input.sourceRepoId,
+				commit: input.commit,
+				filePath: input.filePath,
+			})
+		} catch {
+			bytes = null
+		}
+	}
+	if (!bytes) {
+		const snapshot = input.files[input.filePath]
+		if (snapshot == null) return { kind: 'not-found' }
+		bytes = snapshotStringToBytes(snapshot, input.filePath)
+	}
+	if (bytes.byteLength > maxPackageFilePreviewBytes) {
+		return { kind: 'too-large' }
+	}
+	const media = sniffPackageFileMedia({
+		path: input.filePath,
+		bytes,
+	})
+	if (!media) return { kind: 'not-media' }
+	return {
+		kind: 'ok',
+		bytes,
+		contentType: media.contentType,
+		filename: safeContentDispositionFilename(input.filePath),
+	}
+}
+
+export async function loadCommunityPackageFileRaw(input: {
+	env: Env
+	request: Request
+	listingId: string
+	selectedPath: string
+	ref?: string
+}): Promise<PackageFileRawResult> {
+	if (!input.selectedPath) return { kind: 'not-found' }
+	const listing = await getCommunityListingById(input.env.APP_DB, {
+		listingId: input.listingId,
+		includeDelisted: false,
+	})
+	if (!listing) return { kind: 'not-found' }
+
+	const source = await getEntitySourceById(input.env.APP_DB, listing.sourceId)
+	const treeRef = input.ref?.trim() ?? ''
+	const resolved = await resolvePublicTreeCommit({
+		env: input.env,
+		request: input.request,
+		sourceRepoId: source?.repo_id ?? null,
+		publishedCommit: source?.published_commit ?? listing.pinnedCommit,
+		pinnedCommit: listing.pinnedCommit,
+		ref: treeRef,
+	})
+	const loaded = await loadPublicTreeFiles({
+		env: input.env,
+		request: input.request,
+		listingId: listing.id,
+		sourceId: listing.sourceId,
+		sourceRepoId: source?.repo_id ?? null,
+		commit: resolved.commit,
+		pinnedCommit: listing.pinnedCommit,
+	})
+	const media = await readPackageFileMediaBytes({
+		env: input.env,
+		files: loaded.files,
+		filePath: input.selectedPath,
+		sourceRepoId: source?.repo_id ?? null,
+		commit: resolved.commit,
+	})
+	if (media.kind !== 'ok') return media
+	return { ...media, isPrivate: false }
+}
+
+export async function loadAccountPackageFileRaw(input: {
+	env: Env
+	request: Request
+	userId: string
+	username: string
+	packageId: string
+	selectedPath: string
+	ref?: string
+}): Promise<PackageFileRawResult> {
+	if (!input.selectedPath) return { kind: 'not-found' }
+	const record = await getSavedPackageById(input.env.APP_DB, {
+		userId: input.userId,
+		packageId: input.packageId,
+	})
+	if (!record) return { kind: 'not-found' }
+
+	const source = await getEntitySourceById(input.env.APP_DB, record.sourceId)
+	const treeRef = input.ref?.trim() ?? ''
+	const resolved = await resolvePublicTreeCommit({
+		env: input.env,
+		request: input.request,
+		sourceRepoId: source?.repo_id ?? null,
+		publishedCommit: source?.published_commit ?? '',
+		pinnedCommit: source?.published_commit ?? '',
+		ref: treeRef,
+	})
+	const loaded = await loadPublicTreeFiles({
+		env: input.env,
+		request: input.request,
+		sourceId: record.sourceId,
+		sourceRepoId: source?.repo_id ?? null,
+		commit: resolved.commit,
+		pinnedCommit: source?.published_commit ?? '',
+	})
+	let files = loaded.files
+	if (Object.keys(files).length === 0) {
+		try {
+			const packageSource = await loadPackageSourceBySourceId({
+				env: input.env,
+				baseUrl: getAppBaseUrl({
+					env: input.env,
+					requestUrl: input.request.url,
+				}),
+				userId: input.userId,
+				sourceId: record.sourceId,
+			})
+			files = packageSource.files
+		} catch {
+			files = {}
+		}
+	}
+	const media = await readPackageFileMediaBytes({
+		env: input.env,
+		files,
+		filePath: input.selectedPath,
+		sourceRepoId: source?.repo_id ?? null,
+		commit: resolved.commit,
+	})
+	if (media.kind !== 'ok') return media
+	return { ...media, isPrivate: record.isPrivate }
+}
+
+export async function loadAccessiblePackageFileRaw(input: {
+	env: Env
+	request: Request
+	username: string
+	kodyId: string
+	selectedPath: string
+	ref?: string
+}): Promise<PackageFileRawResult> {
+	const page = await loadPackagePage({
+		env: input.env,
+		request: input.request,
+		username: input.username,
+		kodyId: input.kodyId,
+	})
+	if (page.kind === 'unauthorized') return { kind: 'unauthorized' }
+	if (page.kind !== 'page') return { kind: 'not-found' }
+
+	if (page.listing?.listing) {
+		return loadCommunityPackageFileRaw({
+			env: input.env,
+			request: input.request,
+			listingId: page.listing.listing.id,
+			selectedPath: input.selectedPath,
+			ref: input.ref,
+		})
+	}
+
+	if (!page.ownerPackage) return { kind: 'not-found' }
+	const user = await readAuthenticatedAppUser(input.request, input.env)
+	if (!user) return { kind: 'unauthorized' }
+	return loadAccountPackageFileRaw({
+		env: input.env,
+		request: input.request,
+		userId: user.mcpUser.userId,
+		username: page.username,
+		packageId: page.ownerPackage.id,
+		selectedPath: input.selectedPath,
+		ref: input.ref,
+	})
 }

--- a/packages/worker/src/app/router-specificity.node.test.ts
+++ b/packages/worker/src/app/router-specificity.node.test.ts
@@ -43,6 +43,14 @@ test('router prefers static nested paths and package files over dynamic siblings
 		createStubHandler('community-files'),
 	)
 	router.get(
+		routePattern(routes.communityPackageRaw),
+		createStubHandler('community-raw'),
+	)
+	router.get(
+		routePattern(routes.communityDetailRaw),
+		createStubHandler('listing-uuid-raw'),
+	)
+	router.get(
 		routePattern(routes.communityPackageApprovePublish),
 		createStubHandler('community-approve-publish'),
 	)
@@ -112,6 +120,24 @@ test('router prefers static nested paths and package files over dynamic siblings
 			)
 		).text(),
 	).toBe('community-files')
+	expect(
+		await (
+			await router.fetch(
+				new Request(
+					'http://localhost/@kentcdodds/devin/raw/main/docs/logo.png',
+				),
+			)
+		).text(),
+	).toBe('community-raw')
+	expect(
+		await (
+			await router.fetch(
+				new Request(
+					'http://localhost/community/550e8400-e29b-41d4-a716-446655440000/raw/docs/logo.png',
+				),
+			)
+		).text(),
+	).toBe('listing-uuid-raw')
 	expect(
 		await (
 			await router.fetch(

--- a/packages/worker/src/app/router.ts
+++ b/packages/worker/src/app/router.ts
@@ -111,6 +111,10 @@ import {
 	createCommunityPackageTreeHandler,
 } from '#app/handlers/package-files.ts'
 import {
+	createCommunityDetailRawHandler,
+	createCommunityPackageRawHandler,
+} from '#app/handlers/package-files-raw.ts'
+import {
 	createAccountPasskeysApiHandler,
 	createAccountPasskeysHandler,
 } from '#app/handlers/account-passkeys.ts'
@@ -494,11 +498,13 @@ export function createAppRouter(env: Env) {
 			communityDetailApi: createCommunityDetailApiHandler(env),
 			communityDetailFiles: createCommunityDetailFilesHandler(env),
 			communityDetailFilesApi: createCommunityDetailFilesApiHandler(env),
+			communityDetailRaw: createCommunityDetailRawHandler(env),
 			communityPackage: createCommunityPackageHandler(env),
 			communityPackageApi: createCommunityPackageApiHandler(env),
 			communityPackageSettings: createCommunityPackageSettingsHandler(env),
 			communityPackageFiles: createCommunityPackageFilesHandler(env),
 			communityPackageTree: createCommunityPackageTreeHandler(env),
+			communityPackageRaw: createCommunityPackageRawHandler(env),
 			communityPackageFilesApi: createCommunityPackageFilesApiHandler(env),
 			communityDetailIcon: createCommunityIconHandler(env),
 			integrationLogo: createIntegrationLogoHandler(env),

--- a/packages/worker/src/repo/artifact-file.node.test.ts
+++ b/packages/worker/src/repo/artifact-file.node.test.ts
@@ -241,6 +241,13 @@ test('readArtifactTreeAtCommit walks the fetched commit tree', async () => {
 					content: async () => Uint8Array.from([0x89, 0x50, 0x4e, 0x47, 0, 2]),
 				},
 			])
+			await input.map('photo.jpg', [
+				{
+					type: async () => 'blob',
+					content: async () =>
+						Uint8Array.from([0xff, 0xd8, 0xff, 0xe0, 0x10, 0x4a]),
+				},
+			])
 		},
 	)
 
@@ -254,11 +261,15 @@ test('readArtifactTreeAtCommit walks the fetched commit tree', async () => {
 	expect(tree?.['__proto__']).toBe('not proto\n')
 	expect(tree?.['community-icon.png']).not.toBe(tree?.['other-icon.png'])
 	expect(tree?.['community-icon.png']).toBe(
-		new TextDecoder('latin1').decode(
-			Uint8Array.from([0x89, 0x50, 0x4e, 0x47, 0, 1]),
-		),
+		String.fromCharCode(...Uint8Array.from([0x89, 0x50, 0x4e, 0x47, 0, 1])),
 	)
 	expect(tree?.['community-icon.png']).toContain('\0')
+	expect(tree?.['photo.jpg']).toBe(
+		String.fromCharCode(
+			...Uint8Array.from([0xff, 0xd8, 0xff, 0xe0, 0x10, 0x4a]),
+		),
+	)
+	expect(tree?.['photo.jpg']).not.toContain('\0')
 	expect(mocks.TREE).toHaveBeenCalledWith({
 		ref: 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
 	})

--- a/packages/worker/src/repo/artifact-file.ts
+++ b/packages/worker/src/repo/artifact-file.ts
@@ -11,6 +11,11 @@ import {
 	wrapArtifactsGitHttpError,
 } from './artifacts-git-retry.ts'
 import { createEphemeralGitWorkspace } from './ephemeral-git-workspace.ts'
+import {
+	bytesToLatin1String,
+	shouldStoreArtifactBlobAsLatin1,
+	snapshotStringToBytes,
+} from '#universal/package-file-media.ts'
 import { loadIsomorphicGit } from './isomorphic-git-lazy.ts'
 
 export async function readArtifactFileAtCommit(input: {
@@ -57,7 +62,10 @@ export async function readFirstArtifactFileAtCommit(input: {
 		for (const filePath of input.filePaths) {
 			const content = snapshot?.files[filePath]
 			if (content != null) {
-				return { path: filePath, bytes: new TextEncoder().encode(content) }
+				return {
+					path: filePath,
+					bytes: snapshotStringToBytes(content, filePath),
+				}
 			}
 		}
 		return null
@@ -198,7 +206,7 @@ export async function readArtifactTreeAtCommit(input: {
 					if ((await entry.type()) !== 'blob') return
 					const content = await entry.content()
 					if (content == null) return
-					files[filepath] = decodeArtifactBlob(content)
+					files[filepath] = decodeArtifactBlob(content, filepath)
 				},
 			})
 			return files
@@ -212,12 +220,15 @@ export async function readArtifactTreeAtCommit(input: {
 	}
 }
 
-function decodeArtifactBlob(content: Uint8Array | string) {
+function decodeArtifactBlob(content: Uint8Array | string, filePath: string) {
 	if (typeof content === 'string') return content
-	// Null-byte blobs stay byte-for-byte (latin1) so two binaries remain
-	// distinguishable. The publish diff still skips a text patch when the
-	// decoded string includes `\0`.
-	if (content.includes(0)) return new TextDecoder('latin1').decode(content)
+	// Null-byte blobs and allowlisted media/binaries stay byte-for-byte
+	// (latin1) so a later `/raw/` preview can recover the original bytes.
+	// The publish diff still skips a text patch when the decoded string
+	// includes `\0`.
+	if (content.includes(0) || shouldStoreArtifactBlobAsLatin1(filePath)) {
+		return bytesToLatin1String(content)
+	}
 	return new TextDecoder().decode(content)
 }
 

--- a/packages/worker/universal/loader-data.ts
+++ b/packages/worker/universal/loader-data.ts
@@ -25,6 +25,7 @@ import {
 import { type CommunityListingSort } from '#universal/community-search.ts'
 import { type PublicCodeRunsWindow } from '#universal/code-runs.ts'
 import { type HighlightedCode } from '#universal/highlighted-code.ts'
+import { type PackageFilesContentKind } from '#universal/package-file-media.ts'
 import { type WalkthroughHostPick } from '#universal/walkthrough-hosts.ts'
 import { type ConnectedMcpAgent } from '#universal/connected-mcp-agents.ts'
 import { type ReferralProgramSummary } from '#universal/referral-program.ts'
@@ -187,8 +188,10 @@ export type PackageFilesLoaderData = {
 	children: Array<PackageFilesChildLoaderData>
 	content: string | null
 	contentPath: string | null
-	contentKind: 'markdown' | 'code' | 'text' | null
+	contentKind: PackageFilesContentKind | null
 	language: string | null
+	contentByteLength?: number | null
+	mediaHref?: string | null
 	contentHighlighted?: HighlightedCode | null
 	contentFences?: Array<HighlightedCode>
 	username?: string

--- a/packages/worker/universal/package-file-media.node.test.ts
+++ b/packages/worker/universal/package-file-media.node.test.ts
@@ -1,0 +1,129 @@
+import { expect, test } from 'vitest'
+import {
+	bytesToLatin1String,
+	classifyPackageFileMedia,
+	latin1StringToBytes,
+	looksLikeSvg,
+	maxPackageFilePreviewBytes,
+	packageFileKindLabel,
+	safeContentDispositionFilename,
+	shouldStoreArtifactBlobAsLatin1,
+	sniffPackageFileMedia,
+	snapshotStringToBytes,
+} from './package-file-media.ts'
+
+const pngBytes = Uint8Array.from([
+	0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0, 0, 0, 0xd,
+])
+const pngLatin1 = bytesToLatin1String(pngBytes)
+const jpegBytes = Uint8Array.from([0xff, 0xd8, 0xff, 0xe0, 0, 0x10, 0x4a, 0x46])
+const jpegLatin1 = bytesToLatin1String(jpegBytes)
+
+test('classifies allowlisted media, SVG safety, and non-preview binaries', () => {
+	expect(
+		classifyPackageFileMedia({ path: 'logo.png', content: pngLatin1 }),
+	).toEqual({
+		kind: 'image',
+		contentType: 'image/png',
+		byteLength: pngBytes.byteLength,
+	})
+	expect(
+		classifyPackageFileMedia({ path: 'clip.mp4', content: 'ftypxxxx' }),
+	).toMatchObject({ kind: 'video', contentType: 'video/mp4' })
+	expect(
+		classifyPackageFileMedia({ path: 'sound.mp3', content: 'ID3' }),
+	).toMatchObject({ kind: 'audio', contentType: 'audio/mpeg' })
+
+	expect(
+		classifyPackageFileMedia({
+			path: 'icon.svg',
+			content: '<svg xmlns="http://www.w3.org/2000/svg"></svg>',
+		}),
+	).toEqual({
+		kind: 'image',
+		contentType: 'image/svg+xml',
+		byteLength: new TextEncoder().encode(
+			'<svg xmlns="http://www.w3.org/2000/svg"></svg>',
+		).byteLength,
+	})
+	expect(
+		classifyPackageFileMedia({
+			path: 'evil.svg',
+			content: '<!DOCTYPE html><script>alert(1)</script>',
+		}),
+	).toBeNull()
+	expect(looksLikeSvg('<script>alert(1)</script>')).toBe(false)
+	expect(looksLikeSvg('<svg><script>alert(1)</script></svg>')).toBe(true)
+
+	expect(
+		classifyPackageFileMedia({ path: 'app.wasm', content: 'wasm\0' }),
+	).toMatchObject({ kind: 'binary', contentType: null })
+	expect(
+		classifyPackageFileMedia({ path: 'mystery.bin', content: 'nope' }),
+	).toMatchObject({ kind: 'binary' })
+	expect(
+		classifyPackageFileMedia({ path: 'notes.txt', content: 'ok\0nope' }),
+	).toMatchObject({ kind: 'binary' })
+	expect(
+		classifyPackageFileMedia({ path: 'src/index.ts', content: 'export {}\n' }),
+	).toBeNull()
+
+	const oversized = 'x'.repeat(maxPackageFilePreviewBytes + 1)
+	expect(
+		classifyPackageFileMedia({ path: 'huge.png', content: oversized }),
+	).toMatchObject({ kind: 'binary', contentType: null })
+})
+
+test('raw sniff requires allowlisted extension and matching magic', () => {
+	expect(sniffPackageFileMedia({ path: 'logo.png', bytes: pngBytes })).toEqual({
+		kind: 'image',
+		contentType: 'image/png',
+	})
+	expect(
+		sniffPackageFileMedia({
+			path: 'logo.png',
+			bytes: new TextEncoder().encode('<!DOCTYPE html><h1>nope</h1>'),
+		}),
+	).toBeNull()
+	expect(
+		sniffPackageFileMedia({
+			path: 'page.html',
+			bytes: pngBytes,
+		}),
+	).toBeNull()
+	expect(
+		sniffPackageFileMedia({ path: 'photo.jpg', bytes: jpegBytes }),
+	).toEqual({
+		kind: 'image',
+		contentType: 'image/jpeg',
+	})
+	expect(
+		sniffPackageFileMedia({
+			path: 'icon.svg',
+			bytes: new TextEncoder().encode(
+				'<?xml version="1.0"?><svg xmlns="http://www.w3.org/2000/svg"/>',
+			),
+		}),
+	).toEqual({ kind: 'image', contentType: 'image/svg+xml' })
+	expect(
+		sniffPackageFileMedia({
+			path: 'icon.svg',
+			bytes: new TextEncoder().encode('<html><svg></svg></html>'),
+		}),
+	).toBeNull()
+})
+
+test('latin1 snapshot helpers recover binary bytes and skip SVG', () => {
+	expect(shouldStoreArtifactBlobAsLatin1('logo.png')).toBe(true)
+	expect(shouldStoreArtifactBlobAsLatin1('archive.zip')).toBe(true)
+	expect(shouldStoreArtifactBlobAsLatin1('icon.svg')).toBe(false)
+	expect(shouldStoreArtifactBlobAsLatin1('src/index.ts')).toBe(false)
+	expect(snapshotStringToBytes(pngLatin1, 'logo.png')).toEqual(pngBytes)
+	expect(latin1StringToBytes(jpegLatin1)).toEqual(jpegBytes)
+	expect(packageFileKindLabel('docs/logo.PNG', 'image')).toBe('PNG')
+	expect(packageFileKindLabel('clip.webm', 'video')).toBe('WEBM')
+	expect(packageFileKindLabel('app.wasm', 'binary')).toBe('Binary')
+	expect(safeContentDispositionFilename('docs/my"file\n.png')).toBe(
+		'my_file_.png',
+	)
+})

--- a/packages/worker/universal/package-file-media.ts
+++ b/packages/worker/universal/package-file-media.ts
@@ -12,7 +12,7 @@
  * filename alone is not enough to serve bytes as renderable media.
  */
 
-export type PackageFilesTextKind = 'markdown' | 'code' | 'text'
+type PackageFilesTextKind = 'markdown' | 'code' | 'text'
 export type PackageFilesMediaKind = 'image' | 'video' | 'audio'
 export type PackageFilesContentKind =
 	| PackageFilesTextKind
@@ -79,7 +79,7 @@ const binaryExtensions = new Set([
 	'zip',
 ])
 
-export function packageFileExtension(path: string) {
+function packageFileExtension(path: string) {
 	const name = path.split('/').pop() ?? ''
 	const separator = name.lastIndexOf('.')
 	if (separator <= 0) return ''
@@ -96,9 +96,7 @@ export function isPackageFilesMediaKind(
 	return kind === 'image' || kind === 'video' || kind === 'audio'
 }
 
-export function allowlistedPackageFileMedia(
-	path: string,
-): MediaType | undefined {
+function allowlistedPackageFileMedia(path: string): MediaType | undefined {
 	return mediaTypesByExtension[packageFileExtension(path)]
 }
 
@@ -144,7 +142,7 @@ export function snapshotStringToBytes(content: string, path: string) {
 	return new TextEncoder().encode(content)
 }
 
-export function measurePackageFileBytes(path: string, content: string) {
+function measurePackageFileBytes(path: string, content: string) {
 	return snapshotStringToBytes(content, path).byteLength
 }
 

--- a/packages/worker/universal/package-file-media.ts
+++ b/packages/worker/universal/package-file-media.ts
@@ -1,0 +1,309 @@
+/**
+ * Allowlisted media / binary detection for the package files explorer.
+ *
+ * Raster and video bytes are served on a same-origin `/raw/` route and
+ * previewed with `<img>` / `<video>` / `<audio>`. SVG is XSS-sensitive: we
+ * never inject markup into the DOM. A `.svg` that looks like SVG is previewed
+ * only as `<img src="…/raw/…">` (scripts do not run in `<img>`). Anything that
+ * looks like HTML stays source/code.
+ *
+ * Classification requires an allowlisted extension. The raw route also sniffs
+ * magic bytes (or the SVG text shape) before setting a media Content-Type —
+ * filename alone is not enough to serve bytes as renderable media.
+ */
+
+export type PackageFilesTextKind = 'markdown' | 'code' | 'text'
+export type PackageFilesMediaKind = 'image' | 'video' | 'audio'
+export type PackageFilesContentKind =
+	| PackageFilesTextKind
+	| PackageFilesMediaKind
+	| 'binary'
+
+export const maxPackageFilePreviewBytes = 10 * 1024 * 1024
+
+type MediaType = {
+	kind: PackageFilesMediaKind
+	contentType: string
+}
+
+const mediaTypesByExtension: Record<string, MediaType> = {
+	png: { kind: 'image', contentType: 'image/png' },
+	jpg: { kind: 'image', contentType: 'image/jpeg' },
+	jpeg: { kind: 'image', contentType: 'image/jpeg' },
+	gif: { kind: 'image', contentType: 'image/gif' },
+	webp: { kind: 'image', contentType: 'image/webp' },
+	avif: { kind: 'image', contentType: 'image/avif' },
+	svg: { kind: 'image', contentType: 'image/svg+xml' },
+	mp4: { kind: 'video', contentType: 'video/mp4' },
+	webm: { kind: 'video', contentType: 'video/webm' },
+	ogv: { kind: 'video', contentType: 'video/ogg' },
+	mp3: { kind: 'audio', contentType: 'audio/mpeg' },
+	wav: { kind: 'audio', contentType: 'audio/wav' },
+	ogg: { kind: 'audio', contentType: 'audio/ogg' },
+	oga: { kind: 'audio', contentType: 'audio/ogg' },
+}
+
+const binaryExtensions = new Set([
+	'7z',
+	'a',
+	'apk',
+	'bin',
+	'bz2',
+	'class',
+	'db',
+	'dll',
+	'dmg',
+	'dylib',
+	'eot',
+	'exe',
+	'gz',
+	'ico',
+	'iso',
+	'lib',
+	'o',
+	'obj',
+	'otf',
+	'parquet',
+	'pdf',
+	'pyc',
+	'rar',
+	'so',
+	'sqlite',
+	'tar',
+	'tgz',
+	'ttf',
+	'wasm',
+	'woff',
+	'woff2',
+	'xz',
+	'zip',
+])
+
+export function packageFileExtension(path: string) {
+	const name = path.split('/').pop() ?? ''
+	const separator = name.lastIndexOf('.')
+	if (separator <= 0) return ''
+	return name.slice(separator + 1).toLowerCase()
+}
+
+export function packageFileBaseName(path: string) {
+	return path.split('/').pop() || path
+}
+
+export function isPackageFilesMediaKind(
+	kind: string | null | undefined,
+): kind is PackageFilesMediaKind {
+	return kind === 'image' || kind === 'video' || kind === 'audio'
+}
+
+export function allowlistedPackageFileMedia(
+	path: string,
+): MediaType | undefined {
+	return mediaTypesByExtension[packageFileExtension(path)]
+}
+
+/**
+ * Raster / video / unknown-binary snapshots stay latin1 so a later preview
+ * can recover the original bytes. SVG is text (UTF-8).
+ */
+export function shouldStoreArtifactBlobAsLatin1(path: string) {
+	const extension = packageFileExtension(path)
+	if (extension === 'svg') return false
+	return (
+		Object.hasOwn(mediaTypesByExtension, extension) ||
+		binaryExtensions.has(extension)
+	)
+}
+
+export function latin1StringToBytes(value: string) {
+	const bytes = new Uint8Array(value.length)
+	for (let index = 0; index < value.length; index += 1) {
+		bytes[index] = value.charCodeAt(index) & 0xff
+	}
+	return bytes
+}
+
+/**
+ * Byte-for-byte string encoding. Do not use `TextDecoder('latin1')` — the
+ * Encoding spec maps that label to windows-1252, which remaps 0x80–0x9F
+ * (PNG's leading 0x89 becomes U+2030).
+ */
+export function bytesToLatin1String(bytes: Uint8Array) {
+	const chunkSize = 0x8000
+	let result = ''
+	for (let offset = 0; offset < bytes.length; offset += chunkSize) {
+		result += String.fromCharCode(...bytes.subarray(offset, offset + chunkSize))
+	}
+	return result
+}
+
+export function snapshotStringToBytes(content: string, path: string) {
+	if (content.includes('\0') || shouldStoreArtifactBlobAsLatin1(path)) {
+		return latin1StringToBytes(content)
+	}
+	return new TextEncoder().encode(content)
+}
+
+export function measurePackageFileBytes(path: string, content: string) {
+	return snapshotStringToBytes(content, path).byteLength
+}
+
+/**
+ * SVG preview is `<img src>` only. Reject HTML/script documents so they stay
+ * in the source view instead of being served as `image/svg+xml`.
+ */
+export function looksLikeSvg(content: string) {
+	const trimmed = content.replace(/^\uFEFF/, '').trimStart()
+	if (
+		/^<(?:!DOCTYPE\s+html|html|head|body|script|iframe|object|embed)\b/i.test(
+			trimmed,
+		)
+	) {
+		return false
+	}
+	if (/^<svg[\s>/]/i.test(trimmed)) return true
+	return (
+		/^<\?xml\b/i.test(trimmed) && /<svg[\s>/]/i.test(trimmed.slice(0, 2048))
+	)
+}
+
+function readAscii(bytes: Uint8Array, offset: number, length: number) {
+	if (bytes.byteLength < offset + length) return ''
+	return String.fromCharCode(...bytes.subarray(offset, offset + length))
+}
+
+function startsWithBytes(
+	bytes: Uint8Array,
+	expected: ReadonlyArray<number>,
+	offset = 0,
+) {
+	if (bytes.byteLength < offset + expected.length) return false
+	return expected.every((value, index) => bytes[offset + index] === value)
+}
+
+function hasFtypBrand(bytes: Uint8Array, brands?: ReadonlyArray<string>) {
+	if (readAscii(bytes, 4, 4) !== 'ftyp') return false
+	if (!brands || brands.length === 0) return true
+	const major = readAscii(bytes, 8, 4)
+	if (brands.includes(major)) return true
+	for (
+		let offset = 16;
+		offset + 4 <= Math.min(bytes.byteLength, 256);
+		offset += 4
+	) {
+		if (brands.includes(readAscii(bytes, offset, 4))) return true
+	}
+	return false
+}
+
+function matchesMediaMagic(bytes: Uint8Array, contentType: string) {
+	switch (contentType) {
+		case 'image/png':
+			return startsWithBytes(
+				bytes,
+				[0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a],
+			)
+		case 'image/jpeg':
+			return startsWithBytes(bytes, [0xff, 0xd8, 0xff])
+		case 'image/gif':
+			return (
+				startsWithBytes(bytes, [0x47, 0x49, 0x46, 0x38, 0x37, 0x61]) ||
+				startsWithBytes(bytes, [0x47, 0x49, 0x46, 0x38, 0x39, 0x61])
+			)
+		case 'image/webp':
+			return (
+				startsWithBytes(bytes, [0x52, 0x49, 0x46, 0x46]) &&
+				startsWithBytes(bytes, [0x57, 0x45, 0x42, 0x50], 8)
+			)
+		case 'image/avif':
+			return hasFtypBrand(bytes, ['avif', 'avis'])
+		case 'video/mp4':
+			return hasFtypBrand(bytes)
+		case 'video/webm':
+			return startsWithBytes(bytes, [0x1a, 0x45, 0xdf, 0xa3])
+		case 'video/ogg':
+		case 'audio/ogg':
+			return startsWithBytes(bytes, [0x4f, 0x67, 0x67, 0x53])
+		case 'audio/mpeg':
+			return (
+				startsWithBytes(bytes, [0x49, 0x44, 0x33]) ||
+				(bytes[0] === 0xff && bytes.length > 1 && (bytes[1]! & 0xe0) === 0xe0)
+			)
+		case 'audio/wav':
+			return (
+				startsWithBytes(bytes, [0x52, 0x49, 0x46, 0x46]) &&
+				startsWithBytes(bytes, [0x57, 0x41, 0x56, 0x45], 8)
+			)
+		case 'image/svg+xml':
+			return looksLikeSvg(new TextDecoder().decode(bytes))
+		default:
+			return false
+	}
+}
+
+export function sniffPackageFileMedia(input: {
+	path: string
+	bytes: Uint8Array
+}): MediaType | null {
+	const media = allowlistedPackageFileMedia(input.path)
+	if (!media) return null
+	if (input.bytes.byteLength > maxPackageFilePreviewBytes) return null
+	if (!matchesMediaMagic(input.bytes, media.contentType)) return null
+	return media
+}
+
+/**
+ * Explorer classification. Allowlisted media becomes a preview kind (content
+ * is omitted from the page payload). Known binaries and NUL blobs become
+ * `binary` so they are never dumped as code. SVG must look like SVG or it
+ * falls through to the XML/source view.
+ */
+export function classifyPackageFileMedia(input: {
+	path: string
+	content: string
+}): {
+	kind: PackageFilesMediaKind | 'binary'
+	contentType: string | null
+	byteLength: number
+} | null {
+	const media = allowlistedPackageFileMedia(input.path)
+	const byteLength = measurePackageFileBytes(input.path, input.content)
+	if (media) {
+		if (byteLength > maxPackageFilePreviewBytes) {
+			return { kind: 'binary', contentType: null, byteLength }
+		}
+		if (media.contentType === 'image/svg+xml') {
+			if (!looksLikeSvg(input.content)) return null
+			return { kind: 'image', contentType: media.contentType, byteLength }
+		}
+		return {
+			kind: media.kind,
+			contentType: media.contentType,
+			byteLength,
+		}
+	}
+	if (
+		binaryExtensions.has(packageFileExtension(input.path)) ||
+		input.content.includes('\0')
+	) {
+		return { kind: 'binary', contentType: null, byteLength }
+	}
+	return null
+}
+
+export function packageFileKindLabel(
+	path: string | null | undefined,
+	contentKind: PackageFilesContentKind | null | undefined,
+) {
+	if (contentKind === 'binary') return 'Binary'
+	if (isPackageFilesMediaKind(contentKind) && path) {
+		const extension = packageFileExtension(path)
+		return extension ? extension.toUpperCase() : 'Media'
+	}
+	return ''
+}
+
+export function safeContentDispositionFilename(path: string) {
+	const name = packageFileBaseName(path).replace(/["\\\r\n]/g, '_')
+	return name || 'file'
+}

--- a/packages/worker/universal/package-files.node.test.ts
+++ b/packages/worker/universal/package-files.node.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from 'vitest'
+import { bytesToLatin1String } from './package-file-media.ts'
 import {
 	buildPackageFilesAncestors,
 	buildPackageFilesApiHref,
@@ -6,6 +7,7 @@ import {
 	findDirectoryReadmePath,
 	getAccountPackageFilesHref,
 	getCommunityPackageFilesHref,
+	getCommunityPackageRawHref,
 	getPackageSettingsHref,
 	getPackageTreeHref,
 	isReservedPackageFilesKodyId,
@@ -66,6 +68,43 @@ test('package files views normalize paths and distinguish root, directories, fil
 		contentPath: 'src/index.ts',
 		contentKind: 'code',
 		language: 'ts',
+	})
+
+	const pngBytes = Uint8Array.from([
+		0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0, 1,
+	])
+	const png = bytesToLatin1String(pngBytes)
+	const image = buildPackageFilesView({
+		files: { ...files, 'docs/logo.png': png },
+		selectedPath: 'docs/logo.png',
+	})
+	expect(image).toMatchObject({
+		kind: 'file',
+		content: null,
+		contentKind: 'image',
+		language: null,
+		contentByteLength: pngBytes.byteLength,
+	})
+	expect(
+		buildPackageFilesView({
+			files: { 'app.wasm': 'wasm\0module' },
+			selectedPath: 'app.wasm',
+		}),
+	).toMatchObject({
+		kind: 'file',
+		content: null,
+		contentKind: 'binary',
+	})
+	expect(
+		buildPackageFilesView({
+			files: { 'evil.svg': '<!DOCTYPE html><script>alert(1)</script>' },
+			selectedPath: 'evil.svg',
+		}),
+	).toMatchObject({
+		kind: 'file',
+		content: '<!DOCTYPE html><script>alert(1)</script>',
+		contentKind: 'code',
+		language: 'xml',
 	})
 
 	expect(buildPackageFilesView({ files, selectedPath: 'missing' })).toBeNull()
@@ -156,4 +195,20 @@ test('files hrefs use the default-branch fallback and avoid reserved kody ids', 
 			'src/index.ts',
 		),
 	).toBe('/profiles/kentcdodds/packages/devin/files.json?path=src%2Findex.ts')
+	expect(
+		getCommunityPackageRawHref({
+			listingId: 'listing-1',
+			ownerUsername: 'kentcdodds',
+			kodyId: 'devin',
+			relativePath: 'docs/logo.png',
+		}),
+	).toBe('/@kentcdodds/devin/raw/main/docs/logo.png')
+	expect(
+		getCommunityPackageRawHref({
+			listingId: 'listing-1',
+			ownerUsername: 'kentcdodds',
+			kodyId: 'packages',
+			relativePath: 'docs/logo.png',
+		}),
+	).toBe('/community/listing-1/raw/docs/logo.png')
 })

--- a/packages/worker/universal/package-files.ts
+++ b/packages/worker/universal/package-files.ts
@@ -1,11 +1,18 @@
 import { createMultiMatcher } from 'remix/route-pattern/match'
+import {
+	classifyPackageFileMedia,
+	type PackageFilesContentKind,
+} from '#universal/package-file-media.ts'
 import { routes } from '#universal/routes.ts'
+
+export type { PackageFilesContentKind }
 
 /**
  * Second-segment `/@username/…` namespaces claimed before the app router.
  * A package whose `kody.id` is one of these cannot use
- * `/@owner/:kodyId/files/…` because `/@owner/packages/files/…` is a hosted
- * package-app path. Fall back to `/community/:listingId/files/…`.
+ * `/@owner/:kodyId/files/…` or `/raw/…` because `/@owner/packages/files/…`
+ * is a hosted package-app path. Fall back to
+ * `/community/:listingId/files/…` and `/community/:listingId/raw/…`.
  */
 const reservedPackageFilesKodyIds = [
 	'packages',
@@ -15,8 +22,6 @@ const reservedPackageFilesKodyIds = [
 ] as const
 
 export type PackageFilesKind = 'file' | 'directory'
-
-type PackageFilesContentKind = 'markdown' | 'code' | 'text'
 
 type PackageFilesChild = {
 	name: string
@@ -37,6 +42,7 @@ export type PackageFilesView = {
 	contentPath: string | null
 	contentKind: PackageFilesContentKind | null
 	language: string | null
+	contentByteLength: number | null
 	children: Array<PackageFilesChild>
 }
 
@@ -299,6 +305,23 @@ export function buildPackageFilesView(input: {
 
 	if (isFile) {
 		const content = input.files[selectedPath] ?? ''
+		const media = classifyPackageFileMedia({
+			path: selectedPath,
+			content,
+		})
+		if (media) {
+			return {
+				paths,
+				selectedPath,
+				kind: 'file',
+				content: null,
+				contentPath: selectedPath,
+				contentKind: media.kind,
+				language: null,
+				contentByteLength: media.byteLength,
+				children: [],
+			}
+		}
 		const language = languageFromFilePath(selectedPath)
 		return {
 			paths,
@@ -308,6 +331,7 @@ export function buildPackageFilesView(input: {
 			contentPath: selectedPath,
 			contentKind: contentKindFromLanguage(language),
 			language,
+			contentByteLength: new TextEncoder().encode(content).byteLength,
 			children: [],
 		}
 	}
@@ -323,6 +347,9 @@ export function buildPackageFilesView(input: {
 		contentPath,
 		contentKind: language ? contentKindFromLanguage(language) : null,
 		language,
+		contentByteLength: content
+			? new TextEncoder().encode(content).byteLength
+			: null,
 		children: listPackageFilesChildren(paths, selectedPath),
 	}
 }
@@ -417,6 +444,57 @@ export function getPackageSettingsHref(input: {
 	return routes.communityPackageSettings.href({
 		username: input.username,
 		kodyId: input.kodyId,
+	})
+}
+
+export function getCommunityPackageRawHref(input: {
+	listingId: string
+	ownerUsername?: string | null
+	kodyId?: string | null
+	ref?: string
+	relativePath: string
+}) {
+	const relativePath = input.relativePath.trim()
+	const ref = publicTreeRefForHref(input.ref)
+	if (
+		input.ownerUsername &&
+		input.kodyId &&
+		!isReservedPackageFilesKodyId(input.kodyId)
+	) {
+		return relativePath
+			? routes.communityPackageRaw.href({
+					username: input.ownerUsername,
+					kodyId: input.kodyId,
+					ref,
+					relativePath,
+				})
+			: routes.communityPackageRaw.href({
+					username: input.ownerUsername,
+					kodyId: input.kodyId,
+					ref,
+				})
+	}
+	return relativePath
+		? routes.communityDetailRaw.href({
+				listingId: input.listingId,
+				relativePath,
+			})
+		: routes.communityDetailRaw.href({ listingId: input.listingId })
+}
+
+export function getPackageRawHref(input: {
+	username: string
+	kodyId: string
+	listingId?: string | null
+	ref?: string
+	relativePath: string
+}) {
+	return getCommunityPackageRawHref({
+		listingId: input.listingId ?? '',
+		ownerUsername: input.username,
+		kodyId: input.kodyId,
+		ref: input.ref,
+		relativePath: input.relativePath,
 	})
 }
 

--- a/packages/worker/universal/package-files.ts
+++ b/packages/worker/universal/package-files.ts
@@ -5,8 +5,6 @@ import {
 } from '#universal/package-file-media.ts'
 import { routes } from '#universal/routes.ts'
 
-export type { PackageFilesContentKind }
-
 /**
  * Second-segment `/@username/…` namespaces claimed before the app router.
  * A package whose `kody.id` is one of these cannot use

--- a/packages/worker/universal/routes.ts
+++ b/packages/worker/universal/routes.ts
@@ -181,6 +181,7 @@ export const routes = route({
 	communityDetailApi: '/community/:listingId.json',
 	communityDetailFiles: '/community/:listingId/files(/*relativePath)',
 	communityDetailFilesApi: '/community/:listingId/files.json',
+	communityDetailRaw: '/community/:listingId/raw(/*relativePath)',
 	communityDetailIcon: '/community/:listingId/icon/:iconCommit',
 	communityDetailOgImage: '/community/:listingId/og.png',
 	communityReportApiPost: post('/community/:listingId/report.json'),
@@ -195,6 +196,7 @@ export const routes = route({
 	communityPackage: '/@:username/:kodyId',
 	communityPackageFiles: '/@:username/:kodyId/files(/*relativePath)',
 	communityPackageTree: '/@:username/:kodyId/tree/:ref(/*relativePath)',
+	communityPackageRaw: '/@:username/:kodyId/raw/:ref(/*relativePath)',
 	communityPackageSettings: '/@:username/:kodyId/settings',
 	communityPackageApprovePublish: '/@:username/:kodyId/approve-publish',
 	// JSON companion lives under `/profiles/…` with the other username-keyed

--- a/tools/control-kody/feature-catalog.ts
+++ b/tools/control-kody/feature-catalog.ts
@@ -122,6 +122,7 @@ export const featureCatalog: ReadonlyArray<Feature> = [
 			'/account/packages/:packageId/approve-publish.json',
 			'/account/packages/:packageId/files.json',
 			'/profiles/:username/packages/:kodyId/approve-publish.json',
+			'/@:username/:kodyId/raw/:ref(/*relativePath)',
 		],
 	},
 	{
@@ -241,6 +242,8 @@ export const featureCatalog: ReadonlyArray<Feature> = [
 			'/community/:listingId/install.json',
 			'/profiles/:username.json',
 			'/profiles/:username/packages/:kodyId.json',
+			'/@:username/:kodyId/raw/:ref(/*relativePath)',
+			'/community/:listingId/raw(/*relativePath)',
 		],
 	},
 	{


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

When someone opens a browser-renderable image or video in the package files explorer (community and account `/tree/...` UIs), show the media instead of garbled latin1/code.

## Why

`contentKind` was only `markdown | code | text`. Snapshots store non-text blobs as strings, so `.png` / `.mp4` / `.wasm` fell through to the plaintext highlighter.

## Summary

- Classify files with a strict extension allowlist (`png`, `jpg`/`jpeg`, `gif`, `webp`, `avif`, `svg`, `mp4`, `webm`, `ogv`, `mp3`, `wav`, `ogg`/`oga`). Known binaries and NUL blobs become `binary`.
- Explorer JSON/SSR **omits** media and binary payload. Preview uses a same-origin `/raw/` URL, not base64 in the HTML.
- New routes: `/@:username/:kodyId/raw/:ref(/*relativePath)` and `/community/:listingId/raw(/*relativePath)`. Same authz as the tree (public listings public, private packages owner-only).
- Raw responses: allowlist MIME **and** magic-byte sniff, `Content-Disposition: inline`, `X-Content-Type-Options: nosniff`, `Content-Security-Policy: default-src 'none'; sandbox`. Never `text/html` or JavaScript. Cap is 10 MiB.
- Prefer git blob bytes (`readArtifactFileAtCommit`); snapshot fallback uses byte-for-byte `String.fromCharCode` (not `TextDecoder('latin1')`, which is windows-1252 and corrupts PNG `0x89`).
- Tree and `/raw/` share listing-tree resolution. A hex ref that only falls back to the listing pin snapshot 404s on both, so `/raw/<other-sha>/` cannot serve the pin's media.
- Non-preview binaries show “This is a binary file and cannot be previewed.” — no code dump.

## Security

- **SVG:** XSS-sensitive. Preview is `<img src="…/raw/…">` only. Scripts do not run in `<img>`. Markup is never injected. A `.svg` that looks like HTML stays in the XML/source view. Navigating to the raw SVG URL still gets `sandbox` + `default-src 'none'`.
- **Allowlist + sniff:** filename alone does not set a renderable `Content-Type`. HTML named `logo.png` is 404 from `/raw/`.
- **No live HTML/JS/CSS:** no `iframe srcdoc`, `object`, `embed`, or `innerHTML` of repo files. Site-wide CSP is unchanged (`img-src 'self'` already covers the preview).
- **Authz** matches the tree. Private raw responses are `private, no-store`.

## Testing

- Node unit: media classification, explorer view, loader omit-bytes + `mediaHref`, raw handler headers, artifact latin1 round-trip, router specificity, shared tree/raw hex-snapshot 404.
- `npm run test:node` and `npm run test:workers` passed on push (2949 + 341). CI Validate / Node / Workers / E2E / MCP / Static green on `d426356f`.
- Preview (`https://kody-pr-2177.kody-a99.workers.dev`, `/health` merge `6a9b29e0` of `d426356f`): created `@user-me/media-preview`. Tree JSON serves README as `markdown`. `/raw/main/README.md` is 404 (`not-media`). `/raw/<unrelated-hex>/logo.png` is 404. Logged-in UI: profile → package → Browse files → README renders as markdown.
- Could not push a real PNG on this preview: `packageGetGitRemote` / `packageSave` hit Artifacts source-safety `account not found`. Image `/raw/` success path is covered by unit tests.

![Preview profile with media-preview package](https://cursor.com/artifacts/c/art-28eba36f-3acf-46e3-a1c4-aff4df8d890b)
![Package files tree with README selected](https://cursor.com/artifacts/c/art-730c2c89-2f93-4ad4-bba8-7fd365ebb8e1)
<a href="https://cursor.com/agents/bc-30ba72be-8666-4d1f-b0c0-3498963d07cc/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpreview_package_files_explorer.mp4"><img src="https://cursor.com/artifacts/c/art-fa109ab0-d2e9-48b7-a2f3-aa8b5548128f" alt="preview_package_files_explorer.mp4" /></a>

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `6a599ced` · **Head:** `d426356f`

**Classification:** extends — `app-ui` gains `/raw/` media routes and explorer preview kinds; `repo-sessions` stores allowlisted media/binary blobs as true byte-for-byte strings so `/raw/` can recover them.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | extends — new `/raw/` routes, `contentKind` media/binary, explorer preview, shared tree/raw hex guard |
| `repo-sessions` | runtime | extends — artifact tree decode uses byte-for-byte encoding for media/binaries |

### Change flow

Opening a PNG in the explorer classifies it as image, omits bytes from the page payload, then loads them from `/raw/` after the same authz, tree resolution, and a magic sniff.

```mermaid
sequenceDiagram
	actor User
	participant appUi as app-ui
	participant repoSessions as repo-sessions
	User->>appUi: open /@owner/pkg/tree/ref/logo.png
	appUi->>appUi: classify allowlisted image and omit bytes from JSON
	appUi-->>User: explorer chrome plus img src=/raw/
	User->>appUi: GET /@owner/pkg/raw/ref/logo.png
	appUi->>appUi: same tree authz and hex listing-snapshot 404
	appUi->>appUi: refuse HTML and JS types
	appUi->>repoSessions: read blob bytes at commit
	repoSessions-->>appUi: PNG bytes
	appUi->>appUi: sniff magic, allowlist Content-Type, nosniff
	appUi-->>User: image/png inline
```

### Before / after

```
contentKind: markdown | code | text
```

```
contentKind: markdown | code | text | image | video | audio | binary
mediaHref?: string
GET /@:username/:kodyId/raw/:ref/*
hex + listing-snapshot-only → 404 on tree and raw
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-30ba72be-8666-4d1f-b0c0-3498963d07cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-30ba72be-8666-4d1f-b0c0-3498963d07cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Package file explorers now preview allowlisted images, videos, and audio directly in the file viewer.
  * Binary files display a clear non-preview message instead of raw or garbled content.
  * Raw media URLs support inline browser viewing with appropriate media types.
  * Private package media remains access-controlled and uses private, non-cached responses.
  * SVG previews are safely rendered without injecting markup.
  * Text file views show line counts and byte sizes.

* **Documentation**
  * Updated package, community, architecture, and feature catalog documentation for media previews and raw-file routes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->