### PR TITLE
Batch /community overview listing queries (KODY-7G)

### DIFF
--- a/packages/worker/src/community/community-index-overview.node.test.ts
+++ b/packages/worker/src/community/community-index-overview.node.test.ts
@@ -1,0 +1,178 @@
+import { DatabaseSync } from 'node:sqlite'
+import { expect, test } from 'vitest'
+import { type CommunityListingCategory } from '#universal/community-categories.ts'
+import { createD1FromSqlite } from '#worker/test-support/create-d1-from-sqlite.ts'
+import { ensureCommunityFlowSchema } from './community-flow-test-schema.ts'
+import {
+	insertCommunityListing,
+	listCommunityIndexOverviewCandidates,
+	upsertCommunityRating,
+} from './repo.ts'
+import { listCommunityIndexOverview } from './service.ts'
+import { type CommunityListingStatus } from './types.ts'
+
+async function createOverviewDb() {
+	const sqlite = new DatabaseSync(':memory:')
+	await ensureCommunityFlowSchema(createD1FromSqlite(sqlite))
+	const queries: Array<string> = []
+	const db = createD1FromSqlite(sqlite, { queries })
+	return { db, queries }
+}
+
+async function insertOverviewListing(
+	db: D1Database,
+	input: {
+		id: string
+		category: CommunityListingCategory
+		publishedAt: string
+		status?: CommunityListingStatus
+	},
+) {
+	await insertCommunityListing(db, {
+		id: input.id,
+		owner_user_id: 'owner-1',
+		package_id: `pkg-${input.id}`,
+		source_id: `src-${input.id}`,
+		kody_id: input.id,
+		name: `@owner/${input.id}`,
+		description: `${input.id} helpers`,
+		tags_json: '[]',
+		category: input.category,
+		search_text: null,
+		readme_content: null,
+		license: 'MIT',
+		pinned_commit: 'commit-1',
+		status: input.status ?? 'active',
+		published_at: input.publishedAt,
+	})
+}
+
+function publishedAtForDay(day: number) {
+	return `2026-07-${String(day).padStart(2, '0')}T00:00:00.000Z`
+}
+
+test('listCommunityIndexOverview loads shelves with one windowed listing query', async () => {
+	const { db, queries } = await createOverviewDb()
+	const env = { APP_DB: db } as Env
+
+	queries.length = 0
+	const empty = await listCommunityIndexOverview({ env, sort: 'newest' })
+	expect(empty).toEqual({
+		listings: [],
+		groups: [],
+		categoryCounts: {
+			integrations: 0,
+			examples: 0,
+			productivity: 0,
+			apps: 0,
+			utilities: 0,
+			other: 0,
+		},
+	})
+	expect(queries).toEqual([
+		"SELECT category, COUNT(*) AS listing_count FROM community_listings WHERE status = 'active' GROUP BY category",
+	])
+
+	for (const day of [1, 2, 3, 4, 5, 6, 7, 8]) {
+		await insertOverviewListing(db, {
+			id: `integration-${day}`,
+			category: 'integrations',
+			publishedAt: publishedAtForDay(day),
+		})
+	}
+	await insertOverviewListing(db, {
+		id: 'integration-delisted',
+		category: 'integrations',
+		publishedAt: publishedAtForDay(9),
+		status: 'delisted',
+	})
+	await insertOverviewListing(db, {
+		id: 'utility-3',
+		category: 'utilities',
+		publishedAt: publishedAtForDay(3),
+	})
+	await insertOverviewListing(db, {
+		id: 'utility-5',
+		category: 'utilities',
+		publishedAt: publishedAtForDay(5),
+	})
+	await upsertCommunityRating(db, {
+		id: 'rating-oldest',
+		listing_id: 'integration-1',
+		user_id: 'rater-1',
+		stars: 5,
+		adaptation_effort: 2,
+		note: null,
+	})
+
+	queries.length = 0
+	const newestTwoIntegrations = await listCommunityIndexOverviewCandidates(db, {
+		limitPerCategory: 2,
+		categories: ['integrations'],
+	})
+	expect(newestTwoIntegrations.map((listing) => listing.id)).toEqual([
+		'integration-8',
+		'integration-7',
+	])
+	expect(queries).toHaveLength(1)
+	expect(queries[0]).toContain('ROW_NUMBER()')
+	expect(queries[0]).toContain('PARTITION BY category')
+
+	queries.length = 0
+	const newest = await listCommunityIndexOverview({ env, sort: 'newest' })
+	expect(newest.groups.map((group) => [group.category, group.total])).toEqual([
+		['integrations', 8],
+		['utilities', 2],
+	])
+	expect(newest.groups[0]?.listings.map((listing) => listing.id)).toEqual([
+		'integration-8',
+		'integration-7',
+		'integration-6',
+		'integration-5',
+		'integration-4',
+		'integration-3',
+	])
+	expect(newest.groups[1]?.listings.map((listing) => listing.id)).toEqual([
+		'utility-5',
+		'utility-3',
+	])
+	expect(newest.listings.map((listing) => listing.id)).toEqual([
+		'integration-8',
+		'integration-7',
+		'integration-6',
+		'integration-5',
+		'integration-4',
+		'integration-3',
+		'utility-5',
+		'utility-3',
+	])
+	expect(newest.categoryCounts.integrations).toBe(8)
+	expect(newest.categoryCounts.examples).toBe(0)
+
+	const listingSelects = queries.filter((query) =>
+		query.includes('ROW_NUMBER()'),
+	)
+	expect(listingSelects).toHaveLength(1)
+	expect(listingSelects[0]).toContain('category_rank <= ?')
+	expect(
+		queries.filter((query) => query.includes('GROUP BY category')),
+	).toHaveLength(1)
+	expect(
+		queries.filter((query) => query.includes('FROM community_ratings')),
+	).toHaveLength(1)
+	expect(
+		queries.filter((query) => query.includes('FROM community_forks')),
+	).toHaveLength(1)
+	expect(queries).toHaveLength(4)
+
+	const best = await listCommunityIndexOverview({ env, sort: 'best' })
+	expect(best.groups[0]?.listings[0]).toEqual(
+		expect.objectContaining({
+			id: 'integration-1',
+			averageStars: 5,
+			ratingCount: 1,
+			forkCount: 0,
+		}),
+	)
+	expect(best.groups[0]?.listings).toHaveLength(6)
+})

--- a/packages/worker/src/community/community-service.node.test.ts
+++ b/packages/worker/src/community/community-service.node.test.ts
@@ -22,6 +22,7 @@ const mockModule = vi.hoisted(() => ({
 	getCommunityListingByOwnerAndKodyId: vi.fn(),
 	getCommunityListingById: vi.fn(),
 	listCommunityListingCandidates: vi.fn(),
+	listCommunityIndexOverviewCandidates: vi.fn(),
 	countActiveCommunityListingsByCategory: vi.fn(),
 	getCommunityRatingAggregatesByListingIds: vi.fn(),
 	countCommunityForksByListingIds: vi.fn(),
@@ -142,6 +143,8 @@ vi.mock('./repo.ts', async (importOriginal) => {
 			mockModule.getCommunityListingById(...args),
 		listCommunityListingCandidates: (...args: Array<unknown>) =>
 			mockModule.listCommunityListingCandidates(...args),
+		listCommunityIndexOverviewCandidates: (...args: Array<unknown>) =>
+			mockModule.listCommunityIndexOverviewCandidates(...args),
 		countActiveCommunityListingsByCategory: (...args: Array<unknown>) =>
 			mockModule.countActiveCommunityListingsByCategory(...args),
 		getCommunityRatingAggregatesByListingIds: (...args: Array<unknown>) =>
@@ -714,7 +717,11 @@ test('searchCommunityListings falls back to unfiltered candidates when LIKE pref
 	)
 })
 
-test('listCommunityIndexOverview queries only populated categories and uses SQL totals', async () => {
+test('listCommunityIndexOverview batches populated categories and uses SQL totals', async () => {
+	mockModule.listCommunityListingCandidates.mockClear()
+	mockModule.listCommunityIndexOverviewCandidates.mockClear()
+	mockModule.getCommunityRatingAggregatesByListingIds.mockClear()
+	mockModule.countCommunityForksByListingIds.mockClear()
 	const integrationListings = Array.from({ length: 8 }, (_, index) =>
 		sampleListing({
 			id: `listing-integration-${index}`,
@@ -738,13 +745,10 @@ test('listCommunityIndexOverview queries only populated categories and uses SQL 
 		utilities: 2,
 		other: 0,
 	})
-	mockModule.listCommunityListingCandidates.mockImplementation(
-		async (_db: unknown, input: { category?: string | null }) => {
-			if (input.category === 'integrations') return integrationListings
-			if (input.category === 'utilities') return [utilityListing]
-			throw new Error(`unexpected category ${String(input.category)}`)
-		},
-	)
+	mockModule.listCommunityIndexOverviewCandidates.mockResolvedValue([
+		...integrationListings,
+		utilityListing,
+	])
 	mockModule.getCommunityRatingAggregatesByListingIds.mockResolvedValue({})
 	mockModule.countCommunityForksByListingIds.mockResolvedValue({})
 
@@ -753,23 +757,21 @@ test('listCommunityIndexOverview queries only populated categories and uses SQL 
 		sort: 'newest',
 	})
 
-	expect(mockModule.listCommunityListingCandidates).toHaveBeenCalledTimes(2)
-	expect(mockModule.listCommunityListingCandidates).toHaveBeenCalledWith(
+	expect(mockModule.listCommunityListingCandidates).not.toHaveBeenCalled()
+	expect(mockModule.listCommunityIndexOverviewCandidates).toHaveBeenCalledTimes(
+		1,
+	)
+	expect(mockModule.listCommunityIndexOverviewCandidates).toHaveBeenCalledWith(
 		expect.anything(),
 		{
-			includeDelisted: false,
-			limit: communityIndexOverviewCandidateLimitPerCategory,
-			category: 'integrations',
+			limitPerCategory: communityIndexOverviewCandidateLimitPerCategory,
+			categories: ['integrations', 'utilities'],
 		},
 	)
-	expect(mockModule.listCommunityListingCandidates).toHaveBeenCalledWith(
-		expect.anything(),
-		{
-			includeDelisted: false,
-			limit: communityIndexOverviewCandidateLimitPerCategory,
-			category: 'utilities',
-		},
-	)
+	expect(
+		mockModule.getCommunityRatingAggregatesByListingIds,
+	).toHaveBeenCalledTimes(1)
+	expect(mockModule.countCommunityForksByListingIds).toHaveBeenCalledTimes(1)
 	expect(overview.groups.map((group) => [group.category, group.total])).toEqual(
 		[
 			['integrations', 40],

--- a/packages/worker/src/community/repo.ts
+++ b/packages/worker/src/community/repo.ts
@@ -637,6 +637,49 @@ export async function listCommunityListingCandidates(
 	return (rows.results ?? []).map(mapCommunityListingRow)
 }
 
+/**
+ * Unfiltered `/community` overview candidates: one windowed read of the
+ * newest `limitPerCategory` active listings per category. Optional
+ * `categories` keeps the window on populated shelves only.
+ */
+export async function listCommunityIndexOverviewCandidates(
+	db: D1Database,
+	input: {
+		limitPerCategory: number
+		categories?: ReadonlyArray<CommunityListingCategory>
+	},
+): Promise<Array<CommunityListingRecord>> {
+	const categories = input.categories ?? []
+	const categoryFilter =
+		categories.length > 0
+			? `AND community_listings.category IN (${categories.map(() => '?').join(', ')})`
+			: ''
+	const rows = await db
+		.prepare(
+			`WITH ranked AS (
+				SELECT
+					id,
+					ROW_NUMBER() OVER (
+						PARTITION BY category
+						ORDER BY published_at DESC
+					) AS category_rank
+				FROM community_listings
+				WHERE status = 'active'
+					${categoryFilter}
+			)
+			SELECT ${communityListingSelectColumns}
+			FROM community_listings
+			${communityListingSourceJoin}
+			INNER JOIN ranked
+				ON ranked.id = community_listings.id
+			WHERE ranked.category_rank <= ?
+			ORDER BY community_listings.published_at DESC`,
+		)
+		.bind(...categories, input.limitPerCategory)
+		.all<Record<string, unknown>>()
+	return (rows.results ?? []).map(mapCommunityListingRow)
+}
+
 export async function deleteCommunityListing(
 	db: D1Database,
 	input: {

--- a/packages/worker/src/community/service.ts
+++ b/packages/worker/src/community/service.ts
@@ -87,6 +87,7 @@ import {
 	insertCommunityReport,
 	countActiveCommunityListingsByCategory,
 	extractCommunityListingLikeTokens,
+	listCommunityIndexOverviewCandidates,
 	listCommunityListingCandidates,
 	listCommunityReports as listCommunityReportsFromDb,
 	listFeaturedCommunityListings as listFeaturedCommunityListingsFromDb,
@@ -152,10 +153,11 @@ export const COMMUNITY_SEARCH_MIN_RELEVANCE = 0.2
 
 // Community search/browse never scores more than this many listings in
 // memory; candidates are pre-filtered (including stored category) and
-// recency-ordered in SQL. Unfiltered All uses per-category overview
-// queries instead of this global window. Filtered browse ranks within
-// the newest 500 of that category. Revisit with a materialized score
-// column if a single category approaches this size.
+// recency-ordered in SQL. Unfiltered All uses one windowed overview
+// query (newest N per populated category) instead of this global
+// window. Filtered browse ranks within the newest 500 of that
+// category. Revisit with a materialized score column if a single
+// category approaches this size.
 export const COMMUNITY_SEARCH_CANDIDATE_LIMIT = 500
 
 function normalizeCommunityActivityPage(value: number | undefined) {
@@ -972,29 +974,41 @@ export async function listCommunityIndexOverview(input: {
 	const populated = communityListingCategories.filter(
 		(category) => categoryCounts[category] > 0,
 	)
-	const groups = await Promise.all(
-		populated.map(async (category) => {
-			const rows = await listCommunityListingCandidates(input.env.APP_DB, {
-				includeDelisted: false,
-				limit: communityIndexOverviewCandidateLimitPerCategory,
-				category,
-			})
-			const withAggregates = await attachListingAggregatesBatch(
-				input.env.APP_DB,
-				rows,
-			)
-			const visible = withAggregates
-				.sort((left, right) =>
-					compareCommunityListingsForSort(left, right, sort),
-				)
-				.slice(0, communityIndexOverviewLimitPerCategory)
-			return {
-				category,
-				listings: visible,
-				total: categoryCounts[category],
-			}
-		}),
+	if (populated.length === 0) {
+		return {
+			listings: [],
+			groups: [],
+			categoryCounts,
+		}
+	}
+	const rows = await listCommunityIndexOverviewCandidates(input.env.APP_DB, {
+		limitPerCategory: communityIndexOverviewCandidateLimitPerCategory,
+		categories: populated,
+	})
+	const withAggregates = await attachListingAggregatesBatch(
+		input.env.APP_DB,
+		rows,
 	)
+	const byCategory = new Map<
+		CommunityListingCategory,
+		Array<CommunityListingWithAggregates>
+	>()
+	for (const listing of withAggregates) {
+		const group = byCategory.get(listing.category) ?? []
+		group.push(listing)
+		byCategory.set(listing.category, group)
+	}
+	const groups = populated.map((category) => {
+		const candidates = byCategory.get(category) ?? []
+		const visible = candidates
+			.sort((left, right) => compareCommunityListingsForSort(left, right, sort))
+			.slice(0, communityIndexOverviewLimitPerCategory)
+		return {
+			category,
+			listings: visible,
+			total: categoryCounts[category],
+		}
+	})
 	return {
 		listings: groups.flatMap((group) => group.listings),
 		groups,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop the unfiltered community index from issuing one near-identical `community_listings` SELECT per populated category on `GET /community`.

## Why

Sentry performance issue [KODY-7G](https://kent-c-dodds-tech-llc.sentry.io/issues/7721609164/) (`N+1 Query` on transaction `GET /community`, event `a6de49895bcd4dcaa783c24bc36b81b7`) shows:

- cause span: `SELECT category, COUNT(*) AS listing_count FROM community_listings WHERE status = 'active' GROUP BY category`
- 6 repeating offender spans: the full listing SELECT (`communityListingSelectColumns` + source join), `numRepeatingSpans: 6`

In repo code, `listCommunityIndexOverview` loaded those counts, then `Promise.all` over populated categories and called `listCommunityListingCandidates` (limit 50) plus `attachListingAggregatesBatch` once per category. Six populated categories produced exactly this N+1.

## Summary

- Add `listCommunityIndexOverviewCandidates`: one SQLite window (`ROW_NUMBER() OVER (PARTITION BY category ORDER BY published_at DESC)`) that returns up to 50 newest active listings per populated category.
- Attach rating/fork aggregates once for the combined candidate set.
- Preserve shelf behavior: 6 cards per populated category after Best/Newest sort, SQL totals from the count query, empty categories omitted.
- Filtered/search paths still use `listCommunityListingCandidates`.

## Testing

- `packages/worker/src/community/community-index-overview.node.test.ts` asserts one windowed listing SELECT, one ratings IN, one forks IN, shelf shape, SQL totals, delisted exclusion, and Best vs Newest.
- Existing mocked overview test now expects one candidate call (not one per category).
- Commit hook: worker typecheck green.
- Pre-push: `test:node` 941 files / 3004 tests; `test:workers` 94 files / 342 tests.
- Focused re-run: the two community overview node files, 30 tests passed.
- CI Validate (Static, Node, Workers, MCP, E2E) and Cursor Bugbot are green.
- Preview `kody-pr-2223` (`https://kody-pr-2223.kody-a99.workers.dev`): logged-in `GET /community.json` returns `groups: []` on the empty isolated catalog; `?category=integrations` still returns `groups: null`; `GET /community` 200 shows "The shelf is waiting."

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends community-listings</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `21fac46f` · **Head:** `3f82c549`

**Classification:** extends — unfiltered `/community` overview still returns the same shelves and SQL totals, but candidate loading is one windowed listing read plus one aggregate batch instead of one SELECT (and one aggregate batch) per populated category.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `community-listings` | assistant | extends — new `listCommunityIndexOverviewCandidates` window query, single aggregate attach |

### Change flow

Unfiltered `/community` loads category counts, then one partitioned candidate read, then one ratings/forks batch.

```mermaid
sequenceDiagram
	actor Browser
	participant communityListings as community-listings
	participant d1AppDb as d1-app-db
	Browser->>communityListings: GET /community unfiltered overview
	communityListings->>d1AppDb: COUNT active listings GROUP BY category
	communityListings->>d1AppDb: ROW_NUMBER window 50 newest per populated category
	communityListings->>d1AppDb: one ratings IN and one forks IN
	communityListings-->>Browser: shelves of 6 plus SQL totals
```

### Before / after

| Step | Before | After |
| --- | --- | --- |
| Category totals | 1 `GROUP BY category` count | unchanged |
| Listing candidates | 1 full listing SELECT per populated category | 1 `ROW_NUMBER() OVER (PARTITION BY category)` SELECT |
| Rating/fork aggregates | 1 batch per category | 1 batch for the combined candidate set |
| Filtered/search browse | `listCommunityListingCandidates` | unchanged |

### Invariants

Public community reads stay deliberate: only `status = 'active'` rows enter the window, empty categories stay omitted, and chip/"See all" totals still come from the SQL count query.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b932e42b-4b0e-4b03-b5e2-e2fc20f18fc1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b932e42b-4b0e-4b03-b5e2-e2fc20f18fc1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved loading of the community index overview by retrieving listings more efficiently in a single operation.
  - Category sections now load together more consistently, with per-category result limits maintained.
  - Empty community indexes return promptly without unnecessary processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->