### PR TITLE
Drop the package Code/Settings tab hairline

### DIFF
--- a/packages/worker/client/package-files-explorer.tsx
+++ b/packages/worker/client/package-files-explorer.tsx
@@ -613,7 +613,6 @@ const headCss = {
 	viewTransitionName: 'files-head',
 	// The back link reads as part of this head, so it sits tight to the title.
 	marginTop: spacing.sm,
-	marginBottom: spacing.lg,
 	display: 'grid',
 	gap: spacing.xs,
 }
@@ -628,6 +627,7 @@ const titleCss = {
 // Two columns need room for both: below the tablet breakpoint the blob is too
 // narrow to read code in, so the tree moves above it and runs full width.
 const layoutCss = {
+	marginTop: spacing.lg,
 	display: 'grid',
 	gridTemplateColumns: '18.75rem minmax(0, 1fr)',
 	gap: spacing.lg,

--- a/packages/worker/universal/package-repo-nav.tsx
+++ b/packages/worker/universal/package-repo-nav.tsx
@@ -214,14 +214,12 @@ const navCss = {
 	alignItems: 'center',
 	gap: spacing.sm,
 	marginTop: '1.1rem',
-	borderBottom: `1px solid ${colors.border}`,
 }
 
 const tabCss = {
 	display: 'inline-flex',
 	alignItems: 'center',
 	padding: '0.55rem 0.15rem',
-	marginBottom: '-1px',
 	borderBottom: '2px solid transparent',
 	color: colors.textMuted,
 	fontSize: '0.95rem',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop the Code/Settings tab hairline from sitting flush on the file tree and preview cards.

## Why

That full-width rule bumped into the rounded cards with no gap, so the Code tab looked cramped. Removing the line is cleaner than padding a divider we do not need. The active tab already has a green underline.

## Summary

- Drop the hairline and the `-1px` tab overlap from the shared package chrome (`Code` / `Settings` on listing, files, and settings).
- Give the files grid the same top gap the fallback title already used, so the cards sit below the tabs instead of against them.

## Testing

- `npm run test:push` (node 3015, workers 341)

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `f6d68851` · **Head:** `57ceb2c5`

**Classification:** composes — no primitives added or changed; this PR restyles existing package chrome.

### Primitives touched

| Primitive | Group    | Impact   |
| --------- | -------- | -------- |
| `app-ui`  | surfaces | composes |

### Change flow

Package Code, Settings, and listing pages share one tab row. The row no longer draws a full-width rule, and the files explorer adds space above the tree and blob.

```mermaid
sequenceDiagram
	actor User
	participant appUi as app-ui
	User->>appUi: GET /@user/kodyId/tree/ref
	appUi-->>User: chrome tabs without hairline, then spaced file cards
	User->>appUi: GET /@user/kodyId/settings
	appUi-->>User: same chrome, no hairline
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a5f488d8-35eb-4633-b2c9-d1b8ff7e25cd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a5f488d8-35eb-4633-b2c9-d1b8ff7e25cd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved spacing around the file explorer heading and its main two-column layout.
  - Refined repository navigation tabs with clearer individual tab boundaries and a primary-color indicator for the active tab.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->