### PR TITLE
Never flash a loading state on route changes: fix the load latch, move every client route onto createRouteData, document no-flash navigation

### DIFF
--- a/.agents/skills/remix/SKILL.md
+++ b/.agents/skills/remix/SKILL.md
@@ -284,7 +284,11 @@ full examples.
   Node apps. Do not use it on the origin Worker; Kody owns `renderToStream` plus
   Workers Assets
 - `remix/spa` — client-only `run(router)` for apps with no server document. Kody
-  keeps a custom client router on top of server-rendered HTML
+  keeps a custom client router on top of server-rendered HTML: it runs the
+  destination's loader before committing the URL, and route components read the
+  payload through `createRouteData` (`#client/route-data.tsx`) so the previous
+  page stays until the next one is ready — see
+  `docs/contributing/no-flash-navigation.md` before adding a client route
 - `remix/headers` — typed header parsers and builders. Use when reading
   `Accept`, `Cookie`, or setting `CacheControl`, `Vary`, etc., instead of
   hand-formatting strings

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,8 @@ This file is intentionally brief. Detailed instructions live in focused docs:
   - [docs/contributing/oxlint-js-plugins.md](./docs/contributing/oxlint-js-plugins.md)
   - [docs/contributing/remix.md](./docs/contributing/remix.md) and the
     repo-local [Remix skill](./.agents/skills/remix/SKILL.md)
+  - [docs/contributing/no-flash-navigation.md](./docs/contributing/no-flash-navigation.md)
+    (client routes keep the previous page until the next one is ready)
   - [docs/contributing/cloudflare-agents-sdk.md](./docs/contributing/cloudflare-agents-sdk.md)
 - MCP capabilities (search/execute graph, domains, registry):
   - [docs/contributing/adding-capabilities.md](./docs/contributing/adding-capabilities.md)

--- a/docs/contributing/import-boundaries.md
+++ b/docs/contributing/import-boundaries.md
@@ -33,6 +33,9 @@ That config includes `client/**` and `universal/**` only.
   or `packages/worker/universal/**` (except client test files that assert
   server/client parity)
 - any `#client/*` import from `packages/worker/universal/**`
+- any `#client/route-load-latch.ts` import from
+  `packages/worker/client/routes/**` (routes read loader payloads through
+  `createRouteData`; see [no-flash navigation](./no-flash-navigation.md))
 
 The rule covers static imports, re-exports (`export … from`), dynamic
 `import()`, and `vi.mock` / `vi.unmock` specifiers, so tests cannot route around

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -41,6 +41,8 @@ style, tests, MCP capabilities, and runtime architecture.
   (`typescript/no-explicit-any`, `TODO`/`FIXME`/`HACK`, file-size ratchet,
   vanished-copy `kody-custom/no-tautological-absence`, knip)
 - [Remix skills and page checklist](./remix.md), [frames](./frames.md)
+- [No-flash navigation](./no-flash-navigation.md) (load-before-commit router,
+  `createRouteData` keeps the previous page until the next one is ready)
 - [Cloudflare Agents SDK usage](./cloudflare-agents-sdk.md)
 
 ## Testing

--- a/docs/contributing/no-flash-navigation.md
+++ b/docs/contributing/no-flash-navigation.md
@@ -102,13 +102,73 @@ Snapshot meanings:
   failed, after a stale refresh (a form POST redirecting back to the same URL),
   or on a cold SPA mount without SSR data.
 - `not-found` / `error`: the fallback fetch for the current location settled
-  that way.
+  that way (`load` returned `null`, or threw — the thrown error is
+  `snapshot.error`).
+
+`load` may also return `routeDataRedirect('/login')` when the fetch answered
+401: the route keeps its current content while the browser leaves for the login
+document.
 
 Register the component and its loader in
 `packages/worker/client/routes/index.tsx` under the same `routePattern(...)`
 key; the loader is what lets the router load-before-commit. Reuse one component
 for sibling patterns (list and detail, `/docs` and `/docs/:slug`) so remix/ui
 keeps the instance and its last-good payload across the switch.
+
+### Routes that own state (account, admin)
+
+Account and admin pages hold forms, selections, and action feedback in their
+closure and mutate that state from POST responses. They use the same helper and
+apply a payload into that state when its identity changes:
+
+```tsx
+let appliedPayload: AccountJobsLoaderData | null = null
+let appliedError: Error | null = null
+const jobsData = createRouteData({
+	key: 'accountJobs',
+	locationKey: getDataLatchKey, // list and detail hrefs share one payload
+	async load(href, signal) {
+		const response = await fetch(buildJobsApiRequestUrl(href), { signal })
+		if (response.status === 401) return routeDataRedirect('/login')
+		const payload = await readJson<AccountJobsLoaderData>(response)
+		if (!response.ok || !payload?.ok)
+			throw new Error('Unable to load scheduled jobs.')
+		return payload
+	},
+})
+
+return () => {
+	const currentHref = readCurrentRouterHref(handle)
+	const snapshot = jobsData.read(handle, currentHref)
+	if (snapshot.data && snapshot.data !== appliedPayload) {
+		appliedPayload = snapshot.data
+		applyPayload(snapshot.data)
+	}
+	if (snapshot.error && snapshot.error !== appliedError) {
+		appliedError = snapshot.error
+		setMessage(snapshot.error.message, 'error')
+	}
+	const pending = snapshot.kind === 'pending'
+	return (
+		<AccountManagementShell busy={pending && appliedPayload !== null}>
+			{/* header, message, and the page — rendered from closure state */}
+		</AccountManagementShell>
+	)
+}
+```
+
+- `AccountManagementShell busy` sets `aria-busy` and renders the hidden live
+  region for every account/admin page in one place.
+- Loaders that return several keys assemble them with a `consume(handle, href)`
+  option instead of `key` (all-or-nothing: return `null` when a required key is
+  missing so the fallback fetch loads the full set).
+- `locationKey(href)` names which hrefs share one payload (a list page and its
+  detail pages, filters that the payload ignores).
+- `reload(handle, currentHref)` refetches the current location after a mutation
+  the route wants to reconcile with the server; the current payload stays on
+  screen under `pending` until the fresh one lands.
+- A standalone "Loading…" paragraph is only correct when
+  `appliedPayload === null` — nothing has ever rendered here.
 
 ## When a section is slow
 
@@ -133,11 +193,10 @@ where content goes.
   `route-load-latch.node.test.ts` pin the data-continuity contract: preloaded
   payloads are applied without a refetch, previous payloads stay while a
   fallback runs, aborted fetches re-arm, and late completions are dropped.
-- `e2e/docs.spec.ts` observes `<main>` through a guide-to-guide click and fails
-  on any intermediate DOM state without an `<h1>`, any `role="status"` loading
-  copy, or a second request for the payload the router already loaded.
-
-Routes that still hand-roll `createRouteLoadLatch` follow the same latch
-contract (the latch records applied route data itself), so they get the
-single-commit navigation; migrate them to `createRouteData` when touching them
-so they also keep their last-good content on the fallback path.
+- `e2e/docs.spec.ts` and `e2e/account-navigation.spec.ts` observe `<main>`
+  through guide-to-guide and account/admin section clicks
+  (`e2e/main-transitions.ts`) and fail on any intermediate DOM state without an
+  `<h1>`, any loading copy where content was, or a repeated request for a
+  payload the router already loaded.
+- `createRouteLoadLatch` is the helper's internal latch; client routes read
+  through `createRouteData` and do not hand-roll load bookkeeping.

--- a/docs/contributing/no-flash-navigation.md
+++ b/docs/contributing/no-flash-navigation.md
@@ -1,0 +1,143 @@
+# No-flash navigation
+
+Changing routes never clears the current page and never shows a loading state in
+its place. The next page replaces the previous one in a single DOM commit,
+already holding its data. This document describes the mechanism that makes that
+the default and the one helper a route uses to stay on it.
+
+## How a navigation works
+
+```mermaid
+sequenceDiagram
+	participant U as User
+	participant R as client-router
+	participant L as route loader
+	participant P as navigation-data slot
+	participant C as route component
+
+	U->>R: click same-origin link
+	R->>L: loader(url) (intent prefetch may already be in flight)
+	Note over R: previous page stays on screen<br/>NavigationProgress bar after 150ms
+	L-->>R: payload
+	R->>P: setPreloadedNavigationData(href, payload)
+	R->>R: pushState + notify()
+	R->>C: one re-render with the new href
+	C->>P: createRouteData.read() consumes the payload
+	C-->>U: previous article replaced in one commit
+```
+
+1. `packages/worker/client/client-router.tsx` intercepts the click and runs the
+   destination's loader from `clientRouteLoaders`
+   (`packages/worker/client/routes/index.tsx`) **before** it touches the URL.
+   Hover, focus, and touch start that loader early (`intent-prefetch.ts`), and
+   the lazy route chunk is warmed alongside it (`lazy-route.tsx`).
+2. While the loader runs, nothing about the page changes. The only pending UI is
+   the 3px `NavigationProgress` bar, and only when the navigation is still
+   pending after 150ms.
+3. The loader result is parked in the single-slot navigation store
+   (`navigation-data.ts`), the URL is committed, and the tree re-renders once.
+4. The route's `createRouteData(...).read(handle, currentHref)` consumes that
+   slot (or the SSR-embedded payload on the first document) and returns
+   `kind: 'ready'` with the new payload. The previous content and the new
+   content are never on screen together and no intermediate state exists.
+
+Persistent shells (`/account`, `/admin`, `/docs`) additionally skip the page
+view transition so their rail does not re-animate; `shouldUseViewTransition` in
+`client-router.tsx` owns that list, and `prefers-reduced-motion` disables
+transitions everywhere.
+
+## Writing a route
+
+Use `createRouteData` from `#client/route-data.tsx`. It owns consume-once of the
+loader payload, the fallback fetch and its href latch, abort handling, and the
+last-good payload the route keeps rendering while any fallback runs.
+
+```tsx
+import {
+	createRouteData,
+	renderRoutePendingStatus,
+} from '#client/route-data.tsx'
+
+export function ThingRoute(handle: Handle) {
+	const thingData = createRouteData({
+		key: 'thing', // AppLoaderData key returned by thingRouteLoader
+		async load(href, signal) {
+			const response = await fetch(apiHrefFor(href), { signal })
+			if (response.status === 404) return null // -> kind: 'not-found'
+			const payload = await readJson<ThingLoaderData>(response)
+			if (!response.ok || !payload?.ok) throw new Error('Unable to load.') // -> 'error'
+			return payload
+		},
+	})
+
+	return () => {
+		const currentHref = readCurrentRouterHref(handle)
+		const snapshot = thingData.read(handle, currentHref)
+		if (snapshot.kind === 'not-found') return <NotFound />
+		if (snapshot.kind === 'error') return <LoadError />
+		const thing = snapshot.data
+		// Only the SPA cold path (no SSR payload, nothing loaded before) has
+		// nothing to keep on screen.
+		if (thing === null) return <p role="status">Loading…</p>
+		const pending = snapshot.kind === 'pending'
+		return (
+			<article aria-busy={pending ? 'true' : undefined}>
+				{pending ? renderRoutePendingStatus() : null}
+				<h1>{thing.title}</h1>
+			</article>
+		)
+	}
+}
+```
+
+Snapshot meanings:
+
+- `ready`: `data` describes the current location. This is every navigation on
+  the happy path.
+- `pending`: a fallback fetch for the current location is in flight. `data` is
+  the last good payload — the previous page when `stale` is true — and the route
+  keeps rendering it under `aria-busy` with the visually hidden
+  `renderRoutePendingStatus()` live region so assistive tech hears the update
+  without the layout moving. Fallback fetches happen when the router's loader
+  failed, after a stale refresh (a form POST redirecting back to the same URL),
+  or on a cold SPA mount without SSR data.
+- `not-found` / `error`: the fallback fetch for the current location settled
+  that way.
+
+Register the component and its loader in
+`packages/worker/client/routes/index.tsx` under the same `routePattern(...)`
+key; the loader is what lets the router load-before-commit. Reuse one component
+for sibling patterns (list and detail, `/docs` and `/docs/:slug`) so remix/ui
+keeps the instance and its last-good payload across the switch.
+
+## When a section is slow
+
+Keep the ordering: make the loader faster, then cache it, then split the slow
+part out. A slow section is not a reason to render the page early with a spinner
+where content goes.
+
+- **Speed**: the loader payload is what the navigation waits on. Trim it to what
+  the route renders; move expensive derivations server-side.
+- **Cache**: intent prefetch already starts the loader on hover/focus.
+  `prefetchRouteHrefs` warms a list of destinations on render (the equivalent of
+  `prefetch="render"`) for links the visitor is likely to click next.
+- **Stream / defer**: when one region is genuinely slow and the rest is not,
+  split it into its own loader key or a Remix `<Frame>` (see
+  [frames](./frames.md)) with a `fallback` that reserves the region's height, so
+  the stable chrome commits at once and only that region fills in later. Keep
+  the region's box fixed so the fill-in does not shift layout.
+
+## What the checks cover
+
+- `packages/worker/client/route-data.node.test.ts` and
+  `route-load-latch.node.test.ts` pin the data-continuity contract: preloaded
+  payloads are applied without a refetch, previous payloads stay while a
+  fallback runs, aborted fetches re-arm, and late completions are dropped.
+- `e2e/docs.spec.ts` observes `<main>` through a guide-to-guide click and fails
+  on any intermediate DOM state without an `<h1>`, any `role="status"` loading
+  copy, or a second request for the payload the router already loaded.
+
+Routes that still hand-roll `createRouteLoadLatch` follow the same latch
+contract (the latch records applied route data itself), so they get the
+single-commit navigation; migrate them to `createRouteData` when touching them
+so they also keep their last-good content on the fallback path.

--- a/docs/contributing/remix.md
+++ b/docs/contributing/remix.md
@@ -80,9 +80,12 @@ the narrowest owners. The core route-wiring path is five files:
    Use the helpers in `#app/page-auth.ts` (`requireAuthenticatedPageUser`,
    `requirePageSession`, `requirePageUserWithRole`) for page auth, and use
    `#app/request-body.ts` helpers when the page reads structured request bodies.
-4. `packages/worker/client/routes/<page>.tsx` — add the route component and,
-   when the page participates in SPA preload navigation, its route loader.
-   Import shared loader payload types from `#universal/loader-data.ts`
+4. `packages/worker/client/routes/<page>.tsx` — add the route component and its
+   route loader, and read the payload through `createRouteData` from
+   `#client/route-data.tsx` so navigations replace the previous page in one
+   commit with no loading state (see
+   [no-flash navigation](./no-flash-navigation.md)). Import shared loader
+   payload types from `#universal/loader-data.ts`
    (`kody-custom/prefer-loader-data-types` enforces this). Keep UI-only state
    types local.
 5. `packages/worker/client/routes/index.tsx` — register the component in

--- a/e2e/account-navigation.spec.ts
+++ b/e2e/account-navigation.spec.ts
@@ -48,9 +48,16 @@ async function clickThroughSections(
 
 test('account section switches keep the current page on screen (no loading flash, no refetch)', async ({
 	page,
+	seedE2eUser,
 	login,
 }) => {
-	await login()
+	const runId = Date.now()
+	const user = await seedE2eUser({
+		email: `account-nav-${runId}@example.com`,
+		username: `account-nav-${runId}`,
+		password: 'account-nav-password',
+	})
+	await login({ email: user.email, password: user.password, mode: 'login' })
 	await page.goto('/account/jobs')
 	await waitForClientHydration(page)
 	await expect(

--- a/e2e/account-navigation.spec.ts
+++ b/e2e/account-navigation.spec.ts
@@ -1,0 +1,108 @@
+import {
+	collectJsonRequests,
+	expectSingleCommitTransition,
+	observeMainTransitions,
+	readMainTransitions,
+} from './main-transitions.ts'
+import {
+	expect,
+	test,
+	type Page,
+	waitForClientHydration,
+} from './playwright-utils.ts'
+
+/**
+ * Account and admin pages sit in a persistent shell; moving between them is
+ * tab switching. Each hop must replace the previous page in one commit: the
+ * heading never disappears, no "Loading…" copy takes the content's place,
+ * and the destination payload the router preloaded is never fetched twice.
+ */
+async function clickThroughSections(
+	page: Page,
+	navName: string,
+	hops: Array<{ link: string; heading: string | RegExp }>,
+	fromHeading: string | RegExp,
+) {
+	const requests = collectJsonRequests(page)
+	let previousHeading = fromHeading
+	for (const hop of hops) {
+		requests.reset()
+		await observeMainTransitions(page)
+		await page
+			.getByRole('navigation', { name: navName })
+			.getByRole('link', { name: hop.link, exact: true })
+			.click()
+		await expect(
+			page.getByRole('heading', { level: 1, name: hop.heading }),
+		).toBeVisible()
+		// Let any stray follow-up render land before reading the log.
+		await page.waitForTimeout(250)
+		expectSingleCommitTransition(await readMainTransitions(page), {
+			fromHeading: previousHeading,
+			toHeading: hop.heading,
+		})
+		expect(requests.duplicates(), requests.paths.join(', ')).toEqual([])
+		previousHeading = hop.heading
+	}
+}
+
+test('account section switches keep the current page on screen (no loading flash, no refetch)', async ({
+	page,
+	login,
+}) => {
+	await login()
+	await page.goto('/account/jobs')
+	await waitForClientHydration(page)
+	await expect(
+		page.getByRole('heading', { level: 1, name: 'Jobs' }),
+	).toBeVisible()
+
+	await clickThroughSections(
+		page,
+		'Account sections',
+		[
+			{ link: 'Memories', heading: 'Memories' },
+			{ link: 'Secrets', heading: 'Secrets' },
+			{ link: 'Workflows', heading: 'Workflows' },
+			{ link: 'Overview', heading: 'Account' },
+			{ link: 'Jobs', heading: 'Jobs' },
+		],
+		'Jobs',
+	)
+})
+
+test('admin section switches keep the current page on screen (no loading flash, no refetch)', async ({
+	page,
+	seedE2eUser,
+	assignRole,
+	login,
+}) => {
+	const runId = Date.now()
+	const adminUser = await seedE2eUser({
+		email: `admin-nav-${runId}@example.com`,
+		username: `admin-nav-${runId}`,
+		password: 'admin-nav-password',
+	})
+	await assignRole(adminUser.email, 'admin')
+	await login({
+		email: adminUser.email,
+		password: adminUser.password,
+		mode: 'login',
+	})
+	await page.goto('/admin/roles')
+	await waitForClientHydration(page)
+	await expect(
+		page.getByRole('heading', { level: 1, name: 'Admin roles' }),
+	).toBeVisible()
+
+	await clickThroughSections(
+		page,
+		'Admin sections',
+		[
+			{ link: 'Invites', heading: 'Admin invites' },
+			{ link: 'Feature flags', heading: 'Admin feature flags' },
+			{ link: 'Roles', heading: 'Admin roles' },
+		],
+		'Admin roles',
+	)
+})

--- a/e2e/docs.spec.ts
+++ b/e2e/docs.spec.ts
@@ -1,4 +1,93 @@
-import { expect, test } from './playwright-utils.ts'
+import {
+	expect,
+	test,
+	type Page,
+	waitForClientHydration,
+} from './playwright-utils.ts'
+
+type MainSnapshot = {
+	h1: string
+	status: string
+}
+
+/**
+ * Record every distinct state `<main>` passes through from now until read.
+ * Navigation must swap the previous article for the next one in a single
+ * commit: no intermediate state without an `<h1>` and no `role="status"`
+ * loading copy — that is the "flash of loading" this suite guards against.
+ */
+async function observeMainTransitions(page: Page) {
+	await page.evaluate(() => {
+		const main = document.getElementById('main')
+		if (!main) throw new Error('Expected #main')
+		const snapshot = () => ({
+			h1: main.querySelector('h1')?.textContent?.trim() ?? '',
+			status: Array.from(main.querySelectorAll('[role="status"]'))
+				.map((node) => node.textContent?.trim() ?? '')
+				.join(' | '),
+		})
+		const log: Array<MainSnapshot> = [snapshot()]
+		const observer = new MutationObserver(() => {
+			const next = snapshot()
+			const last = log[log.length - 1]
+			if (last && last.h1 === next.h1 && last.status === next.status) return
+			log.push(next)
+		})
+		observer.observe(main, {
+			childList: true,
+			subtree: true,
+			characterData: true,
+		})
+		Object.assign(window, { __kodyMainTransitions: log })
+	})
+}
+
+async function readMainTransitions(page: Page) {
+	return page.evaluate(
+		() =>
+			(window as unknown as { __kodyMainTransitions: Array<MainSnapshot> })
+				.__kodyMainTransitions,
+	)
+}
+
+test('docs guide switches keep the current article on screen until the next one is ready (no loading flash)', async ({
+	page,
+}) => {
+	await page.context().clearCookies()
+	await page.goto('/docs/memory')
+	await waitForClientHydration(page)
+	await expect(
+		page.getByRole('heading', { level: 1, name: 'Shared memory' }),
+	).toBeVisible()
+
+	const docRequests: Array<string> = []
+	page.on('request', (request) => {
+		if (request.url().includes('/docs/') && request.url().endsWith('.json')) {
+			docRequests.push(new URL(request.url()).pathname)
+		}
+	})
+
+	await observeMainTransitions(page)
+	const sidebar = page.getByRole('navigation', { name: 'Docs' }).first()
+	await sidebar.getByRole('link', { name: 'Secrets', exact: true }).click()
+	await expect(page).toHaveURL(/\/docs\/secrets$/)
+	await expect(
+		page.getByRole('heading', { level: 1, name: 'Secrets' }),
+	).toBeVisible()
+
+	const transitions = await readMainTransitions(page)
+	expect(transitions[0]?.h1).toBe('Shared memory')
+	expect(transitions.at(-1)?.h1).toBe('Secrets')
+	for (const state of transitions) {
+		// Every intermediate DOM state still shows an article title.
+		expect(state.h1, JSON.stringify(transitions)).not.toBe('')
+		// ...and never a loading message in place of one.
+		expect(state.status, JSON.stringify(transitions)).not.toMatch(/loading/i)
+	}
+	// The router preloads the destination once; the route must not refetch
+	// the payload it was just handed (that refetch was the loading flash).
+	expect(docRequests).toEqual(['/docs/secrets.json'])
+})
 
 test('docs site: header says Docs, /docs opens the introduction with a sidebar, and legacy /guides redirects', async ({
 	page,

--- a/e2e/docs.spec.ts
+++ b/e2e/docs.spec.ts
@@ -1,54 +1,9 @@
 import {
-	expect,
-	test,
-	type Page,
-	waitForClientHydration,
-} from './playwright-utils.ts'
-
-type MainSnapshot = {
-	h1: string
-	status: string
-}
-
-/**
- * Record every distinct state `<main>` passes through from now until read.
- * Navigation must swap the previous article for the next one in a single
- * commit: no intermediate state without an `<h1>` and no `role="status"`
- * loading copy — that is the "flash of loading" this suite guards against.
- */
-async function observeMainTransitions(page: Page) {
-	await page.evaluate(() => {
-		const main = document.getElementById('main')
-		if (!main) throw new Error('Expected #main')
-		const snapshot = () => ({
-			h1: main.querySelector('h1')?.textContent?.trim() ?? '',
-			status: Array.from(main.querySelectorAll('[role="status"]'))
-				.map((node) => node.textContent?.trim() ?? '')
-				.join(' | '),
-		})
-		const log: Array<MainSnapshot> = [snapshot()]
-		const observer = new MutationObserver(() => {
-			const next = snapshot()
-			const last = log[log.length - 1]
-			if (last && last.h1 === next.h1 && last.status === next.status) return
-			log.push(next)
-		})
-		observer.observe(main, {
-			childList: true,
-			subtree: true,
-			characterData: true,
-		})
-		Object.assign(window, { __kodyMainTransitions: log })
-	})
-}
-
-async function readMainTransitions(page: Page) {
-	return page.evaluate(
-		() =>
-			(window as unknown as { __kodyMainTransitions: Array<MainSnapshot> })
-				.__kodyMainTransitions,
-	)
-}
+	expectSingleCommitTransition,
+	observeMainTransitions,
+	readMainTransitions,
+} from './main-transitions.ts'
+import { expect, test, waitForClientHydration } from './playwright-utils.ts'
 
 test('docs guide switches keep the current article on screen until the next one is ready (no loading flash)', async ({
 	page,
@@ -75,15 +30,10 @@ test('docs guide switches keep the current article on screen until the next one 
 		page.getByRole('heading', { level: 1, name: 'Secrets' }),
 	).toBeVisible()
 
-	const transitions = await readMainTransitions(page)
-	expect(transitions[0]?.h1).toBe('Shared memory')
-	expect(transitions.at(-1)?.h1).toBe('Secrets')
-	for (const state of transitions) {
-		// Every intermediate DOM state still shows an article title.
-		expect(state.h1, JSON.stringify(transitions)).not.toBe('')
-		// ...and never a loading message in place of one.
-		expect(state.status, JSON.stringify(transitions)).not.toMatch(/loading/i)
-	}
+	expectSingleCommitTransition(await readMainTransitions(page), {
+		fromHeading: 'Shared memory',
+		toHeading: 'Secrets',
+	})
 	// The router preloads the destination once; the route must not refetch
 	// the payload it was just handed (that refetch was the loading flash).
 	expect(docRequests).toEqual(['/docs/secrets.json'])

--- a/e2e/main-transitions.ts
+++ b/e2e/main-transitions.ts
@@ -1,0 +1,107 @@
+import { expect, type Page } from '@playwright/test'
+
+export type MainSnapshot = {
+	h1: string
+	status: string
+	/** Visible paragraphs whose copy starts with "Loading". */
+	loadingCopy: string
+}
+
+/**
+ * Record every distinct state `<main>` passes through from now until read.
+ * Navigation must swap the previous page for the next one in a single
+ * commit: no intermediate state without an `<h1>` and no loading copy where
+ * content was — that is the "flash of loading" these specs guard against.
+ */
+export async function observeMainTransitions(page: Page) {
+	await page.evaluate(() => {
+		const main = document.getElementById('main')
+		if (!main) throw new Error('Expected #main')
+		const snapshot = () => ({
+			h1: main.querySelector('h1')?.textContent?.trim() ?? '',
+			status: Array.from(main.querySelectorAll('[role="status"]'))
+				.map((node) => node.textContent?.trim() ?? '')
+				.join(' | '),
+			loadingCopy: Array.from(main.querySelectorAll('p'))
+				.map((node) => node.textContent?.trim() ?? '')
+				.filter((text) => /^Loading/i.test(text))
+				.join(' | '),
+		})
+		const log: Array<MainSnapshot> = [snapshot()]
+		const observer = new MutationObserver(() => {
+			const next = snapshot()
+			const last = log[log.length - 1]
+			if (
+				last &&
+				last.h1 === next.h1 &&
+				last.status === next.status &&
+				last.loadingCopy === next.loadingCopy
+			) {
+				return
+			}
+			log.push(next)
+		})
+		observer.observe(main, {
+			childList: true,
+			subtree: true,
+			characterData: true,
+		})
+		Object.assign(window, { __kodyMainTransitions: log })
+	})
+}
+
+export async function readMainTransitions(page: Page) {
+	return page.evaluate(
+		() =>
+			(window as unknown as { __kodyMainTransitions: Array<MainSnapshot> })
+				.__kodyMainTransitions,
+	)
+}
+
+/**
+ * Assert a recorded navigation went from `fromHeading` to `toHeading` without
+ * blanking the page or showing loading copy in between.
+ */
+export function expectSingleCommitTransition(
+	transitions: Array<MainSnapshot>,
+	input: { fromHeading: string | RegExp; toHeading: string | RegExp },
+) {
+	const detail = JSON.stringify(transitions)
+	expect(transitions[0]?.h1, detail).toMatch(input.fromHeading)
+	expect(transitions.at(-1)?.h1, detail).toMatch(input.toHeading)
+	for (const state of transitions) {
+		// Every intermediate DOM state still shows a page title.
+		expect(state.h1, detail).not.toBe('')
+		// ...and never a loading message in place of content.
+		expect(state.status, detail).not.toMatch(/loading/i)
+		expect(state.loadingCopy, detail).toBe('')
+	}
+}
+
+/**
+ * Collect same-origin `.json` payload requests so a spec can assert the
+ * destination payload is requested once (the router preloads it) and never
+ * refetched by the route after commit.
+ */
+export function collectJsonRequests(page: Page) {
+	const paths: Array<string> = []
+	page.on('request', (request) => {
+		const url = new URL(request.url())
+		if (url.pathname.endsWith('.json')) paths.push(url.pathname)
+	})
+	return {
+		paths,
+		reset() {
+			paths.splice(0)
+		},
+		duplicates() {
+			const seen = new Set<string>()
+			const repeated = new Set<string>()
+			for (const path of paths) {
+				if (seen.has(path)) repeated.add(path)
+				seen.add(path)
+			}
+			return Array.from(repeated)
+		},
+	}
+}

--- a/packages/worker/client/route-data.node.test.ts
+++ b/packages/worker/client/route-data.node.test.ts
@@ -1,0 +1,270 @@
+import { type Handle } from 'remix/ui'
+import { renderToString } from 'remix/ui/server'
+import { afterEach, beforeEach, expect, test } from 'vitest'
+import { type DocDetailLoaderData } from '#universal/loader-data.ts'
+import { AppLoaderDataProvider } from './loader-data-context.tsx'
+import {
+	clearPreloadedNavigationData,
+	markNavigationDataStale,
+	setPreloadedNavigationData,
+} from './navigation-data.ts'
+import { createRouteData, renderRoutePendingStatus } from './route-data.tsx'
+
+// The fallback fetch only queues in a browser; stand in for `document` so
+// the helper takes the client path.
+const previousDocument = globalThis.document
+beforeEach(() => {
+	clearPreloadedNavigationData()
+	globalThis.document = {} as unknown as Document
+})
+afterEach(() => {
+	clearPreloadedNavigationData()
+	globalThis.document = previousDocument
+})
+
+function createDoc(slug: string): DocDetailLoaderData {
+	return {
+		ok: true,
+		id: slug,
+		slug,
+		title: slug,
+		summary: '',
+		body: `# ${slug}`,
+		category: 'guide',
+		audience: 'humans',
+	} as DocDetailLoaderData
+}
+
+type QueuedTask = (signal: AbortSignal) => unknown
+
+function createStubHandle() {
+	const queuedTasks: Array<QueuedTask> = []
+	let updateCount = 0
+	const handle = {
+		context: {
+			get(provider: unknown) {
+				if (provider === AppLoaderDataProvider) {
+					return { loaderData: undefined, consumedKeys: new Set() }
+				}
+				// No RouterLocationProvider in the stub tree; consumption
+				// falls through to the preloaded navigation slot.
+				throw new Error('context not available')
+			},
+		},
+		queueTask(task: QueuedTask) {
+			queuedTasks.push(task)
+		},
+		update() {
+			updateCount++
+			return Promise.resolve(new AbortController().signal)
+		},
+	} as unknown as Handle
+	return {
+		handle,
+		queuedTasks,
+		/** Run queued tasks like the scheduler would, with a live signal. */
+		async flushTasks(signal = new AbortController().signal) {
+			const tasks = queuedTasks.splice(0)
+			for (const task of tasks) await task(signal)
+		},
+		getUpdateCount: () => updateCount,
+	}
+}
+
+function createDeferred<T>() {
+	let resolve!: (value: T) => void
+	let reject!: (reason: unknown) => void
+	const promise = new Promise<T>((res, rej) => {
+		resolve = res
+		reject = rej
+	})
+	return { promise, resolve, reject }
+}
+
+test('preloaded navigation data replaces the previous payload in one render and is never refetched', async () => {
+	const { handle, queuedTasks, flushTasks } = createStubHandle()
+	const loads: Array<string> = []
+	const docData = createRouteData({
+		key: 'docDetail',
+		async load(href) {
+			loads.push(href)
+			return createDoc('fallback')
+		},
+	})
+
+	setPreloadedNavigationData('/docs/memory', { docDetail: createDoc('memory') })
+	let snapshot = docData.read(handle, '/docs/memory')
+	expect(snapshot).toEqual({
+		kind: 'ready',
+		data: createDoc('memory'),
+		stale: false,
+	})
+	// The consume helper schedules one corrective render; run it. That render
+	// finds nothing to consume and must not queue a fetch.
+	await flushTasks()
+	snapshot = docData.read(handle, '/docs/memory')
+	expect(snapshot.kind).toBe('ready')
+	expect(queuedTasks).toHaveLength(0)
+
+	// SPA navigation to another guide with the router's preloaded payload.
+	setPreloadedNavigationData('/docs/secrets', {
+		docDetail: createDoc('secrets'),
+	})
+	snapshot = docData.read(handle, '/docs/secrets')
+	expect(snapshot).toEqual({
+		kind: 'ready',
+		data: createDoc('secrets'),
+		stale: false,
+	})
+	await flushTasks()
+	snapshot = docData.read(handle, '/docs/secrets')
+	expect(snapshot.kind).toBe('ready')
+	expect(snapshot.data?.slug).toBe('secrets')
+	expect(loads).toEqual([])
+})
+
+test('a commit without preloaded data keeps the previous payload on screen (stale + pending) until the fallback fetch lands', async () => {
+	const { handle, queuedTasks, flushTasks, getUpdateCount } = createStubHandle()
+	const deferred = createDeferred<DocDetailLoaderData | null>()
+	const docData = createRouteData({
+		key: 'docDetail',
+		load: () => deferred.promise,
+	})
+
+	setPreloadedNavigationData('/docs/memory', { docDetail: createDoc('memory') })
+	docData.read(handle, '/docs/memory')
+	await flushTasks()
+
+	// The router's loader failed for /docs/secrets, so the route commits with
+	// nothing preloaded. It must keep showing "memory" while it refetches.
+	const pending = docData.read(handle, '/docs/secrets')
+	expect(pending.kind).toBe('pending')
+	expect(pending.stale).toBe(true)
+	expect(pending.data?.slug).toBe('memory')
+	expect(queuedTasks).toHaveLength(1)
+
+	// Re-renders while the fetch is in flight do not queue a second fetch.
+	expect(docData.read(handle, '/docs/secrets').kind).toBe('pending')
+	expect(queuedTasks).toHaveLength(1)
+
+	const updatesBeforeFetch = getUpdateCount()
+	const flushing = flushTasks()
+	deferred.resolve(createDoc('secrets'))
+	await flushing
+	// Exactly one render for the applied result.
+	expect(getUpdateCount()).toBe(updatesBeforeFetch + 1)
+	const ready = docData.read(handle, '/docs/secrets')
+	expect(ready).toEqual({
+		kind: 'ready',
+		data: createDoc('secrets'),
+		stale: false,
+	})
+})
+
+test('fallback fetch outcomes: not-found, error (latched), and stale refresh', async () => {
+	const { handle, queuedTasks, flushTasks } = createStubHandle()
+	let nextResult: () => Promise<DocDetailLoaderData | null> = () =>
+		Promise.resolve(null)
+	const docData = createRouteData({
+		key: 'docDetail',
+		load: () => nextResult(),
+	})
+
+	// Cold SPA mount: nothing to keep, pending with no data.
+	expect(docData.read(handle, '/docs/missing')).toEqual({
+		kind: 'pending',
+		data: null,
+		stale: false,
+	})
+	await flushTasks()
+	expect(docData.read(handle, '/docs/missing')).toEqual({
+		kind: 'not-found',
+		data: null,
+		stale: false,
+	})
+	expect(queuedTasks).toHaveLength(0)
+
+	// A failing fetch reports `error` once and does not re-queue in a loop.
+	nextResult = () => Promise.reject(new Error('boom'))
+	expect(docData.read(handle, '/docs/broken').kind).toBe('pending')
+	await flushTasks()
+	expect(docData.read(handle, '/docs/broken')).toEqual({
+		kind: 'error',
+		data: null,
+		stale: false,
+	})
+	expect(docData.read(handle, '/docs/broken').kind).toBe('error')
+	expect(queuedTasks).toHaveLength(0)
+
+	// Same-location stale refresh (form POST redirect back here) refetches
+	// while keeping the current payload visible.
+	nextResult = () => Promise.resolve(createDoc('memory'))
+	setPreloadedNavigationData('/docs/memory', { docDetail: createDoc('memory') })
+	docData.read(handle, '/docs/memory')
+	await flushTasks()
+	markNavigationDataStale('/docs/memory')
+	const refreshing = docData.read(handle, '/docs/memory')
+	expect(refreshing.kind).toBe('pending')
+	expect(refreshing.stale).toBe(false)
+	expect(refreshing.data?.slug).toBe('memory')
+	expect(queuedTasks).toHaveLength(1)
+	await flushTasks()
+	expect(docData.read(handle, '/docs/memory').kind).toBe('ready')
+})
+
+test('an aborted fallback fetch releases the latch and schedules the render that re-queues it', async () => {
+	const { handle, queuedTasks, flushTasks, getUpdateCount } = createStubHandle()
+	const docData = createRouteData({
+		key: 'docDetail',
+		load: (_href, signal) =>
+			new Promise<DocDetailLoaderData | null>((_resolve, reject) => {
+				signal.addEventListener('abort', () => reject(new Error('aborted')))
+			}),
+	})
+
+	expect(docData.read(handle, '/docs/memory').kind).toBe('pending')
+	expect(queuedTasks).toHaveLength(1)
+	// remix/ui aborts the task signal when the component re-renders for an
+	// unrelated reason (e.g. the shell refreshing its session).
+	const controller = new AbortController()
+	const flushing = flushTasks(controller.signal)
+	controller.abort()
+	await flushing
+	expect(getUpdateCount()).toBe(1)
+
+	// The scheduled render re-queues the fetch instead of sitting in pending.
+	expect(docData.read(handle, '/docs/memory').kind).toBe('pending')
+	expect(queuedTasks).toHaveLength(1)
+})
+
+test('late completions for a location the user already left are dropped', async () => {
+	const { handle, flushTasks, getUpdateCount } = createStubHandle()
+	const deferred = createDeferred<DocDetailLoaderData | null>()
+	const docData = createRouteData({
+		key: 'docDetail',
+		load: () => deferred.promise,
+	})
+
+	expect(docData.read(handle, '/docs/memory').kind).toBe('pending')
+	const flushing = flushTasks()
+	// Navigate on with preloaded data before the first fetch resolves.
+	setPreloadedNavigationData('/docs/secrets', {
+		docDetail: createDoc('secrets'),
+	})
+	expect(docData.read(handle, '/docs/secrets').data?.slug).toBe('secrets')
+	deferred.resolve(createDoc('memory'))
+	await flushing
+	// No update for the abandoned location, and the current one is untouched.
+	expect(getUpdateCount()).toBe(0)
+	expect(docData.read(handle, '/docs/secrets')).toEqual({
+		kind: 'ready',
+		data: createDoc('secrets'),
+		stale: false,
+	})
+})
+
+test('pending status is a visually hidden live region', async () => {
+	const html = await renderToString(renderRoutePendingStatus())
+	expect(html).toContain('role="status"')
+	expect(html).toContain('Loading…')
+})

--- a/packages/worker/client/route-data.node.test.ts
+++ b/packages/worker/client/route-data.node.test.ts
@@ -98,6 +98,7 @@ test('preloaded navigation data replaces the previous payload in one render and 
 		kind: 'ready',
 		data: createDoc('memory'),
 		stale: false,
+		error: null,
 	})
 	// The consume helper schedules one corrective render; run it. That render
 	// finds nothing to consume and must not queue a fetch.
@@ -115,6 +116,7 @@ test('preloaded navigation data replaces the previous payload in one render and 
 		kind: 'ready',
 		data: createDoc('secrets'),
 		stale: false,
+		error: null,
 	})
 	await flushTasks()
 	snapshot = docData.read(handle, '/docs/secrets')
@@ -158,6 +160,7 @@ test('a commit without preloaded data keeps the previous payload on screen (stal
 		kind: 'ready',
 		data: createDoc('secrets'),
 		stale: false,
+		error: null,
 	})
 })
 
@@ -175,12 +178,14 @@ test('fallback fetch outcomes: not-found, error (latched), and stale refresh', a
 		kind: 'pending',
 		data: null,
 		stale: false,
+		error: null,
 	})
 	await flushTasks()
 	expect(docData.read(handle, '/docs/missing')).toEqual({
 		kind: 'not-found',
 		data: null,
 		stale: false,
+		error: null,
 	})
 	expect(queuedTasks).toHaveLength(0)
 
@@ -192,6 +197,7 @@ test('fallback fetch outcomes: not-found, error (latched), and stale refresh', a
 		kind: 'error',
 		data: null,
 		stale: false,
+		error: new Error('boom'),
 	})
 	expect(docData.read(handle, '/docs/broken').kind).toBe('error')
 	expect(queuedTasks).toHaveLength(0)
@@ -260,6 +266,7 @@ test('late completions for a location the user already left are dropped', async 
 		kind: 'ready',
 		data: createDoc('secrets'),
 		stale: false,
+		error: null,
 	})
 })
 

--- a/packages/worker/client/route-data.tsx
+++ b/packages/worker/client/route-data.tsx
@@ -1,0 +1,215 @@
+import { type Handle, css } from 'remix/ui'
+import { type AppLoaderData } from '#universal/loader-data.ts'
+import { visuallyHiddenCss } from '#universal/styles/style-primitives.ts'
+import {
+	normalizeRouterHref,
+	tryConsumeRouteLoaderData,
+} from '#client/loader-data-context.tsx'
+import { consumeStaleNavigationData } from '#client/navigation-data.ts'
+import { createRouteLoadLatch } from '#client/route-load-latch.ts'
+
+/**
+ * Route data with content continuity across navigations.
+ *
+ * The client router runs a route's loader *before* it commits the URL swap,
+ * so on the happy path a route re-renders already holding the next payload
+ * (SSR-embedded on the first document, preloaded by the router on SPA
+ * navigations) and the previous content is replaced in one DOM commit —
+ * nothing is blanked, no loading state is shown.
+ *
+ * This helper owns everything around that path so a route cannot reintroduce
+ * a flash loader by accident:
+ *
+ * - consume-once of the route's loader-data key for the current location
+ * - the href latch that decides when a *fallback* fetch is needed (the
+ *   router's loader failed, a stale refresh after a form POST, a cold SPA
+ *   mount without SSR data) and never re-queues an in-flight one
+ * - the abort-safe `queueTask` fetch, with late completions for a location
+ *   the user already left dropped on the floor
+ * - the "last good payload" the route keeps rendering while that fallback
+ *   fetch runs, so the page never empties out mid-navigation
+ *
+ * Routes call `read(handle, currentHref)` once per render and switch on the
+ * snapshot. Render `snapshot.data` whenever it is non-null (with
+ * `aria-busy` while `pending`, see `renderRoutePendingStatus`); reserve a
+ * standalone loading message for `data === null`, which only happens when
+ * there has never been anything to show.
+ */
+
+export type RouteDataSnapshot<T> = {
+	/**
+	 * `ready`: `data` describes the current location.
+	 * `pending`: a fallback fetch for the current location is in flight (or
+	 * queued this render); `data` is the last good payload, possibly from the
+	 * previous location (`stale`), or null when nothing was ever loaded.
+	 * `not-found` / `error`: the fallback fetch for the current location
+	 * settled that way.
+	 */
+	kind: 'ready' | 'pending' | 'not-found' | 'error'
+	data: T | null
+	/** `data` belongs to a different location than the one being rendered. */
+	stale: boolean
+}
+
+type RouteDataOptions<K extends keyof AppLoaderData, T> = {
+	/** Loader-data key the route's loader returns (`#universal/loader-data.ts`). */
+	key: K
+	/**
+	 * Fallback fetch for `href`. Return `null` for a 404; throw for any other
+	 * failure. Do not call `handle.update()` inside — the helper schedules the
+	 * render once the result is applied.
+	 */
+	load: (href: string, signal: AbortSignal) => Promise<T | null>
+	/**
+	 * Map a consumed loader payload to route data. Defaults to the payload
+	 * itself when it does not carry `ok: false`.
+	 */
+	fromLoaderData?: (payload: NonNullable<AppLoaderData[K]>) => T | null
+}
+
+function defaultFromLoaderData<T>(payload: unknown): T | null {
+	if (
+		typeof payload === 'object' &&
+		payload !== null &&
+		'ok' in payload &&
+		payload.ok === false
+	) {
+		return null
+	}
+	return payload as T
+}
+
+export function createRouteData<
+	K extends keyof AppLoaderData,
+	T = NonNullable<AppLoaderData[K]>,
+>(options: RouteDataOptions<K, T>) {
+	const latch = createRouteLoadLatch()
+	const fromLoaderData =
+		options.fromLoaderData ??
+		((payload: NonNullable<AppLoaderData[K]>) =>
+			defaultFromLoaderData<T>(payload))
+
+	let data: T | null = null
+	/** Location (pathname + search) `data` / `outcome` describe. */
+	let dataHref: string | null = null
+	let outcome: 'ready' | 'not-found' | 'error' | null = null
+	/** Location a fallback fetch is in flight for. */
+	let pendingHref: string | null = null
+	/** Location of the latest render; late completions for others are dropped. */
+	let renderedHref: string | null = null
+
+	function applyLoaded(href: string, result: T | null) {
+		dataHref = href
+		data = result
+		outcome = result === null ? 'not-found' : 'ready'
+	}
+
+	function queueFallbackLoad(handle: Handle, currentHref: string) {
+		const href = normalizeRouterHref(currentHref)
+		const attempt = latch.getPendingAttempt()
+		pendingHref = href
+
+		// remix/ui aborts a queued task's signal whenever the component
+		// re-renders for any reason (a shell session refresh, for example).
+		// Release the latch so the next render may re-queue, and when the
+		// route is still on this location, schedule that render ourselves —
+		// otherwise nothing would, and the route would sit in `pending`.
+		function handleAbort() {
+			latch.clearPending(currentHref, attempt)
+			if (renderedHref === href && pendingHref === href) {
+				void handle.update()
+			}
+		}
+
+		handle.queueTask(async (signal) => {
+			try {
+				const result = await options.load(currentHref, signal)
+				if (signal.aborted) {
+					handleAbort()
+					return
+				}
+				if (renderedHref !== href) return
+				applyLoaded(href, result)
+				pendingHref = null
+				latch.markLoaded(currentHref)
+				void handle.update()
+			} catch {
+				if (signal.aborted) {
+					handleAbort()
+					return
+				}
+				if (renderedHref !== href) return
+				data = null
+				dataHref = href
+				outcome = 'error'
+				pendingHref = null
+				latch.markFailed(currentHref)
+				void handle.update()
+			}
+		})
+	}
+
+	return {
+		/** Call once per render with the router href the route is rendering. */
+		read(handle: Handle, currentHref: string): RouteDataSnapshot<T> {
+			const href = normalizeRouterHref(currentHref)
+			renderedHref = href
+
+			const payload = tryConsumeRouteLoaderData(
+				handle,
+				options.key,
+				currentHref,
+			)
+			let appliedRouteData = false
+			if (payload !== undefined) {
+				const selected = fromLoaderData(
+					payload as NonNullable<AppLoaderData[K]>,
+				)
+				if (selected !== null) {
+					data = selected
+					dataHref = href
+					outcome = 'ready'
+					pendingHref = null
+					appliedRouteData = true
+				}
+			}
+
+			const needsStaleRefresh = consumeStaleNavigationData(currentHref)
+			const needsLoad = latch.needsLoad({
+				currentHref,
+				appliedRouteData,
+				needsStaleRefresh,
+			})
+			if (needsLoad && typeof document !== 'undefined') {
+				queueFallbackLoad(handle, currentHref)
+			}
+
+			const stale = data !== null && dataHref !== href
+			if (pendingHref === href) {
+				return { kind: 'pending', data, stale }
+			}
+			if (dataHref === href && outcome !== null) {
+				return { kind: outcome, data: outcome === 'ready' ? data : null, stale }
+			}
+			// Server render (or a client render before hydration) without a
+			// payload for this location: nothing is in flight yet, but the
+			// route still has nothing current to show.
+			return { kind: 'pending', data, stale }
+		},
+	}
+}
+
+/**
+ * Screen-reader announcement for a route that keeps its last good content
+ * on screen while a fallback fetch runs. Visually silent (the content and the
+ * chrome stay exactly where they were, so there is nothing to lay out), but
+ * assistive tech hears that the page is updating instead of being told a
+ * stale page is the destination. Pair with `aria-busy` on the region.
+ */
+export function renderRoutePendingStatus(label = 'Loading…') {
+	return (
+		<p role="status" mix={css(visuallyHiddenCss)}>
+			{label}
+		</p>
+	)
+}

--- a/packages/worker/client/route-data.tsx
+++ b/packages/worker/client/route-data.tsx
@@ -74,7 +74,7 @@ function isRouteDataRedirect(value: unknown): value is RouteDataRedirect {
 	return typeof value === 'object' && value !== null && redirectMarker in value
 }
 
-export type RouteDataLoadResult<T> = T | null | RouteDataRedirect
+type RouteDataLoadResult<T> = T | null | RouteDataRedirect
 
 type RouteDataSource<K extends keyof AppLoaderData, T> =
 	| {

--- a/packages/worker/client/route-data.tsx
+++ b/packages/worker/client/route-data.tsx
@@ -20,7 +20,7 @@ import { createRouteLoadLatch } from '#client/route-load-latch.ts'
  * This helper owns everything around that path so a route cannot reintroduce
  * a flash loader by accident:
  *
- * - consume-once of the route's loader-data key for the current location
+ * - consume-once of the route's loader-data key(s) for the current location
  * - the href latch that decides when a *fallback* fetch is needed (the
  *   router's loader failed, a stale refresh after a form POST, a cold SPA
  *   mount without SSR data) and never re-queues an in-flight one
@@ -34,6 +34,10 @@ import { createRouteLoadLatch } from '#client/route-load-latch.ts'
  * `aria-busy` while `pending`, see `renderRoutePendingStatus`); reserve a
  * standalone loading message for `data === null`, which only happens when
  * there has never been anything to show.
+ *
+ * Routes that keep their own closure state (forms, selections, action
+ * feedback) apply `snapshot.data` into that state when its identity changes
+ * and otherwise leave their state model alone.
  */
 
 export type RouteDataSnapshot<T> = {
@@ -49,22 +53,68 @@ export type RouteDataSnapshot<T> = {
 	data: T | null
 	/** `data` belongs to a different location than the one being rendered. */
 	stale: boolean
+	/** The failure behind `kind: 'error'`; null otherwise. */
+	error: Error | null
 }
 
-type RouteDataOptions<K extends keyof AppLoaderData, T> = {
-	/** Loader-data key the route's loader returns (`#universal/loader-data.ts`). */
-	key: K
+const redirectMarker = Symbol('route-data-redirect')
+
+type RouteDataRedirect = { [redirectMarker]: true; to: string }
+
+/**
+ * Return from `load` when the fetch answered with a session problem (401)
+ * and the browser must leave for a full document (login). The route stays
+ * on its current content while the document navigates away.
+ */
+export function routeDataRedirect(to: string): RouteDataRedirect {
+	return { [redirectMarker]: true, to }
+}
+
+function isRouteDataRedirect(value: unknown): value is RouteDataRedirect {
+	return typeof value === 'object' && value !== null && redirectMarker in value
+}
+
+export type RouteDataLoadResult<T> = T | null | RouteDataRedirect
+
+type RouteDataSource<K extends keyof AppLoaderData, T> =
+	| {
+			/** Loader-data key the route's loader returns (`#universal/loader-data.ts`). */
+			key: K
+			/**
+			 * Map a consumed loader payload to route data. Defaults to the
+			 * payload itself when it does not carry `ok: false`.
+			 */
+			fromLoaderData?: (payload: NonNullable<AppLoaderData[K]>) => T | null
+			consume?: never
+	  }
+	| {
+			key?: never
+			fromLoaderData?: never
+			/**
+			 * Routes whose loader returns several keys assemble them here with
+			 * `tryConsumeRouteLoaderData` (all-or-nothing: return null when a
+			 * required key is missing so the fallback fetch loads the full set).
+			 */
+			consume: (handle: Handle, href: string) => T | null
+	  }
+
+type RouteDataOptions<K extends keyof AppLoaderData, T> = RouteDataSource<
+	K,
+	T
+> & {
 	/**
-	 * Fallback fetch for `href`. Return `null` for a 404; throw for any other
-	 * failure. Do not call `handle.update()` inside — the helper schedules the
-	 * render once the result is applied.
+	 * Fallback fetch for `href`. Return `null` for a 404, `routeDataRedirect`
+	 * for a session redirect, and throw for any other failure (the message
+	 * surfaces as `snapshot.error`). Do not call `handle.update()` inside —
+	 * the helper schedules the render once the result is applied.
 	 */
-	load: (href: string, signal: AbortSignal) => Promise<T | null>
+	load: (href: string, signal: AbortSignal) => Promise<RouteDataLoadResult<T>>
 	/**
-	 * Map a consumed loader payload to route data. Defaults to the payload
-	 * itself when it does not carry `ok: false`.
+	 * Which locations share one payload. Defaults to pathname + search. A
+	 * list/detail route whose detail pages reuse the list payload maps them to
+	 * the same key so moving between them is not a new load.
 	 */
-	fromLoaderData?: (payload: NonNullable<AppLoaderData[K]>) => T | null
+	locationKey?: (href: string) => string
 }
 
 function defaultFromLoaderData<T>(payload: unknown): T | null {
@@ -84,30 +134,33 @@ export function createRouteData<
 	T = NonNullable<AppLoaderData[K]>,
 >(options: RouteDataOptions<K, T>) {
 	const latch = createRouteLoadLatch()
-	const fromLoaderData =
-		options.fromLoaderData ??
-		((payload: NonNullable<AppLoaderData[K]>) =>
-			defaultFromLoaderData<T>(payload))
+	const toLocationKey = options.locationKey ?? normalizeRouterHref
 
-	let data: T | null = null
-	/** Location (pathname + search) `data` / `outcome` describe. */
-	let dataHref: string | null = null
-	let outcome: 'ready' | 'not-found' | 'error' | null = null
-	/** Location a fallback fetch is in flight for. */
-	let pendingHref: string | null = null
-	/** Location of the latest render; late completions for others are dropped. */
-	let renderedHref: string | null = null
-
-	function applyLoaded(href: string, result: T | null) {
-		dataHref = href
-		data = result
-		outcome = result === null ? 'not-found' : 'ready'
+	function consume(handle: Handle, currentHref: string): T | null {
+		if (options.consume) return options.consume(handle, currentHref)
+		const payload = tryConsumeRouteLoaderData(handle, options.key, currentHref)
+		if (payload === undefined) return null
+		const fromLoaderData =
+			options.fromLoaderData ??
+			((value: NonNullable<AppLoaderData[K]>) =>
+				defaultFromLoaderData<T>(value))
+		return fromLoaderData(payload as NonNullable<AppLoaderData[K]>)
 	}
 
+	let data: T | null = null
+	/** Location key `data` / `outcome` describe. */
+	let dataKey: string | null = null
+	let outcome: 'ready' | 'not-found' | 'error' | null = null
+	let error: Error | null = null
+	/** Location key a fallback fetch is in flight for. */
+	let pendingKey: string | null = null
+	/** Location key of the latest render; late completions for others are dropped. */
+	let renderedKey: string | null = null
+
 	function queueFallbackLoad(handle: Handle, currentHref: string) {
-		const href = normalizeRouterHref(currentHref)
+		const key = toLocationKey(currentHref)
 		const attempt = latch.getPendingAttempt()
-		pendingHref = href
+		pendingKey = key
 
 		// remix/ui aborts a queued task's signal whenever the component
 		// re-renders for any reason (a shell session refresh, for example).
@@ -115,8 +168,8 @@ export function createRouteData<
 		// route is still on this location, schedule that render ourselves —
 		// otherwise nothing would, and the route would sit in `pending`.
 		function handleAbort() {
-			latch.clearPending(currentHref, attempt)
-			if (renderedHref === href && pendingHref === href) {
+			latch.clearPending(key, attempt)
+			if (renderedKey === key && pendingKey === key) {
 				void handle.update()
 			}
 		}
@@ -128,22 +181,31 @@ export function createRouteData<
 					handleAbort()
 					return
 				}
-				if (renderedHref !== href) return
-				applyLoaded(href, result)
-				pendingHref = null
-				latch.markLoaded(currentHref)
+				if (renderedKey !== key) return
+				if (isRouteDataRedirect(result)) {
+					// Leave the page as is; the document is about to change.
+					window.location.assign(result.to)
+					return
+				}
+				data = result
+				dataKey = key
+				outcome = result === null ? 'not-found' : 'ready'
+				error = null
+				pendingKey = null
+				latch.markLoaded(key)
 				void handle.update()
-			} catch {
+			} catch (caught) {
 				if (signal.aborted) {
 					handleAbort()
 					return
 				}
-				if (renderedHref !== href) return
+				if (renderedKey !== key) return
 				data = null
-				dataHref = href
+				dataKey = key
 				outcome = 'error'
-				pendingHref = null
-				latch.markFailed(currentHref)
+				error = caught instanceof Error ? caught : new Error(String(caught))
+				pendingKey = null
+				latch.markFailed(key)
 				void handle.update()
 			}
 		})
@@ -152,31 +214,22 @@ export function createRouteData<
 	return {
 		/** Call once per render with the router href the route is rendering. */
 		read(handle: Handle, currentHref: string): RouteDataSnapshot<T> {
-			const href = normalizeRouterHref(currentHref)
-			renderedHref = href
+			const key = toLocationKey(currentHref)
+			renderedKey = key
 
-			const payload = tryConsumeRouteLoaderData(
-				handle,
-				options.key,
-				currentHref,
-			)
-			let appliedRouteData = false
-			if (payload !== undefined) {
-				const selected = fromLoaderData(
-					payload as NonNullable<AppLoaderData[K]>,
-				)
-				if (selected !== null) {
-					data = selected
-					dataHref = href
-					outcome = 'ready'
-					pendingHref = null
-					appliedRouteData = true
-				}
+			const consumed = consume(handle, currentHref)
+			const appliedRouteData = consumed !== null
+			if (consumed !== null) {
+				data = consumed
+				dataKey = key
+				outcome = 'ready'
+				error = null
+				pendingKey = null
 			}
 
 			const needsStaleRefresh = consumeStaleNavigationData(currentHref)
 			const needsLoad = latch.needsLoad({
-				currentHref,
+				currentHref: key,
 				appliedRouteData,
 				needsStaleRefresh,
 			})
@@ -184,17 +237,40 @@ export function createRouteData<
 				queueFallbackLoad(handle, currentHref)
 			}
 
-			const stale = data !== null && dataHref !== href
-			if (pendingHref === href) {
-				return { kind: 'pending', data, stale }
+			const stale = data !== null && dataKey !== key
+			if (pendingKey === key) {
+				return { kind: 'pending', data, stale, error: null }
 			}
-			if (dataHref === href && outcome !== null) {
-				return { kind: outcome, data: outcome === 'ready' ? data : null, stale }
+			if (dataKey === key && outcome !== null) {
+				return {
+					kind: outcome,
+					data: outcome === 'ready' ? data : null,
+					stale,
+					error: outcome === 'error' ? error : null,
+				}
 			}
 			// Server render (or a client render before hydration) without a
 			// payload for this location: nothing is in flight yet, but the
 			// route still has nothing current to show.
-			return { kind: 'pending', data, stale }
+			return { kind: 'pending', data, stale, error: null }
+		},
+		/**
+		 * Fetch the current location again (after a mutation the route wants
+		 * to reconcile with the server). The current payload stays on screen
+		 * under `pending` until the fresh one lands. No-op while a fetch for
+		 * this location is already in flight.
+		 */
+		reload(handle: Handle, currentHref: string) {
+			if (typeof document === 'undefined') return
+			const key = toLocationKey(currentHref)
+			if (pendingKey === key) return
+			latch.needsLoad({
+				currentHref: key,
+				appliedRouteData: false,
+				needsStaleRefresh: true,
+			})
+			queueFallbackLoad(handle, currentHref)
+			void handle.update()
 		},
 	}
 }

--- a/packages/worker/client/route-load-latch.node.test.ts
+++ b/packages/worker/client/route-load-latch.node.test.ts
@@ -78,6 +78,47 @@ test('load, fail, navigate, and stale-refresh workflows share one latch', () => 
 	).toBe(true)
 })
 
+test('applied route data on a new location is a completed load, so the corrective render does not refetch', () => {
+	const latch = createRouteLoadLatch()
+	// Full document load of /docs/memory: SSR data applied.
+	latch.markLoaded('/docs/memory')
+	expect(
+		latch.needsLoad({
+			...baseInput,
+			currentHref: '/docs/memory',
+			appliedRouteData: true,
+		}),
+	).toBe(false)
+
+	// SPA navigation to /docs/secrets: the router preloaded the payload, the
+	// route applies it and (as every route does) calls markLoaded before
+	// needsLoad — while the latch still thinks the location is /docs/memory.
+	latch.markLoaded('/docs/secrets')
+	expect(
+		latch.needsLoad({
+			...baseInput,
+			currentHref: '/docs/secrets',
+			appliedRouteData: true,
+		}),
+	).toBe(false)
+	expect(latch.isLoadedFor('/docs/secrets')).toBe(true)
+
+	// The consume helper schedules one corrective render with nothing left to
+	// apply. It must not queue a fetch for data the route already rendered.
+	expect(latch.needsLoad({ ...baseInput, currentHref: '/docs/secrets' })).toBe(
+		false,
+	)
+
+	// A stale refresh for the same location still forces a real reload.
+	expect(
+		latch.needsLoad({
+			...baseInput,
+			currentHref: '/docs/secrets',
+			needsStaleRefresh: true,
+		}),
+	).toBe(true)
+})
+
 test('applied route data and in-page hashes do not force a new load', () => {
 	const latch = createRouteLoadLatch()
 	expect(

--- a/packages/worker/client/route-load-latch.ts
+++ b/packages/worker/client/route-load-latch.ts
@@ -35,13 +35,16 @@ export function createRouteLoadLatch() {
 	let lastSeenHref = ''
 
 	return {
-		/** Record a successful load (or applied preloaded data) for `href`. */
+		/**
+		 * Record a successful fallback load for `href`. Applied route data does
+		 * not need this: `needsLoad({ appliedRouteData: true })` records the
+		 * location itself (calling this first is harmless).
+		 */
 		markLoaded(href: string) {
 			const key = toLatchKey(href)
 			// Ignore late completions after navigating away so they cannot
 			// clobber the active location's loaded/pending markers. Allow
-			// markLoaded before the first needsLoad (applied route data is
-			// often recorded in the same render pass before needsLoad runs).
+			// markLoaded before the first needsLoad (initial render).
 			if (lastSeenHref !== '' && key !== lastSeenHref) return
 			lastLoadedHref = key
 			lastFailedHref = null
@@ -118,7 +121,20 @@ export function createRouteLoadLatch() {
 				lastFailedHref = null
 				lastPendingHref = null
 			}
+			// Applied route data (SSR-embedded or preloaded by the router before
+			// commit) is a completed load for this location. Record it here
+			// rather than relying on the route's own `markLoaded` call: that call
+			// usually runs earlier in the same render pass, while `lastSeenHref`
+			// still names the previous location, so `markLoaded` treats it as a
+			// late completion and ignores it. Without this the corrective render
+			// scheduled by the consume helper sees `currentHref !== lastLoadedHref`,
+			// re-queues a fetch for data the route already has, and the route
+			// flashes its loading state for a full network round trip on every
+			// same-component navigation (docs guide -> guide, post -> post).
 			if (input.appliedRouteData) {
+				lastLoadedHref = currentHref
+				lastFailedHref = null
+				lastPendingHref = null
 				return false
 			}
 			const shouldLoad =

--- a/packages/worker/client/routes/account-activity.tsx
+++ b/packages/worker/client/routes/account-activity.tsx
@@ -3,10 +3,8 @@ import { type Handle, css } from 'remix/ui'
 import { CopyTextButton } from '#client/copy-text-button.tsx'
 import { on } from '#client/event-mixin.ts'
 import { navigate, readCurrentRouterHref } from '#client/client-router.tsx'
-import { createRouteLoadLatch } from '#client/route-load-latch.ts'
 import { replaceLocation } from '#client/replace-location.ts'
-import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
-import { consumeStaleNavigationData } from '#client/navigation-data.ts'
+import { createRouteData, routeDataRedirect } from '#client/route-data.tsx'
 import {
 	type AccountStatus,
 	readJson,
@@ -69,12 +67,7 @@ import { getGhostButtonCss } from '#universal/styles/style-primitives.ts'
 
 const clampedCellCss = css(recordCellClamp(30))
 
-function tryConsumeAccountActivityLoaderData(handle: Handle, href: string) {
-	return tryConsumeRouteLoaderData(handle, 'accountActivity', href)
-}
-
 export function AccountActivityRoute(handle: Handle) {
-	let status: AccountStatus = 'loading'
 	let runs: Array<AccountActivityRunListItem> = []
 	let selectedRun: AccountActivityRunDetail | null = null
 	let summary: AccountActivitySummary | null = null
@@ -82,7 +75,26 @@ export function AccountActivityRoute(handle: Handle) {
 	let retentionDays = 30
 	let message: string | null = null
 	let loadingMore = false
-	const loadLatch = createRouteLoadLatch()
+	/** Payload last applied to the closure state above. */
+	let appliedPayload: AccountActivityLoaderData | null = null
+	let appliedError: Error | null = null
+	const activityData = createRouteData({
+		key: 'accountActivity',
+		locationKey: getDataLatchKey,
+		async load(href, signal) {
+			const response = await fetch(buildActivityApiRequestUrl(href), {
+				headers: { Accept: 'application/json' },
+				credentials: 'include',
+				signal,
+			})
+			if (response.status === 401) return routeDataRedirect('/login')
+			const payload = await readJson<AccountActivityLoaderData>(response)
+			if (!response.ok || !payload?.ok) {
+				throw new Error('Unable to load activity.')
+			}
+			return payload
+		},
+	})
 	const secondaryButtonCss = getGhostButtonCss({ size: 'sm' })
 
 	function getCurrentHref() {
@@ -107,41 +119,6 @@ export function AccountActivityRoute(handle: Handle) {
 		summary = payload.summary
 		nextCursor = payload.nextCursor
 		retentionDays = payload.retentionDays
-	}
-
-	async function loadActivity(signal: AbortSignal) {
-		const href = getCurrentHref()
-		const latchKey = getDataLatchKey(href)
-		try {
-			const response = await fetch(buildActivityApiRequestUrl(href), {
-				headers: { Accept: 'application/json' },
-				credentials: 'include',
-				signal,
-			})
-			if (signal.aborted) return
-			if (response.status === 401) {
-				window.location.assign('/login')
-				return
-			}
-			const payload = await readJson<AccountActivityLoaderData>(response)
-			if (!response.ok || !payload?.ok) {
-				throw new Error('Unable to load activity.')
-			}
-			if (getDataLatchKey(getCurrentHref()) !== latchKey) return
-			applyPayload(payload)
-			setMessage(null)
-			status = 'ready'
-			loadLatch.markLoaded(latchKey)
-			handle.update()
-		} catch (error) {
-			if (signal.aborted) return
-			status = 'error'
-			setMessage(
-				error instanceof Error ? error.message : 'Unable to load activity.',
-			)
-			loadLatch.markFailed(latchKey)
-			handle.update()
-		}
 	}
 
 	async function loadMoreRuns() {
@@ -179,16 +156,6 @@ export function AccountActivityRoute(handle: Handle) {
 		}
 	}
 
-	function applyRouteLoaderData(href: string) {
-		if (!activityRoute.isRoutePath(href)) return false
-		const routeData = tryConsumeAccountActivityLoaderData(handle, href)
-		if (!routeData) return false
-		applyPayload(routeData)
-		status = 'ready'
-		loadLatch.markLoaded(getDataLatchKey(href))
-		return true
-	}
-
 	function updateFilters(input: {
 		view?: AccountActivityViewFilter
 		status?: AccountActivityStatusFilter
@@ -223,18 +190,23 @@ export function AccountActivityRoute(handle: Handle) {
 
 	return () => {
 		const currentHref = getCurrentHref()
-		const appliedRouteData = applyRouteLoaderData(currentHref)
-		const needsStaleRefresh =
-			consumeStaleNavigationData(currentHref) && !appliedRouteData
-		const latchKey = getDataLatchKey(currentHref)
-		const needsLoad = loadLatch.needsLoad({
-			currentHref: latchKey,
-			appliedRouteData,
-			needsStaleRefresh,
-		})
-		if (needsLoad && typeof document !== 'undefined') {
-			handle.queueTask(loadActivity)
+		const snapshot = activityData.read(handle, currentHref)
+		if (snapshot.data && snapshot.data !== appliedPayload) {
+			appliedPayload = snapshot.data
+			applyPayload(snapshot.data)
+			setMessage(null)
 		}
+		if (snapshot.error && snapshot.error !== appliedError) {
+			appliedError = snapshot.error
+			setMessage(snapshot.error.message)
+		}
+		const pending = snapshot.kind === 'pending'
+		const status: AccountStatus =
+			snapshot.kind === 'error'
+				? 'error'
+				: pending && appliedPayload === null
+					? 'loading'
+					: 'ready'
 
 		const selection = activityRoute.getSelection(currentHref)
 		const viewFilter = readViewFilter(currentHref)
@@ -256,7 +228,7 @@ export function AccountActivityRoute(handle: Handle) {
 		const waitingForDetail =
 			selection.selectedId != null &&
 			!detail &&
-			(needsLoad || listMatch != null || status === 'loading')
+			(pending || listMatch != null || status === 'loading')
 		const showRunNotFound =
 			selection.selectedId != null &&
 			!detail &&
@@ -272,7 +244,7 @@ export function AccountActivityRoute(handle: Handle) {
 		})
 
 		return (
-			<AccountManagementShell>
+			<AccountManagementShell busy={pending && appliedPayload !== null}>
 				<AccountPageHeader
 					title="Activity"
 					description="Open failures first, plus a Recent runs week of jobs, executes, package apps, webhooks, and workflows — with the logs you need to diagnose them."

--- a/packages/worker/client/routes/account-billing.tsx
+++ b/packages/worker/client/routes/account-billing.tsx
@@ -6,9 +6,7 @@ import {
 	type AdminPlanName,
 } from '#universal/loader-data.ts'
 import { readCurrentRouterHref } from '#client/client-router.tsx'
-import { createRouteLoadLatch } from '#client/route-load-latch.ts'
-import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
-import { consumeStaleNavigationData } from '#client/navigation-data.ts'
+import { createRouteData, routeDataRedirect } from '#client/route-data.tsx'
 import {
 	type AccountStatus,
 	readJson,
@@ -58,7 +56,6 @@ const jsonRequestHeaders = {
 }
 const billingCancellationFeedbackApiPath =
 	'/account/billing/cancellation-feedback.json'
-const billingPath = '/account/billing'
 const billingPortalPath = '/account/billing/portal'
 
 type SubscriptionStatusTone = 'ok' | 'warn' | 'action' | 'muted'
@@ -67,10 +64,6 @@ type CheckoutMode = 'checkout' | 'portal_update' | 'portal'
 
 const multipleSubscriptionsMessage =
 	'You have more than one active Stripe subscription, so plan changes are handled in the Stripe portal. Opening Stripe…'
-
-function isBillingPath(href: string) {
-	return new URL(href, 'http://localhost').pathname === billingPath
-}
 
 /** Stripe missing → "None"; manual/effective compatibility missing → "Free". */
 function formatPlanLabel(
@@ -203,8 +196,6 @@ export async function accountBillingRouteLoader(
 }
 
 export function AccountBillingRoute(handle: Handle) {
-	let status: AccountStatus = 'loading'
-	let data: AccountBillingLoaderData | null = null
 	let message: string | null = null
 	let messageTone: 'error' | 'info' = 'info'
 	let checkoutPending: CheckoutPending = null
@@ -216,11 +207,27 @@ export function AccountBillingRoute(handle: Handle) {
 		standard: 'month',
 		pro: 'month',
 	}
-	const loadLatch = createRouteLoadLatch()
+	/** Payload last applied to the closure state above. */
+	let appliedPayload: AccountBillingLoaderData | null = null
+	let appliedError: Error | null = null
+	const billingData = createRouteData({
+		key: 'accountBilling',
+		async load(_href, signal) {
+			const response = await fetch(billingApiPath, {
+				headers: { Accept: 'application/json' },
+				credentials: 'include',
+				signal,
+			})
+			if (response.status === 401) return routeDataRedirect('/login')
+			const payload = await readJson<AccountBillingLoaderData>(response)
+			if (!response.ok || !payload?.ok) {
+				throw new Error('Unable to load billing.')
+			}
+			return payload
+		},
+	})
 
 	function applyPayload(payload: AccountBillingLoaderData) {
-		data = payload
-		status = 'ready'
 		message = payload.error ?? payload.notice ?? null
 		messageTone = payload.error ? 'error' : 'info'
 	}
@@ -305,61 +312,27 @@ export function AccountBillingRoute(handle: Handle) {
 		handle.update()
 	}
 
-	async function loadBilling(signal: AbortSignal) {
-		const href = readCurrentRouterHref(handle)
-		try {
-			const response = await fetch(billingApiPath, {
-				headers: { Accept: 'application/json' },
-				credentials: 'include',
-				signal,
-			})
-			if (signal.aborted) return
-			if (response.status === 401) {
-				window.location.assign('/login')
-				return
-			}
-			const payload = await readJson<AccountBillingLoaderData>(response)
-			if (!response.ok || !payload?.ok) {
-				throw new Error('Unable to load billing.')
-			}
-			applyPayload(payload)
-			loadLatch.markLoaded(href)
-			handle.update()
-		} catch (error) {
-			if (signal.aborted) return
-			status = 'error'
-			message =
-				error instanceof Error ? error.message : 'Unable to load billing.'
-			messageTone = 'error'
-			loadLatch.markFailed(href)
-			handle.update()
-		}
-	}
-
-	function applyRouteLoaderData(href: string) {
-		if (!isBillingPath(href)) return false
-		const routeData = tryConsumeRouteLoaderData(handle, 'accountBilling', href)
-		if (!routeData) return false
-		applyPayload(routeData)
-		loadLatch.markLoaded(href)
-		return true
-	}
-
 	return () => {
 		const currentHref = readCurrentRouterHref(handle)
-		const appliedRouteData = applyRouteLoaderData(currentHref)
-		const needsStaleRefresh =
-			consumeStaleNavigationData(currentHref) && !appliedRouteData
-		const needsLoad = loadLatch.needsLoad({
-			currentHref,
-			appliedRouteData,
-			needsStaleRefresh,
-		})
-		if (needsLoad && typeof document !== 'undefined') {
-			handle.queueTask(loadBilling)
+		const snapshot = billingData.read(handle, currentHref)
+		if (snapshot.data && snapshot.data !== appliedPayload) {
+			appliedPayload = snapshot.data
+			applyPayload(snapshot.data)
 		}
+		if (snapshot.error && snapshot.error !== appliedError) {
+			appliedError = snapshot.error
+			message = snapshot.error.message
+			messageTone = 'error'
+		}
+		const pending = snapshot.kind === 'pending'
+		const status: AccountStatus =
+			snapshot.kind === 'error'
+				? 'error'
+				: pending && appliedPayload === null
+					? 'loading'
+					: 'ready'
 
-		const billing = status === 'ready' ? data : null
+		const billing = snapshot.data
 		const subscriptionStatus = billing?.subscriptionStatus?.trim() || null
 		const statusInfo = subscriptionStatus
 			? describeSubscriptionStatus(subscriptionStatus)
@@ -387,7 +360,10 @@ export function AccountBillingRoute(handle: Handle) {
 			: []
 
 		return (
-			<AccountManagementShell maxWidth={layoutMaxWidths.content}>
+			<AccountManagementShell
+				maxWidth={layoutMaxWidths.content}
+				busy={pending && appliedPayload !== null}
+			>
 				<AccountPageHeader
 					title="Billing"
 					description="View your plan, subscribe to Standard or Pro, manage your Stripe subscription, and share your referral link."

--- a/packages/worker/client/routes/account-email-shared.ts
+++ b/packages/worker/client/routes/account-email-shared.ts
@@ -1,6 +1,4 @@
-import { type Handle } from 'remix/ui'
 import { createListDetailRoute } from '#client/list-detail-route.ts'
-import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
 import { readJson } from '#client/routes/account-approval-shared.ts'
 import {
 	routeLoaderRedirect,
@@ -143,8 +141,4 @@ export function directionLabel(
 	direction: AccountEmailMessageListItem['direction'],
 ) {
 	return direction === 'outbound' ? 'Outbound' : 'Inbound'
-}
-
-export function consumeAccountEmailPayload(handle: Handle, href: string) {
-	return tryConsumeRouteLoaderData(handle, 'accountEmail', href)
 }

--- a/packages/worker/client/routes/account-email.tsx
+++ b/packages/worker/client/routes/account-email.tsx
@@ -5,7 +5,7 @@ import { on } from '#client/event-mixin.ts'
 import { navigate, readCurrentRouterHref } from '#client/client-router.tsx'
 import { replaceLocation } from '#client/replace-location.ts'
 import { createDoubleCheck } from '#client/double-check.ts'
-import { consumeStaleNavigationData } from '#client/navigation-data.ts'
+import { createRouteData, routeDataRedirect } from '#client/route-data.tsx'
 import { acceptedEmailVerificationDelivery } from '#universal/email-verification-delivery.ts'
 import { readJson } from '#client/routes/account-approval-shared.ts'
 import {
@@ -38,7 +38,6 @@ import {
 	accountEmailRouteLoader,
 	buildEmailApiRequestUrl,
 	clampedCellCss,
-	consumeAccountEmailPayload,
 	directionLabel,
 	emailRoute,
 	getDataKey,
@@ -55,7 +54,6 @@ import {
 export { accountEmailRouteLoader }
 
 export function AccountEmailRoute(handle: Handle) {
-	let status: PageStatus = 'loading'
 	let data: AccountEmailLoaderData | null = null
 	let message: string | null = null
 	let messageTone: 'error' | 'info' = 'info'
@@ -66,10 +64,26 @@ export function AccountEmailRoute(handle: Handle) {
 	let resendMessage: string | null = null
 	let resendTone: 'error' | 'info' = 'info'
 	let resendAccepted = false
-	let loadRequestId = 0
-	let lastLoadedDataKey = ''
-	let loadingDataKey: string | null = null
-	let lastFailedDataKey: string | null = null
+	/** Payload last applied from the route data snapshot (mutations update `data` directly). */
+	let appliedPayload: AccountEmailLoaderData | null = null
+	let appliedError: Error | null = null
+	const emailData = createRouteData({
+		key: 'accountEmail',
+		locationKey: getDataKey,
+		async load(href, signal) {
+			const response = await fetch(buildEmailApiRequestUrl(href), {
+				headers: { Accept: 'application/json' },
+				credentials: 'include',
+				signal,
+			})
+			if (response.status === 401) return routeDataRedirect('/login')
+			const payload = await readJson<AccountEmailLoaderData>(response)
+			if (!response.ok || !payload?.ok) {
+				throw new Error('Unable to load your email inbox.')
+			}
+			return payload
+		},
+	})
 
 	const secondaryButtonCss = getGhostButtonCss({ size: 'sm' })
 
@@ -113,9 +127,6 @@ export function AccountEmailRoute(handle: Handle) {
 				? 'Message not found.'
 				: null
 		messageTone = selectedId && !payload.selectedMessage ? 'error' : 'info'
-		status = 'ready'
-		lastLoadedDataKey = getDataKey(href)
-		lastFailedDataKey = null
 	}
 
 	async function handleResendVerification() {
@@ -249,83 +260,25 @@ export function AccountEmailRoute(handle: Handle) {
 		}
 	}
 
-	async function loadAccountEmail() {
-		const href = getCurrentHref()
-		const dataKey = getDataKey(href)
-		loadingDataKey = dataKey
-		const requestId = ++loadRequestId
-		try {
-			const response = await fetch(buildEmailApiRequestUrl(href), {
-				headers: { Accept: 'application/json' },
-				credentials: 'include',
-			})
-			if (
-				requestId !== loadRequestId ||
-				getDataKey(getCurrentHref()) !== dataKey
-			)
-				return
-			if (response.status === 401) {
-				window.location.assign('/login')
-				return
-			}
-			const payload = await readJson<AccountEmailLoaderData>(response)
-			if (!response.ok || !payload?.ok) {
-				throw new Error('Unable to load your email inbox.')
-			}
-			applyPayload(payload, href)
-			handle.update()
-		} catch (error) {
-			if (
-				requestId !== loadRequestId ||
-				getDataKey(getCurrentHref()) !== dataKey
-			)
-				return
-			status = 'error'
-			message =
-				error instanceof Error
-					? error.message
-					: 'Unable to load your email inbox.'
-			messageTone = 'error'
-			lastFailedDataKey = dataKey
-			handle.update()
-		} finally {
-			if (requestId === loadRequestId && loadingDataKey === dataKey) {
-				loadingDataKey = null
-			}
-		}
-	}
-
-	function applyRouteLoaderData(href: string) {
-		if (!emailRoute.isRoutePath(href)) return false
-		const routeData = consumeAccountEmailPayload(handle, href)
-		if (!routeData) return false
-		applyPayload(routeData, href)
-		return true
-	}
-
-	let lastSeenDataKey = ''
-
 	return () => {
 		const currentHref = getCurrentHref()
-		const currentDataKey = getDataKey(currentHref)
-		if (currentDataKey !== lastSeenDataKey) {
-			lastSeenDataKey = currentDataKey
-			lastFailedDataKey = null
+		const snapshot = emailData.read(handle, currentHref)
+		if (snapshot.data && snapshot.data !== appliedPayload) {
+			appliedPayload = snapshot.data
+			applyPayload(snapshot.data, currentHref)
 		}
-		const appliedRouteData = applyRouteLoaderData(currentHref)
-		const needsStaleRefresh =
-			consumeStaleNavigationData(currentHref) && !appliedRouteData
-		const needsLoad =
-			(status === 'loading' ||
-				currentDataKey !== lastLoadedDataKey ||
-				needsStaleRefresh) &&
-			currentDataKey !== lastFailedDataKey &&
-			loadingDataKey !== currentDataKey
-		if (!appliedRouteData && needsLoad && typeof document !== 'undefined') {
-			status = 'loading'
-			loadingDataKey = currentDataKey
-			handle.queueTask(loadAccountEmail)
+		if (snapshot.error && snapshot.error !== appliedError) {
+			appliedError = snapshot.error
+			message = snapshot.error.message
+			messageTone = 'error'
 		}
+		const pending = snapshot.kind === 'pending'
+		const status: PageStatus =
+			snapshot.kind === 'error'
+				? 'error'
+				: pending && data === null
+					? 'loading'
+					: 'ready'
 
 		const selectedMessageId = emailRoute.getSelection(currentHref).selectedId
 		const selectedMessage: AccountEmailMessageDetail | null =
@@ -342,13 +295,16 @@ export function AccountEmailRoute(handle: Handle) {
 		const showUnverified = data != null && !data.emailVerified
 
 		return (
-			<AccountManagementShell maxWidth="min(100%, 92rem)">
+			<AccountManagementShell
+				maxWidth="min(100%, 92rem)"
+				busy={pending && data !== null}
+			>
 				<AccountPageHeader
 					title="Email inbox"
 					description="Browse inbound and outbound messages for your platform email address. Compose and reply through Kody agents."
 					currentHref={currentHref}
 				/>
-				{status === 'loading' && lastLoadedDataKey === '' ? (
+				{status === 'loading' ? (
 					<p mix={css({ color: colors.textMuted, margin: 0 })}>
 						Loading email inbox…
 					</p>
@@ -400,7 +356,7 @@ export function AccountEmailRoute(handle: Handle) {
 						) : null}
 						<RecordTable
 							mode="expand"
-							busy={status === 'loading'}
+							busy={pending}
 							ariaLabel="Inbox messages"
 							selectedId={selectedMessageId}
 							countLabel={

--- a/packages/worker/client/routes/account-integrations.tsx
+++ b/packages/worker/client/routes/account-integrations.tsx
@@ -9,10 +9,12 @@ import { navigate, readCurrentRouterHref } from '#client/client-router.tsx'
 import { createDoubleCheck } from '#client/double-check.ts'
 import { createUndoableAction } from '#client/undoable-action.ts'
 import { UndoToast } from '#client/undo-toast.tsx'
-import { createRouteLoadLatch } from '#client/route-load-latch.ts'
 import { replaceLocation } from '#client/replace-location.ts'
-import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
-import { consumeStaleNavigationData } from '#client/navigation-data.ts'
+import {
+	type RouteDataSnapshot,
+	createRouteData,
+	routeDataRedirect,
+} from '#client/route-data.tsx'
 import {
 	type AccountStatus,
 	readJson,
@@ -56,7 +58,6 @@ import {
 export { accountIntegrationsRouteLoader } from '#client/routes/account-integrations-shared.ts'
 
 export function AccountIntegrationsRoute(handle: Handle) {
-	let status: AccountStatus = 'loading'
 	let integrations: Array<AccountIntegrationListItem> = []
 	let apps: Array<AccountOauthAppListItem> = []
 	let savedPackages: Array<{ id: string; kodyId: string }> = []
@@ -65,7 +66,28 @@ export function AccountIntegrationsRoute(handle: Handle) {
 	let usageSavingName: string | null = null
 	let approvalSubmitting = false
 	let message: string | null = null
-	const loadLatch = createRouteLoadLatch()
+	/** Payload last applied to the closure state above. */
+	let appliedPayload: AccountIntegrationsLoaderData | null = null
+	let appliedError: Error | null = null
+	let lastSnapshot: RouteDataSnapshot<AccountIntegrationsLoaderData> | null =
+		null
+	const integrationsData = createRouteData({
+		key: 'accountIntegrations',
+		locationKey: getDataLatchKey,
+		async load(href, signal) {
+			const response = await fetch(buildIntegrationsApiHref(href), {
+				headers: { Accept: 'application/json' },
+				credentials: 'include',
+				signal,
+			})
+			if (response.status === 401) return routeDataRedirect('/login')
+			const payload = await readJson<AccountIntegrationsLoaderData>(response)
+			if (!response.ok || !payload?.ok) {
+				throw new Error('Unable to load integrations.')
+			}
+			return payload
+		},
+	})
 	const disconnectChecks = new Map<
 		string,
 		ReturnType<typeof createDoubleCheck>
@@ -348,83 +370,39 @@ export function AccountIntegrationsRoute(handle: Handle) {
 		handle.update()
 	}
 
-	async function loadIntegrations(signal: AbortSignal) {
-		const href = getCurrentHref()
-		const latchKey = getDataLatchKey(href)
-		try {
-			const response = await fetch(buildIntegrationsApiHref(href), {
-				headers: { Accept: 'application/json' },
-				credentials: 'include',
-				signal,
-			})
-			if (signal.aborted) return
-			if (response.status === 401) {
-				window.location.assign('/login')
-				return
-			}
-			const payload = await readJson<AccountIntegrationsLoaderData>(response)
-			if (!response.ok || !payload?.ok) {
-				throw new Error('Unable to load integrations.')
-			}
-			if (getDataLatchKey(getCurrentHref()) !== latchKey) return
-			integrations = payload.integrations
-			apps = payload.apps ?? []
-			savedPackages = payload.savedPackages ?? []
-			approval = payload.approval ?? null
-			status = 'ready'
-			message = null
-			loadLatch.markLoaded(latchKey)
-			handle.update()
-		} catch (error) {
-			if (signal.aborted) return
-			status = 'error'
-			message =
-				error instanceof Error ? error.message : 'Unable to load integrations.'
-			loadLatch.markFailed(latchKey)
-			handle.update()
-		}
-	}
-
-	function applyRouteLoaderData(href: string) {
-		if (isHoldingOptimisticRemoval()) return false
-		if (!integrationsRoute.isRoutePath(href)) return false
-		const routeData = tryConsumeRouteLoaderData(
-			handle,
-			'accountIntegrations',
-			href,
-		)
-		if (!routeData) return false
-		integrations = routeData.integrations
-		apps = routeData.apps ?? []
-		savedPackages = routeData.savedPackages ?? []
-		approval = routeData.approval ?? null
-		status = 'ready'
+	function applyPayload(payload: AccountIntegrationsLoaderData) {
+		integrations = payload.integrations
+		apps = payload.apps ?? []
+		savedPackages = payload.savedPackages ?? []
+		approval = payload.approval ?? null
 		message = null
-		loadLatch.markLoaded(getDataLatchKey(href))
-		return true
 	}
 
 	return () => {
 		const currentHref = getCurrentHref()
-		const appliedRouteData = applyRouteLoaderData(currentHref)
-		// Hold optimistic list state for the undo window. Do not consume a
-		// stale-refresh or latch a load — both would clobber the removal or
-		// block the next fetch after undo.
-		const needsStaleRefresh =
-			!isHoldingOptimisticRemoval() &&
-			consumeStaleNavigationData(currentHref) &&
-			!appliedRouteData
-		const latchKey = getDataLatchKey(currentHref)
-		const needsLoad =
-			!isHoldingOptimisticRemoval() &&
-			loadLatch.needsLoad({
-				currentHref: latchKey,
-				appliedRouteData,
-				needsStaleRefresh,
-			})
-		if (needsLoad && typeof document !== 'undefined') {
-			handle.queueTask(loadIntegrations)
+		// Hold optimistic list state for the undo window. Do not consume loader
+		// data or a stale-refresh, and do not latch a load — all would clobber
+		// the removal or block the next fetch after undo.
+		const snapshot =
+			isHoldingOptimisticRemoval() && lastSnapshot
+				? lastSnapshot
+				: integrationsData.read(handle, currentHref)
+		lastSnapshot = snapshot
+		if (snapshot.data && snapshot.data !== appliedPayload) {
+			appliedPayload = snapshot.data
+			applyPayload(snapshot.data)
 		}
+		if (snapshot.error && snapshot.error !== appliedError) {
+			appliedError = snapshot.error
+			message = snapshot.error.message
+		}
+		const pending = snapshot.kind === 'pending'
+		const status: AccountStatus =
+			snapshot.kind === 'error'
+				? 'error'
+				: pending && appliedPayload === null
+					? 'loading'
+					: 'ready'
 
 		const search = readSearchFilter(currentHref)
 		const setupIntro =
@@ -453,7 +431,7 @@ export function AccountIntegrationsRoute(handle: Handle) {
 			: null
 
 		return (
-			<AccountManagementShell>
+			<AccountManagementShell busy={pending && appliedPayload !== null}>
 				<AccountPageHeader
 					title="Integrations"
 					description="Services you connect so Kody can use them."

--- a/packages/worker/client/routes/account-jobs.tsx
+++ b/packages/worker/client/routes/account-jobs.tsx
@@ -2,10 +2,8 @@ import { type Handle, css } from 'remix/ui'
 import { on } from '#client/event-mixin.ts'
 import { navigate, readCurrentRouterHref } from '#client/client-router.tsx'
 import { createDoubleCheck } from '#client/double-check.ts'
-import { createRouteLoadLatch } from '#client/route-load-latch.ts'
 import { replaceLocation } from '#client/replace-location.ts'
-import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
-import { consumeStaleNavigationData } from '#client/navigation-data.ts'
+import { createRouteData, routeDataRedirect } from '#client/route-data.tsx'
 import {
 	type AccountStatus,
 	readJson,
@@ -64,12 +62,7 @@ const clampedCellCss = css(recordCellClamp(28))
 
 type MessageTone = 'info' | 'error'
 
-function tryConsumeAccountJobsLoaderData(handle: Handle, href: string) {
-	return tryConsumeRouteLoaderData(handle, 'accountJobs', href)
-}
-
 export function AccountJobsRoute(handle: Handle) {
-	let status: AccountStatus = 'loading'
 	let actionState: 'idle' | 'busy' = 'idle'
 	let username = ''
 	let jobs: Array<AccountJobListItem> = []
@@ -91,8 +84,27 @@ export function AccountJobsRoute(handle: Handle) {
 	}
 	let message: string | null = null
 	let messageTone: MessageTone = 'info'
-	const loadLatch = createRouteLoadLatch()
+	/** Payload last applied to the closure state above. */
+	let appliedPayload: AccountJobsLoaderData | null = null
+	let appliedError: Error | null = null
 	const deleteJobCheck = createDoubleCheck(handle)
+	const jobsData = createRouteData({
+		key: 'accountJobs',
+		locationKey: getDataLatchKey,
+		async load(href, signal) {
+			const response = await fetch(buildJobsApiRequestUrl(href), {
+				headers: { Accept: 'application/json' },
+				credentials: 'include',
+				signal,
+			})
+			if (response.status === 401) return routeDataRedirect('/login')
+			const payload = await readJson<AccountJobsLoaderData>(response)
+			if (!response.ok || !payload?.ok) {
+				throw new Error('Unable to load scheduled jobs.')
+			}
+			return payload
+		},
+	})
 
 	const secondaryButtonCss = getGhostButtonCss({ size: 'sm' })
 
@@ -138,44 +150,6 @@ export function AccountJobsRoute(handle: Handle) {
 		selectedJob = payload.selectedJob
 		applyRetention(payload.retention)
 		deleteJobCheck.reset()
-	}
-
-	async function loadJobs(signal: AbortSignal) {
-		const href = getCurrentHref()
-		const latchKey = getDataLatchKey(href)
-		try {
-			const response = await fetch(buildJobsApiRequestUrl(href), {
-				headers: { Accept: 'application/json' },
-				credentials: 'include',
-				signal,
-			})
-			if (signal.aborted) return
-			if (response.status === 401) {
-				window.location.assign('/login')
-				return
-			}
-			const payload = await readJson<AccountJobsLoaderData>(response)
-			if (!response.ok || !payload?.ok) {
-				throw new Error('Unable to load scheduled jobs.')
-			}
-			if (getDataLatchKey(getCurrentHref()) !== latchKey) return
-			applyPayload(payload)
-			if (messageTone === 'error') setMessage(null)
-			status = 'ready'
-			loadLatch.markLoaded(latchKey)
-			handle.update()
-		} catch (error) {
-			if (signal.aborted) return
-			status = 'error'
-			setMessage(
-				error instanceof Error
-					? error.message
-					: 'Unable to load scheduled jobs.',
-				'error',
-			)
-			loadLatch.markFailed(latchKey)
-			handle.update()
-		}
 	}
 
 	async function postAction(input: {
@@ -226,30 +200,25 @@ export function AccountJobsRoute(handle: Handle) {
 		}
 	}
 
-	function applyRouteLoaderData(href: string) {
-		if (!jobsRoute.isRoutePath(href)) return false
-		const routeData = tryConsumeAccountJobsLoaderData(handle, href)
-		if (!routeData) return false
-		applyPayload(routeData)
-		status = 'ready'
-		loadLatch.markLoaded(getDataLatchKey(href))
-		return true
-	}
-
 	return () => {
 		const currentHref = getCurrentHref()
-		const appliedRouteData = applyRouteLoaderData(currentHref)
-		const needsStaleRefresh =
-			consumeStaleNavigationData(currentHref) && !appliedRouteData
-		const latchKey = getDataLatchKey(currentHref)
-		const needsLoad = loadLatch.needsLoad({
-			currentHref: latchKey,
-			appliedRouteData,
-			needsStaleRefresh,
-		})
-		if (needsLoad && typeof document !== 'undefined') {
-			handle.queueTask(loadJobs)
+		const snapshot = jobsData.read(handle, currentHref)
+		if (snapshot.data && snapshot.data !== appliedPayload) {
+			appliedPayload = snapshot.data
+			applyPayload(snapshot.data)
+			if (messageTone === 'error') setMessage(null)
 		}
+		if (snapshot.error && snapshot.error !== appliedError) {
+			appliedError = snapshot.error
+			setMessage(snapshot.error.message, 'error')
+		}
+		const pending = snapshot.kind === 'pending'
+		const status: AccountStatus =
+			snapshot.kind === 'error'
+				? 'error'
+				: pending && appliedPayload === null
+					? 'loading'
+					: 'ready'
 		const isMutating = actionState !== 'idle'
 		const selection = jobsRoute.getSelection(currentHref)
 		const search = readJobsSearchFilter(currentHref)
@@ -273,7 +242,7 @@ export function AccountJobsRoute(handle: Handle) {
 		const waitingForDetail =
 			selection.selectedId != null &&
 			!detail &&
-			(needsLoad || listMatch != null || status === 'loading')
+			(pending || listMatch != null || status === 'loading')
 		const showJobNotFound =
 			selection.selectedId != null &&
 			!detail &&
@@ -281,7 +250,7 @@ export function AccountJobsRoute(handle: Handle) {
 			status === 'ready'
 
 		return (
-			<AccountManagementShell>
+			<AccountManagementShell busy={pending && appliedPayload !== null}>
 				<AccountPageHeader
 					title="Jobs"
 					description="Inspect scheduled package jobs, toggle kill switch or Preserve, and run jobs now. Completed one-off jobs are cleaned up automatically after your retention windows; longer retention uses more scheduled job slots and storage."

--- a/packages/worker/client/routes/account-management-components.tsx
+++ b/packages/worker/client/routes/account-management-components.tsx
@@ -16,6 +16,7 @@ import {
 	layoutMaxWidths,
 	pageGutter,
 } from '#universal/styles/style-primitives.ts'
+import { renderRoutePendingStatus } from '#client/route-data.tsx'
 import { EntityExplainer, resolveEntityExplainer } from './entity-explainer.tsx'
 
 /*
@@ -146,6 +147,14 @@ type AccountManagementShellProps = {
 	 * pages whose forms read better on a narrower measure.
 	 */
 	maxWidth?: string
+	/**
+	 * The route is refetching this location while its last good content stays
+	 * on screen (`createRouteData` snapshot `pending` with data). Marks the
+	 * shell `aria-busy` and announces it to assistive tech without moving
+	 * layout. Leave unset on the cold path where the route shows its own
+	 * loading copy.
+	 */
+	busy?: boolean
 	children: AccountManagementSlot
 }
 
@@ -162,6 +171,7 @@ export function AccountManagementShell(
 	return () => (
 		<section
 			data-account-shell
+			aria-busy={handle.props.busy ? 'true' : undefined}
 			mix={css({
 				maxWidth: layoutMaxWidths.extended,
 				margin: '0 auto',
@@ -220,6 +230,7 @@ export function AccountManagementShell(
 					: {}),
 			})}
 		>
+			{handle.props.busy ? renderRoutePendingStatus() : null}
 			{handle.props.children}
 		</section>
 	)

--- a/packages/worker/client/routes/account-mcp-oauth-clients.tsx
+++ b/packages/worker/client/routes/account-mcp-oauth-clients.tsx
@@ -1,9 +1,7 @@
 import { type Handle, css } from 'remix/ui'
 import { on } from '#client/event-mixin.ts'
 import { readCurrentRouterHref } from '#client/client-router.tsx'
-import { createRouteLoadLatch } from '#client/route-load-latch.ts'
-import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
-import { consumeStaleNavigationData } from '#client/navigation-data.ts'
+import { createRouteData, routeDataRedirect } from '#client/route-data.tsx'
 import {
 	type AccountStatus,
 	readJson,
@@ -38,14 +36,9 @@ import {
 import { type AccountMcpOauthClientsLoaderData } from '#universal/loader-data.ts'
 
 const clientsApiPath = '/account/mcp-oauth-clients.json'
-const clientsPath = '/account/mcp-oauth-clients'
 
 type CreatedClient = AccountMcpOauthClientsLoaderData['clients'][number] & {
 	clientSecret: string
-}
-
-function isClientsPath(href: string) {
-	return new URL(href, 'http://localhost').pathname === clientsPath
 }
 
 export async function accountMcpOauthClientsRouteLoader(
@@ -68,7 +61,6 @@ export async function accountMcpOauthClientsRouteLoader(
 }
 
 export function AccountMcpOauthClientsRoute(handle: Handle) {
-	let status: AccountStatus = 'loading'
 	let actionStatus: 'idle' | 'busy' = 'idle'
 	let clients: AccountMcpOauthClientsLoaderData['clients'] = []
 	let message: string | null = null
@@ -76,7 +68,25 @@ export function AccountMcpOauthClientsRoute(handle: Handle) {
 	let labelDraft = 'Open WebUI'
 	let redirectUrisDraft = ''
 	let createdClient: CreatedClient | null = null
-	const loadLatch = createRouteLoadLatch()
+	/** Payload last applied to the closure state above. */
+	let appliedPayload: AccountMcpOauthClientsLoaderData | null = null
+	let appliedError: Error | null = null
+	const clientsData = createRouteData({
+		key: 'accountMcpOauthClients',
+		async load(_href, signal) {
+			const response = await fetch(clientsApiPath, {
+				headers: { Accept: 'application/json' },
+				credentials: 'include',
+				signal,
+			})
+			if (response.status === 401) return routeDataRedirect('/login')
+			const payload = await readJson<AccountMcpOauthClientsLoaderData>(response)
+			if (!response.ok || !payload?.ok) {
+				throw new Error('Unable to load MCP OAuth clients.')
+			}
+			return payload
+		},
+	})
 	const revokeChecks = new Map<string, ReturnType<typeof createDoubleCheck>>()
 	const primaryButtonCss = getPillButtonCss({ size: 'sm' })
 
@@ -89,42 +99,6 @@ export function AccountMcpOauthClientsRoute(handle: Handle) {
 	}
 	const ghostButtonCss = getGhostButtonCss({ size: 'sm' })
 	const dangerButtonCss = getDangerPillCss({ size: 'sm' })
-
-	async function loadClients(signal: AbortSignal) {
-		const href = readCurrentRouterHref(handle)
-		try {
-			const response = await fetch(clientsApiPath, {
-				headers: { Accept: 'application/json' },
-				credentials: 'include',
-				signal,
-			})
-			if (signal.aborted) return
-			if (response.status === 401) {
-				window.location.assign('/login')
-				return
-			}
-			const payload = await readJson<AccountMcpOauthClientsLoaderData>(response)
-			if (!response.ok || !payload?.ok) {
-				throw new Error('Unable to load MCP OAuth clients.')
-			}
-			clients = payload.clients
-			status = 'ready'
-			message = null
-			messageTone = 'info'
-			loadLatch.markLoaded(href)
-			handle.update()
-		} catch (error) {
-			if (signal.aborted) return
-			status = 'error'
-			message =
-				error instanceof Error
-					? error.message
-					: 'Unable to load MCP OAuth clients.'
-			messageTone = 'error'
-			loadLatch.markFailed(href)
-			handle.update()
-		}
-	}
 
 	async function handleCreate(event: Event) {
 		event.preventDefault()
@@ -228,39 +202,34 @@ export function AccountMcpOauthClientsRoute(handle: Handle) {
 		handle.update()
 	}
 
-	function applyRouteLoaderData(href: string) {
-		if (!isClientsPath(href)) return false
-		const routeData = tryConsumeRouteLoaderData(
-			handle,
-			'accountMcpOauthClients',
-			href,
-		)
-		if (!routeData) return false
-		clients = routeData.clients
-		status = 'ready'
-		message = null
-		messageTone = 'info'
-		loadLatch.markLoaded(href)
-		return true
-	}
-
 	return () => {
 		const currentHref = readCurrentRouterHref(handle)
-		const appliedRouteData = applyRouteLoaderData(currentHref)
-		const needsStaleRefresh =
-			consumeStaleNavigationData(currentHref) && !appliedRouteData
-		const needsLoad = loadLatch.needsLoad({
-			currentHref,
-			appliedRouteData,
-			needsStaleRefresh,
-		})
-		if (needsLoad && typeof document !== 'undefined') {
-			handle.queueTask(loadClients)
+		const snapshot = clientsData.read(handle, currentHref)
+		if (snapshot.data && snapshot.data !== appliedPayload) {
+			appliedPayload = snapshot.data
+			clients = snapshot.data.clients
+			message = null
+			messageTone = 'info'
 		}
+		if (snapshot.error && snapshot.error !== appliedError) {
+			appliedError = snapshot.error
+			message = snapshot.error.message
+			messageTone = 'error'
+		}
+		const pending = snapshot.kind === 'pending'
+		const status: AccountStatus =
+			snapshot.kind === 'error'
+				? 'error'
+				: pending && appliedPayload === null
+					? 'loading'
+					: 'ready'
 		const isBusy = actionStatus === 'busy'
 
 		return (
-			<AccountManagementShell maxWidth={layoutMaxWidths.content}>
+			<AccountManagementShell
+				maxWidth={layoutMaxWidths.content}
+				busy={pending && appliedPayload !== null}
+			>
 				<AccountPageHeader
 					title="MCP OAuth clients"
 					description="Pre-register a confidential client when a host cannot finish dynamic OAuth registration. Most hosts do not need this."

--- a/packages/worker/client/routes/account-mcp-servers.tsx
+++ b/packages/worker/client/routes/account-mcp-servers.tsx
@@ -3,10 +3,8 @@ import { on } from '#client/event-mixin.ts'
 import { navigate, readCurrentRouterHref } from '#client/client-router.tsx'
 import { createDoubleCheck } from '#client/double-check.ts'
 import { createListDetailRoute } from '#client/list-detail-route.ts'
-import { createRouteLoadLatch } from '#client/route-load-latch.ts'
 import { replaceLocation } from '#client/replace-location.ts'
-import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
-import { consumeStaleNavigationData } from '#client/navigation-data.ts'
+import { createRouteData, routeDataRedirect } from '#client/route-data.tsx'
 import {
 	type AccountStatus,
 	readJson,
@@ -89,7 +87,6 @@ export async function accountMcpServersRouteLoader(
 }
 
 export function AccountMcpServersRoute(handle: Handle) {
-	let status: AccountStatus = 'loading'
 	let actionState: 'idle' | 'busy' = 'idle'
 	let servers: Array<McpServerListItem> = []
 	let savedPackages: Array<{ id: string; kodyId: string }> = []
@@ -103,8 +100,27 @@ export function AccountMcpServersRoute(handle: Handle) {
 	let addBearerToken = ''
 	let message: string | null = null
 	let messageTone: MessageTone = 'info'
-	const loadLatch = createRouteLoadLatch()
+	/** Payload last applied to the closure state above. */
+	let appliedPayload: AccountMcpServersPayload | null = null
+	let appliedError: Error | null = null
 	const deleteServerCheck = createDoubleCheck(handle)
+	const serversData = createRouteData({
+		key: 'accountMcpServers',
+		locationKey: getDataLatchKey,
+		async load(_href, signal) {
+			const response = await fetch(accountMcpServersApiPath, {
+				headers: { Accept: 'application/json' },
+				credentials: 'include',
+				signal,
+			})
+			if (response.status === 401) return routeDataRedirect('/login')
+			const payload = await readJson<AccountMcpServersPayload>(response)
+			if (!response.ok || !payload?.ok) {
+				throw new Error('Unable to load MCP server settings.')
+			}
+			return payload
+		},
+	})
 	let oauthResultConsumed = false
 	if (typeof document !== 'undefined') {
 		if (!closeOnboardingMcpOAuthPopupIfOpened()) {
@@ -161,47 +177,6 @@ export function AccountMcpServersRoute(handle: Handle) {
 		)
 		usageSavingId = null
 		deleteServerCheck.reset()
-	}
-
-	async function loadServers(signal: AbortSignal) {
-		const href = getCurrentHref()
-		const latchKey = getDataLatchKey(href)
-		try {
-			const response = await fetch(accountMcpServersApiPath, {
-				headers: { Accept: 'application/json' },
-				credentials: 'include',
-				signal,
-			})
-			if (signal.aborted) return
-			if (response.status === 401) {
-				window.location.assign('/login')
-				return
-			}
-			const payload = await readJson<AccountMcpServersPayload>(response)
-			if (!response.ok || !payload?.ok) {
-				throw new Error('Unable to load MCP server settings.')
-			}
-			if (getDataLatchKey(getCurrentHref()) !== latchKey) return
-			applyPayload(payload)
-			// Clear a stale load-error banner; mutation success messages
-			// (info tone) survive the reload.
-			if (messageTone === 'error') setMessage(null)
-			status = 'ready'
-			loadLatch.markLoaded(latchKey)
-			consumeOAuthResult()
-			handle.update()
-		} catch (error) {
-			if (signal.aborted) return
-			status = 'error'
-			setMessage(
-				error instanceof Error
-					? error.message
-					: 'Unable to load MCP server settings.',
-				'error',
-			)
-			loadLatch.markFailed(latchKey)
-			handle.update()
-		}
 	}
 
 	async function postAction(input: {
@@ -305,21 +280,6 @@ export function AccountMcpServersRoute(handle: Handle) {
 		})
 	}
 
-	function applyRouteLoaderData(href: string) {
-		if (!mcpServersRoute.isRoutePath(href)) return false
-		const routeData = tryConsumeRouteLoaderData(
-			handle,
-			'accountMcpServers',
-			href,
-		)
-		if (!routeData) return false
-		applyPayload(routeData)
-		status = 'ready'
-		loadLatch.markLoaded(getDataLatchKey(href))
-		consumeOAuthResult()
-		return true
-	}
-
 	function getUsageDraft(server: McpServerListItem): McpServerUsageDraft {
 		return (
 			usageDrafts.get(server.id) ?? {
@@ -331,18 +291,26 @@ export function AccountMcpServersRoute(handle: Handle) {
 
 	return () => {
 		const currentHref = getCurrentHref()
-		const appliedRouteData = applyRouteLoaderData(currentHref)
-		const needsStaleRefresh =
-			consumeStaleNavigationData(currentHref) && !appliedRouteData
-		const latchKey = getDataLatchKey(currentHref)
-		const needsLoad = loadLatch.needsLoad({
-			currentHref: latchKey,
-			appliedRouteData,
-			needsStaleRefresh,
-		})
-		if (needsLoad && typeof document !== 'undefined') {
-			handle.queueTask(loadServers)
+		const snapshot = serversData.read(handle, currentHref)
+		if (snapshot.data && snapshot.data !== appliedPayload) {
+			appliedPayload = snapshot.data
+			applyPayload(snapshot.data)
+			// Clear a stale load-error banner; mutation success messages
+			// (info tone) survive the reload.
+			if (messageTone === 'error') setMessage(null)
+			consumeOAuthResult()
 		}
+		if (snapshot.error && snapshot.error !== appliedError) {
+			appliedError = snapshot.error
+			setMessage(snapshot.error.message, 'error')
+		}
+		const pending = snapshot.kind === 'pending'
+		const status: AccountStatus =
+			snapshot.kind === 'error'
+				? 'error'
+				: pending && appliedPayload === null
+					? 'loading'
+					: 'ready'
 		const isMutating = actionState !== 'idle'
 		const selection = mcpServersRoute.getSelection(currentHref)
 		const search = readSearchFilter(currentHref)
@@ -353,7 +321,7 @@ export function AccountMcpServersRoute(handle: Handle) {
 			selection.selectedId != null && !server && status === 'ready'
 
 		return (
-			<AccountManagementShell>
+			<AccountManagementShell busy={pending && appliedPayload !== null}>
 				<AccountPageHeader
 					title="MCP servers"
 					description="Connect remote MCP servers so their tools are available to Kody as kody.mcp capabilities. Use a bearer token for static Authorization, or complete OAuth when the server requires it."

--- a/packages/worker/client/routes/account-memories.tsx
+++ b/packages/worker/client/routes/account-memories.tsx
@@ -2,10 +2,8 @@ import { type Handle, css } from 'remix/ui'
 import { on } from '#client/event-mixin.ts'
 import { navigate, readCurrentRouterHref } from '#client/client-router.tsx'
 import { createListDetailRoute } from '#client/list-detail-route.ts'
-import { createRouteLoadLatch } from '#client/route-load-latch.ts'
 import { replaceLocation } from '#client/replace-location.ts'
-import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
-import { consumeStaleNavigationData } from '#client/navigation-data.ts'
+import { createRouteData, routeDataRedirect } from '#client/route-data.tsx'
 import {
 	type AccountStatus,
 	readJson,
@@ -169,14 +167,32 @@ function formatOptional(value: string | null | undefined) {
 }
 
 export function AccountMemoriesRoute(handle: Handle) {
-	let status: AccountStatus = 'loading'
 	let actionState: 'idle' | 'busy' = 'idle'
 	let memories: Array<AccountMemoryListItem> = []
 	let selectedMemory: AccountMemoryDetail | null = null
 	let message: string | null = null
 	let messageTone: MessageTone = 'info'
 	let deleteMode: DeleteMode = null
-	const loadLatch = createRouteLoadLatch()
+	/** Payload last applied to the closure state above. */
+	let appliedPayload: AccountMemoriesLoaderData | null = null
+	let appliedError: Error | null = null
+	const memoriesData = createRouteData({
+		key: 'accountMemories',
+		locationKey: getDataLatchKey,
+		async load(href, signal) {
+			const response = await fetch(buildMemoriesApiRequestUrl(href), {
+				headers: { Accept: 'application/json' },
+				credentials: 'include',
+				signal,
+			})
+			if (response.status === 401) return routeDataRedirect('/login')
+			const payload = await readJson<AccountMemoriesLoaderData>(response)
+			if (!response.ok || !payload?.ok) {
+				throw new Error('Unable to load memories.')
+			}
+			return payload
+		},
+	})
 
 	const secondaryButtonCss = getGhostButtonCss({ size: 'sm' })
 	const dangerButtonCss = getDangerPillCss({ size: 'sm' })
@@ -213,42 +229,6 @@ export function AccountMemoriesRoute(handle: Handle) {
 		memories = payload.memories
 		selectedMemory = payload.selectedMemory
 		deleteMode = null
-	}
-
-	async function loadMemories(signal: AbortSignal) {
-		const href = getCurrentHref()
-		const latchKey = getDataLatchKey(href)
-		try {
-			const response = await fetch(buildMemoriesApiRequestUrl(href), {
-				headers: { Accept: 'application/json' },
-				credentials: 'include',
-				signal,
-			})
-			if (signal.aborted) return
-			if (response.status === 401) {
-				window.location.assign('/login')
-				return
-			}
-			const payload = await readJson<AccountMemoriesLoaderData>(response)
-			if (!response.ok || !payload?.ok) {
-				throw new Error('Unable to load memories.')
-			}
-			if (getDataLatchKey(getCurrentHref()) !== latchKey) return
-			applyPayload(payload)
-			if (messageTone === 'error') setMessage(null)
-			status = 'ready'
-			loadLatch.markLoaded(latchKey)
-			handle.update()
-		} catch (error) {
-			if (signal.aborted) return
-			status = 'error'
-			setMessage(
-				error instanceof Error ? error.message : 'Unable to load memories.',
-				'error',
-			)
-			loadLatch.markFailed(latchKey)
-			handle.update()
-		}
 	}
 
 	async function postDelete(input: { memoryId: string; force: boolean }) {
@@ -298,30 +278,25 @@ export function AccountMemoriesRoute(handle: Handle) {
 		}
 	}
 
-	function applyRouteLoaderData(href: string) {
-		if (!memoriesRoute.isRoutePath(href)) return false
-		const routeData = tryConsumeRouteLoaderData(handle, 'accountMemories', href)
-		if (!routeData) return false
-		applyPayload(routeData)
-		status = 'ready'
-		loadLatch.markLoaded(getDataLatchKey(href))
-		return true
-	}
-
 	return () => {
 		const currentHref = getCurrentHref()
-		const appliedRouteData = applyRouteLoaderData(currentHref)
-		const needsStaleRefresh =
-			consumeStaleNavigationData(currentHref) && !appliedRouteData
-		const latchKey = getDataLatchKey(currentHref)
-		const needsLoad = loadLatch.needsLoad({
-			currentHref: latchKey,
-			appliedRouteData,
-			needsStaleRefresh,
-		})
-		if (needsLoad && typeof document !== 'undefined') {
-			handle.queueTask(loadMemories)
+		const snapshot = memoriesData.read(handle, currentHref)
+		if (snapshot.data && snapshot.data !== appliedPayload) {
+			appliedPayload = snapshot.data
+			applyPayload(snapshot.data)
+			if (messageTone === 'error') setMessage(null)
 		}
+		if (snapshot.error && snapshot.error !== appliedError) {
+			appliedError = snapshot.error
+			setMessage(snapshot.error.message, 'error')
+		}
+		const pending = snapshot.kind === 'pending'
+		const status: AccountStatus =
+			snapshot.kind === 'error'
+				? 'error'
+				: pending && appliedPayload === null
+					? 'loading'
+					: 'ready'
 		const isMutating = actionState !== 'idle'
 		const selection = memoriesRoute.getSelection(currentHref)
 		const search = readSearchFilter(currentHref)
@@ -334,7 +309,7 @@ export function AccountMemoriesRoute(handle: Handle) {
 		const waitingForDetail =
 			selection.selectedId != null &&
 			!detailMemory &&
-			(needsLoad || listMatch != null || status === 'loading')
+			(pending || listMatch != null || status === 'loading')
 		const showMemoryNotFound =
 			selection.selectedId != null &&
 			!detailMemory &&
@@ -342,7 +317,7 @@ export function AccountMemoriesRoute(handle: Handle) {
 			status === 'ready'
 
 		return (
-			<AccountManagementShell>
+			<AccountManagementShell busy={pending && appliedPayload !== null}>
 				<AccountPageHeader
 					title="Memories"
 					description="Long-term memories Kody stores for your account. Agents create and update them; you can browse, filter, and delete here."

--- a/packages/worker/client/routes/account-package-approve-publish.tsx
+++ b/packages/worker/client/routes/account-package-approve-publish.tsx
@@ -3,9 +3,7 @@ import { createMatcher } from 'remix/route-pattern/match'
 import { routes } from '#universal/routes.ts'
 import { on } from '#client/event-mixin.ts'
 import { readCurrentRouterHref } from '#client/client-router.tsx'
-import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
-import { consumeStaleNavigationData } from '#client/navigation-data.ts'
-import { createRouteLoadLatch } from '#client/route-load-latch.ts'
+import { createRouteData, routeDataRedirect } from '#client/route-data.tsx'
 import { readJson } from '#client/routes/account-approval-shared.ts'
 import {
 	AccountManagementMessage,
@@ -32,6 +30,8 @@ const approvePublishMatcher = createMatcher(
 )
 
 type PageStatus = 'loading' | 'ready' | 'error' | 'promoting'
+
+const loadFailureMessage = 'Unable to load this publish approval.'
 
 function isApprovePublishPath(href: string) {
 	return approvePublishMatcher.match(new URL(href, 'http://localhost')) !== null
@@ -74,47 +74,31 @@ export async function accountPackageApprovePublishRouteLoader(
 }
 
 export function AccountPackageApprovePublishRoute(handle: Handle) {
-	let status: PageStatus = 'loading'
+	/** Payload last applied from the route data; also read by `promoteCommit`. */
 	let payload: AccountPackageApprovePublishLoaderData | null = null
+	let promoting = false
 	let message: string | null = null
-	const loadLatch = createRouteLoadLatch()
-
-	async function loadPage(href: string) {
-		// Do not call handle.update() before the first await — see blog.tsx.
-		try {
+	let appliedError: Error | null = null
+	const approvePublishData = createRouteData({
+		key: 'accountPackageApprovePublish',
+		async load(href, signal) {
 			const response = await fetch(buildApprovePublishApiUrl(href), {
 				headers: { Accept: 'application/json' },
 				credentials: 'include',
-			})
-			if (response.status === 401) {
-				window.location.assign('/login')
-				return
-			}
+				signal,
+			}).catch(() => null)
+			if (!response) throw new Error(loadFailureMessage)
+			if (response.status === 401) return routeDataRedirect('/login')
 			const next =
 				await readJson<AccountPackageApprovePublishLoaderData>(response)
-			if (!response.ok || !next?.ok) {
-				status = 'error'
-				message = 'Unable to load this publish approval.'
-				loadLatch.markFailed(href)
-				handle.update()
-				return
-			}
-			payload = next
-			status = 'ready'
-			message = null
-			loadLatch.markLoaded(href)
-			handle.update()
-		} catch {
-			status = 'error'
-			message = 'Unable to load this publish approval.'
-			loadLatch.markFailed(href)
-			handle.update()
-		}
-	}
+			if (!response.ok || !next?.ok) throw new Error(loadFailureMessage)
+			return next
+		},
+	})
 
 	async function promoteCommit() {
 		if (!payload?.pendingCommit) return
-		status = 'promoting'
+		promoting = true
 		message = null
 		handle.update()
 		try {
@@ -133,14 +117,14 @@ export function AccountPackageApprovePublishRoute(handle: Handle) {
 			})
 			const body = await readJson<{ ok?: boolean; error?: string }>(response)
 			if (!response.ok || body?.ok === false) {
-				status = 'ready'
+				promoting = false
 				message = body?.error ?? 'Could not promote this commit.'
 				handle.update()
 				return
 			}
 			window.location.assign(payload.packageHref)
 		} catch {
-			status = 'ready'
+			promoting = false
 			message = 'Could not promote this commit.'
 			handle.update()
 		}
@@ -152,38 +136,27 @@ export function AccountPackageApprovePublishRoute(handle: Handle) {
 			return <AccountManagementShell>{null}</AccountManagementShell>
 		}
 
-		const routeData = tryConsumeRouteLoaderData(
-			handle,
-			'accountPackageApprovePublish',
-			currentHref,
-		)
-		const appliedRouteData = Boolean(routeData?.ok)
-		if (routeData?.ok) {
-			payload = routeData
-			status = 'ready'
+		const snapshot = approvePublishData.read(handle, currentHref)
+		if (snapshot.data && snapshot.data !== payload) {
+			payload = snapshot.data
 			message = null
-			loadLatch.markLoaded(currentHref)
 		}
-
-		const needsStaleRefresh = consumeStaleNavigationData(currentHref)
-		const needsLoad = loadLatch.needsLoad({
-			currentHref,
-			appliedRouteData,
-			needsStaleRefresh,
-		})
-		if (needsLoad && typeof document !== 'undefined') {
-			status = 'loading'
-			handle.queueTask(async () => {
-				try {
-					await loadPage(currentHref)
-				} catch {
-					loadLatch.markFailed(currentHref)
-				}
-			})
+		if (snapshot.error && snapshot.error !== appliedError) {
+			appliedError = snapshot.error
+			message = snapshot.error.message
 		}
+		const pending = snapshot.kind === 'pending'
+		const status: PageStatus =
+			snapshot.kind === 'error'
+				? 'error'
+				: pending && payload === null
+					? 'loading'
+					: promoting
+						? 'promoting'
+						: 'ready'
 
 		return (
-			<AccountManagementShell>
+			<AccountManagementShell busy={pending && payload !== null}>
 				<AccountPageHeader
 					title={
 						payload?.package.lockedAt

--- a/packages/worker/client/routes/account-passkeys.tsx
+++ b/packages/worker/client/routes/account-passkeys.tsx
@@ -6,9 +6,7 @@ import { startRegistration } from '@simplewebauthn/browser'
 import { type Handle, css } from 'remix/ui'
 import { on } from '#client/event-mixin.ts'
 import { readCurrentRouterHref } from '#client/client-router.tsx'
-import { createRouteLoadLatch } from '#client/route-load-latch.ts'
-import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
-import { consumeStaleNavigationData } from '#client/navigation-data.ts'
+import { createRouteData, routeDataRedirect } from '#client/route-data.tsx'
 import {
 	type AccountStatus,
 	readJson,
@@ -50,12 +48,7 @@ type AccountPasskeysPayload = {
 }
 
 const passkeysApiPath = '/account/passkeys.json'
-const passkeysPath = '/account/passkeys'
 const webauthnRegistrationPath = '/webauthn/registration'
-
-function isPasskeysPath(href: string) {
-	return new URL(href, 'http://localhost').pathname === passkeysPath
-}
 
 export async function accountPasskeysRouteLoader(
 	_url: URL,
@@ -83,48 +76,31 @@ function describeDeviceType(deviceType: string) {
 }
 
 export function AccountPasskeysRoute(handle: Handle) {
-	let status: AccountStatus = 'loading'
 	let actionStatus: 'idle' | 'busy' = 'idle'
 	let passkeys: Array<PasskeyListItem> = []
 	let message: string | null = null
 	let messageTone: 'error' | 'info' = 'info'
 	let renamingPasskeyId: string | null = null
 	let renameDraft = ''
-	const loadLatch = createRouteLoadLatch()
-
-	async function loadPasskeys(signal: AbortSignal) {
-		const href = readCurrentRouterHref(handle)
-		try {
+	/** Payload last applied to the closure state above. */
+	let appliedPayload: AccountPasskeysPayload | null = null
+	let appliedError: Error | null = null
+	const passkeysData = createRouteData({
+		key: 'accountPasskeys',
+		async load(_href, signal) {
 			const response = await fetch(passkeysApiPath, {
 				headers: { Accept: 'application/json' },
 				credentials: 'include',
 				signal,
 			})
-			if (signal.aborted) return
-			if (response.status === 401) {
-				window.location.assign('/login')
-				return
-			}
+			if (response.status === 401) return routeDataRedirect('/login')
 			const payload = await readJson<AccountPasskeysPayload>(response)
 			if (!response.ok || !payload?.ok) {
 				throw new Error('Unable to load passkeys.')
 			}
-			passkeys = payload.passkeys
-			status = 'ready'
-			message = null
-			messageTone = 'info'
-			loadLatch.markLoaded(href)
-			handle.update()
-		} catch (error) {
-			if (signal.aborted) return
-			status = 'error'
-			message =
-				error instanceof Error ? error.message : 'Unable to load passkeys.'
-			messageTone = 'error'
-			loadLatch.markFailed(href)
-			handle.update()
-		}
-	}
+			return payload
+		},
+	})
 
 	async function handleRegisterPasskey() {
 		actionStatus = 'busy'
@@ -309,35 +285,34 @@ export function AccountPasskeysRoute(handle: Handle) {
 		}
 	}
 
-	function applyRouteLoaderData(href: string) {
-		if (!isPasskeysPath(href)) return false
-		const routeData = tryConsumeRouteLoaderData(handle, 'accountPasskeys', href)
-		if (!routeData) return false
-		passkeys = routeData.passkeys
-		status = 'ready'
-		message = null
-		messageTone = 'info'
-		loadLatch.markLoaded(href)
-		return true
-	}
-
 	return () => {
 		const currentHref = readCurrentRouterHref(handle)
-		const appliedRouteData = applyRouteLoaderData(currentHref)
-		const needsStaleRefresh =
-			consumeStaleNavigationData(currentHref) && !appliedRouteData
-		const needsLoad = loadLatch.needsLoad({
-			currentHref,
-			appliedRouteData,
-			needsStaleRefresh,
-		})
-		if (needsLoad && typeof document !== 'undefined') {
-			handle.queueTask(loadPasskeys)
+		const snapshot = passkeysData.read(handle, currentHref)
+		if (snapshot.data && snapshot.data !== appliedPayload) {
+			appliedPayload = snapshot.data
+			passkeys = snapshot.data.passkeys
+			message = null
+			messageTone = 'info'
 		}
+		if (snapshot.error && snapshot.error !== appliedError) {
+			appliedError = snapshot.error
+			message = snapshot.error.message
+			messageTone = 'error'
+		}
+		const pending = snapshot.kind === 'pending'
+		const status: AccountStatus =
+			snapshot.kind === 'error'
+				? 'error'
+				: pending && appliedPayload === null
+					? 'loading'
+					: 'ready'
 		const isBusy = actionStatus === 'busy'
 
 		return (
-			<AccountManagementShell maxWidth={layoutMaxWidths.content}>
+			<AccountManagementShell
+				maxWidth={layoutMaxWidths.content}
+				busy={pending && appliedPayload !== null}
+			>
 				<AccountPageHeader
 					title="Passkeys"
 					description="Sign in with your device's screen lock, a hardware key, or a synced passkey instead of your password."

--- a/packages/worker/client/routes/account-secrets.tsx
+++ b/packages/worker/client/routes/account-secrets.tsx
@@ -9,8 +9,7 @@ import { buildAccountSecretPath } from '@kody-internal/shared/account-secret-rou
 import { navigate, readCurrentRouterHref } from '#client/client-router.tsx'
 import { type ListDetailSelection } from '#client/list-detail-route.ts'
 import { replaceLocation } from '#client/replace-location.ts'
-import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
-import { consumeStaleNavigationData } from '#client/navigation-data.ts'
+import { createRouteData, routeDataRedirect } from '#client/route-data.tsx'
 import { createDoubleCheck } from '#client/double-check.ts'
 import {
 	type AccountStatus,
@@ -69,7 +68,6 @@ export { accountSecretsRouteLoader }
 const clampedCellCss = css(recordCellClamp(26))
 
 export function AccountSecretsRoute(handle: Handle) {
-	let status: AccountStatus = 'loading'
 	let packageOptions: Array<PackageOption> = []
 	let packagesById = new Map<string, { kodyId: string; name: string }>()
 	let secrets: Array<AccountSecretListItem> = []
@@ -79,13 +77,33 @@ export function AccountSecretsRoute(handle: Handle) {
 	let message: string | null = null
 	let submittingApprovalAction: ApprovalAction | null = null
 	let saveState: 'idle' | 'saving' | 'deleting' = 'idle'
-	let lastLoadedDataKey = ''
-	let lastFailedDataKey: string | null = null
-	let loadingDataKey: string | null = null
-	let loadRequestId = 0
 	let retryTimeout: ReturnType<typeof setTimeout> | null = null
 	let showSecretValue = false
+	/** Payload last applied to the closure state above. */
+	let appliedPayload: AccountSecretsLoaderData | null = null
+	let appliedError: Error | null = null
 	const deleteSecretCheck = createDoubleCheck(handle)
+	const secretsData = createRouteData({
+		key: 'accountSecrets',
+		locationKey: getDataRefreshKey,
+		async load(href, signal) {
+			const requestUrl = buildSecretsApiRequestUrl(href)
+			const response = await fetch(
+				`${requestUrl.pathname}${requestUrl.search}`,
+				{
+					headers: { Accept: 'application/json' },
+					credentials: 'include',
+					signal,
+				},
+			)
+			if (response.status === 401) return routeDataRedirect('/login')
+			const payload = await readJson<AccountSecretsLoaderData>(response)
+			if (!response.ok || !payload?.ok) {
+				throw new Error('Unable to load your secrets.')
+			}
+			return payload
+		},
+	})
 
 	function getCurrentHref() {
 		return readCurrentRouterHref(handle)
@@ -165,7 +183,6 @@ export function AccountSecretsRoute(handle: Handle) {
 			(selection.selectedId && !payload.selectedSecret && !payload.approval
 				? 'Secret not found.'
 				: null)
-		status = 'ready'
 		submittingApprovalAction = null
 		saveState = 'idle'
 	}
@@ -177,74 +194,23 @@ export function AccountSecretsRoute(handle: Handle) {
 			: `Unknown package (${packageId})`
 	}
 
-	async function loadAccountSecrets() {
-		const href = getCurrentHref()
-		const selection = secretsRoute.getSelection(href)
-		const dataKey = getDataRefreshKey(href)
-		const requestId = ++loadRequestId
-		loadingDataKey = dataKey
-		try {
-			const requestUrl = buildSecretsApiRequestUrl(href)
-
-			const response = await fetch(
-				`${requestUrl.pathname}${requestUrl.search}`,
-				{
-					headers: { Accept: 'application/json' },
-					credentials: 'include',
-				},
-			)
-			if (
-				requestId !== loadRequestId ||
-				getDataRefreshKey(getCurrentHref()) !== dataKey
-			)
-				return
-			if (response.status === 401) {
-				window.location.assign('/login')
-				return
-			}
-
-			const payload = await readJson<AccountSecretsLoaderData>(response)
-			if (!response.ok || !payload?.ok) {
-				throw new Error('Unable to load your secrets.')
-			}
-
-			lastLoadedDataKey = dataKey
-			lastFailedDataKey = null
-			if (retryTimeout) {
-				clearTimeout(retryTimeout)
-				retryTimeout = null
-			}
-			applyPayload(payload, selection, null)
-			handle.update()
-		} catch (error) {
-			if (
-				requestId !== loadRequestId ||
-				getDataRefreshKey(getCurrentHref()) !== dataKey
-			)
-				return
-			lastFailedDataKey = dataKey
-			status = 'error'
-			message =
-				error instanceof Error ? error.message : 'Unable to load your secrets.'
-			handle.update()
-			if (typeof window !== 'undefined') {
-				if (retryTimeout) {
-					clearTimeout(retryTimeout)
-					retryTimeout = null
-				}
-				retryTimeout = window.setTimeout(() => {
-					retryTimeout = null
-					if (lastFailedDataKey !== dataKey) return
-					if (getDataRefreshKey(getCurrentHref()) !== dataKey) return
-					lastFailedDataKey = null
-					handle.update()
-				}, 3000)
-			}
-		} finally {
-			if (requestId === loadRequestId && loadingDataKey === dataKey) {
-				loadingDataKey = null
-			}
+	function clearRetryTimeout() {
+		if (retryTimeout) {
+			clearTimeout(retryTimeout)
+			retryTimeout = null
 		}
+	}
+
+	/** A failed load retries after a pause while the route stays on that location. */
+	function scheduleRetry(dataKey: string) {
+		if (typeof window === 'undefined') return
+		clearRetryTimeout()
+		retryTimeout = window.setTimeout(() => {
+			retryTimeout = null
+			const href = getCurrentHref()
+			if (getDataRefreshKey(href) !== dataKey) return
+			secretsData.reload(handle, href)
+		}, 3000)
 	}
 
 	async function submitApproval(action: ApprovalAction) {
@@ -306,10 +272,7 @@ export function AccountSecretsRoute(handle: Handle) {
 				nextUrl.searchParams.delete('names')
 				nextUrl.searchParams.delete('name')
 				// `navigate` is async (preload-then-commit); the commit render
-				// consumes its preloaded data and updates `lastLoadedDataKey`.
-				// Pre-setting it to the destination here would make interim
-				// renders (current URL unchanged) look like a location change
-				// and fire a spurious refetch for the pre-approval URL.
+				// consumes its preloaded data through `secretsData`.
 				navigate(`${nextUrl.pathname}${nextUrl.search}`)
 			}
 		} catch (error) {
@@ -500,45 +463,34 @@ export function AccountSecretsRoute(handle: Handle) {
 		handle.update()
 	}
 
-	function applyRouteLoaderData(href: string) {
-		if (!secretsRoute.isRoutePath(href)) return false
-		const routeData = tryConsumeRouteLoaderData(handle, 'accountSecrets', href)
-		if (!routeData) return false
-		const selection = secretsRoute.getSelection(href)
-		applyPayload(routeData, selection, routeData.approvalError)
-		lastLoadedDataKey = getDataRefreshKey(href)
-		lastFailedDataKey = null
-		return true
-	}
-
 	return () => {
 		const currentHref = getCurrentHref()
-		const currentDataKey = getDataRefreshKey(currentHref)
-		// Consume route-loader data before deriving list state below; deriving
-		// first would render this pass from the stale pre-navigation `secrets`
-		// (an empty list on SPA navigation) with no follow-up refetch queued.
-		const appliedRouteData = applyRouteLoaderData(currentHref)
-		// A same-path refresh whose loader failed leaves no preload and no
-		// data-key change; the stale marker forces the fallback refetch.
-		const needsStaleRefresh =
-			consumeStaleNavigationData(currentHref) && !appliedRouteData
-		const isRefreshingForLocationChange =
-			status !== 'loading' &&
-			currentDataKey !== lastLoadedDataKey &&
-			currentDataKey !== lastFailedDataKey
-		const isLoadingCurrentLocation = loadingDataKey === currentDataKey
-		if (
-			!appliedRouteData &&
-			(status === 'loading' ||
-				isRefreshingForLocationChange ||
-				needsStaleRefresh) &&
-			!isLoadingCurrentLocation &&
-			typeof document !== 'undefined'
-		) {
-			handle.queueTask(loadAccountSecrets)
-		}
-
 		const selection = secretsRoute.getSelection(currentHref)
+		// Read route data before deriving list state below; deriving first
+		// would render this pass from the stale pre-navigation `secrets` (an
+		// empty list on SPA navigation).
+		const snapshot = secretsData.read(handle, currentHref)
+		if (snapshot.data && snapshot.data !== appliedPayload) {
+			appliedPayload = snapshot.data
+			clearRetryTimeout()
+			applyPayload(snapshot.data, selection, null)
+		}
+		if (snapshot.error && snapshot.error !== appliedError) {
+			appliedError = snapshot.error
+			message = snapshot.error.message
+			scheduleRetry(getDataRefreshKey(currentHref))
+		}
+		const pending = snapshot.kind === 'pending'
+		const status: AccountStatus =
+			snapshot.kind === 'error'
+				? 'error'
+				: pending && appliedPayload === null
+					? 'loading'
+					: 'ready'
+		// The previous location's payload stays on screen while the new
+		// selection loads; only the detail column shows its placeholder.
+		const isRefreshingForLocationChange = pending && snapshot.stale
+
 		const filters = readFilterState(currentHref, packageOptions)
 		const filteredSecrets = filterSecrets(secrets, filters, packagesById)
 		const packageSelectOptions = packageOptions.map((packageOption) => {
@@ -580,7 +532,7 @@ export function AccountSecretsRoute(handle: Handle) {
 				? approval
 				: null
 		return (
-			<AccountManagementShell>
+			<AccountManagementShell busy={pending && appliedPayload !== null}>
 				<AccountPageHeader
 					title="Secrets"
 					description="Passwords and tokens Kody can use for you."

--- a/packages/worker/client/routes/account-two-factor.tsx
+++ b/packages/worker/client/routes/account-two-factor.tsx
@@ -2,9 +2,7 @@ import { toDataURL } from 'qrcode'
 import { type Handle, css } from 'remix/ui'
 import { on } from '#client/event-mixin.ts'
 import { readCurrentRouterHref } from '#client/client-router.tsx'
-import { createRouteLoadLatch } from '#client/route-load-latch.ts'
-import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
-import { consumeStaleNavigationData } from '#client/navigation-data.ts'
+import { createRouteData, routeDataRedirect } from '#client/route-data.tsx'
 import {
 	type AccountStatus,
 	readJson,
@@ -50,11 +48,6 @@ type TwoFactorSetup = {
 }
 
 const twoFactorApiPath = '/account/two-factor.json'
-const twoFactorPath = '/account/two-factor'
-
-function isTwoFactorPath(href: string) {
-	return new URL(href, 'http://localhost').pathname === twoFactorPath
-}
 
 export async function accountTwoFactorRouteLoader(
 	_url: URL,
@@ -76,7 +69,6 @@ export async function accountTwoFactorRouteLoader(
 }
 
 export function AccountTwoFactorRoute(handle: Handle) {
-	let status: AccountStatus = 'loading'
 	let actionStatus: 'idle' | 'busy' = 'idle'
 	let enabled = false
 	let setup: TwoFactorSetup | null = null
@@ -84,43 +76,25 @@ export function AccountTwoFactorRoute(handle: Handle) {
 	let disableCode = ''
 	let message: string | null = null
 	let messageTone: 'error' | 'info' = 'info'
-	const loadLatch = createRouteLoadLatch()
-
-	async function loadStatus(signal: AbortSignal) {
-		const href = readCurrentRouterHref(handle)
-		try {
+	/** Payload last applied to the closure state above. */
+	let appliedPayload: AccountTwoFactorPayload | null = null
+	let appliedError: Error | null = null
+	const twoFactorData = createRouteData({
+		key: 'accountTwoFactor',
+		async load(_href, signal) {
 			const response = await fetch(twoFactorApiPath, {
 				headers: { Accept: 'application/json' },
 				credentials: 'include',
 				signal,
 			})
-			if (signal.aborted) return
-			if (response.status === 401) {
-				window.location.assign('/login')
-				return
-			}
+			if (response.status === 401) return routeDataRedirect('/login')
 			const payload = await readJson<AccountTwoFactorPayload>(response)
 			if (!response.ok || !payload?.ok) {
 				throw new Error('Unable to load two-factor status.')
 			}
-			enabled = payload.enabled
-			status = 'ready'
-			message = null
-			messageTone = 'info'
-			loadLatch.markLoaded(href)
-			handle.update()
-		} catch (error) {
-			if (signal.aborted) return
-			status = 'error'
-			message =
-				error instanceof Error
-					? error.message
-					: 'Unable to load two-factor status.'
-			messageTone = 'error'
-			loadLatch.markFailed(href)
-			handle.update()
-		}
-	}
+			return payload
+		},
+	})
 
 	async function postTwoFactorAction(body: Record<string, unknown>) {
 		const response = await fetch(twoFactorApiPath, {
@@ -285,39 +259,34 @@ export function AccountTwoFactorRoute(handle: Handle) {
 		handle.update()
 	}
 
-	function applyRouteLoaderData(href: string) {
-		if (!isTwoFactorPath(href)) return false
-		const routeData = tryConsumeRouteLoaderData(
-			handle,
-			'accountTwoFactor',
-			href,
-		)
-		if (!routeData) return false
-		enabled = routeData.enabled
-		status = 'ready'
-		message = null
-		messageTone = 'info'
-		loadLatch.markLoaded(href)
-		return true
-	}
-
 	return () => {
 		const currentHref = readCurrentRouterHref(handle)
-		const appliedRouteData = applyRouteLoaderData(currentHref)
-		const needsStaleRefresh =
-			consumeStaleNavigationData(currentHref) && !appliedRouteData
-		const needsLoad = loadLatch.needsLoad({
-			currentHref,
-			appliedRouteData,
-			needsStaleRefresh,
-		})
-		if (needsLoad && typeof document !== 'undefined') {
-			handle.queueTask(loadStatus)
+		const snapshot = twoFactorData.read(handle, currentHref)
+		if (snapshot.data && snapshot.data !== appliedPayload) {
+			appliedPayload = snapshot.data
+			enabled = snapshot.data.enabled
+			message = null
+			messageTone = 'info'
 		}
+		if (snapshot.error && snapshot.error !== appliedError) {
+			appliedError = snapshot.error
+			message = snapshot.error.message
+			messageTone = 'error'
+		}
+		const pending = snapshot.kind === 'pending'
+		const status: AccountStatus =
+			snapshot.kind === 'error'
+				? 'error'
+				: pending && appliedPayload === null
+					? 'loading'
+					: 'ready'
 		const isBusy = actionStatus === 'busy'
 
 		return (
-			<AccountManagementShell maxWidth={layoutMaxWidths.content}>
+			<AccountManagementShell
+				maxWidth={layoutMaxWidths.content}
+				busy={pending && appliedPayload !== null}
+			>
 				<AccountPageHeader
 					title="Two-factor authentication"
 					description="Add a one-time code from an authenticator app as a second step when signing in."

--- a/packages/worker/client/routes/account-usage.tsx
+++ b/packages/worker/client/routes/account-usage.tsx
@@ -7,13 +7,8 @@ import {
 	type AdminPlanName,
 } from '#universal/loader-data.ts'
 import { readCurrentRouterHref } from '#client/client-router.tsx'
-import { createRouteLoadLatch } from '#client/route-load-latch.ts'
-import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
-import { consumeStaleNavigationData } from '#client/navigation-data.ts'
-import {
-	type AccountStatus,
-	readJson,
-} from '#client/routes/account-approval-shared.ts'
+import { createRouteData, routeDataRedirect } from '#client/route-data.tsx'
+import { readJson } from '#client/routes/account-approval-shared.ts'
 import {
 	routeLoaderRedirect,
 	type RouteLoaderResult,
@@ -40,7 +35,6 @@ import {
 } from '#universal/styles/style-primitives.ts'
 
 const usageApiPath = '/account/usage.json'
-const usagePath = '/account/usage'
 const billingPath = '/account/billing'
 
 const entitlementGroupOrder: Array<
@@ -147,10 +141,6 @@ function usageProgressPercent(item: AccountUsageEntitlementConsumption) {
 	return Math.min(100, Math.round(item.percentOfLimit * 100))
 }
 
-function isUsagePath(href: string) {
-	return new URL(href, 'http://localhost').pathname === usagePath
-}
-
 function groupEntitlementRows(rows: Array<AccountUsageEntitlementConsumption>) {
 	const grouped = new Map<
 		AccountUsageEntitlementConsumption['group'],
@@ -217,70 +207,29 @@ export async function accountUsageRouteLoader(
 }
 
 export function AccountUsageRoute(handle: Handle) {
-	let status: AccountStatus = 'loading'
-	let data: AccountUsageLoaderData | null = null
-	let message: string | null = null
-	const loadLatch = createRouteLoadLatch()
-
-	function applyPayload(payload: AccountUsageLoaderData) {
-		data = payload
-		status = 'ready'
-		message = null
-	}
-
-	async function loadUsage(signal: AbortSignal) {
-		const href = readCurrentRouterHref(handle)
-		try {
+	const usageData = createRouteData({
+		key: 'accountUsage',
+		async load(_href, signal) {
 			const response = await fetch(usageApiPath, {
 				headers: { Accept: 'application/json' },
 				credentials: 'include',
 				signal,
 			})
-			if (signal.aborted) return
-			if (response.status === 401) {
-				window.location.assign('/login')
-				return
-			}
+			if (response.status === 401) return routeDataRedirect('/login')
 			const payload = await readJson<AccountUsageLoaderData>(response)
 			if (!response.ok || !payload?.ok) {
 				throw new Error('Unable to load usage.')
 			}
-			applyPayload(payload)
-			loadLatch.markLoaded(href)
-			handle.update()
-		} catch (error) {
-			if (signal.aborted) return
-			status = 'error'
-			message = error instanceof Error ? error.message : 'Unable to load usage.'
-			loadLatch.markFailed(href)
-			handle.update()
-		}
-	}
-
-	function applyRouteLoaderData(href: string) {
-		if (!isUsagePath(href)) return false
-		const routeData = tryConsumeRouteLoaderData(handle, 'accountUsage', href)
-		if (!routeData) return false
-		applyPayload(routeData)
-		loadLatch.markLoaded(href)
-		return true
-	}
+			return payload
+		},
+	})
 
 	return () => {
 		const currentHref = readCurrentRouterHref(handle)
-		const appliedRouteData = applyRouteLoaderData(currentHref)
-		const needsStaleRefresh =
-			consumeStaleNavigationData(currentHref) && !appliedRouteData
-		const needsLoad = loadLatch.needsLoad({
-			currentHref,
-			appliedRouteData,
-			needsStaleRefresh,
-		})
-		if (needsLoad && typeof document !== 'undefined') {
-			handle.queueTask(loadUsage)
-		}
-
-		const usage = status === 'ready' ? data : null
+		const snapshot = usageData.read(handle, currentHref)
+		const usage = snapshot.data
+		const pending = snapshot.kind === 'pending'
+		const message = snapshot.error?.message ?? null
 		const groupedRows = usage
 			? groupEntitlementRows(usage.entitlementConsumption)
 			: []
@@ -289,7 +238,7 @@ export function AccountUsageRoute(handle: Handle) {
 			: null
 
 		return (
-			<AccountManagementShell>
+			<AccountManagementShell busy={pending && usage !== null}>
 				<AccountPageHeader
 					title="Usage"
 					description="Plan limits, current consumption, and what counts toward each resource."
@@ -300,7 +249,7 @@ export function AccountUsageRoute(handle: Handle) {
 						{message}
 					</AccountManagementMessage>
 				) : null}
-				{status === 'loading' ? (
+				{pending && usage === null ? (
 					<p mix={css(descriptionCss)}>Loading usage…</p>
 				) : null}
 				{usage ? (

--- a/packages/worker/client/routes/account-values.tsx
+++ b/packages/worker/client/routes/account-values.tsx
@@ -3,10 +3,8 @@ import { formatTimestampDate } from '#client/format-timestamp.ts'
 import { navigate, readCurrentRouterHref } from '#client/client-router.tsx'
 import { createDoubleCheck } from '#client/double-check.ts'
 import { createListDetailRoute } from '#client/list-detail-route.ts'
-import { createRouteLoadLatch } from '#client/route-load-latch.ts'
-import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
-import { consumeStaleNavigationData } from '#client/navigation-data.ts'
 import { replaceLocation } from '#client/replace-location.ts'
+import { createRouteData, routeDataRedirect } from '#client/route-data.tsx'
 import { matchesSearchQuery } from '#client/search-filter.ts'
 import {
 	type AccountStatus,
@@ -148,16 +146,34 @@ export async function accountValuesRouteLoader(
 }
 
 export function AccountValuesRoute(handle: Handle) {
-	let status: AccountStatus = 'loading'
 	let saveState: 'idle' | 'deleting' = 'idle'
 	let values: Array<AccountValueListItem> = []
 	let selectedValue: AccountValueDetail | null = null
 	let editorState = createEmptyEditorState()
 	let message: string | null = null
 	let messageTone: 'info' | 'error' = 'info'
-	const loadLatch = createRouteLoadLatch()
+	/** Payload last applied to the closure state above. */
+	let appliedPayload: AccountValuesLoaderData | null = null
+	let appliedError: Error | null = null
 	const deleteValueCheck = createDoubleCheck(handle)
 	let syncedSelectionKey: string | null = null
+	const valuesData = createRouteData({
+		key: 'accountValues',
+		locationKey: getDataLatchKey,
+		async load(href, signal) {
+			const response = await fetch(buildValuesApiRequestUrl(href), {
+				headers: { Accept: 'application/json' },
+				credentials: 'include',
+				signal,
+			})
+			if (response.status === 401) return routeDataRedirect('/login')
+			const payload = await readJson<AccountValuesLoaderData>(response)
+			if (!response.ok || !payload?.ok) {
+				throw new Error('Unable to load values.')
+			}
+			return payload
+		},
+	})
 
 	const dangerButtonCss = getDangerPillCss({ size: 'sm' })
 
@@ -233,42 +249,6 @@ export function AccountValuesRoute(handle: Handle) {
 		syncEditorToSelection(valuesRoute.getSelection(getCurrentHref()))
 	}
 
-	async function loadValues(signal: AbortSignal) {
-		const href = getCurrentHref()
-		const latchKey = getDataLatchKey(href)
-		try {
-			const response = await fetch(buildValuesApiRequestUrl(href), {
-				headers: { Accept: 'application/json' },
-				credentials: 'include',
-				signal,
-			})
-			if (signal.aborted) return
-			if (response.status === 401) {
-				window.location.assign('/login')
-				return
-			}
-			const payload = await readJson<AccountValuesLoaderData>(response)
-			if (!response.ok || !payload?.ok) {
-				throw new Error('Unable to load values.')
-			}
-			if (getDataLatchKey(getCurrentHref()) !== latchKey) return
-			applyPayload(payload)
-			if (messageTone === 'error') setMessage(null)
-			status = 'ready'
-			loadLatch.markLoaded(latchKey)
-			handle.update()
-		} catch (error) {
-			if (signal.aborted) return
-			status = 'error'
-			setMessage(
-				error instanceof Error ? error.message : 'Unable to load values.',
-				'error',
-			)
-			loadLatch.markFailed(latchKey)
-			handle.update()
-		}
-	}
-
 	async function deleteValueEntry() {
 		if (!selectedValue || saveState !== 'idle') return
 		saveState = 'deleting'
@@ -322,30 +302,25 @@ export function AccountValuesRoute(handle: Handle) {
 		handle.update()
 	}
 
-	function applyRouteLoaderData(href: string) {
-		if (!valuesRoute.isRoutePath(href)) return false
-		const routeData = tryConsumeRouteLoaderData(handle, 'accountValues', href)
-		if (!routeData) return false
-		applyPayload(routeData)
-		status = 'ready'
-		loadLatch.markLoaded(getDataLatchKey(href))
-		return true
-	}
-
 	return () => {
 		const currentHref = getCurrentHref()
-		const latchKey = getDataLatchKey(currentHref)
-		const appliedRouteData = applyRouteLoaderData(currentHref)
-		const needsStaleRefresh =
-			consumeStaleNavigationData(currentHref) && !appliedRouteData
-		const needsLoad = loadLatch.needsLoad({
-			currentHref: latchKey,
-			appliedRouteData,
-			needsStaleRefresh,
-		})
-		if (needsLoad && typeof document !== 'undefined') {
-			handle.queueTask(loadValues)
+		const snapshot = valuesData.read(handle, currentHref)
+		if (snapshot.data && snapshot.data !== appliedPayload) {
+			appliedPayload = snapshot.data
+			applyPayload(snapshot.data)
+			if (messageTone === 'error') setMessage(null)
 		}
+		if (snapshot.error && snapshot.error !== appliedError) {
+			appliedError = snapshot.error
+			setMessage(snapshot.error.message, 'error')
+		}
+		const pending = snapshot.kind === 'pending'
+		const status: AccountStatus =
+			snapshot.kind === 'error'
+				? 'error'
+				: pending && appliedPayload === null
+					? 'loading'
+					: 'ready'
 
 		const selection = valuesRoute.getSelection(currentHref)
 		syncEditorToSelection(selection)
@@ -356,14 +331,14 @@ export function AccountValuesRoute(handle: Handle) {
 		const isLoadingSelection =
 			selection.selectedId != null &&
 			(detail == null || detail.id !== selection.selectedId) &&
-			needsLoad
+			pending
 		const showEditor =
 			selection.selectedId != null && detail != null && !isLoadingSelection
 		const showValueNotFound =
 			selection.selectedId != null &&
 			detail == null &&
 			status === 'ready' &&
-			!needsLoad
+			!pending
 		const selectedLabel = detail?.name ?? selection.selectedId ?? 'Value'
 
 		const monospaceValueCss = {
@@ -374,7 +349,7 @@ export function AccountValuesRoute(handle: Handle) {
 		}
 
 		return (
-			<AccountManagementShell>
+			<AccountManagementShell busy={pending && appliedPayload !== null}>
 				<AccountPageHeader
 					title="Values"
 					description="Leftover named rows from an older storage model. New work uses secrets and package storage."

--- a/packages/worker/client/routes/account-waiting.tsx
+++ b/packages/worker/client/routes/account-waiting.tsx
@@ -1,12 +1,7 @@
 import { type Handle, css } from 'remix/ui'
 import { readCurrentRouterHref } from '#client/client-router.tsx'
-import { createRouteLoadLatch } from '#client/route-load-latch.ts'
-import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
-import { consumeStaleNavigationData } from '#client/navigation-data.ts'
-import {
-	type AccountStatus,
-	readJson,
-} from '#client/routes/account-approval-shared.ts'
+import { createRouteData, routeDataRedirect } from '#client/route-data.tsx'
+import { readJson } from '#client/routes/account-approval-shared.ts'
 import {
 	routeLoaderRedirect,
 	type RouteLoaderResult,
@@ -28,11 +23,6 @@ import {
 } from '#universal/styles/style-primitives.ts'
 
 const waitingApiPath = routes.accountWaitingApi.href()
-const waitingPath = routes.accountWaiting.href()
-
-function isWaitingPath(href: string) {
-	return new URL(href, 'http://localhost').pathname === waitingPath
-}
 
 const severityAccent: Record<WaitingSeverity, string> = {
 	block: colors.danger,
@@ -60,88 +50,47 @@ export async function accountWaitingRouteLoader(
 }
 
 export function AccountWaitingRoute(handle: Handle) {
-	let status: AccountStatus = 'loading'
-	let data: AccountWaitingLoaderData | null = null
-	let message: string | null = null
-	const loadLatch = createRouteLoadLatch()
-
-	function applyPayload(payload: AccountWaitingLoaderData) {
-		data = payload
-		status = 'ready'
-		message = null
-	}
-
-	async function loadWaiting(signal: AbortSignal) {
-		const href = readCurrentRouterHref(handle)
-		try {
+	const waitingData = createRouteData({
+		key: 'accountWaiting',
+		async load(_href, signal) {
 			const response = await fetch(waitingApiPath, {
 				headers: { Accept: 'application/json' },
 				credentials: 'include',
 				signal,
 			})
-			if (signal.aborted) return
-			if (response.status === 401) {
-				window.location.assign('/login')
-				return
-			}
+			if (response.status === 401) return routeDataRedirect('/login')
 			const payload = await readJson<AccountWaitingLoaderData>(response)
 			if (!response.ok || !payload?.ok) {
 				throw new Error('Unable to load waiting items.')
 			}
-			applyPayload(payload)
-			loadLatch.markLoaded(href)
-			handle.update()
-		} catch (error) {
-			if (signal.aborted) return
-			status = 'error'
-			message =
-				error instanceof Error ? error.message : 'Unable to load waiting items.'
-			loadLatch.markFailed(href)
-			handle.update()
-		}
-	}
-
-	function applyRouteLoaderData(href: string) {
-		if (!isWaitingPath(href)) return false
-		const routeData = tryConsumeRouteLoaderData(handle, 'accountWaiting', href)
-		if (!routeData) return false
-		applyPayload(routeData)
-		loadLatch.markLoaded(href)
-		return true
-	}
+			return payload
+		},
+	})
 
 	return () => {
 		const currentHref = readCurrentRouterHref(handle)
-		const appliedRouteData = applyRouteLoaderData(currentHref)
-		const needsStaleRefresh =
-			consumeStaleNavigationData(currentHref) && !appliedRouteData
-		const needsLoad = loadLatch.needsLoad({
-			currentHref,
-			appliedRouteData,
-			needsStaleRefresh,
-		})
-		if (needsLoad && typeof document !== 'undefined') {
-			handle.queueTask(loadWaiting)
-		}
+		const snapshot = waitingData.read(handle, currentHref)
+		const data = snapshot.data
+		const pending = snapshot.kind === 'pending'
 
 		return (
-			<AccountManagementShell>
+			<AccountManagementShell busy={pending && data !== null}>
 				<AccountPageHeader
 					title="Waiting"
 					description="Things that need you."
 					currentHref={currentHref}
 				/>
-				{status === 'loading' ? (
+				{pending && data === null ? (
 					<p mix={css({ color: colors.textMuted, margin: 0 })}>
 						Loading waiting items…
 					</p>
 				) : null}
-				{status === 'error' && message ? (
+				{snapshot.error ? (
 					<AccountManagementMessage tone="error">
-						{message}
+						{snapshot.error.message}
 					</AccountManagementMessage>
 				) : null}
-				{status === 'ready' && data ? renderWaitingBody(data.items) : null}
+				{data ? renderWaitingBody(data.items) : null}
 			</AccountManagementShell>
 		)
 	}

--- a/packages/worker/client/routes/account-workflows.tsx
+++ b/packages/worker/client/routes/account-workflows.tsx
@@ -3,10 +3,8 @@ import { on } from '#client/event-mixin.ts'
 import { readCurrentRouterHref } from '#client/client-router.tsx'
 import { createDoubleCheck } from '#client/double-check.ts'
 import { createListDetailRoute } from '#client/list-detail-route.ts'
-import { createRouteLoadLatch } from '#client/route-load-latch.ts'
 import { replaceLocation } from '#client/replace-location.ts'
-import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
-import { consumeStaleNavigationData } from '#client/navigation-data.ts'
+import { createRouteData, routeDataRedirect } from '#client/route-data.tsx'
 import {
 	type AccountStatus,
 	readJson,
@@ -217,20 +215,34 @@ function statusColor(status: AccountWorkflowRunStatus | null) {
 	}
 }
 
-function tryConsumeAccountWorkflowsLoaderData(handle: Handle, href: string) {
-	return tryConsumeRouteLoaderData(handle, 'accountWorkflows', href)
-}
-
 export function AccountWorkflowsRoute(handle: Handle) {
-	let status: AccountStatus = 'loading'
 	let actionState: 'idle' | 'busy' = 'idle'
 	let username = ''
 	let workflows: Array<AccountWorkflowListItem> = []
 	let selectedWorkflow: AccountWorkflowDetail | null = null
 	let message: string | null = null
 	let messageTone: MessageTone = 'info'
-	const loadLatch = createRouteLoadLatch()
+	/** Payload last applied to the closure state above. */
+	let appliedPayload: AccountWorkflowsLoaderData | null = null
+	let appliedError: Error | null = null
 	const cancelWorkflowCheck = createDoubleCheck(handle)
+	const workflowsData = createRouteData({
+		key: 'accountWorkflows',
+		locationKey: getDataLatchKey,
+		async load(href, signal) {
+			const response = await fetch(buildWorkflowsApiRequestUrl(href), {
+				headers: { Accept: 'application/json' },
+				credentials: 'include',
+				signal,
+			})
+			if (response.status === 401) return routeDataRedirect('/login')
+			const payload = await readJson<AccountWorkflowsLoaderData>(response)
+			if (!response.ok || !payload?.ok) {
+				throw new Error('Unable to load workflow runs.')
+			}
+			return payload
+		},
+	})
 
 	const secondaryButtonCss = getGhostButtonCss({ size: 'sm' })
 	const dangerButtonCss = getDangerPillCss({ size: 'sm' })
@@ -267,44 +279,6 @@ export function AccountWorkflowsRoute(handle: Handle) {
 		workflows = payload.workflows
 		selectedWorkflow = payload.selectedWorkflow
 		cancelWorkflowCheck.reset()
-	}
-
-	async function loadWorkflows(signal: AbortSignal) {
-		const href = getCurrentHref()
-		const latchKey = getDataLatchKey(href)
-		try {
-			const response = await fetch(buildWorkflowsApiRequestUrl(href), {
-				headers: { Accept: 'application/json' },
-				credentials: 'include',
-				signal,
-			})
-			if (signal.aborted) return
-			if (response.status === 401) {
-				window.location.assign('/login')
-				return
-			}
-			const payload = await readJson<AccountWorkflowsLoaderData>(response)
-			if (!response.ok || !payload?.ok) {
-				throw new Error('Unable to load workflow runs.')
-			}
-			if (getDataLatchKey(getCurrentHref()) !== latchKey) return
-			applyPayload(payload)
-			if (messageTone === 'error') setMessage(null)
-			status = 'ready'
-			loadLatch.markLoaded(latchKey)
-			handle.update()
-		} catch (error) {
-			if (signal.aborted) return
-			status = 'error'
-			setMessage(
-				error instanceof Error
-					? error.message
-					: 'Unable to load workflow runs.',
-				'error',
-			)
-			loadLatch.markFailed(latchKey)
-			handle.update()
-		}
 	}
 
 	async function postAction(input: {
@@ -366,30 +340,25 @@ export function AccountWorkflowsRoute(handle: Handle) {
 		}
 	}
 
-	function applyRouteLoaderData(href: string) {
-		if (!workflowsRoute.isRoutePath(href)) return false
-		const routeData = tryConsumeAccountWorkflowsLoaderData(handle, href)
-		if (!routeData) return false
-		applyPayload(routeData)
-		status = 'ready'
-		loadLatch.markLoaded(getDataLatchKey(href))
-		return true
-	}
-
 	return () => {
 		const currentHref = getCurrentHref()
-		const appliedRouteData = applyRouteLoaderData(currentHref)
-		const needsStaleRefresh =
-			consumeStaleNavigationData(currentHref) && !appliedRouteData
-		const latchKey = getDataLatchKey(currentHref)
-		const needsLoad = loadLatch.needsLoad({
-			currentHref: latchKey,
-			appliedRouteData,
-			needsStaleRefresh,
-		})
-		if (needsLoad && typeof document !== 'undefined') {
-			handle.queueTask(loadWorkflows)
+		const snapshot = workflowsData.read(handle, currentHref)
+		if (snapshot.data && snapshot.data !== appliedPayload) {
+			appliedPayload = snapshot.data
+			applyPayload(snapshot.data)
+			if (messageTone === 'error') setMessage(null)
 		}
+		if (snapshot.error && snapshot.error !== appliedError) {
+			appliedError = snapshot.error
+			setMessage(snapshot.error.message, 'error')
+		}
+		const pending = snapshot.kind === 'pending'
+		const status: AccountStatus =
+			snapshot.kind === 'error'
+				? 'error'
+				: pending && appliedPayload === null
+					? 'loading'
+					: 'ready'
 		const isMutating = actionState !== 'idle'
 		const selection = workflowsRoute.getSelection(currentHref)
 		const search = readWorkflowsSearchFilter(currentHref)
@@ -413,7 +382,7 @@ export function AccountWorkflowsRoute(handle: Handle) {
 		const waitingForDetail =
 			selection.selectedId != null &&
 			!detail &&
-			(needsLoad || listMatch != null || status === 'loading')
+			(pending || listMatch != null || status === 'loading')
 		const showWorkflowNotFound =
 			selection.selectedId != null &&
 			!detail &&
@@ -422,7 +391,7 @@ export function AccountWorkflowsRoute(handle: Handle) {
 		const canCancel = detail ? isActiveAccountWorkflow(detail) : false
 
 		return (
-			<AccountManagementShell>
+			<AccountManagementShell busy={pending && appliedPayload !== null}>
 				<AccountPageHeader
 					title="Workflows"
 					description="Inspect deferred and long-running workflow runs — inline or package-backed — including status, schedule time, and errors. Cancel a run that has not finished yet."

--- a/packages/worker/client/routes/account.tsx
+++ b/packages/worker/client/routes/account.tsx
@@ -2,9 +2,8 @@ import { type Handle, css } from 'remix/ui'
 import { listenForAvatarFileDrop } from '#client/listen-for-avatar-file-drop.ts'
 import { AccountAvatarEditor } from '#client/routes/account-avatar-editor.tsx'
 import { readCurrentRouterHref } from '#client/client-router.tsx'
-import { createRouteLoadLatch } from '#client/route-load-latch.ts'
 import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
-import { consumeStaleNavigationData } from '#client/navigation-data.ts'
+import { createRouteData, routeDataRedirect } from '#client/route-data.tsx'
 import {
 	type OnboardingChecklistLoaderData,
 	type AccountProfileLoaderData,
@@ -33,7 +32,10 @@ import {
 	accountProfileApiPath,
 	readJson,
 } from '#client/routes/account-approval-shared.ts'
-import { fetchAccountPagePayloads } from '#client/routes/account-page-data.ts'
+import {
+	type AccountPagePayloads,
+	fetchAccountPagePayloads,
+} from '#client/routes/account-page-data.ts'
 import { AccountDeletePanel } from '#client/routes/account-delete-panel.tsx'
 import { renderAccountLogoutPanel } from '#client/routes/account-logout-panel.tsx'
 import {
@@ -69,7 +71,6 @@ function isAccountPath(href: string) {
 }
 
 export function AccountRoute(handle: Handle) {
-	let status: AccountStatus = 'loading'
 	let saveStatus: 'idle' | 'saving' = 'idle'
 	let resendStatus: 'idle' | 'sending' = 'idle'
 	let resendMessage: string | null = null
@@ -100,55 +101,72 @@ export function AccountRoute(handle: Handle) {
 	let consumedCallbackMessage = false
 	let needsOnboarding = false
 	let onboardingChecklist: OnboardingChecklistLoaderData | null = null
-	const loadLatch = createRouteLoadLatch()
+	/** Payload last applied to the closure state above. */
+	let appliedPayload: AccountPagePayloads | null = null
+	let appliedError: Error | null = null
+	const accountData = createRouteData<'accountProfile', AccountPagePayloads>({
+		consume(handle, href) {
+			if (!isAccountPath(href)) return null
+			const accountProfile = tryConsumeRouteLoaderData(
+				handle,
+				'accountProfile',
+				href,
+			)
+			if (!accountProfile) return null
+			const accountConnections = tryConsumeRouteLoaderData(
+				handle,
+				'accountConnections',
+				href,
+			)
+			if (!accountConnections) return null
+			const accountConnectedAgents = tryConsumeRouteLoaderData(
+				handle,
+				'accountConnectedAgents',
+				href,
+			)
+			if (!accountConnectedAgents) return null
+			const onboarding = tryConsumeRouteLoaderData(handle, 'onboarding', href)
+			return {
+				accountProfile,
+				accountConnections,
+				accountConnectedAgents,
+				onboarding: onboarding ?? null,
+			}
+		},
+		async load(href, signal) {
+			const search = new URL(href, 'http://localhost').search
+			const result = await fetchAccountPagePayloads(search, signal)
+			if (result.kind === 'unauthorized') return routeDataRedirect('/login')
+			return result.payloads
+		},
+	})
 
 	function applyOnboardingPayload(payload: OnboardingPayload | null) {
 		needsOnboarding = payload?.needsOnboarding === true
 		onboardingChecklist = payload?.checklist ?? null
 	}
 
-	async function loadAccountProfile(signal: AbortSignal) {
-		const href = readCurrentRouterHref(handle)
-		try {
-			const search = new URL(href, 'http://localhost').search
-			const result = await fetchAccountPagePayloads(search, signal)
-			if (signal.aborted) return
-			if (result.kind === 'unauthorized') {
-				window.location.assign('/login')
-				return
-			}
-			const {
-				accountProfile: payload,
-				accountConnections: connectionsPayload,
-				accountConnectedAgents: connectedAgentsPayload,
-				onboarding,
-			} = result.payloads
-			applyOnboardingPayload(onboarding)
-			accountConnections.applyPayload(connectionsPayload)
-			accountConnectedAgents.applyPayload(connectedAgentsPayload)
-			email = payload.email
-			emailVerified = payload.emailVerified
-			emailVerificationDelivery = payload.emailVerificationDelivery ?? null
-			username = payload.username
-			if (!usernameSaveError) {
-				draftUsername = payload.username
-				message = null
-				messageTone = 'info'
-			}
-			applyProfileFields(payload)
-			accountEmailClaims.applyCurrentEmail(payload.email)
-			status = 'ready'
-			loadLatch.markLoaded(href)
-			handle.update()
-		} catch (error) {
-			if (signal.aborted) return
-			status = 'error'
-			message =
-				error instanceof Error ? error.message : 'Unable to load your account.'
-			messageTone = 'error'
-			loadLatch.markFailed(href)
-			handle.update()
+	function applyPayload(payloads: AccountPagePayloads) {
+		const {
+			accountProfile: payload,
+			accountConnections: connectionsPayload,
+			accountConnectedAgents: connectedAgentsPayload,
+			onboarding,
+		} = payloads
+		applyOnboardingPayload(onboarding)
+		accountConnections.applyPayload(connectionsPayload)
+		accountConnectedAgents.applyPayload(connectedAgentsPayload)
+		email = payload.email
+		emailVerified = payload.emailVerified
+		emailVerificationDelivery = payload.emailVerificationDelivery ?? null
+		username = payload.username
+		if (!usernameSaveError) {
+			draftUsername = payload.username
+			message = null
+			messageTone = 'info'
 		}
+		applyProfileFields(payload)
+		accountEmailClaims.applyCurrentEmail(payload.email)
 	}
 
 	function applyProfileFields(payload: AccountProfileLoaderData) {
@@ -466,59 +484,25 @@ export function AccountRoute(handle: Handle) {
 		}
 	}
 
-	function applyRouteLoaderData(href: string) {
-		if (!isAccountPath(href)) return false
-		const routeData = tryConsumeRouteLoaderData(handle, 'accountProfile', href)
-		if (!routeData) return false
-		const connectionsData = tryConsumeRouteLoaderData(
-			handle,
-			'accountConnections',
-			href,
-		)
-		if (!connectionsData) return false
-		email = routeData.email
-		emailVerified = routeData.emailVerified
-		emailVerificationDelivery = routeData.emailVerificationDelivery ?? null
-		username = routeData.username
-		if (!usernameSaveError) {
-			draftUsername = routeData.username
-			message = null
-			messageTone = 'info'
-		}
-		applyProfileFields(routeData)
-		accountEmailClaims.applyCurrentEmail(routeData.email)
-		accountConnections.applyPayload(connectionsData)
-		const connectedAgentsData = tryConsumeRouteLoaderData(
-			handle,
-			'accountConnectedAgents',
-			href,
-		)
-		if (!connectedAgentsData) return false
-		accountConnectedAgents.applyPayload(connectedAgentsData)
-		const onboardingData = tryConsumeRouteLoaderData(handle, 'onboarding', href)
-		if (onboardingData) {
-			applyOnboardingPayload(onboardingData)
-		}
-		status = 'ready'
-		loadLatch.markLoaded(href)
-		return true
-	}
-
 	return () => {
 		const currentHref = readCurrentRouterHref(handle)
-		const appliedRouteData = applyRouteLoaderData(currentHref)
-		// A same-path refresh whose loader failed leaves no preload and no
-		// href change; the stale marker forces the fallback refetch.
-		const needsStaleRefresh =
-			consumeStaleNavigationData(currentHref) && !appliedRouteData
-		const needsLoad = loadLatch.needsLoad({
-			currentHref,
-			appliedRouteData,
-			needsStaleRefresh,
-		})
-		if (needsLoad && typeof document !== 'undefined') {
-			handle.queueTask(loadAccountProfile)
+		const snapshot = accountData.read(handle, currentHref)
+		if (snapshot.data && snapshot.data !== appliedPayload) {
+			appliedPayload = snapshot.data
+			applyPayload(snapshot.data)
 		}
+		if (snapshot.error && snapshot.error !== appliedError) {
+			appliedError = snapshot.error
+			message = snapshot.error.message
+			messageTone = 'error'
+		}
+		const pending = snapshot.kind === 'pending'
+		const status: AccountStatus =
+			snapshot.kind === 'error'
+				? 'error'
+				: pending && appliedPayload === null
+					? 'loading'
+					: 'ready'
 		// Apply the OAuth flash on both SSR and client from the URL so the
 		// first client render matches the server HTML. A client-only message
 		// mismatched SSR and duplicated the connections list during hydration.
@@ -543,7 +527,7 @@ export function AccountRoute(handle: Handle) {
 		const usernameFieldError = usernameSaveError ?? liveUsernameFormatError
 
 		return (
-			<AccountManagementShell>
+			<AccountManagementShell busy={pending && appliedPayload !== null}>
 				<AccountPageHeader
 					title="Account"
 					description="Manage your profile, security settings, connected accounts, and data."

--- a/packages/worker/client/routes/admin-banners-shared.ts
+++ b/packages/worker/client/routes/admin-banners-shared.ts
@@ -17,7 +17,6 @@ import {
 } from '#universal/youtube-watch.ts'
 
 export const adminBannersApiPath = '/admin/banners.json'
-const adminBannersPath = '/admin/banners'
 
 export type BannerDraft = {
 	id: string | null
@@ -41,10 +40,6 @@ export type BannerDraft = {
 	dismissible: boolean
 	startsAt: string
 	endsAt: string
-}
-
-export function isAdminBannersPath(href: string) {
-	return new URL(href, 'http://localhost').pathname === adminBannersPath
 }
 
 export function emptyDraft(): BannerDraft {

--- a/packages/worker/client/routes/admin-banners.tsx
+++ b/packages/worker/client/routes/admin-banners.tsx
@@ -2,8 +2,7 @@ import { type Handle, css } from 'remix/ui'
 import { on } from '#client/event-mixin.ts'
 import { readCurrentRouterHref } from '#client/client-router.tsx'
 import { createDoubleCheck } from '#client/double-check.ts'
-import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
-import { consumeStaleNavigationData } from '#client/navigation-data.ts'
+import { createRouteData, routeDataRedirect } from '#client/route-data.tsx'
 import { readJson } from '#client/routes/account-approval-shared.ts'
 import {
 	routeLoaderRedirect,
@@ -30,7 +29,6 @@ import {
 	draftFromBanner,
 	draftToInput,
 	emptyDraft,
-	isAdminBannersPath,
 	type BannerDraft,
 } from './admin-banners-shared.ts'
 
@@ -60,69 +58,42 @@ export async function adminBannersRouteLoader(
 }
 
 export function AdminBannersRoute(handle: Handle) {
-	let status: PageStatus = 'loading'
 	let banners: Array<SiteBannerRecord> = []
 	let draft: BannerDraft = emptyDraft()
 	let message: string | null = null
 	let messageTone: 'info' | 'error' = 'info'
 	let actionState: ActionState = 'idle'
-	let lastLoadedHref = ''
-	let loadingForHref: string | null = null
-	let lastFailedHref: string | null = null
-	let loadRequestId = 0
+	/** Payload last applied to the closure state above. */
+	let appliedPayload: AdminBannersLoaderData | null = null
+	let appliedError: Error | null = null
 	const deleteCheck = createDoubleCheck(handle)
 	const secondaryButtonCss = getGhostButtonCss({ size: 'sm' })
-
-	function applyData(payload: AdminBannersLoaderData) {
-		banners = payload.banners
-		status = 'ready'
-		message = null
-		messageTone = 'info'
-		if (draft.id && !payload.banners.some((banner) => banner.id === draft.id)) {
-			draft = emptyDraft()
-		}
-	}
-
-	async function loadBanners() {
-		const href = readCurrentRouterHref(handle)
-		loadingForHref = href
-		const requestId = ++loadRequestId
-		try {
+	const bannersData = createRouteData({
+		key: 'adminBanners',
+		async load(_href, signal) {
 			const response = await fetch(adminBannersApiPath, {
 				headers: { Accept: 'application/json' },
 				credentials: 'include',
+				signal,
 			})
-			if (requestId !== loadRequestId) return
-			if (response.status === 401) {
-				window.location.assign('/login')
-				return
-			}
+			if (response.status === 401) return routeDataRedirect('/login')
 			if (response.status === 403) {
-				status = 'error'
-				message = 'You do not have permission to manage banners.'
-				messageTone = 'error'
-				lastFailedHref = href
-				handle.update()
-				return
+				throw new Error('You do not have permission to manage banners.')
 			}
 			const payload = await readJson<AdminBannersLoaderData>(response)
 			if (!response.ok || !payload?.ok) {
 				throw new Error('Unable to load banners.')
 			}
-			applyData(payload)
-			lastLoadedHref = href
-			lastFailedHref = null
-			handle.update()
-		} catch (error) {
-			if (requestId !== loadRequestId) return
-			status = 'error'
-			message =
-				error instanceof Error ? error.message : 'Unable to load banners.'
-			messageTone = 'error'
-			lastFailedHref = href
-			handle.update()
-		} finally {
-			if (requestId === loadRequestId) loadingForHref = null
+			return payload
+		},
+	})
+
+	function applyData(payload: AdminBannersLoaderData) {
+		banners = payload.banners
+		message = null
+		messageTone = 'info'
+		if (draft.id && !payload.banners.some((banner) => banner.id === draft.id)) {
+			draft = emptyDraft()
 		}
 	}
 
@@ -199,30 +170,26 @@ export function AdminBannersRoute(handle: Handle) {
 
 	return () => {
 		const currentHref = readCurrentRouterHref(handle)
-		const routeData = isAdminBannersPath(currentHref)
-			? tryConsumeRouteLoaderData(handle, 'adminBanners', currentHref)
-			: undefined
-		if (routeData) {
-			applyData(routeData)
-			lastLoadedHref = currentHref
-			lastFailedHref = null
+		const snapshot = bannersData.read(handle, currentHref)
+		if (snapshot.data && snapshot.data !== appliedPayload) {
+			appliedPayload = snapshot.data
+			applyData(snapshot.data)
 		}
-		const needsStaleRefresh =
-			consumeStaleNavigationData(currentHref) && !routeData
-		const needsLoad =
-			(status === 'loading' ||
-				currentHref !== lastLoadedHref ||
-				needsStaleRefresh) &&
-			currentHref !== lastFailedHref &&
-			loadingForHref !== currentHref
-		if (!routeData && needsLoad && typeof document !== 'undefined') {
-			status = 'loading'
-			loadingForHref = currentHref
-			handle.queueTask(loadBanners)
+		if (snapshot.error && snapshot.error !== appliedError) {
+			appliedError = snapshot.error
+			message = snapshot.error.message
+			messageTone = 'error'
 		}
+		const pending = snapshot.kind === 'pending'
+		const status: PageStatus =
+			snapshot.kind === 'error'
+				? 'error'
+				: pending && appliedPayload === null
+					? 'loading'
+					: 'ready'
 
 		return (
-			<AccountManagementShell>
+			<AccountManagementShell busy={pending && appliedPayload !== null}>
 				<AdminPageHeader
 					title="Admin banners"
 					description="Create, target, and enable site announcement banners. Edit the strip itself before you save. Content is live without a deploy."

--- a/packages/worker/client/routes/admin-codemods-shared.ts
+++ b/packages/worker/client/routes/admin-codemods-shared.ts
@@ -32,10 +32,6 @@ export const runModes = [
 	'revert',
 ] as const satisfies ReadonlyArray<RunMode>
 
-export function isAdminCodemodsPath(href: string) {
-	return new URL(href, 'http://localhost').pathname === '/admin/codemods'
-}
-
 export function parseCommaSeparatedIds(value: string): Array<string> {
 	return value
 		.split(',')

--- a/packages/worker/client/routes/admin-codemods.tsx
+++ b/packages/worker/client/routes/admin-codemods.tsx
@@ -1,8 +1,7 @@
 import { type Handle, css } from 'remix/ui'
 import { on } from '#client/event-mixin.ts'
 import { readCurrentRouterHref } from '#client/client-router.tsx'
-import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
-import { consumeStaleNavigationData } from '#client/navigation-data.ts'
+import { createRouteData, routeDataRedirect } from '#client/route-data.tsx'
 import { readJson } from '#client/routes/account-approval-shared.ts'
 import {
 	type LiveRunItem,
@@ -13,7 +12,6 @@ import {
 	adminCodemodsRunApiPath,
 	adminCodemodsRunStopApiPath,
 	formatSummaryCounts,
-	isAdminCodemodsPath,
 	maxRunSteps,
 	mergeSummaryCounts,
 	parseCommaSeparatedIds,
@@ -51,15 +49,32 @@ import {
 const selectCss = getSelectCss()
 
 export function AdminCodemodsRoute(handle: Handle) {
-	let status: PageStatus = 'loading'
 	let codemods: Array<AdminCodemodListItem> = []
 	let runs: Array<AdminCodemodRunListItem> = []
 	let message: string | null = null
 	let messageTone: 'info' | 'error' = 'info'
-	let loadRequestId = 0
-	let lastLoadedHref = ''
-	let loadingForHref: string | null = null
-	let lastFailedHref: string | null = null
+	/** Payload last applied to the closure state above. */
+	let appliedPayload: AdminCodemodsLoaderData | null = null
+	let appliedError: Error | null = null
+	const codemodsData = createRouteData({
+		key: 'adminCodemods',
+		async load(_href, signal) {
+			const response = await fetch(adminCodemodsApiPath, {
+				headers: { Accept: 'application/json' },
+				credentials: 'include',
+				signal,
+			})
+			if (response.status === 401) return routeDataRedirect('/login')
+			if (response.status === 403) {
+				throw new Error('You do not have permission to view package codemods.')
+			}
+			const payload = await readJson<AdminCodemodsLoaderData>(response)
+			if (!response.ok || !payload?.ok) {
+				throw new Error('Unable to load package codemods.')
+			}
+			return payload
+		},
+	})
 
 	let selectedCodemodId = ''
 	let selectedMode: RunMode = 'scan'
@@ -90,54 +105,8 @@ export function AdminCodemodsRoute(handle: Handle) {
 		) {
 			selectedCodemodId = codemods[0]?.id ?? ''
 		}
-		status = 'ready'
 		message = null
 		messageTone = 'info'
-	}
-
-	async function loadCodemods() {
-		const href = readCurrentRouterHref(handle)
-		loadingForHref = href
-		const requestId = ++loadRequestId
-		try {
-			const response = await fetch(adminCodemodsApiPath, {
-				headers: { Accept: 'application/json' },
-				credentials: 'include',
-			})
-			if (requestId !== loadRequestId) return
-			if (response.status === 401) {
-				window.location.assign('/login')
-				return
-			}
-			if (response.status === 403) {
-				status = 'error'
-				message = 'You do not have permission to view package codemods.'
-				messageTone = 'error'
-				lastFailedHref = href
-				handle.update()
-				return
-			}
-			const payload = await readJson<AdminCodemodsLoaderData>(response)
-			if (!response.ok || !payload?.ok) {
-				throw new Error('Unable to load package codemods.')
-			}
-			applyData(payload)
-			lastLoadedHref = href
-			lastFailedHref = null
-			handle.update()
-		} catch (error) {
-			if (requestId !== loadRequestId) return
-			status = 'error'
-			message =
-				error instanceof Error
-					? error.message
-					: 'Unable to load package codemods.'
-			messageTone = 'error'
-			lastFailedHref = href
-			handle.update()
-		} finally {
-			if (requestId === loadRequestId) loadingForHref = null
-		}
 	}
 
 	async function refreshRuns() {
@@ -446,27 +415,23 @@ export function AdminCodemodsRoute(handle: Handle) {
 
 	return () => {
 		const currentHref = readCurrentRouterHref(handle)
-		const routeData = isAdminCodemodsPath(currentHref)
-			? tryConsumeRouteLoaderData(handle, 'adminCodemods', currentHref)
-			: undefined
-		if (routeData) {
-			applyData(routeData)
-			lastLoadedHref = currentHref
-			lastFailedHref = null
+		const snapshot = codemodsData.read(handle, currentHref)
+		if (snapshot.data && snapshot.data !== appliedPayload) {
+			appliedPayload = snapshot.data
+			applyData(snapshot.data)
 		}
-		const needsStaleRefresh =
-			consumeStaleNavigationData(currentHref) && !routeData
-		const needsLoad =
-			(status === 'loading' ||
-				currentHref !== lastLoadedHref ||
-				needsStaleRefresh) &&
-			currentHref !== lastFailedHref &&
-			loadingForHref !== currentHref
-		if (!routeData && needsLoad && typeof document !== 'undefined') {
-			status = 'loading'
-			loadingForHref = currentHref
-			handle.queueTask(loadCodemods)
+		if (snapshot.error && snapshot.error !== appliedError) {
+			appliedError = snapshot.error
+			message = snapshot.error.message
+			messageTone = 'error'
 		}
+		const pending = snapshot.kind === 'pending'
+		const status: PageStatus =
+			snapshot.kind === 'error'
+				? 'error'
+				: pending && appliedPayload === null
+					? 'loading'
+					: 'ready'
 
 		const isRunning = runPhase === 'running'
 		const canMutate = !isRunning && status === 'ready'
@@ -476,7 +441,7 @@ export function AdminCodemodsRoute(handle: Handle) {
 			pendingConfirmKey === getConfirmKey('revert-form', selectedCodemodId)
 
 		return (
-			<AccountManagementShell>
+			<AccountManagementShell busy={pending && appliedPayload !== null}>
 				<AdminPageHeader
 					title="Admin codemods"
 					description="Scan, dry-run, apply, and revert package codemods across the fleet."

--- a/packages/worker/client/routes/admin-community-reports.tsx
+++ b/packages/worker/client/routes/admin-community-reports.tsx
@@ -2,9 +2,7 @@ import { formatTimestamp } from '#client/format-timestamp.ts'
 import { type Handle, css } from 'remix/ui'
 import { on } from '#client/event-mixin.ts'
 import { readCurrentRouterHref } from '#client/client-router.tsx'
-import { readRouterSearch } from '#client/router-location.tsx'
-import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
-import { consumeStaleNavigationData } from '#client/navigation-data.ts'
+import { createRouteData, routeDataRedirect } from '#client/route-data.tsx'
 import { readJson } from '#client/routes/account-approval-shared.ts'
 import { colors, spacing, typography } from '#universal/styles/tokens.ts'
 import {
@@ -61,12 +59,6 @@ const statusOptions = [
 	{ value: 'all', label: 'All' },
 ] as const
 
-function isAdminCommunityReportsPath(href: string) {
-	return (
-		new URL(href, 'http://localhost').pathname === '/admin/community-reports'
-	)
-}
-
 function buildReportsHref(handle: Handle, status: string) {
 	const url = new URL(readCurrentRouterHref(handle), 'http://localhost')
 	if (status === 'open') url.searchParams.delete('status')
@@ -97,17 +89,37 @@ export async function adminCommunityReportsRouteLoader(
 }
 
 export function AdminCommunityReportsRoute(handle: Handle) {
-	let status: PageStatus = 'loading'
 	let reports: Array<AdminCommunityReportListItem> = []
 	let statusFilter = 'open'
 	let message: string | null = null
 	let actionState: 'idle' | 'acting' = 'idle'
 	let noteByReportId = new Map<string, string>()
 	let pendingDoubleCheckKey: string | null = null
-	let loadRequestId = 0
-	let lastLoadedHref = ''
-	let loadingForHref: string | null = null
-	let lastFailedHref: string | null = null
+	/** Payload last applied to the closure state above. */
+	let appliedPayload: AdminCommunityReportsLoaderData | null = null
+	let appliedError: Error | null = null
+	const reportsData = createRouteData({
+		key: 'adminCommunityReports',
+		async load(href, signal) {
+			const response = await fetch(
+				`${adminCommunityReportsApiPath}${new URL(href, 'http://localhost').search}`,
+				{
+					headers: { Accept: 'application/json' },
+					credentials: 'include',
+					signal,
+				},
+			)
+			if (response.status === 401) return routeDataRedirect('/login')
+			if (response.status === 403) {
+				throw new Error('You do not have permission to view community reports.')
+			}
+			const payload = await readJson<AdminCommunityReportsLoaderData>(response)
+			if (!response.ok || !payload?.ok) {
+				throw new Error('Unable to load community reports.')
+			}
+			return payload
+		},
+	})
 
 	function getDoubleCheckKey(reportId: string, intent: ReportIntent) {
 		return `${reportId}:${intent}`
@@ -152,55 +164,6 @@ export function AdminCommunityReportsRoute(handle: Handle) {
 		handle.update()
 	}
 
-	async function loadReports() {
-		const href = readCurrentRouterHref(handle)
-		loadingForHref = href
-		const requestId = ++loadRequestId
-		try {
-			const response = await fetch(
-				`${adminCommunityReportsApiPath}${readRouterSearch(handle)}`,
-				{
-					headers: { Accept: 'application/json' },
-					credentials: 'include',
-				},
-			)
-			if (requestId !== loadRequestId) return
-			if (response.status === 401) {
-				window.location.assign('/login')
-				return
-			}
-			if (response.status === 403) {
-				status = 'error'
-				message = 'You do not have permission to view community reports.'
-				lastFailedHref = href
-				handle.update()
-				return
-			}
-			const payload = await readJson<AdminCommunityReportsLoaderData>(response)
-			if (!response.ok || !payload?.ok) {
-				throw new Error('Unable to load community reports.')
-			}
-			reports = payload.reports
-			statusFilter = payload.statusFilter
-			status = 'ready'
-			message = null
-			lastLoadedHref = href
-			lastFailedHref = null
-			handle.update()
-		} catch (error) {
-			if (requestId !== loadRequestId) return
-			status = 'error'
-			message =
-				error instanceof Error
-					? error.message
-					: 'Unable to load community reports.'
-			lastFailedHref = href
-			handle.update()
-		} finally {
-			if (requestId === loadRequestId) loadingForHref = null
-		}
-	}
-
 	async function submitReportAction(reportId: string, intent: ReportIntent) {
 		if (actionState !== 'idle') return
 		actionState = 'acting'
@@ -230,8 +193,7 @@ export function AdminCommunityReportsRoute(handle: Handle) {
 				throw new Error(payload?.error ?? 'Unable to complete action.')
 			}
 			actionState = 'idle'
-			status = 'loading'
-			handle.update()
+			reportsData.reload(handle, readCurrentRouterHref(handle))
 		} catch (error) {
 			actionState = 'idle'
 			message =
@@ -240,57 +202,33 @@ export function AdminCommunityReportsRoute(handle: Handle) {
 		}
 	}
 
-	function applyRouteLoaderData(href: string) {
-		if (!isAdminCommunityReportsPath(href)) return false
-		const routeData = tryConsumeRouteLoaderData(
-			handle,
-			'adminCommunityReports',
-			href,
-		)
-		if (!routeData) return false
-		reports = routeData.reports
-		statusFilter = routeData.statusFilter
-		status = 'ready'
-		message = null
-		lastLoadedHref = href
-		lastFailedHref = null
-		return true
-	}
-
 	const secondaryButtonCss = getGhostButtonCss({ size: 'sm' })
 	const dangerButtonCss = getDangerPillCss({ size: 'sm' })
-
-	let lastSeenHref = ''
 
 	return () => {
 		const currentHref = readCurrentRouterHref(handle)
 		const isMutating = actionState !== 'idle'
-		// The failure latch only guards retry loops for the location that
-		// failed; leaving it (or coming back) must allow a fresh attempt.
-		if (currentHref !== lastSeenHref) {
-			lastSeenHref = currentHref
-			lastFailedHref = null
+		const snapshot = reportsData.read(handle, currentHref)
+		if (snapshot.data && snapshot.data !== appliedPayload) {
+			appliedPayload = snapshot.data
+			reports = snapshot.data.reports
+			statusFilter = snapshot.data.statusFilter
+			message = null
 		}
-
-		const appliedRouteData = applyRouteLoaderData(currentHref)
-		// A same-path refresh whose loader failed leaves no preload and no
-		// href change; the stale marker forces the fallback refetch.
-		const needsStaleRefresh =
-			consumeStaleNavigationData(currentHref) && !appliedRouteData
-		const needsLoad =
-			(status === 'loading' ||
-				currentHref !== lastLoadedHref ||
-				needsStaleRefresh) &&
-			currentHref !== lastFailedHref &&
-			loadingForHref !== currentHref
-		if (!appliedRouteData && needsLoad && typeof document !== 'undefined') {
-			status = 'loading'
-			loadingForHref = currentHref
-			handle.queueTask(loadReports)
+		if (snapshot.error && snapshot.error !== appliedError) {
+			appliedError = snapshot.error
+			message = snapshot.error.message
 		}
+		const pending = snapshot.kind === 'pending'
+		const status: PageStatus =
+			snapshot.kind === 'error'
+				? 'error'
+				: pending && appliedPayload === null
+					? 'loading'
+					: 'ready'
 
 		return (
-			<AccountManagementShell>
+			<AccountManagementShell busy={pending && appliedPayload !== null}>
 				<AdminPageHeader
 					title="Community reports"
 					description="Review open reports and moderate community listings."

--- a/packages/worker/client/routes/admin-feature-flags.tsx
+++ b/packages/worker/client/routes/admin-feature-flags.tsx
@@ -2,8 +2,7 @@ import { formatNullableTimestamp } from '#client/format-timestamp.ts'
 import { type Handle, css } from 'remix/ui'
 import { on } from '#client/event-mixin.ts'
 import { readCurrentRouterHref } from '#client/client-router.tsx'
-import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
-import { consumeStaleNavigationData } from '#client/navigation-data.ts'
+import { createRouteData, routeDataRedirect } from '#client/route-data.tsx'
 import { readJson } from '#client/routes/account-approval-shared.ts'
 import { colors, mq, spacing, typography } from '#universal/styles/tokens.ts'
 import {
@@ -51,10 +50,6 @@ type ActionState =
 	| 'deleting-stale'
 
 const adminFeatureFlagsApiPath = '/admin/feature-flags.json'
-
-function isAdminFeatureFlagsPath(href: string) {
-	return new URL(href, 'http://localhost').pathname === '/admin/feature-flags'
-}
 
 function formatMeasureLabel(measure: FeatureFlagSuccessMetricMeasure): string {
 	switch (measure) {
@@ -137,64 +132,37 @@ export async function adminFeatureFlagsRouteLoader(
 }
 
 export function AdminFeatureFlagsRoute(handle: Handle) {
-	let status: PageStatus = 'loading'
 	let featureFlags: Array<AdminFeatureFlag> = []
 	let message: string | null = null
 	let messageTone: 'info' | 'error' = 'info'
 	let actionState: ActionState = 'idle'
-	let lastLoadedHref = ''
-	let loadingForHref: string | null = null
-	let lastFailedHref: string | null = null
-	let loadRequestId = 0
-
-	function applyData(payload: AdminFeatureFlagsLoaderData) {
-		featureFlags = payload.featureFlags
-		status = 'ready'
-		message = null
-		messageTone = 'info'
-	}
-
-	async function loadFeatureFlags() {
-		const href = readCurrentRouterHref(handle)
-		loadingForHref = href
-		const requestId = ++loadRequestId
-		try {
+	/** Payload last applied to the closure state above. */
+	let appliedPayload: AdminFeatureFlagsLoaderData | null = null
+	let appliedError: Error | null = null
+	const featureFlagsData = createRouteData({
+		key: 'adminFeatureFlags',
+		async load(_href, signal) {
 			const response = await fetch(adminFeatureFlagsApiPath, {
 				headers: { Accept: 'application/json' },
 				credentials: 'include',
+				signal,
 			})
-			if (requestId !== loadRequestId) return
-			if (response.status === 401) {
-				window.location.assign('/login')
-				return
-			}
+			if (response.status === 401) return routeDataRedirect('/login')
 			if (response.status === 403) {
-				status = 'error'
-				message = 'You do not have permission to view feature flags.'
-				messageTone = 'error'
-				lastFailedHref = href
-				handle.update()
-				return
+				throw new Error('You do not have permission to view feature flags.')
 			}
 			const payload = await readJson<AdminFeatureFlagsLoaderData>(response)
 			if (!response.ok || !payload?.ok) {
 				throw new Error('Unable to load feature flags.')
 			}
-			applyData(payload)
-			lastLoadedHref = href
-			lastFailedHref = null
-			handle.update()
-		} catch (error) {
-			if (requestId !== loadRequestId) return
-			status = 'error'
-			message =
-				error instanceof Error ? error.message : 'Unable to load feature flags.'
-			messageTone = 'error'
-			lastFailedHref = href
-			handle.update()
-		} finally {
-			if (requestId === loadRequestId) loadingForHref = null
-		}
+			return payload
+		},
+	})
+
+	function applyData(payload: AdminFeatureFlagsLoaderData) {
+		featureFlags = payload.featureFlags
+		message = null
+		messageTone = 'info'
 	}
 
 	async function submitAdminAction(
@@ -293,33 +261,29 @@ export function AdminFeatureFlagsRoute(handle: Handle) {
 
 	return () => {
 		const currentHref = readCurrentRouterHref(handle)
-		const routeData = isAdminFeatureFlagsPath(currentHref)
-			? tryConsumeRouteLoaderData(handle, 'adminFeatureFlags', currentHref)
-			: undefined
-		if (routeData) {
-			applyData(routeData)
-			lastLoadedHref = currentHref
-			lastFailedHref = null
+		const snapshot = featureFlagsData.read(handle, currentHref)
+		if (snapshot.data && snapshot.data !== appliedPayload) {
+			appliedPayload = snapshot.data
+			applyData(snapshot.data)
 		}
-		const needsStaleRefresh =
-			consumeStaleNavigationData(currentHref) && !routeData
-		const needsLoad =
-			(status === 'loading' ||
-				currentHref !== lastLoadedHref ||
-				needsStaleRefresh) &&
-			currentHref !== lastFailedHref &&
-			loadingForHref !== currentHref
-		if (!routeData && needsLoad && typeof document !== 'undefined') {
-			status = 'loading'
-			loadingForHref = currentHref
-			handle.queueTask(loadFeatureFlags)
+		if (snapshot.error && snapshot.error !== appliedError) {
+			appliedError = snapshot.error
+			message = snapshot.error.message
+			messageTone = 'error'
 		}
+		const pending = snapshot.kind === 'pending'
+		const status: PageStatus =
+			snapshot.kind === 'error'
+				? 'error'
+				: pending && appliedPayload === null
+					? 'loading'
+					: 'ready'
 		const isMutating = actionState !== 'idle'
 		const registryFlags = featureFlags.filter((flag) => !flag.stale)
 		const staleFlags = featureFlags.filter((flag) => flag.stale)
 
 		return (
-			<AccountManagementShell>
+			<AccountManagementShell busy={pending && appliedPayload !== null}>
 				<AdminPageHeader
 					title="Admin feature flags"
 					description="Toggle registry feature flags, set percentage rollouts, and manage per-user overrides."

--- a/packages/worker/client/routes/admin-insights-shared.ts
+++ b/packages/worker/client/routes/admin-insights-shared.ts
@@ -41,10 +41,6 @@ export const authCategoryColors: Record<string, string> = {
 	oauth: chartColor.violet,
 }
 
-export function isAdminInsightsPath(href: string) {
-	return new URL(href, 'http://localhost').pathname === '/admin/insights'
-}
-
 /** `2026-06-29` -> `Jun 29` */
 export function formatDayLabel(dayKey: string) {
 	const monthIndex = Number(dayKey.slice(5, 7)) - 1

--- a/packages/worker/client/routes/admin-insights.tsx
+++ b/packages/worker/client/routes/admin-insights.tsx
@@ -1,7 +1,6 @@
 import { css, type Handle } from 'remix/ui'
 import { readCurrentRouterHref } from '#client/client-router.tsx'
-import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
-import { consumeStaleNavigationData } from '#client/navigation-data.ts'
+import { createRouteData, routeDataRedirect } from '#client/route-data.tsx'
 import { readJson } from '#client/routes/account-approval-shared.ts'
 import { colors } from '#universal/styles/tokens.ts'
 import { type AdminInsightsLoaderData } from '#universal/loader-data.ts'
@@ -10,106 +9,62 @@ import {
 	AccountManagementShell,
 	AdminPageHeader,
 } from './account-management-components.tsx'
-import {
-	adminInsightsApiPath,
-	isAdminInsightsPath,
-} from './admin-insights-shared.ts'
+import { adminInsightsApiPath } from './admin-insights-shared.ts'
 import { renderDashboard } from './admin-insights-dashboard.tsx'
 
 type PageStatus = 'loading' | 'ready' | 'error'
 
 export function AdminInsightsRoute(handle: Handle) {
-	let status: PageStatus = 'loading'
 	let data: AdminInsightsLoaderData | null = null
 	let message: string | null = null
-	let loadRequestId = 0
-	let lastLoadedHref = ''
-	let loadingForHref: string | null = null
-	let lastFailedHref: string | null = null
-
-	function applyData(payload: AdminInsightsLoaderData, href: string) {
-		data = payload
-		status = 'ready'
-		message = null
-		lastLoadedHref = href
-		lastFailedHref = null
-	}
-
-	async function loadAdminInsights() {
-		const href = readCurrentRouterHref(handle)
-		loadingForHref = href
-		const requestId = ++loadRequestId
-		try {
+	/** Payload last applied to the closure state above. */
+	let appliedPayload: AdminInsightsLoaderData | null = null
+	let appliedError: Error | null = null
+	const insightsData = createRouteData({
+		key: 'adminInsights',
+		async load(_href, signal) {
 			const response = await fetch(adminInsightsApiPath, {
 				headers: { Accept: 'application/json' },
 				credentials: 'include',
+				signal,
 			})
-			if (requestId !== loadRequestId) return
-			if (response.status === 401) {
-				window.location.assign('/login')
-				return
-			}
+			if (response.status === 401) return routeDataRedirect('/login')
 			if (response.status === 403) {
-				status = 'error'
-				message = 'You do not have permission to view admin insights.'
-				lastFailedHref = href
-				handle.update()
-				return
+				throw new Error('You do not have permission to view admin insights.')
 			}
 			const payload = await readJson<AdminInsightsLoaderData>(response)
 			if (!response.ok || !payload?.ok) {
 				throw new Error('Unable to load admin insights.')
 			}
-			applyData(payload, href)
-			handle.update()
-		} catch (error) {
-			if (requestId !== loadRequestId) return
-			status = 'error'
-			message =
-				error instanceof Error
-					? error.message
-					: 'Unable to load admin insights.'
-			lastFailedHref = href
-			handle.update()
-		} finally {
-			if (requestId === loadRequestId) loadingForHref = null
-		}
-	}
-
-	function applyRouteLoaderData(href: string) {
-		if (!isAdminInsightsPath(href)) return false
-		const routeData = tryConsumeRouteLoaderData(handle, 'adminInsights', href)
-		if (!routeData) return false
-		applyData(routeData, href)
-		return true
-	}
-
-	let lastSeenHref = ''
+			return payload
+		},
+	})
 
 	return () => {
 		const currentHref = readCurrentRouterHref(handle)
-		if (currentHref !== lastSeenHref) {
-			lastSeenHref = currentHref
-			lastFailedHref = null
+		const snapshot = insightsData.read(handle, currentHref)
+		if (snapshot.data && snapshot.data !== appliedPayload) {
+			appliedPayload = snapshot.data
+			data = snapshot.data
+			message = null
 		}
-
-		const appliedRouteData = applyRouteLoaderData(currentHref)
-		const needsStaleRefresh =
-			consumeStaleNavigationData(currentHref) && !appliedRouteData
-		const needsLoad =
-			(status === 'loading' ||
-				currentHref !== lastLoadedHref ||
-				needsStaleRefresh) &&
-			currentHref !== lastFailedHref &&
-			loadingForHref !== currentHref
-		if (!appliedRouteData && needsLoad && typeof document !== 'undefined') {
-			status = 'loading'
-			loadingForHref = currentHref
-			handle.queueTask(loadAdminInsights)
+		if (snapshot.error && snapshot.error !== appliedError) {
+			appliedError = snapshot.error
+			message = snapshot.error.message
 		}
+		const pending = snapshot.kind === 'pending'
+		const status: PageStatus =
+			snapshot.kind === 'error'
+				? 'error'
+				: pending && appliedPayload === null
+					? 'loading'
+					: 'ready'
 
 		return (
-			<AccountManagementShell maxWidth="min(100%, 92rem)">
+			<AccountManagementShell
+				maxWidth="min(100%, 92rem)"
+				busy={pending && appliedPayload !== null}
+			>
 				<AdminPageHeader
 					title="Admin insights"
 					description="Platform-wide activity at a glance. Aggregated account metadata only — user content is never shown."

--- a/packages/worker/client/routes/admin-invites.tsx
+++ b/packages/worker/client/routes/admin-invites.tsx
@@ -2,8 +2,7 @@ import { formatNullableTimestamp } from '#client/format-timestamp.ts'
 import { type Handle, css } from 'remix/ui'
 import { on } from '#client/event-mixin.ts'
 import { readCurrentRouterHref } from '#client/client-router.tsx'
-import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
-import { consumeStaleNavigationData } from '#client/navigation-data.ts'
+import { createRouteData, routeDataRedirect } from '#client/route-data.tsx'
 import { readJson } from '#client/routes/account-approval-shared.ts'
 import { colors, mq, spacing, typography } from '#universal/styles/tokens.ts'
 import {
@@ -45,9 +44,6 @@ type PageStatus = 'loading' | 'ready' | 'error'
 
 const adminInvitesApiPath = '/admin/invites.json'
 
-function isAdminInvitesPath(href: string) {
-	return new URL(href, 'http://localhost').pathname === '/admin/invites'
-}
 function getInviteStatus(invite: AdminInviteListItem) {
 	if (invite.revokedAt) return 'Revoked'
 	if (invite.expiresAt && Date.parse(invite.expiresAt) <= Date.now()) {
@@ -80,7 +76,6 @@ export async function adminInvitesRouteLoader(
 }
 
 export function AdminInvitesRoute(handle: Handle) {
-	let status: PageStatus = 'loading'
 	let invites: Array<AdminInviteListItem> = []
 	let availablePlans: Array<AdminPlanName> = []
 	let signupMode: SignupModeSetting | null = null
@@ -94,71 +89,40 @@ export function AdminInvitesRoute(handle: Handle) {
 		| 'revoking'
 		| 'savingSignupMode' = 'idle'
 	const signupModePanel = createAdminInvitesSignupModePanel(handle)
-	let lastLoadedHref = ''
-	let loadingForHref: string | null = null
-	let lastFailedHref: string | null = null
-	let loadRequestId = 0
-
-	function applyData(payload: AdminInvitesLoaderData) {
-		invites = payload.invites
-		availablePlans = payload.availablePlans
-		signupMode = payload.signupMode
-		status = 'ready'
-		message = null
-		messageTone = 'info'
-	}
-
-	async function loadInvites() {
-		const href = readCurrentRouterHref(handle)
-		loadingForHref = href
-		// A slow response that resolves after a newer load started must not
-		// clobber the newer load's state (matches the other admin loaders).
-		const requestId = ++loadRequestId
-		try {
+	/** Payload last applied to the closure state above. */
+	let appliedPayload: AdminInvitesLoaderData | null = null
+	let appliedError: Error | null = null
+	const invitesData = createRouteData({
+		key: 'adminInvites',
+		async load(_href, signal) {
 			const response = await fetch(adminInvitesApiPath, {
 				headers: { Accept: 'application/json' },
 				credentials: 'include',
+				signal,
 			})
-			if (requestId !== loadRequestId) return
-			if (response.status === 401) {
-				window.location.assign('/login')
-				return
-			}
+			if (response.status === 401) return routeDataRedirect('/login')
 			if (response.status === 403) {
-				status = 'error'
-				message = 'You do not have permission to view invites.'
-				messageTone = 'error'
-				lastFailedHref = href
-				handle.update()
-				return
+				throw new Error('You do not have permission to view invites.')
 			}
 			const payload = await readJson<AdminInvitesLoaderData>(response)
 			if (!response.ok || !payload?.ok) {
 				throw new Error('Unable to load invites.')
 			}
-			applyData(payload)
-			lastLoadedHref = href
-			lastFailedHref = null
-			handle.update()
-		} catch (error) {
-			if (requestId !== loadRequestId) return
-			status = 'error'
-			message =
-				error instanceof Error ? error.message : 'Unable to load invites.'
-			messageTone = 'error'
-			lastFailedHref = href
-			handle.update()
-		} finally {
-			if (requestId === loadRequestId) loadingForHref = null
-		}
+			return payload
+		},
+	})
+
+	function applyData(payload: AdminInvitesLoaderData) {
+		invites = payload.invites
+		availablePlans = payload.availablePlans
+		signupMode = payload.signupMode
+		message = null
+		messageTone = 'info'
 	}
 
 	function retryLoad() {
-		lastFailedHref = null
-		status = 'loading'
 		message = null
-		handle.update()
-		handle.queueTask(loadInvites)
+		invitesData.reload(handle, readCurrentRouterHref(handle))
 	}
 
 	async function submitAdminAction(body: Record<string, unknown>) {
@@ -257,34 +221,30 @@ export function AdminInvitesRoute(handle: Handle) {
 
 	return () => {
 		const currentHref = readCurrentRouterHref(handle)
-		const routeData = isAdminInvitesPath(currentHref)
-			? tryConsumeRouteLoaderData(handle, 'adminInvites', currentHref)
-			: undefined
-		if (routeData) {
-			applyData(routeData)
-			lastLoadedHref = currentHref
-			lastFailedHref = null
+		const snapshot = invitesData.read(handle, currentHref)
+		if (snapshot.data && snapshot.data !== appliedPayload) {
+			appliedPayload = snapshot.data
+			applyData(snapshot.data)
 		}
-		const needsStaleRefresh =
-			consumeStaleNavigationData(currentHref) && !routeData
-		const needsLoad =
-			(status === 'loading' ||
-				currentHref !== lastLoadedHref ||
-				needsStaleRefresh) &&
-			currentHref !== lastFailedHref &&
-			loadingForHref !== currentHref
-		if (!routeData && needsLoad && typeof document !== 'undefined') {
-			status = 'loading'
-			loadingForHref = currentHref
-			handle.queueTask(loadInvites)
+		if (snapshot.error && snapshot.error !== appliedError) {
+			appliedError = snapshot.error
+			message = snapshot.error.message
+			messageTone = 'error'
 		}
+		const pending = snapshot.kind === 'pending'
+		const status: PageStatus =
+			snapshot.kind === 'error'
+				? 'error'
+				: pending && appliedPayload === null
+					? 'loading'
+					: 'ready'
 		const isMutating = actionState !== 'idle'
 		// Plan options arrive with loader data; disable create until then so an
 		// empty <select> cannot submit plan="" before Max is available.
 		const inviteFormDisabled = isMutating || availablePlans.length === 0
 
 		return (
-			<AccountManagementShell>
+			<AccountManagementShell busy={pending && appliedPayload !== null}>
 				<AdminPageHeader
 					title="Admin invites"
 					description="Create and revoke launch-cohort invite codes for production signup."

--- a/packages/worker/client/routes/admin-platform-feedback.tsx
+++ b/packages/worker/client/routes/admin-platform-feedback.tsx
@@ -1,14 +1,12 @@
 import { formatTimestamp } from '#client/format-timestamp.ts'
 import { readCurrentRouterHref } from '#client/client-router.tsx'
 import { on } from '#client/event-mixin.ts'
-import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
-import { consumeStaleNavigationData } from '#client/navigation-data.ts'
 import { replaceLocation } from '#client/replace-location.ts'
+import { createRouteData, routeDataRedirect } from '#client/route-data.tsx'
 import {
 	routeLoaderRedirect,
 	type RouteLoaderResult,
 } from '#client/route-loader.ts'
-import { readRouterSearch } from '#client/router-location.tsx'
 import { readJson } from '#client/routes/account-approval-shared.ts'
 import { colors, spacing, typography } from '#universal/styles/tokens.ts'
 import {
@@ -70,13 +68,6 @@ const untrustedTextCss = css({
 	overflowWrap: 'anywhere',
 	fontFamily: 'inherit',
 })
-
-function isAdminPlatformFeedbackPath(href: string) {
-	return (
-		new URL(href, 'http://localhost').pathname ===
-		routes.adminPlatformFeedback.href()
-	)
-}
 
 function readFilterState(href: string): FeedbackFilterState {
 	const url = new URL(href, 'http://localhost')
@@ -158,104 +149,57 @@ export async function adminPlatformFeedbackRouteLoader(
 }
 
 export function AdminPlatformFeedbackRoute(handle: Handle) {
-	let status: PageStatus = 'loading'
 	let data: AdminPlatformFeedbackLoaderData | null = null
 	let message: string | null = null
-	let loadRequestId = 0
-	let lastLoadedHref = ''
-	let loadingForHref: string | null = null
-	let lastFailedHref: string | null = null
-
-	const secondaryButtonCss = getGhostButtonCss({ size: 'sm' })
-
-	function applyData(payload: AdminPlatformFeedbackLoaderData, href: string) {
-		data = payload
-		status = 'ready'
-		message = null
-		lastLoadedHref = href
-		lastFailedHref = null
-	}
-
-	async function loadPlatformFeedback() {
-		const href = readCurrentRouterHref(handle)
-		loadingForHref = href
-		const requestId = ++loadRequestId
-		try {
+	/** Payload last applied to the closure state above. */
+	let appliedPayload: AdminPlatformFeedbackLoaderData | null = null
+	let appliedError: Error | null = null
+	const feedbackData = createRouteData({
+		key: 'adminPlatformFeedback',
+		async load(href, signal) {
 			const response = await fetch(
 				routes.adminPlatformFeedbackApi.href(null, {
-					searchParams: new URLSearchParams(readRouterSearch(handle)),
+					searchParams: new URL(href, 'http://localhost').searchParams,
 				}),
 				{
 					headers: { Accept: 'application/json' },
 					credentials: 'include',
+					signal,
 				},
 			)
-			if (requestId !== loadRequestId) return
-			if (response.status === 401) {
-				window.location.assign(routes.login.href())
-				return
-			}
+			if (response.status === 401) return routeDataRedirect(routes.login.href())
 			if (response.status === 403) {
-				status = 'error'
-				message = 'You do not have permission to view platform feedback.'
-				lastFailedHref = href
-				handle.update()
-				return
+				throw new Error('You do not have permission to view platform feedback.')
 			}
 			const payload = await readJson<AdminPlatformFeedbackLoaderData>(response)
 			if (!response.ok || !payload?.ok) {
 				throw new Error('Unable to load platform feedback.')
 			}
-			applyData(payload, href)
-			handle.update()
-		} catch (error) {
-			if (requestId !== loadRequestId) return
-			status = 'error'
-			message =
-				error instanceof Error
-					? error.message
-					: 'Unable to load platform feedback.'
-			lastFailedHref = href
-			handle.update()
-		} finally {
-			if (requestId === loadRequestId) loadingForHref = null
-		}
-	}
+			return payload
+		},
+	})
 
-	function applyRouteLoaderData(href: string) {
-		if (!isAdminPlatformFeedbackPath(href)) return false
-		const routeData = tryConsumeRouteLoaderData(
-			handle,
-			'adminPlatformFeedback',
-			href,
-		)
-		if (!routeData) return false
-		applyData(routeData, href)
-		return true
-	}
-
-	let lastSeenHref = ''
+	const secondaryButtonCss = getGhostButtonCss({ size: 'sm' })
 
 	return () => {
 		const currentHref = readCurrentRouterHref(handle)
-		if (currentHref !== lastSeenHref) {
-			lastSeenHref = currentHref
-			lastFailedHref = null
+		const snapshot = feedbackData.read(handle, currentHref)
+		if (snapshot.data && snapshot.data !== appliedPayload) {
+			appliedPayload = snapshot.data
+			data = snapshot.data
+			message = null
 		}
-		const appliedRouteData = applyRouteLoaderData(currentHref)
-		const needsStaleRefresh =
-			consumeStaleNavigationData(currentHref) && !appliedRouteData
-		const needsLoad =
-			(status === 'loading' ||
-				currentHref !== lastLoadedHref ||
-				needsStaleRefresh) &&
-			currentHref !== lastFailedHref &&
-			loadingForHref !== currentHref
-		if (!appliedRouteData && needsLoad && typeof document !== 'undefined') {
-			status = 'loading'
-			loadingForHref = currentHref
-			handle.queueTask(loadPlatformFeedback)
+		if (snapshot.error && snapshot.error !== appliedError) {
+			appliedError = snapshot.error
+			message = snapshot.error.message
 		}
+		const pending = snapshot.kind === 'pending'
+		const status: PageStatus =
+			snapshot.kind === 'error'
+				? 'error'
+				: pending && appliedPayload === null
+					? 'loading'
+					: 'ready'
 
 		const selectedFeedback = data?.selectedFeedback ?? null
 		const selectedFeedbackId = readSelectedFeedbackId(currentHref)
@@ -268,14 +212,17 @@ export function AdminPlatformFeedbackRoute(handle: Handle) {
 		const hasActiveFilters = Boolean(filters.status || filters.category)
 
 		return (
-			<AccountManagementShell maxWidth="min(100%, 92rem)">
+			<AccountManagementShell
+				maxWidth="min(100%, 92rem)"
+				busy={pending && appliedPayload !== null}
+			>
 				<AdminPageHeader
 					title="Platform feedback"
 					description="Read attributed feedback that users explicitly approved for admin review."
 					currentHref={currentHref}
 				/>
 
-				{status === 'loading' && lastLoadedHref === '' ? (
+				{status === 'loading' ? (
 					<p mix={css({ color: colors.textMuted, margin: 0 })}>
 						Loading platform feedback…
 					</p>
@@ -311,7 +258,7 @@ export function AdminPlatformFeedbackRoute(handle: Handle) {
 
 						<RecordTable
 							mode="expand"
-							busy={status === 'loading'}
+							busy={pending}
 							ariaLabel="Platform feedback queue"
 							selectedId={selectedFeedbackId}
 							countLabel={`${data.total} submission${data.total === 1 ? '' : 's'}`}

--- a/packages/worker/client/routes/admin-platform-integrations-shared.ts
+++ b/packages/worker/client/routes/admin-platform-integrations-shared.ts
@@ -27,10 +27,6 @@ export type TokenExchangeStyleOption =
 	| 'basic-json'
 	| 'basic-form'
 
-export function isAdminPlatformIntegrationsPath(href: string) {
-	return platformIntegrationsRoute.isRoutePath(href)
-}
-
 export function readSearchFilter(href: string) {
 	return new URL(href, 'http://localhost').searchParams.get('q')?.trim() ?? ''
 }

--- a/packages/worker/client/routes/admin-platform-integrations.tsx
+++ b/packages/worker/client/routes/admin-platform-integrations.tsx
@@ -3,9 +3,8 @@ import { normalizeProviderKey } from '@kody-internal/shared/url-hosts.ts'
 import { type Handle, css } from 'remix/ui'
 import { on } from '#client/event-mixin.ts'
 import { readCurrentRouterHref } from '#client/client-router.tsx'
-import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
-import { consumeStaleNavigationData } from '#client/navigation-data.ts'
 import { replaceLocation } from '#client/replace-location.ts'
+import { createRouteData, routeDataRedirect } from '#client/route-data.tsx'
 import { readJson } from '#client/routes/account-approval-shared.ts'
 import { renderIntegrationForm } from '#client/routes/admin-platform-integrations-form.tsx'
 import {
@@ -16,7 +15,6 @@ import {
 	filterApps,
 	getCurrentSearch,
 	getDataKey,
-	isAdminPlatformIntegrationsPath,
 	parseExtraAuthorizeParams,
 	platformIntegrationsRoute,
 	readSearchFilter,
@@ -39,33 +37,52 @@ import {
 import {
 	type AdminPlatformIntegrationApp,
 	type AdminPlatformIntegrationsLoaderData,
-	type AppLoaderData,
 } from '#universal/loader-data.ts'
 
 const clampedCellCss = css(recordCellClamp(28))
 
 export function AdminPlatformIntegrationsRoute(handle: Handle) {
-	let status: PageStatus = 'loading'
 	let apps: Array<AdminPlatformIntegrationApp> = []
 	let message: string | null = null
 	let messageTone: 'info' | 'error' = 'info'
 	let actionState: ActionState = 'idle'
 	/** Slug of the row an action is running against, for per-row labels. */
 	let pendingSlug: string | null = null
-	let lastLoadedDataKey = ''
-	let loadingDataKey: string | null = null
-	let lastFailedDataKey: string | null = null
-	let loadRequestId = 0
 	let pendingLogoBase64: string | undefined = undefined
 	let removeLogoChecked = false
 	/** Bumped after a successful edit save so uncontrolled fields remount. */
 	let formRevision = 0
+	/** Payload last applied to the closure state above. */
+	let appliedPayload: AdminPlatformIntegrationsLoaderData | null = null
+	let appliedError: Error | null = null
+	const integrationsData = createRouteData({
+		key: 'adminPlatformIntegrations',
+		locationKey: getDataKey,
+		async load(_href, signal) {
+			const response = await fetch(adminPlatformIntegrationsApiPath, {
+				headers: { Accept: 'application/json' },
+				credentials: 'include',
+				signal,
+			})
+			if (response.status === 401) return routeDataRedirect('/login')
+			if (response.status === 403) {
+				throw new Error(
+					'You do not have permission to view platform integrations.',
+				)
+			}
+			const payload =
+				await readJson<AdminPlatformIntegrationsLoaderData>(response)
+			if (!response.ok || !payload?.ok) {
+				throw new Error('Unable to load platform integrations.')
+			}
+			return payload
+		},
+	})
 
 	const primaryButtonCss = getPillButtonCss({ size: 'sm' })
 
 	function applyData(payload: AdminPlatformIntegrationsLoaderData) {
 		apps = payload.apps
-		status = 'ready'
 		message = null
 		messageTone = 'info'
 	}
@@ -79,53 +96,6 @@ export function AdminPlatformIntegrationsRoute(handle: Handle) {
 		resetFormState()
 		message = null
 		messageTone = 'info'
-	}
-
-	async function loadPlatformIntegrations() {
-		const href = readCurrentRouterHref(handle)
-		const dataKey = getDataKey(href)
-		loadingDataKey = dataKey
-		const requestId = ++loadRequestId
-		try {
-			const response = await fetch(adminPlatformIntegrationsApiPath, {
-				headers: { Accept: 'application/json' },
-				credentials: 'include',
-			})
-			if (requestId !== loadRequestId) return
-			if (response.status === 401) {
-				window.location.assign('/login')
-				return
-			}
-			if (response.status === 403) {
-				status = 'error'
-				message = 'You do not have permission to view platform integrations.'
-				messageTone = 'error'
-				lastFailedDataKey = dataKey
-				handle.update()
-				return
-			}
-			const payload =
-				await readJson<AdminPlatformIntegrationsLoaderData>(response)
-			if (!response.ok || !payload?.ok) {
-				throw new Error('Unable to load platform integrations.')
-			}
-			applyData(payload)
-			lastLoadedDataKey = dataKey
-			lastFailedDataKey = null
-			handle.update()
-		} catch (error) {
-			if (requestId !== loadRequestId) return
-			status = 'error'
-			message =
-				error instanceof Error
-					? error.message
-					: 'Unable to load platform integrations.'
-			messageTone = 'error'
-			lastFailedDataKey = dataKey
-			handle.update()
-		} finally {
-			if (requestId === loadRequestId) loadingDataKey = null
-		}
 	}
 
 	async function submitAdminAction(
@@ -368,36 +338,23 @@ export function AdminPlatformIntegrationsRoute(handle: Handle) {
 
 	return () => {
 		const currentHref = readCurrentRouterHref(handle)
-		const currentDataKey = getDataKey(currentHref)
-		const routeData = isAdminPlatformIntegrationsPath(currentHref)
-			? (tryConsumeRouteLoaderData(
-					handle,
-					'adminPlatformIntegrations' as keyof AppLoaderData,
-					currentHref,
-				) as AdminPlatformIntegrationsLoaderData | undefined)
-			: undefined
-		if (routeData) {
-			applyData(routeData)
-			lastLoadedDataKey = currentDataKey
-			lastFailedDataKey = null
+		const snapshot = integrationsData.read(handle, currentHref)
+		if (snapshot.data && snapshot.data !== appliedPayload) {
+			appliedPayload = snapshot.data
+			applyData(snapshot.data)
 		}
-		const needsStaleRefresh =
-			consumeStaleNavigationData(currentHref) && !routeData
-		const needsLoad =
-			(status === 'loading' ||
-				currentDataKey !== lastLoadedDataKey ||
-				needsStaleRefresh) &&
-			currentDataKey !== lastFailedDataKey &&
-			loadingDataKey !== currentDataKey
-		if (!routeData && needsLoad && typeof document !== 'undefined') {
-			// Keep the table mounted during search/selection navigations; only
-			// show the page-level loading line on the first fetch.
-			if (lastLoadedDataKey === '') {
-				status = 'loading'
-			}
-			loadingDataKey = currentDataKey
-			handle.queueTask(loadPlatformIntegrations)
+		if (snapshot.error && snapshot.error !== appliedError) {
+			appliedError = snapshot.error
+			message = snapshot.error.message
+			messageTone = 'error'
 		}
+		const pending = snapshot.kind === 'pending'
+		const status: PageStatus =
+			snapshot.kind === 'error'
+				? 'error'
+				: pending && appliedPayload === null
+					? 'loading'
+					: 'ready'
 
 		const selection = platformIntegrationsRoute.getSelection(currentHref)
 		const search = readSearchFilter(currentHref)
@@ -413,13 +370,13 @@ export function AdminPlatformIntegrationsRoute(handle: Handle) {
 			editingApp == null &&
 			status === 'ready'
 		return (
-			<AccountManagementShell>
+			<AccountManagementShell busy={pending && appliedPayload !== null}>
 				<AdminPageHeader
 					title="Admin platform integrations"
 					description="Manage operator-provisioned OAuth apps stored in the platform_oauth_apps table."
 					currentHref={currentHref}
 				/>
-				{status === 'loading' && lastLoadedDataKey === '' ? (
+				{status === 'loading' ? (
 					<p mix={css({ color: colors.textMuted, margin: 0 })}>
 						Loading platform integrations…
 					</p>
@@ -429,10 +386,10 @@ export function AdminPlatformIntegrationsRoute(handle: Handle) {
 						{message}
 					</AccountManagementMessage>
 				) : null}
-				{status === 'ready' || lastLoadedDataKey !== '' ? (
+				{status === 'ready' || appliedPayload !== null ? (
 					<RecordTable
 						mode="expand"
-						busy={status === 'loading'}
+						busy={pending}
 						ariaLabel="Platform integrations"
 						selectedId={selection.selectedId}
 						createRow={

--- a/packages/worker/client/routes/admin-provider-marks-shared.ts
+++ b/packages/worker/client/routes/admin-provider-marks-shared.ts
@@ -11,10 +11,6 @@ import {
 
 export const adminProviderMarksApiPath = '/admin/provider-marks.json'
 
-export function isAdminProviderMarksPath(href: string) {
-	return new URL(href, 'http://localhost').pathname === '/admin/provider-marks'
-}
-
 export function splitAliasInput(raw: string): Array<string> {
 	return raw
 		.split(/[\s,]+/)

--- a/packages/worker/client/routes/admin-provider-marks.tsx
+++ b/packages/worker/client/routes/admin-provider-marks.tsx
@@ -3,14 +3,12 @@ import { type Handle, css, ref } from 'remix/ui'
 import { on } from '#client/event-mixin.ts'
 import { readCurrentRouterHref } from '#client/client-router.tsx'
 import { createDoubleCheck } from '#client/double-check.ts'
-import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
-import { consumeStaleNavigationData } from '#client/navigation-data.ts'
+import { createRouteData, routeDataRedirect } from '#client/route-data.tsx'
 import { readJson } from '#client/routes/account-approval-shared.ts'
 import {
 	adminProviderMarksApiPath,
 	filterMarks,
 	groupMarks,
-	isAdminProviderMarksPath,
 	markGroupKey,
 	splitAliasInput,
 } from '#client/routes/admin-provider-marks-shared.ts'
@@ -24,7 +22,6 @@ import { RecordTableSearch } from './record-table.tsx'
 import {
 	type AdminProviderMark,
 	type AdminProviderMarksLoaderData,
-	type AppLoaderData,
 } from '#universal/loader-data.ts'
 import {
 	colors,
@@ -90,7 +87,6 @@ const markTileCss = {
 }
 
 export function AdminProviderMarksRoute(handle: Handle) {
-	let status: PageStatus = 'loading'
 	let marks: Array<AdminProviderMark> = []
 	let message: string | null = null
 	let messageTone: 'info' | 'error' = 'info'
@@ -98,16 +94,34 @@ export function AdminProviderMarksRoute(handle: Handle) {
 	let search = ''
 	let selectedSlug: string | null = null
 	let creating = false
-	let lastLoadedHref = ''
-	let loadingHref: string | null = null
-	let lastFailedHref: string | null = null
-	let loadRequestId = 0
 	let pendingLogoBase64: string | undefined = undefined
 	let logoReadRevision = 0
 	let removeLogoChecked = false
 	let formRevision = 0
 	const openGroups = new Set<string>()
 	const deleteCheck = createDoubleCheck(handle)
+	/** Payload last applied to the closure state above. */
+	let appliedPayload: AdminProviderMarksLoaderData | null = null
+	let appliedError: Error | null = null
+	const marksData = createRouteData({
+		key: 'adminProviderMarks',
+		async load(_href, signal) {
+			const response = await fetch(adminProviderMarksApiPath, {
+				headers: { Accept: 'application/json' },
+				credentials: 'include',
+				signal,
+			})
+			if (response.status === 401) return routeDataRedirect('/login')
+			if (response.status === 403) {
+				throw new Error('You do not have permission to view provider marks.')
+			}
+			const payload = await readJson<AdminProviderMarksLoaderData>(response)
+			if (!response.ok || !payload?.ok) {
+				throw new Error('Unable to load provider marks.')
+			}
+			return payload
+		},
+	})
 
 	const primaryButtonCss = getPillButtonCss({ size: 'sm' })
 	const ghostButtonCss = getGhostButtonCss({ size: 'sm' })
@@ -115,7 +129,6 @@ export function AdminProviderMarksRoute(handle: Handle) {
 
 	function applyData(payload: AdminProviderMarksLoaderData) {
 		marks = payload.marks
-		status = 'ready'
 		message = null
 		messageTone = 'info'
 	}
@@ -132,51 +145,6 @@ export function AdminProviderMarksRoute(handle: Handle) {
 		if (slug) openGroups.add(markGroupKey(slug))
 		resetFormState()
 		formRevision += 1
-	}
-
-	async function loadMarks() {
-		const href = readCurrentRouterHref(handle)
-		loadingHref = href
-		const requestId = ++loadRequestId
-		try {
-			const response = await fetch(adminProviderMarksApiPath, {
-				headers: { Accept: 'application/json' },
-				credentials: 'include',
-			})
-			if (requestId !== loadRequestId) return
-			if (response.status === 401) {
-				window.location.assign('/login')
-				return
-			}
-			if (response.status === 403) {
-				status = 'error'
-				message = 'You do not have permission to view provider marks.'
-				messageTone = 'error'
-				lastFailedHref = href
-				handle.update()
-				return
-			}
-			const payload = await readJson<AdminProviderMarksLoaderData>(response)
-			if (!response.ok || !payload?.ok) {
-				throw new Error('Unable to load provider marks.')
-			}
-			applyData(payload)
-			lastLoadedHref = href
-			lastFailedHref = null
-			handle.update()
-		} catch (error) {
-			if (requestId !== loadRequestId) return
-			status = 'error'
-			message =
-				error instanceof Error
-					? error.message
-					: 'Unable to load provider marks.'
-			messageTone = 'error'
-			lastFailedHref = href
-			handle.update()
-		} finally {
-			if (loadingHref === href) loadingHref = null
-		}
 	}
 
 	function handleLogoFileChange(event: Event) {
@@ -484,30 +452,23 @@ export function AdminProviderMarksRoute(handle: Handle) {
 
 	return () => {
 		const currentHref = readCurrentRouterHref(handle)
-		const routeData = isAdminProviderMarksPath(currentHref)
-			? (tryConsumeRouteLoaderData(
-					handle,
-					'adminProviderMarks' as keyof AppLoaderData,
-					currentHref,
-				) as AdminProviderMarksLoaderData | undefined)
-			: undefined
-		if (routeData) {
-			applyData(routeData)
-			lastLoadedHref = currentHref
-			lastFailedHref = null
+		const snapshot = marksData.read(handle, currentHref)
+		if (snapshot.data && snapshot.data !== appliedPayload) {
+			appliedPayload = snapshot.data
+			applyData(snapshot.data)
 		}
-		const needsStaleRefresh =
-			consumeStaleNavigationData(currentHref) && !routeData
-		const needsLoad =
-			(status === 'loading' ||
-				currentHref !== lastLoadedHref ||
-				needsStaleRefresh) &&
-			currentHref !== lastFailedHref &&
-			loadingHref !== currentHref
-		if (!routeData && needsLoad && typeof document !== 'undefined') {
-			if (lastLoadedHref === '') status = 'loading'
-			handle.queueTask(loadMarks)
+		if (snapshot.error && snapshot.error !== appliedError) {
+			appliedError = snapshot.error
+			message = snapshot.error.message
+			messageTone = 'error'
 		}
+		const pending = snapshot.kind === 'pending'
+		const status: PageStatus =
+			snapshot.kind === 'error'
+				? 'error'
+				: pending && appliedPayload === null
+					? 'loading'
+					: 'ready'
 
 		const filteredMarks = filterMarks(marks, search)
 		const groups = groupMarks(filteredMarks)
@@ -518,7 +479,7 @@ export function AdminProviderMarksRoute(handle: Handle) {
 		const isMutating = actionState !== 'idle'
 
 		return (
-			<AccountManagementShell>
+			<AccountManagementShell busy={pending && appliedPayload !== null}>
 				<AdminPageHeader
 					title="Admin provider marks"
 					description="Operator-owned brand marks for saved integrations. Open a letter, pick a mark, and edit it in that group. Login and onboarding keep their inline icons."
@@ -529,9 +490,7 @@ export function AdminProviderMarksRoute(handle: Handle) {
 						{message}
 					</AccountManagementMessage>
 				) : null}
-				{status === 'loading' && lastLoadedHref === '' ? (
-					<p>Loading provider marks…</p>
-				) : null}
+				{status === 'loading' ? <p>Loading provider marks…</p> : null}
 				<RecordTableSearch
 					label="Filter marks"
 					placeholder="Filter marks"

--- a/packages/worker/client/routes/admin-reserved-usernames.tsx
+++ b/packages/worker/client/routes/admin-reserved-usernames.tsx
@@ -1,8 +1,7 @@
 import { type Handle, css } from 'remix/ui'
 import { on } from '#client/event-mixin.ts'
 import { readCurrentRouterHref } from '#client/client-router.tsx'
-import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
-import { consumeStaleNavigationData } from '#client/navigation-data.ts'
+import { createRouteData, routeDataRedirect } from '#client/route-data.tsx'
 import { readJson } from '#client/routes/account-approval-shared.ts'
 import { colors, mq, spacing, typography } from '#universal/styles/tokens.ts'
 import {
@@ -32,13 +31,6 @@ type PageStatus = 'loading' | 'ready' | 'error'
 type ActionState = 'idle' | 'adding' | 'removing'
 
 const adminReservedUsernamesApiPath = '/admin/reserved-usernames.json'
-const adminReservedUsernamesPath = '/admin/reserved-usernames'
-
-function isAdminReservedUsernamesPath(href: string) {
-	return (
-		new URL(href, 'http://localhost').pathname === adminReservedUsernamesPath
-	)
-}
 
 export async function adminReservedUsernamesRouteLoader(
 	url: URL,
@@ -66,7 +58,6 @@ export async function adminReservedUsernamesRouteLoader(
 }
 
 export function AdminReservedUsernamesRoute(handle: Handle) {
-	let status: PageStatus = 'loading'
 	let builtIn: Array<string> = []
 	let added: Array<string> = []
 	let removed: Array<string> = []
@@ -75,64 +66,38 @@ export function AdminReservedUsernamesRoute(handle: Handle) {
 	let message: string | null = null
 	let messageTone: 'info' | 'error' = 'info'
 	let actionState: ActionState = 'idle'
-	let lastLoadedHref = ''
-	let loadingForHref: string | null = null
-	let lastFailedHref: string | null = null
-	let loadRequestId = 0
+	/** Payload last applied to the closure state above. */
+	let appliedPayload: AdminReservedUsernamesLoaderData | null = null
+	let appliedError: Error | null = null
+	const reservedUsernamesData = createRouteData({
+		key: 'adminReservedUsernames',
+		async load(_href, signal) {
+			const response = await fetch(adminReservedUsernamesApiPath, {
+				headers: { Accept: 'application/json' },
+				credentials: 'include',
+				signal,
+			})
+			if (response.status === 401) return routeDataRedirect('/login')
+			if (response.status === 403) {
+				throw new Error(
+					'You do not have permission to view reserved usernames.',
+				)
+			}
+			const payload = await readJson<AdminReservedUsernamesLoaderData>(response)
+			if (!response.ok || !payload?.ok) {
+				throw new Error('Unable to load reserved usernames.')
+			}
+			return payload
+		},
+	})
 
 	function applyData(payload: AdminReservedUsernamesLoaderData) {
 		builtIn = payload.builtIn
 		added = payload.added
 		removed = payload.removed
 		conflicts = payload.conflicts
-		status = 'ready'
 		message = null
 		messageTone = 'info'
-	}
-
-	async function loadReservedUsernames() {
-		const href = readCurrentRouterHref(handle)
-		loadingForHref = href
-		const requestId = ++loadRequestId
-		try {
-			const response = await fetch(adminReservedUsernamesApiPath, {
-				headers: { Accept: 'application/json' },
-				credentials: 'include',
-			})
-			if (requestId !== loadRequestId) return
-			if (response.status === 401) {
-				window.location.assign('/login')
-				return
-			}
-			if (response.status === 403) {
-				status = 'error'
-				message = 'You do not have permission to view reserved usernames.'
-				messageTone = 'error'
-				lastFailedHref = href
-				handle.update()
-				return
-			}
-			const payload = await readJson<AdminReservedUsernamesLoaderData>(response)
-			if (!response.ok || !payload?.ok) {
-				throw new Error('Unable to load reserved usernames.')
-			}
-			applyData(payload)
-			lastLoadedHref = href
-			lastFailedHref = null
-			handle.update()
-		} catch (error) {
-			if (requestId !== loadRequestId) return
-			status = 'error'
-			message =
-				error instanceof Error
-					? error.message
-					: 'Unable to load reserved usernames.'
-			messageTone = 'error'
-			lastFailedHref = href
-			handle.update()
-		} finally {
-			if (requestId === loadRequestId) loadingForHref = null
-		}
 	}
 
 	async function submitAdminAction(body: Record<string, unknown>) {
@@ -196,27 +161,23 @@ export function AdminReservedUsernamesRoute(handle: Handle) {
 
 	return () => {
 		const currentHref = readCurrentRouterHref(handle)
-		const routeData = isAdminReservedUsernamesPath(currentHref)
-			? tryConsumeRouteLoaderData(handle, 'adminReservedUsernames', currentHref)
-			: undefined
-		if (routeData) {
-			applyData(routeData)
-			lastLoadedHref = currentHref
-			lastFailedHref = null
+		const snapshot = reservedUsernamesData.read(handle, currentHref)
+		if (snapshot.data && snapshot.data !== appliedPayload) {
+			appliedPayload = snapshot.data
+			applyData(snapshot.data)
 		}
-		const needsStaleRefresh =
-			consumeStaleNavigationData(currentHref) && !routeData
-		const needsLoad =
-			(status === 'loading' ||
-				currentHref !== lastLoadedHref ||
-				needsStaleRefresh) &&
-			currentHref !== lastFailedHref &&
-			loadingForHref !== currentHref
-		if (!routeData && needsLoad && typeof document !== 'undefined') {
-			status = 'loading'
-			loadingForHref = currentHref
-			handle.queueTask(loadReservedUsernames)
+		if (snapshot.error && snapshot.error !== appliedError) {
+			appliedError = snapshot.error
+			message = snapshot.error.message
+			messageTone = 'error'
 		}
+		const pending = snapshot.kind === 'pending'
+		const status: PageStatus =
+			snapshot.kind === 'error'
+				? 'error'
+				: pending && appliedPayload === null
+					? 'loading'
+					: 'ready'
 		const isMutating = actionState !== 'idle'
 		const normalizedQuery = builtInQuery.trim().toLowerCase()
 		const visibleBuiltIn = normalizedQuery
@@ -224,7 +185,7 @@ export function AdminReservedUsernamesRoute(handle: Handle) {
 			: builtIn
 
 		return (
-			<AccountManagementShell>
+			<AccountManagementShell busy={pending && appliedPayload !== null}>
 				<AdminPageHeader
 					title="Reserved usernames"
 					description="Usernames become {username}.kody.run subdomains and {username}@ mail locals. Built-in names stay locked unless explicitly unreserved; system-email locals and kody-prefixed names cannot be unreserved."

--- a/packages/worker/client/routes/admin-roles.tsx
+++ b/packages/worker/client/routes/admin-roles.tsx
@@ -1,7 +1,6 @@
 import { type Handle, css } from 'remix/ui'
 import { readCurrentRouterHref } from '#client/client-router.tsx'
-import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
-import { consumeStaleNavigationData } from '#client/navigation-data.ts'
+import { createRouteData, routeDataRedirect } from '#client/route-data.tsx'
 import { readJson } from '#client/routes/account-approval-shared.ts'
 import { colors, spacing, typography } from '#universal/styles/tokens.ts'
 import {
@@ -19,10 +18,6 @@ import {
 type AccountStatus = 'loading' | 'ready' | 'error'
 
 const adminRolesApiPath = '/admin/roles.json'
-
-function isAdminRolesPath(href: string) {
-	return new URL(href, 'http://localhost').pathname === '/admin/roles'
-}
 
 export async function adminRolesRouteLoader(
 	_url: URL,
@@ -47,99 +42,52 @@ export async function adminRolesRouteLoader(
 }
 
 export function AdminRolesRoute(handle: Handle) {
-	let status: AccountStatus = 'loading'
 	let roles: AdminRolesLoaderData['roles'] = []
 	let message: string | null = null
-	let loadRequestId = 0
-	let lastLoadedHref = ''
-	let loadingForHref: string | null = null
-	let lastFailedHref: string | null = null
-
-	async function loadAdminRoles() {
-		const href = readCurrentRouterHref(handle)
-		loadingForHref = href
-		const requestId = ++loadRequestId
-		try {
+	let appliedPayload: AdminRolesLoaderData | null = null
+	let appliedError: Error | null = null
+	const rolesData = createRouteData({
+		key: 'adminRoles',
+		async load(_href, signal) {
 			const response = await fetch(adminRolesApiPath, {
 				headers: { Accept: 'application/json' },
 				credentials: 'include',
+				signal,
 			})
-			if (requestId !== loadRequestId) return
-			if (response.status === 401) {
-				window.location.assign('/login')
-				return
-			}
+			if (response.status === 401) return routeDataRedirect('/login')
 			if (response.status === 403) {
-				status = 'error'
-				message = 'You do not have permission to view admin roles.'
-				lastFailedHref = href
-				handle.update()
-				return
+				throw new Error('You do not have permission to view admin roles.')
 			}
 			const payload = await readJson<AdminRolesLoaderData>(response)
 			if (!response.ok || !payload?.ok) {
 				throw new Error('Unable to load admin roles.')
 			}
-			roles = payload.roles
-			status = 'ready'
-			message = null
-			lastLoadedHref = readCurrentRouterHref(handle)
-			lastFailedHref = null
-			handle.update()
-		} catch (error) {
-			if (requestId !== loadRequestId) return
-			status = 'error'
-			message =
-				error instanceof Error ? error.message : 'Unable to load admin roles.'
-			lastFailedHref = href
-			handle.update()
-		} finally {
-			if (requestId === loadRequestId) loadingForHref = null
-		}
-	}
-
-	function applyRouteLoaderData(href: string) {
-		if (!isAdminRolesPath(href)) return false
-		const routeData = tryConsumeRouteLoaderData(handle, 'adminRoles', href)
-		if (!routeData) return false
-		roles = routeData.roles
-		status = 'ready'
-		message = null
-		lastLoadedHref = href
-		lastFailedHref = null
-		return true
-	}
-
-	let lastSeenHref = ''
+			return payload
+		},
+	})
 
 	return () => {
 		const currentHref = readCurrentRouterHref(handle)
-		// The failure latch only guards retry loops for the location that
-		// failed; leaving it (or coming back) must allow a fresh attempt.
-		if (currentHref !== lastSeenHref) {
-			lastSeenHref = currentHref
-			lastFailedHref = null
+		const snapshot = rolesData.read(handle, currentHref)
+		if (snapshot.data && snapshot.data !== appliedPayload) {
+			appliedPayload = snapshot.data
+			roles = snapshot.data.roles
+			message = null
 		}
-
-		const appliedRouteData = applyRouteLoaderData(currentHref)
-		// A same-path refresh whose loader failed leaves no preload and no
-		// href change; the stale marker forces the fallback refetch.
-		const needsStaleRefresh =
-			consumeStaleNavigationData(currentHref) && !appliedRouteData
-		const needsLoad =
-			(status === 'loading' ||
-				currentHref !== lastLoadedHref ||
-				needsStaleRefresh) &&
-			currentHref !== lastFailedHref &&
-			loadingForHref !== currentHref
-		if (!appliedRouteData && needsLoad && typeof document !== 'undefined') {
-			status = 'loading'
-			loadingForHref = currentHref
-			handle.queueTask(loadAdminRoles)
+		if (snapshot.error && snapshot.error !== appliedError) {
+			appliedError = snapshot.error
+			message = snapshot.error.message
 		}
+		const pending = snapshot.kind === 'pending'
+		const status: AccountStatus =
+			snapshot.kind === 'error'
+				? 'error'
+				: pending && appliedPayload === null
+					? 'loading'
+					: 'ready'
 
 		return (
-			<AccountManagementShell>
+			<AccountManagementShell busy={pending && appliedPayload !== null}>
 				<AdminPageHeader
 					title="Admin roles"
 					description="Read-only view of roles and the permissions attached to each."

--- a/packages/worker/client/routes/admin-system-email.tsx
+++ b/packages/worker/client/routes/admin-system-email.tsx
@@ -3,9 +3,7 @@ import { formatNullableTimestamp } from '#client/format-timestamp.ts'
 import { type Handle, css } from 'remix/ui'
 import { Tab, TabList, TabPanel, Tabs } from 'remix/ui/tabs'
 import { readCurrentRouterHref } from '#client/client-router.tsx'
-import { readRouterSearch } from '#client/router-location.tsx'
-import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
-import { consumeStaleNavigationData } from '#client/navigation-data.ts'
+import { createRouteData, routeDataRedirect } from '#client/route-data.tsx'
 import { readJson } from '#client/routes/account-approval-shared.ts'
 import {
 	colors,
@@ -60,9 +58,6 @@ const emailHtmlPreviewIframeCss = css({
 	background: colors.surface,
 })
 
-function isAdminSystemEmailPath(href: string) {
-	return new URL(href, 'http://localhost').pathname === '/admin/system-email'
-}
 function formatByteCount(value: number) {
 	return new Intl.NumberFormat().format(value)
 }
@@ -94,98 +89,53 @@ export async function adminSystemEmailRouteLoader(
 }
 
 export function AdminSystemEmailRoute(handle: Handle) {
-	let status: PageStatus = 'loading'
 	let data: AdminSystemEmailLoaderData | null = null
 	let message: string | null = null
-	let loadRequestId = 0
-	let lastLoadedHref = ''
-	let loadingForHref: string | null = null
-	let lastFailedHref: string | null = null
-
-	function applyData(payload: AdminSystemEmailLoaderData, href: string) {
-		data = payload
-		status = 'ready'
-		message = null
-		lastLoadedHref = href
-		lastFailedHref = null
-	}
-
-	async function loadSystemEmail() {
-		const href = readCurrentRouterHref(handle)
-		loadingForHref = href
-		const requestId = ++loadRequestId
-		try {
+	/** Payload last applied to the closure state above. */
+	let appliedPayload: AdminSystemEmailLoaderData | null = null
+	let appliedError: Error | null = null
+	const systemEmailData = createRouteData({
+		key: 'adminSystemEmail',
+		async load(href, signal) {
 			const response = await fetch(
-				`${adminSystemEmailApiPath}${readRouterSearch(handle)}`,
+				`${adminSystemEmailApiPath}${new URL(href, 'http://localhost').search}`,
 				{
 					headers: { Accept: 'application/json' },
 					credentials: 'include',
+					signal,
 				},
 			)
-			if (requestId !== loadRequestId) return
-			if (response.status === 401) {
-				window.location.assign('/login')
-				return
-			}
+			if (response.status === 401) return routeDataRedirect('/login')
 			if (response.status === 403) {
-				status = 'error'
-				message = 'You do not have permission to view system email.'
-				lastFailedHref = href
-				handle.update()
-				return
+				throw new Error('You do not have permission to view system email.')
 			}
 			const payload = await readJson<AdminSystemEmailLoaderData>(response)
 			if (!response.ok || !payload?.ok) {
 				throw new Error('Unable to load system email.')
 			}
-			applyData(payload, href)
-			handle.update()
-		} catch (error) {
-			if (requestId !== loadRequestId) return
-			status = 'error'
-			message =
-				error instanceof Error ? error.message : 'Unable to load system email.'
-			lastFailedHref = href
-			handle.update()
-		} finally {
-			if (requestId === loadRequestId) loadingForHref = null
-		}
-	}
-
-	function applyRouteLoaderData(href: string) {
-		if (!isAdminSystemEmailPath(href)) return false
-		const routeData = tryConsumeRouteLoaderData(
-			handle,
-			'adminSystemEmail',
-			href,
-		)
-		if (!routeData) return false
-		applyData(routeData, href)
-		return true
-	}
-
-	let lastSeenHref = ''
+			return payload
+		},
+	})
 
 	return () => {
 		const currentHref = readCurrentRouterHref(handle)
-		if (currentHref !== lastSeenHref) {
-			lastSeenHref = currentHref
-			lastFailedHref = null
+		const snapshot = systemEmailData.read(handle, currentHref)
+		if (snapshot.data && snapshot.data !== appliedPayload) {
+			appliedPayload = snapshot.data
+			data = snapshot.data
+			message = null
 		}
-		const appliedRouteData = applyRouteLoaderData(currentHref)
-		const needsStaleRefresh =
-			consumeStaleNavigationData(currentHref) && !appliedRouteData
-		const needsLoad =
-			(status === 'loading' ||
-				currentHref !== lastLoadedHref ||
-				needsStaleRefresh) &&
-			currentHref !== lastFailedHref &&
-			loadingForHref !== currentHref
-		if (!appliedRouteData && needsLoad && typeof document !== 'undefined') {
-			status = 'loading'
-			loadingForHref = currentHref
-			handle.queueTask(loadSystemEmail)
+		if (snapshot.error && snapshot.error !== appliedError) {
+			appliedError = snapshot.error
+			message = snapshot.error.message
 		}
+		const pending = snapshot.kind === 'pending'
+		const status: PageStatus =
+			snapshot.kind === 'error'
+				? 'error'
+				: pending && appliedPayload === null
+					? 'loading'
+					: 'ready'
 
 		const totalPages = data
 			? Math.max(1, Math.ceil(data.total / data.pageSize))
@@ -193,13 +143,16 @@ export function AdminSystemEmailRoute(handle: Handle) {
 		const selectedMessage = data?.selectedMessage ?? null
 
 		return (
-			<AccountManagementShell maxWidth="min(100%, 92rem)">
+			<AccountManagementShell
+				maxWidth="min(100%, 92rem)"
+				busy={pending && appliedPayload !== null}
+			>
 				<AdminPageHeader
 					title="Admin system email"
 					description="Operator-owned inboxes for reserved platform addresses. These messages are not user account data."
 					currentHref={currentHref}
 				/>
-				{status === 'loading' && lastLoadedHref === '' ? (
+				{status === 'loading' ? (
 					<p mix={css({ color: colors.textMuted, margin: 0 })}>
 						Loading system email…
 					</p>
@@ -223,7 +176,7 @@ export function AdminSystemEmailRoute(handle: Handle) {
 						>
 							<RecordTable
 								mode="expand"
-								busy={status === 'loading'}
+								busy={pending}
 								ariaLabel="System inbox messages"
 								selectedId={selectedMessage?.id ?? null}
 								countLabel={`${data.total} stored`}

--- a/packages/worker/client/routes/admin-users-shared.ts
+++ b/packages/worker/client/routes/admin-users-shared.ts
@@ -14,11 +14,7 @@ import {
 const adminUsersApiPath = '/admin/users.json'
 export const adminUserUsageApiPath = '/admin/users/usage.json'
 
-const {
-	isRoutePath: isAdminUsersListDetailPath,
-	getSelection,
-	buildDetailHref,
-} = createListDetailRoute('/admin/users')
+const { getSelection, buildDetailHref } = createListDetailRoute('/admin/users')
 
 export { getSelection }
 
@@ -29,11 +25,6 @@ export function formatUsageLimit(limit: number) {
 export function formatUsagePercent(value: number | null) {
 	if (value === null) return '—'
 	return `${Math.round(value * 100)}%`
-}
-
-export function isAdminUsersPath(href: string) {
-	const path = new URL(href, 'http://localhost').pathname
-	return path === '/admin' || isAdminUsersListDetailPath(href)
 }
 
 export type AdminUserFilterState = {

--- a/packages/worker/client/routes/admin-users.tsx
+++ b/packages/worker/client/routes/admin-users.tsx
@@ -8,8 +8,7 @@ import {
 	type InfiniteListSnapshot,
 } from '#client/infinite-list.ts'
 import { infiniteScrollSentinel } from '#client/infinite-scroll.ts'
-import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
-import { consumeStaleNavigationData } from '#client/navigation-data.ts'
+import { createRouteData, routeDataRedirect } from '#client/route-data.tsx'
 import { readJson } from '#client/routes/account-approval-shared.ts'
 import { colors } from '#universal/styles/tokens.ts'
 import { getGhostButtonCss } from '#universal/styles/style-primitives.ts'
@@ -31,7 +30,6 @@ import {
 	getDataKey,
 	getListKey,
 	getSelection,
-	isAdminUsersPath,
 	parseSelectedStableUserId,
 	readFilterState,
 } from './admin-users-shared.ts'
@@ -86,11 +84,30 @@ export function AdminUsersRoute(handle: Handle) {
 	// edits it. Null stored plan values are shown/saved as `free`.
 	let selectedPlanChoice: AdminPlanName = 'free'
 	let planDraftStableUserId: string | null = null
-	let loadRequestId = 0
-	let lastLoadedDataKey = ''
 	let lastLoadedListKey = ''
-	let loadingDataKey: string | null = null
-	let lastFailedDataKey: string | null = null
+	/** Payload last applied to the closure state above. */
+	let appliedPayload: AdminUsersLoaderData | null = null
+	let appliedError: Error | null = null
+	const usersData = createRouteData({
+		key: 'adminUsers',
+		locationKey: getDataKey,
+		async load(href, signal) {
+			const response = await fetch(buildAdminUsersApiRequestUrl(href), {
+				headers: { Accept: 'application/json' },
+				credentials: 'include',
+				signal,
+			})
+			if (response.status === 401) return routeDataRedirect('/login')
+			if (response.status === 403) {
+				throw new Error('You do not have permission to view admin users.')
+			}
+			const payload = await readJson<AdminUsersLoaderData>(response)
+			if (!response.ok || !payload?.ok) {
+				throw new Error('Unable to load admin users.')
+			}
+			return payload
+		},
+	})
 	let usageStatus: UsageStatus = 'loading'
 	let usageData: AdminUserUsageLoaderData | null = null
 	let usageMessage: string | null = null
@@ -146,9 +163,6 @@ export function AdminUsersRoute(handle: Handle) {
 			getSelectedStableUserIdFromHref(href) != null && !payload.selectedUser
 				? 'User not found.'
 				: null
-		status = 'ready'
-		lastLoadedDataKey = getDataKey(href)
-		lastFailedDataKey = null
 	}
 
 	function buildHrefWithUpdatedFilters(
@@ -212,56 +226,6 @@ export function AdminUsersRoute(handle: Handle) {
 	// refreshed record.
 	function resetPlanDraft() {
 		planDraftStableUserId = null
-	}
-
-	async function loadAdminUsers() {
-		const href = getCurrentHref()
-		const dataKey = getDataKey(href)
-		loadingDataKey = dataKey
-		const requestId = ++loadRequestId
-		try {
-			const response = await fetch(buildAdminUsersApiRequestUrl(href), {
-				headers: { Accept: 'application/json' },
-				credentials: 'include',
-			})
-			if (
-				requestId !== loadRequestId ||
-				getDataKey(getCurrentHref()) !== dataKey
-			)
-				return
-			if (response.status === 401) {
-				window.location.assign('/login')
-				return
-			}
-			if (response.status === 403) {
-				status = 'error'
-				message = 'You do not have permission to view admin users.'
-				lastFailedDataKey = dataKey
-				handle.update()
-				return
-			}
-			const payload = await readJson<AdminUsersLoaderData>(response)
-			if (!response.ok || !payload?.ok) {
-				throw new Error('Unable to load admin users.')
-			}
-			applyPayload(payload, href)
-			handle.update()
-		} catch (error) {
-			if (
-				requestId !== loadRequestId ||
-				getDataKey(getCurrentHref()) !== dataKey
-			)
-				return
-			status = 'error'
-			message =
-				error instanceof Error ? error.message : 'Unable to load admin users.'
-			lastFailedDataKey = dataKey
-			handle.update()
-		} finally {
-			if (requestId === loadRequestId && loadingDataKey === dataKey) {
-				loadingDataKey = null
-			}
-		}
 	}
 
 	async function loadMoreUsers() {
@@ -392,12 +356,10 @@ export function AdminUsersRoute(handle: Handle) {
 				throw new Error(payload?.error || 'Unable to update user roles.')
 			}
 			applyMutationPayload(payload, href)
-			lastLoadedDataKey = getDataKey(href)
 			message =
 				action === 'assign_role'
 					? `Assigned ${selectedRoleToAssign} role.`
 					: `Removed ${selectedRoleToAssign} role.`
-			status = 'ready'
 			actionState = 'idle'
 			handle.update()
 		} catch (error) {
@@ -444,9 +406,7 @@ export function AdminUsersRoute(handle: Handle) {
 			}
 			applyMutationPayload(payload, href)
 			invalidateUsage()
-			lastLoadedDataKey = getDataKey(href)
 			message = `Updated admin grant to ${plan}.`
-			status = 'ready'
 			actionState = 'idle'
 			handle.update()
 		} catch (error) {
@@ -490,7 +450,6 @@ export function AdminUsersRoute(handle: Handle) {
 				throw new Error(payload?.error || 'Unable to update verification.')
 			}
 			applyMutationPayload(payload, href)
-			lastLoadedDataKey = getDataKey(href)
 			if (action === 'mint_verify_url' && payload.verifyUrl) {
 				mintedVerifyUrl = payload.verifyUrl
 				mintedVerifyUrlForStableUserId = selectedUser.stableUserId
@@ -501,7 +460,6 @@ export function AdminUsersRoute(handle: Handle) {
 				mintedVerifyUrlForStableUserId = null
 				message = 'Marked email verified.'
 			}
-			status = 'ready'
 			actionState = 'idle'
 			handle.update()
 		} catch (error) {
@@ -549,14 +507,12 @@ export function AdminUsersRoute(handle: Handle) {
 				throw new Error(payload?.error || 'Unable to update the account.')
 			}
 			applyMutationPayload(payload, href)
-			lastLoadedDataKey = getDataKey(href)
 			message =
 				action === 'suspend_user'
 					? 'Account suspended.'
 					: action === 'unsuspend_user'
 						? 'Account suspension cleared.'
 						: 'Outbound email resumed.'
-			status = 'ready'
 			actionState = 'idle'
 			handle.update()
 		} catch (error) {
@@ -569,44 +525,27 @@ export function AdminUsersRoute(handle: Handle) {
 
 	const secondaryButtonCss = getGhostButtonCss({ size: 'sm' })
 
-	function applyRouteLoaderData(href: string) {
-		if (!isAdminUsersPath(href)) return false
-		const routeData = tryConsumeRouteLoaderData(handle, 'adminUsers', href)
-		if (!routeData) return false
-		applyPayload(routeData, href)
-		return true
-	}
-
-	let lastSeenDataKey = ''
-
 	return () => {
 		const currentHref = getCurrentHref()
-		const currentDataKey = getDataKey(currentHref)
-		// The failure latch only guards retry loops for the location that
-		// failed; leaving it (or coming back) must allow a fresh attempt.
-		if (currentDataKey !== lastSeenDataKey) {
-			lastSeenDataKey = currentDataKey
-			lastFailedDataKey = null
-		}
-		// Consume route-loader data before deriving the list snapshot and
+		// Apply route data before deriving the list snapshot and
 		// `selectedUser`; deriving first would render this pass from the
 		// stale pre-navigation closure state.
-		const appliedRouteData = applyRouteLoaderData(currentHref)
-		// A same-path refresh whose loader failed leaves no preload and no
-		// data-key change; the stale marker forces the fallback refetch.
-		const needsStaleRefresh =
-			consumeStaleNavigationData(currentHref) && !appliedRouteData
-		const needsLoad =
-			(status === 'loading' ||
-				currentDataKey !== lastLoadedDataKey ||
-				needsStaleRefresh) &&
-			currentDataKey !== lastFailedDataKey &&
-			loadingDataKey !== currentDataKey
-		if (!appliedRouteData && needsLoad && typeof document !== 'undefined') {
-			status = 'loading'
-			loadingDataKey = currentDataKey
-			handle.queueTask(loadAdminUsers)
+		const snapshot = usersData.read(handle, currentHref)
+		if (snapshot.data && snapshot.data !== appliedPayload) {
+			appliedPayload = snapshot.data
+			applyPayload(snapshot.data, currentHref)
 		}
+		if (snapshot.error && snapshot.error !== appliedError) {
+			appliedError = snapshot.error
+			message = snapshot.error.message
+		}
+		const pending = snapshot.kind === 'pending'
+		status =
+			snapshot.kind === 'error'
+				? 'error'
+				: pending && appliedPayload === null
+					? 'loading'
+					: 'ready'
 
 		const { items: users, hasMore, totalCount, isLoadingMore } = usersSnapshot
 		const filters = readFilterState(currentHref)
@@ -645,13 +584,13 @@ export function AdminUsersRoute(handle: Handle) {
 		}
 
 		return (
-			<AccountManagementShell>
+			<AccountManagementShell busy={pending && appliedPayload !== null}>
 				<AdminPageHeader
 					title="Admin users"
 					description="Review account metadata and manage role assignments and entitlement plans. User content is never shown here."
 					currentHref={currentHref}
 				/>
-				{status === 'loading' && lastLoadedDataKey === '' ? (
+				{status === 'loading' ? (
 					<p mix={css({ color: colors.textMuted, margin: 0 })}>
 						Loading users…
 					</p>
@@ -670,7 +609,7 @@ export function AdminUsersRoute(handle: Handle) {
 				) : null}
 				<RecordTable
 					mode="expand"
-					busy={status === 'loading'}
+					busy={pending}
 					ariaLabel="User accounts"
 					selectedId={selectedStableUserId}
 					// Unconditional: the snapshot keeps the previous window during a

--- a/packages/worker/client/routes/blog-post.tsx
+++ b/packages/worker/client/routes/blog-post.tsx
@@ -10,8 +10,10 @@ import { routes } from '#universal/routes.ts'
 import { renderMarkdownNodes } from '#client/markdown-view.tsx'
 import { readCurrentRouterHref } from '#client/client-router.tsx'
 import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
-import { consumeStaleNavigationData } from '#client/navigation-data.ts'
-import { createRouteLoadLatch } from '#client/route-load-latch.ts'
+import {
+	createRouteData,
+	renderRoutePendingStatus,
+} from '#client/route-data.tsx'
 import {
 	routeLoaderRedirect,
 	type RouteLoaderResult,
@@ -85,36 +87,14 @@ export async function blogPostRouteLoader(
 }
 
 export function BlogPostRoute(handle: Handle) {
-	let status: 'loading' | 'ready' | 'error' | 'not-found' = 'loading'
-	let post: BlogPostLoaderData | null = null
 	let signupMode: SignupMode = 'invite'
-	/** Slug that `post` / `status` currently describe; used to hide stale UI. */
-	let loadedSlug: string | null = null
-	const loadLatch = createRouteLoadLatch()
-
-	// Re-lexing markdown on every handle.update() would be wasted work; cache
-	// the rendered body per markdown string (same policy as MarkdownView).
-	let renderedForBody: string | null = null
-	let renderedBody: Array<RemixNode> = []
-
-	function renderPostBody(body: string) {
-		if (renderedForBody !== body) {
-			renderedForBody = body
-			// First-party prose: headings keep their authored h2 rhythm and
-			// Kent's outbound links are not tagged as user-generated content.
-			renderedBody = renderMarkdownNodes(body, {
-				headingOffset: 0,
-				linkRel: 'noopener noreferrer',
-				headingIds: true,
-				fences: post?.bodyFences,
-			})
-		}
-		return renderedBody
-	}
-
-	async function loadPost(slug: string, signal: AbortSignal) {
-		// Do not call handle.update() before the first await — see blog.tsx.
-		try {
+	const postData = createRouteData({
+		key: 'blogPost',
+		async load(href, signal) {
+			const slug = getSlugFromPathname(
+				new URL(href, 'http://localhost').pathname,
+			)
+			if (!slug) return null
 			const [response, config] = await Promise.all([
 				fetch(routes.blogPostApi.href({ slug }), {
 					headers: { Accept: 'application/json' },
@@ -122,30 +102,34 @@ export function BlogPostRoute(handle: Handle) {
 				}),
 				fetchPublicAuthConfig(signal),
 			])
-			if (signal.aborted) return
 			signupMode = parseSignupMode(config?.signupMode)
-			if (response.status === 404) {
-				post = null
-				status = 'not-found'
-				loadedSlug = slug
-				handle.update()
-				return
-			}
+			if (response.status === 404) return null
 			const payload = await readJson<BlogPostLoaderData>(response)
-			if (signal.aborted) return
 			if (!response.ok || !payload?.ok) {
 				throw new Error('Unable to load blog post.')
 			}
-			post = payload
-			status = 'ready'
-			loadedSlug = slug
-			handle.update()
-		} catch {
-			if (signal.aborted) return
-			status = 'error'
-			loadedSlug = slug
-			handle.update()
+			return payload
+		},
+	})
+
+	// Re-lexing markdown on every handle.update() would be wasted work; cache
+	// the rendered body per markdown string (same policy as MarkdownView).
+	let renderedForBody: string | null = null
+	let renderedBody: Array<RemixNode> = []
+
+	function renderPostBody(post: BlogPostLoaderData) {
+		if (renderedForBody !== post.body) {
+			renderedForBody = post.body
+			// First-party prose: headings keep their authored h2 rhythm and
+			// Kent's outbound links are not tagged as user-generated content.
+			renderedBody = renderMarkdownNodes(post.body, {
+				headingOffset: 0,
+				linkRel: 'noopener noreferrer',
+				headingIds: true,
+				fences: post.bodyFences,
+			})
 		}
+		return renderedBody
 	}
 
 	return () => {
@@ -155,62 +139,16 @@ export function BlogPostRoute(handle: Handle) {
 			return <article mix={css(postCss)} />
 		}
 
-		const routeData = tryConsumeRouteLoaderData(handle, 'blogPost', currentHref)
 		const signupModeData = tryConsumeRouteLoaderData(
 			handle,
 			'signupMode',
 			currentHref,
 		)
 		if (signupModeData) signupMode = signupModeData
-		const appliedRouteData = Boolean(routeData?.ok)
-		if (routeData?.ok) {
-			post = routeData
-			status = 'ready'
-			loadedSlug = routeData.slug
-			loadLatch.markLoaded(currentHref)
-		}
-
-		const needsStaleRefresh = consumeStaleNavigationData(currentHref)
-		const needsLoad = loadLatch.needsLoad({
-			currentHref,
-			appliedRouteData,
-			needsStaleRefresh,
-		})
-		if (needsLoad && typeof document !== 'undefined') {
-			status = 'loading'
-			const loadAttempt = loadLatch.getPendingAttempt()
-			handle.queueTask(async (signal) => {
-				try {
-					await loadPost(slug, signal)
-					if (signal.aborted) {
-						loadLatch.clearPending(currentHref, loadAttempt)
-						return
-					}
-					if (status === 'ready' || status === 'not-found') {
-						loadLatch.markLoaded(currentHref)
-					} else {
-						loadLatch.markFailed(currentHref)
-					}
-				} catch {
-					if (signal.aborted) {
-						loadLatch.clearPending(currentHref, loadAttempt)
-						return
-					}
-					loadLatch.markFailed(currentHref)
-				}
-			})
-		}
-
-		// Never show another post's content: mismatched loadedSlug means the
-		// URL already moved on while this closure still holds prior state.
-		const contentMatchesSlug = loadedSlug === slug
-		const showNotFound = status === 'not-found' && contentMatchesSlug
-		const showError = status === 'error' && contentMatchesSlug
-		const showReady = status === 'ready' && post !== null && contentMatchesSlug
-		const showLoading = !showNotFound && !showError && !showReady
+		const snapshot = postData.read(handle, currentHref)
 		const signedOutCta = publicSignupPrimaryCta(signupMode)
 
-		if (showNotFound) {
+		if (snapshot.kind === 'not-found') {
 			return (
 				<article mix={css(postCss)}>
 					<a href={routes.blog.href()} mix={css(postBackCss)}>
@@ -226,8 +164,11 @@ export function BlogPostRoute(handle: Handle) {
 			)
 		}
 
+		const post = snapshot.data
+		const pending = snapshot.kind === 'pending'
+
 		return (
-			<article mix={css(postCss)}>
+			<article mix={css(postCss)} aria-busy={pending ? 'true' : undefined}>
 				<a
 					data-rise
 					style={{ '--rise': '0' }}
@@ -237,17 +178,19 @@ export function BlogPostRoute(handle: Handle) {
 					← All posts
 				</a>
 
-				{showLoading ? (
-					<p mix={css(postStatusCss)} role="status">
-						Loading post…
-					</p>
-				) : null}
-				{showError ? (
+				{snapshot.kind === 'error' ? (
 					<p mix={css(postStatusCss)} role="status">
 						Unable to load this blog post.
 					</p>
 				) : null}
-				{showReady && post ? (
+				{/* Only the SPA cold path has no previous post to keep on screen. */}
+				{pending && post === null ? (
+					<p mix={css(postStatusCss)} role="status">
+						Loading post…
+					</p>
+				) : null}
+				{pending && post !== null ? renderRoutePendingStatus() : null}
+				{post !== null ? (
 					<>
 						<header mix={css(postHeadCss)}>
 							<h1 data-rise style={{ '--rise': '1' }}>
@@ -283,7 +226,7 @@ export function BlogPostRoute(handle: Handle) {
 							</aside>
 						) : null}
 
-						<div mix={css(proseCss)}>{renderPostBody(post.body)}</div>
+						<div mix={css(proseCss)}>{renderPostBody(post)}</div>
 
 						<footer mix={css(postFootCss)}>
 							{post.readNext ? (

--- a/packages/worker/client/routes/blog.tsx
+++ b/packages/worker/client/routes/blog.tsx
@@ -10,10 +10,11 @@ import {
 } from '#universal/loader-data.ts'
 import { routes } from '#universal/routes.ts'
 import { readCurrentRouterHref } from '#client/client-router.tsx'
-import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
-import { consumeStaleNavigationData } from '#client/navigation-data.ts'
 import { revealCard } from '#client/reveal.ts'
-import { createRouteLoadLatch } from '#client/route-load-latch.ts'
+import {
+	createRouteData,
+	renderRoutePendingStatus,
+} from '#client/route-data.tsx'
 import { type RouteLoaderResult } from '#client/route-loader.ts'
 import { readJson } from '#client/routes/account-approval-shared.ts'
 import { colors, transitions } from '#universal/styles/tokens.ts'
@@ -51,33 +52,20 @@ export async function blogRouteLoader(
 }
 
 export function BlogRoute(handle: Handle) {
-	let status: 'loading' | 'ready' | 'error' = 'loading'
-	let posts: BlogLoaderData['posts'] = []
-	const loadLatch = createRouteLoadLatch()
-
-	async function loadBlog(signal: AbortSignal) {
-		// Do not call handle.update() before the first await. Remix aborts this
-		// queueTask on re-render; an early update aborts the fetch, needsLoad
-		// re-queues, and the scheduler hits "infinite loop detected".
-		try {
+	const blogData = createRouteData({
+		key: 'blog',
+		async load(_href, signal) {
 			const response = await fetch(blogApiPath, {
 				headers: { Accept: 'application/json' },
 				signal,
 			})
 			const payload = await readJson<BlogLoaderData>(response)
-			if (signal.aborted) return
 			if (!response.ok || !payload?.ok) {
 				throw new Error('Unable to load blog posts.')
 			}
-			posts = payload.posts
-			status = 'ready'
-			handle.update()
-		} catch {
-			if (signal.aborted) return
-			status = 'error'
-			handle.update()
-		}
-	}
+			return payload
+		},
+	})
 
 	return () => {
 		const currentHref = readCurrentRouterHref(handle)
@@ -85,46 +73,14 @@ export function BlogRoute(handle: Handle) {
 			return <section mix={css(blogPageCss)} />
 		}
 
-		const routeData = tryConsumeRouteLoaderData(handle, 'blog', currentHref)
-		const appliedRouteData = Boolean(routeData?.ok)
-		if (routeData?.ok) {
-			posts = routeData.posts
-			status = 'ready'
-			loadLatch.markLoaded(currentHref)
-		}
-
-		const needsStaleRefresh = consumeStaleNavigationData(currentHref)
-		const needsLoad = loadLatch.needsLoad({
-			currentHref,
-			appliedRouteData,
-			needsStaleRefresh,
-		})
-		if (needsLoad && typeof document !== 'undefined') {
-			status = 'loading'
-			const loadAttempt = loadLatch.getPendingAttempt()
-			handle.queueTask(async (signal) => {
-				try {
-					await loadBlog(signal)
-					if (signal.aborted) {
-						loadLatch.clearPending(currentHref, loadAttempt)
-						return
-					}
-					if (status === 'ready') loadLatch.markLoaded(currentHref)
-					else loadLatch.markFailed(currentHref)
-				} catch {
-					if (signal.aborted) {
-						loadLatch.clearPending(currentHref, loadAttempt)
-						return
-					}
-					loadLatch.markFailed(currentHref)
-				}
-			})
-		}
-
-		const [featuredPost, ...listPosts] = posts
+		const snapshot = blogData.read(handle, currentHref)
+		const posts = snapshot.data?.posts ?? null
+		const pending = snapshot.kind === 'pending'
+		const [featuredPost, ...listPosts] = posts ?? []
 
 		return (
-			<section mix={css(blogPageCss)}>
+			<section mix={css(blogPageCss)} aria-busy={pending ? 'true' : undefined}>
+				{pending && posts !== null ? renderRoutePendingStatus() : null}
 				<header mix={css(blogHeadCss)}>
 					<h1 data-rise style={{ '--rise': '0' }}>
 						Notes from the <em>eucalyptus</em>
@@ -144,10 +100,12 @@ export function BlogRoute(handle: Handle) {
 					</a>
 				</header>
 
-				{status === 'loading' ? (
-					<p mix={css(listStatusCss)}>Loading posts…</p>
+				{pending && posts === null ? (
+					<p mix={css(listStatusCss)} role="status">
+						Loading posts…
+					</p>
 				) : null}
-				{status === 'error' ? (
+				{snapshot.kind === 'error' ? (
 					<div mix={css(listStatusCss)}>
 						<p mix={css({ margin: 0 })}>Unable to load blog posts.</p>
 						<button
@@ -161,13 +119,13 @@ export function BlogRoute(handle: Handle) {
 						</button>
 					</div>
 				) : null}
-				{status === 'ready' && featuredPost ? (
+				{posts !== null && featuredPost ? (
 					<ul mix={css(postListCss)}>
 						{renderFeaturedPostItem(featuredPost)}
 						{listPosts.map((post, index) => renderPostItem(post, index + 1))}
 					</ul>
 				) : null}
-				{status === 'ready' && !featuredPost ? (
+				{posts !== null && !featuredPost ? (
 					<p mix={css(listStatusCss)}>No posts yet.</p>
 				) : null}
 			</section>

--- a/packages/worker/client/routes/discord.tsx
+++ b/packages/worker/client/routes/discord.tsx
@@ -1,9 +1,10 @@
 import { type Handle, css } from 'remix/ui'
 import { on } from '#client/event-mixin.ts'
 import { readCurrentRouterHref } from '#client/client-router.tsx'
-import { createRouteLoadLatch } from '#client/route-load-latch.ts'
-import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
-import { consumeStaleNavigationData } from '#client/navigation-data.ts'
+import {
+	createRouteData,
+	renderRoutePendingStatus,
+} from '#client/route-data.tsx'
 import { ProviderIcon } from '#client/provider-icons.tsx'
 import { startSocialSignIn } from '#client/social-sign-in.ts'
 import { type RouteLoaderResult } from '#client/route-loader.ts'
@@ -92,33 +93,25 @@ export async function discordRouteLoader(
 }
 
 export function DiscordRoute(handle: Handle) {
-	let status: 'loading' | 'ready' | 'error' = 'loading'
+	/** Last good payload; the action handlers read it between renders. */
 	let page: DiscordPageLoaderData | null = null
 	let busy = false
 	let actionMessage: { text: string; tone: 'error' | 'info' } | null = null
-	const loadLatch = createRouteLoadLatch()
-
-	async function loadPage(signal: AbortSignal) {
-		try {
+	const pageData = createRouteData({
+		key: 'discord',
+		async load(_href, signal) {
 			const response = await fetch(discordApiPath, {
 				headers: { Accept: 'application/json' },
 				credentials: 'include',
 				signal,
 			})
 			const payload = await readJson<DiscordPageLoaderData>(response)
-			if (signal.aborted) return
 			if (!response.ok || !payload?.ok) {
 				throw new Error('Unable to load Discord connection status.')
 			}
-			page = payload
-			status = 'ready'
-			handle.update()
-		} catch {
-			if (signal.aborted) return
-			status = 'error'
-			handle.update()
-		}
-	}
+			return payload
+		},
+	})
 
 	async function handleConnectDiscord() {
 		busy = true
@@ -209,41 +202,18 @@ export function DiscordRoute(handle: Handle) {
 			return <section mix={css(pageCss)} />
 		}
 
-		const routeData = tryConsumeRouteLoaderData(handle, 'discord', currentHref)
-		const appliedRouteData = Boolean(routeData?.ok)
-		if (routeData?.ok) {
-			page = routeData
-			status = 'ready'
-			loadLatch.markLoaded(currentHref)
+		const snapshot = pageData.read(handle, currentHref)
+		if (snapshot.data && snapshot.data !== page) {
+			page = snapshot.data
 		}
-
-		const needsStaleRefresh = consumeStaleNavigationData(currentHref)
-		const needsLoad = loadLatch.needsLoad({
-			currentHref,
-			appliedRouteData,
-			needsStaleRefresh,
-		})
-		if (needsLoad && typeof document !== 'undefined') {
-			status = 'loading'
-			const loadAttempt = loadLatch.getPendingAttempt()
-			handle.queueTask(async (signal) => {
-				try {
-					await loadPage(signal)
-					if (signal.aborted) {
-						loadLatch.clearPending(currentHref, loadAttempt)
-						return
-					}
-					if (status === 'ready') loadLatch.markLoaded(currentHref)
-					else loadLatch.markFailed(currentHref)
-				} catch {
-					if (signal.aborted) {
-						loadLatch.clearPending(currentHref, loadAttempt)
-						return
-					}
-					loadLatch.markFailed(currentHref)
-				}
-			})
-		}
+		const pending = snapshot.kind === 'pending'
+		const status: 'loading' | 'ready' | 'error' =
+			snapshot.kind === 'error'
+				? 'error'
+				: pending && page === null
+					? 'loading'
+					: 'ready'
+		const routeBusy = pending && page !== null
 
 		const callbackMessage = readCallbackMessage(currentHref)
 		const message = actionMessage ?? callbackMessage
@@ -263,7 +233,8 @@ export function DiscordRoute(handle: Handle) {
 			(!page.signedIn || !page.discordConnected)
 
 		return (
-			<section mix={css(pageCss)}>
+			<section mix={css(pageCss)} aria-busy={routeBusy ? 'true' : undefined}>
+				{routeBusy ? renderRoutePendingStatus() : null}
 				<header mix={css(pageHeaderCss)}>
 					<h1 mix={css(titleCss)}>
 						<ProviderIcon providerId="discord" size="1em" />

--- a/packages/worker/client/routes/doc-detail.tsx
+++ b/packages/worker/client/routes/doc-detail.tsx
@@ -12,9 +12,10 @@ import {
 } from '#universal/docs-nav.ts'
 import { renderMarkdownNodes } from '#client/markdown-view.tsx'
 import { readCurrentRouterHref } from '#client/client-router.tsx'
-import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
-import { consumeStaleNavigationData } from '#client/navigation-data.ts'
-import { createRouteLoadLatch } from '#client/route-load-latch.ts'
+import {
+	createRouteData,
+	renderRoutePendingStatus,
+} from '#client/route-data.tsx'
 import {
 	routeLoaderRedirect,
 	type RouteLoaderResult,
@@ -165,62 +166,44 @@ function describeDoc(doc: DocDetailLoaderData): string {
 }
 
 export function DocDetailRoute(handle: Handle) {
-	let status: 'loading' | 'ready' | 'error' | 'not-found' = 'loading'
-	let doc: DocDetailLoaderData | null = null
-	/** Slug that `doc` / `status` currently describe. */
-	let loadedSlug: string | null = null
-	const loadLatch = createRouteLoadLatch()
+	const docData = createRouteData({
+		key: 'docDetail',
+		async load(href, signal) {
+			const slug = getDocSlugFromPathname(
+				new URL(href, 'http://localhost').pathname,
+			)
+			if (!slug) return null
+			const response = await fetch(routes.docDetailApi.href({ slug }), {
+				headers: { Accept: 'application/json' },
+				signal,
+			})
+			if (response.status === 404) return null
+			const payload = await readJson<DocDetailLoaderData>(response)
+			if (!response.ok || !payload?.ok) {
+				throw new Error('Unable to load doc.')
+			}
+			return payload
+		},
+	})
 
 	// Re-lexing markdown on every handle.update() would be wasted work; cache
 	// the rendered body per markdown string (same policy as MarkdownView).
 	let renderedForBody: string | null = null
 	let renderedBody: Array<RemixNode> = []
 
-	function renderDocBody(body: string) {
-		if (renderedForBody !== body) {
-			renderedForBody = body
-			renderedBody = renderMarkdownNodes(stripLeadingH1(body), {
+	function renderDocBody(doc: DocDetailLoaderData) {
+		if (renderedForBody !== doc.body) {
+			renderedForBody = doc.body
+			renderedBody = renderMarkdownNodes(stripLeadingH1(doc.body), {
 				headingOffset: 0,
 				linkRel: 'noopener noreferrer',
 				linkPolicy: 'first-party',
 				copyCodeBlocks: true,
 				headingIds: true,
-				fences: doc?.bodyFences,
+				fences: doc.bodyFences,
 			})
 		}
 		return renderedBody
-	}
-
-	async function loadDoc(slug: string, signal: AbortSignal) {
-		// Do not call handle.update() before the first await — see blog.tsx.
-		try {
-			const response = await fetch(routes.docDetailApi.href({ slug }), {
-				headers: { Accept: 'application/json' },
-				signal,
-			})
-			if (signal.aborted) return
-			if (response.status === 404) {
-				doc = null
-				status = 'not-found'
-				loadedSlug = slug
-				handle.update()
-				return
-			}
-			const payload = await readJson<DocDetailLoaderData>(response)
-			if (signal.aborted) return
-			if (!response.ok || !payload?.ok) {
-				throw new Error('Unable to load doc.')
-			}
-			doc = payload
-			status = 'ready'
-			loadedSlug = slug
-			handle.update()
-		} catch {
-			if (signal.aborted) return
-			status = 'error'
-			loadedSlug = slug
-			handle.update()
-		}
 	}
 
 	return () => {
@@ -230,59 +213,9 @@ export function DocDetailRoute(handle: Handle) {
 			return <article mix={css(docPageCss)} />
 		}
 
-		const routeData = tryConsumeRouteLoaderData(
-			handle,
-			'docDetail',
-			currentHref,
-		)
-		const appliedRouteData = Boolean(routeData?.ok)
-		if (routeData?.ok) {
-			doc = routeData
-			status = 'ready'
-			loadedSlug = routeData.slug
-			loadLatch.markLoaded(currentHref)
-		}
+		const snapshot = docData.read(handle, currentHref)
 
-		const needsStaleRefresh = consumeStaleNavigationData(currentHref)
-		const needsLoad = loadLatch.needsLoad({
-			currentHref,
-			appliedRouteData,
-			needsStaleRefresh,
-		})
-		if (needsLoad && typeof document !== 'undefined') {
-			status = 'loading'
-			const loadAttempt = loadLatch.getPendingAttempt()
-			handle.queueTask(async (signal) => {
-				try {
-					await loadDoc(slug, signal)
-					if (signal.aborted) {
-						loadLatch.clearPending(currentHref, loadAttempt)
-						return
-					}
-					if (status === 'ready' || status === 'not-found') {
-						loadLatch.markLoaded(currentHref)
-					} else {
-						loadLatch.markFailed(currentHref)
-					}
-				} catch {
-					if (signal.aborted) {
-						loadLatch.clearPending(currentHref, loadAttempt)
-						return
-					}
-					loadLatch.markFailed(currentHref)
-				}
-			})
-		}
-
-		// Never show another doc's content after a fast navigation.
-		const contentMatchesSlug = loadedSlug === slug
-		const showNotFound = status === 'not-found' && contentMatchesSlug
-		const showError = status === 'error' && contentMatchesSlug
-		const showReady = status === 'ready' && doc !== null && contentMatchesSlug
-		const showLoading = !showNotFound && !showError && !showReady
-		const section = findDocsNavSection(slug)
-
-		if (showNotFound) {
+		if (snapshot.kind === 'not-found') {
 			return renderDocsShell({
 				current: slug,
 				children: (
@@ -304,79 +237,101 @@ export function DocDetailRoute(handle: Handle) {
 			})
 		}
 
-		return renderDocsShell({
-			current: slug,
-			children: (
-				<article mix={css(docPageCss)}>
-					{showLoading ? (
-						<p mix={css(docStatusCss)} role="status">
-							Loading…
-						</p>
-					) : null}
-					{showError ? (
+		if (snapshot.kind === 'error') {
+			return renderDocsShell({
+				current: slug,
+				children: (
+					<article mix={css(docPageCss)}>
 						<p mix={css(docStatusCss)} role="status">
 							Unable to load this page.
 						</p>
+					</article>
+				),
+			})
+		}
+
+		const doc = snapshot.data
+		// Nothing has ever rendered here (SPA cold mount without SSR data), so
+		// there is no previous article to keep on screen while the fallback
+		// fetch runs. Every other path keeps the last article visible.
+		if (doc === null) {
+			return renderDocsShell({
+				current: slug,
+				children: (
+					<article mix={css(docPageCss)} aria-busy="true">
+						<p mix={css(docStatusCss)} role="status">
+							Loading…
+						</p>
+					</article>
+				),
+			})
+		}
+
+		const pending = snapshot.kind === 'pending'
+		// While a fallback fetch runs the sidebar already marks the destination
+		// and the article below is the previous doc (`snapshot.stale`); keep it
+		// on screen under `aria-busy` rather than blanking the column, and let
+		// the pager/eyebrow follow the doc actually shown.
+		return renderDocsShell({
+			current: slug,
+			children: (
+				<article mix={css(docPageCss)} aria-busy={pending ? 'true' : undefined}>
+					{pending ? renderRoutePendingStatus() : null}
+					<header mix={css(docHeadCss)}>
+						<p data-rise style={{ '--rise': '0' }} mix={css(docEyebrowCss)}>
+							{doc.category === 'provider' ? (
+								<a href={routes.docsConnect.href()}>Connect a provider</a>
+							) : (
+								(findDocsNavSection(doc.slug)?.label ?? 'Docs')
+							)}
+						</p>
+						<h1
+							data-docs-heading
+							tabIndex={-1}
+							data-rise
+							style={{ '--rise': '1' }}
+						>
+							{doc.title}
+						</h1>
+						<p data-rise style={{ '--rise': '2' }} mix={css(docMetaCss)}>
+							{describeDoc(doc)}
+						</p>
+					</header>
+
+					{doc.image && doc.imageAlt ? (
+						<img
+							src={doc.image}
+							alt={doc.imageAlt}
+							width={1024}
+							height={1024}
+							loading="eager"
+							decoding="async"
+							data-rise
+							style={{ '--rise': '3' }}
+							mix={css(docImageCss)}
+						/>
 					) : null}
-					{showReady && doc ? (
-						<>
-							<header mix={css(docHeadCss)}>
-								<p data-rise style={{ '--rise': '0' }} mix={css(docEyebrowCss)}>
-									{doc.category === 'provider' ? (
-										<a href={routes.docsConnect.href()}>Connect a provider</a>
-									) : (
-										(section?.label ?? 'Docs')
-									)}
-								</p>
-								<h1
-									data-docs-heading
-									tabIndex={-1}
-									data-rise
-									style={{ '--rise': '1' }}
-								>
-									{doc.title}
-								</h1>
-								<p data-rise style={{ '--rise': '2' }} mix={css(docMetaCss)}>
-									{describeDoc(doc)}
-								</p>
-							</header>
 
-							{doc.image && doc.imageAlt ? (
-								<img
-									src={doc.image}
-									alt={doc.imageAlt}
-									width={1024}
-									height={1024}
-									loading="eager"
-									decoding="async"
-									data-rise
-									style={{ '--rise': '3' }}
-									mix={css(docImageCss)}
-								/>
-							) : null}
+					{interactiveDocRenderers[doc.slug]?.(
+						doc.walkthroughHighlights,
+						doc.walkthroughHosts,
+					) ?? <div mix={css(docProseCss)}>{renderDocBody(doc)}</div>}
 
-							{interactiveDocRenderers[doc.slug]?.(
-								doc.walkthroughHighlights,
-								doc.walkthroughHosts,
-							) ?? <div mix={css(docProseCss)}>{renderDocBody(doc.body)}</div>}
+					{renderDocsPager(doc.slug)}
 
-							{renderDocsPager(doc.slug)}
-
-							<footer mix={css(docFootCss)}>
-								<p>
-									Working with an agent? This page is also plain markdown at{' '}
-									<a
-										href={routes.docDetailMarkdown.href({ slug: doc.slug })}
-										data-rmx-document
-									>
-										/docs/{doc.slug}.md
-									</a>
-									, or load it over MCP with{' '}
-									<code>{`search({ entity: '${doc.id}:guide' })`}</code>.
-								</p>
-							</footer>
-						</>
-					) : null}
+					<footer mix={css(docFootCss)}>
+						<p>
+							Working with an agent? This page is also plain markdown at{' '}
+							<a
+								href={routes.docDetailMarkdown.href({ slug: doc.slug })}
+								data-rmx-document
+							>
+								/docs/{doc.slug}.md
+							</a>
+							, or load it over MCP with{' '}
+							<code>{`search({ entity: '${doc.id}:guide' })`}</code>.
+						</p>
+					</footer>
 				</article>
 			),
 		})

--- a/packages/worker/client/routes/docs-connect.tsx
+++ b/packages/worker/client/routes/docs-connect.tsx
@@ -3,9 +3,10 @@ import { type DocsConnectLoaderData } from '#universal/loader-data.ts'
 import { routes } from '#universal/routes.ts'
 import { docHref } from '#universal/docs-nav.ts'
 import { readCurrentRouterHref } from '#client/client-router.tsx'
-import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
-import { consumeStaleNavigationData } from '#client/navigation-data.ts'
-import { createRouteLoadLatch } from '#client/route-load-latch.ts'
+import {
+	createRouteData,
+	renderRoutePendingStatus,
+} from '#client/route-data.tsx'
 import { type RouteLoaderResult } from '#client/route-loader.ts'
 import { readJson } from '#client/routes/account-approval-shared.ts'
 import {
@@ -51,30 +52,20 @@ export async function docsConnectRouteLoader(
 }
 
 export function DocsConnectRoute(handle: Handle) {
-	let status: 'loading' | 'ready' | 'error' = 'loading'
-	let guides: DocsConnectLoaderData['guides'] = []
-	const loadLatch = createRouteLoadLatch()
-
-	async function loadGuides(signal: AbortSignal) {
-		try {
+	const guidesData = createRouteData({
+		key: 'docsConnect',
+		async load(_href, signal) {
 			const response = await fetch(docsConnectApiPath, {
 				headers: { Accept: 'application/json' },
 				signal,
 			})
 			const payload = await readJson<DocsConnectLoaderData>(response)
-			if (signal.aborted) return
 			if (!response.ok || !payload?.ok) {
 				throw new Error('Unable to load connection docs.')
 			}
-			guides = payload.guides
-			status = 'ready'
-			handle.update()
-		} catch {
-			if (signal.aborted) return
-			status = 'error'
-			handle.update()
-		}
-	}
+			return payload
+		},
+	})
 
 	return () => {
 		const currentHref = readCurrentRouterHref(handle)
@@ -82,50 +73,18 @@ export function DocsConnectRoute(handle: Handle) {
 			return <section mix={css(connectPageCss)} />
 		}
 
-		const routeData = tryConsumeRouteLoaderData(
-			handle,
-			'docsConnect',
-			currentHref,
-		)
-		const appliedRouteData = Boolean(routeData?.ok)
-		if (routeData?.ok) {
-			guides = routeData.guides
-			status = 'ready'
-			loadLatch.markLoaded(currentHref)
-		}
-
-		const needsStaleRefresh = consumeStaleNavigationData(currentHref)
-		const needsLoad = loadLatch.needsLoad({
-			currentHref,
-			appliedRouteData,
-			needsStaleRefresh,
-		})
-		if (needsLoad && typeof document !== 'undefined') {
-			status = 'loading'
-			const loadAttempt = loadLatch.getPendingAttempt()
-			handle.queueTask(async (signal) => {
-				try {
-					await loadGuides(signal)
-					if (signal.aborted) {
-						loadLatch.clearPending(currentHref, loadAttempt)
-						return
-					}
-					if (status === 'ready') loadLatch.markLoaded(currentHref)
-					else loadLatch.markFailed(currentHref)
-				} catch {
-					if (signal.aborted) {
-						loadLatch.clearPending(currentHref, loadAttempt)
-						return
-					}
-					loadLatch.markFailed(currentHref)
-				}
-			})
-		}
+		const snapshot = guidesData.read(handle, currentHref)
+		const guides = snapshot.data?.guides ?? null
+		const pending = snapshot.kind === 'pending'
 
 		return renderDocsShell({
 			current: 'connect',
 			children: (
-				<section mix={css(connectPageCss)}>
+				<section
+					mix={css(connectPageCss)}
+					aria-busy={pending ? 'true' : undefined}
+				>
+					{pending && guides !== null ? renderRoutePendingStatus() : null}
 					<header mix={css(connectHeadCss)}>
 						<p data-rise style={{ '--rise': '0' }} mix={css(connectEyebrowCss)}>
 							Docs
@@ -158,13 +117,17 @@ export function DocsConnectRoute(handle: Handle) {
 						</p>
 					</header>
 
-					{status === 'loading' ? (
-						<p mix={css(docsListStatusCss)}>Loading connection docs…</p>
+					{pending && guides === null ? (
+						<p mix={css(docsListStatusCss)} role="status">
+							Loading connection docs…
+						</p>
 					) : null}
-					{status === 'error' ? (
-						<p mix={css(docsListStatusCss)}>Unable to load connection docs.</p>
+					{snapshot.kind === 'error' ? (
+						<p mix={css(docsListStatusCss)} role="status">
+							Unable to load connection docs.
+						</p>
 					) : null}
-					{status === 'ready' ? (
+					{guides !== null ? (
 						<>
 							<section>
 								<h2 mix={css(docsGroupHeadingCss)}>Providers</h2>

--- a/packages/worker/client/routes/home.tsx
+++ b/packages/worker/client/routes/home.tsx
@@ -1,9 +1,11 @@
 import { type Handle, type RemixNode } from 'remix/ui'
 import { CopyTextButton } from '#client/copy-text-button.tsx'
 import { readCurrentRouterHref } from '#client/client-router.tsx'
-import { createRouteLoadLatch } from '#client/route-load-latch.ts'
 import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
-import { consumeStaleNavigationData } from '#client/navigation-data.ts'
+import {
+	createRouteData,
+	renderRoutePendingStatus,
+} from '#client/route-data.tsx'
 import {
 	fetchOnboardingPayload,
 	type OnboardingPayload,
@@ -145,19 +147,64 @@ export async function homeRouteLoader(
 	return result
 }
 
+type HomePagePayloads = {
+	onboarding: OnboardingPayload | null
+	codeRuns: { window: PublicCodeRunsWindow | null } | null
+	walkthroughHosts?: WalkthroughHostPick
+	signupMode?: SignupMode
+}
+
 export function HomeRoute(handle: Handle) {
 	let loggedIn = false
 	let discoveryPrompt = ''
 	let codeRunsWindow: PublicCodeRunsWindow | null = null
-	let onboardingStatus: 'idle' | 'loading' | 'ready' = 'idle'
 	let walkthroughHosts: WalkthroughHostPick | null = null
 	let signupMode: SignupMode = 'invite'
-	const loadLatch = createRouteLoadLatch()
+	/** Payload last applied to the closure state above. */
+	let appliedPayload: HomePagePayloads | null = null
+	const homeData = createRouteData<'onboarding', HomePagePayloads>({
+		consume(handle, href) {
+			if (!isHomePath(href)) return null
+			const onboarding = tryConsumeRouteLoaderData(handle, 'onboarding', href)
+			const codeRuns = tryConsumeRouteLoaderData(handle, 'codeRuns', href)
+			const hosts = tryConsumeRouteLoaderData(handle, 'walkthroughHosts', href)
+			const signupModeData = tryConsumeRouteLoaderData(
+				handle,
+				'signupMode',
+				href,
+			)
+			// The optional keys stand on their own (a document may embed the
+			// ticker window without an onboarding payload); apply them even
+			// when the required key is missing and the fallback fetch runs.
+			if (hosts) walkthroughHosts = hosts
+			applyCodeRunsPayload(codeRuns ?? null)
+			if (signupModeData) signupMode = signupModeData
+			if (!onboarding) return null
+			return {
+				onboarding,
+				codeRuns: codeRuns ?? null,
+				walkthroughHosts: hosts,
+				signupMode: signupModeData,
+			}
+		},
+		async load(_href, signal) {
+			const [onboarding, codeRuns, authConfig] = await Promise.all([
+				fetchOnboardingPayload(signal),
+				fetchCodeRunsPayload(signal),
+				fetchPublicAuthConfig(signal),
+			])
+			return {
+				onboarding,
+				codeRuns,
+				walkthroughHosts: walkthroughHosts ?? pickWalkthroughHosts(),
+				signupMode: parseSignupMode(authConfig?.signupMode),
+			}
+		},
+	})
 
 	function applyOnboardingPayload(payload: OnboardingPayload | null) {
 		loggedIn = payload?.loggedIn === true
 		discoveryPrompt = payload?.discoveryPrompt ?? ''
-		onboardingStatus = 'ready'
 	}
 
 	function applyCodeRunsPayload(
@@ -167,67 +214,30 @@ export function HomeRoute(handle: Handle) {
 		codeRunsWindow = payload.window
 	}
 
-	async function loadHomePayload(signal: AbortSignal) {
-		const href = readCurrentRouterHref(handle)
-		try {
-			const [payload, codeRuns, authConfig] = await Promise.all([
-				fetchOnboardingPayload(signal),
-				fetchCodeRunsPayload(signal),
-				fetchPublicAuthConfig(signal),
-			])
-			if (signal.aborted) return
-			applyOnboardingPayload(payload)
-			applyCodeRunsPayload(codeRuns)
-			signupMode = parseSignupMode(authConfig?.signupMode)
-			if (!walkthroughHosts) walkthroughHosts = pickWalkthroughHosts()
-			loadLatch.markLoaded(href)
-			handle.update()
-		} catch {
-			if (signal.aborted) return
-			onboardingStatus = 'ready'
-			loadLatch.markFailed(href)
-			handle.update()
-		}
-	}
-
-	function applyRouteLoaderData(href: string) {
-		if (!isHomePath(href)) return false
-		const onboardingData = tryConsumeRouteLoaderData(handle, 'onboarding', href)
-		const codeRunsData = tryConsumeRouteLoaderData(handle, 'codeRuns', href)
-		const hostsData = tryConsumeRouteLoaderData(
-			handle,
-			'walkthroughHosts',
-			href,
-		)
-		const signupModeData = tryConsumeRouteLoaderData(handle, 'signupMode', href)
-		if (hostsData) walkthroughHosts = hostsData
-		if (codeRunsData) applyCodeRunsPayload(codeRunsData)
-		if (signupModeData) signupMode = signupModeData
-		if (!onboardingData) return false
-		applyOnboardingPayload(onboardingData)
-		loadLatch.markLoaded(href)
-		return true
+	function applyHomePayload(payload: HomePagePayloads) {
+		if (payload.walkthroughHosts) walkthroughHosts = payload.walkthroughHosts
+		applyCodeRunsPayload(payload.codeRuns)
+		if (payload.signupMode) signupMode = payload.signupMode
+		applyOnboardingPayload(payload.onboarding)
 	}
 
 	return () => {
 		const currentHref = readCurrentRouterHref(handle)
-		const appliedRouteData = applyRouteLoaderData(currentHref)
-		const needsStaleRefresh =
-			consumeStaleNavigationData(currentHref) && !appliedRouteData
-		const needsLoad = loadLatch.needsLoad({
-			currentHref,
-			appliedRouteData,
-			needsStaleRefresh,
-		})
-		if (needsLoad && typeof document !== 'undefined') {
-			onboardingStatus = 'loading'
-			handle.queueTask(loadHomePayload)
+		const snapshot = homeData.read(handle, currentHref)
+		if (snapshot.data && snapshot.data !== appliedPayload) {
+			appliedPayload = snapshot.data
+			applyHomePayload(snapshot.data)
 		}
+		const pending = snapshot.kind === 'pending'
+		const busy = pending && appliedPayload !== null
 
-		const isSignedIn = onboardingStatus === 'ready' && loggedIn
+		// A failed fallback fetch still settles the door for a visitor.
+		const onboardingReady = appliedPayload !== null || snapshot.kind === 'error'
+		const isSignedIn = onboardingReady && loggedIn
 
 		return (
-			<div>
+			<div aria-busy={busy ? 'true' : undefined}>
+				{busy ? renderRoutePendingStatus() : null}
 				<section data-parallax-scope class="landing-hero">
 					<h1 data-rise style={{ '--rise': '0' }} class="landing-hero-title">
 						{landingHeroHeadlineLead} <em>{landingHeroHeadlineAccent}</em>

--- a/packages/worker/client/routes/onboarding.tsx
+++ b/packages/worker/client/routes/onboarding.tsx
@@ -2,9 +2,12 @@ import { type Handle, css, ref } from 'remix/ui'
 import { normalizeRedirectTo } from '#universal/safe-redirect.ts'
 import { navigate, readCurrentRouterHref } from '#client/client-router.tsx'
 import { discardRenderPrefetches } from '#client/intent-prefetch.ts'
-import { createRouteLoadLatch } from '#client/route-load-latch.ts'
 import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
-import { consumeStaleNavigationData } from '#client/navigation-data.ts'
+import {
+	createRouteData,
+	renderRoutePendingStatus,
+	routeDataRedirect,
+} from '#client/route-data.tsx'
 import { readRouterSearch } from '#client/router-location.tsx'
 import { type AccountStatus } from '#client/routes/account-approval-shared.ts'
 import {
@@ -67,6 +70,13 @@ import { getGhostButtonCss } from '#universal/styles/style-primitives.ts'
  */
 
 type OnboardingStep = OnboardingWizardStepNumber
+
+type OnboardingPagePayloads = {
+	onboarding: OnboardingPayload
+	onboardingAgentChooser?: OnboardingAgentChooserPick
+	/** Router/SSR snapshots merge into progress already seen; live fetches replace it. */
+	source: 'live' | 'snapshot'
+}
 
 function isOnboardingPath(href: string) {
 	return isOnboardingPagePath(new URL(href, 'http://localhost').pathname)
@@ -168,7 +178,40 @@ export function OnboardingRoute(handle: Handle) {
 	// Panel entrances only play for real step changes, never on the first
 	// paint — the page-open choreography belongs to the head's data-rise.
 	let panelAnimationArmed = false
-	const loadLatch = createRouteLoadLatch()
+	/** Payload last applied to the closure state above. */
+	let appliedPayload: OnboardingPagePayloads | null = null
+	let appliedError: Error | null = null
+	const onboardingData = createRouteData<'onboarding', OnboardingPagePayloads>({
+		locationKey: onboardingDataHref,
+		consume(handle, href) {
+			if (!isOnboardingPath(href)) return null
+			const chooserData = tryConsumeRouteLoaderData(
+				handle,
+				'onboardingAgentChooser',
+				href,
+			)
+			const routeData = tryConsumeRouteLoaderData(handle, 'onboarding', href)
+			if (!routeData) return null
+			return {
+				onboarding: routeData,
+				onboardingAgentChooser: chooserData,
+				source: 'snapshot',
+			}
+		},
+		async load(_href, signal) {
+			const redirectTo = readOnboardingRedirectTo(handle)
+			const payload = await fetchOnboardingPayload(signal)
+			if (!payload) {
+				throw new Error('Unable to load onboarding.')
+			}
+			if (payload.loggedIn && !payload.emailVerified) {
+				return routeDataRedirect(
+					resolveOnboardingPendingVerificationPath(redirectTo),
+				)
+			}
+			return { onboarding: payload, source: 'live' }
+		},
+	})
 
 	function applyPayload(
 		payload: OnboardingPayload,
@@ -308,36 +351,6 @@ export function OnboardingRoute(handle: Handle) {
 		})
 	}
 
-	async function loadOnboarding(signal: AbortSignal) {
-		const href = readCurrentRouterHref(handle)
-		const redirectTo = readOnboardingRedirectTo(handle)
-		try {
-			const payload = await fetchOnboardingPayload(signal)
-			if (signal.aborted) return
-			if (!payload) {
-				throw new Error('Unable to load onboarding.')
-			}
-			if (payload.loggedIn && !payload.emailVerified) {
-				window.location.assign(
-					resolveOnboardingPendingVerificationPath(redirectTo),
-				)
-				return
-			}
-			applyPayload(payload, 'live')
-			flushPendingAdvanceToAccess(false)
-			if (!agentChooser) agentChooser = resolveOnboardingAgentChooser()
-			loadLatch.markLoaded(onboardingDataHref(href))
-			handle.update()
-		} catch (error) {
-			if (signal.aborted) return
-			status = 'error'
-			message =
-				error instanceof Error ? error.message : 'Unable to load onboarding.'
-			loadLatch.markFailed(onboardingDataHref(href))
-			handle.update()
-		}
-	}
-
 	// Users typically keep this page open while their MCP client connects
 	// or a Step 2 first-search / second grant lands, so poll the same JSON
 	// endpoint until those signals arrive without a manual refresh.
@@ -400,46 +413,36 @@ export function OnboardingRoute(handle: Handle) {
 		}, handle.signal)
 	}
 
-	function applyRouteLoaderData(href: string) {
-		if (!isOnboardingPath(href)) return false
-		const chooserData = tryConsumeRouteLoaderData(
-			handle,
-			'onboardingAgentChooser',
-			href,
-		)
-		if (chooserData) {
-			rememberOnboardingAgentChooser(chooserData)
-			agentChooser = chooserData
-		}
-		const routeData = tryConsumeRouteLoaderData(handle, 'onboarding', href)
-		if (!routeData) return false
-		if (routeData.loggedIn && !routeData.emailVerified) {
-			window.location.assign(
-				resolveOnboardingPendingVerificationPath(
-					readOnboardingRedirectTo(handle),
-				),
-			)
-			return true
-		}
-		applyPayload(routeData)
-		loadLatch.markLoaded(onboardingDataHref(href))
-		return true
-	}
-
 	return () => {
 		const currentHref = readCurrentRouterHref(handle)
-		const appliedRouteData = applyRouteLoaderData(currentHref)
-		flushPendingAdvanceToAccess(true)
-		const needsStaleRefresh =
-			consumeStaleNavigationData(currentHref) && !appliedRouteData
-		const needsLoad = loadLatch.needsLoad({
-			currentHref: onboardingDataHref(currentHref),
-			appliedRouteData,
-			needsStaleRefresh,
-		})
-		if (needsLoad && typeof document !== 'undefined') {
-			handle.queueTask(loadOnboarding)
+		const snapshot = onboardingData.read(handle, currentHref)
+		if (snapshot.data && snapshot.data !== appliedPayload) {
+			appliedPayload = snapshot.data
+			const { onboarding, onboardingAgentChooser, source } = snapshot.data
+			if (onboardingAgentChooser) {
+				rememberOnboardingAgentChooser(onboardingAgentChooser)
+				agentChooser = onboardingAgentChooser
+			}
+			if (onboarding.loggedIn && !onboarding.emailVerified) {
+				window.location.assign(
+					resolveOnboardingPendingVerificationPath(
+						readOnboardingRedirectTo(handle),
+					),
+				)
+			} else {
+				applyPayload(onboarding, source)
+				if (source === 'live' && !agentChooser) {
+					agentChooser = resolveOnboardingAgentChooser()
+				}
+			}
 		}
+		if (snapshot.error && snapshot.error !== appliedError) {
+			appliedError = snapshot.error
+			status = 'error'
+			message = snapshot.error.message
+		}
+		const busy = snapshot.kind === 'pending' && appliedPayload !== null
+		flushPendingAdvanceToAccess(true)
 
 		const location = readOnboardingLocation(currentHref)
 		const activeStep: OnboardingStep = location?.valid
@@ -485,7 +488,8 @@ export function OnboardingRoute(handle: Handle) {
 				: null
 
 		return (
-			<section mix={css(onboardCss)}>
+			<section mix={css(onboardCss)} aria-busy={busy ? 'true' : undefined}>
+				{busy ? renderRoutePendingStatus() : null}
 				<header mix={css(onboardHeadCss)}>
 					<h1 data-rise style={{ '--rise': '0' }}>
 						Get started with <em>Kody</em>

--- a/packages/worker/client/routes/package-files.tsx
+++ b/packages/worker/client/routes/package-files.tsx
@@ -5,9 +5,7 @@ import { type Handle, css } from 'remix/ui'
 import { createMatcher } from 'remix/route-pattern/match'
 import { PackageFilesExplorer } from '#client/package-files-explorer.tsx'
 import { readCurrentRouterHref } from '#client/client-router.tsx'
-import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
-import { consumeStaleNavigationData } from '#client/navigation-data.ts'
-import { createRouteLoadLatch } from '#client/route-load-latch.ts'
+import { createRouteData, routeDataRedirect } from '#client/route-data.tsx'
 import {
 	routeLoaderRedirect,
 	type RouteLoaderResult,
@@ -171,51 +169,29 @@ const messageCss = {
 }
 
 export function PackageFilesRoute(handle: Handle) {
-	let status: 'loading' | 'ready' | 'error' | 'not-found' = 'loading'
-	let data: PackageFilesLoaderData | null = null
-	let loadedHref = ''
-	const loadLatch = createRouteLoadLatch()
-
-	async function loadFiles(apiHref: string, href: string, signal: AbortSignal) {
-		try {
-			const response = await fetch(apiHref, {
+	const filesData = createRouteData({
+		key: 'packageFiles',
+		async load(href, signal) {
+			const location = readFilesLocation(new URL(href, 'http://localhost'))
+			if (!location) return null
+			const response = await fetch(location.apiHref, {
 				headers: { Accept: 'application/json' },
 				credentials: 'include',
 				signal,
 			})
-			if (signal.aborted) return
-			if (response.status === 401) {
-				window.location.assign('/login')
-				return
-			}
+			if (response.status === 401) return routeDataRedirect('/login')
 			if (response.status === 404) {
 				const moved = await readJson<MovedPayload>(response)
-				if (moved?.redirectTo) {
-					window.location.assign(moved.redirectTo)
-					return
-				}
-				data = null
-				status = 'not-found'
-				loadedHref = href
-				handle.update()
-				return
+				if (moved?.redirectTo) return routeDataRedirect(moved.redirectTo)
+				return null
 			}
 			const payload = await readJson<PackageFilesLoaderData>(response)
-			if (signal.aborted) return
 			if (!response.ok || !payload?.ok) {
 				throw new Error('Unable to load package files.')
 			}
-			data = payload
-			status = 'ready'
-			loadedHref = href
-			handle.update()
-		} catch {
-			if (signal.aborted) return
-			status = 'error'
-			loadedHref = href
-			handle.update()
-		}
-	}
+			return payload
+		},
+	})
 
 	return () => {
 		const currentHref = readCurrentRouterHref(handle)
@@ -224,57 +200,15 @@ export function PackageFilesRoute(handle: Handle) {
 			return <article />
 		}
 
-		const routeData = tryConsumeRouteLoaderData(
-			handle,
-			'packageFiles',
-			currentHref,
-		)
-		const appliedRouteData = Boolean(routeData?.ok)
-		if (routeData?.ok) {
-			data = routeData
-			status = 'ready'
-			loadedHref = currentHref
-			loadLatch.markLoaded(currentHref)
-		}
-
-		const needsStaleRefresh = consumeStaleNavigationData(currentHref)
-		const needsLoad = loadLatch.needsLoad({
-			currentHref,
-			appliedRouteData,
-			needsStaleRefresh,
-		})
-		if (needsLoad && typeof document !== 'undefined') {
-			status = 'loading'
-			const loadAttempt = loadLatch.getPendingAttempt()
-			handle.queueTask(async (signal) => {
-				try {
-					await loadFiles(location.apiHref, currentHref, signal)
-					if (signal.aborted) {
-						loadLatch.clearPending(currentHref, loadAttempt)
-						return
-					}
-					if (status === 'ready' || status === 'not-found') {
-						loadLatch.markLoaded(currentHref)
-					} else {
-						loadLatch.markFailed(currentHref)
-					}
-				} catch {
-					if (signal.aborted) {
-						loadLatch.clearPending(currentHref, loadAttempt)
-						return
-					}
-					loadLatch.markFailed(currentHref)
-				}
-			})
-		}
+		const snapshot = filesData.read(handle, currentHref)
 
 		// A miss or a failure replaces the explorer — there is nothing to keep
 		// showing, and the visitor has to be told.
-		if (status === 'not-found' || status === 'error') {
+		if (snapshot.kind === 'not-found' || snapshot.kind === 'error') {
 			return (
 				<article mix={css(messageCss)}>
 					<p>
-						{status === 'not-found'
+						{snapshot.kind === 'not-found'
 							? 'Those files were not found.'
 							: 'Unable to load package files.'}
 					</p>
@@ -284,6 +218,7 @@ export function PackageFilesRoute(handle: Handle) {
 
 		// Only the very first load has nothing to show; a server-rendered visit
 		// arrives with data already applied, so this is the SPA cold path.
+		const data = snapshot.data
 		if (!data) {
 			return (
 				<article mix={css(messageCss)}>
@@ -297,11 +232,10 @@ export function PackageFilesRoute(handle: Handle) {
 		// under the new URL would render the wrong tree with the wrong links.
 		const currentPathname = new URL(currentHref, 'http://localhost').pathname
 		if (
-			data &&
+			snapshot.stale &&
 			currentPathname !== data.filesBasePath &&
 			!currentPathname.startsWith(`${data.filesBasePath}/`)
 		) {
-			data = null
 			return (
 				<article mix={css(messageCss)}>
 					<p>Loading files…</p>
@@ -314,10 +248,7 @@ export function PackageFilesRoute(handle: Handle) {
 		// between renders blinked the whole tree out and back, and made the
 		// page transition run twice per click.
 		return (
-			<PackageFilesExplorer
-				data={data}
-				busy={status === 'loading' || loadedHref !== currentHref}
-			/>
+			<PackageFilesExplorer data={data} busy={snapshot.kind === 'pending'} />
 		)
 	}
 }

--- a/packages/worker/client/routes/package-settings.tsx
+++ b/packages/worker/client/routes/package-settings.tsx
@@ -3,13 +3,14 @@ import { type Handle, css } from 'remix/ui'
 import { createMatcher } from 'remix/route-pattern/match'
 import { readCurrentRouterHref } from '#client/client-router.tsx'
 import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
-import { consumeStaleNavigationData } from '#client/navigation-data.ts'
+import {
+	createRouteData,
+	renderRoutePendingStatus,
+	routeDataRedirect,
+} from '#client/route-data.tsx'
 import { readRouterPathname } from '#client/router-location.tsx'
 import { readJson } from '#client/routes/account-approval-shared.ts'
-import {
-	type AccountPackageDetail,
-	type AppLoaderData,
-} from '#universal/loader-data.ts'
+import { type AccountPackageDetail } from '#universal/loader-data.ts'
 import { renderPackageRepoChrome } from '#universal/package-repo-nav.tsx'
 import { routes } from '#universal/routes.ts'
 import {
@@ -29,6 +30,19 @@ import {
 
 const settingsMatcher = createMatcher(routes.communityPackageSettings.pattern)
 
+/** Shell payload for the settings page, normalized from either source. */
+type PackageSettingsShell =
+	| { kind: 'unauthorized' }
+	| {
+			kind: 'owner'
+			ownerPackage: AccountPackageDetail
+			username: string
+			kodyId: string
+			isPrivate: boolean
+			/** Only the detail API reports this; SSR shell data leaves it as is. */
+			ownerProfilePublic?: boolean
+	  }
+
 export function PackageSettingsRoute(handle: Handle) {
 	let ownerPackage: AccountPackageDetail | null = null
 	let username = ''
@@ -36,12 +50,77 @@ export function PackageSettingsRoute(handle: Handle) {
 	let isPrivate = false
 	let ownerProfilePublic = true
 	let ownerDetailsMessage: string | null = null
-	let shellStatus: 'loading' | 'ready' | 'error' | 'missing' = 'loading'
-	let shellLoadRequestId = 0
-	let shellLoadedForPathname: string | null = null
-	let shellRequestedForPathname: string | null = null
-	let shellUnauthorized = false
+	/** Payload last applied to the closure state above. */
+	let appliedShell: PackageSettingsShell | null = null
 	const lockInFlight = new Map<string, string | null>()
+	const settingsData = createRouteData<
+		'communityDetailShell',
+		PackageSettingsShell
+	>({
+		consume(routeHandle, href) {
+			const routeData = tryConsumeRouteLoaderData(
+				routeHandle,
+				'communityDetailShell',
+				href,
+			)
+			if (!routeData) return null
+			if (!routeData.ok) return { kind: 'unauthorized' }
+			const pathname = new URL(href, 'http://localhost').pathname
+			if (routeData.listingId) {
+				rememberListingId(pathname, routeData.listingId)
+			}
+			if (!routeData.ownerPackage || !routeData.viewerIsOwner) return null
+			return {
+				kind: 'owner',
+				ownerPackage: routeData.ownerPackage,
+				username: routeData.username,
+				kodyId: routeData.kodyId || routeData.ownerPackage.kodyId,
+				isPrivate: routeData.isPrivate,
+			}
+		},
+		async load(href, signal) {
+			const ref = getPackageSettingsPageRef(
+				new URL(href, 'http://localhost').pathname,
+			)
+			if (!ref) return null
+			const response = await fetch(ref.detailApiHref, {
+				headers: { Accept: 'application/json' },
+				signal,
+			})
+			const payload = await readJson<
+				CommunityDetailApiPayload | CommunityPackageMovedPayload
+			>(response)
+			if (response.status === 401) return { kind: 'unauthorized' }
+			if (response.status === 404) {
+				const movedTo = payload && !payload.ok ? payload.redirectTo : null
+				if (movedTo) {
+					return routeDataRedirect(
+						packageMoveDestination(ref.pathname, movedTo),
+					)
+				}
+				return null
+			}
+			if (
+				!response.ok ||
+				!payload?.ok ||
+				!payload.ownerPackage ||
+				!payload.viewerIsOwner
+			) {
+				return null
+			}
+			if (payload.listing) {
+				rememberListingId(ref.pathname, payload.listing.id)
+			}
+			return {
+				kind: 'owner',
+				ownerPackage: payload.ownerPackage,
+				username: payload.username,
+				kodyId: payload.kodyId || payload.ownerPackage.kodyId,
+				isPrivate: payload.isPrivate ?? payload.ownerPackage.isPrivate,
+				ownerProfilePublic: payload.ownerProfilePublic,
+			}
+		},
+	})
 
 	function applyOwnerPackageLock(packageId: string, lockedAt: string | null) {
 		if (ownerPackage?.id === packageId) {
@@ -84,127 +163,13 @@ export function PackageSettingsRoute(handle: Handle) {
 		handle.update()
 	}
 
-	async function loadSettingsShell() {
-		const ref = getPackageSettingsPageRef(readRouterPathname(handle))
-		if (!ref) return
-
-		const requestId = ++shellLoadRequestId
-		if (shellLoadedForPathname !== ref.pathname) {
-			shellStatus = 'loading'
-			handle.update()
-		}
-
-		try {
-			const response = await fetch(ref.detailApiHref, {
-				headers: { Accept: 'application/json' },
-			})
-			if (requestId !== shellLoadRequestId) return
-			const payload = await readJson<
-				CommunityDetailApiPayload | CommunityPackageMovedPayload
-			>(response)
-			if (response.status === 401) {
-				shellLoadedForPathname = ref.pathname
-				shellUnauthorized = true
-				shellStatus = 'ready'
-				handle.update()
-				return
-			}
-			if (response.status === 404) {
-				const movedTo = payload && !payload.ok ? payload.redirectTo : null
-				if (movedTo) {
-					window.location.assign(packageMoveDestination(ref.pathname, movedTo))
-					return
-				}
-				shellLoadedForPathname = ref.pathname
-				shellStatus = 'missing'
-				handle.update()
-				return
-			}
-			if (
-				!response.ok ||
-				!payload?.ok ||
-				!payload.ownerPackage ||
-				!payload.viewerIsOwner
-			) {
-				shellLoadedForPathname = ref.pathname
-				shellStatus = 'missing'
-				handle.update()
-				return
-			}
-			if (payload.listing) {
-				rememberListingId(ref.pathname, payload.listing.id)
-			}
-			ownerPackage = payload.ownerPackage
-			username = payload.username
-			kodyId = payload.kodyId || payload.ownerPackage.kodyId
-			isPrivate = payload.isPrivate ?? payload.ownerPackage.isPrivate
-			ownerProfilePublic = payload.ownerProfilePublic
-			ownerDetailsMessage = null
-			shellUnauthorized = false
-			shellLoadedForPathname = ref.pathname
-			shellStatus = 'ready'
-			handle.update()
-		} catch {
-			if (requestId !== shellLoadRequestId) return
-			shellLoadedForPathname = ref.pathname
-			shellStatus = 'error'
-			handle.update()
-		}
-	}
-
-	function applyRouteShellData(
-		routeData: AppLoaderData['communityDetailShell'],
-		pathname: string,
-	) {
-		if (!routeData) return false
-		if (!routeData.ok) {
-			shellUnauthorized = true
-			shellLoadedForPathname = pathname
-			shellStatus = 'ready'
-			return true
-		}
-		if (!routeData.ownerPackage || !routeData.viewerIsOwner) {
-			shellLoadedForPathname = pathname
-			shellStatus = 'missing'
-			return true
-		}
-		ownerPackage = routeData.ownerPackage
-		username = routeData.username
-		kodyId = routeData.kodyId || routeData.ownerPackage.kodyId
-		isPrivate = routeData.isPrivate
-		ownerDetailsMessage = null
-		shellUnauthorized = false
-		shellLoadedForPathname = pathname
-		shellStatus = 'ready'
-		return true
-	}
-
 	return () => {
 		const currentHref = readCurrentRouterHref(handle)
 		const pathname = readRouterPathname(handle)
-		const routeData = tryConsumeRouteLoaderData(
-			handle,
-			'communityDetailShell',
-			currentHref,
-		)
-		if (routeData?.ok && routeData.listingId) {
-			rememberListingId(pathname, routeData.listingId)
-		}
 		const ref = getPackageSettingsPageRef(pathname)
 		const urlParams = settingsMatcher.match(
 			new URL(pathname, 'http://localhost'),
 		)?.params
-
-		if (
-			(routeData && !routeData.ok) ||
-			(shellUnauthorized && shellLoadedForPathname === pathname)
-		) {
-			applyRouteShellData(routeData, pathname)
-			return renderMissingListing(
-				'Unauthorized',
-				'You are not allowed to view this page.',
-			)
-		}
 
 		if (!ref) {
 			return renderMissingListing(
@@ -213,29 +178,36 @@ export function PackageSettingsRoute(handle: Handle) {
 			)
 		}
 
-		const appliedShellData = applyRouteShellData(routeData, pathname)
-		const needsStaleRefresh =
-			consumeStaleNavigationData(currentHref) && !appliedShellData
-		if (
-			(needsStaleRefresh ||
-				(shellLoadedForPathname !== pathname &&
-					shellRequestedForPathname !== pathname)) &&
-			typeof document !== 'undefined'
-		) {
-			if (shellLoadedForPathname !== pathname) {
-				shellStatus = 'loading'
+		const snapshot = settingsData.read(handle, currentHref)
+		if (snapshot.data && snapshot.data !== appliedShell) {
+			appliedShell = snapshot.data
+			if (snapshot.data.kind === 'owner') {
+				ownerPackage = snapshot.data.ownerPackage
+				username = snapshot.data.username
+				kodyId = snapshot.data.kodyId
+				isPrivate = snapshot.data.isPrivate
+				if (snapshot.data.ownerProfilePublic !== undefined) {
+					ownerProfilePublic = snapshot.data.ownerProfilePublic
+				}
+				ownerDetailsMessage = null
 			}
-			shellRequestedForPathname = pathname
-			handle.queueTask(loadSettingsShell)
 		}
 
-		const shellMatches = shellLoadedForPathname === pathname
-		const showReady = shellStatus === 'ready' && shellMatches
-		const showError = shellStatus === 'error' && shellMatches
-		const showMissing = shellStatus === 'missing' && shellMatches
-		if (showMissing) {
+		if (snapshot.data?.kind === 'unauthorized' && !snapshot.stale) {
+			return renderMissingListing(
+				'Unauthorized',
+				'You are not allowed to view this page.',
+			)
+		}
+		if (snapshot.kind === 'not-found') {
 			return renderMissingListing('Not Found', 'We could not find that page.')
 		}
+
+		const pending = snapshot.kind === 'pending'
+		// The previous package's settings (`snapshot.stale`) stay on screen
+		// while a fallback fetch runs; the loading copy is for the cold path.
+		const showReady = snapshot.data?.kind === 'owner'
+		const showError = snapshot.kind === 'error'
 		const statusMessage = showError
 			? 'Unable to load package settings.'
 			: showReady
@@ -246,7 +218,12 @@ export function PackageSettingsRoute(handle: Handle) {
 		const chromeKodyId = kodyId || urlParams?.kodyId || ''
 
 		return (
-			<article mix={css(detailArticleCss)} data-testid="package-settings">
+			<article
+				mix={css(detailArticleCss)}
+				data-testid="package-settings"
+				aria-busy={pending && showReady ? 'true' : undefined}
+			>
+				{pending && showReady ? renderRoutePendingStatus() : null}
 				{chromeUsername && chromeKodyId
 					? renderPackageRepoChrome({
 							username: chromeUsername,

--- a/packages/worker/client/routes/pending-verification-path.ts
+++ b/packages/worker/client/routes/pending-verification-path.ts
@@ -5,7 +5,7 @@ import {
 
 export { resolvePostVerificationRedirect }
 
-export const pendingVerificationPath = '/pending-verification'
+const pendingVerificationPath = '/pending-verification'
 
 /**
  * Pending-verification URL, optionally carrying a safe post-verify redirect

--- a/packages/worker/client/routes/pending-verification.tsx
+++ b/packages/worker/client/routes/pending-verification.tsx
@@ -1,9 +1,7 @@
 import { type Handle, css } from 'remix/ui'
 import { normalizeRedirectTo } from '#universal/safe-redirect.ts'
 import { readCurrentRouterHref } from '#client/client-router.tsx'
-import { createRouteLoadLatch } from '#client/route-load-latch.ts'
-import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
-import { consumeStaleNavigationData } from '#client/navigation-data.ts'
+import { createRouteData, routeDataRedirect } from '#client/route-data.tsx'
 import { type AccountStatus } from '#client/routes/account-approval-shared.ts'
 import {
 	AccountManagementHeader,
@@ -16,10 +14,7 @@ import {
 	requestResendVerification,
 } from '#client/routes/email-verification-prompt.tsx'
 import { resolveContinueVerificationFeedback } from '#client/routes/pending-verification-continue.ts'
-import {
-	pendingVerificationPath,
-	resolvePostVerificationRedirect,
-} from '#client/routes/pending-verification-path.ts'
+import { resolvePostVerificationRedirect } from '#client/routes/pending-verification-path.ts'
 import {
 	routeLoaderRedirect,
 	type RouteLoaderResult,
@@ -34,10 +29,6 @@ import {
 } from '#universal/email-verification-delivery.ts'
 import { type PendingVerificationLoaderData } from '#universal/loader-data.ts'
 import { buildAuthLink } from '#client/auth-links.ts'
-
-function isPendingVerificationPath(href: string) {
-	return new URL(href, 'http://localhost').pathname === pendingVerificationPath
-}
 
 function readPendingRedirectTo(handle: Handle) {
 	return normalizeRedirectTo(
@@ -78,55 +69,40 @@ export async function pendingVerificationRouteLoader(
 }
 
 export function PendingVerificationRoute(handle: Handle) {
-	let status: AccountStatus = 'loading'
 	let email = ''
 	let emailVerificationDelivery: EmailVerificationDelivery | null = null
 	let message: string | null = null
 	let resendStatus: 'idle' | 'sending' = 'idle'
 	let resendMessage: string | null = null
 	let resendTone: 'error' | 'info' = 'info'
-	const loadLatch = createRouteLoadLatch()
 	let deliveryPollScheduled = false
+	/** Payload last applied to the closure state above. */
+	let appliedPayload: PendingVerificationLoaderData | null = null
+	let appliedError: Error | null = null
+	const pendingData = createRouteData({
+		key: 'pendingVerification',
+		async load(_href, signal) {
+			const session = await fetchSessionInfo(signal)
+			if (!session) {
+				return routeDataRedirect(buildLoginRedirectForPending(handle))
+			}
+			if (session.emailVerified) {
+				return routeDataRedirect(
+					resolvePostVerificationRedirect(readPendingRedirectTo(handle)),
+				)
+			}
+			return {
+				ok: true as const,
+				email: session.email,
+				emailVerificationDelivery: session.emailVerificationDelivery,
+			}
+		},
+	})
 
 	function applyPayload(payload: PendingVerificationLoaderData) {
 		email = payload.email
 		emailVerificationDelivery = payload.emailVerificationDelivery ?? null
-		status = 'ready'
 		message = null
-	}
-
-	async function loadPending(signal: AbortSignal) {
-		const href = readCurrentRouterHref(handle)
-		try {
-			const session = await fetchSessionInfo(signal)
-			if (signal.aborted) return
-			if (!session) {
-				window.location.assign(buildLoginRedirectForPending(handle))
-				return
-			}
-			if (session.emailVerified) {
-				window.location.assign(
-					resolvePostVerificationRedirect(readPendingRedirectTo(handle)),
-				)
-				return
-			}
-			applyPayload({
-				ok: true,
-				email: session.email,
-				emailVerificationDelivery: session.emailVerificationDelivery,
-			})
-			loadLatch.markLoaded(href)
-			handle.update()
-		} catch (error) {
-			if (signal.aborted) return
-			status = 'error'
-			message =
-				error instanceof Error
-					? error.message
-					: 'Unable to load verification status.'
-			loadLatch.markFailed(href)
-			handle.update()
-		}
 	}
 
 	async function pollVerificationDelivery() {
@@ -198,32 +174,24 @@ export function PendingVerificationRoute(handle: Handle) {
 		handle.update()
 	}
 
-	function applyRouteLoaderData(href: string) {
-		if (!isPendingVerificationPath(href)) return false
-		const routeData = tryConsumeRouteLoaderData(
-			handle,
-			'pendingVerification',
-			href,
-		)
-		if (!routeData) return false
-		applyPayload(routeData)
-		loadLatch.markLoaded(href)
-		return true
-	}
-
 	return () => {
 		const currentHref = readCurrentRouterHref(handle)
-		const appliedRouteData = applyRouteLoaderData(currentHref)
-		const needsStaleRefresh =
-			consumeStaleNavigationData(currentHref) && !appliedRouteData
-		const needsLoad = loadLatch.needsLoad({
-			currentHref,
-			appliedRouteData,
-			needsStaleRefresh,
-		})
-		if (needsLoad && typeof document !== 'undefined') {
-			handle.queueTask(loadPending)
+		const snapshot = pendingData.read(handle, currentHref)
+		if (snapshot.data && snapshot.data !== appliedPayload) {
+			appliedPayload = snapshot.data
+			applyPayload(snapshot.data)
 		}
+		if (snapshot.error && snapshot.error !== appliedError) {
+			appliedError = snapshot.error
+			message = snapshot.error.message
+		}
+		const pending = snapshot.kind === 'pending'
+		const status: AccountStatus =
+			snapshot.kind === 'error'
+				? 'error'
+				: pending && appliedPayload === null
+					? 'loading'
+					: 'ready'
 		if (
 			status === 'ready' &&
 			!deliveryPollScheduled &&
@@ -238,7 +206,10 @@ export function PendingVerificationRoute(handle: Handle) {
 		}
 
 		return (
-			<AccountManagementShell maxWidth={layoutMaxWidths.content}>
+			<AccountManagementShell
+				maxWidth={layoutMaxWidths.content}
+				busy={pending && appliedPayload !== null}
+			>
 				<AccountManagementHeader
 					title="Check your email"
 					description="Your Kody account is ready. Verify your email before connecting an AI agent or using MCP."

--- a/tools/oxlint/import-boundaries.node.test.ts
+++ b/tools/oxlint/import-boundaries.node.test.ts
@@ -109,6 +109,22 @@ test('client and universal modules cannot import server layers', () => {
 	).toBe(null)
 })
 
+test('client routes read loader payloads through createRouteData, not the raw load latch', () => {
+	const routeFile = 'packages/worker/client/routes/account-jobs.tsx'
+	const helperFile = 'packages/worker/client/route-data.tsx'
+
+	expect(
+		findImportBoundaryViolation(routeFile, '#client/route-load-latch.ts'),
+	).toMatch(/read loader payloads through createRouteData/)
+	expect(findImportBoundaryViolation(routeFile, '#client/route-data.tsx')).toBe(
+		null,
+	)
+	// The helper itself owns the latch.
+	expect(
+		findImportBoundaryViolation(helperFile, '#client/route-load-latch.ts'),
+	).toBe(null)
+})
+
 test('import boundaries have no legacy exceptions', () => {
 	const entries = importBoundaries.flatMap(
 		(boundary: {

--- a/tools/oxlint/local-plugin.js
+++ b/tools/oxlint/local-plugin.js
@@ -207,6 +207,23 @@ export const importBoundaries = [
 		skipTestFiles: true,
 	},
 	{
+		/**
+		 * The href latch is `createRouteData`'s internal bookkeeping. Routes
+		 * that used it directly also had to hand-roll consume-once, the
+		 * fallback fetch, and the loading UI — and blanked the page while a
+		 * refetch ran (docs/contributing/no-flash-navigation.md).
+		 */
+		id: 'routes-to-load-latch',
+		filePattern: /(^|\/)packages\/worker\/client\/routes\/.+$/,
+		forbiddenPrefixes: ['#client/route-load-latch.ts'],
+		message:
+			'Client routes read loader payloads through createRouteData (#client/route-data.tsx), which owns the load latch, the fallback fetch, and the last-good payload the page keeps showing. Do not import #client/route-load-latch.ts directly (see docs/contributing/no-flash-navigation.md).',
+		allowedSpecifiers: [],
+		neverAllowedPrefix: null,
+		neverAllowedMessage: null,
+		skipTestFiles: true,
+	},
+	{
 		id: 'universal-to-client',
 		filePattern: /(^|\/)packages\/worker\/universal\/.+$/,
 		forbiddenPrefixes: ['#client/'],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Route changes never clear the current page or flash a loading state — docs guide → guide first, then the same contract for every client route (account, admin, blog, home, onboarding, package pages) — and make that the default path for future routes.

## Why

Switching between docs guides briefly showed `Loading…` in place of the article. The pages *are* server-rendered and the client router *does* load the destination's payload before committing the URL; the flash came from a bug in the shared href latch that every route used.

**Root cause.** On a same-component navigation (`/docs/memory` → `/docs/secrets`, blog post → post, account list → detail) the route applied the router's preloaded payload and called `loadLatch.markLoaded(currentHref)` before `needsLoad()` — while the latch's `lastSeenHref` still named the previous location, so `markLoaded()` treated the call as a *late completion* and ignored it. The corrective render that `tryConsumeRouteLoaderData` schedules then saw `currentHref !== lastLoadedHref`, queued a **redundant fetch** for data the route already had, and the route set `status = 'loading'`, blanked the content, and showed `Loading…` for a full network round trip (three renders per navigation, two JSON requests). Runtime trace before the fix:

```
render  { href: /docs/secrets, routeData: secrets, status: ready }   <- payload consumed
render  { href: /docs/secrets, needsLoad: true, showLoading: true }  <- corrective render refetches
render  { href: /docs/secrets, status: ready }                       <- 7ms locally, a full RTT in prod
```

Not related to #2194 (view transitions); that shell work is untouched and still holds.

## Summary

- `route-load-latch.ts`: `needsLoad({ appliedRouteData: true })` records the location as loaded itself. This alone removes the redundant refetch and the flash on the happy path.
- `route-data.tsx` (new): `createRouteData({ key | consume, load, locationKey? })` — consume-once of the loader payload (single key or a multi-key `consume`), the fallback-fetch latch, abort-safe `queueTask` (re-arms after remix/ui aborts the task on an unrelated re-render), late-completion drops, `routeDataRedirect('/login')` for 401s, `reload()` for post-mutation refreshes, and the **last good payload** a route keeps rendering while a fallback fetch runs. Routes switch on one snapshot: `ready` / `pending` (with data, possibly `stale`) / `not-found` / `error` (with `error`).
- **All 40 client routes that load data now read through it** — docs, blog, home, onboarding, discord, package files, package settings, pending verification, and every account and admin page (the 20 that used `createRouteLoadLatch` and the 14 that hand-rolled `lastLoadedHref` / `loadRequestId` latches). Standalone loading copy only remains on the cold path where nothing has ever rendered; `AccountManagementShell busy=` sets `aria-busy` + a visually hidden `role="status"` for every account/admin page while its last good content stays on screen; post-mutation reloads go through `reload()`. Dead per-route helpers (`isXxxPath` guards, consume wrappers, latch-key bookkeeping) are removed.
- Lint: `kody-custom/enforce-import-boundaries` now rejects `#client/route-load-latch.ts` from `packages/worker/client/routes/**` (only `route-data.tsx` owns the latch), so a new route cannot hand-roll it again.
- Docs: `docs/contributing/no-flash-navigation.md` (how load-before-commit works, how to write a route on it incl. state-owning account/admin routes, speed → cache → stream for slow sections, which checks cover it), linked from the contributing index, `remix.md`'s page checklist, `import-boundaries.md`, the repo-local Remix skill, and one AGENTS.md pointer.
- Tests: latch regression mirroring the exact render sequence; `route-data.node.test.ts` for the continuity contract; import-boundary unit test; `e2e/main-transitions.ts` shared `<main>` observer used by `e2e/docs.spec.ts` (guide → guide) and the new `e2e/account-navigation.spec.ts` (account sections as a seeded user, admin sections as an admin) — each fails on any intermediate DOM state without an `<h1>`, any loading copy where content was, or a repeated payload request.

## Testing

- Reproduced with a Playwright `MutationObserver` probe before the fix: every guide→guide click passed through `{"h1":"","status":"Loading…"}` with 2 JSON requests. After: single commit, 1 JSON request. Same result for blog post → post and for every account and admin section hop as a logged-in admin (`/account/jobs → memories → secrets → workflows → overview → jobs`, `/admin/roles → invites → feature-flags → users → banners → insights → roles`).
- Loader-failure path (first destination JSON forced to 500): same-component hops keep the previous content under `aria-busy` until the fallback lands; cross-component hops keep the shell header/nav and show the destination's cold copy only in the never-rendered content slot.
- Regression proof: `e2e/docs.spec.ts` fails on the old client code (`[{"h1":"Shared memory"},{"h1":"","status":"Loading…"},{"h1":"Secrets"}]`); `e2e/account-navigation.spec.ts` fails with the latch fix reverted (`{"h1":"Memories","status":"Loading…"}`).
- Gates: `npm run typecheck`, `npm run lint` (warning count unchanged from `main`; none in touched files), `npm run format:check`, `npm run knip`, `docs:check-temporal`, `mermaid:check`, `slop-ratchet:check`, `primitives:check` all pass. `CI=1 npm run test:node` (3023 tests), `CI=1 npm run test:workers` (341), `CI=1 npm run test:e2e:run` (15) all pass.
- Preview (`kody-pr-2201`, first revision): scripted smoke + `/docs/*.json` + the DOM-transition probe against the real origin: single-commit swaps, one payload request each.

**How to verify manually:** open `/docs/memory`, click `Secrets` in the sidebar (repeat a few guides); sign in and click through the Account sections nav and the Admin sections nav. Pages should swap with no blank frame and no `Loading…`; the network panel shows exactly one payload request per click.

## Residual risks / product calls

- **Fallback path shows the previous page under the new URL (same component).** When the router's loader fails (network blip, 5xx) a same-component route keeps the *previous* content visible with `aria-busy` and a hidden `Loading…` live region while it refetches. The URL and nav already point at the destination. I judged a briefly stale-but-busy page better than an empty column; `renderRoutePendingStatus` is the one place to change if you want a visible non-blanking indicator.
- **Cross-component fallback still shows the destination's cold copy** (e.g. `Loading memories…` under the Jobs → Memories hop when the loader failed) — there is nothing from that page to keep. The shell header/nav stay put, so this is a content-slot message, not a page flash.
- Small behavioural nuances from the migration, each called out in its file: `account.tsx` consume is now all-or-nothing across its three required keys (SSR always embeds all); `account-values`/`account-jobs` detail placeholders stay for the whole in-flight fallback fetch rather than one render; `account-secrets` keeps its 3s auto-retry via `reload()`; `home.tsx` still applies optional keys (ticker window, hosts, signup mode) when the onboarding key is absent.
- Not migrated, on purpose: `login`, `oauth-authorize`, `connect-oauth`, `connect-secrets`, `community-detail`, `profile`, `faq`, `pricing`, `account-billing-success`. They either only read optional embedded data with no fallback fetch, or are single-visit flow/frame pages whose auxiliary status line sits beside frame-owned content — none blank content on navigation.
- `/docs/how-kody-works.json` is ~172KB (walkthrough highlights, 30× a normal guide, ~140ms warm on the preview). Not a flash, but the one docs payload worth trimming or streaming later.
- No change to view transitions, `prefers-reduced-motion`, or the #2194 shell list.

## System changes

See recap below.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends app-ui</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `b6fc3062` · **Head:** `04a7b4fc`

**Classification:** extends — the client route data contract in `app-ui` changes: the load latch records applied route data, `createRouteData` (new helper) owns consume-once, the fallback fetch, and the last-good payload, and every client route (docs, blog, home, onboarding, discord, package files, package settings, pending verification, all account and admin pages — 40 routes) reads through it. A lint boundary keeps routes off the raw latch. No primitive added or removed; `primitives.yaml` untouched.

### Primitives touched

| Primitive | Group    | Impact                                                                                                                                                                                                                 |
| --------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `app-ui`  | surfaces | extends — `route-load-latch` counts applied route data as loaded; `route-data.tsx` added; 40 client routes migrated; `AccountManagementShell busy=`; `kody-custom/enforce-import-boundaries` forbids `#client/route-load-latch.ts` from routes |

### Change flow

A section switch (docs guide → guide, account Jobs → Memories, admin Roles → Invites) swaps pages in one DOM commit; before, the corrective render refetched the payload and flashed `Loading…`.

```mermaid
sequenceDiagram
	actor User
	participant appUi as app-ui (client-router)
	participant slot as app-ui (navigation-data slot)
	participant route as app-ui (route component)
	participant latch as app-ui (route-load-latch)
	User->>appUi: click section link (sidebar, account nav, admin nav)
	appUi->>slot: setPreloadedNavigationData(payload) after loader resolves
	appUi->>route: pushState and one re-render with new href
	route->>slot: createRouteData.read consumes payload (key or multi-key consume)
	route->>latch: needsLoad({ appliedRouteData: true }) records location as loaded
	Note over route: apply payload into closure state, previous page replaced in one commit
	route->>latch: corrective render needsLoad() is false (was true, queued a refetch and showed loading copy)
	alt router loader failed, commit without payload
		route->>latch: needsLoad() true, queue fallback fetch (401 -> routeDataRedirect)
		Note over route: same component keeps last good content, AccountManagementShell busy sets aria-busy and hidden role=status
		route-->>User: swap when the fetch lands
	end
```

### Before / after

| Path                                              | Before                                                                     | After                                                             |
| ------------------------------------------------- | -------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| Same-component hop, preloaded (guide → guide, list → detail) | commit → `Loading…` (content blank) → refetch → content; 2 JSON requests | commit → content; 1 JSON request                                  |
| Same-component hop, router loader failed          | content blank + `Loading…` until fallback fetch                            | previous content stays under `aria-busy` until fallback fetch     |
| Cross-component hop, router loader failed         | header + `Loading…`                                                        | header + `Loading…` (unchanged: nothing from that page to keep)   |
| Cold SPA mount without SSR payload                | `Loading…`                                                                 | `Loading…` (unchanged)                                            |
| New route importing `#client/route-load-latch.ts` | allowed                                                                    | lint error pointing at `createRouteData`                          |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f47a6997-58e1-4f82-b546-413cc971d87f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f47a6997-58e1-4f82-b546-413cc971d87f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved in-app navigation so the current page remains visible until the destination is ready, reducing flashes and abrupt loading screens.
  * Preserved existing content during background refreshes while indicating pending updates.
  * Improved handling for loading, not-found, error, aborted, and slow-loading states.
  * Added accessible navigation status announcements and busy-state indicators.
  * Improved sign-in redirects when account or admin data requires authentication.

* **Documentation**
  * Added guidance for building and testing no-flash client navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->