### PR TITLE
Stop docs chrome from re-animating on guide switches

### DIFF
--- a/.agents/skills/control-kody/references/features/marketing.md
+++ b/.agents/skills/control-kody/references/features/marketing.md
@@ -6,7 +6,9 @@ Logged-out landing, pricing, FAQ, support, legal, guides, blog, Discord invite.
 
 `/`, `/pricing`, `/faq`, `/support`, `/privacy`, `/terms`, `/docs`,
 `/docs/:slug`, `/docs/connect`, `/llms.txt`, `/blog`, `/blog/:slug`, `/discord`.
-Legacy `/guides*` URLs 308 to `/docs*`.
+Legacy `/guides*` URLs 308 to `/docs*`. Intra-docs navigation (guide to guide,
+or guide to `/docs` / `/docs/connect`) is an instant shell swap — no page
+view-transition — so the sidebar does not re-animate.
 
 ## Drive it
 

--- a/packages/worker/client/app.tsx
+++ b/packages/worker/client/app.tsx
@@ -39,6 +39,7 @@ import {
 import { SiteFooter } from './site-footer.tsx'
 import { SiteHeader } from './site-header.tsx'
 import { Toaster } from './toaster.tsx'
+import { isDocsPagePath } from '#universal/docs-nav.ts'
 import { type AppLoaderData } from '#universal/loader-data.ts'
 import { isPackageFilesPathname } from '#universal/package-files.ts'
 import { isProfilePathname } from '#universal/profile-path.ts'
@@ -161,9 +162,18 @@ export function App(handle: Handle<AppProps>) {
 			if (nextPathname === lastFocusManagedPathname) return
 			lastFocusManagedPathname = nextPathname
 			handle.queueTask(() => {
+				// Docs guide changes: announce the new article title, not the
+				// shared `<main>` landmark that already had focus.
+				const heading = document.querySelector('[data-docs-heading]')
 				const main = document.getElementById('main')
-				if (!(main instanceof HTMLElement)) return
-				main.focus({ preventScroll: true })
+				const target =
+					heading instanceof HTMLElement
+						? heading
+						: main instanceof HTMLElement
+							? main
+							: null
+				if (!target) return
+				target.focus({ preventScroll: true })
 			})
 		})
 		// Router form POSTs mutate server state, which may include auth (e.g.
@@ -203,6 +213,7 @@ export function App(handle: Handle<AppProps>) {
 			currentPathname === '/community' ||
 			currentPathname === '/onboarding' ||
 			currentPathname.startsWith('/onboarding/step-') ||
+			isDocsPagePath(currentPathname) ||
 			isProfilePathname(currentPathname) ||
 			isCommunityListingPathname(currentPathname) ||
 			getSlugFromPathname(currentPathname) !== null

--- a/packages/worker/client/client-router.node.test.ts
+++ b/packages/worker/client/client-router.node.test.ts
@@ -112,9 +112,9 @@ test('package approve-publish is not swallowed by the package detail route', () 
 })
 
 test('view transitions skip shell tab switches, including when from-path was never recorded', () => {
-	// Tab switching inside the account/admin shell: the rail is unchanged and
-	// full-height, so a snapshot transition would squash it between two page
-	// heights. These swap instantly.
+	// Tab switching inside a persistent shell (account/admin rail, docs
+	// sidebar): the chrome is unchanged and full-height, so a snapshot
+	// transition would squash or fade it. These swap instantly.
 	expect(isSameShellAreaNavigation('/account', '/account/secrets')).toBe(true)
 	expect(
 		isSameShellAreaNavigation('/account/jobs?view=failed', '/account/values'),
@@ -122,9 +122,14 @@ test('view transitions skip shell tab switches, including when from-path was nev
 	expect(
 		isSameShellAreaNavigation('/admin/users', '/admin/feature-flags'),
 	).toBe(true)
+	expect(isSameShellAreaNavigation('/docs', '/docs/oauth')).toBe(true)
+	expect(isSameShellAreaNavigation('/docs/oauth', '/docs/connect')).toBe(true)
+	expect(isSameShellAreaNavigation('/docs/how-kody-works', '/docs')).toBe(true)
 	expect(isSameShellAreaNavigation('/pricing', '/account')).toBe(false)
 	expect(isSameShellAreaNavigation('/account', '/pricing')).toBe(false)
 	expect(isSameShellAreaNavigation('/account', '/admin/users')).toBe(false)
+	expect(isSameShellAreaNavigation('/docs', '/pricing')).toBe(false)
+	expect(isSameShellAreaNavigation('/docs', '/documentation')).toBe(false)
 	expect(isSameShellAreaNavigation(null, '/account')).toBe(false)
 	expect(isSameShellAreaNavigation('/account', '/accounts-payable')).toBe(false)
 
@@ -160,6 +165,17 @@ test('view transitions skip shell tab switches, including when from-path was nev
 	expect(animate({ from: '/account/usage', to: '/account/activity' })).toBe(
 		false,
 	)
+	expect(animate({ from: '/docs', to: '/docs/oauth' })).toBe(false)
+	expect(animate({ from: '/docs/oauth', to: '/docs/connect' })).toBe(false)
+	expect(
+		animate({
+			from: null,
+			to: '/docs/how-kody-works',
+			hasPersistentShell: true,
+		}),
+	).toBe(false)
+	expect(animate({ from: '/pricing', to: '/docs' })).toBe(true)
+	expect(animate({ from: '/docs/oauth', to: '/blog' })).toBe(true)
 
 	// Leaving, entering, or crossing shells is still a real page change.
 	expect(

--- a/packages/worker/client/client-router.tsx
+++ b/packages/worker/client/client-router.tsx
@@ -101,11 +101,18 @@ function getCurrentDocumentPath() {
  * and the rail is a full-height element whose box tracks the page — so a
  * transition would scale its snapshot between two different heights and the
  * rail would visibly squash. These navigations swap instantly.
+ *
+ * `/docs` is the same kind of shell: the sidebar lives inside `<main>`
+ * (`view-transition-name: page`), so a page transition would fade and slide
+ * unchanged nav chrome on every guide click.
  */
-const shellAreas = ['/account', '/admin']
+const shellAreas = ['/account', '/admin', '/docs']
 
-/** Live account/admin rail. Present only while a shell page is on screen. */
-export const persistentShellNavSelector = '[data-account-nav]'
+/**
+ * Live persistent-shell chrome. Present only while a shell page is on
+ * screen — account/admin rail or the docs sidebar.
+ */
+export const persistentShellNavSelector = '[data-account-nav], [data-docs-nav]'
 
 function isWithinArea(pathname: string, area: string) {
 	return pathname === area || pathname.startsWith(`${area}/`)

--- a/packages/worker/client/markdown-view.tsx
+++ b/packages/worker/client/markdown-view.tsx
@@ -87,8 +87,8 @@ export type RenderMarkdownOptions = {
 	fences?: Array<HighlightedCode>
 	/**
 	 * When true, headings get kebab-case `id` attributes (unique within one
-	 * render) so first-party posts can deep-link to a section. Off by default
-	 * so third-party READMEs do not grow extra attributes.
+	 * render) so first-party posts and docs can deep-link to a section. Off
+	 * by default so third-party READMEs do not grow extra attributes.
 	 */
 	headingIds?: boolean
 	/**

--- a/packages/worker/client/routes/doc-detail.tsx
+++ b/packages/worker/client/routes/doc-detail.tsx
@@ -58,7 +58,8 @@ const interactiveDocRenderers: Readonly<
  * code blocks → previous/next → a quiet foot with the raw markdown twin for
  * agents (`data-rmx-document` so the SPA does not intercept
  * `/docs/:slug.md`). Interactive slugs (how-kody-works, google-oauth) swap
- * the prose body for a transcript walkthrough.
+ * the prose body for a transcript walkthrough. Body headings get kebab-case
+ * ids so in-doc and legacy fragment links land.
  */
 
 /**
@@ -183,6 +184,7 @@ export function DocDetailRoute(handle: Handle) {
 				linkRel: 'noopener noreferrer',
 				linkPolicy: 'first-party',
 				copyCodeBlocks: true,
+				headingIds: true,
 				fences: doc?.bodyFences,
 			})
 		}
@@ -289,7 +291,9 @@ export function DocDetailRoute(handle: Handle) {
 							<p mix={css(docEyebrowCss)}>
 								<a href={routes.docs.href()}>Docs</a>
 							</p>
-							<h1>Doc not found</h1>
+							<h1 data-docs-heading tabIndex={-1}>
+								Doc not found
+							</h1>
 							<p mix={css(docMetaCss)}>
 								That page does not exist or may have moved. Start from{' '}
 								<a href={routes.docs.href()}>What is Kody?</a>.
@@ -324,7 +328,12 @@ export function DocDetailRoute(handle: Handle) {
 										(section?.label ?? 'Docs')
 									)}
 								</p>
-								<h1 data-rise style={{ '--rise': '1' }}>
+								<h1
+									data-docs-heading
+									tabIndex={-1}
+									data-rise
+									style={{ '--rise': '1' }}
+								>
 									{doc.title}
 								</h1>
 								<p data-rise style={{ '--rise': '2' }} mix={css(docMetaCss)}>

--- a/packages/worker/client/routes/docs-connect.tsx
+++ b/packages/worker/client/routes/docs-connect.tsx
@@ -130,7 +130,12 @@ export function DocsConnectRoute(handle: Handle) {
 						<p data-rise style={{ '--rise': '0' }} mix={css(connectEyebrowCss)}>
 							Docs
 						</p>
-						<h1 data-rise style={{ '--rise': '1' }}>
+						<h1
+							data-docs-heading
+							tabIndex={-1}
+							data-rise
+							style={{ '--rise': '1' }}
+						>
 							Connect a provider
 						</h1>
 						<p data-rise style={{ '--rise': '2' }}>

--- a/packages/worker/client/routes/docs-shell.node.test.ts
+++ b/packages/worker/client/routes/docs-shell.node.test.ts
@@ -1,0 +1,48 @@
+import { jsx } from 'remix/ui/jsx-runtime'
+import { renderToString } from 'remix/ui/server'
+import { expect, test } from 'vitest'
+import { renderDocsPager, renderDocsShell } from '#client/routes/docs-shell.tsx'
+import { docsIntroSlug } from '#universal/docs-nav.ts'
+
+test('docs shell marks the sidebar and highlights the open page', async () => {
+	const html = await renderToString(
+		renderDocsShell({
+			current: 'oauth',
+			children: jsx('p', { children: 'Article' }),
+		}),
+	)
+
+	expect(html).toContain('data-docs-nav')
+	expect(html).toContain('href="/docs/oauth"')
+	expect(html).toContain('aria-current="page"')
+	expect(html).toContain('OAuth (bring your own app)')
+	expect(html).toContain('data-section-current="true"')
+	expect(html).not.toContain('href="/docs/what-is-kody"')
+	expect(html).toContain('href="/docs"')
+})
+
+test('docs shell treats /docs/connect as the providers section', async () => {
+	const html = await renderToString(
+		renderDocsShell({
+			current: 'connect',
+			children: jsx('p', { children: 'Providers' }),
+		}),
+	)
+
+	expect(html).toContain('href="/docs/connect"')
+	expect(html).toContain('Connect a provider')
+	expect(html).toMatch(/<a[^>]*href="\/docs\/connect"[^>]*aria-current="page"/)
+	expect(html).toContain('data-section-current="true"')
+})
+
+test('docs pager omits empty placeholders and links neighbors', async () => {
+	const first = await renderToString(renderDocsPager(docsIntroSlug))
+	expect(first).toContain('How Kody works')
+	expect(first).toContain('href="/docs/how-kody-works"')
+	expect(first).not.toContain('<span></span>')
+	expect(first).not.toContain('Previous')
+
+	const last = await renderToString(renderDocsPager('platform-friction'))
+	expect(last).toContain('Previous')
+	expect(last).not.toContain('Next')
+})

--- a/packages/worker/client/routes/docs-shell.tsx
+++ b/packages/worker/client/routes/docs-shell.tsx
@@ -1,10 +1,12 @@
-import { type RemixNode, css } from 'remix/ui'
+import { type RemixNode, css, ref } from 'remix/ui'
+import { routerEvents } from '#client/client-router.tsx'
 import { type DocSummaryLoaderData } from '#universal/loader-data.ts'
 import {
 	docHref,
+	docsCurrentPageLabel,
 	docsNav,
 	findDocsNavNeighbors,
-	findDocsNavSection,
+	resolveDocsNavSection,
 	type DocsNavSection,
 } from '#universal/docs-nav.ts'
 import { routes } from '#universal/routes.ts'
@@ -31,20 +33,30 @@ export function renderDocsShell(input: {
 	children: RemixNode
 }) {
 	const { current, children } = input
-	const currentSection = findDocsNavSection(current)
+	const currentSection = resolveDocsNavSection(current)
 	return (
 		<div mix={css(docsLayoutCss)}>
-			<aside mix={css(docsSidebarCss)}>
+			<aside data-docs-nav mix={css(docsSidebarCss)}>
 				<nav aria-label="Docs" mix={css(docsSidebarNavCss)}>
 					{renderDocsNavSections(current, currentSection)}
 				</nav>
 			</aside>
-			<details mix={css(docsMobileMenuCss)}>
+			<details
+				mix={[
+					css(docsMobileMenuCss),
+					ref((node, signal) => {
+						if (!(node instanceof HTMLDetailsElement)) return
+						const close = () => {
+							node.open = false
+						}
+						routerEvents.addEventListener('navigate', close, { signal })
+					}),
+				]}
+			>
 				<summary>
 					<span>Docs</span>
 					<span mix={css(docsMobileMenuCurrentCss)}>
-						{currentSection?.label ??
-							(current === 'connect' ? 'Connect a provider' : '')}
+						{docsCurrentPageLabel(current)}
 					</span>
 				</summary>
 				<nav aria-label="Docs" mix={css(docsSidebarNavCss)}>
@@ -104,17 +116,13 @@ export function renderDocsPager(slug: string) {
 					<span>Previous</span>
 					<strong>{prev.label}</strong>
 				</a>
-			) : (
-				<span />
-			)}
+			) : null}
 			{next ? (
 				<a href={docHref(next.slug)} mix={css(docsPagerNextLinkCss)}>
 					<span>Next</span>
 					<strong>{next.label}</strong>
 				</a>
-			) : (
-				<span />
-			)}
+			) : null}
 		</nav>
 	)
 }
@@ -209,6 +217,9 @@ const docsNavSectionCss = {
 	'& h2 a[aria-current="page"]': {
 		color: colors.primaryText,
 	},
+	'&:has(a[data-section-current]) h2': {
+		color: colors.text,
+	},
 	'& ul': {
 		listStyle: 'none',
 		margin: 0,
@@ -282,12 +293,13 @@ const docsMainCss = {
 }
 
 const docsPagerCss = {
-	display: 'grid',
-	gridTemplateColumns: '1fr 1fr',
+	display: 'flex',
+	flexWrap: 'wrap' as const,
+	justifyContent: 'space-between',
 	gap: '1rem',
 	marginTop: 'clamp(2.5rem, 6vw, 3.5rem)',
 	[mq.mobile]: {
-		gridTemplateColumns: '1fr',
+		flexDirection: 'column' as const,
 	},
 }
 
@@ -316,7 +328,12 @@ const docsPagerLinkCss = {
 }
 
 const docsPagerNextLinkCss = mergeCss(docsPagerLinkCss, {
+	marginInlineStart: 'auto',
 	textAlign: 'right' as const,
+	[mq.mobile]: {
+		marginInlineStart: 0,
+		textAlign: 'left' as const,
+	},
 })
 
 export const docListCss = {

--- a/packages/worker/public/styles.css
+++ b/packages/worker/public/styles.css
@@ -449,8 +449,10 @@ html.is-settled {
 	   leaving `/account` or `/admin` has an old snapshot and no new one.
 	   Pinning old/new (`animation: none`) froze that leftover rail on top
 	   of the destination. Old/new fade; only the group stays still so
-	   account↔admin (rail on both sides) does not morph/squash. Browsers
-	   without the API never match these pseudos — the swap is instant. */
+	   account↔admin (rail on both sides) does not morph/squash. Intra-docs
+	   guide switches skip this API entirely (client-router shell areas) so
+	   the sidebar inside `page` does not fade. Browsers without the API
+	   never match these pseudos — the swap is instant. */
 	::view-transition-old(root),
 	::view-transition-new(root) {
 		animation: none;

--- a/packages/worker/src/app/handlers/docs.node.test.ts
+++ b/packages/worker/src/app/handlers/docs.node.test.ts
@@ -220,6 +220,7 @@ test('docs connect index serves JSON and markdown without colliding with doc slu
 	expect(body).toContain('https://kody.example/docs.md')
 	expect(body).toContain('https://kody.example/docs/how-kody-works.md')
 	expect(body).toContain('https://kody.example/docs/local-mcp-tunnels.md')
+	expect(body).toContain('https://kody.example/docs/locked-mcp-server.md')
 	expect(body).toContain('https://kody.example/docs/integration-bootstrap.md')
 	for (const guide of listProviderGuides()) {
 		expect(body).toContain(`https://kody.example/docs/${guide.slug}.md`)

--- a/packages/worker/src/app/handlers/docs.tsx
+++ b/packages/worker/src/app/handlers/docs.tsx
@@ -142,6 +142,7 @@ export function buildDocsConnectMarkdown(baseUrl: string): string {
 		`- [Integration bootstrap](${baseUrl}${docMarkdownHref('integration-bootstrap')}) — the sequence before any provider-backed package`,
 		`- [OAuth (bring your own app)](${baseUrl}${docMarkdownHref('oauth')}) — the standard \`/connect/oauth\` path for providers without a walkthrough`,
 		`- [Connect a home MCP server](${baseUrl}${docMarkdownHref('local-mcp-tunnels')}) — run a local MCP process and connect it to Kody`,
+		`- [Lock an MCP server to a package](${baseUrl}${docMarkdownHref('locked-mcp-server')}) — keep a connected server's tools off execute and other packages`,
 		'',
 	)
 	return lines.join('\n')

--- a/packages/worker/universal/docs-nav.node.test.ts
+++ b/packages/worker/universal/docs-nav.node.test.ts
@@ -1,0 +1,33 @@
+import { expect, test } from 'vitest'
+import {
+	docsCurrentPageLabel,
+	docsIntroSlug,
+	isDocsPagePath,
+	resolveDocsNavSection,
+} from './docs-nav.ts'
+
+test('isDocsPagePath covers the docs shell and rejects lookalike paths', () => {
+	expect(isDocsPagePath('/docs')).toBe(true)
+	expect(isDocsPagePath('/docs/')).toBe(true)
+	expect(isDocsPagePath('/docs/oauth')).toBe(true)
+	expect(isDocsPagePath('/docs/connect')).toBe(true)
+	expect(isDocsPagePath('/docs/oauth.md')).toBe(true)
+	expect(isDocsPagePath('/documentation')).toBe(false)
+	expect(isDocsPagePath('/blog')).toBe(false)
+	expect(isDocsPagePath('/account')).toBe(false)
+})
+
+test('resolveDocsNavSection maps connect to providers and slugs to their section', () => {
+	expect(resolveDocsNavSection('connect')?.id).toBe('providers')
+	expect(resolveDocsNavSection('github')?.id).toBe('providers')
+	expect(resolveDocsNavSection(docsIntroSlug)?.id).toBe('introduction')
+	expect(resolveDocsNavSection('oauth')?.id).toBe('integrations')
+	expect(resolveDocsNavSection('missing-doc')).toBeNull()
+})
+
+test('docsCurrentPageLabel prefers the sidebar item over the section', () => {
+	expect(docsCurrentPageLabel('connect')).toBe('Connect a provider')
+	expect(docsCurrentPageLabel(docsIntroSlug)).toBe('What is Kody?')
+	expect(docsCurrentPageLabel('oauth')).toBe('OAuth (bring your own app)')
+	expect(docsCurrentPageLabel('missing-doc')).toBe('Docs')
+})

--- a/packages/worker/universal/docs-nav.ts
+++ b/packages/worker/universal/docs-nav.ts
@@ -180,6 +180,33 @@ export function isReservedDocsIndexSlug(slug: string): boolean {
 	return (reservedDocsIndexSlugs as ReadonlyArray<string>).includes(slug)
 }
 
+/**
+ * HTML docs chrome: `/docs`, `/docs/connect`, and `/docs/:slug`. Companion
+ * twins (`.md` / `.json` / `llms.txt`) match too; the SPA leaves those.
+ */
+export function isDocsPagePath(pathname: string): boolean {
+	return pathname === '/docs' || pathname.startsWith('/docs/')
+}
+
+/**
+ * Sidebar section for the current page. `/docs/connect` is the providers
+ * index (not a catalog slug), so it resolves to that section.
+ */
+export function resolveDocsNavSection(current: string): DocsNavSection | null {
+	if (current === 'connect') {
+		return docsNav.find((section) => section.id === 'providers') ?? null
+	}
+	return findDocsNavSection(current)
+}
+
+/** Short label for the open page — mobile menu current, focus target copy. */
+export function docsCurrentPageLabel(current: string): string {
+	if (current === 'connect') return 'Connect a provider'
+	const section = findDocsNavSection(current)
+	const item = section?.items.find((entry) => entry.slug === current)
+	return item?.label ?? section?.label ?? 'Docs'
+}
+
 /** Every advertised slug in reading order (sidebar order). */
 export function listDocsNavSlugs(): ReadonlyArray<string> {
 	return docsNav.flatMap((section) => section.items.map((item) => item.slug))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Make the `/docs` shell feel like a stable reading chrome: switching guides must not replay enter/rise/fade on the sidebar, header, or other unchanged frames. Also fix the docs IA/UX bugs found in a full pass of the guide list and detail experience.

## Why

Selecting a new guide ran the same page view-transition as a marketing-page change. The docs sidebar lives inside `<main>` (`view-transition-name: page`), so unchanged chrome faded and slid 8px on every click. Kent asked to stop that distraction and to audit the rest of the docs UI.

## Summary

- Treat `/docs` as a persistent shell (same skip as `/account` and `/admin`). Intra-docs navigations swap instantly; `prefers-reduced-motion` still disables view transitions. `data-rise` stays gated on first document load via `html[data-spa-nav]`.
- Mark the sidebar with `data-docs-nav` so a first click after a full load (when `from` was never recorded) also skips the transition.
- Focus the article `h1` (`data-docs-heading`) after a docs navigation instead of the shared `#main` landmark.
- Include `/docs` in redesigned marketing gutters so the article is not double-padded against the site header.
- Emit kebab-case heading ids on doc bodies so in-doc and legacy fragments (for example `#after-an-integration-smoke-test`) land.
- Mobile menu shows the current page label and closes on navigate; prev/next pager no longer leaves an empty cell on small screens.
- `/docs/connect.md` Related list now includes Lock an MCP server, matching the HTML page.

## Testing

- `vitest` node-unit: docs-nav, docs-shell, client-router view-transition skip, docs connect markdown.
- Pre-push: `test:node` (3002) and `test:workers` (341).
- Local docs walk (index, connect, several guides, fragment link, keyboard) after this draft.

## Residual

- `DocDetailRoute` and `DocsConnectRoute` are still separate client entries, so the sidebar remounts when crossing `/docs/connect` (no animation; scroll position in the sidebar may reset).
- No in-page TOC; headings now have ids if we add one later.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `7f2de088` · **Head:** `f96d344d`

**Classification:** extends — docs intra-shell navigation no longer uses the page view-transition, and the docs article gains heading ids, focus, and gutter ownership.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `app-ui` | surfaces | extends — `/docs` joins persistent-shell skip, docs heading ids, focus, and gutters |

Unmatched paths: `packages/worker/public/styles.css` (comment on the skip), `.agents/skills/control-kody/references/features/marketing.md` (agent map).

### Change flow

A sidebar click inside `/docs` now skips `startViewTransition` and focuses the new article title.

```mermaid
sequenceDiagram
	actor Reader
	participant appUi as app-ui
	Reader->>appUi: click another guide in the docs sidebar
	appUi->>appUi: classify /docs to /docs/:slug as same shell
	Note over appUi: skip startViewTransition, set data-spa-nav
	appUi->>appUi: swap article, keep sidebar chrome still
	appUi->>appUi: focus data-docs-heading
```

### Invariants

Per-user isolation is untouched. This is anonymous marketing HTML plus client navigation policy.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-819d7916-a618-4957-bfbb-ebe20096734a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-819d7916-a618-4957-bfbb-ebe20096734a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Documentation pages now provide clearer sidebar highlighting, mobile menu behavior, keyboard focus, and previous/next navigation.
  * Added a related link from “Connect a provider” to locked MCP server documentation.
  * Legacy `/guides*` links now redirect to `/docs*`.

* **Bug Fixes**
  * Switching between documentation pages is now instantaneous without unnecessary page transitions.
  * Documentation layouts avoid empty navigation placeholders and apply consistent page spacing and focus behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->