### PR TITLE
Clarify packageSubscriptionDispatch as interactive MCP smoke test

### DIFF
--- a/docs/contributing/decisions/0013-synthetic-package-requests.md
+++ b/docs/contributing/decisions/0013-synthetic-package-requests.md
@@ -43,13 +43,17 @@ Synthetic MCP calls set the markers; callers cannot forge them.
   `Kody-Synthetic: true` before the handler runs. Returns exactly
   `{ status, headers, body, truncated }`; binary response bodies are base64.
   Rejects websocket upgrade requests.
-- **`packageSubscriptionDispatch`** — invoke one declared subscription handler
-  on one saved package. Accepts exactly one of `params` or `email_message_id`
-  (not both). The platform sets top-level envelope fields `synthetic: true` and,
-  for stored-mail replay, `replay_of`. Replay rebuilds the stored inbound email
-  envelope from D1. There is **no caller `idempotency_key`** — the platform
-  generates internal idempotency keys. Targets only the named package; it does
-  not fan out platform events or enqueue production Queue delivery.
+- **`packageSubscriptionDispatch`** — interactive-MCP post-publish smoke test:
+  invoke one declared subscription handler on one owner-scoped saved package
+  without waiting for a real event. Accepts exactly one of `params` or
+  `email_message_id` (not both). The platform sets top-level envelope fields
+  `synthetic: true` and, for stored-mail replay, `replay_of`. Replay rebuilds
+  the stored inbound email envelope from D1. There is **no caller
+  `idempotency_key`** — the platform generates internal idempotency keys.
+  Targets only the named package; it does not fan out platform events or enqueue
+  production Queue delivery. Package composition stays a static `kody:@` import
+  ([0037](./0037-no-author-packages-invoke.md)); this capability is not a
+  successor to `packages.invoke`.
 
 Run records for both surfaces include the same synthetic markers the handler
 payload carries. Handlers treat synthetic invocations identically to production
@@ -67,8 +71,12 @@ agents can run before treating the publish complete.
 - Synthetic app fetches do not replace hosted-URL checks for UI, cookies, OAuth
   redirect flows, or websocket facets — they prove handler/runtime wiring only.
 - Synthetic subscription dispatch validates handler code and manifest wiring for
-  one package; it does not substitute for end-to-end tests of Queue delivery,
-  admin-role gates, or multi-subscriber fan-out.
+  one package from interactive MCP. It does not substitute for end-to-end tests
+  of Queue delivery, admin-role gates, or multi-subscriber fan-out. Package
+  jobs, subscription handlers, webhooks, and other package runtimes cannot call
+  it. Wake or reuse another package with a static `kody:@scope/pkg/export`
+  import (plus `kody.dependencies`), computed `import(specifier)` when the name
+  is data, workflows for exactly-once, or inbound webhooks for external clients.
 - `app_fetch` synthetic requests remain excluded from package activation
   milestones, matching public HTTP traffic.
 - Authors who smoke-test handlers with real side effects should use fixture

--- a/docs/contributing/decisions/0037-no-author-packages-invoke.md
+++ b/docs/contributing/decisions/0037-no-author-packages-invoke.md
@@ -37,7 +37,10 @@ Composition is import plus workflows. Agents stop seeing invoke in usage docs,
 guides, and MCP copy. Fleet source migrates with package codemod
 `0008-packages-invoke-to-static-import` (literal specifiers → static import,
 including Markdown examples; computed specifiers → `import(specifier)`; keyed
-invokes stay `needsManual` for workflows).
+invokes stay `needsManual` for workflows). Interactive MCP
+`packageSubscriptionDispatch` is the post-publish subscription smoke test
+([0013](./0013-synthetic-package-requests.md)), not a replacement for
+`packages.invoke`.
 
 Revisit only if the computed `import(specifier)` facade cannot stand in for
 caller-owned name-as-data loads after the quarantined helper is deleted.

--- a/docs/contributing/packages-and-manifests.md
+++ b/docs/contributing/packages-and-manifests.md
@@ -216,7 +216,10 @@ await handleEvent({ event })
 that call it ([#1750](https://github.com/kentcdodds/kody/issues/1750)). Authors
 and agents do not get that helper. Fleet source migrates with package codemod
 `0008-packages-invoke-to-static-import`. See
-[0037](./decisions/0037-no-author-packages-invoke.md).
+[0037](./decisions/0037-no-author-packages-invoke.md). Interactive MCP
+`packageSubscriptionDispatch` is the post-publish subscription smoke test
+([0013](./decisions/0013-synthetic-package-requests.md)), not a composition
+primitive.
 
 Exact scoped resolution avoids bare-id collisions. A `kody:@person/...` target
 resolves that caller-owned person package. A `kody:@kody/...` target is not

--- a/docs/guides/package-authoring.md
+++ b/docs/guides/package-authoring.md
@@ -348,10 +348,11 @@ irreversible-side-effect guard when a smoke test should stay safe.
    `packageStorage()` side effects. See
    [Package app fetch](../use/package-app-fetch.md) and the
    [Package apps](./package-apps.md) playbook (`package_apps:guide`).
-4. **Subscriptions** — `packageSubscriptionDispatch` with the scoped name (or
-   `package_id` when the name is not known), `topic`, and exactly one of
-   `params` (fixture) or `email_message_id` (stored-mail replay) for each
-   declared topic. See
+4. **Subscriptions** — from interactive MCP, `packageSubscriptionDispatch` with
+   the scoped name (or `package_id` when the name is not known), `topic`, and
+   exactly one of `params` (fixture) or `email_message_id` (stored-mail replay)
+   for each declared topic. This verifies the handler you just published. Reuse
+   another package with a static `kody:@scope/package/export` import. See
    [Synthetic event dispatch](../use/synthetic-event-dispatch.md) and the
    [package subscriptions guide](./package-subscriptions.md#synthetic-dispatch).
 5. Optional UI checks — open `hosted_app_url` when the publish response includes

--- a/docs/guides/package-subscriptions.md
+++ b/docs/guides/package-subscriptions.md
@@ -3,21 +3,21 @@ id: package_subscriptions
 title: Package subscriptions and events
 summary:
   Use package.json#kody.subscriptions for package-owned event handlers; discover
-  subscribers with packageSubscriptionsList; smoke-test handlers with
-  packageSubscriptionDispatch; follow metadata-first email, run.error.recorded
-  activity notifiers, integration.auth.failed / integration.auth.succeeded
-  reconnect notifiers, mcp.server.disconnected / mcp.server.reconnected
-  connection episodes, consent-gated admin-only platform.feedback.submitted
-  notification guidance, admin-only community.activity.recorded /
-  community.listing.published community notifications, admin-only
-  status.incident.opened / status.incident.resolved operator telemetry,
-  admin-only fleet.package_error_rate.elevated package-runtime health,
-  admin-only fleet.entitlement.crossed entitlement crossings, admin-only
-  auth.denial.burst / email.delivery.burst operator bursts, admin-only
-  user.created / user.deleted account lifecycle notifications, and admin-only
-  user.email_verification.failed / user.email_verification.stalled /
-  user.email_outbound.paused / email.system-message.sent mail-operator
-  notifications.
+  subscribers with packageSubscriptionsList; smoke-test one handler from
+  interactive MCP with packageSubscriptionDispatch; follow metadata-first email,
+  run.error.recorded activity notifiers, integration.auth.failed /
+  integration.auth.succeeded reconnect notifiers, mcp.server.disconnected /
+  mcp.server.reconnected connection episodes, consent-gated admin-only
+  platform.feedback.submitted notification guidance, admin-only
+  community.activity.recorded / community.listing.published community
+  notifications, admin-only status.incident.opened / status.incident.resolved
+  operator telemetry, admin-only fleet.package_error_rate.elevated
+  package-runtime health, admin-only fleet.entitlement.crossed entitlement
+  crossings, admin-only auth.denial.burst / email.delivery.burst operator
+  bursts, admin-only user.created / user.deleted account lifecycle
+  notifications, and admin-only user.email_verification.failed /
+  user.email_verification.stalled / user.email_outbound.paused /
+  email.system-message.sent mail-operator notifications.
 category: platform
 ---
 
@@ -80,14 +80,17 @@ fan-out, or deciding whether a package already subscribes to a topic.
 
 ## Synthetic dispatch
 
-`packageSubscriptionDispatch` invokes **one** subscription handler on **one**
-saved package over MCP. It is a platform-marked real-surface run with real side
-effects. Use it immediately after publish to verify handler wiring without
-waiting for production fan-out.
+`packageSubscriptionDispatch` is the **interactive MCP** post-publish smoke test
+for **one** declared subscription handler on **one** owner-scoped saved package.
+It is a platform-marked real-surface run with real side effects. Call it after
+publish to verify handler wiring without waiting for production fan-out.
+
+Package reuse is a static `import … from 'kody:@scope/pkg/export'` (declare
+`kody.dependencies`). See [Package reuse](../use/packages.md#package-reuse).
 
 ```json
 {
-	"package_id": "550e8400-e29b-41d4-a716-446655440000",
+	"kody_id": "@kody/email-automation",
 	"package_scope": "kody",
 	"topic": "email.message.received",
 	"params": {}
@@ -98,7 +101,7 @@ For stored inbound mail, replay with `email_message_id` instead of `params`:
 
 ```json
 {
-	"package_id": "550e8400-e29b-41d4-a716-446655440000",
+	"kody_id": "@kody/email-automation",
 	"package_scope": "kody",
 	"topic": "email.message.received",
 	"email_message_id": "00000000000000000000000000000001"

--- a/docs/guides/package-subscriptions.md
+++ b/docs/guides/package-subscriptions.md
@@ -88,10 +88,11 @@ publish to verify handler wiring without waiting for production fan-out.
 Package reuse is a static `import … from 'kody:@scope/pkg/export'` (declare
 `kody.dependencies`). See [Package reuse](../use/packages.md#package-reuse).
 
+Reuse the scoped `name` from `packageSubscriptionsList` as leftover `kody_id`.
+
 ```json
 {
-	"kody_id": "@kody/email-automation",
-	"package_scope": "kody",
+	"kody_id": "@owner/email-automation",
 	"topic": "email.message.received",
 	"params": {}
 }
@@ -101,8 +102,7 @@ For stored inbound mail, replay with `email_message_id` instead of `params`:
 
 ```json
 {
-	"kody_id": "@kody/email-automation",
-	"package_scope": "kody",
+	"kody_id": "@owner/email-automation",
 	"topic": "email.message.received",
 	"email_message_id": "00000000000000000000000000000001"
 }

--- a/docs/guides/triggers.md
+++ b/docs/guides/triggers.md
@@ -121,9 +121,9 @@ your laptop — anything that can POST JSON can start a package this way.
 When the trigger is something Kody already knows about — a message landing in
 your inbox, a repo push, a run error, an integration losing auth — a package
 subscribes to that topic in `package.json#kody.subscriptions` and Kody invokes
-the handler with the event payload. `packageSubscriptionDispatch` sends a
-synthetic event so you can test a handler before the real one arrives. Topics,
-payloads, and package-emitted events:
+the handler with the event payload. After publish, smoke-test that handler from
+interactive MCP with `packageSubscriptionDispatch`. Reuse another package with a
+static `kody:@` import. Topics, payloads, and package-emitted events:
 [Subscriptions and events](./package-subscriptions.md).
 
 ## The inbox is a trigger too
@@ -138,8 +138,9 @@ nothing else. See [Email primitives](../use/email-primitives.md).
 
 - A schedule is optional, not the point. If the person cannot name a time they
   want something to happen, leave the trigger off and let them ask.
-- Test before you enable: invoke the wrapper from `execute`, dispatch a
-  synthetic event, or send yourself one webhook.
+- Test before you enable: import the wrapper from `execute`, smoke-test a
+  subscription from interactive MCP with `packageSubscriptionDispatch`, or send
+  yourself one webhook.
 - Keep the wrapper quiet. Notify only when there is news; an empty digest every
   morning trains people to ignore the real one.
 - Failures and recent runs for every trigger live on `/account/activity`.

--- a/docs/use/index.md
+++ b/docs/use/index.md
@@ -79,8 +79,8 @@ MCP-level reference detail those docs link into.
   smoke, absolute asset URLs, lean forks
 - [Package app fetch](./package-app-fetch.md) — platform-marked real-surface
   `app_fetch` smoke tests after publish
-- [Synthetic event dispatch](./synthetic-event-dispatch.md) — platform-marked
-  real-surface subscription handler smoke tests
+- [Synthetic event dispatch](./synthetic-event-dispatch.md) — interactive MCP
+  post-publish smoke test for one subscription handler
 - [Waiting](./waiting.md) — current-state items only you can clear
   (`/account/waiting` and `waitingSummary`)
 - [Activity](./activity.md) — failures and recent runs for jobs, apps, webhooks,

--- a/docs/use/package-app-fetch.md
+++ b/docs/use/package-app-fetch.md
@@ -97,8 +97,8 @@ marker the handler saw.
 ## Related
 
 - [Packages](./packages.md) — package apps and `hosted_app_url`
-- [Synthetic event dispatch](./synthetic-event-dispatch.md) — subscription
-  handler smoke tests
+- [Synthetic event dispatch](./synthetic-event-dispatch.md) — interactive MCP
+  post-publish smoke test for one subscription handler
 - [Package apps guide](../guides/package-apps.md) — session handoff,
   `packageAppFetch` smoke, asset URLs, lean forks
 - [Package authoring guide](../guides/package-authoring.md#verify-your-publish)

--- a/docs/use/packages.md
+++ b/docs/use/packages.md
@@ -221,12 +221,13 @@ Person-owned packages must not import a platform scope; `communityFork` first.
 `packageStorage()` on a static import reaches the declaring package's bucket for
 **caller-owned** packages.
 
-There is no author-facing `packages.invoke`. External trusted clients that must
-call a named export over HTTP use inbound webhooks: declare one webhook per
-export, mint a handle with `webhookUrlMint`, register it with `webhookUrlApply`
-when a provider needs the URL, and POST JSON (`inputMode: "params"` and
-`Idempotency-Key` for first-party clients). See
-[Inbound webhooks](./webhooks.md).
+There is no author-facing `packages.invoke`. Interactive MCP
+`packageSubscriptionDispatch` is the post-publish subscription smoke test, not a
+composition primitive. External trusted clients that must call a named export
+over HTTP use inbound webhooks: declare one webhook per export, mint a handle
+with `webhookUrlMint`, register it with `webhookUrlApply` when a provider needs
+the URL, and POST JSON (`inputMode: "params"` and `Idempotency-Key` for
+first-party clients). See [Inbound webhooks](./webhooks.md).
 
 Scoped resolution is exact: `kody:@kentcdodds/google` selects the caller's
 package under that person scope. A person scope never grants access to another
@@ -396,7 +397,11 @@ or did not dispatch, or checking which packages subscribe to
 `fleet.package_error_rate.elevated`, `fleet.entitlement.crossed`,
 `auth.denial.burst`, `email.delivery.burst`, `user.created`, `user.deleted`,
 `user.email_verification.failed`, `user.email_verification.stalled`,
-`user.email_outbound.paused`, and `email.system-message.sent`.
+`user.email_outbound.paused`, and `email.system-message.sent`. After publish,
+smoke-test one declared handler from interactive MCP with
+`packageSubscriptionDispatch`
+([Synthetic event dispatch](./synthetic-event-dispatch.md)). Reuse another
+package with a static `kody:@` import ([Package reuse](#package-reuse)).
 
 For accepted stored inbound email, the topic is `email.message.received`.
 Quarantined inbound email dispatches `email.message.quarantined` instead. Both

--- a/docs/use/synthetic-event-dispatch.md
+++ b/docs/use/synthetic-event-dispatch.md
@@ -1,13 +1,21 @@
 # Synthetic event dispatch
 
-`packageSubscriptionDispatch` invokes a **single** subscription handler on a
-saved package over MCP. It is a **platform-marked real-surface** `subscription`
-run through the normal package execution path (`packageStorage()`, secrets,
-`kody:runtime`). **Side effects are real.**
+`packageSubscriptionDispatch` is the **interactive MCP** smoke test for **one**
+declared `package.json#kody.subscriptions` handler on an **owner-scoped** saved
+package. Call it after publish to verify wiring without waiting for a real
+platform event. It is a **platform-marked real-surface** `subscription` run
+(`packageStorage()`, secrets, `kody:runtime`). **Side effects are real.**
 
-Use it to verify `package.json#kody.subscriptions` wiring immediately after
-publish. It targets only the package you name; it does not fan out to other
-subscribers and does not enqueue production Queue delivery.
+It targets only the package you name. It does not fan out to other subscribers
+and does not enqueue production Queue delivery.
+
+Package reuse is a static `import … from 'kody:@scope/pkg/export'` (declare
+`kody.dependencies`). When the name is data, use computed `import(specifier)`
+for a caller-owned or forked module. Exactly-once work uses
+[workflows](./workflows.md). External clients use
+[inbound webhooks](./webhooks.md). Another package's secret mounts and
+`packageContext` apply when that package is the run — its job, subscription,
+webhook, or app.
 
 The platform sets top-level envelope fields `synthetic: true` and, for
 stored-mail replay, `replay_of`. Real event dispatch strips caller-supplied
@@ -18,16 +26,17 @@ deliberately visible irreversible-side-effect guard says otherwise.
 
 ## When to use it
 
-- After `packagePublishExternalPush` when the package declares subscriptions and
-  `test_hints` includes topic snippets
-- To debug handler logic with a minimal fixture payload
+- From an interactive MCP agent after `packagePublishExternalPush` when the
+  package declares subscriptions and `test_hints` includes topic snippets
+- To debug that same package's handler logic with a minimal fixture payload
 - To replay a stored inbound message with `email_message_id`
 - Together with [Package app fetch](./package-app-fetch.md) as part of
   post-publish verification
 
 Use `packageSubscriptionsList` first to confirm the topic and handler path. Use
 real platform events for end-to-end delivery, admin-role gates, filters, and
-multi-package fan-out.
+multi-package fan-out. Reuse another package from a job or subscription with a
+static `kody:@` import — see [Package reuse](./packages.md#package-reuse).
 
 ## Call shape
 
@@ -35,7 +44,7 @@ Search the `packages` domain, then call `packageSubscriptionDispatch`:
 
 ```json
 {
-	"package_id": "550e8400-e29b-41d4-a716-446655440000",
+	"kody_id": "@owner/email-automation",
 	"topic": "email.message.received",
 	"params": {}
 }
@@ -45,7 +54,8 @@ Fields:
 
 | Field              | Required | Meaning                                                                 |
 | ------------------ | -------- | ----------------------------------------------------------------------- |
-| `package_id`       | yes      | Saved-package UUID                                                      |
+| scoped name        | one of   | `@owner/leaf` (or the name leaf) in leftover `kody_id`                  |
+| `package_id`       | one of   | Saved-package UUID when the scoped name is not known                    |
 | `package_scope`    | no       | Owner scope for delegated packages; preserve it from publish test hints |
 | `topic`            | yes      | Exact topic key from `kody.subscriptions`                               |
 | `params`           | one of   | Handler input fixture — use `{}` only when the handler tolerates empty  |
@@ -56,8 +66,9 @@ top-level request `idempotency_key` — the platform generates it. A
 package-emitted event fixture can still include its production
 `params.idempotency_key` inside the nested event envelope.
 
-Look up the package with `package_id`. Preserve `package_scope` when it appears
-in a publish test hint so dispatch resolves the intended owner-scoped package.
+Look up the package with the scoped `@owner/leaf` name (or `package_id` when the
+name is not known). Preserve `package_scope` when it appears in a publish test
+hint so dispatch resolves the intended owner-scoped package.
 
 ### Fixture input (`params`)
 
@@ -79,7 +90,7 @@ Example minimal `run.error.recorded` fixture:
 
 ```json
 {
-	"package_id": "550e8400-e29b-41d4-a716-446655440000",
+	"kody_id": "@owner/email-automation",
 	"topic": "run.error.recorded",
 	"params": {
 		"event": "run.error.recorded",
@@ -112,7 +123,7 @@ Example minimal `integration.auth.failed` fixture:
 
 ```json
 {
-	"package_id": "550e8400-e29b-41d4-a716-446655440000",
+	"kody_id": "@owner/email-automation",
 	"topic": "integration.auth.failed",
 	"params": {
 		"event": "integration.auth.failed",
@@ -145,7 +156,7 @@ Example minimal `integration.auth.succeeded` fixture:
 
 ```json
 {
-	"package_id": "550e8400-e29b-41d4-a716-446655440000",
+	"kody_id": "@owner/email-automation",
 	"topic": "integration.auth.succeeded",
 	"params": {
 		"event": "integration.auth.succeeded",
@@ -168,7 +179,7 @@ Example minimal `mcp.server.disconnected` fixture:
 
 ```json
 {
-	"package_id": "550e8400-e29b-41d4-a716-446655440000",
+	"kody_id": "@owner/email-automation",
 	"topic": "mcp.server.disconnected",
 	"params": {
 		"event": "mcp.server.disconnected",
@@ -192,7 +203,7 @@ For email topics, pass a stored message id instead of hand-building metadata:
 
 ```json
 {
-	"package_id": "550e8400-e29b-41d4-a716-446655440000",
+	"kody_id": "@owner/email-automation",
 	"topic": "email.message.received",
 	"email_message_id": "00000000000000000000000000000001"
 }
@@ -230,7 +241,8 @@ surface) for run records; the run record includes `synthetic: true` (and
 
 ## Related
 
-- [Packages](./packages.md) — subscription manifest shape
+- [Packages](./packages.md) — subscription manifest shape and
+  [package reuse](./packages.md#package-reuse)
 - [Package app fetch](./package-app-fetch.md) — app handler smoke tests
 - [Package subscriptions guide](../guides/package-subscriptions.md) — topic
   payloads and production delivery semantics

--- a/packages/worker/src/mcp/capabilities/packages/package-subscription-dispatch.ts
+++ b/packages/worker/src/mcp/capabilities/packages/package-subscription-dispatch.ts
@@ -42,7 +42,7 @@ import { loadPackageManifestBySourceId } from '#worker/package-registry/source.t
 
 const maxSyntheticSubscriptionResultBytes = 102_400
 
-const packageRuntimeCallerErrorMessage = `${packageSubscriptionDispatchCapabilityName} is unavailable from package runtime contexts. Call it from an interactive MCP agent instead.`
+const packageRuntimeCallerErrorMessage = `${packageSubscriptionDispatchCapabilityName} is unavailable from package runtime contexts. It is the interactive-MCP post-publish subscription smoke test. Compose another package with a static kody:@scope/pkg/export import.`
 
 function assertDirectMcpCaller(callerContext: {
 	executionOrigin?: string
@@ -112,7 +112,7 @@ export const packageSubscriptionDispatchCapability = defineDomainCapability(
 	{
 		name: packageSubscriptionDispatchCapabilityName,
 		description:
-			'Synthetically dispatch one declared package.json#kody.subscriptions handler for the signed-in user (or delegated package scope). Supply params for a custom envelope, or email_message_id to replay a stored inbound email receipt envelope. Platform code marks the invocation synthetic and strips caller-supplied synthetic/replay_of markers on real dispatch paths.',
+			'Interactive-MCP post-publish smoke test for one declared package.json#kody.subscriptions handler on an owner-scoped saved package. Real-surface run with real side effects; does not wait for a production event and is unavailable from package jobs, subscriptions, webhooks, or other package runtimes. Package composition is a static kody:@scope/pkg/export import (plus kody.dependencies), not this capability. Pass params for a fixture envelope or email_message_id to replay stored inbound mail. The platform marks the run synthetic.',
 		keywords: [
 			'package',
 			'subscription',
@@ -127,6 +127,9 @@ export const packageSubscriptionDispatchCapability = defineDomainCapability(
 			'mcp.server.reconnected',
 			'test',
 			'smoke',
+			'post-publish',
+			'verification',
+			'interactive',
 			'simulate',
 			'probe',
 			'debug',

--- a/packages/worker/src/package-invocations/subscription-envelope.ts
+++ b/packages/worker/src/package-invocations/subscription-envelope.ts
@@ -47,7 +47,7 @@ export function buildPackageSubscriptionNotFoundMessage(input: {
 	kodyId: string
 	topic: string
 }) {
-	return `Package "${input.kodyId}" does not declare subscription "${input.topic}" in package.json#kody.subscriptions. Inspect handlers with packageSubscriptionsList, or test dispatch with ${packageSubscriptionDispatchCapabilityName} once a handler is declared.`
+	return `Package "${input.kodyId}" does not declare subscription "${input.topic}" in package.json#kody.subscriptions. Inspect handlers with packageSubscriptionsList, or smoke-test the handler from interactive MCP with ${packageSubscriptionDispatchCapabilityName} once a handler is declared.`
 }
 
 /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Make `packageSubscriptionDispatch` fail-closed as the owner-scoped interactive MCP smoke test for one declared subscription handler, so agents compose packages with static `kody:@` import instead.

## Why

Agents (and package authors) treated dispatch as a wake-another-package / composition API: foreign `wake` imports were routing into `kody.packageSubscriptionDispatch(...)`, and interactive MCP execute runs the *target* package's secrets, so it looked like the cross-package primitive. Composition is static `kody:@` import. Dispatch is decision 0013 post-publish verification without waiting for real events.

## Summary

- Rewrite the capability description so the first sentence is interactive-MCP post-publish smoke test, and point composition at `kody:@scope/pkg/export`.
- Teach the same purpose in usage docs, guides, and decisions 0013 / 0037.
- Runtime caller error and undeclared-topic hint now name the smoke-test purpose and the static-import playbook.
- New examples use scoped package name (leftover `kody_id`) instead of UUID-only `package_id`.
- No gate, secret, or stamp changes.

## Testing

- `npm run typecheck` (pre-commit)
- `npm run test:push` (node-unit + workers-unit on push)
- `npm run lint`, `docs:check-temporal`, `docs:check-decisions`, `mermaid:check`, `format:check`

## System changes

Docs + capability/error copy only. Interactive-MCP-only runtime gate is unchanged.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `70431d2d` · **Head:** `824817d6`

**Classification:** composes — no primitives added or changed; this PR rewrites capability and docs copy so dispatch stays the smoke-test path.

### Primitives touched

| Primitive         | Group     | Impact                                                                 |
| ----------------- | --------- | ---------------------------------------------------------------------- |
| `saved-packages`  | assistant | composes — capability description and runtime-caller error copy        |

Unmatched paths are usage/guide/decision docs plus `subscription-envelope.ts` (undeclared-topic hint string).

### Change flow

An interactive MCP agent looking up dispatch now sees smoke-test purpose first; a package job still cannot call it and is pointed at static import.

```mermaid
sequenceDiagram
	actor Agent
	participant mcpServer as mcp-server
	participant capabilityRegistry as capability-registry
	participant savedPackages as saved-packages
	Agent->>mcpServer: search packages domain
	mcpServer->>capabilityRegistry: return rewritten packageSubscriptionDispatch description
	Note over capabilityRegistry: Interactive-MCP post-publish smoke test
	Agent->>savedPackages: packageSubscriptionDispatch after publish
	Note over savedPackages: one declared handler, real side effects
	alt package job or subscription caller
		savedPackages-->>Agent: unavailable from package runtime, use static kody:@ import
	end
```

### Before / after

**Capability description**

```text
Before: Synthetically dispatch one declared package.json#kody.subscriptions handler for the signed-in user (or delegated package scope). Supply params for a custom envelope, or email_message_id to replay a stored inbound email receipt envelope. Platform code marks the invocation synthetic and strips caller-supplied synthetic/replay_of markers on real dispatch paths.

After: Interactive-MCP post-publish smoke test for one declared package.json#kody.subscriptions handler on an owner-scoped saved package. Real-surface run with real side effects; does not wait for a production event and is unavailable from package jobs, subscriptions, webhooks, or other package runtimes. Package composition is a static kody:@scope/pkg/export import (plus kody.dependencies), not this capability. Pass params for a fixture envelope or email_message_id to replay stored inbound mail. The platform marks the run synthetic.
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-936ff1b0-65bc-4b8a-93e7-4acc52f3ffb4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-936ff1b0-65bc-4b8a-93e7-4acc52f3ffb4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that synthetic subscription dispatch is an interactive MCP, post-publish smoke test for a single owner-scoped package and handler.
  * Updated examples to identify packages by scoped name, with saved-package IDs supported as an alternative.
  * Added guidance for static package reuse, computed imports, workflows, inbound webhooks, and package context.
  * Clarified that synthetic dispatch is not a package-composition mechanism or replacement for end-to-end delivery testing.

* **Bug Fixes**
  * Improved capability and error messages to explain supported usage and runtime restrictions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->