### PR TITLE
Hide webhook URL secrets from model-visible tool output

### DIFF
--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -1363,13 +1363,15 @@ on write unless a migration backfills existing rows.
   invocation replay lives in the RunLog Durable Object ledger (see
   [Run records](./run-records.md)); the current D1 schema has no
   `package_invocations` table.
-- `webhook_endpoints` (`0001-squashed-init.sql`) stores per-user minted URL
-  state for `package.json#kody.webhooks`, keyed by
-  `(user_id, package_id, webhook_name)`. URL secrets are SHA-256 hashed;
-  verification secrets stay in the secrets primitive (`secretName` at delivery
-  time). Delivery history is recorded as `webhook` surface run records (see
-  [Run records](./run-records.md) and [Inbound webhooks](./webhooks.md)), not as
-  D1 rows.
+- `webhook_endpoints` (`0001-squashed-init.sql`,
+  `0057-webhook-url-secret-encrypted.sql`) stores per-user minted URL state for
+  `package.json#kody.webhooks`, keyed by `(user_id, package_id, webhook_name)`.
+  URL secrets are SHA-256 hashed for ingress and AES-GCM encrypted
+  (`url_secret_encrypted`) for server-side apply. MCP capabilities never return
+  the plaintext URL. Verification secrets stay in the secrets primitive
+  (`secretName` at delivery time). Delivery history is recorded as `webhook`
+  surface run records (see [Run records](./run-records.md) and
+  [Inbound webhooks](./webhooks.md)), not as D1 rows.
 - `system_email_daily_counters` (`0001-squashed-init.sql`) stores fixed
   per-local daily receive counters for operator-owned system inboxes. These
   counters are not user entitlements and are pruned by the system-email

--- a/docs/contributing/architecture/webhooks.md
+++ b/docs/contributing/architecture/webhooks.md
@@ -135,13 +135,20 @@ consumer's 15-minute wall-clock limit before later messages are acknowledged.
   re-scopes by the owning user.
 - Account deletion/export include `webhook_endpoints` (minted URL state).
   Delivery history lives in run records and is covered with the rest of `RunLog`
-  export/deletion. Export redacts `url_secret_hash`.
+  export/deletion. Export redacts `url_secret_hash` and `url_secret_encrypted`.
 - Plaintext URL secrets and verification secrets are never logged. URL secrets
-  are hashed; verification secrets stay in the secrets primitive.
+  are hashed for ingress and stored encrypted for `webhookUrlApply`. MCP mint,
+  rotate, list, and apply never return the credential URL. Verification secrets
+  stay in the secrets primitive.
 
 ## Storage
 
 Minted endpoint state lives in the D1 `webhook_endpoints` table defined by
-`packages/worker/migrations/0001-squashed-init.sql`. Delivery history is in the
-per-user `RunLog` Durable Object (`webhook` surface), not in D1. See
+`packages/worker/migrations/0001-squashed-init.sql`, with `url_secret_encrypted`
+added in `0057-webhook-url-secret-encrypted.sql`. `webhookUrlMint` /
+`webhookUrlRotate` return an opaque `handle` (`whh_<id>`) and `url_host`.
+`webhookUrlApply` resolves the handle inside Kody, substitutes `{{webhookUrl}}`
+(or a first-class GitHub helper), and calls the destination through a user
+integration or host-approved secret. Delivery history is in the per-user
+`RunLog` Durable Object (`webhook` surface), not in D1. See
 [Data storage](./data-storage.md) and [Run records](./run-records.md).

--- a/docs/contributing/architecture/webhooks.md
+++ b/docs/contributing/architecture/webhooks.md
@@ -147,8 +147,10 @@ Minted endpoint state lives in the D1 `webhook_endpoints` table defined by
 `packages/worker/migrations/0001-squashed-init.sql`, with `url_secret_encrypted`
 added in `0057-webhook-url-secret-encrypted.sql`. `webhookUrlMint` /
 `webhookUrlRotate` return an opaque `handle` (`whh_<id>`) and `url_host`.
-`webhookUrlApply` resolves the handle inside Kody, substitutes `{{webhookUrl}}`
-(or a first-class GitHub helper), and calls the destination through a user
-integration or host-approved secret. Delivery history is in the per-user
-`RunLog` Durable Object (`webhook` surface), not in D1. See
-[Data storage](./data-storage.md) and [Run records](./run-records.md).
+`webhookUrlApply` resolves the handle inside Kody and registers the URL through
+a first-class destination adapter (GitHub repository hooks via the user GitHub
+integration or a host-approved GitHub token). The credential is injected into
+the provider API field; apply does not accept an arbitrary outbound URL.
+Delivery history is in the per-user `RunLog` Durable Object (`webhook` surface),
+not in D1. See [Data storage](./data-storage.md) and
+[Run records](./run-records.md).

--- a/docs/contributing/package-invocation-api.md
+++ b/docs/contributing/package-invocation-api.md
@@ -240,7 +240,7 @@ curl --fail --silent \
 ```
 
 New first-party callers declare one webhook per export (`inputMode: "params"`),
-mint a URL with `webhookUrlMint`, and send `Idempotency-Key`. There is no `*`
+mint a handle with `webhookUrlMint`, and send `Idempotency-Key`. There is no `*`
 webhook. See [Inbound webhooks](../use/webhooks.md).
 
 ## Related

--- a/docs/guides/account-package-invocation-token-setup.md
+++ b/docs/guides/account-package-invocation-token-setup.md
@@ -27,5 +27,5 @@ Discord gateways, YouTube WebSub, Raycast extensions, and social-launch clients
 mint one webhook URL per export and POST JSON. Vendor HMAC handlers stay on
 `inputMode: "request"`.
 
-See [Inbound webhooks](../use/webhooks.md). `webhookUrlMint` returns the
-credential URL once. Do not create new invocation tokens.
+See [Inbound webhooks](../use/webhooks.md). `webhookUrlMint` returns a `handle`;
+register the URL with `webhookUrlApply`. Do not create new invocation tokens.

--- a/docs/guides/triggers.md
+++ b/docs/guides/triggers.md
@@ -103,8 +103,9 @@ Kody dispatches the validated request to the package export that owns it.
    and the **name** of the signing secret in your secret store. One webhook name
    binds one export; there is no wildcard.
 2. Store the signing secret with `secretSet` under that name.
-3. Mint the URL with `webhookUrlMint` and paste it into the provider. The URL
-   secret is returned only on mint or rotate — treat the URL as a credential.
+3. Mint the URL with `webhookUrlMint` (returns a `handle`, not the credential)
+   and register it with `webhookUrlApply`. Treat the URL as a credential; tool
+   output never includes it.
 
 Declaring a webhook does not open ingress; minting does. Deliveries are
 rate-limited per webhook (default 60 per minute, at most 600), and body-only

--- a/docs/use/packages.md
+++ b/docs/use/packages.md
@@ -223,8 +223,9 @@ Person-owned packages must not import a platform scope; `communityFork` first.
 
 There is no author-facing `packages.invoke`. External trusted clients that must
 call a named export over HTTP use inbound webhooks: declare one webhook per
-export, mint a URL with `webhookUrlMint`, and POST JSON (`inputMode: "params"`
-and `Idempotency-Key` for first-party clients). See
+export, mint a handle with `webhookUrlMint`, register it with `webhookUrlApply`
+when a provider needs the URL, and POST JSON (`inputMode: "params"` and
+`Idempotency-Key` for first-party clients). See
 [Inbound webhooks](./webhooks.md).
 
 Scoped resolution is exact: `kody:@kentcdodds/google` selects the caller's
@@ -446,7 +447,8 @@ payloads and the distinction between live HEAD and package publish.
 
 Inbound HTTP webhooks are declared under `package.json#kody.webhooks` and bound
 to a package export. Declaring a webhook does not open ingress — mint a URL with
-`webhookUrlMint` first. Full contract, signature examples, and payload shape:
+`webhookUrlMint` first, then `webhookUrlApply` to register the URL. Full
+contract, signature examples, and payload shape:
 [Inbound webhooks](./webhooks.md).
 
 ## Package-owned jobs

--- a/docs/use/packages.md
+++ b/docs/use/packages.md
@@ -447,9 +447,9 @@ payloads and the distinction between live HEAD and package publish.
 
 Inbound HTTP webhooks are declared under `package.json#kody.webhooks` and bound
 to a package export. Declaring a webhook does not open ingress — mint a URL with
-`webhookUrlMint` first, then `webhookUrlApply` to register the URL. Full
-contract, signature examples, and payload shape:
-[Inbound webhooks](./webhooks.md).
+`webhookUrlMint` first, then `webhookUrlApply` to register a first-class
+destination (GitHub repository hooks). Full contract, signature examples, and
+payload shape: [Inbound webhooks](./webhooks.md).
 
 ## Package-owned jobs
 

--- a/docs/use/webhooks.md
+++ b/docs/use/webhooks.md
@@ -13,8 +13,10 @@ are an unadvertised drain; new callers use webhooks.
 
 There is no `*` / multi-export URL. One declared webhook name binds one export.
 
-Treat every minted URL as a **credential**. The URL secret is returned only on
-mint/rotate and is never stored in plaintext.
+Treat every minted URL as a **credential**. Mint and rotate return an opaque
+`handle` (and `url_host`), never the URL or `url_secret`. Register the URL with
+`webhookUrlApply` so the credential stays inside Kody. MCP and execute never
+return the URL.
 
 ## Declare a webhook in the package manifest
 
@@ -77,13 +79,60 @@ Use the MCP `webhooks` domain:
 2. Store the HMAC secret with `secretSet` under the name used in
    `verification.secretName` (for example `sentryWebhookSecret`).
 3. Call `webhookUrlMint` with the package id/kody id and `webhookName`.
-4. Store the returned `url` immediately and paste it into the provider.
+4. Call `webhookUrlApply` with the returned `handle` and a destination (`github`
+   helper or generic `https` with `{{webhookUrl}}` substituted server-side). Use
+   a connected integration or a host-approved token secret.
 
-Other capabilities: `webhookList` (declarations joined with minted/enabled
-state), `webhookUrlRotate`, `webhookEnable`, `webhookDisable`, and
+Other capabilities: `webhookList` (declarations joined with minted handle /
+enabled state), `webhookUrlRotate`, `webhookEnable`, `webhookDisable`, and
 `webhookDeliveryList` (metadata only; bodies are never stored). The same
 delivery history also appears under [Activity](./activity.md)
-(`/account/activity` and the `runs` capabilities).
+(`/account/activity` and the `runs` capabilities). List, mint, rotate, and apply
+never return the credential URL.
+
+### Apply a handle to a destination
+
+`webhookUrlApply` resolves the handle inside Kody and registers the URL. The
+model never sees the secret.
+
+GitHub (first-class helper — creates `POST /repos/{owner}/{repo}/hooks`):
+
+```ts
+await kody.webhooks.webhookUrlApply({
+	handle,
+	destination: {
+		type: 'github',
+		owner: 'acme',
+		repo: 'api',
+		events: ['push', 'pull_request'],
+		integration: 'github',
+	},
+})
+```
+
+Generic HTTPS (must include `{{webhookUrl}}` in `url`, `headers`, or `body`).
+Authorize with a connected integration or a host-approved secret — not a raw
+unauthenticated POST:
+
+```ts
+await kody.webhooks.webhookUrlApply({
+	handle,
+	destination: {
+		type: 'https',
+		integration: 'github',
+		url: 'https://api.github.com/repos/acme/api/hooks',
+		headers: { Accept: 'application/vnd.github+json' },
+		body: JSON.stringify({
+			name: 'web',
+			config: { url: '{{webhookUrl}}', content_type: 'json' },
+			events: ['push'],
+		}),
+	},
+})
+```
+
+Returns `{ ok, url_host, http_status, remote_id, error }`. Remote bodies that
+echo the hook URL are stripped.
 
 ## Ingress URL
 
@@ -260,7 +309,8 @@ webhook declaration per export.
 Republishing a package that removes or renames a webhook deactivates that
 ingress (unknown name → 404). Disable with `webhookDisable` without deleting the
 mint; re-enable with `webhookEnable`. Rotate the URL secret with
-`webhookUrlRotate` when a credential may have leaked.
+`webhookUrlRotate` when a credential may have leaked, then call
+`webhookUrlApply` again with the same handle so providers get the new URL.
 
 ## Related
 

--- a/docs/use/webhooks.md
+++ b/docs/use/webhooks.md
@@ -79,9 +79,9 @@ Use the MCP `webhooks` domain:
 2. Store the HMAC secret with `secretSet` under the name used in
    `verification.secretName` (for example `sentryWebhookSecret`).
 3. Call `webhookUrlMint` with the package id/kody id and `webhookName`.
-4. Call `webhookUrlApply` with the returned `handle` and a destination (`github`
-   helper or generic `https` with `{{webhookUrl}}` substituted server-side). Use
-   a connected integration or a host-approved token secret.
+4. Call `webhookUrlApply` with the returned `handle` and a first-class
+   destination. GitHub repository hooks use the connected `github` integration
+   (or a host-approved GitHub token).
 
 Other capabilities: `webhookList` (declarations joined with minted handle /
 enabled state), `webhookUrlRotate`, `webhookEnable`, `webhookDisable`, and
@@ -92,10 +92,12 @@ never return the credential URL.
 
 ### Apply a handle to a destination
 
-`webhookUrlApply` resolves the handle inside Kody and registers the URL. The
-model never sees the secret.
+`webhookUrlApply` resolves the handle inside Kody and registers the URL through
+a first-class destination adapter. The model never sees the secret. Apply does
+not accept an arbitrary outbound URL: substituting the credential into a
+caller-chosen request would let the model exfiltrate it.
 
-GitHub (first-class helper — creates `POST /repos/{owner}/{repo}/hooks`):
+GitHub (creates `POST /repos/{owner}/{repo}/hooks` on `api.github.com`):
 
 ```ts
 await kody.webhooks.webhookUrlApply({
@@ -110,26 +112,10 @@ await kody.webhooks.webhookUrlApply({
 })
 ```
 
-Generic HTTPS (must include `{{webhookUrl}}` in `url`, `headers`, or `body`).
-Authorize with a connected integration or a host-approved secret — not a raw
-unauthenticated POST:
-
-```ts
-await kody.webhooks.webhookUrlApply({
-	handle,
-	destination: {
-		type: 'https',
-		integration: 'github',
-		url: 'https://api.github.com/repos/acme/api/hooks',
-		headers: { Accept: 'application/vnd.github+json' },
-		body: JSON.stringify({
-			name: 'web',
-			config: { url: '{{webhookUrl}}', content_type: 'json' },
-			events: ['push'],
-		}),
-	},
-})
-```
+Authorize with the user's GitHub OAuth integration (default `github`) or a
+host-approved GitHub token (`secretName`). Additional vendor adapters can follow
+the same pattern (known host + known API). Other providers still POST to the
+minted ingress URL; apply does not register them.
 
 Returns `{ ok, url_host, http_status, remote_id, error }`. Remote bodies that
 echo the hook URL are stripped.

--- a/packages/worker/migrations/0057-webhook-url-secret-encrypted.sql
+++ b/packages/worker/migrations/0057-webhook-url-secret-encrypted.sql
@@ -1,0 +1,3 @@
+-- Store the minted URL secret encrypted so webhookUrlApply (and website-only
+-- reveal) can consume it without returning the credential to the model.
+ALTER TABLE webhook_endpoints ADD COLUMN url_secret_encrypted TEXT;

--- a/packages/worker/src/account/data-targets.node.test.ts
+++ b/packages/worker/src/account/data-targets.node.test.ts
@@ -193,6 +193,9 @@ test('every accountUserDataTargets kind has a shared match builder and export gu
 	expect(accountExportRedactedColumnsByTable.user_oauth_apps).toEqual(
 		expect.arrayContaining(['client_secret_encrypted']),
 	)
+	expect(accountExportRedactedColumnsByTable.webhook_endpoints).toEqual(
+		expect.arrayContaining(['url_secret_hash', 'url_secret_encrypted']),
+	)
 	expect(
 		accountExportForeignUserIdColumnsByTable.community_activity_events,
 	).toEqual(expect.arrayContaining(['actor_user_id']))

--- a/packages/worker/src/account/data-targets.ts
+++ b/packages/worker/src/account/data-targets.ts
@@ -774,7 +774,7 @@ export const accountExportRedactedColumnsByTable: Readonly<
 	user_oauth_apps: ['client_secret_encrypted'],
 	users: ['password_hash'],
 	verifications: ['secret'],
-	webhook_endpoints: ['url_secret_hash'],
+	webhook_endpoints: ['url_secret_hash', 'url_secret_encrypted'],
 }
 
 // Cross-user export rows can include another user's stable id. Keep the

--- a/packages/worker/src/mcp/capabilities/webhooks/domain.ts
+++ b/packages/worker/src/mcp/capabilities/webhooks/domain.ts
@@ -4,12 +4,14 @@ import { webhookDeliveryListCapability } from './webhook-delivery-list.ts'
 import { webhookDisableCapability } from './webhook-disable.ts'
 import { webhookEnableCapability } from './webhook-enable.ts'
 import { webhookListCapability } from './webhook-list.ts'
+import { webhookUrlApplyCapability } from './webhook-url-apply.ts'
 import { webhookUrlMintCapability } from './webhook-url-mint.ts'
 import { webhookUrlRotateCapability } from './webhook-url-rotate.ts'
 
 export const webhooksDomain = defineDomain({
 	name: capabilityDomainNames.webhooks,
-	description: 'Package-declared inbound webhooks with minted credential URLs.',
+	description:
+		'Package-declared inbound webhooks with minted handles. Register destinations with webhookUrlApply — credential URLs never appear in tool output.',
 	keywords: [
 		'webhook',
 		'inbound',
@@ -21,11 +23,13 @@ export const webhooksDomain = defineDomain({
 		'signature',
 		'hmac',
 		'mint',
+		'apply',
 	],
 	capabilities: [
 		webhookListCapability,
 		webhookUrlMintCapability,
 		webhookUrlRotateCapability,
+		webhookUrlApplyCapability,
 		webhookEnableCapability,
 		webhookDisableCapability,
 		webhookDeliveryListCapability,

--- a/packages/worker/src/mcp/capabilities/webhooks/domain.ts
+++ b/packages/worker/src/mcp/capabilities/webhooks/domain.ts
@@ -11,7 +11,7 @@ import { webhookUrlRotateCapability } from './webhook-url-rotate.ts'
 export const webhooksDomain = defineDomain({
 	name: capabilityDomainNames.webhooks,
 	description:
-		'Package-declared inbound webhooks with minted handles. Register destinations with webhookUrlApply — credential URLs never appear in tool output.',
+		'Package-declared inbound webhooks with minted handles. Register first-class destinations with webhookUrlApply — credential URLs never appear in tool output.',
 	keywords: [
 		'webhook',
 		'inbound',

--- a/packages/worker/src/mcp/capabilities/webhooks/shared.ts
+++ b/packages/worker/src/mcp/capabilities/webhooks/shared.ts
@@ -50,6 +50,16 @@ export const listedWebhookSchema = z.object({
 	minted: z
 		.boolean()
 		.describe('True when a URL secret has been minted for this webhook.'),
+	handle: z
+		.string()
+		.nullable()
+		.describe(
+			'Opaque handle for webhookUrlApply. Null when not minted. Never a credential.',
+		),
+	url_host: z
+		.string()
+		.nullable()
+		.describe('Public hostname of the ingress origin. Null when not minted.'),
 	enabled: z
 		.boolean()
 		.nullable()
@@ -58,23 +68,29 @@ export const listedWebhookSchema = z.object({
 	rotated_at: z.string().nullable(),
 })
 
-export const mintedWebhookUrlSchema = z.object({
+export const mintedWebhookHandleSchema = z.object({
 	package_id: z.string(),
 	package_kody_id: z.string(),
 	name: z.string(),
-	url: z
+	handle: z
 		.string()
 		.describe(
-			'Full ingress URL including the URL secret. Treat as a credential; shown only on mint/rotate.',
+			'Opaque handle for webhookUrlApply. Does not contain the URL secret.',
 		),
-	url_secret: z
+	url_host: z
 		.string()
-		.describe(
-			'URL path secret. Shown only on mint/rotate; never retrievable later.',
-		),
+		.describe('Public hostname of the ingress origin (no path or secret).'),
 	enabled: z.boolean(),
 	created_at: z.string(),
 	rotated_at: z.string(),
+})
+
+export const webhookUrlApplyResultSchema = z.object({
+	ok: z.boolean(),
+	url_host: z.string(),
+	http_status: z.number().int(),
+	remote_id: z.string().nullable(),
+	error: z.string().nullable(),
 })
 
 export const webhookDeliverySchema = z.object({
@@ -110,6 +126,8 @@ export function toListedWebhookCapability(webhook: {
 	verification: z.infer<typeof webhookVerificationPublicSchema>
 	replay?: z.infer<typeof webhookReplayPublicSchema>
 	minted: boolean
+	handle: string | null
+	urlHost: string | null
 	enabled: boolean | null
 	createdAt: string | null
 	rotatedAt: string | null
@@ -127,6 +145,8 @@ export function toListedWebhookCapability(webhook: {
 		verification: webhook.verification,
 		replay: webhook.replay ?? null,
 		minted: webhook.minted,
+		handle: webhook.handle,
+		url_host: webhook.urlHost,
 		enabled: webhook.enabled,
 		created_at: webhook.createdAt,
 		rotated_at: webhook.rotatedAt,
@@ -137,8 +157,8 @@ export function toMintedWebhookCapability(minted: {
 	packageId: string
 	packageKodyId: string
 	name: string
-	url: string
-	urlSecret: string
+	handle: string
+	urlHost: string
 	enabled: boolean
 	createdAt: string
 	rotatedAt: string
@@ -147,11 +167,27 @@ export function toMintedWebhookCapability(minted: {
 		package_id: minted.packageId,
 		package_kody_id: minted.packageKodyId,
 		name: minted.name,
-		url: minted.url,
-		url_secret: minted.urlSecret,
+		handle: minted.handle,
+		url_host: minted.urlHost,
 		enabled: minted.enabled,
 		created_at: minted.createdAt,
 		rotated_at: minted.rotatedAt,
+	}
+}
+
+export function toAppliedWebhookCapability(applied: {
+	ok: boolean
+	urlHost: string
+	httpStatus: number
+	remoteId: string | null
+	error: string | null
+}) {
+	return {
+		ok: applied.ok,
+		url_host: applied.urlHost,
+		http_status: applied.httpStatus,
+		remote_id: applied.remoteId,
+		error: applied.error,
 	}
 }
 

--- a/packages/worker/src/mcp/capabilities/webhooks/webhook-capabilities.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/webhooks/webhook-capabilities.node.test.ts
@@ -5,6 +5,7 @@ const mockModule = vi.hoisted(() => ({
 	listWebhooksForUser: vi.fn(),
 	mintWebhookUrlForUser: vi.fn(),
 	rotateWebhookUrlForUser: vi.fn(),
+	applyWebhookUrlForUser: vi.fn(),
 	setWebhookEnabledForUser: vi.fn(),
 	resolveSavedPackage: vi.fn(),
 	getWebhookEndpointByKey: vi.fn(),
@@ -18,6 +19,8 @@ vi.mock('#worker/webhooks/service.ts', () => ({
 		mockModule.mintWebhookUrlForUser(...args),
 	rotateWebhookUrlForUser: (...args: Array<unknown>) =>
 		mockModule.rotateWebhookUrlForUser(...args),
+	applyWebhookUrlForUser: (...args: Array<unknown>) =>
+		mockModule.applyWebhookUrlForUser(...args),
 	setWebhookEnabledForUser: (...args: Array<unknown>) =>
 		mockModule.setWebhookEnabledForUser(...args),
 }))
@@ -42,6 +45,7 @@ const { webhookUrlMintCapability } = await import('./webhook-url-mint.ts')
 const { webhookUrlRotateCapability } = await import('./webhook-url-rotate.ts')
 const { webhookEnableCapability } = await import('./webhook-enable.ts')
 const { webhookDisableCapability } = await import('./webhook-disable.ts')
+const { webhookUrlApplyCapability } = await import('./webhook-url-apply.ts')
 const { webhookDeliveryListCapability } =
 	await import('./webhook-delivery-list.ts')
 
@@ -79,6 +83,8 @@ test('webhook capabilities expose mint once and never leak secrets on list', asy
 				encoding: 'hex',
 			},
 			minted: true,
+			handle: 'whh_ep-1',
+			urlHost: 'heykody.dev',
 			enabled: true,
 			createdAt: '2026-07-24T00:00:00.000Z',
 			rotatedAt: '2026-07-24T00:00:00.000Z',
@@ -88,8 +94,8 @@ test('webhook capabilities expose mint once and never leak secrets on list', asy
 		packageId: 'pkg-1',
 		packageKodyId: 'sentry-bridge',
 		name: 'sentry',
-		url: 'https://heykody.dev/@user/webhooks/sentry-bridge/sentry/secret-once',
-		urlSecret: 'secret-once',
+		handle: 'whh_ep-1',
+		urlHost: 'heykody.dev',
 		enabled: true,
 		createdAt: '2026-07-24T00:00:00.000Z',
 		rotatedAt: '2026-07-24T00:00:00.000Z',
@@ -98,8 +104,8 @@ test('webhook capabilities expose mint once and never leak secrets on list', asy
 		packageId: 'pkg-1',
 		packageKodyId: 'sentry-bridge',
 		name: 'sentry',
-		url: 'https://heykody.dev/@user/webhooks/sentry-bridge/sentry/new-secret',
-		urlSecret: 'new-secret',
+		handle: 'whh_ep-1',
+		urlHost: 'heykody.dev',
 		enabled: true,
 		createdAt: '2026-07-24T00:00:00.000Z',
 		rotatedAt: '2026-07-24T01:00:00.000Z',
@@ -170,19 +176,53 @@ test('webhook capabilities expose mint once and never leak secrets on list', asy
 	const ctx = createCapabilityContext()
 	const listed = await webhookListCapability.handler({}, ctx)
 	expect(listed.webhooks[0]?.minted).toBe(true)
+	expect(listed.webhooks[0]?.handle).toBe('whh_ep-1')
 	expect(JSON.stringify(listed)).not.toContain('secret-once')
 
 	const minted = await webhookUrlMintCapability.handler(
 		{ kodyId: 'sentry-bridge', webhookName: 'sentry' },
 		ctx,
 	)
-	expect(minted.webhook.url_secret).toBe('secret-once')
+	expect(minted.webhook.handle).toBe('whh_ep-1')
+	expect(minted.webhook.url_host).toBe('heykody.dev')
+	expect(minted.webhook).not.toHaveProperty('url')
+	expect(minted.webhook).not.toHaveProperty('url_secret')
 
 	const rotated = await webhookUrlRotateCapability.handler(
 		{ kodyId: 'sentry-bridge', webhookName: 'sentry' },
 		ctx,
 	)
-	expect(rotated.webhook.url_secret).toBe('new-secret')
+	expect(rotated.webhook.handle).toBe('whh_ep-1')
+	expect(rotated.webhook).not.toHaveProperty('url_secret')
+
+	mockModule.applyWebhookUrlForUser.mockResolvedValue({
+		ok: true,
+		urlHost: 'heykody.dev',
+		httpStatus: 201,
+		remoteId: '4242',
+		error: null,
+	})
+	await expect(
+		webhookUrlApplyCapability.handler(
+			{
+				handle: 'whh_ep-1',
+				destination: { type: 'github', owner: 'acme', repo: 'api' },
+			},
+			ctx,
+		),
+	).resolves.toEqual({
+		ok: true,
+		url_host: 'heykody.dev',
+		http_status: 201,
+		remote_id: '4242',
+		error: null,
+	})
+	expect(mockModule.applyWebhookUrlForUser).toHaveBeenCalledWith(
+		expect.objectContaining({
+			handle: 'whh_ep-1',
+			destination: { type: 'github', owner: 'acme', repo: 'api' },
+		}),
+	)
 
 	await expect(
 		webhookDisableCapability.handler(

--- a/packages/worker/src/mcp/capabilities/webhooks/webhook-capabilities.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/webhooks/webhook-capabilities.node.test.ts
@@ -238,6 +238,13 @@ test('webhook capabilities expose mint once and never leak secrets on list', asy
 			repo: 'api',
 		}).success,
 	).toBe(true)
+	expect(
+		webhookUrlApplyDestinationSchema.safeParse({
+			type: 'github',
+			owner: '..',
+			repo: 'api',
+		}).success,
+	).toBe(false)
 
 	await expect(
 		webhookDisableCapability.handler(

--- a/packages/worker/src/mcp/capabilities/webhooks/webhook-capabilities.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/webhooks/webhook-capabilities.node.test.ts
@@ -45,7 +45,8 @@ const { webhookUrlMintCapability } = await import('./webhook-url-mint.ts')
 const { webhookUrlRotateCapability } = await import('./webhook-url-rotate.ts')
 const { webhookEnableCapability } = await import('./webhook-enable.ts')
 const { webhookDisableCapability } = await import('./webhook-disable.ts')
-const { webhookUrlApplyCapability } = await import('./webhook-url-apply.ts')
+const { webhookUrlApplyCapability, webhookUrlApplyDestinationSchema } =
+	await import('./webhook-url-apply.ts')
 const { webhookDeliveryListCapability } =
 	await import('./webhook-delivery-list.ts')
 
@@ -223,6 +224,20 @@ test('webhook capabilities expose mint once and never leak secrets on list', asy
 			destination: { type: 'github', owner: 'acme', repo: 'api' },
 		}),
 	)
+	expect(
+		webhookUrlApplyDestinationSchema.safeParse({
+			type: 'https',
+			url: 'https://attacker.example/exfil',
+			body: '{"url":"{{webhookUrl}}"}',
+		}).success,
+	).toBe(false)
+	expect(
+		webhookUrlApplyDestinationSchema.safeParse({
+			type: 'github',
+			owner: 'acme',
+			repo: 'api',
+		}).success,
+	).toBe(true)
 
 	await expect(
 		webhookDisableCapability.handler(

--- a/packages/worker/src/mcp/capabilities/webhooks/webhook-list.ts
+++ b/packages/worker/src/mcp/capabilities/webhooks/webhook-list.ts
@@ -10,7 +10,7 @@ export const webhookListCapability = defineDomainCapability(
 	{
 		name: 'webhookList',
 		description:
-			"List package.json#kody.webhooks declarations across the signed-in user's saved packages, joined with minted URL / enabled state. Declaring a webhook does not open ingress until webhookUrlMint is called. URL secrets are never returned.",
+			"List package.json#kody.webhooks declarations across the signed-in user's saved packages, joined with minted handle / enabled state. Declaring a webhook does not open ingress until webhookUrlMint is called. URL secrets and credential URLs are never returned.",
 		keywords: [
 			'webhook',
 			'list',

--- a/packages/worker/src/mcp/capabilities/webhooks/webhook-url-apply.ts
+++ b/packages/worker/src/mcp/capabilities/webhooks/webhook-url-apply.ts
@@ -2,12 +2,8 @@ import { z } from 'zod'
 import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
-import {
-	webhookUrlApplyGithubContentTypes,
-	webhookUrlApplyHttpsMethods,
-} from '#worker/webhooks/apply.ts'
+import { webhookUrlApplyGithubContentTypes } from '#worker/webhooks/apply.ts'
 import { applyWebhookUrlForUser } from '#worker/webhooks/service.ts'
-import { webhookUrlPlaceholder } from '#worker/webhooks/redact.ts'
 import {
 	toAppliedWebhookCapability,
 	webhookUrlApplyResultSchema,
@@ -18,37 +14,7 @@ const githubSlugSchema = z
 	.min(1)
 	.regex(/^[A-Za-z0-9_.-]+$/, 'Must be a GitHub owner or repository slug.')
 
-const httpsDestinationSchema = z.object({
-	type: z.literal('https'),
-	url: z
-		.string()
-		.url()
-		.describe(
-			`Destination URL. Include ${webhookUrlPlaceholder} here or in headers/body.`,
-		),
-	method: z.enum(webhookUrlApplyHttpsMethods).optional(),
-	headers: z.record(z.string(), z.string()).optional(),
-	body: z
-		.string()
-		.optional()
-		.describe(`Request body. Substitute ${webhookUrlPlaceholder} server-side.`),
-	integration: z
-		.string()
-		.min(1)
-		.optional()
-		.describe(
-			'OAuth integration name for Authorization. Mutually exclusive with secretName.',
-		),
-	secretName: z
-		.string()
-		.min(1)
-		.optional()
-		.describe(
-			'Host-approved secret used as a Bearer token. Mutually exclusive with integration.',
-		),
-})
-
-const githubDestinationSchema = z.object({
+export const webhookUrlApplyDestinationSchema = z.object({
 	type: z.literal('github'),
 	owner: githubSlugSchema,
 	repo: githubSlugSchema,
@@ -83,13 +49,12 @@ export const webhookUrlApplyCapability = defineDomainCapability(
 	{
 		name: 'webhookUrlApply',
 		description:
-			'Register a minted webhook URL at a destination without exposing the credential. Pass the handle from webhookUrlMint, webhookUrlRotate, or webhookList. Use type github for GitHub repo hooks, or type https with {{webhookUrl}} substituted server-side via a user integration or host-approved secret. Returns ok, remote_id, and url_host only.',
+			'Register a minted webhook URL at a first-class destination without exposing the credential. Pass the handle from webhookUrlMint, webhookUrlRotate, or webhookList. Destination type github creates the repo hook via the user GitHub integration (or a host-approved GitHub token) and injects the URL server-side. Returns ok, remote_id, and url_host only.',
 		keywords: [
 			'webhook',
 			'apply',
 			'register',
 			'github',
-			'stripe',
 			'handle',
 			'destination',
 		],
@@ -103,10 +68,7 @@ export const webhookUrlApplyCapability = defineDomainCapability(
 				.describe(
 					'Opaque handle from webhookUrlMint, webhookUrlRotate, or webhookList.',
 				),
-			destination: z.discriminatedUnion('type', [
-				httpsDestinationSchema,
-				githubDestinationSchema,
-			]),
+			destination: webhookUrlApplyDestinationSchema,
 		}),
 		outputSchema: webhookUrlApplyResultSchema,
 		async handler(args, ctx) {

--- a/packages/worker/src/mcp/capabilities/webhooks/webhook-url-apply.ts
+++ b/packages/worker/src/mcp/capabilities/webhooks/webhook-url-apply.ts
@@ -1,0 +1,127 @@
+import { z } from 'zod'
+import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
+import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
+import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
+import {
+	webhookUrlApplyGithubContentTypes,
+	webhookUrlApplyHttpsMethods,
+} from '#worker/webhooks/apply.ts'
+import { applyWebhookUrlForUser } from '#worker/webhooks/service.ts'
+import { webhookUrlPlaceholder } from '#worker/webhooks/redact.ts'
+import {
+	toAppliedWebhookCapability,
+	webhookUrlApplyResultSchema,
+} from './shared.ts'
+
+const githubSlugSchema = z
+	.string()
+	.min(1)
+	.regex(/^[A-Za-z0-9_.-]+$/, 'Must be a GitHub owner or repository slug.')
+
+const httpsDestinationSchema = z.object({
+	type: z.literal('https'),
+	url: z
+		.string()
+		.url()
+		.describe(
+			`Destination URL. Include ${webhookUrlPlaceholder} here or in headers/body.`,
+		),
+	method: z.enum(webhookUrlApplyHttpsMethods).optional(),
+	headers: z.record(z.string(), z.string()).optional(),
+	body: z
+		.string()
+		.optional()
+		.describe(`Request body. Substitute ${webhookUrlPlaceholder} server-side.`),
+	integration: z
+		.string()
+		.min(1)
+		.optional()
+		.describe(
+			'OAuth integration name for Authorization. Mutually exclusive with secretName.',
+		),
+	secretName: z
+		.string()
+		.min(1)
+		.optional()
+		.describe(
+			'Host-approved secret used as a Bearer token. Mutually exclusive with integration.',
+		),
+})
+
+const githubDestinationSchema = z.object({
+	type: z.literal('github'),
+	owner: githubSlugSchema,
+	repo: githubSlugSchema,
+	events: z.array(z.string().min(1)).optional(),
+	contentType: z.enum(webhookUrlApplyGithubContentTypes).optional(),
+	active: z.boolean().optional(),
+	integration: z
+		.string()
+		.min(1)
+		.optional()
+		.describe(
+			'OAuth integration name. Defaults to "github" when secretName is omitted.',
+		),
+	secretName: z
+		.string()
+		.min(1)
+		.optional()
+		.describe(
+			'Host-approved GitHub token secret. Use instead of an OAuth integration.',
+		),
+	hookSecretName: z
+		.string()
+		.min(1)
+		.optional()
+		.describe(
+			'Optional HMAC secret name to set as the GitHub hook secret. Defaults to the package webhook verification.secretName when present.',
+		),
+})
+
+export const webhookUrlApplyCapability = defineDomainCapability(
+	capabilityDomainNames.webhooks,
+	{
+		name: 'webhookUrlApply',
+		description:
+			'Register a minted webhook URL at a destination without exposing the credential. Pass the handle from webhookUrlMint, webhookUrlRotate, or webhookList. Use type github for GitHub repo hooks, or type https with {{webhookUrl}} substituted server-side via a user integration or host-approved secret. Returns ok, remote_id, and url_host only.',
+		keywords: [
+			'webhook',
+			'apply',
+			'register',
+			'github',
+			'stripe',
+			'handle',
+			'destination',
+		],
+		readOnly: false,
+		idempotent: false,
+		destructive: false,
+		inputSchema: z.object({
+			handle: z
+				.string()
+				.min(1)
+				.describe(
+					'Opaque handle from webhookUrlMint, webhookUrlRotate, or webhookList.',
+				),
+			destination: z.discriminatedUnion('type', [
+				httpsDestinationSchema,
+				githubDestinationSchema,
+			]),
+		}),
+		outputSchema: webhookUrlApplyResultSchema,
+		async handler(args, ctx) {
+			const user = requireMcpUser(ctx.callerContext)
+			const applied = await applyWebhookUrlForUser({
+				env: ctx.env,
+				userId: user.userId,
+				email: user.email,
+				username: user.username,
+				handle: args.handle,
+				destination: args.destination,
+				requestUrl: ctx.callerContext.baseUrl,
+				waitUntil: ctx.waitUntil,
+			})
+			return toAppliedWebhookCapability(applied)
+		},
+	},
+)

--- a/packages/worker/src/mcp/capabilities/webhooks/webhook-url-apply.ts
+++ b/packages/worker/src/mcp/capabilities/webhooks/webhook-url-apply.ts
@@ -13,6 +13,10 @@ const githubSlugSchema = z
 	.string()
 	.min(1)
 	.regex(/^[A-Za-z0-9_.-]+$/, 'Must be a GitHub owner or repository slug.')
+	.refine(
+		(value) => value !== '.' && value !== '..',
+		'Must be a GitHub owner or repository slug.',
+	)
 
 export const webhookUrlApplyDestinationSchema = z.object({
 	type: z.literal('github'),

--- a/packages/worker/src/mcp/capabilities/webhooks/webhook-url-mint.ts
+++ b/packages/worker/src/mcp/capabilities/webhooks/webhook-url-mint.ts
@@ -4,7 +4,7 @@ import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
 import { mintWebhookUrlForUser } from '#worker/webhooks/service.ts'
 import {
-	mintedWebhookUrlSchema,
+	mintedWebhookHandleSchema,
 	requirePackageRef,
 	toMintedWebhookCapability,
 	webhookPackageRefSchema,
@@ -15,8 +15,8 @@ export const webhookUrlMintCapability = defineDomainCapability(
 	{
 		name: 'webhookUrlMint',
 		description:
-			'Mint (or remint) the URL secret for a package-declared webhook and return the full ingress URL once. Treat the URL as a credential — it cannot be retrieved later (use webhookUrlRotate). Declaring kody.webhooks alone does not open ingress; minting does.',
-		keywords: ['webhook', 'mint', 'url', 'activate', 'credential', 'inbound'],
+			'Mint (or remint) the URL secret for a package-declared webhook and return an opaque handle plus url_host. The credential URL is never returned — register it with webhookUrlApply. Declaring kody.webhooks alone does not open ingress; minting does.',
+		keywords: ['webhook', 'mint', 'url', 'activate', 'handle', 'inbound'],
 		readOnly: false,
 		idempotent: false,
 		destructive: false,
@@ -41,7 +41,7 @@ export const webhookUrlMintCapability = defineDomainCapability(
 				}
 			}),
 		outputSchema: z.object({
-			webhook: mintedWebhookUrlSchema,
+			webhook: mintedWebhookHandleSchema,
 		}),
 		async handler(args, ctx) {
 			const user = requireMcpUser(ctx.callerContext)

--- a/packages/worker/src/mcp/capabilities/webhooks/webhook-url-rotate.ts
+++ b/packages/worker/src/mcp/capabilities/webhooks/webhook-url-rotate.ts
@@ -4,7 +4,7 @@ import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
 import { rotateWebhookUrlForUser } from '#worker/webhooks/service.ts'
 import {
-	mintedWebhookUrlSchema,
+	mintedWebhookHandleSchema,
 	requirePackageRef,
 	toMintedWebhookCapability,
 	webhookPackageRefSchema,
@@ -15,8 +15,8 @@ export const webhookUrlRotateCapability = defineDomainCapability(
 	{
 		name: 'webhookUrlRotate',
 		description:
-			'Rotate the URL secret for a minted package webhook and return the new full URL once. The replaced URL stops working immediately.',
-		keywords: ['webhook', 'rotate', 'secret', 'credential', 'url'],
+			'Rotate the URL secret for a minted package webhook and return a new opaque handle. The replaced URL stops working immediately. Register the new URL with webhookUrlApply — the credential is never returned.',
+		keywords: ['webhook', 'rotate', 'secret', 'handle', 'url'],
 		readOnly: false,
 		idempotent: false,
 		destructive: false,
@@ -38,7 +38,7 @@ export const webhookUrlRotateCapability = defineDomainCapability(
 				}
 			}),
 		outputSchema: z.object({
-			webhook: mintedWebhookUrlSchema,
+			webhook: mintedWebhookHandleSchema,
 		}),
 		async handler(args, ctx) {
 			const user = requireMcpUser(ctx.callerContext)

--- a/packages/worker/src/mcp/secrets/crypto.node.test.ts
+++ b/packages/worker/src/mcp/secrets/crypto.node.test.ts
@@ -5,9 +5,12 @@ import {
 	decryptUnversionedCiphertext,
 	encryptSecretValue,
 	encryptPlatformOauthClientSecret,
+	encryptWebhookUrlSecret,
+	decryptWebhookUrlSecret,
 	platformOauthAppContext,
 	secretCiphertextPurposes,
 	userSecretContext,
+	userWebhookUrlSecretContext,
 } from './crypto.ts'
 
 const primaryKey = 'primary-secret-store-key-at-least-32-chars!!'
@@ -81,6 +84,23 @@ test('secret AAD/versioning binds identity context, platform OAuth slugs, and re
 			platformOauthAppContext('two'),
 		),
 	).rejects.toThrow('Unable to decrypt platform client secret.')
+
+	const webhookContext = userWebhookUrlSecretContext('user-a', 'endpoint-1')
+	const webhookEncrypted = await encryptWebhookUrlSecret(
+		env,
+		'webhook-url-secret',
+		webhookContext,
+	)
+	expect(
+		await decryptWebhookUrlSecret(env, webhookEncrypted, webhookContext),
+	).toBe('webhook-url-secret')
+	await expect(
+		decryptWebhookUrlSecret(
+			env,
+			webhookEncrypted,
+			userWebhookUrlSecretContext('user-a', 'endpoint-2'),
+		),
+	).rejects.toThrow('Unable to decrypt webhook URL secret.')
 
 	// Reproduce the pre-v2 format: AES-GCM with no AAD, `<iv>.<ciphertext>`.
 	const digest = await crypto.subtle.digest(

--- a/packages/worker/src/mcp/secrets/crypto.ts
+++ b/packages/worker/src/mcp/secrets/crypto.ts
@@ -136,6 +136,7 @@ const platformOauthClientSecretPurpose = 'platform-oauth-client-secret'
 const userOauthAccessTokenPurpose = 'user-oauth-access-token'
 const userOauthRefreshTokenPurpose = 'user-oauth-refresh-token'
 const userOauthClientSecretPurpose = 'user-oauth-client-secret'
+const webhookUrlSecretPurpose = 'webhook-url-secret'
 
 /** Purpose strings for the maintenance-only unversioned decrypt path. */
 export const secretCiphertextPurposes = {
@@ -144,6 +145,7 @@ export const secretCiphertextPurposes = {
 	userOauthAccessToken: userOauthAccessTokenPurpose,
 	userOauthRefreshToken: userOauthRefreshTokenPurpose,
 	userOauthClientSecret: userOauthClientSecretPurpose,
+	webhookUrlSecret: webhookUrlSecretPurpose,
 } as const
 
 export type SecretCiphertextPurpose =
@@ -301,6 +303,44 @@ export async function decryptUserOauthClientSecret(
 		)
 	} catch {
 		throw new Error('Unable to decrypt OAuth app client secret.')
+	}
+}
+
+/** AAD context for a minted webhook URL secret ciphertext. */
+export function userWebhookUrlSecretContext(
+	userId: string,
+	endpointId: string,
+) {
+	return `user:${userId}:webhook-endpoint:${endpointId}`
+}
+
+export async function encryptWebhookUrlSecret(
+	env: Pick<Env, 'SECRET_STORE_KEY'>,
+	value: string,
+	context: string,
+) {
+	return encryptWithKey(
+		env.SECRET_STORE_KEY,
+		webhookUrlSecretPurpose,
+		context,
+		value,
+	)
+}
+
+export async function decryptWebhookUrlSecret(
+	env: Pick<Env, 'SECRET_STORE_KEY'>,
+	payload: string,
+	context: string,
+) {
+	try {
+		return await decryptWithKey(
+			env.SECRET_STORE_KEY,
+			webhookUrlSecretPurpose,
+			context,
+			payload,
+		)
+	} catch {
+		throw new Error('Unable to decrypt webhook URL secret.')
 	}
 }
 

--- a/packages/worker/src/webhooks/apply.node.test.ts
+++ b/packages/worker/src/webhooks/apply.node.test.ts
@@ -16,6 +16,10 @@ const integrationMocks = vi.hoisted(() => ({
 	refreshIntegrationTokens: vi.fn(),
 }))
 
+const secretMocks = vi.hoisted(() => ({
+	resolveSecretForHost: vi.fn(),
+}))
+
 vi.mock('#worker/integrations/service.ts', () => ({
 	getJoinedIntegration: (...args: Array<unknown>) =>
 		integrationMocks.getJoinedIntegration(...args),
@@ -57,6 +61,11 @@ vi.mock('#worker/package-invocations/module-artifacts.ts', () => ({
 vi.mock('#worker/package-registry/repo.ts', () => ({
 	listSavedPackagesByUserId: vi.fn(async () => []),
 	getSavedPackageByKodyId: vi.fn(),
+}))
+
+vi.mock('#mcp/secrets/service.ts', () => ({
+	resolveSecretForHost: (...args: Array<unknown>) =>
+		secretMocks.resolveSecretForHost(...args),
 }))
 
 vi.mock('#worker/package-registry/source.ts', () => ({
@@ -282,4 +291,46 @@ test('webhookUrlApply fails when the package manifest cannot be loaded', async (
 			destination: { type: 'github', owner: 'acme', repo: 'api' },
 		}),
 	).rejects.toThrow('Could not load the package manifest')
+})
+
+test('webhookUrlApply fails when a configured hook secret cannot be resolved', async () => {
+	const { userId, env, minted } = await mintOwnerWebhook()
+	mockGithubIntegration()
+	secretMocks.resolveSecretForHost.mockResolvedValue({
+		found: false,
+	})
+	const fetchMock = vi.fn()
+	vi.stubGlobal('fetch', fetchMock)
+
+	await expect(
+		applyWebhookUrlForUser({
+			env,
+			userId,
+			username: 'owner',
+			handle: minted.handle,
+			destination: {
+				type: 'github',
+				owner: 'acme',
+				repo: 'api',
+				hookSecretName: 'githubHookSecret',
+			},
+		}),
+	).rejects.toThrow('githubHookSecret')
+	expect(fetchMock).not.toHaveBeenCalled()
+	vi.unstubAllGlobals()
+})
+
+test('webhookUrlApply rejects dot-only GitHub slugs', async () => {
+	const { userId, env, minted } = await mintOwnerWebhook()
+	mockGithubIntegration()
+
+	await expect(
+		applyWebhookUrlForUser({
+			env,
+			userId,
+			username: 'owner',
+			handle: minted.handle,
+			destination: { type: 'github', owner: '..', repo: 'api' },
+		}),
+	).rejects.toThrow('GitHub owner')
 })

--- a/packages/worker/src/webhooks/apply.node.test.ts
+++ b/packages/worker/src/webhooks/apply.node.test.ts
@@ -1,5 +1,6 @@
 import { DatabaseSync } from 'node:sqlite'
 import { expect, test, vi } from 'vitest'
+import { loadPackageManifestBySourceId } from '#worker/package-registry/source.ts'
 import { createD1FromSqlite } from '#worker/test-support/create-d1-from-sqlite.ts'
 import { createStableUserIdFromEmail } from '#worker/user-id.ts'
 import {
@@ -80,6 +81,44 @@ vi.mock('#worker/package-registry/source.ts', () => ({
 	})),
 }))
 
+function mockGithubIntegration() {
+	integrationMocks.getJoinedIntegration.mockResolvedValue({
+		lane: 'user',
+		app: {
+			apiBaseUrl: 'https://api.github.com',
+			requiredHosts: ['api.github.com'],
+		},
+		connection: {
+			name: 'github',
+			requiredHosts: ['api.github.com'],
+			usageMode: 'any',
+			allowedPackageIds: [],
+		},
+	})
+	integrationMocks.resolveIntegrationAccessToken.mockResolvedValue('ghs_test')
+	integrationMocks.assertCanUseIntegration.mockResolvedValue(undefined)
+}
+
+async function mintOwnerWebhook() {
+	const userId = await createStableUserIdFromEmail('owner@example.com')
+	const { env, db } = createEnv(userId)
+	await db
+		.prepare(
+			`INSERT INTO users (username, email, password_hash, stable_user_id)
+			VALUES ('owner', 'owner@example.com', 'hash', ?)`,
+		)
+		.bind(userId)
+		.run()
+	const minted = await mintWebhookUrlForUser({
+		env,
+		userId,
+		username: 'owner',
+		kodyId: 'sentry-bridge',
+		webhookName: 'sentry',
+	})
+	return { userId, env, db, minted }
+}
+
 function createEnv(userId: string) {
 	const sqlite = new DatabaseSync(':memory:')
 	sqlite.exec(`
@@ -117,48 +156,18 @@ function createEnv(userId: string) {
 }
 
 test('webhookUrlApply registers a GitHub hook from a handle without exposing the URL', async () => {
-	const userId = await createStableUserIdFromEmail('owner@example.com')
-	const { env, db } = createEnv(userId)
-	await db
-		.prepare(
-			`INSERT INTO users (username, email, password_hash, stable_user_id)
-			VALUES ('owner', 'owner@example.com', 'hash', ?)`,
-		)
-		.bind(userId)
-		.run()
-
-	const minted = await mintWebhookUrlForUser({
-		env,
-		userId,
-		username: 'owner',
-		kodyId: 'sentry-bridge',
-		webhookName: 'sentry',
-	})
+	const { userId, env, db, minted } = await mintOwnerWebhook()
 	const revealed = await revealWebhookUrlForWebsite({
 		env,
 		userId,
 		username: 'owner',
 		handle: minted.handle,
 	})
-
-	integrationMocks.getJoinedIntegration.mockResolvedValue({
-		lane: 'user',
-		app: {
-			apiBaseUrl: 'https://api.github.com',
-			requiredHosts: ['api.github.com'],
-		},
-		connection: {
-			name: 'github',
-			requiredHosts: ['api.github.com'],
-			usageMode: 'any',
-			allowedPackageIds: [],
-		},
-	})
-	integrationMocks.resolveIntegrationAccessToken.mockResolvedValue('ghs_test')
-	integrationMocks.assertCanUseIntegration.mockResolvedValue(undefined)
+	mockGithubIntegration()
 
 	const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
 		expect(url).toBe('https://api.github.com/repos/acme/api/hooks')
+		expect(init?.redirect).toBe('manual')
 		const body = JSON.parse(String(init?.body)) as {
 			config: { url: string }
 		}
@@ -224,4 +233,53 @@ test('webhookUrlApply registers a GitHub hook from a handle without exposing the
 	).rejects.toThrow('not recoverable')
 
 	vi.unstubAllGlobals()
+})
+
+test('webhookUrlApply does not follow credential-bearing redirects', async () => {
+	const { userId, env, minted } = await mintOwnerWebhook()
+	mockGithubIntegration()
+	const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+		expect(init?.redirect).toBe('manual')
+		return new Response(null, {
+			status: 307,
+			headers: { Location: 'https://attacker.example/exfil' },
+		})
+	})
+	vi.stubGlobal('fetch', fetchMock)
+
+	const applied = await applyWebhookUrlForUser({
+		env,
+		userId,
+		username: 'owner',
+		handle: minted.handle,
+		destination: { type: 'github', owner: 'acme', repo: 'api' },
+	})
+
+	expect(applied).toEqual({
+		ok: false,
+		urlHost: 'heykody.dev',
+		httpStatus: 307,
+		remoteId: null,
+		error: 'Destination redirected. Apply does not follow redirects.',
+	})
+	expect(fetchMock).toHaveBeenCalledTimes(1)
+	vi.unstubAllGlobals()
+})
+
+test('webhookUrlApply fails when the package manifest cannot be loaded', async () => {
+	const { userId, env, minted } = await mintOwnerWebhook()
+	mockGithubIntegration()
+	vi.mocked(loadPackageManifestBySourceId).mockRejectedValueOnce(
+		new Error('Saved package source bindings are not available.'),
+	)
+
+	await expect(
+		applyWebhookUrlForUser({
+			env,
+			userId,
+			username: 'owner',
+			handle: minted.handle,
+			destination: { type: 'github', owner: 'acme', repo: 'api' },
+		}),
+	).rejects.toThrow('Could not load the package manifest')
 })

--- a/packages/worker/src/webhooks/apply.node.test.ts
+++ b/packages/worker/src/webhooks/apply.node.test.ts
@@ -1,0 +1,243 @@
+import { DatabaseSync } from 'node:sqlite'
+import { expect, test, vi } from 'vitest'
+import { createD1FromSqlite } from '#worker/test-support/create-d1-from-sqlite.ts'
+import { createStableUserIdFromEmail } from '#worker/user-id.ts'
+import { webhookUrlPlaceholder } from './redact.ts'
+import {
+	applyWebhookUrlForUser,
+	mintWebhookUrlForUser,
+	revealWebhookUrlForWebsite,
+} from './service.ts'
+
+const integrationMocks = vi.hoisted(() => ({
+	getJoinedIntegration: vi.fn(),
+	resolveIntegrationAccessToken: vi.fn(),
+	assertCanUseIntegration: vi.fn(),
+	refreshIntegrationTokens: vi.fn(),
+}))
+
+vi.mock('#worker/integrations/service.ts', () => ({
+	getJoinedIntegration: (...args: Array<unknown>) =>
+		integrationMocks.getJoinedIntegration(...args),
+}))
+
+vi.mock('#worker/integrations/credentials.ts', () => ({
+	resolveIntegrationAccessToken: (...args: Array<unknown>) =>
+		integrationMocks.resolveIntegrationAccessToken(...args),
+}))
+
+vi.mock('#worker/integrations/package-access.ts', () => ({
+	assertCanUseIntegration: (...args: Array<unknown>) =>
+		integrationMocks.assertCanUseIntegration(...args),
+}))
+
+vi.mock('#worker/integrations/token-refresh.ts', () => ({
+	refreshIntegrationTokens: (...args: Array<unknown>) =>
+		integrationMocks.refreshIntegrationTokens(...args),
+}))
+
+vi.mock('#worker/package-invocations/module-artifacts.ts', () => ({
+	resolveSavedPackage: vi.fn(async (input: { packageIdOrKodyId: string }) => {
+		if (
+			input.packageIdOrKodyId === 'pkg-1' ||
+			input.packageIdOrKodyId === 'sentry-bridge'
+		) {
+			return {
+				id: 'pkg-1',
+				kodyId: 'sentry-bridge',
+				name: '@owner/sentry-bridge',
+				userId: 'ignored',
+				sourceId: 'src-1',
+			}
+		}
+		return null
+	}),
+}))
+
+vi.mock('#worker/package-registry/repo.ts', () => ({
+	listSavedPackagesByUserId: vi.fn(async () => []),
+	getSavedPackageByKodyId: vi.fn(),
+}))
+
+vi.mock('#worker/package-registry/source.ts', () => ({
+	loadPackageManifestBySourceId: vi.fn(async () => ({
+		manifest: {
+			name: '@owner/sentry-bridge',
+			exports: {
+				'./handle-sentry-webhook': './src/handle-sentry-webhook.ts',
+			},
+			kody: {
+				id: 'sentry-bridge',
+				description: 'Sentry bridge',
+				webhooks: [
+					{
+						name: 'sentry',
+						export: './handle-sentry-webhook',
+						responseMode: 'ack',
+					},
+				],
+			},
+		},
+	})),
+}))
+
+function createEnv(userId: string) {
+	const sqlite = new DatabaseSync(':memory:')
+	sqlite.exec(`
+		CREATE TABLE webhook_endpoints (
+			id TEXT PRIMARY KEY,
+			user_id TEXT NOT NULL,
+			package_id TEXT NOT NULL,
+			webhook_name TEXT NOT NULL,
+			url_secret_hash TEXT NOT NULL,
+			url_secret_encrypted TEXT,
+			enabled INTEGER NOT NULL DEFAULT 1 CHECK (enabled IN (0, 1)),
+			created_at TEXT NOT NULL,
+			rotated_at TEXT NOT NULL
+		);
+		CREATE UNIQUE INDEX idx_webhook_endpoints_user_package_name
+		ON webhook_endpoints(user_id, package_id, webhook_name);
+		CREATE TABLE users (
+			id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+			username TEXT NOT NULL UNIQUE,
+			email TEXT NOT NULL UNIQUE,
+			password_hash TEXT NOT NULL,
+			stable_user_id TEXT NOT NULL
+		);
+	`)
+	const db = createD1FromSqlite(sqlite)
+	return {
+		env: {
+			APP_DB: db,
+			APP_BASE_URL: 'https://heykody.dev',
+			SECRET_STORE_KEY: 'test-secret-store-key-32-chars-minimum',
+		} as Env,
+		db,
+		userId,
+	}
+}
+
+test('webhookUrlApply registers a GitHub hook from a handle without exposing the URL', async () => {
+	const userId = await createStableUserIdFromEmail('owner@example.com')
+	const { env, db } = createEnv(userId)
+	await db
+		.prepare(
+			`INSERT INTO users (username, email, password_hash, stable_user_id)
+			VALUES ('owner', 'owner@example.com', 'hash', ?)`,
+		)
+		.bind(userId)
+		.run()
+
+	const minted = await mintWebhookUrlForUser({
+		env,
+		userId,
+		username: 'owner',
+		kodyId: 'sentry-bridge',
+		webhookName: 'sentry',
+	})
+	const revealed = await revealWebhookUrlForWebsite({
+		env,
+		userId,
+		username: 'owner',
+		handle: minted.handle,
+	})
+
+	integrationMocks.getJoinedIntegration.mockResolvedValue({
+		lane: 'user',
+		app: {
+			apiBaseUrl: 'https://api.github.com',
+			requiredHosts: ['api.github.com'],
+		},
+		connection: {
+			name: 'github',
+			requiredHosts: ['api.github.com'],
+			usageMode: 'any',
+			allowedPackageIds: [],
+		},
+	})
+	integrationMocks.resolveIntegrationAccessToken.mockResolvedValue('ghs_test')
+	integrationMocks.assertCanUseIntegration.mockResolvedValue(undefined)
+
+	const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+		expect(url).toBe('https://api.github.com/repos/acme/api/hooks')
+		const body = JSON.parse(String(init?.body)) as {
+			config: { url: string }
+		}
+		expect(body.config.url).toBe(revealed.url)
+		return new Response(
+			JSON.stringify({
+				id: 4242,
+				config: { url: revealed.url },
+			}),
+			{ status: 201 },
+		)
+	})
+	vi.stubGlobal('fetch', fetchMock)
+
+	const applied = await applyWebhookUrlForUser({
+		env,
+		userId,
+		username: 'owner',
+		handle: minted.handle,
+		destination: {
+			type: 'github',
+			owner: 'acme',
+			repo: 'api',
+			events: ['push', 'pull_request'],
+		},
+	})
+
+	expect(applied).toEqual({
+		ok: true,
+		urlHost: 'heykody.dev',
+		httpStatus: 201,
+		remoteId: '4242',
+		error: null,
+	})
+	expect(JSON.stringify(applied)).not.toContain(revealed.url)
+	expect(JSON.stringify(applied)).not.toContain(
+		revealed.url.slice(revealed.url.lastIndexOf('/') + 1),
+	)
+	expect(fetchMock).toHaveBeenCalledTimes(1)
+	expect(integrationMocks.assertCanUseIntegration).toHaveBeenCalledWith(
+		expect.objectContaining({
+			userId,
+			name: 'github',
+			packageId: 'pkg-1',
+		}),
+	)
+
+	await expect(
+		applyWebhookUrlForUser({
+			env,
+			userId,
+			username: 'owner',
+			handle: minted.handle,
+			destination: {
+				type: 'https',
+				url: 'https://api.github.com/repos/acme/api/hooks',
+				body: '{"url":"missing-placeholder"}',
+				integration: 'github',
+			},
+		}),
+	).rejects.toThrow(webhookUrlPlaceholder)
+
+	await db
+		.prepare(
+			`UPDATE webhook_endpoints SET url_secret_encrypted = NULL
+			WHERE user_id = ?`,
+		)
+		.bind(userId)
+		.run()
+	await expect(
+		applyWebhookUrlForUser({
+			env,
+			userId,
+			username: 'owner',
+			handle: minted.handle,
+			destination: { type: 'github', owner: 'acme', repo: 'api' },
+		}),
+	).rejects.toThrow('not recoverable')
+
+	vi.unstubAllGlobals()
+})

--- a/packages/worker/src/webhooks/apply.node.test.ts
+++ b/packages/worker/src/webhooks/apply.node.test.ts
@@ -2,7 +2,6 @@ import { DatabaseSync } from 'node:sqlite'
 import { expect, test, vi } from 'vitest'
 import { createD1FromSqlite } from '#worker/test-support/create-d1-from-sqlite.ts'
 import { createStableUserIdFromEmail } from '#worker/user-id.ts'
-import { webhookUrlPlaceholder } from './redact.ts'
 import {
 	applyWebhookUrlForUser,
 	mintWebhookUrlForUser,
@@ -206,21 +205,6 @@ test('webhookUrlApply registers a GitHub hook from a handle without exposing the
 			packageId: 'pkg-1',
 		}),
 	)
-
-	await expect(
-		applyWebhookUrlForUser({
-			env,
-			userId,
-			username: 'owner',
-			handle: minted.handle,
-			destination: {
-				type: 'https',
-				url: 'https://api.github.com/repos/acme/api/hooks',
-				body: '{"url":"missing-placeholder"}',
-				integration: 'github',
-			},
-		}),
-	).rejects.toThrow(webhookUrlPlaceholder)
 
 	await db
 		.prepare(

--- a/packages/worker/src/webhooks/apply.ts
+++ b/packages/worker/src/webhooks/apply.ts
@@ -42,8 +42,9 @@ export type WebhookUrlApplyResult = {
 	error: string | null
 }
 
-const applyResponseBodyMaxChars = 16_384
+const applyResponseBodyMaxBytes = 16_384
 const applyErrorSnippetMaxChars = 300
+const applyRequestTimeoutMs = 15_000
 const defaultGithubEvents = ['push'] as const
 
 function integrationAllowedHosts(joined: JoinedIntegration) {
@@ -88,13 +89,19 @@ async function loadDeclaredWebhookIfPresent(input: {
 	savedPackage: SavedPackageRecord
 	webhookName: string
 }): Promise<PackageWebhookManifestEntry | null> {
-	const loaded = await loadPackageManifestBySourceId({
-		env: input.env,
-		baseUrl: input.baseUrl,
-		userId: input.userId,
-		sourceId: input.savedPackage.sourceId,
-	}).catch(() => null)
-	if (!loaded) return null
+	let loaded
+	try {
+		loaded = await loadPackageManifestBySourceId({
+			env: input.env,
+			baseUrl: input.baseUrl,
+			userId: input.userId,
+			sourceId: input.savedPackage.sourceId,
+		})
+	} catch {
+		throw new McpCallerError(
+			'Could not load the package manifest to read webhook verification. Retry after the package source is available.',
+		)
+	}
 	return (
 		listPackageWebhooks(loaded.manifest).find(
 			(webhook) => webhook.name === input.webhookName,
@@ -261,6 +268,75 @@ function parseJsonPayload(text: string): unknown {
 	}
 }
 
+function isRedirectStatus(status: number) {
+	return status >= 300 && status < 400
+}
+
+function applyFetchInit(input: {
+	method: string
+	headers: Headers
+	body?: string
+}): RequestInit {
+	return {
+		method: input.method,
+		headers: input.headers,
+		body: input.body,
+		redirect: 'manual',
+		signal: AbortSignal.timeout(applyRequestTimeoutMs),
+	}
+}
+
+async function fetchApplyDestination(input: {
+	url: string
+	method: string
+	headers: Headers
+	body?: string
+}): Promise<Response> {
+	try {
+		return await fetch(input.url, applyFetchInit(input))
+	} catch (error) {
+		if (error instanceof DOMException && error.name === 'TimeoutError') {
+			throw new McpCallerError('Destination request timed out.')
+		}
+		throw error
+	}
+}
+
+async function readApplyResponseBody(response: Response): Promise<string> {
+	if (response.body == null) {
+		const text = await response.text()
+		return text.length > applyResponseBodyMaxBytes
+			? text.slice(0, applyResponseBodyMaxBytes)
+			: text
+	}
+	const reader = response.body.getReader()
+	const decoder = new TextDecoder()
+	let body = ''
+	let totalBytes = 0
+	try {
+		while (true) {
+			const { done, value } = await reader.read()
+			if (done) break
+			if (!value || value.byteLength === 0) continue
+			if (totalBytes + value.byteLength > applyResponseBodyMaxBytes) {
+				const remaining = applyResponseBodyMaxBytes - totalBytes
+				if (remaining > 0) {
+					body += decoder.decode(value.slice(0, remaining), { stream: true })
+				}
+				void reader.cancel().catch(() => {})
+				break
+			}
+			totalBytes += value.byteLength
+			body += decoder.decode(value, { stream: true })
+		}
+		body += decoder.decode()
+		return body
+	} catch (error) {
+		void reader.cancel().catch(() => {})
+		throw error
+	}
+}
+
 async function sendAuthorizedApplyRequest(input: {
 	url: string
 	method: string
@@ -272,28 +348,46 @@ async function sendAuthorizedApplyRequest(input: {
 }): Promise<WebhookUrlApplyResult> {
 	const headers = new Headers(input.headers)
 	headers.set('Authorization', input.authorization)
-	let response = await fetch(input.url, {
+	let response = await fetchApplyDestination({
+		url: input.url,
 		method: input.method,
 		headers,
 		body: input.body,
 	})
+	if (isRedirectStatus(response.status)) {
+		await response.body?.cancel()
+		return {
+			ok: false,
+			urlHost: '',
+			httpStatus: response.status,
+			remoteId: null,
+			error: 'Destination redirected. Apply does not follow redirects.',
+		}
+	}
 	if (response.status === 401) {
 		await response.body?.cancel()
 		const retryHeaders = new Headers(input.headers)
 		retryHeaders.set('Authorization', await input.retryAuthorization())
-		response = await fetch(input.url, {
+		response = await fetchApplyDestination({
+			url: input.url,
 			method: input.method,
 			headers: retryHeaders,
 			body: input.body,
 		})
+		if (isRedirectStatus(response.status)) {
+			await response.body?.cancel()
+			return {
+				ok: false,
+				urlHost: '',
+				httpStatus: response.status,
+				remoteId: null,
+				error: 'Destination redirected. Apply does not follow redirects.',
+			}
+		}
 	}
-	const rawBody = await response.text()
-	const bounded =
-		rawBody.length > applyResponseBodyMaxChars
-			? rawBody.slice(0, applyResponseBodyMaxChars)
-			: rawBody
+	const rawBody = await readApplyResponseBody(response)
 	const redactedBody = String(
-		redactWebhookCredentials(bounded, input.secrets) ?? '',
+		redactWebhookCredentials(rawBody, input.secrets) ?? '',
 	)
 	const payload = parseJsonPayload(redactedBody)
 	const remoteId = extractRemoteId(payload)

--- a/packages/worker/src/webhooks/apply.ts
+++ b/packages/worker/src/webhooks/apply.ts
@@ -16,23 +16,9 @@ import { type SavedPackageRecord } from '#worker/package-registry/types.ts'
 import {
 	collectWebhookCredentialSecrets,
 	redactWebhookCredentials,
-	substituteWebhookUrlPlaceholder,
-	templateIncludesWebhookUrlPlaceholder,
-	webhookUrlPlaceholder,
 } from './redact.ts'
 
-export const webhookUrlApplyHttpsMethods = ['POST', 'PUT', 'PATCH'] as const
 export const webhookUrlApplyGithubContentTypes = ['json', 'form'] as const
-
-export type WebhookUrlApplyHttpsDestination = {
-	type: 'https'
-	url: string
-	method?: (typeof webhookUrlApplyHttpsMethods)[number]
-	headers?: Record<string, string>
-	body?: string
-	integration?: string
-	secretName?: string
-}
 
 export type WebhookUrlApplyGithubDestination = {
 	type: 'github'
@@ -46,9 +32,7 @@ export type WebhookUrlApplyGithubDestination = {
 	hookSecretName?: string
 }
 
-export type WebhookUrlApplyDestination =
-	| WebhookUrlApplyHttpsDestination
-	| WebhookUrlApplyGithubDestination
+export type WebhookUrlApplyDestination = WebhookUrlApplyGithubDestination
 
 export type WebhookUrlApplyResult = {
 	ok: boolean
@@ -335,73 +319,6 @@ async function sendAuthorizedApplyRequest(input: {
 	}
 }
 
-function requireHttpsPlaceholder(input: {
-	url: string
-	headers?: Record<string, string>
-	body?: string
-}) {
-	const headerValues = Object.values(input.headers ?? {}).join('\n')
-	const haystack = `${input.url}\n${headerValues}\n${input.body ?? ''}`
-	if (templateIncludesWebhookUrlPlaceholder(haystack)) return
-	throw new McpCallerError(
-		`HTTPS apply must include ${webhookUrlPlaceholder} in url, headers, or body so Kody can substitute the credential server-side.`,
-	)
-}
-
-async function dispatchHttpsApply(input: {
-	env: Env
-	userId: string
-	userEmail?: string | null
-	baseUrl: string
-	packageId: string
-	packageKodyId: string
-	webhookUrl: string
-	urlSecret: string
-	destination: WebhookUrlApplyHttpsDestination
-	waitUntil?: (promise: Promise<unknown>) => void
-}): Promise<WebhookUrlApplyResult> {
-	requireHttpsPlaceholder(input.destination)
-	const url = substituteWebhookUrlPlaceholder(
-		input.destination.url,
-		input.webhookUrl,
-	)
-	const headers: Record<string, string> = {}
-	for (const [key, value] of Object.entries(input.destination.headers ?? {})) {
-		headers[key] = substituteWebhookUrlPlaceholder(value, input.webhookUrl)
-	}
-	const body =
-		input.destination.body === undefined
-			? undefined
-			: substituteWebhookUrlPlaceholder(
-					input.destination.body,
-					input.webhookUrl,
-				)
-	const auth = await authorizeApplyRequest({
-		env: input.env,
-		userId: input.userId,
-		userEmail: input.userEmail,
-		baseUrl: input.baseUrl,
-		packageId: input.packageId,
-		packageKodyId: input.packageKodyId,
-		url,
-		integration: input.destination.integration,
-		secretName: input.destination.secretName,
-		waitUntil: input.waitUntil,
-	})
-	return sendAuthorizedApplyRequest({
-		url,
-		method: input.destination.method ?? 'POST',
-		headers,
-		body,
-		authorization: auth.authorization,
-		retryAuthorization: auth.retryAuthorization,
-		secrets: collectWebhookCredentialSecrets({
-			url: input.webhookUrl,
-			urlSecret: input.urlSecret,
-		}),
-	})
-}
-
 async function dispatchGithubApply(input: {
 	env: Env
 	userId: string
@@ -500,45 +417,20 @@ export async function dispatchWebhookUrlApply(input: {
 	destination: WebhookUrlApplyDestination
 	waitUntil?: (promise: Promise<unknown>) => void
 }): Promise<WebhookUrlApplyResult> {
-	let result: WebhookUrlApplyResult
-	switch (input.destination.type) {
-		case 'https':
-			result = await dispatchHttpsApply({
-				env: input.env,
-				userId: input.userId,
-				userEmail: input.userEmail,
-				baseUrl: input.baseUrl,
-				packageId: input.packageId,
-				packageKodyId: input.packageKodyId,
-				webhookUrl: input.webhookUrl,
-				urlSecret: input.urlSecret,
-				destination: input.destination,
-				waitUntil: input.waitUntil,
-			})
-			break
-		case 'github':
-			result = await dispatchGithubApply({
-				env: input.env,
-				userId: input.userId,
-				userEmail: input.userEmail,
-				baseUrl: input.baseUrl,
-				packageId: input.packageId,
-				packageKodyId: input.packageKodyId,
-				webhookName: input.webhookName,
-				savedPackage: input.savedPackage,
-				webhookUrl: input.webhookUrl,
-				urlSecret: input.urlSecret,
-				destination: input.destination,
-				waitUntil: input.waitUntil,
-			})
-			break
-		default: {
-			const exhaustive: never = input.destination
-			throw new Error(
-				`Unhandled webhook apply destination: ${String(exhaustive)}`,
-			)
-		}
-	}
+	const result = await dispatchGithubApply({
+		env: input.env,
+		userId: input.userId,
+		userEmail: input.userEmail,
+		baseUrl: input.baseUrl,
+		packageId: input.packageId,
+		packageKodyId: input.packageKodyId,
+		webhookName: input.webhookName,
+		savedPackage: input.savedPackage,
+		webhookUrl: input.webhookUrl,
+		urlSecret: input.urlSecret,
+		destination: input.destination,
+		waitUntil: input.waitUntil,
+	})
 	const secrets = collectWebhookCredentialSecrets({
 		url: input.webhookUrl,
 		urlSecret: input.urlSecret,

--- a/packages/worker/src/webhooks/apply.ts
+++ b/packages/worker/src/webhooks/apply.ts
@@ -109,10 +109,17 @@ async function loadDeclaredWebhookIfPresent(input: {
 	)
 }
 
+function assertGithubRepoSlug(value: string, label: 'owner' | 'repository') {
+	if (value === '.' || value === '..' || !/^[A-Za-z0-9_.-]+$/.test(value)) {
+		throw new McpCallerError(`Must be a GitHub ${label} slug.`)
+	}
+}
+
 async function resolveHookSigningSecret(input: {
 	env: Env
 	userId: string
 	packageId: string
+	baseUrl: string
 	secretName: string
 }) {
 	const resolved = await resolveSecretForHost({
@@ -126,8 +133,27 @@ async function resolveHookSigningSecret(input: {
 		},
 		host: 'api.github.com',
 	})
-	if (!resolved.found || !resolved.value) return null
-	if (!resolved.allowedHosts.includes('api.github.com')) return null
+	if (!resolved.found || !resolved.value) {
+		throw new McpCallerError(
+			`Secret "${input.secretName}" was not found for this user.`,
+		)
+	}
+	if (!resolved.allowedHosts.includes('api.github.com')) {
+		const approvalUrl = buildSecretHostApprovalUrl({
+			baseUrl: input.baseUrl,
+			name: input.secretName,
+			scope: resolved.scope ?? 'user',
+			requestedHost: 'api.github.com',
+			storageContext: {
+				sessionId: null,
+				appId: null,
+				packageId: input.packageId,
+			},
+		})
+		throw new McpCallerError(
+			`Secret "${input.secretName}" is not approved for host "api.github.com". Approve it at ${approvalUrl}.`,
+		)
+	}
 	return resolved.value
 }
 
@@ -429,6 +455,8 @@ async function dispatchGithubApply(input: {
 }): Promise<WebhookUrlApplyResult> {
 	const owner = input.destination.owner.trim()
 	const repo = input.destination.repo.trim()
+	assertGithubRepoSlug(owner, 'owner')
+	assertGithubRepoSlug(repo, 'repository')
 	const url = `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/hooks`
 	const declared = await loadDeclaredWebhookIfPresent({
 		env: input.env,
@@ -446,6 +474,7 @@ async function dispatchGithubApply(input: {
 				env: input.env,
 				userId: input.userId,
 				packageId: input.packageId,
+				baseUrl: input.baseUrl,
 				secretName: hookSecretName,
 			})
 		: null

--- a/packages/worker/src/webhooks/apply.ts
+++ b/packages/worker/src/webhooks/apply.ts
@@ -1,0 +1,558 @@
+import { McpCallerError } from '#mcp/caller-error.ts'
+import { normalizeHost } from '#mcp/secrets/allowed-hosts.ts'
+import { buildSecretHostApprovalUrl } from '#mcp/secrets/host-approval.ts'
+import { resolveSecretForHost } from '#mcp/secrets/service.ts'
+import { assertCanUseIntegration } from '#worker/integrations/package-access.ts'
+import { resolveIntegrationAccessToken } from '#worker/integrations/credentials.ts'
+import { getJoinedIntegration } from '#worker/integrations/service.ts'
+import { refreshIntegrationTokens } from '#worker/integrations/token-refresh.ts'
+import { type JoinedIntegration } from '#worker/integrations/types.ts'
+import {
+	listPackageWebhooks,
+	type PackageWebhookManifestEntry,
+} from '#worker/package-registry/manifest.ts'
+import { loadPackageManifestBySourceId } from '#worker/package-registry/source.ts'
+import { type SavedPackageRecord } from '#worker/package-registry/types.ts'
+import {
+	collectWebhookCredentialSecrets,
+	redactWebhookCredentials,
+	substituteWebhookUrlPlaceholder,
+	templateIncludesWebhookUrlPlaceholder,
+	webhookUrlPlaceholder,
+} from './redact.ts'
+
+export const webhookUrlApplyHttpsMethods = ['POST', 'PUT', 'PATCH'] as const
+export const webhookUrlApplyGithubContentTypes = ['json', 'form'] as const
+
+export type WebhookUrlApplyHttpsDestination = {
+	type: 'https'
+	url: string
+	method?: (typeof webhookUrlApplyHttpsMethods)[number]
+	headers?: Record<string, string>
+	body?: string
+	integration?: string
+	secretName?: string
+}
+
+export type WebhookUrlApplyGithubDestination = {
+	type: 'github'
+	owner: string
+	repo: string
+	events?: Array<string>
+	contentType?: (typeof webhookUrlApplyGithubContentTypes)[number]
+	active?: boolean
+	integration?: string
+	secretName?: string
+	hookSecretName?: string
+}
+
+export type WebhookUrlApplyDestination =
+	| WebhookUrlApplyHttpsDestination
+	| WebhookUrlApplyGithubDestination
+
+export type WebhookUrlApplyResult = {
+	ok: boolean
+	urlHost: string
+	httpStatus: number
+	remoteId: string | null
+	error: string | null
+}
+
+const applyResponseBodyMaxChars = 16_384
+const applyErrorSnippetMaxChars = 300
+const defaultGithubEvents = ['push'] as const
+
+function integrationAllowedHosts(joined: JoinedIntegration) {
+	const hosts = new Set<string>()
+	for (const host of joined.connection.requiredHosts) {
+		const normalized = normalizeHost(host)
+		if (normalized) hosts.add(normalized)
+	}
+	if (joined.lane === 'platform') {
+		for (const host of joined.app.requiredHosts) {
+			const normalized = normalizeHost(host)
+			if (normalized) hosts.add(normalized)
+		}
+	}
+	if (joined.app.apiBaseUrl) {
+		try {
+			const apiHost = normalizeHost(new URL(joined.app.apiBaseUrl).hostname)
+			if (apiHost) hosts.add(apiHost)
+		} catch {
+			// Invalid apiBaseUrl is ignored; host checks still use requiredHosts.
+		}
+	}
+	return hosts
+}
+
+function assertDestinationHostAllowed(input: {
+	joined: JoinedIntegration
+	integrationName: string
+	url: string
+}) {
+	const host = normalizeHost(new URL(input.url).hostname)
+	if (integrationAllowedHosts(input.joined).has(host)) return
+	throw new McpCallerError(
+		`Integration "${input.integrationName}" does not allow requests to host "${host}".`,
+	)
+}
+
+async function loadDeclaredWebhookIfPresent(input: {
+	env: Env
+	baseUrl: string
+	userId: string
+	savedPackage: SavedPackageRecord
+	webhookName: string
+}): Promise<PackageWebhookManifestEntry | null> {
+	const loaded = await loadPackageManifestBySourceId({
+		env: input.env,
+		baseUrl: input.baseUrl,
+		userId: input.userId,
+		sourceId: input.savedPackage.sourceId,
+	}).catch(() => null)
+	if (!loaded) return null
+	return (
+		listPackageWebhooks(loaded.manifest).find(
+			(webhook) => webhook.name === input.webhookName,
+		) ?? null
+	)
+}
+
+async function resolveHookSigningSecret(input: {
+	env: Env
+	userId: string
+	packageId: string
+	secretName: string
+}) {
+	const resolved = await resolveSecretForHost({
+		env: input.env,
+		userId: input.userId,
+		name: input.secretName,
+		storageContext: {
+			sessionId: null,
+			appId: null,
+			packageId: input.packageId,
+		},
+		host: 'api.github.com',
+	})
+	if (!resolved.found || !resolved.value) return null
+	if (!resolved.allowedHosts.includes('api.github.com')) return null
+	return resolved.value
+}
+
+async function authorizeApplyRequest(input: {
+	env: Env
+	userId: string
+	userEmail?: string | null
+	baseUrl: string
+	packageId: string
+	packageKodyId: string
+	url: string
+	integration?: string
+	secretName?: string
+	waitUntil?: (promise: Promise<unknown>) => void
+}): Promise<{
+	authorization: string
+	retryAuthorization: () => Promise<string>
+}> {
+	const secretName = input.secretName?.trim() ?? ''
+	const integrationName = input.integration?.trim() ?? ''
+	if (secretName && integrationName) {
+		throw new McpCallerError(
+			'Provide either integration or secretName, not both.',
+		)
+	}
+	if (secretName) {
+		const host = normalizeHost(new URL(input.url).hostname)
+		const resolved = await resolveSecretForHost({
+			env: input.env,
+			userId: input.userId,
+			name: secretName,
+			storageContext: {
+				sessionId: null,
+				appId: null,
+				packageId: input.packageId,
+			},
+			host,
+		})
+		if (!resolved.found || !resolved.value) {
+			throw new McpCallerError(
+				`Secret "${secretName}" was not found for this user.`,
+			)
+		}
+		if (!resolved.allowedHosts.includes(host)) {
+			const approvalUrl = buildSecretHostApprovalUrl({
+				baseUrl: input.baseUrl,
+				name: secretName,
+				scope: resolved.scope ?? 'user',
+				requestedHost: host,
+				storageContext: {
+					sessionId: null,
+					appId: null,
+					packageId: input.packageId,
+				},
+			})
+			throw new McpCallerError(
+				`Secret "${secretName}" is not approved for host "${host}". Approve it at ${approvalUrl}.`,
+			)
+		}
+		const authorization = `Bearer ${resolved.value}`
+		return {
+			authorization,
+			retryAuthorization: async () => authorization,
+		}
+	}
+
+	const name = integrationName || 'github'
+	const joined = await getJoinedIntegration({
+		env: input.env,
+		userId: input.userId,
+		name,
+	})
+	if (!joined) {
+		throw new McpCallerError(
+			`Integration "${name}" was not found. Connect it at /connect/oauth?provider=${encodeURIComponent(name)} or pass secretName for a host-approved token.`,
+		)
+	}
+	await assertCanUseIntegration({
+		env: input.env,
+		baseUrl: input.baseUrl,
+		userId: input.userId,
+		name,
+		packageId: input.packageId,
+		packageKodyId: input.packageKodyId,
+	})
+	assertDestinationHostAllowed({
+		joined,
+		integrationName: name,
+		url: input.url,
+	})
+	const readToken = async () => {
+		const token = await resolveIntegrationAccessToken({
+			env: input.env,
+			userId: input.userId,
+			name,
+		})
+		if (!token) {
+			throw new McpCallerError(
+				`Integration "${name}" does not have a stored access token. Reconnect at /connect/oauth?provider=${encodeURIComponent(name)}.`,
+			)
+		}
+		return `Bearer ${token}`
+	}
+	return {
+		authorization: await readToken(),
+		retryAuthorization: async () => {
+			await refreshIntegrationTokens({
+				env: input.env,
+				userId: input.userId,
+				userEmail: input.userEmail ?? undefined,
+				name,
+				baseUrl: input.baseUrl,
+				packageId: input.packageId,
+				packageKodyId: input.packageKodyId,
+				waitUntil: input.waitUntil,
+			})
+			return readToken()
+		},
+	}
+}
+
+function extractRemoteId(payload: unknown): string | null {
+	if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+		return null
+	}
+	const id = (payload as { id?: unknown }).id
+	if (typeof id === 'number' && Number.isFinite(id)) return String(id)
+	if (typeof id === 'string' && id.trim()) return id.trim()
+	return null
+}
+
+function parseJsonPayload(text: string): unknown {
+	if (!text.trim()) return null
+	try {
+		return JSON.parse(text) as unknown
+	} catch {
+		return null
+	}
+}
+
+async function sendAuthorizedApplyRequest(input: {
+	url: string
+	method: string
+	headers: Record<string, string>
+	body?: string
+	authorization: string
+	retryAuthorization: () => Promise<string>
+	secrets: ReadonlyArray<string>
+}): Promise<WebhookUrlApplyResult> {
+	const headers = new Headers(input.headers)
+	headers.set('Authorization', input.authorization)
+	let response = await fetch(input.url, {
+		method: input.method,
+		headers,
+		body: input.body,
+	})
+	if (response.status === 401) {
+		await response.body?.cancel()
+		const retryHeaders = new Headers(input.headers)
+		retryHeaders.set('Authorization', await input.retryAuthorization())
+		response = await fetch(input.url, {
+			method: input.method,
+			headers: retryHeaders,
+			body: input.body,
+		})
+	}
+	const rawBody = await response.text()
+	const bounded =
+		rawBody.length > applyResponseBodyMaxChars
+			? rawBody.slice(0, applyResponseBodyMaxChars)
+			: rawBody
+	const redactedBody = String(
+		redactWebhookCredentials(bounded, input.secrets) ?? '',
+	)
+	const payload = parseJsonPayload(redactedBody)
+	const remoteId = extractRemoteId(payload)
+	if (response.ok) {
+		return {
+			ok: true,
+			urlHost: '',
+			httpStatus: response.status,
+			remoteId,
+			error: null,
+		}
+	}
+	const snippet =
+		redactedBody.trim().length > 0
+			? redactedBody.trim().slice(0, applyErrorSnippetMaxChars)
+			: response.statusText
+	return {
+		ok: false,
+		urlHost: '',
+		httpStatus: response.status,
+		remoteId,
+		error: String(redactWebhookCredentials(snippet, input.secrets) ?? snippet),
+	}
+}
+
+function requireHttpsPlaceholder(input: {
+	url: string
+	headers?: Record<string, string>
+	body?: string
+}) {
+	const headerValues = Object.values(input.headers ?? {}).join('\n')
+	const haystack = `${input.url}\n${headerValues}\n${input.body ?? ''}`
+	if (templateIncludesWebhookUrlPlaceholder(haystack)) return
+	throw new McpCallerError(
+		`HTTPS apply must include ${webhookUrlPlaceholder} in url, headers, or body so Kody can substitute the credential server-side.`,
+	)
+}
+
+async function dispatchHttpsApply(input: {
+	env: Env
+	userId: string
+	userEmail?: string | null
+	baseUrl: string
+	packageId: string
+	packageKodyId: string
+	webhookUrl: string
+	urlSecret: string
+	destination: WebhookUrlApplyHttpsDestination
+	waitUntil?: (promise: Promise<unknown>) => void
+}): Promise<WebhookUrlApplyResult> {
+	requireHttpsPlaceholder(input.destination)
+	const url = substituteWebhookUrlPlaceholder(
+		input.destination.url,
+		input.webhookUrl,
+	)
+	const headers: Record<string, string> = {}
+	for (const [key, value] of Object.entries(input.destination.headers ?? {})) {
+		headers[key] = substituteWebhookUrlPlaceholder(value, input.webhookUrl)
+	}
+	const body =
+		input.destination.body === undefined
+			? undefined
+			: substituteWebhookUrlPlaceholder(
+					input.destination.body,
+					input.webhookUrl,
+				)
+	const auth = await authorizeApplyRequest({
+		env: input.env,
+		userId: input.userId,
+		userEmail: input.userEmail,
+		baseUrl: input.baseUrl,
+		packageId: input.packageId,
+		packageKodyId: input.packageKodyId,
+		url,
+		integration: input.destination.integration,
+		secretName: input.destination.secretName,
+		waitUntil: input.waitUntil,
+	})
+	return sendAuthorizedApplyRequest({
+		url,
+		method: input.destination.method ?? 'POST',
+		headers,
+		body,
+		authorization: auth.authorization,
+		retryAuthorization: auth.retryAuthorization,
+		secrets: collectWebhookCredentialSecrets({
+			url: input.webhookUrl,
+			urlSecret: input.urlSecret,
+		}),
+	})
+}
+
+async function dispatchGithubApply(input: {
+	env: Env
+	userId: string
+	userEmail?: string | null
+	baseUrl: string
+	packageId: string
+	packageKodyId: string
+	webhookName: string
+	savedPackage: SavedPackageRecord
+	webhookUrl: string
+	urlSecret: string
+	destination: WebhookUrlApplyGithubDestination
+	waitUntil?: (promise: Promise<unknown>) => void
+}): Promise<WebhookUrlApplyResult> {
+	const owner = input.destination.owner.trim()
+	const repo = input.destination.repo.trim()
+	const url = `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/hooks`
+	const declared = await loadDeclaredWebhookIfPresent({
+		env: input.env,
+		baseUrl: input.baseUrl,
+		userId: input.userId,
+		savedPackage: input.savedPackage,
+		webhookName: input.webhookName,
+	})
+	const hookSecretName =
+		input.destination.hookSecretName?.trim() ||
+		declared?.verification?.secretName ||
+		''
+	const hookSecret = hookSecretName
+		? await resolveHookSigningSecret({
+				env: input.env,
+				userId: input.userId,
+				packageId: input.packageId,
+				secretName: hookSecretName,
+			})
+		: null
+	const config: Record<string, string> = {
+		url: input.webhookUrl,
+		content_type: input.destination.contentType ?? 'json',
+		insecure_ssl: '0',
+	}
+	if (hookSecret) config.secret = hookSecret
+	const body = JSON.stringify({
+		name: 'web',
+		active: input.destination.active !== false,
+		events: input.destination.events?.length
+			? input.destination.events
+			: [...defaultGithubEvents],
+		config,
+	})
+	const auth = await authorizeApplyRequest({
+		env: input.env,
+		userId: input.userId,
+		userEmail: input.userEmail,
+		baseUrl: input.baseUrl,
+		packageId: input.packageId,
+		packageKodyId: input.packageKodyId,
+		url,
+		integration: input.destination.integration,
+		secretName: input.destination.secretName,
+		waitUntil: input.waitUntil,
+	})
+	const secrets = collectWebhookCredentialSecrets({
+		url: input.webhookUrl,
+		urlSecret: input.urlSecret,
+	})
+	if (hookSecret) secrets.push(hookSecret)
+	return sendAuthorizedApplyRequest({
+		url,
+		method: 'POST',
+		headers: {
+			Accept: 'application/vnd.github+json',
+			'Content-Type': 'application/json',
+			'User-Agent': 'kody',
+			'X-GitHub-Api-Version': '2022-11-28',
+		},
+		body,
+		authorization: auth.authorization,
+		retryAuthorization: auth.retryAuthorization,
+		secrets,
+	})
+}
+
+export async function dispatchWebhookUrlApply(input: {
+	env: Env
+	userId: string
+	userEmail?: string | null
+	baseUrl: string
+	packageId: string
+	packageKodyId: string
+	webhookName: string
+	savedPackage: SavedPackageRecord
+	webhookUrl: string
+	urlSecret: string
+	urlHost: string
+	destination: WebhookUrlApplyDestination
+	waitUntil?: (promise: Promise<unknown>) => void
+}): Promise<WebhookUrlApplyResult> {
+	let result: WebhookUrlApplyResult
+	switch (input.destination.type) {
+		case 'https':
+			result = await dispatchHttpsApply({
+				env: input.env,
+				userId: input.userId,
+				userEmail: input.userEmail,
+				baseUrl: input.baseUrl,
+				packageId: input.packageId,
+				packageKodyId: input.packageKodyId,
+				webhookUrl: input.webhookUrl,
+				urlSecret: input.urlSecret,
+				destination: input.destination,
+				waitUntil: input.waitUntil,
+			})
+			break
+		case 'github':
+			result = await dispatchGithubApply({
+				env: input.env,
+				userId: input.userId,
+				userEmail: input.userEmail,
+				baseUrl: input.baseUrl,
+				packageId: input.packageId,
+				packageKodyId: input.packageKodyId,
+				webhookName: input.webhookName,
+				savedPackage: input.savedPackage,
+				webhookUrl: input.webhookUrl,
+				urlSecret: input.urlSecret,
+				destination: input.destination,
+				waitUntil: input.waitUntil,
+			})
+			break
+		default: {
+			const exhaustive: never = input.destination
+			throw new Error(
+				`Unhandled webhook apply destination: ${String(exhaustive)}`,
+			)
+		}
+	}
+	const secrets = collectWebhookCredentialSecrets({
+		url: input.webhookUrl,
+		urlSecret: input.urlSecret,
+	})
+	return {
+		ok: result.ok,
+		urlHost: input.urlHost,
+		httpStatus: result.httpStatus,
+		remoteId: result.remoteId,
+		error:
+			typeof result.error === 'string'
+				? String(
+						redactWebhookCredentials(result.error, secrets) ?? result.error,
+					)
+				: null,
+	}
+}

--- a/packages/worker/src/webhooks/handle.ts
+++ b/packages/worker/src/webhooks/handle.ts
@@ -1,0 +1,20 @@
+export const webhookUrlHandlePrefix = 'whh_'
+
+export function formatWebhookUrlHandle(endpointId: string) {
+	return `${webhookUrlHandlePrefix}${endpointId}`
+}
+
+export function parseWebhookUrlHandle(handle: string) {
+	const trimmed = handle.trim()
+	if (!trimmed.startsWith(webhookUrlHandlePrefix)) return null
+	const endpointId = trimmed.slice(webhookUrlHandlePrefix.length)
+	return endpointId.length > 0 ? endpointId : null
+}
+
+export function webhookUrlHostFromOrigin(origin: string) {
+	try {
+		return new URL(origin).host
+	} catch {
+		return origin.replace(/^https?:\/\//, '').replace(/\/.*$/, '')
+	}
+}

--- a/packages/worker/src/webhooks/http.workers.test.ts
+++ b/packages/worker/src/webhooks/http.workers.test.ts
@@ -158,12 +158,22 @@ async function ensureSchema(db: D1Database) {
 				package_id TEXT NOT NULL,
 				webhook_name TEXT NOT NULL,
 				url_secret_hash TEXT NOT NULL,
+				url_secret_encrypted TEXT,
 				enabled INTEGER NOT NULL DEFAULT 1,
 				created_at TEXT NOT NULL,
 				rotated_at TEXT NOT NULL
 			)`,
 		)
 		.run()
+	try {
+		await db
+			.prepare(
+				`ALTER TABLE webhook_endpoints ADD COLUMN url_secret_encrypted TEXT`,
+			)
+			.run()
+	} catch {
+		// Column already present on newer schemas.
+	}
 }
 
 async function seedOwner() {

--- a/packages/worker/src/webhooks/redact.ts
+++ b/packages/worker/src/webhooks/redact.ts
@@ -1,16 +1,3 @@
-export const webhookUrlPlaceholder = '{{webhookUrl}}'
-
-export function substituteWebhookUrlPlaceholder(
-	template: string,
-	webhookUrl: string,
-) {
-	return template.replaceAll(webhookUrlPlaceholder, webhookUrl)
-}
-
-export function templateIncludesWebhookUrlPlaceholder(template: string) {
-	return template.includes(webhookUrlPlaceholder)
-}
-
 function redactPlaintext(value: string, secrets: ReadonlyArray<string>) {
 	let redacted = value
 	for (const secret of secrets) {

--- a/packages/worker/src/webhooks/redact.ts
+++ b/packages/worker/src/webhooks/redact.ts
@@ -1,0 +1,46 @@
+export const webhookUrlPlaceholder = '{{webhookUrl}}'
+
+export function substituteWebhookUrlPlaceholder(
+	template: string,
+	webhookUrl: string,
+) {
+	return template.replaceAll(webhookUrlPlaceholder, webhookUrl)
+}
+
+export function templateIncludesWebhookUrlPlaceholder(template: string) {
+	return template.includes(webhookUrlPlaceholder)
+}
+
+function redactPlaintext(value: string, secrets: ReadonlyArray<string>) {
+	let redacted = value
+	for (const secret of secrets) {
+		if (!secret) continue
+		redacted = redacted.split(secret).join('[redacted]')
+	}
+	return redacted
+}
+
+export function redactWebhookCredentials(
+	value: unknown,
+	secrets: ReadonlyArray<string>,
+): unknown {
+	if (typeof value === 'string') return redactPlaintext(value, secrets)
+	if (Array.isArray(value)) {
+		return value.map((entry) => redactWebhookCredentials(entry, secrets))
+	}
+	if (value && typeof value === 'object') {
+		const result: Record<string, unknown> = {}
+		for (const [key, entry] of Object.entries(value)) {
+			result[key] = redactWebhookCredentials(entry, secrets)
+		}
+		return result
+	}
+	return value
+}
+
+export function collectWebhookCredentialSecrets(input: {
+	url: string
+	urlSecret: string
+}) {
+	return [input.url, input.urlSecret]
+}

--- a/packages/worker/src/webhooks/repo.ts
+++ b/packages/worker/src/webhooks/repo.ts
@@ -6,6 +6,7 @@ type WebhookEndpointRow = {
 	package_id: string
 	webhook_name: string
 	url_secret_hash: string
+	url_secret_encrypted?: string | null
 	enabled: number
 	created_at: string
 	rotated_at: string
@@ -18,6 +19,7 @@ function mapEndpointRow(row: WebhookEndpointRow): WebhookEndpointRecord {
 		packageId: row.package_id,
 		webhookName: row.webhook_name,
 		urlSecretHash: row.url_secret_hash,
+		urlSecretEncrypted: row.url_secret_encrypted ?? null,
 		enabled: row.enabled === 1,
 		createdAt: row.created_at,
 		rotatedAt: row.rotated_at,
@@ -163,5 +165,27 @@ export async function setWebhookEndpointEnabled(input: {
 		userId: input.userId,
 		packageId: input.packageId,
 		webhookName: input.webhookName,
+	})
+}
+
+export async function updateWebhookEndpointSecretCiphertext(input: {
+	db: D1Database
+	userId: string
+	endpointId: string
+	urlSecretEncrypted: string
+}): Promise<WebhookEndpointRecord | null> {
+	const result = await input.db
+		.prepare(
+			`UPDATE webhook_endpoints
+			SET url_secret_encrypted = ?
+			WHERE id = ? AND user_id = ?`,
+		)
+		.bind(input.urlSecretEncrypted, input.endpointId, input.userId)
+		.run()
+	if ((result.meta.changes ?? 0) === 0) return null
+	return getWebhookEndpointByIdForUser({
+		db: input.db,
+		userId: input.userId,
+		endpointId: input.endpointId,
 	})
 }

--- a/packages/worker/src/webhooks/repo.ts
+++ b/packages/worker/src/webhooks/repo.ts
@@ -27,12 +27,12 @@ function mapEndpointRow(row: WebhookEndpointRow): WebhookEndpointRecord {
 }
 
 /**
- * Insert or rotate a minted webhook URL secret.
- * Concurrent mints for the same (user, package, name) resolve via the unique
- * index instead of throwing a constraint error.
+ * Insert or rotate a minted webhook URL secret. Hash and ciphertext are written
+ * in the same statement. The caller encrypts with `id` as AAD, so `id` must be
+ * the existing endpoint id on update.
  *
- * When `updateEnabledOnConflict` is true (mint/activate), conflict updates also
- * set `enabled` from the insert row. Rotate passes false so disable state sticks.
+ * When `updateEnabledOnConflict` is true (mint/activate), updates also set
+ * `enabled`. Rotate passes false so disable state sticks.
  */
 export async function upsertWebhookEndpointSecret(input: {
 	db: D1Database
@@ -41,41 +41,77 @@ export async function upsertWebhookEndpointSecret(input: {
 	packageId: string
 	webhookName: string
 	urlSecretHash: string
+	urlSecretEncrypted: string
 	enabled?: boolean
 	updateEnabledOnConflict?: boolean
 	now?: string
 }): Promise<WebhookEndpointRecord> {
 	const now = input.now ?? new Date().toISOString()
 	const enabled = input.enabled === false ? 0 : 1
-	const conflictSql = input.updateEnabledOnConflict
-		? `ON CONFLICT(user_id, package_id, webhook_name)
-			DO UPDATE SET
-				url_secret_hash = excluded.url_secret_hash,
-				rotated_at = excluded.rotated_at,
-				enabled = excluded.enabled`
-		: `ON CONFLICT(user_id, package_id, webhook_name)
-			DO UPDATE SET
-				url_secret_hash = excluded.url_secret_hash,
-				rotated_at = excluded.rotated_at`
-	await input.db
-		.prepare(
-			`INSERT INTO webhook_endpoints (
-				id, user_id, package_id, webhook_name, url_secret_hash,
-				enabled, created_at, rotated_at
-			) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-			${conflictSql}`,
-		)
-		.bind(
-			input.id,
-			input.userId,
-			input.packageId,
-			input.webhookName,
-			input.urlSecretHash,
-			enabled,
-			now,
-			now,
-		)
-		.run()
+	const existing = await getWebhookEndpointByKey({
+		db: input.db,
+		userId: input.userId,
+		packageId: input.packageId,
+		webhookName: input.webhookName,
+	})
+	if (existing) {
+		if (existing.id !== input.id) {
+			throw new Error('Unable to upsert webhook endpoint.')
+		}
+		const result = input.updateEnabledOnConflict
+			? await input.db
+					.prepare(
+						`UPDATE webhook_endpoints
+						SET url_secret_hash = ?, url_secret_encrypted = ?, rotated_at = ?, enabled = ?
+						WHERE user_id = ? AND id = ?`,
+					)
+					.bind(
+						input.urlSecretHash,
+						input.urlSecretEncrypted,
+						now,
+						enabled,
+						input.userId,
+						existing.id,
+					)
+					.run()
+			: await input.db
+					.prepare(
+						`UPDATE webhook_endpoints
+						SET url_secret_hash = ?, url_secret_encrypted = ?, rotated_at = ?
+						WHERE user_id = ? AND id = ?`,
+					)
+					.bind(
+						input.urlSecretHash,
+						input.urlSecretEncrypted,
+						now,
+						input.userId,
+						existing.id,
+					)
+					.run()
+		if ((result.meta.changes ?? 0) === 0) {
+			throw new Error('Unable to upsert webhook endpoint.')
+		}
+	} else {
+		await input.db
+			.prepare(
+				`INSERT INTO webhook_endpoints (
+					id, user_id, package_id, webhook_name, url_secret_hash,
+					url_secret_encrypted, enabled, created_at, rotated_at
+				) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			)
+			.bind(
+				input.id,
+				input.userId,
+				input.packageId,
+				input.webhookName,
+				input.urlSecretHash,
+				input.urlSecretEncrypted,
+				enabled,
+				now,
+				now,
+			)
+			.run()
+	}
 	const record = await getWebhookEndpointByKey({
 		db: input.db,
 		userId: input.userId,
@@ -165,27 +201,5 @@ export async function setWebhookEndpointEnabled(input: {
 		userId: input.userId,
 		packageId: input.packageId,
 		webhookName: input.webhookName,
-	})
-}
-
-export async function updateWebhookEndpointSecretCiphertext(input: {
-	db: D1Database
-	userId: string
-	endpointId: string
-	urlSecretEncrypted: string
-}): Promise<WebhookEndpointRecord | null> {
-	const result = await input.db
-		.prepare(
-			`UPDATE webhook_endpoints
-			SET url_secret_encrypted = ?
-			WHERE id = ? AND user_id = ?`,
-		)
-		.bind(input.urlSecretEncrypted, input.endpointId, input.userId)
-		.run()
-	if ((result.meta.changes ?? 0) === 0) return null
-	return getWebhookEndpointByIdForUser({
-		db: input.db,
-		userId: input.userId,
-		endpointId: input.endpointId,
 	})
 }

--- a/packages/worker/src/webhooks/service.node.test.ts
+++ b/packages/worker/src/webhooks/service.node.test.ts
@@ -1,11 +1,17 @@
 import { DatabaseSync } from 'node:sqlite'
 import { expect, test, vi } from 'vitest'
+import {
+	decryptWebhookUrlSecret,
+	userWebhookUrlSecretContext,
+} from '#mcp/secrets/crypto.ts'
 import { createD1FromSqlite } from '#worker/test-support/create-d1-from-sqlite.ts'
 import { createStableUserIdFromEmail } from '#worker/user-id.ts'
 import { hashWebhookUrlSecret } from './crypto.ts'
+import { parseWebhookUrlHandle } from './handle.ts'
 import {
 	listWebhooksForUser,
 	mintWebhookUrlForUser,
+	revealWebhookUrlForWebsite,
 	rotateWebhookUrlForUser,
 	setWebhookEnabledForUser,
 } from './service.ts'
@@ -88,6 +94,7 @@ function createEnv(userId: string) {
 			package_id TEXT NOT NULL,
 			webhook_name TEXT NOT NULL,
 			url_secret_hash TEXT NOT NULL,
+			url_secret_encrypted TEXT,
 			enabled INTEGER NOT NULL DEFAULT 1 CHECK (enabled IN (0, 1)),
 			created_at TEXT NOT NULL,
 			rotated_at TEXT NOT NULL
@@ -149,8 +156,20 @@ test('mint/list/rotate/enable/disable webhooks are package-centered and user-sco
 		kodyId: 'sentry-bridge',
 		webhookName: 'sentry',
 	})
-	expect(minted.url).toContain('/@owner/webhooks/sentry-bridge/sentry/')
-	expect(minted.urlSecret.length).toBeGreaterThan(10)
+	expect(minted.handle.startsWith('whh_')).toBe(true)
+	expect(minted.urlHost).toBe('heykody.dev')
+	expect(minted).not.toHaveProperty('url')
+	expect(minted).not.toHaveProperty('urlSecret')
+	expect(minted).not.toHaveProperty('url_secret')
+
+	const revealed = await revealWebhookUrlForWebsite({
+		env,
+		userId,
+		username: 'owner',
+		handle: minted.handle,
+	})
+	expect(revealed.url).toContain('/@owner/webhooks/sentry-bridge/sentry/')
+	expect(revealed.urlHost).toBe('heykody.dev')
 
 	const listed = await listWebhooksForUser({
 		env,
@@ -159,8 +178,13 @@ test('mint/list/rotate/enable/disable webhooks are package-centered and user-sco
 	})
 	expect(listed[0]?.minted).toBe(true)
 	expect(listed[0]?.enabled).toBe(true)
+	expect(listed[0]?.handle).toBe(minted.handle)
+	expect(listed[0]?.urlHost).toBe('heykody.dev')
 	expect(listed[0]).not.toHaveProperty('url')
-	expect(JSON.stringify(listed)).not.toContain(minted.urlSecret)
+	expect(JSON.stringify(listed)).not.toContain(revealed.url)
+	expect(JSON.stringify(listed)).not.toContain(
+		revealed.url.slice(revealed.url.lastIndexOf('/') + 1),
+	)
 
 	const otherList = await listWebhooksForUser({
 		env,
@@ -177,16 +201,31 @@ test('mint/list/rotate/enable/disable webhooks are package-centered and user-sco
 		kodyId: 'sentry-bridge',
 		webhookName: 'sentry',
 	})
-	expect(rotated.urlSecret).not.toBe(minted.urlSecret)
+	expect(rotated.handle).toBe(minted.handle)
+	expect(rotated).not.toHaveProperty('url')
 	const stored = await db
 		.prepare(
-			`SELECT url_secret_hash FROM webhook_endpoints
+			`SELECT id, url_secret_hash, url_secret_encrypted FROM webhook_endpoints
 			WHERE user_id = ? AND package_id = 'pkg-1' AND webhook_name = 'sentry'`,
 		)
 		.bind(userId)
-		.first<{ url_secret_hash: string }>()
+		.first<{
+			id: string
+			url_secret_hash: string
+			url_secret_encrypted: string
+		}>()
+	expect(stored?.id).toBe(parseWebhookUrlHandle(rotated.handle))
+	expect(stored?.url_secret_encrypted).toBeTruthy()
+	const rotatedSecret = await decryptWebhookUrlSecret(
+		env,
+		stored!.url_secret_encrypted,
+		userWebhookUrlSecretContext(userId, stored!.id),
+	)
 	expect(stored?.url_secret_hash).toBe(
-		await hashWebhookUrlSecret(rotated.urlSecret),
+		await hashWebhookUrlSecret(rotatedSecret),
+	)
+	expect(rotatedSecret).not.toBe(
+		revealed.url.slice(revealed.url.lastIndexOf('/') + 1),
 	)
 
 	const disabled = await setWebhookEnabledForUser({
@@ -215,5 +254,6 @@ test('mint/list/rotate/enable/disable webhooks are package-centered and user-sco
 		webhookName: 'sentry',
 	})
 	expect(reminted.enabled).toBe(true)
-	expect(reminted.urlSecret).not.toBe(rotatedWhileDisabled.urlSecret)
+	expect(reminted.handle).toBe(rotatedWhileDisabled.handle)
+	expect(reminted).not.toHaveProperty('urlSecret')
 })

--- a/packages/worker/src/webhooks/service.ts
+++ b/packages/worker/src/webhooks/service.ts
@@ -5,6 +5,7 @@ import {
 	userWebhookUrlSecretContext,
 } from '#mcp/secrets/crypto.ts'
 import { getAppBaseUrl } from '#worker/app-base-url.ts'
+import { getUniqueConstraintField } from '#worker/database-errors.ts'
 import { resolvePublicUsername } from '#worker/identity/user-lookup.ts'
 import {
 	listPackageWebhooks,
@@ -35,7 +36,6 @@ import {
 	getWebhookEndpointByKey,
 	listWebhookEndpointsForUser,
 	setWebhookEndpointEnabled,
-	updateWebhookEndpointSecretCiphertext,
 	upsertWebhookEndpointSecret,
 } from './repo.ts'
 import { type WebhookEndpointRecord } from './types.ts'
@@ -250,28 +250,45 @@ export async function mintWebhookUrlForUser(input: {
 
 	const urlSecret = await generateWebhookUrlSecret()
 	const urlSecretHash = await hashWebhookUrlSecret(urlSecret)
-	const record = await upsertWebhookEndpointSecret({
+	const existing = await getWebhookEndpointByKey({
 		db: input.env.APP_DB,
-		id: crypto.randomUUID(),
 		userId: input.userId,
 		packageId: savedPackage.id,
 		webhookName,
-		urlSecretHash,
-		enabled: true,
-		updateEnabledOnConflict: activate,
 	})
-
-	const encrypted = await encryptWebhookUrlSecret(
-		input.env,
-		urlSecret,
-		userWebhookUrlSecretContext(input.userId, record.id),
-	)
-	const stored = await updateWebhookEndpointSecretCiphertext({
-		db: input.env.APP_DB,
-		userId: input.userId,
-		endpointId: record.id,
-		urlSecretEncrypted: encrypted,
-	})
+	let endpointId = existing?.id ?? crypto.randomUUID()
+	let stored: WebhookEndpointRecord | null = null
+	for (let attempt = 0; attempt < 2; attempt++) {
+		const encrypted = await encryptWebhookUrlSecret(
+			input.env,
+			urlSecret,
+			userWebhookUrlSecretContext(input.userId, endpointId),
+		)
+		try {
+			stored = await upsertWebhookEndpointSecret({
+				db: input.env.APP_DB,
+				id: endpointId,
+				userId: input.userId,
+				packageId: savedPackage.id,
+				webhookName,
+				urlSecretHash,
+				urlSecretEncrypted: encrypted,
+				enabled: true,
+				updateEnabledOnConflict: activate,
+			})
+			break
+		} catch (error) {
+			if (attempt > 0 || !getUniqueConstraintField(error)) throw error
+			const raced = await getWebhookEndpointByKey({
+				db: input.env.APP_DB,
+				userId: input.userId,
+				packageId: savedPackage.id,
+				webhookName,
+			})
+			if (!raced) throw error
+			endpointId = raced.id
+		}
+	}
 	if (!stored) {
 		throw new Error('Unable to persist webhook URL secret.')
 	}

--- a/packages/worker/src/webhooks/service.ts
+++ b/packages/worker/src/webhooks/service.ts
@@ -1,3 +1,9 @@
+import { McpCallerError } from '#mcp/caller-error.ts'
+import {
+	decryptWebhookUrlSecret,
+	encryptWebhookUrlSecret,
+	userWebhookUrlSecretContext,
+} from '#mcp/secrets/crypto.ts'
 import { getAppBaseUrl } from '#worker/app-base-url.ts'
 import { resolvePublicUsername } from '#worker/identity/user-lookup.ts'
 import {
@@ -8,12 +14,28 @@ import { resolveSavedPackage } from '#worker/package-invocations/module-artifact
 import { listSavedPackagesByUserId } from '#worker/package-registry/repo.ts'
 import { loadPackageManifestBySourceId } from '#worker/package-registry/source.ts'
 import { type SavedPackageRecord } from '#worker/package-registry/types.ts'
-import { generateWebhookUrlSecret, hashWebhookUrlSecret } from './crypto.ts'
+import {
+	dispatchWebhookUrlApply,
+	type WebhookUrlApplyDestination,
+	type WebhookUrlApplyResult,
+} from './apply.ts'
+import {
+	generateWebhookUrlSecret,
+	hashWebhookUrlSecret,
+	webhookUrlSecretMatches,
+} from './crypto.ts'
+import {
+	formatWebhookUrlHandle,
+	parseWebhookUrlHandle,
+	webhookUrlHostFromOrigin,
+} from './handle.ts'
 import { buildWebhookEndpointUrl } from './public-url.ts'
 import {
+	getWebhookEndpointByIdForUser,
 	getWebhookEndpointByKey,
 	listWebhookEndpointsForUser,
 	setWebhookEndpointEnabled,
+	updateWebhookEndpointSecretCiphertext,
 	upsertWebhookEndpointSecret,
 } from './repo.ts'
 import { type WebhookEndpointRecord } from './types.ts'
@@ -31,21 +53,30 @@ export type ListedWebhook = {
 	verification: PackageWebhookManifestEntry['verification']
 	replay: PackageWebhookManifestEntry['replay']
 	minted: boolean
+	handle: string | null
+	urlHost: string | null
 	enabled: boolean | null
 	createdAt: string | null
 	rotatedAt: string | null
 }
 
-export type MintedWebhookUrl = {
+export type MintedWebhookHandle = {
 	packageId: string
 	packageKodyId: string
 	name: string
-	url: string
-	urlSecret: string
+	handle: string
+	urlHost: string
 	enabled: boolean
 	createdAt: string
 	rotatedAt: string
 }
+
+export type {
+	WebhookUrlApplyDestination,
+	WebhookUrlApplyGithubDestination,
+	WebhookUrlApplyHttpsDestination,
+	WebhookUrlApplyResult,
+} from './apply.ts'
 
 async function resolveOwnerUsername(input: {
 	db: D1Database
@@ -138,6 +169,7 @@ export async function listWebhooksForUser(input: {
 	}
 
 	const listed: Array<ListedWebhook> = []
+	const urlHost = webhookUrlHostFromOrigin(input.baseUrl)
 	for (const savedPackage of filteredPackages) {
 		const loaded = await loadPackageManifestBySourceId({
 			env: input.env,
@@ -168,6 +200,8 @@ export async function listWebhooksForUser(input: {
 				verification: webhook.verification,
 				replay: webhook.replay,
 				minted: mint !== undefined,
+				handle: mint ? formatWebhookUrlHandle(mint.id) : null,
+				urlHost: mint ? urlHost : null,
 				enabled: mint?.enabled ?? null,
 				createdAt: mint?.createdAt ?? null,
 				rotatedAt: mint?.rotatedAt ?? null,
@@ -193,7 +227,7 @@ export async function mintWebhookUrlForUser(input: {
 	requestUrl?: string | null
 	/** When false, rotate secret without forcing enabled=true on conflict. */
 	activate?: boolean
-}): Promise<MintedWebhookUrl> {
+}): Promise<MintedWebhookHandle> {
 	const webhookName = input.webhookName.trim()
 	if (!webhookName) throw new Error('webhookName is required.')
 	const activate = input.activate !== false
@@ -228,26 +262,30 @@ export async function mintWebhookUrlForUser(input: {
 		updateEnabledOnConflict: activate,
 	})
 
-	const username = await resolveOwnerUsername({
+	const encrypted = await encryptWebhookUrlSecret(
+		input.env,
+		urlSecret,
+		userWebhookUrlSecretContext(input.userId, record.id),
+	)
+	const stored = await updateWebhookEndpointSecretCiphertext({
 		db: input.env.APP_DB,
-		email: input.email,
-		username: input.username,
+		userId: input.userId,
+		endpointId: record.id,
+		urlSecretEncrypted: encrypted,
 	})
+	if (!stored) {
+		throw new Error('Unable to persist webhook URL secret.')
+	}
+
 	return {
 		packageId: savedPackage.id,
 		packageKodyId: savedPackage.kodyId,
 		name: webhookName,
-		urlSecret,
-		url: buildWebhookEndpointUrl({
-			origin: baseUrl,
-			username,
-			packageKodyId: savedPackage.kodyId,
-			webhookName,
-			urlSecret,
-		}),
-		enabled: record.enabled,
-		createdAt: record.createdAt,
-		rotatedAt: record.rotatedAt,
+		handle: formatWebhookUrlHandle(stored.id),
+		urlHost: webhookUrlHostFromOrigin(baseUrl),
+		enabled: stored.enabled,
+		createdAt: stored.createdAt,
+		rotatedAt: stored.rotatedAt,
 	}
 }
 
@@ -260,7 +298,7 @@ export async function rotateWebhookUrlForUser(input: {
 	kodyId?: string
 	webhookName: string
 	requestUrl?: string | null
-}): Promise<MintedWebhookUrl> {
+}): Promise<MintedWebhookHandle> {
 	const webhookName = input.webhookName.trim()
 	if (!webhookName) throw new Error('webhookName is required.')
 	const savedPackage = await resolveOwnedPackage({
@@ -315,4 +353,121 @@ export async function setWebhookEnabledForUser(input: {
 		)
 	}
 	return updated
+}
+
+async function resolveMintedWebhookUrl(input: {
+	env: Env
+	userId: string
+	email?: string | null
+	username?: string | null
+	handle: string
+	requestUrl?: string | null
+}) {
+	const endpointId = parseWebhookUrlHandle(input.handle)
+	if (!endpointId) {
+		throw new McpCallerError('Invalid webhook URL handle.')
+	}
+	const endpoint = await getWebhookEndpointByIdForUser({
+		db: input.env.APP_DB,
+		userId: input.userId,
+		endpointId,
+	})
+	if (!endpoint) {
+		throw new McpCallerError('Webhook handle was not found for this user.')
+	}
+	if (!endpoint.urlSecretEncrypted) {
+		throw new McpCallerError(
+			'Webhook URL secret is not recoverable from this mint. Call webhookUrlRotate, then webhookUrlApply.',
+		)
+	}
+	const urlSecret = await decryptWebhookUrlSecret(
+		input.env,
+		endpoint.urlSecretEncrypted,
+		userWebhookUrlSecretContext(input.userId, endpoint.id),
+	)
+	const matches = await webhookUrlSecretMatches({
+		candidate: urlSecret,
+		storedHash: endpoint.urlSecretHash,
+	})
+	if (!matches) {
+		throw new McpCallerError(
+			'Webhook URL secret is inconsistent. Call webhookUrlRotate, then webhookUrlApply.',
+		)
+	}
+	const savedPackage = await resolveOwnedPackage({
+		db: input.env.APP_DB,
+		userId: input.userId,
+		packageId: endpoint.packageId,
+	})
+	const baseUrl = getAppBaseUrl({
+		env: input.env,
+		requestUrl: input.requestUrl,
+	})
+	const username = await resolveOwnerUsername({
+		db: input.env.APP_DB,
+		email: input.email,
+		username: input.username,
+	})
+	const url = buildWebhookEndpointUrl({
+		origin: baseUrl,
+		username,
+		packageKodyId: savedPackage.kodyId,
+		webhookName: endpoint.webhookName,
+		urlSecret,
+	})
+	return {
+		endpoint,
+		savedPackage,
+		urlSecret,
+		url,
+		urlHost: webhookUrlHostFromOrigin(baseUrl),
+		baseUrl,
+	}
+}
+
+export async function applyWebhookUrlForUser(input: {
+	env: Env
+	userId: string
+	email?: string | null
+	username?: string | null
+	handle: string
+	destination: WebhookUrlApplyDestination
+	requestUrl?: string | null
+	waitUntil?: (promise: Promise<unknown>) => void
+}): Promise<WebhookUrlApplyResult> {
+	const resolved = await resolveMintedWebhookUrl(input)
+	return dispatchWebhookUrlApply({
+		env: input.env,
+		userId: input.userId,
+		userEmail: input.email,
+		baseUrl: resolved.baseUrl,
+		packageId: resolved.savedPackage.id,
+		packageKodyId: resolved.savedPackage.kodyId,
+		webhookName: resolved.endpoint.webhookName,
+		savedPackage: resolved.savedPackage,
+		webhookUrl: resolved.url,
+		urlSecret: resolved.urlSecret,
+		urlHost: resolved.urlHost,
+		destination: input.destination,
+		waitUntil: input.waitUntil,
+	})
+}
+
+/**
+ * Website-only debug reveal. Do not expose this through MCP or execute.
+ */
+export async function revealWebhookUrlForWebsite(input: {
+	env: Env
+	userId: string
+	email?: string | null
+	username?: string | null
+	handle: string
+	requestUrl?: string | null
+}) {
+	const resolved = await resolveMintedWebhookUrl(input)
+	return {
+		handle: formatWebhookUrlHandle(resolved.endpoint.id),
+		urlHost: resolved.urlHost,
+		url: resolved.url,
+	}
 }

--- a/packages/worker/src/webhooks/service.ts
+++ b/packages/worker/src/webhooks/service.ts
@@ -74,7 +74,6 @@ export type MintedWebhookHandle = {
 export type {
 	WebhookUrlApplyDestination,
 	WebhookUrlApplyGithubDestination,
-	WebhookUrlApplyHttpsDestination,
 	WebhookUrlApplyResult,
 } from './apply.ts'
 

--- a/packages/worker/src/webhooks/types.ts
+++ b/packages/worker/src/webhooks/types.ts
@@ -44,6 +44,7 @@ export type WebhookEndpointRecord = {
 	packageId: string
 	webhookName: string
 	urlSecretHash: string
+	urlSecretEncrypted: string | null
 	enabled: boolean
 	createdAt: string
 	rotatedAt: string

--- a/packages/worker/universal/how-kody-works-transcript.ts
+++ b/packages/worker/universal/how-kody-works-transcript.ts
@@ -494,7 +494,7 @@ const notifySearchMarkdown = `# Search results
 For full detail on entity-backed hits, call \`search\` with \`entity: "{id}:{type}"\`.
 
 1. **guide** Durable package lifecycle guide — Choose reuse vs temporary execute vs a new durable package. Entity: \`package_lifecycle:guide\`
-2. **capability** \`webhookUrlMint\` (\`webhooks\`) — Mint an inbound webhook URL for a package-declared webhook. Entity: \`webhookUrlMint:capability\`
+2. **capability** \`webhookUrlMint\` (\`webhooks\`) — Mint an inbound webhook URL handle for a package-declared webhook. Entity: \`webhookUrlMint:capability\`
 3. **capability** \`jobList\` (\`jobs\`) — List scheduled jobs for the signed-in user. Entity: \`jobList:capability\``
 
 export const howKodyWorksTranscriptActs: Array<TranscriptAct> = [

--- a/tools/migration-ledger.json
+++ b/tools/migration-ledger.json
@@ -227,6 +227,10 @@
 		{
 			"filename": "0056-drop-fleet-execute-days.sql",
 			"sha256": "6706cd3841ea5efc255cd09cd7688cf042e9f9850488d0c0d5492f9ca355978f"
+		},
+		{
+			"filename": "0057-webhook-url-secret-encrypted.sql",
+			"sha256": "9894e2f5fc7be2cca807562ee7d8b705d724f1004d032f4f6f923759340260e5"
 		}
 	]
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Satisfy OpenAI Apps review rejection **14393831** (`url_secret` / full credential-bearing webhook URL in model-visible tool output) without taking away agent autonomy for destinations Kody can register safely.

## Why

`webhookUrlMint` and `webhookUrlRotate` returned the plaintext ingress URL and `url_secret`. Host models (including ChatGPT) must not see usable webhook credentials. List already redacted; mint/rotate did not.

A generic `apply({ url, body: '{{webhookUrl}}' })` would still let the model exfiltrate the minted URL to an attacker host. That is unacceptable for secret substitution.

## Summary

- `webhookUrlMint` / `webhookUrlRotate` return metadata plus an opaque `handle` (`whh_<endpoint-id>`) and `url_host`. They never return `url` or `url_secret`.
- New `webhookUrlApply` resolves the handle inside Kody and registers the URL through a **first-class destination adapter**. The GitHub adapter creates `POST /repos/{owner}/{repo}/hooks` on `api.github.com` via the user GitHub integration (or a host-approved GitHub token) and injects the credential into GitHub's hook config.
- **Apply does not accept a caller-chosen HTTPS URL.** Integrations-only adapters are the safest path that still gives zero copy/paste for GitHub. A future host-allowlist primitive could widen autonomy; raw HTTPS substitution is out of scope.
- Minted secrets are stored encrypted (`url_secret_encrypted`) so apply can consume them. Ingress still uses the SHA-256 hash. Hash and ciphertext are written in one statement.
- Apply fails closed when a configured GitHub hook signing secret is missing or not approved for `api.github.com`, when the package manifest cannot be loaded, or when GitHub owner/repo is `.` / `..`.
- Destination `fetch` uses `redirect: 'manual'`, a 15s timeout, and a bounded response read. Credential echoes are redacted from results.
- Docs and types updated for agents.

### API shape

**Mint / rotate / list (minted rows)**

```ts
{ handle: 'whh_…', url_host: 'kody.codes', package_id, package_kody_id, name, enabled, … }
```

**Apply**

```ts
webhookUrlApply({
  handle,
  destination: {
    type: 'github',
    owner,
    repo,
    events?,
    contentType?,
    active?,
    integration?, // default 'github' when secretName omitted
    secretName?,
    hookSecretName?,
  },
})
// → { ok, url_host, http_status, remote_id, error }
```

## Testing

- `vitest` node: webhook service, GitHub apply happy path + redaction + legacy ciphertext, redirect not followed, manifest-load failure, missing hook secret, dot-only slugs rejected, capability schema rejects `type: 'https'`
- Pre-commit: worker typecheck and `migrations:check`
- Push hook: `test:node` and `test:workers` on each push

## System changes

Medium risk: extends the inbound webhooks contract and D1 mint row. No new primitive.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `3157bf9e` · **Head:** `4fb898c5`

**Classification:** extends — webhook mint/rotate contract changes, GitHub-only apply capability, encrypted secret column.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `webhooks` | assistant | extends — mint/rotate return `handle` + `url_host`, add GitHub `webhookUrlApply` |
| `d1-app-db` | storage | extends — `webhook_endpoints.url_secret_encrypted` |
| `mcp-server` | surfaces | extends — webhook URL secret ciphertext purpose and capability schemas |
| `app-ui` | surfaces | composes — factory transcript copy |
| `account-export` | assistant | extends — export redacts `url_secret_encrypted` |

### Change flow

Agents mint a handle, then GitHub apply injects the real URL inside Kody so the model never sees `url_secret` and cannot send it to an arbitrary host.

```mermaid
sequenceDiagram
	actor Agent
	participant mcpServer as mcp-server
	participant webhooks as webhooks
	participant d1AppDb as d1-app-db
	participant Destination
	Agent->>mcpServer: webhookUrlMint
	mcpServer->>webhooks: mintWebhookUrlForUser
	webhooks->>d1AppDb: write url_secret_hash and url_secret_encrypted
	webhooks-->>mcpServer: handle and url_host
	mcpServer-->>Agent: no url or url_secret
	Agent->>mcpServer: webhookUrlApply type github
	mcpServer->>webhooks: resolve handle, POST api.github.com hooks
	webhooks->>Destination: inject URL in GitHub hook config
	Destination-->>webhooks: remote hook id
	webhooks-->>Agent: ok, remote_id, url_host
```

### Before / after

```
mint/rotate → { url, url_secret, ... }
```

```
mint/rotate → { handle, url_host, ... }
apply(handle, { type: 'github', owner, repo }) → { ok, url_host, http_status, remote_id, error }
```

Apply does not accept a caller-chosen HTTPS URL. First-class adapters only.

### Invariants

Per-user isolation is unchanged: handle lookup and decrypt AAD are scoped by `userId`.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1310e39e-0b84-4b58-81de-5c4cb02067e8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1310e39e-0b84-4b58-81de-5c4cb02067e8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `webhookUrlApply` to register webhook handles with GitHub repository destinations.
  - Webhook minting and rotation now return opaque handles and host information instead of credential URLs.
  - Added application results with status, errors, and remote identifiers.

- **Security**
  - Credential URLs and secrets are excluded from MCP responses and account exports.
  - Webhook secrets are encrypted for server-side application and protected from credential-bearing redirects.

- **Documentation**
  - Updated setup, lifecycle, package invocation, and architecture guidance for the handle-based workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->