### PR TITLE
Keep a prepended created admin user when selecting a row

### DIFF
--- a/packages/worker/client/routes/admin-users-shared.node.test.ts
+++ b/packages/worker/client/routes/admin-users-shared.node.test.ts
@@ -10,6 +10,7 @@ import { planNames } from '#universal/plans.ts'
 import {
 	nextAdminUsersWindowAfterCreate,
 	nextAdminUsersWindowAfterMutation,
+	shouldReseedAdminUsersWindow,
 } from './admin-users-shared.ts'
 
 function stableUserId(id: number) {
@@ -109,6 +110,30 @@ test('create reseeds from the refreshed page and prepends a user that paging omi
 	])
 	expect(omittedFromPageOne.totalCount).toBe(21)
 	expect(omittedFromPageOne.hasMore).toBe(true)
+
+	const omittedLastRow = nextAdminUsersWindowAfterCreate({
+		currentItems: [existing],
+		currentHasMore: true,
+		currentTotal: 20,
+		payload: {
+			...basePayload,
+			users: [existing],
+			total: 2,
+			createdUserInFilteredList: true,
+		},
+	})
+	expect(omittedLastRow.items.map((item) => item.username)).toEqual([
+		'created',
+		'existing',
+	])
+	expect(omittedLastRow.hasMore).toBe(false)
+	expect(shouldReseedAdminUsersWindow('q=&role=&verification=', '')).toBe(true)
+	expect(
+		shouldReseedAdminUsersWindow(
+			'q=&role=&verification=',
+			'q=&role=&verification=',
+		),
+	).toBe(false)
 
 	const refreshFailed = nextAdminUsersWindowAfterCreate({
 		currentItems: [existing],

--- a/packages/worker/client/routes/admin-users-shared.ts
+++ b/packages/worker/client/routes/admin-users-shared.ts
@@ -116,18 +116,27 @@ export function nextAdminUsersWindowAfterCreate(input: {
 		!alreadyListed &&
 		input.payload.createdUserInFilteredList === true
 	const items = canInsert ? [created, ...baseItems] : baseItems
-	if (input.payload.listRefreshFailed) {
-		return {
-			items,
-			hasMore: input.currentHasMore,
-			totalCount: canInsert ? input.currentTotal + 1 : input.currentTotal,
-		}
-	}
+	const totalCount = input.payload.listRefreshFailed
+		? canInsert
+			? input.currentTotal + 1
+			: input.currentTotal
+		: input.payload.total
 	return {
 		items,
-		hasMore: input.payload.page * input.payload.pageSize < input.payload.total,
-		totalCount: input.payload.total,
+		hasMore:
+			input.payload.listRefreshFailed && !canInsert
+				? input.currentHasMore
+				: items.length < totalCount,
+		totalCount,
 	}
+}
+
+/** Filter changes reseed; selection-only navigations keep the loaded window. */
+export function shouldReseedAdminUsersWindow(
+	listKey: string,
+	lastLoadedListKey: string,
+) {
+	return listKey !== lastLoadedListKey
 }
 
 /**

--- a/packages/worker/client/routes/admin-users.tsx
+++ b/packages/worker/client/routes/admin-users.tsx
@@ -33,6 +33,7 @@ import {
 	nextAdminUsersWindowAfterCreate,
 	nextAdminUsersWindowAfterMutation,
 	parseSelectedStableUserId,
+	shouldReseedAdminUsersWindow,
 	readFilterState,
 } from './admin-users-shared.ts'
 import {
@@ -145,10 +146,9 @@ export function AdminUsersRoute(handle: Handle) {
 		availableRoles = payload.availableRoles
 		availablePlans = payload.availablePlans
 		const listKey = getListKey(href)
-		// Selection-only navigations deep in the scroll window keep the
-		// already-loaded pages; anything else reseeds from page one so
-		// filter changes and plain revisits always show fresh data.
-		if (listKey !== lastLoadedListKey || loadedThroughPage <= 1) {
+		// Filter changes reseed. Selection-only navigations keep the window
+		// so a created row prepended off page one does not vanish.
+		if (shouldReseedAdminUsersWindow(listKey, lastLoadedListKey)) {
 			loadedThroughPage = payload.page
 			// reset() invalidates any in-flight load-more so a stale page
 			// fetched for the previous filters can never append into the


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Keep a newly created admin user visible in the users table after the admin selects a row.

## Why

#2222 prepends a newest account that oldest-first paging left off page one. Bugbot on that head found that opening any user refetches route data and `applyPayload` reseeds page one whenever `loadedThroughPage <= 1`, so the prepended row disappears. A second, low-severity note: Load more can still show when the prepended window already contains every filtered user.

## Summary

- Selection-only navigations keep the loaded admin-users window. Filter changes still reseed.
- After create, `hasMore` follows the actual window length so Load more hides when the prepended row was the only missing account.

## Testing

- `npx vitest run --project node-unit packages/worker/client/routes/admin-users-shared.node.test.ts`
- Preview https://kody-pr-2225.kody-a99.workers.dev: `/health` is the merge of `fbf6dfb7`; seed login works; `GET /admin` and `GET /admin/users.json` are 403 (expected, seed is not admin). Create-then-select is covered by unit tests.
- Local pre-push hit an unrelated `router-specificity` 405-vs-404 failure from the Remix rc.2 upgrade on `main` (`#2224`); this diff does not touch the router.

## System changes

Medium risk: extends the admin-users list window so selection no longer reseeds page one. Referral attribution is unchanged.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `c9cfa8c1` · **Head:** `fbf6dfb7`

**Classification:** extends — admin users selection keeps the loaded window, so a created row prepended off page one stays visible.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | extends — selection no longer reseeds page one; create `hasMore` uses window length |

### Change flow

Selecting a user still refetches route data. This PR stops that fetch from replacing a window that already includes a prepended created row.

```mermaid
sequenceDiagram
	actor Admin
	participant appUi as app-ui
	Admin->>appUi: create user
	appUi->>appUi: reseed page one and prepend created row if omitted
	Admin->>appUi: open a user
	appUi->>appUi: refetch route data
	alt same list filters
		appUi->>appUi: keep loaded window including prepended row
	else filters changed
		appUi->>appUi: reseed from page one
	end
```

### Before / after

**create then select a user**

```
before: applyPayload reseeds page one because loadedThroughPage is 1
after:  same list key keeps the prepended created row
```

**create prepends the only missing row**

```
before: hasMore stays true from page * pageSize < total
after:  hasMore is items.length < total
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c5f9bae8-bdce-4cbe-be21-1c2cfccac035?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c5f9bae8-bdce-4cbe-be21-1c2cfccac035&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Newly created admin users remain visible in the user list, including when they fall outside the currently loaded page.
  - Pagination indicators now accurately reflect whether additional users are available after creating a user.
  - Applying a new filter refreshes the list appropriately, while selection-only navigation preserves the currently loaded results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->