### PR TITLE
Stop MCP secretLock from granting user-secret package access

### DIFF
--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -1393,11 +1393,13 @@ on write unless a migration backfills existing rows.
   `forker_user_id`; index in `0001-squashed-init.sql`). Self-authored packages
   and adopted forks (`community_forks.adopted_at` / `adoption_note`) skip that
   grant for read/use only. Mutations from package code (`secretSet` /
-  `secretDelete`) always require the grant. Agents add a package to that grant
-  with `secretLock`; removing a grant is website-only. Official OAuth token
-  rotation persists host-side and does not use that write grant. Authorship and
-  adoption never imply a host allowlist. Package-scoped secrets are owned
-  exclusively by the package id in their bucket binding.
+  `secretDelete`) always require the grant. Only the account owner can add a
+  package to that grant (secret editor or `/account/secrets/approve`).
+  `secretLock` returns an approval URL and does not change `allowed_packages`.
+  Removing a grant is website-only. Official OAuth token rotation persists
+  host-side and does not use that write grant. Authorship and adoption never
+  imply a host allowlist. Package-scoped secrets are owned exclusively by the
+  package id in their bucket binding.
 - `user_oauth_apps.extra_authorize_params_json`,
   `user_integrations.scopes_json`, `user_integrations.required_hosts_json`, and
   `user_integrations.allowed_packages_json` (`0001-squashed-init.sql` /

--- a/docs/contributing/architecture/mcp-client-servers.md
+++ b/docs/contributing/architecture/mcp-client-servers.md
@@ -165,8 +165,9 @@ fetch `{canonical-app-origin}/oauth/client-metadata.json`; that document's
   `mcpServerReconnect`, `mcpServerRefresh`, `mcpServerRemove`,
   `mcpServerSetEnabled`, `mcpServerLock`). `mcpServerAdd` accepts optional
   `bearerToken`. `mcpServerLock` grants a package; unlock is website-only.
-  Integration connections and user secrets use the same tighten-only shape
-  (`integrationLock`, `secretLock`).
+  Integration connections use the same tighten-only shape (`integrationLock`).
+  User-secret package grants are website-only; `secretLock` returns an approval
+  URL and does not add `allowed_packages`.
 
 ## Isolation and lifecycle
 

--- a/docs/guides/account-secret-setup.md
+++ b/docs/guides/account-secret-setup.md
@@ -66,8 +66,9 @@ Self-authored packages and adopted community forks (`communityForkAdopt`) can
 read and use the user's secrets without an `allowed_packages` grant; updating or
 deleting a user secret from package code still requires that grant. Only the
 account owner can add a package to that grant on the secret editor or
-`/account/secrets/approve`. `secretLock` returns an approval URL; it does not
-apply the grant. Removing a grant is also website-only. When an **unadopted
+`/account/secrets/approve` — a focused Allow page like `/connect/secrets`.
+`secretLock` returns that approval URL; it does not apply the grant. Send the
+link and wait. Removing a grant is also website-only. When an **unadopted
 community-forked** package needs access to one or more **existing** user
 secrets, either adopt it after reviewing the source or send the user an approval
 link — do not ask them to recreate the secrets.

--- a/docs/guides/account-secret-setup.md
+++ b/docs/guides/account-secret-setup.md
@@ -64,11 +64,13 @@ so the user can paste immediately.
 
 Self-authored packages and adopted community forks (`communityForkAdopt`) can
 read and use the user's secrets without an `allowed_packages` grant; updating or
-deleting a user secret from package code still requires that grant. Agents can
-add a package to that grant with `secretLock`; removing a grant is website-only.
-When an **unadopted community-forked** package needs access to one or more
-**existing** user secrets, either adopt it after reviewing the source or send
-the user an approval link — do not ask them to recreate the secrets.
+deleting a user secret from package code still requires that grant. Only the
+account owner can add a package to that grant on the secret editor or
+`/account/secrets/approve`. `secretLock` returns an approval URL; it does not
+apply the grant. Removing a grant is also website-only. When an **unadopted
+community-forked** package needs access to one or more **existing** user
+secrets, either adopt it after reviewing the source or send the user an approval
+link — do not ask them to recreate the secrets.
 
 - Single secret:
   `/account/secrets/user/{secretName}?package_id={savedPackageId}&package={kodyId}`

--- a/docs/guides/locked-gmail-drafts.md
+++ b/docs/guides/locked-gmail-drafts.md
@@ -89,9 +89,10 @@ grant is website-only at `/account/integrations/:name`.
 
 A connected MCP server uses the same tighten-only shape: lock the **server** to
 a package so execute and other packages cannot call `kody.mcp["name"]`. See
-[Lock an MCP server to a package](./locked-mcp-server.md). User secrets use
-`secretLock` to add a package to `allowed_packages`; removing that grant is
-website-only at `/account/secrets/user/:name`.
+[Lock an MCP server to a package](./locked-mcp-server.md). User secrets require
+a website grant on `allowed_packages`. `secretLock` returns the approval URL and
+does not apply the grant. Removing a grant is website-only at
+`/account/secrets/user/:name`.
 
 Usage detail: [Packages → Publish lock](../use/packages.md#publish-lock).
 

--- a/docs/guides/secrets.md
+++ b/docs/guides/secrets.md
@@ -63,9 +63,11 @@ Saving a secret does not by itself let anything use it.
   after reviewing the source get read/use automatically. Unadopted forks need an
   explicit grant. Updating or deleting a user secret from package code always
   needs the grant. Only the account owner can add a package to that grant on
-  `/account/secrets/user/:name` or `/account/secrets/approve`. `secretLock`
-  returns an approval URL for the owner to click; it does not change
-  `allowed_packages`. Removing a grant is also website-only.
+  `/account/secrets/user/:name` or `/account/secrets/approve` — a focused Allow
+  page, the same spirit as host approval on `/connect/secrets`. `secretLock`
+  returns that approval URL for the owner to click; it does not change
+  `allowed_packages`. Send the link and wait. Removing a grant is also
+  website-only.
 
 Bulk approval URLs (`/account/secrets/approve?package_id=…&names=a,b`) let you
 approve several pending secrets for one package in a click.

--- a/docs/guides/secrets.md
+++ b/docs/guides/secrets.md
@@ -62,8 +62,10 @@ Saving a secret does not by itself let anything use it.
   user-scoped secret. Packages you authored and community forks you adopted
   after reviewing the source get read/use automatically. Unadopted forks need an
   explicit grant. Updating or deleting a user secret from package code always
-  needs the grant. Agents add a package with `secretLock`; removing a grant is
-  website-only on `/account/secrets/user/:name`.
+  needs the grant. Only the account owner can add a package to that grant on
+  `/account/secrets/user/:name` or `/account/secrets/approve`. `secretLock`
+  returns an approval URL for the owner to click; it does not change
+  `allowed_packages`. Removing a grant is also website-only.
 
 Bulk approval URLs (`/account/secrets/approve?package_id=…&names=a,b`) let you
 approve several pending secrets for one package in a click.

--- a/docs/use/secrets-and-values.md
+++ b/docs/use/secrets-and-values.md
@@ -138,12 +138,13 @@ packages the user authored themselves and adopted community forks
 packages need explicit **package** approval (`allowed_packages`) before those
 read/use paths. Updating or deleting a user secret from package code
 (`secretSet`, `secretDelete`) always needs the grant, including for
-self-authored and adopted packages. Agents can add a package to that grant with
-**`secretLock`**. Removing a grant is website-only on
-`/account/secrets/user/:name`. `secretSet` cannot change `allowed_packages`.
-Official OAuth token rotation (`createAuthenticatedFetch` 401 retry via
-`integrationTokenRefresh`) persists host-side and does not need that write
-grant.
+self-authored and adopted packages. Only the account owner can add a package to
+that grant on `/account/secrets/user/:name` or `/account/secrets/approve`.
+**`secretLock`** returns an approval URL for the owner to click; it does not
+change `allowed_packages`. Removing a grant is also website-only. `secretSet`
+cannot change `allowed_packages`. Official OAuth token rotation
+(`createAuthenticatedFetch` 401 retry via `integrationTokenRefresh`) persists
+host-side and does not need that write grant.
 
 **Host approval is separate and is never automatic**, including for
 self-authored and adopted packages. An empty host allowlist blocks

--- a/docs/use/secrets-and-values.md
+++ b/docs/use/secrets-and-values.md
@@ -140,11 +140,12 @@ read/use paths. Updating or deleting a user secret from package code
 (`secretSet`, `secretDelete`) always needs the grant, including for
 self-authored and adopted packages. Only the account owner can add a package to
 that grant on `/account/secrets/user/:name` or `/account/secrets/approve`.
-**`secretLock`** returns an approval URL for the owner to click; it does not
-change `allowed_packages`. Removing a grant is also website-only. `secretSet`
-cannot change `allowed_packages`. Official OAuth token rotation
-(`createAuthenticatedFetch` 401 retry via `integrationTokenRefresh`) persists
-host-side and does not need that write grant.
+**`secretLock`** returns an approval URL for the owner to click (one-click
+Allow, same spirit as `/connect/secrets`); it does not change
+`allowed_packages`. Send the link and wait. Removing a grant is also
+website-only. `secretSet` cannot change `allowed_packages`. Official OAuth token
+rotation (`createAuthenticatedFetch` 401 retry via `integrationTokenRefresh`)
+persists host-side and does not need that write grant.
 
 **Host approval is separate and is never automatic**, including for
 self-authored and adopted packages. An empty host allowlist blocks

--- a/packages/worker/client/routes/account-approval-shared.ts
+++ b/packages/worker/client/routes/account-approval-shared.ts
@@ -38,6 +38,11 @@ export function allowHostsButtonLabel(
 	return `Allow all ${validCount} hosts`
 }
 
+export function allowPackagesButtonLabel(secretCount: number) {
+	if (secretCount <= 1) return 'Allow access'
+	return `Allow all ${secretCount} secrets`
+}
+
 export const accountSecretsApiPath = '/account/secrets.json'
 export const accountProfileApiPath = '/account/profile.json'
 

--- a/packages/worker/client/routes/account-secrets-approval.node.test.ts
+++ b/packages/worker/client/routes/account-secrets-approval.node.test.ts
@@ -1,0 +1,101 @@
+import { expect, test } from 'vitest'
+import {
+	isPackageApprovalHref,
+	isPackageSecretApprovalAlreadyGranted,
+	readPackageSecretApprovalView,
+} from './account-secrets-approval.tsx'
+
+const secret = {
+	id: 'user:openai-api-key',
+	name: 'openai-api-key',
+	scope: 'user' as const,
+	description: '',
+	packageId: null,
+	packageTitle: null,
+	allowedHosts: [],
+	allowedPackages: ['pkg-notes'],
+	createdAt: '2026-01-01T00:00:00.000Z',
+	updatedAt: '2026-01-01T00:00:00.000Z',
+	expiresAt: null,
+	ttlMs: null,
+}
+
+const approval = {
+	name: 'openai-api-key',
+	names: ['openai-api-key'],
+	scope: 'user' as const,
+	requestedHost: '',
+	requestedHosts: [],
+	rejectedHosts: [],
+	requestedPackageId: 'pkg-notes',
+	currentAllowedHosts: [],
+	currentAllowedPackages: [],
+}
+
+test('package secret approval hrefs and already-granted checks match host-approval spirit', () => {
+	expect(isPackageApprovalHref('/account/secrets/approve')).toBe(true)
+	expect(
+		isPackageApprovalHref(
+			'/account/secrets/approve?package_id=pkg-notes&names=openai-api-key',
+		),
+	).toBe(true)
+	expect(
+		isPackageApprovalHref(
+			'/account/secrets/user/openai-api-key?package_id=pkg-notes&package=notes',
+		),
+	).toBe(true)
+	expect(isPackageApprovalHref('/account/secrets/user/openai-api-key')).toBe(
+		false,
+	)
+	expect(isPackageApprovalHref('/account/secrets')).toBe(false)
+
+	expect(
+		isPackageSecretApprovalAlreadyGranted({
+			secrets: [{ ...secret, allowedPackages: [] }],
+			approval,
+		}),
+	).toBe(false)
+	expect(
+		isPackageSecretApprovalAlreadyGranted({
+			secrets: [secret],
+			approval,
+		}),
+	).toBe(true)
+	expect(
+		isPackageSecretApprovalAlreadyGranted({
+			secrets: [],
+			approval,
+		}),
+	).toBe(false)
+	expect(
+		isPackageSecretApprovalAlreadyGranted({
+			secrets: [secret],
+			approval: { ...approval, names: ['openai-api-key', 'missing'] },
+		}),
+	).toBe(false)
+
+	expect(
+		readPackageSecretApprovalView({
+			completed: null,
+			alreadyGranted: false,
+		}),
+	).toEqual({ fullyAllowed: false, showBackToSecrets: false })
+	expect(
+		readPackageSecretApprovalView({
+			completed: 'approve',
+			alreadyGranted: false,
+		}),
+	).toEqual({ fullyAllowed: true, showBackToSecrets: true })
+	expect(
+		readPackageSecretApprovalView({
+			completed: null,
+			alreadyGranted: true,
+		}),
+	).toEqual({ fullyAllowed: true, showBackToSecrets: true })
+	expect(
+		readPackageSecretApprovalView({
+			completed: 'reject',
+			alreadyGranted: false,
+		}),
+	).toEqual({ fullyAllowed: false, showBackToSecrets: true })
+})

--- a/packages/worker/client/routes/account-secrets-approval.node.test.ts
+++ b/packages/worker/client/routes/account-secrets-approval.node.test.ts
@@ -48,6 +48,19 @@ test('package secret approval hrefs and already-granted checks match host-approv
 		false,
 	)
 	expect(isPackageApprovalHref('/account/secrets')).toBe(false)
+	expect(
+		isPackageApprovalHref(
+			'/account/secrets/new?package_id=pkg-notes&package=notes&name=openai-api-key',
+		),
+	).toBe(false)
+	expect(isPackageApprovalHref('/account/secrets?package_id=pkg-notes')).toBe(
+		false,
+	)
+	expect(
+		isPackageApprovalHref(
+			'/account/secrets/package/pkg-notes/signingSecret?package_id=pkg-notes',
+		),
+	).toBe(false)
 
 	expect(
 		isPackageSecretApprovalAlreadyGranted({

--- a/packages/worker/client/routes/account-secrets-approval.tsx
+++ b/packages/worker/client/routes/account-secrets-approval.tsx
@@ -1,4 +1,5 @@
 import { type AccountSecretsLoaderData } from '#universal/loader-data.ts'
+import { parseAccountSecretPath } from '@kody-internal/shared/account-secret-route.ts'
 import { css } from 'remix/ui'
 import { on } from '#client/event-mixin.ts'
 import {
@@ -342,7 +343,8 @@ const packageApprovalSecondaryButtonCss = getSecondaryButtonCss({
 export function isPackageApprovalHref(href: string) {
 	const url = new URL(href, 'http://localhost')
 	if (url.pathname === routes.accountSecretsApprove.href()) return true
-	return Boolean(url.searchParams.get('package_id')?.trim())
+	if (!url.searchParams.get('package_id')?.trim()) return false
+	return parseAccountSecretPath(url.pathname)?.scope === 'user'
 }
 
 export function isPackageSecretApprovalAlreadyGranted(input: {

--- a/packages/worker/client/routes/account-secrets-approval.tsx
+++ b/packages/worker/client/routes/account-secrets-approval.tsx
@@ -1,13 +1,16 @@
+import { type AccountSecretsLoaderData } from '#universal/loader-data.ts'
 import { css } from 'remix/ui'
 import { on } from '#client/event-mixin.ts'
 import {
 	type ApprovalAction,
 	type ApprovalView,
 	allowHostsButtonLabel,
+	allowPackagesButtonLabel,
 	approvalRejectedHosts,
 	approvalRequestedHosts,
 	getScopeLabel,
 } from '#client/routes/account-approval-shared.ts'
+import { routes } from '#universal/routes.ts'
 import {
 	colors,
 	radius,
@@ -15,9 +18,17 @@ import {
 	typography,
 } from '#universal/styles/tokens.ts'
 import {
+	cardCss,
 	getAccentCalloutCss,
 	getGhostButtonCss,
 	getPillButtonCss,
+	getPrimaryButtonCss,
+	getSecondaryButtonCss,
+	pageDescriptionCss,
+	pageEyebrowCss,
+	pageHeaderCss,
+	pageTitleCss,
+	stackedPageCss,
 } from '#universal/styles/style-primitives.ts'
 import { accountDisclosureCss } from './account-management-components.tsx'
 
@@ -53,9 +64,9 @@ export function renderSecretApprovalCard(props: {
 						color: colors.text,
 					})}
 				>
-					{approvalCard.requestedHost && !approvalCard.requestedPackageId
-						? 'Allow access'
-						: 'Approve secret access'}
+					{approvalCard.requestedPackageId
+						? 'Allow package access'
+						: 'Allow access'}
 				</h2>
 				{approvalCard.requestedPackageId ? (
 					<div mix={css({ display: 'grid', gap: spacing.xs })}>
@@ -218,11 +229,9 @@ export function renderSecretApprovalCard(props: {
 							css(secretApprovalPrimaryButtonCss),
 						]}
 					>
-						{approvalCard.requestedPackageId && approvalCard.names.length > 1
-							? `Approve all (${approvalCard.names.length})`
-							: approvalCard.requestedPackageId
-								? 'Approve'
-								: allowHostsButtonLabel(hosts.length, rejectedHosts.length)}
+						{approvalCard.requestedPackageId
+							? allowPackagesButtonLabel(approvalCard.names.length)
+							: allowHostsButtonLabel(hosts.length, rejectedHosts.length)}
 					</button>
 				) : null}
 				<button
@@ -306,4 +315,216 @@ const secretApprovalAdvancedCss = {
 	...accountDisclosureCss,
 	color: colors.textMuted,
 	fontSize: typography.fontSize.sm,
+}
+
+const packageApprovalPageCss = {
+	...stackedPageCss,
+	maxWidth: '32rem',
+	margin: '0 auto',
+}
+
+const packageApprovalHeaderCss = {
+	...pageHeaderCss,
+	justifyItems: 'center',
+	textAlign: 'center' as const,
+}
+
+const packageApprovalPrimaryButtonCss = getPrimaryButtonCss({
+	size: 'lg',
+	weight: 'semibold',
+})
+
+const packageApprovalSecondaryButtonCss = getSecondaryButtonCss({
+	size: 'lg',
+	weight: 'semibold',
+})
+
+export function isPackageApprovalHref(href: string) {
+	const url = new URL(href, 'http://localhost')
+	if (url.pathname === routes.accountSecretsApprove.href()) return true
+	return Boolean(url.searchParams.get('package_id')?.trim())
+}
+
+export function isPackageSecretApprovalAlreadyGranted(input: {
+	secrets: AccountSecretsLoaderData['secrets']
+	approval: ApprovalView
+}) {
+	const packageId = input.approval.requestedPackageId?.trim()
+	if (!packageId || input.approval.names.length === 0) return false
+	return input.approval.names.every((name) =>
+		input.secrets.some(
+			(item) =>
+				item.name === name &&
+				item.scope === input.approval.scope &&
+				item.allowedPackages.includes(packageId),
+		),
+	)
+}
+
+export function readPackageSecretApprovalView(input: {
+	completed: ApprovalAction | null
+	alreadyGranted: boolean
+}) {
+	const fullyAllowed = input.completed === 'approve' || input.alreadyGranted
+	return {
+		fullyAllowed,
+		showBackToSecrets: fullyAllowed || input.completed === 'reject',
+	}
+}
+
+export function renderPackageSecretApprovalPage(props: {
+	approval: ApprovalView | null
+	approvalError: string | null
+	packagesById: ReadonlyMap<string, { kodyId: string; name: string }>
+	completed: ApprovalAction | null
+	alreadyGranted: boolean
+	submittingAction: ApprovalAction | null
+	message: string | null
+	onSubmit: (action: ApprovalAction) => void
+}) {
+	const {
+		approval,
+		approvalError,
+		packagesById,
+		completed,
+		alreadyGranted,
+		submittingAction,
+		message,
+		onSubmit,
+	} = props
+	const view = readPackageSecretApprovalView({
+		completed,
+		alreadyGranted,
+	})
+	const names = approval?.names.length
+		? approval.names
+		: approval?.name
+			? [approval.name]
+			: []
+	const packageId = approval?.requestedPackageId ?? null
+	const packageLabel = packageId
+		? (packagesById.get(packageId)?.kodyId ?? packageId)
+		: null
+
+	return (
+		<section
+			mix={css(packageApprovalPageCss)}
+			data-testid="account-secrets-package-approval"
+		>
+			<header mix={css(packageApprovalHeaderCss)}>
+				<span mix={css(pageEyebrowCss)}>Allow secret packages</span>
+				<h1 mix={css(pageTitleCss)}>
+					{view.fullyAllowed
+						? 'Access allowed'
+						: completed === 'reject'
+							? 'Request rejected'
+							: 'Allow this package to use these secrets'}
+				</h1>
+				<p mix={css(pageDescriptionCss)}>
+					{view.fullyAllowed
+						? 'This package can use the saved secrets below.'
+						: completed === 'reject'
+							? 'No package grant was added. You can allow later from this same link.'
+							: approval
+								? 'Kody only grants a user secret to a package you allow. Agents cannot do this for you.'
+								: 'Open an approval link from Kody to allow a saved package to use a secret.'}
+				</p>
+			</header>
+
+			{approvalError ? (
+				<section
+					mix={css({
+						...cardCss,
+						border: `1px solid ${colors.danger}`,
+					})}
+					data-testid="account-secrets-package-approval-error"
+				>
+					<p mix={css({ margin: 0, color: colors.danger })}>{approvalError}</p>
+				</section>
+			) : null}
+
+			{message ? (
+				<p mix={css({ margin: 0, color: colors.danger })}>{message}</p>
+			) : null}
+
+			{approval && packageId ? (
+				<section
+					mix={css(cardCss)}
+					data-testid="account-secrets-package-approval-card"
+				>
+					<div mix={css({ display: 'grid', gap: spacing.sm })}>
+						<div mix={css({ display: 'grid', gap: spacing.xs })}>
+							<span mix={css({ color: colors.textMuted })}>
+								{names.length === 1 ? 'Secret' : 'Secrets'}
+							</span>
+							<ul
+								mix={css({
+									margin: 0,
+									paddingLeft: spacing.lg,
+									display: 'grid',
+									gap: spacing.xs,
+								})}
+							>
+								{names.map((name) => (
+									<li key={name}>
+										<code>{name}</code>
+									</li>
+								))}
+							</ul>
+						</div>
+						<div mix={css({ display: 'grid', gap: spacing.xs })}>
+							<span mix={css({ color: colors.textMuted })}>Package</span>
+							<strong mix={css({ color: colors.text })}>{packageLabel}</strong>
+						</div>
+					</div>
+					{view.showBackToSecrets ? (
+						<a
+							href={routes.accountSecrets.href()}
+							mix={css(packageApprovalSecondaryButtonCss)}
+						>
+							Back to secrets
+						</a>
+					) : (
+						<div
+							mix={css({
+								display: 'flex',
+								gap: spacing.sm,
+								flexWrap: 'wrap',
+							})}
+						>
+							{completed !== 'approve' ? (
+								<button
+									type="button"
+									disabled={submittingAction != null}
+									mix={[
+										on('click', () => {
+											onSubmit('approve')
+										}),
+										css(packageApprovalPrimaryButtonCss),
+									]}
+									data-testid="allow-secret-package"
+								>
+									{submittingAction === 'approve'
+										? 'Allowing access…'
+										: allowPackagesButtonLabel(names.length)}
+								</button>
+							) : null}
+							<button
+								type="button"
+								disabled={submittingAction != null}
+								mix={[
+									on('click', () => {
+										onSubmit('reject')
+									}),
+									css(packageApprovalSecondaryButtonCss),
+								]}
+							>
+								Reject
+							</button>
+						</div>
+					)}
+				</section>
+			) : null}
+		</section>
+	)
 }

--- a/packages/worker/client/routes/account-secrets.tsx
+++ b/packages/worker/client/routes/account-secrets.tsx
@@ -528,6 +528,8 @@ export function AccountSecretsRoute(handle: Handle) {
 
 		if (isPackageApprovalHref(currentHref)) {
 			const approvalError = appliedPayload?.approvalError ?? null
+			const pageApprovalError =
+				approvalError ?? (status === 'error' ? message : null)
 			const alreadyGranted =
 				approval != null &&
 				completedPackageApproval !== 'reject' &&
@@ -537,12 +539,12 @@ export function AccountSecretsRoute(handle: Handle) {
 				})
 			return renderPackageSecretApprovalPage({
 				approval,
-				approvalError: approvalError ?? (status === 'error' ? message : null),
+				approvalError: pageApprovalError,
 				packagesById,
 				completed: completedPackageApproval,
 				alreadyGranted,
 				submittingAction: submittingApprovalAction,
-				message: message && message !== approvalError ? message : null,
+				message: message && message !== pageApprovalError ? message : null,
 				onSubmit: (action) => {
 					void submitApproval(action)
 				},

--- a/packages/worker/client/routes/account-secrets.tsx
+++ b/packages/worker/client/routes/account-secrets.tsx
@@ -38,7 +38,10 @@ import {
 	recordStampCss,
 } from './record-table.tsx'
 import {
+	isPackageApprovalHref,
+	isPackageSecretApprovalAlreadyGranted,
 	renderAlreadyAddedNotice,
+	renderPackageSecretApprovalPage,
 	renderSecretApprovalCard,
 } from './account-secrets-approval.tsx'
 import { renderSecretEditor } from './account-secrets-editor.tsx'
@@ -76,6 +79,8 @@ export function AccountSecretsRoute(handle: Handle) {
 	let editorState = createEmptyEditorState([])
 	let message: string | null = null
 	let submittingApprovalAction: ApprovalAction | null = null
+	let completedPackageApproval: ApprovalAction | null = null
+	let packageApprovalHref: string | null = null
 	let saveState: 'idle' | 'saving' | 'deleting' = 'idle'
 	let retryTimeout: ReturnType<typeof setTimeout> | null = null
 	let showSecretValue = false
@@ -232,23 +237,21 @@ export function AccountSecretsRoute(handle: Handle) {
 			>(action, `${requestUrl.pathname}${requestUrl.search}`)
 			if (!payload) return
 
-			const isBulkPackageApproval =
-				Boolean(approval.requestedPackageId) && approval.names.length > 1
+			const isPackageApproval = Boolean(approval.requestedPackageId)
 			applyPayload(
 				payload,
 				selection,
-				action === 'approve'
-					? approval.requestedPackageId
-						? isBulkPackageApproval
-							? `Approved package access for ${approval.names.length} secrets.`
-							: 'Approved requested package.'
-						: 'Approved requested host.'
-					: approval.requestedPackageId
-						? isBulkPackageApproval
-							? 'Rejected bulk package approval request.'
-							: 'Rejected package approval request.'
+				isPackageApproval
+					? null
+					: action === 'approve'
+						? 'Approved requested host.'
 						: 'Rejected host approval request.',
 			)
+			if (isPackageApproval) {
+				completedPackageApproval = action
+				handle.update()
+				return
+			}
 			handle.update()
 
 			if (typeof window !== 'undefined' && window.location.search) {
@@ -518,6 +521,34 @@ export function AccountSecretsRoute(handle: Handle) {
 		const canCreatePackageSecrets = packageOptions.length > 0
 		const showEditor = selection.isCreating || selectedSecret != null
 		const secretValueAutofocusKey = getNewSecretValueAutofocusKey(currentHref)
+		if (packageApprovalHref !== currentHref) {
+			packageApprovalHref = currentHref
+			completedPackageApproval = null
+		}
+
+		if (isPackageApprovalHref(currentHref)) {
+			const approvalError = appliedPayload?.approvalError ?? null
+			const alreadyGranted =
+				approval != null &&
+				completedPackageApproval !== 'reject' &&
+				isPackageSecretApprovalAlreadyGranted({
+					secrets,
+					approval,
+				})
+			return renderPackageSecretApprovalPage({
+				approval,
+				approvalError: approvalError ?? (status === 'error' ? message : null),
+				packagesById,
+				completed: completedPackageApproval,
+				alreadyGranted,
+				submittingAction: submittingApprovalAction,
+				message: message && message !== approvalError ? message : null,
+				onSubmit: (action) => {
+					void submitApproval(action)
+				},
+			})
+		}
+
 		const alreadyAddedNotice = getAlreadyAddedNotice({
 			href: currentHref,
 			selectedSecret,

--- a/packages/worker/src/mcp/capabilities/secrets/secret-lock.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/secrets/secret-lock.node.test.ts
@@ -1,63 +1,161 @@
-import { expect, test, vi } from 'vitest'
+import { DatabaseSync } from 'node:sqlite'
+import { expect, test } from 'vitest'
 import { McpCallerError } from '#mcp/caller-error.ts'
 import { createMcpCallerContext } from '#mcp/context.ts'
+import {
+	listSecrets,
+	lockSecretToPackage,
+	saveSecret,
+} from '#mcp/secrets/service.ts'
+import { applyAllMigrations as applyRepositoryMigrations } from '#worker/test-support/apply-all-migrations.ts'
+import { createD1FromSqlite } from '#worker/test-support/create-d1-from-sqlite.ts'
+import { createInMemoryUserMeterEnv } from '#worker/test-support/user-meter.ts'
+import { secretLockCapability } from './secret-lock.ts'
 
-const mockModule = vi.hoisted(() => ({
-	lockSecretToPackage: vi.fn(),
-}))
+const migrationsDirectory = new URL('../../../../migrations/', import.meta.url)
 
-vi.mock('#mcp/secrets/service.ts', () => ({
-	lockSecretToPackage: (...args: Array<unknown>) =>
-		mockModule.lockSecretToPackage(...args),
-}))
+function createHarness() {
+	const sqlite = new DatabaseSync(':memory:')
+	applyRepositoryMigrations(sqlite, migrationsDirectory)
+	const env = {
+		APP_DB: createD1FromSqlite(sqlite),
+		SECRET_STORE_KEY: 'test-secret-store-key-32-chars-minimum',
+		...createInMemoryUserMeterEnv().env,
+	} as Env
+	return { sqlite, env }
+}
 
-const { secretLockCapability } = await import('./secret-lock.ts')
+function seedPackage(
+	sqlite: DatabaseSync,
+	input: { id: string; userId: string; kodyId: string },
+) {
+	sqlite
+		.prepare(
+			`INSERT INTO saved_packages (
+				id, user_id, name, kody_id, description, source_id
+			) VALUES (?, ?, ?, ?, ?, ?)`,
+		)
+		.run(
+			input.id,
+			input.userId,
+			input.kodyId,
+			input.kodyId,
+			'',
+			`source-${input.id}`,
+		)
+}
 
-test('secretLock grants a package and rejects missing packages', async () => {
-	mockModule.lockSecretToPackage.mockResolvedValue({
+async function allowedPackagesFor(
+	env: Env,
+	userId: string,
+	name: string,
+): Promise<Array<string>> {
+	const secrets = await listSecrets({ env, userId, scope: 'user' })
+	return secrets.find((secret) => secret.name === name)?.allowedPackages ?? []
+}
+
+test('secretLock returns an approval URL without widening allowed_packages', async () => {
+	const { sqlite, env } = createHarness()
+	const userId = 'user-secret-lock'
+	seedPackage(sqlite, { id: 'pkg-notes', userId, kodyId: 'notes' })
+	seedPackage(sqlite, { id: 'pkg-mail', userId, kodyId: 'mail' })
+	await saveSecret({
+		env,
+		userId,
+		scope: 'user',
 		name: 'openai-api-key',
-		allowedPackages: ['pkg-drafts'],
+		value: 'sk-test',
 	})
 
 	const ctx = {
-		env: {} as Env,
+		env,
 		callerContext: createMcpCallerContext({
 			baseUrl: 'https://kody.codes',
 			user: {
-				userId: 'user-1',
+				userId,
 				email: 'alice@example.com',
 				displayName: 'Alice',
 			},
 		}),
 	}
 
-	await expect(
-		secretLockCapability.handler(
-			{ name: 'openai-api-key', package_id: 'pkg-drafts' },
-			ctx,
-		),
-	).resolves.toEqual({
+	const approvalUrl =
+		'https://kody.codes/account/secrets/user/openai-api-key?package_id=pkg-notes&package=notes'
+	const pending = await secretLockCapability.handler(
+		{ name: 'openai-api-key', package_id: 'pkg-notes' },
+		ctx,
+	)
+	expect(pending).toEqual({
 		name: 'openai-api-key',
 		scope: 'user',
-		allowed_packages: ['pkg-drafts'],
+		allowed_packages: [],
 		usage_url: 'https://kody.codes/account/secrets/user/openai-api-key',
+		status: 'approval_required',
+		approval_url: approvalUrl,
+		message:
+			"Agents cannot add packages to a user secret's allowed_packages. Only the account owner can grant access on the website. Send the user this approval link and wait: https://kody.codes/account/secrets/user/openai-api-key?package_id=pkg-notes&package=notes",
 	})
-	expect(mockModule.lockSecretToPackage).toHaveBeenCalledWith({
-		env: ctx.env,
-		userId: 'user-1',
-		name: 'openai-api-key',
-		packageId: 'pkg-drafts',
-	})
+	expect(await allowedPackagesFor(env, userId, 'openai-api-key')).toEqual([])
 
-	mockModule.lockSecretToPackage.mockRejectedValueOnce(
-		new Error('Saved package not found for this user.'),
+	const websiteGrant = await lockSecretToPackage({
+		env,
+		userId,
+		name: 'openai-api-key',
+		packageId: 'pkg-notes',
+	})
+	expect(websiteGrant.allowedPackages).toEqual(['pkg-notes'])
+
+	const alreadyGranted = await secretLockCapability.handler(
+		{ name: 'openai-api-key', package_id: 'pkg-notes' },
+		ctx,
 	)
-	const missing = await secretLockCapability
+	expect(alreadyGranted).toEqual({
+		name: 'openai-api-key',
+		scope: 'user',
+		allowed_packages: ['pkg-notes'],
+		usage_url: 'https://kody.codes/account/secrets/user/openai-api-key',
+		status: 'already_granted',
+		approval_url: approvalUrl,
+		message:
+			'Package "notes" already has an allowed_packages grant on this secret.',
+	})
+	expect(await allowedPackagesFor(env, userId, 'openai-api-key')).toEqual([
+		'pkg-notes',
+	])
+
+	const additional = await secretLockCapability.handler(
+		{ name: 'openai-api-key', package_id: 'pkg-mail' },
+		ctx,
+	)
+	expect(additional.status).toBe('approval_required')
+	expect(additional.allowed_packages).toEqual(['pkg-notes'])
+	expect(additional.approval_url).toBe(
+		'https://kody.codes/account/secrets/user/openai-api-key?package_id=pkg-mail&package=mail',
+	)
+	expect(await allowedPackagesFor(env, userId, 'openai-api-key')).toEqual([
+		'pkg-notes',
+	])
+
+	const missingPackage = await secretLockCapability
 		.handler({ name: 'openai-api-key', package_id: 'missing' }, ctx)
 		.then(
 			() => null,
 			(error: unknown) => error,
 		)
-	expect(missing).toBeInstanceOf(McpCallerError)
-	expect((missing as Error).message).toContain('Saved package not found')
+	expect(missingPackage).toBeInstanceOf(McpCallerError)
+	expect((missingPackage as Error).message).toContain('Saved package not found')
+
+	const missingSecret = await secretLockCapability
+		.handler({ name: 'missing-secret', package_id: 'pkg-notes' }, ctx)
+		.then(
+			() => null,
+			(error: unknown) => error,
+		)
+	expect(missingSecret).toBeInstanceOf(McpCallerError)
+	expect((missingSecret as Error).message).toContain(
+		'Secret not found for this scope.',
+	)
+	expect(await allowedPackagesFor(env, userId, 'openai-api-key')).toEqual([
+		'pkg-notes',
+	])
 })

--- a/packages/worker/src/mcp/capabilities/secrets/secret-lock.ts
+++ b/packages/worker/src/mcp/capabilities/secrets/secret-lock.ts
@@ -29,7 +29,7 @@ export const secretLockCapability = defineDomainCapability(
 	{
 		name: 'secretLock',
 		description:
-			'Return a website approval URL so the account owner can grant a user-scoped secret to a saved package. This capability does not change allowed_packages. Only the owner can add a grant at /account/secrets/user/:name or /account/secrets/approve. Removing a grant is also website-only. Send the approval_url to the user and wait; do not treat this call as a grant. User secrets still allow execute and self-authored / adopted packages to read unless the owner tightens further on the account page. secretSet cannot change allowed_packages.',
+			'Return a website approval URL so the account owner can grant a user-scoped secret to a saved package (one-click Allow, same spirit as /connect/secrets host approval). This capability does not change allowed_packages. Send the approval_url to the user and wait; never treat this call as a grant. Only the owner can add a grant at /account/secrets/approve or the secret editor. Removing a grant is also website-only. User secrets still allow execute and self-authored / adopted packages to read unless the owner tightens further on the account page. secretSet cannot change allowed_packages.',
 		keywords: [
 			'secret',
 			'lock',

--- a/packages/worker/src/mcp/capabilities/secrets/secret-lock.ts
+++ b/packages/worker/src/mcp/capabilities/secrets/secret-lock.ts
@@ -4,14 +4,24 @@ import { defineDomainCapability } from '#mcp/capabilities/define-domain-capabili
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
 import { type CapabilityContext } from '#mcp/capabilities/types.ts'
-import { buildSecretUsageUrl } from '#mcp/secrets/package-approval-url.ts'
-import { lockSecretToPackage } from '#mcp/secrets/service.ts'
+import {
+	createSecretPackageGrantAlreadyPresentMessage,
+	createSecretPackageGrantRequiresWebsiteMessage,
+} from '#mcp/secrets/errors.ts'
+import {
+	buildSecretPackageApprovalUrl,
+	buildSecretUsageUrl,
+} from '#mcp/secrets/package-approval-url.ts'
+import { inspectUserSecretPackageGrant } from '#mcp/secrets/service.ts'
 
 const outputSchema = z.object({
 	name: z.string(),
 	scope: z.literal('user'),
 	allowed_packages: z.array(z.string()),
 	usage_url: z.string(),
+	status: z.enum(['approval_required', 'already_granted']),
+	approval_url: z.string(),
+	message: z.string(),
 })
 
 export const secretLockCapability = defineDomainCapability(
@@ -19,7 +29,7 @@ export const secretLockCapability = defineDomainCapability(
 	{
 		name: 'secretLock',
 		description:
-			'Grant a user-scoped secret to a saved package by adding that package id to allowed_packages. Additional grants accumulate. Agents can grant; removing a grant is website-only at /account/secrets/user/:name. This capability cannot remove packages. User secrets still allow execute and self-authored / adopted packages to read unless the owner tightens further on the account page. secretSet cannot change allowed_packages.',
+			'Return a website approval URL so the account owner can grant a user-scoped secret to a saved package. This capability does not change allowed_packages. Only the owner can add a grant at /account/secrets/user/:name or /account/secrets/approve. Removing a grant is also website-only. Send the approval_url to the user and wait; do not treat this call as a grant. User secrets still allow execute and self-authored / adopted packages to read unless the owner tightens further on the account page. secretSet cannot change allowed_packages.',
 		keywords: [
 			'secret',
 			'lock',
@@ -28,8 +38,9 @@ export const secretLockCapability = defineDomainCapability(
 			'restrict',
 			'grant',
 			'allowed_packages',
+			'approval',
 		],
-		readOnly: false,
+		readOnly: true,
 		idempotent: true,
 		destructive: false,
 		inputSchema: z.object({
@@ -46,26 +57,54 @@ export const secretLockCapability = defineDomainCapability(
 		) {
 			const user = requireMcpUser(ctx.callerContext)
 			try {
-				const updated = await lockSecretToPackage({
+				const state = await inspectUserSecretPackageGrant({
 					env: ctx.env,
 					userId: user.userId,
 					name: args.name,
 					packageId: args.package_id,
 				})
+				const approvalUrl = buildSecretPackageApprovalUrl({
+					baseUrl: ctx.callerContext.baseUrl,
+					name: state.secret.name,
+					scope: 'user',
+					packageId: state.savedPackage.id,
+					kodyId: state.savedPackage.kodyId,
+					storageContext: null,
+				})
+				const usageUrl = buildSecretUsageUrl({
+					baseUrl: ctx.callerContext.baseUrl,
+					name: state.secret.name,
+				})
+				if (state.alreadyGranted) {
+					return {
+						name: state.secret.name,
+						scope: 'user' as const,
+						allowed_packages: state.secret.allowedPackages,
+						usage_url: usageUrl,
+						status: 'already_granted' as const,
+						approval_url: approvalUrl,
+						message: createSecretPackageGrantAlreadyPresentMessage({
+							packageName: state.savedPackage.kodyId,
+						}),
+					}
+				}
 				return {
-					name: updated.name,
+					name: state.secret.name,
 					scope: 'user' as const,
-					allowed_packages: updated.allowedPackages,
-					usage_url: buildSecretUsageUrl({
-						baseUrl: ctx.callerContext.baseUrl,
-						name: updated.name,
+					allowed_packages: state.secret.allowedPackages,
+					usage_url: usageUrl,
+					status: 'approval_required' as const,
+					approval_url: approvalUrl,
+					message: createSecretPackageGrantRequiresWebsiteMessage({
+						approvalUrl,
 					}),
 				}
 			} catch (error) {
+				if (error instanceof McpCallerError) throw error
 				throw new McpCallerError(
 					error instanceof Error
 						? error.message
-						: 'Unable to lock this secret to a package.',
+						: 'Unable to inspect this secret package grant.',
 					{ cause: error },
 				)
 			}

--- a/packages/worker/src/mcp/secrets/errors.ts
+++ b/packages/worker/src/mcp/secrets/errors.ts
@@ -106,6 +106,18 @@ export function createPackageSecretAccessDeniedMessage(input: {
 	return `Secret "${input.secretName}" is not allowed for package "${input.packageName}". If this package should be able to use the secret, ask the user whether to approve that package in the account secrets UI, then retry after they approve that policy change.${approvalSuffix}`
 }
 
+export function createSecretPackageGrantRequiresWebsiteMessage(input: {
+	approvalUrl: string
+}) {
+	return `Agents cannot add packages to a user secret's allowed_packages. Only the account owner can grant access on the website. Send the user this approval link and wait: ${input.approvalUrl}`
+}
+
+export function createSecretPackageGrantAlreadyPresentMessage(input: {
+	packageName: string
+}) {
+	return `Package "${input.packageName}" already has an allowed_packages grant on this secret.`
+}
+
 export function createPackageSecretAccessDeniedBatchMessage(
 	entries: Array<PackageApprovalEntry>,
 	options: { bulkApprovalUrl?: string | null } = {},

--- a/packages/worker/src/mcp/secrets/service.ts
+++ b/packages/worker/src/mcp/secrets/service.ts
@@ -1066,17 +1066,26 @@ export async function setSecretAllowedPackages(input: {
 	})
 }
 
+type UserSecretPackageGrantState = {
+	secret: SecretMetadata
+	savedPackage: {
+		id: string
+		kodyId: string
+	}
+	alreadyGranted: boolean
+}
+
 /**
- * Tighten-only package grant on a user secret. Adds `packageId` to
- * `allowed_packages`. Additional grants accumulate. Removing a grant is
- * website-only. User-scope only — package secrets do not have this grant.
+ * Read-only lookup for a user secret + saved package grant. Does not mutate
+ * `allowed_packages`. MCP `secretLock` uses this; applying a grant is
+ * website-only via `lockSecretToPackage` / `setSecretAllowedPackages`.
  */
-export async function lockSecretToPackage(input: {
+export async function inspectUserSecretPackageGrant(input: {
 	env: Pick<Env, 'APP_DB'>
 	userId: string
 	name: string
 	packageId: string
-}): Promise<SecretMetadata> {
+}): Promise<UserSecretPackageGrantState> {
 	const packageId = input.packageId.trim()
 	if (!packageId) {
 		throw new Error('Package id is required.')
@@ -1106,8 +1115,8 @@ export async function lockSecretToPackage(input: {
 		throw new Error('Secret not found for this scope.')
 	}
 	const currentPackages = parseAllowedPackages(existingEntry.allowed_packages)
-	if (currentPackages.includes(packageId)) {
-		return toSecretMetadata({
+	return {
+		secret: toSecretMetadata({
 			name: input.name.trim(),
 			scope: 'user',
 			description: existingEntry.description,
@@ -1120,14 +1129,38 @@ export async function lockSecretToPackage(input: {
 				existingEntry.expires_at,
 				bucket.expires_at,
 			),
-		})
+		}),
+		savedPackage: {
+			id: savedPackage.id,
+			kodyId: savedPackage.kodyId,
+		},
+		alreadyGranted: currentPackages.includes(packageId),
+	}
+}
+
+/**
+ * Tighten-only package grant on a user secret. Adds `packageId` to
+ * `allowed_packages`. Additional grants accumulate. Removing a grant is
+ * website-only. User-scope only — package secrets do not have this grant.
+ * Account secret editor and `/account/secrets/approve` apply grants through
+ * `setSecretAllowedPackages` (or this helper). MCP `secretLock` must not.
+ */
+export async function lockSecretToPackage(input: {
+	env: Pick<Env, 'APP_DB'>
+	userId: string
+	name: string
+	packageId: string
+}): Promise<SecretMetadata> {
+	const state = await inspectUserSecretPackageGrant(input)
+	if (state.alreadyGranted) {
+		return state.secret
 	}
 	return setSecretAllowedPackages({
 		env: input.env,
 		userId: input.userId,
 		name: input.name,
 		scope: 'user',
-		allowedPackages: [...currentPackages, packageId],
+		allowedPackages: [...state.secret.allowedPackages, state.savedPackage.id],
 	})
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Close a privilege hole: MCP agents must not be able to widen a user secret’s `allowed_packages`. Only the account owner, via website approval, may grant a package onto a user secret. That approval should feel like host approval on `/connect/secrets`.

## Why

`secretLock` called `lockSecretToPackage` and applied the grant immediately for any authenticated MCP user/agent. That skipped the human approval model that already exists (`/account/secrets/user/:name`, `/account/secrets/approve`, pending-approval summaries). Agents cannot revoke grants, so a single `secretLock` permanently widened access (for example wake webhook URL secrets).

Kent confirmed this is unwanted: agent-applied grants via `secretLock` are too loose. Package approval should hand the owner a one-click Allow link, the same spirit as expanding hosts.

## Summary

- `secretLock` is read-only. It inspects the secret and package, then returns `{ name, scope, allowed_packages, usage_url, status, approval_url, message }` **without** adding the package.
  - `status: "approval_required"` when the package is not already granted — send `approval_url` to the owner and wait.
  - `status: "already_granted"` when the grant already exists (idempotent, still no write).
- Website account secret editor and `/account/secrets/approve` remain the only ways to add `allowed_packages`.
- Package approval URLs (`buildSecretPackageApprovalUrl` and bulk `/account/secrets/approve?package_id=…&names=…`) now render a focused Allow page: secret + package, **Allow access**, **Access allowed**. No new route. `/account/secrets/new?package_id=` stays on the editor.
- Capability description and agent-facing secrets docs tell agents to send the approval link and wait.

## Siblings (`integrationLock` / `mcpServerLock`) — not changed

Those capabilities can still add packages after lock. That is a different playbook:

- First lock (open/`any` → `packages` + one package) **restricts** execute and other packages. Docs tell agents to do this (`locked-gmail-drafts`, `locked-mcp-server`).
- Adding *additional* packages after the first is the analogous widen hole.

Changing the initial lock-from-open would break the documented “lock Gmail / MCP server to a package” hardening flow. Left for a follow-up: require website approval for *additional* packages after the first lock, while still allowing the initial restrict.

## Testing

- `vitest` node-unit: `secret-lock`, package-approval view helpers, `account-secrets` handler
- `test:push` (node-unit + workers-unit) on push
- Preview seed: create package + secrets, GET Allow HTML, POST approve, UI Allow click stays on the page
- `docs:check-temporal`, `knip`

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `5ca8468a` · **Head:** `11deec21`

**Classification:** extends — `secretLock` no longer mutates `allowed_packages`, and package approval on existing account routes matches host Allow UX.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `secrets` | assistant | extends — `secretLock` is read-only and cannot widen grants |
| `mcp-server` | surfaces | extends — capability contract adds `status`, `approval_url`, and `message` |
| `app-ui` | surfaces | extends — `/account/secrets/approve` and user-secret `package_id` links are a focused Allow page |

### Change flow

An MCP agent that calls `secretLock` receives a website approval URL. The owner Allow-clicks on the existing approve route. `allowed_packages` changes only after that click.

```mermaid
sequenceDiagram
	actor Agent
	actor Owner
	participant mcpServer as mcp-server
	participant secrets as secrets
	participant appUi as app-ui
	Agent->>mcpServer: secretLock name plus package_id
	mcpServer->>secrets: inspectUserSecretPackageGrant read-only
	secrets-->>mcpServer: allowed_packages unchanged
	mcpServer-->>Agent: approval_required plus approval_url
	Agent->>Owner: send approval_url
	Owner->>appUi: Allow on /account/secrets/approve
	appUi->>secrets: setSecretAllowedPackages or lockSecretToPackage
	appUi-->>Owner: Access allowed
```

### Before / after

```
before: secretLock → lockSecretToPackage → allowed_packages += package_id
        package grant → card on secrets editor, Approve, then navigate away
after:  secretLock → inspect only → { status, approval_url, allowed_packages unchanged }
        package grant → focused Allow page, Access allowed, same spirit as /connect/secrets
        /account/secrets/new?package_id= stays on the editor
```

### Invariants

Per-user secret isolation is unchanged. MCP callers cannot widen `allowed_packages`; only the signed-in account owner on the website can.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3d88f21a-b42a-4f33-abe8-8321d390ed2e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3d88f21a-b42a-4f33-abe8-8321d390ed2e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `secretLock` now reports whether package access requires approval or is already granted.
  * Provides approval and usage links for packages awaiting access.
  * Added a dedicated website page for reviewing, approving, or rejecting package access requests.

* **Bug Fixes**
  * Package grants are no longer applied automatically through `secretLock`.
  * Account owners must approve package access through the website; removing grants remains website-only.

* **Documentation**
  * Updated account, secret, and MCP guidance to reflect the owner-approval workflow and updated `secretLock` behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->