### PR TITLE
Allow Fathom sendBeacon in CSP and document the pageview cliff

### DIFF
--- a/docs/contributing/environment-variables.md
+++ b/docs/contributing/environment-variables.md
@@ -82,8 +82,11 @@ Optional Wrangler `var` (public, non-secret; see
   `packages/worker/wrangler.jsonc`; it is intentionally unset for local dev,
   preview, and tests so those environments never send pageviews. The CSP in
   `packages/worker/src/app/security-headers.ts` allowlists
-  `https://cdn.usefathom.com` in `script-src` and `img-src` for the tracker and
-  its image beacon.
+  `https://cdn.usefathom.com` in `script-src`, `img-src`, and `connect-src` for
+  the tracker, its image pageview beacon, and `sendBeacon` duration/event pings.
+  After a production domain change, also update the site's Allowed domains list
+  in the Fathom dashboard (Settings → Sites → site → Firewall); the API token
+  cannot read or write that list.
 
 ## YouTube watch overlay
 

--- a/docs/contributing/environment-variables.md
+++ b/docs/contributing/environment-variables.md
@@ -84,9 +84,11 @@ Optional Wrangler `var` (public, non-secret; see
   `packages/worker/src/app/security-headers.ts` allowlists
   `https://cdn.usefathom.com` in `script-src`, `img-src`, and `connect-src` for
   the tracker, its image pageview beacon, and `sendBeacon` duration/event pings.
-  After a production domain change, also update the site's Allowed domains list
-  in the Fathom dashboard (Settings → Sites → site → Firewall); the API token
-  cannot read or write that list.
+  A 200 collect GIF is not proof of ingest: Fathom still bot-filters datacenter
+  IPs. After a production domain change, confirm the dashboard shows the new
+  hostname and check the toolbar bot icon; Site Firewall Allowed domains is
+  optional (empty does not filter). The API token cannot read or write firewall
+  settings.
 
 ## YouTube watch overlay
 

--- a/docs/contributing/operator-accounts.md
+++ b/docs/contributing/operator-accounts.md
@@ -376,11 +376,14 @@ Committed Wrangler var: `FATHOM_SITE_ID=WKKSDJGN`
 `packages/worker/src/app/security-headers.ts` (`script-src`, `img-src`, and
 `connect-src`).
 
-Dashboard: [app.usefathom.com](https://app.usefathom.com/). No secret. After
-changing `APP_BASE_URL`, open Settings → Sites → **kody.codes** → Firewall and
-put the live hostname (`kody.codes`) on Allowed domains. A leftover
-`heykody.app` / `heykody.dev` allowlist drops every `kody.codes` pageview while
-still returning a 200 GIF. The API token cannot read or write firewall settings.
+Dashboard: [app.usefathom.com](https://app.usefathom.com/). No secret. The
+collect GIF always returns 200, including for traffic Fathom later drops
+(datacenter / bot filter, or a Site Firewall allow/block list). After a domain
+change, reload the site dashboard and confirm hostname `https://kody.codes`
+appears; the toolbar bot icon shows how many requests were classified as
+non-human. Settings → Sites → **kody.codes** → Firewall → Domains is optional
+hygiene (empty list does not filter; if you use Allow, include `kody.codes`).
+The API token cannot read or write firewall settings.
 
 Recovery: Fathom account login. Losing the site id only drops analytics; the app
 stays up.

--- a/docs/contributing/operator-accounts.md
+++ b/docs/contributing/operator-accounts.md
@@ -373,9 +373,14 @@ Privacy-first pageviews on production SSR pages only.
 Committed Wrangler var: `FATHOM_SITE_ID=WKKSDJGN`
 (`packages/worker/wrangler.jsonc`). Unset in local, preview, and test. Script:
 `https://cdn.usefathom.com/script.js` (`data-spa=auto`). CSP allowlist in
-`packages/worker/src/app/security-headers.ts`.
+`packages/worker/src/app/security-headers.ts` (`script-src`, `img-src`, and
+`connect-src`).
 
-Dashboard: [app.usefathom.com](https://app.usefathom.com/). No secret.
+Dashboard: [app.usefathom.com](https://app.usefathom.com/). No secret. After
+changing `APP_BASE_URL`, open Settings → Sites → **kody.codes** → Firewall and
+put the live hostname (`kody.codes`) on Allowed domains. A leftover
+`heykody.app` / `heykody.dev` allowlist drops every `kody.codes` pageview while
+still returning a 200 GIF. The API token cannot read or write firewall settings.
 
 Recovery: Fathom account login. Losing the site id only drops analytics; the app
 stays up.

--- a/docs/contributing/security.md
+++ b/docs/contributing/security.md
@@ -133,11 +133,13 @@ package-app surfaces:
 
 - `Content-Security-Policy` with `script-src 'self' https://cdn.usefathom.com`
   (no `'unsafe-inline'`; the Fathom Analytics tracker is the only allowed
-  external script and its image beacon is also allowed in `img-src`; the
+  external script; its image pageview beacon is allowed in `img-src` and its
+  `sendBeacon` duration/event pings are allowed in `connect-src`; the
   scroll-restoration restore script is an inline classic script allowed only by
   its sha256 hash), `frame-ancestors 'none'`, `base-uri 'self'`,
   `object-src 'none'`, `form-action 'self'`, `worker-src 'self' blob:` (for
-  Sentry Session Replay), and same-origin `connect-src`. The client bundle loads
+  Sentry Session Replay), and `connect-src` limited to `'self'` plus the Fathom,
+  Cloudflare Web Analytics, and Turnstile beacon hosts. The client bundle loads
   as an external module. `style-src` allows `'unsafe-inline'` because
   SSR-streamed styles arrive as inline `<style>` tags; style injection is far
   lower risk than script injection.

--- a/packages/worker/src/app/security-headers.ts
+++ b/packages/worker/src/app/security-headers.ts
@@ -25,14 +25,14 @@ import { scrollRestorationInlineScriptCspHash } from '#universal/router-scroll-r
  *   of the OAuth consent screen and account pages.
  * - `base-uri`, `object-src`, and `form-action` are locked to prevent base-tag
  *   injection, plugin content, and form exfiltration to third-party origins.
- * - `connect-src 'self'` is safe because the first-party client only calls
- *   same-origin JSON endpoints; all third-party calls happen server-side.
- *   Browser Sentry envelopes stay same-origin too via the `/sentry-tunnel`
- *   route (see `handlers/sentry-tunnel.ts`).
- * - `https://cdn.usefathom.com` in `script-src` and `img-src` allows the
- *   Fathom Analytics tracker (rendered only when FATHOM_SITE_ID is set, see
- *   `ssr-document.tsx`): the script loads from that host and reports
- *   pageviews via an image beacon to the same host.
+ * - `connect-src` stays `'self'` for first-party JSON and the `/sentry-tunnel`
+ *   route (see `handlers/sentry-tunnel.ts`). The listed third-party hosts are
+ *   the only browser beacons that leave the origin.
+ * - `https://cdn.usefathom.com` in `script-src`, `img-src`, and `connect-src`
+ *   allows the Fathom Analytics tracker (rendered only when FATHOM_SITE_ID is
+ *   set, see `ssr-document.tsx`): the script loads from that host, reports
+ *   pageviews via an image beacon, and uses `navigator.sendBeacon` for
+ *   visit-duration pings and `trackEvent`.
  * - Cloudflare Web Analytics: injected at the edge by Cloudflare,
  *   privacy-preserving, no cookies. The beacon script loads from
  *   `https://static.cloudflareinsights.com` (`script-src`) and POSTs to
@@ -58,7 +58,7 @@ const contentSecurityPolicy = [
 	"font-src 'self' data:",
 	"style-src 'self' 'unsafe-inline'",
 	`script-src 'self' ${scrollRestorationInlineScriptCspHash} https://cdn.usefathom.com https://static.cloudflareinsights.com https://challenges.cloudflare.com`,
-	"connect-src 'self' https://cloudflareinsights.com https://challenges.cloudflare.com",
+	"connect-src 'self' https://cdn.usefathom.com https://cloudflareinsights.com https://challenges.cloudflare.com",
 	'frame-src https://challenges.cloudflare.com https://www.youtube-nocookie.com',
 	"worker-src 'self' blob:",
 ].join('; ')

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -651,7 +651,9 @@ test('renderAppPage embeds the Fathom tracker only when FATHOM_SITE_ID is set', 
 		'https://cdn.usefathom.com https://static.cloudflareinsights.com',
 	)
 	expect(csp).toContain("img-src 'self' data: blob: https://cdn.usefathom.com")
-	expect(csp).toContain("connect-src 'self' https://cloudflareinsights.com")
+	expect(csp).toContain(
+		"connect-src 'self' https://cdn.usefathom.com https://cloudflareinsights.com",
+	)
 })
 
 test('renderAppPage emits a pre-hydration scroll restoration script in the document body', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Unblock Fathom `sendBeacon` (visit duration and `trackEvent`) on production `kody.codes`. Pageviews themselves were never a CSP problem.

## Why

**Pageview zero (dashboard, already fixed):** Fathom site `WKKSDJGN` (kody.codes) Firewall → Domains **Allow** list contained only `heykody.dev` and `heykody.app`. After `#1418` moved the canonical origin to `kody.codes`, collect GIFs still returned 200 and were discarded. Adding `kody.codes` to that Allow list restored realtime + pageviews immediately. Do not treat this as a code or CSP defect.

**Events / duration (this PR):** current Fathom `script.js` uses `navigator.sendBeacon` for duration pings and `trackEvent`. First-party CSP `connect-src` listed Cloudflare Insights and Turnstile but not `https://cdn.usefathom.com`, so those beacons were blocked. Pageview GIFs use `img-src`, which already allowed the CDN.

## Summary

- Add `https://cdn.usefathom.com` to first-party CSP `connect-src`.
- Update comments/docs that claimed image-only beacons.
- Assert `connect-src` includes `cdn.usefathom.com` on the Fathom SSR render test.

## Testing

- `npm run test:push`: Node 2962, Workers 341.
- Preview `https://kody-pr-2180.kody-a99.workers.dev` (anonymous `/` and signed-in `/account`): `connect-src` includes `https://cdn.usefathom.com`.
- Production after merge (`c1645b46`): `/health` matches; live CSP `connect-src` includes `https://cdn.usefathom.com`.
- Fathom Allow list now includes `kody.codes` (dashboard). Pageviews are a hostname-allowlist concern, not this diff.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `e816baec` · **Head:** `f71bd689`

**Classification:** extends — first-party CSP `connect-src` now allows the Fathom beacon host; no new primitives.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `app-ui` | surfaces | extends — first-party HTML CSP `connect-src` gains `https://cdn.usefathom.com` |

### Change flow

Trusted HTML responses allow Fathom `sendBeacon` in addition to the existing image pageview beacon.

```mermaid
sequenceDiagram
	actor Browser
	participant appUi as app-ui
	participant fathomCdn as cdn.usefathom.com
	Browser->>appUi: GET /
	appUi-->>Browser: CSP connect-src includes cdn.usefathom.com
	Browser->>fathomCdn: img pageview beacon
	Browser->>fathomCdn: sendBeacon duration and trackEvent
```

### Before / after

```text
connect-src 'self' https://cloudflareinsights.com https://challenges.cloudflare.com
connect-src 'self' https://cdn.usefathom.com https://cloudflareinsights.com https://challenges.cloudflare.com
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-235bcea4-89b6-401b-92e0-70fe19b6099b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-235bcea4-89b6-401b-92e0-70fe19b6099b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Fathom Analytics guidance with expanded CSP requirements and beacon behavior details.
  * Added troubleshooting guidance for domain changes, bot filtering, firewall settings, and dashboard verification.

* **Bug Fixes**
  * Allowed Fathom Analytics event and duration beacons through the site’s Content Security Policy.

* **Tests**
  * Updated security checks to verify the Fathom connection endpoint is permitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->