### PR TITLE
List caller-owned package secret metadata from execute

### DIFF
--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -424,11 +424,14 @@ The schema is defined by migrations in `packages/worker/migrations/`:
   derived at read time from `community_forks`
 - `secret_buckets`: encrypted-secret ownership buckets scoped to `user`,
   `package`, or `session`. Package buckets bind directly to `saved_packages.id`;
-  package runtimes may use their own package secrets. User secrets are
-  auto-granted for read/use to self-authored packages (no `community_forks` row
-  for that `saved_packages.id` + `userId`) and adopted forks
-  (`community_forks.adopted_at` set via `communityForkAdopt`). Person accounts
-  do not run official platform packages
+  package runtimes may use their own package secrets. `secretList` can list
+  caller-owned package-bucket metadata (with `package_id`) from execute without
+  a package runtime binding; resolve, fetch placeholders, and mounts still
+  require package context. Search ranks user-scoped secret references only. User
+  secrets are auto-granted for read/use to self-authored packages (no
+  `community_forks` row for that `saved_packages.id` + `userId`) and adopted
+  forks (`community_forks.adopted_at` set via `communityForkAdopt`). Person
+  accounts do not run official platform packages
   ([0036](../decisions/0036-platform-packages-fork-only.md)). Unadopted
   community forks (`community_forks.forked_package_id`, indexed in the squashed
   baseline) still require an explicit `allowed_packages` grant on every package

--- a/docs/guides/secret-backed-integration.md
+++ b/docs/guides/secret-backed-integration.md
@@ -124,8 +124,9 @@ Rules:
 
 - `kody.secretList({})` returns metadata only (names, allowed hosts, and
   `package_id` for package-scoped secrets) — use it to find the right secret
-  name, then reference that name in a placeholder. Search does not auto-surface
-  package-scoped secrets; using them still requires package context.
+  name, then reference that name in a placeholder. Search does not return or
+  rank package-scoped secret references; using them still requires package
+  context.
 - Placeholders only resolve in secret-aware `fetch` paths; they are not general
   string interpolation.
 - Never echo a resolvable literal placeholder into chat, logs, issue bodies, or

--- a/docs/guides/secret-backed-integration.md
+++ b/docs/guides/secret-backed-integration.md
@@ -122,8 +122,10 @@ const response = await fetch('https://api.example.com/v1/me', {
 
 Rules:
 
-- `kody.secretList({})` returns metadata only (names, allowed hosts) — use it to
-  find the right secret name, then reference that name in a placeholder.
+- `kody.secretList({})` returns metadata only (names, allowed hosts, and
+  `package_id` for package-scoped secrets) — use it to find the right secret
+  name, then reference that name in a placeholder. Search does not auto-surface
+  package-scoped secrets; using them still requires package context.
 - Placeholders only resolve in secret-aware `fetch` paths; they are not general
   string interpolation.
 - Never echo a resolvable literal placeholder into chat, logs, issue bodies, or

--- a/docs/guides/secrets.md
+++ b/docs/guides/secrets.md
@@ -25,7 +25,7 @@ secret value. `secretList` returns metadata only: names, descriptions, approved
 hosts, expiry, remaining time to live, and `package_id` for package-scoped
 secrets. Explicit listing includes caller-owned package-scoped metadata even
 from execute; using a package secret still requires package context. Search does
-not auto-surface those rows. `secretLock` returns grant-status metadata and an
+not return or rank those rows. `secretLock` returns grant-status metadata and an
 `approval_url` for the owner to click; it does not apply the grant.
 
 This is why you can hand an agent a job that needs your GitHub token without the
@@ -82,10 +82,11 @@ approve several pending secrets for one package in a click.
 ## Scopes
 
 - **User secrets** belong to the account and can be approved for any package.
-- **Package secrets** belong to one saved package and exist only while that
-  package runs — they are package config, keyed by the package id. `secretList`
-  and `packageGet` expose their metadata with `package_id`; search does not
-  auto-surface them, and use still needs package context.
+- **Package secrets** belong to one saved package. They are package config,
+  keyed by the package id, and can be used only with package context.
+  `secretList` and `packageGet` expose their metadata with `package_id` even
+  outside an active package run. Search does not return or rank those
+  references.
 
 OAuth access and refresh tokens are different: they live on the integration,
 rotate through `createAuthenticatedFetch`, and do not appear in the secrets

--- a/docs/guides/secrets.md
+++ b/docs/guides/secrets.md
@@ -22,9 +22,11 @@ that uses a secret. It can never read one.
 The secrets capabilities are `secretList`, `secretSet`, `secretSetMany`,
 `secretLock`, `secretDelete`, and `secretJwtSign`. No capability returns a
 secret value. `secretList` returns metadata only: names, descriptions, approved
-hosts, expiry, and remaining time to live. `secretLock` returns grant-status
-metadata and an `approval_url` for the owner to click; it does not apply the
-grant.
+hosts, expiry, remaining time to live, and `package_id` for package-scoped
+secrets. Explicit listing includes caller-owned package-scoped metadata even
+from execute; using a package secret still requires package context. Search does
+not auto-surface those rows. `secretLock` returns grant-status metadata and an
+`approval_url` for the owner to click; it does not apply the grant.
 
 This is why you can hand an agent a job that needs your GitHub token without the
 token ever entering the prompt, the transcript, or the model provider's logs.
@@ -81,7 +83,9 @@ approve several pending secrets for one package in a click.
 
 - **User secrets** belong to the account and can be approved for any package.
 - **Package secrets** belong to one saved package and exist only while that
-  package runs — they are package config, keyed by the package id.
+  package runs — they are package config, keyed by the package id. `secretList`
+  and `packageGet` expose their metadata with `package_id`; search does not
+  auto-surface them, and use still needs package context.
 
 OAuth access and refresh tokens are different: they live on the integration,
 rotate through `createAuthenticatedFetch`, and do not appear in the secrets

--- a/docs/use/packages.md
+++ b/docs/use/packages.md
@@ -195,7 +195,8 @@ exhaustive.
   that imports `kody:@scope/id/export` and calls it). When helpful, point the
   export at a `types` file and put the JSDoc there. Package search detail and
   `packageGet` surface package descriptions, export descriptions, function
-  signatures, JSDoc, and type definitions.
+  signatures, JSDoc, type definitions, and FYI metadata for associated
+  package-scoped secrets (names and `package_id`, never values).
 
 ### Package reuse
 

--- a/docs/use/search.md
+++ b/docs/use/search.md
@@ -2,7 +2,8 @@
 
 The **search** tool finds **built-in capabilities**, **official guides**,
 **saved packages**, **saved integrations**, and **user secret references**
-(metadata only, not secret values).
+(metadata only, not secret values). Package-scoped secrets are not
+auto-surfaced; call **`secretList`** or **`packageGet`** for that metadata.
 
 **Public package listings** are not included. Use the `community` domain
 (`communitySearch`, `communityGet`) or the public `/community` pages. See
@@ -210,10 +211,11 @@ and refresh tokens live on the connection — call
 
 Long-term memory retrieval also requires a signed-in MCP user.
 
-Use **search** as the default way to discover whether an integration or secret
-already exists before switching to **execute**. Runtime code inside **execute**
-can call **`kody.secretList(...)`** when it needs secret metadata, but
-**search** is the primary discovery path.
+Use **search** as the default way to discover whether an integration or
+user-scoped secret already exists before switching to **execute**. Runtime code
+inside **execute** can call **`kody.secretList(...)`** when it needs secret
+metadata, including caller-owned package-scoped rows with **`package_id`**.
+**search** does not automatically rank package-scoped secrets.
 
 Saved integrations and the `integration_*` capabilities live in the
 **integrations** domain (`integrationList`, `integrationGet`, `integrationSave`,

--- a/docs/use/search.md
+++ b/docs/use/search.md
@@ -2,8 +2,9 @@
 
 The **search** tool finds **built-in capabilities**, **official guides**,
 **saved packages**, **saved integrations**, and **user secret references**
-(metadata only, not secret values). Package-scoped secrets are not
-auto-surfaced; call **`secretList`** or **`packageGet`** for that metadata.
+(metadata only, not secret values). Search does not return or rank
+package-scoped secret references; call **`secretList`** or **`packageGet`** for
+that metadata.
 
 **Public package listings** are not included. Use the `community` domain
 (`communitySearch`, `communityGet`) or the public `/community` pages. See
@@ -215,7 +216,8 @@ Use **search** as the default way to discover whether an integration or
 user-scoped secret already exists before switching to **execute**. Runtime code
 inside **execute** can call **`kody.secretList(...)`** when it needs secret
 metadata, including caller-owned package-scoped rows with **`package_id`**.
-**search** does not automatically rank package-scoped secrets.
+**search** does not return or rank package-scoped secret references; use
+**`secretList`** or **`packageGet`** for that metadata.
 
 Saved integrations and the `integration_*` capabilities live in the
 **integrations** domain (`integrationList`, `integrationGet`, `integrationSave`,

--- a/docs/use/secrets-and-values.md
+++ b/docs/use/secrets-and-values.md
@@ -11,16 +11,22 @@ switching to **execute**.
 
 During **execute**, **`await kody.secretList({})`** (or a narrowed **`scope`**
 such as **`package`**) returns **metadata only**: names, descriptions, allowed
-hosts, **`expires_at`**, and remaining **`ttl_ms`** — not plaintext values.
-Expired secrets stay in the list with **`ttl_ms: 0`**. Fetch placeholders and
-**`resolve`** treat them as missing so Kody stops sending the value.
+hosts, **`package_id`** for package-scoped secrets, **`expires_at`**, and
+remaining **`ttl_ms`** — not plaintext values. Explicit listing includes
+caller-owned package-scoped metadata even without a package runtime; using a
+package secret still requires package context. **search** does not automatically
+surface package-scoped secrets. Expired secrets stay in the list with
+**`ttl_ms: 0`**. Fetch placeholders and **`resolve`** treat them as missing so
+Kody stops sending the value.
 
-Package-scoped secrets belong to one saved package. User-scoped secrets follow
-the bundler stamp: code that originates from package A authorizes as A,
-including when B statically imports A's export. B's own code still cannot read a
-secret locked only to A — including by passing A's id to `kody.packageSecretGet`
-/ `Has`. Only A's stamped `packageSecrets` binding carries that authority.
-Access rules are covered in [Package approval](#package-approval).
+Package-scoped secrets belong to one saved package. **`packageGet`** includes
+their metadata as an FYI when you are inspecting that package. User-scoped
+secrets follow the bundler stamp: code that originates from package A authorizes
+as A, including when B statically imports A's export. B's own code still cannot
+read a secret locked only to A — including by passing A's id to
+`kody.packageSecretGet` / `Has`. Only A's stamped `packageSecrets` binding
+carries that authority. Access rules are covered in
+[Package approval](#package-approval).
 
 **`kody.secretSet(...)`** persists a value that is already available inside
 execution (for example an API key the package just minted). It does not return

--- a/docs/use/secrets-and-values.md
+++ b/docs/use/secrets-and-values.md
@@ -14,8 +14,8 @@ such as **`package`**) returns **metadata only**: names, descriptions, allowed
 hosts, **`package_id`** for package-scoped secrets, **`expires_at`**, and
 remaining **`ttl_ms`** — not plaintext values. Explicit listing includes
 caller-owned package-scoped metadata even without a package runtime; using a
-package secret still requires package context. **search** does not automatically
-surface package-scoped secrets. Expired secrets stay in the list with
+package secret still requires package context. **search** does not return or
+rank package-scoped secret references. Expired secrets stay in the list with
 **`ttl_ms: 0`**. Fetch placeholders and **`resolve`** treat them as missing so
 Kody stops sending the value.
 

--- a/packages/worker/src/community/community-flow-test-schema.ts
+++ b/packages/worker/src/community/community-flow-test-schema.ts
@@ -1,6 +1,7 @@
 import { ensureUsersTestSchema } from '#worker/users-test-schema.ts'
 import { ensureUserStorageBucketsTestSchema } from '#worker/storage-buckets/test-schema.ts'
 import { ensurePackageInvocationTokensTestSchema } from '#worker/package-invocations/test-schema.ts'
+import { ensureSecretBucketsTestSchema } from '#worker/secrets-test-schema.ts'
 
 /**
  * Community flow workers-unit schema. Adds the community tables and the
@@ -21,6 +22,7 @@ export async function ensureCommunityFlowSchema(db: D1Database) {
 	})
 	await ensureUserStorageBucketsTestSchema(db)
 	await ensurePackageInvocationTokensTestSchema(db)
+	await ensureSecretBucketsTestSchema(db)
 	const statements = [
 		`CREATE TABLE IF NOT EXISTS saved_packages (
 			id TEXT PRIMARY KEY NOT NULL,

--- a/packages/worker/src/mcp/capabilities/packages/get-package.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/packages/get-package.node.test.ts
@@ -4,6 +4,7 @@ const mockModule = vi.hoisted(() => ({
 	getSavedPackageWithCommunityProvenanceById: vi.fn(),
 	loadPackageSourceBySourceId: vi.fn(),
 	resolvePackageOwnerContext: vi.fn(),
+	listPackageSecretsByPackageIds: vi.fn(async () => new Map()),
 }))
 
 vi.mock('#worker/community/fork-listing-relation.ts', () => ({
@@ -28,6 +29,11 @@ vi.mock('#worker/package-registry/package-owner.ts', () => ({
 	packageScopeInputDescription: 'package scope',
 	resolvePackageOwnerContext: (...args: Array<unknown>) =>
 		mockModule.resolvePackageOwnerContext(...args),
+}))
+
+vi.mock('#mcp/secrets/service.ts', () => ({
+	listPackageSecretsByPackageIds: (...args: Array<unknown>) =>
+		mockModule.listPackageSecretsByPackageIds(...args),
 }))
 
 const { getPackageCapability } = await import('./get-package.ts')
@@ -263,6 +269,73 @@ test('getPackageCapability returns export metadata for owner and delegated packa
 	expect(delegated.exports[0]).toMatchObject({
 		subpath: './post-message',
 		import_specifier: 'kody:@kody/discord-gateway/post-message',
+	})
+	expect(withUsername.package_secrets).toEqual([])
+	expect(delegated.package_secrets).toEqual([])
+})
+
+test('getPackageCapability includes package-scoped secret metadata as FYI', async () => {
+	mockModule.getSavedPackageWithCommunityProvenanceById.mockReset()
+	mockModule.loadPackageSourceBySourceId.mockReset()
+	stubSavedPackage()
+	mockModule.loadPackageSourceBySourceId.mockResolvedValue({
+		source: { id: 'source-1' },
+		manifest: {
+			name: '@kentcdodds/discord-gateway',
+			exports: { '.': './src/index.ts' },
+			kody: {
+				id: 'discord-gateway',
+				description: 'Discord helpers',
+			},
+		},
+		files: {},
+	})
+	mockModule.listPackageSecretsByPackageIds.mockResolvedValueOnce(
+		new Map([
+			[
+				'package-1',
+				[
+					{
+						name: 'discordBotToken',
+						scope: 'package',
+						description: 'Bot token for this package',
+						packageId: 'package-1',
+						allowedHosts: ['discord.com'],
+						allowedPackages: [],
+						createdAt: '2026-04-25T00:00:00.000Z',
+						updatedAt: '2026-04-26T00:00:00.000Z',
+						expiresAt: null,
+						ttlMs: null,
+					},
+				],
+			],
+		]),
+	)
+
+	const result = await getPackageCapability.handler(
+		{ package_id: 'package-1' },
+		createCallerContext(),
+	)
+
+	expect(result.package_secrets).toEqual([
+		{
+			name: 'discordBotToken',
+			scope: 'package',
+			description: 'Bot token for this package',
+			package_id: 'package-1',
+			allowed_hosts: ['discord.com'],
+			allowed_packages: [],
+			created_at: '2026-04-25T00:00:00.000Z',
+			updated_at: '2026-04-26T00:00:00.000Z',
+			expires_at: null,
+			ttl_ms: null,
+		},
+	])
+	expect(result.package_secrets[0]).not.toHaveProperty('value')
+	expect(mockModule.listPackageSecretsByPackageIds).toHaveBeenCalledWith({
+		env: expect.objectContaining({ APP_DB: expect.anything() }),
+		userId: 'user-1',
+		packageIds: ['package-1'],
 	})
 })
 

--- a/packages/worker/src/mcp/capabilities/packages/get-package.ts
+++ b/packages/worker/src/mcp/capabilities/packages/get-package.ts
@@ -3,19 +3,21 @@ import { McpCallerError } from '#mcp/caller-error.ts'
 import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
+import { toSecretCapabilityOutput } from '#mcp/capabilities/secrets/shared.ts'
+import { listPackageSecretsByPackageIds } from '#mcp/secrets/service.ts'
+import { applySavedPackageForkListingAncestry } from '#worker/community/fork-listing-relation.ts'
 import { buildPackageSearchProjection } from '#worker/package-registry/manifest.ts'
 import { buildPackageImportSpecifier } from '#worker/package-registry/package-import-specifier.ts'
 import {
 	packageScopeInputDescription,
 	resolvePackageOwnerContext,
 } from '#worker/package-registry/package-owner.ts'
-import { applySavedPackageForkListingAncestry } from '#worker/community/fork-listing-relation.ts'
 import { getSavedPackageWithCommunityProvenanceById } from '#worker/package-registry/repo.ts'
+import { loadPackageSourceBySourceId } from '#worker/package-registry/source.ts'
 import {
 	buildPlainRepoPromotionErrorMessage,
 	findPlainRepoPromotionHint,
 } from '#worker/repo/user-repos.ts'
-import { loadPackageSourceBySourceId } from '#worker/package-registry/source.ts'
 import { packageDetailSchema } from './shared.ts'
 
 export const getPackageCapability = defineDomainCapability(
@@ -23,7 +25,7 @@ export const getPackageCapability = defineDomainCapability(
 	{
 		name: 'packageGet',
 		description:
-			'Load one saved package metadata record for the signed-in user, including community-fork source listing provenance, ready-to-import export specifiers, and callable export contracts.',
+			'Load one saved package metadata record for the signed-in user, including community-fork source listing provenance, ready-to-import export specifiers, callable export contracts, and FYI metadata for associated package-scoped secrets (names and package_id, never values).',
 		keywords: ['package', 'get', 'read', 'metadata', 'exports', 'imports'],
 		readOnly: true,
 		idempotent: true,
@@ -79,6 +81,14 @@ export const getPackageCapability = defineDomainCapability(
 				loaded.manifest,
 				loaded.files,
 			)
+			const packageSecretsById = await listPackageSecretsByPackageIds({
+				env: ctx.env,
+				userId: owner.ownerUserId,
+				packageIds: [saved.id],
+			})
+			const packageSecrets = (packageSecretsById.get(saved.id) ?? []).map(
+				(secret) => toSecretCapabilityOutput(secret),
+			)
 			return {
 				package_id: saved.id,
 				kody_id: saved.kodyId,
@@ -102,6 +112,7 @@ export const getPackageCapability = defineDomainCapability(
 				listing_ahead: saved.listingAhead,
 				created_at: saved.createdAt,
 				updated_at: saved.updatedAt,
+				package_secrets: packageSecrets,
 				exports: (projection.exports ?? []).map((exportDetail) => ({
 					subpath: exportDetail.subpath,
 					import_specifier: buildPackageImportSpecifier(

--- a/packages/worker/src/mcp/capabilities/packages/shared.ts
+++ b/packages/worker/src/mcp/capabilities/packages/shared.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { secretMetadataSchema } from '#mcp/capabilities/secrets/shared.ts'
 import {
 	type SavedPackageRecord,
 	type SavedPackageWithCommunityProvenanceRecord,
@@ -248,6 +249,11 @@ export const packageInvocationTokenMetadataSchema = z.object({
 export const packageDetailSchema =
 	packageSummaryWithCommunityProvenanceSchema.extend({
 		exports: z.array(packageExportSurfaceSchema),
+		package_secrets: z
+			.array(secretMetadataSchema)
+			.describe(
+				'FYI metadata for package-scoped secrets owned by this package, including package_id. Never plaintext values. These are not execute-usable via search; using them still requires package context.',
+			),
 	})
 
 export function toPackageInvocationTokenMetadata(token: {

--- a/packages/worker/src/mcp/capabilities/secrets/secret-list.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/secrets/secret-list.node.test.ts
@@ -1,7 +1,11 @@
+import { DatabaseSync } from 'node:sqlite'
 import { expect, test, vi } from 'vitest'
 import { createMcpCallerContext } from '#mcp/context.ts'
 import * as secretService from '#mcp/secrets/service.ts'
 import { type SecretMetadata } from '#mcp/secrets/types.ts'
+import { applyAllMigrations as applyRepositoryMigrations } from '#worker/test-support/apply-all-migrations.ts'
+import { createD1FromSqlite } from '#worker/test-support/create-d1-from-sqlite.ts'
+import { createInMemoryUserMeterEnv } from '#worker/test-support/user-meter.ts'
 import { secretListCapability } from './secret-list.ts'
 
 const mockModule = vi.hoisted(() => ({
@@ -95,6 +99,12 @@ test('secretList matches implicit user-secret read access and still lists packag
 		'GrantedSearch',
 		'packageToken',
 	])
+	expect(
+		executeListed.secrets.find((secret) => secret.name === 'packageToken'),
+	).toMatchObject({
+		scope: 'package',
+		package_id: 'pkg-1',
+	})
 	expect(mockModule.getSavedPackageById).not.toHaveBeenCalled()
 
 	mockModule.getSavedPackageById.mockResolvedValueOnce(savedPackage)
@@ -143,4 +153,52 @@ test('secretList matches implicit user-secret read access and still lists packag
 	])
 	expect(listSecretsSpy).toHaveBeenCalled()
 	listSecretsSpy.mockRestore()
+})
+
+test('secretList from execute returns caller-owned package metadata with package_id', async () => {
+	const sqlite = new DatabaseSync(':memory:')
+	applyRepositoryMigrations(
+		sqlite,
+		new URL('../../../../migrations/', import.meta.url),
+	)
+	const env = {
+		APP_DB: createD1FromSqlite(sqlite),
+		SECRET_STORE_KEY: 'test-secret-store-key-32-chars-minimum',
+		...createInMemoryUserMeterEnv().env,
+	} as Env
+	const userId = 'user-execute-list'
+	await secretService.saveSecret({
+		env,
+		userId,
+		scope: 'package',
+		name: 'discordBotToken',
+		value: 'package-only-value',
+		storageContext: {
+			sessionId: null,
+			appId: null,
+			packageId: 'pkg-discord',
+			storageId: 'pkg-discord',
+		},
+	})
+
+	const listed = await secretListCapability.handler(
+		{ scope: 'package' },
+		{
+			env,
+			callerContext: createMcpCallerContext({
+				baseUrl: 'https://example.com',
+				user: { userId },
+			}),
+		},
+	)
+
+	expect(listed.secrets).toEqual([
+		expect.objectContaining({
+			name: 'discordBotToken',
+			scope: 'package',
+			package_id: 'pkg-discord',
+		}),
+	])
+	expect(listed.secrets[0]).not.toHaveProperty('value')
+	expect(JSON.stringify(listed)).not.toContain('package-only-value')
 })

--- a/packages/worker/src/mcp/capabilities/secrets/secret-list.ts
+++ b/packages/worker/src/mcp/capabilities/secrets/secret-list.ts
@@ -13,7 +13,7 @@ export const secretListCapability = defineDomainCapability(
 	{
 		name: 'secretList',
 		description:
-			'List available secret references for the signed-in user. Results include metadata such as names, descriptions, allowed hosts, and allowed packages — never plaintext values. From a package runtime, self-authored and adopted packages see user secrets they can already read; unadopted community forks see only explicitly granted user secrets. Listing a secret does not approve a host: outbound `fetch` still resolves `{{secret:name}}` (optionally `{{secret:name|scope=user}}`) only for approved hosts. Use `kody.secretList({ scope })` inside execute-time code for the same metadata. Use `/account/secrets/new` for user-provided API key, token, and credential entry or rotation.',
+			'List available secret references for the signed-in user. Results include metadata such as names, descriptions, allowed hosts, allowed packages, and package_id for package-scoped secrets — never plaintext values. Explicit listing includes caller-owned package-scoped metadata from execute (no package runtime); using a package secret still requires package context. From a package runtime, self-authored and adopted packages see user secrets they can already read; unadopted community forks see only explicitly granted user secrets. Listing a secret does not approve a host: outbound `fetch` still resolves `{{secret:name}}` (optionally `{{secret:name|scope=user}}`) only for approved hosts. Use `kody.secretList({ scope })` inside execute-time code for the same metadata. Use `/account/secrets/new` for user-provided API key, token, and credential entry or rotation.',
 		keywords: ['secret', 'list', 'discovery', 'metadata', 'credentials'],
 		readOnly: true,
 		idempotent: true,
@@ -23,7 +23,7 @@ export const secretListCapability = defineDomainCapability(
 				.enum(secretScopeValues)
 				.optional()
 				.describe(
-					'Optional scope filter. When omitted, list all accessible scopes in default precedence order.',
+					'Optional scope filter. When omitted, list all accessible scopes. Package-scoped metadata is included for caller-owned secrets (with package_id) even without a package runtime; session secrets stay session-bound. Using a package secret still requires package context.',
 				),
 		}),
 		outputSchema: z.object({

--- a/packages/worker/src/mcp/secrets/repo.node.test.ts
+++ b/packages/worker/src/mcp/secrets/repo.node.test.ts
@@ -3,7 +3,10 @@ import { DatabaseSync } from 'node:sqlite'
 import { expect, test } from 'vitest'
 import { applyAllMigrations } from '#worker/test-support/apply-all-migrations.ts'
 import { createD1FromSqlite } from '#worker/test-support/create-d1-from-sqlite.ts'
-import { listPackageScopeSecretMetadata } from './repo.ts'
+import {
+	listPackageScopeSecretMetadata,
+	listSecretBucketsByScope,
+} from './repo.ts'
 
 function createSecretsDb(options?: { maxBindings?: number }) {
 	const sqlite = new DatabaseSync(':memory:')
@@ -78,6 +81,37 @@ test('listPackageScopeSecretMetadata chunks package ids to stay within the D1 bi
 			name: 'zeta-token',
 			binding_key: 'package-100',
 			scope: 'package',
+		}),
+	])
+})
+
+test('listSecretBucketsByScope returns caller-owned package buckets only', async () => {
+	const { sqlite, db } = createSecretsDb()
+	insertPackageSecret(sqlite, {
+		bucketId: 'bucket-owned',
+		userId: 'user-1',
+		packageId: 'package-owned',
+		name: 'owned-token',
+	})
+	insertPackageSecret(sqlite, {
+		bucketId: 'bucket-other',
+		userId: 'user-2',
+		packageId: 'package-other',
+		name: 'other-token',
+	})
+
+	const buckets = await listSecretBucketsByScope({
+		db,
+		userId: 'user-1',
+		scope: 'package',
+		now: '2026-08-31T00:00:00.000Z',
+	})
+
+	expect(buckets).toEqual([
+		expect.objectContaining({
+			user_id: 'user-1',
+			scope: 'package',
+			binding_key: 'package-owned',
 		}),
 	])
 })

--- a/packages/worker/src/mcp/secrets/repo.ts
+++ b/packages/worker/src/mcp/secrets/repo.ts
@@ -324,6 +324,26 @@ export async function deleteSecretEntry(input: {
 	return (result.meta.changes ?? 0) > 0
 }
 
+export async function listSecretBucketsByScope(input: {
+	db: D1Database
+	userId: string
+	scope: SecretScope
+	now?: string
+}): Promise<Array<SecretBucketRow>> {
+	const now = input.now ?? new Date().toISOString()
+	const { results } = await input.db
+		.prepare(
+			`SELECT id, user_id, scope, binding_key, expires_at, created_at, updated_at
+			FROM secret_buckets
+			WHERE user_id = ? AND scope = ?
+				AND (expires_at IS NULL OR expires_at > ?)
+			ORDER BY binding_key ASC`,
+		)
+		.bind(input.userId, input.scope, now)
+		.all<Record<string, unknown>>()
+	return (results ?? []).map(mapSecretBucketRow)
+}
+
 export async function listSecretMetadataForBucket(input: {
 	db: D1Database
 	bucket: SecretBucketRow

--- a/packages/worker/src/mcp/secrets/secret-bindings.ts
+++ b/packages/worker/src/mcp/secrets/secret-bindings.ts
@@ -11,6 +11,20 @@ export function resolveSecretScopeOrder(storageContext: StorageContext | null) {
 	)
 }
 
+/**
+ * Listing can discover caller-owned package-bucket metadata without a package
+ * runtime binding. Resolve/use still go through `resolveSecretScopeOrder` and
+ * require `packageId`. Session secrets stay session-bound.
+ */
+export function resolveSecretListScopeOrder(
+	storageContext: StorageContext | null,
+) {
+	return defaultSecretLookupOrder.filter((scope) => {
+		if (scope === 'package') return true
+		return getSecretBindingKey(scope, storageContext) != null
+	})
+}
+
 export function getSecretBindingKey(
 	scope: SecretScope,
 	storageContext: StorageContext | null,

--- a/packages/worker/src/mcp/secrets/service.node.test.ts
+++ b/packages/worker/src/mcp/secrets/service.node.test.ts
@@ -11,6 +11,7 @@ import {
 import {
 	listPackageSecretsByPackageIds,
 	listSecrets,
+	listUserSecretsForSearch,
 	resolveSecret,
 	saveSecret,
 	setSecretAllowedPackages,
@@ -139,7 +140,8 @@ function createSecretTestDb(
 								normalizedQuery.startsWith(
 									'select id, user_id, scope, binding_key',
 								) &&
-								normalizedQuery.includes('from secret_buckets')
+								normalizedQuery.includes('from secret_buckets') &&
+								normalizedQuery.includes('binding_key = ?')
 							) {
 								const [userId, scope, bindingKey, now] = params as Array<string>
 								const bucket =
@@ -166,6 +168,26 @@ function createSecretTestDb(
 							return null
 						},
 						async all<T>() {
+							if (
+								normalizedQuery.startsWith(
+									'select id, user_id, scope, binding_key',
+								) &&
+								normalizedQuery.includes('from secret_buckets') &&
+								normalizedQuery.includes('order by binding_key')
+							) {
+								const [userId, scope, now] = params as Array<string>
+								const results = Array.from(buckets.values())
+									.filter(
+										(bucket) =>
+											bucket.user_id === userId &&
+											bucket.scope === scope &&
+											(bucket.expires_at == null || bucket.expires_at > now),
+									)
+									.sort((left, right) =>
+										left.binding_key.localeCompare(right.binding_key),
+									)
+								return { results: results as Array<T>, meta: { changes: 0 } }
+							}
 							if (
 								normalizedQuery.includes('from secret_buckets b') &&
 								normalizedQuery.includes('join secret_entries e') &&
@@ -205,6 +227,44 @@ function createSecretTestDb(
 											left.scope.localeCompare(right.scope) ||
 											left.binding_key.localeCompare(right.binding_key),
 									)
+								return { results: results as Array<T>, meta: { changes: 0 } }
+							}
+							if (
+								normalizedQuery.includes('from secret_buckets b') &&
+								normalizedQuery.includes("b.scope = 'user'")
+							) {
+								const [userId, now] = params as Array<string>
+								const results = Array.from(entries.values())
+									.flatMap((entry) => {
+										const bucket = Array.from(buckets.values()).find(
+											(candidate) => candidate.id === entry.bucket_id,
+										)
+										if (
+											!bucket ||
+											bucket.user_id !== userId ||
+											bucket.scope !== 'user'
+										) {
+											return []
+										}
+										if (bucket.expires_at != null && bucket.expires_at <= now) {
+											return []
+										}
+										return [
+											{
+												scope: bucket.scope,
+												binding_key: bucket.binding_key,
+												name: entry.name,
+												description: entry.description,
+												allowed_hosts: entry.allowed_hosts,
+												allowed_packages: entry.allowed_packages,
+												created_at: entry.created_at,
+												updated_at: entry.updated_at,
+												entry_expires_at: entry.expires_at,
+												bucket_expires_at: bucket.expires_at,
+											},
+										]
+									})
+									.sort((left, right) => left.name.localeCompare(right.name))
 								return { results: results as Array<T>, meta: { changes: 0 } }
 							}
 							if (
@@ -566,6 +626,198 @@ test('saveSecret rejects unavailable scoped storage as McpCallerError', async ()
 			error.message ===
 				'Secret scope "package" is unavailable in this context.',
 	)
+})
+
+test('listSecrets from execute lists caller-owned package metadata without weakening resolve', async () => {
+	const testDb = createSecretTestDb()
+	const env = {
+		APP_DB: testDb.db,
+		COOKIE_SECRET: 'test-cookie-secret',
+		SECRET_STORE_KEY: 'test-secret-store-key-32-chars-minimum',
+		...createInMemoryUserMeterEnv().env,
+	}
+	const userId = 'user-123'
+	const otherUserId = 'user-other'
+	const executeContext = {
+		sessionId: null,
+		appId: null,
+		packageId: null,
+		storageId: null,
+	}
+	await saveSecret({
+		env,
+		userId,
+		scope: 'user',
+		name: 'accountToken',
+		value: 'user-value',
+	})
+	await saveSecret({
+		env,
+		userId,
+		scope: 'package',
+		name: 'discordBotToken',
+		value: 'package-only-value',
+		storageContext: {
+			sessionId: null,
+			appId: null,
+			packageId: 'pkg-discord',
+			storageId: 'pkg-discord',
+		},
+	})
+	await saveSecret({
+		env,
+		userId,
+		scope: 'package',
+		name: 'notesToken',
+		value: 'notes-only-value',
+		storageContext: {
+			sessionId: null,
+			appId: null,
+			packageId: 'pkg-notes',
+			storageId: 'pkg-notes',
+		},
+	})
+	await saveSecret({
+		env,
+		userId,
+		scope: 'session',
+		name: 'sessionToken',
+		value: 'session-only-value',
+		storageContext: {
+			sessionId: 'session-abc',
+			appId: null,
+			packageId: null,
+			storageId: null,
+		},
+		sessionExpiresAt: '2099-01-01T00:00:00.000Z',
+	})
+	await saveSecret({
+		env,
+		userId: otherUserId,
+		scope: 'package',
+		name: 'foreignToken',
+		value: 'other-user-value',
+		storageContext: {
+			sessionId: null,
+			appId: null,
+			packageId: 'pkg-foreign',
+			storageId: 'pkg-foreign',
+		},
+	})
+
+	const listedAll = await listSecrets({
+		env,
+		userId,
+		storageContext: executeContext,
+	})
+	expect(listedAll).toEqual(
+		expect.arrayContaining([
+			expect.objectContaining({
+				name: 'accountToken',
+				scope: 'user',
+				packageId: null,
+			}),
+			expect.objectContaining({
+				name: 'discordBotToken',
+				scope: 'package',
+				packageId: 'pkg-discord',
+			}),
+			expect.objectContaining({
+				name: 'notesToken',
+				scope: 'package',
+				packageId: 'pkg-notes',
+			}),
+		]),
+	)
+	expect(listedAll.map((secret) => secret.name)).not.toContain('sessionToken')
+	expect(listedAll.map((secret) => secret.name)).not.toContain('foreignToken')
+	expect(
+		listedAll.find((secret) => secret.name === 'discordBotToken'),
+	).not.toHaveProperty('value')
+
+	const listedPackageScope = await listSecrets({
+		env,
+		userId,
+		scope: 'package',
+		storageContext: executeContext,
+	})
+	expect(listedPackageScope).toEqual([
+		expect.objectContaining({
+			name: 'discordBotToken',
+			scope: 'package',
+			packageId: 'pkg-discord',
+		}),
+		expect.objectContaining({
+			name: 'notesToken',
+			scope: 'package',
+			packageId: 'pkg-notes',
+		}),
+	])
+
+	const listedOnePackage = await listSecrets({
+		env,
+		userId,
+		scope: 'package',
+		storageContext: {
+			sessionId: null,
+			appId: null,
+			packageId: 'pkg-discord',
+			storageId: 'pkg-discord',
+		},
+	})
+	expect(listedOnePackage).toEqual([
+		expect.objectContaining({
+			name: 'discordBotToken',
+			scope: 'package',
+			packageId: 'pkg-discord',
+		}),
+	])
+
+	const searchRows = await listUserSecretsForSearch({ env, userId })
+	expect(searchRows).toEqual([
+		expect.objectContaining({
+			name: 'accountToken',
+			scope: 'user',
+			packageId: null,
+		}),
+	])
+	expect(searchRows.map((row) => row.name)).not.toContain('discordBotToken')
+	expect(searchRows.map((row) => row.name)).not.toContain('notesToken')
+
+	await expect(
+		resolveSecret({
+			env,
+			userId,
+			name: 'discordBotToken',
+			storageContext: executeContext,
+		}),
+	).resolves.toMatchObject({ found: false, value: null })
+	await expect(
+		resolveSecret({
+			env,
+			userId,
+			name: 'discordBotToken',
+			scope: 'package',
+			storageContext: executeContext,
+		}),
+	).resolves.toMatchObject({ found: false, value: null })
+	await expect(
+		resolveSecret({
+			env,
+			userId,
+			name: 'discordBotToken',
+			storageContext: {
+				sessionId: null,
+				appId: null,
+				packageId: 'pkg-discord',
+				storageId: 'pkg-discord',
+			},
+		}),
+	).resolves.toMatchObject({
+		found: true,
+		value: 'package-only-value',
+		scope: 'package',
+	})
 })
 
 test('listPackageSecretsByPackageIds groups package-owned secrets', async () => {

--- a/packages/worker/src/mcp/secrets/service.ts
+++ b/packages/worker/src/mcp/secrets/service.ts
@@ -24,6 +24,7 @@ import {
 import { assertSecretNameAllowed, isReservedSecretName } from './name-guards.ts'
 import {
 	getSecretBindingKey,
+	resolveSecretListScopeOrder,
 	resolveSecretScopeOrder,
 } from './secret-bindings.ts'
 import { type StorageContext } from '#mcp/storage.ts'
@@ -32,6 +33,7 @@ import {
 	getSecretBucket,
 	getSecretEntry,
 	listPackageScopeSecretMetadata,
+	listSecretBucketsByScope,
 	listSecretMetadataForBucket,
 	listUserScopeSecretMetadata,
 	updateApprovedUserSecretEntriesForPackageAtomically,
@@ -836,10 +838,10 @@ async function getAccessibleBuckets(input: {
 }) {
 	const scopes = input.scope
 		? [input.scope]
-		: resolveSecretScopeOrder(input.storageContext)
+		: resolveSecretListScopeOrder(input.storageContext)
 	const buckets = await Promise.all(
 		scopes.map((scope) =>
-			getExistingBucketForScope({
+			listAccessibleBucketsForScope({
 				db: input.db,
 				userId: input.userId,
 				scope,
@@ -847,9 +849,30 @@ async function getAccessibleBuckets(input: {
 			}),
 		),
 	)
-	return buckets.filter(
-		(bucket): bucket is NonNullable<typeof bucket> => bucket != null,
-	)
+	return buckets.flat()
+}
+
+async function listAccessibleBucketsForScope(input: {
+	db: D1Database
+	userId: string
+	scope: SecretScope
+	storageContext: StorageContext | null
+}) {
+	if (
+		input.scope === 'package' &&
+		getSecretBindingKey('package', input.storageContext) == null
+	) {
+		// Listing-only: discover caller-owned package buckets without a
+		// package runtime binding. Resolve/use still go through
+		// getExistingBucketForScope and require packageId.
+		return listSecretBucketsByScope({
+			db: input.db,
+			userId: input.userId,
+			scope: 'package',
+		})
+	}
+	const bucket = await getExistingBucketForScope(input)
+	return bucket ? [bucket] : []
 }
 
 async function getExistingBucketForScope(input: {

--- a/packages/worker/src/mcp/tools/search-entity-plugins/secret.ts
+++ b/packages/worker/src/mcp/tools/search-entity-plugins/secret.ts
@@ -66,7 +66,7 @@ export const secretSearchEntityPlugin = {
 			`- Placeholder: \`${buildSecretUsage(detail.row.name)}\``,
 			'- Use placeholders only in execute-time fetch URL, header, or body fields.',
 			'- Do not place the literal placeholder token into visible content such as prompts, comments, issue bodies, logs, or returned strings.',
-			'- List secret metadata with `kody.secretList(...)` inside `execute` when needed. Explicit listing includes caller-owned package-scoped metadata with `package_id`; search does not auto-surface those. Using a package secret still requires package context.',
+			'- List secret metadata with `kody.secretList(...)` inside `execute` when needed. Explicit listing includes caller-owned package-scoped metadata with `package_id`; search does not return or rank package-scoped secret references. Using a package secret still requires package context.',
 		]
 		return {
 			markdown: lines.join('\n'),

--- a/packages/worker/src/mcp/tools/search-entity-plugins/secret.ts
+++ b/packages/worker/src/mcp/tools/search-entity-plugins/secret.ts
@@ -66,7 +66,7 @@ export const secretSearchEntityPlugin = {
 			`- Placeholder: \`${buildSecretUsage(detail.row.name)}\``,
 			'- Use placeholders only in execute-time fetch URL, header, or body fields.',
 			'- Do not place the literal placeholder token into visible content such as prompts, comments, issue bodies, logs, or returned strings.',
-			'- List secret metadata with `kody.secretList(...)` inside `execute` when needed.',
+			'- List secret metadata with `kody.secretList(...)` inside `execute` when needed. Explicit listing includes caller-owned package-scoped metadata with `package_id`; search does not auto-surface those. Using a package secret still requires package context.',
 		]
 		return {
 			markdown: lines.join('\n'),

--- a/packages/worker/src/package-invocations/test-schema.ts
+++ b/packages/worker/src/package-invocations/test-schema.ts
@@ -1,6 +1,7 @@
 /**
- * Workers-unit D1 does not apply migrations. Suites that call packageGet
- * (which lists tokens) need this table.
+ * Workers-unit D1 does not apply migrations. Suites that still read
+ * package invocation token metadata need this table. packageGet secret
+ * FYI metadata uses `#worker/secrets-test-schema`.
  */
 export async function ensurePackageInvocationTokensTestSchema(db: D1Database) {
 	await db

--- a/packages/worker/src/secrets-test-schema.ts
+++ b/packages/worker/src/secrets-test-schema.ts
@@ -1,0 +1,37 @@
+/**
+ * Workers-unit D1 does not apply migrations. Suites that call packageGet
+ * (which lists package-scoped secret metadata) need these tables.
+ */
+export async function ensureSecretBucketsTestSchema(db: D1Database) {
+	await db
+		.prepare(
+			`CREATE TABLE IF NOT EXISTS secret_buckets (
+				id TEXT PRIMARY KEY NOT NULL,
+				user_id TEXT NOT NULL,
+				scope TEXT NOT NULL CHECK (scope IN ('session', 'package', 'user')),
+				binding_key TEXT NOT NULL,
+				expires_at TEXT,
+				created_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+				updated_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+				UNIQUE(user_id, scope, binding_key)
+			)`,
+		)
+		.run()
+	await db
+		.prepare(
+			`CREATE TABLE IF NOT EXISTS secret_entries (
+				bucket_id TEXT NOT NULL,
+				name TEXT NOT NULL,
+				description TEXT NOT NULL DEFAULT '',
+				encrypted_value TEXT NOT NULL,
+				allowed_hosts TEXT NOT NULL DEFAULT '[]',
+				allowed_packages TEXT NOT NULL DEFAULT '[]',
+				lookup_hash TEXT,
+				expires_at TEXT,
+				created_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+				updated_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+				PRIMARY KEY (bucket_id, name)
+			)`,
+		)
+		.run()
+}

--- a/tools/check-worker-startup-bundles.ts
+++ b/tools/check-worker-startup-bundles.ts
@@ -115,7 +115,13 @@ const startupBundles: ReadonlyArray<StartupBundleDefinition> = [
 		packageDir: 'packages/runtime-worker',
 		entryFile: 'runtime-worker.js',
 		bundler: 'wrangler',
-		maxEntryBytes: 3_620_000,
+		// Listing-only helpers live in the shared secrets service module
+		// (resolveSecretListScopeOrder / listSecretBucketsByScope). Runtime
+		// does not call them, but they sit in the same module as resolve
+		// and add a few KB. Raised from 3_620_000 for package-secret list
+		// discovery; split the listing path out of service.ts if this
+		// budget is raised again.
+		maxEntryBytes: 3_630_000,
 		forbiddenSources: [
 			...sharedDeferredGuideSources,
 			'/packages/worker/src/repo/repo-session-do.ts',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Let agents discover **caller-owned package-scoped secret metadata** (names and `package_id`, never values) from explicit `secretList` and from `packageGet`, without putting those secrets into search rankings or weakening resolve/use.

## Why

`getSecretBindingKey('package', storageContext)` requires `storageContext.packageId`. MCP execute has none, so `getAccessibleBuckets` skipped package buckets and `secretList({ scope: 'package' })` returned `[]`. Kent signed off on this small platform polish. Grok-bot wake secrets stay a separate package bug.

## Summary

- `secretList` (including `scope: 'package'` or listing all accessible scopes) returns caller-owned package-scoped metadata with `package_id` from execute/account context.
- When a package runtime binding is present, listing still filters to that package.
- Resolve, fetch placeholders, and mounts still require package context.
- Session secrets stay session-bound.
- Search still ranks user-scoped secret references only (does not return or rank package-scoped secrets).
- `packageGet` includes associated package-scoped secret metadata as FYI.
- Capability and usage docs clarify listing vs use vs search.

## Startup budget

Raised the runtime worker startup-entry budget from `3_620_000` to `3_630_000` bytes. Listing helpers (`resolveSecretListScopeOrder` / `listSecretBucketsByScope`) live in the shared secrets service module that runtime already imports for resolve. They add ~2.8KB to the runtime entry; they do not change resolve/use. Split the listing path out of `service.ts` if this budget is raised again.

## Testing

- Focused node tests: `secretList` from execute returns package-scoped rows with `package_id`; `listUserSecretsForSearch` / search loaders still omit them; resolve without `packageId` still misses.
- `packageGet` FYI metadata test (no values).
- Workers-unit community flow schema now creates `secret_buckets` / `secret_entries` so `packageGet` can list metadata.
- Local `test:push` (node-unit + workers-unit) passed after the schema helper.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `518e2d6d` · **Head:** `d67737c0`

**Classification:** extends — listing and `packageGet` contracts change so agents can see caller-owned package secret metadata. Resolve/use gates and search ranking stay the same.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `secrets` | assistant | extends — `secretList` discovers owned package-bucket metadata without a package runtime binding |
| `saved-packages` | assistant | extends — `packageGet` returns `package_secrets` FYI metadata |
| `mcp-server` | surfaces | extends — listing scope order and secret search copy |
| `community-listings` | assistant | composes — workers-unit schema only |

### Change flow

Execute `secretList` can list owned package secret metadata. Resolve still needs package context. Search stays user-scoped.

```mermaid
sequenceDiagram
	actor Agent
	participant mcpServer as mcp-server
	participant secrets as secrets
	participant savedPackages as saved-packages
	Agent->>mcpServer: search query
	mcpServer->>secrets: listUserSecretsForSearch
	Note over secrets: user-scoped rows only
	Agent->>mcpServer: execute secretList
	mcpServer->>secrets: listSecrets without packageId
	secrets-->>mcpServer: package rows with package_id
	Note over secrets: metadata only, no values
	Agent->>mcpServer: execute packageGet
	mcpServer->>savedPackages: load package detail
	savedPackages->>secrets: listPackageSecretsByPackageIds
	savedPackages-->>mcpServer: package_secrets FYI
	Agent->>mcpServer: resolve or fetch placeholder
	mcpServer->>secrets: resolveSecret
	Note over secrets: still requires package context
```

### Before / after

**`secretList` from execute (no `packageId`)**

```text
before: [] for scope=package
after:  caller-owned package rows with package_id
```

**`packageGet`**

```text
before: exports and provenance only
after:  same, plus package_secrets metadata FYI
```

### Invariants

- `no-secrets-in-chat` — list and `packageGet` still return metadata only, never plaintext values.
- Per-user isolation — package-bucket listing stays `user_id`-scoped. Session secrets stay session-bound.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4f55de2c-738d-4d73-aa89-814757ff040a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4f55de2c-738d-4d73-aa89-814757ff040a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `secretList` now shows metadata for caller-owned package-scoped secrets, including `package_id`, without exposing secret values.
  * Package details now include associated package-secret metadata for reference.
  * Package-scoped secrets can be explicitly listed without an active package runtime context.

* **Documentation**
  * Clarified that search does not automatically surface package-scoped secrets and that using them still requires package context.
  * Updated secret discovery and package export guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->