### PR TITLE
Document Fathom hostname Allow list after the pageview drop

### DIFF
--- a/docs/contributing/environment-variables.md
+++ b/docs/contributing/environment-variables.md
@@ -84,11 +84,12 @@ Optional Wrangler `var` (public, non-secret; see
   `packages/worker/src/app/security-headers.ts` allowlists
   `https://cdn.usefathom.com` in `script-src`, `img-src`, and `connect-src` for
   the tracker, its image pageview beacon, and `sendBeacon` duration/event pings.
-  A 200 collect GIF is not proof of ingest: Fathom still bot-filters datacenter
-  IPs. After a production domain change, confirm the dashboard shows the new
-  hostname and check the toolbar bot icon; Site Firewall Allowed domains is
-  optional (empty does not filter). The API token cannot read or write firewall
-  settings.
+  After a production domain change, add the new hostname to the site's Firewall
+  → Domains **Allow** list (Settings → Sites → site → Firewall). A leftover
+  `heykody.*` Allow list discards `kody.codes` pageviews while the collect GIF
+  still returns 200. The API token cannot read or write that list. `connect-src`
+  is required for `sendBeacon` duration/events, not for the image pageview
+  beacon.
 
 ## YouTube watch overlay
 

--- a/docs/contributing/operator-accounts.md
+++ b/docs/contributing/operator-accounts.md
@@ -376,14 +376,14 @@ Committed Wrangler var: `FATHOM_SITE_ID=WKKSDJGN`
 `packages/worker/src/app/security-headers.ts` (`script-src`, `img-src`, and
 `connect-src`).
 
-Dashboard: [app.usefathom.com](https://app.usefathom.com/). No secret. The
-collect GIF always returns 200, including for traffic Fathom later drops
-(datacenter / bot filter, or a Site Firewall allow/block list). After a domain
-change, reload the site dashboard and confirm hostname `https://kody.codes`
-appears; the toolbar bot icon shows how many requests were classified as
-non-human. Settings → Sites → **kody.codes** → Firewall → Domains is optional
-hygiene (empty list does not filter; if you use Allow, include `kody.codes`).
-The API token cannot read or write firewall settings.
+Dashboard: [app.usefathom.com](https://app.usefathom.com/). No secret. After
+changing `APP_BASE_URL`, open Settings → Sites → **kody.codes** → Firewall →
+Domains and put the live hostname (`kody.codes`) on the **Allow** list. A
+leftover `heykody.app` / `heykody.dev` Allow list drops every `kody.codes`
+pageview while still returning a 200 GIF. The collect GIF is not proof of
+ingest. The API token cannot read or write firewall settings. First-party CSP
+`connect-src` must also include `https://cdn.usefathom.com` for `sendBeacon`
+duration and `trackEvent` (pageviews use the image beacon).
 
 Recovery: Fathom account login. Losing the site id only drops analytics; the app
 stays up.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Record the confirmed Fathom dashboard cause of the `kody.codes` pageview cliff so the next domain change does not repeat it.

## Why

Site `WKKSDJGN` Firewall → Domains **Allow** listed only `heykody.dev` and `heykody.app`. Collect GIFs for `kody.codes` returned 200 and were discarded until `kody.codes` was added. `#2180` already shipped CSP `connect-src` for `sendBeacon` duration/events; this follow-up replaces the interim “allowlist is optional hygiene” wording that landed in that PR.

## Summary

- Operator and env-var docs: after an `APP_BASE_URL` change, Settings → Sites → site → Firewall → Domains **Allow** must include the live hostname.
- A leftover `heykody.*` Allow list drops `kody.codes` pageviews while the GIF stays 200.
- `connect-src https://cdn.usefathom.com` is for duration/`trackEvent`, not pageviews.

## Testing

- Docs-only. Local `test:push` green (Node 2970, Workers 341).
- Production CSP from `#2180` already includes Fathom `connect-src`.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `a7aca63a` · **Head:** `c014b2f8`

**Classification:** composes — contributing docs only; no primitive code change.

### Primitives touched

_None. Unmatched paths are contributing docs._

### Change flow

Operator docs now name the Fathom Firewall Allow list that discarded `kody.codes` pageviews.

```mermaid
sequenceDiagram
	actor Operator
	participant docs as contributing docs
	participant fathomDash as Fathom dashboard
	Operator->>docs: read Fathom recovery
	docs-->>Operator: Settings, Sites, Firewall, Domains Allow must include kody.codes
	Operator->>fathomDash: add kody.codes to Allow list
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-235bcea4-89b6-401b-92e0-70fe19b6099b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-235bcea4-89b6-401b-92e0-70fe19b6099b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Fathom Analytics troubleshooting guidance for production hostname changes.
  * Clarified that live hostnames must be added to the Firewall Domains Allow list.
  * Added warnings about retired hostnames potentially causing pageviews to be dropped despite successful responses.
  * Documented CSP requirements for `sendBeacon` duration and event tracking.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->