### PR TITLE
Delete leftover community_forks on failed fork cleanup and packageDelete

### DIFF
--- a/docs/contributing/adding-capabilities.md
+++ b/docs/contributing/adding-capabilities.md
@@ -252,6 +252,7 @@ rule.
 - `adminPlatformFeedbackGet`
 - `adminPlatformFeedbackUpdate`
 - `adminCommunityActivityList`
+- `adminCommunityOrphanForksCleanup`
 - `adminPackageCodemodScan`
 - `adminPackageCodemodDryRun`
 - `adminPackageCodemodApply`

--- a/docs/contributing/architecture/authorization.md
+++ b/docs/contributing/architecture/authorization.md
@@ -355,6 +355,11 @@ rating notes, private package source, and all unrelated account content. Fork
 rows snapshot the public listing name and kody id so intentional listing
 deletion does not erase retained fork provenance; legacy orphan rows whose
 listing identity cannot be recovered use explicit deleted/unknown placeholders.
+`adminCommunityOrphanForksCleanup` is a separate audited maintenance mutation
+that previews or deletes leftover `community_forks` rows whose entity source and
+saved package are both gone. It can name those fork, package, and source ids
+because operators need them to confirm the row. Healthy inert forks (source
+present, no `saved_packages` row) are not orphans.
 
 New fork and rating writes enqueue an opaque activity id for durable
 `community.activity.recorded` package-subscription delivery. The Queue consumer

--- a/docs/contributing/community-packages.md
+++ b/docs/contributing/community-packages.md
@@ -202,6 +202,10 @@ Artifacts repo is missing, persist falls back to the older full-tree snapshot
 sync. Isolate memory / Artifacts `MEMORY_LIMIT` failures surface as
 `CommunityForkResourceLimitError` (honest UI/MCP copy; fork count does not
 increment). Records `community_forks` — **without** inserting `saved_packages`.
+Failed persist cleanup deletes the dest Artifacts repo, the inert entity source,
+any `package_kody_id_redirects` for the allocated package id, and the matching
+`community_forks` row so a leftover metadata row cannot inflate `fork_count` or
+block a retry.
 
 `communityFork` returns request-scoped `serverTiming` entries
 (`{ name, durationMs }`), the same shape as `execute`. They are not written to
@@ -259,7 +263,12 @@ Capabilities:
 - `communitySetFeatured` (admin-only via `requiredRole`)
 
 The admin domain also exposes `adminCommunityActivityList`, guarded by
-`requiredRole: 'admin'`, for the narrow operator activity feed.
+`requiredRole: 'admin'`, for the narrow operator activity feed, and
+`adminCommunityOrphanForksCleanup` for leftover `community_forks` rows whose
+inert entity source and saved package are both gone. Healthy community forks
+stay inert (no `saved_packages` row) and keep an `entity_sources` row, so a
+missing package alone is not an orphan. `apply` defaults to false (preview);
+optional `fork_ids` still skip any row that still has a source or package.
 
 Register the domain in `builtinDomains` and `capabilityDomainNames` like other
 builtin domains (see [Adding capabilities](./adding-capabilities.md)). Do not
@@ -387,7 +396,9 @@ browse intentionally ranks only the newest 500 candidates. The reported
 production mismatch for `@kentcdodds/github` was therefore consistent with a
 data snapshot/cache artifact rather than a defect in the aggregate SQL; the
 worker integration test pins that a successful fork increments the surfaced
-count.
+count. Failed fork cleanup, `packageDelete` of the forked copy, and
+`adminCommunityOrphanForksCleanup` remove the matching `community_forks` row, so
+the live count drops without a separate recount.
 
 `computeCommunityBayesianScore` in `service.ts` implements the prior so a few
 5-star ratings do not beat many good ratings.

--- a/docs/guides/package-lifecycle.md
+++ b/docs/guides/package-lifecycle.md
@@ -222,7 +222,8 @@ explicitly asked to delete that package.
 1. Load the package with `packageGet` or `packageList`.
 2. Show the owner the package name and that delete removes jobs, storage,
    secrets, tokens, the public listing if one exists, and Artifacts repos.
-   Existing forks keep their copies. This cannot be undone.
+   Existing forks of a listing keep their copies. A community fork record for
+   the deleted package itself is removed. This cannot be undone.
 3. Wait for the owner to type the package name.
 4. Call `packageDelete` with `package_id` and `confirm_name` matching that name
    exactly. The capability refuses and names the expected value when

--- a/docs/use/community-packages.md
+++ b/docs/use/community-packages.md
@@ -48,8 +48,9 @@ on that review.
 - Making a package **private** unlists it: public URLs 404; existing forks keep
   their copies. Type the package slug to confirm (`confirm_name` for agents).
 - Deleting a package (`packageDelete` or **Delete package** on the package page)
-  also unlists it. Type the package name to confirm. Existing forks keep their
-  copies.
+  also unlists it. Type the package name to confirm. Existing forks of that
+  listing keep their copies. If the deleted package was itself a community fork,
+  that fork record is removed and the listing's fork count drops.
 - Hidden and locked stay separate from visibility.
 
 ### Icon

--- a/packages/worker/src/community/community-service.node.test.ts
+++ b/packages/worker/src/community/community-service.node.test.ts
@@ -52,6 +52,9 @@ const mockModule = vi.hoisted(() => ({
 	cleanupArtifactReposForPackage: vi.fn(),
 	deleteUserScopedArtifactRepo: vi.fn(async () => false),
 	insertCommunityFork: vi.fn(),
+	deleteCommunityForksForPackage: vi.fn(async () => 0),
+	deletePackageKodyIdRedirects: vi.fn(async () => undefined),
+	invalidateCommunityPublicCache: vi.fn(),
 	deleteCommunityListing: vi.fn(),
 	deleteCommunityRatingsByListingId: vi.fn(),
 	deleteCommunitySnapshot: vi.fn(),
@@ -172,6 +175,8 @@ vi.mock('./repo.ts', async (importOriginal) => {
 			mockModule.getCommunityReportById(...args),
 		insertCommunityFork: (...args: Array<unknown>) =>
 			mockModule.insertCommunityFork(...args),
+		deleteCommunityForksForPackage: (...args: Array<unknown>) =>
+			mockModule.deleteCommunityForksForPackage(...args),
 		deleteCommunityListing: (...args: Array<unknown>) =>
 			mockModule.deleteCommunityListing(...args),
 		deleteCommunityRatingsByListingId: (...args: Array<unknown>) =>
@@ -182,6 +187,20 @@ vi.mock('./repo.ts', async (importOriginal) => {
 			mockModule.setCommunityListingStatus(...args),
 	}
 })
+
+vi.mock('./package-url.ts', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('./package-url.ts')>()
+	return {
+		...actual,
+		deletePackageKodyIdRedirects: (...args: Array<unknown>) =>
+			mockModule.deletePackageKodyIdRedirects(...args),
+	}
+})
+
+vi.mock('#app/data-cache.ts', () => ({
+	invalidateCommunityPublicCache: (...args: Array<unknown>) =>
+		mockModule.invalidateCommunityPublicCache(...args),
+}))
 
 vi.mock('./snapshot.ts', () => ({
 	writeCommunitySnapshot: (...args: Array<unknown>) =>
@@ -1314,7 +1333,74 @@ test('forkCommunityListing cleans up entity source when snapshot sync fails', as
 			userId: 'user-2',
 		},
 	)
+	expect(mockModule.deleteCommunityForksForPackage).toHaveBeenCalledWith(
+		expect.anything(),
+		{
+			userId: 'user-2',
+			packageId: expect.any(String),
+			sourceId: 'fork-source-1',
+		},
+	)
+	expect(mockModule.deletePackageKodyIdRedirects).toHaveBeenCalledWith({
+		db: expect.anything(),
+		userId: 'user-2',
+		packageId: expect.any(String),
+	})
 	expect(mockModule.insertCommunityFork).not.toHaveBeenCalled()
+})
+
+test('forkCommunityListing removes the community_forks row when persist fails after writing it', async () => {
+	mockModule.getCommunityListingById.mockResolvedValue(sampleListing())
+	mockModule.readCommunitySnapshot.mockResolvedValue({
+		version: 1,
+		listingId: 'listing-1',
+		pinnedCommit: 'commit-1',
+		createdAt: '2026-07-01T00:00:00.000Z',
+		files: validPublishSource().files,
+	})
+	mockModule.getSavedPackageByKodyId.mockResolvedValue(null)
+	mockModule.getSavedPackageByName.mockResolvedValue(null)
+	mockModule.listCommunityForksByListingAndUser.mockResolvedValue([])
+	mockModule.ensureEntitySource.mockResolvedValue({
+		id: 'fork-source-1',
+		bootstrapAccess: { token: 'bootstrap' },
+	})
+	mockModule.syncArtifactSourceSnapshot.mockResolvedValue('commit-fork-1')
+	mockModule.insertCommunityFork.mockResolvedValue(undefined)
+	mockModule.invalidateCommunityPublicCache.mockImplementationOnce(() => {
+		throw new Error('cache invalidate failed')
+	})
+	mockModule.cleanupArtifactReposForPackage.mockResolvedValue(0)
+	mockModule.deleteEntitySource.mockResolvedValue(true)
+	mockModule.deleteCommunityForksForPackage.mockResolvedValue(1)
+	mockModule.deleteUserScopedArtifactRepo.mockResolvedValueOnce(true)
+	consoleWarn.mockImplementation(() => {})
+
+	await expect(
+		forkCommunityListing({
+			env: createEnv(),
+			baseUrl: 'https://heykody.dev',
+			userId: 'user-2',
+			expectedPackageScope: 'jane',
+			listingId: 'listing-1',
+			kodyId: 'my-discord-gateway',
+		}),
+	).rejects.toThrow('cache invalidate failed')
+
+	expect(mockModule.insertCommunityFork).toHaveBeenCalled()
+	expect(mockModule.deleteCommunityForksForPackage).toHaveBeenCalledWith(
+		expect.anything(),
+		{
+			userId: 'user-2',
+			packageId: expect.any(String),
+			sourceId: 'fork-source-1',
+		},
+	)
+	expect(mockModule.deletePackageKodyIdRedirects).toHaveBeenCalledWith({
+		db: expect.anything(),
+		userId: 'user-2',
+		packageId: expect.any(String),
+	})
 })
 
 test('forkCommunityListing copies at the Artifacts layer when the origin repo exists', async () => {

--- a/packages/worker/src/community/orphan-forks.node.test.ts
+++ b/packages/worker/src/community/orphan-forks.node.test.ts
@@ -123,6 +123,20 @@ test('orphan fork cleanup and package delete drop leftover community_forks witho
 		'listing-plaid': 3,
 	})
 
+	const emptyFilter = await cleanupOrphanedCommunityForks({
+		env,
+		apply: true,
+		forkIds: [],
+	})
+	expect(emptyFilter).toEqual({
+		applied: true,
+		deletedCount: 0,
+		orphans: [],
+	})
+	expect(await countCommunityForksByListingIds(db, ['listing-plaid'])).toEqual({
+		'listing-plaid': 3,
+	})
+
 	const preview = await cleanupOrphanedCommunityForks({
 		env,
 		apply: false,

--- a/packages/worker/src/community/orphan-forks.node.test.ts
+++ b/packages/worker/src/community/orphan-forks.node.test.ts
@@ -1,0 +1,195 @@
+import { DatabaseSync } from 'node:sqlite'
+import { expect, test } from 'vitest'
+import { createD1FromSqlite } from '#worker/test-support/create-d1-from-sqlite.ts'
+import {
+	countCommunityForksByListingIds,
+	deleteCommunityForksForPackage,
+	insertCommunityFork,
+} from './repo.ts'
+import { cleanupOrphanedCommunityForks } from './service.ts'
+
+function createOrphanForkDb() {
+	const sqlite = new DatabaseSync(':memory:')
+	sqlite.exec(`
+		CREATE TABLE saved_packages (
+			id TEXT PRIMARY KEY NOT NULL,
+			user_id TEXT NOT NULL,
+			name TEXT NOT NULL,
+			kody_id TEXT NOT NULL,
+			description TEXT NOT NULL DEFAULT '',
+			source_id TEXT NOT NULL
+		);
+		CREATE TABLE entity_sources (
+			id TEXT PRIMARY KEY NOT NULL,
+			user_id TEXT NOT NULL,
+			entity_kind TEXT NOT NULL,
+			entity_id TEXT NOT NULL
+		);
+		CREATE TABLE community_listings (
+			id TEXT PRIMARY KEY NOT NULL,
+			owner_user_id TEXT NOT NULL,
+			package_id TEXT NOT NULL,
+			source_id TEXT NOT NULL,
+			kody_id TEXT NOT NULL,
+			name TEXT NOT NULL,
+			description TEXT NOT NULL DEFAULT '',
+			license TEXT NOT NULL DEFAULT 'MIT',
+			pinned_commit TEXT NOT NULL,
+			status TEXT NOT NULL DEFAULT 'active'
+		);
+		CREATE TABLE community_forks (
+			id TEXT PRIMARY KEY NOT NULL,
+			listing_id TEXT NOT NULL,
+			forker_user_id TEXT NOT NULL,
+			origin_commit TEXT NOT NULL,
+			forked_package_id TEXT NOT NULL,
+			forked_source_id TEXT NOT NULL,
+			target_kody_id TEXT NOT NULL,
+			listing_name TEXT,
+			listing_kody_id TEXT,
+			adopted_at TEXT,
+			adoption_note TEXT,
+			actor TEXT,
+			created_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP)
+		);
+	`)
+	return { sqlite, db: createD1FromSqlite(sqlite) }
+}
+
+async function seedListingAndForks(db: D1Database) {
+	await db
+		.prepare(
+			`INSERT INTO community_listings (
+				id, owner_user_id, package_id, source_id, kody_id, name, pinned_commit
+			) VALUES ('listing-plaid', 'owner-1', 'origin-package', 'origin-source',
+				'plaid', '@kody/plaid', 'commit-origin')`,
+		)
+		.run()
+	await db
+		.prepare(
+			`INSERT INTO entity_sources (id, user_id, entity_kind, entity_id)
+			VALUES ('source-inert', 'user-kent', 'package', 'package-inert'),
+				('source-live', 'user-kent', 'package', 'package-live')`,
+		)
+		.run()
+	await db
+		.prepare(
+			`INSERT INTO saved_packages (id, user_id, name, kody_id, source_id)
+			VALUES ('package-live', 'user-kent', '@kentcdodds/plaid', 'plaid',
+				'source-live')`,
+		)
+		.run()
+	await insertCommunityFork(db, {
+		id: 'fork-inert',
+		listing_id: 'listing-plaid',
+		forker_user_id: 'user-kent',
+		origin_commit: 'commit-origin',
+		forked_package_id: 'package-inert',
+		forked_source_id: 'source-inert',
+		target_kody_id: 'plaid-inert',
+		listing_name: '@kody/plaid',
+		listing_kody_id: 'plaid',
+	})
+	await insertCommunityFork(db, {
+		id: 'fork-live',
+		listing_id: 'listing-plaid',
+		forker_user_id: 'user-kent',
+		origin_commit: 'commit-origin',
+		forked_package_id: 'package-live',
+		forked_source_id: 'source-live',
+		target_kody_id: 'plaid',
+		listing_name: '@kody/plaid',
+		listing_kody_id: 'plaid',
+	})
+	await insertCommunityFork(db, {
+		id: 'fork-orphan',
+		listing_id: 'listing-plaid',
+		forker_user_id: 'user-kent',
+		origin_commit: 'commit-origin',
+		forked_package_id: 'package-missing',
+		forked_source_id: 'source-missing',
+		target_kody_id: 'plaid-fork-test-cleanup',
+		listing_name: '@kody/plaid',
+		listing_kody_id: 'plaid',
+	})
+}
+
+test('orphan fork cleanup and package delete drop leftover community_forks without touching healthy forks', async () => {
+	const { db } = createOrphanForkDb()
+	await seedListingAndForks(db)
+	const env = { APP_DB: db } as Env
+
+	expect(await countCommunityForksByListingIds(db, ['listing-plaid'])).toEqual({
+		'listing-plaid': 3,
+	})
+
+	const preview = await cleanupOrphanedCommunityForks({
+		env,
+		apply: false,
+	})
+	expect(preview).toMatchObject({
+		applied: false,
+		deletedCount: 0,
+		orphans: [
+			expect.objectContaining({
+				forkId: 'fork-orphan',
+				forkedPackageId: 'package-missing',
+				forkedSourceId: 'source-missing',
+				targetKodyId: 'plaid-fork-test-cleanup',
+			}),
+		],
+	})
+	expect(await countCommunityForksByListingIds(db, ['listing-plaid'])).toEqual({
+		'listing-plaid': 3,
+	})
+
+	const skippedHealthy = await cleanupOrphanedCommunityForks({
+		env,
+		apply: true,
+		forkIds: ['fork-inert', 'fork-live'],
+	})
+	expect(skippedHealthy).toEqual({
+		applied: true,
+		deletedCount: 0,
+		orphans: [],
+	})
+	expect(await countCommunityForksByListingIds(db, ['listing-plaid'])).toEqual({
+		'listing-plaid': 3,
+	})
+
+	const applied = await cleanupOrphanedCommunityForks({
+		env,
+		apply: true,
+		forkIds: ['fork-orphan'],
+	})
+	expect(applied).toMatchObject({
+		applied: true,
+		deletedCount: 1,
+		orphans: [
+			expect.objectContaining({
+				forkId: 'fork-orphan',
+			}),
+		],
+	})
+	expect(await countCommunityForksByListingIds(db, ['listing-plaid'])).toEqual({
+		'listing-plaid': 2,
+	})
+
+	expect(
+		await deleteCommunityForksForPackage(db, {
+			userId: 'user-kent',
+			packageId: 'package-live',
+			sourceId: 'source-live',
+		}),
+	).toBe(1)
+	expect(await countCommunityForksByListingIds(db, ['listing-plaid'])).toEqual({
+		'listing-plaid': 1,
+	})
+
+	const remaining = await db
+		.prepare(`SELECT id, target_kody_id FROM community_forks`)
+		.all<{ id: string; target_kody_id: string }>()
+	expect(remaining.results).toEqual([
+		{ id: 'fork-inert', target_kody_id: 'plaid-inert' },
+	])
+})

--- a/packages/worker/src/community/repo.ts
+++ b/packages/worker/src/community/repo.ts
@@ -758,6 +758,120 @@ export async function insertCommunityFork(
 		.run()
 }
 
+export async function deleteCommunityForksForPackage(
+	db: D1Database,
+	input: {
+		userId: string
+		packageId: string
+		sourceId?: string
+	},
+): Promise<number> {
+	const result = input.sourceId
+		? await db
+				.prepare(
+					`DELETE FROM community_forks
+					WHERE forker_user_id = ?
+						AND (forked_package_id = ? OR forked_source_id = ?)`,
+				)
+				.bind(input.userId, input.packageId, input.sourceId)
+				.run()
+		: await db
+				.prepare(
+					`DELETE FROM community_forks
+					WHERE forker_user_id = ?
+						AND forked_package_id = ?`,
+				)
+				.bind(input.userId, input.packageId)
+				.run()
+	return result.meta.changes ?? 0
+}
+
+export type OrphanedCommunityForkRow = {
+	id: string
+	listing_id: string
+	listing_name: string | null
+	listing_kody_id: string | null
+	forker_user_id: string
+	forked_package_id: string
+	forked_source_id: string
+	target_kody_id: string
+	created_at: string
+}
+
+/**
+ * Fork rows whose inert source and saved package are both gone. Healthy
+ * community forks stay inert (no `saved_packages` row) and keep an
+ * `entity_sources` row, so a missing package alone is not an orphan.
+ */
+export async function listOrphanedCommunityForks(
+	db: D1Database,
+	input: {
+		forkIds?: Array<string>
+	} = {},
+): Promise<Array<OrphanedCommunityForkRow>> {
+	const uniqueForkIds = [...new Set(input.forkIds ?? [])]
+	const orphans: Array<OrphanedCommunityForkRow> = []
+	const idChunks =
+		uniqueForkIds.length === 0
+			? [[] as Array<string>]
+			: chunkArray(uniqueForkIds, maxSqlBindingsPerChunk)
+	for (const idChunk of idChunks) {
+		const idFilter =
+			idChunk.length > 0
+				? `AND community_forks.id IN (${idChunk.map(() => '?').join(', ')})`
+				: ''
+		const rows = await db
+			.prepare(
+				`SELECT community_forks.id AS id,
+					community_forks.listing_id AS listing_id,
+					community_forks.listing_name AS listing_name,
+					community_forks.listing_kody_id AS listing_kody_id,
+					community_forks.forker_user_id AS forker_user_id,
+					community_forks.forked_package_id AS forked_package_id,
+					community_forks.forked_source_id AS forked_source_id,
+					community_forks.target_kody_id AS target_kody_id,
+					community_forks.created_at AS created_at
+				FROM community_forks
+				WHERE NOT EXISTS (
+					SELECT 1
+					FROM entity_sources
+					WHERE entity_sources.id = community_forks.forked_source_id
+				)
+				AND NOT EXISTS (
+					SELECT 1
+					FROM saved_packages
+					WHERE saved_packages.id = community_forks.forked_package_id
+				)
+				${idFilter}
+				ORDER BY community_forks.created_at ASC`,
+			)
+			.bind(...idChunk)
+			.all<OrphanedCommunityForkRow>()
+		orphans.push(...(rows.results ?? []))
+	}
+	return orphans
+}
+
+export async function deleteCommunityForksByIds(
+	db: D1Database,
+	forkIds: Array<string>,
+): Promise<number> {
+	const uniqueForkIds = [...new Set(forkIds)]
+	if (uniqueForkIds.length === 0) return 0
+	let deleted = 0
+	for (const idChunk of chunkArray(uniqueForkIds, maxSqlBindingsPerChunk)) {
+		const result = await db
+			.prepare(
+				`DELETE FROM community_forks
+				WHERE id IN (${idChunk.map(() => '?').join(', ')})`,
+			)
+			.bind(...idChunk)
+			.run()
+		deleted += result.meta.changes ?? 0
+	}
+	return deleted
+}
+
 export async function repointOrphanedCommunityForksToListing(
 	db: D1Database,
 	input: {

--- a/packages/worker/src/community/repo.ts
+++ b/packages/worker/src/community/repo.ts
@@ -810,6 +810,7 @@ export async function listOrphanedCommunityForks(
 	} = {},
 ): Promise<Array<OrphanedCommunityForkRow>> {
 	const uniqueForkIds = [...new Set(input.forkIds ?? [])]
+	if (input.forkIds !== undefined && uniqueForkIds.length === 0) return []
 	const orphans: Array<OrphanedCommunityForkRow> = []
 	const idChunks =
 		uniqueForkIds.length === 0

--- a/packages/worker/src/community/service.ts
+++ b/packages/worker/src/community/service.ts
@@ -60,9 +60,14 @@ import { assertNotCommunityBanned } from './assert-not-community-banned.ts'
 import { CommunityActionError } from './errors.ts'
 import { enqueueCommunityListingPublishedDispatch } from './listing-published-dispatch-queue-producer.ts'
 import { type CommunityListingPublishedProjection } from './listing-published-subscription-event.ts'
-import { getCommunityPackageHref } from './package-url.ts'
+import {
+	deletePackageKodyIdRedirects,
+	getCommunityPackageHref,
+} from './package-url.ts'
 import {
 	countCommunityForksByListingIds,
+	deleteCommunityForksByIds,
+	deleteCommunityForksForPackage,
 	deleteCommunityListing,
 	deleteCommunityRatingsByListingId,
 	getCommunityActivityByIdForAdmin,
@@ -83,6 +88,7 @@ import {
 	getCommunityReportById,
 	insertCommunityFork,
 	insertCommunityListing,
+	listOrphanedCommunityForks,
 	insertCommunityBan,
 	insertCommunityReport,
 	countActiveCommunityListingsByCategory,
@@ -361,6 +367,37 @@ async function cleanupFailedCommunityFork(input: {
 			}),
 		)
 	})
+	await deleteCommunityForksForPackage(input.env.APP_DB, {
+		userId: input.userId,
+		packageId: input.packageId,
+		sourceId: input.sourceId,
+	}).catch((error) => {
+		console.warn(
+			JSON.stringify({
+				message: 'community fork row cleanup failed',
+				userId: input.userId,
+				packageId: input.packageId,
+				sourceId: input.sourceId,
+				error: getErrorMessage(error),
+			}),
+		)
+	})
+	await deletePackageKodyIdRedirects({
+		db: input.env.APP_DB,
+		userId: input.userId,
+		packageId: input.packageId,
+	}).catch((error) => {
+		console.warn(
+			JSON.stringify({
+				message: 'community fork kody id redirect cleanup failed',
+				userId: input.userId,
+				packageId: input.packageId,
+				sourceId: input.sourceId,
+				error: getErrorMessage(error),
+			}),
+		)
+	})
+	invalidateCommunityPublicCache()
 }
 
 function buildListingSearchDocument(listing: CommunityListingRecord) {
@@ -1575,6 +1612,68 @@ export async function forkCommunityListing(
 		prepareCommunityFork(input),
 	)
 	return await persistPreparedCommunityFork(prepared, { serverTiming })
+}
+
+export type OrphanedCommunityFork = {
+	forkId: string
+	listingId: string
+	listingName: string | null
+	listingKodyId: string | null
+	forkerUserId: string
+	forkedPackageId: string
+	forkedSourceId: string
+	targetKodyId: string
+	createdAt: string
+}
+
+export async function cleanupOrphanedCommunityForks(input: {
+	env: Env
+	apply: boolean
+	forkIds?: Array<string>
+}): Promise<{
+	applied: boolean
+	deletedCount: number
+	orphans: Array<OrphanedCommunityFork>
+}> {
+	const orphans = (
+		await listOrphanedCommunityForks(input.env.APP_DB, {
+			forkIds: input.forkIds,
+		})
+	).map((row) => ({
+		forkId: row.id,
+		listingId: row.listing_id,
+		listingName: row.listing_name,
+		listingKodyId: row.listing_kody_id,
+		forkerUserId: row.forker_user_id,
+		forkedPackageId: row.forked_package_id,
+		forkedSourceId: row.forked_source_id,
+		targetKodyId: row.target_kody_id,
+		createdAt: row.created_at,
+	}))
+	if (!input.apply) {
+		return {
+			applied: false,
+			deletedCount: 0,
+			orphans,
+		}
+	}
+	if (orphans.length === 0) {
+		return {
+			applied: true,
+			deletedCount: 0,
+			orphans,
+		}
+	}
+	const deletedCount = await deleteCommunityForksByIds(
+		input.env.APP_DB,
+		orphans.map((row) => row.forkId),
+	)
+	invalidateCommunityPublicCache()
+	return {
+		applied: true,
+		deletedCount,
+		orphans,
+	}
 }
 
 export type AdoptCommunityForkResult = {

--- a/packages/worker/src/mcp/capabilities/admin/admin-community-orphan-forks-cleanup.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-community-orphan-forks-cleanup.node.test.ts
@@ -1,0 +1,101 @@
+import { expect, test, vi } from 'vitest'
+import { createMcpCallerContext } from '#mcp/context.ts'
+import {
+	auditEventSummaries,
+	logAuditEventSpy,
+} from '#worker/test-support/audit-log-spy.ts'
+import { adminCommunityOrphanForksCleanupCapability } from './admin-community-orphan-forks-cleanup.ts'
+
+const mocks = vi.hoisted(() => ({
+	cleanupOrphanedCommunityForks: vi.fn(),
+}))
+
+vi.mock('#worker/community/service.ts', () => ({
+	cleanupOrphanedCommunityForks: mocks.cleanupOrphanedCommunityForks,
+}))
+
+function createContext(roles: Array<string>) {
+	return {
+		env: { APP_DB: {} as D1Database } as Env,
+		callerContext: createMcpCallerContext({
+			baseUrl: 'https://heykody.dev',
+			user: {
+				userId: 'actor-1',
+				username: 'actor',
+				email: 'actor@example.com',
+				roles,
+			},
+		}),
+	}
+}
+
+test('admin orphan fork cleanup enforces admin role, previews by default, and applies only when asked', async () => {
+	await expect(
+		adminCommunityOrphanForksCleanupCapability.handler(
+			{},
+			createContext(['user']),
+		),
+	).rejects.toThrow('lacks required role "admin"')
+	expect(mocks.cleanupOrphanedCommunityForks).not.toHaveBeenCalled()
+	expect(logAuditEventSpy).toHaveBeenCalledWith(
+		expect.objectContaining({
+			category: 'auth',
+			action: 'mcp_capability_denied',
+			result: 'failure',
+			reason: 'role',
+		}),
+	)
+
+	mocks.cleanupOrphanedCommunityForks.mockResolvedValue({
+		applied: true,
+		deletedCount: 1,
+		orphans: [
+			{
+				forkId: 'fork-orphan',
+				listingId: 'listing-1',
+				listingName: '@kody/plaid',
+				listingKodyId: 'plaid',
+				forkerUserId: 'user-kent',
+				forkedPackageId: 'package-missing',
+				forkedSourceId: 'source-missing',
+				targetKodyId: 'plaid-fork-test-cleanup',
+				createdAt: '2026-09-10T00:00:00.000Z',
+			},
+		],
+	})
+
+	const result = await adminCommunityOrphanForksCleanupCapability.handler(
+		{
+			apply: true,
+			fork_ids: ['fork-orphan'],
+		},
+		createContext(['admin']),
+	)
+
+	expect(mocks.cleanupOrphanedCommunityForks).toHaveBeenCalledWith({
+		env: expect.anything(),
+		apply: true,
+		forkIds: ['fork-orphan'],
+	})
+	expect(result).toEqual({
+		applied: true,
+		deleted_count: 1,
+		orphans: [
+			{
+				fork_id: 'fork-orphan',
+				listing_id: 'listing-1',
+				listing_name: '@kody/plaid',
+				listing_kody_id: 'plaid',
+				forker_user_id: 'user-kent',
+				forked_package_id: 'package-missing',
+				forked_source_id: 'source-missing',
+				target_kody_id: 'plaid-fork-test-cleanup',
+				created_at: '2026-09-10T00:00:00.000Z',
+			},
+		],
+	})
+	expect(auditEventSummaries()).toEqual([
+		'mcp_capability_denied:failure',
+		'adminCommunityOrphanForksCleanup:success',
+	])
+})

--- a/packages/worker/src/mcp/capabilities/admin/admin-community-orphan-forks-cleanup.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-community-orphan-forks-cleanup.ts
@@ -1,0 +1,90 @@
+import { z } from 'zod'
+import { cleanupOrphanedCommunityForks } from '#worker/community/service.ts'
+import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
+import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
+import {
+	adminMutationCapabilityAccess,
+	auditAdminCapabilityInvocation,
+} from './admin-shared.ts'
+
+const orphanedForkSchema = z.object({
+	fork_id: z.string(),
+	listing_id: z.string(),
+	listing_name: z.string().nullable(),
+	listing_kody_id: z.string().nullable(),
+	forker_user_id: z.string(),
+	forked_package_id: z.string(),
+	forked_source_id: z.string(),
+	target_kody_id: z.string(),
+	created_at: z.string(),
+})
+
+export const adminCommunityOrphanForksCleanupCapability =
+	defineDomainCapability(capabilityDomainNames.admin, {
+		...adminMutationCapabilityAccess,
+		name: 'adminCommunityOrphanForksCleanup',
+		description:
+			'Admin-only maintenance for leftover community_forks rows whose inert entity source and saved package are both gone. Healthy community forks stay inert (no saved_packages row) and keep an entity_sources row, so a missing package alone is not an orphan and is never deleted. apply defaults to false (preview). Optional fork_ids limits the scan to those ids and still skips any that still have a source or package. Audited.',
+		keywords: [
+			'admin',
+			'community',
+			'forks',
+			'orphan',
+			'cleanup',
+			'maintenance',
+		],
+		destructive: true,
+		inputSchema: z.object({
+			apply: z
+				.boolean()
+				.optional()
+				.describe(
+					'When true, delete matching orphan rows. Defaults to false (preview only).',
+				),
+			fork_ids: z
+				.array(z.string().min(1))
+				.max(90)
+				.optional()
+				.describe(
+					'Optional fork row ids to inspect. When set, only those ids that are true orphans are previewed or deleted.',
+				),
+		}),
+		outputSchema: z.object({
+			applied: z.boolean(),
+			deleted_count: z.number().int().nonnegative(),
+			orphans: z.array(orphanedForkSchema),
+		}),
+		async handler(args, ctx) {
+			const apply = args.apply === true
+			return auditAdminCapabilityInvocation(
+				ctx,
+				'adminCommunityOrphanForksCleanup',
+				async () => {
+					const result = await cleanupOrphanedCommunityForks({
+						env: ctx.env,
+						apply,
+						forkIds: args.fork_ids,
+					})
+					return {
+						applied: result.applied,
+						deleted_count: result.deletedCount,
+						orphans: result.orphans.map((orphan) => ({
+							fork_id: orphan.forkId,
+							listing_id: orphan.listingId,
+							listing_name: orphan.listingName,
+							listing_kody_id: orphan.listingKodyId,
+							forker_user_id: orphan.forkerUserId,
+							forked_package_id: orphan.forkedPackageId,
+							forked_source_id: orphan.forkedSourceId,
+							target_kody_id: orphan.targetKodyId,
+							created_at: orphan.createdAt,
+						})),
+					}
+				},
+				{
+					successReason: (result) =>
+						`applied=${result.applied ? 1 : 0};deleted=${result.deleted_count};orphans=${result.orphans.length}`,
+				},
+			)
+		},
+	})

--- a/packages/worker/src/mcp/capabilities/admin/admin-community-orphan-forks-cleanup.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-community-orphan-forks-cleanup.ts
@@ -43,6 +43,7 @@ export const adminCommunityOrphanForksCleanupCapability =
 				),
 			fork_ids: z
 				.array(z.string().min(1))
+				.min(1)
 				.max(90)
 				.optional()
 				.describe(

--- a/packages/worker/src/mcp/capabilities/admin/domain.ts
+++ b/packages/worker/src/mcp/capabilities/admin/domain.ts
@@ -2,6 +2,7 @@ import { defineDomain } from '#mcp/capabilities/define-domain.ts'
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { adminAuditLogQueryCapability } from './admin-audit-log-query.ts'
 import { adminCommunityActivityListCapability } from './admin-community-activity-list.ts'
+import { adminCommunityOrphanForksCleanupCapability } from './admin-community-orphan-forks-cleanup.ts'
 import { adminFeatureFlagListCapability } from './admin-feature-flag-list.ts'
 import { adminFeatureFlagOverrideCapability } from './admin-feature-flag-override.ts'
 import { adminFeatureFlagSetCapability } from './admin-feature-flag-set.ts'
@@ -67,6 +68,7 @@ export const adminDomain = defineDomain({
 		'system email',
 		'platform feedback',
 		'community activity',
+		'orphan forks',
 		'platform accounts',
 		'platform oauth apps',
 		'provider marks',
@@ -138,5 +140,6 @@ export const adminDomain = defineDomain({
 		adminPlatformFeedbackGetCapability,
 		adminPlatformFeedbackUpdateCapability,
 		adminCommunityActivityListCapability,
+		adminCommunityOrphanForksCleanupCapability,
 	],
 })

--- a/packages/worker/src/mcp/capabilities/registry.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/registry.node.test.ts
@@ -104,6 +104,9 @@ test('getCapabilityRegistryForContext filters admin capabilities by current call
 	).toBeTruthy()
 	expect(adminRegistry.capabilityMap.adminMailboxMaintenance).toBeTruthy()
 	expect(
+		adminRegistry.capabilityMap.adminCommunityOrphanForksCleanup,
+	).toBeTruthy()
+	expect(
 		adminRegistry.capabilityMap.adminUserMeterStorageReconcile,
 	).toBeTruthy()
 	expect(
@@ -124,6 +127,9 @@ test('getCapabilityRegistryForContext filters admin capabilities by current call
 		regularRegistry.capabilityMap.adminUserMeterStorageReconcile,
 	).toBeUndefined()
 	expect(regularRegistry.capabilityMap.adminMailboxMaintenance).toBeUndefined()
+	expect(
+		regularRegistry.capabilityMap.adminCommunityOrphanForksCleanup,
+	).toBeUndefined()
 	expect(
 		regularRegistry.capabilityDomains.some((domain) => domain.name === 'admin'),
 	).toBe(false)

--- a/packages/worker/src/package-registry/service.node.test.ts
+++ b/packages/worker/src/package-registry/service.node.test.ts
@@ -40,7 +40,9 @@ const mockModule = vi.hoisted(() => ({
 	clearStorage: vi.fn(async () => ({ ok: true as const })),
 	storageRunnerRpc: vi.fn(),
 	getCommunityListingByOwnerAndPackage: vi.fn(),
+	deleteCommunityForksForPackage: vi.fn(),
 	unpublishCommunityListing: vi.fn(),
+	invalidateCommunityPublicCache: vi.fn(),
 }))
 
 vi.mock('./manifest.ts', () => ({
@@ -156,6 +158,13 @@ vi.mock('#worker/repo/entity-sources.ts', () => ({
 vi.mock('#worker/community/repo.ts', () => ({
 	getCommunityListingByOwnerAndPackage: (...args: Array<unknown>) =>
 		mockModule.getCommunityListingByOwnerAndPackage(...args),
+	deleteCommunityForksForPackage: (...args: Array<unknown>) =>
+		mockModule.deleteCommunityForksForPackage(...args),
+}))
+
+vi.mock('#app/data-cache.ts', () => ({
+	invalidateCommunityPublicCache: (...args: Array<unknown>) =>
+		mockModule.invalidateCommunityPublicCache(...args),
 }))
 
 vi.mock('#worker/community/service.ts', () => ({
@@ -235,6 +244,9 @@ function setupDefaultMocks() {
 	mockModule.getCommunityListingByOwnerAndPackage.mockResolvedValue(null)
 	mockModule.unpublishCommunityListing.mockReset()
 	mockModule.unpublishCommunityListing.mockResolvedValue(undefined)
+	mockModule.deleteCommunityForksForPackage.mockReset()
+	mockModule.deleteCommunityForksForPackage.mockResolvedValue(0)
+	mockModule.invalidateCommunityPublicCache.mockReset()
 }
 
 test('refreshSavedPackageProjection defers search-index upsert and retriever cache via waitUntil', async () => {
@@ -596,6 +608,7 @@ test('deleteSavedPackageProjection resyncs the job manager after removing packag
 		{ id: 'job-1', source_id: 'source-1' },
 		{ id: 'job-2', source_id: 'source-other' },
 	])
+	mockModule.deleteCommunityForksForPackage.mockResolvedValue(1)
 
 	await deleteSavedPackageProjection({
 		env,
@@ -636,6 +649,15 @@ test('deleteSavedPackageProjection resyncs the job manager after removing packag
 		userId: 'user-1',
 		packageId: 'package-1',
 	})
+	expect(mockModule.deleteCommunityForksForPackage).toHaveBeenCalledWith(
+		env.APP_DB,
+		{
+			userId: 'user-1',
+			packageId: 'package-1',
+			sourceId: 'source-1',
+		},
+	)
+	expect(mockModule.invalidateCommunityPublicCache).toHaveBeenCalledTimes(1)
 	expect(
 		mockModule.removePackageRetrieverManifestCacheEntries,
 	).toHaveBeenCalledWith({

--- a/packages/worker/src/package-registry/service.ts
+++ b/packages/worker/src/package-registry/service.ts
@@ -2,12 +2,16 @@ import { getErrorMessage } from '@kody-internal/shared/error-message.ts'
 import { withAccountWriteLease } from '#worker/account/deletion-state.ts'
 import { parseTagsJson } from '@kody-internal/shared/tags-json.ts'
 import * as Sentry from '@sentry/cloudflare'
+import { invalidateCommunityPublicCache } from '#app/data-cache.ts'
 import {
 	deletePackageKodyIdRedirects,
 	releasePackageKodyIdRedirect,
 	retirePackageKodyId,
 } from '#worker/community/package-url.ts'
-import { getCommunityListingByOwnerAndPackage } from '#worker/community/repo.ts'
+import {
+	deleteCommunityForksForPackage,
+	getCommunityListingByOwnerAndPackage,
+} from '#worker/community/repo.ts'
 import { unpublishCommunityListing } from '#worker/community/service.ts'
 import { buildSavedPackageEmbedText } from './embed.ts'
 import { buildPackageSearchProjection } from './manifest.ts'
@@ -624,6 +628,17 @@ export async function deleteSavedPackageProjection(input: {
 				userId: input.userId,
 				packageId: input.packageId,
 			})
+			const deletedForks = await deleteCommunityForksForPackage(
+				input.env.APP_DB,
+				{
+					userId: input.userId,
+					packageId: input.packageId,
+					sourceId: savedPackage?.sourceId,
+				},
+			)
+			if (deletedForks > 0) {
+				invalidateCommunityPublicCache()
+			}
 			try {
 				await removePackageRetrieverManifestCacheEntries({
 					env: input.env,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop leftover `community_forks` rows from inflating live `fork_count` and blocking retries after a failed `communityFork` or a later `packageDelete`. Give operators a safe way to clear the two existing `@kody/plaid` orphans in production without touching healthy inert forks or Patch's working `@kentcdodds/plaid` stub.

## Why

`cleanupFailedCommunityFork` deleted the dest Artifacts repo and inert entity source but left the `community_forks` row. `fork_count` is a live `COUNT(*)` over that table, so orphans inflate counts and make `communityFork` report "already forked". `packageDelete` had the same gap for a materialized fork.

A missing `saved_packages` row alone is **not** an orphan. Healthy `communityFork` copies stay inert on purpose (source exists, no saved package). The production leftovers are rows whose **source and saved package are both gone**.

## Summary

- Failed fork persist now also deletes matching `community_forks` rows and any `package_kody_id_redirects` for the allocated package id.
- `packageDelete` / `deleteSavedPackageProjection` deletes the owner's `community_forks` row for that package.
- New admin-only `adminCommunityOrphanForksCleanup`: preview by default, `apply: true` to delete, optional `fork_ids` still skips any row that still has a source or package. An explicit empty `fork_ids` array matches nothing (does not sweep all orphans).
- Playbook tests: failed persist after the fork row is written removes it, package delete removes it, live `fork_count` drops, healthy inert/live forks stay.

## Testing

- `vitest` node-unit: community service, orphan-forks playbook, package-registry delete, admin capability, registry role gate
- Pre-push: `test:node` 3012 passed, `test:workers` 342 passed
- Preview `kody-pr-2231`: health/login, empty `/community.json`, `/admin` 403, `package-create` + `POST /account/packages.json` delete of `@user-me/orphan-fork-preview` (list went to 0). Seed user is not admin, so the orphan sweep itself is not exercisable on preview.
- Bugbot: no new issues on `1eb91d2b`. CodeRabbit empty-`fork_ids` finding addressed in `a230f230`.

## Prod cleanup (after deploy)

Healthy inert forks must not be swept by "missing saved package" alone. Use the admin capability with the two known fork ids:

```js
// preview
await kody.adminCommunityOrphanForksCleanup({
	fork_ids: [
		'f431d616-6b7c-47e0-bfa3-67b3903fe3da',
		'b8fd72fa-32d5-47fc-b70c-88f5e5440970',
	],
})

// apply
await kody.adminCommunityOrphanForksCleanup({
	apply: true,
	fork_ids: [
		'f431d616-6b7c-47e0-bfa3-67b3903fe3da',
		'b8fd72fa-32d5-47fc-b70c-88f5e5440970',
	],
})
```

Then confirm `adminCommunityActivityList({ listing_id: '9af1a567-26bd-4b6d-a6eb-0d07cc7edb05', kind: 'fork' })` and `communityGet` `fork_count`. Do **not** delete package `a2dbd223-402b-42a6-b3dd-b47988b72f57` (`@kentcdodds/plaid`).

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `372239e9` · **Head:** `a230f230`

**Classification:** extends — failed fork cleanup and `packageDelete` now remove `community_forks` rows, and a new admin maintenance capability sweeps leftovers whose source and saved package are both gone.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `community-listings` | assistant | extends — failed persist deletes the matching `community_forks` row, and orphan sweep removes rows with no source and no saved package |
| `saved-packages` | assistant | extends — `deleteSavedPackageProjection` deletes the owner's `community_forks` row for that package id |
| `rbac` | auth | extends — new admin-only `adminCommunityOrphanForksCleanup` |
| `capability-registry` | assistant | composes — registers and role-gates the new admin capability |

`webhooks` matched `packages/worker/src/package-registry/` by ownership root only. This diff does not change inbound webhook behavior.

### Change flow

Failed `communityFork` persist and `packageDelete` both drop leftover `community_forks` rows so live `fork_count` falls. The admin sweep is a separate preview-or-apply path for already-orphaned production rows.

```mermaid
sequenceDiagram
	actor Caller
	participant mcpServer as mcp-server
	participant communityListings as community-listings
	participant savedPackages as saved-packages
	participant rbac as rbac
	participant d1AppDb as d1-app-db
	Caller->>mcpServer: communityFork
	mcpServer->>communityListings: persistPreparedCommunityFork
	alt persist fails after fork row write
		communityListings->>d1AppDb: DELETE community_forks for package_id or source_id
		communityListings->>d1AppDb: DELETE package_kody_id_redirects for package_id
	end
	Caller->>mcpServer: packageDelete
	mcpServer->>savedPackages: deleteSavedPackageProjection
	savedPackages->>d1AppDb: DELETE community_forks for forked_package_id
	Caller->>mcpServer: adminCommunityOrphanForksCleanup
	mcpServer->>rbac: requiredRole admin
	rbac->>communityListings: cleanupOrphanedCommunityForks
	communityListings->>d1AppDb: SELECT or DELETE forks with no entity_sources and no saved_packages
	Note over communityListings: inert forks keep entity_sources and are not orphans
```

### Invariants

Per-user isolation is unchanged: owner-path deletes are scoped to `forker_user_id`. The admin sweep only deletes rows whose entity source and saved package are both missing, so healthy inert forks and Patch's `@kentcdodds/plaid` stub stay. An explicit empty `fork_ids` filter matches nothing.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1d74a33f-80ce-416e-9eea-28a1ec38b9cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1d74a33f-80ce-416e-9eea-28a1ec38b9cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an admin-only capability to preview and remove orphaned community fork records.
  - Cleanup can target specific forks and defaults to preview mode before deletion.
  - Deleting packages or failed forks now removes associated fork records and refreshes public community data.
  - Existing forks retain their copies when the original listing is deleted or made private.

- **Documentation**
  - Updated administrator and community package guidance to describe orphan detection, cleanup behavior, and fork-count updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->