### PR TITLE
Resume onboarding at the current step so connected agents stay visible

### DIFF
--- a/.agents/skills/control-kody/references/features/onboarding.md
+++ b/.agents/skills/control-kody/references/features/onboarding.md
@@ -8,10 +8,11 @@ known memory subject or package name, shows a short "You made …" chip.
 
 ## How to get there
 
-Signed-in visit to `/onboarding`. Step 1 is `/onboarding/step-1` (optional
-`:agent`). Step 2 is `/onboarding/step-2`. Step 3 is `/onboarding/step-3`
-(optional `:agent`). Leftover `/onboarding/step-2/:service` URLs redirect to
-Step 2. Also linked from account.
+Signed-in visit to `/onboarding` (resumes at the first unfinished step; finished
+accounts land on Step 3 so connected agents stay visible). Step 1 is
+`/onboarding/step-1` (optional `:agent`). Step 2 is `/onboarding/step-2`. Step 3
+is `/onboarding/step-3` (optional `:agent`). Leftover
+`/onboarding/step-2/:service` URLs redirect to Step 2. Also linked from account.
 
 ## Drive it
 

--- a/docs/contributing/architecture/onboarding.md
+++ b/docs/contributing/architecture/onboarding.md
@@ -7,6 +7,7 @@ optional first-win email guide share one contract:
 
 | Surface                                  | Role                                                                      |
 | ---------------------------------------- | ------------------------------------------------------------------------- |
+| Wizard index `/onboarding`               | Redirects to the first unfinished step (Step 3 once Step 2 is done)       |
 | Wizard Step 1 `/onboarding/step-1`       | Connect an MCP host                                                       |
 | Wizard Step 2 `/onboarding/step-2`       | Make something useful (one prompt + first `search` + `onboarding:guide`)  |
 | Wizard Step 3 `/onboarding/step-3`       | Connect a second agent (same-ecosystem hosts greyed; `portability:guide`) |
@@ -33,11 +34,14 @@ hidden if nothing sensible). `hasSecondMcpClient` is unique inbound OAuth
 the connected label stays "You've connected a second agent." When the
 second-agent Standard gift is active, that status adds "Standard is free for 2
 weeks." Step 3 copy advertises "Connect a second agent and get Standard free for
-2 weeks." Same-ecosystem greying stays picker UX only. Account → Connected
-agents lists those inbound hosts grouped by display name, with public logos for
-known kinds, newest-first sort, best-effort labels, and per-`clientId` revoke.
-That list is not `users.mcp_client_name` (first-touch) and not
-`/account/mcp-oauth-clients` (user-minted confidential clients).
+2 weeks." Same-ecosystem greying stays picker UX only. `/onboarding` resumes at
+that step instead of always opening the Step 1 picker, and every wizard step
+still lists already-connected hosts so a return visit cannot hide Cursor or
+Claude Desktop. Account → Connected agents lists those inbound hosts grouped by
+display name, with public logos for known kinds, newest-first sort, best-effort
+labels, and per-`clientId` revoke. That list is not `users.mcp_client_name`
+(first-touch) and not `/account/mcp-oauth-clients` (user-minted confidential
+clients).
 
 `first-win` is not a wizard step and is not a checklist item. Signed-in
 `/onboarding` does not probe Mailbox for that loop. MCP registers

--- a/packages/worker/client/routes/onboarding-agent-chooser-session.node.test.ts
+++ b/packages/worker/client/routes/onboarding-agent-chooser-session.node.test.ts
@@ -150,6 +150,48 @@ test('client loads of the selection step reuse the SSR agent order', async () =>
 	}
 })
 
+test('client /onboarding resume follows payload progress, not always step 1', async () => {
+	const originalFetch = globalThis.fetch
+	clearOnboardingPayloadCache()
+	const finished = {
+		...anonymousOnboardingPayload,
+		loggedIn: true,
+		emailVerified: true,
+		needsOnboarding: false,
+		hasMcpClient: true,
+		hasAccessWin: true,
+		hasSecondMcpClient: true,
+		connectedAgents: [
+			{
+				clientId: 'cursor-client',
+				label: 'Cursor',
+				kind: 'cursor' as const,
+				connectedAt: '2026-09-08T17:00:00.000Z',
+			},
+			{
+				clientId: 'claude-desktop-client',
+				label: 'Claude Desktop',
+				kind: 'claude-desktop' as const,
+				connectedAt: '2026-09-08T18:00:00.000Z',
+			},
+		],
+	} satisfies OnboardingPayload
+	globalThis.fetch = (async () => Response.json(finished)) as typeof fetch
+	try {
+		const indexRedirect = await onboardingRouteLoader(
+			new URL('https://example.com/onboarding'),
+			new AbortController().signal,
+		)
+		expect(isRouteLoaderRedirect(indexRedirect)).toBe(true)
+		if (isRouteLoaderRedirect(indexRedirect)) {
+			expect(indexRedirect.to).toBe('/onboarding/step-3')
+		}
+	} finally {
+		globalThis.fetch = originalFetch
+		clearOnboardingPayloadCache()
+	}
+})
+
 test('onboarding agent chooser session ignores invalid storage and does not persist on the server', () => {
 	installBrowserSession()
 	try {

--- a/packages/worker/client/routes/onboarding-selected-agent-session.ts
+++ b/packages/worker/client/routes/onboarding-selected-agent-session.ts
@@ -1,10 +1,10 @@
 /**
  * Browser-session store for the Step 1 agent the visitor actually picked.
  *
- * Step 2 and Step 3 URLs do not carry the first agent, and the onboarding
- * payload only has grant counts — not a step-1 display name. Remember the
- * explicit choice so Step 2 can say "Copy a prompt to Cursor…" and Step 3
- * can grey the same-ecosystem family.
+ * Step 2 and Step 3 URLs do not carry the first agent. The payload's
+ * `connectedAgents` can recover a named host on return visits; this session
+ * remembers the explicit picker choice so Step 2 can say "Copy a prompt to
+ * Cursor…" and Step 3 can grey the same-ecosystem family in the same tab.
  */
 
 import {

--- a/packages/worker/client/routes/onboarding-wizard-panels.node.test.ts
+++ b/packages/worker/client/routes/onboarding-wizard-panels.node.test.ts
@@ -17,6 +17,10 @@ function connectPanel(selected: {
 	loggedIn?: boolean
 	hasMcpClient?: boolean
 	search?: string
+	connectedAgents?: Array<{
+		label: string
+		kind?: 'claude-desktop' | 'cursor'
+	}>
 }) {
 	return renderConnectAgentPanel({
 		entrance: css({}),
@@ -24,6 +28,7 @@ function connectPanel(selected: {
 		onSelectStep() {},
 		loggedIn: selected.loggedIn ?? false,
 		hasMcpClient: selected.hasMcpClient ?? false,
+		connectedAgents: selected.connectedAgents,
 		selectedAgent: selected.agent,
 		selectedAgentLabel: selected.label,
 		agentChooser: null,
@@ -38,6 +43,10 @@ function accessPanel(selected: {
 	hasAccessWin?: boolean
 	selectedAgentLabel?: string | null
 	discoveryPrompt?: string
+	connectedAgents?: Array<{
+		label: string
+		kind?: 'claude-desktop' | 'cursor'
+	}>
 }) {
 	return renderAccessPanel({
 		entrance: css({}),
@@ -47,6 +56,7 @@ function accessPanel(selected: {
 		hasAccessWin: selected.hasAccessWin ?? false,
 		discoveryPrompt: selected.discoveryPrompt ?? discoveryPrompt,
 		selectedAgentLabel: selected.selectedAgentLabel ?? null,
+		connectedAgents: selected.connectedAgents,
 	})
 }
 
@@ -115,9 +125,18 @@ test('step 1 title names the selected agent and offers a text change link', asyn
 			label: 'Cursor',
 			loggedIn: true,
 			hasMcpClient: true,
+			connectedAgents: [
+				{ label: 'Cursor', kind: 'cursor' },
+				{ label: 'Claude Desktop', kind: 'claude-desktop' },
+			],
 		}),
 	)
 	expect(connected).toContain('Cursor is connected')
+	expect(connected).toContain('data-testid="onboarding-connected-agents"')
+	expect(connected).toContain(
+		'aria-label="Connected: Cursor and Claude Desktop"',
+	)
+	expect(connected).toContain('data-agent-kind="claude-desktop"')
 })
 
 test('step 2 shows one prompt and a search waiting spinner', async () => {
@@ -126,13 +145,22 @@ test('step 2 shows one prompt and a search waiting spinner', async () => {
 	expect(unconnected).toContain('data-testid="onboarding-unconnected-prompt"')
 
 	const waiting = await renderToString(
-		accessPanel({ hasMcpClient: true, selectedAgentLabel: 'Cursor' }),
+		accessPanel({
+			hasMcpClient: true,
+			selectedAgentLabel: 'Cursor',
+			connectedAgents: [
+				{ label: 'Cursor', kind: 'cursor' },
+				{ label: 'Claude Desktop', kind: 'claude-desktop' },
+			],
+		}),
 	)
 	expect(waiting).toContain('data-testid="onboarding-step-2-prompt"')
 	expect(waiting).toContain('data-testid="onboarding-search-status"')
 	expect(waiting).toContain('data-testid="onboarding-guide-pointer"')
 	expect(waiting).toContain('data-testid="onboarding-wizard-next"')
 	expect(waiting).not.toContain('data-connected="true"')
+	expect(waiting).toContain('data-testid="onboarding-connected-agents"')
+	expect(waiting).toContain('aria-label="Connected: Cursor and Claude Desktop"')
 
 	const started = await renderToString(
 		accessPanel({

--- a/packages/worker/client/routes/onboarding-wizard-panels.tsx
+++ b/packages/worker/client/routes/onboarding-wizard-panels.tsx
@@ -59,6 +59,7 @@ export function renderConnectAgentPanel(
 		entrance: MixValue
 		loggedIn: boolean
 		hasMcpClient: boolean
+		connectedAgents?: ReadonlyArray<OnboardingConnectedAgentListItem>
 		selectedAgent: McpClientKind | null
 		selectedAgentLabel: string | null
 		agentChooser: OnboardingAgentChooserPick | null
@@ -86,6 +87,7 @@ export function renderConnectAgentPanel(
 				tilt: '2deg',
 			})}
 			{renderConnectAgentStatus(props)}
+			{renderConnectedAgentsLine(props.connectedAgents)}
 			<OnboardingMcpClientTabs
 				mcpServerUrl={props.mcpServerUrl}
 				highlights={props.mcpHighlights}
@@ -109,6 +111,7 @@ export function renderAccessPanel(
 		hasAccessWin: boolean
 		discoveryPrompt: string
 		selectedAgentLabel: string | null
+		connectedAgents?: ReadonlyArray<OnboardingConnectedAgentListItem>
 	},
 ) {
 	const accessLede = props.hasMcpClient
@@ -153,6 +156,7 @@ export function renderAccessPanel(
 					})}
 				</div>
 			) : null}
+			{renderConnectedAgentsLine(props.connectedAgents)}
 			<p mix={css(panelLedeCss)} data-testid="onboarding-access-lede">
 				{accessLede}
 			</p>
@@ -211,8 +215,6 @@ export function renderSecondAgentPanel(
 		memorySubject: props.accessWinMemorySubject,
 		packageName: props.persistedPackageName,
 	})
-	const connectedItems = uniqueOnboardingConnectedAgents(connectedAgents)
-	const connectedLabels = onboardingConnectedAgentLabelsLine(connectedItems)
 	return (
 		<section
 			id="onboarding-step-3"
@@ -256,32 +258,7 @@ export function renderSecondAgentPanel(
 					props.secondAgentGiftActive === true,
 				),
 			})}
-			{connectedItems.length > 0 ? (
-				<p
-					mix={css(connectedAgentsLineCss)}
-					data-testid="onboarding-connected-agents"
-					aria-label={connectedLabels ?? undefined}
-				>
-					<span aria-hidden="true">
-						Connected:{' '}
-						{connectedItems.map((agent, index) => (
-							<span key={agent.label}>
-								{onboardingConnectedListSeparator(index, connectedItems.length)}
-								<span
-									mix={css(connectedAgentItemCss)}
-									data-testid="onboarding-connected-agent"
-									data-agent-kind={agent.kind ?? 'unknown'}
-								>
-									{agent.kind && agent.kind !== 'other' ? (
-										<AgentPickerMark agent={agent.kind} size="inline" />
-									) : null}
-									{agent.label}
-								</span>
-							</span>
-						))}
-					</span>
-				</p>
-			) : null}
+			{renderConnectedAgentsLine(connectedAgents)}
 			<OnboardingMcpClientTabs
 				mcpServerUrl={props.mcpServerUrl}
 				highlights={props.mcpHighlights}
@@ -387,6 +364,40 @@ function renderAgentPanelHead(props: {
 				mix={css(panelArtCss)}
 			/>
 		</div>
+	)
+}
+
+function renderConnectedAgentsLine(
+	agents: ReadonlyArray<OnboardingConnectedAgentListItem> | undefined,
+) {
+	const connectedItems = uniqueOnboardingConnectedAgents(agents ?? [])
+	const connectedLabels = onboardingConnectedAgentLabelsLine(connectedItems)
+	if (connectedItems.length === 0) return null
+	return (
+		<p
+			mix={css(connectedAgentsLineCss)}
+			data-testid="onboarding-connected-agents"
+			aria-label={connectedLabels ?? undefined}
+		>
+			<span aria-hidden="true">
+				Connected:{' '}
+				{connectedItems.map((agent, index) => (
+					<span key={agent.label}>
+						{onboardingConnectedListSeparator(index, connectedItems.length)}
+						<span
+							mix={css(connectedAgentItemCss)}
+							data-testid="onboarding-connected-agent"
+							data-agent-kind={agent.kind ?? 'unknown'}
+						>
+							{agent.kind && agent.kind !== 'other' ? (
+								<AgentPickerMark agent={agent.kind} size="inline" />
+							) : null}
+							{agent.label}
+						</span>
+					</span>
+				))}
+			</span>
+		</p>
 	)
 }
 

--- a/packages/worker/client/routes/onboarding.tsx
+++ b/packages/worker/client/routes/onboarding.tsx
@@ -24,6 +24,7 @@ import {
 	onboardingWizardStepByNumber,
 	onboardingWizardStepHref,
 	parseOnboardingPathname,
+	resolveOnboardingFirstAgentKind,
 	type OnboardingWizardStepNumber,
 } from '#universal/onboarding-process.ts'
 import { resolveOnboardingStep3SelectedAgent } from '#universal/onboarding-agent-ecosystems.ts'
@@ -97,7 +98,13 @@ export async function onboardingRouteLoader(
 		)
 	}
 	if (url.pathname === onboardingStepPaths.index) {
-		return routeLoaderRedirect(onboardingIndexRedirectHref(url.search))
+		return routeLoaderRedirect(
+			onboardingIndexRedirectHref(url.search, {
+				hasMcpClient: payload.hasMcpClient,
+				hasAccessWin: payload.hasAccessWin,
+				hasSecondMcpClient: payload.hasSecondMcpClient,
+			}),
+		)
 	}
 	const location = parseOnboardingPathname(url.pathname)
 	if (location && !location.valid) {
@@ -109,6 +116,20 @@ export async function onboardingRouteLoader(
 		onboarding: payload,
 		onboardingAgentChooser: resolveOnboardingAgentChooser(),
 	}
+}
+
+function mergeConnectedAgents(
+	current: OnboardingPayload['connectedAgents'],
+	incoming: OnboardingPayload['connectedAgents'] | undefined,
+) {
+	const next = incoming ?? []
+	if (current.length === 0) return next
+	if (next.length === 0) return current
+	const byId = new Map(current.map((agent) => [agent.clientId, agent]))
+	for (const agent of next) {
+		byId.set(agent.clientId, agent)
+	}
+	return [...byId.values()]
 }
 
 function sameConnectedAgents(
@@ -168,9 +189,9 @@ export function OnboardingRoute(handle: Handle) {
 				: payload.hasSecondMcpClient
 		secondAgentGiftActive = payload.secondAgentStandardGift?.active === true
 		connectedAgents =
-			source === 'live' || connectedAgents.length === 0
+			source === 'live'
 				? (payload.connectedAgents ?? [])
-				: connectedAgents
+				: mergeConnectedAgents(connectedAgents, payload.connectedAgents)
 		hasMcpClient =
 			source === 'snapshot'
 				? hasMcpClient || payload.hasMcpClient
@@ -430,7 +451,11 @@ export function OnboardingRoute(handle: Handle) {
 		if (activeStep === 1 && selectedAgent) {
 			rememberOnboardingSelectedAgent(selectedAgent)
 		}
-		const firstAgent = readRememberedOnboardingSelectedAgent()
+		const firstAgent = resolveOnboardingFirstAgentKind(
+			readRememberedOnboardingSelectedAgent(),
+			connectedAgents,
+		)
+		if (firstAgent) rememberOnboardingSelectedAgent(firstAgent)
 		const visibleSelectedAgent =
 			activeStep === 3
 				? resolveOnboardingStep3SelectedAgent(
@@ -491,6 +516,7 @@ export function OnboardingRoute(handle: Handle) {
 									onSelectStep: selectStep,
 									hasMcpClient,
 									loggedIn,
+									connectedAgents,
 									selectedAgent: visibleSelectedAgent,
 									selectedAgentLabel,
 									agentChooser,
@@ -509,6 +535,7 @@ export function OnboardingRoute(handle: Handle) {
 									hasAccessWin,
 									discoveryPrompt,
 									selectedAgentLabel: connectedAgentLabel,
+									connectedAgents,
 									search: readRouterSearch(handle),
 								})
 							: null}

--- a/packages/worker/client/routes/onboarding.tsx
+++ b/packages/worker/client/routes/onboarding.tsx
@@ -455,7 +455,6 @@ export function OnboardingRoute(handle: Handle) {
 			readRememberedOnboardingSelectedAgent(),
 			connectedAgents,
 		)
-		if (firstAgent) rememberOnboardingSelectedAgent(firstAgent)
 		const visibleSelectedAgent =
 			activeStep === 3
 				? resolveOnboardingStep3SelectedAgent(

--- a/packages/worker/src/app/handlers/onboarding.node.test.ts
+++ b/packages/worker/src/app/handlers/onboarding.node.test.ts
@@ -26,6 +26,7 @@ const mockModule = vi.hoisted(() => ({
 	listMcpServerSettings: vi.fn(),
 	loadMcpClientHubSnapshotOrNull: vi.fn(),
 	listSavedPackagesByUserId: vi.fn(),
+	loadOnboardingAccessWin: vi.fn(async () => false),
 }))
 
 vi.mock('#app/ssr-render.tsx', () => ({
@@ -52,6 +53,16 @@ vi.mock('#worker/package-registry/repo.ts', () => ({
 	listSavedPackagesByUserId: (...args: Array<unknown>) =>
 		mockModule.listSavedPackagesByUserId(...args),
 }))
+
+vi.mock('#mcp/onboarding-checklist.ts', async (importOriginal) => {
+	const actual =
+		await importOriginal<typeof import('#mcp/onboarding-checklist.ts')>()
+	return {
+		...actual,
+		loadOnboardingAccessWin: (...args: Array<unknown>) =>
+			mockModule.loadOnboardingAccessWin(...args),
+	}
+})
 
 vi.mock('#mcp/capabilities/mcp-servers/shared.ts', async (importOriginal) => {
 	const actual =
@@ -120,6 +131,71 @@ test('onboarding serves public setup content to anonymous visitors', async () =>
 	expect(anonymousPayload.setupPrompt.length).toBeGreaterThan(0)
 	expect(anonymousPayload.discoveryPrompt).toContain('https://example.com')
 	expectDisconnectedFeaturedCatalog(anonymousPayload.featuredMcpServers)
+})
+
+test('signed-in /onboarding resumes at the unfinished wizard step', async () => {
+	setAuthSessionSecret(testCookieSecret)
+	mockModule.readAuthenticatedAppUser.mockResolvedValue({
+		username: 'greg',
+		emailVerified: true,
+		mcpUser: { userId: 'user-1' },
+	})
+	const grants = vi.fn(async () => ({
+		items: [] as Array<{ id: string; clientId: string }>,
+	}))
+	const env = {
+		COOKIE_SECRET: testCookieSecret,
+		OAUTH_PROVIDER: { listUserGrants: grants },
+	} as Env
+	const handler = createOnboardingHandler(env)
+
+	mockModule.loadOnboardingAccessWin.mockResolvedValue(false)
+	const freshAccount = await handler.handler(
+		new RequestContext(new Request('https://example.com/onboarding')),
+	)
+	expect(freshAccount.status).toBe(302)
+	expect(freshAccount.headers.get('Location')).toBe(
+		'https://example.com/onboarding/step-1',
+	)
+
+	grants.mockResolvedValue({
+		items: [
+			{ id: 'g1', clientId: 'cursor-client' },
+			{ id: 'g2', clientId: 'claude-desktop-client' },
+		],
+	})
+	const midOnboarding = await handler.handler(
+		new RequestContext(new Request('https://example.com/onboarding')),
+	)
+	expect(midOnboarding.status).toBe(302)
+	expect(midOnboarding.headers.get('Location')).toBe(
+		'https://example.com/onboarding/step-2',
+	)
+
+	mockModule.loadOnboardingAccessWin.mockResolvedValue(true)
+	const finishedTwoAgents = await handler.handler(
+		new RequestContext(
+			new Request('https://example.com/onboarding?redirectTo=%2F'),
+		),
+	)
+	expect(finishedTwoAgents.status).toBe(302)
+	expect(finishedTwoAgents.headers.get('Location')).toBe(
+		'https://example.com/onboarding/step-3?redirectTo=%2F',
+	)
+
+	mockModule.readAuthenticatedAppUser.mockResolvedValue({
+		username: 'greg',
+		emailVerified: false,
+		mcpUser: { userId: 'user-1' },
+	})
+	const unverified = await handler.handler(
+		new RequestContext(new Request('https://example.com/onboarding')),
+	)
+	expect(unverified.status).toBe(302)
+	expect(unverified.headers.get('Location')).toBe(
+		'https://example.com/pending-verification',
+	)
+	mockModule.loadOnboardingAccessWin.mockResolvedValue(false)
 })
 
 test('onboarding API includes the authenticated package-scope username', async () => {

--- a/packages/worker/src/app/handlers/onboarding.ts
+++ b/packages/worker/src/app/handlers/onboarding.ts
@@ -7,6 +7,10 @@ import {
 	loadOnboardingAccessWinMemorySubject,
 	readOnboardingChecklistDismissed,
 } from '#mcp/onboarding-checklist.ts'
+import { hasSecondConnectedMcpClient } from '#universal/connected-mcp-agents.ts'
+import { loadInboundMcpConnectionState } from '#worker/connected-mcp-agents.ts'
+import { type OAuthGrantListHelpers } from '#worker/oauth-grants.ts'
+import { resolveOAuthHelpers } from '#worker/oauth-helpers.ts'
 import { normalizeRedirectTo } from '#app/auth-redirect.ts'
 import { readAuthenticatedAppUser } from '#app/authenticated-user.ts'
 import {
@@ -45,6 +49,7 @@ import {
 	onboardingStepPaths,
 	onboardingWizardStepHref,
 	parseOnboardingPathname,
+	type OnboardingWizardProgress,
 } from '#universal/onboarding-process.ts'
 import {
 	highlightResultsByKey,
@@ -241,6 +246,46 @@ async function loadOnboardingChooserFields(
 	}
 }
 
+async function loadOnboardingResumeProgress(
+	env: Env,
+	userId: string,
+): Promise<OnboardingWizardProgress> {
+	const helpers = await resolveOAuthHelpers<OAuthGrantListHelpers>(env)
+	const [inbound, hasAccessWin] = await Promise.all([
+		loadInboundMcpConnectionState(helpers, userId),
+		loadOnboardingAccessWin(env, userId),
+	])
+	return {
+		hasMcpClient: inbound.uniqueClientCount > 0,
+		hasAccessWin,
+		hasSecondMcpClient: hasSecondConnectedMcpClient(inbound.uniqueClientCount),
+	}
+}
+
+async function redirectOnboardingIndex(env: Env, request: Request) {
+	const requestUrl = new URL(request.url)
+	const user = await readAuthenticatedAppUser(request, env, {
+		prefetchFeatureFlags: true,
+	})
+	if (!user) {
+		return Response.redirect(
+			new URL(onboardingIndexRedirectHref(requestUrl.search), request.url),
+			302,
+		)
+	}
+	if (!user.emailVerified) {
+		return redirectUnverifiedToPending(request)
+	}
+	const progress = await loadOnboardingResumeProgress(env, user.mcpUser.userId)
+	return Response.redirect(
+		new URL(
+			onboardingIndexRedirectHref(requestUrl.search, progress),
+			request.url,
+		),
+		302,
+	)
+}
+
 function redirectUnverifiedToPending(request: Request) {
 	const requestUrl = new URL(request.url)
 	const redirectTo = normalizeRedirectTo(
@@ -275,10 +320,7 @@ export function createOnboardingHandler(env: Env) {
 		async handler({ request }) {
 			const requestUrl = new URL(request.url)
 			if (requestUrl.pathname === onboardingStepPaths.index) {
-				return Response.redirect(
-					new URL(onboardingIndexRedirectHref(requestUrl.search), request.url),
-					302,
-				)
+				return redirectOnboardingIndex(env, request)
 			}
 			const location = parseOnboardingPathname(requestUrl.pathname)
 			if (location && !location.valid) {

--- a/packages/worker/universal/onboarding-process.node.test.ts
+++ b/packages/worker/universal/onboarding-process.node.test.ts
@@ -23,6 +23,8 @@ import {
 	portabilityGuideEntity,
 	portabilityGuideSlug,
 	remainingOnboardingWizardLabels,
+	resolveOnboardingFirstAgentKind,
+	resumeOnboardingWizardStep,
 } from './onboarding-process.ts'
 
 const guidesDir = join(
@@ -48,6 +50,20 @@ test('the derived checklist covers verify-email plus each wizard step', () => {
 	expect(onboardingIndexRedirectHref('?redirectTo=%2F')).toBe(
 		'/onboarding/step-1?redirectTo=%2F',
 	)
+	expect(
+		onboardingIndexRedirectHref('?redirectTo=%2F', {
+			hasMcpClient: true,
+			hasAccessWin: false,
+			hasSecondMcpClient: false,
+		}),
+	).toBe('/onboarding/step-2?redirectTo=%2F')
+	expect(
+		onboardingIndexRedirectHref('', {
+			hasMcpClient: true,
+			hasAccessWin: true,
+			hasSecondMcpClient: true,
+		}),
+	).toBe('/onboarding/step-3')
 	expect(onboardingChecklistItemHref('install-starter', 'kentcdodds')).toBe(
 		'/@kentcdodds',
 	)
@@ -187,6 +203,56 @@ test('step 2 is one short prompt that retrieves the onboarding guide', () => {
 	expect(onboardingSecondAgentConnectedStatusLabel(true)).toBe(
 		"You've connected a second agent. Standard is free for 2 weeks.",
 	)
+})
+
+test('resume step is the first unfinished wizard step, else step 3', () => {
+	expect(
+		resumeOnboardingWizardStep({
+			hasMcpClient: false,
+			hasAccessWin: false,
+			hasSecondMcpClient: false,
+		}),
+	).toBe(1)
+	expect(
+		resumeOnboardingWizardStep({
+			hasMcpClient: true,
+			hasAccessWin: false,
+			hasSecondMcpClient: false,
+		}),
+	).toBe(2)
+	expect(
+		resumeOnboardingWizardStep({
+			hasMcpClient: true,
+			hasAccessWin: true,
+			hasSecondMcpClient: false,
+		}),
+	).toBe(3)
+	expect(
+		resumeOnboardingWizardStep({
+			hasMcpClient: true,
+			hasAccessWin: true,
+			hasSecondMcpClient: true,
+		}),
+	).toBe(3)
+	expect(
+		resolveOnboardingFirstAgentKind(null, [
+			{
+				kind: 'claude-desktop',
+				connectedAt: '2026-09-08T18:00:00.000Z',
+			},
+			{ kind: 'cursor', connectedAt: '2026-09-08T17:00:00.000Z' },
+		]),
+	).toBe('cursor')
+	expect(
+		resolveOnboardingFirstAgentKind('claude-desktop', [
+			{ kind: 'cursor', connectedAt: '2026-09-08T17:00:00.000Z' },
+		]),
+	).toBe('claude-desktop')
+	expect(
+		resolveOnboardingFirstAgentKind(null, [
+			{ kind: 'cursor', connectedAt: null },
+		]),
+	).toBeNull()
 })
 
 test('search leftover notice lists remaining wizard steps, not a quest', () => {

--- a/packages/worker/universal/onboarding-process.ts
+++ b/packages/worker/universal/onboarding-process.ts
@@ -200,6 +200,31 @@ export function uniqueOnboardingConnectedAgents(
 	return unique
 }
 
+/**
+ * Step 1 identity for Step 2 copy and Step 3 greying. Prefer the explicit
+ * picker choice; on return visits fall back to the earliest dated named
+ * inbound host so a cleared session still names Cursor / Claude Desktop.
+ */
+export function resolveOnboardingFirstAgentKind(
+	remembered: McpClientKind | null | undefined,
+	connectedAgents: ReadonlyArray<{
+		kind?: McpClientKind | null
+		connectedAt?: string | null
+	}> = [],
+): McpClientKind | null {
+	if (remembered && remembered !== 'other') return remembered
+	let oldest: { kind: McpClientKind; connectedAt: string } | null = null
+	for (const agent of connectedAgents) {
+		const kind = agent.kind
+		const connectedAt = agent.connectedAt
+		if (!kind || kind === 'other' || !connectedAt) continue
+		if (!oldest || connectedAt < oldest.connectedAt) {
+			oldest = { kind, connectedAt }
+		}
+	}
+	return oldest?.kind ?? null
+}
+
 export function onboardingConnectedListSeparator(
 	index: number,
 	length: number,
@@ -222,11 +247,27 @@ export function onboardingConnectedAgentLabelsLine(
 	return `Connected: ${labels.slice(0, -1).join(', ')}, and ${labels.at(-1)}`
 }
 
-export function remainingOnboardingWizardLabels(input: {
+export type OnboardingWizardProgress = {
 	hasMcpClient: boolean
 	hasAccessWin: boolean
 	hasSecondMcpClient: boolean
-}): Array<string> {
+}
+
+/**
+ * First unfinished wizard step. Finished accounts resume on Step 3 so the
+ * Connected list stays visible instead of a fresh Step 1 picker.
+ */
+export function resumeOnboardingWizardStep(
+	progress: OnboardingWizardProgress,
+): OnboardingWizardStepNumber {
+	if (!progress.hasMcpClient) return 1
+	if (!progress.hasAccessWin) return 2
+	return 3
+}
+
+export function remainingOnboardingWizardLabels(
+	input: OnboardingWizardProgress,
+): Array<string> {
 	const remaining: Array<string> = []
 	if (!input.hasMcpClient) {
 		remaining.push(onboardingWizardStepByNumber(1).label)
@@ -272,8 +313,12 @@ export function onboardingWizardStepHref(
 	return `${onboardingWizardStepByNumber(number).path}${search}`
 }
 
-export function onboardingIndexRedirectHref(search = '') {
-	return `${routes.onboardingStep1.href()}${search}`
+export function onboardingIndexRedirectHref(
+	search = '',
+	progress?: OnboardingWizardProgress,
+) {
+	const step = progress ? resumeOnboardingWizardStep(progress) : 1
+	return onboardingWizardStepHref(step, search)
 }
 
 export function onboardingChecklistItemHref(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Keep already-connected MCP hosts visible after onboarding, and send returning users to the wizard step that matches their progress.

## Why

During livestream testing, Greg connected Cursor and Claude Desktop in onboarding. Account → Connected agents showed both hosts, but landing back on `/onboarding` (from the homepage “Connect your agent” pill) always opened Step 1’s fresh picker. That panel never listed prior connections, so Claude Desktop and connected status looked missing. Kent called it a simple bug: return visits should resume at the correct step (Step 3 when appropriate) and still show the Connected list.

Root cause: `/onboarding` always 302’d to `/onboarding/step-1` before reading inbound grants or Step 2 access-win progress. Connected hosts only rendered on Step 3, and Step 2 named the first agent from session storage — empty on a new tab.

## Summary

- `/onboarding` now resumes at the first unfinished wizard step (Step 1 → 2 → 3). Finished accounts land on Step 3 so the Connected list stays on screen instead of a blank picker.
- Every wizard panel lists inbound connected hosts (same “Connected: Cursor and Claude Desktop” line).
- First-agent identity for Step 2 copy and Step 3 greying falls back to the earliest dated named inbound host when the picker session is gone. That inferred name stays render-local (not written to shared session storage).
- Snapshot hydration unions connected agents by `clientId` so a later SSR payload cannot drop a host the live poll already saw.

## Testing

- Focused node-unit suites for onboarding process, handler, wizard panels, and client loader (18 tests). Handler case: two inbound `clientId`s + access win → 302 `/onboarding/step-3`; mid-onboarding → Step 2; empty → Step 1.
- Pre-commit `typecheck` passed.
- Push hook: `test:node` 2977 passed, `test:workers` 341 passed.
- Preview `kody-pr-2188`: signed in as `me@kentcdodds.com`. Seed account has no inbound grants, so `GET /onboarding` 302s to `/onboarding/step-1`. Two-agent resume is covered by the handler unit test.
- Addressed CodeRabbit: do not persist an inferred first agent into shared session storage (cross-account leak in the same browser).

## Repro

1. Sign in, complete Step 1 (e.g. Cursor) and Step 3 (e.g. Claude Desktop).
2. Confirm Account → Connected agents lists both.
3. Open `/` and click “Connect your agent”, or visit `/onboarding`.
4. Before: Step 1 picker, no Claude Desktop / connected line.
5. After: redirect to Step 3 (or Step 2 if the access win is still missing) with `Connected: Cursor and Claude Desktop`.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `9866911` · **Head:** `51a37ba`

**Classification:** extends — onboarding resume and connected-host display change on `app-ui`. No primitives added.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `app-ui` | surfaces | extends — `/onboarding` resume step and Connected list on every wizard panel |
| `mcp-oauth` | auth | composes — resume reads unique inbound `clientId`s |

### Change flow

Signed-in `/onboarding` now reads inbound grants and the Step 2 access win, then 302s to the first unfinished step so the Connected list is not hidden behind a fresh Step 1 picker.

```mermaid
sequenceDiagram
	actor User
	participant appUi as app-ui
	participant mcpOauth as mcp-oauth
	User->>appUi: GET /onboarding
	appUi->>mcpOauth: list unique inbound clientIds
	appUi->>appUi: load Step 2 access win
	alt no host yet
		appUi-->>User: 302 /onboarding/step-1
	else host connected, no access win
		appUi-->>User: 302 /onboarding/step-2
	else access win done
		appUi-->>User: 302 /onboarding/step-3
	end
	Note over appUi: Connected list on every wizard panel
```

### Invariants

Per-user isolation is unchanged: resume and the Connected list still read only the signed-in user’s inbound grants.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d8e5b354-7883-4027-a772-77a71b256a47?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d8e5b354-7883-4027-a772-77a71b256a47&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Onboarding now resumes at the first unfinished step for returning users.
  - Completed onboarding accounts go directly to Step 3, keeping connected agents visible.
  - Connected agents are displayed consistently across onboarding steps, with names and agent details preserved.
  - Returning users’ previously selected agent information is restored when available.

- **Documentation**
  - Updated onboarding guidance to describe resume behavior and connected-agent display details.

- **Tests**
  - Added coverage for onboarding redirects, progress-based resumption, and connected-agent rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->