### PR TITLE
Add Gabriel Alegría as an early Kody user testimonial

### DIFF
--- a/packages/worker/client/markdown-view.node.test.ts
+++ b/packages/worker/client/markdown-view.node.test.ts
@@ -210,9 +210,15 @@ test('first-party headingIds emit unique kebab-case heading ids', async () => {
 	const html = await renderToString(
 		jsx('div', {
 			children: renderMarkdownNodes(
-				['## Josh Tomaino', '', '## Josh Tomaino', '', '## Jett Hays'].join(
-					'\n',
-				),
+				[
+					'## Josh Tomaino',
+					'',
+					'## Josh Tomaino',
+					'',
+					'## Jett Hays',
+					'',
+					'## Gabriel Alegría',
+				].join('\n'),
 				{ headingOffset: 0, headingIds: true },
 			),
 		}),
@@ -220,6 +226,7 @@ test('first-party headingIds emit unique kebab-case heading ids', async () => {
 	expect(html).toContain('<h2 id="josh-tomaino">Josh Tomaino</h2>')
 	expect(html).toContain('<h2 id="josh-tomaino-2">Josh Tomaino</h2>')
 	expect(html).toContain('<h2 id="jett-hays">Jett Hays</h2>')
+	expect(html).toContain('<h2 id="gabriel-alegria">Gabriel Alegría</h2>')
 })
 
 test('getSafeMarkdownLinkHref allowlists protocols and blocks user-scope paths', () => {

--- a/packages/worker/client/routes/landing-testimonials-carousel.tsx
+++ b/packages/worker/client/routes/landing-testimonials-carousel.tsx
@@ -584,43 +584,56 @@ function renderChevron(direction: 'prev' | 'next') {
 	)
 }
 
-function renderTestimonialCard(item: LandingTestimonial) {
+function renderTestimonialIdentity(item: LandingTestimonial) {
 	const attribution = testimonialAttribution(item)
+	return (
+		<>
+			{item.photo ? (
+				<img
+					src={item.photo}
+					alt=""
+					width={56}
+					height={56}
+					class="landing-testimonial-photo"
+					decoding="async"
+					loading="lazy"
+				/>
+			) : (
+				<span class="landing-testimonial-initials" aria-hidden="true">
+					{testimonialInitials(item.name)}
+				</span>
+			)}
+			<span class="landing-testimonial-meta">
+				<span class="landing-testimonial-name">{item.name}</span>
+				{attribution ? (
+					<span class="landing-testimonial-title">{attribution}</span>
+				) : null}
+			</span>
+		</>
+	)
+}
+
+function renderTestimonialCard(item: LandingTestimonial) {
 	const storyHref = testimonialStoryHref(item)
+	const identity = renderTestimonialIdentity(item)
 	return (
 		<article key={item.name} class="landing-testimonial-card">
 			<blockquote class="landing-testimonial-quote">
 				<p>{item.quote}</p>
 			</blockquote>
 			<footer class="landing-testimonial-person">
-				<a
-					href={item.href}
-					class="landing-testimonial-link"
-					target="_blank"
-					rel="noopener noreferrer"
-				>
-					{item.photo ? (
-						<img
-							src={item.photo}
-							alt=""
-							width={56}
-							height={56}
-							class="landing-testimonial-photo"
-							decoding="async"
-							loading="lazy"
-						/>
-					) : (
-						<span class="landing-testimonial-initials" aria-hidden="true">
-							{testimonialInitials(item.name)}
-						</span>
-					)}
-					<span class="landing-testimonial-meta">
-						<span class="landing-testimonial-name">{item.name}</span>
-						{attribution ? (
-							<span class="landing-testimonial-title">{attribution}</span>
-						) : null}
-					</span>
-				</a>
+				{item.href ? (
+					<a
+						href={item.href}
+						class="landing-testimonial-identity landing-testimonial-link"
+						target="_blank"
+						rel="noopener noreferrer"
+					>
+						{identity}
+					</a>
+				) : (
+					<div class="landing-testimonial-identity">{identity}</div>
+				)}
 				{storyHref ? (
 					<a href={storyHref} class="landing-testimonial-story">
 						Read the full story

--- a/packages/worker/public/styles.css
+++ b/packages/worker/public/styles.css
@@ -1671,14 +1671,17 @@ html.is-settled {
 	margin: 1.35rem 0 0;
 }
 
-.landing-testimonial-link {
+.landing-testimonial-identity {
 	display: inline-flex;
 	align-items: center;
 	gap: 0.85rem;
 	min-width: 0;
 	color: inherit;
-	text-decoration: none;
 	border-radius: var(--radius-md);
+}
+
+.landing-testimonial-link {
+	text-decoration: none;
 }
 
 .landing-testimonial-link:hover .landing-testimonial-name {

--- a/packages/worker/src/app/handlers/landing-testimonials-ssr.node.test.ts
+++ b/packages/worker/src/app/handlers/landing-testimonials-ssr.node.test.ts
@@ -100,7 +100,7 @@ test('early-users blog post SSR renders approved vignettes and heading anchors',
 	expect(html).toContain('id="gabriel-alegria"')
 	expect(html).toContain('Gabriel Alegría')
 	expect(html).toContain('Software Engineer, IB.')
-	expect(html).toContain(
+	expect(html.replace(/\s+/g, ' ')).toContain(
 		'a package that hits Railway and posts specific output to Discord',
 	)
 	expect(getReadNextBlogPost(landingTestimonialsStorySlug)).not.toBeNull()

--- a/packages/worker/src/app/handlers/landing-testimonials-ssr.node.test.ts
+++ b/packages/worker/src/app/handlers/landing-testimonials-ssr.node.test.ts
@@ -67,9 +67,17 @@ test('homepage carousel SSR keeps short quotes and story links only for vignette
 	})
 	expect(response.status).toBe(200)
 	const html = await response.text()
-	expect(html.match(/class="landing-testimonial-story"/g)).toHaveLength(2)
+	expect(html.match(/class="landing-testimonial-story"/g)).toHaveLength(3)
 	expect(html).toContain('href="/blog/early-kody-users#josh-tomaino"')
 	expect(html).toContain('href="/blog/early-kody-users#jett-hays"')
+	expect(html).toContain('href="/blog/early-kody-users#gabriel-alegria"')
+	expect(html).toContain('Gabriel Alegría')
+	expect(html).toContain(
+		'Railway health checks land in Discord, a personal task list replaced the Notion notes I always lost',
+	)
+	expect(html).toMatch(
+		/<div class="landing-testimonial-identity">[\s\S]*?Gabriel Alegría/,
+	)
 })
 
 test('early-users blog post SSR renders approved vignettes and heading anchors', async () => {
@@ -89,5 +97,11 @@ test('early-users blog post SSR renders approved vignettes and heading anchors',
 
 	expect(html).toContain('id="josh-tomaino"')
 	expect(html).toContain('id="jett-hays"')
+	expect(html).toContain('id="gabriel-alegria"')
+	expect(html).toContain('Gabriel Alegría')
+	expect(html).toContain('Software Engineer, IB.')
+	expect(html).toContain(
+		'a package that hits Railway and posts specific output to Discord',
+	)
 	expect(getReadNextBlogPost(landingTestimonialsStorySlug)).not.toBeNull()
 })

--- a/packages/worker/src/blog/catalog.node.test.ts
+++ b/packages/worker/src/blog/catalog.node.test.ts
@@ -191,6 +191,9 @@ test('blog catalog enumerates posts with required fields and slug lookup', () =>
 	)
 	expect(earlyUsersBody).toContain('## Josh Tomaino')
 	expect(earlyUsersBody).toContain('## Jett Hays')
+	expect(earlyUsersBody).toContain('## Gabriel Alegría')
+	expect(earlyUsersBody).toContain('leaving Linear behind for small projects')
+	expect(earlyUsersBody).toContain('the way I always did with Notion')
 
 	const comparison = getBlogPost('kody-vs-executor')
 	expect(comparison?.title).toBe('Kody vs Executor?')

--- a/packages/worker/src/blog/posts/early-kody-users.md
+++ b/packages/worker/src/blog/posts/early-kody-users.md
@@ -35,3 +35,16 @@ Head of Software, Sentala.
 > We operate in contested environments where a downed service could mean life or
 > death for some of the world's most endangered species. Kody helps us keep that
 > critical infrastructure running.
+
+## Gabriel Alegría
+
+Software Engineer, IB.
+
+> I started with jobs for my business health checks: a package that hits Railway
+> and posts specific output to Discord on a private server. Then the agent
+> suggested a task-list package tailored to me, and I built it. I am even
+> thinking about leaving Linear behind for small projects.
+>
+> I have only scratched the surface, and Kody already changed how I work.
+> Everything I need is condensed in one place. I can store wacky ideas and not
+> lose them the way I always did with Notion.

--- a/packages/worker/universal/landing-testimonials.node.test.ts
+++ b/packages/worker/universal/landing-testimonials.node.test.ts
@@ -52,10 +52,17 @@ test('shuffleTestimonials can grow to six entries and randomizes with the provid
 test('testimonialInitials falls back to two letters from the public name', () => {
 	expect(testimonialInitials('Maciek Sitkowski')).toBe('MS')
 	expect(testimonialInitials('Justin Elias')).toBe('JE')
+	expect(testimonialInitials('Gabriel Alegría')).toBe('GA')
 	expect(testimonialInitials('Ada')).toBe('A')
 })
 
 test('testimonialAttribution joins verified role and employer and omits blanks', () => {
+	expect(
+		testimonialAttribution({
+			title: 'Software Engineer',
+			company: 'IB',
+		}),
+	).toBe('Software Engineer, IB')
 	expect(
 		testimonialAttribution({
 			title: 'Lead Developer',
@@ -77,18 +84,26 @@ test('carousel story links opt in only when a vignette heading exists', () => {
 		(entry) => entry.name === 'Josh Tomaino',
 	)
 	const jett = landingTestimonials.find((entry) => entry.name === 'Jett Hays')
-	if (!josh || !jett) {
-		throw new Error('expected Josh and Jett testimonials')
+	const gabriel = landingTestimonials.find(
+		(entry) => entry.name === 'Gabriel Alegría',
+	)
+	if (!josh || !jett || !gabriel) {
+		throw new Error('expected Josh, Jett, and Gabriel testimonials')
 	}
 
 	expect(testimonialStoryHref(josh)).toBe('/blog/early-kody-users#josh-tomaino')
 	expect(testimonialStoryHref(jett)).toBe('/blog/early-kody-users#jett-hays')
+	expect(testimonialStoryHref(gabriel)).toBe(
+		'/blog/early-kody-users#gabriel-alegria',
+	)
+	expect(gabriel.photo).toBeNull()
+	expect(gabriel.href).toBeNull()
 	expect(testimonialStoryHref({})).toBeNull()
 	expect(
 		landingTestimonials
 			.filter((entry) => testimonialStoryHref(entry) != null)
 			.map((entry) => entry.name),
-	).toEqual(['Josh Tomaino', 'Jett Hays'])
+	).toEqual(['Josh Tomaino', 'Jett Hays', 'Gabriel Alegría'])
 })
 
 test('every hosted testimonial photo exists under public/images/testimonials', () => {

--- a/packages/worker/universal/landing-testimonials.ts
+++ b/packages/worker/universal/landing-testimonials.ts
@@ -1,7 +1,8 @@
 /**
  * Homepage testimonials. Keep this list data-only — the carousel scales to
- * about six entries without a layout rewrite. Do not invent quotes or fill
- * empty slots; add real cleared quotes only.
+ * about seven entries without a layout rewrite. Do not invent quotes or fill
+ * empty slots; add real cleared quotes only. Opt a card into the early-users
+ * post with `storyAnchor` matching that heading id (accents strip to ASCII).
  */
 
 import { routes } from '#universal/routes.ts'
@@ -13,8 +14,8 @@ export type LandingTestimonial = {
 	name: string
 	/** Public profile photo under `/images/testimonials/`, or null for initials. */
 	photo: string | null
-	/** Personal site or primary public social profile. */
-	href: string
+	/** Personal site or primary public social profile, or null when none is published. */
+	href: string | null
 	/** Verified public occupation or role — omit if unsure. */
 	title?: string
 	/** Verified public employer — omit if unsure. */
@@ -43,6 +44,16 @@ export const landingTestimonials = [
 		title: 'Head of Software',
 		company: 'Sentala',
 		storyAnchor: 'jett-hays',
+	},
+	{
+		quote:
+			'Kody transformed how I work. Railway health checks land in Discord, a personal task list replaced the Notion notes I always lost, and everything I need lives in one place.',
+		name: 'Gabriel Alegría',
+		photo: null,
+		href: null,
+		title: 'Software Engineer',
+		company: 'IB',
+		storyAnchor: 'gabriel-alegria',
 	},
 	{
 		quote:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Add Gabriel Alegría's approved early-user quote to the homepage carousel and the fuller vignette to `/blog/early-kody-users`, matching the Josh Tomaino / Jett Hays opt-in story-link pattern.

## Why

Pam confirmed Gabriel LGTM'd the wording. #2165 held him out until that yes. Both surfaces should ship together so **Read the full story** is honest.

## Summary

- Homepage carousel: short quote, `Gabriel Alegría, Software Engineer, IB`, story link to `/blog/early-kody-users#gabriel-alegria`.
- Early-users post: approved two-paragraph vignette with the same attribution and accented name.
- Story links still render only when `storyAnchor` is set (Josh, Jett, Gabriel). Other cards stay quote-only.
- No public photo or profile URL was provided, so the card uses initials and a non-link identity instead of inventing an outbound destination.

## Testing

- Pre-push: `test:node` (3015) and `test:workers` (341)
- Focused node-unit: testimonials, blog catalog, markdown heading ids (accent → `gabriel-alegria`), homepage + blog SSR
- Preview `https://kody-pr-2200.kody-a99.workers.dev` (`/health` merge sha `2a55c237`, PR head `3c51af1d`):
  - `preview:manual-test --check / --check /blog/early-kody-users` both 200
  - Anonymous HTML: 7 cards, story links only on Josh, Jett, and Gabriel; Gabriel quote, accent, `Software Engineer, IB`, `GA` initials, href `#gabriel-alegria`
  - Blog HTML: `id="gabriel-alegria"` plus the approved Railway/Discord and Notion vignette
  - Browser: homepage card visible with the accent and **Read the full story**
  - A later pass hit Cloudflare `1042` on the preview origin (production `/blog/early-kody-users` stayed 200). That is a preview-worker fetch flake, not missing copy.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `b6fc3062` · **Head:** `3c51af1d`

**Classification:** composes — no primitives added or changed. This PR adds approved testimonial copy and opts Gabriel into the existing `storyAnchor` link.

### Primitives touched

| Primitive | Group    | Impact                                                                 |
| --------- | -------- | ---------------------------------------------------------------------- |
| `app-ui`  | surfaces | composes — carousel card, story href, first-party heading id           |

Unmatched paths are the early-users markdown post, blog catalog pins, and landing CSS on the same public marketing surface.

### Change flow

Homepage cards still share the early-users post. Gabriel's card opts in with `storyAnchor`, and the accented heading strips to `#gabriel-alegria`.

```mermaid
sequenceDiagram
	actor Visitor
	participant appUi as app-ui
	Visitor->>appUi: open homepage carousel
	appUi->>appUi: render Gabriel quote when storyAnchor is set
	Visitor->>appUi: activate Read the full story from Gabriel Alegría
	appUi->>appUi: GET /blog/early-kody-users#gabriel-alegria
	Note over appUi: heading id strips the accent to gabriel-alegria
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16a39161-9d30-4fa5-9666-06a88672fac7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16a39161-9d30-4fa5-9666-06a88672fac7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new customer testimonial from Gabriel Alegría, including their role, experience, and story details.
  - Updated the testimonials carousel to support entries without profile photos or story links, displaying initials when no photo is available.
  - Added the new testimonial to the relevant homepage and customer story content.

- **Bug Fixes**
  - Improved heading links so accented characters are normalized correctly in generated IDs.
  - Testimonial identities without links are no longer rendered as empty links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->