### PR TITLE
Fix status-page MCP execute card lagging organic last-success

### DIFF
--- a/docs/contributing/architecture/index.md
+++ b/docs/contributing/architecture/index.md
@@ -45,8 +45,9 @@ landed in the previous minute, the status worker runs at most one authenticated
 `POST /__maintenance/mcp-execute-health` per hour. Public status reads never
 trigger that execute. When the status Durable Object's last-success timestamp is
 already stale, `/` and `/status.json` refresh `executeEvidence` from origin
-`GET /health/components` and persist a newer timestamp so the next cron can skip
-the synthetic.
+`GET /health/components` and persist a newer timestamp (merged with whatever
+cron or another snapshot wrote during that fetch) so the next cron can skip the
+synthetic.
 
 ## Core docs
 

--- a/docs/contributing/architecture/index.md
+++ b/docs/contributing/architecture/index.md
@@ -42,8 +42,11 @@ smoke does not prove MCP execute health. Authenticated MCP execute evidence is a
 timestamp-only fleet heartbeat from successful execute completion, shown on
 `status.kody.codes` with source and last-verified time. When no organic success
 landed in the previous minute, the status worker runs at most one authenticated
-`POST /__maintenance/mcp-execute-health` per hour. `GET /health` and status-page
-reads stay cheap and never trigger that execute.
+`POST /__maintenance/mcp-execute-health` per hour. Public status reads never
+trigger that execute. When the status Durable Object's last-success timestamp is
+already stale, `/` and `/status.json` refresh `executeEvidence` from origin
+`GET /health/components` and persist a newer timestamp so the next cron can skip
+the synthetic.
 
 ## Core docs
 

--- a/docs/contributing/architecture/request-lifecycle.md
+++ b/docs/contributing/architecture/request-lifecycle.md
@@ -108,7 +108,8 @@ Requests are handled in this order:
      with a dedicated canary token). Public health and status GETs do not run
      that probe. A stale status-page snapshot may re-read origin
      `GET /health/components` `executeEvidence` (never execute) so organic
-     last-success is not one cron tick behind the live heartbeat.
+     last-success is not one cron tick behind the live heartbeat. Persist merges
+     with any newer timestamp written while that fetch was in flight.
 7. Public `@username` ingress handled in `packages/worker/src/index.ts` before
    the OAuth provider / app router (needs `ExecutionContext` for background
    work). Production forwards package-invocation and package-app paths to

--- a/docs/contributing/architecture/request-lifecycle.md
+++ b/docs/contributing/architecture/request-lifecycle.md
@@ -106,7 +106,9 @@ Requests are handled in this order:
      the traffic-backed heartbeat plus the hourly
      `POST /__maintenance/mcp-execute-health` fallback (legacy `/mcp` execute
      with a dedicated canary token). Public health and status GETs do not run
-     that probe.
+     that probe. A stale status-page snapshot may re-read origin
+     `GET /health/components` `executeEvidence` (never execute) so organic
+     last-success is not one cron tick behind the live heartbeat.
 7. Public `@username` ingress handled in `packages/worker/src/index.ts` before
    the OAuth provider / app router (needs `ExecutionContext` for background
    work). Production forwards package-invocation and package-app paths to

--- a/docs/contributing/setup-manifest.md
+++ b/docs/contributing/setup-manifest.md
@@ -338,10 +338,14 @@ Without that secret, alert sends are skipped and logged.
 MCP execute evidence on the status page is a timestamp-only last-success
 heartbeat from real authenticated execute completions, plus at most one hourly
 synthetic when the last organic success is older than a minute. Public status
-GETs and origin `GET /health` never trigger that execute. The optional origin
-Worker secret `MCP_EXECUTE_HEALTH_CANARY_ACCESS_TOKEN` is a dedicated canary
-OAuth access token for the synthetic; when it is unset the fallback stays
-unknown rather than impersonating a customer.
+GETs and origin `GET /health` never trigger that execute. When the status
+worker's stored last-success is already older than a minute, public `/` and
+`/status.json` re-read origin `GET /health/components` `executeEvidence` so the
+card can stay "recent · organic" under live traffic without waiting for the next
+cron write. The optional origin Worker secret
+`MCP_EXECUTE_HEALTH_CANARY_ACCESS_TOKEN` is a dedicated canary OAuth access
+token for the synthetic; when it is unset the fallback stays unknown rather than
+impersonating a customer.
 
 An optional Worker secret `STATUS_INCIDENT_EVENT_SECRET` (synced from the
 same-named GitHub Actions secret when present) is shared with the main worker.

--- a/packages/status/execute-health.node.test.ts
+++ b/packages/status/execute-health.node.test.ts
@@ -8,6 +8,9 @@ import {
 	executeHealthOrganicFreshMs,
 	executeHealthSyntheticCooldownMs,
 	mergeExecuteLastSuccess,
+	readExecuteHealthSyntheticResult,
+	resolvePublicExecuteLastSuccess,
+	shouldRefreshExecuteLastSuccess,
 } from './execute-health.ts'
 
 const hourMs = executeHealthSyntheticCooldownMs
@@ -167,6 +170,23 @@ test('caller failures are not automatically a global outage, and one organic suc
 	expect(failedSynthetic.detail).toMatch(/not an outage/i)
 	expect(failedSynthetic.detail).toMatch(/caller-code errors/i)
 
+	const staleOrganicAfterFailedSynthetic = deriveExecuteHealthView({
+		now: start + 2 * minuteMs,
+		lastSuccessAt: start,
+		lastSyntheticAttemptAt: start + minuteMs,
+		lastSyntheticSuccessAt: null,
+		lastSyntheticError: 'HTTP 500',
+		syntheticConfigured: true,
+	})
+	expect(staleOrganicAfterFailedSynthetic.status).toBe('unknown')
+	expect(staleOrganicAfterFailedSynthetic.source).toBe('organic')
+	expect(staleOrganicAfterFailedSynthetic.detail).toMatch(
+		/missing or stale telemetry/i,
+	)
+	expect(staleOrganicAfterFailedSynthetic.detail).not.toMatch(
+		/last synthetic attempt failed/i,
+	)
+
 	const organic = deriveExecuteHealthView({
 		now: start + 5_000,
 		lastSuccessAt: start,
@@ -278,4 +298,98 @@ test('public reads do not run a synthetic; only a claimed tick can', async () =>
 	expect(ran.lastSyntheticAttemptAt).toBe(start + minuteMs)
 	expect(ran.lastSyntheticError).toBe('timeout')
 	expect(ran.lastSyntheticSuccessAt).toBeNull()
+})
+
+test('stale stored cron snapshot refreshes from live origin evidence and stays organic', async () => {
+	const stored = start
+	const live = start + 105_000
+	const now = start + 121_000
+	expect(
+		shouldRefreshExecuteLastSuccess({
+			now,
+			storedLastSuccessAt: stored,
+		}),
+	).toBe(true)
+
+	let fetches = 0
+	const resolved = await resolvePublicExecuteLastSuccess({
+		now,
+		storedLastSuccessAt: stored,
+		fetchLive: async () => {
+			fetches += 1
+			return live
+		},
+	})
+	expect(fetches).toBe(1)
+	expect(resolved.persist).toBe(true)
+	expect(resolved.lastSuccessAt).toBe(live)
+
+	const view = deriveExecuteHealthView({
+		now,
+		lastSuccessAt: resolved.lastSuccessAt,
+		lastSyntheticAttemptAt: stored,
+		lastSyntheticSuccessAt: null,
+		lastSyntheticError: 'HTTP 500',
+		syntheticConfigured: true,
+	})
+	expect(view.status).toBe('recent')
+	expect(view.source).toBe('organic')
+	expect(view.lastVerifiedAt).toBe(new Date(live).toISOString())
+	expect(view.detail).toMatch(/organic/i)
+	expect(view.detail).not.toMatch(/last synthetic attempt failed/i)
+
+	let skippedFetches = 0
+	const freshStored = await resolvePublicExecuteLastSuccess({
+		now: start + 15_000,
+		storedLastSuccessAt: start,
+		fetchLive: async () => {
+			skippedFetches += 1
+			return start + 10_000
+		},
+	})
+	expect(skippedFetches).toBe(0)
+	expect(freshStored.persist).toBe(false)
+	expect(freshStored.lastSuccessAt).toBe(start)
+
+	const originDown = await resolvePublicExecuteLastSuccess({
+		now,
+		storedLastSuccessAt: stored,
+		fetchLive: async () => null,
+	})
+	expect(originDown.persist).toBe(false)
+	expect(originDown.lastSuccessAt).toBe(stored)
+})
+
+test('synthetic maintenance errors keep origin reason instead of collapsing to HTTP status', () => {
+	expect(
+		readExecuteHealthSyntheticResult({
+			status: 500,
+			body: {
+				ok: false,
+				reason: 'not-configured',
+				error: 'Execute health canary is not configured',
+			},
+		}),
+	).toEqual({ ok: false, error: 'not-configured' })
+	expect(
+		readExecuteHealthSyntheticResult({
+			status: 500,
+			body: {
+				ok: false,
+				error: 'Authenticated MCP execute probe initialize failed: HTTP 401',
+			},
+		}),
+	).toEqual({
+		ok: false,
+		error: 'Authenticated MCP execute probe initialize failed: HTTP 401',
+	})
+	expect(
+		readExecuteHealthSyntheticResult({
+			status: 200,
+			body: { ok: true },
+		}),
+	).toEqual({ ok: true, error: null })
+	expect(readExecuteHealthSyntheticResult({ status: 502, body: null })).toEqual(
+		{ ok: false, error: 'HTTP 502' },
+	)
 })

--- a/packages/status/execute-health.node.test.ts
+++ b/packages/status/execute-health.node.test.ts
@@ -358,6 +358,34 @@ test('stale stored cron snapshot refreshes from live origin evidence and stays o
 	})
 	expect(originDown.persist).toBe(false)
 	expect(originDown.lastSuccessAt).toBe(stored)
+
+	let concurrentStored = stored
+	const newerDuringFetch = start + 120_000
+	const raced = await resolvePublicExecuteLastSuccess({
+		now,
+		storedLastSuccessAt: stored,
+		fetchLive: async () => {
+			concurrentStored = newerDuringFetch
+			return live
+		},
+		readStoredAfterFetch: () => concurrentStored,
+	})
+	expect(raced.lastSuccessAt).toBe(newerDuringFetch)
+	expect(raced.persist).toBe(false)
+
+	let olderConcurrentStored = stored
+	const olderDuringFetch = start + 80_000
+	const liveWinsRace = await resolvePublicExecuteLastSuccess({
+		now,
+		storedLastSuccessAt: stored,
+		fetchLive: async () => {
+			olderConcurrentStored = olderDuringFetch
+			return live
+		},
+		readStoredAfterFetch: () => olderConcurrentStored,
+	})
+	expect(liveWinsRace.lastSuccessAt).toBe(live)
+	expect(liveWinsRace.persist).toBe(true)
 })
 
 test('synthetic maintenance errors keep origin reason instead of collapsing to HTTP status', () => {

--- a/packages/status/execute-health.ts
+++ b/packages/status/execute-health.ts
@@ -40,6 +40,53 @@ export function mergeExecuteLastSuccess(
 	return newerTimestamp(incoming, stored)
 }
 
+/**
+ * Public `/` and `/status.json` start from cron-written last-success.
+ * When that stored timestamp is already outside the organic window, refresh
+ * from origin `GET /health/components` (cheap; never runs execute). Fresh
+ * stored evidence skips the fetch so a healthy origin is not on the
+ * snapshot hot path.
+ */
+export function shouldRefreshExecuteLastSuccess(input: {
+	now: number
+	storedLastSuccessAt: number | null
+}): boolean {
+	if (input.storedLastSuccessAt === null) return true
+	return input.now - input.storedLastSuccessAt >= executeHealthOrganicFreshMs
+}
+
+export async function resolvePublicExecuteLastSuccess(input: {
+	now: number
+	storedLastSuccessAt: number | null
+	fetchLive: () => Promise<number | null>
+}): Promise<{ lastSuccessAt: number | null; persist: boolean }> {
+	if (!shouldRefreshExecuteLastSuccess(input)) {
+		return { lastSuccessAt: input.storedLastSuccessAt, persist: false }
+	}
+	const live = await input.fetchLive()
+	const merged = mergeExecuteLastSuccess(live, input.storedLastSuccessAt)
+	return {
+		lastSuccessAt: merged,
+		persist: merged !== null && merged !== input.storedLastSuccessAt,
+	}
+}
+
+export function readExecuteHealthSyntheticResult(input: {
+	status: number
+	body: { ok?: unknown; reason?: unknown; error?: unknown } | null
+}): { ok: boolean; error?: string | null } {
+	if (input.status >= 200 && input.status < 300 && input.body?.ok === true) {
+		return { ok: true, error: null }
+	}
+	const reason =
+		typeof input.body?.reason === 'string' ? input.body.reason.trim() : ''
+	const message =
+		typeof input.body?.error === 'string' ? input.body.error.trim() : ''
+	if (reason) return { ok: false, error: reason.slice(0, 200) }
+	if (message) return { ok: false, error: message.slice(0, 200) }
+	return { ok: false, error: `HTTP ${String(input.status)}` }
+}
+
 export function decideExecuteHealthProbe(input: {
 	now: number
 	lastSuccessAt: number | null
@@ -225,7 +272,7 @@ function executeHealthDetail(input: {
 	) {
 		return 'Not recently exercised. Synthetic fallback is not configured. Missing telemetry is not an outage.'
 	}
-	if (input.lastSyntheticError) {
+	if (input.lastSyntheticError && input.source === null) {
 		return `Not recently exercised. Last synthetic attempt failed; missing telemetry is not an outage. Caller-code errors are not a platform outage.`
 	}
 	return 'Not recently exercised. Missing or stale telemetry is not an outage and is not proof the path is freshly healthy.'

--- a/packages/status/execute-health.ts
+++ b/packages/status/execute-health.ts
@@ -59,15 +59,21 @@ export async function resolvePublicExecuteLastSuccess(input: {
 	now: number
 	storedLastSuccessAt: number | null
 	fetchLive: () => Promise<number | null>
+	readStoredAfterFetch?: () => number | null
 }): Promise<{ lastSuccessAt: number | null; persist: boolean }> {
 	if (!shouldRefreshExecuteLastSuccess(input)) {
 		return { lastSuccessAt: input.storedLastSuccessAt, persist: false }
 	}
 	const live = await input.fetchLive()
-	const merged = mergeExecuteLastSuccess(live, input.storedLastSuccessAt)
+	// Durable Object input gates open on this fetch, so cron or another
+	// snapshot can write a newer timestamp first. Re-read before merge so
+	// persist cannot rewind that write.
+	const storedAfter =
+		input.readStoredAfterFetch?.() ?? input.storedLastSuccessAt
+	const merged = mergeExecuteLastSuccess(live, storedAfter)
 	return {
 		lastSuccessAt: merged,
-		persist: merged !== null && merged !== input.storedLastSuccessAt,
+		persist: merged !== null && merged !== storedAfter,
 	}
 }
 

--- a/packages/status/probes.node.test.ts
+++ b/packages/status/probes.node.test.ts
@@ -1,5 +1,9 @@
 import { expect, test } from 'vitest'
-import { jobsProbeOrigin, runAllProbes } from './probes.ts'
+import {
+	fetchExecuteEvidenceLastSuccessAt,
+	jobsProbeOrigin,
+	runAllProbes,
+} from './probes.ts'
 import { statusComponentIds } from './status-types.ts'
 
 type FakeRoute = {
@@ -209,6 +213,9 @@ test('probe failures isolate to the affected component and map error details', a
 				{ id: 'kv', ok: true, latencyMs: 2 },
 				{ id: 'assets', ok: true, latencyMs: 9 },
 			],
+			executeEvidence: {
+				lastSuccessAt: '2026-09-10T22:23:29.243Z',
+			},
 		},
 	}
 	const componentOutcomes = await probe(components)
@@ -218,7 +225,9 @@ test('probe failures isolate to the affected component and map error details', a
 	})
 	expect(outcome(componentOutcomes, 'kv')?.ok).toBe(true)
 	expect(outcome(componentOutcomes, 'assets')?.ok).toBe(true)
-	expect(componentOutcomes.executeLastSuccessAt).toBeNull()
+	expect(componentOutcomes.executeLastSuccessAt).toBe(
+		Date.parse('2026-09-10T22:23:29.243Z'),
+	)
 
 	const unreachable = healthyRoutes()
 	unreachable[`${primaryOrigin}/health`] = { error: 'connection refused' }
@@ -244,4 +253,49 @@ test('probe failures isolate to the affected component and map error details', a
 			detail: `HTTP ${String(status)}`,
 		})
 	}
+})
+
+test('public execute-evidence refresh reads lastSuccessAt without following a failed storage card', async () => {
+	const requested: Array<{ url: string; cacheControl: string | null }> = []
+	const fetcher = (async (input: RequestInfo | URL, init?: RequestInit) => {
+		const url = typeof input === 'string' ? input : input.toString()
+		const headers = new Headers(init?.headers)
+		requested.push({
+			url,
+			cacheControl: headers.get('Cache-Control'),
+		})
+		return new Response(
+			JSON.stringify({
+				ok: false,
+				components: [{ id: 'app_db', ok: false, error: 'timeout' }],
+				executeEvidence: {
+					lastSuccessAt: '2026-09-10T22:23:29.243Z',
+				},
+			}),
+			{ status: 503 },
+		)
+	}) as typeof fetch
+
+	await expect(
+		fetchExecuteEvidenceLastSuccessAt({
+			primaryOrigin,
+			fetcher,
+		}),
+	).resolves.toBe(Date.parse('2026-09-10T22:23:29.243Z'))
+	expect(requested).toEqual([
+		{
+			url: `${primaryOrigin}/health/components`,
+			cacheControl: 'no-cache',
+		},
+	])
+
+	const failingFetcher = (async () => {
+		throw new Error('origin down')
+	}) as typeof fetch
+	await expect(
+		fetchExecuteEvidenceLastSuccessAt({
+			primaryOrigin,
+			fetcher: failingFetcher,
+		}),
+	).resolves.toBeNull()
 })

--- a/packages/status/probes.ts
+++ b/packages/status/probes.ts
@@ -66,7 +66,10 @@ async function timedFetch(
 		const response = await fetcher(url, {
 			redirect: 'manual',
 			signal: AbortSignal.timeout(probeTimeoutMs),
-			headers: { 'User-Agent': 'kody-status-prober' },
+			headers: {
+				'User-Agent': 'kody-status-prober',
+				'Cache-Control': 'no-cache',
+			},
 		})
 		return { response, latencyMs: Date.now() - startedAt }
 	} catch (error) {
@@ -322,12 +325,43 @@ async function probeStorageComponents(
 	}
 }
 
+const executeEvidenceRefreshTimeoutMs = 2_000
+
 function parseExecuteLastSuccessAt(
 	value: string | null | undefined,
 ): number | null {
 	if (!value) return null
 	const parsed = Date.parse(value)
 	return Number.isFinite(parsed) ? parsed : null
+}
+
+/**
+ * Cheap origin executeEvidence read. Never starts MCP execute. Used by
+ * public status snapshots when stored last-success is already stale, and
+ * shares the same parser as the minute cron.
+ */
+export async function fetchExecuteEvidenceLastSuccessAt(input: {
+	primaryOrigin: string
+	fetcher?: typeof fetch
+	timeoutMs?: number
+}): Promise<number | null> {
+	const fetcher = input.fetcher ?? fetch
+	try {
+		const response = await fetcher(`${input.primaryOrigin}/health/components`, {
+			redirect: 'manual',
+			signal: AbortSignal.timeout(
+				input.timeoutMs ?? executeEvidenceRefreshTimeoutMs,
+			),
+			headers: {
+				'User-Agent': 'kody-status-prober',
+				'Cache-Control': 'no-cache',
+			},
+		})
+		const body = await readJsonBody<HealthComponentsBody>(response)
+		return parseExecuteLastSuccessAt(body?.executeEvidence?.lastSuccessAt)
+	} catch {
+		return null
+	}
 }
 
 export type ProbeRunResult = {

--- a/packages/status/readme.md
+++ b/packages/status/readme.md
@@ -23,9 +23,10 @@ deploys, code, or database are broken (see decision record 0004).
     execute. When the Durable Object's last-success timestamp is already outside
     the one-minute organic window, those public reads refresh `executeEvidence`
     from origin `GET /health/components` (same cheap timestamp-only field the
-    cron uses; a down origin fails open to stored state). Missing or stale
-    telemetry is unknown, not an outage, and does not change overall status or
-    hide other incidents.
+    cron uses; a down origin fails open to stored state; persist merges with any
+    newer timestamp written during that fetch). Missing or stale telemetry is
+    unknown, not an outage, and does not change overall status or hide other
+    incidents.
 - Public storage cards are the main-worker bindings that take the product down
   (`app_db`, `kv`, `assets`). Operator `GET /health/components` reports
   `audit_db` as well; it is not a public card and does not open incidents or

--- a/packages/status/readme.md
+++ b/packages/status/readme.md
@@ -23,10 +23,10 @@ deploys, code, or database are broken (see decision record 0004).
     execute. When the Durable Object's last-success timestamp is already outside
     the one-minute organic window, those public reads refresh `executeEvidence`
     from origin `GET /health/components` (same cheap timestamp-only field the
-    cron uses; a down origin fails open to stored state; persist merges with any
-    newer timestamp written during that fetch). Missing or stale telemetry is
-    unknown, not an outage, and does not change overall status or hide other
-    incidents.
+    cron uses; a down origin fails open to stored state; persist and cron
+    synthetic writes merge with any newer timestamp written during those
+    fetches). Missing or stale telemetry is unknown, not an outage, and does not
+    change overall status or hide other incidents.
 - Public storage cards are the main-worker bindings that take the product down
   (`app_db`, `kv`, `assets`). Operator `GET /health/components` reports
   `audit_db` as well; it is not a public card and does not open incidents or

--- a/packages/status/readme.md
+++ b/packages/status/readme.md
@@ -15,13 +15,17 @@ deploys, code, or database are broken (see decision record 0004).
     `status: "ok"`; an apex 302 is not up)
   - jobs-worker `GET /health` and `GET /health/components` over a service
     binding (no public jobs hostname; JOBS_DB rides on the Jobs component)
-  - MCP execute evidence: a successful authenticated execute completion in the
+  -     MCP execute evidence: a successful authenticated execute completion in the
     previous minute (read cheaply from `/health/components`) skips a synthetic.
     Otherwise the worker runs at most one authenticated
     `POST /__maintenance/mcp-execute-health` per rolling hour. Failed attempts
-    consume that budget. Public `/`, `/status.json`, and `/health` never trigger
-    that execute. Missing or stale telemetry is unknown, not an outage, and does
-    not change overall status or hide other incidents.
+    consume that budget. Public `/` and `/status.json` never trigger that
+    execute. When the Durable Object's last-success timestamp is already outside
+    the one-minute organic window, those public reads refresh `executeEvidence`
+    from origin `GET /health/components` (same cheap timestamp-only field the
+    cron uses; a down origin fails open to stored state). Missing or stale
+    telemetry is unknown, not an outage, and does not change overall status or
+    hide other incidents.
 - Public storage cards are the main-worker bindings that take the product down
   (`app_db`, `kv`, `assets`). Operator `GET /health/components` reports
   `audit_db` as well; it is not a public card and does not open incidents or

--- a/packages/status/status-store.ts
+++ b/packages/status/status-store.ts
@@ -273,8 +273,14 @@ export class StatusStore extends DurableObject<StatusWorkerEnv> {
 	}
 
 	private writeExecuteHealthState(state: ExecuteHealthCoordinatorState) {
-		if (state.lastSuccessAt !== null) {
-			this.setMeta(executeLastSuccessMetaKey, String(state.lastSuccessAt))
+		// getSnapshot can persist newer organic last-success while the
+		// synthetic fetch has the input gate open. Never rewind that write.
+		const lastSuccessAt = mergeExecuteLastSuccess(
+			state.lastSuccessAt,
+			this.readEpochMeta(executeLastSuccessMetaKey),
+		)
+		if (lastSuccessAt !== null) {
+			this.setMeta(executeLastSuccessMetaKey, String(lastSuccessAt))
 		}
 		if (state.lastSyntheticAttemptAt !== null) {
 			this.setMeta(

--- a/packages/status/status-store.ts
+++ b/packages/status/status-store.ts
@@ -42,9 +42,15 @@ import {
 	applyExecuteHealthTick,
 	deriveExecuteHealthView,
 	mergeExecuteLastSuccess,
+	readExecuteHealthSyntheticResult,
+	resolvePublicExecuteLastSuccess,
 	type ExecuteHealthCoordinatorState,
 } from './execute-health.ts'
-import { jobsProbeOrigin, runAllProbes } from './probes.ts'
+import {
+	fetchExecuteEvidenceLastSuccessAt,
+	jobsProbeOrigin,
+	runAllProbes,
+} from './probes.ts'
 import {
 	fetchRelevantProviderIncidents,
 	parseProviderIncidentCache,
@@ -309,14 +315,27 @@ export class StatusStore extends DurableObject<StatusWorkerEnv> {
 				signal: AbortSignal.timeout(15_000),
 			},
 		)
-		if (!response.ok) {
-			return { ok: false, error: `HTTP ${String(response.status)}` }
+		let body: { ok?: unknown; reason?: unknown; error?: unknown } | null = null
+		try {
+			body = (await response.json()) as {
+				ok?: unknown
+				reason?: unknown
+				error?: unknown
+			}
+		} catch {
+			body = null
 		}
-		const body = (await response.json()) as { ok?: boolean }
-		if (body.ok !== true) {
-			return { ok: false, error: 'probe-failed' }
+		const result = readExecuteHealthSyntheticResult({
+			status: response.status,
+			body,
+		})
+		if (!result.ok) {
+			console.warn(
+				'execute-health-synthetic-failed',
+				result.error ?? `HTTP ${String(response.status)}`,
+			)
 		}
-		return { ok: true, error: null }
+		return result
 	}
 
 	private loadComponentState(
@@ -695,6 +714,24 @@ export class StatusStore extends DurableObject<StatusWorkerEnv> {
 	}
 
 	async getSnapshot(): Promise<StatusSnapshot> {
+		const storedLastSuccessAt = this.readEpochMeta(executeLastSuccessMetaKey)
+		const resolvedLastSuccess = await resolvePublicExecuteLastSuccess({
+			now: Date.now(),
+			storedLastSuccessAt,
+			fetchLive: () =>
+				fetchExecuteEvidenceLastSuccessAt({
+					primaryOrigin: this.env.PRIMARY_ORIGIN,
+				}),
+		})
+		if (
+			resolvedLastSuccess.persist &&
+			resolvedLastSuccess.lastSuccessAt !== null
+		) {
+			this.setMeta(
+				executeLastSuccessMetaKey,
+				String(resolvedLastSuccess.lastSuccessAt),
+			)
+		}
 		const now = Date.now()
 		const windowStartMs = Date.parse(
 			`${toDay(now - (uptimeWindowDays - 1) * 24 * 60 * 60 * 1000)}T00:00:00.000Z`,
@@ -727,9 +764,7 @@ export class StatusStore extends DurableObject<StatusWorkerEnv> {
 			jobsCommit: this.getMeta(jobsCommitMetaKey),
 			executeHealth: deriveExecuteHealthView({
 				now,
-				...this.readExecuteHealthState(
-					this.readEpochMeta(executeLastSuccessMetaKey),
-				),
+				...this.readExecuteHealthState(resolvedLastSuccess.lastSuccessAt),
 			}),
 		}
 	}

--- a/packages/status/status-store.ts
+++ b/packages/status/status-store.ts
@@ -722,6 +722,7 @@ export class StatusStore extends DurableObject<StatusWorkerEnv> {
 				fetchExecuteEvidenceLastSuccessAt({
 					primaryOrigin: this.env.PRIMARY_ORIGIN,
 				}),
+			readStoredAfterFetch: () => this.readEpochMeta(executeLastSuccessMetaKey),
 		})
 		if (
 			resolvedLastSuccess.persist &&


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Keep the public status-page MCP execute card aligned with live organic execute traffic so `status.kody.codes` shows **Recently verified · organic traffic** under normal load, without treating missing/stale execute telemetry as a platform outage.

## Why

Live production (sampled ~2026-09-10T22:23:45Z) showed a split:

- `https://kody.codes/health/components` `executeEvidence.lastSuccessAt` = `2026-09-10T22:23:29.243Z` (fresh organic)
- `https://status.kody.codes/status.json` `executeHealth.lastVerifiedAt` = `2026-09-10T22:21:44.790Z` (~121s stale) with copy **Last synthetic attempt failed…**

The fleet heartbeat and origin `/health/components` path were working. The status worker snapshot only read Durable Object meta written by the minute cron, so a 60s organic window plus cron/coalesce jitter made live origin evidence look stale. A leftover `lastSyntheticError` then replaced the public detail. Kent confirmed heavy organic execute traffic, so the synthetic should have been skipped.

## Summary

- Public `/` and `/status.json` refresh cheap origin `GET /health/components` `executeEvidence` when stored last-success is already outside the 60s organic window, persist a newer timestamp, and never start MCP execute.
- After that origin fetch, persist re-reads Durable Object last-success and merges `max` so a concurrent cron or snapshot write cannot be rewound (Bugbot persist race).
- Cron `writeExecuteHealthState` also merges stored last-success so a synthetic await cannot overwrite a newer organic timestamp persisted by `getSnapshot` (CodeRabbit).
- Fresh stored evidence skips that fetch so a healthy origin is not on the snapshot hot path. A down/hung origin fails open to stored state (2s timeout).
- Cron probes send `Cache-Control: no-cache`. A 503 `/health/components` body still yields `executeEvidence`.
- Sticky synthetic-failure copy is used only when there is no last-success source. Stale organic evidence uses the generic “missing or stale telemetry” detail.
- Synthetic maintenance errors keep origin `reason` / `error` instead of collapsing to `HTTP 500`.
- No new secrets. The hourly canary still uses `MCP_EXECUTE_HEALTH_CANARY_ACCESS_TOKEN` (1-hour OAuth access tokens) if organic traffic actually goes quiet; that is a leftover ops follow-up, not this card’s primary bug.

## Testing

- `vitest run` in `packages/status` — 14 files, 37 tests passed, including the Kent reproduction (stored 121s stale + live origin 16s fresh → `recent` / `organic`) and the persist-race case (newer stored timestamp written during fetch is not rewound).
- `tsc --noEmit -p packages/status/tsconfig.json`
- Pre-push hook: `test:node` + `test:workers`

## How to verify after status-worker deploy

1. Compare the same second:
   - `curl -fsS https://kody.codes/health/components`
   - `curl -fsS https://status.kody.codes/status.json`
2. Under live execute traffic, `executeHealth.lastVerifiedAt` should match or be within ~60s of `executeEvidence.lastSuccessAt`.
3. The MCP execute card should read **Recently verified · organic traffic**.
4. `overallStatus` stays `operational` even if execute evidence is unknown.

The kody.codes PR preview does not deploy the status worker, so a logged-in preview UI pass cannot prove this card. Verification is the live `status.kody.codes` split after the status-worker deploy.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `09e78ece` · **Head:** `6f403f63`

**Classification:** extends — status-page public snapshots refresh stale organic execute evidence from origin `/health/components` and persist without rewinding a newer timestamp written during that fetch or a later synthetic write.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `status-page` | surfaces | extends — `/` and `/status.json` refresh and persist `executeEvidence` when stored last-success is stale; persist and cron synthetic writes re-read Durable Object meta and merge `max` so concurrent writes cannot rewind last-success |
| `app-ui` | surfaces | composes — unchanged `GET /health/components` cheap timestamp read |

### Change flow

A status-page viewer sees organic execute last-success from origin when the Durable Object snapshot is already older than one minute, without overwriting a newer timestamp written while that fetch or the hourly synthetic is in flight.

```mermaid
sequenceDiagram
	actor Viewer
	participant statusPage as status-page
	participant appUi as app-ui
	Viewer->>statusPage: GET / or /status.json
	alt stored lastSuccessAt younger than 60s
		statusPage->>statusPage: derive executeHealth from Durable Object meta
	else stored lastSuccessAt missing or stale
		statusPage->>appUi: GET /health/components with Cache-Control no-cache
		Note over statusPage: input gate opens during fetch
		appUi-->>statusPage: executeEvidence.lastSuccessAt
		statusPage->>statusPage: re-read stored last-success, merge max, persist only if newer
	end
```

### Invariants

Per-user isolation is not implicated (status data is global operational telemetry). Public status GETs still never trigger a paid MCP execute. A down origin fails open to stored last-success and does not change `overallStatus`. Persist and cron synthetic writes never rewind a newer last-success written while a fetch was in flight.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-86ec75bf-0d48-4366-acae-52d66f9e24cb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-86ec75bf-0d48-4366-acae-52d66f9e24cb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Public status pages now refresh stale execute-health timestamps from the origin without triggering active probes.
  * Organic health status is preserved when synthetic probes fail, provided verified evidence is available.
  * Health-check errors now report clearer, bounded messages with improved HTTP fallback handling.
  * Public status reads continue to fail open to stored data when the origin is unavailable.
  * Concurrent updates no longer overwrite newer health evidence.

* **Documentation**
  * Updated architecture, setup, and status documentation to describe refreshed health-evidence behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->