### PR TITLE
Stretch package file line hover across the full scroll width

### DIFF
--- a/packages/worker/client/package-files-explorer.tsx
+++ b/packages/worker/client/package-files-explorer.tsx
@@ -961,8 +961,13 @@ const codeCss = {
 	// Padding lives on `code`, not the .line spans, so the fallback output
 	// (plaintext before the Shiki chunk resolves, or an oversized file) gets
 	// the same gutters as highlighted lines.
+	//
+	// Grid + min-width: 100% sizes `code` to the longest line (and at least
+	// the pane). Each `.line` stretches to that column so hover paint covers
+	// the full scroll width, not just the tokens on that row.
 	'& code': {
-		display: 'block',
+		display: 'grid',
+		minWidth: '100%',
 		paddingInline: spacing.md,
 		counterReset: 'package-file-line',
 	},

--- a/packages/worker/client/package-files-explorer.tsx
+++ b/packages/worker/client/package-files-explorer.tsx
@@ -962,11 +962,12 @@ const codeCss = {
 	// (plaintext before the Shiki chunk resolves, or an oversized file) gets
 	// the same gutters as highlighted lines.
 	//
-	// Grid + min-width: 100% sizes `code` to the longest line (and at least
-	// the pane). Each `.line` stretches to that column so hover paint covers
-	// the full scroll width, not just the tokens on that row.
+	// `fit-content` + min-width: 100% sizes `code` to the longest line (and
+	// at least the pane). Block `.line` children stretch to that box so
+	// hover paint covers the full scroll width, not just the tokens.
 	'& code': {
-		display: 'grid',
+		display: 'block',
+		width: 'fit-content',
 		minWidth: '100%',
 		paddingInline: spacing.md,
 		counterReset: 'package-file-line',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Make the Browse Files code-line hover highlight span the full width of the pane, including when the file is scrolled horizontally.

## Why

`.line` spans were only as wide as their tokens. Hover paint stopped at the end of the text, so a horizontally scrolled view showed a truncated highlight with empty white space beside it.

## Summary

- Size the highlighted `code` element with `width: fit-content` and `min-width: 100%` so it is at least the pane and as wide as the longest line.
- Keep each Shiki `.line` as a block child so rows stack, and they stretch to that box. Hover then covers the full scroll width.

## Testing

- `npm run test:push` (node 3023, workers 341)

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `a34e9881` · **Head:** `0cc86bf7`

**Classification:** composes — no primitives added or changed; this PR restyles existing package file chrome.

### Primitives touched

| Primitive | Group    | Impact   |
| --------- | -------- | -------- |
| `app-ui`  | surfaces | composes |

### Change flow

Package Browse Files sizes the code box to the longest line so every hovered row paints across the full scroll width.

```mermaid
sequenceDiagram
	actor User
	participant appUi as app-ui
	User->>appUi: GET /@user/kodyId/tree/ref/path
	appUi-->>User: code pane sized to the longest line
	User->>appUi: hover a short line while scrolled
	appUi-->>User: highlight spans the full scroll width
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a5f488d8-35eb-4633-b2c9-d1b8ff7e25cd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a5f488d8-35eb-4633-b2c9-d1b8ff7e25cd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved highlighted code panes so line highlighting and the line-number gutter span the full scrollable row width, including lines with shorter content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->