### PR TITLE
Link factory on /pricing to the factory guide

### DIFF
--- a/packages/worker/client/routes/pricing.tsx
+++ b/packages/worker/client/routes/pricing.tsx
@@ -16,6 +16,7 @@ import {
 	publicSignupPrimaryCta,
 	type PublicSignupCta,
 } from '#universal/public-signup-copy.ts'
+import { routes } from '#universal/routes.ts'
 import { parseSignupMode, type SignupMode } from '#universal/signup-mode.ts'
 import { colors, radius, typography } from '#universal/styles/tokens.ts'
 import {
@@ -53,6 +54,7 @@ type LimitGroup = {
 
 const count = new Intl.NumberFormat('en-US')
 const size = new Intl.NumberFormat('en-US', { maximumFractionDigits: 1 })
+const factoryGuideHref = routes.guideDetail.href({ slug: 'kody-factory' })
 
 const limitGroups: ReadonlyArray<LimitGroup> = [
 	{
@@ -158,7 +160,8 @@ export function PricingRoute(handle: Handle) {
 						</h2>
 						<p mix={css(planPriceCss)}>$0</p>
 						<p mix={css(planCopyCss)}>
-							The whole factory. 5 jobs, no faster than every 15 minutes.
+							The whole {factoryGuideLink()}. 5 jobs, no faster than every 15
+							minutes.
 						</p>
 						{isSignedIn ? (
 							<a href="/account" mix={css(planPillButtonCss)}>
@@ -189,7 +192,8 @@ export function PricingRoute(handle: Handle) {
 						</p>
 						<p mix={css(planPriceNoteCss)}>$10/mo billed annually</p>
 						<p mix={css(planCopyCss)}>
-							Same factory. More room for jobs, workflows, and daily volume.
+							Same {factoryGuideLink()}. More room for jobs, workflows, and
+							daily volume.
 						</p>
 						{renderPaidPlanCta(isSignedIn, signedOutCta)}
 					</section>
@@ -206,8 +210,8 @@ export function PricingRoute(handle: Handle) {
 						</p>
 						<p mix={css(planPriceNoteCss)}>$40/mo billed annually</p>
 						<p mix={css(planCopyCss)}>
-							Same factory. More room for storage, jobs, workflows, and daily
-							volume.
+							Same {factoryGuideLink()}. More room for storage, jobs, workflows,
+							and daily volume.
 						</p>
 						{renderPaidPlanCta(isSignedIn, signedOutCta)}
 					</section>
@@ -310,6 +314,10 @@ export function PricingRoute(handle: Handle) {
 			</section>
 		)
 	}
+}
+
+function factoryGuideLink() {
+	return <a href={factoryGuideHref}>factory</a>
 }
 
 function renderPaidPlanCta(isSignedIn: boolean, signedOutCta: PublicSignupCta) {
@@ -442,6 +450,11 @@ const planCopyCss = {
 	fontSize: '0.98rem',
 	maxWidth: '34ch',
 	textWrap: 'pretty' as const,
+	'& a': {
+		color: colors.primaryText,
+		textDecoration: 'underline',
+		textUnderlineOffset: '0.15em',
+	},
 	'@media (max-width: 680px)': {
 		marginInline: 'auto',
 	},

--- a/packages/worker/src/app/ssr-render-pricing.node.test.ts
+++ b/packages/worker/src/app/ssr-render-pricing.node.test.ts
@@ -84,4 +84,6 @@ test('renderAppPage renders the redesigned pricing page', async () => {
 	expect(html).toContain('mailto:kody@kody.codes')
 	expect(html).toContain('Unique worker days per month')
 	expect(html).toContain('Durable Object rows read per month')
+	expect(html).toMatch(/<a[^>]*href="\/guides\/kody-factory"[^>]*>factory<\/a>/)
+	expect(html.match(/href="\/guides\/kody-factory"/g)?.length).toBe(3)
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Point people on `/pricing` at the factory guide when they see the word factory, so the Free (and paid) blurbs explain the product without expanding copy.

## Why

Kent (via Pam) from Matt livestream feedback: linking **factory** is clearer than expanding Free copy.

## Summary

- Free card still says `The whole factory. 5 jobs, no faster than every 15 minutes.`
- The word factory links to `/guides/kody-factory` via `routes.guideDetail`.
- Same link on Standard and Pro “Same factory…” lines for consistency.
- In-prose link styling matches other marketing guide links (primary color, underline).

## Testing

- Focused: `vitest run --project node-unit packages/worker/src/app/ssr-render-pricing.node.test.ts`
- Pre-push hook: `test:node` and `test:workers`
- CI: Validate (Static, Node, Workers, MCP, E2E) green
- Bugbot: no issues
- Preview `https://kody-pr-2181.kody-a99.workers.dev/pricing`: all three cards link `factory` to `/guides/kody-factory`. Clicked Free and Pro in the browser.

![Preview /pricing cards with factory links](https://cursor.com/artifacts/c/art-6dc69c70-8d04-4d0b-ac10-7d40b56405d9)
![Factory guide after clicking factory](https://cursor.com/artifacts/c/art-e7aea4b9-df8e-4af7-b3ad-3345272b8c95)
<a href="https://cursor.com/agents/bc-135a44b6-172e-445a-8a61-1d1346f6e01d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpricing_factory_guide_link_walkthrough.mp4"><img src="https://cursor.com/artifacts/c/art-3369f6a6-8450-4702-9429-f3b170c26793" alt="pricing_factory_guide_link_walkthrough.mp4" /></a>

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `c1645b46` · **Head:** `915f09ac`

**Classification:** composes — no primitives added or changed; this PR wires an existing guide route into pricing copy.

### Primitives touched

| Primitive | Group    | Impact   |
| --------- | -------- | -------- |
| `app-ui`  | surfaces | composes |

### Change flow

Anonymous visitors on `/pricing` can follow the word factory to the existing factory guide.

```mermaid
sequenceDiagram
	actor Visitor
	participant appUi as app-ui
	Visitor->>appUi: GET /pricing
	appUi->>Visitor: Free Standard Pro blurbs with factory link
	Visitor->>appUi: click factory
	appUi->>Visitor: GET /guides/kody-factory
```

### Before / after

**Before:** `The whole factory.` / `Same factory.` as plain text.

**After:** the word `factory` is an in-prose link to `/guides/kody-factory` on Free, Standard, and Pro.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-135a44b6-172e-445a-8a61-1d1346f6e01d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-135a44b6-172e-445a-8a61-1d1346f6e01d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added links from each pricing plan’s “factory” reference to the Kody Factory guide.
  - Styled the new guide links to match the pricing page and display an underline.

- **Tests**
  - Added coverage confirming all three pricing plans link to the Kody Factory guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->