### PR TITLE
Filter own packages by visibility, listing, and hidden

### DIFF
--- a/.agents/skills/control-kody/references/features/packages.md
+++ b/.agents/skills/control-kody/references/features/packages.md
@@ -5,13 +5,17 @@ Repo-backed saved packages: list, detail, files, approve-publish.
 ## How to get there
 
 `/@username` lists your packages, including private and unpublished packages
-when you view your own profile. Each package lives at `/@username/:kodyId` (the
-URL slug is the package name leaf; README), `/@username/:kodyId/tree/:ref`
-(files), `/@username/:kodyId/assets/…` (README-relative images from the
-published or pinned commit), `/@username/:kodyId/settings` (lock, visibility,
-delete), and `/@username/:kodyId/approve-publish` (published-vs-HEAD review).
-Opening an allowlisted image or video in the tree renders a preview; the bytes
-come from `/@username/:kodyId/raw/:ref/…` (same authz as the tree). Legacy
+when you view your own profile. Own-profile GET filters:
+`visibility=public|private`, `listing=published|unpublished|ahead` (ahead =
+local edits not republished), and `hidden=yes|no`. Guests can use
+`listing=published|unpublished` only; owner-only params are ignored for them.
+Search stays `q=`. Each package lives at `/@username/:kodyId` (the URL slug is
+the package name leaf; README), `/@username/:kodyId/tree/:ref` (files),
+`/@username/:kodyId/assets/…` (README-relative images from the published or
+pinned commit), `/@username/:kodyId/settings` (lock, visibility, delete), and
+`/@username/:kodyId/approve-publish` (published-vs-HEAD review). Opening an
+allowlisted image or video in the tree renders a preview; the bytes come from
+`/@username/:kodyId/raw/:ref/…` (same authz as the tree). Legacy
 `/account/packages` HTML URLs only redirect to these canonical pages.
 
 ## Drive it

--- a/packages/worker/client/routes/profile-search.ts
+++ b/packages/worker/client/routes/profile-search.ts
@@ -1,5 +1,0 @@
-export {
-	readProfileSearchQueryFromHref,
-	readProfilePackageFiltersFromHref,
-	buildProfileHref,
-} from '#universal/profile-search.ts'

--- a/packages/worker/client/routes/profile-search.ts
+++ b/packages/worker/client/routes/profile-search.ts
@@ -1,4 +1,5 @@
-export function readProfileSearchQueryFromHref(href: string) {
-	const url = new URL(href, 'http://localhost')
-	return url.searchParams.get('q') ?? ''
-}
+export {
+	readProfileSearchQueryFromHref,
+	readProfilePackageFiltersFromHref,
+	buildProfileHref,
+} from '#universal/profile-search.ts'

--- a/packages/worker/client/routes/profile.tsx
+++ b/packages/worker/client/routes/profile.tsx
@@ -140,6 +140,8 @@ export function ProfileRoute(handle: Handle) {
 		const href = readCurrentRouterHref(handle)
 		if (!isProfilePathname(new URL(href, 'http://localhost').pathname)) return
 
+		handle.update()
+
 		const frame = handle.frames.get(PROFILE_TARGET)
 		if (!frame) return
 
@@ -153,12 +155,6 @@ export function ProfileRoute(handle: Handle) {
 	return () => {
 		const username = getCurrentUsername(handle)
 		const currentHref = readCurrentRouterHref(handle)
-		// The frame decides which filters the viewer may use; the shell only
-		// carries whatever is in the URL forward when a new search is submitted.
-		const filters = readProfilePackageFiltersFromHref(currentHref, {
-			allowOwnerFilters: true,
-		})
-		const searchQuery = filters.query
 
 		if (!username) {
 			return (
@@ -205,6 +201,12 @@ export function ProfileRoute(handle: Handle) {
 			shell != null && shell.ok && shellLoadedForUsername === username
 				? shell
 				: null
+		// The frame decides which filters the viewer may use; the shell only
+		// carries owner-only params forward when this is the signed-in owner.
+		const filters = readProfilePackageFiltersFromHref(currentHref, {
+			allowOwnerFilters: readyShell?.isSelf === true,
+		})
+		const searchQuery = filters.query
 
 		if (showUnavailable) {
 			return (

--- a/packages/worker/client/routes/profile.tsx
+++ b/packages/worker/client/routes/profile.tsx
@@ -22,7 +22,7 @@ import { type RouteLoaderResult } from '#client/route-loader.ts'
 import { readRouterPathname } from '#client/router-location.tsx'
 import { readJson } from '#client/routes/account-approval-shared.ts'
 import { on } from '#client/event-mixin.ts'
-import { readProfileSearchQueryFromHref } from '#client/routes/profile-search.ts'
+import { readProfilePackageFiltersFromHref } from '#universal/profile-search.ts'
 import { renderProfileIdentity } from '#client/routes/profile-identity.tsx'
 import { colors, spacing, typography } from '#universal/styles/tokens.ts'
 import {
@@ -153,7 +153,12 @@ export function ProfileRoute(handle: Handle) {
 	return () => {
 		const username = getCurrentUsername(handle)
 		const currentHref = readCurrentRouterHref(handle)
-		const searchQuery = readProfileSearchQueryFromHref(currentHref)
+		// The frame decides which filters the viewer may use; the shell only
+		// carries whatever is in the URL forward when a new search is submitted.
+		const filters = readProfilePackageFiltersFromHref(currentHref, {
+			allowOwnerFilters: true,
+		})
+		const searchQuery = filters.query
 
 		if (!username) {
 			return (
@@ -245,10 +250,23 @@ export function ProfileRoute(handle: Handle) {
 							data-rmx-history="push"
 							mix={css(searchFormCss)}
 						>
+							{filters.visibility !== 'all' ? (
+								<input
+									type="hidden"
+									name="visibility"
+									value={filters.visibility}
+								/>
+							) : null}
+							{filters.listing !== 'all' ? (
+								<input type="hidden" name="listing" value={filters.listing} />
+							) : null}
+							{filters.hidden !== 'all' ? (
+								<input type="hidden" name="hidden" value={filters.hidden} />
+							) : null}
 							<label mix={css(searchFieldCss)}>
 								<span mix={css(fieldLabelCss)}>Search packages</span>
 								<input
-									key={searchQuery}
+									key={`${searchQuery}:${filters.visibility}:${filters.listing}:${filters.hidden}`}
 									type="search"
 									name="q"
 									defaultValue={searchQuery}

--- a/packages/worker/src/app/frames/profile.ts
+++ b/packages/worker/src/app/frames/profile.ts
@@ -25,6 +25,9 @@ registerFrame(PROFILE_TARGET, {
 			packages: data.packages,
 			activity: data.activity,
 			query: data.query,
+			visibility: data.visibility,
+			listing: data.listing,
+			hidden: data.hidden,
 			isSelf: data.isSelf,
 		})
 	},

--- a/packages/worker/src/app/handlers/profile.node.test.ts
+++ b/packages/worker/src/app/handlers/profile.node.test.ts
@@ -127,10 +127,43 @@ test('profile API and page respect visibility and expose packages/activity', asy
 	expect(publicBody.activity).toHaveLength(1)
 	expect(publicBody.isSelf).toBe(false)
 	expect(publicBody.loggedIn).toBe(false)
+	expect(publicBody.visibility).toBe('all')
+	expect(publicBody.listing).toBe('all')
+	expect(publicBody.hidden).toBe('all')
 	expect(mockModule.listPublicProfilePackages).toHaveBeenCalledWith(
 		expect.objectContaining({
 			ownerStableUserId: 'stable-alice',
 			includePrivate: false,
+			filters: {
+				query: '',
+				visibility: 'all',
+				listing: 'all',
+				hidden: 'all',
+			},
+		}),
+	)
+
+	mockModule.listPublicProfilePackages.mockClear()
+	const guestFilterResponse = await apiHandler.handler({
+		request: new Request(
+			'https://example.com/profiles/alice.json?visibility=private&listing=published&hidden=yes',
+		),
+		params: { username: 'alice' },
+		url: new URL(
+			'https://example.com/profiles/alice.json?visibility=private&listing=published&hidden=yes',
+		),
+	} as never)
+	expect(guestFilterResponse.status).toBe(200)
+	expect((await guestFilterResponse.json()).listing).toBe('published')
+	expect(mockModule.listPublicProfilePackages).toHaveBeenCalledWith(
+		expect.objectContaining({
+			includePrivate: false,
+			filters: {
+				query: '',
+				visibility: 'all',
+				listing: 'published',
+				hidden: 'all',
+			},
 		}),
 	)
 
@@ -168,19 +201,32 @@ test('profile API and page respect visibility and expose packages/activity', asy
 	mockModule.listPublicProfilePackages.mockResolvedValue([])
 	mockModule.getProfileActivity.mockResolvedValue([])
 	const ownResponse = await apiHandler.handler({
-		request: new Request('https://example.com/profiles/alice.json'),
+		request: new Request(
+			'https://example.com/profiles/alice.json?visibility=private&listing=ahead&hidden=yes',
+		),
 		params: { username: 'alice' },
-		url: new URL('https://example.com/profiles/alice.json'),
+		url: new URL(
+			'https://example.com/profiles/alice.json?visibility=private&listing=ahead&hidden=yes',
+		),
 	} as never)
 	const ownBody = await ownResponse.json()
 	expect(ownResponse.status).toBe(200)
 	expect(ownBody.ok).toBe(true)
 	expect(ownBody.isSelf).toBe(true)
 	expect(ownBody.profile.visibility).toBe('private')
+	expect(ownBody.visibility).toBe('private')
+	expect(ownBody.listing).toBe('ahead')
+	expect(ownBody.hidden).toBe('yes')
 	expect(mockModule.listPublicProfilePackages).toHaveBeenCalledWith(
 		expect.objectContaining({
 			ownerStableUserId: 'stable-alice',
 			includePrivate: true,
+			filters: {
+				query: '',
+				visibility: 'private',
+				listing: 'ahead',
+				hidden: 'yes',
+			},
 		}),
 	)
 

--- a/packages/worker/src/app/handlers/profile.node.test.ts
+++ b/packages/worker/src/app/handlers/profile.node.test.ts
@@ -20,6 +20,9 @@ vi.mock('#worker/community/profile-service.ts', () => ({
 		mockModule.getCommunityProfileByUsername(...args),
 	getProfileActivity: (...args: Array<unknown>) =>
 		mockModule.getProfileActivity(...args),
+}))
+
+vi.mock('#worker/community/profile-package-list.ts', () => ({
 	listPublicProfilePackages: (...args: Array<unknown>) =>
 		mockModule.listPublicProfilePackages(...args),
 }))

--- a/packages/worker/src/app/profile-content.node.test.ts
+++ b/packages/worker/src/app/profile-content.node.test.ts
@@ -130,3 +130,87 @@ test('profile packages link listings, prefer listing kody ids, and separate publ
 	expect(ownEmptyHtml).toContain('You have no packages yet.')
 	expect(ownEmptyHtml).not.toContain('No public packages to take yet.')
 })
+
+test('profile package filters render owner-only pills, keep other filters in each href, and explain an empty filtered list', async () => {
+	const ownHtml = await renderProfileContentHtml({
+		profile,
+		packages: [listedPackage, unpublishedPackage],
+		activity: [],
+		query: 'fathom',
+		visibility: 'private',
+		listing: 'all',
+		hidden: 'all',
+		isSelf: true,
+	})
+
+	expect(ownHtml).toContain('data-testid="profile-package-filters"')
+	expect(ownHtml).toContain('data-testid="profile-package-filter-visibility"')
+	expect(ownHtml).toContain('data-testid="profile-package-filter-listing"')
+	expect(ownHtml).toContain('data-testid="profile-package-filter-hidden"')
+	// The selected pill is marked; sibling pills in the same group are not.
+	expect(ownHtml).toContain(
+		'href="/@kody?q=fathom&amp;visibility=private" aria-current="page"',
+	)
+	expect(ownHtml).toContain('href="/@kody?q=fathom&amp;visibility=public"')
+	expect(ownHtml).not.toContain(
+		'href="/@kody?q=fathom&amp;visibility=public" aria-current="page"',
+	)
+	// Switching one axis keeps the query and the other active filters.
+	expect(ownHtml).toContain(
+		'href="/@kody?q=fathom&amp;visibility=private&amp;listing=ahead"',
+	)
+	expect(ownHtml).toContain(
+		'href="/@kody?q=fathom&amp;visibility=private&amp;hidden=yes"',
+	)
+	// The visibility "All" pill drops only its own param and is not current.
+	expect(ownHtml).toMatch(/<a href="\/@kody\?q=fathom" class=/)
+	expect(ownHtml).toContain('Needs republish')
+
+	// Guests see the same packages with only the listing axis.
+	const guestHtml = await renderProfileContentHtml({
+		profile,
+		packages: [listedPackage, unpublishedPackage],
+		activity: [],
+		query: null,
+		listing: 'published',
+		isSelf: false,
+	})
+	expect(guestHtml).toContain('data-testid="profile-package-filters"')
+	expect(guestHtml).toContain('data-testid="profile-package-filter-listing"')
+	expect(guestHtml).toContain(
+		'href="/@kody?listing=published" aria-current="page"',
+	)
+	expect(guestHtml).toContain('href="/@kody?listing=unpublished"')
+	expect(guestHtml).not.toContain(
+		'data-testid="profile-package-filter-visibility"',
+	)
+	expect(guestHtml).not.toContain('data-testid="profile-package-filter-hidden"')
+	expect(guestHtml).not.toContain('visibility=private')
+	expect(guestHtml).not.toContain('listing=ahead')
+
+	// A guest profile with nothing to show has nothing to filter either.
+	const guestEmptyHtml = await renderProfileContentHtml({
+		profile,
+		packages: [],
+		activity: [],
+		query: null,
+		isSelf: false,
+	})
+	expect(guestEmptyHtml).not.toContain('data-testid="profile-package-filters"')
+
+	// Owners keep the toolbar when a filter empties the list so they can back out.
+	const ownFilteredEmptyHtml = await renderProfileContentHtml({
+		profile,
+		packages: [],
+		activity: [],
+		query: null,
+		visibility: 'private',
+		isSelf: true,
+	})
+	expect(ownFilteredEmptyHtml).toContain(
+		'data-testid="profile-package-filters"',
+	)
+	expect(ownFilteredEmptyHtml).toContain('No packages matched these filters.')
+	expect(ownFilteredEmptyHtml).toContain('href="/@kody"')
+	expect(ownFilteredEmptyHtml).not.toContain('You have no packages yet.')
+})

--- a/packages/worker/src/app/profile-content.tsx
+++ b/packages/worker/src/app/profile-content.tsx
@@ -9,6 +9,10 @@ import {
 import { formatCommunityPublishedDate } from '#universal/community-display.ts'
 import { renderCommunityListingName } from '#universal/community-listing-name.tsx'
 import {
+	type ProfilePackageFilters,
+	type ProfilePackageHiddenFilter,
+	type ProfilePackageListingFilter,
+	type ProfilePackageVisibilityFilter,
 	type PublicCommunityActivityItem,
 	type PublicCommunityProfile,
 	type PublicProfilePackageItem,
@@ -17,10 +21,6 @@ import { getCommunityListingHref } from '#universal/community-links.ts'
 import {
 	buildProfileHref,
 	profilePackageFiltersAreActive,
-	type ProfilePackageFilters,
-	type ProfilePackageHiddenFilter,
-	type ProfilePackageListingFilter,
-	type ProfilePackageVisibilityFilter,
 } from '#universal/profile-search.ts'
 import { routes } from '#universal/routes.ts'
 import { UserAvatar } from '#universal/user-avatar.tsx'

--- a/packages/worker/src/app/profile-content.tsx
+++ b/packages/worker/src/app/profile-content.tsx
@@ -14,6 +14,14 @@ import {
 	type PublicProfilePackageItem,
 } from '#universal/community-public-types.ts'
 import { getCommunityListingHref } from '#universal/community-links.ts'
+import {
+	buildProfileHref,
+	profilePackageFiltersAreActive,
+	type ProfilePackageFilters,
+	type ProfilePackageHiddenFilter,
+	type ProfilePackageListingFilter,
+	type ProfilePackageVisibilityFilter,
+} from '#universal/profile-search.ts'
 import { routes } from '#universal/routes.ts'
 import { UserAvatar } from '#universal/user-avatar.tsx'
 import {
@@ -35,6 +43,9 @@ export type ProfileContentProps = {
 	packages: Array<PublicProfilePackageItem>
 	activity: Array<PublicCommunityActivityItem>
 	query: string | null
+	visibility?: ProfilePackageVisibilityFilter
+	listing?: ProfilePackageListingFilter
+	hidden?: ProfilePackageHiddenFilter
 	isSelf: boolean
 }
 
@@ -80,137 +91,275 @@ function renderProfilePackageDates(
 	return `${published} · edited ${formatCommunityPublishedDate(pkg.updatedAt)}, not republished`
 }
 
-export function ProfileContent(handle: Handle<ProfileContentProps>) {
-	const { profile, packages, activity, query, isSelf } = handle.props
+type ProfileFilterChoice<Filter extends string> = {
+	value: Filter
+	label: string
+	title?: string
+}
 
-	return () => (
-		<div data-testid="profile-frame">
-			<section mix={css(sectionCss)} data-testid="profile-packages">
-				{packages.length === 0 ? (
-					<p mix={css(emptyCss)} data-testid="profile-packages-empty">
-						{query
-							? 'No packages matched your search.'
-							: isSelf
-								? 'You have no packages yet.'
-								: 'No public packages to take yet.'}
-					</p>
-				) : (
-					<ul mix={css(packageListCss)}>
-						{packages.map((pkg) => {
-							const packageHref = routes.communityPackage.href({
-								username: profile.username,
-								kodyId: pkg.communityListingKodyId ?? pkg.kodyId,
-							})
-							const listingHref = pkg.communityListingId
-								? getCommunityListingHref({
-										listingId: pkg.communityListingId,
-										ownerUsername: profile.username,
-										kodyId: pkg.communityListingKodyId,
-									})
-								: null
-							return (
-								<li key={pkg.kodyId} mix={css(cardCss)}>
-									<div mix={css(packageHeadingCss)}>
-										<div mix={css(packageTitleGroupCss)}>
-											{listingHref ? (
-												<a
-													href={listingHref}
-													title="fork"
-													aria-label="fork"
-													mix={css(forkButtonCss)}
-												>
-													{renderForkIcon()}
-												</a>
-											) : null}
-											<h3 mix={css(packageNameCss)}>
-												<a href={packageHref} mix={css(packageNameLinkCss)}>
-													{renderCommunityListingName(pkg.name)}
-												</a>
-											</h3>
-										</div>
-										{pkg.hidden ? (
-											<span mix={css(unpublishedBadgeCss)}>Hidden</span>
-										) : null}
-										{pkg.isPrivate ? (
-											<span mix={css(unpublishedBadgeCss)}>Private</span>
-										) : null}
-										{pkg.communityListingId ? (
-											<span mix={css(communityBadgeCss)}>Community</span>
-										) : (
-											<span mix={css(unpublishedBadgeCss)}>Not published</span>
-										)}
-									</div>
-									{pkg.description ? (
-										<p mix={css(descriptionCss)}>{pkg.description}</p>
-									) : null}
-									{pkg.tags.length > 0 ? (
-										<ul mix={css(tagListCss)}>
-											{pkg.tags.map((tag) => (
-												<li key={tag} mix={css(tagPillCss)}>
-													{tag}
-												</li>
-											))}
-										</ul>
-									) : null}
-									<p mix={css(mutedCss)}>
-										{renderProfilePackageDates(pkg, { isSelf })}
-									</p>
-								</li>
-							)
-						})}
-					</ul>
-				)}
-			</section>
+function renderProfileFilterNav<Filter extends string>(input: {
+	label: string
+	ariaLabel: string
+	testId: string
+	selected: Filter
+	choices: Array<ProfileFilterChoice<Filter>>
+	hrefFor: (value: Filter) => string
+}) {
+	return (
+		<nav
+			aria-label={input.ariaLabel}
+			data-testid={input.testId}
+			mix={css(filterNavCss)}
+		>
+			<span aria-hidden="true" mix={css(filterNavLabelCss)}>
+				{input.label}
+			</span>
+			{input.choices.map((choice) => (
+				<a
+					key={choice.value}
+					href={input.hrefFor(choice.value)}
+					aria-current={input.selected === choice.value ? 'page' : undefined}
+					title={choice.title}
+					mix={css(filterLinkCss)}
+				>
+					{choice.label}
+				</a>
+			))}
+		</nav>
+	)
+}
 
-			<section mix={css(activitySectionCss)} data-testid="profile-activity">
-				<h2 mix={css(sectionTitleCss)}>Recent activity</h2>
-				<p mix={css(mutedCss)} data-testid="profile-activity-hint">
-					Community publishes and forks. Editing a package without republishing
-					it does not appear here.
-				</p>
-				{activity.length === 0 ? (
-					<p mix={css(descriptionCss)}>No public activity yet.</p>
-				) : (
-					<ul mix={css(activityListCss)}>
-						{activity.map((item) => (
-							<li
-								key={`${item.type}:${item.listingId}:${item.createdAt}`}
-								mix={css(activityItemCss)}
-							>
-								<span mix={css(activityActorCss)}>
-									<UserAvatar
-										displayName={item.actorDisplayName}
-										avatarUrl={item.actorAvatarUrl}
-										size={32}
-									/>
-									<span>
-										{communityActivityVerb(item.type)}{' '}
-										<a
-											href={getCommunityListingHref({
-												listingId: item.listingId,
-												listingName: item.listingName,
-												kodyId: item.listingKodyId,
-											})}
-											mix={css(mutedLinkCss)}
-										>
-											{item.listingName}
-										</a>
-									</span>
-								</span>
-								<time
-									dateTime={item.createdAt}
-									mix={css(mutedCss)}
-									title={item.createdAt}
-								>
-									{formatCommunityActivityDate(item.createdAt)}
-								</time>
-							</li>
-						))}
-					</ul>
-				)}
-			</section>
+/**
+ * GET filter pills above the package list, in the same grammar as the
+ * community category chips. Every link carries the other active filters and
+ * the search query so narrowing one axis never resets another. Guests only
+ * get the listing axis; visibility, hidden, and "needs republish" describe
+ * owner-only inventory the server ignores for them anyway.
+ */
+function renderProfilePackageFilters(input: {
+	username: string
+	filters: ProfilePackageFilters
+	isSelf: boolean
+}) {
+	const { username, filters, isSelf } = input
+	const listingChoices: Array<
+		ProfileFilterChoice<ProfilePackageListingFilter>
+	> = [
+		{ value: 'all', label: 'All' },
+		{ value: 'published', label: 'Published' },
+		{ value: 'unpublished', label: 'Not published' },
+	]
+	if (isSelf) {
+		listingChoices.push({
+			value: 'ahead',
+			label: 'Needs republish',
+			title: 'Published packages edited since their last publish',
+		})
+	}
+	return (
+		<div data-testid="profile-package-filters" mix={css(filterToolbarCss)}>
+			{isSelf
+				? renderProfileFilterNav<ProfilePackageVisibilityFilter>({
+						label: 'Visibility',
+						ariaLabel: 'Filter packages by visibility',
+						testId: 'profile-package-filter-visibility',
+						selected: filters.visibility,
+						choices: [
+							{ value: 'all', label: 'All' },
+							{ value: 'public', label: 'Public' },
+							{ value: 'private', label: 'Private' },
+						],
+						hrefFor: (visibility) =>
+							buildProfileHref({ username, ...filters, visibility }),
+					})
+				: null}
+			{renderProfileFilterNav<ProfilePackageListingFilter>({
+				label: 'Listing',
+				ariaLabel: 'Filter packages by community listing',
+				testId: 'profile-package-filter-listing',
+				selected: filters.listing,
+				choices: listingChoices,
+				hrefFor: (listing) =>
+					buildProfileHref({ username, ...filters, listing }),
+			})}
+			{isSelf
+				? renderProfileFilterNav<ProfilePackageHiddenFilter>({
+						label: 'Hidden',
+						ariaLabel: 'Filter packages by hidden state',
+						testId: 'profile-package-filter-hidden',
+						selected: filters.hidden,
+						choices: [
+							{ value: 'all', label: 'All' },
+							{ value: 'yes', label: 'Hidden' },
+							{ value: 'no', label: 'Visible' },
+						],
+						hrefFor: (hidden) =>
+							buildProfileHref({ username, ...filters, hidden }),
+					})
+				: null}
 		</div>
 	)
+}
+
+function renderProfilePackagesEmptyCopy(input: {
+	query: string | null
+	filtersActive: boolean
+	isSelf: boolean
+}) {
+	if (input.query) return 'No packages matched your search.'
+	if (input.filtersActive) return 'No packages matched these filters.'
+	return input.isSelf
+		? 'You have no packages yet.'
+		: 'No public packages to take yet.'
+}
+
+export function ProfileContent(handle: Handle<ProfileContentProps>) {
+	return () => {
+		const { profile, packages, activity, query, isSelf } = handle.props
+		const filters: ProfilePackageFilters = {
+			query: query ?? '',
+			visibility: handle.props.visibility ?? 'all',
+			listing: handle.props.listing ?? 'all',
+			hidden: handle.props.hidden ?? 'all',
+		}
+		const filtersActive = profilePackageFiltersAreActive(filters)
+		const showFilters =
+			isSelf || packages.length > 0 || Boolean(query) || filtersActive
+
+		return (
+			<div data-testid="profile-frame">
+				<section mix={css(sectionCss)} data-testid="profile-packages">
+					{showFilters
+						? renderProfilePackageFilters({
+								username: profile.username,
+								filters,
+								isSelf,
+							})
+						: null}
+					{packages.length === 0 ? (
+						<p mix={css(emptyCss)} data-testid="profile-packages-empty">
+							{renderProfilePackagesEmptyCopy({ query, filtersActive, isSelf })}
+						</p>
+					) : (
+						<ul mix={css(packageListCss)}>
+							{packages.map((pkg) => {
+								const packageHref = routes.communityPackage.href({
+									username: profile.username,
+									kodyId: pkg.communityListingKodyId ?? pkg.kodyId,
+								})
+								const listingHref = pkg.communityListingId
+									? getCommunityListingHref({
+											listingId: pkg.communityListingId,
+											ownerUsername: profile.username,
+											kodyId: pkg.communityListingKodyId,
+										})
+									: null
+								return (
+									<li key={pkg.kodyId} mix={css(cardCss)}>
+										<div mix={css(packageHeadingCss)}>
+											<div mix={css(packageTitleGroupCss)}>
+												{listingHref ? (
+													<a
+														href={listingHref}
+														title="fork"
+														aria-label="fork"
+														mix={css(forkButtonCss)}
+													>
+														{renderForkIcon()}
+													</a>
+												) : null}
+												<h3 mix={css(packageNameCss)}>
+													<a href={packageHref} mix={css(packageNameLinkCss)}>
+														{renderCommunityListingName(pkg.name)}
+													</a>
+												</h3>
+											</div>
+											{pkg.hidden ? (
+												<span mix={css(unpublishedBadgeCss)}>Hidden</span>
+											) : null}
+											{pkg.isPrivate ? (
+												<span mix={css(unpublishedBadgeCss)}>Private</span>
+											) : null}
+											{pkg.communityListingId ? (
+												<span mix={css(communityBadgeCss)}>Community</span>
+											) : (
+												<span mix={css(unpublishedBadgeCss)}>
+													Not published
+												</span>
+											)}
+										</div>
+										{pkg.description ? (
+											<p mix={css(descriptionCss)}>{pkg.description}</p>
+										) : null}
+										{pkg.tags.length > 0 ? (
+											<ul mix={css(tagListCss)}>
+												{pkg.tags.map((tag) => (
+													<li key={tag} mix={css(tagPillCss)}>
+														{tag}
+													</li>
+												))}
+											</ul>
+										) : null}
+										<p mix={css(mutedCss)}>
+											{renderProfilePackageDates(pkg, { isSelf })}
+										</p>
+									</li>
+								)
+							})}
+						</ul>
+					)}
+				</section>
+
+				<section mix={css(activitySectionCss)} data-testid="profile-activity">
+					<h2 mix={css(sectionTitleCss)}>Recent activity</h2>
+					<p mix={css(mutedCss)} data-testid="profile-activity-hint">
+						Community publishes and forks. Editing a package without
+						republishing it does not appear here.
+					</p>
+					{activity.length === 0 ? (
+						<p mix={css(descriptionCss)}>No public activity yet.</p>
+					) : (
+						<ul mix={css(activityListCss)}>
+							{activity.map((item) => (
+								<li
+									key={`${item.type}:${item.listingId}:${item.createdAt}`}
+									mix={css(activityItemCss)}
+								>
+									<span mix={css(activityActorCss)}>
+										<UserAvatar
+											displayName={item.actorDisplayName}
+											avatarUrl={item.actorAvatarUrl}
+											size={32}
+										/>
+										<span>
+											{communityActivityVerb(item.type)}{' '}
+											<a
+												href={getCommunityListingHref({
+													listingId: item.listingId,
+													listingName: item.listingName,
+													kodyId: item.listingKodyId,
+												})}
+												mix={css(mutedLinkCss)}
+											>
+												{item.listingName}
+											</a>
+										</span>
+									</span>
+									<time
+										dateTime={item.createdAt}
+										mix={css(mutedCss)}
+										title={item.createdAt}
+									>
+										{formatCommunityActivityDate(item.createdAt)}
+									</time>
+								</li>
+							))}
+						</ul>
+					)}
+				</section>
+			</div>
+		)
+	}
 }
 
 export async function renderProfileContentHtml(props: ProfileContentProps) {
@@ -226,6 +375,57 @@ const activityActorCss = {
 const sectionCss = {
 	display: 'grid',
 	gap: spacing.md,
+}
+
+const filterToolbarCss = {
+	display: 'grid',
+	gap: spacing.sm,
+}
+
+/* Same bordered-pill grammar as the community category chips. */
+const filterNavCss = {
+	display: 'flex',
+	flexWrap: 'wrap' as const,
+	alignItems: 'center',
+	gap: '0.4rem',
+	'& a': {
+		backgroundColor: colors.surface,
+		border: `1.5px solid ${colors.border}`,
+		borderRadius: '999px',
+		padding: '0.35rem 0.85rem',
+	},
+}
+
+const filterNavLabelCss = {
+	color: colors.textMuted,
+	fontSize: '0.8rem',
+	fontWeight: 600,
+	textTransform: 'uppercase' as const,
+	letterSpacing: '0.04em',
+	minWidth: '5.5rem',
+}
+
+const filterLinkCss = {
+	display: 'inline-flex',
+	alignItems: 'center',
+	justifyContent: 'center',
+	minHeight: '2rem',
+	padding: '0.3rem 0.95rem',
+	borderRadius: '999px',
+	color: colors.textMuted,
+	fontSize: '0.88rem',
+	fontWeight: 650,
+	lineHeight: 1.2,
+	textDecoration: 'none',
+	transition: `background-color 140ms ${transitions.easeOut}, color 140ms ${transitions.easeOut}, border-color 140ms ${transitions.easeOut}`,
+	'&:hover': {
+		color: colors.text,
+	},
+	'&[aria-current="page"]': {
+		backgroundColor: colors.primarySoft,
+		borderColor: colors.primarySoft,
+		color: colors.primaryText,
+	},
 }
 
 const activitySectionCss = {

--- a/packages/worker/src/app/profile-data.ts
+++ b/packages/worker/src/app/profile-data.ts
@@ -11,10 +11,10 @@ import {
 import { type ProfileLoaderData } from '#universal/loader-data.ts'
 import { readProfilePackageFiltersFromUrl } from '#universal/profile-search.ts'
 import { getUsernameFormatValidationError } from '#worker/identity/username.ts'
+import { listPublicProfilePackages } from '#worker/community/profile-package-list.ts'
 import {
 	getCommunityProfileByUsername,
 	getProfileActivity,
-	listPublicProfilePackages,
 } from '#worker/community/profile-service.ts'
 
 const defaultProfilePackageLimit = 50

--- a/packages/worker/src/app/profile-data.ts
+++ b/packages/worker/src/app/profile-data.ts
@@ -9,6 +9,7 @@ import {
 	toPublicProfilePackageItem,
 } from '#app/community-public.ts'
 import { type ProfileLoaderData } from '#universal/loader-data.ts'
+import { readProfilePackageFiltersFromUrl } from '#universal/profile-search.ts'
 import { getUsernameFormatValidationError } from '#worker/identity/username.ts'
 import {
 	getCommunityProfileByUsername,
@@ -69,7 +70,9 @@ async function loadProfileDataUncached(
 	}
 
 	const url = new URL(request.url)
-	const query = url.searchParams.get('q')?.trim() ?? ''
+	const filters = readProfilePackageFiltersFromUrl(url, {
+		allowOwnerFilters: isSelf,
+	})
 	const packageLimit = readPositiveInt(
 		url.searchParams.get('limit'),
 		defaultProfilePackageLimit,
@@ -80,9 +83,10 @@ async function loadProfileDataUncached(
 		listPublicProfilePackages({
 			env,
 			ownerStableUserId: profile.userId,
-			query: query || undefined,
+			query: filters.query || undefined,
 			limit: packageLimit,
 			includePrivate: isSelf,
+			filters,
 		}),
 		getProfileActivity({
 			env,
@@ -99,7 +103,10 @@ async function loadProfileDataUncached(
 			toPublicProfilePackageItem(pkg, { includeOwnerVisibility: isSelf }),
 		),
 		activity: activity.map(toPublicCommunityActivityItem),
-		query: query || null,
+		query: filters.query || null,
+		visibility: filters.visibility,
+		listing: filters.listing,
+		hidden: filters.hidden,
 		isSelf,
 		loggedIn: Boolean(user),
 	}

--- a/packages/worker/src/community/profile-package-list.ts
+++ b/packages/worker/src/community/profile-package-list.ts
@@ -1,0 +1,93 @@
+import { type ProfilePackageFilters } from '#universal/community-public-types.ts'
+import { listPublicProfilePackages as listPublicProfilePackagesFromDb } from './profile-repo.ts'
+import { type PublicProfilePackage } from './types.ts'
+
+const activeListingExistsSql = `EXISTS (
+	SELECT 1 FROM community_listings AS cl
+	WHERE cl.owner_user_id = saved_packages.user_id
+		AND cl.status = 'active'
+		AND cl.package_id = saved_packages.id
+)`
+
+const listingAheadSql = `EXISTS (
+	SELECT 1 FROM community_listings AS cl
+	WHERE cl.owner_user_id = saved_packages.user_id
+		AND cl.status = 'active'
+		AND cl.package_id = saved_packages.id
+		AND saved_packages.updated_at > cl.published_at
+)`
+
+function profilePackageFilterWhereSql(
+	filters: ProfilePackageFilters,
+): Array<string> {
+	const conditions: Array<string> = []
+	switch (filters.visibility) {
+		case 'all':
+			break
+		case 'public':
+			conditions.push('is_private = 0')
+			break
+		case 'private':
+			conditions.push('is_private = 1')
+			break
+		default: {
+			const exhaustive: never = filters.visibility
+			throw new Error(`Unhandled profile visibility filter: ${exhaustive}`)
+		}
+	}
+	switch (filters.hidden) {
+		case 'all':
+			break
+		case 'yes':
+			conditions.push('hidden = 1')
+			break
+		case 'no':
+			conditions.push('hidden = 0')
+			break
+		default: {
+			const exhaustive: never = filters.hidden
+			throw new Error(`Unhandled profile hidden filter: ${exhaustive}`)
+		}
+	}
+	switch (filters.listing) {
+		case 'all':
+			break
+		case 'published':
+			conditions.push(activeListingExistsSql)
+			break
+		case 'unpublished':
+			conditions.push(`NOT ${activeListingExistsSql}`)
+			break
+		case 'ahead':
+			conditions.push(listingAheadSql)
+			break
+		default: {
+			const exhaustive: never = filters.listing
+			throw new Error(`Unhandled profile listing filter: ${exhaustive}`)
+		}
+	}
+	return conditions
+}
+
+/**
+ * Owner/guest GET filters for `/@username`. Kept out of `profile-service` so
+ * the runtime worker's MCP profile-get path does not load this SQL.
+ */
+export async function listPublicProfilePackages(input: {
+	env: Env
+	ownerStableUserId: string
+	query?: string
+	limit: number
+	includePrivate?: boolean
+	filters?: ProfilePackageFilters
+}): Promise<Array<PublicProfilePackage>> {
+	return await listPublicProfilePackagesFromDb(input.env.APP_DB, {
+		ownerStableUserId: input.ownerStableUserId,
+		query: input.query,
+		limit: input.limit,
+		includePrivate: input.includePrivate,
+		additionalWhereSql: input.filters
+			? profilePackageFilterWhereSql(input.filters)
+			: undefined,
+	})
+}

--- a/packages/worker/src/community/profile-repo.ts
+++ b/packages/worker/src/community/profile-repo.ts
@@ -3,7 +3,6 @@ import { chunkArray } from '@kody-internal/shared/chunk.ts'
 import { utcSqliteTimestamp } from '@kody-internal/shared/date-keys.ts'
 import { parseTagsJson } from '@kody-internal/shared/tags-json.ts'
 import { normalizeStableUserId } from '#worker/user-id.ts'
-import { type ProfilePackageFilters } from '#universal/profile-search.ts'
 import { extractCommunityListingLikeTokens } from './repo.ts'
 import {
 	type CommunityActivityEventType,
@@ -323,73 +322,6 @@ const publicPackageSearchColumns = [
 	'tags_json',
 ] as const
 
-const activeListingExistsSql = `EXISTS (
-	SELECT 1 FROM community_listings AS cl
-	WHERE cl.owner_user_id = saved_packages.user_id
-		AND cl.status = 'active'
-		AND cl.package_id = saved_packages.id
-)`
-
-const listingAheadSql = `EXISTS (
-	SELECT 1 FROM community_listings AS cl
-	WHERE cl.owner_user_id = saved_packages.user_id
-		AND cl.status = 'active'
-		AND cl.package_id = saved_packages.id
-		AND saved_packages.updated_at > cl.published_at
-)`
-
-function applyProfilePackageFilters(
-	conditions: Array<string>,
-	filters: ProfilePackageFilters | undefined,
-) {
-	if (filters == null) return
-	switch (filters.visibility) {
-		case 'all':
-			break
-		case 'public':
-			conditions.push('is_private = 0')
-			break
-		case 'private':
-			conditions.push('is_private = 1')
-			break
-		default: {
-			const exhaustive: never = filters.visibility
-			throw new Error(`Unhandled profile visibility filter: ${exhaustive}`)
-		}
-	}
-	switch (filters.hidden) {
-		case 'all':
-			break
-		case 'yes':
-			conditions.push('hidden = 1')
-			break
-		case 'no':
-			conditions.push('hidden = 0')
-			break
-		default: {
-			const exhaustive: never = filters.hidden
-			throw new Error(`Unhandled profile hidden filter: ${exhaustive}`)
-		}
-	}
-	switch (filters.listing) {
-		case 'all':
-			break
-		case 'published':
-			conditions.push(activeListingExistsSql)
-			break
-		case 'unpublished':
-			conditions.push(`NOT ${activeListingExistsSql}`)
-			break
-		case 'ahead':
-			conditions.push(listingAheadSql)
-			break
-		default: {
-			const exhaustive: never = filters.listing
-			throw new Error(`Unhandled profile listing filter: ${exhaustive}`)
-		}
-	}
-}
-
 export async function listPublicProfilePackages(
 	db: D1Database,
 	input: {
@@ -398,13 +330,16 @@ export async function listPublicProfilePackages(
 		limit: number
 		/** When true, include private and hidden packages (own-profile inventory). */
 		includePrivate?: boolean
-		filters?: ProfilePackageFilters
+		/** Extra AND clauses. Origin profile filters pass these; MCP does not. */
+		additionalWhereSql?: Array<string>
 	},
 ): Promise<Array<PublicProfilePackage>> {
 	const conditions = input.includePrivate
 		? ['user_id = ?']
 		: ['user_id = ?', 'is_private = 0', 'hidden = 0']
-	applyProfilePackageFilters(conditions, input.filters)
+	if (input.additionalWhereSql && input.additionalWhereSql.length > 0) {
+		conditions.push(...input.additionalWhereSql)
+	}
 	const bindings: Array<unknown> = [input.ownerStableUserId]
 	const tokens = extractCommunityListingLikeTokens(input.query ?? '')
 	if (tokens.length > 0) {

--- a/packages/worker/src/community/profile-repo.ts
+++ b/packages/worker/src/community/profile-repo.ts
@@ -3,6 +3,7 @@ import { chunkArray } from '@kody-internal/shared/chunk.ts'
 import { utcSqliteTimestamp } from '@kody-internal/shared/date-keys.ts'
 import { parseTagsJson } from '@kody-internal/shared/tags-json.ts'
 import { normalizeStableUserId } from '#worker/user-id.ts'
+import { type ProfilePackageFilters } from '#universal/profile-search.ts'
 import { extractCommunityListingLikeTokens } from './repo.ts'
 import {
 	type CommunityActivityEventType,
@@ -322,6 +323,73 @@ const publicPackageSearchColumns = [
 	'tags_json',
 ] as const
 
+const activeListingExistsSql = `EXISTS (
+	SELECT 1 FROM community_listings AS cl
+	WHERE cl.owner_user_id = saved_packages.user_id
+		AND cl.status = 'active'
+		AND cl.package_id = saved_packages.id
+)`
+
+const listingAheadSql = `EXISTS (
+	SELECT 1 FROM community_listings AS cl
+	WHERE cl.owner_user_id = saved_packages.user_id
+		AND cl.status = 'active'
+		AND cl.package_id = saved_packages.id
+		AND saved_packages.updated_at > cl.published_at
+)`
+
+function applyProfilePackageFilters(
+	conditions: Array<string>,
+	filters: ProfilePackageFilters | undefined,
+) {
+	if (filters == null) return
+	switch (filters.visibility) {
+		case 'all':
+			break
+		case 'public':
+			conditions.push('is_private = 0')
+			break
+		case 'private':
+			conditions.push('is_private = 1')
+			break
+		default: {
+			const exhaustive: never = filters.visibility
+			throw new Error(`Unhandled profile visibility filter: ${exhaustive}`)
+		}
+	}
+	switch (filters.hidden) {
+		case 'all':
+			break
+		case 'yes':
+			conditions.push('hidden = 1')
+			break
+		case 'no':
+			conditions.push('hidden = 0')
+			break
+		default: {
+			const exhaustive: never = filters.hidden
+			throw new Error(`Unhandled profile hidden filter: ${exhaustive}`)
+		}
+	}
+	switch (filters.listing) {
+		case 'all':
+			break
+		case 'published':
+			conditions.push(activeListingExistsSql)
+			break
+		case 'unpublished':
+			conditions.push(`NOT ${activeListingExistsSql}`)
+			break
+		case 'ahead':
+			conditions.push(listingAheadSql)
+			break
+		default: {
+			const exhaustive: never = filters.listing
+			throw new Error(`Unhandled profile listing filter: ${exhaustive}`)
+		}
+	}
+}
+
 export async function listPublicProfilePackages(
 	db: D1Database,
 	input: {
@@ -330,11 +398,13 @@ export async function listPublicProfilePackages(
 		limit: number
 		/** When true, include private and hidden packages (own-profile inventory). */
 		includePrivate?: boolean
+		filters?: ProfilePackageFilters
 	},
 ): Promise<Array<PublicProfilePackage>> {
 	const conditions = input.includePrivate
 		? ['user_id = ?']
 		: ['user_id = ?', 'is_private = 0', 'hidden = 0']
+	applyProfilePackageFilters(conditions, input.filters)
 	const bindings: Array<unknown> = [input.ownerStableUserId]
 	const tokens = extractCommunityListingLikeTokens(input.query ?? '')
 	if (tokens.length > 0) {

--- a/packages/worker/src/community/profile-service.ts
+++ b/packages/worker/src/community/profile-service.ts
@@ -1,3 +1,4 @@
+import { type ProfilePackageFilters } from '#universal/profile-search.ts'
 import { invalidateCommunityPublicCache } from '#app/data-cache.ts'
 import { resolveUserStableId } from '#worker/user-id.ts'
 import { CommunityActionError } from './errors.ts'
@@ -174,11 +175,13 @@ export async function listPublicProfilePackages(input: {
 	query?: string
 	limit: number
 	includePrivate?: boolean
+	filters?: ProfilePackageFilters
 }): Promise<Array<PublicProfilePackage>> {
 	return await listPublicProfilePackagesFromDb(input.env.APP_DB, {
 		ownerStableUserId: input.ownerStableUserId,
 		query: input.query,
 		limit: input.limit,
 		includePrivate: input.includePrivate,
+		filters: input.filters,
 	})
 }

--- a/packages/worker/src/community/profile-service.ts
+++ b/packages/worker/src/community/profile-service.ts
@@ -1,4 +1,3 @@
-import { type ProfilePackageFilters } from '#universal/profile-search.ts'
 import { invalidateCommunityPublicCache } from '#app/data-cache.ts'
 import { resolveUserStableId } from '#worker/user-id.ts'
 import { CommunityActionError } from './errors.ts'
@@ -175,13 +174,11 @@ export async function listPublicProfilePackages(input: {
 	query?: string
 	limit: number
 	includePrivate?: boolean
-	filters?: ProfilePackageFilters
 }): Promise<Array<PublicProfilePackage>> {
 	return await listPublicProfilePackagesFromDb(input.env.APP_DB, {
 		ownerStableUserId: input.ownerStableUserId,
 		query: input.query,
 		limit: input.limit,
 		includePrivate: input.includePrivate,
-		filters: input.filters,
 	})
 }

--- a/packages/worker/src/community/profile-service.workers.test.ts
+++ b/packages/worker/src/community/profile-service.workers.test.ts
@@ -65,8 +65,9 @@ async function insertListing(input: {
 	packageId: string
 	name: string
 	kodyId: string
+	publishedAt?: string
 }) {
-	const now = new Date().toISOString()
+	const publishedAt = input.publishedAt ?? new Date().toISOString()
 	await runSql(
 		`INSERT INTO community_listings (
 			id, owner_user_id, package_id, source_id, kody_id, name, description,
@@ -82,9 +83,9 @@ async function insertListing(input: {
 		JSON.stringify(['catalog']),
 		'MIT',
 		'commit-1',
-		now,
-		now,
-		now,
+		publishedAt,
+		publishedAt,
+		publishedAt,
 	)
 }
 
@@ -316,6 +317,93 @@ test('listPublicProfilePackages filters private/hidden packages and supports que
 	expect(
 		ownInventory.find((pkg) => pkg.kodyId === 'secret-notes')?.isPrivate,
 	).toBe(true)
+
+	const publicNotesId = allPublic.find(
+		(pkg) => pkg.kodyId === 'public-notes',
+	)?.packageId
+	if (!publicNotesId) throw new Error('expected public-notes package id')
+	await insertListing({
+		id: `listing-${crypto.randomUUID()}`,
+		ownerUserId: owner.userId,
+		packageId: publicNotesId,
+		name: `@${owner.username}/public-notes`,
+		kodyId: 'public-notes',
+		publishedAt: '2026-06-01T00:00:00.000Z',
+	})
+
+	const published = await listPublicProfilePackages({
+		env,
+		ownerStableUserId: owner.userId,
+		limit: 10,
+		includePrivate: true,
+		filters: {
+			query: '',
+			visibility: 'all',
+			listing: 'published',
+			hidden: 'all',
+		},
+	})
+	expect(published.map((pkg) => pkg.kodyId)).toEqual(['public-notes'])
+
+	const unpublished = await listPublicProfilePackages({
+		env,
+		ownerStableUserId: owner.userId,
+		limit: 10,
+		includePrivate: true,
+		filters: {
+			query: '',
+			visibility: 'all',
+			listing: 'unpublished',
+			hidden: 'all',
+		},
+	})
+	expect(unpublished.map((pkg) => pkg.kodyId).sort()).toEqual([
+		'calendar',
+		'hidden-notes',
+		'secret-notes',
+	])
+
+	const privateOnly = await listPublicProfilePackages({
+		env,
+		ownerStableUserId: owner.userId,
+		limit: 10,
+		includePrivate: true,
+		filters: {
+			query: '',
+			visibility: 'private',
+			listing: 'all',
+			hidden: 'all',
+		},
+	})
+	expect(privateOnly.map((pkg) => pkg.kodyId)).toEqual(['secret-notes'])
+
+	const hiddenOnly = await listPublicProfilePackages({
+		env,
+		ownerStableUserId: owner.userId,
+		limit: 10,
+		includePrivate: true,
+		filters: {
+			query: '',
+			visibility: 'all',
+			listing: 'all',
+			hidden: 'yes',
+		},
+	})
+	expect(hiddenOnly.map((pkg) => pkg.kodyId)).toEqual(['hidden-notes'])
+
+	const ahead = await listPublicProfilePackages({
+		env,
+		ownerStableUserId: owner.userId,
+		limit: 10,
+		includePrivate: true,
+		filters: {
+			query: '',
+			visibility: 'all',
+			listing: 'ahead',
+			hidden: 'all',
+		},
+	})
+	expect(ahead.map((pkg) => pkg.kodyId)).toEqual(['public-notes'])
 })
 
 test('profile activity includes own private publishes and hides them from public reads', async () => {

--- a/packages/worker/src/community/profile-service.workers.test.ts
+++ b/packages/worker/src/community/profile-service.workers.test.ts
@@ -6,11 +6,11 @@ import {
 } from '#app/data-cache.ts'
 import { createStableUserIdFromEmail } from '#worker/user-id.ts'
 import { ensureCommunityFlowSchema } from './community-flow-test-schema.ts'
+import { listPublicProfilePackages } from './profile-package-list.ts'
 import { insertCommunityActivityEvent } from './profile-repo.ts'
 import {
 	getCommunityProfileByUsername,
 	getProfileActivity,
-	listPublicProfilePackages,
 	updateCommunityProfile,
 } from './profile-service.ts'
 

--- a/packages/worker/universal/community-public-types.ts
+++ b/packages/worker/universal/community-public-types.ts
@@ -110,6 +110,22 @@ export type PublicProfilePackageItem = {
 	hidden?: boolean
 }
 
+/** GET query contract for the `/@username` package list. */
+export type ProfilePackageVisibilityFilter = 'all' | 'public' | 'private'
+export type ProfilePackageListingFilter =
+	| 'all'
+	| 'published'
+	| 'unpublished'
+	| 'ahead'
+export type ProfilePackageHiddenFilter = 'all' | 'yes' | 'no'
+
+export type ProfilePackageFilters = {
+	query: string
+	visibility: ProfilePackageVisibilityFilter
+	listing: ProfilePackageListingFilter
+	hidden: ProfilePackageHiddenFilter
+}
+
 export type CommunityActivityEventType =
 	| 'listing_published'
 	| 'listing_updated'

--- a/packages/worker/universal/loader-data.ts
+++ b/packages/worker/universal/loader-data.ts
@@ -1,5 +1,8 @@
 import {
 	type OnboardingFeaturedListing,
+	type ProfilePackageHiddenFilter,
+	type ProfilePackageListingFilter,
+	type ProfilePackageVisibilityFilter,
 	type ProfileVisibility,
 	type PublicCommunityActivityItem,
 	type PublicCommunityListing,
@@ -19,11 +22,6 @@ import {
 	type CommunityListingCategory,
 } from '#universal/community-categories.ts'
 import { type CommunityListingSort } from '#universal/community-search.ts'
-import {
-	type ProfilePackageHiddenFilter,
-	type ProfilePackageListingFilter,
-	type ProfilePackageVisibilityFilter,
-} from '#universal/profile-search.ts'
 import { type HighlightedCode } from '#universal/highlighted-code.ts'
 import { type PackageFilesContentKind } from '#universal/package-file-media.ts'
 import { type WalkthroughHostPick } from '#universal/walkthrough-hosts.ts'

--- a/packages/worker/universal/loader-data.ts
+++ b/packages/worker/universal/loader-data.ts
@@ -19,6 +19,11 @@ import {
 	type CommunityListingCategory,
 } from '#universal/community-categories.ts'
 import { type CommunityListingSort } from '#universal/community-search.ts'
+import {
+	type ProfilePackageHiddenFilter,
+	type ProfilePackageListingFilter,
+	type ProfilePackageVisibilityFilter,
+} from '#universal/profile-search.ts'
 import { type HighlightedCode } from '#universal/highlighted-code.ts'
 import { type PackageFilesContentKind } from '#universal/package-file-media.ts'
 import { type WalkthroughHostPick } from '#universal/walkthrough-hosts.ts'
@@ -233,6 +238,9 @@ export type ProfileLoaderData = {
 	packages: Array<PublicProfilePackageItem>
 	activity: Array<PublicCommunityActivityItem>
 	query: string | null
+	visibility: ProfilePackageVisibilityFilter
+	listing: ProfilePackageListingFilter
+	hidden: ProfilePackageHiddenFilter
 	isSelf: boolean
 	loggedIn: boolean
 }

--- a/packages/worker/universal/profile-search.node.test.ts
+++ b/packages/worker/universal/profile-search.node.test.ts
@@ -1,0 +1,82 @@
+import { expect, test } from 'vitest'
+import {
+	buildProfileHref,
+	profilePackageFiltersAreActive,
+	readProfilePackageFiltersFromHref,
+	readProfileSearchQueryFromHref,
+} from './profile-search.ts'
+
+test('profile package filter hrefs omit defaults and ignore owner-only params for guests', () => {
+	expect(buildProfileHref({ username: 'kody' })).toBe('/@kody')
+	expect(
+		buildProfileHref({
+			username: 'kody',
+			query: '  notes  ',
+			visibility: 'all',
+			listing: 'all',
+			hidden: 'all',
+		}),
+	).toBe('/@kody?q=notes')
+	expect(
+		buildProfileHref({
+			username: 'kody',
+			query: 'notes',
+			visibility: 'private',
+			listing: 'unpublished',
+			hidden: 'yes',
+		}),
+	).toBe('/@kody?q=notes&visibility=private&listing=unpublished&hidden=yes')
+	expect(
+		buildProfileHref({
+			username: 'kody',
+			listing: 'ahead',
+		}),
+	).toBe('/@kody?listing=ahead')
+
+	expect(
+		readProfilePackageFiltersFromHref(
+			'/@kody?q=notes&visibility=private&listing=unpublished&hidden=yes',
+			{ allowOwnerFilters: true },
+		),
+	).toEqual({
+		query: 'notes',
+		visibility: 'private',
+		listing: 'unpublished',
+		hidden: 'yes',
+	})
+	expect(
+		readProfilePackageFiltersFromHref(
+			'/@kody?visibility=private&listing=ahead&hidden=yes',
+		),
+	).toEqual({
+		query: '',
+		visibility: 'all',
+		listing: 'all',
+		hidden: 'all',
+	})
+	expect(readProfilePackageFiltersFromHref('/@kody?listing=published')).toEqual(
+		{
+			query: '',
+			visibility: 'all',
+			listing: 'published',
+			hidden: 'all',
+		},
+	)
+	expect(readProfileSearchQueryFromHref('/@kody?q=obsidian')).toBe('obsidian')
+	expect(
+		profilePackageFiltersAreActive({
+			query: 'notes',
+			visibility: 'all',
+			listing: 'all',
+			hidden: 'all',
+		}),
+	).toBe(false)
+	expect(
+		profilePackageFiltersAreActive({
+			query: '',
+			visibility: 'private',
+			listing: 'all',
+			hidden: 'all',
+		}),
+	).toBe(true)
+})

--- a/packages/worker/universal/profile-search.ts
+++ b/packages/worker/universal/profile-search.ts
@@ -1,0 +1,123 @@
+import { routes } from '#universal/routes.ts'
+
+export const profilePackageVisibilities = ['all', 'public', 'private'] as const
+export const profilePackageListings = [
+	'all',
+	'published',
+	'unpublished',
+	'ahead',
+] as const
+export const profilePackageHiddenFilters = ['all', 'yes', 'no'] as const
+
+export type ProfilePackageVisibilityFilter =
+	(typeof profilePackageVisibilities)[number]
+export type ProfilePackageListingFilter =
+	(typeof profilePackageListings)[number]
+export type ProfilePackageHiddenFilter =
+	(typeof profilePackageHiddenFilters)[number]
+
+export type ProfilePackageFilters = {
+	query: string
+	visibility: ProfilePackageVisibilityFilter
+	listing: ProfilePackageListingFilter
+	hidden: ProfilePackageHiddenFilter
+}
+
+export const defaultProfilePackageFilters = {
+	query: '',
+	visibility: 'all',
+	listing: 'all',
+	hidden: 'all',
+} as const satisfies ProfilePackageFilters
+
+function parseVisibility(
+	raw: string | null | undefined,
+): ProfilePackageVisibilityFilter {
+	return raw === 'public' || raw === 'private' ? raw : 'all'
+}
+
+function parseListing(
+	raw: string | null | undefined,
+): ProfilePackageListingFilter {
+	return raw === 'published' || raw === 'unpublished' || raw === 'ahead'
+		? raw
+		: 'all'
+}
+
+function parseHidden(
+	raw: string | null | undefined,
+): ProfilePackageHiddenFilter {
+	return raw === 'yes' || raw === 'no' ? raw : 'all'
+}
+
+export function readProfilePackageFiltersFromUrl(
+	url: URL,
+	options?: { allowOwnerFilters?: boolean },
+): ProfilePackageFilters {
+	const allowOwnerFilters = options?.allowOwnerFilters === true
+	const listing = parseListing(url.searchParams.get('listing'))
+	return {
+		query: url.searchParams.get('q')?.trim() ?? '',
+		visibility: allowOwnerFilters
+			? parseVisibility(url.searchParams.get('visibility'))
+			: 'all',
+		listing:
+			allowOwnerFilters || listing !== 'ahead'
+				? listing
+				: defaultProfilePackageFilters.listing,
+		hidden: allowOwnerFilters
+			? parseHidden(url.searchParams.get('hidden'))
+			: 'all',
+	}
+}
+
+export function readProfilePackageFiltersFromHref(
+	href: string,
+	options?: { allowOwnerFilters?: boolean },
+): ProfilePackageFilters {
+	return readProfilePackageFiltersFromUrl(
+		new URL(href, 'http://localhost'),
+		options,
+	)
+}
+
+export function readProfileSearchQueryFromHref(href: string) {
+	return readProfilePackageFiltersFromHref(href).query
+}
+
+export function profilePackageFiltersAreActive(filters: ProfilePackageFilters) {
+	return (
+		filters.visibility !== 'all' ||
+		filters.listing !== 'all' ||
+		filters.hidden !== 'all'
+	)
+}
+
+export function buildProfileHref(input: {
+	username: string
+	query?: string | null
+	visibility?: ProfilePackageVisibilityFilter
+	listing?: ProfilePackageListingFilter
+	hidden?: ProfilePackageHiddenFilter
+}) {
+	const searchParams = new URLSearchParams()
+	const query = input.query?.trim() ?? ''
+	if (query.length > 0) searchParams.set('q', query)
+	if (input.visibility === 'public' || input.visibility === 'private') {
+		searchParams.set('visibility', input.visibility)
+	}
+	if (
+		input.listing === 'published' ||
+		input.listing === 'unpublished' ||
+		input.listing === 'ahead'
+	) {
+		searchParams.set('listing', input.listing)
+	}
+	if (input.hidden === 'yes' || input.hidden === 'no') {
+		searchParams.set('hidden', input.hidden)
+	}
+	return routes.profile.href(
+		{ username: input.username },
+		searchParams.size > 0 ? { searchParams } : undefined,
+	)
+}

--- a/packages/worker/universal/profile-search.ts
+++ b/packages/worker/universal/profile-search.ts
@@ -1,27 +1,10 @@
 import { routes } from '#universal/routes.ts'
-
-const profilePackageVisibilities = ['all', 'public', 'private'] as const
-const profilePackageListings = [
-	'all',
-	'published',
-	'unpublished',
-	'ahead',
-] as const
-const profilePackageHiddenFilters = ['all', 'yes', 'no'] as const
-
-export type ProfilePackageVisibilityFilter =
-	(typeof profilePackageVisibilities)[number]
-export type ProfilePackageListingFilter =
-	(typeof profilePackageListings)[number]
-export type ProfilePackageHiddenFilter =
-	(typeof profilePackageHiddenFilters)[number]
-
-export type ProfilePackageFilters = {
-	query: string
-	visibility: ProfilePackageVisibilityFilter
-	listing: ProfilePackageListingFilter
-	hidden: ProfilePackageHiddenFilter
-}
+import {
+	type ProfilePackageFilters,
+	type ProfilePackageHiddenFilter,
+	type ProfilePackageListingFilter,
+	type ProfilePackageVisibilityFilter,
+} from '#universal/community-public-types.ts'
 
 const defaultProfilePackageFilters = {
 	query: '',

--- a/packages/worker/universal/profile-search.ts
+++ b/packages/worker/universal/profile-search.ts
@@ -1,13 +1,13 @@
 import { routes } from '#universal/routes.ts'
 
-export const profilePackageVisibilities = ['all', 'public', 'private'] as const
-export const profilePackageListings = [
+const profilePackageVisibilities = ['all', 'public', 'private'] as const
+const profilePackageListings = [
 	'all',
 	'published',
 	'unpublished',
 	'ahead',
 ] as const
-export const profilePackageHiddenFilters = ['all', 'yes', 'no'] as const
+const profilePackageHiddenFilters = ['all', 'yes', 'no'] as const
 
 export type ProfilePackageVisibilityFilter =
 	(typeof profilePackageVisibilities)[number]
@@ -23,7 +23,7 @@ export type ProfilePackageFilters = {
 	hidden: ProfilePackageHiddenFilter
 }
 
-export const defaultProfilePackageFilters = {
+const defaultProfilePackageFilters = {
 	query: '',
 	visibility: 'all',
 	listing: 'all',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Make `/@username` (your packages list) filterable for the inventory states you already see on each card.

## Why

A mixed public/private inventory is hard to scan with search alone. Owners need to jump to private, unpublished, hidden, or “needs republish” packages without scrolling the first 50.

## Summary

- GET filters on the profile package list: `visibility=public|private`, `listing=published|unpublished|ahead`, `hidden=yes|no`, plus existing `q=`
- SQL applies them before the 50-item limit
- Guests can use Published / Not published only; owner-only params are ignored for them
- Filter pills match the community browse chip grammar; search keeps the active params as hidden inputs
- Pill navigation re-renders the profile shell so Search does not drop the selected filters
- Filter SQL lives in an origin-only module so the runtime worker stays under its startup budget

## Testing

- `npx vitest run --project node-unit` on profile-search, profile-content, and profile handler tests
- `npx vitest run --project workers-unit packages/worker/src/community/profile-service.workers.test.ts`
- `npm run worker-startup-bundles:check` — runtime `3619740 / 3620000`
- Preview UI pass as the seeded owner with mixed packages: pills, guest listing-only toolbar, and Search after a pill

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends community-listings</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `09e78ece` · **Head:** `77f069f4`

**Classification:** extends — `listPublicProfilePackages` gains visibility, listing, and hidden GET filters. The Remix profile UI composes that contract as community-style pills.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `community-listings` | assistant | extends — profile package SQL accepts `visibility`, `listing`, and `hidden` |
| `app-ui` | surfaces | composes — `/@username` filter pills, search hidden inputs, and shell re-render on pill navigation |

### Change flow

Own-profile GET `/@username` applies inventory filters in SQL before the 50-item limit. Pill clicks update the URL, the shell re-renders so search keeps those params, and origin-only filter SQL stays out of the runtime worker.

```mermaid
sequenceDiagram
	actor Owner
	participant appUi as app-ui
	participant communityListings as community-listings
	Owner->>appUi: GET /@username?visibility=private
	appUi->>communityListings: listPublicProfilePackages with owner filters
	Note over communityListings: guests keep published or unpublished only
	communityListings-->>appUi: matching saved_packages rows
	appUi-->>Owner: pills plus filtered package cards
	Owner->>appUi: Search with q
	Note over appUi: hidden inputs match the current URL filters
```

### Before / after

| | Before | After |
| --- | --- | --- |
| Own profile | `q=` only | `visibility`, `listing`, `hidden` plus `q=` |
| Guests | public non-hidden list | `listing=published` or `unpublished` only |
| Search after a pill | could drop or reuse stale params | shell `handle.update()` keeps filters |
| Runtime worker | n/a | filter SQL stays origin-only so startup stays under budget |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a5f488d8-35eb-4633-b2c9-d1b8ff7e25cd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a5f488d8-35eb-4633-b2c9-d1b8ff7e25cd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added package filters to profile pages for visibility, publication status, and hidden packages.
  - Profile owners can filter by public/private, published/unpublished/ahead, and hidden/visible packages.
  - Guests can filter by publication status; owner-only filters are ignored.
  - Filter selections preserve search terms and other active filters.
  - Added contextual empty states, including “Needs republish” and no matching packages.

- **Documentation**
  - Documented supported profile package filters and query parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->