### PR TITLE
Fix daily friction: health --sha, preview 10007, and Cloud Agent dev:ensure

### DIFF
--- a/.agents/skills/control-kody/SKILL.md
+++ b/.agents/skills/control-kody/SKILL.md
@@ -47,7 +47,8 @@ CI green is not enough for a user-visible account change. Prefer:
 1. `doctor` then `dev` or `preview`
 2. `request` / `--check` as the seed user **with data for this change**
 3. A computerUse video or screenshot of the same page
-4. After merge, `health --origin https://kody.codes --sha <merge>`
+4. After merge, `health --origin https://kody.codes --sha <merge>` (full SHA,
+   unique short SHA, or a later descendant HEAD that contains the merge)
 
 See
 [docs/contributing/control-kody.md](../../../docs/contributing/control-kody.md)

--- a/.agents/skills/visual-recap/SKILL.md
+++ b/.agents/skills/visual-recap/SKILL.md
@@ -223,7 +223,9 @@ Format rules:
    and node labels; pull behavioral detail from architecture docs / the diff,
    not by rewriting map summaries. Choose the graph type using **Choosing a
    diagram**.
-5. Upsert it into the PR description:
+5. Upsert it into the PR description.
+
+   Validate mermaid and compute the merged body:
 
    ```bash
    node .agents/skills/visual-recap/scripts/upsert-recap-block.mjs <pr-number> <block-file>
@@ -232,6 +234,13 @@ Format rules:
    The script rejects mermaid GitHub cannot parse, then replaces the content
    between the markers, or appends the block to the end of the description on
    first run. It never touches text outside the markers.
+
+   **Cloud Agents:** `gh pr edit` fails with
+   `Resource not accessible by integration (updatePullRequest)`. Do not treat
+   that as a reason to skip the recap. Run the script anyway so mermaid is
+   checked; when it prints the merged PR body, apply that body with Cursor
+   **ManagePullRequest**. Do not have Kody, a Kody workflow, or Kody's GitHub
+   integration edit the PR.
 
 6. Re-run steps 2-5 after pushing significant new commits to the PR.
 

--- a/.agents/skills/visual-recap/scripts/upsert-recap-block.mjs
+++ b/.agents/skills/visual-recap/scripts/upsert-recap-block.mjs
@@ -4,6 +4,11 @@
 //   node upsert-recap-block.mjs <pr-number> <block-file>
 // The block file must start with the start marker and end with the end
 // marker. Requires the `gh` CLI to be authenticated.
+//
+// Cloud Agents cannot `gh pr edit` (GraphQL updatePullRequest is forbidden
+// for the integration token). On that failure the script still validates
+// mermaid, prints the merged body, and tells the agent to apply it with
+// Cursor ManagePullRequest.
 import { execFileSync, spawnSync } from 'node:child_process'
 import { readFileSync } from 'node:fs'
 import path from 'node:path'
@@ -13,57 +18,99 @@ const startMarker = '<!-- system-recap:start -->'
 const endMarker = '<!-- system-recap:end -->'
 const repoRoot = fileURLToPath(new URL('../../../..', import.meta.url))
 
-const [prNumber, blockFile] = process.argv.slice(2)
-if (!prNumber || !blockFile) {
-	console.error('usage: upsert-recap-block.mjs <pr-number> <block-file>')
-	process.exit(1)
-}
-
-const block = readFileSync(blockFile, 'utf8').trim()
-if (!block.startsWith(startMarker) || !block.endsWith(endMarker)) {
-	console.error(
-		`block file must start with "${startMarker}" and end with "${endMarker}"`,
+export function isGhPrEditForbidden(error) {
+	const text =
+		error instanceof Error
+			? `${error.message}${
+					'stderr' in error && typeof error.stderr === 'string'
+						? error.stderr
+						: ''
+				}`
+			: String(error)
+	return (
+		text.includes('Resource not accessible by integration') ||
+		text.includes('updatePullRequest')
 	)
-	process.exit(1)
 }
 
-const mermaidCheck = spawnSync(
-	process.execPath,
-	[
-		path.join(repoRoot, 'tools/check-mermaid-syntax.ts'),
-		'--stdin',
-		'--label',
-		blockFile,
-	],
-	{ input: block, encoding: 'utf8', cwd: repoRoot },
-)
-if (mermaidCheck.status !== 0) {
-	process.stderr.write(mermaidCheck.stdout)
-	process.stderr.write(mermaidCheck.stderr)
-	process.exit(mermaidCheck.status === null ? 1 : mermaidCheck.status)
+export function mergeRecapBody(body, block) {
+	const startIndex = body.indexOf(startMarker)
+	const endIndex = body.indexOf(endMarker)
+	const hasExistingBlock =
+		startIndex !== -1 && endIndex !== -1 && endIndex > startIndex
+	const nextBody = hasExistingBlock
+		? body.slice(0, startIndex) +
+			block +
+			body.slice(endIndex + endMarker.length)
+		: `${body.trimEnd()}\n\n${block}\n`
+	return { hasExistingBlock, nextBody }
 }
 
-const body = execFileSync(
-	'gh',
-	['pr', 'view', prNumber, '--json', 'body', '--jq', '.body'],
-	{ encoding: 'utf8' },
-)
+function main() {
+	const [prNumber, blockFile] = process.argv.slice(2)
+	if (!prNumber || !blockFile) {
+		console.error('usage: upsert-recap-block.mjs <pr-number> <block-file>')
+		process.exit(1)
+	}
 
-const startIndex = body.indexOf(startMarker)
-const endIndex = body.indexOf(endMarker)
-const hasExistingBlock =
-	startIndex !== -1 && endIndex !== -1 && endIndex > startIndex
+	const block = readFileSync(blockFile, 'utf8').trim()
+	if (!block.startsWith(startMarker) || !block.endsWith(endMarker)) {
+		console.error(
+			`block file must start with "${startMarker}" and end with "${endMarker}"`,
+		)
+		process.exit(1)
+	}
 
-const nextBody = hasExistingBlock
-	? body.slice(0, startIndex) + block + body.slice(endIndex + endMarker.length)
-	: `${body.trimEnd()}\n\n${block}\n`
+	const mermaidCheck = spawnSync(
+		process.execPath,
+		[
+			path.join(repoRoot, 'tools/check-mermaid-syntax.ts'),
+			'--stdin',
+			'--label',
+			blockFile,
+		],
+		{ input: block, encoding: 'utf8', cwd: repoRoot },
+	)
+	if (mermaidCheck.status !== 0) {
+		process.stderr.write(mermaidCheck.stdout)
+		process.stderr.write(mermaidCheck.stderr)
+		process.exit(mermaidCheck.status === null ? 1 : mermaidCheck.status)
+	}
 
-execFileSync('gh', ['pr', 'edit', prNumber, '--body-file', '-'], {
-	input: nextBody,
-})
+	const body = execFileSync(
+		'gh',
+		['pr', 'view', prNumber, '--json', 'body', '--jq', '.body'],
+		{ encoding: 'utf8' },
+	)
 
-console.log(
-	hasExistingBlock
-		? `updated system-recap block on PR #${prNumber}`
-		: `added system-recap block to PR #${prNumber}`,
-)
+	const { hasExistingBlock, nextBody } = mergeRecapBody(body, block)
+
+	try {
+		execFileSync('gh', ['pr', 'edit', prNumber, '--body-file', '-'], {
+			input: nextBody,
+		})
+	} catch (error) {
+		if (isGhPrEditForbidden(error)) {
+			console.error(
+				`gh pr edit cannot update PR #${prNumber} (Resource not accessible by integration). Cloud Agents must apply this recap with Cursor ManagePullRequest. Merged PR body follows.`,
+			)
+			process.stdout.write(nextBody)
+			if (!nextBody.endsWith('\n')) process.stdout.write('\n')
+			process.exit(2)
+		}
+		throw error
+	}
+
+	console.log(
+		hasExistingBlock
+			? `updated system-recap block on PR #${prNumber}`
+			: `added system-recap block to PR #${prNumber}`,
+	)
+}
+
+if (
+	process.argv[1] &&
+	fileURLToPath(import.meta.url) === path.resolve(process.argv[1])
+) {
+	main()
+}

--- a/.agents/skills/visual-recap/scripts/upsert-recap-block.mjs
+++ b/.agents/skills/visual-recap/scripts/upsert-recap-block.mjs
@@ -96,7 +96,8 @@ function main() {
 			)
 			process.stdout.write(nextBody)
 			if (!nextBody.endsWith('\n')) process.stdout.write('\n')
-			process.exit(2)
+			process.exitCode = 2
+			return
 		}
 		throw error
 	}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -240,7 +240,7 @@ jobs:
 
             node tools/ci/sync-worker-secrets.ts --env "" --name "$mock_worker_name" --config "$dir/wrangler.jsonc" --set "MOCK_API_TOKEN=$MOCK_API_TOKEN"
 
-            npx wrangler deploy --env preview --name "$mock_worker_name" --config "$dir/wrangler.jsonc" 2>&1 | tee "$deploy_log"
+            node ./wrangler-env.ts deploy --env preview --name "$mock_worker_name" --config "$dir/wrangler.jsonc" 2>&1 | tee "$deploy_log"
 
             mock_url="$(node -e 'const fs = require("node:fs"); const text = fs.readFileSync(process.argv[1], "utf8").replace(/\u001b\[[0-9;]*m/g, ""); const worker = process.argv[2]; const escaped = worker.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"); const workerUrlRegex = new RegExp(`https://(?:[a-zA-Z0-9-]+\\.)?${escaped}\\.[a-zA-Z0-9._-]+\\.workers\\.dev`, "g"); const matches = text.match(workerUrlRegex); process.stdout.write(matches?.at(-1) ?? "")' "$deploy_log" "$mock_worker_name")"
             if [ -z "$mock_url" ]; then

--- a/docs/contributing/cloud-agents.md
+++ b/docs/contributing/cloud-agents.md
@@ -103,11 +103,19 @@ dispatcher. The command is a no-op on machines without `~/.cursor/agent-hooks`.
   3742–3751, prints `App running at http://localhost:<port>` and exits 0 when a
   server is already up, waits for a kody/workerd leftover that accepts TCP but
   does not serve `/health` before replacing it, then starts `npm run dev` and
-  waits until `/health` is actually ok before printing the resolved URL. If the
-  latest wrangler line is Reloading and `/health` still misses the budget, the
-  process is left running so a retry can reuse it. UI verification opens that
-  real origin (for example `/onboarding`); do not substitute a `renderToString`
-  dump of one component.
+  waits until `/health` is actually ok before printing the resolved URL. If
+  `packages/worker/.env` is missing, it copies `.env.example` first so
+  `npm run dev` (`--env-file=packages/worker/.env`) can start. If wrangler
+  accepts TCP but Remix logs `Invalid environment variables` /
+  `Missing APP_DB binding` (or the same for `BUNDLE_ARTIFACTS_KV`,
+  `STORAGE_RUNNER`, `PACKAGE_REALTIME_SESSION`, `MCP_CLIENT_HUB`), `dev:ensure`
+  exits immediately with that hint instead of waiting 180s. Those bindings come
+  from `wrangler.jsonc` via the Vite Cloudflare plugin, not from `.env`; a
+  snapshot that cannot provide local D1/KV/DO persist cannot serve `/` or
+  `/blog/*`. If the latest wrangler line is Reloading and `/health` still misses
+  the budget, the process is left running so a retry can reuse it. UI
+  verification opens that real origin (for example `/onboarding`); do not
+  substitute a `renderToString` dump of one component.
 - `npm run dev` starts the optional Cloudflare API mock, then Vite so origin SSR
   and the client hydrate in one workerd graph. Generated platform, runtime,
   jobs, and highlight configs join as Vite auxiliary workers (local D1/KV/DO
@@ -127,7 +135,9 @@ dispatcher. The command is a no-op on machines without `~/.cursor/agent-hooks`.
 ## Environment file
 
 Copy `packages/worker/.env.example` to `packages/worker/.env` if missing.
-`COOKIE_SECRET` and `SECRET_STORE_KEY` are required for local dev.
+`dev:ensure` does this copy itself. `COOKIE_SECRET` and `SECRET_STORE_KEY` are
+required for local dev. The file does not create D1, KV, or Durable Object
+bindings.
 
 ## Seeding a test account
 

--- a/docs/contributing/control-kody.md
+++ b/docs/contributing/control-kody.md
@@ -17,6 +17,11 @@ npm run control-kody -- package-create --origin <preview> --kody-id <slug> [--he
 
 Same entry: `node tools/control-kody.ts`.
 
+`health --sha` succeeds when `/health` `commitSha` equals the argument, uniquely
+starts with it (git short SHA, 7+ characters), or is a descendant that contains
+it (`git merge-base --is-ancestor`). A later main HEAD deploy still counts as
+the merge being live.
+
 ## Feature Map
 
 [`.agents/skills/control-kody/references/features/`](../../.agents/skills/control-kody/references/features/README.md)

--- a/docs/contributing/testing-principles.md
+++ b/docs/contributing/testing-principles.md
@@ -82,7 +82,13 @@ factories explicitly inside each test (or a per-test factory). Do not introduce
   the flow is important enough to justify the maintenance cost.
 - Avoid tests that only assert a string blob contains a description or other
   incidental copy. Favor behavior-focused assertions (structured output,
-  user-visible outcomes, or stable public contracts) instead.
+  user-visible outcomes, or stable public contracts) instead. When a blog
+  catalog pin must quote an approved sentence, run the source through
+  `normalizeMarkdownPhraseSource` in
+  [`packages/worker/src/blog/catalog.ts`](../../packages/worker/src/blog/catalog.ts)
+  first. oxfmt reflows markdown blockquotes onto continuation `>` lines, so a
+  raw `post.body.includes('exact phrase')` fails after format even though the
+  words are still there.
 - Do not add tests whose only value is pinning configuration-style strings such
   as tool descriptions, usage hints, warnings, or other instructional copy. If
   the behavior matters, test the behavior or stable structured contract rather

--- a/packages/worker/src/blog/catalog.node.test.ts
+++ b/packages/worker/src/blog/catalog.node.test.ts
@@ -1,7 +1,20 @@
 import { expect, test } from 'vitest'
-import { getBlogPost, getReadNextBlogPost, listBlogPosts } from './catalog.ts'
+import {
+	getBlogPost,
+	getReadNextBlogPost,
+	listBlogPosts,
+	normalizeMarkdownPhraseSource,
+} from './catalog.ts'
 import { parseBlogPostMarkdown } from './parse-frontmatter.ts'
 import { buildBlogRssXml } from './rss.ts'
+
+test('normalizeMarkdownPhraseSource strips blockquote markers and wrapping', () => {
+	expect(
+		normalizeMarkdownPhraseSource(
+			'> funnels all my tools into one secure MCP\n> I can manage myself\n',
+		),
+	).toBe('funnels all my tools into one secure MCP I can manage myself ')
+})
 
 test('parseBlogPostMarkdown reads frontmatter and rejects invalid input', () => {
 	const post = parseBlogPostMarkdown(
@@ -169,9 +182,7 @@ test('blog catalog enumerates posts with required fields and slug lookup', () =>
 	expect(earlyUsers?.title).toBe('Early Kody users')
 	expect(earlyUsers?.date).toBe('2026-09-08')
 	expect(earlyUsers?.placeholder).toBe(true)
-	const earlyUsersBody = (earlyUsers?.body ?? '')
-		.replaceAll(/^>\s?/gm, '')
-		.replace(/\s+/g, ' ')
+	const earlyUsersBody = normalizeMarkdownPhraseSource(earlyUsers?.body ?? '')
 	expect(earlyUsersBody).toContain(
 		'funnels all my tools into one secure MCP I can manage myself',
 	)

--- a/packages/worker/src/blog/catalog.ts
+++ b/packages/worker/src/blog/catalog.ts
@@ -73,6 +73,15 @@ export function getBlogPost(slug: string): BlogPost | null {
 	return postsBySlug.get(slug) ?? null
 }
 
+/**
+ * Collapse markdown blockquote markers and wrapping so phrase pins survive
+ * oxfmt reflow. Use this instead of `post.body.includes('exact sentence')`
+ * when the pin lives in a `>` blockquote.
+ */
+export function normalizeMarkdownPhraseSource(source: string) {
+	return source.replaceAll(/^>\s?/gm, '').replace(/\s+/g, ' ')
+}
+
 export function listBlogPosts(): ReadonlyArray<BlogPost> {
 	return blogPosts
 }

--- a/tools/ci/resource-utils.node.test.ts
+++ b/tools/ci/resource-utils.node.test.ts
@@ -909,6 +909,11 @@ test('Cloudflare API requests retry gateway HTML/text blips then succeed', async
 	).toBe(true)
 	expect(isRetryableCloudflareFailure('Gateway Timeout [code: 504]')).toBe(true)
 	expect(
+		isRetryableCloudflareFailure(
+			'This Worker does not exist on your account [code: 10007]',
+		),
+	).toBe(false)
+	expect(
 		isRetryableCloudflareApiError(
 			new Error('Cloudflare API request failed (403): Authentication error'),
 		),

--- a/tools/control-kody.node.test.ts
+++ b/tools/control-kody.node.test.ts
@@ -17,6 +17,7 @@ import {
 	localSeedEmail,
 	parseControlArgs,
 	playwrightBrowsersInstalled,
+	isGitAncestor,
 	readHealth,
 	repoRootFromHere,
 	requestAsSession,
@@ -284,6 +285,58 @@ test('control-kody parses commands, maps every required route, and drives a seed
 			expect(stale.ok).toBe(false)
 		},
 	)
+})
+
+test('readHealth accepts a unique short SHA and a descendant live SHA', async () => {
+	await withAuthServer(
+		(_request, response) => {
+			response.setHeader('Content-Type', 'application/json')
+			response.end(
+				JSON.stringify({
+					ok: true,
+					commitSha: '91bab582b2040e7b55a84f2415be82c1684ad565',
+				}),
+			)
+		},
+		async (origin) => {
+			const prefix = await readHealth({
+				origin,
+				expectedSha: '91bab582',
+			})
+			expect(prefix.ok).toBe(true)
+			expect(prefix.detail).toContain('matches 91bab582')
+
+			const descendant = await readHealth({
+				origin,
+				expectedSha: 'ab07b020aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+				isAncestor: (ancestor, descendantSha) =>
+					ancestor === 'ab07b020aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' &&
+					descendantSha === '91bab582b2040e7b55a84f2415be82c1684ad565',
+			})
+			expect(descendant.ok).toBe(true)
+			expect(descendant.detail).toContain('descendant of')
+
+			const unrelated = await readHealth({
+				origin,
+				expectedSha: 'ffffffffffffffffffffffffffffffffffffffff',
+				isAncestor: () => false,
+			})
+			expect(unrelated.ok).toBe(false)
+		},
+	)
+
+	expect(
+		isGitAncestor('missing', 'also-missing', {
+			execFile: () => {
+				throw new Error('not an ancestor')
+			},
+		}),
+	).toBe(false)
+	expect(
+		isGitAncestor('parent', 'child', {
+			execFile: () => Buffer.from(''),
+		}),
+	).toBe(true)
 })
 
 test('control-kody request stops when auto-login fails', async () => {

--- a/tools/control-kody.ts
+++ b/tools/control-kody.ts
@@ -518,10 +518,31 @@ export async function requestAsSession(input: {
 	}
 }
 
+export function isGitAncestor(
+	ancestor: string,
+	descendant: string,
+	options: {
+		execFile?: typeof execFileSync
+		cwd?: string
+	} = {},
+) {
+	const execFile = options.execFile ?? execFileSync
+	try {
+		execFile('git', ['merge-base', '--is-ancestor', ancestor, descendant], {
+			cwd: options.cwd ?? process.cwd(),
+			stdio: 'ignore',
+		})
+		return true
+	} catch {
+		return false
+	}
+}
+
 export async function readHealth(input: {
 	origin: string
 	expectedSha: string | null
 	fetchImpl?: typeof fetch
+	isAncestor?: (ancestor: string, descendant: string) => boolean
 }) {
 	const fetchImpl = input.fetchImpl ?? fetch
 	const response = await fetchImpl(healthUrlForOrigin(input.origin))
@@ -531,7 +552,22 @@ export async function readHealth(input: {
 	} catch {
 		body = null
 	}
-	const evaluated = evaluateAppHealth(body, input.expectedSha)
+	let evaluated = evaluateAppHealth(body, input.expectedSha)
+	if (
+		!evaluated.ok &&
+		input.expectedSha &&
+		evaluated.commitSha &&
+		response.ok
+	) {
+		const isAncestor = input.isAncestor ?? isGitAncestor
+		if (isAncestor(input.expectedSha, evaluated.commitSha)) {
+			evaluated = {
+				ok: true,
+				commitSha: evaluated.commitSha,
+				detail: `ok, commitSha ${evaluated.commitSha} (descendant of ${input.expectedSha})`,
+			}
+		}
+	}
 	return {
 		ok: response.ok && evaluated.ok,
 		status: response.status,

--- a/tools/deploy.ts
+++ b/tools/deploy.ts
@@ -13,6 +13,7 @@ import {
 	readConfigFlag,
 	readNameFlag,
 } from './origin-worker-config.ts'
+import { runWranglerDeployWithRetry } from './wrangler-deploy-retry.ts'
 
 function run(
 	command: string,
@@ -129,10 +130,15 @@ export async function deploy(args: ReadonlyArray<string>) {
 		originViteWranglerConfigPath,
 		`${JSON.stringify(emittedConfig, null, '\t')}\n`,
 	)
-	run(resolveWranglerCommand(), originViteDeployArgs(args, workerName), {
-		...process.env,
-		...(cloudflareEnv ? { CLOUDFLARE_ENV: cloudflareEnv } : {}),
+	const result = await runWranglerDeployWithRetry({
+		command: resolveWranglerCommand(),
+		args: originViteDeployArgs(args, workerName),
+		env: {
+			...process.env,
+			...(cloudflareEnv ? { CLOUDFLARE_ENV: cloudflareEnv } : {}),
+		},
 	})
+	if (result.status !== 0) process.exit(result.status)
 }
 
 if (isExecutedDirectly(import.meta.url)) {

--- a/tools/deploy.ts
+++ b/tools/deploy.ts
@@ -138,7 +138,7 @@ export async function deploy(args: ReadonlyArray<string>) {
 			...(cloudflareEnv ? { CLOUDFLARE_ENV: cloudflareEnv } : {}),
 		},
 	})
-	if (result.status !== 0) process.exit(result.status)
+	if (result.status !== 0) process.exitCode = result.status
 }
 
 if (isExecutedDirectly(import.meta.url)) {

--- a/tools/ensure-dev.node.test.ts
+++ b/tools/ensure-dev.node.test.ts
@@ -3,8 +3,11 @@ import {
 	collectAncestorPids,
 	collectKodyDevKillPids,
 	ensureDev,
+	ensureWorkerEnvFile,
 	envWithPreferredNode26,
+	formatMissingWranglerBindingHint,
 	isKodyDevProcess,
+	isMissingWranglerBindingOutput,
 	isKodyDevSupervisor,
 	isWranglerStillStarting,
 	parseLsofListenPids,
@@ -308,6 +311,81 @@ test('envWithPreferredNode26 prepends nvm Node 26 only when the current runtime 
 		hasNodeBin: () => true,
 	})
 	expect(binDir).toBe('/home/agent/.nvm/versions/node/v26.7.0/bin')
+})
+
+test('ensureWorkerEnvFile copies .env.example once and refuses when both are missing', () => {
+	const copied: Array<string> = []
+	const present = new Set(['/repo/packages/worker/.env.example'])
+	const created = ensureWorkerEnvFile('/repo', {
+		exists: (file) => present.has(file),
+		copyFile: (from, to) => {
+			copied.push(`${from}->${to}`)
+			present.add(to)
+		},
+	})
+	expect(created).toEqual({
+		created: true,
+		path: '/repo/packages/worker/.env',
+	})
+	expect(copied).toEqual([
+		'/repo/packages/worker/.env.example->/repo/packages/worker/.env',
+	])
+	expect(
+		ensureWorkerEnvFile('/repo', {
+			exists: (file) => present.has(file),
+			copyFile: () => {
+				throw new Error('should not copy again')
+			},
+		}).created,
+	).toBe(false)
+	expect(() =>
+		ensureWorkerEnvFile('/empty', {
+			exists: () => false,
+			copyFile: () => {},
+		}),
+	).toThrow(/\.env\.example is not present/)
+})
+
+test('ensureDev fails immediately when wrangler logs missing bindings', async () => {
+	const stopped: Array<string> = []
+	await expect(
+		ensureDev({
+			ports: [3742],
+			probeHealth: async () => false,
+			listListenerPids: () => [],
+			readProcess: () => null,
+			protectedPids: new Set([1]),
+			killProcess: () => {},
+			startDev: () => ({
+				unref() {},
+				async stop() {
+					stopped.push('stop')
+				},
+				lastOutput: () =>
+					'Invalid environment variables: APP_DB: Missing APP_DB binding for database access',
+			}),
+			sleep: async () => {},
+			now: (() => {
+				let t = 0
+				return () => {
+					t += 1
+					return t
+				}
+			})(),
+			readyTimeoutMs: 180_000,
+			readyPollMs: 1,
+			log: () => {},
+		}),
+	).rejects.toThrow(/fails immediately instead of waiting 180s/)
+	expect(stopped).toEqual(['stop'])
+	expect(
+		isMissingWranglerBindingOutput(
+			'Invalid environment variables: APP_DB: Missing APP_DB binding',
+		),
+	).toBe(true)
+	expect(
+		formatMissingWranglerBindingHint('APP_DB missing').toLowerCase(),
+	).toContain('cloud agent')
 })
 
 test('ensureDev stops the child and surfaces output when /health never becomes ready', async () => {

--- a/tools/ensure-dev.node.test.ts
+++ b/tools/ensure-dev.node.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from 'vitest'
 import {
+	appendDevOutputChunk,
 	collectAncestorPids,
 	collectKodyDevKillPids,
 	ensureDev,
@@ -8,6 +9,7 @@ import {
 	formatMissingWranglerBindingHint,
 	isKodyDevProcess,
 	isMissingWranglerBindingOutput,
+	joinDevOutput,
 	isKodyDevSupervisor,
 	isWranglerStillStarting,
 	parseLsofListenPids,
@@ -386,6 +388,23 @@ test('ensureDev fails immediately when wrangler logs missing bindings', async ()
 	expect(
 		formatMissingWranglerBindingHint('APP_DB missing').toLowerCase(),
 	).toContain('cloud agent')
+})
+
+test('dev output matching keeps a split fatal phrase across chunk boundaries', () => {
+	const buffered: Array<string> = []
+	const state = { pending: '' }
+	appendDevOutputChunk(buffered, state, 'Invalid environment vari')
+	expect(
+		isMissingWranglerBindingOutput(joinDevOutput(buffered, state.pending)),
+	).toBe(false)
+	appendDevOutputChunk(
+		buffered,
+		state,
+		'ables: APP_DB: Missing APP_DB binding for database access\n',
+	)
+	expect(
+		isMissingWranglerBindingOutput(joinDevOutput(buffered, state.pending)),
+	).toBe(true)
 })
 
 test('ensureDev stops the child and surfaces output when /health never becomes ready', async () => {

--- a/tools/ensure-dev.node.test.ts
+++ b/tools/ensure-dev.node.test.ts
@@ -407,6 +407,24 @@ test('dev output matching keeps a split fatal phrase across chunk boundaries', (
 	).toBe(true)
 })
 
+test('dev output matching keeps a split fatal phrase when stdout and stderr interleave', () => {
+	const buffered: Array<string> = []
+	const stdout = { pending: '' }
+	const stderr = { pending: '' }
+	appendDevOutputChunk(buffered, stdout, 'Invalid environment vari')
+	appendDevOutputChunk(buffered, stderr, 'vite optimizing deps...\n')
+	appendDevOutputChunk(
+		buffered,
+		stdout,
+		'ables: APP_DB: Missing APP_DB binding for database access\n',
+	)
+	expect(
+		isMissingWranglerBindingOutput(
+			joinDevOutput(buffered, stdout.pending, stderr.pending),
+		),
+	).toBe(true)
+})
+
 test('ensureDev stops the child and surfaces output when /health never becomes ready', async () => {
 	const stopped: Array<string> = []
 	await expect(

--- a/tools/ensure-dev.ts
+++ b/tools/ensure-dev.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from 'node:child_process'
-import { existsSync, readdirSync, readFileSync } from 'node:fs'
+import { copyFileSync, existsSync, readdirSync, readFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import path from 'node:path'
 import { setTimeout as delay } from 'node:timers/promises'
@@ -266,6 +266,51 @@ export function formatAppRunning(origin: string) {
 	return `App running at ${origin}`
 }
 
+export const workerEnvRelativePath = 'packages/worker/.env'
+export const workerEnvExampleRelativePath = 'packages/worker/.env.example'
+
+export function ensureWorkerEnvFile(
+	root = process.cwd(),
+	options: {
+		copyFile?: (from: string, to: string) => void
+		exists?: (file: string) => boolean
+	} = {},
+) {
+	const exists = options.exists ?? existsSync
+	const copyFile = options.copyFile ?? copyFileSync
+	const envPath = path.join(root, workerEnvRelativePath)
+	const examplePath = path.join(root, workerEnvExampleRelativePath)
+	if (exists(envPath)) return { created: false, path: envPath }
+	if (!exists(examplePath)) {
+		throw new Error(
+			`${workerEnvRelativePath} is missing and ${workerEnvExampleRelativePath} is not present. See docs/contributing/cloud-agents.md.`,
+		)
+	}
+	copyFile(examplePath, envPath)
+	return { created: true, path: envPath }
+}
+
+export function isMissingWranglerBindingOutput(output: string) {
+	const lower = output.toLowerCase()
+	return (
+		lower.includes('invalid environment variables') ||
+		lower.includes('missing app_db binding') ||
+		lower.includes('missing bundle_artifacts_kv') ||
+		lower.includes('missing storage_runner') ||
+		lower.includes('missing package_realtime_session') ||
+		lower.includes('missing mcp_client_hub')
+	)
+}
+
+export function formatMissingWranglerBindingHint(output: string) {
+	return (
+		'Local wrangler accepted TCP but Remix has no D1/KV/DO bindings (Missing APP_DB / BUNDLE_ARTIFACTS_KV / STORAGE_RUNNER / …). ' +
+		'Copying packages/worker/.env from .env.example is not enough; those bindings come from wrangler.jsonc via the Vite Cloudflare plugin, not from .env. ' +
+		'On a Cloud Agent this fails immediately instead of waiting 180s. See docs/contributing/cloud-agents.md.' +
+		(output.trim() ? `\n${output.trim()}` : '')
+	)
+}
+
 export async function waitForHealthyOrigin(input: {
 	ports: ReadonlyArray<number>
 	probeHealth: (origin: string) => Promise<boolean>
@@ -274,18 +319,24 @@ export async function waitForHealthyOrigin(input: {
 	now?: () => number
 	sleep?: (ms: number) => Promise<void>
 	isCancelled?: () => boolean
+	getOutput?: () => string
+	fatalOutput?: (output: string) => string | null
 }) {
 	const now = input.now ?? Date.now
 	const sleep = input.sleep ?? delay
 	const deadline = now() + input.timeoutMs
 	while (now() < deadline) {
 		if (input.isCancelled?.()) return null
+		const fatal = input.fatalOutput?.(input.getOutput?.() ?? '')
+		if (fatal) throw new Error(fatal)
 		const origin = await findHealthyWorkerOrigin(input.ports, {
 			probe: input.probeHealth,
 		})
 		if (origin) return origin
 		await sleep(input.pollMs)
 	}
+	const fatal = input.fatalOutput?.(input.getOutput?.() ?? '')
+	if (fatal) throw new Error(fatal)
 	return findHealthyWorkerOrigin(input.ports, { probe: input.probeHealth })
 }
 
@@ -368,15 +419,27 @@ export async function ensureDev(deps: EnsureDevDeps): Promise<EnsureDevResult> {
 
 	const replacedPids = await replaceStaleKodyListeners(deps)
 	const started = deps.startDev()
-	const origin = await waitForHealthyOrigin({
-		ports: deps.ports,
-		probeHealth: deps.probeHealth,
-		timeoutMs: deps.readyTimeoutMs,
-		pollMs: deps.readyPollMs,
-		now: deps.now,
-		sleep: deps.sleep,
-		isCancelled: started.hasExited,
-	})
+	const fatalBindingOutput = (output: string) =>
+		isMissingWranglerBindingOutput(output)
+			? formatMissingWranglerBindingHint(output)
+			: null
+	let origin: string | null
+	try {
+		origin = await waitForHealthyOrigin({
+			ports: deps.ports,
+			probeHealth: deps.probeHealth,
+			timeoutMs: deps.readyTimeoutMs,
+			pollMs: deps.readyPollMs,
+			now: deps.now,
+			sleep: deps.sleep,
+			isCancelled: started.hasExited,
+			getOutput: started.lastOutput,
+			fatalOutput: fatalBindingOutput,
+		})
+	} catch (error) {
+		await started.stop()
+		throw error
+	}
 	if (!origin) {
 		const output = started.lastOutput?.()?.trim() ?? ''
 		const stillStarting = Boolean(
@@ -443,6 +506,12 @@ function defaultKillProcess(pid: number, signal: NodeJS.Signals) {
 }
 
 function createDefaultStartDev(env: NodeJS.ProcessEnv): StartedDevHandle {
+	const envFile = ensureWorkerEnvFile()
+	if (envFile.created) {
+		console.log(
+			`Created ${workerEnvRelativePath} from ${workerEnvExampleRelativePath}`,
+		)
+	}
 	const child = spawnInOwnProcessGroup(resolveNpmCommand(), ['run', 'dev'], {
 		stdio: ['ignore', 'pipe', 'pipe'],
 		env,

--- a/tools/ensure-dev.ts
+++ b/tools/ensure-dev.ts
@@ -290,6 +290,30 @@ export function ensureWorkerEnvFile(
 	return { created: true, path: envPath }
 }
 
+export function appendDevOutputChunk(
+	buffered: Array<string>,
+	state: { pending: string },
+	chunk: string,
+	maxLines = 80,
+) {
+	const parts = `${state.pending}${chunk}`.split(/\r?\n/)
+	state.pending = parts.pop() ?? ''
+	for (const line of parts) {
+		if (!line) continue
+		buffered.push(line)
+		if (buffered.length > maxLines) buffered.shift()
+	}
+}
+
+export function joinDevOutput(
+	buffered: ReadonlyArray<string>,
+	pending: string,
+) {
+	if (!pending) return buffered.join('\n')
+	if (buffered.length === 0) return pending
+	return `${buffered.join('\n')}\n${pending}`
+}
+
 export function isMissingWranglerBindingOutput(output: string) {
 	const lower = output.toLowerCase()
 	return (
@@ -518,17 +542,13 @@ function createDefaultStartDev(env: NodeJS.ProcessEnv): StartedDevHandle {
 		cwd: process.cwd(),
 	})
 	const buffered: Array<string> = []
+	const outputState = { pending: '' }
 	let exited = false
-	const onLine = (chunk: Buffer | string) => {
-		const text = chunk.toString()
-		for (const line of text.split(/\r?\n/)) {
-			if (!line) continue
-			buffered.push(line)
-			if (buffered.length > 80) buffered.shift()
-		}
+	const onChunk = (chunk: Buffer | string) => {
+		appendDevOutputChunk(buffered, outputState, chunk.toString())
 	}
-	child.stdout?.on('data', onLine)
-	child.stderr?.on('data', onLine)
+	child.stdout?.on('data', onChunk)
+	child.stderr?.on('data', onChunk)
 	child.once('exit', (code, signal) => {
 		exited = true
 		if (code && code !== 0) {
@@ -545,7 +565,7 @@ function createDefaultStartDev(env: NodeJS.ProcessEnv): StartedDevHandle {
 	}
 	return {
 		hasExited: () => exited || child.exitCode !== null,
-		lastOutput: () => buffered.join('\n'),
+		lastOutput: () => joinDevOutput(buffered, outputState.pending),
 		unref() {
 			detachPipes()
 			child.unref()

--- a/tools/ensure-dev.ts
+++ b/tools/ensure-dev.ts
@@ -307,11 +307,12 @@ export function appendDevOutputChunk(
 
 export function joinDevOutput(
 	buffered: ReadonlyArray<string>,
-	pending: string,
+	...pendings: Array<string>
 ) {
-	if (!pending) return buffered.join('\n')
-	if (buffered.length === 0) return pending
-	return `${buffered.join('\n')}\n${pending}`
+	const tails = pendings.filter((part) => part.length > 0)
+	if (tails.length === 0) return buffered.join('\n')
+	if (buffered.length === 0) return tails.join('\n')
+	return `${buffered.join('\n')}\n${tails.join('\n')}`
 }
 
 export function isMissingWranglerBindingOutput(output: string) {
@@ -542,18 +543,20 @@ function createDefaultStartDev(env: NodeJS.ProcessEnv): StartedDevHandle {
 		cwd: process.cwd(),
 	})
 	const buffered: Array<string> = []
-	const outputState = { pending: '' }
+	const stdoutState = { pending: '' }
+	const stderrState = { pending: '' }
 	let exited = false
-	const onChunk = (chunk: Buffer | string) => {
-		appendDevOutputChunk(buffered, outputState, chunk.toString())
-	}
-	child.stdout?.on('data', onChunk)
-	child.stderr?.on('data', onChunk)
+	child.stdout?.on('data', (chunk: Buffer | string) => {
+		appendDevOutputChunk(buffered, stdoutState, chunk.toString())
+	})
+	child.stderr?.on('data', (chunk: Buffer | string) => {
+		appendDevOutputChunk(buffered, stderrState, chunk.toString())
+	})
 	child.once('exit', (code, signal) => {
 		exited = true
 		if (code && code !== 0) {
 			console.error(
-				`npm run dev exited (${signal ?? `code ${code}`}). Last output:\n${buffered.join('\n')}`,
+				`npm run dev exited (${signal ?? `code ${code}`}). Last output:\n${joinDevOutput(buffered, stdoutState.pending, stderrState.pending)}`,
 			)
 		}
 	})
@@ -565,7 +568,8 @@ function createDefaultStartDev(env: NodeJS.ProcessEnv): StartedDevHandle {
 	}
 	return {
 		hasExited: () => exited || child.exitCode !== null,
-		lastOutput: () => joinDevOutput(buffered, outputState.pending),
+		lastOutput: () =>
+			joinDevOutput(buffered, stdoutState.pending, stderrState.pending),
 		unref() {
 			detachPipes()
 			child.unref()

--- a/tools/preview-manual-test.node.test.ts
+++ b/tools/preview-manual-test.node.test.ts
@@ -151,6 +151,20 @@ test('preview manual test parses flags, PR comments, worker URLs, and health pay
 		commitSha: 'abc',
 		detail: 'ok, commitSha abc',
 	})
+	expect(
+		evaluateAppHealth(
+			{
+				ok: true,
+				commitSha: '91bab582b2040e7b55a84f2415be82c1684ad565',
+			},
+			'91bab582',
+		),
+	).toEqual({
+		ok: true,
+		commitSha: '91bab582b2040e7b55a84f2415be82c1684ad565',
+		detail:
+			'ok, commitSha 91bab582b2040e7b55a84f2415be82c1684ad565 (matches 91bab582)',
+	})
 	expect(evaluateAppHealth({ ok: true, commitSha: 'old' }, 'new').ok).toBe(
 		false,
 	)

--- a/tools/preview-manual-test.ts
+++ b/tools/preview-manual-test.ts
@@ -460,6 +460,19 @@ export function flattenGhJsonPages(parsed: unknown): Array<unknown> {
 	return parsed
 }
 
+export const minUniqueShaPrefixLength = 7
+
+export function shaEqualsOrUniquePrefix(actual: string, expected: string) {
+	if (actual === expected) return true
+	const actualLower = actual.toLowerCase()
+	const expectedLower = expected.toLowerCase()
+	if (actualLower === expectedLower) return true
+	return (
+		expectedLower.length >= minUniqueShaPrefixLength &&
+		actualLower.startsWith(expectedLower)
+	)
+}
+
 export function commitShaMatchesExpected(
 	commitSha: string | null,
 	expectedSha: string | null,
@@ -467,7 +480,11 @@ export function commitShaMatchesExpected(
 ) {
 	if (!expectedSha) return true
 	if (!commitSha) return false
-	return commitSha === expectedSha || commitParents.includes(expectedSha)
+	if (shaEqualsOrUniquePrefix(commitSha, expectedSha)) return true
+	return commitParents.some(
+		(parent) =>
+			parent === expectedSha || shaEqualsOrUniquePrefix(parent, expectedSha),
+	)
 }
 
 export function evaluateAppHealth(
@@ -607,9 +624,19 @@ function healthMatchDetail(
 	if (
 		expectedSha &&
 		commitSha !== expectedSha &&
-		commitParents.includes(expectedSha)
+		commitParents.some(
+			(parent) =>
+				parent === expectedSha || shaEqualsOrUniquePrefix(parent, expectedSha),
+		)
 	) {
 		return `ok, commitSha ${commitSha} (merge of ${expectedSha})`
+	}
+	if (
+		expectedSha &&
+		commitSha !== expectedSha &&
+		shaEqualsOrUniquePrefix(commitSha, expectedSha)
+	) {
+		return `ok, commitSha ${commitSha} (matches ${expectedSha})`
 	}
 	return `ok, commitSha ${commitSha}`
 }

--- a/tools/upsert-recap-block.node.test.ts
+++ b/tools/upsert-recap-block.node.test.ts
@@ -1,0 +1,33 @@
+import { expect, test } from 'vitest'
+import {
+	isGhPrEditForbidden,
+	mergeRecapBody,
+} from '../.agents/skills/visual-recap/scripts/upsert-recap-block.mjs'
+
+const startMarker = '<!-- system-recap:start -->'
+const endMarker = '<!-- system-recap:end -->'
+
+test('mergeRecapBody replaces an existing recap and appends when missing', () => {
+	const block = `${startMarker}\nnew\n${endMarker}`
+	const replaced = mergeRecapBody(
+		`intro\n${startMarker}\nold\n${endMarker}\nfooter\n`,
+		block,
+	)
+	expect(replaced.hasExistingBlock).toBe(true)
+	expect(replaced.nextBody).toBe(`intro\n${block}\nfooter\n`)
+
+	const appended = mergeRecapBody('intro\n', block)
+	expect(appended.hasExistingBlock).toBe(false)
+	expect(appended.nextBody).toBe(`intro\n\n${block}\n`)
+})
+
+test('isGhPrEditForbidden recognizes the Cloud Agent GraphQL denial', () => {
+	expect(
+		isGhPrEditForbidden(
+			new Error(
+				'GraphQL: Resource not accessible by integration (updatePullRequest)',
+			),
+		),
+	).toBe(true)
+	expect(isGhPrEditForbidden(new Error('HTTP 401 Bad credentials'))).toBe(false)
+})

--- a/tools/wrangler-deploy-retry.node.test.ts
+++ b/tools/wrangler-deploy-retry.node.test.ts
@@ -1,8 +1,10 @@
+import { Writable } from 'node:stream'
 import { expect, test } from 'vitest'
 import {
 	isRetryableWorkersDevSubdomainRace,
 	isRetryableWranglerDeployFailure,
 	runWranglerDeployWithRetry,
+	spawnWranglerDeploy,
 } from './wrangler-deploy-retry.ts'
 
 test('isRetryableWorkersDevSubdomainRace requires a successful upload then 10007', () => {
@@ -74,4 +76,25 @@ test('runWranglerDeployWithRetry does not retry a genuine missing worker', async
 	})
 	expect(result.status).toBe(1)
 	expect(attempts).toEqual([1])
+})
+
+test('spawnWranglerDeploy captures more than spawnSync maxBuffer without killing', async () => {
+	const oversizedBytes = 2 * 1024 * 1024
+	const sink = new Writable({
+		write(_chunk, _encoding, callback) {
+			callback()
+		},
+	})
+	const result = await spawnWranglerDeploy(
+		process.execPath,
+		[
+			'-e',
+			`process.stdout.write('x'.repeat(${String(oversizedBytes)})); process.stderr.write('Uploaded kody\\n')`,
+		],
+		undefined,
+		{ stdout: sink, stderr: sink },
+	)
+	expect(result.status).toBe(0)
+	expect(result.output.includes('Uploaded kody')).toBe(true)
+	expect(result.output.length).toBeGreaterThan(1024 * 1024)
 })

--- a/tools/wrangler-deploy-retry.node.test.ts
+++ b/tools/wrangler-deploy-retry.node.test.ts
@@ -1,0 +1,77 @@
+import { expect, test } from 'vitest'
+import {
+	isRetryableWorkersDevSubdomainRace,
+	isRetryableWranglerDeployFailure,
+	runWranglerDeployWithRetry,
+} from './wrangler-deploy-retry.ts'
+
+test('isRetryableWorkersDevSubdomainRace requires a successful upload then 10007', () => {
+	expect(
+		isRetryableWorkersDevSubdomainRace(
+			'Uploaded kody-pr-2170-highlight\nThis Worker does not exist on your account [code: 10007]',
+		),
+	).toBe(true)
+	expect(
+		isRetryableWorkersDevSubdomainRace(
+			'This Worker does not exist on your account [code: 10007]',
+		),
+	).toBe(false)
+	expect(isRetryableWorkersDevSubdomainRace('Uploaded kody-pr-1-jobs')).toBe(
+		false,
+	)
+	expect(
+		isRetryableWranglerDeployFailure(
+			'Received a malformed response from the API\nupstream connect error or disconnect/reset before headers',
+		),
+	).toBe(true)
+})
+
+test('runWranglerDeployWithRetry retries a 10007 subdomain race then succeeds', async () => {
+	const attempts: Array<number> = []
+	const result = await runWranglerDeployWithRetry({
+		command: 'wrangler',
+		args: ['deploy'],
+		maxAttempts: 3,
+		sleep: async () => {},
+		log: () => {},
+		run: () => {
+			attempts.push(attempts.length + 1)
+			if (attempts.length === 1) {
+				return {
+					status: 1,
+					output:
+						'Uploaded kody-pr-2163-jobs\nThis Worker does not exist on your account [code: 10007]\n',
+					errorMessage: '',
+				}
+			}
+			return {
+				status: 0,
+				output: 'Uploaded kody-pr-2163-jobs\n',
+				errorMessage: '',
+			}
+		},
+	})
+	expect(result.status).toBe(0)
+	expect(attempts).toEqual([1, 2])
+})
+
+test('runWranglerDeployWithRetry does not retry a genuine missing worker', async () => {
+	const attempts: Array<number> = []
+	const result = await runWranglerDeployWithRetry({
+		command: 'wrangler',
+		args: ['deploy'],
+		maxAttempts: 3,
+		sleep: async () => {},
+		log: () => {},
+		run: () => {
+			attempts.push(attempts.length + 1)
+			return {
+				status: 1,
+				output: 'This Worker does not exist on your account [code: 10007]\n',
+				errorMessage: '',
+			}
+		},
+	})
+	expect(result.status).toBe(1)
+	expect(attempts).toEqual([1])
+})

--- a/tools/wrangler-deploy-retry.ts
+++ b/tools/wrangler-deploy-retry.ts
@@ -1,4 +1,4 @@
-import { spawnSync } from 'node:child_process'
+import { spawn } from 'node:child_process'
 import { isRetryableCloudflareFailure } from './ci/resource-utils.ts'
 
 export const wranglerDeployRetryMaxAttempts = 4
@@ -25,17 +25,76 @@ export type WranglerDeployRunResult = {
 	errorMessage: string
 }
 
+export type WranglerDeployRun = (
+	command: string,
+	args: ReadonlyArray<string>,
+	env?: NodeJS.ProcessEnv,
+) => WranglerDeployRunResult | Promise<WranglerDeployRunResult>
+
+/**
+ * Stream stdout/stderr to the parent (no spawnSync maxBuffer) and wait for
+ * `close` so the last pipe chunks are captured before retry classification.
+ */
+export function spawnWranglerDeploy(
+	command: string,
+	args: ReadonlyArray<string>,
+	env?: NodeJS.ProcessEnv,
+	forwardTo: {
+		stdout?: NodeJS.WritableStream
+		stderr?: NodeJS.WritableStream
+	} = {},
+): Promise<WranglerDeployRunResult> {
+	const stdout = forwardTo.stdout ?? process.stdout
+	const stderr = forwardTo.stderr ?? process.stderr
+	return new Promise((resolve) => {
+		const chunks: Array<string> = []
+		const child = spawn(command, [...args], {
+			env,
+			stdio: ['inherit', 'pipe', 'pipe'],
+		})
+		function forward(
+			stream: NodeJS.ReadableStream | null,
+			dest: NodeJS.WritableStream,
+		) {
+			if (!stream) return
+			stream.on('data', (chunk: Buffer | string) => {
+				const text = typeof chunk === 'string' ? chunk : chunk.toString('utf8')
+				chunks.push(text)
+				dest.write(chunk)
+			})
+		}
+		forward(child.stdout, stdout)
+		forward(child.stderr, stderr)
+		let settled = false
+		function finish(result: WranglerDeployRunResult) {
+			if (settled) return
+			settled = true
+			resolve(result)
+		}
+		child.once('error', (error) => {
+			finish({
+				status: 1,
+				output: chunks.join(''),
+				errorMessage: error.message,
+			})
+		})
+		child.once('close', (code) => {
+			finish({
+				status: code ?? 1,
+				output: chunks.join(''),
+				errorMessage: '',
+			})
+		})
+	})
+}
+
 export async function runWranglerDeployWithRetry(input: {
 	command: string
 	args: ReadonlyArray<string>
 	env?: NodeJS.ProcessEnv
 	maxAttempts?: number
 	sleep?: (ms: number) => Promise<void>
-	run?: (
-		command: string,
-		args: ReadonlyArray<string>,
-		env?: NodeJS.ProcessEnv,
-	) => WranglerDeployRunResult
+	run?: WranglerDeployRun
 	log?: (line: string) => void
 }) {
 	const maxAttempts = input.maxAttempts ?? wranglerDeployRetryMaxAttempts
@@ -45,28 +104,14 @@ export async function runWranglerDeployWithRetry(input: {
 			new Promise((resolve) => {
 				setTimeout(resolve, ms)
 			}))
-	const run =
-		input.run ??
-		((command, args, env) => {
-			const result = spawnSync(command, [...args], {
-				encoding: 'utf8',
-				env,
-			})
-			return {
-				status: result.status ?? 1,
-				output: `${result.stdout ?? ''}${result.stderr ?? ''}`,
-				errorMessage: result.error?.message ?? '',
-			}
-		})
+	const run = input.run ?? spawnWranglerDeploy
 	const log =
 		input.log ??
 		((line) => {
 			console.error(line)
 		})
 
-	const echoOutput = input.run === undefined
-	let last = run(input.command, input.args, input.env)
-	if (echoOutput && last.output) process.stdout.write(last.output)
+	let last = await run(input.command, input.args, input.env)
 	for (let attempt = 1; attempt < maxAttempts; attempt += 1) {
 		if (last.status === 0) return last
 		const combined = `${last.output} ${last.errorMessage}`
@@ -75,8 +120,7 @@ export async function runWranglerDeployWithRetry(input: {
 			`Retrying wrangler deploy (attempt ${attempt + 1}/${maxAttempts}) after a transient Cloudflare deploy race.`,
 		)
 		await wait(wranglerDeployRetryBaseDelayMs * 2 ** (attempt - 1))
-		last = run(input.command, input.args, input.env)
-		if (echoOutput && last.output) process.stdout.write(last.output)
+		last = await run(input.command, input.args, input.env)
 	}
 	return last
 }

--- a/tools/wrangler-deploy-retry.ts
+++ b/tools/wrangler-deploy-retry.ts
@@ -1,0 +1,82 @@
+import { spawnSync } from 'node:child_process'
+import { isRetryableCloudflareFailure } from './ci/resource-utils.ts'
+
+export const wranglerDeployRetryMaxAttempts = 4
+export const wranglerDeployRetryBaseDelayMs = 1_000
+
+export function isRetryableWorkersDevSubdomainRace(output: string) {
+	const uploaded = /uploaded\s+\S+/i.test(output)
+	const missingAfterUpload =
+		/\b10007\b/.test(output) &&
+		/this worker does not exist on your account/i.test(output)
+	return uploaded && missingAfterUpload
+}
+
+export function isRetryableWranglerDeployFailure(output: string) {
+	return (
+		isRetryableWorkersDevSubdomainRace(output) ||
+		isRetryableCloudflareFailure(output)
+	)
+}
+
+export type WranglerDeployRunResult = {
+	status: number
+	output: string
+	errorMessage: string
+}
+
+export async function runWranglerDeployWithRetry(input: {
+	command: string
+	args: ReadonlyArray<string>
+	env?: NodeJS.ProcessEnv
+	maxAttempts?: number
+	sleep?: (ms: number) => Promise<void>
+	run?: (
+		command: string,
+		args: ReadonlyArray<string>,
+		env?: NodeJS.ProcessEnv,
+	) => WranglerDeployRunResult
+	log?: (line: string) => void
+}) {
+	const maxAttempts = input.maxAttempts ?? wranglerDeployRetryMaxAttempts
+	const wait =
+		input.sleep ??
+		((ms: number) =>
+			new Promise((resolve) => {
+				setTimeout(resolve, ms)
+			}))
+	const run =
+		input.run ??
+		((command, args, env) => {
+			const result = spawnSync(command, [...args], {
+				encoding: 'utf8',
+				env,
+			})
+			return {
+				status: result.status ?? 1,
+				output: `${result.stdout ?? ''}${result.stderr ?? ''}`,
+				errorMessage: result.error?.message ?? '',
+			}
+		})
+	const log =
+		input.log ??
+		((line) => {
+			console.error(line)
+		})
+
+	const echoOutput = input.run === undefined
+	let last = run(input.command, input.args, input.env)
+	if (echoOutput && last.output) process.stdout.write(last.output)
+	for (let attempt = 1; attempt < maxAttempts; attempt += 1) {
+		if (last.status === 0) return last
+		const combined = `${last.output} ${last.errorMessage}`
+		if (!isRetryableWranglerDeployFailure(combined)) return last
+		log(
+			`Retrying wrangler deploy (attempt ${attempt + 1}/${maxAttempts}) after a transient Cloudflare deploy race.`,
+		)
+		await wait(wranglerDeployRetryBaseDelayMs * 2 ** (attempt - 1))
+		last = run(input.command, input.args, input.env)
+		if (echoOutput && last.output) process.stdout.write(last.output)
+	}
+	return last
+}

--- a/wrangler-env.ts
+++ b/wrangler-env.ts
@@ -22,6 +22,7 @@ import {
 import { writeLocalRuntimeDevConfig } from './tools/local-runtime-dev-config.ts'
 import { writeLocalPlatformDevConfig } from './tools/local-platform-dev-config.ts'
 import { patchWranglerProxyWorkerErrors } from './tools/patch-wrangler-proxy-worker-errors.ts'
+import { runWranglerDeployWithRetry } from './tools/wrangler-deploy-retry.ts'
 
 const envName = process.env.CLOUDFLARE_ENV ?? 'production'
 const portWaitTimeoutMs = 5000
@@ -268,6 +269,15 @@ const wranglerCommand =
 // workers-sdk#14926: one ProxyWorker fetch failure must not exit `wrangler
 // dev`. Apply the pending upstream exemption before every local launch.
 patchWranglerProxyWorkerErrors()
+
+if (args[0] === 'deploy') {
+	const deployResult = await runWranglerDeployWithRetry({
+		command: wranglerCommand,
+		args: commandArgs,
+		env: processEnv,
+	})
+	process.exit(deployResult.status)
+}
 
 const proc = spawnChildProcess(wranglerCommand, commandArgs, {
 	stdio: ['inherit', 'inherit', 'inherit'],

--- a/wrangler-env.ts
+++ b/wrangler-env.ts
@@ -276,59 +276,63 @@ if (args[0] === 'deploy') {
 		args: commandArgs,
 		env: processEnv,
 	})
-	process.exit(deployResult.status)
+	process.exitCode = deployResult.status
+} else {
+	await runAttachedWranglerProcess()
 }
 
-const proc = spawnChildProcess(wranglerCommand, commandArgs, {
-	stdio: ['inherit', 'inherit', 'inherit'],
-	env: processEnv,
-})
-const procExited = createExitPromise(proc)
+async function runAttachedWranglerProcess() {
+	const proc = spawnChildProcess(wranglerCommand, commandArgs, {
+		stdio: ['inherit', 'inherit', 'inherit'],
+		env: processEnv,
+	})
+	const procExited = createExitPromise(proc)
 
-let isShuttingDown = false
+	let isShuttingDown = false
 
-process.once('exit', () => {
-	signalChildProcessTree(proc, 'SIGTERM')
-})
+	process.once('exit', () => {
+		signalChildProcessTree(proc, 'SIGTERM')
+	})
 
-function handleSignal(signal: NodeJS.Signals) {
-	if (isShuttingDown) return
-	isShuttingDown = true
-	void (async () => {
-		await stopChildProcessTree(proc, {
-			sigintTimeoutMs: signal === 'SIGINT' ? 5000 : 0,
-			sigtermTimeoutMs: 5000,
-			sigkillTimeoutMs: 1000,
-		})
-		// A signal-initiated shutdown is a normal stop (Ctrl+C, supervisor
-		// stop), not a failure; exiting 1 here fails CI steps that stop the
-		// dev server deliberately.
-		process.exit(0)
-	})()
-}
-
-process.on('SIGINT', () => handleSignal('SIGINT'))
-process.on('SIGTERM', () => handleSignal('SIGTERM'))
-
-let exitCode: number | null
-try {
-	exitCode = await procExited
-} catch (error) {
-	console.error(error instanceof Error ? error.message : String(error))
-	process.exit(1)
-}
-if (isDevCommand && resolvedPort) {
-	const didFreePort = await waitForPortFree(
-		Number.parseInt(resolvedPort, 10),
-		portWaitTimeoutMs,
-	)
-	if (!didFreePort) {
-		console.warn(
-			`Timed out waiting for port ${resolvedPort} to free up before exit.`,
-		)
+	function handleSignal(signal: NodeJS.Signals) {
+		if (isShuttingDown) return
+		isShuttingDown = true
+		void (async () => {
+			await stopChildProcessTree(proc, {
+				sigintTimeoutMs: signal === 'SIGINT' ? 5000 : 0,
+				sigtermTimeoutMs: 5000,
+				sigkillTimeoutMs: 1000,
+			})
+			// A signal-initiated shutdown is a normal stop (Ctrl+C, supervisor
+			// stop), not a failure; exiting 1 here fails CI steps that stop the
+			// dev server deliberately.
+			process.exit(0)
+		})()
 	}
+
+	process.on('SIGINT', () => handleSignal('SIGINT'))
+	process.on('SIGTERM', () => handleSignal('SIGTERM'))
+
+	let exitCode: number | null
+	try {
+		exitCode = await procExited
+	} catch (error) {
+		console.error(error instanceof Error ? error.message : String(error))
+		process.exit(1)
+	}
+	if (isDevCommand && resolvedPort) {
+		const didFreePort = await waitForPortFree(
+			Number.parseInt(resolvedPort, 10),
+			portWaitTimeoutMs,
+		)
+		if (!didFreePort) {
+			console.warn(
+				`Timed out waiting for port ${resolvedPort} to free up before exit.`,
+			)
+		}
+	}
+	process.exitCode = exitCode ?? 1
 }
-process.exit(exitCode)
 
 function createExitPromise(proc: ChildProcess) {
 	return new Promise<number | null>((resolve, reject) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Clear the 2026-09-09 friction-log sweep: six open `friction` issues that were costing Cloud Agents and ship-pr loops.

## Why

Eligible issues #2171–#2176 were still open on main. #2174 is the same Cloud Agent `dev:ensure` papercut as #2171.

## Summary

- `health --sha` accepts a unique short SHA (7+) and a later descendant HEAD (`git merge-base --is-ancestor`).
- Blog catalog phrase pins use `normalizeMarkdownPhraseSource` so oxfmt-wrapped blockquotes still match.
- `upsert-recap-block.mjs` prints the merged PR body when `gh pr edit` is forbidden so Cloud Agents can apply it with ManagePullRequest.
- `dev:ensure` copies `packages/worker/.env.example` when `.env` is missing and fails immediately on missing wrangler bindings instead of waiting 180s.
- Wrangler deploy retries a post-upload workers.dev `10007` race (and existing malformed/503 flakes). A missing worker without an upload is not retried.

## Testing

- `npx vitest run --project node-unit` on the touched suites (51 tests).
- Push hook: `test:node` 3012 passed, `test:workers` 341 passed.
- `npm run typecheck`, knip, mermaid, and docs temporal checks on the edited docs.

## System changes

Contributor tooling, docs, tests, and preview-deploy retry only. No product primitives.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `e3ec12d2` · **Head:** `f605b156`

**Classification:** composes — no primitives added or changed; this PR wires contributor tools and preview deploy retry around existing wrangler and `/health` checks.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ------ | ------ |
| _(none matched)_ | — | unmatched paths are `tools/`, `.agents/`, docs, and preview workflow |

### Change flow

Daily friction issues now fail fast or retry at the contributor-tool boundary instead of hanging or false-failing.

```mermaid
sequenceDiagram
	actor Agent
	participant ensureDev as ensure-dev
	participant wranglerDeploy as wrangler-deploy-retry
	participant controlKody as control-kody
	participant health as origin /health
	Agent->>ensureDev: npm run dev:ensure
	ensureDev->>ensureDev: copy .env.example if missing
	ensureDev-->>Agent: fail immediately on Missing APP_DB
	Agent->>wranglerDeploy: preview wrangler deploy
	wranglerDeploy-->>Agent: retry 10007 after Uploaded
	Agent->>controlKody: health --sha short or ancestor
	controlKody->>health: GET /health
	health-->>controlKody: commitSha
	controlKody-->>Agent: ok on prefix or descendant
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-10cd3085-c2de-4a4d-b28d-e168a5502676?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-10cd3085-c2de-4a4d-b28d-e168a5502676&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Deployment commands now retry certain transient Cloudflare and Workers.dev failures while preserving command output.
  - Health checks and preview validation accept exact SHAs, unique short SHA prefixes, and deployed descendant commits.
  - Local development setup creates the worker environment file automatically and reports missing bindings immediately with actionable guidance.
  - Visual recap workflows provide a validated merged PR body when direct PR editing is unavailable.

- **Documentation**
  - Updated contributor guidance for deployment health checks, local setup, visual recaps, and Markdown phrase testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->