### PR TITLE
Homepage hero: two-column layout with YouTube demo player and video chooser

### DIFF
--- a/packages/worker/.env.example
+++ b/packages/worker/.env.example
@@ -21,6 +21,10 @@ OIDC_SIGNING_PRIVATE_KEY_PEM="-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9
 # from kody@<APP_BASE_URL hostname> when set)
 APP_BASE_URL=
 
+# Optional local override of the Wrangler SIGNUP_MODE var (invite / open /
+# waitlist). `npm run dev` uses the production env, which defaults to invite.
+# SIGNUP_MODE=open
+
 # Optional override for the user email domain. Defaults to
 # inbox.<APP_BASE_URL hostname> (e.g. inbox.kody.codes): every user inbox
 # and user outbound sender lives at {username}@<this domain>, keeping user

--- a/packages/worker/client/routes/home.tsx
+++ b/packages/worker/client/routes/home.tsx
@@ -28,6 +28,7 @@ import {
 	type WalkthroughHostPick,
 } from '#universal/walkthrough-hosts.ts'
 import { LandingHeroAgents } from '#client/routes/landing-hero-agents.tsx'
+import { LandingHeroVideo } from '#client/routes/landing-hero-video.tsx'
 import { LandingByokDemo } from './landing-byok-demo.tsx'
 import { LandingTestimonialsCarousel } from './landing-testimonials-carousel.tsx'
 import { LandingLoopPlayer } from './landing-loop-player.tsx'
@@ -40,9 +41,10 @@ import { WalkthroughHostIntro } from './walkthrough-host-intro.tsx'
  * work. Motion is enhance-only (`html.js`) and fully off under
  * `prefers-reduced-motion`.
  *
- * Positioning (public door): stop sweating switching agents. The hero stage
- * (Kody with the host agents tethered around it) names the agents; the H1
- * matches the home OG card. Factory / npm / packages stay below the fold.
+ * Positioning (public door): stop sweating switching agents. The top fold is
+ * H1 + CTAs beside the demo (lite YouTube player); Kody with the host agents
+ * tethered around the lantern sits under that row. The H1 matches the home
+ * OG card. Factory / npm / packages stay below the fold.
  * The factory closer is the ritual: ask once, save it, trigger it.
  *
  * Layout styles live in `public/styles.css` (`.landing-*`) so SSR does not
@@ -178,36 +180,45 @@ export function HomeRoute(handle: Handle) {
 			<div aria-busy={busy ? 'true' : undefined}>
 				{busy ? renderRoutePendingStatus() : null}
 				<section data-parallax-scope class="landing-hero">
-					<h1 data-rise style={{ '--rise': '0' }} class="landing-hero-title">
-						{landingHeroHeadlineLead} <em>{landingHeroHeadlineAccent}</em>
-						<br />
-						{landingHeroHeadlineRest}
-					</h1>
-					<LandingHeroAgents hosts={walkthroughHosts ?? undefined} />
-					{isSignedIn ? null : (
-						<div
-							data-rise
-							style={{ '--rise': '2' }}
-							class="landing-hero-actions"
-						>
-							<a
-								href={homepageSignupPath}
-								class="landing-pill landing-hero-cta"
+					<div class="landing-hero-top">
+						<div class="landing-hero-intro">
+							<h1
+								data-rise
+								style={{ '--rise': '0' }}
+								class="landing-hero-title"
 							>
-								{publicCreateAccountLabel}
-							</a>
-							{discoveryPrompt ? (
-								<span class="landing-hero-cta landing-hero-copy">
-									<CopyTextButton
-										class="landing-hero-copy-button"
-										value={discoveryPrompt}
-										idleLabel={landingHeroCopyPromptLabel}
-										variant="ghost"
-									/>
-								</span>
-							) : null}
+								{landingHeroHeadlineLead} <em>{landingHeroHeadlineAccent}</em>
+								<br />
+								{landingHeroHeadlineRest}
+							</h1>
+							{isSignedIn ? null : (
+								<div
+									data-rise
+									style={{ '--rise': '2' }}
+									class="landing-hero-actions"
+								>
+									<a
+										href={homepageSignupPath}
+										class="landing-pill landing-hero-cta"
+									>
+										{publicCreateAccountLabel}
+									</a>
+									{discoveryPrompt ? (
+										<span class="landing-hero-cta landing-hero-copy">
+											<CopyTextButton
+												class="landing-hero-copy-button"
+												value={discoveryPrompt}
+												idleLabel={landingHeroCopyPromptLabel}
+												variant="ghost"
+											/>
+										</span>
+									) : null}
+								</div>
+							)}
 						</div>
-					)}
+						<LandingHeroVideo />
+					</div>
+					<LandingHeroAgents hosts={walkthroughHosts ?? undefined} />
 				</section>
 
 				<section aria-labelledby="pitch-title" class="landing-pitch">

--- a/packages/worker/client/routes/landing-hero-video.node.test.ts
+++ b/packages/worker/client/routes/landing-hero-video.node.test.ts
@@ -1,0 +1,59 @@
+import { jsx } from 'remix/ui/jsx-runtime'
+import { renderToString } from 'remix/ui/server'
+import { expect, test } from 'vitest'
+import {
+	chooserOverflow,
+	LandingHeroVideo,
+	nextChooserIndex,
+} from './landing-hero-video.tsx'
+import { landingHeroDemoVideos } from '#universal/landing-hero-copy.ts'
+
+test('nextChooserIndex moves along the strip, wraps at the ends, ignores other keys', () => {
+	expect(nextChooserIndex(0, 'ArrowRight', 3)).toBe(1)
+	expect(nextChooserIndex(0, 'ArrowDown', 3)).toBe(1)
+	expect(nextChooserIndex(2, 'ArrowRight', 3)).toBe(0)
+	expect(nextChooserIndex(1, 'ArrowLeft', 3)).toBe(0)
+	expect(nextChooserIndex(1, 'ArrowUp', 3)).toBe(0)
+	expect(nextChooserIndex(0, 'ArrowLeft', 3)).toBe(2)
+	expect(nextChooserIndex(1, 'Home', 3)).toBe(0)
+	expect(nextChooserIndex(1, 'End', 3)).toBe(2)
+	expect(nextChooserIndex(1, 'Enter', 3)).toBeNull()
+	expect(nextChooserIndex(1, 'a', 3)).toBeNull()
+	expect(nextChooserIndex(0, 'ArrowRight', 0)).toBeNull()
+})
+
+test('chooserOverflow only reports an edge when there is content past it', () => {
+	const fits = { scrollLeft: 0, clientWidth: 400, scrollWidth: 400 }
+	expect(chooserOverflow(fits)).toEqual({ start: false, end: false })
+	const atStart = { scrollLeft: 0, clientWidth: 400, scrollWidth: 900 }
+	expect(chooserOverflow(atStart)).toEqual({ start: false, end: true })
+	const middle = { scrollLeft: 200, clientWidth: 400, scrollWidth: 900 }
+	expect(chooserOverflow(middle)).toEqual({ start: true, end: true })
+	const atEnd = { scrollLeft: 500, clientWidth: 400, scrollWidth: 900 }
+	expect(chooserOverflow(atEnd)).toEqual({ start: true, end: false })
+	// Sub-pixel scroll positions do not flicker the fades.
+	const nearlyEnd = { scrollLeft: 499.5, clientWidth: 400, scrollWidth: 900 }
+	expect(chooserOverflow(nearlyEnd)).toEqual({ start: true, end: false })
+})
+
+test('hero video renders the first video in the player and every video as a listbox option', async () => {
+	const html = await renderToString(jsx(LandingHeroVideo, {}))
+	const [first, ...rest] = landingHeroDemoVideos
+	if (!first) throw new Error('expected at least one hero video')
+
+	// Poster, not an embed, until the visitor clicks.
+	expect(html).not.toContain('youtube-nocookie.com')
+	expect(html).toContain('data-testid="landing-hero-video-play"')
+
+	expect(html).toContain('role="listbox"')
+	expect(html).toContain('tabindex="0"')
+	expect(html.match(/role="option"/g)).toHaveLength(
+		landingHeroDemoVideos.length,
+	)
+	expect(html.match(/aria-selected="true"/g)).toHaveLength(1)
+	expect(html).toContain(`/youtube-thumb/${first.videoId}`)
+	for (const video of rest) {
+		expect(html).toContain(`/youtube-thumb/${video.videoId}`)
+		expect(html).toContain(video.title)
+	}
+})

--- a/packages/worker/client/routes/landing-hero-video.tsx
+++ b/packages/worker/client/routes/landing-hero-video.tsx
@@ -1,0 +1,231 @@
+import { ref, type Handle } from 'remix/ui'
+import { on } from '#client/event-mixin.ts'
+import { YouTubeLightPlayer } from '#client/youtube-light-player.tsx'
+import {
+	landingHeroChooserLabel,
+	landingHeroDemoPlaylistId,
+	landingHeroDemoVideos,
+} from '#universal/landing-hero-copy.ts'
+import { youtubeThumbPath } from '#universal/youtube-watch.ts'
+
+/**
+ * Where a keypress moves the chooser's active thumbnail. `null` means the key
+ * is not a navigation key. Arrows wrap at both ends so a long strip can be
+ * walked in either direction from wherever the visitor is. Both axes are
+ * accepted so up/down feel natural on a touch-scrolled strip too.
+ */
+export function nextChooserIndex(
+	current: number,
+	key: string,
+	count: number,
+): number | null {
+	if (count <= 0) return null
+	switch (key) {
+		case 'ArrowRight':
+		case 'ArrowDown':
+			return (current + 1) % count
+		case 'ArrowLeft':
+		case 'ArrowUp':
+			return (current - 1 + count) % count
+		case 'Home':
+			return 0
+		case 'End':
+			return count - 1
+		default:
+			return null
+	}
+}
+
+/**
+ * Which edges of a horizontal scroller have more content past them. Drives
+ * the fade masks so an edge only fades when there is something to scroll to.
+ */
+export function chooserOverflow(input: {
+	scrollLeft: number
+	clientWidth: number
+	scrollWidth: number
+}) {
+	return {
+		start: input.scrollLeft > 1,
+		end: input.scrollLeft + input.clientWidth < input.scrollWidth - 1,
+	}
+}
+
+function prefersReducedMotion() {
+	return (
+		typeof window !== 'undefined' &&
+		window.matchMedia('(prefers-reduced-motion: reduce)').matches
+	)
+}
+
+/**
+ * Hero media column: the lite player plus a single-tab-stop listbox of
+ * thumbnails under it, laid out as a horizontally scrolling strip so the list
+ * can grow. Clicking a thumbnail (or Enter/Space on the active one) swaps the
+ * video in the player and starts it, since choosing a video is the play
+ * gesture. Arrow keys move the active thumbnail (wrapping) and scroll it into
+ * view without changing the video; hover and keyboard-active both zoom the
+ * whole thumbnail (neighbours step aside) and slide its title out from behind
+ * it (see `.landing-hero-chooser*` in styles.css). Choosing moves focus to the
+ * player.
+ */
+export function LandingHeroVideo(handle: Handle) {
+	const videos = landingHeroDemoVideos
+	let selectedIndex = 0
+	let activeIndex = 0
+	let chosen = false
+	let scroller: HTMLElement | null = null
+	let overflowStart = false
+	let overflowEnd = false
+	const playerId = `${handle.id}-player`
+
+	function optionId(index: number) {
+		return `${handle.id}-video-${index}`
+	}
+
+	function syncOverflow() {
+		if (!scroller) return
+		const next = chooserOverflow(scroller)
+		if (next.start === overflowStart && next.end === overflowEnd) return
+		overflowStart = next.start
+		overflowEnd = next.end
+		handle.update()
+	}
+
+	// Centre the option in the strip; horizontal only, so the page never
+	// jumps the way `scrollIntoView` can when the hero is partly off-screen.
+	function revealOption(index: number) {
+		handle.queueTask(() => {
+			const option = document.getElementById(optionId(index))
+			if (!scroller || !option) return
+			const left =
+				option.offsetLeft - (scroller.clientWidth - option.offsetWidth) / 2
+			scroller.scrollTo({
+				left,
+				behavior: prefersReducedMotion() ? 'auto' : 'smooth',
+			})
+		})
+	}
+
+	// Choosing hands focus to the player so keyboard control (space, arrows,
+	// captions) lands on the video the visitor just picked instead of leaving
+	// them parked on the strip.
+	function focusPlayer() {
+		handle.queueTask(() => {
+			const frame = document
+				.getElementById(playerId)
+				?.querySelector<HTMLIFrameElement>('iframe')
+			frame?.focus({ preventScroll: true })
+		})
+	}
+
+	function choose(index: number) {
+		if (index < 0 || index >= videos.length) return
+		selectedIndex = index
+		activeIndex = index
+		chosen = true
+		handle.update()
+		revealOption(index)
+		focusPlayer()
+	}
+
+	function attachScroller(node: HTMLElement, signal: AbortSignal) {
+		scroller = node
+		const observer = new ResizeObserver(syncOverflow)
+		observer.observe(node)
+		node.addEventListener('scroll', syncOverflow, { signal, passive: true })
+		signal.addEventListener(
+			'abort',
+			() => {
+				observer.disconnect()
+				scroller = null
+			},
+			{ once: true },
+		)
+	}
+
+	return () => {
+		const selected = videos[selectedIndex]
+		if (!selected) return null
+
+		return (
+			<div class="landing-hero-media">
+				<div
+					id={playerId}
+					data-rise
+					style={{ '--rise': '1' }}
+					class="landing-hero-video"
+				>
+					<YouTubeLightPlayer
+						videoId={selected.videoId}
+						playlistId={landingHeroDemoPlaylistId}
+						title={selected.title}
+						autoplay={chosen}
+						playTestId="landing-hero-video-play"
+					/>
+				</div>
+				{videos.length > 1 ? (
+					<div
+						role="listbox"
+						tabIndex={0}
+						aria-label={landingHeroChooserLabel}
+						aria-activedescendant={optionId(activeIndex)}
+						data-rise
+						style={{ '--rise': '1.5' }}
+						class="landing-hero-chooser"
+						data-testid="landing-hero-chooser"
+						data-overflow-start={overflowStart ? '' : undefined}
+						data-overflow-end={overflowEnd ? '' : undefined}
+						mix={[
+							ref(attachScroller),
+							on('keydown', (event: KeyboardEvent) => {
+								const next = nextChooserIndex(
+									activeIndex,
+									event.key,
+									videos.length,
+								)
+								if (next !== null) {
+									event.preventDefault()
+									if (next !== activeIndex) {
+										activeIndex = next
+										handle.update()
+										revealOption(next)
+									}
+									return
+								}
+								if (event.key === 'Enter' || event.key === ' ') {
+									event.preventDefault()
+									choose(activeIndex)
+								}
+							}),
+						]}
+					>
+						{videos.map((video, index) => (
+							<div
+								key={video.videoId}
+								id={optionId(index)}
+								role="option"
+								aria-selected={index === selectedIndex ? 'true' : 'false'}
+								data-active={index === activeIndex ? '' : undefined}
+								class="landing-hero-chooser-option"
+								mix={on('click', () => choose(index))}
+							>
+								<span class="landing-hero-chooser-thumb">
+									<img
+										src={youtubeThumbPath(video.videoId)}
+										alt=""
+										width={480}
+										height={270}
+										loading="lazy"
+										decoding="async"
+									/>
+								</span>
+								<span class="landing-hero-chooser-title">{video.title}</span>
+							</div>
+						))}
+					</div>
+				) : null}
+			</div>
+		)
+	}
+}

--- a/packages/worker/client/youtube-light-player.node.test.ts
+++ b/packages/worker/client/youtube-light-player.node.test.ts
@@ -1,0 +1,21 @@
+import { jsx } from 'remix/ui/jsx-runtime'
+import { renderToString } from 'remix/ui/server'
+import { expect, test } from 'vitest'
+import { YouTubeLightPlayer } from './youtube-light-player.tsx'
+import { youtubeWatchSampleVideoId } from '#universal/youtube-watch.ts'
+
+const videoId = youtubeWatchSampleVideoId
+
+test('youtube light player paints a first-party poster without embedding', async () => {
+	const html = await renderToString(
+		jsx(YouTubeLightPlayer, {
+			videoId,
+			title: 'Watch the Kody demo',
+			playTestId: 'landing-hero-video-play',
+		}),
+	)
+	expect(html).toContain(`/youtube-thumb/${videoId}`)
+	expect(html).toContain('data-testid="landing-hero-video-play"')
+	expect(html).toContain('Play video')
+	expect(html).not.toContain('youtube-nocookie.com')
+})

--- a/packages/worker/client/youtube-light-player.node.test.ts
+++ b/packages/worker/client/youtube-light-player.node.test.ts
@@ -1,10 +1,14 @@
 import { jsx } from 'remix/ui/jsx-runtime'
 import { renderToString } from 'remix/ui/server'
 import { expect, test } from 'vitest'
-import { YouTubeLightPlayer } from './youtube-light-player.tsx'
+import {
+	nextLightPlayerPlaying,
+	YouTubeLightPlayer,
+} from './youtube-light-player.tsx'
 import { youtubeWatchSampleVideoId } from '#universal/youtube-watch.ts'
 
 const videoId = youtubeWatchSampleVideoId
+const otherVideoId = 'iGMkgjXc8Ho'
 
 test('youtube light player paints a first-party poster without embedding', async () => {
 	const html = await renderToString(
@@ -18,4 +22,66 @@ test('youtube light player paints a first-party poster without embedding', async
 	expect(html).toContain('data-testid="landing-hero-video-play"')
 	expect(html).toContain('Play video')
 	expect(html).not.toContain('youtube-nocookie.com')
+})
+
+test('youtube light player embeds immediately when autoplay is set', async () => {
+	const html = await renderToString(
+		jsx(YouTubeLightPlayer, {
+			videoId,
+			playlistId: 'PLXa53KPj2nlE',
+			title: 'Watch the Kody demo',
+			autoplay: true,
+		}),
+	)
+	expect(html).toContain(`youtube-nocookie.com/embed/${videoId}`)
+	expect(html).toContain('list=PLXa53KPj2nlE')
+	expect(html).not.toContain('data-testid="landing-hero-video-play"')
+})
+
+test('nextLightPlayerPlaying starts the same video when autoplay becomes true', () => {
+	const poster = nextLightPlayerPlaying({
+		playing: false,
+		renderedVideoId: videoId,
+		videoId,
+		autoplay: false,
+	})
+	expect(poster).toEqual({ renderedVideoId: videoId, playing: false })
+
+	const chooseCurrent = nextLightPlayerPlaying({
+		playing: false,
+		renderedVideoId: videoId,
+		videoId,
+		autoplay: true,
+	})
+	expect(chooseCurrent).toEqual({ renderedVideoId: videoId, playing: true })
+
+	const stayPlaying = nextLightPlayerPlaying({
+		playing: true,
+		renderedVideoId: videoId,
+		videoId,
+		autoplay: false,
+	})
+	expect(stayPlaying).toEqual({ renderedVideoId: videoId, playing: true })
+
+	const switchPoster = nextLightPlayerPlaying({
+		playing: true,
+		renderedVideoId: videoId,
+		videoId: otherVideoId,
+		autoplay: false,
+	})
+	expect(switchPoster).toEqual({
+		renderedVideoId: otherVideoId,
+		playing: false,
+	})
+
+	const switchAndPlay = nextLightPlayerPlaying({
+		playing: false,
+		renderedVideoId: videoId,
+		videoId: otherVideoId,
+		autoplay: true,
+	})
+	expect(switchAndPlay).toEqual({
+		renderedVideoId: otherVideoId,
+		playing: true,
+	})
 })

--- a/packages/worker/client/youtube-light-player.tsx
+++ b/packages/worker/client/youtube-light-player.tsx
@@ -13,8 +13,27 @@ import { colors, radius, typography } from '#universal/styles/tokens.ts'
  * one exception is `autoplay`, which callers set only after the visitor has
  * already picked a video (a click is the gesture). When `videoId` changes the
  * player re-derives its state for the new video instead of carrying the old
- * one over.
+ * one over. The same `videoId` still starts when `autoplay` becomes true so
+ * the hero chooser can play the already-selected clip.
  */
+export function nextLightPlayerPlaying(input: {
+	playing: boolean
+	renderedVideoId: string
+	videoId: string
+	autoplay: boolean
+}) {
+	if (input.videoId !== input.renderedVideoId) {
+		return {
+			renderedVideoId: input.videoId,
+			playing: input.autoplay,
+		}
+	}
+	return {
+		renderedVideoId: input.renderedVideoId,
+		playing: input.playing || input.autoplay,
+	}
+}
+
 export function YouTubeLightPlayer(
 	handle: Handle<{
 		videoId: string
@@ -29,10 +48,14 @@ export function YouTubeLightPlayer(
 
 	return () => {
 		const videoId = handle.props.videoId
-		if (videoId !== renderedVideoId) {
-			renderedVideoId = videoId
-			playing = handle.props.autoplay === true
-		}
+		const next = nextLightPlayerPlaying({
+			playing,
+			renderedVideoId,
+			videoId,
+			autoplay: handle.props.autoplay === true,
+		})
+		renderedVideoId = next.renderedVideoId
+		playing = next.playing
 		const title = handle.props.title ?? 'YouTube video'
 		if (playing) {
 			return (

--- a/packages/worker/client/youtube-light-player.tsx
+++ b/packages/worker/client/youtube-light-player.tsx
@@ -1,0 +1,129 @@
+import { css, type Handle } from 'remix/ui'
+import { on } from '#client/event-mixin.ts'
+import {
+	youtubeNocookieEmbedUrl,
+	youtubeThumbPath,
+} from '#universal/youtube-watch.ts'
+import { colors, radius, typography } from '#universal/styles/tokens.ts'
+
+/**
+ * First-party lite YouTube player: poster + play, then the privacy-enhanced
+ * embed. Used by the site-wide `/?youtubeId=` overlay and the homepage hero.
+ * Playback starts on click so `prefers-reduced-motion` never autoplays; the
+ * one exception is `autoplay`, which callers set only after the visitor has
+ * already picked a video (a click is the gesture). When `videoId` changes the
+ * player re-derives its state for the new video instead of carrying the old
+ * one over.
+ */
+export function YouTubeLightPlayer(
+	handle: Handle<{
+		videoId: string
+		playlistId?: string
+		title?: string
+		playTestId?: string
+		autoplay?: boolean
+	}>,
+) {
+	let renderedVideoId = handle.props.videoId
+	let playing = handle.props.autoplay === true
+
+	return () => {
+		const videoId = handle.props.videoId
+		if (videoId !== renderedVideoId) {
+			renderedVideoId = videoId
+			playing = handle.props.autoplay === true
+		}
+		const title = handle.props.title ?? 'YouTube video'
+		if (playing) {
+			return (
+				<iframe
+					title={title}
+					src={youtubeNocookieEmbedUrl(videoId, {
+						playlistId: handle.props.playlistId,
+					})}
+					allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+					allowFullScreen
+					mix={css(frameCss)}
+				/>
+			)
+		}
+
+		return (
+			<button
+				type="button"
+				data-testid={handle.props.playTestId}
+				mix={[
+					css(posterButtonCss),
+					on('click', () => {
+						playing = true
+						handle.update()
+					}),
+				]}
+			>
+				<img
+					src={youtubeThumbPath(videoId)}
+					alt=""
+					width={1280}
+					height={720}
+					mix={css(posterImageCss)}
+				/>
+				<span mix={css(playBadgeCss)} aria-hidden="true">
+					▶
+				</span>
+				<span mix={css(visuallyHiddenCss)}>Play video</span>
+			</button>
+		)
+	}
+}
+
+const frameCss = {
+	width: '100%',
+	height: '100%',
+	border: 'none',
+}
+
+const posterButtonCss = {
+	appearance: 'none',
+	display: 'block',
+	width: '100%',
+	height: '100%',
+	padding: 0,
+	border: 'none',
+	backgroundColor: '#000',
+	cursor: 'pointer',
+	position: 'relative' as const,
+}
+
+const posterImageCss = {
+	width: '100%',
+	height: '100%',
+	objectFit: 'cover' as const,
+}
+
+const playBadgeCss = {
+	position: 'absolute' as const,
+	inset: 0,
+	margin: 'auto',
+	width: '4.5rem',
+	height: '4.5rem',
+	borderRadius: radius.full,
+	backgroundColor: 'rgba(0, 0, 0, 0.72)',
+	color: colors.onPrimary,
+	display: 'grid',
+	placeItems: 'center',
+	fontSize: '1.5rem',
+	lineHeight: 1,
+}
+
+const visuallyHiddenCss = {
+	position: 'absolute' as const,
+	width: '1px',
+	height: '1px',
+	padding: 0,
+	margin: '-1px',
+	overflow: 'hidden' as const,
+	clip: 'rect(0, 0, 0, 0)',
+	whiteSpace: 'nowrap' as const,
+	border: 0,
+	fontFamily: typography.fontFamily,
+}

--- a/packages/worker/client/youtube-watch-overlay.tsx
+++ b/packages/worker/client/youtube-watch-overlay.tsx
@@ -9,8 +9,6 @@ import { type YoutubeWatchLoaderData } from '#universal/loader-data.ts'
 import {
 	parseYoutubeWatchSearch,
 	stripYoutubeWatchSearch,
-	youtubeNocookieEmbedUrl,
-	youtubeThumbPath,
 } from '#universal/youtube-watch.ts'
 import { hoverMq } from '#universal/styles/style-primitives.ts'
 import {
@@ -19,6 +17,7 @@ import {
 	spacing,
 	typography,
 } from '#universal/styles/tokens.ts'
+import { YouTubeLightPlayer } from './youtube-light-player.tsx'
 
 function emptyYoutubeWatchSnapshot(): YoutubeWatchLoaderData {
 	return {
@@ -29,11 +28,9 @@ function emptyYoutubeWatchSnapshot(): YoutubeWatchLoaderData {
 export function YouTubeWatchOverlay(
 	handle: Handle<{ snapshot?: YoutubeWatchLoaderData }>,
 ) {
-	let playing = false
 	let dialogNode: HTMLDialogElement | null = null
 
 	function closeWatch() {
-		playing = false
 		dialogNode?.close()
 		const pathname = readRouterPathname(handle)
 		const search = readRouterSearch(handle)
@@ -41,11 +38,6 @@ export function YouTubeWatchOverlay(
 		if (next !== `${pathname}${search}`) {
 			navigate(next)
 		}
-		handle.update()
-	}
-
-	function startPlayback() {
-		playing = true
 		handle.update()
 	}
 
@@ -91,33 +83,10 @@ export function YouTubeWatchOverlay(
 					<h2 id={titleId} mix={css(visuallyHiddenCss)}>
 						Watch video
 					</h2>
-					{playing ? (
-						<iframe
-							title="YouTube video"
-							src={youtubeNocookieEmbedUrl(videoId)}
-							allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-							allowFullScreen
-							mix={css(frameCss)}
-						/>
-					) : (
-						<button
-							type="button"
-							data-testid="youtube-watch-play"
-							mix={[css(posterButtonCss), on('click', startPlayback)]}
-						>
-							<img
-								src={youtubeThumbPath(videoId)}
-								alt=""
-								width={1280}
-								height={720}
-								mix={css(posterImageCss)}
-							/>
-							<span mix={css(playBadgeCss)} aria-hidden="true">
-								▶
-							</span>
-							<span mix={css(visuallyHiddenCss)}>Play video</span>
-						</button>
-					)}
+					<YouTubeLightPlayer
+						videoId={videoId}
+						playTestId="youtube-watch-play"
+					/>
 					<button
 						type="button"
 						aria-label="Close video"
@@ -150,45 +119,6 @@ const stageCss = {
 	backgroundColor: '#000',
 	borderRadius: radius.card,
 	overflow: 'hidden' as const,
-}
-
-const frameCss = {
-	width: '100%',
-	height: '100%',
-	border: 'none',
-}
-
-const posterButtonCss = {
-	appearance: 'none',
-	display: 'block',
-	width: '100%',
-	height: '100%',
-	padding: 0,
-	border: 'none',
-	backgroundColor: '#000',
-	cursor: 'pointer',
-	position: 'relative' as const,
-}
-
-const posterImageCss = {
-	width: '100%',
-	height: '100%',
-	objectFit: 'cover' as const,
-}
-
-const playBadgeCss = {
-	position: 'absolute' as const,
-	inset: 0,
-	margin: 'auto',
-	width: '4.5rem',
-	height: '4.5rem',
-	borderRadius: radius.full,
-	backgroundColor: 'rgba(0, 0, 0, 0.72)',
-	color: colors.onPrimary,
-	display: 'grid',
-	placeItems: 'center',
-	fontSize: '1.5rem',
-	lineHeight: 1,
 }
 
 const closeCss = {

--- a/packages/worker/public/styles.css
+++ b/packages/worker/public/styles.css
@@ -773,13 +773,30 @@ html.is-settled {
 	text-align: center;
 }
 
+.landing-hero-top {
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) minmax(0, 1.15fr);
+	gap: clamp(1.5rem, 4vw, 3rem);
+	align-items: center;
+	text-align: left;
+}
+
+.landing-hero-intro {
+	display: flex;
+	flex-direction: column;
+	align-items: stretch;
+	align-self: start;
+	min-width: 0;
+}
+
 .landing-hero-title {
 	margin: 0;
-	font-size: clamp(2.7rem, 6.5vw, 5rem);
+	font-size: clamp(2.4rem, 5.2vw, 4.25rem);
 	font-weight: 760;
 	line-height: 1.02;
 	letter-spacing: -0.03em;
 	font-variation-settings: 'opsz' 96;
+	text-wrap: balance;
 }
 
 .landing-hero-title em {
@@ -788,20 +805,216 @@ html.is-settled {
 }
 
 .landing-hero-actions {
-	margin-top: 2.2rem;
+	margin-top: 1.6rem;
 	display: flex;
+	flex-direction: column;
 	align-items: stretch;
-	justify-content: center;
-	flex-wrap: nowrap;
-	gap: 0.8rem 1rem;
-	width: min(100%, 38rem);
-	margin-inline: auto;
+	gap: 0.75rem;
+	width: 100%;
+}
+
+.landing-hero-media {
+	min-width: 0;
+}
+
+.landing-hero-video {
+	position: relative;
+	width: 100%;
+	aspect-ratio: 16 / 9;
+	min-height: 12.5rem;
+	background-color: #000;
+	border-radius: var(--radius-card);
+	overflow: hidden;
+}
+
+/* Video chooser: a horizontally scrolling strip of small thumbnails that can
+   grow with the video list. One tab stop (the listbox); arrow keys move
+   `data-active` (wrapping) and scroll it into view; Enter picks. The strip
+   bleeds past the video's edges by `--chooser-bleed` (negative margin +
+   matching padding) so the zoomed thumb has room and the first/last thumb
+   still align with the player at rest. Edges fade only when there is more to
+   scroll to on that side (`data-overflow-*`, set from scroll position).
+   Each option reserves a title slot (padding-bottom) below its thumbnail; the
+   title rests *behind* the thumb (translated up, z-index 0, faded so it cannot
+   peek through the rounded corners) and slides down into    the slot on hover or
+   keyboard-active while the whole thumb zooms and its neighbours step aside. The listbox
+   draws no ring of its own — the active option carries it, so the indicator is
+   on the thing the arrows move. */
+.landing-hero-chooser {
+	--chooser-thumb-width: 6.75rem;
+	--chooser-title-slot: 3.4rem;
+	--chooser-zoom: 1.18;
+	/* Half the zoomed card's extra width, plus a breath: how far neighbours
+	   step aside so the zoomed card never covers them. */
+	--chooser-shift: calc(
+		var(--chooser-thumb-width) * (var(--chooser-zoom) - 1) / 2 + 0.15rem
+	);
+	/* Must hold a card that has stepped aside by --chooser-shift plus its
+	   focus ring, and must stay within the hero's smallest side padding
+	   (1.25rem) so the strip never widens the page on phones. */
+	--chooser-bleed: 1.2rem;
+	--chooser-fade: 2.75rem;
+	--chooser-fade-start: black;
+	--chooser-fade-end: black;
+	position: relative;
+	display: flex;
+	gap: 0.6rem;
+	margin: calc(0.85rem - var(--chooser-bleed)) calc(-1 * var(--chooser-bleed)) 0;
+	padding: var(--chooser-bleed) var(--chooser-bleed) 0;
+	overflow-x: auto;
+	overflow-y: hidden;
+	scroll-snap-type: x proximity;
+	scroll-padding-inline: var(--chooser-bleed);
+	scrollbar-width: none;
+}
+
+.landing-hero-chooser::-webkit-scrollbar {
+	display: none;
+}
+
+.landing-hero-chooser:focus-visible {
+	outline: none;
+}
+
+.landing-hero-chooser[data-overflow-start] {
+	--chooser-fade-start: transparent;
+}
+
+.landing-hero-chooser[data-overflow-end] {
+	--chooser-fade-end: transparent;
+}
+
+.landing-hero-chooser[data-overflow-start],
+.landing-hero-chooser[data-overflow-end] {
+	mask-image: linear-gradient(
+		to right,
+		var(--chooser-fade-start),
+		black var(--chooser-fade),
+		black calc(100% - var(--chooser-fade)),
+		var(--chooser-fade-end)
+	);
+}
+
+.landing-hero-chooser-option {
+	position: relative;
+	flex: 0 0 var(--chooser-thumb-width);
+	width: var(--chooser-thumb-width);
+	padding-bottom: var(--chooser-title-slot);
+	scroll-snap-align: center;
+	cursor: pointer;
+}
+
+.landing-hero-chooser-option:hover,
+.landing-hero-chooser:focus-visible .landing-hero-chooser-option[data-active] {
+	z-index: 2;
+}
+
+.landing-hero-chooser-thumb {
+	position: relative;
+	z-index: 1;
+	display: block;
+	aspect-ratio: 16 / 9;
+	overflow: hidden;
+	background-color: #000;
+	border-radius: var(--radius-md);
+	box-shadow: var(--shadow-sm);
+	scale: 1;
+}
+
+.landing-hero-chooser-thumb img {
+	display: block;
+	width: 100%;
+	height: 100%;
+	object-fit: cover;
+}
+
+.landing-hero-chooser-option[aria-selected='true'] .landing-hero-chooser-thumb {
+	outline: 2.5px solid var(--color-primary);
+	outline-offset: 2px;
+}
+
+.landing-hero-chooser:focus-visible
+	.landing-hero-chooser-option[data-active]
+	.landing-hero-chooser-thumb {
+	outline: 2.5px solid var(--color-primary);
+	outline-offset: 3px;
+}
+
+.landing-hero-chooser-title {
+	position: absolute;
+	inset: auto -0.6rem 0;
+	z-index: 0;
+	box-sizing: border-box;
+	height: var(--chooser-title-slot);
+	padding: 0.65rem 0.2rem 0;
+	font-size: 0.72rem;
+	line-height: 1.3;
+	color: var(--color-text-muted);
+	text-align: center;
+	text-wrap: balance;
+	display: -webkit-box;
+	-webkit-box-orient: vertical;
+	-webkit-line-clamp: 3;
+	overflow: hidden;
+	translate: 0 -100%;
+	opacity: 0;
+}
+
+.landing-hero-chooser-option:hover .landing-hero-chooser-thumb,
+.landing-hero-chooser:focus-visible
+	.landing-hero-chooser-option[data-active]
+	.landing-hero-chooser-thumb {
+	scale: var(--chooser-zoom);
+	box-shadow: var(--shadow-md);
+}
+
+/* Neighbours make room for the zoomed card: everything before it slides
+   left, everything after slides right, by the card's horizontal overflow.
+   `:has(~ …)` reaches the preceding siblings, which plain combinators cannot.
+   Transform-only, so the strip's scroll geometry does not change under the
+   pointer; the outermost cards move into the bleed padding. */
+.landing-hero-chooser-option:has(~ .landing-hero-chooser-option:hover),
+.landing-hero-chooser:focus-visible
+	.landing-hero-chooser-option:has(
+		~ .landing-hero-chooser-option[data-active]
+	) {
+	translate: calc(-1 * var(--chooser-shift)) 0;
+}
+
+.landing-hero-chooser-option:hover ~ .landing-hero-chooser-option,
+.landing-hero-chooser:focus-visible
+	.landing-hero-chooser-option[data-active]
+	~ .landing-hero-chooser-option {
+	translate: var(--chooser-shift) 0;
+}
+.landing-hero-chooser-option:hover .landing-hero-chooser-title,
+.landing-hero-chooser:focus-visible
+	.landing-hero-chooser-option[data-active]
+	.landing-hero-chooser-title {
+	translate: 0 0;
+	opacity: 1;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+	.landing-hero-chooser-option {
+		transition: translate 260ms var(--ease-out);
+	}
+
+	.landing-hero-chooser-thumb {
+		transition:
+			scale 260ms var(--ease-out),
+			box-shadow 260ms var(--ease-out);
+	}
+
+	.landing-hero-chooser-title {
+		transition:
+			translate 260ms var(--ease-out),
+			opacity 200ms var(--ease-out);
+	}
 }
 
 .landing-hero-cta {
-	flex: 1 1 0;
 	width: 100%;
-	min-width: 0;
 	box-sizing: border-box;
 }
 
@@ -814,14 +1027,15 @@ html.is-settled {
 	width: 100%;
 }
 
-@media (max-width: 520px) {
-	.landing-hero-actions {
-		flex-wrap: wrap;
-		width: min(100%, 22rem);
+@media (max-width: 800px) {
+	.landing-hero-top {
+		grid-template-columns: 1fr;
 	}
 
-	.landing-hero-cta {
-		flex: 1 1 100%;
+	/* Single column: the headline owns the full width, so scale with it
+	   instead of the two-column 5.2vw that assumed a ~45% column. */
+	.landing-hero-title {
+		font-size: clamp(2.5rem, 8.5vw, 4.25rem);
 	}
 }
 
@@ -946,7 +1160,7 @@ html.is-settled {
    travel them (frame-driven, shown only with JS + motion OK). */
 .landing-hero-agents {
 	width: min(100%, 40rem);
-	margin: 1.75rem auto 0;
+	margin: 2.5rem auto 0;
 }
 
 .landing-hero-agents-stage {

--- a/packages/worker/src/app/ssr-render-homepage-hero.node.test.ts
+++ b/packages/worker/src/app/ssr-render-homepage-hero.node.test.ts
@@ -3,6 +3,10 @@ import { setAuthSessionSecret } from '#app/auth-session.ts'
 import { resetDataCacheForTests } from '#app/data-cache.ts'
 import { loadHomePageOnboardingData } from '#app/onboarding-data.ts'
 import { renderAppPage } from '#app/ssr-render.tsx'
+import {
+	landingHeroDemoVideoId,
+	landingHeroDemoVideos,
+} from '#universal/landing-hero-copy.ts'
 import { createMemoryKv } from '#worker/test-support/auth-provider-harness.ts'
 import { executePreparedD1Batch } from '#worker/test-support/d1-prepared-batch.ts'
 import { testOidcSigningEnv } from '#worker/test-support/oidc-signing-env.ts'
@@ -109,6 +113,17 @@ test('homepage hero headline and session-aware CTAs', async () => {
 	expect(anonymousHero).toContain('landing-hero-actions')
 	expect(anonymousHero).toContain('Create a free account')
 	expect(anonymousHero).toContain('Copy the discovery prompt')
+	expect(anonymousHero).toContain('landing-hero-top')
+	expect(anonymousHero).toContain('landing-hero-video')
+	expect(anonymousHero).toContain(`/youtube-thumb/${landingHeroDemoVideoId}`)
+	expect(anonymousHero).toContain('role="listbox"')
+	for (const video of landingHeroDemoVideos) {
+		expect(anonymousHero).toContain(`/youtube-thumb/${video.videoId}`)
+	}
+	expect(anonymousHero).toContain('landing-hero-agents')
+	expect(anonymousHero.indexOf('landing-hero-top')).toBeLessThan(
+		anonymousHero.indexOf('landing-hero-agents'),
+	)
 
 	const signedIn = await renderAppPage({
 		request: new Request(requestUrl),
@@ -122,4 +137,6 @@ test('homepage hero headline and session-aware CTAs', async () => {
 	expect(signedInHero).not.toContain('landing-hero-actions')
 	expect(signedInHero).not.toContain('Create a free account')
 	expect(signedInHero).not.toContain('Copy the discovery prompt')
+	expect(signedInHero).toContain('landing-hero-video')
+	expect(signedInHero).toContain('landing-hero-agents')
 })

--- a/packages/worker/src/app/youtube-watch-allowlist.node.test.ts
+++ b/packages/worker/src/app/youtube-watch-allowlist.node.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from 'vitest'
+import { landingHeroDemoVideoIds } from '#universal/landing-hero-copy.ts'
 import { youtubeWatchSampleVideoId } from '#universal/youtube-watch.ts'
 import {
 	loadPlaylistVideoIds,
@@ -6,6 +7,7 @@ import {
 } from './youtube-watch-allowlist.ts'
 
 const videoId = youtubeWatchSampleVideoId
+const builtInVideoIds = [...new Set([videoId, ...landingHeroDemoVideoIds])]
 const playlistId = 'PLV5CVI1eNcJhP4nrJt85L7PxHjebFpDfY'
 
 test('loadPlaylistVideoIds parses the Atom feed and caches the xml', async () => {
@@ -62,7 +64,7 @@ test('resolveYoutubeWatchAllowedVideoIds uses extra ids when playlists are none'
 			throw new Error('playlist fetch should not run')
 		},
 	})
-	expect(ids).toEqual([videoId])
+	expect(ids).toEqual(builtInVideoIds)
 })
 
 test('resolveYoutubeWatchAllowedVideoIds always includes the look-preview sample id', async () => {
@@ -74,7 +76,7 @@ test('resolveYoutubeWatchAllowedVideoIds always includes the look-preview sample
 			throw new Error('playlist fetch should not run')
 		},
 	})
-	expect(ids).toEqual([videoId])
+	expect(ids).toEqual(builtInVideoIds)
 })
 
 test('resolveYoutubeWatchAllowedVideoIds skips playlist fetch when loadPlaylists is false', async () => {
@@ -95,7 +97,7 @@ test('resolveYoutubeWatchAllowedVideoIds skips playlist fetch when loadPlaylists
 			},
 		],
 	})
-	expect(ids).toEqual([videoId])
+	expect(ids).toEqual(builtInVideoIds)
 })
 
 test('resolveYoutubeWatchAllowedVideoIds uses listedBanners instead of querying D1', async () => {
@@ -117,5 +119,5 @@ test('resolveYoutubeWatchAllowedVideoIds uses listedBanners instead of querying 
 			},
 		],
 	})
-	expect(ids).toEqual([videoId, bannerVideoId])
+	expect(ids).toEqual([...builtInVideoIds, bannerVideoId])
 })

--- a/packages/worker/src/app/youtube-watch-allowlist.ts
+++ b/packages/worker/src/app/youtube-watch-allowlist.ts
@@ -1,3 +1,4 @@
+import { landingHeroDemoVideoIds } from '#universal/landing-hero-copy.ts'
 import {
 	mergeYoutubeWatchAllowlist,
 	parseYoutubePlaylistFeedXml,
@@ -30,8 +31,8 @@ export async function resolveYoutubeWatchAllowedVideoIds(input: {
 		| ReadonlyArray<YoutubeWatchBannerHrefs>
 	/**
 	 * Playlist Atom fetch. Default true for thumbs and `?youtubeId=` SSR.
-	 * Plain documents skip it: env extras, the sample id, and banner hrefs
-	 * still allow Watch CTAs and look-preview.
+	 * Plain documents skip it: env extras, the sample id, the homepage hero
+	 * demo id, and banner hrefs still allow Watch CTAs and look-preview.
 	 */
 	loadPlaylists?: boolean
 }): Promise<Array<string>> {
@@ -54,7 +55,11 @@ export async function resolveYoutubeWatchAllowedVideoIds(input: {
 	])
 	return mergeYoutubeWatchAllowlist({
 		playlistVideoIds,
-		extraVideoIds: [...extraVideoIds, youtubeWatchSampleVideoId],
+		extraVideoIds: [
+			...extraVideoIds,
+			youtubeWatchSampleVideoId,
+			...landingHeroDemoVideoIds,
+		],
 		hrefs,
 	})
 }

--- a/packages/worker/universal/landing-hero-copy.ts
+++ b/packages/worker/universal/landing-hero-copy.ts
@@ -9,3 +9,39 @@ export const landingHeroHeadlineRest = 'Switching Agents'
 export const landingHeroHeadline = `${landingHeroHeadlineLead} ${landingHeroHeadlineAccent} ${landingHeroHeadlineRest}`
 
 export const landingHeroCopyPromptLabel = 'Copy the discovery prompt'
+
+/**
+ * Videos offered by the homepage hero, in display order. The first one loads
+ * in the lite player; the rest sit in the thumbnail chooser under it. The
+ * watch allowlist always includes every id here so the first-party thumb
+ * proxy works without extra env. `landingHeroDemoPlaylistId` is passed on the
+ * embed so end-of-video recommendations stay in that playlist.
+ */
+export const landingHeroDemoVideos: ReadonlyArray<{
+	videoId: string
+	title: string
+}> = [
+	{
+		videoId: 'iGMkgjXc8Ho',
+		title: 'Build a PR-ready check in Cursor, then run it from Claude',
+	},
+	{
+		videoId: 'QA0xYMAMjEg',
+		title: 'Introducing Kody: Your Personal Software Factory',
+	},
+	{
+		videoId: 'OZKDO9Pzmo0',
+		title:
+			'Shade automation from an INTENT.md — deterministic code, no model in the loop',
+	},
+	{
+		videoId: 'aySqbxQo9lM',
+		title: 'Kody enables awesome triage-to-production workflows',
+	},
+]
+export const landingHeroDemoVideoIds = landingHeroDemoVideos.map(
+	(video) => video.videoId,
+)
+export const landingHeroDemoVideoId = landingHeroDemoVideoIds[0] ?? ''
+export const landingHeroDemoPlaylistId = 'PLXa53KPj2nlE'
+export const landingHeroChooserLabel = 'More Kody videos'

--- a/packages/worker/universal/youtube-watch.node.test.ts
+++ b/packages/worker/universal/youtube-watch.node.test.ts
@@ -140,4 +140,12 @@ test('banner images rewrite YouTube hosts to first-party thumb paths', () => {
 	expect(youtubeNocookieEmbedUrl(videoId)).toBe(
 		`https://www.youtube-nocookie.com/embed/${videoId}?autoplay=1&rel=0`,
 	)
+	expect(
+		youtubeNocookieEmbedUrl(videoId, { playlistId: 'PLXa53KPj2nlE' }),
+	).toBe(
+		`https://www.youtube-nocookie.com/embed/${videoId}?autoplay=1&rel=0&listType=playlist&list=PLXa53KPj2nlE`,
+	)
+	expect(youtubeNocookieEmbedUrl(videoId, { playlistId: 'not-a-list' })).toBe(
+		`https://www.youtube-nocookie.com/embed/${videoId}?autoplay=1&rel=0`,
+	)
 })

--- a/packages/worker/universal/youtube-watch.ts
+++ b/packages/worker/universal/youtube-watch.ts
@@ -36,8 +36,16 @@ export function youtubePlaylistFeedUrl(playlistId: string): string {
 	return `https://www.youtube.com/feeds/videos.xml?playlist_id=${encodeURIComponent(playlistId)}`
 }
 
-export function youtubeNocookieEmbedUrl(videoId: string): string {
+export function youtubeNocookieEmbedUrl(
+	videoId: string,
+	options?: { playlistId?: string },
+): string {
 	const params = new URLSearchParams({ autoplay: '1', rel: '0' })
+	const playlistId = options?.playlistId?.trim()
+	if (playlistId && isYoutubePlaylistId(playlistId)) {
+		params.set('listType', 'playlist')
+		params.set('list', playlistId)
+	}
 	return `https://www.youtube-nocookie.com/embed/${videoId}?${params.toString()}`
 }
 

--- a/tools/local-origin-dev-config.node.test.ts
+++ b/tools/local-origin-dev-config.node.test.ts
@@ -19,6 +19,17 @@ test('keeps an explicit APP_BASE_URL and does not invent Cloudflare vars', () =>
 	})
 })
 
+test('copies SIGNUP_MODE so local vite can override the Wrangler default', () => {
+	expect(
+		collectLocalOriginDevVars({
+			SIGNUP_MODE: 'open',
+		}),
+	).toEqual({
+		WRANGLER_IS_LOCAL_DEV: 'true',
+		SIGNUP_MODE: 'open',
+	})
+})
+
 test('does not serialize Worker secrets or a live Cloudflare token', () => {
 	expect(
 		collectLocalOriginDevVars({

--- a/tools/local-origin-dev-config.ts
+++ b/tools/local-origin-dev-config.ts
@@ -11,6 +11,7 @@ export const localOriginDevVarKeys = [
 	'CLOUDFLARE_ACCOUNT_ID',
 	'CLOUDFLARE_API_SOURCE_SNAPSHOTS',
 	'APP_BASE_URL',
+	'SIGNUP_MODE',
 ] as const
 
 /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Ship the public homepage hero as a two-column fold: headline and CTAs on the left, a first-party lite YouTube demo player plus thumbnail chooser on the right, with the host-agent lantern stage underneath.

## Why

Visitors should be able to watch a Kody demo without leaving `/`, pick another video from the same playlist strip, and do that with keyboard and screen-reader support. The previous hero put the agent stage first and had no in-fold demo player.

## Summary

- Rebases Kent's `homepage-hero-video-chooser` onto current `main` (open signup, tools-strip, and testimonial commits).
- Homepage hero is now `landing-hero-top` (H1 + Create-account / copy-prompt CTAs beside `LandingHeroVideo`) with `LandingHeroAgents` below that row.
- New shared `YouTubeLightPlayer` (poster + play, then youtube-nocookie embed). The site-wide `/?youtubeId=` overlay reuses it.
- Hero chooser is a single-tab-stop listbox: arrows wrap and scroll, Enter/Space/click swaps the video and starts it, focus moves to the player.
- Watch allowlist always includes `landingHeroDemoVideoIds` so first-party `/youtube-thumb/` works without extra env.
- Embeds pass `landingHeroDemoPlaylistId` so end-of-video recommendations stay in the Kody playlist.
- Rebase kept main's open signup: the hero CTA is always **Create a free account** (no waitlist branch).
- Follow-up: honor `autoplay` when the already-selected thumbnail is chosen (Bugbot + CodeRabbit).

## Testing

- [x] `npm run validate` (authoritative local gate) — passed on the rebased branch
- [x] Focused: homepage hero SSR, chooser keyboard helpers, lite player, YouTube allowlist
- [x] Preview HTML (`https://kody-pr-2212.kody-a99.workers.dev`): anonymous `/` has two-column hero, poster (no embed), 4 listbox options, Create-account CTA
- [x] Preview HTML: signed-in `/` hides hero CTAs, still shows player + chooser + agents
- [x] Preview HTML: `/?youtubeId=QA0xYMAMjEg` still uses the shared lite player overlay
- [ ] Preview UI pass after the autoplay fix deploy

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `0ca0869` · **Head:** `7dfb427`

**Classification:** extends — homepage `app-ui` hero layout, shared lite player, and watch-allowlist extras change. No new primitive.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `app-ui` | surfaces | extends — two-column hero, `LandingHeroVideo` listbox, extracted `YouTubeLightPlayer`, allowlist always includes hero demo ids |

Unmatched paths: `packages/worker/public/styles.css` (hero/chooser CSS for `app-ui`), `packages/worker/.env.example` and `tools/local-origin-dev-config.ts` (local `SIGNUP_MODE` override leftover from the pre-open-signup base, not a new primitive).

### Change flow

Anonymous `/` SSR paints the two-column hero with a poster and first-party thumbs. Choosing a video (or clicking play) swaps in the privacy-enhanced embed.

```mermaid
sequenceDiagram
	actor Visitor
	participant appUi as app-ui
	Visitor->>appUi: GET /
	appUi-->>Visitor: landing-hero-top with poster and listbox thumbs
	Note over appUi: allowlist always includes landingHeroDemoVideoIds so /youtube-thumb works
	Visitor->>appUi: click play or choose a thumbnail
	appUi-->>Visitor: youtube-nocookie embed, focus moves to the player
```

### Before / after

**Hero fold**

```
before: H1 → LandingHeroAgents → CTAs
after:  landing-hero-top (H1 + CTAs | LandingHeroVideo) → LandingHeroAgents
```

**YouTube player**

```
before: poster/embed markup lived only in youtube-watch-overlay
after:  YouTubeLightPlayer shared by overlay and homepage hero
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e86dfdf9-7158-42f6-8f1b-d359d52f4483?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e86dfdf9-7158-42f6-8f1b-d359d52f4483&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a video-led landing page hero with responsive layout, thumbnails, titles, keyboard navigation, and accessible selection controls.
  - Added lightweight YouTube playback with poster images, privacy-enhanced embeds, click-to-play behavior, and optional playlists.
  - Added multiple selectable demo videos with scrolling controls and improved playback transitions.

- **Documentation**
  - Documented local signup-mode overrides for development environments.

- **Tests**
  - Added coverage for video selection, accessibility, overflow behavior, playback, playlists, and signup-mode configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->