### PR TITLE
Contain docs walkthroughs and prefetch every sidebar guide

### DIFF
--- a/.agents/skills/control-kody/references/features/marketing.md
+++ b/.agents/skills/control-kody/references/features/marketing.md
@@ -12,7 +12,9 @@ doc to `/docs` / `/docs/connect`) is an instant shell swap — no page
 view-transition — so the sidebar does not re-animate. How Kody works (and other
 interactive walkthroughs) stay in the article column; they do not break out over
 the nav. The docs shell opts out of overflow anchoring so replacing the article
-does not bump the rail.
+does not bump the rail. After hydrate it independently prefetches every sidebar
+href (one loader request per slug, including `/docs/connect`) so a click adopts
+a warm payload instead of waiting on a cold fetch.
 
 ## Drive it
 

--- a/.agents/skills/control-kody/references/features/marketing.md
+++ b/.agents/skills/control-kody/references/features/marketing.md
@@ -9,7 +9,10 @@ Discord invite.
 `/docs/:slug`, `/docs/connect`, `/llms.txt`, `/blog`, `/blog/:slug`, `/discord`.
 Legacy `/guides*` URLs 308 to `/docs*`. Intra-docs navigation (doc to doc, or a
 doc to `/docs` / `/docs/connect`) is an instant shell swap — no page
-view-transition — so the sidebar does not re-animate.
+view-transition — so the sidebar does not re-animate. How Kody works (and other
+interactive walkthroughs) stay in the article column; they do not break out over
+the nav. The docs shell opts out of overflow anchoring so replacing the article
+does not bump the rail.
 
 ## Drive it
 

--- a/docs/contributing/architecture/request-lifecycle.md
+++ b/docs/contributing/architecture/request-lifecycle.md
@@ -334,6 +334,9 @@ lands, the navigation adopts the in-flight or freshly settled prefetch instead
 of starting the loader from scratch; results expire after a short TTL and
 failures fall back to a normal loader run. Form POSTs abort any pending prefetch
 so pre-mutation data is never shown. Opt a link out with `data-prefetch="none"`.
+Rendered lists can also warm many destinations at once (`prefetchRouteHrefs`).
+Onboarding chips share one `/onboarding.json` payload; docs sidebar slugs do
+not, so they pass `{ independent: true }` and run one loader per href.
 
 A thin top-of-viewport **navigation progress bar** listens for `navigationstart`
 / `navigationend` on `routerEvents` and appears only when a navigation is still

--- a/docs/contributing/code-style.md
+++ b/docs/contributing/code-style.md
@@ -71,7 +71,10 @@ file style first, then run the formatter.
 - Articles and guides sit on `articleMeasure` (43rem). To let a block use more
   horizontal room when the viewport has it — code samples, transcripts — spread
   `getArticleBreakoutCss()` from the same primitives file into that child's css
-  object. It stays a no-op on a phone and grows up to the header measure.
+  object. It stays a no-op on a phone and grows up to the header measure. Do
+  **not** use it under the `/docs` sidebar shell: the breakout is
+  viewport-centered and paints over the nav. Docs walkthroughs stay in the
+  article column.
 
 ## Destructive actions
 

--- a/docs/contributing/no-flash-navigation.md
+++ b/docs/contributing/no-flash-navigation.md
@@ -181,6 +181,10 @@ where content goes.
 - **Cache**: intent prefetch already starts the loader on hover/focus.
   `prefetchRouteHrefs` warms a list of destinations on render (the equivalent of
   `prefetch="render"`) for links the visitor is likely to click next.
+  Destinations that share a **matcher** and not a payload (every `/docs/:slug`)
+  must pass `{ independent: true }` — a shared warmup would attach one article
+  JSON to every slug. The docs shell does that for every sidebar href after
+  hydrate (`DocsNavPrefetch`).
 - **Stream / defer**: when one region is genuinely slow and the rest is not,
   split it into its own loader key or a Remix `<Frame>` (see
   [frames](./frames.md)) with a `fallback` that reserves the region's height, so

--- a/e2e/docs.spec.ts
+++ b/e2e/docs.spec.ts
@@ -9,18 +9,23 @@ test('docs guide switches keep the current article on screen until the next one 
 	page,
 }) => {
 	await page.context().clearCookies()
-	await page.goto('/docs/memory')
-	await waitForClientHydration(page)
-	await expect(
-		page.getByRole('heading', { level: 1, name: 'Shared memory' }),
-	).toBeVisible()
-
 	const docRequests: Array<string> = []
 	page.on('request', (request) => {
 		if (request.url().includes('/docs/') && request.url().endsWith('.json')) {
 			docRequests.push(new URL(request.url()).pathname)
 		}
 	})
+
+	await page.goto('/docs/memory')
+	await waitForClientHydration(page)
+	await expect(
+		page.getByRole('heading', { level: 1, name: 'Shared memory' }),
+	).toBeVisible()
+	await expect
+		.poll(
+			() => docRequests.filter((path) => path === '/docs/secrets.json').length,
+		)
+		.toBe(1)
 
 	await observeMainTransitions(page)
 	const sidebar = page.getByRole('navigation', { name: 'Docs' }).first()
@@ -34,9 +39,11 @@ test('docs guide switches keep the current article on screen until the next one 
 		fromHeading: 'Shared memory',
 		toHeading: 'Secrets',
 	})
-	// The router preloads the destination once; the route must not refetch
-	// the payload it was just handed (that refetch was the loading flash).
-	expect(docRequests).toEqual(['/docs/secrets.json'])
+	// Render-prefetch already warmed every sidebar href. Click must adopt
+	// that snapshot — a second /docs/secrets.json is the loading-flash refetch.
+	expect(docRequests.filter((path) => path === '/docs/secrets.json')).toEqual([
+		'/docs/secrets.json',
+	])
 })
 
 test('docs site: header says Docs, /docs opens the introduction with a sidebar, and legacy /guides redirects', async ({

--- a/packages/worker/client/client-router.node.test.ts
+++ b/packages/worker/client/client-router.node.test.ts
@@ -497,3 +497,58 @@ test('prefetchRouteHrefs warms every registered destination so click skips a col
 		globalThis.window = previousWindow
 	}
 })
+
+test('prefetchRouteHrefs independent warms each docs slug with its own request', async () => {
+	abortIntentPrefetch()
+	const previousWindow = globalThis.window
+	globalThis.window = {
+		location: {
+			href: 'https://kody.local/docs/memory',
+			origin: 'https://kody.local',
+			pathname: '/docs/memory',
+			search: '',
+			hash: '',
+		},
+	} as unknown as Window & typeof globalThis
+
+	const calls: Array<string> = []
+	const loader: RouteLoader = async (url) => {
+		const href = `${url.pathname}${url.search}`
+		calls.push(href)
+		return { docDetail: { ok: true, slug: href } as never }
+	}
+	registerRouteLoaders({
+		[routePattern(routes.docDetail)]: loader,
+		[routePattern(routes.docsConnect)]: loader,
+		[routePattern(routes.docs)]: loader,
+	})
+
+	try {
+		prefetchRouteHrefs(
+			['/docs/oauth', '/docs/memory', '/docs/secrets', '/docs/connect'],
+			{ independent: true },
+		)
+		expect(calls).toEqual(['/docs/oauth', '/docs/secrets', '/docs/connect'])
+		await Promise.resolve()
+
+		const oauth = takePrefetchedRouteResult('/docs/oauth')
+		expect(oauth).not.toBeNull()
+		await expect(oauth).resolves.toEqual({
+			docDetail: { ok: true, slug: '/docs/oauth' },
+		})
+		expect(takePrefetchedRouteResult('/docs/oauth')).toBeNull()
+
+		const secrets = takePrefetchedRouteResult('/docs/secrets')
+		expect(secrets).not.toBeNull()
+		await expect(secrets).resolves.toEqual({
+			docDetail: { ok: true, slug: '/docs/secrets' },
+		})
+		expect(takePrefetchedRouteResult('/docs/connect')).not.toBeNull()
+		expect(takePrefetchedRouteResult('/docs/memory')).toBeNull()
+		expect(calls).toHaveLength(3)
+	} finally {
+		abortIntentPrefetch()
+		registerRouteLoaders({})
+		globalThis.window = previousWindow
+	}
+})

--- a/packages/worker/client/client-router.tsx
+++ b/packages/worker/client/client-router.tsx
@@ -7,6 +7,7 @@ import { applyDocumentHead } from './document-head.ts'
 import { installFileDropNavigationGuard } from './file-drop-navigation.ts'
 import {
 	abortIntentPrefetch,
+	prefetchEachRouteOnRender,
 	prefetchRouteOnIntent,
 	prefetchRoutesOnRender,
 	takePrefetchedRouteResult,
@@ -465,10 +466,14 @@ function runIntentPrefetch(destination: URL) {
 
 /**
  * Render prefetch for a list of same-origin hrefs. Destinations that share a
- * loader share one request. Remix 3 in this repo has no `<Link prefetch>` —
+ * loader share one request unless `independent` is set (docs slugs share a
+ * matcher, not a payload). Remix 3 in this repo has no `<Link prefetch>` —
  * this is the client-router equivalent of `prefetch="render"`.
  */
-export function prefetchRouteHrefs(hrefs: ReadonlyArray<string>): void {
+export function prefetchRouteHrefs(
+	hrefs: ReadonlyArray<string>,
+	options?: { independent?: boolean },
+): void {
 	const groups = new Map<RouteLoader, Array<string>>()
 	const seen = new Set<string>()
 	const currentPath = getCurrentPathWithSearchAndHash()
@@ -498,12 +503,11 @@ export function prefetchRouteHrefs(hrefs: ReadonlyArray<string>): void {
 		groups.set(loader, group)
 	}
 
+	const warm = options?.independent
+		? prefetchEachRouteOnRender
+		: prefetchRoutesOnRender
 	for (const [loader, groupHrefs] of groups) {
-		prefetchRoutesOnRender(
-			groupHrefs,
-			loader,
-			(href) => new URL(href, prefetchBaseHref()),
-		)
+		warm(groupHrefs, loader, (href) => new URL(href, prefetchBaseHref()))
 	}
 }
 

--- a/packages/worker/client/intent-prefetch.node.test.ts
+++ b/packages/worker/client/intent-prefetch.node.test.ts
@@ -3,6 +3,7 @@ import {
 	abortIntentPrefetch,
 	discardRenderPrefetches,
 	maxPrefetchAgeMs,
+	prefetchEachRouteOnRender,
 	prefetchRouteOnIntent,
 	prefetchRoutesOnRender,
 	takePrefetchedRouteResult,
@@ -174,6 +175,42 @@ test('render prefetch keeps every chip warm so click adopts without a cold loade
 	expect(
 		takePrefetchedRouteResult('/onboarding/step-2/not-listed'),
 	).not.toBeNull()
+})
+
+test('independent render prefetch runs one loader per href and keeps siblings after adopt', async () => {
+	abortIntentPrefetch()
+	const calls: Array<{ href: string; signal: AbortSignal }> = []
+	const resolvers = new Map<
+		string,
+		(value: Awaited<ReturnType<RouteLoader>>) => void
+	>()
+	const loader: RouteLoader = (url, signal) => {
+		const href = `${url.pathname}${url.search}`
+		calls.push({ href, signal })
+		return new Promise((resolve) => {
+			resolvers.set(href, resolve)
+		})
+	}
+
+	prefetchEachRouteOnRender(['/docs/oauth', '/docs/memory'], loader)
+	prefetchEachRouteOnRender(['/docs/oauth', '/docs/memory'], loader)
+	expect(calls.map((call) => call.href)).toEqual([
+		'/docs/oauth',
+		'/docs/memory',
+	])
+
+	const navigation = new AbortController()
+	const oauth = takePrefetchedRouteResult('/docs/oauth', navigation.signal)
+	expect(oauth).not.toBeNull()
+	navigation.abort()
+	expect(calls[0]?.signal.aborted).toBe(false)
+
+	const memory = takePrefetchedRouteResult('/docs/memory')
+	expect(memory).not.toBeNull()
+	expect(calls[1]?.signal.aborted).toBe(false)
+	resolvers.get('/docs/memory')?.({ docDetail: { ok: true } as never })
+	await expect(memory).resolves.toEqual({ docDetail: { ok: true } })
+	expect(takePrefetchedRouteResult('/docs/memory')).toBeNull()
 })
 
 test('discardRenderPrefetches drops chip snapshots so a later click cannot rewind', async () => {

--- a/packages/worker/client/intent-prefetch.ts
+++ b/packages/worker/client/intent-prefetch.ts
@@ -157,6 +157,36 @@ export function prefetchRoutesOnRender(
 }
 
 /**
+ * Like `prefetchRoutesOnRender`, but each href runs its own loader. Use this
+ * when destinations share a matcher (every `/docs/:slug`) and not a payload.
+ */
+export function prefetchEachRouteOnRender(
+	hrefs: ReadonlyArray<string>,
+	loader: RouteLoader,
+	urlForHref: (href: string) => URL = (href) => new URL(href, routerHrefOrigin),
+): void {
+	const seen = new Set<string>()
+	for (const href of hrefs) {
+		const normalized = normalizePrefetchHref(href)
+		if (seen.has(normalized)) continue
+		seen.add(normalized)
+		if (isUsablePrefetch(renderSlots.get(normalized))) continue
+		if (isUsablePrefetch(slot) && slot?.href === normalized) continue
+		const controller = new AbortController()
+		const record: PrefetchSlot = {
+			href: normalized,
+			promise: loader(urlForHref(normalized), controller.signal),
+			controller,
+			settledAt: null,
+			failed: false,
+			retainRequest: true,
+		}
+		renderSlots.set(normalized, record)
+		attachSettleHandlers([record])
+	}
+}
+
+/**
  * Consumes the prefetched loader result for `href`. Returns the in-flight or
  * fresh settled promise, or `null` when there is no usable prefetch (wrong
  * href, expired, or failed — failures let the navigation retry the loader).

--- a/packages/worker/client/routes/docs-shell.node.test.ts
+++ b/packages/worker/client/routes/docs-shell.node.test.ts
@@ -12,6 +12,7 @@ test('docs shell marks the sidebar and highlights the open page', async () => {
 		}),
 	)
 
+	expect(html).toContain('data-docs-shell')
 	expect(html).toContain('data-docs-nav')
 	expect(html).toContain('href="/docs/oauth"')
 	expect(html).toContain('aria-current="page"')

--- a/packages/worker/client/routes/docs-shell.tsx
+++ b/packages/worker/client/routes/docs-shell.tsx
@@ -1,11 +1,12 @@
-import { type RemixNode, css, ref } from 'remix/ui'
-import { routerEvents } from '#client/client-router.tsx'
+import { type Handle, type RemixNode, css, ref } from 'remix/ui'
+import { prefetchRouteHrefs, routerEvents } from '#client/client-router.tsx'
 import { type DocSummaryLoaderData } from '#universal/loader-data.ts'
 import {
 	docHref,
 	docsCurrentPageLabel,
 	docsNav,
 	findDocsNavNeighbors,
+	listDocsPrefetchHrefs,
 	resolveDocsNavSection,
 	type DocsNavSection,
 } from '#universal/docs-nav.ts'
@@ -36,6 +37,7 @@ export function renderDocsShell(input: {
 	const currentSection = resolveDocsNavSection(current)
 	return (
 		<div data-docs-shell mix={css(docsLayoutCss)}>
+			<DocsNavPrefetch />
 			<aside data-docs-nav mix={css(docsSidebarCss)}>
 				<nav aria-label="Docs" mix={css(docsSidebarNavCss)}>
 					{renderDocsNavSections(current, currentSection)}
@@ -66,6 +68,25 @@ export function renderDocsShell(input: {
 			<div mix={css(docsMainCss)}>{children}</div>
 		</div>
 	)
+}
+
+/**
+ * Render-warm every sidebar destination. Hover/focus already prefetch one
+ * href (`prefetch="intent"`). Docs slugs share a matcher, not a payload, so
+ * each request stays independent.
+ */
+function DocsNavPrefetch(handle: Handle) {
+	let warmedKey = ''
+	return () => {
+		handle.queueTask(() => {
+			const hrefs = listDocsPrefetchHrefs()
+			const key = hrefs.join('\0')
+			if (key === warmedKey) return
+			warmedKey = key
+			prefetchRouteHrefs(hrefs, { independent: true })
+		})
+		return null
+	}
 }
 
 function renderDocsNavSections(

--- a/packages/worker/client/routes/docs-shell.tsx
+++ b/packages/worker/client/routes/docs-shell.tsx
@@ -35,7 +35,7 @@ export function renderDocsShell(input: {
 	const { current, children } = input
 	const currentSection = resolveDocsNavSection(current)
 	return (
-		<div mix={css(docsLayoutCss)}>
+		<div data-docs-shell mix={css(docsLayoutCss)}>
 			<aside data-docs-nav mix={css(docsSidebarCss)}>
 				<nav aria-label="Docs" mix={css(docsSidebarNavCss)}>
 					{renderDocsNavSections(current, currentSection)}
@@ -175,6 +175,9 @@ const docsLayoutCss = {
 	maxWidth: layoutMaxWidths.extended,
 	marginInline: 'auto',
 	paddingInline: pageGutter,
+	// Clicked sidebar links would otherwise become the scroll anchor; replacing
+	// the article then fights scroll restoration and the rail/content bump.
+	overflowAnchor: 'none' as const,
 	[mq.tablet]: {
 		display: 'block',
 	},
@@ -186,10 +189,14 @@ const docsSidebarCss = {
 	top: '4.5rem',
 	maxHeight: 'calc(100vh - 5.5rem)',
 	overflowY: 'auto' as const,
+	overflowAnchor: 'none' as const,
 	paddingBlock: 'clamp(2.5rem, 6vw, 4rem) 2rem',
 	paddingRight: '0.5rem',
 	borderRight: `1px solid ${colors.border}`,
 	scrollbarWidth: 'thin' as const,
+	// Lift out of `<main>` / `page` if a view transition still starts.
+	// Intra-docs clicks skip VT; leaving docs fades this name (styles.css).
+	viewTransitionName: 'docs-nav',
 	[mq.tablet]: {
 		display: 'none',
 	},
@@ -235,11 +242,14 @@ const docsNavSectionCss = {
 		color: colors.textMuted,
 		textDecoration: 'none',
 		lineHeight: 1.35,
+		// Same weight for every item so the active highlight cannot reflow
+		// the rail when aria-current moves.
+		fontWeight: 650,
+		overflowAnchor: 'none' as const,
 		transition: `color ${transitions.fast}, background ${transitions.fast}`,
 	},
 	'& li a[aria-current="page"]': {
 		color: colors.primaryText,
-		fontWeight: 650,
 		background: colors.primarySoftest,
 	},
 	[hoverMq]: {
@@ -290,6 +300,7 @@ const docsMobileMenuCurrentCss = {
 
 const docsMainCss = {
 	minWidth: 0,
+	overflowAnchor: 'none' as const,
 }
 
 const docsPagerCss = {

--- a/packages/worker/client/routes/interactive-guide-walkthrough.node.test.ts
+++ b/packages/worker/client/routes/interactive-guide-walkthrough.node.test.ts
@@ -2,7 +2,10 @@ import { renderToString } from 'remix/ui/server'
 import { expect, test } from 'vitest'
 import { googleOauthTranscriptActs } from './google-oauth-transcript.ts'
 import { renderGoogleOauthWalkthrough } from './google-oauth-walkthrough.tsx'
-import { renderInteractiveGuideLine } from './interactive-guide-walkthrough.tsx'
+import {
+	interactiveGuideActCss,
+	renderInteractiveGuideLine,
+} from './interactive-guide-walkthrough.tsx'
 
 test('google oauth connect bubbles wrap the prefilled url instead of overflowing', async () => {
 	const connectLine = googleOauthTranscriptActs
@@ -26,4 +29,11 @@ test('google oauth connect bubbles wrap the prefilled url instead of overflowing
 	const guide = await renderToString(renderGoogleOauthWalkthrough())
 	expect(guide).toContain('/connect/oauth?provider=google')
 	expect(guide).toContain('Connect and verify')
+})
+
+test('walkthrough acts stay in the article column instead of breaking out', () => {
+	const serialized = JSON.stringify(interactiveGuideActCss)
+	expect(serialized).not.toContain('100vw')
+	expect(serialized).not.toContain('50vw')
+	expect(interactiveGuideActCss.maxWidth).toBe('100%')
 })

--- a/packages/worker/client/routes/interactive-guide-walkthrough.tsx
+++ b/packages/worker/client/routes/interactive-guide-walkthrough.tsx
@@ -19,10 +19,7 @@ import {
 	transcriptFileLang,
 } from './interactive-guide-transcript.ts'
 import { renderWalkthroughKicker } from './walkthrough-ask-kicker.tsx'
-import {
-	getAccentCalloutCss,
-	getArticleBreakoutCss,
-} from '#universal/styles/style-primitives.ts'
+import { getAccentCalloutCss } from '#universal/styles/style-primitives.ts'
 import {
 	colors,
 	radius,
@@ -400,9 +397,12 @@ const leadCss = {
 }
 
 export const interactiveGuideActCss = {
-	...getArticleBreakoutCss(),
+	// Stay in the docs article column. Viewport-centered `getArticleBreakoutCss`
+	// was for the old standalone guide page; inside the sidebar shell it
+	// paints over the nav.
 	marginTop: 'clamp(2.4rem, 6vw, 3.4rem)',
 	minWidth: 0,
+	maxWidth: '100%',
 	'& h2': {
 		margin: '0.2rem 0 0',
 		fontSize: '1.55rem',

--- a/packages/worker/public/styles.css
+++ b/packages/worker/public/styles.css
@@ -450,9 +450,10 @@ html.is-settled {
 	   Pinning old/new (`animation: none`) froze that leftover rail on top
 	   of the destination. Old/new fade; only the group stays still so
 	   account↔admin (rail on both sides) does not morph/squash. Intra-docs
-	   guide switches skip this API entirely (client-router shell areas) so
-	   the sidebar inside `page` does not fade. Browsers without the API
-	   never match these pseudos — the swap is instant. */
+	   guide switches skip this API entirely (client-router shell areas).
+	   The docs sidebar is also named `docs-nav` so a leftover transition
+	   cannot slide the rail. Browsers without the API never match these
+	   pseudos — the swap is instant. */
 	::view-transition-old(root),
 	::view-transition-new(root) {
 		animation: none;
@@ -476,6 +477,7 @@ html.is-settled {
 	::view-transition-new(nav-progress),
 	::view-transition-group(nav-progress),
 	::view-transition-group(account-nav),
+	::view-transition-group(docs-nav),
 	::view-transition-group(files-back),
 	::view-transition-group(files-head),
 	::view-transition-group(files-tree),
@@ -491,6 +493,7 @@ html.is-settled {
 	   than being pinned outright: none of these are on screen outside
 	   `/files`, and pinning old/new strands the leftover snapshot. */
 	::view-transition-old(account-nav),
+	::view-transition-old(docs-nav),
 	::view-transition-old(files-back),
 	::view-transition-old(files-head),
 	::view-transition-old(files-tree),
@@ -499,6 +502,7 @@ html.is-settled {
 	}
 
 	::view-transition-new(account-nav),
+	::view-transition-new(docs-nav),
 	::view-transition-new(files-back),
 	::view-transition-new(files-head),
 	::view-transition-new(files-tree),

--- a/packages/worker/universal/docs-nav.node.test.ts
+++ b/packages/worker/universal/docs-nav.node.test.ts
@@ -1,8 +1,11 @@
 import { expect, test } from 'vitest'
 import {
+	docHref,
 	docsCurrentPageLabel,
 	docsIntroSlug,
 	isDocsPagePath,
+	listDocsNavSlugs,
+	listDocsPrefetchHrefs,
 	resolveDocsNavSection,
 } from './docs-nav.ts'
 
@@ -28,4 +31,15 @@ test('resolveDocsNavSection maps connect to providers and slugs to their section
 test('docsCurrentPageLabel uses the connect branch and falls back for unknown slugs', () => {
 	expect(docsCurrentPageLabel('connect')).toBe('Connect a provider')
 	expect(docsCurrentPageLabel('missing-doc')).toBe('Docs')
+})
+
+test('listDocsPrefetchHrefs covers the intro, every advertised slug, and connect', () => {
+	const hrefs = listDocsPrefetchHrefs()
+	expect(hrefs).toContain('/docs')
+	expect(hrefs).toContain('/docs/how-kody-works')
+	expect(hrefs).toContain('/docs/oauth')
+	expect(hrefs).toContain('/docs/connect')
+	expect(hrefs).not.toContain('/docs/what-is-kody')
+	expect(hrefs).toEqual([...listDocsNavSlugs().map(docHref), '/docs/connect'])
+	expect(new Set(hrefs).size).toBe(hrefs.length)
 })

--- a/packages/worker/universal/docs-nav.ts
+++ b/packages/worker/universal/docs-nav.ts
@@ -212,6 +212,14 @@ export function listDocsNavSlugs(): ReadonlyArray<string> {
 	return docsNav.flatMap((section) => section.items.map((item) => item.slug))
 }
 
+/**
+ * Same-origin hrefs the docs sidebar can navigate to. Used to render-prefetch
+ * every guide (and `/docs/connect`) so a click does not wait on a cold loader.
+ */
+export function listDocsPrefetchHrefs(): ReadonlyArray<string> {
+	return [...listDocsNavSlugs().map(docHref), '/docs/connect']
+}
+
 export function findDocsNavSection(slug: string): DocsNavSection | null {
 	return (
 		docsNav.find((section) =>

--- a/packages/worker/universal/styles/style-primitives.node.test.ts
+++ b/packages/worker/universal/styles/style-primitives.node.test.ts
@@ -1,5 +1,10 @@
 import { expect, test } from 'vitest'
-import { getAuthInputCss, getSelectCss, inputCss } from './style-primitives.ts'
+import {
+	getArticleBreakoutCss,
+	getAuthInputCss,
+	getSelectCss,
+	inputCss,
+} from './style-primitives.ts'
 import { colors } from './tokens.ts'
 
 test('text input and select primitives use the field-border token', () => {
@@ -7,4 +12,11 @@ test('text input and select primitives use the field-border token', () => {
 	expect(getAuthInputCss().border).toBe(`1.5px solid ${colors.fieldBorder}`)
 	expect(getSelectCss().border).toBe(`1.5px solid ${colors.fieldBorder}`)
 	expect(inputCss.border).not.toBe(`1px solid ${colors.border}`)
+})
+
+test('article breakout is viewport-centered and must not be used under the docs sidebar', () => {
+	const breakout = getArticleBreakoutCss()
+	expect(breakout.width).toContain('100vw')
+	expect(breakout.marginInline).toContain('50vw')
+	expect(breakout.maxWidth).toBe('none')
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Keep How Kody works (and the other interactive walkthroughs) inside the docs article column, stop the sidebar/content bump on guide switches, and make every docs sidebar link click-ready.

## Why

The walkthrough still used viewport-centered article breakout from the old standalone guide page, so conversation blocks painted over the left nav. Guide clicks also fought overflow anchoring and a changing nav font-weight. Main's no-flash work (`#2201`) already latches `createRouteData` so same-component SPA nav no longer flashes "Loading…". Docs slugs still share a matcher, not a payload, so a shared render warmup would attach one article JSON to every slug.

## Summary

- Drop `getArticleBreakoutCss()` / `100vw` from walkthrough acts. They stay in the article measure.
- Docs shell opts out of overflow anchoring, keeps nav font-weight stable, and pins `docs-nav` for view transitions.
- `prefetchEachRouteOnRender` + `prefetchRouteHrefs(..., { independent: true })` warm every sidebar href (and `/docs/connect`) after hydrate. Hover/focus intent prefetch was already global.
- Rebased onto `#2201`. Do not call `prefetchRouteHrefs(docsHrefs)` without `independent: true`.
- Keep `getArticleBreakoutCss` as a tested primitive so knip stays green and non-docs articles can still break out.

## Testing

- Targeted unit tests for walkthrough CSS, docs nav hrefs, independent prefetch, and client-router grouping.
- Pre-push: Node unit (3028) and Workers unit (341). Knip after pinning the breakout helper.
- `e2e/docs.spec.ts` asserts `/docs/secrets.json` is requested once on hydrate and is not refetched on click (CI E2E passed).
- Preview https://kody-pr-2204.kody-a99.workers.dev at 1440×900: sidebar right edge 424.5px, walkthrough figures left edge 480.5px (56px gap, no overlap). Every advertised slug JSON warmed independently. Clicking Secrets did not issue a second `/docs/secrets.json`.

![How Kody works contained beside the docs sidebar](https://cursor.com/artifacts/c/art-80d33689-6c2c-4afd-a5b7-5f393ce53f77)

<a href="https://cursor.com/agents/bc-819d7916-a618-4957-bfbb-ebe20096734a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdocs_sidebar_nav_containment_demo.mp4"><img src="https://cursor.com/artifacts/c/art-02600ea1-5daf-47b5-904c-3567676ebc1f" alt="docs_sidebar_nav_containment_demo.mp4" /></a>

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends app-ui</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `f210d0e4` · **Head:** `b2b19033`

**Classification:** extends — docs walkthroughs stay in the article column, and sidebar hrefs warm with one loader request each instead of sharing one JSON.

### Primitives touched

| Primitive | Group    | Impact                                                                 |
| --------- | -------- | ---------------------------------------------------------------------- |
| `app-ui`  | surfaces | extends — independent render prefetch, overflow-anchor, walkthrough measure |

### Change flow

Hydrated docs pages warm every sidebar destination independently, then a click adopts that slug's JSON and swaps the article without breaking out over the rail.

```mermaid
sequenceDiagram
	actor User
	participant appUi as app-ui
	User->>appUi: hydrate /docs
	appUi->>appUi: DocsNavPrefetch lists sidebar hrefs
	appUi->>appUi: prefetchRouteHrefs independent, one loader per slug
	User->>appUi: click a sidebar link
	appUi->>appUi: adopt that slug JSON
	appUi->>appUi: swap article in the docs shell
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-819d7916-a618-4957-bfbb-ebe20096734a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-819d7916-a618-4957-bfbb-ebe20096734a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Documentation sidebar destinations now preload independently, including the Connect page, for faster navigation.
  - In-document navigation uses smoother view transitions.
- **Bug Fixes**
  - Interactive walkthroughs remain within the article column instead of overlapping sidebar navigation.
  - Sidebar navigation no longer causes unwanted scroll anchoring or layout shifts.
- **Documentation**
  - Updated contributor guidance to explain documentation prefetching and article layout requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->