### PR TITLE
Speed up signed-in homepage SSR

### DIFF
--- a/docs/contributing/architecture/youtube-watch.md
+++ b/docs/contributing/architecture/youtube-watch.md
@@ -47,7 +47,9 @@ Failed playlist fetches fail open: env extra ids and banner hrefs still work.
 
 SSR documents without `?youtubeId=` skip the playlist fetch. They still merge
 env extras, the sample id, and enabled-banner hrefs (from the same
-`listEnabledSiteBanners` read as the site-banner loader). `?youtubeId=` HTML and
+`listEnabledSiteBanners` read as the site-banner loader). Home starts that
+shared read next to auth and code-runs so signed-in `/` (always `no-store`) does
+not wait for banners only after those finish. `?youtubeId=` HTML and
 `/youtube-thumb/:videoId` still load playlists. Shared watch links are full
 document loads, so they still resolve playlist ids.
 

--- a/packages/worker/src/app/handlers/home.node.test.ts
+++ b/packages/worker/src/app/handlers/home.node.test.ts
@@ -6,10 +6,7 @@ import {
 	type AuthSession,
 } from '#app/auth-session.ts'
 import { createHomeHandler } from '#app/handlers/home.ts'
-import {
-	loadOnboardingData,
-	loadPublicOnboardingData,
-} from '#app/onboarding-data.ts'
+import { loadOnboardingData } from '#app/onboarding-data.ts'
 import { hasResolvedRequestFeatureFlags } from '#app/request-feature-flags-cache.ts'
 import { loadSessionInfo } from '#app/session-info.ts'
 import { renderAppPage } from '#app/ssr-render.tsx'
@@ -22,64 +19,14 @@ vi.mock('#worker/usage/code-runs-window.ts', () => ({
 	loadPublicCodeRunsWindow: vi.fn(async () => null),
 }))
 
-vi.mock('#app/onboarding-data.ts', () => ({
-	loadOnboardingData: vi.fn(async () => ({
-		ok: true,
-		loggedIn: true,
-		username: 'home-user',
-		mcpServerUrl: 'https://example.com/mcp',
-		setupPrompt: '',
-		discoveryPrompt: '',
-		persistPrompt: '',
-		hasAccessWin: false,
-		hasSecondMcpClient: false,
-		hasMcpClient: false,
-		connectedAgents: [],
-		secondAgentStandardGift: {
-			received: false,
-			active: false,
-			status: 'none',
-			expiresAt: null,
-			grantedAt: null,
-		},
-		emailVerified: false,
-		needsOnboarding: true,
-		featuredListings: [],
-		featuredMcpServers: [],
-		customMcpServers: [],
-		persistedPackageName: null,
-		accessWinMemorySubject: null,
-		checklist: null,
-	})),
-	loadPublicOnboardingData: vi.fn(() => ({
-		ok: true,
-		loggedIn: false,
-		username: null,
-		mcpServerUrl: 'https://example.com/mcp',
-		setupPrompt: '',
-		discoveryPrompt: '',
-		persistPrompt: '',
-		hasAccessWin: false,
-		hasSecondMcpClient: false,
-		hasMcpClient: false,
-		connectedAgents: [],
-		secondAgentStandardGift: {
-			received: false,
-			active: false,
-			status: 'none',
-			expiresAt: null,
-			grantedAt: null,
-		},
-		emailVerified: false,
-		needsOnboarding: true,
-		featuredListings: [],
-		featuredMcpServers: [],
-		customMcpServers: [],
-		persistedPackageName: null,
-		accessWinMemorySubject: null,
-		checklist: null,
-	})),
-}))
+vi.mock('#app/onboarding-data.ts', async (importOriginal) => {
+	const actual =
+		await importOriginal<typeof import('#app/onboarding-data.ts')>()
+	return {
+		...actual,
+		loadOnboardingData: vi.fn(actual.loadOnboardingData),
+	}
+})
 
 vi.mock('#app/ssr-render.tsx', () => ({
 	renderAppPage: vi.fn(),
@@ -239,18 +186,23 @@ test('authenticated home SSR prefetches flags while loading page data', async ()
 		'compute-overage-charging': true,
 	})
 	expect(counts.batchSizes).toEqual([2, 2])
-	expect(loadOnboardingData).toHaveBeenCalledWith(
-		expect.objectContaining({ featuredMcpServers: [] }),
-	)
+	expect(loadOnboardingData).not.toHaveBeenCalled()
+	const homeInput = vi.mocked(renderAppPage).mock.calls.at(-1)?.[0]
+	expect(homeInput?.listedBanners).toEqual(expect.any(Promise))
+	expect(homeInput?.loaderData?.onboarding).toMatchObject({
+		loggedIn: true,
+		username: 'home-user',
+		emailVerified: false,
+		featuredMcpServers: [],
+		setupPrompt: '',
+		persistPrompt: '',
+	})
+	expect(
+		homeInput?.loaderData?.onboarding?.discoveryPrompt.length,
+	).toBeGreaterThan(0)
 })
 
 test('anonymous home SSR omits the unused onboarding chooser catalog', async () => {
-	const actual = await vi.importActual<
-		typeof import('#app/onboarding-data.ts')
-	>('#app/onboarding-data.ts')
-	vi.mocked(loadPublicOnboardingData).mockImplementation(
-		actual.loadPublicOnboardingData,
-	)
 	vi.mocked(renderAppPage).mockResolvedValue(new Response('ok'))
 
 	setAuthSessionSecret(testCookieSecret)

--- a/packages/worker/src/app/handlers/home.ts
+++ b/packages/worker/src/app/handlers/home.ts
@@ -10,10 +10,8 @@ import {
 	prefersMarkdown,
 	withVaryAccept,
 } from '#app/markdown-negotiation.ts'
-import {
-	loadOnboardingData,
-	loadPublicOnboardingData,
-} from '#app/onboarding-data.ts'
+import { loadHomePageOnboardingData } from '#app/onboarding-data.ts'
+import { loadEnabledSiteBannersForSsr } from '#app/site-banner-ssr.ts'
 import { renderAppPage } from '#app/ssr-render.tsx'
 import { resolveSignupMode } from '#app/signup-mode-setting.ts'
 import { pickWalkthroughHosts } from '#universal/walkthrough-hosts.ts'
@@ -38,6 +36,9 @@ export function createHomeHandler(env: Env) {
 
 			const serverTiming: Array<ServerTimingEntry> = []
 			const walkthroughHosts = pickWalkthroughHosts()
+			// Start the banner list with auth and code-runs so signed-in /
+			// (always no-store) does not pay that D1 after those finish.
+			const listedBanners = loadEnabledSiteBannersForSsr(env)
 			const [codeRunsWindow, signupMode, user] = await Promise.all([
 				pushServerTiming(serverTiming, 'code-runs', () =>
 					loadPublicCodeRunsWindow(env),
@@ -48,44 +49,10 @@ export function createHomeHandler(env: Env) {
 				}),
 			])
 			const codeRuns = { ok: true as const, window: codeRunsWindow }
-			if (!user) {
-				// Anonymous visits still embed discovery-prompt copy so the
-				// hero does not pop it in after /onboarding.json. The MCP
-				// chooser catalog and setup prompts stay off / — home does
-				// not render them, and they dominated rmx-data (~7 kB).
-				return withAgentDiscoveryLinkHeaders(
-					withVaryAccept(
-						await renderAppPage({
-							request,
-							env,
-							loaderData: {
-								onboarding: {
-									...loadPublicOnboardingData({
-										env,
-										requestUrl: request.url,
-									}),
-									featuredMcpServers: [],
-									setupPrompt: '',
-									persistPrompt: '',
-								},
-								codeRuns,
-								walkthroughHosts,
-								signupMode,
-							},
-							serverTiming,
-						}),
-					),
-					origin,
-				)
-			}
-
-			const onboarding = await loadOnboardingData({
+			const onboarding = loadHomePageOnboardingData({
 				env,
 				requestUrl: request.url,
-				stableUserId: user.mcpUser.userId,
-				username: user.username,
-				emailVerified: user.emailVerified,
-				featuredMcpServers: [],
+				user,
 			})
 			return withAgentDiscoveryLinkHeaders(
 				withVaryAccept(
@@ -98,6 +65,7 @@ export function createHomeHandler(env: Env) {
 							walkthroughHosts,
 							signupMode,
 						},
+						listedBanners,
 						serverTiming,
 					}),
 				),

--- a/packages/worker/src/app/onboarding-data.node.test.ts
+++ b/packages/worker/src/app/onboarding-data.node.test.ts
@@ -4,6 +4,7 @@ import {
 	buildFirstWinPrompt,
 	buildMcpServerUrl,
 	buildPersistFirstPackagePrompt,
+	loadHomePageOnboardingData,
 	loadOnboardingData,
 	loadPublicOnboardingData,
 } from '#app/onboarding-data.ts'
@@ -68,6 +69,31 @@ test('onboarding data builds the MCP URL and derives incomplete setup from verif
 	expect(publicData.setupPrompt.length).toBeGreaterThan(0)
 	expect(publicData.discoveryPrompt).toContain('https://heykody.dev')
 	expect(publicData.persistPrompt).toContain('https://heykody.dev')
+	const homeAnonymous = loadHomePageOnboardingData({
+		env: { APP_BASE_URL: 'https://heykody.dev' },
+		requestUrl: 'https://heykody.dev/',
+	})
+	expect(homeAnonymous.loggedIn).toBe(false)
+	expect(homeAnonymous.featuredMcpServers).toEqual([])
+	expect(homeAnonymous.setupPrompt).toBe('')
+	expect(homeAnonymous.persistPrompt).toBe('')
+	expect(homeAnonymous.discoveryPrompt).toContain('https://heykody.dev')
+
+	const homeSignedIn = loadHomePageOnboardingData({
+		env: { APP_BASE_URL: 'https://heykody.dev' },
+		requestUrl: 'https://heykody.dev/',
+		user: { username: 'kent', emailVerified: true },
+	})
+	expect(homeSignedIn).toMatchObject({
+		loggedIn: true,
+		username: 'kent',
+		emailVerified: true,
+		needsOnboarding: false,
+		featuredMcpServers: [],
+		setupPrompt: '',
+		persistPrompt: '',
+	})
+
 	expect(publicData.featuredMcpServers.map((server) => server.id)).toContain(
 		'notion',
 	)

--- a/packages/worker/src/app/onboarding-data.ts
+++ b/packages/worker/src/app/onboarding-data.ts
@@ -107,6 +107,40 @@ export function loadPublicOnboardingData(input: {
 	}
 }
 
+/**
+ * Homepage SSR only needs login, email verification, and the discovery
+ * prompt. Listing inbound MCP grants (and labeling each client) is for
+ * `/onboarding`, not `/`.
+ */
+export function loadHomePageOnboardingData(input: {
+	env: Pick<OnboardingEnv, 'APP_BASE_URL'>
+	requestUrl: string | URL
+	user?: { username: string; emailVerified: boolean } | null
+}): OnboardingLoaderData {
+	const publicData = loadPublicOnboardingData({
+		env: input.env,
+		requestUrl: input.requestUrl,
+	})
+	if (!input.user) {
+		return {
+			...publicData,
+			featuredMcpServers: [],
+			setupPrompt: '',
+			persistPrompt: '',
+		}
+	}
+	return {
+		...publicData,
+		loggedIn: true,
+		username: input.user.username,
+		emailVerified: input.user.emailVerified,
+		needsOnboarding: !input.user.emailVerified,
+		featuredMcpServers: [],
+		setupPrompt: '',
+		persistPrompt: '',
+	}
+}
+
 export async function loadOnboardingData(input: {
 	env: OnboardingEnv
 	requestUrl: string | URL

--- a/packages/worker/src/app/ssr-render.tsx
+++ b/packages/worker/src/app/ssr-render.tsx
@@ -20,6 +20,7 @@ import {
 	loadEnabledSiteBannersForSsr,
 	loadSiteBannerLoaderData,
 } from '#app/site-banner-ssr.ts'
+import { type SiteBannerRecord } from '#universal/site-banners.ts'
 import { loadYoutubeWatchLoaderData } from '#app/youtube-watch-ssr.ts'
 import { parseYoutubeWatchSearch } from '#universal/youtube-watch.ts'
 import { getInlineStylesheet } from '#app/inline-stylesheet.ts'
@@ -77,6 +78,10 @@ export type RenderAppPageInput = {
 	extraSetCookies?: Array<string>
 	/** Loader phases already recorded for this request; session + ssr append. */
 	serverTiming?: Array<ServerTimingEntry>
+	/** Shared enabled-banner read started by the handler, if any. */
+	listedBanners?:
+		| Promise<ReadonlyArray<SiteBannerRecord>>
+		| ReadonlyArray<SiteBannerRecord>
 }
 
 export async function renderAppPage(input: RenderAppPageInput) {
@@ -100,7 +105,7 @@ export async function renderAppPage(input: RenderAppPageInput) {
 		() => loadSessionInfo(request, env),
 	)
 	const requestUrl = new URL(request.url)
-	const listedBanners = loadEnabledSiteBannersForSsr(env)
+	const listedBanners = input.listedBanners ?? loadEnabledSiteBannersForSsr(env)
 	const [siteBanner, youtubeWatch] = await Promise.all([
 		pushServerTiming(serverTiming, 'siteBanner', () =>
 			loadSiteBannerLoaderData({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Make logged-in `/` feel closer to the anonymous cache hit. Signed-in HTML is always `no-store`, so every visit pays the full worker path.

## Why

Anonymous `/` is in good shape (weekly `site-perf` `ok`, miss ~150 ms, hit ~60 ms). Logged-in `/` still listed every inbound MCP OAuth grant and labeled each client **after** auth, then waited for the `site_banners` D1 read. Home only uses login, email verification, and the discovery prompt. Kent’s session has many grants, so that listing is the likely “still feels slow when logged in” cost.

Production seed login is blocked by Turnstile, so this is from the handler path plus local tests, not a signed-in production timing.

## Summary

- Add `loadHomePageOnboardingData`: same slim homepage payload for anonymous and signed-in, no OAuth grant listing
- Start the shared enabled-banner read next to auth and code-runs, and pass it into `renderAppPage`
- Keep `/onboarding` on the full `loadOnboardingData` path

## Testing

- `npx vitest run --project node-unit packages/worker/src/app/handlers/home.node.test.ts packages/worker/src/app/onboarding-data.node.test.ts`
- Pre-push: `test:node` 2962 passed, `test:workers` 341 passed

## System changes

Low risk. Home CTAs for a verified user stay “Connect your agent” / “Open your account”.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `51540f89` · **Head:** `2d7c9de5`

**Classification:** composes — homepage SSR skips unused inbound-grant work and starts the existing banner read earlier.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `app-ui` | surfaces | composes — home handler uses a slim onboarding snapshot and passes a shared banner promise into SSR |
| `app-sessions` | auth | composes — `onboarding-data.ts` is under this root; session auth is unchanged |

### Change flow

Signed-in homepage SSR no longer lists OAuth grants before rendering.

```mermaid
sequenceDiagram
	actor visitor as Signed-in visitor
	participant appUi as app-ui
	visitor->>appUi: GET /
	appUi->>appUi: start site_banners read with auth
	appUi->>appUi: slim homepage onboarding snapshot
	Note over appUi: no listUserOAuthGrants or client labeling
	appUi-->>visitor: no-store HTML
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-37f8639b-8a61-4a07-a70a-92e3a420656f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-37f8639b-8a61-4a07-a70a-92e3a420656f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved homepage loading by fetching site banners in parallel with other page data, reducing delays for signed-in visitors.

- **Bug Fixes**
  - Standardized homepage rendering for anonymous and signed-in visitors.
  - Signed-in visitors now receive consistent onboarding status and account verification information during server-rendered page loads.
  - Homepage banner data is reused during rendering to avoid duplicate loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->