### PR TITLE
Fix admin create-user list refresh and keep the setup link

### DIFF
--- a/docs/use/privacy.md
+++ b/docs/use/privacy.md
@@ -129,35 +129,35 @@ package source, rating notes, email, stable user ids, private profiles, secrets,
 or unrelated account content. Admin-configured notification packages may receive
 the same community metadata, and a metadata-only `user.created` or
 `user.deleted` event when a person account is created or self-deleted (stable
-user id, username, email, the create source or delete timestamp, and first-touch
-marketing attribution fields when present). Referral rows are account data
-(export and deletion) and are not included on those lifecycle events. Those
-lifecycle events omit passwords, roles, plan, secrets, and unrelated account
-content. Admin-configured notification packages may also receive a metadata-only
-`user.email_verification.failed` event when signup/verify mail first hits a
-terminal delivery failure (stable user id, username, email, status, `class`
-(`sender_block` / `other` / `null`), an admin user URL, and `occurred_at`). That
-event omits SMTP transcripts, tokens, and unrelated account content.
-Admin-configured notification packages may also receive a metadata-only
-`user.email_verification.stalled` event when signup/verify mail stays `accepted`
-for an hour with no Cloudflare lifecycle event (stable user id, username, email,
-`accepted_at`, stall threshold, an admin user URL, and `occurred_at`). That
-event omits SMTP transcripts, tokens, and unrelated account content.
-Admin-configured notification packages may also receive a metadata-only
-`user.email_outbound.paused` event when outbound sending is paused after a spam
-complaint or repeated bounces (stable user id, username, email, reason, bounce
-threshold when the reason is `bounced`, an admin user URL, and `occurred_at`).
-That event omits SMTP transcripts, message bodies, and unrelated account
-content. Admin-configured notification packages may also receive
-`email.system-message.sent` when operator correspondence leaves a reserved
-system sender (`kody@`, `support@`, and the other system locals). That event
-includes the recipients, subject, and sent text/HTML because outbound system
-mail is not stored on the inbound system-email graph; it is admin-only and omits
+user id, username, email, the create source and `created_at` or delete
+timestamp, and first-touch marketing attribution fields when present). Referral
+rows are account data (export and deletion) and are not included on those
+lifecycle events. Those lifecycle events omit passwords, roles, plan, secrets,
+and unrelated account content. Admin-configured notification packages may also
+receive a metadata-only `user.email_verification.failed` event when
+signup/verify mail first hits a terminal delivery failure (stable user id,
+username, email, status, `class` (`sender_block` / `other` / `null`), an admin
+user URL, and `occurred_at`). That event omits SMTP transcripts, tokens, and
 unrelated account content. Admin-configured notification packages may also
-receive metadata-only `auth.denial.burst` or `email.delivery.burst` events when
-hourly MCP auth denials or shared-domain bounce/complaint counts cross their
-thresholds (count, threshold, window, insights URL, and `observed_at`). Those
-events omit user identities, tokens, recipients, and message content.
+receive a metadata-only `user.email_verification.stalled` event when
+signup/verify mail stays `accepted` for an hour with no Cloudflare lifecycle
+event (stable user id, username, email, `accepted_at`, stall threshold, an admin
+user URL, and `occurred_at`). That event omits SMTP transcripts, tokens, and
+unrelated account content. Admin-configured notification packages may also
+receive a metadata-only `user.email_outbound.paused` event when outbound sending
+is paused after a spam complaint or repeated bounces (stable user id, username,
+email, reason, bounce threshold when the reason is `bounced`, an admin user URL,
+and `occurred_at`). That event omits SMTP transcripts, message bodies, and
+unrelated account content. Admin-configured notification packages may also
+receive `email.system-message.sent` when operator correspondence leaves a
+reserved system sender (`kody@`, `support@`, and the other system locals). That
+event includes the recipients, subject, and sent text/HTML because outbound
+system mail is not stored on the inbound system-email graph; it is admin-only
+and omits unrelated account content. Admin-configured notification packages may
+also receive metadata-only `auth.denial.burst` or `email.delivery.burst` events
+when hourly MCP auth denials or shared-domain bounce/complaint counts cross
+their thresholds (count, threshold, window, insights URL, and `observed_at`).
+Those events omit user identities, tokens, recipients, and message content.
 Admin-configured notification packages may also receive a metadata-only
 `fleet.package_error_rate.elevated` event when package-runtime error rates rise
 (window bounds, per-metric counts and rates, public status URL, insights URL,

--- a/packages/worker/client/routes/admin-users-shared.node.test.ts
+++ b/packages/worker/client/routes/admin-users-shared.node.test.ts
@@ -1,5 +1,9 @@
 import { expect, test } from 'vitest'
 
+import {
+	createInfiniteList,
+	type InfiniteListSnapshot,
+} from '#client/infinite-list.ts'
 import { type AdminUserListItem } from '#universal/loader-data.ts'
 import { roleNames } from '#universal/permissions.ts'
 import { planNames } from '#universal/plans.ts'
@@ -169,4 +173,61 @@ test('create reseeds from the refreshed page and prepends a user that paging omi
 		href: '/admin/users',
 	})
 	expect(patchedWindow.items).toEqual([rolePatched])
+})
+
+test('failed create refresh keeps the current window when reset runs after the snapshot is read', () => {
+	const existing = user({
+		stableUserId: stableUserId(1),
+		username: 'existing',
+	})
+	const created = user({
+		stableUserId: stableUserId(9),
+		username: 'created',
+	})
+	let snapshot: InfiniteListSnapshot<AdminUserListItem> = {
+		items: [],
+		hasMore: false,
+		totalCount: 0,
+		error: null,
+		isLoadingInitial: false,
+		isLoadingMore: false,
+	}
+	const list = createInfiniteList<AdminUserListItem>({
+		mergeDirection: 'append',
+		getKey: (item) => item.stableUserId,
+		onSnapshot: (next) => {
+			snapshot = next
+		},
+	})
+	list.replaceWindow({
+		items: [existing],
+		hasMore: true,
+		totalCount: 20,
+	})
+	const nextWindow = nextAdminUsersWindowAfterCreate({
+		currentItems: snapshot.items,
+		currentHasMore: snapshot.hasMore,
+		currentTotal: snapshot.totalCount,
+		payload: {
+			ok: true,
+			selectedUser: null,
+			page: 1,
+			pageSize: 20,
+			availableRoles: [...roleNames],
+			availablePlans: [...planNames],
+			updatedUser: created,
+			users: [],
+			total: 0,
+			listRefreshFailed: true,
+			createdUserInFilteredList: true,
+		},
+	})
+	list.reset()
+	list.replaceWindow(nextWindow)
+	expect(snapshot.items.map((item) => item.username)).toEqual([
+		'created',
+		'existing',
+	])
+	expect(snapshot.totalCount).toBe(21)
+	expect(snapshot.hasMore).toBe(true)
 })

--- a/packages/worker/client/routes/admin-users-shared.node.test.ts
+++ b/packages/worker/client/routes/admin-users-shared.node.test.ts
@@ -51,7 +51,7 @@ function user(
 	}
 }
 
-test('create reseeds from the refreshed page; mutation cannot insert a new user', () => {
+test('create reseeds from the refreshed page and prepends a user that paging omitted', () => {
 	const existing = user({
 		stableUserId: stableUserId(1),
 		username: 'existing',
@@ -60,31 +60,72 @@ test('create reseeds from the refreshed page; mutation cannot insert a new user'
 		stableUserId: stableUserId(9),
 		username: 'created',
 	})
-	const refreshedPage = {
+	const basePayload = {
 		ok: true as const,
-		users: [existing, created],
 		selectedUser: null,
 		page: 1,
 		pageSize: 20,
-		total: 2,
 		availableRoles: [...roleNames],
 		availablePlans: [...planNames],
-		updatedUser: null,
+		updatedUser: created,
 	}
 
-	const createdWindow = nextAdminUsersWindowAfterCreate(refreshedPage)
-	expect(createdWindow.items.map((item) => item.username)).toEqual([
+	const onPage = nextAdminUsersWindowAfterCreate({
+		currentItems: [existing],
+		currentHasMore: false,
+		currentTotal: 1,
+		payload: {
+			...basePayload,
+			users: [existing, created],
+			total: 2,
+		},
+	})
+	expect(onPage.items.map((item) => item.username)).toEqual([
 		'existing',
 		'created',
 	])
-	expect(createdWindow.totalCount).toBe(2)
-	expect(createdWindow.hasMore).toBe(false)
+	expect(onPage.totalCount).toBe(2)
+	expect(onPage.hasMore).toBe(false)
+
+	const omittedFromPageOne = nextAdminUsersWindowAfterCreate({
+		currentItems: [existing],
+		currentHasMore: true,
+		currentTotal: 20,
+		payload: {
+			...basePayload,
+			users: [existing],
+			total: 21,
+		},
+	})
+	expect(omittedFromPageOne.items.map((item) => item.username)).toEqual([
+		'created',
+		'existing',
+	])
+	expect(omittedFromPageOne.totalCount).toBe(21)
+	expect(omittedFromPageOne.hasMore).toBe(true)
+
+	const refreshFailed = nextAdminUsersWindowAfterCreate({
+		currentItems: [existing],
+		currentHasMore: false,
+		currentTotal: 1,
+		payload: {
+			...basePayload,
+			users: [],
+			total: 0,
+			listRefreshFailed: true,
+		},
+	})
+	expect(refreshFailed.items.map((item) => item.username)).toEqual([
+		'created',
+		'existing',
+	])
+	expect(refreshFailed.totalCount).toBe(2)
 
 	const mutationWindow = nextAdminUsersWindowAfterMutation({
 		currentItems: [existing],
 		payload: {
-			...refreshedPage,
-			updatedUser: created,
+			...basePayload,
+			users: [existing],
 			total: 2,
 		},
 		href: '/admin/users',
@@ -101,7 +142,7 @@ test('create reseeds from the refreshed page; mutation cannot insert a new user'
 	const patchedWindow = nextAdminUsersWindowAfterMutation({
 		currentItems: [existing],
 		payload: {
-			...refreshedPage,
+			...basePayload,
 			users: [rolePatched],
 			updatedUser: rolePatched,
 			total: 1,

--- a/packages/worker/client/routes/admin-users-shared.node.test.ts
+++ b/packages/worker/client/routes/admin-users-shared.node.test.ts
@@ -1,0 +1,112 @@
+import { expect, test } from 'vitest'
+
+import { type AdminUserListItem } from '#universal/loader-data.ts'
+import { roleNames } from '#universal/permissions.ts'
+import { planNames } from '#universal/plans.ts'
+import {
+	nextAdminUsersWindowAfterCreate,
+	nextAdminUsersWindowAfterMutation,
+} from './admin-users-shared.ts'
+
+function stableUserId(id: number) {
+	return id.toString(16).padStart(64, '0')
+}
+
+function user(
+	overrides: Partial<AdminUserListItem> & Pick<AdminUserListItem, 'username'>,
+): AdminUserListItem {
+	const id = overrides.stableUserId ?? stableUserId(1)
+	return {
+		stableUserId: id,
+		email: `${overrides.username}@example.com`,
+		email_verified: true,
+		email_verified_at: '2026-01-01T00:00:00.000Z',
+		plan: 'free',
+		manualPlan: 'free',
+		stripePlan: null,
+		effectivePlan: 'free',
+		entitlementLadder: 'public',
+		stripeCustomerLinked: false,
+		suspended_at: null,
+		email_outbound_paused_at: null,
+		email_verification_delivery: null,
+		email_verification_delivery_detail: null,
+		utm_source: null,
+		utm_medium: null,
+		utm_campaign: null,
+		utm_content: null,
+		utm_term: null,
+		first_touch_landing_path: null,
+		first_touch_referrer: null,
+		first_mcp_connected_at: null,
+		first_execute_at: null,
+		first_search_at: null,
+		first_saved_package_at: null,
+		mcp_client_name: null,
+		last_active_at: null,
+		created_at: '2026-01-01T00:00:00.000Z',
+		updated_at: '2026-01-01T00:00:00.000Z',
+		roles: ['user'],
+		...overrides,
+	}
+}
+
+test('create reseeds from the refreshed page; mutation cannot insert a new user', () => {
+	const existing = user({
+		stableUserId: stableUserId(1),
+		username: 'existing',
+	})
+	const created = user({
+		stableUserId: stableUserId(9),
+		username: 'created',
+	})
+	const refreshedPage = {
+		ok: true as const,
+		users: [existing, created],
+		selectedUser: null,
+		page: 1,
+		pageSize: 20,
+		total: 2,
+		availableRoles: [...roleNames],
+		availablePlans: [...planNames],
+		updatedUser: null,
+	}
+
+	const createdWindow = nextAdminUsersWindowAfterCreate(refreshedPage)
+	expect(createdWindow.items.map((item) => item.username)).toEqual([
+		'existing',
+		'created',
+	])
+	expect(createdWindow.totalCount).toBe(2)
+	expect(createdWindow.hasMore).toBe(false)
+
+	const mutationWindow = nextAdminUsersWindowAfterMutation({
+		currentItems: [existing],
+		payload: {
+			...refreshedPage,
+			updatedUser: created,
+			total: 2,
+		},
+		href: '/admin/users',
+	})
+	expect(mutationWindow.items.map((item) => item.username)).toEqual([
+		'existing',
+	])
+	expect(mutationWindow.totalCount).toBe(2)
+
+	const rolePatched = user({
+		...existing,
+		roles: ['user', 'admin'],
+	})
+	const patchedWindow = nextAdminUsersWindowAfterMutation({
+		currentItems: [existing],
+		payload: {
+			...refreshedPage,
+			users: [rolePatched],
+			updatedUser: rolePatched,
+			total: 1,
+		},
+		href: '/admin/users',
+	})
+	expect(patchedWindow.items).toEqual([rolePatched])
+})

--- a/packages/worker/client/routes/admin-users-shared.node.test.ts
+++ b/packages/worker/client/routes/admin-users-shared.node.test.ts
@@ -78,6 +78,7 @@ test('create reseeds from the refreshed page and prepends a user that paging omi
 			...basePayload,
 			users: [existing, created],
 			total: 2,
+			createdUserInFilteredList: true,
 		},
 	})
 	expect(onPage.items.map((item) => item.username)).toEqual([
@@ -95,6 +96,7 @@ test('create reseeds from the refreshed page and prepends a user that paging omi
 			...basePayload,
 			users: [existing],
 			total: 21,
+			createdUserInFilteredList: true,
 		},
 	})
 	expect(omittedFromPageOne.items.map((item) => item.username)).toEqual([
@@ -113,6 +115,7 @@ test('create reseeds from the refreshed page and prepends a user that paging omi
 			users: [],
 			total: 0,
 			listRefreshFailed: true,
+			createdUserInFilteredList: true,
 		},
 	})
 	expect(refreshFailed.items.map((item) => item.username)).toEqual([
@@ -120,6 +123,22 @@ test('create reseeds from the refreshed page and prepends a user that paging omi
 		'existing',
 	])
 	expect(refreshFailed.totalCount).toBe(2)
+
+	const excludedByFilter = nextAdminUsersWindowAfterCreate({
+		currentItems: [existing],
+		currentHasMore: false,
+		currentTotal: 1,
+		payload: {
+			...basePayload,
+			users: [existing],
+			total: 1,
+			createdUserInFilteredList: false,
+		},
+	})
+	expect(excludedByFilter.items.map((item) => item.username)).toEqual([
+		'existing',
+	])
+	expect(excludedByFilter.totalCount).toBe(1)
 
 	const mutationWindow = nextAdminUsersWindowAfterMutation({
 		currentItems: [existing],

--- a/packages/worker/client/routes/admin-users-shared.ts
+++ b/packages/worker/client/routes/admin-users-shared.ts
@@ -1,9 +1,14 @@
 import { createListDetailRoute } from '#client/list-detail-route.ts'
 import { readJson } from '#client/routes/account-approval-shared.ts'
 import { formatIntegerNumber } from '#client/charts/chart-theme.ts'
-import { type AdminUsersLoaderData } from '#universal/loader-data.ts'
+import {
+	type AdminUserListItem,
+	type AdminUsersLoaderData,
+	type AdminUsersMutationData,
+} from '#universal/loader-data.ts'
 import {
 	isAdminUserVerificationFilter,
+	isStalledEmailVerificationDelivery,
 	type AdminUserVerificationFilter,
 } from '#universal/email-verification-delivery.ts'
 import {
@@ -85,6 +90,66 @@ export function buildUserDetailHrefFrom(
 export function getDataKey(href: string) {
 	const pathname = new URL(href, 'http://localhost').pathname
 	return `${pathname}?${getListKey(href)}`
+}
+
+/**
+ * Create responses carry a refreshed first page. Use that window instead of
+ * patching existing rows — `updatedUser` is null and a new id cannot be
+ * mapped into the current snapshot.
+ */
+export function nextAdminUsersWindowAfterCreate(payload: AdminUsersLoaderData) {
+	return {
+		items: payload.users,
+		hasMore: payload.page * payload.pageSize < payload.total,
+		totalCount: payload.total,
+	}
+}
+
+/**
+ * Role / plan / verification mutations patch the target in place so a
+ * scrolled list keeps its loaded window. A create cannot use this path.
+ */
+export function nextAdminUsersWindowAfterMutation(input: {
+	currentItems: Array<AdminUserListItem>
+	payload: AdminUsersMutationData
+	href: string
+}) {
+	const updatedUser = input.payload.updatedUser
+	const { role, verification } = readFilterState(input.href)
+	// The server ignores unknown role values, so only a known role counts
+	// as an active filter — otherwise every mutation would wrongly remove
+	// its target from the list.
+	const activeRoleFilter = (
+		input.payload.availableRoles as Array<string>
+	).includes(role)
+		? role
+		: ''
+	const matchesRoleFilter =
+		!updatedUser ||
+		!activeRoleFilter ||
+		(updatedUser.roles as Array<string>).includes(activeRoleFilter)
+	const matchesVerificationFilter =
+		!updatedUser ||
+		verification !== 'stalled' ||
+		isStalledEmailVerificationDelivery({
+			emailVerified: updatedUser.email_verified,
+			delivery: updatedUser.email_verification_delivery,
+		})
+	const matchesActiveFilters = matchesRoleFilter && matchesVerificationFilter
+	const nextItems = updatedUser
+		? matchesActiveFilters
+			? input.currentItems.map((item) =>
+					item.stableUserId === updatedUser.stableUserId ? updatedUser : item,
+				)
+			: input.currentItems.filter(
+					(item) => item.stableUserId !== updatedUser.stableUserId,
+				)
+		: input.currentItems
+	return {
+		items: nextItems,
+		hasMore: nextItems.length < input.payload.total,
+		totalCount: input.payload.total,
+	}
 }
 
 export function parseSelectedStableUserId(value: string | null): string | null {

--- a/packages/worker/client/routes/admin-users-shared.ts
+++ b/packages/worker/client/routes/admin-users-shared.ts
@@ -93,15 +93,36 @@ export function getDataKey(href: string) {
 }
 
 /**
- * Create responses carry a refreshed first page. Use that window instead of
- * patching existing rows — `updatedUser` is null and a new id cannot be
- * mapped into the current snapshot.
+ * Create reseeds from the refreshed first page, then prepends the created
+ * row when oldest-first paging left it off page one. A failed refresh
+ * keeps the current window and still splices that row in when present.
  */
-export function nextAdminUsersWindowAfterCreate(payload: AdminUsersLoaderData) {
+export function nextAdminUsersWindowAfterCreate(input: {
+	currentItems: Array<AdminUserListItem>
+	currentHasMore: boolean
+	currentTotal: number
+	payload: AdminUsersMutationData
+}) {
+	const created = input.payload.updatedUser
+	const baseItems = input.payload.listRefreshFailed
+		? input.currentItems
+		: input.payload.users
+	const alreadyListed =
+		created != null &&
+		baseItems.some((item) => item.stableUserId === created.stableUserId)
+	const items = created && !alreadyListed ? [created, ...baseItems] : baseItems
+	if (input.payload.listRefreshFailed) {
+		return {
+			items,
+			hasMore: input.currentHasMore,
+			totalCount:
+				created && !alreadyListed ? input.currentTotal + 1 : input.currentTotal,
+		}
+	}
 	return {
-		items: payload.users,
-		hasMore: payload.page * payload.pageSize < payload.total,
-		totalCount: payload.total,
+		items,
+		hasMore: input.payload.page * input.payload.pageSize < input.payload.total,
+		totalCount: input.payload.total,
 	}
 }
 

--- a/packages/worker/client/routes/admin-users-shared.ts
+++ b/packages/worker/client/routes/admin-users-shared.ts
@@ -94,8 +94,9 @@ export function getDataKey(href: string) {
 
 /**
  * Create reseeds from the refreshed first page, then prepends the created
- * row when oldest-first paging left it off page one. A failed refresh
- * keeps the current window and still splices that row in when present.
+ * row when oldest-first paging left it off page one and the server says
+ * it still matches the active filters. A failed refresh keeps the current
+ * window and only splices that row in when those same conditions hold.
  */
 export function nextAdminUsersWindowAfterCreate(input: {
 	currentItems: Array<AdminUserListItem>
@@ -110,13 +111,16 @@ export function nextAdminUsersWindowAfterCreate(input: {
 	const alreadyListed =
 		created != null &&
 		baseItems.some((item) => item.stableUserId === created.stableUserId)
-	const items = created && !alreadyListed ? [created, ...baseItems] : baseItems
+	const canInsert =
+		created != null &&
+		!alreadyListed &&
+		input.payload.createdUserInFilteredList === true
+	const items = canInsert ? [created, ...baseItems] : baseItems
 	if (input.payload.listRefreshFailed) {
 		return {
 			items,
 			hasMore: input.currentHasMore,
-			totalCount:
-				created && !alreadyListed ? input.currentTotal + 1 : input.currentTotal,
+			totalCount: canInsert ? input.currentTotal + 1 : input.currentTotal,
 		}
 	}
 	return {

--- a/packages/worker/client/routes/admin-users.tsx
+++ b/packages/worker/client/routes/admin-users.tsx
@@ -12,7 +12,6 @@ import { createRouteData, routeDataRedirect } from '#client/route-data.tsx'
 import { readJson } from '#client/routes/account-approval-shared.ts'
 import { colors } from '#universal/styles/tokens.ts'
 import { getGhostButtonCss } from '#universal/styles/style-primitives.ts'
-import { isStalledEmailVerificationDelivery } from '#universal/email-verification-delivery.ts'
 import { type RoleName } from '#universal/permissions.ts'
 import {
 	type AdminCreatedUserSetup,
@@ -31,6 +30,8 @@ import {
 	getDataKey,
 	getListKey,
 	getSelection,
+	nextAdminUsersWindowAfterCreate,
+	nextAdminUsersWindowAfterMutation,
 	parseSelectedStableUserId,
 	readFilterState,
 } from './admin-users-shared.ts'
@@ -276,45 +277,17 @@ export function AdminUsersRoute(handle: Handle) {
 	function applyMutationPayload(payload: AdminUsersMutationData, href: string) {
 		availableRoles = payload.availableRoles
 		availablePlans = payload.availablePlans
-		const updatedUser = payload.updatedUser
-		const { role, verification } = readFilterState(href)
-		// The server ignores unknown role values, so only a known role counts
-		// as an active filter — otherwise every mutation would wrongly remove
-		// its target from the list.
-		const activeRoleFilter = (availableRoles as Array<string>).includes(role)
-			? role
-			: ''
-		const matchesRoleFilter =
-			!updatedUser ||
-			!activeRoleFilter ||
-			(updatedUser.roles as Array<string>).includes(activeRoleFilter)
-		const matchesVerificationFilter =
-			!updatedUser ||
-			verification !== 'stalled' ||
-			isStalledEmailVerificationDelivery({
-				emailVerified: updatedUser.email_verified,
-				delivery: updatedUser.email_verification_delivery,
-			})
-		const matchesActiveFilters = matchesRoleFilter && matchesVerificationFilter
-		const currentItems = usersSnapshot.items
-		const nextItems = updatedUser
-			? matchesActiveFilters
-				? currentItems.map((item) =>
-						item.stableUserId === updatedUser.stableUserId ? updatedUser : item,
-					)
-				: currentItems.filter(
-						(item) => item.stableUserId !== updatedUser.stableUserId,
-					)
-			: currentItems
+		const nextWindow = nextAdminUsersWindowAfterMutation({
+			currentItems: usersSnapshot.items,
+			payload,
+			href,
+		})
 		// reset() invalidates any in-flight load-more so a page fetched before
 		// the mutation cannot merge stale rows or counts back in afterward.
 		userList.reset()
-		userList.replaceWindow({
-			items: nextItems,
-			hasMore: nextItems.length < payload.total,
-			totalCount: payload.total,
-		})
+		userList.replaceWindow(nextWindow)
 		const selectedStableUserId = getSelectedStableUserIdFromHref(href)
+		const updatedUser = payload.updatedUser
 		selectedUserFallback =
 			payload.selectedUser ??
 			(updatedUser &&
@@ -322,6 +295,22 @@ export function AdminUsersRoute(handle: Handle) {
 			updatedUser.stableUserId === selectedStableUserId
 				? updatedUser
 				: selectedUserFallback)
+		resetPlanDraft()
+	}
+
+	function applyCreateUserPayload(
+		payload: AdminUsersMutationData,
+		href: string,
+	) {
+		if (payload.listRefreshFailed) return
+		availableRoles = payload.availableRoles
+		availablePlans = payload.availablePlans
+		const nextWindow = nextAdminUsersWindowAfterCreate(payload)
+		loadedThroughPage = payload.page
+		userList.reset()
+		userList.replaceWindow(nextWindow)
+		lastLoadedListKey = getListKey(href)
+		selectedUserFallback = payload.selectedUser
 		resetPlanDraft()
 	}
 
@@ -561,7 +550,7 @@ export function AdminUsersRoute(handle: Handle) {
 			if (!response.ok || !payload?.ok) {
 				throw new Error(payload?.error || 'Unable to create user.')
 			}
-			applyMutationPayload(payload, href)
+			applyCreateUserPayload(payload, href)
 			createdUser = payload.createdUser ?? createdUser
 			message = 'User created. Copy the setup link below.'
 			actionState = 'idle'

--- a/packages/worker/client/routes/admin-users.tsx
+++ b/packages/worker/client/routes/admin-users.tsx
@@ -302,15 +302,24 @@ export function AdminUsersRoute(handle: Handle) {
 		payload: AdminUsersMutationData,
 		href: string,
 	) {
-		if (payload.listRefreshFailed) return
-		availableRoles = payload.availableRoles
-		availablePlans = payload.availablePlans
-		const nextWindow = nextAdminUsersWindowAfterCreate(payload)
-		loadedThroughPage = payload.page
+		if (payload.listRefreshFailed && !payload.updatedUser) return
+		const nextWindow = nextAdminUsersWindowAfterCreate({
+			currentItems: usersSnapshot.items,
+			currentHasMore: usersSnapshot.hasMore,
+			currentTotal: usersSnapshot.totalCount,
+			payload,
+		})
+		if (!payload.listRefreshFailed) {
+			availableRoles = payload.availableRoles
+			availablePlans = payload.availablePlans
+			loadedThroughPage = payload.page
+			lastLoadedListKey = getListKey(href)
+			selectedUserFallback = payload.selectedUser ?? payload.updatedUser
+		} else if (payload.updatedUser) {
+			selectedUserFallback = payload.updatedUser
+		}
 		userList.reset()
 		userList.replaceWindow(nextWindow)
-		lastLoadedListKey = getListKey(href)
-		selectedUserFallback = payload.selectedUser
 		resetPlanDraft()
 	}
 

--- a/packages/worker/client/routes/admin-users.tsx
+++ b/packages/worker/client/routes/admin-users.tsx
@@ -315,15 +315,15 @@ export function AdminUsersRoute(handle: Handle) {
 		selectedUserFallback = payload.listRefreshFailed
 			? keepFallback
 			: (payload.selectedUser ?? keepFallback)
+		// reset() emits an empty snapshot; read the current window first.
+		const nextWindow = nextAdminUsersWindowAfterCreate({
+			currentItems: usersSnapshot.items,
+			currentHasMore: usersSnapshot.hasMore,
+			currentTotal: usersSnapshot.totalCount,
+			payload,
+		})
 		userList.reset()
-		userList.replaceWindow(
-			nextAdminUsersWindowAfterCreate({
-				currentItems: usersSnapshot.items,
-				currentHasMore: usersSnapshot.hasMore,
-				currentTotal: usersSnapshot.totalCount,
-				payload,
-			}),
-		)
+		userList.replaceWindow(nextWindow)
 		resetPlanDraft()
 	}
 

--- a/packages/worker/client/routes/admin-users.tsx
+++ b/packages/worker/client/routes/admin-users.tsx
@@ -282,8 +282,6 @@ export function AdminUsersRoute(handle: Handle) {
 			payload,
 			href,
 		})
-		// reset() invalidates any in-flight load-more so a page fetched before
-		// the mutation cannot merge stale rows or counts back in afterward.
 		userList.reset()
 		userList.replaceWindow(nextWindow)
 		const selectedStableUserId = getSelectedStableUserIdFromHref(href)
@@ -303,23 +301,29 @@ export function AdminUsersRoute(handle: Handle) {
 		href: string,
 	) {
 		if (payload.listRefreshFailed && !payload.updatedUser) return
-		const nextWindow = nextAdminUsersWindowAfterCreate({
-			currentItems: usersSnapshot.items,
-			currentHasMore: usersSnapshot.hasMore,
-			currentTotal: usersSnapshot.totalCount,
-			payload,
-		})
+		const selectedId = getSelectedStableUserIdFromHref(href)
+		const keepFallback =
+			payload.updatedUser?.stableUserId === selectedId
+				? payload.updatedUser
+				: selectedUserFallback
 		if (!payload.listRefreshFailed) {
 			availableRoles = payload.availableRoles
 			availablePlans = payload.availablePlans
 			loadedThroughPage = payload.page
 			lastLoadedListKey = getListKey(href)
-			selectedUserFallback = payload.selectedUser ?? payload.updatedUser
-		} else if (payload.updatedUser) {
-			selectedUserFallback = payload.updatedUser
 		}
+		selectedUserFallback = payload.listRefreshFailed
+			? keepFallback
+			: (payload.selectedUser ?? keepFallback)
 		userList.reset()
-		userList.replaceWindow(nextWindow)
+		userList.replaceWindow(
+			nextAdminUsersWindowAfterCreate({
+				currentItems: usersSnapshot.items,
+				currentHasMore: usersSnapshot.hasMore,
+				currentTotal: usersSnapshot.totalCount,
+				payload,
+			}),
+		)
 		resetPlanDraft()
 	}
 

--- a/packages/worker/client/routes/privacy.tsx
+++ b/packages/worker/client/routes/privacy.tsx
@@ -166,20 +166,21 @@ export function PrivacyRoute(_handle: Handle) {
 					receive the same community metadata, and a metadata-only{' '}
 					<code>user.created</code> or <code>user.deleted</code> event when a
 					person account is created or self-deleted (stable user id, username,
-					email, the create source or delete timestamp, and first-touch
-					marketing attribution fields when present). Those lifecycle events
-					omit passwords, roles, plan, secrets, and unrelated account content.
-					Admin-configured notification packages may also receive a
-					metadata-only <code>user.email_verification.failed</code> event when
-					signup/verify mail first hits a terminal delivery failure (stable user
-					id, username, email, status, <code>class</code> (
-					<code>sender_block</code> / <code>other</code> / <code>null</code>),
-					an admin user URL, and <code>occurred_at</code>). That event omits
-					SMTP transcripts, tokens, and unrelated account content.
-					Admin-configured notification packages may also receive a
-					metadata-only <code>user.email_verification.stalled</code> event when
-					signup/verify mail stays <code>accepted</code> for an hour with no
-					Cloudflare lifecycle event (stable user id, username, email,{' '}
+					email, the create source and <code>created_at</code> or delete
+					timestamp, and first-touch marketing attribution fields when present).
+					Those lifecycle events omit passwords, roles, plan, secrets, and
+					unrelated account content. Admin-configured notification packages may
+					also receive a metadata-only{' '}
+					<code>user.email_verification.failed</code> event when signup/verify
+					mail first hits a terminal delivery failure (stable user id, username,
+					email, status, <code>class</code> (<code>sender_block</code> /{' '}
+					<code>other</code> / <code>null</code>), an admin user URL, and{' '}
+					<code>occurred_at</code>). That event omits SMTP transcripts, tokens,
+					and unrelated account content. Admin-configured notification packages
+					may also receive a metadata-only{' '}
+					<code>user.email_verification.stalled</code> event when signup/verify
+					mail stays <code>accepted</code> for an hour with no Cloudflare
+					lifecycle event (stable user id, username, email,{' '}
 					<code>accepted_at</code>, stall threshold, an admin user URL, and{' '}
 					<code>occurred_at</code>). That event omits SMTP transcripts, tokens,
 					and unrelated account content. Admin-configured notification packages

--- a/packages/worker/src/admin/users-data.ts
+++ b/packages/worker/src/admin/users-data.ts
@@ -221,6 +221,34 @@ function buildAdminUserListWhereClause(
 	}
 }
 
+/**
+ * Whether `stableUserId` belongs in the filtered admin-users result for
+ * this request URL. Uses the same WHERE clause as the page query so the
+ * client can prepend a created row without reimplementing filters.
+ */
+export async function adminUserMatchesListFilters(
+	env: Env,
+	requestUrl: string,
+	stableUserId: string,
+): Promise<boolean> {
+	if (!isStableUserId(stableUserId)) return false
+	const url = new URL(requestUrl, 'http://localhost')
+	const filters = readAdminUserListFilters(url)
+	const { whereClause, params } = buildAdminUserListWhereClause(
+		filters,
+		new Date(),
+	)
+	const membershipWhere = whereClause
+		? `${whereClause} AND stable_user_id = ?`
+		: 'WHERE stable_user_id = ?'
+	const row = await env.APP_DB.prepare(
+		`SELECT 1 AS found FROM users ${membershipWhere} LIMIT 1`,
+	)
+		.bind(...params, stableUserId)
+		.first<{ found: number }>()
+	return row != null
+}
+
 export async function loadAdminUsersData(
 	env: Env,
 	requestUrl: string,

--- a/packages/worker/src/app/handlers/admin-users.node.test.ts
+++ b/packages/worker/src/app/handlers/admin-users.node.test.ts
@@ -252,6 +252,15 @@ function createAdminTestEnv(input: {
 								return { results: [] as Array<T>, meta: { changes: 0 } }
 							},
 							async first<T>() {
+								if (normalizedQuery.includes('select 1 as found from users')) {
+									const { rows, paramIndex } = applyListFilters(params)
+									const stableUserId = String(params[paramIndex] ?? '')
+									return (
+										rows.some((row) => row.stable_user_id === stableUserId)
+											? { found: 1 }
+											: null
+									) as T
+								}
 								if (
 									normalizedQuery.includes(
 										'select deleting_at from users where stable_user_id',
@@ -1261,9 +1270,10 @@ test('create_user action returns setup link, logs audit, maps duplicate email to
 		userRoles: [{ user_id: 9, role_name: 'user' }],
 	})
 	const handler = createAdminUsersApiHandler(env as unknown as Env)
-	async function postCreateUser(body: Record<string, unknown>) {
+	async function postCreateUser(body: Record<string, unknown>, search = '') {
+		const href = `https://example.com/admin/users.json${search}`
 		return handler.handler({
-			request: new Request('https://example.com/admin/users.json', {
+			request: new Request(href, {
 				method: 'POST',
 				headers: {
 					Accept: 'application/json',
@@ -1272,7 +1282,7 @@ test('create_user action returns setup link, logs audit, maps duplicate email to
 				body: JSON.stringify(body),
 			}),
 			params: {},
-			url: new URL('https://example.com/admin/users.json'),
+			url: new URL(href),
 		} as never)
 	}
 
@@ -1300,6 +1310,43 @@ test('create_user action returns setup link, logs audit, maps duplicate email to
 	expect(createdPayload.users).toEqual([
 		expect.objectContaining({ stableUserId: createdUser.stableUserId }),
 	])
+	expect(createdPayload.createdUserInFilteredList).toBe(true)
+
+	mockModule.adminCreateUserWithPasswordSetup.mockResolvedValueOnce(createdUser)
+	const roleFiltered = await postCreateUser(
+		{
+			action: 'create_user',
+			email: 'new-user@example.com',
+			username: 'new-user',
+		},
+		'?role=admin',
+	)
+	expect(roleFiltered.status).toBe(200)
+	expect((await roleFiltered.json()).createdUserInFilteredList).toBe(false)
+
+	mockModule.adminCreateUserWithPasswordSetup.mockResolvedValueOnce(createdUser)
+	const searchFiltered = await postCreateUser(
+		{
+			action: 'create_user',
+			email: 'new-user@example.com',
+			username: 'new-user',
+		},
+		'?q=nobody-matches',
+	)
+	expect(searchFiltered.status).toBe(200)
+	expect((await searchFiltered.json()).createdUserInFilteredList).toBe(false)
+
+	mockModule.adminCreateUserWithPasswordSetup.mockResolvedValueOnce(createdUser)
+	const searchMatch = await postCreateUser(
+		{
+			action: 'create_user',
+			email: 'new-user@example.com',
+			username: 'new-user',
+		},
+		'?q=new-user',
+	)
+	expect(searchMatch.status).toBe(200)
+	expect((await searchMatch.json()).createdUserInFilteredList).toBe(true)
 	expect(mockModule.scheduleUserCreatedEvent).toHaveBeenCalledWith({
 		env,
 		user: {
@@ -1359,6 +1406,7 @@ test('create_user action returns setup link, logs audit, maps duplicate email to
 				username: createdUser.username,
 			}),
 		)
+		expect(refreshFailedPayload.createdUserInFilteredList).toBe(true)
 		expect(consoleWarn).toHaveBeenCalledWith(
 			'admin-users-create-list-refresh-failed',
 			expect.any(Error),

--- a/packages/worker/src/app/handlers/admin-users.node.test.ts
+++ b/packages/worker/src/app/handlers/admin-users.node.test.ts
@@ -1247,8 +1247,18 @@ test('create_user action returns setup link, logs audit, maps duplicate email to
 	}
 	mockModule.adminCreateUserWithPasswordSetup.mockResolvedValueOnce(createdUser)
 	const env = createAdminTestEnv({
-		users: [],
-		userRoles: [],
+		users: [
+			{
+				id: 9,
+				username: 'new-user',
+				email: 'new-user@example.com',
+				email_verified_at: '2026-09-10T00:00:00.000Z',
+				plan: 'free',
+				created_at: '2026-09-10 00:00:00',
+				updated_at: '2026-09-10 00:00:00',
+			},
+		],
+		userRoles: [{ user_id: 9, role_name: 'user' }],
 	})
 	const handler = createAdminUsersApiHandler(env as unknown as Env)
 	async function postCreateUser(body: Record<string, unknown>) {
@@ -1280,7 +1290,16 @@ test('create_user action returns setup link, logs audit, maps duplicate email to
 		setupLink: createdUser.setupLink,
 		setupTokenExpiresAt: createdUser.setupTokenExpiresAt,
 	})
-	expect(createdPayload.updatedUser).toBeNull()
+	expect(createdPayload.updatedUser).toEqual(
+		expect.objectContaining({
+			stableUserId: createdUser.stableUserId,
+			username: createdUser.username,
+			email: createdUser.email,
+		}),
+	)
+	expect(createdPayload.users).toEqual([
+		expect.objectContaining({ stableUserId: createdUser.stableUserId }),
+	])
 	expect(mockModule.scheduleUserCreatedEvent).toHaveBeenCalledWith({
 		env,
 		user: {
@@ -1334,6 +1353,12 @@ test('create_user action returns setup link, logs audit, maps duplicate email to
 			setupLink: createdUser.setupLink,
 			setupTokenExpiresAt: createdUser.setupTokenExpiresAt,
 		})
+		expect(refreshFailedPayload.updatedUser).toEqual(
+			expect.objectContaining({
+				stableUserId: createdUser.stableUserId,
+				username: createdUser.username,
+			}),
+		)
 		expect(consoleWarn).toHaveBeenCalledWith(
 			'admin-users-create-list-refresh-failed',
 			expect.any(Error),

--- a/packages/worker/src/app/handlers/admin-users.node.test.ts
+++ b/packages/worker/src/app/handlers/admin-users.node.test.ts
@@ -2,12 +2,16 @@ import { expect, test, vi } from 'vitest'
 import { adminUserListItemFieldNames } from './admin-users.ts'
 import { type PermissionString, type RoleName } from '#universal/permissions.ts'
 import { logAuditEventSpy } from '#worker/test-support/audit-log-spy.ts'
+import { consoleWarn } from '#worker/test-support/console-spies.ts'
 import type * as AuditLog from '#worker/audit-log.ts'
 
 const mockModule = vi.hoisted(() => ({
 	readAuthenticatedAppUser: vi.fn(),
 	adminCreateUserWithPasswordSetup: vi.fn(),
 	scheduleUserCreatedEvent: vi.fn(),
+	loadAdminUsersData: undefined as
+		| ((...args: Array<unknown>) => Promise<unknown>)
+		| undefined,
 }))
 
 vi.mock('#app/authenticated-user.ts', () => ({
@@ -31,6 +35,20 @@ vi.mock('#worker/identity/schedule-user-lifecycle-event.ts', () => ({
 	scheduleUserCreatedEvent: (...args: Array<unknown>) =>
 		mockModule.scheduleUserCreatedEvent(...args),
 }))
+
+vi.mock('#worker/admin/users-data.ts', async (importOriginal) => {
+	const actual =
+		await importOriginal<typeof import('#worker/admin/users-data.ts')>()
+	return {
+		...actual,
+		loadAdminUsersData: (
+			...args: Parameters<typeof actual.loadAdminUsersData>
+		) =>
+			mockModule.loadAdminUsersData
+				? mockModule.loadAdminUsersData(...args)
+				: actual.loadAdminUsersData(...args),
+	}
+})
 
 // The shared audit-log-spy setup file routes logAuditEvent; this test also
 // needs a deterministic request IP for its audit assertions.
@@ -1211,7 +1229,7 @@ test('mark email verified and mint verify url actions update the account and log
 	expect(alreadyVerified.status).toBe(400)
 })
 
-test('create_user action returns setup link, logs audit, and maps duplicate email to 409', async () => {
+test('create_user action returns setup link, logs audit, maps duplicate email to 409, and keeps the setup link when list refresh fails', async () => {
 	const { AdminCreateUserError } =
 		await import('#worker/identity/admin-user-creation.ts')
 	logAuditEventSpy.mockClear()
@@ -1293,4 +1311,34 @@ test('create_user action returns setup link, logs audit, and maps duplicate emai
 		error: 'That email is already in use.',
 		code: 'email_exists',
 	})
+
+	mockModule.adminCreateUserWithPasswordSetup.mockResolvedValueOnce(createdUser)
+	mockModule.loadAdminUsersData = async () => {
+		throw new Error('list refresh failed')
+	}
+	consoleWarn.mockImplementation(() => {})
+	try {
+		const refreshFailed = await postCreateUser({
+			action: 'create_user',
+			email: 'refresh-fail@example.com',
+			username: 'refresh-fail',
+		})
+		expect(refreshFailed.status).toBe(200)
+		const refreshFailedPayload = await refreshFailed.json()
+		expect(refreshFailedPayload.ok).toBe(true)
+		expect(refreshFailedPayload.listRefreshFailed).toBe(true)
+		expect(refreshFailedPayload.createdUser).toEqual({
+			stableUserId: createdUser.stableUserId,
+			email: createdUser.email,
+			username: createdUser.username,
+			setupLink: createdUser.setupLink,
+			setupTokenExpiresAt: createdUser.setupTokenExpiresAt,
+		})
+		expect(consoleWarn).toHaveBeenCalledWith(
+			'admin-users-create-list-refresh-failed',
+			expect.any(Error),
+		)
+	} finally {
+		mockModule.loadAdminUsersData = undefined
+	}
 })

--- a/packages/worker/src/app/handlers/admin-users.node.test.ts
+++ b/packages/worker/src/app/handlers/admin-users.node.test.ts
@@ -1347,6 +1347,20 @@ test('create_user action returns setup link, logs audit, maps duplicate email to
 	)
 	expect(searchMatch.status).toBe(200)
 	expect((await searchMatch.json()).createdUserInFilteredList).toBe(true)
+
+	mockModule.adminCreateUserWithPasswordSetup.mockResolvedValueOnce(createdUser)
+	const verificationFiltered = await postCreateUser(
+		{
+			action: 'create_user',
+			email: 'new-user@example.com',
+			username: 'new-user',
+		},
+		'?verification=stalled',
+	)
+	expect(verificationFiltered.status).toBe(200)
+	expect((await verificationFiltered.json()).createdUserInFilteredList).toBe(
+		false,
+	)
 	expect(mockModule.scheduleUserCreatedEvent).toHaveBeenCalledWith({
 		env,
 		user: {

--- a/packages/worker/src/app/handlers/admin-users.ts
+++ b/packages/worker/src/app/handlers/admin-users.ts
@@ -30,6 +30,7 @@ import {
 } from '#worker/identity/email-verification-admin.ts'
 import {
 	parsePlanName,
+	planNames,
 	resolvePlanWrite,
 	type PlanName,
 } from '#universal/plans.ts'
@@ -681,12 +682,31 @@ async function handleCreateUserAction(input: {
 		})
 
 		const { userId: _userId, ...boundaryUser } = createdUser
-		const payload = await loadAdminUsersData(input.env, input.request.url)
-		return jsonResponse({
-			...payload,
-			updatedUser: null,
-			createdUser: boundaryUser,
-		})
+		try {
+			const payload = await loadAdminUsersData(input.env, input.request.url)
+			return jsonResponse({
+				...payload,
+				updatedUser: null,
+				createdUser: boundaryUser,
+			})
+		} catch (error) {
+			// The account and one-time setup link already exist. A list refresh
+			// failure must not become a 500 that drops that link.
+			console.warn('admin-users-create-list-refresh-failed', error)
+			return jsonResponse({
+				ok: true,
+				users: [],
+				selectedUser: null,
+				page: 1,
+				pageSize: 20,
+				total: 0,
+				availableRoles: [...roleNames],
+				availablePlans: [...planNames],
+				updatedUser: null,
+				createdUser: boundaryUser,
+				listRefreshFailed: true,
+			})
+		}
 	} catch (error) {
 		const message =
 			error instanceof Error ? error.message : 'Unable to create user.'

--- a/packages/worker/src/app/handlers/admin-users.ts
+++ b/packages/worker/src/app/handlers/admin-users.ts
@@ -16,6 +16,7 @@ import {
 	clearAdminUserEmailOutboundPause,
 	loadAdminUserByTarget,
 	loadAdminUserRowByStableUserId,
+	adminUserMatchesListFilters,
 	loadAdminUsersData,
 	loadRolesByUserIds,
 	adminUserListItemFieldNames,
@@ -685,12 +686,20 @@ async function handleCreateUserAction(input: {
 		const createdListItem = await loadAdminUserByTarget(input.env.APP_DB, {
 			stableUserId: createdUser.stableUserId,
 		}).catch(() => null)
+		const createdUserInFilteredList = createdListItem
+			? await adminUserMatchesListFilters(
+					input.env,
+					input.request.url,
+					createdUser.stableUserId,
+				).catch(() => false)
+			: false
 		try {
 			const payload = await loadAdminUsersData(input.env, input.request.url)
 			return jsonResponse({
 				...payload,
 				updatedUser: createdListItem,
 				createdUser: boundaryUser,
+				createdUserInFilteredList,
 			})
 		} catch (error) {
 			// The account and one-time setup link already exist. A list refresh
@@ -707,6 +716,7 @@ async function handleCreateUserAction(input: {
 				availablePlans: [...planNames],
 				updatedUser: createdListItem,
 				createdUser: boundaryUser,
+				createdUserInFilteredList,
 				listRefreshFailed: true,
 			})
 		}

--- a/packages/worker/src/app/handlers/admin-users.ts
+++ b/packages/worker/src/app/handlers/admin-users.ts
@@ -682,11 +682,14 @@ async function handleCreateUserAction(input: {
 		})
 
 		const { userId: _userId, ...boundaryUser } = createdUser
+		const createdListItem = await loadAdminUserByTarget(input.env.APP_DB, {
+			stableUserId: createdUser.stableUserId,
+		}).catch(() => null)
 		try {
 			const payload = await loadAdminUsersData(input.env, input.request.url)
 			return jsonResponse({
 				...payload,
-				updatedUser: null,
+				updatedUser: createdListItem,
 				createdUser: boundaryUser,
 			})
 		} catch (error) {
@@ -702,7 +705,7 @@ async function handleCreateUserAction(input: {
 				total: 0,
 				availableRoles: [...roleNames],
 				availablePlans: [...planNames],
-				updatedUser: null,
+				updatedUser: createdListItem,
 				createdUser: boundaryUser,
 				listRefreshFailed: true,
 			})

--- a/packages/worker/universal/loader-data.ts
+++ b/packages/worker/universal/loader-data.ts
@@ -350,6 +350,12 @@ export type AdminUsersMutationData = AdminUsersLoaderData & {
 	 * the current list window and still show `createdUser` / the setup link.
 	 */
 	listRefreshFailed?: boolean
+	/**
+	 * The created row matches the request's active list filters. The client
+	 * only prepends `updatedUser` when this is true, so a search/role/
+	 * verification filter cannot gain a non-matching row.
+	 */
+	createdUserInFilteredList?: boolean
 }
 
 type AdminRoleListItem = {

--- a/packages/worker/universal/loader-data.ts
+++ b/packages/worker/universal/loader-data.ts
@@ -345,6 +345,11 @@ export type AdminUsersMutationData = AdminUsersLoaderData & {
 	verifyUrl?: string | null
 	verifyUrlExpiresAt?: number | null
 	createdUser?: AdminCreatedUserSetup
+	/**
+	 * Create succeeded but `loadAdminUsersData` failed. The client must keep
+	 * the current list window and still show `createdUser` / the setup link.
+	 */
+	listRefreshFailed?: boolean
 }
 
 type AdminRoleListItem = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Land the three still-valid CodeRabbit findings from #2221 that arrived at squash-merge time and were not processed.

## Why

#2221 removed leftover signup invite codes and moved admin create-user onto `/admin/users`. CodeRabbit posted two major bugs and one privacy-copy gap ~29s before merge. This follow-up fixes those without touching referral links or resurrecting invite codes.

## Summary

- `create_user` success reseeds the admin users list from the response’s refreshed `users` page, then prepends the created row only when oldest-first paging omitted it **and** `createdUserInFilteredList` is true (same WHERE clause as the page query).
- If `loadAdminUsersData` throws after `adminCreateUserWithPasswordSetup` succeeds, the handler still returns 200 with the one-time setup link and `listRefreshFailed`. The URL-selected user fallback is not replaced by the created row. The client reads the current list window **before** `reset()`, so a failed refresh cannot collapse the table to the created row or empty.
- Privacy doc and `/privacy` copy now name `user.created` `created_at` alongside the create source.

## Testing

- `npx vitest run --project node-unit` on `admin-users.node.test.ts` and `admin-users-shared.node.test.ts`
- Pre-push: `test:node` 3004 and `test:workers` 342
- Filter membership coverage: unfiltered and `?q=new-user` include the created user; `?role=admin`, `?q=nobody-matches`, and `?verification=stalled` exclude it
- Failed-refresh client coverage: `reset()` after reading the snapshot keeps the current window plus the created row
- Preview: `/privacy` includes `created_at` next to the create source; `/admin` is 403 for the seed user (expected). Admin create-user is covered by unit tests because the preview seed is not an admin.

## System changes

Medium risk: extends admin create-user list refresh and the create-user JSON contract. Referral attribution is unchanged.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `f5a7f8b7` · **Head:** `26a9682a`

**Classification:** extends — admin `create_user` reseeds from the refreshed page, prepends the created row only when it matches active filters, and keeps the one-time setup link when list refresh fails. Mutation patching is unchanged.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | extends — create path reseeds from `payload.users` and prepends only when `createdUserInFilteredList` |
| `rbac` | auth | extends — create isolates list-refresh failure and returns filter membership plus `listRefreshFailed` |

### Change flow

Admin create-user still persists the account first. This PR changes the post-create list refresh and the client window update.

```mermaid
sequenceDiagram
	actor Admin
	participant appUi as app-ui
	participant rbac as rbac
	Admin->>appUi: submit create_user
	appUi->>rbac: POST /admin/users.json create_user
	rbac->>rbac: persist account and setup token
	rbac->>rbac: load created list row
	rbac->>rbac: adminUserMatchesListFilters
	rbac->>rbac: loadAdminUsersData
	alt list refresh succeeds
		rbac-->>appUi: users page plus createdUser and filter membership
		appUi->>appUi: reseed page and prepend created row only if it matches filters
	else list refresh fails
		rbac-->>appUi: createdUser setup link plus listRefreshFailed
		appUi->>appUi: read current window then reset so the list is not wiped
	end
```

### Before / after

**create_user success + list refresh**

```
before: applyMutationPayload maps existing rows (new user never appears)
after:  reseed from the refreshed page and prepend the created row only if filters match
```

**create_user success + list refresh throws**

```
before: shared catch returns 500 and drops the setup link
after:  200 with createdUser.setupLink and listRefreshFailed
        client keeps the current window instead of resetting then reading empty
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c5f9bae8-bdce-4cbe-be21-1c2cfccac035?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c5f9bae8-bdce-4cbe-be21-1c2cfccac035&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Admin user creation now preserves the created account and setup link even if refreshing the user list fails.
  - User-list updates now correctly reflect newly created users and changes to roles or verification status without incorrectly adding users from mutation responses.
  - Newly created users are added only when they match the active search and filter criteria.

- **Documentation**
  - Expanded privacy policy details for admin-configured notification events, exposed fields, exclusions, and lifecycle timestamps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->