### PR TITLE
Fix communityFork overwrite gate on person-account first publish

### DIFF
--- a/packages/worker/src/repo/artifact-repo-fork.node.test.ts
+++ b/packages/worker/src/repo/artifact-repo-fork.node.test.ts
@@ -180,15 +180,11 @@ test('persistForkedArtifactRepoContents syncs only changed files on production r
 		copiedOriginCommit: 'commit-origin',
 		destCommit: 'commit-edited',
 	})
-	expect(mockModule.updateEntitySource).toHaveBeenCalledWith(
-		env.APP_DB,
-		expect.objectContaining({
-			publishedCommit: 'commit-origin',
-		}),
-	)
+	expect(mockModule.updateEntitySource).not.toHaveBeenCalled()
 	expect(mockModule.syncArtifactSourceSnapshot).toHaveBeenCalledWith(
 		expect.objectContaining({
 			files: { 'package.json': '{"name":"@jane/demo"}' },
+			existingHeadCommit: 'commit-origin',
 		}),
 	)
 	expect(mockModule.readArtifactFileAtCommit).not.toHaveBeenCalled()
@@ -245,12 +241,7 @@ test('persistForkedArtifactRepoContents stamps dest HEAD and rewrites only dest 
 		copiedOriginCommit: 'commit-head',
 		destCommit: 'commit-rewritten',
 	})
-	expect(mockModule.updateEntitySource).toHaveBeenCalledWith(
-		env.APP_DB,
-		expect.objectContaining({
-			publishedCommit: 'commit-head',
-		}),
-	)
+	expect(mockModule.updateEntitySource).not.toHaveBeenCalled()
 	expect(mockModule.readArtifactFileAtCommit).toHaveBeenCalledWith({
 		env,
 		repoId: 'package-dest',
@@ -259,6 +250,7 @@ test('persistForkedArtifactRepoContents stamps dest HEAD and rewrites only dest 
 	})
 	expect(mockModule.syncArtifactSourceSnapshot).toHaveBeenCalledWith(
 		expect.objectContaining({
+			existingHeadCommit: 'commit-head',
 			files: {
 				'package.json': `${JSON.stringify(
 					{
@@ -306,6 +298,46 @@ test('persistForkedArtifactRepoContents rejects a forked dest with no HEAD', asy
 	expect(mockModule.syncArtifactSourceSnapshot).not.toHaveBeenCalled()
 })
 
+test('persistForkedArtifactRepoContents stamps dest HEAD only when the rewrite is already a no-op', async () => {
+	resetArtifactRepoForkMocks()
+	mockModule.resolveExistingArtifactSourceRepo.mockResolvedValue({
+		info: async () => ({
+			remote:
+				'https://acct.artifacts.cloudflare.net/git/default/package-dest.git',
+		}),
+	})
+	mockModule.isLoopbackArtifactsRemote.mockReturnValue(false)
+	mockModule.resolveArtifactSourceHead.mockResolvedValue({
+		branch: 'main',
+		commit: 'commit-head',
+	})
+	mockModule.updateEntitySource.mockResolvedValue(true)
+
+	const persisted = await persistForkedArtifactRepoContents({
+		env,
+		baseUrl: 'https://kody.test',
+		userId: 'user-1',
+		source,
+		originCommit: 'commit-head',
+		expectedPackageScope: 'jane',
+		targetKodyId: 'demo',
+		changedFiles: {},
+		files: { 'package.json': '{"name":"@jane/demo"}' },
+	})
+
+	expect(persisted).toEqual({
+		copiedOriginCommit: 'commit-head',
+		destCommit: 'commit-head',
+	})
+	expect(mockModule.updateEntitySource).toHaveBeenCalledWith(
+		env.APP_DB,
+		expect.objectContaining({
+			publishedCommit: 'commit-head',
+		}),
+	)
+	expect(mockModule.syncArtifactSourceSnapshot).not.toHaveBeenCalled()
+})
+
 test('persistForkedArtifactRepoContents fails closed when dest published_commit cannot be stamped', async () => {
 	resetArtifactRepoForkMocks()
 	mockModule.resolveExistingArtifactSourceRepo.mockResolvedValue({
@@ -330,7 +362,7 @@ test('persistForkedArtifactRepoContents fails closed when dest published_commit 
 			originCommit: 'commit-head',
 			expectedPackageScope: 'jane',
 			targetKodyId: 'demo',
-			changedFiles: { 'package.json': '{"name":"@jane/demo"}' },
+			changedFiles: {},
 			files: { 'package.json': '{"name":"@jane/demo"}' },
 		}),
 	).rejects.toThrow(/could not be marked at dest HEAD commit-head/)

--- a/packages/worker/src/repo/artifact-repo-fork.ts
+++ b/packages/worker/src/repo/artifact-repo-fork.ts
@@ -45,12 +45,14 @@ export type PersistForkedArtifactRepoResult = {
  * dest contents match production's "fork + small commit" outcome without
  * opening a RepoSession.
  *
- * Production remotes stamp `published_commit` to dest HEAD (the default
- * branch tip Artifacts copied), then apply edits through the existing-source
- * session path. When dest HEAD matches the listing pin used in prepare,
- * `changedFiles` apply. When dest HEAD is ahead of that pin, only dest
- * HEAD's `package.json` is rewritten so pin-relative edits cannot revert
- * later origin commits.
+ * Production remotes apply the rewrite as a first publish from dest HEAD
+ * (the default-branch tip Artifacts copied). They must not stamp
+ * `published_commit` before that rewrite: doing so opens the existing-source
+ * session path and `publishSession({ force: true })`, which the overwrite
+ * gate correctly rejects for a brand-new fork. When dest HEAD matches the
+ * listing pin used in prepare, `changedFiles` apply. When dest HEAD is
+ * ahead of that pin, only dest HEAD's `package.json` is rewritten so
+ * pin-relative edits cannot revert later origin commits.
  */
 export async function persistForkedArtifactRepoContents(input: {
 	env: Env
@@ -116,16 +118,6 @@ export async function persistForkedArtifactRepoContents(input: {
 		)
 	}
 
-	const marked = await updateEntitySource(input.env.APP_DB, {
-		id: input.source.id,
-		userId: input.source.user_id,
-		publishedCommit: destHead.commit,
-	})
-	if (!marked) {
-		throw new Error(
-			`Forked source "${input.source.id}" could not be marked at dest HEAD ${destHead.commit}.`,
-		)
-	}
 	const filesToSync =
 		destHead.commit === input.originCommit
 			? input.changedFiles
@@ -137,6 +129,16 @@ export async function persistForkedArtifactRepoContents(input: {
 					targetKodyId: input.targetKodyId,
 				})
 	if (Object.keys(filesToSync).length === 0) {
+		const marked = await updateEntitySource(input.env.APP_DB, {
+			id: input.source.id,
+			userId: input.source.user_id,
+			publishedCommit: destHead.commit,
+		})
+		if (!marked) {
+			throw new Error(
+				`Forked source "${input.source.id}" could not be marked at dest HEAD ${destHead.commit}.`,
+			)
+		}
 		return {
 			copiedOriginCommit: destHead.commit,
 			destCommit: destHead.commit,
@@ -148,6 +150,7 @@ export async function persistForkedArtifactRepoContents(input: {
 		userId: input.userId,
 		sourceId: input.source.id,
 		files: filesToSync,
+		existingHeadCommit: destHead.commit,
 		bootstrapAccess: input.bootstrapAccess ?? null,
 		serverTiming: input.serverTiming,
 	})

--- a/packages/worker/src/repo/repo-session-do-publish.node.test.ts
+++ b/packages/worker/src/repo/repo-session-do-publish.node.test.ts
@@ -1375,3 +1375,31 @@ test('runChecks forwards expectedPackageScope for a still-plain repo so promote 
 		}),
 	)
 })
+
+test('publishSession still requires overwrite confirmation for forced publishes of already-published packages', async () => {
+	setCommonSessionFixtures()
+	mockModule.getEntitySourceById.mockResolvedValue({
+		id: 'source-1',
+		user_id: 'user-1',
+		entity_kind: 'package',
+		entity_id: 'package-1',
+		repo_id: 'source-repo',
+		published_commit: 'commit-base',
+		manifest_path: 'package.json',
+		source_root: '/',
+	})
+	mockModule.git.push.mockClear()
+	mockModule.updateEntitySource.mockClear()
+
+	await expect(
+		new RepoSession(createDurableObjectState(), createEnv()).publishSession({
+			sessionId: 'session-1',
+			userId: 'user-1',
+			force: true,
+		}),
+	).rejects.toThrow(
+		'repo forced publish would overwrite existing package source "source-1"',
+	)
+	expect(mockModule.git.push).not.toHaveBeenCalled()
+	expect(mockModule.updateEntitySource).not.toHaveBeenCalled()
+})

--- a/packages/worker/src/repo/repo-session-do.node.test.ts
+++ b/packages/worker/src/repo/repo-session-do.node.test.ts
@@ -1328,8 +1328,23 @@ test('bootstrapSource first-publishes from dest HEAD without replacing the forke
 		expiresAt: '2025-10-09T08:53:20.000Z',
 	}
 	const jobManifest = '{"version":1,"kind":"job","entrypoint":"src/job.ts"}'
+	const destWorkspaceFiles = {
+		'kody.json': jobManifest,
+		'src/job.ts':
+			'export default async function main() { return { ok: true } }',
+		'README.md': 'forked dest tree',
+	}
 	mockModule.getEntitySourceById.mockResolvedValue(unpublishedSource)
-	mockModule.workspaceReadFile.mockResolvedValue(jobManifest)
+	mockModule.workspaceGlob.mockResolvedValue(
+		Object.keys(destWorkspaceFiles).map((path) => ({
+			type: 'file' as const,
+			path: `/session/${path}`,
+		})),
+	)
+	mockModule.workspaceReadFile.mockImplementation(async (path: string) => {
+		const relative = path.replace(/^\/session\//, '')
+		return destWorkspaceFiles[relative] ?? null
+	})
 	mockModule.gitState.headCommit = 'commit-dest-head'
 	mockModule.gitState.statusEntries = [{ status: 'modified' }]
 	mockModule.git.clone.mockClear()
@@ -1349,6 +1364,7 @@ test('bootstrapSource first-publishes from dest HEAD without replacing the forke
 	})
 
 	expect(cloned.publishedCommit).toBe('commit-dest-head')
+	expect(cloned.files).toEqual(destWorkspaceFiles)
 	expect(mockModule.git.clone).toHaveBeenCalledWith(
 		expect.objectContaining({
 			branch: 'main',

--- a/packages/worker/src/repo/repo-session-do.node.test.ts
+++ b/packages/worker/src/repo/repo-session-do.node.test.ts
@@ -1302,3 +1302,105 @@ test('readFile retries D1 reads and falls back to cached sessions when replicas 
 		content: 'export default {}',
 	})
 })
+
+test('bootstrapSource first-publishes from dest HEAD without replacing the forked tree', async () => {
+	consoleWarn.mockImplementation(() => {})
+	restoreRepoSessionMockBaseline()
+	const unpublishedSource = {
+		id: 'source-1',
+		user_id: 'user-1',
+		entity_kind: 'job' as const,
+		entity_id: 'job-1',
+		repo_id: 'job-1',
+		published_commit: null,
+		indexed_commit: null,
+		manifest_path: 'kody.json',
+		source_root: '/',
+		last_external_check_at: null,
+		external_check_until: null,
+		created_at: '2026-04-16T00:00:00.000Z',
+		updated_at: '2026-04-16T00:00:00.000Z',
+	}
+	const bootstrapAccess = {
+		defaultBranch: 'main',
+		remote: 'https://acct.artifacts.cloudflare.net/git/default/job-1.git',
+		token: 'art_v1_bootstrap?expires=1760000000',
+		expiresAt: '2025-10-09T08:53:20.000Z',
+	}
+	const jobManifest = '{"version":1,"kind":"job","entrypoint":"src/job.ts"}'
+	mockModule.getEntitySourceById.mockResolvedValue(unpublishedSource)
+	mockModule.workspaceReadFile.mockResolvedValue(jobManifest)
+	mockModule.gitState.headCommit = 'commit-dest-head'
+	mockModule.gitState.statusEntries = [{ status: 'modified' }]
+	mockModule.git.clone.mockClear()
+	mockModule.git.init.mockClear()
+	mockModule.updateEntitySource.mockClear()
+
+	const cloned = await new RepoSession(
+		createDurableObjectState(),
+		createEnv(),
+	).bootstrapSource({
+		sessionId: 'session-bootstrap-fork',
+		sourceId: 'source-1',
+		userId: 'user-1',
+		existingHeadCommit: 'commit-dest-head',
+		bootstrapAccess,
+		edits: [{ kind: 'write', path: 'kody.json', content: jobManifest }],
+	})
+
+	expect(cloned.publishedCommit).toBe('commit-dest-head')
+	expect(mockModule.git.clone).toHaveBeenCalledWith(
+		expect.objectContaining({
+			branch: 'main',
+			singleBranch: true,
+		}),
+	)
+	expect(mockModule.git.init).not.toHaveBeenCalled()
+	expect(mockModule.updateEntitySource).toHaveBeenCalledWith(
+		expect.anything(),
+		expect.objectContaining({
+			id: 'source-1',
+			publishedCommit: 'commit-dest-head',
+		}),
+	)
+
+	restoreRepoSessionMockBaseline()
+	mockModule.getEntitySourceById.mockResolvedValue(unpublishedSource)
+	mockModule.gitState.headCommit = 'commit-other'
+	mockModule.git.clone.mockClear()
+	mockModule.updateEntitySource.mockClear()
+
+	await expect(
+		new RepoSession(createDurableObjectState(), createEnv()).bootstrapSource({
+			sessionId: 'session-bootstrap-mismatch',
+			sourceId: 'source-1',
+			userId: 'user-1',
+			existingHeadCommit: 'commit-dest-head',
+			bootstrapAccess,
+			edits: [{ kind: 'write', path: 'kody.json', content: jobManifest }],
+		}),
+	).rejects.toThrow(/does not match expected "commit-dest-head"/)
+	expect(mockModule.updateEntitySource).not.toHaveBeenCalled()
+
+	restoreRepoSessionMockBaseline()
+	mockModule.getEntitySourceById.mockResolvedValue(unpublishedSource)
+	mockModule.workspaceReadFile.mockResolvedValue(jobManifest)
+	mockModule.gitState.headCommit = 'commit-empty-bootstrap'
+	mockModule.gitState.statusEntries = [{ status: 'modified' }]
+	mockModule.git.clone.mockClear()
+	mockModule.git.init.mockClear()
+
+	await new RepoSession(
+		createDurableObjectState(),
+		createEnv(),
+	).bootstrapSource({
+		sessionId: 'session-bootstrap-empty',
+		sourceId: 'source-1',
+		userId: 'user-1',
+		bootstrapAccess,
+		edits: [{ kind: 'write', path: 'kody.json', content: jobManifest }],
+	})
+
+	expect(mockModule.git.init).toHaveBeenCalled()
+	expect(mockModule.git.clone).not.toHaveBeenCalled()
+})

--- a/packages/worker/src/repo/repo-session-do.ts
+++ b/packages/worker/src/repo/repo-session-do.ts
@@ -1532,6 +1532,16 @@ class RepoSessionBase extends DurableObject<Env> {
 				return commit
 			},
 		)
+		const snapshotFiles = await pushServerTiming(
+			serverTiming,
+			'bootstrap-workspace-snapshot',
+			() => this.collectWorkspaceFiles(),
+		)
+		if (input.existingHeadCommit && Object.keys(snapshotFiles).length === 0) {
+			throw new Error(
+				`Source "${source.id}" first-publish from dest HEAD produced an empty workspace snapshot.`,
+			)
+		}
 		await pushServerTiming(serverTiming, 'bootstrap-git-push', () =>
 			this.git.push({
 				dir: repoSessionWorkspacePrefix,
@@ -1566,6 +1576,7 @@ class RepoSessionBase extends DurableObject<Env> {
 			sessionId: input.sessionId,
 			publishedCommit,
 			message: `Bootstrapped source ${source.id} in ${source.repo_id}.`,
+			files: snapshotFiles,
 			serverTiming,
 		}
 	}

--- a/packages/worker/src/repo/repo-session-do.ts
+++ b/packages/worker/src/repo/repo-session-do.ts
@@ -1402,6 +1402,7 @@ class RepoSessionBase extends DurableObject<Env> {
 		sourceId: string
 		userId: string
 		bootstrapAccess?: ArtifactBootstrapAccess | null
+		existingHeadCommit?: string
 		edits: Array<{
 			kind: 'write' | 'replace' | 'writeJson'
 			path: string
@@ -1468,23 +1469,45 @@ class RepoSessionBase extends DurableObject<Env> {
 			input.bootstrapAccess?.defaultBranch ??
 			remoteSetup.sourceInfo?.defaultBranch ??
 			defaultSessionBranch
-		await pushServerTiming(serverTiming, 'bootstrap-git-init', async () => {
-			await this.resetWorkspace()
-			await this.workspace.mkdir(repoSessionWorkspacePrefix, {
-				recursive: true,
-			})
-			await this.git.init({
-				dir: repoSessionWorkspacePrefix,
-				defaultBranch: targetBranch,
-			})
-			await this.ensureRemote({
-				name: 'source',
-				url: buildAuthenticatedArtifactsRemote({
+		const sourceRemoteUrl = buildAuthenticatedArtifactsRemote({
+			remote: remoteSetup.remote,
+			token: remoteSetup.token,
+		})
+		if (input.existingHeadCommit) {
+			await pushServerTiming(serverTiming, 'bootstrap-git-clone', async () => {
+				await this.cloneArtifactsRepoWithRetry({
 					remote: remoteSetup.remote,
 					token: remoteSetup.token,
-				}),
+					branch: targetBranch,
+					resetBeforeFirstAttempt: true,
+				})
+				const head = await this.getHeadCommit()
+				if (head !== input.existingHeadCommit) {
+					throw new Error(
+						`Forked dest HEAD "${head ?? 'none'}" does not match expected "${input.existingHeadCommit}".`,
+					)
+				}
+				await this.ensureRemote({
+					name: 'source',
+					url: sourceRemoteUrl,
+				})
 			})
-		})
+		} else {
+			await pushServerTiming(serverTiming, 'bootstrap-git-init', async () => {
+				await this.resetWorkspace()
+				await this.workspace.mkdir(repoSessionWorkspacePrefix, {
+					recursive: true,
+				})
+				await this.git.init({
+					dir: repoSessionWorkspacePrefix,
+					defaultBranch: targetBranch,
+				})
+				await this.ensureRemote({
+					name: 'source',
+					url: sourceRemoteUrl,
+				})
+			})
+		}
 		await pushServerTiming(serverTiming, 'bootstrap-write-files', () =>
 			this.applyWorkspaceEdits({
 				edits: input.edits as Array<RepoSessionEdit>,

--- a/packages/worker/src/repo/repo-session-rpc.ts
+++ b/packages/worker/src/repo/repo-session-rpc.ts
@@ -132,6 +132,7 @@ export type RepoSessionRpc = {
 		userId: string
 		edits: Array<Exclude<RepoSessionEdit, { kind: 'delete' | 'move' }>>
 		bootstrapAccess?: ArtifactBootstrapAccess | null
+		existingHeadCommit?: string
 	}) => Promise<RepoSourceBootstrapResult>
 	runChecks: (payload: {
 		sessionId: string

--- a/packages/worker/src/repo/source-sync.node.test.ts
+++ b/packages/worker/src/repo/source-sync.node.test.ts
@@ -360,11 +360,18 @@ test('syncArtifactSourceSnapshot first-publishes a forked dest HEAD without forc
 		repo_id: 'package-1',
 		manifest_path: 'package.json',
 	}
+	const destWorkspaceFiles = {
+		'package.json':
+			'{"name":"@jane/demo","exports":{".":"./src/index.ts"},"kody":{"id":"demo","description":"Demo"},"private":true}',
+		'src/index.ts': 'export const ready = true\n',
+		'README.md': 'forked dest tree',
+	}
 	const bootstrapClient = {
 		bootstrapSource: vi.fn(async () => ({
 			sessionId: 'source-sync-source-1-session',
 			publishedCommit: 'commit-fork-rewrite',
 			message: 'Bootstrapped source source-1 in package-1.',
+			files: destWorkspaceFiles,
 		})),
 		openSession: vi.fn(),
 		applyEdits: vi.fn(),
@@ -401,6 +408,39 @@ test('syncArtifactSourceSnapshot first-publishes a forked dest HEAD without forc
 	)
 	expect(bootstrapClient.openSession).not.toHaveBeenCalled()
 	expect(bootstrapClient.publishSession).not.toHaveBeenCalled()
+	expect(mockModule.writePublishedSourceSnapshot).toHaveBeenCalledWith(
+		expect.objectContaining({
+			files: destWorkspaceFiles,
+			source: expect.objectContaining({
+				published_commit: 'commit-fork-rewrite',
+			}),
+		}),
+	)
+
+	mockModule.getEntitySourceById.mockReset()
+	mockModule.repoSessionRpc.mockReset()
+	mockModule.writePublishedSourceSnapshot.mockReset()
+	const overlayOnlyClient = {
+		...bootstrapClient,
+		bootstrapSource: vi.fn(async () => ({
+			sessionId: 'source-sync-source-1-session',
+			publishedCommit: 'commit-fork-rewrite',
+			message: 'Bootstrapped source source-1 in package-1.',
+		})),
+	}
+	mockModule.getEntitySourceById.mockResolvedValueOnce(unpublishedPackageSource)
+	mockModule.repoSessionRpc.mockReturnValueOnce(overlayOnlyClient as never)
+
+	await expect(
+		syncArtifactSourceSnapshot({
+			...createSyncEnv(),
+			existingHeadCommit: 'commit-dest-head',
+			files: {
+				'package.json': destWorkspaceFiles['package.json'],
+			},
+		}),
+	).rejects.toThrow(/produced no workspace snapshot/)
+	expect(mockModule.writePublishedSourceSnapshot).not.toHaveBeenCalled()
 
 	mockModule.getEntitySourceById.mockReset()
 	mockModule.repoSessionRpc.mockReset()

--- a/packages/worker/src/repo/source-sync.node.test.ts
+++ b/packages/worker/src/repo/source-sync.node.test.ts
@@ -258,12 +258,11 @@ test('syncArtifactSourceSnapshot bootstraps new sources and uses repo sessions f
 			rollbackOnError: true,
 		}),
 	)
-	expect(sessionClient.publishSession).toHaveBeenCalledWith(
-		expect.objectContaining({
-			userId: 'user-1',
-			force: true,
-		}),
-	)
+	expect(sessionClient.publishSession).toHaveBeenCalledWith({
+		sessionId: expect.stringMatching(/^source-sync-source-1-/),
+		userId: 'user-1',
+		force: true,
+	})
 	expect(mockModule.writePublishedSourceSnapshot).not.toHaveBeenCalled()
 	expect(mockModule.updateEntitySource).not.toHaveBeenCalled()
 	expect(sessionClient.discardSession).toHaveBeenCalledWith(
@@ -344,4 +343,94 @@ test('syncArtifactSourceSnapshot refuses to bootstrap a locked package without a
 	expect(allowedCommit).toBe('commit-bootstrap-locked')
 	expect(allowedBootstrapClient.bootstrapSource).toHaveBeenCalled()
 	expect(mockModule.loadLockedSavedPackage).not.toHaveBeenCalled()
+})
+
+test('syncArtifactSourceSnapshot first-publishes a forked dest HEAD without force overwrite', async () => {
+	mockModule.getEntitySourceById.mockReset()
+	mockModule.updateEntitySource.mockReset()
+	mockModule.repoSessionRpc.mockReset()
+	mockModule.writePublishedSourceSnapshot.mockReset()
+	mockModule.loadLockedSavedPackage.mockReset()
+	mockModule.loadLockedSavedPackage.mockResolvedValue(null)
+
+	const unpublishedPackageSource = {
+		...createUnpublishedSourceRow(),
+		entity_kind: 'package' as const,
+		entity_id: 'package-1',
+		repo_id: 'package-1',
+		manifest_path: 'package.json',
+	}
+	const bootstrapClient = {
+		bootstrapSource: vi.fn(async () => ({
+			sessionId: 'source-sync-source-1-session',
+			publishedCommit: 'commit-fork-rewrite',
+			message: 'Bootstrapped source source-1 in package-1.',
+		})),
+		openSession: vi.fn(),
+		applyEdits: vi.fn(),
+		publishSession: vi.fn(),
+		discardSession: vi.fn(async () => ({
+			ok: true as const,
+			sessionId: 'source-sync-source-1-session',
+			deleted: false,
+		})),
+	}
+	mockModule.getEntitySourceById.mockResolvedValueOnce(unpublishedPackageSource)
+	mockModule.repoSessionRpc.mockReturnValueOnce(bootstrapClient as never)
+
+	const destCommit = await syncArtifactSourceSnapshot({
+		...createSyncEnv(),
+		existingHeadCommit: 'commit-dest-head',
+		files: {
+			'package.json':
+				'{"name":"@jane/demo","exports":{".":"./src/index.ts"},"kody":{"id":"demo","description":"Demo"},"private":true}',
+		},
+	})
+
+	expect(destCommit).toBe('commit-fork-rewrite')
+	expect(bootstrapClient.bootstrapSource).toHaveBeenCalledWith(
+		expect.objectContaining({
+			existingHeadCommit: 'commit-dest-head',
+			edits: [
+				expect.objectContaining({
+					kind: 'write',
+					path: 'package.json',
+				}),
+			],
+		}),
+	)
+	expect(bootstrapClient.openSession).not.toHaveBeenCalled()
+	expect(bootstrapClient.publishSession).not.toHaveBeenCalled()
+
+	mockModule.getEntitySourceById.mockReset()
+	mockModule.repoSessionRpc.mockReset()
+	const publishedClient = {
+		bootstrapSource: vi.fn(),
+		openSession: vi.fn(),
+		applyEdits: vi.fn(),
+		publishSession: vi.fn(),
+		discardSession: vi.fn(async () => ({
+			ok: true as const,
+			sessionId: 'source-sync-source-1-session',
+			deleted: false,
+		})),
+	}
+	mockModule.getEntitySourceById.mockResolvedValueOnce({
+		...unpublishedPackageSource,
+		published_commit: 'commit-existing-1',
+	})
+	mockModule.repoSessionRpc.mockReturnValueOnce(publishedClient as never)
+
+	await expect(
+		syncArtifactSourceSnapshot({
+			...createSyncEnv(),
+			existingHeadCommit: 'commit-dest-head',
+			files: {
+				'package.json':
+					'{"name":"@jane/demo","exports":{".":"./src/index.ts"},"kody":{"id":"demo","description":"Demo"},"private":true}',
+			},
+		}),
+	).rejects.toThrow(/already has a published commit/)
+	expect(publishedClient.bootstrapSource).not.toHaveBeenCalled()
+	expect(publishedClient.publishSession).not.toHaveBeenCalled()
 })

--- a/packages/worker/src/repo/source-sync.ts
+++ b/packages/worker/src/repo/source-sync.ts
@@ -33,6 +33,12 @@ type SyncArtifactSourceInput = {
 	sourceId: string | null
 	files: Record<string, string>
 	bootstrapAccess?: ArtifactBootstrapAccess | null
+	/**
+	 * First-publish a storage-layer fork from dest HEAD. Applies `files` on
+	 * top of that commit through `bootstrapSource` instead of force-publishing
+	 * an already-stamped source (which hits the overwrite confirmation gate).
+	 */
+	existingHeadCommit?: string
 	destructiveOverwriteConfirmed?: boolean
 	privateVisibilityChangeConfirmed?: boolean
 	/**
@@ -155,6 +161,11 @@ export async function syncArtifactSourceSnapshot(
 			'Entity source ownership mismatch: refusing to sync a repo snapshot for another user.',
 		)
 	}
+	if (source.published_commit && input.existingHeadCommit) {
+		throw new Error(
+			`Source "${source.id}" already has a published commit; existingHeadCommit is only valid for first publish from a forked dest HEAD.`,
+		)
+	}
 	const sessionId = buildSyncSessionId(source.id)
 	const session = repoSessionRpc(input.env, sessionId)
 	const edits = Object.entries(input.files).map(([path, content]) => ({
@@ -172,7 +183,8 @@ export async function syncArtifactSourceSnapshot(
 			})
 			if (
 				input.bootstrapAccess?.remote &&
-				isLoopbackArtifactsRemote(input.bootstrapAccess.remote)
+				isLoopbackArtifactsRemote(input.bootstrapAccess.remote) &&
+				input.existingHeadCommit == null
 			) {
 				return await pushServerTiming(
 					input.serverTiming,
@@ -244,6 +256,9 @@ export async function syncArtifactSourceSnapshot(
 						userId: input.userId,
 						edits,
 						bootstrapAccess: input.bootstrapAccess ?? null,
+						...(input.existingHeadCommit
+							? { existingHeadCommit: input.existingHeadCommit }
+							: {}),
 					})
 					if (input.serverTiming && result.serverTiming) {
 						input.serverTiming.push(...result.serverTiming)

--- a/packages/worker/src/repo/source-sync.ts
+++ b/packages/worker/src/repo/source-sync.ts
@@ -266,11 +266,21 @@ export async function syncArtifactSourceSnapshot(
 					return result
 				},
 			)
+			const snapshotFiles = bootstrapResult.files ?? input.files
+			if (
+				input.existingHeadCommit &&
+				(bootstrapResult.files == null ||
+					Object.keys(bootstrapResult.files).length === 0)
+			) {
+				throw new Error(
+					`Source "${source.id}" first-publish from dest HEAD produced no workspace snapshot.`,
+				)
+			}
 			await pushServerTiming(input.serverTiming, 'published-snapshot', () =>
 				writePublishedSnapshotWithRevert({
 					env: input.env,
 					source,
-					files: input.files,
+					files: snapshotFiles,
 					publishedCommit: bootstrapResult.publishedCommit,
 				}),
 			)

--- a/packages/worker/src/repo/types.ts
+++ b/packages/worker/src/repo/types.ts
@@ -383,6 +383,12 @@ export type RepoSourceBootstrapResult = {
 	sessionId: string
 	publishedCommit: string
 	message: string
+	/**
+	 * Workspace tree after bootstrap. Required for dest-HEAD first publish so
+	 * the published snapshot is the forked repo plus overlays, not just the
+	 * rewritten files passed into sync.
+	 */
+	files?: Record<string, string>
 	serverTiming?: Array<ServerTimingEntry>
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Person-account one-click Install and `communityFork` should copy a public listing into a new inert source without asking for destructive-overwrite confirmation.

## Why

Fixes #2190. Storage-layer forks stamped `published_commit` to dest HEAD before the `@user/…` `package.json` rewrite. `syncArtifactSourceSnapshot` then treated that brand-new source as already published and called `publishSession({ force: true })` without `destructiveOverwriteConfirmed`. The overwrite gate correctly rejected that as overwriting existing package source, so every person-account Install failed and minted a new source UUID on each attempt.

This is a path bug, not a product decision. The gate should still require confirm for real forced publishes of already-published sources.

## Summary

- `persistForkedArtifactRepoContents` no longer stamps `published_commit` before the rewrite.
- The rewrite is a first publish from dest HEAD via `bootstrapSource({ existingHeadCommit })`, which clones the forked tree, applies only the changed files, then stamps `published_commit`.
- The published KV snapshot is the full dest workspace after the rewrite, not only overlay files.
- Empty rewrites still stamp dest HEAD only when there is nothing to commit.
- Force-publish of an already-published package still requires `confirm_destructive_overwrite`.

## Testing

- `vitest` node-unit: `artifact-repo-fork`, `source-sync`, `repo-session-do`, `repo-session-do-publish` (44 tests).
- Pre-push: `test:node` (2990) and `test:workers` (341).

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `7be81a92` · **Head:** `ad80f2ea`

**Classification:** extends — first-publish path for storage-layer community forks; overwrite gate unchanged for already-published sources.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `repo-sessions` | runtime | extends — `bootstrapSource` can first-publish from dest HEAD and returns the full workspace snapshot |

### Change flow

Person-account `communityFork` copies origin HEAD at the storage layer, then first-publishes the scope rewrite from that dest tip. It no longer stamps `published_commit` before the rewrite, so force-publish overwrite confirmation does not fire. The published snapshot is the cloned dest tree plus overlays.

```mermaid
sequenceDiagram
	actor User
	participant communityFork as communityFork
	participant artifactFork as artifact-repo-fork
	participant sourceSync as source-sync
	participant repoSessions as repo-sessions
	User->>communityFork: Install or communityFork
	communityFork->>artifactFork: persistForkedArtifactRepoContents
	artifactFork->>artifactFork: copy dest HEAD, do not stamp published_commit
	artifactFork->>sourceSync: sync with existingHeadCommit
	sourceSync->>repoSessions: bootstrapSource existingHeadCommit
	repoSessions->>repoSessions: clone dest HEAD, apply rewrite, collect workspace
	repoSessions->>sourceSync: first publish plus full dest snapshot
	Note over repoSessions: published_commit stamped after rewrite
```

### Invariants

Per-user isolation is unchanged. The overwrite confirmation gate still blocks `publishSession({ force: true })` on already-published package sources unless the caller passes `destructiveOverwriteConfirmed`.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1c081160-1a8d-4691-b6e0-82617c4c84e1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1c081160-1a8d-4691-b6e0-82617c4c84e1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Forked artifact sources can be first-published from an existing destination commit while preserving the destination’s complete contents.
  - Source updates are applied on top of the destination state instead of replacing the forked tree.
  - Unchanged forks can be recorded without unnecessary synchronization.

- **Bug Fixes**
  - Publishing no longer overwrites already-published package sources without confirmation, including forced publishes.
  - Added validation for mismatched destination commits, empty fork snapshots, and invalid attempts to reuse published sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->