### PR TITLE
Fork community packages at the Artifacts storage layer

### DIFF
--- a/docs/contributing/community-packages.md
+++ b/docs/contributing/community-packages.md
@@ -189,16 +189,22 @@ is not community-banned. It upserts D1 metadata including optional browse
 `category` from `package.json#kody.category` or well-known tags, and writes a
 SHA-keyed source snapshot.
 
-`forkCommunityListing` reads the KV snapshot, rewrites `package.json` name/kody
-id to the forker's scope, scans cross-scope references, calls
-`ensureEntitySource` + `syncArtifactSourceSnapshot`, and records
-`community_forks` — **without** inserting `saved_packages`.
+`forkCommunityListing` reads the KV snapshot for rewrite/scan (Worker), then
+copies the origin Artifacts repo with `POST .../repos/{source}/fork` so the tree
+never enters a RepoSession isolate as `Record<path, string>` edits. Only
+rewritten files (`package.json` and self-reference text) are applied to the
+destination. When the origin Artifacts repo is missing, persist falls back to
+the older full-tree snapshot sync. Isolate memory / Artifacts `MEMORY_LIMIT`
+failures surface as `CommunityForkResourceLimitError` (honest UI/MCP copy; fork
+count does not increment). Records `community_forks` — **without** inserting
+`saved_packages`.
 
 `communityFork` returns request-scoped `serverTiming` entries
 (`{ name, durationMs }`), the same shape as `execute`. They are not written to
-D1 or Analytics Engine. Nested `bootstrap-*` phases come from the RepoSession
-Durable Object; `bootstrap-source` is the RPC wall clock, including isolate
-startup. Subtract the nested bootstrap phases from `bootstrap-source` to
+D1 or Analytics Engine. The storage-layer path records `artifacts-fork`. The
+legacy full-tree fallback may still include nested `bootstrap-*` phases from the
+RepoSession Durable Object; `bootstrap-source` is the RPC wall clock, including
+isolate startup. Subtract the nested bootstrap phases from `bootstrap-source` to
 estimate cold start. `Date.now()` in Workers only advances across I/O, so
 CPU-only steps may report `0`.
 

--- a/docs/contributing/community-packages.md
+++ b/docs/contributing/community-packages.md
@@ -191,13 +191,17 @@ SHA-keyed source snapshot.
 
 `forkCommunityListing` reads the KV snapshot for rewrite/scan (Worker), then
 copies the origin Artifacts repo with `POST .../repos/{source}/fork` so the tree
-never enters a RepoSession isolate as `Record<path, string>` edits. Only
-rewritten files (`package.json` and self-reference text) are applied to the
-destination. When the origin Artifacts repo is missing, persist falls back to
-the older full-tree snapshot sync. Isolate memory / Artifacts `MEMORY_LIMIT`
-failures surface as `CommunityForkResourceLimitError` (honest UI/MCP copy; fork
-count does not increment). Records `community_forks` — **without** inserting
-`saved_packages`.
+never enters a RepoSession isolate as `Record<path, string>` edits. Persist
+stamps dest `published_commit` to dest HEAD (the default-branch tip the fork
+copied) and records that SHA on `community_forks.origin_commit`. When dest HEAD
+matches the listing pin used in prepare, only rewritten files (`package.json`
+and self-reference text) are applied. When dest HEAD is ahead of that pin,
+persist re-derives the `package.json` rewrite from dest HEAD instead of applying
+pin-relative edits that would revert later origin commits. When the origin
+Artifacts repo is missing, persist falls back to the older full-tree snapshot
+sync. Isolate memory / Artifacts `MEMORY_LIMIT` failures surface as
+`CommunityForkResourceLimitError` (honest UI/MCP copy; fork count does not
+increment). Records `community_forks` — **without** inserting `saved_packages`.
 
 `communityFork` returns request-scoped `serverTiming` entries
 (`{ name, durationMs }`), the same shape as `execute`. They are not written to

--- a/packages/mock-servers/cloudflare/src/mock-artifacts-do.ts
+++ b/packages/mock-servers/cloudflare/src/mock-artifacts-do.ts
@@ -190,6 +190,13 @@ export class MockCloudflareArtifactsDurableObject {
 					remote: command.payload.remote,
 				}
 				storage.repos[repo.name] = repo
+				const sourceSnapshot = storage.snapshots[source.name]
+				if (sourceSnapshot) {
+					storage.snapshots[repo.name] = {
+						published_commit: sourceSnapshot.published_commit,
+						files: { ...sourceSnapshot.files },
+					}
+				}
 				await this.writeStorage(storage)
 				return Response.json({ repo })
 			}

--- a/packages/worker/src/app/handlers/community-install.node.test.ts
+++ b/packages/worker/src/app/handlers/community-install.node.test.ts
@@ -1,5 +1,7 @@
 import { expect, test, vi } from 'vitest'
 import { CommunityActionError } from '#worker/community/errors.ts'
+import { communityForkResourceLimitMessage } from '#worker/community/fork-resource-limit.ts'
+import { durableObjectIsolateMemoryResetMessage } from '#worker/sentry-options.ts'
 import { createCommunityInstallApiPostHandler } from './community-install.ts'
 import type * as CloudflareWorkers from 'cloudflare:workers'
 
@@ -222,4 +224,21 @@ test('community install POST enforces gates and maps install outcomes', async ()
 	})
 	expect(consoleError).toHaveBeenCalled()
 	consoleError.mockRestore()
+
+	const resourceConsoleError = vi
+		.spyOn(console, 'error')
+		.mockImplementation(() => {})
+	mockModule.installCommunityListing.mockRejectedValue(
+		new Error(durableObjectIsolateMemoryResetMessage),
+	)
+	const resourceLimit = await handler.handler(
+		buildInstallRequest({ acknowledged: true }),
+	)
+	expect(resourceLimit.status).toBe(503)
+	expect(await resourceLimit.json()).toEqual({
+		ok: false,
+		error: communityForkResourceLimitMessage,
+	})
+	expect(resourceConsoleError).toHaveBeenCalled()
+	resourceConsoleError.mockRestore()
 })

--- a/packages/worker/src/app/handlers/community-install.node.test.ts
+++ b/packages/worker/src/app/handlers/community-install.node.test.ts
@@ -239,6 +239,12 @@ test('community install POST enforces gates and maps install outcomes', async ()
 		ok: false,
 		error: communityForkResourceLimitMessage,
 	})
-	expect(resourceConsoleError).toHaveBeenCalled()
+	expect(resourceConsoleError).toHaveBeenCalledWith(
+		'Community install failed:',
+		expect.objectContaining({
+			error: durableObjectIsolateMemoryResetMessage,
+			userMessage: communityForkResourceLimitMessage,
+		}),
+	)
 	resourceConsoleError.mockRestore()
 })

--- a/packages/worker/src/app/handlers/community-install.ts
+++ b/packages/worker/src/app/handlers/community-install.ts
@@ -152,7 +152,7 @@ export function createCommunityInstallApiPostHandler(env: Env) {
 							: new CommunityForkResourceLimitError(error)
 					console.error(
 						'Community install failed:',
-						communityForkResourceLimitLogFields(mapped),
+						communityForkResourceLimitLogFields(error),
 					)
 					return jsonResponse({ ok: false, error: mapped.message }, 503)
 				}

--- a/packages/worker/src/app/handlers/community-install.ts
+++ b/packages/worker/src/app/handlers/community-install.ts
@@ -10,6 +10,11 @@ import {
 import { isOfficialCommunityListing } from '#universal/community-links.ts'
 import { type routes } from '#universal/routes.ts'
 import { CommunityActionError } from '#worker/community/errors.ts'
+import {
+	CommunityForkResourceLimitError,
+	communityForkResourceLimitLogFields,
+	isCommunityForkResourceLimitCause,
+} from '#worker/community/fork-resource-limit.ts'
 import { installCommunityListing } from '#worker/community/install.ts'
 import { getCommunityListingById } from '#worker/community/repo.ts'
 import { EntitlementLimitError } from '#worker/entitlements/errors.ts'
@@ -136,6 +141,20 @@ export function createCommunityInstallApiPostHandler(env: Env) {
 					error instanceof EntitlementLimitError
 				) {
 					return jsonResponse({ ok: false, error: error.message }, 400)
+				}
+				if (
+					error instanceof CommunityForkResourceLimitError ||
+					isCommunityForkResourceLimitCause(error)
+				) {
+					const mapped =
+						error instanceof CommunityForkResourceLimitError
+							? error
+							: new CommunityForkResourceLimitError(error)
+					console.error(
+						'Community install failed:',
+						communityForkResourceLimitLogFields(mapped),
+					)
+					return jsonResponse({ ok: false, error: mapped.message }, 503)
 				}
 				console.error('Community install failed:', error)
 				return jsonResponse(

--- a/packages/worker/src/community/community-flow.workers.test.ts
+++ b/packages/worker/src/community/community-flow.workers.test.ts
@@ -24,6 +24,8 @@ import {
 import { installCommunityListing } from '#worker/community/install.ts'
 import { insertSavedPackage } from '#worker/package-registry/repo.ts'
 import { writePublishedSourceSnapshot } from '#worker/package-runtime/published-runtime-artifacts.ts'
+import { writeArtifactSourceSnapshot } from '#worker/repo/artifact-source-snapshot.ts'
+import { getArtifactsBinding } from '#worker/repo/artifacts.ts'
 import { insertEntitySource } from '#worker/repo/entity-sources.ts'
 import { type EntitySourceRow } from '#worker/repo/types.ts'
 import { createStableUserIdFromEmail } from '#worker/user-id.ts'
@@ -181,6 +183,13 @@ async function seedOwnerPackage(input: {
 		source: entitySource,
 		files,
 	})
+	const artifacts = getArtifactsBinding(input.testEnv)
+	await artifacts.create(entitySource.repo_id, { readOnly: false })
+	await writeArtifactSourceSnapshot({
+		env: input.testEnv,
+		repoId: entitySource.repo_id,
+		files,
+	})
 	return { entitySource, files }
 }
 
@@ -321,6 +330,10 @@ test('public package flow works end-to-end through capability handlers', async (
 		expect.arrayContaining([
 			expect.objectContaining({
 				name: 'prepare',
+				durationMs: expect.any(Number),
+			}),
+			expect.objectContaining({
+				name: 'artifacts-fork',
 				durationMs: expect.any(Number),
 			}),
 			expect.objectContaining({

--- a/packages/worker/src/community/community-service.node.test.ts
+++ b/packages/worker/src/community/community-service.node.test.ts
@@ -47,7 +47,7 @@ const mockModule = vi.hoisted(() => ({
 	persistForkedArtifactRepoContents: vi.fn(),
 	deleteEntitySource: vi.fn(),
 	cleanupArtifactReposForPackage: vi.fn(),
-	deleteUserScopedArtifactRepo: vi.fn(),
+	deleteUserScopedArtifactRepo: vi.fn(async () => false),
 	insertCommunityFork: vi.fn(),
 	deleteCommunityListing: vi.fn(),
 	deleteCommunityRatingsByListingId: vi.fn(),
@@ -1290,6 +1290,11 @@ test('forkCommunityListing cleans up entity source when snapshot sync fails', as
 		}),
 	).rejects.toThrow('sync failed')
 
+	expect(mockModule.deleteUserScopedArtifactRepo).toHaveBeenCalledWith({
+		env: createEnv(),
+		userId: 'user-2',
+		repoName: expect.stringMatching(/^package-/),
+	})
 	expect(mockModule.cleanupArtifactReposForPackage).toHaveBeenCalledWith({
 		env: createEnv(),
 		userId: 'user-2',

--- a/packages/worker/src/community/community-service.node.test.ts
+++ b/packages/worker/src/community/community-service.node.test.ts
@@ -1,7 +1,11 @@
 import { expect, test, vi } from 'vitest'
 import { communityIndexOverviewCandidateLimitPerCategory } from '#universal/community-categories.ts'
+import { durableObjectIsolateMemoryResetMessage } from '#worker/sentry-options.ts'
 import { consoleError } from '#worker/test-support/console-spies.ts'
-import { CommunityActionError } from './errors.ts'
+import {
+	CommunityActionError,
+	CommunityForkResourceLimitError,
+} from './errors.ts'
 import type * as CommunityRepo from './repo.ts'
 import { type CommunityListingRecord } from './types.ts'
 
@@ -39,8 +43,11 @@ const mockModule = vi.hoisted(() => ({
 	ensureEntitySource: vi.fn(),
 	getEntitySourceById: vi.fn(),
 	syncArtifactSourceSnapshot: vi.fn(),
+	forkArtifactRepo: vi.fn(),
+	persistForkedArtifactRepoContents: vi.fn(),
 	deleteEntitySource: vi.fn(),
 	cleanupArtifactReposForPackage: vi.fn(),
+	deleteUserScopedArtifactRepo: vi.fn(),
 	insertCommunityFork: vi.fn(),
 	deleteCommunityListing: vi.fn(),
 	deleteCommunityRatingsByListingId: vi.fn(),
@@ -93,6 +100,15 @@ vi.mock('#worker/repo/source-sync.ts', () => ({
 		mockModule.syncArtifactSourceSnapshot(...args),
 }))
 
+vi.mock('#worker/repo/artifact-repo-fork.ts', () => ({
+	forkArtifactRepo: (...args: Array<unknown>) =>
+		mockModule.forkArtifactRepo(...args),
+	persistForkedArtifactRepoContents: (...args: Array<unknown>) =>
+		mockModule.persistForkedArtifactRepoContents(...args),
+	shouldFallbackFromArtifactFork: (error: unknown) =>
+		error instanceof Error && /not found/i.test(error.message),
+}))
+
 vi.mock('#worker/repo/entity-sources.ts', () => ({
 	deleteEntitySource: (...args: Array<unknown>) =>
 		mockModule.deleteEntitySource(...args),
@@ -103,6 +119,8 @@ vi.mock('#worker/repo/entity-sources.ts', () => ({
 vi.mock('#worker/repo/artifact-repo-cleanup.ts', () => ({
 	cleanupArtifactReposForPackage: (...args: Array<unknown>) =>
 		mockModule.cleanupArtifactReposForPackage(...args),
+	deleteUserScopedArtifactRepo: (...args: Array<unknown>) =>
+		mockModule.deleteUserScopedArtifactRepo(...args),
 }))
 
 vi.mock('./repo.ts', async (importOriginal) => {
@@ -191,6 +209,7 @@ const {
 } = await import('./service.ts')
 
 const testBundleArtifactsKv = {
+	get: vi.fn(async () => null),
 	delete: vi.fn(async () => undefined),
 	list: vi.fn(async () => ({
 		keys: [{ name: 'derived-cache:v1:community-icon:v1:listing-1:commit-1' }],
@@ -1282,6 +1301,105 @@ test('forkCommunityListing cleans up entity source when snapshot sync fails', as
 			id: 'fork-source-1',
 			userId: 'user-2',
 		},
+	)
+	expect(mockModule.insertCommunityFork).not.toHaveBeenCalled()
+})
+
+test('forkCommunityListing copies at the Artifacts layer when the origin repo exists', async () => {
+	mockModule.getCommunityListingById.mockResolvedValue(sampleListing())
+	mockModule.getEntitySourceById.mockResolvedValue({
+		id: 'origin-source-1',
+		repo_id: 'package-origin-1',
+		published_commit: 'commit-1',
+	})
+	mockModule.readCommunitySnapshot.mockResolvedValue({
+		version: 1,
+		listingId: 'listing-1',
+		pinnedCommit: 'commit-1',
+		createdAt: '2026-07-01T00:00:00.000Z',
+		files: validPublishSource().files,
+	})
+	mockModule.getSavedPackageByKodyId.mockResolvedValue(null)
+	mockModule.getSavedPackageByName.mockResolvedValue(null)
+	mockModule.listCommunityForksByListingAndUser.mockResolvedValue([])
+	mockModule.forkArtifactRepo.mockResolvedValue({
+		id: 'repo-fork',
+		name: 'package-dest',
+	})
+	mockModule.ensureEntitySource.mockResolvedValue({
+		id: 'fork-source-1',
+		repo_id: 'package-dest',
+		user_id: 'user-2',
+	})
+	mockModule.persistForkedArtifactRepoContents.mockResolvedValue(
+		'commit-fork-1',
+	)
+
+	const result = await forkCommunityListing({
+		env: createEnv(),
+		baseUrl: 'https://heykody.dev',
+		userId: 'user-2',
+		expectedPackageScope: 'jane',
+		listingId: 'listing-1',
+		kodyId: 'my-discord-gateway',
+	})
+
+	expect(result.filesCount).toBeGreaterThan(0)
+	expect(mockModule.forkArtifactRepo).toHaveBeenCalledWith(
+		expect.objectContaining({
+			sourceRepoId: 'package-origin-1',
+		}),
+	)
+	expect(mockModule.persistForkedArtifactRepoContents).toHaveBeenCalledWith(
+		expect.objectContaining({
+			originCommit: 'commit-1',
+			changedFiles: expect.objectContaining({
+				'package.json': expect.any(String),
+			}),
+		}),
+	)
+	expect(mockModule.syncArtifactSourceSnapshot).not.toHaveBeenCalled()
+	expect(mockModule.insertCommunityFork).toHaveBeenCalled()
+})
+
+test('forkCommunityListing maps isolate memory resets to CommunityForkResourceLimitError', async () => {
+	mockModule.getEntitySourceById.mockResolvedValue(undefined)
+	mockModule.forkArtifactRepo.mockReset()
+	mockModule.getCommunityListingById.mockResolvedValue(sampleListing())
+	mockModule.readCommunitySnapshot.mockResolvedValue({
+		version: 1,
+		listingId: 'listing-1',
+		pinnedCommit: 'commit-1',
+		createdAt: '2026-07-01T00:00:00.000Z',
+		files: validPublishSource().files,
+	})
+	mockModule.getSavedPackageByKodyId.mockResolvedValue(null)
+	mockModule.getSavedPackageByName.mockResolvedValue(null)
+	mockModule.listCommunityForksByListingAndUser.mockResolvedValue([])
+	mockModule.ensureEntitySource.mockResolvedValue({
+		id: 'fork-source-1',
+		bootstrapAccess: { token: 'bootstrap' },
+	})
+	mockModule.syncArtifactSourceSnapshot.mockRejectedValue(
+		new Error(durableObjectIsolateMemoryResetMessage),
+	)
+	mockModule.cleanupArtifactReposForPackage.mockResolvedValue(0)
+	mockModule.deleteEntitySource.mockResolvedValue(true)
+
+	await expect(
+		forkCommunityListing({
+			env: createEnv(),
+			baseUrl: 'https://heykody.dev',
+			userId: 'user-2',
+			expectedPackageScope: 'jane',
+			listingId: 'listing-1',
+			kodyId: 'my-discord-gateway',
+		}),
+	).rejects.toSatisfy(
+		(error: unknown) =>
+			error instanceof CommunityForkResourceLimitError &&
+			/too large to finish forking/.test(error.message) &&
+			!/isolate exceeded/.test(error.message),
 	)
 	expect(mockModule.insertCommunityFork).not.toHaveBeenCalled()
 })

--- a/packages/worker/src/community/community-service.node.test.ts
+++ b/packages/worker/src/community/community-service.node.test.ts
@@ -1331,9 +1331,10 @@ test('forkCommunityListing copies at the Artifacts layer when the origin repo ex
 		repo_id: 'package-dest',
 		user_id: 'user-2',
 	})
-	mockModule.persistForkedArtifactRepoContents.mockResolvedValue(
-		'commit-fork-1',
-	)
+	mockModule.persistForkedArtifactRepoContents.mockResolvedValue({
+		copiedOriginCommit: 'commit-head',
+		destCommit: 'commit-rewritten',
+	})
 
 	const result = await forkCommunityListing({
 		env: createEnv(),
@@ -1353,13 +1354,21 @@ test('forkCommunityListing copies at the Artifacts layer when the origin repo ex
 	expect(mockModule.persistForkedArtifactRepoContents).toHaveBeenCalledWith(
 		expect.objectContaining({
 			originCommit: 'commit-1',
+			expectedPackageScope: 'jane',
+			targetKodyId: 'my-discord-gateway',
 			changedFiles: expect.objectContaining({
 				'package.json': expect.any(String),
 			}),
 		}),
 	)
 	expect(mockModule.syncArtifactSourceSnapshot).not.toHaveBeenCalled()
-	expect(mockModule.insertCommunityFork).toHaveBeenCalled()
+	expect(mockModule.insertCommunityFork).toHaveBeenCalledWith(
+		expect.anything(),
+		expect.objectContaining({
+			origin_commit: 'commit-head',
+		}),
+	)
+	expect(result.originCommit).toBe('commit-head')
 })
 
 test('forkCommunityListing maps isolate memory resets to CommunityForkResourceLimitError', async () => {

--- a/packages/worker/src/community/community-service.node.test.ts
+++ b/packages/worker/src/community/community-service.node.test.ts
@@ -1,7 +1,10 @@
 import { expect, test, vi } from 'vitest'
 import { communityIndexOverviewCandidateLimitPerCategory } from '#universal/community-categories.ts'
 import { durableObjectIsolateMemoryResetMessage } from '#worker/sentry-options.ts'
-import { consoleError } from '#worker/test-support/console-spies.ts'
+import {
+	consoleError,
+	consoleWarn,
+} from '#worker/test-support/console-spies.ts'
 import {
 	CommunityActionError,
 	CommunityForkResourceLimitError,
@@ -1278,6 +1281,7 @@ test('forkCommunityListing cleans up entity source when snapshot sync fails', as
 	)
 	mockModule.cleanupArtifactReposForPackage.mockResolvedValue(0)
 	mockModule.deleteEntitySource.mockResolvedValue(true)
+	consoleWarn.mockImplementation(() => {})
 
 	await expect(
 		forkCommunityListing({
@@ -1290,6 +1294,9 @@ test('forkCommunityListing cleans up entity source when snapshot sync fails', as
 		}),
 	).rejects.toThrow('sync failed')
 
+	expect(consoleWarn).toHaveBeenCalledWith(
+		expect.stringContaining('community fork dest artifact repo cleanup failed'),
+	)
 	expect(mockModule.deleteUserScopedArtifactRepo).toHaveBeenCalledWith({
 		env: createEnv(),
 		userId: 'user-2',
@@ -1399,6 +1406,7 @@ test('forkCommunityListing maps isolate memory resets to CommunityForkResourceLi
 	)
 	mockModule.cleanupArtifactReposForPackage.mockResolvedValue(0)
 	mockModule.deleteEntitySource.mockResolvedValue(true)
+	consoleWarn.mockImplementation(() => {})
 
 	await expect(
 		forkCommunityListing({

--- a/packages/worker/src/community/errors.ts
+++ b/packages/worker/src/community/errors.ts
@@ -5,6 +5,25 @@ export class CommunityActionError extends Error {
 	}
 }
 
+/**
+ * User-facing copy when a community fork/install dies on isolate memory,
+ * CPU reset, or Artifacts `MEMORY_LIMIT`. The listing is unchanged: no
+ * fork row, no increment. Keep internals on the cause / Sentry, not here.
+ */
+export const communityForkResourceLimitMessage =
+	'This package is too large to finish forking. Nothing was copied into your account, and the listing fork count did not change. Try again in a moment.'
+
+export class CommunityForkResourceLimitError extends Error {
+	override readonly name = 'CommunityForkResourceLimitError'
+
+	constructor(cause?: unknown) {
+		super(
+			communityForkResourceLimitMessage,
+			cause === undefined ? undefined : { cause },
+		)
+	}
+}
+
 export class CommunityActivityDispatchCancelledError extends Error {
 	readonly kind: string
 	readonly activityId: string

--- a/packages/worker/src/community/fork-resource-limit.node.test.ts
+++ b/packages/worker/src/community/fork-resource-limit.node.test.ts
@@ -28,6 +28,11 @@ test('isCommunityForkResourceLimitCause matches isolate reset and Artifacts MEMO
 		),
 	).toBe(true)
 	expect(
+		isCommunityForkResourceLimitCause(
+			new Error('ArtifactsError: Memory limit exceeded during import'),
+		),
+	).toBe(true)
+	expect(
 		isCommunityForkResourceLimitCause(new Error('artifacts unavailable')),
 	).toBe(false)
 })

--- a/packages/worker/src/community/fork-resource-limit.node.test.ts
+++ b/packages/worker/src/community/fork-resource-limit.node.test.ts
@@ -1,0 +1,50 @@
+import { expect, test } from 'vitest'
+import { durableObjectIsolateMemoryResetMessage } from '#worker/sentry-options.ts'
+import {
+	CommunityForkResourceLimitError,
+	communityForkResourceLimitMessage,
+	isCommunityForkResourceLimitCause,
+	rethrowCommunityForkFailure,
+} from './fork-resource-limit.ts'
+
+test('isCommunityForkResourceLimitCause matches isolate reset and Artifacts MEMORY_LIMIT', () => {
+	expect(
+		isCommunityForkResourceLimitCause(
+			new Error(durableObjectIsolateMemoryResetMessage),
+		),
+	).toBe(true)
+	expect(
+		isCommunityForkResourceLimitCause(
+			new Error('publish failed', {
+				cause: new Error(durableObjectIsolateMemoryResetMessage),
+			}),
+		),
+	).toBe(true)
+	expect(
+		isCommunityForkResourceLimitCause(
+			Object.assign(new Error('import exceeded service memory limits'), {
+				code: 'MEMORY_LIMIT',
+			}),
+		),
+	).toBe(true)
+	expect(
+		isCommunityForkResourceLimitCause(new Error('artifacts unavailable')),
+	).toBe(false)
+})
+
+test('rethrowCommunityForkFailure wraps resource limits without leaking isolate text', () => {
+	try {
+		rethrowCommunityForkFailure(
+			new Error(durableObjectIsolateMemoryResetMessage),
+		)
+		throw new Error('expected rethrow')
+	} catch (error) {
+		expect(error).toBeInstanceOf(CommunityForkResourceLimitError)
+		expect((error as Error).message).toBe(communityForkResourceLimitMessage)
+		expect((error as Error).message).not.toMatch(/isolate exceeded/)
+	}
+
+	expect(() => rethrowCommunityForkFailure(new Error('sync failed'))).toThrow(
+		'sync failed',
+	)
+})

--- a/packages/worker/src/community/fork-resource-limit.ts
+++ b/packages/worker/src/community/fork-resource-limit.ts
@@ -1,0 +1,45 @@
+import {
+	errorCauseChainIncludes,
+	getErrorCauseChain,
+	getErrorMessage,
+} from '@kody-internal/shared/error-message.ts'
+import { isDurableObjectIsolateResourceLimitResetMessage } from '#worker/sentry-options.ts'
+import {
+	CommunityForkResourceLimitError,
+	communityForkResourceLimitMessage,
+} from './errors.ts'
+
+export {
+	CommunityForkResourceLimitError,
+	communityForkResourceLimitMessage,
+} from './errors.ts'
+
+function isArtifactsMemoryLimitError(error: unknown) {
+	if (error === null || typeof error !== 'object') return false
+	return (error as { code?: unknown }).code === 'MEMORY_LIMIT'
+}
+
+export function isCommunityForkResourceLimitCause(error: unknown) {
+	if (error instanceof CommunityForkResourceLimitError) return true
+	if (getErrorCauseChain(error).some(isArtifactsMemoryLimitError)) return true
+	return errorCauseChainIncludes(
+		error,
+		isDurableObjectIsolateResourceLimitResetMessage,
+	)
+}
+
+export function rethrowCommunityForkFailure(error: unknown): never {
+	if (error instanceof CommunityForkResourceLimitError) throw error
+	if (isCommunityForkResourceLimitCause(error)) {
+		throw new CommunityForkResourceLimitError(error)
+	}
+	throw error
+}
+
+export function communityForkResourceLimitLogFields(error: unknown) {
+	return {
+		message: 'community-fork-resource-limit',
+		error: getErrorMessage(error),
+		userMessage: communityForkResourceLimitMessage,
+	}
+}

--- a/packages/worker/src/community/fork-resource-limit.ts
+++ b/packages/worker/src/community/fork-resource-limit.ts
@@ -3,6 +3,7 @@ import {
 	getErrorCauseChain,
 	getErrorMessage,
 } from '@kody-internal/shared/error-message.ts'
+import { artifactsBindingErrorCode } from '#worker/repo/artifacts.ts'
 import { isDurableObjectIsolateResourceLimitResetMessage } from '#worker/sentry-options.ts'
 import {
 	CommunityForkResourceLimitError,
@@ -15,8 +16,14 @@ export {
 } from './errors.ts'
 
 function isArtifactsMemoryLimitError(error: unknown) {
-	if (error === null || typeof error !== 'object') return false
-	return (error as { code?: unknown }).code === 'MEMORY_LIMIT'
+	if (
+		error !== null &&
+		typeof error === 'object' &&
+		(error as { code?: unknown }).code === 'MEMORY_LIMIT'
+	) {
+		return true
+	}
+	return artifactsBindingErrorCode(error) === 'MEMORY_LIMIT'
 }
 
 export function isCommunityForkResourceLimitCause(error: unknown) {

--- a/packages/worker/src/community/fork-scan.node.test.ts
+++ b/packages/worker/src/community/fork-scan.node.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from 'vitest'
 import {
+	collectChangedForkFiles,
 	rewritePackageManifestForFork,
 	scanCrossScopeReferences,
 } from './fork-scan.ts'
@@ -165,4 +166,24 @@ import util from 'kody:@owner/util/helper'`,
 	expect(
 		withoutAllowlist.some((entry) => entry.specifier === 'kody:@kody/'),
 	).toBe(true)
+})
+
+test('collectChangedForkFiles returns only rewritten paths', () => {
+	expect(
+		collectChangedForkFiles({
+			originFiles: {
+				'package.json': '{"name":"@owner/demo"}',
+				'src/index.ts': 'export const n = "@owner/demo"\n',
+				'poster.png': 'binary-bytes',
+			},
+			rewrittenFiles: {
+				'package.json': '{"name":"@jane/demo"}',
+				'src/index.ts': 'export const n = "@jane/demo"\n',
+				'poster.png': 'binary-bytes',
+			},
+		}),
+	).toEqual({
+		'package.json': '{"name":"@jane/demo"}',
+		'src/index.ts': 'export const n = "@jane/demo"\n',
+	})
 })

--- a/packages/worker/src/community/fork-scan.ts
+++ b/packages/worker/src/community/fork-scan.ts
@@ -111,3 +111,21 @@ export function scanCrossScopeReferences(input: {
 		return left.specifier.localeCompare(right.specifier)
 	})
 }
+
+/**
+ * Files whose contents changed during fork rewrite (typically `package.json`
+ * plus any self-references). The storage-layer copy already has the origin
+ * tree; only these paths should be written back.
+ */
+export function collectChangedForkFiles(input: {
+	originFiles: Record<string, string>
+	rewrittenFiles: Record<string, string>
+}): Record<string, string> {
+	const changed: Record<string, string> = {}
+	for (const [path, content] of Object.entries(input.rewrittenFiles)) {
+		if (input.originFiles[path] !== content) {
+			changed[path] = content
+		}
+	}
+	return changed
+}

--- a/packages/worker/src/community/service.ts
+++ b/packages/worker/src/community/service.ts
@@ -314,6 +314,24 @@ async function cleanupFailedCommunityFork(input: {
 	sourceId: string
 	packageId: string
 }) {
+	await deleteUserScopedArtifactRepo({
+		env: input.env,
+		userId: input.userId,
+		repoName: buildEntityRepoId({
+			entityKind: 'package',
+			entityId: input.packageId,
+		}),
+	}).catch((error) => {
+		console.warn(
+			JSON.stringify({
+				message: 'community fork dest artifact repo cleanup failed',
+				userId: input.userId,
+				packageId: input.packageId,
+				sourceId: input.sourceId,
+				error: getErrorMessage(error),
+			}),
+		)
+	})
 	await cleanupArtifactReposForPackage({
 		env: input.env,
 		userId: input.userId,

--- a/packages/worker/src/community/service.ts
+++ b/packages/worker/src/community/service.ts
@@ -28,13 +28,24 @@ import {
 } from '#worker/package-registry/repo.ts'
 import { rewriteForkedPackageSelfReferences } from '#worker/package-registry/platform-package-policy.ts'
 import { loadPackageSourceBySourceId } from '#worker/package-registry/source.ts'
-import { cleanupArtifactReposForPackage } from '#worker/repo/artifact-repo-cleanup.ts'
+import {
+	cleanupArtifactReposForPackage,
+	deleteUserScopedArtifactRepo,
+} from '#worker/repo/artifact-repo-cleanup.ts'
 import {
 	deleteEntitySource,
 	getEntitySourceById,
 } from '#worker/repo/entity-sources.ts'
 import { readArtifactSourceSnapshot } from '#worker/repo/artifact-source-snapshot.ts'
-import { resolveArtifactSourceHead } from '#worker/repo/artifacts.ts'
+import {
+	buildEntityRepoId,
+	resolveArtifactSourceHead,
+} from '#worker/repo/artifacts.ts'
+import {
+	forkArtifactRepo,
+	persistForkedArtifactRepoContents,
+	shouldFallbackFromArtifactFork,
+} from '#worker/repo/artifact-repo-fork.ts'
 import { readPublishedSourceSnapshot } from '#worker/package-runtime/published-runtime-artifacts.ts'
 import { ensureEntitySource } from '#worker/repo/source-service.ts'
 import { syncArtifactSourceSnapshot } from '#worker/repo/source-sync.ts'
@@ -96,9 +107,11 @@ import {
 	insertCommunityActivityEvent,
 } from './profile-repo.ts'
 import {
+	collectChangedForkFiles,
 	rewritePackageManifestForFork,
 	scanCrossScopeReferences,
 } from './fork-scan.ts'
+import { rethrowCommunityForkFailure } from './fork-resource-limit.ts'
 import {
 	deleteCommunitySnapshot,
 	readCommunitySnapshot,
@@ -1199,7 +1212,9 @@ export type PreparedCommunityFork = {
 	packageId: string
 	targetKodyId: string
 	targetName: string
+	originRepoId: string | null
 	files: Record<string, string>
+	changedFiles: Record<string, string>
 	crossScopeReferences: Array<CrossScopeReference>
 }
 
@@ -1356,9 +1371,13 @@ export async function prepareCommunityFork(
 		)
 	}
 
+	const originFiles = {
+		...files,
+		'package.json': packageJsonContent,
+	}
 	const rewrittenFiles = rewriteForkedPackageSelfReferences({
 		files: {
-			...files,
+			...originFiles,
 			'package.json': rewrittenManifest.content,
 		},
 		originPackageName: listing.name,
@@ -1381,14 +1400,20 @@ export async function prepareCommunityFork(
 		packageId: crypto.randomUUID(),
 		targetKodyId,
 		targetName: rewrittenManifest.targetName,
+		originRepoId: source?.repo_id ?? null,
 		files: rewrittenFiles,
+		changedFiles: collectChangedForkFiles({
+			originFiles,
+			rewrittenFiles,
+		}),
 		crossScopeReferences,
 	}
 }
 
 /**
- * Create the Artifacts repo, sync the rewritten snapshot, and insert the
- * inert `community_forks` row. Callers that already hold a prepared fork
+ * Create the Artifacts repo, copy the origin tree at the storage layer when
+ * possible, apply only rewritten files, and insert the inert
+ * `community_forks` row. Callers that already hold a prepared fork
  * (one-click install) can overlap this with `runRepoChecks`.
  */
 export async function persistPreparedCommunityFork(
@@ -1397,25 +1422,73 @@ export async function persistPreparedCommunityFork(
 ): Promise<ForkCommunityListingResult> {
 	const persistStartedAt = Date.now()
 	const serverTiming = options?.serverTiming
-	const ensuredSource = await ensureEntitySource({
-		db: prepared.env.APP_DB,
-		env: prepared.env,
-		userId: prepared.userId,
+	const destRepoId = buildEntityRepoId({
 		entityKind: 'package',
 		entityId: prepared.packageId,
-		requirePersistence: true,
-		serverTiming,
 	})
+	let copiedAtStorageLayer = false
+	const originRepoId = prepared.originRepoId
+	if (originRepoId) {
+		try {
+			await pushServerTiming(serverTiming, 'artifacts-fork', () =>
+				forkArtifactRepo({
+					env: prepared.env,
+					sourceRepoId: originRepoId,
+					targetRepoId: destRepoId,
+				}),
+			)
+			copiedAtStorageLayer = true
+		} catch (error) {
+			if (!shouldFallbackFromArtifactFork(error)) {
+				rethrowCommunityForkFailure(error)
+			}
+		}
+	}
+	let ensuredSource
 	try {
-		await syncArtifactSourceSnapshot({
+		ensuredSource = await ensureEntitySource({
+			db: prepared.env.APP_DB,
 			env: prepared.env,
-			baseUrl: prepared.baseUrl,
 			userId: prepared.userId,
-			sourceId: ensuredSource.id,
-			files: prepared.files,
-			bootstrapAccess: ensuredSource.bootstrapAccess ?? null,
+			entityKind: 'package',
+			entityId: prepared.packageId,
+			requirePersistence: true,
 			serverTiming,
 		})
+	} catch (error) {
+		if (copiedAtStorageLayer) {
+			await deleteUserScopedArtifactRepo({
+				env: prepared.env,
+				userId: prepared.userId,
+				repoName: destRepoId,
+			})
+		}
+		rethrowCommunityForkFailure(error)
+	}
+	try {
+		if (copiedAtStorageLayer) {
+			await persistForkedArtifactRepoContents({
+				env: prepared.env,
+				baseUrl: prepared.baseUrl,
+				userId: prepared.userId,
+				source: ensuredSource,
+				originCommit: prepared.originCommit,
+				changedFiles: prepared.changedFiles,
+				files: prepared.files,
+				bootstrapAccess: ensuredSource.bootstrapAccess ?? null,
+				serverTiming,
+			})
+		} else {
+			await syncArtifactSourceSnapshot({
+				env: prepared.env,
+				baseUrl: prepared.baseUrl,
+				userId: prepared.userId,
+				sourceId: ensuredSource.id,
+				files: prepared.files,
+				bootstrapAccess: ensuredSource.bootstrapAccess ?? null,
+				serverTiming,
+			})
+		}
 
 		const forkId = crypto.randomUUID()
 		await pushServerTiming(serverTiming, 'fork-row', async () => {
@@ -1466,7 +1539,7 @@ export async function persistPreparedCommunityFork(
 			sourceId: ensuredSource.id,
 			packageId: prepared.packageId,
 		})
-		throw error
+		rethrowCommunityForkFailure(error)
 	}
 }
 

--- a/packages/worker/src/community/service.ts
+++ b/packages/worker/src/community/service.ts
@@ -1212,6 +1212,7 @@ export type PreparedCommunityFork = {
 	packageId: string
 	targetKodyId: string
 	targetName: string
+	expectedPackageScope: string
 	originRepoId: string | null
 	files: Record<string, string>
 	changedFiles: Record<string, string>
@@ -1400,6 +1401,7 @@ export async function prepareCommunityFork(
 		packageId: crypto.randomUUID(),
 		targetKodyId,
 		targetName: rewrittenManifest.targetName,
+		expectedPackageScope: input.expectedPackageScope,
 		originRepoId: source?.repo_id ?? null,
 		files: rewrittenFiles,
 		changedFiles: collectChangedForkFiles({
@@ -1466,18 +1468,22 @@ export async function persistPreparedCommunityFork(
 		rethrowCommunityForkFailure(error)
 	}
 	try {
+		let originCommit = prepared.originCommit
 		if (copiedAtStorageLayer) {
-			await persistForkedArtifactRepoContents({
+			const persisted = await persistForkedArtifactRepoContents({
 				env: prepared.env,
 				baseUrl: prepared.baseUrl,
 				userId: prepared.userId,
 				source: ensuredSource,
 				originCommit: prepared.originCommit,
+				expectedPackageScope: prepared.expectedPackageScope,
+				targetKodyId: prepared.targetKodyId,
 				changedFiles: prepared.changedFiles,
 				files: prepared.files,
 				bootstrapAccess: ensuredSource.bootstrapAccess ?? null,
 				serverTiming,
 			})
+			originCommit = persisted.copiedOriginCommit
 		} else {
 			await syncArtifactSourceSnapshot({
 				env: prepared.env,
@@ -1496,7 +1502,7 @@ export async function persistPreparedCommunityFork(
 				id: forkId,
 				listing_id: prepared.listingId,
 				forker_user_id: prepared.userId,
-				origin_commit: prepared.originCommit,
+				origin_commit: originCommit,
 				forked_package_id: prepared.packageId,
 				forked_source_id: ensuredSource.id,
 				target_kody_id: prepared.targetKodyId,
@@ -1526,7 +1532,7 @@ export async function persistPreparedCommunityFork(
 			sourceId: ensuredSource.id,
 			targetKodyId: prepared.targetKodyId,
 			targetName: prepared.targetName,
-			originCommit: prepared.originCommit,
+			originCommit,
 			crossScopeReferences: prepared.crossScopeReferences,
 			filesCount: Object.keys(prepared.files).length,
 			files: prepared.files,

--- a/packages/worker/src/community/service.ts
+++ b/packages/worker/src/community/service.ts
@@ -314,24 +314,24 @@ async function cleanupFailedCommunityFork(input: {
 	sourceId: string
 	packageId: string
 }) {
-	await deleteUserScopedArtifactRepo({
+	const destDeleted = await deleteUserScopedArtifactRepo({
 		env: input.env,
 		userId: input.userId,
 		repoName: buildEntityRepoId({
 			entityKind: 'package',
 			entityId: input.packageId,
 		}),
-	}).catch((error) => {
+	})
+	if (!destDeleted) {
 		console.warn(
 			JSON.stringify({
 				message: 'community fork dest artifact repo cleanup failed',
 				userId: input.userId,
 				packageId: input.packageId,
 				sourceId: input.sourceId,
-				error: getErrorMessage(error),
 			}),
 		)
-	})
+	}
 	await cleanupArtifactReposForPackage({
 		env: input.env,
 		userId: input.userId,

--- a/packages/worker/src/repo/artifact-repo-fork.node.test.ts
+++ b/packages/worker/src/repo/artifact-repo-fork.node.test.ts
@@ -1,0 +1,162 @@
+import { expect, test, vi } from 'vitest'
+
+const mockModule = vi.hoisted(() => ({
+	getArtifactsBinding: vi.fn(),
+	isArtifactRepoNotFoundError: vi.fn(),
+	isLoopbackArtifactsRemote: vi.fn(),
+	resolveExistingArtifactSourceRepo: vi.fn(),
+	writeArtifactSourceSnapshot: vi.fn(),
+	writePublishedSourceSnapshot: vi.fn(),
+	updateEntitySource: vi.fn(),
+	syncArtifactSourceSnapshot: vi.fn(),
+}))
+
+vi.mock('./artifacts.ts', () => ({
+	getArtifactsBinding: (...args: Array<unknown>) =>
+		mockModule.getArtifactsBinding(...args),
+	isArtifactRepoNotFoundError: (...args: Array<unknown>) =>
+		mockModule.isArtifactRepoNotFoundError(...args),
+	isLoopbackArtifactsRemote: (...args: Array<unknown>) =>
+		mockModule.isLoopbackArtifactsRemote(...args),
+	resolveExistingArtifactSourceRepo: (...args: Array<unknown>) =>
+		mockModule.resolveExistingArtifactSourceRepo(...args),
+}))
+
+vi.mock('./artifact-source-snapshot.ts', () => ({
+	writeArtifactSourceSnapshot: (...args: Array<unknown>) =>
+		mockModule.writeArtifactSourceSnapshot(...args),
+}))
+
+vi.mock('#worker/package-runtime/published-runtime-artifacts.ts', () => ({
+	writePublishedSourceSnapshot: (...args: Array<unknown>) =>
+		mockModule.writePublishedSourceSnapshot(...args),
+}))
+
+vi.mock('./entity-sources.ts', () => ({
+	updateEntitySource: (...args: Array<unknown>) =>
+		mockModule.updateEntitySource(...args),
+}))
+
+vi.mock('./source-sync.ts', () => ({
+	syncArtifactSourceSnapshot: (...args: Array<unknown>) =>
+		mockModule.syncArtifactSourceSnapshot(...args),
+}))
+
+const { forkArtifactRepo, persistForkedArtifactRepoContents } =
+	await import('./artifact-repo-fork.ts')
+
+const env = { APP_DB: {} as D1Database } as Env
+const source = {
+	id: 'source-1',
+	user_id: 'user-1',
+	entity_kind: 'package' as const,
+	entity_id: 'package-1',
+	repo_id: 'package-dest',
+	published_commit: null,
+	indexed_commit: null,
+	manifest_path: 'package.json',
+	source_root: '/',
+	last_external_check_at: null,
+	external_check_until: null,
+	created_at: '2026-09-08T00:00:00.000Z',
+	updated_at: '2026-09-08T00:00:00.000Z',
+}
+
+test('forkArtifactRepo delegates to the Artifacts binding fork', async () => {
+	const fork = vi.fn(async () => ({
+		id: 'repo_dest',
+		name: 'package-dest',
+		description: null,
+		defaultBranch: 'main',
+		remote: 'https://example.test/git/package-dest.git',
+		token: 'tok',
+		expiresAt: '2026-09-08T01:00:00.000Z',
+	}))
+	mockModule.getArtifactsBinding.mockReturnValue({ fork })
+
+	await expect(
+		forkArtifactRepo({
+			env,
+			sourceRepoId: 'package-origin',
+			targetRepoId: 'package-dest',
+		}),
+	).resolves.toMatchObject({ name: 'package-dest' })
+	expect(fork).toHaveBeenCalledWith('package-origin', 'package-dest', {
+		readOnly: false,
+		defaultBranchOnly: true,
+	})
+})
+
+test('persistForkedArtifactRepoContents writes the full rewritten tree on loopback remotes', async () => {
+	mockModule.resolveExistingArtifactSourceRepo.mockResolvedValue({
+		info: async () => ({
+			remote: 'http://127.0.0.1:1/git/default/package-dest.git',
+		}),
+	})
+	mockModule.isLoopbackArtifactsRemote.mockReturnValue(true)
+	mockModule.writeArtifactSourceSnapshot.mockResolvedValue({
+		published_commit: 'commit-loopback',
+		files: {},
+	})
+
+	const publishedCommit = await persistForkedArtifactRepoContents({
+		env,
+		baseUrl: 'https://kody.test',
+		userId: 'user-1',
+		source,
+		originCommit: 'commit-origin',
+		changedFiles: { 'package.json': '{"name":"@jane/demo"}' },
+		files: {
+			'package.json': '{"name":"@jane/demo"}',
+			'poster.png': 'huge-binary',
+		},
+	})
+
+	expect(publishedCommit).toBe('commit-loopback')
+	expect(mockModule.writeArtifactSourceSnapshot).toHaveBeenCalledWith({
+		env,
+		repoId: 'package-dest',
+		files: {
+			'package.json': '{"name":"@jane/demo"}',
+			'poster.png': 'huge-binary',
+		},
+	})
+	expect(mockModule.syncArtifactSourceSnapshot).not.toHaveBeenCalled()
+})
+
+test('persistForkedArtifactRepoContents syncs only changed files on production remotes', async () => {
+	mockModule.resolveExistingArtifactSourceRepo.mockResolvedValue({
+		info: async () => ({
+			remote:
+				'https://acct.artifacts.cloudflare.net/git/default/package-dest.git',
+		}),
+	})
+	mockModule.isLoopbackArtifactsRemote.mockReturnValue(false)
+	mockModule.syncArtifactSourceSnapshot.mockResolvedValue('commit-edited')
+
+	const publishedCommit = await persistForkedArtifactRepoContents({
+		env,
+		baseUrl: 'https://kody.test',
+		userId: 'user-1',
+		source,
+		originCommit: 'commit-origin',
+		changedFiles: { 'package.json': '{"name":"@jane/demo"}' },
+		files: {
+			'package.json': '{"name":"@jane/demo"}',
+			'poster.png': 'huge-binary',
+		},
+	})
+
+	expect(publishedCommit).toBe('commit-edited')
+	expect(mockModule.updateEntitySource).toHaveBeenCalledWith(
+		env.APP_DB,
+		expect.objectContaining({
+			publishedCommit: 'commit-origin',
+		}),
+	)
+	expect(mockModule.syncArtifactSourceSnapshot).toHaveBeenCalledWith(
+		expect.objectContaining({
+			files: { 'package.json': '{"name":"@jane/demo"}' },
+		}),
+	)
+})

--- a/packages/worker/src/repo/artifact-repo-fork.node.test.ts
+++ b/packages/worker/src/repo/artifact-repo-fork.node.test.ts
@@ -71,7 +71,12 @@ const source = {
 	updated_at: '2026-09-08T00:00:00.000Z',
 }
 
+function resetArtifactRepoForkMocks() {
+	for (const mock of Object.values(mockModule)) mock.mockReset()
+}
+
 test('forkArtifactRepo delegates to the Artifacts binding fork', async () => {
+	resetArtifactRepoForkMocks()
 	const fork = vi.fn(async () => ({
 		id: 'repo_dest',
 		name: 'package-dest',
@@ -97,6 +102,7 @@ test('forkArtifactRepo delegates to the Artifacts binding fork', async () => {
 })
 
 test('persistForkedArtifactRepoContents writes the full rewritten tree on loopback remotes', async () => {
+	resetArtifactRepoForkMocks()
 	mockModule.resolveExistingArtifactSourceRepo.mockResolvedValue({
 		info: async () => ({
 			remote: 'http://127.0.0.1:1/git/default/package-dest.git',
@@ -140,6 +146,7 @@ test('persistForkedArtifactRepoContents writes the full rewritten tree on loopba
 })
 
 test('persistForkedArtifactRepoContents syncs only changed files on production remotes', async () => {
+	resetArtifactRepoForkMocks()
 	mockModule.resolveExistingArtifactSourceRepo.mockResolvedValue({
 		info: async () => ({
 			remote:
@@ -188,6 +195,7 @@ test('persistForkedArtifactRepoContents syncs only changed files on production r
 })
 
 test('persistForkedArtifactRepoContents stamps dest HEAD and rewrites only dest package.json when dest HEAD is not the listing pin', async () => {
+	resetArtifactRepoForkMocks()
 	mockModule.resolveExistingArtifactSourceRepo.mockResolvedValue({
 		info: async () => ({
 			remote:
@@ -268,8 +276,7 @@ test('persistForkedArtifactRepoContents stamps dest HEAD and rewrites only dest 
 })
 
 test('persistForkedArtifactRepoContents rejects a forked dest with no HEAD', async () => {
-	mockModule.updateEntitySource.mockClear()
-	mockModule.syncArtifactSourceSnapshot.mockClear()
+	resetArtifactRepoForkMocks()
 	mockModule.resolveExistingArtifactSourceRepo.mockResolvedValue({
 		info: async () => ({
 			remote:
@@ -300,7 +307,7 @@ test('persistForkedArtifactRepoContents rejects a forked dest with no HEAD', asy
 })
 
 test('persistForkedArtifactRepoContents fails closed when dest published_commit cannot be stamped', async () => {
-	mockModule.syncArtifactSourceSnapshot.mockClear()
+	resetArtifactRepoForkMocks()
 	mockModule.resolveExistingArtifactSourceRepo.mockResolvedValue({
 		info: async () => ({
 			remote:

--- a/packages/worker/src/repo/artifact-repo-fork.node.test.ts
+++ b/packages/worker/src/repo/artifact-repo-fork.node.test.ts
@@ -4,7 +4,9 @@ const mockModule = vi.hoisted(() => ({
 	getArtifactsBinding: vi.fn(),
 	isArtifactRepoNotFoundError: vi.fn(),
 	isLoopbackArtifactsRemote: vi.fn(),
+	resolveArtifactSourceHead: vi.fn(),
 	resolveExistingArtifactSourceRepo: vi.fn(),
+	readArtifactFileAtCommit: vi.fn(),
 	writeArtifactSourceSnapshot: vi.fn(),
 	writePublishedSourceSnapshot: vi.fn(),
 	updateEntitySource: vi.fn(),
@@ -18,8 +20,15 @@ vi.mock('./artifacts.ts', () => ({
 		mockModule.isArtifactRepoNotFoundError(...args),
 	isLoopbackArtifactsRemote: (...args: Array<unknown>) =>
 		mockModule.isLoopbackArtifactsRemote(...args),
+	resolveArtifactSourceHead: (...args: Array<unknown>) =>
+		mockModule.resolveArtifactSourceHead(...args),
 	resolveExistingArtifactSourceRepo: (...args: Array<unknown>) =>
 		mockModule.resolveExistingArtifactSourceRepo(...args),
+}))
+
+vi.mock('./artifact-file.ts', () => ({
+	readArtifactFileAtCommit: (...args: Array<unknown>) =>
+		mockModule.readArtifactFileAtCommit(...args),
 }))
 
 vi.mock('./artifact-source-snapshot.ts', () => ({
@@ -99,12 +108,14 @@ test('persistForkedArtifactRepoContents writes the full rewritten tree on loopba
 		files: {},
 	})
 
-	const publishedCommit = await persistForkedArtifactRepoContents({
+	const persisted = await persistForkedArtifactRepoContents({
 		env,
 		baseUrl: 'https://kody.test',
 		userId: 'user-1',
 		source,
 		originCommit: 'commit-origin',
+		expectedPackageScope: 'jane',
+		targetKodyId: 'demo',
 		changedFiles: { 'package.json': '{"name":"@jane/demo"}' },
 		files: {
 			'package.json': '{"name":"@jane/demo"}',
@@ -112,7 +123,10 @@ test('persistForkedArtifactRepoContents writes the full rewritten tree on loopba
 		},
 	})
 
-	expect(publishedCommit).toBe('commit-loopback')
+	expect(persisted).toEqual({
+		copiedOriginCommit: 'commit-origin',
+		destCommit: 'commit-loopback',
+	})
 	expect(mockModule.writeArtifactSourceSnapshot).toHaveBeenCalledWith({
 		env,
 		repoId: 'package-dest',
@@ -132,14 +146,20 @@ test('persistForkedArtifactRepoContents syncs only changed files on production r
 		}),
 	})
 	mockModule.isLoopbackArtifactsRemote.mockReturnValue(false)
+	mockModule.resolveArtifactSourceHead.mockResolvedValue({
+		branch: 'main',
+		commit: 'commit-origin',
+	})
 	mockModule.syncArtifactSourceSnapshot.mockResolvedValue('commit-edited')
 
-	const publishedCommit = await persistForkedArtifactRepoContents({
+	const persisted = await persistForkedArtifactRepoContents({
 		env,
 		baseUrl: 'https://kody.test',
 		userId: 'user-1',
 		source,
 		originCommit: 'commit-origin',
+		expectedPackageScope: 'jane',
+		targetKodyId: 'demo',
 		changedFiles: { 'package.json': '{"name":"@jane/demo"}' },
 		files: {
 			'package.json': '{"name":"@jane/demo"}',
@@ -147,7 +167,10 @@ test('persistForkedArtifactRepoContents syncs only changed files on production r
 		},
 	})
 
-	expect(publishedCommit).toBe('commit-edited')
+	expect(persisted).toEqual({
+		copiedOriginCommit: 'commit-origin',
+		destCommit: 'commit-edited',
+	})
 	expect(mockModule.updateEntitySource).toHaveBeenCalledWith(
 		env.APP_DB,
 		expect.objectContaining({
@@ -159,4 +182,116 @@ test('persistForkedArtifactRepoContents syncs only changed files on production r
 			files: { 'package.json': '{"name":"@jane/demo"}' },
 		}),
 	)
+	expect(mockModule.readArtifactFileAtCommit).not.toHaveBeenCalled()
+})
+
+test('persistForkedArtifactRepoContents stamps dest HEAD and rewrites only dest package.json when dest HEAD is not the listing pin', async () => {
+	mockModule.resolveExistingArtifactSourceRepo.mockResolvedValue({
+		info: async () => ({
+			remote:
+				'https://acct.artifacts.cloudflare.net/git/default/package-dest.git',
+		}),
+	})
+	mockModule.isLoopbackArtifactsRemote.mockReturnValue(false)
+	mockModule.resolveArtifactSourceHead.mockResolvedValue({
+		branch: 'main',
+		commit: 'commit-head',
+	})
+	const destHeadManifest = `${JSON.stringify(
+		{
+			name: '@kody/doom',
+			version: '2.0.0',
+			kody: { id: 'doom', extra: true },
+		},
+		null,
+		'\t',
+	)}\n`
+	mockModule.readArtifactFileAtCommit.mockResolvedValue(
+		new TextEncoder().encode(destHeadManifest),
+	)
+	mockModule.syncArtifactSourceSnapshot.mockResolvedValue('commit-rewritten')
+
+	const persisted = await persistForkedArtifactRepoContents({
+		env,
+		baseUrl: 'https://kody.test',
+		userId: 'user-1',
+		source,
+		originCommit: 'commit-pin',
+		expectedPackageScope: 'jane',
+		targetKodyId: 'demo',
+		changedFiles: {
+			'package.json': '{"name":"@jane/demo","version":"1.0.0"}',
+			'README.md': 'rewritten from the listing pin',
+		},
+		files: {
+			'package.json': '{"name":"@jane/demo","version":"1.0.0"}',
+			'README.md': 'rewritten from the listing pin',
+			'poster.png': 'huge-binary',
+		},
+	})
+
+	expect(persisted).toEqual({
+		copiedOriginCommit: 'commit-head',
+		destCommit: 'commit-rewritten',
+	})
+	expect(mockModule.updateEntitySource).toHaveBeenCalledWith(
+		env.APP_DB,
+		expect.objectContaining({
+			publishedCommit: 'commit-head',
+		}),
+	)
+	expect(mockModule.readArtifactFileAtCommit).toHaveBeenCalledWith({
+		env,
+		repoId: 'package-dest',
+		commit: 'commit-head',
+		filePath: 'package.json',
+	})
+	expect(mockModule.syncArtifactSourceSnapshot).toHaveBeenCalledWith(
+		expect.objectContaining({
+			files: {
+				'package.json': `${JSON.stringify(
+					{
+						name: '@jane/demo',
+						version: '2.0.0',
+						kody: { id: 'demo', extra: true },
+						private: true,
+					},
+					null,
+					'\t',
+				)}\n`,
+			},
+		}),
+	)
+})
+
+test('persistForkedArtifactRepoContents rejects a forked dest with no HEAD', async () => {
+	mockModule.updateEntitySource.mockClear()
+	mockModule.syncArtifactSourceSnapshot.mockClear()
+	mockModule.resolveExistingArtifactSourceRepo.mockResolvedValue({
+		info: async () => ({
+			remote:
+				'https://acct.artifacts.cloudflare.net/git/default/package-dest.git',
+		}),
+	})
+	mockModule.isLoopbackArtifactsRemote.mockReturnValue(false)
+	mockModule.resolveArtifactSourceHead.mockResolvedValue({
+		branch: 'main',
+		commit: null,
+	})
+
+	await expect(
+		persistForkedArtifactRepoContents({
+			env,
+			baseUrl: 'https://kody.test',
+			userId: 'user-1',
+			source,
+			originCommit: 'commit-pin',
+			expectedPackageScope: 'jane',
+			targetKodyId: 'demo',
+			changedFiles: { 'package.json': '{"name":"@jane/demo"}' },
+			files: { 'package.json': '{"name":"@jane/demo"}' },
+		}),
+	).rejects.toThrow(/default branch has no HEAD/)
+	expect(mockModule.updateEntitySource).not.toHaveBeenCalled()
+	expect(mockModule.syncArtifactSourceSnapshot).not.toHaveBeenCalled()
 })

--- a/packages/worker/src/repo/artifact-repo-fork.node.test.ts
+++ b/packages/worker/src/repo/artifact-repo-fork.node.test.ts
@@ -107,6 +107,7 @@ test('persistForkedArtifactRepoContents writes the full rewritten tree on loopba
 		published_commit: 'commit-loopback',
 		files: {},
 	})
+	mockModule.updateEntitySource.mockResolvedValue(true)
 
 	const persisted = await persistForkedArtifactRepoContents({
 		env,
@@ -150,6 +151,7 @@ test('persistForkedArtifactRepoContents syncs only changed files on production r
 		branch: 'main',
 		commit: 'commit-origin',
 	})
+	mockModule.updateEntitySource.mockResolvedValue(true)
 	mockModule.syncArtifactSourceSnapshot.mockResolvedValue('commit-edited')
 
 	const persisted = await persistForkedArtifactRepoContents({
@@ -209,6 +211,7 @@ test('persistForkedArtifactRepoContents stamps dest HEAD and rewrites only dest 
 	mockModule.readArtifactFileAtCommit.mockResolvedValue(
 		new TextEncoder().encode(destHeadManifest),
 	)
+	mockModule.updateEntitySource.mockResolvedValue(true)
 	mockModule.syncArtifactSourceSnapshot.mockResolvedValue('commit-rewritten')
 
 	const persisted = await persistForkedArtifactRepoContents({
@@ -293,5 +296,36 @@ test('persistForkedArtifactRepoContents rejects a forked dest with no HEAD', asy
 		}),
 	).rejects.toThrow(/default branch has no HEAD/)
 	expect(mockModule.updateEntitySource).not.toHaveBeenCalled()
+	expect(mockModule.syncArtifactSourceSnapshot).not.toHaveBeenCalled()
+})
+
+test('persistForkedArtifactRepoContents fails closed when dest published_commit cannot be stamped', async () => {
+	mockModule.syncArtifactSourceSnapshot.mockClear()
+	mockModule.resolveExistingArtifactSourceRepo.mockResolvedValue({
+		info: async () => ({
+			remote:
+				'https://acct.artifacts.cloudflare.net/git/default/package-dest.git',
+		}),
+	})
+	mockModule.isLoopbackArtifactsRemote.mockReturnValue(false)
+	mockModule.resolveArtifactSourceHead.mockResolvedValue({
+		branch: 'main',
+		commit: 'commit-head',
+	})
+	mockModule.updateEntitySource.mockResolvedValue(false)
+
+	await expect(
+		persistForkedArtifactRepoContents({
+			env,
+			baseUrl: 'https://kody.test',
+			userId: 'user-1',
+			source,
+			originCommit: 'commit-head',
+			expectedPackageScope: 'jane',
+			targetKodyId: 'demo',
+			changedFiles: { 'package.json': '{"name":"@jane/demo"}' },
+			files: { 'package.json': '{"name":"@jane/demo"}' },
+		}),
+	).rejects.toThrow(/could not be marked at dest HEAD commit-head/)
 	expect(mockModule.syncArtifactSourceSnapshot).not.toHaveBeenCalled()
 })

--- a/packages/worker/src/repo/artifact-repo-fork.ts
+++ b/packages/worker/src/repo/artifact-repo-fork.ts
@@ -1,9 +1,12 @@
+import { rewritePackageManifestForFork } from '#worker/community/fork-scan.ts'
 import { writePublishedSourceSnapshot } from '#worker/package-runtime/published-runtime-artifacts.ts'
+import { readArtifactFileAtCommit } from './artifact-file.ts'
 import { writeArtifactSourceSnapshot } from './artifact-source-snapshot.ts'
 import {
 	getArtifactsBinding,
 	isArtifactRepoNotFoundError,
 	isLoopbackArtifactsRemote,
+	resolveArtifactSourceHead,
 	resolveExistingArtifactSourceRepo,
 	type ArtifactBootstrapAccess,
 	type ArtifactCreateRepoResult,
@@ -28,17 +31,26 @@ export async function forkArtifactRepo(input: {
 	})
 }
 
+export type PersistForkedArtifactRepoResult = {
+	copiedOriginCommit: string
+	destCommit: string | null
+}
+
 /**
- * After a storage-layer Artifacts fork, rewrite only the changed files.
+ * After a storage-layer Artifacts fork, stamp dest HEAD and rewrite only
+ * what is safe against that tip.
  *
  * Loopback remotes (local mock) have no real git object store: the copied
  * mock snapshot is overwritten with the already-rewritten Worker tree so
  * dest contents match production's "fork + small commit" outcome without
  * opening a RepoSession.
  *
- * Production remotes apply `changedFiles` only through the existing-source
- * session path (applyEdits + publish). The origin tree is already in the
- * dest repo; binaries never become `Record<path, string>` RPC edits.
+ * Production remotes stamp `published_commit` to dest HEAD (the default
+ * branch tip Artifacts copied), then apply edits through the existing-source
+ * session path. When dest HEAD matches the listing pin used in prepare,
+ * `changedFiles` apply. When dest HEAD is ahead of that pin, only dest
+ * HEAD's `package.json` is rewritten so pin-relative edits cannot revert
+ * later origin commits.
  */
 export async function persistForkedArtifactRepoContents(input: {
 	env: Env
@@ -46,11 +58,13 @@ export async function persistForkedArtifactRepoContents(input: {
 	userId: string
 	source: EntitySourceRow
 	originCommit: string
+	expectedPackageScope: string
+	targetKodyId: string
 	changedFiles: Record<string, string>
 	files: Record<string, string>
 	bootstrapAccess?: ArtifactBootstrapAccess | null
 	serverTiming?: Array<ServerTimingEntry>
-}): Promise<string | null> {
+}): Promise<PersistForkedArtifactRepoResult> {
 	const destRepo = await resolveExistingArtifactSourceRepo(
 		input.env,
 		input.source.repo_id,
@@ -79,25 +93,86 @@ export async function persistForkedArtifactRepoContents(input: {
 					userId: input.source.user_id,
 					publishedCommit: snapshot.published_commit,
 				})
-				return snapshot.published_commit
+				return {
+					copiedOriginCommit: input.originCommit,
+					destCommit: snapshot.published_commit,
+				}
 			},
+		)
+	}
+
+	const destHead = await resolveArtifactSourceHead(
+		input.env,
+		input.source.repo_id,
+	)
+	if (!destHead.commit) {
+		throw new Error(
+			`Forked artifact repo "${input.source.repo_id}" default branch has no HEAD.`,
 		)
 	}
 
 	await updateEntitySource(input.env.APP_DB, {
 		id: input.source.id,
 		userId: input.source.user_id,
-		publishedCommit: input.originCommit,
+		publishedCommit: destHead.commit,
 	})
-	return await syncArtifactSourceSnapshot({
+	const filesToSync =
+		destHead.commit === input.originCommit
+			? input.changedFiles
+			: await buildDestHeadRewriteFiles({
+					env: input.env,
+					repoId: input.source.repo_id,
+					destHead: destHead.commit,
+					expectedPackageScope: input.expectedPackageScope,
+					targetKodyId: input.targetKodyId,
+				})
+	if (Object.keys(filesToSync).length === 0) {
+		return {
+			copiedOriginCommit: destHead.commit,
+			destCommit: destHead.commit,
+		}
+	}
+	const destCommit = await syncArtifactSourceSnapshot({
 		env: input.env,
 		baseUrl: input.baseUrl,
 		userId: input.userId,
 		sourceId: input.source.id,
-		files: input.changedFiles,
+		files: filesToSync,
 		bootstrapAccess: input.bootstrapAccess ?? null,
 		serverTiming: input.serverTiming,
 	})
+	return {
+		copiedOriginCommit: destHead.commit,
+		destCommit,
+	}
+}
+
+async function buildDestHeadRewriteFiles(input: {
+	env: Env
+	repoId: string
+	destHead: string
+	expectedPackageScope: string
+	targetKodyId: string
+}): Promise<Record<string, string>> {
+	const bytes = await readArtifactFileAtCommit({
+		env: input.env,
+		repoId: input.repoId,
+		commit: input.destHead,
+		filePath: 'package.json',
+	})
+	if (!bytes) {
+		throw new Error(
+			`Forked artifact repo "${input.repoId}" is missing package.json at ${input.destHead}.`,
+		)
+	}
+	const manifestContent = new TextDecoder().decode(bytes)
+	const rewritten = rewritePackageManifestForFork({
+		manifestContent,
+		expectedPackageScope: input.expectedPackageScope,
+		targetKodyId: input.targetKodyId,
+	})
+	if (rewritten.content === manifestContent) return {}
+	return { 'package.json': rewritten.content }
 }
 
 export function shouldFallbackFromArtifactFork(error: unknown) {

--- a/packages/worker/src/repo/artifact-repo-fork.ts
+++ b/packages/worker/src/repo/artifact-repo-fork.ts
@@ -88,11 +88,16 @@ export async function persistForkedArtifactRepoContents(input: {
 					},
 					files: input.files,
 				})
-				await updateEntitySource(input.env.APP_DB, {
+				const marked = await updateEntitySource(input.env.APP_DB, {
 					id: input.source.id,
 					userId: input.source.user_id,
 					publishedCommit: snapshot.published_commit,
 				})
+				if (!marked) {
+					throw new Error(
+						`Forked source "${input.source.id}" could not be marked at dest commit ${snapshot.published_commit}.`,
+					)
+				}
 				return {
 					copiedOriginCommit: input.originCommit,
 					destCommit: snapshot.published_commit,
@@ -111,11 +116,16 @@ export async function persistForkedArtifactRepoContents(input: {
 		)
 	}
 
-	await updateEntitySource(input.env.APP_DB, {
+	const marked = await updateEntitySource(input.env.APP_DB, {
 		id: input.source.id,
 		userId: input.source.user_id,
 		publishedCommit: destHead.commit,
 	})
+	if (!marked) {
+		throw new Error(
+			`Forked source "${input.source.id}" could not be marked at dest HEAD ${destHead.commit}.`,
+		)
+	}
 	const filesToSync =
 		destHead.commit === input.originCommit
 			? input.changedFiles

--- a/packages/worker/src/repo/artifact-repo-fork.ts
+++ b/packages/worker/src/repo/artifact-repo-fork.ts
@@ -1,0 +1,105 @@
+import { writePublishedSourceSnapshot } from '#worker/package-runtime/published-runtime-artifacts.ts'
+import { writeArtifactSourceSnapshot } from './artifact-source-snapshot.ts'
+import {
+	getArtifactsBinding,
+	isArtifactRepoNotFoundError,
+	isLoopbackArtifactsRemote,
+	resolveExistingArtifactSourceRepo,
+	type ArtifactBootstrapAccess,
+	type ArtifactCreateRepoResult,
+} from './artifacts.ts'
+import { updateEntitySource } from './entity-sources.ts'
+import { syncArtifactSourceSnapshot } from './source-sync.ts'
+import { type EntitySourceRow } from './types.ts'
+import {
+	pushServerTiming,
+	type ServerTimingEntry,
+} from '#worker/server-timing.ts'
+
+export async function forkArtifactRepo(input: {
+	env: Env
+	sourceRepoId: string
+	targetRepoId: string
+}): Promise<ArtifactCreateRepoResult> {
+	const binding = getArtifactsBinding(input.env)
+	return await binding.fork(input.sourceRepoId, input.targetRepoId, {
+		readOnly: false,
+		defaultBranchOnly: true,
+	})
+}
+
+/**
+ * After a storage-layer Artifacts fork, rewrite only the changed files.
+ *
+ * Loopback remotes (local mock) have no real git object store: the copied
+ * mock snapshot is overwritten with the already-rewritten Worker tree so
+ * dest contents match production's "fork + small commit" outcome without
+ * opening a RepoSession.
+ *
+ * Production remotes apply `changedFiles` only through the existing-source
+ * session path (applyEdits + publish). The origin tree is already in the
+ * dest repo; binaries never become `Record<path, string>` RPC edits.
+ */
+export async function persistForkedArtifactRepoContents(input: {
+	env: Env
+	baseUrl: string
+	userId: string
+	source: EntitySourceRow
+	originCommit: string
+	changedFiles: Record<string, string>
+	files: Record<string, string>
+	bootstrapAccess?: ArtifactBootstrapAccess | null
+	serverTiming?: Array<ServerTimingEntry>
+}): Promise<string | null> {
+	const destRepo = await resolveExistingArtifactSourceRepo(
+		input.env,
+		input.source.repo_id,
+	)
+	const info = destRepo ? await destRepo.info() : null
+	if (info?.remote && isLoopbackArtifactsRemote(info.remote)) {
+		return await pushServerTiming(
+			input.serverTiming,
+			'fork-loopback-snapshot',
+			async () => {
+				const snapshot = await writeArtifactSourceSnapshot({
+					env: input.env,
+					repoId: input.source.repo_id,
+					files: input.files,
+				})
+				await writePublishedSourceSnapshot({
+					env: input.env,
+					source: {
+						...input.source,
+						published_commit: snapshot.published_commit,
+					},
+					files: input.files,
+				})
+				await updateEntitySource(input.env.APP_DB, {
+					id: input.source.id,
+					userId: input.source.user_id,
+					publishedCommit: snapshot.published_commit,
+				})
+				return snapshot.published_commit
+			},
+		)
+	}
+
+	await updateEntitySource(input.env.APP_DB, {
+		id: input.source.id,
+		userId: input.source.user_id,
+		publishedCommit: input.originCommit,
+	})
+	return await syncArtifactSourceSnapshot({
+		env: input.env,
+		baseUrl: input.baseUrl,
+		userId: input.userId,
+		sourceId: input.source.id,
+		files: input.changedFiles,
+		bootstrapAccess: input.bootstrapAccess ?? null,
+		serverTiming: input.serverTiming,
+	})
+}
+
+export function shouldFallbackFromArtifactFork(error: unknown) {
+	return isArtifactRepoNotFoundError(error)
+}

--- a/packages/worker/src/repo/artifacts-mock-cloudflare.node.test.ts
+++ b/packages/worker/src/repo/artifacts-mock-cloudflare.node.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from 'vitest'
 import { startCloudflareMock } from '#worker/test-support/cloudflare-mock-server.ts'
+import { writeArtifactSourceSnapshot } from './artifact-source-snapshot.ts'
 import { getArtifactsBinding } from './artifacts.ts'
 
 const mockAccountId = 'cf_account_mock_123'
@@ -63,4 +64,29 @@ test('Cloudflare mock implements the Artifacts REST workflow used in local dev',
 		artifactRepoCount?: number
 	}
 	expect(meta.artifactRepoCount).toBe(1)
+
+	const sourceFiles = {
+		'package.json': '{"name":"@owner/demo"}',
+		'poster.png': 'not-sent-over-rpc-in-production',
+	}
+	await writeArtifactSourceSnapshot({
+		env: {
+			...env,
+			CLOUDFLARE_API_SOURCE_SNAPSHOTS: 'true',
+		},
+		repoId: repoName,
+		files: sourceFiles,
+	})
+	const forkedName = `${repoName}-fork`
+	const forked = await binding.fork(repoName, forkedName, { readOnly: false })
+	expect(forked.name).toBe(forkedName)
+	const destSnapshot = await fetch(
+		`${mock.origin}/client/v4/accounts/${mockAccountId}/artifacts/namespaces/default/repos/${forkedName}/mock-source-snapshot`,
+		{ headers: { Authorization: `Bearer ${mock.token}` } },
+	)
+	expect(destSnapshot.status).toBe(200)
+	const destPayload = (await destSnapshot.json()) as {
+		result?: { files?: Record<string, string> }
+	}
+	expect(destPayload.result?.files).toEqual(sourceFiles)
 }, 75_000)

--- a/packages/worker/src/repo/artifacts.node.test.ts
+++ b/packages/worker/src/repo/artifacts.node.test.ts
@@ -19,8 +19,10 @@ const {
 	buildArtifactsGitAuth,
 	buildAuthenticatedArtifactsRemote,
 	ensureArtifactRepoReady,
+	artifactsBindingErrorCode,
 	getArtifactsBinding,
 	getArtifactsNamespace,
+	isArtifactRepoNotFoundError,
 	parseArtifactTokenSecret,
 	resolveArtifactDefaultBranchHead,
 	resolveArtifactSourceHead,
@@ -982,4 +984,32 @@ test('artifacts REST client forks a repo without sending file contents', async (
 		token: 'art_v1_fork?expires=1760000000',
 	})
 	fetchMock.mockRestore()
+})
+
+test('isArtifactRepoNotFoundError matches repo-scoped messages only', () => {
+	expect(
+		isArtifactRepoNotFoundError(
+			new Error('Artifacts repo "package-origin" was not found.'),
+		),
+	).toBe(true)
+	expect(
+		isArtifactRepoNotFoundError(
+			new Error('Repository not found: package-origin'),
+		),
+	).toBe(true)
+	expect(isArtifactRepoNotFoundError(new Error('Repo not found'))).toBe(true)
+	expect(
+		artifactsBindingErrorCode(
+			new Error('ArtifactsError: Repository not found: package-origin'),
+		),
+	).toBe('NOT_FOUND')
+	expect(isArtifactRepoNotFoundError(new Error('Secret not found'))).toBe(false)
+	expect(
+		isArtifactRepoNotFoundError(
+			new Error('git: repository not found on the remote'),
+		),
+	).toBe(false)
+	expect(isArtifactRepoNotFoundError(new Error('User was not found'))).toBe(
+		false,
+	)
 })

--- a/packages/worker/src/repo/artifacts.node.test.ts
+++ b/packages/worker/src/repo/artifacts.node.test.ts
@@ -923,3 +923,63 @@ test('artifacts REST logs redact plaintext tokens on revoke', async () => {
 	info.mockRestore()
 	fetchMock.mockRestore()
 })
+
+test('artifacts REST client forks a repo without sending file contents', async () => {
+	const fetchMock = vi
+		.spyOn(globalThis, 'fetch')
+		.mockImplementation(async (input, init) => {
+			const url = new URL(String(input))
+			const method = init?.method ?? 'GET'
+			expect(method).toBe('POST')
+			expect(url.pathname).toBe(
+				'/client/v4/accounts/acct/artifacts/namespaces/default/repos/package-origin/fork',
+			)
+			const body = JSON.parse(String(init?.body ?? '{}')) as Record<
+				string,
+				unknown
+			>
+			expect(body).toEqual({
+				name: 'package-dest',
+				read_only: false,
+				default_branch_only: true,
+			})
+			expect(JSON.stringify(body)).not.toContain('files')
+			return new Response(
+				JSON.stringify({
+					success: true,
+					result: {
+						id: 'repo_dest',
+						name: 'package-dest',
+						description: null,
+						default_branch: 'main',
+						remote:
+							'https://acct.artifacts.cloudflare.net/git/default/package-dest.git',
+						token: 'art_v1_fork?expires=1760000000',
+					},
+					errors: [],
+					messages: [],
+				}),
+				{
+					status: 200,
+					headers: { 'content-type': 'application/json' },
+				},
+			)
+		})
+
+	const env = {
+		CLOUDFLARE_ACCOUNT_ID: 'acct',
+		CLOUDFLARE_API_TOKEN: 'token-123',
+		CLOUDFLARE_API_BASE_URL: 'https://api.example.com',
+	} as Env
+	await expect(
+		getArtifactsBinding(env).fork('package-origin', 'package-dest', {
+			readOnly: false,
+			defaultBranchOnly: true,
+		}),
+	).resolves.toMatchObject({
+		id: 'repo_dest',
+		name: 'package-dest',
+		token: 'art_v1_fork?expires=1760000000',
+	})
+	fetchMock.mockRestore()
+})

--- a/packages/worker/src/repo/artifacts.ts
+++ b/packages/worker/src/repo/artifacts.ts
@@ -69,6 +69,22 @@ export type ArtifactDeleteRepoResult = {
 	alreadyDeleted: boolean
 }
 
+export type ArtifactCreateRepoResult = {
+	id: string
+	name: string
+	description: string | null
+	defaultBranch: string
+	remote: string
+	token: string
+	expiresAt: string
+}
+
+export type ArtifactForkRepoOpts = {
+	description?: string
+	readOnly?: boolean
+	defaultBranchOnly?: boolean
+}
+
 export type ArtifactNamespaceBinding = {
 	create(
 		name: string,
@@ -77,15 +93,17 @@ export type ArtifactNamespaceBinding = {
 			readOnly?: boolean
 			setDefaultBranch?: string
 		},
-	): Promise<{
-		id: string
-		name: string
-		description: string | null
-		defaultBranch: string
-		remote: string
-		token: string
-		expiresAt: string
-	}>
+	): Promise<ArtifactCreateRepoResult>
+	/**
+	 * Copy `sourceName` to `targetName` at the Artifacts storage layer.
+	 * Blobs stay in the git object store — callers must not materialize the
+	 * tree in a Worker or Durable Object isolate.
+	 */
+	fork(
+		sourceName: string,
+		targetName: string,
+		opts?: ArtifactForkRepoOpts,
+	): Promise<ArtifactCreateRepoResult>
 	get(name: string): Promise<ArtifactGetRepoResult>
 	delete(name: string): Promise<ArtifactDeleteRepoResult>
 	list(opts?: { limit?: number; cursor?: string }): Promise<{
@@ -234,6 +252,12 @@ function artifactsBindingErrorCode(error: unknown) {
 	if (/^Import in progress(?::|\b)/i.test(message)) {
 		return 'IMPORT_IN_PROGRESS'
 	}
+	if (/^Fork in progress(?::|\b)/i.test(message)) {
+		return 'FORK_IN_PROGRESS'
+	}
+	if (/^Memory limit(?::|\b)/i.test(message)) {
+		return 'MEMORY_LIMIT'
+	}
 	return null
 }
 
@@ -380,10 +404,45 @@ function adaptNativeArtifactsBinding(
 				if (code === 'NOT_FOUND') {
 					return { status: 'not_found' as const }
 				}
-				if (code === 'IMPORT_IN_PROGRESS') {
+				if (code === 'IMPORT_IN_PROGRESS' || code === 'FORK_IN_PROGRESS') {
 					return { status: 'importing' as const, retryAfter: 5 }
 				}
 				throw error
+			}
+		},
+		fork: async (sourceName, targetName, opts) => {
+			if (rest) {
+				return await rest.fork(sourceName, targetName, opts)
+			}
+			const handle = await getNativeRepoOrThrow(native, sourceName)
+			if (typeof handle.fork !== 'function') {
+				throw new Error(
+					'Artifacts native fork is unavailable and no REST credentials are configured.',
+				)
+			}
+			const created = await handle.fork(targetName, {
+				...(opts?.description !== undefined
+					? { description: opts.description }
+					: {}),
+				...(opts?.readOnly !== undefined ? { readOnly: opts.readOnly } : {}),
+				...(opts?.defaultBranchOnly !== undefined
+					? { defaultBranchOnly: opts.defaultBranchOnly }
+					: {}),
+			})
+			return {
+				id: created.id,
+				name: created.name,
+				description: created.description,
+				defaultBranch: created.defaultBranch,
+				remote: created.remote,
+				token: created.token,
+				expiresAt: resolveCreatedTokenExpiry({
+					token: created.token,
+					tokenExpiresAt:
+						typeof created.tokenExpiresAt === 'string'
+							? created.tokenExpiresAt
+							: null,
+				}),
 			}
 		},
 		delete: async (name) => {
@@ -503,6 +562,34 @@ function createArtifactsRestBinding(env: Env, namespace: string) {
 			return {
 				status: 'ready' as const,
 				repo: repoHandle(name),
+			}
+		},
+		fork: async (sourceName, targetName, opts) => {
+			const result = await requestArtifactsApi<ArtifactRestCreateRepoResult>(
+				client,
+				{
+					method: 'POST',
+					path: `${basePath}/repos/${encodeURIComponent(sourceName)}/fork`,
+					body: {
+						name: targetName,
+						...(opts?.description ? { description: opts.description } : {}),
+						...(opts?.readOnly !== undefined
+							? { read_only: opts.readOnly }
+							: {}),
+						...(opts?.defaultBranchOnly !== undefined
+							? { default_branch_only: opts.defaultBranchOnly }
+							: {}),
+					},
+				},
+			)
+			return {
+				id: result.id,
+				name: result.name,
+				description: result.description,
+				defaultBranch: result.default_branch,
+				remote: result.remote,
+				token: result.token,
+				expiresAt: parseArtifactTokenExpiry(result.token),
 			}
 		},
 		delete: async (name) => {
@@ -851,6 +938,16 @@ export function isLoopbackArtifactsRemote(remote: string) {
 	} catch {
 		return false
 	}
+}
+
+export function isArtifactRepoNotFoundError(error: unknown) {
+	if (artifactsBindingErrorCode(error) === 'NOT_FOUND') {
+		return true
+	}
+	if (!(error instanceof Error)) {
+		return false
+	}
+	return /was not found|not found/i.test(error.message)
 }
 
 function isArtifactRepoAlreadyExistsError(error: unknown) {

--- a/packages/worker/src/repo/artifacts.ts
+++ b/packages/worker/src/repo/artifacts.ts
@@ -236,7 +236,7 @@ function readArtifactsErrorMessage(error: unknown) {
 	return ''
 }
 
-function artifactsBindingErrorCode(error: unknown) {
+export function artifactsBindingErrorCode(error: unknown) {
 	if (isArtifactsBindingError(error)) return error.code
 	// JSRPC may flatten the class so `name` is Error and the message is
 	// `ArtifactsError: Repository not found: <repo>`. Strip that prefix,
@@ -947,7 +947,9 @@ export function isArtifactRepoNotFoundError(error: unknown) {
 	if (!(error instanceof Error)) {
 		return false
 	}
-	return /was not found|not found/i.test(error.message)
+	return /^(?:Artifacts repo "[^"]+" was not found\.?|Repo(?:sitory)? not found\b)/i.test(
+		error.message,
+	)
 }
 
 function isArtifactRepoAlreadyExistsError(error: unknown) {

--- a/packages/worker/src/test-support/artifacts-msw-handlers.ts
+++ b/packages/worker/src/test-support/artifacts-msw-handlers.ts
@@ -107,6 +107,60 @@ export function createArtifactsMswHandlers(input: {
 			return envelope(repo)
 		}),
 		http.post(
+			`${apiOrigin}${reposPath}/:repoName/fork`,
+			async ({ params, request }) => {
+				const sourceName = decodeURIComponent(String(params.repoName))
+				const source = repos.get(sourceName)
+				if (!source) {
+					return errorEnvelope(404, 1002, 'repo not found')
+				}
+				const body = (await request.json()) as {
+					name?: string
+					description?: string | null
+					read_only?: boolean
+				}
+				const targetName = body.name?.trim() ?? ''
+				if (!targetName) {
+					return errorEnvelope(400, 1001, 'target repo name is required')
+				}
+				if (repos.has(targetName)) {
+					return errorEnvelope(409, 1003, 'repo already exists')
+				}
+				const now = new Date().toISOString()
+				const repo: StoredRepo = {
+					id: `repo_${crypto.randomUUID()}`,
+					name: targetName,
+					description:
+						typeof body.description === 'string'
+							? body.description
+							: source.description,
+					default_branch: source.default_branch,
+					created_at: now,
+					updated_at: now,
+					last_push_at: source.last_push_at,
+					source: source.name,
+					read_only: body.read_only === true,
+					remote: `http://127.0.0.1:1/git/${namespace}/${targetName}.git`,
+				}
+				repos.set(targetName, repo)
+				const sourceSnapshot = snapshots.get(sourceName)
+				if (sourceSnapshot) {
+					snapshots.set(targetName, {
+						published_commit: sourceSnapshot.published_commit,
+						files: { ...sourceSnapshot.files },
+					})
+				}
+				return envelope({
+					id: repo.id,
+					name: repo.name,
+					description: repo.description,
+					default_branch: repo.default_branch,
+					remote: repo.remote,
+					token: `art_v1_${targetName}?expires=${Math.floor(Date.now() / 1000) + 3600}`,
+				})
+			},
+		),
+		http.post(
 			`${apiOrigin}${reposPath}/:repoName/mock-source-snapshot`,
 			async ({ params, request }) => {
 				const repoName = decodeURIComponent(String(params.repoName))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Make community fork/install work for large public packages (for example `@kody/doom`) without loading the full file tree into a Durable Object isolate, and show an honest error when isolate memory still runs out.

## Why

`communityFork` / one-click install copied the listing by materializing every file as a `Record<path, string>` and sending those writes through `RepoSession.bootstrapSource`. Large binaries (base64 icons, posters) blew the DO isolate. The UI then said “Unable to install this public package.” even though the real failure was `Durable Object's isolate exceeded its memory limit and was reset.` Fork count stayed 0.

## Summary

- **Error honesty:** isolate memory / CPU reset and Artifacts `MEMORY_LIMIT` (including flattened JSRPC `ArtifactsError: Memory limit …` messages) map to `CommunityForkResourceLimitError`. Install returns **503** with: the package is too large to finish forking, nothing was copied, fork count did not change. Logs keep the original failure; the toast stays sanitized.
- **Storage-layer copy:** when the listing has an origin Artifacts repo, persist calls `POST .../repos/{source}/fork`. The tree stays in git storage. Only rewritten files are applied afterward.
- **Dest HEAD stamp:** persist stamps `published_commit` to dest HEAD (the default-branch tip Artifacts copied), not the listing pin. `community_forks.origin_commit` records that copied SHA. When dest HEAD is ahead of the pin, persist re-derives the `package.json` rewrite from dest HEAD instead of applying pin-relative edits. Persist fails closed if the dest `entity_sources` row cannot be stamped. Failed persist also deletes the dest Artifacts repo by package id, and warns when that delete returns false (the helper does not reject).
- **Fallback:** only repo-scoped Artifacts not-found errors (`NOT_FOUND`, `Artifacts repo "…" was not found`, `Repo not found` / `Repository not found`) fall back to the old full-tree snapshot sync.
- Local mock + MSW fork now copy the mock snapshot so dest contents match the source.

## Testing

- Node unit: error mapping (including flattened MEMORY_LIMIT), repo-scoped not-found matching, dest HEAD ≠ listing pin, stamp fail-closed, dest-repo cleanup warn, install handler 503 with original-error logs.
- Workers: `community-flow.workers.test.ts` (fork records `artifacts-fork` timing).
- `test:push` on this branch: 929 node files / 2955 tests, 94 workers files / 341 tests.
- Preview (`https://kody-pr-2178.kody-a99.workers.dev`, merge of `0b2be3c0`): signed in as seed user. `GET /community.json` is an empty catalog. `POST /community/missing-listing/install.json` returns 404 `Community listing not found.` The isolated preview D1 has no public listings, so a real fork/install of `@kody/doom` cannot be exercised there.

## Residual risk

- `prepareCommunityFork` still reads the listing KV snapshot into the **Worker** for rewrite, scan, and one-click checks/projection.
- Production rewrite of `package.json` still opens a RepoSession to `applyEdits` the small changed set. A package that OOMs on clone could still fail; the new error mapping covers that.
- Listings with no origin Artifacts repo still use the in-memory snapshot sync.
- When dest HEAD is ahead of the listing pin, only dest HEAD `package.json` is rewritten. Other pin-relative self-reference edits are not applied onto that newer tree.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `6a599ced` · **Head:** `3ad58f4e`

**Classification:** extends — Artifacts binding gains `fork`, and community persist copies at the storage layer instead of bootstrapping the full tree through a RepoSession.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `community-listings` | assistant | extends — fork persist, dest HEAD stamp, and install error mapping |
| `artifacts-repos` | storage | extends — namespace `fork` on REST and native adapters |
| `repo-sessions` | runtime | composes — changed-file `applyEdits` only after storage copy |

### Change flow

Community install/fork copies the origin Artifacts repo remotely, stamps dest HEAD, then writes only rewritten files that are safe against that tip. Isolate memory failures return 503 without incrementing fork count.

```mermaid
sequenceDiagram
	actor User
	participant communityListings as community-listings
	participant artifactsRepos as artifacts-repos
	participant repoSessions as repo-sessions
	User->>communityListings: POST install.json or communityFork
	communityListings->>artifactsRepos: POST repos/source/fork
	Note over artifactsRepos: origin blobs stay in git storage
	communityListings->>artifactsRepos: resolve dest HEAD after fork
	communityListings->>communityListings: stamp published_commit to dest HEAD
	alt dest HEAD matches listing pin
		communityListings->>repoSessions: applyEdits of prepared rewritten files
	else dest HEAD is ahead of pin
		communityListings->>artifactsRepos: read dest HEAD package.json
		communityListings->>repoSessions: applyEdits of dest HEAD rewrite only
	end
	alt isolate memory or MEMORY_LIMIT
		communityListings-->>User: 503 package too large, fork count unchanged
	else success
		communityListings-->>User: inert fork or installed package
	end
```

### Invariants

Per-user isolation is unchanged: dest repo id is still `package-{newPackageId}` owned by the forker, and only public/active listings can be forked.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b2919783-a795-4092-b098-9ac0360c267b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b2919783-a795-4092-b098-9ac0360c267b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Community repository forks now preserve source snapshots and history more reliably.
  * Added support for forking repositories through the Artifacts service.
  * Forks apply only changed files and handle destinations that have advanced beyond the listing version.

* **Bug Fixes**
  * Resource-limit failures now return a clear service-unavailable response without exposing internal details.
  * Failed resource-limited forks perform cleanup correctly.
  * Forks now stop safely when destination updates cannot be recorded.

* **Documentation**
  * Updated community package documentation to describe revised fork behavior and timing details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->