### PR TITLE
Prefer maxres YouTube posters for the homepage hero

### DIFF
--- a/docs/contributing/architecture/youtube-watch.md
+++ b/docs/contributing/architecture/youtube-watch.md
@@ -11,7 +11,9 @@ banner stay external and do not get rewritten to `/?youtubeId=`.
   player.
 - **Homepage hero**: `/` two-column player + video chooser
   (`landing-hero-video.tsx`). Demo ids are always allowlisted.
-- **Thumbnail proxy**: `GET /youtube-thumb/:videoId` (404 unless allowlisted)
+- **Thumbnail proxy**: `GET /youtube-thumb/:videoId` (404 unless allowlisted).
+  Fetches `maxresdefault.jpg` first (1280×720), then `sddefault.jpg`, then
+  `hqdefault.jpg` when a higher quality is missing.
 - **Admin helper**: `/admin/banners` paste a watch URL to fill `/?youtubeId=` +
   the first-party thumb path
 

--- a/packages/worker/src/app/handlers/youtube-thumb.node.test.ts
+++ b/packages/worker/src/app/handlers/youtube-thumb.node.test.ts
@@ -44,9 +44,57 @@ test('youtube thumb proxy serves allowlisted first-party bytes', async () => {
 	expect(response.headers.get('Content-Type')).toBe('image/jpeg')
 	expect(response.headers.get('Cache-Control')).toContain('max-age=86400')
 	expect(new Uint8Array(await response.arrayBuffer())).toEqual(bytes)
+	expect(fetchMock).toHaveBeenCalledTimes(1)
 	expect(fetchMock).toHaveBeenCalledWith(
-		`https://i.ytimg.com/vi/${videoId}/hqdefault.jpg`,
+		`https://i.ytimg.com/vi/${videoId}/maxresdefault.jpg`,
 		expect.objectContaining({ signal: expect.any(AbortSignal) }),
 	)
+	fetchMock.mockRestore()
+})
+
+test('youtube thumb proxy falls back when maxres is missing', async () => {
+	const bytes = Uint8Array.from([0xff, 0xd8, 0xff, 0xdb])
+	const fetchMock = vi
+		.spyOn(globalThis, 'fetch')
+		.mockImplementation(async (input) => {
+			const url = String(input)
+			if (url.endsWith('/maxresdefault.jpg')) {
+				return new Response('Not Found', { status: 404 })
+			}
+			if (url.endsWith('/sddefault.jpg')) {
+				return new Response(bytes, {
+					headers: { 'Content-Type': 'image/jpeg' },
+				})
+			}
+			return new Response('Not Found', { status: 404 })
+		})
+	const env = {
+		YOUTUBE_ALLOWED_PLAYLIST_IDS: 'none',
+		YOUTUBE_ALLOWED_VIDEO_IDS: videoId,
+	} as Env
+	const response = await callHandler(env, videoId)
+	expect(response.status).toBe(200)
+	expect(new Uint8Array(await response.arrayBuffer())).toEqual(bytes)
+	expect(fetchMock.mock.calls.map(([input]) => String(input))).toEqual([
+		`https://i.ytimg.com/vi/${videoId}/maxresdefault.jpg`,
+		`https://i.ytimg.com/vi/${videoId}/sddefault.jpg`,
+	])
+	fetchMock.mockRestore()
+})
+
+test('youtube thumb proxy 404s when every thumbnail quality is missing', async () => {
+	const fetchMock = vi
+		.spyOn(globalThis, 'fetch')
+		.mockResolvedValue(new Response('Not Found', { status: 404 }))
+	const env = {
+		YOUTUBE_ALLOWED_PLAYLIST_IDS: 'none',
+		YOUTUBE_ALLOWED_VIDEO_IDS: videoId,
+	} as Env
+	expect((await callHandler(env, videoId)).status).toBe(404)
+	expect(fetchMock.mock.calls.map(([input]) => String(input))).toEqual([
+		`https://i.ytimg.com/vi/${videoId}/maxresdefault.jpg`,
+		`https://i.ytimg.com/vi/${videoId}/sddefault.jpg`,
+		`https://i.ytimg.com/vi/${videoId}/hqdefault.jpg`,
+	])
 	fetchMock.mockRestore()
 })

--- a/packages/worker/src/app/handlers/youtube-thumb.ts
+++ b/packages/worker/src/app/handlers/youtube-thumb.ts
@@ -2,7 +2,7 @@ import { type Action } from 'remix/router'
 import { type routes } from '#universal/routes.ts'
 import {
 	isYoutubeVideoId,
-	youtubeThumbnailSourceUrl,
+	youtubeThumbnailSourceUrls,
 } from '#universal/youtube-watch.ts'
 import { resolveYoutubeWatchAllowedVideoIds } from '#app/youtube-watch-allowlist.ts'
 
@@ -25,10 +25,8 @@ export function createYoutubeThumbHandler(env: Env) {
 			}
 
 			try {
-				const upstream = await fetch(youtubeThumbnailSourceUrl(videoId), {
-					signal: AbortSignal.timeout(2_500),
-				})
-				if (!upstream.ok) return notFound()
+				const upstream = await fetchFirstYoutubeThumbnail(videoId)
+				if (!upstream) return notFound()
 				const bytes = await upstream.arrayBuffer()
 				const contentType = upstream.headers.get('Content-Type') ?? 'image/jpeg'
 				return new Response(request.method === 'HEAD' ? null : bytes, {
@@ -44,6 +42,17 @@ export function createYoutubeThumbHandler(env: Env) {
 			}
 		},
 	} satisfies Action<typeof routes.youtubeThumb>
+}
+
+async function fetchFirstYoutubeThumbnail(
+	videoId: string,
+): Promise<Response | null> {
+	const signal = AbortSignal.timeout(2_500)
+	for (const url of youtubeThumbnailSourceUrls(videoId)) {
+		const upstream = await fetch(url, { signal })
+		if (upstream.ok) return upstream
+	}
+	return null
 }
 
 function notFound() {

--- a/packages/worker/universal/youtube-watch.node.test.ts
+++ b/packages/worker/universal/youtube-watch.node.test.ts
@@ -12,6 +12,7 @@ import {
 	youtubeNocookieEmbedUrl,
 	youtubeThumbPath,
 	youtubeThumbnailSourceUrl,
+	youtubeThumbnailSourceUrls,
 	youtubeWatchHref,
 } from './youtube-watch.ts'
 
@@ -135,8 +136,13 @@ test('banner images rewrite YouTube hosts to first-party thumb paths', () => {
 		}),
 	).toBe('/brand/launch.png')
 	expect(youtubeThumbnailSourceUrl(videoId)).toBe(
-		`https://i.ytimg.com/vi/${videoId}/hqdefault.jpg`,
+		`https://i.ytimg.com/vi/${videoId}/maxresdefault.jpg`,
 	)
+	expect(youtubeThumbnailSourceUrls(videoId)).toEqual([
+		`https://i.ytimg.com/vi/${videoId}/maxresdefault.jpg`,
+		`https://i.ytimg.com/vi/${videoId}/sddefault.jpg`,
+		`https://i.ytimg.com/vi/${videoId}/hqdefault.jpg`,
+	])
 	expect(youtubeNocookieEmbedUrl(videoId)).toBe(
 		`https://www.youtube-nocookie.com/embed/${videoId}?autoplay=1&rel=0`,
 	)

--- a/packages/worker/universal/youtube-watch.ts
+++ b/packages/worker/universal/youtube-watch.ts
@@ -28,8 +28,27 @@ export function youtubeThumbPath(videoId: string): string {
 	return `${youtubeThumbPathPrefix}${videoId}`
 }
 
+const youtubeThumbnailFileNames = [
+	'maxresdefault.jpg',
+	'sddefault.jpg',
+	'hqdefault.jpg',
+] as const
+
 export function youtubeThumbnailSourceUrl(videoId: string): string {
-	return `https://i.ytimg.com/vi/${videoId}/hqdefault.jpg`
+	return youtubeThumbnailUrl(videoId, 'maxresdefault.jpg')
+}
+
+export function youtubeThumbnailSourceUrls(videoId: string): Array<string> {
+	return youtubeThumbnailFileNames.map((fileName) =>
+		youtubeThumbnailUrl(videoId, fileName),
+	)
+}
+
+function youtubeThumbnailUrl(
+	videoId: string,
+	fileName: (typeof youtubeThumbnailFileNames)[number],
+): string {
+	return `https://i.ytimg.com/vi/${videoId}/${fileName}`
 }
 
 export function youtubePlaylistFeedUrl(playlistId: string): string {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Serve sharper homepage hero and lite-player posters without changing the first-party `/youtube-thumb/:videoId` contract.

## Why

`youtubeThumbnailSourceUrl` hardcoded `hqdefault.jpg` (480×360). The lite player and hero chooser stretch that through `/youtube-thumb/{id}`, so the poster looked soft. All four current hero ids already publish `maxresdefault.jpg` (1280×720).

## Summary

- Prefer `https://i.ytimg.com/vi/{id}/maxresdefault.jpg`
- Fall back to `sddefault.jpg` then `hqdefault.jpg` when a higher quality is missing (404 / not ok)
- `/youtube-thumb` proxy walks that list and returns the first successful JPEG
- Tests cover maxres-first, sd fallback, and all-qualities-missing 404

## Testing

- `youtube-watch.node.test.ts` and `youtube-thumb.node.test.ts` updated
- `test:node` + `test:workers` passed on push (`test:push` hook)

## System changes

Low risk. Same allowlist, route, and response shape. Only the upstream ytimg filename order changes.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `21fac46f` · **Head:** `5f642e12`

**Classification:** composes — same `/youtube-thumb/:videoId` route, allowlist, and JPEG response shape. Only the upstream ytimg filename order changes.

### Primitives touched

| Primitive | Group    | Impact                                                                 |
| --------- | -------- | ---------------------------------------------------------------------- |
| `app-ui`  | surfaces | composes — first-party thumb proxy tries maxres, then sd, then hq     |

### Change flow

Homepage lite-player and hero-chooser posters still load `/youtube-thumb/:id`. The proxy now asks YouTube for `maxresdefault.jpg` first and walks down to `hqdefault.jpg` when a higher quality is missing.

```mermaid
sequenceDiagram
	actor Browser
	participant appUi as app-ui
	Browser->>appUi: GET /youtube-thumb/:videoId
	appUi->>appUi: fetch maxresdefault.jpg from ytimg
	alt maxres missing
		appUi->>appUi: fetch sddefault.jpg then hqdefault.jpg
	end
	appUi-->>Browser: first-party JPEG poster
```

### Before / after

| | Upstream file |
| --- | --- |
| Before | `hqdefault.jpg` only (480×360) |
| After | `maxresdefault.jpg` → `sddefault.jpg` → `hqdefault.jpg` |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4c0214b8-2c3c-42b7-8e79-e7d96a9e6df9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4c0214b8-2c3c-42b7-8e79-e7d96a9e6df9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - YouTube thumbnails now prioritize the highest-resolution image available.
  - If the highest-quality thumbnail is unavailable, the system automatically falls back to lower-resolution alternatives.
  - Thumbnails now return a not-found response only when all supported image qualities are unavailable.

- **Documentation**
  - Updated the YouTube watch overlay architecture documentation to describe the thumbnail fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->