### PR TITLE
Fix fleet entitlement alerts to use entitlement ladder

### DIFF
--- a/docs/contributing/architecture/entitlements.md
+++ b/docs/contributing/architecture/entitlements.md
@@ -329,10 +329,12 @@ the same cold zero-init path):
   `storage_bytes` from UserMeter)
 - Admin fleet entitlement-pressure panel and `usage_entitlement_alert` lane —
   same `readAdminEntitlementConsumption` helper over a bounded sweep of the top
-  ~15 active users by current-month event count. The lane emits one
-  `fleet.entitlement.crossed` event per 80% or 100% crossing (and per first
-  over-threshold runtime-duration month, unique Dynamic Worker cost month, or
-  three-of-seven execute-cap train) to admin-owned packages. Staying over the
+  ~15 active users by current-month event count. The sweep selects
+  `users.entitlement_ladder` and passes it through so legacy Standard/Pro is
+  scored against `legacyPlanLimits` (the same table enforcement uses). The lane
+  emits one `fleet.entitlement.crossed` event per 80% or 100% crossing (and per
+  first over-threshold runtime-duration month, unique Dynamic Worker cost month,
+  or three-of-seven execute-cap train) to admin-owned packages. Staying over the
   same threshold does not emit again; dropping below and climbing back is a new
   instance. KV prefix `fleet-entitlement-crossing:v1` stores
   `{prefix}:{userId}:entitlement:{threshold}:{resource}` for stock limits,

--- a/docs/contributing/architecture/usage-metering.md
+++ b/docs/contributing/architecture/usage-metering.md
@@ -504,8 +504,10 @@ ORDER BY executes DESC
   (execute + job_run + workflow_run), top-10 event counts (excluding
   observe-only `durable_object_gb_seconds`), per-metric duration leaders, and an
   entitlement-pressure panel that reuses `readAdminEntitlementConsumption` for
-  the top ~15 users by those same customer event counts. Queries are
-  `LIMIT`-bounded; entitlement reads run with modest concurrency.
+  the top ~15 users by those same customer event counts, passing each row's
+  `users.entitlement_ladder` so legacy Standard/Pro is scored against
+  `legacyPlanLimits`. Queries are `LIMIT`-bounded; entitlement reads run with
+  modest concurrency.
 - **Proactive alerts** (`usage_entitlement_alert` scheduled lane in
   `packages/worker/src/app/usage-entitlement-alerts.ts`): hourly sweep of the
   same ~15-user bound. Emits `fleet.entitlement.crossed` to admin-owned packages

--- a/packages/worker/src/admin/entitlement-consumption.node.test.ts
+++ b/packages/worker/src/admin/entitlement-consumption.node.test.ts
@@ -1,0 +1,65 @@
+import { expect, test, vi } from 'vitest'
+import {
+	entitlementResourceLabels,
+	legacyPlanLimits,
+	planLimits,
+} from '#universal/plans.ts'
+
+const readCurrentEntitlementResourceUsage = vi.fn()
+
+vi.mock('#worker/entitlements/service.ts', () => ({
+	readCurrentEntitlementResourceUsage: (...args: Array<unknown>) =>
+		readCurrentEntitlementResourceUsage(...args),
+}))
+
+const { readAdminEntitlementConsumption } =
+	await import('#worker/admin/entitlement-consumption.ts')
+
+test('readAdminEntitlementConsumption scores legacy Standard against legacyPlanLimits', async () => {
+	const outboundCurrent = 15_016
+	readCurrentEntitlementResourceUsage.mockImplementation(async (input) => {
+		return input.resource === 'outbound_fetches_per_day' ? outboundCurrent : 0
+	})
+	const env = { APP_DB: {} } as Env
+	const now = new Date('2026-07-08T12:00:00.000Z')
+	const [publicConsumption, legacyConsumption] = await Promise.all([
+		readAdminEntitlementConsumption({
+			env,
+			usageUserId: 'grant',
+			plan: 'standard',
+			ladder: 'public',
+			now,
+		}),
+		readAdminEntitlementConsumption({
+			env,
+			usageUserId: 'grant',
+			plan: 'standard',
+			ladder: 'legacy',
+			now,
+		}),
+	])
+	const publicOutbound = publicConsumption.find(
+		(item) => item.resource === 'outbound_fetches_per_day',
+	)
+	const legacyOutbound = legacyConsumption.find(
+		(item) => item.resource === 'outbound_fetches_per_day',
+	)
+	expect(publicOutbound).toEqual({
+		resource: 'outbound_fetches_per_day',
+		label: entitlementResourceLabels.outbound_fetches_per_day,
+		current: outboundCurrent,
+		limit: planLimits.standard.maxOutboundFetchesPerDay,
+		percentOfLimit:
+			outboundCurrent / planLimits.standard.maxOutboundFetchesPerDay,
+		overEightyPercent: true,
+	})
+	expect(legacyOutbound).toEqual({
+		resource: 'outbound_fetches_per_day',
+		label: entitlementResourceLabels.outbound_fetches_per_day,
+		current: outboundCurrent,
+		limit: legacyPlanLimits.standard.maxOutboundFetchesPerDay,
+		percentOfLimit:
+			outboundCurrent / legacyPlanLimits.standard.maxOutboundFetchesPerDay,
+		overEightyPercent: false,
+	})
+})

--- a/packages/worker/src/admin/entitlement-consumption.ts
+++ b/packages/worker/src/admin/entitlement-consumption.ts
@@ -28,13 +28,15 @@ export const entitlementWarningThreshold = 0.8
 /**
  * Current entitlement consumption for one account. `storage_bytes` is read from
  * UserMeter via `readCurrentEntitlementResourceUsage`, matching the signed-in
- * account usage page.
+ * account usage page. `ladder` must be the account's stored
+ * `users.entitlement_ladder` so legacy Standard/Pro is scored against
+ * `legacyPlanLimits`, matching `consumeDailyEntitlement`.
  */
 export async function readAdminEntitlementConsumption(input: {
 	env: Env
 	usageUserId: string
 	plan: PlanName
-	ladder?: EntitlementLadder
+	ladder: EntitlementLadder
 	now: Date
 }): Promise<Array<AdminUsageEntitlementConsumption>> {
 	return await Promise.all(
@@ -46,11 +48,7 @@ export async function readAdminEntitlementConsumption(input: {
 				resource,
 				now: input.now,
 			})
-			const limit = resolvePlanLimit(
-				input.plan,
-				resource,
-				input.ladder ?? 'public',
-			)
+			const limit = resolvePlanLimit(input.plan, resource, input.ladder)
 			const percentOfLimit = limit === 0 ? null : current / limit
 			return {
 				resource,

--- a/packages/worker/src/admin/fleet-usage-insights.node.test.ts
+++ b/packages/worker/src/admin/fleet-usage-insights.node.test.ts
@@ -13,6 +13,7 @@ vi.mock('#worker/admin/entitlement-consumption.ts', () => ({
 const {
 	detectFleetUsagePressure,
 	fleetRuntimeDurationAlertThresholdMs,
+	loadFleetEntitlementCrossingSnapshots,
 	loadFleetUsageInsights,
 } = await import('#worker/admin/fleet-usage-insights.ts')
 
@@ -38,6 +39,7 @@ function createFleetDb(input: {
 		username: string
 		plan: string
 		stripe_plan: string | null
+		entitlement_ladder: string | null
 		event_count: number
 	}>
 	runtimeByUser?: Record<string, number>
@@ -203,6 +205,7 @@ test('loadFleetUsageInsights returns bounded consumer rankings and pressure pane
 				username: 'alice',
 				plan: 'free',
 				stripe_plan: null,
+				entitlement_ladder: 'public',
 				event_count: 50,
 			},
 		],
@@ -317,6 +320,7 @@ test('detectFleetUsagePressure flags entitlement, runtime, and unique-worker cos
 				username: 'alice',
 				plan: 'free',
 				stripe_plan: null,
+				entitlement_ladder: 'public',
 				event_count: 50,
 			},
 			{
@@ -324,6 +328,7 @@ test('detectFleetUsagePressure flags entitlement, runtime, and unique-worker cos
 				username: 'bob',
 				plan: 'pro',
 				stripe_plan: null,
+				entitlement_ladder: 'public',
 				event_count: 40,
 			},
 			{
@@ -331,6 +336,7 @@ test('detectFleetUsagePressure flags entitlement, runtime, and unique-worker cos
 				username: 'kentcdodds',
 				plan: 'max',
 				stripe_plan: null,
+				entitlement_ladder: 'public',
 				event_count: 90,
 			},
 		],
@@ -392,5 +398,142 @@ test('detectFleetUsagePressure flags entitlement, runtime, and unique-worker cos
 		'execute',
 		'job_run',
 		'workflow_run',
+	])
+	expect(
+		entitlementMocks.readAdminEntitlementConsumption.mock.calls.map(
+			([input]) => ({
+				usageUserId: input.usageUserId,
+				plan: input.plan,
+				ladder: input.ladder,
+			}),
+		),
+	).toEqual(
+		expect.arrayContaining([
+			{ usageUserId: 'user-a', plan: 'free', ladder: 'public' },
+			{ usageUserId: 'user-b', plan: 'pro', ladder: 'public' },
+			{ usageUserId: 'user-admin', plan: 'max', ladder: 'public' },
+		]),
+	)
+})
+
+test('fleet entitlement pressure scores legacy Standard against the legacy outbound ceiling', async () => {
+	const outboundCurrent = 15_016
+	const publicStandardOutboundLimit = 5_000
+	const legacyStandardOutboundLimit = 20_000
+	entitlementMocks.readAdminEntitlementConsumption.mockImplementation(
+		async (input) => {
+			const limit =
+				input.ladder === 'legacy'
+					? legacyStandardOutboundLimit
+					: publicStandardOutboundLimit
+			const percentOfLimit = outboundCurrent / limit
+			return [
+				{
+					resource: 'outbound_fetches_per_day',
+					label: 'outbound fetches / day',
+					current: outboundCurrent,
+					limit,
+					percentOfLimit,
+					overEightyPercent: percentOfLimit > 0.8,
+				},
+			]
+		},
+	)
+	const db = createFleetDb({
+		activeUsers: [
+			{
+				stable_user_id: 'grant',
+				username: 'grant',
+				plan: 'standard',
+				stripe_plan: 'standard',
+				entitlement_ladder: 'legacy',
+				event_count: 80,
+			},
+			{
+				stable_user_id: 'pat',
+				username: 'pat',
+				plan: 'standard',
+				stripe_plan: 'standard',
+				entitlement_ladder: 'public',
+				event_count: 70,
+			},
+		],
+	})
+	const now = new Date('2026-07-08T12:00:00.000Z')
+	const env = { APP_DB: db } as Env
+	const [snapshots, issues, insights] = await Promise.all([
+		loadFleetEntitlementCrossingSnapshots({ db, env, now }),
+		detectFleetUsagePressure({ db, env, now }),
+		loadFleetUsageInsights({ db, env, now }),
+	])
+	expect(
+		entitlementMocks.readAdminEntitlementConsumption.mock.calls.map(
+			([input]) => ({
+				usageUserId: input.usageUserId,
+				plan: input.plan,
+				ladder: input.ladder,
+			}),
+		),
+	).toEqual(
+		expect.arrayContaining([
+			{ usageUserId: 'grant', plan: 'standard', ladder: 'legacy' },
+			{ usageUserId: 'pat', plan: 'standard', ladder: 'public' },
+		]),
+	)
+	expect(snapshots).toEqual([
+		expect.objectContaining({
+			stableUserId: 'grant',
+			plan: 'standard',
+			ladder: 'legacy',
+			entitlements: [
+				expect.objectContaining({
+					resource: 'outbound_fetches_per_day',
+					current: outboundCurrent,
+					limit: legacyStandardOutboundLimit,
+					overEightyPercent: false,
+				}),
+			],
+		}),
+		expect.objectContaining({
+			stableUserId: 'pat',
+			plan: 'standard',
+			ladder: 'public',
+			entitlements: [
+				expect.objectContaining({
+					resource: 'outbound_fetches_per_day',
+					current: outboundCurrent,
+					limit: publicStandardOutboundLimit,
+					overEightyPercent: true,
+				}),
+			],
+		}),
+	])
+	expect(issues).toEqual([
+		{
+			kind: 'entitlement',
+			stableUserId: 'pat',
+			username: 'pat',
+			resource: 'outbound_fetches_per_day',
+			label: 'outbound fetches / day',
+			current: outboundCurrent,
+			limit: publicStandardOutboundLimit,
+			percentOfLimit: outboundCurrent / publicStandardOutboundLimit,
+		},
+	])
+	expect(insights.entitlementPressure).toEqual([
+		{
+			stableUserId: 'pat',
+			username: 'pat',
+			plan: 'standard',
+			pressuredResources: [
+				{
+					resource: 'outbound_fetches_per_day',
+					label: 'outbound fetches / day',
+					current: outboundCurrent,
+					limit: publicStandardOutboundLimit,
+					percentOfLimit: outboundCurrent / publicStandardOutboundLimit,
+				},
+			],
+		},
 	])
 })

--- a/packages/worker/src/admin/fleet-usage-insights.ts
+++ b/packages/worker/src/admin/fleet-usage-insights.ts
@@ -5,8 +5,10 @@ import {
 	toAdminDynamicWorkerCost,
 } from '#universal/dynamic-worker-cost.ts'
 import {
+	parseEntitlementLadder,
 	parseStoredPlanName,
 	resolveEffectivePlan,
+	type EntitlementLadder,
 	type PlanName,
 } from '#universal/plans.ts'
 import { observeOnlyUsageEventTypes } from '#universal/usage-event-types.ts'
@@ -65,6 +67,7 @@ type ActiveUserRow = {
 	username: string
 	plan: string
 	stripe_plan: string | null
+	entitlement_ladder: string | null
 	event_count: number
 }
 
@@ -104,6 +107,7 @@ export type FleetEntitlementCrossingSnapshot = {
 	stableUserId: string
 	username: string
 	plan: PlanName
+	ladder: EntitlementLadder
 	isAdmin: boolean
 	entitlements: Array<{
 		resource: AdminUsageEntitlementResource
@@ -185,16 +189,19 @@ export async function loadFleetEntitlementCrossingSnapshots(input: {
 				parseStoredPlanName(user.plan),
 				user.stripe_plan,
 			)
+			const ladder = parseEntitlementLadder(user.entitlement_ladder)
 			const consumption = await readAdminEntitlementConsumption({
 				env: input.env,
 				usageUserId: user.stable_user_id,
 				plan,
+				ladder,
 				now: input.now,
 			})
 			snapshots.push({
 				stableUserId: user.stable_user_id,
 				username: user.username,
 				plan,
+				ladder,
 				isAdmin: adminUserIds.has(user.stable_user_id),
 				entitlements: consumption.map((item) => ({
 					resource: item.resource,
@@ -455,10 +462,12 @@ async function buildEntitlementPressurePanel(input: {
 			const plan = toAdminPlanName(
 				resolveEffectivePlan(parseStoredPlanName(user.plan), user.stripe_plan),
 			)
+			const ladder = parseEntitlementLadder(user.entitlement_ladder)
 			const consumption = await readAdminEntitlementConsumption({
 				env: input.env,
 				usageUserId: user.stable_user_id,
 				plan,
+				ladder,
 				now: input.now,
 			})
 			const pressuredResources = consumption
@@ -493,13 +502,13 @@ async function listActiveUsersForEntitlementSweep(
 ): Promise<Array<ActiveUserRow>> {
 	const rows = await db
 		.prepare(
-			`SELECT u.stable_user_id, u.username, u.plan, u.stripe_plan, SUM(r.event_count) AS event_count
+			`SELECT u.stable_user_id, u.username, u.plan, u.stripe_plan, u.entitlement_ladder, SUM(r.event_count) AS event_count
 			 FROM usage_rollups r
 			 INNER JOIN users u ON u.stable_user_id = r.user_id
 			 WHERE r.month = ?
 				AND r.metric NOT IN (${observeOnlyMetricPlaceholders})
 				AND u.deleting_at IS NULL
-			 GROUP BY u.stable_user_id, u.username, u.plan, u.stripe_plan
+			 GROUP BY u.stable_user_id, u.username, u.plan, u.stripe_plan, u.entitlement_ladder
 			 ORDER BY event_count DESC
 			 LIMIT ?`,
 		)

--- a/packages/worker/src/app/usage-entitlement-alerts.node.test.ts
+++ b/packages/worker/src/app/usage-entitlement-alerts.node.test.ts
@@ -78,6 +78,7 @@ function snapshot(input: {
 		stableUserId: input.stableUserId ?? 'user-a',
 		username: input.username ?? 'alice',
 		plan: input.plan ?? 'free',
+		ladder: 'public',
 		isAdmin: input.isAdmin ?? false,
 		entitlements: [
 			{


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop paging operators when a legacy Standard/Pro subscriber is still under their real entitlement ceiling.

## Why

`loadFleetEntitlementCrossingSnapshots` and the insights pressure panel called `readAdminEntitlementConsumption` with `plan` but no `ladder`. That helper defaulted to `public`, so a Stripe Standard user on `entitlement_ladder = 'legacy'` (outbound **20_000**) was scored against public Standard (**5_000**). Account `grant` alerted at `15016 / 5000` (300%) while still under the real 20k cap. `consumeDailyEntitlement` already uses `entitlement.ladder`; only the fleet alert and insights path were wrong.

## Summary

- `listActiveUsersForEntitlementSweep` selects `users.entitlement_ladder`.
- Fleet crossing snapshots and the insights pressure panel pass that ladder into `readAdminEntitlementConsumption`.
- `readAdminEntitlementConsumption` now requires `ladder` (no silent `public` default). Per-user admin usage and user warning emails already passed it.
- `FleetEntitlementCrossingSnapshot` includes `ladder` for debugging and tests.
- Tests: a legacy Standard user at 15,016 outbound is evaluated against `legacyPlanLimits` (20k, not pressured); a public Standard peer at the same count is pressured against 5k.
- Docs: entitlements and usage-metering architecture notes the sweep threads ladder.

## Testing

- Pre-commit: worker typecheck
- Pre-push: `npm run test:node` (942 files / 2996 tests) and `npm run test:workers` (94 files / 341 tests)
- Focused coverage: `entitlement-consumption.node.test.ts`, `fleet-usage-insights.node.test.ts`

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `5ffc67f1` · **Head:** `f45be990`

**Classification:** composes — no primitives added or changed; this PR wires each user's stored entitlement ladder into the existing fleet consumption helper.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `entitlements` | auth | composes — required `ladder` on `readAdminEntitlementConsumption`, scored with `resolvePlanLimit` |
| `usage-metering` | storage | composes — fleet crossing snapshots and insights pressure use the same ladder enforcement already uses |
| `app-ui` | surfaces | composes — crossing-snapshot fixture carries `ladder` |
| `d1-app-db` | storage | composes — active-user sweep selects `users.entitlement_ladder` |

Admin helpers under `packages/worker/src/admin/` are unmatched by the classifier map; they are the call-site wiring for the rows above.

### Change flow

Hourly fleet alerts and the insights pressure panel read each swept user's stored ladder and score consumption against that ladder's plan table.

```mermaid
sequenceDiagram
	actor Cron
	participant scheduledCron as scheduled-cron
	participant entitlements as entitlements
	participant d1AppDb as d1-app-db
	participant usageMetering as usage-metering
	Cron->>scheduledCron: usage_entitlement_alert hour
	scheduledCron->>d1AppDb: select entitlement_ladder in active-user sweep
	d1AppDb-->>scheduledCron: plan plus ladder
	scheduledCron->>entitlements: readAdminEntitlementConsumption plan and ladder
	Note over entitlements: legacy Standard uses legacyPlanLimits outbound 20000
	entitlements-->>scheduledCron: current over ladder-aware limit
	scheduledCron->>usageMetering: fleet.entitlement.crossed only when over 80 percent of that limit
```

### Before / after

```text
before: readAdminEntitlementConsumption({ plan }) → ladder defaults to public
after:  sweep selects entitlement_ladder → readAdminEntitlementConsumption({ plan, ladder })
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-53b2dacd-0d7c-4dbd-8647-4da1319caad8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-53b2dacd-0d7c-4dbd-8647-4da1319caad8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Admin entitlement-pressure and usage insights now apply the correct limits for legacy Standard and Pro accounts.
  - Usage thresholds and crossing indicators now accurately distinguish legacy plan behavior from public-plan behavior.

- **Documentation**
  - Updated architecture documentation to explain how legacy plan limits are applied in entitlement-pressure monitoring and fleet usage reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->