### PR TITLE
Fix concurrent MCP OAuth refresh-token rotation

### DIFF
--- a/docs/contributing/architecture/authentication.md
+++ b/docs/contributing/architecture/authentication.md
@@ -712,11 +712,14 @@ intercepts `POST /oauth/token` refresh grants:
   mint. Stolen refresh tokens therefore cannot walk the family forever; they
   work only while they remain the current or previous token, or while a replay
   still matches the grant's current hash.
-- Refresh grants for one `userId`/`grantId` pair are serialized in the handling
-  isolate so two overlapping first-use refreshes re-read the snapshot after the
-  first rotation. That is isolate-local, not a cross-isolate Durable Object
-  lock. Two current-token refreshes that land on different isolates can still
-  race the provider before a snapshot is visible.
+- Previous-token reuse and matching replay skip the isolate lock so a
+  current-token rotation cannot turn a still-valid previous token into
+  `invalid_grant`. Provider rotation for one `userId`/`grantId` pair is
+  serialized in the handling isolate. After a rotation the isolate remembers the
+  new family in memory so a waiter can reuse it even when Workers KV still
+  serves the pre-rotation miss. That is isolate-local, not a cross-isolate
+  Durable Object lock. Two current-token refreshes that land on different
+  isolates can still race the provider before a snapshot is visible.
 - Encrypted snapshots live in `BUNDLE_ARTIFACTS_KV` under
   `derived-cache:v1:mcp-oauth-refresh-family:` / `-replay:` with KV TTLs of two
   hours and one hour. Retention is the TTL, so account deletion does not sweep

--- a/docs/contributing/architecture/authentication.md
+++ b/docs/contributing/architecture/authentication.md
@@ -680,7 +680,7 @@ routed from `packages/worker/src/index.ts`.
   unverified, so no grant/token is created until verification succeeds.
 
 Token lifetimes are set on the `OAuthProvider` in
-`packages/worker/src/index.ts`:
+`packages/worker/src/oauth-provider-options.ts`:
 
 - Access tokens keep the provider default of 1 hour
 - Refresh tokens are issued with no expiry (`refreshTokenTTL: undefined`). The
@@ -691,6 +691,32 @@ Token lifetimes are set on the `OAuthProvider` in
   created through `OAuthHelpers.createClient()` are unexpiring. A DCR client
   record that already has a KV TTL still expires at that instant unless the host
   re-registers
+
+The provider still rotates refresh tokens on use and keeps only the current hash
+plus the immediately previous hash on the grant. MCP hosts on one machine often
+share one stored client and each keep their own copy of the last refresh token
+they saw, so a second host presenting the previous token must not mint a third
+token and invalidate the sibling. `packages/worker/src/oauth-refresh-family.ts`
+intercepts `POST /oauth/token` refresh grants:
+
+- Reuse of the current family's previous refresh token returns the stored
+  current access and refresh tokens when the access token has at least 60
+  seconds left. The grant does not rotate again.
+- The same reuse, when the stored access token is too close to expiry, refreshes
+  once through the stored _current_ refresh token and records a replay for the
+  presented previous token so overlapping siblings converge on that result.
+- A one-hour replay record keyed by the consumed refresh-token hash returns that
+  same current family when the hash still matches the grant's current token.
+  After the next rotation the old replay no longer matches and the consumed
+  token is `invalid_grant`.
+- Tokens that are neither current, previous, nor a still-matching replay do not
+  mint. Stolen refresh tokens therefore cannot walk the family forever; they
+  work only while they remain the current or previous token, or during the
+  one-hour replay window of the rotation that consumed them.
+- Encrypted snapshots live in `BUNDLE_ARTIFACTS_KV` under
+  `derived-cache:v1:mcp-oauth-refresh-family:` / `-replay:` with KV TTLs of two
+  hours and one hour. Retention is the TTL, so account deletion does not sweep
+  those keys.
 
 `/mcp` is protected by `packages/worker/src/mcp-auth.ts`:
 
@@ -715,6 +741,8 @@ Token lifetimes are set on the `OAuthProvider` in
 
 - `packages/worker/src/index.ts` for route order and integration points
 - `packages/worker/src/oauth-handlers.ts` for OAuth authorization logic
+- `packages/worker/src/oauth-refresh-family.ts` for refresh-token family reuse
+  on `/oauth/token`
 - `packages/worker/src/mcp-auth.ts` for MCP token enforcement
 - `packages/worker/src/app/auth-session.ts` for cookie format/signing
 - `packages/worker/src/app/handlers/auth.ts` for app login/signup flow

--- a/docs/contributing/architecture/authentication.md
+++ b/docs/contributing/architecture/authentication.md
@@ -718,11 +718,13 @@ intercepts `POST /oauth/token` refresh grants:
   serialized in the handling isolate. After a rotation the isolate remembers the
   new family in memory so a waiter can reuse it even when Workers KV still
   serves the pre-rotation miss. Isolate memory keeps only the current replay
-  entry and is dropped when the handling isolate revokes that grant. That is
-  isolate-local, not a cross-isolate Durable Object lock. Two current-token
-  refreshes that land on different isolates can still race the provider before a
-  snapshot is visible. A revoke that lands on another isolate can leave residual
-  memory until that isolate exits.
+  entry and is dropped when the handling isolate revokes that grant. Revoke
+  waits for any in-flight persist, then marks the grant forgotten so a later
+  remember cannot rewrite deleted-grant tokens. That is isolate-local, not a
+  cross-isolate Durable Object lock. Two current-token refreshes that land on
+  different isolates can still race the provider before a snapshot is visible. A
+  revoke that lands on another isolate can leave residual memory until that
+  isolate exits.
 - Encrypted snapshots live in `BUNDLE_ARTIFACTS_KV` under
   `derived-cache:v1:mcp-oauth-refresh-family:` / `-replay:` with KV TTLs of two
   hours and one hour. Retention is the TTL, so account deletion does not sweep

--- a/docs/contributing/architecture/authentication.md
+++ b/docs/contributing/architecture/authentication.md
@@ -717,9 +717,12 @@ intercepts `POST /oauth/token` refresh grants:
   `invalid_grant`. Provider rotation for one `userId`/`grantId` pair is
   serialized in the handling isolate. After a rotation the isolate remembers the
   new family in memory so a waiter can reuse it even when Workers KV still
-  serves the pre-rotation miss. That is isolate-local, not a cross-isolate
-  Durable Object lock. Two current-token refreshes that land on different
-  isolates can still race the provider before a snapshot is visible.
+  serves the pre-rotation miss. Isolate memory keeps only the current replay
+  entry and is dropped when the handling isolate revokes that grant. That is
+  isolate-local, not a cross-isolate Durable Object lock. Two current-token
+  refreshes that land on different isolates can still race the provider before a
+  snapshot is visible. A revoke that lands on another isolate can leave residual
+  memory until that isolate exits.
 - Encrypted snapshots live in `BUNDLE_ARTIFACTS_KV` under
   `derived-cache:v1:mcp-oauth-refresh-family:` / `-replay:` with KV TTLs of two
   hours and one hour. Retention is the TTL, so account deletion does not sweep

--- a/docs/contributing/architecture/authentication.md
+++ b/docs/contributing/architecture/authentication.md
@@ -719,12 +719,13 @@ intercepts `POST /oauth/token` refresh grants:
   new family in memory so a waiter can reuse it even when Workers KV still
   serves the pre-rotation miss. Isolate memory keeps only the current replay
   entry and is dropped when the handling isolate revokes that grant. Revoke
-  waits for any in-flight persist, then marks the grant forgotten so a later
-  remember cannot rewrite deleted-grant tokens. That is isolate-local, not a
-  cross-isolate Durable Object lock. Two current-token refreshes that land on
-  different isolates can still race the provider before a snapshot is visible. A
-  revoke that lands on another isolate can leave residual memory until that
-  isolate exits.
+  marks the grant forgotten immediately so lock-skipping reuse cannot serve
+  cached tokens, then waits for any in-flight persist so a later remember cannot
+  rewrite deleted-grant tokens. That is isolate-local, not a cross-isolate
+  Durable Object lock. Two current-token refreshes that land on different
+  isolates can still race the provider before a snapshot is visible. A revoke
+  that lands on another isolate can leave residual memory until that isolate
+  exits.
 - Encrypted snapshots live in `BUNDLE_ARTIFACTS_KV` under
   `derived-cache:v1:mcp-oauth-refresh-family:` / `-replay:` with KV TTLs of two
   hours and one hour. Retention is the TTL, so account deletion does not sweep

--- a/docs/contributing/architecture/authentication.md
+++ b/docs/contributing/architecture/authentication.md
@@ -700,23 +700,26 @@ token and invalidate the sibling. `packages/worker/src/oauth-refresh-family.ts`
 intercepts `POST /oauth/token` refresh grants:
 
 - Reuse of the current family's previous refresh token returns the stored
-  current access and refresh tokens when the access token has at least 60
-  seconds left. The grant does not rotate again.
-- The same reuse, when the stored access token is too close to expiry, refreshes
-  once through the stored _current_ refresh token and records a replay for the
-  presented previous token so overlapping siblings converge on that result.
+  current access and refresh tokens. The grant does not rotate again, even when
+  that access token is near expiry — only presenting the current refresh token
+  rotates. The sibling can then refresh with the current token.
 - A one-hour replay record keyed by the consumed refresh-token hash returns that
-  same current family when the hash still matches the grant's current token.
-  After the next rotation the old replay no longer matches and the consumed
-  token is `invalid_grant`.
+  same current family when the hash still matches the grant's current token,
+  even when the stored access token is near expiry. After the next rotation the
+  old replay no longer matches and the consumed token is `invalid_grant`. The
+  one-hour TTL is maximum retention, not guaranteed acceptance.
 - Tokens that are neither current, previous, nor a still-matching replay do not
   mint. Stolen refresh tokens therefore cannot walk the family forever; they
-  work only while they remain the current or previous token, or during the
-  one-hour replay window of the rotation that consumed them.
+  work only while they remain the current or previous token, or while a replay
+  still matches the grant's current hash.
+- Two hosts that present the same current refresh token at the same instant can
+  still race the provider before a snapshot exists. The interceptor does not
+  serialize those current-token refreshes.
 - Encrypted snapshots live in `BUNDLE_ARTIFACTS_KV` under
   `derived-cache:v1:mcp-oauth-refresh-family:` / `-replay:` with KV TTLs of two
   hours and one hour. Retention is the TTL, so account deletion does not sweep
-  those keys.
+  those keys. Snapshot writes are best-effort: a KV or encrypt failure does not
+  replace the provider's minted response.
 
 `/mcp` is protected by `packages/worker/src/mcp-auth.ts`:
 

--- a/docs/contributing/architecture/authentication.md
+++ b/docs/contributing/architecture/authentication.md
@@ -712,9 +712,11 @@ intercepts `POST /oauth/token` refresh grants:
   mint. Stolen refresh tokens therefore cannot walk the family forever; they
   work only while they remain the current or previous token, or while a replay
   still matches the grant's current hash.
-- Two hosts that present the same current refresh token at the same instant can
-  still race the provider before a snapshot exists. The interceptor does not
-  serialize those current-token refreshes.
+- Refresh grants for one `userId`/`grantId` pair are serialized in the handling
+  isolate so two overlapping first-use refreshes re-read the snapshot after the
+  first rotation. That is isolate-local, not a cross-isolate Durable Object
+  lock. Two current-token refreshes that land on different isolates can still
+  race the provider before a snapshot is visible.
 - Encrypted snapshots live in `BUNDLE_ARTIFACTS_KV` under
   `derived-cache:v1:mcp-oauth-refresh-family:` / `-replay:` with KV TTLs of two
   hours and one hour. Retention is the TTL, so account deletion does not sweep

--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -571,7 +571,9 @@ OAuth provider state is stored in `OAUTH_KV` through the
 snapshots, bundle artifacts, package retriever caches, and community listing
 snapshots are stored in `BUNDLE_ARTIFACTS_KV`. That binding also holds the
 platform-owned `platform-settings:v1:reserved-usernames` runtime
-reserved-username override.
+reserved-username override and short-lived encrypted MCP OAuth refresh-family
+snapshots (`derived-cache:v1:mcp-oauth-refresh-family:` /
+`derived-cache:v1:mcp-oauth-refresh-replay:`).
 
 - Bindings are configured in `packages/worker/wrangler.jsonc` (remote KV IDs are
   supplied at deploy time via generated Wrangler configs, not committed in the
@@ -1469,6 +1471,13 @@ app-owned keys in it. App-owned `BUNDLE_ARTIFACTS_KV` keys are:
 - `package-retriever-manifest:v1:{userId}:{packageId}:{revision}`.
 - `package-retriever-index-entry:v1:{userId}:{scope}:{packageId}:{retrieverKey}`
   for per-entry retriever index rows.
+- `derived-cache:v1:mcp-oauth-refresh-family:{userId}:{grantId}` and
+  `derived-cache:v1:mcp-oauth-refresh-replay:{userId}:{grantId}:{tokenHash}` —
+  encrypted MCP OAuth refresh-family snapshots used so concurrent hosts sharing
+  one client can reuse the previous refresh token without invalidating siblings
+  (`packages/worker/src/oauth-refresh-family.ts`). Written with KV
+  `expirationTtl` (two hours / one hour). Retention is the TTL, so
+  account-deletion cleanup is not required.
 - `derived-cache:v1:usage-rollups:user:{userId}:asof:{YYYY-MM}` — derived
   per-user usage read model written with KV `expirationTtl`; retention is five
   minutes, so immediate account-deletion cleanup is not required.

--- a/docs/contributing/architecture/primitives.yaml
+++ b/docs/contributing/architecture/primitives.yaml
@@ -168,6 +168,7 @@ primitives:
     summary: Bearer tokens for /mcp via workers-oauth-provider.
     code:
       - packages/worker/src/oauth-handlers.ts
+      - packages/worker/src/oauth-refresh-family.ts
       - packages/worker/src/mcp-auth.ts
       - packages/worker/src/oidc/
     docs:

--- a/docs/use/troubleshooting.md
+++ b/docs/use/troubleshooting.md
@@ -24,9 +24,10 @@ the expired access token, get a 401, and ask for a full browser login instead.
 
 Concurrent MCP hosts that share one stored Kody OAuth client can refresh at the
 same time. Reusing the previous refresh token returns the current family tokens
-instead of minting a new one that invalidates siblings. A refresh token older
-than the current/previous pair (and outside the one-hour replay window) is
-`invalid_grant` and needs a new browser login.
+instead of minting a new one that invalidates siblings. A consumed token's
+one-hour replay is the maximum retention, not a guarantee: after the next
+rotation that replay no longer matches and is `invalid_grant`. Tokens outside
+the current/previous pair and that window also need a new browser login.
 
 Try this first:
 

--- a/docs/use/troubleshooting.md
+++ b/docs/use/troubleshooting.md
@@ -22,12 +22,18 @@ Kody access tokens last one hour. A host that stores the refresh token should
 call `/oauth/token` and stay signed in. Cursor does this. Some Codex builds send
 the expired access token, get a 401, and ask for a full browser login instead.
 
+Concurrent MCP hosts that share one stored Kody OAuth client can refresh at the
+same time. Reusing the previous refresh token returns the current family tokens
+instead of minting a new one that invalidates siblings. A refresh token older
+than the current/previous pair (and outside the one-hour replay window) is
+`invalid_grant` and needs a new browser login.
+
 Try this first:
 
 1. Update Codex.
 2. Run `codex mcp logout kody`, then `codex mcp login kody`.
-3. Avoid running Codex desktop and the CLI at the same time against the same
-   login. They can race a rotating refresh token and both get kicked out.
+3. If two Codex processes still prompt together, update Kody — overlapping
+   refreshes on one shared client should stay signed in.
 
 If it still happens about every hour or every new Codex launch, that is the host
 skipping refresh. Cursor and Claude Code stay logged in. Email

--- a/packages/worker/src/connected-mcp-agents.ts
+++ b/packages/worker/src/connected-mcp-agents.ts
@@ -6,6 +6,7 @@ import {
 import {
 	listUserOAuthGrants,
 	listUserOAuthGrantsForClient,
+	revokeOAuthGrant,
 	type OAuthClientInfo,
 	type OAuthGrantHelpers,
 	type OAuthGrantListHelpers,
@@ -49,7 +50,7 @@ export async function revokeConnectedMcpAgent(input: {
 	)
 	if (grants.length === 0) return { error: 'not_found' }
 	for (const grant of grants) {
-		await input.helpers.revokeGrant(grant.id, input.userId)
+		await revokeOAuthGrant(input.helpers, grant.id, input.userId)
 	}
 	return { revoked: grants.length }
 }

--- a/packages/worker/src/oauth-grants.ts
+++ b/packages/worker/src/oauth-grants.ts
@@ -80,7 +80,7 @@ export async function revokeOAuthGrant(
 	userId: string,
 ) {
 	const result = await helpers.revokeGrant(grantId, userId)
-	forgetRefreshFamilyGrant(userId, grantId)
+	await forgetRefreshFamilyGrant(userId, grantId)
 	return result
 }
 

--- a/packages/worker/src/oauth-grants.ts
+++ b/packages/worker/src/oauth-grants.ts
@@ -1,4 +1,5 @@
 import { getErrorMessage } from '@kody-internal/shared/error-message.ts'
+import { forgetRefreshFamilyGrant } from '#worker/oauth-refresh-family.ts'
 
 export type OAuthGrantListItem = {
 	id: string
@@ -73,6 +74,16 @@ export async function listUserOAuthGrantsForClient(
 
 const maxRevokePasses = 3
 
+export async function revokeOAuthGrant(
+	helpers: OAuthGrantHelpers,
+	grantId: string,
+	userId: string,
+) {
+	const result = await helpers.revokeGrant(grantId, userId)
+	forgetRefreshFamilyGrant(userId, grantId)
+	return result
+}
+
 /**
  * Revoke every grant for `userId`. Re-lists after each pass so a grant
  * created while the previous snapshot was being revoked cannot survive.
@@ -89,7 +100,7 @@ export async function revokeAllOAuthGrantsForUser(input: {
 		const grants = await listUserOAuthGrants(input.helpers, input.userId)
 		if (grants.length === 0) return revoked
 		for (const grant of grants) {
-			await input.helpers.revokeGrant(grant.id, input.userId)
+			await revokeOAuthGrant(input.helpers, grant.id, input.userId)
 			revoked += 1
 		}
 	}
@@ -123,7 +134,7 @@ export async function revokeAllOAuthGrantsBestEffort(input: {
 		}
 		for (const grant of page.items) {
 			try {
-				await input.helpers.revokeGrant(grant.id, input.userId)
+				await revokeOAuthGrant(input.helpers, grant.id, input.userId)
 				revoked += 1
 			} catch (error) {
 				input.warnings.push(

--- a/packages/worker/src/oauth-handlers.ts
+++ b/packages/worker/src/oauth-handlers.ts
@@ -34,7 +34,10 @@ import { getPkceValidationError } from '#worker/oauth-pkce.ts'
 import { oauthPaths } from '#universal/oauth-paths.ts'
 import { getAppBaseUrl } from '#worker/app-base-url.ts'
 import { mcpResourcePath } from './mcp-auth.ts'
-import { listUserOAuthGrantsForClient } from '#worker/oauth-grants.ts'
+import {
+	listUserOAuthGrantsForClient,
+	revokeOAuthGrant,
+} from '#worker/oauth-grants.ts'
 import { hasSecondConnectedMcpClient } from '#universal/connected-mcp-agents.ts'
 import { loadInboundMcpConnectionState } from '#worker/connected-mcp-agents.ts'
 import { maybeEvaluateSecondAgentStandardGift } from '#worker/entitlements/second-agent-standard-gift.ts'
@@ -538,7 +541,7 @@ async function handleResetClientRequest(
 		const userId = resolveUserStableId(userRecord)
 		const grants = await listUserOAuthGrantsForClient(helpers, userId, clientId)
 		await Promise.all(
-			grants.map((grant) => helpers.revokeGrant(grant.id, userId)),
+			grants.map((grant) => revokeOAuthGrant(helpers, grant.id, userId)),
 		)
 		const ownsClient = await userOwnsMcpOauthClient(
 			env.APP_DB,

--- a/packages/worker/src/oauth-refresh-family.node.test.ts
+++ b/packages/worker/src/oauth-refresh-family.node.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from 'vitest'
 import {
 	decideRefreshFamilyAction,
+	handleMcpOAuthTokenRequest,
 	hashOAuthToken,
 	mcpOAuthRefreshFamilyReplayKey,
 	mcpOAuthRefreshFamilySnapshotKey,
@@ -49,7 +50,6 @@ test('refresh family keys and token parsing stay grant-scoped', async () => {
 })
 
 test('refresh family returns current tokens on previous reuse and rejects stale replay', () => {
-	const nowSeconds = 1_000
 	const current = snapshot()
 	const family = grant()
 
@@ -59,7 +59,6 @@ test('refresh family returns current tokens on previous reuse and rejects stale 
 			grant: family,
 			snapshot: current,
 			replay: null,
-			nowSeconds,
 		}),
 	).toEqual({ kind: 'return-snapshot' })
 
@@ -69,7 +68,6 @@ test('refresh family returns current tokens on previous reuse and rejects stale 
 			grant: family,
 			snapshot: current,
 			replay: current,
-			nowSeconds,
 		}),
 	).toEqual({ kind: 'return-replay' })
 
@@ -79,27 +77,18 @@ test('refresh family returns current tokens on previous reuse and rejects stale 
 			grant: family,
 			snapshot: current,
 			replay: null,
-			nowSeconds,
 		}),
 	).toEqual({ kind: 'pass-through' })
-
-	expect(
-		decideRefreshFamilyAction({
-			presentedHash: 'hash-rt1',
-			grant: family,
-			snapshot: current,
-			replay: null,
-			nowSeconds: 1_980,
-		}),
-	).toEqual({ kind: 'refresh-stored-current' })
 
 	expect(
 		decideRefreshFamilyAction({
 			presentedHash: 'hash-rt0',
 			grant: family,
 			snapshot: current,
-			replay: snapshot({ currentRefreshTokenHash: 'hash-rt2' }),
-			nowSeconds,
+			replay: snapshot({
+				currentRefreshTokenHash: 'hash-rt2',
+				accessExpiresAt: 1_010,
+			}),
 		}),
 	).toEqual({ kind: 'return-replay' })
 
@@ -109,7 +98,6 @@ test('refresh family returns current tokens on previous reuse and rejects stale 
 			grant: grant({ currentRefreshTokenHash: 'hash-rt3' }),
 			snapshot: snapshot({ currentRefreshTokenHash: 'hash-rt2' }),
 			replay: snapshot({ currentRefreshTokenHash: 'hash-rt2' }),
-			nowSeconds,
 		}),
 	).toEqual({ kind: 'pass-through' })
 
@@ -119,7 +107,6 @@ test('refresh family returns current tokens on previous reuse and rejects stale 
 			grant: null,
 			snapshot: current,
 			replay: current,
-			nowSeconds,
 		}),
 	).toEqual({ kind: 'pass-through' })
 
@@ -129,7 +116,49 @@ test('refresh family returns current tokens on previous reuse and rejects stale 
 			grant: family,
 			snapshot: current,
 			replay: null,
-			nowSeconds,
 		}),
 	).toEqual({ kind: 'pass-through' })
+})
+
+test('refresh family persist failures still return provider-minted tokens', async () => {
+	const minted = {
+		access_token: 'user-1:grant-1:at2',
+		refresh_token: 'user-1:grant-1:rt2',
+		token_type: 'bearer',
+		expires_in: 3600,
+		scope: 'profile email',
+	}
+	const { response } = await handleMcpOAuthTokenRequest({
+		request: new Request('https://heykody.dev/oauth/token', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+			body: new URLSearchParams({
+				grant_type: 'refresh_token',
+				refresh_token: 'user-1:grant-1:rt1',
+			}),
+		}),
+		env: {
+			SECRET_STORE_KEY: 'test-secret-store-key-32-chars-minimum',
+			BUNDLE_ARTIFACTS_KV: {
+				async get() {
+					return null
+				},
+				async put() {
+					throw new Error('kv unavailable')
+				},
+			},
+			OAUTH_KV: {
+				async get() {
+					return null
+				},
+			},
+		} as unknown as Env,
+		fetchProvider: async () =>
+			new Response(JSON.stringify(minted), {
+				status: 200,
+				headers: { 'Content-Type': 'application/json' },
+			}),
+	})
+	expect(response.status).toBe(200)
+	await expect(response.json()).resolves.toEqual(minted)
 })

--- a/packages/worker/src/oauth-refresh-family.node.test.ts
+++ b/packages/worker/src/oauth-refresh-family.node.test.ts
@@ -430,10 +430,27 @@ test('refresh family forget wins over an in-flight persist', async () => {
 	})
 	await currentRefreshEntered
 	const forget = forgetRefreshFamilyGrant('user-race', 'grant-race')
+	const reuseDuringLockWait = handleMcpOAuthTokenRequest({
+		request: refreshTokenRequest('user-race:grant-race:rt1'),
+		env,
+		fetchProvider,
+	})
+	const reuseWhileLocked = await Promise.race([
+		reuseDuringLockWait.then((result) => ({ kind: 'returned', result })),
+		new Promise<{ kind: 'waiting' }>((resolve) => {
+			setTimeout(() => resolve({ kind: 'waiting' }), 20)
+		}),
+	])
+	expect(reuseWhileLocked.kind).toBe('waiting')
 	releaseCurrentRefresh()
 	const currentRefreshResult = await currentRefresh
 	expect(currentRefreshResult.response.status).toBe(200)
 	await forget
+	const reuseAfterForget = await reuseDuringLockWait
+	expect(reuseAfterForget.response.status).toBe(400)
+	await expect(reuseAfterForget.response.json()).resolves.toEqual({
+		error: 'invalid_grant',
+	})
 
 	const afterRevoke = await handleMcpOAuthTokenRequest({
 		request: refreshTokenRequest('user-race:grant-race:rt2'),

--- a/packages/worker/src/oauth-refresh-family.node.test.ts
+++ b/packages/worker/src/oauth-refresh-family.node.test.ts
@@ -1,0 +1,135 @@
+import { expect, test } from 'vitest'
+import {
+	decideRefreshFamilyAction,
+	hashOAuthToken,
+	mcpOAuthRefreshFamilyReplayKey,
+	mcpOAuthRefreshFamilySnapshotKey,
+	parseOAuthRefreshToken,
+	type RefreshFamilyGrantIds,
+	type RefreshFamilySnapshot,
+} from './oauth-refresh-family.ts'
+
+function snapshot(overrides: Partial<RefreshFamilySnapshot> = {}) {
+	return {
+		userId: 'user-1',
+		grantId: 'grant-1',
+		currentRefreshTokenHash: 'hash-rt2',
+		refreshToken: 'user-1:grant-1:rt2',
+		accessToken: 'user-1:grant-1:at2',
+		accessExpiresAt: 2_000,
+		tokenType: 'bearer',
+		scope: 'profile email',
+		resource: 'https://heykody.dev/mcp',
+		...overrides,
+	} satisfies RefreshFamilySnapshot
+}
+
+function grant(overrides: Partial<RefreshFamilyGrantIds> = {}) {
+	return {
+		currentRefreshTokenHash: 'hash-rt2',
+		previousRefreshTokenHash: 'hash-rt1',
+		...overrides,
+	} satisfies RefreshFamilyGrantIds
+}
+
+test('refresh family keys and token parsing stay grant-scoped', async () => {
+	expect(parseOAuthRefreshToken('user-1:grant-1:rt1')).toEqual({
+		userId: 'user-1',
+		grantId: 'grant-1',
+	})
+	expect(parseOAuthRefreshToken('not-a-token')).toBeNull()
+	expect(parseOAuthRefreshToken('user-1:grant-1:')).toBeNull()
+	expect(mcpOAuthRefreshFamilySnapshotKey('user-1', 'grant-1')).toBe(
+		'derived-cache:v1:mcp-oauth-refresh-family:user-1:grant-1',
+	)
+	expect(mcpOAuthRefreshFamilyReplayKey('user-1', 'grant-1', 'abc')).toBe(
+		'derived-cache:v1:mcp-oauth-refresh-replay:user-1:grant-1:abc',
+	)
+	expect(await hashOAuthToken('user-1:grant-1:rt1')).toMatch(/^[0-9a-f]{64}$/)
+})
+
+test('refresh family returns current tokens on previous reuse and rejects stale replay', () => {
+	const nowSeconds = 1_000
+	const current = snapshot()
+	const family = grant()
+
+	expect(
+		decideRefreshFamilyAction({
+			presentedHash: 'hash-rt1',
+			grant: family,
+			snapshot: current,
+			replay: null,
+			nowSeconds,
+		}),
+	).toEqual({ kind: 'return-snapshot' })
+
+	expect(
+		decideRefreshFamilyAction({
+			presentedHash: 'hash-rt1',
+			grant: family,
+			snapshot: current,
+			replay: current,
+			nowSeconds,
+		}),
+	).toEqual({ kind: 'return-replay' })
+
+	expect(
+		decideRefreshFamilyAction({
+			presentedHash: 'hash-rt2',
+			grant: family,
+			snapshot: current,
+			replay: null,
+			nowSeconds,
+		}),
+	).toEqual({ kind: 'pass-through' })
+
+	expect(
+		decideRefreshFamilyAction({
+			presentedHash: 'hash-rt1',
+			grant: family,
+			snapshot: current,
+			replay: null,
+			nowSeconds: 1_980,
+		}),
+	).toEqual({ kind: 'refresh-stored-current' })
+
+	expect(
+		decideRefreshFamilyAction({
+			presentedHash: 'hash-rt0',
+			grant: family,
+			snapshot: current,
+			replay: snapshot({ currentRefreshTokenHash: 'hash-rt2' }),
+			nowSeconds,
+		}),
+	).toEqual({ kind: 'return-replay' })
+
+	expect(
+		decideRefreshFamilyAction({
+			presentedHash: 'hash-rt1',
+			grant: grant({ currentRefreshTokenHash: 'hash-rt3' }),
+			snapshot: snapshot({ currentRefreshTokenHash: 'hash-rt2' }),
+			replay: snapshot({ currentRefreshTokenHash: 'hash-rt2' }),
+			nowSeconds,
+		}),
+	).toEqual({ kind: 'pass-through' })
+
+	expect(
+		decideRefreshFamilyAction({
+			presentedHash: 'hash-rt1',
+			grant: null,
+			snapshot: current,
+			replay: current,
+			nowSeconds,
+		}),
+	).toEqual({ kind: 'pass-through' })
+
+	expect(
+		decideRefreshFamilyAction({
+			presentedHash: 'hash-unknown',
+			grant: family,
+			snapshot: current,
+			replay: null,
+			nowSeconds,
+		}),
+	).toEqual({ kind: 'pass-through' })
+})

--- a/packages/worker/src/oauth-refresh-family.node.test.ts
+++ b/packages/worker/src/oauth-refresh-family.node.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from 'vitest'
 import {
 	decideRefreshFamilyAction,
+	forgetRefreshFamilyGrant,
 	handleMcpOAuthTokenRequest,
 	hashOAuthToken,
 	mcpOAuthRefreshFamilyReplayKey,
@@ -327,4 +328,45 @@ test('refresh family previous reuse does not wait for a current-token rotation',
 	const currentRefreshResult = await currentRefresh
 	expect(currentRefreshResult.response.status).toBe(200)
 	await expect(currentRefreshResult.response.json()).resolves.toEqual(rotated)
+})
+
+test('refresh family isolate memory does not survive grant revoke', async () => {
+	const env = missingKvEnv()
+	const family = mintedTokens(
+		'user-rev:grant-rev:rt2',
+		'user-rev:grant-rev:at2',
+	)
+	let providerCalls = 0
+	const fetchProvider = async () => {
+		providerCalls += 1
+		if (providerCalls === 1) {
+			return new Response(JSON.stringify(family), {
+				status: 200,
+				headers: { 'Content-Type': 'application/json' },
+			})
+		}
+		return new Response(JSON.stringify({ error: 'invalid_grant' }), {
+			status: 400,
+			headers: { 'Content-Type': 'application/json' },
+		})
+	}
+
+	const seeded = await handleMcpOAuthTokenRequest({
+		request: refreshTokenRequest('user-rev:grant-rev:rt1'),
+		env,
+		fetchProvider,
+	})
+	expect(seeded.response.status).toBe(200)
+	forgetRefreshFamilyGrant('user-rev', 'grant-rev')
+
+	const afterRevoke = await handleMcpOAuthTokenRequest({
+		request: refreshTokenRequest('user-rev:grant-rev:rt1'),
+		env,
+		fetchProvider,
+	})
+	expect(afterRevoke.response.status).toBe(400)
+	await expect(afterRevoke.response.json()).resolves.toEqual({
+		error: 'invalid_grant',
+	})
+	expect(providerCalls).toBe(2)
 })

--- a/packages/worker/src/oauth-refresh-family.node.test.ts
+++ b/packages/worker/src/oauth-refresh-family.node.test.ts
@@ -120,6 +120,46 @@ test('refresh family returns current tokens on previous reuse and rejects stale 
 	).toEqual({ kind: 'pass-through' })
 })
 
+function refreshTokenRequest(refreshToken: string) {
+	return new Request('https://heykody.dev/oauth/token', {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+		body: new URLSearchParams({
+			grant_type: 'refresh_token',
+			refresh_token: refreshToken,
+		}),
+	})
+}
+
+function mintedTokens(refreshToken: string, accessToken: string) {
+	return {
+		access_token: accessToken,
+		refresh_token: refreshToken,
+		token_type: 'bearer',
+		expires_in: 3600,
+		scope: 'profile email',
+	}
+}
+
+function missingKvEnv() {
+	return {
+		SECRET_STORE_KEY: 'test-secret-store-key-32-chars-minimum',
+		BUNDLE_ARTIFACTS_KV: {
+			async get() {
+				return null
+			},
+			async put() {
+				return undefined
+			},
+		},
+		OAUTH_KV: {
+			async get() {
+				return null
+			},
+		},
+	} as unknown as Env
+}
+
 test('refresh family persist failures still return provider-minted tokens', async () => {
 	const minted = {
 		access_token: 'user-1:grant-1:at2',
@@ -161,4 +201,130 @@ test('refresh family persist failures still return provider-minted tokens', asyn
 	})
 	expect(response.status).toBe(200)
 	await expect(response.json()).resolves.toEqual(minted)
+})
+
+test('refresh family reuses isolate memory when KV still misses after the first rotation', async () => {
+	const env = missingKvEnv()
+	const first = mintedTokens('user-mem:grant-mem:rt2', 'user-mem:grant-mem:at2')
+	let providerCalls = 0
+	const fetchProvider = async () => {
+		providerCalls += 1
+		if (providerCalls === 1) {
+			return new Response(JSON.stringify(first), {
+				status: 200,
+				headers: { 'Content-Type': 'application/json' },
+			})
+		}
+		return new Response(JSON.stringify({ error: 'invalid_grant' }), {
+			status: 400,
+			headers: { 'Content-Type': 'application/json' },
+		})
+	}
+
+	const [left, right] = await Promise.all([
+		handleMcpOAuthTokenRequest({
+			request: refreshTokenRequest('user-mem:grant-mem:rt1'),
+			env,
+			fetchProvider,
+		}),
+		handleMcpOAuthTokenRequest({
+			request: refreshTokenRequest('user-mem:grant-mem:rt1'),
+			env,
+			fetchProvider,
+		}),
+	])
+	expect(left.response.status).toBe(200)
+	expect(right.response.status).toBe(200)
+	await expect(left.response.json()).resolves.toMatchObject({
+		access_token: first.access_token,
+		refresh_token: first.refresh_token,
+	})
+	await expect(right.response.json()).resolves.toMatchObject({
+		access_token: first.access_token,
+		refresh_token: first.refresh_token,
+	})
+	expect(providerCalls).toBe(1)
+
+	const reused = await handleMcpOAuthTokenRequest({
+		request: refreshTokenRequest('user-mem:grant-mem:rt1'),
+		env,
+		fetchProvider,
+	})
+	expect(reused.response.status).toBe(200)
+	await expect(reused.response.json()).resolves.toMatchObject({
+		access_token: first.access_token,
+		refresh_token: first.refresh_token,
+	})
+	expect(providerCalls).toBe(1)
+})
+
+test('refresh family previous reuse does not wait for a current-token rotation', async () => {
+	const env = missingKvEnv()
+	const family = mintedTokens(
+		'user-lock:grant-lock:rt2',
+		'user-lock:grant-lock:at2',
+	)
+	const rotated = mintedTokens(
+		'user-lock:grant-lock:rt3',
+		'user-lock:grant-lock:at3',
+	)
+	let releaseCurrentRefresh = () => {}
+	const currentRefreshHeld = new Promise<void>((resolve) => {
+		releaseCurrentRefresh = resolve
+	})
+	let currentRefreshStarted = () => {}
+	const currentRefreshEntered = new Promise<void>((resolve) => {
+		currentRefreshStarted = resolve
+	})
+	const fetchProvider = async (request: Request) => {
+		const formData = await request.clone().formData()
+		const presented = formData.get('refresh_token')
+		if (presented === 'user-lock:grant-lock:rt1') {
+			return new Response(JSON.stringify(family), {
+				status: 200,
+				headers: { 'Content-Type': 'application/json' },
+			})
+		}
+		if (presented === 'user-lock:grant-lock:rt2') {
+			currentRefreshStarted()
+			await currentRefreshHeld
+			return new Response(JSON.stringify(rotated), {
+				status: 200,
+				headers: { 'Content-Type': 'application/json' },
+			})
+		}
+		return new Response(JSON.stringify({ error: 'invalid_grant' }), {
+			status: 400,
+			headers: { 'Content-Type': 'application/json' },
+		})
+	}
+
+	const seeded = await handleMcpOAuthTokenRequest({
+		request: refreshTokenRequest('user-lock:grant-lock:rt1'),
+		env,
+		fetchProvider,
+	})
+	expect(seeded.response.status).toBe(200)
+	await expect(seeded.response.json()).resolves.toEqual(family)
+
+	const currentRefresh = handleMcpOAuthTokenRequest({
+		request: refreshTokenRequest('user-lock:grant-lock:rt2'),
+		env,
+		fetchProvider,
+	})
+	await currentRefreshEntered
+	const previousReuse = await handleMcpOAuthTokenRequest({
+		request: refreshTokenRequest('user-lock:grant-lock:rt1'),
+		env,
+		fetchProvider,
+	})
+	expect(previousReuse.response.status).toBe(200)
+	await expect(previousReuse.response.json()).resolves.toMatchObject({
+		access_token: family.access_token,
+		refresh_token: family.refresh_token,
+	})
+	releaseCurrentRefresh()
+	const currentRefreshResult = await currentRefresh
+	expect(currentRefreshResult.response.status).toBe(200)
+	await expect(currentRefreshResult.response.json()).resolves.toEqual(rotated)
 })

--- a/packages/worker/src/oauth-refresh-family.node.test.ts
+++ b/packages/worker/src/oauth-refresh-family.node.test.ts
@@ -357,7 +357,7 @@ test('refresh family isolate memory does not survive grant revoke', async () => 
 		fetchProvider,
 	})
 	expect(seeded.response.status).toBe(200)
-	forgetRefreshFamilyGrant('user-rev', 'grant-rev')
+	await forgetRefreshFamilyGrant('user-rev', 'grant-rev')
 
 	const afterRevoke = await handleMcpOAuthTokenRequest({
 		request: refreshTokenRequest('user-rev:grant-rev:rt1'),
@@ -369,4 +369,79 @@ test('refresh family isolate memory does not survive grant revoke', async () => 
 		error: 'invalid_grant',
 	})
 	expect(providerCalls).toBe(2)
+})
+
+test('refresh family forget wins over an in-flight persist', async () => {
+	const env = missingKvEnv()
+	const family = mintedTokens(
+		'user-race:grant-race:rt2',
+		'user-race:grant-race:at2',
+	)
+	const rotated = mintedTokens(
+		'user-race:grant-race:rt3',
+		'user-race:grant-race:at3',
+	)
+	let releaseCurrentRefresh = () => {}
+	const currentRefreshHeld = new Promise<void>((resolve) => {
+		releaseCurrentRefresh = resolve
+	})
+	let currentRefreshStarted = () => {}
+	const currentRefreshEntered = new Promise<void>((resolve) => {
+		currentRefreshStarted = resolve
+	})
+	let seededFirstRefresh = false
+	let rotatedCurrentOnce = false
+	const fetchProvider = async (request: Request) => {
+		const formData = await request.clone().formData()
+		const presented = formData.get('refresh_token')
+		if (presented === 'user-race:grant-race:rt1' && !seededFirstRefresh) {
+			seededFirstRefresh = true
+			return new Response(JSON.stringify(family), {
+				status: 200,
+				headers: { 'Content-Type': 'application/json' },
+			})
+		}
+		if (presented === 'user-race:grant-race:rt2' && !rotatedCurrentOnce) {
+			rotatedCurrentOnce = true
+			currentRefreshStarted()
+			await currentRefreshHeld
+			return new Response(JSON.stringify(rotated), {
+				status: 200,
+				headers: { 'Content-Type': 'application/json' },
+			})
+		}
+		return new Response(JSON.stringify({ error: 'invalid_grant' }), {
+			status: 400,
+			headers: { 'Content-Type': 'application/json' },
+		})
+	}
+
+	const seeded = await handleMcpOAuthTokenRequest({
+		request: refreshTokenRequest('user-race:grant-race:rt1'),
+		env,
+		fetchProvider,
+	})
+	expect(seeded.response.status).toBe(200)
+
+	const currentRefresh = handleMcpOAuthTokenRequest({
+		request: refreshTokenRequest('user-race:grant-race:rt2'),
+		env,
+		fetchProvider,
+	})
+	await currentRefreshEntered
+	const forget = forgetRefreshFamilyGrant('user-race', 'grant-race')
+	releaseCurrentRefresh()
+	const currentRefreshResult = await currentRefresh
+	expect(currentRefreshResult.response.status).toBe(200)
+	await forget
+
+	const afterRevoke = await handleMcpOAuthTokenRequest({
+		request: refreshTokenRequest('user-race:grant-race:rt2'),
+		env,
+		fetchProvider,
+	})
+	expect(afterRevoke.response.status).toBe(400)
+	await expect(afterRevoke.response.json()).resolves.toEqual({
+		error: 'invalid_grant',
+	})
 })

--- a/packages/worker/src/oauth-refresh-family.ts
+++ b/packages/worker/src/oauth-refresh-family.ts
@@ -16,7 +16,10 @@ import {
  * current tokens without rotating, even when the stored access token is near
  * expiry. A one-hour replay of the consumed token returns that same current
  * family while the hash still matches. Tokens outside that family do not
- * mint. See `docs/contributing/architecture/authentication.md`.
+ * mint. Refresh grants for one user/grant pair run one at a time in this
+ * isolate so overlapping first-use siblings re-read the snapshot after the
+ * first rotation. See
+ * `docs/contributing/architecture/authentication.md`.
  */
 
 const mcpOAuthRefreshFamilyReplayTtlSeconds = 60 * 60
@@ -133,6 +136,39 @@ export function decideRefreshFamilyAction(input: {
 	return { kind: 'pass-through' }
 }
 
+const refreshFamilyGrantLocks = new Map<string, Promise<void>>()
+
+function refreshFamilyGrantLockKey(userId: string, grantId: string) {
+	return `${userId}:${grantId}`
+}
+
+async function withRefreshFamilyGrantLock<T>(
+	userId: string,
+	grantId: string,
+	work: () => Promise<T>,
+): Promise<T> {
+	const key = refreshFamilyGrantLockKey(userId, grantId)
+	let release = () => {}
+	const held = new Promise<void>((resolve) => {
+		release = resolve
+	})
+	const previous = refreshFamilyGrantLocks.get(key) ?? Promise.resolve()
+	const tail = previous.then(
+		() => held,
+		() => held,
+	)
+	refreshFamilyGrantLocks.set(key, tail)
+	try {
+		await previous.catch(() => undefined)
+		return await work()
+	} finally {
+		release()
+		if (refreshFamilyGrantLocks.get(key) === tail) {
+			refreshFamilyGrantLocks.delete(key)
+		}
+	}
+}
+
 export async function handleMcpOAuthTokenRequest(input: {
 	request: Request
 	env: Env
@@ -143,6 +179,27 @@ export async function handleMcpOAuthTokenRequest(input: {
 		.formData()
 		.catch(() => null)
 	const grantType = readFormString(formData?.get('grant_type'))
+	if (grantType === 'refresh_token' && formData) {
+		const presented = readFormString(formData.get('refresh_token'))
+		const parsed = presented ? parseOAuthRefreshToken(presented) : null
+		if (parsed) {
+			return withRefreshFamilyGrantLock(parsed.userId, parsed.grantId, () =>
+				completeMcpOAuthTokenRequest(input, formData, grantType),
+			)
+		}
+	}
+	return completeMcpOAuthTokenRequest(input, formData, grantType)
+}
+
+async function completeMcpOAuthTokenRequest(
+	input: {
+		request: Request
+		env: Env
+		fetchProvider: (request: Request) => Promise<Response>
+	},
+	formData: FormData | null,
+	grantType: string | null,
+) {
 	if (grantType === 'refresh_token' && formData) {
 		const reuseResponse = await tryRefreshFamilyReuse({
 			request: input.request,

--- a/packages/worker/src/oauth-refresh-family.ts
+++ b/packages/worker/src/oauth-refresh-family.ts
@@ -1,0 +1,511 @@
+import {
+	decryptSecretValue,
+	encryptSecretValue,
+} from '#worker/mcp/secrets/crypto.ts'
+
+/**
+ * MCP hosts on one machine often share a stored OAuth client but keep their
+ * own in-memory refresh token. The provider rotates on every refresh and only
+ * keeps a 1-deep previous token; reusing that previous token mints a *new*
+ * refresh token and silently invalidates the sibling that already received
+ * the current one (`RT1→RT2`, `RT1→RT3`, `RT2→invalid_grant`).
+ *
+ * Kody keeps an encrypted snapshot of the current family tokens and treats
+ * reuse of the immediately previous refresh token as idempotent: return the
+ * current tokens when the access token is still usable, and rotate at most
+ * once (via the stored current refresh token) when it is not. A one-hour
+ * replay of the consumed token returns that same current family while the
+ * hash still matches. Tokens outside that family do not mint. See
+ * `docs/contributing/architecture/authentication.md`.
+ */
+
+const mcpOAuthRefreshFamilyMinAccessRemainingSeconds = 60
+const mcpOAuthRefreshFamilyReplayTtlSeconds = 60 * 60
+const mcpOAuthRefreshFamilySnapshotTtlSeconds = 60 * 60 * 2
+
+const refreshFamilySnapshotKeyPrefix =
+	'derived-cache:v1:mcp-oauth-refresh-family:'
+const refreshFamilyReplayKeyPrefix =
+	'derived-cache:v1:mcp-oauth-refresh-replay:'
+
+export type RefreshFamilyActionKind =
+	| 'return-snapshot'
+	| 'return-replay'
+	| 'refresh-stored-current'
+	| 'pass-through'
+
+export type RefreshFamilyAction = { kind: RefreshFamilyActionKind }
+
+export type RefreshFamilyGrantIds = {
+	currentRefreshTokenHash?: string
+	previousRefreshTokenHash?: string
+}
+
+export type RefreshFamilySnapshot = {
+	userId: string
+	grantId: string
+	currentRefreshTokenHash: string
+	refreshToken: string
+	accessToken: string
+	accessExpiresAt: number
+	tokenType: string
+	scope: string
+	resource?: string
+}
+
+type StoredGrantRecord = {
+	refreshTokenId?: string
+	previousRefreshTokenId?: string
+}
+
+type TokenResponseBody = {
+	access_token?: unknown
+	refresh_token?: unknown
+	token_type?: unknown
+	expires_in?: unknown
+	scope?: unknown
+	resource?: unknown
+}
+
+export function mcpOAuthRefreshFamilySnapshotKey(
+	userId: string,
+	grantId: string,
+) {
+	return `${refreshFamilySnapshotKeyPrefix}${userId}:${grantId}`
+}
+
+export function mcpOAuthRefreshFamilyReplayKey(
+	userId: string,
+	grantId: string,
+	tokenHash: string,
+) {
+	return `${refreshFamilyReplayKeyPrefix}${userId}:${grantId}:${tokenHash}`
+}
+
+export function parseOAuthRefreshToken(token: string) {
+	const parts = token.split(':')
+	const userId = parts[0]
+	const grantId = parts[1]
+	if (
+		parts.length !== 3 ||
+		!userId ||
+		!grantId ||
+		parts.some((part) => part.length === 0)
+	) {
+		return null
+	}
+	return { userId, grantId }
+}
+
+export async function hashOAuthToken(token: string) {
+	const digest = await crypto.subtle.digest(
+		'SHA-256',
+		new TextEncoder().encode(token),
+	)
+	return Array.from(new Uint8Array(digest))
+		.map((byte) => byte.toString(16).padStart(2, '0'))
+		.join('')
+}
+
+export function decideRefreshFamilyAction(input: {
+	presentedHash: string
+	grant: RefreshFamilyGrantIds | null
+	snapshot: RefreshFamilySnapshot | null
+	replay: RefreshFamilySnapshot | null
+	nowSeconds: number
+	minAccessRemainingSeconds?: number
+}): RefreshFamilyAction {
+	const minRemaining =
+		input.minAccessRemainingSeconds ??
+		mcpOAuthRefreshFamilyMinAccessRemainingSeconds
+	const replayIsCurrentFamily =
+		input.replay !== null &&
+		input.grant !== null &&
+		input.replay.currentRefreshTokenHash === input.grant.currentRefreshTokenHash
+	if (
+		replayIsCurrentFamily &&
+		input.replay &&
+		input.replay.accessExpiresAt - input.nowSeconds >= minRemaining
+	) {
+		return { kind: 'return-replay' }
+	}
+	if (!input.grant || !input.snapshot) {
+		return { kind: 'pass-through' }
+	}
+	const snapshotMatchesCurrent =
+		input.snapshot.currentRefreshTokenHash ===
+		input.grant.currentRefreshTokenHash
+	if (!snapshotMatchesCurrent) {
+		return { kind: 'pass-through' }
+	}
+	const isPrevious =
+		input.presentedHash === input.grant.previousRefreshTokenHash
+	if (!isPrevious) {
+		return { kind: 'pass-through' }
+	}
+	const accessRemaining = input.snapshot.accessExpiresAt - input.nowSeconds
+	if (accessRemaining >= minRemaining) {
+		return { kind: 'return-snapshot' }
+	}
+	return { kind: 'refresh-stored-current' }
+}
+
+export async function handleMcpOAuthTokenRequest(input: {
+	request: Request
+	env: Env
+	fetchProvider: (request: Request) => Promise<Response>
+}) {
+	const formData = await input.request
+		.clone()
+		.formData()
+		.catch(() => null)
+	const grantType = readFormString(formData?.get('grant_type'))
+	if (grantType === 'refresh_token' && formData) {
+		const reuseResponse = await tryRefreshFamilyReuse({
+			request: input.request,
+			env: input.env,
+			formData,
+			fetchProvider: input.fetchProvider,
+		})
+		if (reuseResponse) {
+			return {
+				response: addOAuthTokenCorsHeaders(reuseResponse, input.request),
+				grantType,
+			}
+		}
+	}
+	const response = await input.fetchProvider(input.request)
+	if (response.ok) {
+		await persistRefreshFamilyFromTokenResponse({
+			env: input.env,
+			response,
+			presentedRefreshToken:
+				grantType === 'refresh_token'
+					? readFormString(formData?.get('refresh_token'))
+					: null,
+		})
+	}
+	return { response, grantType }
+}
+
+function readFormString(value: FormDataEntryValue | null | undefined) {
+	return typeof value === 'string' && value.length > 0 ? value : null
+}
+
+async function tryRefreshFamilyReuse(input: {
+	request: Request
+	env: Env
+	formData: FormData
+	fetchProvider: (request: Request) => Promise<Response>
+}) {
+	const presented = readFormString(input.formData.get('refresh_token'))
+	if (!presented) return null
+	const parsed = parseOAuthRefreshToken(presented)
+	if (!parsed) return null
+	const presentedHash = await hashOAuthToken(presented)
+	const replay = await readRefreshFamilySnapshotAtKey(
+		input.env,
+		mcpOAuthRefreshFamilyReplayKey(
+			parsed.userId,
+			parsed.grantId,
+			presentedHash,
+		),
+		parsed,
+	)
+	const snapshot = await readRefreshFamilySnapshot(
+		input.env,
+		parsed.userId,
+		parsed.grantId,
+	)
+	const grant = await readGrantRefreshIds(
+		input.env,
+		parsed.userId,
+		parsed.grantId,
+	)
+	const action = decideRefreshFamilyAction({
+		presentedHash,
+		grant,
+		snapshot,
+		replay,
+		nowSeconds: Math.floor(Date.now() / 1000),
+	})
+	switch (action.kind) {
+		case 'return-replay':
+			return replay ? createFamilyTokenResponse(replay) : null
+		case 'return-snapshot':
+			return snapshot ? createFamilyTokenResponse(snapshot) : null
+		case 'refresh-stored-current': {
+			if (!snapshot) return null
+			const providerResponse = await input.fetchProvider(
+				rewriteRefreshTokenRequest(
+					input.request,
+					input.formData,
+					snapshot.refreshToken,
+				),
+			)
+			if (providerResponse.ok) {
+				await persistRefreshFamilyFromTokenResponse({
+					env: input.env,
+					response: providerResponse,
+					presentedRefreshToken: presented,
+					alsoReplayToken: snapshot.refreshToken,
+				})
+			}
+			return providerResponse
+		}
+		case 'pass-through':
+			return null
+		default: {
+			const exhaustive: never = action.kind
+			throw new Error(`unexpected refresh family action: ${exhaustive}`)
+		}
+	}
+}
+
+async function persistRefreshFamilyFromTokenResponse(input: {
+	env: Env
+	response: Response
+	presentedRefreshToken: string | null
+	alsoReplayToken?: string
+}) {
+	if (!canPersistRefreshFamily(input.env)) return
+	const body = (await input.response
+		.clone()
+		.json()
+		.catch(() => null)) as TokenResponseBody | null
+	if (!body || typeof body.refresh_token !== 'string') return
+	if (typeof body.access_token !== 'string') return
+	const parsed = parseOAuthRefreshToken(body.refresh_token)
+	if (!parsed) return
+	const expiresIn =
+		typeof body.expires_in === 'number' && Number.isFinite(body.expires_in)
+			? Math.floor(body.expires_in)
+			: null
+	if (expiresIn === null || expiresIn < 1) return
+	const nowSeconds = Math.floor(Date.now() / 1000)
+	const snapshot: RefreshFamilySnapshot = {
+		userId: parsed.userId,
+		grantId: parsed.grantId,
+		currentRefreshTokenHash: await hashOAuthToken(body.refresh_token),
+		refreshToken: body.refresh_token,
+		accessToken: body.access_token,
+		accessExpiresAt: nowSeconds + expiresIn,
+		tokenType: typeof body.token_type === 'string' ? body.token_type : 'bearer',
+		scope: typeof body.scope === 'string' ? body.scope : '',
+		resource: typeof body.resource === 'string' ? body.resource : undefined,
+	}
+	await writeRefreshFamilySnapshot(input.env, snapshot)
+	const replayTokens = [
+		input.presentedRefreshToken,
+		input.alsoReplayToken,
+	].filter((token): token is string => typeof token === 'string')
+	for (const token of replayTokens) {
+		await writeRefreshFamilyReplay(
+			input.env,
+			snapshot,
+			await hashOAuthToken(token),
+		)
+	}
+}
+
+function canPersistRefreshFamily(env: Env) {
+	return Boolean(env.BUNDLE_ARTIFACTS_KV && env.SECRET_STORE_KEY)
+}
+
+async function readGrantRefreshIds(
+	env: Env,
+	userId: string,
+	grantId: string,
+): Promise<RefreshFamilyGrantIds | null> {
+	if (!env.OAUTH_KV) return null
+	const grant = await env.OAUTH_KV.get<StoredGrantRecord>(
+		`grant:${userId}:${grantId}`,
+		{ type: 'json' },
+	)
+	if (!grant) return null
+	return {
+		currentRefreshTokenHash:
+			typeof grant.refreshTokenId === 'string'
+				? grant.refreshTokenId
+				: undefined,
+		previousRefreshTokenHash:
+			typeof grant.previousRefreshTokenId === 'string'
+				? grant.previousRefreshTokenId
+				: undefined,
+	}
+}
+
+async function readRefreshFamilySnapshot(
+	env: Env,
+	userId: string,
+	grantId: string,
+) {
+	return readRefreshFamilySnapshotAtKey(
+		env,
+		mcpOAuthRefreshFamilySnapshotKey(userId, grantId),
+		{ userId, grantId },
+	)
+}
+
+async function readRefreshFamilySnapshotAtKey(
+	env: Env,
+	key: string,
+	expected: { userId: string; grantId: string },
+) {
+	if (!canPersistRefreshFamily(env)) return null
+	const ciphertext = await env.BUNDLE_ARTIFACTS_KV.get(key)
+	if (!ciphertext) return null
+	try {
+		const parsed = JSON.parse(
+			await decryptSecretValue(
+				env,
+				ciphertext,
+				refreshFamilySecretContext(expected.userId, expected.grantId),
+			),
+		) as Partial<RefreshFamilySnapshot>
+		if (
+			parsed.userId !== expected.userId ||
+			parsed.grantId !== expected.grantId ||
+			typeof parsed.currentRefreshTokenHash !== 'string' ||
+			typeof parsed.refreshToken !== 'string' ||
+			typeof parsed.accessToken !== 'string' ||
+			typeof parsed.accessExpiresAt !== 'number' ||
+			typeof parsed.tokenType !== 'string' ||
+			typeof parsed.scope !== 'string'
+		) {
+			return null
+		}
+		return {
+			userId: parsed.userId,
+			grantId: parsed.grantId,
+			currentRefreshTokenHash: parsed.currentRefreshTokenHash,
+			refreshToken: parsed.refreshToken,
+			accessToken: parsed.accessToken,
+			accessExpiresAt: parsed.accessExpiresAt,
+			tokenType: parsed.tokenType,
+			scope: parsed.scope,
+			resource:
+				typeof parsed.resource === 'string' ? parsed.resource : undefined,
+		} satisfies RefreshFamilySnapshot
+	} catch {
+		return null
+	}
+}
+
+async function writeRefreshFamilySnapshot(
+	env: Env,
+	snapshot: RefreshFamilySnapshot,
+) {
+	if (!canPersistRefreshFamily(env)) return
+	const ciphertext = await encryptSecretValue(
+		env,
+		JSON.stringify(snapshot),
+		refreshFamilySecretContext(snapshot.userId, snapshot.grantId),
+	)
+	await env.BUNDLE_ARTIFACTS_KV.put(
+		mcpOAuthRefreshFamilySnapshotKey(snapshot.userId, snapshot.grantId),
+		ciphertext,
+		{ expirationTtl: mcpOAuthRefreshFamilySnapshotTtlSeconds },
+	)
+}
+
+async function writeRefreshFamilyReplay(
+	env: Env,
+	snapshot: RefreshFamilySnapshot,
+	tokenHash: string,
+) {
+	if (!canPersistRefreshFamily(env)) return
+	const ciphertext = await encryptSecretValue(
+		env,
+		JSON.stringify(snapshot),
+		refreshFamilySecretContext(snapshot.userId, snapshot.grantId),
+	)
+	await env.BUNDLE_ARTIFACTS_KV.put(
+		mcpOAuthRefreshFamilyReplayKey(
+			snapshot.userId,
+			snapshot.grantId,
+			tokenHash,
+		),
+		ciphertext,
+		{ expirationTtl: mcpOAuthRefreshFamilyReplayTtlSeconds },
+	)
+}
+
+function refreshFamilySecretContext(userId: string, grantId: string) {
+	return `mcp-oauth-refresh-family:${userId}:${grantId}`
+}
+
+function rewriteRefreshTokenRequest(
+	request: Request,
+	formData: FormData,
+	refreshToken: string,
+) {
+	const params = new URLSearchParams()
+	for (const [key, value] of formData.entries()) {
+		if (typeof value === 'string') {
+			params.append(key, value)
+		}
+	}
+	params.set('refresh_token', refreshToken)
+	return new Request(request.url, {
+		method: request.method,
+		headers: request.headers,
+		body: params,
+	})
+}
+
+function createFamilyTokenResponse(snapshot: RefreshFamilySnapshot) {
+	const expiresIn = Math.max(
+		0,
+		snapshot.accessExpiresAt - Math.floor(Date.now() / 1000),
+	)
+	const body: Record<string, string | number> = {
+		access_token: snapshot.accessToken,
+		token_type: snapshot.tokenType,
+		expires_in: expiresIn,
+		refresh_token: snapshot.refreshToken,
+		scope: snapshot.scope,
+	}
+	if (snapshot.resource) {
+		body.resource = snapshot.resource
+	}
+	return new Response(JSON.stringify(body), {
+		status: 200,
+		headers: {
+			'Content-Type': 'application/json',
+			'Cache-Control': 'no-store',
+			Pragma: 'no-cache',
+		},
+	})
+}
+
+function addOAuthTokenCorsHeaders(response: Response, request: Request) {
+	const origin = request.headers.get('Origin')
+	if (!origin) return response
+	const headers = new Headers(response.headers)
+	headers.set('Access-Control-Allow-Origin', origin)
+	headers.set('Access-Control-Allow-Methods', '*')
+	headers.set('Access-Control-Allow-Headers', 'Authorization, *')
+	const exposedHeaders = (headers.get('Access-Control-Expose-Headers') ?? '')
+		.split(',')
+		.map((name) => name.trim())
+		.filter(Boolean)
+	for (const requiredHeader of ['WWW-Authenticate', 'Retry-After']) {
+		if (
+			!exposedHeaders.some(
+				(name) => name.toLowerCase() === requiredHeader.toLowerCase(),
+			)
+		) {
+			exposedHeaders.push(requiredHeader)
+		}
+	}
+	headers.set('Access-Control-Expose-Headers', exposedHeaders.join(', '))
+	headers.set('Access-Control-Max-Age', '86400')
+	const vary = headers.get('Vary')
+	headers.set('Vary', vary ? `${vary}, Origin` : 'Origin')
+	return new Response(response.body, {
+		status: response.status,
+		statusText: response.statusText,
+		headers,
+	})
+}

--- a/packages/worker/src/oauth-refresh-family.ts
+++ b/packages/worker/src/oauth-refresh-family.ts
@@ -180,6 +180,8 @@ export async function forgetRefreshFamilyGrant(
 	grantId: string,
 ) {
 	const key = refreshFamilyGrantLockKey(userId, grantId)
+	refreshFamilyForgotten.add(key)
+	refreshFamilyMemory.delete(key)
 	await withRefreshFamilyGrantLock(userId, grantId, async () => {
 		refreshFamilyMemory.delete(key)
 		refreshFamilyForgotten.add(key)
@@ -351,10 +353,10 @@ async function tryRefreshFamilyReuse(input: { env: Env; formData: FormData }) {
 	const parsed = parseOAuthRefreshToken(presented)
 	if (!parsed) return null
 	const presentedHash = await hashOAuthToken(presented)
-	const memory =
-		refreshFamilyMemory.get(
-			refreshFamilyGrantLockKey(parsed.userId, parsed.grantId),
-		) ?? null
+	const memoryKey = refreshFamilyGrantLockKey(parsed.userId, parsed.grantId)
+	const memory = refreshFamilyForgotten.has(memoryKey)
+		? null
+		: (refreshFamilyMemory.get(memoryKey) ?? null)
 	const kvReplay = await readRefreshFamilySnapshotAtKey(
 		input.env,
 		mcpOAuthRefreshFamilyReplayKey(

--- a/packages/worker/src/oauth-refresh-family.ts
+++ b/packages/worker/src/oauth-refresh-family.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/cloudflare'
 import {
 	decryptSecretValue,
 	encryptSecretValue,
@@ -12,14 +13,12 @@ import {
  *
  * Kody keeps an encrypted snapshot of the current family tokens and treats
  * reuse of the immediately previous refresh token as idempotent: return the
- * current tokens when the access token is still usable, and rotate at most
- * once (via the stored current refresh token) when it is not. A one-hour
- * replay of the consumed token returns that same current family while the
- * hash still matches. Tokens outside that family do not mint. See
- * `docs/contributing/architecture/authentication.md`.
+ * current tokens without rotating, even when the stored access token is near
+ * expiry. A one-hour replay of the consumed token returns that same current
+ * family while the hash still matches. Tokens outside that family do not
+ * mint. See `docs/contributing/architecture/authentication.md`.
  */
 
-const mcpOAuthRefreshFamilyMinAccessRemainingSeconds = 60
 const mcpOAuthRefreshFamilyReplayTtlSeconds = 60 * 60
 const mcpOAuthRefreshFamilySnapshotTtlSeconds = 60 * 60 * 2
 
@@ -31,7 +30,6 @@ const refreshFamilyReplayKeyPrefix =
 export type RefreshFamilyActionKind =
 	| 'return-snapshot'
 	| 'return-replay'
-	| 'refresh-stored-current'
 	| 'pass-through'
 
 export type RefreshFamilyAction = { kind: RefreshFamilyActionKind }
@@ -112,21 +110,12 @@ export function decideRefreshFamilyAction(input: {
 	grant: RefreshFamilyGrantIds | null
 	snapshot: RefreshFamilySnapshot | null
 	replay: RefreshFamilySnapshot | null
-	nowSeconds: number
-	minAccessRemainingSeconds?: number
 }): RefreshFamilyAction {
-	const minRemaining =
-		input.minAccessRemainingSeconds ??
-		mcpOAuthRefreshFamilyMinAccessRemainingSeconds
 	const replayIsCurrentFamily =
 		input.replay !== null &&
 		input.grant !== null &&
 		input.replay.currentRefreshTokenHash === input.grant.currentRefreshTokenHash
-	if (
-		replayIsCurrentFamily &&
-		input.replay &&
-		input.replay.accessExpiresAt - input.nowSeconds >= minRemaining
-	) {
+	if (replayIsCurrentFamily) {
 		return { kind: 'return-replay' }
 	}
 	if (!input.grant || !input.snapshot) {
@@ -138,16 +127,10 @@ export function decideRefreshFamilyAction(input: {
 	if (!snapshotMatchesCurrent) {
 		return { kind: 'pass-through' }
 	}
-	const isPrevious =
-		input.presentedHash === input.grant.previousRefreshTokenHash
-	if (!isPrevious) {
-		return { kind: 'pass-through' }
-	}
-	const accessRemaining = input.snapshot.accessExpiresAt - input.nowSeconds
-	if (accessRemaining >= minRemaining) {
+	if (input.presentedHash === input.grant.previousRefreshTokenHash) {
 		return { kind: 'return-snapshot' }
 	}
-	return { kind: 'refresh-stored-current' }
+	return { kind: 'pass-through' }
 }
 
 export async function handleMcpOAuthTokenRequest(input: {
@@ -176,7 +159,7 @@ export async function handleMcpOAuthTokenRequest(input: {
 	}
 	const response = await input.fetchProvider(input.request)
 	if (response.ok) {
-		await persistRefreshFamilyFromTokenResponse({
+		await persistRefreshFamilyBestEffort({
 			env: input.env,
 			response,
 			presentedRefreshToken:
@@ -227,32 +210,12 @@ async function tryRefreshFamilyReuse(input: {
 		grant,
 		snapshot,
 		replay,
-		nowSeconds: Math.floor(Date.now() / 1000),
 	})
 	switch (action.kind) {
 		case 'return-replay':
 			return replay ? createFamilyTokenResponse(replay) : null
 		case 'return-snapshot':
 			return snapshot ? createFamilyTokenResponse(snapshot) : null
-		case 'refresh-stored-current': {
-			if (!snapshot) return null
-			const providerResponse = await input.fetchProvider(
-				rewriteRefreshTokenRequest(
-					input.request,
-					input.formData,
-					snapshot.refreshToken,
-				),
-			)
-			if (providerResponse.ok) {
-				await persistRefreshFamilyFromTokenResponse({
-					env: input.env,
-					response: providerResponse,
-					presentedRefreshToken: presented,
-					alsoReplayToken: snapshot.refreshToken,
-				})
-			}
-			return providerResponse
-		}
 		case 'pass-through':
 			return null
 		default: {
@@ -262,11 +225,24 @@ async function tryRefreshFamilyReuse(input: {
 	}
 }
 
+async function persistRefreshFamilyBestEffort(input: {
+	env: Env
+	response: Response
+	presentedRefreshToken: string | null
+}) {
+	try {
+		await persistRefreshFamilyFromTokenResponse(input)
+	} catch (error) {
+		// Snapshot writes are best-effort. The provider already minted tokens;
+		// a KV or encrypt failure must not hide that response.
+		Sentry.captureException(error)
+	}
+}
+
 async function persistRefreshFamilyFromTokenResponse(input: {
 	env: Env
 	response: Response
 	presentedRefreshToken: string | null
-	alsoReplayToken?: string
 }) {
 	if (!canPersistRefreshFamily(input.env)) return
 	const body = (await input.response
@@ -295,15 +271,11 @@ async function persistRefreshFamilyFromTokenResponse(input: {
 		resource: typeof body.resource === 'string' ? body.resource : undefined,
 	}
 	await writeRefreshFamilySnapshot(input.env, snapshot)
-	const replayTokens = [
-		input.presentedRefreshToken,
-		input.alsoReplayToken,
-	].filter((token): token is string => typeof token === 'string')
-	for (const token of replayTokens) {
+	if (input.presentedRefreshToken) {
 		await writeRefreshFamilyReplay(
 			input.env,
 			snapshot,
-			await hashOAuthToken(token),
+			await hashOAuthToken(input.presentedRefreshToken),
 		)
 	}
 }
@@ -433,25 +405,6 @@ async function writeRefreshFamilyReplay(
 
 function refreshFamilySecretContext(userId: string, grantId: string) {
 	return `mcp-oauth-refresh-family:${userId}:${grantId}`
-}
-
-function rewriteRefreshTokenRequest(
-	request: Request,
-	formData: FormData,
-	refreshToken: string,
-) {
-	const params = new URLSearchParams()
-	for (const [key, value] of formData.entries()) {
-		if (typeof value === 'string') {
-			params.append(key, value)
-		}
-	}
-	params.set('refresh_token', refreshToken)
-	return new Request(request.url, {
-		method: request.method,
-		headers: request.headers,
-		body: params,
-	})
 }
 
 function createFamilyTokenResponse(snapshot: RefreshFamilySnapshot) {

--- a/packages/worker/src/oauth-refresh-family.ts
+++ b/packages/worker/src/oauth-refresh-family.ts
@@ -158,7 +158,7 @@ function rememberRefreshFamily(
 ) {
 	const key = refreshFamilyGrantLockKey(snapshot.userId, snapshot.grantId)
 	const existing = refreshFamilyMemory.get(key)
-	const replays = new Map(existing?.replays)
+	const replays = new Map<string, RefreshFamilySnapshot>()
 	if (presentedHash) {
 		replays.set(presentedHash, snapshot)
 	}
@@ -171,6 +171,10 @@ function rememberRefreshFamily(
 		},
 		replays,
 	})
+}
+
+export function forgetRefreshFamilyGrant(userId: string, grantId: string) {
+	refreshFamilyMemory.delete(refreshFamilyGrantLockKey(userId, grantId))
 }
 
 function resolveRefreshFamilyViews(input: {

--- a/packages/worker/src/oauth-refresh-family.ts
+++ b/packages/worker/src/oauth-refresh-family.ts
@@ -16,10 +16,12 @@ import {
  * current tokens without rotating, even when the stored access token is near
  * expiry. A one-hour replay of the consumed token returns that same current
  * family while the hash still matches. Tokens outside that family do not
- * mint. Refresh grants for one user/grant pair run one at a time in this
- * isolate so overlapping first-use siblings re-read the snapshot after the
- * first rotation. See
- * `docs/contributing/architecture/authentication.md`.
+ * mint. Previous-token reuse and matching replay are read-only and skip the
+ * isolate lock so a current-token rotation cannot invalidate a sibling that
+ * still holds the previous token. Provider rotation for one user/grant pair
+ * runs one at a time in this isolate; waiters retry reuse from an in-memory
+ * snapshot written on persist so they do not depend on Workers KV seeing the
+ * new keys. See `docs/contributing/architecture/authentication.md`.
  */
 
 const mcpOAuthRefreshFamilyReplayTtlSeconds = 60 * 60
@@ -138,8 +140,98 @@ export function decideRefreshFamilyAction(input: {
 
 const refreshFamilyGrantLocks = new Map<string, Promise<void>>()
 
+type RefreshFamilyMemoryRecord = {
+	snapshot: RefreshFamilySnapshot
+	grant: RefreshFamilyGrantIds
+	replays: Map<string, RefreshFamilySnapshot>
+}
+
+const refreshFamilyMemory = new Map<string, RefreshFamilyMemoryRecord>()
+
 function refreshFamilyGrantLockKey(userId: string, grantId: string) {
 	return `${userId}:${grantId}`
+}
+
+function rememberRefreshFamily(
+	snapshot: RefreshFamilySnapshot,
+	presentedHash: string | null,
+) {
+	const key = refreshFamilyGrantLockKey(snapshot.userId, snapshot.grantId)
+	const existing = refreshFamilyMemory.get(key)
+	const replays = new Map(existing?.replays)
+	if (presentedHash) {
+		replays.set(presentedHash, snapshot)
+	}
+	refreshFamilyMemory.set(key, {
+		snapshot,
+		grant: {
+			currentRefreshTokenHash: snapshot.currentRefreshTokenHash,
+			previousRefreshTokenHash:
+				presentedHash ?? existing?.grant.previousRefreshTokenHash,
+		},
+		replays,
+	})
+}
+
+function resolveRefreshFamilyViews(input: {
+	presentedHash: string
+	memory: RefreshFamilyMemoryRecord | null
+	kvGrant: RefreshFamilyGrantIds | null
+	kvSnapshot: RefreshFamilySnapshot | null
+	kvReplay: RefreshFamilySnapshot | null
+}) {
+	const memory = input.memory
+	if (!memory) {
+		return {
+			grant: input.kvGrant,
+			snapshot: input.kvSnapshot,
+			replay: input.kvReplay,
+		}
+	}
+	const memoryReplay = memory.replays.get(input.presentedHash) ?? null
+	if (!input.kvGrant) {
+		return {
+			grant: memory.grant,
+			snapshot: memory.snapshot,
+			replay: memoryReplay ?? input.kvReplay,
+		}
+	}
+	if (
+		memory.grant.currentRefreshTokenHash ===
+		input.kvGrant.currentRefreshTokenHash
+	) {
+		return {
+			grant: input.kvGrant,
+			snapshot: memory.snapshot,
+			replay: memoryReplay ?? input.kvReplay,
+		}
+	}
+	if (
+		memory.grant.currentRefreshTokenHash ===
+		input.kvGrant.previousRefreshTokenHash
+	) {
+		return {
+			grant: input.kvGrant,
+			snapshot: input.kvSnapshot,
+			replay: input.kvReplay,
+		}
+	}
+	if (
+		input.kvGrant.currentRefreshTokenHash ===
+			memory.grant.previousRefreshTokenHash ||
+		input.kvGrant.currentRefreshTokenHash === input.presentedHash
+	) {
+		return {
+			grant: memory.grant,
+			snapshot: memory.snapshot,
+			replay: memoryReplay ?? input.kvReplay,
+		}
+	}
+	return {
+		grant: input.kvGrant,
+		snapshot: input.kvSnapshot,
+		replay: input.kvReplay,
+	}
 }
 
 async function withRefreshFamilyGrantLock<T>(
@@ -183,6 +275,16 @@ export async function handleMcpOAuthTokenRequest(input: {
 		const presented = readFormString(formData.get('refresh_token'))
 		const parsed = presented ? parseOAuthRefreshToken(presented) : null
 		if (parsed) {
+			const reuseResponse = await tryRefreshFamilyReuse({
+				env: input.env,
+				formData,
+			})
+			if (reuseResponse) {
+				return {
+					response: addOAuthTokenCorsHeaders(reuseResponse, input.request),
+					grantType,
+				}
+			}
 			return withRefreshFamilyGrantLock(parsed.userId, parsed.grantId, () =>
 				completeMcpOAuthTokenRequest(input, formData, grantType),
 			)
@@ -202,10 +304,8 @@ async function completeMcpOAuthTokenRequest(
 ) {
 	if (grantType === 'refresh_token' && formData) {
 		const reuseResponse = await tryRefreshFamilyReuse({
-			request: input.request,
 			env: input.env,
 			formData,
-			fetchProvider: input.fetchProvider,
 		})
 		if (reuseResponse) {
 			return {
@@ -232,18 +332,17 @@ function readFormString(value: FormDataEntryValue | null | undefined) {
 	return typeof value === 'string' && value.length > 0 ? value : null
 }
 
-async function tryRefreshFamilyReuse(input: {
-	request: Request
-	env: Env
-	formData: FormData
-	fetchProvider: (request: Request) => Promise<Response>
-}) {
+async function tryRefreshFamilyReuse(input: { env: Env; formData: FormData }) {
 	const presented = readFormString(input.formData.get('refresh_token'))
 	if (!presented) return null
 	const parsed = parseOAuthRefreshToken(presented)
 	if (!parsed) return null
 	const presentedHash = await hashOAuthToken(presented)
-	const replay = await readRefreshFamilySnapshotAtKey(
+	const memory =
+		refreshFamilyMemory.get(
+			refreshFamilyGrantLockKey(parsed.userId, parsed.grantId),
+		) ?? null
+	const kvReplay = await readRefreshFamilySnapshotAtKey(
 		input.env,
 		mcpOAuthRefreshFamilyReplayKey(
 			parsed.userId,
@@ -252,16 +351,23 @@ async function tryRefreshFamilyReuse(input: {
 		),
 		parsed,
 	)
-	const snapshot = await readRefreshFamilySnapshot(
+	const kvSnapshot = await readRefreshFamilySnapshot(
 		input.env,
 		parsed.userId,
 		parsed.grantId,
 	)
-	const grant = await readGrantRefreshIds(
+	const kvGrant = await readGrantRefreshIds(
 		input.env,
 		parsed.userId,
 		parsed.grantId,
 	)
+	const { grant, snapshot, replay } = resolveRefreshFamilyViews({
+		presentedHash,
+		memory,
+		kvGrant,
+		kvSnapshot,
+		kvReplay,
+	})
 	const action = decideRefreshFamilyAction({
 		presentedHash,
 		grant,
@@ -301,7 +407,6 @@ async function persistRefreshFamilyFromTokenResponse(input: {
 	response: Response
 	presentedRefreshToken: string | null
 }) {
-	if (!canPersistRefreshFamily(input.env)) return
 	const body = (await input.response
 		.clone()
 		.json()
@@ -327,13 +432,14 @@ async function persistRefreshFamilyFromTokenResponse(input: {
 		scope: typeof body.scope === 'string' ? body.scope : '',
 		resource: typeof body.resource === 'string' ? body.resource : undefined,
 	}
+	const presentedHash = input.presentedRefreshToken
+		? await hashOAuthToken(input.presentedRefreshToken)
+		: null
+	rememberRefreshFamily(snapshot, presentedHash)
+	if (!canPersistRefreshFamily(input.env)) return
 	await writeRefreshFamilySnapshot(input.env, snapshot)
-	if (input.presentedRefreshToken) {
-		await writeRefreshFamilyReplay(
-			input.env,
-			snapshot,
-			await hashOAuthToken(input.presentedRefreshToken),
-		)
+	if (presentedHash) {
+		await writeRefreshFamilyReplay(input.env, snapshot, presentedHash)
 	}
 }
 

--- a/packages/worker/src/oauth-refresh-family.ts
+++ b/packages/worker/src/oauth-refresh-family.ts
@@ -147,6 +147,7 @@ type RefreshFamilyMemoryRecord = {
 }
 
 const refreshFamilyMemory = new Map<string, RefreshFamilyMemoryRecord>()
+const refreshFamilyForgotten = new Set<string>()
 
 function refreshFamilyGrantLockKey(userId: string, grantId: string) {
 	return `${userId}:${grantId}`
@@ -157,6 +158,7 @@ function rememberRefreshFamily(
 	presentedHash: string | null,
 ) {
 	const key = refreshFamilyGrantLockKey(snapshot.userId, snapshot.grantId)
+	if (refreshFamilyForgotten.has(key)) return
 	const existing = refreshFamilyMemory.get(key)
 	const replays = new Map<string, RefreshFamilySnapshot>()
 	if (presentedHash) {
@@ -173,8 +175,15 @@ function rememberRefreshFamily(
 	})
 }
 
-export function forgetRefreshFamilyGrant(userId: string, grantId: string) {
-	refreshFamilyMemory.delete(refreshFamilyGrantLockKey(userId, grantId))
+export async function forgetRefreshFamilyGrant(
+	userId: string,
+	grantId: string,
+) {
+	const key = refreshFamilyGrantLockKey(userId, grantId)
+	await withRefreshFamilyGrantLock(userId, grantId, async () => {
+		refreshFamilyMemory.delete(key)
+		refreshFamilyForgotten.add(key)
+	})
 }
 
 function resolveRefreshFamilyViews(input: {

--- a/packages/worker/src/oauth-refresh-family.workers.test.ts
+++ b/packages/worker/src/oauth-refresh-family.workers.test.ts
@@ -1,0 +1,250 @@
+import { expect, test } from 'vitest'
+import { createExecutionContext, waitOnExecutionContext } from 'cloudflare:test'
+import { env, exports } from 'cloudflare:workers'
+import { createPasswordHash } from '@kody-internal/shared/password-hash.ts'
+import { createStableUserIdFromEmail } from '#worker/user-id.ts'
+
+type TokenPayload = {
+	access_token: string
+	refresh_token: string
+	token_type: string
+	expires_in: number
+	scope?: string
+	resource?: string
+}
+
+async function workerFetch(
+	request: Request,
+	workerEnv: Env = env,
+): Promise<Response> {
+	const ctx = createExecutionContext()
+	const response = await exports.default.fetch(request, workerEnv, ctx)
+	await waitOnExecutionContext(ctx)
+	return response
+}
+
+async function createS256CodeChallenge(verifier: string) {
+	const digest = await crypto.subtle.digest(
+		'SHA-256',
+		new TextEncoder().encode(verifier),
+	)
+	return btoa(String.fromCharCode(...new Uint8Array(digest)))
+		.replace(/\+/g, '-')
+		.replace(/\//g, '_')
+		.replace(/=+$/, '')
+}
+
+async function seedWorkerUser(email: string, password: string) {
+	const passwordHash = await createPasswordHash(password)
+	const stableUserId = await createStableUserIdFromEmail(email)
+	await env.APP_DB.prepare(
+		`CREATE TABLE IF NOT EXISTS users (
+			id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+			username TEXT NOT NULL UNIQUE,
+			email TEXT NOT NULL UNIQUE,
+			password_hash TEXT NOT NULL,
+			email_verified_at TEXT,
+			stable_user_id TEXT NOT NULL,
+			created_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+			updated_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP)
+		)`,
+	).run()
+	try {
+		await env.APP_DB.prepare(
+			`ALTER TABLE users ADD COLUMN stable_user_id TEXT`,
+		).run()
+	} catch {
+		// Column already present on a fresh CREATE above.
+	}
+	await env.APP_DB.prepare(
+		`CREATE TABLE IF NOT EXISTS verifications (
+			id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+			type TEXT NOT NULL,
+			target TEXT NOT NULL,
+			secret TEXT NOT NULL,
+			algorithm TEXT NOT NULL,
+			digits INTEGER NOT NULL,
+			period INTEGER NOT NULL,
+			char_set TEXT NOT NULL,
+			expires_at INTEGER,
+			created_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+			UNIQUE (target, type)
+		)`,
+	).run()
+	await env.APP_DB.prepare(
+		`INSERT INTO users (username, email, password_hash, email_verified_at, stable_user_id)
+			VALUES (?, ?, ?, ?, ?)
+			ON CONFLICT(email) DO UPDATE SET
+				password_hash = excluded.password_hash,
+				email_verified_at = excluded.email_verified_at,
+				stable_user_id = COALESCE(users.stable_user_id, excluded.stable_user_id)`,
+	)
+		.bind(
+			`user-${crypto.randomUUID().slice(0, 8)}`,
+			email,
+			passwordHash,
+			new Date(0).toISOString(),
+			stableUserId,
+		)
+		.run()
+}
+
+function tokenEnv() {
+	return new Proxy(env, {
+		get(target, prop, receiver) {
+			if (prop === 'OAUTH_PROVIDER') return undefined
+			return Reflect.get(target, prop, receiver)
+		},
+	}) as Env
+}
+
+async function exchangeRefreshToken(
+	clientId: string,
+	refreshToken: string,
+	workerEnv: Env,
+) {
+	const response = await workerFetch(
+		new Request('https://heykody.dev/oauth/token', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+			body: new URLSearchParams({
+				grant_type: 'refresh_token',
+				client_id: clientId,
+				refresh_token: refreshToken,
+				resource: 'https://heykody.dev/mcp',
+			}),
+		}),
+		workerEnv,
+	)
+	return response
+}
+
+async function mintSharedClientTokens() {
+	const email = `refresh-family-${crypto.randomUUID()}@example.com`
+	const password = 'password123'
+	await seedWorkerUser(email, password)
+
+	const registerResponse = await workerFetch(
+		new Request('https://heykody.dev/oauth/register', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				client_name: 'Concurrent MCP host',
+				redirect_uris: ['https://host.example/callback'],
+				token_endpoint_auth_method: 'none',
+				grant_types: ['authorization_code', 'refresh_token'],
+				response_types: ['code'],
+			}),
+		}),
+	)
+	expect(registerResponse.status).toBe(201)
+	const registered = (await registerResponse.json()) as { client_id: string }
+	const verifier = 'refresh-family-verifier-0123456789'
+	const authorizeUrl = new URL('https://heykody.dev/oauth/authorize')
+	authorizeUrl.searchParams.set('response_type', 'code')
+	authorizeUrl.searchParams.set('client_id', registered.client_id)
+	authorizeUrl.searchParams.set('redirect_uri', 'https://host.example/callback')
+	authorizeUrl.searchParams.set('scope', 'profile email')
+	authorizeUrl.searchParams.set(
+		'code_challenge',
+		await createS256CodeChallenge(verifier),
+	)
+	authorizeUrl.searchParams.set('code_challenge_method', 'S256')
+	authorizeUrl.searchParams.set('resource', 'https://heykody.dev/mcp')
+	authorizeUrl.searchParams.set('state', 'refresh-family-state')
+
+	const approvalResponse = await workerFetch(
+		new Request(authorizeUrl, {
+			method: 'POST',
+			headers: {
+				Accept: 'application/json',
+				'Content-Type': 'application/x-www-form-urlencoded',
+			},
+			body: new URLSearchParams({
+				decision: 'approve',
+				email,
+				password,
+			}),
+		}),
+	)
+	expect(approvalResponse.status).toBe(200)
+	const approvalPayload = (await approvalResponse.json()) as {
+		redirectTo: string
+	}
+	const code = new URL(approvalPayload.redirectTo).searchParams.get('code')
+	expect(code).toBeTruthy()
+
+	const isolatedEnv = tokenEnv()
+	const tokenResponse = await workerFetch(
+		new Request('https://heykody.dev/oauth/token', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+			body: new URLSearchParams({
+				grant_type: 'authorization_code',
+				client_id: registered.client_id,
+				code: code ?? '',
+				redirect_uri: 'https://host.example/callback',
+				code_verifier: verifier,
+				resource: 'https://heykody.dev/mcp',
+			}),
+		}),
+		isolatedEnv,
+	)
+	expect(tokenResponse.status).toBe(200)
+	const tokens = (await tokenResponse.json()) as TokenPayload
+	expect(tokens.refresh_token).toBeTruthy()
+	return {
+		clientId: registered.client_id,
+		tokens,
+		env: isolatedEnv,
+	}
+}
+
+test('shared MCP OAuth client refresh reuse returns the current family token', async () => {
+	const {
+		clientId,
+		tokens: first,
+		env: isolatedEnv,
+	} = await mintSharedClientTokens()
+	const rt1 = first.refresh_token
+
+	const firstRefresh = await exchangeRefreshToken(clientId, rt1, isolatedEnv)
+	expect(firstRefresh.status).toBe(200)
+	const afterRt1 = (await firstRefresh.json()) as TokenPayload
+	const rt2 = afterRt1.refresh_token
+	expect(rt2).not.toBe(rt1)
+
+	const reusedRt1 = await exchangeRefreshToken(clientId, rt1, isolatedEnv)
+	expect(reusedRt1.status).toBe(200)
+	const reused = (await reusedRt1.json()) as TokenPayload
+	expect(reused.refresh_token).toBe(rt2)
+	expect(reused.access_token).toBe(afterRt1.access_token)
+
+	const [left, right] = await Promise.all([
+		exchangeRefreshToken(clientId, rt1, isolatedEnv),
+		exchangeRefreshToken(clientId, rt1, isolatedEnv),
+	])
+	expect(left.status).toBe(200)
+	expect(right.status).toBe(200)
+	const leftTokens = (await left.json()) as TokenPayload
+	const rightTokens = (await right.json()) as TokenPayload
+	expect(leftTokens.refresh_token).toBe(rt2)
+	expect(rightTokens.refresh_token).toBe(rt2)
+
+	const currentStillWorks = await exchangeRefreshToken(
+		clientId,
+		rt2,
+		isolatedEnv,
+	)
+	expect(currentStillWorks.status).toBe(200)
+	const afterRt2 = (await currentStillWorks.json()) as TokenPayload
+	expect(afterRt2.refresh_token).toBeTruthy()
+	expect(afterRt2.refresh_token).not.toBe(rt1)
+	expect(afterRt2.refresh_token).not.toBe(rt2)
+
+	const staleSibling = await exchangeRefreshToken(clientId, rt1, isolatedEnv)
+	expect(staleSibling.status).toBe(400)
+	await expect(staleSibling.json()).resolves.toMatchObject({
+		error: 'invalid_grant',
+	})
+})

--- a/packages/worker/src/oauth-refresh-family.workers.test.ts
+++ b/packages/worker/src/oauth-refresh-family.workers.test.ts
@@ -208,11 +208,19 @@ test('shared MCP OAuth client refresh reuse returns the current family token', a
 	} = await mintSharedClientTokens()
 	const rt1 = first.refresh_token
 
-	const firstRefresh = await exchangeRefreshToken(clientId, rt1, isolatedEnv)
-	expect(firstRefresh.status).toBe(200)
-	const afterRt1 = (await firstRefresh.json()) as TokenPayload
+	const [firstLeft, firstRight] = await Promise.all([
+		exchangeRefreshToken(clientId, rt1, isolatedEnv),
+		exchangeRefreshToken(clientId, rt1, isolatedEnv),
+	])
+	expect(firstLeft.status).toBe(200)
+	expect(firstRight.status).toBe(200)
+	const firstLeftTokens = (await firstLeft.json()) as TokenPayload
+	const firstRightTokens = (await firstRight.json()) as TokenPayload
+	expect(firstLeftTokens.refresh_token).toBe(firstRightTokens.refresh_token)
+	expect(firstLeftTokens.refresh_token).not.toBe(rt1)
+	expect(firstLeftTokens.access_token).toBe(firstRightTokens.access_token)
+	const afterRt1 = firstLeftTokens
 	const rt2 = afterRt1.refresh_token
-	expect(rt2).not.toBe(rt1)
 
 	const reusedRt1 = await exchangeRefreshToken(clientId, rt1, isolatedEnv)
 	expect(reusedRt1.status).toBe(200)

--- a/packages/worker/src/origin-handler.ts
+++ b/packages/worker/src/origin-handler.ts
@@ -68,6 +68,7 @@ import { handleOidcJwksRequest } from '#worker/oidc/jwks.ts'
 import { handleOidcUserinfoRequest } from '#worker/oidc/userinfo.ts'
 import { handleOidcLogoutRequest } from '#worker/oidc/logout.ts'
 import { enrichOAuthTokenResponse } from '#worker/oidc/token-enrichment.ts'
+import { handleMcpOAuthTokenRequest } from '#worker/oauth-refresh-family.ts'
 import { runWithDynamicWorkerEvaluationBudget } from '#worker/dynamic-worker-evaluation-budget.ts'
 
 // Immutable caching is only safe when asset URLs are versioned by a real
@@ -682,23 +683,19 @@ async function handleOriginAppFetch(
 			return addOAuthDiscoveryCorsHeaders(metadataResponse, request)
 		}
 	}
-	let tokenGrantType: string | null = null
-	if (url.pathname === oauthPaths.token && request.method === 'POST') {
-		const formData = await request
-			.clone()
-			.formData()
-			.catch(() => null)
-		const grantType = formData?.get('grant_type')
-		tokenGrantType = typeof grantType === 'string' ? grantType : null
-	}
 	try {
-		const response = await oauthProvider.fetch(request, env, ctx)
-		if (url.pathname === oauthPaths.token) {
+		if (url.pathname === oauthPaths.token && request.method === 'POST') {
+			const { response, grantType } = await handleMcpOAuthTokenRequest({
+				request,
+				env,
+				fetchProvider: (providerRequest) =>
+					oauthProvider.fetch(providerRequest, env, ctx),
+			})
 			return enrichOAuthTokenResponse(request, response, env, {
-				grantType: tokenGrantType,
+				grantType,
 			})
 		}
-		return response
+		return await oauthProvider.fetch(request, env, ctx)
 	} catch (error) {
 		if (!isOAuthProviderOwnedPath(url.pathname)) throw error
 		Sentry.captureException(error)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop concurrent MCP hosts that share one stored Kody OAuth client from knocking each other out with `invalid_grant` during refresh-token rotation.

## Why

Platform feedback `e3d8036a-d5ac-4998-ba60-7d18f588528c` (Noah; Kent confirmed): multiple MCP processes on one machine share a stored client but each holds its own refresh token. Kody’s 1-hour access TTL plus the provider’s 1-deep rotation races: `RT1→RT2`, then `RT1` reuse mints `RT3` and invalidates `RT2`. That is a setup Kody onboarding encourages.

## Summary

- Intercept `POST /oauth/token` refresh grants in `oauth-refresh-family.ts`.
- Reuse of the previous refresh token returns the current family tokens without rotating, even when the stored access token is near expiry.
- A matching one-hour replay also returns that family while the hash still matches the grant’s current token.
- Persist is best-effort: a KV or encrypt failure does not hide already-minted provider tokens. The isolate also remembers the minted family in memory so a waiter can reuse it when Workers KV still serves a pre-rotation miss.
- Previous-token reuse and matching replay skip the isolate lock so a current-token rotation cannot invalidate a sibling that still holds the previous token. Only provider rotation is serialized per user/grant in the handling isolate.
- Isolate memory keeps only the current replay entry. Revoke marks the grant forgotten immediately so lock-skipping reuse cannot serve cached tokens, then waits for in-flight persist so remember cannot resurrect a deleted grant.
- Replay that no longer matches the grant’s current hash is `invalid_grant` — stolen tokens outside the current/previous pair and a still-matching replay do not mint forever.
- Access-token TTL stays 1 hour. Encrypted snapshots live in `BUNDLE_ARTIFACTS_KV` derived-cache with KV TTLs.
- Residual: two current-token refreshes that land on different isolates can still race the provider before a snapshot is visible. A revoke that lands on another isolate can leave residual memory until that isolate exits.
- Docs: authentication token lifecycle, KV key contract, troubleshooting.

**Risk:** medium (`extends` `mcp-oauth`). Return-current-token grace, not a new primitive or a change to stolen-token-forever policy.

## Testing

- `vitest` node-unit: `oauth-refresh-family.node.test.ts` (decision table, persist-failure still returns minted tokens, concurrent first-use converges when KV get stays null, previous reuse does not wait on an in-flight current-token rotation, isolate memory does not survive grant revoke, forget wins over an in-flight persist, reuse does not return memory while forget waits on the rotate lock).
- `vitest` workers-unit: `oauth-refresh-family.workers.test.ts` (concurrent first RT1 refresh converges, RT1 reuse returns RT2, later RT1 is `invalid_grant`).
- Existing `oauth-handlers.workers.test.ts` (22) still pass.
- Preview family dance passed on merge of `9c5d1315` (`9ffcaf2d` at https://kody-pr-2233.kody-a99.workers.dev): concurrent first-use converged; previous reuse returned current family; stale sibling `invalid_grant`. Seed login and `/account/connected-agents.json` listed the dance client.

## System changes

See the system recap block.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `58f567e4` · **Head:** `9c5d1315`

**Classification:** extends — MCP OAuth refresh grants return the current family tokens on previous-token reuse instead of minting a sibling-killing rotation.

### Primitives touched

| Primitive   | Group | Impact                                                                                                                                                                                          |
| ----------- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `mcp-oauth` | auth  | extends — previous refresh reuse returns the current family without rotating; rotate-only isolate lock; isolate memory covers KV miss, is dropped on revoke, and cannot resurrect after persist |

Unmatched wiring: `origin-handler.ts` calls the family interceptor on `POST /oauth/token`. `primitives.yaml` adds that module to the `mcp-oauth` code roots.

### Change flow

Overlapping MCP hosts that share one client refresh without invalidating siblings.

```mermaid
sequenceDiagram
	actor HostA
	actor HostB
	participant mcpOauth as mcp-oauth
	HostA->>mcpOauth: POST /oauth/token refresh_token=RT1
	Note over mcpOauth: first use takes isolate rotate lock
	mcpOauth-->>HostA: access plus RT2 and remember family
	HostB->>mcpOauth: POST /oauth/token refresh_token=RT1
	Note over mcpOauth: previous reuse skips lock
	mcpOauth-->>HostB: same access plus RT2 no extra rotate
	HostA->>mcpOauth: POST /oauth/token refresh_token=RT2
	Note over mcpOauth: current token rotates under lock
	HostB->>mcpOauth: POST /oauth/token refresh_token=RT1
	Note over mcpOauth: reuse returns prior family without waiting
	mcpOauth-->>HostB: same RT2 family
	mcpOauth-->>HostA: rotate to RT3 and refresh replay
	HostB->>mcpOauth: POST /oauth/token refresh_token=RT1
	mcpOauth-->>HostB: invalid_grant outside current previous replay
```

### Invariants

Per-user isolation is unchanged: snapshots, replay keys, isolate memory, and the rotate lock are scoped by `userId` and `grantId`. Stolen refresh tokens outside the current/previous pair and a still-matching one-hour replay do not mint. Snapshot writes are best-effort so a KV failure does not hide provider-minted tokens. Isolate memory keeps only the current replay. Revoke marks the grant forgotten immediately so lock-skipping reuse cannot serve cached family tokens, then waits for in-flight persist so remember cannot resurrect that grant. A revoke that lands on another isolate can leave residual memory until that isolate exits.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dc2ab8ed-0a53-4521-a608-092e56a45baa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dc2ab8ed-0a53-4521-a608-092e56a45baa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved OAuth refresh-token handling for shared MCP clients.
  - Concurrent refresh requests can reuse the current token family, reducing unnecessary authentication failures.
  - Previously used tokens may be replayed for up to one hour; expired or invalid tokens continue to require sign-in.
  - Provider-issued tokens remain available if refresh-session caching encounters an error.
  - Revoking OAuth access now also clears associated refresh-session state.

- **Documentation**
  - Updated authentication and data-storage architecture guidance.
  - Expanded troubleshooting instructions for concurrent Codex clients and stale refresh tokens.
  - Added guidance on where to review when modifying authentication behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->