### PR TITLE
Default Reply-To to support@ on outbound kody@ mail

### DIFF
--- a/docs/contributing/adding-capabilities.md
+++ b/docs/contributing/adding-capabilities.md
@@ -193,8 +193,9 @@ documented metadata projection for activity on public community listings.
 reserved system sender (`kody@<apex>` by default) to arbitrary recipients, so
 the platform can answer a feedback report or a system-inbox message. It never
 touches a user mailbox, sender identity, or plan entitlement, and it carries its
-own per-sender daily cap. User mail keeps its own boundary: `emailSend` remains
-notify-self and `emailReply` remains reply-only.
+own per-sender daily cap. Mail from `kody@` sets Reply-To to `support@<apex>`
+unless `reply_to` is provided. User mail keeps its own boundary: `emailSend`
+remains notify-self and `emailReply` remains reply-only.
 
 Platform feedback list/get is the only admin capability surface that reviews
 user-authored private text, and only after explicit approval. Community activity

--- a/docs/contributing/architecture/authentication.md
+++ b/docs/contributing/architecture/authentication.md
@@ -224,8 +224,10 @@ accounts are created verified. Unverified accounts can sign in and see their
 status on `/account`.
 
 Verification mail is sent from `kody@<SYSTEM_EMAIL_DOMAIN>` through Cloudflare
-Email Sending. Provider accept is not delivery: the send stores
-`provider_message_id` in `transactional_email_delivery_index` and sets
+Email Sending and sets `Reply-To: support@<same domain>` so human replies land
+on support rather than the transactional sender. Provider accept is not
+delivery: the send stores `provider_message_id` in
+`transactional_email_delivery_index` and sets
 `users.email_verification_delivery_status` to `accepted`. Later Cloudflare
 lifecycle events (`delivered`, `bounced`, `failed`, `rejected`, `complained`)
 update that status. A Fastmail-style sender-domain/IP block (`RLR613`, `RLR813`,

--- a/docs/contributing/architecture/authorization.md
+++ b/docs/contributing/architecture/authorization.md
@@ -302,15 +302,15 @@ review. Reviewer identity, reviewer timestamp, and admin note are internal
 review metadata.
 
 A successful resolve or dismiss transition emails the submitter from the
-platform transactional sender (`kody@<apex>`). The mail uses the standard
-transactional template: the decision, thanks, and an invitation to send more
-feedback through their agent. Optional `user_message` is included only in that
-email and is never stored. `admin_note` is never mailed. The status update
-succeeds even if the email cannot send. Triage does not email. Already-resolved
-or already-dismissed no-op updates do not send, so existing terminal records are
-not backfilled. Sends are skipped when the submitter has no current account
-email, outbound email is paused, or the account is suspended. One email is sent
-per feedback id per terminal status.
+platform transactional sender (`kody@<apex>`), with `Reply-To: support@<apex>`.
+The mail uses the standard transactional template: the decision, thanks, and an
+invitation to send more feedback through their agent. Optional `user_message` is
+included only in that email and is never stored. `admin_note` is never mailed.
+The status update succeeds even if the email cannot send. Triage does not email.
+Already-resolved or already-dismissed no-op updates do not send, so existing
+terminal records are not backfilled. Sends are skipped when the submitter has no
+current account email, outbound email is paused, or the account is suspended.
+One email is sent per feedback id per terminal status.
 
 After a consent-gated submission is persisted, Kody enqueues its id for durable
 `platform.feedback.submitted` package-subscription delivery. The Queue consumer

--- a/docs/use/email-primitives.md
+++ b/docs/use/email-primitives.md
@@ -36,8 +36,10 @@ platform-assigned sender address.
   unsubscribe footer and `List-Unsubscribe` headers), and platform-feedback
   resolve/dismiss mail) and the operator-owned system inboxes (`kody`,
   `support`, `abuse`, `postmaster`, `security`, `admin`, and `psl` at the apex
-  route to Kody's system inbox, so replies to transactional mail land there).
-  All other apex mail is rejected.
+  route to Kody's system inbox). Mail from `kody@<apex>` sets
+  `Reply-To: support@<apex>` unless the caller supplies a different Reply-To, so
+  human replies land at support rather than at the transactional sender. All
+  other apex mail is rejected.
 - Reserved local parts never route to a user inbox and can never be registered
   as usernames.
 - User outbound mail always sends from `{username}@<platform domain>`. The from

--- a/packages/shared/src/transactional-sender-reply-to.node.test.ts
+++ b/packages/shared/src/transactional-sender-reply-to.node.test.ts
@@ -1,0 +1,41 @@
+import { expect, test } from 'vitest'
+import { resolveTransactionalSenderReplyTo } from './transactional-sender-reply-to.ts'
+
+test('kody@ From defaults Reply-To to support@ on the same domain unless overridden', () => {
+	expect(resolveTransactionalSenderReplyTo({ from: 'kody@kody.codes' })).toBe(
+		'support@kody.codes',
+	)
+	expect(
+		resolveTransactionalSenderReplyTo({
+			from: '  Kody@Kody.Example.com  ',
+		}),
+	).toBe('support@kody.example.com')
+	expect(
+		resolveTransactionalSenderReplyTo({
+			from: 'kody@kody.codes',
+			replyTo: 'ops@example.com',
+		}),
+	).toBe('ops@example.com')
+	expect(
+		resolveTransactionalSenderReplyTo({
+			from: 'kody@kody.codes',
+			replyTo: '  Abuse@Kody.codes  ',
+		}),
+	).toBe('Abuse@Kody.codes')
+	expect(
+		resolveTransactionalSenderReplyTo({
+			from: 'kody@kody.codes',
+			replyTo: '   ',
+		}),
+	).toBe('support@kody.codes')
+	expect(
+		resolveTransactionalSenderReplyTo({ from: 'support@kody.codes' }),
+	).toBeUndefined()
+	expect(
+		resolveTransactionalSenderReplyTo({
+			from: 'alice@inbox.kody.codes',
+		}),
+	).toBeUndefined()
+	expect(resolveTransactionalSenderReplyTo({ from: 'kody+' })).toBeUndefined()
+	expect(resolveTransactionalSenderReplyTo({ from: '' })).toBeUndefined()
+})

--- a/packages/shared/src/transactional-sender-reply-to.ts
+++ b/packages/shared/src/transactional-sender-reply-to.ts
@@ -1,0 +1,28 @@
+/** Platform transactional From local (`kody@<apex>`). */
+const transactionalSenderLocal = 'kody'
+
+/** Default Reply-To local when From is the transactional sender. */
+const transactionalSenderDefaultReplyToLocal = 'support'
+
+/**
+ * Resolve Reply-To for outbound mail. An explicit `replyTo` always wins.
+ * Otherwise mail From `kody@<domain>` replies to `support@<domain>` so human
+ * replies land on support rather than the transactional sender.
+ */
+export function resolveTransactionalSenderReplyTo(input: {
+	from: string
+	replyTo?: string | null
+}): string | undefined {
+	const explicit = input.replyTo?.trim()
+	if (explicit) return explicit
+
+	const from = input.from.trim()
+	const at = from.lastIndexOf('@')
+	if (at <= 0 || at === from.length - 1) return undefined
+	const local = from.slice(0, at).toLowerCase()
+	const domain = from.slice(at + 1).toLowerCase()
+	if (local !== transactionalSenderLocal || domain.length === 0) {
+		return undefined
+	}
+	return `${transactionalSenderDefaultReplyToLocal}@${domain}`
+}

--- a/packages/status/alert-email.node.test.ts
+++ b/packages/status/alert-email.node.test.ts
@@ -1,0 +1,83 @@
+import { expect, test } from 'vitest'
+import { sendAlertEmail } from './alert-email.ts'
+
+test('sendAlertEmail defaults Reply-To to support@ when From is kody@ unless overridden', async () => {
+	const payloads: Array<Record<string, unknown>> = []
+	const fetcher: typeof fetch = async (_input, init) => {
+		payloads.push(JSON.parse(String(init?.body)) as Record<string, unknown>)
+		return Response.json({ success: true })
+	}
+
+	await sendAlertEmail(
+		{
+			accountId: 'account-123',
+			apiToken: 'token-123',
+			apiBaseUrl: 'https://api.cloudflare.test',
+			fetcher,
+		},
+		{
+			from: 'kody@kody.codes',
+			to: 'ops@example.com',
+			subject: 'Incident',
+			text: 'App is down',
+			html: '<p>App is down</p>',
+		},
+	)
+	await sendAlertEmail(
+		{
+			accountId: 'account-123',
+			apiToken: 'token-123',
+			apiBaseUrl: 'https://api.cloudflare.test',
+			fetcher,
+		},
+		{
+			from: 'kody@kody.codes',
+			to: 'ops@example.com',
+			subject: 'Override',
+			text: 'Still down',
+			html: '<p>Still down</p>',
+			replyTo: 'security@kody.codes',
+		},
+	)
+	await sendAlertEmail(
+		{
+			accountId: 'account-123',
+			apiToken: 'token-123',
+			apiBaseUrl: 'https://api.cloudflare.test',
+			fetcher,
+		},
+		{
+			from: 'status@example.com',
+			to: 'ops@example.com',
+			subject: 'Other sender',
+			text: 'Ok',
+			html: '<p>Ok</p>',
+		},
+	)
+
+	expect(payloads).toEqual([
+		{
+			from: 'kody@kody.codes',
+			to: 'ops@example.com',
+			subject: 'Incident',
+			text: 'App is down',
+			html: '<p>App is down</p>',
+			replyTo: 'support@kody.codes',
+		},
+		{
+			from: 'kody@kody.codes',
+			to: 'ops@example.com',
+			subject: 'Override',
+			text: 'Still down',
+			html: '<p>Still down</p>',
+			replyTo: 'security@kody.codes',
+		},
+		{
+			from: 'status@example.com',
+			to: 'ops@example.com',
+			subject: 'Other sender',
+			text: 'Ok',
+			html: '<p>Ok</p>',
+		},
+	])
+})

--- a/packages/status/alert-email.ts
+++ b/packages/status/alert-email.ts
@@ -1,3 +1,5 @@
+import { resolveTransactionalSenderReplyTo } from '@kody-internal/shared/transactional-sender-reply-to.ts'
+
 /**
  * Sends operator alert email through the Cloudflare Email REST API — the same
  * mechanism the main worker uses for ops alerts. When credentials are absent
@@ -20,6 +22,7 @@ export type AlertEmailMessage = {
 	subject: string
 	text: string
 	html: string
+	replyTo?: string | null
 }
 
 export type AlertEmailResult = {
@@ -47,6 +50,10 @@ export async function sendAlertEmail(
 		apiBaseUrl.endsWith('/') ? apiBaseUrl : `${apiBaseUrl}/`,
 	)
 	const fetcher = config.fetcher ?? fetch
+	const replyTo = resolveTransactionalSenderReplyTo({
+		from: message.from,
+		replyTo: message.replyTo,
+	})
 	let response: Response
 	try {
 		response = await fetcher(endpoint.toString(), {
@@ -55,7 +62,14 @@ export async function sendAlertEmail(
 				Authorization: `Bearer ${apiToken}`,
 				'Content-Type': 'application/json',
 			},
-			body: JSON.stringify(message),
+			body: JSON.stringify({
+				from: message.from,
+				to: message.to,
+				subject: message.subject,
+				text: message.text,
+				html: message.html,
+				...(replyTo ? { replyTo } : {}),
+			}),
 		})
 	} catch (error) {
 		const detail = error instanceof Error ? error.message : String(error)

--- a/packages/worker/src/app/email/cloudflare-email.node.test.ts
+++ b/packages/worker/src/app/email/cloudflare-email.node.test.ts
@@ -179,3 +179,71 @@ test('sendCloudflareEmail delivers through the mock API and handles configuratio
 	expect(consoleWarn).toHaveBeenCalledTimes(1)
 	expect(consoleInfo).toHaveBeenCalledTimes(1)
 }, 75_000)
+
+test('sendCloudflareEmail defaults Reply-To to support@ when From is kody@ unless overridden', async () => {
+	const payloads: Array<Record<string, unknown>> = []
+	using _server = createMswNodeServer(
+		[
+			http.post(
+				`https://api.cloudflare.test/client/v4/accounts/${mockAccountId}/email/sending/send`,
+				async ({ request }) => {
+					payloads.push((await request.json()) as Record<string, unknown>)
+					return HttpResponse.json({
+						success: true,
+						result: { message_id: 'reply-to-1' },
+					})
+				},
+			),
+		],
+		{ onUnhandledRequest: 'bypass' },
+	)
+	const config = {
+		accountId: mockAccountId,
+		apiBaseUrl: 'https://api.cloudflare.test',
+		apiToken: 'test-token',
+	}
+
+	await sendCloudflareEmail(config, {
+		to: 'user@example.com',
+		from: 'kody@kody.codes',
+		subject: 'Verify your email',
+		html: '<p>Verify</p>',
+		text: 'Verify',
+	})
+	await sendCloudflareEmail(config, {
+		to: 'user@example.com',
+		from: 'kody@kody.codes',
+		subject: 'Operator override',
+		html: '<p>Override</p>',
+		text: 'Override',
+		replyTo: 'abuse@kody.codes',
+	})
+	await sendCloudflareEmail(config, {
+		to: 'user@example.com',
+		from: 'support@kody.codes',
+		subject: 'Support sender',
+		html: '<p>Support</p>',
+		text: 'Support',
+	})
+	await sendCloudflareEmail(config, {
+		to: 'me@example.com',
+		from: 'alice@inbox.kody.codes',
+		subject: 'User mail',
+		html: '<p>User</p>',
+		text: 'User',
+	})
+
+	expect(payloads).toHaveLength(4)
+	expect(payloads[0]).toMatchObject({
+		from: 'kody@kody.codes',
+		replyTo: 'support@kody.codes',
+	})
+	expect(payloads[1]).toMatchObject({
+		from: 'kody@kody.codes',
+		replyTo: 'abuse@kody.codes',
+	})
+	expect(payloads[2]).toMatchObject({ from: 'support@kody.codes' })
+	expect(payloads[2]).not.toHaveProperty('replyTo')
+	expect(payloads[3]).toMatchObject({ from: 'alice@inbox.kody.codes' })
+	expect(payloads[3]).not.toHaveProperty('replyTo')
+})

--- a/packages/worker/src/app/email/cloudflare-email.ts
+++ b/packages/worker/src/app/email/cloudflare-email.ts
@@ -3,6 +3,7 @@ import {
 	outboundEmailSchema,
 	type OutboundEmail,
 } from '@kody-internal/shared/outbound-email.ts'
+import { resolveTransactionalSenderReplyTo } from '@kody-internal/shared/transactional-sender-reply-to.ts'
 import { redactEmailRecipient } from '#worker/audit-log.ts'
 
 type CloudflareEmailClientConfig = {
@@ -138,7 +139,10 @@ export async function sendCloudflareEmail(
 ): Promise<CloudflareSendResult> {
 	const normalized = normalizeEmailPayload({
 		...message,
-		replyTo: message.replyTo,
+		replyTo: resolveTransactionalSenderReplyTo({
+			from: message.from,
+			replyTo: message.replyTo,
+		}),
 		headers: message.headers,
 		attachments: message.attachments,
 	})

--- a/packages/worker/src/email/system-outbound.ts
+++ b/packages/worker/src/email/system-outbound.ts
@@ -1,3 +1,4 @@
+import { resolveTransactionalSenderReplyTo } from '@kody-internal/shared/transactional-sender-reply-to.ts'
 import { sendCloudflareEmail } from '#app/email/cloudflare-email.ts'
 import { McpCallerError } from '#mcp/caller-error.ts'
 import { normalizeEmailAddress } from './address.ts'
@@ -90,9 +91,11 @@ function resolveRecipients(to: string | Array<string>): Array<string> {
  * This is the operator correspondence channel, structurally separate from
  * user mail: it does not touch any user mailbox, sender identity, or plan
  * entitlement, and it is protected by its own per-sender daily cap so a
- * runaway caller cannot burn the apex domain's sending reputation. Callers
- * are responsible for the authorization check — today only admin-gated,
- * audit-logged capabilities and internal platform alerts reach it.
+ * runaway caller cannot burn the apex domain's sending reputation. Mail
+ * From `kody@<domain>` sets Reply-To to `support@<domain>` unless the
+ * caller passes an explicit `replyTo`. Callers are responsible for the
+ * authorization check — today only admin-gated, audit-logged capabilities
+ * and internal platform alerts reach it.
  */
 export async function sendSystemEmail(input: {
 	env: SystemOutboundEnv
@@ -128,10 +131,17 @@ export async function sendSystemEmail(input: {
 	if (!text && !html) {
 		throw new McpCallerError('Email text or HTML body is required.')
 	}
-	const replyTo = input.replyTo ? normalizeEmailAddress(input.replyTo) : null
-	if (input.replyTo && !replyTo) {
+	const explicitReplyTo = input.replyTo
+		? normalizeEmailAddress(input.replyTo)
+		: null
+	if (input.replyTo && !explicitReplyTo) {
 		throw new McpCallerError(`Invalid reply-to address: ${input.replyTo}`)
 	}
+	const replyTo =
+		resolveTransactionalSenderReplyTo({
+			from,
+			replyTo: explicitReplyTo,
+		}) ?? null
 
 	const now = input.now ?? new Date()
 	const consumed = await consumeSystemEmailDailySend({

--- a/packages/worker/src/email/system-outbound.workers.test.ts
+++ b/packages/worker/src/email/system-outbound.workers.test.ts
@@ -101,6 +101,51 @@ test('sendSystemEmail sends from the reserved system sender to external recipien
 		}),
 	])
 	expect(await readSendCounter('kody', now)).toBe(1)
+
+	mocks.dispatchSystemEmailSentSubscriptionEvent.mockClear()
+	payloads.length = 0
+	const defaulted = await sendSystemEmail({
+		env: createSystemEnv(),
+		to: 'second@example.com',
+		subject: 'No explicit reply-to',
+		text: 'Default Reply-To please.',
+		now,
+	})
+	expect(defaulted.from).toBe('kody@kody.example.com')
+	expect(mocks.dispatchSystemEmailSentSubscriptionEvent).toHaveBeenCalledWith(
+		expect.objectContaining({
+			event: expect.objectContaining({
+				from: 'kody@kody.example.com',
+				reply_to: 'support@kody.example.com',
+			}),
+		}),
+	)
+	expect(payloads).toEqual([
+		expect.objectContaining({
+			from: 'kody@kody.example.com',
+			replyTo: 'support@kody.example.com',
+		}),
+	])
+
+	mocks.dispatchSystemEmailSentSubscriptionEvent.mockClear()
+	payloads.length = 0
+	await sendSystemEmail({
+		env: createSystemEnv(),
+		localPart: 'support',
+		to: 'third@example.com',
+		subject: 'Support sender',
+		text: 'No default Reply-To.',
+		now,
+	})
+	expect(mocks.dispatchSystemEmailSentSubscriptionEvent).toHaveBeenCalledWith(
+		expect.objectContaining({
+			event: expect.objectContaining({
+				from: 'support@kody.example.com',
+				reply_to: null,
+			}),
+		}),
+	)
+	expect(payloads[0]).not.toHaveProperty('replyTo')
 })
 
 test('sendSystemEmail rejects unusable senders, recipients, and bodies', async () => {

--- a/packages/worker/src/mcp/capabilities/admin/admin-system-email-send.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-system-email-send.ts
@@ -36,7 +36,7 @@ const inputSchema = z
 			.min(1)
 			.optional()
 			.describe(
-				'Optional Reply-To. Replies to the system sender already land in the operator system inbox.',
+				'Optional Reply-To. Mail from kody@ defaults to support@ on the same apex; an explicit value wins. Other system senders do not default.',
 			),
 		headers: z
 			.record(z.string(), z.string())
@@ -62,7 +62,7 @@ export const adminSystemEmailSendCapability = defineDomainCapability(
 		...adminMutationCapabilityAccess,
 		name: 'adminSystemEmailSend',
 		description:
-			'Send operator correspondence from a reserved system sender (kody@<apex> by default) to an external recipient. Admin-only and audit-logged; capped per sender per day. Replies land in the operator system inbox. Use emailSend/emailReply for user mail — this sender speaks for the platform, not for a user account.',
+			'Send operator correspondence from a reserved system sender (kody@<apex> by default) to an external recipient. Admin-only and audit-logged; capped per sender per day. Mail from kody@ sets Reply-To to support@<apex> unless reply_to is provided. Use emailSend/emailReply for user mail — this sender speaks for the platform, not for a user account.',
 		keywords: [
 			'admin',
 			'system email',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Human replies to platform transactional mail should land on `support@kody.codes` (Email Routing forwards that address) instead of requiring a reply to the `kody@` sender itself.

## Why

Outbound mail still sends **From** `kody@<apex>` so transactional identity stays intact. Without a Reply-To, clients reply to `kody@`. Operator intent is that those replies go to `support@` unless a caller set an explicit Reply-To.

## Summary

- Shared helper `resolveTransactionalSenderReplyTo` defaults Reply-To to `support@<domain>` when From is `kody@<domain>`.
- Applied in `sendCloudflareEmail` (verification, password-reset, billing, campaigns, feedback, and other transactional REST sends), `sendSystemEmail` (so `email.system-message.sent` matches the header), and status `sendAlertEmail`.
- Explicit `replyTo` / `reply_to` still wins. Other system locals (`support@`, `admin@`, …) and user inbox senders are unchanged.
- Tests cover the default, the override, and non-`kody@` senders.

## Testing

- `test:push` on commit/push: node-unit 2973 passed, workers-unit 341 passed (includes the new helper, Cloudflare send, system-outbound, and status alert tests).
- Typecheck ran on commit.

## System changes

Extends the outbound email send helpers (medium). No From-address or routing-rule change. User `emailSend` / `{username}@inbox…` is out of scope.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `6cebf082` · **Head:** `80ee9b3a`

**Classification:** extends — outbound send helpers default Reply-To when From is `kody@`.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `email` | assistant | extends — `sendSystemEmail` defaults Reply-To for `kody@` and records it on `email.system-message.sent` |
| `app-ui` | surfaces | extends — `sendCloudflareEmail` applies the same default for all REST sends |
| `status-page` | surfaces | extends — status `sendAlertEmail` applies the same default |
| `rbac` | auth | composes — `adminSystemEmailSend` copy only |

### Change flow

Outbound mail From `kody@` picks up `Reply-To: support@` in each send helper unless the caller already set one.

```mermaid
sequenceDiagram
	actor Caller
	participant email as email
	participant appUi as app-ui
	participant statusPage as status-page
	Caller->>email: sendSystemEmail from kody@
	email->>email: default replyTo to support@ unless explicit
	email->>appUi: sendCloudflareEmail with resolved replyTo
	Note over email: email.system-message.sent carries the same reply_to
	Caller->>appUi: transactional send from kody@
	appUi->>appUi: default replyTo to support@ unless explicit
	Caller->>statusPage: sendAlertEmail from kody@
	statusPage->>statusPage: default replyTo to support@ unless explicit
```

### Before / after

| Path | Before | After |
| --- | --- | --- |
| From `kody@<apex>`, no Reply-To | header omitted | `Reply-To: support@<apex>` |
| Explicit `replyTo` / `reply_to` | passed through | still wins |
| From `support@` / user inbox | no default | unchanged |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-008af365-dd53-41b8-8841-e24f991734ac?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-008af365-dd53-41b8-8841-e24f991734ac&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Transactional emails sent from `kody@` now default replies to `support@` on the same domain.
  * Explicit Reply-To addresses continue to take priority.
  * Alert emails now support an optional Reply-To address.

* **Documentation**
  * Updated email, authentication, authorization, and admin capability documentation to describe Reply-To routing.

* **Tests**
  * Added coverage for default, explicit, invalid, and non-transactional sender scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->