### PR TITLE
Keep account tables from horizontally scrolling at normal widths

### DIFF
--- a/packages/worker/client/routes/record-table-controls.tsx
+++ b/packages/worker/client/routes/record-table-controls.tsx
@@ -174,6 +174,11 @@ export function recordCellClamp(ch: number) {
 
 /** Date/duration cell: one token, aligned figures, quieter than the name. */
 export const recordStampCss = {
+	display: 'block',
+	minWidth: 0,
+	maxWidth: '100%',
+	overflow: 'hidden',
+	textOverflow: 'ellipsis',
 	whiteSpace: 'nowrap' as const,
 	fontVariantNumeric: 'tabular-nums',
 	color: colors.textMuted,

--- a/packages/worker/client/routes/record-table.node.test.ts
+++ b/packages/worker/client/routes/record-table.node.test.ts
@@ -254,6 +254,7 @@ test('record table keeps container drops, row links, and expand/pane selection c
 		}),
 	)
 	expect(overflowHtml).toContain('table-layout: fixed')
+	expect(overflowHtml).toContain('overflow-x: hidden')
 	expect(overflowHtml).toContain('@container (max-width: 400px)')
 	expect(overflowHtml).toContain('overflow-x: auto')
 	expect(overflowHtml).toContain('overflow: clip')

--- a/packages/worker/client/routes/record-table.node.test.ts
+++ b/packages/worker/client/routes/record-table.node.test.ts
@@ -243,7 +243,8 @@ test('record table keeps container drops, row links, and expand/pane selection c
 		createHtml.indexOf('</table>'),
 	)
 
-	// Wide rows stay reachable via horizontal overflow.
+	// The table stays in the pane (`table-layout: fixed`). Horizontal overflow
+	// is only for a very narrow container, not for five nowrap columns.
 	const overflowHtml = await renderToString(
 		jsx(RecordTable, {
 			mode: 'expand',
@@ -252,6 +253,8 @@ test('record table keeps container drops, row links, and expand/pane selection c
 			rows,
 		}),
 	)
+	expect(overflowHtml).toContain('table-layout: fixed')
+	expect(overflowHtml).toContain('@container (max-width: 400px)')
 	expect(overflowHtml).toContain('overflow-x: auto')
 	expect(overflowHtml).toContain('overflow: clip')
 })

--- a/packages/worker/client/routes/record-table.tsx
+++ b/packages/worker/client/routes/record-table.tsx
@@ -348,6 +348,7 @@ const primaryCellCss = {
 	'@container (max-width: 620px)': {
 		whiteSpace: 'normal',
 		overflow: 'visible',
+		overflowWrap: 'anywhere',
 	},
 }
 

--- a/packages/worker/client/routes/record-table.tsx
+++ b/packages/worker/client/routes/record-table.tsx
@@ -218,8 +218,11 @@ const paneCss = {
 const tableScrollerCss = {
 	width: '100%',
 	minWidth: 0,
-	overflowX: 'auto' as const,
-	WebkitOverflowScrolling: 'touch' as const,
+	overflowX: 'hidden' as const,
+	'@container (max-width: 400px)': {
+		overflowX: 'auto' as const,
+		WebkitOverflowScrolling: 'touch' as const,
+	},
 }
 
 const toolbarCss = {
@@ -250,7 +253,7 @@ const countCss = {
 
 const tableCss = {
 	width: '100%',
-	minWidth: '100%',
+	tableLayout: 'fixed' as const,
 	borderCollapse: 'collapse' as const,
 	fontSize: typography.fontSize.sm,
 }
@@ -276,14 +279,17 @@ const cellCss = {
 	borderBottom: `1px solid ${colors.border}`,
 	verticalAlign: 'middle' as const,
 	color: colors.text,
+	overflow: 'hidden',
+	textOverflow: 'ellipsis',
 }
 
 /**
  * Below 620px the same `<table>` becomes a list of cards — no duplicate DOM.
  * Cells carry their own label from `data-label`; the primary cell is the
- * card's heading and keeps none. Column `drop` priorities shed fields first;
- * when nowrap content still overflows the pane, the table scroller takes over
- * with horizontal overflow rather than clipping under `overflow: hidden`.
+ * card's heading and keeps none. Column `drop` priorities shed fields first.
+ * `table-layout: fixed` keeps the table in the pane at normal widths; the
+ * scroller only allows horizontal overflow on a very narrow container
+ * (unbreakable leftovers, not five readable columns fighting for 26ch each).
  */
 const cardFallbackCss = {
 	'@container (max-width: 620px)': {
@@ -339,12 +345,9 @@ const primaryCellCss = {
 	...cellCss,
 	fontWeight: 620,
 	whiteSpace: 'nowrap' as const,
-	// Let the cell shrink so sibling columns and the scroller can claim width
-	// instead of the primary name forcing the whole table past the pane.
-	maxWidth: '28rem',
 	'@container (max-width: 620px)': {
 		whiteSpace: 'normal',
-		maxWidth: 'none',
+		overflow: 'visible',
 	},
 }
 
@@ -367,6 +370,9 @@ const recordRowCss = {
 		backgroundColor: colors.background,
 		boxShadow: `inset 3px 0 0 ${colors.primary}`,
 		borderBottom: `1px solid ${colors.border}`,
+		// The editor (datetime-local, combobox, long help text) must not
+		// contribute min-content width back into the table.
+		minWidth: 0,
 	},
 }
 
@@ -383,6 +389,7 @@ export const recordBodyCss = {
 	display: 'grid',
 	gap: spacing.lg,
 	minWidth: 0,
+	maxWidth: '100%',
 }
 
 const footerCss = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop the secrets (and other account) record table from horizontally scrolling except on a very narrow container.

## Why

The expanded secret editor sits inside an auto-layout table. Nowrap cells, 26ch clamps, and Chrome’s `datetime-local` min-content made the table wider than the 200px-railed content column, so the pane grew a horizontal scrollbar at ordinary laptop widths.

## Summary

- `RecordTable` uses `table-layout: fixed` so columns share the pane instead of sizing to content.
- Horizontal overflow is allowed only below a `400px` container query.
- Expanded-record cells keep `min-width: 0` so the editor cannot stretch the table.
- Nowrap duration stamps ellipsize inside the column; card-mode names wrap unbroken strings.

## Testing

- `vitest run --project node-unit packages/worker/client/routes/record-table.node.test.ts`
- Preview `https://kody-pr-2230.kody-a99.workers.dev/account/secrets/user/layoutCheckKey` as the seed user: no horizontal overflow at 1440, 1100, or 390

![Preview secrets editor at 1440px, no horizontal scroll](https://cursor.com/artifacts/c/art-42aca374-770c-4cd1-aed7-cd6067199409)
![Preview secrets editor at 1100px, no horizontal scroll](https://cursor.com/artifacts/c/art-02ae2d91-6768-451c-a678-7312443f43d1)
![Preview secrets editor at 390px card layout, no horizontal scroll](https://cursor.com/artifacts/c/art-6d7cf29b-788a-424d-8d27-af803265b27a)

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `372239e9` · **Head:** `57787f1d`

**Classification:** composes — CSS on the existing account RecordTable. No primitive contract, storage, or auth change.

### Primitives touched

| Primitive | Group    | Impact                                                         |
| --------- | -------- | -------------------------------------------------------------- |
| `app-ui`  | surfaces | composes — RecordTable layout so list/detail screens stay in-pane |

### Change flow

Account list/detail tables size to the pane. Horizontal scroll is only a narrow-container fallback.

```mermaid
sequenceDiagram
	actor User
	participant appUi as app-ui
	User->>appUi: GET /account/secrets/:id
	appUi->>appUi: RecordTable expand with table-layout fixed
	Note over appUi: overflow-x auto only under 400px container
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a5f488d8-35eb-4633-b2c9-d1b8ff7e25cd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a5f488d8-35eb-4633-b2c9-d1b8ff7e25cd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved record table layout across different screen sizes.
  * Long cell content now truncates with ellipses or wraps within narrow cards instead of widening the table.
  * Horizontal overflow is hidden by default, with touch scrolling available in very narrow containers.
  * Expanded records and embedded content remain constrained within the table pane.
  * Fixed-layout tables provide more consistent column sizing and prevent content from expanding the surrounding layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->