### PR TITLE
Show leftover kody_id in create examples and normalize token-list names

### DIFF
--- a/.agents/skills/control-kody/references/features/packages.md
+++ b/.agents/skills/control-kody/references/features/packages.md
@@ -17,10 +17,10 @@ come from `/@username/:kodyId/raw/:ref/…` (same authz as the tree). Legacy
 ## Drive it
 
 Preview seed has **no** packages until you create one. Package creation is
-MCP-only (`packageGetGitRemote({ create: true })` with the package name leaf or
-`@owner/leaf`). There is no create action on `POST /account/packages.json`. Use
-the CLI — logged-in preview testing does not require agents to hand-roll an MCP
-OAuth dance — the CLI does it for them:
+MCP-only (`packageGetGitRemote({ create: true, kody_id })` with the package name
+leaf or `@owner/leaf`). There is no create action on
+`POST /account/packages.json`. Use the CLI — logged-in preview testing does not
+require agents to hand-roll an MCP OAuth dance — the CLI does it for them:
 
 ```bash
 npm run control-kody -- package-create --origin <preview> --package-name <leaf-or-@scope/leaf> [--head-ahead]

--- a/docs/contributing/control-kody.md
+++ b/docs/contributing/control-kody.md
@@ -47,8 +47,8 @@ Override with `--email` / `--password`. `--cookie-file` defaults to
 [`preview-manual-test`](./preview-manual-testing.md) and its own seed.
 
 `package-create` registers a stub saved package on a PR preview (or local
-origin) through MCP `packageGetGitRemote({ create: true })`. Pass the package
-name leaf or `@owner/leaf` with `--package-name`. It reuses `--origin`,
+origin) through MCP `packageGetGitRemote({ create: true, kody_id })`. Pass the
+package name leaf or `@owner/leaf` with `--package-name`. It reuses `--origin`,
 `--email`, `--password`, `--cookie-file`, and `--json`. Pass
 `--package-name <leaf-or-@scope/leaf>` (required; `--kody-id` is an alias),
 `--description` (optional), and `--head-ahead` to push one unpublished commit so

--- a/docs/contributing/preview-manual-testing.md
+++ b/docs/contributing/preview-manual-testing.md
@@ -93,8 +93,9 @@ the product JSON APIs (`/account/*.json` in
 `packages/worker/universal/routes.ts`) or, for a saved package,
 `npm run control-kody -- package-create --origin <preview> --package-name <leaf-or-@scope/leaf> [--head-ahead]`.
 Those JSON endpoints are the same ones the UI posts to. Package creation is
-MCP-only (`packageGetGitRemote({ create: true })` with the package name leaf or
-`@owner/leaf`); there is no create action on `POST /account/packages.json`.
+MCP-only (`packageGetGitRemote({ create: true, kody_id })` with the package name
+leaf or `@owner/leaf`); there is no create action on
+`POST /account/packages.json`.
 
 `/mcp` stays OAuth-protected; an unauthenticated GET is 401 by design. Logged-in
 preview testing does not require agents to hand-roll an MCP OAuth dance — the

--- a/docs/guides/how-kody-works.md
+++ b/docs/guides/how-kody-works.md
@@ -30,8 +30,8 @@ Agent notes — for AI agents explaining or recreating this loop:
   `package_lifecycle:guide`, then `search` with
   `entity: ["package_authoring:guide", "package_lifecycle:guide"]`. Coding agents
   then use the git lane:
-  `packageGetGitRemote({ create: true, description })` with the new
-  `@owner/leaf` name (or the name leaf), clone via `setup_commands`, write
+  `packageGetGitRemote({ create: true, kody_id: '@owner/leaf', description })`
+  (or the name leaf in leftover `kody_id`), clone via `setup_commands`, write
   the export, push, and `packagePublishExternalPush`. Tool-only agents (no local
   git) create with `packageSave` and update through a repo session
   (`repoOpenSession`, `repoEditFiles`, `repoCommit`, `repoRunChecks`,

--- a/docs/guides/package-authoring.md
+++ b/docs/guides/package-authoring.md
@@ -34,8 +34,8 @@ There are two lanes for writing package source. Pick based on whether you have
 local filesystem and git access:
 
 - **Git lane (coding agents — preferred).** Call
-  `packageGetGitRemote({ create: true, description })` with the new
-  `@owner/leaf` name (or the name leaf) to register a stub saved package and
+  `packageGetGitRemote({ create: true, kody_id: '@owner/leaf', description })`
+  (or the name leaf in leftover `kody_id`) to register a stub saved package and
   mint a short-lived authenticated remote in one call (for existing packages,
   omit `create` and pass the scoped name, or `package_id` when the name is not
   known). Run the returned `setup_commands` to clone into a temporary directory

--- a/docs/guides/package-lifecycle.md
+++ b/docs/guides/package-lifecycle.md
@@ -126,10 +126,10 @@ a new package.
 
 When a normal filesystem and git client are available:
 
-1. Call `packageGetGitRemote`. For a new package, pass `create: true`, the
-   `@owner/leaf` name (or the name leaf), and `description`; for an existing
-   package, omit `create` and pass the scoped name, or `package_id` when the
-   name is not known.
+1. Call `packageGetGitRemote`. For a new package, pass `create: true`, leftover
+   `kody_id` set to the `@owner/leaf` name (or the name leaf), and
+   `description`; for an existing package, omit `create` and pass leftover
+   `kody_id` or `package_id` when the name is not known.
 2. Run the returned setup commands and clone into a temporary directory. Those
    commands set local git `user.email` and `user.name` from `git_author` (the
    signed-in Kody account). Do not invent a git identity.

--- a/docs/use/packages.md
+++ b/docs/use/packages.md
@@ -662,12 +662,14 @@ publish checks run.
    `user.name` from `git_author`. Use that identity for commits; do not invent
    an email.
 
-   To start a **new** package in this lane, pass `create: true` with the new
-   `@owner/leaf` name (or the name leaf) and an optional `description`:
+   To start a **new** package in this lane, pass `create: true` with leftover
+   `kody_id` set to the new `@owner/leaf` name (or the name leaf) and an
+   optional `description`:
 
    ```json
    {
    	"create": true,
+   	"kody_id": "@you/new-package",
    	"description": "What this package is for"
    }
    ```

--- a/packages/worker/client/routes/how-kody-works-transcript.node.test.ts
+++ b/packages/worker/client/routes/how-kody-works-transcript.node.test.ts
@@ -42,7 +42,8 @@ test('factory transcript covers ask, invoke, and a quiet daily email', () => {
 			tool.inputs.some(
 				(input) =>
 					input.value.includes('packageGetGitRemote') &&
-					input.value.includes('create: true'),
+					input.value.includes('create: true') &&
+					input.value.includes("kody_id: '@you/kody-bot-shipped'"),
 			),
 		),
 	).toBe(true)

--- a/packages/worker/src/mcp/capabilities/packages/package-invocation-token-capabilities.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/packages/package-invocation-token-capabilities.node.test.ts
@@ -6,6 +6,7 @@ const mockModule = vi.hoisted(() => ({
 	getPackageInvocationTokenById: vi.fn(),
 	getSavedPackageById: vi.fn(),
 	getSavedPackageByKodyId: vi.fn(),
+	resolvePackageOwnerContext: vi.fn(),
 }))
 
 vi.mock('#worker/package-invocations/repo.ts', () => ({
@@ -20,6 +21,11 @@ vi.mock('#worker/package-registry/repo.ts', () => ({
 		mockModule.getSavedPackageById(...args),
 	getSavedPackageByKodyId: (...args: Array<unknown>) =>
 		mockModule.getSavedPackageByKodyId(...args),
+}))
+
+vi.mock('#worker/package-registry/package-owner.ts', () => ({
+	resolvePackageOwnerContext: (...args: Array<unknown>) =>
+		mockModule.resolvePackageOwnerContext(...args),
 }))
 
 const { packageInvocationTokenListCapability } =
@@ -60,6 +66,14 @@ test('package invocation token capabilities return package-scoped metadata witho
 	mockModule.getPackageInvocationTokenById.mockReset()
 	mockModule.getSavedPackageById.mockReset()
 	mockModule.getSavedPackageByKodyId.mockReset()
+	mockModule.resolvePackageOwnerContext.mockReset()
+	mockModule.resolvePackageOwnerContext.mockResolvedValue({
+		ownerUserId: 'user-1',
+		ownerScope: 'user',
+		ownerEmail: 'user@example.com',
+		actorUserId: 'user-1',
+		delegated: false,
+	})
 	mockModule.getSavedPackageById.mockResolvedValue({
 		id: 'package-1',
 		kodyId: 'discord-gateway',
@@ -165,4 +179,25 @@ test('package invocation token capabilities return package-scoped metadata witho
 			context,
 		),
 	).rejects.toThrow(/not found/i)
+
+	mockModule.getSavedPackageById.mockResolvedValue(null)
+	mockModule.getSavedPackageByKodyId.mockResolvedValue({
+		id: 'package-1',
+		kodyId: 'discord-gateway',
+	})
+	await packageInvocationTokenListCapability.handler(
+		{ package_id: '@user/discord-gateway' },
+		context,
+	)
+	expect(mockModule.getSavedPackageByKodyId).toHaveBeenLastCalledWith(
+		expect.anything(),
+		{ userId: 'user-1', kodyId: 'discord-gateway' },
+	)
+
+	await expect(
+		packageInvocationTokenListCapability.handler(
+			{ package_id: '@other/discord-gateway' },
+			context,
+		),
+	).rejects.toThrow(/does not match the acting owner/)
 })

--- a/packages/worker/src/mcp/capabilities/packages/package-invocation-token-list.ts
+++ b/packages/worker/src/mcp/capabilities/packages/package-invocation-token-list.ts
@@ -1,9 +1,13 @@
+import { type McpUserContext } from '@kody-internal/shared/chat.ts'
+import { getErrorMessage } from '@kody-internal/shared/error-message.ts'
 import { z } from 'zod'
 import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
 import { McpCallerError } from '#mcp/caller-error.ts'
 import { listPackageInvocationTokensByPackageId } from '#worker/package-invocations/repo.ts'
+import { normalizePackageNameInput } from '#worker/package-registry/package-name.ts'
+import { resolvePackageOwnerContext } from '#worker/package-registry/package-owner.ts'
 import {
 	getSavedPackageById,
 	getSavedPackageByKodyId,
@@ -12,6 +16,28 @@ import {
 	packageInvocationTokenMetadataSchema,
 	toPackageInvocationTokenMetadata,
 } from './shared.ts'
+
+async function resolveSavedPackageByName(
+	env: Env,
+	user: McpUserContext,
+	packageName: string,
+) {
+	const owner = await resolvePackageOwnerContext(env, user)
+	let kodyId: string
+	try {
+		kodyId = normalizePackageNameInput({
+			value: packageName,
+			ownerScope: owner.ownerScope,
+			action: 'resolve',
+		})
+	} catch (error) {
+		throw new McpCallerError(getErrorMessage(error), { cause: error })
+	}
+	return await getSavedPackageByKodyId(env.APP_DB, {
+		userId: owner.ownerUserId,
+		kodyId,
+	})
+}
 
 export const packageInvocationTokenListCapability = defineDomainCapability(
 	capabilityDomainNames.invocationTokens,
@@ -35,7 +61,7 @@ export const packageInvocationTokenListCapability = defineDomainCapability(
 				.string()
 				.min(1)
 				.describe(
-					'Package name (`@owner/leaf` or the name leaf), or `package_id` when the name is not known.',
+					'Saved-package UUID, or package name (`@owner/leaf` or the name leaf). Prefer the scoped name when you know it.',
 				),
 		}),
 		outputSchema: z.object({
@@ -47,11 +73,7 @@ export const packageInvocationTokenListCapability = defineDomainCapability(
 				(await getSavedPackageById(ctx.env.APP_DB, {
 					userId: user.userId,
 					packageId: args.package_id,
-				})) ??
-				(await getSavedPackageByKodyId(ctx.env.APP_DB, {
-					userId: user.userId,
-					kodyId: args.package_id,
-				}))
+				})) ?? (await resolveSavedPackageByName(ctx.env, user, args.package_id))
 			if (!savedPackage) {
 				throw new McpCallerError('Saved package not found for this user.')
 			}

--- a/packages/worker/universal/community-empty-state.tsx
+++ b/packages/worker/universal/community-empty-state.tsx
@@ -18,7 +18,7 @@ import {
 } from '#universal/styles/style-primitives.ts'
 
 function buildCreatePackagePrompt(query: string) {
-	return `I searched Kody Community for "${query}" and found no published package. Create this package for me. First open search({ entity: ["package_authoring:guide", "package_lifecycle:guide"] }). Then choose a scoped package.json name (@you/leaf) and call packageGetGitRemote({ create: true }) to create its repository. Build, test, and publish a useful package that matches my search.`
+	return `I searched Kody Community for "${query}" and found no published package. Create this package for me. First open search({ entity: ["package_authoring:guide", "package_lifecycle:guide"] }). Then choose a scoped package.json name (@you/leaf) and call packageGetGitRemote({ create: true, kody_id: '@you/leaf' }) to create its repository. Build, test, and publish a useful package that matches my search.`
 }
 
 /**

--- a/packages/worker/universal/how-kody-works-transcript.ts
+++ b/packages/worker/universal/how-kody-works-transcript.ts
@@ -230,6 +230,7 @@ const getGitRemoteCreateCode = `import { kody } from 'kody:runtime'
 export default async function main() {
 	return await kody.packageGetGitRemote({
 		create: true,
+		kody_id: '@you/kody-bot-shipped',
 		description: 'What kody-bot shipped since you last asked.',
 	})
 }`

--- a/packages/worker/universal/onboarding-examples.node.test.ts
+++ b/packages/worker/universal/onboarding-examples.node.test.ts
@@ -126,6 +126,6 @@ test('example prompt searches the user-owned scoped package and statically impor
 	)
 	expect(prompt).toContain('not a platform "kody:@kody/')
 	expect(buildOnboardingPackageAuthoringPrompt('hn-pulse')).toContain(
-		'packageGetGitRemote({ create: true }) with the package name leaf "hn-pulse"',
+		'packageGetGitRemote({ create: true, kody_id: "hn-pulse" })',
 	)
 })

--- a/packages/worker/universal/onboarding-examples.ts
+++ b/packages/worker/universal/onboarding-examples.ts
@@ -121,7 +121,7 @@ export function buildOnboardingPackageAuthoringPrompt(kodyId: string): string {
 	return [
 		`Help me change my Kody package "${kodyId}" or create a new package.`,
 		'First open search({ entity: ["package_authoring:guide", "package_lifecycle:guide"] }).',
-		`Then call packageGetGitRemote({ create: true }) with the package name leaf ${JSON.stringify(kodyId)} or the matching @owner/leaf so we can work in the package repository.`,
+		`Then call packageGetGitRemote({ create: true, kody_id: ${JSON.stringify(kodyId)} }) or pass the matching @owner/leaf in leftover kody_id so we can work in the package repository.`,
 		'Ask what I want the package to do, then follow the guides.',
 	].join(' ')
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Follow-up to #2229. Make create examples actually work, and make `packageInvocationTokenList` honor the scoped names its schema already advertised.

## Why

Bugbot and CodeRabbit on #2229 found two leftover gaps after that PR squash-merged at `ec64f3f0`:

- Create prompts and copy-paste snippets called `packageGetGitRemote({ create: true })` without leftover `kody_id`. The handler still reads the new name from that field, so those examples fail before a stub is registered.
- `packageInvocationTokenList` described `package_id` as accepting `@owner/leaf`, then looked up the raw string as leftover `kody_id`.

## Summary

- Create examples, onboarding/community prompts, and authoring docs pass leftover `kody_id` with a leaf or `@owner/leaf` value.
- `packageInvocationTokenList` normalizes a matching scoped name (and rejects a foreign scope) before the leftover leaf lookup. UUID lookup is unchanged.

## Testing

- Pre-push on `9e9c2fc`: `test:node` 3015 passed, `test:workers` 342 passed
- Focused: token-list capabilities (leaf, `@user/leaf`, foreign `@other/leaf`), onboarding prompt, how-kody-works transcript

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `ec64f3f` · **Head:** `9e9c2fc`

**Classification:** extends — token-list name lookup now strips a matching `@scope/leaf`. Create teaching copy names leftover `kody_id` so examples work.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `saved-packages` | assistant | extends — normalize scoped names in `packageInvocationTokenList` |
| `app-ui` | surfaces | composes — create prompts include leftover `kody_id` |

### Change flow

Create examples pass leftover `kody_id`. Token list resolves a scoped name to the leftover leaf before lookup.

```mermaid
sequenceDiagram
	actor Agent
	participant mcpServer as mcp-server
	participant savedPackages as saved-packages
	participant d1AppDb as d1-app-db
	Agent->>mcpServer: packageGetGitRemote create with leftover kody_id
	mcpServer->>savedPackages: normalizePackageNameInput
	savedPackages->>d1AppDb: insert or reuse saved_packages leaf
	Agent->>mcpServer: packageInvocationTokenList with @owner/leaf
	mcpServer->>savedPackages: normalize scoped name
	savedPackages->>d1AppDb: lookup leftover kody_id leaf
```

### Before / after

| Surface | Before (#2229) | After |
| --- | --- | --- |
| Create examples | `create: true` only | leftover `kody_id` with `@owner/leaf` or leaf |
| Token list name lookup | raw string as `kody_id` | matching scope stripped, foreign scope rejected |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-04c9601f-806b-48d8-b156-f69b88069b54?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-04c9601f-806b-48d8-b156-f69b88069b54&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated package creation guidance and examples to include the package identifier when creating repositories.
  - Clarified accepted package-name formats and handling for new or existing packages.

- **Bug Fixes**
  - Improved saved-package lookup using scoped package names.
  - Added owner validation to prevent access to packages belonging to another owner.

- **Tests**
  - Expanded coverage for scoped package resolution, owner validation, and package-creation tool inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->