### PR TITLE
Raise public execute + outbound daily/weekly caps

### DIFF
--- a/.agents/skills/control-kody/references/features/billing.md
+++ b/.agents/skills/control-kody/references/features/billing.md
@@ -19,12 +19,14 @@ Do not complete a real Stripe checkout from a Cloud Agent. Existing subscribers
 change plans through the Stripe portal (proration). Deleting an account refunds
 unused paid subscription time automatically. `/account/usage` and `usageGet`
 include unique Dynamic Worker days and Durable Object rows-read with what-counts
-copy. Public-ladder overage uses the list rates on `/pricing`. Monthly includes
-follow the effective plan at invoice time, including an unexpired second-agent
-gift or referral Standard overlay. Referral share links set a one-week last-wins
-`kody_ref` cookie; signup persists the referrer then. Referral rewards fire on
-the referee's first qualifying paid Stripe invoice (not a trial) after both
-emails are verified; do not invent a paid invoice from this environment.
+copy. Public-ladder execute and outbound fetches show today and this UTC week
+(Monday–Sunday); whichever window hits first blocks. Public-ladder overage uses
+the list rates on `/pricing`. Monthly includes follow the effective plan at
+invoice time, including an unexpired second-agent gift or referral Standard
+overlay. Referral share links set a one-week last-wins `kody_ref` cookie; signup
+persists the referrer then. Referral rewards fire on the referee's first
+qualifying paid Stripe invoice (not a trial) after both emails are verified; do
+not invent a paid invoice from this environment.
 
 ## APIs
 

--- a/docs/contributing/architecture/entitlements.md
+++ b/docs/contributing/architecture/entitlements.md
@@ -196,8 +196,11 @@ other resources use the ordinary `planLimits.max` numbers.
 
 `execute_calls_per_day`, `outbound_fetches_per_day`, and `job_runs_per_day` are
 daily-counter resources (same mechanism as `email_sends_per_day`, consumed
-atomically with `consumeDailyEntitlement`). They close the metering →
-enforcement loop for the compute surfaces `usage-metering.md` already observes:
+atomically with `consumeDailyEntitlement`). Public Free/Standard/Pro also apply
+a UTC-week hard cap on execute and outbound fetches (Monday–Sunday, summed from
+the same UserMeter daily rows). Whichever window hits first blocks. `max` and
+legacy Standard/Pro stay daily-only. They close the metering → enforcement loop
+for the compute surfaces `usage-metering.md` already observes:
 
 - **Execute calls** are consumed at the top of the MCP `execute` tool handler
   (`packages/worker/src/mcp/tools/execute.ts`) before any bundling or sandbox
@@ -270,13 +273,14 @@ including an unexpired second-agent gift or referral Standard credit (the later
 of the two expiry columns, same helper as `getUserEntitlement`). There is no
 month-end plan snapshot; a plan or overlay that is expired when the job runs
 prices the prior month against the then-current includes. D1 evaluation failures
-fail closed (no charges). Execute is a hard daily cap with no overage
-(`computeMeteringPolicy.executeCallsPerDay`) — an execute overage would
-double-charge the same burn as unique worker days. Durable Object duration is
-unmetered; a later duration rate should stay list plus a thin markup. Overage is
-a heavy-tail safety valve only (`computeMeteringPolicy.overageRole`): included
-amounts and the public Pro $49 price are not sized to monetize via overage.
-Legacy Standard/Pro accounts are not cut and not billed on these allotments
+fail closed (no charges). Execute and outbound fetches are hard daily and weekly
+caps with no overage (`computeMeteringPolicy.executeCallsPerDay`) — an execute
+overage would double-charge the same burn as unique worker days. Durable Object
+duration is unmetered; a later duration rate should stay list plus a thin
+markup. Overage is a heavy-tail safety valve only
+(`computeMeteringPolicy.overageRole`): included amounts and the public Pro $49
+price are not sized to monetize via overage. Legacy Standard/Pro accounts are
+not cut and not billed on these allotments
 (`computeMeteringPolicy.legacyMonthlyMeters`); they get the same approaching and
 reached warnings. See [Usage metering](./usage-metering.md).
 
@@ -718,10 +722,11 @@ Rules:
   per-user UserMeter Durable Object** (UTC day keys). Call
   `consumeDailyEntitlement` on every attempt: it resolves the plan limit,
   atomically checks and increments inside the DO, and throws
-  `EntitlementLimitError` when over limit. Every resolved plan has a finite
-  numeric limit. Counting attempts rather than successes keeps the limit
-  abuse-resistant for permanent rejects (parse failures, entitlement/quota
-  rejects).
+  `EntitlementLimitError` when over limit. Public Free/Standard/Pro execute and
+  outbound also check a UTC-week sum of those same daily rows; whichever window
+  hits first blocks. Every resolved plan has a finite numeric limit. Counting
+  attempts rather than successes keeps the limit abuse-resistant for permanent
+  rejects (parse failures, entitlement/quota rejects).
 
   **Cold bootstrap:** missing `(resource, day)` rows trigger
   `UserMeter.initialize({ count: 0 })` (`INSERT OR IGNORE`) before retrying the

--- a/docs/contributing/architecture/usage-metering.md
+++ b/docs/contributing/architecture/usage-metering.md
@@ -155,12 +155,13 @@ Cloudflare bill unit: one unique Dynamic Worker id per user per UTC day, on
 every sandbox surface that creates a worker.
 `PlanLimits.maxUniqueWorkerDaysPerMonth` is the public included allotment shown
 on `/pricing`. It is not in `entitlementResources` and does not replace the hard
-daily `execute` / `job_run` caps. `usageGet` and the account usage UI report
-this meter (and Durable Object rows-read) with `whatCounts` / `howToReduce` so
-the include is self-explanatory. When unique-worker-day pressure is hot (limit
-denial or over 80%), those payloads also include a short `mechanic` line: meter
-name plus what a unique worker day is. Agent-facing package docs do not repeat
-the cost model; see [Platform efficiency](../../guides/platform-efficiency.md).
+daily `execute` / `job_run` caps, or the public-ladder weekly execute and
+outbound-fetch windows. `usageGet` and the account usage UI report this meter
+(and Durable Object rows-read) with `whatCounts` / `howToReduce` so the include
+is self-explanatory. When unique-worker-day pressure is hot (limit denial or
+over 80%), those payloads also include a short `mechanic` line: meter name plus
+what a unique worker day is. Agent-facing package docs do not repeat the cost
+model; see [Platform efficiency](../../guides/platform-efficiency.md).
 
 ### Unique worker days by surface
 

--- a/packages/shared/src/date-keys.node.test.ts
+++ b/packages/shared/src/date-keys.node.test.ts
@@ -1,9 +1,21 @@
 import { expect, test } from 'vitest'
-import { isoTimestampDayKey, utcDayKey, utcMonthKey } from './date-keys.ts'
+import {
+	isoTimestampDayKey,
+	utcDayKey,
+	utcMonthKey,
+	utcWeekStart,
+} from './date-keys.ts'
 
 test('date keys derive stable UTC prefixes', () => {
 	const date = new Date('2026-07-05T23:59:59.999Z')
 	expect(utcDayKey(date)).toBe('2026-07-05')
 	expect(utcMonthKey(date)).toBe('2026-07')
 	expect(isoTimestampDayKey('2026-07-05T23:59:59.999Z')).toBe('2026-07-05')
+})
+
+test('utcWeekStart is the UTC Monday of the containing week', () => {
+	expect(utcWeekStart(new Date('2026-07-06T00:00:00.000Z'))).toBe('2026-07-06')
+	expect(utcWeekStart(new Date('2026-07-08T15:00:00.000Z'))).toBe('2026-07-06')
+	expect(utcWeekStart(new Date('2026-07-12T23:59:59.999Z'))).toBe('2026-07-06')
+	expect(utcWeekStart(new Date('2026-07-13T00:00:00.000Z'))).toBe('2026-07-13')
 })

--- a/packages/shared/src/date-keys.ts
+++ b/packages/shared/src/date-keys.ts
@@ -1,9 +1,19 @@
 const isoDayKeyLength = 'YYYY-MM-DD'.length
 const isoMonthKeyLength = 'YYYY-MM'.length
+const utcDayMs = 24 * 60 * 60 * 1000
 
 /** UTC calendar day key, for example `2026-07-08`. */
 export function utcDayKey(date: Date = new Date()) {
 	return date.toISOString().slice(0, isoDayKeyLength)
+}
+
+/**
+ * UTC Monday that starts the week containing `date`, for example
+ * `2026-07-06` for Sunday 2026-07-12.
+ */
+export function utcWeekStart(date: Date = new Date()) {
+	const daysSinceMonday = (date.getUTCDay() + 6) % 7
+	return utcDayKey(new Date(date.getTime() - daysSinceMonday * utcDayMs))
 }
 
 /** UTC calendar month key, for example `2026-07`. */

--- a/packages/worker/client/routes/account-usage.node.test.ts
+++ b/packages/worker/client/routes/account-usage.node.test.ts
@@ -1,6 +1,31 @@
 import { expect, test } from 'vitest'
-import { type AccountUsageComputeOverage } from '#universal/loader-data.ts'
-import { computeAccountUsageOverageNotice } from './account-usage.tsx'
+import {
+	type AccountUsageComputeOverage,
+	type AccountUsageEntitlementConsumption,
+} from '#universal/loader-data.ts'
+import {
+	computeAccountUsageOverageNotice,
+	formatEntitlementUsedPercent,
+	hotterUsagePercent,
+} from './account-usage.tsx'
+
+function entitlement(
+	overrides: Partial<AccountUsageEntitlementConsumption> = {},
+): AccountUsageEntitlementConsumption {
+	return {
+		resource: 'execute_calls_per_day',
+		label: 'execute calls per day',
+		group: 'daily',
+		kind: 'counter',
+		whatCounts: 'Execute calls today (UTC).',
+		howToReduce: 'Run fewer execute calls today or this week.',
+		current: 30,
+		limit: 150,
+		percentOfLimit: 0.2,
+		overEightyPercent: false,
+		...overrides,
+	}
+}
 
 function overage(
 	overrides: Partial<AccountUsageComputeOverage> & {
@@ -56,4 +81,52 @@ test('approaching notice mentions billing only while charging is enabled', () =>
 	).toMatchObject({
 		title: 'Compute overage billing is paused',
 	})
+})
+
+test('hotterUsagePercent uses the closer of daily and weekly windows', () => {
+	expect(hotterUsagePercent(entitlement())).toBe(0.2)
+	expect(
+		hotterUsagePercent(
+			entitlement({
+				week: {
+					current: 360,
+					limit: 400,
+					percentOfLimit: 0.9,
+					overEightyPercent: true,
+				},
+			}),
+		),
+	).toBe(0.9)
+	expect(
+		hotterUsagePercent(
+			entitlement({
+				percentOfLimit: 0.95,
+				week: {
+					current: 100,
+					limit: 400,
+					percentOfLimit: 0.25,
+					overEightyPercent: false,
+				},
+			}),
+		),
+	).toBe(0.95)
+	expect(
+		hotterUsagePercent(entitlement({ percentOfLimit: null, week: undefined })),
+	).toBeNull()
+})
+
+test('formatEntitlementUsedPercent shows today and this week', () => {
+	expect(formatEntitlementUsedPercent(entitlement())).toBe('20%')
+	expect(
+		formatEntitlementUsedPercent(
+			entitlement({
+				week: {
+					current: 360,
+					limit: 400,
+					percentOfLimit: 0.9,
+					overEightyPercent: true,
+				},
+			}),
+		),
+	).toBe('20% today · 90% this week')
 })

--- a/packages/worker/client/routes/account-usage.tsx
+++ b/packages/worker/client/routes/account-usage.tsx
@@ -66,6 +66,26 @@ function formatUsagePercent(value: number | null) {
 	return `${Math.round(value * 100)}%`
 }
 
+/** Whichever window is closer to its cap — daily or weekly — is what blocks. */
+export function hotterUsagePercent(
+	item: Pick<AccountUsageEntitlementConsumption, 'percentOfLimit' | 'week'>,
+) {
+	const percents = [item.percentOfLimit, item.week?.percentOfLimit].filter(
+		(value): value is number => value != null,
+	)
+	if (percents.length === 0) return null
+	return Math.max(...percents)
+}
+
+export function formatEntitlementUsedPercent(
+	item: Pick<AccountUsageEntitlementConsumption, 'percentOfLimit' | 'week'>,
+) {
+	if (item.week) {
+		return `${formatUsagePercent(item.percentOfLimit)} today · ${formatUsagePercent(item.week.percentOfLimit)} this week`
+	}
+	return formatUsagePercent(item.percentOfLimit)
+}
+
 function formatPlanLabel(plan: AdminPlanName) {
 	return plan.charAt(0).toUpperCase() + plan.slice(1)
 }
@@ -138,8 +158,9 @@ function formatLimitValue(item: AccountUsageEntitlementConsumption) {
 }
 
 function usageProgressPercent(item: AccountUsageEntitlementConsumption) {
-	if (item.percentOfLimit === null) return null
-	return Math.min(100, Math.round(item.percentOfLimit * 100))
+	const percent = hotterUsagePercent(item)
+	if (percent === null) return null
+	return Math.min(100, Math.round(percent * 100))
 }
 
 function groupEntitlementRows(rows: Array<AccountUsageEntitlementConsumption>) {
@@ -168,7 +189,7 @@ function renderUsageProgressBar(item: AccountUsageEntitlementConsumption) {
 	return (
 		<div
 			role="img"
-			aria-label={`${item.label}: ${formatUsagePercent(item.percentOfLimit)} of plan limit`}
+			aria-label={`${item.label}: ${formatEntitlementUsedPercent(item)} of plan limit`}
 			mix={css({
 				height: '8px',
 				borderRadius: radius.md,
@@ -408,10 +429,11 @@ export function AccountUsageRoute(handle: Handle) {
 								>
 									{usage.warnings.map((item) => (
 										<li key={item.resource}>
-											<strong>{item.label}</strong>: {formatCurrentValue(item)}{' '}
-											/ {formatLimitValue(item)} (
-											{formatUsagePercent(item.percentOfLimit)}).{' '}
-											{item.howToReduce}{' '}
+											<strong>{item.label}</strong>:{' '}
+											{item.week
+												? `${formatCurrentValue(item)} / ${formatLimitValue(item)} today (${formatUsagePercent(item.percentOfLimit)}) · ${formatIntegerNumber(item.week.current)} / ${formatIntegerNumber(item.week.limit)} this week (${formatUsagePercent(item.week.percentOfLimit)})`
+												: `${formatCurrentValue(item)} / ${formatLimitValue(item)} (${formatUsagePercent(item.percentOfLimit)})`}
+											. {item.howToReduce}{' '}
 											<a href={billingPath} mix={css(primaryLinkCss)}>
 												Upgrade your plan
 											</a>
@@ -488,7 +510,7 @@ export function AccountUsageRoute(handle: Handle) {
 															: {},
 													)}
 												>
-													{formatUsagePercent(item.percentOfLimit)}
+													{formatEntitlementUsedPercent(item)}
 												</span>
 											),
 											progress: renderUsageProgressBar(item),

--- a/packages/worker/client/routes/account-usage.tsx
+++ b/packages/worker/client/routes/account-usage.tsx
@@ -57,7 +57,8 @@ const entitlementGroupNotes: Partial<
 > = {
 	monthly:
 		'Included unique worker days and Durable Object rows-read this UTC month.',
-	daily: 'Counters reset at UTC midnight.',
+	daily:
+		'Daily counters reset at UTC midnight. Execute and outbound fetches also have a this-week cap (UTC Monday–Sunday). High daily headroom for bursts; weekly total keeps it sustainable.',
 }
 
 function formatUsagePercent(value: number | null) {
@@ -290,7 +291,12 @@ export function AccountUsageRoute(handle: Handle) {
 									/>
 								</>
 							) : null}
-							<p mix={css(descriptionCss)}>Usage day (UTC): {usage.today}</p>
+							<p mix={css(descriptionCss)}>
+								Usage day (UTC): {usage.today}
+								{usage.weekStart
+									? ` · Week starts (UTC Monday): ${usage.weekStart}`
+									: ''}
+							</p>
 							<p mix={css({ margin: 0 })}>
 								<a href={billingPath} mix={css(primaryLinkCss)}>
 									Manage billing
@@ -329,7 +335,7 @@ export function AccountUsageRoute(handle: Handle) {
 						) : null}
 						<AccountManagementPanel
 							title="Monthly compute"
-							description="Unique worker-days and Durable Object rows-read against this month's include. Execute stays on a hard daily cap. Durable Object duration is unmetered."
+							description="Unique worker-days and Durable Object rows-read against this month's include. Execute and outbound fetches are hard daily and weekly caps. Durable Object duration is unmetered."
 						>
 							<RecordTable
 								mode="none"
@@ -459,11 +465,18 @@ export function AccountUsageRoute(handle: Handle) {
 														})}
 													>
 														{item.whatCounts} {item.howToReduce}
+														{item.week
+															? ' High daily headroom for bursts; weekly total keeps it sustainable.'
+															: ''}
 													</span>
 												</span>
 											),
-											current: formatCurrentValue(item),
-											limit: formatLimitValue(item),
+											current: item.week
+												? `${formatCurrentValue(item)} today · ${formatIntegerNumber(item.week.current)} this week`
+												: formatCurrentValue(item),
+											limit: item.week
+												? `${formatLimitValue(item)} / day · ${formatIntegerNumber(item.week.limit)} / week`
+												: formatLimitValue(item),
 											used: (
 												<span
 													mix={css(

--- a/packages/worker/client/routes/faq.tsx
+++ b/packages/worker/client/routes/faq.tsx
@@ -157,8 +157,9 @@ const faqItems: ReadonlyArray<FaqItem> = [
 					{count.format(freeLimits.maxSavedPackages)} saved packages,{' '}
 					{count.format(freeLimits.maxScheduledJobs)} scheduled jobs (no faster
 					than every {formatMinJobInterval(freeLimits.minJobIntervalMs)}),{' '}
-					{count.format(freeLimits.maxExecuteCallsPerDay)} execute calls per
-					day, and the rest of the entitlements on Pricing. Paid plans raise the
+					{count.format(freeLimits.maxExecuteCallsPerDay)} execute calls per day
+					({count.format(freeLimits.maxExecuteCallsPerWeek ?? 0)} this week),
+					and the rest of the entitlements on Pricing. Paid plans raise the
 					caps.
 				</p>
 				<p>

--- a/packages/worker/client/routes/pricing.tsx
+++ b/packages/worker/client/routes/pricing.tsx
@@ -7,6 +7,7 @@ import {
 	formatDurableObjectRowsRead,
 	formatMinJobInterval,
 	planLimits,
+	weeklyComputeWindowNote,
 	type PlanLimits,
 } from '#universal/plans.ts'
 import {
@@ -45,6 +46,7 @@ type LimitRow = {
 
 type LimitGroup = {
 	title: string
+	note?: string
 	rows: ReadonlyArray<LimitRow>
 }
 
@@ -69,10 +71,13 @@ const limitGroups: ReadonlyArray<LimitGroup> = [
 	},
 	{
 		title: 'Compute',
+		note: weeklyComputeWindowNote,
 		rows: [
 			{ label: 'Concurrent workflows', key: 'maxConcurrentWorkflows' },
 			{ label: 'Execute calls per day', key: 'maxExecuteCallsPerDay' },
+			{ label: 'Execute calls per week', key: 'maxExecuteCallsPerWeek' },
 			{ label: 'Outbound fetches per day', key: 'maxOutboundFetchesPerDay' },
+			{ label: 'Outbound fetches per week', key: 'maxOutboundFetchesPerWeek' },
 			{ label: 'Job runs per day', key: 'maxJobRunsPerDay' },
 			{
 				label: 'Unique worker days per month',
@@ -264,6 +269,13 @@ export function PricingRoute(handle: Handle) {
 											{renderLimitCell(row, planLimits.pro)}
 										</tr>
 									)),
+									...(group.note
+										? [
+												<tr key={`${group.title}-note`} data-note>
+													<td colspan={4}>{group.note}</td>
+												</tr>,
+											]
+										: []),
 								])}
 							</tbody>
 						</table>
@@ -279,8 +291,10 @@ export function PricingRoute(handle: Handle) {
 						Stripe customer are invoiced like other public-ladder accounts.
 						Those allotments are not hard-cut. Grandfathered legacy Standard/Pro
 						accounts are not billed for these meters until they leave the legacy
-						ladder. Execute is a hard daily cap. Durable Object duration is
-						unmetered.
+						ladder. Execute and outbound fetches are hard daily and weekly caps
+						on public plans (whichever window hits first blocks). Grandfathered
+						legacy Standard/Pro and Max stay daily-only. Durable Object duration
+						is unmetered.
 					</p>
 				</section>
 
@@ -321,6 +335,9 @@ function renderPaidPlanCta(isSignedIn: boolean, signedOutCta: PublicSignupCta) {
 
 function renderLimitCell(row: LimitRow, limits: PlanLimits) {
 	const value = limits[row.key]
+	if (value == null) {
+		return <td>—</td>
+	}
 	const cell = row.format ? row.format(value) : { text: count.format(value) }
 	return (
 		<td>
@@ -604,6 +621,13 @@ const limitsTableCss = {
 		fontWeight: 450,
 		color: colors.text,
 		textAlign: 'left' as const,
+	},
+	'& tr[data-note] td': {
+		padding: '0.45rem 0.2rem 0.85rem',
+		color: colors.textMuted,
+		fontSize: '0.88rem',
+		whiteSpace: 'normal' as const,
+		borderBottom: `1px solid ${colors.border}`,
 	},
 	'& td': {
 		textAlign: 'left' as const,

--- a/packages/worker/src/app/account-usage-data.node.test.ts
+++ b/packages/worker/src/app/account-usage-data.node.test.ts
@@ -208,9 +208,16 @@ test('loadAccountUsageData returns plan rows and authoritative UserMeter daily c
 	expect(currentFor(authoritative, 'email_sends_per_day')?.current).toBe(101)
 	expect(currentFor(authoritative, 'email_receives_per_day')?.current).toBe(202)
 	expect(currentFor(authoritative, 'execute_calls_per_day')?.current).toBe(303)
+	expect(currentFor(authoritative, 'execute_calls_per_day')?.week).toEqual({
+		current: 303,
+		limit: 4_000,
+		percentOfLimit: 303 / 4_000,
+		overEightyPercent: false,
+	})
 	expect(currentFor(authoritative, 'outbound_fetches_per_day')?.current).toBe(
 		404,
 	)
+	expect(authoritative?.weekStart).toBe('2026-07-20')
 	expect(currentFor(authoritative, 'concurrent_workflows')?.current).toBe(3)
 	expect(currentFor(authoritative, 'stored_email_messages')?.current).toBe(7)
 	expect(currentFor(authoritative, 'saved_packages')?.current).toBe(4)

--- a/packages/worker/src/app/account-usage-data.ts
+++ b/packages/worker/src/app/account-usage-data.ts
@@ -14,6 +14,7 @@ import { resolveUserStableId } from '#worker/user-id.ts'
 import {
 	type AccountUsageEntitlementConsumption,
 	type AccountUsageLoaderData,
+	type AccountUsageWeekWindow,
 } from '#universal/loader-data.ts'
 
 type UsageUserRow = {
@@ -85,6 +86,7 @@ export async function loadAccountUsageData(input: {
 		manualPlan,
 		stripePlan: parseStripePlanName(row.stripe_plan),
 		today: snapshot.today,
+		weekStart: snapshot.weekStart,
 		entitlementConsumption: snapshot.resources.map(toAccountUsageRow),
 		warnings: [
 			...computeOverageUsageWarningRows(computeOverage).map(toAccountUsageRow),
@@ -105,6 +107,7 @@ function toAccountUsageRow(row: {
 	limit: number
 	percentOfLimit: number | null
 	overEightyPercent: boolean
+	week?: AccountUsageWeekWindow
 }): AccountUsageEntitlementConsumption {
 	return {
 		resource: row.resource,
@@ -117,5 +120,6 @@ function toAccountUsageRow(row: {
 		limit: row.limit,
 		percentOfLimit: row.percentOfLimit,
 		overEightyPercent: row.overEightyPercent,
+		...(row.week ? { week: row.week } : {}),
 	}
 }

--- a/packages/worker/src/app/admin-insights-data.ts
+++ b/packages/worker/src/app/admin-insights-data.ts
@@ -1,5 +1,9 @@
 import { cachified } from '@epic-web/cachified'
-import { utcDayKey, utcMonthKey } from '@kody-internal/shared/date-keys.ts'
+import {
+	utcDayKey,
+	utcMonthKey,
+	utcWeekStart,
+} from '@kody-internal/shared/date-keys.ts'
 import { createKvCachifiedCache } from '#worker/kv-cachified.ts'
 import { jobsData } from '#worker/jobs/jobs-data.ts'
 import { adminUsageMetrics } from '#worker/admin/user-usage-data.ts'
@@ -731,11 +735,7 @@ async function countQuery(db: D1Database, query: string) {
 	return Number(row?.n ?? 0)
 }
 
-/** UTC Monday day key of the week containing the given date. */
-export function utcWeekStart(date: Date) {
-	const daysSinceMonday = (date.getUTCDay() + 6) % 7
-	return utcDayKey(new Date(date.getTime() - daysSinceMonday * dayMs))
-}
+export { utcWeekStart }
 
 /** Oldest-first list of UTC Monday keys ending with the week containing now. */
 export function listUtcWeekStarts(now: Date, weeks: number) {

--- a/packages/worker/src/app/ssr-render-pricing.node.test.ts
+++ b/packages/worker/src/app/ssr-render-pricing.node.test.ts
@@ -84,5 +84,14 @@ test('renderAppPage renders the redesigned pricing page', async () => {
 	expect(html).toContain('mailto:kody@kody.codes')
 	expect(html).toContain('Unique worker days per month')
 	expect(html).toContain('Durable Object rows read per month')
+	expect(html).toContain('Execute calls per week')
+	expect(html).toContain('Outbound fetches per week')
+	expect(html).toContain(
+		'High daily headroom for bursts; weekly total keeps it sustainable.',
+	)
+	expect(html).toContain('1,500')
+	expect(html).toContain('4,000')
+	expect(html).toContain('50,000')
+	expect(html).toContain('120,000')
 	expect(html).toMatch(/<a[^>]*href="\/docs\/kody-factory"[^>]*>factory<\/a>/)
 })

--- a/packages/worker/src/entitlements/entitlements.node.test.ts
+++ b/packages/worker/src/entitlements/entitlements.node.test.ts
@@ -905,8 +905,8 @@ test('public execute and outbound enforce daily and weekly windows; legacy and m
 		plan: 'free',
 		limit: 1_000,
 		current: 1_000,
-		window: 'day',
 	})
+	expect(dailyDenied.details.window).toBeUndefined()
 
 	await meter.seed({
 		userId: legacyUserId,

--- a/packages/worker/src/entitlements/entitlements.node.test.ts
+++ b/packages/worker/src/entitlements/entitlements.node.test.ts
@@ -228,6 +228,19 @@ test('entitlement limit messages always identify a known plan name', () => {
 	}
 	const message = buildEntitlementLimitMessage(details)
 	expect(parseEntitlementLimitMessage(message)).toEqual(details)
+
+	const weeklyDetails = {
+		code: 'entitlement_limit_exceeded' as const,
+		resource: 'execute_calls_per_day' as const,
+		plan: 'free' as const,
+		limit: 400,
+		current: 400,
+		window: 'week' as const,
+		upgradeHint: buildEntitlementUpgradeHint('execute_calls_per_day'),
+	}
+	expect(
+		parseEntitlementLimitMessage(buildEntitlementLimitMessage(weeklyDetails)),
+	).toEqual(weeklyDetails)
 	expect(
 		parseEntitlementLimitMessage(
 			'Plan limit reached: this deployment allows at most 100 concurrent workflows and you currently have 100. hint',
@@ -771,6 +784,175 @@ test('plan user daily entitlements increment, enforce at limit, and reset on a n
 			now,
 		}),
 	).toBe(limit)
+})
+
+test('public execute and outbound enforce daily and weekly windows; legacy and max stay daily-only', async () => {
+	const freeEmail = 'weekly-free@example.com'
+	const legacyEmail = 'weekly-legacy@example.com'
+	const maxEmail = 'weekly-max@example.com'
+	const freeUserId = await createStableUserIdFromEmail(freeEmail)
+	const legacyUserId = await createStableUserIdFromEmail(legacyEmail)
+	const maxUserId = await createStableUserIdFromEmail(maxEmail)
+	const { db } = createEntitlementsTestDb({
+		users: [
+			{ email: freeEmail, plan: 'free', stable_user_id: freeUserId },
+			{
+				email: legacyEmail,
+				plan: 'free',
+				stripe_plan: 'standard',
+				entitlement_ladder: 'legacy',
+				stable_user_id: legacyUserId,
+			},
+			{ email: maxEmail, plan: 'max', stable_user_id: maxUserId },
+		],
+	})
+	const meter = createInMemoryUserMeterEnv()
+	const wednesday = new Date('2026-07-08T15:00:00.000Z')
+	const monday = new Date('2026-07-06T15:00:00.000Z')
+	const tuesday = new Date('2026-07-07T15:00:00.000Z')
+
+	await meter.seed({
+		userId: freeUserId,
+		resource: 'execute_calls_per_day',
+		day: utcDayKey(monday),
+		count: 150,
+	})
+	await meter.seed({
+		userId: freeUserId,
+		resource: 'execute_calls_per_day',
+		day: utcDayKey(tuesday),
+		count: 150,
+	})
+	await meter.seed({
+		userId: freeUserId,
+		resource: 'execute_calls_per_day',
+		day: utcDayKey(wednesday),
+		count: 99,
+	})
+	await consumeDailyEntitlement({
+		db,
+		env: meter.env,
+		userId: freeUserId,
+		email: freeEmail,
+		resource: 'execute_calls_per_day',
+		now: wednesday,
+	})
+	expect(
+		await readMeterDailyCount({
+			env: meter.env,
+			userId: freeUserId,
+			resource: 'execute_calls_per_day',
+			now: wednesday,
+		}),
+	).toBe(100)
+	const weeklyDenied = await consumeDailyEntitlement({
+		db,
+		env: meter.env,
+		userId: freeUserId,
+		email: freeEmail,
+		resource: 'execute_calls_per_day',
+		now: wednesday,
+	}).then(
+		() => null,
+		(thrown: unknown) => thrown,
+	)
+	if (!(weeklyDenied instanceof EntitlementLimitError)) {
+		throw new Error('Expected weekly EntitlementLimitError.')
+	}
+	expect(weeklyDenied.details).toMatchObject({
+		resource: 'execute_calls_per_day',
+		plan: 'free',
+		limit: 400,
+		current: 400,
+		window: 'week',
+	})
+	expect(weeklyDenied.message).toContain('execute calls this week')
+
+	const dailyUserId = await createStableUserIdFromEmail(
+		'daily-first@example.com',
+	)
+	const { db: dailyDb } = createEntitlementsTestDb({
+		users: [
+			{
+				email: 'daily-first@example.com',
+				plan: 'free',
+				stable_user_id: dailyUserId,
+			},
+		],
+	})
+	await meter.seed({
+		userId: dailyUserId,
+		resource: 'outbound_fetches_per_day',
+		day: utcDayKey(wednesday),
+		count: 1_000,
+	})
+	const dailyDenied = await consumeDailyEntitlement({
+		db: dailyDb,
+		env: meter.env,
+		userId: dailyUserId,
+		email: 'daily-first@example.com',
+		resource: 'outbound_fetches_per_day',
+		now: wednesday,
+	}).then(
+		() => null,
+		(thrown: unknown) => thrown,
+	)
+	if (!(dailyDenied instanceof EntitlementLimitError)) {
+		throw new Error('Expected daily EntitlementLimitError.')
+	}
+	expect(dailyDenied.details).toMatchObject({
+		resource: 'outbound_fetches_per_day',
+		plan: 'free',
+		limit: 1_000,
+		current: 1_000,
+		window: 'day',
+	})
+
+	await meter.seed({
+		userId: legacyUserId,
+		resource: 'execute_calls_per_day',
+		day: utcDayKey(monday),
+		count: 400,
+	})
+	await consumeDailyEntitlement({
+		db,
+		env: meter.env,
+		userId: legacyUserId,
+		email: legacyEmail,
+		resource: 'execute_calls_per_day',
+		now: wednesday,
+	})
+	expect(
+		await readMeterDailyCount({
+			env: meter.env,
+			userId: legacyUserId,
+			resource: 'execute_calls_per_day',
+			now: wednesday,
+		}),
+	).toBe(1)
+
+	await meter.seed({
+		userId: maxUserId,
+		resource: 'outbound_fetches_per_day',
+		day: utcDayKey(monday),
+		count: 10_000,
+	})
+	await consumeDailyEntitlement({
+		db,
+		env: meter.env,
+		userId: maxUserId,
+		email: maxEmail,
+		resource: 'outbound_fetches_per_day',
+		now: wednesday,
+	})
+	expect(
+		await readMeterDailyCount({
+			env: meter.env,
+			userId: maxUserId,
+			resource: 'outbound_fetches_per_day',
+			now: wednesday,
+		}),
+	).toBe(1)
 })
 
 test('refundDailyEntitlement decrements the user/day counter and floors at zero', async () => {

--- a/packages/worker/src/entitlements/errors.ts
+++ b/packages/worker/src/entitlements/errors.ts
@@ -8,12 +8,17 @@ import {
 import {
 	entitlementResourceLabels,
 	formatMinJobInterval,
+	isWeeklyComputeWindowResource,
 	parsePlanName,
+	weeklyEntitlementResourceLabel,
 	type EntitlementResource,
 	type PlanName,
+	type WeeklyComputeWindowResource,
 } from '#universal/plans.ts'
 
 export const entitlementLimitErrorCode = 'entitlement_limit_exceeded' as const
+
+export type EntitlementLimitWindow = 'day' | 'week'
 
 export type EntitlementLimitErrorDetails = {
 	code: typeof entitlementLimitErrorCode
@@ -23,6 +28,8 @@ export type EntitlementLimitErrorDetails = {
 	limit: number
 	current: number
 	upgradeHint: string
+	/** Which hard window blocked. Omit for stock/count resources. */
+	window?: EntitlementLimitWindow
 }
 
 export function buildEntitlementUpgradeHint(resource: EntitlementResource) {
@@ -35,21 +42,46 @@ export function buildEntitlementUpgradeHint(resource: EntitlementResource) {
  * MCP and UI surfaces. Keep changes here only; enforcement points must not
  * compose their own messages.
  */
+function entitlementLimitLabel(
+	resource: EntitlementResource,
+	window: EntitlementLimitWindow | undefined,
+) {
+	if (window === 'week' && isWeeklyComputeWindowResource(resource)) {
+		return weeklyEntitlementResourceLabel(resource)
+	}
+	return entitlementResourceLabels[resource]
+}
+
 export function buildEntitlementLimitMessage(
 	details: EntitlementLimitErrorDetails,
 ) {
-	const label = entitlementResourceLabels[details.resource]
+	const label = entitlementLimitLabel(details.resource, details.window)
 	return `Plan limit reached: your "${details.plan}" plan allows at most ${details.limit} ${label} and you currently have ${details.current}. ${details.upgradeHint}`
 }
 
 export function parseEntitlementLimitMessage(
 	message: string,
 ): EntitlementLimitErrorDetails | null {
-	for (const [resource, label] of Object.entries(
-		entitlementResourceLabels,
-	) as Array<[EntitlementResource, string]>) {
+	const weeklyLabels = (
+		['execute_calls_per_day', 'outbound_fetches_per_day'] as const
+	).map((resource) => ({
+		resource: resource satisfies WeeklyComputeWindowResource,
+		label: weeklyEntitlementResourceLabel(resource),
+		window: 'week' as const,
+	}))
+	const dailyLabels = (
+		Object.entries(entitlementResourceLabels) as Array<
+			[EntitlementResource, string]
+		>
+	).map(([resource, label]) => ({
+		resource,
+		label,
+		window: undefined as EntitlementLimitWindow | undefined,
+	}))
+	// Weekly labels first so "this week" is not swallowed by "per day".
+	for (const entry of [...weeklyLabels, ...dailyLabels]) {
 		const match = new RegExp(
-			`^Plan limit reached: your "([^"]+)" plan allows at most (\\d+) ${escapeRegex(label)} and you currently have (\\d+)\\. (.+)$`,
+			`^Plan limit reached: your "([^"]+)" plan allows at most (\\d+) ${escapeRegex(entry.label)} and you currently have (\\d+)\\. (.+)$`,
 		).exec(message)
 		if (!match) continue
 
@@ -63,11 +95,12 @@ export function parseEntitlementLimitMessage(
 
 		return {
 			code: entitlementLimitErrorCode,
-			resource,
+			resource: entry.resource,
 			plan,
 			limit,
 			current,
 			upgradeHint: match[4] ?? '',
+			...(entry.window ? { window: entry.window } : {}),
 		}
 	}
 	return null

--- a/packages/worker/src/entitlements/resource-visibility.ts
+++ b/packages/worker/src/entitlements/resource-visibility.ts
@@ -25,7 +25,8 @@ export const entitlementResourceGroupNotes: Partial<
 > = {
 	monthly:
 		'Included unique worker days and Durable Object rows-read this UTC month. Public-ladder overage invoices when a payment method is on file; unpaid Free is asked to upgrade.',
-	daily: 'Counters reset at UTC midnight.',
+	daily:
+		'Daily counters reset at UTC midnight. Execute and outbound fetches also have a this-week cap (UTC Monday–Sunday). High daily headroom for bursts; weekly total keeps it sustainable.',
 }
 
 export type EntitlementResourceVisibility = {
@@ -120,15 +121,18 @@ export const entitlementResourceVisibility: Record<
 	execute_calls_per_day: {
 		group: 'daily',
 		kind: 'counter',
-		whatCounts: 'MCP execute tool runs today (UTC), including failed attempts.',
-		howToReduce: 'Run fewer execute calls today, or upgrade your plan.',
+		whatCounts:
+			'MCP execute tool runs today (UTC), including failed attempts. Public plans also cap the UTC week.',
+		howToReduce:
+			'Run fewer execute calls today or this week, or upgrade your plan.',
 	},
 	outbound_fetches_per_day: {
 		group: 'daily',
 		kind: 'counter',
 		whatCounts:
-			'Sandbox outbound HTTP fetches through the fetch gateway today (UTC).',
-		howToReduce: 'Fetch less from user code today, or upgrade your plan.',
+			'Sandbox outbound HTTP fetches through the fetch gateway today (UTC). Public plans also cap the UTC week.',
+		howToReduce:
+			'Fetch less from user code today or this week, or upgrade your plan.',
 	},
 	job_runs_per_day: {
 		group: 'daily',

--- a/packages/worker/src/entitlements/service.ts
+++ b/packages/worker/src/entitlements/service.ts
@@ -1130,8 +1130,7 @@ export async function consumeDailyEntitlement(
 		}
 	}
 	if (!result.consumed) {
-		const deniedWindow = result.deniedWindow ?? 'day'
-		if (deniedWindow === 'week' && weekLimit !== null) {
+		if (result.deniedWindow === 'week' && weekLimit !== null) {
 			throw new EntitlementLimitError({
 				resource,
 				plan,
@@ -1146,7 +1145,6 @@ export async function consumeDailyEntitlement(
 			plan,
 			limit,
 			current: result.count,
-			window: 'day',
 			upgradeHint: buildEntitlementUpgradeHint(resource),
 		})
 	}

--- a/packages/worker/src/entitlements/service.ts
+++ b/packages/worker/src/entitlements/service.ts
@@ -1,9 +1,11 @@
-import { utcDayKey } from '@kody-internal/shared/date-keys.ts'
+import { utcDayKey, utcWeekStart } from '@kody-internal/shared/date-keys.ts'
 import { type JobsStore } from '@kody-internal/shared/jobs/store.ts'
 import {
+	isWeeklyComputeWindowResource,
 	parseEntitlementLadder,
 	parseStoredPlanName,
 	resolvePlanLimit,
+	resolveWeeklyPlanLimit,
 	type EntitlementResource,
 	type PlanName,
 	type UserEntitlement,
@@ -329,6 +331,30 @@ export async function readDailyEntitlementResourceUsage(input: {
 			)
 		}
 	}
+	return result.count
+}
+
+/**
+ * Sum UserMeter daily rows for the UTC week containing `now`. Missing days
+ * count as zero; does not bootstrap today's key.
+ */
+export async function readWeeklyEntitlementResourceUsage(input: {
+	env: UserMeterEnv
+	userId: string
+	resource: EntitlementResource
+	now?: Date
+}): Promise<number> {
+	const resource = assertDailyEntitlementResource(input.resource)
+	const now = input.now ?? new Date()
+	const startDay = utcWeekStart(now)
+	const endDay = utcDayKey(now)
+	const meter = userMeterRpc({ env: input.env, userId: input.userId })
+	const result = await meter.readRange({
+		resource,
+		startDay,
+		endDay,
+		now: now.toISOString(),
+	})
 	return result.count
 }
 
@@ -1074,13 +1100,20 @@ export async function consumeDailyEntitlement(
 	})
 	const plan = entitlement.plan
 	const limit = resolvePlanLimit(plan, resource, entitlement.ladder)
+	const weekLimit = isWeeklyComputeWindowResource(resource)
+		? resolveWeeklyPlanLimit(plan, resource, entitlement.ladder)
+		: null
+	const weekStart = weekLimit === null ? undefined : utcWeekStart(now)
 	const meter = userMeterRpc({ env: input.env, userId: input.userId })
-	let result = await meter.consume({
+	const consumeInput = {
 		resource,
 		day,
 		limit,
 		updatedAt,
-	})
+		weekStart,
+		weekLimit,
+	}
+	let result = await meter.consume(consumeInput)
 	if (result.outcome === 'needs_bootstrap') {
 		await ensureUserMeterCounterInitializedAtZero({
 			env: input.env,
@@ -1089,12 +1122,7 @@ export async function consumeDailyEntitlement(
 			day,
 			updatedAt,
 		})
-		result = await meter.consume({
-			resource,
-			day,
-			limit,
-			updatedAt,
-		})
+		result = await meter.consume(consumeInput)
 		if (result.outcome === 'needs_bootstrap') {
 			throw new Error(
 				'UserMeter consume still needs bootstrap after initialize.',
@@ -1102,11 +1130,23 @@ export async function consumeDailyEntitlement(
 		}
 	}
 	if (!result.consumed) {
+		const deniedWindow = result.deniedWindow ?? 'day'
+		if (deniedWindow === 'week' && weekLimit !== null) {
+			throw new EntitlementLimitError({
+				resource,
+				plan,
+				limit: weekLimit,
+				current: result.weekCount ?? 0,
+				window: 'week',
+				upgradeHint: buildEntitlementUpgradeHint(resource),
+			})
+		}
 		throw new EntitlementLimitError({
 			resource,
 			plan,
 			limit,
 			current: result.count,
+			window: 'day',
 			upgradeHint: buildEntitlementUpgradeHint(resource),
 		})
 	}

--- a/packages/worker/src/entitlements/usage-snapshot.node.test.ts
+++ b/packages/worker/src/entitlements/usage-snapshot.node.test.ts
@@ -130,6 +130,16 @@ test('readEntitlementUsageSnapshot warns at 80% and includes the account resourc
 	expect(snapshot.resources.map((row) => row.resource)).toEqual(
 		accountUsageEntitlementResources,
 	)
+	expect(snapshot.weekStart).toBe('2026-07-20')
+	const execute = snapshot.resources.find(
+		(row) => row.resource === 'execute_calls_per_day',
+	)
+	expect(execute?.week).toEqual({
+		current: 0,
+		limit: 400,
+		percentOfLimit: 0,
+		overEightyPercent: false,
+	})
 
 	const otherUserSnapshot = await readEntitlementUsageSnapshot({
 		db,
@@ -173,4 +183,14 @@ test('readEntitlementUsageSnapshot uses the requested entitlement ladder', async
 			(row) => row.resource === 'execute_calls_per_day',
 		)?.limit,
 	).toBe(legacyPlanLimits.standard.maxExecuteCallsPerDay)
+	expect(
+		publicSnapshot.resources.find(
+			(row) => row.resource === 'execute_calls_per_day',
+		)?.week?.limit,
+	).toBe(planLimits.standard.maxExecuteCallsPerWeek)
+	expect(
+		legacySnapshot.resources.find(
+			(row) => row.resource === 'execute_calls_per_day',
+		)?.week,
+	).toBeUndefined()
 })

--- a/packages/worker/src/entitlements/usage-snapshot.node.test.ts
+++ b/packages/worker/src/entitlements/usage-snapshot.node.test.ts
@@ -194,3 +194,45 @@ test('readEntitlementUsageSnapshot uses the requested entitlement ladder', async
 		)?.week,
 	).toBeUndefined()
 })
+
+test('readEntitlementUsageSnapshot warns when the weekly window is hotter than today', async () => {
+	const now = new Date('2026-07-25T12:00:00.000Z')
+	const email = 'weekly-hot@example.com'
+	const { stableUserId, db } = createUsageTestDb({ email })
+	const env = withUsageEnv({ APP_DB: db })
+	await env.meter.seed({
+		userId: stableUserId,
+		resource: 'execute_calls_per_day',
+		day: '2026-07-20',
+		count: 330,
+	})
+	await env.meter.seed({
+		userId: stableUserId,
+		resource: 'execute_calls_per_day',
+		day: utcDayKey(now),
+		count: 10,
+	})
+	const snapshot = await readEntitlementUsageSnapshot({
+		db,
+		env: env as Env,
+		usageUserId: stableUserId,
+		plan: 'free',
+		ladder: 'public',
+		now,
+	})
+	const execute = snapshot.resources.find(
+		(row) => row.resource === 'execute_calls_per_day',
+	)
+	expect(execute?.current).toBe(10)
+	expect(execute?.percentOfLimit).toBe(10 / 150)
+	expect(execute?.week).toEqual({
+		current: 340,
+		limit: 400,
+		percentOfLimit: 340 / 400,
+		overEightyPercent: true,
+	})
+	expect(execute?.overEightyPercent).toBe(true)
+	expect(
+		snapshot.warnings.some((row) => row.resource === 'execute_calls_per_day'),
+	).toBe(true)
+})

--- a/packages/worker/src/entitlements/usage-snapshot.ts
+++ b/packages/worker/src/entitlements/usage-snapshot.ts
@@ -1,7 +1,9 @@
-import { utcDayKey } from '@kody-internal/shared/date-keys.ts'
+import { utcDayKey, utcWeekStart } from '@kody-internal/shared/date-keys.ts'
 import {
 	entitlementResourceLabels,
+	isWeeklyComputeWindowResource,
 	resolvePlanLimit,
+	resolveWeeklyPlanLimit,
 	type EntitlementLadder,
 	type EntitlementResource,
 	type PlanName,
@@ -12,10 +14,20 @@ import {
 	type EntitlementResourceGroup,
 	type EntitlementResourceVisibilityKind,
 } from './resource-visibility.ts'
-import { readCurrentEntitlementResourceUsage } from './service.ts'
+import {
+	readCurrentEntitlementResourceUsage,
+	readWeeklyEntitlementResourceUsage,
+} from './service.ts'
 import { listUserStorageBucketEstimates } from '#worker/storage-buckets/service.ts'
 
 export const entitlementUsageWarningThreshold = 0.8
+
+export type EntitlementUsageWeekWindow = {
+	current: number
+	limit: number
+	percentOfLimit: number | null
+	overEightyPercent: boolean
+}
 
 export type EntitlementUsageSnapshotRow = {
 	resource: EntitlementResource
@@ -28,11 +40,13 @@ export type EntitlementUsageSnapshotRow = {
 	limit: number
 	percentOfLimit: number | null
 	overEightyPercent: boolean
+	week?: EntitlementUsageWeekWindow
 }
 
 export type EntitlementUsageSnapshot = {
 	plan: PlanName
 	today: string
+	weekStart: string
 	resources: Array<EntitlementUsageSnapshotRow>
 	warnings: Array<EntitlementUsageSnapshotRow>
 }
@@ -92,6 +106,18 @@ export async function readEntitlementUsageSnapshot(input: {
 				visibility.kind === 'per_unit_max' || limit === 0
 					? null
 					: current / limit
+			const week = await readWeeklyUsageWindow({
+				env: input.env,
+				userId: input.usageUserId,
+				plan: input.plan,
+				ladder: input.ladder,
+				resource,
+				now,
+			})
+			const overEightyPercent =
+				(percentOfLimit !== null &&
+					percentOfLimit > entitlementUsageWarningThreshold) ||
+				(week?.overEightyPercent ?? false)
 			return {
 				resource,
 				label: entitlementResourceLabels[resource],
@@ -102,16 +128,44 @@ export async function readEntitlementUsageSnapshot(input: {
 				current,
 				limit,
 				percentOfLimit,
-				overEightyPercent:
-					percentOfLimit !== null &&
-					percentOfLimit > entitlementUsageWarningThreshold,
+				overEightyPercent,
+				...(week ? { week } : {}),
 			}
 		}),
 	)
 	return {
 		plan: input.plan,
 		today: utcDayKey(now),
+		weekStart: utcWeekStart(now),
 		resources,
 		warnings: resources.filter((row) => row.overEightyPercent),
+	}
+}
+
+async function readWeeklyUsageWindow(input: {
+	env: Env
+	userId: string
+	plan: PlanName
+	ladder: EntitlementLadder
+	resource: EntitlementResource
+	now: Date
+}): Promise<EntitlementUsageWeekWindow | undefined> {
+	if (!isWeeklyComputeWindowResource(input.resource)) return undefined
+	const limit = resolveWeeklyPlanLimit(input.plan, input.resource, input.ladder)
+	if (limit === null) return undefined
+	const current = await readWeeklyEntitlementResourceUsage({
+		env: input.env,
+		userId: input.userId,
+		resource: input.resource,
+		now: input.now,
+	})
+	const percentOfLimit = limit === 0 ? null : current / limit
+	return {
+		current,
+		limit,
+		percentOfLimit,
+		overEightyPercent:
+			percentOfLimit !== null &&
+			percentOfLimit > entitlementUsageWarningThreshold,
 	}
 }

--- a/packages/worker/src/entitlements/user-meter-do.ts
+++ b/packages/worker/src/entitlements/user-meter-do.ts
@@ -27,7 +27,11 @@ export function isDailyEntitlementResource(
 	return (dailyEntitlementResources as ReadonlyArray<string>).includes(resource)
 }
 
-/** Retention window for UserMeter daily rows (enforcement needs today only). */
+/**
+ * Retention window for UserMeter daily rows. Enforcement needs today and,
+ * for execute/outbound, the current UTC week (Monday–Sunday). Seven days
+ * covers that week.
+ */
 export const userMeterDailyCounterRetentionDays = 7
 
 const metaSchemaVersionKey = 'schema_version'
@@ -78,9 +82,15 @@ export type UserMeterBootstrapState = {
 	outcome: 'needs_bootstrap'
 }
 
+export type UserMeterDeniedWindow = 'day' | 'week'
+
 export type UserMeterConsumeResult =
 	| UserMeterBootstrapState
-	| (UserMeterReadyState & { consumed: boolean })
+	| (UserMeterReadyState & {
+			consumed: boolean
+			deniedWindow?: UserMeterDeniedWindow
+			weekCount?: number
+	  })
 
 export type UserMeterReadResult = UserMeterBootstrapState | UserMeterReadyState
 
@@ -694,6 +704,24 @@ class UserMeterBase extends DurableObject<Env> {
 		}
 	}
 
+	private sumRange(
+		resource: DailyEntitlementResource,
+		startDay: string,
+		endDay: string,
+	): number {
+		const row = this.ctx.storage.sql
+			.exec<{ total: number }>(
+				`SELECT COALESCE(SUM(count), 0) AS total
+				FROM daily_counters
+				WHERE resource = ? AND day >= ? AND day <= ?`,
+				resource,
+				startDay,
+				endDay,
+			)
+			.toArray()[0]
+		return Math.max(0, Number(row?.total ?? 0))
+	}
+
 	/** Cold-key seed at zero; INSERT OR IGNORE is concurrency-safe. */
 	async initialize(input: {
 		resource: string
@@ -731,6 +759,8 @@ class UserMeterBase extends DurableObject<Env> {
 		day: string
 		limit: number
 		updatedAt: string
+		weekStart?: string
+		weekLimit?: number | null
 	}): Promise<UserMeterConsumeResult> {
 		const resource = assertDailyResource(input.resource)
 		const day = assertUtcDayKey(input.day)
@@ -742,10 +772,34 @@ class UserMeterBase extends DurableObject<Env> {
 			return { outcome: 'needs_bootstrap' }
 		}
 
+		const weekLimit =
+			typeof input.weekLimit === 'number' && Number.isFinite(input.weekLimit)
+				? input.weekLimit
+				: null
+		const weekStart = input.weekStart ? assertUtcDayKey(input.weekStart) : null
+		const weekCount =
+			weekStart && weekLimit !== null
+				? this.sumRange(resource, weekStart, day)
+				: undefined
+
 		if (input.limit < 1 || existing.count + 1 > input.limit) {
 			return {
 				...readyState(existing.count, existing.revision),
 				consumed: false,
+				deniedWindow: 'day',
+				weekCount,
+			}
+		}
+		if (
+			weekStart &&
+			weekLimit !== null &&
+			(weekLimit < 1 || (weekCount ?? 0) + 1 > weekLimit)
+		) {
+			return {
+				...readyState(existing.count, existing.revision),
+				consumed: false,
+				deniedWindow: 'week',
+				weekCount,
 			}
 		}
 
@@ -771,6 +825,28 @@ class UserMeterBase extends DurableObject<Env> {
 		return {
 			...readyState(row.count, row.revision),
 			consumed: row.count === nextCount && row.revision === nextRevision,
+			weekCount: weekCount === undefined ? undefined : weekCount + 1,
+		}
+	}
+
+	/**
+	 * Sum daily counts for `resource` from `startDay` through `endDay`
+	 * inclusive. Missing days count as zero.
+	 */
+	async readRange(input: {
+		resource: string
+		startDay: string
+		endDay: string
+		now?: string
+	}): Promise<{ outcome: 'ready'; count: number }> {
+		const resource = assertDailyResource(input.resource)
+		const startDay = assertUtcDayKey(input.startDay)
+		const endDay = assertUtcDayKey(input.endDay)
+		const now = input.now ? new Date(input.now) : new Date()
+		this.deleteStaleCounters(Number.isNaN(now.valueOf()) ? new Date() : now)
+		return {
+			outcome: 'ready',
+			count: this.sumRange(resource, startDay, endDay),
 		}
 	}
 
@@ -1611,7 +1687,15 @@ export type UserMeterRpc = DurableObjectPitrRpc & {
 		day: string
 		limit: number
 		updatedAt: string
+		weekStart?: string
+		weekLimit?: number | null
 	}) => Promise<UserMeterConsumeResult>
+	readRange: (input: {
+		resource: string
+		startDay: string
+		endDay: string
+		now?: string
+	}) => Promise<{ outcome: 'ready'; count: number }>
 	consumeInboundDelivery: (input: {
 		deliveryId: string
 		resource: string

--- a/packages/worker/src/entitlements/user-meter.workers.test.ts
+++ b/packages/worker/src/entitlements/user-meter.workers.test.ts
@@ -400,6 +400,69 @@ test('next UTC day cold consume starts at zero independently', async () => {
 	expect(dailyPrepareCalls).toBe(0)
 }, 30_000)
 
+test('UserMeter consume denies public execute when the UTC week hits first', async () => {
+	const wednesday = new Date('2026-07-08T15:00:00.000Z')
+	const monday = new Date('2026-07-06T15:00:00.000Z')
+	const tuesday = new Date('2026-07-07T15:00:00.000Z')
+	const user = await seedFreeUser('meter-weekly-execute')
+	const meter = userMeterRpc({ env, userId: user.userId })
+	await meter.initialize({
+		resource: 'execute_calls_per_day',
+		day: utcDayKey(monday),
+		count: 150,
+		updatedAt: monday.toISOString(),
+	})
+	await meter.initialize({
+		resource: 'execute_calls_per_day',
+		day: utcDayKey(tuesday),
+		count: 150,
+		updatedAt: tuesday.toISOString(),
+	})
+	await meter.initialize({
+		resource: 'execute_calls_per_day',
+		day: utcDayKey(wednesday),
+		count: 99,
+		updatedAt: wednesday.toISOString(),
+	})
+	expect(
+		await meter.readRange({
+			resource: 'execute_calls_per_day',
+			startDay: utcDayKey(monday),
+			endDay: utcDayKey(wednesday),
+			now: wednesday.toISOString(),
+		}),
+	).toEqual({ outcome: 'ready', count: 399 })
+
+	await consumeDailyEntitlement({
+		db: env.APP_DB,
+		env,
+		userId: user.userId,
+		email: user.email,
+		resource: 'execute_calls_per_day',
+		now: wednesday,
+	})
+	const denied = await consumeDailyEntitlement({
+		db: env.APP_DB,
+		env,
+		userId: user.userId,
+		email: user.email,
+		resource: 'execute_calls_per_day',
+		now: wednesday,
+	}).then(
+		() => null,
+		(thrown: unknown) => thrown,
+	)
+	if (!(denied instanceof EntitlementLimitError)) {
+		throw new Error('Expected weekly EntitlementLimitError.')
+	}
+	expect(denied.details).toMatchObject({
+		resource: 'execute_calls_per_day',
+		limit: 400,
+		current: 400,
+		window: 'week',
+	})
+}, 30_000)
+
 test('UserMeter daily entitlement consume/refund/read/export/purge workflow is per-user without D1 daily table', async () => {
 	const now = recentDailyCounterNow()
 	const day = utcDayKey(now)

--- a/packages/worker/src/mcp/capabilities/account/usage-get.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/account/usage-get.node.test.ts
@@ -137,6 +137,17 @@ test('usageGet returns self-scoped entitlement snapshot', async () => {
 	)
 	expect(saved?.current).toBe(1)
 	expect(saved?.limit).toBeGreaterThan(0)
+	const execute = result.resources.find(
+		(row) => row.resource === 'execute_calls_per_day',
+	)
+	expect(execute?.limit).toBe(1_500)
+	expect(execute?.week).toEqual({
+		current: 0,
+		limit: 4_000,
+		percent: 0,
+		overEightyPercent: false,
+	})
+	expect(result.weekStart).toMatch(/^\d{4}-\d{2}-\d{2}$/)
 })
 
 test('usageGet reports legacy Standard ceilings for grandfathered accounts', async () => {
@@ -160,7 +171,8 @@ test('usageGet reports legacy Standard ceilings for grandfathered accounts', asy
 		(row) => row.resource === 'execute_calls_per_day',
 	)
 	expect(execute?.limit).toBe(500)
-	expect(execute?.limit).not.toBe(150)
+	expect(execute?.week).toBeUndefined()
+	expect(result.weekStart).toMatch(/^\d{4}-\d{2}-\d{2}$/)
 })
 
 test('usageGet warns on unique worker days with whatCounts and howToReduce', async () => {

--- a/packages/worker/src/mcp/capabilities/account/usage-get.ts
+++ b/packages/worker/src/mcp/capabilities/account/usage-get.ts
@@ -13,6 +13,13 @@ import {
 import { getUserEntitlement } from '#worker/entitlements/service.ts'
 import { readEntitlementUsageSnapshot } from '#worker/entitlements/usage-snapshot.ts'
 
+const usageWeekWindowSchema = z.object({
+	current: z.number().int().nonnegative(),
+	limit: z.number().int().nonnegative(),
+	percent: z.number().nullable(),
+	overEightyPercent: z.boolean(),
+})
+
 const usageResourceSchema = z.object({
 	resource: z.string(),
 	label: z.string(),
@@ -25,6 +32,7 @@ const usageResourceSchema = z.object({
 	percent: z.number().nullable(),
 	overEightyPercent: z.boolean(),
 	mechanic: z.string().optional(),
+	week: usageWeekWindowSchema.optional(),
 })
 
 export const usageGetCapability = defineDomainCapability(
@@ -51,6 +59,8 @@ export const usageGetCapability = defineDomainCapability(
 			plan: z.enum(planNames),
 			/** UTC day for daily-rate counters (YYYY-MM-DD). */
 			day: z.string(),
+			/** UTC Monday that starts the week for execute/outbound weekly windows. */
+			weekStart: z.string(),
 			resources: z.array(usageResourceSchema),
 			warnings: z.array(usageResourceSchema),
 		}),
@@ -102,6 +112,12 @@ export const usageGetCapability = defineDomainCapability(
 				limit: number
 				percentOfLimit: number | null
 				overEightyPercent: boolean
+				week?: {
+					current: number
+					limit: number
+					percentOfLimit: number | null
+					overEightyPercent: boolean
+				}
 			}) => ({
 				resource: row.resource,
 				label: row.label,
@@ -116,11 +132,22 @@ export const usageGetCapability = defineDomainCapability(
 				...(row.resource === 'unique_worker_days' && row.overEightyPercent
 					? { mechanic: uniqueWorkerDayMechanic }
 					: {}),
+				...(row.week
+					? {
+							week: {
+								current: row.week.current,
+								limit: row.week.limit,
+								percent: row.week.percentOfLimit,
+								overEightyPercent: row.week.overEightyPercent,
+							},
+						}
+					: {}),
 			})
 			const computeRows = toComputeOverageUsageRows(computeOverage)
 			return {
 				plan: snapshot.plan,
 				day: snapshot.today,
+				weekStart: snapshot.weekStart,
 				resources: [
 					...computeRows.map(mapRow),
 					...snapshot.resources.map(mapRow),

--- a/packages/worker/src/mcp/entitlement-metadata.ts
+++ b/packages/worker/src/mcp/entitlement-metadata.ts
@@ -31,6 +31,7 @@ export type McpEntitlementMetadata =
 			upgradeHint: string
 			used?: number
 			remaining?: number
+			window?: 'day' | 'week'
 	  }
 	| {
 			code: typeof jobIntervalFloorErrorCode
@@ -94,6 +95,7 @@ function toEntitlementLimitMetadata(
 		limit: details.limit,
 		current: details.current,
 		upgradeHint: details.upgradeHint,
+		...(details.window ? { window: details.window } : {}),
 	} as const
 	if (!isDailyEntitlementResource(details.resource)) return metadata
 	return {

--- a/packages/worker/src/mcp/waiting/derive-waiting.ts
+++ b/packages/worker/src/mcp/waiting/derive-waiting.ts
@@ -316,9 +316,13 @@ async function collectEntitlementCaps(
 		return snapshot.resources
 			.filter(
 				(row) =>
-					row.percentOfLimit != null &&
-					row.percentOfLimit >= 1 &&
-					row.limit > 0,
+					(row.percentOfLimit != null &&
+						row.percentOfLimit >= 1 &&
+						row.limit > 0) ||
+					(row.week != null &&
+						row.week.percentOfLimit != null &&
+						row.week.percentOfLimit >= 1 &&
+						row.week.limit > 0),
 			)
 			.map((row) => ({
 				resource: row.resource,

--- a/packages/worker/src/test-support/user-meter.ts
+++ b/packages/worker/src/test-support/user-meter.ts
@@ -61,6 +61,20 @@ export function createInMemoryUserMeterEnv() {
 			return rows.get(counterKey(resource, day)) ?? null
 		}
 
+		function sumRange(resource: string, startDay: string, endDay: string) {
+			let total = 0
+			for (const [entryKey, row] of rows) {
+				const separator = entryKey.indexOf('\0')
+				if (separator < 0) continue
+				const rowResource = entryKey.slice(0, separator)
+				const day = entryKey.slice(separator + 1)
+				if (rowResource !== resource) continue
+				if (day < startDay || day > endDay) continue
+				total += row.count
+			}
+			return total
+		}
+
 		function ready(row: MeterRow) {
 			return {
 				outcome: 'ready' as const,
@@ -179,6 +193,8 @@ export function createInMemoryUserMeterEnv() {
 				day: string
 				limit: number
 				updatedAt: string
+				weekStart?: string
+				weekLimit?: number | null
 			}) {
 				if (!isDailyEntitlementResource(input.resource)) {
 					throw new Error(`Invalid daily resource: ${input.resource}`)
@@ -186,20 +202,64 @@ export function createInMemoryUserMeterEnv() {
 				const resource: DailyEntitlementResource = input.resource
 				const existing = readRow(resource, input.day)
 				if (!existing) return { outcome: 'needs_bootstrap' as const }
+				const weekLimit =
+					typeof input.weekLimit === 'number' &&
+					Number.isFinite(input.weekLimit)
+						? input.weekLimit
+						: null
+				const weekStart = input.weekStart ?? null
+				const weekCount =
+					weekStart && weekLimit !== null
+						? sumRange(resource, weekStart, input.day)
+						: undefined
 				if (input.limit < 1 || existing.count + 1 > input.limit) {
-					return { ...ready(existing), consumed: false }
+					return {
+						...ready(existing),
+						consumed: false,
+						deniedWindow: 'day' as const,
+						weekCount,
+					}
+				}
+				if (
+					weekStart &&
+					weekLimit !== null &&
+					(weekLimit < 1 || (weekCount ?? 0) + 1 > weekLimit)
+				) {
+					return {
+						...ready(existing),
+						consumed: false,
+						deniedWindow: 'week' as const,
+						weekCount,
+					}
 				}
 				const next = {
 					count: existing.count + 1,
 					revision: existing.revision + 1,
 				}
 				rows.set(counterKey(resource, input.day), next)
-				return { ...ready(next), consumed: true }
+				return {
+					...ready(next),
+					consumed: true,
+					weekCount: weekCount === undefined ? undefined : weekCount + 1,
+				}
 			},
 			async read(input: { resource: string; day: string }) {
 				const existing = readRow(input.resource, input.day)
 				if (!existing) return { outcome: 'needs_bootstrap' as const }
 				return ready(existing)
+			},
+			async readRange(input: {
+				resource: string
+				startDay: string
+				endDay: string
+			}) {
+				if (!isDailyEntitlementResource(input.resource)) {
+					throw new Error(`Invalid daily resource: ${input.resource}`)
+				}
+				return {
+					outcome: 'ready' as const,
+					count: sumRange(input.resource, input.startDay, input.endDay),
+				}
 			},
 			async claimDynamicWorkerDay(input: {
 				workerId: string

--- a/packages/worker/universal/loader-data.ts
+++ b/packages/worker/universal/loader-data.ts
@@ -1962,6 +1962,13 @@ export type AccountBillingSuccessLoaderData = {
 	needsOnboarding: boolean
 }
 
+export type AccountUsageWeekWindow = {
+	current: number
+	limit: number
+	percentOfLimit: number | null
+	overEightyPercent: boolean
+}
+
 export type AccountUsageEntitlementConsumption = {
 	resource: string
 	label: string
@@ -1973,6 +1980,7 @@ export type AccountUsageEntitlementConsumption = {
 	limit: number
 	percentOfLimit: number | null
 	overEightyPercent: boolean
+	week?: AccountUsageWeekWindow
 }
 
 type AccountUsageComputeMeter = {
@@ -2001,6 +2009,7 @@ export type AccountUsageLoaderData = {
 	manualPlan: AdminPlanName
 	stripePlan: AdminPlanName | null
 	today: string
+	weekStart: string
 	entitlementConsumption: Array<AccountUsageEntitlementConsumption>
 	warnings: Array<AccountUsageEntitlementConsumption>
 	computeOverage: AccountUsageComputeOverage

--- a/packages/worker/universal/plans.node.test.ts
+++ b/packages/worker/universal/plans.node.test.ts
@@ -5,6 +5,7 @@ import {
 	resolveEntitlementLadderAfterPaidAccessChange,
 	resolvePlanLimit,
 	resolvePlanLimits,
+	resolveWeeklyPlanLimit,
 } from './plans.ts'
 
 test('formatDurableObjectRowsRead uses billion-scale labels', () => {
@@ -14,16 +15,19 @@ test('formatDurableObjectRowsRead uses billion-scale labels', () => {
 })
 
 test('resolvePlanLimit uses public numbers unless the legacy ladder applies', () => {
-	expect(resolvePlanLimit('standard', 'execute_calls_per_day')).toBe(150)
+	expect(resolvePlanLimit('free', 'execute_calls_per_day')).toBe(150)
+	expect(resolvePlanLimit('standard', 'execute_calls_per_day')).toBe(500)
 	expect(resolvePlanLimit('standard', 'execute_calls_per_day', 'public')).toBe(
-		150,
+		500,
 	)
 	expect(resolvePlanLimit('standard', 'execute_calls_per_day', 'legacy')).toBe(
 		500,
 	)
+	expect(resolvePlanLimit('pro', 'execute_calls_per_day')).toBe(1_500)
+	expect(resolvePlanLimit('pro', 'outbound_fetches_per_day')).toBe(50_000)
 	expect(resolvePlanLimit('pro', 'scheduled_jobs', 'legacy')).toBe(150)
 	expect(resolvePlanLimit('pro', 'scheduled_jobs', 'public')).toBe(75)
-	expect(resolvePlanLimit('free', 'execute_calls_per_day', 'legacy')).toBe(100)
+	expect(resolvePlanLimit('free', 'execute_calls_per_day', 'legacy')).toBe(150)
 	expect(resolvePlanLimit('max', 'execute_calls_per_day', 'legacy')).toBe(
 		25_000,
 	)
@@ -31,6 +35,29 @@ test('resolvePlanLimit uses public numbers unless the legacy ladder applies', ()
 	expect(resolvePlanLimits('pro', 'public').minJobIntervalMs).toBe(
 		5 * 60 * 1000,
 	)
+})
+
+test('public Free/Standard/Pro have weekly execute and outbound windows; max and legacy do not', () => {
+	expect(resolveWeeklyPlanLimit('free', 'execute_calls_per_day')).toBe(400)
+	expect(resolveWeeklyPlanLimit('standard', 'execute_calls_per_day')).toBe(
+		1_200,
+	)
+	expect(resolveWeeklyPlanLimit('pro', 'execute_calls_per_day')).toBe(4_000)
+	expect(resolveWeeklyPlanLimit('free', 'outbound_fetches_per_day')).toBe(2_500)
+	expect(resolveWeeklyPlanLimit('standard', 'outbound_fetches_per_day')).toBe(
+		40_000,
+	)
+	expect(resolveWeeklyPlanLimit('pro', 'outbound_fetches_per_day')).toBe(
+		120_000,
+	)
+	expect(resolveWeeklyPlanLimit('max', 'execute_calls_per_day')).toBeNull()
+	expect(
+		resolveWeeklyPlanLimit('standard', 'execute_calls_per_day', 'legacy'),
+	).toBeNull()
+	expect(
+		resolveWeeklyPlanLimit('pro', 'outbound_fetches_per_day', 'legacy'),
+	).toBeNull()
+	expect(resolveWeeklyPlanLimit('free', 'job_runs_per_day')).toBeNull()
 })
 
 test('parseEntitlementLadder treats blank as public and rejects unknown names', () => {

--- a/packages/worker/universal/plans.ts
+++ b/packages/worker/universal/plans.ts
@@ -216,12 +216,26 @@ export type PlanLimits = {
 	/** Maximum MCP execute-tool runs per UTC day. */
 	maxExecuteCallsPerDay: number
 	/**
+	 * Maximum MCP execute-tool runs per UTC week (Monday–Sunday). `null`
+	 * means no weekly window — daily is the only hard cap. Public
+	 * Free/Standard/Pro set a weekly total so a 1–2 day burst cannot spend
+	 * a full week of daily headroom. `max` and legacy Standard/Pro leave
+	 * this unset so their daily-only behavior stays unchanged.
+	 */
+	maxExecuteCallsPerWeek: number | null
+	/**
 	 * Maximum sandbox outbound fetches (through the fetch gateway) per UTC
 	 * day. Bounds cost abuse and third-party hammering from user code; the
 	 * shared Worker egress identity means one user's fetch flood can burn
 	 * reputation for the whole deployment.
 	 */
 	maxOutboundFetchesPerDay: number
+	/**
+	 * Maximum sandbox outbound fetches per UTC week (Monday–Sunday).
+	 * `null` means no weekly window. Same public-vs-legacy/`max` rule as
+	 * {@link PlanLimits.maxExecuteCallsPerWeek}.
+	 */
+	maxOutboundFetchesPerWeek: number | null
 	/**
 	 * Maximum scheduled-job executions per UTC day (cron, interval, and
 	 * run-now). Separate from `maxScheduledJobs` (how many job rows you may
@@ -355,11 +369,13 @@ export const planLimits: Record<PlanName, PlanLimits> = {
 		// Concurrent active runs (not lifetime or daily). One at a time on
 		// free; a second deferred workflow is the upgrade nudge.
 		maxConcurrentWorkflows: 1,
-		// Unique execute is the Dynamic Worker bill. 100/day covers a real
-		// agent morning (~70 observed) without pricing a free account at
-		// Standard's unique-execute ceiling.
-		maxExecuteCallsPerDay: 100,
-		maxOutboundFetchesPerDay: 500,
+		// Unique execute is the Dynamic Worker bill. Daily headroom covers a
+		// bursty agent morning; the weekly total keeps a free account from
+		// spending a full week of that headroom every day.
+		maxExecuteCallsPerDay: 150,
+		maxExecuteCallsPerWeek: 400,
+		maxOutboundFetchesPerDay: 1_000,
+		maxOutboundFetchesPerWeek: 2_500,
 		maxJobRunsPerDay: 500,
 		minJobIntervalMs: 15 * 60 * 1000,
 		maxUniqueWorkerDaysPerMonth: 50,
@@ -377,11 +393,13 @@ export const planLimits: Record<PlanName, PlanLimits> = {
 		maxSecrets: 100,
 		maxStorageBytes: 1024 * 1024 * 1024,
 		maxConcurrentWorkflows: 10,
-		// Public Standard execute is a try-paid rung, not the old 500/day
-		// ceiling. Continuous pre-cut subscribers keep
-		// {@link legacyPlanLimits}.
-		maxExecuteCallsPerDay: 150,
-		maxOutboundFetchesPerDay: 5_000,
+		// Public Standard execute is a try-paid rung with bursty daily
+		// headroom and a weekly total. Continuous pre-cut subscribers keep
+		// {@link legacyPlanLimits} (daily-only, no weekly window).
+		maxExecuteCallsPerDay: 500,
+		maxExecuteCallsPerWeek: 1_200,
+		maxOutboundFetchesPerDay: 15_000,
+		maxOutboundFetchesPerWeek: 40_000,
 		maxJobRunsPerDay: 1_500,
 		minJobIntervalMs: 15 * 60 * 1000,
 		maxUniqueWorkerDaysPerMonth: 350,
@@ -399,12 +417,14 @@ export const planLimits: Record<PlanName, PlanLimits> = {
 		maxSecrets: 200,
 		maxStorageBytes: 5 * 1024 * 1024 * 1024,
 		maxConcurrentWorkflows: 50,
-		// Execute is a hard daily cap with no overage. Unique-worker-day
-		// overage is a heavy-tail safety valve
+		// Execute is a hard daily + weekly cap with no overage.
+		// Unique-worker-day overage is a heavy-tail safety valve
 		// ({@link computeOverageRatesUsd}), not a reason to shrink this
 		// include or the public $49 Pro price.
-		maxExecuteCallsPerDay: 750,
-		maxOutboundFetchesPerDay: 25_000,
+		maxExecuteCallsPerDay: 1_500,
+		maxExecuteCallsPerWeek: 4_000,
+		maxOutboundFetchesPerDay: 50_000,
+		maxOutboundFetchesPerWeek: 120_000,
 		maxJobRunsPerDay: 8_000,
 		minJobIntervalMs: 5 * 60 * 1000,
 		maxUniqueWorkerDaysPerMonth: 2_000,
@@ -435,8 +455,10 @@ export const planLimits: Record<PlanName, PlanLimits> = {
 		// peak is not stored; 25,000 is at least 2× a ~12,500 peak (~3×
 		// August avg). Unique-DW ceiling is $50/day ($0.002 × 25,000).
 		maxExecuteCallsPerDay: 25_000,
+		maxExecuteCallsPerWeek: null,
 		// 2× pro (40_000). Today's fetch spike (~17,000) stays well under.
 		maxOutboundFetchesPerDay: 80_000,
+		maxOutboundFetchesPerWeek: null,
 		// 2× the previous public Pro (20_000). Busy days are ~1,500–1,700
 		// job runs. `max` ceilings stay on that earlier Pro table; they
 		// still dominate every paid plan.
@@ -471,7 +493,9 @@ export const legacyPlanLimits: Record<'standard' | 'pro', PlanLimits> = {
 		maxStorageBytes: 1024 * 1024 * 1024,
 		maxConcurrentWorkflows: 50,
 		maxExecuteCallsPerDay: 500,
+		maxExecuteCallsPerWeek: null,
 		maxOutboundFetchesPerDay: 20_000,
+		maxOutboundFetchesPerWeek: null,
 		maxJobRunsPerDay: 10_000,
 		minJobIntervalMs: 0,
 		maxUniqueWorkerDaysPerMonth: 350,
@@ -490,7 +514,9 @@ export const legacyPlanLimits: Record<'standard' | 'pro', PlanLimits> = {
 		maxStorageBytes: 5 * 1024 * 1024 * 1024,
 		maxConcurrentWorkflows: 100,
 		maxExecuteCallsPerDay: 800,
+		maxExecuteCallsPerWeek: null,
 		maxOutboundFetchesPerDay: 40_000,
+		maxOutboundFetchesPerWeek: null,
 		maxJobRunsPerDay: 20_000,
 		minJobIntervalMs: 0,
 		maxUniqueWorkerDaysPerMonth: 2_000,
@@ -515,8 +541,8 @@ export const cloudflareComputeListUsd = {
  * amounts or the public Pro $49 price to monetize via overage. When
  * invoicing is enabled, public-ladder usage above the include is priced
  * at these rates (`computeMeteringPolicy.publicMonthlyMeters`). Execute
- * has no overage (hard daily cap — an execute overage would double-charge
- * the same burn as unique worker days). Durable Object duration is
+ * has no overage (hard daily + weekly cap — an execute overage would
+ * double-charge the same burn as unique worker days). Durable Object duration is
  * unmetered. Legacy Standard/Pro is not cut and not billed on these
  * allotments. Who is invoiced is {@link computeOverageBillingPolicy},
  * not this table.
@@ -529,7 +555,8 @@ export const computeOverageRatesUsd = {
 export const computeMeteringPolicy = {
 	uniqueWorkerDays: 'included_then_overage',
 	durableObjectRowsRead: 'included_then_overage',
-	executeCallsPerDay: 'hard_daily_cap',
+	executeCallsPerDay: 'hard_daily_and_weekly_cap',
+	outboundFetchesPerDay: 'hard_daily_and_weekly_cap',
 	durableObjectDuration: 'unmetered',
 	publicMonthlyMeters: 'charge_list_rates',
 	legacyMonthlyMeters: 'no_cut_no_bill',
@@ -627,6 +654,70 @@ export function resolvePlanLimit(
 		default: {
 			const exhaustive: never = resource
 			throw new Error(`Unknown entitlement resource: ${String(exhaustive)}`)
+		}
+	}
+}
+
+/** Daily resources that also have a public-ladder weekly hard cap. */
+export const weeklyComputeWindowResources = [
+	'execute_calls_per_day',
+	'outbound_fetches_per_day',
+] as const satisfies ReadonlyArray<EntitlementResource>
+
+export type WeeklyComputeWindowResource =
+	(typeof weeklyComputeWindowResources)[number]
+
+export function isWeeklyComputeWindowResource(
+	resource: EntitlementResource,
+): resource is WeeklyComputeWindowResource {
+	return (weeklyComputeWindowResources as ReadonlyArray<string>).includes(
+		resource,
+	)
+}
+
+/**
+ * One-liner for pricing and /account usage next to execute / outbound
+ * daily+weekly meters.
+ */
+export const weeklyComputeWindowNote =
+	'High daily headroom for bursts; weekly total keeps it sustainable.'
+
+/**
+ * Weekly hard cap for execute or outbound on the public ladder.
+ * Returns `null` when the plan/ladder has no weekly window (`max`,
+ * legacy Standard/Pro, or any other resource).
+ */
+export function resolveWeeklyPlanLimit(
+	plan: PlanName,
+	resource: EntitlementResource,
+	ladder: EntitlementLadder = 'public',
+): number | null {
+	if (!isWeeklyComputeWindowResource(resource)) return null
+	const limits = resolvePlanLimits(plan, ladder)
+	switch (resource) {
+		case 'execute_calls_per_day':
+			return limits.maxExecuteCallsPerWeek
+		case 'outbound_fetches_per_day':
+			return limits.maxOutboundFetchesPerWeek
+		default: {
+			const exhaustive: never = resource
+			throw new Error(`Unknown weekly compute resource: ${String(exhaustive)}`)
+		}
+	}
+}
+
+/** Human label for a weekly execute/outbound denial. */
+export function weeklyEntitlementResourceLabel(
+	resource: WeeklyComputeWindowResource,
+): string {
+	switch (resource) {
+		case 'execute_calls_per_day':
+			return 'execute calls this week'
+		case 'outbound_fetches_per_day':
+			return 'outbound fetches this week'
+		default: {
+			const exhaustive: never = resource
+			throw new Error(`Unknown weekly compute resource: ${String(exhaustive)}`)
 		}
 	}
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Raise public Free/Standard/Pro execute and outbound-fetch hard caps, and add a UTC-week window so a 1–2 day burst cannot spend a full week of daily headroom.

## Why

Kent-approved public ladder: weekly windows (not monthly) on execute and outbound fetches only. Legacy Standard/Pro and Max stay daily-only. Other meters are unchanged.

## Summary

- Public daily caps: execute Free 150 / Standard 500 / Pro 1,500; outbound Free 1,000 / Standard 15,000 / Pro 50,000.
- Public weekly caps on the same UserMeter daily rows (UTC Monday–Sunday): execute 400 / 1,200 / 4,000; outbound 2,500 / 40,000 / 120,000.
- Enforcement uses both windows — whichever hits first blocks.
- Weekly meters **reuse** `execute_calls_per_day` and `outbound_fetches_per_day` (no new entitlement resource keys). `maxExecuteCallsPerWeek` / `maxOutboundFetchesPerWeek` are new `PlanLimits` fields; `null` on Max and legacy means no weekly window.
- `/pricing`, `/account/usage`, and `usageGet` show today and this week, with “High daily headroom for bursts; weekly total keeps it sustainable.”
- Used percent / progress bar / approaching-limit copy use the hotter of the two windows (Bugbot).
- FAQ free-plan copy and architecture docs updated.

## Testing

- Local `npm run validate` green (format, lint, typecheck, node, workers, e2e 15, mcp, builds, knip).
- Pre-push after Bugbot fix: `test:node` 3000 passed, `test:workers` 342 passed.
- Preview `GET /account/usage.json` as seed user: Free execute 150/day + 400/week, outbound 1,000/day + 2,500/week; `job_runs_per_day` unchanged and has no week window.
- Preview `/pricing` SSR: weekly rows and the burst/sustainable one-liner.
- Focused tests: plans, dual-window entitlements, usage snapshot (weekly-hot warning), account usage hotter-percent, usageGet, pricing SSR, date-keys, UserMeter weekly deny.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `0ca08695` · **Head:** `09c2bda1`

**Classification:** extends — public execute/outbound limits and UserMeter consume now enforce a second UTC-week window; usage and pricing surfaces report both.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `entitlements` | auth | extends — public daily numbers and weekly PlanLimits fields; consume throws on the first window hit |
| `user-meter` | storage | extends — consume sums current UTC week and can deny on week; new `readRange` |
| `app-ui` | surfaces | extends — pricing table, FAQ, and /account/usage show today + this week; used percent follows the hotter window |
| `mcp-server` | surfaces | extends — usageGet week fields; waiting treats a full weekly window as a cap |
| `account-export` | assistant | extends — `usageGet` payload includes `weekStart` and optional `week` |
| `email-reporting` | storage | composes — `utcWeekStart` moved to shared date-keys only |

### Change flow

Public execute and outbound consume still increment one daily UserMeter row; the same RPC now also sums the UTC week and blocks if either cap would be exceeded.

```mermaid
sequenceDiagram
	actor User
	participant mcpServer as mcp-server
	participant entitlements as entitlements
	participant userMeter as user-meter
	participant appUi as app-ui
	User->>mcpServer: execute or gateway fetch
	mcpServer->>entitlements: consumeDailyEntitlement
	entitlements->>userMeter: consume day plus optional weekLimit
	alt daily or weekly cap hit
		userMeter-->>entitlements: consumed false
		entitlements-->>mcpServer: EntitlementLimitError
	else under both windows
		userMeter-->>entitlements: increment daily row
	end
	User->>appUi: GET /pricing or /account/usage
	appUi->>entitlements: resolvePlanLimits and usage snapshot
	entitlements->>userMeter: read today and readRange this week
```

### Before / after

| Plan | Execute today → new daily / weekly | Outbound today → new daily / weekly |
| --- | --- | --- |
| Free | 100 → 150 / 400 | 500 → 1,000 / 2,500 |
| Standard | 150 → 500 / 1,200 | 5,000 → 15,000 / 40,000 |
| Pro | 750 → 1,500 / 4,000 | 25,000 → 50,000 / 120,000 |
| Max / legacy | unchanged daily; weekly `null` | unchanged daily; weekly `null` |

### Invariants

Per-user isolation is unchanged: UserMeter remains one DO per user, and weekly totals are sums of that user's daily rows.

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9de4a377-114b-4ac7-9260-0752cc128c98?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9de4a377-114b-4ac7-9260-0752cc128c98&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added weekly UTC Monday–Sunday caps for execute calls and outbound fetches on public Free, Standard, and Pro plans.
  - Pricing, FAQ, and account usage pages now show weekly limits, usage, week start dates, and cap guidance.
  - Usage responses and limit messages identify whether a daily or weekly cap was reached.
  - Daily and weekly limits are enforced, with whichever is reached first blocking further activity.
  - Legacy and Max plans remain subject to daily limits only.

- **Documentation**
  - Updated billing, architecture, and usage-metering documentation to describe weekly caps and plan-specific behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->