### PR TITLE
Narrow LOADER Dynamic Worker ids to cut deploy-thrash CF cost

### DIFF
--- a/docs/contributing/architecture/usage-metering.md
+++ b/docs/contributing/architecture/usage-metering.md
@@ -205,6 +205,32 @@ APP_LOADER package-app isolates record UWD when the worker id is stable
 (`app_fetch` / `app_realtime`). One-off `APP_LOADER.load()` without a hashed id
 has no worker id to claim and does not emit `dynamic_worker_day`.
 
+### LOADER worker identity
+
+`createStableDynamicWorkerId` in `packages/worker/src/mcp/dynamic-worker-id.ts`
+mints the execute-sandbox worker id. The hash is the sandbox-contract version
+(`dynamicWorkerCacheKeyVersion`, bumped only when the executor or identity
+contract changes), the `LOADER` binding name, the acting `userId` and
+`storageContext`, compatibility date/flags, the main module name, and the module
+graph (agent code plus the generated executor harness).
+
+Timeout, `allowOutboundFetch`, and the excluded fetch hostname are baked into
+that harness text, so they are not hashed again. Deploy SHA (`APP_COMMIT_SHA`),
+email, and other request-only `gatewayProps` fields are not part of the key: a
+parent deploy remints ids only when the harness or module graph actually
+changes.
+
+`userId` and `storageContext` stay in the key because `LOADER.get` reuses the
+first factory's WorkerCode for a given id, including the `KodyFetchGateway`
+`globalOutbound` stub. Those props authorize outbound fetch, secrets, and quota,
+so two users (or two storage contexts) with the same module graph still get
+distinct ids. UWD metering stays `(userId, workerId, day)` via
+`claimDynamicWorkerDay` and is independent of this hash.
+
+When modules are not deterministically hashable, the id is a UUID and is not
+reused. Hashable modules still produce a stable id when `userId` is null or
+`APP_COMMIT_SHA` is unset.
+
 Customer-facing monthly overage is unique worker days plus Durable Object
 rows-read, billed on the public ladder at `computeOverageRatesUsd` when
 `compute-overage-charging` is on. Unpaid Free is a soft-block, not a charge.

--- a/docs/guides/platform-efficiency.md
+++ b/docs/guides/platform-efficiency.md
@@ -25,8 +25,9 @@ meter.
 
 - The first use of a given worker id on a UTC day counts once for that user.
 - Repeating the same worker id on the same UTC day does not add another day.
-- Worker identity follows the **module graph** for that run: the same published
-  graph reuses one isolate; a different graph is a different isolate.
+- Worker identity follows the acting user plus the **module graph** for that
+  run: the same user and published graph reuse one isolate; a different graph or
+  a different user is a different isolate.
 
 Each plan includes a monthly unique-worker-day allotment. Public-ladder overage
 uses the published unique-worker-day rate on

--- a/docs/use/execute.md
+++ b/docs/use/execute.md
@@ -273,9 +273,10 @@ limit, current usage, upgrade hint). Daily quota denials add compact `used` and
 (meter name and what a unique worker day is). Ordinary successful execute
 results omit `entitlement`.
 
-Dynamic Worker identity for an execute run follows that module graph, so the
-same graph reuses one isolate for the UTC day. The cost model is documented once
-in [Platform efficiency](../guides/platform-efficiency.md).
+Dynamic Worker identity for an execute run follows the acting user and that
+module graph, so the same user and graph reuse one isolate for the UTC day. The
+cost model is documented once in
+[Platform efficiency](../guides/platform-efficiency.md).
 
 For memory mutations, the workflow is explicit and strict:
 

--- a/packages/worker/src/mcp/dynamic-worker-id.node.test.ts
+++ b/packages/worker/src/mcp/dynamic-worker-id.node.test.ts
@@ -1,0 +1,142 @@
+import { expect, test } from 'vitest'
+import {
+	createStableDynamicWorkerId,
+	dynamicWorkerCacheKeyVersion,
+} from '#mcp/dynamic-worker-id.ts'
+import { type StorageContext } from '#mcp/storage.ts'
+import { createDynamicWorkerCompatibilityOptions } from '#worker/dynamic-worker-compatibility.ts'
+
+function createWorkerOptions(modules: Record<string, string>) {
+	return {
+		...createDynamicWorkerCompatibilityOptions(),
+		mainModule: 'executor.js',
+		modules,
+	}
+}
+
+async function mintId(input: {
+	userId?: string | null
+	storageContext?: StorageContext | null
+	modules?: Record<string, string>
+	cacheKeyVersion?: number
+}) {
+	return await createStableDynamicWorkerId({
+		userId: input.userId === undefined ? 'user-1' : input.userId,
+		storageContext:
+			input.storageContext === undefined ? null : input.storageContext,
+		workerOptions: {
+			...createDynamicWorkerCompatibilityOptions(),
+			mainModule: 'executor.js',
+			modules: input.modules ?? {
+				'executor.js': 'export default class Executor {}',
+			},
+		},
+		cacheKeyVersion: input.cacheKeyVersion,
+	})
+}
+
+test('createStableDynamicWorkerId is stable for the same modules, user, and storage context', async () => {
+	const modules = {
+		'executor.js': 'export default class Executor { evaluate() { return 1 } }',
+	}
+	const storageContext = {
+		sessionId: 'session-1',
+		appId: 'app-1',
+		storageId: 'storage-1',
+	}
+
+	const first = await mintId({ modules, storageContext })
+	const second = await mintId({ modules, storageContext })
+	expect(first).toBe(second)
+	expect(first).toMatch(/^kody-[A-Za-z0-9_-]{43}$/)
+
+	expect(await mintId({ modules, storageContext, userId: 'user-1' })).toBe(
+		first,
+	)
+
+	const otherUser = await mintId({
+		modules,
+		storageContext,
+		userId: 'user-2',
+	})
+	expect(otherUser).not.toBe(first)
+
+	const otherStorage = await mintId({
+		modules,
+		userId: 'user-1',
+		storageContext: {
+			sessionId: 'session-2',
+			appId: 'app-1',
+			storageId: 'storage-1',
+		},
+	})
+	expect(otherStorage).not.toBe(first)
+
+	const otherCode = await mintId({
+		modules: {
+			'executor.js':
+				'export default class Executor { evaluate() { return 2 } }',
+		},
+		storageContext,
+	})
+	expect(otherCode).not.toBe(first)
+
+	const bumped = await mintId({
+		modules,
+		storageContext,
+		cacheKeyVersion: dynamicWorkerCacheKeyVersion + 1,
+	})
+	expect(bumped).not.toBe(first)
+	expect(await mintId({ modules, storageContext })).toBe(first)
+
+	const missingUser = await mintId({
+		modules,
+		userId: null,
+		storageContext: null,
+	})
+	const missingUserAgain = await mintId({
+		modules,
+		userId: null,
+		storageContext: null,
+	})
+	expect(missingUser).toBe(missingUserAgain)
+	expect(missingUser).not.toBe(first)
+
+	const nonHashableFirst = await createStableDynamicWorkerId({
+		userId: 'user-1',
+		storageContext: null,
+		workerOptions: createWorkerOptions({
+			'executor.js': 'export default class Executor {}',
+		}),
+	})
+	const nonHashable = await createStableDynamicWorkerId({
+		userId: 'user-1',
+		storageContext: null,
+		workerOptions: {
+			...createDynamicWorkerCompatibilityOptions(),
+			mainModule: 'executor.js',
+			modules: {
+				'executor.js': {
+					js: 'export default class Executor {}',
+					onLoad: async () => 'not-hashable',
+				} as never,
+			},
+		},
+	})
+	const nonHashableAgain = await createStableDynamicWorkerId({
+		userId: 'user-1',
+		storageContext: null,
+		workerOptions: {
+			...createDynamicWorkerCompatibilityOptions(),
+			mainModule: 'executor.js',
+			modules: {
+				'executor.js': {
+					js: 'export default class Executor {}',
+					onLoad: async () => 'not-hashable',
+				} as never,
+			},
+		},
+	})
+	expect(nonHashable).not.toBe(nonHashableAgain)
+	expect(nonHashable).not.toBe(nonHashableFirst)
+})

--- a/packages/worker/src/mcp/dynamic-worker-id.ts
+++ b/packages/worker/src/mcp/dynamic-worker-id.ts
@@ -1,0 +1,160 @@
+import { bytesToBase64Url } from '@kody-internal/shared/base64.ts'
+import { sha256Base64Url } from '@kody-internal/shared/sha256.ts'
+import { type StorageContext } from '#mcp/storage.ts'
+import { type WorkerLoaderModules } from '#worker/worker-loader-types.ts'
+
+export const dynamicWorkerIdPrefix = 'kody-'
+
+/**
+ * Sandbox-contract / cache-key version. Bump only when the executor harness
+ * or LOADER identity contract changes — not on every parent commit.
+ */
+export const dynamicWorkerCacheKeyVersion = 5
+
+export type DynamicWorkerIdOptions = {
+	compatibilityDate: string
+	compatibilityFlags: Array<string>
+	mainModule: string
+	modules: WorkerLoaderModules
+}
+
+/**
+ * Stable LOADER id for a Dynamic Worker isolate.
+ *
+ * Identity is the module graph (agent code plus generated harness), compat
+ * knobs, an explicit contract version, and the acting-user facets bound on
+ * `globalOutbound` (`userId`, `storageContext`). `LOADER.get` reuses the
+ * first factory's WorkerCode for a given id, including that gateway stub, so
+ * those facets stay in the key. Deploy SHA, email, and other request-only
+ * gateway fields do not.
+ *
+ * UUID fallback when modules are not deterministically hashable.
+ */
+export async function createStableDynamicWorkerId(input: {
+	userId: string | null
+	storageContext: StorageContext | null
+	workerOptions: DynamicWorkerIdOptions
+	cacheKeyVersion?: number
+}) {
+	if (!areWorkerModulesDeterministicallyHashable(input.workerOptions.modules)) {
+		return `${dynamicWorkerIdPrefix}${crypto.randomUUID()}`
+	}
+	const hash = await sha256Base64Url(
+		canonicalJsonStringify({
+			version: input.cacheKeyVersion ?? dynamicWorkerCacheKeyVersion,
+			binding: 'LOADER',
+			userId: input.userId,
+			storageContext: input.storageContext,
+			compatibilityDate: input.workerOptions.compatibilityDate,
+			compatibilityFlags: input.workerOptions.compatibilityFlags,
+			mainModule: input.workerOptions.mainModule,
+			modules: input.workerOptions.modules,
+		}),
+	)
+	return `${dynamicWorkerIdPrefix}${hash.slice(0, 43)}`
+}
+
+function areWorkerModulesDeterministicallyHashable(
+	modules: WorkerLoaderModules,
+) {
+	for (const moduleValue of Object.values(modules)) {
+		if (!isDeterministicallyHashableWorkerModule(moduleValue)) {
+			return false
+		}
+	}
+	return true
+}
+
+function isDeterministicallyHashableWorkerModule(
+	moduleValue: WorkerLoaderModules[string],
+) {
+	if (typeof moduleValue === 'string') return true
+	if (moduleValue === null || typeof moduleValue !== 'object') return false
+	const record = moduleValue as Record<string, unknown>
+	for (const key of ['js', 'cjs', 'text'] as const) {
+		const value = record[key]
+		if (value !== undefined && typeof value !== 'string') return false
+	}
+	if (record.data !== undefined && !(record.data instanceof ArrayBuffer)) {
+		return false
+	}
+	if (
+		record.json !== undefined &&
+		!isDeterministicallyHashableValue(record.json)
+	) {
+		return false
+	}
+	for (const [key, value] of Object.entries(record)) {
+		if (
+			key !== 'js' &&
+			key !== 'cjs' &&
+			key !== 'text' &&
+			key !== 'data' &&
+			key !== 'json'
+		) {
+			return false
+		}
+		if (key === 'data' || key === 'json') continue
+		if (value !== undefined && typeof value !== 'string') return false
+	}
+	return true
+}
+
+function isDeterministicallyHashableValue(value: unknown): boolean {
+	if (value === null) return true
+	const valueType = typeof value
+	if (
+		valueType === 'string' ||
+		valueType === 'number' ||
+		valueType === 'boolean'
+	) {
+		return true
+	}
+	if (valueType === 'bigint' || valueType === 'undefined') return true
+	if (valueType === 'function' || valueType === 'symbol') return false
+	if (value instanceof ArrayBuffer || ArrayBuffer.isView(value)) return true
+	if (Array.isArray(value)) {
+		return value.every((entry) => isDeterministicallyHashableValue(entry))
+	}
+	if (valueType === 'object') {
+		const record = value as Record<string, unknown>
+		return Object.values(record).every((entry) =>
+			isDeterministicallyHashableValue(entry),
+		)
+	}
+	return false
+}
+
+function canonicalJsonStringify(value: unknown) {
+	return JSON.stringify(canonicalizeForHash(value))
+}
+
+function canonicalizeForHash(value: unknown): unknown {
+	if (value === undefined) return { __kodyType: 'undefined' }
+	if (value === null) return null
+	if (typeof value === 'bigint')
+		return { __kodyType: 'bigint', value: String(value) }
+	if (typeof value !== 'object') return value
+	if (value instanceof ArrayBuffer) {
+		return {
+			__kodyType: 'arrayBuffer',
+			value: bytesToBase64Url(new Uint8Array(value)),
+		}
+	}
+	if (ArrayBuffer.isView(value)) {
+		return {
+			__kodyType: 'arrayBuffer',
+			value: bytesToBase64Url(
+				new Uint8Array(value.buffer, value.byteOffset, value.byteLength),
+			),
+		}
+	}
+	if (Array.isArray(value))
+		return value.map((entry) => canonicalizeForHash(entry))
+	const record = value as Record<string, unknown>
+	return Object.fromEntries(
+		Object.keys(record)
+			.sort((left, right) => left.localeCompare(right))
+			.map((key) => [key, canonicalizeForHash(record[key])]),
+	)
+}

--- a/packages/worker/src/mcp/execute-console-capture.workers.test.ts
+++ b/packages/worker/src/mcp/execute-console-capture.workers.test.ts
@@ -142,8 +142,8 @@ test(
 	async () => {
 		silenceIncidentalRuntimeWarnings()
 		const userId = 'user-console-capture-reuse'
-		// Identical code + modules => same dynamic-worker id when APP_COMMIT_SHA
-		// is set. Per-run labels arrive through RPC dispatchers, not baked code.
+		// Identical code + modules + acting user => same dynamic-worker id.
+		// Per-run labels arrive through RPC dispatchers, not baked code.
 		const bundle = await buildEntryBundle({
 			env: reuseEnv,
 			userId,

--- a/packages/worker/src/mcp/execute-dynamic-worker-reuse.workers.test.ts
+++ b/packages/worker/src/mcp/execute-dynamic-worker-reuse.workers.test.ts
@@ -10,7 +10,7 @@ import { silenceIncidentalRuntimeWarnings } from '#worker/test-support/incidenta
  * disposed" failures (communityPublish / communitySearch / repo publish
  * capabilities intermittently failing on repeated calls).
  *
- * Execute uses stable dynamic-worker ids when `APP_COMMIT_SHA` is set, so two
+ * Execute uses a stable dynamic-worker id for a hashable module graph, so two
  * executes with identical code reuse one sandbox isolate — and the isolate's
  * ES module cache survives between them. The `kody:runtime` virtual module
  * used to freeze the first run's `kody` capability proxy into module scope;
@@ -19,8 +19,9 @@ import { silenceIncidentalRuntimeWarnings } from '#worker/test-support/incidenta
  * later execute with the same code (including from a brand-new conversation)
  * then called capabilities through disposed stubs.
  *
- * `APP_COMMIT_SHA` is unset in local dev and tests, which is why this only
- * reproduced in deployed environments before this suite pinned it.
+ * Reuse no longer depends on `APP_COMMIT_SHA`. This suite still pins one so
+ * the fixture matches deployed env shape; the regression is the stale
+ * dispatcher stubs on a reused isolate.
  */
 
 const reuseEnv = {

--- a/packages/worker/src/mcp/executor.node.test.ts
+++ b/packages/worker/src/mcp/executor.node.test.ts
@@ -7,6 +7,7 @@ import {
 	createSecretScopeUnavailableMessage,
 } from '#mcp/secrets/errors.ts'
 import { createKodyProviderProxySource } from '#mcp/kody-provider-proxy-source.ts'
+import { type StorageContext } from '#mcp/storage.ts'
 import {
 	ComputeOverageLimitError,
 	EntitlementLimitError,
@@ -100,11 +101,19 @@ function createExecutorTestExports() {
 	} as never
 }
 
-function createGatewayProps(userId: string) {
+function createGatewayProps(
+	userId: string,
+	overrides?: {
+		email?: string | null
+		storageContext?: StorageContext | null
+	},
+) {
 	return {
 		baseUrl: 'https://heykody.dev',
 		userId,
-		storageContext: null,
+		email: overrides?.email ?? `${userId}@example.com`,
+		storageContext:
+			overrides?.storageContext === undefined ? null : overrides.storageContext,
 	}
 }
 
@@ -749,7 +758,9 @@ test('createExecuteExecutor reuses stable dynamic worker ids until binding conte
 	const second = await createExecuteExecutor({
 		env,
 		exports,
-		gatewayProps: createGatewayProps('user-1'),
+		gatewayProps: createGatewayProps('user-1', {
+			email: 'other-address@example.com',
+		}),
 	}).execute('async () => "ok"', [
 		{
 			name: 'kody',
@@ -813,24 +824,23 @@ test('createExecuteExecutor reuses stable dynamic worker ids until binding conte
 		}).execute('async () => "ok"', scopedProviders)
 	}
 	expect(noUserLoader.ids).toHaveLength(2)
-	expect(new Set(noUserLoader.ids).size).toBe(2)
-	expect(noUserLoader.factoryCallCount).toBe(2)
+	expect(new Set(noUserLoader.ids).size).toBe(1)
+	expect(noUserLoader.factoryCallCount).toBe(1)
 
-	const noCommitLoader = createFakeWorkerLoader()
-	const noCommitEnv = {
-		...createExecutorTestEnv(noCommitLoader.loader),
-		APP_COMMIT_SHA: undefined,
-	} as Env
-	for (let index = 0; index < 2; index += 1) {
+	const commitShaLoader = createFakeWorkerLoader()
+	for (const commitSha of ['commit-aaa', 'commit-bbb', undefined]) {
 		await createExecuteExecutor({
-			env: noCommitEnv,
+			env: {
+				...createExecutorTestEnv(commitShaLoader.loader),
+				APP_COMMIT_SHA: commitSha,
+			} as Env,
 			exports,
 			gatewayProps: createGatewayProps('user-1'),
 		}).execute('async () => "ok"', scopedProviders)
 	}
-	expect(noCommitLoader.ids).toHaveLength(2)
-	expect(new Set(noCommitLoader.ids).size).toBe(2)
-	expect(noCommitLoader.factoryCallCount).toBe(2)
+	expect(commitShaLoader.ids).toHaveLength(3)
+	expect(new Set(commitShaLoader.ids).size).toBe(1)
+	expect(commitShaLoader.factoryCallCount).toBe(1)
 
 	const bundledLoader = createFakeWorkerLoader()
 	for (let index = 0; index < 2; index += 1) {
@@ -871,10 +881,7 @@ test('createExecuteExecutor reuses stable dynamic worker ids until binding conte
 		await createExecuteExecutor({
 			env: createExecutorTestEnv(differentStorageLoader.loader),
 			exports,
-			gatewayProps: {
-				...createGatewayProps('user-1'),
-				storageContext,
-			},
+			gatewayProps: createGatewayProps('user-1', { storageContext }),
 			modules: {
 				'entry.js': 'export default async function main() { return "ok" }',
 			},

--- a/packages/worker/src/mcp/executor.ts
+++ b/packages/worker/src/mcp/executor.ts
@@ -5,12 +5,10 @@ import {
 	type ExecuteResult,
 	type ResolvedProvider,
 } from '@cloudflare/codemode'
-import { bytesToBase64Url } from '@kody-internal/shared/base64.ts'
 import {
 	getErrorCauseChain,
 	getErrorMessage,
 } from '@kody-internal/shared/error-message.ts'
-import { sha256Base64Url } from '@kody-internal/shared/sha256.ts'
 import { type ContentBlock } from '@modelcontextprotocol/sdk/types.js'
 import { exports as workerExports } from 'cloudflare:workers'
 import {
@@ -73,6 +71,7 @@ import {
 } from '#worker/sentry-options.ts'
 import { parseStorageEstimateReadErrorMessage } from '#worker/storage-estimate-error.ts'
 import { isTransientDurableObjectResetError } from '#worker/durable-object-reset-retry.ts'
+import { createStableDynamicWorkerId } from '#mcp/dynamic-worker-id.ts'
 import {
 	createEvaluationSideEffectTracker,
 	createHostSideEffectProvider,
@@ -89,8 +88,6 @@ export { runWithDynamicWorkerEvaluationBudget } from '#worker/dynamic-worker-eva
 export const defaultExecutionResponseLimitBytes = 102_400
 const maxSupportedExecutorTimeoutMs = 2_147_483_647
 const dynamicWorkerMainModule = 'executor.js'
-const dynamicWorkerIdPrefix = 'kody-'
-const dynamicWorkerCacheKeyVersion = 4
 const hostEvaluationDrainGraceMs = 100
 const reservedProviderNames = new Set([
 	'__dispatchers',
@@ -157,7 +154,6 @@ type DynamicWorkerExecutorInput = {
 	globalOutbound: Fetcher | null
 	modules?: WorkerLoaderModules
 	gatewayProps: FetchGatewayProps
-	appCommitSha?: string | null
 	usageEnv: UsageEnv & UserMeterEnv
 	rawFetchHostSink?: RawFetchHostSink
 	/**
@@ -182,14 +178,6 @@ type DynamicWorkerExecutorInput = {
 	 * an execution context the writes stay awaited so they are not dropped.
 	 */
 	waitUntil?: (promise: Promise<unknown>) => void
-}
-
-type DynamicWorkerExecutorOptions = {
-	compatibilityDate: string
-	compatibilityFlags: Array<string>
-	mainModule: string
-	modules: WorkerLoaderModules
-	globalOutbound: Fetcher | null
 }
 
 type DynamicWorkerEntrypoint = {
@@ -532,7 +520,6 @@ export function createExecuteExecutor(input: {
 		}),
 		modules: input.modules,
 		gatewayProps,
-		appCommitSha: input.env.APP_COMMIT_SHA ?? null,
 		usageEnv: input.env,
 		rawFetchHostSink: input.rawFetchHostSink,
 		recordExecuteUsage: input.recordExecuteUsage,
@@ -579,9 +566,8 @@ function createStableDynamicWorkerExecutor(input: DynamicWorkerExecutorInput) {
 				globalOutbound: input.globalOutbound,
 			}
 			const workerId = await createStableDynamicWorkerId({
-				appCommitSha: input.appCommitSha ?? null,
-				gatewayProps: input.gatewayProps,
-				timeoutMs: input.timeout,
+				userId: input.gatewayProps.userId,
+				storageContext: input.gatewayProps.storageContext,
 				workerOptions,
 			})
 			await runExecuteBookkeeping(
@@ -959,146 +945,6 @@ function removeReservedExecutorModule(
 ) {
 	const { [dynamicWorkerMainModule]: _ignored, ...safeModules } = modules ?? {}
 	return safeModules
-}
-
-async function createStableDynamicWorkerId(input: {
-	appCommitSha: string | null
-	gatewayProps: FetchGatewayProps
-	timeoutMs: number
-	workerOptions: DynamicWorkerExecutorOptions
-}) {
-	if (!canReuseDynamicWorkerId(input)) {
-		return `${dynamicWorkerIdPrefix}${crypto.randomUUID()}`
-	}
-	const hash = await sha256Base64Url(
-		canonicalJsonStringify({
-			version: dynamicWorkerCacheKeyVersion,
-			binding: 'LOADER',
-			appCommitSha: input.appCommitSha,
-			gatewayProps: input.gatewayProps,
-			timeoutMs: input.timeoutMs,
-			compatibilityDate: input.workerOptions.compatibilityDate,
-			compatibilityFlags: input.workerOptions.compatibilityFlags,
-			mainModule: input.workerOptions.mainModule,
-			modules: input.workerOptions.modules,
-		}),
-	)
-	return `${dynamicWorkerIdPrefix}${hash.slice(0, 43)}`
-}
-
-function canReuseDynamicWorkerId(input: {
-	appCommitSha: string | null
-	gatewayProps: FetchGatewayProps
-	workerOptions: DynamicWorkerExecutorOptions
-}) {
-	if (!input.gatewayProps.userId) return false
-	if (!input.appCommitSha) return false
-	return areWorkerModulesDeterministicallyHashable(input.workerOptions.modules)
-}
-
-function areWorkerModulesDeterministicallyHashable(
-	modules: WorkerLoaderModules,
-) {
-	for (const moduleValue of Object.values(modules)) {
-		if (!isDeterministicallyHashableWorkerModule(moduleValue)) {
-			return false
-		}
-	}
-	return true
-}
-
-function isDeterministicallyHashableWorkerModule(
-	moduleValue: WorkerLoaderModules[string],
-) {
-	if (typeof moduleValue === 'string') return true
-	if (moduleValue === null || typeof moduleValue !== 'object') return false
-	const record = moduleValue as Record<string, unknown>
-	for (const key of ['js', 'cjs', 'text'] as const) {
-		const value = record[key]
-		if (value !== undefined && typeof value !== 'string') return false
-	}
-	if (record.data !== undefined && !(record.data instanceof ArrayBuffer)) {
-		return false
-	}
-	if (
-		record.json !== undefined &&
-		!isDeterministicallyHashableValue(record.json)
-	) {
-		return false
-	}
-	for (const [key, value] of Object.entries(record)) {
-		if (
-			key !== 'js' &&
-			key !== 'cjs' &&
-			key !== 'text' &&
-			key !== 'data' &&
-			key !== 'json'
-		) {
-			return false
-		}
-		if (key === 'data' || key === 'json') continue
-		if (value !== undefined && typeof value !== 'string') return false
-	}
-	return true
-}
-
-function isDeterministicallyHashableValue(value: unknown): boolean {
-	if (value === null) return true
-	const valueType = typeof value
-	if (
-		valueType === 'string' ||
-		valueType === 'number' ||
-		valueType === 'boolean'
-	) {
-		return true
-	}
-	if (valueType === 'bigint' || valueType === 'undefined') return true
-	if (valueType === 'function' || valueType === 'symbol') return false
-	if (value instanceof ArrayBuffer || ArrayBuffer.isView(value)) return true
-	if (Array.isArray(value)) {
-		return value.every((entry) => isDeterministicallyHashableValue(entry))
-	}
-	if (valueType === 'object') {
-		const record = value as Record<string, unknown>
-		return Object.values(record).every((entry) =>
-			isDeterministicallyHashableValue(entry),
-		)
-	}
-	return false
-}
-
-function canonicalJsonStringify(value: unknown) {
-	return JSON.stringify(canonicalizeForHash(value))
-}
-
-function canonicalizeForHash(value: unknown): unknown {
-	if (value === undefined) return { __kodyType: 'undefined' }
-	if (value === null) return null
-	if (typeof value === 'bigint')
-		return { __kodyType: 'bigint', value: String(value) }
-	if (typeof value !== 'object') return value
-	if (value instanceof ArrayBuffer) {
-		return {
-			__kodyType: 'arrayBuffer',
-			value: bytesToBase64Url(new Uint8Array(value)),
-		}
-	}
-	if (ArrayBuffer.isView(value)) {
-		return {
-			__kodyType: 'arrayBuffer',
-			value: bytesToBase64Url(
-				new Uint8Array(value.buffer, value.byteOffset, value.byteLength),
-			),
-		}
-	}
-	if (Array.isArray(value))
-		return value.map((entry) => canonicalizeForHash(entry))
-	const record = value as Record<string, unknown>
-	return Object.fromEntries(
-		Object.keys(record)
-			.sort((left, right) => left.localeCompare(right))
-			.map((key) => [key, canonicalizeForHash(record[key])]),
-	)
 }
 
 export type ExecutionErrorDetails =


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Cut Kody’s Cloudflare Dynamic Worker bill by stopping fleet-wide LOADER id remints on every parent deploy. User entitlement tables, plan limits, and pricing are unchanged.

## Why

`createStableDynamicWorkerId` hashed more than the isolate’s WorkerCode. `appCommitSha` reminted every sandbox id on unrelated platform deploys. The entire `gatewayProps` object (`email`, `baseUrl`, timeouts, …) also split ids when those fields were already baked into the harness or are request-only.

Cloudflare bills unique Dynamic Worker ids. UWD metering stays `(userId, workerId, day)` via `claimDynamicWorkerDay` — this PR does not cheapen user meters.

## Summary

- Hash identity is now: contract version (`dynamicWorkerCacheKeyVersion` **5**), `LOADER`, acting `userId` + `storageContext`, compat date/flags, main module, and the module graph (agent code + generated harness).
- **Left the key:** `appCommitSha`, the rest of `gatewayProps` (email, baseUrl, outbound fetch timeout, `allowOutboundFetch`). Timeout / allow-outbound / excluded hostname stay in the harness text, so they are not double-hashed.
- **Stayed in the key:** `userId` and `storageContext`. `LOADER.get` reuses the first factory’s WorkerCode, including the `KodyFetchGateway` `globalOutbound` stub. Those props authorize fetch, secrets, and quota. Cross-user same-id for identical code is **not** safe with today’s mint-time gateway.
- Reuse no longer requires `userId` or `APP_COMMIT_SHA`. Hashable modules with `userId: null` still get a stable id. Non-hashable modules still fall back to UUID.
- Tests prove: same modules + user + storage → same id across email / deploy SHA variants; different user, storage, or agent code → different id; version bump → different id.
- Docs updated in `usage-metering.md`, `platform-efficiency.md`, and `execute.md`.

**Out of scope:** thin-child / parent-proxy, entitlement or pricing changes, provider-stub generation.

## Testing

- `npm run test:node` (push hook): 3002 passed
- `npm run test:workers` (push hook): 341 passed
- Focused: `dynamic-worker-id.node.test.ts`, `executor.node.test.ts`
- CI: Static, Node, Workers, MCP, E2E, Validate, Bugbot **pass**. CodeRabbit still pending (not blocking for medium risk).

### Preview manual test report — **PASS**

| Field | Value |
| --- | --- |
| Preview | https://kody-pr-2215.kody-a99.workers.dev |
| `/health` SHA | `46c2d847bea77d0252ac6d7ea4e9c712d105f830` (merge of `76cb70c7`) |
| Seed | `me@kentcdodds.com` / `user-me` |

What ran:

1. `preview:manual-test` — health/login/MCP 401/runtime/platform + `GET /account/usage.json` + empty packages. **Pass.**
2. `control-kody package-create --kody-id loader-id-preview` — MCP `execute` created `@user-me/loader-id-preview`. **Pass.**
3. MCP `execute` same code twice (`tag: stable-a`) then a slight change (`tag: stable-b`). Results ok. Same-code sandbox **67ms → 3ms** (warm isolate). **Pass.**
4. MCP `execute` of `kody.usageGet({})` — kody tools work. **Pass.**
5. MCP `execute` `fetch('https://example.com')` — `{status:200}`. **Pass.**
6. Usage for the acting seed user (UserMeter, immediate): `execute_calls_per_day` **6/150**, `outbound_fetches_per_day` **1/5000**, `saved_packages` **1**. No other user on this preview. **Pass** (no cross-user bleed observed).
7. `unique_worker_days` account rollup stayed **0**. Preview `/account/usage` reads hourly AE→D1 `usage_rollups`, not the live UserMeter claim. Immediate execute/fetch counters are the live proof. **Noted, not a fail.**
8. UI: `/account/usage`, `/@user-me/loader-id-preview`, `/@user-me`. **Pass.**

Error paths: `/mcp` 401 without OAuth (expected).

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `3157bf9e` · **Head:** `76cb70c7`

**Classification:** extends — LOADER sandbox identity no longer remints on parent deploy SHA. `userId` / `storageContext` stay in the key because mint-time `globalOutbound` is user-bound.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `mcp-server` | surfaces | extends — `createStableDynamicWorkerId` cache key |

Unmatched docs: `usage-metering.md`, `platform-efficiency.md`, `execute.md` (describe the same identity contract). Entitlements / pricing primitives are not touched.

### Change flow

Execute mints a LOADER id from the module graph and acting-user gateway facets, then claims UWD for that user.

```mermaid
sequenceDiagram
	actor Agent
	participant mcpServer as mcp-server
	participant userMeter as user-meter
	Agent->>mcpServer: execute same module graph
	Note over mcpServer: hash version, modules, userId, storageContext
	Note over mcpServer: omit APP_COMMIT_SHA and email
	mcpServer->>mcpServer: LOADER.get stable id
	mcpServer->>userMeter: claimDynamicWorkerDay acting userId
```

### Invariants

Per-user isolation still holds for outbound fetch, secrets, and quota: distinct `userId` / `storageContext` still mint distinct worker ids because `LOADER.get` caches the first `KodyFetchGateway` stub.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d01816e6-faee-48f0-9aeb-e56aa22929c4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d01816e6-faee-48f0-9aeb-e56aa22929c4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dynamic workers now reuse isolates based on the acting user, storage context, and module graph.
  * Worker reuse no longer depends on deployment commit identifiers.
  * Non-deterministically hashable modules receive unique worker identities.

* **Documentation**
  * Updated usage, efficiency, and architecture documentation to explain Dynamic Worker identity and reuse behavior.

* **Tests**
  * Added coverage for stable identities, user and storage changes, module changes, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->