### PR TITLE
Reject malformed hosts on /connect/secrets approval (#2195)

### DIFF
--- a/.agents/skills/control-kody/references/features/secrets.md
+++ b/.agents/skills/control-kody/references/features/secrets.md
@@ -27,3 +27,6 @@ https://kody.codes/account/secrets” note with no body is not proof.
 
 - Never paste secret values into chat, PRs, or execute params.
 - Preview seed starts with zero secrets.
+- `/connect/secrets` rejects hosts that are not hostname-shaped (truncated
+  tokens, paths, empty values). Those must not appear as a successful Allow
+  target, and they must not land in `allowedHosts`.

--- a/docs/contributing/secret-host-approval.md
+++ b/docs/contributing/secret-host-approval.md
@@ -60,7 +60,8 @@ lowercase, strip `http(s)://` and take `URL.hostname` for full URLs), it is:
   RFC 2606 special-use suffix (`test`, `example`, `invalid`)
 - `localhost` or a `*.localhost` name
 - an IPv4 or IPv6 address (shape only — not a policy allow/deny for private
-  networks)
+  networks). IPv6 is stored as `URL.hostname` serializes it (`[::1]`), so Allow
+  and later fetch matching use the same token
 
 A host is **rejected** (shown as invalid, never written) when it is:
 

--- a/docs/contributing/secret-host-approval.md
+++ b/docs/contributing/secret-host-approval.md
@@ -46,6 +46,39 @@ URL (`/connect/secrets?names=...&hosts=...`) or the bulk package approval URL
 (`/account/secrets/approve?package_id=...&names=...`) over one link per secret.
 Agents must never auto-approve host or package access.
 
+## Host shape
+
+`/connect/secrets` (and the Allow write) treat each `hosts` value as a hostname
+token, not free-form text. The same helper classifies hosts on the approval read
+path and again before `allowedHosts` is written, so the UI and persistence
+cannot diverge.
+
+A host is **valid** when, after the existing `normalizeHost` cleanup (trim,
+lowercase, strip `http(s)://` and take `URL.hostname` for full URLs), it is:
+
+- a dotted DNS hostname whose public suffix is ICANN, a private PSL entry, or an
+  RFC 2606 special-use suffix (`test`, `example`, `invalid`)
+- `localhost` or a `*.localhost` name
+- an IPv4 or IPv6 address (shape only — not a policy allow/deny for private
+  networks)
+
+A host is **rejected** (shown as invalid, never written) when it is:
+
+- empty or whitespace-only (dropped before classification)
+- path-bearing or otherwise malformed (`api.openai.com/v1`, embedded spaces,
+  userinfo, a leftover path or query, a bare label such as `openai`)
+- a dotted name whose public suffix is not in the lists above (`api.ope`,
+  `api.o`) — the usual leftover when a terminal soft-wraps a long approval URL
+
+Rejected hosts appear on the approval page with an explanation that the link may
+have been truncated. **Allow** only grants the valid hosts. **Allow all N
+hosts** is offered only when every listed host is valid; mixed lists use **Allow
+N valid hosts** and never report unqualified success while rejected hosts
+remain.
+
+This is host-shape validation only. Look-alike FQDNs, homoglyphs, and
+first-party API allow/deny lists are out of scope.
+
 ## What agents must not do
 
 Do not design or document any MCP capability, package app helper, or client

--- a/docs/guides/account-secret-setup.md
+++ b/docs/guides/account-secret-setup.md
@@ -57,6 +57,8 @@ so the user can paste immediately.
 - The account form prefills the requested hosts and packages for review.
 - Host approval uses the dedicated **`/connect/secrets`** page (`name` / `names`
   and `hosts`). Package grants use `/account/secrets/approve`.
+- `hosts` must be hostname-shaped. Truncated or path-bearing values are rejected
+  on that page and are not written to `allowedHosts`.
 
 ## Package approval URLs (after a package exists)
 

--- a/docs/guides/secrets.md
+++ b/docs/guides/secrets.md
@@ -53,9 +53,11 @@ Saving a secret does not by itself let anything use it.
 - **Host approval** decides which destinations a secret may be sent to. A secret
   with an empty host allowlist blocks every placeholder fetch, including from
   packages you wrote yourself. Approve hosts on `/connect/secrets` — one link
-  can cover several secrets and several hosts at once. Kody never approves a
-  host automatically; an ad hoc smoke test that happened to work does not widen
-  the allowlist.
+  can cover several secrets and several hosts at once. Hosts that are not valid
+  hostname shapes (truncated tokens, paths, empty values) are flagged on that
+  page and are not written to the allowlist. Kody never approves a host
+  automatically; an ad hoc smoke test that happened to work does not widen the
+  allowlist.
 - **Package approval** decides which saved packages may read and use a
   user-scoped secret. Packages you authored and community forks you adopted
   after reviewing the source get read/use automatically. Unadopted forks need an

--- a/docs/use/secrets-and-values.md
+++ b/docs/use/secrets-and-values.md
@@ -119,8 +119,11 @@ approval path the error provides. Host approval lives on the dedicated
 **`/connect/oauth`**. A link looks like
 `/connect/secrets?name=cloudflareToken&hosts=api.cloudflare.com`. When several
 hosts (or several secrets) need approval together, Kody can send one link with
-comma-separated **`names`** and **`hosts`**. That page lists every host and
-approves them in one click.
+comma-separated **`names`** and **`hosts`**. That page lists every valid host
+and approves them in one click. Values that are not hostname-shaped (a truncated
+token such as `api.ope`, a path such as `api.openai.com/v1`, empty or
+whitespace) are shown as invalid and are not written to the allowlist — copy the
+link again if a client wrapped it.
 
 Saving a secret does not by itself approve new hosts. Self-authored and adopted
 packages do not skip this gate: an empty host allowlist blocks secret-bearing

--- a/packages/worker/client/routes/account-approval-shared.ts
+++ b/packages/worker/client/routes/account-approval-shared.ts
@@ -4,19 +4,17 @@ export type AccountStatus = 'loading' | 'ready' | 'error'
 export type ApprovalAction = 'approve' | 'reject'
 export type ApprovalScope = 'session' | 'package' | 'user'
 
-export type RejectedApprovalHost = {
-	host: string
-	reason: 'malformed' | 'unknown_suffix'
-	message: string
-}
-
 export type ApprovalView = {
 	name: string
 	names: Array<string>
 	scope: ApprovalScope
 	requestedHost: string
 	requestedHosts: Array<string>
-	rejectedHosts: Array<RejectedApprovalHost>
+	rejectedHosts: Array<{
+		host: string
+		reason: 'malformed' | 'unknown_suffix'
+		message: string
+	}>
 	currentAllowedHosts: Array<string>
 	requestedPackageId: string | null
 	currentAllowedPackages: Array<string>

--- a/packages/worker/client/routes/account-approval-shared.ts
+++ b/packages/worker/client/routes/account-approval-shared.ts
@@ -4,15 +4,40 @@ export type AccountStatus = 'loading' | 'ready' | 'error'
 export type ApprovalAction = 'approve' | 'reject'
 export type ApprovalScope = 'session' | 'package' | 'user'
 
+export type RejectedApprovalHost = {
+	host: string
+	reason: 'malformed' | 'unknown_suffix'
+	message: string
+}
+
 export type ApprovalView = {
 	name: string
 	names: Array<string>
 	scope: ApprovalScope
 	requestedHost: string
 	requestedHosts: Array<string>
+	rejectedHosts: Array<RejectedApprovalHost>
 	currentAllowedHosts: Array<string>
 	requestedPackageId: string | null
 	currentAllowedPackages: Array<string>
+}
+
+export function approvalRequestedHosts(approval: ApprovalView) {
+	if (approval.requestedHosts.length > 0) return approval.requestedHosts
+	return approval.requestedHost ? [approval.requestedHost] : []
+}
+
+export function approvalRejectedHosts(approval: ApprovalView) {
+	return approval.rejectedHosts ?? []
+}
+
+export function allowHostsButtonLabel(
+	validCount: number,
+	rejectedCount: number,
+) {
+	if (validCount <= 1) return 'Allow access'
+	if (rejectedCount > 0) return `Allow ${validCount} valid hosts`
+	return `Allow all ${validCount} hosts`
 }
 
 export const accountSecretsApiPath = '/account/secrets.json'

--- a/packages/worker/client/routes/account-secrets-approval.tsx
+++ b/packages/worker/client/routes/account-secrets-approval.tsx
@@ -3,6 +3,9 @@ import { on } from '#client/event-mixin.ts'
 import {
 	type ApprovalAction,
 	type ApprovalView,
+	allowHostsButtonLabel,
+	approvalRejectedHosts,
+	approvalRequestedHosts,
 	getScopeLabel,
 } from '#client/routes/account-approval-shared.ts'
 import {
@@ -12,6 +15,7 @@ import {
 	typography,
 } from '#universal/styles/tokens.ts'
 import {
+	getAccentCalloutCss,
 	getGhostButtonCss,
 	getPillButtonCss,
 } from '#universal/styles/style-primitives.ts'
@@ -24,6 +28,8 @@ export function renderSecretApprovalCard(props: {
 	onSubmit: (action: ApprovalAction) => void
 }) {
 	const { approvalCard, packagesById, disabled, onSubmit } = props
+	const hosts = approvalHosts(approvalCard)
+	const rejectedHosts = approvalRejectedHosts(approvalCard)
 	const requestedPackageMetadata = approvalCard.requestedPackageId
 		? packagesById.get(approvalCard.requestedPackageId)
 		: null
@@ -93,17 +99,17 @@ export function renderSecretApprovalCard(props: {
 				) : (
 					<div mix={css({ display: 'grid', gap: spacing.xs })}>
 						<p mix={css({ margin: 0, color: colors.textMuted })}>
-							{approvalHosts(approvalCard).length > 1
+							{hosts.length > 1
 								? 'Let Kody use this secret at these hosts.'
-								: 'Let Kody use this connection at '}
-							{approvalHosts(approvalCard).length === 1 ? (
-								<strong mix={css({ color: colors.text })}>
-									{approvalHosts(approvalCard)[0]}
-								</strong>
+								: hosts.length === 1
+									? 'Let Kody use this connection at '
+									: 'This approval link did not include a valid host.'}
+							{hosts.length === 1 ? (
+								<strong mix={css({ color: colors.text })}>{hosts[0]}</strong>
 							) : null}
-							{approvalHosts(approvalCard).length === 1 ? '.' : null}
+							{hosts.length === 1 ? '.' : null}
 						</p>
-						{approvalHosts(approvalCard).length > 1 ? (
+						{hosts.length > 1 ? (
 							<ul
 								mix={css({
 									margin: 0,
@@ -112,12 +118,44 @@ export function renderSecretApprovalCard(props: {
 									gap: spacing.xs,
 								})}
 							>
-								{approvalHosts(approvalCard).map((host) => (
+								{hosts.map((host) => (
 									<li key={host}>
 										<strong mix={css({ color: colors.text })}>{host}</strong>
 									</li>
 								))}
 							</ul>
+						) : null}
+						{rejectedHosts.length > 0 ? (
+							<div
+								mix={css(getAccentCalloutCss({ accentColor: colors.danger }))}
+								data-testid="secret-approval-rejected-hosts"
+							>
+								<span mix={css({ color: colors.danger, fontWeight: 600 })}>
+									{rejectedHosts.length === 1
+										? 'This host is not valid'
+										: `${rejectedHosts.length} hosts are not valid`}
+								</span>
+								<ul
+									mix={css({
+										margin: 0,
+										paddingLeft: spacing.lg,
+										display: 'grid',
+										gap: spacing.xs,
+									})}
+								>
+									{rejectedHosts.map((entry) => (
+										<li key={entry.host}>
+											<strong mix={css({ color: colors.text })}>
+												{entry.host}
+											</strong>
+											<span mix={css({ color: colors.textMuted })}>
+												{' '}
+												— {entry.message}
+											</span>
+										</li>
+									))}
+								</ul>
+							</div>
 						) : null}
 					</div>
 				)}
@@ -171,22 +209,22 @@ export function renderSecretApprovalCard(props: {
 				)}
 			</div>
 			<div mix={css({ display: 'flex', gap: spacing.sm, flexWrap: 'wrap' })}>
-				<button
-					type="button"
-					disabled={disabled}
-					mix={[
-						on('click', () => onSubmit('approve')),
-						css(secretApprovalPrimaryButtonCss),
-					]}
-				>
-					{approvalCard.requestedPackageId && approvalCard.names.length > 1
-						? `Approve all (${approvalCard.names.length})`
-						: approvalHosts(approvalCard).length > 1
-							? `Allow all ${approvalHosts(approvalCard).length} hosts`
-							: approvalCard.requestedHost && !approvalCard.requestedPackageId
-								? 'Allow access'
-								: 'Approve'}
-				</button>
+				{approvalCard.requestedPackageId || hosts.length > 0 ? (
+					<button
+						type="button"
+						disabled={disabled}
+						mix={[
+							on('click', () => onSubmit('approve')),
+							css(secretApprovalPrimaryButtonCss),
+						]}
+					>
+						{approvalCard.requestedPackageId && approvalCard.names.length > 1
+							? `Approve all (${approvalCard.names.length})`
+							: approvalCard.requestedPackageId
+								? 'Approve'
+								: allowHostsButtonLabel(hosts.length, rejectedHosts.length)}
+					</button>
+				) : null}
 				<button
 					type="button"
 					disabled={disabled}
@@ -203,8 +241,7 @@ export function renderSecretApprovalCard(props: {
 }
 
 function approvalHosts(approvalCard: ApprovalView) {
-	if (approvalCard.requestedHosts.length > 0) return approvalCard.requestedHosts
-	return approvalCard.requestedHost ? [approvalCard.requestedHost] : []
+	return approvalRequestedHosts(approvalCard)
 }
 
 export function renderAlreadyAddedNotice(items: Array<string>) {

--- a/packages/worker/client/routes/connect-secrets.node.test.ts
+++ b/packages/worker/client/routes/connect-secrets.node.test.ts
@@ -1,6 +1,9 @@
 import { expect, test } from 'vitest'
 import { allowHostsButtonLabel } from './account-approval-shared.ts'
-import { isConnectSecretsAlreadyAllowed } from './connect-secrets.tsx'
+import {
+	isConnectSecretsAlreadyAllowed,
+	readConnectSecretsView,
+} from './connect-secrets.tsx'
 
 const secret = {
 	id: 'user:googleAccessToken',
@@ -98,4 +101,18 @@ test('connect secrets is already allowed only when every listed secret is presen
 	expect(allowHostsButtonLabel(2, 0)).toBe('Allow all 2 hosts')
 	expect(allowHostsButtonLabel(1, 1)).toBe('Allow access')
 	expect(allowHostsButtonLabel(2, 1)).toBe('Allow 2 valid hosts')
+
+	expect(
+		readConnectSecretsView({
+			hostCount: 1,
+			rejectedCount: 1,
+			completed: 'approve',
+			alreadyAllowed: false,
+		}),
+	).toEqual({
+		onlyInvalid: false,
+		fullyAllowed: false,
+		leftoverInvalid: true,
+		showBackToSecrets: true,
+	})
 })

--- a/packages/worker/client/routes/connect-secrets.node.test.ts
+++ b/packages/worker/client/routes/connect-secrets.node.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from 'vitest'
+import { allowHostsButtonLabel } from './account-approval-shared.ts'
 import { isConnectSecretsAlreadyAllowed } from './connect-secrets.tsx'
 
 const secret = {
@@ -22,6 +23,7 @@ const approval = {
 	scope: 'user' as const,
 	requestedHost: 'gmail.googleapis.com',
 	requestedHosts: ['gmail.googleapis.com', 'oauth2.googleapis.com'],
+	rejectedHosts: [],
 	requestedPackageId: null,
 	currentAllowedHosts: ['oauth2.googleapis.com'],
 	currentAllowedPackages: [],
@@ -53,4 +55,47 @@ test('connect secrets is already allowed only when every listed secret is presen
 			approval,
 		}),
 	).toBe(false)
+
+	expect(
+		isConnectSecretsAlreadyAllowed({
+			secrets: [
+				{
+					...secret,
+					allowedHosts: ['gmail.googleapis.com', 'oauth2.googleapis.com'],
+				},
+			],
+			approval: {
+				...approval,
+				rejectedHosts: [
+					{
+						host: 'api.ope',
+						reason: 'unknown_suffix',
+						message: 'truncated',
+					},
+				],
+			},
+		}),
+	).toBe(true)
+
+	expect(
+		isConnectSecretsAlreadyAllowed({
+			secrets: [secret],
+			approval: {
+				...approval,
+				requestedHost: '',
+				requestedHosts: [],
+				rejectedHosts: [
+					{
+						host: 'api.ope',
+						reason: 'unknown_suffix',
+						message: 'truncated',
+					},
+				],
+			},
+		}),
+	).toBe(false)
+
+	expect(allowHostsButtonLabel(2, 0)).toBe('Allow all 2 hosts')
+	expect(allowHostsButtonLabel(1, 1)).toBe('Allow access')
+	expect(allowHostsButtonLabel(2, 1)).toBe('Allow 2 valid hosts')
 })

--- a/packages/worker/client/routes/connect-secrets.tsx
+++ b/packages/worker/client/routes/connect-secrets.tsx
@@ -143,14 +143,14 @@ export function ConnectSecretsRoute(handle: Handle) {
 			})
 		const hosts = approval ? approvalRequestedHosts(approval) : []
 		const names = approval?.names.length ? approval.names : []
-		const onlyInvalid =
-			hosts.length === 0 && rejectedHosts.length > 0 && completed !== 'reject'
-		const fullyAllowed =
-			(completed === 'approve' || alreadyAllowed) &&
-			rejectedHosts.length === 0 &&
-			!onlyInvalid
-		const leftoverInvalid =
-			rejectedHosts.length > 0 && (completed === 'approve' || alreadyAllowed)
+		const view = readConnectSecretsView({
+			hostCount: hosts.length,
+			rejectedCount: rejectedHosts.length,
+			completed,
+			alreadyAllowed,
+		})
+		const { onlyInvalid, fullyAllowed, leftoverInvalid, showBackToSecrets } =
+			view
 
 		return (
 			<section mix={css(connectSecretsPageCss)} data-testid="connect-secrets">
@@ -278,7 +278,7 @@ export function ConnectSecretsRoute(handle: Handle) {
 								</div>
 							) : null}
 						</div>
-						{fullyAllowed || alreadyAllowed || completed === 'reject' ? (
+						{showBackToSecrets ? (
 							<a
 								href={routes.accountSecrets.href()}
 								mix={css(connectSecretsSecondaryButtonCss)}
@@ -330,6 +330,35 @@ export function ConnectSecretsRoute(handle: Handle) {
 				) : null}
 			</section>
 		)
+	}
+}
+
+export function readConnectSecretsView(input: {
+	hostCount: number
+	rejectedCount: number
+	completed: ApprovalAction | null
+	alreadyAllowed: boolean
+}) {
+	const onlyInvalid =
+		input.hostCount === 0 &&
+		input.rejectedCount > 0 &&
+		input.completed !== 'reject'
+	const fullyAllowed =
+		(input.completed === 'approve' || input.alreadyAllowed) &&
+		input.rejectedCount === 0 &&
+		!onlyInvalid
+	const leftoverInvalid =
+		input.rejectedCount > 0 &&
+		(input.completed === 'approve' || input.alreadyAllowed)
+	return {
+		onlyInvalid,
+		fullyAllowed,
+		leftoverInvalid,
+		showBackToSecrets:
+			fullyAllowed ||
+			leftoverInvalid ||
+			input.alreadyAllowed ||
+			input.completed === 'reject',
 	}
 }
 

--- a/packages/worker/client/routes/connect-secrets.tsx
+++ b/packages/worker/client/routes/connect-secrets.tsx
@@ -7,6 +7,9 @@ import {
 	type ApprovalAction,
 	type ApprovalView,
 	accountSecretsApiPath,
+	allowHostsButtonLabel,
+	approvalRejectedHosts,
+	approvalRequestedHosts,
 	submitApprovalRequest,
 } from '#client/routes/account-approval-shared.ts'
 import {
@@ -16,6 +19,7 @@ import {
 import { colors, spacing } from '#universal/styles/tokens.ts'
 import {
 	cardCss,
+	getAccentCalloutCss,
 	getPrimaryButtonCss,
 	getSecondaryButtonCss,
 	pageDescriptionCss,
@@ -129,6 +133,7 @@ export function ConnectSecretsRoute(handle: Handle) {
 		const currentHref = getCurrentHref()
 		applyRouteLoaderData(currentHref)
 		const approval = data?.approval ?? null
+		const rejectedHosts = approval ? approvalRejectedHosts(approval) : []
 		const alreadyAllowed =
 			approval != null &&
 			completed !== 'reject' &&
@@ -136,32 +141,44 @@ export function ConnectSecretsRoute(handle: Handle) {
 				secrets: data?.secrets ?? [],
 				approval,
 			})
-		const hosts = approval?.requestedHosts?.length
-			? approval.requestedHosts
-			: approval?.requestedHost
-				? [approval.requestedHost]
-				: []
+		const hosts = approval ? approvalRequestedHosts(approval) : []
 		const names = approval?.names.length ? approval.names : []
+		const onlyInvalid =
+			hosts.length === 0 && rejectedHosts.length > 0 && completed !== 'reject'
+		const fullyAllowed =
+			(completed === 'approve' || alreadyAllowed) &&
+			rejectedHosts.length === 0 &&
+			!onlyInvalid
+		const leftoverInvalid =
+			rejectedHosts.length > 0 && (completed === 'approve' || alreadyAllowed)
 
 		return (
 			<section mix={css(connectSecretsPageCss)} data-testid="connect-secrets">
 				<header mix={css(connectSecretsHeaderCss)}>
 					<span mix={css(pageEyebrowCss)}>Allow secret hosts</span>
 					<h1 mix={css(pageTitleCss)}>
-						{completed === 'approve' || alreadyAllowed
+						{fullyAllowed
 							? 'Access allowed'
-							: completed === 'reject'
-								? 'Request rejected'
-								: 'Allow this secret at these hosts'}
+							: leftoverInvalid
+								? 'Some hosts could not be allowed'
+								: onlyInvalid
+									? 'These hosts are not valid'
+									: completed === 'reject'
+										? 'Request rejected'
+										: 'Allow this secret at these hosts'}
 					</h1>
 					<p mix={css(pageDescriptionCss)}>
-						{completed === 'approve' || alreadyAllowed
+						{fullyAllowed
 							? 'Kody can send this saved secret to the hosts below.'
-							: completed === 'reject'
-								? 'No hosts were added. You can approve later from this same link.'
-								: approval
-									? 'Kody only sends a saved secret to hosts you approve. Saving a secret does not do this automatically.'
-									: 'Open an approval link from Kody to allow a saved secret at a host.'}
+							: leftoverInvalid
+								? 'Valid hosts were allowed. Invalid hosts from this link were not written to the allowlist — copy the approval link again if it was truncated.'
+								: onlyInvalid
+									? 'Kody did not treat these values as hosts you can allow. Copy the approval link again if it was truncated.'
+									: completed === 'reject'
+										? 'No hosts were added. You can approve later from this same link.'
+										: approval
+											? 'Kody only sends a saved secret to hosts you approve. Saving a secret does not do this automatically.'
+											: 'Open an approval link from Kody to allow a saved secret at a host.'}
 					</p>
 				</header>
 
@@ -183,7 +200,7 @@ export function ConnectSecretsRoute(handle: Handle) {
 					<p mix={css({ margin: 0, color: colors.danger })}>{message}</p>
 				) : null}
 
-				{approval && hosts.length > 0 ? (
+				{approval && (hosts.length > 0 || rejectedHosts.length > 0) ? (
 					<section mix={css(cardCss)} data-testid="connect-secrets-card">
 						<div mix={css({ display: 'grid', gap: spacing.sm })}>
 							<div mix={css({ display: 'grid', gap: spacing.xs })}>
@@ -205,29 +222,63 @@ export function ConnectSecretsRoute(handle: Handle) {
 									))}
 								</ul>
 							</div>
-							<div mix={css({ display: 'grid', gap: spacing.xs })}>
-								<span mix={css({ color: colors.textMuted })}>
-									{hosts.length === 1 ? 'Host' : 'Hosts'}
-								</span>
-								<ul
-									mix={css({
-										margin: 0,
-										paddingLeft: spacing.lg,
-										display: 'grid',
-										gap: spacing.xs,
-									})}
+							{hosts.length > 0 ? (
+								<div mix={css({ display: 'grid', gap: spacing.xs })}>
+									<span mix={css({ color: colors.textMuted })}>
+										{hosts.length === 1 ? 'Host' : 'Hosts'}
+									</span>
+									<ul
+										mix={css({
+											margin: 0,
+											paddingLeft: spacing.lg,
+											display: 'grid',
+											gap: spacing.xs,
+										})}
+									>
+										{hosts.map((host) => (
+											<li key={host}>
+												<strong mix={css({ color: colors.text })}>
+													{host}
+												</strong>
+											</li>
+										))}
+									</ul>
+								</div>
+							) : null}
+							{rejectedHosts.length > 0 ? (
+								<div
+									mix={css(getAccentCalloutCss({ accentColor: colors.danger }))}
+									data-testid="connect-secrets-rejected-hosts"
 								>
-									{hosts.map((host) => (
-										<li key={host}>
-											<strong mix={css({ color: colors.text })}>{host}</strong>
-										</li>
-									))}
-								</ul>
-							</div>
+									<span mix={css({ color: colors.danger, fontWeight: 600 })}>
+										{rejectedHosts.length === 1
+											? 'This host is not valid'
+											: `${rejectedHosts.length} hosts are not valid`}
+									</span>
+									<ul
+										mix={css({
+											margin: 0,
+											paddingLeft: spacing.lg,
+											display: 'grid',
+											gap: spacing.xs,
+										})}
+									>
+										{rejectedHosts.map((entry) => (
+											<li key={entry.host}>
+												<strong mix={css({ color: colors.text })}>
+													{entry.host}
+												</strong>
+												<span mix={css({ color: colors.textMuted })}>
+													{' '}
+													— {entry.message}
+												</span>
+											</li>
+										))}
+									</ul>
+								</div>
+							) : null}
 						</div>
-						{completed === 'approve' ||
-						alreadyAllowed ||
-						completed === 'reject' ? (
+						{fullyAllowed || alreadyAllowed || completed === 'reject' ? (
 							<a
 								href={routes.accountSecrets.href()}
 								mix={css(connectSecretsSecondaryButtonCss)}
@@ -242,22 +293,25 @@ export function ConnectSecretsRoute(handle: Handle) {
 									flexWrap: 'wrap',
 								})}
 							>
-								<button
-									type="button"
-									disabled={submittingAction != null}
-									mix={[
-										on('click', () => {
-											void submitApproval('approve')
-										}),
-										css(connectSecretsPrimaryButtonCss),
-									]}
-								>
-									{submittingAction === 'approve'
-										? 'Allowing access…'
-										: hosts.length > 1
-											? `Allow all ${hosts.length} hosts`
-											: 'Allow access'}
-								</button>
+								{hosts.length > 0 && completed !== 'approve' ? (
+									<button
+										type="button"
+										disabled={submittingAction != null}
+										mix={[
+											on('click', () => {
+												void submitApproval('approve')
+											}),
+											css(connectSecretsPrimaryButtonCss),
+										]}
+									>
+										{submittingAction === 'approve'
+											? 'Allowing access…'
+											: allowHostsButtonLabel(
+													hosts.length,
+													rejectedHosts.length,
+												)}
+									</button>
+								) : null}
 								<button
 									type="button"
 									disabled={submittingAction != null}
@@ -283,6 +337,7 @@ export function isConnectSecretsAlreadyAllowed(input: {
 	secrets: AccountSecretsLoaderData['secrets']
 	approval: ApprovalView
 }) {
+	if (approvalRequestedHosts(input.approval).length === 0) return false
 	const pendingPairs = collectPendingHostPairs(input.secrets, input.approval)
 	if (pendingPairs.length > 0) return false
 	return input.approval.names.every((name) =>
@@ -296,11 +351,7 @@ function collectPendingHostPairs(
 	secrets: AccountSecretsLoaderData['secrets'],
 	approval: ApprovalView,
 ) {
-	const hosts = approval.requestedHosts.length
-		? approval.requestedHosts
-		: approval.requestedHost
-			? [approval.requestedHost]
-			: []
+	const hosts = approvalRequestedHosts(approval)
 	const pairs: Array<{ name: string; host: string }> = []
 	for (const name of approval.names) {
 		const secret = secrets.find(

--- a/packages/worker/src/app/account-secrets-data.ts
+++ b/packages/worker/src/app/account-secrets-data.ts
@@ -12,7 +12,8 @@ import {
 	resolveSecret,
 } from '#mcp/secrets/service.ts'
 import { type SecretScope } from '#mcp/secrets/types.ts'
-import { normalizeBulkHostApprovalHosts } from '#mcp/secrets/host-approval.ts'
+import { type RejectedApprovalHost } from '#mcp/secrets/approval-host-shape.ts'
+import { classifyBulkApprovalHosts } from '#mcp/secrets/host-approval.ts'
 import { normalizeBulkPackageSecretApprovalNames } from '#mcp/secrets/package-approval-url.ts'
 import { listSavedPackagesByUserId } from '#worker/package-registry/repo.ts'
 
@@ -60,6 +61,7 @@ type SecretApprovalView = {
 	scope: SecretScope
 	requestedHost: string
 	requestedHosts: Array<string>
+	rejectedHosts: Array<RejectedApprovalHost>
 	requestedPackageId: string | null
 	currentAllowedHosts: Array<string>
 	currentAllowedPackages: Array<string>
@@ -111,6 +113,7 @@ async function buildAccountSecretsPayload(input: {
 }): Promise<AccountSecretsLoaderData> {
 	const url = new URL(input.request.url)
 	const requestedApprovalHosts = readApprovalHosts(url)
+	const rejectedApprovalHosts = requestedApprovalHosts.rejected
 	const requestedPackageId = readRequestedPackageId(url)
 	const requestedSecretNames = readRequestedSecretNames(url)
 	const requestedHostScope = readHostApprovalScope(url)
@@ -139,7 +142,9 @@ async function buildAccountSecretsPayload(input: {
 	let approval: SecretApprovalView | null = null
 	let approvalError: string | null = null
 	const hasApprovalTarget = Boolean(
-		requestedApprovalHosts.length > 0 || requestedPackageId,
+		requestedApprovalHosts.valid.length > 0 ||
+		rejectedApprovalHosts.length > 0 ||
+		requestedPackageId,
 	)
 	const hasApprovalSubject = Boolean(
 		input.selectedSecretId || requestedSecretNames.length > 0,
@@ -150,7 +155,8 @@ async function buildAccountSecretsPayload(input: {
 				env: input.env,
 				userId: input.user.mcpUser.userId,
 				secretId: input.selectedSecretId ?? null,
-				requestedHosts: requestedApprovalHosts,
+				requestedHosts: requestedApprovalHosts.valid,
+				rejectedHosts: rejectedApprovalHosts,
 				requestedPackageId,
 				requestedSecretNames,
 				requestedHostScope,
@@ -227,12 +233,14 @@ type ResolvedSecretApproval =
 			name: string
 			scope: SecretScope
 			requestedHost: string
+			rejectedHosts: Array<RejectedApprovalHost>
 			storageContext: StorageContext | null
 	  }
 	| {
 			kind: 'host_bulk'
 			names: Array<string>
 			hosts: Array<string>
+			rejectedHosts: Array<RejectedApprovalHost>
 			scope: SecretScope
 			storageContext: StorageContext | null
 	  }
@@ -254,6 +262,7 @@ type ResolvedSecretApproval =
 function resolveApprovalRequest(input: {
 	secretId: string | null
 	requestedHosts: Array<string>
+	rejectedHosts?: Array<RejectedApprovalHost>
 	requestedPackageId: string | null
 	requestedSecretNames?: Array<string>
 	requestedHostScope?: SecretScope
@@ -262,8 +271,13 @@ function resolveApprovalRequest(input: {
 	const requestedSecretNames = normalizeBulkPackageSecretApprovalNames(
 		input.requestedSecretNames ?? [],
 	)
-	const requestedHosts = normalizeBulkHostApprovalHosts(input.requestedHosts)
-	if (requestedHosts.length > 0 && input.requestedPackageId) {
+	const classified = classifyBulkApprovalHosts(input.requestedHosts)
+	const requestedHosts = classified.valid
+	const rejectedHosts = input.rejectedHosts ?? classified.rejected
+	if (
+		(requestedHosts.length > 0 || rejectedHosts.length > 0) &&
+		input.requestedPackageId
+	) {
 		throw new Error('Approval request contains both host and package.')
 	}
 	if (requestedSecretNames.length > 0) {
@@ -281,13 +295,14 @@ function resolveApprovalRequest(input: {
 				storageContext: null,
 			}
 		}
-		if (requestedHosts.length === 0) {
+		if (requestedHosts.length === 0 && rejectedHosts.length === 0) {
 			throw new Error('Bulk secret approval requires a package_id or hosts.')
 		}
 		return {
 			kind: 'host_bulk',
 			names: requestedSecretNames,
 			hosts: requestedHosts,
+			rejectedHosts,
 			scope: input.requestedHostScope ?? 'user',
 			storageContext: input.requestedHostStorageContext ?? null,
 		}
@@ -309,7 +324,7 @@ function resolveApprovalRequest(input: {
 			storageContext,
 		}
 	}
-	if (requestedHosts.length === 1) {
+	if (requestedHosts.length === 1 && rejectedHosts.length === 0) {
 		const requestedHost = requestedHosts[0]
 		if (!requestedHost) {
 			throw new Error('Invalid approval request host.')
@@ -319,14 +334,16 @@ function resolveApprovalRequest(input: {
 			name: parsed.name,
 			scope: parsed.scope,
 			requestedHost,
+			rejectedHosts,
 			storageContext,
 		}
 	}
-	if (requestedHosts.length > 1) {
+	if (requestedHosts.length > 0 || rejectedHosts.length > 0) {
 		return {
 			kind: 'host_bulk',
 			names: [parsed.name],
 			hosts: requestedHosts,
+			rejectedHosts,
 			scope: parsed.scope,
 			storageContext,
 		}
@@ -339,6 +356,7 @@ async function resolveSecretApprovalView(input: {
 	userId: string
 	secretId: string | null
 	requestedHosts: Array<string>
+	rejectedHosts: Array<RejectedApprovalHost>
 	requestedPackageId: string | null
 	requestedSecretNames: Array<string>
 	requestedHostScope: SecretScope
@@ -348,6 +366,7 @@ async function resolveSecretApprovalView(input: {
 	const approval = resolveApprovalRequest({
 		secretId: input.secretId,
 		requestedHosts: input.requestedHosts,
+		rejectedHosts: input.rejectedHosts,
 		requestedPackageId: input.requestedPackageId,
 		requestedSecretNames: input.requestedSecretNames,
 		requestedHostScope: input.requestedHostScope,
@@ -387,6 +406,7 @@ async function resolveSecretApprovalView(input: {
 				scope: 'user',
 				requestedHost: '',
 				requestedHosts: [],
+				rejectedHosts: [],
 				requestedPackageId: approval.packageId,
 				currentAllowedHosts: [],
 				currentAllowedPackages: [approval.packageId],
@@ -400,6 +420,7 @@ async function resolveSecretApprovalView(input: {
 			scope: 'user',
 			requestedHost: '',
 			requestedHosts: [],
+			rejectedHosts: [],
 			requestedPackageId: approval.packageId,
 			currentAllowedHosts: firstSecret?.allowedHosts ?? [],
 			currentAllowedPackages: firstSecret?.allowedPackages ?? [],
@@ -431,6 +452,7 @@ async function resolveSecretApprovalView(input: {
 			scope: approval.scope,
 			requestedHost: approval.hosts[0] ?? '',
 			requestedHosts: approval.hosts,
+			rejectedHosts: approval.rejectedHosts,
 			requestedPackageId: null,
 			currentAllowedHosts: firstSecret?.allowedHosts ?? [],
 			currentAllowedPackages: firstSecret?.allowedPackages ?? [],
@@ -460,6 +482,7 @@ async function resolveSecretApprovalView(input: {
 		scope: approval.scope,
 		requestedHost: approval.kind === 'host' ? approval.requestedHost : '',
 		requestedHosts: approval.kind === 'host' ? [approval.requestedHost] : [],
+		rejectedHosts: approval.kind === 'host' ? approval.rejectedHosts : [],
 		requestedPackageId: approval.kind === 'package' ? approval.packageId : null,
 		currentAllowedHosts: secret.allowedHosts,
 		currentAllowedPackages: secret.allowedPackages,
@@ -592,9 +615,7 @@ function readApprovalHosts(url: URL) {
 		...url.searchParams.getAll('allowed-host'),
 		...url.searchParams.getAll('allowedHosts'),
 	]
-	return normalizeBulkHostApprovalHosts(
-		values.flatMap((value) => value.split(',')),
-	)
+	return classifyBulkApprovalHosts(values.flatMap((value) => value.split(',')))
 }
 
 function readHostApprovalScope(url: URL): SecretScope {

--- a/packages/worker/src/app/handlers/account-secrets.node.test.ts
+++ b/packages/worker/src/app/handlers/account-secrets.node.test.ts
@@ -799,6 +799,115 @@ test('host bulk approval adds every requested host to each listed secret', async
 	)
 })
 
+test('host approval rejects truncated and malformed hosts instead of writing them', async () => {
+	mockModule.setSecretAllowedHosts.mockClear()
+	const secret = {
+		name: 'openaiApiKey',
+		scope: 'user' as const,
+		description: 'OpenAI API key',
+		packageId: null,
+		allowedHosts: [] as Array<string>,
+		allowedPackages: [],
+		createdAt: new Date(0).toISOString(),
+		updatedAt: new Date(0).toISOString(),
+		expiresAt: null,
+		ttlMs: null,
+	}
+	mockModule.listSecrets.mockResolvedValue([secret])
+	mockModule.listSavedPackagesByUserId.mockResolvedValue([])
+	mockModule.listPackageSecretsByPackageIds.mockResolvedValue(new Map())
+
+	const handler = createAccountSecretsApiHandler(createEnv())
+	const mixedView = await handler.handler({
+		request: new Request(
+			'https://example.com/account/secrets.json?names=openaiApiKey&hosts=hooks.slack.com,api.ope',
+			{ method: 'GET' },
+		),
+		params: {},
+	} as never)
+	expect(mixedView.status).toBe(200)
+	await expect(mixedView.json()).resolves.toMatchObject({
+		ok: true,
+		approval: {
+			name: 'openaiApiKey',
+			names: ['openaiApiKey'],
+			requestedHost: 'hooks.slack.com',
+			requestedHosts: ['hooks.slack.com'],
+			rejectedHosts: [
+				{
+					host: 'api.ope',
+					reason: 'unknown_suffix',
+				},
+			],
+		},
+	})
+
+	const mixedApprove = await handler.handler({
+		request: new Request(
+			'https://example.com/account/secrets.json?names=openaiApiKey&hosts=hooks.slack.com,api.ope',
+			{
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ action: 'approve' }),
+			},
+		),
+		params: {},
+	} as never)
+	expect(mixedApprove.status).toBe(200)
+	await expect(mixedApprove.json()).resolves.toMatchObject({
+		ok: true,
+		approval: {
+			requestedHosts: ['hooks.slack.com'],
+			rejectedHosts: [{ host: 'api.ope', reason: 'unknown_suffix' }],
+		},
+	})
+	expect(mockModule.setSecretAllowedHosts).toHaveBeenCalledWith(
+		expect.objectContaining({
+			name: 'openaiApiKey',
+			allowedHosts: ['hooks.slack.com'],
+		}),
+	)
+
+	mockModule.setSecretAllowedHosts.mockClear()
+	const invalidOnlyView = await handler.handler({
+		request: new Request(
+			'https://example.com/account/secrets.json?names=openaiApiKey&hosts=api.openai.com/v1,%20%20,api.ope',
+			{ method: 'GET' },
+		),
+		params: {},
+	} as never)
+	expect(invalidOnlyView.status).toBe(200)
+	await expect(invalidOnlyView.json()).resolves.toMatchObject({
+		ok: true,
+		approval: {
+			requestedHosts: [],
+			rejectedHosts: [
+				{ host: 'api.ope', reason: 'unknown_suffix' },
+				{ host: 'api.openai.com/v1', reason: 'malformed' },
+			],
+		},
+	})
+
+	const invalidOnlyApprove = await handler.handler({
+		request: new Request(
+			'https://example.com/account/secrets.json?names=openaiApiKey&hosts=api.ope',
+			{
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ action: 'approve' }),
+			},
+		),
+		params: {},
+	} as never)
+	expect(invalidOnlyApprove.status).toBe(400)
+	await expect(invalidOnlyApprove.json()).resolves.toMatchObject({
+		ok: false,
+		error:
+			'None of the requested hosts are valid. The approval link may have been truncated — copy it again.',
+	})
+	expect(mockModule.setSecretAllowedHosts).not.toHaveBeenCalled()
+})
+
 test('approval requests reject invalid targets and ignore stale capability query params', async () => {
 	const handler = createAccountSecretsApiHandler(createEnv())
 

--- a/packages/worker/src/app/handlers/account-secrets.ts
+++ b/packages/worker/src/app/handlers/account-secrets.ts
@@ -35,6 +35,7 @@ import { listSavedPackagesByUserId } from '#worker/package-registry/repo.ts'
 import { type routes } from '#universal/routes.ts'
 import { normalizeAllowedPackages } from '#mcp/secrets/allowed-packages.ts'
 import { normalizeAllowedHosts } from '#mcp/secrets/allowed-hosts.ts'
+import { filterValidApprovalHosts } from '#mcp/secrets/approval-host-shape.ts'
 import {
 	canonicalIntegrationName,
 	normalizeIntegrationConfig,
@@ -795,9 +796,11 @@ async function handleApprovalAction(input: {
 }) {
 	try {
 		const url = new URL(input.request.url)
+		const classifiedHosts = readApprovalHosts(url)
 		const approval = resolveApprovalRequest({
 			secretId: readAccountSecretsSelectedSecretId(input.request.url),
-			requestedHosts: readApprovalHosts(url),
+			requestedHosts: classifiedHosts.valid,
+			rejectedHosts: classifiedHosts.rejected,
 			requestedPackageId: readRequestedPackageId(url),
 			requestedSecretNames: readRequestedSecretNames(url),
 			requestedHostScope: readHostApprovalScope(url),
@@ -912,6 +915,17 @@ async function handleApprovalAction(input: {
 
 		if (approval.kind === 'host') {
 			if (input.action === 'approve') {
+				const hostsToGrant = filterValidApprovalHosts([approval.requestedHost])
+				if (hostsToGrant.length === 0) {
+					return jsonResponse(
+						{
+							ok: false,
+							error:
+								'None of the requested hosts are valid. The approval link may have been truncated — copy it again.',
+						},
+						400,
+					)
+				}
 				const current = await listSecrets({
 					env: input.env,
 					userId: input.user.mcpUser.userId,
@@ -932,7 +946,7 @@ async function handleApprovalAction(input: {
 					scope: approval.scope,
 					allowedHosts: normalizeAllowedHosts([
 						...secret.allowedHosts,
-						approval.requestedHost,
+						...hostsToGrant,
 					]),
 					storageContext: approval.storageContext,
 				})
@@ -949,6 +963,17 @@ async function handleApprovalAction(input: {
 
 		if (approval.kind === 'host_bulk') {
 			if (input.action === 'approve') {
+				const hostsToGrant = filterValidApprovalHosts(approval.hosts)
+				if (hostsToGrant.length === 0) {
+					return jsonResponse(
+						{
+							ok: false,
+							error:
+								'None of the requested hosts are valid. The approval link may have been truncated — copy it again.',
+						},
+						400,
+					)
+				}
 				const current = await listSecrets({
 					env: input.env,
 					userId: input.user.mcpUser.userId,
@@ -974,7 +999,7 @@ async function handleApprovalAction(input: {
 						scope: approval.scope,
 						allowedHosts: normalizeAllowedHosts([
 							...secret.allowedHosts,
-							...approval.hosts,
+							...hostsToGrant,
 						]),
 						storageContext: approval.storageContext,
 					})

--- a/packages/worker/src/app/ssr-render-connect-secrets.node.test.ts
+++ b/packages/worker/src/app/ssr-render-connect-secrets.node.test.ts
@@ -132,6 +132,7 @@ test('renderAppPage server-renders the dedicated connect-secrets approval page',
 					scope: 'user',
 					requestedHost: 'gmail.googleapis.com',
 					requestedHosts: ['gmail.googleapis.com', 'oauth2.googleapis.com'],
+					rejectedHosts: [],
 					requestedPackageId: null,
 					currentAllowedHosts: ['oauth2.googleapis.com'],
 					currentAllowedPackages: [],
@@ -147,4 +148,91 @@ test('renderAppPage server-renders the dedicated connect-secrets approval page',
 	expect(connectSecretsHtml).toContain('oauth2.googleapis.com')
 	expect(connectSecretsHtml).toContain('Allow all 2 hosts')
 	expect(connectSecretsHtml).not.toContain('New secret')
+})
+
+test('renderAppPage flags invalid connect-secrets hosts instead of offering Allow all', async () => {
+	resetDataCacheForTests()
+	setAuthSessionSecret(testCookieSecret)
+	const env = {
+		COOKIE_SECRET: testCookieSecret,
+		SECRET_STORE_KEY: 'LOCAL_TEST_SECRET_STORE_KEY_32_CHARS_MINIMUM',
+		...testOidcSigningEnv,
+		APP_DB: createUserTestDb(),
+		BUNDLE_ARTIFACTS_KV: {},
+		JOB_MANAGER: {},
+		STORAGE_RUNNER: {},
+		PACKAGE_REALTIME_SESSION: {},
+		MCP_CLIENT_HUB: {},
+	} as unknown as Env
+	const cookie = await createAuthCookie(
+		{
+			stableUserId: testStableUserIdFromEmail('user@example.com'),
+			email: 'user@example.com',
+			rememberMe: false,
+		} satisfies AuthSession,
+		false,
+	)
+
+	const connectSecretsResponse = await renderAppPage({
+		request: new Request(
+			'https://example.com/connect/secrets?names=slackWebhookPath,openaiApiKey&hosts=hooks.slack.com,api.ope',
+			{ headers: { Cookie: cookie } },
+		),
+		env,
+		loaderData: {
+			accountSecrets: {
+				ok: true,
+				email: 'user@example.com',
+				packageOptions: [],
+				packages: [],
+				secrets: [
+					{
+						id: 'user:openaiApiKey',
+						name: 'openaiApiKey',
+						scope: 'user',
+						description: '',
+						packageId: null,
+						packageTitle: null,
+						allowedHosts: [],
+						allowedPackages: [],
+						createdAt: '2026-01-01T00:00:00.000Z',
+						updatedAt: '2026-01-01T00:00:00.000Z',
+						expiresAt: null,
+						ttlMs: null,
+					},
+				],
+				selectedSecret: null,
+				approval: {
+					name: 'openaiApiKey',
+					names: ['openaiApiKey'],
+					scope: 'user',
+					requestedHost: 'hooks.slack.com',
+					requestedHosts: ['hooks.slack.com'],
+					rejectedHosts: [
+						{
+							host: 'api.ope',
+							reason: 'unknown_suffix',
+							message:
+								"This host doesn't look complete (unknown public suffix). The approval link may have been truncated — copy it again.",
+						},
+					],
+					requestedPackageId: null,
+					currentAllowedHosts: [],
+					currentAllowedPackages: [],
+				},
+				approvalError: null,
+			},
+		},
+	})
+	expect(connectSecretsResponse.status).toBe(200)
+	const connectSecretsHtml = await connectSecretsResponse.text()
+	expect(connectSecretsHtml).toContain('data-testid="connect-secrets"')
+	expect(connectSecretsHtml).toContain('hooks.slack.com')
+	expect(connectSecretsHtml).toContain('api.ope')
+	expect(connectSecretsHtml).toContain(
+		'data-testid="connect-secrets-rejected-hosts"',
+	)
+	expect(connectSecretsHtml).toContain('This host is not valid')
+	expect(connectSecretsHtml).toContain('Allow access')
+	expect(connectSecretsHtml).not.toContain('Allow all 2 hosts')
 })

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -1566,6 +1566,7 @@ test('renderAppPage server-renders simplified integration and secret-approval pa
 					scope: 'user',
 					requestedHost: 'gmail.googleapis.com',
 					requestedHosts: ['gmail.googleapis.com'],
+					rejectedHosts: [],
 					requestedPackageId: null,
 					currentAllowedHosts: ['oauth2.googleapis.com'],
 					currentAllowedPackages: [],

--- a/packages/worker/src/mcp/secrets/approval-host-shape.node.test.ts
+++ b/packages/worker/src/mcp/secrets/approval-host-shape.node.test.ts
@@ -79,4 +79,16 @@ test('approval host classification accepts happy-path hosts and rejects truncate
 			},
 		],
 	)
+	expect(
+		classifyApprovalHosts(['::1', '[::1]', '2001:db8::1', 'not:an:ip']).valid,
+	).toEqual(['[2001:db8::1]', '[::1]'])
+	expect(
+		classifyApprovalHosts(['not:an:ip', '::1/128', '[::1]:443']).rejected.map(
+			(entry) => [entry.host, entry.reason],
+		),
+	).toEqual([
+		['::1/128', 'malformed'],
+		['[::1]:443', 'malformed'],
+		['not:an:ip', 'malformed'],
+	])
 })

--- a/packages/worker/src/mcp/secrets/approval-host-shape.node.test.ts
+++ b/packages/worker/src/mcp/secrets/approval-host-shape.node.test.ts
@@ -1,0 +1,82 @@
+import { expect, test } from 'vitest'
+import {
+	classifyApprovalHosts,
+	filterValidApprovalHosts,
+	rejectedApprovalHostMessage,
+} from './approval-host-shape.ts'
+
+test('approval host classification accepts happy-path hosts and rejects truncated or malformed values', () => {
+	const classified = classifyApprovalHosts([
+		'api.openai.com',
+		'hooks.slack.com',
+		'api.ope',
+		'api.openai.com/v1',
+		'  ',
+		'',
+		'api. openai.com',
+		'openai',
+		'https://api.github.com/path',
+		'localhost',
+		'127.0.0.1',
+		'API.Cloudflare.com',
+	])
+
+	expect(classified.valid).toEqual([
+		'127.0.0.1',
+		'api.cloudflare.com',
+		'api.github.com',
+		'api.openai.com',
+		'hooks.slack.com',
+		'localhost',
+	])
+	expect(
+		classified.rejected.map((entry) => [entry.host, entry.reason]),
+	).toEqual([
+		['api. openai.com', 'malformed'],
+		['api.ope', 'unknown_suffix'],
+		['api.openai.com/v1', 'malformed'],
+		['openai', 'malformed'],
+	])
+	expect(
+		classified.rejected.find((entry) => entry.host === 'api.ope')?.message,
+	).toBe(rejectedApprovalHostMessage('unknown_suffix'))
+	expect(
+		classified.rejected.find((entry) => entry.host === 'api.openai.com/v1')
+			?.message,
+	).toBe(rejectedApprovalHostMessage('malformed'))
+
+	expect(
+		filterValidApprovalHosts([
+			'hooks.slack.com',
+			'api.ope',
+			'api.openai.com/v1',
+		]),
+	).toEqual(['hooks.slack.com'])
+	expect(classifyApprovalHosts(['', '   '])).toEqual({
+		valid: [],
+		rejected: [],
+	})
+	expect(classifyApprovalHosts(['api.test', 'foo.localhost']).valid).toEqual([
+		'api.test',
+		'foo.localhost',
+	])
+	expect(classifyApprovalHosts(['999.1.1.1', 'com', 'api.o']).rejected).toEqual(
+		[
+			{
+				host: '999.1.1.1',
+				reason: 'malformed',
+				message: rejectedApprovalHostMessage('malformed'),
+			},
+			{
+				host: 'api.o',
+				reason: 'unknown_suffix',
+				message: rejectedApprovalHostMessage('unknown_suffix'),
+			},
+			{
+				host: 'com',
+				reason: 'malformed',
+				message: rejectedApprovalHostMessage('malformed'),
+			},
+		],
+	)
+})

--- a/packages/worker/src/mcp/secrets/approval-host-shape.ts
+++ b/packages/worker/src/mcp/secrets/approval-host-shape.ts
@@ -47,15 +47,15 @@ export function classifyApprovalHosts(
 	const valid: Array<string> = []
 	const rejected: Array<RejectedApprovalHost> = []
 	for (const host of limited) {
-		const reason = classifyNormalizedApprovalHost(host)
-		if (reason == null) {
-			valid.push(host)
+		const classified = classifyNormalizedApprovalHost(host)
+		if (classified.reason == null) {
+			if (!valid.includes(classified.host)) valid.push(classified.host)
 			continue
 		}
 		rejected.push({
 			host,
-			reason,
-			message: rejectedApprovalHostMessage(reason),
+			reason: classified.reason,
+			message: rejectedApprovalHostMessage(classified.reason),
 		})
 	}
 	return { valid, rejected }
@@ -65,32 +65,39 @@ export function filterValidApprovalHosts(hosts: Array<string>) {
 	return classifyApprovalHosts(hosts).valid
 }
 
-function classifyNormalizedApprovalHost(
-	host: string,
-): RejectedApprovalHostReason | null {
-	if (host.length === 0 || host.length > maxHostnameLength) return 'malformed'
-	if (containsForbiddenHostChars(host)) return 'malformed'
+function classifyNormalizedApprovalHost(host: string): {
+	host: string
+	reason: RejectedApprovalHostReason | null
+} {
+	const ipv6 = canonicalizeIpv6Host(host)
+	if (ipv6) return { host: ipv6, reason: null }
+	if (host.length === 0 || host.length > maxHostnameLength) {
+		return { host, reason: 'malformed' }
+	}
+	if (containsForbiddenHostChars(host)) return { host, reason: 'malformed' }
 	if (host.startsWith('.') || host.endsWith('.') || host.includes('..')) {
-		return 'malformed'
+		return { host, reason: 'malformed' }
 	}
-	if (isIpAddress(host)) return null
-	if (looksLikeInvalidIpv4(host)) return 'malformed'
+	if (isIpv4Address(host)) return { host, reason: null }
+	if (looksLikeInvalidIpv4(host)) return { host, reason: 'malformed' }
 	if (host === 'localhost' || host.endsWith('.localhost')) {
-		return isDnsLabelList(host) ? null : 'malformed'
+		return { host, reason: isDnsLabelList(host) ? null : 'malformed' }
 	}
-	if (!host.includes('.')) return 'malformed'
-	if (!isHostnameToken(host)) return 'malformed'
+	if (!host.includes('.')) return { host, reason: 'malformed' }
+	if (!isHostnameToken(host)) return { host, reason: 'malformed' }
 
 	const parsed = parse(host, { detectIp: false, validateHostname: true })
-	if (parsed.hostname !== host) return 'malformed'
-	if (parsed.isIcann === true || parsed.isPrivate === true) return null
+	if (parsed.hostname !== host) return { host, reason: 'malformed' }
+	if (parsed.isIcann === true || parsed.isPrivate === true) {
+		return { host, reason: null }
+	}
 	if (
 		parsed.publicSuffix != null &&
 		specialUsePublicSuffixes.has(parsed.publicSuffix)
 	) {
-		return null
+		return { host, reason: null }
 	}
-	return 'unknown_suffix'
+	return { host, reason: 'unknown_suffix' }
 }
 
 function containsForbiddenHostChars(host: string) {
@@ -114,11 +121,6 @@ function isDnsLabelList(host: string) {
 	})
 }
 
-function isIpAddress(host: string) {
-	if (isIpv4Address(host)) return true
-	return isIpv6Address(host)
-}
-
 function isIpv4Address(host: string) {
 	const parts = host.split('.')
 	if (parts.length !== 4) return false
@@ -135,13 +137,19 @@ function looksLikeInvalidIpv4(host: string) {
 	return parts.every((part) => /^\d+$/.test(part))
 }
 
-function isIpv6Address(host: string) {
+/**
+ * `URL.hostname` in this runtime serializes IPv6 as a bracketed host (`[::1]`),
+ * including compressed forms. Compare against that serialization rather than
+ * the unbracketed input, and persist the same form fetch matching uses.
+ */
+function canonicalizeIpv6Host(host: string) {
 	const inner =
 		host.startsWith('[') && host.endsWith(']') ? host.slice(1, -1) : host
-	if (!inner.includes(':')) return false
+	if (!inner.includes(':')) return null
 	try {
-		return new URL(`http://[${inner}]/`).hostname === inner
+		const hostname = new URL(`http://[${inner}]/`).hostname
+		return hostname.startsWith('[') && hostname.endsWith(']') ? hostname : null
 	} catch {
-		return false
+		return null
 	}
 }

--- a/packages/worker/src/mcp/secrets/approval-host-shape.ts
+++ b/packages/worker/src/mcp/secrets/approval-host-shape.ts
@@ -1,0 +1,147 @@
+import { parse } from 'tldts'
+import { normalizeAllowedHosts } from './allowed-hosts.ts'
+
+export type RejectedApprovalHostReason = 'malformed' | 'unknown_suffix'
+
+export type RejectedApprovalHost = {
+	host: string
+	reason: RejectedApprovalHostReason
+	message: string
+}
+
+export type ClassifiedApprovalHosts = {
+	valid: Array<string>
+	rejected: Array<RejectedApprovalHost>
+}
+
+/**
+ * RFC 2606 / 6761 special-use suffixes that tldts does not mark ICANN.
+ * `.localhost` is handled separately so `foo.localhost` stays valid.
+ */
+const specialUsePublicSuffixes = new Set(['example', 'invalid', 'test'])
+
+const maxHostnameLength = 253
+
+export function rejectedApprovalHostMessage(
+	reason: RejectedApprovalHostReason,
+): string {
+	switch (reason) {
+		case 'malformed':
+			return "This host isn't valid — the link may have been truncated. Copy it again from Kody."
+		case 'unknown_suffix':
+			return "This host doesn't look complete (unknown public suffix). The approval link may have been truncated — copy it again."
+		default: {
+			const _exhaustive: never = reason
+			return _exhaustive
+		}
+	}
+}
+
+export function classifyApprovalHosts(
+	hosts: Array<string>,
+	options?: { limit?: number },
+): ClassifiedApprovalHosts {
+	const normalized = normalizeAllowedHosts(hosts)
+	const limited =
+		options?.limit == null ? normalized : normalized.slice(0, options.limit)
+	const valid: Array<string> = []
+	const rejected: Array<RejectedApprovalHost> = []
+	for (const host of limited) {
+		const reason = classifyNormalizedApprovalHost(host)
+		if (reason == null) {
+			valid.push(host)
+			continue
+		}
+		rejected.push({
+			host,
+			reason,
+			message: rejectedApprovalHostMessage(reason),
+		})
+	}
+	return { valid, rejected }
+}
+
+export function filterValidApprovalHosts(hosts: Array<string>) {
+	return classifyApprovalHosts(hosts).valid
+}
+
+function classifyNormalizedApprovalHost(
+	host: string,
+): RejectedApprovalHostReason | null {
+	if (host.length === 0 || host.length > maxHostnameLength) return 'malformed'
+	if (containsForbiddenHostChars(host)) return 'malformed'
+	if (host.startsWith('.') || host.endsWith('.') || host.includes('..')) {
+		return 'malformed'
+	}
+	if (isIpAddress(host)) return null
+	if (looksLikeInvalidIpv4(host)) return 'malformed'
+	if (host === 'localhost' || host.endsWith('.localhost')) {
+		return isDnsLabelList(host) ? null : 'malformed'
+	}
+	if (!host.includes('.')) return 'malformed'
+	if (!isHostnameToken(host)) return 'malformed'
+
+	const parsed = parse(host, { detectIp: false, validateHostname: true })
+	if (parsed.hostname !== host) return 'malformed'
+	if (parsed.isIcann === true || parsed.isPrivate === true) return null
+	if (
+		parsed.publicSuffix != null &&
+		specialUsePublicSuffixes.has(parsed.publicSuffix)
+	) {
+		return null
+	}
+	return 'unknown_suffix'
+}
+
+function containsForbiddenHostChars(host: string) {
+	return /[\s/?#@\\]/.test(host)
+}
+
+function isHostnameToken(host: string) {
+	if (isDnsLabelList(host)) return true
+	// IDN API hosts are uncommon; still accept a dotted token tldts can parse
+	// when it has no forbidden characters (already checked).
+	return !host.includes(':')
+}
+
+function isDnsLabelList(host: string) {
+	return host.split('.').every((label) => {
+		if (label.length === 0 || label.length > 63) return false
+		return (
+			/^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/.test(label) ||
+			/^xn--[a-z0-9-]+$/.test(label)
+		)
+	})
+}
+
+function isIpAddress(host: string) {
+	if (isIpv4Address(host)) return true
+	return isIpv6Address(host)
+}
+
+function isIpv4Address(host: string) {
+	const parts = host.split('.')
+	if (parts.length !== 4) return false
+	return parts.every((part) => {
+		if (!/^\d{1,3}$/.test(part)) return false
+		const value = Number(part)
+		return value >= 0 && value <= 255
+	})
+}
+
+function looksLikeInvalidIpv4(host: string) {
+	const parts = host.split('.')
+	if (parts.length !== 4) return false
+	return parts.every((part) => /^\d+$/.test(part))
+}
+
+function isIpv6Address(host: string) {
+	const inner =
+		host.startsWith('[') && host.endsWith(']') ? host.slice(1, -1) : host
+	if (!inner.includes(':')) return false
+	try {
+		return new URL(`http://[${inner}]/`).hostname === inner
+	} catch {
+		return false
+	}
+}

--- a/packages/worker/src/mcp/secrets/host-approval.node.test.ts
+++ b/packages/worker/src/mcp/secrets/host-approval.node.test.ts
@@ -61,4 +61,22 @@ test('host approval URLs use /connect/secrets and support multiple hosts', () =>
 	).toBe(
 		'https://example.com/connect/secrets?name=onlyOne&hosts=api.example.com%2Coauth.example.com',
 	)
+
+	expect(
+		buildSecretHostBulkApprovalUrl({
+			baseUrl: 'https://example.com',
+			names: ['openaiApiKey'],
+			hosts: ['hooks.slack.com', 'api.ope', 'api.openai.com/v1'],
+		}),
+	).toBe(
+		'https://example.com/connect/secrets?name=openaiApiKey&hosts=hooks.slack.com',
+	)
+
+	expect(() =>
+		buildSecretHostBulkApprovalUrl({
+			baseUrl: 'https://example.com',
+			names: ['openaiApiKey'],
+			hosts: ['api.ope', 'api.openai.com/v1'],
+		}),
+	).toThrow('At least one host is required for host approval.')
 })

--- a/packages/worker/src/mcp/secrets/host-approval.node.test.ts
+++ b/packages/worker/src/mcp/secrets/host-approval.node.test.ts
@@ -79,4 +79,16 @@ test('host approval URLs use /connect/secrets and support multiple hosts', () =>
 			hosts: ['api.ope', 'api.openai.com/v1'],
 		}),
 	).toThrow('At least one host is required for host approval.')
+
+	expect(
+		buildSecretHostApprovalUrl({
+			baseUrl: 'https://example.com',
+			name: 'localToken',
+			scope: 'user',
+			requestedHost: '::1',
+			storageContext: null,
+		}),
+	).toBe(
+		'https://example.com/connect/secrets?name=localToken&hosts=%5B%3A%3A1%5D',
+	)
 })

--- a/packages/worker/src/mcp/secrets/host-approval.ts
+++ b/packages/worker/src/mcp/secrets/host-approval.ts
@@ -1,13 +1,22 @@
 import { type StorageContext } from '#mcp/storage.ts'
-import { normalizeAllowedHosts } from './allowed-hosts.ts'
+import {
+	classifyApprovalHosts,
+	type ClassifiedApprovalHosts,
+} from './approval-host-shape.ts'
 import { normalizeBulkPackageSecretApprovalNames } from './package-approval-url.ts'
 import { type SecretScope } from './types.ts'
 
 const connectSecretsPath = '/connect/secrets'
 const maxBulkHostApprovalHosts = 20
 
+export function classifyBulkApprovalHosts(
+	hosts: Array<string>,
+): ClassifiedApprovalHosts {
+	return classifyApprovalHosts(hosts, { limit: maxBulkHostApprovalHosts })
+}
+
 export function normalizeBulkHostApprovalHosts(hosts: Array<string>) {
-	return normalizeAllowedHosts(hosts).slice(0, maxBulkHostApprovalHosts)
+	return classifyBulkApprovalHosts(hosts).valid
 }
 
 export function buildSecretHostApprovalUrl(input: {

--- a/packages/worker/universal/loader-data.ts
+++ b/packages/worker/universal/loader-data.ts
@@ -1467,6 +1467,11 @@ export type AccountSecretsLoaderData = {
 		scope: 'package' | 'session' | 'user'
 		requestedHost: string
 		requestedHosts: Array<string>
+		rejectedHosts: Array<{
+			host: string
+			reason: 'malformed' | 'unknown_suffix'
+			message: string
+		}>
 		requestedPackageId: string | null
 		currentAllowedHosts: Array<string>
 		currentAllowedPackages: Array<string>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop `/connect/secrets` from treating truncated or malformed `hosts` values as successful Allow targets, so junk never lands in `allowedHosts`.

Fixes #2195.

## Why

A terminal soft-wrap can cut an approval URL so the last host arrives as `api.ope` instead of `api.openai.com`. That wrap is not a Kody bug. Kody’s failure was the missing host-shape check: the page offered **Allow all 2 hosts**, reported success, and wrote the broken token while the real host was never approved.

## Summary

- Shared `classifyApprovalHosts` helper used on the approval **read** path and again on the Allow **write** path.
- Valid hosts: dotted ICANN/private-PSL/RFC 2606 special-use names, `localhost` / `*.localhost`, and IPv4/IPv6 **shape** (no network lookup). IPv6 is stored as `URL.hostname` serializes it (`[::1]`), matching later fetch checks.
- Rejected (shown, never written): paths (`api.openai.com/v1`), whitespace/empty, bare labels, and unknown public suffixes (`api.ope`, `api.o`) via the existing `tldts` PSL.
- UI: rejected hosts get a callout (“copy the link again”). **Allow all N** is only for an all-valid list. Mixed lists use **Allow N valid hosts**. All-invalid lists hide Allow and return 400 if posted. After a mixed Allow, the page stays on **Back to secrets** (not a leftover Reject-only row).
- Docs: `docs/contributing/secret-host-approval.md` plus usage/guide notes.

## Chosen bar for `api.ope`

A pure FQDN regex still accepts `api.ope`. This repo already depends on `tldts`. Hosts whose public suffix is not ICANN, private PSL, or RFC 2606 (`test` / `example` / `invalid`) are **rejected** as `unknown_suffix`. No DNS at approve time. No first-party API allowlist.

## Product boundary (not in this PR)

Look-alike FQDNs (`api.openai.com.evil.example`), homoglyphs, and an allow/deny model for known API hosts stay a Kent product call. Eng scope is host-shape validation and honest UI/write semantics only.

## Review follow-ups

- Bugbot: IPv6 was documented as valid but rejected because `URL.hostname` is bracketed in this runtime. Fixed by canonicalizing to that form.
- CodeRabbit: mixed Allow with leftover rejected hosts now treats that state as terminal (**Back to secrets**).
- Skipped the duplicated `rejectedHosts` type-sharing nit. The JSON shape is two stable reason strings; a unused re-export of the same type already failed knip.

## Testing

- `approval-host-shape.node.test.ts`: happy path, truncated `api.ope`, path, whitespace, empty, bare label, localhost/IP, IPv6 (`::1` / `[::1]`) and junk IPv6-shaped tokens
- Account secrets API: mixed approve writes only `hooks.slack.com`; all-invalid approve is 400 and writes nothing
- SSR: mixed list shows the rejected callout and does not offer **Allow all 2 hosts**
- Connect-secrets view helper: leftover-invalid after approve shows the back link
- Pre-commit typecheck passed
- `test:push` (node-unit 3005 + workers-unit 341) passed on this push
- Isolated Playwright e2e: 12 passed
- Preview (seeded `me@kentcdodds.com`): mixed `hooks.slack.com,api.ope` and path `api.openai.com/v1` — invalid hosts are callouts, no **Allow all 2 hosts**, Allow hidden when nothing is valid

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `f112299d` · **Head:** `c761fd54`

**Classification:** extends — `/connect/secrets` and the Allow write now classify host shape before presenting or persisting `allowedHosts`.

### Primitives touched

| Primitive    | Group    | Impact                                                                |
| ------------ | -------- | --------------------------------------------------------------------- |
| `app-ui`     | surfaces | extends — approval loader, Allow action, and connect-secrets UI       |
| `mcp-server` | surfaces | extends — shared `classifyApprovalHosts` used by read and write paths |

### Change flow

A truncated or malformed `hosts` query is classified before the approval page renders, and classified again before Allow writes `allowedHosts`.

```mermaid
sequenceDiagram
	actor User
	participant appUi as app-ui
	participant mcpServer as mcp-server
	User->>appUi: GET /connect/secrets with hosts query
	appUi->>mcpServer: classifyApprovalHosts
	mcpServer-->>appUi: valid and rejected host lists
	appUi-->>User: valid hosts plus rejected callout
	alt Allow when at least one host is valid
		User->>appUi: POST approve
		appUi->>mcpServer: filterValidApprovalHosts
		mcpServer-->>appUi: valid hosts only
		appUi->>appUi: setSecretAllowedHosts with valid hosts
		appUi-->>User: partial or full success without writing rejects
	end
```

### Before / after

| Path | Before | After |
| ---- | ------ | ----- |
| `hosts=hooks.slack.com,api.ope` | Both shown as Allow targets, both written | `hooks.slack.com` approvable, `api.ope` rejected |
| `hosts=api.openai.com/v1` | Path kept and written | Rejected as malformed |
| Allow all | Claimed success for every token | Only valid hosts written, UI stays honest |

### Invariants

Per-user secret isolation is unchanged. This PR does not add an API-host allowlist or a deny model for look-alike FQDNs.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-518ecab1-b0af-49fe-a683-73f362968a48?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-518ecab1-b0af-49fe-a683-73f362968a48&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Host approval now validates requested hostnames and distinguishes valid hosts from rejected entries.
  - Invalid, truncated, empty, or path-based values are clearly identified with explanatory messages.
  - Mixed approvals grant access only to valid hosts; approvals containing no valid hosts are blocked.
  - Approval actions and button labels reflect the number of valid and rejected hosts.
  - IPv6 hosts are supported with consistent formatting.

- **Documentation**
  - Added guidance covering accepted hostname formats, validation behavior, IPv6 handling, and troubleshooting truncated approval links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->