### PR TITLE
Retry webhook URL mint on concurrent first-write id race

### DIFF
--- a/packages/worker/src/webhooks/errors.ts
+++ b/packages/worker/src/webhooks/errors.ts
@@ -1,0 +1,9 @@
+export class WebhookEndpointIdRaceError extends Error {
+	readonly existingId: string
+
+	constructor(existingId: string) {
+		super('Unable to upsert webhook endpoint.')
+		this.name = 'WebhookEndpointIdRaceError'
+		this.existingId = existingId
+	}
+}

--- a/packages/worker/src/webhooks/repo.ts
+++ b/packages/worker/src/webhooks/repo.ts
@@ -1,3 +1,4 @@
+import { WebhookEndpointIdRaceError } from './errors.ts'
 import { type WebhookEndpointRecord } from './types.ts'
 
 type WebhookEndpointRow = {
@@ -56,7 +57,7 @@ export async function upsertWebhookEndpointSecret(input: {
 	})
 	if (existing) {
 		if (existing.id !== input.id) {
-			throw new Error('Unable to upsert webhook endpoint.')
+			throw new WebhookEndpointIdRaceError(existing.id)
 		}
 		const result = input.updateEnabledOnConflict
 			? await input.db

--- a/packages/worker/src/webhooks/service.node.test.ts
+++ b/packages/worker/src/webhooks/service.node.test.ts
@@ -7,7 +7,9 @@ import {
 import { createD1FromSqlite } from '#worker/test-support/create-d1-from-sqlite.ts'
 import { createStableUserIdFromEmail } from '#worker/user-id.ts'
 import { hashWebhookUrlSecret } from './crypto.ts'
+import { WebhookEndpointIdRaceError } from './errors.ts'
 import { parseWebhookUrlHandle } from './handle.ts'
+import * as webhookRepo from './repo.ts'
 import {
 	listWebhooksForUser,
 	mintWebhookUrlForUser,
@@ -256,4 +258,104 @@ test('mint/list/rotate/enable/disable webhooks are package-centered and user-sco
 	expect(reminted.enabled).toBe(true)
 	expect(reminted.handle).toBe(rotatedWhileDisabled.handle)
 	expect(reminted).not.toHaveProperty('urlSecret')
+})
+
+test('first mint that loses the id race retries with the persisted endpoint id', async () => {
+	const userId = await createStableUserIdFromEmail('race@example.com')
+	const { env, db } = createEnv(userId)
+	const winnerId = '11111111-1111-1111-1111-111111111111'
+	await db
+		.prepare(
+			`INSERT INTO webhook_endpoints (
+				id, user_id, package_id, webhook_name, url_secret_hash,
+				url_secret_encrypted, enabled, created_at, rotated_at
+			) VALUES (?, ?, 'pkg-1', 'sentry', 'stale-hash', 'stale-ciphertext', 1, ?, ?)`,
+		)
+		.bind(
+			winnerId,
+			userId,
+			'2026-09-01T00:00:00.000Z',
+			'2026-09-01T00:00:00.000Z',
+		)
+		.run()
+
+	try {
+		await webhookRepo.upsertWebhookEndpointSecret({
+			db,
+			id: '22222222-2222-2222-2222-222222222222',
+			userId,
+			packageId: 'pkg-1',
+			webhookName: 'sentry',
+			urlSecretHash: 'unused-hash',
+			urlSecretEncrypted: 'unused-ciphertext',
+		})
+		throw new Error('expected WebhookEndpointIdRaceError')
+	} catch (error) {
+		expect(error).toBeInstanceOf(WebhookEndpointIdRaceError)
+		if (!(error instanceof WebhookEndpointIdRaceError)) throw error
+		expect(error.existingId).toBe(winnerId)
+	}
+
+	const getByKey = vi.spyOn(webhookRepo, 'getWebhookEndpointByKey')
+	const upsert = vi.spyOn(webhookRepo, 'upsertWebhookEndpointSecret')
+	getByKey.mockImplementationOnce(async () => null)
+
+	const minted = await mintWebhookUrlForUser({
+		env,
+		userId,
+		email: 'race@example.com',
+		username: 'racer',
+		kodyId: 'sentry-bridge',
+		webhookName: 'sentry',
+	})
+
+	expect(upsert).toHaveBeenCalledTimes(2)
+	expect(parseWebhookUrlHandle(minted.handle)).toBe(winnerId)
+	expect(minted.handle).toBe(`whh_${winnerId}`)
+
+	const stored = await db
+		.prepare(
+			`SELECT url_secret_hash, url_secret_encrypted FROM webhook_endpoints
+			WHERE user_id = ? AND id = ?`,
+		)
+		.bind(userId, winnerId)
+		.first<{
+			url_secret_hash: string
+			url_secret_encrypted: string
+		}>()
+	expect(stored?.url_secret_encrypted).toBeTruthy()
+	expect(stored?.url_secret_encrypted).not.toBe('stale-ciphertext')
+	const mintedSecret = await decryptWebhookUrlSecret(
+		env,
+		stored!.url_secret_encrypted,
+		userWebhookUrlSecretContext(userId, winnerId),
+	)
+	expect(stored?.url_secret_hash).toBe(await hashWebhookUrlSecret(mintedSecret))
+
+	getByKey.mockRestore()
+	upsert.mockRestore()
+})
+
+test('concurrent first mints converge on one handle', async () => {
+	const userId = await createStableUserIdFromEmail('parallel@example.com')
+	const { env } = createEnv(userId)
+	const [first, second] = await Promise.all([
+		mintWebhookUrlForUser({
+			env,
+			userId,
+			username: 'parallel',
+			kodyId: 'sentry-bridge',
+			webhookName: 'sentry',
+		}),
+		mintWebhookUrlForUser({
+			env,
+			userId,
+			username: 'parallel',
+			kodyId: 'sentry-bridge',
+			webhookName: 'sentry',
+		}),
+	])
+	expect(first.handle).toBe(second.handle)
+	expect(first.urlHost).toBe('heykody.dev')
+	expect(second).not.toHaveProperty('url')
 })

--- a/packages/worker/src/webhooks/service.ts
+++ b/packages/worker/src/webhooks/service.ts
@@ -25,6 +25,7 @@ import {
 	hashWebhookUrlSecret,
 	webhookUrlSecretMatches,
 } from './crypto.ts'
+import { WebhookEndpointIdRaceError } from './errors.ts'
 import {
 	formatWebhookUrlHandle,
 	parseWebhookUrlHandle,
@@ -278,7 +279,12 @@ export async function mintWebhookUrlForUser(input: {
 			})
 			break
 		} catch (error) {
-			if (attempt > 0 || !getUniqueConstraintField(error)) throw error
+			if (attempt > 0) throw error
+			if (error instanceof WebhookEndpointIdRaceError) {
+				endpointId = error.existingId
+				continue
+			}
+			if (!getUniqueConstraintField(error)) throw error
 			const raced = await getWebhookEndpointByKey({
 				db: input.env.APP_DB,
 				userId: input.userId,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to #2213 / OpenAI Apps review case 14393831.

## Intent

Keep `webhookUrlMint` autonomous under concurrent first writes: the loser should adopt the persisted endpoint id and finish, not throw a generic upsert failure.

## Why

Bugbot on #2213 (`4fb898c5`, [discussion](https://github.com/kentcdodds/kody/pull/2213#discussion_r3973818963)): two first-time mint callers can both see no row and generate different UUIDs. The winner inserts. The loser's `upsertWebhookEndpointSecret` re-looks up, finds the other id, and threw `Unable to upsert webhook endpoint.` Mint only retried when `getUniqueConstraintField(error)` was set, so that interleaving never retried — even though a mint already succeeded. Encrypt AAD includes the endpoint id, so the retry must re-encrypt before writing.

## Summary

- `upsertWebhookEndpointSecret` throws typed `WebhookEndpointIdRaceError` with `existingId` when the looked-up row id differs from the caller-generated id.
- `mintWebhookUrlForUser` retries once on that error (same two-attempt loop as unique-constraint races) and re-encrypts with the winner id.
- Unique-constraint retry path is unchanged.
- Tests: forced id-mismatch retry (ciphertext decrypts under the winner AAD) and concurrent first mints converge on one handle.

## Testing

- `npx vitest run --project node-unit packages/worker/src/webhooks/service.node.test.ts` — 3 passed
- Pre-commit `typecheck` + `migrations:check`
- Pre-push `test:node` + `test:workers` (94 worker files / 342 tests)

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends Inbound webhooks</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `99564044` · **Head:** `c386dd7d`

**Classification:** extends — concurrent first `webhookUrlMint` now retries when the loser sees the winner's endpoint id, not only on a unique-constraint failure.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `webhooks` | assistant | extends — id-mismatch upsert throws `WebhookEndpointIdRaceError` and mint re-encrypts AAD with the persisted id |

### Change flow

Two first-time mint callers can generate different ids. The loser now adopts the winner and writes ciphertext bound to that id.

```mermaid
sequenceDiagram
	actor Agent
	participant webhooks as webhooks
	participant d1AppDb as d1-app-db
	Agent->>webhooks: webhookUrlMint first write from two callers
	webhooks->>d1AppDb: lookup empty key then insert generated id
	Note over webhooks: loser sees a different persisted id
	webhooks-->>webhooks: throw WebhookEndpointIdRaceError with existingId
	webhooks->>webhooks: re-encrypt url secret AAD with winner id
	webhooks->>d1AppDb: upsert hash and ciphertext on persisted id
	webhooks-->>Agent: return handle for the winner id
```

### Invariants

- `per-user-isolation` — endpoint lookup and decrypt AAD stay scoped to the calling `userId`. The retry adopts only the row already persisted for that user and webhook key.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1310e39e-0b84-4b58-81de-5c4cb02067e8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1310e39e-0b84-4b58-81de-5c4cb02067e8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved webhook URL creation when multiple requests target the same endpoint simultaneously.
  * Conflicting requests now retry and converge on the existing webhook endpoint instead of failing unexpectedly.
  * Ensured the correct endpoint identifier and stored secret are retained after a race condition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->