### PR TITLE
Fix Cloudflare REST reply_to field for kody@ Reply-To

### DIFF
--- a/packages/shared/src/cloudflare-send-body.node.test.ts
+++ b/packages/shared/src/cloudflare-send-body.node.test.ts
@@ -1,0 +1,64 @@
+import { expect, test } from 'vitest'
+import { toCloudflareSendBody } from './cloudflare-send-body.ts'
+
+test('toCloudflareSendBody maps replyTo to reply_to and omits camelCase', () => {
+	expect(
+		toCloudflareSendBody({
+			from: 'kody@kody.codes',
+			to: 'user@example.com',
+			subject: 'Verify',
+			html: '<p>Verify</p>',
+			text: 'Verify',
+			replyTo: 'support@kody.codes',
+		}),
+	).toEqual({
+		from: 'kody@kody.codes',
+		to: 'user@example.com',
+		subject: 'Verify',
+		html: '<p>Verify</p>',
+		text: 'Verify',
+		reply_to: 'support@kody.codes',
+	})
+	expect(
+		toCloudflareSendBody({
+			from: 'kody@kody.codes',
+			to: 'user@example.com',
+			subject: 'Override',
+			html: '<p>Override</p>',
+			replyTo: '  abuse@kody.codes  ',
+		}),
+	).toEqual({
+		from: 'kody@kody.codes',
+		to: 'user@example.com',
+		subject: 'Override',
+		html: '<p>Override</p>',
+		reply_to: 'abuse@kody.codes',
+	})
+	expect(
+		toCloudflareSendBody({
+			from: 'support@kody.codes',
+			to: 'user@example.com',
+			subject: 'Support',
+			html: '<p>Support</p>',
+		}),
+	).toEqual({
+		from: 'support@kody.codes',
+		to: 'user@example.com',
+		subject: 'Support',
+		html: '<p>Support</p>',
+	})
+	expect(
+		toCloudflareSendBody({
+			from: 'support@kody.codes',
+			to: 'user@example.com',
+			subject: 'Blank',
+			html: '<p>Blank</p>',
+			replyTo: '   ',
+		}),
+	).toEqual({
+		from: 'support@kody.codes',
+		to: 'user@example.com',
+		subject: 'Blank',
+		html: '<p>Blank</p>',
+	})
+})

--- a/packages/shared/src/cloudflare-send-body.ts
+++ b/packages/shared/src/cloudflare-send-body.ts
@@ -1,0 +1,16 @@
+/**
+ * Cloudflare Email Sending REST (`POST .../email/sending/send`) uses snake_case
+ * `reply_to`. The Workers binding uses camelCase `replyTo`. Internal outbound
+ * mail stays `replyTo`; only this mapper changes the REST wire field.
+ * @see https://developers.cloudflare.com/email-service/examples/email-sending/recipients/
+ */
+export function toCloudflareSendBody<T extends { replyTo?: string | null }>(
+	outbound: T,
+): Omit<T, 'replyTo'> & { reply_to?: string } {
+	const { replyTo, ...rest } = outbound
+	const trimmed = replyTo?.trim()
+	if (!trimmed) {
+		return rest
+	}
+	return { ...rest, reply_to: trimmed }
+}

--- a/packages/status/alert-email.node.test.ts
+++ b/packages/status/alert-email.node.test.ts
@@ -62,7 +62,7 @@ test('sendAlertEmail defaults Reply-To to support@ when From is kody@ unless ove
 			subject: 'Incident',
 			text: 'App is down',
 			html: '<p>App is down</p>',
-			replyTo: 'support@kody.codes',
+			reply_to: 'support@kody.codes',
 		},
 		{
 			from: 'kody@kody.codes',
@@ -70,7 +70,7 @@ test('sendAlertEmail defaults Reply-To to support@ when From is kody@ unless ove
 			subject: 'Override',
 			text: 'Still down',
 			html: '<p>Still down</p>',
-			replyTo: 'security@kody.codes',
+			reply_to: 'security@kody.codes',
 		},
 		{
 			from: 'status@example.com',
@@ -80,4 +80,8 @@ test('sendAlertEmail defaults Reply-To to support@ when From is kody@ unless ove
 			html: '<p>Ok</p>',
 		},
 	])
+	expect(payloads[0]).not.toHaveProperty('replyTo')
+	expect(payloads[1]).not.toHaveProperty('replyTo')
+	expect(payloads[2]).not.toHaveProperty('replyTo')
+	expect(payloads[2]).not.toHaveProperty('reply_to')
 })

--- a/packages/status/alert-email.ts
+++ b/packages/status/alert-email.ts
@@ -1,3 +1,4 @@
+import { toCloudflareSendBody } from '@kody-internal/shared/cloudflare-send-body.ts'
 import { resolveTransactionalSenderReplyTo } from '@kody-internal/shared/transactional-sender-reply-to.ts'
 
 /**
@@ -62,14 +63,16 @@ export async function sendAlertEmail(
 				Authorization: `Bearer ${apiToken}`,
 				'Content-Type': 'application/json',
 			},
-			body: JSON.stringify({
-				from: message.from,
-				to: message.to,
-				subject: message.subject,
-				text: message.text,
-				html: message.html,
-				...(replyTo ? { replyTo } : {}),
-			}),
+			body: JSON.stringify(
+				toCloudflareSendBody({
+					from: message.from,
+					to: message.to,
+					subject: message.subject,
+					text: message.text,
+					html: message.html,
+					replyTo,
+				}),
+			),
 		})
 	} catch (error) {
 		const detail = error instanceof Error ? error.message : String(error)

--- a/packages/worker/src/app/email/cloudflare-email.node.test.ts
+++ b/packages/worker/src/app/email/cloudflare-email.node.test.ts
@@ -236,14 +236,18 @@ test('sendCloudflareEmail defaults Reply-To to support@ when From is kody@ unles
 	expect(payloads).toHaveLength(4)
 	expect(payloads[0]).toMatchObject({
 		from: 'kody@kody.codes',
-		replyTo: 'support@kody.codes',
+		reply_to: 'support@kody.codes',
 	})
+	expect(payloads[0]).not.toHaveProperty('replyTo')
 	expect(payloads[1]).toMatchObject({
 		from: 'kody@kody.codes',
-		replyTo: 'abuse@kody.codes',
+		reply_to: 'abuse@kody.codes',
 	})
+	expect(payloads[1]).not.toHaveProperty('replyTo')
 	expect(payloads[2]).toMatchObject({ from: 'support@kody.codes' })
 	expect(payloads[2]).not.toHaveProperty('replyTo')
+	expect(payloads[2]).not.toHaveProperty('reply_to')
 	expect(payloads[3]).toMatchObject({ from: 'alice@inbox.kody.codes' })
 	expect(payloads[3]).not.toHaveProperty('replyTo')
+	expect(payloads[3]).not.toHaveProperty('reply_to')
 })

--- a/packages/worker/src/app/email/cloudflare-email.ts
+++ b/packages/worker/src/app/email/cloudflare-email.ts
@@ -1,4 +1,5 @@
 import { parseSafe } from 'remix/data-schema'
+import { toCloudflareSendBody } from '@kody-internal/shared/cloudflare-send-body.ts'
 import {
 	outboundEmailSchema,
 	type OutboundEmail,
@@ -93,7 +94,7 @@ async function sendViaCloudflareApi(
 				Authorization: `Bearer ${config.apiToken}`,
 				'Content-Type': 'application/json',
 			},
-			body: JSON.stringify(message),
+			body: JSON.stringify(toCloudflareSendBody(message)),
 		})
 	} catch (error) {
 		console.warn('cloudflare-email-api-request-failed', error)

--- a/packages/worker/src/email/outbound.workers.test.ts
+++ b/packages/worker/src/email/outbound.workers.test.ts
@@ -750,12 +750,13 @@ test('sendOutboundEmail preserves reply headers and records failed fallback send
 	expect(fetchCalls[0]?.body).toMatchObject({
 		html: 'Body',
 		to: 'recipient@example.com',
-		replyTo: 'reply@example.com',
+		reply_to: 'reply@example.com',
 		headers: {
 			'In-Reply-To': inbound.messageIdHeader,
 			References: '<root@example.com>',
 		},
 	})
+	expect(fetchCalls[0]?.body).not.toHaveProperty('replyTo')
 	expect(fetchCalls[0]?.body.headers).not.toHaveProperty('Message-ID')
 	expect(fetchCalls[0]?.body.headers).not.toHaveProperty(
 		'X-Kody-Email-Message-Id',

--- a/packages/worker/src/email/system-outbound.workers.test.ts
+++ b/packages/worker/src/email/system-outbound.workers.test.ts
@@ -97,9 +97,10 @@ test('sendSystemEmail sends from the reserved system sender to external recipien
 			subject: 'Thanks for the report',
 			text: 'We shipped the fix.',
 			html: '<!doctype html><html lang="en"><body><p>We shipped the fix.</p></body></html>',
-			replyTo: 'support@kody.example.com',
+			reply_to: 'support@kody.example.com',
 		}),
 	])
+	expect(payloads[0]).not.toHaveProperty('replyTo')
 	expect(await readSendCounter('kody', now)).toBe(1)
 
 	mocks.dispatchSystemEmailSentSubscriptionEvent.mockClear()
@@ -123,9 +124,10 @@ test('sendSystemEmail sends from the reserved system sender to external recipien
 	expect(payloads).toEqual([
 		expect.objectContaining({
 			from: 'kody@kody.example.com',
-			replyTo: 'support@kody.example.com',
+			reply_to: 'support@kody.example.com',
 		}),
 	])
+	expect(payloads[0]).not.toHaveProperty('replyTo')
 
 	mocks.dispatchSystemEmailSentSubscriptionEvent.mockClear()
 	payloads.length = 0
@@ -146,6 +148,7 @@ test('sendSystemEmail sends from the reserved system sender to external recipien
 		}),
 	)
 	expect(payloads[0]).not.toHaveProperty('replyTo')
+	expect(payloads[0]).not.toHaveProperty('reply_to')
 })
 
 test('sendSystemEmail rejects unusable senders, recipients, and bodies', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Restore outbound mail from `kody@` so Cloudflare Email Sending REST accepts it again. #2184 still defaults Reply-To to `support@` for that sender; only the REST wire field was wrong.

## Why

#2184 injects internal `replyTo` (camelCase) into `POST /client/v4/accounts/{account_id}/email/sending/send`. The Workers binding uses `replyTo`; the REST API requires snake_case `reply_to`. Cloudflare rejects the camelCase body with `email.sending.error.invalid_request_schema`. Mail From `support@` (no Reply-To) still works.

Docs: https://developers.cloudflare.com/email-service/examples/email-sending/recipients/

## Summary

- Add `toCloudflareSendBody()` in `@kody-internal/shared` to map `replyTo` → `reply_to` and omit camelCase from the REST JSON.
- Use it in `sendViaCloudflareApi` and `sendAlertEmail`.
- Keep `OutboundEmail` / callers as `replyTo`.
- Do not change Email Routing, MX, or the default `support@` Reply-To product behavior.

## Testing

- Pre-push `npm run test:push` (`test:node` + `test:workers`): 937 node files / 2974 tests and 94 workers files / 341 tests passed, including:
  - `packages/shared/src/cloudflare-send-body.node.test.ts`
  - `packages/worker/src/app/email/cloudflare-email.node.test.ts`
  - `packages/status/alert-email.node.test.ts`
  - `packages/worker/src/email/system-outbound.workers.test.ts`
  - `packages/worker/src/email/outbound.workers.test.ts`
- Typecheck ran on commit (worker + status).
- No UI change; preview cannot exercise live Cloudflare Email Sending REST without sending production mail.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `281a0777` · **Head:** `6ddc5e36`

**Classification:** extends — REST send body now uses `reply_to` instead of camelCase `replyTo`. Internal outbound helpers stay `replyTo`.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | extends — `sendViaCloudflareApi` maps `replyTo` to `reply_to` |
| `status-page` | surfaces | extends — alert email REST body uses the same mapper |
| `email` | assistant | composes — outbound/system-email tests assert the REST wire field |

Unmatched: `packages/shared/src/cloudflare-send-body.ts` (shared REST mapper used by both send sites).

### Change flow

Origin and status alert sends keep internal `replyTo`, then map it to Cloudflare REST `reply_to` before `POST .../email/sending/send`.

```mermaid
sequenceDiagram
	actor Origin
	participant appUi as app-ui
	participant statusPage as status-page
	Origin->>appUi: sendCloudflareEmail keeps replyTo
	appUi->>appUi: toCloudflareSendBody writes reply_to
	Note over appUi: POST email/sending/send omits camelCase replyTo
	Origin->>statusPage: sendAlertEmail keeps replyTo
	statusPage->>statusPage: toCloudflareSendBody writes reply_to
	Note over statusPage: POST email/sending/send omits camelCase replyTo
```

### Before / after

```diff
- { "from": "kody@kody.codes", "replyTo": "support@kody.codes", ... }
+ { "from": "kody@kody.codes", "reply_to": "support@kody.codes", ... }
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d47f83a7-abcc-42a1-b324-e544281e0fd6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d47f83a7-abcc-42a1-b324-e544281e0fd6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Cloudflare email requests now send the Reply-To address using the API-compatible `reply_to` format.
  - Reply-To values are trimmed before sending, preventing accidental whitespace from affecting delivery.
  - Missing or whitespace-only Reply-To values are omitted from outgoing requests instead of being sent as empty fields.
  - Updated email handling across alerts and worker-generated messages for consistent Reply-To behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->